### PR TITLE
Fix undervote counting for contests with more then 1 seat

### DIFF
--- a/apps/election-manager/src/lib/votecounting.test.ts
+++ b/apps/election-manager/src/lib/votecounting.test.ts
@@ -477,6 +477,73 @@ describe('filterTalliesByParams in a primary election', () => {
   })
 })
 
+test('undervotes counted in n of m contest properly', () => {
+  // Create mock CVR data
+  const mockCVR: CastVoteRecord = {
+    _ballotId: 'abc',
+    _ballotStyleId: '12D',
+    _ballotType: 'standard',
+    _precinctId: '21',
+    _testBallot: false,
+    _scannerId: '1',
+    'county-commissioners': [],
+  }
+
+  // tabulate it
+  let electionTally = computeFullElectionTally(primaryElectionSample, [
+    [mockCVR],
+  ])!
+
+  // The county commissioners race has 4 seats. Each vote less then 4 should be counted
+  // as an additional undervote.
+  expect(
+    electionTally.overallTally.contestTallyMetadata['county-commissioners']
+      ?.undervotes
+  ).toBe(4)
+
+  electionTally = computeFullElectionTally(primaryElectionSample, [
+    [{ ...mockCVR, 'county-commissioners': ['argent'] }],
+  ])!
+  expect(
+    electionTally.overallTally.contestTallyMetadata['county-commissioners']
+      ?.undervotes
+  ).toBe(3)
+
+  electionTally = computeFullElectionTally(primaryElectionSample, [
+    [{ ...mockCVR, 'county-commissioners': ['argent', 'bainbridge'] }],
+  ])!
+  expect(
+    electionTally.overallTally.contestTallyMetadata['county-commissioners']
+      ?.undervotes
+  ).toBe(2)
+
+  electionTally = computeFullElectionTally(primaryElectionSample, [
+    [
+      {
+        ...mockCVR,
+        'county-commissioners': ['argent', 'bainbridge', 'hennessey'],
+      },
+    ],
+  ])!
+  expect(
+    electionTally.overallTally.contestTallyMetadata['county-commissioners']
+      ?.undervotes
+  ).toBe(1)
+
+  electionTally = computeFullElectionTally(primaryElectionSample, [
+    [
+      {
+        ...mockCVR,
+        'county-commissioners': ['argent', 'bainbridge', 'hennessey', 'savoy'],
+      },
+    ],
+  ])!
+  expect(
+    electionTally.overallTally.contestTallyMetadata['county-commissioners']
+      ?.undervotes
+  ).toBe(0)
+})
+
 test('overvote report', async () => {
   // get the election
   const election = parseElection(


### PR DESCRIPTION
Branch is based off of: https://github.com/votingworks/vxsuite/pull/209
Could be separated off but its touching related code so I thought it was simplest to just have it dependent on that change. 

According to VVSG for N of M contests the number of undervotes is the number of votes less than the number of seats in the contest, not just 1 for any ballot with less than the number of seats. See section 2.4.3 requirement c: https://www.eac.gov/sites/default/files/eac_assets/1/28/VVSG.1.1.VOL.1.FINAL1.pdf 

```
c. For all systems, there shall be a complete accounting of undervotes for N of M
contests as well as races involving only one voting choice. In a “vote for N”
contest, where L votes are recorded and L<N, the undervotes = N−L. In a “vote
for 3” contest, votes would be recorded as follows:
• A vote for no candidates = 3 undervotes.
• A vote for 1 candidate = 2 undervotes.
• A vote for 2 candidates = 1 undervote. 
```

The existing snapshot tests for tabulation uses electionSample.json which only has 1 seat contests so no results changed there.