### PR TITLE
fix(em): change "Cancel" to "Close" after export

### DIFF
--- a/apps/election-manager/src/components/ExportElectionBallotPackageModalButton.test.tsx
+++ b/apps/election-manager/src/components/ExportElectionBallotPackageModalButton.test.tsx
@@ -94,7 +94,7 @@ test('Modal renders export confirmation screen when usb detected and manual link
     expect(window.kiosk!.saveAs).toHaveBeenCalledTimes(1)
   })
 
-  fireEvent.click(getByText('Cancel'))
+  fireEvent.click(getByText('Close'))
   expect(queryAllByTestId('modal')).toHaveLength(0)
 })
 
@@ -171,6 +171,6 @@ test('Modal renders renders loading message while rendering ballots appropriatel
   fireEvent.click(getByText('Eject USB'))
   expect(ejectFunction).toHaveBeenCalledTimes(1)
 
-  fireEvent.click(getByText('Cancel'))
+  fireEvent.click(getByText('Close'))
   expect(queryAllByTestId('modal')).toHaveLength(0)
 })

--- a/apps/election-manager/src/components/ExportElectionBallotPackageModalButton.tsx
+++ b/apps/election-manager/src/components/ExportElectionBallotPackageModalButton.tsx
@@ -280,7 +280,7 @@ const ExportElectionBallotPackageModalButton: React.FC = () => {
       if (usbDriveStatus !== UsbDriveStatus.recentlyEjected) {
         actions = (
           <React.Fragment>
-            <LinkButton onPress={closeModal}>Cancel</LinkButton>
+            <LinkButton onPress={closeModal}>Close</LinkButton>
             <USBControllerButton primary small={false} />
           </React.Fragment>
         )


### PR DESCRIPTION
When exporting the ballot package we prompt the user to either "Eject USB" or "Cancel", but in this context "Cancel" sounds odd as there isn't really an operation that's being canceled. This changes it to "~Not Now~Close" instead.

![image](https://user-images.githubusercontent.com/1938/110040154-2dacd580-7cf7-11eb-859f-88354d837f2e.png)
