### PR TITLE
Update tally cvr file list table

### DIFF
--- a/apps/election-manager/src/config/types.ts
+++ b/apps/election-manager/src/config/types.ts
@@ -122,7 +122,9 @@ export type CastVoteRecordLists = ReadonlyArray<ReadonlyArray<CastVoteRecord>>
 export interface CastVoteRecordFile {
   readonly name: string
   readonly count: number
+  readonly scannerIds: readonly string[]
   readonly precinctIds: readonly string[]
+  readonly exportTimestamp: Date
 }
 export type CastVoteRecordFilesDictionary = Dictionary<CastVoteRecordFile>
 

--- a/apps/election-manager/src/screens/TallyScreen.tsx
+++ b/apps/election-manager/src/screens/TallyScreen.tsx
@@ -3,6 +3,7 @@
 import React, { useContext, useState, useEffect, useCallback } from 'react'
 import fileDownload from 'js-file-download'
 import pluralize from 'pluralize'
+import moment from 'moment'
 
 import { CastVoteRecordLists, InputEventFunction } from '../config/types'
 
@@ -183,7 +184,10 @@ const TallyScreen: React.FC = () => {
               <React.Fragment>
                 <tr>
                   <TD as="th" narrow nowrap>
-                    File Name
+                    File Exported At
+                  </TD>
+                  <TD as="th" narrow nowrap>
+                    Scanner ID
                   </TD>
                   <TD as="th" nowrap narrow>
                     CVR Count
@@ -192,15 +196,28 @@ const TallyScreen: React.FC = () => {
                     Precinct(s)
                   </TD>
                 </tr>
-                {castVoteRecordFileList.map(({ name, count, precinctIds }) => (
-                  <tr key={name}>
-                    <TD narrow nowrap>
-                      {name}
-                    </TD>
-                    <TD narrow>{format.count(count)}</TD>
-                    <TD>{getPrecinctNames(precinctIds)}</TD>
-                  </tr>
-                ))}
+                {castVoteRecordFileList.map(
+                  ({
+                    name,
+                    exportTimestamp,
+                    count,
+                    scannerIds,
+                    precinctIds,
+                  }) => (
+                    <tr key={name}>
+                      <TD narrow nowrap>
+                        {moment(exportTimestamp).format(
+                          'MM/DD/YYYY hh:mm:ss A'
+                        )}
+                      </TD>
+                      <TD narrow nowrap>
+                        {scannerIds && scannerIds.join(', ')}
+                      </TD>
+                      <TD narrow>{format.count(count)}</TD>
+                      <TD>{getPrecinctNames(precinctIds)}</TD>
+                    </tr>
+                  )
+                )}
                 <tr>
                   <TD as="th" narrow nowrap>
                     Total CVRs Count


### PR DESCRIPTION
Updates the table of loaded CVR files to match the format when importing files. Since in the new workflow a typical user will never see the full filename or interact with that I don't think it makes sense to show it in this table. However, if the user manually imports files with custom names it might be more confusing. Instead we're now showing the scanner ID and the file export timestamp. 

The scanner ID is taken from the actual CVR file data so that will work for files named properly and custom named files, technically this is stored on a per-CVR level so there is nothing in the data format enforcing that there is only 1 scanner ID per file, in case there is more then one this will just show a comma separated list of the scanner IDs in the table. 

The export timestamp will prefer the timestamp in the filename if it can parse it out, but if that doesn't work then it will fall back to the file last modified timestamp. 

Screenshot
![Screen Shot 2021-01-05 at 1 52 18 PM](https://user-images.githubusercontent.com/14897017/103704480-3f276a80-4f5e-11eb-9794-daef8096c4f8.png)
