### PR TITLE
fix(bsd): no longer validate election data structure on client to satisfy JSON serialization

### DIFF
--- a/apps/bsd/src/util/ballot-package.ts
+++ b/apps/bsd/src/util/ballot-package.ts
@@ -2,7 +2,6 @@ import {
   BallotStyle,
   Contest,
   ElectionDefinition,
-  parseElection,
   Precinct,
 } from '@votingworks/types'
 import type { BallotLocales } from '@votingworks/hmpb-interpreter'
@@ -179,7 +178,7 @@ async function readBallotPackageFromZip(
 
   return {
     electionDefinition: {
-      election: parseElection(JSON.parse(electionData)),
+      election: JSON.parse(electionData),
       electionData,
       electionHash: sha256(electionData),
     },


### PR DESCRIPTION
Longer term, we want to revisit the fragility of checking the round-trip JSON serialization, which we cannot rely on.

Short term, this solves the problem with the smallest possible code change. Plus, no good reason to validate the election data structure on the client, the server can handle it fine.