### PR TITLE
feat(em): allow custom file picker on export

### DIFF
--- a/apps/election-manager/src/components/ExportElectionBallotPackageModalButton.tsx
+++ b/apps/election-manager/src/components/ExportElectionBallotPackageModalButton.tsx
@@ -116,9 +116,9 @@ const ExportElectionBallotPackageModalButton: React.FC = () => {
     }
     try {
       const usbPath = await getDevicePath()
-      const pathToFolder = path.join(usbPath!, BALLOT_PACKAGES_FOLDER)
-      const pathToFile = path.join(pathToFolder, defaultFileName)
-      if (openDialog) {
+      const pathToFolder = usbPath && path.join(usbPath, BALLOT_PACKAGES_FOLDER)
+      const pathToFile = path.join(pathToFolder ?? '.', defaultFileName)
+      if (openDialog || !pathToFolder) {
         await state.archive.beginWithDialog({
           defaultPath: pathToFile,
           filters: [{ name: 'Archive Files', extensions: ['zip'] }],
@@ -161,7 +161,12 @@ const ExportElectionBallotPackageModalButton: React.FC = () => {
             <Prose>
               <h1>No USB Drive Detected</h1>
               <p>
-                <USBImage src="usb-drive.svg" alt="Insert USB Image" />
+                <USBImage
+                  src="usb-drive.svg"
+                  alt="Insert USB Image"
+                  // hidden feature to export with file dialog by double-clicking
+                  onDoubleClick={() => saveFileCallback(true)}
+                />
                 Please insert a USB drive in order to export the ballot
                 configuration.
               </p>


### PR DESCRIPTION
This may not be a feature we want to encourage enough to add another button, so I implemented this as a hidden "button" you activate by double-clicking on the USB drive image.


https://user-images.githubusercontent.com/1938/110041892-b4fb4880-7cf9-11eb-9418-664f2d00d456.mov

