### PR TITLE
Bump npm version

### DIFF
--- a/libs/ballot-encoder/package.json
+++ b/libs/ballot-encoder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@votingworks/ballot-encoder",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "main": "src/index.js",
   "types": "src/index.d.ts",
   "files": [


### PR DESCRIPTION
Published 5.1.0 incorrectly, so bumping the version so I can publish a new version 5.1.1 properly. Tested the right workflow by publishing https://www.npmjs.com/package/@votingworks/ballot-encoder/v/5.1.0-beta.1 which looks right (tested imported in bmd and everything worked fine). This was my bad for not reading the readme. 