### PR TITLE
feat(bsd): add dialog to set and reset thresholds

### DIFF
--- a/apps/bsd/src/components/SetMarkThresholdsModal.test.tsx
+++ b/apps/bsd/src/components/SetMarkThresholdsModal.test.tsx
@@ -1,0 +1,209 @@
+import React from 'react'
+
+import {
+  render,
+  fireEvent,
+  getByText as domGetByText,
+  waitFor,
+} from '@testing-library/react'
+import { electionSample } from '@votingworks/fixtures'
+import { Router } from 'react-router-dom'
+import { createMemoryHistory } from 'history'
+
+import SetMarkThresholdsModal from './SetMarkThresholdsModal'
+
+test('renders warning message before allowing overrides to be set', () => {
+  const closeFn = jest.fn()
+  const { getByText } = render(
+    <Router history={createMemoryHistory()}>
+      <SetMarkThresholdsModal
+        onClose={closeFn}
+        election={electionSample}
+        markThresholdOverrides={undefined}
+        setMarkThresholdOverrides={jest.fn()}
+      />
+    </Router>
+  )
+  getByText('Override Mark Thresholds')
+  getByText(/WARNING: Do not proceed/)
+  fireEvent.click(getByText('Close'))
+  expect(closeFn).toHaveBeenCalled()
+})
+
+test('renders reset modal when overrides are set', async () => {
+  const closeFn = jest.fn()
+  const setMarkThresholdOverrides = jest.fn().mockResolvedValueOnce('')
+  const { getByText } = render(
+    <Router history={createMemoryHistory()}>
+      <SetMarkThresholdsModal
+        onClose={closeFn}
+        election={electionSample}
+        markThresholdOverrides={{ definite: 0.32, marginal: 0.24 }}
+        setMarkThresholdOverrides={setMarkThresholdOverrides}
+      />
+    </Router>
+  )
+  getByText('Reset Mark Thresholds')
+  const currentThresholds = getByText('Current Thresholds')
+  domGetByText(currentThresholds, /Definite: 0.32/)
+  domGetByText(currentThresholds, /Marginal: 0.24/)
+
+  const defaultThresholds = getByText('Default Thresholds')
+  domGetByText(defaultThresholds, /Definite: 0.25/)
+  domGetByText(defaultThresholds, /Marginal: 0.17/)
+
+  fireEvent.click(getByText('Close'))
+  expect(closeFn).toHaveBeenCalled()
+
+  fireEvent.click(getByText('Reset Thresholds'))
+  expect(setMarkThresholdOverrides).toHaveBeenCalledWith(undefined)
+  await waitFor(() => {
+    expect(closeFn).toHaveBeenCalledTimes(2)
+  })
+})
+test('reset modal displays errors appropriately', async () => {
+  const closeFn = jest.fn()
+  const setMarkThresholdOverrides = jest
+    .fn()
+    .mockRejectedValueOnce(new Error('Hakuna Matata'))
+  const { getByText } = render(
+    <Router history={createMemoryHistory()}>
+      <SetMarkThresholdsModal
+        onClose={closeFn}
+        election={electionSample}
+        markThresholdOverrides={{ definite: 0.32, marginal: 0.24 }}
+        setMarkThresholdOverrides={setMarkThresholdOverrides}
+      />
+    </Router>
+  )
+  getByText('Reset Mark Thresholds')
+  fireEvent.click(getByText('Reset Thresholds'))
+  expect(setMarkThresholdOverrides).toHaveBeenCalledWith(undefined)
+  await waitFor(() => {
+    getByText('Error')
+  })
+  getByText(/Hakuna Matata/)
+  fireEvent.click(getByText('Close'))
+  expect(closeFn).toHaveBeenCalledTimes(1)
+})
+
+test('allows users to set thresholds properly', async () => {
+  const closeFn = jest.fn()
+  const setThresholds = jest.fn()
+  const { getByText, getByTestId } = render(
+    <Router history={createMemoryHistory()}>
+      <SetMarkThresholdsModal
+        onClose={closeFn}
+        election={electionSample}
+        markThresholdOverrides={undefined}
+        setMarkThresholdOverrides={setThresholds}
+      />
+    </Router>
+  )
+  getByText('Override Mark Thresholds')
+  getByText(/WARNING: Do not proceed/)
+  fireEvent.click(getByText('Proceed to Override Thresholds'))
+
+  const definiteInput = getByTestId('definite-text-input').closest('input')!
+  expect(definiteInput.value).toBe('0.25')
+  fireEvent.change(definiteInput, { target: { value: '0.12' } })
+  expect(definiteInput.value).toBe('0.12')
+
+  const marginalInput = getByTestId('marginal-text-input').closest('input')!
+  expect(marginalInput.value).toBe('0.17')
+  fireEvent.change(marginalInput, { target: { value: '0.21' } })
+  expect(marginalInput.value).toBe('0.21')
+
+  fireEvent.click(getByText('Override Thresholds'))
+  expect(setThresholds).toHaveBeenCalledWith({ definite: 0.12, marginal: 0.21 })
+  await waitFor(() => {
+    expect(closeFn).toHaveBeenCalledTimes(1)
+  })
+})
+
+test('setting thresholds renders an error if given a non number', async () => {
+  const closeFn = jest.fn()
+  const setThresholds = jest.fn()
+  const { getByText, getByTestId } = render(
+    <Router history={createMemoryHistory()}>
+      <SetMarkThresholdsModal
+        onClose={closeFn}
+        election={electionSample}
+        markThresholdOverrides={undefined}
+        setMarkThresholdOverrides={setThresholds}
+      />
+    </Router>
+  )
+  getByText('Override Mark Thresholds')
+  getByText(/WARNING: Do not proceed/)
+  fireEvent.click(getByText('Proceed to Override Thresholds'))
+
+  const definiteInput = getByTestId('definite-text-input').closest('input')!
+  fireEvent.change(definiteInput, { target: { value: 'giraffes' } })
+  expect(definiteInput.value).toBe('giraffes')
+
+  fireEvent.click(getByText('Override Thresholds'))
+  getByText('Error')
+  getByText(/Inputted definite threshold invalid: giraffes./)
+  expect(setThresholds).toHaveBeenCalledTimes(0)
+  expect(closeFn).toHaveBeenCalledTimes(0)
+})
+
+test('setting thresholds renders an error if given a number greater than 1', async () => {
+  const closeFn = jest.fn()
+  const setThresholds = jest.fn()
+  const { getByText, getByTestId } = render(
+    <Router history={createMemoryHistory()}>
+      <SetMarkThresholdsModal
+        onClose={closeFn}
+        election={electionSample}
+        markThresholdOverrides={undefined}
+        setMarkThresholdOverrides={setThresholds}
+      />
+    </Router>
+  )
+  getByText('Override Mark Thresholds')
+  getByText(/WARNING: Do not proceed/)
+  fireEvent.click(getByText('Proceed to Override Thresholds'))
+
+  const definiteInput = getByTestId('definite-text-input').closest('input')!
+  fireEvent.change(definiteInput, { target: { value: '314' } })
+  expect(definiteInput.value).toBe('314')
+
+  fireEvent.click(getByText('Override Thresholds'))
+  getByText('Error')
+  getByText(/Inputted definite threshold invalid: 314./)
+  expect(setThresholds).toHaveBeenCalledTimes(0)
+  expect(closeFn).toHaveBeenCalledTimes(0)
+})
+
+test('setting thresholds renders an error if saving throws an error', async () => {
+  const closeFn = jest.fn()
+  const setThresholds = jest
+    .fn()
+    .mockRejectedValueOnce(new Error('Hakuna Matata'))
+  const { getByText } = render(
+    <Router history={createMemoryHistory()}>
+      <SetMarkThresholdsModal
+        onClose={closeFn}
+        election={electionSample}
+        markThresholdOverrides={undefined}
+        setMarkThresholdOverrides={setThresholds}
+      />
+    </Router>
+  )
+  getByText('Override Mark Thresholds')
+  getByText(/WARNING: Do not proceed/)
+  fireEvent.click(getByText('Proceed to Override Thresholds'))
+
+  fireEvent.click(getByText('Override Thresholds'))
+  await waitFor(() => {
+    getByText('Error')
+  })
+  getByText(/Hakuna Matata/)
+  expect(setThresholds).toHaveBeenCalledTimes(1)
+  expect(closeFn).toHaveBeenCalledTimes(0)
+
+  fireEvent.click(getByText('Close'))
+  expect(closeFn).toHaveBeenCalledTimes(1)
+})

--- a/apps/bsd/src/components/SetMarkThresholdsModal.tsx
+++ b/apps/bsd/src/components/SetMarkThresholdsModal.tsx
@@ -1,0 +1,242 @@
+import React, { useState } from 'react'
+import styled from 'styled-components'
+
+import { Election, MarkThresholds, Optional } from '@votingworks/types'
+
+import Modal from './Modal'
+import Button from './Button'
+import Prose from './Prose'
+import LinkButton from './LinkButton'
+import Loading from './Loading'
+import throwIllegalValue from '../util/throwIllegalValue'
+import TextInput from './TextInput'
+import Text from './Text'
+
+export interface Props {
+  onClose: () => void
+  election: Election
+  markThresholdOverrides: Optional<MarkThresholds>
+  setMarkThresholdOverrides: (
+    markThresholds: Optional<MarkThresholds>
+  ) => Promise<void>
+}
+
+const ThresholdColumns = styled.div`
+  display: flex;
+  flex-direction: row;
+  > div {
+    flex: 1;
+  }
+`
+
+enum ModalState {
+  SAVING = 'saving',
+  RESET_THRESHOLDS = 'reset_thresholds',
+  SET_THRESHOLDS = 'set_thresholds',
+  CONFIRM_INTENT = 'confirm_intent',
+  ERROR = 'error',
+}
+
+export const DefaultMarkThresholds: Readonly<MarkThresholds> = {
+  marginal: 0.17,
+  definite: 0.25,
+}
+
+const SetMarkThresholdsModal: React.FC<Props> = ({
+  onClose,
+  election,
+  markThresholdOverrides,
+  setMarkThresholdOverrides,
+}) => {
+  const [currentState, setCurrentState] = useState<ModalState>(
+    markThresholdOverrides === undefined
+      ? ModalState.CONFIRM_INTENT
+      : ModalState.RESET_THRESHOLDS
+  )
+
+  const [errorMessage, setErrorMessage] = useState('')
+  const defaultMarkThresholds = election.markThresholds ?? DefaultMarkThresholds
+  const defaultDefiniteThreshold = defaultMarkThresholds.definite
+  const defaultMarginalThreshold = defaultMarkThresholds.marginal
+
+  const [definiteThreshold, setDefiniteThreshold] = useState(
+    defaultDefiniteThreshold.toString()
+  )
+  const [marginalThreshold, setMarginalThreshold] = useState(
+    defaultMarginalThreshold.toString()
+  )
+
+  const overrideThresholds = async (definite: string, marginal: string) => {
+    setCurrentState(ModalState.SAVING)
+    try {
+      const definiteFloat = parseFloat(definite)
+      if (Number.isNaN(definiteFloat) || definiteFloat > 1) {
+        throw new Error(
+          `Inputted definite threshold invalid: ${definite}. Please enter a number from 0 to 1.`
+        )
+      }
+      const marginalFloat = parseFloat(marginal)
+      if (Number.isNaN(marginalFloat) || marginalFloat > 1) {
+        throw new Error(
+          `Inputted marginal threshold invalid: ${marginal}. Please enter a number from 0 to 1.`
+        )
+      }
+      await setMarkThresholdOverrides({
+        definite: definiteFloat,
+        marginal: marginalFloat,
+      })
+      onClose()
+    } catch (error) {
+      setCurrentState(ModalState.ERROR)
+      setErrorMessage(`Error setting thresholds: ${error.message}`)
+    }
+  }
+
+  const resetThresholds = async () => {
+    setCurrentState(ModalState.SAVING)
+    try {
+      await setMarkThresholdOverrides(undefined)
+      onClose()
+    } catch (error) {
+      setCurrentState(ModalState.ERROR)
+      setErrorMessage(`Error setting thresholds: ${error.message}`)
+    }
+  }
+
+  switch (currentState) {
+    case ModalState.SAVING:
+      return <Modal content={<Loading />} onOverlayClick={onClose} />
+    case ModalState.ERROR:
+      return (
+        <Modal
+          content={
+            <Prose>
+              <h1>Error</h1>
+              <p>{errorMessage}</p>
+            </Prose>
+          }
+          onOverlayClick={onClose}
+          actions={
+            <React.Fragment>
+              <LinkButton onPress={onClose}>Close</LinkButton>
+            </React.Fragment>
+          }
+        />
+      )
+    case ModalState.CONFIRM_INTENT:
+      return (
+        <Modal
+          content={
+            <Prose>
+              <h1>Override Mark Thresholds</h1>
+              <p>
+                WARNING: Do not proceed unless you have been instructed to do so
+                by a member of VotingWorks staff. Changing mark thresholds will
+                impact the performance of your scanner.
+              </p>
+            </Prose>
+          }
+          onOverlayClick={onClose}
+          actions={
+            <React.Fragment>
+              <LinkButton onPress={onClose}>Close</LinkButton>
+              {
+                <Button
+                  danger
+                  onPress={() => setCurrentState(ModalState.SET_THRESHOLDS)}
+                >
+                  Proceed to Override Thresholds
+                </Button>
+              }{' '}
+            </React.Fragment>
+          }
+        />
+      )
+    case ModalState.SET_THRESHOLDS:
+      return (
+        <Modal
+          content={
+            <Prose>
+              <h1>Override Mark Thresholds</h1>
+              <Text>Definite:</Text>
+              <TextInput
+                data-testid="definite-text-input"
+                value={definiteThreshold}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setDefiniteThreshold(e.target.value)
+                }
+              />
+              <Text>Marginal:</Text>
+              <TextInput
+                data-testid="marginal-text-input"
+                value={marginalThreshold}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setMarginalThreshold(e.target.value)
+                }
+              />
+            </Prose>
+          }
+          onOverlayClick={onClose}
+          actions={
+            <React.Fragment>
+              <LinkButton onPress={onClose}>Close</LinkButton>
+              {
+                <Button
+                  danger
+                  onPress={() =>
+                    overrideThresholds(definiteThreshold, marginalThreshold)
+                  }
+                >
+                  Override Thresholds
+                </Button>
+              }{' '}
+            </React.Fragment>
+          }
+        />
+      )
+    case ModalState.RESET_THRESHOLDS:
+      return (
+        <Modal
+          content={
+            <Prose>
+              <h1>Reset Mark Thresholds</h1>
+              <p>Reset thresholds to the election defaults?</p>
+              <ThresholdColumns>
+                <div>
+                  Current Thresholds
+                  <Text small>
+                    Definite: {markThresholdOverrides!.definite}
+                    <br />
+                    Marginal: {markThresholdOverrides!.marginal}
+                  </Text>
+                </div>
+                <div>
+                  Default Thresholds
+                  <Text small>
+                    Definite: {defaultMarkThresholds.definite}
+                    <br />
+                    Marginal: {defaultMarkThresholds.marginal}
+                  </Text>
+                </div>
+              </ThresholdColumns>
+            </Prose>
+          }
+          onOverlayClick={onClose}
+          actions={
+            <React.Fragment>
+              <LinkButton onPress={onClose}>Close</LinkButton>
+              {
+                <Button primary onPress={resetThresholds}>
+                  Reset Thresholds
+                </Button>
+              }{' '}
+            </React.Fragment>
+          }
+        />
+      )
+    default:
+      throwIllegalValue(currentState)
+  }
+}
+
+export default SetMarkThresholdsModal

--- a/apps/bsd/src/components/TextInput.tsx
+++ b/apps/bsd/src/components/TextInput.tsx
@@ -1,0 +1,15 @@
+import styled from 'styled-components'
+
+interface Props {
+  disabled?: boolean
+}
+
+const TextInput = styled.input<Props>`
+  border: 1px solid #cccccc;
+  background: ${({ disabled = false }) => (disabled ? '#dddddd' : '#ffffff')};
+  width: 100%;
+  padding: 0.35rem 0.5rem;
+  line-height: 1.25;
+`
+
+export default TextInput

--- a/apps/bsd/src/config/types.ts
+++ b/apps/bsd/src/config/types.ts
@@ -1,6 +1,7 @@
 import type {
   AdjudicationReason,
   Election,
+  MarkThresholds,
   OptionalElection,
   VotesDict,
 } from '@votingworks/types'
@@ -122,11 +123,13 @@ export type GetConfigRequest = void
 export interface GetConfigResponse {
   election?: Election
   testMode: boolean
+  markThresholdOverrides?: MarkThresholds | null
 }
 
 export interface PatchConfigRequest {
   election?: Election | ElectionDefinition | null
   testMode?: boolean
+  markThresholdOverrides?: MarkThresholds | null
 }
 export type PatchConfigResponse = OkResponse
 

--- a/apps/bsd/src/screens/AdvancedOptionsScreen.tsx
+++ b/apps/bsd/src/screens/AdvancedOptionsScreen.tsx
@@ -1,3 +1,4 @@
+import { MarkThresholds, Optional, Election } from '@votingworks/types'
 import React, { useCallback, useState } from 'react'
 import Button from '../components/Button'
 import LinkButton from '../components/LinkButton'
@@ -7,6 +8,7 @@ import Modal from '../components/Modal'
 import Prose from '../components/Prose'
 import Screen from '../components/Screen'
 import ToggleTestModeButton from '../components/ToggleTestModeButton'
+import SetMarkThresholdsModal from '../components/SetMarkThresholdsModal'
 
 interface Props {
   unconfigureServer: () => Promise<void>
@@ -16,6 +18,11 @@ interface Props {
   isTestMode: boolean
   isTogglingTestMode: boolean
   toggleTestMode: () => Promise<void>
+  setMarkThresholdOverrides: (
+    markThresholds: Optional<MarkThresholds>
+  ) => Promise<void>
+  markThresholds: Optional<MarkThresholds>
+  election: Election
 }
 
 const AdvancedOptionsScreen: React.FC<Props> = ({
@@ -26,6 +33,9 @@ const AdvancedOptionsScreen: React.FC<Props> = ({
   isTestMode,
   isTogglingTestMode,
   toggleTestMode,
+  setMarkThresholdOverrides,
+  markThresholds,
+  election,
 }) => {
   const [isConfirmingFactoryReset, setIsConfirmingFactoryReset] = useState(
     false
@@ -35,6 +45,9 @@ const AdvancedOptionsScreen: React.FC<Props> = ({
   const toggleIsConfirmingFactoryReset = () =>
     setIsConfirmingFactoryReset((s) => !s)
   const [isConfirmingZero, setIsConfirmingZero] = useState(false)
+  const [isSetMarkThresholdModalOpen, setIsMarkThresholdModalOpen] = useState(
+    false
+  )
   const toggleIsConfirmingZero = () => setIsConfirmingZero((s) => !s)
   const exportBackup = useCallback(async () => {
     try {
@@ -71,6 +84,16 @@ const AdvancedOptionsScreen: React.FC<Props> = ({
                   Factory Reset…
                 </Button>
               </p>
+              <p>
+                <Button
+                  onPress={() => setIsMarkThresholdModalOpen(true)}
+                  disabled={hasBatches}
+                >
+                  {markThresholds === undefined
+                    ? 'Override Mark Thresholds…'
+                    : 'Reset Mark Thresholds…'}
+                </Button>
+              </p>
               {backupError && <p style={{ color: 'red' }}>{backupError}</p>}
               <p>
                 <Button onPress={exportBackup} disabled={isBackingUp}>
@@ -99,7 +122,8 @@ const AdvancedOptionsScreen: React.FC<Props> = ({
               <h1>Delete All Scanned Ballot Data?</h1>
               <p>
                 This will permanently delete all scanned ballot data and reset
-                the scanner to only be configured with the current election.
+                the scanner to only be configured with the current election,
+                with the default mark thresholds.
               </p>
             </Prose>
           }
@@ -132,6 +156,14 @@ const AdvancedOptionsScreen: React.FC<Props> = ({
             </React.Fragment>
           }
           onOverlayClick={toggleIsConfirmingFactoryReset}
+        />
+      )}
+      {isSetMarkThresholdModalOpen && (
+        <SetMarkThresholdsModal
+          setMarkThresholdOverrides={setMarkThresholdOverrides}
+          markThresholdOverrides={markThresholds}
+          election={election}
+          onClose={() => setIsMarkThresholdModalOpen(false)}
         />
       )}
     </React.Fragment>

--- a/apps/bsd/src/util/throwIllegalValue.ts
+++ b/apps/bsd/src/util/throwIllegalValue.ts
@@ -1,0 +1,3 @@
+export default function throwIllegalValue(s: never): never {
+  throw new Error(`Illegal Value: ${s}`)
+}


### PR DESCRIPTION
Adds modal in advanced options to set the mark thresholds on the scanner. 

Setting the overrides when they are not set:

https://user-images.githubusercontent.com/14897017/110172936-bc325d00-7db2-11eb-850e-d71ccd3306c9.mov

Resetting overrides: 

https://user-images.githubusercontent.com/14897017/110173381-585c6400-7db3-11eb-9541-37d140c4e622.mov


Zeroing ballot data or doing a factory reset will also clear these overrides.
