### PR TITLE
test(hmpb-interpreter): remove outdated ts-jest config

### DIFF
--- a/libs/hmpb-interpreter/jest.config.js
+++ b/libs/hmpb-interpreter/jest.config.js
@@ -2,11 +2,6 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/node_modules/'],
-  globals: {
-    'ts-jest': {
-      packageJson: 'package.json',
-    },
-  },
   collectCoverageFrom: ['src/**/*', '!test/fixtures/**/*'],
   coverageThreshold: {
     global: {


### PR DESCRIPTION
Fixes this warning:
```
ts-jest[config] (WARN) The option `packageJson` is deprecated and will be removed in ts-jest 27. This option is not used by internal `ts-jest`
```

This config was needed when we were using yarn pnp, but we're not anymore.