### PR TITLE
feat(election-manager): disables editing an election

### DIFF
--- a/apps/election-manager/src/App.test.tsx
+++ b/apps/election-manager/src/App.test.tsx
@@ -74,7 +74,9 @@ const createMemoryStorageWith = async ({
 }
 
 it('create election works', async () => {
-  const { getByText, getAllByText } = render(<App />)
+  const { getByText, getAllByText, queryAllByText, getByTestId } = render(
+    <App />
+  )
 
   await screen.findByText('Create New Election Definition')
   fireEvent.click(getByText('Create New Election Definition'))
@@ -85,7 +87,12 @@ it('create election works', async () => {
   fireEvent.click(getByText('English/Spanish'))
 
   fireEvent.click(getByText('Definition'))
-  fireEvent.click(getByText('JSON Editor'))
+
+  // Verify editing an election is disabled
+  fireEvent.click(getByText('View Definition JSON'))
+  expect(queryAllByText('Save').length).toBe(0)
+  expect(queryAllByText('Reset').length).toBe(0)
+  expect(getByTestId('json-input').hasAttribute('disabled')).toBe(true)
 
   // remove the election
   fireEvent.click(getByText('Remove'))
@@ -389,8 +396,7 @@ it('changing election resets sems and cvr files', async () => {
   )
 
   fireEvent.click(getByText('Definition'))
-  fireEvent.click(getByText('JSON Editor'))
-  fireEvent.click(getByText('Remove'))
+  fireEvent.click(getByText('Remove Election'))
   fireEvent.click(getByText('Remove Election Definition'))
   await waitFor(() => {
     fireEvent.click(getByText('Create New Election Definition'))

--- a/apps/election-manager/src/__snapshots__/App.test.tsx.snap
+++ b/apps/election-manager/src/__snapshots__/App.test.tsx.snap
@@ -374,7 +374,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
             President
           </h3>
           <table
-            class="sc-fFubgz hqxDEn"
+            class="sc-idOhPF eZzLIR"
           >
             <tbody>
               <tr>
@@ -382,7 +382,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Presidential Electors for Joe Biden for President and Kamala Harris for Vice President
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   13
                 </td>
@@ -392,7 +392,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Presidential Electors for Donald J. Trump for President and Michael R. Pence for Vice President
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   13
                 </td>
@@ -402,7 +402,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Presidential Electors for Phil Collins for President and Bill Parker for Vice President
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   13
                 </td>
@@ -412,7 +412,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Write-In
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   0
                 </td>
@@ -448,7 +448,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
             Senate 
           </h3>
           <table
-            class="sc-fFubgz hqxDEn"
+            class="sc-idOhPF eZzLIR"
           >
             <tbody>
               <tr>
@@ -456,7 +456,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Mike Espy
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   13
                 </td>
@@ -466,7 +466,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Cindy Hyde-Smith
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   13
                 </td>
@@ -476,7 +476,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Jimmy Edwards
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   13
                 </td>
@@ -486,7 +486,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Write-In
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   0
                 </td>
@@ -522,7 +522,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
             1st Congressional District
           </h3>
           <table
-            class="sc-fFubgz hqxDEn"
+            class="sc-idOhPF eZzLIR"
           >
             <tbody>
               <tr>
@@ -530,7 +530,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Antonia Eliason
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   26
                 </td>
@@ -540,7 +540,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Trent Kelly
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   13
                 </td>
@@ -550,7 +550,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Write-In
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   0
                 </td>
@@ -586,7 +586,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
             Supreme Court District 3(Northern) Position 3
           </h3>
           <table
-            class="sc-fFubgz hqxDEn"
+            class="sc-idOhPF eZzLIR"
           >
             <tbody>
               <tr>
@@ -594,7 +594,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Josiah Dennis Coleman
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   26
                 </td>
@@ -604,7 +604,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Percy L. Lynchard
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   13
                 </td>
@@ -614,7 +614,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Write-In
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   0
                 </td>
@@ -650,7 +650,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
             Election Commissioner  01
           </h3>
           <table
-            class="sc-fFubgz hqxDEn"
+            class="sc-idOhPF eZzLIR"
           >
             <tbody>
               <tr>
@@ -658,7 +658,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Glynda Chaney Fulce
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   9
                 </td>
@@ -668,7 +668,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Write-In
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   0
                 </td>
@@ -704,7 +704,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
             Election Commissioner 02
           </h3>
           <table
-            class="sc-fFubgz hqxDEn"
+            class="sc-idOhPF eZzLIR"
           >
             <tbody>
               <tr>
@@ -712,7 +712,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Charles Beck
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   6
                 </td>
@@ -722,7 +722,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Sharon Brooks
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   3
                 </td>
@@ -732,7 +732,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Write-In
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   0
                 </td>
@@ -768,7 +768,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
             Election Commissioner 03
           </h3>
           <table
-            class="sc-fFubgz hqxDEn"
+            class="sc-idOhPF eZzLIR"
           >
             <tbody>
               <tr>
@@ -776,7 +776,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Dorothy Anderson
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   9
                 </td>
@@ -786,7 +786,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Write-In
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   0
                 </td>
@@ -822,7 +822,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
             Election Commissioner 04
           </h3>
           <table
-            class="sc-fFubgz hqxDEn"
+            class="sc-idOhPF eZzLIR"
           >
             <tbody>
               <tr>
@@ -830,7 +830,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Willie Mae Guillory
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   6
                 </td>
@@ -840,7 +840,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Lewis Wright
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   3
                 </td>
@@ -850,7 +850,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Write-In
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   0
                 </td>
@@ -886,7 +886,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
             Election Commissioner 05
           </h3>
           <table
-            class="sc-fFubgz hqxDEn"
+            class="sc-idOhPF eZzLIR"
           >
             <tbody>
               <tr>
@@ -894,7 +894,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Ouida A Loper
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   2
                 </td>
@@ -904,7 +904,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Wayne McLeod
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   1
                 </td>
@@ -914,7 +914,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Write-In
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   0
                 </td>
@@ -950,7 +950,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
             School Board 05
           </h3>
           <table
-            class="sc-fFubgz hqxDEn"
+            class="sc-idOhPF eZzLIR"
           >
             <tbody>
               <tr>
@@ -958,7 +958,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Michael D Thomas
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   3
                 </td>
@@ -968,7 +968,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
                   Write-In
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   0
                 </td>
@@ -1005,7 +1005,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
 House Concurrent Resolution No. 47
           </h3>
           <table
-            class="sc-fFubgz hqxDEn"
+            class="sc-idOhPF eZzLIR"
           >
             <tbody>
               <tr>
@@ -1013,7 +1013,7 @@ House Concurrent Resolution No. 47
                   YES
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   26
                 </td>
@@ -1023,7 +1023,7 @@ House Concurrent Resolution No. 47
                   NO
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   13
                 </td>
@@ -1060,7 +1060,7 @@ House Concurrent Resolution No. 47
 House Bill 1796 - Flag Referendum
           </h3>
           <table
-            class="sc-fFubgz hqxDEn"
+            class="sc-idOhPF eZzLIR"
           >
             <tbody>
               <tr>
@@ -1068,7 +1068,7 @@ House Bill 1796 - Flag Referendum
                   YES
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   26
                 </td>
@@ -1078,7 +1078,7 @@ House Bill 1796 - Flag Referendum
                   NO
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   13
                 </td>
@@ -1114,7 +1114,7 @@ House Bill 1796 - Flag Referendum
             Ballot Measure 1 – Either/Neither
           </h3>
           <table
-            class="sc-fFubgz hqxDEn"
+            class="sc-idOhPF eZzLIR"
           >
             <tbody>
               <tr>
@@ -1122,7 +1122,7 @@ House Bill 1796 - Flag Referendum
                   FOR APPROVAL OF EITHER Initiative No. 65 OR Alternative Measure No. 65 A
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   26
                 </td>
@@ -1132,7 +1132,7 @@ House Bill 1796 - Flag Referendum
                   AGAINST BOTH Initiative Measure No. 65 AND Alternative Measure No. 65 A
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   13
                 </td>
@@ -1168,7 +1168,7 @@ House Bill 1796 - Flag Referendum
             Ballot Measure 1 – Pick One
           </h3>
           <table
-            class="sc-fFubgz hqxDEn"
+            class="sc-idOhPF eZzLIR"
           >
             <tbody>
               <tr>
@@ -1176,7 +1176,7 @@ House Bill 1796 - Flag Referendum
                   FOR Initiative Measure No. 65
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   26
                 </td>
@@ -1186,7 +1186,7 @@ House Bill 1796 - Flag Referendum
                   FOR Alternative Measure 65 A
                 </td>
                 <td
-                  class="sc-bkzZxe hhbIzz"
+                  class="sc-dIUggk eLNEQI"
                 >
                   13
                 </td>
@@ -1232,7 +1232,7 @@ exports[`tabulating CVRs 1`] = `
         President
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -1240,7 +1240,7 @@ exports[`tabulating CVRs 1`] = `
               Presidential Electors for Joe Biden for President and Kamala Harris for Vice President
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               27
             </td>
@@ -1250,7 +1250,7 @@ exports[`tabulating CVRs 1`] = `
               Presidential Electors for Donald J. Trump for President and Michael R. Pence for Vice President
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               36
             </td>
@@ -1260,7 +1260,7 @@ exports[`tabulating CVRs 1`] = `
               Presidential Electors for Phil Collins for President and Bill Parker for Vice President
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               29
             </td>
@@ -1270,7 +1270,7 @@ exports[`tabulating CVRs 1`] = `
               Write-In
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -1306,7 +1306,7 @@ exports[`tabulating CVRs 1`] = `
         Senate 
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -1314,7 +1314,7 @@ exports[`tabulating CVRs 1`] = `
               Mike Espy
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               29
             </td>
@@ -1324,7 +1324,7 @@ exports[`tabulating CVRs 1`] = `
               Cindy Hyde-Smith
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               35
             </td>
@@ -1334,7 +1334,7 @@ exports[`tabulating CVRs 1`] = `
               Jimmy Edwards
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               28
             </td>
@@ -1344,7 +1344,7 @@ exports[`tabulating CVRs 1`] = `
               Write-In
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -1380,7 +1380,7 @@ exports[`tabulating CVRs 1`] = `
         1st Congressional District
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -1388,7 +1388,7 @@ exports[`tabulating CVRs 1`] = `
               Antonia Eliason
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               46
             </td>
@@ -1398,7 +1398,7 @@ exports[`tabulating CVRs 1`] = `
               Trent Kelly
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               46
             </td>
@@ -1408,7 +1408,7 @@ exports[`tabulating CVRs 1`] = `
               Write-In
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -1444,7 +1444,7 @@ exports[`tabulating CVRs 1`] = `
         Supreme Court District 3(Northern) Position 3
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -1452,7 +1452,7 @@ exports[`tabulating CVRs 1`] = `
               Josiah Dennis Coleman
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               37
             </td>
@@ -1462,7 +1462,7 @@ exports[`tabulating CVRs 1`] = `
               Percy L. Lynchard
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               58
             </td>
@@ -1472,7 +1472,7 @@ exports[`tabulating CVRs 1`] = `
               Write-In
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -1508,7 +1508,7 @@ exports[`tabulating CVRs 1`] = `
         Election Commissioner  01
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -1516,7 +1516,7 @@ exports[`tabulating CVRs 1`] = `
               Glynda Chaney Fulce
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               17
             </td>
@@ -1526,7 +1526,7 @@ exports[`tabulating CVRs 1`] = `
               Write-In
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -1562,7 +1562,7 @@ exports[`tabulating CVRs 1`] = `
         Election Commissioner 02
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -1570,7 +1570,7 @@ exports[`tabulating CVRs 1`] = `
               Charles Beck
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               5
             </td>
@@ -1580,7 +1580,7 @@ exports[`tabulating CVRs 1`] = `
               Sharon Brooks
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               9
             </td>
@@ -1590,7 +1590,7 @@ exports[`tabulating CVRs 1`] = `
               Write-In
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -1626,7 +1626,7 @@ exports[`tabulating CVRs 1`] = `
         Election Commissioner 03
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -1634,7 +1634,7 @@ exports[`tabulating CVRs 1`] = `
               Dorothy Anderson
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               22
             </td>
@@ -1644,7 +1644,7 @@ exports[`tabulating CVRs 1`] = `
               Write-In
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -1680,7 +1680,7 @@ exports[`tabulating CVRs 1`] = `
         Election Commissioner 04
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -1688,7 +1688,7 @@ exports[`tabulating CVRs 1`] = `
               Willie Mae Guillory
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               10
             </td>
@@ -1698,7 +1698,7 @@ exports[`tabulating CVRs 1`] = `
               Lewis Wright
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               14
             </td>
@@ -1708,7 +1708,7 @@ exports[`tabulating CVRs 1`] = `
               Write-In
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -1744,7 +1744,7 @@ exports[`tabulating CVRs 1`] = `
         Election Commissioner 05
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -1752,7 +1752,7 @@ exports[`tabulating CVRs 1`] = `
               Ouida A Loper
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               9
             </td>
@@ -1762,7 +1762,7 @@ exports[`tabulating CVRs 1`] = `
               Wayne McLeod
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               6
             </td>
@@ -1772,7 +1772,7 @@ exports[`tabulating CVRs 1`] = `
               Write-In
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -1808,7 +1808,7 @@ exports[`tabulating CVRs 1`] = `
         School Board 05
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -1816,7 +1816,7 @@ exports[`tabulating CVRs 1`] = `
               Michael D Thomas
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               19
             </td>
@@ -1826,7 +1826,7 @@ exports[`tabulating CVRs 1`] = `
               Write-In
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -1863,7 +1863,7 @@ exports[`tabulating CVRs 1`] = `
 House Concurrent Resolution No. 47
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -1871,7 +1871,7 @@ House Concurrent Resolution No. 47
               YES
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               40
             </td>
@@ -1881,7 +1881,7 @@ House Concurrent Resolution No. 47
               NO
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               53
             </td>
@@ -1918,7 +1918,7 @@ House Concurrent Resolution No. 47
 House Bill 1796 - Flag Referendum
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -1926,7 +1926,7 @@ House Bill 1796 - Flag Referendum
               YES
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               43
             </td>
@@ -1936,7 +1936,7 @@ House Bill 1796 - Flag Referendum
               NO
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               52
             </td>
@@ -1972,7 +1972,7 @@ House Bill 1796 - Flag Referendum
         Ballot Measure 1 – Either/Neither
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -1980,7 +1980,7 @@ House Bill 1796 - Flag Referendum
               FOR APPROVAL OF EITHER Initiative No. 65 OR Alternative Measure No. 65 A
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               39
             </td>
@@ -1990,7 +1990,7 @@ House Bill 1796 - Flag Referendum
               AGAINST BOTH Initiative Measure No. 65 AND Alternative Measure No. 65 A
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               53
             </td>
@@ -2026,7 +2026,7 @@ House Bill 1796 - Flag Referendum
         Ballot Measure 1 – Pick One
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -2034,7 +2034,7 @@ House Bill 1796 - Flag Referendum
               FOR Initiative Measure No. 65
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               40
             </td>
@@ -2044,7 +2044,7 @@ House Bill 1796 - Flag Referendum
               FOR Alternative Measure 65 A
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               49
             </td>
@@ -2087,7 +2087,7 @@ exports[`tabulating CVRs 2`] = `
         President
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -2095,7 +2095,7 @@ exports[`tabulating CVRs 2`] = `
               Presidential Electors for Joe Biden for President and Kamala Harris for Vice President
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2105,7 +2105,7 @@ exports[`tabulating CVRs 2`] = `
               Presidential Electors for Donald J. Trump for President and Michael R. Pence for Vice President
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2115,7 +2115,7 @@ exports[`tabulating CVRs 2`] = `
               Presidential Electors for Phil Collins for President and Bill Parker for Vice President
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2125,7 +2125,7 @@ exports[`tabulating CVRs 2`] = `
               Write-In
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2161,7 +2161,7 @@ exports[`tabulating CVRs 2`] = `
         Senate 
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -2169,7 +2169,7 @@ exports[`tabulating CVRs 2`] = `
               Mike Espy
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2179,7 +2179,7 @@ exports[`tabulating CVRs 2`] = `
               Cindy Hyde-Smith
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2189,7 +2189,7 @@ exports[`tabulating CVRs 2`] = `
               Jimmy Edwards
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2199,7 +2199,7 @@ exports[`tabulating CVRs 2`] = `
               Write-In
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2235,7 +2235,7 @@ exports[`tabulating CVRs 2`] = `
         1st Congressional District
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -2243,7 +2243,7 @@ exports[`tabulating CVRs 2`] = `
               Antonia Eliason
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2253,7 +2253,7 @@ exports[`tabulating CVRs 2`] = `
               Trent Kelly
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2263,7 +2263,7 @@ exports[`tabulating CVRs 2`] = `
               Write-In
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2299,7 +2299,7 @@ exports[`tabulating CVRs 2`] = `
         Supreme Court District 3(Northern) Position 3
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -2307,7 +2307,7 @@ exports[`tabulating CVRs 2`] = `
               Josiah Dennis Coleman
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2317,7 +2317,7 @@ exports[`tabulating CVRs 2`] = `
               Percy L. Lynchard
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2327,7 +2327,7 @@ exports[`tabulating CVRs 2`] = `
               Write-In
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2363,7 +2363,7 @@ exports[`tabulating CVRs 2`] = `
         Election Commissioner  01
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -2371,7 +2371,7 @@ exports[`tabulating CVRs 2`] = `
               Glynda Chaney Fulce
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2381,7 +2381,7 @@ exports[`tabulating CVRs 2`] = `
               Write-In
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2417,7 +2417,7 @@ exports[`tabulating CVRs 2`] = `
         Election Commissioner 02
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -2425,7 +2425,7 @@ exports[`tabulating CVRs 2`] = `
               Charles Beck
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2435,7 +2435,7 @@ exports[`tabulating CVRs 2`] = `
               Sharon Brooks
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2445,7 +2445,7 @@ exports[`tabulating CVRs 2`] = `
               Write-In
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2481,7 +2481,7 @@ exports[`tabulating CVRs 2`] = `
         Election Commissioner 03
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -2489,7 +2489,7 @@ exports[`tabulating CVRs 2`] = `
               Dorothy Anderson
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2499,7 +2499,7 @@ exports[`tabulating CVRs 2`] = `
               Write-In
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2535,7 +2535,7 @@ exports[`tabulating CVRs 2`] = `
         Election Commissioner 04
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -2543,7 +2543,7 @@ exports[`tabulating CVRs 2`] = `
               Willie Mae Guillory
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2553,7 +2553,7 @@ exports[`tabulating CVRs 2`] = `
               Lewis Wright
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2563,7 +2563,7 @@ exports[`tabulating CVRs 2`] = `
               Write-In
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2599,7 +2599,7 @@ exports[`tabulating CVRs 2`] = `
         Election Commissioner 05
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -2607,7 +2607,7 @@ exports[`tabulating CVRs 2`] = `
               Ouida A Loper
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2617,7 +2617,7 @@ exports[`tabulating CVRs 2`] = `
               Wayne McLeod
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2627,7 +2627,7 @@ exports[`tabulating CVRs 2`] = `
               Write-In
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2663,7 +2663,7 @@ exports[`tabulating CVRs 2`] = `
         School Board 05
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -2671,7 +2671,7 @@ exports[`tabulating CVRs 2`] = `
               Michael D Thomas
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2681,7 +2681,7 @@ exports[`tabulating CVRs 2`] = `
               Write-In
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2718,7 +2718,7 @@ exports[`tabulating CVRs 2`] = `
 House Concurrent Resolution No. 47
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -2726,7 +2726,7 @@ House Concurrent Resolution No. 47
               YES
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2736,7 +2736,7 @@ House Concurrent Resolution No. 47
               NO
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2773,7 +2773,7 @@ House Concurrent Resolution No. 47
 House Bill 1796 - Flag Referendum
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -2781,7 +2781,7 @@ House Bill 1796 - Flag Referendum
               YES
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2791,7 +2791,7 @@ House Bill 1796 - Flag Referendum
               NO
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2827,7 +2827,7 @@ House Bill 1796 - Flag Referendum
         Ballot Measure 1 – Either/Neither
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -2835,7 +2835,7 @@ House Bill 1796 - Flag Referendum
               FOR APPROVAL OF EITHER Initiative No. 65 OR Alternative Measure No. 65 A
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2845,7 +2845,7 @@ House Bill 1796 - Flag Referendum
               AGAINST BOTH Initiative Measure No. 65 AND Alternative Measure No. 65 A
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2881,7 +2881,7 @@ House Bill 1796 - Flag Referendum
         Ballot Measure 1 – Pick One
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -2889,7 +2889,7 @@ House Bill 1796 - Flag Referendum
               FOR Initiative Measure No. 65
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2899,7 +2899,7 @@ House Bill 1796 - Flag Referendum
               FOR Alternative Measure 65 A
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -2942,7 +2942,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
         President
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -2950,7 +2950,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Presidential Electors for Joe Biden for President and Kamala Harris for Vice President
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               54
             </td>
@@ -2960,7 +2960,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Presidential Electors for Donald J. Trump for President and Michael R. Pence for Vice President
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               72
             </td>
@@ -2970,7 +2970,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Presidential Electors for Phil Collins for President and Bill Parker for Vice President
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               58
             </td>
@@ -2980,7 +2980,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Write-In
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -3016,7 +3016,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
         Senate 
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -3024,7 +3024,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Mike Espy
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               58
             </td>
@@ -3034,7 +3034,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Cindy Hyde-Smith
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               70
             </td>
@@ -3044,7 +3044,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Jimmy Edwards
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               56
             </td>
@@ -3054,7 +3054,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Write-In
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -3090,7 +3090,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
         1st Congressional District
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -3098,7 +3098,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Antonia Eliason
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               92
             </td>
@@ -3108,7 +3108,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Trent Kelly
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               92
             </td>
@@ -3118,7 +3118,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Write-In
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -3154,7 +3154,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
         Supreme Court District 3(Northern) Position 3
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -3162,7 +3162,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Josiah Dennis Coleman
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               74
             </td>
@@ -3172,7 +3172,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Percy L. Lynchard
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               116
             </td>
@@ -3182,7 +3182,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Write-In
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -3218,7 +3218,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
         Election Commissioner  01
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -3226,7 +3226,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Glynda Chaney Fulce
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               34
             </td>
@@ -3236,7 +3236,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Write-In
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -3272,7 +3272,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
         Election Commissioner 02
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -3280,7 +3280,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Charles Beck
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               10
             </td>
@@ -3290,7 +3290,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Sharon Brooks
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               18
             </td>
@@ -3300,7 +3300,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Write-In
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -3336,7 +3336,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
         Election Commissioner 03
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -3344,7 +3344,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Dorothy Anderson
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               44
             </td>
@@ -3354,7 +3354,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Write-In
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -3390,7 +3390,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
         Election Commissioner 04
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -3398,7 +3398,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Willie Mae Guillory
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               20
             </td>
@@ -3408,7 +3408,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Lewis Wright
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               28
             </td>
@@ -3418,7 +3418,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Write-In
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -3454,7 +3454,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
         Election Commissioner 05
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -3462,7 +3462,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Ouida A Loper
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               18
             </td>
@@ -3472,7 +3472,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Wayne McLeod
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               12
             </td>
@@ -3482,7 +3482,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Write-In
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -3518,7 +3518,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
         School Board 05
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -3526,7 +3526,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Michael D Thomas
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               38
             </td>
@@ -3536,7 +3536,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
               Write-In
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               0
             </td>
@@ -3573,7 +3573,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
 House Concurrent Resolution No. 47
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -3581,7 +3581,7 @@ House Concurrent Resolution No. 47
               YES
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               80
             </td>
@@ -3591,7 +3591,7 @@ House Concurrent Resolution No. 47
               NO
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               106
             </td>
@@ -3628,7 +3628,7 @@ House Concurrent Resolution No. 47
 House Bill 1796 - Flag Referendum
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -3636,7 +3636,7 @@ House Bill 1796 - Flag Referendum
               YES
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               86
             </td>
@@ -3646,7 +3646,7 @@ House Bill 1796 - Flag Referendum
               NO
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               104
             </td>
@@ -3682,7 +3682,7 @@ House Bill 1796 - Flag Referendum
         Ballot Measure 1 – Either/Neither
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -3690,7 +3690,7 @@ House Bill 1796 - Flag Referendum
               FOR APPROVAL OF EITHER Initiative No. 65 OR Alternative Measure No. 65 A
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               78
             </td>
@@ -3700,7 +3700,7 @@ House Bill 1796 - Flag Referendum
               AGAINST BOTH Initiative Measure No. 65 AND Alternative Measure No. 65 A
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               106
             </td>
@@ -3736,7 +3736,7 @@ House Bill 1796 - Flag Referendum
         Ballot Measure 1 – Pick One
       </h3>
       <table
-        class="sc-fFubgz hqxDEn"
+        class="sc-idOhPF eZzLIR"
       >
         <tbody>
           <tr>
@@ -3744,7 +3744,7 @@ House Bill 1796 - Flag Referendum
               FOR Initiative Measure No. 65
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               80
             </td>
@@ -3754,7 +3754,7 @@ House Bill 1796 - Flag Referendum
               FOR Alternative Measure 65 A
             </td>
             <td
-              class="sc-bkzZxe hhbIzz"
+              class="sc-dIUggk eLNEQI"
             >
               98
             </td>

--- a/apps/election-manager/src/components/ElectionManager.tsx
+++ b/apps/election-manager/src/components/ElectionManager.tsx
@@ -31,10 +31,10 @@ const ElectionManager: React.FC = () => {
         <DefinitionScreen />
       </Route>
       <Route path={routerPaths.definitionEditor}>
-        <DefinitionEditorScreen />
+        <DefinitionEditorScreen allowEditing={false} />
       </Route>
       <Route path={routerPaths.definitionContest({ contestId: ':contestId' })}>
-        <DefinitionContestsScreen />
+        <DefinitionContestsScreen allowEditing={false} />
       </Route>
       <Route exact path={routerPaths.ballotsList}>
         <BallotListScreen />

--- a/apps/election-manager/src/components/RemoveElectionModal.tsx
+++ b/apps/election-manager/src/components/RemoveElectionModal.tsx
@@ -1,0 +1,45 @@
+import React, { useContext } from 'react'
+import { useHistory } from 'react-router-dom'
+
+import AppContext from '../contexts/AppContext'
+import routerPaths from '../routerPaths'
+import Modal from './Modal'
+import Prose from './Prose'
+import Button from './Button'
+
+export interface Props {
+  onClose: () => void
+}
+
+const RemoveElectionModal: React.FC<Props> = ({ onClose }) => {
+  const history = useHistory()
+  const { saveElection } = useContext(AppContext)
+
+  const unconfigureElection = () => {
+    saveElection(undefined)
+    history.push(routerPaths.root)
+  }
+
+  return (
+    <Modal
+      centerContent
+      content={
+        <Prose textCenter>
+          <p>Do you want to remove the current election definition?</p>
+          <p>All data will be removed from this app.</p>
+        </Prose>
+      }
+      onOverlayClick={onClose}
+      actions={
+        <React.Fragment>
+          <Button onPress={onClose}>Cancel</Button>
+          <Button danger onPress={unconfigureElection}>
+            Remove Election Definition
+          </Button>
+        </React.Fragment>
+      }
+    />
+  )
+}
+
+export default RemoveElectionModal

--- a/apps/election-manager/src/screens/DefinitionContestsScreen.tsx
+++ b/apps/election-manager/src/screens/DefinitionContestsScreen.tsx
@@ -134,6 +134,7 @@ const ToggleField = ({
   value,
   optional,
   onChange,
+  disabled,
 }: {
   name: string
   label?: string
@@ -142,36 +143,47 @@ const ToggleField = ({
   value: boolean
   optional?: boolean
   onChange: ButtonEventFunction
+  disabled?: boolean
 }) => (
   <StyledField>
     <label htmlFor={name}>
-      <strong>{label}</strong>
+      <strong>{label}:</strong>
       {optional && <small> (optional)</small>}
     </label>
-    <SegmentedButton>
-      <Button
-        small
-        disabled={!!value}
-        name={name}
-        value="true"
-        onPress={onChange}
-      >
-        {trueLabel}
-      </Button>
-      <Button
-        small
-        disabled={!value}
-        name={name}
-        value="false"
-        onPress={onChange}
-      >
-        {falseLabel}
-      </Button>
-    </SegmentedButton>
+    {disabled ? (
+      value ? (
+        trueLabel
+      ) : (
+        falseLabel
+      )
+    ) : (
+      <SegmentedButton>
+        <Button
+          small
+          disabled={!!value}
+          name={name}
+          value="true"
+          onPress={onChange}
+        >
+          {trueLabel}
+        </Button>
+        <Button
+          small
+          disabled={!value}
+          name={name}
+          value="false"
+          onPress={onChange}
+        >
+          {falseLabel}
+        </Button>
+      </SegmentedButton>
+    )}
   </StyledField>
 )
 
-const DefinitionContestsScreen: React.FC = () => {
+const DefinitionContestsScreen: React.FC<{ allowEditing: boolean }> = ({
+  allowEditing,
+}) => {
   const { electionDefinition, saveElection } = useContext(AppContext)
   const { election } = electionDefinition!
   const { contestId } = useParams<{ contestId: string }>()
@@ -179,15 +191,17 @@ const DefinitionContestsScreen: React.FC = () => {
   const contest = election.contests[contestIndex]
 
   const saveContest = (newContest: AnyContest) => {
-    const newElection: Election = {
-      ...election,
-      contests: [
-        ...election.contests.slice(0, contestIndex),
-        newContest,
-        ...election.contests.slice(contestIndex + 1),
-      ],
+    if (allowEditing) {
+      const newElection: Election = {
+        ...election,
+        contests: [
+          ...election.contests.slice(0, contestIndex),
+          newContest,
+          ...election.contests.slice(contestIndex + 1),
+        ],
+      }
+      saveElection(JSON.stringify(newElection))
     }
-    saveElection(JSON.stringify(newElection))
   }
 
   const saveTextField: InputEventFunction = (event) => {
@@ -279,10 +293,11 @@ ${fileContent}`
       <NavigationScreen>
         <PageHeader>
           <Prose maxWidth={false}>
-            <h1>Edit Contest</h1>
+            <h1>{allowEditing ? 'Edit' : 'View'} Contest</h1>
             <p>
-              Disabled fields are shown for informational purpose and can be
-              edited in the JSON Editor if necessary.
+              {allowEditing
+                ? 'Disabled fields are shown for informational purpose and can be edited in the JSON Editor if necessary.'
+                : 'Editing currently disabled.'}
             </p>
           </Prose>
         </PageHeader>
@@ -403,12 +418,14 @@ ${fileContent}`
               label="Section Name"
               value={contest.section}
               onChange={saveTextField}
+              disabled={!allowEditing}
             />
             <TextField
               label="Title"
               name="title"
               value={contest.title}
               onChange={saveTextField}
+              disabled={!allowEditing}
             />
             {contest.type === 'yesno' && (
               <TextField
@@ -416,6 +433,7 @@ ${fileContent}`
                 name="shortTitle"
                 value={contest.shortTitle}
                 onChange={saveTextField}
+                disabled={!allowEditing}
               />
             )}
             {contest.type === 'candidate' && (
@@ -429,12 +447,14 @@ ${fileContent}`
                   step={1}
                   pattern="\d*"
                   onChange={saveTextField}
+                  disabled={!allowEditing}
                 />
                 <ToggleField
                   name="allowWriteIns"
                   label="Allow Write-Ins"
                   value={contest.allowWriteIns}
                   onChange={saveToggleField}
+                  disabled={!allowEditing}
                 />
                 <h2>Candidates</h2>
                 <ol>
@@ -445,6 +465,7 @@ ${fileContent}`
                         label="Candidate Name"
                         value={candidate.name}
                         onChange={saveCandidateTextField}
+                        disabled={!allowEditing}
                       />
                       <TextField
                         name={`${index}.id`}
@@ -474,6 +495,7 @@ ${fileContent}`
                   type="textarea"
                   value={contest.description}
                   onChange={saveTextField}
+                  disabled={!allowEditing}
                 />
                 <FileInputButton
                   buttonProps={{
@@ -481,6 +503,7 @@ ${fileContent}`
                   }}
                   accept="image/svg+xml"
                   onChange={appendSvgToDescription}
+                  disabled={!allowEditing}
                 >
                   Append SVG Image to Description
                 </FileInputButton>
@@ -494,42 +517,49 @@ ${fileContent}`
                   type="textarea"
                   value={contest.description}
                   onChange={saveTextField}
+                  disabled={!allowEditing}
                 />
                 <TextField
                   label="Either Neither Instruction Label"
                   name="eitherNeitherLabel"
                   value={contest.eitherNeitherLabel}
                   onChange={saveTextField}
+                  disabled={!allowEditing}
                 />
                 <TextField
                   label="Either Option Label"
                   name="eitherOption"
                   value={contest.eitherOption.label}
                   onChange={saveMsEitherNeitherOptionLabel}
+                  disabled={!allowEditing}
                 />
                 <TextField
                   label="Neither Option Label"
                   name="neitherOption"
                   value={contest.neitherOption.label}
                   onChange={saveMsEitherNeitherOptionLabel}
+                  disabled={!allowEditing}
                 />
                 <TextField
                   label="Pick One Instruction Label"
                   name="pickOneLabel"
                   value={contest.pickOneLabel}
                   onChange={saveTextField}
+                  disabled={!allowEditing}
                 />
                 <TextField
                   label="First Option Label"
                   name="firstOption"
                   value={contest.firstOption.label}
                   onChange={saveMsEitherNeitherOptionLabel}
+                  disabled={!allowEditing}
                 />
                 <TextField
                   label="First Option Label"
                   name="secondOption"
                   value={contest.secondOption.label}
                   onChange={saveMsEitherNeitherOptionLabel}
+                  disabled={!allowEditing}
                 />
               </React.Fragment>
             )}

--- a/apps/election-manager/src/screens/DefinitionEditorScreen.tsx
+++ b/apps/election-manager/src/screens/DefinitionEditorScreen.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useContext, useState, useEffect } from 'react'
 import styled from 'styled-components'
-import { useHistory } from 'react-router-dom'
 import fileDownload from 'js-file-download'
 
 import dashify from 'dashify'
@@ -10,12 +9,11 @@ import AppContext from '../contexts/AppContext'
 
 import Button from '../components/Button'
 import Textarea from '../components/Textarea'
-import routerPaths from '../routerPaths'
 import ButtonBar from '../components/ButtonBar'
-import Modal from '../components/Modal'
 import Prose from '../components/Prose'
 import NavigationScreen from '../components/NavigationScreen'
 import { TextareaEventFunction } from '../config/types'
+import RemoveElectionModal from '../components/RemoveElectionModal'
 
 const Header = styled.div`
   margin-bottom: 1rem;
@@ -31,8 +29,9 @@ const FlexTextareaWrapper = styled.div`
     font-family: monospace;
   }
 `
-const DefinitionEditorScreen: React.FC = () => {
-  const history = useHistory()
+const DefinitionEditorScreen: React.FC<{ allowEditing: boolean }> = ({
+  allowEditing,
+}) => {
   const { electionDefinition, saveElection } = useContext(AppContext)
   const { election, electionData } = electionDefinition!
   const stringifiedElection = JSON.stringify(election, undefined, 2)
@@ -46,10 +45,6 @@ const DefinitionEditorScreen: React.FC = () => {
   }
   const initConfirmingUnconfig = () => {
     setIsConfimingUnconfig(true)
-  }
-  const unconfigureElection = () => {
-    saveElection(undefined)
-    history.push(routerPaths.root)
   }
 
   const validateElectionDefinition = useCallback(() => {
@@ -98,17 +93,21 @@ const DefinitionEditorScreen: React.FC = () => {
           </Header>
         )}
         <ButtonBar padded dark>
-          <Button
-            small
-            primary={dirty && !error}
-            onPress={handleSaveElection}
-            disabled={!dirty || !!error}
-          >
-            Save
-          </Button>
-          <Button small onPress={resetElectionConfig} disabled={!dirty}>
-            Reset
-          </Button>
+          {allowEditing && (
+            <React.Fragment>
+              <Button
+                small
+                primary={dirty && !error}
+                onPress={handleSaveElection}
+                disabled={!dirty || !!error}
+              >
+                Save
+              </Button>
+              <Button small onPress={resetElectionConfig} disabled={!dirty}>
+                Reset
+              </Button>
+            </React.Fragment>
+          )}
           <div />
           <div />
           <div />
@@ -125,27 +124,16 @@ const DefinitionEditorScreen: React.FC = () => {
           </Button>
         </ButtonBar>
         <FlexTextareaWrapper>
-          <Textarea onChange={editElection} value={electionString} />
+          <Textarea
+            onChange={editElection}
+            value={electionString}
+            disabled={!allowEditing}
+            data-testid="json-input"
+          />
         </FlexTextareaWrapper>
       </NavigationScreen>
       {isConfimingUnconfig && (
-        <Modal
-          centerContent
-          content={
-            <Prose textCenter>
-              <p>Do you want to remove the current election definition?</p>
-              <p>All data will be removed from this app.</p>
-            </Prose>
-          }
-          actions={
-            <React.Fragment>
-              <Button onPress={cancelConfirmingUnconfig}>Cancel</Button>
-              <Button danger onPress={unconfigureElection}>
-                Remove Election Definition
-              </Button>
-            </React.Fragment>
-          }
-        />
+        <RemoveElectionModal onClose={cancelConfirmingUnconfig} />
       )}
     </React.Fragment>
   )

--- a/apps/election-manager/src/screens/DefinitionScreen.tsx
+++ b/apps/election-manager/src/screens/DefinitionScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { useContext, useState } from 'react'
 import { Contest } from '@votingworks/types'
 import styled from 'styled-components'
 
@@ -12,6 +12,7 @@ import NavigationScreen from '../components/NavigationScreen'
 import LinkButton from '../components/LinkButton'
 import Prose from '../components/Prose'
 import Text from '../components/Text'
+import RemoveElectionModal from '../components/RemoveElectionModal'
 
 const ButtonListItem = styled.span`
   display: block;
@@ -26,6 +27,8 @@ interface ContestSection {
 const DefinitionScreen: React.FC = () => {
   const { electionDefinition, configuredAt } = useContext(AppContext)
   const { election } = electionDefinition!
+
+  const [isRemovingElection, setIsRemovingElection] = useState(false)
 
   const electionsBySection = election.contests.reduce<ContestSection[]>(
     (prev, curr) => {
@@ -89,12 +92,26 @@ const DefinitionScreen: React.FC = () => {
           ))}
           <h1>Advanced Features</h1>
           <p>
-            <LinkButton to={routerPaths.definitionEditor}>
-              JSON Editor
-            </LinkButton>
+            <ButtonListItem>
+              <LinkButton to={routerPaths.definitionEditor}>
+                View Definition JSON
+              </LinkButton>
+            </ButtonListItem>
+            <ButtonListItem>
+              <LinkButton
+                danger
+                to={routerPaths.definitionEditor}
+                onPress={() => setIsRemovingElection(true)}
+              >
+                Remove Election
+              </LinkButton>
+            </ButtonListItem>
           </p>
         </Prose>
       </NavigationScreen>
+      {isRemovingElection && (
+        <RemoveElectionModal onClose={() => setIsRemovingElection(false)} />
+      )}
     </React.Fragment>
   )
 }


### PR DESCRIPTION
Made the contest edit page and the json edit page read-only to display the same information without allowing editing. I also added a remove election button to the make Definition screen so its a little easier to access then having to go into the JSON editor (although it is still there as well). 


https://user-images.githubusercontent.com/14897017/111547882-13331d00-8737-11eb-914c-74c118a177d6.mov

