### PR TITLE
feat(scan): show "No Scanner" when no device is connected

### DIFF
--- a/apps/bsd/src/AppRoot.tsx
+++ b/apps/bsd/src/AppRoot.tsx
@@ -21,6 +21,7 @@ import Main, { MainChild } from './components/Main'
 import Screen from './components/Screen'
 import Prose from './components/Prose'
 import Text from './components/Text'
+import ScanButton from './components/ScanButton'
 import USBControllerButton from './components/USBControllerButton'
 import useInterval from './hooks/useInterval'
 
@@ -444,9 +445,7 @@ const App: React.FC = () => {
                       pluralize('ballots', adjudication.remaining, true)}
                   </LinkButton>
                 )}
-                <Button small disabled={isScanning} primary onPress={scanBatch}>
-                  Scan New Batch
-                </Button>
+                <ScanButton onPress={scanBatch} disabled={isScanning} />
               </MainNav>
               <StatusFooter />
             </Screen>

--- a/apps/bsd/src/components/ScanButton.test.tsx
+++ b/apps/bsd/src/components/ScanButton.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { act, render, screen } from '@testing-library/react'
+import ScanButton, { FUJITSU_VENDOR_ID } from './ScanButton'
+import fakeKiosk, { fakeDevice } from '../../test/helpers/fakeKiosk'
+
+beforeEach(() => {
+  delete window.kiosk
+})
+
+test('is enabled by default outside kiosk browser', async () => {
+  render(<ScanButton onPress={jest.fn()} />)
+  const button = (await screen.findByText(
+    'Scan New Batch'
+  )) as HTMLButtonElement
+  expect(button.disabled).toBeFalsy()
+})
+
+test('is disabled by default inside kiosk browser', async () => {
+  window.kiosk = fakeKiosk()
+  render(<ScanButton onPress={jest.fn()} />)
+  const button = (await screen.findByText('No Scanner')) as HTMLButtonElement
+  expect(button.disabled).toBeTruthy()
+})
+
+test('calls onPress when clicked', async () => {
+  const onPress = jest.fn()
+  render(<ScanButton onPress={onPress} />)
+  ;(await screen.findByText('Scan New Batch')).click()
+  expect(onPress).toHaveBeenCalledTimes(1)
+})
+
+test('reacts to hardware changes in kiosk browser', async () => {
+  const kiosk = fakeKiosk()
+  window.kiosk = kiosk
+
+  render(<ScanButton onPress={jest.fn()} />)
+
+  act(() => {
+    // "plug in" a Fujitsu device
+    kiosk.devices.next(new Set([fakeDevice({ vendorId: FUJITSU_VENDOR_ID })]))
+  })
+
+  await screen.findByText('Scan New Batch')
+
+  act(() => {
+    // "unplug" all devices
+    kiosk.devices.next(new Set())
+  })
+
+  await screen.findByText('No Scanner')
+})

--- a/apps/bsd/src/components/ScanButton.tsx
+++ b/apps/bsd/src/components/ScanButton.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react'
+import Button from './Button'
+
+export interface Props {
+  onPress(): void
+  disabled?: boolean
+}
+
+export const FUJITSU_VENDOR_ID = 0x4c5
+
+const ScanButton: React.FC<Props> = ({ onPress, disabled }) => {
+  const [isScannerConnected, setIsScannerConnected] = useState(!window.kiosk)
+
+  useEffect(() => {
+    const subscription = window.kiosk?.devices.subscribe((devices) => {
+      setIsScannerConnected(
+        [...devices].some((device) => device.vendorId === FUJITSU_VENDOR_ID)
+      )
+    })
+    return () => subscription?.unsubscribe()
+  })
+
+  return (
+    <Button
+      small
+      disabled={disabled || !isScannerConnected}
+      primary
+      onPress={onPress}
+    >
+      {isScannerConnected ? 'Scan New Batch' : 'No Scanner'}
+    </Button>
+  )
+}
+
+export default ScanButton

--- a/apps/bsd/test/helpers/fakeKiosk.ts
+++ b/apps/bsd/test/helpers/fakeKiosk.ts
@@ -47,7 +47,11 @@ export default function fakeKiosk({
 }: {
   battery?: Partial<KioskBrowser.BatteryInfo>
   printers?: Partial<KioskBrowser.PrinterInfo>[]
-} = {}): jest.Mocked<KioskBrowser.Kiosk> {
+} = {}): jest.Mocked<
+  KioskBrowser.Kiosk & {
+    devices: BehaviorSubject<Set<KioskBrowser.Device>>
+  }
+> {
   let processedPrinters = printers || [{}]
 
   processedPrinters = processedPrinters.map(fakePrinterInfo)


### PR DESCRIPTION
Tested manually with fi-7180 and fi-7600.

![image](https://user-images.githubusercontent.com/1938/111393333-c50a1500-8675-11eb-97ff-6e51e0d96170.png)

Closes #367