### PR TITLE
build(module-scan): prepare for production

### DIFF
--- a/apps/module-scan/.eslintrc.js
+++ b/apps/module-scan/.eslintrc.js
@@ -32,7 +32,7 @@ module.exports = {
       jsx: true,
     },
     ecmaVersion: 2018,
-    project: ['./tsconfig.json', './public/tsconfig.json'],
+    project: ['./tsconfig.test.json'],
     sourceType: 'module',
   },
   plugins: ['@typescript-eslint', 'jest', 'no-array-sort-mutation'],

--- a/apps/module-scan/.gitignore
+++ b/apps/module-scan/.gitignore
@@ -8,3 +8,4 @@ coverage/
 .DS_Store
 debug-dump*.zip
 /*.png
+/lib

--- a/apps/module-scan/Makefile
+++ b/apps/module-scan/Makefile
@@ -1,3 +1,4 @@
+NODE_ENV ?= development
 PLATFORM := $(shell uname)
 TIMESTAMP := $(shell date --iso-8601=seconds --utc | sed 's/+.*$\//g' | tr ':' '-')
 
@@ -5,16 +6,10 @@ TIMESTAMP := $(shell date --iso-8601=seconds --utc | sed 's/+.*$\//g' | tr ':' '
 FORCE:
 
 install:
-ifeq ($(PLATFORM),Darwin)
-	brew install libjpeg libpng
-else ifeq ($(PLATFORM),Linux)
 	sudo apt install -y build-essential libx11-dev libjpeg-dev libpng-dev
-else
-	@echo "I don't know how to install libjpeg and libpng on your platform: $(PLATFORM)"
-endif
 
 build: FORCE
-	pnpm install
+	pnpm install && pnpm build
 
 run:
 	pnpm start

--- a/apps/module-scan/README.md
+++ b/apps/module-scan/README.md
@@ -29,7 +29,10 @@ pnpm test
 
 ```sh
 # use a real scanner
-pnpm start
+pnpm dev
+
+# build & run for production
+pnpm build && pnpm start
 ```
 
 ## Mock Scanning
@@ -38,13 +41,13 @@ You can also scan directly from image files instead of using a real scanner:
 
 ```sh
 # single batch with single sheet
-MOCK_SCANNER_FILES=front.png,back.png pnpm start
+MOCK_SCANNER_FILES=front.png,back.png pnpm dev
 
 # single batch with multiple sheets
-MOCK_SCANNER_FILES=front-01.png,back-01.png,front-02.png,back-02.png pnpm start
+MOCK_SCANNER_FILES=front-01.png,back-01.png,front-02.png,back-02.png pnpm dev
 
 # multiple batches with one sheet each (note ",," batch separator)
-MOCK_SCANNER_FILES=front-01.png,back-01.png,,front-02.png,back-02.png pnpm start
+MOCK_SCANNER_FILES=front-01.png,back-01.png,,front-02.png,back-02.png pnpm dev
 
 # use a manifest file
 cat <<EOS > manifest
@@ -56,11 +59,11 @@ back-01.png
 front-02.png
 back-02.png
 EOS
-MOCK_SCANNER_FILES=@manifest pnpm start
+MOCK_SCANNER_FILES=@manifest pnpm dev
 
 # scanning from an election backup file
 ./bin/extract-backup /path/to/election-backup.zip
-MOCK_SCANNER_FILES=@/path/to/election-backup/manifest pnpm start
+MOCK_SCANNER_FILES=@/path/to/election-backup/manifest pnpm dev
 ```
 
 ## Switching Workspaces
@@ -70,7 +73,7 @@ in the root of the folder when running this service. To choose another location,
 set `MODULE_SCAN_WORKSPACE` to the path to another folder:
 
 ```sh
-$ MODULE_SCAN_WORKSPACE=/path/to/workspace pnpm start
+$ MODULE_SCAN_WORKSPACE=/path/to/workspace pnpm dev
 ```
 
 ## API Documentation

--- a/apps/module-scan/package.json
+++ b/apps/module-scan/package.json
@@ -5,8 +5,9 @@
   "scripts": {
     "build": "tsc --build",
     "format": "prettier '**/*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
-    "lint": "tsc --build && eslint '*/**/*.{js,jsx,ts,tsx}' --quiet",
-    "start": "ts-node --transpile-only --files ./src/index.ts",
+    "lint": "tsc --build && eslint '{src,test}/**/*.{js,jsx,ts,tsx}' --quiet",
+    "dev": "ts-node --transpile-only --files ./src/index.ts",
+    "start": "node ./lib/index.js",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "test:debug": "node --inspect-brk $(which jest) --runInBand --no-cache",

--- a/apps/module-scan/src/workers/child-process-worker.js
+++ b/apps/module-scan/src/workers/child-process-worker.js
@@ -1,7 +1,9 @@
 // @ts-check
 /* eslint-disable @typescript-eslint/no-var-requires */
 
-require('ts-node').register({ transpileOnly: true })
+if (process.env.NODE_ENV !== 'production') {
+  require('ts-node').register({ transpileOnly: true })
+}
 
 const { resolve } = require('path')
 const json = require('./json-serialization')

--- a/apps/module-scan/src/workers/worker-thread-worker.js
+++ b/apps/module-scan/src/workers/worker-thread-worker.js
@@ -1,7 +1,9 @@
 // @ts-check
 /* eslint-disable @typescript-eslint/no-var-requires */
 
-require('ts-node').register({ transpileOnly: true })
+if (process.env.NODE_ENV !== 'production') {
+  require('ts-node').register({ transpileOnly: true })
+}
 
 const { resolve } = require('path')
 const { parentPort, workerData } = require('worker_threads')

--- a/apps/module-scan/tsconfig.json
+++ b/apps/module-scan/tsconfig.json
@@ -8,15 +8,16 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "module": "commonjs",
     "moduleResolution": "node",
-    "noEmit": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "outDir": "lib",
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
     "target": "es2017"
   },
-  "include": ["src", "types", "test"],
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "test"],
   "references": [
     { "path": "../../libs/ballot-encoder" },
     { "path": "../../libs/hmpb-interpreter" }

--- a/apps/module-scan/tsconfig.test.json
+++ b/apps/module-scan/tsconfig.test.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src", "test"],
+  "exclude": []
+}


### PR DESCRIPTION
Separate running in dev and running in prod. Modifies our TS config to emit files to `lib`, and `make run` now runs the built version of the app.