### PR TITLE
fix(types): unify more `module-scan` types

### DIFF
--- a/apps/bsd/src/api/config.test.ts
+++ b/apps/bsd/src/api/config.test.ts
@@ -15,13 +15,17 @@ test('PATCH /config/election', async () => {
 test('PATCH /config/election fails', async () => {
   fetchMock.patchOnce(
     '/config/election',
-    new Response(JSON.stringify({ status: 'error', error: 'bad election!' }), {
-      status: 400,
-    })
+    new Response(
+      JSON.stringify({
+        status: 'error',
+        errors: [{ type: 'invalid-value', message: 'bad election!' }],
+      }),
+      { status: 400 }
+    )
   )
   await expect(
     config.setElection(testElectionDefinition.electionData)
-  ).rejects.toThrowError('PATCH /config/election failed: bad election!')
+  ).rejects.toThrowError('bad election!')
 })
 
 test('DELETE /config/election to delete election', async () => {

--- a/apps/bsd/src/config/types.ts
+++ b/apps/bsd/src/config/types.ts
@@ -36,15 +36,6 @@ export interface CastVoteRecord
   _scannerId: string
 }
 
-export interface OkResponse {
-  status: 'ok'
-}
-
-export interface ErrorResponse {
-  status: 'error'
-  error: string
-}
-
 export type Ballot = BmdBallotInfo | HmpbBallotInfo | UnreadableBallotInfo
 
 export interface BmdBallotInfo {

--- a/apps/bsd/src/config/types/ballot-review.ts
+++ b/apps/bsd/src/config/types/ballot-review.ts
@@ -1,6 +1,7 @@
-import * as t from '@votingworks/types'
 import type { Point, Rect } from '@votingworks/hmpb-interpreter'
-import { OkResponse, AdjudicationReasonInfo } from '../types'
+import * as t from '@votingworks/types'
+import { OkResponse } from '@votingworks/types/src/api'
+import { AdjudicationReasonInfo } from '../types'
 
 type ContestId = t.Contest['id']
 

--- a/apps/bsd/src/screens/DashboardScreen.test.tsx
+++ b/apps/bsd/src/screens/DashboardScreen.test.tsx
@@ -1,7 +1,7 @@
 import { act, render, waitFor } from '@testing-library/react'
 import {
   ScannerStatus,
-  ScanStatusResponse,
+  GetScanStatusResponse,
 } from '@votingworks/types/api/module-scan'
 import { createMemoryHistory } from 'history'
 import React from 'react'
@@ -15,7 +15,7 @@ const noneLeftAdjudicationStatus = {
 
 test('null state', () => {
   const deleteBatch = jest.fn()
-  const status: ScanStatusResponse = {
+  const status: GetScanStatusResponse = {
     batches: [],
     adjudication: noneLeftAdjudicationStatus,
     scanner: ScannerStatus.Unknown,
@@ -38,7 +38,7 @@ test('null state', () => {
 
 test('shows scanned ballot count', () => {
   const deleteBatch = jest.fn()
-  const status: ScanStatusResponse = {
+  const status: GetScanStatusResponse = {
     batches: [
       {
         id: 'a',
@@ -74,7 +74,7 @@ test('shows scanned ballot count', () => {
 
 test('shows whether a batch is scanning', () => {
   const deleteBatch = jest.fn()
-  const status: ScanStatusResponse = {
+  const status: GetScanStatusResponse = {
     batches: [
       {
         id: 'a',
@@ -101,7 +101,7 @@ test('shows whether a batch is scanning', () => {
 
 test('allows deleting a batch', async () => {
   const deleteBatch = jest.fn()
-  const status: ScanStatusResponse = {
+  const status: GetScanStatusResponse = {
     batches: [
       {
         id: 'a',

--- a/apps/bsd/src/screens/DashboardScreen.tsx
+++ b/apps/bsd/src/screens/DashboardScreen.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import pluralize from 'pluralize'
 
 import {
-  ScanStatusResponse,
+  GetScanStatusResponse,
   AdjudicationStatus,
 } from '@votingworks/types/api/module-scan'
 
@@ -32,7 +32,7 @@ const shortDateTime = (iso8601Timestamp: string) => {
 interface Props {
   adjudicationStatus: AdjudicationStatus
   isScanning: boolean
-  status: ScanStatusResponse
+  status: GetScanStatusResponse
   deleteBatch(batchId: string): Promise<void>
 }
 

--- a/apps/bsd/src/setupTests.ts
+++ b/apps/bsd/src/setupTests.ts
@@ -1,8 +1,12 @@
 import fetchMock from 'fetch-mock'
 import jestFetchMock from 'jest-fetch-mock'
+import { TextDecoder, TextEncoder } from 'util'
 
 beforeEach(() => {
   jestFetchMock.enableMocks()
   fetchMock.reset()
   fetchMock.mock()
 })
+
+globalThis.TextDecoder = TextDecoder as typeof globalThis.TextDecoder
+globalThis.TextEncoder = TextEncoder as typeof globalThis.TextEncoder

--- a/apps/module-scan/src/endToEndHmpb.test.ts
+++ b/apps/module-scan/src/endToEndHmpb.test.ts
@@ -101,7 +101,8 @@ test('going through the whole process works', async () => {
     .expect(200)
     .then((response) => {
       expect(response.body).toEqual({
-        status: 'could not scan: interpreter still loading',
+        status: 'error',
+        errors: [{ type: 'scan-error', message: 'interpreter still loading' }],
       })
     })
 

--- a/apps/precinct-scanner/src/App.test.tsx
+++ b/apps/precinct-scanner/src/App.test.tsx
@@ -5,6 +5,7 @@ import { render, waitFor, fireEvent } from '@testing-library/react'
 import { fakeKiosk, fakeUsbDrive } from '@votingworks/test-utils'
 import { join } from 'path'
 import { electionSampleDefinition } from '@votingworks/fixtures'
+import { GetTestModeConfigResponse } from '@votingworks/types/api/module-scan'
 import App from './App'
 
 beforeEach(() => {
@@ -12,8 +13,12 @@ beforeEach(() => {
 })
 
 test('app can load and configure from a usb stick', async () => {
+  const getTestModeResponseBody: GetTestModeConfigResponse = {
+    status: 'ok',
+    testMode: true,
+  }
   fetchMock.getOnce('/config/election', new Response('null'))
-  fetchMock.get('/config/testMode', { testMode: true })
+  fetchMock.get('/config/testMode', getTestModeResponseBody)
   const { getByText } = render(<App />)
   await waitFor(() => getByText('Loading Configuration…'))
   jest.advanceTimersByTime(1001)

--- a/apps/precinct-scanner/src/AppUnhappyPaths.test.tsx
+++ b/apps/precinct-scanner/src/AppUnhappyPaths.test.tsx
@@ -2,23 +2,25 @@ import React from 'react'
 import fetchMock from 'fetch-mock'
 import { render, waitFor, fireEvent } from '@testing-library/react'
 import { electionSampleDefinition } from '@votingworks/fixtures'
+import { GetTestModeConfigResponse } from '@votingworks/types/api/module-scan'
 import App from './App'
 
 test('when module scan doesnt respond shows loading screen', async () => {
-  fetchMock.getOnce('/config/election', { status: 404 })
+  fetchMock.get('/config/election', { status: 404 })
   const spy = jest.spyOn(console, 'error').mockReturnValue()
 
   const { getByText } = render(<App />)
   await waitFor(() => getByText('Loading Configuration…'))
-  expect(spy).toHaveBeenCalledWith(
-    'failed to initialize:',
-    new Error('fetch response is not ok')
-  )
+  expect(spy).toHaveBeenCalledWith('failed to initialize:', expect.any(Error))
 })
 
 test('module-scan fails to unconfigure', async () => {
+  const getTestModeResponseBody: GetTestModeConfigResponse = {
+    status: 'ok',
+    testMode: true,
+  }
   fetchMock.getOnce('/config/election', electionSampleDefinition)
-  fetchMock.getOnce('/config/testMode', { testMode: true })
+  fetchMock.getOnce('/config/testMode', getTestModeResponseBody)
   fetchMock.deleteOnce('/config/election', { status: 404 })
   const spy = jest.spyOn(console, 'error').mockReturnValue()
 

--- a/apps/precinct-scanner/src/api/config.ts
+++ b/apps/precinct-scanner/src/api/config.ts
@@ -1,11 +1,17 @@
+import { ElectionDefinition, safeParseJSON } from '@votingworks/types'
+import { ErrorsResponse, OkResponse } from '@votingworks/types/api'
 import {
-  ElectionDefinition,
-  ErrorAPIResponse,
-  OkAPIResponse,
-} from '@votingworks/types'
-import fetchJSON from '../utils/fetchJSON'
+  GetElectionConfigResponse,
+  GetElectionConfigResponseSchema,
+  GetTestModeConfigResponseSchema,
+  PatchElectionConfigRequest,
+  PatchTestModeConfigRequest,
+} from '@votingworks/types/api/module-scan'
 
-async function patch(url: string, value: unknown): Promise<void> {
+async function patch<Body extends string | ArrayBuffer | unknown>(
+  url: string,
+  value: Body
+): Promise<void> {
   const isJSON = typeof value !== 'string' && !(value instanceof ArrayBuffer)
   const response = await fetch(url, {
     method: 'PATCH',
@@ -14,10 +20,10 @@ async function patch(url: string, value: unknown): Promise<void> {
       'Content-Type': isJSON ? 'application/json' : 'application/octet-stream',
     },
   })
-  const body: OkAPIResponse | ErrorAPIResponse = await response.json()
+  const body: OkResponse | ErrorsResponse = await response.json()
 
   if (body.status !== 'ok') {
-    throw new Error(`PATCH ${url} failed: ${body.error}`)
+    throw new Error(`PATCH ${url} failed: ${JSON.stringify(body.errors)}`)
   }
 }
 
@@ -26,32 +32,48 @@ async function del(url: string): Promise<void> {
     method: 'DELETE',
     headers: { 'Content-Type': 'application/json' },
   })
-  const body: OkAPIResponse | ErrorAPIResponse = await response.json()
+  const body: OkResponse | ErrorsResponse = await response.json()
 
   if (body.status !== 'ok') {
-    throw new Error(`DELETE ${url} failed: ${body.error}`)
+    throw new Error(`DELETE ${url} failed: ${JSON.stringify(body.errors)}`)
   }
 }
 
 export async function getElectionDefinition(): Promise<
   ElectionDefinition | undefined
 > {
-  return (await fetchJSON('/config/election')) ?? undefined
+  return (
+    (safeParseJSON(
+      await (
+        await fetch('/config/election', {
+          headers: { Accept: 'application/json' },
+        })
+      ).text(),
+      GetElectionConfigResponseSchema
+    ).unwrap() as Exclude<GetElectionConfigResponse, string>) ?? undefined
+  )
 }
 
 export async function setElection(electionData?: string): Promise<void> {
   if (typeof electionData === 'undefined') {
     await del('/config/election')
   } else {
-    await patch('/config/election', electionData)
+    await patch<PatchElectionConfigRequest>(
+      '/config/election',
+      new TextEncoder().encode(electionData)
+    )
   }
 }
 
 export async function getTestMode(): Promise<boolean> {
-  const { testMode } = await fetchJSON('/config/testMode')
-  return testMode
+  return safeParseJSON(
+    await (await fetch('/config/testMode')).text(),
+    GetTestModeConfigResponseSchema
+  ).unwrap().testMode
 }
 
 export async function setTestMode(testMode: boolean): Promise<void> {
-  await patch('/config/testMode', { testMode })
+  await patch<PatchTestModeConfigRequest>('/config/testMode', {
+    testMode,
+  })
 }

--- a/apps/precinct-scanner/src/config/ballot-review-types.ts
+++ b/apps/precinct-scanner/src/config/ballot-review-types.ts
@@ -1,5 +1,6 @@
 import * as t from '@votingworks/types'
 import type { Point, Rect } from '@votingworks/hmpb-interpreter'
+import { OkResponse } from '@votingworks/types/api'
 import { AdjudicationReasonInfo } from './types'
 
 type ContestId = t.Contest['id']
@@ -20,7 +21,7 @@ export interface MarksByOptionId {
   [key: string]: MarkStatus | undefined
 }
 
-export type PutBallotResponse = t.OkAPIResponse
+export type PutBallotResponse = OkResponse
 
 export interface ContestLayout {
   bounds: Rect

--- a/apps/precinct-scanner/src/setupTests.ts
+++ b/apps/precinct-scanner/src/setupTests.ts
@@ -1,8 +1,12 @@
 import fetchMock from 'fetch-mock'
 import jestFetchMock from 'jest-fetch-mock'
+import { TextDecoder, TextEncoder } from 'util'
 
 beforeEach(() => {
   jestFetchMock.enableMocks()
   fetchMock.reset()
   fetchMock.mock()
 })
+
+globalThis.TextDecoder = TextDecoder as typeof globalThis.TextDecoder
+globalThis.TextEncoder = TextEncoder as typeof globalThis.TextEncoder

--- a/libs/types/src/api/index.test.ts
+++ b/libs/types/src/api/index.test.ts
@@ -1,0 +1,12 @@
+import { safeParse } from '../'
+import { ErrorsResponseSchema, OkResponseSchema } from './'
+
+test('OkResponse', () => {
+  safeParse(OkResponseSchema, { status: 'ok' }).unwrap()
+  safeParse(OkResponseSchema, {}).unwrapErr()
+})
+
+test('ErrorsResponse', () => {
+  safeParse(ErrorsResponseSchema, { status: 'error', errors: [] }).unwrap()
+  safeParse(ErrorsResponseSchema, { status: 'ok' }).unwrapErr()
+})

--- a/libs/types/src/api/index.ts
+++ b/libs/types/src/api/index.ts
@@ -1,1 +1,24 @@
+import * as z from 'zod'
+import { ISO8601Date } from '../schema'
+
 export type ISO8601Timestamp = string
+
+export const ISO8601TimestampSchema = ISO8601Date
+
+export type OkResponse<Props = Record<string, unknown>> = {
+  status: 'ok'
+} & Props
+
+export const OkResponseSchema: z.ZodSchema<OkResponse> = z.object({
+  status: z.literal('ok'),
+})
+
+export interface ErrorsResponse {
+  status: 'error'
+  errors: { type: string; message: string }[]
+}
+
+export const ErrorsResponseSchema: z.ZodSchema<ErrorsResponse> = z.object({
+  status: z.literal('error'),
+  errors: z.array(z.object({ type: z.string(), message: z.string() })),
+})

--- a/libs/types/src/api/module-scan.ts
+++ b/libs/types/src/api/module-scan.ts
@@ -1,9 +1,26 @@
-import { ISO8601Timestamp } from '.'
+import * as z from 'zod'
+import {
+  ErrorsResponse,
+  ErrorsResponseSchema,
+  ISO8601Timestamp,
+  ISO8601TimestampSchema,
+  OkResponse,
+  OkResponseSchema,
+} from '.'
+import { ElectionDefinition, MarkThresholds } from '../election'
+import * as s from '../schema'
 
 export interface AdjudicationStatus {
   adjudicated: number
   remaining: number
 }
+
+export const AdjudicationStatusSchema: z.ZodSchema<AdjudicationStatus> = z.object(
+  {
+    adjudicated: z.number(),
+    remaining: z.number(),
+  }
+)
 
 export interface BatchInfo {
   id: string
@@ -13,12 +30,13 @@ export interface BatchInfo {
   count: number
 }
 
-export interface ScanStatus {
-  electionHash?: string
-  batches: BatchInfo[]
-  adjudication: AdjudicationStatus
-  scanner: ScannerStatus
-}
+export const BatchInfoSchema: z.ZodSchema<BatchInfo> = z.object({
+  id: s.Id,
+  startedAt: ISO8601TimestampSchema,
+  endedAt: z.optional(ISO8601TimestampSchema),
+  error: z.optional(z.string()),
+  count: z.number().nonnegative(),
+})
 
 export enum ScannerStatus {
   WaitingForPaper = 'WaitingForPaper',
@@ -27,8 +45,411 @@ export enum ScannerStatus {
   Unknown = 'Unknown',
 }
 
+export const ScannerStatusSchema = z.nativeEnum(ScannerStatus)
+
+export interface ScanStatus {
+  electionHash?: string
+  batches: BatchInfo[]
+  adjudication: AdjudicationStatus
+  scanner: ScannerStatus
+}
+
+export const ScanStatusSchema: z.ZodSchema<ScanStatus> = z.object({
+  electionHash: z.optional(s.HexString),
+  batches: z.array(BatchInfoSchema),
+  adjudication: AdjudicationStatusSchema,
+  scanner: ScannerStatusSchema,
+})
+
 /**
  * @url /scan/status
  * @method GET
  */
-export type ScanStatusResponse = ScanStatus
+export type GetScanStatusResponse = ScanStatus
+
+/**
+ * @url /scan/status
+ * @method GET
+ */
+export const GetScanStatusResponseSchema: z.ZodSchema<GetScanStatusResponse> = ScanStatusSchema
+
+/**
+ * @url /config/election
+ * @method GET
+ */
+export type GetElectionConfigResponse = ElectionDefinition | null | string
+
+/**
+ * @url /config/election
+ * @method GET
+ */
+export const GetElectionConfigResponseSchema: z.ZodSchema<GetElectionConfigResponse> = z.union(
+  [s.ElectionDefinition, z.null(), z.string()]
+)
+
+/**
+ * @url /config/election
+ * @method PATCH
+ */
+export type PatchElectionConfigResponse = OkResponse | ErrorsResponse
+
+/**
+ * @url /config/election
+ * @method PATCH
+ */
+export const PatchElectionConfigResponseSchema: z.ZodSchema<PatchElectionConfigResponse> = z.union(
+  [OkResponseSchema, ErrorsResponseSchema]
+)
+
+/**
+ * @url /config/election
+ * @method PATCH
+ */
+export type PatchElectionConfigRequest = Uint8Array // should be Buffer, but this triggers type errors
+
+/**
+ * @url /config/election
+ * @method PATCH
+ */
+export const PatchElectionConfigRequestSchema: z.ZodSchema<PatchElectionConfigRequest> = z.instanceof(
+  // should be Buffer, but this triggers type errors
+  Uint8Array
+)
+
+/**
+ * @url /config/election
+ * @method DELETE
+ */
+export type DeleteElectionConfigResponse = OkResponse
+
+/**
+ * @url /config/election
+ * @method DELETE
+ */
+export const DeleteElectionConfigResponseSchema: z.ZodSchema<DeleteElectionConfigResponse> = OkResponseSchema
+
+/**
+ * @url /config/testMode
+ * @method GET
+ */
+export type GetTestModeConfigResponse = OkResponse<{ testMode: boolean }>
+
+/**
+ * @url /config/testMode
+ * @method GET
+ */
+export const GetTestModeConfigResponseSchema: z.ZodSchema<GetTestModeConfigResponse> = z.object(
+  {
+    status: z.literal('ok'),
+    testMode: z.boolean(),
+  }
+)
+
+/**
+ * @url /config/testMode
+ * @method PATCH
+ */
+export interface PatchTestModeConfigRequest {
+  testMode: boolean
+}
+
+/**
+ * @url /config/testMode
+ * @method PATCH
+ */
+export const PatchTestModeConfigRequestSchema: z.ZodSchema<PatchTestModeConfigRequest> = z.object(
+  {
+    testMode: z.boolean(),
+  }
+)
+
+/**
+ * @url /config/testMode
+ * @method PATCH
+ */
+export type PatchTestModeConfigResponse = OkResponse | ErrorsResponse
+
+/**
+ * @url /config/testMode
+ * @method PATCH
+ */
+export const PatchTestModeConfigResponseSchema: z.ZodSchema<PatchTestModeConfigResponse> = z.union(
+  [OkResponseSchema, ErrorsResponseSchema]
+)
+
+/**
+ * @url /config/markThresholdOverrides
+ * @method GET
+ */
+export type GetMarkThresholdOverridesConfigResponse = OkResponse<{
+  markThresholdOverrides?: MarkThresholds
+}>
+
+/**
+ * @url /config/markThresholdOverrides
+ * @method GET
+ */
+export const GetMarkThresholdOverridesConfigResponseSchema: z.ZodSchema<GetMarkThresholdOverridesConfigResponse> = z.object(
+  {
+    status: z.literal('ok'),
+    markThresholdOverrides: z.optional(s.MarkThresholds),
+  }
+)
+
+/**
+ * @url /config/markThresholdOverrides
+ * @method DELETE
+ */
+export type DeleteMarkThresholdOverridesConfigResponse = OkResponse
+
+/**
+ * @url /config/markThresholdOverrides
+ * @method DELETE
+ */
+export const DeleteMarkThresholdOverridesConfigResponseSchema = OkResponseSchema
+
+/**
+ * @url /config/markThresholdOverrides
+ * @method PATCH
+ */
+export interface PatchMarkThresholdOverridesConfigRequest {
+  markThresholdOverrides?: MarkThresholds
+}
+
+/**
+ * @url /config/markThresholdOverrides
+ * @method PATCH
+ */
+export const PatchMarkThresholdOverridesConfigRequestSchema: z.ZodSchema<PatchMarkThresholdOverridesConfigRequest> = z.object(
+  {
+    markThresholdOverrides: z.optional(s.MarkThresholds),
+  }
+)
+
+/**
+ * @url /config/markThresholdOverrides
+ * @method PATCH
+ */
+export type PatchMarkThresholdOverridesConfigResponse =
+  | OkResponse
+  | ErrorsResponse
+
+/**
+ * @url /config/markThresholdOverrides
+ * @method PATCH
+ */
+export const PatchMarkThresholdOverridesConfigResponseSchema: z.ZodSchema<PatchMarkThresholdOverridesConfigResponse> = z.union(
+  [OkResponseSchema, ErrorsResponseSchema]
+)
+
+/**
+ * @url /config/skipElectionHashCheck
+ * @method PATCH
+ */
+export interface PatchSkipElectionHashCheckConfigRequest {
+  skipElectionHashCheck: boolean
+}
+
+/**
+ * @url /config/skipElectionHashCheck
+ * @method PATCH
+ */
+export const PatchSkipElectionHashCheckConfigRequestSchema: z.ZodSchema<PatchSkipElectionHashCheckConfigRequest> = z.object(
+  {
+    skipElectionHashCheck: z.boolean(),
+  }
+)
+
+/**
+ * @url /config/skipElectionHashCheck
+ * @method PATCH
+ */
+export type PatchSkipElectionHashCheckConfigResponse =
+  | OkResponse
+  | ErrorsResponse
+
+/**
+ * @url /config/skipElectionHashCheck
+ * @method PATCH
+ */
+export const PatchSkipElectionHashCheckConfigResponseSchema: z.ZodSchema<PatchSkipElectionHashCheckConfigResponse> = z.union(
+  [OkResponseSchema, ErrorsResponseSchema]
+)
+
+/**
+ * @url /scan/scanBatch
+ * @method POST
+ */
+export type ScanBatchRequest = never
+
+/**
+ * @url /scan/scanBatch
+ * @method POST
+ */
+export const ScanBatchRequestSchema: z.ZodSchema<ScanBatchRequest> = z.never()
+
+/**
+ * @url /scan/scanBatch
+ * @method POST
+ */
+export type ScanBatchResponse = OkResponse<{ batchId: string }> | ErrorsResponse
+
+/**
+ * @url /scan/scanBatch
+ * @method POST
+ */
+export const ScanBatchResponseSchema: z.ZodSchema<ScanBatchResponse> = z.union([
+  z.object({
+    status: z.literal('ok'),
+    batchId: z.string(),
+  }),
+  ErrorsResponseSchema,
+])
+
+/**
+ * @url /scan/scanContinue
+ * @method POST
+ */
+export interface ScanContinueRequest {
+  override?: boolean
+}
+
+/**
+ * @url /scan/scanContinue
+ * @method POST
+ */
+export const ScanContinueRequestSchema: z.ZodSchema<ScanContinueRequest> = z.object(
+  {
+    override: z.optional(z.boolean()),
+  }
+)
+
+/**
+ * @url /scan/scanContinue
+ * @method POST
+ */
+export type ScanContinueResponse = OkResponse | ErrorsResponse
+
+/**
+ * @url /scan/scanContinue
+ * @method POST
+ */
+export const ScanContinueResponseSchema: z.ZodSchema<ScanContinueResponse> = z.union(
+  [OkResponseSchema, ErrorsResponseSchema]
+)
+
+/**
+ * This is `never` because the request is not JSON, but multipart/form-data,
+ * so none of the actual data ends up in `request.body`.
+ *
+ * @url /scan/hmpb/addTemplates
+ * @method POST
+ */
+export type AddTemplatesRequest = never
+
+/**
+ * This is `never` because the request is not JSON, but multipart/form-data,
+ * so none of the actual data ends up in `request.body`.
+ *
+ * @url /scan/hmpb/addTemplates
+ * @method POST
+ */
+export const AddTemplatesRequestSchema: z.ZodSchema<AddTemplatesRequest> = z.never()
+
+/**
+ * @url /scan/hmpb/addTemplates
+ * @method POST
+ */
+export type AddTemplatesResponse = OkResponse | ErrorsResponse
+
+/**
+ * @url /scan/hmpb/addTemplates
+ * @method POST
+ */
+export const AddTemplatesResponseSchema: z.ZodSchema<AddTemplatesResponse> = z.union(
+  [OkResponseSchema, ErrorsResponseSchema]
+)
+
+/**
+ * This is `never` because there is no request data.
+ *
+ * @url /scan/hmpb/doneTemplates
+ * @method POST
+ */
+export type DoneTemplatesRequest = never
+
+/**
+ * This is `never` because there is no request data.
+ *
+ * @url /scan/hmpb/doneTemplates
+ * @method POST
+ */
+export const DoneTemplatesRequestSchema: z.ZodSchema<DoneTemplatesRequest> = z.never()
+
+/**
+ * @url /scan/hmpb/doneTemplates
+ * @method POST
+ */
+export type DoneTemplatesResponse = OkResponse
+
+/**
+ * @url /scan/hmpb/doneTemplates
+ * @method POST
+ */
+export const DoneTemplatesResponseSchema: z.ZodSchema<DoneTemplatesResponse> = OkResponseSchema
+
+/**
+ * This is `never` because there is no request data.
+ *
+ * @url /scan/export
+ * @method POST
+ */
+export type ExportRequest = never
+
+/**
+ * This is `never` because there is no request data.
+ *
+ * @url /scan/export
+ * @method POST
+ */
+export const ExportRequestSchema: z.ZodSchema<ExportRequest> = z.never()
+
+/**
+ * @url /scan/export
+ * @method POST
+ */
+export type ExportResponse = string
+
+/**
+ * @url /scan/export
+ * @method POST
+ */
+export const ExportResponseSchema: z.ZodSchema<ExportResponse> = z.string()
+
+/**
+ * This is `never` because there is no request data.
+ *
+ * @url /scan/zero
+ * @method POST
+ */
+export type ZeroRequest = never
+
+/**
+ * This is `never` because there is no request data.
+ *
+ * @url /scan/zero
+ * @method POST
+ */
+export const ZeroRequestSchema: z.ZodSchema<ZeroRequest> = z.never()
+
+/**
+ * @url /scan/zero
+ * @method POST
+ */
+export type ZeroResponse = OkResponse
+
+/**
+ * @url /scan/zero
+ * @method POST
+ */
+export const ZeroResponseSchema: z.ZodSchema<ZeroResponse> = OkResponseSchema

--- a/libs/types/src/generic.ts
+++ b/libs/types/src/generic.ts
@@ -5,14 +5,6 @@ export type Optional<T> = T | undefined
 export interface Provider<T> {
   get(): Promise<T>
 }
-export interface OkAPIResponse {
-  status: 'ok'
-}
-
-export interface ErrorAPIResponse {
-  status: 'error'
-  error: string
-}
 
 /**
  * Represents either success with a value `T` or failure with error `E`.


### PR DESCRIPTION
Provides types and zod schemas for most of the `module-scan` API request and response bodies. This also uses them in many, but not all, relevant server and client locations.