### PR TITLE
Make SEMS workflow language generic and remove option to exclude SEMS data in final export 

### DIFF
--- a/apps/election-manager/src/App.test.tsx
+++ b/apps/election-manager/src/App.test.tsx
@@ -317,7 +317,9 @@ it('tabulating CVRs with SEMS file', async () => {
   await waitFor(() =>
     expect(getByTestId('total-ballot-count').textContent).toEqual('200')
   )
-  expect(getAllByText('SEMS File (sems-results.csv)').length).toBe(3)
+  expect(getAllByText('External Results File (sems-results.csv)').length).toBe(
+    3
+  )
 
   fireEvent.click(getByText('View Unofficial Full Election Tally Report'))
   const ballotsByDataSource = getAllByTestId('data-source-table')
@@ -327,7 +329,7 @@ it('tabulating CVRs with SEMS file', async () => {
   domGetByText(vxRow, '100')
 
   const semsRow = domGetByTestId(ballotsByDataSource[0], 'externalvoterecords')
-  domGetByText(semsRow, 'Imported SEMS File')
+  domGetByText(semsRow, 'External Results File')
   domGetByText(semsRow, '100')
 
   const totalsRow = domGetByTestId(ballotsByDataSource[0], 'total')
@@ -345,7 +347,7 @@ it('tabulating CVRs with SEMS file', async () => {
   domGetByText(precinctRow, '50')
 
   const semsRow2 = domGetByTestId(ballotsByDataSource[0], 'externalvoterecords')
-  domGetByText(semsRow2, 'Imported SEMS File')
+  domGetByText(semsRow2, 'External Results File')
   domGetByText(semsRow2, '100')
 
   const totalsRow2 = domGetByTestId(ballotsByDataSource[0], 'total')
@@ -356,8 +358,8 @@ it('tabulating CVRs with SEMS file', async () => {
   fireEvent.click(getByText('Back to Tally Index'))
 
   // Test removing the SEMS file
-  fireEvent.click(getByText('Remove SEMS File…'))
-  fireEvent.click(getByText('Remove SEMS Files'))
+  fireEvent.click(getByText('Remove External Results File…'))
+  fireEvent.click(getByText('Remove External Files'))
 
   await waitFor(() =>
     expect(getByTestId('total-ballot-count').textContent).toEqual('100')
@@ -468,12 +470,14 @@ it('clearing all files after marking as official clears SEMS and CVR file', asyn
 
   fireEvent.click(getByText('Clear All Results…'))
   getByText(
-    'Do you want to remove the 1 uploaded CVR file and the SEMS file sems-results.csv?'
+    'Do you want to remove the 1 uploaded CVR file and the external results file sems-results.csv?'
   )
   fireEvent.click(getByText('Remove All Files'))
 
   expect(getByText('Remove CVR Files…').closest('button')).toBeDisabled()
-  expect(getByText('Remove SEMS File…').closest('button')).toBeDisabled()
+  expect(
+    getByText('Remove External Results File…').closest('button')
+  ).toBeDisabled()
 
   expect(getByText('Import CVR Files').closest('button')).toBeEnabled()
   expect(getByTestId('import-sems-button')).toBeEnabled()

--- a/apps/election-manager/src/components/BallotCountsTable.test.tsx
+++ b/apps/election-manager/src/components/BallotCountsTable.test.tsx
@@ -273,8 +273,10 @@ describe('Ballot Counts by Scanner', () => {
       }
     })
 
-    getByText('SEMS File (file-name.csv)')
-    let tableRow = getByText('SEMS File (file-name.csv)').closest('tr')
+    getByText('External Results File (file-name.csv)')
+    let tableRow = getByText('External Results File (file-name.csv)').closest(
+      'tr'
+    )
     expect(tableRow).toBeDefined()
     expect(domGetByText(tableRow!, 54))
 
@@ -575,8 +577,10 @@ describe('Ballots Counts by VotingMethod', () => {
       )
     })
 
-    getByText('SEMS File (file-name.csv)')
-    let tableRow = getByText('SEMS File (file-name.csv)').closest('tr')
+    getByText('External Results File (file-name.csv)')
+    let tableRow = getByText('External Results File (file-name.csv)').closest(
+      'tr'
+    )
     expect(tableRow).toBeDefined()
     expect(domGetByText(tableRow!, 54))
 

--- a/apps/election-manager/src/components/BallotCountsTable.tsx
+++ b/apps/election-manager/src/components/BallotCountsTable.tsx
@@ -166,7 +166,7 @@ const BallotCountsTable: React.FC<Props> = ({ breakdownCategory }) => {
               {externalVoteRecordsFile && (
                 <tr data-testid="table-row">
                   <TD narrow nowrap>
-                    SEMS File ({externalVoteRecordsFile.name})
+                    External Results File ({externalVoteRecordsFile.name})
                   </TD>
                   <TD>{format.count(totalBallotCountExternal)}</TD>
                   <TD />
@@ -312,7 +312,7 @@ const BallotCountsTable: React.FC<Props> = ({ breakdownCategory }) => {
             {externalVoteRecordsFile && (
               <tr data-testid="table-row">
                 <TD narrow nowrap>
-                  SEMS File ({externalVoteRecordsFile.name})
+                  External Results File ({externalVoteRecordsFile.name})
                 </TD>
                 <TD>{format.count(totalBallotCountExternal)}</TD>
                 <TD />

--- a/apps/election-manager/src/components/ConfirmRemovingFileModal.tsx
+++ b/apps/election-manager/src/components/ConfirmRemovingFileModal.tsx
@@ -70,10 +70,11 @@ export const ConfirmRemovingFileModal: React.FC<Props> = ({
       break
     }
     case ResultsFileType.SEMS: {
-      fileTypeName = 'SEMS'
+      fileTypeName = 'External'
       mainContent = (
         <p>
-          Do you want to remove the SEMS file {externalVoteRecordsFile!.name}?
+          Do you want to remove the external results file{' '}
+          {externalVoteRecordsFile!.name}?
         </p>
       )
       break
@@ -88,7 +89,7 @@ export const ConfirmRemovingFileModal: React.FC<Props> = ({
             Do you want to remove the {fileList.length} uploaded CVR{' '}
             {pluralize('files', fileList.length)}
             {externalVoteRecordsFile &&
-              ` and the SEMS file ${externalVoteRecordsFile!.name}`}
+              ` and the external results file ${externalVoteRecordsFile!.name}`}
             ?
           </p>
           <p>All reports will be unavailable without CVR data.</p>

--- a/apps/election-manager/src/components/ExportFinalResultsModal.test.tsx
+++ b/apps/election-manager/src/components/ExportFinalResultsModal.test.tsx
@@ -147,7 +147,6 @@ test('render export modal when a usb drive is mounted and exports with external 
     }
   )
   getByText('Save Results File')
-  getByText(/Include data from SEMS file/)
   getByText(/Save the final tally results to /)
   getByText(
     'votingworks-live-results_choctaw-county_mock-general-election-choctaw-2020_2020-03-14_01-59-26.csv'

--- a/apps/election-manager/src/components/ExportFinalResultsModal.tsx
+++ b/apps/election-manager/src/components/ExportFinalResultsModal.tsx
@@ -5,7 +5,7 @@ import fileDownload from 'js-file-download'
 
 import AppContext from '../contexts/AppContext'
 import Modal from './Modal'
-import Button, { SegmentedButton } from './Button'
+import Button from './Button'
 import Prose from './Prose'
 import LinkButton from './LinkButton'
 import Loading from './Loading'
@@ -46,7 +46,6 @@ const ExportFinalResultsModal: React.FC<Props> = ({ onClose }) => {
   const [errorMessage, setErrorMessage] = useState('')
 
   const [savedFilename, setSavedFilename] = useState('')
-  const [includeExternalFile, setIncludeExternalFile] = useState(true)
   const defaultFilename = useMemo(
     () =>
       generateFinalExportDefaultFilename(
@@ -61,7 +60,7 @@ const ExportFinalResultsModal: React.FC<Props> = ({ onClose }) => {
     defaultFilename: string
   ) => {
     setCurrentState(ModalState.SAVING)
-    const includeExternalData = externalVoteRecordsFile && includeExternalFile
+    const includeExternalData = externalVoteRecordsFile !== undefined
 
     try {
       const CastVoteRecordsString = castVoteRecordFiles.castVoteRecords
@@ -246,37 +245,12 @@ const ExportFinalResultsModal: React.FC<Props> = ({ onClose }) => {
         />
       )
     case UsbDriveStatus.mounted: {
-      let options = null
-      if (externalVoteRecordsFile) {
-        options = (
-          <p>
-            Include data from SEMS file:{' '}
-            <SegmentedButton>
-              <Button
-                small
-                disabled={includeExternalFile}
-                onPress={() => setIncludeExternalFile(true)}
-              >
-                Yes
-              </Button>
-              <Button
-                small
-                disabled={!includeExternalFile}
-                onPress={() => setIncludeExternalFile(false)}
-              >
-                No
-              </Button>
-            </SegmentedButton>
-          </p>
-        )
-      }
       return (
         <Modal
           content={
             <MainChild>
               <Prose>
                 <h1>Save Results File</h1>
-                {options}
                 <p>
                   Save the final tally results to{' '}
                   <strong>{defaultFilename}</strong> directly on the inserted

--- a/apps/election-manager/src/components/TallyReportMetadata.test.tsx
+++ b/apps/election-manager/src/components/TallyReportMetadata.test.tsx
@@ -38,7 +38,7 @@ test('Renders with data source tables when external ballot count specified', () 
   getByText('Ballots Cast by Data Source')
   const internalRow = getByText('VotingWorks Data').closest('tr')!
   domGetByText(internalRow, '1,234')
-  const externalRow = getByText('Imported SEMS File').closest('tr')!
+  const externalRow = getByText('External Results File').closest('tr')!
   domGetByText(externalRow, '2,345')
   const totalRow = getByText('Total').closest('tr')!
   domGetByText(totalRow, '3,579')
@@ -75,7 +75,7 @@ test('Renders with data source table and voting method table when all data provi
   domGetByText(internalRow, '1,234')
   const externalRow = domGetByText(
     dataSourceTable,
-    'Imported SEMS File'
+    'External Results File'
   ).closest('tr')!
   domGetByText(externalRow, '2,345')
   const totalRow = domGetByText(dataSourceTable, 'Total').closest('tr')!
@@ -89,7 +89,7 @@ test('Renders with data source table and voting method table when all data provi
   domGetByText(row2, '1,045')
   const row3 = domGetByText(votingMethodTable, 'Other').closest('tr')!
   domGetByText(row3, '12')
-  const row4 = domGetByText(votingMethodTable, 'Imported SEMS File').closest(
+  const row4 = domGetByText(votingMethodTable, 'External Results File').closest(
     'tr'
   )!
   domGetByText(row4, '2,345')

--- a/apps/election-manager/src/components/TallyReportMetadata.tsx
+++ b/apps/election-manager/src/components/TallyReportMetadata.tsx
@@ -48,7 +48,7 @@ const TallyReportMetadata: React.FC<Props> = ({
               <TD textAlign="right">{format.count(internalBallotCount)}</TD>
             </tr>
             <tr data-testid="externalvoterecords">
-              <TD>Imported SEMS File</TD>
+              <TD>External Results File </TD>
               <TD textAlign="right">{format.count(externalBallotCount)}</TD>
             </tr>
             <tr data-testid="total">
@@ -103,7 +103,7 @@ const TallyReportMetadata: React.FC<Props> = ({
             {tableRows}
             {externalBallotCount !== undefined && (
               <tr data-testid="externalvoterecords">
-                <TD>Imported SEMS File</TD>
+                <TD>External Results File</TD>
                 <TD textAlign="right">{format.count(externalBallotCount)}</TD>
               </tr>
             )}

--- a/apps/election-manager/src/screens/TallyScreen.tsx
+++ b/apps/election-manager/src/screens/TallyScreen.tsx
@@ -183,7 +183,7 @@ const TallyScreen: React.FC = () => {
           {moment(externalVoteRecordsFile.lastModified).format(TIME_FORMAT)}
         </TD>
         <TD narrow nowrap>
-          SEMS File ({externalVoteRecordsFile.name})
+          External Results File ({externalVoteRecordsFile.name})
         </TD>
         <TD narrow>{format.count(externalFileBallotCount)}</TD>
         <TD>{getPrecinctNames(precinctsInExternalFile)}</TD>
@@ -276,7 +276,7 @@ const TallyScreen: React.FC = () => {
             data-testid="import-sems-button"
             disabled={!!fullElectionExternalTally || isOfficialResults}
           >
-            Import SEMS File
+            Import External Results File
           </FileInputButton>{' '}
           <Button
             disabled={!hasCastVoteRecordFiles || isOfficialResults}
@@ -309,7 +309,7 @@ const TallyScreen: React.FC = () => {
               disabled={!externalVoteRecordsFile}
               onPress={() => confirmRemoveFiles(ResultsFileType.SEMS)}
             >
-              Remove SEMS File…
+              Remove External Results File…
             </Button>
           </p>
         )}
@@ -352,8 +352,9 @@ const TallyScreen: React.FC = () => {
             <Prose textCenter>
               <h1>Mark Unofficial Tally Results as Official Tally Results?</h1>
               <p>
-                Have all CVR and SEMS files been loaded? Once results are marked
-                as official, no additional CVR or SEMS files can be loaded.
+                Have all CVR and external results files been loaded? Once
+                results are marked as official, no additional CVR or external
+                files can be loaded.
               </p>
               <p>Have all unofficial tally reports been reviewed?</p>
             </Prose>


### PR DESCRIPTION
Removes the ability to toggle whether or not you want to include SEMS data in the final export, it should always be included and the user could always remove the file if they wanted to. Also updates all language referring to a "SEMS File" to instead refer to a generic "External Results File". Split into two commits. 