### PR TITLE
fix(ps) reflect polls open status in bmd printed ps report

### DIFF
--- a/apps/bmd/src/pages/PollWorkerScreen.tsx
+++ b/apps/bmd/src/pages/PollWorkerScreen.tsx
@@ -391,7 +391,7 @@ const PollWorkerScreen: React.FC<Props> = ({
                     : `Open Polls for ${precinct.name}`}
                 </Button>
               </p>
-              {!isPollsOpen && isPrintMode && isTallyOnCardFromPrecinctScanner && (
+              {isPrintMode && isTallyOnCardFromPrecinctScanner && (
                 <Prose>
                   <h1> Results Reports </h1>
                   <Button
@@ -602,8 +602,12 @@ const PollWorkerScreen: React.FC<Props> = ({
                   }
                   currentDateTime={currentDateTime}
                   election={election}
-                  isLiveMode={isLiveMode}
-                  isPollsOpen={false}
+                  isLiveMode={
+                    (talliesOnCard as PrecinctScannerCardTally).isLiveMode
+                  }
+                  isPollsOpen={
+                    (talliesOnCard as PrecinctScannerCardTally).isPollsOpen
+                  }
                   machineMetadata={talliesOnCard?.metadata}
                   machineConfig={machineConfig} // not used
                   precinctId={appPrecinctId}
@@ -618,7 +622,9 @@ const PollWorkerScreen: React.FC<Props> = ({
                   }
                   currentDateTime={currentDateTime}
                   election={election}
-                  isPollsOpen={false}
+                  isPollsOpen={
+                    (talliesOnCard as PrecinctScannerCardTally).isPollsOpen
+                  }
                   tally={talliesOnCard!.tally}
                   precinctId={appPrecinctId}
                   reportPurpose={reportPurpose}

--- a/apps/precinct-scanner/src/screens/PollWorkerScreen.tsx
+++ b/apps/precinct-scanner/src/screens/PollWorkerScreen.tsx
@@ -56,6 +56,7 @@ const PollWorkerScreen: React.FC<Props> = ({
       tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: castVoteRecords.length,
       isLiveMode,
+      isPollsOpen: !isPollsOpen, // When we are saving we are about to either open or close polls and want the state to reflect what it will be after that is complete.
       tally,
       metadata: [
         {

--- a/libs/utils/src/types.ts
+++ b/libs/utils/src/types.ts
@@ -61,4 +61,5 @@ export interface PrecinctScannerCardTally {
   readonly metadata: readonly CardTallyMetadataEntry[]
   readonly totalBallotsScanned: number
   readonly isLiveMode: boolean
+  readonly isPollsOpen: boolean
 }


### PR DESCRIPTION
Saved the polls open status from precinct-scanner when saving tallies to the pollworker card so that that status is reflected in the report printed by bmd (previously was hardcoded to always be closed). 

Always shows the "Print Precinct Scanner Report" button in bmd regardless of the isPollsOpen status in bmd

I noticed we weren't reflecting isLiveMode in the bmd report either despite already saving that to card so also updated to reflect that in the printed report. 