### PR TITLE
feat(ps): show contest details on overvote screen

### DIFF
--- a/apps/precinct-scanner/src/App.test.tsx
+++ b/apps/precinct-scanner/src/App.test.tsx
@@ -503,7 +503,7 @@ test('voter can cast a ballot that needs review and adjudicate as desired', asyn
     },
   } as BallotSheetInfo)
   await advanceTimersAndPromises(1)
-  await screen.findByText('Overvote Warning')
+  await screen.findByText('Ballot Requires Review')
   expect(fetchMock.calls('scan/scanBatch')).toHaveLength(1)
 
   fetchMock.post('/scan/scanContinue', {
@@ -608,7 +608,7 @@ test('voter can cast a ballot that needs review and adjudicate as desired', asyn
     { overwriteRoutes: false }
   )
   await advanceTimersAndPromises(1)
-  await screen.findByText('Overvote Warning')
+  await screen.findByText('Ballot Requires Review')
   expect(fetchMock.calls('scan/scanBatch')).toHaveLength(2)
 
   // Simulate voter pulling out the ballot
@@ -945,10 +945,10 @@ test('voter can cast another ballot while the success screen is showing', async 
   expect(fetchMock.calls('scan/scanBatch')).toHaveLength(1)
   await advanceTimersAndPromises(1)
   await waitFor(() => expect(fetchMock.calls('scan/scanBatch')).toHaveLength(2))
-  await screen.findByText('Overvote Warning')
+  await screen.findByText('Ballot Requires Review')
   // Even after the timeout to expire the success screen occurs we stay on the review screen.
   await advanceTimersAndPromises(5)
-  await screen.findByText('Overvote Warning')
+  await screen.findByText('Ballot Requires Review')
   // No more ballots have scanned even though the scanner is ready for paper
   expect(fetchMock.calls('scan/scanBatch')).toHaveLength(2)
   const adminCard = adminCardForElection(electionSampleDefinition.electionHash)

--- a/apps/precinct-scanner/src/AppRoot.tsx
+++ b/apps/precinct-scanner/src/AppRoot.tsx
@@ -9,7 +9,6 @@ import makeDebug from 'debug'
 import { PrecinctScannerCardTally } from '@votingworks/utils'
 
 import {
-  AdjudicationReason,
   AdminCardData,
   CardData,
   OptionalElectionDefinition,
@@ -27,6 +26,7 @@ import {
   RejectedScanningReason,
   CastVoteRecord,
   MachineConfig,
+  AdjudicationReasonInfo,
 } from './config/types'
 import {
   CARD_POLLING_INTERVAL,
@@ -91,7 +91,7 @@ interface HardwareState {
 }
 
 interface ScanInformationState {
-  adjudicationReasons: AdjudicationReason[]
+  adjudicationReasonInfo: AdjudicationReasonInfo[]
   rejectionReason?: RejectedScanningReason
 }
 
@@ -137,7 +137,7 @@ const initialSharedState: Readonly<SharedState> = {
 }
 
 const initialScanInformationState: Readonly<ScanInformationState> = {
-  adjudicationReasons: [],
+  adjudicationReasonInfo: [],
   rejectionReason: undefined,
 }
 
@@ -177,7 +177,7 @@ type AppAction =
     }
   | {
       type: 'ballotNeedsReview'
-      adjudicationReasons: AdjudicationReason[]
+      adjudicationReasonInfo: AdjudicationReasonInfo[]
     }
   | {
       type: 'ballotRejected'
@@ -300,7 +300,7 @@ const appReducer = (state: State, action: AppAction): State => {
       return {
         ...state,
         ...initialScanInformationState,
-        adjudicationReasons: action.adjudicationReasons,
+        adjudicationReasonInfo: action.adjudicationReasonInfo,
         ballotState: BallotState.NEEDS_REVIEW,
       }
     case 'readyToInsertBallot':
@@ -401,7 +401,7 @@ const AppRoot: React.FC<Props> = ({
     scannedBallotCount,
     timeoutToInsertScreen,
     isStatusPollingEnabled,
-    adjudicationReasons,
+    adjudicationReasonInfo,
     rejectionReason,
     isTestMode,
     hasCardReaderAttached,
@@ -481,7 +481,7 @@ const AppRoot: React.FC<Props> = ({
         case ScanningResultType.NeedsReview:
           dispatchAppState({
             type: 'ballotNeedsReview',
-            adjudicationReasons: scanningResult.adjudicationReasons,
+            adjudicationReasonInfo: scanningResult.adjudicationReasonInfo,
           })
           break
         case ScanningResultType.Accepted: {
@@ -984,7 +984,7 @@ const AppRoot: React.FC<Props> = ({
         voterScreen = (
           <ScanWarningScreen
             acceptBallot={acceptBallot}
-            adjudicationReasons={adjudicationReasons}
+            adjudicationReasonInfo={adjudicationReasonInfo}
           />
         )
         break

--- a/apps/precinct-scanner/src/AppUnhappyPaths.test.tsx
+++ b/apps/precinct-scanner/src/AppUnhappyPaths.test.tsx
@@ -209,7 +209,7 @@ test('error from module-scan in accepting a reviewable ballot', async () => {
     },
   } as BallotSheetInfo)
   await advanceTimersAndPromises(1)
-  await screen.findByText('Overvote Warning')
+  await screen.findByText('Ballot Requires Review')
   expect(fetchMock.calls('scan/scanBatch')).toHaveLength(1)
   fetchMock.post('/scan/scanContinue', {
     body: { status: 'error' },
@@ -319,7 +319,7 @@ test('error from module-scan in ejecting a reviewable ballot', async () => {
     },
   } as BallotSheetInfo)
   await advanceTimersAndPromises(1)
-  await screen.findByText('Overvote Warning')
+  await screen.findByText('Ballot Requires Review')
   expect(fetchMock.calls('scan/scanBatch')).toHaveLength(1)
   fetchMock.post('/scan/scanContinue', {
     body: { status: 'error' },

--- a/apps/precinct-scanner/src/config/types.ts
+++ b/apps/precinct-scanner/src/config/types.ts
@@ -51,7 +51,7 @@ export interface RejectedScanningResult {
 
 export interface ScanningResultNeedsReview {
   resultType: ScanningResultType.NeedsReview
-  adjudicationReasons: AdjudicationReason[]
+  adjudicationReasonInfo: AdjudicationReasonInfo[]
 }
 
 export type ISO8601Timestamp = string

--- a/apps/precinct-scanner/src/screens/ScanWarningScreen.tsx
+++ b/apps/precinct-scanner/src/screens/ScanWarningScreen.tsx
@@ -1,22 +1,28 @@
 /* istanbul ignore file */
-import React, { useState } from 'react'
+import React, { useState, useContext } from 'react'
 import { Button, Prose, Text } from '@votingworks/ui'
 
-import { AdjudicationReason } from '@votingworks/types'
+import { AdjudicationReason, AnyContest } from '@votingworks/types'
+import {
+  AdjudicationReasonInfo,
+  OvervoteAdjudicationReasonInfo,
+} from '../config/types'
 import { ExclamationTriangle } from '../components/Graphics'
 import { CenteredLargeProse, CenteredScreen } from '../components/Layout'
 import { Absolute } from '../components/Absolute'
 import { Bar } from '../components/Bar'
 import Modal from '../components/Modal'
+import AppContext from '../contexts/AppContext'
 
 interface Props {
   acceptBallot: () => Promise<void>
-  adjudicationReasons: AdjudicationReason[]
+  adjudicationReasonInfo: AdjudicationReasonInfo[]
 }
 const ScanWarningScreen: React.FC<Props> = ({
   acceptBallot,
-  adjudicationReasons,
+  adjudicationReasonInfo,
 }) => {
+  const { electionDefinition } = useContext(AppContext)
   const [confirmTabulate, setConfirmTabulate] = useState(false)
   const openConfirmTabulateModal = () => setConfirmTabulate(true)
   const closeConfirmTabulateModal = () => setConfirmTabulate(false)
@@ -26,22 +32,51 @@ const ScanWarningScreen: React.FC<Props> = ({
     acceptBallot()
   }
 
-  const isOvervote = adjudicationReasons.includes(AdjudicationReason.Overvote)
-  const isBlank = adjudicationReasons.includes(AdjudicationReason.BlankBallot)
+  const overvoteReasons = adjudicationReasonInfo.filter(
+    (a) => a.type === AdjudicationReason.Overvote
+  )
+  const blankReasons = adjudicationReasonInfo.filter(
+    (a) => a.type === AdjudicationReason.BlankBallot
+  )
+  const isOvervote = overvoteReasons.length > 0
+  const isBlank = blankReasons.length > 0
+
+  const overvoteContests: AnyContest[] = overvoteReasons
+    .map((o) =>
+      electionDefinition!.election.contests.find(
+        (c) => c.id === (o as OvervoteAdjudicationReasonInfo).contestId
+      )
+    )
+    .filter((c): c is AnyContest => !!c)
+  let overvoteContestNames = ''
+  if (overvoteContests.length === 1) {
+    overvoteContestNames = overvoteContests[0]!.title
+  } else if (overvoteContests.length > 1) {
+    overvoteContestNames = `${overvoteContests
+      .slice(0, overvoteContests.length - 1)
+      .map((c) => c.title)
+      .join(', ')} and ${overvoteContests[overvoteContests.length - 1]!.title} `
+  }
 
   return (
     <CenteredScreen infoBar={false}>
       <ExclamationTriangle />
       <CenteredLargeProse>
-        <h1>
-          {isOvervote
-            ? 'Overvote Warning'
-            : isBlank
-            ? 'Blank Ballot'
-            : 'Ballot Requires Review'}
-        </h1>
-        <p>Remove the ballot, fix the issue, then scan again.</p>
-        <Text italic>Ask a poll worker if you need assistance.</Text>
+        <h1>{isBlank ? 'Blank Ballot' : 'Ballot Requires Review'}</h1>
+        {isOvervote ? (
+          <React.Fragment>
+            <p>Too many marks for:</p>
+            <p>{overvoteContestNames}</p>
+            <Text italic>
+              Remove ballot and ask the poll worker for a new ballot.
+            </Text>
+          </React.Fragment>
+        ) : (
+          <React.Fragment>
+            <p>Remove the ballot, fix the issue, then scan again.</p>
+            <Text italic>Ask a poll worker if you need assistance.</Text>
+          </React.Fragment>
+        )}
       </CenteredLargeProse>
       <Absolute bottom left right>
         <Bar style={{ justifyContent: 'flex-end' }}>


### PR DESCRIPTION
Shows contest details on overvote warning screen: 

![Screen Shot 2021-05-25 at 2 13 26 PM](https://user-images.githubusercontent.com/14897017/119569811-1c0e2380-bd64-11eb-90b9-b54c8684467c.png)

Maximum lines of text that fit without scrolling (at 1920x1280): 
<img width="1098" alt="Screen Shot 2021-05-25 at 2 19 42 PM" src="https://user-images.githubusercontent.com/14897017/119569933-4829a480-bd64-11eb-8035-f215c316813c.png">

I don't feel that strongly about the copy @beausmith if you want to change anything feel free.
