### PR TITLE
Allow user to specify what voting method to count external results as

### DIFF
--- a/apps/election-manager/src/App.test.tsx
+++ b/apps/election-manager/src/App.test.tsx
@@ -20,6 +20,7 @@ import {
   cvrsStorageKey,
   electionDefinitionStorageKey,
   externalVoteRecordsFileStorageKey,
+  externalVotingMethodStorageKey,
 } from './AppRoot'
 
 import CastVoteRecordFiles from './utils/CastVoteRecordFiles'
@@ -31,6 +32,7 @@ import fakeFileWriter from '../test/helpers/fakeFileWriter'
 import { convertFileToStorageString } from './utils/file'
 import { eitherNeitherElectionDefinition } from '../test/renderInAppContext'
 import hasTextAcrossElements from '../test/util/hasTextAcrossElements'
+import { VotingMethod } from './config/types'
 
 const EITHER_NEITHER_CVR_DATA = electionWithMsEitherNeitherWithDataFiles.cvrData
 const EITHER_NEITHER_CVR_FILE = new File([EITHER_NEITHER_CVR_DATA], 'cvrs.txt')
@@ -301,6 +303,7 @@ test('tabulating CVRs with SEMS file', async () => {
     new File([EITHER_NEITHER_SEMS_DATA], 'sems-results.csv')
   )
   await storage.set(externalVoteRecordsFileStorageKey, semsFileStorageString)
+  await storage.set(externalVotingMethodStorageKey, VotingMethod.Precinct)
 
   const { getByText, getByTestId, getAllByTestId, getAllByText } = render(
     <App storage={storage} />
@@ -314,7 +317,7 @@ test('tabulating CVRs with SEMS file', async () => {
     expect(getByTestId('total-ballot-count').textContent).toEqual('200')
   )
   expect(getAllByText('External Results File (sems-results.csv)').length).toBe(
-    3
+    2
   )
 
   fireEvent.click(getByText('View Unofficial Full Election Tally Report'))
@@ -327,14 +330,7 @@ test('tabulating CVRs with SEMS file', async () => {
 
   const precinctRow = domGetByTestId(ballotsByVotingMethod[0], 'standard')
   domGetByText(precinctRow, 'Precinct')
-  domGetByText(precinctRow, '50')
-
-  const semsRow = domGetByTestId(
-    ballotsByVotingMethod[0],
-    'externalvoterecords'
-  )
-  domGetByText(semsRow, 'External Results File')
-  domGetByText(semsRow, '100')
+  domGetByText(precinctRow, '150')
 
   const totalRow = domGetByTestId(ballotsByVotingMethod[0], 'total')
   domGetByText(totalRow, 'Total Ballots Cast')
@@ -369,6 +365,7 @@ test('changing election resets sems and cvr files', async () => {
     new File([EITHER_NEITHER_SEMS_DATA], 'sems-results.csv')
   )
   await storage.set(externalVoteRecordsFileStorageKey, semsFileStorageString)
+  await storage.set(externalVotingMethodStorageKey, VotingMethod.Precinct)
 
   const { getByText, getByTestId } = render(<App storage={storage} />)
 
@@ -409,6 +406,7 @@ test('clearing all files after marking as official clears SEMS and CVR file', as
     new File([EITHER_NEITHER_SEMS_DATA], 'sems-results.csv')
   )
   await storage.set(externalVoteRecordsFileStorageKey, semsFileStorageString)
+  await storage.set(externalVotingMethodStorageKey, VotingMethod.Precinct)
 
   const { getByText, getByTestId } = render(<App storage={storage} />)
 

--- a/apps/election-manager/src/__snapshots__/App.test.tsx.snap
+++ b/apps/election-manager/src/__snapshots__/App.test.tsx.snap
@@ -2531,21 +2531,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
             <td
               class="sc-dIUggk grVjzA"
             >
-              50
-            </td>
-          </tr>
-          <tr
-            data-testid="externalvoterecords"
-          >
-            <td
-              class="sc-dIUggk fMFRds"
-            >
-              External Results File
-            </td>
-            <td
-              class="sc-dIUggk grVjzA"
-            >
-              100
+              150
             </td>
           </tr>
           <tr

--- a/apps/election-manager/src/components/BallotCountsTable.test.tsx
+++ b/apps/election-manager/src/components/BallotCountsTable.test.tsx
@@ -68,6 +68,7 @@ describe('Ballot Counts by Precinct', () => {
       numberOfBallotsCounted: 54,
     }),
     resultsByCategory: externalResultsByCategory,
+    votingMethod: VotingMethod.Precinct,
   }
 
   it('renders as expected when there is no tally data', () => {
@@ -191,6 +192,7 @@ describe('Ballot Counts by Scanner', () => {
     overallTally: fakeExternalTally({
       numberOfBallotsCounted: 54,
     }),
+    votingMethod: VotingMethod.Precinct,
     resultsByCategory: new Map(),
   }
 
@@ -329,6 +331,7 @@ describe('Ballots Counts by Party', () => {
       numberOfBallotsCounted: 54,
     }),
     resultsByCategory: externalResultsByCategory,
+    votingMethod: VotingMethod.Precinct,
   }
 
   it('does not render when the election has not ballot styles with parties', () => {
@@ -481,11 +484,14 @@ describe('Ballots Counts by VotingMethod', () => {
     resultsByCategory,
   }
 
+  const numExternalBallots = 54
+
   const fullElectionExternalTally = {
     overallTally: fakeExternalTally({
-      numberOfBallotsCounted: 54,
+      numberOfBallotsCounted: numExternalBallots,
     }),
     resultsByCategory: new Map(),
+    votingMethod: VotingMethod.Precinct,
   }
 
   it('renders as expected when there is no data', () => {
@@ -565,9 +571,14 @@ describe('Ballots Counts by VotingMethod', () => {
       }
     )
 
+    // The external tally is configured to be labelled as precinct data.
+
     expectedLabels.forEach(({ method, label }) => {
-      const expectedNumberOfBallots =
+      let expectedNumberOfBallots =
         resultsByVotingMethod[method]?.numberOfBallotsCounted ?? 0
+      if (method === VotingMethod.Precinct) {
+        expectedNumberOfBallots += numExternalBallots
+      }
       getByText(label)
       const tableRow = getByText(label).closest('tr')
       expect(tableRow).toBeDefined()
@@ -577,18 +588,11 @@ describe('Ballots Counts by VotingMethod', () => {
       )
     })
 
-    getByText('External Results File (file-name.csv)')
-    let tableRow = getByText('External Results File (file-name.csv)').closest(
-      'tr'
-    )
-    expect(tableRow).toBeDefined()
-    expect(domGetByText(tableRow!, 54))
-
     getByText('Total Ballot Count')
-    tableRow = getByText('Total Ballot Count').closest('tr')
+    const tableRow = getByText('Total Ballot Count').closest('tr')
     expect(tableRow).toBeDefined()
     expect(domGetByText(tableRow!, 131))
 
-    expect(getAllByTestId('table-row').length).toBe(expectedLabels.length + 3)
+    expect(getAllByTestId('table-row').length).toBe(expectedLabels.length + 2)
   })
 })

--- a/apps/election-manager/src/components/BallotCountsTable.tsx
+++ b/apps/election-manager/src/components/BallotCountsTable.tsx
@@ -281,8 +281,14 @@ const BallotCountsTable: React.FC<Props> = ({ breakdownCategory }) => {
               <TD as="th">View Tally</TD>
             </tr>
             {Object.values(VotingMethod).map((votingMethod) => {
-              const votingMethodBallotsCount =
+              let votingMethodBallotsCount =
                 resultsByVotingMethod[votingMethod]?.numberOfBallotsCounted ?? 0
+
+              // Include external results as appropriate
+              if (votingMethod === fullElectionExternalTally?.votingMethod) {
+                votingMethodBallotsCount += totalBallotCountExternal
+              }
+
               if (
                 votingMethod === VotingMethod.Unknown &&
                 votingMethodBallotsCount === 0
@@ -309,15 +315,6 @@ const BallotCountsTable: React.FC<Props> = ({ breakdownCategory }) => {
                 </tr>
               )
             })}
-            {externalVoteRecordsFile && (
-              <tr data-testid="table-row">
-                <TD narrow nowrap>
-                  External Results File ({externalVoteRecordsFile.name})
-                </TD>
-                <TD>{format.count(totalBallotCountExternal)}</TD>
-                <TD />
-              </tr>
-            )}
             <tr data-testid="table-row">
               <TD narrow nowrap>
                 <strong>Total Ballot Count</strong>

--- a/apps/election-manager/src/components/ExportFinalResultsModal.test.tsx
+++ b/apps/election-manager/src/components/ExportFinalResultsModal.test.tsx
@@ -8,6 +8,7 @@ import MockDate from 'mockdate'
 import { UsbDriveStatus } from '../lib/usbstick'
 import ExportFinalResultsModal from './ExportFinalResultsModal'
 import renderInAppContext from '../../test/renderInAppContext'
+import { VotingMethod } from '../config/types'
 
 beforeEach(() => {
   jest.useFakeTimers()
@@ -142,6 +143,7 @@ test('render export modal when a usb drive is mounted and exports with external 
       fullElectionExternalTally: {
         overallTally: { contestTallies: {}, numberOfBallotsCounted: 0 },
         resultsByCategory: new Map(),
+        votingMethod: VotingMethod.Precinct,
       },
       externalVoteRecordsFile: externalFile,
     }

--- a/apps/election-manager/src/components/FileInputButton.tsx
+++ b/apps/election-manager/src/components/FileInputButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { RefObject } from 'react'
 import styled from 'styled-components'
 
 import { InputEventFunction } from '../config/types'
@@ -33,6 +33,7 @@ interface Props {
   multiple?: boolean
   children: string
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void
+  innerRef?: RefObject<HTMLInputElement>
 }
 
 const FileInputButton: React.FC<Props> = ({
@@ -41,6 +42,7 @@ const FileInputButton: React.FC<Props> = ({
   children,
   disabled,
   onChange,
+  innerRef,
   ...rest
 }) => {
   const onBlur: InputEventFunction = (event) => {
@@ -56,6 +58,7 @@ const FileInputButton: React.FC<Props> = ({
           disabled={disabled}
           onBlur={onBlur}
           onChange={onChange}
+          ref={innerRef}
           type="file"
         />
         {children}

--- a/apps/election-manager/src/components/ImportExternalResultsModal.tsx
+++ b/apps/election-manager/src/components/ImportExternalResultsModal.tsx
@@ -1,0 +1,137 @@
+import React, { useContext, useEffect, useState } from 'react'
+
+import * as format from '../utils/format'
+import { VotingMethod } from '../config/types'
+import AppContext from '../contexts/AppContext'
+import readFileAsync from '../lib/readFileAsync'
+import { convertSEMSFileToExternalTally } from '../utils/semsTallies'
+import LinkButton from './LinkButton'
+import Loading from './Loading'
+import Modal from './Modal'
+import Prose from './Prose'
+import Button, { SegmentedButton } from './Button'
+
+export interface Props {
+  onClose: () => void
+  selectedFile?: File
+}
+
+const ImportExternalResultsModal: React.FC<Props> = ({
+  onClose,
+  selectedFile,
+}) => {
+  const { saveExternalVoteRecordsFile, electionDefinition } = useContext(
+    AppContext
+  )
+
+  const [errorMessage, setErrorMessage] = useState('')
+  const [isImportingFile, setIsImportingFile] = useState(true)
+  const [numberBallotsToImport, setNumberBallotsToImport] = useState(0)
+  const [ballotType, setBallotType] = useState<VotingMethod>(
+    VotingMethod.Precinct
+  )
+
+  const { election } = electionDefinition!
+
+  const loadFile = async (file: File) => {
+    const fileContent = await readFileAsync(file)
+    // Compute the tallies to see if there are any errors, if so display
+    // an error modal.
+    try {
+      const tally = convertSEMSFileToExternalTally(
+        fileContent,
+        election,
+        ballotType // We are not storing this tally, the ballot type here is not accurate yet but is thrown away
+      )
+      setNumberBallotsToImport(tally.overallTally.numberOfBallotsCounted)
+      setIsImportingFile(false)
+    } catch (error) {
+      setErrorMessage(`Failed to import external file. ${error.message}`)
+    }
+  }
+
+  useEffect(() => {
+    if (selectedFile !== undefined) {
+      loadFile(selectedFile)
+    }
+  }, [selectedFile])
+
+  const saveImportedFile = async () => {
+    if (selectedFile !== undefined) {
+      await saveExternalVoteRecordsFile({
+        file: selectedFile,
+        votingMethod: ballotType,
+      })
+      onClose()
+    }
+  }
+
+  if (isImportingFile) {
+    return (
+      <Modal
+        onOverlayClick={onClose}
+        actions={
+          <LinkButton disabled onPress={onClose}>
+            Close
+          </LinkButton>
+        }
+        content={<Loading>Importing File</Loading>}
+      />
+    )
+  }
+
+  if (errorMessage !== '') {
+    return (
+      <Modal
+        onOverlayClick={onClose}
+        actions={<LinkButton onPress={onClose}>Close</LinkButton>}
+        content={
+          <Prose>
+            <h1>Error</h1>
+            <p>{errorMessage}</p>
+          </Prose>
+        }
+      />
+    )
+  }
+
+  return (
+    <Modal
+      onOverlayClick={onClose}
+      actions={
+        <React.Fragment>
+          <LinkButton onPress={onClose}>Cancel</LinkButton>
+          <LinkButton onPress={saveImportedFile} primary>
+            Import Results
+          </LinkButton>
+        </React.Fragment>
+      }
+      content={
+        <Prose>
+          <h1>External Results File Loaded</h1>
+          <p>
+            The file ({selectedFile?.name}) contained{' '}
+            {format.count(numberBallotsToImport)} ballots.
+          </p>
+          <p>Select the voting method for these ballots.</p>
+          <SegmentedButton>
+            <Button
+              disabled={ballotType === VotingMethod.Precinct}
+              onPress={() => setBallotType(VotingMethod.Precinct)}
+            >
+              Precinct
+            </Button>
+            <Button
+              disabled={ballotType === VotingMethod.Absentee}
+              onPress={() => setBallotType(VotingMethod.Absentee)}
+            >
+              Absentee
+            </Button>
+          </SegmentedButton>
+        </Prose>
+      }
+    />
+  )
+}
+
+export default ImportExternalResultsModal

--- a/apps/election-manager/src/components/TallyReportSummary.test.tsx
+++ b/apps/election-manager/src/components/TallyReportSummary.test.tsx
@@ -15,8 +15,7 @@ test('Renders with data source table and voting method table when all data provi
   const { getByText, getByTestId } = render(
     <TallyReportSummary
       election={electionWithMsEitherNeither}
-      internalBallotCount={1234}
-      externalBallotCount={2345}
+      totalBallotCount={3579}
       ballotCountsByVotingMethod={ballotCounts}
     />
   )
@@ -29,10 +28,6 @@ test('Renders with data source table and voting method table when all data provi
   domGetByText(row2, '1,045')
   const row3 = domGetByText(votingMethodTable, 'Other').closest('tr')!
   domGetByText(row3, '12')
-  const row4 = domGetByText(votingMethodTable, 'External Results File').closest(
-    'tr'
-  )!
-  domGetByText(row4, '2,345')
   const row5 = domGetByText(votingMethodTable, 'Total Ballots Cast').closest(
     'tr'
   )!
@@ -48,8 +43,7 @@ test('Hides the other row in the voting method table when empty', () => {
   const { queryAllByText, unmount } = render(
     <TallyReportSummary
       election={electionWithMsEitherNeither}
-      internalBallotCount={1234}
-      externalBallotCount={2345}
+      totalBallotCount={3579}
       ballotCountsByVotingMethod={ballotCounts}
     />
   )
@@ -64,8 +58,7 @@ test('Hides the other row in the voting method table when empty', () => {
   const { queryAllByText: queryAllByText2 } = render(
     <TallyReportSummary
       election={electionWithMsEitherNeither}
-      internalBallotCount={1234}
-      externalBallotCount={2345}
+      totalBallotCount={3579}
       ballotCountsByVotingMethod={ballotCounts2}
     />
   )

--- a/apps/election-manager/src/components/TallyReportSummary.tsx
+++ b/apps/election-manager/src/components/TallyReportSummary.tsx
@@ -22,18 +22,14 @@ const BallotSummary = styled.div`
 
 interface Props {
   election: Election
-  internalBallotCount: number
-  externalBallotCount?: number
+  totalBallotCount: number
   ballotCountsByVotingMethod: Dictionary<number>
 }
 
 const TallyReportSummary: React.FC<Props> = ({
-  internalBallotCount,
-  externalBallotCount,
+  totalBallotCount,
   ballotCountsByVotingMethod,
 }) => {
-  const totalBallotCount = internalBallotCount + (externalBallotCount ?? 0)
-
   return (
     <BallotSummary>
       <h3>Ballots by Voting Method</h3>
@@ -56,12 +52,6 @@ const TallyReportSummary: React.FC<Props> = ({
               </tr>
             )
           })}
-          {externalBallotCount !== undefined && (
-            <tr data-testid="externalvoterecords">
-              <TD>External Results File</TD>
-              <TD textAlign="right">{format.count(externalBallotCount)}</TD>
-            </tr>
-          )}
           <tr data-testid="total">
             <TD>
               <strong>Total Ballots Cast</strong>

--- a/apps/election-manager/src/config/types.ts
+++ b/apps/election-manager/src/config/types.ts
@@ -127,6 +127,12 @@ export interface FullElectionExternalTally {
     TallyCategory,
     Dictionary<ExternalTally>
   >
+  readonly votingMethod: VotingMethod
+}
+
+export interface ExternalFileConfiguration {
+  readonly file: File
+  readonly votingMethod: VotingMethod
 }
 
 export type OptionalExternalTally = Optional<ExternalTally>

--- a/apps/election-manager/src/contexts/AppContext.ts
+++ b/apps/election-manager/src/contexts/AppContext.ts
@@ -1,5 +1,5 @@
 import { createContext, RefObject } from 'react'
-import { ElectionDefinition } from '@votingworks/types'
+import { ElectionDefinition, Optional } from '@votingworks/types'
 import {
   SaveElection,
   PrintedBallot,
@@ -7,6 +7,7 @@ import {
   FullElectionTally,
   OptionalFullElectionExternalTally,
   OptionalFile,
+  ExternalFileConfiguration,
 } from '../config/types'
 import { UsbDriveStatus } from '../lib/usbstick'
 import CastVoteRecordFiles, {
@@ -38,7 +39,9 @@ export interface AppContextInterface {
   setFullElectionExternalTally: React.Dispatch<
     React.SetStateAction<OptionalFullElectionExternalTally>
   >
-  saveExternalVoteRecordsFile: (externalFile: OptionalFile) => void
+  saveExternalVoteRecordsFile: (
+    externalFileConfig: Optional<ExternalFileConfiguration>
+  ) => void
   setIsTabulationRunning: React.Dispatch<React.SetStateAction<boolean>>
 }
 

--- a/apps/election-manager/src/screens/TallyReportScreen.tsx
+++ b/apps/election-manager/src/screens/TallyReportScreen.tsx
@@ -207,8 +207,25 @@ const TallyReportScreen: React.FC = () => {
             const externalTallyForReport = filterExternalTalliesByParams(
               fullElectionExternalTally,
               election,
-              { precinctId, partyId }
+              { precinctId, partyId, scannerId, votingMethod }
             )
+            const ballotCountsByVotingMethod = {
+              ...tallyForReport.ballotCountsByVotingMethod,
+            }
+
+            if (externalTallyForReport) {
+              ballotCountsByVotingMethod[
+                fullElectionExternalTally!.votingMethod
+              ] =
+                externalTallyForReport.numberOfBallotsCounted +
+                (ballotCountsByVotingMethod[
+                  fullElectionExternalTally!.votingMethod
+                ] ?? 0)
+            }
+
+            const reportBallotCount =
+              tallyForReport.numberOfBallotsCounted +
+              (externalTallyForReport?.numberOfBallotsCounted ?? 0)
 
             if (precinctId) {
               const precinctName = find(
@@ -231,15 +248,8 @@ const TallyReportScreen: React.FC = () => {
                   <ContestColumns>
                     <TallyReportSummary
                       election={election}
-                      internalBallotCount={
-                        tallyForReport.numberOfBallotsCounted
-                      }
-                      externalBallotCount={
-                        externalTallyForReport?.numberOfBallotsCounted
-                      }
-                      ballotCountsByVotingMethod={
-                        tallyForReport.ballotCountsByVotingMethod
-                      }
+                      totalBallotCount={reportBallotCount}
+                      ballotCountsByVotingMethod={ballotCountsByVotingMethod}
                     />
                     <ContestTally
                       election={election}
@@ -270,12 +280,8 @@ const TallyReportScreen: React.FC = () => {
                   <ContestColumns>
                     <TallyReportSummary
                       election={election}
-                      internalBallotCount={
-                        tallyForReport?.numberOfBallotsCounted ?? 0
-                      }
-                      ballotCountsByVotingMethod={
-                        tallyForReport.ballotCountsByVotingMethod
-                      }
+                      totalBallotCount={reportBallotCount}
+                      ballotCountsByVotingMethod={ballotCountsByVotingMethod}
                     />
                     <ContestTally
                       election={election}
@@ -305,6 +311,7 @@ const TallyReportScreen: React.FC = () => {
                     <ContestTally
                       election={election}
                       electionTally={tallyForReport}
+                      externalTally={externalTallyForReport}
                     />
                   </ContestColumns>
                 </ReportSection>
@@ -329,13 +336,8 @@ const TallyReportScreen: React.FC = () => {
                 <ContestColumns>
                   <TallyReportSummary
                     election={election}
-                    internalBallotCount={tallyForReport.numberOfBallotsCounted}
-                    externalBallotCount={
-                      externalTallyForReport?.numberOfBallotsCounted
-                    }
-                    ballotCountsByVotingMethod={
-                      tallyForReport.ballotCountsByVotingMethod
-                    }
+                    totalBallotCount={reportBallotCount}
+                    ballotCountsByVotingMethod={ballotCountsByVotingMethod}
                   />
                   <ContestTally
                     election={election}

--- a/apps/election-manager/src/utils/semsTallies.test.ts
+++ b/apps/election-manager/src/utils/semsTallies.test.ts
@@ -9,6 +9,7 @@ import {
   ContestOptionTally,
   ContestTally,
   TallyCategory,
+  VotingMethod,
 } from '../config/types'
 import { writeInCandidate } from './election'
 import {
@@ -436,7 +437,8 @@ describe('convertSEMSFileToExternalTally', () => {
   it('computes tallies properly on either neither general election', async () => {
     const convertedTally = convertSEMSFileToExternalTally(
       eitherNeitherSEMSContent,
-      electionWithMsEitherNeither
+      electionWithMsEitherNeither,
+      VotingMethod.Precinct
     )
 
     const expectedNumberOfVotesByPrecinct: Dictionary<number> = {
@@ -457,6 +459,7 @@ describe('convertSEMSFileToExternalTally', () => {
 
     // Check that the number of ballots in each precinct report and the overall tally are as expected.
     expect(convertedTally.overallTally.numberOfBallotsCounted).toBe(100)
+    expect(convertedTally.votingMethod).toBe(VotingMethod.Precinct)
     for (const precinctId of Object.keys(expectedNumberOfVotesByPrecinct)) {
       const tallyForPrecinct = convertedTally.resultsByCategory.get(
         TallyCategory.Precinct
@@ -540,7 +543,8 @@ describe('convertSEMSFileToExternalTally', () => {
   it('converts primary election sems file properly', async () => {
     const convertedTally = convertSEMSFileToExternalTally(
       primarySEMSContent,
-      multiPartyPrimaryElection
+      multiPartyPrimaryElection,
+      VotingMethod.Absentee
     )
 
     const expectedNumberOfVotesByPrecinct: Dictionary<number> = {
@@ -553,6 +557,7 @@ describe('convertSEMSFileToExternalTally', () => {
 
     // Check that the number of ballots in each precinct report and the overall tally are as expected.
     expect(convertedTally.overallTally.numberOfBallotsCounted).toBe(4530)
+    expect(convertedTally.votingMethod).toBe(VotingMethod.Absentee)
     for (const precinctId of Object.keys(expectedNumberOfVotesByPrecinct)) {
       const tallyForPrecinct = convertedTally.resultsByCategory.get(
         TallyCategory.Precinct

--- a/apps/election-manager/src/utils/semsTallies.ts
+++ b/apps/election-manager/src/utils/semsTallies.ts
@@ -243,7 +243,8 @@ function sanitizeItem(item: string): string {
 
 export function convertSEMSFileToExternalTally(
   fileContent: string,
-  election: Election
+  election: Election,
+  votingMethodForFile: VotingMethod
 ): FullElectionExternalTally {
   const parsedRows: SEMSFileRow[] = []
   fileContent.split('\n').forEach((row) => {
@@ -350,6 +351,7 @@ export function convertSEMSFileToExternalTally(
   return {
     overallTally,
     resultsByCategory,
+    votingMethod: votingMethodForFile,
   }
 }
 
@@ -375,8 +377,12 @@ export function filterExternalTalliesByParams(
     votingMethod?: VotingMethod
   }
 ): OptionalExternalTally {
-  if (!fullTally || scannerId || votingMethod) {
+  if (!fullTally || scannerId) {
     return undefined
+  }
+
+  if (votingMethod && fullTally.votingMethod !== votingMethod) {
+    return getEmptyTally()
   }
 
   const { overallTally, resultsByCategory } = fullTally

--- a/apps/election-manager/test/renderInAppContext.tsx
+++ b/apps/election-manager/test/renderInAppContext.tsx
@@ -5,7 +5,7 @@ import { sha256 } from 'js-sha256'
 import { render as testRender } from '@testing-library/react'
 import type { RenderResult } from '@testing-library/react'
 import { electionWithMsEitherNeitherRawData } from '@votingworks/fixtures'
-import { Election, ElectionDefinition } from '@votingworks/types'
+import { Election, ElectionDefinition, Optional } from '@votingworks/types'
 
 import AppContext from '../src/contexts/AppContext'
 import {
@@ -15,6 +15,7 @@ import {
   FullElectionTally,
   OptionalFullElectionExternalTally,
   OptionalFile,
+  ExternalFileConfiguration,
 } from '../src/config/types'
 import CastVoteRecordFiles, {
   SaveCastVoteRecordFiles,
@@ -53,7 +54,9 @@ interface RenderInAppContextParams {
   setFullElectionExternalTally?: React.Dispatch<
     React.SetStateAction<OptionalFullElectionExternalTally>
   >
-  saveExternalVoteRecordsFile?: (externalFile: OptionalFile) => void
+  saveExternalVoteRecordsFile?: (
+    externalFileConfig: Optional<ExternalFileConfiguration>
+  ) => void
   fullElectionExternalTally?: OptionalFullElectionExternalTally
   externalVoteRecordsFile?: OptionalFile
 }


### PR DESCRIPTION
Asks users to specify which voting method to count external results as before finalizing the import. Then counts the external tallies as that voting method in all appropriate places. 

https://user-images.githubusercontent.com/14897017/113062407-88a3e200-9168-11eb-92ef-8592286ccc73.mov

https://zube.io/votingworks/vxsuite/c/3169