### PR TITLE
fix(module-scan): improve quirc perf

### DIFF
--- a/apps/module-scan/src/util/qrcode.ts
+++ b/apps/module-scan/src/util/qrcode.ts
@@ -5,7 +5,6 @@ import { detect as qrdetect } from '@votingworks/qrdetect'
 import makeDebug from 'debug'
 import jsQR from 'jsqr'
 import { decode as quircDecode, QRCode } from 'node-quirc'
-import { toPNG } from './images'
 import { time } from './perf'
 
 const debug = makeDebug('module-scan:qrcode')
@@ -97,7 +96,7 @@ export const detectQRCode = async (
     {
       name: 'quirc',
       detect: async (imageData: ImageData): Promise<Buffer[]> => {
-        const results = await quircDecode(await toPNG(imageData))
+        const results = await quircDecode(imageData)
         return results
           .filter((result): result is QRCode => !('err' in result))
           .map((result) => result.data)

--- a/apps/module-scan/types/node-quirc.d.ts
+++ b/apps/module-scan/types/node-quirc.d.ts
@@ -38,9 +38,9 @@ declare module 'node-quirc' {
     err: string
   }
 
-  export function decode(img: Buffer): Promise<DecodeResult>
+  export function decode(img: Buffer | ImageData): Promise<DecodeResult>
   export function decode(
-    img: Buffer,
+    img: Buffer | ImageData,
     callback: (err: Error, results: DecodeResult) => void
   ): Promise<DecodeResult>
 }


### PR DESCRIPTION
My PR was merged (https://github.com/kAworu/node-quirc/pull/15), so now we can pass an `ImageData` directly to be decoded without encoding as a PNG first.