### PR TITLE
fix(scan): display overvoted contest titles boldly

### DIFF
--- a/apps/precinct-scanner/src/utils/toSentence.ts
+++ b/apps/precinct-scanner/src/utils/toSentence.ts
@@ -1,0 +1,23 @@
+import React from 'react'
+
+/**
+ * Joins elements of `list` along with `comma` and `and` into parts that, when
+ * displayed together, form a sentence.
+ */
+export function toSentence(
+  list: Iterable<React.ReactChild>,
+  comma = ', ',
+  and = ' and '
+): React.ReactChild[] {
+  const elements = [...list]
+
+  if (elements.length < 2) {
+    return elements
+  }
+
+  return [
+    ...elements.slice(0, -1).flatMap((element) => [element, comma]),
+    and,
+    elements[elements.length - 1],
+  ]
+}


### PR DESCRIPTION
|Before|After|
|-|-|
|![localhost_3000_(Lenovo IdeaPad Flex 14 (FHD)) (1)](https://user-images.githubusercontent.com/1938/119575268-a017d980-bd6b-11eb-963d-49d1dcb36011.png)|![localhost_3000_(Lenovo IdeaPad Flex 14 (FHD))](https://user-images.githubusercontent.com/1938/119575283-a6a65100-bd6b-11eb-9b24-6eb71936183c.png)|

Includes a couple other minor fixes:
- avoid TS casting by using type predicates when filtering
- encapsulate sentence-building functionality in `toSentence` utility
- match `a pollworker` from elsewhere rather than `the pollworker`