### PR TITLE
Add election title subheading to tally reports

### DIFF
--- a/apps/election-manager/src/App.test.tsx
+++ b/apps/election-manager/src/App.test.tsx
@@ -240,6 +240,9 @@ it('tabulating CVRs', async () => {
   eitherNeitherElection.precincts.forEach((p) => {
     getByText(`Official Precinct Tally Report for: ${p.name}`)
   })
+  expect(getAllByText('Mock General Election Choctaw 2020').length).toBe(
+    eitherNeitherElection.precincts.length
+  )
 
   fireEvent.click(getByText('Tally'))
   fireEvent.click(getByText('Remove CVR Files…'))

--- a/apps/election-manager/src/screens/TallyReportScreen.tsx
+++ b/apps/election-manager/src/screens/TallyReportScreen.tsx
@@ -186,6 +186,7 @@ const TallyReportScreen: React.FC = () => {
                       <h1>
                         {statusPrefix} Precinct Tally Report for: {precinctName}
                       </h1>
+                      <h2>{electionTitle}</h2>
                       <TallyReportMetadata
                         generatedAtTime={generatedAtTime}
                         election={election}
@@ -212,6 +213,7 @@ const TallyReportScreen: React.FC = () => {
                         {statusPrefix} Scanner Tally Report for Scanner{' '}
                         {scannerId}
                       </h1>
+                      <h2>{electionTitle}</h2>
                       <TallyReportMetadata
                         generatedAtTime={generatedAtTime}
                         election={election}


### PR DESCRIPTION
Adds a h2 with the election title as a subheader on the precinct-specific and scanner-specific tally reports. This title is included in the main title of the tally reports for the full election tally report but not for the scanner or precinct specific ones, including when you print all the precinct reports together at once. Crucially this title contains the party name when the election is in a primary with different primaries and different tally reports for each primary. Without including this the scanner/precinct tally reports are really confusing as its impossible to tell which report is showing with party without inferring that information from the candidates in the contests. 

Screenshot: 
<img width="1294" alt="Screen Shot 2021-02-03 at 1 31 56 PM" src="https://user-images.githubusercontent.com/14897017/106813450-d9de9c00-6625-11eb-89cc-5ef74f754c84.png">
