### PR TITLE
feat(bmd): add `make demo` to launch demo app

### DIFF
--- a/apps/bmd/.eslintignore
+++ b/apps/bmd/.eslintignore
@@ -6,4 +6,5 @@
 /cypress/support
 /prodserver/**/*.js
 /src/**/*.js
+/script/**/*.js
 /.eslintrc.js

--- a/apps/bmd/Makefile
+++ b/apps/bmd/Makefile
@@ -7,3 +7,8 @@ build: FORCE
 
 run:
 	cd prodserver && node index.js
+
+demo:
+	# Preserve BROWSER as DEMO_BROWSER, then tell react-scripts to use our script
+	# as the browser launcher.
+	pnpm install && DEMO_BROWSER=${BROWSER} BROWSER=./script/open-demo.js pnpm start

--- a/apps/bmd/package.json
+++ b/apps/bmd/package.json
@@ -145,6 +145,7 @@
     "jest-styled-components": "^6.3.4",
     "lint-staged": "^10.2.4",
     "prettier": "^2.1.1",
+    "react-dev-utils": "^11.0.3",
     "start-server-and-test": "^1.11.0",
     "stylelint": "^13.3.3",
     "stylelint-config-palantir": "^4.0.1",

--- a/apps/bmd/script/open-demo.js
+++ b/apps/bmd/script/open-demo.js
@@ -1,0 +1,8 @@
+const openBrowser = require('react-dev-utils/openBrowser')
+
+// Restore original BROWSER variable and delete the placeholder.
+process.env.BROWSER = process.env.DEMO_BROWSER
+delete process.env.DEMO_BROWSER
+
+// Open whatever we would have opened, but with the right path.
+openBrowser(new URL('/#demo', process.argv[2]).toString())

--- a/apps/bmd/src/AppData.test.tsx
+++ b/apps/bmd/src/AppData.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { render } from '@testing-library/react'
 
 import App from './App'
-import SampleApp, { getSampleStorage } from './SampleApp'
+import DemoApp, { getSampleStorage } from './DemoApp'
 import { activationStorageKey, electionStorageKey, AppStorage } from './AppRoot'
 
 import {
@@ -62,7 +62,7 @@ describe('loads election', () => {
 
   it('sample app loads election and activates ballot', async () => {
     const storage = getSampleStorage()
-    const { getAllByText, getByText } = render(<SampleApp storage={storage} />)
+    const { getAllByText, getByText } = render(<DemoApp storage={storage} />)
 
     // Let the initial hardware detection run.
     await advanceTimersAndPromises()

--- a/apps/bmd/src/DemoApp.tsx
+++ b/apps/bmd/src/DemoApp.tsx
@@ -55,7 +55,7 @@ export function getSampleMachineConfigProvider(): Provider<MachineConfig> {
 }
 
 /* istanbul ignore next */
-const SampleApp: React.FC<Props> = ({
+const DemoApp: React.FC<Props> = ({
   card = getSampleCard(),
   storage = getSampleStorage(),
   machineConfig = getSampleMachineConfigProvider(),
@@ -71,4 +71,4 @@ const SampleApp: React.FC<Props> = ({
   />
 )
 
-export default SampleApp
+export default DemoApp

--- a/apps/bmd/src/index.tsx
+++ b/apps/bmd/src/index.tsx
@@ -2,7 +2,7 @@ import 'abortcontroller-polyfill/dist/polyfill-patch-fetch'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './App'
-import SampleApp from './SampleApp'
+import DemoApp from './DemoApp'
 
 import * as serviceWorker from './serviceWorker'
 import {
@@ -12,7 +12,7 @@ import {
 import memoize from './utils/memoize'
 import { getUSEnglishVoice } from './utils/voices'
 
-const isSampleApp = window.location.hash === '#sample'
+const isDemoApp = window.location.hash === '#demo'
 // FIXME: `?reader=on` won't be here on reload since we're using the browser
 // history `pushState` API to manipulate the location. Perhaps disable that
 // since we don't really care about page URLs anyway?
@@ -28,8 +28,8 @@ if (readerEnabled) {
 }
 
 ReactDOM.render(
-  isSampleApp ? (
-    <SampleApp screenReader={screenReader} />
+  isDemoApp ? (
+    <DemoApp screenReader={screenReader} />
   ) : (
     <App screenReader={screenReader} />
   ),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,7 @@ importers:
       jest-styled-components: 6.3.4_styled-components@4.4.1
       lint-staged: 10.5.3
       prettier: 2.2.1
+      react-dev-utils: 11.0.3
       start-server-and-test: 1.11.7
       stylelint: 13.8.0
       stylelint-config-palantir: 4.0.1_stylelint@13.8.0
@@ -219,6 +220,7 @@ importers:
       pluralize: ^8.0.0
       prettier: ^2.1.1
       react: ^17.0.1
+      react-dev-utils: ^11.0.3
       react-dom: ^17.0.1
       react-gamepad: ^1.0.3
       react-idle-timer: 4.2.12
@@ -946,8 +948,7 @@ packages:
       integrity: sha512-XsH1mkG5a4J8feeH50Il436pyNCVj6n7EeILYhAHVibQDrxV9gZso198vBZ/dxyhbnfjwK315gvi3/EtEpoekQ==
   /@babel/code-frame/7.10.4:
     dependencies:
-      '@babel/highlight': 7.10.4
-    dev: false
+      '@babel/highlight': 7.13.8
     resolution:
       integrity: sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==
   /@babel/code-frame/7.12.11:
@@ -1447,6 +1448,13 @@ packages:
       js-tokens: 4.0.0
     resolution:
       integrity: sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==
+  /@babel/highlight/7.13.8:
+    dependencies:
+      '@babel/helper-validator-identifier': 7.12.11
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+    resolution:
+      integrity: sha512-4vrIhfJyfNf+lCtXC2ck1rKSzDwciqF7IWFhXXrSOUC2O5DrVp+w4c6ed4AllTxhTkUP5x2tYj41VaxdVMMRDw==
   /@babel/parser/7.12.11:
     engines:
       node: '>=6.0.0'
@@ -7238,7 +7246,6 @@ packages:
     resolution:
       integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
   /address/1.1.2:
-    dev: false
     engines:
       node: '>= 0.12.0'
     resolution:
@@ -8130,7 +8137,6 @@ packages:
     resolution:
       integrity: sha512-+e/UqUzwmzJamNF50tBV6tZPTORow7gQ96iFow+8b562OdMpEK0BcJEq2OSPEDmAbSMBQ7PKZ87ubFkgxpYWgw==
   /big.js/5.2.2:
-    dev: false
     resolution:
       integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
   /binary-extensions/1.13.1:
@@ -8310,11 +8316,10 @@ packages:
       integrity: sha512-TpfK0TDgv71dzuTsEAlQiHeWQ/tiPqgNZVdv046fvNtBZrjbv2O3TsWCDU0AWGJJKCF/KsjNdLzR9hXOsh/CfA==
   /browserslist/4.14.2:
     dependencies:
-      caniuse-lite: 1.0.30001174
-      electron-to-chromium: 1.3.636
+      caniuse-lite: 1.0.30001196
+      electron-to-chromium: 1.3.681
       escalade: 3.1.1
-      node-releases: 1.1.69
-    dev: false
+      node-releases: 1.1.71
     engines:
       node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7
     hasBin: true
@@ -8584,6 +8589,9 @@ packages:
   /caniuse-lite/1.0.30001174:
     resolution:
       integrity: sha512-tqClL/4ThQq6cfFXH3oJL4rifFBeM6gTkphjao5kgwMaW9yn0tKgQLAEfKzDwj6HQWCB/aWo8kTFlSvIN8geEA==
+  /caniuse-lite/1.0.30001196:
+    resolution:
+      integrity: sha512-CPvObjD3ovWrNBaXlAIGWmg2gQQuJ5YhuciUOjPRox6hIQttu8O+b51dx6VIpIY9ESd2d0Vac1RKpICdG4rGUg==
   /canvas/2.6.1:
     dependencies:
       nan: 2.14.2
@@ -9969,7 +9977,6 @@ packages:
     dependencies:
       address: 1.1.2
       debug: 2.6.9
-    dev: false
     engines:
       node: '>= 4.2.1'
     hasBin: true
@@ -10195,6 +10202,9 @@ packages:
   /electron-to-chromium/1.3.636:
     resolution:
       integrity: sha512-Adcvng33sd3gTjNIDNXGD1G4H6qCImIy2euUJAQHtLNplEKU5WEz5KRJxupRNIIT8sD5oFZLTKBWAf12Bsz24A==
+  /electron-to-chromium/1.3.681:
+    resolution:
+      integrity: sha512-W6uYvSUTHuyX2DZklIESAqx57jfmGjUkd7Z3RWqLdj9Mmt39ylhBuvFXlskQnvBHj0MYXIeQI+mjiwVddZLSvA==
   /elegant-spinner/1.0.1:
     dev: true
     engines:
@@ -10235,7 +10245,6 @@ packages:
     resolution:
       integrity: sha1-TapNnbAPmBmIDHn6RXrlsJof04k=
   /emojis-list/3.0.0:
-    dev: false
     engines:
       node: '>= 4'
     resolution:
@@ -11605,6 +11614,7 @@ packages:
       merge2: 1.4.1
       micromatch: 4.0.2
       picomatch: 2.2.2
+    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -11776,7 +11786,6 @@ packages:
     resolution:
       integrity: sha512-u4AYWPgbI5GBhs6id1KdImZWn5yfyFrrQ8OWZdN7ZMfA8Bf4HcO0BGo9bmUIEV8yrp8I1xVfJ/dn90GtFNNJcg==
   /filesize/6.1.0:
-    dev: false
     engines:
       node: '>= 0.4.0'
     resolution:
@@ -11934,7 +11943,7 @@ packages:
       integrity: sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=
   /follow-redirects/1.13.1_debug@4.3.1:
     dependencies:
-      debug: 4.3.1_supports-color@6.1.0
+      debug: 4.3.1
     engines:
       node: '>=4.0'
     peerDependencies:
@@ -11990,14 +11999,13 @@ packages:
       integrity: sha512-DuVkPNrM12jR41KM2e+N+styka0EgLkTnXmNcXdgOM37vtGeY+oCBK/Jx0hzSeEU6memFCtWb4htrHPMDfwwUQ==
   /fork-ts-checker-webpack-plugin/4.1.6:
     dependencies:
-      '@babel/code-frame': 7.12.11
+      '@babel/code-frame': 7.10.4
       chalk: 2.4.2
       micromatch: 3.1.10
       minimatch: 3.0.4
       semver: 5.7.1
       tapable: 1.1.3
       worker-rpc: 0.1.1
-    dev: false
     engines:
       node: '>=6.11.5'
       yarn: '>=1.0.0'
@@ -12357,11 +12365,10 @@ packages:
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.2.4
+      fast-glob: 3.2.5
       ignore: 5.1.8
       merge2: 1.4.1
       slash: 3.0.0
-    dev: false
     engines:
       node: '>=10'
     resolution:
@@ -12429,7 +12436,6 @@ packages:
     dependencies:
       duplexer: 0.1.2
       pify: 4.0.1
-    dev: false
     engines:
       node: '>=6'
     resolution:
@@ -12917,6 +12923,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-Vs/gxoM4DqNAYR7pugIxi0Xc8XAun/uy7AQu4fLLqaTBHxjOP9pJ266Q9MWA/ly4z6rAFZbvViOtihxUZ7O28A==
+  /immer/8.0.1:
+    dev: true
+    resolution:
+      integrity: sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
   /import-cwd/2.1.0:
     dependencies:
       import-from: 2.1.0
@@ -13482,7 +13492,6 @@ packages:
     resolution:
       integrity: sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==
   /is-root/2.1.0:
-    dev: false
     engines:
       node: '>=6'
     resolution:
@@ -15598,8 +15607,7 @@ packages:
     dependencies:
       big.js: 5.2.2
       emojis-list: 3.0.0
-      json5: 2.1.3
-    dev: false
+      json5: 2.2.0
     engines:
       node: '>=8.9.0'
     resolution:
@@ -16014,7 +16022,6 @@ packages:
     resolution:
       integrity: sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
   /microevent.ts/0.1.1:
-    dev: false
     resolution:
       integrity: sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g==
   /micromark/2.11.2:
@@ -16515,6 +16522,9 @@ packages:
   /node-releases/1.1.69:
     resolution:
       integrity: sha512-DGIjo79VDEyAnRlfSqYTsy+yoHd2IOjJiKUozD2MV2D85Vso6Bug56mb9tT/fY5Urt0iqk01H7x+llAruDR2zA==
+  /node-releases/1.1.71:
+    resolution:
+      integrity: sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==
   /nopt/4.0.3:
     dependencies:
       abbrev: 1.1.1
@@ -16825,6 +16835,15 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-f2wt9DCBKKjlFbjzGb8MOAW8LH8F0mrs1zc7KTjAJ9PZNQbfenzWbNP1VZJvw6ICMG9r14Ah6yfwPn7T7i646A==
+  /open/7.4.2:
+    dependencies:
+      is-docker: 2.1.1
+      is-wsl: 2.2.0
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
   /opencollective-postinstall/2.0.3:
     dev: true
     hasBin: true
@@ -17325,7 +17344,6 @@ packages:
     resolution:
       integrity: sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
   /pify/4.0.1:
-    dev: false
     engines:
       node: '>=6'
     resolution:
@@ -17390,7 +17408,6 @@ packages:
   /pkg-up/3.1.0:
     dependencies:
       find-up: 3.0.0
-    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -18665,6 +18682,37 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-rlgpCupaW6qQqvu0hvv2FDv40QG427fjghV56XyPcP5aKtOAPzNAhQ7bHqk1YdS2vpW1W7aSV3JobedxuPlBAA==
+  /react-dev-utils/11.0.3:
+    dependencies:
+      '@babel/code-frame': 7.10.4
+      address: 1.1.2
+      browserslist: 4.14.2
+      chalk: 2.4.2
+      cross-spawn: 7.0.3
+      detect-port-alt: 1.1.6
+      escape-string-regexp: 2.0.0
+      filesize: 6.1.0
+      find-up: 4.1.0
+      fork-ts-checker-webpack-plugin: 4.1.6
+      global-modules: 2.0.0
+      globby: 11.0.1
+      gzip-size: 5.1.1
+      immer: 8.0.1
+      is-root: 2.1.0
+      loader-utils: 2.0.0
+      open: 7.4.2
+      pkg-up: 3.1.0
+      prompts: 2.4.0
+      react-error-overlay: 6.0.9
+      recursive-readdir: 2.2.2
+      shell-quote: 1.7.2
+      strip-ansi: 6.0.0
+      text-table: 0.2.0
+    dev: true
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-4lEA5gF4OHrcJLMUV1t+4XbNDiJbsAWCH5Z2uqlTqW6dD7Cf5nEASkeXrCI/Mz83sI2o527oBIFKVMXtRf1Vtg==
   /react-dom/17.0.1_react@17.0.1:
     dependencies:
       loose-envify: 1.4.0
@@ -18693,6 +18741,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-HvPuUQnLp5H7TouGq3kzBeioJmXms1wHy9EGjz2OURWBp4qZO6AfGEcnxts1D/CbwPLRAgTMPCEgYhA3sEM4vw==
+  /react-error-overlay/6.0.9:
+    dev: true
+    resolution:
+      integrity: sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
   /react-gamepad/1.0.3_react@17.0.1:
     dependencies:
       react: 17.0.1
@@ -19169,7 +19221,6 @@ packages:
   /recursive-readdir/2.2.2:
     dependencies:
       minimatch: 3.0.4
-    dev: false
     engines:
       node: '>=0.10.0'
     resolution:
@@ -19995,7 +20046,6 @@ packages:
     resolution:
       integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
   /shell-quote/1.7.2:
-    dev: false
     resolution:
       integrity: sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
   /shellwords/0.1.1:
@@ -21037,7 +21087,6 @@ packages:
     resolution:
       integrity: sha512-rxZevLGTUzWna/qBLObOe16kB2RTnnbhciwgPbMMlazz1yZGVEgnZK762xyVdVznhqxrfCeBMmMkgOOaPwjH7g==
   /tapable/1.1.3:
-    dev: false
     engines:
       node: '>=6'
     resolution:
@@ -22765,7 +22814,6 @@ packages:
   /worker-rpc/0.1.1:
     dependencies:
       microevent.ts: 0.1.1
-    dev: false
     resolution:
       integrity: sha512-P1WjMrUB3qgJNI9jfmpZ/htmBEjFh//6l/5y8SD9hg1Ef5zTTVVoRjTrTEzPrNBQvmhMxkoTsjOXN10GWU7aCg==
   /wrap-ansi/2.1.0:


### PR DESCRIPTION
I changed from "sample" to "demo" because it's not a random (or otherwise) _sample_ of various BMD application configurations, but a _demonstration_ using a particular configuration.

This could be something that every app could have in its makefile to easily start a demo version.