### PR TITLE
Add export scanner results autosave modal

### DIFF
--- a/apps/bsd/prodserver/index.js
+++ b/apps/bsd/prodserver/index.js
@@ -26,7 +26,7 @@ app.get('*', (req, res) => {
 
 app.get('/machine-config', (req, res) => {
   res.json({
-    "machineId": process.env.VX_MACHINE_ID || "000",
+    "machineId": process.env.VX_MACHINE_ID || "0000",
   })
 })
 

--- a/apps/bsd/prodserver/index.js
+++ b/apps/bsd/prodserver/index.js
@@ -24,4 +24,10 @@ app.get('*', (req, res) => {
   res.sendFile(path.join(__dirname, '../build/index.html'))
 })
 
+app.get('/machine-config', (req, res) => {
+  res.json({
+    "machineId": process.env.VX_MACHINE_ID || "000",
+  })
+})
+
 app.listen(port, () => console.log(`BSD listening on port ${port}!`))

--- a/apps/bsd/src/App.test.tsx
+++ b/apps/bsd/src/App.test.tsx
@@ -23,7 +23,7 @@ beforeEach(() => {
     adjudication: { adjudicated: 0, remaining: 0 },
   })
   fetchMock.get('/machine-config', {
-    machineId: '001',
+    machineId: '0001',
   })
 
   const oldWindowLocation = window.location

--- a/apps/bsd/src/App.test.tsx
+++ b/apps/bsd/src/App.test.tsx
@@ -22,6 +22,9 @@ beforeEach(() => {
     batches: [],
     adjudication: { adjudicated: 0, remaining: 0 },
   })
+  fetchMock.get('/machine-config', {
+    machineId: '001',
+  })
 
   const oldWindowLocation = window.location
   Object.defineProperty(window, 'location', {

--- a/apps/bsd/src/App.test.tsx
+++ b/apps/bsd/src/App.test.tsx
@@ -120,20 +120,31 @@ test('clicking export shows modal and makes a request to export', async () => {
     { testMode: true, election: electionSample },
     { overwriteRoutes: true }
   )
+  fetchMock.getOnce(
+    '/scan/status',
+    {
+      batches: [{ id: 1, count: 2, ballots: [], startedAt: '' }],
+      adjudication: { adjudicated: 0, remaining: 0 },
+    },
+    { overwriteRoutes: true }
+  )
 
   fetchMock.postOnce('/scan/export', {
     body: '',
   })
 
-  const { getByText, queryByText } = render(<App />)
-  const exportingModalText = 'Exporting CVRs…'
+  const { getByText, queryByText, getByTestId } = render(<App />)
+  const exportingModalText = 'No USB Drive Detected'
 
   await act(async () => {
     // wait for the config to load
     await sleep(500)
 
     fireEvent.click(getByText('Export'))
-    getByText(exportingModalText)
+    await waitFor(() => getByText(exportingModalText))
+    fireEvent.click(getByTestId('manual-export'))
+    await waitFor(() => getByText('Download Complete'))
+    fireEvent.click(getByText('Cancel'))
   })
 
   expect(fetchMock.called('/scan/export')).toBe(true)

--- a/apps/bsd/src/AppRoot.tsx
+++ b/apps/bsd/src/AppRoot.tsx
@@ -11,6 +11,7 @@ import {
   ScanStatusResponse,
   CardReadLongResponse,
   CardReadResponse,
+  MachineConfig,
 } from './config/types'
 
 import AppContext from './contexts/AppContext'
@@ -44,6 +45,8 @@ import LinkButton from './components/LinkButton'
 import MainNav from './components/MainNav'
 import StatusFooter from './components/StatusFooter'
 
+import machineConfigProvider from './util/machineConfig'
+
 const App: React.FC = () => {
   const history = useHistory()
   const [cardServerAvailable, setCardServerAvailable] = useState(true)
@@ -67,6 +70,10 @@ const App: React.FC = () => {
 
   const [isExportingCVRs, setIsExportingCVRs] = useState(false)
 
+  const [machineConfig, setMachineConfig] = useState<MachineConfig>({
+    machineId: '000',
+  })
+
   const { adjudication } = status
 
   const [isScanning, setIsScanning] = useState(false)
@@ -89,6 +96,19 @@ const App: React.FC = () => {
 
     initialize()
   }, [refreshConfig])
+
+  useEffect(() => {
+    const initialize = async () => {
+      try {
+        const newMachineConfig = await machineConfigProvider.get()
+        setMachineConfig(newMachineConfig)
+      } catch (e) {
+        window.setTimeout(initialize, 1000)
+      }
+    }
+
+    initialize()
+  }, [setMachineConfig])
 
   const updateStatus = useCallback(async () => {
     try {
@@ -360,6 +380,7 @@ const App: React.FC = () => {
         value={{
           usbDriveStatus: displayUsbStatus,
           usbDriveEject: doEject,
+          machineConfig,
         }}
       >
         <Switch>
@@ -457,6 +478,7 @@ const App: React.FC = () => {
         value={{
           usbDriveStatus: displayUsbStatus,
           usbDriveEject: doEject,
+          machineConfig,
         }}
       >
         <LoadElectionScreen

--- a/apps/bsd/src/AppRoot.tsx
+++ b/apps/bsd/src/AppRoot.tsx
@@ -1,10 +1,7 @@
 import React, { useEffect, useState, useCallback } from 'react'
 import { Route, Switch, useHistory } from 'react-router-dom'
-import fileDownload from 'js-file-download'
 import pluralize from 'pluralize'
 import { Election, OptionalElection } from '@votingworks/ballot-encoder'
-import Prose from './components/Prose'
-import Modal from './components/Modal'
 
 import {
   CardData,
@@ -45,6 +42,7 @@ import LinkButton from './components/LinkButton'
 import MainNav from './components/MainNav'
 import StatusFooter from './components/StatusFooter'
 
+import ExportResultsModal from './components/ExportResultsModal'
 import machineConfigProvider from './util/machineConfig'
 
 const App: React.FC = () => {
@@ -254,53 +252,6 @@ const App: React.FC = () => {
     }
   }, [history, isTestMode, refreshConfig])
 
-  const exportResults = useCallback(async () => {
-    if (!election) {
-      return
-    }
-
-    setIsExportingCVRs(true)
-
-    try {
-      const response = await fetch(`/scan/export`, {
-        method: 'post',
-      })
-
-      const blob = await response.blob()
-
-      setIsExportingCVRs(false)
-
-      if (response.status !== 200) {
-        // eslint-disable-next-line no-console
-        console.log('error downloading CVRs')
-        return
-      }
-
-      const cvrFilename = `${`cvrs-${election.county.name}-${election.title}`
-        .replace(/[^a-z0-9]+/gi, '-')
-        .replace(/(^-|-$)+/g, '')
-        .toLocaleLowerCase()}.jsonl`
-
-      if (window.kiosk) {
-        const fileWriter = await window.kiosk.saveAs({
-          defaultPath: cvrFilename,
-        })
-
-        if (!fileWriter) {
-          throw new Error('could not begin download; no file was chosen')
-        }
-
-        await fileWriter.write(await blob.text())
-        await fileWriter.end()
-      } else {
-        fileDownload(blob, cvrFilename, 'application/x-jsonlines')
-      }
-    } catch (error) {
-      setIsExportingCVRs(false)
-      console.log('failed getOutputFile()', error) // eslint-disable-line no-console
-    }
-  }, [election, setIsExportingCVRs])
-
   const deleteBatch = useCallback(
     async (id: number) => {
       setPendingDeleteBatchIds((previousIds) => [...previousIds, id])
@@ -375,6 +326,15 @@ const App: React.FC = () => {
       )
     }
 
+    let exportButtonTitle
+    if (adjudication.remaining > 0) {
+      exportButtonTitle =
+        'You cannot export results until all ballots have been adjudicated.'
+    } else if (status.batches.length === 0) {
+      exportButtonTitle =
+        'You cannot export results until you have scanned at least 1 ballot.'
+    }
+
     return (
       <AppContext.Provider
         value={{
@@ -430,13 +390,11 @@ const App: React.FC = () => {
                 </LinkButton>
                 <Button
                   small
-                  onPress={exportResults}
-                  disabled={adjudication.remaining > 0}
-                  title={
-                    adjudication.remaining > 0
-                      ? 'You cannot export results until all ballots have been adjudicated.'
-                      : undefined
+                  onPress={() => setIsExportingCVRs(true)}
+                  disabled={
+                    adjudication.remaining > 0 || status.batches.length === 0
                   }
+                  title={exportButtonTitle}
                 >
                   Export
                 </Button>
@@ -457,14 +415,17 @@ const App: React.FC = () => {
               </MainNav>
               <StatusFooter election={election} electionHash={electionHash} />
             </Screen>
-            <Modal
+            <ExportResultsModal
               isOpen={isExportingCVRs}
-              centerContent
-              content={
-                <Prose textCenter>
-                  <h1>Exporting CVRs…</h1>
-                </Prose>
-              }
+              onClose={() => setIsExportingCVRs(false)}
+              usbDriveStatus={displayUsbStatus}
+              election={election}
+              electionHash={electionHash}
+              isTestMode={isTestMode}
+              numberOfBallots={status.batches.reduce(
+                (prev, next) => prev + next.count,
+                0
+              )}
             />
           </Route>
         </Switch>

--- a/apps/bsd/src/AppRoot.tsx
+++ b/apps/bsd/src/AppRoot.tsx
@@ -69,7 +69,7 @@ const App: React.FC = () => {
   const [isExportingCVRs, setIsExportingCVRs] = useState(false)
 
   const [machineConfig, setMachineConfig] = useState<MachineConfig>({
-    machineId: '000',
+    machineId: '0000',
   })
 
   const { adjudication } = status
@@ -101,7 +101,7 @@ const App: React.FC = () => {
         const newMachineConfig = await machineConfigProvider.get()
         setMachineConfig(newMachineConfig)
       } catch (e) {
-        window.setTimeout(initialize, 1000)
+        // TODO: what should happen in machineConfig not returned?
       }
     }
 

--- a/apps/bsd/src/components/ButtonBar.tsx
+++ b/apps/bsd/src/components/ButtonBar.tsx
@@ -40,7 +40,7 @@ const ButtonBar = styled('nav')<Props>`
   }
   & > *:only-child {
     @media (min-width: 480px) {
-      flex: 0;
+      flex: ${({ centerOnlyChild = true }) => (centerOnlyChild ? 0 : 1)};
       margin: ${({ centerOnlyChild = true }) =>
         centerOnlyChild ? 'auto' : undefined};
       min-width: 33.333%;

--- a/apps/bsd/src/components/ExportResultsModal.test.tsx
+++ b/apps/bsd/src/components/ExportResultsModal.test.tsx
@@ -1,0 +1,192 @@
+import React from 'react'
+
+import { render, fireEvent, waitFor } from '@testing-library/react'
+import { electionSample } from '@votingworks/ballot-encoder'
+import { Router } from 'react-router-dom'
+import { createMemoryHistory } from 'history'
+import fetchMock from 'fetch-mock'
+
+import { UsbDriveStatus } from '../lib/usbstick'
+import ExportResultsModal from './ExportResultsModal'
+import fakeKiosk, { fakeUsbDrive } from '../../test/helpers/fakeKiosk'
+import fakeFileWriter from '../../test/helpers/fakeFileWriter'
+
+test('renders loading screen when usb drive is mounting or ejecting in export modal', () => {
+  const usbStatuses = [UsbDriveStatus.present, UsbDriveStatus.ejecting]
+
+  for (const status of usbStatuses) {
+    const closeFn = jest.fn()
+    const { getByText, unmount } = render(
+      <Router history={createMemoryHistory()}>
+        <ExportResultsModal
+          isOpen
+          onClose={closeFn}
+          usbDriveStatus={status}
+          election={electionSample}
+          electionHash="testHash12"
+          numberOfBallots={5}
+          isTestMode
+        />
+      </Router>
+    )
+    getByText('Loading')
+    unmount()
+  }
+})
+
+test('render no usb found screen when there is not a mounted usb drive', () => {
+  const usbStatuses = [
+    UsbDriveStatus.absent,
+    UsbDriveStatus.notavailable,
+    UsbDriveStatus.recentlyEjected,
+  ]
+
+  for (const status of usbStatuses) {
+    const closeFn = jest.fn()
+    const { getByText, unmount, getByAltText } = render(
+      <Router history={createMemoryHistory()}>
+        <ExportResultsModal
+          isOpen
+          onClose={closeFn}
+          usbDriveStatus={status}
+          election={electionSample}
+          electionHash="testHash12"
+          numberOfBallots={5}
+          isTestMode
+        />
+      </Router>
+    )
+    getByText('No USB Drive Detected')
+    getByText(
+      'Please insert a USB drive in order to export the scanner results.'
+    )
+    getByAltText('Insert USB Image')
+
+    fireEvent.click(getByText('Cancel'))
+    expect(closeFn).toHaveBeenCalled()
+
+    unmount()
+  }
+})
+
+test('render export modal when a usb drive is mounted as expected and allows custom export', async () => {
+  const mockKiosk = fakeKiosk()
+  const fileWriter = fakeFileWriter()
+  window.kiosk = mockKiosk
+  const saveAsFunction = jest.fn().mockResolvedValue(fileWriter)
+  mockKiosk.saveAs = saveAsFunction
+  mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()])
+
+  fetchMock.postOnce('/scan/export', {
+    body: '',
+  })
+
+  const closeFn = jest.fn()
+  const { getByText, getByAltText } = render(
+    <Router history={createMemoryHistory()}>
+      <ExportResultsModal
+        isOpen
+        onClose={closeFn}
+        usbDriveStatus={UsbDriveStatus.mounted}
+        election={electionSample}
+        electionHash="testHash12"
+        numberOfBallots={5}
+        isTestMode
+      />
+    </Router>
+  )
+  getByText('Export Results')
+  getByText(
+    /A CVR file will automatically be saved to the default location on the mounted USB drive. /
+  )
+  getByAltText('Insert USB Image')
+
+  fireEvent.click(getByText('Custom'))
+  await waitFor(() => getByText(/Download Complete/))
+  await waitFor(() => {
+    expect(saveAsFunction).toHaveBeenCalledTimes(1)
+  })
+  expect(fetchMock.called('/scan/export')).toBe(true)
+
+  fireEvent.click(getByText('Cancel'))
+  expect(closeFn).toHaveBeenCalled()
+})
+
+test('render export modal when a usb drive is mounted as expected and allows automatic export', async () => {
+  const mockKiosk = fakeKiosk()
+  window.kiosk = mockKiosk
+  mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()])
+
+  fetchMock.postOnce('/scan/export', {
+    body: '',
+  })
+
+  const closeFn = jest.fn()
+  const { getByText } = render(
+    <Router history={createMemoryHistory()}>
+      <ExportResultsModal
+        isOpen
+        onClose={closeFn}
+        usbDriveStatus={UsbDriveStatus.mounted}
+        election={electionSample}
+        electionHash="testHash12"
+        numberOfBallots={5}
+        isTestMode
+      />
+    </Router>
+  )
+  getByText('Export Results')
+
+  fireEvent.click(getByText('Export'))
+  await waitFor(() => getByText(/Download Complete/))
+  await waitFor(() => {
+    expect(mockKiosk.makeDirectory).toHaveBeenCalledTimes(1)
+  })
+  expect(
+    mockKiosk.makeDirectory
+  ).toHaveBeenCalledWith(
+    'fake mount point/cast-vote-records/franklin-county_general-election_testHash12',
+    { recursive: true }
+  )
+  expect(mockKiosk.writeFile).toHaveBeenCalledTimes(1)
+  expect(fetchMock.called('/scan/export')).toBe(true)
+
+  getByText('Eject USB')
+  fireEvent.click(getByText('Cancel'))
+  expect(closeFn).toHaveBeenCalled()
+  getByText('Export Results') // Closing should reset back to the starting export screen
+})
+
+test('render export modal with errors when appropriate and clears errors when closed', async () => {
+  const mockKiosk = fakeKiosk()
+  window.kiosk = mockKiosk
+
+  fetchMock.postOnce('/scan/export', {
+    body: '',
+  })
+
+  const closeFn = jest.fn()
+  const { getByText } = render(
+    <Router history={createMemoryHistory()}>
+      <ExportResultsModal
+        isOpen
+        onClose={closeFn}
+        usbDriveStatus={UsbDriveStatus.mounted}
+        election={electionSample}
+        electionHash="testHash12"
+        numberOfBallots={5}
+        isTestMode
+      />
+    </Router>
+  )
+  getByText('Export Results')
+
+  fireEvent.click(getByText('Export'))
+  await waitFor(() => getByText(/Download Failed/))
+  getByText(/Failed to save results./)
+  getByText(/Cannot read property '0' of undefined/)
+
+  fireEvent.click(getByText('Close'))
+  expect(closeFn).toHaveBeenCalled()
+  getByText('Export Results') // Closing should reset back to the starting export screen
+})

--- a/apps/bsd/src/components/ExportResultsModal.tsx
+++ b/apps/bsd/src/components/ExportResultsModal.tsx
@@ -92,12 +92,17 @@ const ExportResultsModal: React.FC<Props> = ({
 
       if (window.kiosk) {
         const usbPath = await getDevicePath()
+        if (!usbPath) {
+          throw new Error(
+            'could not begin downloand; path to usb drive missing'
+          )
+        }
         const electionFolderName = generateElectionBasedSubfolderName(
           election,
           electionHash!
         )
         const pathToFolder = path.join(
-          usbPath!,
+          usbPath,
           SCANNER_RESULTS_FOLDER,
           electionFolderName
         )

--- a/apps/bsd/src/components/ExportResultsModal.tsx
+++ b/apps/bsd/src/components/ExportResultsModal.tsx
@@ -1,0 +1,269 @@
+import React, { useContext, useState } from 'react'
+import styled from 'styled-components'
+import { Election } from '@votingworks/ballot-encoder'
+import fileDownload from 'js-file-download'
+import path from 'path'
+
+import AppContext from '../contexts/AppContext'
+import Modal from './Modal'
+import Button from './Button'
+import Prose from './Prose'
+import LinkButton from './LinkButton'
+import Loading from './Loading'
+import USBControllerButton from './USBControllerButton'
+import { getDevicePath, UsbDriveStatus } from '../lib/usbstick'
+import {
+  generateElectionBasedSubfolderName,
+  generateFilenameForScanningResults,
+  SCANNER_RESULTS_FOLDER,
+} from '../util/filenames'
+
+function throwBadStatus(s: never): never {
+  throw new Error(`Bad status: ${s}`)
+}
+
+const USBImage = styled.img`
+  margin-right: auto;
+  margin-left: auto;
+  height: 200px;
+`
+
+export interface Props {
+  isOpen: boolean
+  onClose: () => void
+  usbDriveStatus: UsbDriveStatus
+  election: Election
+  electionHash: string | undefined
+  numberOfBallots: number
+  isTestMode: boolean
+}
+
+enum ModalState {
+  ERROR = 'error',
+  SAVING = 'saving',
+  DONE = 'done',
+  INIT = 'init',
+}
+
+const ExportResultsModal: React.FC<Props> = ({
+  isOpen,
+  onClose: onCloseFromProps,
+  usbDriveStatus,
+  election,
+  electionHash,
+  numberOfBallots,
+  isTestMode,
+}) => {
+  const [currentState, setCurrentState] = useState<ModalState>(ModalState.INIT)
+  const [errorMessage, setErrorMessage] = useState('')
+
+  const { machineConfig } = useContext(AppContext)
+
+  const onClose = () => {
+    setErrorMessage('')
+    setCurrentState(ModalState.INIT)
+    onCloseFromProps()
+  }
+
+  const exportResults = async (openDialog: boolean) => {
+    setCurrentState(ModalState.SAVING)
+
+    try {
+      const response = await fetch(`/scan/export`, {
+        method: 'post',
+      })
+
+      const blob = await response.blob()
+
+      if (response.status !== 200) {
+        setErrorMessage(
+          `Failed to save results. Error retrieving CVRs from the scanner.`
+        )
+        setCurrentState(ModalState.ERROR)
+        return
+      }
+
+      const cvrFilename = generateFilenameForScanningResults(
+        machineConfig.machineId,
+        numberOfBallots,
+        isTestMode,
+        new Date()
+      )
+
+      if (window.kiosk) {
+        const usbPath = await getDevicePath()
+        const electionFolderName = generateElectionBasedSubfolderName(
+          election,
+          electionHash!
+        )
+        const pathToFolder = path.join(
+          usbPath!,
+          SCANNER_RESULTS_FOLDER,
+          electionFolderName
+        )
+        const pathToFile = path.join(pathToFolder, cvrFilename)
+        if (openDialog) {
+          const fileWriter = await window.kiosk.saveAs({
+            defaultPath: pathToFile,
+          })
+
+          if (!fileWriter) {
+            throw new Error('could not begin download; no file was chosen')
+          }
+
+          await fileWriter.write(await blob.text())
+          await fileWriter.end()
+        } else {
+          await window.kiosk.makeDirectory(pathToFolder, {
+            recursive: true,
+          })
+          await window.kiosk.writeFile(pathToFile, await blob.text())
+        }
+        setCurrentState(ModalState.DONE)
+      } else {
+        fileDownload(blob, cvrFilename, 'application/x-jsonlines')
+        setCurrentState(ModalState.DONE)
+      }
+    } catch (error) {
+      setErrorMessage(`Failed to save results. ${error.message}`)
+      setCurrentState(ModalState.ERROR)
+    }
+  }
+
+  if (currentState === ModalState.ERROR) {
+    return (
+      <Modal
+        isOpen={isOpen}
+        content={
+          <Prose>
+            <h1>Download Failed</h1>
+            <p>{errorMessage}</p>
+          </Prose>
+        }
+        onOverlayClick={onClose}
+        actions={<LinkButton onPress={onClose}>Close</LinkButton>}
+      />
+    )
+  }
+
+  if (currentState === ModalState.DONE) {
+    let actions = (
+      <React.Fragment>
+        <LinkButton onPress={onClose}>Cancel</LinkButton>
+        <USBControllerButton small={false} primary />
+      </React.Fragment>
+    )
+    if (usbDriveStatus === UsbDriveStatus.recentlyEjected) {
+      actions = <LinkButton onPress={onClose}>Close</LinkButton>
+    }
+    return (
+      <Modal
+        isOpen={isOpen}
+        content={
+          <Prose>
+            <h1>Download Complete</h1>
+            <p>
+              CVR results file saved successfully! You may now eject the USB
+              drive and take it to Election Manager for tabulation.
+            </p>
+          </Prose>
+        }
+        onOverlayClick={onClose}
+        actions={actions}
+      />
+    )
+  }
+
+  if (currentState === ModalState.SAVING) {
+    return (
+      <Modal isOpen={isOpen} content={<Loading />} onOverlayClick={onClose} />
+    )
+  }
+
+  if (currentState !== ModalState.INIT) {
+    throwBadStatus(currentState) // Creates a compile time check that all states are being handled.
+  }
+
+  switch (usbDriveStatus) {
+    case UsbDriveStatus.absent:
+    case UsbDriveStatus.notavailable:
+    case UsbDriveStatus.recentlyEjected:
+      // When run not through kiosk mode let the user download the file
+      // on the machine for internal debugging use
+      return (
+        <Modal
+          isOpen={isOpen}
+          content={
+            <Prose>
+              <h1>No USB Drive Detected</h1>
+              <p>
+                <USBImage src="usb-stick.svg" alt="Insert USB Image" />
+                Please insert a USB drive in order to export the scanner
+                results.
+              </p>
+            </Prose>
+          }
+          onOverlayClick={onClose}
+          actions={
+            <React.Fragment>
+              <LinkButton onPress={onClose}>Cancel</LinkButton>
+              {!window.kiosk && (
+                <Button
+                  data-testid="manual-export"
+                  onPress={() => exportResults(true)}
+                >
+                  Export
+                </Button>
+              )}{' '}
+            </React.Fragment>
+          }
+        />
+      )
+    case UsbDriveStatus.ejecting:
+    case UsbDriveStatus.present:
+      return (
+        <Modal
+          isOpen={isOpen}
+          content={<Loading />}
+          onOverlayClick={onClose}
+          actions={
+            <React.Fragment>
+              <LinkButton onPress={onClose}>Cancel</LinkButton>
+            </React.Fragment>
+          }
+        />
+      )
+    case UsbDriveStatus.mounted:
+      return (
+        <Modal
+          isOpen={isOpen}
+          content={
+            <Prose>
+              <h1>Export Results</h1>
+              <USBImage src="usb-stick.svg" alt="Insert USB Image" />
+              <p>
+                A CVR file will automatically be saved to the default location
+                on the mounted USB drive. Optionally, you may pick a custom
+                export location.
+              </p>
+            </Prose>
+          }
+          onOverlayClick={onClose}
+          actions={
+            <React.Fragment>
+              <LinkButton onPress={onClose}>Cancel</LinkButton>
+              <Button onPress={() => exportResults(true)}>Custom</Button>
+              <Button primary onPress={() => exportResults(false)}>
+                Export
+              </Button>
+            </React.Fragment>
+          }
+        />
+      )
+    default:
+      // Creates a compile time check to make sure this switch statement includes all enum values for UsbDriveStatus
+      throwBadStatus(usbDriveStatus)
+  }
+}
+
+export default ExportResultsModal

--- a/apps/bsd/src/components/Modal.tsx
+++ b/apps/bsd/src/components/Modal.tsx
@@ -69,7 +69,7 @@ const Modal: React.FC<Props> = ({
   >
     <ModalContent centerContent={centerContent}>{content}</ModalContent>
     {actions && (
-      <ButtonBar naturalOrder dark={false} as="div">
+      <ButtonBar centerOnlyChild={false} naturalOrder dark={false} as="div">
         {actions}
       </ButtonBar>
     )}

--- a/apps/bsd/src/components/USBControllerButton.test.tsx
+++ b/apps/bsd/src/components/USBControllerButton.test.tsx
@@ -5,6 +5,7 @@ import USBControllerButton from './USBControllerButton'
 
 import AppContext from '../contexts/AppContext'
 import { UsbDriveStatus } from '../lib/usbstick'
+import fakeMachineConfig from '../../test/helpers/fakeMachineConfig'
 
 jest.mock('../lib/usbstick')
 
@@ -23,6 +24,7 @@ const renderWithStatus = (status: UsbDriveStatus) => {
       value={{
         usbDriveStatus: status,
         usbDriveEject: jest.fn(),
+        machineConfig: fakeMachineConfig(),
       }}
     >
       <USBControllerButton />

--- a/apps/bsd/src/components/USBControllerButton.tsx
+++ b/apps/bsd/src/components/USBControllerButton.tsx
@@ -8,8 +8,9 @@ import { UsbDriveStatus } from '../lib/usbstick'
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const doNothing = () => {}
 
-const USBControllerButton: React.FC<{ primary?: boolean }> = ({
+const USBControllerButton: React.FC<{ primary?: boolean; small?: boolean }> = ({
   primary = false,
+  small = true,
 }) => {
   const { usbDriveStatus: status, usbDriveEject } = useContext(AppContext)
 
@@ -19,7 +20,7 @@ const USBControllerButton: React.FC<{ primary?: boolean }> = ({
 
   if (status === UsbDriveStatus.absent) {
     return (
-      <Button small disabled onPress={doNothing}>
+      <Button small={small} disabled onPress={doNothing}>
         No USB
       </Button>
     )
@@ -27,7 +28,7 @@ const USBControllerButton: React.FC<{ primary?: boolean }> = ({
 
   if (status === UsbDriveStatus.present) {
     return (
-      <Button small disabled onPress={doNothing}>
+      <Button small={small} disabled onPress={doNothing}>
         Connecting…
       </Button>
     )
@@ -35,7 +36,7 @@ const USBControllerButton: React.FC<{ primary?: boolean }> = ({
 
   if (status === UsbDriveStatus.recentlyEjected) {
     return (
-      <Button small disabled onPress={doNothing}>
+      <Button small={small} disabled onPress={doNothing}>
         Ejected
       </Button>
     )
@@ -43,14 +44,14 @@ const USBControllerButton: React.FC<{ primary?: boolean }> = ({
 
   if (status === UsbDriveStatus.ejecting) {
     return (
-      <Button small disabled onPress={doNothing}>
+      <Button small={small} disabled onPress={doNothing}>
         Ejecting…
       </Button>
     )
   }
 
   return (
-    <Button small primary={primary} onPress={usbDriveEject}>
+    <Button small={small} primary={primary} onPress={usbDriveEject}>
       Eject USB
     </Button>
   )

--- a/apps/bsd/src/config/types.ts
+++ b/apps/bsd/src/config/types.ts
@@ -16,6 +16,12 @@ import type { AdjudicationInfo } from './types/ballot-review'
 export interface Dictionary<T> {
   [key: string]: T | undefined
 }
+export interface Provider<T> {
+  get(): Promise<T>
+}
+export interface MachineConfig {
+  machineId: string
+}
 
 // Events
 export type InputEvent = React.FormEvent<EventTarget>

--- a/apps/bsd/src/contexts/AppContext.ts
+++ b/apps/bsd/src/contexts/AppContext.ts
@@ -1,13 +1,16 @@
 import { createContext } from 'react'
+import { MachineConfig } from '../config/types'
 
 interface AppContextInterface {
   usbDriveStatus: string
   usbDriveEject: () => void
+  machineConfig: MachineConfig
 }
 
 const appContext: AppContextInterface = {
   usbDriveStatus: '',
   usbDriveEject: () => undefined,
+  machineConfig: { machineId: '000' },
 }
 
 const AppContext = createContext(appContext)

--- a/apps/bsd/src/contexts/AppContext.ts
+++ b/apps/bsd/src/contexts/AppContext.ts
@@ -10,7 +10,7 @@ interface AppContextInterface {
 const appContext: AppContextInterface = {
   usbDriveStatus: '',
   usbDriveEject: () => undefined,
-  machineConfig: { machineId: '000' },
+  machineConfig: { machineId: '0000' },
 }
 
 const AppContext = createContext(appContext)

--- a/apps/bsd/src/setupProxy.js
+++ b/apps/bsd/src/setupProxy.js
@@ -12,4 +12,10 @@ module.exports = function (app) {
   app.use(proxy('/card', { target: 'http://localhost:3001/' }))
   app.use(proxy('/scan', { target: 'http://localhost:3002/' }))
   app.use(proxy('/config', { target: 'http://localhost:3002/' }))
+
+  app.get('/machine-config', (req, res) => {
+    res.json({
+      machineId: process.env.VX_MACHINE_ID || '000',
+    })
+  })
 }

--- a/apps/bsd/src/setupProxy.js
+++ b/apps/bsd/src/setupProxy.js
@@ -15,7 +15,7 @@ module.exports = function (app) {
 
   app.get('/machine-config', (req, res) => {
     res.json({
-      machineId: process.env.VX_MACHINE_ID || '000',
+      machineId: process.env.VX_MACHINE_ID || '0000',
     })
   })
 }

--- a/apps/bsd/src/util/filenames.test.ts
+++ b/apps/bsd/src/util/filenames.test.ts
@@ -1,28 +1,109 @@
-import { parseBallotExportPackageInfoFromFilename } from './filenames'
+import { electionSample } from '@votingworks/ballot-encoder'
+import {
+  parseBallotExportPackageInfoFromFilename,
+  generateElectionBasedSubfolderName,
+  generateFilenameForScanningResults,
+} from './filenames'
 
-test('parses a basic name properly', () => {
-  const name =
-    'choctaw-county_2020-general-election_a5753d5776__2020-12-02_09-42-50.zip'
+describe('parseBallotExportPackageInfoFromFilename', () => {
+  test('parses a basic name properly', () => {
+    const name =
+      'choctaw-county_2020-general-election_a5753d5776__2020-12-02_09-42-50.zip'
 
-  const parsedInfo = parseBallotExportPackageInfoFromFilename(name)
-  expect(parsedInfo).toBeTruthy()
-  const { electionCounty, electionName, electionHash, timestamp } = parsedInfo!
-  expect(electionCounty).toBe('choctaw county')
-  expect(electionName).toBe('2020 general election')
-  expect(electionHash).toBe('a5753d5776')
-  expect(timestamp).toStrictEqual(new Date(2020, 11, 2, 9, 42, 50))
+    const parsedInfo = parseBallotExportPackageInfoFromFilename(name)
+    expect(parsedInfo).toBeTruthy()
+    const {
+      electionCounty,
+      electionName,
+      electionHash,
+      timestamp,
+    } = parsedInfo!
+    expect(electionCounty).toBe('choctaw county')
+    expect(electionName).toBe('2020 general election')
+    expect(electionHash).toBe('a5753d5776')
+    expect(timestamp).toStrictEqual(new Date(2020, 11, 2, 9, 42, 50))
+  })
+
+  test('fails to parse a name with the section seperator twice', () => {
+    const name =
+      'choctaw-county_2020-general-election__a5753d5776__2020-12-02_09-42-50.zip'
+
+    expect(parseBallotExportPackageInfoFromFilename(name)).toBeUndefined()
+  })
+
+  test('fails to parse a name with a bad election string', () => {
+    const name =
+      'choctaw-county_2020-general_election_a5753d5776__2020-12-02_09-42-50.zip'
+
+    expect(parseBallotExportPackageInfoFromFilename(name)).toBeUndefined()
+  })
 })
 
-test('fails to parse a name with the section seperator twice', () => {
-  const name =
-    'choctaw-county_2020-general-election__a5753d5776__2020-12-02_09-42-50.zip'
+describe('generateElectionBasedSubfolderName', () => {
+  test('generates basic election subfolder name as expected', () => {
+    const mockElection = {
+      ...electionSample,
+      county: { name: 'King County', id: '' },
+      title: 'General Election',
+    }
+    expect(generateElectionBasedSubfolderName(mockElection, 'testHash12')).toBe(
+      'king-county_general-election_testHash12'
+    )
+  })
 
-  expect(parseBallotExportPackageInfoFromFilename(name)).toBeUndefined()
+  test('generates election subfolder name as expected when election county and title have weird characters', () => {
+    const mockElection = {
+      ...electionSample,
+      county: { name: '-K(ing&COUN-----TY**', id: '' },
+      title: 'General-Election@@',
+    }
+    expect(generateElectionBasedSubfolderName(mockElection, 'testHash12')).toBe(
+      'k-ing-coun-ty_general-election_testHash12'
+    )
+  })
+
+  test('generates election subfolder name as expected when election hash length varies', () => {
+    const mockElection = {
+      ...electionSample,
+      county: { name: 'King County', id: '' },
+      title: 'General Election',
+    }
+    expect(
+      generateElectionBasedSubfolderName(
+        mockElection,
+        'testHash12thisisextratext'
+      )
+    ).toBe('king-county_general-election_testHash12')
+
+    expect(generateElectionBasedSubfolderName(mockElection, '')).toBe(
+      'king-county_general-election_'
+    )
+
+    expect(generateElectionBasedSubfolderName(mockElection, 'short')).toBe(
+      'king-county_general-election_short'
+    )
+  })
 })
 
-test('fails to parse a name with a bad election string', () => {
-  const name =
-    'choctaw-county_2020-general_election_a5753d5776__2020-12-02_09-42-50.zip'
+describe('generateFilenameForScanningResults', () => {
+  test('generates basic scanning results filename in test mode', () => {
+    const time = new Date(2019, 2, 14, 15, 9, 26)
+    expect(generateFilenameForScanningResults('1', 0, true, time)).toBe(
+      'TEST__machine_1__0_ballots__2019-03-14_15-09-26.jsonl'
+    )
 
-  expect(parseBallotExportPackageInfoFromFilename(name)).toBeUndefined()
+    expect(
+      generateFilenameForScanningResults('po!n@y:__', 35, true, time)
+    ).toBe('TEST__machine_pony__35_ballots__2019-03-14_15-09-26.jsonl')
+  })
+
+  test('generates basic scanning results filename not in test mode', () => {
+    const time = new Date(2019, 2, 14, 15, 9, 26)
+    expect(generateFilenameForScanningResults('1', 0, false, time)).toBe(
+      'machine_1__0_ballots__2019-03-14_15-09-26.jsonl'
+    )
+    expect(
+      generateFilenameForScanningResults('<3-u!n#icorn<3', 1, false, time)
+    ).toBe('machine_3unicorn3__1_ballots__2019-03-14_15-09-26.jsonl')
+  })
 })

--- a/apps/bsd/src/util/filenames.ts
+++ b/apps/bsd/src/util/filenames.ts
@@ -60,10 +60,10 @@ export function generateElectionBasedSubfolderName(
 ): string {
   const electionCountyName = sanitizeString(
     election.county.name,
-    WORD_SEPERATOR
+    WORD_SEPARATOR
   )
-  const electionTitle = sanitizeString(election.title, WORD_SEPERATOR)
-  return `${`${electionCountyName}${SUBSECTION_SEPERATOR}${electionTitle}`.toLocaleLowerCase()}${SUBSECTION_SEPERATOR}${electionHash.slice(
+  const electionTitle = sanitizeString(election.title, WORD_SEPARATOR)
+  return `${`${electionCountyName}${SUBSECTION_SEPARATOR}${electionTitle}`.toLocaleLowerCase()}${SUBSECTION_SEPARATOR}${electionHash.slice(
     0,
     10
   )}`
@@ -78,11 +78,11 @@ export function generateFilenameForScanningResults(
   isTestMode: boolean,
   time: Date = new Date()
 ): string {
-  const machineString = `machine${SUBSECTION_SEPERATOR}${sanitizeString(
+  const machineString = `machine${SUBSECTION_SEPARATOR}${sanitizeString(
     machineId
   )}`
-  const ballotString = `${numBallotsScanned}${SUBSECTION_SEPERATOR}ballots`
+  const ballotString = `${numBallotsScanned}${SUBSECTION_SEPARATOR}ballots`
   const timeInformation = moment(time).format(TIME_FORMAT_STRING)
-  const filename = `${machineString}${SECTION_SEPERATOR}${ballotString}${SECTION_SEPERATOR}${timeInformation}.jsonl`
-  return isTestMode ? `TEST${SECTION_SEPERATOR}${filename}` : filename
+  const filename = `${machineString}${SECTION_SEPARATOR}${ballotString}${SECTION_SEPARATOR}${timeInformation}.jsonl`
+  return isTestMode ? `TEST${SECTION_SEPARATOR}${filename}` : filename
 }

--- a/apps/bsd/src/util/machineConfig.ts
+++ b/apps/bsd/src/util/machineConfig.ts
@@ -1,0 +1,20 @@
+import { Provider } from '../config/types'
+import fetchJSON from './fetchJSON'
+
+interface MachineConfigResponse {
+  machineId: string
+}
+
+const machineConfigProvider: Provider<{ machineId: string }> = {
+  async get() {
+    const { machineId } = await fetchJSON<MachineConfigResponse>(
+      '/machine-config'
+    )
+
+    return {
+      machineId,
+    }
+  },
+}
+
+export default machineConfigProvider

--- a/apps/bsd/test/helpers/fakeFileWriter.ts
+++ b/apps/bsd/test/helpers/fakeFileWriter.ts
@@ -1,0 +1,16 @@
+export type Chunk = Parameters<KioskBrowser.FileWriter['write']>[0]
+
+export default function fakeFileWriter(): jest.Mocked<
+  KioskBrowser.FileWriter & { chunks: readonly Chunk[] }
+> {
+  const chunks: Chunk[] = []
+  const fileWriter = {
+    write: jest.fn().mockImplementation((chunk) => {
+      chunks.push(chunk)
+    }),
+    end: jest.fn().mockResolvedValue(undefined),
+    chunks,
+  }
+
+  return fileWriter
+}

--- a/apps/bsd/test/helpers/fakeKiosk.ts
+++ b/apps/bsd/test/helpers/fakeKiosk.ts
@@ -65,6 +65,8 @@ export default function fakeKiosk({
     unmountUsbDrive: jest.fn(),
     getFileSystemEntries: jest.fn(),
     readFile: jest.fn(),
+    writeFile: jest.fn(),
+    makeDirectory: jest.fn(),
     storage: {
       set: jest.fn(),
       get: jest.fn(),

--- a/apps/bsd/test/helpers/fakeMachineConfig.ts
+++ b/apps/bsd/test/helpers/fakeMachineConfig.ts
@@ -1,7 +1,7 @@
 import { Provider, MachineConfig } from '../../src/config/types'
 
 export default function fakeMachineConfig({
-  machineId = '000',
+  machineId = '0000',
 }: Partial<MachineConfig> = {}): MachineConfig {
   return { machineId }
 }

--- a/apps/bsd/test/helpers/fakeMachineConfig.ts
+++ b/apps/bsd/test/helpers/fakeMachineConfig.ts
@@ -1,0 +1,18 @@
+import { Provider, MachineConfig } from '../../src/config/types'
+
+export default function fakeMachineConfig({
+  machineId = '000',
+}: Partial<MachineConfig> = {}): MachineConfig {
+  return { machineId }
+}
+
+export function fakeMachineConfigProvider(
+  props: Partial<MachineConfig> = {}
+): Provider<MachineConfig> {
+  const config = fakeMachineConfig(props)
+  return {
+    async get() {
+      return config
+    },
+  }
+}

--- a/apps/bsd/types/kiosk-browser.d.ts
+++ b/apps/bsd/types/kiosk-browser.d.ts
@@ -111,6 +111,17 @@ declare namespace KioskBrowser {
     readFile(path: string): Promise<Buffer>
     readFile(path: string, encoding: string): Promise<string>
 
+    /**
+     * Writes a file to a specified file path
+     */
+    writeFile(path: string): Promise<FileWriter>
+    writeFile(path: string, content: Buffer | string): Promise<void>
+
+    /**
+     * Creates a directory at the specified path.
+     */
+    makeDirectory(path: string, options?: MakeDirectoryOptions): Promise<void>
+
     // storage
     storage: {
       set<K extends keyof M>(key: string, value: M[K]): Promise<void>


### PR DESCRIPTION
Branch depends on https://github.com/votingworks/vxsuite/pull/106 as I wanted to reuse some shared components (but could be separated)

Adds a new modal when exporting scanner results that handles different USB drive states and can either save to a custom file location or save by default to `/cast-vote-records/<election name>/<scannerId><numBallots><timestamp>.jsonl`. Mimics the UI and copy of the export modal for the ballot package in election manager. When run not through kiosk mode there is an export button on the "no usb" screen so that we can still more easily save files when developing locally, it functions how the download out of kiosk mode did before this change. One small functionality change is that I am now disabling the export button when there are 0 results to export. 

I tried to break things into commits a bit more with this PR to make it a bit simpler to review. The commit messages are fairly self explanatory. Some Notes:
-   The first commit copies a pattern in the bmd code that gets the machine ID environment variable accessible from the frontend, I did this as I wanted it included in the filename. I think we should consider in the future showing this on the header/footer as well. 
- The "ui tweaks" commit has a change to autoexpand the button width in a ButtonBar when centerOnlyTrue is false (and set that in the Modal component), this is how it worked in ElectionManager but ElectionManager is on a much older version of these components code so I wasn't completely sure what was intentional.  
- The final commit is most of the actual work

## Screenshots 
(happy to make a gif as well if both are useful but I thought these would be easier for review)
### No Usb Screen
![Screen Shot 2020-12-09 at 3 46 38 PM](https://user-images.githubusercontent.com/14897017/101706197-74af6580-3a3d-11eb-8a98-ae85efa1278a.png)

### USB is mounted - main export screen
![Screen Shot 2020-12-09 at 3 49 09 PM](https://user-images.githubusercontent.com/14897017/101706168-66614980-3a3d-11eb-823c-beb49cd4fbc0.png)

### Download Complete
![Screen Shot 2020-12-09 at 3 49 49 PM](https://user-images.githubusercontent.com/14897017/101706539-2b134a80-3a3e-11eb-936d-9f87921c616d.png)

### Download Complete - after eject
![Screen Shot 2020-12-09 at 3 49 59 PM](https://user-images.githubusercontent.com/14897017/101706114-4d589880-3a3d-11eb-830d-0b45982c2d84.png)

### Download Failed
![Screen Shot 2020-12-09 at 4 45 00 PM](https://user-images.githubusercontent.com/14897017/101706442-f0a9ad80-3a3d-11eb-870c-84b74e019188.png)

