### PR TITLE
fix(election-manager): fix occasionally unresponsive filepicker

### DIFF
--- a/apps/election-manager/src/AppRoot.tsx
+++ b/apps/election-manager/src/AppRoot.tsx
@@ -280,37 +280,50 @@ const AppRoot: React.FC<Props> = ({ storage }) => {
     }
   }
 
-  const saveElection: SaveElection = async (electionJSON) => {
-    // we set a new election definition, reset everything
-    storage.clear()
-    setIsOfficialResults(false)
-    setCastVoteRecordFiles(CastVoteRecordFiles.empty)
-    setExternalVoteRecordsFile(undefined)
-    setPrintedBallots([])
-    setElectionDefinition(undefined)
+  const saveElection: SaveElection = useCallback(
+    async (electionJSON) => {
+      // we set a new election definition, reset everything
+      storage.clear()
+      setIsOfficialResults(false)
+      setCastVoteRecordFiles(CastVoteRecordFiles.empty)
+      setExternalVoteRecordsFile(undefined)
+      setPrintedBallots([])
+      setElectionDefinition(undefined)
 
-    if (electionJSON) {
-      const electionData = electionJSON
-      const electionHash = sha256(electionData)
-      const election = parseElection(JSON.parse(electionData))
+      if (electionJSON) {
+        const electionData = electionJSON
+        const electionHash = sha256(electionData)
+        const election = parseElection(JSON.parse(electionData))
 
-      setElectionDefinition({
-        electionData,
-        electionHash,
-        election,
-      })
+        setElectionDefinition({
+          electionData,
+          electionHash,
+          election,
+        })
 
-      const newConfiguredAt = new Date().toISOString()
-      setConfiguredAt(newConfiguredAt)
+        const newConfiguredAt = new Date().toISOString()
+        setConfiguredAt(newConfiguredAt)
 
-      await storage.set(configuredAtStorageKey, newConfiguredAt)
-      await storage.set(electionDefinitionStorageKey, {
-        election,
-        electionData,
-        electionHash,
-      })
-    }
-  }
+        await storage.set(configuredAtStorageKey, newConfiguredAt)
+        await storage.set(electionDefinitionStorageKey, {
+          election,
+          electionData,
+          electionHash,
+        })
+      }
+    },
+    [
+      storage,
+      setIsOfficialResults,
+      setCastVoteRecordFiles,
+      setExternalVoteRecordsFile,
+      setPrintedBallots,
+      setElectionDefinition,
+      parseElection,
+      setElectionDefinition,
+      setConfiguredAt,
+    ]
+  )
 
   return (
     <AppContext.Provider


### PR DESCRIPTION
So deep in the dependency list for what triggers this useEffect in UnconfiguredScreen: https://github.com/votingworks/vxsuite/blob/main/apps/election-manager/src/screens/UnconfiguredScreen.tsx#L193 is this saveElection function. Since it's not defined with useCallback is causes that useEffect to trigger anytime AppRoot rerenders which happens, for example, anytime a usb drive mounts or unmounts. 

Since that useEffect causes UnconfiguredScreen to reload the SEMs input conversion file information the isLoading state is temporarily set to true while that call occurs, which causes the screen to render a Loading screen instead of the main screen with the file input buttons. If this happens when a filepicker is open the input element gets lost from the DOM. Even if the input element is recreated by the time you select a file in the filepicker, it can't connect it back to the original input and the onChange function will never be triggered. So by making this function use useCallback it prevents this chain of events from occurring whenever a usb drive is mounted/unmounted (or AppRoot rerenders for other reasons) which fixes the confusing behavior of the filepicker on the UnconfiguredScreen.

