### PR TITLE
feat(types): add `AsyncResult`

### DIFF
--- a/libs/plustek-sdk/examples/web/index.ts
+++ b/libs/plustek-sdk/examples/web/index.ts
@@ -149,7 +149,7 @@ async function main(args: readonly string[]): Promise<number> {
                 (error) => res.writeHead(400).end(`${error}`),
                 async ({ files }) => {
                   debug('loading a mock sheet: %o', files)
-                  ;(await scanner.manualLoad(files)).mapOrElse(
+                  ;(await scanner.simulateLoadSheet(files)).mapOrElse(
                     (error) => res.writeHead(500).end(`${error}`),
                     () => res.writeHead(200).end()
                   )
@@ -157,7 +157,7 @@ async function main(args: readonly string[]): Promise<number> {
               )
             }
           } else if (req.method === 'DELETE') {
-            (await scanner.manualRemove()).mapOrElse(
+            (await scanner.simulateRemoveSheet()).mapOrElse(
               (error) => res.writeHead(500).end(`${error}`),
               () => res.writeHead(200).end()
             )

--- a/libs/types/src/generic.test.ts
+++ b/libs/types/src/generic.test.ts
@@ -1,4 +1,4 @@
-import { err, ok } from './generic'
+import { asyncResult, AsyncResult, err, ok, Result } from './generic'
 
 test('ok is Ok', () => {
   expect(ok(0).isOk()).toBe(true)
@@ -151,4 +151,252 @@ test('err expect', () => {
 
 test('err expectErr', () => {
   expect(err(0).expectErr('expected an error')).toBe(0)
+})
+
+test('mapResult', () => {
+  expect(
+    ok(0)
+      .mapResult((r) => err(r.ok()))
+      .mapResult((r) => ok(r.err()))
+      .ok()
+  ).toEqual(0)
+})
+
+test('tap', () => {
+  const callback = jest.fn()
+  const result = ok(0)
+  expect(result.tap(callback)).toBe(result)
+  expect(callback).toHaveBeenCalledWith(result)
+})
+
+test('async async', async () => {
+  expect(await ok(0).async().async().isOk()).toEqual(true)
+})
+
+test('async ok is ok', async () => {
+  expect(await ok(0).async().isOk()).toEqual(true)
+})
+
+test('async ok is not Err', async () => {
+  expect(await ok(0).async().isErr()).toBe(false)
+})
+
+test('async ok has contained value', async () => {
+  const value = {}
+  expect(await ok(value).async().ok()).toBe(value)
+})
+
+test('async ok without contained value', async () => {
+  expect(await ok().async().ok()).toBeUndefined()
+})
+
+test('async ok has no contained error', async () => {
+  expect(await ok(0).async().err()).toBeUndefined()
+})
+
+test('async ok andThen', async () => {
+  expect(
+    await ok(0)
+      .async()
+      .andThen((n) => ok(n + 1).async())
+      .unwrap()
+  ).toBe(1)
+  expect(
+    await ok(0)
+      .async()
+      .andThen((n) => err(n + 1))
+      .unwrapErr()
+  ).toBe(1)
+})
+
+test('async ok map', async () => {
+  expect(
+    await ok(0)
+      .async()
+      .map((n) => n + 1)
+      .unwrap()
+  ).toBe(1)
+})
+
+test('async ok mapErr', async () => {
+  expect(
+    await ok(0)
+      .async()
+      .mapErr(() => -1)
+      .unwrap()
+  ).toBe(0)
+})
+
+test('async ok mapOr', async () => {
+  expect(
+    await ok(0)
+      .async()
+      .mapOr(-1, (n) => n + 1)
+  ).toBe(1)
+})
+
+test('async ok mapOrElse', async () => {
+  expect(
+    await ok(0)
+      .async()
+      .mapOrElse(
+        () => -1,
+        (n) => n + 1
+      )
+  ).toBe(1)
+})
+
+test('async ok unwrap', async () => {
+  expect(await ok(0).async().unwrap()).toBe(0)
+})
+
+test('async ok unwrapErr', async () => {
+  // for some reason `await expect(…).rejects.toThrowError(…)` does not work
+  try {
+    await ok('value').async().unwrapErr()
+    fail()
+  } catch (error) {
+    expect(error).toBe('value')
+  }
+})
+
+test('async ok expect', async () => {
+  expect(await ok(0).async().expect('expected a number')).toBe(0)
+})
+
+test('async ok expectErr', async () => {
+  // for some reason `await expect(…).rejects.toThrowError(…)` does not work
+  try {
+    await ok(0).async().expectErr('expected an error')
+    fail()
+  } catch (error) {
+    expect(error).toBe('expected an error')
+  }
+})
+
+test('async err is Err', async () => {
+  expect(await err(0).async().isErr()).toBe(true)
+})
+
+test('async err is not Ok', async () => {
+  expect(await err(0).async().isOk()).toBe(false)
+})
+
+test('async err has contained error', async () => {
+  const error = {}
+  expect(await err(error).async().err()).toBe(error)
+})
+
+test('async err has no contained value', async () => {
+  expect(await err(0).async().ok()).toBeUndefined()
+})
+
+test('async err andThen', async () => {
+  expect(
+    await err(0)
+      .async()
+      .andThen(() => ok<number, number>(1))
+      .unwrapErr()
+  ).toBe(0)
+})
+
+test('async err map', async () => {
+  expect(
+    await err(0)
+      .async()
+      .map(() => 1)
+      .map((n) => Promise.resolve(n))
+      .unwrapErr()
+  ).toBe(0)
+})
+
+test('async err mapErr', async () => {
+  expect(
+    await err(0)
+      .async()
+      .mapErr((n) => n + 1)
+      .mapErr((n) => Promise.resolve(n * 2))
+      .unwrapErr()
+  ).toEqual(2)
+})
+
+test('async err mapOr', async () => {
+  expect(
+    await err(0)
+      .async()
+      .mapOr(-1, () => 1)
+  ).toBe(-1)
+})
+
+test('async err mapOrElse', async () => {
+  expect(
+    await err(0)
+      .async()
+      .mapOrElse(
+        () => -1,
+        () => 1
+      )
+  ).toBe(-1)
+})
+
+test('async err unwrap', async () => {
+  // for some reason `await expect(…).rejects.toThrowError(…)` does not work
+  try {
+    await err('error').async().unwrap()
+    fail()
+  } catch (error) {
+    expect(error).toEqual('error')
+  }
+})
+
+test('async err unwrapErr', async () => {
+  expect(await err('error').async().unwrapErr()).toBe('error')
+})
+
+test('async err expect', async () => {
+  // for some reason `await expect(…).rejects.toThrowError(…)` does not work
+  try {
+    await err(0).async().expect('expected a value')
+  } catch (error) {
+    expect(error).toEqual('expected a value')
+  }
+})
+
+test('async err expectErr', async () => {
+  expect(await err(0).async().expectErr('expected an error')).toBe(0)
+})
+
+test('async chains', async () => {
+  function getData(): AsyncResult<number[], Error> {
+    return asyncResult(Promise.resolve(ok([1, 2, 3])))
+  }
+
+  function sum(numbers: readonly number[]): Result<number, Error> {
+    return numbers.length === 0
+      ? err(new Error('nothing to sum'))
+      : ok(numbers.reduce((sum, n) => sum + n, 0))
+  }
+
+  function negate(number: number): Result<number, Error> {
+    return number === 0 ? err(new Error('cannot negate zero')) : ok(-number)
+  }
+
+  expect(await getData().andThen(sum).andThen(negate).ok()).toEqual(-6)
+})
+
+test('async mapResult', async () => {
+  expect(
+    await ok(0)
+      .async()
+      .mapResult((r) => err(r.ok()))
+      .mapResult((r) => ok(r.err()))
+      .ok()
+  ).toEqual(0)
+})
+
+test('async tap', () => {
+  const callback = jest.fn()
+  const result = ok(0).async()
+  expect(result.tap(callback)).toBe(result)
+  expect(callback).toHaveBeenCalledWith(result)
 })

--- a/libs/types/src/generic.ts
+++ b/libs/types/src/generic.ts
@@ -11,6 +11,16 @@ export interface Provider<T> {
  */
 export interface Result<T, E> {
   /**
+   * Gets an async version of this result.
+   */
+  async(): AsyncResult<T, E>
+
+  /**
+   * Returns `this`.
+   */
+  toResult(): this
+
+  /**
    * Returns `true` if the result is `Ok`.
    */
   isOk(): this is Ok<T>
@@ -81,7 +91,17 @@ export interface Result<T, E> {
    * Applies `fn` to a contained `Ok` value for a new `Result`, or returns `Err`
    * as-is.
    */
-  andThen<U>(fn: (value: T) => Result<U, E>): Result<U, E>
+  andThen<U, F>(fn: (value: T) => Result<U, F>): Result<U, E | F>
+
+  /**
+   * Applies `fn` to the result, returning whatever `fn` returns.
+   */
+  mapResult<U>(fn: (result: this) => U): U
+
+  /**
+   * Applies `fn` to the result, returning the same result.
+   */
+  tap(fn: (result: this) => void): this
 
   /**
    * Returns a contained `Ok` value, or throws a contained `Err` error.
@@ -122,6 +142,155 @@ export interface Result<T, E> {
    *   console.log(err(NaN).expectErr('expected an error')) // logs `NaN`
    */
   expectErr(throwable: unknown): E
+}
+
+export interface AsyncResult<T, E> {
+  /**
+   * Gets `this`.
+   */
+  async(): this
+
+  /**
+   * Resolves to a `Result` for the same values.
+   */
+  toResult(): Promise<Result<T, E>>
+
+  /**
+   * Returns `true` if the result is `Ok`.
+   */
+  isOk(): Promise<boolean>
+
+  /**
+   * Returns `true` if the result is `Err`.
+   */
+  isErr(): Promise<boolean>
+
+  /**
+   * Returns the value if result is `Ok`, otherwise undefined.
+   */
+  ok(): Promise<Optional<T>>
+
+  /**
+   * Returns the error if result is `Err`, otherwise undefined.
+   */
+  err(): Promise<Optional<E>>
+
+  /**
+   * Maps a `Result<T, E>` to `Result<U, E>` by applying `fn` to an `Ok` value,
+   * leaving an `Err` value untouched.
+   *
+   * @example
+   *
+   *   const times2 = (n: number) => n * 2
+   *   console.log(ok(1).map(times2).ok()) // logs `2`
+   *   console.log(err(-1).map(times2).ok()) // logs `undefined`
+   */
+  map<U>(fn: (value: T) => U | Promise<U>): AsyncResult<U, E>
+
+  /**
+   * Maps a `Result<T, E>` to `Result<T, F>` by applying `fn` to an `Err` value,
+   * leaving an `Ok` value untouched.
+   *
+   * @example
+   *
+   *   const times2 = (n: number) => n * 2
+   *   console.log(ok(1).mapErr(times2).ok()) // logs `1`
+   *   console.log(err(-1).mapErr(times2).err()) // logs `-2`
+   */
+  mapErr<F>(fn: (error: E) => F | Promise<F>): AsyncResult<T, F>
+
+  /**
+   * Applies `fn` to a contained `Ok` value or returns `defaultValue` for `Err`.
+   *
+   * @example
+   *
+   *   const times2 = (n: number) => n * 2
+   *   console.log(ok(1).mapOr(-1, times2)) // logs `2`
+   *   console.log(err(NaN).mapOr(-1, times2)) // logs `-1`
+   */
+  mapOr<U>(
+    defaultValue: U | Promise<U>,
+    fn: (value: T) => U | Promise<U>
+  ): Promise<U>
+
+  /**
+   * Applies `fn` to a contained `Ok` value or `defaultFn` to a contained `Err`
+   * error.
+   *
+   * @example
+   *
+   *   const times2 = (n: number) => n * 2
+   *   console.log(ok(1).mapOrElse(() => -1, times2)) // logs `2`
+   *   console.log(err(NaN).mapOrElse(() => -1, times2)) // logs `-1`
+   */
+  mapOrElse<U>(
+    defaultFn: (error: E) => U | Promise<U>,
+    fn: (value: T) => U | Promise<U>
+  ): Promise<U>
+
+  /**
+   * Applies `fn` to a contained `Ok` value for a new `Result`, or returns `Err`
+   * as-is.
+   */
+  andThen<U, F>(
+    fn: (
+      value: T
+    ) =>
+      | Result<U, E | F>
+      | AsyncResult<U, E | F>
+      | Promise<Result<U, E | F>>
+      | Promise<AsyncResult<U, E | F>>
+  ): AsyncResult<U, E | F>
+
+  /**
+   * Applies `fn` to the result, returning whatever `fn` returns.
+   */
+  mapResult<U>(fn: (result: this) => U): U
+
+  /**
+   * Applies `fn` to the result, returning the same result.
+   */
+  tap(fn: (result: this) => void): this
+
+  /**
+   * Returns a contained `Ok` value, or throws a contained `Err` error.
+   *
+   * @example
+   *
+   *   console.log(ok(1).unwrap()) // logs `1`
+   *   console.log(err(NaN).unwrap()) // throws `NaN`
+   */
+  unwrap(): Promise<T>
+
+  /**
+   * Returns a contained `Err` error, or throws a contained `Ok` value.
+   *
+   * @example
+   *
+   *   console.log(ok(1).unwrapErr()) // throws `1`
+   *   console.log(err(NaN).unwrapErr()) // logs `NaN`
+   */
+  unwrapErr(): Promise<E>
+
+  /**
+   * Returns a contained `Ok` value, or throws `throwable`.
+   *
+   * @example
+   *
+   *   console.log(ok(1).expect('expected a number')) // logs `1`
+   *   console.log(err(NaN).expect('expected a number')) // throws 'expected a number'
+   */
+  expect(throwable: unknown): Promise<T>
+
+  /**
+   * Returns a contained `Err` error, or throws `throwable`.
+   *
+   * @example
+   *
+   *   console.log(ok(1).expectErr('expected an error')) // throws 'expected an error'
+   *   console.log(err(NaN).expectErr('expected an error')) // logs `NaN`
+   */
+  expectErr(throwable: unknown): Promise<E>
 }
 
 export interface Ok<T> extends Result<T, never> {
@@ -235,7 +404,7 @@ export interface Err<E> extends Result<never, E> {
   /**
    * Returns `Err` as-is.
    */
-  andThen<U>(fn: (value: never) => Result<U, E>): Err<E>
+  andThen<U, F>(fn: (value: never) => Result<U, F>): Err<E>
 
   /**
    * Throws the contained error.
@@ -258,48 +427,431 @@ export interface Err<E> extends Result<never, E> {
   expectErr(throwable: unknown): E
 }
 
-export function ok<E>(): Result<void, E>
-export function ok<T, E>(value: T): Result<T, E>
-export function ok<T, E>(value: T = (undefined as unknown) as T): Result<T, E> {
-  return {
-    isOk: () => true,
-    isErr: () => false,
-    ok: () => value,
-    err: () => undefined,
-    map: (fn) => ok(fn(value)),
-    mapErr: () => ok(value),
-    mapOr: (_defaultValue, fn) => fn(value),
-    mapOrElse: (_defaultFn, fn) => fn(value),
-    andThen: (fn) => fn(value),
-    unwrap: () => value,
-    unwrapErr: () => {
-      throw value
-    },
-    expect: () => value,
-    expectErr: (throwable) => {
+class ResultImpl<T, E> implements Result<T, E> {
+  private readonly _isOk: boolean
+  private readonly _value?: T
+  private readonly _error?: E
+
+  public constructor(isOk: true, value: T)
+  public constructor(isOk: false, error: E)
+  public constructor(isOk: boolean, valueOrError: T | E) {
+    this._isOk = isOk
+    if (isOk) {
+      this._value = valueOrError as T
+    } else {
+      this._error = valueOrError as E
+    }
+  }
+
+  /**
+   * Returns `this`.
+   */
+  public toResult(): this {
+    return this
+  }
+
+  /**
+   * Returns a wrapper for this `Result` to prepare for async operations.
+   */
+  public async(): AsyncResult<T, E> {
+    return asyncResult(this)
+  }
+
+  /**
+   * Returns `true` if the result is `Ok`.
+   */
+  public isOk(): this is Ok<T> {
+    return this._isOk
+  }
+
+  /**
+   * Returns `true` if the result is `Err`.
+   */
+  public isErr(): this is Err<E> {
+    return !this._isOk
+  }
+
+  /**
+   * Returns the value if result is `Ok`, otherwise undefined.
+   */
+  public ok(): Optional<T> {
+    return this._value
+  }
+
+  /**
+   * Returns the error if result is `Err`, otherwise undefined.
+   */
+  public err(): Optional<E> {
+    return this._error
+  }
+
+  /**
+   * Maps a `Result<T, E>` to `Result<U, E>` by applying `fn` to an `Ok` value,
+   * leaving an `Err` value untouched.
+   *
+   * @example
+   *
+   *   const times2 = (n: number) => n * 2
+   *   console.log(ok(1).map(times2).ok()) // logs `2`
+   *   console.log(err(-1).map(times2).ok()) // logs `undefined`
+   */
+  public map<U>(fn: (value: T) => U): Result<U, E> {
+    return this.isOk() ? ok(fn(this.unwrap())) : err(this.unwrapErr())
+  }
+
+  /**
+   * Maps a `Result<T, E>` to `Result<T, F>` by applying `fn` to an `Err` value,
+   * leaving an `Ok` value untouched.
+   *
+   * @example
+   *
+   *   const times2 = (n: number) => n * 2
+   *   console.log(ok(1).mapErr(times2).ok()) // logs `1`
+   *   console.log(err(-1).mapErr(times2).err()) // logs `-2`
+   */
+  public mapErr<F>(fn: (error: E) => F): Result<T, F> {
+    return this.isOk() ? ok(this.unwrap()) : err(fn(this.unwrapErr()))
+  }
+
+  /**
+   * Applies `fn` to a contained `Ok` value or returns `defaultValue` for `Err`.
+   *
+   * @example
+   *
+   *   const times2 = (n: number) => n * 2
+   *   console.log(ok(1).mapOr(-1, times2)) // logs `2`
+   *   console.log(err(NaN).mapOr(-1, times2)) // logs `-1`
+   */
+  public mapOr<U>(defaultValue: U, fn: (value: T) => U): U {
+    return this.isOk() ? fn(this.unwrap()) : defaultValue
+  }
+
+  /**
+   * Applies `fn` to a contained `Ok` value or `defaultFn` to a contained `Err`
+   * error.
+   *
+   * @example
+   *
+   *   const times2 = (n: number) => n * 2
+   *   console.log(ok(1).mapOrElse(() => -1, times2)) // logs `2`
+   *   console.log(err(NaN).mapOrElse(() => -1, times2)) // logs `-1`
+   */
+  public mapOrElse<U>(defaultFn: (error: E) => U, fn: (value: T) => U): U {
+    return this.isOk() ? fn(this.unwrap()) : defaultFn(this.unwrapErr())
+  }
+
+  /**
+   * Applies `fn` to a contained `Ok` value for a new `Result`, or returns `Err`
+   * as-is.
+   */
+  public andThen<U>(fn: (value: T) => Result<U, E>): Result<U, E>
+  public andThen<U, F>(fn: (value: T) => Result<U, F>): Result<U, E | F>
+  public andThen<U>(fn: (value: T) => Result<U, E>): Result<U, E> {
+    return this.isOk() ? fn(this.unwrap()) : err(this.unwrapErr())
+  }
+
+  /**
+   * Applies `fn` to the result, returning whatever `fn` returns.
+   */
+  public mapResult<U>(fn: (result: this) => U): U {
+    return fn(this)
+  }
+
+  /**
+   * Applies `fn` to the result, returning the same result.
+   */
+  public tap(fn: (result: this) => void): this {
+    fn(this)
+    return this
+  }
+
+  /**
+   * Returns a contained `Ok` value, or throws a contained `Err` error.
+   *
+   * @example
+   *
+   *   console.log(ok(1).unwrap()) // logs `1`
+   *   console.log(err(NaN).unwrap()) // throws `NaN`
+   */
+  public unwrap(): T {
+    if (this.isErr()) {
+      throw this.err()
+    }
+    return this._value as T
+  }
+
+  /**
+   * Returns a contained `Err` error, or throws a contained `Ok` value.
+   *
+   * @example
+   *
+   *   console.log(ok(1).unwrapErr()) // throws `1`
+   *   console.log(err(NaN).unwrapErr()) // logs `NaN`
+   */
+  public unwrapErr(): E {
+    if (this.isOk()) {
+      throw this.ok()
+    }
+    return this._error as E
+  }
+
+  /**
+   * Returns a contained `Ok` value, or throws `throwable`.
+   *
+   * @example
+   *
+   *   console.log(ok(1).expect('expected a number')) // logs `1`
+   *   console.log(err(NaN).expect('expected a number')) // throws 'expected a number'
+   */
+  public expect(throwable: unknown): T {
+    if (this.isErr()) {
       throw throwable
-    },
+    }
+    return this._value as T
+  }
+
+  /**
+   * Returns a contained `Err` error, or throws `throwable`.
+   *
+   * @example
+   *
+   *   console.log(ok(1).expectErr('expected an error')) // throws 'expected an error'
+   *   console.log(err(NaN).expectErr('expected an error')) // logs `NaN`
+   */
+  public expectErr(throwable: unknown): E {
+    if (this.isOk()) {
+      throw throwable
+    }
+    return this._error as E
   }
 }
 
-export function err<T, E>(error: E): Result<T, E> {
-  return {
-    isOk: () => false,
-    isErr: () => true,
-    ok: () => undefined,
-    err: () => error,
-    map: () => err(error),
-    mapErr: (fn) => err(fn(error)),
-    mapOr: (defaultValue) => defaultValue,
-    mapOrElse: (defaultFn) => defaultFn(error),
-    andThen: () => err(error),
-    unwrap: () => {
-      throw error
-    },
-    unwrapErr: () => error,
-    expect: (throwable) => {
-      throw throwable
-    },
-    expectErr: () => error,
+/**
+ * Wraps a `Result` and provides an async-aware API for working with it.
+ */
+class AsyncResultImpl<T, E> implements AsyncResult<T, E> {
+  private readonly _result: Promise<Result<T, E>>
+
+  public constructor(result: Promise<Result<T, E>>) {
+    this._result = result
   }
+
+  /**
+   * Resolves to the wrapped `Result`.
+   */
+  public toResult(): Promise<Result<T, E>> {
+    return this._result
+  }
+
+  /**
+   * Returns `this`.
+   */
+  public async(): this {
+    return this
+  }
+
+  /**
+   * Resolves to `true` if the wrapped `Result` is `Ok`.
+   */
+  public async isOk(): Promise<boolean> {
+    return (await this._result).isOk()
+  }
+
+  /**
+   * Resolves to `true` if the wrapped `Result` is `Err`.
+   */
+  public async isErr(): Promise<boolean> {
+    return (await this._result).isErr()
+  }
+
+  /**
+   * Resolves to the wrapped value if result is `Ok`, otherwise undefined.
+   */
+  public async ok(): Promise<Optional<T>> {
+    return (await this._result).ok()
+  }
+
+  /**
+   * Resolves to the wrapped error if result is `Err`, otherwise undefined.
+   */
+  public async err(): Promise<Optional<E>> {
+    return (await this._result).err()
+  }
+
+  /**
+   * Maps the wrapped result by applying `fn` to an `Ok` value, leaving an `Err`
+   * value untouched.
+   *
+   * @example
+   *
+   *   const maybeUserInfo = await getUserInput('Enter an ID:')
+   *     .map(fetchUserById)
+   *     .ok()
+   */
+  public map<U>(fn: (value: T) => U | Promise<U>): AsyncResult<U, E> {
+    return asyncResult(
+      this._result.then(async (result) =>
+        result.isOk() ? ok(await fn(result.unwrap())) : err(result.unwrapErr())
+      )
+    )
+  }
+
+  /**
+   * Maps the wrapped error by applying `fn` to an `Err` value, leaving an `Ok`
+   * value untouched.
+   *
+   * @example
+   *
+   *   await readFile('file.txt')
+   *     .mapErr(describeError)
+   *     .mapOrElse(
+   *       (error) => console.error('reading file failed:', error),
+   *       (contents) => console.log('file contents:', contents)
+   *     )
+   */
+  public mapErr<F>(fn: (error: E) => F | Promise<F>): AsyncResult<T, F> {
+    return asyncResult(
+      this._result.then(async (result) =>
+        result.isOk() ? ok(result.unwrap()) : err(await fn(result.unwrapErr()))
+      )
+    )
+  }
+
+  /**
+   * Maps the wrapped value if result is `Ok`, or resolves to `defaultValue`.
+   *
+   * @example
+   *
+   *   const size = await stat('file.txt').mapOr(
+   *     -1,
+   *     (stat) => stat.size
+   *   )
+   */
+  public async mapOr<U>(
+    defaultValue: U | Promise<U>,
+    fn: (value: T) => U | Promise<U>
+  ): Promise<U> {
+    return (await this.isOk()) ? fn(await this.unwrap()) : defaultValue
+  }
+
+  /**
+   * Maps both the wrapped value and error as appropriate:
+   *
+   * @example
+   *
+   *   await open('file.txt').mapOrElse(
+   *     (error) => makePlaceholderFile('file.txt'),
+   *     (file) => wrapFile(file)
+   *   )
+   */
+  public async mapOrElse<U>(
+    defaultFn: (error: E) => U | Promise<U>,
+    fn: (value: T) => U | Promise<U>
+  ): Promise<U> {
+    return (await this.isOk())
+      ? fn(await this.unwrap())
+      : defaultFn(await this.unwrapErr())
+  }
+
+  /**
+   * Applies `fn` to a contained `Ok` value. Useful for setting up a chain of
+   * actions to be completed.
+   *
+   * @example
+   *
+   *   const maybeAnalysis = await open('file.txt')
+   *     .andThen((file) => file.read(1024))
+   *     .andThen((head) => analyze(head))
+   *     .ok()
+   */
+  public andThen<U, F>(
+    fn: (
+      value: T
+    ) =>
+      | Result<U, E | F>
+      | AsyncResult<U, E | F>
+      | Promise<Result<U, E | F> | AsyncResult<U, E | F>>
+  ): AsyncResult<U, E | F> {
+    return asyncResult(
+      this._result
+        .then(
+          async (result): Promise<Result<U, E | F> | AsyncResult<U, E | F>> =>
+            result.isOk() ? fn(result.unwrap()) : err<U, E>(result.unwrapErr())
+        )
+        .then((result) => result.toResult())
+    )
+  }
+
+  /**
+   * Applies `fn` to the result, returning whatever `fn` returns.
+   */
+  public mapResult<U>(fn: (result: this) => U): U {
+    return fn(this)
+  }
+
+  /**
+   * Applies `fn` to the result, returning the same result. Useful for logging
+   * or debugging.
+   */
+  public tap(fn: (result: this) => void): this {
+    fn(this)
+    return this
+  }
+
+  /**
+   * Resolves to the contained value or rejects with the error.
+   */
+  public async unwrap(): Promise<T> {
+    return (await this._result).unwrap()
+  }
+
+  /**
+   * Resolves to the contained error or rejects with the value.
+   */
+  public async unwrapErr(): Promise<E> {
+    return (await this._result).unwrapErr()
+  }
+
+  /**
+   * Resolves to the contained value or rejects with `throwable`.
+   */
+  public async expect(throwable: unknown): Promise<T> {
+    return (await this._result).expect(throwable)
+  }
+
+  /**
+   * Resolves to the contained error or rejects with `throwable`.
+   */
+  public async expectErr(throwable: unknown): Promise<E> {
+    return (await this._result).expectErr(throwable)
+  }
+}
+
+/**
+ * Returns an empty `Result`.
+ */
+export function ok<E>(): Result<void, E>
+
+/**
+ * Returns a `Result` containing `value`.
+ */
+export function ok<T, E>(value: T): Result<T, E>
+export function ok<T, E>(value: T = (undefined as unknown) as T): Result<T, E> {
+  return new ResultImpl(true, value)
+}
+
+/**
+ * Returns a `Result` containing `error`.
+ */
+export function err<T, E>(error: E): Result<T, E> {
+  return new ResultImpl(false, error)
+}
+
+/**
+ * Returns an `AsyncResult` with wrapping the resolved `result`.
+ */
+export function asyncResult<T, E = Error>(
+  result: Result<T, E> | Promise<Result<T, E>>
+): AsyncResult<T, E> {
+  return new AsyncResultImpl(Promise.resolve(result))
 }


### PR DESCRIPTION
## Description

The `Result` type was built to represent an operation that could succeed or fail, providing methods for working with that result and chaining it etc. This is good, except that many of the operations we may want to do are asynchronous. This meant we could not use the chaining methods such as `andThen` or `map` very effectively.

This commit adds `AsyncResult`, which has the same methods as `Result` except that they are promise-aware. This allows chaining operations that are asynchronous, with the terminating methods of `.ok` and `.err` etc. return promises instead of bare values.

As a reminder, `Result` is cargo-culted from [Rust's `std::result::Result`](https://doc.rust-lang.org/std/result/enum.Result.html). As far as I'm aware, `AsyncResult` doesn't really have an equivalent but that's probably just my ignorance.

## Notes

@beausmith, this kind of goes back on some of the changes I pushed for when I first started at VotingWorks. Specifically, using explicit `async`/`await` and normal JavaScript constructs like `if`/`for`/`while`/etc. The `AsyncResult` type ends up being kind of a _super_-`Promise` that also has a sync variant in `Result`. This PR includes some refactoring that illustrates what I mean.

For example, instead of this:

```ts
const scanSheet = async (): Promise<SheetOf<string> | undefined> => {
  debug('PlustekScanner#scanSheet BEGIN')
  const clientResult = await this.clientProvider.get()

  if (clientResult.isErr()) {
    return undefined
  }

  const client = clientResult.unwrap()
  const scanResult = await client.scan()

  if (scanResult.isErr()) {
    return undefined
  }

  const { files } = scanResult.unwrap()
  return [files[0], files[1]]
}
```

We have this:

```ts
const scanSheet = async (): Promise<SheetOf<string> | undefined> => {
  debug('PlustekScanner#scanSheet BEGIN')
  return asyncResult(this.clientProvider.get())
    .andThen((client) => client.scan())
    .mapOr(undefined, ({ files }) => [files[0], files[1]])
}
```

Note that it's less explicit checking of the result, instead letting the chaining of `.andThen` and `.mapOr` handle passing the "error" along and replacing it with `undefined` at the `.mapOr` call.