### PR TITLE
build(bmd): upgrade to TypeScript v4

### DIFF
--- a/apps/bmd/package.json
+++ b/apps/bmd/package.json
@@ -107,7 +107,7 @@
     "react-scripts": "3.4.0",
     "rxjs": "^6.5.5",
     "styled-components": "^4.4.1",
-    "typescript": "^3.8.3",
+    "typescript": "^4.1.3",
     "use-interval": "^1.2.1"
   },
   "devDependencies": {

--- a/apps/bmd/src/components/Button.tsx
+++ b/apps/bmd/src/components/Button.tsx
@@ -1,10 +1,6 @@
 import React, { MouseEventHandler, useState } from 'react'
 import styled, { css, StyledComponent } from 'styled-components'
 
-interface Attrs extends HTMLButtonElement {
-  readonly type: string
-}
-
 export interface ButtonInterface {
   readonly big?: boolean
   readonly danger?: boolean
@@ -43,7 +39,7 @@ const buttonStyles = css<StyledButtonProps>`
 export const DecoyButton = styled.div`
   ${buttonStyles}/* stylelint-disable-line value-keyword-case */
 `
-const StyledButton = styled('button').attrs((props: Attrs) => ({
+const StyledButton = styled('button').attrs((props) => ({
   type: props.type ?? 'button',
 }))`
   ${buttonStyles}/* stylelint-disable-line value-keyword-case */

--- a/apps/bmd/src/components/ChoiceButton.tsx
+++ b/apps/bmd/src/components/ChoiceButton.tsx
@@ -5,10 +5,6 @@ import * as GLOBALS from '../config/globals'
 
 import Button, { Props as ButtonProps } from './Button'
 
-interface Attrs extends HTMLButtonElement {
-  readonly type: string
-}
-
 interface Props
   extends ButtonProps,
     React.PropsWithoutRef<JSX.IntrinsicElements['button']> {
@@ -16,7 +12,7 @@ interface Props
   isSelected: boolean
 }
 
-const StyledChoiceButton = styled('button').attrs((props: Attrs) => ({
+const StyledChoiceButton = styled('button').attrs((props) => ({
   role: 'option',
   type: props.type ?? 'button',
 }))<Props>`

--- a/apps/bmd/src/pages/TestBallotDeckScreen.test.tsx
+++ b/apps/bmd/src/pages/TestBallotDeckScreen.test.tsx
@@ -39,15 +39,13 @@ it('renders test decks appropriately', () => {
   expect(getAllByText('FOR Measure 420A', { exact: false })).toHaveLength(31)
   expect(getAllByText('County Commissioners')).toHaveLength(52)
 
-  const oldWindowPrint = window.print
-  delete window.print
-  window.print = jest.fn()
+  const printSpy = jest.spyOn(window, 'print').mockReturnValue()
 
   fireEvent.click(getByText('Print 63 ballots'))
 
   expect(window.print).toHaveBeenCalled()
 
-  window.print = oldWindowPrint
+  printSpy.mockRestore()
 
   window.kiosk = fakeKiosk()
 

--- a/apps/bmd/yarn.lock
+++ b/apps/bmd/yarn.lock
@@ -13781,10 +13781,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
+  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
 
 unherit@^1.0.4:
   version "1.1.1"


### PR DESCRIPTION
The issue with styled-components was fixed by simply letting TS infer the types. The other issue was due to a change in TS v4.0: https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/#operands-for-delete-must-be-optional.