### PR TITLE
refactor(em) moves final export to new tallies endpoint in mcs

### DIFF
--- a/apps/election-manager/src/AppRoot.tsx
+++ b/apps/election-manager/src/AppRoot.tsx
@@ -34,6 +34,7 @@ import {
   CastVoteRecordLists,
   VotingMethod,
   ExternalFileConfiguration,
+  ExportableTallies,
 } from './config/types'
 import {
   convertFileToStorageString,
@@ -41,6 +42,7 @@ import {
 } from './utils/file'
 import { convertSEMSFileToExternalTally } from './utils/semsTallies'
 import readFileAsync from './lib/readFileAsync'
+import { getExportableTallies } from './utils/exportableTallies'
 
 export interface AppStorage {
   electionDefinition?: ElectionDefinition
@@ -362,6 +364,15 @@ const AppRoot: React.FC<Props> = ({ storage }) => {
     ]
   )
 
+  const generateExportableTallies = (): ExportableTallies => {
+    assert(electionDefinition)
+    return getExportableTallies(
+      fullElectionTally,
+      fullElectionExternalTally ? [fullElectionExternalTally] : [],
+      electionDefinition.election
+    )
+  }
+
   return (
     <AppContext.Provider
       value={{
@@ -386,6 +397,7 @@ const AppRoot: React.FC<Props> = ({ storage }) => {
         setFullElectionExternalTally,
         isTabulationRunning,
         setIsTabulationRunning,
+        generateExportableTallies,
       }}
     >
       <ElectionManager />

--- a/apps/election-manager/src/components/ExportFinalResultsModal.test.tsx
+++ b/apps/election-manager/src/components/ExportFinalResultsModal.test.tsx
@@ -68,15 +68,15 @@ test('render export modal when a usb drive is mounted as expected and allows aut
   window.kiosk = mockKiosk
   mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()])
 
-  fetchMock.getOnce('/convert/results/files', {
+  fetchMock.getOnce('/convert/tallies/files', {
     inputFiles: [{ name: 'name' }, { name: 'name' }],
     outputFiles: [{ name: 'name' }],
   })
 
-  fetchMock.post('/convert/results/submitfile', { body: { status: 'ok' } })
-  fetchMock.post('/convert/results/process', { body: { status: 'ok' } })
+  fetchMock.post('/convert/tallies/submitfile', { body: { status: 'ok' } })
+  fetchMock.post('/convert/tallies/process', { body: { status: 'ok' } })
 
-  fetchMock.getOnce('/convert/results/output?name=name', { body: '' })
+  fetchMock.getOnce('/convert/tallies/output?name=name', { body: '' })
 
   fetchMock.post('/convert/reset', { body: { status: 'ok' } })
 
@@ -105,10 +105,10 @@ test('render export modal when a usb drive is mounted as expected and allows aut
       '{"body":""}'
     )
   })
-  expect(fetchMock.called('/convert/results/files')).toBe(true)
-  expect(fetchMock.called('/convert/results/submitfile')).toBe(true)
-  expect(fetchMock.called('/convert/results/process')).toBe(true)
-  expect(fetchMock.called('/convert/results/output?name=name')).toBe(true)
+  expect(fetchMock.called('/convert/tallies/files')).toBe(true)
+  expect(fetchMock.called('/convert/tallies/submitfile')).toBe(true)
+  expect(fetchMock.called('/convert/tallies/process')).toBe(true)
+  expect(fetchMock.called('/convert/tallies/output?name=name')).toBe(true)
   expect(fetchMock.called('/convert/reset')).toBe(true)
 
   fireEvent.click(getByText('Close'))
@@ -120,19 +120,17 @@ test('render export modal when a usb drive is mounted and exports with external 
   window.kiosk = mockKiosk
   mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()])
 
-  fetchMock.getOnce('/convert/results/files', {
+  fetchMock.getOnce('/convert/tallies/files', {
     inputFiles: [{ name: 'name' }, { name: 'name' }],
     outputFiles: [{ name: 'name' }],
   })
 
-  fetchMock.post('/convert/results/submitfile', { body: { status: 'ok' } })
-  fetchMock.post('/convert/results/process', { body: { status: 'ok' } })
+  fetchMock.post('/convert/tallies/submitfile', { body: { status: 'ok' } })
+  fetchMock.post('/convert/tallies/process', { body: { status: 'ok' } })
 
-  fetchMock.getOnce('/convert/results/output?name=name', { body: 'og-results' })
+  fetchMock.getOnce('/convert/tallies/output?name=name', { body: 'og-results' })
 
   fetchMock.post('/convert/reset', { body: { status: 'ok' } })
-
-  fetchMock.post('/convert/results/combine', { body: 'combine-results' })
 
   const externalFile = new File(['content'], 'to-combine.csv')
   const closeFn = jest.fn()
@@ -163,15 +161,14 @@ test('render export modal when a usb drive is mounted and exports with external 
     expect(mockKiosk.writeFile).toHaveBeenNthCalledWith(
       1,
       'fake mount point/votingworks-live-results_choctaw-county_mock-general-election-choctaw-2020_2020-03-14_01-59-26.csv',
-      'combine-results'
+      'og-results'
     )
   })
-  expect(fetchMock.called('/convert/results/files')).toBe(true)
-  expect(fetchMock.called('/convert/results/submitfile')).toBe(true)
-  expect(fetchMock.called('/convert/results/process')).toBe(true)
-  expect(fetchMock.called('/convert/results/output?name=name')).toBe(true)
+  expect(fetchMock.called('/convert/tallies/files')).toBe(true)
+  expect(fetchMock.called('/convert/tallies/submitfile')).toBe(true)
+  expect(fetchMock.called('/convert/tallies/process')).toBe(true)
+  expect(fetchMock.called('/convert/tallies/output?name=name')).toBe(true)
   expect(fetchMock.called('/convert/reset')).toBe(true)
-  expect(fetchMock.called('/convert/results/combine')).toBe(true)
 
   fireEvent.click(getByText('Close'))
   expect(closeFn).toHaveBeenCalled()
@@ -182,7 +179,7 @@ test('render export modal with errors when appropriate', async () => {
   window.kiosk = mockKiosk
 
   // When inputFiles doesn't return 2 expected files the saving code will error.
-  fetchMock.getOnce('/convert/results/files', {
+  fetchMock.getOnce('/convert/tallies/files', {
     inputFiles: [],
     outputFiles: [],
   })

--- a/apps/election-manager/src/config/types.ts
+++ b/apps/election-manager/src/config/types.ts
@@ -131,6 +131,15 @@ export interface FullElectionExternalTally {
   readonly votingMethod: VotingMethod
 }
 
+export interface ExportableContestTally {
+  readonly tallies: Dictionary<number>
+  readonly metadata: ContestTallyMeta
+}
+export type ExportableTally = Dictionary<ExportableContestTally>
+export interface ExportableTallies {
+  readonly talliesByPrecinct: Dictionary<ExportableTally>
+}
+
 export interface ExternalFileConfiguration {
   readonly file: File
   readonly votingMethod: VotingMethod

--- a/apps/election-manager/src/contexts/AppContext.ts
+++ b/apps/election-manager/src/contexts/AppContext.ts
@@ -8,12 +8,14 @@ import {
   OptionalFullElectionExternalTally,
   OptionalFile,
   ExternalFileConfiguration,
+  ExportableTallies,
 } from '../config/types'
 import { UsbDriveStatus } from '../lib/usbstick'
 import CastVoteRecordFiles, {
   SaveCastVoteRecordFiles,
 } from '../utils/CastVoteRecordFiles'
 import { getEmptyFullElectionTally } from '../lib/votecounting'
+import { getEmptyExportableTallies } from '../utils/exportableTallies'
 
 export interface AppContextInterface {
   castVoteRecordFiles: CastVoteRecordFiles
@@ -43,6 +45,7 @@ export interface AppContextInterface {
     externalFileConfig: Optional<ExternalFileConfiguration>
   ) => void
   setIsTabulationRunning: React.Dispatch<React.SetStateAction<boolean>>
+  generateExportableTallies: () => ExportableTallies
 }
 
 const appContext: AppContextInterface = {
@@ -67,6 +70,7 @@ const appContext: AppContextInterface = {
   saveExternalVoteRecordsFile: () => undefined,
   isTabulationRunning: false,
   setIsTabulationRunning: () => undefined,
+  generateExportableTallies: getEmptyExportableTallies,
 }
 
 const AppContext = createContext(appContext)

--- a/apps/election-manager/src/utils/__snapshots__/exportableTallies.test.ts.snap
+++ b/apps/election-manager/src/utils/__snapshots__/exportableTallies.test.ts.snap
@@ -1,0 +1,1976 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getExportableTallies builds expected tally object for election with either neither with just internal data 1`] = `
+Object {
+  "talliesByPrecinct": Object {
+    "6522": Object {
+      "750000015": Object {
+        "metadata": Object {
+          "ballots": 19,
+          "overvotes": 0,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "no": 11,
+          "yes": 7,
+        },
+      },
+      "750000016": Object {
+        "metadata": Object {
+          "ballots": 19,
+          "overvotes": 0,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "no": 7,
+          "yes": 11,
+        },
+      },
+      "750000017": Object {
+        "metadata": Object {
+          "ballots": 19,
+          "overvotes": 0,
+          "undervotes": 2,
+        },
+        "tallies": Object {
+          "no": 7,
+          "yes": 10,
+        },
+      },
+      "750000018": Object {
+        "metadata": Object {
+          "ballots": 19,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 13,
+          "yes": 6,
+        },
+      },
+      "775020870": Object {
+        "metadata": Object {
+          "ballots": 19,
+          "overvotes": 0,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "775031976": 5,
+          "775031993": 13,
+          "__write-in": 0,
+        },
+      },
+      "775020872": Object {
+        "metadata": Object {
+          "ballots": 19,
+          "overvotes": 1,
+          "undervotes": 2,
+        },
+        "tallies": Object {
+          "775031978": 8,
+          "775031979": 8,
+          "__write-in": 0,
+        },
+      },
+      "775020876": Object {
+        "metadata": Object {
+          "ballots": 19,
+          "overvotes": 0,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "775031987": 9,
+          "775031988": 4,
+          "775031989": 5,
+          "__write-in": 0,
+        },
+      },
+      "775020877": Object {
+        "metadata": Object {
+          "ballots": 19,
+          "overvotes": 1,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031985": 8,
+          "775031986": 2,
+          "775031990": 8,
+          "__write-in": 0,
+        },
+      },
+      "775020903": Object {
+        "metadata": Object {
+          "ballots": 19,
+          "overvotes": 2,
+          "undervotes": 2,
+        },
+        "tallies": Object {
+          "775032021": 9,
+          "775032022": 6,
+          "__write-in": 0,
+        },
+      },
+      "775020904": Object {
+        "metadata": Object {
+          "ballots": 19,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775032023": 19,
+          "__write-in": 0,
+        },
+      },
+    },
+    "6524": Object {
+      "750000015": Object {
+        "metadata": Object {
+          "ballots": 7,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 4,
+          "yes": 3,
+        },
+      },
+      "750000016": Object {
+        "metadata": Object {
+          "ballots": 7,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 5,
+          "yes": 2,
+        },
+      },
+      "750000017": Object {
+        "metadata": Object {
+          "ballots": 7,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 5,
+          "yes": 2,
+        },
+      },
+      "750000018": Object {
+        "metadata": Object {
+          "ballots": 7,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 3,
+          "yes": 4,
+        },
+      },
+      "775020870": Object {
+        "metadata": Object {
+          "ballots": 7,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031976": 1,
+          "775031993": 6,
+          "__write-in": 0,
+        },
+      },
+      "775020872": Object {
+        "metadata": Object {
+          "ballots": 7,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031978": 3,
+          "775031979": 4,
+          "__write-in": 0,
+        },
+      },
+      "775020876": Object {
+        "metadata": Object {
+          "ballots": 7,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031987": 2,
+          "775031988": 2,
+          "775031989": 3,
+          "__write-in": 0,
+        },
+      },
+      "775020877": Object {
+        "metadata": Object {
+          "ballots": 7,
+          "overvotes": 0,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "775031985": 2,
+          "775031986": 3,
+          "775031990": 1,
+          "__write-in": 0,
+        },
+      },
+      "775020899": Object {
+        "metadata": Object {
+          "ballots": 7,
+          "overvotes": 0,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "775032015": 6,
+          "__write-in": 0,
+        },
+      },
+    },
+    "6525": Object {
+      "750000015": Object {
+        "metadata": Object {
+          "ballots": 11,
+          "overvotes": 0,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "no": 4,
+          "yes": 6,
+        },
+      },
+      "750000016": Object {
+        "metadata": Object {
+          "ballots": 11,
+          "overvotes": 0,
+          "undervotes": 2,
+        },
+        "tallies": Object {
+          "no": 5,
+          "yes": 4,
+        },
+      },
+      "750000017": Object {
+        "metadata": Object {
+          "ballots": 11,
+          "overvotes": 0,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "no": 5,
+          "yes": 5,
+        },
+      },
+      "750000018": Object {
+        "metadata": Object {
+          "ballots": 11,
+          "overvotes": 0,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "no": 5,
+          "yes": 5,
+        },
+      },
+      "775020870": Object {
+        "metadata": Object {
+          "ballots": 11,
+          "overvotes": 0,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "775031976": 2,
+          "775031993": 8,
+          "__write-in": 0,
+        },
+      },
+      "775020872": Object {
+        "metadata": Object {
+          "ballots": 11,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031978": 6,
+          "775031979": 5,
+          "__write-in": 0,
+        },
+      },
+      "775020876": Object {
+        "metadata": Object {
+          "ballots": 11,
+          "overvotes": 0,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "775031987": 4,
+          "775031988": 4,
+          "775031989": 2,
+          "__write-in": 0,
+        },
+      },
+      "775020877": Object {
+        "metadata": Object {
+          "ballots": 11,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031985": 3,
+          "775031986": 6,
+          "775031990": 2,
+          "__write-in": 0,
+        },
+      },
+      "775020902": Object {
+        "metadata": Object {
+          "ballots": 11,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775032019": 5,
+          "775032020": 6,
+          "__write-in": 0,
+        },
+      },
+    },
+    "6526": Object {
+      "750000015": Object {
+        "metadata": Object {
+          "ballots": 7,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 5,
+          "yes": 2,
+        },
+      },
+      "750000016": Object {
+        "metadata": Object {
+          "ballots": 7,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 4,
+          "yes": 3,
+        },
+      },
+      "750000017": Object {
+        "metadata": Object {
+          "ballots": 8,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 6,
+          "yes": 2,
+        },
+      },
+      "750000018": Object {
+        "metadata": Object {
+          "ballots": 8,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 3,
+          "yes": 5,
+        },
+      },
+      "775020870": Object {
+        "metadata": Object {
+          "ballots": 8,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031976": 5,
+          "775031993": 3,
+          "__write-in": 0,
+        },
+      },
+      "775020872": Object {
+        "metadata": Object {
+          "ballots": 8,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031978": 3,
+          "775031979": 5,
+          "__write-in": 0,
+        },
+      },
+      "775020876": Object {
+        "metadata": Object {
+          "ballots": 8,
+          "overvotes": 0,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "775031987": 1,
+          "775031988": 4,
+          "775031989": 2,
+          "__write-in": 0,
+        },
+      },
+      "775020877": Object {
+        "metadata": Object {
+          "ballots": 8,
+          "overvotes": 1,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031985": 1,
+          "775031986": 1,
+          "775031990": 5,
+          "__write-in": 0,
+        },
+      },
+      "775020901": Object {
+        "metadata": Object {
+          "ballots": 8,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775032018": 8,
+          "__write-in": 0,
+        },
+      },
+    },
+    "6527": Object {
+      "750000015": Object {
+        "metadata": Object {
+          "ballots": 5,
+          "overvotes": 1,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 1,
+          "yes": 3,
+        },
+      },
+      "750000016": Object {
+        "metadata": Object {
+          "ballots": 5,
+          "overvotes": 0,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "no": 4,
+          "yes": 0,
+        },
+      },
+      "750000017": Object {
+        "metadata": Object {
+          "ballots": 5,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 3,
+          "yes": 2,
+        },
+      },
+      "750000018": Object {
+        "metadata": Object {
+          "ballots": 5,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 3,
+          "yes": 2,
+        },
+      },
+      "775020870": Object {
+        "metadata": Object {
+          "ballots": 5,
+          "overvotes": 0,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "775031976": 2,
+          "775031993": 2,
+          "__write-in": 0,
+        },
+      },
+      "775020872": Object {
+        "metadata": Object {
+          "ballots": 5,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031978": 1,
+          "775031979": 4,
+          "__write-in": 0,
+        },
+      },
+      "775020876": Object {
+        "metadata": Object {
+          "ballots": 5,
+          "overvotes": 0,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "775031987": 2,
+          "775031988": 0,
+          "775031989": 2,
+          "__write-in": 0,
+        },
+      },
+      "775020877": Object {
+        "metadata": Object {
+          "ballots": 5,
+          "overvotes": 0,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "775031985": 1,
+          "775031986": 0,
+          "775031990": 3,
+          "__write-in": 0,
+        },
+      },
+      "775020899": Object {
+        "metadata": Object {
+          "ballots": 5,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775032015": 5,
+          "__write-in": 0,
+        },
+      },
+    },
+    "6528": Object {
+      "750000015": Object {
+        "metadata": Object {
+          "ballots": 6,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 5,
+          "yes": 1,
+        },
+      },
+      "750000016": Object {
+        "metadata": Object {
+          "ballots": 6,
+          "overvotes": 1,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 1,
+          "yes": 4,
+        },
+      },
+      "750000017": Object {
+        "metadata": Object {
+          "ballots": 7,
+          "overvotes": 1,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 3,
+          "yes": 3,
+        },
+      },
+      "750000018": Object {
+        "metadata": Object {
+          "ballots": 7,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 4,
+          "yes": 3,
+        },
+      },
+      "775020870": Object {
+        "metadata": Object {
+          "ballots": 7,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031976": 6,
+          "775031993": 1,
+          "__write-in": 0,
+        },
+      },
+      "775020872": Object {
+        "metadata": Object {
+          "ballots": 7,
+          "overvotes": 1,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "775031978": 1,
+          "775031979": 4,
+          "__write-in": 0,
+        },
+      },
+      "775020876": Object {
+        "metadata": Object {
+          "ballots": 7,
+          "overvotes": 0,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "775031987": 3,
+          "775031988": 2,
+          "775031989": 1,
+          "__write-in": 0,
+        },
+      },
+      "775020877": Object {
+        "metadata": Object {
+          "ballots": 7,
+          "overvotes": 1,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031985": 2,
+          "775031986": 3,
+          "775031990": 1,
+          "__write-in": 0,
+        },
+      },
+      "775020900": Object {
+        "metadata": Object {
+          "ballots": 7,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775032016": 3,
+          "775032017": 4,
+          "__write-in": 0,
+        },
+      },
+    },
+    "6529": Object {
+      "750000015": Object {
+        "metadata": Object {
+          "ballots": 12,
+          "overvotes": 2,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "no": 4,
+          "yes": 5,
+        },
+      },
+      "750000016": Object {
+        "metadata": Object {
+          "ballots": 12,
+          "overvotes": 2,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "no": 5,
+          "yes": 4,
+        },
+      },
+      "750000017": Object {
+        "metadata": Object {
+          "ballots": 12,
+          "overvotes": 1,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "no": 6,
+          "yes": 4,
+        },
+      },
+      "750000018": Object {
+        "metadata": Object {
+          "ballots": 12,
+          "overvotes": 2,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 8,
+          "yes": 2,
+        },
+      },
+      "775020870": Object {
+        "metadata": Object {
+          "ballots": 12,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031976": 8,
+          "775031993": 4,
+          "__write-in": 0,
+        },
+      },
+      "775020872": Object {
+        "metadata": Object {
+          "ballots": 12,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031978": 10,
+          "775031979": 2,
+          "__write-in": 0,
+        },
+      },
+      "775020876": Object {
+        "metadata": Object {
+          "ballots": 12,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031987": 5,
+          "775031988": 3,
+          "775031989": 4,
+          "__write-in": 0,
+        },
+      },
+      "775020877": Object {
+        "metadata": Object {
+          "ballots": 12,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031985": 3,
+          "775031986": 7,
+          "775031990": 2,
+          "__write-in": 0,
+        },
+      },
+      "775020901": Object {
+        "metadata": Object {
+          "ballots": 12,
+          "overvotes": 0,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "775032018": 11,
+          "__write-in": 0,
+        },
+      },
+    },
+    "6532": Object {
+      "750000015": Object {
+        "metadata": Object {
+          "ballots": 9,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 5,
+          "yes": 4,
+        },
+      },
+      "750000016": Object {
+        "metadata": Object {
+          "ballots": 9,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 4,
+          "yes": 5,
+        },
+      },
+      "750000017": Object {
+        "metadata": Object {
+          "ballots": 9,
+          "overvotes": 0,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "no": 3,
+          "yes": 5,
+        },
+      },
+      "750000018": Object {
+        "metadata": Object {
+          "ballots": 9,
+          "overvotes": 0,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "no": 2,
+          "yes": 6,
+        },
+      },
+      "775020870": Object {
+        "metadata": Object {
+          "ballots": 9,
+          "overvotes": 0,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "775031976": 1,
+          "775031993": 7,
+          "__write-in": 0,
+        },
+      },
+      "775020872": Object {
+        "metadata": Object {
+          "ballots": 9,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031978": 3,
+          "775031979": 6,
+          "__write-in": 0,
+        },
+      },
+      "775020876": Object {
+        "metadata": Object {
+          "ballots": 9,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031987": 3,
+          "775031988": 3,
+          "775031989": 3,
+          "__write-in": 0,
+        },
+      },
+      "775020877": Object {
+        "metadata": Object {
+          "ballots": 9,
+          "overvotes": 0,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "775031985": 4,
+          "775031986": 3,
+          "775031990": 1,
+          "__write-in": 0,
+        },
+      },
+      "775020902": Object {
+        "metadata": Object {
+          "ballots": 9,
+          "overvotes": 1,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775032019": 3,
+          "775032020": 5,
+          "__write-in": 0,
+        },
+      },
+    },
+    "6534": Object {
+      "750000015": Object {
+        "metadata": Object {
+          "ballots": 5,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 4,
+          "yes": 1,
+        },
+      },
+      "750000016": Object {
+        "metadata": Object {
+          "ballots": 5,
+          "overvotes": 1,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 1,
+          "yes": 3,
+        },
+      },
+      "750000017": Object {
+        "metadata": Object {
+          "ballots": 5,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 4,
+          "yes": 1,
+        },
+      },
+      "750000018": Object {
+        "metadata": Object {
+          "ballots": 5,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 3,
+          "yes": 2,
+        },
+      },
+      "775020870": Object {
+        "metadata": Object {
+          "ballots": 5,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031976": 2,
+          "775031993": 3,
+          "__write-in": 0,
+        },
+      },
+      "775020872": Object {
+        "metadata": Object {
+          "ballots": 5,
+          "overvotes": 1,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031978": 3,
+          "775031979": 1,
+          "__write-in": 0,
+        },
+      },
+      "775020876": Object {
+        "metadata": Object {
+          "ballots": 5,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031987": 3,
+          "775031988": 1,
+          "775031989": 1,
+          "__write-in": 0,
+        },
+      },
+      "775020877": Object {
+        "metadata": Object {
+          "ballots": 5,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031985": 1,
+          "775031986": 3,
+          "775031990": 1,
+          "__write-in": 0,
+        },
+      },
+      "775020900": Object {
+        "metadata": Object {
+          "ballots": 5,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775032016": 1,
+          "775032017": 4,
+          "__write-in": 0,
+        },
+      },
+    },
+    "6536": Object {
+      "750000015": Object {
+        "metadata": Object {
+          "ballots": 3,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 2,
+          "yes": 1,
+        },
+      },
+      "750000016": Object {
+        "metadata": Object {
+          "ballots": 3,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 3,
+          "yes": 0,
+        },
+      },
+      "750000017": Object {
+        "metadata": Object {
+          "ballots": 3,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 3,
+          "yes": 0,
+        },
+      },
+      "750000018": Object {
+        "metadata": Object {
+          "ballots": 3,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 0,
+          "yes": 3,
+        },
+      },
+      "775020870": Object {
+        "metadata": Object {
+          "ballots": 3,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031976": 1,
+          "775031993": 2,
+          "__write-in": 0,
+        },
+      },
+      "775020872": Object {
+        "metadata": Object {
+          "ballots": 3,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031978": 2,
+          "775031979": 1,
+          "__write-in": 0,
+        },
+      },
+      "775020876": Object {
+        "metadata": Object {
+          "ballots": 3,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031987": 0,
+          "775031988": 1,
+          "775031989": 2,
+          "__write-in": 0,
+        },
+      },
+      "775020877": Object {
+        "metadata": Object {
+          "ballots": 3,
+          "overvotes": 0,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "775031985": 0,
+          "775031986": 2,
+          "775031990": 0,
+          "__write-in": 0,
+        },
+      },
+      "775020900": Object {
+        "metadata": Object {
+          "ballots": 3,
+          "overvotes": 0,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "775032016": 1,
+          "775032017": 1,
+          "__write-in": 0,
+        },
+      },
+    },
+    "6537": Object {
+      "750000015": Object {
+        "metadata": Object {
+          "ballots": 5,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 2,
+          "yes": 3,
+        },
+      },
+      "750000016": Object {
+        "metadata": Object {
+          "ballots": 5,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 4,
+          "yes": 1,
+        },
+      },
+      "750000017": Object {
+        "metadata": Object {
+          "ballots": 5,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 2,
+          "yes": 3,
+        },
+      },
+      "750000018": Object {
+        "metadata": Object {
+          "ballots": 5,
+          "overvotes": 1,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 2,
+          "yes": 2,
+        },
+      },
+      "775020870": Object {
+        "metadata": Object {
+          "ballots": 5,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031976": 2,
+          "775031993": 3,
+          "__write-in": 0,
+        },
+      },
+      "775020872": Object {
+        "metadata": Object {
+          "ballots": 5,
+          "overvotes": 0,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "775031978": 1,
+          "775031979": 3,
+          "__write-in": 0,
+        },
+      },
+      "775020876": Object {
+        "metadata": Object {
+          "ballots": 5,
+          "overvotes": 1,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "775031987": 2,
+          "775031988": 0,
+          "775031989": 1,
+          "__write-in": 0,
+        },
+      },
+      "775020877": Object {
+        "metadata": Object {
+          "ballots": 5,
+          "overvotes": 1,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031985": 2,
+          "775031986": 2,
+          "775031990": 0,
+          "__write-in": 0,
+        },
+      },
+      "775020902": Object {
+        "metadata": Object {
+          "ballots": 5,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775032019": 2,
+          "775032020": 3,
+          "__write-in": 0,
+        },
+      },
+    },
+    "6538": Object {
+      "750000015": Object {
+        "metadata": Object {
+          "ballots": 6,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 4,
+          "yes": 2,
+        },
+      },
+      "750000016": Object {
+        "metadata": Object {
+          "ballots": 6,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 5,
+          "yes": 1,
+        },
+      },
+      "750000017": Object {
+        "metadata": Object {
+          "ballots": 6,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 4,
+          "yes": 2,
+        },
+      },
+      "750000018": Object {
+        "metadata": Object {
+          "ballots": 6,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 4,
+          "yes": 2,
+        },
+      },
+      "775020870": Object {
+        "metadata": Object {
+          "ballots": 6,
+          "overvotes": 0,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "775031976": 2,
+          "775031993": 3,
+          "__write-in": 0,
+        },
+      },
+      "775020872": Object {
+        "metadata": Object {
+          "ballots": 6,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031978": 5,
+          "775031979": 1,
+          "__write-in": 0,
+        },
+      },
+      "775020876": Object {
+        "metadata": Object {
+          "ballots": 6,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031987": 2,
+          "775031988": 1,
+          "775031989": 3,
+          "__write-in": 0,
+        },
+      },
+      "775020877": Object {
+        "metadata": Object {
+          "ballots": 6,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031985": 1,
+          "775031986": 2,
+          "775031990": 3,
+          "__write-in": 0,
+        },
+      },
+      "775020899": Object {
+        "metadata": Object {
+          "ballots": 6,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775032015": 6,
+          "__write-in": 0,
+        },
+      },
+    },
+    "6539": Object {
+      "750000015": Object {
+        "metadata": Object {
+          "ballots": 3,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 2,
+          "yes": 1,
+        },
+      },
+      "750000016": Object {
+        "metadata": Object {
+          "ballots": 3,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 1,
+          "yes": 2,
+        },
+      },
+      "750000017": Object {
+        "metadata": Object {
+          "ballots": 3,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 2,
+          "yes": 1,
+        },
+      },
+      "750000018": Object {
+        "metadata": Object {
+          "ballots": 3,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "no": 2,
+          "yes": 1,
+        },
+      },
+      "775020870": Object {
+        "metadata": Object {
+          "ballots": 3,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031976": 0,
+          "775031993": 3,
+          "__write-in": 0,
+        },
+      },
+      "775020872": Object {
+        "metadata": Object {
+          "ballots": 3,
+          "overvotes": 0,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "775031978": 0,
+          "775031979": 2,
+          "__write-in": 0,
+        },
+      },
+      "775020876": Object {
+        "metadata": Object {
+          "ballots": 3,
+          "overvotes": 0,
+          "undervotes": 1,
+        },
+        "tallies": Object {
+          "775031987": 0,
+          "775031988": 2,
+          "775031989": 0,
+          "__write-in": 0,
+        },
+      },
+      "775020877": Object {
+        "metadata": Object {
+          "ballots": 3,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775031985": 1,
+          "775031986": 1,
+          "775031990": 1,
+          "__write-in": 0,
+        },
+      },
+      "775020901": Object {
+        "metadata": Object {
+          "ballots": 3,
+          "overvotes": 0,
+          "undervotes": 0,
+        },
+        "tallies": Object {
+          "775032018": 3,
+          "__write-in": 0,
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`getExportableTallies builds expected tally object for primary election with just internal data 1`] = `
+Object {
+  "talliesByPrecinct": Object {
+    "precinct-1": Object {
+      "assistant-mayor-contest-liberty": Object {
+        "metadata": Object {
+          "ballots": 150,
+          "overvotes": 30,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "jenna-morasca": 30,
+          "sandra-diaz-twine": 30,
+        },
+      },
+      "chief-pokemon-constitution": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 60,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "flareon": 30,
+          "umbreon": 30,
+          "vaporeon": 240,
+        },
+      },
+      "governor-contest-constitution": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 30,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "dax-shepherd": 300,
+          "kristen-bell": 30,
+        },
+      },
+      "governor-contest-federalist": Object {
+        "metadata": Object {
+          "ballots": 300,
+          "overvotes": 60,
+          "undervotes": 60,
+        },
+        "tallies": Object {
+          "__write-in": 60,
+          "chidi-anagonye": 60,
+          "eleanor-shellstrop": 60,
+        },
+      },
+      "governor-contest-liberty": Object {
+        "metadata": Object {
+          "ballots": 150,
+          "overvotes": 30,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "aaron-aligator": 30,
+          "peter-pigeon": 30,
+        },
+      },
+      "mayor-contest-constitution": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 30,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "ethan-zohn": 300,
+          "tina-wesson": 30,
+        },
+      },
+      "mayor-contest-federalist": Object {
+        "metadata": Object {
+          "ballots": 150,
+          "overvotes": 30,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "brain-heidik": 30,
+          "vecepia-towery": 30,
+        },
+      },
+      "mayor-contest-liberty": Object {
+        "metadata": Object {
+          "ballots": 150,
+          "overvotes": 30,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "jason-mendoza": 30,
+          "tahani-al-jamil": 30,
+        },
+      },
+      "schoolboard-constitution": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 120,
+          "undervotes": 90,
+        },
+        "tallies": Object {
+          "__write-in": 120,
+          "aras-baskauskas": 150,
+          "earl-cole": 120,
+          "todd-herzog": 120,
+          "yul-kwon": 120,
+        },
+      },
+    },
+    "precinct-2": Object {
+      "chief-pokemon-constitution": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 60,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "flareon": 30,
+          "umbreon": 30,
+          "vaporeon": 240,
+        },
+      },
+      "chief-pokemon-liberty": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 60,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "bulbasaur": 30,
+          "charmander": 30,
+          "squirtle": 240,
+        },
+      },
+      "governor-contest-constitution": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 30,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "dax-shepherd": 300,
+          "kristen-bell": 30,
+        },
+      },
+      "governor-contest-liberty": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 30,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "aaron-aligator": 30,
+          "peter-pigeon": 300,
+        },
+      },
+      "mayor-contest-constitution": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 30,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "ethan-zohn": 300,
+          "tina-wesson": 30,
+        },
+      },
+      "schoolboard-constitution": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 120,
+          "undervotes": 90,
+        },
+        "tallies": Object {
+          "__write-in": 120,
+          "aras-baskauskas": 150,
+          "earl-cole": 120,
+          "todd-herzog": 120,
+          "yul-kwon": 120,
+        },
+      },
+      "schoolboard-liberty": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 120,
+          "undervotes": 90,
+        },
+        "tallies": Object {
+          "__write-in": 120,
+          "amber-brkich": 150,
+          "chris-daugherty": 120,
+          "danni-boatwright": 120,
+          "tom-westman": 120,
+        },
+      },
+    },
+    "precinct-3": Object {
+      "assistant-mayor-contest-liberty": Object {
+        "metadata": Object {
+          "ballots": 150,
+          "overvotes": 30,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "jenna-morasca": 30,
+          "sandra-diaz-twine": 30,
+        },
+      },
+      "chief-pokemon-constitution": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 60,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "flareon": 30,
+          "umbreon": 30,
+          "vaporeon": 240,
+        },
+      },
+      "governor-contest-constitution": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 30,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "dax-shepherd": 300,
+          "kristen-bell": 30,
+        },
+      },
+      "governor-contest-liberty": Object {
+        "metadata": Object {
+          "ballots": 150,
+          "overvotes": 30,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "aaron-aligator": 30,
+          "peter-pigeon": 30,
+        },
+      },
+      "mayor-contest-constitution": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 30,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "ethan-zohn": 300,
+          "tina-wesson": 30,
+        },
+      },
+      "mayor-contest-liberty": Object {
+        "metadata": Object {
+          "ballots": 150,
+          "overvotes": 30,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "jason-mendoza": 30,
+          "tahani-al-jamil": 30,
+        },
+      },
+      "schoolboard-constitution": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 120,
+          "undervotes": 90,
+        },
+        "tallies": Object {
+          "__write-in": 120,
+          "aras-baskauskas": 150,
+          "earl-cole": 120,
+          "todd-herzog": 120,
+          "yul-kwon": 120,
+        },
+      },
+    },
+    "precinct-4": Object {
+      "chief-pokemon-constitution": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 60,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "flareon": 30,
+          "umbreon": 30,
+          "vaporeon": 240,
+        },
+      },
+      "chief-pokemon-liberty": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 60,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "bulbasaur": 30,
+          "charmander": 30,
+          "squirtle": 240,
+        },
+      },
+      "governor-contest-constitution": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 30,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "dax-shepherd": 300,
+          "kristen-bell": 30,
+        },
+      },
+      "governor-contest-liberty": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 30,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "aaron-aligator": 30,
+          "peter-pigeon": 300,
+        },
+      },
+      "mayor-contest-constitution": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 30,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "ethan-zohn": 300,
+          "tina-wesson": 30,
+        },
+      },
+      "schoolboard-constitution": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 120,
+          "undervotes": 90,
+        },
+        "tallies": Object {
+          "__write-in": 120,
+          "aras-baskauskas": 150,
+          "earl-cole": 120,
+          "todd-herzog": 120,
+          "yul-kwon": 120,
+        },
+      },
+      "schoolboard-liberty": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 120,
+          "undervotes": 90,
+        },
+        "tallies": Object {
+          "__write-in": 120,
+          "amber-brkich": 150,
+          "chris-daugherty": 120,
+          "danni-boatwright": 120,
+          "tom-westman": 120,
+        },
+      },
+    },
+    "precinct-5": Object {
+      "assistant-mayor-contest-liberty": Object {
+        "metadata": Object {
+          "ballots": 150,
+          "overvotes": 30,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "jenna-morasca": 30,
+          "sandra-diaz-twine": 30,
+        },
+      },
+      "chief-pokemon-constitution": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 60,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "flareon": 30,
+          "umbreon": 30,
+          "vaporeon": 240,
+        },
+      },
+      "chief-pokemon-federalist": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 30,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "eevee": 300,
+          "pikachu": 30,
+        },
+      },
+      "chief-pokemon-liberty": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 60,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "bulbasaur": 30,
+          "charmander": 30,
+          "squirtle": 240,
+        },
+      },
+      "governor-contest-constitution": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 30,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "dax-shepherd": 300,
+          "kristen-bell": 30,
+        },
+      },
+      "governor-contest-federalist": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 30,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "chidi-anagonye": 300,
+          "eleanor-shellstrop": 30,
+        },
+      },
+      "governor-contest-liberty": Object {
+        "metadata": Object {
+          "ballots": 570,
+          "overvotes": 60,
+          "undervotes": 60,
+        },
+        "tallies": Object {
+          "__write-in": 60,
+          "aaron-aligator": 60,
+          "peter-pigeon": 330,
+        },
+      },
+      "mayor-contest-constitution": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 30,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "ethan-zohn": 300,
+          "tina-wesson": 30,
+        },
+      },
+      "mayor-contest-federalist": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 30,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "brain-heidik": 300,
+          "vecepia-towery": 30,
+        },
+      },
+      "mayor-contest-liberty": Object {
+        "metadata": Object {
+          "ballots": 150,
+          "overvotes": 30,
+          "undervotes": 30,
+        },
+        "tallies": Object {
+          "__write-in": 30,
+          "jason-mendoza": 30,
+          "tahani-al-jamil": 30,
+        },
+      },
+      "schoolboard-constitution": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 120,
+          "undervotes": 90,
+        },
+        "tallies": Object {
+          "__write-in": 120,
+          "aras-baskauskas": 150,
+          "earl-cole": 120,
+          "todd-herzog": 120,
+          "yul-kwon": 120,
+        },
+      },
+      "schoolboard-federalist": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 120,
+          "undervotes": 90,
+        },
+        "tallies": Object {
+          "__write-in": 120,
+          "bob-crowley": 120,
+          "jt-thomas": 120,
+          "natalie-white": 120,
+          "parvati-shallow": 150,
+        },
+      },
+      "schoolboard-liberty": Object {
+        "metadata": Object {
+          "ballots": 420,
+          "overvotes": 120,
+          "undervotes": 90,
+        },
+        "tallies": Object {
+          "__write-in": 120,
+          "amber-brkich": 150,
+          "chris-daugherty": 120,
+          "danni-boatwright": 120,
+          "tom-westman": 120,
+        },
+      },
+    },
+  },
+}
+`;

--- a/apps/election-manager/src/utils/exportableTallies.test.ts
+++ b/apps/election-manager/src/utils/exportableTallies.test.ts
@@ -1,0 +1,363 @@
+import {
+  electionMultiPartyPrimaryWithDataFiles,
+  electionWithMsEitherNeitherWithDataFiles,
+} from '@votingworks/fixtures'
+import {
+  CandidateContest,
+  Dictionary,
+  Election,
+  YesNoContest,
+} from '@votingworks/types'
+import {
+  CastVoteRecord,
+  ContestOptionTally,
+  ExportableTallies,
+  VotingMethod,
+} from '../config/types'
+import { computeFullElectionTally, parseCVRs } from '../lib/votecounting'
+import { writeInCandidate } from './election'
+import {
+  getCombinedExportableContestTally,
+  getExportableTallies,
+} from './exportableTallies'
+import { convertSEMSFileToExternalTally } from './semsTallies'
+
+const multiPartyPrimaryElection =
+  electionMultiPartyPrimaryWithDataFiles.electionDefinition.election
+const electionWithMsEitherNeither =
+  electionWithMsEitherNeitherWithDataFiles.electionDefinition.election
+
+const yesnocontest = electionWithMsEitherNeither.contests.find(
+  (c) => c.id === '750000017'
+) as YesNoContest
+const presidentcontest = electionWithMsEitherNeither.contests.find(
+  (c) => c.id === '775020876'
+) as CandidateContest
+
+function parseCVRsAndAssertSuccess(
+  cvrsFileContents: string,
+  election: Election
+): CastVoteRecord[] {
+  return [...parseCVRs(cvrsFileContents, election)].map(({ cvr, errors }) => {
+    expect({ cvr, errors }).toEqual({ cvr, errors: [] })
+    return cvr
+  })
+}
+
+function assertTalliesAreIdenticalMultiples(
+  baseTally: ExportableTallies,
+  multipleTally: ExportableTallies,
+  multiplier: number
+): void {
+  // Both tallies should have the same precincts defined
+  expect(Object.keys(baseTally.talliesByPrecinct)).toEqual(
+    Object.keys(multipleTally.talliesByPrecinct)
+  )
+  for (const precinctId of Object.keys(baseTally.talliesByPrecinct)) {
+    expect(precinctId in multipleTally.talliesByPrecinct)
+    const baseForPrecinct = baseTally.talliesByPrecinct[precinctId]
+    const multipleForPrecinct = multipleTally.talliesByPrecinct[precinctId]
+    // Both tallies should have the same contests defined
+    expect(Object.keys(baseForPrecinct!)).toEqual(
+      Object.keys(multipleForPrecinct!)
+    )
+    for (const contestId of Object.keys(baseForPrecinct!)) {
+      expect(contestId in multipleForPrecinct!)
+      const baseContestTally = baseForPrecinct![contestId]!
+      const multipleContestTally = multipleForPrecinct![contestId]!
+      // Metadata should be mulitiplied
+      expect(multipleContestTally.metadata).toEqual({
+        ballots: baseContestTally.metadata.ballots * multiplier,
+        overvotes: baseContestTally.metadata.overvotes * multiplier,
+        undervotes: baseContestTally.metadata.undervotes * multiplier,
+      })
+
+      // Both tallies should have the same candidates defined
+      expect(Object.keys(baseContestTally.tallies)).toEqual(
+        Object.keys(multipleContestTally.tallies)
+      )
+
+      for (const optionId of Object.keys(baseContestTally.tallies)) {
+        // Candidate/yes/no tallies should be multipled
+        expect(multipleContestTally.tallies[optionId]!).toEqual(
+          multiplier * baseContestTally.tallies[optionId]!
+        )
+      }
+    }
+  }
+}
+
+describe('getCombinedExportableContestTally', () => {
+  it('combines yes no contests as expected', () => {
+    const emptyExportable = {
+      tallies: {},
+      metadata: { ballots: 0, undervotes: 0, overvotes: 0 },
+    }
+    const emptyContestTally = {
+      contest: yesnocontest,
+      tallies: {
+        yes: { option: ['yes'], tally: 0 },
+        no: { option: ['no'], tally: 0 },
+      } as Dictionary<ContestOptionTally>,
+      metadata: { ballots: 0, undervotes: 0, overvotes: 0 },
+    }
+    expect(
+      getCombinedExportableContestTally(emptyExportable, emptyContestTally)
+    ).toEqual({
+      tallies: {
+        yes: 0,
+        no: 0,
+      },
+      metadata: { ballots: 0, undervotes: 0, overvotes: 0 },
+    })
+
+    const populatedContestTally = {
+      contest: yesnocontest,
+      tallies: {
+        yes: { option: ['yes'], tally: 3 },
+        no: { option: ['no'], tally: 4 },
+      } as Dictionary<ContestOptionTally>,
+      metadata: { ballots: 18, undervotes: 5, overvotes: 6 },
+    }
+    const results = getCombinedExportableContestTally(
+      emptyExportable,
+      populatedContestTally
+    )
+    expect(results).toEqual({
+      tallies: {
+        yes: 3,
+        no: 4,
+      },
+      metadata: { ballots: 18, undervotes: 5, overvotes: 6 },
+    })
+    expect(
+      getCombinedExportableContestTally(results, populatedContestTally)
+    ).toEqual({
+      tallies: {
+        yes: 6,
+        no: 8,
+      },
+      metadata: { ballots: 36, undervotes: 10, overvotes: 12 },
+    })
+  })
+
+  it('combines candidate contests as expected', () => {
+    const emptyExportable = {
+      tallies: {},
+      metadata: { ballots: 0, undervotes: 0, overvotes: 0 },
+    }
+    const emptyContestTally = {
+      contest: presidentcontest,
+      tallies: {
+        775031988: {
+          option: presidentcontest.candidates.find(
+            (c) => c.id === '775031988'
+          )!,
+          tally: 0,
+        },
+        775031989: {
+          option: presidentcontest.candidates.find(
+            (c) => c.id === '775031989'
+          )!,
+          tally: 0,
+        },
+      } as Dictionary<ContestOptionTally>,
+      metadata: { ballots: 0, undervotes: 0, overvotes: 0 },
+    }
+
+    expect(
+      getCombinedExportableContestTally(emptyExportable, emptyContestTally)
+    ).toEqual({
+      tallies: {
+        '775031988': 0,
+        '775031989': 0,
+      },
+      metadata: { ballots: 0, undervotes: 0, overvotes: 0 },
+    })
+
+    const partialContestTally = {
+      contest: presidentcontest,
+      tallies: {
+        775031988: {
+          option: presidentcontest.candidates.find(
+            (c) => c.id === '775031988'
+          )!,
+          tally: 12,
+        },
+        775031989: {
+          option: presidentcontest.candidates.find(
+            (c) => c.id === '775031989'
+          )!,
+          tally: 8,
+        },
+      } as Dictionary<ContestOptionTally>,
+      metadata: { ballots: 30, undervotes: 6, overvotes: 4 },
+    }
+    const partialResult = getCombinedExportableContestTally(
+      emptyExportable,
+      partialContestTally
+    )
+    expect(partialResult).toEqual({
+      tallies: {
+        775031988: 12,
+        775031989: 8,
+      },
+      metadata: { ballots: 30, undervotes: 6, overvotes: 4 },
+    })
+
+    const tallyForEveryone = {
+      contest: presidentcontest,
+      tallies: {
+        775031988: {
+          option: presidentcontest.candidates.find(
+            (c) => c.id === '775031988'
+          )!,
+          tally: 8,
+        },
+        775031989: {
+          option: presidentcontest.candidates.find(
+            (c) => c.id === '775031989'
+          )!,
+          tally: 12,
+        },
+        775031987: {
+          option: presidentcontest.candidates.find(
+            (c) => c.id === '775031987'
+          )!,
+          tally: 10,
+        },
+        '__write-in': {
+          option: writeInCandidate,
+          tally: 10,
+        },
+      } as Dictionary<ContestOptionTally>,
+      metadata: { ballots: 40, undervotes: 4, overvotes: 6 },
+    }
+
+    expect(
+      getCombinedExportableContestTally(partialResult, tallyForEveryone)
+    ).toEqual({
+      tallies: {
+        775031988: 20,
+        775031989: 20,
+        775031987: 10,
+        '__write-in': 10,
+      },
+      metadata: { ballots: 70, undervotes: 10, overvotes: 10 },
+    })
+  })
+})
+
+describe('getExportableTallies', () => {
+  it('builds expected tally object for election with either neither with just internal data', () => {
+    const castVoteRecords = parseCVRsAndAssertSuccess(
+      electionWithMsEitherNeitherWithDataFiles.cvrData,
+      electionWithMsEitherNeither
+    )
+    const fullInternalTally = computeFullElectionTally(
+      electionWithMsEitherNeither,
+      [castVoteRecords]
+    )
+    const tally = getExportableTallies(
+      fullInternalTally,
+      [],
+      electionWithMsEitherNeither
+    )
+    expect(tally).toMatchSnapshot()
+  })
+
+  it('builds expected tally object for election with either neither with external and internal data', () => {
+    const castVoteRecords = parseCVRsAndAssertSuccess(
+      electionWithMsEitherNeitherWithDataFiles.cvrData,
+      electionWithMsEitherNeither
+    )
+    const fullInternalTally = computeFullElectionTally(
+      electionWithMsEitherNeither,
+      [castVoteRecords]
+    )
+    const fullExternalTally = convertSEMSFileToExternalTally(
+      electionWithMsEitherNeitherWithDataFiles.semsData,
+      electionWithMsEitherNeither,
+      VotingMethod.Precinct
+    )
+    // Get tally with just CVR data
+    const baseTally = getExportableTallies(
+      fullInternalTally,
+      [],
+      electionWithMsEitherNeither
+    )
+    // Get tally with CVR and SEMS data
+    const doubleTally = getExportableTallies(
+      fullInternalTally,
+      [fullExternalTally],
+      electionWithMsEitherNeither
+    )
+
+    // doubleTally should be exactly 2 times everything in baseTally
+    assertTalliesAreIdenticalMultiples(baseTally, doubleTally, 2)
+    // Get tally with SEMS data duplicated 3x
+    const quadrupleTally = getExportableTallies(
+      fullInternalTally,
+      [fullExternalTally, fullExternalTally, fullExternalTally],
+      electionWithMsEitherNeither
+    )
+    // quadrupleTally should be exactly 4 times everyhting in baseTally
+    assertTalliesAreIdenticalMultiples(baseTally, quadrupleTally, 4)
+  })
+
+  it('builds expected tally object for primary election with just internal data', () => {
+    const castVoteRecords = parseCVRsAndAssertSuccess(
+      electionMultiPartyPrimaryWithDataFiles.cvrData,
+      multiPartyPrimaryElection
+    )
+    const fullInternalTally = computeFullElectionTally(
+      multiPartyPrimaryElection,
+      [castVoteRecords]
+    )
+    const tally = getExportableTallies(
+      fullInternalTally,
+      [],
+      multiPartyPrimaryElection
+    )
+    expect(tally).toMatchSnapshot()
+  })
+
+  it('builds expected tally object for primary election with external and internal data', () => {
+    const castVoteRecords = parseCVRsAndAssertSuccess(
+      electionMultiPartyPrimaryWithDataFiles.cvrData,
+      multiPartyPrimaryElection
+    )
+    const fullInternalTally = computeFullElectionTally(
+      multiPartyPrimaryElection,
+      [castVoteRecords]
+    )
+    const fullExternalTally = convertSEMSFileToExternalTally(
+      electionMultiPartyPrimaryWithDataFiles.semsData,
+      multiPartyPrimaryElection,
+      VotingMethod.Precinct
+    )
+    // Get tally with just CVR data
+    const baseTally = getExportableTallies(
+      fullInternalTally,
+      [],
+      multiPartyPrimaryElection
+    )
+    // Get tally with CVR and SEMS data
+    const doubleTally = getExportableTallies(
+      fullInternalTally,
+      [fullExternalTally],
+      multiPartyPrimaryElection
+    )
+
+    // doubleTally should be exactly 2 times everything in baseTally
+    assertTalliesAreIdenticalMultiples(baseTally, doubleTally, 2)
+    // Get tally with SEMS data duplicated 3x
+    const quadrupleTally = getExportableTallies(
+      fullInternalTally,
+      [fullExternalTally, fullExternalTally, fullExternalTally],
+      multiPartyPrimaryElection
+    )
+    // quadrupleTally should be exactly 4 times everyhting in baseTally
+    assertTalliesAreIdenticalMultiples(baseTally, quadrupleTally, 4)
+  })
+})

--- a/apps/election-manager/src/utils/exportableTallies.ts
+++ b/apps/election-manager/src/utils/exportableTallies.ts
@@ -1,0 +1,105 @@
+import { Dictionary, Election, getContests } from '@votingworks/types'
+import {
+  ContestTally,
+  ExportableContestTally,
+  ExportableTallies,
+  ExportableTally,
+  ExternalTally,
+  FullElectionExternalTally,
+  FullElectionTally,
+  TallyCategory,
+} from '../config/types'
+import { expandEitherNeitherContests } from './election'
+
+export function getEmptyExportableTallies(): ExportableTallies {
+  return {
+    talliesByPrecinct: {},
+  }
+}
+
+// only exported for testing
+export function getCombinedExportableContestTally(
+  exportableTally: ExportableContestTally,
+  newTally: ContestTally
+): ExportableContestTally {
+  const combinedOptionsTallies: Dictionary<number> = {}
+
+  // Add in any keys in the exportable tally, combined with tallies, if they exist, from the new tally.
+  for (const optionId of Object.keys(exportableTally.tallies)) {
+    const currentValue = exportableTally.tallies[optionId] ?? 0
+    const newValue = newTally.tallies[optionId]?.tally ?? 0
+    combinedOptionsTallies[optionId] = currentValue + newValue
+  }
+
+  // Add in any keys from the new tally that don't already exist in the dictionary
+  for (const optionId of Object.keys(newTally.tallies)) {
+    if (!(optionId in combinedOptionsTallies)) {
+      combinedOptionsTallies[optionId] = newTally.tallies[optionId]?.tally ?? 0
+    }
+  }
+
+  return {
+    tallies: combinedOptionsTallies,
+    metadata: {
+      overvotes:
+        exportableTally.metadata.overvotes + newTally.metadata.overvotes,
+      undervotes:
+        exportableTally.metadata.undervotes + newTally.metadata.undervotes,
+      ballots: exportableTally.metadata.ballots + newTally.metadata.ballots,
+    },
+  }
+}
+
+export function getExportableTallies(
+  internalElectionTally: FullElectionTally,
+  externalElectionTallies: FullElectionExternalTally[],
+  election: Election
+): ExportableTallies {
+  const talliesByPrecinct = internalElectionTally.resultsByCategory.get(
+    TallyCategory.Precinct
+  )
+  const externalTalliesByPrecinct = externalElectionTallies
+    .map((t) => t.resultsByCategory.get(TallyCategory.Precinct))
+    .filter((t): t is Dictionary<ExternalTally> => !!t)
+
+  if (talliesByPrecinct === undefined) {
+    return getEmptyExportableTallies()
+  }
+  const exportableTalliesByPrecinct: Dictionary<ExportableTally> = {}
+  for (const precinct of election.precincts) {
+    const ballotStylesForPrecinct = election.ballotStyles.filter((bs) =>
+      bs.precincts.includes(precinct.id)
+    )
+    const ballotStyleContests = new Set(
+      ballotStylesForPrecinct.flatMap((bs) =>
+        expandEitherNeitherContests(getContests({ ballotStyle: bs, election }))
+      )
+    )
+    const tallyForPrecinct = talliesByPrecinct[precinct.id]
+    const externalTalliesForPrecinct = externalTalliesByPrecinct
+      .map((t) => t[precinct.id])
+      .filter((t): t is ExternalTally => !!t)
+    const exportableTallyForPrecinct: ExportableTally = {}
+    for (const contest of ballotStyleContests) {
+      let exportableContestTally: ExportableContestTally = {
+        tallies: {},
+        metadata: { ballots: 0, undervotes: 0, overvotes: 0 },
+      }
+      const contestTalliesToCombine = [
+        tallyForPrecinct?.contestTallies[contest.id],
+        ...externalTalliesForPrecinct.map((t) => t.contestTallies[contest.id]),
+      ].filter((t): t is ContestTally => !!t)
+      for (const contestTallyToCombine of contestTalliesToCombine) {
+        exportableContestTally = getCombinedExportableContestTally(
+          exportableContestTally,
+          contestTallyToCombine
+        )
+      }
+      exportableTallyForPrecinct[contest.id] = exportableContestTally
+    }
+    exportableTalliesByPrecinct[precinct.id] = exportableTallyForPrecinct
+  }
+  return {
+    talliesByPrecinct: exportableTalliesByPrecinct,
+  }
+}

--- a/apps/election-manager/src/utils/semsTallies.test.ts
+++ b/apps/election-manager/src/utils/semsTallies.test.ts
@@ -805,4 +805,15 @@ describe('parseSEMSFileAndValidateForElection', () => {
       'No valid CSV data found in imported file. Please check file contents.',
     ])
   })
+
+  it('can parse a row with a comma in the contest name', () => {
+    const csvRowRaw2 =
+      '"10","6522","750000017","Ballot ,Measure 2","0","NP","0","Write In Votes","0","NP","0",'
+    expect(
+      parseSEMSFileAndValidateForElection(
+        csvRowRaw2,
+        electionWithMsEitherNeither
+      )
+    ).toEqual([])
+  })
 })

--- a/apps/election-manager/src/utils/semsTallies.ts
+++ b/apps/election-manager/src/utils/semsTallies.ts
@@ -248,7 +248,9 @@ function sanitizeItem(item: string): string {
 function parseFileContentRows(fileContent: string): SEMSFileRow[] {
   const parsedRows: SEMSFileRow[] = []
   fileContent.split('\n').forEach((row) => {
-    const entries = row.split(',').map((e) => sanitizeItem(e))
+    const entries = row
+      .split(/,(?=(?:(?:[^"]*"){2})*[^"]*$)/)
+      .map((e) => sanitizeItem(e))
     if (entries.length >= 11) {
       parsedRows.push({
         countyId: entries[0],

--- a/apps/election-manager/test/renderInAppContext.tsx
+++ b/apps/election-manager/test/renderInAppContext.tsx
@@ -16,6 +16,7 @@ import {
   OptionalFullElectionExternalTally,
   OptionalFile,
   ExternalFileConfiguration,
+  ExportableTallies,
 } from '../src/config/types'
 import CastVoteRecordFiles, {
   SaveCastVoteRecordFiles,
@@ -59,6 +60,7 @@ interface RenderInAppContextParams {
   ) => void
   fullElectionExternalTally?: OptionalFullElectionExternalTally
   externalVoteRecordsFile?: OptionalFile
+  generateExportableTallies?: () => ExportableTallies
 }
 
 export default function renderInAppContext(
@@ -87,6 +89,7 @@ export default function renderInAppContext(
     setFullElectionExternalTally = jest.fn(),
     fullElectionExternalTally = undefined,
     externalVoteRecordsFile = undefined,
+    generateExportableTallies = jest.fn(),
   } = {} as RenderInAppContextParams
 ): RenderResult {
   return testRender(
@@ -113,6 +116,7 @@ export default function renderInAppContext(
         setFullElectionExternalTally,
         fullElectionExternalTally,
         externalVoteRecordsFile,
+        generateExportableTallies,
       }}
     >
       <Router history={history}>{component}</Router>


### PR DESCRIPTION
Depends on https://github.com/votingworks/module-converter-sems/pull/44

Refactors the export of election manager to instead of sending the raw CVR files and combining with the stored SEMS file, instead send 1 exported json blob of precomputed tallies by precinct. The new /tallies endpoints in module-converter-sems will transform this data into the SEMs file. 

Today we can only have one fullElectionExternalTally object, but that will soon change to add in manual data entry so I made the function to generate the exportable json blob take an array in order to prepare for handling that. 