### PR TITLE
refactor(fixtures): misc improvements to CVR script

### DIFF
--- a/libs/fixtures/.eslintignore
+++ b/libs/fixtures/.eslintignore
@@ -1,3 +1,2 @@
 jest.config.js
 src/data/**/**/*.csv.ts
-scripts/generateSampleCVRFile.ts

--- a/libs/fixtures/tsconfig.test.json
+++ b/libs/fixtures/tsconfig.test.json
@@ -1,4 +1,5 @@
 {
   "extends": "./tsconfig.json",
+  "include": ["src", "src/data/*.json", "src/data/**/*.json", "scripts/**/*.ts"],
   "exclude": []
 }


### PR DESCRIPTION
- remove unneeded `@param` type annotations; they are redundant in `.ts` files
- use generics instead of `any`
- use `Map` instead of `Dictionary` in some cases to make typing easier
- mark inputs as readonly where appropriate
- make `generateCVRs` a generator; not really utilized in this implementation, but could be a lower-memory way to build CVRs if we don't need to look at all CVRs at once
- just write to the `fs.WritableStream`; there's no need to wait for it to be open