### PR TITLE
test(lint): fix lint and run checks in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,10 @@ jobs:
           paths:
             - libs/ballot-encoder/node_modules
       - run:
+          name: Run Linters
+          command: |
+            yarn --cwd libs/ballot-encoder lint
+      - run:
           name: Run Front-End Test and Coverage
           command: |
             yarn --cwd libs/ballot-encoder test:coverage
@@ -46,6 +50,10 @@ jobs:
             dotcache-cache-{{checksum ".circleci/config.yml" }}-{{ checksum "apps/bas/yarn.lock" }}
           paths:
             - apps/bas/node_modules
+      - run:
+          name: Run Linters
+          command: |
+            yarn --cwd apps/bas lint
       - run:
           name: Run Front-End Test and Coverage
           command: |
@@ -68,6 +76,10 @@ jobs:
           paths:
             - apps/bmd/node_modules
       - run:
+          name: Run Linters
+          command: |
+            yarn --cwd apps/bmd lint
+      - run:
           name: Run Front-End Test and Coverage
           command: |
             yarn --cwd apps/bmd test:coverage
@@ -88,6 +100,10 @@ jobs:
             dotcache-cache-{{checksum ".circleci/config.yml" }}-{{ checksum "apps/bsd/yarn.lock" }}
           paths:
             - apps/bsd/node_modules
+      - run:
+          name: Run Linters
+          command: |
+            yarn --cwd apps/bsd lint
       - run:
           name: Run Front-End Test and Coverage
           command: |
@@ -110,6 +126,10 @@ jobs:
           paths:
             - apps/election-manager/node_modules
       - run:
+          name: Run Linters
+          command: |
+            yarn --cwd apps/election-manager lint
+      - run:
           name: Run Front-End Test and Coverage
           command: |
             yarn --cwd apps/election-manager test:coverage
@@ -131,6 +151,10 @@ jobs:
           paths:
             - libs/hmpb-interpreter/node_modules
       - run:
+          name: Run Linters
+          command: |
+            yarn --cwd libs/hmpb-interpreter lint
+      - run:
           name: Run Tests with Coverage
           command: |
             yarn --cwd libs/hmpb-interpreter test:coverage
@@ -151,6 +175,10 @@ jobs:
             dotcache-cache-{{checksum ".circleci/config.yml" }}-{{ checksum "apps/module-scan/yarn.lock" }}
           paths:
             - apps/module-scan/node_modules
+      - run:
+          name: Run Linters
+          command: |
+            yarn --cwd apps/module-scan lint
       - run:
           name: Run Tests with Coverage
           command: |

--- a/apps/bsd/src/screens/BallotReviewScreen.test.tsx
+++ b/apps/bsd/src/screens/BallotReviewScreen.test.tsx
@@ -82,7 +82,15 @@ test('renders ballot options for each contest option', async () => {
     ],
     layout: [
       {
-        bounds: { x: 0, y: 0, width: 10, height: 10 }, // bogus
+        // bogus
+        bounds: { x: 0, y: 0, width: 10, height: 10 },
+        // bogus
+        corners: [
+          { x: 0, y: 0 },
+          { x: 9, y: 0 },
+          { x: 0, y: 9 },
+          { x: 9, y: 9 },
+        ],
         options: [
           {
             bounds: { x: 0, y: 50, width: 250, height: 100 }, // this one matters

--- a/apps/election-manager/.eslintignore
+++ b/apps/election-manager/.eslintignore
@@ -3,6 +3,7 @@
 /cypress/plugins
 /cypress/integration/examples
 /cypress/support
+/prodserver
 /src/**/*.js
 *.d.ts
 /src/serviceWorker.ts

--- a/apps/election-manager/src/components/Button.tsx
+++ b/apps/election-manager/src/components/Button.tsx
@@ -60,8 +60,8 @@ export const DecoyButton = styled.div`
   ${buttonStyles}/* stylelint-disable-line value-keyword-case */
 `
 
-const StyledButton = styled('button').attrs((props: Attrs) => ({
-  type: props.type ?? 'button',
+const StyledButton = styled('button').attrs<Attrs>(({ type }) => ({
+  type: type ?? 'button',
 }))`
   ${buttonStyles}/* stylelint-disable-line value-keyword-case */
 `

--- a/libs/ballot-encoder/.eslintrc.js
+++ b/libs/ballot-encoder/.eslintrc.js
@@ -10,7 +10,6 @@ module.exports = {
   },
   parser: '@typescript-eslint/parser', // Specifies the ESLint parser
   extends: [
-    'airbnb-base',
     'plugin:import/errors',
     'plugin:import/warnings',
     'plugin:import/typescript',

--- a/libs/ballot-encoder/src/bits/BitReader.ts
+++ b/libs/ballot-encoder/src/bits/BitReader.ts
@@ -153,7 +153,6 @@ export default class BitReader {
   private sizeofUint({ max }: { max: number }): number
   private sizeofUint({ size }: { size: number }): number
   private sizeofUint({ max, size }: { max?: number; size?: number }): number
-  // eslint-disable-next-line class-methods-use-this
   private sizeofUint({ max, size }: { max?: number; size?: number }): number {
     if (typeof max !== 'undefined' && typeof size !== 'undefined') {
       throw new Error("cannot specify both 'max' and 'size' options")

--- a/libs/ballot-encoder/src/bits/BitWriter.test.ts
+++ b/libs/ballot-encoder/src/bits/BitWriter.test.ts
@@ -130,7 +130,6 @@ test('has a debug method to help understanding the contents', () => {
     .writeUint8(1, 2, 3)
     .debug()
 
-  /* eslint-disable no-console */
   expect(console.log).toHaveBeenNthCalledWith(1, 'wrote true')
   expect(console.log).toHaveBeenNthCalledWith(2, '1')
   expect(console.log).toHaveBeenNthCalledWith(3, 'wrote false')
@@ -139,5 +138,4 @@ test('has a debug method to help understanding the contents', () => {
     5,
     '10000000 01000000 10000000 11'
   )
-  /* eslint-enable no-console */
 })

--- a/libs/ballot-encoder/src/bits/BitWriter.ts
+++ b/libs/ballot-encoder/src/bits/BitWriter.ts
@@ -185,10 +185,8 @@ export default class BitWriter {
 
   public debug(label?: string): this {
     if (label) {
-      // eslint-disable-next-line no-console
       console.log(label)
     }
-    // eslint-disable-next-line no-console
     console.log(
       inGroupsOf(
         8,

--- a/libs/ballot-encoder/src/bits/utils.ts
+++ b/libs/ballot-encoder/src/bits/utils.ts
@@ -46,7 +46,6 @@ export function sizeof(number: number): number {
 
   let maxBits = 1
 
-  // eslint-disable-next-line no-cond-assign, no-param-reassign
   while ((number >>= 1)) {
     maxBits += 1
   }

--- a/libs/ballot-encoder/src/election.ts
+++ b/libs/ballot-encoder/src/election.ts
@@ -154,7 +154,6 @@ export enum AdjudicationReason {
 }
 
 // Updating this value is a breaking change.
-// eslint-disable-next-line no-bitwise
 export const BallotTypeMaximumValue = (1 << 4) - 1
 
 export interface CompletedBallot {

--- a/libs/ballot-encoder/src/index.ts
+++ b/libs/ballot-encoder/src/index.ts
@@ -6,10 +6,8 @@ export * from './election'
 export { v0, v1 }
 
 export enum EncoderVersion {
-  /* eslint-disable no-shadow */
   v0 = 0,
   v1 = 1,
-  /* eslint-enable no-shadow */
 }
 
 /**


### PR DESCRIPTION
ballot-encoder has been broken for a while, and others were introduced recently.