### PR TITLE
Implement export final results modal

### DIFF
--- a/apps/election-manager/package.json
+++ b/apps/election-manager/package.json
@@ -92,6 +92,7 @@
     "i18next": "^19.4.5",
     "js-file-download": "^0.4.12",
     "js-sha256": "^0.9.0",
+    "mockdate": "^3.0.2",
     "moment": "^2.26.0",
     "node-fetch": "^2.6.0",
     "normalize.css": "^8.0.1",

--- a/apps/election-manager/src/components/ExportFinalResultsModal.test.tsx
+++ b/apps/election-manager/src/components/ExportFinalResultsModal.test.tsx
@@ -88,7 +88,7 @@ test('render export modal when a usb drive is mounted as expected and allows aut
       usbDriveStatus: UsbDriveStatus.mounted,
     }
   )
-  getByText('Save Results')
+  getByText('Save Results File')
   getByText(/Save the final tally results to /)
   getByText(
     'votingworks-live-results_choctaw-county_mock-general-election-choctaw-2020_2020-03-14_01-59-26.csv'
@@ -97,7 +97,7 @@ test('render export modal when a usb drive is mounted as expected and allows aut
   fireEvent.click(getByText('Save'))
   await waitFor(() => getByText(/Saving/))
   jest.advanceTimersByTime(2001)
-  await waitFor(() => getByText(/Results Saved/))
+  await waitFor(() => getByText(/Results File Saved/))
   await waitFor(() => {
     expect(mockKiosk.writeFile).toHaveBeenCalledTimes(1)
     expect(mockKiosk.writeFile).toHaveBeenNthCalledWith(
@@ -133,7 +133,7 @@ test('render export modal with errors when appropriate and clears errors when cl
       usbDriveStatus: UsbDriveStatus.mounted,
     }
   )
-  getByText('Save Results')
+  getByText('Save Results File')
 
   fireEvent.click(getByText('Save'))
   await waitFor(() => getByText(/Saving Results Failed/))
@@ -142,5 +142,5 @@ test('render export modal with errors when appropriate and clears errors when cl
 
   fireEvent.click(getByText('Close'))
   expect(closeFn).toHaveBeenCalled()
-  getByText('Save Results') // Closing should reset back to the starting export screen
+  getByText('Save Results File') // Closing should reset back to the starting export screen
 })

--- a/apps/election-manager/src/components/ExportFinalResultsModal.test.tsx
+++ b/apps/election-manager/src/components/ExportFinalResultsModal.test.tsx
@@ -1,0 +1,146 @@
+import React from 'react'
+
+import { fireEvent, waitFor } from '@testing-library/react'
+import fetchMock from 'fetch-mock'
+import MockDate from 'mockdate'
+
+import { UsbDriveStatus } from '../lib/usbstick'
+import ExportFinalResultsModal from './ExportFinalResultsModal'
+import fakeKiosk, { fakeUsbDrive } from '../../test/helpers/fakeKiosk'
+import renderInAppContext from '../../test/renderInAppContext'
+
+beforeEach(() => {
+  jest.useFakeTimers()
+  MockDate.set(new Date(2020, 2, 14, 1, 59, 26))
+  fetchMock.reset()
+})
+
+afterEach(() => {
+  MockDate.reset()
+  jest.useRealTimers()
+})
+
+test('renders loading screen when usb drive is mounting or ejecting in export modal', () => {
+  const usbStatuses = [UsbDriveStatus.present, UsbDriveStatus.ejecting]
+
+  for (const status of usbStatuses) {
+    const closeFn = jest.fn()
+    const { getByText, unmount } = renderInAppContext(
+      <ExportFinalResultsModal isOpen onClose={closeFn} />,
+      { usbDriveStatus: status }
+    )
+    getByText('Loading')
+    unmount()
+  }
+})
+
+test('render no usb found screen when there is not a mounted usb drive', () => {
+  const usbStatuses = [
+    UsbDriveStatus.absent,
+    UsbDriveStatus.notavailable,
+    UsbDriveStatus.recentlyEjected,
+  ]
+
+  for (const status of usbStatuses) {
+    const closeFn = jest.fn()
+    const {
+      getByText,
+      unmount,
+      getByAltText,
+    } = renderInAppContext(
+      <ExportFinalResultsModal isOpen onClose={closeFn} />,
+      { usbDriveStatus: status }
+    )
+    getByText('No USB Drive Detected')
+    getByText(
+      'Please insert a USB drive where the election results will be saved.'
+    )
+    getByAltText('Insert USB Image')
+
+    fireEvent.click(getByText('Cancel'))
+    expect(closeFn).toHaveBeenCalled()
+
+    unmount()
+  }
+})
+
+test('render export modal when a usb drive is mounted as expected and allows automatic export', async () => {
+  const mockKiosk = fakeKiosk()
+  window.kiosk = mockKiosk
+  mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()])
+
+  fetchMock.getOnce('/convert/results/files', {
+    inputFiles: [{ name: 'name' }, { name: 'name' }],
+    outputFiles: [{ name: 'name' }],
+  })
+
+  fetchMock.post('/convert/results/submitfile', { body: { status: 'ok' } })
+  fetchMock.post('/convert/results/process', { body: { status: 'ok' } })
+
+  fetchMock.getOnce('/convert/results/output?name=name', { body: '' })
+
+  fetchMock.post('/convert/reset', { body: { status: 'ok' } })
+
+  const closeFn = jest.fn()
+  const { getByText } = renderInAppContext(
+    <ExportFinalResultsModal isOpen onClose={closeFn} />,
+    {
+      usbDriveStatus: UsbDriveStatus.mounted,
+    }
+  )
+  getByText('Save Results')
+  getByText(/Save the final tally results to /)
+  getByText(
+    'votingworks-live-results_choctaw-county_mock-general-election-choctaw-2020_2020-03-14_01-59-26.csv'
+  )
+
+  fireEvent.click(getByText('Save'))
+  await waitFor(() => getByText(/Saving/))
+  jest.advanceTimersByTime(2001)
+  await waitFor(() => getByText(/Results Saved/))
+  await waitFor(() => {
+    expect(mockKiosk.writeFile).toHaveBeenCalledTimes(1)
+    expect(mockKiosk.writeFile).toHaveBeenNthCalledWith(
+      1,
+      'fake mount point/votingworks-live-results_choctaw-county_mock-general-election-choctaw-2020_2020-03-14_01-59-26.csv',
+      '{"body":""}'
+    )
+  })
+  expect(fetchMock.called('/convert/results/files')).toBe(true)
+  expect(fetchMock.called('/convert/results/submitfile')).toBe(true)
+  expect(fetchMock.called('/convert/results/process')).toBe(true)
+  expect(fetchMock.called('/convert/results/output?name=name')).toBe(true)
+  expect(fetchMock.called('/convert/reset')).toBe(true)
+
+  fireEvent.click(getByText('Close'))
+  expect(closeFn).toHaveBeenCalled()
+})
+
+test('render export modal with errors when appropriate and clears errors when closed', async () => {
+  const mockKiosk = fakeKiosk()
+  window.kiosk = mockKiosk
+
+  // When inputFiles doesn't return 2 expected files the saving code will error.
+  fetchMock.getOnce('/convert/results/files', {
+    inputFiles: [],
+    outputFiles: [],
+  })
+
+  const closeFn = jest.fn()
+  const { getByText } = renderInAppContext(
+    <ExportFinalResultsModal isOpen onClose={closeFn} />,
+    {
+      usbDriveStatus: UsbDriveStatus.mounted,
+    }
+  )
+  getByText('Save Results')
+
+  fireEvent.click(getByText('Save'))
+  await waitFor(() => getByText(/Saving Results Failed/))
+  getByText(/Failed to save results./)
+  getByText(/Cannot read property 'name' of undefined/)
+
+  fireEvent.click(getByText('Close'))
+  expect(closeFn).toHaveBeenCalled()
+  getByText('Save Results') // Closing should reset back to the starting export screen
+})

--- a/apps/election-manager/src/components/ExportFinalResultsModal.tsx
+++ b/apps/election-manager/src/components/ExportFinalResultsModal.tsx
@@ -110,6 +110,7 @@ const ExportFinalResultsModal: React.FC<Props> = ({
           }
 
           await fileWriter.write(await results.text())
+          setSavedFilename(fileWriter.filename)
           await fileWriter.end()
         } else {
           await window.kiosk!.writeFile(pathToFile, await results.text())
@@ -158,15 +159,16 @@ const ExportFinalResultsModal: React.FC<Props> = ({
         isOpen={isOpen}
         content={
           <Prose>
-            <h1>Results Saved</h1>
+            <h1>Results File Saved</h1>
+            <p>You may now eject the USB drive.</p>
             <p>
-              Results file succesfully saved{' '}
+              Results file successfully saved{' '}
               {savedFilename !== '' && (
                 <span>
                   as <strong>{savedFilename}</strong>
                 </span>
               )}{' '}
-              directly on the inserted USB drive. You may now eject the USB.
+              directly on the inserted USB drive.
             </p>
           </Prose>
         }
@@ -180,7 +182,7 @@ const ExportFinalResultsModal: React.FC<Props> = ({
     return (
       <Modal
         isOpen={isOpen}
-        content={<Loading>Saving</Loading>}
+        content={<Loading>Saving Results File</Loading>}
         onOverlayClick={onClose}
       />
     )
@@ -252,7 +254,7 @@ const ExportFinalResultsModal: React.FC<Props> = ({
           content={
             <MainChild>
               <Prose>
-                <h1>Save Results</h1>
+                <h1>Save Results File</h1>
                 <p>
                   Save the final tally results to{' '}
                   <strong>{defaultFilename}</strong> directly on the inserted

--- a/apps/election-manager/src/components/ExportFinalResultsModal.tsx
+++ b/apps/election-manager/src/components/ExportFinalResultsModal.tsx
@@ -1,0 +1,287 @@
+import React, { useContext, useState } from 'react'
+import styled from 'styled-components'
+import path from 'path'
+import fileDownload from 'js-file-download'
+
+import AppContext from '../contexts/AppContext'
+import Modal from './Modal'
+import Button from './Button'
+import Prose from './Prose'
+import LinkButton from './LinkButton'
+import Loading from './Loading'
+import { MainChild } from './Main'
+import USBControllerButton from './USBControllerButton'
+import ConverterClient from '../lib/ConverterClient'
+import { UsbDriveStatus, getDevicePath } from '../lib/usbstick'
+import { generateFinalExportDefaultFilename } from '../utils/filenames'
+
+function throwBadStatus(s: never): never {
+  throw new Error(`Bad status: ${s}`)
+}
+
+const USBImage = styled.img`
+  margin-right: auto;
+  margin-left: auto;
+  height: 200px;
+`
+
+export interface Props {
+  isOpen: boolean
+  onClose: () => void
+}
+
+enum ModalState {
+  ERROR = 'error',
+  SAVING = 'saving',
+  DONE = 'done',
+  INIT = 'init',
+}
+
+const ExportFinalResultsModal: React.FC<Props> = ({
+  isOpen,
+  onClose: onCloseFromProps,
+}) => {
+  const {
+    usbDriveStatus,
+    castVoteRecordFiles,
+    electionDefinition,
+  } = useContext(AppContext)
+
+  const [currentState, setCurrentState] = useState(ModalState.INIT)
+  const [errorMessage, setErrorMessage] = useState('')
+
+  const [savedFilename, setSavedFilename] = useState('')
+
+  const onClose = () => {
+    setErrorMessage('')
+    setCurrentState(ModalState.INIT)
+    setSavedFilename('')
+    onCloseFromProps()
+  }
+
+  const exportResults = async (
+    openFileDialog: boolean,
+    defaultFilename: string
+  ) => {
+    setCurrentState(ModalState.SAVING)
+
+    try {
+      const CastVoteRecordsString = castVoteRecordFiles.castVoteRecords
+        .flat(1)
+        .map((c) => JSON.stringify(c))
+        .join('\n')
+
+      // process on the server
+      const client = new ConverterClient('results')
+      const { inputFiles, outputFiles } = await client.getFiles()
+      const [electionDefinitionFile, cvrFile] = inputFiles
+      const resultsFile = outputFiles[0]
+
+      await client.setInputFile(
+        electionDefinitionFile.name,
+        new File(
+          [electionDefinition!.electionData],
+          electionDefinitionFile.name,
+          {
+            type: 'application/json',
+          }
+        )
+      )
+      await client.setInputFile(
+        cvrFile.name,
+        new File([CastVoteRecordsString], 'cvrs')
+      )
+      await client.process()
+
+      // download the result
+      const results = await client.getOutputFile(resultsFile.name)
+      if (!window.kiosk) {
+        fileDownload(results, defaultFilename, 'text/csv')
+      } else {
+        const usbPath = await getDevicePath()
+        const pathToFile = path.join(usbPath!, defaultFilename)
+        if (openFileDialog) {
+          const fileWriter = await window.kiosk.saveAs({
+            defaultPath: pathToFile,
+          })
+
+          if (!fileWriter) {
+            throw new Error('could not begin download; no file was chosen')
+          }
+
+          await fileWriter.write(await results.text())
+          await fileWriter.end()
+        } else {
+          await window.kiosk!.writeFile(pathToFile, await results.text())
+          setSavedFilename(defaultFilename)
+        }
+      }
+
+      // reset server files
+      await client.reset()
+      await new Promise((resolve) => setTimeout(resolve, 2000))
+      setCurrentState(ModalState.DONE)
+    } catch (error) {
+      setErrorMessage(`Failed to save results. ${error.message}`)
+      setCurrentState(ModalState.ERROR)
+    }
+  }
+
+  if (currentState === ModalState.ERROR) {
+    return (
+      <Modal
+        isOpen={isOpen}
+        content={
+          <Prose>
+            <h1>Saving Results Failed</h1>
+            <p>{errorMessage}</p>
+          </Prose>
+        }
+        onOverlayClick={onClose}
+        actions={<LinkButton onPress={onClose}>Close</LinkButton>}
+      />
+    )
+  }
+
+  if (currentState === ModalState.DONE) {
+    let actions = (
+      <React.Fragment>
+        <LinkButton onPress={onClose}>Close</LinkButton>
+        <USBControllerButton small={false} primary />
+      </React.Fragment>
+    )
+    if (usbDriveStatus === UsbDriveStatus.recentlyEjected) {
+      actions = <LinkButton onPress={onClose}>Close</LinkButton>
+    }
+    return (
+      <Modal
+        isOpen={isOpen}
+        content={
+          <Prose>
+            <h1>Results Saved</h1>
+            <p>
+              Results file succesfully saved{' '}
+              {savedFilename !== '' && (
+                <span>
+                  as <strong>{savedFilename}</strong>
+                </span>
+              )}{' '}
+              directly on the inserted USB drive. You may now eject the USB.
+            </p>
+          </Prose>
+        }
+        onOverlayClick={onClose}
+        actions={actions}
+      />
+    )
+  }
+
+  if (currentState === ModalState.SAVING) {
+    return (
+      <Modal
+        isOpen={isOpen}
+        content={<Loading>Saving</Loading>}
+        onOverlayClick={onClose}
+      />
+    )
+  }
+
+  if (currentState !== ModalState.INIT) {
+    throwBadStatus(currentState) // Creates a compile time check that all states are being handled.
+  }
+
+  const isTestMode = castVoteRecordFiles?.fileMode === 'test'
+  const defaultFilename = generateFinalExportDefaultFilename(
+    isTestMode,
+    electionDefinition!.election
+  )
+
+  switch (usbDriveStatus) {
+    case UsbDriveStatus.absent:
+    case UsbDriveStatus.notavailable:
+    case UsbDriveStatus.recentlyEjected:
+      // When run not through kiosk mode let the user download the file
+      // on the machine for internal debugging use
+      return (
+        <Modal
+          isOpen={isOpen}
+          content={
+            <Prose>
+              <h1>No USB Drive Detected</h1>
+              <p>
+                <USBImage src="usb-drive.svg" alt="Insert USB Image" />
+                Please insert a USB drive where the election results will be
+                saved.
+              </p>
+            </Prose>
+          }
+          onOverlayClick={onClose}
+          actions={
+            <React.Fragment>
+              <LinkButton onPress={onClose}>Cancel</LinkButton>
+              {!window.kiosk && (
+                <Button
+                  data-testid="manual-export"
+                  onPress={() => exportResults(true, defaultFilename)}
+                >
+                  Save
+                </Button>
+              )}{' '}
+            </React.Fragment>
+          }
+        />
+      )
+    case UsbDriveStatus.ejecting:
+    case UsbDriveStatus.present:
+      return (
+        <Modal
+          isOpen={isOpen}
+          content={<Loading />}
+          onOverlayClick={onClose}
+          actions={
+            <React.Fragment>
+              <LinkButton onPress={onClose}>Cancel</LinkButton>
+            </React.Fragment>
+          }
+        />
+      )
+    case UsbDriveStatus.mounted:
+      return (
+        <Modal
+          isOpen={isOpen}
+          content={
+            <MainChild>
+              <Prose>
+                <h1>Save Results</h1>
+                <p>
+                  Save the final tally results to{' '}
+                  <strong>{defaultFilename}</strong> directly on the inserted
+                  USB drive?
+                </p>
+              </Prose>
+            </MainChild>
+          }
+          onOverlayClick={onClose}
+          actions={
+            <React.Fragment>
+              <LinkButton onPress={onClose}>Cancel</LinkButton>
+              <Button onPress={() => exportResults(true, defaultFilename)}>
+                Save As…
+              </Button>
+              <Button
+                primary
+                onPress={() => exportResults(false, defaultFilename)}
+              >
+                Save
+              </Button>
+            </React.Fragment>
+          }
+        />
+      )
+    default:
+      // Creates a compile time check to make sure this switch statement includes all enum values for UsbDriveStatus
+      throwBadStatus(usbDriveStatus)
+  }
+}
+
+export default ExportFinalResultsModal

--- a/apps/election-manager/src/utils/filenames.test.ts
+++ b/apps/election-manager/src/utils/filenames.test.ts
@@ -1,6 +1,7 @@
 import {
   generateFilenameForBallotExportPackage,
   parseCVRFileInfoFromFilename,
+  generateFinalExportDefaultFilename,
 } from './filenames'
 import { defaultElectionDefinition } from '../../test/renderInAppContext'
 
@@ -66,6 +67,32 @@ test('generates ballot export package name with zero padded time pieces', () => 
   expect(generateFilenameForBallotExportPackage(mockElection, time)).toBe(
     'king-county_general-election_testHash12__2019-03-01_01-09-02.zip'
   )
+})
+
+describe('generateFinalExportDefaultFilename', () => {
+  test('generates the correct filename for test mode', () => {
+    const mockElection = {
+      ...defaultElectionDefinition.election,
+      county: { name: 'King County', id: '' },
+      title: 'General Election',
+    }
+    const time = new Date(2019, 2, 1, 1, 9, 2)
+    expect(generateFinalExportDefaultFilename(true, mockElection, time)).toBe(
+      'votingworks-test-results_king-county_general-election_2019-03-01_01-09-02.csv'
+    )
+  })
+
+  test('generates the correct filename for live mode', () => {
+    const time = new Date(2019, 2, 1, 1, 9, 2)
+    const mockElection = {
+      ...defaultElectionDefinition.election,
+      county: { name: 'King County', id: '' },
+      title: 'General Election',
+    }
+    expect(generateFinalExportDefaultFilename(false, mockElection, time)).toBe(
+      'votingworks-live-results_king-county_general-election_2019-03-01_01-09-02.csv'
+    )
+  })
 })
 
 describe('parseCVRFileInfoFromFilename', () => {

--- a/apps/election-manager/src/utils/filenames.ts
+++ b/apps/election-manager/src/utils/filenames.ts
@@ -25,17 +25,22 @@ function sanitizeString(input: string, replacement = ''): string {
     .toLocaleLowerCase()
 }
 
-export function generateFilenameForBallotExportPackage(
-  electionDefinition: ElectionDefinition,
-  time: Date = new Date()
-): string {
-  const { election, electionHash } = electionDefinition
+function generateElectionName(election: Election): string {
   const electionCountyName = sanitizeString(
     election.county.name,
     WORD_SEPARATOR
   )
   const electionTitle = sanitizeString(election.title, WORD_SEPARATOR)
-  const electionInformation = `${electionCountyName}${SUBSECTION_SEPARATOR}${electionTitle}${SUBSECTION_SEPARATOR}${electionHash.slice(
+  return `${electionCountyName}${SUBSECTION_SEPARATOR}${electionTitle}`
+}
+
+export function generateFilenameForBallotExportPackage(
+  electionDefinition: ElectionDefinition,
+  time: Date = new Date()
+): string {
+  const { election, electionHash } = electionDefinition
+  const electionName = generateElectionName(election)
+  const electionInformation = `${electionName}${SUBSECTION_SEPARATOR}${electionHash.slice(
     0,
     10
   )}`
@@ -90,4 +95,15 @@ export function parseCVRFileInfoFromFilename(
     isTestModeResults,
     timestamp: parsedTime.toDate(),
   }
+}
+
+export function generateFinalExportDefaultFilename(
+  isTestModeResults: boolean,
+  election: Election,
+  time: Date = new Date()
+): string {
+  const filemode = isTestModeResults ? 'test' : 'live'
+  const timeInformation = moment(time).format(TIME_FORMAT_STRING)
+  const electionName = generateElectionName(election)
+  return `votingworks${WORD_SEPARATOR}${filemode}${WORD_SEPARATOR}results${SUBSECTION_SEPARATOR}${electionName}${SUBSECTION_SEPARATOR}${timeInformation}.csv`
 }

--- a/apps/election-manager/test/helpers/fakeFileWriter.ts
+++ b/apps/election-manager/test/helpers/fakeFileWriter.ts
@@ -9,6 +9,7 @@ export default function fakeFileWriter(): jest.Mocked<
       chunks.push(chunk)
     }),
     end: jest.fn().mockResolvedValue(undefined),
+    filename: '',
     chunks,
   }
 

--- a/apps/election-manager/types/kiosk-browser.d.ts
+++ b/apps/election-manager/types/kiosk-browser.d.ts
@@ -86,6 +86,8 @@ declare namespace KioskBrowser {
      * will fail. Resolves when the file is successfully closed.
      */
     end(): Promise<void>
+
+    filename: string
   }
 
   export interface Kiosk {

--- a/apps/election-manager/yarn.lock
+++ b/apps/election-manager/yarn.lock
@@ -8837,6 +8837,11 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+mockdate@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-3.0.2.tgz#a5a7bb5820da617747af424d7a4dcb22c6c03d79"
+  integrity sha512-ldfYSUW1ocqSHGTK6rrODUiqAFPGAg0xaHqYJ5tvj1hQyFsjuHpuWgWFTZWwDVlzougN/s2/mhDr8r5nY5xDpA==
+
 moment@^2.26.0:
   version "2.26.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.26.0.tgz#5e1f82c6bafca6e83e808b30c8705eed0dcbd39a"


### PR DESCRIPTION
## Summary
Implements a new modal for exporting the final results from election manager. When not in kiosk mode for internal testing you can download a file without inserting a USB stick. 

## Notes
A few notes that I wasn't sure about / looking for feedback
 - Design of the text input box. We had talked about making it so the user could only enter a prefix instead of editing the full filename, or making it a more "hidden" user flow to edit the filename but I wasn't sure what a design for those options would look like so I went for a simpler solution of not letting them edit the file extension but edit the rest of the filename, that said I am making sure they don't enter any illegal characters (they can only enter alphanumeric characters plus hyphens and underscores) in the text box so I think its pretty safe, and I like that this makes it obvious what the filename is. I also kind of thought bolding the "filename" label conflicts with the title in the modal but I thought the input needed a label so... wasn't sure the best design.
 - I considered including the election name / county in the default filename, however this made the filename really long and overflow the text box so I opted against it for simplicity since the user will need to find this file themselves to upload the results. I think this is the right tradeoff since they'll likely be using a clean USB for each election anyway. 
 - The copy on the final "Done" Screen particularly the final sentence. Happy to just remove it but I wasn't sure the best way to try to communicate the next step to the election official in a generalized enough manner to work for multiple states/reporting systems. 


## Screenshots
![Screen Shot 2021-01-08 at 12 14 01 PM](https://user-images.githubusercontent.com/14897017/104060892-755a2980-51ac-11eb-8fa7-4cd25bff2090.png)
![Screen Shot 2021-01-08 at 12 14 10 PM](https://user-images.githubusercontent.com/14897017/104060889-7428fc80-51ac-11eb-83ab-42e729817d3f.png)

https://user-images.githubusercontent.com/14897017/104060979-97ec4280-51ac-11eb-8473-549d2ac6461e.mov


## Testing
Ran newly implemented tests. 
Manually tested changing the filename, making sure illegal characters can not be added, and that the filename is actually the filename that is saved.
Diffed the file saved here with the file saved prior to any changes and verified nothing has changed. 

## Review Request
Looking for code/product experience sign-off from anyone available and design input from @beausmith 
