### PR TITLE
Move error and warning messages from Tally Screen into import modal

### DIFF
--- a/apps/election-manager/src/components/ExportFinalResultsModal.tsx
+++ b/apps/election-manager/src/components/ExportFinalResultsModal.tsx
@@ -1,0 +1,235 @@
+import React, { useContext, useState, useEffect } from 'react'
+import styled from 'styled-components'
+
+import AppContext from '../contexts/AppContext'
+import Modal from './Modal'
+import Button from './Button'
+import Prose from './Prose'
+import LinkButton from './LinkButton'
+import Loading from './Loading'
+import TextInput from './TextInput'
+import Text from './Text'
+import { MainChild } from './Main'
+import USBControllerButton from './USBControllerButton'
+import { UsbDriveStatus } from '../lib/usbstick'
+
+function throwBadStatus(s: never): never {
+  throw new Error(`Bad status: ${s}`)
+}
+
+const USBImage = styled.img`
+  margin-right: auto;
+  margin-left: auto;
+  height: 200px;
+`
+
+const TextInputRow = styled.span`
+  display: flex;
+  align-items: center;
+  margin-top: 0;
+  & > *:not(:first-child) {
+    margin-left: 5px;
+  }
+`
+
+const FilenameInput = styled(TextInput)`
+  text-align: right;
+`
+
+const LabelText = styled(Text)`
+  margin-bottom: 0;
+  font-weight: 700;
+`
+
+export interface Props {
+  isOpen: boolean
+  onClose: () => void
+}
+
+enum ModalState {
+  ERROR = 'error',
+  SAVING = 'saving',
+  DONE = 'done',
+  INIT = 'init',
+}
+
+const ExportFinalResultsModal: React.FC<Props> = ({
+  isOpen,
+  onClose: onCloseFromProps,
+}) => {
+  const { usbDriveStatus } = useContext(AppContext)
+
+  const [currentState, setCurrentState] = useState<ModalState>(ModalState.INIT)
+  const [errorMessage, setErrorMessage] = useState('')
+
+  const [filename, setFilename] = useState('')
+
+  useEffect(() => {
+    if (filename === '' && usbDriveStatus === UsbDriveStatus.mounted) {
+      setFilename('this-is-the-default-filename')
+    }
+  }, [usbDriveStatus, isOpen])
+
+  const onClose = () => {
+    setErrorMessage('')
+    setCurrentState(ModalState.INIT)
+    setFilename('')
+    onCloseFromProps()
+  }
+
+  const exportResults = async () => {
+    setCurrentState(ModalState.SAVING)
+  }
+
+  const handleFilenameInputChange = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    let newValue = event.currentTarget.value
+    newValue = newValue.replace(/[^A-Za-z-]/gi, '')
+    setFilename(newValue)
+  }
+
+  if (currentState === ModalState.ERROR) {
+    return (
+      <Modal
+        isOpen={isOpen}
+        content={
+          <Prose>
+            <h1>Download Failed</h1>
+            <p>{errorMessage}</p>
+          </Prose>
+        }
+        onOverlayClick={onClose}
+        actions={<LinkButton onPress={onClose}>Close</LinkButton>}
+      />
+    )
+  }
+
+  if (currentState === ModalState.DONE) {
+    let actions = (
+      <React.Fragment>
+        <LinkButton onPress={onClose}>Cancel</LinkButton>
+        <USBControllerButton small={false} primary />
+      </React.Fragment>
+    )
+    if (usbDriveStatus === UsbDriveStatus.recentlyEjected) {
+      actions = <LinkButton onPress={onClose}>Close</LinkButton>
+    }
+    return (
+      <Modal
+        isOpen={isOpen}
+        content={
+          <Prose>
+            <h1>Download Complete</h1>
+            <p>
+              CVR results file saved successfully! You may now eject the USB
+              drive and take it to Election Manager for tabulation.
+            </p>
+          </Prose>
+        }
+        onOverlayClick={onClose}
+        actions={actions}
+      />
+    )
+  }
+
+  if (currentState === ModalState.SAVING) {
+    return (
+      <Modal isOpen={isOpen} content={<Loading />} onOverlayClick={onClose} />
+    )
+  }
+
+  if (currentState !== ModalState.INIT) {
+    throwBadStatus(currentState) // Creates a compile time check that all states are being handled.
+  }
+
+  switch (usbDriveStatus) {
+    case UsbDriveStatus.absent:
+    case UsbDriveStatus.notavailable:
+    case UsbDriveStatus.recentlyEjected:
+      // When run not through kiosk mode let the user download the file
+      // on the machine for internal debugging use
+      return (
+        <Modal
+          isOpen={isOpen}
+          content={
+            <Prose>
+              <h1>No USB Drive Detected</h1>
+              <p>
+                <USBImage src="usb-drive.svg" alt="Insert USB Image" />
+                Please insert a USB drive in order to export the scanner
+                results.
+              </p>
+            </Prose>
+          }
+          onOverlayClick={onClose}
+          actions={
+            <React.Fragment>
+              <LinkButton onPress={onClose}>Cancel</LinkButton>
+              {!window.kiosk && (
+                <Button
+                  data-testid="manual-export"
+                  onPress={() => exportResults()}
+                >
+                  Export
+                </Button>
+              )}{' '}
+            </React.Fragment>
+          }
+        />
+      )
+    case UsbDriveStatus.ejecting:
+    case UsbDriveStatus.present:
+      return (
+        <Modal
+          isOpen={isOpen}
+          content={<Loading />}
+          onOverlayClick={onClose}
+          actions={
+            <React.Fragment>
+              <LinkButton onPress={onClose}>Cancel</LinkButton>
+            </React.Fragment>
+          }
+        />
+      )
+    case UsbDriveStatus.mounted:
+      return (
+        <Modal
+          isOpen={isOpen}
+          content={
+            <MainChild>
+              <Prose>
+                <h1>Export Results</h1>
+                <p>
+                  Export the final tally results to the following filename on
+                  the inserted USB drive.
+                </p>
+              </Prose>
+              <LabelText small>Filename</LabelText>
+              <TextInputRow>
+                <FilenameInput
+                  value={filename}
+                  onChange={handleFilenameInputChange}
+                />
+                <span>.csv</span>
+              </TextInputRow>
+            </MainChild>
+          }
+          onOverlayClick={onClose}
+          actions={
+            <React.Fragment>
+              <LinkButton onPress={onClose}>Cancel</LinkButton>
+              <Button primary onPress={() => exportResults()}>
+                Export
+              </Button>
+            </React.Fragment>
+          }
+        />
+      )
+    default:
+      // Creates a compile time check to make sure this switch statement includes all enum values for UsbDriveStatus
+      throwBadStatus(usbDriveStatus)
+  }
+}
+
+export default ExportFinalResultsModal

--- a/apps/election-manager/src/components/ImportCVRFilesModal.test.tsx
+++ b/apps/election-manager/src/components/ImportCVRFilesModal.test.tsx
@@ -158,7 +158,7 @@ describe('Screens display properly when USB is mounted', () => {
         'live1',
         'utf-8'
       )
-      // When the import is succesfull the modal should automatically be closed.
+      // When the import is successful the modal should automatically be closed.
       expect(closeFn).toHaveBeenCalledTimes(2)
     })
   })

--- a/apps/election-manager/src/components/ImportCVRFilesModal.test.tsx
+++ b/apps/election-manager/src/components/ImportCVRFilesModal.test.tsx
@@ -86,7 +86,7 @@ describe('Screens display properly when USB is mounted', () => {
 
     // You can still manually import files
     fireEvent.change(getByTestId('manual-input'), {
-      target: { files: [new File(['file'], 'file.jsonl')] },
+      target: { files: [new File([''], 'file.jsonl')] },
     })
     await waitFor(() => expect(closeFn).toHaveBeenCalledTimes(2))
     expect(saveCVR).toHaveBeenCalledTimes(1)
@@ -158,6 +158,8 @@ describe('Screens display properly when USB is mounted', () => {
         'live1',
         'utf-8'
       )
+      // When the import is succesfull the modal should automatically be closed.
+      expect(closeFn).toHaveBeenCalledTimes(2)
     })
   })
 
@@ -199,6 +201,9 @@ describe('Screens display properly when USB is mounted', () => {
     const tableRows = getAllByTestId('table-row')
     expect(tableRows).toHaveLength(3)
 
+    window.kiosk!.readFile = jest
+      .fn()
+      .mockResolvedValueOnce('invalid-file-contents')
     fireEvent.click(domGetByText(tableRows[1], 'Select'))
     getByText('Loading')
     await waitFor(() => {
@@ -209,6 +214,9 @@ describe('Screens display properly when USB is mounted', () => {
         'test1',
         'utf-8'
       )
+      // There should be an error importing the file.
+      getByText('Error')
+      getByText(/There was an error reading the content of the file/)
     })
   })
 
@@ -275,6 +283,10 @@ describe('Screens display properly when USB is mounted', () => {
     fireEvent.click(getByText('Cancel'))
     expect(closeFn).toHaveBeenCalledTimes(1)
 
+    window.kiosk!.readFile = jest
+      .fn()
+      .mockResolvedValueOnce(JSON.stringify(cvr))
+
     fireEvent.click(domGetByText(tableRows[1], 'Select'))
     getByText('Loading')
     await waitFor(() => {
@@ -284,6 +296,11 @@ describe('Screens display properly when USB is mounted', () => {
         1,
         'test2',
         'utf-8'
+      )
+      // There should be a message about importing a duplicate file displayed.
+      getByText('Duplicate File')
+      getByText(
+        'The selected file was ignored as a duplicate of a previously imported file.'
       )
     })
   })
@@ -355,6 +372,7 @@ describe('Screens display properly when USB is mounted', () => {
         'live1',
         'utf-8'
       )
+      expect(closeFn).toHaveBeenCalledTimes(2)
     })
   })
 

--- a/apps/election-manager/src/components/ImportCVRFilesModal.tsx
+++ b/apps/election-manager/src/components/ImportCVRFilesModal.tsx
@@ -204,11 +204,7 @@ const ImportCVRFilesModal: React.FC<Props> = ({
           </Prose>
         }
         onOverlayClick={onClose}
-        actions={
-          <React.Fragment>
-            <LinkButton onPress={onClose}>Close</LinkButton>
-          </React.Fragment>
-        }
+        actions={<LinkButton onPress={onClose}>Close</LinkButton>}
       />
     )
   }

--- a/apps/election-manager/src/components/ImportCVRFilesModal.tsx
+++ b/apps/election-manager/src/components/ImportCVRFilesModal.tsx
@@ -75,7 +75,7 @@ const ImportCVRFilesModal: React.FC<Props> = ({
     castVoteRecordFiles,
     electionDefinition,
   } = useContext(AppContext)
-  const [currentState, setCurrentState] = useState<ModalState>(ModalState.INIT)
+  const [currentState, setCurrentState] = useState(ModalState.INIT)
   const [foundFiles, setFoundFiles] = useState<KioskBrowser.FileSystemEntry[]>(
     []
   )

--- a/apps/election-manager/src/screens/TallyScreen.tsx
+++ b/apps/election-manager/src/screens/TallyScreen.tsx
@@ -27,6 +27,7 @@ import LinkButton from '../components/LinkButton'
 import HorizontalRule from '../components/HorizontalRule'
 import Prose from '../components/Prose'
 import ImportCVRFilesModal from '../components/ImportCVRFilesModal'
+import ExportFinalResultsModal from '../components/ExportFinalResultsModal'
 import Modal from '../components/Modal'
 
 const TallyScreen: React.FC = () => {
@@ -44,6 +45,9 @@ const TallyScreen: React.FC = () => {
   const [isLoadingCVRFile, setIsLoadingCVRFile] = useState(false)
   const [isConfimingRemoveCVRs, setIsConfirmingRemoveCVRs] = useState(false)
   const [isImportCVRModalOpen, setIsImportCVRModalOpen] = useState(false)
+  const [isExportResultsModalOpen, setIsExportResultsModalOpen] = useState(
+    false
+  )
 
   const cancelConfirmingRemoveCVRs = () => {
     setIsConfirmingRemoveCVRs(false)
@@ -372,7 +376,9 @@ const TallyScreen: React.FC = () => {
           <React.Fragment>
             <h2>Export Options</h2>
             <p>
-              <Button onPress={exportResults}>Export Results File</Button>
+              <Button onPress={() => setIsExportResultsModalOpen(true)}>
+                Export Results File
+              </Button>
             </p>
           </React.Fragment>
         )}
@@ -457,6 +463,10 @@ const TallyScreen: React.FC = () => {
       <ImportCVRFilesModal
         isOpen={isImportCVRModalOpen}
         onClose={() => setIsImportCVRModalOpen(false)}
+      />
+      <ExportFinalResultsModal
+        isOpen={isExportResultsModalOpen}
+        onClose={() => setIsExportResultsModalOpen(false)}
       />
     </React.Fragment>
   )

--- a/apps/election-manager/src/screens/TallyScreen.tsx
+++ b/apps/election-manager/src/screens/TallyScreen.tsx
@@ -225,32 +225,6 @@ const TallyScreen: React.FC = () => {
             )}
           </tbody>
         </Table>
-        {castVoteRecordFiles.duplicateFiles.length > 0 && (
-          <Text warning>
-            {castVoteRecordFiles.duplicateFiles.length === 1 && (
-              <React.Fragment>
-                The file{' '}
-                <strong>{castVoteRecordFiles.duplicateFiles.join(', ')}</strong>{' '}
-                was ignored as a duplicate of a file already loaded.
-              </React.Fragment>
-            )}
-            {castVoteRecordFiles.duplicateFiles.length > 1 && (
-              <React.Fragment>
-                The files{' '}
-                <strong>{castVoteRecordFiles.duplicateFiles.join(', ')}</strong>{' '}
-                were ignored as duplicates of files already loaded.
-              </React.Fragment>
-            )}
-          </Text>
-        )}
-        {castVoteRecordFiles.lastError && (
-          <Text error>
-            There was an error reading the content of the file{' '}
-            <strong>{castVoteRecordFiles.lastError.filename}</strong>:{' '}
-            {castVoteRecordFiles.lastError.message}. Please ensure this file
-            only contains valid CVR data for this election.
-          </Text>
-        )}
         <p>
           <Button
             onPress={() => setIsImportCVRModalOpen(true)}


### PR DESCRIPTION
Removes the error/duplicate message warnings from the tally screen page and instead moves them into a final screen in the in import modal. This means the user will only see these messages when importing, right now they will seem them forever. I did not make a final "import complete" screen in the modal when the import happens successfully and instead just close the modal as I thought it would be better to reduce the number of clicks when things go well. 

Duplicate File: 

https://user-images.githubusercontent.com/14897017/103805983-3049c200-5009-11eb-8eb9-7ab9ab3b3e09.mov


Error: 

https://user-images.githubusercontent.com/14897017/103805917-1a3c0180-5009-11eb-8030-9deb538fccd2.mov

