### PR TITLE
Enforce pollworker election hash matches the election in bmd

### DIFF
--- a/apps/bmd/src/AppEndToEnd.test.tsx
+++ b/apps/bmd/src/AppEndToEnd.test.tsx
@@ -20,6 +20,7 @@ import {
   getNewVoterCard,
   getUsedVoterCard,
   pollWorkerCardForElection,
+  getInvalidPollWorkerCard,
 } from '../test/helpers/smartcards'
 
 import {
@@ -71,6 +72,7 @@ it('VxMark+Print end-to-end flow', async () => {
   const pollWorkerCard = pollWorkerCardForElection(
     electionDefinition.electionHash
   )
+  const invalidPollWorkerCard = getInvalidPollWorkerCard()
   const getByTextWithMarkup = withMarkup(getByText)
 
   card.removeCard()
@@ -125,6 +127,14 @@ it('VxMark+Print end-to-end flow', async () => {
   getByText('Insert Poll Worker card to open.')
 
   // ---------------
+
+  // Using an invalid Poll Worker Card shows an error
+  card.insertCard(invalidPollWorkerCard)
+  await advanceTimersAndPromises()
+  getByText('Invalid Card Data')
+  getByText('Card is not configured for this election.')
+  getByText('Please ask admin for assistance.')
+  card.removeCard()
 
   // Open Polls with Poll Worker Card
   card.insertCard(pollWorkerCard)

--- a/apps/bmd/src/pages/WrongElectionScreen.tsx
+++ b/apps/bmd/src/pages/WrongElectionScreen.tsx
@@ -5,10 +5,12 @@ import Screen from '../components/Screen'
 
 interface Props {
   useEffectToggleLargeDisplay: () => void
+  isVoterCard: boolean
 }
 
 const WrongElectionScreen: React.FC<Props> = ({
   useEffectToggleLargeDisplay,
+  isVoterCard,
 }: Props) => {
   useEffect(useEffectToggleLargeDisplay, [])
 
@@ -19,7 +21,9 @@ const WrongElectionScreen: React.FC<Props> = ({
           <Prose textCenter>
             <h1>Invalid Card Data</h1>
             <p>Card is not configured for this election.</p>
-            <p>Please ask poll worker for assistance.</p>
+            <p>
+              Please ask {isVoterCard ? 'poll worker' : 'admin'} for assistance.
+            </p>
           </Prose>
         </MainChild>
       </Main>

--- a/apps/bmd/test/helpers/smartcards.ts
+++ b/apps/bmd/test/helpers/smartcards.ts
@@ -133,6 +133,12 @@ export const pollWorkerCardForElection = (electionHash: string): string =>
     h: electionHash,
   })
 
+export const getInvalidPollWorkerCard = (): string =>
+  JSON.stringify({
+    t: 'pollworker',
+    h: 'notanelectionhash',
+  })
+
 export const createVoterCard = (
   cardData: Partial<VoterCardData> = {}
 ): string => {

--- a/apps/module-smartcards/writePollWorkerCard.py
+++ b/apps/module-smartcards/writePollWorkerCard.py
@@ -6,7 +6,11 @@ from smartcards.core import CardInterface
 import time
 time.sleep(2)
 
-short_value = json.dumps({'t':'pollworker', 'h': 'fixme'})
+f = open(sys.argv[1], "rb")
+election_bytes = f.read()
+f.close()
+
+short_value = json.dumps({'t':'pollworker', 'h': hashlib.sha256(election_bytes).hexdigest()})
 
 print(CardInterface.card)
 CardInterface.override_protection()


### PR DESCRIPTION
@eventualbuddha I saw Ben's comment in slack that you are working on this after I started playing around so if you had a different plan hear, I'm happy to abandon this. 

Reuses the "wrong election" screen when a voter card is for the wrong election for showing when a pollworker card is inserted with the wrong election hash. I change the text to "Ask a pollworker for assistance" to "Ask an admin for assistance" in this case. 

Also updates the writePollWorkerCard.py script to write the election hash. 

![Screen Shot 2021-03-19 at 9 50 34 AM](https://user-images.githubusercontent.com/14897017/111817986-e64c4a80-889b-11eb-8c40-81bde9de8be7.png)
