### PR TITLE
Include sems data in tally reports

### DIFF
--- a/apps/election-manager/src/App.test.tsx
+++ b/apps/election-manager/src/App.test.tsx
@@ -231,7 +231,7 @@ it('tabulating CVRs', async () => {
     getAllByText('Official Mock General Election Choctaw 2020 Tally Report')
       .length > 0
   ).toBe(true)
-  getByText('Number of Ballots Cast: 100')
+  expect(getAllByText('Total Number of Ballots Cast: 100').length).toBe(2)
   expect(getByTestId('tally-report-contents')).toMatchSnapshot()
 
   fireEvent.click(getByText('Tally'))
@@ -261,6 +261,6 @@ it('tabulating CVRs', async () => {
   // When there are no CVRs imported the full tally report is labeled as the zero report
   fireEvent.click(getByText('View Unofficial Full Election Tally Report'))
   // Verify the zero report generates properly
-  getByText('Number of Ballots Cast: 0')
+  expect(getAllByText('Total Number of Ballots Cast: 0').length).toBe(2)
   expect(getByTestId('tally-report-contents')).toMatchSnapshot()
 })

--- a/apps/election-manager/src/AppRoot.tsx
+++ b/apps/election-manager/src/AppRoot.tsx
@@ -39,7 +39,7 @@ import {
   convertFileToStorageString,
   convertStorageStringToFile,
 } from './utils/file'
-import { convertSEMsFileToExternalTally } from './utils/semsTallies'
+import { convertSEMSFileToExternalTally } from './utils/semsTallies'
 import readFileAsync from './lib/readFileAsync'
 
 export interface AppStorage {
@@ -223,7 +223,7 @@ const AppRoot: React.FC<Props> = ({ storage }) => {
       if (externalVoteRecordsFile) {
         setIsTabulationRunning(true)
         const fileContent = await readFileAsync(externalVoteRecordsFile)
-        const externalTally = convertSEMsFileToExternalTally(
+        const externalTally = convertSEMSFileToExternalTally(
           fileContent,
           electionDefinition!.election
         )

--- a/apps/election-manager/src/components/ConfirmRemovingFileModal.tsx
+++ b/apps/election-manager/src/components/ConfirmRemovingFileModal.tsx
@@ -71,7 +71,7 @@ export const ConfirmRemovingFileModal: React.FC<Props> = ({
       fileTypeName = 'SEMS'
       mainContent = (
         <p>
-          Do you want to remove the SEMs file {externalVoteRecordsFile!.name}?
+          Do you want to remove the SEMS file {externalVoteRecordsFile!.name}?
         </p>
       )
       break

--- a/apps/election-manager/src/config/types.ts
+++ b/apps/election-manager/src/config/types.ts
@@ -118,6 +118,7 @@ export interface FullElectionExternalTally {
   >
 }
 
+export type OptionalExternalTally = Optional<ExternalTally>
 export type OptionalFullElectionTally = Optional<FullElectionTally>
 export type OptionalFullElectionExternalTally = Optional<FullElectionExternalTally>
 

--- a/apps/election-manager/src/lib/votecounting.ts
+++ b/apps/election-manager/src/lib/votecounting.ts
@@ -29,6 +29,7 @@ import {
   getEitherNeitherContests,
   expandEitherNeitherContests,
   writeInCandidate,
+  getDistrictIdsForPartyId,
 } from '../utils/election'
 
 import find from '../utils/find'
@@ -259,9 +260,9 @@ export function tallyVotesByContest({
   const contestTallies: Dictionary<ContestTally> = {}
   const { contests } = election
 
-  const districtsForParty = election.ballotStyles
-    .filter((bs) => bs.partyId === filterContestsByParty)
-    .flatMap((bs) => bs.districts)
+  const districtsForParty = filterContestsByParty
+    ? getDistrictIdsForPartyId(election, filterContestsByParty)
+    : []
 
   expandEitherNeitherContests(contests).forEach((contest) => {
     if (

--- a/apps/election-manager/src/screens/TallyReportScreen.tsx
+++ b/apps/election-manager/src/screens/TallyReportScreen.tsx
@@ -39,12 +39,6 @@ const TallyHeader = styled.div`
   }
 `
 
-const MetadataSection = styled.div`
-  h3 {
-    margin-bottom: 0.25em;
-  }
-`
-
 interface Props {
   election: Election
   generatedAtTime: Date
@@ -63,22 +57,22 @@ const TallyReportMetadata: React.FC<Props> = ({
   const totalBallotCount = votingWorksBallotCount + (externalBallotCount ?? 0)
   const ballotsByDataSource =
     externalBallotCount !== undefined ? (
-      <MetadataSection>
+      <React.Fragment>
         <h3>Ballots Cast by Data Source</h3>
         <Table>
           <tbody>
             <tr>
-              <TD as="th">Data Source</TD>{' '}
+              <TD as="th">Data Source</TD>
               <TD as="th" textAlign="right">
                 Number of Ballots Cast
               </TD>
             </tr>
             <tr>
-              <TD>VotingWorks Data</TD>{' '}
+              <TD>VotingWorks Data</TD>
               <TD textAlign="right">{format.count(votingWorksBallotCount)}</TD>
             </tr>
             <tr>
-              <TD>Imported SEMs File</TD>{' '}
+              <TD>Imported SEMS File</TD>
               <TD textAlign="right">{format.count(externalBallotCount)}</TD>
             </tr>
             <tr>
@@ -91,7 +85,7 @@ const TallyReportMetadata: React.FC<Props> = ({
             </tr>
           </tbody>
         </Table>
-      </MetadataSection>
+      </React.Fragment>
     ) : (
       <Text>
         Total Number of Ballots Cast: {format.count(totalBallotCount)}
@@ -100,11 +94,13 @@ const TallyReportMetadata: React.FC<Props> = ({
 
   return (
     <React.Fragment>
-      {electionDate}, {election.county.name}, {election.state}
-      <br />
-      <Text small as="span">
-        This report was created on {generatedAt}
-      </Text>
+      <p>
+        {electionDate}, {election.county.name}, {election.state}
+        <br />
+        <Text small as="span">
+          This report was created on {generatedAt}
+        </Text>
+      </p>
       {ballotsByDataSource}
     </React.Fragment>
   )

--- a/apps/election-manager/src/screens/TallyReportScreen.tsx
+++ b/apps/election-manager/src/screens/TallyReportScreen.tsx
@@ -20,7 +20,9 @@ import ContestTally from '../components/ContestTally'
 import NavigationScreen from '../components/NavigationScreen'
 import Prose from '../components/Prose'
 import Text from '../components/Text'
+import Table, { TD } from '../components/Table'
 import LinkButton from '../components/LinkButton'
+
 import routerPaths from '../routerPaths'
 import { filterTalliesByParams } from '../lib/votecounting'
 import {
@@ -28,6 +30,7 @@ import {
   localeLongDateAndTime,
 } from '../utils/IntlDateTimeFormats'
 import LogoMark from '../components/LogoMark'
+import { filterExternalTalliesByParams } from '../utils/semsTallies'
 
 const TallyHeader = styled.div`
   page-break-before: always;
@@ -36,18 +39,64 @@ const TallyHeader = styled.div`
   }
 `
 
+const MetadataSection = styled.div`
+  h3 {
+    margin-bottom: 0.25em;
+  }
+`
+
 interface Props {
   election: Election
   generatedAtTime: Date
-  ballotCount?: number
+  votingWorksBallotCount: number
+  externalBallotCount?: number
 }
+
 const TallyReportMetadata: React.FC<Props> = ({
   election,
   generatedAtTime,
-  ballotCount,
+  votingWorksBallotCount,
+  externalBallotCount,
 }) => {
   const electionDate = localeWeedkayAndDate.format(new Date(election.date))
   const generatedAt = localeLongDateAndTime.format(generatedAtTime)
+  const totalBallotCount = votingWorksBallotCount + (externalBallotCount ?? 0)
+  const ballotsByDataSource =
+    externalBallotCount !== undefined ? (
+      <MetadataSection>
+        <h3>Ballots Cast by Data Source</h3>
+        <Table>
+          <tbody>
+            <tr>
+              <TD as="th">Data Source</TD>{' '}
+              <TD as="th" textAlign="right">
+                Number of Ballots Cast
+              </TD>
+            </tr>
+            <tr>
+              <TD>VotingWorks Data</TD>{' '}
+              <TD textAlign="right">{format.count(votingWorksBallotCount)}</TD>
+            </tr>
+            <tr>
+              <TD>Imported SEMs File</TD>{' '}
+              <TD textAlign="right">{format.count(externalBallotCount)}</TD>
+            </tr>
+            <tr>
+              <TD>
+                <strong>Total</strong>
+              </TD>
+              <TD textAlign="right">
+                <strong>{format.count(totalBallotCount)}</strong>
+              </TD>
+            </tr>
+          </tbody>
+        </Table>
+      </MetadataSection>
+    ) : (
+      <Text>
+        Total Number of Ballots Cast: {format.count(totalBallotCount)}
+      </Text>
+    )
 
   return (
     <React.Fragment>
@@ -56,9 +105,7 @@ const TallyReportMetadata: React.FC<Props> = ({
       <Text small as="span">
         This report was created on {generatedAt}
       </Text>
-      {ballotCount !== undefined && (
-        <Text>Number of Ballots Cast: {format.count(ballotCount)}</Text>
-      )}
+      {ballotsByDataSource}
     </React.Fragment>
   )
 }
@@ -72,6 +119,7 @@ const TallyReportScreen: React.FC = () => {
     electionDefinition,
     isOfficialResults,
     fullElectionTally,
+    fullElectionExternalTally,
     isTabulationRunning,
   } = useContext(AppContext)
 
@@ -132,6 +180,16 @@ const TallyReportScreen: React.FC = () => {
   }
 
   const generatedAtTime = new Date()
+  const singlePrecinctId = precinctIds.length === 1 ? precinctIds[0] : undefined
+  const outerTallyReport = filterTalliesByParams(fullElectionTally!, election, {
+    precinctId: singlePrecinctId,
+    scannerId,
+  })
+  const outerExternalTallyReport = filterExternalTalliesByParams(
+    fullElectionExternalTally,
+    election,
+    { precinctId: singlePrecinctId, scannerId }
+  )
 
   return (
     <React.Fragment>
@@ -141,6 +199,10 @@ const TallyReportScreen: React.FC = () => {
           <TallyReportMetadata
             generatedAtTime={generatedAtTime}
             election={election}
+            votingWorksBallotCount={outerTallyReport.numberOfBallotsCounted}
+            externalBallotCount={
+              outerExternalTallyReport?.numberOfBallotsCounted
+            }
           />
           <p>
             <PrintButton primary>Print {statusPrefix} Tally Report</PrintButton>
@@ -173,6 +235,11 @@ const TallyReportScreen: React.FC = () => {
               election,
               { precinctId, scannerId, partyId }
             )
+            const externalTallyForReport = filterExternalTalliesByParams(
+              fullElectionExternalTally,
+              election,
+              { precinctId, partyId }
+            )
 
             if (precinctId) {
               const precinctName = find(
@@ -190,14 +257,21 @@ const TallyReportScreen: React.FC = () => {
                       <TallyReportMetadata
                         generatedAtTime={generatedAtTime}
                         election={election}
-                        ballotCount={tallyForReport.numberOfBallotsCounted}
+                        votingWorksBallotCount={
+                          tallyForReport.numberOfBallotsCounted
+                        }
+                        externalBallotCount={
+                          externalTallyForReport?.numberOfBallotsCounted
+                        }
                       />
                     </Prose>
                   </TallyHeader>
                   <HorizontalRule />
+                  <h2>Contest Tallies</h2>
                   <ContestTally
                     election={election}
                     electionTally={tallyForReport}
+                    externalTally={externalTallyForReport}
                     precinctId={precinctId}
                   />
                 </React.Fragment>
@@ -217,11 +291,14 @@ const TallyReportScreen: React.FC = () => {
                       <TallyReportMetadata
                         generatedAtTime={generatedAtTime}
                         election={election}
-                        ballotCount={tallyForReport.numberOfBallotsCounted}
+                        votingWorksBallotCount={
+                          tallyForReport?.numberOfBallotsCounted ?? 0
+                        }
                       />
                     </Prose>
                   </TallyHeader>
                   <HorizontalRule />
+                  <h2>Contest Tallies</h2>
                   <ContestTally
                     election={election}
                     electionTally={tallyForReport}
@@ -240,15 +317,22 @@ const TallyReportScreen: React.FC = () => {
                     <TallyReportMetadata
                       generatedAtTime={generatedAtTime}
                       election={election}
-                      ballotCount={tallyForReport.numberOfBallotsCounted}
+                      votingWorksBallotCount={
+                        tallyForReport.numberOfBallotsCounted
+                      }
+                      externalBallotCount={
+                        externalTallyForReport?.numberOfBallotsCounted
+                      }
                     />
                   </Prose>
                 </TallyHeader>
+                <h2>Contest Tallies</h2>
                 <HorizontalRule />
                 <div data-testid="tally-report-contents">
                   <ContestTally
                     election={election}
                     electionTally={tallyForReport}
+                    externalTally={externalTallyForReport}
                   />
                 </div>
               </React.Fragment>

--- a/apps/election-manager/src/screens/TallyScreen.tsx
+++ b/apps/election-manager/src/screens/TallyScreen.tsx
@@ -139,8 +139,15 @@ const TallyScreen: React.FC = () => {
 
   const resultsByPrecinct =
     fullElectionTally?.resultsByCategory.get(TallyCategory.Precinct) || {}
+  const externalResultsByPrecinct =
+    fullElectionExternalTally?.resultsByCategory.get(TallyCategory.Precinct) ||
+    {}
   const resultsByScanner =
     fullElectionTally?.resultsByCategory.get(TallyCategory.Scanner) || {}
+  const totalBallotCountVotingWorks =
+    fullElectionTally?.overallTally.numberOfBallotsCounted ?? 0
+  const totalBallotCountExternal =
+    fullElectionExternalTally?.overallTally.numberOfBallotsCounted ?? 0
 
   const tallyResultsTable = isTabulationRunning ? (
     <Loading>Tabulating Results…</Loading>
@@ -165,12 +172,19 @@ const TallyScreen: React.FC = () => {
             .map((precinct) => {
               const precinctBallotsCount =
                 resultsByPrecinct[precinct.id]?.numberOfBallotsCounted ?? 0
+              const externalPrecinctBallotsCount =
+                externalResultsByPrecinct[precinct.id]
+                  ?.numberOfBallotsCounted ?? 0
               return (
                 <tr key={precinct.id}>
                   <TD narrow nowrap>
                     {precinct.name}
                   </TD>
-                  <TD>{format.count(precinctBallotsCount)}</TD>
+                  <TD>
+                    {format.count(
+                      precinctBallotsCount + externalPrecinctBallotsCount
+                    )}
+                  </TD>
                   <TD>
                     <LinkButton
                       small
@@ -191,7 +205,7 @@ const TallyScreen: React.FC = () => {
             <TD>
               <strong data-testid="total-ballot-count">
                 {format.count(
-                  fullElectionTally?.overallTally.numberOfBallotsCounted ?? 0
+                  totalBallotCountVotingWorks + totalBallotCountExternal
                 )}
               </strong>
             </TD>
@@ -209,6 +223,13 @@ const TallyScreen: React.FC = () => {
         </tbody>
       </Table>
       <h2>Ballot Count by Scanner</h2>
+      {fullElectionExternalTally && (
+        <p>
+          The following results only include ballots counted with VotingWorks
+          scanners. The data from the imported SEMs file is not included in
+          these reports.
+        </p>
+      )}
       <Table>
         <tbody>
           <tr>

--- a/apps/election-manager/src/screens/TallyScreen.tsx
+++ b/apps/election-manager/src/screens/TallyScreen.tsx
@@ -13,7 +13,7 @@ import * as format from '../utils/format'
 import AppContext from '../contexts/AppContext'
 import ConverterClient from '../lib/ConverterClient'
 import {
-  convertSEMsFileToExternalTally,
+  convertSEMSFileToExternalTally,
   getPrecinctIdsInExternalTally,
 } from '../utils/semsTallies'
 import readFileAsync from '../lib/readFileAsync'
@@ -94,7 +94,7 @@ const TallyScreen: React.FC = () => {
     ''
   )
 
-  const importExternalSEMsFile: InputEventFunction = async (event) => {
+  const importExternalSEMSFile: InputEventFunction = async (event) => {
     const input = event.currentTarget
     const files = Array.from(input.files || [])
     if (files.length === 1) {
@@ -104,7 +104,7 @@ const TallyScreen: React.FC = () => {
       // Compute the tallies to see if there are any errors, if so display
       // an error modal.
       try {
-        convertSEMsFileToExternalTally(fileContent, election)
+        convertSEMSFileToExternalTally(fileContent, election)
         setIsImportExternalModalOpen(false)
         setIsTabulationRunning(false)
         saveExternalVoteRecordsFile(files[0])
@@ -226,7 +226,7 @@ const TallyScreen: React.FC = () => {
       {fullElectionExternalTally && (
         <p>
           The following results only include ballots counted with VotingWorks
-          scanners. The data from the imported SEMs file is not included in
+          scanners. The data from the imported SEMS file is not included in
           these reports.
         </p>
       )}
@@ -400,7 +400,7 @@ const TallyScreen: React.FC = () => {
             Import CVR Files
           </Button>{' '}
           <FileInputButton
-            onChange={importExternalSEMsFile}
+            onChange={importExternalSEMSFile}
             accept="*"
             disabled={!!fullElectionExternalTally}
           >

--- a/apps/election-manager/src/screens/TallyScreen.tsx
+++ b/apps/election-manager/src/screens/TallyScreen.tsx
@@ -199,7 +199,7 @@ const TallyScreen: React.FC = () => {
               )
             })}
           <tr>
-            <TD narrow>
+            <TD narrow nowrap>
               <strong>Total Ballot Count</strong>
             </TD>
             <TD>

--- a/apps/election-manager/src/utils/__snapshots__/semsTallies.test.ts.snap
+++ b/apps/election-manager/src/utils/__snapshots__/semsTallies.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`convertSEMsFileToExternalTally computes tallies properly on either neither general election 1`] = `
+exports[`convertSEMSFileToExternalTally computes tallies properly on either neither general election 1`] = `
 Object {
   "750000015": Object {
     "contest": Object {
@@ -686,7 +686,7 @@ House Bill 1796 - Flag Referendum",
 }
 `;
 
-exports[`convertSEMsFileToExternalTally computes tallies properly on either neither general election 2`] = `
+exports[`convertSEMSFileToExternalTally computes tallies properly on either neither general election 2`] = `
 Object {
   "750000015": Object {
     "contest": Object {
@@ -1194,7 +1194,7 @@ House Bill 1796 - Flag Referendum",
 }
 `;
 
-exports[`convertSEMsFileToExternalTally computes tallies properly on either neither general election 3`] = `
+exports[`convertSEMSFileToExternalTally computes tallies properly on either neither general election 3`] = `
 Object {
   "750000015": Object {
     "contest": Object {
@@ -1650,7 +1650,7 @@ House Bill 1796 - Flag Referendum",
 }
 `;
 
-exports[`convertSEMsFileToExternalTally computes tallies properly on either neither general election 4`] = `
+exports[`convertSEMSFileToExternalTally computes tallies properly on either neither general election 4`] = `
 Object {
   "750000015": Object {
     "contest": Object {
@@ -2117,7 +2117,7 @@ House Bill 1796 - Flag Referendum",
 }
 `;
 
-exports[`convertSEMsFileToExternalTally computes tallies properly on either neither general election 5`] = `
+exports[`convertSEMSFileToExternalTally computes tallies properly on either neither general election 5`] = `
 Object {
   "750000015": Object {
     "contest": Object {
@@ -2573,7 +2573,7 @@ House Bill 1796 - Flag Referendum",
 }
 `;
 
-exports[`convertSEMsFileToExternalTally computes tallies properly on either neither general election 6`] = `
+exports[`convertSEMSFileToExternalTally computes tallies properly on either neither general election 6`] = `
 Object {
   "750000015": Object {
     "contest": Object {
@@ -3029,7 +3029,7 @@ House Bill 1796 - Flag Referendum",
 }
 `;
 
-exports[`convertSEMsFileToExternalTally computes tallies properly on either neither general election 7`] = `
+exports[`convertSEMSFileToExternalTally computes tallies properly on either neither general election 7`] = `
 Object {
   "750000015": Object {
     "contest": Object {
@@ -3496,7 +3496,7 @@ House Bill 1796 - Flag Referendum",
 }
 `;
 
-exports[`convertSEMsFileToExternalTally computes tallies properly on either neither general election 8`] = `
+exports[`convertSEMSFileToExternalTally computes tallies properly on either neither general election 8`] = `
 Object {
   "750000015": Object {
     "contest": Object {
@@ -3952,7 +3952,7 @@ House Bill 1796 - Flag Referendum",
 }
 `;
 
-exports[`convertSEMsFileToExternalTally computes tallies properly on either neither general election 9`] = `
+exports[`convertSEMSFileToExternalTally computes tallies properly on either neither general election 9`] = `
 Object {
   "750000015": Object {
     "contest": Object {
@@ -4419,7 +4419,7 @@ House Bill 1796 - Flag Referendum",
 }
 `;
 
-exports[`convertSEMsFileToExternalTally computes tallies properly on either neither general election 10`] = `
+exports[`convertSEMSFileToExternalTally computes tallies properly on either neither general election 10`] = `
 Object {
   "750000015": Object {
     "contest": Object {
@@ -4886,7 +4886,7 @@ House Bill 1796 - Flag Referendum",
 }
 `;
 
-exports[`convertSEMsFileToExternalTally computes tallies properly on either neither general election 11`] = `
+exports[`convertSEMSFileToExternalTally computes tallies properly on either neither general election 11`] = `
 Object {
   "750000015": Object {
     "contest": Object {
@@ -5353,7 +5353,7 @@ House Bill 1796 - Flag Referendum",
 }
 `;
 
-exports[`convertSEMsFileToExternalTally computes tallies properly on either neither general election 12`] = `
+exports[`convertSEMSFileToExternalTally computes tallies properly on either neither general election 12`] = `
 Object {
   "750000015": Object {
     "contest": Object {
@@ -5820,7 +5820,7 @@ House Bill 1796 - Flag Referendum",
 }
 `;
 
-exports[`convertSEMsFileToExternalTally computes tallies properly on either neither general election 13`] = `
+exports[`convertSEMSFileToExternalTally computes tallies properly on either neither general election 13`] = `
 Object {
   "750000015": Object {
     "contest": Object {
@@ -6276,7 +6276,7 @@ House Bill 1796 - Flag Referendum",
 }
 `;
 
-exports[`convertSEMsFileToExternalTally computes tallies properly on either neither general election 14`] = `
+exports[`convertSEMSFileToExternalTally computes tallies properly on either neither general election 14`] = `
 Object {
   "750000015": Object {
     "contest": Object {
@@ -6732,7 +6732,7 @@ House Bill 1796 - Flag Referendum",
 }
 `;
 
-exports[`convertSEMsFileToExternalTally converts primary election sems file properly 1`] = `
+exports[`convertSEMSFileToExternalTally converts primary election sems file properly 1`] = `
 Object {
   "assistant-mayor-contest-liberty": Object {
     "contest": Object {
@@ -7556,7 +7556,7 @@ Object {
 }
 `;
 
-exports[`convertSEMsFileToExternalTally converts primary election sems file properly 2`] = `
+exports[`convertSEMSFileToExternalTally converts primary election sems file properly 2`] = `
 Object {
   "assistant-mayor-contest-liberty": Object {
     "contest": Object {
@@ -8380,7 +8380,7 @@ Object {
 }
 `;
 
-exports[`convertSEMsFileToExternalTally converts primary election sems file properly 3`] = `
+exports[`convertSEMSFileToExternalTally converts primary election sems file properly 3`] = `
 Object {
   "assistant-mayor-contest-liberty": Object {
     "contest": Object {
@@ -9204,7 +9204,7 @@ Object {
 }
 `;
 
-exports[`convertSEMsFileToExternalTally converts primary election sems file properly 4`] = `
+exports[`convertSEMSFileToExternalTally converts primary election sems file properly 4`] = `
 Object {
   "assistant-mayor-contest-liberty": Object {
     "contest": Object {
@@ -10028,7 +10028,7 @@ Object {
 }
 `;
 
-exports[`convertSEMsFileToExternalTally converts primary election sems file properly 5`] = `
+exports[`convertSEMSFileToExternalTally converts primary election sems file properly 5`] = `
 Object {
   "assistant-mayor-contest-liberty": Object {
     "contest": Object {
@@ -10852,7 +10852,7 @@ Object {
 }
 `;
 
-exports[`convertSEMsFileToExternalTally converts primary election sems file properly 6`] = `
+exports[`convertSEMSFileToExternalTally converts primary election sems file properly 6`] = `
 Object {
   "assistant-mayor-contest-liberty": Object {
     "contest": Object {

--- a/apps/election-manager/src/utils/election.ts
+++ b/apps/election-manager/src/utils/election.ts
@@ -27,6 +27,15 @@ export const writeInCandidate: Candidate = {
   isWriteIn: true,
 }
 
+export function getDistrictIdsForPartyId(
+  election: Election,
+  partyId: string
+): string[] {
+  return election.ballotStyles
+    .filter((bs) => bs.partyId === partyId)
+    .flatMap((bs) => bs.districts)
+}
+
 export function getContestOptionsForContest(
   contest: AnyContest
 ): readonly ContestOption[] {

--- a/apps/election-manager/src/utils/semsTallies.test.ts
+++ b/apps/election-manager/src/utils/semsTallies.test.ts
@@ -21,7 +21,7 @@ import {
   getContestTallyForCandidateContest,
   getContestTallyForYesNoContest,
   SEMSFileRow,
-  convertSEMsFileToExternalTally,
+  convertSEMSFileToExternalTally,
 } from './semsTallies'
 
 const mockSemsRow = {
@@ -39,11 +39,11 @@ const mockSemsRow = {
 }
 
 const fixturesPath = path.join(__dirname, '../../../../libs/fixtures/src/data')
-const eitherNeitherSEMsPath = path.join(
+const eitherNeitherSEMSPath = path.join(
   fixturesPath,
   'electionWithMsEitherNeither/converted-sems-results.csv'
 )
-const primarySEMsPath = path.join(
+const primarySEMSPath = path.join(
   fixturesPath,
   'electionMultiPartyPrimary/converted-sems-results.csv'
 )
@@ -437,10 +437,10 @@ describe('getContestTallyForYesNoContest', () => {
   })
 })
 
-describe('convertSEMsFileToExternalTally', () => {
+describe('convertSEMSFileToExternalTally', () => {
   it('computes tallies properly on either neither general election', async () => {
-    const semsFileContent = await fs.readFile(eitherNeitherSEMsPath, 'utf8')
-    const convertedTally = convertSEMsFileToExternalTally(
+    const semsFileContent = await fs.readFile(eitherNeitherSEMSPath, 'utf8')
+    const convertedTally = convertSEMSFileToExternalTally(
       semsFileContent,
       electionWithMsEitherNeither
     )
@@ -544,8 +544,8 @@ describe('convertSEMsFileToExternalTally', () => {
   })
 
   it('converts primary election sems file properly', async () => {
-    const semsFileContent = await fs.readFile(primarySEMsPath, 'utf8')
-    const convertedTally = convertSEMsFileToExternalTally(
+    const semsFileContent = await fs.readFile(primarySEMSPath, 'utf8')
+    const convertedTally = convertSEMSFileToExternalTally(
       semsFileContent,
       multiPartyPrimaryElection
     )

--- a/apps/election-manager/src/utils/semsTallies.ts
+++ b/apps/election-manager/src/utils/semsTallies.ts
@@ -14,11 +14,18 @@ import {
   ContestTally,
   ExternalTally,
   FullElectionExternalTally,
+  OptionalExternalTally,
+  OptionalFullElectionExternalTally,
   TallyCategory,
   YesNoOption,
 } from '../config/types'
 import assert from './assert'
-import { expandEitherNeitherContests, getContests } from './election'
+import {
+  expandEitherNeitherContests,
+  getContests,
+  getDistrictIdsForPartyId,
+} from './election'
+import { getEmptyTally } from '../lib/votecounting'
 
 const WriteInCandidateId = '0'
 const OvervoteCandidateId = '1'
@@ -332,4 +339,54 @@ export function getPrecinctIdsInExternalTally(
 ): string[] {
   const resultsByPrecinct = tally.resultsByCategory.get(TallyCategory.Precinct)
   return resultsByPrecinct ? Object.keys(resultsByPrecinct) : []
+}
+
+export function filterExternalTalliesByParams(
+  fullTally: OptionalFullElectionExternalTally,
+  election: Election,
+  {
+    precinctId,
+    partyId,
+    scannerId,
+  }: { precinctId?: string; partyId?: string; scannerId?: string }
+): OptionalExternalTally {
+  if (!fullTally || scannerId) {
+    return undefined
+  }
+
+  const { overallTally, resultsByCategory } = fullTally
+
+  let filteredTally = overallTally
+
+  if (precinctId) {
+    filteredTally =
+      resultsByCategory.get(TallyCategory.Precinct)?.[precinctId] ||
+      getEmptyTally()
+  }
+
+  if (!partyId) {
+    return filteredTally
+  }
+
+  // Filter contests by party and recompute the number of ballots based on those contests.
+  const districtsForParty = getDistrictIdsForPartyId(election, partyId)
+  const filteredContestTallies: Dictionary<ContestTally> = {}
+  Object.keys(filteredTally.contestTallies).forEach((contestId) => {
+    const contestTally = filteredTally.contestTallies[contestId]
+    if (
+      contestTally &&
+      districtsForParty.includes(contestTally.contest.districtId) &&
+      contestTally.contest.partyId === partyId
+    ) {
+      filteredContestTallies[contestId] = contestTally
+    }
+  })
+  const numberOfBallotsCounted = getTotalNumberOfBallots(
+    filteredContestTallies,
+    election
+  )
+  return {
+    contestTallies: filteredContestTallies,
+    numberOfBallotsCounted,
+  }
 }

--- a/apps/election-manager/src/utils/semsTallies.ts
+++ b/apps/election-manager/src/utils/semsTallies.ts
@@ -237,7 +237,7 @@ function sanitizeItem(item: string): string {
   return item.replace(/['"`]/g, '').trim()
 }
 
-export function convertSEMsFileToExternalTally(
+export function convertSEMSFileToExternalTally(
   fileContent: string,
   election: Election
 ): FullElectionExternalTally {


### PR DESCRIPTION
Includes sems file in the ballot count tables and tally reports. When there is a SEMs file loaded, adds a "ballots cast by data source" table to the tally report screen page, and the tally reports themselves. When there is not a SEMs file loaded this is just 1 line with the total number of ballots. I imagine adding another table here with the ballot breakdown by voting method eventually as well. 
Tally Screen:
![Screen Shot 2021-02-17 at 10 07 28 AM](https://user-images.githubusercontent.com/14897017/108247793-f8559480-7107-11eb-8d4f-009bbee96356.png)

Tally Report Screen:
(If there are multiple reports in this tally report, i.e. by party or for all precincts this table is for all the ballots combined across all reports)
![Screen Shot 2021-02-17 at 9 31 19 AM](https://user-images.githubusercontent.com/14897017/108247944-25a24280-7108-11eb-9d53-da1e8795cf34.png)

Tally Report:
![Screen Shot 2021-02-17 at 9 35 21 AM](https://user-images.githubusercontent.com/14897017/108247913-1c18da80-7108-11eb-9975-a6a36b901bbc.png)
