### PR TITLE
refactor(bmd): simplify write ins data in tallies and add ballots cast

### DIFF
--- a/apps/bmd/src/config/types.ts
+++ b/apps/bmd/src/config/types.ts
@@ -82,22 +82,21 @@ export interface SerializableActivationData {
 
 // Votes
 export type YesOrNo = Exclude<YesNoVote[0] | YesNoVote[1], undefined>
-export interface WriteInCandidateTally {
-  name: string
-  tally: number
-}
 export type TallyCount = number
 export interface CandidateVoteTally {
   candidates: TallyCount[]
-  writeIns: WriteInCandidateTally[]
+  writeIns: TallyCount
   undervotes: TallyCount
+  ballotsCast: TallyCount
 }
 export interface YesNoVoteTally {
   yes: TallyCount
   no: TallyCount
   undervotes: TallyCount
+  ballotsCast: TallyCount
 }
 export interface MsEitherNeitherTally {
+  ballotsCast: TallyCount
   eitherOption: TallyCount
   neitherOption: TallyCount
   eitherNeitherUndervotes: TallyCount

--- a/apps/bmd/src/pages/PollWorkerScreen.test.tsx
+++ b/apps/bmd/src/pages/PollWorkerScreen.test.tsx
@@ -237,7 +237,8 @@ test('results combination option is shown with prior tally results when provided
   existingTally[0] = {
     candidates: [5, 5, 5, 5, 5, 0],
     undervotes: 3,
-    writeIns: [],
+    writeIns: 0,
+    ballotsCast: 28,
   }
   const talliesOnCard = {
     tally: existingTally,
@@ -260,7 +261,8 @@ test('results combination option is shown with prior tally results when provided
   currentTally[0] = {
     candidates: [1, 0, 1, 0, 1, 0],
     undervotes: 3,
-    writeIns: [],
+    writeIns: 0,
+    ballotsCast: 6,
   }
 
   const { getByText, getAllByTestId } = render(
@@ -332,7 +334,8 @@ test('results combination option is shown with prior tally results when results 
   existingTally[0] = {
     candidates: [6, 5, 6, 5, 6, 0],
     undervotes: 6,
-    writeIns: [],
+    writeIns: 0,
+    ballotsCast: 34,
   }
   const talliesOnCard = {
     tally: existingTally,
@@ -360,7 +363,8 @@ test('results combination option is shown with prior tally results when results 
   currentTally[0] = {
     candidates: [1, 0, 1, 0, 1, 0],
     undervotes: 3,
-    writeIns: [],
+    writeIns: 0,
+    ballotsCast: 6,
   }
 
   const { getByText, getAllByTestId, queryByText } = render(

--- a/apps/bmd/src/utils/eitherNeither.test.ts
+++ b/apps/bmd/src/utils/eitherNeither.test.ts
@@ -29,6 +29,7 @@ test('counts first option without first answer', () => {
     firstOption: 1,
     secondOption: 0,
     pickOneUndervotes: 0,
+    ballotsCast: 1,
   })
 })
 
@@ -50,6 +51,7 @@ test('counts second option without first answer', () => {
     firstOption: 0,
     secondOption: 1,
     pickOneUndervotes: 0,
+    ballotsCast: 1,
   })
 })
 
@@ -71,6 +73,7 @@ test('counts first option with either answer', () => {
     firstOption: 1,
     secondOption: 0,
     pickOneUndervotes: 0,
+    ballotsCast: 1,
   })
 })
 
@@ -92,6 +95,7 @@ test('counts second option with either answer', () => {
     firstOption: 0,
     secondOption: 1,
     pickOneUndervotes: 0,
+    ballotsCast: 1,
   })
 })
 
@@ -113,6 +117,7 @@ test('counts first option with neither answer', () => {
     firstOption: 1,
     secondOption: 0,
     pickOneUndervotes: 0,
+    ballotsCast: 1,
   })
 })
 
@@ -134,6 +139,7 @@ test('counts second option with neither answer', () => {
     firstOption: 0,
     secondOption: 1,
     pickOneUndervotes: 0,
+    ballotsCast: 1,
   })
 })
 
@@ -155,6 +161,7 @@ test('counts either option with no selected preference', () => {
     firstOption: 0,
     secondOption: 0,
     pickOneUndervotes: 1,
+    ballotsCast: 1,
   })
 })
 
@@ -176,6 +183,7 @@ test('happily counts neither option with no selected preference', () => {
     firstOption: 0,
     secondOption: 0,
     pickOneUndervotes: 1,
+    ballotsCast: 1,
   })
 })
 
@@ -194,5 +202,6 @@ test('counts missing contests from votes dict as undervotes', () => {
     firstOption: 0,
     secondOption: 0,
     pickOneUndervotes: 1,
+    ballotsCast: 1,
   })
 })

--- a/apps/bmd/src/utils/eitherNeither.ts
+++ b/apps/bmd/src/utils/eitherNeither.ts
@@ -36,6 +36,7 @@ export const computeTallyForEitherNeitherContests = ({
       ...newTally[contestIndex],
     } as MsEitherNeitherTally
 
+    eitherNeitherTally.ballotsCast++
     // Tabulate EitherNeither section
     const eitherNeitherVote = votes[contest.eitherNeitherContestId] as YesNoVote
     const singleEitherNeitherVote = getSingleYesNoVote(eitherNeitherVote)

--- a/apps/bmd/src/utils/election.ts
+++ b/apps/bmd/src/utils/election.ts
@@ -4,7 +4,7 @@ import { Tally } from '../config/types'
 export const getZeroTally = (election: Election): Tally =>
   election.contests.map((contest) => {
     if (contest.type === 'yesno') {
-      return { yes: 0, no: 0, undervotes: 0 }
+      return { yes: 0, no: 0, undervotes: 0, ballotsCast: 0 }
     }
 
     if (contest.type === 'ms-either-neither') {
@@ -15,6 +15,7 @@ export const getZeroTally = (election: Election): Tally =>
         firstOption: 0,
         secondOption: 0,
         pickOneUndervotes: 0,
+        ballotsCast: 0,
       }
     }
 
@@ -22,8 +23,9 @@ export const getZeroTally = (election: Election): Tally =>
     if (contest.type === 'candidate') {
       return {
         candidates: contest.candidates.map(() => 0),
-        writeIns: [],
+        writeIns: 0,
         undervotes: 0,
+        ballotsCast: 0,
       }
     }
 

--- a/apps/bmd/src/utils/tallies.test.ts
+++ b/apps/bmd/src/utils/tallies.test.ts
@@ -27,12 +27,18 @@ test('counts missing votes counts as undervotes for appropriate ballot style', (
     } else if (contest.type === 'candidate') {
       const expectedResults = {
         candidates: contest.candidates.map(() => 0),
-        writeIns: [],
+        writeIns: 0,
         undervotes: contest.seats,
+        ballotsCast: 1,
       }
       expect(tally[contestIdx]).toEqual(expectedResults)
     } else if (contest.type === 'yesno') {
-      expect(tally[contestIdx]).toEqual({ yes: 0, no: 0, undervotes: 1 })
+      expect(tally[contestIdx]).toEqual({
+        yes: 0,
+        no: 0,
+        undervotes: 1,
+        ballotsCast: 1,
+      })
     } else if (contest.type === 'ms-either-neither') {
       expect(tally[contestIdx]).toEqual({
         eitherOption: 0,
@@ -41,6 +47,7 @@ test('counts missing votes counts as undervotes for appropriate ballot style', (
         firstOption: 0,
         secondOption: 0,
         pickOneUndervotes: 1,
+        ballotsCast: 1,
       })
     }
     contestIdx += 1
@@ -67,8 +74,9 @@ test('adds vote to tally as expected', () => {
     } else {
       expect(tally1[contestIdx]).toEqual({
         candidates: [1, 0],
-        writeIns: [],
+        writeIns: 0,
         undervotes: 0,
+        ballotsCast: 1,
       })
     }
     contestIdx += 1
@@ -88,8 +96,9 @@ test('adds vote to tally as expected', () => {
     } else {
       expect(tally2[contestIdx]).toEqual({
         candidates: [1, 1],
-        writeIns: [],
+        writeIns: 0,
         undervotes: 0,
+        ballotsCast: 2,
       })
     }
     contestIdx += 1
@@ -109,8 +118,9 @@ test('adds vote to tally as expected', () => {
     } else {
       expect(tally3[contestIdx]).toEqual({
         candidates: [1, 1],
-        writeIns: [],
+        writeIns: 0,
         undervotes: 1,
+        ballotsCast: 3,
       })
     }
     contestIdx += 1
@@ -145,43 +155,51 @@ test('tallies votes across many contests appropriately', () => {
 
   expect(tally[0]).toEqual({
     candidates: [0, 0, 1, 0, 0, 0],
-    writeIns: [],
+    writeIns: 0,
     undervotes: 0,
+    ballotsCast: 1,
   })
   expect(tally[1]).toEqual({
     candidates: [0, 0, 0, 0, 0, 0, 0],
-    writeIns: [],
+    writeIns: 0,
     undervotes: 1,
+    ballotsCast: 1,
   })
   expect(tally[2]).toEqual({
     candidates: [1, 0, 0, 0, 0],
-    writeIns: [],
+    writeIns: 0,
     undervotes: 0,
+    ballotsCast: 1,
   })
   expect(tally[8]).toEqual({
     candidates: [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    writeIns: [],
+    writeIns: 0,
     undervotes: 2,
+    ballotsCast: 1,
   })
   expect(tally[9]).toEqual({
     candidates: [0],
-    writeIns: [{ name: 'WRITE IN', tally: 1 }],
+    writeIns: 1,
     undervotes: 0,
+    ballotsCast: 1,
   })
   expect(tally[12]).toEqual({
     yes: 1,
     no: 0,
     undervotes: 0,
+    ballotsCast: 1,
   })
   expect(tally[13]).toEqual({
     yes: 0,
     no: 1,
     undervotes: 0,
+    ballotsCast: 1,
   })
   expect(tally[14]).toEqual({
     yes: 0,
     no: 0,
     undervotes: 1,
+    ballotsCast: 1,
   })
   expect(tally[20]).toEqual({
     eitherOption: 1,
@@ -190,6 +208,7 @@ test('tallies votes across many contests appropriately', () => {
     firstOption: 0,
     secondOption: 0,
     pickOneUndervotes: 1,
+    ballotsCast: 1,
   })
 })
 
@@ -201,18 +220,14 @@ test('can combine contest tallies as expected', () => {
   tally1[0] = {
     candidates: [11, 2, 5, 1, 0, 0],
     undervotes: 3,
-    writeIns: [
-      { name: 'eevee', tally: 3 },
-      { name: 'flareon', tally: 7 },
-    ],
+    writeIns: 10,
+    ballotsCast: 32,
   }
   tally2[0] = {
     candidates: [3, 0, 2, 1, 5, 0],
     undervotes: 2,
-    writeIns: [
-      { name: 'eevee', tally: 2 },
-      { name: 'jolteon', tally: 3 },
-    ],
+    writeIns: 5,
+    ballotsCast: 18,
   }
 
   // Modify a yes no contest
@@ -220,11 +235,13 @@ test('can combine contest tallies as expected', () => {
     yes: 5,
     no: 17,
     undervotes: 3,
+    ballotsCast: 25,
   }
   tally2[12] = {
     yes: 3,
     no: 2,
     undervotes: 10,
+    ballotsCast: 15,
   }
 
   // Modify an either neither contest
@@ -235,6 +252,7 @@ test('can combine contest tallies as expected', () => {
     firstOption: 18,
     secondOption: 4,
     pickOneUndervotes: 3,
+    ballotsCast: 40,
   }
   tally2[20] = {
     eitherOption: 2,
@@ -243,6 +261,7 @@ test('can combine contest tallies as expected', () => {
     firstOption: 2,
     secondOption: 16,
     pickOneUndervotes: 2,
+    ballotsCast: 35,
   }
 
   const combinedTallies = combineTallies(election, tally1, tally2)
@@ -250,17 +269,15 @@ test('can combine contest tallies as expected', () => {
   expect(combinedTallies[0]).toEqual({
     candidates: [14, 2, 7, 2, 5, 0],
     undervotes: 5,
-    writeIns: [
-      { name: 'eevee', tally: 5 },
-      { name: 'flareon', tally: 7 },
-      { name: 'jolteon', tally: 3 },
-    ],
+    writeIns: 15,
+    ballotsCast: 50,
   })
 
   expect(combinedTallies[12]).toEqual({
     yes: 8,
     no: 19,
     undervotes: 13,
+    ballotsCast: 40,
   })
 
   expect(combinedTallies[20]).toEqual({
@@ -270,6 +287,7 @@ test('can combine contest tallies as expected', () => {
     firstOption: 20,
     secondOption: 20,
     pickOneUndervotes: 5,
+    ballotsCast: 75,
   })
 
   // Everything else should still be a zero tally
@@ -300,7 +318,8 @@ test('combineTallies throws error when given incompatible tallies', () => {
   tally1[0] = {
     candidates: [0, 0, 0],
     undervotes: 0,
-    writeIns: [],
+    writeIns: 0,
+    ballotsCast: 0,
   }
   expect(() => {
     combineTallies(election, tally1, tally2)

--- a/apps/bmd/src/utils/tallies.ts
+++ b/apps/bmd/src/utils/tallies.ts
@@ -26,21 +26,11 @@ const combineCandidateTallies = (
   for (let i = 0; i < tally1.candidates.length; i++) {
     candidates.push(tally1.candidates[i] + tally2.candidates[i])
   }
-  const writeInVotes = [...tally1.writeIns]
-  for (const writeInVote of tally2.writeIns) {
-    const existingWriteInIdx = writeInVotes.findIndex(
-      (v) => v.name === writeInVote.name
-    )
-    if (existingWriteInIdx >= 0) {
-      writeInVotes[existingWriteInIdx].tally += writeInVote.tally
-    } else {
-      writeInVotes.push(writeInVote)
-    }
-  }
   return {
     candidates,
     undervotes: tally1.undervotes + tally2.undervotes,
-    writeIns: writeInVotes,
+    writeIns: tally1.writeIns + tally2.writeIns,
+    ballotsCast: tally1.ballotsCast + tally2.ballotsCast,
   }
 }
 
@@ -52,6 +42,7 @@ const combineYesNoTallies = (
     yes: tally1.yes + tally2.yes,
     no: tally1.no + tally2.no,
     undervotes: tally1.undervotes + tally2.undervotes,
+    ballotsCast: tally1.ballotsCast + tally2.ballotsCast,
   }
 }
 
@@ -67,6 +58,7 @@ const combineEitherNeitherTallies = (
     firstOption: tally1.firstOption + tally2.firstOption,
     secondOption: tally1.secondOption + tally2.secondOption,
     pickOneUndervotes: tally1.pickOneUndervotes + tally2.pickOneUndervotes,
+    ballotsCast: tally1.ballotsCast + tally2.ballotsCast,
   }
 }
 
@@ -162,23 +154,13 @@ export const calculateTally = ({
       } else {
         yesnoContestTally[yesnovote]++
       }
+      yesnoContestTally.ballotsCast++
     } else if (contest.type === 'candidate') {
       const candidateContestTally = contestTally as CandidateVoteTally
       const vote = (votes[contest.id] ?? []) as CandidateVote
       vote.forEach((candidate) => {
         if (candidate.isWriteIn) {
-          const tallyContestWriteIns = candidateContestTally.writeIns
-          const writeIn = tallyContestWriteIns.find(
-            (c) => c.name === candidate.name
-          )
-          if (typeof writeIn === 'undefined') {
-            tallyContestWriteIns.push({
-              name: candidate.name,
-              tally: 1,
-            })
-          } else {
-            writeIn.tally++
-          }
+          candidateContestTally.writeIns++
         } else {
           const candidateIndex = contest.candidates.findIndex(
             (c) => c.id === candidate.id
@@ -195,6 +177,7 @@ export const calculateTally = ({
         }
       })
       candidateContestTally.undervotes += contest.seats - vote.length
+      candidateContestTally.ballotsCast++
     }
   }
   return tally


### PR DESCRIPTION
Simplifies the data structure in the Tally objects kept in BMD to just have the count of write ins and not the count for each unique name. We don't do anything with the name based data in the reports so its simpler to just have 1 count. Also adds ballots cast to this data structure which should prepare us to be able to move the printed report to the format in election-manager more easily (note that we don't need to track overvotes because they are impossible to occur in bmds). 