### PR TITLE
Add Ballot Counts by Party Table

### DIFF
--- a/apps/election-manager/src/components/BallotCountsTable.test.tsx
+++ b/apps/election-manager/src/components/BallotCountsTable.test.tsx
@@ -1,0 +1,487 @@
+import React from 'react'
+
+import { getByText as domGetByText } from '@testing-library/react'
+
+import {
+  electionWithMsEitherNeither,
+  multiPartyPrimaryElectionDefinition,
+} from '@votingworks/fixtures'
+
+import renderInAppContext from '../../test/renderInAppContext'
+import {
+  Dictionary,
+  ExternalTally,
+  Tally,
+  TallyCategory,
+} from '../config/types'
+import BallotCountsTable from './BallotCountsTable'
+
+describe('Ballot Counts by Precinct', () => {
+  const resultsByPrecinct: Dictionary<Tally> = {
+    // French Camp
+    '6526': {
+      numberOfBallotsCounted: 25,
+      castVoteRecords: [],
+      contestTallies: {},
+    },
+    // Kenego
+    '6529': {
+      numberOfBallotsCounted: 52,
+      castVoteRecords: [],
+      contestTallies: {},
+    },
+    // District 5
+    '6522': {
+      numberOfBallotsCounted: 0,
+      castVoteRecords: [],
+      contestTallies: {},
+    },
+  }
+  const resultsByCategory = new Map()
+  resultsByCategory.set(TallyCategory.Precinct, resultsByPrecinct)
+
+  const externalResultsByPrecinct: Dictionary<ExternalTally> = {
+    // French Camp
+    '6526': {
+      numberOfBallotsCounted: 13,
+      contestTallies: {},
+    },
+    // East Weir
+    '6525': {
+      numberOfBallotsCounted: 0,
+      contestTallies: {},
+    },
+    // Hebron
+    '6528': {
+      numberOfBallotsCounted: 22,
+      contestTallies: {},
+    },
+  }
+  const externalResultsByCategory = new Map()
+  externalResultsByCategory.set(
+    TallyCategory.Precinct,
+    externalResultsByPrecinct
+  )
+
+  const fullElectionTally = {
+    overallTally: {
+      numberOfBallotsCounted: 77,
+      castVoteRecords: [],
+      contestTallies: {},
+    },
+    resultsByCategory,
+  }
+  const fullElectionExternalTally = {
+    overallTally: {
+      numberOfBallotsCounted: 54,
+      contestTallies: {},
+    },
+    resultsByCategory: externalResultsByCategory,
+  }
+
+  it('renders as expected when there is no tally data', () => {
+    const { getByText, getAllByTestId } = renderInAppContext(
+      <BallotCountsTable breakdownCategory={TallyCategory.Precinct} />
+    )
+    electionWithMsEitherNeither.precincts.forEach((precinct) => {
+      getByText(precinct.name)
+      const tableRow = getByText(precinct.name).closest('tr')
+      expect(tableRow).toBeDefined()
+      expect(domGetByText(tableRow!, 0))
+      expect(
+        domGetByText(tableRow!, `View Unofficial ${precinct.name} Tally Report`)
+      )
+    })
+    getByText('Total Ballot Count')
+    const tableRow = getByText('Total Ballot Count').closest('tr')
+    expect(tableRow).toBeDefined()
+    expect(domGetByText(tableRow!, 0))
+    expect(
+      domGetByText(tableRow!, 'View Unofficial Tally Reports for All Precincts')
+    )
+
+    // There should be 2 more rows then the number of precincts (header row and totals row)
+    expect(getAllByTestId('table-row').length).toBe(
+      electionWithMsEitherNeither.precincts.length + 2
+    )
+  })
+
+  it('renders as expected when there is tally data', () => {
+    const { getByText, getAllByTestId } = renderInAppContext(
+      <BallotCountsTable breakdownCategory={TallyCategory.Precinct} />,
+      {
+        fullElectionTally,
+      }
+    )
+    electionWithMsEitherNeither.precincts.forEach((precinct) => {
+      // Expect that 0 ballots are counted when the precinct is missing in the dictionary or the tally says there are 0 ballots
+      const expectedNumberOfBallots =
+        resultsByPrecinct[precinct.id]?.numberOfBallotsCounted ?? 0
+      getByText(precinct.name)
+      const tableRow = getByText(precinct.name).closest('tr')
+      expect(tableRow).toBeDefined()
+      expect(domGetByText(tableRow!, expectedNumberOfBallots))
+      expect(
+        domGetByText(tableRow!, `View Unofficial ${precinct.name} Tally Report`)
+      )
+    })
+    getByText('Total Ballot Count')
+    const tableRow = getByText('Total Ballot Count').closest('tr')
+    expect(tableRow).toBeDefined()
+    expect(domGetByText(tableRow!, 77))
+    expect(
+      domGetByText(tableRow!, 'View Unofficial Tally Reports for All Precincts')
+    )
+
+    // There should be 2 more rows then the number of precincts (header row and totals row)
+    expect(getAllByTestId('table-row').length).toBe(
+      electionWithMsEitherNeither.precincts.length + 2
+    )
+  })
+
+  it('renders as expected when there is tally data and sems data', () => {
+    const { getByText, getAllByTestId } = renderInAppContext(
+      <BallotCountsTable breakdownCategory={TallyCategory.Precinct} />,
+      {
+        fullElectionTally,
+        fullElectionExternalTally,
+      }
+    )
+    electionWithMsEitherNeither.precincts.forEach((precinct) => {
+      // Expect that 0 ballots are counted when the precinct is missing in the dictionary or the tally says there are 0 ballots
+      const expectedNumberOfBallots =
+        (resultsByPrecinct[precinct.id]?.numberOfBallotsCounted ?? 0) +
+        (externalResultsByPrecinct[precinct.id]?.numberOfBallotsCounted ?? 0)
+      getByText(precinct.name)
+      const tableRow = getByText(precinct.name).closest('tr')
+      expect(tableRow).toBeDefined()
+      expect(domGetByText(tableRow!, expectedNumberOfBallots))
+      expect(
+        domGetByText(tableRow!, `View Unofficial ${precinct.name} Tally Report`)
+      )
+    })
+    getByText('Total Ballot Count')
+    const tableRow = getByText('Total Ballot Count').closest('tr')
+    expect(tableRow).toBeDefined()
+    expect(domGetByText(tableRow!, 131))
+    expect(
+      domGetByText(tableRow!, 'View Unofficial Tally Reports for All Precincts')
+    )
+
+    // There should be 2 more rows then the number of precincts (header row and totals row)
+    expect(getAllByTestId('table-row').length).toBe(
+      electionWithMsEitherNeither.precincts.length + 2
+    )
+  })
+})
+
+describe('Ballot Counts by Scanner', () => {
+  const resultsByScanner: Dictionary<Tally> = {
+    'scanner-1': {
+      numberOfBallotsCounted: 25,
+      castVoteRecords: [],
+      contestTallies: {},
+    },
+    'scanner-2': {
+      numberOfBallotsCounted: 52,
+      castVoteRecords: [],
+      contestTallies: {},
+    },
+    'scanner-3': {
+      numberOfBallotsCounted: 0,
+      castVoteRecords: [],
+      contestTallies: {},
+    },
+  }
+  const resultsByCategory = new Map()
+  resultsByCategory.set(TallyCategory.Scanner, resultsByScanner)
+
+  const fullElectionTally = {
+    overallTally: {
+      numberOfBallotsCounted: 77,
+      castVoteRecords: [],
+      contestTallies: {},
+    },
+    resultsByCategory,
+  }
+  const fullElectionExternalTally = {
+    overallTally: {
+      numberOfBallotsCounted: 54,
+      contestTallies: {},
+    },
+    resultsByCategory: new Map(),
+  }
+
+  it('renders as expected when there is no tally data', () => {
+    const { getByText, getAllByTestId } = renderInAppContext(
+      <BallotCountsTable breakdownCategory={TallyCategory.Scanner} />
+    )
+
+    getByText('Total Ballot Count')
+    const tableRow = getByText('Total Ballot Count').closest('tr')
+    expect(tableRow).toBeDefined()
+    expect(domGetByText(tableRow!, 0))
+
+    // There should be 2 rows in the table, the header row and the totals row.
+    expect(getAllByTestId('table-row').length).toBe(2)
+  })
+
+  it('renders as expected when there is tally data', () => {
+    const { getByText, getAllByTestId } = renderInAppContext(
+      <BallotCountsTable breakdownCategory={TallyCategory.Scanner} />,
+      {
+        fullElectionTally,
+      }
+    )
+
+    const scannerIds = ['scanner-1', 'scanner-2', 'scanner-3']
+
+    scannerIds.forEach((scannerId) => {
+      // Expect that 0 ballots are counted when the precinct is missing in the dictionary or the tally says there are 0 ballots
+      const expectedNumberOfBallots =
+        resultsByScanner[scannerId]?.numberOfBallotsCounted ?? 0
+      getByText(scannerId)
+      const tableRow = getByText(scannerId).closest('tr')
+      expect(tableRow).toBeDefined()
+      expect(domGetByText(tableRow!, expectedNumberOfBallots))
+      if (expectedNumberOfBallots > 0) {
+        expect(
+          domGetByText(
+            tableRow!,
+            `View Unofficial Scanner ${scannerId} Tally Report`
+          )
+        )
+      }
+    })
+    getByText('Total Ballot Count')
+    const tableRow = getByText('Total Ballot Count').closest('tr')
+    expect(tableRow).toBeDefined()
+    expect(domGetByText(tableRow!, 77))
+
+    expect(getAllByTestId('table-row').length).toBe(scannerIds.length + 2)
+  })
+
+  it('renders as expected when there is tally data and sems data', () => {
+    const { getByText, getAllByTestId } = renderInAppContext(
+      <BallotCountsTable breakdownCategory={TallyCategory.Scanner} />,
+      {
+        fullElectionTally,
+        fullElectionExternalTally,
+        externalVoteRecordsFile: new File(['blah'], 'file-name.csv'),
+      }
+    )
+
+    const scannerIds = ['scanner-1', 'scanner-2', 'scanner-3']
+
+    scannerIds.forEach((scannerId) => {
+      // Expect that 0 ballots are counted when the precinct is missing in the dictionary or the tally says there are 0 ballots
+      const expectedNumberOfBallots =
+        resultsByScanner[scannerId]?.numberOfBallotsCounted ?? 0
+      getByText(scannerId)
+      const tableRow = getByText(scannerId).closest('tr')
+      expect(tableRow).toBeDefined()
+      expect(domGetByText(tableRow!, expectedNumberOfBallots))
+      if (expectedNumberOfBallots > 0) {
+        expect(
+          domGetByText(
+            tableRow!,
+            `View Unofficial Scanner ${scannerId} Tally Report`
+          )
+        )
+      }
+    })
+
+    getByText('SEMS File (file-name.csv)')
+    let tableRow = getByText('SEMS File (file-name.csv)').closest('tr')
+    expect(tableRow).toBeDefined()
+    expect(domGetByText(tableRow!, 54))
+
+    getByText('Total Ballot Count')
+    tableRow = getByText('Total Ballot Count').closest('tr')
+    expect(tableRow).toBeDefined()
+    expect(domGetByText(tableRow!, 131))
+
+    expect(getAllByTestId('table-row').length).toBe(scannerIds.length + 3)
+  })
+})
+
+// Test party ballot counts
+describe('Ballots Counts by Party', () => {
+  const resultsByParty: Dictionary<Tally> = {
+    // Liberty
+    '0': {
+      numberOfBallotsCounted: 25,
+      castVoteRecords: [],
+      contestTallies: {},
+    },
+    // Federalist
+    '4': {
+      numberOfBallotsCounted: 52,
+      castVoteRecords: [],
+      contestTallies: {},
+    },
+  }
+  const resultsByCategory = new Map()
+  resultsByCategory.set(TallyCategory.Party, resultsByParty)
+
+  const externalResultsByParty: Dictionary<Tally> = {
+    // Liberty
+    '0': {
+      numberOfBallotsCounted: 13,
+      castVoteRecords: [],
+      contestTallies: {},
+    },
+    // Constitution
+    '3': {
+      numberOfBallotsCounted: 73,
+      castVoteRecords: [],
+      contestTallies: {},
+    },
+  }
+  const externalResultsByCategory = new Map()
+  externalResultsByCategory.set(TallyCategory.Party, externalResultsByParty)
+
+  const fullElectionTally = {
+    overallTally: {
+      numberOfBallotsCounted: 77,
+      castVoteRecords: [],
+      contestTallies: {},
+    },
+    resultsByCategory,
+  }
+
+  const fullElectionExternalTally = {
+    overallTally: {
+      numberOfBallotsCounted: 54,
+      contestTallies: {},
+    },
+    resultsByCategory: externalResultsByCategory,
+  }
+
+  it('does not render when the election has not ballot styles with parties', () => {
+    // The default election is not a primary
+    const { container } = renderInAppContext(
+      <BallotCountsTable breakdownCategory={TallyCategory.Party} />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders as expected when there is no data', () => {
+    const expectedParties = [
+      'Constitution Party',
+      'Federalist Party',
+      'Liberty Party',
+    ]
+    const { getByText, getAllByTestId } = renderInAppContext(
+      <BallotCountsTable breakdownCategory={TallyCategory.Party} />,
+      {
+        electionDefinition: {
+          ...multiPartyPrimaryElectionDefinition,
+          electionData: '',
+        },
+      }
+    )
+
+    expectedParties.forEach((partyName) => {
+      getByText(partyName)
+      const tableRow = getByText(partyName).closest('tr')
+      expect(tableRow).toBeDefined()
+      expect(domGetByText(tableRow!, 0))
+      expect(
+        domGetByText(tableRow!, `View Unofficial ${partyName} Tally Report`)
+      )
+    })
+
+    getByText('Total Ballot Count')
+    const tableRow = getByText('Total Ballot Count').closest('tr')
+    expect(tableRow).toBeDefined()
+    expect(domGetByText(tableRow!, 0))
+    expect(
+      domGetByText(tableRow!, 'View Unofficial Full Election Tally Report')
+    )
+
+    expect(getAllByTestId('table-row').length).toBe(expectedParties.length + 2)
+  })
+
+  it('renders as expected when there is tally data', () => {
+    const expectedParties = [
+      { partyName: 'Constitution Party', partyId: '3' },
+      { partyName: 'Federalist Party', partyId: '4' },
+      { partyName: 'Liberty Party', partyId: '0' },
+    ]
+    const { getByText, getAllByTestId } = renderInAppContext(
+      <BallotCountsTable breakdownCategory={TallyCategory.Party} />,
+      {
+        electionDefinition: {
+          ...multiPartyPrimaryElectionDefinition,
+          electionData: '',
+        },
+        fullElectionTally,
+      }
+    )
+
+    expectedParties.forEach(({ partyName, partyId }) => {
+      const expectedNumberOfBallots =
+        resultsByParty[partyId]?.numberOfBallotsCounted ?? 0
+      getByText(partyName)
+      const tableRow = getByText(partyName).closest('tr')
+      expect(tableRow).toBeDefined()
+      expect(domGetByText(tableRow!, expectedNumberOfBallots))
+      expect(
+        domGetByText(tableRow!, `View Unofficial ${partyName} Tally Report`)
+      )
+    })
+
+    getByText('Total Ballot Count')
+    const tableRow = getByText('Total Ballot Count').closest('tr')
+    expect(tableRow).toBeDefined()
+    expect(domGetByText(tableRow!, 77))
+    expect(
+      domGetByText(tableRow!, 'View Unofficial Full Election Tally Report')
+    )
+
+    expect(getAllByTestId('table-row').length).toBe(expectedParties.length + 2)
+  })
+
+  it('renders as expected where there is tally data and sems data', () => {
+    const expectedParties = [
+      { partyName: 'Constitution Party', partyId: '3' },
+      { partyName: 'Federalist Party', partyId: '4' },
+      { partyName: 'Liberty Party', partyId: '0' },
+    ]
+    const { getByText, getAllByTestId } = renderInAppContext(
+      <BallotCountsTable breakdownCategory={TallyCategory.Party} />,
+      {
+        electionDefinition: {
+          ...multiPartyPrimaryElectionDefinition,
+          electionData: '',
+        },
+        fullElectionTally,
+        fullElectionExternalTally,
+      }
+    )
+
+    expectedParties.forEach(({ partyName, partyId }) => {
+      const expectedNumberOfBallots =
+        (resultsByParty[partyId]?.numberOfBallotsCounted ?? 0) +
+        (externalResultsByParty[partyId]?.numberOfBallotsCounted ?? 0)
+      getByText(partyName)
+      const tableRow = getByText(partyName).closest('tr')
+      expect(tableRow).toBeDefined()
+      expect(domGetByText(tableRow!, expectedNumberOfBallots))
+      expect(
+        domGetByText(tableRow!, `View Unofficial ${partyName} Tally Report`)
+      )
+    })
+
+    getByText('Total Ballot Count')
+    const tableRow = getByText('Total Ballot Count').closest('tr')
+    expect(tableRow).toBeDefined()
+    expect(domGetByText(tableRow!, 131))
+    expect(
+      domGetByText(tableRow!, 'View Unofficial Full Election Tally Report')
+    )
+
+    expect(getAllByTestId('table-row').length).toBe(expectedParties.length + 2)
+  })
+})

--- a/apps/election-manager/src/components/BallotCountsTable.tsx
+++ b/apps/election-manager/src/components/BallotCountsTable.tsx
@@ -1,0 +1,280 @@
+import React, { useContext } from 'react'
+import { TallyCategory } from '../config/types'
+
+import * as format from '../utils/format'
+import throwIllegalValue from '../utils/throwIllegalValue'
+import { getPartiesWithPrimaryElections } from '../utils/election'
+
+import AppContext from '../contexts/AppContext'
+import Loading from './Loading'
+import Table, { TD } from './Table'
+import LinkButton from './LinkButton'
+import routerPaths from '../routerPaths'
+
+export interface Props {
+  breakdownCategory: TallyCategory
+}
+
+const BallotCountsTable: React.FC<Props> = ({ breakdownCategory }) => {
+  const {
+    electionDefinition,
+    isTabulationRunning,
+    fullElectionTally,
+    fullElectionExternalTally,
+    externalVoteRecordsFile,
+    isOfficialResults,
+  } = useContext(AppContext)
+  const { election } = electionDefinition!
+
+  if (isTabulationRunning) {
+    return <Loading />
+  }
+
+  const statusPrefix = isOfficialResults ? 'Official' : 'Unofficial'
+
+  const totalBallotCountInternal =
+    fullElectionTally?.overallTally.numberOfBallotsCounted ?? 0
+  const totalBallotCountExternal =
+    fullElectionExternalTally?.overallTally.numberOfBallotsCounted ?? 0
+
+  switch (breakdownCategory) {
+    case TallyCategory.Precinct: {
+      const resultsByPrecinct =
+        fullElectionTally?.resultsByCategory.get(TallyCategory.Precinct) || {}
+      const externalResultsByPrecinct =
+        fullElectionExternalTally?.resultsByCategory.get(
+          TallyCategory.Precinct
+        ) || {}
+      return (
+        <Table>
+          <tbody>
+            <tr data-testid="table-row">
+              <TD as="th" narrow>
+                Precinct
+              </TD>
+              <TD as="th">Ballot Count</TD>
+              <TD as="th">View Tally</TD>
+            </tr>
+            {[...election.precincts]
+              .sort((a, b) =>
+                a.name.localeCompare(b.name, undefined, {
+                  ignorePunctuation: true,
+                })
+              )
+              .map((precinct) => {
+                const precinctBallotsCount =
+                  resultsByPrecinct[precinct.id]?.numberOfBallotsCounted ?? 0
+                const externalPrecinctBallotsCount =
+                  externalResultsByPrecinct[precinct.id]
+                    ?.numberOfBallotsCounted ?? 0
+                return (
+                  <tr key={precinct.id} data-testid="table-row">
+                    <TD narrow nowrap>
+                      {precinct.name}
+                    </TD>
+                    <TD>
+                      {format.count(
+                        precinctBallotsCount + externalPrecinctBallotsCount
+                      )}
+                    </TD>
+                    <TD>
+                      <LinkButton
+                        small
+                        to={routerPaths.tallyPrecinctReport({
+                          precinctId: precinct.id,
+                        })}
+                      >
+                        View {statusPrefix} {precinct.name} Tally Report
+                      </LinkButton>
+                    </TD>
+                  </tr>
+                )
+              })}
+            <tr data-testid="table-row">
+              <TD narrow nowrap>
+                <strong>Total Ballot Count</strong>
+              </TD>
+              <TD>
+                <strong data-testid="total-ballot-count">
+                  {format.count(
+                    totalBallotCountInternal + totalBallotCountExternal
+                  )}
+                </strong>
+              </TD>
+              <TD>
+                <LinkButton
+                  small
+                  to={routerPaths.tallyPrecinctReport({
+                    precinctId: 'all',
+                  })}
+                >
+                  View {statusPrefix} Tally Reports for All Precincts
+                </LinkButton>
+              </TD>
+            </tr>
+          </tbody>
+        </Table>
+      )
+    }
+    case TallyCategory.Scanner: {
+      const resultsByScanner =
+        fullElectionTally?.resultsByCategory.get(TallyCategory.Scanner) || {}
+
+      return (
+        <React.Fragment>
+          {fullElectionExternalTally && (
+            <p>
+              The following results only include ballots counted with
+              VotingWorks scanners. The data from the imported SEMS file is not
+              included in these reports.
+            </p>
+          )}
+          <Table>
+            <tbody>
+              <tr data-testid="table-row">
+                <TD as="th" narrow>
+                  Scanner ID
+                </TD>
+                <TD as="th">Ballot Count</TD>
+                <TD as="th">View Tally</TD>
+              </tr>
+              {Object.keys(resultsByScanner)
+                .sort((a, b) =>
+                  a.localeCompare(b, 'en', {
+                    numeric: true,
+                    ignorePunctuation: true,
+                  })
+                )
+                .map((scannerId) => {
+                  const scannerBallotsCount =
+                    resultsByScanner[scannerId]?.numberOfBallotsCounted ?? 0
+                  return (
+                    <tr key={scannerId} data-testid="table-row">
+                      <TD narrow nowrap>
+                        {scannerId}
+                      </TD>
+                      <TD>{format.count(scannerBallotsCount)}</TD>
+                      <TD>
+                        {!!scannerBallotsCount && (
+                          <LinkButton
+                            small
+                            to={routerPaths.tallyScannerReport({
+                              scannerId,
+                            })}
+                          >
+                            View {statusPrefix} Scanner {scannerId} Tally Report
+                          </LinkButton>
+                        )}
+                      </TD>
+                    </tr>
+                  )
+                })}
+              {externalVoteRecordsFile && (
+                <tr data-testid="table-row">
+                  <TD narrow nowrap>
+                    SEMS File ({externalVoteRecordsFile.name})
+                  </TD>
+                  <TD>{format.count(totalBallotCountExternal)}</TD>
+                  <TD />
+                </tr>
+              )}
+              <tr data-testid="table-row">
+                <TD narrow nowrap>
+                  <strong>Total Ballot Count</strong>
+                </TD>
+                <TD>
+                  <strong>
+                    {format.count(
+                      totalBallotCountInternal + totalBallotCountExternal
+                    )}
+                  </strong>
+                </TD>
+                <TD />
+              </tr>
+            </tbody>
+          </Table>
+        </React.Fragment>
+      )
+    }
+    case TallyCategory.Party: {
+      const resultsByParty =
+        fullElectionTally?.resultsByCategory.get(TallyCategory.Party) || {}
+      const externalResultsByParty =
+        fullElectionExternalTally?.resultsByCategory.get(TallyCategory.Party) ||
+        {}
+      const partiesForPrimaries = getPartiesWithPrimaryElections(election)
+      if (partiesForPrimaries.length === 0) {
+        return null
+      }
+
+      return (
+        <Table>
+          <tbody>
+            <tr data-testid="table-row">
+              <TD as="th" narrow>
+                Party
+              </TD>
+              <TD as="th">Ballot Count</TD>
+              <TD as="th">View Tally</TD>
+            </tr>
+            {[...partiesForPrimaries]
+              .sort((a, b) =>
+                a.fullName.localeCompare(b.fullName, undefined, {
+                  ignorePunctuation: true,
+                })
+              )
+              .map((party) => {
+                const partyBallotsCount =
+                  resultsByParty[party.id]?.numberOfBallotsCounted ?? 0
+                const externalPartyBallotsCount =
+                  externalResultsByParty[party.id]?.numberOfBallotsCounted ?? 0
+                return (
+                  <tr data-testid="table-row" key={party.id}>
+                    <TD narrow nowrap>
+                      {party.fullName}
+                    </TD>
+                    <TD>
+                      {format.count(
+                        partyBallotsCount + externalPartyBallotsCount
+                      )}
+                    </TD>
+                    <TD>
+                      <LinkButton
+                        small
+                        to={routerPaths.tallyPartyReport({
+                          partyId: party.id,
+                        })}
+                      >
+                        View {statusPrefix} {party.fullName} Tally Report
+                      </LinkButton>
+                    </TD>
+                  </tr>
+                )
+              })}
+            <tr data-testid="table-row">
+              <TD narrow nowrap>
+                <strong>Total Ballot Count</strong>
+              </TD>
+              <TD>
+                <strong data-testid="total-ballot-count">
+                  {format.count(
+                    totalBallotCountInternal + totalBallotCountExternal
+                  )}
+                </strong>
+              </TD>
+              <TD>
+                <LinkButton small to={routerPaths.tallyFullReport}>
+                  View {statusPrefix} Full Election Tally Report
+                </LinkButton>
+              </TD>
+            </tr>
+          </tbody>
+        </Table>
+      )
+    }
+    default:
+      throwIllegalValue(breakdownCategory)
+  }
+}
+
+export default BallotCountsTable

--- a/apps/election-manager/src/components/ElectionManager.tsx
+++ b/apps/election-manager/src/components/ElectionManager.tsx
@@ -92,6 +92,14 @@ const ElectionManager: React.FC = () => {
       >
         <TallyReportScreen />
       </Route>
+      <Route
+        path={[
+          routerPaths.tallyPartyReport({ partyId: ':partyId' }),
+          routerPaths.tallyFullReport,
+        ]}
+      >
+        <TallyReportScreen />
+      </Route>
       <Route path={routerPaths.overvoteCombinationReport}>
         <OvervoteCombinationReportScreen />
       </Route>

--- a/apps/election-manager/src/config/types.ts
+++ b/apps/election-manager/src/config/types.ts
@@ -61,6 +61,9 @@ export interface PrecinctReportScreenProps {
 export interface ScannerReportScreenProps {
   scannerId: string
 }
+export interface PartyReportScreenProps {
+  partyId: string
+}
 
 // Tallies
 export type YesNoOption = ['yes'] | ['no'] | []

--- a/apps/election-manager/src/routerPaths.ts
+++ b/apps/election-manager/src/routerPaths.ts
@@ -1,5 +1,6 @@
 import {
   BallotScreenProps,
+  PartyReportScreenProps,
   PrecinctReportScreenProps,
   ScannerReportScreenProps,
 } from './config/types'
@@ -26,6 +27,8 @@ const routerPaths = {
     `/tally/print-test-deck/${precinctId}`,
   tallyPrecinctReport: ({ precinctId }: PrecinctReportScreenProps): string =>
     `/tally/precinct/${precinctId}`,
+  tallyPartyReport: ({ partyId }: PartyReportScreenProps): string =>
+    `/tally/party/${partyId}`,
   tallyScannerReport: ({ scannerId }: ScannerReportScreenProps): string =>
     `/tally/scanner/${scannerId}`,
   tallyFullReport: '/tally/full',

--- a/apps/election-manager/src/screens/TallyReportScreen.tsx
+++ b/apps/election-manager/src/screens/TallyReportScreen.tsx
@@ -10,6 +10,7 @@ import * as format from '../utils/format'
 import {
   PrecinctReportScreenProps,
   ScannerReportScreenProps,
+  PartyReportScreenProps,
 } from '../config/types'
 import AppContext from '../contexts/AppContext'
 
@@ -42,19 +43,19 @@ const TallyHeader = styled.div`
 interface Props {
   election: Election
   generatedAtTime: Date
-  votingWorksBallotCount: number
+  internalBallotCount: number
   externalBallotCount?: number
 }
 
 const TallyReportMetadata: React.FC<Props> = ({
   election,
   generatedAtTime,
-  votingWorksBallotCount,
+  internalBallotCount,
   externalBallotCount,
 }) => {
   const electionDate = localeWeedkayAndDate.format(new Date(election.date))
   const generatedAt = localeLongDateAndTime.format(generatedAtTime)
-  const totalBallotCount = votingWorksBallotCount + (externalBallotCount ?? 0)
+  const totalBallotCount = internalBallotCount + (externalBallotCount ?? 0)
   const ballotsByDataSource =
     externalBallotCount !== undefined ? (
       <React.Fragment>
@@ -69,7 +70,7 @@ const TallyReportMetadata: React.FC<Props> = ({
             </tr>
             <tr>
               <TD>VotingWorks Data</TD>
-              <TD textAlign="right">{format.count(votingWorksBallotCount)}</TD>
+              <TD textAlign="right">{format.count(internalBallotCount)}</TD>
             </tr>
             <tr>
               <TD>Imported SEMS File</TD>
@@ -111,6 +112,7 @@ const TallyReportScreen: React.FC = () => {
     precinctId: precinctIdFromProps,
   } = useParams<PrecinctReportScreenProps>()
   const { scannerId } = useParams<ScannerReportScreenProps>()
+  const { partyId: partyIdFromProps } = useParams<PartyReportScreenProps>()
   const {
     electionDefinition,
     isOfficialResults,
@@ -133,9 +135,10 @@ const TallyReportScreen: React.FC = () => {
   const { election } = electionDefinition!
   const statusPrefix = isOfficialResults ? 'Official' : 'Unofficial'
 
-  const ballotStylePartyIds = Array.from(
-    new Set(election.ballotStyles.map((bs) => bs.partyId))
-  )
+  const ballotStylePartyIds =
+    partyIdFromProps !== undefined
+      ? [partyIdFromProps]
+      : Array.from(new Set(election.ballotStyles.map((bs) => bs.partyId)))
 
   const precinctIds =
     precinctIdFromProps === 'all'
@@ -157,6 +160,10 @@ const TallyReportScreen: React.FC = () => {
     }
     if (precinctIdFromProps === 'all') {
       return `${statusPrefix} ${election.title} Tally Reports for All Precincts`
+    }
+    if (partyIdFromProps) {
+      const party = election.parties.find((p) => p.id === partyIdFromProps)!
+      return `${statusPrefix} Tally Report for ${party.fullName}`
     }
     return `${statusPrefix} ${election.title} Tally Report`
   }
@@ -180,11 +187,12 @@ const TallyReportScreen: React.FC = () => {
   const outerTallyReport = filterTalliesByParams(fullElectionTally!, election, {
     precinctId: singlePrecinctId,
     scannerId,
+    partyId: partyIdFromProps,
   })
   const outerExternalTallyReport = filterExternalTalliesByParams(
     fullElectionExternalTally,
     election,
-    { precinctId: singlePrecinctId, scannerId }
+    { precinctId: singlePrecinctId, scannerId, partyId: partyIdFromProps }
   )
 
   return (
@@ -195,7 +203,7 @@ const TallyReportScreen: React.FC = () => {
           <TallyReportMetadata
             generatedAtTime={generatedAtTime}
             election={election}
-            votingWorksBallotCount={outerTallyReport.numberOfBallotsCounted}
+            internalBallotCount={outerTallyReport.numberOfBallotsCounted}
             externalBallotCount={
               outerExternalTallyReport?.numberOfBallotsCounted
             }
@@ -253,7 +261,7 @@ const TallyReportScreen: React.FC = () => {
                       <TallyReportMetadata
                         generatedAtTime={generatedAtTime}
                         election={election}
-                        votingWorksBallotCount={
+                        internalBallotCount={
                           tallyForReport.numberOfBallotsCounted
                         }
                         externalBallotCount={
@@ -287,7 +295,7 @@ const TallyReportScreen: React.FC = () => {
                       <TallyReportMetadata
                         generatedAtTime={generatedAtTime}
                         election={election}
-                        votingWorksBallotCount={
+                        internalBallotCount={
                           tallyForReport?.numberOfBallotsCounted ?? 0
                         }
                       />
@@ -313,7 +321,7 @@ const TallyReportScreen: React.FC = () => {
                     <TallyReportMetadata
                       generatedAtTime={generatedAtTime}
                       election={election}
-                      votingWorksBallotCount={
+                      internalBallotCount={
                         tallyForReport.numberOfBallotsCounted
                       }
                       externalBallotCount={

--- a/apps/election-manager/src/utils/election.ts
+++ b/apps/election-manager/src/utils/election.ts
@@ -7,6 +7,7 @@ import {
   MsEitherNeitherContest,
   VotesDict,
   Precinct,
+  Party,
 } from '@votingworks/types'
 import dashify from 'dashify'
 import { LANGUAGES } from '../config/globals'
@@ -34,6 +35,13 @@ export function getDistrictIdsForPartyId(
   return election.ballotStyles
     .filter((bs) => bs.partyId === partyId)
     .flatMap((bs) => bs.districts)
+}
+
+export function getPartiesWithPrimaryElections(election: Election): Party[] {
+  const partyIds = election.ballotStyles
+    .map((bs) => bs.partyId)
+    .filter((id): id is string => id !== undefined)
+  return election.parties.filter((party) => partyIds.includes(party.id))
 }
 
 export function getContestOptionsForContest(


### PR DESCRIPTION
Adds a Ballot Counts by Party table to the TallyScreen, and refactors the ballot tables into their own component. I put them all in one component as there is some shared logic, but the approach admittedly made a bit more sense when I was planning to control which table to view with the segmented button instead of displaying all of them. Also added a bunch of testing for all of the ballot count tables. 

Ballot Counts by Party (this section is hidden in the case of a general election) 
![Screen Shot 2021-02-19 at 8 45 53 AM](https://user-images.githubusercontent.com/14897017/108534395-f4a04a00-728e-11eb-81b7-abf3369db8e2.png)

By Party Tally Report Screen, the printed tally reports are identical to the ones already printed just only the report for the party you are viewing gets printed. 
![Screen Shot 2021-02-19 at 8 46 01 AM](https://user-images.githubusercontent.com/14897017/108534390-f23df000-728e-11eb-85d7-e1a04d29616f.png)