### PR TITLE
refactor(scan): prepare for precinct scanner

### DIFF
--- a/apps/module-scan/src/LoopScanner.test.ts
+++ b/apps/module-scan/src/LoopScanner.test.ts
@@ -15,15 +15,15 @@ test('copies files in pairs', async () => {
   })
   const scanner = new LoopScanner([[[f1, f2]], [[f3, f4]]])
 
-  expect(readFiles((await scanner.scanSheets().next()).value)).toEqual([
+  expect(readFiles((await scanner.scanSheets().scanSheet())!)).toEqual([
     '1',
     '2',
   ])
-  expect(readFiles((await scanner.scanSheets().next()).value)).toEqual([
+  expect(readFiles((await scanner.scanSheets().scanSheet())!)).toEqual([
     '3',
     '4',
   ])
-  expect(readFiles((await scanner.scanSheets().next()).value)).toEqual([
+  expect(readFiles((await scanner.scanSheets().scanSheet())!)).toEqual([
     '1',
     '2',
   ])

--- a/apps/module-scan/src/LoopScanner.ts
+++ b/apps/module-scan/src/LoopScanner.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs-extra'
 import { join, resolve } from 'path'
-import { Scanner } from './scanner'
+import { makeBatchControlMethod, Scanner } from './scanner'
 import { SheetOf } from './types'
 
 type Batch = readonly SheetOf<string>[]
@@ -95,7 +95,9 @@ export default class LoopScanner implements Scanner {
   /**
    * "Scans" the next sheet by returning the paths for the next two images.
    */
-  public async *scanSheets(): AsyncGenerator<SheetOf<string>> {
+  public scanSheets = makeBatchControlMethod(async function* (
+    this: LoopScanner
+  ): AsyncGenerator<SheetOf<string>> {
     if (this.nextBatchIndex >= this.batches.length) {
       this.nextBatchIndex = 0
     }
@@ -107,5 +109,5 @@ export default class LoopScanner implements Scanner {
         yield sheet
       }
     }
-  }
+  })
 }

--- a/apps/module-scan/src/endToEnd.test.ts
+++ b/apps/module-scan/src/endToEnd.test.ts
@@ -8,7 +8,7 @@ import request from 'supertest'
 import * as fsExtra from 'fs-extra'
 import { dirSync } from 'tmp'
 import { makeMockScanner, MockScanner } from '../test/util/mocks'
-import SystemImporter from './importer'
+import Importer from './importer'
 import { buildApp } from './server'
 import { CastVoteRecord } from './types'
 import { createWorkspace, Workspace } from './util/workspace'
@@ -23,14 +23,14 @@ const sampleBallotImagesPath = path.join(
 jest.setTimeout(20000)
 
 let app: Application
-let importer: SystemImporter
+let importer: Importer
 let workspace: Workspace
 let scanner: MockScanner
 
 beforeEach(async () => {
   scanner = makeMockScanner()
   workspace = await createWorkspace(dirSync().name)
-  importer = new SystemImporter({
+  importer = new Importer({
     workspace,
     scanner,
   })

--- a/apps/module-scan/src/endToEndHmpb.test.ts
+++ b/apps/module-scan/src/endToEndHmpb.test.ts
@@ -8,7 +8,7 @@ import { dirSync } from 'tmp'
 import * as choctawMockGeneral2020Fixtures from '../test/fixtures/choctaw-mock-general-election-2020'
 import * as stateOfHamilton from '../test/fixtures/state-of-hamilton'
 import { makeMockScanner, MockScanner } from '../test/util/mocks'
-import SystemImporter, { Importer } from './importer'
+import Importer from './importer'
 import { buildApp } from './server'
 import { BallotPackageManifest, CastVoteRecord } from './types'
 import { MarkStatus } from './types/ballot-review'
@@ -48,7 +48,7 @@ let app: Application
 beforeEach(async () => {
   workspace = await createWorkspace(dirSync().name)
   scanner = makeMockScanner()
-  importer = new SystemImporter({ workspace, scanner })
+  importer = new Importer({ workspace, scanner })
   app = buildApp({ importer, store: workspace.store })
 })
 

--- a/apps/module-scan/src/importer.test.ts
+++ b/apps/module-scan/src/importer.test.ts
@@ -1,17 +1,22 @@
+import { encodeHMPBBallotPageMetadata } from '@votingworks/ballot-encoder'
 import {
   asElectionDefinition,
   electionSample as election,
 } from '@votingworks/fixtures'
-import { BallotType } from '@votingworks/types'
-import { encodeHMPBBallotPageMetadata } from '@votingworks/ballot-encoder'
 import { BallotPageMetadata } from '@votingworks/hmpb-interpreter'
+import { BallotType } from '@votingworks/types'
 import * as fs from 'fs-extra'
 import { join } from 'path'
 import { dirSync } from 'tmp'
 import { v4 as uuid } from 'uuid'
 import { makeImageFile, mockWorkerPoolProvider } from '../test/util/mocks'
 import Importer, { sleep } from './importer'
-import { Scanner } from './scanner'
+import {
+  BatchControl,
+  makeBatchControl,
+  makeBatchControlMethod,
+  Scanner,
+} from './scanner'
 import { SheetOf } from './types'
 import { BallotSheetInfo } from './util/ballotAdjudicationReasons'
 import { createWorkspace, Workspace } from './util/workspace'
@@ -48,41 +53,33 @@ test('startImport calls scanner.scanSheet', async () => {
   await importer.configure(asElectionDefinition(election))
 
   // failed scan
-  const generator: AsyncGenerator<SheetOf<string>> = {
-    async next(): Promise<IteratorResult<SheetOf<string>>> {
+  const generator: BatchControl = makeBatchControl(
+    // eslint-disable-next-line require-yield
+    (async function* (): AsyncGenerator<SheetOf<string>> {
       throw new Error('scanner is a banana')
-    },
+    })()
+  )
 
-    return(): Promise<IteratorResult<SheetOf<string>>> {
-      throw new Error('scanner is a banana')
-    },
-
-    throw: jest.fn(),
-
-    [Symbol.asyncIterator](): AsyncGenerator<SheetOf<string>> {
-      return generator
-    },
-  }
-
+  jest.spyOn(generator, 'endBatch')
   scanner.scanSheets.mockImplementationOnce(() => generator)
 
   await importer.startImport()
   await importer.waitForEndOfBatchOrScanningPause()
 
-  expect(generator.throw).toHaveBeenCalled()
+  expect(generator.endBatch).toHaveBeenCalled()
 
   const batches = await workspace.store.batchStatus()
   expect(batches[0].error).toEqual('Error: scanner is a banana')
 
   // successful scan
-  scanner.scanSheets.mockImplementationOnce(async function* (): AsyncGenerator<
-    SheetOf<string>
-  > {
-    yield [
-      join(sampleBallotImagesPath, 'sample-batch-1-ballot-1.png'),
-      join(sampleBallotImagesPath, 'blank-page.png'),
-    ]
-  })
+  scanner.scanSheets.mockImplementationOnce(
+    makeBatchControlMethod(async function* (): AsyncGenerator<SheetOf<string>> {
+      yield [
+        join(sampleBallotImagesPath, 'sample-batch-1-ballot-1.png'),
+        join(sampleBallotImagesPath, 'blank-page.png'),
+      ]
+    })
+  )
   await importer.startImport()
   await importer.waitForEndOfBatchOrScanningPause()
   await importer.unconfigure()
@@ -358,24 +355,24 @@ test('scanning pauses on adjudication then continues', async () => {
       return 'sheet-3'
     })
 
-  scanner.scanSheets.mockImplementationOnce(async function* (): AsyncGenerator<
-    SheetOf<string>
-  > {
-    yield [
-      join(sampleBallotImagesPath, 'sample-batch-1-ballot-1.png'),
-      join(sampleBallotImagesPath, 'blank-page.png'),
-    ]
+  scanner.scanSheets.mockImplementationOnce(
+    makeBatchControlMethod(async function* (): AsyncGenerator<SheetOf<string>> {
+      yield [
+        join(sampleBallotImagesPath, 'sample-batch-1-ballot-1.png'),
+        join(sampleBallotImagesPath, 'blank-page.png'),
+      ]
 
-    yield [
-      join(sampleBallotImagesPath, 'sample-batch-1-ballot-2.png'),
-      join(sampleBallotImagesPath, 'blank-page.png'),
-    ]
+      yield [
+        join(sampleBallotImagesPath, 'sample-batch-1-ballot-2.png'),
+        join(sampleBallotImagesPath, 'blank-page.png'),
+      ]
 
-    yield [
-      join(sampleBallotImagesPath, 'sample-batch-1-ballot-3.png'),
-      join(sampleBallotImagesPath, 'blank-page.png'),
-    ]
-  })
+      yield [
+        join(sampleBallotImagesPath, 'sample-batch-1-ballot-3.png'),
+        join(sampleBallotImagesPath, 'blank-page.png'),
+      ]
+    })
+  )
 
   await importer.startImport()
   await importer.waitForEndOfBatchOrScanningPause()

--- a/apps/module-scan/src/importer.test.ts
+++ b/apps/module-scan/src/importer.test.ts
@@ -10,7 +10,7 @@ import { join } from 'path'
 import { dirSync } from 'tmp'
 import { v4 as uuid } from 'uuid'
 import { makeImageFile, mockWorkerPoolProvider } from '../test/util/mocks'
-import SystemImporter, { sleep } from './importer'
+import Importer, { sleep } from './importer'
 import { Scanner } from './scanner'
 import { SheetOf } from './types'
 import { BallotSheetInfo } from './util/ballotAdjudicationReasons'
@@ -36,7 +36,7 @@ test('startImport calls scanner.scanSheet', async () => {
   const scanner: jest.Mocked<Scanner> = {
     scanSheets: jest.fn(),
   }
-  const importer = new SystemImporter({
+  const importer = new Importer({
     workspace,
     scanner,
   })
@@ -92,7 +92,7 @@ test('unconfigure clears all data.', async () => {
   const scanner: jest.Mocked<Scanner> = {
     scanSheets: jest.fn(),
   }
-  const importer = new SystemImporter({
+  const importer = new Importer({
     workspace,
     scanner,
   })
@@ -107,7 +107,7 @@ test('setTestMode zeroes and sets test mode on the interpreter', async () => {
   const scanner: jest.Mocked<Scanner> = {
     scanSheets: jest.fn(),
   }
-  const importer = new SystemImporter({
+  const importer = new Importer({
     workspace,
     scanner,
   })
@@ -161,7 +161,7 @@ test('restoreConfig reconfigures the interpreter worker', async () => {
     workers.Input,
     workers.Output
   >(workerCall)
-  const importer = new SystemImporter({
+  const importer = new Importer({
     workspace,
     scanner,
     workerPoolProvider,
@@ -179,7 +179,7 @@ test('cannot add HMPB templates before configuring an election', async () => {
   const scanner: jest.Mocked<Scanner> = {
     scanSheets: jest.fn(),
   }
-  const importer = new SystemImporter({
+  const importer = new Importer({
     workspace,
     scanner,
   })
@@ -207,7 +207,7 @@ test('manually importing files', async () => {
     workers.Input,
     workers.Output
   >(workerCall)
-  const importer = new SystemImporter({
+  const importer = new Importer({
     workspace,
     scanner,
     workerPoolProvider,
@@ -326,7 +326,7 @@ test('scanning pauses on adjudication then continues', async () => {
     }
   }
 
-  const importer = new SystemImporter({
+  const importer = new Importer({
     workspace,
     scanner,
   })
@@ -432,7 +432,7 @@ test('importing a sheet normalizes and orders HMPB pages', async () => {
     workers.Output
   >(workerCall)
 
-  const importer = new SystemImporter({
+  const importer = new Importer({
     workspace,
     scanner,
     workerPoolProvider,

--- a/apps/module-scan/src/importer.ts
+++ b/apps/module-scan/src/importer.ts
@@ -31,33 +31,6 @@ export interface Options {
   workerPoolProvider?: () => WorkerPool<workers.Input, workers.Output>
 }
 
-export interface Importer {
-  addHmpbTemplates(
-    pdf: Buffer,
-    metadata: BallotMetadata
-  ): Promise<BallotPageLayout[]>
-  doneHmpbTemplates(): Promise<void>
-  configure(electionDefinition: ElectionDefinition): Promise<void>
-  doExport(): Promise<string>
-  startImport(): Promise<string>
-  continueImport(override?: boolean): Promise<void>
-  waitForEndOfBatchOrScanningPause(): Promise<void>
-  doZero(): Promise<void>
-  importFile(
-    batchId: string,
-    frontImagePath: string,
-    backImagePath: string
-  ): Promise<string>
-  getStatus(): Promise<ScanStatus>
-  restoreConfig(): Promise<void>
-  setTestMode(testMode: boolean): Promise<void>
-  setSkipElectionHashCheck(skipElectionHashCheck: boolean): Promise<void>
-  setMarkThresholdOverrides(
-    markThresholds: Optional<MarkThresholds>
-  ): Promise<void>
-  unconfigure(): Promise<void>
-}
-
 export class HmpbInterpretationError extends Error {}
 
 export async function saveImages(
@@ -87,7 +60,7 @@ export async function saveImages(
 /**
  * Imports ballot images from a `Scanner` and stores them in a `Store`.
  */
-export default class SystemImporter implements Importer {
+export default class Importer {
   private workspace: Workspace
   private scanner: Scanner
   private sheetGenerator: AsyncGenerator<SheetOf<string>> | undefined

--- a/apps/module-scan/src/scanner.ts
+++ b/apps/module-scan/src/scanner.ts
@@ -13,32 +13,6 @@ export interface BatchControl {
   endBatch(): Promise<void>
 }
 
-export function makeBatchControlMethod(
-  factory: () => AsyncGenerator<SheetOf<string>>
-): () => BatchControl {
-  return function (this: never): BatchControl {
-    return makeBatchControl(factory.call(this))
-  }
-}
-
-export function makeBatchControl(
-  generator: AsyncGenerator<SheetOf<string>>
-): BatchControl {
-  return {
-    scanSheet: async (): Promise<SheetOf<string> | undefined> => {
-      const next = await generator.next()
-      if (next.done) {
-        return undefined
-      } else {
-        return next.value
-      }
-    },
-    endBatch: async (): Promise<void> => {
-      await generator.return(undefined)
-    },
-  }
-}
-
 export interface Scanner {
   scanSheets(directory?: string): BatchControl
 }
@@ -126,7 +100,7 @@ export class FujitsuScanner implements Scanner {
     )
 
     const scannedFiles: string[] = []
-    const results = queue<Promise<IteratorResult<SheetOf<string>>>>()
+    const results = queue<Promise<SheetOf<string> | undefined>>()
     let done = false
     const scanimage = streamExecFile('scanimage', args)
 
@@ -143,10 +117,7 @@ export class FujitsuScanner implements Scanner {
       scannedFiles.push(path)
       if (scannedFiles.length % 2 === 0) {
         results.resolve(
-          Promise.resolve({
-            value: scannedFiles.slice(-2) as SheetOf<string>,
-            done: false,
-          })
+          Promise.resolve(scannedFiles.slice(-2) as SheetOf<string>)
         )
       }
     })
@@ -161,12 +132,12 @@ export class FujitsuScanner implements Scanner {
       if (code !== 0) {
         results.rejectAll(new Error(`scanimage exited with code=${code}`))
       } else {
-        results.resolveAll(Promise.resolve({ value: undefined, done }))
+        results.resolveAll(Promise.resolve(undefined))
       }
     })
 
-    const generator: AsyncGenerator<SheetOf<string>> = {
-      async next(): Promise<IteratorResult<SheetOf<string>>> {
+    return {
+      scanSheet: async (): Promise<SheetOf<string> | undefined> => {
         if (results.isEmpty() && !done) {
           debug(
             'scanimage [pid=%d] sending RETURN twice to scan another sheet',
@@ -178,46 +149,20 @@ export class FujitsuScanner implements Scanner {
         return results.get()
       },
 
-      return(value: unknown): Promise<IteratorResult<SheetOf<string>>> {
+      endBatch: async (): Promise<void> => {
         if (!done) {
           done = true
           debug(
-            'scanimage [pid=%d] generator return called, stopping scan by closing stdin',
+            'scanimage [pid=%d] stopping scan by closing stdin',
             scanimage.pid
           )
-          return new Promise((resolve) => {
+          await new Promise<void>((resolve) => {
             scanimage.stdin?.end(() => {
-              resolve({ value, done: true })
+              resolve()
             })
           })
         }
-
-        return Promise.resolve({ value, done })
-      },
-
-      throw(): Promise<IteratorResult<SheetOf<string>>> {
-        if (!done) {
-          done = true
-          debug(
-            'scanimage [pid=%d] generator throw called, stopping scan by closing stdin',
-            scanimage.pid
-          )
-          return new Promise((resolve) => {
-            scanimage.stdin?.end(() => {
-              resolve({ value: undefined, done: true })
-            })
-          })
-        }
-
-        return Promise.resolve({ value: undefined, done })
-      },
-
-      /* istanbul ignore next - required by TS, but unclear of what use it is */
-      [Symbol.asyncIterator](): AsyncGenerator<SheetOf<string>> {
-        return generator
       },
     }
-
-    return makeBatchControl(generator)
   }
 }

--- a/apps/module-scan/src/server.ts
+++ b/apps/module-scan/src/server.ts
@@ -15,7 +15,7 @@ import multer from 'multer'
 import * as path from 'path'
 import { inspect } from 'util'
 import backup from './backup'
-import SystemImporter, { Importer } from './importer'
+import Importer from './importer'
 import { FujitsuScanner, Scanner, ScannerMode } from './scanner'
 import Store from './store'
 import { BallotConfig } from './types'
@@ -585,7 +585,7 @@ export async function start({
   scanner = scanner ?? new FujitsuScanner({ mode: ScannerMode.Gray })
   importer =
     importer ??
-    new SystemImporter({
+    new Importer({
       workspace,
       scanner,
       workerPoolProvider: (): WorkerPool<workers.Input, workers.Output> =>
@@ -596,7 +596,7 @@ export async function start({
   app.listen(port, () => {
     log(`Listening at http://localhost:${port}/`)
 
-    if (importer instanceof SystemImporter) {
+    if (importer instanceof Importer) {
       log(`Scanning ballots into ${workspace?.ballotImagesPath}`)
     }
   })

--- a/apps/module-scan/test/util/mocks.ts
+++ b/apps/module-scan/test/util/mocks.ts
@@ -2,11 +2,21 @@ import { ChildProcess } from 'child_process'
 import { EventEmitter } from 'events'
 import { Readable, Writable } from 'stream'
 import { fileSync } from 'tmp'
-import { Importer } from '../../src/importer'
+import { MaybeMocked, mocked } from 'ts-jest/dist/utils/testing'
+import SystemImporter from '../../src/importer'
 import { Scanner } from '../../src/scanner'
 import { SheetOf } from '../../src/types'
 import { writeImageData } from '../../src/util/images'
 import { inlinePool, WorkerOps, WorkerPool } from '../../src/workers/pool'
+
+export function makeMock<T>(cls: new (...args: never[]) => T): MaybeMocked<T> {
+  if (!jest.isMockFunction(cls)) {
+    throw new Error(
+      `${cls} is not a mock function; are you missing a jest.mock(…) call?`
+    )
+  }
+  return mocked(new cls())
+}
 
 export function mockWorkerPoolProvider<I, O>(
   call: (input: I) => Promise<O>
@@ -23,24 +33,8 @@ export function makeMockWorkerOps<I>(): jest.Mocked<WorkerOps<I>> {
   }
 }
 
-export function makeMockImporter(): jest.Mocked<Importer> {
-  return {
-    addHmpbTemplates: jest.fn(),
-    doneHmpbTemplates: jest.fn(),
-    configure: jest.fn(),
-    doExport: jest.fn(),
-    startImport: jest.fn(),
-    continueImport: jest.fn(),
-    waitForEndOfBatchOrScanningPause: jest.fn(),
-    importFile: jest.fn(),
-    doZero: jest.fn(),
-    getStatus: jest.fn(),
-    restoreConfig: jest.fn(),
-    setTestMode: jest.fn(),
-    setSkipElectionHashCheck: jest.fn(),
-    unconfigure: jest.fn(),
-    setMarkThresholdOverrides: jest.fn(),
-  }
+export function makeMockImporter(): jest.Mocked<SystemImporter> {
+  return makeMock(SystemImporter)
 }
 
 type ScanSessionStep =

--- a/apps/module-scan/test/util/mocks.ts
+++ b/apps/module-scan/test/util/mocks.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from 'events'
 import { Readable, Writable } from 'stream'
 import { fileSync } from 'tmp'
 import { MaybeMocked, mocked } from 'ts-jest/dist/utils/testing'
-import { Scanner } from '../../src/scanner'
+import { makeBatchControlMethod, Scanner } from '../../src/scanner'
 import { SheetOf } from '../../src/types'
 import { writeImageData } from '../../src/util/images'
 import { inlinePool, WorkerOps, WorkerPool } from '../../src/workers/pool'
@@ -105,7 +105,9 @@ export function makeMockScanner(): MockScanner {
   let nextScannerSession: ScannerSessionPlan | undefined
 
   return {
-    async *scanSheets(): AsyncGenerator<SheetOf<string>> {
+    scanSheets: makeBatchControlMethod(async function* (): AsyncGenerator<
+      SheetOf<string>
+    > {
       const session = nextScannerSession
       nextScannerSession = undefined
 
@@ -125,7 +127,7 @@ export function makeMockScanner(): MockScanner {
             throw step.error
         }
       }
-    },
+    }),
 
     /**
      * Gets the next scanner session to be used when `scanSheets` is called.

--- a/apps/module-scan/test/util/mocks.ts
+++ b/apps/module-scan/test/util/mocks.ts
@@ -3,7 +3,6 @@ import { EventEmitter } from 'events'
 import { Readable, Writable } from 'stream'
 import { fileSync } from 'tmp'
 import { MaybeMocked, mocked } from 'ts-jest/dist/utils/testing'
-import SystemImporter from '../../src/importer'
 import { Scanner } from '../../src/scanner'
 import { SheetOf } from '../../src/types'
 import { writeImageData } from '../../src/util/images'
@@ -31,10 +30,6 @@ export function makeMockWorkerOps<I>(): jest.Mocked<WorkerOps<I>> {
     send: jest.fn(),
     describe: jest.fn(),
   }
-}
-
-export function makeMockImporter(): jest.Mocked<SystemImporter> {
-  return makeMock(SystemImporter)
 }
 
 type ScanSessionStep =


### PR DESCRIPTION
Replaces the async generator-based API for scanning a batch with a more domain-specific API that we can more easily expand to include commands for the precinct scanner (e.g. ejection).