### PR TITLE
refactor(all): assume `Modal` is open

### DIFF
--- a/apps/bmd/src/components/CandidateContest.tsx
+++ b/apps/bmd/src/components/CandidateContest.tsx
@@ -431,106 +431,111 @@ const CandidateContest: React.FC<Props> = ({
           )}
         </VariableContentContainer>
       </Main>
-      <Modal
-        isOpen={!!attemptedOvervoteCandidate}
-        ariaLabel=""
-        centerContent
-        content={
-          <Prose>
-            <Text id="modalaudiofocus">
-              You may only select {contest.seats}{' '}
-              {contest.seats === 1 ? 'candidate' : 'candidates'} in this
-              contest. To vote for {attemptedOvervoteCandidate?.name}, you must
-              first unselect the selected{' '}
-              {contest.seats === 1 ? 'candidate' : 'candidates'}.
-              <span aria-label="Use the select button to continue." />
-            </Text>
-          </Prose>
-        }
-        actions={
-          <Button
-            primary
-            autoFocus
-            onPress={closeAttemptedVoteAlert}
-            aria-label="use the select button to continue."
-          >
-            Okay
-          </Button>
-        }
-      />
-      <Modal
-        isOpen={!!candidatePendingRemoval}
-        centerContent
-        content={
-          <Prose>
-            <Text id="modalaudiofocus">
-              Do you want to unselect and remove {candidatePendingRemoval?.name}
-              ?
-            </Text>
-          </Prose>
-        }
-        actions={
-          <React.Fragment>
-            <Button danger onPress={confirmRemovePendingWriteInCandidate}>
-              Yes, Remove.
-            </Button>
-            <Button onPress={clearCandidateIdPendingRemoval}>Cancel</Button>
-          </React.Fragment>
-        }
-      />
-      <Modal
-        ariaLabel=""
-        isOpen={writeInCandateModalIsOpen}
-        className="writein-modal-content"
-        content={
-          <WriteInModalContent>
-            <Prose id="modalaudiofocus" maxWidth={false}>
-              <h1 aria-label="Write-In Candidate.">Write-In Candidate</h1>
-              <Text aria-label="Enter the name of a person who is not on the ballot. Use the up and down buttons to navigate between the letters of a standard keyboard. Use the select button to select the current letter.">
-                Enter the name of a person who is <strong>not</strong> on the
-                ballot.
+      {attemptedOvervoteCandidate && (
+        <Modal
+          ariaLabel=""
+          centerContent
+          content={
+            <Prose>
+              <Text id="modalaudiofocus">
+                You may only select {contest.seats}{' '}
+                {contest.seats === 1 ? 'candidate' : 'candidates'} in this
+                contest. To vote for {attemptedOvervoteCandidate?.name}, you
+                must first unselect the selected{' '}
+                {contest.seats === 1 ? 'candidate' : 'candidates'}.
+                <span aria-label="Use the select button to continue." />
               </Text>
-              {writeInCandidateName.length >
-                WRITE_IN_CANDIDATE_MAX_LENGTH - 5 && (
-                <Text error>
-                  <strong>Note:</strong> You have entered{' '}
-                  {writeInCandidateName.length} of maximum{' '}
-                  {WRITE_IN_CANDIDATE_MAX_LENGTH} characters.
-                </Text>
-              )}
             </Prose>
-            <WriteInCandidateForm>
-              <WriteInCandidateFieldSet>
-                <Prose>
-                  <h3>{contest.title} (write-in)</h3>
-                </Prose>
-                <WriteInCandidateName>
-                  {writeInCandidateName}
-                  <WriteInCandidateCursor />
-                </WriteInCandidateName>
-              </WriteInCandidateFieldSet>
-              <VirtualKeyboard
-                onKeyPress={onKeyboardInput}
-                keyDisabled={keyDisabled}
-              />
-            </WriteInCandidateForm>
-          </WriteInModalContent>
-        }
-        actions={
-          <React.Fragment>
+          }
+          actions={
             <Button
-              primary={normalizeCandidateName(writeInCandidateName).length > 0}
-              onPress={addWriteInCandidate}
-              disabled={
-                normalizeCandidateName(writeInCandidateName).length === 0
-              }
+              primary
+              autoFocus
+              onPress={closeAttemptedVoteAlert}
+              aria-label="use the select button to continue."
             >
-              Accept
+              Okay
             </Button>
-            <Button onPress={cancelWriteInCandidateModal}>Cancel</Button>
-          </React.Fragment>
-        }
-      />
+          }
+        />
+      )}
+      {candidatePendingRemoval && (
+        <Modal
+          centerContent
+          content={
+            <Prose>
+              <Text id="modalaudiofocus">
+                Do you want to unselect and remove{' '}
+                {candidatePendingRemoval?.name}?
+              </Text>
+            </Prose>
+          }
+          actions={
+            <React.Fragment>
+              <Button danger onPress={confirmRemovePendingWriteInCandidate}>
+                Yes, Remove.
+              </Button>
+              <Button onPress={clearCandidateIdPendingRemoval}>Cancel</Button>
+            </React.Fragment>
+          }
+        />
+      )}
+      {writeInCandateModalIsOpen && (
+        <Modal
+          ariaLabel=""
+          className="writein-modal-content"
+          content={
+            <WriteInModalContent>
+              <Prose id="modalaudiofocus" maxWidth={false}>
+                <h1 aria-label="Write-In Candidate.">Write-In Candidate</h1>
+                <Text aria-label="Enter the name of a person who is not on the ballot. Use the up and down buttons to navigate between the letters of a standard keyboard. Use the select button to select the current letter.">
+                  Enter the name of a person who is <strong>not</strong> on the
+                  ballot.
+                </Text>
+                {writeInCandidateName.length >
+                  WRITE_IN_CANDIDATE_MAX_LENGTH - 5 && (
+                  <Text error>
+                    <strong>Note:</strong> You have entered{' '}
+                    {writeInCandidateName.length} of maximum{' '}
+                    {WRITE_IN_CANDIDATE_MAX_LENGTH} characters.
+                  </Text>
+                )}
+              </Prose>
+              <WriteInCandidateForm>
+                <WriteInCandidateFieldSet>
+                  <Prose>
+                    <h3>{contest.title} (write-in)</h3>
+                  </Prose>
+                  <WriteInCandidateName>
+                    {writeInCandidateName}
+                    <WriteInCandidateCursor />
+                  </WriteInCandidateName>
+                </WriteInCandidateFieldSet>
+                <VirtualKeyboard
+                  onKeyPress={onKeyboardInput}
+                  keyDisabled={keyDisabled}
+                />
+              </WriteInCandidateForm>
+            </WriteInModalContent>
+          }
+          actions={
+            <React.Fragment>
+              <Button
+                primary={
+                  normalizeCandidateName(writeInCandidateName).length > 0
+                }
+                onPress={addWriteInCandidate}
+                disabled={
+                  normalizeCandidateName(writeInCandidateName).length === 0
+                }
+              >
+                Accept
+              </Button>
+              <Button onPress={cancelWriteInCandidateModal}>Cancel</Button>
+            </React.Fragment>
+          }
+        />
+      )}
     </React.Fragment>
   )
 }

--- a/apps/bmd/src/components/Modal.tsx
+++ b/apps/bmd/src/components/Modal.tsx
@@ -23,7 +23,6 @@ const ModalContent = styled('div')<ModalContentInterface>`
 `
 
 interface Props {
-  isOpen: boolean
   ariaLabel?: string
   className?: string
   content?: ReactNode
@@ -38,7 +37,6 @@ const Modal: React.FC<Props> = ({
   centerContent,
   className = '',
   content,
-  isOpen,
   onAfterOpen = () => {
     /* istanbul ignore next - unclear why this isn't covered */
     window.setTimeout(() => {
@@ -57,7 +55,7 @@ const Modal: React.FC<Props> = ({
     ariaHideApp
     aria-modal
     role="alertdialog"
-    isOpen={isOpen}
+    isOpen
     contentLabel={ariaLabel}
     portalClassName="modal-portal"
     className={`modal-content ${className}`}

--- a/apps/bmd/src/components/YesNoContest.tsx
+++ b/apps/bmd/src/components/YesNoContest.tsx
@@ -242,35 +242,36 @@ const YesNoContest: React.FC<Props> = ({ contest, vote, updateVote }) => {
           </ChoicesGrid>
         </ContestFooter>
       </Main>
-      <Modal
-        isOpen={!!overvoteSelection}
-        centerContent
-        content={
-          <Prose>
-            {overvoteSelection && (
-              <p id="modalaudiofocus">
-                Do you want to change your vote to{' '}
-                <strong>{YES_NO_VOTES[overvoteSelection]}</strong>? To change
-                your vote, first unselect your vote for{' '}
-                <strong>
-                  {
+      {overvoteSelection && (
+        <Modal
+          centerContent
+          content={
+            <Prose>
+              {overvoteSelection && (
+                <p id="modalaudiofocus">
+                  Do you want to change your vote to{' '}
+                  <strong>{YES_NO_VOTES[overvoteSelection]}</strong>? To change
+                  your vote, first unselect your vote for{' '}
+                  <strong>
                     {
-                      no: YES_NO_VOTES.yes,
-                      yes: YES_NO_VOTES.no,
-                    }[overvoteSelection]
-                  }
-                </strong>
-                .
-              </p>
-            )}
-          </Prose>
-        }
-        actions={
-          <Button primary autoFocus onPress={closeOvervoteAlert}>
-            Okay
-          </Button>
-        }
-      />
+                      {
+                        no: YES_NO_VOTES.yes,
+                        yes: YES_NO_VOTES.no,
+                      }[overvoteSelection]
+                    }
+                  </strong>
+                  .
+                </p>
+              )}
+            </Prose>
+          }
+          actions={
+            <Button primary autoFocus onPress={closeOvervoteAlert}>
+              Okay
+            </Button>
+          }
+        />
+      )}
     </React.Fragment>
   )
 }

--- a/apps/bmd/src/pages/AdminScreen.tsx
+++ b/apps/bmd/src/pages/AdminScreen.tsx
@@ -288,177 +288,178 @@ const AdminScreen: React.FC<Props> = ({
           </Prose>
         )}
       </Sidebar>
-      <Modal
-        isOpen={isSystemDateModalActive}
-        centerContent
-        content={
-          <Prose textCenter>
-            <h1>{formatFullDateTimeZone(systemDate)}</h1>
-            <div>
-              <p>
-                <InputGroup as="span">
-                  <Select
-                    data-testid="selectYear"
-                    value={systemDate.getFullYear()}
-                    name="year"
-                    disabled={isSavingDate}
-                    onBlur={updateSystemTime}
-                    onChange={updateSystemTime}
-                  >
-                    <option value="" disabled>
-                      Year
-                    </option>
-                    {[...Array(11).keys()].map((i) => (
-                      <option key={i} value={2020 + i}>
-                        {2020 + i}
+      {isSystemDateModalActive && (
+        <Modal
+          centerContent
+          content={
+            <Prose textCenter>
+              <h1>{formatFullDateTimeZone(systemDate)}</h1>
+              <div>
+                <p>
+                  <InputGroup as="span">
+                    <Select
+                      data-testid="selectYear"
+                      value={systemDate.getFullYear()}
+                      name="year"
+                      disabled={isSavingDate}
+                      onBlur={updateSystemTime}
+                      onChange={updateSystemTime}
+                    >
+                      <option value="" disabled>
+                        Year
                       </option>
-                    ))}
-                  </Select>
-                  <Select
-                    data-testid="selectMonth"
-                    value={systemDate.getMonth()}
-                    name="month"
-                    disabled={isSavingDate}
-                    onBlur={updateSystemTime}
-                    onChange={updateSystemTime}
-                    style={{
-                      width: '4.7rem',
-                    }}
-                  >
-                    <option value="" disabled>
-                      Month
-                    </option>
-                    {MONTHS_SHORT.map((month, index) => (
-                      <option key={month} value={index}>
-                        {month}
+                      {[...Array(11).keys()].map((i) => (
+                        <option key={i} value={2020 + i}>
+                          {2020 + i}
+                        </option>
+                      ))}
+                    </Select>
+                    <Select
+                      data-testid="selectMonth"
+                      value={systemDate.getMonth()}
+                      name="month"
+                      disabled={isSavingDate}
+                      onBlur={updateSystemTime}
+                      onChange={updateSystemTime}
+                      style={{
+                        width: '4.7rem',
+                      }}
+                    >
+                      <option value="" disabled>
+                        Month
                       </option>
-                    ))}
-                  </Select>
-                  <Select
-                    data-testid="selectDay"
-                    value={systemDate.getDate()}
-                    name="day"
-                    disabled={isSavingDate}
-                    onBlur={updateSystemTime}
-                    onChange={updateSystemTime}
-                    style={{
-                      width: '4.15rem',
-                    }}
-                  >
-                    <option value="" disabled>
-                      Day
-                    </option>
-                    {getDaysInMonth(
-                      systemDate.getFullYear(),
-                      systemDate.getMonth()
-                    ).map((day) => (
-                      <option key={day.getDate()} value={day.getDate()}>
-                        {day.getDate()}
+                      {MONTHS_SHORT.map((month, index) => (
+                        <option key={month} value={index}>
+                          {month}
+                        </option>
+                      ))}
+                    </Select>
+                    <Select
+                      data-testid="selectDay"
+                      value={systemDate.getDate()}
+                      name="day"
+                      disabled={isSavingDate}
+                      onBlur={updateSystemTime}
+                      onChange={updateSystemTime}
+                      style={{
+                        width: '4.15rem',
+                      }}
+                    >
+                      <option value="" disabled>
+                        Day
                       </option>
-                    ))}
-                  </Select>
-                </InputGroup>
-              </p>
-              <p>
-                <InputGroup as="span">
-                  <Select
-                    data-testid="selectHour"
-                    value={systemDate.getHours() % 12 || 12}
-                    name="hour"
-                    disabled={isSavingDate}
-                    onBlur={updateSystemTime}
-                    onChange={updateSystemTime}
-                    style={{
-                      width: '4rem',
-                    }}
-                  >
-                    <option value="" disabled>
-                      Hour
-                    </option>
-                    {[...Array(12).keys()].map((hour) => (
-                      <option key={hour} value={hour + 1}>
-                        {hour + 1}
+                      {getDaysInMonth(
+                        systemDate.getFullYear(),
+                        systemDate.getMonth()
+                      ).map((day) => (
+                        <option key={day.getDate()} value={day.getDate()}>
+                          {day.getDate()}
+                        </option>
+                      ))}
+                    </Select>
+                  </InputGroup>
+                </p>
+                <p>
+                  <InputGroup as="span">
+                    <Select
+                      data-testid="selectHour"
+                      value={systemDate.getHours() % 12 || 12}
+                      name="hour"
+                      disabled={isSavingDate}
+                      onBlur={updateSystemTime}
+                      onChange={updateSystemTime}
+                      style={{
+                        width: '4rem',
+                      }}
+                    >
+                      <option value="" disabled>
+                        Hour
                       </option>
-                    ))}
-                  </Select>
-                  <Select
-                    data-testid="selectMinute"
-                    value={systemDate.getMinutes()}
-                    name="minute"
-                    disabled={isSavingDate}
-                    onBlur={updateSystemTime}
-                    onChange={updateSystemTime}
-                    style={{
-                      width: '4.15rem',
-                    }}
-                  >
-                    <option value="" disabled>
-                      Minute
-                    </option>
-                    {[...Array(60).keys()].map((minute) => (
-                      <option key={minute} value={minute}>
-                        {minute < 10 ? `0${minute}` : minute}
+                      {[...Array(12).keys()].map((hour) => (
+                        <option key={hour} value={hour + 1}>
+                          {hour + 1}
+                        </option>
+                      ))}
+                    </Select>
+                    <Select
+                      data-testid="selectMinute"
+                      value={systemDate.getMinutes()}
+                      name="minute"
+                      disabled={isSavingDate}
+                      onBlur={updateSystemTime}
+                      onChange={updateSystemTime}
+                      style={{
+                        width: '4.15rem',
+                      }}
+                    >
+                      <option value="" disabled>
+                        Minute
                       </option>
-                    ))}
-                  </Select>
-                  <Select
-                    data-testid="selectMeridian"
-                    value={systemMeridian}
-                    name="meridian"
-                    disabled={isSavingDate}
-                    onBlur={updateSystemTime}
-                    onChange={updateSystemTime}
-                    style={{
-                      width: '4.5rem',
-                    }}
-                  >
-                    {['AM', 'PM'].map((meridian) => (
-                      <option key={meridian} value={meridian}>
-                        {meridian}
+                      {[...Array(60).keys()].map((minute) => (
+                        <option key={minute} value={minute}>
+                          {minute < 10 ? `0${minute}` : minute}
+                        </option>
+                      ))}
+                    </Select>
+                    <Select
+                      data-testid="selectMeridian"
+                      value={systemMeridian}
+                      name="meridian"
+                      disabled={isSavingDate}
+                      onBlur={updateSystemTime}
+                      onChange={updateSystemTime}
+                      style={{
+                        width: '4.5rem',
+                      }}
+                    >
+                      {['AM', 'PM'].map((meridian) => (
+                        <option key={meridian} value={meridian}>
+                          {meridian}
+                        </option>
+                      ))}
+                    </Select>
+                  </InputGroup>
+                </p>
+                <p>
+                  <InputGroup as="span">
+                    <Select
+                      data-testid="selectTimezone"
+                      value={timezone}
+                      disabled={isSavingDate}
+                      onBlur={updateTimeZone}
+                      onChange={updateTimeZone}
+                    >
+                      <option value="UTC" disabled>
+                        Select timezone…
                       </option>
-                    ))}
-                  </Select>
-                </InputGroup>
-              </p>
-              <p>
-                <InputGroup as="span">
-                  <Select
-                    data-testid="selectTimezone"
-                    value={timezone}
-                    disabled={isSavingDate}
-                    onBlur={updateTimeZone}
-                    onChange={updateTimeZone}
-                  >
-                    <option value="UTC" disabled>
-                      Select timezone…
-                    </option>
-                    {AMERICA_TIMEZONES.map((tz) => (
-                      <option key={tz} value={tz}>
-                        {formatTimeZoneName(systemDate, tz)} (
-                        {tz.split('/')[1].replace(/_/gi, ' ')})
-                      </option>
-                    ))}
-                  </Select>
-                </InputGroup>
-              </p>
-            </div>
-          </Prose>
-        }
-        actions={
-          <React.Fragment>
-            <Button
-              disabled={!timezone || isSavingDate}
-              primary={!isSavingDate}
-              onPress={saveDateAndZone}
-            >
-              {isSavingDate ? 'Saving…' : 'Save'}
-            </Button>
-            <Button disabled={isSavingDate} onPress={cancelSystemDateEdit}>
-              Cancel
-            </Button>
-          </React.Fragment>
-        }
-      />
+                      {AMERICA_TIMEZONES.map((tz) => (
+                        <option key={tz} value={tz}>
+                          {formatTimeZoneName(systemDate, tz)} (
+                          {tz.split('/')[1].replace(/_/gi, ' ')})
+                        </option>
+                      ))}
+                    </Select>
+                  </InputGroup>
+                </p>
+              </div>
+            </Prose>
+          }
+          actions={
+            <React.Fragment>
+              <Button
+                disabled={!timezone || isSavingDate}
+                primary={!isSavingDate}
+                onPress={saveDateAndZone}
+              >
+                {isSavingDate ? 'Saving…' : 'Save'}
+              </Button>
+              <Button disabled={isSavingDate} onPress={cancelSystemDateEdit}>
+                Cancel
+              </Button>
+            </React.Fragment>
+          }
+        />
+      )}
     </Screen>
   )
 }

--- a/apps/bmd/src/pages/PollWorkerScreen.tsx
+++ b/apps/bmd/src/pages/PollWorkerScreen.tsx
@@ -253,78 +253,81 @@ const PollWorkerScreen: React.FC<Props> = ({
             <Text center>Remove card when finished.</Text>
           </Prose>
         </Sidebar>
-        <Modal
-          isOpen={isConfirmingPrintReport}
-          centerContent
-          content={
-            <Prose textCenter>
-              <p>
-                {isPollsOpen
-                  ? 'Close Polls and print Polls Closed report?'
-                  : 'Open polls and print Polls Opened report?'}
-              </p>
-            </Prose>
-          }
-          actions={
-            <React.Fragment>
-              <Button primary onPress={requestPrintReport}>
-                Yes
-              </Button>
-              <Button onPress={cancelConfirmPrint}>Cancel</Button>
-            </React.Fragment>
-          }
-        />
-        <Modal
-          isOpen={isPrintingReport}
-          centerContent
-          content={
-            <Prose textCenter>
-              <Loading as="p">
-                {isPollsOpen
-                  ? `Printing Polls Closed report for ${precinct.name}`
-                  : `Printing Polls Opened report for ${precinct.name}`}
-              </Loading>
-            </Prose>
-          }
-        />
-        <Modal
-          isOpen={isConfirmingEnableLiveMode}
-          centerContent
-          content={
-            <Prose textCenter>
-              {isPrintMode ? (
-                <h1>
-                  Switch to Live&nbsp;Election&nbsp;Mode and reset the tally of
-                  printed ballots?
-                </h1>
-              ) : (
-                <h1>Switch to Live&nbsp;Election&nbsp;Mode?</h1>
-              )}
-              <p>
-                Today is Election Day and this machine is in{' '}
-                <strong>Testing&nbsp;Mode.</strong>
-              </p>
-              <p>
-                <em>
-                  Note: Switching back to Testing&nbsp;Mode requires an
-                  Admin&nbsp;Card.
-                </em>
-              </p>
-            </Prose>
-          }
-          actions={
-            <React.Fragment>
-              <Button
-                primary
-                danger={isPrintMode}
-                onPress={confirmEnableLiveMode}
-              >
-                Switch to Live&nbsp;Mode
-              </Button>
-              <Button onPress={cancelEnableLiveMode}>Cancel</Button>
-            </React.Fragment>
-          }
-        />
+        {isConfirmingPrintReport && (
+          <Modal
+            centerContent
+            content={
+              <Prose textCenter>
+                <p>
+                  {isPollsOpen
+                    ? 'Close Polls and print Polls Closed report?'
+                    : 'Open polls and print Polls Opened report?'}
+                </p>
+              </Prose>
+            }
+            actions={
+              <React.Fragment>
+                <Button primary onPress={requestPrintReport}>
+                  Yes
+                </Button>
+                <Button onPress={cancelConfirmPrint}>Cancel</Button>
+              </React.Fragment>
+            }
+          />
+        )}
+        {isPrintingReport && (
+          <Modal
+            centerContent
+            content={
+              <Prose textCenter>
+                <Loading as="p">
+                  {isPollsOpen
+                    ? `Printing Polls Closed report for ${precinct.name}`
+                    : `Printing Polls Opened report for ${precinct.name}`}
+                </Loading>
+              </Prose>
+            }
+          />
+        )}
+        {isConfirmingEnableLiveMode && (
+          <Modal
+            centerContent
+            content={
+              <Prose textCenter>
+                {isPrintMode ? (
+                  <h1>
+                    Switch to Live&nbsp;Election&nbsp;Mode and reset the tally
+                    of printed ballots?
+                  </h1>
+                ) : (
+                  <h1>Switch to Live&nbsp;Election&nbsp;Mode?</h1>
+                )}
+                <p>
+                  Today is Election Day and this machine is in{' '}
+                  <strong>Testing&nbsp;Mode.</strong>
+                </p>
+                <p>
+                  <em>
+                    Note: Switching back to Testing&nbsp;Mode requires an
+                    Admin&nbsp;Card.
+                  </em>
+                </p>
+              </Prose>
+            }
+            actions={
+              <React.Fragment>
+                <Button
+                  primary
+                  danger={isPrintMode}
+                  onPress={confirmEnableLiveMode}
+                >
+                  Switch to Live&nbsp;Mode
+                </Button>
+                <Button onPress={cancelEnableLiveMode}>Cancel</Button>
+              </React.Fragment>
+            }
+          />
+        )}
       </Screen>
       {isPrintMode &&
         reportPurposes.map((reportPurpose) => (

--- a/apps/bsd/src/AppRoot.tsx
+++ b/apps/bsd/src/AppRoot.tsx
@@ -472,18 +472,19 @@ const App: React.FC = () => {
               </MainNav>
               <StatusFooter election={election} electionHash={electionHash} />
             </Screen>
-            <ExportResultsModal
-              isOpen={isExportingCVRs}
-              onClose={() => setIsExportingCVRs(false)}
-              usbDriveStatus={displayUsbStatus}
-              election={election}
-              electionHash={electionHash}
-              isTestMode={isTestMode}
-              numberOfBallots={status.batches.reduce(
-                (prev, next) => prev + next.count,
-                0
-              )}
-            />
+            {isExportingCVRs && (
+              <ExportResultsModal
+                onClose={() => setIsExportingCVRs(false)}
+                usbDriveStatus={displayUsbStatus}
+                election={election}
+                electionHash={electionHash}
+                isTestMode={isTestMode}
+                numberOfBallots={status.batches.reduce(
+                  (prev, next) => prev + next.count,
+                  0
+                )}
+              />
+            )}
           </Route>
         </Switch>
       </AppContext.Provider>

--- a/apps/bsd/src/components/ExportResultsModal.test.tsx
+++ b/apps/bsd/src/components/ExportResultsModal.test.tsx
@@ -19,7 +19,6 @@ test('renders loading screen when usb drive is mounting or ejecting in export mo
     const { getByText, unmount } = render(
       <Router history={createMemoryHistory()}>
         <ExportResultsModal
-          isOpen
           onClose={closeFn}
           usbDriveStatus={status}
           election={electionSample}
@@ -46,7 +45,6 @@ test('render no usb found screen when there is not a mounted usb drive', () => {
     const { getByText, unmount, getByAltText } = render(
       <Router history={createMemoryHistory()}>
         <ExportResultsModal
-          isOpen
           onClose={closeFn}
           usbDriveStatus={status}
           election={electionSample}
@@ -85,7 +83,6 @@ test('render export modal when a usb drive is mounted as expected and allows cus
   const { getByText, getByAltText } = render(
     <Router history={createMemoryHistory()}>
       <ExportResultsModal
-        isOpen
         onClose={closeFn}
         usbDriveStatus={UsbDriveStatus.mounted}
         election={electionSample}
@@ -125,7 +122,6 @@ test('render export modal when a usb drive is mounted as expected and allows aut
   const { getByText } = render(
     <Router history={createMemoryHistory()}>
       <ExportResultsModal
-        isOpen
         onClose={closeFn}
         usbDriveStatus={UsbDriveStatus.mounted}
         election={electionSample}
@@ -154,10 +150,9 @@ test('render export modal when a usb drive is mounted as expected and allows aut
   getByText('Eject USB')
   fireEvent.click(getByText('Cancel'))
   expect(closeFn).toHaveBeenCalled()
-  getByText('Export Results') // Closing should reset back to the starting export screen
 })
 
-test('render export modal with errors when appropriate and clears errors when closed', async () => {
+test('render export modal with errors when appropriate', async () => {
   const mockKiosk = fakeKiosk()
   window.kiosk = mockKiosk
 
@@ -169,7 +164,6 @@ test('render export modal with errors when appropriate and clears errors when cl
   const { getByText } = render(
     <Router history={createMemoryHistory()}>
       <ExportResultsModal
-        isOpen
         onClose={closeFn}
         usbDriveStatus={UsbDriveStatus.mounted}
         election={electionSample}
@@ -188,5 +182,4 @@ test('render export modal with errors when appropriate and clears errors when cl
 
   fireEvent.click(getByText('Close'))
   expect(closeFn).toHaveBeenCalled()
-  getByText('Export Results') // Closing should reset back to the starting export screen
 })

--- a/apps/bsd/src/components/ExportResultsModal.tsx
+++ b/apps/bsd/src/components/ExportResultsModal.tsx
@@ -29,7 +29,6 @@ const USBImage = styled.img`
 `
 
 export interface Props {
-  isOpen: boolean
   onClose: () => void
   usbDriveStatus: UsbDriveStatus
   election: Election
@@ -46,8 +45,7 @@ enum ModalState {
 }
 
 const ExportResultsModal: React.FC<Props> = ({
-  isOpen,
-  onClose: onCloseFromProps,
+  onClose,
   usbDriveStatus,
   election,
   electionHash,
@@ -58,12 +56,6 @@ const ExportResultsModal: React.FC<Props> = ({
   const [errorMessage, setErrorMessage] = useState('')
 
   const { machineConfig } = useContext(AppContext)
-
-  const onClose = () => {
-    setErrorMessage('')
-    setCurrentState(ModalState.INIT)
-    onCloseFromProps()
-  }
 
   const exportResults = async (openDialog: boolean) => {
     setCurrentState(ModalState.SAVING)
@@ -138,7 +130,6 @@ const ExportResultsModal: React.FC<Props> = ({
   if (currentState === ModalState.ERROR) {
     return (
       <Modal
-        isOpen={isOpen}
         content={
           <Prose>
             <h1>Download Failed</h1>
@@ -163,7 +154,6 @@ const ExportResultsModal: React.FC<Props> = ({
     }
     return (
       <Modal
-        isOpen={isOpen}
         content={
           <Prose>
             <h1>Download Complete</h1>
@@ -180,9 +170,7 @@ const ExportResultsModal: React.FC<Props> = ({
   }
 
   if (currentState === ModalState.SAVING) {
-    return (
-      <Modal isOpen={isOpen} content={<Loading />} onOverlayClick={onClose} />
-    )
+    return <Modal content={<Loading />} onOverlayClick={onClose} />
   }
 
   if (currentState !== ModalState.INIT) {
@@ -197,7 +185,6 @@ const ExportResultsModal: React.FC<Props> = ({
       // on the machine for internal debugging use
       return (
         <Modal
-          isOpen={isOpen}
           content={
             <Prose>
               <h1>No USB Drive Detected</h1>
@@ -228,7 +215,6 @@ const ExportResultsModal: React.FC<Props> = ({
     case UsbDriveStatus.present:
       return (
         <Modal
-          isOpen={isOpen}
           content={<Loading />}
           onOverlayClick={onClose}
           actions={
@@ -241,7 +227,6 @@ const ExportResultsModal: React.FC<Props> = ({
     case UsbDriveStatus.mounted:
       return (
         <Modal
-          isOpen={isOpen}
           content={
             <Prose>
               <h1>Export Results</h1>

--- a/apps/bsd/src/components/Modal.tsx
+++ b/apps/bsd/src/components/Modal.tsx
@@ -23,7 +23,6 @@ const ModalContent = styled('div')<ModalContentInterface>`
 `
 
 interface Props {
-  isOpen: boolean
   ariaLabel?: string
   className?: string
   content?: ReactNode
@@ -39,7 +38,6 @@ const Modal: React.FC<Props> = ({
   centerContent,
   className = '',
   content,
-  isOpen,
   onAfterOpen = () => {
     window.setTimeout(() => {
       const element = document.getElementById('modalaudiofocus')
@@ -58,7 +56,7 @@ const Modal: React.FC<Props> = ({
     ariaHideApp
     aria-modal
     role="alertdialog"
-    isOpen={isOpen}
+    isOpen
     contentLabel={ariaLabel}
     portalClassName="modal-portal"
     className={`modal-content ${className}`}

--- a/apps/bsd/src/components/ToggleTestModeButton.tsx
+++ b/apps/bsd/src/components/ToggleTestModeButton.tsx
@@ -43,40 +43,41 @@ const ToggleTestModeButton: React.FC<Props> = ({
           ? 'Toggle to Live Mode'
           : 'Toggle to Test Mode'}
       </Button>
-      <Modal
-        isOpen={isConfirming}
-        centerContent
-        content={
-          <Prose textCenter>
-            <h1>
-              {isTogglingTestMode
-                ? isTestMode
-                  ? 'Toggling to Live Mode'
-                  : 'Toggling to Test Mode'
-                : isTestMode
-                ? 'Toggle to Live Mode'
-                : 'Toggle to Test Mode'}
-            </h1>
-            <p>
-              {isTogglingTestMode
-                ? 'Zeroing out scanned ballots and reloading…'
-                : 'Toggling test mode will zero out your scanned ballots. Are you sure?'}
-            </p>
-          </Prose>
-        }
-        actions={
-          !isTogglingTestMode && (
-            <React.Fragment>
-              <Button onPress={toggleIsConfirming}>Cancel</Button>
-              <Button ref={defaultButtonRef} primary onPress={toggleTestMode}>
-                {isTestMode ? 'Toggle to Live Mode' : 'Toggle to Test Mode'}
-              </Button>
-            </React.Fragment>
-          )
-        }
-        onOverlayClick={toggleIsConfirming}
-        onAfterOpen={focusDefaultButton}
-      />
+      {isConfirming && (
+        <Modal
+          centerContent
+          content={
+            <Prose textCenter>
+              <h1>
+                {isTogglingTestMode
+                  ? isTestMode
+                    ? 'Toggling to Live Mode'
+                    : 'Toggling to Test Mode'
+                  : isTestMode
+                  ? 'Toggle to Live Mode'
+                  : 'Toggle to Test Mode'}
+              </h1>
+              <p>
+                {isTogglingTestMode
+                  ? 'Zeroing out scanned ballots and reloading…'
+                  : 'Toggling test mode will zero out your scanned ballots. Are you sure?'}
+              </p>
+            </Prose>
+          }
+          actions={
+            !isTogglingTestMode && (
+              <React.Fragment>
+                <Button onPress={toggleIsConfirming}>Cancel</Button>
+                <Button ref={defaultButtonRef} primary onPress={toggleTestMode}>
+                  {isTestMode ? 'Toggle to Live Mode' : 'Toggle to Test Mode'}
+                </Button>
+              </React.Fragment>
+            )
+          }
+          onOverlayClick={toggleIsConfirming}
+          onAfterOpen={focusDefaultButton}
+        />
+      )}
     </React.Fragment>
   )
 }

--- a/apps/bsd/src/screens/AdvancedOptionsScreen.tsx
+++ b/apps/bsd/src/screens/AdvancedOptionsScreen.tsx
@@ -91,47 +91,49 @@ const AdvancedOptionsScreen: React.FC<Props> = ({
           </LinkButton>
         </MainNav>
       </Screen>
-      <Modal
-        isOpen={isConfirmingZero}
-        centerContent
-        content={
-          <Prose textCenter>
-            <h1>Delete All Scanned Ballot Data?</h1>
-            <p>
-              This will permanently delete all scanned ballot data and reset the
-              scanner to only be configured with the current election.
-            </p>
-          </Prose>
-        }
-        actions={
-          <React.Fragment>
-            <Button onPress={toggleIsConfirmingZero}>Cancel</Button>
-            <Button danger onPress={zeroData}>
-              Yes, Delete Ballot Data
-            </Button>
-          </React.Fragment>
-        }
-        onOverlayClick={toggleIsConfirmingZero}
-      />
-      <Modal
-        isOpen={isConfirmingFactoryReset}
-        centerContent
-        content={
-          <Prose textCenter>
-            <h1>Factory Reset?</h1>
-            <p>Remove election configuration and all scanned ballot data?</p>
-          </Prose>
-        }
-        actions={
-          <React.Fragment>
-            <Button onPress={toggleIsConfirmingFactoryReset}>Cancel</Button>
-            <Button danger onPress={unconfigureServer}>
-              Yes, Factory Reset
-            </Button>
-          </React.Fragment>
-        }
-        onOverlayClick={toggleIsConfirmingFactoryReset}
-      />
+      {isConfirmingZero && (
+        <Modal
+          centerContent
+          content={
+            <Prose textCenter>
+              <h1>Delete All Scanned Ballot Data?</h1>
+              <p>
+                This will permanently delete all scanned ballot data and reset
+                the scanner to only be configured with the current election.
+              </p>
+            </Prose>
+          }
+          actions={
+            <React.Fragment>
+              <Button onPress={toggleIsConfirmingZero}>Cancel</Button>
+              <Button danger onPress={zeroData}>
+                Yes, Delete Ballot Data
+              </Button>
+            </React.Fragment>
+          }
+          onOverlayClick={toggleIsConfirmingZero}
+        />
+      )}
+      {isConfirmingFactoryReset && (
+        <Modal
+          centerContent
+          content={
+            <Prose textCenter>
+              <h1>Factory Reset?</h1>
+              <p>Remove election configuration and all scanned ballot data?</p>
+            </Prose>
+          }
+          actions={
+            <React.Fragment>
+              <Button onPress={toggleIsConfirmingFactoryReset}>Cancel</Button>
+              <Button danger onPress={unconfigureServer}>
+                Yes, Factory Reset
+              </Button>
+            </React.Fragment>
+          }
+          onOverlayClick={toggleIsConfirmingFactoryReset}
+        />
+      )}
     </React.Fragment>
   )
 }

--- a/apps/election-manager/src/components/ConfirmRemovingFileModal.tsx
+++ b/apps/election-manager/src/components/ConfirmRemovingFileModal.tsx
@@ -10,13 +10,11 @@ import Prose from './Prose'
 import Modal from './Modal'
 
 export interface Props {
-  isOpen: boolean
   onClose: () => void
   fileType: ResultsFileType
 }
 
 export const ConfirmRemovingFileModal: React.FC<Props> = ({
-  isOpen,
   onClose,
   fileType,
 }) => {
@@ -82,7 +80,6 @@ export const ConfirmRemovingFileModal: React.FC<Props> = ({
 
   return (
     <Modal
-      isOpen={isOpen}
       centerContent
       content={<Prose textCenter>{mainContent}</Prose>}
       actions={

--- a/apps/election-manager/src/components/ExportElectionBallotPackageModalButton.tsx
+++ b/apps/election-manager/src/components/ExportElectionBallotPackageModalButton.tsx
@@ -316,12 +316,13 @@ const ExportElectionBallotPackageModalButton: React.FC = () => {
       <LinkButton small onPress={() => setIsModalOpen(true)}>
         Export Ballot Package
       </LinkButton>
-      <Modal
-        isOpen={isModalOpen}
-        content={mainContent}
-        onOverlayClick={closeModal}
-        actions={actions}
-      />
+      {isModalOpen && (
+        <Modal
+          content={mainContent}
+          onOverlayClick={closeModal}
+          actions={actions}
+        />
+      )}
     </React.Fragment>
   )
 }

--- a/apps/election-manager/src/components/ExportFinalResultsModal.test.tsx
+++ b/apps/election-manager/src/components/ExportFinalResultsModal.test.tsx
@@ -26,7 +26,7 @@ test('renders loading screen when usb drive is mounting or ejecting in export mo
   for (const status of usbStatuses) {
     const closeFn = jest.fn()
     const { getByText, unmount } = renderInAppContext(
-      <ExportFinalResultsModal isOpen onClose={closeFn} />,
+      <ExportFinalResultsModal onClose={closeFn} />,
       { usbDriveStatus: status }
     )
     getByText('Loading')
@@ -43,13 +43,11 @@ test('render no usb found screen when there is not a mounted usb drive', () => {
 
   for (const status of usbStatuses) {
     const closeFn = jest.fn()
-    const {
-      getByText,
-      unmount,
-      getByAltText,
-    } = renderInAppContext(
-      <ExportFinalResultsModal isOpen onClose={closeFn} />,
-      { usbDriveStatus: status }
+    const { getByText, unmount, getByAltText } = renderInAppContext(
+      <ExportFinalResultsModal onClose={closeFn} />,
+      {
+        usbDriveStatus: status,
+      }
     )
     getByText('No USB Drive Detected')
     getByText(
@@ -83,7 +81,7 @@ test('render export modal when a usb drive is mounted as expected and allows aut
 
   const closeFn = jest.fn()
   const { getByText } = renderInAppContext(
-    <ExportFinalResultsModal isOpen onClose={closeFn} />,
+    <ExportFinalResultsModal onClose={closeFn} />,
     {
       usbDriveStatus: UsbDriveStatus.mounted,
     }
@@ -138,7 +136,7 @@ test('render export modal when a usb drive is mounted and exports with external 
   const externalFile = new File(['content'], 'to-combine.csv')
   const closeFn = jest.fn()
   const { getByText } = renderInAppContext(
-    <ExportFinalResultsModal isOpen onClose={closeFn} />,
+    <ExportFinalResultsModal onClose={closeFn} />,
     {
       usbDriveStatus: UsbDriveStatus.mounted,
       fullElectionExternalTally: {
@@ -178,7 +176,7 @@ test('render export modal when a usb drive is mounted and exports with external 
   expect(closeFn).toHaveBeenCalled()
 })
 
-test('render export modal with errors when appropriate and clears errors when closed', async () => {
+test('render export modal with errors when appropriate', async () => {
   const mockKiosk = fakeKiosk()
   window.kiosk = mockKiosk
 
@@ -190,7 +188,7 @@ test('render export modal with errors when appropriate and clears errors when cl
 
   const closeFn = jest.fn()
   const { getByText } = renderInAppContext(
-    <ExportFinalResultsModal isOpen onClose={closeFn} />,
+    <ExportFinalResultsModal onClose={closeFn} />,
     {
       usbDriveStatus: UsbDriveStatus.mounted,
     }
@@ -204,5 +202,4 @@ test('render export modal with errors when appropriate and clears errors when cl
 
   fireEvent.click(getByText('Close'))
   expect(closeFn).toHaveBeenCalled()
-  getByText('Save Results File') // Closing should reset back to the starting export screen
 })

--- a/apps/election-manager/src/components/ExportFinalResultsModal.tsx
+++ b/apps/election-manager/src/components/ExportFinalResultsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useContext, useMemo, useState } from 'react'
 import styled from 'styled-components'
 import path from 'path'
 import fileDownload from 'js-file-download'
@@ -23,7 +23,6 @@ const USBImage = styled.img`
 `
 
 export interface Props {
-  isOpen: boolean
   onClose: () => void
 }
 
@@ -34,47 +33,28 @@ enum ModalState {
   INIT = 'init',
 }
 
-const ExportFinalResultsModal: React.FC<Props> = ({
-  isOpen,
-  onClose: onCloseFromProps,
-}) => {
+const ExportFinalResultsModal: React.FC<Props> = ({ onClose }) => {
   const {
     usbDriveStatus,
     castVoteRecordFiles,
     electionDefinition,
     externalVoteRecordsFile,
   } = useContext(AppContext)
+  const isTestMode = castVoteRecordFiles?.fileMode === 'test'
 
   const [currentState, setCurrentState] = useState(ModalState.INIT)
   const [errorMessage, setErrorMessage] = useState('')
 
   const [savedFilename, setSavedFilename] = useState('')
   const [includeExternalFile, setIncludeExternalFile] = useState(true)
-  const [defaultFilename, setDefaultFilename] = useState('')
-
-  const isTestMode = castVoteRecordFiles?.fileMode === 'test'
-
-  /*
-   * We use useEffect here since this Modal is rendered even when the Modal
-   * is closed, i.e. when isOpen is false. We want to "reset" the filename whenever
-   * the modal opens again but not on every render of the dialog.
-   */
-  useEffect(() => {
-    setDefaultFilename(
+  const defaultFilename = useMemo(
+    () =>
       generateFinalExportDefaultFilename(
         isTestMode,
         electionDefinition!.election
-      )
-    )
-  }, [isOpen])
-
-  const onClose = () => {
-    setErrorMessage('')
-    setCurrentState(ModalState.INIT)
-    setSavedFilename('')
-    setDefaultFilename('')
-    onCloseFromProps()
-  }
+      ),
+    []
+  )
 
   const exportResults = async (
     openFileDialog: boolean,
@@ -160,7 +140,6 @@ const ExportFinalResultsModal: React.FC<Props> = ({
   if (currentState === ModalState.ERROR) {
     return (
       <Modal
-        isOpen={isOpen}
         content={
           <Prose>
             <h1>Saving Results Failed</h1>
@@ -185,7 +164,6 @@ const ExportFinalResultsModal: React.FC<Props> = ({
     }
     return (
       <Modal
-        isOpen={isOpen}
         content={
           <Prose>
             <h1>Results File Saved</h1>
@@ -210,7 +188,6 @@ const ExportFinalResultsModal: React.FC<Props> = ({
   if (currentState === ModalState.SAVING) {
     return (
       <Modal
-        isOpen={isOpen}
         content={<Loading>Saving Results File</Loading>}
         onOverlayClick={onClose}
       />
@@ -229,7 +206,6 @@ const ExportFinalResultsModal: React.FC<Props> = ({
       // on the machine for internal debugging use
       return (
         <Modal
-          isOpen={isOpen}
           content={
             <Prose>
               <h1>No USB Drive Detected</h1>
@@ -260,7 +236,6 @@ const ExportFinalResultsModal: React.FC<Props> = ({
     case UsbDriveStatus.present:
       return (
         <Modal
-          isOpen={isOpen}
           content={<Loading />}
           onOverlayClick={onClose}
           actions={
@@ -297,7 +272,6 @@ const ExportFinalResultsModal: React.FC<Props> = ({
       }
       return (
         <Modal
-          isOpen={isOpen}
           content={
             <MainChild>
               <Prose>

--- a/apps/election-manager/src/components/ImportCVRFilesModal.test.tsx
+++ b/apps/election-manager/src/components/ImportCVRFilesModal.test.tsx
@@ -29,7 +29,7 @@ test('No USB screen shows when there is no USB drive', async () => {
   for (const usbStatus of usbStatuses) {
     const closeFn = jest.fn()
     const { unmount, getByText } = renderInAppContext(
-      <ImportCVRFilesModal isOpen onClose={closeFn} />,
+      <ImportCVRFilesModal onClose={closeFn} />,
       { usbDriveStatus: usbStatus }
     )
     getByText('No USB Drive Detected')
@@ -46,7 +46,7 @@ test('Loading screen show while usb is mounting or ejecting', async () => {
   for (const usbStatus of usbStatuses) {
     const closeFn = jest.fn()
     const { unmount, getByText } = renderInAppContext(
-      <ImportCVRFilesModal isOpen onClose={closeFn} />,
+      <ImportCVRFilesModal onClose={closeFn} />,
       { usbDriveStatus: usbStatus }
     )
     getByText('Loading')
@@ -69,7 +69,7 @@ describe('Screens display properly when USB is mounted', () => {
     const closeFn = jest.fn()
     const saveCVR = jest.fn()
     const { getByText, getByTestId } = renderInAppContext(
-      <ImportCVRFilesModal isOpen onClose={closeFn} />,
+      <ImportCVRFilesModal onClose={closeFn} />,
       {
         usbDriveStatus: UsbDriveStatus.mounted,
         saveCastVoteRecordFiles: saveCVR,
@@ -116,7 +116,7 @@ describe('Screens display properly when USB is mounted', () => {
       .fn()
       .mockResolvedValue(fileEntries)
     const { getByText, getAllByTestId } = renderInAppContext(
-      <ImportCVRFilesModal isOpen onClose={closeFn} />,
+      <ImportCVRFilesModal onClose={closeFn} />,
       {
         usbDriveStatus: UsbDriveStatus.mounted,
         saveCastVoteRecordFiles: saveCVR,
@@ -187,7 +187,7 @@ describe('Screens display properly when USB is mounted', () => {
       .fn()
       .mockResolvedValue(fileEntries)
     const { getByText, getAllByTestId } = renderInAppContext(
-      <ImportCVRFilesModal isOpen onClose={closeFn} />,
+      <ImportCVRFilesModal onClose={closeFn} />,
       {
         usbDriveStatus: UsbDriveStatus.mounted,
         saveCastVoteRecordFiles: saveCVR,
@@ -257,7 +257,7 @@ describe('Screens display properly when USB is mounted', () => {
       defaultElectionDefinition.election
     )
     const { getByText, getAllByTestId } = renderInAppContext(
-      <ImportCVRFilesModal isOpen onClose={closeFn} />,
+      <ImportCVRFilesModal onClose={closeFn} />,
       {
         usbDriveStatus: UsbDriveStatus.mounted,
         castVoteRecordFiles: added,
@@ -342,7 +342,7 @@ describe('Screens display properly when USB is mounted', () => {
       defaultElectionDefinition.election
     )
     const { getByText, getAllByTestId } = renderInAppContext(
-      <ImportCVRFilesModal isOpen onClose={closeFn} />,
+      <ImportCVRFilesModal onClose={closeFn} />,
       {
         usbDriveStatus: UsbDriveStatus.mounted,
         castVoteRecordFiles: added,
@@ -403,7 +403,7 @@ describe('Screens display properly when USB is mounted', () => {
       defaultElectionDefinition.election
     )
     const { getByText, getAllByTestId } = renderInAppContext(
-      <ImportCVRFilesModal isOpen onClose={closeFn} />,
+      <ImportCVRFilesModal onClose={closeFn} />,
       {
         usbDriveStatus: UsbDriveStatus.mounted,
         castVoteRecordFiles: added,

--- a/apps/election-manager/src/components/ImportCVRFilesModal.tsx
+++ b/apps/election-manager/src/components/ImportCVRFilesModal.tsx
@@ -57,7 +57,6 @@ enum ModalState {
 }
 
 export interface Props {
-  isOpen: boolean
   onClose: () => void
 }
 
@@ -65,10 +64,7 @@ function throwBadStatus(s: never): never {
   throw new Error(`Bad status: ${s}`)
 }
 
-const ImportCVRFilesModal: React.FC<Props> = ({
-  isOpen,
-  onClose: onCloseFromProps,
-}) => {
+const ImportCVRFilesModal: React.FC<Props> = ({ onClose }) => {
   const {
     usbDriveStatus,
     saveCastVoteRecordFiles,
@@ -80,11 +76,6 @@ const ImportCVRFilesModal: React.FC<Props> = ({
     []
   )
   const { election, electionHash } = electionDefinition!
-
-  const onClose = () => {
-    setCurrentState(ModalState.INIT)
-    onCloseFromProps()
-  }
 
   const importSelectedFile = async (
     fileEntry: KioskBrowser.FileSystemEntry
@@ -168,7 +159,6 @@ const ImportCVRFilesModal: React.FC<Props> = ({
   if (currentState === ModalState.ERROR) {
     return (
       <Modal
-        isOpen={isOpen}
         content={
           <Prose>
             <h1>Error</h1>
@@ -193,7 +183,6 @@ const ImportCVRFilesModal: React.FC<Props> = ({
   if (currentState === ModalState.DUPLICATE) {
     return (
       <Modal
-        isOpen={isOpen}
         content={
           <Prose>
             <h1>Duplicate File</h1>
@@ -216,7 +205,6 @@ const ImportCVRFilesModal: React.FC<Props> = ({
   ) {
     return (
       <Modal
-        isOpen={isOpen}
         content={<Loading />}
         onOverlayClick={onClose}
         actions={
@@ -237,7 +225,6 @@ const ImportCVRFilesModal: React.FC<Props> = ({
   ) {
     return (
       <Modal
-        isOpen={isOpen}
         content={
           <Prose>
             <h1>No USB Drive Detected</h1>
@@ -357,7 +344,6 @@ const ImportCVRFilesModal: React.FC<Props> = ({
 
     return (
       <Modal
-        isOpen={isOpen}
         className="import-cvr-modal"
         content={
           <MainChild>

--- a/apps/election-manager/src/components/Modal.tsx
+++ b/apps/election-manager/src/components/Modal.tsx
@@ -23,7 +23,6 @@ const ModalContent = styled('div')<ModalContentInterface>`
 `
 
 interface Props {
-  isOpen: boolean
   ariaLabel?: string
   className?: string
   content?: ReactNode
@@ -39,7 +38,6 @@ const Modal: React.FC<Props> = ({
   centerContent,
   className = '',
   content,
-  isOpen,
   onAfterOpen = () => {
     window.setTimeout(() => {
       const element = document.getElementById('modalaudiofocus')
@@ -58,7 +56,7 @@ const Modal: React.FC<Props> = ({
     ariaHideApp
     aria-modal
     role="alertdialog"
-    isOpen={isOpen}
+    isOpen
     contentLabel={ariaLabel}
     portalClassName="modal-portal"
     className={`modal-content ${className}`}

--- a/apps/election-manager/src/components/PrintButton.tsx
+++ b/apps/election-manager/src/components/PrintButton.tsx
@@ -86,38 +86,38 @@ const PrintButton: React.FC<React.PropsWithChildren<PrintButtonProps>> = ({
       <Button onPress={confirmModal ? initConfirmModal : print} {...rest}>
         {children}
       </Button>
-      <Modal
-        isOpen={isPrinting}
-        centerContent
-        content={<Loading>Printing</Loading>}
-      />
-      <Modal
-        isOpen={isConfirming}
-        centerContent
-        content={confirmModal?.content}
-        actions={
-          <React.Fragment>
-            <Button onPress={cancelPrint}>Cancel</Button>
-            <Button onPress={confirmPrint} primary>
-              {confirmModal?.confirmButtonLabel ?? 'Print'}
-            </Button>
-          </React.Fragment>
-        }
-      />
-      <Modal
-        isOpen={showPrintingError}
-        content={
-          <Prose>
-            <h2>The printer is not connected.</h2>
-            <p>Please connect the printer and try again.</p>
-          </Prose>
-        }
-        actions={
-          <React.Fragment>
-            <Button onPress={donePrintingError}>OK</Button>
-          </React.Fragment>
-        }
-      />
+      {isPrinting && (
+        <Modal centerContent content={<Loading>Printing</Loading>} />
+      )}
+      {isConfirming && (
+        <Modal
+          centerContent
+          content={confirmModal?.content}
+          actions={
+            <React.Fragment>
+              <Button onPress={cancelPrint}>Cancel</Button>
+              <Button onPress={confirmPrint} primary>
+                {confirmModal?.confirmButtonLabel ?? 'Print'}
+              </Button>
+            </React.Fragment>
+          }
+        />
+      )}
+      {showPrintingError && (
+        <Modal
+          content={
+            <Prose>
+              <h2>The printer is not connected.</h2>
+              <p>Please connect the printer and try again.</p>
+            </Prose>
+          }
+          actions={
+            <React.Fragment>
+              <Button onPress={donePrintingError}>OK</Button>
+            </React.Fragment>
+          }
+        />
+      )}
     </React.Fragment>
   )
 }

--- a/apps/election-manager/src/screens/DefinitionEditorScreen.tsx
+++ b/apps/election-manager/src/screens/DefinitionEditorScreen.tsx
@@ -133,24 +133,25 @@ const DefinitionEditorScreen: React.FC = () => {
           <Textarea onChange={editElection} value={electionString} />
         </FlexTextareaWrapper>
       </NavigationScreen>
-      <Modal
-        isOpen={isConfimingUnconfig}
-        centerContent
-        content={
-          <Prose textCenter>
-            <p>Do you want to remove the current election definition?</p>
-            <p>All data will be removed from this app.</p>
-          </Prose>
-        }
-        actions={
-          <React.Fragment>
-            <Button onPress={cancelConfirmingUnconfig}>Cancel</Button>
-            <Button danger onPress={unconfigureElection}>
-              Remove Election Definition
-            </Button>
-          </React.Fragment>
-        }
-      />
+      {isConfimingUnconfig && (
+        <Modal
+          centerContent
+          content={
+            <Prose textCenter>
+              <p>Do you want to remove the current election definition?</p>
+              <p>All data will be removed from this app.</p>
+            </Prose>
+          }
+          actions={
+            <React.Fragment>
+              <Button onPress={cancelConfirmingUnconfig}>Cancel</Button>
+              <Button danger onPress={unconfigureElection}>
+                Remove Election Definition
+              </Button>
+            </React.Fragment>
+          }
+        />
+      )}
     </React.Fragment>
   )
 }

--- a/apps/election-manager/src/screens/PrintTestDeckScreen.tsx
+++ b/apps/election-manager/src/screens/PrintTestDeckScreen.tsx
@@ -144,7 +144,6 @@ const PrintTestDeckScreen: React.FC = () => {
       <React.Fragment>
         {precinctIndex !== undefined && currentPrecinct && (
           <Modal
-            isOpen
             centerContent
             content={
               <Loading as="p">

--- a/apps/election-manager/src/screens/TallyScreen.tsx
+++ b/apps/election-manager/src/screens/TallyScreen.tsx
@@ -434,65 +434,68 @@ const TallyScreen: React.FC = () => {
           </React.Fragment>
         )}
       </NavigationScreen>
-      <ConfirmRemovingFileModal
-        isOpen={!!confirmingRemoveFileType}
-        fileType={confirmingRemoveFileType || ResultsFileType.CastVoteRecord}
-        onClose={cancelConfirmingRemoveFiles}
-      />
-      <Modal
-        isOpen={isConfirmingOfficial}
-        centerContent
-        content={
-          <Prose textCenter>
-            <h1>Mark Unofficial Tally Results as Official Tally Results?</h1>
-            <p>
-              Have all CVR files been loaded? Once results are marked as
-              official, no additional CVRs can be loaded.
-            </p>
-            <p>Have all unofficial tally reports been reviewed?</p>
-          </Prose>
-        }
-        actions={
-          <React.Fragment>
-            <Button onPress={cancelConfirmingOfficial}>Cancel</Button>
-            <Button primary onPress={setOfficial}>
-              Mark Tally Results as Official
-            </Button>
-          </React.Fragment>
-        }
-        onOverlayClick={cancelConfirmingOfficial}
-      />
-      <Modal
-        isOpen={isImportExternalModalOpen}
-        onOverlayClick={() => setIsImportExternalModalOpen(false)}
-        actions={
-          <LinkButton
-            disabled={isTabulationRunning}
-            onPress={() => setIsImportExternalModalOpen(false)}
-          >
-            Close
-          </LinkButton>
-        }
-        content={
-          isTabulationRunning ? (
-            <Loading> Tabulating Results ... </Loading>
-          ) : (
-            <Prose>
-              <h1>Error</h1>
-              <p>{externalImportErrorMessage}</p>
+      {confirmingRemoveFileType && (
+        <ConfirmRemovingFileModal
+          fileType={confirmingRemoveFileType || ResultsFileType.CastVoteRecord}
+          onClose={cancelConfirmingRemoveFiles}
+        />
+      )}
+      {isConfirmingOfficial && (
+        <Modal
+          centerContent
+          content={
+            <Prose textCenter>
+              <h1>Mark Unofficial Tally Results as Official Tally Results?</h1>
+              <p>
+                Have all CVR files been loaded? Once results are marked as
+                official, no additional CVRs can be loaded.
+              </p>
+              <p>Have all unofficial tally reports been reviewed?</p>
             </Prose>
-          )
-        }
-      />
+          }
+          actions={
+            <React.Fragment>
+              <Button onPress={cancelConfirmingOfficial}>Cancel</Button>
+              <Button primary onPress={setOfficial}>
+                Mark Tally Results as Official
+              </Button>
+            </React.Fragment>
+          }
+          onOverlayClick={cancelConfirmingOfficial}
+        />
+      )}
+      {isImportExternalModalOpen && (
+        <Modal
+          onOverlayClick={() => setIsImportExternalModalOpen(false)}
+          actions={
+            <LinkButton
+              disabled={isTabulationRunning}
+              onPress={() => setIsImportExternalModalOpen(false)}
+            >
+              Close
+            </LinkButton>
+          }
+          content={
+            isTabulationRunning ? (
+              <Loading> Tabulating Results ... </Loading>
+            ) : (
+              <Prose>
+                <h1>Error</h1>
+                <p>{externalImportErrorMessage}</p>
+              </Prose>
+            )
+          }
+        />
+      )}
 
-      <ImportCVRFilesModal
-        isOpen={isImportCVRModalOpen}
-        onClose={() => setIsImportCVRModalOpen(false)}
-      />
-      <ExportFinalResultsModal
-        isOpen={isExportResultsModalOpen}
-        onClose={() => setIsExportResultsModalOpen(false)}
-      />
+      {isImportCVRModalOpen && (
+        <ImportCVRFilesModal onClose={() => setIsImportCVRModalOpen(false)} />
+      )}
+      {isExportResultsModalOpen && (
+        <ExportFinalResultsModal
+          onClose={() => setIsExportResultsModalOpen(false)}
+        />
+      )}
     </React.Fragment>
   )
 }

--- a/apps/election-manager/src/screens/UnconfiguredScreen.tsx
+++ b/apps/election-manager/src/screens/UnconfiguredScreen.tsx
@@ -211,7 +211,6 @@ const UnconfiguredScreen: React.FC = () => {
     return (
       <NavigationScreen>
         <Modal
-          isOpen
           centerContent
           content={
             <Prose textCenter>


### PR DESCRIPTION
Rather than exposing the `isOpen` property from `react-modal`, just selectively render modals when they're needed. This means that modal state lifetime no longer matches that of their parent components, which in the case of `ExportFinalResultsModal` means we could remove the state-reset code that was triggered when it was closed.