### PR TITLE
Address pr comments from deselected audio PR

### DIFF
--- a/apps/bmd/src/AppContestSingleSeat.test.tsx
+++ b/apps/bmd/src/AppContestSingleSeat.test.tsx
@@ -85,20 +85,17 @@ it('Single Seat Contest', async () => {
   // Deselect the first candidate
   fireEvent.click(getByText(candidate0))
 
-  // Check that the aria label has deselected added
+  // Check that the aria label was updated to be include 'deselected' and is then updated back to the original state
   expect(
     getByText(candidate0).closest('button')?.getAttribute('aria-label')
-  ).toContain('Deselected, ')
-  // Check that other candidates do not have deselected added
+  ).toContain('Deselected,')
   expect(
     getByText(candidate1).closest('button')?.getAttribute('aria-label')
-  ).not.toContain('Deselected, ')
-
-  // After 1 second the deselected label is removed
+  ).not.toContain('Deselected,')
   act(() => {
-    jest.advanceTimersByTime(1001)
+    jest.advanceTimersByTime(101)
   })
   expect(
     getByText(candidate0).closest('button')?.getAttribute('aria-label')
-  ).not.toContain('Deselected, ')
+  ).not.toContain('Deselected,')
 })

--- a/apps/bmd/src/AppContestYesNo.test.tsx
+++ b/apps/bmd/src/AppContestYesNo.test.tsx
@@ -70,20 +70,16 @@ it('Single Seat Contest', async () => {
   fireEvent.click(getByText('Yes'))
   expect(getByText('Yes').closest('button')!.dataset.selected).toBe('false')
 
-  // Check that the aria label was updated to be deselected
-  expect(getByText('Yes').getAttribute('aria-label')).toContain('Deselected, ')
-
-  // Check that the aria label for No was not changed
+  // Check that the aria label was updated to be deselected properly and is then removed
+  expect(getByText('Yes').getAttribute('aria-label')).toContain('Deselected,')
   expect(getByText('No').getAttribute('aria-label')).not.toContain(
-    'Deselected, '
+    'Deselected,'
   )
-
-  // Wait one second and check that the aria label for yes no longer has deselected
   act(() => {
-    jest.advanceTimersByTime(1001)
+    jest.advanceTimersByTime(101)
   })
   expect(getByText('Yes').getAttribute('aria-label')).not.toContain(
-    'Deselected, '
+    'Deselected,'
   )
 
   // Select Yes

--- a/apps/bmd/src/__snapshots__/AppContestMultiSeat.test.tsx.snap
+++ b/apps/bmd/src/__snapshots__/AppContestMultiSeat.test.tsx.snap
@@ -646,7 +646,7 @@ exports[`Single Seat Contest 1`] = `
               class="c10"
             >
               <button
-                aria-label="Selected,  Camille Argent, Federalist."
+                aria-label="Selected, Camille Argent, Federalist."
                 class="c11"
                 data-choice="argent"
                 data-selected="true"
@@ -668,7 +668,7 @@ exports[`Single Seat Contest 1`] = `
                 </div>
               </button>
               <button
-                aria-label="Selected,  Chloe Witherspoon-Smithson, Federalist."
+                aria-label="Selected, Chloe Witherspoon-Smithson, Federalist."
                 class="c11"
                 data-choice="witherspoonsmithson"
                 data-selected="true"
@@ -690,7 +690,7 @@ exports[`Single Seat Contest 1`] = `
                 </div>
               </button>
               <button
-                aria-label="Selected,  Clayton Bainbridge, Federalist."
+                aria-label="Selected, Clayton Bainbridge, Federalist."
                 class="c11"
                 data-choice="bainbridge"
                 data-selected="true"
@@ -712,7 +712,7 @@ exports[`Single Seat Contest 1`] = `
                 </div>
               </button>
               <button
-                aria-label="Selected,  Charlene Hennessey, People's."
+                aria-label="Selected, Charlene Hennessey, People's."
                 class="c11"
                 data-choice="hennessey"
                 data-selected="true"

--- a/apps/bmd/src/__snapshots__/AppContestSingleSeat.test.tsx.snap
+++ b/apps/bmd/src/__snapshots__/AppContestSingleSeat.test.tsx.snap
@@ -646,7 +646,7 @@ exports[`Single Seat Contest 1`] = `
               class="c10"
             >
               <button
-                aria-label="Selected,  Joseph Barchi and Joseph Hallaren, Federalist."
+                aria-label="Selected, Joseph Barchi and Joseph Hallaren, Federalist."
                 class="c11"
                 data-choice="barchi-hallaren"
                 data-selected="true"

--- a/apps/bmd/src/components/CandidateContest.tsx
+++ b/apps/bmd/src/components/CandidateContest.tsx
@@ -147,7 +147,7 @@ const CandidateContest = ({ contest, parties, vote, updateVote }: Props) => {
     if (deselectedCandidate !== '') {
       const timer = setTimeout(() => {
         setDeselectedCandidate('')
-      }, 1000)
+      }, 100)
       return () => clearTimeout(timer)
     }
   }, [deselectedCandidate])
@@ -326,9 +326,9 @@ const CandidateContest = ({ contest, parties, vote, updateVote }: Props) => {
                     findPartyById(parties, candidate.partyId)
                   let prefixAudioText = ''
                   if (isChecked) {
-                    prefixAudioText = 'Selected, '
+                    prefixAudioText = 'Selected,'
                   } else if (deselectedCandidate === candidate.id) {
-                    prefixAudioText = 'Deselected, '
+                    prefixAudioText = 'Deselected,'
                   }
                   return (
                     <ChoiceButton

--- a/apps/bmd/src/components/YesNoContest.tsx
+++ b/apps/bmd/src/components/YesNoContest.tsx
@@ -61,7 +61,7 @@ const YesNoContest = ({ contest, vote, updateVote }: Props) => {
 
   useEffect(() => {
     if (deselectedVote !== '') {
-      const timer = setTimeout(() => setDeselectedVote(''), 1000)
+      const timer = setTimeout(() => setDeselectedVote(''), 100)
       return () => clearTimeout(timer)
     }
   }, [deselectedVote])
@@ -214,9 +214,9 @@ const YesNoContest = ({ contest, vote, updateVote }: Props) => {
               }
               let prefixAudioText = ''
               if (isChecked) {
-                prefixAudioText = 'Selected, '
+                prefixAudioText = 'Selected,'
               } else if (deselectedVote === answer.vote) {
-                prefixAudioText = 'Deselected, '
+                prefixAudioText = 'Deselected,'
               }
               return (
                 <ChoiceButton

--- a/apps/bmd/src/components/__snapshots__/CandidateContest.test.tsx.snap
+++ b/apps/bmd/src/components/__snapshots__/CandidateContest.test.tsx.snap
@@ -310,7 +310,7 @@ exports[`supports multi-seat contests allows a second candidate to be selected w
             class="c8"
           >
             <button
-              aria-label="Selected,  Name 0, Party 0."
+              aria-label="Selected, Name 0, Party 0."
               class="c9"
               data-choice="name-0"
               data-selected="true"
@@ -1017,7 +1017,7 @@ exports[`supports single-seat contest doesn't allow other candidates to be selec
             class="c8"
           >
             <button
-              aria-label="Selected,  Name 0, Party 0."
+              aria-label="Selected, Name 0, Party 0."
               class="c9"
               data-choice="name-0"
               data-selected="true"

--- a/apps/bmd/src/components/__snapshots__/YesNoContest.test.tsx.snap
+++ b/apps/bmd/src/components/__snapshots__/YesNoContest.test.tsx.snap
@@ -637,7 +637,7 @@ exports[`supports yes/no contest displays warning when attempting to change vote
             class="c2"
           >
             <p
-              aria-label="Selected,  Yes on Prop 1"
+              aria-label="Selected, Yes on Prop 1"
               class="c10"
             >
               Yes


### PR DESCRIPTION
Addresses comments from https://github.com/votingworks/vxsuite/pull/50 
I guess we had two spaces before so I had to update the snapshots. 

With 100ms for the timeout if I press enter to deselect then immediately down arrow and up arrow that is still too slow to have the "deselected" text read when I up arrow back to the candidate. 