### PR TITLE
fix(bmd): print test deck without duplex

### DIFF
--- a/apps/bmd/src/pages/TestBallotDeckScreen.test.tsx
+++ b/apps/bmd/src/pages/TestBallotDeckScreen.test.tsx
@@ -44,8 +44,9 @@ it('renders test decks appropriately', async () => {
 
   printSpy.mockRestore()
 
-  window.kiosk = fakeKiosk()
-  window.kiosk.getPrinterInfo = jest
+  const kiosk = fakeKiosk()
+  window.kiosk = kiosk
+  kiosk.getPrinterInfo = jest
     .fn()
     .mockResolvedValue([fakePrinterInfo({ connected: true })])
 
@@ -53,7 +54,7 @@ it('renders test decks appropriately', async () => {
   fireEvent.click(getByText('Print 63 ballots'))
 
   await waitFor(() => {
-    expect(window.kiosk!.print).toHaveBeenCalledWith()
+    expect(kiosk.print).toHaveBeenCalledWith({ sides: 'one-sided' })
   })
 
   getByText('Printing Ballots…')
@@ -75,13 +76,14 @@ it('shows printer not connected when appropriate', async () => {
     />
   )
 
-  window.kiosk = fakeKiosk()
+  const kiosk = fakeKiosk()
+  window.kiosk = kiosk
 
   fireEvent.click(getByText('All Precincts'))
 
   fireEvent.click(getByText('Print 63 ballots'))
 
-  expect(window.kiosk!.getPrinterInfo).toHaveBeenCalled()
+  expect(kiosk.getPrinterInfo).toHaveBeenCalled()
 
   await waitFor(() => {
     getByText('The printer is not connected.')

--- a/apps/bmd/src/pages/TestBallotDeckScreen.tsx
+++ b/apps/bmd/src/pages/TestBallotDeckScreen.tsx
@@ -158,7 +158,11 @@ const TestBallotDeckScreen: React.FC<Props> = ({
       setIsPrinting(false)
     }, (ballots.length + TEST_DECK_PRINTING_TIMEOUT_SECONDS) * 1000)
 
-    await (window.kiosk ?? window).print()
+    if (window.kiosk) {
+      await window.kiosk.print({ sides: 'one-sided' })
+    } else {
+      window.print()
+    }
   }
 
   return (


### PR DESCRIPTION
BMD ballots are single-sided, so printing them duplex (the kiosk-browser default) makes no sense.

Closes #349