### PR TITLE
Make prose the proper width in import cvr modal

### DIFF
--- a/apps/election-manager/src/components/ImportCVRFilesModal.tsx
+++ b/apps/election-manager/src/components/ImportCVRFilesModal.tsx
@@ -361,7 +361,7 @@ const ImportCVRFilesModal: React.FC<Props> = ({
         className="import-cvr-modal"
         content={
           <MainChild>
-            <Prose>
+            <Prose maxWidth={false}>
               <Header>Import {headerModeText} CVR Files </Header>
               <p>{instructionalText}</p>
             </Prose>


### PR DESCRIPTION
The modal is extra wide here to support the table of file results when that is displayed. The width makes the inner Prose block hit it's maxWidth which causes it to look weird in the modal, this disables the maxWidth on the Prose. 

Before
![Screen Shot 2021-01-12 at 3 26 34 PM](https://user-images.githubusercontent.com/14897017/104387081-406f0f00-54eb-11eb-88e4-c4e4bbdbb4c1.png)

After
![Screen Shot 2021-01-12 at 3 28 18 PM](https://user-images.githubusercontent.com/14897017/104387077-3e0cb500-54eb-11eb-9a5a-fa2c1efaab2b.png)