### PR TITLE
Automatically save ballot config when exporting

### DIFF
--- a/apps/election-manager/src/App.test.tsx
+++ b/apps/election-manager/src/App.test.tsx
@@ -46,6 +46,8 @@ const EITHER_NEITHER_CVRS = new File(
 
 jest.mock('./components/HandMarkedPaperBallot')
 
+type WriteFileOp = (path: string) => Promise<KioskBrowser.FileWriter>
+
 beforeEach(() => {
   // we don't care about network errors logged to the console, they're crowding things
   jest.spyOn(console, 'error').mockImplementation(() => {}) // eslint-disable-line @typescript-eslint/no-empty-function
@@ -132,12 +134,14 @@ it('printing ballots, print report, and test decks', async () => {
   fireEvent.click(getByText('Close'))
 
   // Mock the file stream and export again
-  mockKiosk.writeFile.mockResolvedValue(fakeFileWriter())
+  ;(mockKiosk.writeFile as WriteFileOp) = jest
+    .fn()
+    .mockResolvedValue(fakeFileWriter())
   fireEvent.click(getByText('Export Ballot Package'))
   fireEvent.click(getByText('Export'))
   await screen.findByText(/Generating Ballot/)
   expect(mockKiosk.makeDirectory).toHaveBeenCalledTimes(2)
-  expect(mockKiosk.writeFile).toHaveBeenCalledTimes(2)
+  expect(mockKiosk.writeFile).toHaveBeenCalledTimes(1) // Since we recreated the jest function to mock the response this will be 1
 
   fireEvent.click(getByText('Ballots'))
   fireEvent.click(getAllByText('View Ballot')[0])

--- a/apps/election-manager/src/App.test.tsx
+++ b/apps/election-manager/src/App.test.tsx
@@ -21,6 +21,7 @@ import App from './App'
 
 import sleep from './utils/sleep'
 import { ElectionDefinition } from './config/types'
+import fakeFileWriter from '../test/helpers/fakeFileWriter'
 
 const eitherNeitherElectionData = fs.readFileSync(
   join(__dirname, '../test/fixtures/eitherneither-election.json'),
@@ -121,13 +122,22 @@ it('printing ballots, print report, and test decks', async () => {
   // go print some ballots
   fireEvent.click(getByText('Export Ballot Package'))
   fireEvent.click(getByText('Export'))
-  expect(mockKiosk.saveAs).toHaveBeenCalledTimes(1)
 
   jest.useRealTimers()
 
   // we're not mocking the filestream yet
   await screen.findByText(/Download Failed/)
+  expect(mockKiosk.makeDirectory).toHaveBeenCalledTimes(1)
+  expect(mockKiosk.writeFile).toHaveBeenCalledTimes(1)
   fireEvent.click(getByText('Close'))
+
+  // Mock the file stream and export again
+  mockKiosk.writeFile.mockResolvedValue(fakeFileWriter())
+  fireEvent.click(getByText('Export Ballot Package'))
+  fireEvent.click(getByText('Export'))
+  await screen.findByText(/Generating Ballot/)
+  expect(mockKiosk.makeDirectory).toHaveBeenCalledTimes(2)
+  expect(mockKiosk.writeFile).toHaveBeenCalledTimes(2)
 
   fireEvent.click(getByText('Ballots'))
   fireEvent.click(getAllByText('View Ballot')[0])

--- a/apps/election-manager/src/components/ExportElectionBallotPackageModalButton.test.tsx
+++ b/apps/election-manager/src/components/ExportElectionBallotPackageModalButton.test.tsx
@@ -129,7 +129,7 @@ test('Modal renders error message appropriately', async () => {
   fireEvent.click(getByText('Export Ballot Package'))
   await waitFor(() => getByText('Export'))
 
-  fireEvent.click(queryAllByTestId('manual-link')[0])
+  fireEvent.click(getByText('Custom'))
 
   await waitFor(() => getByText(/Download Failed/))
   expect(queryAllByTestId('modal')).toHaveLength(1)

--- a/apps/election-manager/src/components/ExportElectionBallotPackageModalButton.test.tsx
+++ b/apps/election-manager/src/components/ExportElectionBallotPackageModalButton.test.tsx
@@ -128,7 +128,7 @@ test('Modal renders error message appropriately', async () => {
   fireEvent.click(getByText('Export Ballot Package'))
   await waitFor(() => getByText('Export'))
 
-  fireEvent.click(getByText('Export'))
+  fireEvent.click(queryAllByTestId('manual-link')[0])
 
   await waitFor(() => getByText(/Download Failed/))
   expect(queryAllByTestId('modal')).toHaveLength(1)
@@ -145,8 +145,8 @@ test('Modal renders renders loading message while rendering ballots appropriatel
   const mockKiosk = fakeKiosk()
   const fileWriter = fakeFileWriter()
   window.kiosk = mockKiosk
-  const saveAsFunction = jest.fn().mockResolvedValue(fileWriter)
-  mockKiosk.saveAs = saveAsFunction
+  const writeFunction = jest.fn().mockResolvedValue(fileWriter)
+  mockKiosk.writeFile = writeFunction
   const ejectFunction = jest.fn()
   const { queryAllByTestId, getByText, queryAllByText } = renderInAppContext(
     <ExportElectionBallotPackageModalButton />,
@@ -161,7 +161,8 @@ test('Modal renders renders loading message while rendering ballots appropriatel
   fireEvent.click(getByText('Export'))
 
   await waitFor(() => getByText(/Download Complete/))
-  expect(saveAsFunction).toHaveBeenCalledTimes(1)
+  expect(writeFunction).toHaveBeenCalledTimes(1)
+  expect(mockKiosk.makeDirectory).toHaveBeenCalledTimes(1)
 
   expect(queryAllByTestId('modal')).toHaveLength(1)
   expect(

--- a/apps/election-manager/src/components/ExportElectionBallotPackageModalButton.test.tsx
+++ b/apps/election-manager/src/components/ExportElectionBallotPackageModalButton.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { fireEvent, waitFor } from '@testing-library/react'
-import fakeKiosk from '../../test/helpers/fakeKiosk'
+import fakeKiosk, { fakeUsbDrive } from '../../test/helpers/fakeKiosk'
 import renderInAppContext from '../../test/renderInAppContext'
 import ExportElectionBallotPackageModalButton from './ExportElectionBallotPackageModalButton'
 import { UsbDriveStatus } from '../lib/usbstick'
@@ -8,11 +8,16 @@ import fakeFileWriter from '../../test/helpers/fakeFileWriter'
 
 jest.mock('../components/HandMarkedPaperBallot')
 
-beforeAll(() => {
-  window.kiosk = fakeKiosk()
+beforeEach(() => {
+  const mockKiosk = fakeKiosk()
+  mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()])
+  const fileWriter = fakeFileWriter()
+  mockKiosk.saveAs = jest.fn().mockResolvedValue(fileWriter)
+  mockKiosk.writeFile = jest.fn().mockResolvedValue(fileWriter)
+  window.kiosk = mockKiosk
 })
 
-afterAll(() => {
+afterEach(() => {
   delete window.kiosk
 })
 
@@ -60,11 +65,6 @@ test('Modal renders insert usb screen appropriately', async () => {
 })
 
 test('Modal renders export confirmation screen when usb detected and manual link works as expected', async () => {
-  const mockKiosk = fakeKiosk()
-  const fileWriter = fakeFileWriter()
-  window.kiosk = mockKiosk
-  const saveAsFunction = jest.fn().mockResolvedValue(fileWriter)
-  mockKiosk.saveAs = saveAsFunction
   const {
     getByText,
     queryAllByText,
@@ -91,7 +91,7 @@ test('Modal renders export confirmation screen when usb detected and manual link
   fireEvent.click(getByText('Custom'))
   await waitFor(() => getByText(/Download Complete/))
   await waitFor(() => {
-    expect(saveAsFunction).toHaveBeenCalledTimes(1)
+    expect(window.kiosk!.saveAs).toHaveBeenCalledTimes(1)
   })
 
   fireEvent.click(getByText('Cancel'))
@@ -119,6 +119,7 @@ test('Modal renders loading screen when usb drive is mounting or ejecting', asyn
 })
 
 test('Modal renders error message appropriately', async () => {
+  window.kiosk!.saveAs = jest.fn().mockResolvedValue(undefined)
   const { queryAllByTestId, getByText, queryAllByText } = renderInAppContext(
     <ExportElectionBallotPackageModalButton />,
     {
@@ -142,11 +143,6 @@ test('Modal renders error message appropriately', async () => {
 })
 
 test('Modal renders renders loading message while rendering ballots appropriately', async () => {
-  const mockKiosk = fakeKiosk()
-  const fileWriter = fakeFileWriter()
-  window.kiosk = mockKiosk
-  const writeFunction = jest.fn().mockResolvedValue(fileWriter)
-  mockKiosk.writeFile = writeFunction
   const ejectFunction = jest.fn()
   const { queryAllByTestId, getByText, queryAllByText } = renderInAppContext(
     <ExportElectionBallotPackageModalButton />,
@@ -161,8 +157,8 @@ test('Modal renders renders loading message while rendering ballots appropriatel
   fireEvent.click(getByText('Export'))
 
   await waitFor(() => getByText(/Download Complete/))
-  expect(writeFunction).toHaveBeenCalledTimes(1)
-  expect(mockKiosk.makeDirectory).toHaveBeenCalledTimes(1)
+  expect(window.kiosk!.writeFile).toHaveBeenCalledTimes(1)
+  expect(window.kiosk!.makeDirectory).toHaveBeenCalledTimes(1)
 
   expect(queryAllByTestId('modal')).toHaveLength(1)
   expect(

--- a/apps/election-manager/src/components/ExportElectionBallotPackageModalButton.tsx
+++ b/apps/election-manager/src/components/ExportElectionBallotPackageModalButton.tsx
@@ -25,7 +25,7 @@ import USBControllerButton from './USBControllerButton'
 import * as workflow from '../workflows/ExportElectionBallotPackageWorkflow'
 import {
   generateFilenameForBallotExportPackage,
-  EXPORT_FOLDER,
+  BALLOT_PACKAGES_FOLDER,
 } from '../utils/filenames'
 
 const USBImage = styled.img`
@@ -116,18 +116,15 @@ const ExportElectionBallotPackageModalButton: React.FC = () => {
     }
     try {
       const usbPath = await getDevicePath()
-      const pathToFolder = path.join(usbPath, EXPORT_FOLDER)
-      const pathToFile = path.join(usbPath, EXPORT_FOLDER, defaultFileName)
+      const pathToFolder = path.join(usbPath!, BALLOT_PACKAGES_FOLDER)
+      const pathToFile = path.join(pathToFolder, defaultFileName)
       if (openDialog) {
         await state.archive.beginWithDialog({
           defaultPath: pathToFile,
           filters: [{ name: 'Archive Files', extensions: ['zip'] }],
         })
       } else {
-        await window.kiosk!.makeDirectory(pathToFolder, {
-          recursive: true,
-        })
-        await state.archive.beginWithDirectSave(pathToFile)
+        await state.archive.beginWithDirectSave(pathToFolder, defaultFileName)
       }
       await state.archive.file('election.json', electionData)
       await state.archive.file(

--- a/apps/election-manager/src/components/ExportElectionBallotPackageModalButton.tsx
+++ b/apps/election-manager/src/components/ExportElectionBallotPackageModalButton.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useContext, useEffect, useState } from 'react'
 import pluralize from 'pluralize'
 import styled from 'styled-components'
+import path from 'path'
 import { getElectionLocales } from '@votingworks/ballot-encoder'
 
 import { DEFAULT_LOCALE } from '../config/globals'
@@ -22,7 +23,10 @@ import { getDevicePath, UsbDriveStatus } from '../lib/usbstick'
 import USBControllerButton from './USBControllerButton'
 
 import * as workflow from '../workflows/ExportElectionBallotPackageWorkflow'
-import { generateFilenameForBallotExportPackage } from '../utils/filenames'
+import {
+  generateFilenameForBallotExportPackage,
+  EXPORT_FOLDER,
+} from '../utils/filenames'
 
 const USBImage = styled.img`
   margin-right: auto;
@@ -111,20 +115,19 @@ const ExportElectionBallotPackageModalButton: React.FC = () => {
       )
     }
     try {
-      const usbPathRaw = await getDevicePath()
-      const usbPath = usbPathRaw ? `${usbPathRaw}/` : ''
+      const usbPath = await getDevicePath()
+      const pathToFolder = path.join(usbPath, EXPORT_FOLDER)
+      const pathToFile = path.join(usbPath, EXPORT_FOLDER, defaultFileName)
       if (openDialog) {
         await state.archive.beginWithDialog({
-          defaultPath: `${usbPath}ballot-export-packages/${defaultFileName}`,
+          defaultPath: pathToFile,
           filters: [{ name: 'Archive Files', extensions: ['zip'] }],
         })
       } else {
-        await window.kiosk!.makeDirectory(`${usbPath}ballot-export-packages`, {
+        await window.kiosk!.makeDirectory(pathToFolder, {
           recursive: true,
         })
-        await state.archive.beginWithDirectSave(
-          `${usbPath}ballot-export-packages/${defaultFileName}`
-        )
+        await state.archive.beginWithDirectSave(pathToFile)
       }
       await state.archive.file('election.json', electionData)
       await state.archive.file(

--- a/apps/election-manager/src/lib/usbstick.ts
+++ b/apps/election-manager/src/lib/usbstick.ts
@@ -12,21 +12,15 @@ export enum UsbDriveStatus {
 }
 
 const getDevice = async () => {
-  const devices = await window.kiosk!.getUsbDrives()
-  if (devices && devices.length > 0) {
-    return devices[0]
-  }
+  return (await window.kiosk!.getUsbDrives())[0]
 }
 
-export const getDevicePath = async (): Promise<string> => {
+export const getDevicePath = async (): Promise<string | undefined> => {
   if (!isAvailable()) {
-    return ''
+    return
   }
   const device = await getDevice()
-  if (!device) {
-    return ''
-  }
-  return device.mountPoint || ''
+  return device.mountPoint
 }
 
 export const getStatus = async (): Promise<UsbDriveStatus> => {
@@ -52,7 +46,7 @@ export const doMount = async (): Promise<void> => {
   }
 
   const device = await getDevice()
-  if (!device || device.mountPoint) {
+  if (device.mountPoint) {
     return
   }
 
@@ -65,7 +59,7 @@ export const doUnmount = async (): Promise<void> => {
   }
 
   const device = await getDevice()
-  if (!device || !device.mountPoint) {
+  if (!device.mountPoint) {
     return
   }
 

--- a/apps/election-manager/src/lib/usbstick.ts
+++ b/apps/election-manager/src/lib/usbstick.ts
@@ -12,7 +12,21 @@ export enum UsbDriveStatus {
 }
 
 const getDevice = async () => {
-  return (await window.kiosk!.getUsbDrives())[0]
+  const devices = await window.kiosk!.getUsbDrives()
+  if (devices && devices.length > 0) {
+    return devices[0]
+  }
+}
+
+export const getDevicePath = async (): Promise<string> => {
+  if (!isAvailable()) {
+    return ''
+  }
+  const device = await getDevice()
+  if (!device) {
+    return ''
+  }
+  return device.mountPoint || ''
 }
 
 export const getStatus = async (): Promise<UsbDriveStatus> => {
@@ -38,7 +52,7 @@ export const doMount = async (): Promise<void> => {
   }
 
   const device = await getDevice()
-  if (device.mountPoint) {
+  if (!device || device.mountPoint) {
     return
   }
 
@@ -51,7 +65,7 @@ export const doUnmount = async (): Promise<void> => {
   }
 
   const device = await getDevice()
-  if (!device.mountPoint) {
+  if (!device || !device.mountPoint) {
     return
   }
 

--- a/apps/election-manager/src/utils/DownloadableArchive.test.ts
+++ b/apps/election-manager/src/utils/DownloadableArchive.test.ts
@@ -20,7 +20,6 @@ test('direct file save fails', async () => {
   const kiosk = fakeKiosk()
   const archive = new DownloadableArchive(kiosk)
 
-  kiosk.saveAs.mockResolvedValueOnce(undefined)
   await expect(archive.beginWithDirectSave('path.zip')).rejects.toThrowError(
     'could not begin download; an error occurred'
   )

--- a/apps/election-manager/src/utils/DownloadableArchive.test.ts
+++ b/apps/election-manager/src/utils/DownloadableArchive.test.ts
@@ -6,6 +6,8 @@ import fakeFileWriter from '../../test/helpers/fakeFileWriter'
 const ZIP_MAGIC_BYTES = Buffer.of(0x50, 0x4b, 0x03, 0x04)
 const EMPTY_ZIP_MAGIC_BYTES = Buffer.of(0x50, 0x4b, 0x05, 0x06)
 
+type WriteFileOp = (path: string) => Promise<KioskBrowser.FileWriter>
+
 test('file prompt fails', async () => {
   const kiosk = fakeKiosk()
   const archive = new DownloadableArchive(kiosk)
@@ -51,7 +53,9 @@ test('empty zip file when file is saved directly and passes path to kiosk proper
   const fileWriter = fakeFileWriter()
 
   kiosk.makeDirectory.mockResolvedValueOnce()
-  kiosk.writeFile.mockResolvedValueOnce(fileWriter)
+  ;(kiosk.writeFile as WriteFileOp) = jest
+    .fn()
+    .mockResolvedValueOnce(fileWriter)
 
   expect(fileWriter.chunks).toHaveLength(0)
   await archive.beginWithDirectSave('/path/to/folder', 'file.zip')

--- a/apps/election-manager/src/utils/DownloadableArchive.ts
+++ b/apps/election-manager/src/utils/DownloadableArchive.ts
@@ -34,7 +34,8 @@ export default class DownloadableArchive {
   }
 
   /**
-   * Begins downloading an archive by saving to an exact location that is specified
+   * Begins downloading an archive to the filePath specified. Resolves when
+   * ready to receive files.
    */
   public async beginWithDirectSave(filePath: string): Promise<void> {
     const fileWriter = await this.kiosk.writeFile(filePath)

--- a/apps/election-manager/src/utils/DownloadableArchive.ts
+++ b/apps/election-manager/src/utils/DownloadableArchive.ts
@@ -1,4 +1,5 @@
 import ZipStream from 'zip-stream'
+import path from 'path'
 
 /**
  * Provides support for downloading a Zip archive of files. Requires
@@ -37,7 +38,14 @@ export default class DownloadableArchive {
    * Begins downloading an archive to the filePath specified. Resolves when
    * ready to receive files.
    */
-  public async beginWithDirectSave(filePath: string): Promise<void> {
+  public async beginWithDirectSave(
+    pathToFolder: string,
+    filename: string
+  ): Promise<void> {
+    await this.kiosk.makeDirectory(pathToFolder, {
+      recursive: true,
+    })
+    const filePath = path.join(pathToFolder, filename)
     const fileWriter = await this.kiosk.writeFile(filePath)
 
     if (!fileWriter) {

--- a/apps/election-manager/src/utils/filenames.ts
+++ b/apps/election-manager/src/utils/filenames.ts
@@ -14,7 +14,7 @@ function sanitizeString(input: string): string {
     .toLocaleLowerCase()
 }
 
-// eslint-disable-next-line import/prefer-default-export
+export const EXPORT_FOLDER = 'ballot-export-packages'
 export function generateFilenameForBallotExportPackage(
   electionDefinition: ElectionDefinition,
   time: Date = new Date()

--- a/apps/election-manager/src/utils/filenames.ts
+++ b/apps/election-manager/src/utils/filenames.ts
@@ -14,7 +14,8 @@ function sanitizeString(input: string): string {
     .toLocaleLowerCase()
 }
 
-export const EXPORT_FOLDER = 'ballot-export-packages'
+export const BALLOT_PACKAGES_FOLDER = 'ballot-packages'
+
 export function generateFilenameForBallotExportPackage(
   electionDefinition: ElectionDefinition,
   time: Date = new Date()

--- a/apps/election-manager/test/helpers/fakeKiosk.ts
+++ b/apps/election-manager/test/helpers/fakeKiosk.ts
@@ -65,6 +65,8 @@ export default function fakeKiosk({
     getUsbDrives: jest.fn().mockResolvedValue([]),
     mountUsbDrive: jest.fn(),
     unmountUsbDrive: jest.fn(),
+    writeFile: jest.fn().mockResolvedValue(undefined),
+    makeDirectory: jest.fn(),
     storage: {
       set: jest.fn(),
       get: jest.fn(),

--- a/apps/election-manager/types/kiosk-browser.d.ts
+++ b/apps/election-manager/types/kiosk-browser.d.ts
@@ -87,8 +87,15 @@ declare namespace KioskBrowser {
      */
     saveAs(options?: SaveAsOptions): Promise<FileWriter | undefined>
 
+    /**
+     * Writes a file to a specified file path
+     */
     writeFile(path: string): Promise<FileWriter>
+    writeFile(path: string, content: Buffer | string): Promise<void>
 
+    /*
+     * Creates a directory at the specified path.
+     */
     makeDirectory(path: string, options?: MakeDirectoryOptions): Promise<void>
 
     // USB sticks

--- a/apps/election-manager/types/kiosk-browser.d.ts
+++ b/apps/election-manager/types/kiosk-browser.d.ts
@@ -43,6 +43,11 @@ declare namespace KioskBrowser {
     filters?: FileFilter[]
   }
 
+  export interface MakeDirectoryOptions {
+    recursive?: boolean
+    mode?: number
+  }
+
   export interface FileFilter {
     // Docs: http://electronjs.org/docs/api/structures/file-filter
     extensions: string[]
@@ -81,6 +86,10 @@ declare namespace KioskBrowser {
      * Once chosen, resolves with a handle to the file to write data to it.
      */
     saveAs(options?: SaveAsOptions): Promise<FileWriter | undefined>
+
+    writeFile(path: string): Promise<FileWriter>
+
+    makeDirectory(path: string, options?: MakeDirectoryOptions): Promise<void>
 
     // USB sticks
     getUsbDrives(): Promise<UsbDrive[]>


### PR DESCRIPTION
~~Depends on https://github.com/votingworks/kiosk-browser/pull/62 and https://github.com/votingworks/vxsuite/pull/97 (branch is based on the second PR)~~ All dependencies are now merged

Automatically saves the ballot export zip to the ballot-export-packages on the inserted USB device when exported. When the user opens the manual save dialog it also automatically opens under the path to the ballot-export-packages folder in the usb drive. If that folder doesn't exist, the file dialog will just open in the root of the USB drive which seems reasonable. When clicking "export" the folder will be created if it doesn't exist already. 