### PR TITLE
feat(bmd): check election hash

### DIFF
--- a/apps/bmd/src/AppContestCandidateNoParty.test.tsx
+++ b/apps/bmd/src/AppContestCandidateNoParty.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 
 import { Election } from '@votingworks/types'
+import { asElectionDefinition } from '@votingworks/fixtures'
 import App from './App'
 
 import { advanceTimers, getNewVoterCard } from '../test/helpers/smartcards'
@@ -47,10 +48,10 @@ it('Single Seat Contest', async () => {
   const storage = new MemoryStorage<AppStorage>()
   const machineConfig = fakeMachineConfigProvider()
 
-  storage.set(electionStorageKey, {
-    election: electionWithNoPartyCandidateContests,
-    electionHash: 'test-hash',
-  })
+  storage.set(
+    electionStorageKey,
+    asElectionDefinition(electionWithNoPartyCandidateContests)
+  )
   setStateInStorage(storage)
 
   const { container, getByText, queryByText } = render(

--- a/apps/bmd/src/AppContestMsEitherNeither.test.tsx
+++ b/apps/bmd/src/AppContestMsEitherNeither.test.tsx
@@ -7,6 +7,7 @@ import {
   parseElection,
   vote,
 } from '@votingworks/types'
+import { asElectionDefinition } from '@votingworks/fixtures'
 import electionSample from './data/electionSample.json'
 
 import App from './App'
@@ -28,14 +29,15 @@ import { MemoryHardware } from './utils/Hardware'
 import { fakeMachineConfigProvider } from '../test/helpers/fakeMachineConfig'
 
 test('Renders Ballot with EitherNeither: blank', () => {
-  const election = parseElection(electionSample)
+  const electionDefinition = asElectionDefinition(parseElection(electionSample))
+  const { election } = electionDefinition
   const { getByText } = renderWithBallotContext(
     <Route path="/print" component={PrintPage} />,
     {
       ballotStyleId: '12',
       precinctId: '23',
       route: '/print',
-      election,
+      electionDefinition,
       votes: vote(
         getContests({
           ballotStyle: getBallotStyle({
@@ -59,14 +61,15 @@ test('Renders Ballot with EitherNeither: blank', () => {
 })
 
 test('Renders Ballot with EitherNeither: Either & blank', () => {
-  const election = parseElection(electionSample)
+  const electionDefinition = asElectionDefinition(parseElection(electionSample))
+  const { election } = electionDefinition
   const { getByText } = renderWithBallotContext(
     <Route path="/print" component={PrintPage} />,
     {
       ballotStyleId: '12',
       precinctId: '23',
       route: '/print',
-      election,
+      electionDefinition,
       votes: vote(
         getContests({
           ballotStyle: getBallotStyle({
@@ -93,14 +96,15 @@ test('Renders Ballot with EitherNeither: Either & blank', () => {
 })
 
 test('Renders Ballot with EitherNeither: Neither & firstOption', () => {
-  const election = parseElection(electionSample)
+  const electionDefinition = asElectionDefinition(parseElection(electionSample))
+  const { election } = electionDefinition
   const { getByText } = renderWithBallotContext(
     <Route path="/print" component={PrintPage} />,
     {
       ballotStyleId: '12',
       precinctId: '23',
       route: '/print',
-      election,
+      electionDefinition,
       votes: vote(
         getContests({
           ballotStyle: getBallotStyle({
@@ -127,14 +131,15 @@ test('Renders Ballot with EitherNeither: Neither & firstOption', () => {
 })
 
 test('Renders Ballot with EitherNeither: blank & secondOption', () => {
-  const election = parseElection(electionSample)
+  const electionDefinition = asElectionDefinition(parseElection(electionSample))
+  const { election } = electionDefinition
   const { getByText } = renderWithBallotContext(
     <Route path="/print" component={PrintPage} />,
     {
       ballotStyleId: '12',
       precinctId: '23',
       route: '/print',
-      election,
+      electionDefinition,
       votes: vote(
         getContests({
           ballotStyle: getBallotStyle({

--- a/apps/bmd/src/AppEndToEnd.test.tsx
+++ b/apps/bmd/src/AppEndToEnd.test.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import { fireEvent, render, waitFor, within } from '@testing-library/react'
+import { asElectionDefinition } from '@votingworks/fixtures'
+import { parseElection } from '@votingworks/types'
 import { advanceBy } from 'jest-date-mock'
 import { sha256 } from 'js-sha256'
 import * as GLOBALS from './config/globals'
@@ -12,12 +14,12 @@ import App from './App'
 import withMarkup from '../test/helpers/withMarkup'
 
 import {
-  adminCard,
+  adminCardForElection,
   advanceTimersAndPromises,
   getAlternateNewVoterCard,
   getNewVoterCard,
   getUsedVoterCard,
-  pollWorkerCard,
+  pollWorkerCardForElection,
 } from '../test/helpers/smartcards'
 
 import {
@@ -44,6 +46,7 @@ jest.useFakeTimers()
 jest.setTimeout(15000)
 
 it('VxMark+Print end-to-end flow', async () => {
+  const electionDefinition = asElectionDefinition(parseElection(electionSample))
   const card = new MemoryCard()
   const hardware = MemoryHardware.standard
   const printer = fakePrinter()
@@ -64,6 +67,10 @@ it('VxMark+Print end-to-end flow', async () => {
       printer={printer}
       storage={storage}
     />
+  )
+  const adminCard = adminCardForElection(electionDefinition.electionHash)
+  const pollWorkerCard = pollWorkerCardForElection(
+    electionDefinition.electionHash
   )
   const getByTextWithMarkup = withMarkup(getByText)
 

--- a/apps/bmd/src/AppMarkOnly.test.tsx
+++ b/apps/bmd/src/AppMarkOnly.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { fireEvent, render, within } from '@testing-library/react'
 // import { electionSample } from '@votingworks/fixtures'
+import { asElectionDefinition } from '@votingworks/fixtures'
+import { parseElection } from '@votingworks/types'
 import electionSample from './data/electionSample.json'
 
 import App from './App'
@@ -8,11 +10,11 @@ import App from './App'
 import withMarkup from '../test/helpers/withMarkup'
 
 import {
-  adminCard,
+  adminCardForElection,
   advanceTimersAndPromises,
   getExpiredVoterCard,
   getNewVoterCard,
-  pollWorkerCard,
+  pollWorkerCardForElection,
 } from '../test/helpers/smartcards'
 
 import {
@@ -33,7 +35,12 @@ beforeEach(() => {
 it('VxMarkOnly flow', async () => {
   jest.useFakeTimers()
 
+  const electionDefinition = asElectionDefinition(parseElection(electionSample))
   const card = new MemoryCard()
+  const adminCard = adminCardForElection(electionDefinition.electionHash)
+  const pollWorkerCard = pollWorkerCardForElection(
+    electionDefinition.electionHash
+  )
   const hardware = MemoryHardware.standard
   const storage = new MemoryStorage<AppStorage>()
   const machineConfig = fakeMachineConfigProvider()

--- a/apps/bmd/src/AppPrintOnly.test.tsx
+++ b/apps/bmd/src/AppPrintOnly.test.tsx
@@ -1,18 +1,21 @@
 import React from 'react'
 import { fireEvent, render, within } from '@testing-library/react'
-import { electionSample } from '@votingworks/fixtures'
+import {
+  asElectionDefinition,
+  electionSampleDefinition,
+} from '@votingworks/fixtures'
 import { encodeBallot } from '@votingworks/ballot-encoder'
-import { BallotType, Election } from '@votingworks/types'
+import { BallotType } from '@votingworks/types'
 
 import App from './App'
 
 import {
-  adminCard,
+  adminCardForElection,
   advanceTimersAndPromises,
   getExpiredVoterCard,
   getNewVoterCard,
   getUsedVoterCard,
-  pollWorkerCard,
+  pollWorkerCardForElection,
   sampleVotes1,
   sampleVotes2,
   sampleVotes3,
@@ -41,8 +44,10 @@ jest.useFakeTimers()
 jest.setTimeout(12000)
 
 test('VxPrintOnly flow', async () => {
-  const election = electionSample
+  const { election, electionHash } = electionSampleDefinition
   const card = new MemoryCard()
+  const adminCard = adminCardForElection(electionHash)
+  const pollWorkerCard = pollWorkerCardForElection(electionHash)
   const printer = fakePrinter()
   const hardware = MemoryHardware.standard
   const storage = new MemoryStorage<AppStorage>()
@@ -403,8 +408,10 @@ test('VxPrintOnly flow', async () => {
 })
 
 test('VxPrint retains app mode when unconfigured', async () => {
-  const election = electionSample
+  const { election, electionHash } = electionSampleDefinition
   const card = new MemoryCard()
+  const adminCard = adminCardForElection(electionHash)
+  const pollWorkerCard = pollWorkerCardForElection(electionHash)
   const printer = fakePrinter()
   const hardware = MemoryHardware.standard
   const storage = new MemoryStorage<AppStorage>()
@@ -507,10 +514,14 @@ test('VxPrint retains app mode when unconfigured', async () => {
 })
 
 test('VxPrint prompts to change to live mode on election day', async () => {
-  const election: Election = {
-    ...electionSample,
+  const electionDefinition = asElectionDefinition({
+    ...electionSampleDefinition.election,
     date: new Date().toISOString(),
-  }
+  })
+  const adminCard = adminCardForElection(electionDefinition.electionHash)
+  const pollWorkerCard = pollWorkerCardForElection(
+    electionDefinition.electionHash
+  )
   const card = new MemoryCard()
   const printer = fakePrinter()
   const hardware = MemoryHardware.standard
@@ -532,7 +543,7 @@ test('VxPrint prompts to change to live mode on election day', async () => {
   // ---------------
 
   // Configure with Admin Card
-  card.insertCard(adminCard, election)
+  card.insertCard(adminCard, electionDefinition.election)
   await advanceTimersAndPromises()
   fireEvent.click(getByText('Load Election Definition'))
 

--- a/apps/bmd/src/AppRoot.tsx
+++ b/apps/bmd/src/AppRoot.tsx
@@ -73,6 +73,7 @@ import {
 import { getSingleYesNoVote } from './utils/votes'
 
 interface CardState {
+  adminCardElectionHash: string
   isAdminCardPresent: boolean
   isCardlessVoter: boolean
   isPollWorkerCardPresent: boolean
@@ -146,6 +147,7 @@ export const votesStorageKey = 'votes'
 export const blankBallotVotes = {}
 
 const initialCardState: Readonly<CardState> = {
+  adminCardElectionHash: '',
   isAdminCardPresent: false,
   isCardlessVoter: false,
   isPollWorkerCardPresent: false,
@@ -281,7 +283,7 @@ const calculateTally = ({
 
 // Sets State. All side effects done outside: storage, fetching, etc
 type AppAction =
-  | { type: 'processAdminCard' }
+  | { type: 'processAdminCard'; electionHash: string }
   | { type: 'processPollWorkerCard' }
   | { type: 'processVoterCard'; voterState: Partial<InitialUserState> }
   | { type: 'pauseCardProcessing' }
@@ -320,6 +322,7 @@ const appReducer = (state: State, action: AppAction): State => {
         ...state,
         ...initialCardState,
         isAdminCardPresent: true,
+        adminCardElectionHash: action.electionHash,
       }
     case 'processPollWorkerCard':
       return {
@@ -515,6 +518,7 @@ const AppRoot: React.FC<Props> = ({
   const PostVotingInstructionsTimeout = useRef(0)
   const [appState, dispatchAppState] = useReducer(appReducer, initialAppState)
   const {
+    adminCardElectionHash,
     appPrecinctId,
     ballotsPrintedCount,
     ballotStyleId,
@@ -552,13 +556,13 @@ const AppRoot: React.FC<Props> = ({
   const ballotStyle = optionalElectionDefinition?.election
     ? getBallotStyle({
         ballotStyleId,
-        election: optionalElectionDefinition?.election,
+        election: optionalElectionDefinition.election,
       })
     : ''
   const contests =
     optionalElectionDefinition?.election && ballotStyle
       ? getContests({
-          election: optionalElectionDefinition?.election,
+          election: optionalElectionDefinition.election,
           ballotStyle,
         })
       : []
@@ -689,15 +693,23 @@ const AppRoot: React.FC<Props> = ({
     const electionData = await card.readLongString()
     /* istanbul ignore else */
     if (electionData) {
+      const computedElectionHash = sha256(electionData)
+      /* istanbul ignore next */
+      if (computedElectionHash !== adminCardElectionHash) {
+        // eslint-disable-next-line no-console
+        console.error(
+          `computed election hash (${computedElectionHash}) does not match admin card election hash (${adminCardElectionHash})`
+        )
+      }
       dispatchAppState({
         type: 'updateElectionDefinition',
         electionDefinition: {
           election: JSON.parse(electionData),
-          electionHash: sha256(electionData),
+          electionHash: computedElectionHash,
         },
       })
     }
-  }, [card])
+  }, [card, adminCardElectionHash])
 
   const activateCardlessBallotStyleId = (ballotStyleId: string) => {
     dispatchAppState({
@@ -766,13 +778,23 @@ const AppRoot: React.FC<Props> = ({
           break
         }
         case 'pollworker': {
+          /* istanbul ignore next */
+          if (cardData.h !== optionalElectionDefinition?.electionHash) {
+            // eslint-disable-next-line no-console
+            console.error(
+              `poll worker card election hash (${cardData.h}) does not match configured election hash (${optionalElectionDefinition?.electionHash})`
+            )
+          }
           dispatchAppState({ type: 'processPollWorkerCard' })
           break
         }
         case 'admin': {
           /* istanbul ignore else */
           if (longValueExists) {
-            dispatchAppState({ type: 'processAdminCard' })
+            dispatchAppState({
+              type: 'processAdminCard',
+              electionHash: cardData.h,
+            })
           }
           break
         }

--- a/apps/bmd/src/AppSetupErrors.test.tsx
+++ b/apps/bmd/src/AppSetupErrors.test.tsx
@@ -9,12 +9,13 @@ import { MemoryHardware } from './utils/Hardware'
 import { MemoryStorage } from './utils/Storage'
 
 import {
-  adminCard,
+  adminCardForElection,
   advanceTimers,
   advanceTimersAndPromises,
 } from '../test/helpers/smartcards'
 
 import {
+  electionDefinition,
   setElectionInStorage,
   setStateInStorage,
 } from '../test/helpers/election'
@@ -186,12 +187,13 @@ describe('Displays setup warning messages and errors scrrens', () => {
 
   it('Admin screen trumps "No Printer Detected" error', async () => {
     const card = new MemoryCard()
+    const adminCard = adminCardForElection(electionDefinition.electionHash)
     const storage = new MemoryStorage<AppStorage>()
     const machineConfig = fakeMachineConfigProvider({
       appMode: VxPrintOnly,
     })
     const hardware = MemoryHardware.standard
-    setElectionInStorage(storage)
+    setElectionInStorage(storage, electionDefinition)
     setStateInStorage(storage)
     const { getByText } = render(
       <App

--- a/apps/bmd/src/components/ElectionInfo.test.tsx
+++ b/apps/bmd/src/components/ElectionInfo.test.tsx
@@ -1,14 +1,14 @@
 import React from 'react'
 import { render } from '@testing-library/react'
-import { Election } from '@votingworks/types'
+import { asElectionDefinition } from '@votingworks/fixtures'
+import { parseElection } from '@votingworks/types'
 
 import ElectionInfo from './ElectionInfo'
 import electionSampleWithSeal from '../data/electionSampleWithSeal.json'
 
-const electionDefinition = {
-  election: electionSampleWithSeal as Election,
-  electionHash: 'test--hash--content-past-10-chars',
-}
+const electionDefinition = asElectionDefinition(
+  parseElection(electionSampleWithSeal)
+)
 
 it('renders horizontal ElectionInfo with hash when specified', () => {
   const { container } = render(

--- a/apps/bmd/src/components/PrintedBallot.tsx
+++ b/apps/bmd/src/components/PrintedBallot.tsx
@@ -6,10 +6,10 @@ import { encodeBallot } from '@votingworks/ballot-encoder'
 import {
   BallotType,
   CandidateVote,
+  Contests,
+  ElectionDefinition,
   YesNoVote,
   VotesDict,
-  Contests,
-  Election,
 } from '@votingworks/types'
 
 import * as GLOBALS from '../config/globals'
@@ -209,7 +209,7 @@ const MsEitherNeitherContestResult: React.FC<MsEitherNeitherContestResultInterfa
 
 interface Props {
   ballotStyleId: string
-  election: Election
+  electionDefinition: ElectionDefinition
   isLiveMode: boolean
   precinctId: string
   votes: VotesDict
@@ -217,13 +217,16 @@ interface Props {
 
 const PrintBallot: React.FC<Props> = ({
   ballotStyleId,
-  election,
+  electionDefinition,
   isLiveMode,
   precinctId,
   votes,
 }) => {
   const ballotId = randomBase64(10)
-  const { county, date, seal, sealURL, state, parties, title } = election
+  const {
+    election,
+    election: { county, date, seal, sealURL, state, parties, title },
+  } = electionDefinition
   const partyPrimaryAdjective = getPartyPrimaryAdjectiveFromBallotStyle({
     ballotStyleId,
     election,

--- a/apps/bmd/src/components/__snapshots__/ElectionInfo.test.tsx.snap
+++ b/apps/bmd/src/components/__snapshots__/ElectionInfo.test.tsx.snap
@@ -341,7 +341,7 @@ exports[`renders horizontal ElectionInfo with hash when specified 1`] = `
            
           <br />
           Election ID: 
-          test--hash
+          66e55c0ffe
         </p>
       </div>
     </div>
@@ -997,7 +997,7 @@ exports[`renders vertical ElectionInfo with hash when specified 1`] = `
         class="c4"
       >
         Election ID: 
-        test--hash
+        66e55c0ffe
       </p>
     </div>
   </div>

--- a/apps/bmd/src/config/types.ts
+++ b/apps/bmd/src/config/types.ts
@@ -155,10 +155,7 @@ export interface MsEitherNeitherContestResultInterface {
 
 // Smart Card Content
 export type CardDataTypes = 'voter' | 'pollworker' | 'admin'
-export interface CardData {
-  readonly t: CardDataTypes
-}
-export interface VoterCardData extends CardData {
+export interface VoterCardData {
   readonly t: 'voter'
   readonly c: number // created date
   readonly bs: string // ballot style id
@@ -168,14 +165,15 @@ export interface VoterCardData extends CardData {
   readonly u?: number // updated date
   readonly m?: string // mark machine id
 }
-export interface PollworkerCardData extends CardData {
+export interface PollworkerCardData {
   readonly t: 'pollworker'
   readonly h: string
 }
-export interface AdminCardData extends CardData {
+export interface AdminCardData {
   readonly t: 'admin'
   readonly h: string
 }
+export type CardData = VoterCardData | PollworkerCardData | AdminCardData
 
 export interface CardAbsentAPI {
   present: false

--- a/apps/bmd/src/pages/AdminScreen.test.tsx
+++ b/apps/bmd/src/pages/AdminScreen.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { act, fireEvent, within } from '@testing-library/react'
 import MockDate from 'mockdate'
 
+import { asElectionDefinition } from '@votingworks/fixtures'
 import { render } from '../../test/testUtils'
 import fakeKiosk from '../../test/helpers/fakeKiosk'
 import { election, defaultPrecinctId } from '../../test/helpers/election'
@@ -30,7 +31,7 @@ test('renders ClerkScreen for VxPrintOnly', async () => {
       appMode={VxPrintOnly}
       appPrecinctId={defaultPrecinctId}
       ballotsPrintedCount={0}
-      electionDefinition={{ election, electionHash: 'test-hash' }}
+      electionDefinition={asElectionDefinition(election)}
       fetchElection={jest.fn()}
       isLiveMode={false}
       updateAppPrecinctId={jest.fn()}
@@ -67,7 +68,7 @@ test('renders date and time settings modal', async () => {
       appMode={VxMarkOnly}
       appPrecinctId={defaultPrecinctId}
       ballotsPrintedCount={0}
-      electionDefinition={{ election, electionHash: 'test-hash' }}
+      electionDefinition={asElectionDefinition(election)}
       fetchElection={jest.fn()}
       isLiveMode={false}
       updateAppPrecinctId={jest.fn()}

--- a/apps/bmd/src/pages/PollWorkerScreen.test.tsx
+++ b/apps/bmd/src/pages/PollWorkerScreen.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { asElectionDefinition } from '@votingworks/fixtures'
 import { Election } from '@votingworks/types'
 
 import { fireEvent } from '@testing-library/react'
@@ -24,7 +25,7 @@ test('renders PollWorkerScreen', async () => {
       appPrecinctId={defaultPrecinctId}
       ballotsPrintedCount={0}
       ballotStyleId=""
-      electionDefinition={{ election, electionHash: 'test-hash' }}
+      electionDefinition={asElectionDefinition(election)}
       enableLiveMode={jest.fn()}
       hasVotes={false}
       isLiveMode={false}
@@ -51,7 +52,7 @@ test('switching out of test mode on election day', async () => {
       appPrecinctId={defaultPrecinctId}
       ballotsPrintedCount={0}
       ballotStyleId=""
-      electionDefinition={{ election, electionHash: 'test-hash' }}
+      electionDefinition={asElectionDefinition(election)}
       enableLiveMode={enableLiveMode}
       hasVotes={false}
       isLiveMode={false}
@@ -80,7 +81,7 @@ test('keeping test mode on election day', async () => {
       appPrecinctId={defaultPrecinctId}
       ballotsPrintedCount={0}
       ballotStyleId=""
-      electionDefinition={{ election, electionHash: 'test-hash' }}
+      electionDefinition={asElectionDefinition(election)}
       enableLiveMode={enableLiveMode}
       hasVotes={false}
       isLiveMode={false}
@@ -106,7 +107,7 @@ test('live mode on election day', async () => {
       appPrecinctId={defaultPrecinctId}
       ballotsPrintedCount={0}
       ballotStyleId=""
-      electionDefinition={{ election, electionHash: 'test-hash' }}
+      electionDefinition={asElectionDefinition(election)}
       enableLiveMode={enableLiveMode}
       hasVotes={false}
       isLiveMode

--- a/apps/bmd/src/pages/PrintOnlyScreen.tsx
+++ b/apps/bmd/src/pages/PrintOnlyScreen.tsx
@@ -211,7 +211,7 @@ const PrintOnlyScreen: React.FC<Props> = ({
       {isReadyToPrint && (
         <PrintedBallot
           ballotStyleId={ballotStyleId}
-          election={election}
+          electionDefinition={electionDefinition}
           isLiveMode={isLiveMode}
           precinctId={precinctId}
           votes={votes!} // votes exists because isReadyToPrint implies votes!=undefined , but tsc unable to reason about it

--- a/apps/bmd/src/pages/PrintPage.test.tsx
+++ b/apps/bmd/src/pages/PrintPage.test.tsx
@@ -1,4 +1,4 @@
-import { electionSample } from '@votingworks/fixtures'
+import { asElectionDefinition, electionSample } from '@votingworks/fixtures'
 import {
   getBallotStyle,
   getContests,
@@ -52,10 +52,12 @@ it('renders PrintPage with votes', () => {
 })
 
 it('renders PrintPage without votes and inline seal', () => {
-  const election = parseElection(electionSampleWithSeal)
+  const electionDefinition = asElectionDefinition(
+    parseElection(electionSampleWithSeal)
+  )
   const { container } = render(<Route path="/print" component={PrintPage} />, {
     ballotStyleId: '5',
-    election,
+    electionDefinition,
     precinctId: '21',
     route: '/print',
   })
@@ -63,10 +65,12 @@ it('renders PrintPage without votes and inline seal', () => {
 })
 
 it('renders PrintPage without votes and no seal', () => {
-  const election = parseElection(electionSampleNoSeal)
+  const electionDefinition = asElectionDefinition(
+    parseElection(electionSampleNoSeal)
+  )
   const { container } = render(<Route path="/print" component={PrintPage} />, {
     ballotStyleId: '5',
-    election,
+    electionDefinition,
     precinctId: '21',
     route: '/print',
   })

--- a/apps/bmd/src/pages/PrintPage.tsx
+++ b/apps/bmd/src/pages/PrintPage.tsx
@@ -29,7 +29,6 @@ const PrintPage: React.FC = () => {
     updateTally,
     votes,
   } = useContext(BallotContext)
-  const { election } = electionDefinition
   const printerTimer = useRef(0)
 
   const printBallot = useCallback(async () => {
@@ -86,7 +85,7 @@ const PrintPage: React.FC = () => {
       </Screen>
       <PrintedBallot
         ballotStyleId={ballotStyleId}
-        election={election!}
+        electionDefinition={electionDefinition}
         isLiveMode={isLiveMode}
         precinctId={precinctId}
         votes={votes}

--- a/apps/bmd/src/pages/StartPage.test.tsx
+++ b/apps/bmd/src/pages/StartPage.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Route } from 'react-router-dom'
+import { asElectionDefinition } from '@votingworks/fixtures'
 import { parseElection } from '@votingworks/types'
 
 import { render } from '../../test/testUtils'
@@ -10,12 +11,14 @@ import electionPrimarySample from '../data/electionPrimarySample.json'
 import StartPage from './StartPage'
 
 it('renders StartPage', async () => {
-  const election = parseElection(electionPrimarySample)
+  const electionDefinition = asElectionDefinition(
+    parseElection(electionPrimarySample)
+  )
   const { container, getAllByText, getByText } = render(
     <Route path="/" component={StartPage} />,
     {
       ballotStyleId: '12D',
-      election,
+      electionDefinition,
       precinctId: '23',
       route: '/',
     }
@@ -26,9 +29,11 @@ it('renders StartPage', async () => {
 })
 
 it('renders StartPage with inline SVG', async () => {
-  const election = parseElection(electionSampleWithSeal)
+  const electionDefinition = asElectionDefinition(
+    parseElection(electionSampleWithSeal)
+  )
   const { container } = render(<Route path="/" component={StartPage} />, {
-    election,
+    electionDefinition,
     precinctId: '23',
     route: '/',
   })
@@ -36,9 +41,11 @@ it('renders StartPage with inline SVG', async () => {
 })
 
 it('renders StartPage with no seal', async () => {
-  const election = parseElection(electionSampleNoSeal)
+  const electionDefinition = asElectionDefinition(
+    parseElection(electionSampleNoSeal)
+  )
   const { container } = render(<Route path="/" component={StartPage} />, {
-    election,
+    electionDefinition,
     precinctId: '23',
     route: '/',
   })

--- a/apps/bmd/src/pages/TestBallotDeckScreen.test.tsx
+++ b/apps/bmd/src/pages/TestBallotDeckScreen.test.tsx
@@ -1,11 +1,12 @@
 import {
   // electionSample,
-  Election,
+  parseElection,
 } from '@votingworks/types'
 // TODO: Tally: Use electionSample from @votingworks/fixtures once published.
 
 import React from 'react'
 import { fireEvent } from '@testing-library/react'
+import { asElectionDefinition } from '@votingworks/fixtures'
 import electionSample from '../data/electionSample.json'
 import { mockOf, render } from '../../test/testUtils'
 import { randomBase64 } from '../utils/random'
@@ -23,10 +24,7 @@ it('renders test decks appropriately', () => {
     <TestBallotDeckScreen
       appName="VxPrint"
       appPrecinctId="23"
-      electionDefinition={{
-        election: electionSample as Election,
-        electionHash: 'test-hash',
-      }}
+      electionDefinition={asElectionDefinition(parseElection(electionSample))}
       hideTestDeck={jest.fn()}
       isLiveMode={false}
     />

--- a/apps/bmd/src/pages/TestBallotDeckScreen.tsx
+++ b/apps/bmd/src/pages/TestBallotDeckScreen.tsx
@@ -229,7 +229,7 @@ const TestBallotDeckScreen: React.FC<Props> = ({
             // eslint-disable-next-line react/no-array-index-key
             key={`ballot-${i}`}
             ballotStyleId={ballot.ballotStyleId}
-            election={election}
+            electionDefinition={electionDefinition}
             isLiveMode={isLiveMode}
             precinctId={ballot.precinctId}
             votes={ballot.votes}

--- a/apps/bmd/test/helpers/election.ts
+++ b/apps/bmd/test/helpers/election.ts
@@ -1,7 +1,7 @@
-import { sha256 } from 'js-sha256'
 import fs from 'fs'
 import * as path from 'path'
 
+import { asElectionDefinition } from '@votingworks/fixtures'
 import {
   CandidateContest,
   YesNoContest,
@@ -27,10 +27,7 @@ const electionSampleData = fs.readFileSync(
   'utf-8'
 )
 export const election = JSON.parse(electionSampleData) as Election
-export const electionDefinition = {
-  election,
-  electionHash: sha256(electionSampleData),
-}
+export const electionDefinition = asElectionDefinition(election)
 
 export const contest0 = election.contests[0] as CandidateContest
 export const contest1 = election.contests[1] as CandidateContest
@@ -79,8 +76,11 @@ export const voterContests = getContests({
   election,
 })
 
-export const setElectionInStorage = (storage: Storage<AppStorage>): void => {
-  storage.set(electionStorageKey, electionDefinition)
+export const setElectionInStorage = (
+  storage: Storage<AppStorage>,
+  newElectionDefinition = electionDefinition
+): void => {
+  storage.set(electionStorageKey, newElectionDefinition)
 }
 
 export const setStateInStorage = (

--- a/apps/bmd/test/helpers/smartcards.ts
+++ b/apps/bmd/test/helpers/smartcards.ts
@@ -121,15 +121,17 @@ export const sampleVotes3: Readonly<VotesDict> = vote(
   }
 )
 
-export const adminCard = JSON.stringify({
-  t: 'admin',
-  h: 'abcd',
-})
+export const adminCardForElection = (electionHash: string): string =>
+  JSON.stringify({
+    t: 'admin',
+    h: electionHash,
+  })
 
-export const pollWorkerCard = JSON.stringify({
-  t: 'pollworker',
-  h: 'abcd',
-})
+export const pollWorkerCardForElection = (electionHash: string): string =>
+  JSON.stringify({
+    t: 'pollworker',
+    h: electionHash,
+  })
 
 export const createVoterCard = (
   cardData: Partial<VoterCardData> = {}

--- a/apps/bmd/test/testUtils.tsx
+++ b/apps/bmd/test/testUtils.tsx
@@ -4,11 +4,11 @@ import { Router } from 'react-router-dom'
 import { render as testRender } from '@testing-library/react'
 import {
   Contests,
-  Election,
   ElectionDefinition,
   parseElection,
   VotesDict,
 } from '@votingworks/types'
+import { asElectionDefinition } from '@votingworks/fixtures'
 
 import * as GLOBALS from '../src/config/globals'
 
@@ -34,11 +34,12 @@ export function render(
   {
     route = '/',
     ballotStyleId = '',
-    election = parseElection(electionSampleNoSeal),
-    contests = election.contests,
+    electionDefinition = asElectionDefinition(
+      parseElection(electionSampleNoSeal)
+    ),
+    contests = electionDefinition.election.contests,
     markVoterCardVoided = jest.fn(),
     markVoterCardPrinted = jest.fn(),
-    electionHash = '',
     history = createMemoryHistory({ initialEntries: [route] }),
     isCardlessVoter = false,
     isLiveMode = false,
@@ -55,11 +56,10 @@ export function render(
   }: {
     route?: string
     ballotStyleId?: string
-    election?: Election
+    electionDefinition?: ElectionDefinition
     contests?: Contests
     markVoterCardVoided?: MarkVoterCardFunction
     markVoterCardPrinted?: MarkVoterCardFunction
-    electionHash?: string
     history?: History
     isCardlessVoter?: boolean
     isLiveMode?: boolean
@@ -81,7 +81,7 @@ export function render(
         value={{
           ballotStyleId,
           contests,
-          electionDefinition: { election, electionHash } as ElectionDefinition,
+          electionDefinition,
           isCardlessVoter,
           isLiveMode,
           machineConfig,

--- a/libs/fixtures/src/index.test.ts
+++ b/libs/fixtures/src/index.test.ts
@@ -3,6 +3,7 @@ import * as fixtures from '.'
 test('has various election definitions', () => {
   expect(Object.keys(fixtures)).toMatchInlineSnapshot(`
     Array [
+      "asElectionDefinition",
       "electionSample",
       "primaryElectionSample",
       "multiPartyPrimaryElection",

--- a/libs/fixtures/src/index.ts
+++ b/libs/fixtures/src/index.ts
@@ -7,7 +7,7 @@ import multiPartyPrimaryElectionUntyped from './data/electionMultiPartyPrimarySa
 import electionSampleLongContentUntyped from './data/electionSampleLongContent.json'
 import electionWithMsEitherNeitherUntyped from './data/electionWithMsEitherNeither.json'
 
-function electionDefinition(election: Election): ElectionDefinition {
+export function asElectionDefinition(election: Election): ElectionDefinition {
   return {
     election,
     electionHash: sha256(JSON.stringify(election)),
@@ -20,16 +20,16 @@ export const multiPartyPrimaryElection = (multiPartyPrimaryElectionUntyped as un
 export const electionSampleLongContent = (electionSampleLongContentUntyped as unknown) as Election
 export const electionWithMsEitherNeither = (electionWithMsEitherNeitherUntyped as unknown) as Election
 
-export const electionSampleDefinition = electionDefinition(electionSample)
-export const primaryElectionSampleDefinition = electionDefinition(
+export const electionSampleDefinition = asElectionDefinition(electionSample)
+export const primaryElectionSampleDefinition = asElectionDefinition(
   primaryElectionSample
 )
-export const multiPartyPrimaryElectionDefinition = electionDefinition(
+export const multiPartyPrimaryElectionDefinition = asElectionDefinition(
   multiPartyPrimaryElection
 )
-export const electionSampleLongContentDefinition = electionDefinition(
+export const electionSampleLongContentDefinition = asElectionDefinition(
   electionSampleLongContent
 )
-export const electionWithMsEitherNeitherDefinition = electionDefinition(
+export const electionWithMsEitherNeitherDefinition = asElectionDefinition(
   electionWithMsEitherNeither
 )


### PR DESCRIPTION
We now check the election hash on the admin card's short value against our own computed hash. Then, when a poll worker card is inserted we verify the hash matches what we got from the admin card. Voter cards don't currently include an election hash.

Right now we just log when there's a mismatch. This should be replaced with something blocking the action in the future.

Refs #298