### PR TITLE
feat(scan): add precinct scanner

### DIFF
--- a/apps/bsd/src/config/types.ts
+++ b/apps/bsd/src/config/types.ts
@@ -95,6 +95,14 @@ export interface ScanStatusResponse {
   electionHash?: string
   batches: Batch[]
   adjudication: AdjudicationStatus
+  scanner: ScannerStatus
+}
+
+export enum ScannerStatus {
+  WaitingForPaper = 'WaitingForPaper',
+  ReadyToScan = 'ReadyToScan',
+  Error = 'Error',
+  Unknown = 'Unknown',
 }
 
 // eslint-disable-next-line import/no-cycle

--- a/apps/module-scan/package.json
+++ b/apps/module-scan/package.json
@@ -34,6 +34,7 @@
     "@votingworks/ballot-encoder": "workspace:*",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/hmpb-interpreter": "workspace:*",
+    "@votingworks/plustek-sdk": "workspace:*",
     "@votingworks/qrdetect": "^1.0.1",
     "@votingworks/types": "workspace:*",
     "base64-js": "^1.5.1",

--- a/apps/module-scan/src/LoopScanner.ts
+++ b/apps/module-scan/src/LoopScanner.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs-extra'
 import { join, resolve } from 'path'
-import { BatchControl, Scanner } from './scanner'
+import { BatchControl, Scanner, ScannerStatus } from './scanner'
 import { SheetOf } from './types'
 
 type Batch = readonly SheetOf<string>[]
@@ -92,6 +92,10 @@ export default class LoopScanner implements Scanner {
     this.batches = batches
   }
 
+  public async getStatus(): Promise<ScannerStatus> {
+    return ScannerStatus.Unknown
+  }
+
   /**
    * "Scans" the next sheet by returning the paths for the next two images.
    */
@@ -102,6 +106,18 @@ export default class LoopScanner implements Scanner {
     let sheetIndex = 0
 
     return {
+      async acceptSheet(): Promise<boolean> {
+        return false
+      },
+
+      async reviewSheet(): Promise<boolean> {
+        return false
+      },
+
+      async rejectSheet(): Promise<boolean> {
+        return false
+      },
+
       async scanSheet(): Promise<SheetOf<string> | undefined> {
         return currentBatch?.[sheetIndex++]
       },

--- a/apps/module-scan/src/endToEnd.test.ts
+++ b/apps/module-scan/src/endToEnd.test.ts
@@ -34,7 +34,7 @@ beforeEach(async () => {
     workspace,
     scanner,
   })
-  app = buildApp({ importer, store: workspace.store })
+  app = buildApp({ importer, store: workspace.store, scanner })
 })
 
 afterEach(async () => {

--- a/apps/module-scan/src/importer.test.ts
+++ b/apps/module-scan/src/importer.test.ts
@@ -33,6 +33,7 @@ jest.setTimeout(20000)
 
 test('startImport calls scanner.scanSheet', async () => {
   const scanner: jest.Mocked<Scanner> = {
+    getStatus: jest.fn(),
     scanSheets: jest.fn(),
   }
   const importer = new Importer({
@@ -48,6 +49,9 @@ test('startImport calls scanner.scanSheet', async () => {
 
   // failed scan
   const batchControl: BatchControl = {
+    acceptSheet: jest.fn(),
+    reviewSheet: jest.fn(),
+    rejectSheet: jest.fn(),
     scanSheet: jest
       .fn()
       .mockRejectedValueOnce(new Error('scanner is a banana')),
@@ -65,6 +69,9 @@ test('startImport calls scanner.scanSheet', async () => {
 
   // successful scan
   scanner.scanSheets.mockReturnValueOnce({
+    acceptSheet: jest.fn(),
+    reviewSheet: jest.fn(),
+    rejectSheet: jest.fn(),
     scanSheet: jest
       .fn()
       .mockResolvedValueOnce([
@@ -81,6 +88,7 @@ test('startImport calls scanner.scanSheet', async () => {
 
 test('unconfigure clears all data.', async () => {
   const scanner: jest.Mocked<Scanner> = {
+    getStatus: jest.fn(),
     scanSheets: jest.fn(),
   }
   const importer = new Importer({
@@ -96,6 +104,7 @@ test('unconfigure clears all data.', async () => {
 
 test('setTestMode zeroes and sets test mode on the interpreter', async () => {
   const scanner: jest.Mocked<Scanner> = {
+    getStatus: jest.fn(),
     scanSheets: jest.fn(),
   }
   const importer = new Importer({
@@ -145,6 +154,7 @@ test('setTestMode zeroes and sets test mode on the interpreter', async () => {
 
 test('restoreConfig reconfigures the interpreter worker', async () => {
   const scanner: jest.Mocked<Scanner> = {
+    getStatus: jest.fn(),
     scanSheets: jest.fn(),
   }
   const workerCall = jest.fn()
@@ -168,6 +178,7 @@ test('restoreConfig reconfigures the interpreter worker', async () => {
 
 test('cannot add HMPB templates before configuring an election', async () => {
   const scanner: jest.Mocked<Scanner> = {
+    getStatus: jest.fn(),
     scanSheets: jest.fn(),
   }
   const importer = new Importer({
@@ -191,6 +202,7 @@ test('cannot add HMPB templates before configuring an election', async () => {
 
 test('manually importing files', async () => {
   const scanner: jest.Mocked<Scanner> = {
+    getStatus: jest.fn(),
     scanSheets: jest.fn(),
   }
   const workerCall = jest.fn<Promise<workers.Output>, [workers.Input]>()
@@ -301,6 +313,7 @@ test('manually importing files', async () => {
 
 test('scanning pauses on adjudication then continues', async () => {
   const scanner: jest.Mocked<Scanner> = {
+    getStatus: jest.fn(),
     scanSheets: jest.fn(),
   }
   const mockGetNextAdjudicationSheet = async (): Promise<BallotSheetInfo> => {
@@ -350,6 +363,9 @@ test('scanning pauses on adjudication then continues', async () => {
     })
 
   scanner.scanSheets.mockReturnValueOnce({
+    acceptSheet: jest.fn(),
+    reviewSheet: jest.fn(),
+    rejectSheet: jest.fn(),
     scanSheet: jest
       .fn()
       .mockResolvedValueOnce([
@@ -414,6 +430,7 @@ test('scanning pauses on adjudication then continues', async () => {
 
 test('importing a sheet normalizes and orders HMPB pages', async () => {
   const scanner: jest.Mocked<Scanner> = {
+    getStatus: jest.fn(),
     scanSheets: jest.fn(),
   }
   const workerCall = jest.fn<Promise<workers.Output>, [workers.Input]>()

--- a/apps/module-scan/src/importer.ts
+++ b/apps/module-scan/src/importer.ts
@@ -12,6 +12,7 @@ import { v4 as uuid } from 'uuid'
 import { PageInterpretation } from './interpreter'
 import { BatchControl, Scanner } from './scanner'
 import { BallotMetadata, ScanStatus, SheetOf, Side } from './types'
+import { Castability, checkSheetCastability } from './util/castability'
 import { writeImageData } from './util/images'
 import pdfToImages from './util/pdfToImages'
 import { Workspace } from './util/workspace'
@@ -373,8 +374,32 @@ export default class Importer {
 
       const adjudicationStatus = await this.workspace.store.adjudicationStatus()
       if (adjudicationStatus.remaining === 0) {
+        if (!(await this.sheetGenerator.acceptSheet())) {
+          debug('failed to accept interpreted sheet: %s', sheetId)
+        }
         await this.continueImport()
+      } else {
+        const castability = await this.getNextAdjudicationCastability()
+        if (castability) {
+          if (castability === Castability.Uncastable) {
+            await this.sheetGenerator.rejectSheet()
+          } else {
+            await this.sheetGenerator.reviewSheet()
+          }
+        }
       }
+    }
+  }
+
+  public async getNextAdjudicationCastability(): Promise<
+    Castability | undefined
+  > {
+    const sheet = await this.workspace.store.getNextAdjudicationSheet()
+    if (sheet) {
+      return checkSheetCastability([
+        sheet.front.interpretation,
+        sheet.back.interpretation,
+      ])
     }
   }
 
@@ -422,10 +447,12 @@ export default class Importer {
 
     if (sheet) {
       if (override) {
+        await this.sheetGenerator?.acceptSheet()
         for (const side of ['front', 'back'] as Side[]) {
           await this.workspace.store.saveBallotAdjudication(sheet.id, side, {})
         }
       } else {
+        await this.sheetGenerator?.rejectSheet()
         await this.workspace.store.deleteSheet(sheet.id)
       }
     }
@@ -488,10 +515,13 @@ export default class Importer {
     const election = await this.workspace.store.getElectionDefinition()
     const batches = await this.workspace.store.batchStatus()
     const adjudication = await this.workspace.store.adjudicationStatus()
-    if (election) {
-      return { electionHash: election.electionHash, batches, adjudication }
+    const scanner = await this.scanner.getStatus()
+    return {
+      electionHash: election?.electionHash,
+      batches,
+      adjudication,
+      scanner,
     }
-    return { batches, adjudication }
   }
 
   /**

--- a/apps/module-scan/src/scanner.ts
+++ b/apps/module-scan/src/scanner.ts
@@ -1,3 +1,5 @@
+import { PaperStatus, ScannerClient } from '@votingworks/plustek-sdk'
+import { Provider, Result } from '@votingworks/types'
 import makeDebug from 'debug'
 import { join } from 'path'
 import { dirSync } from 'tmp'
@@ -10,10 +12,21 @@ const debug = makeDebug('module-scan:scanner')
 
 export interface BatchControl {
   scanSheet(): Promise<SheetOf<string> | undefined>
+  acceptSheet(): Promise<boolean>
+  reviewSheet(): Promise<boolean>
+  rejectSheet(): Promise<boolean>
   endBatch(): Promise<void>
 }
 
+export enum ScannerStatus {
+  WaitingForPaper = 'WaitingForPaper',
+  ReadyToScan = 'ReadyToScan',
+  Error = 'Error',
+  Unknown = 'Unknown',
+}
+
 export interface Scanner {
+  getStatus(): Promise<ScannerStatus>
   scanSheets(directory?: string): BatchControl
 }
 
@@ -67,6 +80,10 @@ export class FujitsuScanner implements Scanner {
     this.format = format
     this.pageSize = pageSize
     this.mode = mode
+  }
+
+  public async getStatus(): Promise<ScannerStatus> {
+    return ScannerStatus.Unknown
   }
 
   public scanSheets(directory = dirSync().name): BatchControl {
@@ -149,6 +166,18 @@ export class FujitsuScanner implements Scanner {
         return results.get()
       },
 
+      acceptSheet: async (): Promise<boolean> => {
+        return true
+      },
+
+      reviewSheet: async (): Promise<boolean> => {
+        return false
+      },
+
+      rejectSheet: async (): Promise<boolean> => {
+        return false
+      },
+
       endBatch: async (): Promise<void> => {
         if (!done) {
           done = true
@@ -162,6 +191,164 @@ export class FujitsuScanner implements Scanner {
             })
           })
         }
+      },
+    }
+  }
+}
+
+export class PlustekScanner implements Scanner {
+  public constructor(
+    private readonly clientProvider: Provider<Result<ScannerClient, Error>>
+  ) {}
+
+  public async getStatus(): Promise<ScannerStatus> {
+    const clientResult = await this.clientProvider.get()
+
+    if (clientResult.isErr()) {
+      debug(
+        'PlustekScanner#getStatus: failed to get client: %s',
+        clientResult.err()
+      )
+      return ScannerStatus.Error
+    }
+
+    const client = clientResult.unwrap()
+    return (await client.getPaperStatus()).mapOrElse(
+      () => ScannerStatus.Error,
+      (paperStatus) => {
+        debug('PlustekScanner#getStatus: got paper status: %s', paperStatus)
+        return paperStatus === PaperStatus.VtmDevReadyNoPaper
+          ? ScannerStatus.WaitingForPaper
+          : paperStatus === PaperStatus.VtmReadyToScan
+          ? ScannerStatus.ReadyToScan
+          : ScannerStatus.Error
+      }
+    )
+  }
+
+  public scanSheets(directory?: string): BatchControl {
+    debug('scanSheets: ignoring directory: %s', directory)
+    return {
+      scanSheet: async (): Promise<SheetOf<string> | undefined> => {
+        debug('PlustekScanner#scanSheet BEGIN')
+        const clientResult = await this.clientProvider.get()
+
+        if (clientResult.isErr()) {
+          return undefined
+        }
+
+        const client = clientResult.unwrap()
+        const { files } = (await client.scan()).unwrap()
+        return [files[0], files[1]]
+      },
+
+      acceptSheet: async (): Promise<boolean> => {
+        debug('PlustekScanner#acceptSheet BEGIN')
+        const clientResult = await this.clientProvider.get()
+
+        if (clientResult.isErr()) {
+          debug(
+            'PlustekScanner#acceptSheet failed to get client: %s',
+            clientResult.err()
+          )
+          return false
+        }
+
+        const client = clientResult.unwrap()
+        const acceptResult = await client.accept()
+
+        if (acceptResult.isErr()) {
+          debug('PlustekScanner#acceptSheet failed: %s', acceptResult.err())
+          return false
+        }
+
+        return (
+          (
+            await client.waitForStatus({
+              status: PaperStatus.NoPaper,
+              timeout: 1000,
+            })
+          )?.ok() === PaperStatus.NoPaper
+        )
+      },
+
+      reviewSheet: async (): Promise<boolean> => {
+        try {
+          debug('PlustekScanner#reviewSheet BEGIN')
+          const clientResult = await this.clientProvider.get()
+
+          if (clientResult.isErr()) {
+            debug(
+              'PlustekScanner#reviewSheet failed to get client: %s',
+              clientResult.err()
+            )
+            return false
+          }
+
+          const client = clientResult.unwrap()
+          const rejectResult = await client.reject({ hold: true })
+
+          if (rejectResult.isErr()) {
+            debug('PlustekScanner#reviewSheet failed: %s', rejectResult.err())
+            return false
+          }
+
+          return (
+            (
+              await client.waitForStatus({
+                status: PaperStatus.VtmReadyToScan,
+                timeout: 1000,
+              })
+            )?.ok() === PaperStatus.VtmReadyToScan
+          )
+        } finally {
+          debug('PlustekScanner#reviewSheet END')
+        }
+      },
+
+      rejectSheet: async (): Promise<boolean> => {
+        debug('PlustekScanner#rejectSheet BEGIN')
+        const clientResult = await this.clientProvider.get()
+
+        if (clientResult.isErr()) {
+          debug(
+            'PlustekScanner#reviewSheet failed to get client: %s',
+            clientResult.err()
+          )
+          return false
+        }
+
+        const client = clientResult.unwrap()
+        const rejectResult = await client.reject({ hold: false })
+
+        if (rejectResult.isErr()) {
+          debug('PlustekScanner#rejectSheet failed: %s', rejectResult.err())
+          return false
+        }
+
+        return (
+          (
+            await client.waitForStatus({
+              status: PaperStatus.NoPaper,
+              timeout: 1000,
+            })
+          )?.ok() === PaperStatus.NoPaper
+        )
+      },
+
+      endBatch: async (): Promise<void> => {
+        const clientResult = await this.clientProvider.get()
+
+        if (clientResult.isErr()) {
+          debug(
+            'PlustekScanner#endBatch failed to get client: %s',
+            clientResult.err()
+          )
+          return
+        }
+
+        const client = clientResult.unwrap()
+        await client.reject({ hold: false })
       },
     }
   }

--- a/apps/module-scan/src/types.ts
+++ b/apps/module-scan/src/types.ts
@@ -14,6 +14,7 @@ import {
 } from '@votingworks/hmpb-interpreter'
 import { MarkInfo, PageInterpretation } from './interpreter'
 import { MarksByContestId, MarkStatus } from './types/ballot-review'
+import { ScannerStatus } from './scanner'
 
 export type SheetOf<T> = [T, T]
 export type Side = 'front' | 'back'
@@ -50,10 +51,11 @@ export interface ScanStatus {
   electionHash?: string
   batches: BatchInfo[]
   adjudication: AdjudicationStatus
+  scanner: ScannerStatus
 }
 
 export interface BatchInfo {
-  id: number
+  id: string
   startedAt: Date
   endedAt: Date
   error: string

--- a/apps/module-scan/src/util/castability.test.ts
+++ b/apps/module-scan/src/util/castability.test.ts
@@ -1,0 +1,101 @@
+import { BallotType } from '@votingworks/types'
+import {
+  BlankPage,
+  InterpretedBmdPage,
+  InterpretedHmpbPage,
+  UnreadablePage,
+} from '../interpreter'
+import { Castability, checkSheetCastability } from './castability'
+
+const interpretedBmdPage: Readonly<InterpretedBmdPage> = {
+  type: 'InterpretedBmdPage',
+  ballotId: 'abc',
+  metadata: {
+    ballotStyleId: '1',
+    precinctId: '6522',
+    ballotType: BallotType.Standard,
+    electionHash: '',
+    isTestMode: false,
+    locales: { primary: 'en-US' },
+  },
+  votes: {
+    'flag-question': ['yes'],
+  },
+}
+
+const interpretedHmpbPage: Readonly<InterpretedHmpbPage> = {
+  type: 'InterpretedHmpbPage',
+  ballotId: 'abcdefg',
+  metadata: {
+    locales: { primary: 'en-US' },
+    electionHash: '',
+    ballotType: BallotType.Standard,
+    ballotStyleId: '1',
+    precinctId: '6522',
+    isTestMode: false,
+    pageNumber: 1,
+  },
+  markInfo: { marks: [], ballotSize: { width: 1, height: 1 } },
+  adjudicationInfo: {
+    requiresAdjudication: false,
+    enabledReasons: [],
+    allReasonInfos: [],
+  },
+  votes: {},
+}
+
+const interpretedHmpbPageRequiringAdjudication: Readonly<InterpretedHmpbPage> = {
+  ...interpretedHmpbPage,
+  adjudicationInfo: {
+    ...interpretedHmpbPage.adjudicationInfo,
+    requiresAdjudication: true,
+  },
+}
+
+const unreadablePage: Readonly<UnreadablePage> = { type: 'UnreadablePage' }
+
+const blankPage: Readonly<BlankPage> = {
+  type: 'BlankPage',
+}
+
+test('castability of a BMD ballot', () => {
+  expect(checkSheetCastability([interpretedBmdPage, blankPage])).toEqual(
+    Castability.CastableWithoutReview
+  )
+  expect(checkSheetCastability([blankPage, interpretedBmdPage])).toEqual(
+    Castability.CastableWithoutReview
+  )
+})
+
+test('castability of a blank sheet', () => {
+  expect(checkSheetCastability([blankPage, blankPage])).toEqual(
+    Castability.Uncastable
+  )
+})
+
+test('castability of a HMPB ballot not requiring adjudication', () => {
+  expect(
+    checkSheetCastability([interpretedHmpbPage, interpretedHmpbPage])
+  ).toEqual(Castability.CastableWithoutReview)
+})
+
+test('castability of a HMPB ballot requiring adjudication', () => {
+  expect(
+    checkSheetCastability([
+      interpretedHmpbPageRequiringAdjudication,
+      interpretedHmpbPage,
+    ])
+  ).toEqual(Castability.CastableWithReview)
+  expect(
+    checkSheetCastability([
+      interpretedHmpbPage,
+      interpretedHmpbPageRequiringAdjudication,
+    ])
+  ).toEqual(Castability.CastableWithReview)
+})
+
+test('castability of an unreadable ballot', () => {
+  expect(checkSheetCastability([unreadablePage, unreadablePage])).toEqual(
+    Castability.Uncastable
+  )
+})

--- a/apps/module-scan/src/util/castability.ts
+++ b/apps/module-scan/src/util/castability.ts
@@ -1,0 +1,36 @@
+import { PageInterpretation } from '../interpreter'
+import { SheetOf } from '../types'
+
+export enum Castability {
+  Uncastable = 'Uncastable',
+  CastableWithoutReview = 'CastableWithoutReview',
+  CastableWithReview = 'CastableWithReview',
+}
+
+export function checkSheetCastability([
+  front,
+  back,
+]: SheetOf<PageInterpretation>): Castability {
+  if (
+    (front.type === 'InterpretedBmdPage' && back.type === 'BlankPage') ||
+    (front.type === 'BlankPage' && back.type === 'InterpretedBmdPage')
+  ) {
+    return Castability.CastableWithoutReview
+  }
+
+  if (
+    front.type === 'InterpretedHmpbPage' &&
+    back.type === 'InterpretedHmpbPage'
+  ) {
+    if (
+      front.adjudicationInfo.requiresAdjudication ||
+      back.adjudicationInfo.requiresAdjudication
+    ) {
+      return Castability.CastableWithReview
+    } else {
+      return Castability.CastableWithoutReview
+    }
+  }
+
+  return Castability.Uncastable
+}

--- a/apps/module-scan/tsconfig.json
+++ b/apps/module-scan/tsconfig.json
@@ -21,6 +21,7 @@
   "references": [
     { "path": "../../libs/ballot-encoder" },
     { "path": "../../libs/hmpb-interpreter" },
+    { "path": "../../libs/plustek-sdk" },
     { "path": "../../libs/types" }
   ]
 }

--- a/apps/module-scan/tsconfig.test.json
+++ b/apps/module-scan/tsconfig.test.json
@@ -1,5 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src", "test"],
-  "exclude": []
+  "exclude": [],
+  "references": [
+    { "path": "../../libs/ballot-encoder" },
+    { "path": "../../libs/hmpb-interpreter" },
+    { "path": "../../libs/plustek-sdk" },
+    { "path": "../../libs/types" }
+  ]
 }

--- a/libs/plustek-sdk/package.json
+++ b/libs/plustek-sdk/package.json
@@ -1,11 +1,13 @@
 {
-  "name": "plustek-sdk",
+  "name": "@votingworks/plustek-sdk",
+  "private": true,
   "version": "1.0.0",
   "description": "Wraps the official plustek SDK for use with the VTM 300 via NodeJS.",
   "keywords": [],
   "license": "AGPL",
   "author": "VotingWorks <eng@voting.works>",
-  "main": "build/index.js",
+  "main": "build/src/index.js",
+  "types": "build/src/index.d.ts",
   "scripts": {
     "build": "tsc --build tsconfig.test.json",
     "build:watch": "tsc --build --watch tsconfig.test.json",

--- a/libs/plustek-sdk/src/index.ts
+++ b/libs/plustek-sdk/src/index.ts
@@ -1,4 +1,5 @@
 /* istanbul ignore file */
-export * from './scanner'
 export * from './config'
+export * from './errors'
 export * from './paper-status'
+export * from './scanner'

--- a/libs/plustek-sdk/src/scanner.ts
+++ b/libs/plustek-sdk/src/scanner.ts
@@ -8,6 +8,7 @@ import deferred from './util/deferred'
 import { Config, DEFAULT_CONFIG } from './config'
 import { file as createTempFile, dir as createTempDir } from './util/temp'
 import makeDebug from 'debug'
+import sleep from './util/sleep'
 
 const debug = makeDebug('plustek-sdk:scanner')
 
@@ -31,6 +32,11 @@ export type CloseResult = Result<void, ScannerError | Error>
 export interface ScannerClient {
   isConnected(): boolean
   getPaperStatus(): Promise<GetPaperStatusResult>
+  waitForStatus(options: {
+    status: PaperStatus
+    timeout?: number
+    interval?: number
+  }): Promise<GetPaperStatusResult | undefined>
   scan(): Promise<ScanResult>
   accept(): Promise<AcceptResult>
   reject(options: { hold: boolean }): Promise<RejectResult>
@@ -205,16 +211,34 @@ export async function createClient(
 
   await connectedPromise
 
+  const getPaperStatus: ScannerClient['getPaperStatus'] = () =>
+    doIPC('get-paper-status', {
+      data: (data, resolve) => resolve(safeParse(PaperStatusSchema, data)),
+      error: (error, resolve) => resolve(err(error)),
+      else: (line, resolve) =>
+        resolve(err(new Error(`invalid response: ${line}`))),
+    })
+
   return ok({
     isConnected: () => connected,
 
-    getPaperStatus: () =>
-      doIPC('get-paper-status', {
-        data: (data, resolve) => resolve(safeParse(PaperStatusSchema, data)),
-        error: (error, resolve) => resolve(err(error)),
-        else: (line, resolve) =>
-          resolve(err(new Error(`invalid response: ${line}`))),
-      }),
+    getPaperStatus,
+
+    waitForStatus: async ({ status, interval=50,timeout}) => {
+      const until = typeof timeout === 'undefined' ? Infinity : Date.now() + timeout
+      let result: GetPaperStatusResult | undefined
+
+      while (Date.now() < until) {
+        result = await getPaperStatus()
+        if (result.ok() === status) {
+          break
+        }
+
+        await sleep(interval)
+      }
+
+      return result
+    },
 
     scan: () => {
       const files: string[] = []

--- a/libs/plustek-sdk/src/util/sleep.ts
+++ b/libs/plustek-sdk/src/util/sleep.ts
@@ -1,0 +1,3 @@
+export default async function sleep(duration: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, duration))
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ importers:
       '@types/pluralize': 0.0.29
       '@types/react': 17.0.0
       '@types/react-dom': 17.0.0
-      '@types/styled-components': 5.1.7
+      '@types/styled-components': 5.1.9
       http-proxy-middleware: 1.0.6
       normalize.css: 8.0.1
       pluralize: 8.0.0
@@ -98,7 +98,7 @@ importers:
       '@types/react-dom': 17.0.0
       '@types/react-modal': 3.10.6
       '@types/react-router-dom': 5.1.7
-      '@types/styled-components': 5.1.7
+      '@types/styled-components': 5.1.9
       '@votingworks/ballot-encoder': link:../../libs/ballot-encoder
       '@votingworks/qrcode.react': 1.0.1_react@17.0.1
       '@votingworks/ui': link:../../libs/ui
@@ -258,7 +258,7 @@ importers:
       '@types/react': 17.0.0
       '@types/react-dom': 17.0.0
       '@types/react-modal': 3.10.6
-      '@types/styled-components': 5.1.7
+      '@types/styled-components': 5.1.9
       '@votingworks/hmpb-interpreter': link:../../libs/hmpb-interpreter
       '@votingworks/ui': link:../../libs/ui
       fast-text-encoding: 1.0.3
@@ -274,8 +274,8 @@ importers:
       react-router-dom: 5.2.0_react@17.0.1
       react-scripts: 4.0.1_e703000ab01b26b8080bd45c5ecb8346
       rxjs: 6.6.6
-      styled-components: 5.2.1_react-dom@17.0.1+react@17.0.1
-      ts-jest: 26.5.5_typescript@4.2.3
+      styled-components: 5.2.3_react-dom@17.0.1+react@17.0.1
+      ts-jest: 26.4.4_typescript@4.2.3
       typescript: 4.2.3
       use-interval: 1.3.0_react@17.0.1
       yauzl: 2.10.0
@@ -413,7 +413,7 @@ importers:
       '@types/react-dom': 17.0.0
       '@types/react-modal': 3.10.6
       '@types/react-router-dom': 5.1.7
-      '@types/styled-components': 5.1.7
+      '@types/styled-components': 5.1.9
       '@votingworks/ballot-encoder': link:../../libs/ballot-encoder
       '@votingworks/fixtures': link:../../libs/fixtures
       '@votingworks/qrcode.react': 1.0.2_react@17.0.1
@@ -441,11 +441,11 @@ importers:
       react-i18next: 11.8.5_i18next@19.8.4+react@17.0.1
       react-modal: 3.12.1_react-dom@17.0.1+react@17.0.1
       react-router-dom: 5.2.0_react@17.0.1
-      react-scripts: 4.0.1_typescript@4.2.4
+      react-scripts: 4.0.1_typescript@4.2.3
       react-textarea-autosize: 8.3.0_@types+react@17.0.0+react@17.0.1
       rxjs: 6.6.6
-      styled-components: 5.2.1_react-dom@17.0.1+react@17.0.1
-      typescript: 4.2.4
+      styled-components: 5.2.3_react-dom@17.0.1+react@17.0.1
+      typescript: 4.2.3
       use-interval: 1.3.0_react@17.0.1
       zip-stream: 3.0.1
     devDependencies:
@@ -456,8 +456,8 @@ importers:
       '@types/lodash': 4.14.168
       '@types/readable-stream': 2.3.9
       '@types/zip-stream': link:../../libs/@types/zip-stream
-      '@typescript-eslint/eslint-plugin': 4.16.1_73e2bd13a8b35a69cfb92e9563939b3f
-      '@typescript-eslint/parser': 4.16.1_eslint@7.17.0+typescript@4.2.4
+      '@typescript-eslint/eslint-plugin': 4.16.1_a4e9925a57f7bf9df758cdf52b1a7795
+      '@typescript-eslint/parser': 4.16.1_eslint@7.17.0+typescript@4.2.3
       '@votingworks/test-utils': link:../../libs/test-utils
       eslint: 7.17.0
       eslint-config-airbnb: 17.1.1_17164872ad1121ab7d92471b0f0a3e4e
@@ -466,8 +466,8 @@ importers:
       eslint-import-resolver-node: 0.3.4
       eslint-plugin-cypress: 2.11.2_eslint@7.17.0
       eslint-plugin-flowtype: 5.2.0_eslint@7.17.0
-      eslint-plugin-import: 2.22.1_eslint@7.17.0+typescript@4.2.4
-      eslint-plugin-jest: 23.20.0_eslint@7.17.0+typescript@4.2.4
+      eslint-plugin-import: 2.22.1_eslint@7.17.0+typescript@4.2.3
+      eslint-plugin-jest: 23.20.0_eslint@7.17.0+typescript@4.2.3
       eslint-plugin-jsx-a11y: 6.4.1_eslint@7.17.0
       eslint-plugin-no-array-sort-mutation: link:../../libs/eslint-plugin-no-array-sort-mutation
       eslint-plugin-prettier: 3.3.1_18bc709ad1b4fcdd674db622dfd1f758
@@ -717,7 +717,7 @@ importers:
       '@testing-library/react': 11.2.3_react-dom@17.0.1+react@17.0.1
       '@testing-library/user-event': 12.6.0
       '@types/jest': 24.9.1
-      '@types/node': 12.20.11
+      '@types/node': 12.20.12
       '@types/react': 17.0.0
       '@types/react-dom': 17.0.0
       '@types/react-modal': 3.10.6
@@ -1272,7 +1272,7 @@ packages:
       integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
   /@babel/code-frame/7.12.13:
     dependencies:
-      '@babel/highlight': 7.14.0
+      '@babel/highlight': 7.13.10
     resolution:
       integrity: sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==
   /@babel/code-frame/7.8.3:
@@ -1311,20 +1311,20 @@ packages:
       integrity: sha512-eTAlQKq65zHfkHZV0sIVODCPGVgoo1HdBlbSLi9CqOzuZanMv2ihzY+4paiKr1mH+XmYESMAmJ/dpZ68eN6d8w==
   /@babel/core/7.12.3:
     dependencies:
-      '@babel/code-frame': 7.12.13
-      '@babel/generator': 7.13.16
-      '@babel/helper-module-transforms': 7.13.14
-      '@babel/helpers': 7.13.17
-      '@babel/parser': 7.13.16
-      '@babel/template': 7.12.13
-      '@babel/traverse': 7.13.17
-      '@babel/types': 7.13.17
+      '@babel/code-frame': 7.12.11
+      '@babel/generator': 7.12.11
+      '@babel/helper-module-transforms': 7.12.1
+      '@babel/helpers': 7.12.5
+      '@babel/parser': 7.12.11
+      '@babel/template': 7.12.7
+      '@babel/traverse': 7.12.12
+      '@babel/types': 7.12.12
       convert-source-map: 1.7.0
       debug: 4.3.1
       gensync: 1.0.0-beta.2
-      json5: 2.2.0
-      lodash: 4.17.21
-      resolve: 1.20.0
+      json5: 2.1.3
+      lodash: 4.17.20
+      resolve: 1.19.0
       semver: 5.7.1
       source-map: 0.5.7
     dev: false
@@ -1412,33 +1412,55 @@ packages:
       source-map: 0.5.7
     resolution:
       integrity: sha512-grBBR75UnKOcUWMp8WoDxNsWCFl//XCK6HWTrBQKTr5SV9f5g0pNOjdyzi/DTBv12S9GnYPInIXQBTky7OXEMg==
-  /@babel/generator/7.14.0:
-    dependencies:
-      '@babel/types': 7.14.0
-      jsesc: 2.5.2
-      source-map: 0.5.7
-    dev: false
-    resolution:
-      integrity: sha512-C6u00HbmsrNPug6A+CiNl8rEys7TsdcXwg12BHi2ca5rUfAs3+UwZsuDQSXnc+wCElCXMB8gMaJ3YXDdh8fAlg==
   /@babel/helper-annotate-as-pure/7.12.10:
     dependencies:
       '@babel/types': 7.12.12
     dev: false
     resolution:
       integrity: sha512-XplmVbC1n+KY6jL8/fgLVXXUauDIB+lD5+GsQEh6F6GBF1dq1qy4DP4yXWzDKcoqXB3X58t61e85Fitoww4JVQ==
-  /@babel/helper-annotate-as-pure/7.12.13:
-    dependencies:
-      '@babel/types': 7.14.0
-    dev: false
-    resolution:
-      integrity: sha512-7YXfX5wQ5aYM/BOlbSccHDbuXXFPxeoUmfWtz8le2yTkTZc+BxsiEnENFoi2SlmA8ewDkG2LgIMIVzzn2h8kfw==
   /@babel/helper-builder-binary-assignment-operator-visitor/7.10.4:
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.12.1
-      '@babel/types': 7.13.17
+      '@babel/types': 7.12.12
     dev: false
     resolution:
       integrity: sha512-L0zGlFrGWZK4PbT8AszSfLTM5sDU1+Az/En9VrdT8/LmEiJt4zXt+Jve9DCAnQcbqDhCI+29y/L93mrDzddCcg==
+  /@babel/helper-compilation-targets/7.12.5_@babel+core@7.12.10:
+    dependencies:
+      '@babel/compat-data': 7.12.7
+      '@babel/core': 7.12.10
+      '@babel/helper-validator-option': 7.12.11
+      browserslist: 4.16.1
+      semver: 5.7.1
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    resolution:
+      integrity: sha512-+qH6NrscMolUlzOYngSBMIOQpKUGPPsc61Bu5W10mg84LxZ7cmvnBHzARKbDoFxVvqqAbj6Tg6N7bSrWSPXMyw==
+  /@babel/helper-compilation-targets/7.12.5_@babel+core@7.12.3:
+    dependencies:
+      '@babel/compat-data': 7.12.7
+      '@babel/core': 7.12.3
+      '@babel/helper-validator-option': 7.12.11
+      browserslist: 4.16.1
+      semver: 5.7.1
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    resolution:
+      integrity: sha512-+qH6NrscMolUlzOYngSBMIOQpKUGPPsc61Bu5W10mg84LxZ7cmvnBHzARKbDoFxVvqqAbj6Tg6N7bSrWSPXMyw==
+  /@babel/helper-compilation-targets/7.12.5_@babel+core@7.8.4:
+    dependencies:
+      '@babel/compat-data': 7.12.7
+      '@babel/core': 7.8.4
+      '@babel/helper-validator-option': 7.12.11
+      browserslist: 4.16.1
+      semver: 5.7.1
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    resolution:
+      integrity: sha512-+qH6NrscMolUlzOYngSBMIOQpKUGPPsc61Bu5W10mg84LxZ7cmvnBHzARKbDoFxVvqqAbj6Tg6N7bSrWSPXMyw==
   /@babel/helper-compilation-targets/7.12.5_@babel+core@7.9.0:
     dependencies:
       '@babel/compat-data': 7.12.7
@@ -1451,18 +1473,6 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-+qH6NrscMolUlzOYngSBMIOQpKUGPPsc61Bu5W10mg84LxZ7cmvnBHzARKbDoFxVvqqAbj6Tg6N7bSrWSPXMyw==
-  /@babel/helper-compilation-targets/7.13.16_@babel+core@7.12.3:
-    dependencies:
-      '@babel/compat-data': 7.13.15
-      '@babel/core': 7.12.3
-      '@babel/helper-validator-option': 7.12.17
-      browserslist: 4.16.5
-      semver: 6.3.0
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    resolution:
-      integrity: sha512-3gmkYIrpqsLlieFwjkGgLaSHmhnvlAYzZLlYVjlW+QwI+1zE17kGxuJGmIqDQdYp56XdmGeD+Bswx0UTyG18xA==
   /@babel/helper-compilation-targets/7.13.16_@babel+core@7.13.16:
     dependencies:
       '@babel/compat-data': 7.13.15
@@ -1474,39 +1484,27 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-3gmkYIrpqsLlieFwjkGgLaSHmhnvlAYzZLlYVjlW+QwI+1zE17kGxuJGmIqDQdYp56XdmGeD+Bswx0UTyG18xA==
-  /@babel/helper-compilation-targets/7.13.16_@babel+core@7.8.4:
+  /@babel/helper-create-class-features-plugin/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/compat-data': 7.13.15
-      '@babel/core': 7.8.4
-      '@babel/helper-validator-option': 7.12.17
-      browserslist: 4.16.5
-      semver: 6.3.0
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    resolution:
-      integrity: sha512-3gmkYIrpqsLlieFwjkGgLaSHmhnvlAYzZLlYVjlW+QwI+1zE17kGxuJGmIqDQdYp56XdmGeD+Bswx0UTyG18xA==
-  /@babel/helper-create-class-features-plugin/7.12.1_@babel+core@7.12.3:
-    dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-function-name': 7.12.13
-      '@babel/helper-member-expression-to-functions': 7.13.12
-      '@babel/helper-optimise-call-expression': 7.12.13
-      '@babel/helper-replace-supers': 7.13.12
-      '@babel/helper-split-export-declaration': 7.12.13
+      '@babel/core': 7.12.10
+      '@babel/helper-function-name': 7.12.11
+      '@babel/helper-member-expression-to-functions': 7.12.7
+      '@babel/helper-optimise-call-expression': 7.12.10
+      '@babel/helper-replace-supers': 7.12.11
+      '@babel/helper-split-export-declaration': 7.12.11
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-hkL++rWeta/OVOBTRJc9a5Azh5mt5WgZUGAKMD8JM141YsE08K//bp1unBBieO6rUKkIPyUE0USQ30jAy3Sk1w==
-  /@babel/helper-create-class-features-plugin/7.12.1_@babel+core@7.13.16:
+  /@babel/helper-create-class-features-plugin/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-function-name': 7.12.13
-      '@babel/helper-member-expression-to-functions': 7.13.12
-      '@babel/helper-optimise-call-expression': 7.12.13
-      '@babel/helper-replace-supers': 7.13.12
-      '@babel/helper-split-export-declaration': 7.12.13
+      '@babel/core': 7.12.3
+      '@babel/helper-function-name': 7.12.11
+      '@babel/helper-member-expression-to-functions': 7.12.7
+      '@babel/helper-optimise-call-expression': 7.12.10
+      '@babel/helper-replace-supers': 7.12.11
+      '@babel/helper-split-export-declaration': 7.12.11
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -1515,11 +1513,11 @@ packages:
   /@babel/helper-create-class-features-plugin/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-function-name': 7.12.13
-      '@babel/helper-member-expression-to-functions': 7.13.12
-      '@babel/helper-optimise-call-expression': 7.12.13
-      '@babel/helper-replace-supers': 7.13.12
-      '@babel/helper-split-export-declaration': 7.12.13
+      '@babel/helper-function-name': 7.12.11
+      '@babel/helper-member-expression-to-functions': 7.12.7
+      '@babel/helper-optimise-call-expression': 7.12.10
+      '@babel/helper-replace-supers': 7.12.11
+      '@babel/helper-split-export-declaration': 7.12.11
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -1528,30 +1526,30 @@ packages:
   /@babel/helper-create-class-features-plugin/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-function-name': 7.12.13
-      '@babel/helper-member-expression-to-functions': 7.13.12
-      '@babel/helper-optimise-call-expression': 7.12.13
-      '@babel/helper-replace-supers': 7.13.12
-      '@babel/helper-split-export-declaration': 7.12.13
+      '@babel/helper-function-name': 7.12.11
+      '@babel/helper-member-expression-to-functions': 7.12.7
+      '@babel/helper-optimise-call-expression': 7.12.10
+      '@babel/helper-replace-supers': 7.12.11
+      '@babel/helper-split-export-declaration': 7.12.11
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-hkL++rWeta/OVOBTRJc9a5Azh5mt5WgZUGAKMD8JM141YsE08K//bp1unBBieO6rUKkIPyUE0USQ30jAy3Sk1w==
-  /@babel/helper-create-regexp-features-plugin/7.12.7_@babel+core@7.12.3:
+  /@babel/helper-create-regexp-features-plugin/7.12.7_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-annotate-as-pure': 7.12.13
+      '@babel/core': 7.12.10
+      '@babel/helper-annotate-as-pure': 7.12.10
       regexpu-core: 4.7.1
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-idnutvQPdpbduutvi3JVfEgcVIHooQnhvhx0Nk9isOINOIGYkZea1Pk2JlJRiUnMefrlvr0vkByATBY/mB4vjQ==
-  /@babel/helper-create-regexp-features-plugin/7.12.7_@babel+core@7.13.16:
+  /@babel/helper-create-regexp-features-plugin/7.12.7_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-annotate-as-pure': 7.12.13
+      '@babel/core': 7.12.3
+      '@babel/helper-annotate-as-pure': 7.12.10
       regexpu-core: 4.7.1
     dev: false
     peerDependencies:
@@ -1561,7 +1559,7 @@ packages:
   /@babel/helper-create-regexp-features-plugin/7.12.7_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-annotate-as-pure': 7.12.13
+      '@babel/helper-annotate-as-pure': 7.12.10
       regexpu-core: 4.7.1
     dev: false
     peerDependencies:
@@ -1571,7 +1569,7 @@ packages:
   /@babel/helper-create-regexp-features-plugin/7.12.7_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-annotate-as-pure': 7.12.13
+      '@babel/helper-annotate-as-pure': 7.12.10
       regexpu-core: 4.7.1
     dev: false
     peerDependencies:
@@ -1580,15 +1578,15 @@ packages:
       integrity: sha512-idnutvQPdpbduutvi3JVfEgcVIHooQnhvhx0Nk9isOINOIGYkZea1Pk2JlJRiUnMefrlvr0vkByATBY/mB4vjQ==
   /@babel/helper-define-map/7.10.5:
     dependencies:
-      '@babel/helper-function-name': 7.12.13
-      '@babel/types': 7.13.17
-      lodash: 4.17.21
+      '@babel/helper-function-name': 7.12.11
+      '@babel/types': 7.12.12
+      lodash: 4.17.20
     dev: false
     resolution:
       integrity: sha512-fMw4kgFB720aQFXSVaXr79pjjcW5puTCM16+rECJ/plGS+zByelE8l9nCpV1GibxTnFVmUuYG9U8wYfQHdzOEQ==
   /@babel/helper-explode-assignable-expression/7.12.1:
     dependencies:
-      '@babel/types': 7.13.17
+      '@babel/types': 7.12.12
     dev: false
     resolution:
       integrity: sha512-dmUwH8XmlrUpVqgtZ737tK88v07l840z9j3OEhCLwKTkjlvKpfqXVIZ0wpK3aeOxspwGrf/5AP5qLx4rO3w5rA==
@@ -1603,7 +1601,7 @@ packages:
     dependencies:
       '@babel/helper-get-function-arity': 7.12.13
       '@babel/template': 7.12.13
-      '@babel/types': 7.14.0
+      '@babel/types': 7.13.17
     resolution:
       integrity: sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==
   /@babel/helper-get-function-arity/7.12.10:
@@ -1613,12 +1611,12 @@ packages:
       integrity: sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==
   /@babel/helper-get-function-arity/7.12.13:
     dependencies:
-      '@babel/types': 7.14.0
+      '@babel/types': 7.13.17
     resolution:
       integrity: sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==
   /@babel/helper-hoist-variables/7.10.4:
     dependencies:
-      '@babel/types': 7.13.17
+      '@babel/types': 7.12.12
     dev: false
     resolution:
       integrity: sha512-wljroF5PgCk2juF69kanHVs6vrLwIPNp6DLD+Lrl3hoQ3PpPPikaDRNFA+0t81NOoMt2DL6WW/mdU8k4k6ZzuA==
@@ -1639,7 +1637,7 @@ packages:
       integrity: sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==
   /@babel/helper-module-imports/7.13.12:
     dependencies:
-      '@babel/types': 7.14.0
+      '@babel/types': 7.13.17
     resolution:
       integrity: sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==
   /@babel/helper-module-transforms/7.12.1:
@@ -1678,7 +1676,6 @@ packages:
     resolution:
       integrity: sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==
   /@babel/helper-plugin-utils/7.10.4:
-    dev: false
     resolution:
       integrity: sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==
   /@babel/helper-plugin-utils/7.13.0:
@@ -1686,9 +1683,9 @@ packages:
       integrity: sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==
   /@babel/helper-remap-async-to-generator/7.12.1:
     dependencies:
-      '@babel/helper-annotate-as-pure': 7.12.13
+      '@babel/helper-annotate-as-pure': 7.12.10
       '@babel/helper-wrap-function': 7.12.3
-      '@babel/types': 7.13.17
+      '@babel/types': 7.12.12
     dev: false
     resolution:
       integrity: sha512-9d0KQCRM8clMPcDwo8SevNs+/9a8yWVVmaE80FGJcEP8N1qToREmWEGnBn8BUlJhYRFz6fqxeRL1sl5Ogsed7A==
@@ -1720,7 +1717,7 @@ packages:
       integrity: sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==
   /@babel/helper-skip-transparent-expression-wrappers/7.12.1:
     dependencies:
-      '@babel/types': 7.13.17
+      '@babel/types': 7.12.12
     dev: false
     resolution:
       integrity: sha512-Mf5AUuhG1/OCChOJ/HcADmvcHM42WJockombn8ATJG3OnyiSxBK/Mm5x78BQWvmtXZKHgbjdGL2kin/HOLlZGA==
@@ -1731,15 +1728,12 @@ packages:
       integrity: sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==
   /@babel/helper-split-export-declaration/7.12.13:
     dependencies:
-      '@babel/types': 7.14.0
+      '@babel/types': 7.13.17
     resolution:
       integrity: sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==
   /@babel/helper-validator-identifier/7.12.11:
     resolution:
       integrity: sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
-  /@babel/helper-validator-identifier/7.14.0:
-    resolution:
-      integrity: sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==
   /@babel/helper-validator-option/7.12.11:
     dev: false
     resolution:
@@ -1749,10 +1743,10 @@ packages:
       integrity: sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==
   /@babel/helper-wrap-function/7.12.3:
     dependencies:
-      '@babel/helper-function-name': 7.12.13
-      '@babel/template': 7.12.13
-      '@babel/traverse': 7.13.17
-      '@babel/types': 7.13.17
+      '@babel/helper-function-name': 7.12.11
+      '@babel/template': 7.12.7
+      '@babel/traverse': 7.12.12
+      '@babel/types': 7.12.12
     dev: false
     resolution:
       integrity: sha512-Cvb8IuJDln3rs6tzjW3Y8UeelAOdnpB8xtQ4sme2MSZ9wOxrbThporC0y/EtE16VAtoyEfLM404Xr1e0OOp+ow==
@@ -1792,13 +1786,6 @@ packages:
       js-tokens: 4.0.0
     resolution:
       integrity: sha512-4vrIhfJyfNf+lCtXC2ck1rKSzDwciqF7IWFhXXrSOUC2O5DrVp+w4c6ed4AllTxhTkUP5x2tYj41VaxdVMMRDw==
-  /@babel/highlight/7.14.0:
-    dependencies:
-      '@babel/helper-validator-identifier': 7.14.0
-      chalk: 2.4.2
-      js-tokens: 4.0.0
-    resolution:
-      integrity: sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==
   /@babel/parser/7.12.11:
     engines:
       node: '>=6.0.0'
@@ -1806,7 +1793,6 @@ packages:
     resolution:
       integrity: sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==
   /@babel/parser/7.12.15:
-    dev: false
     engines:
       node: '>=6.0.0'
     hasBin: true
@@ -1818,29 +1804,23 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-6bAg36mCwuqLO0hbR+z7PHuqWiCeP7Dzg73OpQwsAB1Eb8HnGEz5xYBzCfbu+YjoaJsJs+qheDxVAuqbt3ILEw==
-  /@babel/parser/7.14.0:
-    engines:
-      node: '>=6.0.0'
-    hasBin: true
-    resolution:
-      integrity: sha512-AHbfoxesfBALg33idaTBVUkLnfXtsgvJREf93p4p0Lwsz4ppfE7g1tpEXVm4vrxUcH4DVhAa9Z1m1zqf9WUC7Q==
-  /@babel/plugin-proposal-async-generator-functions/7.12.12_@babel+core@7.12.3:
+  /@babel/plugin-proposal-async-generator-functions/7.12.12_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-remap-async-to-generator': 7.12.1
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.12.3
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.12.10
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-nrz9y0a4xmUrRq51bYkWJIO5SBZyG2ys2qinHsN0zHDHVsUaModrkpyWWWXfGqYQmOL3x9sQIcTNN/pBGpo09A==
-  /@babel/plugin-proposal-async-generator-functions/7.12.12_@babel+core@7.13.16:
+  /@babel/plugin-proposal-async-generator-functions/7.12.12_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-remap-async-to-generator': 7.12.1
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.13.16
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.12.3
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1849,7 +1829,7 @@ packages:
   /@babel/plugin-proposal-async-generator-functions/7.12.12_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-remap-async-to-generator': 7.12.1
       '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.8.4
     dev: false
@@ -1860,7 +1840,7 @@ packages:
   /@babel/plugin-proposal-async-generator-functions/7.12.12_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-remap-async-to-generator': 7.12.1
       '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.9.0
     dev: false
@@ -1868,21 +1848,21 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-nrz9y0a4xmUrRq51bYkWJIO5SBZyG2ys2qinHsN0zHDHVsUaModrkpyWWWXfGqYQmOL3x9sQIcTNN/pBGpo09A==
-  /@babel/plugin-proposal-class-properties/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-proposal-class-properties/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-create-class-features-plugin': 7.12.1_@babel+core@7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-create-class-features-plugin': 7.12.1_@babel+core@7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-cKp3dlQsFsEs5CWKnN7BnSHOd0EOW8EKpEjkoz1pO2E5KzIDNV9Ros1b0CnmbVgAGXJubOYVBOGCT1OmJwOI7w==
-  /@babel/plugin-proposal-class-properties/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-proposal-class-properties/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-create-class-features-plugin': 7.12.1_@babel+core@7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-create-class-features-plugin': 7.12.1_@babel+core@7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1892,7 +1872,7 @@ packages:
     dependencies:
       '@babel/core': 7.8.4
       '@babel/helper-create-class-features-plugin': 7.12.1_@babel+core@7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1912,7 +1892,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-create-class-features-plugin': 7.12.1_@babel+core@7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-syntax-decorators': 7.12.1_@babel+core@7.12.3
     dev: false
     peerDependencies:
@@ -1930,21 +1910,21 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-e3RvdvS4qPJVTe288DlXjwKflpfy1hr0j5dz5WpIYYeP7vQZg2WfAEIp8k5/Lwis/m5REXEteIz6rrcDtXXG7w==
-  /@babel/plugin-proposal-dynamic-import/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-proposal-dynamic-import/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.12.3
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.12.10
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-a4rhUSZFuq5W8/OO8H7BL5zspjnc1FLd9hlOxIK/f7qG4a0qsqk8uvF/ywgBA8/OmjsapjpvaEOYItfGG1qIvQ==
-  /@babel/plugin-proposal-dynamic-import/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-proposal-dynamic-import/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.13.16
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.12.3
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1953,7 +1933,7 @@ packages:
   /@babel/plugin-proposal-dynamic-import/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.8.4
     dev: false
     peerDependencies:
@@ -1963,28 +1943,28 @@ packages:
   /@babel/plugin-proposal-dynamic-import/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.9.0
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-a4rhUSZFuq5W8/OO8H7BL5zspjnc1FLd9hlOxIK/f7qG4a0qsqk8uvF/ywgBA8/OmjsapjpvaEOYItfGG1qIvQ==
-  /@babel/plugin-proposal-export-namespace-from/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-proposal-export-namespace-from/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.12.3
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.12.10
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-6CThGf0irEkzujYS5LQcjBx8j/4aQGiVv7J9+2f7pGfxqyKh3WnmVJYW3hdrQjyksErMGBPQrCnHfOtna+WLbw==
-  /@babel/plugin-proposal-export-namespace-from/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-proposal-export-namespace-from/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.13.16
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.12.3
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1993,28 +1973,28 @@ packages:
   /@babel/plugin-proposal-export-namespace-from/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.8.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-6CThGf0irEkzujYS5LQcjBx8j/4aQGiVv7J9+2f7pGfxqyKh3WnmVJYW3hdrQjyksErMGBPQrCnHfOtna+WLbw==
-  /@babel/plugin-proposal-json-strings/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-proposal-json-strings/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.12.3
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.12.10
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-GoLDUi6U9ZLzlSda2Df++VSqDJg3CG+dR0+iWsv6XRw1rEq+zwt4DirM9yrxW6XWaTpmai1cWJLMfM8qQJf+yw==
-  /@babel/plugin-proposal-json-strings/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-proposal-json-strings/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.13.16
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.12.3
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2023,7 +2003,7 @@ packages:
   /@babel/plugin-proposal-json-strings/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.8.4
     dev: false
     peerDependencies:
@@ -2033,28 +2013,28 @@ packages:
   /@babel/plugin-proposal-json-strings/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.9.0
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-GoLDUi6U9ZLzlSda2Df++VSqDJg3CG+dR0+iWsv6XRw1rEq+zwt4DirM9yrxW6XWaTpmai1cWJLMfM8qQJf+yw==
-  /@babel/plugin-proposal-logical-assignment-operators/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-proposal-logical-assignment-operators/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.12.3
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.12.10
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-k8ZmVv0JU+4gcUGeCDZOGd0lCIamU/sMtIiX3UWnUc5yzgq6YUGyEolNYD+MLYKfSzgECPcqetVcJP9Afe/aCA==
-  /@babel/plugin-proposal-logical-assignment-operators/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-proposal-logical-assignment-operators/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.13.16
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.12.3
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2063,28 +2043,28 @@ packages:
   /@babel/plugin-proposal-logical-assignment-operators/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.8.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-k8ZmVv0JU+4gcUGeCDZOGd0lCIamU/sMtIiX3UWnUc5yzgq6YUGyEolNYD+MLYKfSzgECPcqetVcJP9Afe/aCA==
-  /@babel/plugin-proposal-nullish-coalescing-operator/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-proposal-nullish-coalescing-operator/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.12.3
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.12.10
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-nZY0ESiaQDI1y96+jk6VxMOaL4LPo/QDHBqL+SF3/vl6dHkTwHlOI8L4ZwuRBHgakRBw5zsVylel7QPbbGuYgg==
-  /@babel/plugin-proposal-nullish-coalescing-operator/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-proposal-nullish-coalescing-operator/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.13.16
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.12.3
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2093,7 +2073,7 @@ packages:
   /@babel/plugin-proposal-nullish-coalescing-operator/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.8.4
     dev: false
     peerDependencies:
@@ -2113,28 +2093,28 @@ packages:
   /@babel/plugin-proposal-numeric-separator/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.12.3
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-MR7Ok+Af3OhNTCxYVjJZHS0t97ydnJZt/DbR4WISO39iDnhiD8XHrY12xuSJ90FFEGjir0Fzyyn7g/zY6hxbxA==
-  /@babel/plugin-proposal-numeric-separator/7.12.7_@babel+core@7.12.3:
+  /@babel/plugin-proposal-numeric-separator/7.12.7_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.12.3
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.12.10
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-8c+uy0qmnRTeukiGsjLGy6uVs/TFjJchGXUeBqlG4VWYOdJWkhhVPdQ3uHwbmalfJwv2JsV0qffXP4asRfL2SQ==
-  /@babel/plugin-proposal-numeric-separator/7.12.7_@babel+core@7.13.16:
+  /@babel/plugin-proposal-numeric-separator/7.12.7_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.13.16
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.12.3
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2143,7 +2123,7 @@ packages:
   /@babel/plugin-proposal-numeric-separator/7.12.7_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.8.4
     dev: false
     peerDependencies:
@@ -2160,23 +2140,23 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-jWioO1s6R/R+wEHizfaScNsAx+xKgwTLNXSh7tTC4Usj3ItsPEhYkEpU4h+lpnBwq7NBVOJXfO6cRFYcX69JUQ==
-  /@babel/plugin-proposal-object-rest-spread/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-proposal-object-rest-spread/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.12.3
-      '@babel/plugin-transform-parameters': 7.12.1_@babel+core@7.12.3
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.12.10
+      '@babel/plugin-transform-parameters': 7.12.1_@babel+core@7.12.10
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-s6SowJIjzlhx8o7lsFx5zmY4At6CTtDvgNQDdPzkBQucle58A6b/TTeEBYtyDgmcXjUTM+vE8YOGHZzzbc/ioA==
-  /@babel/plugin-proposal-object-rest-spread/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-proposal-object-rest-spread/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.13.16
-      '@babel/plugin-transform-parameters': 7.12.1_@babel+core@7.13.16
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.12.3
+      '@babel/plugin-transform-parameters': 7.12.1_@babel+core@7.12.3
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2185,7 +2165,7 @@ packages:
   /@babel/plugin-proposal-object-rest-spread/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.8.4
       '@babel/plugin-transform-parameters': 7.12.1_@babel+core@7.8.4
     dev: false
@@ -2196,7 +2176,7 @@ packages:
   /@babel/plugin-proposal-object-rest-spread/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.9.0
       '@babel/plugin-transform-parameters': 7.12.1_@babel+core@7.9.0
     dev: false
@@ -2204,21 +2184,21 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-s6SowJIjzlhx8o7lsFx5zmY4At6CTtDvgNQDdPzkBQucle58A6b/TTeEBYtyDgmcXjUTM+vE8YOGHZzzbc/ioA==
-  /@babel/plugin-proposal-optional-catch-binding/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-proposal-optional-catch-binding/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.12.3
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.12.10
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-hFvIjgprh9mMw5v42sJWLI1lzU5L2sznP805zeT6rySVRA0Y18StRhDqhSxlap0oVgItRsB6WSROp4YnJTJz0g==
-  /@babel/plugin-proposal-optional-catch-binding/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-proposal-optional-catch-binding/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.13.16
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.12.3
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2227,7 +2207,7 @@ packages:
   /@babel/plugin-proposal-optional-catch-binding/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.8.4
     dev: false
     peerDependencies:
@@ -2237,7 +2217,7 @@ packages:
   /@babel/plugin-proposal-optional-catch-binding/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.9.0
     dev: false
     peerDependencies:
@@ -2247,7 +2227,7 @@ packages:
   /@babel/plugin-proposal-optional-chaining/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-skip-transparent-expression-wrappers': 7.12.1
       '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.12.3
     dev: false
@@ -2255,23 +2235,23 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-c2uRpY6WzaVDzynVY9liyykS+kVU+WRZPMPYpkelXH8KBt1oXoI89kPbZKKG/jDT5UK92FTW2fZkZaJhdiBabw==
-  /@babel/plugin-proposal-optional-chaining/7.12.7_@babel+core@7.12.3:
+  /@babel/plugin-proposal-optional-chaining/7.12.7_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-skip-transparent-expression-wrappers': 7.12.1
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.12.3
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.12.10
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-4ovylXZ0PWmwoOvhU2vhnzVNnm88/Sm9nx7V8BPgMvAzn5zDou3/Awy0EjglyubVHasJj+XCEkr/r1X3P5elCA==
-  /@babel/plugin-proposal-optional-chaining/7.12.7_@babel+core@7.13.16:
+  /@babel/plugin-proposal-optional-chaining/7.12.7_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-skip-transparent-expression-wrappers': 7.12.1
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.13.16
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.12.3
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2280,7 +2260,7 @@ packages:
   /@babel/plugin-proposal-optional-chaining/7.12.7_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-skip-transparent-expression-wrappers': 7.12.1
       '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.8.4
     dev: false
@@ -2298,21 +2278,21 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-NDn5tu3tcv4W30jNhmc2hyD5c56G6cXx4TesJubhxrJeCvuuMpttxr0OnNCqbZGhFjLrg+NIhxxC+BK5F6yS3w==
-  /@babel/plugin-proposal-private-methods/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-proposal-private-methods/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-create-class-features-plugin': 7.12.1_@babel+core@7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-create-class-features-plugin': 7.12.1_@babel+core@7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-mwZ1phvH7/NHK6Kf8LP7MYDogGV+DKB1mryFOEwx5EBNQrosvIczzZFTUmWaeujd5xT6G1ELYWUz3CutMhjE1w==
-  /@babel/plugin-proposal-private-methods/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-proposal-private-methods/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-create-class-features-plugin': 7.12.1_@babel+core@7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-create-class-features-plugin': 7.12.1_@babel+core@7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2322,17 +2302,17 @@ packages:
     dependencies:
       '@babel/core': 7.8.4
       '@babel/helper-create-class-features-plugin': 7.12.1_@babel+core@7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-mwZ1phvH7/NHK6Kf8LP7MYDogGV+DKB1mryFOEwx5EBNQrosvIczzZFTUmWaeujd5xT6G1ELYWUz3CutMhjE1w==
-  /@babel/plugin-proposal-unicode-property-regex/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-proposal-unicode-property-regex/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-create-regexp-features-plugin': 7.12.7_@babel+core@7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-create-regexp-features-plugin': 7.12.7_@babel+core@7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     engines:
       node: '>=4'
@@ -2340,11 +2320,11 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-MYq+l+PvHuw/rKUz1at/vb6nCnQ2gmJBNaM62z0OgH7B2W1D9pvkpYtlti9bGtizNIU1K3zm4bZF9F91efVY0w==
-  /@babel/plugin-proposal-unicode-property-regex/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-proposal-unicode-property-regex/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-create-regexp-features-plugin': 7.12.7_@babel+core@7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-create-regexp-features-plugin': 7.12.7_@babel+core@7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     engines:
       node: '>=4'
@@ -2356,7 +2336,7 @@ packages:
     dependencies:
       '@babel/core': 7.8.4
       '@babel/helper-create-regexp-features-plugin': 7.12.7_@babel+core@7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     engines:
       node: '>=4'
@@ -2368,7 +2348,7 @@ packages:
     dependencies:
       '@babel/core': 7.9.0
       '@babel/helper-create-regexp-features-plugin': 7.12.7_@babel+core@7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     engines:
       node: '>=4'
@@ -2379,7 +2359,7 @@ packages:
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.12.10:
     dependencies:
       '@babel/core': 7.12.10
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
@@ -2387,16 +2367,7 @@ packages:
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
-  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.13.16:
-    dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2405,7 +2376,7 @@ packages:
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2414,7 +2385,7 @@ packages:
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2423,7 +2394,7 @@ packages:
   /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.12.10:
     dependencies:
       '@babel/core': 7.12.10
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
@@ -2431,7 +2402,7 @@ packages:
   /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2440,7 +2411,7 @@ packages:
   /@babel/plugin-syntax-class-properties/7.12.1_@babel+core@7.12.10:
     dependencies:
       '@babel/core': 7.12.10
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
@@ -2448,16 +2419,7 @@ packages:
   /@babel/plugin-syntax-class-properties/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-U40A76x5gTwmESz+qiqssqmeEsKvcSyvtgktrm0uzcARAmM9I1jR221f6Oq+GmHrcD+LvZDag1UTOTe2fL3TeA==
-  /@babel/plugin-syntax-class-properties/7.12.1_@babel+core@7.13.16:
-    dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2466,7 +2428,7 @@ packages:
   /@babel/plugin-syntax-class-properties/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2475,7 +2437,7 @@ packages:
   /@babel/plugin-syntax-decorators/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2484,25 +2446,25 @@ packages:
   /@babel/plugin-syntax-decorators/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-ir9YW5daRrTYiy9UJ2TzdNIJEZu8KclVzDcfSt4iEmOtwQ4llPtWInNKJyKnVXp1vE4bbVd5S31M/im3mYMO1w==
-  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.12.3:
+  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
-  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.13.16:
+  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2511,7 +2473,7 @@ packages:
   /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2520,25 +2482,25 @@ packages:
   /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
-  /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.12.3:
+  /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==
-  /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.13.16:
+  /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2547,7 +2509,7 @@ packages:
   /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2556,7 +2518,7 @@ packages:
   /@babel/plugin-syntax-flow/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2565,7 +2527,7 @@ packages:
   /@babel/plugin-syntax-flow/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2574,7 +2536,7 @@ packages:
   /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.12.10:
     dependencies:
       '@babel/core': 7.12.10
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
@@ -2582,7 +2544,7 @@ packages:
   /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2591,7 +2553,7 @@ packages:
   /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.12.10:
     dependencies:
       '@babel/core': 7.12.10
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
@@ -2599,16 +2561,7 @@ packages:
   /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
-  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.13.16:
-    dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2617,7 +2570,7 @@ packages:
   /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2626,25 +2579,25 @@ packages:
   /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
-  /@babel/plugin-syntax-jsx/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-syntax-jsx/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-1yRi7yAtB0ETgxdY9ti/p2TivUxJkTdhu/ZbF9MshVGqOx1TdB3b7xCXs49Fupgg50N45KcAsRP/ZqWjs9SRjg==
-  /@babel/plugin-syntax-jsx/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-syntax-jsx/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2653,7 +2606,7 @@ packages:
   /@babel/plugin-syntax-jsx/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2662,7 +2615,7 @@ packages:
   /@babel/plugin-syntax-jsx/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2671,7 +2624,7 @@ packages:
   /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.12.10:
     dependencies:
       '@babel/core': 7.12.10
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
@@ -2679,16 +2632,7 @@ packages:
   /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==
-  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.13.16:
-    dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2697,7 +2641,7 @@ packages:
   /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2706,7 +2650,7 @@ packages:
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.12.10:
     dependencies:
       '@babel/core': 7.12.10
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
@@ -2714,16 +2658,7 @@ packages:
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
-  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.13.16:
-    dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2732,7 +2667,7 @@ packages:
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2741,7 +2676,7 @@ packages:
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2750,7 +2685,7 @@ packages:
   /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.12.10:
     dependencies:
       '@babel/core': 7.12.10
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
@@ -2758,16 +2693,7 @@ packages:
   /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==
-  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.13.16:
-    dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2776,7 +2702,7 @@ packages:
   /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2785,7 +2711,7 @@ packages:
   /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2794,7 +2720,7 @@ packages:
   /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.12.10:
     dependencies:
       '@babel/core': 7.12.10
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
@@ -2802,16 +2728,7 @@ packages:
   /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
-  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.13.16:
-    dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2820,7 +2737,7 @@ packages:
   /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2829,7 +2746,7 @@ packages:
   /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2838,7 +2755,7 @@ packages:
   /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.12.10:
     dependencies:
       '@babel/core': 7.12.10
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
@@ -2846,16 +2763,7 @@ packages:
   /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
-  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.13.16:
-    dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2864,7 +2772,7 @@ packages:
   /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2873,7 +2781,7 @@ packages:
   /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2882,7 +2790,7 @@ packages:
   /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.12.10:
     dependencies:
       '@babel/core': 7.12.10
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
@@ -2890,16 +2798,7 @@ packages:
   /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
-  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.13.16:
-    dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2908,7 +2807,7 @@ packages:
   /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2917,7 +2816,7 @@ packages:
   /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2926,7 +2825,7 @@ packages:
   /@babel/plugin-syntax-top-level-await/7.12.1_@babel+core@7.12.10:
     dependencies:
       '@babel/core': 7.12.10
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
@@ -2934,16 +2833,7 @@ packages:
   /@babel/plugin-syntax-top-level-await/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-i7ooMZFS+a/Om0crxZodrTzNEPJHZrlMVGMTEpFAj6rYY/bKCddB0Dk/YxfPuYXOopuhKk/e1jV6h+WUU9XN3A==
-  /@babel/plugin-syntax-top-level-await/7.12.1_@babel+core@7.13.16:
-    dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2952,7 +2842,7 @@ packages:
   /@babel/plugin-syntax-top-level-await/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2961,7 +2851,7 @@ packages:
   /@babel/plugin-syntax-top-level-await/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2970,7 +2860,7 @@ packages:
   /@babel/plugin-syntax-typescript/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2979,25 +2869,25 @@ packages:
   /@babel/plugin-syntax-typescript/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-UZNEcCY+4Dp9yYRCAHrHDU+9ZXLYaY9MgBXSRLkB9WjYFRR6quJBumfVrEkUxrePPBwFcpWfNKXqVRQQtm7mMA==
-  /@babel/plugin-transform-arrow-functions/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-arrow-functions/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-5QB50qyN44fzzz4/qxDPQMBCTHgxg3n0xRBLJUmBlLoU/sFvxVWGZF/ZUfMVDQuJUKXaBhbupxIzIfZ6Fwk/0A==
-  /@babel/plugin-transform-arrow-functions/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-arrow-functions/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3006,7 +2896,7 @@ packages:
   /@babel/plugin-transform-arrow-functions/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3015,28 +2905,28 @@ packages:
   /@babel/plugin-transform-arrow-functions/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-5QB50qyN44fzzz4/qxDPQMBCTHgxg3n0xRBLJUmBlLoU/sFvxVWGZF/ZUfMVDQuJUKXaBhbupxIzIfZ6Fwk/0A==
-  /@babel/plugin-transform-async-to-generator/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-async-to-generator/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-module-imports': 7.13.12
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-module-imports': 7.12.5
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-remap-async-to-generator': 7.12.1
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-SDtqoEcarK1DFlRJ1hHRY5HvJUj5kX4qmtpMAm2QnhOlyuMC4TMdCRgW6WXpv93rZeYNeLP22y8Aq2dbcDRM1A==
-  /@babel/plugin-transform-async-to-generator/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-async-to-generator/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-module-imports': 7.13.12
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-module-imports': 7.12.5
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-remap-async-to-generator': 7.12.1
     dev: false
     peerDependencies:
@@ -3046,8 +2936,8 @@ packages:
   /@babel/plugin-transform-async-to-generator/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-module-imports': 7.13.12
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-module-imports': 7.12.5
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-remap-async-to-generator': 7.12.1
     dev: false
     peerDependencies:
@@ -3057,27 +2947,27 @@ packages:
   /@babel/plugin-transform-async-to-generator/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-module-imports': 7.13.12
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-module-imports': 7.12.5
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-remap-async-to-generator': 7.12.1
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-SDtqoEcarK1DFlRJ1hHRY5HvJUj5kX4qmtpMAm2QnhOlyuMC4TMdCRgW6WXpv93rZeYNeLP22y8Aq2dbcDRM1A==
-  /@babel/plugin-transform-block-scoped-functions/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-block-scoped-functions/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-5OpxfuYnSgPalRpo8EWGPzIYf0lHBWORCkj5M0oLBwHdlux9Ri36QqGW3/LR13RSVOAoUUMzoPI/jpE4ABcHoA==
-  /@babel/plugin-transform-block-scoped-functions/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-block-scoped-functions/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3086,7 +2976,7 @@ packages:
   /@babel/plugin-transform-block-scoped-functions/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3095,25 +2985,25 @@ packages:
   /@babel/plugin-transform-block-scoped-functions/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-5OpxfuYnSgPalRpo8EWGPzIYf0lHBWORCkj5M0oLBwHdlux9Ri36QqGW3/LR13RSVOAoUUMzoPI/jpE4ABcHoA==
-  /@babel/plugin-transform-block-scoping/7.12.12_@babel+core@7.12.3:
+  /@babel/plugin-transform-block-scoping/7.12.12_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-VOEPQ/ExOVqbukuP7BYJtI5ZxxsmegTwzZ04j1aF0dkSypGo9XpDHuOrABsJu+ie+penpSJheDJ11x1BEZNiyQ==
-  /@babel/plugin-transform-block-scoping/7.12.12_@babel+core@7.13.16:
+  /@babel/plugin-transform-block-scoping/7.12.12_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3122,7 +3012,7 @@ packages:
   /@babel/plugin-transform-block-scoping/7.12.12_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3131,38 +3021,38 @@ packages:
   /@babel/plugin-transform-block-scoping/7.12.12_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-VOEPQ/ExOVqbukuP7BYJtI5ZxxsmegTwzZ04j1aF0dkSypGo9XpDHuOrABsJu+ie+penpSJheDJ11x1BEZNiyQ==
-  /@babel/plugin-transform-classes/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-classes/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-annotate-as-pure': 7.12.13
+      '@babel/core': 7.12.10
+      '@babel/helper-annotate-as-pure': 7.12.10
       '@babel/helper-define-map': 7.10.5
-      '@babel/helper-function-name': 7.12.13
-      '@babel/helper-optimise-call-expression': 7.12.13
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-replace-supers': 7.13.12
-      '@babel/helper-split-export-declaration': 7.12.13
+      '@babel/helper-function-name': 7.12.11
+      '@babel/helper-optimise-call-expression': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-replace-supers': 7.12.11
+      '@babel/helper-split-export-declaration': 7.12.11
       globals: 11.12.0
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-/74xkA7bVdzQTBeSUhLLJgYIcxw/dpEpCdRDiHgPJ3Mv6uC11UhjpOhl72CgqbBCmt1qtssCyB2xnJm1+PFjog==
-  /@babel/plugin-transform-classes/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-classes/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-annotate-as-pure': 7.12.13
+      '@babel/core': 7.12.3
+      '@babel/helper-annotate-as-pure': 7.12.10
       '@babel/helper-define-map': 7.10.5
-      '@babel/helper-function-name': 7.12.13
-      '@babel/helper-optimise-call-expression': 7.12.13
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-replace-supers': 7.13.12
-      '@babel/helper-split-export-declaration': 7.12.13
+      '@babel/helper-function-name': 7.12.11
+      '@babel/helper-optimise-call-expression': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-replace-supers': 7.12.11
+      '@babel/helper-split-export-declaration': 7.12.11
       globals: 11.12.0
     dev: false
     peerDependencies:
@@ -3172,13 +3062,13 @@ packages:
   /@babel/plugin-transform-classes/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-annotate-as-pure': 7.12.13
+      '@babel/helper-annotate-as-pure': 7.12.10
       '@babel/helper-define-map': 7.10.5
-      '@babel/helper-function-name': 7.12.13
-      '@babel/helper-optimise-call-expression': 7.12.13
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-replace-supers': 7.13.12
-      '@babel/helper-split-export-declaration': 7.12.13
+      '@babel/helper-function-name': 7.12.11
+      '@babel/helper-optimise-call-expression': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-replace-supers': 7.12.11
+      '@babel/helper-split-export-declaration': 7.12.11
       globals: 11.12.0
     dev: false
     peerDependencies:
@@ -3188,32 +3078,32 @@ packages:
   /@babel/plugin-transform-classes/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-annotate-as-pure': 7.12.13
+      '@babel/helper-annotate-as-pure': 7.12.10
       '@babel/helper-define-map': 7.10.5
-      '@babel/helper-function-name': 7.12.13
-      '@babel/helper-optimise-call-expression': 7.12.13
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-replace-supers': 7.13.12
-      '@babel/helper-split-export-declaration': 7.12.13
+      '@babel/helper-function-name': 7.12.11
+      '@babel/helper-optimise-call-expression': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-replace-supers': 7.12.11
+      '@babel/helper-split-export-declaration': 7.12.11
       globals: 11.12.0
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-/74xkA7bVdzQTBeSUhLLJgYIcxw/dpEpCdRDiHgPJ3Mv6uC11UhjpOhl72CgqbBCmt1qtssCyB2xnJm1+PFjog==
-  /@babel/plugin-transform-computed-properties/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-computed-properties/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-vVUOYpPWB7BkgUWPo4C44mUQHpTZXakEqFjbv8rQMg7TC6S6ZhGZ3otQcRH6u7+adSlE5i0sp63eMC/XGffrzg==
-  /@babel/plugin-transform-computed-properties/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-computed-properties/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3222,7 +3112,7 @@ packages:
   /@babel/plugin-transform-computed-properties/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3231,25 +3121,25 @@ packages:
   /@babel/plugin-transform-computed-properties/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-vVUOYpPWB7BkgUWPo4C44mUQHpTZXakEqFjbv8rQMg7TC6S6ZhGZ3otQcRH6u7+adSlE5i0sp63eMC/XGffrzg==
-  /@babel/plugin-transform-destructuring/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-destructuring/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-fRMYFKuzi/rSiYb2uRLiUENJOKq4Gnl+6qOv5f8z0TZXg3llUwUhsNNwrwaT/6dUhJTzNpBr+CUvEWBtfNY1cw==
-  /@babel/plugin-transform-destructuring/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-destructuring/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3258,7 +3148,7 @@ packages:
   /@babel/plugin-transform-destructuring/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3267,27 +3157,27 @@ packages:
   /@babel/plugin-transform-destructuring/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-fRMYFKuzi/rSiYb2uRLiUENJOKq4Gnl+6qOv5f8z0TZXg3llUwUhsNNwrwaT/6dUhJTzNpBr+CUvEWBtfNY1cw==
-  /@babel/plugin-transform-dotall-regex/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-dotall-regex/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-create-regexp-features-plugin': 7.12.7_@babel+core@7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-create-regexp-features-plugin': 7.12.7_@babel+core@7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-B2pXeRKoLszfEW7J4Hg9LoFaWEbr/kzo3teWHmtFCszjRNa/b40f9mfeqZsIDLLt/FjwQ6pz/Gdlwy85xNckBA==
-  /@babel/plugin-transform-dotall-regex/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-dotall-regex/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-create-regexp-features-plugin': 7.12.7_@babel+core@7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-create-regexp-features-plugin': 7.12.7_@babel+core@7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3297,7 +3187,7 @@ packages:
     dependencies:
       '@babel/core': 7.8.4
       '@babel/helper-create-regexp-features-plugin': 7.12.7_@babel+core@7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3307,25 +3197,25 @@ packages:
     dependencies:
       '@babel/core': 7.9.0
       '@babel/helper-create-regexp-features-plugin': 7.12.7_@babel+core@7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-B2pXeRKoLszfEW7J4Hg9LoFaWEbr/kzo3teWHmtFCszjRNa/b40f9mfeqZsIDLLt/FjwQ6pz/Gdlwy85xNckBA==
-  /@babel/plugin-transform-duplicate-keys/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-duplicate-keys/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-iRght0T0HztAb/CazveUpUQrZY+aGKKaWXMJ4uf9YJtqxSUe09j3wteztCUDRHs+SRAL7yMuFqUsLoAKKzgXjw==
-  /@babel/plugin-transform-duplicate-keys/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-duplicate-keys/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3334,7 +3224,7 @@ packages:
   /@babel/plugin-transform-duplicate-keys/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3343,27 +3233,27 @@ packages:
   /@babel/plugin-transform-duplicate-keys/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-iRght0T0HztAb/CazveUpUQrZY+aGKKaWXMJ4uf9YJtqxSUe09j3wteztCUDRHs+SRAL7yMuFqUsLoAKKzgXjw==
-  /@babel/plugin-transform-exponentiation-operator/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-exponentiation-operator/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
+      '@babel/core': 7.12.10
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.10.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-7tqwy2bv48q+c1EHbXK0Zx3KXd2RVQp6OC7PbwFNt/dPTAV3Lu5sWtWuAj8owr5wqtWnqHfl2/mJlUmqkChKug==
-  /@babel/plugin-transform-exponentiation-operator/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-exponentiation-operator/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
+      '@babel/core': 7.12.3
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.10.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3373,7 +3263,7 @@ packages:
     dependencies:
       '@babel/core': 7.8.4
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.10.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3383,7 +3273,7 @@ packages:
     dependencies:
       '@babel/core': 7.9.0
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.10.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3392,7 +3282,7 @@ packages:
   /@babel/plugin-transform-flow-strip-types/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-syntax-flow': 7.12.1_@babel+core@7.12.3
     dev: false
     peerDependencies:
@@ -3409,19 +3299,19 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-7Qfg0lKQhEHs93FChxVLAvhBshOPQDtJUTVHr/ZwQNRccCm4O9D79r9tVSoV8iNwjP1YgfD+e/fgHcPkN1qEQg==
-  /@babel/plugin-transform-for-of/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-for-of/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Zaeq10naAsuHo7heQvyV0ptj4dlZJwZgNAtBYBnu5nNKJoW62m0zKcIEyVECrUKErkUkg6ajMy4ZfnVZciSBhg==
-  /@babel/plugin-transform-for-of/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-for-of/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3430,7 +3320,7 @@ packages:
   /@babel/plugin-transform-for-of/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3439,27 +3329,27 @@ packages:
   /@babel/plugin-transform-for-of/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Zaeq10naAsuHo7heQvyV0ptj4dlZJwZgNAtBYBnu5nNKJoW62m0zKcIEyVECrUKErkUkg6ajMy4ZfnVZciSBhg==
-  /@babel/plugin-transform-function-name/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-function-name/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-function-name': 7.12.13
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-function-name': 7.12.11
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-JF3UgJUILoFrFMEnOJLJkRHSk6LUSXLmEFsA23aR2O5CSLUxbeUX1IZ1YQ7Sn0aXb601Ncwjx73a+FVqgcljVw==
-  /@babel/plugin-transform-function-name/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-function-name/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-function-name': 7.12.13
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-function-name': 7.12.11
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3468,8 +3358,8 @@ packages:
   /@babel/plugin-transform-function-name/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-function-name': 7.12.13
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-function-name': 7.12.11
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3478,26 +3368,26 @@ packages:
   /@babel/plugin-transform-function-name/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-function-name': 7.12.13
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-function-name': 7.12.11
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-JF3UgJUILoFrFMEnOJLJkRHSk6LUSXLmEFsA23aR2O5CSLUxbeUX1IZ1YQ7Sn0aXb601Ncwjx73a+FVqgcljVw==
-  /@babel/plugin-transform-literals/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-literals/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-+PxVGA+2Ag6uGgL0A5f+9rklOnnMccwEBzwYFL3EUaKuiyVnUipyXncFcfjSkbimLrODoqki1U9XxZzTvfN7IQ==
-  /@babel/plugin-transform-literals/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-literals/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3506,7 +3396,7 @@ packages:
   /@babel/plugin-transform-literals/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3515,25 +3405,25 @@ packages:
   /@babel/plugin-transform-literals/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-+PxVGA+2Ag6uGgL0A5f+9rklOnnMccwEBzwYFL3EUaKuiyVnUipyXncFcfjSkbimLrODoqki1U9XxZzTvfN7IQ==
-  /@babel/plugin-transform-member-expression-literals/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-member-expression-literals/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-1sxePl6z9ad0gFMB9KqmYofk34flq62aqMt9NqliS/7hPEpURUCMbyHXrMPlo282iY7nAvUB1aQd5mg79UD9Jg==
-  /@babel/plugin-transform-member-expression-literals/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-member-expression-literals/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3542,7 +3432,7 @@ packages:
   /@babel/plugin-transform-member-expression-literals/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3551,28 +3441,28 @@ packages:
   /@babel/plugin-transform-member-expression-literals/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-1sxePl6z9ad0gFMB9KqmYofk34flq62aqMt9NqliS/7hPEpURUCMbyHXrMPlo282iY7nAvUB1aQd5mg79UD9Jg==
-  /@babel/plugin-transform-modules-amd/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-modules-amd/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-module-transforms': 7.13.14
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-module-transforms': 7.12.1
+      '@babel/helper-plugin-utils': 7.10.4
       babel-plugin-dynamic-import-node: 2.3.3
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-tDW8hMkzad5oDtzsB70HIQQRBiTKrhfgwC/KkJeGsaNFTdWhKNt/BiE8c5yj19XiGyrxpbkOfH87qkNg1YGlOQ==
-  /@babel/plugin-transform-modules-amd/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-modules-amd/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-module-transforms': 7.13.14
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-module-transforms': 7.12.1
+      '@babel/helper-plugin-utils': 7.10.4
       babel-plugin-dynamic-import-node: 2.3.3
     dev: false
     peerDependencies:
@@ -3582,8 +3472,8 @@ packages:
   /@babel/plugin-transform-modules-amd/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-module-transforms': 7.13.14
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-module-transforms': 7.12.1
+      '@babel/helper-plugin-utils': 7.10.4
       babel-plugin-dynamic-import-node: 2.3.3
     dev: false
     peerDependencies:
@@ -3593,32 +3483,32 @@ packages:
   /@babel/plugin-transform-modules-amd/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-module-transforms': 7.13.14
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-module-transforms': 7.12.1
+      '@babel/helper-plugin-utils': 7.10.4
       babel-plugin-dynamic-import-node: 2.3.3
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-tDW8hMkzad5oDtzsB70HIQQRBiTKrhfgwC/KkJeGsaNFTdWhKNt/BiE8c5yj19XiGyrxpbkOfH87qkNg1YGlOQ==
-  /@babel/plugin-transform-modules-commonjs/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-modules-commonjs/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-module-transforms': 7.13.14
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-simple-access': 7.13.12
+      '@babel/core': 7.12.10
+      '@babel/helper-module-transforms': 7.12.1
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-simple-access': 7.12.1
       babel-plugin-dynamic-import-node: 2.3.3
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-dY789wq6l0uLY8py9c1B48V8mVL5gZh/+PQ5ZPrylPYsnAvnEMjqsUXkuoDVPeVK+0VyGar+D08107LzDQ6pag==
-  /@babel/plugin-transform-modules-commonjs/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-modules-commonjs/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-module-transforms': 7.13.14
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-simple-access': 7.13.12
+      '@babel/core': 7.12.3
+      '@babel/helper-module-transforms': 7.12.1
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-simple-access': 7.12.1
       babel-plugin-dynamic-import-node: 2.3.3
     dev: false
     peerDependencies:
@@ -3628,9 +3518,9 @@ packages:
   /@babel/plugin-transform-modules-commonjs/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-module-transforms': 7.13.14
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-simple-access': 7.13.12
+      '@babel/helper-module-transforms': 7.12.1
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-simple-access': 7.12.1
       babel-plugin-dynamic-import-node: 2.3.3
     dev: false
     peerDependencies:
@@ -3640,21 +3530,21 @@ packages:
   /@babel/plugin-transform-modules-commonjs/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-module-transforms': 7.13.14
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-simple-access': 7.13.12
+      '@babel/helper-module-transforms': 7.12.1
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-simple-access': 7.12.1
       babel-plugin-dynamic-import-node: 2.3.3
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-dY789wq6l0uLY8py9c1B48V8mVL5gZh/+PQ5ZPrylPYsnAvnEMjqsUXkuoDVPeVK+0VyGar+D08107LzDQ6pag==
-  /@babel/plugin-transform-modules-systemjs/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-modules-systemjs/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
+      '@babel/core': 7.12.10
       '@babel/helper-hoist-variables': 7.10.4
-      '@babel/helper-module-transforms': 7.13.14
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-module-transforms': 7.12.1
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-validator-identifier': 7.12.11
       babel-plugin-dynamic-import-node: 2.3.3
     dev: false
@@ -3662,12 +3552,12 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Hn7cVvOavVh8yvW6fLwveFqSnd7rbQN3zJvoPNyNaQSvgfKmDBO9U1YL9+PCXGRlZD9tNdWTy5ACKqMuzyn32Q==
-  /@babel/plugin-transform-modules-systemjs/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-modules-systemjs/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
+      '@babel/core': 7.12.3
       '@babel/helper-hoist-variables': 7.10.4
-      '@babel/helper-module-transforms': 7.13.14
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-module-transforms': 7.12.1
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-validator-identifier': 7.12.11
       babel-plugin-dynamic-import-node: 2.3.3
     dev: false
@@ -3679,8 +3569,8 @@ packages:
     dependencies:
       '@babel/core': 7.8.4
       '@babel/helper-hoist-variables': 7.10.4
-      '@babel/helper-module-transforms': 7.13.14
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-module-transforms': 7.12.1
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-validator-identifier': 7.12.11
       babel-plugin-dynamic-import-node: 2.3.3
     dev: false
@@ -3692,8 +3582,8 @@ packages:
     dependencies:
       '@babel/core': 7.9.0
       '@babel/helper-hoist-variables': 7.10.4
-      '@babel/helper-module-transforms': 7.13.14
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-module-transforms': 7.12.1
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-validator-identifier': 7.12.11
       babel-plugin-dynamic-import-node: 2.3.3
     dev: false
@@ -3701,21 +3591,21 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Hn7cVvOavVh8yvW6fLwveFqSnd7rbQN3zJvoPNyNaQSvgfKmDBO9U1YL9+PCXGRlZD9tNdWTy5ACKqMuzyn32Q==
-  /@babel/plugin-transform-modules-umd/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-modules-umd/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-module-transforms': 7.13.14
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-module-transforms': 7.12.1
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-aEIubCS0KHKM0zUos5fIoQm+AZUMt1ZvMpqz0/H5qAQ7vWylr9+PLYurT+Ic7ID/bKLd4q8hDovaG3Zch2uz5Q==
-  /@babel/plugin-transform-modules-umd/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-modules-umd/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-module-transforms': 7.13.14
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-module-transforms': 7.12.1
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3724,8 +3614,8 @@ packages:
   /@babel/plugin-transform-modules-umd/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-module-transforms': 7.13.14
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-module-transforms': 7.12.1
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3734,26 +3624,26 @@ packages:
   /@babel/plugin-transform-modules-umd/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-module-transforms': 7.13.14
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-module-transforms': 7.12.1
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-aEIubCS0KHKM0zUos5fIoQm+AZUMt1ZvMpqz0/H5qAQ7vWylr9+PLYurT+Ic7ID/bKLd4q8hDovaG3Zch2uz5Q==
-  /@babel/plugin-transform-named-capturing-groups-regex/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-named-capturing-groups-regex/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-create-regexp-features-plugin': 7.12.7_@babel+core@7.12.3
+      '@babel/core': 7.12.10
+      '@babel/helper-create-regexp-features-plugin': 7.12.7_@babel+core@7.12.10
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-tB43uQ62RHcoDp9v2Nsf+dSM8sbNodbEicbQNA53zHz8pWUhsgHSJCGpt7daXxRydjb0KnfmB+ChXOv3oADp1Q==
-  /@babel/plugin-transform-named-capturing-groups-regex/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-named-capturing-groups-regex/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-create-regexp-features-plugin': 7.12.7_@babel+core@7.13.16
+      '@babel/core': 7.12.3
+      '@babel/helper-create-regexp-features-plugin': 7.12.7_@babel+core@7.12.3
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -3777,19 +3667,19 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-tB43uQ62RHcoDp9v2Nsf+dSM8sbNodbEicbQNA53zHz8pWUhsgHSJCGpt7daXxRydjb0KnfmB+ChXOv3oADp1Q==
-  /@babel/plugin-transform-new-target/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-new-target/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-+eW/VLcUL5L9IvJH7rT1sT0CzkdUTvPrXC2PXTn/7z7tXLBuKvezYbGdxD5WMRoyvyaujOq2fWoKl869heKjhw==
-  /@babel/plugin-transform-new-target/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-new-target/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3798,7 +3688,7 @@ packages:
   /@babel/plugin-transform-new-target/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3807,27 +3697,27 @@ packages:
   /@babel/plugin-transform-new-target/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-+eW/VLcUL5L9IvJH7rT1sT0CzkdUTvPrXC2PXTn/7z7tXLBuKvezYbGdxD5WMRoyvyaujOq2fWoKl869heKjhw==
-  /@babel/plugin-transform-object-super/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-object-super/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-replace-supers': 7.13.12
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-replace-supers': 7.12.11
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-AvypiGJH9hsquNUn+RXVcBdeE3KHPZexWRdimhuV59cSoOt5kFBmqlByorAeUlGG2CJWd0U+4ZtNKga/TB0cAw==
-  /@babel/plugin-transform-object-super/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-object-super/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-replace-supers': 7.13.12
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-replace-supers': 7.12.11
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3836,8 +3726,8 @@ packages:
   /@babel/plugin-transform-object-super/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-replace-supers': 7.13.12
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-replace-supers': 7.12.11
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3846,26 +3736,26 @@ packages:
   /@babel/plugin-transform-object-super/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-replace-supers': 7.13.12
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-replace-supers': 7.12.11
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-AvypiGJH9hsquNUn+RXVcBdeE3KHPZexWRdimhuV59cSoOt5kFBmqlByorAeUlGG2CJWd0U+4ZtNKga/TB0cAw==
-  /@babel/plugin-transform-parameters/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-parameters/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-xq9C5EQhdPK23ZeCdMxl8bbRnAgHFrw5EOC3KJUsSylZqdkCaFEXxGSBuTSObOpiiHHNyb82es8M1QYgfQGfNg==
-  /@babel/plugin-transform-parameters/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-parameters/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3874,7 +3764,7 @@ packages:
   /@babel/plugin-transform-parameters/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3883,25 +3773,25 @@ packages:
   /@babel/plugin-transform-parameters/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-xq9C5EQhdPK23ZeCdMxl8bbRnAgHFrw5EOC3KJUsSylZqdkCaFEXxGSBuTSObOpiiHHNyb82es8M1QYgfQGfNg==
-  /@babel/plugin-transform-property-literals/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-property-literals/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-6MTCR/mZ1MQS+AwZLplX4cEySjCpnIF26ToWo942nqn8hXSm7McaHQNeGx/pt7suI1TWOWMfa/NgBhiqSnX0cQ==
-  /@babel/plugin-transform-property-literals/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-property-literals/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3910,7 +3800,7 @@ packages:
   /@babel/plugin-transform-property-literals/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3919,16 +3809,16 @@ packages:
   /@babel/plugin-transform-property-literals/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-6MTCR/mZ1MQS+AwZLplX4cEySjCpnIF26ToWo942nqn8hXSm7McaHQNeGx/pt7suI1TWOWMfa/NgBhiqSnX0cQ==
-  /@babel/plugin-transform-react-constant-elements/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-react-constant-elements/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3937,25 +3827,25 @@ packages:
   /@babel/plugin-transform-react-constant-elements/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-KOHd0tIRLoER+J+8f9DblZDa1fLGPwaaN1DI1TVHuQFOpjHV22C3CUB3obeC4fexHY9nx+fH0hQNvLFFfA1mxA==
-  /@babel/plugin-transform-react-display-name/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-react-display-name/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-cAzB+UzBIrekfYxyLlFqf/OagTvHLcVBb5vpouzkYkBclRPraiygVnafvAoipErZLI8ANv8Ecn6E/m5qPXD26w==
-  /@babel/plugin-transform-react-display-name/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-react-display-name/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3964,7 +3854,7 @@ packages:
   /@babel/plugin-transform-react-display-name/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3979,19 +3869,19 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-3Jy/PCw8Fe6uBKtEgz3M82ljt+lTg+xJaM4og+eyu83qLT87ZUSckn0wy7r31jflURWLO83TW6Ylf7lyXj3m5A==
-  /@babel/plugin-transform-react-jsx-development/7.12.12_@babel+core@7.12.3:
+  /@babel/plugin-transform-react-jsx-development/7.12.12_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/plugin-transform-react-jsx': 7.12.12_@babel+core@7.12.3
+      '@babel/core': 7.12.10
+      '@babel/plugin-transform-react-jsx': 7.12.12_@babel+core@7.12.10
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-i1AxnKxHeMxUaWVXQOSIco4tvVvvCxMSfeBMnMM06mpaJt3g+MpxYQQrDfojUQldP1xxraPSJYSMEljoWM/dCg==
-  /@babel/plugin-transform-react-jsx-development/7.12.12_@babel+core@7.13.16:
+  /@babel/plugin-transform-react-jsx-development/7.12.12_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/plugin-transform-react-jsx': 7.12.12_@babel+core@7.13.16
+      '@babel/core': 7.12.3
+      '@babel/plugin-transform-react-jsx': 7.12.12_@babel+core@7.12.3
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4018,7 +3908,7 @@ packages:
   /@babel/plugin-transform-react-jsx-self/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4027,7 +3917,7 @@ packages:
   /@babel/plugin-transform-react-jsx-self/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4036,7 +3926,7 @@ packages:
   /@babel/plugin-transform-react-jsx-source/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4045,33 +3935,33 @@ packages:
   /@babel/plugin-transform-react-jsx-source/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-keQ5kBfjJNRc6zZN1/nVHCd6LLIHq4aUKcVnvE/2l+ZZROSbqoiGFRtT5t3Is89XJxBQaP7NLZX2jgGHdZvvFQ==
-  /@babel/plugin-transform-react-jsx/7.12.12_@babel+core@7.12.3:
+  /@babel/plugin-transform-react-jsx/7.12.12_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-annotate-as-pure': 7.12.13
-      '@babel/helper-module-imports': 7.13.12
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-jsx': 7.12.1_@babel+core@7.12.3
-      '@babel/types': 7.13.17
+      '@babel/core': 7.12.10
+      '@babel/helper-annotate-as-pure': 7.12.10
+      '@babel/helper-module-imports': 7.12.5
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-jsx': 7.12.1_@babel+core@7.12.10
+      '@babel/types': 7.12.12
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-JDWGuzGNWscYcq8oJVCtSE61a5+XAOos+V0HrxnDieUus4UMnBEosDnY1VJqU5iZ4pA04QY7l0+JvHL1hZEfsw==
-  /@babel/plugin-transform-react-jsx/7.12.12_@babel+core@7.13.16:
+  /@babel/plugin-transform-react-jsx/7.12.12_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-annotate-as-pure': 7.12.13
-      '@babel/helper-module-imports': 7.13.12
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-jsx': 7.12.1_@babel+core@7.13.16
-      '@babel/types': 7.13.17
+      '@babel/core': 7.12.3
+      '@babel/helper-annotate-as-pure': 7.12.10
+      '@babel/helper-module-imports': 7.12.5
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-jsx': 7.12.1_@babel+core@7.12.3
+      '@babel/types': 7.12.12
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4080,11 +3970,11 @@ packages:
   /@babel/plugin-transform-react-jsx/7.12.12_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-annotate-as-pure': 7.12.13
-      '@babel/helper-module-imports': 7.13.12
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-annotate-as-pure': 7.12.10
+      '@babel/helper-module-imports': 7.12.5
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-syntax-jsx': 7.12.1_@babel+core@7.8.4
-      '@babel/types': 7.13.17
+      '@babel/types': 7.12.12
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4093,31 +3983,31 @@ packages:
   /@babel/plugin-transform-react-jsx/7.12.12_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-annotate-as-pure': 7.12.13
-      '@babel/helper-module-imports': 7.13.12
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-annotate-as-pure': 7.12.10
+      '@babel/helper-module-imports': 7.12.5
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-syntax-jsx': 7.12.1_@babel+core@7.9.0
-      '@babel/types': 7.13.17
+      '@babel/types': 7.12.12
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-JDWGuzGNWscYcq8oJVCtSE61a5+XAOos+V0HrxnDieUus4UMnBEosDnY1VJqU5iZ4pA04QY7l0+JvHL1hZEfsw==
-  /@babel/plugin-transform-react-pure-annotations/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-react-pure-annotations/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-annotate-as-pure': 7.12.13
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-annotate-as-pure': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-RqeaHiwZtphSIUZ5I85PEH19LOSzxfuEazoY7/pWASCAIBuATQzpSVD+eT6MebeeZT2F4eSL0u4vw6n4Nm0Mjg==
-  /@babel/plugin-transform-react-pure-annotations/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-react-pure-annotations/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-annotate-as-pure': 7.12.13
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-annotate-as-pure': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4126,25 +4016,25 @@ packages:
   /@babel/plugin-transform-react-pure-annotations/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-annotate-as-pure': 7.12.13
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-annotate-as-pure': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-RqeaHiwZtphSIUZ5I85PEH19LOSzxfuEazoY7/pWASCAIBuATQzpSVD+eT6MebeeZT2F4eSL0u4vw6n4Nm0Mjg==
-  /@babel/plugin-transform-regenerator/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-regenerator/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
+      '@babel/core': 7.12.10
       regenerator-transform: 0.14.5
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-gYrHqs5itw6i4PflFX3OdBPMQdPbF4bj2REIUxlMRUFk0/ZOAIpDFuViuxPjUL7YC8UPnf+XG7/utJvqXdPKng==
-  /@babel/plugin-transform-regenerator/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-regenerator/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
+      '@babel/core': 7.12.3
       regenerator-transform: 0.14.5
     dev: false
     peerDependencies:
@@ -4169,19 +4059,19 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-gYrHqs5itw6i4PflFX3OdBPMQdPbF4bj2REIUxlMRUFk0/ZOAIpDFuViuxPjUL7YC8UPnf+XG7/utJvqXdPKng==
-  /@babel/plugin-transform-reserved-words/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-reserved-words/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-pOnUfhyPKvZpVyBHhSBoX8vfA09b7r00Pmm1sH+29ae2hMTKVmSp4Ztsr8KBKjLjx17H0eJqaRC3bR2iThM54A==
-  /@babel/plugin-transform-reserved-words/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-reserved-words/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4190,7 +4080,7 @@ packages:
   /@babel/plugin-transform-reserved-words/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4199,7 +4089,7 @@ packages:
   /@babel/plugin-transform-reserved-words/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4208,9 +4098,9 @@ packages:
   /@babel/plugin-transform-runtime/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-module-imports': 7.13.12
-      '@babel/helper-plugin-utils': 7.13.0
-      resolve: 1.20.0
+      '@babel/helper-module-imports': 7.12.5
+      '@babel/helper-plugin-utils': 7.10.4
+      resolve: 1.19.0
       semver: 5.7.1
     dev: false
     peerDependencies:
@@ -4229,19 +4119,19 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-pUu9VSf3kI1OqbWINQ7MaugnitRss1z533436waNXp+0N3ur3zfut37sXiQMxkuCF4VUjwZucen/quskCh7NHw==
-  /@babel/plugin-transform-shorthand-properties/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-shorthand-properties/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-GFZS3c/MhX1OusqB1MZ1ct2xRzX5ppQh2JU1h2Pnfk88HtFTM+TWQqJNfwkmxtPQtb/s1tk87oENfXJlx7rSDw==
-  /@babel/plugin-transform-shorthand-properties/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-shorthand-properties/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4250,7 +4140,7 @@ packages:
   /@babel/plugin-transform-shorthand-properties/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4259,26 +4149,26 @@ packages:
   /@babel/plugin-transform-shorthand-properties/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-GFZS3c/MhX1OusqB1MZ1ct2xRzX5ppQh2JU1h2Pnfk88HtFTM+TWQqJNfwkmxtPQtb/s1tk87oENfXJlx7rSDw==
-  /@babel/plugin-transform-spread/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-spread/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-skip-transparent-expression-wrappers': 7.12.1
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-vuLp8CP0BE18zVYjsEBZ5xoCecMK6LBMMxYzJnh01rxQRvhNhH1csMMmBfNo5tGpGO+NhdSNW2mzIvBu3K1fng==
-  /@babel/plugin-transform-spread/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-spread/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-skip-transparent-expression-wrappers': 7.12.1
     dev: false
     peerDependencies:
@@ -4288,7 +4178,7 @@ packages:
   /@babel/plugin-transform-spread/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-skip-transparent-expression-wrappers': 7.12.1
     dev: false
     peerDependencies:
@@ -4298,26 +4188,26 @@ packages:
   /@babel/plugin-transform-spread/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-skip-transparent-expression-wrappers': 7.12.1
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-vuLp8CP0BE18zVYjsEBZ5xoCecMK6LBMMxYzJnh01rxQRvhNhH1csMMmBfNo5tGpGO+NhdSNW2mzIvBu3K1fng==
-  /@babel/plugin-transform-sticky-regex/7.12.7_@babel+core@7.12.3:
+  /@babel/plugin-transform-sticky-regex/7.12.7_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-VEiqZL5N/QvDbdjfYQBhruN0HYjSPjC4XkeqW4ny/jNtH9gcbgaqBIXYEZCNnESMAGs0/K/R7oFGMhOyu/eIxg==
-  /@babel/plugin-transform-sticky-regex/7.12.7_@babel+core@7.13.16:
+  /@babel/plugin-transform-sticky-regex/7.12.7_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4326,7 +4216,7 @@ packages:
   /@babel/plugin-transform-sticky-regex/7.12.7_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4335,25 +4225,25 @@ packages:
   /@babel/plugin-transform-sticky-regex/7.12.7_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-VEiqZL5N/QvDbdjfYQBhruN0HYjSPjC4XkeqW4ny/jNtH9gcbgaqBIXYEZCNnESMAGs0/K/R7oFGMhOyu/eIxg==
-  /@babel/plugin-transform-template-literals/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-template-literals/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-b4Zx3KHi+taXB1dVRBhVJtEPi9h1THCeKmae2qP0YdUHIFhVjtpqqNfxeVAa1xeHVhAy4SbHxEwx5cltAu5apw==
-  /@babel/plugin-transform-template-literals/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-template-literals/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4362,7 +4252,7 @@ packages:
   /@babel/plugin-transform-template-literals/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4371,25 +4261,25 @@ packages:
   /@babel/plugin-transform-template-literals/7.12.1_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-b4Zx3KHi+taXB1dVRBhVJtEPi9h1THCeKmae2qP0YdUHIFhVjtpqqNfxeVAa1xeHVhAy4SbHxEwx5cltAu5apw==
-  /@babel/plugin-transform-typeof-symbol/7.12.10_@babel+core@7.12.3:
+  /@babel/plugin-transform-typeof-symbol/7.12.10_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-JQ6H8Rnsogh//ijxspCjc21YPd3VLVoYtAwv3zQmqAt8YGYUtdo5usNhdl4b9/Vir2kPFZl6n1h0PfUz4hJhaA==
-  /@babel/plugin-transform-typeof-symbol/7.12.10_@babel+core@7.13.16:
+  /@babel/plugin-transform-typeof-symbol/7.12.10_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4398,7 +4288,7 @@ packages:
   /@babel/plugin-transform-typeof-symbol/7.12.10_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4407,7 +4297,7 @@ packages:
   /@babel/plugin-transform-typeof-symbol/7.12.10_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4417,7 +4307,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-create-class-features-plugin': 7.12.1_@babel+core@7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-syntax-typescript': 7.12.1_@babel+core@7.12.3
     dev: false
     peerDependencies:
@@ -4428,26 +4318,26 @@ packages:
     dependencies:
       '@babel/core': 7.9.0
       '@babel/helper-create-class-features-plugin': 7.12.1_@babel+core@7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-syntax-typescript': 7.12.1_@babel+core@7.9.0
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-VrsBByqAIntM+EYMqSm59SiMEf7qkmI9dqMt6RbD/wlwueWmYcI0FFK5Fj47pP6DRZm+3teXjosKlwcZJ5lIMw==
-  /@babel/plugin-transform-unicode-escapes/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-unicode-escapes/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-I8gNHJLIc7GdApm7wkVnStWssPNbSRMPtgHdmH3sRM1zopz09UWPS4x5V4n1yz/MIWTVnJ9sp6IkuXdWM4w+2Q==
-  /@babel/plugin-transform-unicode-escapes/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-unicode-escapes/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4456,27 +4346,27 @@ packages:
   /@babel/plugin-transform-unicode-escapes/7.12.1_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-I8gNHJLIc7GdApm7wkVnStWssPNbSRMPtgHdmH3sRM1zopz09UWPS4x5V4n1yz/MIWTVnJ9sp6IkuXdWM4w+2Q==
-  /@babel/plugin-transform-unicode-regex/7.12.1_@babel+core@7.12.3:
+  /@babel/plugin-transform-unicode-regex/7.12.1_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-create-regexp-features-plugin': 7.12.7_@babel+core@7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.10
+      '@babel/helper-create-regexp-features-plugin': 7.12.7_@babel+core@7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-SqH4ClNngh/zGwHZOOQMTD+e8FGWexILV+ePMyiDJttAWRh5dhDL8rcl5lSgU3Huiq6Zn6pWTMvdPAb21Dwdyg==
-  /@babel/plugin-transform-unicode-regex/7.12.1_@babel+core@7.13.16:
+  /@babel/plugin-transform-unicode-regex/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-create-regexp-features-plugin': 7.12.7_@babel+core@7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/core': 7.12.3
+      '@babel/helper-create-regexp-features-plugin': 7.12.7_@babel+core@7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4486,7 +4376,7 @@ packages:
     dependencies:
       '@babel/core': 7.8.4
       '@babel/helper-create-regexp-features-plugin': 7.12.7_@babel+core@7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4496,7 +4386,7 @@ packages:
     dependencies:
       '@babel/core': 7.9.0
       '@babel/helper-create-regexp-features-plugin': 7.12.7_@babel+core@7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4510,73 +4400,73 @@ packages:
     dev: false
     resolution:
       integrity: sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==
-  /@babel/preset-env/7.12.11_@babel+core@7.13.16:
+  /@babel/preset-env/7.12.11_@babel+core@7.12.10:
     dependencies:
-      '@babel/compat-data': 7.13.15
-      '@babel/core': 7.13.16
-      '@babel/helper-compilation-targets': 7.13.16_@babel+core@7.13.16
-      '@babel/helper-module-imports': 7.13.12
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-validator-option': 7.12.17
-      '@babel/plugin-proposal-async-generator-functions': 7.12.12_@babel+core@7.13.16
-      '@babel/plugin-proposal-class-properties': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-proposal-dynamic-import': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-proposal-export-namespace-from': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-proposal-json-strings': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-proposal-logical-assignment-operators': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-proposal-numeric-separator': 7.12.7_@babel+core@7.13.16
-      '@babel/plugin-proposal-object-rest-spread': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-proposal-optional-catch-binding': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-proposal-optional-chaining': 7.12.7_@babel+core@7.13.16
-      '@babel/plugin-proposal-private-methods': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-proposal-unicode-property-regex': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.13.16
-      '@babel/plugin-syntax-class-properties': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.13.16
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.13.16
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.13.16
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.13.16
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.13.16
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.13.16
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.13.16
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.13.16
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.13.16
-      '@babel/plugin-syntax-top-level-await': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-arrow-functions': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-async-to-generator': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-block-scoped-functions': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-block-scoping': 7.12.12_@babel+core@7.13.16
-      '@babel/plugin-transform-classes': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-computed-properties': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-destructuring': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-dotall-regex': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-duplicate-keys': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-exponentiation-operator': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-for-of': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-function-name': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-literals': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-member-expression-literals': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-modules-amd': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-modules-commonjs': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-modules-systemjs': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-modules-umd': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-new-target': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-object-super': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-parameters': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-property-literals': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-regenerator': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-reserved-words': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-shorthand-properties': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-spread': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-sticky-regex': 7.12.7_@babel+core@7.13.16
-      '@babel/plugin-transform-template-literals': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-typeof-symbol': 7.12.10_@babel+core@7.13.16
-      '@babel/plugin-transform-unicode-escapes': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-unicode-regex': 7.12.1_@babel+core@7.13.16
-      '@babel/preset-modules': 0.1.4_@babel+core@7.13.16
-      '@babel/types': 7.13.17
+      '@babel/compat-data': 7.12.7
+      '@babel/core': 7.12.10
+      '@babel/helper-compilation-targets': 7.12.5_@babel+core@7.12.10
+      '@babel/helper-module-imports': 7.12.5
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-validator-option': 7.12.11
+      '@babel/plugin-proposal-async-generator-functions': 7.12.12_@babel+core@7.12.10
+      '@babel/plugin-proposal-class-properties': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-proposal-dynamic-import': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-proposal-export-namespace-from': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-proposal-json-strings': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-proposal-logical-assignment-operators': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-proposal-numeric-separator': 7.12.7_@babel+core@7.12.10
+      '@babel/plugin-proposal-object-rest-spread': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-proposal-optional-catch-binding': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-proposal-optional-chaining': 7.12.7_@babel+core@7.12.10
+      '@babel/plugin-proposal-private-methods': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-proposal-unicode-property-regex': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.12.10
+      '@babel/plugin-syntax-class-properties': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.12.10
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.12.10
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.12.10
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.12.10
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.12.10
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.12.10
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.12.10
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.12.10
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.12.10
+      '@babel/plugin-syntax-top-level-await': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-arrow-functions': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-async-to-generator': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-block-scoped-functions': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-block-scoping': 7.12.12_@babel+core@7.12.10
+      '@babel/plugin-transform-classes': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-computed-properties': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-destructuring': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-dotall-regex': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-duplicate-keys': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-exponentiation-operator': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-for-of': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-function-name': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-literals': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-member-expression-literals': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-modules-amd': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-modules-commonjs': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-modules-systemjs': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-modules-umd': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-new-target': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-object-super': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-parameters': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-property-literals': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-regenerator': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-reserved-words': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-shorthand-properties': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-spread': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-sticky-regex': 7.12.7_@babel+core@7.12.10
+      '@babel/plugin-transform-template-literals': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-typeof-symbol': 7.12.10_@babel+core@7.12.10
+      '@babel/plugin-transform-unicode-escapes': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-unicode-regex': 7.12.1_@babel+core@7.12.10
+      '@babel/preset-modules': 0.1.4_@babel+core@7.12.10
+      '@babel/types': 7.12.12
       core-js-compat: 3.8.2
       semver: 5.7.1
     dev: false
@@ -4586,12 +4476,12 @@ packages:
       integrity: sha512-j8Tb+KKIXKYlDBQyIOy4BLxzv1NUOwlHfZ74rvW+Z0Gp4/cI2IMDPBWAgWceGcE7aep9oL/0K9mlzlMGxA8yNw==
   /@babel/preset-env/7.12.11_@babel+core@7.8.4:
     dependencies:
-      '@babel/compat-data': 7.13.15
+      '@babel/compat-data': 7.12.7
       '@babel/core': 7.8.4
-      '@babel/helper-compilation-targets': 7.13.16_@babel+core@7.8.4
-      '@babel/helper-module-imports': 7.13.12
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-validator-option': 7.12.17
+      '@babel/helper-compilation-targets': 7.12.5_@babel+core@7.8.4
+      '@babel/helper-module-imports': 7.12.5
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-validator-option': 7.12.11
       '@babel/plugin-proposal-async-generator-functions': 7.12.12_@babel+core@7.8.4
       '@babel/plugin-proposal-class-properties': 7.12.1_@babel+core@7.8.4
       '@babel/plugin-proposal-dynamic-import': 7.12.1_@babel+core@7.8.4
@@ -4650,7 +4540,7 @@ packages:
       '@babel/plugin-transform-unicode-escapes': 7.12.1_@babel+core@7.8.4
       '@babel/plugin-transform-unicode-regex': 7.12.1_@babel+core@7.8.4
       '@babel/preset-modules': 0.1.4_@babel+core@7.8.4
-      '@babel/types': 7.13.17
+      '@babel/types': 7.12.12
       core-js-compat: 3.8.2
       semver: 5.7.1
     dev: false
@@ -4660,12 +4550,12 @@ packages:
       integrity: sha512-j8Tb+KKIXKYlDBQyIOy4BLxzv1NUOwlHfZ74rvW+Z0Gp4/cI2IMDPBWAgWceGcE7aep9oL/0K9mlzlMGxA8yNw==
   /@babel/preset-env/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/compat-data': 7.13.15
+      '@babel/compat-data': 7.12.7
       '@babel/core': 7.12.3
-      '@babel/helper-compilation-targets': 7.13.16_@babel+core@7.12.3
-      '@babel/helper-module-imports': 7.13.12
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-validator-option': 7.12.17
+      '@babel/helper-compilation-targets': 7.12.5_@babel+core@7.12.3
+      '@babel/helper-module-imports': 7.12.5
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-validator-option': 7.12.11
       '@babel/plugin-proposal-async-generator-functions': 7.12.12_@babel+core@7.12.3
       '@babel/plugin-proposal-class-properties': 7.12.1_@babel+core@7.12.3
       '@babel/plugin-proposal-dynamic-import': 7.12.1_@babel+core@7.12.3
@@ -4724,7 +4614,7 @@ packages:
       '@babel/plugin-transform-unicode-escapes': 7.12.1_@babel+core@7.12.3
       '@babel/plugin-transform-unicode-regex': 7.12.1_@babel+core@7.12.3
       '@babel/preset-modules': 0.1.4_@babel+core@7.12.3
-      '@babel/types': 7.13.17
+      '@babel/types': 7.12.12
       core-js-compat: 3.8.2
       semver: 5.7.1
     dev: false
@@ -4800,26 +4690,26 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-712DeRXT6dyKAM/FMbQTV/FvRCms2hPCx+3weRjZ8iQVQWZejWWk1wwG6ViWMyqb/ouBbGOl5b6aCk0+j1NmsQ==
-  /@babel/preset-modules/0.1.4_@babel+core@7.12.3:
+  /@babel/preset-modules/0.1.4_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-proposal-unicode-property-regex': 7.12.1_@babel+core@7.12.3
-      '@babel/plugin-transform-dotall-regex': 7.12.1_@babel+core@7.12.3
-      '@babel/types': 7.13.17
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-proposal-unicode-property-regex': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-dotall-regex': 7.12.1_@babel+core@7.12.10
+      '@babel/types': 7.12.12
       esutils: 2.0.3
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==
-  /@babel/preset-modules/0.1.4_@babel+core@7.13.16:
+  /@babel/preset-modules/0.1.4_@babel+core@7.12.3:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-proposal-unicode-property-regex': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-dotall-regex': 7.12.1_@babel+core@7.13.16
-      '@babel/types': 7.13.17
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-proposal-unicode-property-regex': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-dotall-regex': 7.12.1_@babel+core@7.12.3
+      '@babel/types': 7.12.12
       esutils: 2.0.3
     dev: false
     peerDependencies:
@@ -4829,10 +4719,10 @@ packages:
   /@babel/preset-modules/0.1.4_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-proposal-unicode-property-regex': 7.12.1_@babel+core@7.8.4
       '@babel/plugin-transform-dotall-regex': 7.12.1_@babel+core@7.8.4
-      '@babel/types': 7.13.17
+      '@babel/types': 7.12.12
       esutils: 2.0.3
     dev: false
     peerDependencies:
@@ -4842,24 +4732,24 @@ packages:
   /@babel/preset-modules/0.1.4_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-proposal-unicode-property-regex': 7.12.1_@babel+core@7.9.0
       '@babel/plugin-transform-dotall-regex': 7.12.1_@babel+core@7.9.0
-      '@babel/types': 7.13.17
+      '@babel/types': 7.12.12
       esutils: 2.0.3
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==
-  /@babel/preset-react/7.12.10_@babel+core@7.13.16:
+  /@babel/preset-react/7.12.10_@babel+core@7.12.10:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-transform-react-display-name': 7.12.1_@babel+core@7.13.16
-      '@babel/plugin-transform-react-jsx': 7.12.12_@babel+core@7.13.16
-      '@babel/plugin-transform-react-jsx-development': 7.12.12_@babel+core@7.13.16
-      '@babel/plugin-transform-react-pure-annotations': 7.12.1_@babel+core@7.13.16
+      '@babel/core': 7.12.10
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-transform-react-display-name': 7.12.1_@babel+core@7.12.10
+      '@babel/plugin-transform-react-jsx': 7.12.12_@babel+core@7.12.10
+      '@babel/plugin-transform-react-jsx-development': 7.12.12_@babel+core@7.12.10
+      '@babel/plugin-transform-react-pure-annotations': 7.12.1_@babel+core@7.12.10
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4868,7 +4758,7 @@ packages:
   /@babel/preset-react/7.12.10_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-transform-react-display-name': 7.12.1_@babel+core@7.8.4
       '@babel/plugin-transform-react-jsx': 7.12.12_@babel+core@7.8.4
       '@babel/plugin-transform-react-jsx-development': 7.12.12_@babel+core@7.8.4
@@ -4881,7 +4771,7 @@ packages:
   /@babel/preset-react/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-transform-react-display-name': 7.12.1_@babel+core@7.12.3
       '@babel/plugin-transform-react-jsx': 7.12.12_@babel+core@7.12.3
       '@babel/plugin-transform-react-jsx-development': 7.12.12_@babel+core@7.12.3
@@ -4910,7 +4800,7 @@ packages:
   /@babel/preset-typescript/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-transform-typescript': 7.12.1_@babel+core@7.12.3
     dev: false
     peerDependencies:
@@ -4953,8 +4843,8 @@ packages:
   /@babel/template/7.12.13:
     dependencies:
       '@babel/code-frame': 7.12.13
-      '@babel/parser': 7.14.0
-      '@babel/types': 7.14.0
+      '@babel/parser': 7.13.16
+      '@babel/types': 7.13.17
     resolution:
       integrity: sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==
   /@babel/template/7.12.7:
@@ -5005,21 +4895,21 @@ packages:
       globals: 11.12.0
     resolution:
       integrity: sha512-BMnZn0R+X6ayqm3C3To7o1j7Q020gWdqdyP50KEoVqaCO2c/Im7sYZSmVgvefp8TTMQ+9CtwuBp0Z1CZ8V3Pvg==
-  /@babel/traverse/7.14.0_supports-color@5.5.0:
+  /@babel/traverse/7.13.17_supports-color@5.5.0:
     dependencies:
       '@babel/code-frame': 7.12.13
-      '@babel/generator': 7.14.0
+      '@babel/generator': 7.13.16
       '@babel/helper-function-name': 7.12.13
       '@babel/helper-split-export-declaration': 7.12.13
-      '@babel/parser': 7.14.0
-      '@babel/types': 7.14.0
+      '@babel/parser': 7.13.16
+      '@babel/types': 7.13.17
       debug: 4.3.1_supports-color@5.5.0
       globals: 11.12.0
     dev: false
     peerDependencies:
       supports-color: '*'
     resolution:
-      integrity: sha512-dZ/a371EE5XNhTHomvtuLTUyx6UEoJmYX+DT5zBCQN3McHemsuIaKKYqsc/fs26BEkHs/lBZy0J571LP5z9kQA==
+      integrity: sha512-BMnZn0R+X6ayqm3C3To7o1j7Q020gWdqdyP50KEoVqaCO2c/Im7sYZSmVgvefp8TTMQ+9CtwuBp0Z1CZ8V3Pvg==
   /@babel/types/7.12.12:
     dependencies:
       '@babel/helper-validator-identifier': 7.12.11
@@ -5032,7 +4922,6 @@ packages:
       '@babel/helper-validator-identifier': 7.12.11
       lodash: 4.17.20
       to-fast-properties: 2.0.0
-    dev: false
     resolution:
       integrity: sha512-oKrdZTld2im1z8bDwTOQvUbxKwE+854zc16qWZQlcTqMN00pWxHQ4ZeOq0yDMnisOpRykH2/5Qqcrk/OlbAjiQ==
   /@babel/types/7.13.17:
@@ -5041,12 +4930,6 @@ packages:
       to-fast-properties: 2.0.0
     resolution:
       integrity: sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==
-  /@babel/types/7.14.0:
-    dependencies:
-      '@babel/helper-validator-identifier': 7.14.0
-      to-fast-properties: 2.0.0
-    resolution:
-      integrity: sha512-O2LVLdcnWplaGxiPBz12d0HcdN8QdxdsWYhz5LSeuukV/5mn2xUUc3gBeU4QBYPJ18g/UToe8F532XJ608prmg==
   /@bcoe/v8-coverage/0.2.3:
     resolution:
       integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
@@ -5150,7 +5033,6 @@ packages:
       lodash: 4.17.20
       minimatch: 3.0.4
       strip-json-comments: 3.1.1
-    dev: true
     engines:
       node: ^10.12.0 || >=12.0.0
     resolution:
@@ -5167,6 +5049,7 @@ packages:
       lodash: 4.17.20
       minimatch: 3.0.4
       strip-json-comments: 3.1.1
+    dev: true
     engines:
       node: ^10.12.0 || >=12.0.0
     resolution:
@@ -5877,7 +5760,7 @@ packages:
       '@types/resolve': 0.0.8
       builtin-modules: 3.2.0
       is-module: 1.0.0
-      resolve: 1.20.0
+      resolve: 1.19.0
       rollup: 1.32.1
     dev: false
     engines:
@@ -5900,7 +5783,7 @@ packages:
     dependencies:
       '@types/estree': 0.0.39
       estree-walker: 1.0.1
-      picomatch: 2.2.3
+      picomatch: 2.2.2
       rollup: 1.32.1
     dev: false
     engines:
@@ -6162,7 +6045,7 @@ packages:
       integrity: sha512-JioXclZGhFIDL3ddn4Kiq8qEqYM2PyDKV0aYno8+IXTLuYt6TOgHUbUAAFvqtb0Xn37NwP0BTHglejFoYr8RZg==
   /@svgr/hast-util-to-babel-ast/5.5.0:
     dependencies:
-      '@babel/types': 7.13.17
+      '@babel/types': 7.12.12
     dev: false
     engines:
       node: '>=10'
@@ -6181,7 +6064,7 @@ packages:
       integrity: sha512-cLOCSpNWQnDB1/v+SUENHH7a0XY09bfuMKdq9+gYvtuwzC2rU4I0wKGFEp1i24holdQdwodCtDQdFtJiTCWc+w==
   /@svgr/plugin-jsx/5.5.0:
     dependencies:
-      '@babel/core': 7.13.16
+      '@babel/core': 7.12.10
       '@svgr/babel-preset': 5.5.0
       '@svgr/hast-util-to-babel-ast': 5.5.0
       svg-parser: 2.0.4
@@ -6227,10 +6110,10 @@ packages:
       integrity: sha512-bjnWolZ6KVsHhgyCoYRFmbd26p8XVbulCzSG53BDQqAr+JOAderYK7CuYrB3bDjHJuF6LJ7Wrr42+goLRV9qIg==
   /@svgr/webpack/5.4.0:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/plugin-transform-react-constant-elements': 7.12.1_@babel+core@7.13.16
-      '@babel/preset-env': 7.12.11_@babel+core@7.13.16
-      '@babel/preset-react': 7.12.10_@babel+core@7.13.16
+      '@babel/core': 7.12.10
+      '@babel/plugin-transform-react-constant-elements': 7.12.1_@babel+core@7.12.10
+      '@babel/preset-env': 7.12.11_@babel+core@7.12.10
+      '@babel/preset-react': 7.12.10_@babel+core@7.12.10
       '@svgr/core': 5.5.0
       '@svgr/plugin-jsx': 5.5.0
       '@svgr/plugin-svgo': 5.5.0
@@ -6371,7 +6254,6 @@ packages:
       '@types/babel__generator': 7.6.2
       '@types/babel__template': 7.4.0
       '@types/babel__traverse': 7.11.0
-    dev: false
     resolution:
       integrity: sha512-wMTHiiTiBAAPebqaPiPDLFA4LYPKr6Ph0Xq/6rq1Ur3v66HXyG+clfR9CNETkD7MQS8ZHvpQOtA53DLws5WAEQ==
   /@types/babel__core/7.1.14:
@@ -6397,7 +6279,6 @@ packages:
   /@types/babel__traverse/7.11.0:
     dependencies:
       '@babel/types': 7.12.13
-    dev: false
     resolution:
       integrity: sha512-kSjgDMZONiIfSH1Nxcr5JIRMwUetDki63FSQfpTCz8ogF3Ulqm8+mr5f78dUYs6vMiB6gBusQqfQmBvHZj/lwg==
   /@types/babel__traverse/7.11.1:
@@ -6462,7 +6343,7 @@ packages:
   /@types/eslint/7.2.6:
     dependencies:
       '@types/estree': 0.0.46
-      '@types/json-schema': 7.0.7
+      '@types/json-schema': 7.0.6
     dev: false
     resolution:
       integrity: sha512-I+1sYH+NPQ3/tVqCeUSBwTE/0heyvtXqpIopUUArlBm0Kpocb8FbMa3AZ/ASKIFpN3rnEx932TTXDbt9OXsNDw==
@@ -6583,7 +6464,6 @@ packages:
     dependencies:
       jest-diff: 26.6.2
       pretty-format: 26.6.2
-    dev: true
     resolution:
       integrity: sha512-9zi2Y+5USJRxd0FsahERhBwlcvFh6D2GLQnY2FH2BzK8J9s9omvNHIbvABwIluXa0fD8XVKMLTO0aOEuUfACAA==
   /@types/jest/26.0.21:
@@ -6603,6 +6483,7 @@ packages:
     resolution:
       integrity: sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
   /@types/json-schema/7.0.7:
+    dev: true
     resolution:
       integrity: sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
   /@types/json5/0.0.29:
@@ -6665,10 +6546,10 @@ packages:
   /@types/node/12.19.3:
     resolution:
       integrity: sha512-8Jduo8wvvwDzEVJCOvS/G6sgilOLvvhn1eMmK3TW8/T217O7u1jdrK6ImKLv80tVryaPSVeKu6sjDEiFjd4/eg==
-  /@types/node/12.20.11:
+  /@types/node/12.20.12:
     dev: false
     resolution:
-      integrity: sha512-gema+apZ6qLQK7k7F0dGkGCWQYsL0qqKORWOQO6tq46q+x+1C0vbOiOqOwRVlh4RAdbQwV/j/ryr3u5NOG1fPQ==
+      integrity: sha512-KQZ1al2hKOONAs2MFv+yTQP1LkDWMrRJ9YCVRalXltOfXsBmH5IownLxQaiq0lnAHwAViLnh2aTYqrPcRGEbgg==
   /@types/node/14.0.1:
     dev: false
     resolution:
@@ -6770,7 +6651,7 @@ packages:
     dependencies:
       '@types/prop-types': 15.7.3
       '@types/scheduler': 0.16.1
-      csstype: 3.0.8
+      csstype: 3.0.6
     resolution:
       integrity: sha512-onz2BqScSFMoTRdJUZUDD/7xrusM8hBA2Fktk2qgaTYPCgPvWnDEgkrOs8hhPUf2jfcIXkJ5yK6VfYormJS3Jw==
   /@types/readable-stream/2.3.9:
@@ -6781,7 +6662,7 @@ packages:
       integrity: sha512-sqsgQqFT7HmQz/V5jH1O0fvQQnXAJO46Gg9LRO/JPfjmVmGUlcx831TZZO3Y3HtWhIkzf3kTsNT0Z0kzIhIvZw==
   /@types/resolve/0.0.8:
     dependencies:
-      '@types/node': 15.0.1
+      '@types/node': 14.14.20
     dev: false
     resolution:
       integrity: sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
@@ -6819,19 +6700,11 @@ packages:
   /@types/stack-utils/2.0.0:
     resolution:
       integrity: sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
-  /@types/styled-components/5.1.7:
-    dependencies:
-      '@types/hoist-non-react-statics': 3.3.1
-      '@types/react': 17.0.0
-      csstype: 3.0.6
-    dev: false
-    resolution:
-      integrity: sha512-BJzPhFygYspyefAGFZTZ/8lCEY4Tk+Iqktvnko3xmJf9LrLqs3+grxPeU3O0zLl6yjbYBopD0/VikbHgXDbJtA==
   /@types/styled-components/5.1.9:
     dependencies:
       '@types/hoist-non-react-statics': 3.3.1
       '@types/react': 17.0.4
-      csstype: 3.0.8
+      csstype: 3.0.6
     resolution:
       integrity: sha512-kbEG6YlwK8rucITpKEr6pA4Ho9KSQHUUOzZ9lY3va1mtcjvS3D0wDciFyHEiNHKLL/npZCKDQJqm0x44sPO9oA==
   /@types/superagent/4.1.10:
@@ -6908,7 +6781,7 @@ packages:
       integrity: sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
   /@types/webpack-sources/2.1.0:
     dependencies:
-      '@types/node': 15.0.1
+      '@types/node': 14.14.20
       '@types/source-list-map': 0.1.2
       source-map: 0.7.3
     dev: false
@@ -6917,7 +6790,7 @@ packages:
   /@types/webpack/4.41.26:
     dependencies:
       '@types/anymatch': 1.3.1
-      '@types/node': 15.0.1
+      '@types/node': 14.14.20
       '@types/tapable': 1.0.6
       '@types/uglify-js': 3.11.1
       '@types/webpack-sources': 2.1.0
@@ -6976,18 +6849,18 @@ packages:
         optional: true
     resolution:
       integrity: sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==
-  /@typescript-eslint/eslint-plugin/4.16.1_4b7c75eac308ba454583af097e0ad94d:
+  /@typescript-eslint/eslint-plugin/4.13.0_7c35a77949eef03106c52e13aece0106:
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.16.1_eslint@7.19.0+typescript@4.2.4
-      '@typescript-eslint/parser': 4.16.1_eslint@7.19.0+typescript@4.2.4
-      '@typescript-eslint/scope-manager': 4.16.1
+      '@typescript-eslint/experimental-utils': 4.13.0_eslint@7.17.0+typescript@4.2.4
+      '@typescript-eslint/parser': 4.13.0_eslint@7.17.0+typescript@4.2.4
+      '@typescript-eslint/scope-manager': 4.13.0
       debug: 4.3.1
-      eslint: 7.19.0
+      eslint: 7.17.0
       functional-red-black-tree: 1.0.1
-      lodash: 4.17.21
+      lodash: 4.17.20
       regexpp: 3.1.0
       semver: 7.3.4
-      tsutils: 3.20.0_typescript@4.2.4
+      tsutils: 3.19.1_typescript@4.2.4
       typescript: 4.2.4
     dev: false
     engines:
@@ -7000,21 +6873,21 @@ packages:
       typescript:
         optional: true
     resolution:
-      integrity: sha512-SK777klBdlkUZpZLC1mPvyOWk9yAFCWmug13eAjVQ4/Q1LATE/NbcQL1xDHkptQkZOLnPmLUA1Y54m8dqYwnoQ==
-  /@typescript-eslint/eslint-plugin/4.16.1_73e2bd13a8b35a69cfb92e9563939b3f:
+      integrity: sha512-ygqDUm+BUPvrr0jrXqoteMqmIaZ/bixYOc3A4BRwzEPTZPi6E+n44rzNZWaB0YvtukgP+aoj0i/fyx7FkM2p1w==
+  /@typescript-eslint/eslint-plugin/4.13.0_8020b167ee7d7f543c2fef182c50aa77:
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.16.1_eslint@7.17.0+typescript@4.2.4
-      '@typescript-eslint/parser': 4.16.1_eslint@7.17.0+typescript@4.2.4
-      '@typescript-eslint/scope-manager': 4.16.1
+      '@typescript-eslint/experimental-utils': 4.13.0_eslint@7.17.0+typescript@4.2.3
+      '@typescript-eslint/parser': 4.13.0_eslint@7.17.0+typescript@4.2.3
+      '@typescript-eslint/scope-manager': 4.13.0
       debug: 4.3.1
       eslint: 7.17.0
       functional-red-black-tree: 1.0.1
-      lodash: 4.17.21
+      lodash: 4.17.20
       regexpp: 3.1.0
       semver: 7.3.4
-      tsutils: 3.20.0_typescript@4.2.4
-      typescript: 4.2.4
-    dev: true
+      tsutils: 3.19.1_typescript@4.2.3
+      typescript: 4.2.3
+    dev: false
     engines:
       node: ^10.12.0 || >=12.0.0
     peerDependencies:
@@ -7025,7 +6898,7 @@ packages:
       typescript:
         optional: true
     resolution:
-      integrity: sha512-SK777klBdlkUZpZLC1mPvyOWk9yAFCWmug13eAjVQ4/Q1LATE/NbcQL1xDHkptQkZOLnPmLUA1Y54m8dqYwnoQ==
+      integrity: sha512-ygqDUm+BUPvrr0jrXqoteMqmIaZ/bixYOc3A4BRwzEPTZPi6E+n44rzNZWaB0YvtukgP+aoj0i/fyx7FkM2p1w==
   /@typescript-eslint/eslint-plugin/4.16.1_8360ec0b6468ab52d7ec43304a9826d1:
     dependencies:
       '@typescript-eslint/experimental-utils': 4.16.1_eslint@7.19.0+typescript@4.2.3
@@ -7039,6 +6912,7 @@ packages:
       semver: 7.3.4
       tsutils: 3.20.0_typescript@4.2.3
       typescript: 4.2.3
+    dev: true
     engines:
       node: ^10.12.0 || >=12.0.0
     peerDependencies:
@@ -7102,7 +6976,7 @@ packages:
       integrity: sha512-U8SP9VOs275iDXaL08Ln1Fa/wLXfj5aTr/1c0t0j6CdbOnxh+TruXu1p4I0NAvdPBQgoPjHsgKn28mOi0FzfoA==
   /@typescript-eslint/experimental-utils/2.34.0_eslint@6.8.0+typescript@4.2.3:
     dependencies:
-      '@types/json-schema': 7.0.7
+      '@types/json-schema': 7.0.6
       '@typescript-eslint/typescript-estree': 2.34.0_typescript@4.2.3
       eslint: 6.8.0
       eslint-scope: 5.1.1
@@ -7115,10 +6989,10 @@ packages:
       typescript: '*'
     resolution:
       integrity: sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==
-  /@typescript-eslint/experimental-utils/2.34.0_eslint@7.17.0+typescript@4.2.4:
+  /@typescript-eslint/experimental-utils/2.34.0_eslint@7.17.0+typescript@4.2.3:
     dependencies:
-      '@types/json-schema': 7.0.7
-      '@typescript-eslint/typescript-estree': 2.34.0_typescript@4.2.4
+      '@types/json-schema': 7.0.6
+      '@typescript-eslint/typescript-estree': 2.34.0_typescript@4.2.3
       eslint: 7.17.0
       eslint-scope: 5.1.1
       eslint-utils: 2.1.0
@@ -7132,7 +7006,7 @@ packages:
       integrity: sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==
   /@typescript-eslint/experimental-utils/2.34.0_eslint@7.25.0+typescript@4.2.4:
     dependencies:
-      '@types/json-schema': 7.0.7
+      '@types/json-schema': 7.0.6
       '@typescript-eslint/typescript-estree': 2.34.0_typescript@4.2.4
       eslint: 7.25.0
       eslint-scope: 5.1.1
@@ -7145,12 +7019,12 @@ packages:
       typescript: '*'
     resolution:
       integrity: sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==
-  /@typescript-eslint/experimental-utils/3.10.1_eslint@7.19.0+typescript@4.2.3:
+  /@typescript-eslint/experimental-utils/3.10.1_eslint@7.17.0+typescript@4.2.3:
     dependencies:
-      '@types/json-schema': 7.0.7
+      '@types/json-schema': 7.0.6
       '@typescript-eslint/types': 3.10.1
       '@typescript-eslint/typescript-estree': 3.10.1_typescript@4.2.3
-      eslint: 7.19.0
+      eslint: 7.17.0
       eslint-scope: 5.1.1
       eslint-utils: 2.1.0
     dev: false
@@ -7161,12 +7035,12 @@ packages:
       typescript: '*'
     resolution:
       integrity: sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==
-  /@typescript-eslint/experimental-utils/3.10.1_eslint@7.19.0+typescript@4.2.4:
+  /@typescript-eslint/experimental-utils/3.10.1_eslint@7.17.0+typescript@4.2.4:
     dependencies:
-      '@types/json-schema': 7.0.7
+      '@types/json-schema': 7.0.6
       '@typescript-eslint/types': 3.10.1
       '@typescript-eslint/typescript-estree': 3.10.1_typescript@4.2.4
-      eslint: 7.19.0
+      eslint: 7.17.0
       eslint-scope: 5.1.1
       eslint-utils: 2.1.0
     dev: false
@@ -7186,7 +7060,6 @@ packages:
       eslint: 7.17.0
       eslint-scope: 5.1.1
       eslint-utils: 2.1.0
-    dev: true
     engines:
       node: ^10.12.0 || >=12.0.0
     peerDependencies:
@@ -7194,30 +7067,13 @@ packages:
       typescript: '*'
     resolution:
       integrity: sha512-/ZsuWmqagOzNkx30VWYV3MNB/Re/CGv/7EzlqZo5RegBN8tMuPaBgNK6vPBCQA8tcYrbsrTdbx3ixMRRKEEGVw==
-  /@typescript-eslint/experimental-utils/4.13.0_eslint@7.19.0+typescript@4.2.3:
-    dependencies:
-      '@types/json-schema': 7.0.6
-      '@typescript-eslint/scope-manager': 4.13.0
-      '@typescript-eslint/types': 4.13.0
-      '@typescript-eslint/typescript-estree': 4.13.0_typescript@4.2.3
-      eslint: 7.19.0
-      eslint-scope: 5.1.1
-      eslint-utils: 2.1.0
-    dev: false
-    engines:
-      node: ^10.12.0 || >=12.0.0
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    resolution:
-      integrity: sha512-/ZsuWmqagOzNkx30VWYV3MNB/Re/CGv/7EzlqZo5RegBN8tMuPaBgNK6vPBCQA8tcYrbsrTdbx3ixMRRKEEGVw==
-  /@typescript-eslint/experimental-utils/4.13.0_eslint@7.19.0+typescript@4.2.4:
+  /@typescript-eslint/experimental-utils/4.13.0_eslint@7.17.0+typescript@4.2.4:
     dependencies:
       '@types/json-schema': 7.0.6
       '@typescript-eslint/scope-manager': 4.13.0
       '@typescript-eslint/types': 4.13.0
       '@typescript-eslint/typescript-estree': 4.13.0_typescript@4.2.4
-      eslint: 7.19.0
+      eslint: 7.17.0
       eslint-scope: 5.1.1
       eslint-utils: 2.1.0
     dev: false
@@ -7245,23 +7101,6 @@ packages:
       typescript: '*'
     resolution:
       integrity: sha512-0Hm3LSlMYFK17jO4iY3un1Ve9x1zLNn4EM50Lia+0EV99NdbK+cn0er7HC7IvBA23mBg3P+8dUkMXy4leL33UQ==
-  /@typescript-eslint/experimental-utils/4.16.1_eslint@7.17.0+typescript@4.2.4:
-    dependencies:
-      '@types/json-schema': 7.0.7
-      '@typescript-eslint/scope-manager': 4.16.1
-      '@typescript-eslint/types': 4.16.1
-      '@typescript-eslint/typescript-estree': 4.16.1_typescript@4.2.4
-      eslint: 7.17.0
-      eslint-scope: 5.1.1
-      eslint-utils: 2.1.0
-    dev: true
-    engines:
-      node: ^10.12.0 || >=12.0.0
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    resolution:
-      integrity: sha512-0Hm3LSlMYFK17jO4iY3un1Ve9x1zLNn4EM50Lia+0EV99NdbK+cn0er7HC7IvBA23mBg3P+8dUkMXy4leL33UQ==
   /@typescript-eslint/experimental-utils/4.16.1_eslint@7.19.0+typescript@4.2.3:
     dependencies:
       '@types/json-schema': 7.0.7
@@ -7271,23 +7110,7 @@ packages:
       eslint: 7.19.0
       eslint-scope: 5.1.1
       eslint-utils: 2.1.0
-    engines:
-      node: ^10.12.0 || >=12.0.0
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    resolution:
-      integrity: sha512-0Hm3LSlMYFK17jO4iY3un1Ve9x1zLNn4EM50Lia+0EV99NdbK+cn0er7HC7IvBA23mBg3P+8dUkMXy4leL33UQ==
-  /@typescript-eslint/experimental-utils/4.16.1_eslint@7.19.0+typescript@4.2.4:
-    dependencies:
-      '@types/json-schema': 7.0.7
-      '@typescript-eslint/scope-manager': 4.16.1
-      '@typescript-eslint/types': 4.16.1
-      '@typescript-eslint/typescript-estree': 4.16.1_typescript@4.2.4
-      eslint: 7.19.0
-      eslint-scope: 5.1.1
-      eslint-utils: 2.1.0
-    dev: false
+    dev: true
     engines:
       node: ^10.12.0 || >=12.0.0
     peerDependencies:
@@ -7358,7 +7181,6 @@ packages:
       debug: 4.3.1
       eslint: 7.17.0
       typescript: 4.2.3
-    dev: true
     engines:
       node: ^10.12.0 || >=12.0.0
     peerDependencies:
@@ -7377,7 +7199,7 @@ packages:
       debug: 4.3.1
       eslint: 7.17.0
       typescript: 4.2.4
-    dev: true
+    dev: false
     engines:
       node: ^10.12.0 || >=12.0.0
     peerDependencies:
@@ -7396,25 +7218,7 @@ packages:
       debug: 4.3.1
       eslint: 7.19.0
       typescript: 4.2.3
-    engines:
-      node: ^10.12.0 || >=12.0.0
-    peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    resolution:
-      integrity: sha512-KO0J5SRF08pMXzq9+abyHnaGQgUJZ3Z3ax+pmqz9vl81JxmTTOUfQmq7/4awVfq09b6C4owNlOgOwp61pYRBSg==
-  /@typescript-eslint/parser/4.13.0_eslint@7.19.0+typescript@4.2.4:
-    dependencies:
-      '@typescript-eslint/scope-manager': 4.13.0
-      '@typescript-eslint/types': 4.13.0
-      '@typescript-eslint/typescript-estree': 4.13.0_typescript@4.2.4
-      debug: 4.3.1
-      eslint: 7.19.0
-      typescript: 4.2.4
-    dev: false
+    dev: true
     engines:
       node: ^10.12.0 || >=12.0.0
     peerDependencies:
@@ -7463,25 +7267,6 @@ packages:
         optional: true
     resolution:
       integrity: sha512-/c0LEZcDL5y8RyI1zLcmZMvJrsR6SM1uetskFkoh3dvqDKVXPsXI+wFB/CbVw7WkEyyTKobC1mUNp/5y6gRvXg==
-  /@typescript-eslint/parser/4.16.1_eslint@7.17.0+typescript@4.2.4:
-    dependencies:
-      '@typescript-eslint/scope-manager': 4.16.1
-      '@typescript-eslint/types': 4.16.1
-      '@typescript-eslint/typescript-estree': 4.16.1_typescript@4.2.4
-      debug: 4.3.1
-      eslint: 7.17.0
-      typescript: 4.2.4
-    dev: true
-    engines:
-      node: ^10.12.0 || >=12.0.0
-    peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    resolution:
-      integrity: sha512-/c0LEZcDL5y8RyI1zLcmZMvJrsR6SM1uetskFkoh3dvqDKVXPsXI+wFB/CbVw7WkEyyTKobC1mUNp/5y6gRvXg==
   /@typescript-eslint/parser/4.16.1_eslint@7.19.0+typescript@4.2.3:
     dependencies:
       '@typescript-eslint/scope-manager': 4.16.1
@@ -7490,25 +7275,7 @@ packages:
       debug: 4.3.1
       eslint: 7.19.0
       typescript: 4.2.3
-    engines:
-      node: ^10.12.0 || >=12.0.0
-    peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    resolution:
-      integrity: sha512-/c0LEZcDL5y8RyI1zLcmZMvJrsR6SM1uetskFkoh3dvqDKVXPsXI+wFB/CbVw7WkEyyTKobC1mUNp/5y6gRvXg==
-  /@typescript-eslint/parser/4.16.1_eslint@7.19.0+typescript@4.2.4:
-    dependencies:
-      '@typescript-eslint/scope-manager': 4.16.1
-      '@typescript-eslint/types': 4.16.1
-      '@typescript-eslint/typescript-estree': 4.16.1_typescript@4.2.4
-      debug: 4.3.1
-      eslint: 7.19.0
-      typescript: 4.2.4
-    dev: false
+    dev: true
     engines:
       node: ^10.12.0 || >=12.0.0
     peerDependencies:
@@ -7550,6 +7317,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 4.16.1
       '@typescript-eslint/visitor-keys': 4.16.1
+    dev: true
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     resolution:
@@ -7575,6 +7343,7 @@ packages:
     resolution:
       integrity: sha512-/+aPaq163oX+ObOG00M0t9tKkOgdv9lq0IQv/y4SqGkAXmhFmCfgsELV7kOCTb2vVU5VOmVwXBXJTDr353C1rQ==
   /@typescript-eslint/types/4.16.1:
+    dev: true
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     resolution:
@@ -7595,7 +7364,6 @@ packages:
       semver: 7.3.4
       tsutils: 3.19.1_typescript@4.2.3
       typescript: 4.2.3
-    dev: false
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     peerDependencies:
@@ -7632,9 +7400,9 @@ packages:
       debug: 4.3.1
       glob: 7.1.6
       is-glob: 4.0.1
-      lodash: 4.17.21
-      semver: 7.3.5
-      tsutils: 3.20.0_typescript@4.2.3
+      lodash: 4.17.20
+      semver: 7.3.4
+      tsutils: 3.19.1_typescript@4.2.3
       typescript: 4.2.3
     dev: false
     engines:
@@ -7653,9 +7421,9 @@ packages:
       debug: 4.3.1
       glob: 7.1.6
       is-glob: 4.0.1
-      lodash: 4.17.21
-      semver: 7.3.5
-      tsutils: 3.20.0_typescript@4.2.4
+      lodash: 4.17.20
+      semver: 7.3.4
+      tsutils: 3.19.1_typescript@4.2.4
       typescript: 4.2.4
     dev: false
     engines:
@@ -7712,30 +7480,12 @@ packages:
       '@typescript-eslint/types': 4.16.1
       '@typescript-eslint/visitor-keys': 4.16.1
       debug: 4.3.1
-      globby: 11.0.3
+      globby: 11.0.2
       is-glob: 4.0.1
-      semver: 7.3.5
-      tsutils: 3.21.0_typescript@4.2.3
+      semver: 7.3.4
+      tsutils: 3.20.0_typescript@4.2.3
       typescript: 4.2.3
-    engines:
-      node: ^10.12.0 || >=12.0.0
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    resolution:
-      integrity: sha512-m8I/DKHa8YbeHt31T+UGd/l8Kwr0XCTCZL3H4HMvvLCT7HU9V7yYdinTOv1gf/zfqNeDcCgaFH2BMsS8x6NvJg==
-  /@typescript-eslint/typescript-estree/4.16.1_typescript@4.2.4:
-    dependencies:
-      '@typescript-eslint/types': 4.16.1
-      '@typescript-eslint/visitor-keys': 4.16.1
-      debug: 4.3.1
-      globby: 11.0.3
-      is-glob: 4.0.1
-      semver: 7.3.5
-      tsutils: 3.21.0_typescript@4.2.4
-      typescript: 4.2.4
+    dev: true
     engines:
       node: ^10.12.0 || >=12.0.0
     peerDependencies:
@@ -7785,6 +7535,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 4.16.1
       eslint-visitor-keys: 2.0.0
+    dev: true
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     resolution:
@@ -8332,6 +8083,15 @@ packages:
       normalize-path: 2.1.1
     resolution:
       integrity: sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==
+  /anymatch/3.1.1:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.2.2
+    dev: false
+    engines:
+      node: '>= 8'
+    resolution:
+      integrity: sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==
   /anymatch/3.1.2:
     dependencies:
       normalize-path: 3.0.0
@@ -8569,7 +8329,7 @@ packages:
       integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
   /async/2.6.3:
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.17.20
     dev: false
     resolution:
       integrity: sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
@@ -8656,16 +8416,15 @@ packages:
       eslint: '>= 4.12.1'
     resolution:
       integrity: sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==
-  /babel-eslint/10.1.0_eslint@7.19.0:
+  /babel-eslint/10.1.0_eslint@7.17.0:
     dependencies:
-      '@babel/code-frame': 7.12.13
-      '@babel/parser': 7.13.16
-      '@babel/traverse': 7.13.17
-      '@babel/types': 7.13.17
-      eslint: 7.19.0
+      '@babel/code-frame': 7.12.11
+      '@babel/parser': 7.12.11
+      '@babel/traverse': 7.12.12
+      '@babel/types': 7.12.12
+      eslint: 7.17.0
       eslint-visitor-keys: 1.3.0
-      resolve: 1.20.0
-    deprecated: babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.
+      resolve: 1.19.0
     dev: false
     engines:
       node: '>=6'
@@ -8720,11 +8479,11 @@ packages:
       '@babel/core': 7.12.10
       '@jest/transform': 26.6.2
       '@jest/types': 26.6.2
-      '@types/babel__core': 7.1.14
+      '@types/babel__core': 7.1.12
       babel-plugin-istanbul: 6.0.0
       babel-preset-jest: 26.6.2_@babel+core@7.12.10
-      chalk: 4.1.1
-      graceful-fs: 4.2.6
+      chalk: 4.1.0
+      graceful-fs: 4.2.4
       slash: 3.0.0
     engines:
       node: '>= 10.14.2'
@@ -8737,11 +8496,11 @@ packages:
       '@babel/core': 7.12.3
       '@jest/transform': 26.6.2
       '@jest/types': 26.6.2
-      '@types/babel__core': 7.1.14
+      '@types/babel__core': 7.1.12
       babel-plugin-istanbul: 6.0.0
       babel-preset-jest: 26.6.2_@babel+core@7.12.3
-      chalk: 4.1.1
-      graceful-fs: 4.2.6
+      chalk: 4.1.0
+      graceful-fs: 4.2.4
       slash: 3.0.0
     dev: false
     engines:
@@ -8831,9 +8590,9 @@ packages:
       integrity: sha512-PO9t0697lNTmcEHH69mdtYiOIkkOlj9fySqfO3K1eCcdISevLAE0xY59VLLUj0SoiPiTX/JU2CYFpILydUa5Lw==
   /babel-plugin-macros/2.8.0:
     dependencies:
-      '@babel/runtime': 7.12.5
+      '@babel/runtime': 7.9.0
       cosmiconfig: 6.0.0
-      resolve: 1.20.0
+      resolve: 1.15.0
     dev: false
     resolution:
       integrity: sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==
@@ -8879,10 +8638,10 @@ packages:
       integrity: sha512-FEiD7l5ZABdJPpLssKXjBUJMYqzbcNzBowfXDCdJhOpbhWiewapUaY+LZGT8R4Jg2TwOjGjG4RKeyrO5p9sBkA==
   /babel-plugin-styled-components/1.12.0_styled-components@5.2.3:
     dependencies:
-      '@babel/helper-annotate-as-pure': 7.12.13
-      '@babel/helper-module-imports': 7.13.12
+      '@babel/helper-annotate-as-pure': 7.12.10
+      '@babel/helper-module-imports': 7.12.5
       babel-plugin-syntax-jsx: 6.18.0
-      lodash: 4.17.21
+      lodash: 4.17.20
       styled-components: 5.2.3_react-dom@17.0.1+react@17.0.1
     dev: false
     peerDependencies:
@@ -9051,7 +8810,6 @@ packages:
     resolution:
       integrity: sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==
   /balanced-match/1.0.0:
-    dev: true
     resolution:
       integrity: sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
   /balanced-match/1.0.2:
@@ -9398,7 +9156,7 @@ packages:
       chownr: 1.1.4
       figgy-pudding: 3.5.2
       glob: 7.1.6
-      graceful-fs: 4.2.6
+      graceful-fs: 4.2.4
       infer-owner: 1.0.4
       lru-cache: 5.1.1
       mississippi: 3.0.0
@@ -9408,7 +9166,7 @@ packages:
       rimraf: 2.7.1
       ssri: 6.0.1
       unique-filename: 1.1.1
-      y18n: 4.0.3
+      y18n: 4.0.1
     dev: false
     resolution:
       integrity: sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==
@@ -9555,8 +9313,8 @@ packages:
       integrity: sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
   /caniuse-api/3.0.0:
     dependencies:
-      browserslist: 4.16.5
-      caniuse-lite: 1.0.30001218
+      browserslist: 4.16.1
+      caniuse-lite: 1.0.30001174
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
     dev: false
@@ -9694,7 +9452,7 @@ packages:
       integrity: sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==
   /chokidar/3.5.0:
     dependencies:
-      anymatch: 3.1.2
+      anymatch: 3.1.1
       braces: 3.0.2
       glob-parent: 5.1.1
       is-binary-path: 2.1.0
@@ -9705,7 +9463,7 @@ packages:
     engines:
       node: '>= 8.10.0'
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.1
     resolution:
       integrity: sha512-JgQM9JS92ZbFR4P90EvmzNpSGhpPBGBSj10PILeDyYFwp4h2/D9OM03wsJ4zW1fEp4ka2DGrnUeD7FuvQ2aZ2Q==
   /chownr/1.1.4:
@@ -10065,7 +9823,7 @@ packages:
   /compress-commons/4.1.0:
     dependencies:
       buffer-crc32: 0.2.13
-      crc32-stream: 4.0.2
+      crc32-stream: 4.0.1
       normalize-path: 3.0.0
       readable-stream: 3.6.0
     dev: false
@@ -10075,7 +9833,7 @@ packages:
       integrity: sha512-ofaaLqfraD1YRTkrRKPCrGJ1pFeDG/MVCkVVV2FNGeWquSlqw5wOrwOfPQ1xF2u+blpeWASie5EubHz+vsNIgA==
   /compressible/2.0.18:
     dependencies:
-      mime-db: 1.47.0
+      mime-db: 1.45.0
     dev: false
     engines:
       node: '>= 0.6'
@@ -10189,7 +9947,7 @@ packages:
       integrity: sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
   /core-js-compat/3.8.2:
     dependencies:
-      browserslist: 4.16.5
+      browserslist: 4.16.1
       semver: 7.0.0
     dev: false
     resolution:
@@ -10199,17 +9957,12 @@ packages:
     resolution:
       integrity: sha512-v6zfIQqL/pzTVAbZvYUozsxNfxcFb6Ks3ZfEbuneJl3FW9Jb8F6vLWB6f+qTmAu72msUdyb84V8d/yBFf7FNnw==
   /core-js/2.6.12:
-    deprecated: core-js@<3.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.
+    deprecated: core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.
     dev: false
     requiresBuild: true
     resolution:
       integrity: sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
-  /core-js/3.11.1:
-    requiresBuild: true
-    resolution:
-      integrity: sha512-k93Isqg7e4txZWMGNYwevZL9MiogLk8pd1PtwrmFmi8IBq4GXqUaVW/a33Llt6amSI36uSjd0GWwc9pTT9ALlQ==
   /core-js/3.8.2:
-    dev: false
     requiresBuild: true
     resolution:
       integrity: sha512-FfApuSRgrR6G5s58casCBd9M2k+4ikuu4wbW6pJyYU7bd9zvFc9qf7vr5xmrZOhT9nn+8uwlH1oRR9jTnFoA3A==
@@ -10230,7 +9983,7 @@ packages:
     dependencies:
       '@types/parse-json': 4.0.0
       import-fresh: 3.3.0
-      parse-json: 5.2.0
+      parse-json: 5.1.0
       path-type: 4.0.0
       yaml: 1.10.0
     dev: false
@@ -10281,15 +10034,6 @@ packages:
       node: '>= 10'
     resolution:
       integrity: sha512-FN5V+weeO/8JaXsamelVYO1PHyeCsuL3HcG4cqsj0ceARcocxalaShCsohZMSAF+db7UYFwBy1rARK/0oFItUw==
-  /crc32-stream/4.0.2:
-    dependencies:
-      crc-32: 1.2.0
-      readable-stream: 3.6.0
-    dev: false
-    engines:
-      node: '>= 10'
-    resolution:
-      integrity: sha512-DxFZ/Hk473b/muq1VJ///PMNLj0ZMnzye9thBpmjpJKCc5eMgB95aK8zCGrGfQ90cWo561Te6HK9D+j4KPdM6w==
   /create-ecdh/4.0.4:
     dependencies:
       bn.js: 4.11.9
@@ -10321,11 +10065,11 @@ packages:
   /create-require/1.1.1:
     resolution:
       integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
-  /cross-fetch/3.1.4:
+  /cross-fetch/3.0.6:
     dependencies:
       node-fetch: 2.6.1
     resolution:
-      integrity: sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==
+      integrity: sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==
   /cross-spawn/6.0.5:
     dependencies:
       nice-try: 1.0.5
@@ -10451,7 +10195,7 @@ packages:
       postcss-modules-values: 3.0.0
       postcss-value-parser: 4.1.0
       schema-utils: 2.7.1
-      semver: 7.3.5
+      semver: 7.3.4
       webpack: 4.44.2
     dev: false
     engines:
@@ -10672,9 +10416,6 @@ packages:
   /csstype/3.0.6:
     resolution:
       integrity: sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw==
-  /csstype/3.0.8:
-    resolution:
-      integrity: sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==
   /csv-writer/1.6.0:
     dev: false
     resolution:
@@ -11318,7 +11059,7 @@ packages:
       integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   /enhanced-resolve/4.5.0:
     dependencies:
-      graceful-fs: 4.2.6
+      graceful-fs: 4.2.4
       memory-fs: 0.5.0
       tapable: 1.1.3
     dev: false
@@ -11475,7 +11216,7 @@ packages:
     dependencies:
       confusing-browser-globals: 1.0.10
       eslint: 7.17.0
-      eslint-plugin-import: 2.22.1_eslint@7.17.0+typescript@4.2.4
+      eslint-plugin-import: 2.22.1_eslint@7.17.0+typescript@4.2.3
       object.assign: 4.1.2
       object.entries: 1.1.3
     dev: true
@@ -11505,7 +11246,7 @@ packages:
     dependencies:
       eslint: 7.17.0
       eslint-config-airbnb-base: 13.2.0_860e0a3f1402db18f3476b9d86a8ac51
-      eslint-plugin-import: 2.22.1_eslint@7.17.0+typescript@4.2.4
+      eslint-plugin-import: 2.22.1_eslint@7.17.0+typescript@4.2.3
       eslint-plugin-jsx-a11y: 6.4.1_eslint@7.17.0
       eslint-plugin-react: 7.22.0_eslint@7.17.0
       object.assign: 4.1.2
@@ -11620,12 +11361,12 @@ packages:
       integrity: sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==
   /eslint-config-react-app/5.2.1_722dc2f2a0935393abb1a95f828e9840:
     dependencies:
-      '@typescript-eslint/eslint-plugin': 4.16.1_73e2bd13a8b35a69cfb92e9563939b3f
-      '@typescript-eslint/parser': 4.16.1_eslint@7.17.0+typescript@4.2.4
+      '@typescript-eslint/eslint-plugin': 4.16.1_a4e9925a57f7bf9df758cdf52b1a7795
+      '@typescript-eslint/parser': 4.16.1_eslint@7.17.0+typescript@4.2.3
       confusing-browser-globals: 1.0.10
       eslint: 7.17.0
       eslint-plugin-flowtype: 5.2.0_eslint@7.17.0
-      eslint-plugin-import: 2.22.1_eslint@7.17.0+typescript@4.2.4
+      eslint-plugin-import: 2.22.1_eslint@7.17.0+typescript@4.2.3
       eslint-plugin-jsx-a11y: 6.4.1_eslint@7.17.0
       eslint-plugin-react: 7.22.0_eslint@7.17.0
       eslint-plugin-react-hooks: 4.2.0_eslint@7.17.0
@@ -11691,20 +11432,20 @@ packages:
       eslint-plugin-react-hooks: 1.x || 2.x
     resolution:
       integrity: sha512-pGIZ8t0mFLcV+6ZirRgYK6RVqUIKRIi9MmgzUEmrIknsn3AdO0I32asO86dJgloHq+9ZPl8UIg8mYrvgP5u2wQ==
-  /eslint-config-react-app/6.0.0_358978944c0066569aff6b737b791288:
+  /eslint-config-react-app/6.0.0_99e1c64aae30be736f1e64f5f43b0ebd:
     dependencies:
-      '@typescript-eslint/eslint-plugin': 4.16.1_4b7c75eac308ba454583af097e0ad94d
-      '@typescript-eslint/parser': 4.16.1_eslint@7.19.0+typescript@4.2.4
-      babel-eslint: 10.1.0_eslint@7.19.0
+      '@typescript-eslint/eslint-plugin': 4.13.0_8020b167ee7d7f543c2fef182c50aa77
+      '@typescript-eslint/parser': 4.13.0_eslint@7.17.0+typescript@4.2.3
+      babel-eslint: 10.1.0_eslint@7.17.0
       confusing-browser-globals: 1.0.10
-      eslint: 7.19.0
-      eslint-plugin-flowtype: 5.2.0_eslint@7.19.0
-      eslint-plugin-import: 2.22.1_eslint@7.19.0+typescript@4.2.4
-      eslint-plugin-jest: 24.1.3_eslint@7.19.0+typescript@4.2.4
-      eslint-plugin-jsx-a11y: 6.4.1_eslint@7.19.0
-      eslint-plugin-react: 7.22.0_eslint@7.19.0
-      eslint-plugin-react-hooks: 4.2.0_eslint@7.19.0
-      eslint-plugin-testing-library: 3.10.1_eslint@7.19.0+typescript@4.2.4
+      eslint: 7.17.0
+      eslint-plugin-flowtype: 5.2.0_eslint@7.17.0
+      eslint-plugin-import: 2.22.1_eslint@7.17.0+typescript@4.2.3
+      eslint-plugin-jest: 24.1.3_eslint@7.17.0+typescript@4.2.3
+      eslint-plugin-jsx-a11y: 6.4.1_eslint@7.17.0
+      eslint-plugin-react: 7.22.0_eslint@7.17.0
+      eslint-plugin-react-hooks: 4.2.0_eslint@7.17.0
+      eslint-plugin-testing-library: 3.10.1_eslint@7.17.0+typescript@4.2.3
     dev: false
     engines:
       node: ^10.12.0 || >=12.0.0
@@ -11769,7 +11510,6 @@ packages:
       '@typescript-eslint/parser': 4.13.0_eslint@7.17.0+typescript@4.2.3
       debug: 2.6.9
       pkg-dir: 2.0.0
-    dev: true
     engines:
       node: '>=4'
     peerDependencies:
@@ -11782,7 +11522,7 @@ packages:
       '@typescript-eslint/parser': 4.13.0_eslint@7.17.0+typescript@4.2.4
       debug: 2.6.9
       pkg-dir: 2.0.0
-    dev: true
+    dev: false
     engines:
       node: '>=4'
     peerDependencies:
@@ -11795,19 +11535,7 @@ packages:
       '@typescript-eslint/parser': 4.13.0_eslint@7.19.0+typescript@4.2.3
       debug: 2.6.9
       pkg-dir: 2.0.0
-    engines:
-      node: '>=4'
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    resolution:
-      integrity: sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==
-  /eslint-module-utils/2.6.0_eslint@7.19.0+typescript@4.2.4:
-    dependencies:
-      '@typescript-eslint/parser': 4.13.0_eslint@7.19.0+typescript@4.2.4
-      debug: 2.6.9
-      pkg-dir: 2.0.0
-    dev: false
+    dev: true
     engines:
       node: '>=4'
     peerDependencies:
@@ -11874,19 +11602,6 @@ packages:
       eslint: 7.17.0
       lodash: 4.17.20
       string-natural-compare: 3.0.1
-    dev: true
-    engines:
-      node: ^10.12.0 || >=12.0.0
-    peerDependencies:
-      eslint: ^7.1.0
-    resolution:
-      integrity: sha512-z7ULdTxuhlRJcEe1MVljePXricuPOrsWfScRXFhNzVD5dmTHWjIF57AxD0e7AbEoLSbjSsaA5S+hCg43WvpXJQ==
-  /eslint-plugin-flowtype/5.2.0_eslint@7.19.0:
-    dependencies:
-      eslint: 7.19.0
-      lodash: 4.17.20
-      string-natural-compare: 3.0.1
-    dev: false
     engines:
       node: ^10.12.0 || >=12.0.0
     peerDependencies:
@@ -11944,7 +11659,6 @@ packages:
       read-pkg-up: 2.0.0
       resolve: 1.19.0
       tsconfig-paths: 3.9.0
-    dev: true
     engines:
       node: '>=4'
     peerDependencies:
@@ -11968,7 +11682,7 @@ packages:
       read-pkg-up: 2.0.0
       resolve: 1.19.0
       tsconfig-paths: 3.9.0
-    dev: true
+    dev: false
     engines:
       node: '>=4'
     peerDependencies:
@@ -11992,30 +11706,7 @@ packages:
       read-pkg-up: 2.0.0
       resolve: 1.19.0
       tsconfig-paths: 3.9.0
-    engines:
-      node: '>=4'
-    peerDependencies:
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0
-      typescript: '*'
-    resolution:
-      integrity: sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==
-  /eslint-plugin-import/2.22.1_eslint@7.19.0+typescript@4.2.4:
-    dependencies:
-      array-includes: 3.1.2
-      array.prototype.flat: 1.2.4
-      contains-path: 0.1.0
-      debug: 2.6.9
-      doctrine: 1.5.0
-      eslint: 7.19.0
-      eslint-import-resolver-node: 0.3.4
-      eslint-module-utils: 2.6.0_eslint@7.19.0+typescript@4.2.4
-      has: 1.0.3
-      minimatch: 3.0.4
-      object.values: 1.1.2
-      read-pkg-up: 2.0.0
-      resolve: 1.19.0
-      tsconfig-paths: 3.9.0
-    dev: false
+    dev: true
     engines:
       node: '>=4'
     peerDependencies:
@@ -12047,9 +11738,9 @@ packages:
       typescript: '*'
     resolution:
       integrity: sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==
-  /eslint-plugin-jest/23.20.0_eslint@7.17.0+typescript@4.2.4:
+  /eslint-plugin-jest/23.20.0_eslint@7.17.0+typescript@4.2.3:
     dependencies:
-      '@typescript-eslint/experimental-utils': 2.34.0_eslint@7.17.0+typescript@4.2.4
+      '@typescript-eslint/experimental-utils': 2.34.0_eslint@7.17.0+typescript@4.2.3
       eslint: 7.17.0
     dev: true
     engines:
@@ -12075,7 +11766,6 @@ packages:
     dependencies:
       '@typescript-eslint/experimental-utils': 4.13.0_eslint@7.17.0+typescript@4.2.3
       eslint: 7.17.0
-    dev: true
     engines:
       node: '>=10'
     peerDependencies:
@@ -12083,22 +11773,10 @@ packages:
       typescript: '*'
     resolution:
       integrity: sha512-dNGGjzuEzCE3d5EPZQ/QGtmlMotqnYWD/QpCZ1UuZlrMAdhG5rldh0N0haCvhGnUkSeuORS5VNROwF9Hrgn3Lg==
-  /eslint-plugin-jest/24.1.3_eslint@7.19.0+typescript@4.2.3:
+  /eslint-plugin-jest/24.1.3_eslint@7.17.0+typescript@4.2.4:
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.13.0_eslint@7.19.0+typescript@4.2.3
-      eslint: 7.19.0
-    dev: false
-    engines:
-      node: '>=10'
-    peerDependencies:
-      eslint: '>=5'
-      typescript: '*'
-    resolution:
-      integrity: sha512-dNGGjzuEzCE3d5EPZQ/QGtmlMotqnYWD/QpCZ1UuZlrMAdhG5rldh0N0haCvhGnUkSeuORS5VNROwF9Hrgn3Lg==
-  /eslint-plugin-jest/24.1.3_eslint@7.19.0+typescript@4.2.4:
-    dependencies:
-      '@typescript-eslint/experimental-utils': 4.13.0_eslint@7.19.0+typescript@4.2.4
-      eslint: 7.19.0
+      '@typescript-eslint/experimental-utils': 4.13.0_eslint@7.17.0+typescript@4.2.4
+      eslint: 7.17.0
     dev: false
     engines:
       node: '>=10'
@@ -12140,28 +11818,6 @@ packages:
       has: 1.0.3
       jsx-ast-utils: 3.2.0
       language-tags: 1.0.5
-    dev: true
-    engines:
-      node: '>=4.0'
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7
-    resolution:
-      integrity: sha512-0rGPJBbwHoGNPU73/QCLP/vveMlM1b1Z9PponxO87jfr6tuH5ligXbDT6nHSSzBC8ovX2Z+BQu7Bk5D/Xgq9zg==
-  /eslint-plugin-jsx-a11y/6.4.1_eslint@7.19.0:
-    dependencies:
-      '@babel/runtime': 7.12.5
-      aria-query: 4.2.2
-      array-includes: 3.1.2
-      ast-types-flow: 0.0.7
-      axe-core: 4.1.1
-      axobject-query: 2.2.0
-      damerau-levenshtein: 1.0.6
-      emoji-regex: 9.2.0
-      eslint: 7.19.0
-      has: 1.0.3
-      jsx-ast-utils: 3.2.0
-      language-tags: 1.0.5
-    dev: false
     engines:
       node: '>=4.0'
     peerDependencies:
@@ -12306,17 +11962,6 @@ packages:
   /eslint-plugin-react-hooks/4.2.0_eslint@7.17.0:
     dependencies:
       eslint: 7.17.0
-    dev: true
-    engines:
-      node: '>=10'
-    peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
-    resolution:
-      integrity: sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==
-  /eslint-plugin-react-hooks/4.2.0_eslint@7.19.0:
-    dependencies:
-      eslint: 7.19.0
-    dev: false
     engines:
       node: '>=10'
     peerDependencies:
@@ -12366,28 +12011,6 @@ packages:
       prop-types: 15.7.2
       resolve: 1.19.0
       string.prototype.matchall: 4.0.3
-    dev: true
-    engines:
-      node: '>=4'
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7
-    resolution:
-      integrity: sha512-p30tuX3VS+NWv9nQot9xIGAHBXR0+xJVaZriEsHoJrASGCJZDJ8JLNM0YqKqI0AKm6Uxaa1VUHoNEibxRCMQHA==
-  /eslint-plugin-react/7.22.0_eslint@7.19.0:
-    dependencies:
-      array-includes: 3.1.2
-      array.prototype.flatmap: 1.2.4
-      doctrine: 2.1.0
-      eslint: 7.19.0
-      has: 1.0.3
-      jsx-ast-utils: 3.2.0
-      object.entries: 1.1.3
-      object.fromentries: 2.0.3
-      object.values: 1.1.2
-      prop-types: 15.7.2
-      resolve: 1.19.0
-      string.prototype.matchall: 4.0.3
-    dev: false
     engines:
       node: '>=4'
     peerDependencies:
@@ -12415,10 +12038,10 @@ packages:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7
     resolution:
       integrity: sha512-p30tuX3VS+NWv9nQot9xIGAHBXR0+xJVaZriEsHoJrASGCJZDJ8JLNM0YqKqI0AKm6Uxaa1VUHoNEibxRCMQHA==
-  /eslint-plugin-testing-library/3.10.1_eslint@7.19.0+typescript@4.2.3:
+  /eslint-plugin-testing-library/3.10.1_eslint@7.17.0+typescript@4.2.3:
     dependencies:
-      '@typescript-eslint/experimental-utils': 3.10.1_eslint@7.19.0+typescript@4.2.3
-      eslint: 7.19.0
+      '@typescript-eslint/experimental-utils': 3.10.1_eslint@7.17.0+typescript@4.2.3
+      eslint: 7.17.0
     dev: false
     engines:
       node: ^10.12.0 || >=12.0.0
@@ -12428,10 +12051,10 @@ packages:
       typescript: '*'
     resolution:
       integrity: sha512-nQIFe2muIFv2oR2zIuXE4vTbcFNx8hZKRzgHZqJg8rfopIWwoTwtlbCCNELT/jXzVe1uZF68ALGYoDXjLczKiQ==
-  /eslint-plugin-testing-library/3.10.1_eslint@7.19.0+typescript@4.2.4:
+  /eslint-plugin-testing-library/3.10.1_eslint@7.17.0+typescript@4.2.4:
     dependencies:
-      '@typescript-eslint/experimental-utils': 3.10.1_eslint@7.19.0+typescript@4.2.4
-      eslint: 7.19.0
+      '@typescript-eslint/experimental-utils': 3.10.1_eslint@7.17.0+typescript@4.2.4
+      eslint: 7.17.0
     dev: false
     engines:
       node: ^10.12.0 || >=12.0.0
@@ -12495,13 +12118,13 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
-  /eslint-webpack-plugin/2.4.1_eslint@7.19.0+webpack@4.44.2:
+  /eslint-webpack-plugin/2.4.1_eslint@7.17.0+webpack@4.44.2:
     dependencies:
       '@types/eslint': 7.2.6
       arrify: 2.0.1
-      eslint: 7.19.0
+      eslint: 7.17.0
       jest-worker: 26.6.2
-      micromatch: 4.0.4
+      micromatch: 4.0.2
       schema-utils: 3.0.0
       webpack: 4.44.2
     dev: false
@@ -12596,7 +12219,6 @@ packages:
       table: 6.0.7
       text-table: 0.2.0
       v8-compile-cache: 2.2.0
-    dev: true
     engines:
       node: ^10.12.0 || >=12.0.0
     hasBin: true
@@ -12641,6 +12263,7 @@ packages:
       table: 6.0.7
       text-table: 0.2.0
       v8-compile-cache: 2.2.0
+    dev: true
     engines:
       node: ^10.12.0 || >=12.0.0
     hasBin: true
@@ -12726,6 +12349,7 @@ packages:
   /esquery/1.4.0:
     dependencies:
       estraverse: 5.2.0
+    dev: true
     engines:
       node: '>=0.10'
     resolution:
@@ -13133,16 +12757,16 @@ packages:
       integrity: sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
   /fetch-mock/9.11.0:
     dependencies:
-      '@babel/core': 7.13.16
+      '@babel/core': 7.12.10
       '@babel/runtime': 7.12.5
-      core-js: 3.11.1
+      core-js: 3.8.2
       debug: 4.3.1
       glob-to-regexp: 0.4.1
       is-subset: 0.1.1
       lodash.isequal: 4.5.0
       node-fetch: 2.6.1
       path-to-regexp: 2.4.0
-      querystring: 0.2.1
+      querystring: 0.2.0
       whatwg-url: 6.5.0
     engines:
       node: '>=4.0.0'
@@ -13541,7 +13165,7 @@ packages:
       integrity: sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==
   /fs-extra/7.0.1:
     dependencies:
-      graceful-fs: 4.2.6
+      graceful-fs: 4.2.4
       jsonfile: 4.0.0
       universalify: 0.1.2
     dev: false
@@ -13551,7 +13175,7 @@ packages:
       integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
   /fs-extra/8.1.0:
     dependencies:
-      graceful-fs: 4.2.6
+      graceful-fs: 4.2.4
       jsonfile: 4.0.0
       universalify: 0.1.2
     engines:
@@ -13585,7 +13209,7 @@ packages:
       integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
   /fs-write-stream-atomic/1.0.10:
     dependencies:
-      graceful-fs: 4.2.6
+      graceful-fs: 4.2.4
       iferr: 0.1.5
       imurmurhash: 0.1.4
       readable-stream: 2.3.7
@@ -13619,6 +13243,15 @@ packages:
       - darwin
     resolution:
       integrity: sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==
+  /fsevents/2.3.1:
+    dev: false
+    engines:
+      node: ^8.16.0 || ^10.6.0 || >=11.0.0
+    optional: true
+    os:
+      - darwin
+    resolution:
+      integrity: sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==
   /fsevents/2.3.2:
     engines:
       node: ^8.16.0 || ^10.6.0 || >=11.0.0
@@ -13866,6 +13499,7 @@ packages:
       ignore: 5.1.8
       merge2: 1.4.1
       slash: 3.0.0
+    dev: true
     engines:
       node: '>=10'
     resolution:
@@ -14174,7 +13808,7 @@ packages:
       '@types/webpack': 4.41.26
       html-minifier-terser: 5.1.1
       loader-utils: 1.4.0
-      lodash: 4.17.21
+      lodash: 4.17.20
       pretty-error: 2.1.2
       tapable: 1.1.3
       util.promisify: 1.0.0
@@ -14243,7 +13877,7 @@ packages:
     dependencies:
       http-proxy: 1.18.1_debug@4.3.1
       is-glob: 4.0.1
-      lodash: 4.17.21
+      lodash: 4.17.20
       micromatch: 3.1.10
     dev: false
     engines:
@@ -14403,7 +14037,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg==
+  /immer/7.0.9:
+    dev: false
+    resolution:
+      integrity: sha512-Vs/gxoM4DqNAYR7pugIxi0Xc8XAun/uy7AQu4fLLqaTBHxjOP9pJ266Q9MWA/ly4z6rAFZbvViOtihxUZ7O28A==
   /immer/8.0.1:
+    dev: true
     resolution:
       integrity: sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
   /import-cwd/2.1.0:
@@ -15180,13 +14819,13 @@ packages:
       integrity: sha512-fDS7szLcY9sCtIip8Fjry9oGf3I2ht/QT21bAHm5Dmf0mD4X3ReNUf17y+bO6fR8WgbIZTlbyG1ak/53cbRzKQ==
   /jest-circus/26.6.0:
     dependencies:
-      '@babel/traverse': 7.13.17
+      '@babel/traverse': 7.12.12
       '@jest/environment': 26.6.2
       '@jest/test-result': 26.6.2
       '@jest/types': 26.6.2
-      '@types/babel__traverse': 7.11.1
-      '@types/node': 15.0.1
-      chalk: 4.1.1
+      '@types/babel__traverse': 7.11.0
+      '@types/node': 14.14.20
+      chalk: 4.1.0
       co: 4.6.0
       dedent: 0.7.0
       expect: 26.6.2
@@ -15629,7 +15268,7 @@ packages:
       integrity: sha512-zhtMio3Exty18dy8ee8eJ9kjnRyZC1N4C1Nt/VShN1apyXc8rWGtJ9lI7vqiWcyyXS4BVSEn9lxAM2D+07/Tag==
   /jest-fetch-mock/3.0.3:
     dependencies:
-      cross-fetch: 3.1.4
+      cross-fetch: 3.0.6
       promise-polyfill: 8.2.0
     resolution:
       integrity: sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
@@ -16010,12 +15649,12 @@ packages:
   /jest-resolve/26.6.0:
     dependencies:
       '@jest/types': 26.6.2
-      chalk: 4.1.1
-      graceful-fs: 4.2.6
+      chalk: 4.1.0
+      graceful-fs: 4.2.4
       jest-pnp-resolver: 1.2.2_jest-resolve@26.6.0
       jest-util: 26.6.2
       read-pkg-up: 7.0.1
-      resolve: 1.20.0
+      resolve: 1.19.0
       slash: 3.0.0
     dev: false
     engines:
@@ -16903,7 +16542,7 @@ packages:
       integrity: sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
   /jsonfile/4.0.0:
     optionalDependencies:
-      graceful-fs: 4.2.6
+      graceful-fs: 4.2.4
     resolution:
       integrity: sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
   /jsonfile/6.1.0:
@@ -17004,7 +16643,7 @@ packages:
       integrity: sha1-0yHbxNowuovzAk4ED6XBRmH5GTo=
   /last-call-webpack-plugin/3.0.0:
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.17.20
       webpack-sources: 1.4.3
     dev: false
     resolution:
@@ -18524,6 +18163,7 @@ packages:
     dependencies:
       is-docker: 2.1.1
       is-wsl: 2.2.0
+    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -19179,9 +18819,9 @@ packages:
     dev: false
     resolution:
       integrity: sha512-clkFxk/9pcdb4Vkn0hAHq3YnxBQ2p0CGD1dy24jN+reBck+EWxMbxSUqN4Yj7t0w8csl87K6p0gxBe1utkJsYA==
-  /postcss-browser-comments/3.0.0_browserslist@4.16.5:
+  /postcss-browser-comments/3.0.0_browserslist@4.16.1:
     dependencies:
-      browserslist: 4.16.5
+      browserslist: 4.16.1
       postcss: 7.0.35
     dev: false
     engines:
@@ -19247,7 +18887,7 @@ packages:
       integrity: sha512-aAe3OhkS6qJXBbqzvZth2Au4V3KieR5sRQ4ptb2b2O8wgvB3SJBsdG+jsn2BZbbwekDG8nTfcCNKcSfe/lEy8g==
   /postcss-colormin/4.0.3:
     dependencies:
-      browserslist: 4.16.5
+      browserslist: 4.16.1
       color: 3.1.3
       has: 1.0.3
       postcss: 7.0.35
@@ -19491,7 +19131,7 @@ packages:
       integrity: sha512-alx/zmoeXvJjp7L4mxEMjh8lxVlDFX1gqWHzaaQewwMZiVhLo42TEClKaeHbRf6J7j82ZOdTJ808RtN0ZOZwvw==
   /postcss-merge-rules/4.0.3:
     dependencies:
-      browserslist: 4.16.5
+      browserslist: 4.16.1
       caniuse-api: 3.0.0
       cssnano-util-same-parent: 4.0.1
       postcss: 7.0.35
@@ -19525,7 +19165,7 @@ packages:
   /postcss-minify-params/4.0.2:
     dependencies:
       alphanum-sort: 1.0.2
-      browserslist: 4.16.5
+      browserslist: 4.16.1
       cssnano-util-get-arguments: 4.0.0
       postcss: 7.0.35
       postcss-value-parser: 3.3.1
@@ -19651,7 +19291,7 @@ packages:
       integrity: sha512-acwJY95edP762e++00Ehq9L4sZCEcOPyaHwoaFOhIwWCDfik6YvqsYNxckee65JHLKzuNSSmAdxwD2Cud1Z54A==
   /postcss-normalize-unicode/4.0.1:
     dependencies:
-      browserslist: 4.16.5
+      browserslist: 4.16.1
       postcss: 7.0.35
       postcss-value-parser: 3.3.1
     dev: false
@@ -19682,9 +19322,9 @@ packages:
   /postcss-normalize/8.0.1:
     dependencies:
       '@csstools/normalize.css': 10.1.0
-      browserslist: 4.16.5
+      browserslist: 4.16.1
       postcss: 7.0.35
-      postcss-browser-comments: 3.0.0_browserslist@4.16.5
+      postcss-browser-comments: 3.0.0_browserslist@4.16.1
       sanitize.css: 10.0.0
     dev: false
     engines:
@@ -19727,8 +19367,8 @@ packages:
   /postcss-preset-env/6.7.0:
     dependencies:
       autoprefixer: 9.8.6
-      browserslist: 4.16.5
-      caniuse-lite: 1.0.30001218
+      browserslist: 4.16.1
+      caniuse-lite: 1.0.30001174
       css-blank-pseudo: 0.1.4
       css-has-pseudo: 0.10.0
       css-prefers-color-scheme: 3.1.1
@@ -19779,7 +19419,7 @@ packages:
       integrity: sha512-lgXW9sYJdLqtmw23otOzrtbDXofUdfYzNm4PIpNE322/swES3VU9XlXHeJS46zT2onFO7V1QFdD4Q9LiZj8mew==
   /postcss-reduce-initial/4.0.3:
     dependencies:
-      browserslist: 4.16.5
+      browserslist: 4.16.1
       caniuse-api: 3.0.0
       has: 1.0.3
       postcss: 7.0.35
@@ -19850,14 +19490,14 @@ packages:
       integrity: sha512-jQmGnj0hSGLd9RscFw9LyuSVAa5Bl1/KBPqG1NQw9w8ND55nY4ZEsdlVuYJvLPpV+y0nwTV5v/4rHPzZRihQbA==
   /postcss-selector-matches/4.0.0:
     dependencies:
-      balanced-match: 1.0.2
+      balanced-match: 1.0.0
       postcss: 7.0.35
     dev: false
     resolution:
       integrity: sha512-LgsHwQR/EsRYSqlwdGzeaPKVT0Ml7LAT6E75T8W8xLJY62CE4S/l03BWIt3jT8Taq22kXP08s2SfTSzaraoPww==
   /postcss-selector-not/4.0.1:
     dependencies:
-      balanced-match: 1.0.2
+      balanced-match: 1.0.0
       postcss: 7.0.35
     dev: false
     resolution:
@@ -19977,7 +19617,7 @@ packages:
       integrity: sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==
   /postcss/8.2.4:
     dependencies:
-      colorette: 1.2.2
+      colorette: 1.2.1
       nanoid: 3.1.20
       source-map: 0.6.1
     dev: false
@@ -20022,7 +19662,7 @@ packages:
       integrity: sha512-p+T744ZyjjiaFlMUZZv6YPC5JrkNj8maRmPaQCWFJFplUAzpIUTRaTcS+7wmZtUoFXHtESJb23ISliaWyz3SHA==
   /pretty-error/2.1.2:
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.17.20
       renderkid: 2.0.5
     dev: false
     resolution:
@@ -20227,11 +19867,6 @@ packages:
       node: '>=0.4.x'
     resolution:
       integrity: sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
-  /querystring/0.2.1:
-    engines:
-      node: '>=0.4.x'
-    resolution:
-      integrity: sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==
   /querystringify/2.2.0:
     dev: false
     resolution:
@@ -20356,6 +19991,37 @@ packages:
       node: '>=8.10'
     resolution:
       integrity: sha512-XxTbgJnYZmxuPtY3y/UV0D8/65NKkmaia4rXzViknVnZeVlklSh8u6TnaEYPfAi/Gh1TP4mEOXHI6jQOPbeakQ==
+  /react-dev-utils/11.0.1:
+    dependencies:
+      '@babel/code-frame': 7.10.4
+      address: 1.1.2
+      browserslist: 4.14.2
+      chalk: 2.4.2
+      cross-spawn: 7.0.3
+      detect-port-alt: 1.1.6
+      escape-string-regexp: 2.0.0
+      filesize: 6.1.0
+      find-up: 4.1.0
+      fork-ts-checker-webpack-plugin: 4.1.6
+      global-modules: 2.0.0
+      globby: 11.0.1
+      gzip-size: 5.1.1
+      immer: 7.0.9
+      is-root: 2.1.0
+      loader-utils: 2.0.0
+      open: 7.3.1
+      pkg-up: 3.1.0
+      prompts: 2.4.0
+      react-error-overlay: 6.0.8
+      recursive-readdir: 2.2.2
+      shell-quote: 1.7.2
+      strip-ansi: 6.0.0
+      text-table: 0.2.0
+    dev: false
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-rlgpCupaW6qQqvu0hvv2FDv40QG427fjghV56XyPcP5aKtOAPzNAhQ7bHqk1YdS2vpW1W7aSV3JobedxuPlBAA==
   /react-dev-utils/11.0.3:
     dependencies:
       '@babel/code-frame': 7.10.4
@@ -20382,6 +20048,7 @@ packages:
       shell-quote: 1.7.2
       strip-ansi: 6.0.0
       text-table: 0.2.0
+    dev: true
     engines:
       node: '>=10'
     resolution:
@@ -20415,6 +20082,7 @@ packages:
     resolution:
       integrity: sha512-HvPuUQnLp5H7TouGq3kzBeioJmXms1wHy9EGjz2OURWBp4qZO6AfGEcnxts1D/CbwPLRAgTMPCEgYhA3sEM4vw==
   /react-error-overlay/6.0.9:
+    dev: true
     resolution:
       integrity: sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
   /react-gamepad/1.0.3_react@17.0.1:
@@ -20597,9 +20265,9 @@ packages:
       '@babel/core': 7.12.3
       '@pmmmwh/react-refresh-webpack-plugin': 0.4.2_b3cde47da84a0ce999c5f09efff8d650
       '@svgr/webpack': 5.4.0
-      '@typescript-eslint/eslint-plugin': 4.16.1_8360ec0b6468ab52d7ec43304a9826d1
-      '@typescript-eslint/parser': 4.16.1_eslint@7.19.0+typescript@4.2.3
-      babel-eslint: 10.1.0_eslint@7.19.0
+      '@typescript-eslint/eslint-plugin': 4.13.0_8020b167ee7d7f543c2fef182c50aa77
+      '@typescript-eslint/parser': 4.13.0_eslint@7.17.0+typescript@4.2.3
+      babel-eslint: 10.1.0_eslint@7.17.0
       babel-jest: 26.6.3_@babel+core@7.12.3
       babel-loader: 8.1.0_427212bc1158d185e577033f19ca0757
       babel-plugin-named-asset-import: 0.3.7_@babel+core@7.12.3
@@ -20610,16 +20278,16 @@ packages:
       css-loader: 4.3.0_webpack@4.44.2
       dotenv: 8.2.0
       dotenv-expand: 5.1.0
-      eslint: 7.19.0
-      eslint-config-react-app: 6.0.0_358978944c0066569aff6b737b791288
-      eslint-plugin-flowtype: 5.2.0_eslint@7.19.0
-      eslint-plugin-import: 2.22.1_eslint@7.19.0+typescript@4.2.3
-      eslint-plugin-jest: 24.1.3_eslint@7.19.0+typescript@4.2.3
-      eslint-plugin-jsx-a11y: 6.4.1_eslint@7.19.0
-      eslint-plugin-react: 7.22.0_eslint@7.19.0
-      eslint-plugin-react-hooks: 4.2.0_eslint@7.19.0
-      eslint-plugin-testing-library: 3.10.1_eslint@7.19.0+typescript@4.2.3
-      eslint-webpack-plugin: 2.4.1_eslint@7.19.0+webpack@4.44.2
+      eslint: 7.17.0
+      eslint-config-react-app: 6.0.0_99e1c64aae30be736f1e64f5f43b0ebd
+      eslint-plugin-flowtype: 5.2.0_eslint@7.17.0
+      eslint-plugin-import: 2.22.1_eslint@7.17.0+typescript@4.2.3
+      eslint-plugin-jest: 24.1.3_eslint@7.17.0+typescript@4.2.3
+      eslint-plugin-jsx-a11y: 6.4.1_eslint@7.17.0
+      eslint-plugin-react: 7.22.0_eslint@7.17.0
+      eslint-plugin-react-hooks: 4.2.0_eslint@7.17.0
+      eslint-plugin-testing-library: 3.10.1_eslint@7.17.0+typescript@4.2.3
+      eslint-webpack-plugin: 2.4.1_eslint@7.17.0+webpack@4.44.2
       file-loader: 6.1.1_webpack@4.44.2
       fs-extra: 9.0.1
       html-webpack-plugin: 4.5.0_webpack@4.44.2
@@ -20638,7 +20306,7 @@ packages:
       postcss-safe-parser: 5.0.2
       prompts: 2.4.0
       react-app-polyfill: 2.0.0
-      react-dev-utils: 11.0.3
+      react-dev-utils: 11.0.1
       react-refresh: 0.8.3
       resolve: 1.18.1
       resolve-url-loader: 3.1.2
@@ -20658,7 +20326,7 @@ packages:
       node: ^10.12.0 || >=12.0.0
     hasBin: true
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.1
     peerDependencies:
       type-fest: '*'
       typescript: ^3.2.1
@@ -20672,9 +20340,9 @@ packages:
       '@babel/core': 7.12.3
       '@pmmmwh/react-refresh-webpack-plugin': 0.4.2_d00fcc46a48175a4e289da7534b00e9a
       '@svgr/webpack': 5.4.0
-      '@typescript-eslint/eslint-plugin': 4.16.1_8360ec0b6468ab52d7ec43304a9826d1
-      '@typescript-eslint/parser': 4.16.1_eslint@7.19.0+typescript@4.2.3
-      babel-eslint: 10.1.0_eslint@7.19.0
+      '@typescript-eslint/eslint-plugin': 4.13.0_8020b167ee7d7f543c2fef182c50aa77
+      '@typescript-eslint/parser': 4.13.0_eslint@7.17.0+typescript@4.2.3
+      babel-eslint: 10.1.0_eslint@7.17.0
       babel-jest: 26.6.3_@babel+core@7.12.3
       babel-loader: 8.1.0_427212bc1158d185e577033f19ca0757
       babel-plugin-named-asset-import: 0.3.7_@babel+core@7.12.3
@@ -20685,16 +20353,16 @@ packages:
       css-loader: 4.3.0_webpack@4.44.2
       dotenv: 8.2.0
       dotenv-expand: 5.1.0
-      eslint: 7.19.0
-      eslint-config-react-app: 6.0.0_358978944c0066569aff6b737b791288
-      eslint-plugin-flowtype: 5.2.0_eslint@7.19.0
-      eslint-plugin-import: 2.22.1_eslint@7.19.0+typescript@4.2.3
-      eslint-plugin-jest: 24.1.3_eslint@7.19.0+typescript@4.2.3
-      eslint-plugin-jsx-a11y: 6.4.1_eslint@7.19.0
-      eslint-plugin-react: 7.22.0_eslint@7.19.0
-      eslint-plugin-react-hooks: 4.2.0_eslint@7.19.0
-      eslint-plugin-testing-library: 3.10.1_eslint@7.19.0+typescript@4.2.3
-      eslint-webpack-plugin: 2.4.1_eslint@7.19.0+webpack@4.44.2
+      eslint: 7.17.0
+      eslint-config-react-app: 6.0.0_99e1c64aae30be736f1e64f5f43b0ebd
+      eslint-plugin-flowtype: 5.2.0_eslint@7.17.0
+      eslint-plugin-import: 2.22.1_eslint@7.17.0+typescript@4.2.3
+      eslint-plugin-jest: 24.1.3_eslint@7.17.0+typescript@4.2.3
+      eslint-plugin-jsx-a11y: 6.4.1_eslint@7.17.0
+      eslint-plugin-react: 7.22.0_eslint@7.17.0
+      eslint-plugin-react-hooks: 4.2.0_eslint@7.17.0
+      eslint-plugin-testing-library: 3.10.1_eslint@7.17.0+typescript@4.2.3
+      eslint-webpack-plugin: 2.4.1_eslint@7.17.0+webpack@4.44.2
       file-loader: 6.1.1_webpack@4.44.2
       fs-extra: 9.0.1
       html-webpack-plugin: 4.5.0_webpack@4.44.2
@@ -20713,7 +20381,7 @@ packages:
       postcss-safe-parser: 5.0.2
       prompts: 2.4.0
       react-app-polyfill: 2.0.0
-      react-dev-utils: 11.0.3
+      react-dev-utils: 11.0.1
       react-refresh: 0.8.3
       resolve: 1.18.1
       resolve-url-loader: 3.1.2
@@ -20733,7 +20401,7 @@ packages:
       node: ^10.12.0 || >=12.0.0
     hasBin: true
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.1
     peerDependencies:
       typescript: ^3.2.1
     peerDependenciesMeta:
@@ -20746,9 +20414,9 @@ packages:
       '@babel/core': 7.12.3
       '@pmmmwh/react-refresh-webpack-plugin': 0.4.2_d00fcc46a48175a4e289da7534b00e9a
       '@svgr/webpack': 5.4.0
-      '@typescript-eslint/eslint-plugin': 4.16.1_4b7c75eac308ba454583af097e0ad94d
-      '@typescript-eslint/parser': 4.16.1_eslint@7.19.0+typescript@4.2.4
-      babel-eslint: 10.1.0_eslint@7.19.0
+      '@typescript-eslint/eslint-plugin': 4.13.0_7c35a77949eef03106c52e13aece0106
+      '@typescript-eslint/parser': 4.13.0_eslint@7.17.0+typescript@4.2.4
+      babel-eslint: 10.1.0_eslint@7.17.0
       babel-jest: 26.6.3_@babel+core@7.12.3
       babel-loader: 8.1.0_427212bc1158d185e577033f19ca0757
       babel-plugin-named-asset-import: 0.3.7_@babel+core@7.12.3
@@ -20759,16 +20427,16 @@ packages:
       css-loader: 4.3.0_webpack@4.44.2
       dotenv: 8.2.0
       dotenv-expand: 5.1.0
-      eslint: 7.19.0
-      eslint-config-react-app: 6.0.0_358978944c0066569aff6b737b791288
-      eslint-plugin-flowtype: 5.2.0_eslint@7.19.0
-      eslint-plugin-import: 2.22.1_eslint@7.19.0+typescript@4.2.4
-      eslint-plugin-jest: 24.1.3_eslint@7.19.0+typescript@4.2.4
-      eslint-plugin-jsx-a11y: 6.4.1_eslint@7.19.0
-      eslint-plugin-react: 7.22.0_eslint@7.19.0
-      eslint-plugin-react-hooks: 4.2.0_eslint@7.19.0
-      eslint-plugin-testing-library: 3.10.1_eslint@7.19.0+typescript@4.2.4
-      eslint-webpack-plugin: 2.4.1_eslint@7.19.0+webpack@4.44.2
+      eslint: 7.17.0
+      eslint-config-react-app: 6.0.0_99e1c64aae30be736f1e64f5f43b0ebd
+      eslint-plugin-flowtype: 5.2.0_eslint@7.17.0
+      eslint-plugin-import: 2.22.1_eslint@7.17.0+typescript@4.2.4
+      eslint-plugin-jest: 24.1.3_eslint@7.17.0+typescript@4.2.4
+      eslint-plugin-jsx-a11y: 6.4.1_eslint@7.17.0
+      eslint-plugin-react: 7.22.0_eslint@7.17.0
+      eslint-plugin-react-hooks: 4.2.0_eslint@7.17.0
+      eslint-plugin-testing-library: 3.10.1_eslint@7.17.0+typescript@4.2.4
+      eslint-webpack-plugin: 2.4.1_eslint@7.17.0+webpack@4.44.2
       file-loader: 6.1.1_webpack@4.44.2
       fs-extra: 9.0.1
       html-webpack-plugin: 4.5.0_webpack@4.44.2
@@ -20787,7 +20455,7 @@ packages:
       postcss-safe-parser: 5.0.2
       prompts: 2.4.0
       react-app-polyfill: 2.0.0
-      react-dev-utils: 11.0.3
+      react-dev-utils: 11.0.1
       react-refresh: 0.8.3
       resolve: 1.18.1
       resolve-url-loader: 3.1.2
@@ -20807,7 +20475,7 @@ packages:
       node: ^10.12.0 || >=12.0.0
     hasBin: true
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.1
     peerDependencies:
       typescript: ^3.2.1
     peerDependenciesMeta:
@@ -20943,7 +20611,7 @@ packages:
       integrity: sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
   /readdirp/2.2.1:
     dependencies:
-      graceful-fs: 4.2.6
+      graceful-fs: 4.2.4
       micromatch: 3.1.10
       readable-stream: 2.3.7
     dev: false
@@ -20953,7 +20621,7 @@ packages:
       integrity: sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==
   /readdirp/3.5.0:
     dependencies:
-      picomatch: 2.2.3
+      picomatch: 2.2.2
     dev: false
     engines:
       node: '>=8.10.0'
@@ -21106,7 +20774,7 @@ packages:
       css-select: 2.1.0
       dom-converter: 0.2.0
       htmlparser2: 3.10.1
-      lodash: 4.17.21
+      lodash: 4.17.20
       strip-ansi: 3.0.1
     dev: false
     resolution:
@@ -21281,7 +20949,7 @@ packages:
       integrity: sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==
   /resolve/1.18.1:
     dependencies:
-      is-core-module: 2.3.0
+      is-core-module: 2.2.0
       path-parse: 1.0.6
     dev: false
     resolution:
@@ -21386,10 +21054,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==
-  /rollup-plugin-babel/4.4.0_5413d990f07294974cb1fe348397a5ac:
+  /rollup-plugin-babel/4.4.0_80ce04b0f9f43535a9250c8baadaddab:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/helper-module-imports': 7.13.12
+      '@babel/core': 7.12.10
+      '@babel/helper-module-imports': 7.12.5
       rollup: 1.32.1
       rollup-pluginutils: 2.8.2
     deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-babel.
@@ -21401,7 +21069,7 @@ packages:
       integrity: sha512-Lek/TYp1+7g7I+uMfJnnSJ7YWoD58ajo6Oarhlex7lvUce+RCKRuGRSgztDO3/MF/PuGKmUL5iTHKf208UNszw==
   /rollup-plugin-terser/5.3.1_rollup@1.32.1:
     dependencies:
-      '@babel/code-frame': 7.12.13
+      '@babel/code-frame': 7.12.11
       jest-worker: 24.9.0
       rollup: 1.32.1
       rollup-pluginutils: 2.8.2
@@ -21421,7 +21089,7 @@ packages:
   /rollup/1.32.1:
     dependencies:
       '@types/estree': 0.0.46
-      '@types/node': 15.0.1
+      '@types/node': 14.14.20
       acorn: 7.4.1
     dev: false
     hasBin: true
@@ -21609,7 +21277,7 @@ packages:
       integrity: sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==
   /schema-utils/2.7.1:
     dependencies:
-      '@types/json-schema': 7.0.7
+      '@types/json-schema': 7.0.6
       ajv: 6.12.6
       ajv-keywords: 3.5.2_ajv@6.12.6
     dev: false
@@ -21619,7 +21287,7 @@ packages:
       integrity: sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==
   /schema-utils/3.0.0:
     dependencies:
-      '@types/json-schema': 7.0.7
+      '@types/json-schema': 7.0.6
       ajv: 6.12.6
       ajv-keywords: 3.5.2_ajv@6.12.6
     dev: false
@@ -21726,7 +21394,7 @@ packages:
       debug: 2.6.9
       escape-html: 1.0.3
       http-errors: 1.6.3
-      mime-types: 2.1.30
+      mime-types: 2.1.28
       parseurl: 1.3.3
     dev: false
     engines:
@@ -22025,6 +21693,10 @@ packages:
       source-map: 0.6.1
     resolution:
       integrity: sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+  /source-map-url/0.4.0:
+    dev: false
+    resolution:
+      integrity: sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
   /source-map-url/0.4.1:
     resolution:
       integrity: sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==
@@ -22561,7 +22233,7 @@ packages:
   /styled-components/5.2.3_react-dom@17.0.1+react@17.0.1:
     dependencies:
       '@babel/helper-module-imports': 7.13.12
-      '@babel/traverse': 7.14.0_supports-color@5.5.0
+      '@babel/traverse': 7.13.17_supports-color@5.5.0
       '@emotion/is-prop-valid': 0.8.8
       '@emotion/stylis': 0.8.5
       '@emotion/unitless': 0.7.5
@@ -22583,7 +22255,7 @@ packages:
       integrity: sha512-BlR+KrLW3NL1yhvEB+9Nu9Dt51CuOnHoxd+Hj+rYPdtyR8X11uIW9rvhpy3Dk4dXXBsiW1u5U78f00Lf/afGoA==
   /stylehacks/4.0.3:
     dependencies:
-      browserslist: 4.16.5
+      browserslist: 4.16.1
       postcss: 7.0.35
       postcss-selector-parser: 3.1.2
     dev: false
@@ -22691,9 +22363,9 @@ packages:
       integrity: sha512-sVTikaDvMqg2aJjh4r48jsdfmqLT+nqB1MOsaBnvM3OwLx4S+WXcsxsgk5w18h/OZoxZCxuyXMh61iBHcj9Qiw==
   /stylelint-processor-styled-components/1.10.0:
     dependencies:
-      '@babel/parser': 7.12.11
-      '@babel/traverse': 7.12.12
-      micromatch: 4.0.2
+      '@babel/parser': 7.13.16
+      '@babel/traverse': 7.13.17
+      micromatch: 4.0.4
       postcss: 7.0.35
     dev: true
     resolution:
@@ -23324,6 +22996,29 @@ packages:
       typescript: '>=3.8 <5.0'
     resolution:
       integrity: sha512-3lFWKbLxJm34QxyVNNCgXX1u4o/RV0myvA2y2Bxm46iGIjKlaY0own9gIckbjZJPn+WaJEnfPPJ20HHGpoq4yg==
+  /ts-jest/26.4.4_typescript@4.2.3:
+    dependencies:
+      '@types/jest': 26.0.20
+      bs-logger: 0.2.6
+      buffer-from: 1.1.1
+      fast-json-stable-stringify: 2.1.0
+      jest-util: 26.6.2
+      json5: 2.1.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      mkdirp: 1.0.4
+      semver: 7.3.4
+      typescript: 4.2.3
+      yargs-parser: 20.2.4
+    dev: false
+    engines:
+      node: '>= 10'
+    hasBin: true
+    peerDependencies:
+      jest: '>=26 <27'
+      typescript: '>=3.8 <5.0'
+    resolution:
+      integrity: sha512-3lFWKbLxJm34QxyVNNCgXX1u4o/RV0myvA2y2Bxm46iGIjKlaY0own9gIckbjZJPn+WaJEnfPPJ20HHGpoq4yg==
   /ts-jest/26.5.0_jest@26.6.3+typescript@4.2.3:
     dependencies:
       '@types/jest': 26.0.20
@@ -23363,29 +23058,6 @@ packages:
       typescript: 4.2.4
       yargs-parser: 20.2.7
     dev: true
-    engines:
-      node: '>= 10'
-    hasBin: true
-    peerDependencies:
-      jest: '>=26 <27'
-      typescript: '>=3.8 <5.0'
-    resolution:
-      integrity: sha512-7tP4m+silwt1NHqzNRAPjW1BswnAhopTdc2K3HEkRZjF0ZG2F/e/ypVH0xiZIMfItFtD3CX0XFbwPzp9fIEUVg==
-  /ts-jest/26.5.5_typescript@4.2.3:
-    dependencies:
-      bs-logger: 0.2.6
-      buffer-from: 1.1.1
-      fast-json-stable-stringify: 2.1.0
-      jest: 26.6.3_ts-node@9.1.1
-      jest-util: 26.6.2
-      json5: 2.2.0
-      lodash: 4.17.21
-      make-error: 1.3.6
-      mkdirp: 1.0.4
-      semver: 7.3.5
-      typescript: 4.2.3
-      yargs-parser: 20.2.7
-    dev: false
     engines:
       node: '>= 10'
     hasBin: true
@@ -23505,36 +23177,18 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 4.2.3
+    dev: true
     engines:
       node: '>= 6'
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     resolution:
       integrity: sha512-RYbuQuvkhuqVeXweWT3tJLKOEJ/UUw9GjNEZGWdrLLlM+611o1gwLHBpxoFJKKl25fLprp2eVthtKs5JOrNeXg==
-  /tsutils/3.20.0_typescript@4.2.4:
-    dependencies:
-      tslib: 1.14.1
-      typescript: 4.2.4
-    engines:
-      node: '>= 6'
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    resolution:
-      integrity: sha512-RYbuQuvkhuqVeXweWT3tJLKOEJ/UUw9GjNEZGWdrLLlM+611o1gwLHBpxoFJKKl25fLprp2eVthtKs5JOrNeXg==
-  /tsutils/3.21.0_typescript@4.2.3:
-    dependencies:
-      tslib: 1.14.1
-      typescript: 4.2.3
-    engines:
-      node: '>= 6'
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    resolution:
-      integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
   /tsutils/3.21.0_typescript@4.2.4:
     dependencies:
       tslib: 1.14.1
       typescript: 4.2.4
+    dev: true
     engines:
       node: '>= 6'
     peerDependencies:
@@ -23828,7 +23482,7 @@ packages:
     dependencies:
       file-loader: 6.1.1_webpack@4.44.2
       loader-utils: 2.0.0
-      mime-types: 2.1.30
+      mime-types: 2.1.28
       schema-utils: 3.0.0
       webpack: 4.44.2
     dev: false
@@ -24095,7 +23749,7 @@ packages:
       integrity: sha512-nCFfBIPKr5Sh61s4LPpy1Wtfi0HE8isJ3d2Yb5/Ppw2P2B/3eVSEBjKfN0fmHJSK14+31KwMKmcrzs2GM4P0Ww==
   /watchpack/1.7.5:
     dependencies:
-      graceful-fs: 4.2.6
+      graceful-fs: 4.2.4
       neo-async: 2.6.2
     dev: false
     optionalDependencies:
@@ -24269,7 +23923,7 @@ packages:
   /webpack-manifest-plugin/2.2.0_webpack@4.41.5:
     dependencies:
       fs-extra: 7.0.1
-      lodash: 4.17.21
+      lodash: 4.17.20
       object.entries: 1.1.3
       tapable: 1.1.3
       webpack: 4.41.5
@@ -24283,7 +23937,7 @@ packages:
   /webpack-manifest-plugin/2.2.0_webpack@4.44.2:
     dependencies:
       fs-extra: 7.0.1
-      lodash: 4.17.21
+      lodash: 4.17.20
       object.entries: 1.1.3
       tapable: 1.1.3
       webpack: 4.44.2
@@ -24537,8 +24191,8 @@ packages:
       integrity: sha512-UHdwrN3FrDvicM3AqJS/J07X0KXj67R8Cg0waq1MKEOqzo89ap6zh6LmaLnRAjpB+bDIz+7OlPye9iii9KBnxw==
   /workbox-build/5.1.4:
     dependencies:
-      '@babel/core': 7.13.16
-      '@babel/preset-env': 7.12.11_@babel+core@7.13.16
+      '@babel/core': 7.12.10
+      '@babel/preset-env': 7.12.11_@babel+core@7.12.10
       '@babel/runtime': 7.12.5
       '@hapi/joi': 15.1.1
       '@rollup/plugin-node-resolve': 7.1.3_rollup@1.32.1
@@ -24551,10 +24205,10 @@ packages:
       lodash.template: 4.5.0
       pretty-bytes: 5.5.0
       rollup: 1.32.1
-      rollup-plugin-babel: 4.4.0_5413d990f07294974cb1fe348397a5ac
+      rollup-plugin-babel: 4.4.0_80ce04b0f9f43535a9250c8baadaddab
       rollup-plugin-terser: 5.3.1_rollup@1.32.1
       source-map: 0.7.3
-      source-map-url: 0.4.1
+      source-map-url: 0.4.0
       stringify-object: 3.3.0
       strip-comments: 1.0.2
       tempy: 0.3.0
@@ -24727,7 +24381,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.12.5
       fast-json-stable-stringify: 2.1.0
-      source-map-url: 0.4.1
+      source-map-url: 0.4.0
       upath: 1.2.0
       webpack: 4.44.2
       webpack-sources: 1.4.3
@@ -24932,7 +24586,6 @@ packages:
     resolution:
       integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
   /yargs-parser/20.2.4:
-    dev: true
     engines:
       node: '>=10'
     resolution:
@@ -24969,7 +24622,7 @@ packages:
       set-blocking: 2.0.0
       string-width: 3.1.0
       which-module: 2.0.0
-      y18n: 4.0.3
+      y18n: 4.0.1
       yargs-parser: 13.1.2
     dev: false
     resolution:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -581,6 +581,7 @@ importers:
       '@votingworks/ballot-encoder': link:../../libs/ballot-encoder
       '@votingworks/fixtures': link:../../libs/fixtures
       '@votingworks/hmpb-interpreter': link:../../libs/hmpb-interpreter
+      '@votingworks/plustek-sdk': link:../../libs/plustek-sdk
       '@votingworks/qrdetect': 1.0.1
       '@votingworks/types': link:../../libs/types
       base64-js: 1.5.1
@@ -667,6 +668,7 @@ importers:
       '@votingworks/ballot-encoder': workspace:*
       '@votingworks/fixtures': workspace:*
       '@votingworks/hmpb-interpreter': workspace:*
+      '@votingworks/plustek-sdk': workspace:*
       '@votingworks/qrdetect': ^1.0.1
       '@votingworks/types': workspace:*
       base64-js: ^1.5.1


### PR DESCRIPTION
Basic draft of precinct scanner support in `module-scan`. I ended up developing this against bsd, so it actually does work using that as a frontend.

### What's the main idea?

I augmented the `Scanner` interface to have a status (always `Unknown` for Fujitsu, gets actual status from Plustek). This now goes into `/scan/status` as `scanner`. Additionally, a scanner batch has some additional methods for accept/reject/review that `Importer` calls at the appropriate times.

### Where should reviewers focus?

- `BatchControl`'s new methods (e.g. `acceptSheet`) currently return a boolean indicating whether they happened or not, but mostly I'm ignoring the return value so I'm not sure we need it.
- Does shoehorning the precinct scanner to fit with `Importer` make sense?
- Does requiring a different `VX_MACHINE_TYPE` for `bsd` vs `precinct-scanner` make sense?
- Do the `/scan/precinct/*` endpoints actually work for you, @carolinemodic?

### Trying it out

Run this to start `module-scan`:

```
VX_MACHINE_TYPE=precinct-scanner pnpm dev
```

Then you can run `bsd` as normal and try scanning with it.

### TODO

- [ ] tests
- [ ] commit cleanup/separation
- [ ] ensure this works without a plustek scanner attached