### PR TITLE
feat(module-scan): workers can send and receive more types

### DIFF
--- a/apps/module-scan/src/workers/child-process-worker.js
+++ b/apps/module-scan/src/workers/child-process-worker.js
@@ -1,9 +1,10 @@
 // @ts-check
 /* eslint-disable @typescript-eslint/no-var-requires */
 
-const { resolve } = require('path')
-
 require('ts-node').register({ transpileOnly: true })
+
+const { resolve } = require('path')
+const json = require('./json-serialization')
 
 if (typeof process.argv[2] !== 'string') {
   throw new Error('missing worker path')
@@ -15,10 +16,10 @@ process.on('message', async (input) => {
   let output
 
   try {
-    output = await call(input)
+    output = await call(json.deserialize(input))
   } catch (error) {
     output = { type: 'error', error: `${error.stack}` }
   }
 
-  process.send && process.send({ output })
+  process.send && process.send({ output: json.serialize(output) })
 })

--- a/apps/module-scan/src/workers/json-serialization.ts
+++ b/apps/module-scan/src/workers/json-serialization.ts
@@ -1,0 +1,165 @@
+export type SerializedMessage =
+  | string
+  | boolean
+  | number
+  | undefined
+  | null
+  | SerializedUndefined
+  | SerializedArray
+  | SerializedObject
+  | SerializedBuffer
+  | SerializedUint8Array
+
+export interface SerializedUndefined {
+  __dataType__: 'undefined'
+}
+
+export interface SerializedArray {
+  __dataType__: 'Array'
+  // TODO: replace `unknown` with `SerializedMessage` after upgrading
+  // to TS 4.1+, which has support for circular type references.
+  value: Array<unknown>
+}
+
+export interface SerializedObject {
+  __dataType__: 'Object'
+  // TODO: replace `unknown` with `SerializedMessage` after upgrading
+  // to TS 4.1+, which has support for circular type references.
+  value: Record<string, unknown>
+}
+
+export interface SerializedBuffer {
+  __dataType__: 'Buffer'
+  value: ArrayLike<number>
+}
+
+export interface SerializedUint8Array {
+  __dataType__: 'Uint8Array'
+  value: ArrayLike<number>
+}
+
+export function serialize(
+  data: unknown,
+  keypath: readonly string[] = []
+): SerializedMessage {
+  switch (typeof data) {
+    case 'string':
+    case 'number':
+    case 'boolean':
+      return data
+
+    case 'undefined':
+      return { __dataType__: 'undefined' }
+
+    case 'object': {
+      if (data === null) {
+        return data
+      }
+
+      if (Array.isArray(data)) {
+        return {
+          __dataType__: 'Array',
+          value: data.map((element, i) =>
+            serialize(element, [...keypath, i.toString()])
+          ),
+        }
+      }
+
+      if (Buffer.isBuffer(data)) {
+        return { __dataType__: 'Buffer', value: [...data] }
+      }
+
+      if (data instanceof Uint8Array) {
+        return { __dataType__: 'Uint8Array', value: [...data] }
+      }
+
+      const toStringValue = Object.prototype.toString.call(data)
+      if (toStringValue !== '[object Object]') {
+        throw new Error(
+          `unsupported object type ${toStringValue} at key path '${keypath.join(
+            '.'
+          )}'`
+        )
+      }
+
+      const result: Record<string, unknown> = {}
+      for (const [key, value] of Object.entries(data)) {
+        result[key] = serialize(value, [...keypath, key])
+      }
+      return { __dataType__: 'Object', value: result }
+    }
+
+    default:
+      throw new Error(
+        `cannot serialize ${typeof data} in message at key path '${keypath.join(
+          '.'
+        )}'`
+      )
+  }
+}
+
+export function deserialize(
+  data: SerializedMessage,
+  keypath: readonly string[] = []
+): unknown {
+  switch (typeof data) {
+    case 'string':
+    case 'number':
+    case 'boolean':
+      return data
+
+    case 'object': {
+      if (data === null) {
+        return data
+      }
+
+      if (!('__dataType__' in data)) {
+        throw new TypeError(
+          `unknown data type at key path ${keypath.join('.')}`
+        )
+      }
+
+      switch (data.__dataType__) {
+        case 'Array':
+          return data.value.map((element, i) =>
+            deserialize(element as SerializedMessage, [
+              ...keypath,
+              i.toString(),
+            ])
+          )
+
+        case 'Object': {
+          const result: Record<string, unknown> = {}
+          for (const [key, value] of Object.entries(data.value)) {
+            result[key] = deserialize(value as SerializedMessage, [
+              ...keypath,
+              key,
+            ])
+          }
+          return result
+        }
+
+        case 'Buffer':
+          return Buffer.from(data.value)
+
+        case 'Uint8Array':
+          return Uint8Array.from(data.value)
+
+        case 'undefined':
+          return undefined
+
+        default:
+          throw new Error(
+            `unknown serialized data type at key path ${keypath.join('.')}`
+          )
+      }
+    }
+
+    default:
+      throw new Error(
+        `cannot deserialize ${typeof data} in message at key path '${keypath.join(
+          '.'
+        )}'`
+      )
+  }
+}

--- a/apps/module-scan/src/workers/worker-thread-worker.js
+++ b/apps/module-scan/src/workers/worker-thread-worker.js
@@ -1,10 +1,11 @@
 // @ts-check
 /* eslint-disable @typescript-eslint/no-var-requires */
 
+require('ts-node').register({ transpileOnly: true })
+
 const { resolve } = require('path')
 const { parentPort, workerData } = require('worker_threads')
-
-require('ts-node').register({ transpileOnly: true })
+const json = require('./json-serialization')
 
 if (typeof workerData.__workerPath !== 'string') {
   throw new Error('missing worker path')
@@ -18,10 +19,10 @@ pp &&
     let output
 
     try {
-      output = await call(input)
+      output = await call(json.deserialize(input))
     } catch (error) {
       output = { type: 'error', error: `${error.stack}` }
     }
 
-    pp.postMessage({ output })
+    pp.postMessage({ output: json.serialize(output) })
   })


### PR DESCRIPTION
This adds some special handling for `Buffer` and `Uint8Array` to ensure they can be sent across the worker boundary.

I plan to add a QR code reader worker which will need to be able to respond with a `Buffer`.

Refs #157