### PR TITLE
build(all): extend from a base (empty) shared TS config

### DIFF
--- a/apps/bas/tsconfig.json
+++ b/apps/bas/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.shared.json",
   "compilerOptions": {
     "allowJs": true,
     "allowSyntheticDefaultImports": true,

--- a/apps/bmd/tsconfig.json
+++ b/apps/bmd/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.shared.json",
   "compilerOptions": {
     "allowJs": true,
     "allowSyntheticDefaultImports": true,

--- a/apps/bsd/tsconfig.json
+++ b/apps/bsd/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.shared.json",
   "compilerOptions": {
     "allowJs": true,
     "allowSyntheticDefaultImports": true,

--- a/apps/election-manager/tsconfig.json
+++ b/apps/election-manager/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.shared.json",
   "compilerOptions": {
     "allowJs": true,
     "allowSyntheticDefaultImports": true,

--- a/apps/module-scan/tsconfig.json
+++ b/apps/module-scan/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.shared.json",
   "compilerOptions": {
     "allowJs": true,
     "allowSyntheticDefaultImports": true,

--- a/apps/precinct-scanner/tsconfig.json
+++ b/apps/precinct-scanner/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.shared.json",
   "compilerOptions": {
     "allowJs": true,
     "allowSyntheticDefaultImports": true,

--- a/libs/ballot-encoder/tsconfig.json
+++ b/libs/ballot-encoder/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.shared.json",
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "declaration": true,

--- a/libs/fixtures/tsconfig.json
+++ b/libs/fixtures/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.shared.json",
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
 

--- a/libs/hmpb-interpreter/tsconfig.json
+++ b/libs/hmpb-interpreter/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.shared.json",
   "compilerOptions": {
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */

--- a/libs/lsd/tsconfig.json
+++ b/libs/lsd/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.shared.json",
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
 

--- a/libs/plustek-sdk/tsconfig.json
+++ b/libs/plustek-sdk/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.shared.json",
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
 

--- a/libs/test-utils/tsconfig.json
+++ b/libs/test-utils/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.shared.json",
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
 

--- a/libs/types/tsconfig.json
+++ b/libs/types/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.shared.json",
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
 

--- a/libs/ui/tsconfig.json
+++ b/libs/ui/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.shared.json",
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
 

--- a/libs/utils/tsconfig.json
+++ b/libs/utils/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.shared.json",
   "compilerOptions": {
     "target": "es2017",
     "module": "commonjs",

--- a/tsconfig.shared.json
+++ b/tsconfig.shared.json
@@ -1,0 +1,3 @@
+{
+  "compilerOptions": {}
+}


### PR DESCRIPTION
Eventually, all shared config should move to `tsconfig.shared.json`.