### PR TITLE
refactor(module-scan): simplify interpreter types

### DIFF
--- a/apps/module-scan/src/interpreter.test.ts
+++ b/apps/module-scan/src/interpreter.test.ts
@@ -9,7 +9,7 @@ import choctaw2020Election from '../test/fixtures/2020-choctaw/election'
 import * as choctaw2020SpecialFixtures from '../test/fixtures/choctaw-2020-09-22-f30480cc99'
 import * as general2020Fixtures from '../test/fixtures/2020-general'
 import stateOfHamiltonElection from '../test/fixtures/state-of-hamilton/election'
-import SummaryBallotInterpreter, {
+import Interpreter, {
   getBallotImageData,
   InterpretedHmpbPage,
   InterpretedBmdPage,
@@ -50,7 +50,7 @@ test('extracts votes encoded in a QR code', async () => {
   )
   expect(
     (
-      await new SummaryBallotInterpreter(
+      await new Interpreter(
         {
           ...electionSample,
           markThresholds: { definite: 0.2, marginal: 0.17 },
@@ -93,7 +93,7 @@ test('properly detects test ballot in live mode', async () => {
     sampleBallotImagesPath,
     'sample-batch-1-ballot-1.png'
   )
-  const interpretationResult = await new SummaryBallotInterpreter(
+  const interpretationResult = await new Interpreter(
     {
       ...electionSample,
       markThresholds: { definite: 0.2, marginal: 0.17 },
@@ -176,10 +176,7 @@ test('can read metadata in QR code with skewed / dirty ballot', async () => {
 })
 
 test('interprets marks on a HMPB', async () => {
-  const interpreter = new SummaryBallotInterpreter(
-    stateOfHamiltonElection,
-    false
-  )
+  const interpreter = new Interpreter(stateOfHamiltonElection, false)
 
   for await (const { page, pageNumber } of pdfToImages(
     await readFile(join(stateOfHamiltonFixturesRoot, 'ballot.pdf')),
@@ -231,10 +228,7 @@ test('interprets marks on a HMPB', async () => {
 })
 
 test('interprets marks on an upside-down HMPB', async () => {
-  const interpreter = new SummaryBallotInterpreter(
-    stateOfHamiltonElection,
-    false
-  )
+  const interpreter = new Interpreter(stateOfHamiltonElection, false)
 
   for await (const { page, pageNumber } of pdfToImages(
     await readFile(join(stateOfHamiltonFixturesRoot, 'ballot.pdf')),
@@ -1773,7 +1767,7 @@ test('interprets marks in PNG ballots', async () => {
     markThresholds: { definite: 0.2, marginal: 0.12 },
     ...choctaw2020Election,
   }
-  const interpreter = new SummaryBallotInterpreter(election, false)
+  const interpreter = new Interpreter(election, false)
 
   for await (const { page } of pdfToImages(
     await readFile(join(choctaw2020FixturesRoot, 'ballot.pdf')),
@@ -2960,10 +2954,7 @@ test('interprets marks in PNG ballots', async () => {
 })
 
 test('returns metadata if the QR code is readable but the HMPB ballot is not', async () => {
-  const interpreter = new SummaryBallotInterpreter(
-    stateOfHamiltonElection,
-    false
-  )
+  const interpreter = new Interpreter(stateOfHamiltonElection, false)
 
   for await (const { page, pageNumber } of pdfToImages(
     await readFile(join(stateOfHamiltonFixturesRoot, 'ballot.pdf')),
@@ -3009,7 +3000,7 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
 test('scans images where quirc and jsqr cannot find the QR code by providing QR code reading for hmpb-interpreter', async () => {
   const fixtures = choctaw2020SpecialFixtures
   const { election } = fixtures
-  const interpreter = new SummaryBallotInterpreter(election, false)
+  const interpreter = new Interpreter(election, false)
 
   for await (const { page } of pdfToImages(
     await readFile(fixtures.ballot6522Pdf),

--- a/apps/module-scan/src/interpreter.ts
+++ b/apps/module-scan/src/interpreter.ts
@@ -96,17 +96,6 @@ export interface UnreadablePage {
   reason?: string
 }
 
-export interface Interpreter {
-  addHmpbTemplate(
-    imageData: ImageData,
-    metadata?: BallotPageMetadata
-  ): Promise<BallotPageLayout>
-  addHmpbTemplate(layout: BallotPageLayout): Promise<BallotPageLayout>
-  interpretFile(
-    interpretFileParams: InterpretFileParams
-  ): Promise<InterpretFileResult>
-}
-
 interface BallotImageData {
   file: Buffer
   image: ImageData
@@ -205,7 +194,7 @@ export function sheetRequiresAdjudication([
   return frontIsBlankHmpbPage && backIsBlankHmpbPage
 }
 
-export default class SummaryBallotInterpreter implements Interpreter {
+export default class Interpreter {
   private hmpbInterpreter?: HMPBInterpreter
   private election: Election
   private testMode: boolean

--- a/apps/module-scan/src/workers/interpret.ts
+++ b/apps/module-scan/src/workers/interpret.ts
@@ -3,7 +3,7 @@ import makeDebug from 'debug'
 import { readFile } from 'fs-extra'
 import { basename, extname, join } from 'path'
 import { saveImages } from '../importer'
-import SummaryBallotInterpreter, { PageInterpretation } from '../interpreter'
+import Interpreter, { PageInterpretation } from '../interpreter'
 import Store from '../store'
 import pdfToImages from '../util/pdfToImages'
 
@@ -26,7 +26,7 @@ export interface InterpretOutput {
 
 export type Output = InterpretOutput | void
 
-export let interpreter: SummaryBallotInterpreter | undefined
+export let interpreter: Interpreter | undefined
 
 async function getElection(store: Store): Promise<Election | undefined> {
   const electionDefinition = await store.getElectionDefinition()
@@ -51,10 +51,7 @@ export async function configure(store: Store): Promise<void> {
   const templates = await store.getHmpbTemplates()
 
   debug('creating a new interpreter')
-  interpreter = new SummaryBallotInterpreter(
-    election,
-    await store.getTestMode()
-  )
+  interpreter = new Interpreter(election, await store.getTestMode())
 
   debug('hand-marked paper ballot templates: %d', templates.length)
   for (const [pdf, layouts] of templates) {


### PR DESCRIPTION
The class was named `SummaryBallotInterpreter`, and this made sense when it only interpreted summary ballots. I added the ability to interpret HMPB sheets before I understood what a "summary ballot" was.

This commit just renames it to `Interpreter`, which is also the name of the interface that it previously implemented. The interface didn't really do any good, so I just removed it.