### PR TITLE
test(ci): use node v12.19 everywhere

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   nodejs-browsers:
     docker:
-      - image: circleci/node:12.10.0-browsers
+      - image: circleci/node:12.19.0-browsers
   nodejs:
     docker:
       - image: circleci/node:12.19


### PR DESCRIPTION
We should be using the version of node specified in the `.node-version` file. Additionally, pnpm v6 requires node v12.17+ so we need to upgrade past the v12.10 we were on in some CI builds.