### PR TITLE
fix(scan): improve the "delete batch" experience

### DIFF
--- a/apps/bsd/src/AppRoot.tsx
+++ b/apps/bsd/src/AppRoot.tsx
@@ -60,10 +60,6 @@ const App: React.FC = () => {
   ] = useState<ElectionDefinition>()
   const [electionJustLoaded, setElectionJustLoaded] = useState(false)
   const [electionHash, setElectionHash] = useState<string>()
-  // used to hide batches while they're being deleted
-  const [pendingDeleteBatchIds, setPendingDeleteBatchIds] = useState<number[]>(
-    []
-  )
   const [isTestMode, setTestMode] = useState(false)
   const [isTogglingTestMode, setTogglingTestMode] = useState(false)
   const [status, setStatus] = useState<ScanStatusResponse>({
@@ -232,22 +228,11 @@ const App: React.FC = () => {
     [history, refreshConfig]
   )
 
-  const deleteBatch = useCallback(
-    async (id: number) => {
-      setPendingDeleteBatchIds((previousIds) => [...previousIds, id])
-
-      try {
-        await fetch(`/scan/batch/${id}`, {
-          method: 'DELETE',
-        })
-      } finally {
-        setPendingDeleteBatchIds((previousIds) =>
-          previousIds.filter((previousId) => previousId !== id)
-        )
-      }
-    },
-    [setPendingDeleteBatchIds]
-  )
+  const deleteBatch = useCallback(async (id: string) => {
+    await fetchJSON(`/scan/batch/${id}`, {
+      method: 'DELETE',
+    })
+  }, [])
 
   useInterval(
     useCallback(() => {
@@ -409,12 +394,7 @@ const App: React.FC = () => {
                   <DashboardScreen
                     adjudicationStatus={adjudication}
                     isScanning={isScanning}
-                    status={{
-                      ...status,
-                      batches: status.batches.filter(
-                        (batch) => !pendingDeleteBatchIds.includes(batch.id)
-                      ),
-                    }}
+                    status={status}
                     deleteBatch={deleteBatch}
                   />
                 </MainChild>

--- a/apps/bsd/src/config/types.ts
+++ b/apps/bsd/src/config/types.ts
@@ -46,7 +46,7 @@ export interface ErrorResponse {
 }
 
 export interface Batch {
-  id: number
+  id: string
   count: number
   ballots: Ballot[]
   startedAt: string


### PR DESCRIPTION
Previously I had put in some code to quickly hide the batches that had been deleted while the server did the actual delete. However, this turned out to be flaky and would sometimes hide then show then hide the row. In practice deletes are really fast so having this optimization was not useful.

Additionally, the confirmation was using the built-in `confirm` function which doesn't provide a consistent UX with the rest of the application. This commit changes to use a `Modal` and to wait until the delete is confirmed to dismiss the modal.

|Prompt|With Error|
|-|-|
|![image](https://user-images.githubusercontent.com/1938/111540353-491ed400-872c-11eb-8648-8c199621761a.png)|![image](https://user-images.githubusercontent.com/1938/111540362-4b812e00-872c-11eb-92e8-669b6dc63b1c.png)|

Closes #366