### PR TITLE
feat(module-scan): add overrides for mark thresholds

### DIFF
--- a/apps/module-scan/src/importer.ts
+++ b/apps/module-scan/src/importer.ts
@@ -1,4 +1,5 @@
 import { BallotPageLayout, Interpreter } from '@votingworks/hmpb-interpreter'
+import { MarkThresholds, Optional } from '@votingworks/types'
 import makeDebug from 'debug'
 import * as fsExtra from 'fs-extra'
 import * as streams from 'memory-streams'
@@ -53,6 +54,9 @@ export interface Importer {
   getStatus(): Promise<ScanStatus>
   restoreConfig(): Promise<void>
   setTestMode(testMode: boolean): Promise<void>
+  setMarkThresholdOverrides(
+    markThresholds: Optional<MarkThresholds>
+  ): Promise<void>
   unconfigure(): Promise<void>
 }
 
@@ -194,6 +198,14 @@ export default class SystemImporter implements Importer {
     debug('setting test mode to %s', testMode)
     await this.doZero()
     await this.workspace.store.setTestMode(testMode)
+    await this.restoreConfig()
+  }
+
+  public async setMarkThresholdOverrides(
+    markThresholds: Optional<MarkThresholds>
+  ): Promise<void> {
+    debug('setting mark thresholds overrides to %s', markThresholds)
+    await this.workspace.store.setMarkThresholdOverrides(markThresholds)
     await this.restoreConfig()
   }
 
@@ -492,6 +504,7 @@ export default class SystemImporter implements Importer {
    */
   public async doZero(): Promise<void> {
     await this.workspace.store.zero()
+    await this.setMarkThresholdOverrides(undefined)
     fsExtra.emptyDirSync(this.workspace.ballotImagesPath)
   }
 

--- a/apps/module-scan/src/interpreter.test.ts
+++ b/apps/module-scan/src/interpreter.test.ts
@@ -52,7 +52,8 @@ test('extracts votes encoded in a QR code', async () => {
           ...electionSample,
           markThresholds: { definite: 0.2, marginal: 0.17 },
         },
-        true
+        true,
+        undefined
       ).interpretFile({
         ballotImagePath,
         ballotImageFile: await readFile(ballotImagePath),
@@ -95,7 +96,8 @@ test('properly detects test ballot in live mode', async () => {
       ...electionSample,
       markThresholds: { definite: 0.2, marginal: 0.17 },
     },
-    false // this is the test mode
+    false, // this is the test mode
+    undefined
   ).interpretFile({
     ballotImagePath,
     ballotImageFile: await readFile(ballotImagePath),
@@ -174,7 +176,7 @@ test('can read metadata in QR code with skewed / dirty ballot', async () => {
 })
 
 test('interprets marks on a HMPB', async () => {
-  const interpreter = new Interpreter(stateOfHamiltonElection, false)
+  const interpreter = new Interpreter(stateOfHamiltonElection, false, undefined)
 
   for await (const { page, pageNumber } of pdfToImages(
     await readFile(join(stateOfHamiltonFixturesRoot, 'ballot.pdf')),
@@ -226,7 +228,7 @@ test('interprets marks on a HMPB', async () => {
 })
 
 test('interprets marks on an upside-down HMPB', async () => {
-  const interpreter = new Interpreter(stateOfHamiltonElection, false)
+  const interpreter = new Interpreter(stateOfHamiltonElection, false, undefined)
 
   for await (const { page, pageNumber } of pdfToImages(
     await readFile(join(stateOfHamiltonFixturesRoot, 'ballot.pdf')),
@@ -1765,7 +1767,7 @@ test('interprets marks in PNG ballots', async () => {
     markThresholds: { definite: 0.2, marginal: 0.12 },
     ...choctaw2020Election,
   }
-  const interpreter = new Interpreter(election, false)
+  const interpreter = new Interpreter(election, false, undefined)
 
   for await (const { page } of pdfToImages(
     await readFile(join(choctaw2020FixturesRoot, 'ballot.pdf')),
@@ -2952,7 +2954,7 @@ test('interprets marks in PNG ballots', async () => {
 })
 
 test('returns metadata if the QR code is readable but the HMPB ballot is not', async () => {
-  const interpreter = new Interpreter(stateOfHamiltonElection, false)
+  const interpreter = new Interpreter(stateOfHamiltonElection, false, undefined)
 
   for await (const { page, pageNumber } of pdfToImages(
     await readFile(join(stateOfHamiltonFixturesRoot, 'ballot.pdf')),
@@ -2998,7 +3000,7 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
 test('scans images where quirc and jsqr cannot find the QR code by providing QR code reading for hmpb-interpreter', async () => {
   const fixtures = choctaw2020SpecialFixtures
   const { election } = fixtures
-  const interpreter = new Interpreter(election, false)
+  const interpreter = new Interpreter(election, false, undefined)
 
   for await (const { page } of pdfToImages(
     await readFile(fixtures.ballot6522Pdf),

--- a/apps/module-scan/src/interpreter.ts
+++ b/apps/module-scan/src/interpreter.ts
@@ -9,6 +9,7 @@ import {
   Contests,
   Election,
   MarkThresholds,
+  Optional,
   VotesDict,
 } from '@votingworks/types'
 import { decodeBallot, detect } from '@votingworks/ballot-encoder'
@@ -215,11 +216,15 @@ export default class Interpreter {
   private testMode: boolean
   private markThresholds: MarkThresholds
 
-  public constructor(election: Election, testMode: boolean) {
+  public constructor(
+    election: Election,
+    testMode: boolean,
+    markThresholdOverrides: Optional<MarkThresholds>
+  ) {
     this.election = election
     this.testMode = testMode
 
-    const { markThresholds } = election
+    const markThresholds = markThresholdOverrides ?? election.markThresholds
 
     if (!markThresholds) {
       throw new Error('missing mark thresholds')

--- a/apps/module-scan/src/server.ts
+++ b/apps/module-scan/src/server.ts
@@ -3,7 +3,7 @@
 // All actual implementations are in importer.ts and scanner.ts
 //
 
-import { BallotType, Election } from '@votingworks/types'
+import { BallotType, Election, MarkThresholds } from '@votingworks/types'
 import bodyParser from 'body-parser'
 import express, { Application, RequestHandler } from 'express'
 import { readFile } from 'fs-extra'
@@ -41,6 +41,7 @@ export function buildApp({ store, importer }: AppOptions): Application {
     response.json({
       election: (await store.getElectionDefinition())?.election,
       testMode: await store.getTestMode(),
+      markThresholdOverrides: await store.getMarkThresholdOverrides(),
     })
   })
 
@@ -93,6 +94,14 @@ export function buildApp({ store, importer }: AppOptions): Application {
               throw new TypeError()
             }
             await importer.setTestMode(value)
+            break
+          }
+          case ConfigKey.MarkThresholdOverrides: {
+            if (value === null) {
+              await importer.setMarkThresholdOverrides(undefined)
+              break
+            }
+            await importer.setMarkThresholdOverrides(value as MarkThresholds)
             break
           }
         }

--- a/apps/module-scan/src/store.test.ts
+++ b/apps/module-scan/src/store.test.ts
@@ -43,6 +43,42 @@ test('get/set test mode', async () => {
   expect(await store.getTestMode()).toBe(false)
 })
 
+test('get/set mark threshold overrides', async () => {
+  const store = await Store.memoryStore()
+
+  expect(await store.getMarkThresholdOverrides()).toBe(undefined)
+
+  await store.setMarkThresholdOverrides({ definite: 0.4, marginal: 0.5 })
+  expect(await store.getMarkThresholdOverrides()).toStrictEqual({
+    definite: 0.4,
+    marginal: 0.5,
+  })
+
+  await store.setMarkThresholdOverrides(undefined)
+  expect(await store.getMarkThresholdOverrides()).toBe(undefined)
+})
+
+test('get current mark thresholds falls back to election definition defaults', async () => {
+  const store = await Store.memoryStore()
+  await store.setElection(fromElection(election))
+  expect(await store.getCurrentMarkThresholds()).toStrictEqual({
+    definite: 0.17,
+    marginal: 0.12,
+  })
+
+  await store.setMarkThresholdOverrides({ definite: 0.4, marginal: 0.5 })
+  expect(await store.getCurrentMarkThresholds()).toStrictEqual({
+    definite: 0.4,
+    marginal: 0.5,
+  })
+
+  await store.setMarkThresholdOverrides(undefined)
+  expect(await store.getCurrentMarkThresholds()).toStrictEqual({
+    definite: 0.17,
+    marginal: 0.12,
+  })
+})
+
 test('HMPB template handling', async () => {
   const store = await Store.memoryStore()
   const metadata: BallotMetadata = {

--- a/apps/module-scan/src/workers/interpret.ts
+++ b/apps/module-scan/src/workers/interpret.ts
@@ -55,7 +55,11 @@ export async function configure(store: Store): Promise<void> {
   const templates = await store.getHmpbTemplates()
 
   debug('creating a new interpreter')
-  interpreter = new Interpreter(election, await store.getTestMode())
+  interpreter = new Interpreter(
+    election,
+    await store.getTestMode(),
+    await store.getMarkThresholdOverrides()
+  )
 
   debug('hand-marked paper ballot templates: %d', templates.length)
   for (const [pdf, layouts] of templates) {

--- a/apps/module-scan/test/util/mocks.ts
+++ b/apps/module-scan/test/util/mocks.ts
@@ -39,6 +39,7 @@ export function makeMockImporter(): jest.Mocked<Importer> {
     restoreConfig: jest.fn(),
     setTestMode: jest.fn(),
     unconfigure: jest.fn(),
+    setMarkThresholdOverrides: jest.fn(),
   }
 }
 


### PR DESCRIPTION
Adds mark threshold overrides to the config object in module-scan and allows for getting and setting through the existing /config endpoints. 