### PR TITLE
fix: ensure catch-all route works

### DIFF
--- a/apps/prodserver/index.js
+++ b/apps/prodserver/index.js
@@ -16,8 +16,8 @@ if (!appRoot || !fs.statSync(appRoot).isDirectory()) {
   process.exit(1)
 }
 
-const proxy = require(path.join(appRoot, 'src/setupProxy'))
-const pkg = require(path.join(appRoot, 'package.json'))
+const proxy = require(path.resolve(appRoot, 'src/setupProxy'))
+const pkg = require(path.resolve(appRoot, 'package.json'))
 const app = express()
 const port = 3000
 
@@ -28,9 +28,9 @@ app.use((req, res, next) => {
 
 proxy(app)
 
-app.use(express.static(path.join(appRoot, 'build')))
+app.use(express.static(path.resolve(appRoot, 'build')))
 app.get('*', (req, res) => {
-  res.sendFile(path.join(appRoot, 'build/index.html'))
+  res.sendFile(path.resolve(appRoot, 'build/index.html'))
 })
 
 app.listen(port, () => console.log(`${pkg.name} listening on port ${port}!`))


### PR DESCRIPTION
This changes the `path.join` calls to `path.resolve` so that the result is an absolute path. Without this, [express rejects the argument to `sendFile` for security reasons](https://github.com/expressjs/express/blob/0a48e18056865364b2461b2ece7ccb2d1075d3c9/lib/response.js#L424-L426).