### PR TITLE
fix(em): fix overvote counting on multiseat contests

### DIFF
--- a/apps/election-manager/src/lib/__snapshots__/votecounting.test.ts.snap
+++ b/apps/election-manager/src/lib/__snapshots__/votecounting.test.ts.snap
@@ -150,7 +150,7 @@ Array [
     "contestId": "schoolboard-liberty",
     "metadata": Object {
       "ballots": 1260,
-      "overvotes": 180,
+      "overvotes": 360,
       "undervotes": 270,
     },
     "tallies": Object {
@@ -315,7 +315,7 @@ Array [
     "contestId": "schoolboard-constitution",
     "metadata": Object {
       "ballots": 2100,
-      "overvotes": 300,
+      "overvotes": 600,
       "undervotes": 450,
     },
     "tallies": Object {
@@ -472,7 +472,7 @@ Array [
     "contestId": "schoolboard-federalist",
     "metadata": Object {
       "ballots": 420,
-      "overvotes": 60,
+      "overvotes": 120,
       "undervotes": 90,
     },
     "tallies": Object {
@@ -786,7 +786,7 @@ Array [
     "contestId": "schoolboard-federalist",
     "metadata": Object {
       "ballots": 420,
-      "overvotes": 60,
+      "overvotes": 120,
       "undervotes": 90,
     },
     "tallies": Object {
@@ -985,7 +985,7 @@ Array [
     "contestId": "schoolboard-liberty",
     "metadata": Object {
       "ballots": 420,
-      "overvotes": 60,
+      "overvotes": 120,
       "undervotes": 90,
     },
     "tallies": Object {

--- a/apps/election-manager/src/lib/votecounting.test.ts
+++ b/apps/election-manager/src/lib/votecounting.test.ts
@@ -704,7 +704,7 @@ test('undervotes counted in n of m contest properly', () => {
     [mockCVR],
   ])!
 
-  // The county commissioners race has 4 seats. Each vote less then 4 should be counted
+  // The county commissioners race has 4 seats. Each vote less than 4 should be counted
   // as an additional undervote.
   expect(
     electionTally.overallTally.contestTallies['county-commissioners']?.metadata
@@ -752,6 +752,134 @@ test('undervotes counted in n of m contest properly', () => {
     electionTally.overallTally.contestTallies['county-commissioners']?.metadata
       .undervotes
   ).toBe(0)
+})
+
+test('overvotes counted in n of m contest properly', () => {
+  // Create mock CVR data
+  const mockCVR: CastVoteRecord = {
+    _ballotId: 'abc',
+    _ballotStyleId: '12D',
+    _ballotType: 'standard',
+    _precinctId: '21',
+    _testBallot: false,
+    _scannerId: '1',
+    'county-commissioners': [
+      'argent',
+      'witherspoonsmithson',
+      'bainbridge',
+      'hennessey',
+    ],
+  }
+
+  // tabulate it
+  let electionTally = computeFullElectionTally(primaryElectionSample, [
+    [mockCVR],
+  ])!
+
+  expect(
+    electionTally.overallTally.contestTallies['county-commissioners']?.metadata
+      .overvotes
+  ).toBe(0)
+
+  electionTally = computeFullElectionTally(primaryElectionSample, [
+    [
+      {
+        ...mockCVR,
+        'county-commissioners': [
+          'argent',
+          'witherspoonsmithson',
+          'bainbridge',
+          'hennessey',
+          'savoy',
+        ],
+      },
+    ],
+  ])!
+  // The county commissioners race has 4 seats. A ballot with more than 4 votes should have
+  // 4 overvotes.
+  expect(
+    electionTally.overallTally.contestTallies['county-commissioners']?.metadata
+      .overvotes
+  ).toBe(4)
+
+  electionTally = computeFullElectionTally(primaryElectionSample, [
+    [
+      {
+        ...mockCVR,
+        'county-commissioners': [
+          'argent',
+          'witherspoonsmithson',
+          'bainbridge',
+          'hennessey',
+          'savoy',
+          'tawa',
+          'rangel',
+        ],
+      },
+    ],
+  ])!
+  expect(
+    electionTally.overallTally.contestTallies['county-commissioners']?.metadata
+      .overvotes
+  ).toBe(4)
+})
+
+test('overvotes counted in single seat contest properly', () => {
+  // Create mock CVR data
+  const mockCVR: CastVoteRecord = {
+    _ballotId: 'abc',
+    _ballotStyleId: '12D',
+    _ballotType: 'standard',
+    _precinctId: '21',
+    _testBallot: false,
+    _scannerId: '1',
+    'lieutenant-governor': ['norberg'],
+  }
+
+  // tabulate it
+  let electionTally = computeFullElectionTally(primaryElectionSample, [
+    [mockCVR],
+  ])!
+  expect(
+    electionTally.overallTally.contestTallies['lieutenant-governor']?.metadata
+      .overvotes
+  ).toBe(0)
+
+  electionTally = computeFullElectionTally(primaryElectionSample, [
+    [
+      {
+        ...mockCVR,
+        'lieutenant-governor': ['norberg', 'parks'],
+      },
+    ],
+  ])!
+
+  // The lieutenant governor race has 1 seat. A ballot with more than 1 votes should count
+  // as 1 overvote.
+  expect(
+    electionTally.overallTally.contestTallies['lieutenant-governor']?.metadata
+      .overvotes
+  ).toBe(1)
+
+  electionTally = computeFullElectionTally(primaryElectionSample, [
+    [
+      {
+        ...mockCVR,
+        'lieutenant-governor': [
+          'norberg',
+          'parks',
+          'garcia',
+          'qualey',
+          'hovis',
+        ],
+      },
+    ],
+  ])!
+  // There should still only be 1 overvote despite voting for 5 candidates.
+  expect(
+    electionTally.overallTally.contestTallies['lieutenant-governor']?.metadata
+      .overvotes
+  ).toBe(1)
 })
 
 test('overvote report', async () => {

--- a/apps/election-manager/src/lib/votecounting.ts
+++ b/apps/election-manager/src/lib/votecounting.ts
@@ -305,7 +305,7 @@ export function tallyVotesByContest({
         const maxSelectable =
           contest.type === 'yesno' ? 1 : (contest as CandidateContest).seats
         if (selected.length > maxSelectable) {
-          numberOfOvervotes += 1
+          numberOfOvervotes += maxSelectable
           return
         }
         if (selected.length < maxSelectable) {


### PR DESCRIPTION
Fixes overvote tallying to be in line with vvsg 2.0 guidance where the number of overvotes on a contest is equal to the number of seats (if there are more votes then the number of seats). 

Example with a 4 seat contest: 
Voting for 4 candidates is 0 overvotes
Voting for 5 candidates is 4 overvotes
Voting for 87 candidates is 4 overvotes 