### PR TITLE
fix(election-manager): remove sems file when election is reset

### DIFF
--- a/apps/election-manager/src/AppRoot.tsx
+++ b/apps/election-manager/src/AppRoot.tsx
@@ -285,6 +285,7 @@ const AppRoot: React.FC<Props> = ({ storage }) => {
     storage.clear()
     setIsOfficialResults(false)
     setCastVoteRecordFiles(CastVoteRecordFiles.empty)
+    setExternalVoteRecordsFile(undefined)
     setPrintedBallots([])
     setElectionDefinition(undefined)
 


### PR DESCRIPTION
Noticed this bug when testing something else. 