### PR TITLE
feat(bmd): add undervotes to tally computation

### DIFF
--- a/apps/bmd/src/AppCardlessVoting.test.tsx
+++ b/apps/bmd/src/AppCardlessVoting.test.tsx
@@ -164,7 +164,7 @@ test('Cardless Voting Flow', async () => {
   fireEvent.click(within(getByTestId('precincts')).getByText('12'))
   getByText('Ballot style 12 has been activated.')
 
-  // Poll Workder removes their card
+  // Poll Worker removes their card
   card.removeCard()
   await advanceTimersAndPromises()
 
@@ -259,17 +259,12 @@ test('Another Voter submits blank ballot and clicks Done', async () => {
   getByTextWithMarkup('Your ballot has 21 contests.')
   fireEvent.click(getByText('Start Voting'))
 
-  // Voter makes selection in first contest and then advances to review screen
+  // Voter advances through contests without voting in any
   for (let i = 0; i < voterContests.length; i++) {
     const { title } = voterContests[i]
 
     await advanceTimersAndPromises()
     getByText(title)
-
-    // Vote for a candidate contest
-    if (title === presidentContest.title) {
-      fireEvent.click(getByText(presidentContest.candidates[0].name))
-    }
 
     fireEvent.click(getByText('Next'))
   }

--- a/apps/bmd/src/config/types.ts
+++ b/apps/bmd/src/config/types.ts
@@ -90,16 +90,20 @@ export type TallyCount = number
 export interface CandidateVoteTally {
   candidates: TallyCount[]
   writeIns: WriteInCandidateTally[]
+  undervotes: TallyCount
 }
 export interface YesNoVoteTally {
   yes: TallyCount
   no: TallyCount
+  undervotes: TallyCount
 }
 export interface MsEitherNeitherTally {
   eitherOption: TallyCount
   neitherOption: TallyCount
+  eitherNeitherUndervotes: TallyCount
   firstOption: TallyCount
   secondOption: TallyCount
+  pickOneUndervotes: TallyCount
 }
 export type Tally = (
   | CandidateVoteTally

--- a/apps/bmd/src/utils/eitherNeither.test.ts
+++ b/apps/bmd/src/utils/eitherNeither.test.ts
@@ -12,153 +12,187 @@ const measure420Index = election.contests.findIndex(
 const zeroTally = getZeroTally(election)
 
 test('counts first option without first answer', () => {
-  const { tally, contestIds } = computeTallyForEitherNeitherContests({
+  const tally = computeTallyForEitherNeitherContests({
     election,
     tally: zeroTally,
     votes: {
       '420A': [],
       '420B': ['yes'],
     },
+    contests: election.contests,
   })
 
-  expect(contestIds).toEqual(['420A', '420B'])
   expect(tally[measure420Index]).toEqual({
     eitherOption: 0,
     neitherOption: 0,
+    eitherNeitherUndervotes: 1,
     firstOption: 1,
     secondOption: 0,
+    pickOneUndervotes: 0,
   })
 })
 
 test('counts second option without first answer', () => {
-  const { tally, contestIds } = computeTallyForEitherNeitherContests({
+  const tally = computeTallyForEitherNeitherContests({
     election,
     tally: zeroTally,
     votes: {
       '420A': [],
       '420B': ['no'],
     },
+    contests: election.contests,
   })
 
-  expect(contestIds).toEqual(['420A', '420B'])
   expect(tally[measure420Index]).toEqual({
     eitherOption: 0,
     neitherOption: 0,
+    eitherNeitherUndervotes: 1,
     firstOption: 0,
     secondOption: 1,
+    pickOneUndervotes: 0,
   })
 })
 
 test('counts first option with either answer', () => {
-  const { tally, contestIds } = computeTallyForEitherNeitherContests({
+  const tally = computeTallyForEitherNeitherContests({
     election,
     tally: zeroTally,
     votes: {
       '420A': ['yes'],
       '420B': ['yes'],
     },
+    contests: election.contests,
   })
 
-  expect(contestIds).toEqual(['420A', '420B'])
   expect(tally[measure420Index]).toEqual({
     eitherOption: 1,
     neitherOption: 0,
+    eitherNeitherUndervotes: 0,
     firstOption: 1,
     secondOption: 0,
+    pickOneUndervotes: 0,
   })
 })
 
 test('counts second option with either answer', () => {
-  const { tally, contestIds } = computeTallyForEitherNeitherContests({
+  const tally = computeTallyForEitherNeitherContests({
     election,
     tally: zeroTally,
     votes: {
       '420A': ['yes'],
       '420B': ['no'],
     },
+    contests: election.contests,
   })
 
-  expect(contestIds).toEqual(['420A', '420B'])
   expect(tally[measure420Index]).toEqual({
     eitherOption: 1,
     neitherOption: 0,
+    eitherNeitherUndervotes: 0,
     firstOption: 0,
     secondOption: 1,
+    pickOneUndervotes: 0,
   })
 })
 
 test('counts first option with neither answer', () => {
-  const { tally, contestIds } = computeTallyForEitherNeitherContests({
+  const tally = computeTallyForEitherNeitherContests({
     election,
     tally: zeroTally,
     votes: {
       '420A': ['no'],
       '420B': ['yes'],
     },
+    contests: election.contests,
   })
 
-  expect(contestIds).toEqual(['420A', '420B'])
   expect(tally[measure420Index]).toEqual({
     eitherOption: 0,
     neitherOption: 1,
+    eitherNeitherUndervotes: 0,
     firstOption: 1,
     secondOption: 0,
+    pickOneUndervotes: 0,
   })
 })
 
 test('counts second option with neither answer', () => {
-  const { tally, contestIds } = computeTallyForEitherNeitherContests({
+  const tally = computeTallyForEitherNeitherContests({
     election,
     tally: zeroTally,
     votes: {
       '420A': ['no'],
       '420B': ['no'],
     },
+    contests: election.contests,
   })
 
-  expect(contestIds).toEqual(['420A', '420B'])
   expect(tally[measure420Index]).toEqual({
     eitherOption: 0,
     neitherOption: 1,
+    eitherNeitherUndervotes: 0,
     firstOption: 0,
     secondOption: 1,
+    pickOneUndervotes: 0,
   })
 })
 
-test('refuses to count either option with no selected preference', () => {
-  const { tally, contestIds } = computeTallyForEitherNeitherContests({
+test('counts either option with no selected preference', () => {
+  const tally = computeTallyForEitherNeitherContests({
     election,
     tally: zeroTally,
     votes: {
       '420A': ['yes'],
       '420B': [],
     },
+    contests: election.contests,
   })
 
-  expect(contestIds).toEqual(['420A', '420B'])
   expect(tally[measure420Index]).toEqual({
-    eitherOption: 0,
+    eitherOption: 1,
     neitherOption: 0,
+    eitherNeitherUndervotes: 0,
     firstOption: 0,
     secondOption: 0,
+    pickOneUndervotes: 1,
   })
 })
 
 test('happily counts neither option with no selected preference', () => {
-  const { tally, contestIds } = computeTallyForEitherNeitherContests({
+  const tally = computeTallyForEitherNeitherContests({
     election,
     tally: zeroTally,
     votes: {
       '420A': ['no'],
       '420B': [],
     },
+    contests: election.contests,
   })
 
-  expect(contestIds).toEqual(['420A', '420B'])
   expect(tally[measure420Index]).toEqual({
     eitherOption: 0,
     neitherOption: 1,
+    eitherNeitherUndervotes: 0,
     firstOption: 0,
     secondOption: 0,
+    pickOneUndervotes: 1,
+  })
+})
+
+test('counts missing contests from votes dict as undervotes', () => {
+  const tally = computeTallyForEitherNeitherContests({
+    election,
+    tally: zeroTally,
+    votes: {},
+    contests: election.contests,
+  })
+
+  expect(tally[measure420Index]).toEqual({
+    eitherOption: 0,
+    neitherOption: 0,
+    eitherNeitherUndervotes: 1,
+    firstOption: 0,
+    secondOption: 0,
+    pickOneUndervotes: 1,
   })
 })

--- a/apps/bmd/src/utils/election.ts
+++ b/apps/bmd/src/utils/election.ts
@@ -4,15 +4,17 @@ import { Tally } from '../config/types'
 export const getZeroTally = (election: Election): Tally =>
   election.contests.map((contest) => {
     if (contest.type === 'yesno') {
-      return { yes: 0, no: 0 }
+      return { yes: 0, no: 0, undervotes: 0 }
     }
 
     if (contest.type === 'ms-either-neither') {
       return {
         eitherOption: 0,
         neitherOption: 0,
+        eitherNeitherUndervotes: 0,
         firstOption: 0,
         secondOption: 0,
+        pickOneUndervotes: 0,
       }
     }
 
@@ -21,6 +23,7 @@ export const getZeroTally = (election: Election): Tally =>
       return {
         candidates: contest.candidates.map(() => 0),
         writeIns: [],
+        undervotes: 0,
       }
     }
 

--- a/apps/bmd/src/utils/tallies.test.ts
+++ b/apps/bmd/src/utils/tallies.test.ts
@@ -1,0 +1,194 @@
+import { CandidateContest, Election } from '@votingworks/types'
+
+import { calculateTally } from './tallies'
+import { getZeroTally } from './election'
+
+import electionSample from '../data/electionSample.json'
+
+const election = electionSample as Election
+
+test('counts missing votes counts as undervotes for appropriate ballot style', () => {
+  const zeroTally = getZeroTally(election)
+  const tally = calculateTally({
+    election,
+    tally: getZeroTally(election),
+    votes: {},
+    ballotStyleId: '12',
+  })
+
+  const contestIdsNotOnBallots = [
+    'primary-constitution-head-of-party',
+    'measure-666',
+  ]
+  let contestIdx = 0
+  election.contests.forEach((contest) => {
+    if (contestIdsNotOnBallots.includes(contest.id)) {
+      expect(tally[contestIdx]).toEqual(zeroTally[contestIdx])
+    } else if (contest.type === 'candidate') {
+      const expectedResults = {
+        candidates: contest.candidates.map(() => 0),
+        writeIns: [],
+        undervotes: contest.seats,
+      }
+      expect(tally[contestIdx]).toEqual(expectedResults)
+    } else if (contest.type === 'yesno') {
+      expect(tally[contestIdx]).toEqual({ yes: 0, no: 0, undervotes: 1 })
+    } else if (contest.type === 'ms-either-neither') {
+      expect(tally[contestIdx]).toEqual({
+        eitherOption: 0,
+        neitherOption: 0,
+        eitherNeitherUndervotes: 1,
+        firstOption: 0,
+        secondOption: 0,
+        pickOneUndervotes: 1,
+      })
+    }
+    contestIdx += 1
+  })
+})
+
+test('adds vote to tally as expected', () => {
+  const contestId = 'primary-constitution-head-of-party'
+  const sampleContest = electionSample.contests.find((c) => c.id === contestId)
+  const alice = sampleContest!.candidates!.find((c) => c.id === 'alice')!
+  const bob = sampleContest!.candidates!.find((c) => c.id === 'bob')!
+  const zeroTally = getZeroTally(election)
+  const tally1 = calculateTally({
+    election,
+    tally: zeroTally,
+    votes: { 'primary-constitution-head-of-party': [alice] },
+    ballotStyleId: '7C',
+  })
+
+  let contestIdx = 0
+  election.contests.forEach((contest) => {
+    if (contest.id !== contestId) {
+      expect(tally1[contestIdx]).toEqual(zeroTally[contestIdx])
+    } else {
+      expect(tally1[contestIdx]).toEqual({
+        candidates: [1, 0],
+        writeIns: [],
+        undervotes: 0,
+      })
+    }
+    contestIdx += 1
+  })
+
+  const tally2 = calculateTally({
+    election,
+    tally: tally1,
+    votes: { 'primary-constitution-head-of-party': [bob] },
+    ballotStyleId: '7C',
+  })
+
+  contestIdx = 0
+  election.contests.forEach((contest) => {
+    if (contest.id !== contestId) {
+      expect(tally2[contestIdx]).toEqual(zeroTally[contestIdx])
+    } else {
+      expect(tally2[contestIdx]).toEqual({
+        candidates: [1, 1],
+        writeIns: [],
+        undervotes: 0,
+      })
+    }
+    contestIdx += 1
+  })
+
+  const tally3 = calculateTally({
+    election,
+    tally: tally2,
+    votes: { 'primary-constitution-head-of-party': [] },
+    ballotStyleId: '7C',
+  })
+
+  contestIdx = 0
+  election.contests.forEach((contest) => {
+    if (contest.id !== contestId) {
+      expect(tally3[contestIdx]).toEqual(zeroTally[contestIdx])
+    } else {
+      expect(tally3[contestIdx]).toEqual({
+        candidates: [1, 1],
+        writeIns: [],
+        undervotes: 1,
+      })
+    }
+    contestIdx += 1
+  })
+})
+
+test('tallies votes across many contests appropriately', () => {
+  const tally = calculateTally({
+    election,
+    tally: getZeroTally(election),
+    votes: {
+      president: [(election.contests[0] as CandidateContest).candidates[2]!],
+      senator: [], // explicit undervote
+      'representative-district-6': [
+        (election.contests[2] as CandidateContest).candidates[0]!,
+      ],
+      'county-commissioners': [
+        (election.contests[8] as CandidateContest).candidates[0]!,
+        (election.contests[8] as CandidateContest).candidates[1]!,
+      ], // 2 votes in a 4 seat contest
+      'county-registrar-of-wills': [
+        { id: 'write_in_vote', name: 'WRITE IN', isWriteIn: true },
+      ], // write in
+      'judicial-robert-demergue': ['yes'],
+      'judicial-elmer-hull': ['no'],
+      'question-a': [],
+      '420A': ['yes'],
+      '420B': [],
+    },
+    ballotStyleId: '12',
+  })
+
+  expect(tally[0]).toEqual({
+    candidates: [0, 0, 1, 0, 0, 0],
+    writeIns: [],
+    undervotes: 0,
+  })
+  expect(tally[1]).toEqual({
+    candidates: [0, 0, 0, 0, 0, 0, 0],
+    writeIns: [],
+    undervotes: 1,
+  })
+  expect(tally[2]).toEqual({
+    candidates: [1, 0, 0, 0, 0],
+    writeIns: [],
+    undervotes: 0,
+  })
+  expect(tally[8]).toEqual({
+    candidates: [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    writeIns: [],
+    undervotes: 2,
+  })
+  expect(tally[9]).toEqual({
+    candidates: [0],
+    writeIns: [{ name: 'WRITE IN', tally: 1 }],
+    undervotes: 0,
+  })
+  expect(tally[12]).toEqual({
+    yes: 1,
+    no: 0,
+    undervotes: 0,
+  })
+  expect(tally[13]).toEqual({
+    yes: 0,
+    no: 1,
+    undervotes: 0,
+  })
+  expect(tally[14]).toEqual({
+    yes: 0,
+    no: 0,
+    undervotes: 1,
+  })
+  expect(tally[20]).toEqual({
+    eitherOption: 1,
+    neitherOption: 0,
+    eitherNeitherUndervotes: 0,
+    firstOption: 0,
+    secondOption: 0,
+    pickOneUndervotes: 1,
+  })
+})

--- a/apps/bmd/src/utils/tallies.ts
+++ b/apps/bmd/src/utils/tallies.ts
@@ -1,0 +1,97 @@
+import {
+  CandidateVote,
+  Election,
+  getBallotStyle,
+  getContests,
+  VotesDict,
+  YesNoVote,
+} from '@votingworks/types'
+import { CandidateVoteTally, Tally, YesNoVoteTally } from '../config/types'
+import { computeTallyForEitherNeitherContests } from './eitherNeither'
+import { getSingleYesNoVote } from './votes'
+
+export const calculateTally = ({
+  election,
+  tally: prevTally,
+  votes,
+  ballotStyleId,
+}: {
+  election: Election
+  tally: Tally
+  votes: VotesDict
+  ballotStyleId: string
+}): Tally => {
+  const ballotStyle = getBallotStyle({
+    ballotStyleId,
+    election,
+  })!
+  const contestsForBallotStyle = getContests({
+    election,
+    ballotStyle,
+  })
+  // first update the tally for either-neither contests
+  const tally = computeTallyForEitherNeitherContests({
+    election,
+    tally: prevTally,
+    votes,
+    contests: contestsForBallotStyle,
+  })
+
+  for (const contest of contestsForBallotStyle) {
+    if (contest.type === 'ms-either-neither') {
+      continue
+    }
+
+    const contestIndex = election.contests.findIndex((c) => c.id === contest.id)
+    /* istanbul ignore next */
+    if (contestIndex < 0) {
+      throw new Error(`No contest found for contestId: ${contest.id}`)
+    }
+    const contestTally = tally[contestIndex]
+    /* istanbul ignore else */
+    if (contest.type === 'yesno') {
+      const yesnoContestTally = contestTally as YesNoVoteTally
+      const vote = votes[contest.id] as YesNoVote
+      const yesnovote = getSingleYesNoVote(vote)!
+      if (yesnovote === undefined) {
+        yesnoContestTally.undervotes++
+      } else {
+        yesnoContestTally[yesnovote]++
+      }
+    } else if (contest.type === 'candidate') {
+      const candidateContestTally = contestTally as CandidateVoteTally
+      const vote = (votes[contest.id] ?? []) as CandidateVote
+      vote.forEach((candidate) => {
+        if (candidate.isWriteIn) {
+          const tallyContestWriteIns = candidateContestTally.writeIns
+          const writeIn = tallyContestWriteIns.find(
+            (c) => c.name === candidate.name
+          )
+          if (typeof writeIn === 'undefined') {
+            tallyContestWriteIns.push({
+              name: candidate.name,
+              tally: 1,
+            })
+          } else {
+            writeIn.tally++
+          }
+        } else {
+          const candidateIndex = contest.candidates.findIndex(
+            (c) => c.id === candidate.id
+          )
+          if (
+            candidateIndex < 0 ||
+            candidateIndex >= candidateContestTally.candidates.length
+          ) {
+            throw new Error(
+              `unable to find a candidate with id: ${candidate.id}`
+            )
+          }
+          candidateContestTally.candidates[candidateIndex]++
+        }
+      })
+      candidateContestTally.undervotes += contest.seats - vote.length
+    }
+  }
+  return tally
+}


### PR DESCRIPTION
Adds undervotes to the Tally object computed in bmd (note this does not yet change the printed tally report). Doing this to prepare for writing this object to poll worker cards for results accumulation. 

Also updates either/neither tallying to just tally the two contests separately. 