### PR TITLE
perf(scan): improve scanner speed using JPEG

### DIFF
--- a/apps/module-scan/.gitignore
+++ b/apps/module-scan/.gitignore
@@ -8,4 +8,6 @@ coverage/
 .DS_Store
 debug-dump*.zip
 /*.png
+/*.jpeg
+/*.jpg
 /lib

--- a/apps/module-scan/README.md
+++ b/apps/module-scan/README.md
@@ -41,23 +41,23 @@ You can also scan directly from image files instead of using a real scanner:
 
 ```sh
 # single batch with single sheet
-MOCK_SCANNER_FILES=front.png,back.png pnpm dev
+MOCK_SCANNER_FILES=front.jpeg,back.jpeg pnpm dev
 
 # single batch with multiple sheets
-MOCK_SCANNER_FILES=front-01.png,back-01.png,front-02.png,back-02.png pnpm dev
+MOCK_SCANNER_FILES=front-01.jpeg,back-01.jpeg,front-02.jpeg,back-02.jpeg pnpm dev
 
 # multiple batches with one sheet each (note ",," batch separator)
-MOCK_SCANNER_FILES=front-01.png,back-01.png,,front-02.png,back-02.png pnpm dev
+MOCK_SCANNER_FILES=front-01.jpeg,back-01.jpeg,,front-02.jpeg,back-02.jpeg pnpm dev
 
 # use a manifest file
 cat <<EOS > manifest
 # first batch (this is a comment)
-front-01.png
-back-01.png
+front-01.jpeg
+back-01.jpeg
 
 # second batch
-front-02.png
-back-02.png
+front-02.jpeg
+back-02.jpeg
 EOS
 MOCK_SCANNER_FILES=@manifest pnpm dev
 
@@ -66,7 +66,9 @@ MOCK_SCANNER_FILES=@manifest pnpm dev
 MOCK_SCANNER_FILES=@/path/to/election-backup/manifest pnpm dev
 ```
 
-If you are seeing unhandled promise rejection errors you may have an issue with where your image files are located, try moving them into the local scope of the app.
+If you are seeing unhandled promise rejection errors you may have an issue with
+where your image files are located, try moving them into the local scope of the
+app.
 
 ## Switching Workspaces
 

--- a/apps/module-scan/bin/extract-backup
+++ b/apps/module-scan/bin/extract-backup
@@ -14,7 +14,7 @@ BACKUP_DIR=$(realpath "${BACKUP_FILE%.*}")
 mkdir -p "${BACKUP_DIR}"
 
 echo -e "\e[1mExtracting images…\e[0m"
-unzip -o "${BACKUP_FILE}" "*.png" -d "${BACKUP_DIR}"
+unzip -o "${BACKUP_FILE}" "*.png" "*.jpg" "*.jpeg" -d "${BACKUP_DIR}"
 
 echo
 echo -e "\e[1mExtracting database…\e[0m"

--- a/apps/module-scan/src/cli/render-pages.test.ts
+++ b/apps/module-scan/src/cli/render-pages.test.ts
@@ -53,24 +53,24 @@ test('generates one PNG image per PDF page', async () => {
     stderr: stderr.toString(),
   }).toEqual({
     code: 0,
-    stdout: `📝 ${join(tmpDir, 'ballot-p1.png')}\n📝 ${join(
+    stdout: `📝 ${join(tmpDir, 'ballot-p1.jpg')}\n📝 ${join(
       tmpDir,
-      'ballot-p2.png'
+      'ballot-p2.jpg'
     )}\n`,
     stderr: '',
   })
 
-  for (const filename of ['ballot-p1.png', 'ballot-p2.png']) {
+  for (const filename of ['ballot-p1.jpg', 'ballot-p2.jpg']) {
     const { width, height } = await loadImageData(join(tmpDir, filename))
     expect({ width, height }).toEqual({
       width: 1224,
       height: 1584,
     })
   }
-  expect(await pathExists(join(tmpDir, 'ballot-p3.png'))).toBe(false)
+  expect(await pathExists(join(tmpDir, 'ballot-p3.jpg'))).toBe(false)
 })
 
-test('generates one PNG image per PDF page per DB', async () => {
+test('generates one image per PDF page per DB', async () => {
   const tmpDir = tmpNameSync()
   await fs.mkdir(tmpDir)
   const tmpDbPath = join(tmpDir, 'ballots.db')
@@ -102,16 +102,16 @@ test('generates one PNG image per PDF page per DB', async () => {
     stderr: stderr.toString(),
   }).toEqual({
     code: 0,
-    stdout: `📝 ${join(tmpDir, 'ballots-1-Bywy-LIVE-p1.png')}\n📝 ${join(
+    stdout: `📝 ${join(tmpDir, 'ballots-1-Bywy-LIVE-p1.jpg')}\n📝 ${join(
       tmpDir,
-      'ballots-1-Bywy-LIVE-p2.png'
+      'ballots-1-Bywy-LIVE-p2.jpg'
     )}\n`,
     stderr: '',
   })
 
   for (const filename of [
-    'ballots-1-Bywy-LIVE-p1.png',
-    'ballots-1-Bywy-LIVE-p2.png',
+    'ballots-1-Bywy-LIVE-p1.jpg',
+    'ballots-1-Bywy-LIVE-p2.jpg',
   ]) {
     const { width, height } = await loadImageData(join(tmpDir, filename))
     expect({ width, height }).toEqual({
@@ -119,7 +119,7 @@ test('generates one PNG image per PDF page per DB', async () => {
       height: 1584,
     })
   }
-  expect(await pathExists(join(tmpDir, 'ballots-1-Bywy-LIVE-p3.png'))).toBe(
+  expect(await pathExists(join(tmpDir, 'ballots-1-Bywy-LIVE-p3.jpg'))).toBe(
     false
   )
 })

--- a/apps/module-scan/src/importer.ts
+++ b/apps/module-scan/src/importer.ts
@@ -14,7 +14,7 @@ import {
   SheetOf,
   Side,
 } from './types'
-import { toPNG } from './util/images'
+import { writeImageData } from './util/images'
 import pdfToImages from './util/pdfToImages'
 import { Workspace } from './util/workspace'
 import * as workers from './workers/combined'
@@ -78,7 +78,7 @@ export async function saveImages(
 
   if (normalizedImage) {
     debug('about to write normalized ballot image to %s', normalizedImagePath)
-    await fsExtra.writeFile(normalizedImagePath, await toPNG(normalizedImage))
+    await writeImageData(normalizedImagePath, normalizedImage)
     debug('wrote normalized ballot image to %s', normalizedImagePath)
     return { original: originalImagePath, normalized: normalizedImagePath }
   }

--- a/apps/module-scan/src/scanner.ts
+++ b/apps/module-scan/src/scanner.ts
@@ -27,7 +27,6 @@ function dateStamp(date: Date = new Date()): string {
 export enum ScannerImageFormat {
   JPEG = 'jpeg',
   PNG = 'png',
-  TIFF = 'tiff',
 }
 
 export enum ScannerPageSize {
@@ -56,7 +55,7 @@ export class FujitsuScanner implements Scanner {
   private readonly mode?: ScannerMode
 
   public constructor({
-    format = ScannerImageFormat.PNG,
+    format = ScannerImageFormat.JPEG,
     pageSize = ScannerPageSize.Letter,
     mode,
   }: Options = {}) {

--- a/apps/module-scan/test/util/mocks.ts
+++ b/apps/module-scan/test/util/mocks.ts
@@ -1,12 +1,11 @@
 import { ChildProcess } from 'child_process'
 import { EventEmitter } from 'events'
-import { writeFile } from 'fs-extra'
 import { Readable, Writable } from 'stream'
 import { fileSync } from 'tmp'
 import { Importer } from '../../src/importer'
 import { Scanner } from '../../src/scanner'
 import { SheetOf } from '../../src/types'
-import { toPNG } from '../../src/util/images'
+import { writeImageData } from '../../src/util/images'
 import { inlinePool, WorkerOps, WorkerPool } from '../../src/workers/pool'
 
 export function mockWorkerPoolProvider<I, O>(
@@ -271,10 +270,11 @@ export function makeMockChildProcess(): MockChildProcess {
 }
 
 export async function makeImageFile(): Promise<string> {
-  const imageFile = fileSync()
-  await writeFile(
-    imageFile.name,
-    await toPNG({ data: Uint8ClampedArray.of(0, 0, 0), width: 1, height: 1 })
-  )
+  const imageFile = fileSync({ postfix: '.png' })
+  await writeImageData(imageFile.name, {
+    data: Uint8ClampedArray.of(0, 0, 0),
+    width: 1,
+    height: 1,
+  })
   return imageFile.name
 }

--- a/libs/hmpb-interpreter/src/cli/commands/help.test.ts
+++ b/libs/hmpb-interpreter/src/cli/commands/help.test.ts
@@ -95,10 +95,10 @@ test('layout command help', () => {
     Examples
 
     # Annotate layout for a single ballot page.
-    hmpb-interpret layout ballot01.png
+    hmpb-interpret layout ballot01.jpg
 
     # Annotate layout for many ballot pages.
-    hmpb-interpret layout ballot*.png
+    hmpb-interpret layout ballot*.jpg
     "
   `)
 })

--- a/libs/hmpb-interpreter/src/cli/commands/layout.test.ts
+++ b/libs/hmpb-interpreter/src/cli/commands/layout.test.ts
@@ -38,10 +38,10 @@ test('help', () => {
     Examples
 
     # Annotate layout for a single ballot page.
-    hmpb-interpreter layout ballot01.png
+    hmpb-interpreter layout ballot01.jpg
 
     # Annotate layout for many ballot pages.
-    hmpb-interpreter layout ballot*.png
+    hmpb-interpreter layout ballot*.jpg
     "
   `)
 })

--- a/libs/hmpb-interpreter/src/cli/commands/layout.ts
+++ b/libs/hmpb-interpreter/src/cli/commands/layout.ts
@@ -1,14 +1,13 @@
 import { strict as assert } from 'assert'
 import chalk from 'chalk'
 import { GlobalOptions, OptionParseError } from '..'
-import { writeImageToFile } from '../../../test/utils'
 import findContests, { ContestShape } from '../../hmpb/findContests'
 import { Point, Rect } from '../../types'
 import { binarize, RGBA } from '../../utils/binarize'
 import { createImageData } from '../../utils/canvas'
 import { vh } from '../../utils/flip'
 import { getImageChannelCount } from '../../utils/imageFormatUtils'
-import { loadImageData } from '../../utils/images'
+import { loadImageData, writeImageData } from '../../utils/images'
 import { adjacentFile } from '../../utils/path'
 
 export interface Options {
@@ -28,10 +27,10 @@ export function printHelp($0: string, out: NodeJS.WritableStream): void {
   out.write(chalk.italic(`Examples\n`))
   out.write(`\n`)
   out.write(chalk.gray(`# Annotate layout for a single ballot page.\n`))
-  out.write(`${$0} layout ballot01.png\n`)
+  out.write(`${$0} layout ballot01.jpg\n`)
   out.write(`\n`)
   out.write(chalk.gray(`# Annotate layout for many ballot pages.\n`))
-  out.write(`${$0} layout ballot*.png\n`)
+  out.write(`${$0} layout ballot*.jpg\n`)
 }
 
 export async function parseOptions({
@@ -124,7 +123,7 @@ export async function run(
     stdout.write(
       `📝 ${layoutFilePath} ${chalk.gray(`(${contests.length} contest(s))`)}\n`
     )
-    await writeImageToFile(imageData, layoutFilePath)
+    await writeImageData(layoutFilePath, imageData)
   }
 
   return 0

--- a/libs/hmpb-interpreter/src/utils/qrcode/quirc.ts
+++ b/libs/hmpb-interpreter/src/utils/qrcode/quirc.ts
@@ -1,6 +1,5 @@
 import makeDebug from 'debug'
 import { DetectQRCodeResult } from '../../types'
-import { toPNG } from '../images'
 import { withCropping } from './withCropping'
 
 const debug = makeDebug('hmpb-interpreter:quirc')
@@ -13,10 +12,8 @@ export async function detect(
 ): Promise<DetectQRCodeResult | undefined> {
   debug('detecting QR code in %d×%d image', imageData.width, imageData.height)
 
-  // Unfortunately, quirc requires either JPEG or PNG encoded images and can't
-  // handle raw bitmaps.
   const quirc = await import('node-quirc')
-  const result = await quirc.decode(await toPNG(imageData))
+  const result = await quirc.decode(imageData)
 
   for (const symbol of result) {
     if (!('err' in symbol)) {

--- a/libs/hmpb-interpreter/test/utils.ts
+++ b/libs/hmpb-interpreter/test/utils.ts
@@ -1,14 +1,11 @@
 import { strict as assert } from 'assert'
 import { randomBytes } from 'crypto'
-import { promises as fs } from 'fs'
 import { Rect } from '../src/types'
 import { createImageData } from '../src/utils/canvas'
-import crop from '../src/utils/crop'
 import {
   assertGrayscaleImage,
   makeImageTransform,
 } from '../src/utils/imageFormatUtils'
-import { toPNG } from '../src/utils/images'
 
 export function randomImage({
   width = 0,
@@ -103,15 +100,4 @@ export function grayToRGBA(imageData: ImageData): ImageData {
   }
 
   return createImageData(dst, width, height)
-}
-
-export async function writeImageToFile(
-  imageData: ImageData,
-  filePath: string,
-  bounds?: Rect
-): Promise<void> {
-  await fs.writeFile(
-    filePath,
-    await toPNG(bounds ? crop(imageData, bounds) : imageData)
-  )
 }

--- a/libs/hmpb-interpreter/tsconfig.json
+++ b/libs/hmpb-interpreter/tsconfig.json
@@ -4,7 +4,7 @@
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "es2017" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "lib": ["ES2020"],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
It seems the Fujitsu scanners scan noticeably faster on Linux with JPEG as the file format. I do not really understand why, but the results are pretty clear. Scanning sheets at 200dpi/gray/JPEG is a lot faster than 200dpi/gray/PNG. The difference is less notable with 300dpi/lineart.

Closes #364