### PR TITLE
test(lint): disable `import/prefer-default-export`

### DIFF
--- a/apps/bmd/.eslintrc.js
+++ b/apps/bmd/.eslintrc.js
@@ -110,6 +110,7 @@ module.exports = {
     '@typescript-eslint/no-unused-expressions': 'error',
     '@typescript-eslint/no-use-before-define': ['error', { functions: false }],
     'import/extensions': 'off',
+    'import/prefer-default-export': 'off',
     'no-restricted-syntax': [
       'error',
       {

--- a/apps/bmd/src/config/types.ts
+++ b/apps/bmd/src/config/types.ts
@@ -195,5 +195,3 @@ export interface UserSettings {
 }
 export type SetUserSettings = (partial: PartialUserSettings) => void
 export type PartialUserSettings = Partial<UserSettings>
-
-export default {}

--- a/apps/bmd/src/utils/eitherNeither.ts
+++ b/apps/bmd/src/utils/eitherNeither.ts
@@ -27,7 +27,6 @@ interface TallyAndContestIds {
   contestIds: Contest['id'][]
 }
 
-// eslint-disable-next-line import/prefer-default-export
 export const computeTallyForEitherNeitherContests = ({
   election,
   tally,

--- a/apps/bmd/src/utils/election.ts
+++ b/apps/bmd/src/utils/election.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export */
 import { Election, Contest } from '@votingworks/types'
 import { Tally } from '../config/types'
 

--- a/apps/bmd/src/utils/find.ts
+++ b/apps/bmd/src/utils/find.ts
@@ -6,5 +6,3 @@ export const findPartyById = (
 ): Party | undefined => {
   return parties.find((p) => p.id === id)
 }
-
-export default { findPartyById }

--- a/apps/bmd/src/utils/random.ts
+++ b/apps/bmd/src/utils/random.ts
@@ -18,5 +18,3 @@ export function randomBase64(numBytes: number): string {
     )
     .replace(/=+$/, '')
 }
-
-export default { randomBase64 }

--- a/apps/bmd/src/utils/voices.ts
+++ b/apps/bmd/src/utils/voices.ts
@@ -4,7 +4,6 @@ import { VoiceSelector } from './ScreenReader'
  * Get a voice suitable for use with `speechSynthesis` APIs to be spoken to US
  * English speakers.
  */
-// eslint-disable-next-line import/prefer-default-export
 export const getUSEnglishVoice: VoiceSelector = () => {
   // Only use local voices.
   const voices = speechSynthesis

--- a/apps/bmd/src/utils/votes.ts
+++ b/apps/bmd/src/utils/votes.ts
@@ -1,7 +1,6 @@
 import { YesNoVote } from '@votingworks/types'
 import { YesOrNo } from '../config/types'
 
-// eslint-disable-next-line import/prefer-default-export
 export function getSingleYesNoVote(vote?: YesNoVote): YesOrNo | undefined {
   if (vote?.length === 1) {
     return vote[0]

--- a/apps/election-manager/.eslintrc.js
+++ b/apps/election-manager/.eslintrc.js
@@ -78,6 +78,7 @@ module.exports = {
         devDependencies: true,
       },
     ],
+    'import/prefer-default-export': 'off',
     'no-use-before-define': 'off',
     '@typescript-eslint/no-use-before-define': 'error',
     'no-unused-vars': 'off', // base rule must be disabled as it can report incorrect errors: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars.md#options

--- a/apps/election-manager/src/utils/format.ts
+++ b/apps/election-manager/src/utils/format.ts
@@ -1,5 +1,3 @@
-/* eslint-disable import/prefer-default-export */
-
 const countFormatter = new Intl.NumberFormat(undefined, { useGrouping: true })
 
 /**

--- a/apps/election-manager/src/utils/votingMethod.ts
+++ b/apps/election-manager/src/utils/votingMethod.ts
@@ -1,7 +1,6 @@
 import { VotingMethod } from '../config/types'
 import throwIllegalValue from './throwIllegalValue'
 
-// eslint-disable-next-line import/prefer-default-export
 export function getLabelForVotingMethod(votingMethod: VotingMethod): string {
   switch (votingMethod) {
     case VotingMethod.Precinct:


### PR DESCRIPTION
A single named export is fine. Be cool, eslint, be cool.