### PR TITLE
feat(hmpb-interpreter): add layout command

### DIFF
--- a/libs/hmpb-interpreter/.gitignore
+++ b/libs/hmpb-interpreter/.gitignore
@@ -7,6 +7,7 @@ node_modules
 !*.config.js
 !*rc.js
 !types/**/*.d.ts
+!bin/*.js
 
 # yarn
 !.yarn/**/*

--- a/libs/hmpb-interpreter/__mocks__/chalk.ts
+++ b/libs/hmpb-interpreter/__mocks__/chalk.ts
@@ -1,0 +1,5 @@
+const chalk = new Proxy((str: string) => str, {
+  get: () => chalk,
+}) as typeof import('chalk')
+
+export default chalk

--- a/libs/hmpb-interpreter/bin/hmpb-interpreter.js
+++ b/libs/hmpb-interpreter/bin/hmpb-interpreter.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+const main = require('../dist/src/cli').default
+
+main(process.argv, process.stdin, process.stdout, process.stderr).catch(
+  (error) => {
+    console.error(error)
+    process.exit(1)
+  }
+)

--- a/libs/hmpb-interpreter/src/cli/commands/help.test.ts
+++ b/libs/hmpb-interpreter/src/cli/commands/help.test.ts
@@ -1,4 +1,4 @@
-import run, { parseOptions } from './help'
+import { run, parseOptions } from './help'
 import { Readable } from 'stream'
 import MemoryStream from 'memorystream'
 
@@ -13,14 +13,32 @@ async function readStream(stream: Readable): Promise<string> {
 
 test('prints usage examples to stdout', async () => {
   const stdout = new MemoryStream()
-  run({}, Readable.from('') as NodeJS.ReadStream, stdout as NodeJS.WriteStream)
+  run(
+    { $0: 'hmpb-interpreter' },
+    Readable.from('') as NodeJS.ReadStream,
+    stdout as NodeJS.WriteStream
+  )
   stdout.end()
-  expect(await readStream(stdout)).toContain('Examples')
+  expect(await readStream(stdout)).toContain('hmpb-interpreter COMMAND')
 })
 
-test('does not expect any arguments', async () => {
-  expect(await parseOptions([])).toEqual({})
-  await expect(parseOptions(['foo'])).rejects.toThrowError(
-    `Unexpected argument to 'help': foo`
-  )
+test('expects an optional command', async () => {
+  expect(
+    await parseOptions({
+      command: 'help',
+      commandArgs: [],
+      executablePath: 'hmpb-interpreter',
+      nodePath: 'node',
+      help: true,
+    })
+  ).toEqual({ $0: 'hmpb-interpreter', command: undefined })
+  expect(
+    await parseOptions({
+      command: 'help',
+      commandArgs: ['foo'],
+      executablePath: 'hmpb-interpreter',
+      nodePath: 'node',
+      help: true,
+    })
+  ).toEqual({ $0: 'hmpb-interpreter', command: 'foo' })
 })

--- a/libs/hmpb-interpreter/src/cli/commands/help.ts
+++ b/libs/hmpb-interpreter/src/cli/commands/help.ts
@@ -28,7 +28,7 @@ export async function parseOptions({
   }
 }
 
-function printGlobalHelp(options: Options, out: NodeJS.WriteStream): void {
+function printGlobalHelp(options: Options, out: NodeJS.WritableStream): void {
   out.write(`Usage: ${options.$0} COMMAND [ARGS]\n`)
   out.write(`\n`)
   out.write(chalk.bold(`Commands:\n`))
@@ -49,14 +49,14 @@ function printGlobalHelp(options: Options, out: NodeJS.WriteStream): void {
 
 export function printCommandHelp(
   options: Options,
-  out: NodeJS.WriteStream
+  out: NodeJS.WritableStream
 ): void {
   out.write(`Usage: ${options.$0} help COMMAND\n`)
   out.write(`\n`)
   out.write(`Print usage information for COMMAND.\n`)
 }
 
-export function printHelp(options: Options, out: NodeJS.WriteStream): void {
+export function printHelp(options: Options, out: NodeJS.WritableStream): void {
   switch (options.command) {
     case undefined:
       printGlobalHelp(options, out)
@@ -81,8 +81,8 @@ export function printHelp(options: Options, out: NodeJS.WriteStream): void {
 
 export async function run(
   options: Options,
-  _stdin: NodeJS.ReadStream,
-  stdout: NodeJS.WriteStream
+  _stdin: NodeJS.ReadableStream,
+  stdout: NodeJS.WritableStream
 ): Promise<number> {
   printHelp(options, stdout)
   return 0

--- a/libs/hmpb-interpreter/src/cli/commands/interpret.test.ts
+++ b/libs/hmpb-interpreter/src/cli/commands/interpret.test.ts
@@ -4,13 +4,19 @@ import { join } from 'path'
 
 test('parse options: --election', async () => {
   expect(
-    await parseOptions([
-      '--election',
-      join(
-        __dirname,
-        '../../../test/fixtures/election-4e31cb17d8-ballot-style-77-precinct-oaklawn-branch-library/election.json'
-      ),
-    ])
+    await parseOptions({
+      nodePath: 'node',
+      executablePath: 'hmpb-interpreter',
+      help: false,
+      command: 'interpret',
+      commandArgs: [
+        '--election',
+        join(
+          __dirname,
+          '../../../test/fixtures/election-4e31cb17d8-ballot-style-77-precinct-oaklawn-branch-library/election.json'
+        ),
+      ],
+    })
   ).toEqual(
     expect.objectContaining({
       election,
@@ -18,13 +24,19 @@ test('parse options: --election', async () => {
   )
 
   expect(
-    await parseOptions([
-      '-e',
-      join(
-        __dirname,
-        '../../../test/fixtures/election-4e31cb17d8-ballot-style-77-precinct-oaklawn-branch-library/election.json'
-      ),
-    ])
+    await parseOptions({
+      nodePath: 'node',
+      executablePath: 'hmpb-interpreter',
+      help: false,
+      command: 'interpret',
+      commandArgs: [
+        '-e',
+        join(
+          __dirname,
+          '../../../test/fixtures/election-4e31cb17d8-ballot-style-77-precinct-oaklawn-branch-library/election.json'
+        ),
+      ],
+    })
   ).toEqual(
     expect.objectContaining({
       election,

--- a/libs/hmpb-interpreter/src/cli/commands/interpret.ts
+++ b/libs/hmpb-interpreter/src/cli/commands/interpret.ts
@@ -39,7 +39,7 @@ function makeInputFromBallotArgument(arg: string): Input {
   return input
 }
 
-export function printHelp($0: string, out: NodeJS.WriteStream): void {
+export function printHelp($0: string, out: NodeJS.WritableStream): void {
   out.write(`${$0} interpret -e JSON IMG1 [IMG2 …]\n`)
   out.write(`\n`)
   out.write(chalk.italic(`Examples\n`))
@@ -106,18 +106,22 @@ export async function parseOptions({
       }
 
       case '-m':
-      case '--min-mark-score':
+      case '--min-mark-score': {
         i += 1
-        markScoreVoteThreshold = parseFloat(args[i])
+        const thresholdString = args[i]
+        markScoreVoteThreshold =
+          parseFloat(thresholdString) *
+          (thresholdString.endsWith('%') ? 0.01 : 1)
         if (isNaN(markScoreVoteThreshold)) {
           throw new OptionParseError(`Invalid minimum mark score: ${args[i]}`)
         }
         break
+      }
 
       case '-f':
       case '--format':
         i += 1
-        format = args[i] as OutputFormat
+        format = args[i].toLowerCase() as OutputFormat
         if (format !== OutputFormat.Table && format !== OutputFormat.JSON) {
           throw new OptionParseError(`Unknown output format: ${format}`)
         }
@@ -188,8 +192,8 @@ export async function parseOptions({
 
 export async function run(
   options: Options,
-  _stdin: NodeJS.ReadStream,
-  stdout: NodeJS.WriteStream
+  _stdin: NodeJS.ReadableStream,
+  stdout: NodeJS.WritableStream
 ): Promise<number> {
   const interpreter = new Interpreter({
     election: options.election,

--- a/libs/hmpb-interpreter/src/cli/commands/layout.ts
+++ b/libs/hmpb-interpreter/src/cli/commands/layout.ts
@@ -1,0 +1,164 @@
+import { strict as assert } from 'assert'
+import chalk from 'chalk'
+import { GlobalOptions, OptionParseError } from '..'
+import { writeImageToFile } from '../../../test/utils'
+import findContests from '../../hmpb/findContests'
+import { Point, Rect } from '../../types'
+import { binarize, RGBA } from '../../utils/binarize'
+import { getImageChannelCount } from '../../utils/imageFormatUtils'
+import { adjacentFile } from '../../utils/path'
+import { loadImageData } from '../../utils/images'
+
+export interface Options {
+  ballotImagePaths: readonly string[]
+}
+
+const RGBA_CHANNELS = 4
+const RED_OVERLAY_COLOR: RGBA = [0xff, 0, 0, 0x60]
+const GREEN_OVERLAY_COLOR: RGBA = [0, 0xff, 0, 0x60]
+
+export const name = 'layout'
+export const description = 'Annotate the interpreted layout of a ballot page'
+
+export function printHelp($0: string, out: NodeJS.WriteStream): void {
+  out.write(`${$0} layout IMG1 [IMG2 …]\n`)
+  out.write(`\n`)
+  out.write(chalk.italic(`Examples\n`))
+  out.write(`\n`)
+  out.write(chalk.gray(`# Annotate layout for a single ballot page.\n`))
+  out.write(`${$0} layout ballot01.png\n`)
+  out.write(`\n`)
+  out.write(chalk.gray(`# Annotate layout for many ballot pages.\n`))
+  out.write(`${$0} layout ballot*.png\n`)
+}
+
+export async function parseOptions({
+  commandArgs: args,
+}: GlobalOptions): Promise<Options> {
+  const ballotImagePaths: string[] = []
+
+  for (const arg of args) {
+    if (arg.startsWith('-')) {
+      throw new OptionParseError(`unexpected option passed to 'layout': ${arg}`)
+    }
+
+    ballotImagePaths.push(arg)
+  }
+
+  return { ballotImagePaths }
+}
+
+/**
+ * Finds features in an image and writes an image adjacent with overlays marking
+ * those features.
+ */
+export async function run(
+  options: Options,
+  _stdin: NodeJS.ReadStream,
+  stdout: NodeJS.WriteStream
+): Promise<number> {
+  for (const ballotImagePath of options.ballotImagePaths) {
+    const imageData = await loadImageData(ballotImagePath)
+    const binarized: ImageData = {
+      data: new Uint8ClampedArray(imageData.data.length),
+      width: imageData.width,
+      height: imageData.height,
+    }
+    binarize(imageData, binarized)
+
+    const threeColumnContests = [
+      ...findContests(imageData, { columns: [true, true, true] }),
+    ]
+    const contests =
+      threeColumnContests.length === 0
+        ? [...findContests(imageData, { columns: [true, true] })]
+        : threeColumnContests
+    const targetWidth = Math.max(15, Math.round(imageData.width * 0.01))
+
+    for (const contest of contests) {
+      fill(imageData, contest.bounds, GREEN_OVERLAY_COLOR)
+
+      for (const corner of contest.corners) {
+        drawTarget(imageData, corner, RED_OVERLAY_COLOR, targetWidth)
+      }
+    }
+
+    const layoutFilePath = adjacentFile('-layout', ballotImagePath)
+    stdout.write(
+      `📝 ${layoutFilePath} ${chalk.gray(`(${contests.length} contest(s))`)}\n`
+    )
+    await writeImageToFile(imageData, layoutFilePath)
+  }
+
+  return 0
+}
+
+/**
+ * Draws a target composed of concentric squares around a given point. If the
+ * color has transparency, the fill blends with the existing image.
+ */
+function drawTarget(
+  { data, width, height }: ImageData,
+  { x, y }: Point,
+  color: RGBA,
+  size: number
+): void {
+  assert.equal(getImageChannelCount({ data, width, height }), RGBA_CHANNELS)
+
+  const halfSize = Math.ceil(size / 2)
+
+  for (let xd = -halfSize; xd <= halfSize; xd++) {
+    for (let yd = -halfSize; yd <= halfSize; yd++) {
+      if (
+        (xd % 2 !== 0 && Math.abs(yd) <= Math.abs(xd)) ||
+        (yd % 2 !== 0 && Math.abs(xd) <= Math.abs(yd))
+      ) {
+        const offset = ((y + yd) * width + (x + xd)) * RGBA_CHANNELS
+        const dst = data.slice(offset, offset + RGBA_CHANNELS)
+        data.set(alphaBlend(dst, color), offset)
+      }
+    }
+  }
+}
+
+/**
+ * Fills a region of an image with a particular color. If the color has
+ * transparency, the fill blends with the existing image.
+ */
+function fill(
+  { data, width, height }: ImageData,
+  bounds: Rect,
+  color: RGBA
+): void {
+  assert.equal(getImageChannelCount({ data, width, height }), RGBA_CHANNELS)
+
+  for (let y = bounds.y; y < bounds.y + bounds.height; y++) {
+    for (let x = bounds.x; x < bounds.x + bounds.width; x++) {
+      const offset = (y * width + x) * RGBA_CHANNELS
+      const dst = data.slice(offset, offset + RGBA_CHANNELS)
+      data.set(alphaBlend(dst, color), offset)
+    }
+  }
+}
+
+/**
+ * Computes the color of a pixel by blending `src` on top of `dst`.
+ *
+ * @see https://en.wikipedia.org/wiki/Alpha_compositing#Alpha_blending
+ */
+function alphaBlend(dst: ArrayLike<number>, src: ArrayLike<number>): RGBA {
+  const dstR = dst[0]
+  const dstG = dst[1]
+  const dstB = dst[2]
+  const dstA = dst[3]
+  const srcR = src[0]
+  const srcG = src[1]
+  const srcB = src[2]
+  const srcA = src[3]
+  return [
+    (srcR * srcA) / 0xff + ((dstR * dstA) / 0xff) * (1 - srcA / 0xff),
+    (srcG * srcA) / 0xff + ((dstG * dstA) / 0xff) * (1 - srcA / 0xff),
+    (srcB * srcA) / 0xff + ((dstB * dstA) / 0xff) * (1 - srcA / 0xff),
+    (srcA / 0xff + (1 - srcA / 0xff)) * 0xff,
+  ]
+}

--- a/libs/hmpb-interpreter/src/cli/commands/layout.ts
+++ b/libs/hmpb-interpreter/src/cli/commands/layout.ts
@@ -20,7 +20,7 @@ const GREEN_OVERLAY_COLOR: RGBA = [0, 0xff, 0, 0x60]
 export const name = 'layout'
 export const description = 'Annotate the interpreted layout of a ballot page'
 
-export function printHelp($0: string, out: NodeJS.WriteStream): void {
+export function printHelp($0: string, out: NodeJS.WritableStream): void {
   out.write(`${$0} layout IMG1 [IMG2 …]\n`)
   out.write(`\n`)
   out.write(chalk.italic(`Examples\n`))
@@ -54,8 +54,8 @@ export async function parseOptions({
  */
 export async function run(
   options: Options,
-  _stdin: NodeJS.ReadStream,
-  stdout: NodeJS.WriteStream
+  _stdin: NodeJS.ReadableStream,
+  stdout: NodeJS.WritableStream
 ): Promise<number> {
   for (const ballotImagePath of options.ballotImagePaths) {
     const imageData = await loadImageData(ballotImagePath)

--- a/libs/hmpb-interpreter/src/cli/index.ts
+++ b/libs/hmpb-interpreter/src/cli/index.ts
@@ -81,36 +81,36 @@ export async function parseOptions(args: readonly string[]): Promise<Options> {
     }
   }
 
-  const { commandArgs } = globalOptions
-  switch (commandArgs[0]) {
+  const { command } = globalOptions
+  switch (command) {
     case 'help':
       return {
-        command: commandArgs[0],
+        command,
         options: await helpCommand.parseOptions(globalOptions),
       }
 
     case 'interpret':
       return {
-        command: commandArgs[0],
+        command,
         options: await interpretCommand.parseOptions(globalOptions),
       }
 
     case 'layout':
       return {
-        command: commandArgs[0],
+        command,
         options: await layoutCommand.parseOptions(globalOptions),
       }
 
     default:
-      throw new OptionParseError(`Unknown command: ${args[2]}`)
+      throw new OptionParseError(`Unknown command: ${command}`)
   }
 }
 
 export default async function main(
   args: typeof process.argv,
-  stdin: NodeJS.ReadStream,
-  stdout: NodeJS.WriteStream,
-  stderr: NodeJS.WriteStream
+  stdin: NodeJS.ReadableStream,
+  stdout: NodeJS.WritableStream,
+  stderr: NodeJS.WritableStream
 ): Promise<number> {
   try {
     const commandOptions = await parseOptions(args)

--- a/libs/hmpb-interpreter/src/utils/path.ts
+++ b/libs/hmpb-interpreter/src/utils/path.ts
@@ -1,0 +1,14 @@
+import { basename, dirname, extname, join } from 'path'
+
+/**
+ * Gets the path to a file adjacent to this one.
+ *
+ * @example
+ *
+ */
+export function adjacentFile(suffix: string, path: string): string {
+  const dir = dirname(path)
+  const ext = extname(path)
+  const base = basename(path, ext)
+  return join(dir, base + suffix + ext)
+}

--- a/libs/hmpb-interpreter/test/fixtures/election-4e31cb17d8-ballot-style-77-precinct-oaklawn-branch-library/index.ts
+++ b/libs/hmpb-interpreter/test/fixtures/election-4e31cb17d8-ballot-style-77-precinct-oaklawn-branch-library/index.ts
@@ -2,6 +2,7 @@ import { join } from 'path'
 import { Fixture } from '../../fixtures'
 import election from './election'
 
+export const electionPath = join(__dirname, 'election.json')
 export const blankPage1 = new Fixture(join(__dirname, 'blank-p1.jpg'))
 export const blankPage2 = new Fixture(join(__dirname, 'blank-p2.jpg'))
 export const filledInPage1 = new Fixture(join(__dirname, 'filled-in-p1.jpg'))


### PR DESCRIPTION
This command annotates an image with contest/corner/etc information.

![20201102_210050-ballot-0024-a6726196-f77c-45d9-b23a-fa8edd084688-original-layout](https://user-images.githubusercontent.com/1938/98883847-b4d1f700-2443-11eb-9183-7b5aa208a3d4.png)
