### PR TITLE
feat(types): add `safeParse`

### DIFF
--- a/apps/election-manager/src/screens/DefinitionEditorScreen.tsx
+++ b/apps/election-manager/src/screens/DefinitionEditorScreen.tsx
@@ -5,7 +5,7 @@ import fileDownload from 'js-file-download'
 
 import dashify from 'dashify'
 
-import { parseElection } from '@votingworks/types'
+import { safeParseElection } from '@votingworks/types'
 import AppContext from '../contexts/AppContext'
 
 import Button from '../components/Button'
@@ -53,14 +53,9 @@ const DefinitionEditorScreen: React.FC = () => {
   }
 
   const validateElectionDefinition = useCallback(() => {
-    try {
-      setError('')
-      parseElection(JSON.parse(electionString))
-      return true
-    } catch (error) {
-      setError(error.toString())
-      return false
-    }
+    const result = safeParseElection(electionString)
+    setError(result.err()?.message ?? '')
+    return result.isOk()
   }, [electionString])
   const editElection: TextareaEventFunction = (event) => {
     setDirty(true)

--- a/apps/module-scan/src/interpreter.test.ts
+++ b/apps/module-scan/src/interpreter.test.ts
@@ -16,7 +16,6 @@ import Interpreter, {
   UninterpretedHmpbPage,
   UnreadablePage,
 } from './interpreter'
-import { resultError, resultValue } from './types'
 import pdfToImages from './util/pdfToImages'
 import { detectQrcodeInFilePath } from './workers/qrcode'
 
@@ -37,13 +36,13 @@ jest.setTimeout(10000)
 test('does not find QR codes when there are none to find', async () => {
   const filepath = join(sampleBallotImagesPath, 'not-a-ballot.jpg')
   expect(
-    resultError(
+    (
       await getBallotImageData(
         await readFile(filepath),
         filepath,
         await detectQrcodeInFilePath(filepath)
       )
-    )
+    ).unwrapErr()
   ).toEqual({ type: 'UnreadablePage', reason: 'No QR code found' })
 })
 
@@ -118,13 +117,13 @@ test('properly detects test ballot in live mode', async () => {
 test('can read metadata encoded in a QR code with base64', async () => {
   const fixtures = choctaw2020SpecialFixtures
   const { election } = fixtures
-  const { qrcode } = resultValue(
+  const { qrcode } = (
     await getBallotImageData(
       await readFile(fixtures.blankPage1),
       fixtures.blankPage1,
       await detectQrcodeInFilePath(fixtures.blankPage1)
     )
-  )
+  ).unwrap()
 
   expect(metadataFromBytes(election, Buffer.from(qrcode.data)))
     .toMatchInlineSnapshot(`
@@ -146,13 +145,13 @@ test('can read metadata encoded in a QR code with base64', async () => {
 
 test('can read metadata in QR code with skewed / dirty ballot', async () => {
   const fixtures = general2020Fixtures
-  const { qrcode } = resultValue(
+  const { qrcode } = (
     await getBallotImageData(
       await readFile(fixtures.skewedQRCodeBallotPage),
       fixtures.skewedQRCodeBallotPage,
       await detectQrcodeInFilePath(fixtures.skewedQRCodeBallotPage)
     )
-  )
+  ).unwrap()
 
   expect(qrcode.data).toMatchInlineSnapshot(`
     Object {

--- a/apps/module-scan/src/types.ts
+++ b/apps/module-scan/src/types.ts
@@ -16,40 +16,6 @@ import {
 import { MarkInfo, PageInterpretation } from './interpreter'
 import { MarksByContestId, MarkStatus } from './types/ballot-review'
 
-export type Result<E, T> = ErrorResult<E> | ValueResult<T>
-export interface ErrorResult<E> {
-  error: E
-}
-export interface ValueResult<T> {
-  value: T
-}
-
-export function isValueResult<E, T>(
-  result: Result<E, T>
-): result is ValueResult<T> {
-  return 'value' in result
-}
-
-export function isErrorResult<E, T>(
-  result: Result<E, T>
-): result is ErrorResult<E> {
-  return 'error' in result
-}
-
-export function resultValue<E, T>(result: Result<E, T>): T {
-  if (isErrorResult(result)) {
-    throw new TypeError('cannot extract value from error result')
-  }
-  return result.value
-}
-
-export function resultError<E, T>(result: Result<E, T>): E {
-  if (isValueResult(result)) {
-    throw new TypeError('cannot extract error from value result')
-  }
-  return result.error
-}
-
 export type SheetOf<T> = [T, T]
 export type Side = 'front' | 'back'
 

--- a/libs/ballot-encoder/package.json
+++ b/libs/ballot-encoder/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@antongolub/iso8601": "^1.2.1",
     "js-sha256": "^0.9.0",
-    "zod": "1.7.1"
+    "zod": "^1.11.11"
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",

--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@antongolub/iso8601": "^1.2.1",
-    "zod": "1.7.1"
+    "zod": "^1.11.11"
   },
   "devDependencies": {
     "@types/jest": "^26.0.20",

--- a/libs/types/src/generic.test.ts
+++ b/libs/types/src/generic.test.ts
@@ -1,0 +1,113 @@
+import { err, ok } from './generic'
+
+test('ok is Ok', () => {
+  expect(ok(0).isOk()).toBe(true)
+})
+
+test('ok is not Err', () => {
+  expect(ok(0).isErr()).toBe(false)
+})
+
+test('ok has contained value', () => {
+  const value = {}
+  expect(ok(value).ok()).toBe(value)
+})
+
+test('ok has no contained error', () => {
+  expect(ok(0).err()).toBeUndefined()
+})
+
+test('ok map', () => {
+  expect(
+    ok(0)
+      .map((n) => n + 1)
+      .unwrap()
+  ).toBe(1)
+})
+
+test('ok mapOr', () => {
+  expect(ok(0).mapOr(-1, (n) => n + 1)).toBe(1)
+})
+
+test('ok mapOrElse', () => {
+  expect(
+    ok(0).mapOrElse(
+      () => -1,
+      (n) => n + 1
+    )
+  ).toBe(1)
+})
+
+test('ok unwrap', () => {
+  expect(ok(0).unwrap()).toBe(0)
+})
+
+test('ok unwrapErr', () => {
+  expect(() => ok('value').unwrapErr()).toThrowError('value')
+})
+
+test('ok expect', () => {
+  expect(ok(0).expect('expected a number')).toBe(0)
+})
+
+test('ok expectErr', () => {
+  expect(() => ok(0).expectErr('expected an error')).toThrowError(
+    'expected an error'
+  )
+})
+
+test('err is Err', () => {
+  expect(err(0).isErr()).toBe(true)
+})
+
+test('err is not Ok', () => {
+  expect(err(0).isOk()).toBe(false)
+})
+
+test('err has contained error', () => {
+  const error = {}
+  expect(err(error).err()).toBe(error)
+})
+
+test('err has no contained value', () => {
+  expect(err(0).ok()).toBeUndefined()
+})
+
+test('err map', () => {
+  expect(
+    err(0)
+      .map(() => 1)
+      .unwrapErr()
+  ).toBe(0)
+})
+
+test('err mapOr', () => {
+  expect(err(0).mapOr(-1, () => 1)).toBe(-1)
+})
+
+test('err mapOrElse', () => {
+  expect(
+    err(0).mapOrElse(
+      () => -1,
+      () => 1
+    )
+  ).toBe(-1)
+})
+
+test('err unwrap', () => {
+  expect(() => err('error').unwrap()).toThrowError('error')
+})
+
+test('err unwrapErr', () => {
+  expect(err('error').unwrapErr()).toBe('error')
+})
+
+test('err expect', () => {
+  expect(() => err(0).expect('expected a value')).toThrowError(
+    'expected a value'
+  )
+})
+
+test('err expectErr', () => {
+  expect(err(0).expectErr('expected an error')).toBe(0)
+})

--- a/libs/types/src/generic.ts
+++ b/libs/types/src/generic.ts
@@ -1,0 +1,261 @@
+export interface Dictionary<T> {
+  [key: string]: Optional<T>
+}
+export type Optional<T> = T | undefined
+export interface Provider<T> {
+  get(): Promise<T>
+}
+
+/**
+ * Represents either success with a value `T` or failure with error `E`.
+ */
+export interface Result<T, E> {
+  /**
+   * Returns `true` if the result is `Ok`.
+   */
+  isOk(): this is Ok<T>
+
+  /**
+   * Returns `true` if the result is `Err`.
+   */
+  isErr(): this is Err<E>
+
+  /**
+   * Returns the value if result is `Ok`, otherwise undefined.
+   */
+  ok(): Optional<T>
+
+  /**
+   * Returns the error if result is `Err`, otherwise undefined.
+   */
+  err(): Optional<E>
+
+  /**
+   * Maps a `Result<T, E>` to `Result<U, E>` by applying `fn` to an `Ok` value,
+   * leaving an `Err` value untouched.
+   *
+   * @example
+   *
+   *   const times2 = (n: number) => n * 2
+   *   console.log(ok(1).map(times2).ok()) // logs `2`
+   *   console.log(err(-1).map(times2).ok()) // logs `undefined`
+   */
+  map<U>(fn: (value: T) => U): Result<U, E>
+
+  /**
+   * Applies `fn` to a contained `Ok` value or returns `defaultValue` for `Err`.
+   *
+   * @example
+   *
+   *   const times2 = (n: number) => n * 2
+   *   console.log(ok(1).mapOr(-1, times2)) // logs `2`
+   *   console.log(err(NaN).mapOr(-1, times2)) // logs `-1`
+   */
+  mapOr<U>(defaultValue: U, fn: (value: T) => U): U
+
+  /**
+   * Applies `fn` to a contained `Ok` value or `defaultFn` to a contained `Err`
+   * error.
+   *
+   * @example
+   *
+   *   const times2 = (n: number) => n * 2
+   *   console.log(ok(1).mapOrElse(() => -1, times2)) // logs `2`
+   *   console.log(err(NaN).mapOrElse(() => -1, times2)) // logs `-1`
+   */
+  mapOrElse<U>(defaultFn: (error: E) => U, fn: (value: T) => U): U
+
+  /**
+   * Returns a contained `Ok` value, or throws a contained `Err` error.
+   *
+   * @example
+   *
+   *   console.log(ok(1).unwrap()) // logs `1`
+   *   console.log(err(NaN).unwrap()) // throws `NaN`
+   */
+  unwrap(): T
+
+  /**
+   * Returns a contained `Err` error, or throws a contained `Ok` value.
+   *
+   * @example
+   *
+   *   console.log(ok(1).unwrapErr()) // throws `1`
+   *   console.log(err(NaN).unwrapErr()) // logs `NaN`
+   */
+  unwrapErr(): E
+
+  /**
+   * Returns a contained `Ok` value, or throws `throwable`.
+   *
+   * @example
+   *
+   *   console.log(ok(1).expect('expected a number')) // logs `1`
+   *   console.log(err(NaN).expect('expected a number')) // throws 'expected a number'
+   */
+  expect(throwable: unknown): T
+
+  /**
+   * Returns a contained `Err` error, or throws `throwable`.
+   *
+   * @example
+   *
+   *   console.log(ok(1).expectErr('expected an error')) // throws 'expected an error'
+   *   console.log(err(NaN).expectErr('expected an error')) // logs `NaN`
+   */
+  expectErr(throwable: unknown): E
+}
+
+export interface Ok<T> extends Result<T, never> {
+  /**
+   * Returns `true`.
+   */
+  isOk(): true
+
+  /**
+   * Returns `false`.
+   */
+  isErr(): false
+
+  /**
+   * Returns the contained value.
+   */
+  ok(): T
+
+  /**
+   * Returns `undefined`.
+   */
+  err(): undefined
+
+  /**
+   * Applies `fn` to the contained value and returns the result.
+   */
+  map<U>(fn: (value: T) => U): Ok<U>
+
+  /**
+   * Applies `fn` to the contained value and returns the result.
+   */
+  mapOr<U>(defaultValue: U, fn: (value: T) => U): U
+
+  /**
+   * Applies `fn` to the contained value and returns the result.
+   */
+  mapOrElse<U>(defaultFn: (error: never) => U, fn: (value: T) => U): U
+
+  /**
+   * Returns the contained value.
+   */
+  unwrap(): T
+
+  /**
+   * Throws the contained value.
+   */
+  unwrapErr(): never
+
+  /**
+   * Returns the contained value.
+   */
+  expect(throwable: unknown): T
+
+  /**
+   * Throws `throwable`.
+   */
+  expectErr(throwable: unknown): never
+}
+
+export interface Err<E> extends Result<never, E> {
+  /**
+   * Returns `false`.
+   */
+  isOk(): false
+
+  /**
+   * Returns `true`.
+   */
+  isErr(): true
+
+  /**
+   * Returns `undefined`.
+   */
+  ok(): undefined
+
+  /**
+   * Returns the contained error.
+   */
+  err(): E
+
+  /**
+   * Returns a new `Err` wrapping the contained error.
+   */
+  map<U>(fn: (value: never) => U): Err<E>
+
+  /**
+   * Returns `defaultValue`.
+   */
+  mapOr<U>(defaultValue: U, fn: (value: never) => U): U
+
+  /**
+   * Calls `defaultFn` and returns the result.
+   */
+  mapOrElse<U>(defaultFn: (error: E) => U, fn: (value: never) => U): U
+
+  /**
+   * Throws the contained error.
+   */
+  unwrap(): never
+
+  /**
+   * Returns the contained error.
+   */
+  unwrapErr(): E
+
+  /**
+   * Throws `throwable`.
+   */
+  expect(throwable: unknown): never
+
+  /**
+   * Returns the contained error.
+   */
+  expectErr(throwable: unknown): E
+}
+
+export function ok<T, E>(value: T): Result<T, E> {
+  return {
+    isOk: () => true,
+    isErr: () => false,
+    ok: () => value,
+    err: () => undefined,
+    map: (fn) => ok(fn(value)),
+    mapOr: (_defaultValue, fn) => fn(value),
+    mapOrElse: (_defaultFn, fn) => fn(value),
+    unwrap: () => value,
+    unwrapErr: () => {
+      throw value
+    },
+    expect: () => value,
+    expectErr: (throwable) => {
+      throw throwable
+    },
+  }
+}
+
+export function err<T, E>(error: E): Result<T, E> {
+  return {
+    isOk: () => false,
+    isErr: () => true,
+    ok: () => undefined,
+    err: () => error,
+    map: () => err(error),
+    mapOr: (defaultValue) => defaultValue,
+    mapOrElse: (defaultFn) => defaultFn(error),
+    unwrap: () => {
+      throw error
+    },
+    unwrapErr: () => error,
+    expect: (throwable) => {
+      throw throwable
+    },
+    expectErr: () => error,
+  }
+}

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -1,2 +1,3 @@
+export * from './generic'
 export * from './election'
 export * as schema from './schema'

--- a/libs/types/src/schema.test.ts
+++ b/libs/types/src/schema.test.ts
@@ -18,7 +18,7 @@ test('contest IDs cannot start with an underscore', () => {
         ],
       })
     )
-  ).toThrowError('IDs may not start with an underscore')
+  ).toThrowError()
 })
 
 test('allows valid mark thresholds', () => {
@@ -52,14 +52,14 @@ test('disallows invalid mark thresholds', () => {
       ...electionSample,
       markThresholds: { marginal: 0.3 },
     })
-  ).toThrowError('definite: Non-number type: undefined')
+  ).toThrowError()
 
   expect(() =>
     parseElection({
       ...electionSample,
       markThresholds: { definite: 1.2, marginal: 0.3 },
     })
-  ).toThrowError('definite: Value must be <= 1')
+  ).toThrowError('Value should be less than or equal to 1')
 })
 
 test('allows valid adjudication reasons', () => {
@@ -87,14 +87,14 @@ test('disallows invalid adjudication reasons', () => {
       ...electionSample,
       adjudicationReasons: ['abcdefg'],
     })
-  ).toThrowError('"abcdefg" does not match any value in enum')
+  ).toThrowError()
 
   expect(() =>
     parseElection({
       ...electionSample,
       adjudicationReasons: 'foooo',
     })
-  ).toThrowError('Non-array type: string')
+  ).toThrowError()
 })
 
 test('supports ballot layout paper size', () => {
@@ -105,7 +105,7 @@ test('supports ballot layout paper size', () => {
         paperSize: 'A4',
       },
     })
-  ).toThrowError('"A4" does not match any value in enum')
+  ).toThrowError()
 
   expect(() =>
     parseElection({

--- a/libs/types/src/schema.ts
+++ b/libs/types/src/schema.ts
@@ -4,10 +4,7 @@ import {
   AdjudicationReason as AdjudicationReasonEnum,
   BallotPaperSize as BallotPaperSizeEnum,
 } from './election'
-
-/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/no-unused-vars */
-// @ts-ignore
-import type { objectUtil } from 'zod/lib/src/helpers/objectUtil'
+import { err, ok, Result } from './generic'
 
 // Generic
 type StringEnum = {
@@ -199,3 +196,16 @@ export const VotesDict = z.record(Vote)
 
 // Keep this in sync with `src/election.ts`.
 export const BallotType = z.number().min(0).max(2)
+
+export function safeParse<T>(
+  parser: z.ZodType<T>,
+  value: unknown
+): Result<T, z.ZodError> {
+  const result = parser.safeParse(value)
+
+  if (!result.success) {
+    return err(result.error)
+  }
+
+  return ok(result.data)
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -704,7 +704,7 @@ importers:
     dependencies:
       '@antongolub/iso8601': 1.2.1
       js-sha256: 0.9.0
-      zod: 1.7.1
+      zod: 1.11.11
     devDependencies:
       '@types/jest': 26.0.20
       '@types/node': 14.14.20
@@ -757,7 +757,7 @@ importers:
       sort-package-json: ^1.46.1
       ts-jest: ^26.4.3
       typescript: ^4.2.0
-      zod: 1.7.1
+      zod: ^1.11.11
   libs/eslint-plugin-no-array-sort-mutation:
     specifiers: {}
   libs/fixtures:
@@ -915,7 +915,7 @@ importers:
   libs/types:
     dependencies:
       '@antongolub/iso8601': 1.2.1
-      zod: 1.7.1
+      zod: 1.11.11
     devDependencies:
       '@types/jest': 26.0.20
       '@typescript-eslint/eslint-plugin': 4.16.1_8360ec0b6468ab52d7ec43304a9826d1
@@ -941,7 +941,7 @@ importers:
       prettier: ^2.2.1
       ts-jest: ^26.5.0
       typescript: ^4.2.0
-      zod: 1.7.1
+      zod: ^1.11.11
 lockfileVersion: 5.2
 packages:
   /@antongolub/iso8601/1.2.1:
@@ -22837,13 +22837,8 @@ packages:
     resolution:
       integrity: sha512-a65wQ3h5gcQ/nQGWV1mSZCEzCML6EK/vyVPcrPNynySP1j3VBbQKh3nhC8CbORb+jfl2vXvh56Ul5odP1bAHqw==
   /zod/1.11.11:
-    dev: true
     resolution:
       integrity: sha512-q1YeBpu+c7eUX5fDFMyfP97sD74TUQ+UN8va/nvbxnArr5euYsNO6fjiY0SdDkHKNZ+xBR2ZQToaeLgJ6fsB2A==
-  /zod/1.7.1:
-    dev: false
-    resolution:
-      integrity: sha512-EqtwN5PJTgg/iOxMvjezNcha8xDcrcUr2V4oYZ8GMzxzFGfZV+LFI+ey2sBs2mGWSF8qZE8gHIquApWa7jiTYg==
   /zwitch/1.0.5:
     dev: true
     resolution:


### PR DESCRIPTION
This upgrades the zod library to get a new feature: `ZodType#safeParse`. Instead of throwing an exception, failed parsing results in typed errors. To make this easier to use, I added `safeParseElection` and `safeParse` functions to `@votingworks/types`. These return a `Result`, which is a either `Ok` or `Err`, each containing a value representing success or failure. `Result` objects have some methods to make them easier to work with, a subset of the API for `Result` from the Rust language: https://doc.rust-lang.org/1.50.0/std/result/enum.Result.html.

I've been wanting something like this for a while to use instead of throwing exceptions, and this is my initial stab at it (if you don't count my previous half-hearted attempt in module-scan which this commit replaces).