### PR TITLE
fix(em): use non-broken `graceful-fs` version

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5549,7 +5549,7 @@ packages:
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
       glob: 7.1.6
-      graceful-fs: 4.2.6
+      graceful-fs: 4.2.4
       istanbul-lib-coverage: 3.0.0
       istanbul-lib-instrument: 4.0.3
       istanbul-lib-report: 3.0.0
@@ -5583,7 +5583,7 @@ packages:
   /@jest/source-map/26.6.2:
     dependencies:
       callsites: 3.1.0
-      graceful-fs: 4.2.6
+      graceful-fs: 4.2.4
       source-map: 0.6.1
     engines:
       node: '>= 10.14.2'
@@ -5705,7 +5705,7 @@ packages:
       chalk: 4.1.1
       convert-source-map: 1.7.0
       fast-json-stable-stringify: 2.1.0
-      graceful-fs: 4.2.6
+      graceful-fs: 4.2.4
       jest-haste-map: 26.6.2
       jest-regex-util: 26.0.0
       jest-util: 26.6.2
@@ -8353,7 +8353,7 @@ packages:
   /archiver-utils/2.1.0:
     dependencies:
       glob: 7.1.6
-      graceful-fs: 4.2.6
+      graceful-fs: 4.2.4
       lazystream: 1.0.0
       lodash.defaults: 4.2.0
       lodash.difference: 4.5.0
@@ -8722,7 +8722,7 @@ packages:
       babel-plugin-istanbul: 6.0.0
       babel-preset-jest: 26.6.2_@babel+core@7.12.10
       chalk: 4.1.1
-      graceful-fs: 4.2.6
+      graceful-fs: 4.2.4
       slash: 3.0.0
     engines:
       node: '>= 10.14.2'
@@ -8739,7 +8739,7 @@ packages:
       babel-plugin-istanbul: 6.0.0
       babel-preset-jest: 26.6.2_@babel+core@7.12.3
       chalk: 4.1.1
-      graceful-fs: 4.2.6
+      graceful-fs: 4.2.4
       slash: 3.0.0
     dev: false
     engines:
@@ -8877,10 +8877,10 @@ packages:
       integrity: sha512-FEiD7l5ZABdJPpLssKXjBUJMYqzbcNzBowfXDCdJhOpbhWiewapUaY+LZGT8R4Jg2TwOjGjG4RKeyrO5p9sBkA==
   /babel-plugin-styled-components/1.12.0_styled-components@5.2.3:
     dependencies:
-      '@babel/helper-annotate-as-pure': 7.12.13
-      '@babel/helper-module-imports': 7.13.12
+      '@babel/helper-annotate-as-pure': 7.12.10
+      '@babel/helper-module-imports': 7.12.5
       babel-plugin-syntax-jsx: 6.18.0
-      lodash: 4.17.21
+      lodash: 4.17.20
       styled-components: 5.2.3_react-dom@17.0.1+react@17.0.1
     dev: false
     peerDependencies:
@@ -11691,18 +11691,18 @@ packages:
       integrity: sha512-pGIZ8t0mFLcV+6ZirRgYK6RVqUIKRIi9MmgzUEmrIknsn3AdO0I32asO86dJgloHq+9ZPl8UIg8mYrvgP5u2wQ==
   /eslint-config-react-app/6.0.0_358978944c0066569aff6b737b791288:
     dependencies:
-      '@typescript-eslint/eslint-plugin': 4.16.1_4b7c75eac308ba454583af097e0ad94d
-      '@typescript-eslint/parser': 4.16.1_eslint@7.19.0+typescript@4.2.4
+      '@typescript-eslint/eslint-plugin': 4.16.1_8360ec0b6468ab52d7ec43304a9826d1
+      '@typescript-eslint/parser': 4.16.1_eslint@7.19.0+typescript@4.2.3
       babel-eslint: 10.1.0_eslint@7.19.0
       confusing-browser-globals: 1.0.10
       eslint: 7.19.0
       eslint-plugin-flowtype: 5.2.0_eslint@7.19.0
-      eslint-plugin-import: 2.22.1_eslint@7.19.0+typescript@4.2.4
-      eslint-plugin-jest: 24.1.3_eslint@7.19.0+typescript@4.2.4
+      eslint-plugin-import: 2.22.1_eslint@7.19.0+typescript@4.2.3
+      eslint-plugin-jest: 24.1.3_eslint@7.19.0+typescript@4.2.3
       eslint-plugin-jsx-a11y: 6.4.1_eslint@7.19.0
       eslint-plugin-react: 7.22.0_eslint@7.19.0
       eslint-plugin-react-hooks: 4.2.0_eslint@7.19.0
-      eslint-plugin-testing-library: 3.10.1_eslint@7.19.0+typescript@4.2.4
+      eslint-plugin-testing-library: 3.10.1_eslint@7.19.0+typescript@4.2.3
     dev: false
     engines:
       node: ^10.12.0 || >=12.0.0
@@ -13408,7 +13408,7 @@ packages:
       integrity: sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=
   /follow-redirects/1.13.1_debug@4.3.1:
     dependencies:
-      debug: 4.3.1_supports-color@6.1.0
+      debug: 4.3.1
     engines:
       node: '>=4.0'
     peerDependencies:
@@ -13549,7 +13549,7 @@ packages:
       integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
   /fs-extra/8.1.0:
     dependencies:
-      graceful-fs: 4.2.6
+      graceful-fs: 4.2.4
       jsonfile: 4.0.0
       universalify: 0.1.2
     engines:
@@ -15675,7 +15675,7 @@ packages:
       '@types/node': 15.0.1
       anymatch: 3.1.2
       fb-watchman: 2.0.1
-      graceful-fs: 4.2.6
+      graceful-fs: 4.2.4
       jest-regex-util: 26.0.0
       jest-serializer: 26.6.2
       jest-util: 26.6.2
@@ -15892,7 +15892,7 @@ packages:
       '@jest/types': 26.6.2
       '@types/stack-utils': 2.0.0
       chalk: 4.1.1
-      graceful-fs: 4.2.6
+      graceful-fs: 4.2.4
       micromatch: 4.0.4
       pretty-format: 26.6.2
       slash: 3.0.0
@@ -16009,7 +16009,7 @@ packages:
     dependencies:
       '@jest/types': 26.6.2
       chalk: 4.1.1
-      graceful-fs: 4.2.6
+      graceful-fs: 4.2.4
       jest-pnp-resolver: 1.2.2_jest-resolve@26.6.0
       jest-util: 26.6.2
       read-pkg-up: 7.0.1
@@ -16024,7 +16024,7 @@ packages:
     dependencies:
       '@jest/types': 26.6.2
       chalk: 4.1.1
-      graceful-fs: 4.2.6
+      graceful-fs: 4.2.4
       jest-pnp-resolver: 1.2.2_jest-resolve@26.6.2
       jest-util: 26.6.2
       read-pkg-up: 7.0.1
@@ -16360,7 +16360,7 @@ packages:
   /jest-serializer/26.6.2:
     dependencies:
       '@types/node': 15.0.1
-      graceful-fs: 4.2.6
+      graceful-fs: 4.2.4
     engines:
       node: '>= 10.14.2'
     resolution:
@@ -16393,7 +16393,7 @@ packages:
       '@types/prettier': 2.2.3
       chalk: 4.1.1
       expect: 26.6.2
-      graceful-fs: 4.2.6
+      graceful-fs: 4.2.4
       jest-diff: 26.6.2
       jest-get-type: 26.3.0
       jest-haste-map: 26.6.2
@@ -16452,7 +16452,7 @@ packages:
       '@jest/types': 26.6.2
       '@types/node': 15.0.1
       chalk: 4.1.1
-      graceful-fs: 4.2.6
+      graceful-fs: 4.2.4
       is-ci: 2.0.0
       micromatch: 4.0.4
     engines:

--- a/pnpmfile.js
+++ b/pnpmfile.js
@@ -9,6 +9,7 @@ module.exports = {
 /**
  * @typedef {object} Package
  * @property {string} name
+ * @property {string} version
  * @property {Record<string, string>} dependencies
  */
 
@@ -97,6 +98,13 @@ function readPackage(pkg, context) {
       'prettier': '*',
     }
     context.log('jest-circus requires prettier to format code for inline snapshots')
+  }
+
+  if (/^\^?4\.2\./.test(pkg.dependencies['graceful-fs'])) {
+    // Object prototype may only be an Object or null: undefined
+    // Caused by https://github.com/isaacs/node-graceful-fs/commit/c55c1b8cb32510f92bd33d7c833364ecd3964dea
+    pkg.dependencies['graceful-fs'] = '4.2.4'
+    context.log(`${pkg.name}@${pkg.version} may use Object.setPrototypeOf with fs.read, which is undefined in the browser, which crashes`)
   }
 
   return pkg


### PR DESCRIPTION
https://github.com/isaacs/node-graceful-fs/commit/c55c1b8cb32510f92bd33d7c833364ecd3964dea changed `read.__proto__ = fs$read` to `Object.setPrototypeOf(read, fs$read)` to use the more standards-compliant `Object.setPrototypeOf`. However, that function fails if its second argument is `undefined`, which it is when running in the browser by default in a React app (`fs$read` is from `require('fs').read`, and the `fs` module is stubbed). This change was made in `graceful-fs@4.2.5`, and is present in `4.2.6` as well.

To work around this, we just pin to `4.2.4` for now. I'm not sure what the long-term solution should be. Perhaps `graceful-fs` should be graceful (hah!) about this scenario? Or maybe we could have webpack provide a more fully-featured stub to prevent this issue? Or maybe `archiver-utils` shouldn't be including `graceful-fs` at all in the browser?