### PR TITLE
refactor(types): unify election definition

### DIFF
--- a/apps/bmd/src/AppRoot.tsx
+++ b/apps/bmd/src/AppRoot.tsx
@@ -10,7 +10,7 @@ import {
   getBallotStyle,
   getContests,
   getPrecinctById,
-  parseElection,
+  safeParseElectionDefinition,
 } from '@votingworks/types'
 import { decodeBallot, encodeBallot } from '@votingworks/ballot-encoder'
 import 'normalize.css'
@@ -19,7 +19,6 @@ import Gamepad from 'react-gamepad'
 import { RouteComponentProps } from 'react-router-dom'
 import './App.css'
 import IdleTimer from 'react-idle-timer'
-import { sha256 } from 'js-sha256'
 import { map } from 'rxjs/operators'
 import useInterval from '@rooks/use-interval'
 
@@ -620,13 +619,10 @@ const AppRoot: React.FC<Props> = ({
     const electionData = await card.readLongString()
     /* istanbul ignore else */
     if (electionData) {
-      const computedElectionHash = sha256(electionData)
+      const electionDefinitionResult = safeParseElectionDefinition(electionData)
       dispatchAppState({
         type: 'updateElectionDefinition',
-        electionDefinition: {
-          election: parseElection(electionData),
-          electionHash: computedElectionHash,
-        },
+        electionDefinition: electionDefinitionResult.unwrap(),
       })
     }
   }, [card, adminCardElectionHash])

--- a/apps/bmd/src/data/index.ts
+++ b/apps/bmd/src/data/index.ts
@@ -5,9 +5,7 @@ import {
 import { readFileSync } from 'fs'
 import { join } from 'path'
 
-function electionDefinitionFromFile(
-  path: string
-): ElectionDefinition & { electionData: string } {
+function electionDefinitionFromFile(path: string): ElectionDefinition {
   const electionData = readFileSync(path, 'utf-8')
   return {
     ...safeParseElectionDefinition(electionData).unwrap(),

--- a/apps/bsd/src/AppRoot.tsx
+++ b/apps/bsd/src/AppRoot.tsx
@@ -1,12 +1,14 @@
 import React, { useEffect, useState, useCallback } from 'react'
 import { Route, Switch, useHistory } from 'react-router-dom'
 import pluralize from 'pluralize'
-import { MarkThresholds, Optional } from '@votingworks/types'
+import {
+  ElectionDefinition,
+  MarkThresholds,
+  Optional,
+} from '@votingworks/types'
 import styled from 'styled-components'
 
 import { ScanStatusResponse, MachineConfig } from './config/types'
-import { ElectionDefinition } from './util/ballot-package'
-
 import AppContext from './contexts/AppContext'
 
 import {
@@ -59,7 +61,6 @@ const App: React.FC = () => {
     setElectionDefinition,
   ] = useState<ElectionDefinition>()
   const [electionJustLoaded, setElectionJustLoaded] = useState(false)
-  const [electionHash, setElectionHash] = useState<string>()
   const [isTestMode, setTestMode] = useState(false)
   const [isTogglingTestMode, setTogglingTestMode] = useState(false)
   const [status, setStatus] = useState<ScanStatusResponse>({
@@ -129,7 +130,6 @@ const App: React.FC = () => {
   const updateStatus = useCallback(async () => {
     try {
       const newStatus = await fetchJSON<ScanStatusResponse>('/scan/status')
-      setElectionHash(newStatus.electionHash)
       setStatus((prevStatus) => {
         if (JSON.stringify(prevStatus) === JSON.stringify(newStatus)) {
           return prevStatus
@@ -297,7 +297,6 @@ const App: React.FC = () => {
             usbDriveEject: doEject,
             machineConfig,
             electionDefinition,
-            electionHash,
           }}
         >
           <Screen>
@@ -330,7 +329,6 @@ const App: React.FC = () => {
             usbDriveStatus: displayUsbStatus,
             usbDriveEject: doEject,
             electionDefinition,
-            electionHash,
             machineConfig,
           }}
         >
@@ -357,7 +355,6 @@ const App: React.FC = () => {
           usbDriveStatus: displayUsbStatus,
           usbDriveEject: doEject,
           electionDefinition,
-          electionHash,
           machineConfig,
         }}
       >

--- a/apps/bsd/src/api/config.test.ts
+++ b/apps/bsd/src/api/config.test.ts
@@ -1,14 +1,6 @@
 import fetchMock from 'fetch-mock'
-import { electionSampleDefinition } from '@votingworks/fixtures'
+import { electionSampleDefinition as testElectionDefinition } from '@votingworks/fixtures'
 import * as config from './config'
-import { ElectionDefinition } from '../util/ballot-package'
-
-// TODO: Replace this with something straight from `@votingworks/fixtures` when
-// all ElectionDefinition interface definitions are shared.
-const testElectionDefinition: ElectionDefinition = {
-  ...electionSampleDefinition,
-  electionData: JSON.stringify(electionSampleDefinition.election),
-}
 
 test('GET /config', async () => {
   fetchMock.getOnce(

--- a/apps/bsd/src/api/config.ts
+++ b/apps/bsd/src/api/config.ts
@@ -1,6 +1,5 @@
-import { MarkThresholds } from '@votingworks/types'
+import { ElectionDefinition, MarkThresholds } from '@votingworks/types'
 import { ErrorResponse, GetConfigResponse, OkResponse } from '../config/types'
-import { ElectionDefinition } from '../util/ballot-package'
 import fetchJSON from '../util/fetchJSON'
 
 export async function get(): Promise<GetConfigResponse> {

--- a/apps/bsd/src/api/hmpb.test.ts
+++ b/apps/bsd/src/api/hmpb.test.ts
@@ -1,7 +1,5 @@
-import { electionSample as election } from '@votingworks/fixtures'
+import { electionSampleDefinition as electionDefinition } from '@votingworks/fixtures'
 import fetchMock from 'fetch-mock'
-import { sha256 } from 'js-sha256'
-import { ElectionDefinition } from '../util/ballot-package'
 import {
   addTemplates,
   fetchBallotInfo,
@@ -12,14 +10,6 @@ import * as config from './config'
 
 jest.mock('./config')
 const configMock = config as jest.Mocked<typeof config>
-
-const electionData = JSON.stringify(election)
-const electionHash = sha256(electionData)
-const electionDefinition: ElectionDefinition = {
-  election,
-  electionData,
-  electionHash,
-}
 
 test('configures the server with the contained election', async () => {
   configMock.setElectionDefinition.mockResolvedValueOnce()

--- a/apps/bsd/src/api/hmpb.ts
+++ b/apps/bsd/src/api/hmpb.ts
@@ -1,10 +1,7 @@
+import { ElectionDefinition } from '@votingworks/types'
 import { EventEmitter } from 'events'
 import { ReviewBallot, BallotSheetInfo } from '../config/types'
-import {
-  BallotPackage,
-  BallotPackageEntry,
-  ElectionDefinition,
-} from '../util/ballot-package'
+import { BallotPackage, BallotPackageEntry } from '../util/ballot-package'
 import fetchJSON from '../util/fetchJSON'
 import { setElectionDefinition } from './config'
 

--- a/apps/bsd/src/components/ExportResultsModal.test.tsx
+++ b/apps/bsd/src/components/ExportResultsModal.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { render, fireEvent, waitFor } from '@testing-library/react'
-import { electionSampleDefinition } from '@votingworks/fixtures'
+import { electionSampleDefinition as electionDefinition } from '@votingworks/fixtures'
 import { Router } from 'react-router-dom'
 import { createMemoryHistory } from 'history'
 import fetchMock from 'fetch-mock'
@@ -10,14 +10,6 @@ import { fakeKiosk, fakeUsbDrive } from '@votingworks/test-utils'
 import { UsbDriveStatus } from '../lib/usbstick'
 import ExportResultsModal from './ExportResultsModal'
 import fakeFileWriter from '../../test/helpers/fakeFileWriter'
-import { ElectionDefinition } from '../util/ballot-package'
-
-// TODO: Replace this with something straight from `@votingworks/fixtures` when
-// all ElectionDefinition interface definitions are shared.
-const electionDefinition: ElectionDefinition = {
-  ...electionSampleDefinition,
-  electionData: JSON.stringify(electionSampleDefinition.election),
-}
 
 test('renders loading screen when usb drive is mounting or ejecting in export modal', () => {
   const usbStatuses = [UsbDriveStatus.present, UsbDriveStatus.ejecting]

--- a/apps/bsd/src/components/ExportResultsModal.tsx
+++ b/apps/bsd/src/components/ExportResultsModal.tsx
@@ -1,3 +1,4 @@
+import { ElectionDefinition } from '@votingworks/types'
 import React, { useContext, useState } from 'react'
 import styled from 'styled-components'
 import fileDownload from 'js-file-download'
@@ -16,7 +17,6 @@ import {
   generateFilenameForScanningResults,
   SCANNER_RESULTS_FOLDER,
 } from '../util/filenames'
-import { ElectionDefinition } from '../util/ballot-package'
 
 function throwBadStatus(s: never): never {
   throw new Error(`Bad status: ${s}`)

--- a/apps/bsd/src/config/types.ts
+++ b/apps/bsd/src/config/types.ts
@@ -1,6 +1,7 @@
 import type {
   AdjudicationReason,
   Dictionary,
+  ElectionDefinition,
   MarkThresholds,
   VotesDict,
 } from '@votingworks/types'
@@ -10,7 +11,6 @@ import type {
   BallotPageMetadata,
   Size,
 } from '@votingworks/hmpb-interpreter'
-import { ElectionDefinition } from '../util/ballot-package'
 import type { AdjudicationInfo } from './types/ballot-review'
 
 export interface MachineConfig {

--- a/apps/bsd/src/contexts/AppContext.ts
+++ b/apps/bsd/src/contexts/AppContext.ts
@@ -1,6 +1,6 @@
+import { ElectionDefinition } from '@votingworks/types'
 import { createContext } from 'react'
 import { MachineConfig } from '../config/types'
-import { ElectionDefinition } from '../util/ballot-package'
 
 interface AppContextInterface {
   usbDriveStatus: string

--- a/apps/bsd/src/screens/AdvancedOptionsScreen.test.tsx
+++ b/apps/bsd/src/screens/AdvancedOptionsScreen.test.tsx
@@ -3,16 +3,8 @@ import { render, waitFor } from '@testing-library/react'
 import { createMemoryHistory } from 'history'
 import { Router } from 'react-router-dom'
 import { act } from 'react-dom/test-utils'
-import { electionSampleDefinition } from '@votingworks/fixtures'
+import { electionSampleDefinition as testElectionDefinition } from '@votingworks/fixtures'
 import AdvancedOptionsScreen from './AdvancedOptionsScreen'
-import { ElectionDefinition } from '../util/ballot-package'
-
-// TODO: Replace this with something straight from `@votingworks/fixtures` when
-// all ElectionDefinition interface definitions are shared.
-const testElectionDefinition: ElectionDefinition = {
-  ...electionSampleDefinition,
-  electionData: JSON.stringify(electionSampleDefinition.election),
-}
 
 test('clicking "Export Backup…" shows progress', async () => {
   const backup = jest.fn()

--- a/apps/bsd/src/screens/AdvancedOptionsScreen.tsx
+++ b/apps/bsd/src/screens/AdvancedOptionsScreen.tsx
@@ -1,4 +1,8 @@
-import { MarkThresholds, Optional } from '@votingworks/types'
+import {
+  ElectionDefinition,
+  MarkThresholds,
+  Optional,
+} from '@votingworks/types'
 import React, { useCallback, useEffect, useState } from 'react'
 import Button from '../components/Button'
 import LinkButton from '../components/LinkButton'
@@ -9,7 +13,6 @@ import Prose from '../components/Prose'
 import Screen from '../components/Screen'
 import ToggleTestModeButton from '../components/ToggleTestModeButton'
 import SetMarkThresholdsModal from '../components/SetMarkThresholdsModal'
-import { ElectionDefinition } from '../util/ballot-package'
 
 interface Props {
   unconfigureServer: () => Promise<void>

--- a/apps/bsd/src/util/ballot-package.ts
+++ b/apps/bsd/src/util/ballot-package.ts
@@ -1,7 +1,7 @@
 import {
   BallotStyle,
   Contest,
-  Election,
+  ElectionDefinition,
   parseElection,
   Precinct,
 } from '@votingworks/types'
@@ -13,12 +13,6 @@ import { sha256 } from 'js-sha256'
 export interface BallotPackage {
   electionDefinition: ElectionDefinition
   ballots: BallotPackageEntry[]
-}
-
-export interface ElectionDefinition {
-  election: Election
-  electionData: string
-  electionHash: string
 }
 
 export interface BallotPackageEntry {

--- a/apps/bsd/test/renderInAppContext.tsx
+++ b/apps/bsd/test/renderInAppContext.tsx
@@ -2,12 +2,12 @@ import { createMemoryHistory, MemoryHistory } from 'history'
 import { render as testRender } from '@testing-library/react'
 import type { RenderResult } from '@testing-library/react'
 import React from 'react'
-
-import { electionSampleDefinition } from '@votingworks/fixtures'
 import { Router } from 'react-router-dom'
+import { electionSampleDefinition as testElectionDefinition } from '@votingworks/fixtures'
+import { ElectionDefinition } from '@votingworks/types'
+
 import { UsbDriveStatus } from '../src/lib/usbstick'
 import AppContext from '../src/contexts/AppContext'
-import { ElectionDefinition } from '../src/util/ballot-package'
 
 interface RenderInAppContextParams {
   route?: string | undefined
@@ -16,13 +16,6 @@ interface RenderInAppContextParams {
   machineId?: string
   usbDriveStatus?: UsbDriveStatus
   usbDriveEject?: () => void
-}
-
-// TODO: Replace this with something straight from `@votingworks/fixtures` when
-// all ElectionDefinition interface definitions are shared.
-const testElectionDefinition: ElectionDefinition = {
-  ...electionSampleDefinition,
-  electionData: JSON.stringify(electionSampleDefinition.election),
 }
 
 export default function renderInAppContext(

--- a/apps/election-manager/src/App.test.tsx
+++ b/apps/election-manager/src/App.test.tsx
@@ -11,6 +11,7 @@ import {
 } from '@testing-library/react'
 import { electionWithMsEitherNeitherWithDataFiles } from '@votingworks/fixtures'
 import { fakeKiosk, fakeUsbDrive } from '@votingworks/test-utils'
+import { ElectionDefinition } from '@votingworks/types'
 
 import { MemoryStorage } from './utils/Storage'
 import {
@@ -25,7 +26,6 @@ import CastVoteRecordFiles from './utils/CastVoteRecordFiles'
 import App from './App'
 
 import sleep from './utils/sleep'
-import { ElectionDefinition } from './config/types'
 import fakeFileWriter from '../test/helpers/fakeFileWriter'
 import { convertFileToStorageString } from './utils/file'
 import { eitherNeitherElectionDefinition } from '../test/renderInAppContext'

--- a/apps/election-manager/src/AppRoot.tsx
+++ b/apps/election-manager/src/AppRoot.tsx
@@ -5,7 +5,7 @@ import { RouteComponentProps } from 'react-router-dom'
 import 'normalize.css'
 import { sha256 } from 'js-sha256'
 
-import { parseElection } from '@votingworks/types'
+import { ElectionDefinition, parseElection } from '@votingworks/types'
 
 import {
   getStatus as usbDriveGetStatus,
@@ -27,7 +27,6 @@ import { Storage } from './utils/Storage'
 
 import ElectionManager from './components/ElectionManager'
 import {
-  ElectionDefinition,
   SaveElection,
   PrintedBallot,
   ISO8601Timestamp,

--- a/apps/election-manager/src/config/types.ts
+++ b/apps/election-manager/src/config/types.ts
@@ -3,7 +3,6 @@ import {
   Candidate,
   Contest,
   Dictionary,
-  Election,
   Optional,
   Precinct,
 } from '@votingworks/types'
@@ -21,12 +20,6 @@ export type ButtonEventFunction = (
 
 // Election
 export type SaveElection = (electionJSON?: string) => void
-
-export interface ElectionDefinition {
-  election: Election
-  electionData: string
-  electionHash: string
-}
 
 export interface BallotStyleData {
   ballotStyleId: BallotStyle['id']

--- a/apps/election-manager/src/contexts/AppContext.ts
+++ b/apps/election-manager/src/contexts/AppContext.ts
@@ -1,6 +1,6 @@
 import { createContext, RefObject } from 'react'
+import { ElectionDefinition } from '@votingworks/types'
 import {
-  ElectionDefinition,
   SaveElection,
   PrintedBallot,
   ISO8601Timestamp,

--- a/apps/election-manager/src/utils/filenames.ts
+++ b/apps/election-manager/src/utils/filenames.ts
@@ -1,7 +1,5 @@
-import { Election } from '@votingworks/types'
+import { Election, ElectionDefinition } from '@votingworks/types'
 import moment from 'moment'
-
-import { ElectionDefinition } from '../config/types'
 
 const SECTION_SEPARATOR = '__'
 const SUBSECTION_SEPARATOR = '_'

--- a/apps/election-manager/test/renderInAppContext.tsx
+++ b/apps/election-manager/test/renderInAppContext.tsx
@@ -5,11 +5,10 @@ import { sha256 } from 'js-sha256'
 import { render as testRender } from '@testing-library/react'
 import type { RenderResult } from '@testing-library/react'
 import { electionWithMsEitherNeitherRawData } from '@votingworks/fixtures'
-import { Election } from '@votingworks/types'
+import { Election, ElectionDefinition } from '@votingworks/types'
 
 import AppContext from '../src/contexts/AppContext'
 import {
-  ElectionDefinition,
   SaveElection,
   PrintedBallot,
   ISO8601Timestamp,

--- a/apps/module-scan/src/importer.ts
+++ b/apps/module-scan/src/importer.ts
@@ -1,5 +1,9 @@
 import { BallotPageLayout, Interpreter } from '@votingworks/hmpb-interpreter'
-import { MarkThresholds, Optional } from '@votingworks/types'
+import {
+  ElectionDefinition,
+  MarkThresholds,
+  Optional,
+} from '@votingworks/types'
 import makeDebug from 'debug'
 import * as fsExtra from 'fs-extra'
 import * as streams from 'memory-streams'
@@ -7,13 +11,7 @@ import { join } from 'path'
 import { v4 as uuid } from 'uuid'
 import { PageInterpretation } from './interpreter'
 import { Scanner } from './scanner'
-import {
-  BallotMetadata,
-  ElectionDefinition,
-  ScanStatus,
-  SheetOf,
-  Side,
-} from './types'
+import { BallotMetadata, ScanStatus, SheetOf, Side } from './types'
 import { writeImageData } from './util/images'
 import pdfToImages from './util/pdfToImages'
 import { Workspace } from './util/workspace'

--- a/apps/module-scan/src/server.test.ts
+++ b/apps/module-scan/src/server.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable jest/expect-expect */
 
-import { electionSampleDefinition } from '@votingworks/fixtures'
+import { electionSampleDefinition as testElectionDefinition } from '@votingworks/fixtures'
 import {
   AdjudicationReason,
   CandidateContest,
@@ -19,16 +19,9 @@ import zeroRect from '../test/fixtures/zeroRect'
 import { makeMockImporter } from '../test/util/mocks'
 import { Importer } from './importer'
 import { buildApp, start } from './server'
-import { ElectionDefinition, ScanStatus } from './types'
+import { ScanStatus } from './types'
 import { MarkStatus } from './types/ballot-review'
 import { createWorkspace, Workspace } from './util/workspace'
-
-// TODO: Replace this with something straight from `@votingworks/fixtures` when
-// all ElectionDefinition interface definitions are shared.
-const testElectionDefinition: ElectionDefinition = {
-  ...electionSampleDefinition,
-  electionData: JSON.stringify(electionSampleDefinition.election),
-}
 
 jest.mock('./importer')
 

--- a/apps/module-scan/src/store.ts
+++ b/apps/module-scan/src/store.ts
@@ -4,6 +4,7 @@
 
 import {
   AnyContest,
+  ElectionDefinition,
   getBallotStyle,
   getContests,
   MarkThresholds,
@@ -33,7 +34,6 @@ import {
   AdjudicationStatus,
   BallotMetadata,
   BatchInfo,
-  ElectionDefinition,
   getMarkStatus,
   isMarginalMark,
   PageInterpretationWithFiles,

--- a/apps/module-scan/src/types.ts
+++ b/apps/module-scan/src/types.ts
@@ -2,7 +2,6 @@ import {
   BallotStyle,
   Contest,
   Dictionary,
-  Election,
   MarkThresholds,
   Precinct,
 } from '@votingworks/types'
@@ -31,12 +30,6 @@ export interface PageInterpretationWithAdjudication<
   interpretation: T
   contestIds?: readonly string[]
   adjudication?: MarksByContestId
-}
-
-export interface ElectionDefinition {
-  election: Election
-  electionData: string
-  electionHash: string
 }
 
 export interface CastVoteRecord

--- a/apps/module-scan/src/util/electionDefinition.ts
+++ b/apps/module-scan/src/util/electionDefinition.ts
@@ -1,5 +1,4 @@
-import { Election, parseElection } from '@votingworks/types'
-import { ElectionDefinition } from '../types'
+import { Election, ElectionDefinition, parseElection } from '@votingworks/types'
 import { createHash } from 'crypto'
 import type * as z from 'zod'
 

--- a/libs/fixtures/src/index.ts
+++ b/libs/fixtures/src/index.ts
@@ -8,9 +8,7 @@ import multiPartyPrimaryElectionUntyped from './data/electionMultiPartyPrimary/e
 import electionSampleLongContentUntyped from './data/electionSampleLongContent.json'
 import electionWithMsEitherNeitherUntyped from './data/electionWithMsEitherNeither/electionWithMsEitherNeither.json'
 
-export function asElectionDefinition(
-  election: Election
-): ElectionDefinition & { electionData: string } {
+export function asElectionDefinition(election: Election): ElectionDefinition {
   const electionData = JSON.stringify(election)
   return {
     election,

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -121,6 +121,7 @@ export interface Election {
 export type OptionalElection = Optional<Election>
 export interface ElectionDefinition {
   election: Election
+  electionData: string
   electionHash: string
 }
 export type OptionalElectionDefinition = Optional<ElectionDefinition>

--- a/libs/types/src/schema.ts
+++ b/libs/types/src/schema.ts
@@ -1,6 +1,7 @@
 import check8601 from '@antongolub/iso8601'
 import { createHash } from 'crypto'
 import * as z from 'zod'
+import { string } from 'zod'
 import * as t from './election'
 import {
   AdjudicationReason as AdjudicationReasonEnum,
@@ -348,6 +349,7 @@ export const Election: z.ZodSchema<t.Election> = z
 export const OptionalElection: z.ZodSchema<t.OptionalElection> = Election.optional()
 export const ElectionDefinition: z.ZodSchema<t.ElectionDefinition> = z.object({
   election: Election,
+  electionData: z.string(),
   electionHash: z.string(),
 })
 export const OptionalElectionDefinition: z.ZodSchema<t.OptionalElectionDefinition> = ElectionDefinition.optional()
@@ -500,6 +502,7 @@ export function safeParseElectionDefinition(
 ): Result<t.ElectionDefinition, z.ZodError | SyntaxError> {
   return safeParseElection(value).map((election) => ({
     election,
+    electionData: value,
     electionHash: createHash('sha256').update(value).digest('hex'),
   }))
 }


### PR DESCRIPTION
Keeps only a single copy of the `ElectionDefinition` interface.