### PR TITLE
Fix bug with mock card reader breaking the pollworker screen in bmd

### DIFF
--- a/apps/bmd/src/AppEndToEnd.test.tsx
+++ b/apps/bmd/src/AppEndToEnd.test.tsx
@@ -25,6 +25,7 @@ import {
   measure102Contest,
   measure420Contest,
   voterContests,
+  election,
 } from '../test/helpers/election'
 import { MemoryStorage } from './utils/Storage'
 import { MemoryCard } from './utils/Card'
@@ -33,6 +34,7 @@ import { MemoryHardware } from './utils/Hardware'
 import { fakeMachineConfigProvider } from '../test/helpers/fakeMachineConfig'
 import { REPORT_PRINTING_TIMEOUT_SECONDS } from './config/globals'
 import { VxMarkPlusVxPrint } from './config/types'
+import { getZeroTally } from './utils/election'
 
 beforeEach(() => {
   window.location.href = '/'
@@ -370,6 +372,25 @@ it('VxMark+Print end-to-end flow', async () => {
   card.removeCard()
   await advanceTimersAndPromises()
   getByText('Insert Poll Worker card to open.')
+
+  // Insert a pollworker card with tally data on it.
+  card.insertCard(
+    pollWorkerCard,
+    JSON.stringify({
+      tally: getZeroTally(election),
+      metadata: [
+        {
+          machineId: '002',
+          timeSaved: new Date('2020-10-31').getTime(),
+          ballotsPrinted: 3,
+        },
+      ],
+      totalBallotsPrinted: 10,
+    })
+  )
+  await advanceTimersAndPromises()
+  getByText('Open Polls for Center Springfield')
+  getByText('Print Combined Report for 2 Machines')
 
   // ---------------
 

--- a/apps/bmd/src/AppRoot.tsx
+++ b/apps/bmd/src/AppRoot.tsx
@@ -727,11 +727,19 @@ const AppRoot: React.FC<Props> = ({
           const isValid =
             cardData.h === optionalElectionDefinition?.electionHash
 
-          /* istanbul ignore next */
-          const possibleCardTally: Optional<CardTally> =
+          let possibleCardTally: Optional<CardTally> =
             isValid && !!longValueExists
               ? ((await card.readLongObject()) as Optional<CardTally>)
               : undefined
+
+          // Handle a possible invalid object in the card long value
+          if (
+            possibleCardTally?.metadata === undefined ||
+            possibleCardTally?.tally === undefined ||
+            possibleCardTally?.totalBallotsPrinted === undefined
+          ) {
+            possibleCardTally = undefined
+          }
 
           dispatchAppState({
             type: 'processPollWorkerCard',

--- a/apps/module-smartcards/mockCardReader.py
+++ b/apps/module-smartcards/mockCardReader.py
@@ -137,7 +137,7 @@ def enable_pollworker(election_definition: ElectionDefinition):
             "shortValue": json.dumps(
                 {"t": "pollworker", "h": election_definition.election_hash}
             ),
-            "longValue": election_definition.election_data,
+            "longValue": None,
         }
     )
 


### PR DESCRIPTION
The primary issue is that mockCardReader was inaccurately putting the election definition as the long value on the card which is unexpected, that is fixed in the first commit. I also made bmd more resilient to these unexpected results in the second commit which also caused me to realize the case I was missing for full test coverage. 