### PR TITLE
test(smartcards): compute hash in card fixtures

### DIFF
--- a/apps/module-smartcards/fixtures/admin/short.json
+++ b/apps/module-smartcards/fixtures/admin/short.json
@@ -1,1 +1,1 @@
-{"t":"admin","h":"blah"}
+{"t":"admin","h":"{{hash(long)}}"}

--- a/apps/module-smartcards/fixtures/pollworker/short.json
+++ b/apps/module-smartcards/fixtures/pollworker/short.json
@@ -1,1 +1,1 @@
-{"t":"pollworker","h":"blah"}
+{"t":"pollworker","h":"{{hash(long)}}"}

--- a/libs/fixtures/src/index.test.ts
+++ b/libs/fixtures/src/index.test.ts
@@ -1,7 +1,11 @@
 import * as fixtures from '.'
 
 test('has various election definitions', () => {
-  expect(Object.keys(fixtures)).toMatchInlineSnapshot(`
+  expect(
+    Object.entries(fixtures)
+      .filter(([, value]) => typeof value !== 'function')
+      .map(([key]) => key)
+  ).toMatchInlineSnapshot(`
     Array [
       "electionSample",
       "primaryElectionSample",

--- a/libs/fixtures/src/index.ts
+++ b/libs/fixtures/src/index.ts
@@ -7,7 +7,7 @@ import multiPartyPrimaryElectionUntyped from './data/electionMultiPartyPrimarySa
 import electionSampleLongContentUntyped from './data/electionSampleLongContent.json'
 import electionWithMsEitherNeitherUntyped from './data/electionWithMsEitherNeither.json'
 
-function electionDefinition(election: Election): ElectionDefinition {
+export function asElectionDefinition(election: Election): ElectionDefinition {
   return {
     election,
     electionHash: sha256(JSON.stringify(election)),
@@ -20,16 +20,16 @@ export const multiPartyPrimaryElection = (multiPartyPrimaryElectionUntyped as un
 export const electionSampleLongContent = (electionSampleLongContentUntyped as unknown) as Election
 export const electionWithMsEitherNeither = (electionWithMsEitherNeitherUntyped as unknown) as Election
 
-export const electionSampleDefinition = electionDefinition(electionSample)
-export const primaryElectionSampleDefinition = electionDefinition(
+export const electionSampleDefinition = asElectionDefinition(electionSample)
+export const primaryElectionSampleDefinition = asElectionDefinition(
   primaryElectionSample
 )
-export const multiPartyPrimaryElectionDefinition = electionDefinition(
+export const multiPartyPrimaryElectionDefinition = asElectionDefinition(
   multiPartyPrimaryElection
 )
-export const electionSampleLongContentDefinition = electionDefinition(
+export const electionSampleLongContentDefinition = asElectionDefinition(
   electionSampleLongContent
 )
-export const electionWithMsEitherNeitherDefinition = electionDefinition(
+export const electionWithMsEitherNeitherDefinition = asElectionDefinition(
   electionWithMsEitherNeither
 )


### PR DESCRIPTION
This ensures the election hash for fixtures is always up-to-date.