### PR TITLE
refactor(module-scan): import worker path

### DIFF
--- a/apps/module-scan/src/cli/retry-scan/index.ts
+++ b/apps/module-scan/src/cli/retry-scan/index.ts
@@ -4,7 +4,7 @@ import { isAbsolute, join, resolve } from 'path'
 import { dirSync } from 'tmp'
 import { PageInterpretation } from '../../interpreter'
 import { createWorkspace } from '../../util/workspace'
-import { Input, Output } from '../../workers/interpret'
+import { Input, Output, workerPath } from '../../workers/interpret'
 import { childProcessPool } from '../../workers/pool'
 import { Options } from './options'
 
@@ -118,10 +118,7 @@ export async function retryScan(
   listeners?.sheetsLoaded?.(sheets.length, electionDefinition?.election)
 
   listeners?.interpreterLoading?.()
-  const pool = childProcessPool<Input, Output>(
-    join(__dirname, '../../workers/interpret.ts'),
-    cpus().length - 1
-  )
+  const pool = childProcessPool<Input, Output>(workerPath, cpus().length - 1)
   pool.start()
 
   await pool.callAll({ action: 'configure', dbPath: input.store.dbPath })

--- a/apps/module-scan/src/server.ts
+++ b/apps/module-scan/src/server.ts
@@ -17,7 +17,7 @@ import Store, { ALLOWED_CONFIG_KEYS, ConfigKey } from './store'
 import { BallotConfig, ElectionDefinition } from './types'
 import { fromElection, validate } from './util/electionDefinition'
 import { createWorkspace, Workspace } from './util/workspace'
-import { Input, Output } from './workers/interpret'
+import { Input, Output, workerPath } from './workers/interpret'
 import { childProcessPool, WorkerPool } from './workers/pool'
 
 export interface AppOptions {
@@ -532,10 +532,7 @@ export async function start({
       workspace,
       scanner,
       interpreterWorkerPoolProvider: (): WorkerPool<Input, Output> =>
-        childProcessPool(
-          path.join(__dirname, 'workers/interpret.ts'),
-          2 /* front and back */
-        ),
+        childProcessPool(workerPath, 2 /* front and back */),
     })
   app = app ?? buildApp({ importer, store: workspace.store })
 

--- a/apps/module-scan/src/workers/echo.ts
+++ b/apps/module-scan/src/workers/echo.ts
@@ -1,5 +1,7 @@
 /* istanbul ignore file - this file is a demo, and used only in tests */
 
+export const workerPath = __filename
+
 export type Input = unknown
 export type Output = unknown
 

--- a/apps/module-scan/src/workers/interpret.ts
+++ b/apps/module-scan/src/workers/interpret.ts
@@ -9,6 +9,8 @@ import pdfToImages from '../util/pdfToImages'
 
 const debug = makeDebug('module-scan:worker:interpret')
 
+export const workerPath = __filename
+
 export type Input =
   | { action: 'configure'; dbPath: string }
   | {

--- a/apps/module-scan/src/workers/pool.test.ts
+++ b/apps/module-scan/src/workers/pool.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events'
-import { join } from 'path'
 import { makeMockWorkerOps } from '../../test/util/mocks'
+import { workerPath } from './echo'
 import { childProcessPool, WorkerPool, workerThreadPool } from './pool'
 
 test('starts new workers when starting the pool', () => {
@@ -223,7 +223,7 @@ test('releasing a non-owned worker is not allowed', async () => {
 })
 
 test('child process workers work', async () => {
-  const pool = childProcessPool<string, string>(join(__dirname, 'echo.ts'), 1)
+  const pool = childProcessPool<string, string>(workerPath, 1)
   pool.start()
   try {
     expect(await pool.call('hello child process')).toEqual(
@@ -235,7 +235,7 @@ test('child process workers work', async () => {
 })
 
 test('worker thread workers work', async () => {
-  const pool = workerThreadPool<string, string>(join(__dirname, 'echo.ts'), 1)
+  const pool = workerThreadPool<string, string>(workerPath, 1)
   pool.start()
   try {
     expect(await pool.call('hello worker thread')).toEqual(


### PR DESCRIPTION
This ensures that automated refactors, like moving a worker file, automatically update the path. Also, when we eventually stop running with ts-node in production the worker path will point to a built `.js` as expected.