### PR TITLE
chore(all): unify `build:watch` command

### DIFF
--- a/apps/bas/package.json
+++ b/apps/bas/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "script/react-scripts build",
+    "build:watch": "tsc --build --watch",
     "eject": "script/react-scripts eject",
     "format": "prettier '**/*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
     "lint": "tsc --build && eslint '*/**/*.{js,jsx,ts,tsx}' --quiet --fix && pnpm stylelint:run",

--- a/apps/bmd/package.json
+++ b/apps/bmd/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "script/react-scripts build",
+    "build:watch": "tsc --build --watch",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run --browser chrome",
     "format": "prettier '**/*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",

--- a/apps/bsd/package.json
+++ b/apps/bsd/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "script/react-scripts build",
+    "build:watch": "tsc --build --watch",
     "eject": "script/react-scripts eject",
     "format": "prettier '**/*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
     "lint": "tsc --build && eslint '*/**/*.{js,jsx,ts,tsx}' --quiet && pnpm stylelint:run",

--- a/apps/election-manager/package.json
+++ b/apps/election-manager/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "script/react-scripts build",
+    "build:watch": "tsc --build --watch",
     "eject": "script/react-scripts eject",
     "format": "prettier '**/*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
     "lint": "tsc --build && eslint '*/**/*.{js,jsx,ts,tsx}' --quiet && pnpm stylelint:run",

--- a/apps/module-scan/package.json
+++ b/apps/module-scan/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "tsc --build",
+    "build:watch": "tsc --build --watch",
     "dev": "ts-node --transpile-only --files ./src/index.ts",
     "format": "prettier '**/*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
     "lint": "tsc --build && eslint '{src,test}/**/*.{js,jsx,ts,tsx}' --quiet",

--- a/apps/precinct-scanner/package.json
+++ b/apps/precinct-scanner/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "script/react-scripts build",
+    "build:watch": "tsc --build --watch",
     "eject": "script/react-scripts eject",
     "format": "prettier '**/*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
     "lint": "tsc --build && eslint '*/**/*.{js,jsx,ts,tsx}' --quiet && pnpm stylelint:run",

--- a/libs/lsd/package.json
+++ b/libs/lsd/package.json
@@ -15,6 +15,7 @@
   ],
   "scripts": {
     "build": "node-gyp configure build && tsc --build",
+    "build:watch": "tsc --build --watch",
     "lint": "tsc --build && eslint src",
     "test": "jest",
     "test:coverage": "jest --coverage",

--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -9,6 +9,7 @@
   "types": "dist/src/index.d.ts",
   "scripts": {
     "build": "tsc --build",
+    "build:watch": "tsc --build --watch",
     "dev": "tsc --build --watch",
     "lint": "tsc --build && eslint src",
     "prepack": "tsc --build && jest --coverage",

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -9,7 +9,7 @@
   "types": "dist/src/index.d.ts",
   "scripts": {
     "build": "tsc --build",
-    "dev": "tsc --build --watch",
+    "build:watch": "tsc --build --watch",
     "lint": "tsc --build && eslint '*/**/*.{js,jsx,ts,tsx}' --quiet && pnpm stylelint:run",
     "lint:fix": "tsc --build && eslint '*/**/*.{js,jsx,ts,tsx}' --fix --quiet",
     "stylelint:run": "stylelint 'src/**/*.{js,jsx,ts,tsx}'",


### PR DESCRIPTION
Now all projects have a `build:watch` command that does the same thing: build the TypeScript code and all its dependencies.

Extracted from #514