### PR TITLE
Improve validation for SEMS file import

### DIFF
--- a/apps/election-manager/src/components/ImportExternalResultsModal.tsx
+++ b/apps/election-manager/src/components/ImportExternalResultsModal.tsx
@@ -4,7 +4,10 @@ import * as format from '../utils/format'
 import { VotingMethod } from '../config/types'
 import AppContext from '../contexts/AppContext'
 import readFileAsync from '../lib/readFileAsync'
-import { convertSEMSFileToExternalTally } from '../utils/semsTallies'
+import {
+  convertSEMSFileToExternalTally,
+  parseSEMSFileAndValidateForElection,
+} from '../utils/semsTallies'
 import LinkButton from './LinkButton'
 import Loading from './Loading'
 import Modal from './Modal'
@@ -38,15 +41,27 @@ const ImportExternalResultsModal: React.FC<Props> = ({
     // Compute the tallies to see if there are any errors, if so display
     // an error modal.
     try {
+      const fileErrors = parseSEMSFileAndValidateForElection(
+        fileContent,
+        election
+      )
+      if (fileErrors.length > 0) {
+        setErrorMessage(
+          `Failed to import external file. ${fileErrors.join(' ')}`
+        )
+        setIsImportingFile(false)
+        return
+      }
       const tally = convertSEMSFileToExternalTally(
         fileContent,
         election,
         ballotType // We are not storing this tally, the ballot type here is not accurate yet but is thrown away
       )
       setNumberBallotsToImport(tally.overallTally.numberOfBallotsCounted)
-      setIsImportingFile(false)
     } catch (error) {
       setErrorMessage(`Failed to import external file. ${error.message}`)
+    } finally {
+      setIsImportingFile(false)
     }
   }
 


### PR DESCRIPTION
Checks when importing SEMs file: 
- Precinct ID is valid
- Contest ID is valid
- Candidate ID is valid, for yes/no contests this includes checking that the election definition has specified ids for the yes and no options. 

Note that I made the candidate ID checking fairly restrictive w.r.t. write ins, and an error is shown when a write in candidate ID is used for a yes/no contest, or a candidate contest that does not allow write ins. I wouldn't be completely shocked if the TSX machines don't handle this perfectly and always include a write in row with 0 votes (although I have no idea). So I could see an argument to only throw an error in these cases if the number of votes in greater then 0 but I didn't do that here. Open to feedback on how restrictive/permissive to be here. 

https://zube.io/votingworks/vxsuite/c/3188