### PR TITLE
build(all): prevent infinite loops in `tsc -b -w`

### DIFF
--- a/apps/election-manager/tsconfig.json
+++ b/apps/election-manager/tsconfig.json
@@ -17,6 +17,7 @@
     "target": "es2015"
   },
   "include": ["src", "test", "types"],
+  "exclude": ["src/setupProxy.js"],
   "references": [
     { "path": "../../libs/ballot-encoder" },
     { "path": "../../libs/fixtures" },

--- a/apps/precinct-scanner/tsconfig.json
+++ b/apps/precinct-scanner/tsconfig.json
@@ -17,6 +17,7 @@
     "target": "es2015"
   },
   "include": ["src", "test", "types"],
+  "exclude": ["src/setupProxy.js"],
   "references": [
     { "path": "../../libs/ballot-encoder" },
     { "path": "../../libs/hmpb-interpreter" },


### PR DESCRIPTION
When building with `tsc --build --watch` in a React app, TypeScript seems to consider `src/setupProxy.js` both an input file and an output file. Because the `noEmit` option is set, it doesn't complain about this. However, it does update the timestamps of all the outputs when a build completes. This then triggers the file watcher to begin a new build. This only happens after the first build completes and the watcher kicks off a build for the first time and I'm unsure why.

Instructing TypeScript to ignore `src/setupProxy.js` fixes the issue.