### PR TITLE
feat: include ballot type in the CVR output

### DIFF
--- a/apps/bsd/src/config/types.ts
+++ b/apps/bsd/src/config/types.ts
@@ -50,6 +50,7 @@ export interface CastVoteRecord
   extends Dictionary<string | string[] | boolean> {
   _precinctId: string
   _ballotStyleId: string
+  _ballotType: 'absentee' | 'provisional' | 'standard'
   _ballotId: string
   _testBallot: boolean
   _scannerId: string

--- a/apps/election-manager/src/config/types.ts
+++ b/apps/election-manager/src/config/types.ts
@@ -107,6 +107,7 @@ export interface CastVoteRecord
   _precinctId: string
   _ballotId: string
   _ballotStyleId: string
+  _ballotType: 'absentee' | 'provisional' | 'standard'
   _testBallot: boolean
   _scannerId: string
   _pageNumber?: number

--- a/apps/election-manager/src/lib/votecounting.test.ts
+++ b/apps/election-manager/src/lib/votecounting.test.ts
@@ -121,6 +121,7 @@ test('overvote report', async () => {
 test('parsing CVRs flags when a precinct ID in a CVR is not present in the election definition', () => {
   const cvr: CastVoteRecord = {
     _ballotStyleId: '12',
+    _ballotType: 'standard',
     _precinctId: 'not real',
     _ballotId: 'abc',
     _scannerId: 'scanner-1',
@@ -138,6 +139,7 @@ test('parsing CVRs flags when a precinct ID in a CVR is not present in the elect
 test('parsing CVRs flags when a ballot style ID in a CVR is not present in the election definition', () => {
   const cvr: CastVoteRecord = {
     _ballotStyleId: '123',
+    _ballotType: 'standard',
     _precinctId: '23',
     _ballotId: 'abc',
     _scannerId: 'scanner-1',
@@ -156,6 +158,7 @@ test('parsing CVRs flags when a ballot style ID in a CVR is not present in the e
 test('parsing CVRs flags when a contest ID in a CVR is not present in the election definition', () => {
   const cvr: CastVoteRecord = {
     _ballotStyleId: '12',
+    _ballotType: 'standard',
     _precinctId: '23',
     _ballotId: 'abc',
     _scannerId: 'scanner-1',
@@ -176,6 +179,7 @@ test('parsing CVRs flags when a contest ID in a CVR is not present in the electi
 test('parsing CVRs flags when test ballot flag is not a boolean', () => {
   const cvr: CastVoteRecord = {
     _ballotStyleId: '12',
+    _ballotType: 'standard',
     _precinctId: '23',
     _ballotId: 'abc',
     _scannerId: 'scanner-1',
@@ -196,6 +200,7 @@ test('parsing CVRs flags when test ballot flag is not a boolean', () => {
 test('parsing CVRs flags when page number is set but not a number', () => {
   const cvr: CastVoteRecord = {
     _ballotStyleId: '12',
+    _ballotType: 'standard',
     _precinctId: '23',
     _ballotId: 'abc',
     _scannerId: 'scanner-1',
@@ -217,6 +222,7 @@ test('parsing CVRs flags when page number is set but not a number', () => {
 test('parsing CVRs flags when page numbers is set but not an array of numbers', () => {
   const cvr: CastVoteRecord = {
     _ballotStyleId: '12',
+    _ballotType: 'standard',
     _precinctId: '23',
     _ballotId: 'abc',
     _scannerId: 'scanner-1',
@@ -238,6 +244,7 @@ test('parsing CVRs flags when page numbers is set but not an array of numbers', 
 test('parsing CVRs flags when both _pageNumber and _pageNumbers are set', () => {
   const cvr: CastVoteRecord = {
     _ballotStyleId: '12',
+    _ballotType: 'standard',
     _precinctId: '23',
     _ballotId: 'abc',
     _scannerId: 'scanner-1',
@@ -259,6 +266,7 @@ test('parsing CVRs flags when both _pageNumber and _pageNumbers are set', () => 
 test('parsing CVRs flags with _pageNumbers set properly works', () => {
   const cvr: CastVoteRecord = {
     _ballotStyleId: '12',
+    _ballotType: 'standard',
     _precinctId: '23',
     _ballotId: 'abc',
     _scannerId: 'scanner-1',
@@ -277,6 +285,7 @@ test('parsing CVRs flags with _pageNumbers set properly works', () => {
 test('parsing CVRs flags when ballot ID is not a string', () => {
   const cvr: CastVoteRecord = {
     _ballotStyleId: '12',
+    _ballotType: 'standard',
     _precinctId: '23',
     // @ts-expect-error - number instead of a string
     _ballotId: 44,

--- a/apps/election-manager/src/lib/votecounting.ts
+++ b/apps/election-manager/src/lib/votecounting.ts
@@ -82,6 +82,9 @@ export function* parseCVRs(
       const {
         _ballotId,
         _ballotStyleId,
+        // TODO: tally taking ballot type into account
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        _ballotType,
         _precinctId,
         _testBallot,
         _scannerId,
@@ -591,6 +594,7 @@ const processCastVoteRecord = ({
   const newCVR: CastVoteRecord = {
     _precinctId: castVoteRecord._precinctId,
     _ballotStyleId: castVoteRecord._ballotStyleId,
+    _ballotType: castVoteRecord._ballotType,
     _ballotId: castVoteRecord._ballotId,
     _testBallot: castVoteRecord._testBallot,
     _scannerId: castVoteRecord._scannerId,

--- a/apps/election-manager/src/utils/CastVoteRecordFiles.test.ts
+++ b/apps/election-manager/src/utils/CastVoteRecordFiles.test.ts
@@ -27,6 +27,7 @@ test('can add multiple CVR files by creating a new instance', async () => {
   const cvr: CastVoteRecord = {
     _ballotId: 'abc',
     _ballotStyleId: '12',
+    _ballotType: 'standard',
     _precinctId: '23',
     _testBallot: false,
     _scannerId: 'abc',
@@ -50,6 +51,7 @@ test('does not mutate the original when adding a new instance', async () => {
   const cvr: CastVoteRecord = {
     _ballotId: 'abc',
     _ballotStyleId: '12',
+    _ballotType: 'standard',
     _precinctId: '23',
     _testBallot: false,
     _scannerId: 'abc',
@@ -91,6 +93,7 @@ test('records CVR data errors', async () => {
   const cvr: CastVoteRecord = {
     _ballotId: 'abc',
     _ballotStyleId: '12',
+    _ballotType: 'standard',
     _precinctId: '9999',
     _testBallot: false,
     _scannerId: 'abc',
@@ -113,6 +116,7 @@ test('records identical uploaded files', async () => {
   const cvr: CastVoteRecord = {
     _ballotId: 'abc',
     _ballotStyleId: '12',
+    _ballotType: 'standard',
     _precinctId: '23',
     _testBallot: false,
     _scannerId: 'abc',
@@ -137,6 +141,7 @@ test('refuses to tabulate both live and test CVRs', async () => {
   const cvr: CastVoteRecord = {
     _ballotId: 'abc',
     _ballotStyleId: '12',
+    _ballotType: 'standard',
     _precinctId: '23',
     _testBallot: false,
     _scannerId: 'abc',

--- a/apps/module-scan/src/backup.test.ts
+++ b/apps/module-scan/src/backup.test.ts
@@ -327,7 +327,7 @@ test('has cvrs.jsonl', async () => {
 
   const cvrsEntry = entries.find(({ fileName }) => fileName === 'cvrs.jsonl')!
   expect(await readTextEntry(zipfile, cvrsEntry)).toMatchInlineSnapshot(`
-    "{\\"1\\":[],\\"2\\":[],\\"3\\":[],\\"4\\":[],\\"_ballotId\\":\\"abc\\",\\"_ballotStyleId\\":\\"1\\",\\"_precinctId\\":\\"6522\\",\\"_scannerId\\":\\"000\\",\\"_testBallot\\":false,\\"_locales\\":{\\"primary\\":\\"en-US\\"},\\"initiative-65\\":[],\\"initiative-65-a\\":[],\\"flag-question\\":[\\"yes\\"],\\"runoffs-question\\":[]}
+    "{\\"1\\":[],\\"2\\":[],\\"3\\":[],\\"4\\":[],\\"_ballotId\\":\\"abc\\",\\"_ballotStyleId\\":\\"1\\",\\"_ballotType\\":\\"standard\\",\\"_precinctId\\":\\"6522\\",\\"_scannerId\\":\\"000\\",\\"_testBallot\\":false,\\"_locales\\":{\\"primary\\":\\"en-US\\"},\\"initiative-65\\":[],\\"initiative-65-a\\":[],\\"flag-question\\":[\\"yes\\"],\\"runoffs-question\\":[]}
     "
   `)
 })

--- a/apps/module-scan/src/buildCastVoteRecord.test.ts
+++ b/apps/module-scan/src/buildCastVoteRecord.test.ts
@@ -58,6 +58,7 @@ test('generates a CVR from a completed BMD ballot', () => {
       "4": Array [],
       "_ballotId": "abcdefg",
       "_ballotStyleId": "1",
+      "_ballotType": "standard",
       "_locales": Object {
         "primary": "en-US",
       },
@@ -148,6 +149,98 @@ test('generates a CVR from a completed HMPB page', () => {
       ],
       "_ballotId": "abcdefg",
       "_ballotStyleId": "1",
+      "_ballotType": "standard",
+      "_locales": Object {
+        "primary": "en-US",
+      },
+      "_pageNumbers": Array [
+        1,
+        2,
+      ],
+      "_precinctId": "6522",
+      "_scannerId": "000",
+      "_testBallot": false,
+      "initiative-65": Array [
+        "yes",
+        "no",
+      ],
+    }
+  `)
+})
+
+test('generates a CVR from a completed absentee HMPB page', () => {
+  const sheetId = 'sheetid'
+  const ballotId = 'abcdefg'
+  const ballotStyleId = '1'
+  const precinctId = '6522'
+  const ballotStyle = getBallotStyle({ ballotStyleId, election })!
+  const contests = getContests({ ballotStyle, election })
+
+  expect(
+    buildCastVoteRecord(sheetId, ballotId, election, [
+      {
+        interpretation: {
+          type: 'InterpretedHmpbPage',
+          ballotId: 'abcdefg',
+          metadata: {
+            locales: { primary: 'en-US' },
+            electionHash: '',
+            ballotType: BallotType.Absentee,
+            ballotStyleId,
+            precinctId,
+            isTestMode: false,
+            pageNumber: 1,
+          },
+          markInfo: { marks: [], ballotSize: { width: 1, height: 1 } },
+          adjudicationInfo: {
+            requiresAdjudication: false,
+            enabledReasons: [],
+            allReasonInfos: [],
+          },
+          votes: vote(contests, {
+            '1': '1',
+            '2': '22',
+          }),
+        },
+        contestIds: ['1', '2'],
+      },
+      {
+        interpretation: {
+          type: 'InterpretedHmpbPage',
+          ballotId: 'abcdefg',
+          metadata: {
+            locales: { primary: 'en-US' },
+            electionHash: '',
+            ballotType: BallotType.Standard,
+            ballotStyleId,
+            precinctId,
+            isTestMode: false,
+            pageNumber: 2,
+          },
+          markInfo: { marks: [], ballotSize: { width: 1, height: 1 } },
+          adjudicationInfo: {
+            requiresAdjudication: false,
+            enabledReasons: [],
+            allReasonInfos: [],
+          },
+          votes: vote(contests, {
+            'initiative-65': ['yes', 'no'],
+          }),
+        },
+        contestIds: ['initiative-65'],
+      },
+    ])
+  ).toMatchInlineSnapshot(`
+    Object {
+      "1": Array [
+        "1",
+      ],
+      "2": Array [
+        "22",
+      ],
+      "_ballotId": "abcdefg",
+      "_ballotStyleId": "1",
+      "_ballotType": "absentee",
       "_locales": Object {
         "primary": "en-US",
       },
@@ -250,6 +343,7 @@ test('generates a CVR from an adjudicated HMPB page', () => {
       ],
       "_ballotId": "abcdefg",
       "_ballotStyleId": "1",
+      "_ballotType": "standard",
       "_locales": Object {
         "primary": "en-US",
       },
@@ -548,6 +642,7 @@ test('generates a CVR from an adjudicated uninterpreted HMPB page', () => {
       ],
       "_ballotId": "abcdefg",
       "_ballotStyleId": "1",
+      "_ballotType": "standard",
       "_locales": Object {
         "primary": "en-US",
       },

--- a/apps/module-scan/src/buildCastVoteRecord.ts
+++ b/apps/module-scan/src/buildCastVoteRecord.ts
@@ -1,5 +1,6 @@
 import {
   AnyContest,
+  BallotType,
   CandidateVote,
   Contests,
   Dictionary,
@@ -30,10 +31,29 @@ export function buildCastVoteRecordMetadataEntries(
   return {
     _ballotId: ballotId,
     _ballotStyleId: metadata.ballotStyleId,
+    _ballotType: getCVRBallotType(metadata.ballotType),
     _precinctId: metadata.precinctId,
     _scannerId: getMachineId(),
     _testBallot: metadata.isTestMode,
     _locales: metadata.locales,
+  }
+}
+
+export function getCVRBallotType(
+  ballotType: BallotType
+): CastVoteRecord['_ballotType'] {
+  switch (ballotType) {
+    case BallotType.Absentee:
+      return 'absentee'
+
+    case BallotType.Provisional:
+      return 'provisional'
+
+    case BallotType.Standard:
+      return 'standard'
+
+    default:
+      throw new Error(`unknown ballot type: ${ballotType}`)
   }
 }
 

--- a/apps/module-scan/src/endToEndHmpb.test.ts
+++ b/apps/module-scan/src/endToEndHmpb.test.ts
@@ -154,6 +154,7 @@ test('going through the whole process works', async () => {
       Object {
         "_ballotId": "",
         "_ballotStyleId": "12",
+        "_ballotType": "standard",
         "_locales": Object {
           "primary": "en-US",
           "secondary": "es-US",
@@ -296,6 +297,7 @@ test('failed scan with QR code can be adjudicated and exported', async () => {
       Object {
         "_ballotId": "",
         "_ballotStyleId": "12",
+        "_ballotType": "standard",
         "_locales": Object {
           "primary": "en-US",
           "secondary": "es-US",
@@ -440,6 +442,7 @@ test('ms-either-neither end-to-end', async () => {
         ],
         "_ballotId": "",
         "_ballotStyleId": "4",
+        "_ballotType": "standard",
         "_locales": Object {
           "primary": "en-US",
         },

--- a/apps/module-scan/src/types.ts
+++ b/apps/module-scan/src/types.ts
@@ -82,6 +82,7 @@ export interface CastVoteRecord
   > {
   _precinctId: string
   _ballotStyleId: string
+  _ballotType: 'absentee' | 'provisional' | 'standard'
   _ballotId: string
   _testBallot: boolean
   _scannerId: string


### PR DESCRIPTION
Closes #41

Looking for design feedback here, @benadida. Name of the `_ballotType`, values, etc.