### PR TITLE
Add error screen for invalid election hash

### DIFF
--- a/apps/bsd/package.json
+++ b/apps/bsd/package.json
@@ -11,9 +11,9 @@
     "start": "script/react-scripts start",
     "stylelint:run": "stylelint 'src/**/*.{js,jsx,ts,tsx}' && stylelint 'src/**/*.css' --config .stylelintrc-css.js",
     "stylelint:run:fix": "stylelint 'src/**/*.{js,jsx,ts,tsx}' --fix && stylelint 'src/**/*.css' --config .stylelintrc-css.js --fix",
-    "test": "script/react-scripts test --env=jest-environment-jsdom-sixteen",
-    "test:coverage": "pnpm test -- --coverage --watchAll=false",
-    "test:debug": "script/react-scripts --inspect-brk test --runInBand --no-cache"
+    "test": "TZ=UTC script/react-scripts test --env=jest-environment-jsdom-sixteen",
+    "test:coverage": "TZ=UTC pnpm test -- --coverage --watchAll=false",
+    "test:debug": "TZ=UTC script/react-scripts --inspect-brk test --runInBand --no-cache"
   },
   "husky": {
     "hooks": {

--- a/apps/bsd/src/AppRoot.tsx
+++ b/apps/bsd/src/AppRoot.tsx
@@ -349,6 +349,8 @@ const App: React.FC = () => {
             usbDriveStatus: displayUsbStatus,
             usbDriveEject: doEject,
             machineConfig,
+            election,
+            electionHash,
           }}
         >
           <Screen>
@@ -376,10 +378,20 @@ const App: React.FC = () => {
     }
     if (adjudication.remaining > 0 && !isScanning) {
       return (
-        <BallotEjectScreen
-          continueScanning={continueScanning}
-          isTestMode={isTestMode}
-        />
+        <AppContext.Provider
+          value={{
+            usbDriveStatus: displayUsbStatus,
+            usbDriveEject: doEject,
+            election,
+            electionHash,
+            machineConfig,
+          }}
+        >
+          <BallotEjectScreen
+            continueScanning={continueScanning}
+            isTestMode={isTestMode}
+          />
+        </AppContext.Provider>
       )
     }
 
@@ -397,6 +409,8 @@ const App: React.FC = () => {
         value={{
           usbDriveStatus: displayUsbStatus,
           usbDriveEject: doEject,
+          election,
+          electionHash,
           machineConfig,
         }}
       >
@@ -470,11 +484,7 @@ const App: React.FC = () => {
                   Scan New Batch
                 </Button>
               </MainNav>
-              <StatusFooter
-                election={election}
-                electionHash={electionHash}
-                machineConfig={machineConfig}
-              />
+              <StatusFooter />
             </Screen>
             {isExportingCVRs && (
               <ExportResultsModal
@@ -502,6 +512,8 @@ const App: React.FC = () => {
           usbDriveStatus: displayUsbStatus,
           usbDriveEject: doEject,
           machineConfig,
+          election: undefined,
+          electionHash: undefined,
         }}
       >
         <LoadElectionScreen

--- a/apps/bsd/src/components/DebugSheet.tsx
+++ b/apps/bsd/src/components/DebugSheet.tsx
@@ -71,6 +71,7 @@ const DebugSheet: React.FC = () => {
     interpretation.type === 'UnreadablePage' ||
     interpretation.type === 'UninterpretedHmpbPage' ||
     interpretation.type === 'InterpretedBmdPage' ||
+    interpretation.type === 'InvalidElectionHashPage' ||
     page?.type !== 'ReviewMarginalMarksBallot'
   ) {
     return (

--- a/apps/bsd/src/components/DebugSheetPageCell.tsx
+++ b/apps/bsd/src/components/DebugSheetPageCell.tsx
@@ -65,6 +65,9 @@ function interpretationTitle(interpretation: PageInterpretation) {
     case 'UnreadablePage':
       return 'unreadable'
 
+    case 'InvalidElectionHashPage':
+      return 'invalid election'
+
     default:
       // @ts-expect-error - future-proofing in case the enum is out of date
       return interpretation.type

--- a/apps/bsd/src/components/StatusFooter.tsx
+++ b/apps/bsd/src/components/StatusFooter.tsx
@@ -1,9 +1,8 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import styled from 'styled-components'
-import { Election } from '@votingworks/types'
 import Text from './Text'
 import { localeWeedkayAndDate } from '../util/IntlDateTimeFormats'
-import { MachineConfig } from '../config/types'
+import AppContext from '../contexts/AppContext'
 
 const StatusBar = styled.div`
   display: flex;
@@ -14,17 +13,8 @@ const StatusBar = styled.div`
   padding: 0.375rem 1rem;
 `
 
-export interface Props {
-  election: Election
-  electionHash?: string
-  machineConfig: MachineConfig
-}
-
-const StatusFooter: React.FC<Props> = ({
-  election,
-  electionHash,
-  machineConfig,
-}) => {
+const StatusFooter: React.FC = () => {
+  const { election, electionHash, machineConfig } = useContext(AppContext)
   const electionDate =
     election && localeWeedkayAndDate.format(new Date(election?.date))
 

--- a/apps/bsd/src/components/USBControllerButton.test.tsx
+++ b/apps/bsd/src/components/USBControllerButton.test.tsx
@@ -1,11 +1,9 @@
-import { render } from '@testing-library/react'
 import React from 'react'
 
 import USBControllerButton from './USBControllerButton'
 
-import AppContext from '../contexts/AppContext'
 import { UsbDriveStatus } from '../lib/usbstick'
-import fakeMachineConfig from '../../test/helpers/fakeMachineConfig'
+import renderInAppContext from '../../test/renderInAppContext'
 
 jest.mock('../lib/usbstick')
 
@@ -18,40 +16,34 @@ afterAll(() => {
   delete window.kiosk
 })
 
-const renderWithStatus = (status: UsbDriveStatus) => {
-  return render(
-    <AppContext.Provider
-      value={{
-        usbDriveStatus: status,
-        usbDriveEject: jest.fn(),
-        machineConfig: fakeMachineConfig(),
-      }}
-    >
-      <USBControllerButton />
-    </AppContext.Provider>
-  )
-}
-
 test('shows nothing if USB not available', () => {
-  const { container } = renderWithStatus(UsbDriveStatus.notavailable)
+  const { container } = renderInAppContext(<USBControllerButton />, {
+    usbDriveStatus: UsbDriveStatus.notavailable,
+  })
 
   expect(container.firstChild).toMatchInlineSnapshot(`null`)
 })
 
 test('shows No USB if usb available but absent', () => {
-  const { container } = renderWithStatus(UsbDriveStatus.absent)
+  const { container } = renderInAppContext(<USBControllerButton />, {
+    usbDriveStatus: UsbDriveStatus.absent,
+  })
 
   expect(container.firstChild!.firstChild).toMatchInlineSnapshot(`No USB`)
 })
 
 test('shows eject if mounted', () => {
-  const { container } = renderWithStatus(UsbDriveStatus.mounted)
+  const { container } = renderInAppContext(<USBControllerButton />, {
+    usbDriveStatus: UsbDriveStatus.mounted,
+  })
 
   expect(container.firstChild!.firstChild).toMatchInlineSnapshot(`Eject USB`)
 })
 
 test('shows ejected if recently ejected', () => {
-  const { container } = renderWithStatus(UsbDriveStatus.recentlyEjected)
+  const { container } = renderInAppContext(<USBControllerButton />, {
+    usbDriveStatus: UsbDriveStatus.recentlyEjected,
+  })
 
   expect(container.firstChild!.firstChild).toMatchInlineSnapshot(`Ejected`)
 })

--- a/apps/bsd/src/config/types.ts
+++ b/apps/bsd/src/config/types.ts
@@ -169,6 +169,7 @@ export type PageInterpretation =
   | InvalidTestModePage
   | UninterpretedHmpbPage
   | UnreadablePage
+  | InvalidElectionHashPage
 
 export interface BlankPage {
   type: 'BlankPage'
@@ -203,6 +204,12 @@ export interface UninterpretedHmpbPage {
 export interface UnreadablePage {
   type: 'UnreadablePage'
   reason?: string
+}
+
+export interface InvalidElectionHashPage {
+  type: 'InvalidElectionHashPage'
+  expectedElectionHash: string
+  actualElectionHash: string
 }
 
 export type AdjudicationReasonInfo =

--- a/apps/bsd/src/contexts/AppContext.ts
+++ b/apps/bsd/src/contexts/AppContext.ts
@@ -1,3 +1,4 @@
+import { Election } from '@votingworks/types'
 import { createContext } from 'react'
 import { MachineConfig } from '../config/types'
 
@@ -5,12 +6,16 @@ interface AppContextInterface {
   usbDriveStatus: string
   usbDriveEject: () => void
   machineConfig: MachineConfig
+  election?: Election
+  electionHash?: string
 }
 
 const appContext: AppContextInterface = {
   usbDriveStatus: '',
   usbDriveEject: () => undefined,
   machineConfig: { machineId: '0000' },
+  election: undefined,
+  electionHash: undefined,
 }
 
 const AppContext = createContext(appContext)

--- a/apps/bsd/src/screens/BallotEjectScreen.test.tsx
+++ b/apps/bsd/src/screens/BallotEjectScreen.test.tsx
@@ -1,10 +1,11 @@
-import { render, waitFor, fireEvent } from '@testing-library/react'
+import { waitFor, fireEvent } from '@testing-library/react'
 import fetchMock from 'fetch-mock'
 import React from 'react'
 import { act } from 'react-dom/test-utils'
 import { BallotType, AdjudicationReason } from '@votingworks/types'
 import { BallotSheetInfo } from '../config/types'
 import BallotEjectScreen from './BallotEjectScreen'
+import renderInAppContext from '../../test/renderInAppContext'
 
 test('says the sheet is unreadable if it is', async () => {
   const response: BallotSheetInfo = {
@@ -22,7 +23,7 @@ test('says the sheet is unreadable if it is', async () => {
 
   const continueScanning = jest.fn()
 
-  const { container, getByText } = render(
+  const { container, getByText } = renderInAppContext(
     <BallotEjectScreen continueScanning={continueScanning} isTestMode />
   )
 
@@ -108,7 +109,7 @@ test('says the ballot sheet is overvoted if it is', async () => {
 
   const continueScanning = jest.fn()
 
-  const { container, getByText } = render(
+  const { container, getByText } = renderInAppContext(
     <BallotEjectScreen continueScanning={continueScanning} isTestMode />
   )
 
@@ -187,7 +188,7 @@ test('says the ballot sheet is blank if it is', async () => {
 
   const continueScanning = jest.fn()
 
-  const { container, getByText } = render(
+  const { container, getByText } = renderInAppContext(
     <BallotEjectScreen continueScanning={continueScanning} isTestMode />
   )
 
@@ -246,7 +247,7 @@ test('calls out live ballot sheets in test mode', async () => {
 
   const continueScanning = jest.fn()
 
-  const { container, getByText } = render(
+  const { container, getByText } = renderInAppContext(
     <BallotEjectScreen continueScanning={continueScanning} isTestMode />
   )
 
@@ -298,7 +299,7 @@ test('calls out test ballot sheets in live mode', async () => {
 
   const continueScanning = jest.fn()
 
-  const { container, getByText } = render(
+  const { container, getByText } = renderInAppContext(
     <BallotEjectScreen continueScanning={continueScanning} isTestMode={false} />
   )
 
@@ -307,6 +308,46 @@ test('calls out test ballot sheets in live mode', async () => {
   })
 
   expect(container).toMatchSnapshot()
+
+  fireEvent.click(getByText('Confirm Ballot Removed and Continue Scanning'))
+  expect(continueScanning).toHaveBeenCalledWith()
+})
+
+test('shows invalid election screen when appropriate', async () => {
+  const response: BallotSheetInfo = {
+    id: 'mock-sheet-id',
+    front: {
+      image: { url: '/front/url' },
+      interpretation: {
+        type: 'InvalidElectionHashPage',
+        actualElectionHash: 'this-is-a-hash-hooray',
+        expectedElectionHash: 'something',
+      },
+    },
+    back: {
+      image: { url: '/back/url' },
+      interpretation: {
+        type: 'InvalidElectionHashPage',
+        actualElectionHash: 'this-is-a-hash-hooray',
+        expectedElectionHash: 'something',
+      },
+    },
+  }
+  fetchMock.getOnce('/scan/hmpb/review/next-sheet', response)
+
+  const continueScanning = jest.fn()
+
+  const { getByText, queryAllByText } = renderInAppContext(
+    <BallotEjectScreen continueScanning={continueScanning} isTestMode={false} />
+  )
+
+  await act(async () => {
+    await waitFor(() => fetchMock.called)
+  })
+
+  getByText('Wrong Election')
+  getByText('Ballot Election Hash: this-is-a-')
+  expect(queryAllByText('Tabulate Duplicate Ballot').length).toBe(0)
 
   fireEvent.click(getByText('Confirm Ballot Removed and Continue Scanning'))
   expect(continueScanning).toHaveBeenCalledWith()

--- a/apps/bsd/src/screens/__snapshots__/BallotEjectScreen.test.tsx.snap
+++ b/apps/bsd/src/screens/__snapshots__/BallotEjectScreen.test.tsx.snap
@@ -3,19 +3,19 @@
 exports[`calls out live ballot sheets in test mode 1`] = `
 <div>
   <div
-    class="sc-jTzLTM eOyjnu"
+    class="sc-fjdhpX gOpleb"
   >
     <div
-      class="sc-gzVnrw bggTrE"
+      class="sc-htoDjs eZZGvH"
     >
       <div
-        class="sc-htoDjs ipztHg"
+        class="sc-dnqmqq beBlgW"
       >
         <div
-          class="sc-dnqmqq rGeTJ"
+          class="sc-iwsKbI jQvhKG"
         >
           <div
-            class="sc-iwsKbI jjxTtY"
+            class="sc-gZMcBi caXjZP"
           >
             Voting
             <span>
@@ -23,13 +23,13 @@ exports[`calls out live ballot sheets in test mode 1`] = `
             </span>
           </div>
           <div
-            class="sc-gZMcBi giNnHm"
+            class="sc-gqjmRU hnZXkc"
           >
             Ballot Scanner
           </div>
         </div>
         <div
-          class="sc-gqjmRU etjyPA"
+          class="sc-VigVT dQFuUY"
         >
           <button
             class="sc-ifAKCX gKVbpr"
@@ -44,13 +44,13 @@ exports[`calls out live ballot sheets in test mode 1`] = `
       class="sc-bdVaJa kYuSve"
     >
       <div
-        class="sc-jzJRlG jNKpFz"
+        class="sc-kAzzGY kIgkAR"
       >
         <div
           class="sc-htpNat eawaaV"
         >
           <div
-            class="sc-fjdhpX cNwREO"
+            class="sc-cSHVUG eTlAui"
           >
             Live Ballot
           </div>
@@ -66,7 +66,7 @@ exports[`calls out live ballot sheets in test mode 1`] = `
           </p>
         </div>
         <div
-          class="sc-cSHVUG eBwSAE"
+          class="sc-chPdSV bwDMEc"
         >
           <div>
             <img
@@ -83,6 +83,37 @@ exports[`calls out live ballot sheets in test mode 1`] = `
         </div>
       </div>
     </main>
+    <div
+      class="sc-jzJRlG gDbTFU"
+    >
+      <div
+        class="sc-gzVnrw ffzAOv"
+      >
+        Scanner ID: 
+        <strong>
+          0000
+        </strong>
+      </div>
+      <div
+        class="sc-gzVnrw ffzAOv"
+      >
+        <strong>
+          General Election
+        </strong>
+         — 
+        Tuesday, November 3, 2020
+         —
+         
+        Franklin County
+        , 
+        State of Hamilton
+         
+        — Election Hash: 
+        <strong>
+          2f6b1553c7
+        </strong>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -90,19 +121,19 @@ exports[`calls out live ballot sheets in test mode 1`] = `
 exports[`calls out test ballot sheets in live mode 1`] = `
 <div>
   <div
-    class="sc-jTzLTM eOyjnu"
+    class="sc-fjdhpX gOpleb"
   >
     <div
-      class="sc-gzVnrw bggTrE"
+      class="sc-htoDjs eZZGvH"
     >
       <div
-        class="sc-htoDjs ipztHg"
+        class="sc-dnqmqq beBlgW"
       >
         <div
-          class="sc-dnqmqq rGeTJ"
+          class="sc-iwsKbI jQvhKG"
         >
           <div
-            class="sc-iwsKbI jjxTtY"
+            class="sc-gZMcBi caXjZP"
           >
             Voting
             <span>
@@ -110,13 +141,13 @@ exports[`calls out test ballot sheets in live mode 1`] = `
             </span>
           </div>
           <div
-            class="sc-gZMcBi giNnHm"
+            class="sc-gqjmRU hnZXkc"
           >
             Ballot Scanner
           </div>
         </div>
         <div
-          class="sc-gqjmRU etjyPA"
+          class="sc-VigVT dQFuUY"
         >
           <button
             class="sc-ifAKCX gKVbpr"
@@ -131,13 +162,13 @@ exports[`calls out test ballot sheets in live mode 1`] = `
       class="sc-bdVaJa kYuSve"
     >
       <div
-        class="sc-jzJRlG jNKpFz"
+        class="sc-kAzzGY kIgkAR"
       >
         <div
           class="sc-htpNat eawaaV"
         >
           <div
-            class="sc-fjdhpX cNwREO"
+            class="sc-cSHVUG eTlAui"
           >
             Test Ballot
           </div>
@@ -153,7 +184,7 @@ exports[`calls out test ballot sheets in live mode 1`] = `
           </p>
         </div>
         <div
-          class="sc-cSHVUG eBwSAE"
+          class="sc-chPdSV bwDMEc"
         >
           <div>
             <img
@@ -170,6 +201,37 @@ exports[`calls out test ballot sheets in live mode 1`] = `
         </div>
       </div>
     </main>
+    <div
+      class="sc-jzJRlG gDbTFU"
+    >
+      <div
+        class="sc-gzVnrw ffzAOv"
+      >
+        Scanner ID: 
+        <strong>
+          0000
+        </strong>
+      </div>
+      <div
+        class="sc-gzVnrw ffzAOv"
+      >
+        <strong>
+          General Election
+        </strong>
+         — 
+        Tuesday, November 3, 2020
+         —
+         
+        Franklin County
+        , 
+        State of Hamilton
+         
+        — Election Hash: 
+        <strong>
+          2f6b1553c7
+        </strong>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -177,19 +239,19 @@ exports[`calls out test ballot sheets in live mode 1`] = `
 exports[`says the ballot sheet is blank if it is 1`] = `
 <div>
   <div
-    class="sc-jTzLTM eOyjnu"
+    class="sc-fjdhpX gOpleb"
   >
     <div
-      class="sc-gzVnrw bggTrE"
+      class="sc-htoDjs eZZGvH"
     >
       <div
-        class="sc-htoDjs ipztHg"
+        class="sc-dnqmqq beBlgW"
       >
         <div
-          class="sc-dnqmqq rGeTJ"
+          class="sc-iwsKbI jQvhKG"
         >
           <div
-            class="sc-iwsKbI jjxTtY"
+            class="sc-gZMcBi caXjZP"
           >
             Voting
             <span>
@@ -197,13 +259,13 @@ exports[`says the ballot sheet is blank if it is 1`] = `
             </span>
           </div>
           <div
-            class="sc-gZMcBi giNnHm"
+            class="sc-gqjmRU hnZXkc"
           >
             Ballot Scanner
           </div>
         </div>
         <div
-          class="sc-gqjmRU etjyPA"
+          class="sc-VigVT dQFuUY"
         >
           <button
             class="sc-ifAKCX hcRgUA"
@@ -219,13 +281,13 @@ exports[`says the ballot sheet is blank if it is 1`] = `
       class="sc-bdVaJa kYuSve"
     >
       <div
-        class="sc-jzJRlG jNKpFz"
+        class="sc-kAzzGY kIgkAR"
       >
         <div
           class="sc-htpNat eawaaV"
         >
           <div
-            class="sc-fjdhpX cNwREO"
+            class="sc-cSHVUG eTlAui"
           >
             Unknown Reason
           </div>
@@ -264,7 +326,7 @@ exports[`says the ballot sheet is blank if it is 1`] = `
           </p>
         </div>
         <div
-          class="sc-cSHVUG eBwSAE"
+          class="sc-chPdSV bwDMEc"
         >
           <div>
             <img
@@ -281,6 +343,37 @@ exports[`says the ballot sheet is blank if it is 1`] = `
         </div>
       </div>
     </main>
+    <div
+      class="sc-jzJRlG gDbTFU"
+    >
+      <div
+        class="sc-gzVnrw ffzAOv"
+      >
+        Scanner ID: 
+        <strong>
+          0000
+        </strong>
+      </div>
+      <div
+        class="sc-gzVnrw ffzAOv"
+      >
+        <strong>
+          General Election
+        </strong>
+         — 
+        Tuesday, November 3, 2020
+         —
+         
+        Franklin County
+        , 
+        State of Hamilton
+         
+        — Election Hash: 
+        <strong>
+          2f6b1553c7
+        </strong>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -288,19 +381,19 @@ exports[`says the ballot sheet is blank if it is 1`] = `
 exports[`says the ballot sheet is overvoted if it is 1`] = `
 <div>
   <div
-    class="sc-jTzLTM eOyjnu"
+    class="sc-fjdhpX gOpleb"
   >
     <div
-      class="sc-gzVnrw bggTrE"
+      class="sc-htoDjs eZZGvH"
     >
       <div
-        class="sc-htoDjs ipztHg"
+        class="sc-dnqmqq beBlgW"
       >
         <div
-          class="sc-dnqmqq rGeTJ"
+          class="sc-iwsKbI jQvhKG"
         >
           <div
-            class="sc-iwsKbI jjxTtY"
+            class="sc-gZMcBi caXjZP"
           >
             Voting
             <span>
@@ -308,13 +401,13 @@ exports[`says the ballot sheet is overvoted if it is 1`] = `
             </span>
           </div>
           <div
-            class="sc-gZMcBi giNnHm"
+            class="sc-gqjmRU hnZXkc"
           >
             Ballot Scanner
           </div>
         </div>
         <div
-          class="sc-gqjmRU etjyPA"
+          class="sc-VigVT dQFuUY"
         >
           <button
             class="sc-ifAKCX hcRgUA"
@@ -330,13 +423,13 @@ exports[`says the ballot sheet is overvoted if it is 1`] = `
       class="sc-bdVaJa kYuSve"
     >
       <div
-        class="sc-jzJRlG jNKpFz"
+        class="sc-kAzzGY kIgkAR"
       >
         <div
           class="sc-htpNat eawaaV"
         >
           <div
-            class="sc-fjdhpX cNwREO"
+            class="sc-cSHVUG eTlAui"
           >
             Overvote
           </div>
@@ -380,7 +473,7 @@ exports[`says the ballot sheet is overvoted if it is 1`] = `
           </p>
         </div>
         <div
-          class="sc-cSHVUG eBwSAE"
+          class="sc-chPdSV bwDMEc"
         >
           <div>
             <img
@@ -397,6 +490,37 @@ exports[`says the ballot sheet is overvoted if it is 1`] = `
         </div>
       </div>
     </main>
+    <div
+      class="sc-jzJRlG gDbTFU"
+    >
+      <div
+        class="sc-gzVnrw ffzAOv"
+      >
+        Scanner ID: 
+        <strong>
+          0000
+        </strong>
+      </div>
+      <div
+        class="sc-gzVnrw ffzAOv"
+      >
+        <strong>
+          General Election
+        </strong>
+         — 
+        Tuesday, November 3, 2020
+         —
+         
+        Franklin County
+        , 
+        State of Hamilton
+         
+        — Election Hash: 
+        <strong>
+          2f6b1553c7
+        </strong>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -404,19 +528,19 @@ exports[`says the ballot sheet is overvoted if it is 1`] = `
 exports[`says the sheet is unreadable if it is 1`] = `
 <div>
   <div
-    class="sc-jTzLTM eOyjnu"
+    class="sc-fjdhpX gOpleb"
   >
     <div
-      class="sc-gzVnrw bggTrE"
+      class="sc-htoDjs eZZGvH"
     >
       <div
-        class="sc-htoDjs ipztHg"
+        class="sc-dnqmqq beBlgW"
       >
         <div
-          class="sc-dnqmqq rGeTJ"
+          class="sc-iwsKbI jQvhKG"
         >
           <div
-            class="sc-iwsKbI jjxTtY"
+            class="sc-gZMcBi caXjZP"
           >
             Voting
             <span>
@@ -424,13 +548,13 @@ exports[`says the sheet is unreadable if it is 1`] = `
             </span>
           </div>
           <div
-            class="sc-gZMcBi giNnHm"
+            class="sc-gqjmRU hnZXkc"
           >
             Ballot Scanner
           </div>
         </div>
         <div
-          class="sc-gqjmRU etjyPA"
+          class="sc-VigVT dQFuUY"
         >
           <button
             class="sc-ifAKCX hcRgUA"
@@ -446,13 +570,13 @@ exports[`says the sheet is unreadable if it is 1`] = `
       class="sc-bdVaJa kYuSve"
     >
       <div
-        class="sc-jzJRlG jNKpFz"
+        class="sc-kAzzGY kIgkAR"
       >
         <div
           class="sc-htpNat eawaaV"
         >
           <div
-            class="sc-fjdhpX cNwREO"
+            class="sc-cSHVUG eTlAui"
           >
             Unreadable
           </div>
@@ -495,7 +619,7 @@ exports[`says the sheet is unreadable if it is 1`] = `
           </p>
         </div>
         <div
-          class="sc-cSHVUG eBwSAE"
+          class="sc-chPdSV bwDMEc"
         >
           <div>
             <img
@@ -512,6 +636,37 @@ exports[`says the sheet is unreadable if it is 1`] = `
         </div>
       </div>
     </main>
+    <div
+      class="sc-jzJRlG gDbTFU"
+    >
+      <div
+        class="sc-gzVnrw ffzAOv"
+      >
+        Scanner ID: 
+        <strong>
+          0000
+        </strong>
+      </div>
+      <div
+        class="sc-gzVnrw ffzAOv"
+      >
+        <strong>
+          General Election
+        </strong>
+         — 
+        Tuesday, November 3, 2020
+         —
+         
+        Franklin County
+        , 
+        State of Hamilton
+         
+        — Election Hash: 
+        <strong>
+          2f6b1553c7
+        </strong>
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/apps/bsd/test/renderInAppContext.tsx
+++ b/apps/bsd/test/renderInAppContext.tsx
@@ -1,0 +1,47 @@
+import { createMemoryHistory, MemoryHistory } from 'history'
+import { render as testRender } from '@testing-library/react'
+import type { RenderResult } from '@testing-library/react'
+import type { Election } from '@votingworks/types'
+import React from 'react'
+
+import { electionSampleDefinition } from '@votingworks/fixtures'
+import { Router } from 'react-router-dom'
+import { UsbDriveStatus } from '../src/lib/usbstick'
+import AppContext from '../src/contexts/AppContext'
+
+interface RenderInAppContextParams {
+  route?: string | undefined
+  history?: MemoryHistory<any> // eslint-disable-line @typescript-eslint/no-explicit-any
+  election?: Election
+  electionHash?: string
+  machineId?: string
+  usbDriveStatus?: UsbDriveStatus
+  usbDriveEject?: () => void
+}
+
+export default function renderInAppContext(
+  component: React.ReactNode,
+  {
+    route = '/',
+    history = createMemoryHistory({ initialEntries: [route] }),
+    election = electionSampleDefinition.election,
+    electionHash = electionSampleDefinition.electionHash,
+    machineId = '0000',
+    usbDriveStatus = UsbDriveStatus.absent,
+    usbDriveEject = jest.fn(),
+  } = {} as RenderInAppContextParams
+): RenderResult {
+  return testRender(
+    <AppContext.Provider
+      value={{
+        election,
+        electionHash,
+        machineConfig: { machineId },
+        usbDriveStatus,
+        usbDriveEject,
+      }}
+    >
+      <Router history={history}>{component}</Router>
+    </AppContext.Provider>
+  )
+}


### PR DESCRIPTION
Shows an error screen with no option to tabulate the ballot if a ballot is scanned with an unexpected election hash. 
![Screen Shot 2021-03-02 at 3 55 23 PM](https://user-images.githubusercontent.com/14897017/109731268-c9abd500-7b6f-11eb-894d-5edfa6acb54d.png)

