### PR TITLE
fix(scan): make election.json config work

### DIFF
--- a/apps/bsd/package.json
+++ b/apps/bsd/package.json
@@ -114,6 +114,7 @@
     "history": "^4.10.1",
     "husky": "^4.2.5",
     "jest-environment-jsdom-sixteen": "^1.0.3",
+    "jest-fetch-mock": "^3.0.3",
     "lint-staged": "^10.2.3",
     "node-fetch": "^2.6.0",
     "prettier": "^2.1.2",

--- a/apps/bsd/src/App.test.tsx
+++ b/apps/bsd/src/App.test.tsx
@@ -8,7 +8,7 @@ import {
   screen,
 } from '@testing-library/react'
 import { act } from 'react-dom/test-utils'
-import { electionSample } from '@votingworks/fixtures'
+import { electionSample, electionSampleDefinition } from '@votingworks/fixtures'
 import fileDownload from 'js-file-download'
 import fakeKiosk from '../test/helpers/fakeKiosk'
 import App from './App'
@@ -49,7 +49,7 @@ test('renders without crashing', async () => {
 test('shows a "Test mode" button if the app is in Live Mode', async () => {
   fetchMock.getOnce(
     '/config',
-    { testMode: false, election: electionSample },
+    { testMode: false, electionDefinition: electionSampleDefinition },
     { overwriteRoutes: true }
   )
 
@@ -68,7 +68,7 @@ test('shows a "Test mode" button if the app is in Live Mode', async () => {
 test('shows a "Live mode" button if the app is in Test Mode', async () => {
   fetchMock.getOnce(
     '/config',
-    { testMode: true, election: electionSample },
+    { testMode: true, electionDefinition: electionSampleDefinition },
     { overwriteRoutes: true }
   )
 
@@ -87,7 +87,7 @@ test('shows a "Live mode" button if the app is in Test Mode', async () => {
 test('clicking Scan Batch will scan a batch', async () => {
   fetchMock.getOnce(
     '/config',
-    { testMode: true, election: electionSample },
+    { testMode: true, electionDefinition: electionSampleDefinition },
     { overwriteRoutes: true }
   )
 
@@ -120,7 +120,7 @@ test('clicking Scan Batch will scan a batch', async () => {
 test('clicking export shows modal and makes a request to export', async () => {
   fetchMock.getOnce(
     '/config',
-    { testMode: true, election: electionSample },
+    { testMode: true, electionDefinition: electionSampleDefinition },
     { overwriteRoutes: true }
   )
   fetchMock.getOnce(
@@ -157,7 +157,14 @@ test('clicking export shows modal and makes a request to export', async () => {
 
 test('configuring election from usb ballot package works end to end', async () => {
   fetchMock.getOnce('/config', { testMode: true }, { overwriteRoutes: true })
-  fetchMock.patchOnce('/config', { body: '{"status": "ok"}', status: 200 })
+  fetchMock.patchOnce('/config/testMode', {
+    body: '{"status": "ok"}',
+    status: 200,
+  })
+  fetchMock.patchOnce('/config/electionDefinition', {
+    body: '{"status": "ok"}',
+    status: 200,
+  })
 
   const { getByText, getByTestId } = render(<App />)
 
@@ -172,7 +179,7 @@ test('configuring election from usb ballot package works end to end', async () =
 
   fetchMock.getOnce(
     '/config',
-    { testMode: true, election: electionSample },
+    { testMode: true, electionDefinition: electionSampleDefinition },
     { overwriteRoutes: true }
   )
   fireEvent.change(getByTestId('manual-upload-input'), {

--- a/apps/bsd/src/api/config.ts
+++ b/apps/bsd/src/api/config.ts
@@ -1,22 +1,57 @@
-import {
-  GetConfigResponse,
-  PatchConfigResponse,
-  PatchConfigRequest,
-} from '../config/types'
+import { MarkThresholds } from '@votingworks/types'
+import { ErrorResponse, GetConfigResponse, OkResponse } from '../config/types'
+import { ElectionDefinition } from '../util/ballot-package'
 import fetchJSON from '../util/fetchJSON'
 
 export async function get(): Promise<GetConfigResponse> {
   return fetchJSON<GetConfigResponse>('/config')
 }
 
-export async function patch(config: PatchConfigRequest): Promise<void> {
-  const response = await fetchJSON<PatchConfigResponse>('/config', {
+async function patch(url: string, value: unknown): Promise<void> {
+  const response = await fetch(url, {
     method: 'PATCH',
-    body: JSON.stringify(config),
+    body: JSON.stringify(value),
     headers: { 'Content-Type': 'application/json' },
   })
+  const body: OkResponse | ErrorResponse = await response.json()
 
-  if (response.status !== 'ok') {
-    throw new Error(`failed with response status: ${response.status}`)
+  if (body.status !== 'ok') {
+    throw new Error(`PATCH ${url} failed: ${body.error}`)
+  }
+}
+
+async function del(url: string): Promise<void> {
+  const response = await fetch(url, {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+  })
+  const body: OkResponse | ErrorResponse = await response.json()
+
+  if (body.status !== 'ok') {
+    throw new Error(`DELETE ${url} failed: ${body.error}`)
+  }
+}
+
+export async function setElectionDefinition(
+  electionDefinition?: ElectionDefinition
+): Promise<void> {
+  if (typeof electionDefinition === 'undefined') {
+    await del('/config/electionDefinition')
+  } else {
+    await patch('/config/electionDefinition', electionDefinition)
+  }
+}
+
+export async function setTestMode(testMode: boolean): Promise<void> {
+  await patch('/config/testMode', { testMode })
+}
+
+export async function setMarkThresholdOverrides(
+  markThresholdOverrides?: MarkThresholds
+): Promise<void> {
+  if (typeof markThresholdOverrides === 'undefined') {
+    await del('/config/markThresholdOverrides')
+  } else {
+    await patch('/config/markThresholdOverrides', markThresholdOverrides)
   }
 }

--- a/apps/bsd/src/api/hmpb.ts
+++ b/apps/bsd/src/api/hmpb.ts
@@ -6,7 +6,7 @@ import {
   ElectionDefinition,
 } from '../util/ballot-package'
 import fetchJSON from '../util/fetchJSON'
-import { patch as patchConfig } from './config'
+import { setElectionDefinition } from './config'
 
 export interface AddTemplatesEvents extends EventEmitter {
   on(
@@ -55,7 +55,7 @@ export function addTemplates(pkg: BallotPackage): AddTemplatesEvents {
   setImmediate(async () => {
     try {
       result.emit('configuring', pkg, pkg.electionDefinition)
-      await patchConfig({ election: pkg.electionDefinition })
+      await setElectionDefinition(pkg.electionDefinition)
 
       for (const ballot of pkg.ballots) {
         result.emit('uploading', pkg, ballot)

--- a/apps/bsd/src/components/ElectionConfiguration.test.tsx
+++ b/apps/bsd/src/components/ElectionConfiguration.test.tsx
@@ -46,7 +46,6 @@ test('shows insert usb screen when no usb is present with manual upload button',
       'You may load an election configuration via the following methods:'
     )
     getByText('Insert a USB drive')
-    getByText('Insert an Admin Card')
     getByText(/Manually select a file to configure:/)
     getByAltText('Insert USB Image')
     getByText('Select File…')

--- a/apps/bsd/src/components/ElectionConfiguration.tsx
+++ b/apps/bsd/src/components/ElectionConfiguration.tsx
@@ -282,10 +282,6 @@ const ElectionConfiguration: React.FC<Props> = ({
                 packages exported from Election Manager.
               </ListItem>
               <ListItem>
-                <strong>Insert an Admin Card</strong> into an attached card
-                reader.
-              </ListItem>
-              <ListItem>
                 Manually select a file to configure:{' '}
                 <FileInputButton
                   accept=".json,.zip"

--- a/apps/bsd/src/components/ExportResultsModal.test.tsx
+++ b/apps/bsd/src/components/ExportResultsModal.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { render, fireEvent, waitFor } from '@testing-library/react'
-import { electionSample } from '@votingworks/fixtures'
+import { electionSampleDefinition } from '@votingworks/fixtures'
 import { Router } from 'react-router-dom'
 import { createMemoryHistory } from 'history'
 import fetchMock from 'fetch-mock'
@@ -10,6 +10,14 @@ import { UsbDriveStatus } from '../lib/usbstick'
 import ExportResultsModal from './ExportResultsModal'
 import fakeKiosk, { fakeUsbDrive } from '../../test/helpers/fakeKiosk'
 import fakeFileWriter from '../../test/helpers/fakeFileWriter'
+import { ElectionDefinition } from '../util/ballot-package'
+
+// TODO: Replace this with something straight from `@votingworks/fixtures` when
+// all ElectionDefinition interface definitions are shared.
+const electionDefinition: ElectionDefinition = {
+  ...electionSampleDefinition,
+  electionData: JSON.stringify(electionSampleDefinition.election),
+}
 
 test('renders loading screen when usb drive is mounting or ejecting in export modal', () => {
   const usbStatuses = [UsbDriveStatus.present, UsbDriveStatus.ejecting]
@@ -21,8 +29,7 @@ test('renders loading screen when usb drive is mounting or ejecting in export mo
         <ExportResultsModal
           onClose={closeFn}
           usbDriveStatus={status}
-          election={electionSample}
-          electionHash="testHash12"
+          electionDefinition={electionDefinition}
           numberOfBallots={5}
           isTestMode
         />
@@ -47,8 +54,7 @@ test('render no usb found screen when there is not a mounted usb drive', () => {
         <ExportResultsModal
           onClose={closeFn}
           usbDriveStatus={status}
-          election={electionSample}
-          electionHash="testHash12"
+          electionDefinition={electionDefinition}
           numberOfBallots={5}
           isTestMode
         />
@@ -85,8 +91,7 @@ test('render export modal when a usb drive is mounted as expected and allows cus
       <ExportResultsModal
         onClose={closeFn}
         usbDriveStatus={UsbDriveStatus.mounted}
-        election={electionSample}
-        electionHash="testHash12"
+        electionDefinition={electionDefinition}
         numberOfBallots={5}
         isTestMode
       />
@@ -124,8 +129,7 @@ test('render export modal when a usb drive is mounted as expected and allows aut
       <ExportResultsModal
         onClose={closeFn}
         usbDriveStatus={UsbDriveStatus.mounted}
-        election={electionSample}
-        electionHash="testHash12"
+        electionDefinition={electionDefinition}
         numberOfBallots={5}
         isTestMode
       />
@@ -141,7 +145,10 @@ test('render export modal when a usb drive is mounted as expected and allows aut
   expect(
     mockKiosk.makeDirectory
   ).toHaveBeenCalledWith(
-    'fake mount point/cast-vote-records/franklin-county_general-election_testHash12',
+    `fake mount point/cast-vote-records/franklin-county_general-election_${electionDefinition.electionHash.slice(
+      0,
+      10
+    )}`,
     { recursive: true }
   )
   expect(mockKiosk.writeFile).toHaveBeenCalledTimes(1)
@@ -166,8 +173,7 @@ test('render export modal with errors when appropriate', async () => {
       <ExportResultsModal
         onClose={closeFn}
         usbDriveStatus={UsbDriveStatus.mounted}
-        election={electionSample}
-        electionHash="testHash12"
+        electionDefinition={electionDefinition}
         numberOfBallots={5}
         isTestMode
       />

--- a/apps/bsd/src/components/ExportResultsModal.tsx
+++ b/apps/bsd/src/components/ExportResultsModal.tsx
@@ -1,6 +1,5 @@
 import React, { useContext, useState } from 'react'
 import styled from 'styled-components'
-import { Election } from '@votingworks/types'
 import fileDownload from 'js-file-download'
 import path from 'path'
 
@@ -17,6 +16,7 @@ import {
   generateFilenameForScanningResults,
   SCANNER_RESULTS_FOLDER,
 } from '../util/filenames'
+import { ElectionDefinition } from '../util/ballot-package'
 
 function throwBadStatus(s: never): never {
   throw new Error(`Bad status: ${s}`)
@@ -31,8 +31,7 @@ const USBImage = styled.img`
 export interface Props {
   onClose: () => void
   usbDriveStatus: UsbDriveStatus
-  election: Election
-  electionHash: string | undefined
+  electionDefinition: ElectionDefinition
   numberOfBallots: number
   isTestMode: boolean
 }
@@ -47,8 +46,7 @@ enum ModalState {
 const ExportResultsModal: React.FC<Props> = ({
   onClose,
   usbDriveStatus,
-  election,
-  electionHash,
+  electionDefinition,
   numberOfBallots,
   isTestMode,
 }) => {
@@ -90,8 +88,8 @@ const ExportResultsModal: React.FC<Props> = ({
           )
         }
         const electionFolderName = generateElectionBasedSubfolderName(
-          election,
-          electionHash!
+          electionDefinition.election,
+          electionDefinition.electionHash
         )
         const pathToFolder = path.join(
           usbPath,

--- a/apps/bsd/src/components/SetMarkThresholdsModal.test.tsx
+++ b/apps/bsd/src/components/SetMarkThresholdsModal.test.tsx
@@ -18,7 +18,7 @@ test('renders warning message before allowing overrides to be set', () => {
     <Router history={createMemoryHistory()}>
       <SetMarkThresholdsModal
         onClose={closeFn}
-        election={electionSample}
+        markThresholds={electionSample.markThresholds}
         markThresholdOverrides={undefined}
         setMarkThresholdOverrides={jest.fn()}
       />
@@ -37,7 +37,7 @@ test('renders reset modal when overrides are set', async () => {
     <Router history={createMemoryHistory()}>
       <SetMarkThresholdsModal
         onClose={closeFn}
-        election={electionSample}
+        markThresholds={electionSample.markThresholds}
         markThresholdOverrides={{ definite: 0.32, marginal: 0.24 }}
         setMarkThresholdOverrides={setMarkThresholdOverrides}
       />
@@ -70,7 +70,7 @@ test('reset modal displays errors appropriately', async () => {
     <Router history={createMemoryHistory()}>
       <SetMarkThresholdsModal
         onClose={closeFn}
-        election={electionSample}
+        markThresholds={electionSample.markThresholds}
         markThresholdOverrides={{ definite: 0.32, marginal: 0.24 }}
         setMarkThresholdOverrides={setMarkThresholdOverrides}
       />
@@ -94,7 +94,7 @@ test('allows users to set thresholds properly', async () => {
     <Router history={createMemoryHistory()}>
       <SetMarkThresholdsModal
         onClose={closeFn}
-        election={electionSample}
+        markThresholds={electionSample.markThresholds}
         markThresholdOverrides={undefined}
         setMarkThresholdOverrides={setThresholds}
       />
@@ -128,7 +128,7 @@ test('setting thresholds renders an error if given a non number', async () => {
     <Router history={createMemoryHistory()}>
       <SetMarkThresholdsModal
         onClose={closeFn}
-        election={electionSample}
+        markThresholds={electionSample.markThresholds}
         markThresholdOverrides={undefined}
         setMarkThresholdOverrides={setThresholds}
       />
@@ -156,7 +156,7 @@ test('setting thresholds renders an error if given a number greater than 1', asy
     <Router history={createMemoryHistory()}>
       <SetMarkThresholdsModal
         onClose={closeFn}
-        election={electionSample}
+        markThresholds={electionSample.markThresholds}
         markThresholdOverrides={undefined}
         setMarkThresholdOverrides={setThresholds}
       />
@@ -186,7 +186,7 @@ test('setting thresholds renders an error if saving throws an error', async () =
     <Router history={createMemoryHistory()}>
       <SetMarkThresholdsModal
         onClose={closeFn}
-        election={electionSample}
+        markThresholds={electionSample.markThresholds}
         markThresholdOverrides={undefined}
         setMarkThresholdOverrides={setThresholds}
       />

--- a/apps/bsd/src/components/SetMarkThresholdsModal.tsx
+++ b/apps/bsd/src/components/SetMarkThresholdsModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import styled from 'styled-components'
 
-import { Election, MarkThresholds, Optional } from '@votingworks/types'
+import { MarkThresholds } from '@votingworks/types'
 
 import Modal from './Modal'
 import Button from './Button'
@@ -14,11 +14,9 @@ import Text from './Text'
 
 export interface Props {
   onClose: () => void
-  election: Election
-  markThresholdOverrides: Optional<MarkThresholds>
-  setMarkThresholdOverrides: (
-    markThresholds: Optional<MarkThresholds>
-  ) => Promise<void>
+  markThresholds?: MarkThresholds
+  markThresholdOverrides?: MarkThresholds
+  setMarkThresholdOverrides: (markThresholds?: MarkThresholds) => Promise<void>
 }
 
 const ThresholdColumns = styled.div`
@@ -44,7 +42,7 @@ export const DefaultMarkThresholds: Readonly<MarkThresholds> = {
 
 const SetMarkThresholdsModal: React.FC<Props> = ({
   onClose,
-  election,
+  markThresholds,
   markThresholdOverrides,
   setMarkThresholdOverrides,
 }) => {
@@ -55,7 +53,7 @@ const SetMarkThresholdsModal: React.FC<Props> = ({
   )
 
   const [errorMessage, setErrorMessage] = useState('')
-  const defaultMarkThresholds = election.markThresholds ?? DefaultMarkThresholds
+  const defaultMarkThresholds = markThresholds ?? DefaultMarkThresholds
   const defaultDefiniteThreshold = defaultMarkThresholds.definite
   const defaultMarginalThreshold = defaultMarkThresholds.marginal
 

--- a/apps/bsd/src/components/StatusFooter.tsx
+++ b/apps/bsd/src/components/StatusFooter.tsx
@@ -14,22 +14,25 @@ const StatusBar = styled.div`
 `
 
 const StatusFooter: React.FC = () => {
-  const { election, electionHash, machineConfig } = useContext(AppContext)
+  const { electionDefinition, machineConfig } = useContext(AppContext)
   const electionDate =
-    election && localeWeedkayAndDate.format(new Date(election?.date))
+    electionDefinition &&
+    localeWeedkayAndDate.format(new Date(electionDefinition.election.date))
 
   return (
     <StatusBar>
       <Text small white center as="div">
         Scanner ID: <strong>{machineConfig.machineId}</strong>
       </Text>
-      {election && (
+      {electionDefinition && (
         <Text small white center as="div">
-          <strong>{election.title}</strong> — {electionDate} —{' '}
-          {election.county.name}, {election.state}{' '}
-          {electionHash && (
+          <strong>{electionDefinition.election.title}</strong> — {electionDate}{' '}
+          — {electionDefinition.election.county.name},{' '}
+          {electionDefinition.election.state}{' '}
+          {electionDefinition.electionHash && (
             <React.Fragment>
-              — Election Hash: <strong>{electionHash.slice(0, 10)}</strong>
+              — Election Hash:{' '}
+              <strong>{electionDefinition.electionHash.slice(0, 10)}</strong>
             </React.Fragment>
           )}
         </Text>

--- a/apps/bsd/src/config/types.ts
+++ b/apps/bsd/src/config/types.ts
@@ -1,9 +1,7 @@
 import type {
   AdjudicationReason,
   Dictionary,
-  Election,
   MarkThresholds,
-  OptionalElection,
   VotesDict,
 } from '@votingworks/types'
 import type {
@@ -25,27 +23,7 @@ export type ButtonEvent = React.MouseEvent<HTMLButtonElement>
 export type ButtonEventFunction = (event: ButtonEvent) => void
 
 // Election
-export type SetElection = (value: OptionalElection) => void
-
-// Smart Card Content
-export type CardDataTypes = 'voter' | 'pollworker' | 'admin'
-export interface CardData {
-  readonly t: CardDataTypes
-}
-export interface VoterCardData extends CardData {
-  readonly t: 'voter'
-  readonly bs: string
-  readonly pr: string
-  readonly uz?: number
-}
-export interface PollworkerCardData extends CardData {
-  readonly t: 'pollworker'
-  readonly h: string
-}
-export interface AdminCardData extends CardData {
-  readonly t: 'admin'
-  readonly h: string
-}
+export type SetElectionDefinition = (value?: ElectionDefinition) => void
 
 // Scanner Types
 export interface CastVoteRecord
@@ -60,6 +38,11 @@ export interface CastVoteRecord
 
 export interface OkResponse {
   status: 'ok'
+}
+
+export interface ErrorResponse {
+  status: 'error'
+  error: string
 }
 
 export interface Batch {
@@ -116,27 +99,17 @@ export interface ScanStatusResponse {
 
 export type GetConfigRequest = void
 export interface GetConfigResponse {
-  election?: Election
+  electionDefinition?: ElectionDefinition
   testMode: boolean
   markThresholdOverrides?: MarkThresholds | null
 }
 
 export interface PatchConfigRequest {
-  election?: Election | ElectionDefinition | null
+  electionDefinition?: ElectionDefinition | null
   testMode?: boolean
   markThresholdOverrides?: MarkThresholds | null
 }
 export type PatchConfigResponse = OkResponse
-
-export type CardReadRequest = void
-export type CardReadResponse =
-  | { present: false }
-  | { present: true; longValueExists: boolean; shortValue?: string }
-
-export type CardReadLongRequest = void
-export interface CardReadLongResponse {
-  longValue: string
-}
 
 // eslint-disable-next-line import/no-cycle
 export * from './types/ballot-review'

--- a/apps/bsd/src/contexts/AppContext.ts
+++ b/apps/bsd/src/contexts/AppContext.ts
@@ -1,12 +1,12 @@
-import { Election } from '@votingworks/types'
 import { createContext } from 'react'
 import { MachineConfig } from '../config/types'
+import { ElectionDefinition } from '../util/ballot-package'
 
 interface AppContextInterface {
   usbDriveStatus: string
   usbDriveEject: () => void
   machineConfig: MachineConfig
-  election?: Election
+  electionDefinition?: ElectionDefinition
   electionHash?: string
 }
 
@@ -14,7 +14,7 @@ const appContext: AppContextInterface = {
   usbDriveStatus: '',
   usbDriveEject: () => undefined,
   machineConfig: { machineId: '0000' },
-  election: undefined,
+  electionDefinition: undefined,
   electionHash: undefined,
 }
 

--- a/apps/bsd/src/screens/AdvancedOptionsScreen.test.tsx
+++ b/apps/bsd/src/screens/AdvancedOptionsScreen.test.tsx
@@ -3,8 +3,16 @@ import { render, waitFor } from '@testing-library/react'
 import { createMemoryHistory } from 'history'
 import { Router } from 'react-router-dom'
 import { act } from 'react-dom/test-utils'
-import { electionSample } from '@votingworks/fixtures'
+import { electionSampleDefinition } from '@votingworks/fixtures'
 import AdvancedOptionsScreen from './AdvancedOptionsScreen'
+import { ElectionDefinition } from '../util/ballot-package'
+
+// TODO: Replace this with something straight from `@votingworks/fixtures` when
+// all ElectionDefinition interface definitions are shared.
+const testElectionDefinition: ElectionDefinition = {
+  ...electionSampleDefinition,
+  electionData: JSON.stringify(electionSampleDefinition.election),
+}
 
 test('clicking "Export Backup…" shows progress', async () => {
   const backup = jest.fn()
@@ -20,7 +28,7 @@ test('clicking "Export Backup…" shows progress', async () => {
         toggleTestMode={jest.fn()}
         setMarkThresholdOverrides={jest.fn()}
         markThresholds={undefined}
-        election={electionSample}
+        electionDefinition={testElectionDefinition}
       />
     </Router>
   )
@@ -62,7 +70,7 @@ test('backup error shows message', async () => {
         toggleTestMode={jest.fn()}
         setMarkThresholdOverrides={jest.fn()}
         markThresholds={undefined}
-        election={electionSample}
+        electionDefinition={testElectionDefinition}
       />
     </Router>
   )
@@ -136,7 +144,7 @@ test('override mark thresholds button shows when there are no overrides', async 
           toggleTestMode={jest.fn()}
           setMarkThresholdOverrides={jest.fn()}
           markThresholds={testCase.markThresholds}
-          election={electionSample}
+          electionDefinition={testElectionDefinition}
         />
       </Router>
     )

--- a/apps/bsd/src/screens/AdvancedOptionsScreen.tsx
+++ b/apps/bsd/src/screens/AdvancedOptionsScreen.tsx
@@ -1,4 +1,4 @@
-import { MarkThresholds, Optional, Election } from '@votingworks/types'
+import { MarkThresholds, Optional } from '@votingworks/types'
 import React, { useCallback, useState } from 'react'
 import Button from '../components/Button'
 import LinkButton from '../components/LinkButton'
@@ -9,6 +9,7 @@ import Prose from '../components/Prose'
 import Screen from '../components/Screen'
 import ToggleTestModeButton from '../components/ToggleTestModeButton'
 import SetMarkThresholdsModal from '../components/SetMarkThresholdsModal'
+import { ElectionDefinition } from '../util/ballot-package'
 
 interface Props {
   unconfigureServer: () => Promise<void>
@@ -22,7 +23,7 @@ interface Props {
     markThresholds: Optional<MarkThresholds>
   ) => Promise<void>
   markThresholds: Optional<MarkThresholds>
-  election: Election
+  electionDefinition: ElectionDefinition
 }
 
 const AdvancedOptionsScreen: React.FC<Props> = ({
@@ -35,7 +36,7 @@ const AdvancedOptionsScreen: React.FC<Props> = ({
   toggleTestMode,
   setMarkThresholdOverrides,
   markThresholds,
-  election,
+  electionDefinition,
 }) => {
   const [isConfirmingFactoryReset, setIsConfirmingFactoryReset] = useState(
     false
@@ -161,8 +162,8 @@ const AdvancedOptionsScreen: React.FC<Props> = ({
       {isSetMarkThresholdModalOpen && (
         <SetMarkThresholdsModal
           setMarkThresholdOverrides={setMarkThresholdOverrides}
+          markThresholds={electionDefinition.election.markThresholds}
           markThresholdOverrides={markThresholds}
-          election={election}
           onClose={() => setIsMarkThresholdModalOpen(false)}
         />
       )}

--- a/apps/bsd/src/screens/LoadElectionScreen.test.tsx
+++ b/apps/bsd/src/screens/LoadElectionScreen.test.tsx
@@ -6,7 +6,7 @@ import LoadElectionScreen from './LoadElectionScreen'
 test('shows a message that there is no election configuration', () => {
   const { getByText } = render(
     <LoadElectionScreen
-      setElection={jest.fn()}
+      setElectionDefinition={jest.fn()}
       usbDriveStatus={UsbDriveStatus.absent}
     />
   )

--- a/apps/bsd/src/screens/__snapshots__/BallotEjectScreen.test.tsx.snap
+++ b/apps/bsd/src/screens/__snapshots__/BallotEjectScreen.test.tsx.snap
@@ -102,13 +102,15 @@ exports[`calls out live ballot sheets in test mode 1`] = `
         </strong>
          — 
         Tuesday, November 3, 2020
-         —
          
+        — 
         Franklin County
-        , 
+        ,
+         
         State of Hamilton
          
-        — Election Hash: 
+        — Election Hash:
+         
         <strong>
           2f6b1553c7
         </strong>
@@ -220,13 +222,15 @@ exports[`calls out test ballot sheets in live mode 1`] = `
         </strong>
          — 
         Tuesday, November 3, 2020
-         —
          
+        — 
         Franklin County
-        , 
+        ,
+         
         State of Hamilton
          
-        — Election Hash: 
+        — Election Hash:
+         
         <strong>
           2f6b1553c7
         </strong>
@@ -362,13 +366,15 @@ exports[`says the ballot sheet is blank if it is 1`] = `
         </strong>
          — 
         Tuesday, November 3, 2020
-         —
          
+        — 
         Franklin County
-        , 
+        ,
+         
         State of Hamilton
          
-        — Election Hash: 
+        — Election Hash:
+         
         <strong>
           2f6b1553c7
         </strong>
@@ -509,13 +515,15 @@ exports[`says the ballot sheet is overvoted if it is 1`] = `
         </strong>
          — 
         Tuesday, November 3, 2020
-         —
          
+        — 
         Franklin County
-        , 
+        ,
+         
         State of Hamilton
          
-        — Election Hash: 
+        — Election Hash:
+         
         <strong>
           2f6b1553c7
         </strong>
@@ -630,13 +638,15 @@ exports[`says the sheet is unreadable if it is 1`] = `
         </strong>
          — 
         Tuesday, November 3, 2020
-         —
          
+        — 
         Franklin County
-        , 
+        ,
+         
         State of Hamilton
          
-        — Election Hash: 
+        — Election Hash:
+         
         <strong>
           2f6b1553c7
         </strong>

--- a/apps/bsd/src/setupTests.ts
+++ b/apps/bsd/src/setupTests.ts
@@ -1,6 +1,8 @@
 import fetchMock from 'fetch-mock'
+import jestFetchMock from 'jest-fetch-mock'
 
 beforeEach(() => {
+  jestFetchMock.enableMocks()
   fetchMock.reset()
   fetchMock.mock()
 })

--- a/apps/bsd/test/renderInAppContext.tsx
+++ b/apps/bsd/test/renderInAppContext.tsx
@@ -1,22 +1,28 @@
 import { createMemoryHistory, MemoryHistory } from 'history'
 import { render as testRender } from '@testing-library/react'
 import type { RenderResult } from '@testing-library/react'
-import type { Election } from '@votingworks/types'
 import React from 'react'
 
 import { electionSampleDefinition } from '@votingworks/fixtures'
 import { Router } from 'react-router-dom'
 import { UsbDriveStatus } from '../src/lib/usbstick'
 import AppContext from '../src/contexts/AppContext'
+import { ElectionDefinition } from '../src/util/ballot-package'
 
 interface RenderInAppContextParams {
   route?: string | undefined
   history?: MemoryHistory<any> // eslint-disable-line @typescript-eslint/no-explicit-any
-  election?: Election
-  electionHash?: string
+  electionDefinition?: ElectionDefinition
   machineId?: string
   usbDriveStatus?: UsbDriveStatus
   usbDriveEject?: () => void
+}
+
+// TODO: Replace this with something straight from `@votingworks/fixtures` when
+// all ElectionDefinition interface definitions are shared.
+const testElectionDefinition: ElectionDefinition = {
+  ...electionSampleDefinition,
+  electionData: JSON.stringify(electionSampleDefinition.election),
 }
 
 export default function renderInAppContext(
@@ -24,8 +30,7 @@ export default function renderInAppContext(
   {
     route = '/',
     history = createMemoryHistory({ initialEntries: [route] }),
-    election = electionSampleDefinition.election,
-    electionHash = electionSampleDefinition.electionHash,
+    electionDefinition = testElectionDefinition,
     machineId = '0000',
     usbDriveStatus = UsbDriveStatus.absent,
     usbDriveEject = jest.fn(),
@@ -34,8 +39,7 @@ export default function renderInAppContext(
   return testRender(
     <AppContext.Provider
       value={{
-        election,
-        electionHash,
+        electionDefinition,
         machineConfig: { machineId },
         usbDriveStatus,
         usbDriveEject,

--- a/apps/module-scan/src/endToEndHmpb.test.ts
+++ b/apps/module-scan/src/endToEndHmpb.test.ts
@@ -12,7 +12,7 @@ import { buildApp } from './server'
 import { BallotPackageManifest, CastVoteRecord } from './types'
 import { MarkStatus } from './types/ballot-review'
 import { createWorkspace, Workspace } from './util/workspace'
-import { ConfigKey } from './store'
+import { fromElection } from './util/electionDefinition'
 
 const electionFixturesRoot = join(
   __dirname,
@@ -62,8 +62,8 @@ test('going through the whole process works', async () => {
 
   // Do this first so interpreter workers get initialized with the right value.
   await request(app)
-    .patch('/config')
-    .send({ [ConfigKey.SkipElectionHashCheck]: true })
+    .patch('/config/skipElectionHashCheck')
+    .send({ skipElectionHashCheck: true })
     .set('Content-Type', 'application/json')
     .set('Accept', 'application/json')
     .expect(200, { status: 'ok' })
@@ -72,8 +72,8 @@ test('going through the whole process works', async () => {
   await importer.restoreConfig()
 
   await request(app)
-    .patch('/config')
-    .send({ [ConfigKey.Election]: election })
+    .patch('/config/electionDefinition')
+    .send(fromElection(election))
     .set('Content-Type', 'application/json')
     .set('Accept', 'application/json')
     .expect(200, { status: 'ok' })
@@ -202,8 +202,8 @@ test('failed scan with QR code can be adjudicated and exported', async () => {
 
   // Do this first so interpreter workers get initialized with the right value.
   await request(app)
-    .patch('/config')
-    .send({ [ConfigKey.SkipElectionHashCheck]: true })
+    .patch('/config/skipElectionHashCheck')
+    .send({ skipElectionHashCheck: true })
     .set('Content-Type', 'application/json')
     .set('Accept', 'application/json')
     .expect(200, { status: 'ok' })
@@ -212,8 +212,8 @@ test('failed scan with QR code can be adjudicated and exported', async () => {
   await importer.restoreConfig()
 
   await request(app)
-    .patch('/config')
-    .send({ [ConfigKey.Election]: election })
+    .patch('/config/electionDefinition')
+    .send(fromElection(election))
     .set('Content-Type', 'application/json')
     .set('Accept', 'application/json')
     .expect(200, { status: 'ok' })
@@ -359,15 +359,15 @@ test('ms-either-neither end-to-end', async () => {
 
   // Do this first so interpreter workers get initialized with the right value.
   await request(app)
-    .patch('/config')
-    .send({ [ConfigKey.SkipElectionHashCheck]: true })
+    .patch('/config/skipElectionHashCheck')
+    .send({ skipElectionHashCheck: true })
     .set('Content-Type', 'application/json')
     .set('Accept', 'application/json')
     .expect(200, { status: 'ok' })
 
   await request(app)
-    .patch('/config')
-    .send({ [ConfigKey.Election]: election })
+    .patch('/config/electionDefinition')
+    .send(fromElection(election))
     .set('Content-Type', 'application/json')
     .set('Accept', 'application/json')
     .expect(200, { status: 'ok' })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,6 +299,7 @@ importers:
       history: 4.10.1
       husky: 4.3.7
       jest-environment-jsdom-sixteen: 1.0.3
+      jest-fetch-mock: 3.0.3
       lint-staged: 10.5.3
       node-fetch: 2.6.1
       prettier: 2.2.1
@@ -348,6 +349,7 @@ importers:
       http-proxy-middleware: ^1.0.0
       husky: ^4.2.5
       jest-environment-jsdom-sixteen: ^1.0.3
+      jest-fetch-mock: ^3.0.3
       js-file-download: ^0.4.6
       js-sha256: ^0.9.0
       lint-staged: ^10.2.3


### PR DESCRIPTION
When introducing the election hash check I inadvertantly broke scanning with just an election.json instead of a full ballot package. This is because that code path was `JSON.parse`ing the election.json before sending it to the server, thus changing the hash and preventing ballots from being scanned.

To address this, I changed a few things about how the scanner is configured:
- The API now expects `PATCH /config/electionDefinition` rather than `PATCH /config` with a nested object. This ensures we can get the raw JSON and hash it correctly.
- To remove an election config, the API expects `DELETE /config/electionDefinition`.
- Everything in the BSD election config path now expects an `ElectionDefinition`.
- Configuring by admin card is now removed from the scanner. It was just another code path to fix and we weren't using it anyway.

Additionally, there was a `fetch-mock` configuration issue that the changes to the tests brought to light. The simplest way to deal with it was just to use `jest-fetch-mock`.