### PR TITLE
refactor(em): allow for multiple external tallies

### DIFF
--- a/apps/election-manager/src/App.test.tsx
+++ b/apps/election-manager/src/App.test.tsx
@@ -19,8 +19,7 @@ import {
   configuredAtStorageKey,
   cvrsStorageKey,
   electionDefinitionStorageKey,
-  externalVoteRecordsFileStorageKey,
-  externalVotingMethodStorageKey,
+  externalVoteTalliesFileStorageKey,
 } from './AppRoot'
 
 import CastVoteRecordFiles from './utils/CastVoteRecordFiles'
@@ -29,10 +28,13 @@ import App from './App'
 
 import sleep from './utils/sleep'
 import fakeFileWriter from '../test/helpers/fakeFileWriter'
-import { convertFileToStorageString } from './utils/file'
 import { eitherNeitherElectionDefinition } from '../test/renderInAppContext'
 import hasTextAcrossElements from '../test/util/hasTextAcrossElements'
 import { VotingMethod } from './config/types'
+import {
+  convertSEMSFileToExternalTally,
+  convertExternalTalliesToStorageString,
+} from './utils/semsTallies'
 
 const EITHER_NEITHER_CVR_DATA = electionWithMsEitherNeitherWithDataFiles.cvrData
 const EITHER_NEITHER_CVR_FILE = new File([EITHER_NEITHER_CVR_DATA], 'cvrs.txt')
@@ -299,11 +301,17 @@ test('tabulating CVRs with SEMS file', async () => {
   )
   await storage.set(cvrsStorageKey, castVoteRecordFiles.export())
 
-  const semsFileStorageString = await convertFileToStorageString(
-    new File([EITHER_NEITHER_SEMS_DATA], 'sems-results.csv')
+  const semsFileStorageString = await convertSEMSFileToExternalTally(
+    EITHER_NEITHER_SEMS_DATA,
+    eitherNeitherElectionDefinition.election,
+    VotingMethod.Precinct,
+    'sems-results.csv',
+    new Date()
   )
-  await storage.set(externalVoteRecordsFileStorageKey, semsFileStorageString)
-  await storage.set(externalVotingMethodStorageKey, VotingMethod.Precinct)
+  await storage.set(
+    externalVoteTalliesFileStorageKey,
+    convertExternalTalliesToStorageString([semsFileStorageString])
+  )
 
   const { getByText, getByTestId, getAllByTestId, getAllByText } = render(
     <App storage={storage} />
@@ -361,11 +369,17 @@ test('changing election resets sems and cvr files', async () => {
   )
   await storage.set(cvrsStorageKey, castVoteRecordFiles.export())
 
-  const semsFileStorageString = await convertFileToStorageString(
-    new File([EITHER_NEITHER_SEMS_DATA], 'sems-results.csv')
+  const semsFileStorageString = await convertSEMSFileToExternalTally(
+    EITHER_NEITHER_SEMS_DATA,
+    eitherNeitherElectionDefinition.election,
+    VotingMethod.Precinct,
+    'sems-results.csv',
+    new Date()
   )
-  await storage.set(externalVoteRecordsFileStorageKey, semsFileStorageString)
-  await storage.set(externalVotingMethodStorageKey, VotingMethod.Precinct)
+  await storage.set(
+    externalVoteTalliesFileStorageKey,
+    convertExternalTalliesToStorageString([semsFileStorageString])
+  )
 
   const { getByText, getByTestId } = render(<App storage={storage} />)
 
@@ -402,11 +416,17 @@ test('clearing all files after marking as official clears SEMS and CVR file', as
   )
   await storage.set(cvrsStorageKey, castVoteRecordFiles.export())
 
-  const semsFileStorageString = await convertFileToStorageString(
-    new File([EITHER_NEITHER_SEMS_DATA], 'sems-results.csv')
+  const semsFileStorageString = await convertSEMSFileToExternalTally(
+    EITHER_NEITHER_SEMS_DATA,
+    eitherNeitherElectionDefinition.election,
+    VotingMethod.Precinct,
+    'sems-results.csv',
+    new Date()
   )
-  await storage.set(externalVoteRecordsFileStorageKey, semsFileStorageString)
-  await storage.set(externalVotingMethodStorageKey, VotingMethod.Precinct)
+  await storage.set(
+    externalVoteTalliesFileStorageKey,
+    convertExternalTalliesToStorageString([semsFileStorageString])
+  )
 
   const { getByText, getByTestId } = render(<App storage={storage} />)
 

--- a/apps/election-manager/src/components/BallotCountsTable.test.tsx
+++ b/apps/election-manager/src/components/BallotCountsTable.test.tsx
@@ -11,6 +11,7 @@ import { Dictionary } from '@votingworks/types'
 import renderInAppContext from '../../test/renderInAppContext'
 import {
   ExternalTally,
+  ExternalTallySourceType,
   Tally,
   TallyCategory,
   VotingMethod,
@@ -69,6 +70,9 @@ describe('Ballot Counts by Precinct', () => {
     }),
     resultsByCategory: externalResultsByCategory,
     votingMethod: VotingMethod.Precinct,
+    source: ExternalTallySourceType.SEMS,
+    inputSourceName: 'imported-file-name.csv',
+    timestampCreated: new Date(),
   }
 
   it('renders as expected when there is no tally data', () => {
@@ -136,7 +140,7 @@ describe('Ballot Counts by Precinct', () => {
       <BallotCountsTable breakdownCategory={TallyCategory.Precinct} />,
       {
         fullElectionTally,
-        fullElectionExternalTally,
+        fullElectionExternalTallies: [fullElectionExternalTally],
       }
     )
     electionWithMsEitherNeither.precincts.forEach((precinct) => {
@@ -194,6 +198,9 @@ describe('Ballot Counts by Scanner', () => {
     }),
     votingMethod: VotingMethod.Precinct,
     resultsByCategory: new Map(),
+    source: ExternalTallySourceType.SEMS,
+    inputSourceName: 'imported-file-name.csv',
+    timestampCreated: new Date(),
   }
 
   it('renders as expected when there is no tally data', () => {
@@ -250,8 +257,7 @@ describe('Ballot Counts by Scanner', () => {
       <BallotCountsTable breakdownCategory={TallyCategory.Scanner} />,
       {
         fullElectionTally,
-        fullElectionExternalTally,
-        externalVoteRecordsFile: new File(['blah'], 'file-name.csv'),
+        fullElectionExternalTallies: [fullElectionExternalTally],
       }
     )
 
@@ -275,10 +281,10 @@ describe('Ballot Counts by Scanner', () => {
       }
     })
 
-    getByText('External Results File (file-name.csv)')
-    let tableRow = getByText('External Results File (file-name.csv)').closest(
-      'tr'
-    )
+    getByText('External Results File (imported-file-name.csv)')
+    let tableRow = getByText(
+      'External Results File (imported-file-name.csv)'
+    ).closest('tr')
     expect(tableRow).toBeDefined()
     expect(domGetByText(tableRow!, 54))
 
@@ -332,6 +338,9 @@ describe('Ballots Counts by Party', () => {
     }),
     resultsByCategory: externalResultsByCategory,
     votingMethod: VotingMethod.Precinct,
+    source: ExternalTallySourceType.SEMS,
+    inputSourceName: 'imported-file-name.csv',
+    timestampCreated: new Date(),
   }
 
   it('does not render when the election has not ballot styles with parties', () => {
@@ -433,7 +442,7 @@ describe('Ballots Counts by Party', () => {
           electionData: '',
         },
         fullElectionTally,
-        fullElectionExternalTally,
+        fullElectionExternalTallies: [fullElectionExternalTally],
       }
     )
 
@@ -492,6 +501,9 @@ describe('Ballots Counts by VotingMethod', () => {
     }),
     resultsByCategory: new Map(),
     votingMethod: VotingMethod.Precinct,
+    source: ExternalTallySourceType.SEMS,
+    inputSourceName: 'imported-file-name.csv',
+    timestampCreated: new Date(),
   }
 
   it('renders as expected when there is no data', () => {
@@ -566,8 +578,7 @@ describe('Ballots Counts by VotingMethod', () => {
       <BallotCountsTable breakdownCategory={TallyCategory.VotingMethod} />,
       {
         fullElectionTally,
-        fullElectionExternalTally,
-        externalVoteRecordsFile: new File(['blah'], 'file-name.csv'),
+        fullElectionExternalTallies: [fullElectionExternalTally],
       }
     )
 

--- a/apps/election-manager/src/components/ContestTally.tsx
+++ b/apps/election-manager/src/components/ContestTally.tsx
@@ -47,14 +47,14 @@ const Contest = styled.div<ContestProps>`
 interface Props {
   election: Election
   electionTally: Tally
-  externalTally?: ExternalTally
+  externalTallies: ExternalTally[]
   precinctId?: string
 }
 
 const ContestTally: React.FC<Props> = ({
   election,
   electionTally,
-  externalTally,
+  externalTallies,
   precinctId,
 }) => {
   // if there is no precinctId defined, we don't need to do extra work
@@ -70,17 +70,24 @@ const ContestTally: React.FC<Props> = ({
         if (!(electionContest.id in electionTally.contestTallies)) {
           return null
         }
-        const externalTallyContest =
-          externalTally?.contestTallies[electionContest.id]
+        const externalTalliesContest = externalTallies.map(
+          (t) => t.contestTallies[electionContest.id]
+        )
         const primaryContestTally = electionTally.contestTallies[
           electionContest.id
         ]!
 
-        const contestTally = externalTallyContest
-          ? combineContestTallies(primaryContestTally, externalTallyContest)
-          : primaryContestTally
+        let finalContestTally = primaryContestTally
+        externalTalliesContest.forEach((externalTally) => {
+          if (externalTally !== undefined) {
+            finalContestTally = combineContestTallies(
+              finalContestTally,
+              externalTally
+            )
+          }
+        })
 
-        const { contest, tallies, metadata } = contestTally
+        const { contest, tallies, metadata } = finalContestTally
 
         const talliesRelevant = precinctId
           ? districts.includes(contest.districtId)

--- a/apps/election-manager/src/components/ExportFinalResultsModal.test.tsx
+++ b/apps/election-manager/src/components/ExportFinalResultsModal.test.tsx
@@ -8,7 +8,7 @@ import MockDate from 'mockdate'
 import { UsbDriveStatus } from '../lib/usbstick'
 import ExportFinalResultsModal from './ExportFinalResultsModal'
 import renderInAppContext from '../../test/renderInAppContext'
-import { VotingMethod } from '../config/types'
+import { ExternalTallySourceType, VotingMethod } from '../config/types'
 
 beforeEach(() => {
   jest.useFakeTimers()
@@ -132,18 +132,21 @@ test('render export modal when a usb drive is mounted and exports with external 
 
   fetchMock.post('/convert/reset', { body: { status: 'ok' } })
 
-  const externalFile = new File(['content'], 'to-combine.csv')
   const closeFn = jest.fn()
   const { getByText } = renderInAppContext(
     <ExportFinalResultsModal onClose={closeFn} />,
     {
       usbDriveStatus: UsbDriveStatus.mounted,
-      fullElectionExternalTally: {
-        overallTally: { contestTallies: {}, numberOfBallotsCounted: 0 },
-        resultsByCategory: new Map(),
-        votingMethod: VotingMethod.Precinct,
-      },
-      externalVoteRecordsFile: externalFile,
+      fullElectionExternalTallies: [
+        {
+          overallTally: { contestTallies: {}, numberOfBallotsCounted: 0 },
+          resultsByCategory: new Map(),
+          votingMethod: VotingMethod.Precinct,
+          source: ExternalTallySourceType.SEMS,
+          inputSourceName: 'file-name.csv',
+          timestampCreated: new Date(),
+        },
+      ],
     }
   )
   getByText('Save Results File')

--- a/apps/election-manager/src/config/types.ts
+++ b/apps/election-manager/src/config/types.ts
@@ -122,6 +122,11 @@ export interface ExternalTally {
   readonly numberOfBallotsCounted: number
 }
 
+export enum ExternalTallySourceType {
+  SEMS = 'sems',
+  Manual = 'manual-data',
+}
+
 export interface FullElectionExternalTally {
   readonly overallTally: ExternalTally
   readonly resultsByCategory: ReadonlyMap<
@@ -129,6 +134,9 @@ export interface FullElectionExternalTally {
     Dictionary<ExternalTally>
   >
   readonly votingMethod: VotingMethod
+  readonly source: ExternalTallySourceType
+  readonly inputSourceName: string
+  readonly timestampCreated: Date
 }
 
 export interface ExportableContestTally {
@@ -154,7 +162,6 @@ export enum ResultsFileType {
   SEMS = 'sems',
   All = 'all',
 }
-
 export type OptionalFile = Optional<File>
 
 // provisional ballot types are not yet supported.

--- a/apps/election-manager/src/contexts/AppContext.ts
+++ b/apps/election-manager/src/contexts/AppContext.ts
@@ -1,14 +1,12 @@
 import { createContext, RefObject } from 'react'
-import { ElectionDefinition, Optional } from '@votingworks/types'
+import { ElectionDefinition } from '@votingworks/types'
 import {
   SaveElection,
   PrintedBallot,
   ISO8601Timestamp,
   FullElectionTally,
-  OptionalFullElectionExternalTally,
-  OptionalFile,
-  ExternalFileConfiguration,
   ExportableTallies,
+  FullElectionExternalTally,
 } from '../config/types'
 import { UsbDriveStatus } from '../lib/usbstick'
 import CastVoteRecordFiles, {
@@ -34,16 +32,10 @@ export interface AppContextInterface {
   addPrintedBallot: (printedBallot: PrintedBallot) => void
   printedBallots: PrintedBallot[]
   fullElectionTally: FullElectionTally
-  fullElectionExternalTally: OptionalFullElectionExternalTally
-  externalVoteRecordsFile: OptionalFile
+  fullElectionExternalTallies: FullElectionExternalTally[]
   isTabulationRunning: boolean
   setFullElectionTally: React.Dispatch<React.SetStateAction<FullElectionTally>>
-  setFullElectionExternalTally: React.Dispatch<
-    React.SetStateAction<OptionalFullElectionExternalTally>
-  >
-  saveExternalVoteRecordsFile: (
-    externalFileConfig: Optional<ExternalFileConfiguration>
-  ) => void
+  saveExternalTallies: (externalTallies: FullElectionExternalTally[]) => void
   setIsTabulationRunning: React.Dispatch<React.SetStateAction<boolean>>
   generateExportableTallies: () => ExportableTallies
 }
@@ -63,11 +55,9 @@ const appContext: AppContextInterface = {
   addPrintedBallot: () => undefined,
   printedBallots: [],
   fullElectionTally: getEmptyFullElectionTally(),
-  fullElectionExternalTally: undefined,
-  externalVoteRecordsFile: undefined,
+  fullElectionExternalTallies: [],
   setFullElectionTally: () => undefined,
-  setFullElectionExternalTally: () => undefined,
-  saveExternalVoteRecordsFile: () => undefined,
+  saveExternalTallies: () => undefined,
   isTabulationRunning: false,
   setIsTabulationRunning: () => undefined,
   generateExportableTallies: getEmptyExportableTallies,

--- a/apps/election-manager/src/screens/TestDeckScreen.tsx
+++ b/apps/election-manager/src/screens/TestDeckScreen.tsx
@@ -152,6 +152,7 @@ const TestDeckScreen: React.FC = () => {
                   <ContestTally
                     election={election}
                     electionTally={electionTallyForParty}
+                    externalTallies={[]}
                   />
                 </TallyReportColumns>
               </ReportSection>

--- a/apps/election-manager/src/utils/exportableTallies.test.ts
+++ b/apps/election-manager/src/utils/exportableTallies.test.ts
@@ -278,7 +278,9 @@ describe('getExportableTallies', () => {
     const fullExternalTally = convertSEMSFileToExternalTally(
       electionWithMsEitherNeitherWithDataFiles.semsData,
       electionWithMsEitherNeither,
-      VotingMethod.Precinct
+      VotingMethod.Precinct,
+      'file-name',
+      new Date()
     )
     // Get tally with just CVR data
     const baseTally = getExportableTallies(
@@ -334,7 +336,9 @@ describe('getExportableTallies', () => {
     const fullExternalTally = convertSEMSFileToExternalTally(
       electionMultiPartyPrimaryWithDataFiles.semsData,
       multiPartyPrimaryElection,
-      VotingMethod.Precinct
+      VotingMethod.Precinct,
+      'file-name',
+      new Date()
     )
     // Get tally with just CVR data
     const baseTally = getExportableTallies(

--- a/apps/election-manager/src/utils/file.ts
+++ b/apps/election-manager/src/utils/file.ts
@@ -1,5 +1,3 @@
-import readFileAsync from '../lib/readFileAsync'
-
 export async function copyFile(inputFile: File): Promise<File> {
   const reader = new FileReader()
   return new Promise((resolve) => {
@@ -8,26 +6,4 @@ export async function copyFile(inputFile: File): Promise<File> {
     }
     reader.readAsText(inputFile)
   })
-}
-
-export async function convertFileToStorageString(
-  inputFile: File
-): Promise<string> {
-  const fileContent = await readFileAsync(inputFile)
-  return JSON.stringify({
-    name: inputFile.name,
-    lastModified: inputFile.lastModified,
-    content: fileContent,
-  })
-}
-
-export function convertStorageStringToFile(
-  inputString: string
-): File | undefined {
-  const { name, lastModified, content } = JSON.parse(inputString)
-  if (!content || !name) {
-    return undefined
-  }
-  const file = new File([content], name, { lastModified })
-  return file
 }

--- a/apps/election-manager/src/utils/semsTallies.test.ts
+++ b/apps/election-manager/src/utils/semsTallies.test.ts
@@ -8,6 +8,7 @@ import { CandidateContest, Dictionary, YesNoContest } from '@votingworks/types'
 import {
   ContestOptionTally,
   ContestTally,
+  ExternalTallySourceType,
   TallyCategory,
   VotingMethod,
 } from '../config/types'
@@ -439,7 +440,9 @@ describe('convertSEMSFileToExternalTally', () => {
     const convertedTally = convertSEMSFileToExternalTally(
       eitherNeitherSEMSContent,
       electionWithMsEitherNeither,
-      VotingMethod.Precinct
+      VotingMethod.Precinct,
+      'file-name',
+      new Date(2020, 3, 1)
     )
 
     const expectedNumberOfVotesByPrecinct: Dictionary<number> = {
@@ -460,7 +463,10 @@ describe('convertSEMSFileToExternalTally', () => {
 
     // Check that the number of ballots in each precinct report and the overall tally are as expected.
     expect(convertedTally.overallTally.numberOfBallotsCounted).toBe(100)
+    expect(convertedTally.inputSourceName).toBe('file-name')
+    expect(convertedTally.source).toBe(ExternalTallySourceType.SEMS)
     expect(convertedTally.votingMethod).toBe(VotingMethod.Precinct)
+    expect(convertedTally.timestampCreated).toStrictEqual(new Date(2020, 3, 1))
     for (const precinctId of Object.keys(expectedNumberOfVotesByPrecinct)) {
       const tallyForPrecinct = convertedTally.resultsByCategory.get(
         TallyCategory.Precinct
@@ -545,7 +551,9 @@ describe('convertSEMSFileToExternalTally', () => {
     const convertedTally = convertSEMSFileToExternalTally(
       primarySEMSContent,
       multiPartyPrimaryElection,
-      VotingMethod.Absentee
+      VotingMethod.Absentee,
+      'file-name',
+      new Date(2020, 3, 1)
     )
 
     const expectedNumberOfVotesByPrecinct: Dictionary<number> = {

--- a/apps/election-manager/test/renderInAppContext.tsx
+++ b/apps/election-manager/test/renderInAppContext.tsx
@@ -5,7 +5,7 @@ import { sha256 } from 'js-sha256'
 import { render as testRender } from '@testing-library/react'
 import type { RenderResult } from '@testing-library/react'
 import { electionWithMsEitherNeitherRawData } from '@votingworks/fixtures'
-import { Election, ElectionDefinition, Optional } from '@votingworks/types'
+import { Election, ElectionDefinition } from '@votingworks/types'
 
 import AppContext from '../src/contexts/AppContext'
 import {
@@ -13,10 +13,8 @@ import {
   PrintedBallot,
   ISO8601Timestamp,
   FullElectionTally,
-  OptionalFullElectionExternalTally,
-  OptionalFile,
-  ExternalFileConfiguration,
   ExportableTallies,
+  FullElectionExternalTally,
 } from '../src/config/types'
 import CastVoteRecordFiles, {
   SaveCastVoteRecordFiles,
@@ -52,14 +50,8 @@ interface RenderInAppContextParams {
   isTabulationRunning?: boolean
   setFullElectionTally?: React.Dispatch<React.SetStateAction<FullElectionTally>>
   setIsTabulationRunning?: React.Dispatch<React.SetStateAction<boolean>>
-  setFullElectionExternalTally?: React.Dispatch<
-    React.SetStateAction<OptionalFullElectionExternalTally>
-  >
-  saveExternalVoteRecordsFile?: (
-    externalFileConfig: Optional<ExternalFileConfiguration>
-  ) => void
-  fullElectionExternalTally?: OptionalFullElectionExternalTally
-  externalVoteRecordsFile?: OptionalFile
+  saveExternalTallies?: (externalTallies: FullElectionExternalTally[]) => void
+  fullElectionExternalTallies?: FullElectionExternalTally[]
   generateExportableTallies?: () => ExportableTallies
 }
 
@@ -85,10 +77,8 @@ export default function renderInAppContext(
     isTabulationRunning = false,
     setFullElectionTally = jest.fn(),
     setIsTabulationRunning = jest.fn(),
-    saveExternalVoteRecordsFile = jest.fn(),
-    setFullElectionExternalTally = jest.fn(),
-    fullElectionExternalTally = undefined,
-    externalVoteRecordsFile = undefined,
+    saveExternalTallies = jest.fn(),
+    fullElectionExternalTallies = [],
     generateExportableTallies = jest.fn(),
   } = {} as RenderInAppContextParams
 ): RenderResult {
@@ -112,10 +102,8 @@ export default function renderInAppContext(
         isTabulationRunning,
         setFullElectionTally,
         setIsTabulationRunning,
-        saveExternalVoteRecordsFile,
-        setFullElectionExternalTally,
-        fullElectionExternalTally,
-        externalVoteRecordsFile,
+        saveExternalTallies,
+        fullElectionExternalTallies,
         generateExportableTallies,
       }}
     >


### PR DESCRIPTION
Refactors the internal data for non-CVR tallies from a single fullElectionExternalTally object to an array fullElectionExternalTallies. The UI does not allow importing more than one SEMs file but this sets up for allowing the user to manually add data that will live alongside a SEMs file if desired. Also refactors the way we store this data on disk from storing the raw SEMs file to storing the external tally json blob to prepare for manual data as well. 