### PR TITLE
Flag "Wrong Election" ballots properly

### DIFF
--- a/apps/bsd/src/screens/BallotEjectScreen.test.tsx
+++ b/apps/bsd/src/screens/BallotEjectScreen.test.tsx
@@ -319,11 +319,7 @@ test('shows invalid election screen when appropriate', async () => {
     },
     back: {
       image: { url: '/back/url' },
-      interpretation: {
-        type: 'InvalidElectionHashPage',
-        actualElectionHash: 'this-is-a-hash-hooray',
-        expectedElectionHash: 'something',
-      },
+      interpretation: { type: 'BlankPage' },
     },
   }
   fetchMock.getOnce('/scan/hmpb/review/next-sheet', response)

--- a/apps/bsd/src/screens/BallotEjectScreen.tsx
+++ b/apps/bsd/src/screens/BallotEjectScreen.tsx
@@ -141,14 +141,14 @@ const BallotEjectScreen: React.FC<Props> = ({
                 ? isTestMode
                   ? 'Live Ballot'
                   : 'Test Ballot'
+                : isInvalidElectionHashSheet
+                ? 'Wrong Election'
                 : isUnreadableSheet
                 ? 'Unreadable'
                 : isOvervotedSheet
                 ? 'Overvote'
                 : isBlankSheet
                 ? 'Blank Ballot'
-                : isInvalidElectionHashSheet
-                ? 'Wrong Election'
                 : 'Unknown Reason'}
             </EjectReason>
             <p>

--- a/apps/module-scan/src/cli/retry-scan/index.test.ts
+++ b/apps/module-scan/src/cli/retry-scan/index.test.ts
@@ -1,8 +1,8 @@
 import { dirSync } from 'tmp'
-import { retryScan, queryFromOptions } from './'
-import { parseOptions } from './options'
-import * as fixtures from '../../../test/fixtures/state-of-hamilton'
+import * as fixtures from '../../../test/fixtures/choctaw-2020-09-22-f30480cc99'
 import { createWorkspace } from '../../util/workspace'
+import { queryFromOptions, retryScan } from './'
+import { parseOptions } from './options'
 
 jest.setTimeout(20000)
 
@@ -146,7 +146,7 @@ test('full rescan', async () => {
   await store.setElection({
     election: fixtures.election,
     electionData: JSON.stringify(fixtures.election),
-    electionHash: 'not-a-hash',
+    electionHash: '02f807b005e006da160b',
   })
 
   const batchId = await store.addBatch()
@@ -156,16 +156,16 @@ test('full rescan', async () => {
         type: 'UnreadablePage',
         reason: 'just because, okay?',
       },
-      originalFilename: fixtures.filledInPage1,
-      normalizedFilename: fixtures.filledInPage1,
+      originalFilename: fixtures.blankPage1,
+      normalizedFilename: fixtures.blankPage1,
     },
     {
       interpretation: {
         type: 'UnreadablePage',
         reason: 'just because, okay?',
       },
-      originalFilename: fixtures.filledInPage2,
-      normalizedFilename: fixtures.filledInPage2,
+      originalFilename: fixtures.blankPage2,
+      normalizedFilename: fixtures.blankPage2,
     },
   ])
 
@@ -228,7 +228,7 @@ test('writing output to another database', async () => {
   await inputDb.setElection({
     election: fixtures.election,
     electionData: JSON.stringify(fixtures.election),
-    electionHash: 'not-a-hash',
+    electionHash: '02f807b005e006da160b',
   })
 
   const batchId = await inputDb.addBatch()
@@ -238,16 +238,16 @@ test('writing output to another database', async () => {
         type: 'UnreadablePage',
         reason: 'just because, okay?',
       },
-      originalFilename: fixtures.filledInPage1,
-      normalizedFilename: fixtures.filledInPage1,
+      originalFilename: fixtures.blankPage1,
+      normalizedFilename: fixtures.blankPage1,
     },
     {
       interpretation: {
         type: 'UnreadablePage',
         reason: 'just because, okay?',
       },
-      originalFilename: fixtures.filledInPage2,
-      normalizedFilename: fixtures.filledInPage2,
+      originalFilename: fixtures.blankPage2,
+      normalizedFilename: fixtures.blankPage2,
     },
   ])
 
@@ -299,8 +299,8 @@ test('writing output to another database', async () => {
   ).toMatchInlineSnapshot(`
     Array [
       Object {
-        "back_interpretation_json": "{\\"type\\":\\"UninterpretedHmpbPage\\",\\"metadata\\":{\\"electionHash\\":\\"\\",\\"ballotType\\":0,\\"locales\\":{\\"primary\\":\\"en-US\\",\\"secondary\\":\\"es-US\\"},\\"ballotStyleId\\":\\"12\\",\\"precinctId\\":\\"23\\",\\"isTestMode\\":false,\\"pageNumber\\":2}}",
-        "front_interpretation_json": "{\\"type\\":\\"UninterpretedHmpbPage\\",\\"metadata\\":{\\"electionHash\\":\\"\\",\\"ballotType\\":0,\\"locales\\":{\\"primary\\":\\"en-US\\",\\"secondary\\":\\"es-US\\"},\\"ballotStyleId\\":\\"12\\",\\"precinctId\\":\\"23\\",\\"isTestMode\\":false,\\"pageNumber\\":1}}",
+        "back_interpretation_json": "{\\"type\\":\\"UninterpretedHmpbPage\\",\\"metadata\\":{\\"electionHash\\":\\"02f807b005e006da160b\\",\\"precinctId\\":\\"6538\\",\\"ballotStyleId\\":\\"1\\",\\"locales\\":{\\"primary\\":\\"en-US\\"},\\"pageNumber\\":2,\\"isTestMode\\":false,\\"ballotType\\":0}}",
+        "front_interpretation_json": "{\\"type\\":\\"UninterpretedHmpbPage\\",\\"metadata\\":{\\"electionHash\\":\\"02f807b005e006da160b\\",\\"precinctId\\":\\"6538\\",\\"ballotStyleId\\":\\"1\\",\\"locales\\":{\\"primary\\":\\"en-US\\"},\\"pageNumber\\":1,\\"isTestMode\\":false,\\"ballotType\\":0}}",
         "id": "a-test-sheet-id",
       },
     ]

--- a/apps/module-scan/src/endToEndHmpb.test.ts
+++ b/apps/module-scan/src/endToEndHmpb.test.ts
@@ -12,6 +12,7 @@ import { buildApp } from './server'
 import { BallotPackageManifest, CastVoteRecord } from './types'
 import { MarkStatus } from './types/ballot-review'
 import { createWorkspace, Workspace } from './util/workspace'
+import { ConfigKey } from './store'
 
 const electionFixturesRoot = join(
   __dirname,
@@ -59,12 +60,20 @@ afterEach(async () => {
 test('going through the whole process works', async () => {
   jest.setTimeout(25000)
 
+  // Do this first so interpreter workers get initialized with the right value.
+  await request(app)
+    .patch('/config')
+    .send({ [ConfigKey.SkipElectionHashCheck]: true })
+    .set('Content-Type', 'application/json')
+    .set('Accept', 'application/json')
+    .expect(200, { status: 'ok' })
+
   const { election } = stateOfHamilton
   await importer.restoreConfig()
 
   await request(app)
     .patch('/config')
-    .send({ election })
+    .send({ [ConfigKey.Election]: election })
     .set('Content-Type', 'application/json')
     .set('Accept', 'application/json')
     .expect(200, { status: 'ok' })
@@ -191,12 +200,20 @@ test('going through the whole process works', async () => {
 test('failed scan with QR code can be adjudicated and exported', async () => {
   jest.setTimeout(25000)
 
+  // Do this first so interpreter workers get initialized with the right value.
+  await request(app)
+    .patch('/config')
+    .send({ [ConfigKey.SkipElectionHashCheck]: true })
+    .set('Content-Type', 'application/json')
+    .set('Accept', 'application/json')
+    .expect(200, { status: 'ok' })
+
   const { election } = stateOfHamilton
   await importer.restoreConfig()
 
   await request(app)
     .patch('/config')
-    .send({ election })
+    .send({ [ConfigKey.Election]: election })
     .set('Content-Type', 'application/json')
     .set('Accept', 'application/json')
     .expect(200, { status: 'ok' })
@@ -340,9 +357,17 @@ test('ms-either-neither end-to-end', async () => {
   } = choctawMockGeneral2020Fixtures
   await importer.restoreConfig()
 
+  // Do this first so interpreter workers get initialized with the right value.
   await request(app)
     .patch('/config')
-    .send({ election })
+    .send({ [ConfigKey.SkipElectionHashCheck]: true })
+    .set('Content-Type', 'application/json')
+    .set('Accept', 'application/json')
+    .expect(200, { status: 'ok' })
+
+  await request(app)
+    .patch('/config')
+    .send({ [ConfigKey.Election]: election })
     .set('Content-Type', 'application/json')
     .set('Accept', 'application/json')
     .expect(200, { status: 'ok' })

--- a/apps/module-scan/src/importer.ts
+++ b/apps/module-scan/src/importer.ts
@@ -54,6 +54,7 @@ export interface Importer {
   getStatus(): Promise<ScanStatus>
   restoreConfig(): Promise<void>
   setTestMode(testMode: boolean): Promise<void>
+  setSkipElectionHashCheck(skipElectionHashCheck: boolean): Promise<void>
   setMarkThresholdOverrides(
     markThresholds: Optional<MarkThresholds>
   ): Promise<void>
@@ -199,6 +200,16 @@ export default class SystemImporter implements Importer {
     await this.doZero()
     await this.workspace.store.setTestMode(testMode)
     await this.restoreConfig()
+  }
+
+  public async setSkipElectionHashCheck(
+    skipElectionHashCheck: boolean
+  ): Promise<void> {
+    debug(
+      'setting skip check election hash setting to %s',
+      skipElectionHashCheck
+    )
+    await this.workspace.store.setSkipElectionHashCheck(skipElectionHashCheck)
   }
 
   public async setMarkThresholdOverrides(

--- a/apps/module-scan/src/server.ts
+++ b/apps/module-scan/src/server.ts
@@ -96,12 +96,21 @@ export function buildApp({ store, importer }: AppOptions): Application {
             await importer.setTestMode(value)
             break
           }
+
           case ConfigKey.MarkThresholdOverrides: {
             if (value === null) {
               await importer.setMarkThresholdOverrides(undefined)
               break
             }
             await importer.setMarkThresholdOverrides(value as MarkThresholds)
+            break
+          }
+
+          case ConfigKey.SkipElectionHashCheck: {
+            if (typeof value !== 'boolean') {
+              throw new TypeError()
+            }
+            await importer.setSkipElectionHashCheck(value)
             break
           }
         }

--- a/apps/module-scan/src/store.ts
+++ b/apps/module-scan/src/store.ts
@@ -60,6 +60,8 @@ export enum ConfigKey {
   Election = 'election',
   TestMode = 'testMode',
   MarkThresholdOverrides = 'markThresholdOverrides',
+  // @deprecated
+  SkipElectionHashCheck = 'skipElectionHashCheck',
 }
 
 const SchemaPath = join(__dirname, '../schema.sql')
@@ -364,10 +366,26 @@ export default class Store {
   }
 
   /**
+   * Gets whether to skip election hash checks.
+   */
+  public async getSkipElectionHashCheck(): Promise<boolean> {
+    return await this.getConfig(ConfigKey.SkipElectionHashCheck, false)
+  }
+
+  /**
    * Sets the current test mode setting value.
    */
   public async setTestMode(testMode: boolean): Promise<void> {
     await this.setConfig(ConfigKey.TestMode, testMode)
+  }
+
+  /**
+   * Sets whether to check the election hash.
+   */
+  public async setSkipElectionHashCheck(
+    skipElectionHashCheck: boolean
+  ): Promise<void> {
+    await this.setConfig(ConfigKey.SkipElectionHashCheck, skipElectionHashCheck)
   }
 
   /**

--- a/apps/module-scan/src/workers/interpret.ts
+++ b/apps/module-scan/src/workers/interpret.ts
@@ -1,4 +1,3 @@
-import { Election } from '@votingworks/types'
 import makeDebug from 'debug'
 import { readFile } from 'fs-extra'
 import { basename, extname, join } from 'path'
@@ -32,11 +31,6 @@ export type Output = InterpretOutput | void
 
 export let interpreter: Interpreter | undefined
 
-async function getElection(store: Store): Promise<Election | undefined> {
-  const electionDefinition = await store.getElectionDefinition()
-  return electionDefinition?.election
-}
-
 /**
  * Reads election configuration from the database.
  */
@@ -44,19 +38,22 @@ export async function configure(store: Store): Promise<void> {
   interpreter = undefined
 
   debug('configuring from %s', store.dbPath)
-  const election = await getElection(store)
+  const electionDefinition = await store.getElectionDefinition()
 
-  if (!election) {
+  if (!electionDefinition) {
     debug('no election configured')
     return
   }
 
-  debug('election: %o', election.title)
+  debug('election: %o', electionDefinition.election.title)
   const templates = await store.getHmpbTemplates()
 
   debug('creating a new interpreter')
   interpreter = new Interpreter({
-    election,
+    election: electionDefinition.election,
+    electionHash: (await store.getSkipElectionHashCheck())
+      ? undefined
+      : electionDefinition.electionHash,
     testMode: await store.getTestMode(),
     markThresholdOverrides: await store.getMarkThresholdOverrides(),
   })

--- a/apps/module-scan/test/util/mocks.ts
+++ b/apps/module-scan/test/util/mocks.ts
@@ -38,6 +38,7 @@ export function makeMockImporter(): jest.Mocked<Importer> {
     getStatus: jest.fn(),
     restoreConfig: jest.fn(),
     setTestMode: jest.fn(),
+    setSkipElectionHashCheck: jest.fn(),
     unconfigure: jest.fn(),
     setMarkThresholdOverrides: jest.fn(),
   }

--- a/libs/ballot-encoder/src/index.ts
+++ b/libs/ballot-encoder/src/index.ts
@@ -627,6 +627,31 @@ export function detectHMPBBallotPageMetadata(data: Uint8Array): boolean {
 }
 
 /**
+ * Reads the election hash from an encoded ballot or encoded HMPB metadata.
+ */
+export function decodeElectionHash(data: Uint8Array): string | undefined {
+  return decodeElectionHashFromReader(new BitReader(data))
+}
+
+/**
+ * Reads the election hash from an encoded ballot or encoded HMPB metadata.
+ */
+export function decodeElectionHashFromReader(
+  bits: BitReader
+): string | undefined {
+  if (bits.skipUint8(...HMPBPrelude)) {
+    return bits.readString({ encoding: HexEncoding })
+  }
+
+  if (bits.skipUint8(...Prelude)) {
+    return bits.readString({
+      encoding: HexEncoding,
+      length: ELECTION_HASH_LENGTH,
+    })
+  }
+}
+
+/**
  * Reads the HMPB prelude bytes from `bits`. When detected, the cursor of `bits`
  * will be updated to skip the prelude bytes.
  */


### PR DESCRIPTION
We want to enforce that the scanned image has an election hash that matches the one the server was configured with. This isn't too bad implementation-wise. However, it exposed a lot of problems with our tests. They mostly depend on fixtures that are not set up to work when checking election hashes. For example, we can't just use `electionSample` from `@votingworks/fixtures` because it uses `asElectionDefinition` which uses the `JSON.stringify`d version of the election config that was imported, and therefore `JSON.parse`d, by node. This messes up the hash.

We could instead load the file from the built `@votingworks/fixtures`, right? Nope. That's wrong too because TypeScript reformats the JSON when building 🤦🏻‍♂️ (2-space indent to 4-space indent). So we instead have to load the file directly from where it lives in the source if we want to get the right hash. "Why don't we just hardcode the hash and give the server equivalent election config?", I hear you asking. Because the server actually validates that the election definition's string data hashes to the same value, so we can't do that.

On top of that, a lot of the fixtures in module-scan are built using older versions of the ballot. For example, they may be QR codes with the `ballot.page` URL that we never used for real and which don't have an election hash at all.

How do we fix this? Glad you asked:
- Add `electionData` to `ElectionDefinition` in `@votingworks/types`.
- Consolidate all `ElectionDefinition` types (I think there are 3).
- Add `electionData` everywhere we have an `ElectionDefinition`.
- Replace most uses of `asElectionDefinition` (and an even earlier incarnation I found in module-scan: `fromElection` in electionDefinition.ts) with a new `loadElectionDefinition` that reads from a file directly or something.
- Live with the fact that TypeScript modifies the files on build? Either that or stop using `.json` files and do something that preserves the raw bytes.
- Stop importing election definitions directly. It's convenient, but it's gonna bite us.
- Replace all old `ballot.page` fixtures with new ones.
- Surely more than this; it's not a trivial problem.