### PR TITLE
feat(bsd) update copy and options for unreadables

### DIFF
--- a/apps/bsd/src/screens/BallotEjectScreen.test.tsx
+++ b/apps/bsd/src/screens/BallotEjectScreen.test.tsx
@@ -33,15 +33,8 @@ test('says the sheet is unreadable if it is', async () => {
 
   expect(container).toMatchSnapshot()
 
-  fireEvent.click(getByText('Original Ballot Removed'))
   fireEvent.click(getByText('Confirm Ballot Removed and Continue Scanning'))
   expect(continueScanning).toHaveBeenCalledWith()
-
-  continueScanning.mockClear()
-
-  fireEvent.click(getByText('Tabulate Duplicate Ballot'))
-  fireEvent.click(getByText('Tabulate Ballot and Continue Scanning'))
-  expect(continueScanning).toHaveBeenCalledWith(true)
 })
 
 test('says the ballot sheet is overvoted if it is', async () => {

--- a/apps/bsd/src/screens/BallotEjectScreen.tsx
+++ b/apps/bsd/src/screens/BallotEjectScreen.tsx
@@ -110,7 +110,7 @@ const BallotEjectScreen: React.FC<Props> = ({
   }
 
   const allowBallotDuplication =
-    !isInvalidTestModeSheet && !isInvalidElectionHashSheet
+    !isInvalidTestModeSheet && !isInvalidElectionHashSheet && !isUnreadableSheet
 
   return (
     <Screen>
@@ -170,12 +170,7 @@ const BallotEjectScreen: React.FC<Props> = ({
                 </p>
                 <h4>Duplicate Ballot Scan</h4>
                 <p>
-                  {isUnreadableSheet ? (
-                    <React.Fragment>
-                      Confirm sheet was reviewed by the Resolution Board and
-                      tabulate as <strong>unreadable</strong>.
-                    </React.Fragment>
-                  ) : isOvervotedSheet ? (
+                  {isOvervotedSheet ? (
                     <React.Fragment>
                       Confirm ballot sheet was reviewed by the Resolution Board
                       and tabulate as ballot sheet with an{' '}
@@ -209,7 +204,7 @@ const BallotEjectScreen: React.FC<Props> = ({
               ) : (
                 <p>Remove the TEST ballot before continuing.</p>
               )
-            ) : (
+            ) : isInvalidElectionHashSheet ? (
               <React.Fragment>
                 <p>
                   The scanned ballot does not match the election this scanner is
@@ -218,6 +213,18 @@ const BallotEjectScreen: React.FC<Props> = ({
                 <Text small>
                   Ballot Election Hash: {actualElectionHash!.slice(0, 10)}
                 </Text>
+              </React.Fragment>
+            ) : (
+              // Unreadable
+              <React.Fragment>
+                <p>
+                  There was a problem reading the ballot. Remove ballot and
+                  reload in the scanner to try again.
+                </p>
+                <p>
+                  If the error persists remove ballot and create a duplicate
+                  ballot for the Resolution Board to review.
+                </p>
               </React.Fragment>
             )}
           </Prose>

--- a/apps/bsd/src/screens/__snapshots__/BallotEjectScreen.test.tsx.snap
+++ b/apps/bsd/src/screens/__snapshots__/BallotEjectScreen.test.tsx.snap
@@ -557,11 +557,10 @@ exports[`says the sheet is unreadable if it is 1`] = `
           class="sc-VigVT dQFuUY"
         >
           <button
-            class="sc-ifAKCX hcRgUA"
-            disabled=""
+            class="sc-ifAKCX gKVbpr"
             type="button"
           >
-            Continue Scanning
+            Confirm Ballot Removed and Continue Scanning
           </button>
         </div>
       </div>
@@ -587,35 +586,11 @@ exports[`says the sheet is unreadable if it is 1`] = `
             </strong>
             .
           </p>
-          <h4>
-            Original Ballot Scan
-          </h4>
           <p>
-            Remove ballot and create a duplicate ballot for the Resolution Board to review.
-            <br />
-            <button
-              class="sc-ifAKCX fGEpuB"
-              type="button"
-            >
-              Original Ballot Removed
-            </button>
+            There was a problem reading the ballot. Remove ballot and reload in the scanner to try again.
           </p>
-          <h4>
-            Duplicate Ballot Scan
-          </h4>
           <p>
-            Confirm sheet was reviewed by the Resolution Board and tabulate as 
-            <strong>
-              unreadable
-            </strong>
-            .
-            <br />
-            <button
-              class="sc-ifAKCX fGEpuB"
-              type="button"
-            >
-              Tabulate Duplicate Ballot
-            </button>
+            If the error persists remove ballot and create a duplicate ballot for the Resolution Board to review.
           </p>
         </div>
         <div


### PR DESCRIPTION
Removes the option to tabulate unreadable ballots and updates the copy to suggest trying scanning again. 

![Screen Shot 2021-03-02 at 4 32 52 PM](https://user-images.githubusercontent.com/14897017/109734723-59ed1880-7b76-11eb-9e31-169630a4e632.png)
