### PR TITLE
refactor(bsd): clean up async code after #106

### DIFF
--- a/apps/bsd/src/components/ElectionConfiguration.tsx
+++ b/apps/bsd/src/components/ElectionConfiguration.tsx
@@ -35,8 +35,10 @@ const Title = styled.span`
 `
 
 export interface Props {
-  acceptManuallyChosenFile(file: File): void
-  acceptAutomaticallyChosenFile(file: KioskBrowser.FileSystemEntry): void
+  acceptManuallyChosenFile(file: File): Promise<void>
+  acceptAutomaticallyChosenFile(
+    file: KioskBrowser.FileSystemEntry
+  ): Promise<void>
   usbDriveStatus: UsbDriveStatus
 }
 

--- a/apps/bsd/src/screens/LoadElectionScreen.tsx
+++ b/apps/bsd/src/screens/LoadElectionScreen.tsx
@@ -71,22 +71,28 @@ const LoadElectionScreen: React.FC<Props> = ({
     const reader = new FileReader()
 
     if (isElectionJSON) {
-      reader.onload = async () => {
-        const election = JSON.parse(reader.result as string)
-        await patchConfig({ election })
-        setElection(election)
-      }
+      await new Promise<void>((resolve, reject) => {
+        reader.onload = async () => {
+          try {
+            const election = JSON.parse(reader.result as string)
+            await patchConfig({ election })
+            setElection(election)
+            resolve()
+          } catch (err) {
+            reject(err)
+          }
+        }
 
-      reader.readAsText(file)
+        reader.readAsText(file)
+      })
     } else {
-      readBallotPackageFromFile(file).then(handleBallotLoading)
+      await handleBallotLoading(await readBallotPackageFromFile(file))
     }
-    reader.readAsText(file)
   }
 
   const onAutomaticFileImport = async (file: KioskBrowser.FileSystemEntry) => {
     // All automatic file imports will be on zip packages
-    await readBallotPackageFromFilePointer(file).then(handleBallotLoading)
+    await handleBallotLoading(await readBallotPackageFromFilePointer(file))
   }
 
   if (isLoadingTemplates) {


### PR DESCRIPTION
- do not mix async/await & `.then`
- annotate `ElectionConfiguration` props as promise-returning functions
- await the results of reading manually-imported files

Refs #106 