### PR TITLE
refactor(types): consolidate generic types and utils

### DIFF
--- a/apps/bmd/src/AppRoot.tsx
+++ b/apps/bmd/src/AppRoot.tsx
@@ -1,15 +1,18 @@
 /* eslint-disable no-shadow */
 import {
-  CompletedBallot,
-  getPrecinctById,
   BallotType,
   CandidateVote,
-  YesNoVote,
-  OptionalVote,
-  VotesDict,
+  CompletedBallot,
   Election,
   ElectionDefinition,
   OptionalElectionDefinition,
+  OptionalVote,
+  Provider,
+  VotesDict,
+  YesNoVote,
+  getBallotStyle,
+  getContests,
+  getPrecinctById,
 } from '@votingworks/types'
 import { decodeBallot, encodeBallot } from '@votingworks/ballot-encoder'
 import 'normalize.css'
@@ -37,7 +40,6 @@ import {
   CandidateVoteTally,
   YesNoVoteTally,
   SerializableActivationData,
-  Provider,
   MachineConfig,
   PostVotingInstructions,
 } from './config/types'
@@ -59,7 +61,7 @@ import UnconfiguredScreen from './pages/UnconfiguredScreen'
 import UsedCardScreen from './pages/UsedCardScreen'
 import WrongElectionScreen from './pages/WrongElectionScreen'
 import WrongPrecinctScreen from './pages/WrongPrecinctScreen'
-import { getBallotStyle, getContests, getZeroTally } from './utils/election'
+import { getZeroTally } from './utils/election'
 import { computeTallyForEitherNeitherContests } from './utils/eitherNeither'
 import { Printer } from './utils/printer'
 import utcTimestamp from './utils/utcTimestamp'

--- a/apps/bmd/src/DemoApp.tsx
+++ b/apps/bmd/src/DemoApp.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react'
 
-import { VoterCardData } from '@votingworks/types'
+import { Provider, VoterCardData } from '@votingworks/types'
 import { electionSampleDefinition } from '@votingworks/fixtures'
 import App, { Props } from './App'
 import { Card, MemoryCard } from './utils/Card'
 import utcTimestamp from './utils/utcTimestamp'
 import { Storage, MemoryStorage } from './utils/Storage'
 import { AppStorage } from './AppRoot'
-import { Provider, MachineConfig, VxMarkPlusVxPrint } from './config/types'
+import { MachineConfig, VxMarkPlusVxPrint } from './config/types'
 import { MemoryHardware } from './utils/Hardware'
 
 const ballotStyleId = '12'

--- a/apps/bmd/src/components/ElectionInfo.tsx
+++ b/apps/bmd/src/components/ElectionInfo.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import { Precinct, ElectionDefinition } from '@votingworks/types'
+import {
+  ElectionDefinition,
+  Precinct,
+  getPartyPrimaryAdjectiveFromBallotStyle,
+} from '@votingworks/types'
 import { dateLong } from '../utils/date'
-
-import { getPartyPrimaryAdjectiveFromBallotStyle } from '../utils/election'
 
 import Seal from './Seal'
 import Prose from './Prose'

--- a/apps/bmd/src/components/PrintedBallot.tsx
+++ b/apps/bmd/src/components/PrintedBallot.tsx
@@ -8,8 +8,12 @@ import {
   CandidateVote,
   Contests,
   ElectionDefinition,
-  YesNoVote,
   VotesDict,
+  YesNoVote,
+  getBallotStyle,
+  getContests,
+  getPartyPrimaryAdjectiveFromBallotStyle,
+  getPrecinctById,
 } from '@votingworks/types'
 
 import * as GLOBALS from '../config/globals'
@@ -17,12 +21,6 @@ import * as GLOBALS from '../config/globals'
 import { randomBase64 } from '../utils/random'
 import { findPartyById } from '../utils/find'
 import { getSingleYesNoVote } from '../utils/votes'
-import {
-  getBallotStyle,
-  getContests,
-  getPartyPrimaryAdjectiveFromBallotStyle,
-  getPrecinctById,
-} from '../utils/election'
 
 import QRCode from './QRCode'
 import Prose from './Prose'

--- a/apps/bmd/src/config/types.ts
+++ b/apps/bmd/src/config/types.ts
@@ -15,13 +15,6 @@ import {
 } from '@votingworks/types'
 import { Printer } from '../utils/printer'
 
-// Generic
-export type VoidFunction = () => void
-export interface Provider<T> {
-  get(): Promise<T>
-}
-export type Optional<T> = T | undefined
-
 // App
 export const VxPrintOnly = {
   name: 'VxPrint',

--- a/apps/bmd/src/pages/AdminScreen.tsx
+++ b/apps/bmd/src/pages/AdminScreen.tsx
@@ -1,11 +1,7 @@
 import React, { useState } from 'react'
 import { OptionalElectionDefinition } from '@votingworks/types'
 
-import {
-  AppMode,
-  SelectChangeEventFunction,
-  VoidFunction,
-} from '../config/types'
+import { AppMode, SelectChangeEventFunction } from '../config/types'
 
 import TestBallotDeckScreen from './TestBallotDeckScreen'
 

--- a/apps/bmd/src/pages/StartPage.tsx
+++ b/apps/bmd/src/pages/StartPage.tsx
@@ -1,10 +1,9 @@
 import React, { useContext } from 'react'
 import styled from 'styled-components'
 import { RouteComponentProps, withRouter } from 'react-router-dom'
+import { getPartyPrimaryAdjectiveFromBallotStyle } from '@votingworks/types'
 
 import BallotContext from '../contexts/ballotContext'
-
-import { getPartyPrimaryAdjectiveFromBallotStyle } from '../utils/election'
 
 import { Wobble } from '../components/Animations'
 import ElectionInfo from '../components/ElectionInfo'

--- a/apps/bmd/src/utils/eitherNeither.ts
+++ b/apps/bmd/src/utils/eitherNeither.ts
@@ -4,24 +4,17 @@
 
 import {
   Contest,
+  Dictionary,
   Election,
   MsEitherNeitherContest,
-  YesNoVote,
   VotesDict,
-  Dictionary,
+  YesNoVote,
+  getEitherNeitherContests,
 } from '@votingworks/types'
 
 import { Tally, MsEitherNeitherTally } from '../config/types'
 
 import { getSingleYesNoVote } from './votes'
-
-const getEitherNeitherContests = (
-  election: Election
-): MsEitherNeitherContest[] => {
-  return election.contests
-    .filter((c) => c.type === 'ms-either-neither')
-    .map((c) => c as MsEitherNeitherContest)
-}
 
 interface Params {
   election: Election
@@ -45,7 +38,7 @@ export const computeTallyForEitherNeitherContests = ({
   const contestIds: Contest['id'][] = []
 
   const eitherNeitherContestMappings: Dictionary<MsEitherNeitherContest> = {}
-  getEitherNeitherContests(election).forEach((c) => {
+  getEitherNeitherContests(election.contests).forEach((c) => {
     eitherNeitherContestMappings[c.eitherNeitherContestId] = c
     eitherNeitherContestMappings[c.pickOneContestId] = c
   })

--- a/apps/bmd/src/utils/election.ts
+++ b/apps/bmd/src/utils/election.ts
@@ -1,55 +1,6 @@
-import {
-  Election,
-  Contest,
-  BallotStyle,
-  Contests,
-  Precinct,
-} from '@votingworks/types'
+/* eslint-disable import/prefer-default-export */
+import { Election, Contest } from '@votingworks/types'
 import { Tally } from '../config/types'
-
-export const getContests = ({
-  ballotStyle,
-  election,
-}: {
-  ballotStyle: BallotStyle
-  election: Election
-}): Contests =>
-  election.contests.filter(
-    (c) =>
-      ballotStyle.districts.includes(c.districtId) &&
-      ballotStyle.partyId === c.partyId
-  )
-
-export const getPrecinctById = ({
-  election,
-  precinctId,
-}: {
-  election: Election
-  precinctId: string
-}): Precinct | undefined => election.precincts.find((p) => p.id === precinctId)
-
-export const getBallotStyle = ({
-  election,
-  ballotStyleId,
-}: {
-  election: Election
-  ballotStyleId: string
-}): BallotStyle | undefined =>
-  election.ballotStyles.find((bs) => bs.id === ballotStyleId)
-
-export const getPartyPrimaryAdjectiveFromBallotStyle = ({
-  ballotStyleId,
-  election,
-}: {
-  ballotStyleId: string
-  election: Election
-}): string => {
-  const parts = ballotStyleId?.match(/(\d+)(\w+)/i)
-  const abbrev = parts?.[2]
-  const party = election.parties.find((p) => p.abbrev === abbrev)
-  const name = party?.name
-  return name === 'Democrat' ? 'Democratic' : name ?? ''
-}
 
 export const getZeroTally = (election: Election): Tally =>
   election.contests.map((contest) => {
@@ -80,11 +31,3 @@ export const getZeroTally = (election: Election): Tally =>
     // to fail loudly in this situation.
     throw new Error(`unexpected contest type: ${(contest as Contest).type}`)
   })
-
-export default {
-  getBallotStyle,
-  getContests,
-  getPartyPrimaryAdjectiveFromBallotStyle,
-  getPrecinctById,
-  getZeroTally,
-}

--- a/apps/bmd/src/utils/machineConfig.ts
+++ b/apps/bmd/src/utils/machineConfig.ts
@@ -1,5 +1,5 @@
+import { Provider } from '@votingworks/types'
 import {
-  Provider,
   MachineConfig,
   MachineConfigResponse,
   getAppMode,

--- a/apps/bmd/test/helpers/election.ts
+++ b/apps/bmd/test/helpers/election.ts
@@ -7,12 +7,10 @@ import {
   YesNoContest,
   Election,
   MsEitherNeitherContest,
-} from '@votingworks/types'
-import {
-  getBallotStyle,
   getContests,
-  getZeroTally,
-} from '../../src/utils/election'
+  getBallotStyle,
+} from '@votingworks/types'
+import { getZeroTally } from '../../src/utils/election'
 
 import {
   electionStorageKey,

--- a/apps/bmd/test/helpers/fakeMachineConfig.ts
+++ b/apps/bmd/test/helpers/fakeMachineConfig.ts
@@ -1,4 +1,5 @@
-import { Provider, VxMarkOnly, MachineConfig } from '../../src/config/types'
+import { Provider } from '@votingworks/types'
+import { VxMarkOnly, MachineConfig } from '../../src/config/types'
 
 export default function fakeMachineConfig({
   appMode = VxMarkOnly,

--- a/apps/bsd/src/config/types.ts
+++ b/apps/bsd/src/config/types.ts
@@ -1,5 +1,6 @@
 import type {
   AdjudicationReason,
+  Dictionary,
   Election,
   MarkThresholds,
   OptionalElection,
@@ -14,12 +15,6 @@ import type {
 import { ElectionDefinition } from '../util/ballot-package'
 import type { AdjudicationInfo } from './types/ballot-review'
 
-export interface Dictionary<T> {
-  [key: string]: T | undefined
-}
-export interface Provider<T> {
-  get(): Promise<T>
-}
 export interface MachineConfig {
   machineId: string
 }

--- a/apps/bsd/src/util/machineConfig.ts
+++ b/apps/bsd/src/util/machineConfig.ts
@@ -1,4 +1,4 @@
-import { Provider } from '../config/types'
+import { Provider } from '@votingworks/types'
 import fetchJSON from './fetchJSON'
 
 interface MachineConfigResponse {

--- a/apps/bsd/test/helpers/fakeMachineConfig.ts
+++ b/apps/bsd/test/helpers/fakeMachineConfig.ts
@@ -1,4 +1,5 @@
-import { Provider, MachineConfig } from '../../src/config/types'
+import { Provider } from '@votingworks/types'
+import { MachineConfig } from '../../src/config/types'
 
 export default function fakeMachineConfig({
   machineId = '0000',

--- a/apps/election-manager/src/components/BallotCountsTable.test.tsx
+++ b/apps/election-manager/src/components/BallotCountsTable.test.tsx
@@ -6,10 +6,10 @@ import {
   electionWithMsEitherNeither,
   multiPartyPrimaryElectionDefinition,
 } from '@votingworks/fixtures'
+import { Dictionary } from '@votingworks/types'
 
 import renderInAppContext from '../../test/renderInAppContext'
 import {
-  Dictionary,
   ExternalTally,
   Tally,
   TallyCategory,

--- a/apps/election-manager/src/components/ExportElectionBallotPackageModalButton.tsx
+++ b/apps/election-manager/src/components/ExportElectionBallotPackageModalButton.tsx
@@ -2,14 +2,10 @@ import React, { useCallback, useContext, useEffect, useState } from 'react'
 import pluralize from 'pluralize'
 import styled from 'styled-components'
 import path from 'path'
-import { getElectionLocales } from '@votingworks/types'
+import { getElectionLocales, getPrecinctById } from '@votingworks/types'
 
 import { DEFAULT_LOCALE } from '../config/globals'
-import {
-  getBallotPath,
-  getPrecinctById,
-  getHumanBallotLanguageFormat,
-} from '../utils/election'
+import { getBallotPath, getHumanBallotLanguageFormat } from '../utils/election'
 
 import AppContext from '../contexts/AppContext'
 import HandMarkedPaperBallot from './HandMarkedPaperBallot'

--- a/apps/election-manager/src/components/HandMarkedPaperBallot.tsx
+++ b/apps/election-manager/src/components/HandMarkedPaperBallot.tsx
@@ -10,19 +10,23 @@ import { Handler, Previewer, registerHandlers } from 'pagedjs'
 import { TFunction, StringMap } from 'i18next'
 import { useTranslation, Trans } from 'react-i18next'
 import {
+  AnyContest,
   BallotType,
+  Candidate,
   CandidateContest,
   CandidateVote,
+  Dictionary,
   Election,
   OptionalElection,
   Parties,
-  VotesDict,
-  withLocale,
-  YesNoContest,
-  Dictionary,
-  AnyContest,
   Vote,
-  Candidate,
+  VotesDict,
+  YesNoContest,
+  getBallotStyle,
+  getContests,
+  getPartyFullNameFromBallotStyle,
+  getPrecinctById,
+  withLocale,
 } from '@votingworks/types'
 
 import {
@@ -32,12 +36,6 @@ import {
 import AppContext from '../contexts/AppContext'
 
 import findPartyById from '../utils/findPartyById'
-import {
-  getBallotStyle,
-  getContests,
-  getPartyFullNameFromBallotStyle,
-  getPrecinctById,
-} from '../utils/election'
 
 import BubbleMark from './BubbleMark'
 import WriteInLine from './WriteInLine'

--- a/apps/election-manager/src/config/types.ts
+++ b/apps/election-manager/src/config/types.ts
@@ -2,15 +2,11 @@ import {
   BallotStyle,
   Candidate,
   Contest,
+  Dictionary,
   Election,
+  Optional,
   Precinct,
 } from '@votingworks/types'
-
-// Generic
-export declare type Optional<T> = T | undefined
-export interface Dictionary<T> {
-  [key: string]: Optional<T>
-}
 
 // Events
 export type InputEventFunction = (

--- a/apps/election-manager/src/lib/votecounting.ts
+++ b/apps/election-manager/src/lib/votecounting.ts
@@ -1,18 +1,21 @@
 import {
-  Party,
-  YesNoVote,
   Candidate,
   CandidateContest,
   CandidateVote,
   Contest,
   Election,
-  VotesDict,
+  Party,
   Vote,
+  VotesDict,
+  YesNoVote,
+  getBallotStyle,
+  getContests,
+  getEitherNeitherContests,
+  Dictionary,
 } from '@votingworks/types'
 import { strict as assert } from 'assert'
 import {
   ContestOptionTally,
-  Dictionary,
   CastVoteRecord,
   CastVoteRecordLists,
   Tally,
@@ -25,9 +28,6 @@ import {
   VotingMethod,
 } from '../config/types'
 import {
-  getBallotStyle,
-  getContests,
-  getEitherNeitherContests,
   expandEitherNeitherContests,
   writeInCandidate,
   getDistrictIdsForPartyId,

--- a/apps/election-manager/src/screens/PrintedBallotsReportScreen.tsx
+++ b/apps/election-manager/src/screens/PrintedBallotsReportScreen.tsx
@@ -2,7 +2,8 @@ import React, { useContext } from 'react'
 import pluralize from 'pluralize'
 import _ from 'lodash'
 
-import { Dictionary, PrintableBallotType } from '../config/types'
+import { Dictionary } from '@votingworks/types'
+import { PrintableBallotType } from '../config/types'
 import routerPaths from '../routerPaths'
 
 import AppContext from '../contexts/AppContext'

--- a/apps/election-manager/src/screens/TallyScreen.tsx
+++ b/apps/election-manager/src/screens/TallyScreen.tsx
@@ -1,11 +1,11 @@
 import React, { useContext, useState, useEffect } from 'react'
 import moment from 'moment'
 
+import { Optional } from '@votingworks/types'
 import {
   TallyCategory,
   InputEventFunction,
   ResultsFileType,
-  Optional,
 } from '../config/types'
 
 import * as format from '../utils/format'

--- a/apps/election-manager/src/utils/election.ts
+++ b/apps/election-manager/src/utils/election.ts
@@ -1,22 +1,18 @@
 import {
-  Election,
-  BallotStyle,
+  AnyContest,
   Candidate,
   Contests,
-  AnyContest,
+  Election,
   MsEitherNeitherContest,
-  VotesDict,
-  Precinct,
   Party,
+  VotesDict,
+  getContests,
+  getPrecinctById,
+  Dictionary,
 } from '@votingworks/types'
 import dashify from 'dashify'
 import { LANGUAGES } from '../config/globals'
-import {
-  BallotLocale,
-  Dictionary,
-  YesNoOption,
-  ContestOption,
-} from '../config/types'
+import { BallotLocale, YesNoOption, ContestOption } from '../config/types'
 
 import find from './find'
 import sortBy from './sortBy'
@@ -60,26 +56,6 @@ export function getContestOptionsForContest(
   throw new Error(`Unexpected contest type: ${contest.type}`)
 }
 
-export const getContests = ({
-  ballotStyle,
-  election,
-}: {
-  ballotStyle: BallotStyle
-  election: Election
-}): Contests =>
-  election.contests.filter(
-    (c) =>
-      ballotStyle.districts.includes(c.districtId) &&
-      ballotStyle.partyId === c.partyId
-  )
-
-export const getEitherNeitherContests = (
-  contests: Contests
-): MsEitherNeitherContest[] =>
-  contests.filter(
-    (c): c is MsEitherNeitherContest => c.type === 'ms-either-neither'
-  )
-
 export const expandEitherNeitherContests = (
   contests: Contests
 ): Exclude<AnyContest, MsEitherNeitherContest>[] =>
@@ -109,35 +85,6 @@ export const expandEitherNeitherContests = (
           },
         ]
   )
-
-export const getPrecinctById = ({
-  election,
-  precinctId,
-}: {
-  election: Election
-  precinctId: string
-}): Precinct | undefined => election.precincts.find((p) => p.id === precinctId)
-
-export const getBallotStyle = ({
-  ballotStyleId,
-  election,
-}: {
-  ballotStyleId: string
-  election: Election
-}): BallotStyle | undefined =>
-  election.ballotStyles.find((bs) => bs.id === ballotStyleId)
-
-export const getPartyFullNameFromBallotStyle = ({
-  ballotStyleId,
-  election,
-}: {
-  ballotStyleId: string
-  election: Election
-}): string => {
-  const ballotStyle = getBallotStyle({ ballotStyleId, election })
-  const party = election.parties.find((p) => p.id === ballotStyle?.partyId)
-  return party?.fullName || ''
-}
 
 interface BallotStyleData {
   ballotStyleId: string

--- a/apps/election-manager/src/utils/semsTallies.test.ts
+++ b/apps/election-manager/src/utils/semsTallies.test.ts
@@ -3,7 +3,7 @@ import {
   multiPartyPrimaryElection,
   electionWithMsEitherNeither,
 } from '@votingworks/fixtures'
-import { CandidateContest, YesNoContest } from '@votingworks/types'
+import { CandidateContest, Dictionary, YesNoContest } from '@votingworks/types'
 
 import * as path from 'path'
 import { promises as fs } from 'fs'
@@ -11,7 +11,6 @@ import { promises as fs } from 'fs'
 import {
   ContestOptionTally,
   ContestTally,
-  Dictionary,
   TallyCategory,
 } from '../config/types'
 import { writeInCandidate } from './election'

--- a/apps/election-manager/src/utils/semsTallies.ts
+++ b/apps/election-manager/src/utils/semsTallies.ts
@@ -7,6 +7,7 @@ import {
   Dictionary,
   Election,
   YesNoContest,
+  getContests,
 } from '@votingworks/types'
 
 import { strict as assert } from 'assert'
@@ -23,7 +24,6 @@ import {
 } from '../config/types'
 import {
   expandEitherNeitherContests,
-  getContests,
   getDistrictIdsForPartyId,
   getPartiesWithPrimaryElections,
 } from './election'

--- a/apps/module-scan/src/types.ts
+++ b/apps/module-scan/src/types.ts
@@ -1,6 +1,7 @@
 import {
   BallotStyle,
   Contest,
+  Dictionary,
   Election,
   MarkThresholds,
   Precinct,
@@ -14,10 +15,6 @@ import {
 } from '@votingworks/hmpb-interpreter'
 import { MarkInfo, PageInterpretation } from './interpreter'
 import { MarksByContestId, MarkStatus } from './types/ballot-review'
-
-export interface Dictionary<T> {
-  [key: string]: T | undefined
-}
 
 export type Result<E, T> = ErrorResult<E> | ValueResult<T>
 export interface ErrorResult<E> {

--- a/libs/types/src/election.test.ts
+++ b/libs/types/src/election.test.ts
@@ -5,6 +5,7 @@ import {
 } from '../test/election'
 import {
   CandidateContest,
+  getEitherNeitherContests,
   getElectionLocales,
   getPartyFullNameFromBallotStyle,
   getPartyPrimaryAdjectiveFromBallotStyle,
@@ -67,6 +68,12 @@ test('can build votes from a candidate object', () => {
   expect(vote(contests, { CC: candidate })).toEqual({
     CC: [candidate],
   })
+})
+
+test('can get ms-either-neither contests from a list', () => {
+  expect(
+    getEitherNeitherContests(electionWithMsEitherNeither.contests)
+  ).toHaveLength(1)
 })
 
 test('can build votes from a candidates array', () => {

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -1,11 +1,13 @@
 import * as s from './schema'
 
 // Generic
-export type VoidFunction = () => void
 export interface Dictionary<T> {
   [key: string]: Optional<T>
 }
 export type Optional<T> = T | undefined
+export interface Provider<T> {
+  get(): Promise<T>
+}
 
 export type Translations = Record<string, Record<string, string> | undefined>
 
@@ -219,6 +221,17 @@ export const getContests = ({
       ballotStyle.districts.includes(c.districtId) &&
       ballotStyle.partyId === c.partyId
   )
+
+/**
+ * Get all MS either-neither contests.
+ */
+export const getEitherNeitherContests = (
+  contests: Contests
+): MsEitherNeitherContest[] => {
+  return contests.filter(
+    (c): c is MsEitherNeitherContest => c.type === 'ms-either-neither'
+  )
+}
 
 /**
  * Retrieves a precinct by id.


### PR DESCRIPTION
Many of our generic or basic types and utils were duplicated across the projects. This commit brings them into `@votingworks/types`.