### PR TITLE
feat(bmd): show machine id on screen

### DIFF
--- a/apps/bmd/src/AppEndToEnd.test.tsx
+++ b/apps/bmd/src/AppEndToEnd.test.tsx
@@ -98,6 +98,7 @@ it('VxMark+Print end-to-end flow', async () => {
   within(getByTestId('election-info')).getByText(
     `Election ID: ${expectedElectionHash}`
   )
+  within(getByTestId('election-info')).getByText(/Machine ID: 000/)
 
   // Select precinct
   getByText('State of Hamilton')

--- a/apps/bmd/src/AppRoot.tsx
+++ b/apps/bmd/src/AppRoot.tsx
@@ -1097,6 +1097,7 @@ const AppRoot: React.FC<Props> = ({
         updateAppPrecinctId={updateAppPrecinctId}
         toggleLiveMode={toggleLiveMode}
         unconfigure={unconfigure}
+        machineConfig={machineConfig}
       />
     )
   }
@@ -1247,6 +1248,7 @@ const AppRoot: React.FC<Props> = ({
           showNoChargerAttachedWarning={!hasChargerAttached}
           isLiveMode={isLiveMode}
           isPollsOpen={isPollsOpen}
+          machineConfig={machineConfig}
         />
       </IdleTimer>
     )

--- a/apps/bmd/src/__snapshots__/AppContestCandidateNoParty.test.tsx.snap
+++ b/apps/bmd/src/__snapshots__/AppContestCandidateNoParty.test.tsx.snap
@@ -898,6 +898,13 @@ exports[`Single Seat Contest 1`] = `
                   ballot style 
                   12
                 </span>
+                <span
+                  class="c32"
+                >
+                  <br />
+                   Machine ID: 
+                  000
+                </span>
               </p>
             </div>
           </div>

--- a/apps/bmd/src/__snapshots__/AppContestMultiSeat.test.tsx.snap
+++ b/apps/bmd/src/__snapshots__/AppContestMultiSeat.test.tsx.snap
@@ -1186,6 +1186,13 @@ exports[`Single Seat Contest 1`] = `
                   ballot style 
                   12
                 </span>
+                <span
+                  class="c34"
+                >
+                  <br />
+                   Machine ID: 
+                  000
+                </span>
               </p>
             </div>
           </div>

--- a/apps/bmd/src/__snapshots__/AppContestSingleSeat.test.tsx.snap
+++ b/apps/bmd/src/__snapshots__/AppContestSingleSeat.test.tsx.snap
@@ -969,6 +969,13 @@ exports[`Single Seat Contest 1`] = `
                   ballot style 
                   12
                 </span>
+                <span
+                  class="c34"
+                >
+                  <br />
+                   Machine ID: 
+                  000
+                </span>
               </p>
             </div>
           </div>

--- a/apps/bmd/src/__snapshots__/AppContestWriteIn.test.tsx.snap
+++ b/apps/bmd/src/__snapshots__/AppContestWriteIn.test.tsx.snap
@@ -819,6 +819,13 @@ exports[`Single Seat Contest with Write In 1`] = `
                   ballot style 
                   12
                 </span>
+                <span
+                  class="c32"
+                >
+                  <br />
+                   Machine ID: 
+                  000
+                </span>
               </p>
             </div>
           </div>

--- a/apps/bmd/src/components/ElectionInfo.test.tsx
+++ b/apps/bmd/src/components/ElectionInfo.test.tsx
@@ -3,12 +3,14 @@ import { render } from '@testing-library/react'
 
 import ElectionInfo from './ElectionInfo'
 import { electionSampleWithSealDefinition as electionDefinition } from '../data'
+import fakeMachineConfig from '../../test/helpers/fakeMachineConfig'
 
 it('renders horizontal ElectionInfo with hash when specified', () => {
   const { container } = render(
     <ElectionInfo
       precinctId="23"
       electionDefinition={electionDefinition}
+      machineConfig={fakeMachineConfig()}
       horizontal
       showElectionHash
     />
@@ -21,6 +23,7 @@ it('renders horizontal ElectionInfo without hash by default', () => {
     <ElectionInfo
       precinctId="23"
       electionDefinition={electionDefinition}
+      machineConfig={fakeMachineConfig()}
       horizontal
     />
   )
@@ -32,6 +35,7 @@ it('renders vertical ElectionInfo with hash when specified', () => {
     <ElectionInfo
       precinctId="23"
       electionDefinition={electionDefinition}
+      machineConfig={fakeMachineConfig()}
       showElectionHash
     />
   )
@@ -40,7 +44,11 @@ it('renders vertical ElectionInfo with hash when specified', () => {
 
 it('renders vertical ElectionInfo without hash by default', () => {
   const { container } = render(
-    <ElectionInfo precinctId="23" electionDefinition={electionDefinition} />
+    <ElectionInfo
+      precinctId="23"
+      electionDefinition={electionDefinition}
+      machineConfig={fakeMachineConfig()}
+    />
   )
   expect(container).toMatchSnapshot()
 })

--- a/apps/bmd/src/components/ElectionInfo.tsx
+++ b/apps/bmd/src/components/ElectionInfo.tsx
@@ -11,6 +11,7 @@ import { dateLong } from '../utils/date'
 import Seal from './Seal'
 import Prose from './Prose'
 import Text, { NoWrap } from './Text'
+import { MachineConfig } from '../config/types'
 
 const VerticalContainer = styled.div`
   display: block;
@@ -40,6 +41,7 @@ interface Props {
   precinctId: string
   ballotStyleId?: string
   electionDefinition: ElectionDefinition
+  machineConfig: MachineConfig
   horizontal?: boolean
   showElectionHash?: boolean
 }
@@ -48,6 +50,7 @@ const ElectionInfo: React.FC<Props> = ({
   precinctId,
   ballotStyleId,
   electionDefinition,
+  machineConfig,
   horizontal = false,
   showElectionHash = false,
 }) => {
@@ -89,6 +92,11 @@ const ElectionInfo: React.FC<Props> = ({
                   Election ID: {electionHash.substring(0, 10)}
                 </React.Fragment>
               )}
+              <React.Fragment>
+                <NoWrap>
+                  <br /> Machine ID: {machineConfig.machineId}
+                </NoWrap>
+              </React.Fragment>
             </Text>
           </Prose>
         </HorizontalContainer>
@@ -111,6 +119,9 @@ const ElectionInfo: React.FC<Props> = ({
         {showElectionHash && (
           <Text small>Election ID: {electionHash.substring(0, 10)}</Text>
         )}
+        <Text small>
+          <br /> Machine ID: {machineConfig.machineId}
+        </Text>
       </Prose>
     </VerticalContainer>
   )

--- a/apps/bmd/src/components/__snapshots__/ElectionInfo.test.tsx.snap
+++ b/apps/bmd/src/components/__snapshots__/ElectionInfo.test.tsx.snap
@@ -342,6 +342,13 @@ exports[`renders horizontal ElectionInfo with hash when specified 1`] = `
           <br />
           Election ID: 
           4aa260d7fc
+          <span
+            class="c5"
+          >
+            <br />
+             Machine ID: 
+            000
+          </span>
         </p>
       </div>
     </div>
@@ -688,6 +695,13 @@ exports[`renders horizontal ElectionInfo without hash by default 1`] = `
             Center Springfield
           </span>
            
+          <span
+            class="c5"
+          >
+            <br />
+             Machine ID: 
+            000
+          </span>
         </p>
       </div>
     </div>
@@ -999,6 +1013,13 @@ exports[`renders vertical ElectionInfo with hash when specified 1`] = `
         Election ID: 
         4aa260d7fc
       </p>
+      <p
+        class="c4"
+      >
+        <br />
+         Machine ID: 
+        000
+      </p>
     </div>
   </div>
 </div>
@@ -1084,6 +1105,10 @@ exports[`renders vertical ElectionInfo without hash by default 1`] = `
 
 .c2 dl {
   margin: 1rem 0;
+}
+
+.c4 {
+  font-size: 0.8rem;
 }
 
 .c3 {
@@ -1297,6 +1322,13 @@ exports[`renders vertical ElectionInfo without hash by default 1`] = `
         class="c3"
       >
         Center Springfield
+      </p>
+      <p
+        class="c4"
+      >
+        <br />
+         Machine ID: 
+        000
       </p>
     </div>
   </div>

--- a/apps/bmd/src/pages/AdminScreen.test.tsx
+++ b/apps/bmd/src/pages/AdminScreen.test.tsx
@@ -11,6 +11,7 @@ import { advanceTimers } from '../../test/helpers/smartcards'
 
 import AdminScreen from './AdminScreen'
 import { VxPrintOnly, VxMarkOnly } from '../config/types'
+import fakeMachineConfig from '../../test/helpers/fakeMachineConfig'
 
 MockDate.set('2020-10-31T00:00:00.000Z')
 
@@ -37,6 +38,7 @@ test('renders ClerkScreen for VxPrintOnly', async () => {
       updateAppPrecinctId={jest.fn()}
       toggleLiveMode={jest.fn()}
       unconfigure={jest.fn()}
+      machineConfig={fakeMachineConfig()}
     />
   )
 
@@ -74,6 +76,7 @@ test('renders date and time settings modal', async () => {
       updateAppPrecinctId={jest.fn()}
       toggleLiveMode={jest.fn()}
       unconfigure={jest.fn()}
+      machineConfig={fakeMachineConfig()}
     />
   )
 

--- a/apps/bmd/src/pages/AdminScreen.tsx
+++ b/apps/bmd/src/pages/AdminScreen.tsx
@@ -1,7 +1,11 @@
 import React, { useState } from 'react'
 import { OptionalElectionDefinition } from '@votingworks/types'
 
-import { AppMode, SelectChangeEventFunction } from '../config/types'
+import {
+  AppMode,
+  MachineConfig,
+  SelectChangeEventFunction,
+} from '../config/types'
 
 import TestBallotDeckScreen from './TestBallotDeckScreen'
 
@@ -35,6 +39,7 @@ interface Props {
   updateAppPrecinctId: (appPrecinctId: string) => void
   toggleLiveMode: VoidFunction
   unconfigure: VoidFunction
+  machineConfig: MachineConfig
 }
 
 const getMachineTimezone = () =>
@@ -50,6 +55,7 @@ const AdminScreen: React.FC<Props> = ({
   updateAppPrecinctId,
   toggleLiveMode,
   unconfigure,
+  machineConfig,
 }) => {
   const election = electionDefinition?.election
   const changeAppPrecinctId: SelectChangeEventFunction = (event) => {
@@ -143,6 +149,7 @@ const AdminScreen: React.FC<Props> = ({
         appPrecinctId={appPrecinctId}
         electionDefinition={electionDefinition}
         hideTestDeck={hideTestDeck}
+        machineConfig={machineConfig}
         isLiveMode={false} // always false for Test Mode
       />
     )
@@ -267,6 +274,7 @@ const AdminScreen: React.FC<Props> = ({
             <ElectionInfo
               electionDefinition={electionDefinition}
               precinctId={appPrecinctId}
+              machineConfig={machineConfig}
               showElectionHash
               horizontal
             />

--- a/apps/bmd/src/pages/ContestPage.tsx
+++ b/apps/bmd/src/pages/ContestPage.tsx
@@ -34,6 +34,7 @@ const ContestPage: React.FC<RouteComponentProps<ContestParams>> = (props) => {
     updateVote,
     userSettings,
     votes,
+    machineConfig,
   } = useContext(BallotContext)
   const { election } = electionDefinition
   const currentContestIndex = parseInt(contestNumber, 10)
@@ -112,6 +113,7 @@ const ContestPage: React.FC<RouteComponentProps<ContestParams>> = (props) => {
               electionDefinition={electionDefinition}
               ballotStyleId={ballotStyleId}
               precinctId={precinctId}
+              machineConfig={machineConfig}
               horizontal
             />
           </React.Fragment>

--- a/apps/bmd/src/pages/InsertCardScreen.tsx
+++ b/apps/bmd/src/pages/InsertCardScreen.tsx
@@ -9,6 +9,7 @@ import Sidebar from '../components/Sidebar'
 import TestMode from '../components/TestMode'
 import Text from '../components/Text'
 import ElectionInfo from '../components/ElectionInfo'
+import { MachineConfig } from '../config/types'
 
 const InsertCardImage = styled.img`
   margin: 0 auto -1rem;
@@ -22,6 +23,7 @@ interface Props {
   isLiveMode: boolean
   isPollsOpen: boolean
   showNoAccessibleControllerWarning: boolean
+  machineConfig: MachineConfig
 }
 
 const InsertCardScreen: React.FC<Props> = ({
@@ -31,6 +33,7 @@ const InsertCardScreen: React.FC<Props> = ({
   isLiveMode,
   isPollsOpen,
   showNoAccessibleControllerWarning,
+  machineConfig,
 }) => {
   return (
     <Screen flexDirection="row-reverse" white>
@@ -38,6 +41,7 @@ const InsertCardScreen: React.FC<Props> = ({
         <ElectionInfo
           electionDefinition={electionDefinition}
           precinctId={appPrecinctId}
+          machineConfig={machineConfig}
           showElectionHash
         />
       </Sidebar>

--- a/apps/bmd/src/pages/PollWorkerScreen.tsx
+++ b/apps/bmd/src/pages/PollWorkerScreen.tsx
@@ -246,6 +246,7 @@ const PollWorkerScreen: React.FC<Props> = ({
             <ElectionInfo
               electionDefinition={electionDefinition}
               precinctId={appPrecinctId}
+              machineConfig={machineConfig}
               showElectionHash
               horizontal
             />

--- a/apps/bmd/src/pages/ReviewPage.tsx
+++ b/apps/bmd/src/pages/ReviewPage.tsx
@@ -483,6 +483,7 @@ const ReviewPage: React.FC = () => {
             <ElectionInfo
               electionDefinition={electionDefinition}
               precinctId={precinctId}
+              machineConfig={machineConfig}
               horizontal
             />
           </React.Fragment>

--- a/apps/bmd/src/pages/StartPage.tsx
+++ b/apps/bmd/src/pages/StartPage.tsx
@@ -29,6 +29,7 @@ const StartPage: React.FC<Props> = ({ history }) => {
     setUserSettings,
     userSettings,
     forceSaveVote,
+    machineConfig,
   } = useContext(BallotContext)
   const audioFocus = useRef<HTMLDivElement>(null) // eslint-disable-line no-restricted-syntax
   const { election } = electionDefinition
@@ -82,6 +83,7 @@ const StartPage: React.FC<Props> = ({ history }) => {
               electionDefinition={electionDefinition}
               ballotStyleId={ballotStyleId}
               precinctId={precinctId}
+              machineConfig={machineConfig}
               horizontal
             />
           </React.Fragment>

--- a/apps/bmd/src/pages/TestBallotDeckScreen.test.tsx
+++ b/apps/bmd/src/pages/TestBallotDeckScreen.test.tsx
@@ -12,6 +12,7 @@ import electionSample from '../data/electionSample.json'
 import { mockOf, render } from '../../test/testUtils'
 import { randomBase64 } from '../utils/random'
 import TestBallotDeckScreen from './TestBallotDeckScreen'
+import fakeMachineConfig from '../../test/helpers/fakeMachineConfig'
 
 // mock the random value so the snapshots match
 jest.mock('../utils/random')
@@ -25,6 +26,7 @@ it('renders test decks appropriately', async () => {
       appPrecinctId="23"
       electionDefinition={asElectionDefinition(parseElection(electionSample))}
       hideTestDeck={jest.fn()}
+      machineConfig={fakeMachineConfig()}
       isLiveMode={false}
     />
   )
@@ -71,6 +73,7 @@ it('shows printer not connected when appropriate', async () => {
       appName="VxPrint"
       appPrecinctId="23"
       electionDefinition={asElectionDefinition(parseElection(electionSample))}
+      machineConfig={fakeMachineConfig()}
       hideTestDeck={jest.fn()}
       isLiveMode={false}
     />

--- a/apps/bmd/src/pages/TestBallotDeckScreen.tsx
+++ b/apps/bmd/src/pages/TestBallotDeckScreen.tsx
@@ -7,7 +7,11 @@ import {
   ElectionDefinition,
 } from '@votingworks/types'
 
-import { AppModeNames, EventTargetFunction } from '../config/types'
+import {
+  AppModeNames,
+  EventTargetFunction,
+  MachineConfig,
+} from '../config/types'
 
 import Button from '../components/Button'
 import ButtonList from '../components/ButtonList'
@@ -112,6 +116,7 @@ interface Props {
   electionDefinition: ElectionDefinition
   hideTestDeck: () => void
   isLiveMode: boolean
+  machineConfig: MachineConfig
 }
 
 const initialPrecinct: Precinct = { id: '', name: '' }
@@ -122,6 +127,7 @@ const TestBallotDeckScreen: React.FC<Props> = ({
   electionDefinition,
   hideTestDeck,
   isLiveMode,
+  machineConfig,
 }) => {
   const { election } = electionDefinition
   const [ballots, setBallots] = useState<Ballot[]>([])
@@ -232,6 +238,7 @@ const TestBallotDeckScreen: React.FC<Props> = ({
               <ElectionInfo
                 electionDefinition={electionDefinition}
                 precinctId={appPrecinctId}
+                machineConfig={machineConfig}
                 showElectionHash
                 horizontal
               />

--- a/apps/bmd/src/pages/__snapshots__/ContestPage.test.tsx.snap
+++ b/apps/bmd/src/pages/__snapshots__/ContestPage.test.tsx.snap
@@ -878,6 +878,13 @@ exports[`Renders ContestPage 1`] = `
               >
                  
                 
+                <span
+                  class="c30"
+                >
+                  <br />
+                   Machine ID: 
+                  000
+                </span>
               </p>
             </div>
           </div>

--- a/apps/bmd/src/pages/__snapshots__/StartPage.test.tsx.snap
+++ b/apps/bmd/src/pages/__snapshots__/StartPage.test.tsx.snap
@@ -677,6 +677,13 @@ exports[`renders StartPage 1`] = `
                 ballot style 
                 12D
               </span>
+              <span
+                class="c24"
+              >
+                <br />
+                 Machine ID: 
+                000
+              </span>
             </p>
           </div>
         </div>
@@ -1512,6 +1519,13 @@ exports[`renders StartPage with inline SVG 1`] = `
               </span>
                
               
+              <span
+                class="c23"
+              >
+                <br />
+                 Machine ID: 
+                000
+              </span>
             </p>
           </div>
         </div>
@@ -2183,6 +2197,13 @@ exports[`renders StartPage with no seal 1`] = `
               </span>
                
               
+              <span
+                class="c23"
+              >
+                <br />
+                 Machine ID: 
+                000
+              </span>
             </p>
           </div>
         </div>


### PR DESCRIPTION
Adds the machine ID to the info panel in bmd. I added it in the ElectionInfo component which feels... slightly wrong since this isn't election information but this felt like the fastest way to get the information on the screen in a reasonable manner. 

Vertical ElectionInfo layout: 
![Screen Shot 2021-03-26 at 10 44 23 AM](https://user-images.githubusercontent.com/14897017/112683436-c9c98880-8e2e-11eb-918a-8ceb628ef0cc.png)


Horizontal ElectionInfo layout. This one, IMO looks a little strange as its more clearly coupled with the election information, but I'm not sure where else the machine ID would make sense in this sidebar: 
![Screen Shot 2021-03-26 at 10 43 45 AM](https://user-images.githubusercontent.com/14897017/112683453-d0580000-8e2e-11eb-8061-e4f3b5f27800.png)
