### PR TITLE
feat(scan): add remote control scanner mock

### DIFF
--- a/apps/module-scan/README.md
+++ b/apps/module-scan/README.md
@@ -37,7 +37,11 @@ pnpm build && pnpm start
 
 ## Mock Scanning
 
-You can also scan directly from image files instead of using a real scanner:
+There are a few ways of scanning using a mock scanner instead of a real one.
+
+### Define batches upfront
+
+You can defined the batches of sheets to scan upfront.
 
 ```sh
 # single batch with single sheet
@@ -69,6 +73,21 @@ MOCK_SCANNER_FILES=@/path/to/election-backup/manifest pnpm dev
 If you are seeing unhandled promise rejection errors you may have an issue with
 where your image files are located, try moving them into the local scope of the
 app.
+
+### Define batches dynamically
+
+Use an HTTP-controlled scanner to add and update batches as `module-scan` runs:
+
+```sh
+# start module-scan
+MOCK_SCANNER=remote pnpm dev
+
+# in another terminal:
+./bin/mock-scanner new-batch path/to/front.jpg path/to/back.jpg
+./bin/mock-scanner add-to-batch path/to/front2.jpg path/to/back2.jpg
+```
+
+You can issue updates to the remote scanner as long as `module-scan` is running.
 
 ## Switching Workspaces
 

--- a/apps/module-scan/bin/mock-scanner
+++ b/apps/module-scan/bin/mock-scanner
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+pnpx ts-node --transpile-only "${DIR}/../src/cli/mock-scanner" "$@"

--- a/apps/module-scan/package.json
+++ b/apps/module-scan/package.json
@@ -86,6 +86,7 @@
     "eslint-plugin-jest": "^24.1.3",
     "eslint-plugin-no-array-sort-mutation": "workspace:*",
     "eslint-plugin-prettier": "^3.3.1",
+    "got": "^11.8.2",
     "husky": "^4.3.7",
     "jest": "^26.6.3",
     "lint-staged": "^10.5.3",

--- a/apps/module-scan/src/RemoteControlScanner.ts
+++ b/apps/module-scan/src/RemoteControlScanner.ts
@@ -1,0 +1,228 @@
+/* istanbul ignore file */
+
+import { Result, safeParse, safeParseJSON } from '@votingworks/types'
+import bodyParser from 'body-parser'
+import express from 'express'
+import { basename, extname, join } from 'path'
+import { dirSync, tmpNameSync } from 'tmp'
+import { copyFile } from 'fs-extra'
+import * as z from 'zod'
+import { BatchControl, Scanner } from './scanner'
+import { SheetOf } from './types'
+import got from 'got'
+
+export type SheetFiles = SheetOf<string>
+export type Batch = SheetFiles[]
+export type Batches = Batch[]
+export const SheetFilesSchema: z.ZodSchema<SheetFiles> = z.tuple([
+  z.string(),
+  z.string(),
+])
+export const BatchSchema: z.ZodSchema<Batch> = z.array(SheetFilesSchema)
+export const BatchesSchema: z.ZodSchema<Batches> = z.array(BatchSchema)
+
+const DEFAULT_PORT = 8888
+
+export class RemoteControlScannerClient {
+  public constructor(private readonly port = DEFAULT_PORT) {}
+
+  public async getBatches(): Promise<
+    Result<Batches, SyntaxError | z.ZodError>
+  > {
+    return safeParseJSON(
+      (await got.get(`http://localhost:${this.port}/batches`)).body,
+      BatchesSchema
+    )
+  }
+
+  public async getCurrentBatch(): Promise<
+    Result<Batch | undefined, SyntaxError | z.ZodError>
+  > {
+    return safeParseJSON(
+      (await got.get(`http://localhost:${this.port}/batches/current`)).body,
+      BatchSchema
+    )
+  }
+
+  public async addBatch(
+    batch: Batch
+  ): Promise<Result<Batches, SyntaxError | z.ZodError>> {
+    return safeParseJSON(
+      (await got.post(`http://localhost:${this.port}/batches`, { json: batch }))
+        .body,
+      BatchesSchema
+    )
+  }
+
+  public async addSheetsToNextBatch(
+    ...sheets: readonly SheetFiles[]
+  ): Promise<Result<Batch, SyntaxError | z.ZodError>> {
+    return safeParseJSON(
+      (
+        await got.post(`http://localhost:${this.port}/batches/next`, {
+          json: sheets,
+        })
+      ).body,
+      BatchSchema
+    )
+  }
+
+  public async addSheetsToLastBatch(
+    ...sheets: readonly SheetFiles[]
+  ): Promise<Result<Batch, SyntaxError | z.ZodError>> {
+    return safeParseJSON(
+      (
+        await got.post(`http://localhost:${this.port}/batches/last`, {
+          json: sheets,
+        })
+      ).body,
+      BatchSchema
+    )
+  }
+
+  public async getNextBatch(): Promise<
+    Result<Batch, SyntaxError | z.ZodError>
+  > {
+    return safeParseJSON(
+      (await got.get(`http://localhost:${this.port}/batches/next`)).body,
+      BatchSchema
+    )
+  }
+
+  public async getLastBatch(): Promise<
+    Result<Batch, SyntaxError | z.ZodError>
+  > {
+    return safeParseJSON(
+      (await got.get(`http://localhost:${this.port}/batches/last`)).body,
+      BatchSchema
+    )
+  }
+}
+
+export default class RemoteControlScanner implements Scanner {
+  private currentBatch?: Batch
+  private batches: Batch[] = []
+
+  public constructor(port = DEFAULT_PORT) {
+    const app = express()
+
+    app.use(express.json({ limit: '5mb', type: 'application/json' }))
+    app.use(bodyParser.urlencoded({ extended: false }))
+
+    app.get('/', (_request, response) => {
+      response.redirect('/batches')
+    })
+
+    app.get('/batches', (_request, response) => {
+      response.json(this.batches)
+    })
+
+    app.post('/batches', (request, response) => {
+      safeParse(BatchSchema, request.body).mapOrElse(
+        (error) => {
+          response.status(400).json({ error: error.toString() })
+        },
+        (batch) => {
+          this.batches.push(batch)
+          response.status(201).json(this.batches)
+        }
+      )
+    })
+
+    app.get('/batches/current', (_request, response) => {
+      response.json(this.currentBatch ?? [])
+    })
+
+    app.get('/batches/next', (_request, response) => {
+      if (this.batches.length === 0) {
+        this.batches.push([])
+      }
+
+      const batch = this.batches[0]
+      response.json(batch)
+    })
+
+    app.post('/batches/next', (request, response) => {
+      safeParse(BatchSchema, request.body).mapOrElse(
+        (error) => {
+          response.status(400).json({ error: error.toString() })
+        },
+        (sheets) => {
+          if (this.batches.length === 0) {
+            this.batches.push([])
+          }
+
+          const batch = this.batches[0]
+          batch.push(...sheets)
+          response.json(batch)
+        }
+      )
+    })
+
+    app.get('/batches/last', (_request, response) => {
+      if (this.batches.length === 0) {
+        this.batches.push([])
+      }
+
+      const batch = this.batches[this.batches.length - 1]
+      response.json(batch)
+    })
+
+    app.post('/batches/last', (request, response) => {
+      safeParse(BatchSchema, request.body).mapOrElse(
+        (error) => {
+          response.status(400).json({ error: error.toString() })
+        },
+        (sheets) => {
+          if (this.batches.length === 0) {
+            this.batches.push([])
+          }
+
+          const batch = this.batches[this.batches.length - 1]
+          batch.push(...sheets)
+          response.json(batch)
+        }
+      )
+    })
+
+    app.listen(port, () => {
+      console.log(
+        `Remote control scanner listening at http://localhost:${port}/`
+      )
+    })
+  }
+
+  public scanSheets(directory = dirSync().name): BatchControl {
+    if (this.currentBatch) {
+      throw new Error('cannot start a batch when one is already processing')
+    }
+
+    const batch = this.batches.shift()
+    this.currentBatch = batch
+
+    return {
+      scanSheet: async (): Promise<SheetOf<string> | undefined> => {
+        const sheet = batch?.shift()
+
+        if (sheet) {
+          return (await Promise.all(
+            sheet.map(async (path) => {
+              const dest = join(
+                directory,
+                basename(tmpNameSync({ postfix: extname(path) }))
+              )
+              await copyFile(path, dest)
+              return dest
+            })
+          )) as SheetOf<string>
+        }
+      },
+
+      endBatch: async (): Promise<void> => {
+        if (this.currentBatch === batch) {
+          delete this.currentBatch
+        }
+      },
+    }
+  }
+}

--- a/apps/module-scan/src/cli/mock-scanner.ts
+++ b/apps/module-scan/src/cli/mock-scanner.ts
@@ -1,0 +1,200 @@
+/* istanbul ignore file */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+import { err, ok, Result } from '@votingworks/types'
+import { resolve } from 'path'
+import {
+  Batch,
+  Batches,
+  RemoteControlScannerClient,
+} from '../RemoteControlScanner'
+
+/**
+ * @param {readonly string[]} args
+ * @returns {Promise<number>}
+ */
+export default async function main(args: readonly string[]): Promise<number> {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+
+    if (arg === 'help' || arg === '--help' || arg === '-h') {
+      return help(args.slice(i + 1))
+    } else if (arg === 'show') {
+      return show(args.slice(i + 1))
+    } else if (arg === 'new-batch') {
+      return newBatch(args.slice(i + 1))
+    } else if (arg === 'add-to-batch') {
+      return addToBatch(args.slice(i + 1))
+    } else {
+      usage(process.stderr)
+      return 1
+    }
+  }
+
+  return help([])
+}
+
+function help(_args: readonly string[]): number {
+  usage(process.stdout)
+  return 0
+}
+
+function printBatches(batches: Batches): void {
+  if (batches.length === 0) {
+    process.stdout.write('# no batches\n')
+  }
+
+  for (const [i, batch] of batches.entries()) {
+    if (i === 0 && i === batches.length - 1) {
+      process.stdout.write('# next & last batch\n')
+    } else if (i === 0) {
+      process.stdout.write('# next batch\n')
+    } else if (i === batches.length - 1) {
+      process.stdout.write('# last batch\n')
+    }
+    printBatch(batch)
+    process.stdout.write('\n')
+  }
+}
+
+function printBatch(batch: Batch): void {
+  if (batch.length === 0) {
+    process.stdout.write('# → empty batch\n')
+  }
+
+  for (const sheet of batch) {
+    process.stdout.write(sheet[0])
+    process.stdout.write('\n')
+    process.stdout.write(sheet[1])
+    process.stdout.write('\n')
+  }
+  process.stdout.write('\n')
+}
+
+/**
+ * @param {readonly string[]} _args
+ * @returns {Promise<number>}
+ */
+async function show(_args: readonly string[]): Promise<number> {
+  const client = new RemoteControlScannerClient()
+  const [currentResult, batchesResult] = await Promise.all([
+    client.getCurrentBatch(),
+    client.getBatches(),
+  ])
+
+  if (currentResult.isErr() || batchesResult.isErr()) {
+    process.stderr.write(
+      `error: ${currentResult.err() ?? batchesResult.err()}\n`
+    )
+    return 1
+  }
+
+  const currentBatch = currentResult.unwrap()
+  if (currentBatch) {
+    process.stdout.write('# current batch\n')
+    printBatch(currentBatch)
+  }
+
+  printBatches(batchesResult.unwrap())
+  return 0
+}
+
+function parseBatchFromArgs(args: readonly string[]): Result<Batch, Error> {
+  const batch: Batch = []
+
+  for (let i = 0; i < args.length; i += 2) {
+    const front = args[i]
+    const back = args[i + 1]
+
+    if (front.startsWith('-')) {
+      return err(new Error(`error: unexpected option: ${front}\n`))
+    } else if (back.startsWith('-')) {
+      return err(new Error(`error: unexpected option: ${back}\n`))
+    } else if (!back) {
+      return err(new Error(`error: missing back page for front: ${front}\n`))
+    } else {
+      batch.push([resolve(process.cwd(), front), resolve(process.cwd(), back)])
+    }
+  }
+
+  return ok(batch)
+}
+
+async function newBatch(args: readonly string[]): Promise<number> {
+  const parseBatchResult = parseBatchFromArgs(args)
+
+  if (parseBatchResult.isErr()) {
+    process.stderr.write(`error: ${parseBatchResult.err().message}\n`)
+    return 1
+  }
+
+  const client = new RemoteControlScannerClient()
+  return (await client.addBatch(parseBatchResult.unwrap())).mapOrElse(
+    (error) => {
+      process.stderr.write(`error: ${error.message}\n`)
+      return 1
+    },
+    (batches) => {
+      printBatches(batches)
+      return 0
+    }
+  )
+}
+
+async function addToBatch(args: readonly string[]): Promise<number> {
+  let parseBatchResult: Result<Batch, Error>
+  let target: 'next' | 'last' = 'next'
+
+  if (args[0] === '--next') {
+    target = 'next'
+    parseBatchResult = parseBatchFromArgs(args.slice(1))
+  } else if (args[0] === '--last') {
+    target = 'last'
+    parseBatchResult = parseBatchFromArgs(args.slice(1))
+  } else {
+    parseBatchResult = parseBatchFromArgs(args)
+  }
+
+  if (parseBatchResult.isErr()) {
+    process.stderr.write(`error: ${parseBatchResult.err().message}\n`)
+    return 1
+  }
+
+  const client = new RemoteControlScannerClient()
+  const sheets = parseBatchResult.unwrap()
+  return (target === 'next'
+    ? await client.addSheetsToNextBatch(...sheets)
+    : await client.addSheetsToLastBatch(...sheets)
+  ).mapOrElse(
+    (error) => {
+      process.stderr.write(`error: ${error.message}\n`)
+      return 1
+    },
+    (batch) => {
+      process.stdout.write(`# ${target} batch\n`)
+      printBatch(batch)
+      return 0
+    }
+  )
+}
+
+function usage(out: NodeJS.WritableStream): void {
+  out.write(`bin/mock-scanner show\n`)
+  out.write(
+    `bin/mock-scanner new-batch [--next|--last] IMGFRONT IMGBACK [IMGFRONT IMGBACK …]\n`
+  )
+  out.write(
+    `bin/mock-scanner add-to-batch [--next|--last] IMGFRONT IMGBACK [IMGFRONT IMGBACK …]\n`
+  )
+}
+
+if (require.main === module) {
+  main(process.argv.slice(2))
+    .catch((error) => {
+      console.error(error.stack)
+      return 1
+    })
+    .then((code) => {
+      process.exitCode = code
+    })
+}

--- a/apps/module-scan/src/index.ts
+++ b/apps/module-scan/src/index.ts
@@ -1,8 +1,14 @@
 // Import the rest of our application.
 import LoopScanner, { parseBatchesFromEnv } from './LoopScanner'
+import RemoteControlScanner from './RemoteControlScanner'
+import { Scanner } from './scanner'
 import * as server from './server'
 
-function getScanner(): LoopScanner | undefined {
+function getScanner(): Scanner | undefined {
+  if (process.env.MOCK_SCANNER === 'remote') {
+    return new RemoteControlScanner()
+  }
+
   const mockScannerFiles = parseBatchesFromEnv(process.env.MOCK_SCANNER_FILES)
 
   if (mockScannerFiles) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -632,6 +632,7 @@ importers:
       eslint-plugin-jest: 24.1.3_eslint@7.17.0+typescript@4.2.3
       eslint-plugin-no-array-sort-mutation: link:../../libs/eslint-plugin-no-array-sort-mutation
       eslint-plugin-prettier: 3.3.1_69979e61f6e4e06807b16d761b81a74d
+      got: 11.8.2
       husky: 4.3.7
       jest: 26.6.3_canvas@2.6.1+ts-node@9.1.1
       lint-staged: 10.5.3
@@ -686,6 +687,7 @@ importers:
       eslint-plugin-prettier: ^3.3.1
       express: ^4.17.1
       fs-extra: ^9.0.1
+      got: ^11.8.2
       husky: ^4.3.7
       jest: ^26.6.3
       jest-diff: ^26.6.2
@@ -5958,6 +5960,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
+  /@sindresorhus/is/4.0.1:
+    dev: true
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-Qm9hBEBu18wt1PO2flE7LPb30BHMQt1eQgbV76YntdNk73XZGpn3izvGTYxbGgzXKgbCjiia0uxTd3aTNQrY/g==
   /@sinonjs/commons/1.8.1:
     dependencies:
       type-detect: 4.0.8
@@ -6238,6 +6246,14 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-LjepnS/BSAvelnOnnzr6Gg0GcpLmnZ9ThGFK5WJtm1xOqdBE/1IACZU7MMdVzjyUkfFqGz87eRE4hFaSLiUwYg==
+  /@szmarczak/http-timer/4.0.5:
+    dependencies:
+      defer-to-connect: 2.0.1
+    dev: true
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==
   /@testing-library/cypress/5.3.1_cypress@4.12.1:
     dependencies:
       '@babel/runtime': 7.12.5
@@ -6429,6 +6445,15 @@ packages:
     dev: true
     resolution:
       integrity: sha1-ZpetKYcyRsUw8Jo/9aQIYYJCMNU=
+  /@types/cacheable-request/6.0.1:
+    dependencies:
+      '@types/http-cache-semantics': 4.0.0
+      '@types/keyv': 3.1.1
+      '@types/node': 14.14.21
+      '@types/responselike': 1.0.0
+    dev: true
+    resolution:
+      integrity: sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==
   /@types/connect/3.4.34:
     dependencies:
       '@types/node': 12.19.14
@@ -6526,6 +6551,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-giAlZwstKbmvMk1OO7WXSj4OZ0keXAcl2TQq4LWHiiPH2ByaH7WeUzng+Qej8UPxxv+8lRTuouo0iaNDBuzIBA==
+  /@types/http-cache-semantics/4.0.0:
+    dev: true
+    resolution:
+      integrity: sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==
   /@types/http-proxy/1.17.4:
     dependencies:
       '@types/node': 12.19.14
@@ -6606,6 +6635,12 @@ packages:
   /@types/json5/0.0.29:
     resolution:
       integrity: sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+  /@types/keyv/3.1.1:
+    dependencies:
+      '@types/node': 14.14.21
+    dev: true
+    resolution:
+      integrity: sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==
   /@types/lodash.camelcase/4.3.6:
     dependencies:
       '@types/lodash': 4.14.167
@@ -6783,6 +6818,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
+  /@types/responselike/1.0.0:
+    dependencies:
+      '@types/node': 14.14.21
+    dev: true
+    resolution:
+      integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==
   /@types/scheduler/0.16.1:
     resolution:
       integrity: sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
@@ -9474,6 +9515,26 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==
+  /cacheable-lookup/5.0.4:
+    dev: true
+    engines:
+      node: '>=10.6.0'
+    resolution:
+      integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==
+  /cacheable-request/7.0.1:
+    dependencies:
+      clone-response: 1.0.2
+      get-stream: 5.2.0
+      http-cache-semantics: 4.1.0
+      keyv: 4.0.3
+      lowercase-keys: 2.0.0
+      normalize-url: 4.5.0
+      responselike: 2.0.0
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==
   /cachedir/2.3.0:
     dev: true
     engines:
@@ -9892,6 +9953,12 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==
+  /clone-response/1.0.2:
+    dependencies:
+      mimic-response: 1.0.1
+    dev: true
+    resolution:
+      integrity: sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=
   /clone/1.0.4:
     engines:
       node: '>=0.8'
@@ -10865,6 +10932,14 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==
+  /decompress-response/6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+    dev: true
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
   /dedent/0.7.0:
     resolution:
       integrity: sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
@@ -10915,6 +10990,12 @@ packages:
       clone: 1.0.4
     resolution:
       integrity: sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=
+  /defer-to-connect/2.0.1:
+    dev: true
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==
   /define-properties/1.1.3:
     dependencies:
       object-keys: 1.1.1
@@ -13906,6 +13987,24 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==
+  /got/11.8.2:
+    dependencies:
+      '@sindresorhus/is': 4.0.1
+      '@szmarczak/http-timer': 4.0.5
+      '@types/cacheable-request': 6.0.1
+      '@types/responselike': 1.0.0
+      cacheable-lookup: 5.0.4
+      cacheable-request: 7.0.1
+      decompress-response: 6.0.0
+      http2-wrapper: 1.0.3
+      lowercase-keys: 2.0.0
+      p-cancelable: 2.1.1
+      responselike: 2.0.0
+    dev: true
+    engines:
+      node: '>=10.19.0'
+    resolution:
+      integrity: sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==
   /graceful-fs/4.2.4:
     resolution:
       integrity: sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
@@ -14194,6 +14293,10 @@ packages:
       readable-stream: 3.6.0
     resolution:
       integrity: sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==
+  /http-cache-semantics/4.1.0:
+    dev: true
+    resolution:
+      integrity: sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
   /http-deceiver/1.2.7:
     dev: false
     resolution:
@@ -14294,6 +14397,15 @@ packages:
       npm: '>=1.3.7'
     resolution:
       integrity: sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=
+  /http2-wrapper/1.0.3:
+    dependencies:
+      quick-lru: 5.1.1
+      resolve-alpn: 1.1.2
+    dev: true
+    engines:
+      node: '>=10.19.0'
+    resolution:
+      integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==
   /https-browserify/1.0.0:
     dev: false
     resolution:
@@ -16846,6 +16958,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-ese1mwneExSNnqybul7bPvWh6GI=
+  /json-buffer/3.0.1:
+    dev: true
+    resolution:
+      integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
   /json-parse-better-errors/1.0.2:
     resolution:
       integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
@@ -16947,6 +17063,12 @@ packages:
       node: '>=4.0'
     resolution:
       integrity: sha512-EIsmt3O3ljsU6sot/J4E1zDRxfBNrhjyf/OKjlydwgEimQuznlM4Wv7U+ueONJMyEn1WRE0K8dhi3dVAXYT24Q==
+  /keyv/4.0.3:
+    dependencies:
+      json-buffer: 3.0.1
+    dev: true
+    resolution:
+      integrity: sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==
   /killable/1.0.1:
     dev: false
     resolution:
@@ -17438,6 +17560,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==
+  /lowercase-keys/2.0.0:
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
   /lru-cache/5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -17785,12 +17913,24 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+  /mimic-response/1.0.1:
+    dev: true
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
   /mimic-response/2.1.0:
     dev: false
     engines:
       node: '>=8'
     resolution:
       integrity: sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
+  /mimic-response/3.1.0:
+    dev: true
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
   /min-indent/1.0.1:
     engines:
       node: '>=4'
@@ -18273,6 +18413,12 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
+  /normalize-url/4.5.0:
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==
   /normalize.css/8.0.1:
     dev: false
     resolution:
@@ -18640,6 +18786,12 @@ packages:
     dev: true
     resolution:
       integrity: sha1-EnZjl3Sj+O8lcvf+QoDg6kVQwHs=
+  /p-cancelable/2.1.1:
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==
   /p-defer/1.0.0:
     dev: false
     engines:
@@ -20243,6 +20395,12 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
+  /quick-lru/5.1.1:
+    dev: true
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
   /raf/3.4.1:
     dependencies:
       performance-now: 2.1.0
@@ -21196,6 +21354,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+  /resolve-alpn/1.1.2:
+    dev: true
+    resolution:
+      integrity: sha512-8OyfzhAtA32LVUsJSke3auIyINcwdh5l3cvYKdKO0nvsYSKuiLfTM5i78PJswFPT8y6cPW+L1v6/hE95chcpDA==
   /resolve-cwd/2.0.0:
     dependencies:
       resolve-from: 3.0.0
@@ -21296,6 +21458,12 @@ packages:
       path-parse: 1.0.6
     resolution:
       integrity: sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
+  /responselike/2.0.0:
+    dependencies:
+      lowercase-keys: 2.0.0
+    dev: true
+    resolution:
+      integrity: sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==
   /restore-cursor/1.0.1:
     dependencies:
       exit-hook: 1.1.1
@@ -23304,7 +23472,7 @@ packages:
       bs-logger: 0.2.6
       buffer-from: 1.1.1
       fast-json-stable-stringify: 2.1.0
-      jest: 26.6.3
+      jest: 26.6.3_canvas@2.6.1+ts-node@9.1.1
       jest-util: 26.6.2
       json5: 2.1.3
       lodash.memoize: 4.1.2


### PR DESCRIPTION
Running `module-scan` with `MOCK_SCANNER=remote` configures a new "remote controlled" scanner for testing.

@carolinemodic this doesn't serve your needs quite yet as it doesn't incorporate the scanner status stuff from #481, but it can be fairly easily updated.