### PR TITLE
feat(scan): allow configuring for a specific precinct

### DIFF
--- a/apps/bsd/src/components/DebugSheet.tsx
+++ b/apps/bsd/src/components/DebugSheet.tsx
@@ -68,6 +68,7 @@ const DebugSheet: React.FC = () => {
   if (
     interpretation.type === 'BlankPage' ||
     interpretation.type === 'InvalidTestModePage' ||
+    interpretation.type === 'InvalidPrecinctPage' ||
     interpretation.type === 'UnreadablePage' ||
     interpretation.type === 'UninterpretedHmpbPage' ||
     interpretation.type === 'InterpretedBmdPage' ||

--- a/apps/bsd/src/components/DebugSheetPageCell.tsx
+++ b/apps/bsd/src/components/DebugSheetPageCell.tsx
@@ -59,6 +59,9 @@ function interpretationTitle(interpretation: PageInterpretation) {
     case 'InvalidTestModePage':
       return 'invalid test mode'
 
+    case 'InvalidPrecinctPage':
+      return 'invalid precinct'
+
     case 'UninterpretedHmpbPage':
       return 'HMPB (uninterpreted)'
 

--- a/apps/bsd/src/config/types.ts
+++ b/apps/bsd/src/config/types.ts
@@ -96,6 +96,7 @@ export type PageInterpretation =
   | InterpretedBmdPage
   | InterpretedHmpbPage
   | InvalidTestModePage
+  | InvalidPrecinctPage
   | UninterpretedHmpbPage
   | UnreadablePage
   | InvalidElectionHashPage
@@ -122,6 +123,11 @@ export interface InterpretedHmpbPage {
 
 export interface InvalidTestModePage {
   type: 'InvalidTestModePage'
+  metadata: BallotMetadata | BallotPageMetadata
+}
+
+export interface InvalidPrecinctPage {
+  type: 'InvalidPrecinctPage'
   metadata: BallotMetadata | BallotPageMetadata
 }
 

--- a/apps/bsd/src/screens/BallotEjectScreen.test.tsx
+++ b/apps/bsd/src/screens/BallotEjectScreen.test.tsx
@@ -341,3 +341,56 @@ test('shows invalid election screen when appropriate', async () => {
   fireEvent.click(getByText('Confirm Ballot Removed and Continue Scanning'))
   expect(continueScanning).toHaveBeenCalledWith()
 })
+
+test('shows invalid election screen when appropriate', async () => {
+  const response: BallotSheetInfo = {
+    id: 'mock-sheet-id',
+    front: {
+      image: { url: '/front/url' },
+      interpretation: {
+        type: 'InvalidPrecinctPage',
+        metadata: {
+          ballotStyleId: '1',
+          precinctId: '1',
+          ballotType: BallotType.Standard,
+          electionHash: '',
+          isTestMode: false,
+          locales: { primary: 'en-US' },
+          pageNumber: 1,
+        },
+      },
+    },
+    back: {
+      image: { url: '/back/url' },
+      interpretation: {
+        type: 'InvalidPrecinctPage',
+        metadata: {
+          ballotStyleId: '1',
+          precinctId: '1',
+          ballotType: BallotType.Standard,
+          electionHash: '',
+          isTestMode: false,
+          locales: { primary: 'en-US' },
+          pageNumber: 2,
+        },
+      },
+    },
+  }
+  fetchMock.getOnce('/scan/hmpb/review/next-sheet', response)
+
+  const continueScanning = jest.fn()
+
+  const { getByText, queryAllByText } = renderInAppContext(
+    <BallotEjectScreen continueScanning={continueScanning} isTestMode={false} />
+  )
+
+  await act(async () => {
+    await waitFor(() => fetchMock.called)
+  })
+
+  getByText('Wrong Precinct')
+  expect(queryAllByText('Tabulate Duplicate Ballot').length).toBe(0)
+
+  fireEvent.click(getByText('Confirm Ballot Removed and Continue Scanning'))
+  expect(continueScanning).toHaveBeenCalledWith()
+})

--- a/apps/bsd/src/screens/BallotEjectScreen.tsx
+++ b/apps/bsd/src/screens/BallotEjectScreen.tsx
@@ -83,6 +83,7 @@ const BallotEjectScreen: React.FC<Props> = ({
   let isUnreadableSheet = false
   let isInvalidTestModeSheet = false
   let isInvalidElectionHashSheet = false
+  let isInvalidPrecinctSheet = false
 
   let actualElectionHash: string
 
@@ -92,6 +93,8 @@ const BallotEjectScreen: React.FC<Props> = ({
     } else if (interpretation.type === 'InvalidElectionHashPage') {
       isInvalidElectionHashSheet = true
       actualElectionHash = interpretation.actualElectionHash
+    } else if (interpretation.type === 'InvalidPrecinctPage') {
+      isInvalidPrecinctSheet = true
     } else if (interpretation.type === 'InterpretedHmpbPage') {
       if (interpretation.adjudicationInfo.requiresAdjudication) {
         for (const { type } of interpretation.adjudicationInfo.allReasonInfos) {
@@ -110,7 +113,10 @@ const BallotEjectScreen: React.FC<Props> = ({
   }
 
   const allowBallotDuplication =
-    !isInvalidTestModeSheet && !isInvalidElectionHashSheet && !isUnreadableSheet
+    !isInvalidTestModeSheet &&
+    !isInvalidElectionHashSheet &&
+    !isInvalidPrecinctSheet &&
+    !isUnreadableSheet
 
   return (
     <Screen>
@@ -143,6 +149,8 @@ const BallotEjectScreen: React.FC<Props> = ({
                   : 'Test Ballot'
                 : isInvalidElectionHashSheet
                 ? 'Wrong Election'
+                : isInvalidPrecinctSheet
+                ? 'Wrong Precinct'
                 : isUnreadableSheet
                 ? 'Unreadable'
                 : isOvervotedSheet
@@ -213,6 +221,13 @@ const BallotEjectScreen: React.FC<Props> = ({
                 <Text small>
                   Ballot Election Hash: {actualElectionHash!.slice(0, 10)}
                 </Text>
+              </React.Fragment>
+            ) : isInvalidPrecinctSheet ? (
+              <React.Fragment>
+                <p>
+                  The scanned ballot does not match the precinct this scanner is
+                  configured for. Remove the invalid ballot before continuing.
+                </p>
               </React.Fragment>
             ) : (
               // Unreadable

--- a/apps/module-scan/src/importer.test.ts
+++ b/apps/module-scan/src/importer.test.ts
@@ -558,3 +558,130 @@ test('importing a sheet normalizes and orders HMPB pages', async () => {
     ]
   )
 })
+
+test('rejects pages that do not match the current precinct', async () => {
+  const scanner: jest.Mocked<Scanner> = {
+    getStatus: jest.fn(),
+    scanSheets: jest.fn(),
+    calibrate: jest.fn(),
+  }
+  const workerCall = jest.fn<Promise<workers.Output>, [workers.Input]>()
+  const workerPoolProvider = mockWorkerPoolProvider<
+    workers.Input,
+    workers.Output
+  >(workerCall)
+
+  const importer = new Importer({
+    workspace,
+    scanner,
+    workerPoolProvider,
+  })
+
+  await importer.configure(asElectionDefinition(election))
+  await workspace.store.setCurrentPrecinctId(election.precincts[1].id)
+  jest.spyOn(workspace.store, 'addSheet').mockResolvedValueOnce('sheet-id')
+
+  workerCall.mockImplementationOnce(async (input) => {
+    expect(input.action).toEqual('configure')
+  })
+
+  const frontMetadata: BallotPageMetadata = {
+    ballotStyleId: election.ballotStyles[0].id,
+    precinctId: election.precincts[0].id,
+    ballotType: BallotType.Standard,
+    electionHash: '',
+    isTestMode: false,
+    locales: { primary: 'en-US' },
+    pageNumber: 1,
+  }
+  const backMetadata: BallotPageMetadata = {
+    ...frontMetadata,
+    pageNumber: 2,
+  }
+
+  const frontImagePath = await makeImageFile()
+  const backImagePath = await makeImageFile()
+
+  workerCall.mockImplementation(async (input) => {
+    switch (input.action) {
+      case 'configure':
+        break
+
+      case 'detect-qrcode':
+        if (
+          input.imagePath !== frontImagePath &&
+          input.imagePath !== backImagePath
+        ) {
+          throw new Error(`unexpected image path: ${input.imagePath}`)
+        }
+
+        return {
+          blank: false,
+          qrcode:
+            input.imagePath === frontImagePath
+              ? {
+                  data: encodeHMPBBallotPageMetadata(election, frontMetadata),
+                  position: 'bottom',
+                }
+              : // assume back fails to find QR code, then infers it
+                undefined,
+        }
+
+      case 'interpret':
+        if (
+          input.imagePath !== frontImagePath &&
+          input.imagePath !== backImagePath
+        ) {
+          throw new Error(`unexpected image path: ${input.imagePath}`)
+        }
+
+        return {
+          interpretation: {
+            type: 'InterpretedHmpbPage',
+            metadata:
+              input.imagePath === frontImagePath ? frontMetadata : backMetadata,
+            markInfo: {
+              marks: [],
+              ballotSize: { width: 1, height: 1 },
+            },
+            adjudicationInfo: {
+              requiresAdjudication: false,
+              allReasonInfos: [],
+              enabledReasons: [],
+            },
+            votes: {},
+          },
+          originalFilename: '/tmp/original.png',
+          normalizedFilename: '/tmp/normalized.png',
+        }
+
+      default:
+        throw new Error('unexpected action')
+    }
+  })
+
+  await importer.importFile('batch-id', backImagePath, frontImagePath)
+
+  expect(workspace.store.addSheet).toHaveBeenCalledWith(
+    expect.any(String),
+    'batch-id',
+    [
+      expect.objectContaining({
+        interpretation: expect.objectContaining({
+          type: 'InvalidPrecinctPage',
+          metadata: expect.objectContaining({
+            pageNumber: 1,
+          }),
+        }),
+      }),
+      expect.objectContaining({
+        interpretation: expect.objectContaining({
+          type: 'InvalidPrecinctPage',
+          metadata: expect.objectContaining({
+            pageNumber: 2,
+          }),
+        }),
+      }),
+    ]
+  )
+})

--- a/apps/module-scan/src/interpreter.ts
+++ b/apps/module-scan/src/interpreter.ts
@@ -65,6 +65,7 @@ export type PageInterpretation =
   | InterpretedHmpbPage
   | InvalidElectionHashPage
   | InvalidTestModePage
+  | InvalidPrecinctPage
   | UninterpretedHmpbPage
   | UnreadablePage
 
@@ -96,6 +97,11 @@ export interface InvalidElectionHashPage {
 
 export interface InvalidTestModePage {
   type: 'InvalidTestModePage'
+  metadata: BallotMetadata | BallotPageMetadata
+}
+
+export interface InvalidPrecinctPage {
+  type: 'InvalidPrecinctPage'
   metadata: BallotMetadata | BallotPageMetadata
 }
 
@@ -157,6 +163,7 @@ export function sheetRequiresAdjudication([
       pi.type === 'UnreadablePage' ||
       pi.type === 'InvalidTestModePage' ||
       pi.type === 'InvalidElectionHashPage' ||
+      pi.type === 'InvalidPrecinctPage' ||
       (pi.type === 'InterpretedHmpbPage' &&
         pi.adjudicationInfo.requiresAdjudication &&
         !pi.adjudicationInfo.allReasonInfos.some(

--- a/apps/module-scan/src/scanners/fujitsu.test.ts
+++ b/apps/module-scan/src/scanners/fujitsu.test.ts
@@ -1,3 +1,4 @@
+import { ScannerStatus } from '@votingworks/types/api/module-scan'
 import { ChildProcess } from 'child_process'
 import { FujitsuScanner, ScannerMode, ScannerPageSize } from '.'
 import { makeMockChildProcess } from '../../test/util/mocks'
@@ -227,4 +228,26 @@ test('fujitsu scanner fails if scanSheet fails', async () => {
 
   scanimage.emit('exit', 1, null)
   await expect(sheets.scanSheet()).rejects.toThrowError()
+})
+
+test('fujitsu scanner status is always unknown', async () => {
+  const scanner = new FujitsuScanner()
+  expect(await scanner.getStatus()).toEqual(ScannerStatus.Unknown)
+})
+
+test('fujitsu scanner accept/reject/review are no-ops', async () => {
+  const scanimage = makeMockChildProcess()
+  const scanner = new FujitsuScanner()
+
+  exec.mockReturnValueOnce(scanimage)
+  const sheets = scanner.scanSheets()
+
+  expect(await sheets.acceptSheet()).toEqual(true)
+  expect(await sheets.rejectSheet()).toEqual(false)
+  expect(await sheets.reviewSheet()).toEqual(false)
+})
+
+test('fujitsu scanner calibrate is a no-op', async () => {
+  const scanner = new FujitsuScanner()
+  expect(await scanner.calibrate()).toEqual(false)
 })

--- a/apps/precinct-scanner/src/AppRoot.tsx
+++ b/apps/precinct-scanner/src/AppRoot.tsx
@@ -763,10 +763,13 @@ const AppRoot: React.FC<Props> = ({ hardware, card }) => {
     }
   }, [startUsbStatusPolling, startCardShortValueReadPolling])
 
-  const updatePrecinctId = useCallback(async (precinctId: string) => {
-    dispatchAppState({ type: 'updatePrecinctId', precinctId })
-    await config.setCurrentPrecinctId(precinctId)
-  }, [])
+  const updatePrecinctId = useCallback(
+    async (precinctId: string) => {
+      dispatchAppState({ type: 'updatePrecinctId', precinctId })
+      await config.setCurrentPrecinctId(precinctId)
+    },
+    [dispatchAppState]
+  )
 
   if (!hasCardReaderAttached) {
     return <SetupCardReaderPage />

--- a/apps/precinct-scanner/src/AppUnhappyPaths.test.tsx
+++ b/apps/precinct-scanner/src/AppUnhappyPaths.test.tsx
@@ -1,24 +1,46 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { electionSampleDefinition } from '@votingworks/fixtures'
-import {
-  GetScanStatusResponse,
-  ScannerStatus,
-} from '@votingworks/types/api/module-scan'
 import {
   advanceTimers,
   advanceTimersAndPromises,
 } from '@votingworks/test-utils'
 import { AdjudicationReason } from '@votingworks/types'
-
+import {
+  GetCurrentPrecinctConfigResponse,
+  GetScanStatusResponse,
+  GetTestModeConfigResponse,
+  ScannerStatus,
+} from '@votingworks/types/api/module-scan'
 import fetchMock from 'fetch-mock'
 import { DateTime } from 'luxon'
 import React from 'react'
 import { interpretedHmpb } from '../test/fixtures'
+import { adminCardForElection } from '../test/helpers/smartcards'
 import App from './App'
 import { BallotSheetInfo } from './config/types'
 import { MemoryCard } from './utils/Card'
 import { MemoryHardware } from './utils/Hardware'
-import { adminCardForElection } from '../test/helpers/smartcards'
+
+const getTestModeConfigTrueResponseBody: GetTestModeConfigResponse = {
+  status: 'ok',
+  testMode: true,
+}
+
+const scanStatusWaitingForPaperResponseBody: GetScanStatusResponse = {
+  scanner: ScannerStatus.WaitingForPaper,
+  batches: [],
+  adjudication: { adjudicated: 0, remaining: 0 },
+}
+
+const scanStatusReadyToScanResponseBody: GetScanStatusResponse = {
+  scanner: ScannerStatus.ReadyToScan,
+  batches: [],
+  adjudication: { adjudicated: 0, remaining: 0 },
+}
+
+const getPrecinctConfigNoPrecinctResponseBody: GetCurrentPrecinctConfigResponse = {
+  status: 'ok',
+}
 
 beforeEach(() => {
   jest.useFakeTimers()
@@ -35,9 +57,13 @@ test('when module-scan does not respond shows loading screen', async () => {
 })
 
 test('module-scan fails to unconfigure', async () => {
-  fetchMock.get('/config/election', electionSampleDefinition)
-  fetchMock.getOnce('/config/testMode', { status: 'ok', testMode: true })
-  fetchMock.deleteOnce('/config/election', { status: 404 })
+  fetchMock
+    .get('/config/election', { body: electionSampleDefinition })
+    .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
+    .get('/config/precinct', {
+      body: getPrecinctConfigNoPrecinctResponseBody,
+    })
+    .deleteOnce('/config/election', { status: 404 })
 
   const card = new MemoryCard()
   const hardware = MemoryHardware.standard
@@ -49,18 +75,119 @@ test('module-scan fails to unconfigure', async () => {
 
   fireEvent.click(await screen.findByText('Unconfigure Machine'))
   fireEvent.click(await screen.findByText('Unconfigure'))
+
   await screen.findByText('Loading…')
 })
 
 test('error from module-scan in accepting a reviewable ballot', async () => {
-  fetchMock.get('/config/election', electionSampleDefinition)
-  fetchMock.get('/config/testMode', { status: 'ok', testMode: true })
-  fetchMock.get('/scan/status', {
-    status: 'ok',
-    scanner: 'WaitingForPaper',
-    batches: [],
-    adjudication: { adjudicated: 0, remaining: 0 },
-  } as GetScanStatusResponse)
+  fetchMock
+    .get('/config/election', { body: electionSampleDefinition })
+    .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
+    .get('/config/precinct', {
+      body: getPrecinctConfigNoPrecinctResponseBody,
+    })
+  const card = new MemoryCard()
+  const hardware = MemoryHardware.standard
+  render(<App card={card} hardware={hardware} />)
+  advanceTimers(1)
+  await screen.findByText('Insert Your Ballot Below')
+  await screen.findByText('Scan one ballot sheet at a time.')
+  await screen.findByText('General Election')
+  await screen.findByText(/Franklin County/)
+  await screen.findByText(/State of Hamilton/)
+  await screen.findByText('Election ID')
+  await screen.findByText('2f6b1553c7')
+
+  fetchMock.getOnce(
+    '/scan/status',
+    { body: scanStatusReadyToScanResponseBody },
+    { overwriteRoutes: true, repeat: 3 }
+  )
+  fetchMock.post('/scan/scanBatch', {
+    body: { status: 'ok', batchId: 'test-batch' },
+  })
+  fetchMock.getOnce(
+    '/scan/status',
+    {
+      status: 'ok',
+      scanner: ScannerStatus.WaitingForPaper,
+      batches: [
+        {
+          id: 'test-batch',
+          count: 1,
+          startedAt: DateTime.now().toISO(),
+          endedAt: DateTime.now().toISO(),
+        },
+      ],
+      adjudication: { adjudicated: 0, remaining: 1 },
+    } as GetScanStatusResponse,
+    { overwriteRoutes: false, repeat: 1 }
+  )
+  fetchMock.get(
+    '/scan/status',
+    {
+      status: 'ok',
+      scanner: ScannerStatus.ReadyToScan,
+      batches: [
+        {
+          id: 'test-batch',
+          count: 1,
+          startedAt: DateTime.now().toISO(),
+          endedAt: DateTime.now().toISO(),
+        },
+      ],
+      adjudication: { adjudicated: 0, remaining: 1 },
+    } as GetScanStatusResponse,
+    { overwriteRoutes: false }
+  )
+  fetchMock.get('/scan/hmpb/review/next-sheet', {
+    id: 'test-sheet',
+    front: {
+      interpretation: interpretedHmpb({
+        electionDefinition: electionSampleDefinition,
+        pageNumber: 1,
+        adjudicationReason: AdjudicationReason.Overvote,
+      }),
+      image: { url: '/not/real.jpg' },
+    },
+    back: {
+      interpretation: interpretedHmpb({
+        electionDefinition: electionSampleDefinition,
+        pageNumber: 2,
+      }),
+      image: { url: '/not/real.jpg' },
+    },
+  } as BallotSheetInfo)
+  await advanceTimersAndPromises(1)
+  await screen.findByText('Overvote Warning')
+  expect(fetchMock.calls('scan/scanBatch')).toHaveLength(1)
+  fetchMock.post('/scan/scanContinue', {
+    body: { status: 'error' },
+  })
+
+  fireEvent.click(await screen.findByText('Tabulate Ballot'))
+  fireEvent.click(await screen.findByText('Yes, Tabulate Ballot'))
+  await screen.findByText('Scanning Error')
+  expect(fetchMock.calls('/scan/scanContinue')).toHaveLength(1)
+  await advanceTimersAndPromises(5)
+  // Screen does NOT reset automatically to insert ballot screen
+  await screen.findByText('Scanning Error')
+  // Removing ballot resets to insert screen
+  fetchMock.get(
+    '/scan/status',
+    { body: scanStatusWaitingForPaperResponseBody },
+    { overwriteRoutes: true }
+  )
+  await advanceTimersAndPromises(1)
+  await screen.findByText('Insert Your Ballot Below')
+})
+
+test('error from module-scan in ejecting a reviewable ballot', async () => {
+  fetchMock
+    .get('/config/election', electionSampleDefinition)
+    .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
+    .get('/config/precinct', { body: getPrecinctConfigNoPrecinctResponseBody })
+    .get('/scan/status', { body: scanStatusWaitingForPaperResponseBody })
   const card = new MemoryCard()
   const hardware = MemoryHardware.standard
   render(<App card={card} hardware={hardware} />)
@@ -144,121 +271,6 @@ test('error from module-scan in accepting a reviewable ballot', async () => {
   fetchMock.post('/scan/scanContinue', {
     body: { status: 'error' },
   })
-
-  fireEvent.click(await screen.findByText('Tabulate Ballot'))
-  fireEvent.click(await screen.findByText('Yes, Tabulate Ballot'))
-  await screen.findByText('Scanning Error')
-  expect(fetchMock.calls('/scan/scanContinue')).toHaveLength(1)
-  await advanceTimersAndPromises(5)
-  // Screen does NOT reset automatically to insert ballot screen
-  await screen.findByText('Scanning Error')
-  // Removing ballot resets to insert screen
-  fetchMock.get(
-    '/scan/status',
-    {
-      status: 'ok',
-      scanner: ScannerStatus.WaitingForPaper,
-      batches: [],
-      adjudication: { adjudicated: 0, remaining: 0 },
-    } as GetScanStatusResponse,
-    { overwriteRoutes: true }
-  )
-  await advanceTimersAndPromises(1)
-  await screen.findByText('Insert Your Ballot Below')
-})
-
-test('error from module-scan in ejecting a reviewable ballot', async () => {
-  fetchMock.get('/config/election', electionSampleDefinition)
-  fetchMock.get('/config/testMode', { status: 'ok', testMode: true })
-  fetchMock.get('/scan/status', {
-    status: 'ok',
-    scanner: 'WaitingForPaper',
-    batches: [],
-    adjudication: { adjudicated: 0, remaining: 0 },
-  } as GetScanStatusResponse)
-  const card = new MemoryCard()
-  const hardware = MemoryHardware.standard
-  render(<App card={card} hardware={hardware} />)
-  advanceTimers(1)
-  await screen.findByText('Insert Your Ballot Below')
-  await screen.findByText('Scan one ballot sheet at a time.')
-  await screen.findByText('General Election')
-  await screen.findByText(/Franklin County/)
-  await screen.findByText(/State of Hamilton/)
-  await screen.findByText('Election ID')
-  await screen.findByText('2f6b1553c7')
-
-  fetchMock.getOnce(
-    '/scan/status',
-    {
-      status: 'ok',
-      scanner: ScannerStatus.ReadyToScan,
-      batches: [],
-      adjudication: { adjudicated: 0, remaining: 0 },
-    } as GetScanStatusResponse,
-    { overwriteRoutes: true, repeat: 3 }
-  )
-  fetchMock.post('/scan/scanBatch', {
-    body: { status: 'ok', batchId: 'test-batch' },
-  })
-  fetchMock.getOnce(
-    '/scan/status',
-    {
-      status: 'ok',
-      scanner: ScannerStatus.WaitingForPaper,
-      batches: [
-        {
-          id: 'test-batch',
-          count: 1,
-          startedAt: DateTime.now().toISO(),
-          endedAt: DateTime.now().toISO(),
-        },
-      ],
-      adjudication: { adjudicated: 0, remaining: 1 },
-    } as GetScanStatusResponse,
-    { overwriteRoutes: false, repeat: 1 }
-  )
-  fetchMock.get(
-    '/scan/status',
-    {
-      status: 'ok',
-      scanner: ScannerStatus.ReadyToScan,
-      batches: [
-        {
-          id: 'test-batch',
-          count: 1,
-          startedAt: DateTime.now().toISO(),
-          endedAt: DateTime.now().toISO(),
-        },
-      ],
-      adjudication: { adjudicated: 0, remaining: 1 },
-    } as GetScanStatusResponse,
-    { overwriteRoutes: false }
-  )
-  fetchMock.get('/scan/hmpb/review/next-sheet', {
-    id: 'test-sheet',
-    front: {
-      interpretation: interpretedHmpb({
-        electionDefinition: electionSampleDefinition,
-        pageNumber: 1,
-        adjudicationReason: AdjudicationReason.Overvote,
-      }),
-      image: { url: '/not/real.jpg' },
-    },
-    back: {
-      interpretation: interpretedHmpb({
-        electionDefinition: electionSampleDefinition,
-        pageNumber: 2,
-      }),
-      image: { url: '/not/real.jpg' },
-    },
-  } as BallotSheetInfo)
-  await advanceTimersAndPromises(1)
-  await waitFor(async () => await screen.findByText('Overvote Warning'))
-  expect(fetchMock.calls('scan/scanBatch')).toHaveLength(1)
-  fetchMock.post('/scan/scanContinue', {
-    body: { status: 'error' },
-  })
   fetchMock.get(
     '/scan/status',
     {
@@ -277,6 +289,6 @@ test('error from module-scan in ejecting a reviewable ballot', async () => {
     { overwriteRoutes: true }
   )
   await advanceTimersAndPromises(1)
-  await waitFor(async () => await screen.findByText('Insert Your Ballot Below'))
+  await screen.findByText('Insert Your Ballot Below')
   expect(fetchMock.calls('/scan/scanContinue')).toHaveLength(1)
 })

--- a/apps/precinct-scanner/src/api/scan.ts
+++ b/apps/precinct-scanner/src/api/scan.ts
@@ -85,6 +85,12 @@ export async function scanDetectedSheet(): Promise<ScanningResult> {
             rejectionReason: RejectedScanningReason.InvalidElectionHash,
           }
         }
+        if (interpretation.type === 'InvalidPrecinctPage') {
+          return {
+            resultType: ScanningResultType.Rejected,
+            rejectionReason: RejectedScanningReason.InvalidPrecinct,
+          }
+        }
         if (interpretation.type === 'InterpretedHmpbPage') {
           if (interpretation.adjudicationInfo.requiresAdjudication) {
             for (const { type } of interpretation.adjudicationInfo

--- a/apps/precinct-scanner/src/components/ElectionInfoBar.tsx
+++ b/apps/precinct-scanner/src/components/ElectionInfoBar.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
 
 import { Prose, Text, contrastTheme, NoWrap } from '@votingworks/ui'
-import { OptionalElectionDefinition } from '@votingworks/types'
+import {
+  getPrecinctById,
+  OptionalElectionDefinition,
+  Precinct,
+} from '@votingworks/types'
 import { Bar, BarSpacer } from './Bar'
 import { localeWeekdayAndDate } from '../utils/IntlDateTimeFormats'
 
@@ -10,10 +14,12 @@ export type InfoBarMode = 'voter' | 'pollworker' | 'admin'
 interface Props {
   mode?: InfoBarMode
   electionDefinition: OptionalElectionDefinition
+  currentPrecinctId?: Precinct['id']
 }
 const ElectionInfoBar: React.FC<Props> = ({
   electionDefinition,
   mode = 'voter',
+  currentPrecinctId,
 }) => {
   if (!electionDefinition) {
     return null
@@ -21,13 +27,20 @@ const ElectionInfoBar: React.FC<Props> = ({
   const electionDate = localeWeekdayAndDate.format(
     new Date(electionDefinition.election.date)
   )
+  const precinct =
+    typeof currentPrecinctId === 'string'
+      ? getPrecinctById({
+          election: electionDefinition.election,
+          precinctId: currentPrecinctId,
+        })
+      : undefined
   return (
     <Bar theme={{ ...contrastTheme.dark }}>
       <Prose maxWidth={false} compact>
         <NoWrap as="strong">{electionDefinition.election.title}</NoWrap> —{' '}
         <NoWrap>{electionDate}</NoWrap>
         <Text as="div" small>
-          <NoWrap>PRECINCT NAME HERE</NoWrap> —{' '}
+          <NoWrap>{precinct?.name ?? 'All Precincts'}</NoWrap> —{' '}
           <NoWrap>
             {electionDefinition.election.county.name},{' '}
             {electionDefinition.election.state}

--- a/apps/precinct-scanner/src/components/Layout.tsx
+++ b/apps/precinct-scanner/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Screen, Main, MainChild, Prose, fontSizeTheme } from '@votingworks/ui'
-import { ElectionDefinition } from '@votingworks/types'
+import { ElectionDefinition, Precinct } from '@votingworks/types'
 import ElectionInfoBar, { InfoBarMode } from './ElectionInfoBar'
 
 interface Props {
@@ -8,6 +8,7 @@ interface Props {
   infoBar?: boolean
   infoBarMode?: InfoBarMode
   electionDefinition?: ElectionDefinition
+  currentPrecinctId?: Precinct['id']
 }
 
 export const CenteredScreen: React.FC<Props> = ({
@@ -15,6 +16,7 @@ export const CenteredScreen: React.FC<Props> = ({
   infoBar = true,
   infoBarMode,
   electionDefinition,
+  currentPrecinctId,
 }) => (
   <Screen flexDirection="column">
     <Main padded>
@@ -26,6 +28,7 @@ export const CenteredScreen: React.FC<Props> = ({
       <ElectionInfoBar
         mode={infoBarMode}
         electionDefinition={electionDefinition}
+        currentPrecinctId={currentPrecinctId}
       />
     )}
   </Screen>

--- a/apps/precinct-scanner/src/components/__snapshots__/ElectionInfoBar.test.tsx.snap
+++ b/apps/precinct-scanner/src/components/__snapshots__/ElectionInfoBar.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`Renders ElectionInfoBar 1`] = `
         <span
           class="sc-crHlIS ZRmpD"
         >
-          PRECINCT NAME HERE
+          All Precincts
         </span>
          —
          

--- a/apps/precinct-scanner/src/config/types.ts
+++ b/apps/precinct-scanner/src/config/types.ts
@@ -30,6 +30,7 @@ export enum ScanningResultType {
 export enum RejectedScanningReason {
   InvalidTestMode = 'invalid_test_mode',
   InvalidElectionHash = 'invalid_election_hash',
+  InvalidPrecinct = 'invalid_precinct',
   Unreadable = 'unreadable',
   Unknown = 'unknown',
 }
@@ -141,6 +142,7 @@ export type PageInterpretation =
   | InterpretedBmdPage
   | InterpretedHmpbPage
   | InvalidTestModePage
+  | InvalidPrecinctPage
   | UninterpretedHmpbPage
   | UnreadablePage
   | InvalidElectionHashPage
@@ -167,6 +169,11 @@ export interface InterpretedHmpbPage {
 
 export interface InvalidTestModePage {
   type: 'InvalidTestModePage'
+  metadata: BallotMetadata | BallotPageMetadata
+}
+
+export interface InvalidPrecinctPage {
+  type: 'InvalidPrecinctPage'
   metadata: BallotMetadata | BallotPageMetadata
 }
 

--- a/apps/precinct-scanner/src/screens/AdminScreen.tsx
+++ b/apps/precinct-scanner/src/screens/AdminScreen.tsx
@@ -15,7 +15,7 @@ import { Bar } from '../components/Bar'
 import Modal from '../components/Modal'
 
 interface Props {
-  appPrecinctId: string
+  appPrecinctId?: string
   ballotsScannedCount: number
   electionDefinition: ElectionDefinition
   isLiveMode: boolean

--- a/apps/precinct-scanner/src/screens/InsertBallotScreen.tsx
+++ b/apps/precinct-scanner/src/screens/InsertBallotScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { ElectionDefinition } from '@votingworks/types'
+import { ElectionDefinition, Precinct } from '@votingworks/types'
 import { Absolute } from '../components/Absolute'
 import { InsertBallot } from '../components/Graphics'
 import { CenteredLargeProse, CenteredScreen } from '../components/Layout'
@@ -9,14 +9,19 @@ import * as format from '../utils/format'
 interface Props {
   scannedBallotCount: number
   electionDefinition: ElectionDefinition
+  currentPrecinctId?: Precinct['id']
 }
 
 const InsertBallotScreen: React.FC<Props> = ({
   scannedBallotCount,
   electionDefinition,
+  currentPrecinctId,
 }) => {
   return (
-    <CenteredScreen electionDefinition={electionDefinition}>
+    <CenteredScreen
+      electionDefinition={electionDefinition}
+      currentPrecinctId={currentPrecinctId}
+    >
       <InsertBallot />
       <CenteredLargeProse>
         <h1>Insert Your Ballot Below</h1>

--- a/apps/precinct-scanner/src/screens/ScanErrorScreen.tsx
+++ b/apps/precinct-scanner/src/screens/ScanErrorScreen.tsx
@@ -30,6 +30,11 @@ const ScanErrorScreen: React.FC<Props> = ({
           'Scanned ballot does not match the election this scanner is configured for.'
         break
       }
+      case RejectedScanningReason.InvalidPrecinct: {
+        errorInformation =
+          'Scanned ballot does not match the precinct this scanner is configured for.'
+        break
+      }
       case RejectedScanningReason.Unreadable: {
         errorInformation =
           'There was a problem reading this ballot. Please try again.'

--- a/apps/precinct-scanner/src/screens/ScanSuccessScreen.tsx
+++ b/apps/precinct-scanner/src/screens/ScanSuccessScreen.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Prose } from '@votingworks/ui'
-import { ElectionDefinition } from '@votingworks/types'
+import { ElectionDefinition, Precinct } from '@votingworks/types'
 import { Absolute } from '../components/Absolute'
 import { CircleCheck } from '../components/Graphics'
 import { Bar } from '../components/Bar'
@@ -10,14 +10,19 @@ import * as format from '../utils/format'
 interface Props {
   electionDefinition: ElectionDefinition
   scannedBallotCount: number
+  currentPrecinctId?: Precinct['id']
 }
 
 const ScanSuccessScreen: React.FC<Props> = ({
   scannedBallotCount,
   electionDefinition,
+  currentPrecinctId,
 }) => {
   return (
-    <CenteredScreen electionDefinition={electionDefinition}>
+    <CenteredScreen
+      electionDefinition={electionDefinition}
+      currentPrecinctId={currentPrecinctId}
+    >
       <CircleCheck />
       <CenteredLargeProse>
         <h1>Your ballot was counted!</h1>

--- a/libs/types/src/api/module-scan.ts
+++ b/libs/types/src/api/module-scan.ts
@@ -7,7 +7,7 @@ import {
   OkResponse,
   OkResponseSchema,
 } from '.'
-import { ElectionDefinition, MarkThresholds } from '../election'
+import { ElectionDefinition, MarkThresholds, Precinct } from '../election'
 import * as s from '../schema'
 
 export interface AdjudicationStatus {
@@ -176,6 +176,69 @@ export type PatchTestModeConfigResponse = OkResponse | ErrorsResponse
 export const PatchTestModeConfigResponseSchema: z.ZodSchema<PatchTestModeConfigResponse> = z.union(
   [OkResponseSchema, ErrorsResponseSchema]
 )
+
+/**
+ * @url /config/precinct
+ * @method GET
+ */
+export type GetCurrentPrecinctConfigResponse = OkResponse<{
+  precinctId?: Precinct['id']
+}>
+
+/**
+ * @url /config/precinct
+ * @method GET
+ */
+export const GetCurrentPrecinctResponseSchema: z.ZodSchema<GetCurrentPrecinctConfigResponse> = z.object(
+  {
+    status: z.literal('ok'),
+    precinctId: z.optional(s.Id),
+  }
+)
+
+/**
+ * @url /config/precinct
+ * @method PUT
+ */
+export interface PutCurrentPrecinctConfigRequest {
+  precinctId?: Precinct['id']
+}
+
+/**
+ * @url /config/precinct
+ * @method PUT
+ */
+export const PutCurrentPrecinctConfigRequestSchema: z.ZodSchema<PutCurrentPrecinctConfigRequest> = z.object(
+  {
+    precinctId: z.optional(s.Id),
+  }
+)
+
+/**
+ * @url /config/precinct
+ * @method PUT
+ */
+export type PutCurrentPrecinctConfigResponse = OkResponse | ErrorsResponse
+
+/**
+ * @url /config/precinct
+ * @method PUT
+ */
+export const PutCurrentPrecinctConfigResponseSchema: z.ZodSchema<PutCurrentPrecinctConfigResponse> = z.union(
+  [OkResponseSchema, ErrorsResponseSchema]
+)
+
+/**
+ * @url /config/precinct
+ * @method DELETE
+ */
+export type DeleteCurrentPrecinctConfigResponse = OkResponse
+
+/**
+ * @url /config/precinct
+ * @method DELETE
+ */
+export const DeleteCurrentPrecinctConfigResponseSchema = OkResponseSchema
 
 /**
  * @url /config/markThresholdOverrides


### PR DESCRIPTION
At the moment this only prevents counting sheets that don't match the current precinct. It does not zero or close polls or anything like that yet.

https://user-images.githubusercontent.com/1938/118735420-435d7180-b7f5-11eb-96b3-f46908011e7a.mov

Closes #513