### PR TITLE
fix(bmd): read proposition text in audio track

### DIFF
--- a/apps/bmd/src/components/YesNoContest.test.tsx
+++ b/apps/bmd/src/components/YesNoContest.test.tsx
@@ -5,7 +5,8 @@ import { YesNoContest as YesNoContestInterface } from '@votingworks/types'
 import YesNoContest from './YesNoContest'
 
 const contest: YesNoContestInterface = {
-  description: 'description',
+  description:
+    'Institute a garbage collection program that collects garbage on weekdays across the county.',
   districtId: 'district-id',
   id: 'contest-id',
   section: 'County',

--- a/apps/bmd/src/components/YesNoContest.tsx
+++ b/apps/bmd/src/components/YesNoContest.tsx
@@ -153,6 +153,7 @@ const YesNoContest: React.FC<Props> = ({ contest, vote, updateVote }) => {
             <p>
               <strong>Vote Yes or No.</strong>
               <span className="screen-reader-only">
+                {contest.description}
                 To navigate through the contest choices, use the down button. To
                 move to the next contest, use the right button.
               </span>

--- a/apps/bmd/src/components/__snapshots__/YesNoContest.test.tsx.snap
+++ b/apps/bmd/src/components/__snapshots__/YesNoContest.test.tsx.snap
@@ -245,6 +245,7 @@ exports[`supports yes/no contest allows voting for both yes and no 1`] = `
           <span
             class="screen-reader-only"
           >
+            Institute a garbage collection program that collects garbage on weekdays across the county.
             To navigate through the contest choices, use the down button. To move to the next contest, use the right button.
           </span>
         </p>
@@ -266,7 +267,7 @@ exports[`supports yes/no contest allows voting for both yes and no 1`] = `
               class=""
             >
               <span>
-                description
+                Institute a garbage collection program that collects garbage on weekdays across the county.
               </span>
             </p>
           </div>
@@ -615,6 +616,7 @@ exports[`supports yes/no contest displays warning when attempting to change vote
           <span
             class="screen-reader-only"
           >
+            Institute a garbage collection program that collects garbage on weekdays across the county.
             To navigate through the contest choices, use the down button. To move to the next contest, use the right button.
           </span>
         </p>
@@ -636,7 +638,7 @@ exports[`supports yes/no contest displays warning when attempting to change vote
               class=""
             >
               <span>
-                description
+                Institute a garbage collection program that collects garbage on weekdays across the county.
               </span>
             </p>
           </div>


### PR DESCRIPTION
The reason this text wasn't being read is that is appears outside of the "audiofocus" prose block, and is just a text block so it isn't a focusable element that the user can tab to and read. I thought about making the proposition text a focusable text block but I wasn't sure if that was an anti-pattern as there is nothing you can actually do to interact with the element (right now all the focusable elements are things like buttons which you can press). So to not overcomplicate things this just adds the proposition text to the audiofocus element in the screen-reader-only block so it doesn't visually display on the screen display. The audio track will read the proposition text after reading the name of the measure and "vote yes or no" and before explaining how to navigate the contest choices. 

https://zube.io/votingworks/vxsuite/c/2890