### PR TITLE
fix(em): dont allow sems files changes when results are official

### DIFF
--- a/apps/election-manager/src/components/ConfirmRemovingFileModal.tsx
+++ b/apps/election-manager/src/components/ConfirmRemovingFileModal.tsx
@@ -33,6 +33,10 @@ export const ConfirmRemovingFileModal: React.FC<Props> = ({
       case ResultsFileType.SEMS:
         saveExternalVoteRecordsFile(undefined)
         break
+      case ResultsFileType.All:
+        saveCastVoteRecordFiles()
+        saveExternalVoteRecordsFile(undefined)
+        break
       default:
         throwIllegalValue(fileType)
     }
@@ -71,6 +75,24 @@ export const ConfirmRemovingFileModal: React.FC<Props> = ({
         <p>
           Do you want to remove the SEMS file {externalVoteRecordsFile!.name}?
         </p>
+      )
+      break
+    }
+    case ResultsFileType.All: {
+      fileTypeName = ''
+      singleFileRemoval = false
+      const { fileList } = castVoteRecordFiles
+      mainContent = (
+        <React.Fragment>
+          <p>
+            Do you want to remove the {fileList.length} uploaded CVR{' '}
+            {pluralize('files', fileList.length)}
+            {externalVoteRecordsFile &&
+              ` and the SEMS file ${externalVoteRecordsFile!.name}`}
+            ?
+          </p>
+          <p>All reports will be unavailable without CVR data.</p>
+        </React.Fragment>
       )
       break
     }

--- a/apps/election-manager/src/config/types.ts
+++ b/apps/election-manager/src/config/types.ts
@@ -133,6 +133,7 @@ export type OptionalFullElectionExternalTally = Optional<FullElectionExternalTal
 export enum ResultsFileType {
   CastVoteRecord = 'cvr',
   SEMS = 'sems',
+  All = 'all',
 }
 
 export type OptionalFile = Optional<File>

--- a/apps/election-manager/src/screens/TallyScreen.tsx
+++ b/apps/election-manager/src/screens/TallyScreen.tsx
@@ -273,7 +273,8 @@ const TallyScreen: React.FC = () => {
           <FileInputButton
             onChange={importExternalSEMSFile}
             accept="*"
-            disabled={!!fullElectionExternalTally}
+            data-testid="import-sems-button"
+            disabled={!!fullElectionExternalTally || isOfficialResults}
           >
             Import SEMS File
           </FileInputButton>{' '}
@@ -284,22 +285,34 @@ const TallyScreen: React.FC = () => {
             Mark Tally Results as Official…
           </Button>
         </p>
-        <p>
-          <Button
-            danger
-            disabled={!hasCastVoteRecordFiles}
-            onPress={() => confirmRemoveFiles(ResultsFileType.CastVoteRecord)}
-          >
-            Remove CVR Files…
-          </Button>{' '}
-          <Button
-            danger
-            disabled={!externalVoteRecordsFile}
-            onPress={() => confirmRemoveFiles(ResultsFileType.SEMS)}
-          >
-            Remove SEMS File…
-          </Button>
-        </p>
+        {isOfficialResults ? (
+          <p>
+            <Button
+              danger
+              disabled={!hasAnyFiles}
+              onPress={() => confirmRemoveFiles(ResultsFileType.All)}
+            >
+              Clear All Results…
+            </Button>
+          </p>
+        ) : (
+          <p>
+            <Button
+              danger
+              disabled={!hasCastVoteRecordFiles}
+              onPress={() => confirmRemoveFiles(ResultsFileType.CastVoteRecord)}
+            >
+              Remove CVR Files…
+            </Button>{' '}
+            <Button
+              danger
+              disabled={!externalVoteRecordsFile}
+              onPress={() => confirmRemoveFiles(ResultsFileType.SEMS)}
+            >
+              Remove SEMS File…
+            </Button>
+          </p>
+        )}
         {tallyResultsTable}
         {hasConverter && hasCastVoteRecordFiles && (
           <React.Fragment>
@@ -339,8 +352,8 @@ const TallyScreen: React.FC = () => {
             <Prose textCenter>
               <h1>Mark Unofficial Tally Results as Official Tally Results?</h1>
               <p>
-                Have all CVR files been loaded? Once results are marked as
-                official, no additional CVRs can be loaded.
+                Have all CVR and SEMS files been loaded? Once results are marked
+                as official, no additional CVR or SEMS files can be loaded.
               </p>
               <p>Have all unofficial tally reports been reviewed?</p>
             </Prose>


### PR DESCRIPTION
Locks importing SEMS file after marking results as official. Prior to the SEMS workflow after marking results as official you could still remove CVR files which would also remove the official marking. Because of that once results are marked as official I now replace the seperate "remove cvr" and "remove sems" file buttons with one "clear all results" button that will remove all cvr and sems files and mark results as unofficial. Open to suggestions on the copy for "Clear all results" I thought that helped suggest it is a full reset that will do things like mark the results as unofficial again instead of just removing the files. 

I will add more testing with the SEMS part of this workflow once https://github.com/votingworks/vxsuite/pull/275 is landed. 


https://user-images.githubusercontent.com/14897017/108905847-0eb29300-75d5-11eb-9e7e-ea9aad188133.mov

