### PR TITLE
Revert to importing json file directly in ballot encoder

### DIFF
--- a/libs/ballot-encoder/package.json
+++ b/libs/ballot-encoder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@votingworks/ballot-encoder",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "main": "src/index.js",
   "types": "src/index.d.ts",
   "files": [

--- a/libs/ballot-encoder/src/election.ts
+++ b/libs/ballot-encoder/src/election.ts
@@ -1,7 +1,8 @@
 import * as s from './schema'
-import * as fs from 'fs'
-import * as path from 'path'
 import { sha256 } from 'js-sha256'
+
+import electionSampleUntyped from './data/electionSample.json'
+import electionSampleLongContentUntyped from './data/electionSampleLongContent.json'
 
 // Generic
 export type VoidFunction = () => void
@@ -285,30 +286,17 @@ export const validateVotes = ({
   }
 }
 
-const electionSampleAsString = fs.readFileSync(
-  path.resolve(__dirname, './data/electionSample.json'),
-  'utf8'
-)
-const electionSampleLongContentAsString = fs.readFileSync(
-  path.resolve(__dirname, './data/electionSampleLongContent.json'),
-  'utf8'
-)
-
-const electionSampleUntyped = JSON.parse(electionSampleAsString)
-const electionSampleLongContentUntyped = JSON.parse(
-  electionSampleLongContentAsString
-)
 export const electionSample = (electionSampleUntyped as unknown) as Election
 export const electionSampleLongContent = (electionSampleLongContentUntyped as unknown) as Election
 
 export const electionDefinitionSample = {
   election: electionSample,
-  electionHash: sha256(electionSampleAsString),
+  electionHash: sha256(JSON.stringify(electionSampleUntyped)),
 } as ElectionDefinition
 
 export const electionDefinitionSampleLongContent = {
   election: electionSampleLongContent,
-  electionHash: sha256(electionSampleLongContentAsString),
+  electionHash: sha256(JSON.stringify(electionSampleLongContentUntyped)),
 } as ElectionDefinition
 
 /**


### PR DESCRIPTION
This file is imported client-side in bmd and fs does not actually exist in that environment so we can't use fs here. This reverts to just using our previous method of importing the json file directly. Unfortunately this means that the json is automatically parsed as json so we have to stringify it to get the hash. If there is a way around this lmk but I couldn't figure one out. I think though since this is just used for tests and the sample app that it shouldn't be a huge concern. 

Sym-Linked to bmd to test that this actually fixed the problem on bmd's side. 