### PR TITLE
build(module-scan): reference depended-on projects

### DIFF
--- a/apps/module-scan/package.json
+++ b/apps/module-scan/package.json
@@ -6,7 +6,7 @@
     "build": "tsc --build",
     "format": "prettier '**/*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
     "lint": "tsc --build && eslint '*/**/*.{js,jsx,ts,tsx}' --quiet",
-    "start": "ts-node --files ./src/index.ts",
+    "start": "ts-node --transpile-only --files ./src/index.ts",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "test:debug": "node --inspect-brk $(which jest) --runInBand --no-cache",

--- a/apps/module-scan/package.json
+++ b/apps/module-scan/package.json
@@ -3,19 +3,19 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --build",
     "format": "prettier '**/*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
-    "lint": "tsc --noEmit && eslint '*/**/*.{js,jsx,ts,tsx}' --quiet",
+    "lint": "tsc --build && eslint '*/**/*.{js,jsx,ts,tsx}' --quiet",
     "start": "ts-node --files ./src/index.ts",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "test:debug": "node --inspect-brk $(which jest) --runInBand --no-cache",
     "test:watch": "jest --watch",
-    "watch": "tsc -w"
+    "watch": "tsc --build --watch"
   },
   "husky": {
     "hooks": {
-      "pre-commit": "tsc && lint-staged"
+      "pre-commit": "tsc --build && lint-staged"
     }
   },
   "lint-staged": {

--- a/apps/module-scan/tsconfig.json
+++ b/apps/module-scan/tsconfig.json
@@ -16,5 +16,9 @@
     "strict": true,
     "target": "es2017"
   },
-  "include": ["src", "types", "test"]
+  "include": ["src", "types", "test"],
+  "references": [
+    { "path": "../../libs/ballot-encoder" },
+    { "path": "../../libs/hmpb-interpreter" }
+  ]
 }


### PR DESCRIPTION
Without this, `tsc --build` does not build dependencies.