### PR TITLE
feat(scan): add precinct scanner API

### DIFF
--- a/apps/bsd/src/AppRoot.tsx
+++ b/apps/bsd/src/AppRoot.tsx
@@ -8,7 +8,10 @@ import {
 } from '@votingworks/types'
 import styled from 'styled-components'
 
-import { ScanStatusResponse } from '@votingworks/types/api/module-scan'
+import {
+  ScannerStatus,
+  ScanStatusResponse,
+} from '@votingworks/types/api/module-scan'
 import { MachineConfig } from './config/types'
 import AppContext from './contexts/AppContext'
 
@@ -67,6 +70,7 @@ const App: React.FC = () => {
   const [status, setStatus] = useState<ScanStatusResponse>({
     batches: [],
     adjudication: { remaining: 0, adjudicated: 0 },
+    scanner: ScannerStatus.Unknown,
   })
 
   const [usbStatus, setUsbStatus] = useState(UsbDriveStatus.absent)

--- a/apps/bsd/src/screens/DashboardScreen.test.tsx
+++ b/apps/bsd/src/screens/DashboardScreen.test.tsx
@@ -1,5 +1,8 @@
 import { act, render, waitFor } from '@testing-library/react'
-import { ScanStatusResponse } from '@votingworks/types/api/module-scan'
+import {
+  ScannerStatus,
+  ScanStatusResponse,
+} from '@votingworks/types/api/module-scan'
 import { createMemoryHistory } from 'history'
 import React from 'react'
 import { Router } from 'react-router-dom'
@@ -15,6 +18,7 @@ test('null state', () => {
   const status: ScanStatusResponse = {
     batches: [],
     adjudication: noneLeftAdjudicationStatus,
+    scanner: ScannerStatus.Unknown,
   }
   const component = render(
     <Router history={createMemoryHistory()}>
@@ -50,6 +54,7 @@ test('shows scanned ballot count', () => {
       },
     ],
     adjudication: noneLeftAdjudicationStatus,
+    scanner: ScannerStatus.Unknown,
   }
   const component = render(
     <Router history={createMemoryHistory()}>
@@ -78,6 +83,7 @@ test('shows whether a batch is scanning', () => {
       },
     ],
     adjudication: noneLeftAdjudicationStatus,
+    scanner: ScannerStatus.Unknown,
   }
   const component = render(
     <Router history={createMemoryHistory()}>
@@ -111,6 +117,7 @@ test('allows deleting a batch', async () => {
       },
     ],
     adjudication: noneLeftAdjudicationStatus,
+    scanner: ScannerStatus.Unknown,
   }
   const component = render(
     <Router history={createMemoryHistory()}>

--- a/apps/module-scan/src/LoopScanner.ts
+++ b/apps/module-scan/src/LoopScanner.ts
@@ -1,3 +1,4 @@
+import { ScannerStatus } from '@votingworks/types/api/module-scan'
 import { readFileSync } from 'fs-extra'
 import { join, resolve } from 'path'
 import { BatchControl, Scanner } from './scanner'
@@ -92,6 +93,10 @@ export default class LoopScanner implements Scanner {
     this.batches = batches
   }
 
+  public async getStatus(): Promise<ScannerStatus> {
+    return ScannerStatus.Unknown
+  }
+
   /**
    * "Scans" the next sheet by returning the paths for the next two images.
    */
@@ -102,6 +107,18 @@ export default class LoopScanner implements Scanner {
     let sheetIndex = 0
 
     return {
+      async acceptSheet(): Promise<boolean> {
+        return true
+      },
+
+      async reviewSheet(): Promise<boolean> {
+        return false
+      },
+
+      async rejectSheet(): Promise<boolean> {
+        return false
+      },
+
       async scanSheet(): Promise<SheetOf<string> | undefined> {
         return currentBatch?.[sheetIndex++]
       },

--- a/apps/module-scan/src/importer.test.ts
+++ b/apps/module-scan/src/importer.test.ts
@@ -33,6 +33,7 @@ jest.setTimeout(20000)
 
 test('startImport calls scanner.scanSheet', async () => {
   const scanner: jest.Mocked<Scanner> = {
+    getStatus: jest.fn(),
     scanSheets: jest.fn(),
   }
   const importer = new Importer({
@@ -48,6 +49,9 @@ test('startImport calls scanner.scanSheet', async () => {
 
   // failed scan
   const batchControl: BatchControl = {
+    acceptSheet: jest.fn(),
+    reviewSheet: jest.fn(),
+    rejectSheet: jest.fn(),
     scanSheet: jest
       .fn()
       .mockRejectedValueOnce(new Error('scanner is a banana')),
@@ -65,6 +69,9 @@ test('startImport calls scanner.scanSheet', async () => {
 
   // successful scan
   scanner.scanSheets.mockReturnValueOnce({
+    acceptSheet: jest.fn(),
+    reviewSheet: jest.fn(),
+    rejectSheet: jest.fn(),
     scanSheet: jest
       .fn()
       .mockResolvedValueOnce([
@@ -81,6 +88,7 @@ test('startImport calls scanner.scanSheet', async () => {
 
 test('unconfigure clears all data.', async () => {
   const scanner: jest.Mocked<Scanner> = {
+    getStatus: jest.fn(),
     scanSheets: jest.fn(),
   }
   const importer = new Importer({
@@ -96,6 +104,7 @@ test('unconfigure clears all data.', async () => {
 
 test('setTestMode zeroes and sets test mode on the interpreter', async () => {
   const scanner: jest.Mocked<Scanner> = {
+    getStatus: jest.fn(),
     scanSheets: jest.fn(),
   }
   const importer = new Importer({
@@ -145,6 +154,7 @@ test('setTestMode zeroes and sets test mode on the interpreter', async () => {
 
 test('restoreConfig reconfigures the interpreter worker', async () => {
   const scanner: jest.Mocked<Scanner> = {
+    getStatus: jest.fn(),
     scanSheets: jest.fn(),
   }
   const workerCall = jest.fn()
@@ -168,6 +178,7 @@ test('restoreConfig reconfigures the interpreter worker', async () => {
 
 test('cannot add HMPB templates before configuring an election', async () => {
   const scanner: jest.Mocked<Scanner> = {
+    getStatus: jest.fn(),
     scanSheets: jest.fn(),
   }
   const importer = new Importer({
@@ -191,6 +202,7 @@ test('cannot add HMPB templates before configuring an election', async () => {
 
 test('manually importing files', async () => {
   const scanner: jest.Mocked<Scanner> = {
+    getStatus: jest.fn(),
     scanSheets: jest.fn(),
   }
   const workerCall = jest.fn<Promise<workers.Output>, [workers.Input]>()
@@ -301,6 +313,7 @@ test('manually importing files', async () => {
 
 test('scanning pauses on adjudication then continues', async () => {
   const scanner: jest.Mocked<Scanner> = {
+    getStatus: jest.fn(),
     scanSheets: jest.fn(),
   }
   const mockGetNextAdjudicationSheet = async (): Promise<BallotSheetInfo> => {
@@ -350,6 +363,9 @@ test('scanning pauses on adjudication then continues', async () => {
     })
 
   scanner.scanSheets.mockReturnValueOnce({
+    acceptSheet: jest.fn(),
+    reviewSheet: jest.fn(),
+    rejectSheet: jest.fn(),
     scanSheet: jest
       .fn()
       .mockResolvedValueOnce([
@@ -414,6 +430,7 @@ test('scanning pauses on adjudication then continues', async () => {
 
 test('importing a sheet normalizes and orders HMPB pages', async () => {
   const scanner: jest.Mocked<Scanner> = {
+    getStatus: jest.fn(),
     scanSheets: jest.fn(),
   }
   const workerCall = jest.fn<Promise<workers.Output>, [workers.Input]>()

--- a/apps/module-scan/src/scanner.test.ts
+++ b/apps/module-scan/src/scanner.test.ts
@@ -1,7 +1,8 @@
-import { FujitsuScanner, ScannerMode, ScannerPageSize } from './scanner'
-import { streamExecFile } from './exec'
+import { ScannerStatus } from '@votingworks/types/api/module-scan'
 import { ChildProcess } from 'child_process'
 import { makeMockChildProcess } from '../test/util/mocks'
+import { streamExecFile } from './exec'
+import { FujitsuScanner, ScannerMode, ScannerPageSize } from './scanner'
 
 jest.mock('./exec')
 
@@ -227,4 +228,19 @@ test('fujitsu scanner fails if scanSheet fails', async () => {
 
   scanimage.emit('exit', 1, null)
   await expect(sheets.scanSheet()).rejects.toThrowError()
+})
+
+test('fujitsu status', async () => {
+  expect(await new FujitsuScanner().getStatus()).toEqual(ScannerStatus.Unknown)
+})
+
+test('fujitsu accept/review/reject', async () => {
+  const scanimage = makeMockChildProcess()
+  exec.mockReturnValueOnce(scanimage)
+
+  const scanner = new FujitsuScanner()
+  const sheets = scanner.scanSheets()
+  expect(await sheets.acceptSheet()).toEqual(true)
+  expect(await sheets.reviewSheet()).toEqual(false)
+  expect(await sheets.rejectSheet()).toEqual(false)
 })

--- a/apps/module-scan/src/scanner.ts
+++ b/apps/module-scan/src/scanner.ts
@@ -1,3 +1,4 @@
+import { ScannerStatus } from '@votingworks/types/api/module-scan'
 import makeDebug from 'debug'
 import { join } from 'path'
 import { dirSync } from 'tmp'
@@ -10,10 +11,14 @@ const debug = makeDebug('module-scan:scanner')
 
 export interface BatchControl {
   scanSheet(): Promise<SheetOf<string> | undefined>
+  acceptSheet(): Promise<boolean>
+  reviewSheet(): Promise<boolean>
+  rejectSheet(): Promise<boolean>
   endBatch(): Promise<void>
 }
 
 export interface Scanner {
+  getStatus(): Promise<ScannerStatus>
   scanSheets(directory?: string): BatchControl
 }
 
@@ -67,6 +72,10 @@ export class FujitsuScanner implements Scanner {
     this.format = format
     this.pageSize = pageSize
     this.mode = mode
+  }
+
+  public async getStatus(): Promise<ScannerStatus> {
+    return ScannerStatus.Unknown
   }
 
   public scanSheets(directory = dirSync().name): BatchControl {
@@ -147,6 +156,18 @@ export class FujitsuScanner implements Scanner {
         }
 
         return results.get()
+      },
+
+      acceptSheet: async (): Promise<boolean> => {
+        return true
+      },
+
+      reviewSheet: async (): Promise<boolean> => {
+        return false
+      },
+
+      rejectSheet: async (): Promise<boolean> => {
+        return false
       },
 
       endBatch: async (): Promise<void> => {

--- a/apps/module-scan/src/server.test.ts
+++ b/apps/module-scan/src/server.test.ts
@@ -7,7 +7,10 @@ import {
   CandidateContest,
   YesNoContest,
 } from '@votingworks/types'
-import { ScanStatusResponse } from '@votingworks/types/api/module-scan'
+import {
+  ScannerStatus,
+  ScanStatusResponse,
+} from '@votingworks/types/api/module-scan'
 import { Application } from 'express'
 import { promises as fs } from 'fs'
 import { Server } from 'http'
@@ -85,6 +88,7 @@ test('GET /scan/status', async () => {
   const status: ScanStatusResponse = {
     batches: [],
     adjudication: { remaining: 0, adjudicated: 0 },
+    scanner: ScannerStatus.Unknown,
   }
   importer.getStatus.mockResolvedValue(status)
   await request(app)

--- a/apps/module-scan/src/util/castability.test.ts
+++ b/apps/module-scan/src/util/castability.test.ts
@@ -1,0 +1,101 @@
+import { BallotType } from '@votingworks/types'
+import {
+  BlankPage,
+  InterpretedBmdPage,
+  InterpretedHmpbPage,
+  UnreadablePage,
+} from '../interpreter'
+import { Castability, checkSheetCastability } from './castability'
+
+const interpretedBmdPage: Readonly<InterpretedBmdPage> = {
+  type: 'InterpretedBmdPage',
+  ballotId: 'abc',
+  metadata: {
+    ballotStyleId: '1',
+    precinctId: '6522',
+    ballotType: BallotType.Standard,
+    electionHash: '',
+    isTestMode: false,
+    locales: { primary: 'en-US' },
+  },
+  votes: {
+    'flag-question': ['yes'],
+  },
+}
+
+const interpretedHmpbPage: Readonly<InterpretedHmpbPage> = {
+  type: 'InterpretedHmpbPage',
+  ballotId: 'abcdefg',
+  metadata: {
+    locales: { primary: 'en-US' },
+    electionHash: '',
+    ballotType: BallotType.Standard,
+    ballotStyleId: '1',
+    precinctId: '6522',
+    isTestMode: false,
+    pageNumber: 1,
+  },
+  markInfo: { marks: [], ballotSize: { width: 1, height: 1 } },
+  adjudicationInfo: {
+    requiresAdjudication: false,
+    enabledReasons: [],
+    allReasonInfos: [],
+  },
+  votes: {},
+}
+
+const interpretedHmpbPageRequiringAdjudication: Readonly<InterpretedHmpbPage> = {
+  ...interpretedHmpbPage,
+  adjudicationInfo: {
+    ...interpretedHmpbPage.adjudicationInfo,
+    requiresAdjudication: true,
+  },
+}
+
+const unreadablePage: Readonly<UnreadablePage> = { type: 'UnreadablePage' }
+
+const blankPage: Readonly<BlankPage> = {
+  type: 'BlankPage',
+}
+
+test('castability of a BMD ballot', () => {
+  expect(checkSheetCastability([interpretedBmdPage, blankPage])).toEqual(
+    Castability.CastableWithoutReview
+  )
+  expect(checkSheetCastability([blankPage, interpretedBmdPage])).toEqual(
+    Castability.CastableWithoutReview
+  )
+})
+
+test('castability of a blank sheet', () => {
+  expect(checkSheetCastability([blankPage, blankPage])).toEqual(
+    Castability.Uncastable
+  )
+})
+
+test('castability of a HMPB ballot not requiring adjudication', () => {
+  expect(
+    checkSheetCastability([interpretedHmpbPage, interpretedHmpbPage])
+  ).toEqual(Castability.CastableWithoutReview)
+})
+
+test('castability of a HMPB ballot requiring adjudication', () => {
+  expect(
+    checkSheetCastability([
+      interpretedHmpbPageRequiringAdjudication,
+      interpretedHmpbPage,
+    ])
+  ).toEqual(Castability.CastableWithReview)
+  expect(
+    checkSheetCastability([
+      interpretedHmpbPage,
+      interpretedHmpbPageRequiringAdjudication,
+    ])
+  ).toEqual(Castability.CastableWithReview)
+})
+
+test('castability of an unreadable ballot', () => {
+  expect(checkSheetCastability([unreadablePage, unreadablePage])).toEqual(
+    Castability.Uncastable
+  )
+})

--- a/apps/module-scan/src/util/castability.ts
+++ b/apps/module-scan/src/util/castability.ts
@@ -1,0 +1,36 @@
+import { PageInterpretation } from '../interpreter'
+import { SheetOf } from '../types'
+
+export enum Castability {
+  Uncastable = 'Uncastable',
+  CastableWithoutReview = 'CastableWithoutReview',
+  CastableWithReview = 'CastableWithReview',
+}
+
+export function checkSheetCastability([
+  front,
+  back,
+]: SheetOf<PageInterpretation>): Castability {
+  if (
+    (front.type === 'InterpretedBmdPage' && back.type === 'BlankPage') ||
+    (front.type === 'BlankPage' && back.type === 'InterpretedBmdPage')
+  ) {
+    return Castability.CastableWithoutReview
+  }
+
+  if (
+    front.type === 'InterpretedHmpbPage' &&
+    back.type === 'InterpretedHmpbPage'
+  ) {
+    if (
+      front.adjudicationInfo.requiresAdjudication ||
+      back.adjudicationInfo.requiresAdjudication
+    ) {
+      return Castability.CastableWithReview
+    } else {
+      return Castability.CastableWithoutReview
+    }
+  }
+
+  return Castability.Uncastable
+}

--- a/apps/module-scan/test/util/mocks.ts
+++ b/apps/module-scan/test/util/mocks.ts
@@ -1,3 +1,4 @@
+import { ScannerStatus } from '@votingworks/types/api/module-scan'
 import { ChildProcess } from 'child_process'
 import { EventEmitter } from 'events'
 import { Readable, Writable } from 'stream'
@@ -86,6 +87,7 @@ class ScannerSessionPlan {
 
 export interface MockScanner extends Scanner {
   withNextScannerSession(): ScannerSessionPlan
+  getStatus: jest.MockedFunction<Scanner['getStatus']>
 }
 
 /**
@@ -105,6 +107,8 @@ export function makeMockScanner(): MockScanner {
   let nextScannerSession: ScannerSessionPlan | undefined
 
   return {
+    getStatus: jest.fn().mockResolvedValue(ScannerStatus.Unknown),
+
     scanSheets(): BatchControl {
       const session = nextScannerSession
       nextScannerSession = undefined
@@ -117,6 +121,10 @@ export function makeMockScanner(): MockScanner {
       }
 
       return {
+        acceptSheet: jest.fn(),
+        reviewSheet: jest.fn(),
+        rejectSheet: jest.fn(),
+
         scanSheet: async (): Promise<SheetOf<string>> => {
           const step = session.steps[stepIndex++]
 

--- a/libs/types/jest.config.js
+++ b/libs/types/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
     "<rootDir>/node_modules",
     "<rootDir>/dist"
   ],
-  collectCoverageFrom: ['src/**/*.ts'],
+  collectCoverageFrom: ['src/**/*.ts', '!src/api/module-scan.ts'],
   coverageThreshold: {
     global: {
       branches: 100,

--- a/libs/types/src/api/module-scan.ts
+++ b/libs/types/src/api/module-scan.ts
@@ -17,6 +17,14 @@ export interface ScanStatus {
   electionHash?: string
   batches: BatchInfo[]
   adjudication: AdjudicationStatus
+  scanner: ScannerStatus
+}
+
+export enum ScannerStatus {
+  WaitingForPaper = 'WaitingForPaper',
+  ReadyToScan = 'ReadyToScan',
+  Error = 'Error',
+  Unknown = 'Unknown',
 }
 
 /**


### PR DESCRIPTION
This expands the `Scanner` interface to include methods suitable for controlling a precinct scanner, i.e. holding & accepting/rejecting a ballot.

Extracted from #481 