### PR TITLE
fix(bmd): prevent VxPrint from printing for the wrong precinct

### DIFF
--- a/apps/bmd/src/AppPrintOnly.test.tsx
+++ b/apps/bmd/src/AppPrintOnly.test.tsx
@@ -20,6 +20,7 @@ import {
   sampleVotes2,
   sampleVotes3,
   createVoterCard,
+  getAlternateNewVoterCard,
 } from '../test/helpers/smartcards'
 
 import withMarkup from '../test/helpers/withMarkup'
@@ -203,6 +204,19 @@ test('VxPrintOnly flow', async () => {
   card.insertCard(getNewVoterCard())
   await advanceTimersAndPromises()
   getByText('Empty Card')
+  expect(window.document.documentElement.style.fontSize).toBe('48px')
+
+  // Remove card
+  card.removeCard()
+  await advanceTimersAndPromises()
+  getByText('Insert Card')
+  expect(window.document.documentElement.style.fontSize).toBe('48px')
+
+  // Insert Voter for Alternate Precinct
+  card.insertCard(getAlternateNewVoterCard())
+  await advanceTimersAndPromises()
+  getByText('Invalid Card Data')
+  getByText('Card is not configured for this precinct.')
   expect(window.document.documentElement.style.fontSize).toBe('48px')
 
   // Remove card

--- a/apps/bmd/src/AppRoot.tsx
+++ b/apps/bmd/src/AppRoot.tsx
@@ -1246,37 +1246,40 @@ const AppRoot: React.FC<Props> = ({
         />
       )
     }
-    if (isPollsOpen && appMode.isVxPrint && !appMode.isVxMark) {
-      return (
-        <PrintOnlyScreen
-          ballotStyleId={ballotStyleId}
-          ballotsPrintedCount={ballotsPrintedCount}
-          electionDefinition={optionalElectionDefinition}
-          isLiveMode={isLiveMode}
-          isVoterCardPresent={isVoterCardPresent}
-          markVoterCardPrinted={markVoterCardPrinted}
-          precinctId={precinctId}
-          printer={printer}
-          useEffectToggleLargeDisplay={useEffectToggleLargeDisplay}
-          showNoChargerAttachedWarning={!hasChargerAttached}
-          updateTally={updateTally}
-          votes={votes}
-        />
-      )
-    }
-    if (isPollsOpen && appMode.isVxMark) {
-      if (
+    if (isPollsOpen) {
+      const isVoterVoting =
         (isVoterCardPresent || isCardlessVoter) &&
-        ballotStyleId &&
-        precinctId
-      ) {
-        if (appPrecinctId !== precinctId) {
-          return (
-            <WrongPrecinctScreen
-              useEffectToggleLargeDisplay={useEffectToggleLargeDisplay}
-            />
-          )
-        }
+        Boolean(ballotStyleId) &&
+        Boolean(precinctId)
+
+      if (isVoterVoting && appPrecinctId !== precinctId) {
+        return (
+          <WrongPrecinctScreen
+            useEffectToggleLargeDisplay={useEffectToggleLargeDisplay}
+          />
+        )
+      }
+
+      if (appMode.isVxPrint && !appMode.isVxMark) {
+        return (
+          <PrintOnlyScreen
+            ballotStyleId={ballotStyleId}
+            ballotsPrintedCount={ballotsPrintedCount}
+            electionDefinition={optionalElectionDefinition}
+            isLiveMode={isLiveMode}
+            isVoterCardPresent={isVoterCardPresent}
+            markVoterCardPrinted={markVoterCardPrinted}
+            precinctId={precinctId}
+            printer={printer}
+            useEffectToggleLargeDisplay={useEffectToggleLargeDisplay}
+            showNoChargerAttachedWarning={!hasChargerAttached}
+            updateTally={updateTally}
+            votes={votes}
+          />
+        )
+      }
+
+      if (isVoterVoting) {
         return (
           <Gamepad onButtonDown={handleGamepadButtonDown}>
             <BallotContext.Provider


### PR DESCRIPTION
Previously the `PrintOnlyScreen` would always be rendered for VxPrint when polls are open. Now, `WrongPrecinctScreen` can be shown if the configured precinct does not match the card precinct.

Closes #131