### PR TITLE
fix(ps) fix ballot count fetch and turn off polling when polls closed

### DIFF
--- a/apps/precinct-scanner/src/AppUnhappyPaths.test.tsx
+++ b/apps/precinct-scanner/src/AppUnhappyPaths.test.tsx
@@ -76,6 +76,7 @@ test('module-scan fails to unconfigure', async () => {
     .get('/config/precinct', {
       body: getPrecinctConfigNoPrecinctResponseBody,
     })
+    .get('/scan/status', scanStatusWaitingForPaperResponseBody)
     .deleteOnce('/config/election', { status: 404 })
 
   const card = new MemoryCard()
@@ -134,6 +135,7 @@ test('error from module-scan in accepting a reviewable ballot', async () => {
     .get('/config/precinct', {
       body: getPrecinctConfigNoPrecinctResponseBody,
     })
+    .get('/scan/status', { body: scanStatusWaitingForPaperResponseBody })
   const card = new MemoryCard()
   const hardware = MemoryHardware.standard
   render(<App storage={storage} card={card} hardware={hardware} />)

--- a/apps/precinct-scanner/src/screens/PollWorkerScreen.tsx
+++ b/apps/precinct-scanner/src/screens/PollWorkerScreen.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useState } from 'react'
+import makeDebug from 'debug'
 
 import { Precinct } from '@votingworks/types'
 import { Button, Prose, Loading } from '@votingworks/ui'
@@ -15,6 +16,8 @@ import { CastVoteRecord } from '../config/types'
 
 import { calculateTallyFromCVRs } from '../utils/tallies'
 import AppContext from '../contexts/AppContext'
+
+const debug = makeDebug('precinct-scanner:pollworker-screen')
 
 interface Props {
   ballotsScannedCount: number
@@ -44,16 +47,21 @@ const PollWorkerScreen: React.FC<Props> = ({
       castVoteRecords,
       electionDefinition!.election
     )
+    if (castVoteRecords.length !== ballotsScannedCount) {
+      debug(
+        `Warning, ballots scanned count from status endpoint (${ballotsScannedCount}) does not match number of CVRs (${castVoteRecords.length}) `
+      )
+    }
     const cardTally = {
       tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
-      totalBallotsScanned: ballotsScannedCount,
+      totalBallotsScanned: castVoteRecords.length,
       isLiveMode,
       tally,
       metadata: [
         {
           machineId: machineConfig.machineId,
           timeSaved: Date.now(),
-          ballotCount: ballotsScannedCount,
+          ballotCount: castVoteRecords.length,
         } as CardTallyMetadataEntry,
       ],
     } as PrecinctScannerCardTally
@@ -108,7 +116,8 @@ const PollWorkerScreen: React.FC<Props> = ({
       <Absolute top left>
         <Bar>
           <div>
-            Ballots Scanned: <strong>{ballotsScannedCount}</strong>{' '}
+            Ballots Scanned:{' '}
+            <strong data-testid="ballot-count">{ballotsScannedCount}</strong>{' '}
           </div>
         </Bar>
       </Absolute>


### PR DESCRIPTION
Turns off polling the status endpoint when: a card is inserted, or polls are closing. 

Because this polling also updates the ballot count which is displayed visually I added a check to get the current ballot count when refreshing the other config information from module-scan (test mode, etc.) this happens when the scanner is first configured so the ballot count will be initiated properly when the app starts, regardless of whether or not status polling is happening. 

This piece alone should this bug: https://zube.io/votingworks/vxsuite/c/3317 however just to make sure the tally data we're writing to the card is always consistent with the ballot count being written I also updated to NOT use the ballot count displayed visually and instead use the number of ballots returned in /scan/export for this data point. 

Tested by watching the polling and seeing it stop/start at appropriate moments. Made sure ballot count was always initiated properly even when polls are closed on app start. The debug line I added is never triggered from my testing, but I might be missing an edge case. 