### PR TITLE
Alphabetize precincts when printing full tally report

### DIFF
--- a/apps/election-manager/package.json
+++ b/apps/election-manager/package.json
@@ -88,6 +88,7 @@
     "dashify": "^2.0.0",
     "dompurify": "^2.0.12",
     "fetch-mock": "^9.10.7",
+    "history": "^4.10.1",
     "i18next": "^19.4.5",
     "js-file-download": "^0.4.12",
     "js-sha256": "^0.9.0",

--- a/apps/election-manager/src/components/LinkButton.tsx
+++ b/apps/election-manager/src/components/LinkButton.tsx
@@ -5,7 +5,8 @@ import Button, { ButtonInterface } from './Button'
 
 interface Props
   extends ButtonInterface,
-    RouteComponentProps<Record<PropertyKey, string>>,
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    RouteComponentProps<{}>,
     React.PropsWithoutRef<JSX.IntrinsicElements['button']> {
   goBack?: boolean
   onPress?: PointerEventHandler

--- a/apps/election-manager/src/contexts/AppContext.ts
+++ b/apps/election-manager/src/contexts/AppContext.ts
@@ -10,7 +10,7 @@ import CastVoteRecordFiles, {
   SaveCastVoteRecordFiles,
 } from '../utils/CastVoteRecordFiles'
 
-interface AppContextInterface {
+export interface AppContextInterface {
   castVoteRecordFiles: CastVoteRecordFiles
   electionDefinition?: ElectionDefinition
   configuredAt: ISO8601Timestamp

--- a/apps/election-manager/src/screens/PrintTestDeckScreen.test.tsx
+++ b/apps/election-manager/src/screens/PrintTestDeckScreen.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react'
+import { fireEvent, waitFor } from '@testing-library/react'
+import { Route } from 'react-router-dom'
+
+import PrintTestDeckScreen from './PrintTestDeckScreen'
+import fakeKiosk from '../../test/helpers/fakeKiosk'
+import renderInAppContext from '../../test/renderInAppContext'
+
+jest.mock('../components/HandMarkedPaperBallot')
+
+beforeAll(() => {
+  window.kiosk = fakeKiosk()
+})
+
+afterAll(() => {
+  delete window.kiosk
+})
+
+test('Printing the full test deck sorts precincts', async () => {
+  jest.useFakeTimers()
+  const mockKiosk = window.kiosk! as jest.Mocked<KioskBrowser.Kiosk>
+  mockKiosk.getPrinterInfo.mockResolvedValue([
+    {
+      description: 'VxPrinter',
+      isDefault: true,
+      name: 'VxPrinter',
+      status: 0,
+      connected: true,
+    },
+  ])
+
+  const { getByText, getByLabelText } = renderInAppContext(
+    <Route path="/tally/print-test-deck/:precinctId">
+      <PrintTestDeckScreen />
+    </Route>,
+    {
+      route: '/tally/print-test-deck/all',
+    }
+  )
+
+  fireEvent.click(getByText('Print Test Deck'))
+
+  // Check that the printing modals appear in alphabetical order
+  await waitFor(() => getByLabelText('Printing Test Deck, (1 of 13),: ,Bywy.'))
+  jest.advanceTimersByTime(15000)
+  await waitFor(() =>
+    getByLabelText('Printing Test Deck, (2 of 13),: ,Chester.')
+  )
+  jest.advanceTimersByTime(15000)
+  await waitFor(() =>
+    getByLabelText('Printing Test Deck, (3 of 13),: ,District 5.')
+  )
+  jest.advanceTimersByTime(15000)
+  await waitFor(() =>
+    getByLabelText('Printing Test Deck, (4 of 13),: ,East Weir.')
+  )
+  jest.advanceTimersByTime(15000)
+  await waitFor(() =>
+    getByLabelText('Printing Test Deck, (5 of 13),: ,Fentress.')
+  )
+  jest.advanceTimersByTime(15000)
+  await waitFor(() =>
+    getByLabelText('Printing Test Deck, (6 of 13),: ,French Camp.')
+  )
+  jest.advanceTimersByTime(15000)
+  await waitFor(() =>
+    getByLabelText('Printing Test Deck, (7 of 13),: ,Hebron.')
+  )
+  jest.advanceTimersByTime(15000)
+  await waitFor(() =>
+    getByLabelText('Printing Test Deck, (8 of 13),: ,Kenego.')
+  )
+  jest.advanceTimersByTime(15000)
+  await waitFor(() =>
+    getByLabelText('Printing Test Deck, (9 of 13),: ,Panhandle.')
+  )
+  jest.advanceTimersByTime(15000)
+  await waitFor(() =>
+    getByLabelText('Printing Test Deck, (10 of 13),: ,Reform.')
+  )
+  jest.advanceTimersByTime(15000)
+  await waitFor(() =>
+    getByLabelText('Printing Test Deck, (11 of 13),: ,Sherwood.')
+  )
+  jest.advanceTimersByTime(15000)
+  await waitFor(() =>
+    getByLabelText('Printing Test Deck, (12 of 13),: ,Southwest Ackerman.')
+  )
+  jest.advanceTimersByTime(15000)
+  await waitFor(() =>
+    getByLabelText('Printing Test Deck, (13 of 13),: ,West Weir.')
+  )
+})

--- a/apps/election-manager/src/screens/PrintTestDeckScreen.tsx
+++ b/apps/election-manager/src/screens/PrintTestDeckScreen.tsx
@@ -89,10 +89,13 @@ const PrintTestDeckScreen: React.FC = () => {
 
   useEffect(() => {
     if (precinctId) {
+      const sortedPrecincts = [...election.precincts].sort((a, b) =>
+        a.name.localeCompare(b.name, undefined, {
+          ignorePunctuation: true,
+        })
+      )
       const precinctIds =
-        precinctId === 'all'
-          ? election.precincts.map((p) => p.id)
-          : [precinctId]
+        precinctId === 'all' ? sortedPrecincts.map((p) => p.id) : [precinctId]
       setPrecinctIds(precinctIds)
     } else {
       setPrecinctIds([])

--- a/apps/election-manager/test/renderInAppContext.tsx
+++ b/apps/election-manager/test/renderInAppContext.tsx
@@ -1,0 +1,105 @@
+import { createMemoryHistory, MemoryHistory } from 'history'
+import React, { RefObject } from 'react'
+import { Router } from 'react-router-dom'
+import { render as testRender } from '@testing-library/react'
+import type { RenderResult } from '@testing-library/react'
+import * as fs from 'fs'
+import { sha256 } from 'js-sha256'
+import { join } from 'path'
+import { parseElection } from '@votingworks/ballot-encoder'
+
+import AppContext from '../src/contexts/AppContext'
+import {
+  ElectionDefinition,
+  SaveElection,
+  OptionalVoteCounts,
+  PrintedBallot,
+  ISO8601Timestamp,
+} from '../src/config/types'
+import CastVoteRecordFiles, {
+  SaveCastVoteRecordFiles,
+} from '../src/utils/CastVoteRecordFiles'
+
+const eitherNeitherElectionData = fs.readFileSync(
+  join(__dirname, 'fixtures/eitherneither-election.json'),
+  'utf-8'
+)
+const eitherNeitherElectionHash = sha256(eitherNeitherElectionData)
+const eitherNeitherElection = parseElection(
+  JSON.parse(eitherNeitherElectionData)
+)
+
+const defaultElectionDefinition = {
+  election: eitherNeitherElection,
+  electionData: eitherNeitherElectionData,
+  electionHash: eitherNeitherElectionHash,
+}
+
+interface RenderInAppContextParams {
+  route?: string | undefined
+  history?: MemoryHistory<any> // eslint-disable-line @typescript-eslint/no-explicit-any
+  castVoteRecordFiles?: CastVoteRecordFiles
+  electionDefinition?: ElectionDefinition
+  configuredAt?: ISO8601Timestamp
+  isOfficialResults?: boolean
+  printBallotRef?: RefObject<HTMLElement>
+  saveCastVoteRecordFiles?: SaveCastVoteRecordFiles
+  saveElection?: SaveElection
+  setCastVoteRecordFiles?: React.Dispatch<
+    React.SetStateAction<CastVoteRecordFiles>
+  >
+  saveIsOfficialResults?: () => void
+  setVoteCounts?: React.Dispatch<React.SetStateAction<OptionalVoteCounts>>
+  voteCounts?: OptionalVoteCounts
+  usbDriveStatus?: string
+  usbDriveEject?: () => void
+  addPrintedBallot?: (printedBallot: PrintedBallot) => void
+  printedBallots?: PrintedBallot[]
+}
+
+export default function renderInAppContext(
+  component: React.ReactNode,
+  {
+    route = '/',
+    history = createMemoryHistory({ initialEntries: [route] }),
+    castVoteRecordFiles = CastVoteRecordFiles.empty,
+    electionDefinition = defaultElectionDefinition,
+    configuredAt = '',
+    isOfficialResults = false,
+    printBallotRef = undefined,
+    saveCastVoteRecordFiles = jest.fn(),
+    saveElection = jest.fn(),
+    setCastVoteRecordFiles = jest.fn(),
+    saveIsOfficialResults = jest.fn(),
+    setVoteCounts = jest.fn(),
+    voteCounts = undefined,
+    usbDriveStatus = '',
+    usbDriveEject = jest.fn(),
+    addPrintedBallot = jest.fn(),
+    printedBallots = [],
+  } = {} as RenderInAppContextParams
+): RenderResult {
+  return testRender(
+    <AppContext.Provider
+      value={{
+        castVoteRecordFiles,
+        electionDefinition,
+        configuredAt,
+        isOfficialResults,
+        printBallotRef,
+        saveCastVoteRecordFiles,
+        saveElection,
+        setCastVoteRecordFiles,
+        saveIsOfficialResults,
+        setVoteCounts,
+        voteCounts,
+        usbDriveStatus,
+        usbDriveEject,
+        addPrintedBallot,
+        printedBallots,
+      }}
+    >
+      <Router history={history}>{component}</Router>
+    </AppContext.Provider>
+  )
+}

--- a/apps/election-manager/yarn.lock
+++ b/apps/election-manager/yarn.lock
@@ -6508,7 +6508,7 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-history@^4.9.0:
+history@^4.10.1, history@^4.9.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
   integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==


### PR DESCRIPTION
Alphabetizes the precinct list when printing all precincts for the test deck. It didn't seem like there were any tests related to this screen yet to be able to add a test for this, but tested manually. And definitely lmk if I'm missing something. 

https://github.com/votingworks/vxmail/issues/317