### PR TITLE
fix(scan): short circuit interpretation of blank pages

### DIFF
--- a/apps/module-scan/src/importer.ts
+++ b/apps/module-scan/src/importer.ts
@@ -15,7 +15,6 @@ import {
   Side,
 } from './types'
 import { toPNG } from './util/images'
-import { normalizeSheetMetadata } from './util/metadata'
 import pdfToImages from './util/pdfToImages'
 import { Workspace } from './util/workspace'
 import * as workers from './workers/combined'
@@ -256,32 +255,26 @@ export default class SystemImporter implements Importer {
       action: 'detect-qrcode',
       imagePath: backImagePath,
     })
-    const [frontDetectQrcodeOutput, backDetectQrcodeOutput] = [
+    const [
+      frontDetectQrcodeOutput,
+      backDetectQrcodeOutput,
+    ] = qrcodeWorker.normalizeSheetOutput(electionDefinition.election, [
       (await frontDetectQrcodePromise) as qrcodeWorker.Output,
       (await backDetectQrcodePromise) as qrcodeWorker.Output,
-    ]
-    const [
-      frontQrcode,
-      backQrcode,
-    ] = normalizeSheetMetadata(electionDefinition.election, [
-      !frontDetectQrcodeOutput.blank
-        ? frontDetectQrcodeOutput.qrcode
-        : undefined,
-      !backDetectQrcodeOutput.blank ? backDetectQrcodeOutput.qrcode : undefined,
     ])
     const frontInterpretPromise = workerPool.call({
       action: 'interpret',
       imagePath: frontImagePath,
       sheetId,
       ballotImagesPath: this.workspace.ballotImagesPath,
-      qrcode: frontQrcode,
+      detectQrcodeResult: frontDetectQrcodeOutput,
     })
     const backInterpretPromise = workerPool.call({
       action: 'interpret',
       imagePath: backImagePath,
       sheetId,
       ballotImagesPath: this.workspace.ballotImagesPath,
-      qrcode: backQrcode,
+      detectQrcodeResult: backDetectQrcodeOutput,
     })
 
     const frontWorkerOutput = (await frontInterpretPromise) as InterpretOutput


### PR DESCRIPTION
This is an improvement on #340. When the QR code detection step runs, it first determines whether the page is blank. If it is, checking for a QR code is skipped. However, we then do the blank page check and possibly QR code detection _again_ during interpretation. This commit passes the full results from the initial QR code detection so that we do not duplicate that work.

In my testing this does not noticeably speed up the processing of BMD ballots. I believe this is because the front side still takes longer (in parallel) to run than the back (blank) side due to loading/rotating/saving images. However, it's still a good cleanup.