### PR TITLE
feat(scan): add calibration to precinct scanner

### DIFF
--- a/apps/module-scan/src/importer.test.ts
+++ b/apps/module-scan/src/importer.test.ts
@@ -685,3 +685,20 @@ test('rejects pages that do not match the current precinct', async () => {
     ]
   )
 })
+
+test('doCalibrate', async () => {
+  const scanner: jest.Mocked<Scanner> = {
+    getStatus: jest.fn(),
+    scanSheets: jest.fn(),
+    calibrate: jest.fn(),
+  }
+  const importer = new Importer({
+    workspace,
+    scanner,
+  })
+
+  scanner.calibrate.mockResolvedValueOnce(true)
+  expect(await importer.doCalibrate()).toEqual(true)
+  scanner.calibrate.mockResolvedValueOnce(false)
+  expect(await importer.doCalibrate()).toEqual(false)
+})

--- a/apps/module-scan/src/importer.ts
+++ b/apps/module-scan/src/importer.ts
@@ -529,6 +529,15 @@ export default class Importer {
   }
 
   /**
+   * Tell the scanner to calibrate itself.
+   *
+   * @returns whether the calibration succeeded
+   */
+  public async doCalibrate(): Promise<boolean> {
+    return await this.scanner.calibrate()
+  }
+
+  /**
    * Export the current CVRs to a string.
    */
   public async doExport(): Promise<string> {

--- a/apps/module-scan/src/scanners/plustek.test.ts
+++ b/apps/module-scan/src/scanners/plustek.test.ts
@@ -14,6 +14,7 @@ test('plustek scanner cannot get client', async () => {
     get: jest.fn().mockResolvedValue(err(new Error('no client for you!'))),
   })
   expect(await scanner.getStatus()).toEqual(ScannerStatus.Error)
+  expect(await scanner.calibrate()).toEqual(false)
 
   const batch = scanner.scanSheets()
   expect(await batch.scanSheet()).toBeUndefined()
@@ -137,6 +138,24 @@ test('plustek scanner reject sheet w/alwaysHoldOnReject', async () => {
   plustekClient.reject.mockResolvedValueOnce(ok(undefined))
   plustekClient.waitForStatus.mockResolvedValue(ok(PaperStatus.VtmReadyToScan))
   expect(await scanner.scanSheets().rejectSheet()).toEqual(true)
+})
+
+test('plustek scanner calibrate', async () => {
+  const plustekClient = makeMockPlustekClient()
+  const scanner = new PlustekScanner(
+    {
+      get: jest.fn().mockResolvedValue(ok(plustekClient)),
+    },
+    true
+  )
+
+  plustekClient.calibrate.mockResolvedValueOnce(ok(undefined))
+  expect(await scanner.calibrate()).toEqual(true)
+
+  plustekClient.calibrate.mockResolvedValueOnce(
+    err(ScannerError.VtmPsDevReadyNoPaper)
+  )
+  expect(await scanner.calibrate()).toEqual(false)
 })
 
 // eslint-disable-next-line jest/expect-expect

--- a/apps/module-scan/src/scanners/plustek.ts
+++ b/apps/module-scan/src/scanners/plustek.ts
@@ -192,7 +192,21 @@ export class PlustekScanner implements Scanner {
   }
 
   public async calibrate(): Promise<boolean> {
-    return false
+    const clientResult = await this.clientProvider.get()
+
+    if (clientResult.isErr()) {
+      debug(
+        'PlustekScanner#calibrate: failed to get client: %s',
+        clientResult.err()
+      )
+      return false
+    }
+
+    const client = clientResult.unwrap()
+    const result = await client.calibrate()
+
+    debug('PlustekScanner#calibrate: success=%s', result.isOk())
+    return result.isOk()
   }
 }
 

--- a/apps/module-scan/src/server.test.ts
+++ b/apps/module-scan/src/server.test.ts
@@ -825,3 +825,27 @@ test('get next sheet', async () => {
       },
     })
 })
+
+test('calibrate success', async () => {
+  importer.doCalibrate.mockResolvedValueOnce(true)
+
+  await request(app).post('/scan/calibrate').expect(200, {
+    status: 'ok',
+  })
+})
+
+test('calibrate error', async () => {
+  importer.doCalibrate.mockResolvedValueOnce(false)
+
+  await request(app)
+    .post('/scan/calibrate')
+    .expect(200, {
+      status: 'error',
+      errors: [
+        {
+          type: 'calibration-error',
+          message: 'scanner could not be calibrated',
+        },
+      ],
+    })
+})

--- a/apps/module-scan/src/server.ts
+++ b/apps/module-scan/src/server.ts
@@ -17,6 +17,8 @@ import {
 import {
   AddTemplatesRequest,
   AddTemplatesResponse,
+  CalibrateRequest,
+  CalibrateResponse,
   DeleteCurrentPrecinctConfigResponse,
   DeleteElectionConfigResponse,
   DeleteMarkThresholdOverridesConfigResponse,
@@ -527,6 +529,28 @@ export function buildApp({ store, importer }: AppOptions): Application {
     async (_request, response) => {
       const status = await importer.getStatus()
       response.json(status)
+    }
+  )
+
+  app.post<NoParams, CalibrateResponse, CalibrateRequest>(
+    '/scan/calibrate',
+    async (_request, response) => {
+      const success = await importer.doCalibrate()
+      response.json(
+        success
+          ? {
+              status: 'ok',
+            }
+          : {
+              status: 'error',
+              errors: [
+                {
+                  type: 'calibration-error',
+                  message: 'scanner could not be calibrated',
+                },
+              ],
+            }
+      )
     }
   )
 

--- a/apps/precinct-scanner/package.json
+++ b/apps/precinct-scanner/package.json
@@ -80,8 +80,8 @@
     "@types/react-router-dom": "^5.1.5",
     "@types/styled-components": "^5.1.9",
     "@votingworks/hmpb-interpreter": "workspace:*",
-    "@votingworks/utils": "workspace:*",
     "@votingworks/ui": "workspace:*",
+    "@votingworks/utils": "workspace:*",
     "base64-js": "^1.3.1",
     "debug": "^4.3.1",
     "fast-text-encoding": "^1.0.2",
@@ -141,6 +141,7 @@
     "stylelint-config-palantir": "^4.0.1",
     "stylelint-config-prettier": "^8.0.1",
     "stylelint-config-styled-components": "^0.1.1",
-    "stylelint-processor-styled-components": "^1.9.0"
+    "stylelint-processor-styled-components": "^1.9.0",
+    "ts-jest": "^26.5.6"
   }
 }

--- a/apps/precinct-scanner/src/AppRoot.tsx
+++ b/apps/precinct-scanner/src/AppRoot.tsx
@@ -815,6 +815,7 @@ const AppRoot: React.FC<Props> = ({ hardware, card }) => {
         isLiveMode={!isTestMode}
         toggleLiveMode={toggleTestMode}
         unconfigure={unconfigureServer}
+        calibrate={scan.calibrate}
       />
     )
   }

--- a/apps/precinct-scanner/src/api/scan.ts
+++ b/apps/precinct-scanner/src/api/scan.ts
@@ -1,5 +1,6 @@
-import { AdjudicationReason } from '@votingworks/types'
+import { AdjudicationReason, safeParseJSON } from '@votingworks/types'
 import {
+  CalibrateResponseSchema,
   GetScanStatusResponse,
   ScanContinueRequest,
   ScannerStatus,
@@ -148,4 +149,19 @@ export async function endBatch(): Promise<boolean> {
     return false
   }
   return true
+}
+
+export async function calibrate(): Promise<boolean> {
+  const response = await fetch('/scan/calibrate', {
+    method: 'post',
+    headers: { Accept: 'application/json' },
+  })
+
+  return safeParseJSON(
+    await response.text(),
+    CalibrateResponseSchema
+  ).mapOrElse(
+    () => false,
+    ({ status }) => status === 'ok'
+  )
 }

--- a/apps/precinct-scanner/src/components/CalibrateScannerModal.test.tsx
+++ b/apps/precinct-scanner/src/components/CalibrateScannerModal.test.tsx
@@ -1,0 +1,137 @@
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { mocked } from 'ts-jest/utils'
+import { ScannerStatus } from '@votingworks/types/api/module-scan'
+import { deferred } from '@votingworks/utils/src'
+import CalibrateScannerModal from './CalibrateScannerModal'
+import usePrecinctScannerStatus from '../hooks/usePrecinctScannerStatus'
+
+jest.mock('../hooks/usePrecinctScannerStatus')
+
+const usePrecinctScannerStatusMock = mocked(usePrecinctScannerStatus)
+
+test('shows instructions', async () => {
+  const onCalibrate = jest.fn()
+  const onCancel = jest.fn()
+  render(
+    <CalibrateScannerModal onCalibrate={onCalibrate} onCancel={onCancel} />
+  )
+
+  await screen.findByText(/blank sheet of white paper/)
+})
+
+test('waiting for paper', async () => {
+  usePrecinctScannerStatusMock.mockReturnValueOnce(
+    ScannerStatus.WaitingForPaper
+  )
+
+  const onCalibrate = jest.fn()
+  const onCancel = jest.fn()
+  render(
+    <CalibrateScannerModal onCalibrate={onCalibrate} onCancel={onCancel} />
+  )
+
+  expect(
+    ((await screen.findByText('Waiting for Paper')) as HTMLButtonElement)
+      .disabled
+  ).toBe(true)
+
+  fireEvent.click(await screen.findByText('Cancel'))
+  expect(onCancel).toHaveBeenCalled()
+})
+
+test('scanner not available', async () => {
+  usePrecinctScannerStatusMock.mockReturnValueOnce(ScannerStatus.Error)
+
+  const onCalibrate = jest.fn()
+  const onCancel = jest.fn()
+  render(
+    <CalibrateScannerModal onCalibrate={onCalibrate} onCancel={onCancel} />
+  )
+
+  expect(
+    ((await screen.findByText('Cannot Calibrate')) as HTMLButtonElement)
+      .disabled
+  ).toBe(true)
+
+  fireEvent.click(await screen.findByText('Cancel'))
+  expect(onCancel).toHaveBeenCalled()
+})
+
+test('calibrate success', async () => {
+  const { promise, resolve } = deferred<boolean>()
+  usePrecinctScannerStatusMock.mockReturnValueOnce(ScannerStatus.ReadyToScan)
+
+  const onCalibrate = jest.fn().mockResolvedValueOnce(promise)
+  const onCancel = jest.fn()
+  render(
+    <CalibrateScannerModal onCalibrate={onCalibrate} onCancel={onCancel} />
+  )
+
+  // calibrate
+  fireEvent.click(await screen.findByText('Calibrate'))
+  expect(onCalibrate).toHaveBeenCalled()
+  await screen.findByText('Calibrating…')
+  resolve(true)
+  await screen.findByText('Calibration succeeded!')
+
+  // finish
+  fireEvent.click(await screen.findByText('Back'))
+  expect(onCancel).toHaveBeenCalled()
+})
+
+test('calibrate error', async () => {
+  const { promise, resolve } = deferred<boolean>()
+  usePrecinctScannerStatusMock.mockReturnValueOnce(ScannerStatus.ReadyToScan)
+
+  const onCalibrate = jest.fn().mockResolvedValueOnce(promise)
+  const onCancel = jest.fn()
+  render(
+    <CalibrateScannerModal onCalibrate={onCalibrate} onCancel={onCancel} />
+  )
+
+  // calibrate
+  fireEvent.click(await screen.findByText('Calibrate'))
+  expect(onCalibrate).toHaveBeenCalled()
+  await screen.findByText('Calibrating…')
+  resolve(false)
+  await screen.findByText('Calibration failed!')
+
+  // finish
+  fireEvent.click(await screen.findByText('Cancel'))
+  expect(onCancel).toHaveBeenCalled()
+})
+
+test('calibrate error & try again', async () => {
+  const calibrateDeferred1 = deferred<boolean>()
+  const calibrateDeferred2 = deferred<boolean>()
+  usePrecinctScannerStatusMock.mockReturnValue(ScannerStatus.ReadyToScan)
+
+  const onCalibrate = jest
+    .fn()
+    .mockResolvedValueOnce(calibrateDeferred1.promise)
+    .mockResolvedValueOnce(calibrateDeferred2.promise)
+  const onCancel = jest.fn()
+  render(
+    <CalibrateScannerModal onCalibrate={onCalibrate} onCancel={onCancel} />
+  )
+
+  // calibrate
+  fireEvent.click(await screen.findByText('Calibrate'))
+  expect(onCalibrate).toHaveBeenCalledTimes(1)
+  await screen.findByText('Calibrating…')
+  calibrateDeferred1.resolve(false)
+  await screen.findByText('Calibration failed!')
+
+  // try again
+  fireEvent.click(await screen.findByText('Try again'))
+  fireEvent.click(await screen.findByText('Calibrate'))
+  expect(onCalibrate).toHaveBeenCalledTimes(2)
+  await screen.findByText('Calibrating…')
+  calibrateDeferred2.resolve(true)
+  await screen.findByText('Calibration succeeded!')
+
+  // finish
+  fireEvent.click(await screen.findByText('Back'))
+  expect(onCancel).toHaveBeenCalled()
+})

--- a/apps/precinct-scanner/src/components/CalibrateScannerModal.tsx
+++ b/apps/precinct-scanner/src/components/CalibrateScannerModal.tsx
@@ -1,0 +1,122 @@
+import { ScannerStatus } from '@votingworks/types/api/module-scan'
+import { Button, Prose } from '@votingworks/ui'
+import React, { useCallback, useState } from 'react'
+import useCancelablePromise from '../hooks/useCancelablePromise'
+import usePrecinctScannerStatus from '../hooks/usePrecinctScannerStatus'
+import Modal from './Modal'
+
+export interface Props {
+  onCalibrate(): Promise<boolean>
+  onCancel: VoidFunction
+}
+
+const noop = () => {
+  // noop
+}
+
+const CalibrateScannerModal: React.FC<Props> = ({ onCancel, onCalibrate }) => {
+  const makeCancelable = useCancelablePromise()
+  const [calibrationSuccess, setCalibrationSuccess] = useState<boolean>()
+  const [isCalibrating, setIsCalibrating] = useState(false)
+
+  const scannerStatus = usePrecinctScannerStatus(
+    isCalibrating ? false : undefined
+  )
+
+  const beginCalibration = useCallback(async () => {
+    setIsCalibrating(true)
+    try {
+      setCalibrationSuccess(await makeCancelable(onCalibrate()))
+    } finally {
+      setIsCalibrating(false)
+    }
+  }, [onCalibrate, setIsCalibrating])
+
+  const resetAndTryAgain = useCallback(async () => {
+    setCalibrationSuccess(undefined)
+  }, [setCalibrationSuccess])
+
+  if (isCalibrating) {
+    return (
+      <Modal
+        centerContent
+        content={
+          <Prose textCenter>
+            <h1>Calibrating…</h1>
+          </Prose>
+        }
+      />
+    )
+  }
+
+  if (calibrationSuccess === true) {
+    return (
+      <Modal
+        centerContent
+        content={
+          <Prose textCenter>
+            <h1>Calibration succeeded!</h1>
+          </Prose>
+        }
+        actions={<Button onPress={onCancel}>Back</Button>}
+      />
+    )
+  }
+
+  if (calibrationSuccess === false) {
+    return (
+      <Modal
+        centerContent
+        content={
+          <Prose textCenter>
+            <h1>Calibration failed!</h1>
+            <p>There was an error while calibrating.</p>
+          </Prose>
+        }
+        actions={
+          <React.Fragment>
+            <Button primary onPress={resetAndTryAgain}>
+              Try again
+            </Button>
+            <Button onPress={onCancel}>Cancel</Button>
+          </React.Fragment>
+        }
+      />
+    )
+  }
+
+  return (
+    <Modal
+      content={
+        <Prose>
+          <h1>Calibrate Scanner</h1>
+          <p>
+            Insert a <strong>blank sheet of white paper</strong> to calibrate
+            the scanner. The sheet will be not be returned out the front of the
+            scanner.
+          </p>
+        </Prose>
+      }
+      actions={
+        <React.Fragment>
+          {scannerStatus === ScannerStatus.ReadyToScan ? (
+            <Button primary onPress={beginCalibration}>
+              Calibrate
+            </Button>
+          ) : scannerStatus === ScannerStatus.WaitingForPaper ? (
+            <Button disabled onPress={noop}>
+              Waiting for Paper
+            </Button>
+          ) : (
+            <Button disabled onPress={noop}>
+              Cannot Calibrate
+            </Button>
+          )}
+          <Button onPress={onCancel}>Cancel</Button>
+        </React.Fragment>
+      }
+    />
+  )
+}
+
+export default CalibrateScannerModal

--- a/apps/precinct-scanner/src/hooks/usePrecinctScannerStatus.test.tsx
+++ b/apps/precinct-scanner/src/hooks/usePrecinctScannerStatus.test.tsx
@@ -1,0 +1,87 @@
+import { act, render, screen } from '@testing-library/react'
+import {
+  GetScanStatusResponse,
+  ScannerStatus,
+} from '@votingworks/types/api/module-scan'
+import React from 'react'
+import fetchMock, { MockResponseFunction } from 'fetch-mock'
+import usePrecinctScannerStatus from './usePrecinctScannerStatus'
+
+async function sleep(duration: number) {
+  await new Promise((resolve) => setTimeout(resolve, duration))
+}
+
+const scanStatusWaitingForPaperResponse: GetScanStatusResponse = {
+  adjudication: { adjudicated: 0, remaining: 0 },
+  batches: [],
+  scanner: ScannerStatus.WaitingForPaper,
+}
+
+const scanStatusReadyToScanResponse: GetScanStatusResponse = {
+  adjudication: { adjudicated: 0, remaining: 0 },
+  batches: [],
+  scanner: ScannerStatus.ReadyToScan,
+}
+
+test('initial state', async () => {
+  const Component: React.FC = () => {
+    return <React.Fragment>{usePrecinctScannerStatus()}</React.Fragment>
+  }
+
+  render(<Component />)
+  await screen.findByText(ScannerStatus.Unknown)
+})
+
+test('updates from /scan/status', async () => {
+  const Component: React.FC = () => {
+    return <React.Fragment>{usePrecinctScannerStatus(1)}</React.Fragment>
+  }
+
+  // first update
+  fetchMock.getOnce('/scan/status', { body: scanStatusWaitingForPaperResponse })
+  render(<Component />)
+  await screen.findByText(ScannerStatus.WaitingForPaper)
+
+  // second update
+  fetchMock.getOnce(
+    '/scan/status',
+    { body: scanStatusReadyToScanResponse },
+    { overwriteRoutes: false }
+  )
+  await screen.findByText(ScannerStatus.ReadyToScan)
+})
+
+test('disabling', async () => {
+  const Component: React.FC = () => {
+    return <React.Fragment>{usePrecinctScannerStatus(false)}</React.Fragment>
+  }
+
+  fetchMock.getOnce('/scan/status', { body: scanStatusWaitingForPaperResponse })
+
+  render(<Component />)
+  await screen.findByText(ScannerStatus.Unknown)
+})
+
+test('issues one status check at a time', async () => {
+  const Component: React.FC = () => {
+    return <React.Fragment>{usePrecinctScannerStatus(1)}</React.Fragment>
+  }
+
+  const statusEndpoint = jest.fn<
+    ReturnType<MockResponseFunction>,
+    Parameters<MockResponseFunction>
+  >(async () => {
+    await sleep(5)
+    return new Response(JSON.stringify(scanStatusWaitingForPaperResponse), {
+      headers: { 'Content-Type': 'application/json' },
+    })
+  })
+
+  fetchMock.get('/scan/status', statusEndpoint)
+
+  render(<Component />)
+  await screen.findByText(ScannerStatus.Unknown)
+  await act(() => sleep(5))
+  await screen.findByText(ScannerStatus.WaitingForPaper)
+  expect(statusEndpoint.mock.calls.length).toBeLessThanOrEqual(2)
+})

--- a/apps/precinct-scanner/src/hooks/usePrecinctScannerStatus.ts
+++ b/apps/precinct-scanner/src/hooks/usePrecinctScannerStatus.ts
@@ -1,0 +1,39 @@
+import { safeParseJSON } from '@votingworks/types'
+import {
+  GetScanStatusResponseSchema,
+  ScannerStatus,
+} from '@votingworks/types/api/module-scan'
+import { useState } from 'react'
+import useInterval from 'use-interval'
+import useCancelablePromise from './useCancelablePromise'
+
+export default function usePrecinctScannerStatus(
+  interval: number | false = 100
+): ScannerStatus {
+  const [scannerStatus, setScannerStatus] = useState(ScannerStatus.Unknown)
+  const [isFetchingStatus, setIsFetchingStatus] = useState(false)
+  const makeCancelable = useCancelablePromise()
+
+  useInterval(async () => {
+    if (isFetchingStatus) {
+      return
+    }
+    setIsFetchingStatus(true)
+
+    const response = await makeCancelable(
+      fetch('/scan/status', { headers: { Accept: 'application/json' } })
+    )
+
+    safeParseJSON(await response.text(), GetScanStatusResponseSchema).mapOrElse(
+      () => {
+        setScannerStatus(ScannerStatus.Error)
+      },
+      ({ scanner }) => {
+        setScannerStatus(scanner)
+      }
+    )
+    setIsFetchingStatus(false)
+  }, interval)
+
+  return scannerStatus
+}

--- a/apps/precinct-scanner/src/screens/AdminScreen.tsx
+++ b/apps/precinct-scanner/src/screens/AdminScreen.tsx
@@ -13,6 +13,7 @@ import PickDateTimeModal from '../components/PickDateTimeModal'
 import { Absolute } from '../components/Absolute'
 import { Bar } from '../components/Bar'
 import Modal from '../components/Modal'
+import CalibrateScannerModal from '../components/CalibrateScannerModal'
 
 interface Props {
   appPrecinctId?: string
@@ -22,6 +23,7 @@ interface Props {
   updateAppPrecinctId: (appPrecinctId: string) => void
   toggleLiveMode: VoidFunction
   unconfigure: VoidFunction
+  calibrate(): Promise<boolean>
 }
 
 const AdminScreen: React.FC<Props> = ({
@@ -32,6 +34,7 @@ const AdminScreen: React.FC<Props> = ({
   updateAppPrecinctId,
   toggleLiveMode,
   unconfigure,
+  calibrate,
 }) => {
   const { election } = electionDefinition
 
@@ -55,8 +58,24 @@ const AdminScreen: React.FC<Props> = ({
   )
 
   const [confirmUnconfigure, setConfirmUnconfigure] = useState(false)
-  const openConfirmUnconfigureModal = () => setConfirmUnconfigure(true)
-  const closeConfirmUnconfigureModal = () => setConfirmUnconfigure(false)
+  const openConfirmUnconfigureModal = useCallback(
+    () => setConfirmUnconfigure(true),
+    []
+  )
+  const closeConfirmUnconfigureModal = useCallback(
+    () => setConfirmUnconfigure(false),
+    []
+  )
+
+  const [isCalibratingScanner, setIsCalibratingScanner] = useState(false)
+  const openCalibrateScannerModal = useCallback(
+    () => setIsCalibratingScanner(true),
+    []
+  )
+  const closeCalibrateScannerModal = useCallback(
+    () => setIsCalibratingScanner(false),
+    []
+  )
 
   const changeAppPrecinctId: SelectChangeEventFunction = (event) => {
     updateAppPrecinctId(event.currentTarget.value)
@@ -109,6 +128,9 @@ const AdminScreen: React.FC<Props> = ({
           </Button>
         </p>
         <p>
+          <Button onPress={openCalibrateScannerModal}>Calibrate Scanner</Button>
+        </p>
+        <p>
           <Button danger small onPress={openConfirmUnconfigureModal}>
             <span role="img" aria-label="Warning">
               ⚠️
@@ -154,6 +176,12 @@ const AdminScreen: React.FC<Props> = ({
             </React.Fragment>
           }
           onOverlayClick={closeConfirmUnconfigureModal}
+        />
+      )}
+      {isCalibratingScanner && (
+        <CalibrateScannerModal
+          onCalibrate={calibrate}
+          onCancel={closeCalibrateScannerModal}
         />
       )}
     </CenteredScreen>

--- a/libs/types/src/api/module-scan.ts
+++ b/libs/types/src/api/module-scan.ts
@@ -516,3 +516,34 @@ export type ZeroResponse = OkResponse
  * @method POST
  */
 export const ZeroResponseSchema: z.ZodSchema<ZeroResponse> = OkResponseSchema
+
+/**
+ * This is `never` because there is no request data.
+ *
+ * @url /scan/calibrate
+ * @method POST
+ */
+export type CalibrateRequest = never
+
+/**
+ * This is `never` because there is no request data.
+ *
+ * @url /scan/calibrate
+ * @method POST
+ */
+export const CalibrateRequestSchema: z.ZodSchema<CalibrateRequest> = z.never()
+
+/**
+ * @url /scan/calibrate
+ * @method POST
+ */
+export type CalibrateResponse = OkResponse | ErrorsResponse
+
+/**
+ * @url /scan/calibrate
+ * @method POST
+ */
+export const CalibrateResponseSchema: z.ZodSchema<CalibrateResponse> = z.union([
+  OkResponseSchema,
+  ErrorsResponseSchema,
+])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -800,6 +800,7 @@ importers:
       stylelint-config-prettier: 8.0.2_stylelint@13.8.0
       stylelint-config-styled-components: 0.1.1
       stylelint-processor-styled-components: 1.10.0
+      ts-jest: 26.5.6_typescript@4.2.4
     specifiers:
       '@codemod/parser': ^1.0.6
       '@rooks/use-interval': ^4.11.2
@@ -870,6 +871,7 @@ importers:
       stylelint-config-prettier: ^8.0.1
       stylelint-config-styled-components: ^0.1.1
       stylelint-processor-styled-components: ^1.9.0
+      ts-jest: ^26.5.6
       typescript: ^4.2.0
       use-interval: ^1.3.0
       web-vitals: ^1.0.1
@@ -23872,6 +23874,28 @@ packages:
       buffer-from: 1.1.1
       fast-json-stable-stringify: 2.1.0
       jest: 26.6.3
+      jest-util: 26.6.2
+      json5: 2.2.0
+      lodash: 4.17.21
+      make-error: 1.3.6
+      mkdirp: 1.0.4
+      semver: 7.3.5
+      typescript: 4.2.4
+      yargs-parser: 20.2.7
+    dev: true
+    engines:
+      node: '>= 10'
+    hasBin: true
+    peerDependencies:
+      jest: '>=26 <27'
+      typescript: '>=3.8 <5.0'
+    resolution:
+      integrity: sha512-rua+rCP8DxpA8b4DQD/6X2HQS8Zy/xzViVYfEs2OQu68tkCuKLV0Md8pmX55+W24uRIyAsf/BajRfxOs+R2MKA==
+  /ts-jest/26.5.6_typescript@4.2.4:
+    dependencies:
+      bs-logger: 0.2.6
+      buffer-from: 1.1.1
+      fast-json-stable-stringify: 2.1.0
       jest-util: 26.6.2
       json5: 2.2.0
       lodash: 4.17.21


### PR DESCRIPTION
https://user-images.githubusercontent.com/1938/118881846-6006b180-b8a8-11eb-8c09-2ad8fc7a4b52.mov

- Add calibration support to each layer of the stack above `plustek-sdk`.
- Add modal to `precinct-scanner`'s `AdminScreen` to handle calibration.

Closes #511