### PR TITLE
feat(election-manager): adds status footer with election information

### DIFF
--- a/apps/election-manager/src/App.test.tsx
+++ b/apps/election-manager/src/App.test.tsx
@@ -31,6 +31,7 @@ import { ElectionDefinition } from './config/types'
 import fakeFileWriter from '../test/helpers/fakeFileWriter'
 import { convertFileToStorageString } from './utils/file'
 import { eitherNeitherElectionDefinition } from '../test/renderInAppContext'
+import hasTextAcrossElements from '../test/util/hasTextAcrossElements'
 
 const EITHER_NEITHER_CVR_DATA = electionWithMsEitherNeitherWithDataFiles.cvrData
 const EITHER_NEITHER_CVR_FILE = new File([EITHER_NEITHER_CVR_DATA], 'cvrs.txt')
@@ -112,6 +113,16 @@ it('printing ballots, print report, and test decks', async () => {
   jest.advanceTimersByTime(2001) // Cause the usb drive to be detected
 
   await screen.findByText('0 official ballots')
+
+  getByText('Mock General Election Choctaw 2020')
+  getByText(
+    hasTextAcrossElements(
+      `Election Hash: ${eitherNeitherElectionDefinition.electionHash.slice(
+        0,
+        10
+      )}`
+    )
+  )
 
   // go print some ballots
   fireEvent.click(getByText('Export Ballot Package'))
@@ -249,8 +260,9 @@ it('tabulating CVRs', async () => {
   eitherNeitherElectionDefinition.election.precincts.forEach((p) => {
     getByText(`Official Precinct Tally Report for: ${p.name}`)
   })
+  // The election title is written one extra time in the footer of the page.
   expect(getAllByText('Mock General Election Choctaw 2020').length).toBe(
-    eitherNeitherElectionDefinition.election.precincts.length
+    eitherNeitherElectionDefinition.election.precincts.length + 1
   )
 
   fireEvent.click(getByText('Tally'))

--- a/apps/election-manager/src/__snapshots__/App.test.tsx.snap
+++ b/apps/election-manager/src/__snapshots__/App.test.tsx.snap
@@ -5,53 +5,8 @@ exports[`printing ballots, print report, and test decks 1`] = `
   aria-hidden="true"
 >
   <div
-    class="sc-bdfBwQ hltxsL"
+    class="sc-bdfBwQ eVNwUy"
   >
-    <main
-      class="sc-gsTCUz hqEESM"
-    >
-      <div
-        class="sc-dlfnbm kzZCED"
-      >
-        <div
-          class="sc-crrsfI fxsBcU"
-        >
-          <h1>
-            Test Deck
-          </h1>
-          <p>
-            <strong>
-              Election:
-            </strong>
-             
-            Mock General Election Choctaw 2020
-            <br />
-            <strong>
-              Precinct:
-            </strong>
-             
-            District 5
-          </p>
-          <p>
-            <button
-              class="sc-jrAGrp cvGifY"
-              type="button"
-            >
-              Print Test Deck
-            </button>
-          </p>
-          <p>
-            <button
-              class="sc-jrAGrp iWxjsY"
-              role="option"
-              type="button"
-            >
-              Back to Test Deck list
-            </button>
-          </p>
-        </div>
-      </div>
-    </main>
     <div
       class="sc-hKgILt ciSCwP"
     >
@@ -106,6 +61,78 @@ exports[`printing ballots, print report, and test decks 1`] = `
         >
           Eject USB
         </button>
+      </div>
+    </div>
+    <main
+      class="sc-gsTCUz hqEESM"
+    >
+      <div
+        class="sc-dlfnbm kzZCED"
+      >
+        <div
+          class="sc-hBEYos bBKpcB"
+        >
+          <h1>
+            Test Deck
+          </h1>
+          <p>
+            <strong>
+              Election:
+            </strong>
+             
+            Mock General Election Choctaw 2020
+            <br />
+            <strong>
+              Precinct:
+            </strong>
+             
+            District 5
+          </p>
+          <p>
+            <button
+              class="sc-jrAGrp cvGifY"
+              type="button"
+            >
+              Print Test Deck
+            </button>
+          </p>
+          <p>
+            <button
+              class="sc-jrAGrp iWxjsY"
+              role="option"
+              type="button"
+            >
+              Back to Test Deck list
+            </button>
+          </p>
+        </div>
+      </div>
+    </main>
+    <div
+      class="sc-kstrdz hFgVdI"
+    >
+      <div
+        class="sc-crrsfI KbGmM"
+      >
+        <strong>
+          Mock General Election Choctaw 2020
+        </strong>
+         — 
+        Wednesday, August 26, 2020
+         —
+         
+        Choctaw County
+        , 
+        State of Mississippi
+         
+      </div>
+      <div
+        class="sc-crrsfI KbGmM"
+      >
+        Election Hash: 
+        <strong>
+          6bdcd6d885
+        </strong>
       </div>
     </div>
   </div>
@@ -159,61 +186,8 @@ exports[`printing ballots, print report, and test decks 1`] = `
 exports[`printing ballots, print report, and test decks 2`] = `
 <div>
   <div
-    class="sc-bdfBwQ hltxsL"
+    class="sc-bdfBwQ eVNwUy"
   >
-    <main
-      class="sc-gsTCUz hqEESM"
-    >
-      <div
-        class="sc-dlfnbm kzZCED"
-      >
-        <div
-          class="sc-crrsfI fxsBcU"
-        >
-          <h1>
-            Test Ballot Deck Tally
-          </h1>
-          <p>
-            <strong>
-              Election:
-            </strong>
-             
-            Mock General Election Choctaw 2020
-            <br />
-            <strong>
-              Precinct:
-            </strong>
-             
-            All Precincts
-          </p>
-          <p>
-            <button
-              class="sc-jrAGrp cvGifY"
-              type="button"
-            >
-              Print Results Report
-            </button>
-          </p>
-          <p>
-            <button
-              class="sc-jrAGrp hAHAue"
-              type="button"
-            >
-              Save Results Report as PDF
-            </button>
-          </p>
-          <p>
-            <button
-              class="sc-jrAGrp iWxjsY"
-              role="option"
-              type="button"
-            >
-              Back to Test Deck list
-            </button>
-          </p>
-        </div>
-      </div>
-    </main>
     <div
       class="sc-hKgILt ciSCwP"
     >
@@ -270,12 +244,92 @@ exports[`printing ballots, print report, and test decks 2`] = `
         </button>
       </div>
     </div>
+    <main
+      class="sc-gsTCUz hqEESM"
+    >
+      <div
+        class="sc-dlfnbm kzZCED"
+      >
+        <div
+          class="sc-hBEYos bBKpcB"
+        >
+          <h1>
+            Test Ballot Deck Tally
+          </h1>
+          <p>
+            <strong>
+              Election:
+            </strong>
+             
+            Mock General Election Choctaw 2020
+            <br />
+            <strong>
+              Precinct:
+            </strong>
+             
+            All Precincts
+          </p>
+          <p>
+            <button
+              class="sc-jrAGrp cvGifY"
+              type="button"
+            >
+              Print Results Report
+            </button>
+          </p>
+          <p>
+            <button
+              class="sc-jrAGrp hAHAue"
+              type="button"
+            >
+              Save Results Report as PDF
+            </button>
+          </p>
+          <p>
+            <button
+              class="sc-jrAGrp iWxjsY"
+              role="option"
+              type="button"
+            >
+              Back to Test Deck list
+            </button>
+          </p>
+        </div>
+      </div>
+    </main>
+    <div
+      class="sc-kstrdz hFgVdI"
+    >
+      <div
+        class="sc-crrsfI KbGmM"
+      >
+        <strong>
+          Mock General Election Choctaw 2020
+        </strong>
+         — 
+        Wednesday, August 26, 2020
+         —
+         
+        Choctaw County
+        , 
+        State of Mississippi
+         
+      </div>
+      <div
+        class="sc-crrsfI KbGmM"
+      >
+        Election Hash: 
+        <strong>
+          6bdcd6d885
+        </strong>
+      </div>
+    </div>
   </div>
   <div
     class="print-only"
   >
     <div
-      class="sc-jJEJSO iyhAUW"
+      class="sc-hiSbYr chYtqq"
     >
       <h1>
         Test Ballot Deck Tally
@@ -294,16 +348,16 @@ exports[`printing ballots, print report, and test decks 2`] = `
         All Precincts
       </p>
       <div
-        class="sc-iktFzd kAIWOv"
+        class="sc-jJEJSO cJfRAW"
       >
         <div
-          class="sc-crrsfI jJkczz"
+          class="sc-hBEYos lvLIa"
         >
           <div
-            class="sc-kLgntA rDeEm ignore-prose"
+            class="sc-iktFzd dkHGVf ignore-prose"
           >
             <span
-              class="sc-dQppl kMSBOR"
+              class="sc-crrsfI XvqqD"
             >
               39 ballots
                cast /
@@ -320,7 +374,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
             President
           </h3>
           <table
-            class="sc-fodVxV dpEkZU"
+            class="sc-fFubgz hqxDEn"
           >
             <tbody>
               <tr>
@@ -328,7 +382,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Presidential Electors for Joe Biden for President and Kamala Harris for Vice President
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   13
                 </td>
@@ -338,7 +392,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Presidential Electors for Donald J. Trump for President and Michael R. Pence for Vice President
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   13
                 </td>
@@ -348,7 +402,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Presidential Electors for Phil Collins for President and Bill Parker for Vice President
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   13
                 </td>
@@ -358,7 +412,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Write-In
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   0
                 </td>
@@ -368,16 +422,16 @@ exports[`printing ballots, print report, and test decks 2`] = `
         </div>
       </div>
       <div
-        class="sc-iktFzd kAIWOv"
+        class="sc-jJEJSO cJfRAW"
       >
         <div
-          class="sc-crrsfI jJkczz"
+          class="sc-hBEYos lvLIa"
         >
           <div
-            class="sc-kLgntA rDeEm ignore-prose"
+            class="sc-iktFzd dkHGVf ignore-prose"
           >
             <span
-              class="sc-dQppl kMSBOR"
+              class="sc-crrsfI XvqqD"
             >
               39 ballots
                cast /
@@ -394,7 +448,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
             Senate 
           </h3>
           <table
-            class="sc-fodVxV dpEkZU"
+            class="sc-fFubgz hqxDEn"
           >
             <tbody>
               <tr>
@@ -402,7 +456,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Mike Espy
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   13
                 </td>
@@ -412,7 +466,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Cindy Hyde-Smith
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   13
                 </td>
@@ -422,7 +476,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Jimmy Edwards
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   13
                 </td>
@@ -432,7 +486,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Write-In
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   0
                 </td>
@@ -442,16 +496,16 @@ exports[`printing ballots, print report, and test decks 2`] = `
         </div>
       </div>
       <div
-        class="sc-iktFzd kAIWOv"
+        class="sc-jJEJSO cJfRAW"
       >
         <div
-          class="sc-crrsfI jJkczz"
+          class="sc-hBEYos lvLIa"
         >
           <div
-            class="sc-kLgntA rDeEm ignore-prose"
+            class="sc-iktFzd dkHGVf ignore-prose"
           >
             <span
-              class="sc-dQppl kMSBOR"
+              class="sc-crrsfI XvqqD"
             >
               39 ballots
                cast /
@@ -468,7 +522,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
             1st Congressional District
           </h3>
           <table
-            class="sc-fodVxV dpEkZU"
+            class="sc-fFubgz hqxDEn"
           >
             <tbody>
               <tr>
@@ -476,7 +530,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Antonia Eliason
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   26
                 </td>
@@ -486,7 +540,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Trent Kelly
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   13
                 </td>
@@ -496,7 +550,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Write-In
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   0
                 </td>
@@ -506,16 +560,16 @@ exports[`printing ballots, print report, and test decks 2`] = `
         </div>
       </div>
       <div
-        class="sc-iktFzd kAIWOv"
+        class="sc-jJEJSO cJfRAW"
       >
         <div
-          class="sc-crrsfI jJkczz"
+          class="sc-hBEYos lvLIa"
         >
           <div
-            class="sc-kLgntA rDeEm ignore-prose"
+            class="sc-iktFzd dkHGVf ignore-prose"
           >
             <span
-              class="sc-dQppl kMSBOR"
+              class="sc-crrsfI XvqqD"
             >
               39 ballots
                cast /
@@ -532,7 +586,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
             Supreme Court District 3(Northern) Position 3
           </h3>
           <table
-            class="sc-fodVxV dpEkZU"
+            class="sc-fFubgz hqxDEn"
           >
             <tbody>
               <tr>
@@ -540,7 +594,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Josiah Dennis Coleman
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   26
                 </td>
@@ -550,7 +604,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Percy L. Lynchard
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   13
                 </td>
@@ -560,7 +614,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Write-In
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   0
                 </td>
@@ -570,16 +624,16 @@ exports[`printing ballots, print report, and test decks 2`] = `
         </div>
       </div>
       <div
-        class="sc-iktFzd kAIWOv"
+        class="sc-jJEJSO cJfRAW"
       >
         <div
-          class="sc-crrsfI jJkczz"
+          class="sc-hBEYos lvLIa"
         >
           <div
-            class="sc-kLgntA rDeEm ignore-prose"
+            class="sc-iktFzd dkHGVf ignore-prose"
           >
             <span
-              class="sc-dQppl kMSBOR"
+              class="sc-crrsfI XvqqD"
             >
               9 ballots
                cast /
@@ -596,7 +650,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
             Election Commissioner  01
           </h3>
           <table
-            class="sc-fodVxV dpEkZU"
+            class="sc-fFubgz hqxDEn"
           >
             <tbody>
               <tr>
@@ -604,7 +658,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Glynda Chaney Fulce
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   9
                 </td>
@@ -614,7 +668,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Write-In
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   0
                 </td>
@@ -624,16 +678,16 @@ exports[`printing ballots, print report, and test decks 2`] = `
         </div>
       </div>
       <div
-        class="sc-iktFzd kAIWOv"
+        class="sc-jJEJSO cJfRAW"
       >
         <div
-          class="sc-crrsfI jJkczz"
+          class="sc-hBEYos lvLIa"
         >
           <div
-            class="sc-kLgntA rDeEm ignore-prose"
+            class="sc-iktFzd dkHGVf ignore-prose"
           >
             <span
-              class="sc-dQppl kMSBOR"
+              class="sc-crrsfI XvqqD"
             >
               9 ballots
                cast /
@@ -650,7 +704,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
             Election Commissioner 02
           </h3>
           <table
-            class="sc-fodVxV dpEkZU"
+            class="sc-fFubgz hqxDEn"
           >
             <tbody>
               <tr>
@@ -658,7 +712,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Charles Beck
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   6
                 </td>
@@ -668,7 +722,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Sharon Brooks
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   3
                 </td>
@@ -678,7 +732,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Write-In
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   0
                 </td>
@@ -688,16 +742,16 @@ exports[`printing ballots, print report, and test decks 2`] = `
         </div>
       </div>
       <div
-        class="sc-iktFzd kAIWOv"
+        class="sc-jJEJSO cJfRAW"
       >
         <div
-          class="sc-crrsfI jJkczz"
+          class="sc-hBEYos lvLIa"
         >
           <div
-            class="sc-kLgntA rDeEm ignore-prose"
+            class="sc-iktFzd dkHGVf ignore-prose"
           >
             <span
-              class="sc-dQppl kMSBOR"
+              class="sc-crrsfI XvqqD"
             >
               9 ballots
                cast /
@@ -714,7 +768,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
             Election Commissioner 03
           </h3>
           <table
-            class="sc-fodVxV dpEkZU"
+            class="sc-fFubgz hqxDEn"
           >
             <tbody>
               <tr>
@@ -722,7 +776,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Dorothy Anderson
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   9
                 </td>
@@ -732,7 +786,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Write-In
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   0
                 </td>
@@ -742,16 +796,16 @@ exports[`printing ballots, print report, and test decks 2`] = `
         </div>
       </div>
       <div
-        class="sc-iktFzd kAIWOv"
+        class="sc-jJEJSO cJfRAW"
       >
         <div
-          class="sc-crrsfI jJkczz"
+          class="sc-hBEYos lvLIa"
         >
           <div
-            class="sc-kLgntA rDeEm ignore-prose"
+            class="sc-iktFzd dkHGVf ignore-prose"
           >
             <span
-              class="sc-dQppl kMSBOR"
+              class="sc-crrsfI XvqqD"
             >
               9 ballots
                cast /
@@ -768,7 +822,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
             Election Commissioner 04
           </h3>
           <table
-            class="sc-fodVxV dpEkZU"
+            class="sc-fFubgz hqxDEn"
           >
             <tbody>
               <tr>
@@ -776,7 +830,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Willie Mae Guillory
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   6
                 </td>
@@ -786,7 +840,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Lewis Wright
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   3
                 </td>
@@ -796,7 +850,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Write-In
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   0
                 </td>
@@ -806,16 +860,16 @@ exports[`printing ballots, print report, and test decks 2`] = `
         </div>
       </div>
       <div
-        class="sc-iktFzd kAIWOv"
+        class="sc-jJEJSO cJfRAW"
       >
         <div
-          class="sc-crrsfI jJkczz"
+          class="sc-hBEYos lvLIa"
         >
           <div
-            class="sc-kLgntA rDeEm ignore-prose"
+            class="sc-iktFzd dkHGVf ignore-prose"
           >
             <span
-              class="sc-dQppl kMSBOR"
+              class="sc-crrsfI XvqqD"
             >
               3 ballots
                cast /
@@ -832,7 +886,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
             Election Commissioner 05
           </h3>
           <table
-            class="sc-fodVxV dpEkZU"
+            class="sc-fFubgz hqxDEn"
           >
             <tbody>
               <tr>
@@ -840,7 +894,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Ouida A Loper
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   2
                 </td>
@@ -850,7 +904,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Wayne McLeod
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   1
                 </td>
@@ -860,7 +914,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Write-In
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   0
                 </td>
@@ -870,16 +924,16 @@ exports[`printing ballots, print report, and test decks 2`] = `
         </div>
       </div>
       <div
-        class="sc-iktFzd kAIWOv"
+        class="sc-jJEJSO cJfRAW"
       >
         <div
-          class="sc-crrsfI jJkczz"
+          class="sc-hBEYos lvLIa"
         >
           <div
-            class="sc-kLgntA rDeEm ignore-prose"
+            class="sc-iktFzd dkHGVf ignore-prose"
           >
             <span
-              class="sc-dQppl kMSBOR"
+              class="sc-crrsfI XvqqD"
             >
               3 ballots
                cast /
@@ -896,7 +950,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
             School Board 05
           </h3>
           <table
-            class="sc-fodVxV dpEkZU"
+            class="sc-fFubgz hqxDEn"
           >
             <tbody>
               <tr>
@@ -904,7 +958,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Michael D Thomas
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   3
                 </td>
@@ -914,7 +968,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Write-In
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   0
                 </td>
@@ -924,16 +978,16 @@ exports[`printing ballots, print report, and test decks 2`] = `
         </div>
       </div>
       <div
-        class="sc-iktFzd kAIWOv"
+        class="sc-jJEJSO cJfRAW"
       >
         <div
-          class="sc-crrsfI jJkczz"
+          class="sc-hBEYos lvLIa"
         >
           <div
-            class="sc-kLgntA rDeEm ignore-prose"
+            class="sc-iktFzd dkHGVf ignore-prose"
           >
             <span
-              class="sc-dQppl kMSBOR"
+              class="sc-crrsfI XvqqD"
             >
               39 ballots
                cast /
@@ -951,7 +1005,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
 House Concurrent Resolution No. 47
           </h3>
           <table
-            class="sc-fodVxV dpEkZU"
+            class="sc-fFubgz hqxDEn"
           >
             <tbody>
               <tr>
@@ -959,7 +1013,7 @@ House Concurrent Resolution No. 47
                   YES
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   26
                 </td>
@@ -969,7 +1023,7 @@ House Concurrent Resolution No. 47
                   NO
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   13
                 </td>
@@ -979,16 +1033,16 @@ House Concurrent Resolution No. 47
         </div>
       </div>
       <div
-        class="sc-iktFzd kAIWOv"
+        class="sc-jJEJSO cJfRAW"
       >
         <div
-          class="sc-crrsfI jJkczz"
+          class="sc-hBEYos lvLIa"
         >
           <div
-            class="sc-kLgntA rDeEm ignore-prose"
+            class="sc-iktFzd dkHGVf ignore-prose"
           >
             <span
-              class="sc-dQppl kMSBOR"
+              class="sc-crrsfI XvqqD"
             >
               39 ballots
                cast /
@@ -1006,7 +1060,7 @@ House Concurrent Resolution No. 47
 House Bill 1796 - Flag Referendum
           </h3>
           <table
-            class="sc-fodVxV dpEkZU"
+            class="sc-fFubgz hqxDEn"
           >
             <tbody>
               <tr>
@@ -1014,7 +1068,7 @@ House Bill 1796 - Flag Referendum
                   YES
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   26
                 </td>
@@ -1024,7 +1078,7 @@ House Bill 1796 - Flag Referendum
                   NO
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   13
                 </td>
@@ -1034,16 +1088,16 @@ House Bill 1796 - Flag Referendum
         </div>
       </div>
       <div
-        class="sc-iktFzd kAIWOv"
+        class="sc-jJEJSO cJfRAW"
       >
         <div
-          class="sc-crrsfI jJkczz"
+          class="sc-hBEYos lvLIa"
         >
           <div
-            class="sc-kLgntA rDeEm ignore-prose"
+            class="sc-iktFzd dkHGVf ignore-prose"
           >
             <span
-              class="sc-dQppl kMSBOR"
+              class="sc-crrsfI XvqqD"
             >
               39 ballots
                cast /
@@ -1060,7 +1114,7 @@ House Bill 1796 - Flag Referendum
             Ballot Measure 1 – Either/Neither
           </h3>
           <table
-            class="sc-fodVxV dpEkZU"
+            class="sc-fFubgz hqxDEn"
           >
             <tbody>
               <tr>
@@ -1068,7 +1122,7 @@ House Bill 1796 - Flag Referendum
                   FOR APPROVAL OF EITHER Initiative No. 65 OR Alternative Measure No. 65 A
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   26
                 </td>
@@ -1078,7 +1132,7 @@ House Bill 1796 - Flag Referendum
                   AGAINST BOTH Initiative Measure No. 65 AND Alternative Measure No. 65 A
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   13
                 </td>
@@ -1088,16 +1142,16 @@ House Bill 1796 - Flag Referendum
         </div>
       </div>
       <div
-        class="sc-iktFzd kAIWOv"
+        class="sc-jJEJSO cJfRAW"
       >
         <div
-          class="sc-crrsfI jJkczz"
+          class="sc-hBEYos lvLIa"
         >
           <div
-            class="sc-kLgntA rDeEm ignore-prose"
+            class="sc-iktFzd dkHGVf ignore-prose"
           >
             <span
-              class="sc-dQppl kMSBOR"
+              class="sc-crrsfI XvqqD"
             >
               39 ballots
                cast /
@@ -1114,7 +1168,7 @@ House Bill 1796 - Flag Referendum
             Ballot Measure 1 – Pick One
           </h3>
           <table
-            class="sc-fodVxV dpEkZU"
+            class="sc-fFubgz hqxDEn"
           >
             <tbody>
               <tr>
@@ -1122,7 +1176,7 @@ House Bill 1796 - Flag Referendum
                   FOR Initiative Measure No. 65
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   26
                 </td>
@@ -1132,7 +1186,7 @@ House Bill 1796 - Flag Referendum
                   FOR Alternative Measure 65 A
                 </td>
                 <td
-                  class="sc-fFubgz jVzFBN"
+                  class="sc-bkzZxe hhbIzz"
                 >
                   13
                 </td>
@@ -1152,16 +1206,16 @@ exports[`tabulating CVRs 1`] = `
   data-testid="tally-report-contents"
 >
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           100 ballots
            cast /
@@ -1178,7 +1232,7 @@ exports[`tabulating CVRs 1`] = `
         President
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -1186,7 +1240,7 @@ exports[`tabulating CVRs 1`] = `
               Presidential Electors for Joe Biden for President and Kamala Harris for Vice President
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               27
             </td>
@@ -1196,7 +1250,7 @@ exports[`tabulating CVRs 1`] = `
               Presidential Electors for Donald J. Trump for President and Michael R. Pence for Vice President
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               36
             </td>
@@ -1206,7 +1260,7 @@ exports[`tabulating CVRs 1`] = `
               Presidential Electors for Phil Collins for President and Bill Parker for Vice President
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               29
             </td>
@@ -1216,7 +1270,7 @@ exports[`tabulating CVRs 1`] = `
               Write-In
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -1226,16 +1280,16 @@ exports[`tabulating CVRs 1`] = `
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           100 ballots
            cast /
@@ -1252,7 +1306,7 @@ exports[`tabulating CVRs 1`] = `
         Senate 
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -1260,7 +1314,7 @@ exports[`tabulating CVRs 1`] = `
               Mike Espy
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               29
             </td>
@@ -1270,7 +1324,7 @@ exports[`tabulating CVRs 1`] = `
               Cindy Hyde-Smith
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               35
             </td>
@@ -1280,7 +1334,7 @@ exports[`tabulating CVRs 1`] = `
               Jimmy Edwards
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               28
             </td>
@@ -1290,7 +1344,7 @@ exports[`tabulating CVRs 1`] = `
               Write-In
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -1300,16 +1354,16 @@ exports[`tabulating CVRs 1`] = `
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           100 ballots
            cast /
@@ -1326,7 +1380,7 @@ exports[`tabulating CVRs 1`] = `
         1st Congressional District
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -1334,7 +1388,7 @@ exports[`tabulating CVRs 1`] = `
               Antonia Eliason
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               46
             </td>
@@ -1344,7 +1398,7 @@ exports[`tabulating CVRs 1`] = `
               Trent Kelly
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               46
             </td>
@@ -1354,7 +1408,7 @@ exports[`tabulating CVRs 1`] = `
               Write-In
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -1364,16 +1418,16 @@ exports[`tabulating CVRs 1`] = `
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           100 ballots
            cast /
@@ -1390,7 +1444,7 @@ exports[`tabulating CVRs 1`] = `
         Supreme Court District 3(Northern) Position 3
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -1398,7 +1452,7 @@ exports[`tabulating CVRs 1`] = `
               Josiah Dennis Coleman
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               37
             </td>
@@ -1408,7 +1462,7 @@ exports[`tabulating CVRs 1`] = `
               Percy L. Lynchard
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               58
             </td>
@@ -1418,7 +1472,7 @@ exports[`tabulating CVRs 1`] = `
               Write-In
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -1428,16 +1482,16 @@ exports[`tabulating CVRs 1`] = `
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           18 ballots
            cast /
@@ -1454,7 +1508,7 @@ exports[`tabulating CVRs 1`] = `
         Election Commissioner  01
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -1462,7 +1516,7 @@ exports[`tabulating CVRs 1`] = `
               Glynda Chaney Fulce
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               17
             </td>
@@ -1472,7 +1526,7 @@ exports[`tabulating CVRs 1`] = `
               Write-In
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -1482,16 +1536,16 @@ exports[`tabulating CVRs 1`] = `
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           15 ballots
            cast /
@@ -1508,7 +1562,7 @@ exports[`tabulating CVRs 1`] = `
         Election Commissioner 02
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -1516,7 +1570,7 @@ exports[`tabulating CVRs 1`] = `
               Charles Beck
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               5
             </td>
@@ -1526,7 +1580,7 @@ exports[`tabulating CVRs 1`] = `
               Sharon Brooks
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               9
             </td>
@@ -1536,7 +1590,7 @@ exports[`tabulating CVRs 1`] = `
               Write-In
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -1546,16 +1600,16 @@ exports[`tabulating CVRs 1`] = `
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           23 ballots
            cast /
@@ -1572,7 +1626,7 @@ exports[`tabulating CVRs 1`] = `
         Election Commissioner 03
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -1580,7 +1634,7 @@ exports[`tabulating CVRs 1`] = `
               Dorothy Anderson
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               22
             </td>
@@ -1590,7 +1644,7 @@ exports[`tabulating CVRs 1`] = `
               Write-In
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -1600,16 +1654,16 @@ exports[`tabulating CVRs 1`] = `
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           25 ballots
            cast /
@@ -1626,7 +1680,7 @@ exports[`tabulating CVRs 1`] = `
         Election Commissioner 04
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -1634,7 +1688,7 @@ exports[`tabulating CVRs 1`] = `
               Willie Mae Guillory
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               10
             </td>
@@ -1644,7 +1698,7 @@ exports[`tabulating CVRs 1`] = `
               Lewis Wright
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               14
             </td>
@@ -1654,7 +1708,7 @@ exports[`tabulating CVRs 1`] = `
               Write-In
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -1664,16 +1718,16 @@ exports[`tabulating CVRs 1`] = `
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           19 ballots
            cast /
@@ -1690,7 +1744,7 @@ exports[`tabulating CVRs 1`] = `
         Election Commissioner 05
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -1698,7 +1752,7 @@ exports[`tabulating CVRs 1`] = `
               Ouida A Loper
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               9
             </td>
@@ -1708,7 +1762,7 @@ exports[`tabulating CVRs 1`] = `
               Wayne McLeod
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               6
             </td>
@@ -1718,7 +1772,7 @@ exports[`tabulating CVRs 1`] = `
               Write-In
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -1728,16 +1782,16 @@ exports[`tabulating CVRs 1`] = `
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           19 ballots
            cast /
@@ -1754,7 +1808,7 @@ exports[`tabulating CVRs 1`] = `
         School Board 05
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -1762,7 +1816,7 @@ exports[`tabulating CVRs 1`] = `
               Michael D Thomas
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               19
             </td>
@@ -1772,7 +1826,7 @@ exports[`tabulating CVRs 1`] = `
               Write-In
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -1782,16 +1836,16 @@ exports[`tabulating CVRs 1`] = `
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           100 ballots
            cast /
@@ -1809,7 +1863,7 @@ exports[`tabulating CVRs 1`] = `
 House Concurrent Resolution No. 47
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -1817,7 +1871,7 @@ House Concurrent Resolution No. 47
               YES
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               40
             </td>
@@ -1827,7 +1881,7 @@ House Concurrent Resolution No. 47
               NO
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               53
             </td>
@@ -1837,16 +1891,16 @@ House Concurrent Resolution No. 47
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           100 ballots
            cast /
@@ -1864,7 +1918,7 @@ House Concurrent Resolution No. 47
 House Bill 1796 - Flag Referendum
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -1872,7 +1926,7 @@ House Bill 1796 - Flag Referendum
               YES
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               43
             </td>
@@ -1882,7 +1936,7 @@ House Bill 1796 - Flag Referendum
               NO
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               52
             </td>
@@ -1892,16 +1946,16 @@ House Bill 1796 - Flag Referendum
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           98 ballots
            cast /
@@ -1918,7 +1972,7 @@ House Bill 1796 - Flag Referendum
         Ballot Measure 1 – Either/Neither
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -1926,7 +1980,7 @@ House Bill 1796 - Flag Referendum
               FOR APPROVAL OF EITHER Initiative No. 65 OR Alternative Measure No. 65 A
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               39
             </td>
@@ -1936,7 +1990,7 @@ House Bill 1796 - Flag Referendum
               AGAINST BOTH Initiative Measure No. 65 AND Alternative Measure No. 65 A
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               53
             </td>
@@ -1946,16 +2000,16 @@ House Bill 1796 - Flag Referendum
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           98 ballots
            cast /
@@ -1972,7 +2026,7 @@ House Bill 1796 - Flag Referendum
         Ballot Measure 1 – Pick One
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -1980,7 +2034,7 @@ House Bill 1796 - Flag Referendum
               FOR Initiative Measure No. 65
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               40
             </td>
@@ -1990,7 +2044,7 @@ House Bill 1796 - Flag Referendum
               FOR Alternative Measure 65 A
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               49
             </td>
@@ -2007,16 +2061,16 @@ exports[`tabulating CVRs 2`] = `
   data-testid="tally-report-contents"
 >
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           0 ballots
            cast /
@@ -2033,7 +2087,7 @@ exports[`tabulating CVRs 2`] = `
         President
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -2041,7 +2095,7 @@ exports[`tabulating CVRs 2`] = `
               Presidential Electors for Joe Biden for President and Kamala Harris for Vice President
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2051,7 +2105,7 @@ exports[`tabulating CVRs 2`] = `
               Presidential Electors for Donald J. Trump for President and Michael R. Pence for Vice President
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2061,7 +2115,7 @@ exports[`tabulating CVRs 2`] = `
               Presidential Electors for Phil Collins for President and Bill Parker for Vice President
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2071,7 +2125,7 @@ exports[`tabulating CVRs 2`] = `
               Write-In
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2081,16 +2135,16 @@ exports[`tabulating CVRs 2`] = `
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           0 ballots
            cast /
@@ -2107,7 +2161,7 @@ exports[`tabulating CVRs 2`] = `
         Senate 
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -2115,7 +2169,7 @@ exports[`tabulating CVRs 2`] = `
               Mike Espy
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2125,7 +2179,7 @@ exports[`tabulating CVRs 2`] = `
               Cindy Hyde-Smith
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2135,7 +2189,7 @@ exports[`tabulating CVRs 2`] = `
               Jimmy Edwards
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2145,7 +2199,7 @@ exports[`tabulating CVRs 2`] = `
               Write-In
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2155,16 +2209,16 @@ exports[`tabulating CVRs 2`] = `
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           0 ballots
            cast /
@@ -2181,7 +2235,7 @@ exports[`tabulating CVRs 2`] = `
         1st Congressional District
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -2189,7 +2243,7 @@ exports[`tabulating CVRs 2`] = `
               Antonia Eliason
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2199,7 +2253,7 @@ exports[`tabulating CVRs 2`] = `
               Trent Kelly
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2209,7 +2263,7 @@ exports[`tabulating CVRs 2`] = `
               Write-In
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2219,16 +2273,16 @@ exports[`tabulating CVRs 2`] = `
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           0 ballots
            cast /
@@ -2245,7 +2299,7 @@ exports[`tabulating CVRs 2`] = `
         Supreme Court District 3(Northern) Position 3
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -2253,7 +2307,7 @@ exports[`tabulating CVRs 2`] = `
               Josiah Dennis Coleman
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2263,7 +2317,7 @@ exports[`tabulating CVRs 2`] = `
               Percy L. Lynchard
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2273,7 +2327,7 @@ exports[`tabulating CVRs 2`] = `
               Write-In
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2283,16 +2337,16 @@ exports[`tabulating CVRs 2`] = `
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           0 ballots
            cast /
@@ -2309,7 +2363,7 @@ exports[`tabulating CVRs 2`] = `
         Election Commissioner  01
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -2317,7 +2371,7 @@ exports[`tabulating CVRs 2`] = `
               Glynda Chaney Fulce
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2327,7 +2381,7 @@ exports[`tabulating CVRs 2`] = `
               Write-In
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2337,16 +2391,16 @@ exports[`tabulating CVRs 2`] = `
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           0 ballots
            cast /
@@ -2363,7 +2417,7 @@ exports[`tabulating CVRs 2`] = `
         Election Commissioner 02
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -2371,7 +2425,7 @@ exports[`tabulating CVRs 2`] = `
               Charles Beck
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2381,7 +2435,7 @@ exports[`tabulating CVRs 2`] = `
               Sharon Brooks
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2391,7 +2445,7 @@ exports[`tabulating CVRs 2`] = `
               Write-In
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2401,16 +2455,16 @@ exports[`tabulating CVRs 2`] = `
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           0 ballots
            cast /
@@ -2427,7 +2481,7 @@ exports[`tabulating CVRs 2`] = `
         Election Commissioner 03
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -2435,7 +2489,7 @@ exports[`tabulating CVRs 2`] = `
               Dorothy Anderson
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2445,7 +2499,7 @@ exports[`tabulating CVRs 2`] = `
               Write-In
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2455,16 +2509,16 @@ exports[`tabulating CVRs 2`] = `
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           0 ballots
            cast /
@@ -2481,7 +2535,7 @@ exports[`tabulating CVRs 2`] = `
         Election Commissioner 04
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -2489,7 +2543,7 @@ exports[`tabulating CVRs 2`] = `
               Willie Mae Guillory
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2499,7 +2553,7 @@ exports[`tabulating CVRs 2`] = `
               Lewis Wright
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2509,7 +2563,7 @@ exports[`tabulating CVRs 2`] = `
               Write-In
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2519,16 +2573,16 @@ exports[`tabulating CVRs 2`] = `
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           0 ballots
            cast /
@@ -2545,7 +2599,7 @@ exports[`tabulating CVRs 2`] = `
         Election Commissioner 05
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -2553,7 +2607,7 @@ exports[`tabulating CVRs 2`] = `
               Ouida A Loper
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2563,7 +2617,7 @@ exports[`tabulating CVRs 2`] = `
               Wayne McLeod
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2573,7 +2627,7 @@ exports[`tabulating CVRs 2`] = `
               Write-In
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2583,16 +2637,16 @@ exports[`tabulating CVRs 2`] = `
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           0 ballots
            cast /
@@ -2609,7 +2663,7 @@ exports[`tabulating CVRs 2`] = `
         School Board 05
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -2617,7 +2671,7 @@ exports[`tabulating CVRs 2`] = `
               Michael D Thomas
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2627,7 +2681,7 @@ exports[`tabulating CVRs 2`] = `
               Write-In
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2637,16 +2691,16 @@ exports[`tabulating CVRs 2`] = `
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           0 ballots
            cast /
@@ -2664,7 +2718,7 @@ exports[`tabulating CVRs 2`] = `
 House Concurrent Resolution No. 47
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -2672,7 +2726,7 @@ House Concurrent Resolution No. 47
               YES
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2682,7 +2736,7 @@ House Concurrent Resolution No. 47
               NO
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2692,16 +2746,16 @@ House Concurrent Resolution No. 47
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           0 ballots
            cast /
@@ -2719,7 +2773,7 @@ House Concurrent Resolution No. 47
 House Bill 1796 - Flag Referendum
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -2727,7 +2781,7 @@ House Bill 1796 - Flag Referendum
               YES
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2737,7 +2791,7 @@ House Bill 1796 - Flag Referendum
               NO
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2747,16 +2801,16 @@ House Bill 1796 - Flag Referendum
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           0 ballots
            cast /
@@ -2773,7 +2827,7 @@ House Bill 1796 - Flag Referendum
         Ballot Measure 1 – Either/Neither
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -2781,7 +2835,7 @@ House Bill 1796 - Flag Referendum
               FOR APPROVAL OF EITHER Initiative No. 65 OR Alternative Measure No. 65 A
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2791,7 +2845,7 @@ House Bill 1796 - Flag Referendum
               AGAINST BOTH Initiative Measure No. 65 AND Alternative Measure No. 65 A
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2801,16 +2855,16 @@ House Bill 1796 - Flag Referendum
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           0 ballots
            cast /
@@ -2827,7 +2881,7 @@ House Bill 1796 - Flag Referendum
         Ballot Measure 1 – Pick One
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -2835,7 +2889,7 @@ House Bill 1796 - Flag Referendum
               FOR Initiative Measure No. 65
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2845,7 +2899,7 @@ House Bill 1796 - Flag Referendum
               FOR Alternative Measure 65 A
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2862,16 +2916,16 @@ exports[`tabulating CVRs with SEMS file 1`] = `
   data-testid="tally-report-contents"
 >
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           200 ballots
            cast /
@@ -2888,7 +2942,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
         President
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -2896,7 +2950,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Presidential Electors for Joe Biden for President and Kamala Harris for Vice President
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               54
             </td>
@@ -2906,7 +2960,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Presidential Electors for Donald J. Trump for President and Michael R. Pence for Vice President
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               72
             </td>
@@ -2916,7 +2970,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Presidential Electors for Phil Collins for President and Bill Parker for Vice President
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               58
             </td>
@@ -2926,7 +2980,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Write-In
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -2936,16 +2990,16 @@ exports[`tabulating CVRs with SEMS file 1`] = `
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           200 ballots
            cast /
@@ -2962,7 +3016,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
         Senate 
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -2970,7 +3024,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Mike Espy
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               58
             </td>
@@ -2980,7 +3034,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Cindy Hyde-Smith
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               70
             </td>
@@ -2990,7 +3044,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Jimmy Edwards
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               56
             </td>
@@ -3000,7 +3054,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Write-In
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -3010,16 +3064,16 @@ exports[`tabulating CVRs with SEMS file 1`] = `
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           200 ballots
            cast /
@@ -3036,7 +3090,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
         1st Congressional District
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -3044,7 +3098,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Antonia Eliason
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               92
             </td>
@@ -3054,7 +3108,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Trent Kelly
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               92
             </td>
@@ -3064,7 +3118,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Write-In
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -3074,16 +3128,16 @@ exports[`tabulating CVRs with SEMS file 1`] = `
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           200 ballots
            cast /
@@ -3100,7 +3154,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
         Supreme Court District 3(Northern) Position 3
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -3108,7 +3162,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Josiah Dennis Coleman
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               74
             </td>
@@ -3118,7 +3172,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Percy L. Lynchard
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               116
             </td>
@@ -3128,7 +3182,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Write-In
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -3138,16 +3192,16 @@ exports[`tabulating CVRs with SEMS file 1`] = `
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           36 ballots
            cast /
@@ -3164,7 +3218,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
         Election Commissioner  01
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -3172,7 +3226,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Glynda Chaney Fulce
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               34
             </td>
@@ -3182,7 +3236,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Write-In
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -3192,16 +3246,16 @@ exports[`tabulating CVRs with SEMS file 1`] = `
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           30 ballots
            cast /
@@ -3218,7 +3272,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
         Election Commissioner 02
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -3226,7 +3280,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Charles Beck
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               10
             </td>
@@ -3236,7 +3290,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Sharon Brooks
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               18
             </td>
@@ -3246,7 +3300,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Write-In
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -3256,16 +3310,16 @@ exports[`tabulating CVRs with SEMS file 1`] = `
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           46 ballots
            cast /
@@ -3282,7 +3336,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
         Election Commissioner 03
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -3290,7 +3344,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Dorothy Anderson
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               44
             </td>
@@ -3300,7 +3354,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Write-In
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -3310,16 +3364,16 @@ exports[`tabulating CVRs with SEMS file 1`] = `
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           50 ballots
            cast /
@@ -3336,7 +3390,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
         Election Commissioner 04
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -3344,7 +3398,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Willie Mae Guillory
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               20
             </td>
@@ -3354,7 +3408,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Lewis Wright
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               28
             </td>
@@ -3364,7 +3418,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Write-In
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -3374,16 +3428,16 @@ exports[`tabulating CVRs with SEMS file 1`] = `
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           38 ballots
            cast /
@@ -3400,7 +3454,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
         Election Commissioner 05
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -3408,7 +3462,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Ouida A Loper
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               18
             </td>
@@ -3418,7 +3472,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Wayne McLeod
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               12
             </td>
@@ -3428,7 +3482,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Write-In
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -3438,16 +3492,16 @@ exports[`tabulating CVRs with SEMS file 1`] = `
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           38 ballots
            cast /
@@ -3464,7 +3518,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
         School Board 05
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -3472,7 +3526,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Michael D Thomas
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               38
             </td>
@@ -3482,7 +3536,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Write-In
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               0
             </td>
@@ -3492,16 +3546,16 @@ exports[`tabulating CVRs with SEMS file 1`] = `
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           200 ballots
            cast /
@@ -3519,7 +3573,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
 House Concurrent Resolution No. 47
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -3527,7 +3581,7 @@ House Concurrent Resolution No. 47
               YES
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               80
             </td>
@@ -3537,7 +3591,7 @@ House Concurrent Resolution No. 47
               NO
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               106
             </td>
@@ -3547,16 +3601,16 @@ House Concurrent Resolution No. 47
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           200 ballots
            cast /
@@ -3574,7 +3628,7 @@ House Concurrent Resolution No. 47
 House Bill 1796 - Flag Referendum
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -3582,7 +3636,7 @@ House Bill 1796 - Flag Referendum
               YES
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               86
             </td>
@@ -3592,7 +3646,7 @@ House Bill 1796 - Flag Referendum
               NO
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               104
             </td>
@@ -3602,16 +3656,16 @@ House Bill 1796 - Flag Referendum
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           196 ballots
            cast /
@@ -3628,7 +3682,7 @@ House Bill 1796 - Flag Referendum
         Ballot Measure 1 – Either/Neither
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -3636,7 +3690,7 @@ House Bill 1796 - Flag Referendum
               FOR APPROVAL OF EITHER Initiative No. 65 OR Alternative Measure No. 65 A
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               78
             </td>
@@ -3646,7 +3700,7 @@ House Bill 1796 - Flag Referendum
               AGAINST BOTH Initiative Measure No. 65 AND Alternative Measure No. 65 A
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               106
             </td>
@@ -3656,16 +3710,16 @@ House Bill 1796 - Flag Referendum
     </div>
   </div>
   <div
-    class="sc-iktFzd kAIWOv"
+    class="sc-jJEJSO cJfRAW"
   >
     <div
-      class="sc-crrsfI jJkczz"
+      class="sc-hBEYos lvLIa"
     >
       <div
-        class="sc-kLgntA rDeEm ignore-prose"
+        class="sc-iktFzd dkHGVf ignore-prose"
       >
         <span
-          class="sc-dQppl kMSBOR"
+          class="sc-crrsfI XvqqD"
         >
           196 ballots
            cast /
@@ -3682,7 +3736,7 @@ House Bill 1796 - Flag Referendum
         Ballot Measure 1 – Pick One
       </h3>
       <table
-        class="sc-fodVxV dpEkZU"
+        class="sc-fFubgz hqxDEn"
       >
         <tbody>
           <tr>
@@ -3690,7 +3744,7 @@ House Bill 1796 - Flag Referendum
               FOR Initiative Measure No. 65
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               80
             </td>
@@ -3700,7 +3754,7 @@ House Bill 1796 - Flag Referendum
               FOR Alternative Measure 65 A
             </td>
             <td
-              class="sc-fFubgz jVzFBN"
+              class="sc-bkzZxe hhbIzz"
             >
               98
             </td>

--- a/apps/election-manager/src/components/NavigationScreen.tsx
+++ b/apps/election-manager/src/components/NavigationScreen.tsx
@@ -9,6 +9,7 @@ import Main, { MainChild } from './Main'
 import Navigation from './Navigation'
 import LinkButton from './LinkButton'
 import USBControllerButton from './USBControllerButton'
+import StatusFooter from './StatusFooter'
 
 interface Props {
   children: React.ReactNode
@@ -30,11 +31,6 @@ const NavigationScreen: React.FC<Props> = ({
 
   return (
     <Screen>
-      <Main padded>
-        <MainChild center={mainChildCenter} flexContainer={mainChildFlex}>
-          {children}
-        </MainChild>
-      </Main>
       <Navigation
         primaryNav={
           election && (
@@ -63,6 +59,12 @@ const NavigationScreen: React.FC<Props> = ({
         }
         secondaryNav={<USBControllerButton />}
       />
+      <Main padded>
+        <MainChild center={mainChildCenter} flexContainer={mainChildFlex}>
+          {children}
+        </MainChild>
+      </Main>
+      <StatusFooter />
     </Screen>
   )
 }

--- a/apps/election-manager/src/components/Screen.tsx
+++ b/apps/election-manager/src/components/Screen.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 const Screen = styled.div<Props>`
   display: flex;
-  flex-direction: ${({ flexDirection = 'column-reverse' }) => flexDirection};
+  flex-direction: ${({ flexDirection = 'column' }) => flexDirection};
   background-color: ${({ white }) => (white ? 'white' : undefined)};
   height: 100%;
   & > nav {

--- a/apps/election-manager/src/components/StatusFooter.tsx
+++ b/apps/election-manager/src/components/StatusFooter.tsx
@@ -1,0 +1,40 @@
+import React, { useContext } from 'react'
+import styled from 'styled-components'
+import Text from './Text'
+import { localeWeedkayAndDate } from '../utils/IntlDateTimeFormats'
+import AppContext from '../contexts/AppContext'
+
+const StatusBar = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  background: #455a64;
+  padding: 0.375rem 1rem;
+  color: #ffffff;
+`
+
+const StatusFooter: React.FC = () => {
+  const { electionDefinition } = useContext(AppContext)
+  if (electionDefinition === undefined) {
+    return null
+  }
+
+  const { election, electionHash } = electionDefinition
+  const electionDate = localeWeedkayAndDate.format(new Date(election?.date))
+
+  return (
+    <StatusBar>
+      <Text small white center as="div">
+        <strong>{election.title}</strong> — {electionDate} —{' '}
+        {election.county.name}, {election.state}{' '}
+      </Text>
+      <Text small white center as="div">
+        <React.Fragment>
+          Election Hash: <strong>{electionHash.slice(0, 10)}</strong>
+        </React.Fragment>
+      </Text>
+    </StatusBar>
+  )
+}
+
+export default StatusFooter

--- a/apps/election-manager/src/components/Text.tsx
+++ b/apps/election-manager/src/components/Text.tsx
@@ -21,6 +21,7 @@ interface Props {
   warningIcon?: boolean
   wordBreak?: boolean
   voteIcon?: boolean
+  white?: boolean
 }
 
 const iconStyles = css<Props>`
@@ -55,16 +56,18 @@ const Text = styled('p')<Props>`
     undefined};
   white-space: ${({ noWrap, preLine }) =>
     noWrap ? 'nowrap' : preLine ? 'pre-line' : undefined};
-  color: ${({ error, muted, warning }) =>
+  color: ${({ error, muted, warning, white }) =>
     (error && 'red') ??
     (warning && 'darkorange') ??
     (muted && 'gray') ??
+    (white && '#FFFFFF') ??
     undefined};
   @media print {
-    color: ${({ error, muted, warning }) =>
+    color: ${({ error, muted, warning, white }) =>
       (error && 'black') ??
       (warning && 'black') ??
       (muted && 'black') ??
+      (white && '#FFFFFF') ??
       undefined};
   }
   font-size: ${({ small }) => (small ? '0.8em' : undefined)};

--- a/apps/election-manager/test/util/hasTextAcrossElements.tsx
+++ b/apps/election-manager/test/util/hasTextAcrossElements.tsx
@@ -1,0 +1,12 @@
+import { Matcher, Nullish } from '@testing-library/react'
+
+export default function hasTextAcrossElements(text: string): Matcher {
+  return (content: string, node: Nullish<Element>) => {
+    const hasText = (n: Element) => n.textContent === text
+    const nodeHasText = !!node && hasText(node)
+    const childrenDontHaveText = Array.from(node?.children || []).every(
+      (child) => !hasText(child)
+    )
+    return nodeHasText && childrenDontHaveText
+  }
+}


### PR DESCRIPTION
Adds a status footer inspired by the BSD version to election manager to display the current election title and hash within Election Manager. 

Screenshot: 
![Screen Shot 2021-03-16 at 1 20 04 PM](https://user-images.githubusercontent.com/14897017/111376092-43f25400-865c-11eb-93f9-71bbda82344f.png)

https://zube.io/votingworks/vxsuite/c/3116