### PR TITLE
feat(ps): Button bar supports variable content length buttons

### DIFF
--- a/apps/precinct-scanner/src/screens/PollWorkerScreen.tsx
+++ b/apps/precinct-scanner/src/screens/PollWorkerScreen.tsx
@@ -73,17 +73,18 @@ const PollWorkerScreen: React.FC<Props> = ({
         <Modal
           content={
             <Prose>
-              <h1>Open Polls and Save Zero Report</h1>
+              <h1>Save Zero Report?</h1>
               <p>
-                Zero Report will be saved to the current poll worker card.
-                Insert this card into VxMark to print the report.
+                The <strong>Zero Report</strong> will be saved on the currently
+                inserted poll worker card. After the report is saved on the
+                card, insert the card into VxMark to print this report.
               </p>
             </Prose>
           }
           actions={
             <React.Fragment>
-              <Button onPress={openPollsAndSaveZeroReport}>
-                Save Zero Report and Open Polls
+              <Button onPress={openPollsAndSaveZeroReport} primary>
+                Save Report and Open Polls
               </Button>
               <Button onPress={closeConfirmOpenPollsModal}>Cancel</Button>
             </React.Fragment>
@@ -94,17 +95,18 @@ const PollWorkerScreen: React.FC<Props> = ({
         <Modal
           content={
             <Prose>
-              <h1>Close Polls and Save Tabulation Report</h1>
+              <h1>Save Tabulation Report?</h1>
               <p>
-                Tabulation Report will be saved to the current poll worker card.
-                Insert this card into VxMark to print the report.
+                The <strong>Tabulation Report</strong> will be saved on the
+                currently inserted poll worker card. After the report is saved
+                on the card, insert the card into VxMark to print this report.
               </p>
             </Prose>
           }
           actions={
             <React.Fragment>
-              <Button onPress={closePollsAndSaveTabulationReport}>
-                Save Tabulation Report and Close Polls
+              <Button onPress={closePollsAndSaveTabulationReport} primary>
+                Save Report and Close Polls
               </Button>
               <Button onPress={closeConfirmClosePollsModal}>Cancel</Button>
             </React.Fragment>

--- a/libs/ui/src/ButtonBar.tsx
+++ b/libs/ui/src/ButtonBar.tsx
@@ -11,15 +11,16 @@ export const ButtonBar = styled('nav')`
 
   & > *:first-child {
     order: 2;
+    min-width: 50%;
   }
 
   & > * {
-    flex: 1;
+    flex-grow: 1;
     margin: 0.25rem;
   }
   & > *:only-child {
     @media (min-width: 480px) {
-      flex: 0;
+      flex-grow: initial;
       margin: auto;
       min-width: 33.333%;
     }

--- a/libs/ui/src/__snapshots__/ButonBar.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/ButonBar.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`renders ButtonBar 1`] = `
 <nav
-  class="sc-bdvvaa evrdKv"
+  class="sc-bdvvaa jnUhGH"
 >
   foo
 </nav>


### PR DESCRIPTION
Fixed the modal's main button to take more width as necessary. The main button has a min-width of 50% to ensure that it is at least the width of the secondary button. When there are more than two buttons, the width of each button can be overridden with inline styles. 

![image](https://user-images.githubusercontent.com/28444/118727840-49992100-b7e8-11eb-81dd-f9158085d449.png)

![image](https://user-images.githubusercontent.com/28444/118727964-7e0cdd00-b7e8-11eb-8deb-3ba77b2dba04.png)
