### PR TITLE
feat(scan): always hold onto the sheet on reject

### DIFF
--- a/apps/module-scan/src/index.ts
+++ b/apps/module-scan/src/index.ts
@@ -21,9 +21,12 @@ async function getScanner(): Promise<Scanner | undefined> {
         `→ Remove paper: curl -X DELETE http://localhost:${port}/mock\n`
       )
       plustekMockServer(client).listen(port)
-      return new PlustekScanner({
-        get: async (): Promise<Result<ScannerClient, Error>> => ok(client),
-      })
+      return new PlustekScanner(
+        {
+          get: async (): Promise<Result<ScannerClient, Error>> => ok(client),
+        },
+        process.env.MODULE_SCAN_ALWAYS_HOLD_ON_REJECT !== '0'
+      )
     }
   } else {
     const mockScannerFiles = parseBatchesFromEnv(process.env.MOCK_SCANNER_FILES)

--- a/apps/module-scan/src/scanners/plustek.test.ts
+++ b/apps/module-scan/src/scanners/plustek.test.ts
@@ -125,6 +125,20 @@ test('plustek scanner reject sheet', async () => {
   expect(await scanner.scanSheets().rejectSheet()).toEqual(false)
 })
 
+test('plustek scanner reject sheet w/alwaysHoldOnReject', async () => {
+  const plustekClient = makeMockPlustekClient()
+  const scanner = new PlustekScanner(
+    {
+      get: jest.fn().mockResolvedValue(ok(plustekClient)),
+    },
+    true
+  )
+
+  plustekClient.reject.mockResolvedValueOnce(ok(undefined))
+  plustekClient.waitForStatus.mockResolvedValue(ok(PaperStatus.VtmReadyToScan))
+  expect(await scanner.scanSheets().rejectSheet()).toEqual(true)
+})
+
 // eslint-disable-next-line jest/expect-expect
 test('mock server', async () => {
   const client = new MockScannerClient({

--- a/apps/module-scan/src/server.ts
+++ b/apps/module-scan/src/server.ts
@@ -608,15 +608,18 @@ export async function start({
 
   scanner ??=
     process.env.VX_MACHINE_TYPE === 'precinct-scanner'
-      ? new PlustekScanner({
-          get: memo(
-            (): Promise<Result<ScannerClient, Error>> =>
-              createClient({
-                ...DEFAULT_CONFIG,
-                savepath: workspace!.ballotImagesPath,
-              })
-          ),
-        })
+      ? new PlustekScanner(
+          {
+            get: memo(
+              (): Promise<Result<ScannerClient, Error>> =>
+                createClient({
+                  ...DEFAULT_CONFIG,
+                  savepath: workspace!.ballotImagesPath,
+                })
+            ),
+          },
+          process.env.MODULE_SCAN_ALWAYS_HOLD_ON_REJECT !== '0'
+        )
       : new FujitsuScanner({ mode: ScannerMode.Gray })
   let workerPool: WorkerPool<workers.Input, workers.Output> | undefined
   const workerPoolProvider = (): WorkerPool<workers.Input, workers.Output> => {


### PR DESCRIPTION
This is configurable, but by default it's set to hold onto the paper on reject now. This makes `reject` and `review` functionally equivalent.