### PR TITLE
build(typescript): enable noUncheckedIndexedAccess

### DIFF
--- a/libs/ballot-encoder/src/bits/BitCursor.ts
+++ b/libs/ballot-encoder/src/bits/BitCursor.ts
@@ -49,5 +49,23 @@ export default class BitCursor {
     return new BitCursor().set(this.combinedBitOffset)
   }
 
-  public static uint8Masks: readonly Uint8[] = makeMasks(Uint8Size)
+  public static uint8Masks: readonly [
+    Uint8,
+    Uint8,
+    Uint8,
+    Uint8,
+    Uint8,
+    Uint8,
+    Uint8,
+    Uint8
+  ] = makeMasks(Uint8Size) as [
+    Uint8,
+    Uint8,
+    Uint8,
+    Uint8,
+    Uint8,
+    Uint8,
+    Uint8,
+    Uint8
+  ]
 }

--- a/libs/ballot-encoder/src/bits/utils.ts
+++ b/libs/ballot-encoder/src/bits/utils.ts
@@ -25,8 +25,13 @@ export function makeMasks<T extends number>(count: number): T[] {
  *
  * @throws if `number` is outside the range of `Uint8` or is not an integer
  */
-export function toUint8(number: number): Uint8 {
-  if (number < 0x00 || number > 0xff || (number | 0) !== number) {
+export function toUint8(number: unknown): Uint8 {
+  if (
+    typeof number !== 'number' ||
+    number < 0x00 ||
+    number > 0xff ||
+    (number | 0) !== number
+  ) {
     throw new TypeError(`cannot convert number to Uint8: ${number}`)
   }
   return number as Uint8

--- a/libs/ballot-encoder/src/index.test.ts
+++ b/libs/ballot-encoder/src/index.test.ts
@@ -44,8 +44,8 @@ test('can detect an encoded ballot', () => {
 
 test('encodes & decodes with Uint8Array as the standard encoding interface', () => {
   const { election, electionHash } = electionDefinition
-  const ballotStyle = election.ballotStyles[0]
-  const precinct = election.precincts[0]
+  const ballotStyle = election.ballotStyles[0]!
+  const precinct = election.precincts[0]!
   const ballotStyleId = ballotStyle.id
   const precinctId = precinct.id
   const contests = getContests({ election, ballotStyle })
@@ -69,8 +69,8 @@ test('encodes & decodes with Uint8Array as the standard encoding interface', () 
 
 it('encodes & decodes empty votes correctly', () => {
   const { election, electionHash } = electionDefinition
-  const ballotStyle = election.ballotStyles[0]
-  const precinct = election.precincts[0]
+  const ballotStyle = election.ballotStyles[0]!
+  const precinct = election.precincts[0]!
   const ballotStyleId = ballotStyle.id
   const precinctId = precinct.id
   const contests = getContests({ ballotStyle, election })
@@ -126,8 +126,8 @@ it('encodes & decodes empty votes correctly', () => {
 
 it('encodes & decodes without a ballot id', () => {
   const { election, electionHash } = electionDefinition
-  const ballotStyle = election.ballotStyles[0]
-  const precinct = election.precincts[0]
+  const ballotStyle = election.ballotStyles[0]!
+  const precinct = election.precincts[0]!
   const ballotStyleId = ballotStyle.id
   const precinctId = precinct.id
   const contests = getContests({ ballotStyle, election })
@@ -181,8 +181,8 @@ it('encodes & decodes without a ballot id', () => {
 
 it('encodes & decodes whether it is a test ballot', () => {
   const { election, electionHash } = electionDefinition
-  const ballotStyle = election.ballotStyles[0]
-  const precinct = election.precincts[0]
+  const ballotStyle = election.ballotStyles[0]!
+  const precinct = election.precincts[0]!
   const ballotStyleId = ballotStyle.id
   const precinctId = precinct.id
   const contests = getContests({ ballotStyle, election })
@@ -238,8 +238,8 @@ it('encodes & decodes whether it is a test ballot', () => {
 
 it('encodes & decodes the ballot type', () => {
   const { election, electionHash } = electionDefinition
-  const ballotStyle = election.ballotStyles[0]
-  const precinct = election.precincts[0]
+  const ballotStyle = election.ballotStyles[0]!
+  const precinct = election.precincts[0]!
   const ballotStyleId = ballotStyle.id
   const precinctId = precinct.id
   const contests = getContests({ ballotStyle, election })
@@ -295,8 +295,8 @@ it('encodes & decodes the ballot type', () => {
 
 it('encodes & decodes yesno votes correctly', () => {
   const { election, electionHash } = electionDefinition
-  const ballotStyle = election.ballotStyles[0]
-  const precinct = election.precincts[0]
+  const ballotStyle = election.ballotStyles[0]!
+  const precinct = election.precincts[0]!
   const ballotStyleId = ballotStyle.id
   const precinctId = precinct.id
   const ballotId = 'abcde'
@@ -370,10 +370,10 @@ it('encodes & decodes yesno votes correctly', () => {
 
 it('encodes & decodes ms-either-neither votes correctly', () => {
   const { election, electionHash } = electionWithMsEitherNeitherDefinition
-  const ballotStyle = election.ballotStyles[0]
-  const precinct = election.precincts.filter(
-    (p) => p.id === ballotStyle.precincts[0]
-  )[0]
+  const ballotStyle = election.ballotStyles[0]!
+  const precinct = election.precincts.find(
+    (p) => p.id === ballotStyle.precincts[0]!
+  )!
   const ballotStyleId = ballotStyle.id
   const precinctId = precinct.id
   const ballotId = 'abcde'
@@ -464,8 +464,8 @@ it('encodes & decodes ms-either-neither votes correctly', () => {
 
 it('throws on trying to encode a bad yes/no vote', () => {
   const { election, electionHash } = electionDefinition
-  const ballotStyle = election.ballotStyles[0]
-  const precinct = election.precincts[0]
+  const ballotStyle = election.ballotStyles[0]!
+  const precinct = election.precincts[0]!
   const ballotStyleId = ballotStyle.id
   const precinctId = precinct.id
   const ballotId = 'abcde'
@@ -496,8 +496,8 @@ it('throws on trying to encode a bad yes/no vote', () => {
 
 it('throws on trying to encode a ballot style', () => {
   const { election, electionHash } = electionDefinition
-  const ballotStyle = election.ballotStyles[0]
-  const precinct = election.precincts[0]
+  const ballotStyle = election.ballotStyles[0]!
+  const precinct = election.precincts[0]!
   const ballotStyleId = ballotStyle.id + '-CORRUPTED'
   const precinctId = precinct.id
   const ballotId = 'abcde'
@@ -519,7 +519,7 @@ it('throws on trying to encode a ballot style', () => {
 
 test('throws on decoding an incorrect number of precincts', () => {
   const { election, electionHash } = electionDefinition
-  const ballotStyle = election.ballotStyles[0]
+  const ballotStyle = election.ballotStyles[0]!
   const contests = getContests({ ballotStyle, election })
   const encodedBallot = new BitWriter()
     // prelude + version number
@@ -560,7 +560,7 @@ test('throws on decoding an incorrect number of precincts', () => {
 
 test('throws on decoding an incorrect number of ballot styles', () => {
   const { election, electionHash } = electionDefinition
-  const ballotStyle = election.ballotStyles[0]
+  const ballotStyle = election.ballotStyles[0]!
   const contests = getContests({ ballotStyle, election })
   const encodedBallot = new BitWriter()
     // prelude + version number
@@ -601,7 +601,7 @@ test('throws on decoding an incorrect number of ballot styles', () => {
 
 test('throws on decoding an incorrect number of contests', () => {
   const { election, electionHash } = electionDefinition
-  const ballotStyle = election.ballotStyles[0]
+  const ballotStyle = election.ballotStyles[0]!
   const contests = getContests({ ballotStyle, election })
   const encodedBallot = new BitWriter()
     // prelude + version number
@@ -642,8 +642,8 @@ test('throws on decoding an incorrect number of contests', () => {
 
 it('encodes & decodes candidate choice votes correctly', () => {
   const { election, electionHash } = electionDefinition
-  const ballotStyle = election.ballotStyles[0]
-  const precinct = election.precincts[0]
+  const ballotStyle = election.ballotStyles[0]!
+  const precinct = election.precincts[0]!
   const ballotStyleId = ballotStyle.id
   const precinctId = precinct.id
   const ballotId = 'abcde'
@@ -741,8 +741,8 @@ it('encodes & decodes candidate choice votes correctly', () => {
 
 it('encodes & decodes write-in votes correctly', () => {
   const { election, electionHash } = electionDefinition
-  const ballotStyle = election.ballotStyles[0]
-  const precinct = election.precincts[0]
+  const ballotStyle = election.ballotStyles[0]!
+  const precinct = election.precincts[0]!
   const ballotStyleId = ballotStyle.id
   const precinctId = precinct.id
   const contests = getContests({ ballotStyle, election })
@@ -872,8 +872,8 @@ test.skip('cannot decode a ballot with a precinct ID not in the election', () =>
 
 test('cannot decode a ballot that includes extra data at the end', () => {
   const { election, electionHash } = electionDefinition
-  const ballotStyle = election.ballotStyles[0]
-  const precinct = election.precincts[0]
+  const ballotStyle = election.ballotStyles[0]!
+  const precinct = election.precincts[0]!
   const ballotStyleId = ballotStyle.id
   const precinctId = precinct.id
   const contests = getContests({ election, ballotStyle })
@@ -902,8 +902,8 @@ test('cannot decode a ballot that includes extra data at the end', () => {
 
 test('cannot decode a ballot that includes too much padding at the end', () => {
   const { election, electionHash } = electionDefinition
-  const ballotStyle = election.ballotStyles[0]
-  const precinct = election.precincts[0]
+  const ballotStyle = election.ballotStyles[0]!
+  const precinct = election.precincts[0]!
   const ballotStyleId = ballotStyle.id
   const precinctId = precinct.id
   const contests = getContests({ election, ballotStyle })
@@ -934,8 +934,8 @@ test('encode and decode HMPB ballot page metadata', () => {
   const { election, electionHash } = electionDefinition
   const ballotMetadata: HMPBBallotPageMetadata = {
     electionHash,
-    precinctId: election.ballotStyles[0].precincts[0],
-    ballotStyleId: election.ballotStyles[0].id,
+    precinctId: election.ballotStyles[0]!.precincts[0]!,
+    ballotStyleId: election.ballotStyles[0]!.id,
     locales: {
       primary: 'en-US',
     },
@@ -957,8 +957,8 @@ test('encode and decode HMPB ballot page metadata with ballot ID', () => {
   const { election, electionHash } = electionWithMsEitherNeitherDefinition
   const ballotMetadata: HMPBBallotPageMetadata = {
     electionHash,
-    precinctId: election.ballotStyles[2].precincts[1],
-    ballotStyleId: election.ballotStyles[2].id,
+    precinctId: election.ballotStyles[2]!.precincts[1]!,
+    ballotStyleId: election.ballotStyles[2]!.id,
     locales: {
       primary: 'en-US',
       secondary: 'es-US',
@@ -979,7 +979,7 @@ test('encode HMPB ballot page metadata with bad precinct fails', () => {
   const ballotMetadata: HMPBBallotPageMetadata = {
     electionHash,
     precinctId: 'SanDimas', // not an actual precinct ID
-    ballotStyleId: election.ballotStyles[0].id,
+    ballotStyleId: election.ballotStyles[0]!.id,
     locales: {
       primary: 'en-US',
     },
@@ -997,7 +997,7 @@ test('encode HMPB ballot page metadata with bad ballot style fails', () => {
   const { election, electionHash } = electionDefinition
   const ballotMetadata: HMPBBallotPageMetadata = {
     electionHash,
-    precinctId: election.ballotStyles[0].precincts[0],
+    precinctId: election.ballotStyles[0]!.precincts[0]!,
     ballotStyleId: '42', // not a good ballot style
     locales: {
       primary: 'en-US',
@@ -1016,8 +1016,8 @@ test('encode HMPB ballot page metadata with bad primary locale', () => {
   const { election, electionHash } = electionDefinition
   const ballotMetadata: HMPBBallotPageMetadata = {
     electionHash,
-    precinctId: election.ballotStyles[0].precincts[0],
-    ballotStyleId: election.ballotStyles[0].id,
+    precinctId: election.ballotStyles[0]!.precincts[0]!,
+    ballotStyleId: election.ballotStyles[0]!.id,
     locales: {
       primary: 'fr-CA', // not a supported locale
     },
@@ -1035,8 +1035,8 @@ test('encode HMPB ballot page metadata with bad secondary locale', () => {
   const { election, electionHash } = electionDefinition
   const ballotMetadata: HMPBBallotPageMetadata = {
     electionHash,
-    precinctId: election.ballotStyles[0].precincts[0],
-    ballotStyleId: election.ballotStyles[0].id,
+    precinctId: election.ballotStyles[0]!.precincts[0]!,
+    ballotStyleId: election.ballotStyles[0]!.id,
     locales: {
       primary: 'en-US',
       secondary: 'fr-CA', // not a supported locale
@@ -1053,9 +1053,9 @@ test('encode HMPB ballot page metadata with bad secondary locale', () => {
 
 test('detect HMPB ballot page metadata', () => {
   const { election, electionHash } = electionDefinition
-  const ballotStyle = election.ballotStyles[0]
+  const ballotStyle = election.ballotStyles[0]!
   const ballotStyleId = ballotStyle.id
-  const precinctId = ballotStyle.precincts[0]
+  const precinctId = ballotStyle.precincts[0]!
   const ballotMetadata: HMPBBallotPageMetadata = {
     electionHash,
     precinctId,
@@ -1101,8 +1101,8 @@ test('decode election hash from HMPB metadata', () => {
   const { election, electionHash } = electionDefinition
   const ballotMetadata: HMPBBallotPageMetadata = {
     electionHash,
-    precinctId: election.ballotStyles[0].precincts[0],
-    ballotStyleId: election.ballotStyles[0].id,
+    precinctId: election.ballotStyles[0]!.precincts[0]!,
+    ballotStyleId: election.ballotStyles[0]!.id,
     locales: { primary: 'en-US' },
     pageNumber: 3,
     isTestMode: true,
@@ -1116,8 +1116,8 @@ test('decode election hash from HMPB metadata', () => {
 
 test('decode election hash from BMD metadata', () => {
   const { election, electionHash } = electionDefinition
-  const ballotStyle = election.ballotStyles[0]
-  const precinct = election.precincts[0]
+  const ballotStyle = election.ballotStyles[0]!
+  const precinct = election.precincts[0]!
   const ballotStyleId = ballotStyle.id
   const precinctId = precinct.id
   const contests = getContests({ ballotStyle, election })

--- a/libs/ballot-encoder/src/index.ts
+++ b/libs/ballot-encoder/src/index.ts
@@ -229,22 +229,33 @@ export function decodeBallotConfigFromReader(
   const ballotType = bits.readUint({ max: BallotTypeMaximumValue })
   const ballotId = bits.readBoolean() ? bits.readString() : undefined
 
+  const ballotStyle = ballotStyles[ballotStyleIndex]
+  const precinct = precincts[precinctIndex]
+  const primaryLocale =
+    readLocales && typeof primaryLocaleIndex === 'number'
+      ? SUPPORTED_LOCALES[primaryLocaleIndex]
+      : undefined
+  const secondaryLocale =
+    readLocales && typeof secondaryLocaleIndex === 'number'
+      ? SUPPORTED_LOCALES[secondaryLocaleIndex]
+      : undefined
+
+  assert(ballotStyle, `ballot style index ${ballotStyleIndex} is invalid`)
+  assert(precinct, `precinct index ${precinctIndex} is invalid`)
+  assert(
+    !readLocales || (typeof primaryLocaleIndex === 'number' && primaryLocale),
+    `primary locale index ${primaryLocaleIndex} is invalid`
+  )
+
   return {
     ballotId,
-    ballotStyleId: ballotStyles[ballotStyleIndex].id,
+    ballotStyleId: ballotStyle.id,
     ballotType,
     isTestMode,
-    precinctId: precincts[precinctIndex].id,
-    locales:
-      readLocales && typeof primaryLocaleIndex === 'number'
-        ? {
-            primary: SUPPORTED_LOCALES[primaryLocaleIndex],
-            secondary:
-              typeof secondaryLocaleIndex === 'number'
-                ? SUPPORTED_LOCALES[secondaryLocaleIndex]
-                : undefined,
-          }
-        : undefined,
+    precinctId: precinct.id,
+    locales: primaryLocale
+      ? { primary: primaryLocale, secondary: secondaryLocale }
+      : undefined,
     pageNumber,
   }
 }

--- a/libs/ballot-encoder/src/stats.test.ts
+++ b/libs/ballot-encoder/src/stats.test.ts
@@ -31,8 +31,8 @@ test('BMD: smallest possible encoded ballot', () => {
     encodeBallot(election, {
       electionHash,
       ballotId: '',
-      ballotStyleId: election.ballotStyles[0].id,
-      precinctId: election.precincts[0].id,
+      ballotStyleId: election.ballotStyles[0]!.id,
+      precinctId: election.precincts[0]!.id,
       ballotType: BallotType.Standard,
       isTestMode: true,
       votes: {},

--- a/libs/ballot-encoder/tsconfig.json
+++ b/libs/ballot-encoder/tsconfig.json
@@ -9,6 +9,7 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "module": "commonjs",
     "moduleResolution": "node",
+    "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
This only makes the change in ballot-encoder as a test. The rationale for this option is that TypeScript has a concept of optional properties which, when you access them, forces you to verify (or assert) that they're not undefined before you use them. This option is basically that, but for indexed access e.g. `precincts[0]`. Enabling it will make TS assume that the result of such accesses could be undefined.

Why wasn't it like this since strict null checks were enabled? Mostly because it can be annoying. JS developers rely on this being treated as not undefined _a lot_, so even now it's under a separate flag and not bundled into `strict`. I thought it worth trying out in a small library before trying it anywhere bigger.

https://devblogs.microsoft.com/typescript/announcing-typescript-4-1-beta/#no-unchecked-indexed-access