### PR TITLE
fix(scan): ensure bsd can get/set election config

### DIFF
--- a/apps/bsd/src/api/config.ts
+++ b/apps/bsd/src/api/config.ts
@@ -60,7 +60,11 @@ export async function getElectionDefinition(): Promise<
 > {
   return (
     (safeParseJSON(
-      await (await fetch('/config/election')).text(),
+      await (
+        await fetch('/config/election', {
+          headers: { Accept: 'application/json' },
+        })
+      ).text(),
       GetElectionConfigResponseSchema
     ).unwrap() as Exclude<GetElectionConfigResponse, string>) ?? undefined
   )

--- a/apps/bsd/src/api/config.ts
+++ b/apps/bsd/src/api/config.ts
@@ -18,7 +18,10 @@ async function patch<Body extends string | ArrayBuffer | unknown>(
   url: string,
   value: Body
 ): Promise<void> {
-  const isJSON = typeof value !== 'string' && !(value instanceof ArrayBuffer)
+  const isJSON =
+    typeof value !== 'string' &&
+    !(value instanceof ArrayBuffer) &&
+    !(value instanceof Uint8Array)
   const response = await fetch(url, {
     method: 'PATCH',
     body: isJSON ? JSON.stringify(value) : (value as BodyInit),

--- a/apps/precinct-scanner/src/api/config.ts
+++ b/apps/precinct-scanner/src/api/config.ts
@@ -12,7 +12,10 @@ async function patch<Body extends string | ArrayBuffer | unknown>(
   url: string,
   value: Body
 ): Promise<void> {
-  const isJSON = typeof value !== 'string' && !(value instanceof ArrayBuffer)
+  const isJSON =
+    typeof value !== 'string' &&
+    !(value instanceof ArrayBuffer) &&
+    !(value instanceof Uint8Array)
   const response = await fetch(url, {
     method: 'PATCH',
     body: isJSON ? JSON.stringify(value) : (value as BodyInit),


### PR DESCRIPTION
Without this, when there's no election, bsd would get a 404 because it never set an `Accept` header. Thus, module-scan would fall into the `application/octet-stream` case and respond with 404 when there was no election.

Also, the change to using `TextEncoder#encode` gives a `Uint8Array`, not an `ArrayBuffer`.

Highlights the need for integration tests.