### PR TITLE
Add election definition type and exports to ballot encoder

### DIFF
--- a/libs/ballot-encoder/package.json
+++ b/libs/ballot-encoder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@votingworks/ballot-encoder",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "main": "src/index.js",
   "types": "src/index.d.ts",
   "files": [
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@antongolub/iso8601": "^1.2.1",
+    "js-sha256": "^0.9.0",
     "zod": "1.7.1"
   },
   "devDependencies": {

--- a/libs/ballot-encoder/package.json
+++ b/libs/ballot-encoder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@votingworks/ballot-encoder",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "main": "src/index.js",
   "types": "src/index.d.ts",
   "files": [

--- a/libs/ballot-encoder/src/election.ts
+++ b/libs/ballot-encoder/src/election.ts
@@ -1,6 +1,6 @@
-import electionSampleUntyped from './data/electionSample.json'
-import electionSampleLongContentUntyped from './data/electionSampleLongContent.json'
 import * as s from './schema'
+import * as fs from 'fs'
+import { sha256 } from 'js-sha256'
 
 // Generic
 export type VoidFunction = () => void
@@ -118,6 +118,11 @@ export interface Election {
   readonly adjudicationReasons?: readonly AdjudicationReason[]
 }
 export type OptionalElection = Optional<Election>
+export interface ElectionDefinition {
+  election: Election
+  electionHash: string
+}
+export type OptionalElectionDefinition = Optional<ElectionDefinition>
 
 // Votes
 export type CandidateVote = readonly Candidate[]
@@ -279,8 +284,31 @@ export const validateVotes = ({
   }
 }
 
+const electionSampleAsString = fs.readFileSync(
+  './data/electionSample.json',
+  'utf8'
+)
+const electionSampleLongContentAsString = fs.readFileSync(
+  './data/electionSampleLongContent.json',
+  'utf8'
+)
+
+const electionSampleUntyped = JSON.parse(electionSampleAsString)
+const electionSampleLongContentUntyped = JSON.parse(
+  electionSampleLongContentAsString
+)
 export const electionSample = (electionSampleUntyped as unknown) as Election
 export const electionSampleLongContent = (electionSampleLongContentUntyped as unknown) as Election
+
+export const electionDefinitionSample = {
+  election: electionSample,
+  electionHash: sha256(electionSampleAsString),
+} as ElectionDefinition
+
+export const electionDefinitionSampleLongContent = {
+  election: electionSampleLongContent,
+  electionHash: sha256(electionSampleLongContentAsString),
+} as ElectionDefinition
 
 /**
  * @deprecated Does not support i18n. 'party.fullname` should be used instead.

--- a/libs/ballot-encoder/src/election.ts
+++ b/libs/ballot-encoder/src/election.ts
@@ -1,5 +1,6 @@
 import * as s from './schema'
 import * as fs from 'fs'
+import * as path from 'path'
 import { sha256 } from 'js-sha256'
 
 // Generic
@@ -285,11 +286,11 @@ export const validateVotes = ({
 }
 
 const electionSampleAsString = fs.readFileSync(
-  './data/electionSample.json',
+  path.resolve(__dirname, './data/electionSample.json'),
   'utf8'
 )
 const electionSampleLongContentAsString = fs.readFileSync(
-  './data/electionSampleLongContent.json',
+  path.resolve(__dirname, './data/electionSampleLongContent.json'),
   'utf8'
 )
 

--- a/libs/ballot-encoder/yarn.lock
+++ b/libs/ballot-encoder/yarn.lock
@@ -3000,6 +3000,11 @@ jest@^26.6.2:
     import-local "^3.0.2"
     jest-cli "^26.6.2"
 
+js-sha256@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.9.0.tgz#0b89ac166583e91ef9123644bd3c5334ce9d0966"
+  integrity sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
As a first step to https://github.com/votingworks/vxsuite/pull/78 adds the ElectionDefinition type and exports of the sample files to ballot-encoder. 

I tried to do this within my other PR but it felt weird to npm publish things before they were reviewed so I decided to just split it out. 