### PR TITLE
refactor(types): share `module-scan` API types

### DIFF
--- a/apps/bsd/src/AppRoot.tsx
+++ b/apps/bsd/src/AppRoot.tsx
@@ -8,7 +8,8 @@ import {
 } from '@votingworks/types'
 import styled from 'styled-components'
 
-import { ScanStatusResponse, MachineConfig } from './config/types'
+import { ScanStatusResponse } from '@votingworks/types/api/module-scan'
+import { MachineConfig } from './config/types'
 import AppContext from './contexts/AppContext'
 
 import {

--- a/apps/bsd/src/config/types.ts
+++ b/apps/bsd/src/config/types.ts
@@ -45,19 +45,6 @@ export interface ErrorResponse {
   error: string
 }
 
-export interface Batch {
-  id: string
-  count: number
-  ballots: Ballot[]
-  startedAt: string
-  endedAt?: string
-}
-
-export interface AdjudicationStatus {
-  adjudicated: number
-  remaining: number
-}
-
 export type Ballot = BmdBallotInfo | HmpbBallotInfo | UnreadableBallotInfo
 
 export interface BmdBallotInfo {
@@ -89,12 +76,6 @@ export type SerializableBallotPageLayout = Omit<
 export interface MarkInfo {
   marks: BallotMark[]
   ballotSize: Size
-}
-
-export interface ScanStatusResponse {
-  electionHash?: string
-  batches: Batch[]
-  adjudication: AdjudicationStatus
 }
 
 // eslint-disable-next-line import/no-cycle

--- a/apps/bsd/src/screens/BallotReviewScreen.tsx
+++ b/apps/bsd/src/screens/BallotReviewScreen.tsx
@@ -1,3 +1,4 @@
+import { AdjudicationStatus } from '@votingworks/types/api/module-scan'
 import { ReadonlyDeep } from 'type-fest'
 import React, { useCallback, useEffect, useState } from 'react'
 import styled from 'styled-components'
@@ -11,7 +12,6 @@ import {
   ContestOption,
   MarkStatus,
   ReviewMarginalMarksBallot,
-  AdjudicationStatus,
   EventTargetFunction,
 } from '../config/types'
 import fetchJSON from '../util/fetchJSON'

--- a/apps/bsd/src/screens/DashboardScreen.test.tsx
+++ b/apps/bsd/src/screens/DashboardScreen.test.tsx
@@ -1,8 +1,8 @@
 import { act, render, waitFor } from '@testing-library/react'
+import { ScanStatusResponse } from '@votingworks/types/api/module-scan'
 import { createMemoryHistory } from 'history'
 import React from 'react'
 import { Router } from 'react-router-dom'
-import { ScanStatusResponse } from '../config/types'
 import DashboardScreen from './DashboardScreen'
 
 const noneLeftAdjudicationStatus = {
@@ -41,18 +41,12 @@ test('shows scanned ballot count', () => {
         count: 1,
         startedAt: new Date(0).toISOString(),
         endedAt: new Date(0).toISOString(),
-        ballots: [{ id: 1, filename: '/tmp/img1.jpg' }],
       },
       {
         id: 'b',
         count: 3,
         startedAt: new Date(0).toISOString(),
         endedAt: new Date(0).toISOString(),
-        ballots: [
-          { id: 2, filename: '/tmp/img2.jpg' },
-          { id: 3, filename: '/tmp/img3.jpg' },
-          { id: 4, filename: '/tmp/img4.jpg' },
-        ],
       },
     ],
     adjudication: noneLeftAdjudicationStatus,
@@ -81,11 +75,6 @@ test('shows whether a batch is scanning', () => {
         id: 'a',
         count: 3,
         startedAt: new Date(0).toISOString(),
-        ballots: [
-          { id: 2, filename: '/tmp/img2.jpg' },
-          { id: 3, filename: '/tmp/img3.jpg' },
-          { id: 4, filename: '/tmp/img4.jpg' },
-        ],
       },
     ],
     adjudication: noneLeftAdjudicationStatus,
@@ -113,18 +102,12 @@ test('allows deleting a batch', async () => {
         count: 1,
         startedAt: new Date(0).toISOString(),
         endedAt: new Date(0).toISOString(),
-        ballots: [{ id: 1, filename: '/tmp/img1.jpg' }],
       },
       {
         id: 'b',
         count: 3,
         startedAt: new Date(0).toISOString(),
         endedAt: new Date(0).toISOString(),
-        ballots: [
-          { id: 2, filename: '/tmp/img2.jpg' },
-          { id: 3, filename: '/tmp/img3.jpg' },
-          { id: 4, filename: '/tmp/img4.jpg' },
-        ],
       },
     ],
     adjudication: noneLeftAdjudicationStatus,

--- a/apps/bsd/src/screens/DashboardScreen.tsx
+++ b/apps/bsd/src/screens/DashboardScreen.tsx
@@ -2,7 +2,10 @@ import React, { useCallback, useEffect, useState } from 'react'
 import styled from 'styled-components'
 import pluralize from 'pluralize'
 
-import { ScanStatusResponse, AdjudicationStatus } from '../config/types'
+import {
+  ScanStatusResponse,
+  AdjudicationStatus,
+} from '@votingworks/types/api/module-scan'
 
 import Prose from '../components/Prose'
 import Table, { TD } from '../components/Table'

--- a/apps/module-scan/src/importer.ts
+++ b/apps/module-scan/src/importer.ts
@@ -4,6 +4,7 @@ import {
   MarkThresholds,
   Optional,
 } from '@votingworks/types'
+import { ScanStatus } from '@votingworks/types/api/module-scan'
 import makeDebug from 'debug'
 import * as fsExtra from 'fs-extra'
 import * as streams from 'memory-streams'
@@ -11,7 +12,7 @@ import { join } from 'path'
 import { v4 as uuid } from 'uuid'
 import { PageInterpretation } from './interpreter'
 import { BatchControl, Scanner } from './scanner'
-import { BallotMetadata, ScanStatus, SheetOf, Side } from './types'
+import { BallotMetadata, SheetOf, Side } from './types'
 import { writeImageData } from './util/images'
 import pdfToImages from './util/pdfToImages'
 import { Workspace } from './util/workspace'

--- a/apps/module-scan/src/server.test.ts
+++ b/apps/module-scan/src/server.test.ts
@@ -7,6 +7,7 @@ import {
   CandidateContest,
   YesNoContest,
 } from '@votingworks/types'
+import { ScanStatusResponse } from '@votingworks/types/api/module-scan'
 import { Application } from 'express'
 import { promises as fs } from 'fs'
 import { Server } from 'http'
@@ -19,7 +20,6 @@ import zeroRect from '../test/fixtures/zeroRect'
 import { makeMock } from '../test/util/mocks'
 import Importer from './importer'
 import { buildApp, start } from './server'
-import { ScanStatus } from './types'
 import { MarkStatus } from './types/ballot-review'
 import { createWorkspace, Workspace } from './util/workspace'
 
@@ -82,7 +82,7 @@ beforeEach(async () => {
 })
 
 test('GET /scan/status', async () => {
-  const status: ScanStatus = {
+  const status: ScanStatusResponse = {
     batches: [],
     adjudication: { remaining: 0, adjudicated: 0 },
   }

--- a/apps/module-scan/src/store.ts
+++ b/apps/module-scan/src/store.ts
@@ -11,6 +11,10 @@ import {
   Optional,
 } from '@votingworks/types'
 import {
+  AdjudicationStatus,
+  BatchInfo,
+} from '@votingworks/types/api/module-scan'
+import {
   BallotMark,
   BallotPageMetadata,
   BallotTargetMark,
@@ -31,9 +35,7 @@ import {
   sheetRequiresAdjudication,
 } from './interpreter'
 import {
-  AdjudicationStatus,
   BallotMetadata,
-  BatchInfo,
   getMarkStatus,
   isMarginalMark,
   PageInterpretationWithFiles,

--- a/apps/module-scan/src/types.ts
+++ b/apps/module-scan/src/types.ts
@@ -46,25 +46,6 @@ export interface CastVoteRecord
   _locales?: BallotLocales
 }
 
-export interface ScanStatus {
-  electionHash?: string
-  batches: BatchInfo[]
-  adjudication: AdjudicationStatus
-}
-
-export interface BatchInfo {
-  id: number
-  startedAt: Date
-  endedAt: Date
-  error: string
-  count: number
-}
-
-export interface AdjudicationStatus {
-  adjudicated: number
-  remaining: number
-}
-
 export type BallotInfo = BmdBallotInfo | HmpbBallotInfo | UnreadableBallotInfo
 
 export interface BmdBallotInfo {

--- a/apps/module-scan/tsconfig.test.json
+++ b/apps/module-scan/tsconfig.test.json
@@ -1,5 +1,8 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
   "include": ["src", "test"],
   "exclude": []
 }

--- a/apps/precinct-scanner/src/AppRoot.tsx
+++ b/apps/precinct-scanner/src/AppRoot.tsx
@@ -1,3 +1,4 @@
+import { ISO8601Timestamp } from '@votingworks/types/api'
 import React, { useCallback, useEffect, useReducer } from 'react'
 import { RouteComponentProps } from 'react-router-dom'
 import useInterval from '@rooks/use-interval'
@@ -24,7 +25,6 @@ import {
   doMount,
   UsbDriveStatus,
 } from './utils/usbstick'
-import { ISO8601Timestamp } from './config/types'
 import * as config from './api/config'
 
 export interface AppStorage {

--- a/apps/precinct-scanner/src/config/types.ts
+++ b/apps/precinct-scanner/src/config/types.ts
@@ -12,15 +12,9 @@ import type {
 } from '@votingworks/hmpb-interpreter'
 import type { AdjudicationInfo } from './ballot-review-types'
 
-export type ISO8601Timestamp = string
 export interface MachineConfig {
   machineId: string
 }
-
-// Events
-export type InputEvent = React.FormEvent<EventTarget>
-export type ButtonEvent = React.MouseEvent<HTMLButtonElement>
-export type ButtonEventFunction = (event: ButtonEvent) => void
 
 // Election
 export type SetElectionDefinition = (value?: ElectionDefinition) => void
@@ -34,19 +28,6 @@ export interface CastVoteRecord
   _ballotId: string
   _testBallot: boolean
   _scannerId: string
-}
-
-export interface Batch {
-  id: string
-  count: number
-  ballots: Ballot[]
-  startedAt: string
-  endedAt?: string
-}
-
-export interface AdjudicationStatus {
-  adjudicated: number
-  remaining: number
 }
 
 export type Ballot = BmdBallotInfo | HmpbBallotInfo | UnreadableBallotInfo
@@ -80,12 +61,6 @@ export type SerializableBallotPageLayout = Omit<
 export interface MarkInfo {
   marks: BallotMark[]
   ballotSize: Size
-}
-
-export interface ScanStatusResponse {
-  electionHash?: string
-  batches: Batch[]
-  adjudication: AdjudicationStatus
 }
 
 // these data structures live here until we can refactor the code

--- a/libs/types/.eslintignore
+++ b/libs/types/.eslintignore
@@ -1,1 +1,2 @@
-jest.config.js
+*.js
+*.d.ts

--- a/libs/types/api/index.d.ts
+++ b/libs/types/api/index.d.ts
@@ -1,0 +1,1 @@
+export * from '../dist/src/api'

--- a/libs/types/api/index.js
+++ b/libs/types/api/index.js
@@ -1,0 +1,1 @@
+module.exports = require('../dist/src/api')

--- a/libs/types/api/module-scan/index.d.ts
+++ b/libs/types/api/module-scan/index.d.ts
@@ -1,0 +1,1 @@
+export * from '../../dist/src/api/module-scan'

--- a/libs/types/api/module-scan/index.js
+++ b/libs/types/api/module-scan/index.js
@@ -1,0 +1,1 @@
+module.exports = require('../../dist/src/api/module-scan')

--- a/libs/types/src/api/index.ts
+++ b/libs/types/src/api/index.ts
@@ -1,0 +1,1 @@
+export type ISO8601Timestamp = string

--- a/libs/types/src/api/module-scan.ts
+++ b/libs/types/src/api/module-scan.ts
@@ -1,0 +1,26 @@
+import { ISO8601Timestamp } from '.'
+
+export interface AdjudicationStatus {
+  adjudicated: number
+  remaining: number
+}
+
+export interface BatchInfo {
+  id: string
+  startedAt: ISO8601Timestamp
+  endedAt?: ISO8601Timestamp
+  error?: string
+  count: number
+}
+
+export interface ScanStatus {
+  electionHash?: string
+  batches: BatchInfo[]
+  adjudication: AdjudicationStatus
+}
+
+/**
+ * @url /scan/status
+ * @method GET
+ */
+export type ScanStatusResponse = ScanStatus


### PR DESCRIPTION
This moves types needed for the `/scan/status` endpoint into `@votingworks/types`. It makes them accessible from a "vanity" path of `@votingworks/types/api/module-scan` by putting some alias files at `api/module-scan` within `@votingworks/types` that point to the real ones.