### PR TITLE
Add deselected text in audio track when deselecting a candidate

### DIFF
--- a/apps/bmd/src/AppContestSingleSeat.test.tsx
+++ b/apps/bmd/src/AppContestSingleSeat.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { fireEvent, render, wait } from '@testing-library/react'
+import { fireEvent, render, wait, act } from '@testing-library/react'
 
 import App from './App'
 
@@ -81,4 +81,24 @@ it('Single Seat Contest', async () => {
   expect(getByText(candidate1).closest('button')!.dataset.selected).toBe(
     'false'
   )
+
+  // Deselect the first candidate
+  fireEvent.click(getByText(candidate0))
+
+  // Check that the aria label has deselected added
+  expect(
+    getByText(candidate0).closest('button')?.getAttribute('aria-label')
+  ).toContain('Deselected, ')
+  // Check that other candidates do not have deselected added
+  expect(
+    getByText(candidate1).closest('button')?.getAttribute('aria-label')
+  ).not.toContain('Deselected, ')
+
+  // After 1 second the deselected label is removed
+  act(() => {
+    jest.advanceTimersByTime(1001)
+  })
+  expect(
+    getByText(candidate0).closest('button')?.getAttribute('aria-label')
+  ).not.toContain('Deselected, ')
 })

--- a/apps/bmd/src/AppContestYesNo.test.tsx
+++ b/apps/bmd/src/AppContestYesNo.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { fireEvent, render, wait, within } from '@testing-library/react'
+import { fireEvent, render, wait, within, act } from '@testing-library/react'
 
 import App from './App'
 
@@ -69,6 +69,22 @@ it('Single Seat Contest', async () => {
   // Unselect Yes
   fireEvent.click(getByText('Yes'))
   expect(getByText('Yes').closest('button')!.dataset.selected).toBe('false')
+
+  // Check that the aria label was updated to be deselected
+  expect(getByText('Yes').getAttribute('aria-label')).toContain('Deselected, ')
+
+  // Check that the aria label for No was not changed
+  expect(getByText('No').getAttribute('aria-label')).not.toContain(
+    'Deselected, '
+  )
+
+  // Wait one second and check that the aria label for yes no longer has deselected
+  act(() => {
+    jest.advanceTimersByTime(1001)
+  })
+  expect(getByText('Yes').getAttribute('aria-label')).not.toContain(
+    'Deselected, '
+  )
 
   // Select Yes
   fireEvent.click(getByText('Yes'))

--- a/apps/bmd/src/components/CandidateContest.tsx
+++ b/apps/bmd/src/components/CandidateContest.tsx
@@ -109,6 +109,7 @@ const CandidateContest = ({ contest, parties, vote, updateVote }: Props) => {
     false
   )
   const [writeInCandidateName, setWriteInCandidateName] = useState('')
+  const [deselectedCandidate, setDeselectedCandidate] = useState('')
 
   const updateContestChoicesScrollStates = useCallback(() => {
     const target = scrollContainer.current
@@ -142,6 +143,15 @@ const CandidateContest = ({ contest, parties, vote, updateVote }: Props) => {
     }
   }, [vote.length, updateContestChoicesScrollStates])
 
+  useEffect(() => {
+    if (deselectedCandidate !== '') {
+      const timer = setTimeout(() => {
+        setDeselectedCandidate('')
+      }, 1000)
+      return () => clearTimeout(timer)
+    }
+  }, [deselectedCandidate])
+
   const addCandidateToVote = (id: string) => {
     const { candidates } = contest
     const candidate = findCandidateById(candidates, id)!
@@ -151,6 +161,7 @@ const CandidateContest = ({ contest, parties, vote, updateVote }: Props) => {
   const removeCandidateFromVote = (id: string) => {
     const newVote = vote.filter((c) => c.id !== id)
     updateVote(contest.id, newVote)
+    setDeselectedCandidate(id)
   }
 
   const handleUpdateSelection: EventTargetFunction = (event) => {
@@ -313,6 +324,12 @@ const CandidateContest = ({ contest, parties, vote, updateVote }: Props) => {
                   const party =
                     candidate.partyId &&
                     findPartyById(parties, candidate.partyId)
+                  let prefixAudioText = ''
+                  if (isChecked) {
+                    prefixAudioText = 'Selected, '
+                  } else if (deselectedCandidate === candidate.id) {
+                    prefixAudioText = 'Deselected, '
+                  }
                   return (
                     <ChoiceButton
                       key={candidate.id}
@@ -321,11 +338,9 @@ const CandidateContest = ({ contest, parties, vote, updateVote }: Props) => {
                         isDisabled ? handleDisabledClick : handleUpdateSelection
                       }
                       choice={candidate.id}
-                      aria-label={`${
-                        isChecked ? 'Selected, ' : ''
-                      } ${stripQuotes(candidate.name)}${
-                        party ? `, ${party.name}` : ''
-                      }.`}
+                      aria-label={`${prefixAudioText} ${stripQuotes(
+                        candidate.name
+                      )}${party ? `, ${party.name}` : ''}.`}
                     >
                       <Prose>
                         <Text wordBreak>

--- a/apps/bmd/src/components/YesNoContest.tsx
+++ b/apps/bmd/src/components/YesNoContest.tsx
@@ -57,6 +57,13 @@ const YesNoContest = ({ contest, vote, updateVote }: Props) => {
   const [overvoteSelection, setOvervoteSelection] = useState<
     Optional<YesOrNo>
   >()
+  const [deselectedVote, setDeselectedVote] = useState('')
+
+  useEffect(() => {
+    if (deselectedVote !== '') {
+      setTimeout(() => setDeselectedVote(''), 1000)
+    }
+  }, [deselectedVote])
 
   const updateContestChoicesScrollStates = useCallback(() => {
     const target = scrollContainer.current
@@ -96,6 +103,7 @@ const YesNoContest = ({ contest, vote, updateVote }: Props) => {
       .choice as YesOrNo
     if ((vote as string[] | undefined)?.includes(newVote)) {
       updateVote(contest.id, undefined)
+      setDeselectedVote(newVote)
     } else {
       updateVote(contest.id, [newVote] as YesNoVote)
     }
@@ -203,6 +211,12 @@ const YesNoContest = ({ contest, vote, updateVote }: Props) => {
               const handleDisabledClick = () => {
                 handleChangeVoteAlert(answer.vote)
               }
+              let prefixAudioText = ''
+              if (isChecked) {
+                prefixAudioText = 'Selected, '
+              } else if (deselectedVote === answer.vote) {
+                prefixAudioText = 'Deselected, '
+              }
               return (
                 <ChoiceButton
                   key={answer.vote}
@@ -214,9 +228,9 @@ const YesNoContest = ({ contest, vote, updateVote }: Props) => {
                 >
                   <Prose>
                     <Text
-                      aria-label={`${isChecked ? 'Selected, ' : ''} ${
-                        answer.label
-                      } on ${contest.shortTitle ?? contest.title}`}
+                      aria-label={`${prefixAudioText} ${answer.label} on ${
+                        contest.shortTitle ?? contest.title
+                      }`}
                       wordBreak
                     >
                       {answer.label}

--- a/apps/bmd/src/components/YesNoContest.tsx
+++ b/apps/bmd/src/components/YesNoContest.tsx
@@ -61,7 +61,8 @@ const YesNoContest = ({ contest, vote, updateVote }: Props) => {
 
   useEffect(() => {
     if (deselectedVote !== '') {
-      setTimeout(() => setDeselectedVote(''), 1000)
+      const timer = setTimeout(() => setDeselectedVote(''), 1000)
+      return () => clearTimeout(timer)
     }
   }, [deselectedVote])
 


### PR DESCRIPTION
Adds "Deselected" to the beginning of the a choice's audio track right after it is unselected. After 1 second this is removed. I tried removing it right away and it weirdly seemed to work reliably with the space bar but not with the enter key which was strange, and it was impossible to test so I think having the timeout makes the most sense.

Feel free to let me know if this isn't a good spot to add the tests for this. I tried to do it in the component unit test but since I can't control the updateVote function there it wasn't possible. 

https://zube.io/votingworks/vxsuite/c/1783