### PR TITLE
fix(types): allow `ok()` for `Result<void, …>`

### DIFF
--- a/apps/module-scan/src/scanners/plustek.test.ts
+++ b/apps/module-scan/src/scanners/plustek.test.ts
@@ -68,7 +68,7 @@ test('plustek scanner accept sheet', async () => {
   })
 
   // successful accept
-  plustekClient.accept.mockResolvedValueOnce(ok(undefined))
+  plustekClient.accept.mockResolvedValueOnce(ok())
   plustekClient.waitForStatus.mockResolvedValue(ok(PaperStatus.NoPaper))
   expect(await scanner.scanSheets().acceptSheet()).toEqual(true)
 
@@ -77,7 +77,7 @@ test('plustek scanner accept sheet', async () => {
   expect(await scanner.scanSheets().acceptSheet()).toEqual(false)
 
   // failed to get correct final status
-  plustekClient.accept.mockResolvedValueOnce(ok(undefined))
+  plustekClient.accept.mockResolvedValueOnce(ok())
   plustekClient.waitForStatus.mockResolvedValue(undefined)
   expect(await scanner.scanSheets().acceptSheet()).toEqual(false)
 })
@@ -89,7 +89,7 @@ test('plustek scanner review sheet', async () => {
   })
 
   // successful review
-  plustekClient.reject.mockResolvedValueOnce(ok(undefined))
+  plustekClient.reject.mockResolvedValueOnce(ok())
   plustekClient.waitForStatus.mockResolvedValue(ok(PaperStatus.VtmReadyToScan))
   expect(await scanner.scanSheets().reviewSheet()).toEqual(true)
 
@@ -98,7 +98,7 @@ test('plustek scanner review sheet', async () => {
   expect(await scanner.scanSheets().reviewSheet()).toEqual(false)
 
   // failed to get correct final status
-  plustekClient.reject.mockResolvedValueOnce(ok(undefined))
+  plustekClient.reject.mockResolvedValueOnce(ok())
   plustekClient.waitForStatus.mockResolvedValue(undefined)
   expect(await scanner.scanSheets().reviewSheet()).toEqual(false)
 })
@@ -110,7 +110,7 @@ test('plustek scanner reject sheet', async () => {
   })
 
   // successful reject
-  plustekClient.reject.mockResolvedValueOnce(ok(undefined))
+  plustekClient.reject.mockResolvedValueOnce(ok())
   plustekClient.waitForStatus.mockResolvedValue(
     ok(PaperStatus.VtmDevReadyNoPaper)
   )
@@ -121,7 +121,7 @@ test('plustek scanner reject sheet', async () => {
   expect(await scanner.scanSheets().rejectSheet()).toEqual(false)
 
   // failed to get correct final status
-  plustekClient.reject.mockResolvedValueOnce(ok(undefined))
+  plustekClient.reject.mockResolvedValueOnce(ok())
   plustekClient.waitForStatus.mockResolvedValue(undefined)
   expect(await scanner.scanSheets().rejectSheet()).toEqual(false)
 })
@@ -135,7 +135,7 @@ test('plustek scanner reject sheet w/alwaysHoldOnReject', async () => {
     true
   )
 
-  plustekClient.reject.mockResolvedValueOnce(ok(undefined))
+  plustekClient.reject.mockResolvedValueOnce(ok())
   plustekClient.waitForStatus.mockResolvedValue(ok(PaperStatus.VtmReadyToScan))
   expect(await scanner.scanSheets().rejectSheet()).toEqual(true)
 })
@@ -149,7 +149,7 @@ test('plustek scanner calibrate', async () => {
     true
   )
 
-  plustekClient.calibrate.mockResolvedValueOnce(ok(undefined))
+  plustekClient.calibrate.mockResolvedValueOnce(ok())
   expect(await scanner.calibrate()).toEqual(true)
 
   plustekClient.calibrate.mockResolvedValueOnce(

--- a/apps/module-scan/src/scanners/plustek.ts
+++ b/apps/module-scan/src/scanners/plustek.ts
@@ -299,7 +299,7 @@ export function withReconnect(
     },
 
     close: async () => {
-      return (await (await clientPromise)?.close()) ?? ok(undefined)
+      return (await (await clientPromise)?.close()) ?? ok()
     },
 
     getPaperStatus: async () => {

--- a/libs/plustek-sdk/src/mocks.ts
+++ b/libs/plustek-sdk/src/mocks.ts
@@ -97,7 +97,7 @@ export class MockScannerClient implements ScannerClient {
     this.loaded = files
     this.loadedAt = 'front'
     debug('manualLoad success')
-    return ok(undefined)
+    return ok()
   }
 
   /**
@@ -124,7 +124,7 @@ export class MockScannerClient implements ScannerClient {
     delete this.loaded
     delete this.loadedAt
     debug('manualRemove success')
-    return ok(undefined)
+    return ok()
   }
 
   /**
@@ -278,7 +278,7 @@ export class MockScannerClient implements ScannerClient {
     delete this.loaded
     delete this.loadedAt
     debug('accept success')
-    return ok(undefined)
+    return ok()
   }
 
   /**
@@ -316,7 +316,7 @@ export class MockScannerClient implements ScannerClient {
     }
 
     debug('reject success')
-    return ok(undefined)
+    return ok()
   }
 
   public async calibrate(): Promise<CalibrateResult> {
@@ -346,7 +346,7 @@ export class MockScannerClient implements ScannerClient {
     delete this.loaded
     delete this.loadedAt
     debug('calibrate success')
-    return ok(undefined)
+    return ok()
   }
 
   /**
@@ -355,6 +355,6 @@ export class MockScannerClient implements ScannerClient {
   public async close(): Promise<CloseResult> {
     debug('close')
     this.connected = false
-    return ok(undefined)
+    return ok()
   }
 }

--- a/libs/plustek-sdk/src/scanner.ts
+++ b/libs/plustek-sdk/src/scanner.ts
@@ -275,7 +275,7 @@ export async function createClient(
 
     accept: () =>
       doIPC('accept', {
-        ok: (resolve) => resolve(ok(undefined)),
+        ok: (resolve) => resolve(ok()),
         error: (error, resolve) => resolve(err(error)),
         else: (line, resolve) =>
           resolve(err(new Error(`invalid response: ${line}`))),
@@ -283,7 +283,7 @@ export async function createClient(
 
     reject: ({ hold }) =>
       doIPC(hold ? 'reject-hold' : 'reject', {
-        ok: (resolve) => resolve(ok(undefined)),
+        ok: (resolve) => resolve(ok()),
         error: (error, resolve) => resolve(err(error)),
         else: (line, resolve) =>
           resolve(err(new Error(`invalid response: ${line}`))),
@@ -291,7 +291,7 @@ export async function createClient(
 
     calibrate: () =>
       doIPC('calibrate', {
-        ok: (resolve) => resolve(ok(undefined)),
+        ok: (resolve) => resolve(ok()),
         error: (error, resolve) => resolve(err(error)),
         else: (line, resolve) =>
           resolve(err(new Error(`invalid response: ${line}`))),
@@ -300,7 +300,7 @@ export async function createClient(
     close: () => {
       quitting = true
       return doIPC('quit', {
-        ok: (resolve) => resolve(ok(undefined)),
+        ok: (resolve) => resolve(ok()),
         error: (error, resolve) => resolve(err(error)),
         else: (line, resolve) =>
           resolve(err(new Error(`invalid response: ${line}`))),

--- a/libs/types/src/generic.test.ts
+++ b/libs/types/src/generic.test.ts
@@ -13,6 +13,10 @@ test('ok has contained value', () => {
   expect(ok(value).ok()).toBe(value)
 })
 
+test('ok without contained value', () => {
+  expect(ok().ok()).toBeUndefined()
+})
+
 test('ok has no contained error', () => {
   expect(ok(0).err()).toBeUndefined()
 })

--- a/libs/types/src/generic.ts
+++ b/libs/types/src/generic.ts
@@ -258,7 +258,9 @@ export interface Err<E> extends Result<never, E> {
   expectErr(throwable: unknown): E
 }
 
-export function ok<T, E>(value: T): Result<T, E> {
+export function ok<E>(): Result<void, E>
+export function ok<T, E>(value: T): Result<T, E>
+export function ok<T, E>(value: T = (undefined as unknown) as T): Result<T, E> {
   return {
     isOk: () => true,
     isErr: () => false,


### PR DESCRIPTION
Previously it required `ok(undefined)`.