### PR TITLE
Add view all precinct tally report button

### DIFF
--- a/apps/election-manager/src/App.test.tsx
+++ b/apps/election-manager/src/App.test.tsx
@@ -199,8 +199,8 @@ it('tabulating CVRs', async () => {
     EITHER_NEITHER_CVRS,
     eitherNeitherElection
   )
-  await storage.set(cvrsStorageKey, castVoteRecordFiles.export())
 
+  await storage.set(cvrsStorageKey, castVoteRecordFiles.export())
   const { getByText, getAllByText, getByTestId } = render(
     <App storage={storage} />
   )
@@ -208,19 +208,47 @@ it('tabulating CVRs', async () => {
   await screen.findByText('0 official ballots')
 
   fireEvent.click(getByText('Tally'))
+
   await waitFor(() =>
     expect(getByTestId('total-ballot-count').textContent).toEqual('100')
   )
 
+  getByText('View Unofficial Full Election Tally Report')
   fireEvent.click(getByText('Mark Tally Results as Official…'))
   getByText('Mark Unofficial Tally Results as Official Tally Results?')
   fireEvent.click(getByText('Mark Tally Results as Official'))
 
-  fireEvent.click(getByText('View Official Full Election Tally'))
+  fireEvent.click(getByText('View Official Full Election Tally Report'))
 
   expect(
     getAllByText('Official Mock General Election Choctaw 2020 Tally Report')
       .length > 0
   ).toBe(true)
+  expect(getByTestId('tally-report-contents')).toMatchSnapshot()
+
+  fireEvent.click(getByText('Tally'))
+
+  await waitFor(() => {
+    fireEvent.click(getByText('View Official Tally Reports for All Precincts'))
+  })
+
+  getByText(
+    'Official Mock General Election Choctaw 2020 Tally Reports for All Precincts'
+  )
+  // Test that each precinct has a tally report generated
+  eitherNeitherElection.precincts.forEach((p) => {
+    getByText(`Official Precinct Tally Report for: ${p.name}`)
+  })
+
+  fireEvent.click(getByText('Tally'))
+  fireEvent.click(getByText('Remove CVR Files…'))
+  fireEvent.click(getByText('Remove All CVR Files'))
+  await waitFor(() =>
+    expect(getByTestId('total-ballot-count').textContent).toEqual('0')
+  )
+
+  // When there are no CVRs imported the full tally report is labeled as the zero report
+  fireEvent.click(getByText('View Unofficial Full Election Tally Report'))
+  // Verify the zero report generates properly
   expect(getByTestId('tally-report-contents')).toMatchSnapshot()
 })

--- a/apps/election-manager/src/__snapshots__/App.test.tsx.snap
+++ b/apps/election-manager/src/__snapshots__/App.test.tsx.snap
@@ -1997,3 +1997,856 @@ exports[`tabulating CVRs 1`] = `
   </div>
 </div>
 `;
+
+exports[`tabulating CVRs 2`] = `
+<div
+  data-testid="tally-report-contents"
+>
+  <div
+    class="sc-bYEvPH dTbFV"
+  >
+    <div
+      class="sc-crrsfI jJkczz"
+    >
+      <div
+        class="sc-ezrdKe bNwPyO ignore-prose"
+      >
+        <span
+          class="sc-dQppl kMSBOR"
+        >
+          0 ballots
+           cast /
+           
+          0 overvotes
+           /
+           
+          0 undervotes
+        </span>
+      </div>
+      <h3>
+        United States
+        , 
+        President
+      </h3>
+      <table
+        class="sc-fodVxV dpEkZU"
+      >
+        <tbody>
+          <tr>
+            <td>
+              Presidential Electors for Joe Biden for President and Kamala Harris for Vice President
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Presidential Electors for Donald J. Trump for President and Michael R. Pence for Vice President
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Presidential Electors for Phil Collins for President and Bill Parker for Vice President
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Write-In
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div
+    class="sc-bYEvPH dTbFV"
+  >
+    <div
+      class="sc-crrsfI jJkczz"
+    >
+      <div
+        class="sc-ezrdKe bNwPyO ignore-prose"
+      >
+        <span
+          class="sc-dQppl kMSBOR"
+        >
+          0 ballots
+           cast /
+           
+          0 overvotes
+           /
+           
+          0 undervotes
+        </span>
+      </div>
+      <h3>
+        United States
+        , 
+        Senate 
+      </h3>
+      <table
+        class="sc-fodVxV dpEkZU"
+      >
+        <tbody>
+          <tr>
+            <td>
+              Mike Espy
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Cindy Hyde-Smith
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Jimmy Edwards
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Write-In
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div
+    class="sc-bYEvPH dTbFV"
+  >
+    <div
+      class="sc-crrsfI jJkczz"
+    >
+      <div
+        class="sc-ezrdKe bNwPyO ignore-prose"
+      >
+        <span
+          class="sc-dQppl kMSBOR"
+        >
+          0 ballots
+           cast /
+           
+          0 overvotes
+           /
+           
+          0 undervotes
+        </span>
+      </div>
+      <h3>
+        US House Of Representatives
+        , 
+        1st Congressional District
+      </h3>
+      <table
+        class="sc-fodVxV dpEkZU"
+      >
+        <tbody>
+          <tr>
+            <td>
+              Antonia Eliason
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Trent Kelly
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Write-In
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div
+    class="sc-bYEvPH dTbFV"
+  >
+    <div
+      class="sc-crrsfI jJkczz"
+    >
+      <div
+        class="sc-ezrdKe bNwPyO ignore-prose"
+      >
+        <span
+          class="sc-dQppl kMSBOR"
+        >
+          0 ballots
+           cast /
+           
+          0 overvotes
+           /
+           
+          0 undervotes
+        </span>
+      </div>
+      <h3>
+        Northern District
+        , 
+        Supreme Court District 3(Northern) Position 3
+      </h3>
+      <table
+        class="sc-fodVxV dpEkZU"
+      >
+        <tbody>
+          <tr>
+            <td>
+              Josiah Dennis Coleman
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Percy L. Lynchard
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Write-In
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div
+    class="sc-bYEvPH dTbFV"
+  >
+    <div
+      class="sc-crrsfI jJkczz"
+    >
+      <div
+        class="sc-ezrdKe bNwPyO ignore-prose"
+      >
+        <span
+          class="sc-dQppl kMSBOR"
+        >
+          0 ballots
+           cast /
+           
+          0 overvotes
+           /
+           
+          0 undervotes
+        </span>
+      </div>
+      <h3>
+        Election Commissioner 01
+        , 
+        Election Commissioner  01
+      </h3>
+      <table
+        class="sc-fodVxV dpEkZU"
+      >
+        <tbody>
+          <tr>
+            <td>
+              Glynda Chaney Fulce
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Write-In
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div
+    class="sc-bYEvPH dTbFV"
+  >
+    <div
+      class="sc-crrsfI jJkczz"
+    >
+      <div
+        class="sc-ezrdKe bNwPyO ignore-prose"
+      >
+        <span
+          class="sc-dQppl kMSBOR"
+        >
+          0 ballots
+           cast /
+           
+          0 overvotes
+           /
+           
+          0 undervotes
+        </span>
+      </div>
+      <h3>
+        Election Commissioner 02
+        , 
+        Election Commissioner 02
+      </h3>
+      <table
+        class="sc-fodVxV dpEkZU"
+      >
+        <tbody>
+          <tr>
+            <td>
+              Charles Beck
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Sharon Brooks
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Write-In
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div
+    class="sc-bYEvPH dTbFV"
+  >
+    <div
+      class="sc-crrsfI jJkczz"
+    >
+      <div
+        class="sc-ezrdKe bNwPyO ignore-prose"
+      >
+        <span
+          class="sc-dQppl kMSBOR"
+        >
+          0 ballots
+           cast /
+           
+          0 overvotes
+           /
+           
+          0 undervotes
+        </span>
+      </div>
+      <h3>
+        Election Commissioner 03
+        , 
+        Election Commissioner 03
+      </h3>
+      <table
+        class="sc-fodVxV dpEkZU"
+      >
+        <tbody>
+          <tr>
+            <td>
+              Dorothy Anderson
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Write-In
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div
+    class="sc-bYEvPH dTbFV"
+  >
+    <div
+      class="sc-crrsfI jJkczz"
+    >
+      <div
+        class="sc-ezrdKe bNwPyO ignore-prose"
+      >
+        <span
+          class="sc-dQppl kMSBOR"
+        >
+          0 ballots
+           cast /
+           
+          0 overvotes
+           /
+           
+          0 undervotes
+        </span>
+      </div>
+      <h3>
+        Election Commissioner 04
+        , 
+        Election Commissioner 04
+      </h3>
+      <table
+        class="sc-fodVxV dpEkZU"
+      >
+        <tbody>
+          <tr>
+            <td>
+              Willie Mae Guillory
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Lewis Wright
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Write-In
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div
+    class="sc-bYEvPH dTbFV"
+  >
+    <div
+      class="sc-crrsfI jJkczz"
+    >
+      <div
+        class="sc-ezrdKe bNwPyO ignore-prose"
+      >
+        <span
+          class="sc-dQppl kMSBOR"
+        >
+          0 ballots
+           cast /
+           
+          0 overvotes
+           /
+           
+          0 undervotes
+        </span>
+      </div>
+      <h3>
+        Election Commissioner 05
+        , 
+        Election Commissioner 05
+      </h3>
+      <table
+        class="sc-fodVxV dpEkZU"
+      >
+        <tbody>
+          <tr>
+            <td>
+              Ouida A Loper
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Wayne McLeod
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Write-In
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div
+    class="sc-bYEvPH dTbFV"
+  >
+    <div
+      class="sc-crrsfI jJkczz"
+    >
+      <div
+        class="sc-ezrdKe bNwPyO ignore-prose"
+      >
+        <span
+          class="sc-dQppl kMSBOR"
+        >
+          0 ballots
+           cast /
+           
+          0 overvotes
+           /
+           
+          0 undervotes
+        </span>
+      </div>
+      <h3>
+        School Board District 5
+        , 
+        School Board 05
+      </h3>
+      <table
+        class="sc-fodVxV dpEkZU"
+      >
+        <tbody>
+          <tr>
+            <td>
+              Michael D Thomas
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Write-In
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div
+    class="sc-bYEvPH dTbFV"
+  >
+    <div
+      class="sc-crrsfI jJkczz"
+    >
+      <div
+        class="sc-ezrdKe bNwPyO ignore-prose"
+      >
+        <span
+          class="sc-dQppl kMSBOR"
+        >
+          0 ballots
+           cast /
+           
+          0 overvotes
+           /
+           
+          0 undervotes
+        </span>
+      </div>
+      <h3>
+        State Of Mississippi
+        , 
+        Ballot Measure 1 – Either/Neither
+      </h3>
+      <table
+        class="sc-fodVxV dpEkZU"
+      >
+        <tbody>
+          <tr>
+            <td>
+              FOR APPROVAL OF EITHER Initiative No. 65 OR Alternative Measure No. 65 A
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+          <tr>
+            <td>
+              AGAINST BOTH Initiative Measure No. 65 AND Alternative Measure No. 65 A
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div
+    class="sc-bYEvPH dTbFV"
+  >
+    <div
+      class="sc-crrsfI jJkczz"
+    >
+      <div
+        class="sc-ezrdKe bNwPyO ignore-prose"
+      >
+        <span
+          class="sc-dQppl kMSBOR"
+        >
+          0 ballots
+           cast /
+           
+          0 overvotes
+           /
+           
+          0 undervotes
+        </span>
+      </div>
+      <h3>
+        State Of Mississippi
+        , 
+        Ballot Measure 1 – Pick One
+      </h3>
+      <table
+        class="sc-fodVxV dpEkZU"
+      >
+        <tbody>
+          <tr>
+            <td>
+              FOR Initiative Measure No. 65
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+          <tr>
+            <td>
+              FOR Alternative Measure 65 A
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div
+    class="sc-bYEvPH dTbFV"
+  >
+    <div
+      class="sc-crrsfI jJkczz"
+    >
+      <div
+        class="sc-ezrdKe bNwPyO ignore-prose"
+      >
+        <span
+          class="sc-dQppl kMSBOR"
+        >
+          0 ballots
+           cast /
+           
+          0 overvotes
+           /
+           
+          0 undervotes
+        </span>
+      </div>
+      <h3>
+        State Of Mississippi
+        , 
+        Ballot Measure 2: House Concurrent Resolution No. 47
+      </h3>
+      <table
+        class="sc-fodVxV dpEkZU"
+      >
+        <tbody>
+          <tr>
+            <td>
+              YES
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+          <tr>
+            <td>
+              NO
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div
+    class="sc-bYEvPH dTbFV"
+  >
+    <div
+      class="sc-crrsfI jJkczz"
+    >
+      <div
+        class="sc-ezrdKe bNwPyO ignore-prose"
+      >
+        <span
+          class="sc-dQppl kMSBOR"
+        >
+          0 ballots
+           cast /
+           
+          0 overvotes
+           /
+           
+          0 undervotes
+        </span>
+      </div>
+      <h3>
+        State Of Mississippi
+        , 
+        Ballot Measure 3: House Bill 1796 - Flag Referendum
+      </h3>
+      <table
+        class="sc-fodVxV dpEkZU"
+      >
+        <tbody>
+          <tr>
+            <td>
+              YES
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+          <tr>
+            <td>
+              NO
+            </td>
+            <td
+              class="sc-fFubgz jVzFBN"
+            >
+              0
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+`;

--- a/apps/election-manager/src/lib/votecounting.test.ts
+++ b/apps/election-manager/src/lib/votecounting.test.ts
@@ -16,7 +16,11 @@ import {
   getOvervotePairTallies,
   filterTalliesByParams,
 } from './votecounting'
-import { CastVoteRecord, FullElectionTally } from '../config/types'
+import {
+  CastVoteRecord,
+  FullElectionTally,
+  TallyCategory,
+} from '../config/types'
 
 const fixturesPath = path.join(__dirname, '../../test/fixtures')
 const electionFilePath = path.join(fixturesPath, 'election.json')
@@ -93,6 +97,28 @@ test('tabulating a set of CVRs gives expected output', async () => {
   )
 
   expect(numWriteIns).toBe(260)
+})
+
+test('computeFullTally with no results should produce empty tally objects with contests', async () => {
+  const election = parseElection(
+    JSON.parse((await fs.readFile(electionFilePath)).toString('utf-8'))
+  )
+
+  const fullTally = computeFullElectionTally(election, [])
+  expect(fullTally.overallTally.numberOfBallotsCounted).toBe(0)
+  expect(fullTally.overallTally.contestTallies.length).toBe(
+    election.contests.length
+  )
+  const precinctTallies = fullTally.resultsByCategory.get(
+    TallyCategory.Precinct
+  )
+  expect(precinctTallies).toBeDefined()
+  election.precincts.forEach((precinct) => {
+    const precinctTally = precinctTallies![precinct.id]
+    expect(precinctTally).toBeDefined()
+    expect(precinctTally!.numberOfBallotsCounted).toBe(0)
+    expect(precinctTally!.contestTallies.length).toBe(election.contests.length)
+  })
 })
 
 describe('filterTalliesByParams in a typical election', () => {

--- a/apps/election-manager/src/lib/votecounting.ts
+++ b/apps/election-manager/src/lib/votecounting.ts
@@ -426,11 +426,12 @@ export function computeFullElectionTally(
 
   const cvrFilesByPrecinct: Dictionary<CastVoteRecord[]> = {}
   const cvrFilesByScanner: Dictionary<CastVoteRecord[]> = {}
+  election.precincts.forEach((precinct) => {
+    cvrFilesByPrecinct[precinct.id] = []
+  })
+
   castVoteRecords.forEach((CVR) => {
-    let filesForPrecinct = cvrFilesByPrecinct[CVR._precinctId]
-    if (!filesForPrecinct) {
-      cvrFilesByPrecinct[CVR._precinctId] = filesForPrecinct = []
-    }
+    const filesForPrecinct = cvrFilesByPrecinct[CVR._precinctId]!
     filesForPrecinct.push(CVR)
 
     let filesForScanner = cvrFilesByScanner[CVR._scannerId]

--- a/apps/election-manager/src/screens/TallyScreen.tsx
+++ b/apps/election-manager/src/screens/TallyScreen.tsx
@@ -184,8 +184,13 @@ const TallyScreen: React.FC = () => {
               </strong>
             </TD>
             <TD>
-              <LinkButton to={routerPaths.tallyFullReport}>
-                View {statusPrefix} Full Election Tally
+              <LinkButton
+                small
+                to={routerPaths.tallyPrecinctReport({
+                  precinctId: 'all',
+                })}
+              >
+                View {statusPrefix} Tally Reports for All Precincts
               </LinkButton>
             </TD>
           </tr>
@@ -247,16 +252,17 @@ const TallyScreen: React.FC = () => {
           </tr>
         </tbody>
       </Table>
-      {false && (
-        <React.Fragment>
-          <h2>Additional Reports</h2>
-          <p>
-            <LinkButton to={routerPaths.overvoteCombinationReport}>
-              {statusPrefix} Overvote Combination Report
-            </LinkButton>
-          </p>
-        </React.Fragment>
-      )}
+      <h2>{statusPrefix} Tally Reports</h2>
+      <p>
+        <LinkButton to={routerPaths.tallyFullReport}>
+          View {statusPrefix} Full Election Tally Report
+        </LinkButton>
+        {false && (
+          <LinkButton to={routerPaths.overvoteCombinationReport}>
+            {statusPrefix} Overvote Combination Report
+          </LinkButton>
+        )}
+      </p>
     </React.Fragment>
   )
   return (


### PR DESCRIPTION
Adds a button to print all the tally reports by precinct at once. I put this in a new section for default tally reports and also moved the overall tally report button there. I plan to eventually add a "Create custom tally report" button or buttons for any other default reports we want to this section. 

In printing the full precinct by precinct tallies I also noticed a bug from my last PR where I wasn't initializing empty tallies for each precinct when there was no data which caused the precinct reports to be totally blank instead of showing zero tallies. I also fixed that bug and added a test for it. 

## Screenshots
### Tally Screen
![Screen Shot 2021-02-01 at 12 28 32 PM](https://user-images.githubusercontent.com/14897017/106514587-4a9c8180-6489-11eb-8181-c27760be777c.png)
(scrolled further) 
![Screen Shot 2021-02-01 at 12 28 38 PM](https://user-images.githubusercontent.com/14897017/106514585-496b5480-6489-11eb-9ee2-81f96a4d22e1.png)


### Tally Report Screen for printing all precincts tally report 
![Screen Shot 2021-01-29 at 4 43 35 PM](https://user-images.githubusercontent.com/14897017/106341300-98c74000-6251-11eb-87e5-92ddce6d4c24.png)
