### PR TITLE
fix(scan): update for latest backup format

### DIFF
--- a/apps/module-scan/bin/extract-backup
+++ b/apps/module-scan/bin/extract-backup
@@ -13,13 +13,9 @@ fi
 BACKUP_DIR=$(realpath "${BACKUP_FILE%.*}")
 mkdir -p "${BACKUP_DIR}"
 
-echo -e "\e[1mExtracting images…\e[0m"
-unzip -o "${BACKUP_FILE}" "*.png" "*.jpg" "*.jpeg" -d "${BACKUP_DIR}"
-
-echo
-echo -e "\e[1mExtracting database…\e[0m"
-unzip -o "${BACKUP_FILE}" ballots.db -d "${BACKUP_DIR}"
-[ -f "${BACKUP_DIR}/ballots.db.digest" ] || (shasum -a 256 schema.sql | cut -d " " -f 1 > "${BACKUP_DIR}/ballots.db.digest")
+echo -e "\e[1mExtracting images & database…\e[0m"
+unzip -o "${BACKUP_FILE}" -d "${BACKUP_DIR}"
+shasum -a 256 schema.sql | cut -d " " -f 1 > "${BACKUP_DIR}/ballots.db.digest"
 
 MANIFEST_FILE="${BACKUP_DIR}/manifest"
 sqlite3 "${BACKUP_DIR}/ballots.db" "
@@ -49,8 +45,11 @@ echo
 echo -e "\e[1mSuccess! Your backup has been extracted.\e[0m"
 echo -e "Restart module-scan/bsd to see the changes."
 echo
+echo -e "To run module-scan/bsd with the backup as the workspace, run this and then run module-scan in the same terminal:"
+echo -e "$ \e[4mexport MODULE_SCAN_WORKSPACE='${BACKUP_DIR}'\e[0m"
+echo
 echo -e "To re-scan the images using the UI, run this then restart module-scan/bsd in the same terminal:"
-echo -e "$ \e[4mexport MOCK_SCANNER_FILES=@${MANIFEST_FILE}\e[0m"
+echo -e "$ \e[4mexport MOCK_SCANNER_FILES='@${MANIFEST_FILE}'\e[0m"
 echo
 echo -e "To re-scan the images on the CLI, run this:"
-echo -e "$ \e[4m./bin/retry-scan --all -i ${BACKUP_DIR}\e[0m"
+echo -e "$ \e[4m./bin/retry-scan --all -i '${BACKUP_DIR}'\e[0m"

--- a/apps/module-scan/src/store.ts
+++ b/apps/module-scan/src/store.ts
@@ -19,7 +19,7 @@ import {
 import { createHash } from 'crypto'
 import makeDebug from 'debug'
 import { promises as fs } from 'fs'
-import { join } from 'path'
+import { dirname, join } from 'path'
 import * as sqlite3 from 'sqlite3'
 import { Writable } from 'stream'
 import { inspect } from 'util'
@@ -53,6 +53,7 @@ import { BallotSheetInfo } from './util/ballotAdjudicationReasons'
 import getBallotPageContests from './util/getBallotPageContests'
 import { loadImageData } from './util/images'
 import { changesFromMarks, mergeChanges } from './util/marks'
+import { normalizeAndJoin } from './util/path'
 
 const debug = makeDebug('module-scan:store')
 
@@ -590,7 +591,10 @@ export default class Store {
       return
     }
 
-    return row
+    return {
+      original: normalizeAndJoin(dirname(this.dbPath), row.original),
+      normalized: normalizeAndJoin(dirname(this.dbPath), row.normalized),
+    }
   }
 
   public async getPage(

--- a/apps/module-scan/src/util/path.test.ts
+++ b/apps/module-scan/src/util/path.test.ts
@@ -1,0 +1,17 @@
+import { normalizeAndJoin } from './path'
+
+test('normalizeAndJoin with a single path', () => {
+  expect(normalizeAndJoin('a.txt')).toEqual('a.txt')
+})
+
+test('normalizeAndJoin with multiple relative path parts', () => {
+  expect(normalizeAndJoin('a/b', 'c/d', 'e.txt')).toEqual('a/b/c/d/e.txt')
+})
+
+test('normalizeAndJoin with a leading absolute path', () => {
+  expect(normalizeAndJoin('/a', 'b', 'c.txt')).toEqual('/a/b/c.txt')
+})
+
+test('normalizeAndJoin with non-leading absolute paths', () => {
+  expect(normalizeAndJoin('a', '/b', '/c', '../d.txt')).toEqual('/d.txt')
+})

--- a/apps/module-scan/src/util/path.ts
+++ b/apps/module-scan/src/util/path.ts
@@ -1,0 +1,19 @@
+import { isAbsolute, join } from 'path'
+
+/**
+ * Joins path parts by using the last absolute path, if any, and joining
+ * all the following parts, normalizing the result.
+ */
+export function normalizeAndJoin(path: string, ...parts: string[]): string {
+  let result = path
+
+  for (const part of parts) {
+    if (isAbsolute(part)) {
+      result = part
+    } else {
+      result = join(result, part)
+    }
+  }
+
+  return result
+}


### PR DESCRIPTION
`unzip` fails if one of the extract paths/globs doesn't match anything, so since we don't know off the bat whether it has JPEG or PNG files, just unzip everything.

Similarly, `sendFile` wants an absolute path and the paths in the database for image files are relative. This updates the returned paths to be absolute by assuming they're relative to the database file's directory.