### PR TITLE
Add error message when election configuration import fails

### DIFF
--- a/apps/bsd/src/components/ElectionConfiguration.tsx
+++ b/apps/bsd/src/components/ElectionConfiguration.tsx
@@ -41,14 +41,33 @@ export interface Props {
 }
 
 const ElectionConfiguration: React.FC<Props> = ({
-  acceptAutomaticallyChosenFile,
-  acceptManuallyChosenFile,
+  acceptAutomaticallyChosenFile: acceptAutomaticallyChosenFileFromProps,
+  acceptManuallyChosenFile: acceptManuallyChosenFileFromProps,
   usbDriveStatus,
 }) => {
   const [foundFilenames, setFoundFilenames] = useState<
     KioskBrowser.FileSystemEntry[]
   >([])
   const [loadingFiles, setLoadingFiles] = useState(false)
+  const [errorMessage, setErrorMessage] = useState('')
+
+  const acceptAutomaticallyChosenFile = async (
+    file: KioskBrowser.FileSystemEntry
+  ) => {
+    try {
+      await acceptAutomaticallyChosenFileFromProps(file)
+    } catch (error) {
+      setErrorMessage(error.message)
+    }
+  }
+
+  const acceptManuallyChosenFile = async (file: File) => {
+    try {
+      await acceptManuallyChosenFileFromProps(file)
+    } catch (error) {
+      setErrorMessage(error.message)
+    }
+  }
 
   const fetchFilenames = useCallback(async () => {
     setLoadingFiles(true)
@@ -200,6 +219,13 @@ const ElectionConfiguration: React.FC<Props> = ({
                 file you are looking for, you may select a configuration file
                 manually.
               </Text>
+              {errorMessage !== '' && (
+                <Text error>
+                  An error occured while importing the election configuration:{' '}
+                  {errorMessage}. Please check the file you are importing and
+                  try again.
+                </Text>
+              )}
               <Table>
                 <thead>
                   <tr>

--- a/apps/bsd/src/screens/LoadElectionScreen.tsx
+++ b/apps/bsd/src/screens/LoadElectionScreen.tsx
@@ -86,7 +86,7 @@ const LoadElectionScreen: React.FC<Props> = ({
 
   const onAutomaticFileImport = async (file: KioskBrowser.FileSystemEntry) => {
     // All automatic file imports will be on zip packages
-    readBallotPackageFromFilePointer(file).then(handleBallotLoading)
+    await readBallotPackageFromFilePointer(file).then(handleBallotLoading)
   }
 
   if (isLoadingTemplates) {


### PR DESCRIPTION
Got a corrupted ballot package file and realized we weren't handling errors on this page. So this displays an error message when there is an error importing a configuration package. 


https://user-images.githubusercontent.com/14897017/104391809-95178780-54f5-11eb-899c-8f0847fdbe3a.mov

