### PR TITLE
fix(module-scan) fix bug in not handling write ins from bmd ballots

### DIFF
--- a/apps/module-scan/src/buildCastVoteRecord.test.ts
+++ b/apps/module-scan/src/buildCastVoteRecord.test.ts
@@ -76,6 +76,74 @@ test('generates a CVR from a completed BMD ballot', () => {
     `)
   })
 })
+test('generates a CVR from a completed BMD ballot with write in and overvotes', () => {
+  const sheetId = 'sheetid'
+  const ballotId = 'abcdefg'
+  const ballotStyleId = '1'
+  const precinctId = '6522'
+  const ballotStyle = getBallotStyle({ ballotStyleId, election })!
+  const contests = getContests({ ballotStyle, election })
+
+  const blankPageTypes = ['BlankPage', 'UnreadablePage']
+  blankPageTypes.forEach((blankPageType: string) => {
+    expect(
+      buildCastVoteRecord(sheetId, ballotId, election, [
+        {
+          interpretation: {
+            type: 'InterpretedBmdPage',
+            ballotId,
+            metadata: {
+              locales: { primary: 'en-US' },
+              electionHash: '',
+              ballotType: BallotType.Standard,
+              ballotStyleId,
+              precinctId,
+              isTestMode: false,
+            },
+            votes: vote(contests, {
+              '1': {
+                id: 'write-in__PIKACHU',
+                name: 'Pikachu',
+                isWriteIn: true,
+              },
+              '2': ['21', '22'],
+            }),
+          },
+        },
+        {
+          interpretation: {
+            type: blankPageType as 'BlankPage' | 'UnreadablePage',
+          },
+        },
+      ])
+    ).toMatchInlineSnapshot(`
+    Object {
+      "1": Array [
+        "write-in__PIKACHU",
+      ],
+      "2": Array [
+        "21",
+        "22",
+      ],
+      "3": Array [],
+      "4": Array [],
+      "_ballotId": "abcdefg",
+      "_ballotStyleId": "1",
+      "_ballotType": "standard",
+      "_locales": Object {
+        "primary": "en-US",
+      },
+      "_precinctId": "6522",
+      "_scannerId": "000",
+      "_testBallot": false,
+      "flag-question": Array [],
+      "initiative-65": Array [],
+      "initiative-65-a": Array [],
+      "runoffs-question": Array [],
+    }
+    `)
+  })
+})
 
 test('generates a CVR from a completed HMPB page', () => {
   const sheetId = 'sheetid'
@@ -145,6 +213,98 @@ test('generates a CVR from a completed HMPB page', () => {
         "1",
       ],
       "2": Array [
+        "22",
+      ],
+      "_ballotId": "abcdefg",
+      "_ballotStyleId": "1",
+      "_ballotType": "standard",
+      "_locales": Object {
+        "primary": "en-US",
+      },
+      "_pageNumbers": Array [
+        1,
+        2,
+      ],
+      "_precinctId": "6522",
+      "_scannerId": "000",
+      "_testBallot": false,
+      "initiative-65": Array [
+        "yes",
+        "no",
+      ],
+    }
+  `)
+})
+
+test('generates a CVR from a completed HMPB page with write in votes and overvotes', () => {
+  const sheetId = 'sheetid'
+  const ballotId = 'abcdefg'
+  const ballotStyleId = '1'
+  const precinctId = '6522'
+  const ballotStyle = getBallotStyle({ ballotStyleId, election })!
+  const contests = getContests({ ballotStyle, election })
+
+  expect(
+    buildCastVoteRecord(sheetId, ballotId, election, [
+      {
+        interpretation: {
+          type: 'InterpretedHmpbPage',
+          ballotId: 'abcdefg',
+          metadata: {
+            locales: { primary: 'en-US' },
+            electionHash: '',
+            ballotType: BallotType.Standard,
+            ballotStyleId,
+            precinctId,
+            isTestMode: false,
+            pageNumber: 1,
+          },
+          markInfo: { marks: [], ballotSize: { width: 1, height: 1 } },
+          adjudicationInfo: {
+            requiresAdjudication: false,
+            enabledReasons: [],
+            allReasonInfos: [],
+          },
+          votes: vote(contests, {
+            '1': { id: '__write-in-0', name: 'Pikachu', isWriteIn: true },
+            '2': ['21', '22'],
+          }),
+        },
+        contestIds: ['1', '2'],
+      },
+      {
+        interpretation: {
+          type: 'InterpretedHmpbPage',
+          ballotId: 'abcdefg',
+          metadata: {
+            locales: { primary: 'en-US' },
+            electionHash: '',
+            ballotType: BallotType.Standard,
+            ballotStyleId,
+            precinctId,
+            isTestMode: false,
+            pageNumber: 2,
+          },
+          markInfo: { marks: [], ballotSize: { width: 1, height: 1 } },
+          adjudicationInfo: {
+            requiresAdjudication: false,
+            enabledReasons: [],
+            allReasonInfos: [],
+          },
+          votes: vote(contests, {
+            'initiative-65': ['yes', 'no'],
+          }),
+        },
+        contestIds: ['initiative-65'],
+      },
+    ])
+  ).toMatchInlineSnapshot(`
+    Object {
+      "1": Array [
+        "__write-in-0",
+      ],
+      "2": Array [
+        "21",
         "22",
       ],
       "_ballotId": "abcdefg",

--- a/apps/module-scan/src/endToEnd.test.ts
+++ b/apps/module-scan/src/endToEnd.test.ts
@@ -107,7 +107,10 @@ test('going through the whole process works', async () => {
       // sample-batch-1-ballot-1.png
       expect.objectContaining({ president: ['cramer-vuocolo'] }),
       // sample-batch-1-ballot-2.png
-      expect.objectContaining({ president: ['boone-lian'] }),
+      expect.objectContaining({
+        president: ['boone-lian'],
+        'county-commissioners': ['argent', 'bainbridge', 'write-in__BOB SMITH'],
+      }),
       // sample-batch-1-ballot-3.png
       expect.objectContaining({ president: ['barchi-hallaren'] }),
     ])

--- a/apps/module-scan/src/util/allContestOptions.ts
+++ b/apps/module-scan/src/util/allContestOptions.ts
@@ -5,7 +5,8 @@ import { ContestOption } from '../types'
  * Enumerates all contest options in the order they would appear on a HMPB.
  */
 export default function* allContestOptions(
-  contest: AnyContest
+  contest: AnyContest,
+  writeInOptionIds?: readonly string[]
 ): Generator<ContestOption> {
   if (contest.type === 'candidate') {
     for (const candidate of contest.candidates) {
@@ -19,13 +20,25 @@ export default function* allContestOptions(
     }
 
     if (contest.allowWriteIns) {
-      for (let i = 0; i < contest.seats; i++) {
-        yield {
-          type: 'candidate',
-          id: `__write-in-${i}`,
-          contestId: contest.id,
-          name: 'Write-In',
-          isWriteIn: true,
+      if (writeInOptionIds !== undefined) {
+        for (const writeInId of writeInOptionIds) {
+          yield {
+            type: 'candidate',
+            id: writeInId,
+            contestId: contest.id,
+            name: 'Write-In',
+            isWriteIn: true,
+          }
+        }
+      } else {
+        for (let i = 0; i < contest.seats; i++) {
+          yield {
+            type: 'candidate',
+            id: `__write-in-${i}`,
+            contestId: contest.id,
+            name: 'Write-In',
+            isWriteIn: true,
+          }
         }
       }
     }


### PR DESCRIPTION

Fixes a bug with write in votes from BMD ballots getting ignored. The BMD ballots write the ID of the candidate for a write in as "write-in_<NAMEWROTEIN>" and the module-scan code only looks for IDs of a form "__write-in-<i>". This change will accept any candidate in the ballot with "isWriteIn" set to true as a write in vote, election manager currently already has logic to consolidate any ids that start with "write-in" or "__write-in" into the same write in candidate ID. 

Note the new HMPB test I added in buildCastVoteRecord.test.ts always passed, just added for good measure. The bmd one and the additional check in the end to end test fail prior to this change. 