### PR TITLE
docs(monorepo): add project README entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,39 @@ pnpm start
 
 See the individual README documents for more information on how to run the individual services.
 
+### Adding a monorepo project
+
+This repository is a multi-package repository, or "monorepo". Most of them are NPM packages for NodeJS. Here's how to add a library:
+
+```sh
+# put the real name here
+LIB=replace-me
+
+# create the library directory
+cd vxsuite
+mkdir -p "libs/${LIB}"
+cd "libs/${LIB}"
+
+mkdir src
+echo /lib >> .gitignore
+
+# initialize it
+pnpm init "@votingworks/${LIB}"
+pnpm i -D typescript jest ts-jest @types/jest @types/node
+pnpx tsc --init
+pnpx ts-jest config:init
+```
+
+- Edit `package.json` as needed, i.e. set `"scripts"` → `"test"` to `"jest"` and `"main"` and `"types"` as appropriate. See existing `libs` for examples.
+- Edit `tsconfig.json` as needed, i.e. set `"composite": true` and `"outDir": "./lib"`. See existing `libs` for examples.
+- Edit `jest.config.js` as needed, i.e. set coverage thresholds and watch ignore globs. See existing `libs` for examples.
+
+To add a workspace package `foo` as a dependency, do this:
+1. Add `"@votingworks/foo": "workspace:*"` to `dependencies` or `devDependencies` as appropriate.
+2. Run `pnpm i`.
+
+If you need to add a `@types/` package it's easier to just copy one of the existing `libs/@types` directories than to do the above.
+
 ## License
 
 GPLv3


### PR DESCRIPTION
Adds a section to the README explaining how to add a project to the monorepo. I tried to keep it non-specific enough that it won't be immediately out of date.

Closes #383 