### PR TITLE
refactor(types): shrink `Result`

### DIFF
--- a/apps/bmd/src/AppRoot.tsx
+++ b/apps/bmd/src/AppRoot.tsx
@@ -658,7 +658,7 @@ const AppRoot: React.FC<Props> = ({
       const electionDefinitionResult = safeParseElectionDefinition(electionData)
       dispatchAppState({
         type: 'updateElectionDefinition',
-        electionDefinition: electionDefinitionResult.unwrap(),
+        electionDefinition: electionDefinitionResult.unsafeUnwrap(),
       })
     }
   }, [card, adminCardElectionHash])

--- a/apps/bmd/src/data/index.ts
+++ b/apps/bmd/src/data/index.ts
@@ -8,7 +8,7 @@ import { join } from 'path'
 function electionDefinitionFromFile(path: string): ElectionDefinition {
   const electionData = readFileSync(path, 'utf-8')
   return {
-    ...safeParseElectionDefinition(electionData).unwrap(),
+    ...safeParseElectionDefinition(electionData).unsafeUnwrap(),
     electionData,
   }
 }

--- a/apps/bsd/src/AppRoot.tsx
+++ b/apps/bsd/src/AppRoot.tsx
@@ -139,7 +139,7 @@ const App: React.FC = () => {
       const newStatus = safeParseJSON(
         body,
         GetScanStatusResponseSchema
-      ).unwrap()
+      ).unsafeUnwrap()
       setStatus((prevStatus) => {
         if (JSON.stringify(prevStatus) === JSON.stringify(newStatus)) {
           return prevStatus
@@ -176,7 +176,7 @@ const App: React.FC = () => {
           })
         ).text(),
         ScanBatchResponseSchema
-      ).unwrap()
+      ).unsafeUnwrap()
       if (result.status !== 'ok') {
         // eslint-disable-next-line no-alert
         window.alert(`could not scan: ${JSON.stringify(result.errors)}`)
@@ -202,7 +202,7 @@ const App: React.FC = () => {
           })
         ).text(),
         ScanContinueResponseSchema
-      ).unwrap()
+      ).unsafeUnwrap()
     } catch (error) {
       console.log('failed handleFileInput()', error) // eslint-disable-line no-console
     }
@@ -217,7 +217,7 @@ const App: React.FC = () => {
           })
         ).text(),
         ZeroResponseSchema
-      ).unwrap()
+      ).unsafeUnwrap()
       await refreshConfig()
       history.replace('/')
     } catch (error) {

--- a/apps/bsd/src/api/config.ts
+++ b/apps/bsd/src/api/config.ts
@@ -95,7 +95,7 @@ export async function getElectionDefinition(): Promise<
         })
       ).text(),
       GetElectionConfigResponseSchema
-    ).unwrap() as Exclude<GetElectionConfigResponse, string>) ?? undefined
+    ).unsafeUnwrap() as Exclude<GetElectionConfigResponse, string>) ?? undefined
   )
 }
 
@@ -114,7 +114,7 @@ export async function getTestMode(): Promise<boolean> {
   return safeParseJSON(
     await (await fetch('/config/testMode')).text(),
     GetTestModeConfigResponseSchema
-  ).unwrap().testMode
+  ).unsafeUnwrap().testMode
 }
 
 export async function setTestMode(testMode: boolean): Promise<void> {
@@ -153,7 +153,7 @@ export async function getCurrentPrecinctId(): Promise<
       })
     ).text(),
     GetCurrentPrecinctResponseSchema
-  ).unwrap().precinctId
+  ).unsafeUnwrap().precinctId
 }
 
 export async function setCurrentPrecinctId(

--- a/apps/bsd/src/screens/LoadElectionScreen.tsx
+++ b/apps/bsd/src/screens/LoadElectionScreen.tsx
@@ -75,16 +75,17 @@ const LoadElectionScreen: React.FC<Props> = ({
 
     if (isElectionJSON) {
       await new Promise<void>((resolve, reject) => {
-        reader.onload = () => {
+        reader.onload = async () => {
           const electionData = reader.result as string
-          safeParseElectionDefinition(electionData).mapOrElse(
-            reject,
-            async (electionDefinition) => {
-              await config.setElection(electionData)
-              setElectionDefinition(electionDefinition)
-              resolve()
-            }
-          )
+          const result = safeParseElectionDefinition(electionData)
+
+          if (result.isErr()) {
+            reject(result.err())
+          } else {
+            await config.setElection(electionData)
+            setElectionDefinition(result.ok())
+            resolve()
+          }
         }
 
         reader.readAsText(file)

--- a/apps/bsd/src/util/ballot-package.ts
+++ b/apps/bsd/src/util/ballot-package.ts
@@ -177,7 +177,9 @@ async function readBallotPackageFromZip(
   }
 
   return {
-    electionDefinition: safeParseElectionDefinition(electionData).unwrap(),
+    electionDefinition: safeParseElectionDefinition(
+      electionData
+    ).unsafeUnwrap(),
     ballots,
   }
 }

--- a/apps/module-scan/src/interpreter.test.ts
+++ b/apps/module-scan/src/interpreter.test.ts
@@ -42,7 +42,7 @@ test('does not find QR codes when there are none to find', async () => {
         filepath,
         await detectQrcodeInFilePath(filepath)
       )
-    ).unwrapErr()
+    ).unsafeUnwrapErr()
   ).toEqual({ type: 'UnreadablePage', reason: 'No QR code found' })
 })
 
@@ -123,7 +123,7 @@ test('can read metadata encoded in a QR code with base64', async () => {
       fixtures.blankPage1,
       await detectQrcodeInFilePath(fixtures.blankPage1)
     )
-  ).unwrap()
+  ).unsafeUnwrap()
 
   expect(metadataFromBytes(election, Buffer.from(qrcode.data)))
     .toMatchInlineSnapshot(`
@@ -151,7 +151,7 @@ test('can read metadata in QR code with skewed / dirty ballot', async () => {
       fixtures.skewedQRCodeBallotPage,
       await detectQrcodeInFilePath(fixtures.skewedQRCodeBallotPage)
     )
-  ).unwrap()
+  ).unsafeUnwrap()
 
   expect(qrcode.data).toMatchInlineSnapshot(`
     Object {

--- a/apps/module-scan/src/interpreter.ts
+++ b/apps/module-scan/src/interpreter.ts
@@ -299,8 +299,7 @@ export default class Interpreter {
       return { interpretation: result.err() }
     }
 
-    const ballotImageData = result.unwrap()
-
+    const ballotImageData = result.ok()
     if (typeof this.electionHash === 'string') {
       const actualElectionHash =
         decodeElectionHash(ballotImageData.qrcode.data) ?? 'not found'

--- a/apps/module-scan/src/scanners/plustek.test.ts
+++ b/apps/module-scan/src/scanners/plustek.test.ts
@@ -69,7 +69,9 @@ test('plustek scanner accept sheet', async () => {
 
   // successful accept
   plustekClient.accept.mockResolvedValueOnce(ok())
-  plustekClient.waitForStatus.mockResolvedValue(ok(PaperStatus.NoPaper))
+  plustekClient.waitForStatus.mockResolvedValue(
+    ok(PaperStatus.VtmDevReadyNoPaper)
+  )
   expect(await scanner.scanSheets().acceptSheet()).toEqual(true)
 
   // failed accept
@@ -221,26 +223,26 @@ test('withReconnect', async () => {
   const provider = withReconnect({ get: getClient })
 
   // ensure we tried until we got to the good client
-  const wrappedClient = (await provider.get()).unwrap()
+  const wrappedClient = (await provider.get()).unsafeUnwrap()
   expect(wrappedClient).toBeDefined()
-  expect((await wrappedClient.getPaperStatus()).unwrap()).toEqual(
+  expect((await wrappedClient.getPaperStatus()).unsafeUnwrap()).toEqual(
     PaperStatus.VtmDevReadyNoPaper
   )
   expect(getClient).toHaveBeenCalledTimes(4)
 
   // getting the client again should return the same one
-  const wrappedClientAgain = (await provider.get()).unwrap()
+  const wrappedClientAgain = (await provider.get()).unsafeUnwrap()
   expect(wrappedClientAgain).toBe(wrappedClient)
   expect(getClient).toHaveBeenCalledTimes(4)
 
   // interacting with the good client works
   await client.simulateLoadSheet(['/tmp/a.jpg', '/tmp/b.jpg'])
-  ;(await wrappedClient.scan()).unwrap()
-  ;(await wrappedClient.reject({ hold: true })).unwrap()
-  ;(await wrappedClient.accept()).unwrap()
+  ;(await wrappedClient.scan()).unsafeUnwrap()
+  ;(await wrappedClient.reject({ hold: true })).unsafeUnwrap()
+  ;(await wrappedClient.accept()).unsafeUnwrap()
 
   await client.simulateLoadSheet(['/tmp/blank.jpg', '/tmp/blank.jpg'])
-  ;(await wrappedClient.calibrate()).unwrap()
+  ;(await wrappedClient.calibrate()).unsafeUnwrap()
 })
 
 test('withReconnect only re-creates the client once per failure', async () => {
@@ -263,7 +265,7 @@ test('withReconnect only re-creates the client once per failure', async () => {
     .mockResolvedValueOnce(ok(client))
   const provider = withReconnect({ get: getClient })
 
-  const wrappedClient = (await provider.get()).unwrap()
+  const wrappedClient = (await provider.get()).unsafeUnwrap()
 
   await Promise.all([
     wrappedClient.getPaperStatus(),

--- a/apps/module-scan/src/scanners/plustek.ts
+++ b/apps/module-scan/src/scanners/plustek.ts
@@ -34,40 +34,64 @@ export class PlustekScanner implements Scanner {
       return ScannerStatus.Error
     }
 
-    const client = clientResult.unwrap()
-    return (await client.getPaperStatus()).mapOrElse(
-      () => ScannerStatus.Error,
-      (paperStatus) => {
-        debug('PlustekScanner#getStatus: got paper status: %s', paperStatus)
-        return paperStatus === PaperStatus.VtmDevReadyNoPaper
-          ? ScannerStatus.WaitingForPaper
-          : paperStatus === PaperStatus.VtmReadyToScan
-          ? ScannerStatus.ReadyToScan
-          : ScannerStatus.Error
-      }
-    )
+    const client = clientResult.ok()
+    const getPaperStatusResult = await client.getPaperStatus()
+
+    if (getPaperStatusResult.isErr()) {
+      debug(
+        'PlustekScanner#getStatus: failed to get status: %s',
+        getPaperStatusResult.err()
+      )
+      return ScannerStatus.Error
+    }
+
+    const paperStatus = getPaperStatusResult.ok()
+    debug('PlustekScanner#getStatus: got paper status: %s', paperStatus)
+    return paperStatus === PaperStatus.VtmDevReadyNoPaper
+      ? ScannerStatus.WaitingForPaper
+      : paperStatus === PaperStatus.VtmReadyToScan
+      ? ScannerStatus.ReadyToScan
+      : ScannerStatus.Error
   }
 
   public scanSheets(directory?: string): BatchControl {
     debug('scanSheets: ignoring directory: %s', directory)
+
+    const waitForStatus = async (
+      client: ScannerClient,
+      status: PaperStatus
+    ): Promise<boolean> =>
+      (
+        await client.waitForStatus({
+          status,
+          timeout: 1000,
+        })
+      )?.ok() === status
 
     const scanSheet = async (): Promise<SheetOf<string> | undefined> => {
       debug('PlustekScanner#scanSheet BEGIN')
       const clientResult = await this.clientProvider.get()
 
       if (clientResult.isErr()) {
+        debug(
+          'PlustekScanner#scanSheet: failed to get client: %s',
+          clientResult.err()
+        )
         return undefined
       }
 
-      const client = clientResult.unwrap()
+      const client = clientResult.ok()
       const scanResult = await client.scan()
 
       if (scanResult.isErr()) {
+        debug('PlustekScanner#scanSheet: failed to scan: %s', scanResult.err())
         return undefined
       }
 
-      const { files } = scanResult.unwrap()
-      return [files[0], files[1]]
+      const {
+        files: [front, back],
+      } = scanResult.ok()
+      return [front, back]
     }
 
     const acceptSheet = async (): Promise<boolean> => {
@@ -76,113 +100,108 @@ export class PlustekScanner implements Scanner {
 
       if (clientResult.isErr()) {
         debug(
-          'PlustekScanner#acceptSheet failed to get client: %s',
+          'PlustekScanner#acceptSheet: failed to get client: %s',
           clientResult.err()
         )
         return false
       }
 
-      const client = clientResult.unwrap()
+      const client = clientResult.ok()
       const acceptResult = await client.accept()
 
       if (acceptResult.isErr()) {
-        debug('PlustekScanner#acceptSheet failed: %s', acceptResult.err())
+        debug(
+          'PlustekScanner#acceptSheet failed to accept: %s',
+          acceptResult.err()
+        )
         return false
       }
 
-      return (
-        (
-          await client.waitForStatus({
-            status: PaperStatus.NoPaper,
-            timeout: 1000,
-          })
-        )?.ok() === PaperStatus.NoPaper
-      )
+      return await waitForStatus(client, PaperStatus.VtmDevReadyNoPaper)
     }
 
     const reviewSheet = async (): Promise<boolean> => {
-      try {
-        debug('PlustekScanner#reviewSheet BEGIN')
-        const clientResult = await this.clientProvider.get()
+      debug('PlustekScanner#reviewSheet BEGIN')
+      const clientResult = await this.clientProvider.get()
 
-        if (clientResult.isErr()) {
-          debug(
-            'PlustekScanner#reviewSheet failed to get client: %s',
-            clientResult.err()
-          )
-          return false
-        }
-
-        const client = clientResult.unwrap()
-        const rejectResult = await client.reject({ hold: true })
-
-        if (rejectResult.isErr()) {
-          debug('PlustekScanner#reviewSheet failed: %s', rejectResult.err())
-          return false
-        }
-
-        return (
-          (
-            await client.waitForStatus({
-              status: PaperStatus.VtmReadyToScan,
-              timeout: 1000,
-            })
-          )?.ok() === PaperStatus.VtmReadyToScan
+      if (clientResult.isErr()) {
+        debug(
+          'PlustekScanner#reviewSheet: failed to get client: %s',
+          clientResult.err()
         )
-      } finally {
-        debug('PlustekScanner#reviewSheet END')
+        return false
       }
+
+      const client = clientResult.ok()
+      const rejectResult = await client.reject({ hold: true })
+
+      if (rejectResult.isErr()) {
+        debug(
+          'PlustekScanner#reviewSheet failed to reject: %s',
+          rejectResult.err()
+        )
+        return false
+      }
+
+      return await waitForStatus(client, PaperStatus.VtmReadyToScan)
     }
 
     const rejectSheet = async (): Promise<boolean> => {
       debug('PlustekScanner#rejectSheet BEGIN')
-
-      if (this.alwaysHoldOnReject) {
-        debug('alwaysHoldOnReject is true, forwarding to reviewSheet')
-        return await reviewSheet()
-      }
-
       const clientResult = await this.clientProvider.get()
 
       if (clientResult.isErr()) {
         debug(
-          'PlustekScanner#reviewSheet failed to get client: %s',
+          'PlustekScanner#rejectSheet: failed to get client: %s',
           clientResult.err()
         )
         return false
       }
 
-      const client = clientResult.unwrap()
-      const rejectResult = await client.reject({ hold: false })
+      const client = clientResult.ok()
+      const rejectResult = await client.reject({
+        hold: this.alwaysHoldOnReject,
+      })
 
       if (rejectResult.isErr()) {
-        debug('PlustekScanner#rejectSheet failed: %s', rejectResult.err())
+        debug(
+          'PlustekScanner#rejectSheet failed to reject: %s',
+          rejectResult.err()
+        )
         return false
       }
 
-      return (
-        (
-          await client.waitForStatus({
-            status: PaperStatus.VtmDevReadyNoPaper,
-            timeout: 1000,
-          })
-        )?.ok() === PaperStatus.VtmDevReadyNoPaper
+      return await waitForStatus(
+        client,
+        this.alwaysHoldOnReject
+          ? PaperStatus.VtmReadyToScan
+          : PaperStatus.VtmDevReadyNoPaper
       )
     }
 
     const endBatch = async (): Promise<void> => {
+      debug('PlustekScanner#endBatch BEGIN')
       const clientResult = await this.clientProvider.get()
 
       if (clientResult.isErr()) {
         debug(
-          'PlustekScanner#endBatch failed to get client: %s',
+          'PlustekScanner#endBatch: failed to get client: %s',
           clientResult.err()
         )
         return
       }
 
-      const client = clientResult.unwrap()
-      await client.reject({ hold: false })
+      const client = clientResult.ok()
+      const rejectResult = await client.reject({
+        hold: this.alwaysHoldOnReject,
+      })
+
+      if (rejectResult.isErr()) {
+        debug(
+          'PlustekScanner#endBatch failed to end batch: %s',
+          rejectResult.err()
+        )
+      }
     }
 
     return {
@@ -195,6 +214,7 @@ export class PlustekScanner implements Scanner {
   }
 
   public async calibrate(): Promise<boolean> {
+    debug('PlustekScanner#calibrate BEGIN')
     const clientResult = await this.clientProvider.get()
 
     if (clientResult.isErr()) {
@@ -205,11 +225,18 @@ export class PlustekScanner implements Scanner {
       return false
     }
 
-    const client = clientResult.unwrap()
-    const result = await client.calibrate()
+    const client = clientResult.ok()
+    const calibrateResult = await client.calibrate()
 
-    debug('PlustekScanner#calibrate: success=%s', result.isOk())
-    return result.isOk()
+    if (calibrateResult.isErr()) {
+      debug(
+        'PlustekScanner#calibrate: failed to calibrate: %s',
+        calibrateResult.err()
+      )
+      return false
+    }
+
+    return true
   }
 }
 
@@ -223,23 +250,39 @@ export function plustekMockServer(client: MockScannerClient): Application {
     .use(express.json({ limit: '5mb', type: 'application/json' }))
     .use(bodyParser.urlencoded({ extended: false }))
     .put('/mock', async (request, response) => {
-      safeParse(PutMockRequestSchema, request.body).mapOrElse(
-        async (error) =>
-          response.status(400).json({ status: 'error', error: `${error}` }),
-        async ({ files }) =>
-          (await client.simulateLoadSheet(files)).mapOrElse(
-            (error) =>
-              response.status(400).json({ status: 'error', error: `${error}` }),
-            () => response.json({ status: 'ok' })
-          )
+      const bodyParseResult = safeParse(PutMockRequestSchema, request.body)
+
+      if (bodyParseResult.isErr()) {
+        response
+          .status(400)
+          .json({ status: 'error', error: `${bodyParseResult.err()}` })
+        return
+      }
+
+      const simulateResult = await client.simulateLoadSheet(
+        bodyParseResult.ok().files
       )
+
+      if (simulateResult.isErr()) {
+        response
+          .status(400)
+          .json({ status: 'error', error: `${simulateResult.err()}` })
+        return
+      }
+
+      response.json({ status: 'ok' })
     })
     .delete('/mock', async (_request, response) => {
-      ;(await client.simulateRemoveSheet()).mapOrElse(
-        (error) =>
-          response.status(400).json({ status: 'error', error: `${error}` }),
-        () => response.json({ status: 'ok' })
-      )
+      const simulateResult = await client.simulateRemoveSheet()
+
+      if (simulateResult.isErr()) {
+        response
+          .status(400)
+          .json({ status: 'error', error: `${simulateResult.err()}` })
+        return
+      }
+
+      response.json({ status: 'ok' })
     })
 }
 

--- a/apps/module-scan/src/server.test.ts
+++ b/apps/module-scan/src/server.test.ts
@@ -811,8 +811,8 @@ test('start as precinct-scanner rejects a held sheet at startup', async () => {
     passthroughDuration: 0,
   })
   await mockClient.connect()
-  ;(await mockClient.simulateLoadSheet(['a.jpg', 'b.jpg'])).unwrap()
-  ;(await mockClient.scan()).unwrap()
+  ;(await mockClient.simulateLoadSheet(['a.jpg', 'b.jpg'])).unsafeUnwrap()
+  ;(await mockClient.scan()).unsafeUnwrap()
   mocked(plusteksdk.createClient).mockResolvedValueOnce(ok(mockClient))
 
   // start up the server
@@ -824,7 +824,7 @@ test('start as precinct-scanner rejects a held sheet at startup', async () => {
     machineType: 'precinct-scanner',
   })
 
-  expect((await mockClient.getPaperStatus()).unwrap()).toEqual(
+  expect((await mockClient.getPaperStatus()).unsafeUnwrap()).toEqual(
     PaperStatus.VtmReadyToScan
   )
 })

--- a/apps/module-scan/src/store.ts
+++ b/apps/module-scan/src/store.ts
@@ -492,20 +492,19 @@ export default class Store {
     }
 
     const result = safeParseJSON(row.value, schema)
-    return result.mapOrElse(
-      (error) => {
-        debug('failed to validate stored config %s: %s', key, error)
-        return undefined
-      },
-      (value) => {
-        let inspectedResult = inspect(value, false, 2, true)
-        if (inspectedResult.length > 200) {
-          inspectedResult = inspectedResult.slice(0, 199) + '…'
-        }
-        debug('returning stored value for config %s: %s', key, inspectedResult)
-        return value
-      }
-    )
+
+    if (result.isErr()) {
+      debug('failed to validate stored config %s: %s', key, result.err())
+      return undefined
+    }
+
+    const value = result.ok()
+    let inspectedResult = inspect(value, false, 2, true)
+    if (inspectedResult.length > 200) {
+      inspectedResult = inspectedResult.slice(0, 199) + '…'
+    }
+    debug('returning stored value for config %s: %s', key, inspectedResult)
+    return value
   }
 
   /**

--- a/apps/precinct-scanner/src/api/config.ts
+++ b/apps/precinct-scanner/src/api/config.ts
@@ -85,7 +85,7 @@ export async function getElectionDefinition(): Promise<
         })
       ).text(),
       GetElectionConfigResponseSchema
-    ).unwrap() as Exclude<GetElectionConfigResponse, string>) ?? undefined
+    ).unsafeUnwrap() as Exclude<GetElectionConfigResponse, string>) ?? undefined
   )
 }
 
@@ -102,7 +102,7 @@ export async function getTestMode(): Promise<boolean> {
   return safeParseJSON(
     await (await fetch('/config/testMode')).text(),
     GetTestModeConfigResponseSchema
-  ).unwrap().testMode
+  ).unsafeUnwrap().testMode
 }
 
 export async function setTestMode(testMode: boolean): Promise<void> {
@@ -121,7 +121,7 @@ export async function getCurrentPrecinctId(): Promise<
       })
     ).text(),
     GetCurrentPrecinctResponseSchema
-  ).unwrap().precinctId
+  ).unsafeUnwrap().precinctId
 }
 
 export async function setCurrentPrecinctId(

--- a/apps/precinct-scanner/src/api/scan.ts
+++ b/apps/precinct-scanner/src/api/scan.ts
@@ -161,12 +161,9 @@ export async function calibrate(): Promise<boolean> {
     headers: { Accept: 'application/json' },
   })
 
-  return safeParseJSON(
-    await response.text(),
-    CalibrateResponseSchema
-  ).mapOrElse(
-    () => false,
-    ({ status }) => status === 'ok'
+  return (
+    safeParseJSON(await response.text(), CalibrateResponseSchema).ok()
+      ?.status === 'ok'
   )
 }
 

--- a/apps/precinct-scanner/src/hooks/usePrecinctScannerStatus.ts
+++ b/apps/precinct-scanner/src/hooks/usePrecinctScannerStatus.ts
@@ -24,13 +24,9 @@ export default function usePrecinctScannerStatus(
       fetch('/scan/status', { headers: { Accept: 'application/json' } })
     )
 
-    safeParseJSON(await response.text(), GetScanStatusResponseSchema).mapOrElse(
-      () => {
-        setScannerStatus(ScannerStatus.Error)
-      },
-      ({ scanner }) => {
-        setScannerStatus(scanner)
-      }
+    setScannerStatus(
+      safeParseJSON(await response.text(), GetScanStatusResponseSchema).ok()
+        ?.scanner ?? ScannerStatus.Error
     )
     setIsFetchingStatus(false)
   }, interval)

--- a/apps/precinct-scanner/src/utils/ballot-package.ts
+++ b/apps/precinct-scanner/src/utils/ballot-package.ts
@@ -183,7 +183,9 @@ export async function readBallotPackageFromZip(
   }
 
   return {
-    electionDefinition: safeParseElectionDefinition(electionData).unwrap(),
+    electionDefinition: safeParseElectionDefinition(
+      electionData
+    ).unsafeUnwrap(),
     ballots,
   }
 }

--- a/libs/plustek-sdk/examples/scan-simple.ts
+++ b/libs/plustek-sdk/examples/scan-simple.ts
@@ -28,11 +28,11 @@ async function main(): Promise<number> {
 
   debug('open result: %s', openResult.isOk() ? 'ok' : 'not ok')
   if (openResult.isErr()) {
-    console.error('failed to open scanner:', openResult.unwrapErr())
+    console.error('failed to open scanner:', openResult.unsafeUnwrapErr())
     return
   }
 
-  const scanner = openResult.unwrap()
+  const scanner = openResult.unsafeUnwrap()
   await waitUntilReadyToScan(scanner)
   const scanResult = await scanner.scan()
 
@@ -41,7 +41,7 @@ async function main(): Promise<number> {
       process.stdout.write(`${file}\n`)
     }
   } else {
-    process.stderr.write(`failed to scan: ${scanResult.unwrapErr()}\n`)
+    process.stderr.write(`failed to scan: ${scanResult.unsafeUnwrapErr()}\n`)
   }
 
   await scanner.close()
@@ -62,7 +62,7 @@ async function waitUntilReadyToScan(scanner: ScannerClient): Promise<void> {
 
 async function isReadyToScan(scanner: ScannerClient): Promise<boolean> {
   debug('getting paper status')
-  return (await scanner.getPaperStatus()).unwrap() === PaperStatus.VtmReadyToScan
+  return (await scanner.getPaperStatus()).unsafeUnwrap() === PaperStatus.VtmReadyToScan
 }
 
 async function sleep(duration: number): Promise<void> {

--- a/libs/plustek-sdk/examples/web/index.ts
+++ b/libs/plustek-sdk/examples/web/index.ts
@@ -60,7 +60,7 @@ async function main(args: readonly string[]): Promise<number> {
         await mock.connect()
         return mock
       })()
-    : (await createClient()).unwrap()
+    : (await createClient()).unsafeUnwrap()
   const scannedImages = new Map<string, string>()
 
   createServer(async (req, res) => {
@@ -149,7 +149,7 @@ async function main(args: readonly string[]): Promise<number> {
                 (error) => res.writeHead(400).end(`${error}`),
                 async ({ files }) => {
                   debug('loading a mock sheet: %o', files)
-                  ;(await scanner.manualLoad(files)).mapOrElse(
+                  ;(await scanner.simulateLoadSheet(files)).mapOrElse(
                     (error) => res.writeHead(500).end(`${error}`),
                     () => res.writeHead(200).end()
                   )
@@ -157,7 +157,7 @@ async function main(args: readonly string[]): Promise<number> {
               )
             }
           } else if (req.method === 'DELETE') {
-            (await scanner.manualRemove()).mapOrElse(
+            (await scanner.simulateRemoveSheet()).mapOrElse(
               (error) => res.writeHead(500).end(`${error}`),
               () => res.writeHead(200).end()
             )

--- a/libs/plustek-sdk/src/errors.ts
+++ b/libs/plustek-sdk/src/errors.ts
@@ -87,8 +87,6 @@ export enum ScannerError {
 export const ScannerErrorSchema = z.nativeEnum(ScannerError)
 
 export function parseScannerError(error: string): ScannerError | Error {
-  return safeParse(ScannerErrorSchema, error).mapOrElse<ScannerError | Error>(
-    () => new Error(error),
-    (scannerError) => scannerError
-  )
+  const result = safeParse(ScannerErrorSchema, error)
+  return result.isErr() ? new Error(error) : result.ok()
 }

--- a/libs/plustek-sdk/src/mocks.test.ts
+++ b/libs/plustek-sdk/src/mocks.test.ts
@@ -80,7 +80,7 @@ test('unresponsive', async () => {
   expect(
     (await mock.waitForStatus({ status: PaperStatus.VtmReadyToScan }))?.err()
   ).toEqual(ScannerError.SaneStatusIoError)
-  ;(await mock.close()).unwrap()
+  ;(await mock.close()).unsafeUnwrap()
 })
 
 test('scanning', async () => {
@@ -112,7 +112,7 @@ test('accept', async () => {
 
   // accept w/o scan
   await mock.simulateLoadSheet(files)
-  ;(await mock.accept()).unwrap()
+  ;(await mock.accept()).unsafeUnwrap()
   expect((await mock.getPaperStatus()).ok()).toEqual(
     PaperStatus.VtmDevReadyNoPaper
   )
@@ -120,7 +120,7 @@ test('accept', async () => {
   // accept w/scan
   await mock.simulateLoadSheet(files)
   await mock.scan()
-  ;(await mock.accept()).unwrap()
+  ;(await mock.accept()).unsafeUnwrap()
   expect((await mock.getPaperStatus()).ok()).toEqual(
     PaperStatus.VtmDevReadyNoPaper
   )
@@ -142,13 +142,13 @@ test('reject & hold', async () => {
 
   // reject w/o scan
   await mock.simulateLoadSheet(files)
-  ;(await mock.reject({ hold: true })).unwrap()
+  ;(await mock.reject({ hold: true })).unsafeUnwrap()
   expect((await mock.getPaperStatus()).ok()).toEqual(PaperStatus.VtmReadyToScan)
 
   // reject w/scan
   await mock.simulateLoadSheet(files)
   await mock.scan()
-  ;(await mock.reject({ hold: true })).unwrap()
+  ;(await mock.reject({ hold: true })).unsafeUnwrap()
   expect((await mock.getPaperStatus()).ok()).toEqual(PaperStatus.VtmReadyToScan)
 })
 
@@ -168,7 +168,7 @@ test('reject w/o hold', async () => {
 
   // reject w/o scan
   await mock.simulateLoadSheet(files)
-  ;(await mock.reject({ hold: false })).unwrap()
+  ;(await mock.reject({ hold: false })).unsafeUnwrap()
   expect((await mock.getPaperStatus()).ok()).toEqual(
     PaperStatus.VtmDevReadyNoPaper
   )
@@ -176,7 +176,7 @@ test('reject w/o hold', async () => {
   // reject w/scan
   await mock.simulateLoadSheet(files)
   await mock.scan()
-  ;(await mock.reject({ hold: false })).unwrap()
+  ;(await mock.reject({ hold: false })).unsafeUnwrap()
   expect((await mock.getPaperStatus()).ok()).toEqual(
     PaperStatus.VtmDevReadyNoPaper
   )
@@ -198,7 +198,7 @@ test('calibrate', async () => {
   await mock.scan()
   expect((await mock.calibrate()).err()).toEqual(ScannerError.SaneStatusNoDocs)
   await mock.reject({ hold: true })
-  ;(await mock.calibrate()).unwrap()
+  ;(await mock.calibrate()).unsafeUnwrap()
   expect((await mock.getPaperStatus()).ok()).toEqual(
     PaperStatus.VtmDevReadyNoPaper
   )

--- a/libs/plustek-sdk/src/plustekctl.test.ts
+++ b/libs/plustek-sdk/src/plustekctl.test.ts
@@ -1,5 +1,5 @@
 import { findBinaryPath } from './plustekctl'
 
 test('plustekctl', async () => {
-  expect((await findBinaryPath()).unwrap()).toEqual('plustekctl')
+  expect((await findBinaryPath()).unsafeUnwrap()).toEqual('plustekctl')
 })

--- a/libs/plustek-sdk/src/scanner.test.ts
+++ b/libs/plustek-sdk/src/scanner.test.ts
@@ -23,7 +23,7 @@ beforeEach(() => {
 test('cannot find plustekctl', async () => {
   findBinaryPath.mockResolvedValueOnce(err(new Error('ENOENT')))
   const result = await createClient()
-  expect(result.unwrapErr()).toEqual(new Error('unable to find plustekctl'))
+  expect(result.unsafeUnwrapErr()).toEqual(new Error('unable to find plustekctl'))
 })
 
 test('no savepath given', async () => {
@@ -75,7 +75,7 @@ test('cannot spawn plustekctl', async () => {
       throw new Error('onConnected unexpectedly called!')
     }),
   })
-  expect(result.unwrapErr()).toEqual(
+  expect(result.unsafeUnwrapErr()).toEqual(
     new Error('connection error: Error: spawn plustekctl ENOMEM')
   )
 })
@@ -93,7 +93,7 @@ test('plustekctl spawns but immediately exits', async () => {
       throw new Error('onConnected unexpectedly called!')
     }),
   })
-  expect(result.unwrapErr()).toEqual(
+  expect(result.unsafeUnwrapErr()).toEqual(
     new Error(
       'connection error: plustekctl exited unexpectedly (code=0, signal=undefined)'
     )
@@ -114,7 +114,7 @@ test('plustekctl spawns but fails the handshake', async () => {
       throw new Error('onConnected unexpectedly called!')
     }),
   })
-  expect(result.unwrapErr()).toEqual(
+  expect(result.unsafeUnwrapErr()).toEqual(
     new Error(
       'connection error: plustekctl exited unexpectedly (code=1, signal=undefined)'
     )
@@ -139,7 +139,7 @@ test('client connects and disconnects successfully', async () => {
       onConnected,
       onDisconnected,
     })
-  ).unwrap()
+  ).unsafeUnwrap()
 
   expect(client.isConnected()).toEqual(true)
   expect(onConnected).toHaveBeenCalledTimes(1)
@@ -149,7 +149,7 @@ test('client connects and disconnects successfully', async () => {
   await nextTick
   expect(plustekctl.stdin.toString()).toEqual('quit\n')
   plustekctl.stdout.append('<<<>>>\nquit: ok\n<<<>>>\n')
-  ;(await closeResultPromise).unwrap()
+  ;(await closeResultPromise).unsafeUnwrap()
 
   // simulate plustekctl exiting
   plustekctl.emit('exit', 0)
@@ -172,7 +172,7 @@ test('unsuccessful disconnect returns error', async () => {
       }),
       onDisconnected,
     })
-  ).unwrap()
+  ).unsafeUnwrap()
 
   // initiate quit
   const closeResultPromise = client.close()
@@ -183,7 +183,7 @@ test('unsuccessful disconnect returns error', async () => {
   )
   plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
 
-  expect((await closeResultPromise).unwrapErr()).toEqual(
+  expect((await closeResultPromise).unsafeUnwrapErr()).toEqual(
     new Error(`invalid response: uh uh uh! you didn't say the magic word!`)
   )
 })
@@ -200,25 +200,25 @@ test('client cannot send commands after disconnect', async () => {
         plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
       }),
     })
-  ).unwrap()
+  ).unsafeUnwrap()
 
   // simulate plustekctl exiting
   plustekctl.emit('exit', 0)
 
   expect(client.isConnected()).toEqual(false)
-  expect((await client.getPaperStatus()).unwrapErr()).toEqual(
+  expect((await client.getPaperStatus()).unsafeUnwrapErr()).toEqual(
     new Error('client is disconnected')
   )
-  expect((await client.scan()).unwrapErr()).toEqual(
+  expect((await client.scan()).unsafeUnwrapErr()).toEqual(
     new Error('client is disconnected')
   )
-  expect((await client.close()).unwrapErr()).toEqual(
+  expect((await client.close()).unsafeUnwrapErr()).toEqual(
     new Error('client is disconnected')
   )
-  expect((await client.accept()).unwrapErr()).toEqual(
+  expect((await client.accept()).unsafeUnwrapErr()).toEqual(
     new Error('client is disconnected')
   )
-  expect((await client.reject({ hold: true })).unwrapErr()).toEqual(
+  expect((await client.reject({ hold: true })).unsafeUnwrapErr()).toEqual(
     new Error('client is disconnected')
   )
 })
@@ -235,7 +235,7 @@ test('client responds with wrong IPC command', async () => {
         plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
       }),
     })
-  ).unwrap()
+  ).unsafeUnwrap()
 
   const resultPromise = client.getPaperStatus()
   await nextTick
@@ -245,7 +245,7 @@ test('client responds with wrong IPC command', async () => {
   )
   plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
 
-  expect((await resultPromise).unwrapErr()).toEqual(
+  expect((await resultPromise).unsafeUnwrapErr()).toEqual(
     new Error('invalid response: unknown-response-thing: hey there!')
   )
 })
@@ -262,7 +262,7 @@ test('getPaperStatus succeeds', async () => {
         plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
       }),
     })
-  ).unwrap()
+  ).unsafeUnwrap()
 
   const resultPromise = client.getPaperStatus()
   await nextTick
@@ -272,7 +272,7 @@ test('getPaperStatus succeeds', async () => {
   )
   plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
 
-  expect((await resultPromise).unwrap()).toEqual(PaperStatus.VtmReadyToScan)
+  expect((await resultPromise).unsafeUnwrap()).toEqual(PaperStatus.VtmReadyToScan)
 })
 
 test('getPaperStatus returns error for invalid response', async () => {
@@ -287,7 +287,7 @@ test('getPaperStatus returns error for invalid response', async () => {
         plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
       }),
     })
-  ).unwrap()
+  ).unsafeUnwrap()
 
   const resultPromise = client.getPaperStatus()
   await nextTick
@@ -297,7 +297,7 @@ test('getPaperStatus returns error for invalid response', async () => {
   )
   plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
 
-  expect(((await resultPromise).unwrapErr() as Error).message).toContain(
+  expect(((await resultPromise).unsafeUnwrapErr() as Error).message).toContain(
     'not a real status'
   )
 })
@@ -314,7 +314,7 @@ test('getPaperStatus returns known error', async () => {
         plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
       }),
     })
-  ).unwrap()
+  ).unsafeUnwrap()
 
   const resultPromise = client.getPaperStatus()
   await nextTick
@@ -324,7 +324,7 @@ test('getPaperStatus returns known error', async () => {
   )
   plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
 
-  expect((await resultPromise).unwrapErr()).toEqual(ScannerError.NoDevices)
+  expect((await resultPromise).unsafeUnwrapErr()).toEqual(ScannerError.NoDevices)
 })
 
 test('getPaperStatus returns unknown error', async () => {
@@ -339,7 +339,7 @@ test('getPaperStatus returns unknown error', async () => {
         plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
       }),
     })
-  ).unwrap()
+  ).unsafeUnwrap()
 
   const resultPromise = client.getPaperStatus()
   await nextTick
@@ -347,7 +347,7 @@ test('getPaperStatus returns unknown error', async () => {
   plustekctl.stdout.append(`<<<>>>\nget-paper-status: err=WHAT??\n<<<>>>\n`)
   plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
 
-  expect(((await resultPromise).unwrapErr() as Error).message).toEqual('WHAT??')
+  expect(((await resultPromise).unsafeUnwrapErr() as Error).message).toEqual('WHAT??')
 })
 
 test('scan succeeds', async () => {
@@ -362,7 +362,7 @@ test('scan succeeds', async () => {
         plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
       }),
     })
-  ).unwrap()
+  ).unsafeUnwrap()
 
   const resultPromise = client.scan()
   await nextTick
@@ -372,7 +372,7 @@ test('scan succeeds', async () => {
   plustekctl.stdout.append(`<<<>>>\nscan: ok\n<<<>>>\n`)
   plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
 
-  expect((await resultPromise).unwrap()).toEqual({
+  expect((await resultPromise).unsafeUnwrap()).toEqual({
     files: ['file01.jpg', 'file02.jpg'],
   })
 })
@@ -389,7 +389,7 @@ test('scan responds with error', async () => {
         plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
       }),
     })
-  ).unwrap()
+  ).unsafeUnwrap()
 
   const resultPromise = client.scan()
   await nextTick
@@ -399,7 +399,7 @@ test('scan responds with error', async () => {
   )
   plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
 
-  expect((await resultPromise).unwrapErr()).toEqual(ScannerError.InvalidParam)
+  expect((await resultPromise).unsafeUnwrapErr()).toEqual(ScannerError.InvalidParam)
 })
 
 test('scan returns error for invalid response', async () => {
@@ -414,7 +414,7 @@ test('scan returns error for invalid response', async () => {
         plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
       }),
     })
-  ).unwrap()
+  ).unsafeUnwrap()
 
   const resultPromise = client.scan()
   await nextTick
@@ -422,7 +422,7 @@ test('scan returns error for invalid response', async () => {
   plustekctl.stdout.append(`<<<>>>\nbooga booga!\n<<<>>>\n`)
   plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
 
-  expect(((await resultPromise).unwrapErr() as Error).message).toEqual(
+  expect(((await resultPromise).unsafeUnwrapErr() as Error).message).toEqual(
     'invalid response: booga booga!'
   )
 })
@@ -439,7 +439,7 @@ test('scan returns error for unknown data', async () => {
         plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
       }),
     })
-  ).unwrap()
+  ).unsafeUnwrap()
 
   const resultPromise = client.scan()
   await nextTick
@@ -447,7 +447,7 @@ test('scan returns error for unknown data', async () => {
   plustekctl.stdout.append(`<<<>>>\nscan: url=localhost\n<<<>>>\n`)
   plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
 
-  expect(((await resultPromise).unwrapErr() as Error).message).toEqual(
+  expect(((await resultPromise).unsafeUnwrapErr() as Error).message).toEqual(
     'unexpected response data: url=localhost'
   )
 })
@@ -464,7 +464,7 @@ test('calibrate succeeds', async () => {
         plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
       }),
     })
-  ).unwrap()
+  ).unsafeUnwrap()
 
   const resultPromise = client.calibrate()
   await nextTick
@@ -472,7 +472,7 @@ test('calibrate succeeds', async () => {
   plustekctl.stdout.append(`<<<>>>\ncalibrate: ok\n<<<>>>\n`)
   plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
 
-  ;(await resultPromise).unwrap()
+  ;(await resultPromise).unsafeUnwrap()
 })
 
 test('calibrate responds with error', async () => {
@@ -487,7 +487,7 @@ test('calibrate responds with error', async () => {
         plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
       }),
     })
-  ).unwrap()
+  ).unsafeUnwrap()
 
   const resultPromise = client.calibrate()
   await nextTick
@@ -497,7 +497,7 @@ test('calibrate responds with error', async () => {
   )
   plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
 
-  expect((await resultPromise).unwrapErr()).toEqual(ScannerError.InvalidParam)
+  expect((await resultPromise).unsafeUnwrapErr()).toEqual(ScannerError.InvalidParam)
 })
 
 test('calibrate returns error for invalid response', async () => {
@@ -512,7 +512,7 @@ test('calibrate returns error for invalid response', async () => {
         plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
       }),
     })
-  ).unwrap()
+  ).unsafeUnwrap()
 
   const resultPromise = client.calibrate()
   await nextTick
@@ -520,7 +520,7 @@ test('calibrate returns error for invalid response', async () => {
   plustekctl.stdout.append(`<<<>>>\nbooga booga!\n<<<>>>\n`)
   plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
 
-  expect(((await resultPromise).unwrapErr() as Error).message).toEqual(
+  expect(((await resultPromise).unsafeUnwrapErr() as Error).message).toEqual(
     'invalid response: booga booga!'
   )
 })
@@ -537,7 +537,7 @@ test('calibrate returns error for unknown data', async () => {
         plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
       }),
     })
-  ).unwrap()
+  ).unsafeUnwrap()
 
   const resultPromise = client.calibrate()
   await nextTick
@@ -545,7 +545,7 @@ test('calibrate returns error for unknown data', async () => {
   plustekctl.stdout.append(`<<<>>>\ncalibrate: key=value\n<<<>>>\n`)
   plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
 
-  expect(((await resultPromise).unwrapErr() as Error).message).toEqual(
+  expect(((await resultPromise).unsafeUnwrapErr() as Error).message).toEqual(
     'invalid response: calibrate: key=value'
   )
 })
@@ -562,14 +562,14 @@ test('accept succeeds', async () => {
         plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
       }),
     })
-  ).unwrap()
+  ).unsafeUnwrap()
 
   const resultPromise = client.accept()
   await nextTick
   expect(plustekctl.stdin.toString()).toEqual('accept\n')
   plustekctl.stdout.append(`<<<>>>\naccept: ok\n<<<>>>\n`)
   plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
-  ;(await resultPromise).unwrap()
+  ;(await resultPromise).unsafeUnwrap()
 })
 
 test('accept returns known error', async () => {
@@ -584,7 +584,7 @@ test('accept returns known error', async () => {
         plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
       }),
     })
-  ).unwrap()
+  ).unsafeUnwrap()
 
   const resultPromise = client.accept()
   await nextTick
@@ -594,7 +594,7 @@ test('accept returns known error', async () => {
   )
   plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
 
-  expect((await resultPromise).unwrapErr()).toEqual(ScannerError.NoSupportEject)
+  expect((await resultPromise).unsafeUnwrapErr()).toEqual(ScannerError.NoSupportEject)
 })
 
 test('accept returns error for invalid response', async () => {
@@ -609,7 +609,7 @@ test('accept returns error for invalid response', async () => {
         plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
       }),
     })
-  ).unwrap()
+  ).unsafeUnwrap()
 
   const resultPromise = client.accept()
   await nextTick
@@ -617,7 +617,7 @@ test('accept returns error for invalid response', async () => {
   plustekctl.stdout.append(`<<<>>>\naccept: NOPE\n<<<>>>\n`)
   plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
 
-  expect(((await resultPromise).unwrapErr() as Error).message).toEqual(
+  expect(((await resultPromise).unsafeUnwrapErr() as Error).message).toEqual(
     'invalid response: accept: NOPE'
   )
 })
@@ -634,14 +634,14 @@ test('reject succeeds', async () => {
         plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
       }),
     })
-  ).unwrap()
+  ).unsafeUnwrap()
 
   const resultPromise = client.reject({ hold: false })
   await nextTick
   expect(plustekctl.stdin.toString()).toEqual('reject\n')
   plustekctl.stdout.append(`<<<>>>\nreject: ok\n<<<>>>\n`)
   plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
-  ;(await resultPromise).unwrap()
+  ;(await resultPromise).unsafeUnwrap()
 })
 
 test('reject returns known error', async () => {
@@ -656,7 +656,7 @@ test('reject returns known error', async () => {
         plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
       }),
     })
-  ).unwrap()
+  ).unsafeUnwrap()
 
   const resultPromise = client.reject({ hold: false })
   await nextTick
@@ -666,7 +666,7 @@ test('reject returns known error', async () => {
   )
   plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
 
-  expect((await resultPromise).unwrapErr()).toEqual(ScannerError.NoSupportEject)
+  expect((await resultPromise).unsafeUnwrapErr()).toEqual(ScannerError.NoSupportEject)
 })
 
 test('reject returns error for invalid response', async () => {
@@ -681,7 +681,7 @@ test('reject returns error for invalid response', async () => {
         plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
       }),
     })
-  ).unwrap()
+  ).unsafeUnwrap()
 
   const resultPromise = client.reject({ hold: false })
   await nextTick
@@ -689,7 +689,7 @@ test('reject returns error for invalid response', async () => {
   plustekctl.stdout.append(`<<<>>>\nreject: NOPE\n<<<>>>\n`)
   plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
 
-  expect(((await resultPromise).unwrapErr() as Error).message).toEqual(
+  expect(((await resultPromise).unsafeUnwrapErr() as Error).message).toEqual(
     'invalid response: reject: NOPE'
   )
 })
@@ -706,14 +706,14 @@ test('reject-hold succeeds', async () => {
         plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
       }),
     })
-  ).unwrap()
+  ).unsafeUnwrap()
 
   const resultPromise = client.reject({ hold: true })
   await nextTick
   expect(plustekctl.stdin.toString()).toEqual('reject-hold\n')
   plustekctl.stdout.append(`<<<>>>\nreject-hold: ok\n<<<>>>\n`)
   plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
-  ;(await resultPromise).unwrap()
+  ;(await resultPromise).unsafeUnwrap()
 })
 
 test('scan followed by reject succeeds', async () => {
@@ -728,7 +728,7 @@ test('scan followed by reject succeeds', async () => {
         plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
       }),
     })
-  ).unwrap()
+  ).unsafeUnwrap()
 
   const scanResultPromise = client.scan()
   await nextTick
@@ -738,7 +738,7 @@ test('scan followed by reject succeeds', async () => {
   plustekctl.stdout.append(`<<<>>>\nscan: ok\n<<<>>>\n`)
   plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
 
-  expect((await scanResultPromise).unwrap()).toEqual({
+  expect((await scanResultPromise).unsafeUnwrap()).toEqual({
     files: ['file01.jpg', 'file02.jpg'],
   })
 
@@ -747,7 +747,7 @@ test('scan followed by reject succeeds', async () => {
   expect(plustekctl.stdin.toString()).toEqual('scan\nreject\n')
   plustekctl.stdout.append('<<<>>>\nreject: ok\n<<<>>>\n')
   plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
-  ;(await rejectResultPromise).unwrap()
+  ;(await rejectResultPromise).unsafeUnwrap()
 })
 
 test('overlapping calls', async () => {
@@ -762,7 +762,7 @@ test('overlapping calls', async () => {
         plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
       }),
     })
-  ).unwrap()
+  ).unsafeUnwrap()
 
   // enqueue IPCs #1 & #2
   const scanResultPromise = client.scan()
@@ -775,7 +775,7 @@ test('overlapping calls', async () => {
   plustekctl.stdout.append(`<<<>>>\nscan: file=file02.jpg\n<<<>>>\n`)
   plustekctl.stdout.append(`<<<>>>\nscan: ok\n<<<>>>\n`)
 
-  expect((await scanResultPromise).unwrap()).toEqual({
+  expect((await scanResultPromise).unsafeUnwrap()).toEqual({
     files: ['file01.jpg', 'file02.jpg'],
   })
 
@@ -790,7 +790,7 @@ test('overlapping calls', async () => {
     `<<<>>>\nget-paper-status: ${PaperStatus.ReadyToEject}\n<<<>>>\n`
   )
 
-  expect((await getPaperStatusResultPromise).unwrap()).toEqual(
+  expect((await getPaperStatusResultPromise).unsafeUnwrap()).toEqual(
     PaperStatus.ReadyToEject
   )
 
@@ -800,7 +800,7 @@ test('overlapping calls', async () => {
   )
 
   plustekctl.stdout.append(`<<<>>>\naccept: ok\n<<<>>>\n`)
-  ;(await acceptResultPromise).unwrap()
+  ;(await acceptResultPromise).unsafeUnwrap()
 })
 
 test('waitForStatus does not have to wait', async () => {
@@ -815,7 +815,7 @@ test('waitForStatus does not have to wait', async () => {
         plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
       }),
     })
-  ).unwrap()
+  ).unsafeUnwrap()
 
   const resultPromise = client.waitForStatus({
     status: PaperStatus.VtmReadyToScan,
@@ -827,7 +827,7 @@ test('waitForStatus does not have to wait', async () => {
   )
   plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
   const result = await resultPromise
-  expect(result?.unwrap()).toEqual(PaperStatus.VtmReadyToScan)
+  expect(result?.unsafeUnwrap()).toEqual(PaperStatus.VtmReadyToScan)
 })
 
 test('waitForStatus times out', async () => {
@@ -842,7 +842,7 @@ test('waitForStatus times out', async () => {
         plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
       }),
     })
-  ).unwrap()
+  ).unsafeUnwrap()
 
   const resultPromise = client.waitForStatus({
     status: PaperStatus.VtmReadyToScan,
@@ -856,7 +856,7 @@ test('waitForStatus times out', async () => {
   )
   plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
   const result = await resultPromise
-  expect(result?.unwrap()).toEqual(PaperStatus.Jam)
+  expect(result?.unsafeUnwrap()).toEqual(PaperStatus.Jam)
 })
 
 test('waitForStatus immediate timeout', async () => {
@@ -871,7 +871,7 @@ test('waitForStatus immediate timeout', async () => {
         plustekctl.stdout.append('<<<>>>\nready\n<<<>>>\n')
       }),
     })
-  ).unwrap()
+  ).unsafeUnwrap()
 
   const resultPromise = client.waitForStatus({
     status: PaperStatus.VtmReadyToScan,

--- a/libs/plustek-sdk/src/scanner.ts
+++ b/libs/plustek-sdk/src/scanner.ts
@@ -85,7 +85,7 @@ export async function createClient(
     JSON.stringify(resolvedConfig, undefined, 2)
   )
   const args = ['--config', configFilePath, '--delimiter', CLI_DELIMITER]
-  const plustekctlPath = plustekctlResult.unwrap()
+  const plustekctlPath = plustekctlResult.ok()
   debug('spawning: %s %o', plustekctlPath, args)
   const plustekctl = spawn(plustekctlPath, args, { stdio: 'pipe' })
   debug('spawned %s with pid=%d', plustekctlPath, plustekctl.pid)

--- a/libs/types/src/api/index.test.ts
+++ b/libs/types/src/api/index.test.ts
@@ -2,11 +2,14 @@ import { safeParse } from '../'
 import { ErrorsResponseSchema, OkResponseSchema } from './'
 
 test('OkResponse', () => {
-  safeParse(OkResponseSchema, { status: 'ok' }).unwrap()
-  safeParse(OkResponseSchema, {}).unwrapErr()
+  safeParse(OkResponseSchema, { status: 'ok' }).unsafeUnwrap()
+  safeParse(OkResponseSchema, {}).unsafeUnwrapErr()
 })
 
 test('ErrorsResponse', () => {
-  safeParse(ErrorsResponseSchema, { status: 'error', errors: [] }).unwrap()
-  safeParse(ErrorsResponseSchema, { status: 'ok' }).unwrapErr()
+  safeParse(ErrorsResponseSchema, {
+    status: 'error',
+    errors: [],
+  }).unsafeUnwrap()
+  safeParse(ErrorsResponseSchema, { status: 'ok' }).unsafeUnwrapErr()
 })

--- a/libs/types/src/election.test.ts
+++ b/libs/types/src/election.test.ts
@@ -5,8 +5,8 @@ import {
 } from '../test/election'
 import {
   CandidateContest,
-  getEitherNeitherContests,
   expandEitherNeitherContests,
+  getEitherNeitherContests,
   getElectionLocales,
   getPartyFullNameFromBallotStyle,
   getPartyPrimaryAdjectiveFromBallotStyle,
@@ -18,7 +18,6 @@ import {
   withLocale,
   YesNoContest,
 } from './election'
-import { ContestTypes } from './schema'
 
 test('can build votes from a candidate ID', () => {
   const contests = election.contests.filter((c) => c.id === 'CC')

--- a/libs/types/src/generic.test.ts
+++ b/libs/types/src/generic.test.ts
@@ -21,64 +21,12 @@ test('ok has no contained error', () => {
   expect(ok(0).err()).toBeUndefined()
 })
 
-test('ok andThen', () => {
-  expect(
-    ok(0)
-      .andThen((n) => ok(n + 1))
-      .unwrap()
-  ).toBe(1)
-  expect(
-    ok(0)
-      .andThen((n) => err(n + 1))
-      .unwrapErr()
-  ).toBe(1)
+test('ok unsafeUnwrap', () => {
+  expect(ok(0).unsafeUnwrap()).toBe(0)
 })
 
-test('ok map', () => {
-  expect(
-    ok(0)
-      .map((n) => n + 1)
-      .unwrap()
-  ).toBe(1)
-})
-
-test('ok mapErr', () => {
-  expect(
-    ok(0)
-      .mapErr(() => -1)
-      .unwrap()
-  ).toBe(0)
-})
-
-test('ok mapOr', () => {
-  expect(ok(0).mapOr(-1, (n) => n + 1)).toBe(1)
-})
-
-test('ok mapOrElse', () => {
-  expect(
-    ok(0).mapOrElse(
-      () => -1,
-      (n) => n + 1
-    )
-  ).toBe(1)
-})
-
-test('ok unwrap', () => {
-  expect(ok(0).unwrap()).toBe(0)
-})
-
-test('ok unwrapErr', () => {
-  expect(() => ok('value').unwrapErr()).toThrowError('value')
-})
-
-test('ok expect', () => {
-  expect(ok(0).expect('expected a number')).toBe(0)
-})
-
-test('ok expectErr', () => {
-  expect(() => ok(0).expectErr('expected an error')).toThrowError(
-    'expected an error'
-  )
+test('ok unsafeUnwrapErr', () => {
+  expect(() => ok('value').unsafeUnwrapErr()).toThrowError('value')
 })
 
 test('err is Err', () => {
@@ -98,57 +46,10 @@ test('err has no contained value', () => {
   expect(err(0).ok()).toBeUndefined()
 })
 
-test('err andThen', () => {
-  expect(
-    err(0)
-      .andThen(() => ok(1))
-      .unwrapErr()
-  ).toBe(0)
+test('err unsafeUnwrap', () => {
+  expect(() => err('error').unsafeUnwrap()).toThrowError('error')
 })
 
-test('err map', () => {
-  expect(
-    err(0)
-      .map(() => 1)
-      .unwrapErr()
-  ).toBe(0)
-})
-
-test('err mapErr', () => {
-  expect(
-    err(0)
-      .mapErr((n) => n + 1)
-      .unwrapErr()
-  ).toEqual(1)
-})
-
-test('err mapOr', () => {
-  expect(err(0).mapOr(-1, () => 1)).toBe(-1)
-})
-
-test('err mapOrElse', () => {
-  expect(
-    err(0).mapOrElse(
-      () => -1,
-      () => 1
-    )
-  ).toBe(-1)
-})
-
-test('err unwrap', () => {
-  expect(() => err('error').unwrap()).toThrowError('error')
-})
-
-test('err unwrapErr', () => {
-  expect(err('error').unwrapErr()).toBe('error')
-})
-
-test('err expect', () => {
-  expect(() => err(0).expect('expected a value')).toThrowError(
-    'expected a value'
-  )
-})
-
-test('err expectErr', () => {
-  expect(err(0).expectErr('expected an error')).toBe(0)
+test('err unsafeUnwrapErr', () => {
+  expect(err('error').unsafeUnwrapErr()).toBe('error')
 })

--- a/libs/types/src/generic.ts
+++ b/libs/types/src/generic.ts
@@ -9,131 +9,18 @@ export interface Provider<T> {
 /**
  * Represents either success with a value `T` or failure with error `E`.
  */
-export interface Result<T, E> {
+export type Result<T, E> = Ok<T> | Err<E>
+
+export interface Ok<T> {
   /**
-   * Returns `true` if the result is `Ok`.
+   * Returns `true`.
    */
   isOk(): this is Ok<T>
 
   /**
-   * Returns `true` if the result is `Err`.
-   */
-  isErr(): this is Err<E>
-
-  /**
-   * Returns the value if result is `Ok`, otherwise undefined.
-   */
-  ok(): Optional<T>
-
-  /**
-   * Returns the error if result is `Err`, otherwise undefined.
-   */
-  err(): Optional<E>
-
-  /**
-   * Maps a `Result<T, E>` to `Result<U, E>` by applying `fn` to an `Ok` value,
-   * leaving an `Err` value untouched.
-   *
-   * @example
-   *
-   *   const times2 = (n: number) => n * 2
-   *   console.log(ok(1).map(times2).ok()) // logs `2`
-   *   console.log(err(-1).map(times2).ok()) // logs `undefined`
-   */
-  map<U>(fn: (value: T) => U): Result<U, E>
-
-  /**
-   * Maps a `Result<T, E>` to `Result<T, F>` by applying `fn` to an `Err` value,
-   * leaving an `Ok` value untouched.
-   *
-   * @example
-   *
-   *   const times2 = (n: number) => n * 2
-   *   console.log(ok(1).mapErr(times2).ok()) // logs `1`
-   *   console.log(err(-1).mapErr(times2).err()) // logs `-2`
-   */
-  mapErr<F>(fn: (error: E) => F): Result<T, F>
-
-  /**
-   * Applies `fn` to a contained `Ok` value or returns `defaultValue` for `Err`.
-   *
-   * @example
-   *
-   *   const times2 = (n: number) => n * 2
-   *   console.log(ok(1).mapOr(-1, times2)) // logs `2`
-   *   console.log(err(NaN).mapOr(-1, times2)) // logs `-1`
-   */
-  mapOr<U>(defaultValue: U, fn: (value: T) => U): U
-
-  /**
-   * Applies `fn` to a contained `Ok` value or `defaultFn` to a contained `Err`
-   * error.
-   *
-   * @example
-   *
-   *   const times2 = (n: number) => n * 2
-   *   console.log(ok(1).mapOrElse(() => -1, times2)) // logs `2`
-   *   console.log(err(NaN).mapOrElse(() => -1, times2)) // logs `-1`
-   */
-  mapOrElse<U>(defaultFn: (error: E) => U, fn: (value: T) => U): U
-
-  /**
-   * Applies `fn` to a contained `Ok` value for a new `Result`, or returns `Err`
-   * as-is.
-   */
-  andThen<U>(fn: (value: T) => Result<U, E>): Result<U, E>
-
-  /**
-   * Returns a contained `Ok` value, or throws a contained `Err` error.
-   *
-   * @example
-   *
-   *   console.log(ok(1).unwrap()) // logs `1`
-   *   console.log(err(NaN).unwrap()) // throws `NaN`
-   */
-  unwrap(): T
-
-  /**
-   * Returns a contained `Err` error, or throws a contained `Ok` value.
-   *
-   * @example
-   *
-   *   console.log(ok(1).unwrapErr()) // throws `1`
-   *   console.log(err(NaN).unwrapErr()) // logs `NaN`
-   */
-  unwrapErr(): E
-
-  /**
-   * Returns a contained `Ok` value, or throws `throwable`.
-   *
-   * @example
-   *
-   *   console.log(ok(1).expect('expected a number')) // logs `1`
-   *   console.log(err(NaN).expect('expected a number')) // throws 'expected a number'
-   */
-  expect(throwable: unknown): T
-
-  /**
-   * Returns a contained `Err` error, or throws `throwable`.
-   *
-   * @example
-   *
-   *   console.log(ok(1).expectErr('expected an error')) // throws 'expected an error'
-   *   console.log(err(NaN).expectErr('expected an error')) // logs `NaN`
-   */
-  expectErr(throwable: unknown): E
-}
-
-export interface Ok<T> extends Result<T, never> {
-  /**
-   * Returns `true`.
-   */
-  isOk(): true
-
-  /**
    * Returns `false`.
    */
-  isErr(): false
+  isErr(): this is Err<never>
 
   /**
    * Returns the contained value.
@@ -146,61 +33,26 @@ export interface Ok<T> extends Result<T, never> {
   err(): undefined
 
   /**
-   * Applies `fn` to the contained value and returns the result.
-   */
-  map<U>(fn: (value: T) => U): Ok<U>
-
-  /**
-   * Applies `fn` to the contained error and returns the result.
-   */
-  mapErr(fn: (error: never) => unknown): Ok<T>
-
-  /**
-   * Applies `fn` to the contained value and returns the result.
-   */
-  mapOr<U>(defaultValue: U, fn: (value: T) => U): U
-
-  /**
-   * Applies `fn` to the contained value and returns the result.
-   */
-  mapOrElse<U>(defaultFn: (error: never) => U, fn: (value: T) => U): U
-
-  /**
-   * Applies `fn` to a contained `Ok` value for a new `Result`.
-   */
-  andThen<U>(fn: (value: T) => Result<U, never>): Ok<U>
-
-  /**
    * Returns the contained value.
    */
-  unwrap(): T
+  unsafeUnwrap(): T
 
   /**
    * Throws the contained value.
    */
-  unwrapErr(): never
-
-  /**
-   * Returns the contained value.
-   */
-  expect(throwable: unknown): T
-
-  /**
-   * Throws `throwable`.
-   */
-  expectErr(throwable: unknown): never
+  unsafeUnwrapErr(): never
 }
 
-export interface Err<E> extends Result<never, E> {
+export interface Err<E> {
   /**
    * Returns `false`.
    */
-  isOk(): false
+  isOk(): this is Ok<never>
 
   /**
    * Returns `true`.
    */
-  isErr(): true
+  isErr(): this is Err<E>
 
   /**
    * Returns `undefined`.
@@ -213,93 +65,50 @@ export interface Err<E> extends Result<never, E> {
   err(): E
 
   /**
-   * Returns a new `Err` wrapping the contained error.
-   */
-  map<U>(fn: (value: never) => U): Err<E>
-
-  /**
-   * Applies `fn` to the contained error and wraps it in `Err`.
-   */
-  mapErr<F>(fn: (error: E) => F): Err<F>
-
-  /**
-   * Returns `defaultValue`.
-   */
-  mapOr<U>(defaultValue: U, fn: (value: never) => U): U
-
-  /**
-   * Calls `defaultFn` and returns the result.
-   */
-  mapOrElse<U>(defaultFn: (error: E) => U, fn: (value: never) => U): U
-
-  /**
-   * Returns `Err` as-is.
-   */
-  andThen<U>(fn: (value: never) => Result<U, E>): Err<E>
-
-  /**
    * Throws the contained error.
    */
-  unwrap(): never
+  unsafeUnwrap(): never
 
   /**
    * Returns the contained error.
    */
-  unwrapErr(): E
-
-  /**
-   * Throws `throwable`.
-   */
-  expect(throwable: unknown): never
-
-  /**
-   * Returns the contained error.
-   */
-  expectErr(throwable: unknown): E
+  unsafeUnwrapErr(): E
 }
 
+/**
+ * Returns an empty `Result`.
+ */
 export function ok<E>(): Result<void, E>
+
+/**
+ * Returns a `Result` containing `value`.
+ */
 export function ok<T, E>(value: T): Result<T, E>
 export function ok<T, E>(value: T = (undefined as unknown) as T): Result<T, E> {
   return {
-    isOk: () => true,
     isErr: () => false,
-    ok: () => value,
+    isOk: () => true,
     err: () => undefined,
-    map: (fn) => ok(fn(value)),
-    mapErr: () => ok(value),
-    mapOr: (_defaultValue, fn) => fn(value),
-    mapOrElse: (_defaultFn, fn) => fn(value),
-    andThen: (fn) => fn(value),
-    unwrap: () => value,
-    unwrapErr: () => {
+    ok: () => value,
+    unsafeUnwrap: () => value,
+    unsafeUnwrapErr: () => {
       throw value
-    },
-    expect: () => value,
-    expectErr: (throwable) => {
-      throw throwable
     },
   }
 }
 
+/**
+ * Returns a `Result` containing `error`.
+ */
 export function err<T, E>(error: E): Result<T, E> {
   return {
-    isOk: () => false,
     isErr: () => true,
-    ok: () => undefined,
+    isOk: () => false,
     err: () => error,
-    map: () => err(error),
-    mapErr: (fn) => err(fn(error)),
-    mapOr: (defaultValue) => defaultValue,
-    mapOrElse: (defaultFn) => defaultFn(error),
-    andThen: () => err(error),
-    unwrap: () => {
+    ok: () => undefined,
+    unsafeUnwrap: () => {
       throw error
     },
-    unwrapErr: () => error,
-    expect: (throwable) => {
-      throw throwable
-    },
-    expectErr: () => error,
+    unsafeUnwrapErr: () => error,
   }
 }

--- a/libs/types/src/schema.test.ts
+++ b/libs/types/src/schema.test.ts
@@ -15,28 +15,27 @@ import {
   safeParseJSON,
 } from './schema'
 
-test('parseElection throws on error', () => {
+test('parseElection', () => {
   expect(() => parseElection({})).toThrowError()
+  expect(() => parseElection(electionSample)).not.toThrowError()
 })
 
 test('parsing fails on an empty object', () => {
-  safeParseElection({}).expectErr('empty object should fail')
+  safeParseElection({}).unsafeUnwrapErr()
 })
 
 test('parsing JSON.parses a string', () => {
-  expect(
-    safeParseElection(electionData).expect('expected parsing to succeed')
-  ).toEqual(electionSample)
+  expect(safeParseElection(electionData).unsafeUnwrap()).toEqual(electionSample)
 })
 
 test('parsing invalid JSON', () => {
-  expect(safeParseElection('{').unwrapErr().message).toEqual(
+  expect(safeParseElection('{').unsafeUnwrapErr().message).toEqual(
     'Unexpected end of JSON input'
   )
 })
 
 test('parsing JSON without a schema', () => {
-  expect(safeParseJSON('{}').unwrap()).toEqual({})
+  expect(safeParseJSON('{}').unsafeUnwrap()).toEqual({})
 })
 
 test('parsing gives specific errors for nested objects', () => {
@@ -51,7 +50,7 @@ test('parsing gives specific errors for nested objects', () => {
           title: 42,
         },
       ],
-    }).unwrapErr()
+    }).unsafeUnwrapErr()
   ).toMatchInlineSnapshot(`
     [Error: [
       {
@@ -250,7 +249,7 @@ test('ensures dates are ISO 8601-formatted', () => {
     safeParseElection({
       ...electionSample,
       date: 'not ISO',
-    }).unwrapErr()
+    }).unsafeUnwrapErr()
   ).toMatchInlineSnapshot(`
     [Error: [
       {
@@ -265,7 +264,7 @@ test('ensures dates are ISO 8601-formatted', () => {
 })
 
 test('parsing a valid election object succeeds', () => {
-  const parsed = safeParseElection(electionSample as unknown).unwrap()
+  const parsed = safeParseElection(electionSample as unknown).unsafeUnwrap()
 
   // This check is here to prove TS inferred that `parsed` is an `Election`.
   expect(parsed.title).toEqual(electionSample.title)
@@ -277,7 +276,7 @@ test('parsing a valid election object succeeds', () => {
 test('parsing a valid election with ms-either-neither succeeds', () => {
   const parsed = safeParseElection(
     electionWithMsEitherNeither as unknown
-  ).unwrap()
+  ).unsafeUnwrap()
 
   // This check is here to prove TS inferred that `parsed` is an `Election`.
   expect(parsed.title).toEqual(electionWithMsEitherNeither.title)
@@ -287,7 +286,9 @@ test('parsing a valid election with ms-either-neither succeeds', () => {
 })
 
 test('parsing a valid election', () => {
-  expect(safeParseElection(electionSample).unwrap()).toEqual(electionSample)
+  expect(safeParseElection(electionSample).unsafeUnwrap()).toEqual(
+    electionSample
+  )
 })
 
 test('contest IDs cannot start with an underscore', () => {
@@ -295,7 +296,7 @@ test('contest IDs cannot start with an underscore', () => {
     safeParse(CandidateContest, {
       ...electionSample.contests[0],
       id: '_president',
-    }).unwrapErr()
+    }).unsafeUnwrapErr()
   ).toMatchInlineSnapshot(`
     [Error: [
       {
@@ -313,12 +314,12 @@ test('allows valid mark thresholds', () => {
   safeParseElection({
     ...electionSample,
     markThresholds: { definite: 0.2, marginal: 0.2 },
-  }).unwrap()
+  }).unsafeUnwrap()
 
   safeParseElection({
     ...electionSample,
     markThresholds: { definite: 0.2, marginal: 0.1 },
-  }).unwrap()
+  }).unsafeUnwrap()
 })
 
 test('disallows invalid mark thresholds', () => {
@@ -326,7 +327,7 @@ test('disallows invalid mark thresholds', () => {
     safeParseElection({
       ...electionSample,
       markThresholds: { definite: 0.2, marginal: 0.3 },
-    }).unwrapErr()
+    }).unsafeUnwrapErr()
   ).toMatchInlineSnapshot(`
     [Error: [
       {
@@ -343,7 +344,7 @@ test('disallows invalid mark thresholds', () => {
     safeParseElection({
       ...electionSample,
       markThresholds: { marginal: 0.3 },
-    }).unwrapErr()
+    }).unsafeUnwrapErr()
   ).toMatchInlineSnapshot(`
     [Error: [
       {
@@ -363,7 +364,7 @@ test('disallows invalid mark thresholds', () => {
     safeParseElection({
       ...electionSample,
       markThresholds: { definite: 1.2, marginal: 0.3 },
-    }).unwrapErr()
+    }).unsafeUnwrapErr()
   ).toMatchInlineSnapshot(`
     [Error: [
       {
@@ -385,7 +386,7 @@ test('allows valid adjudication reasons', () => {
   safeParseElection({
     ...electionSample,
     adjudicationReasons: [],
-  }).unwrap()
+  }).unsafeUnwrap()
 
   safeParseElection({
     ...electionSample,
@@ -393,7 +394,7 @@ test('allows valid adjudication reasons', () => {
       t.AdjudicationReason.MarginalMark,
       t.AdjudicationReason.UninterpretableBallot,
     ],
-  }).unwrap()
+  }).unsafeUnwrap()
 })
 
 test('disallows invalid adjudication reasons', () => {
@@ -401,7 +402,7 @@ test('disallows invalid adjudication reasons', () => {
     safeParseElection({
       ...electionSample,
       adjudicationReasons: ['abcdefg'],
-    }).unwrapErr()
+    }).unsafeUnwrapErr()
   ).toMatchInlineSnapshot(`
     [Error: [
       {
@@ -427,7 +428,7 @@ test('disallows invalid adjudication reasons', () => {
     safeParseElection({
       ...electionSample,
       adjudicationReasons: 'foooo',
-    }).unwrapErr()
+    }).unsafeUnwrapErr()
   ).toMatchInlineSnapshot(`
     [Error: [
       {
@@ -450,7 +451,7 @@ test('supports ballot layout paper size', () => {
       ballotLayout: {
         paperSize: 'A4',
       },
-    }).unwrapErr()
+    }).unsafeUnwrapErr()
   ).toMatchInlineSnapshot(`
     [Error: [
       {
@@ -472,7 +473,7 @@ test('supports ballot layout paper size', () => {
     safeParseElection({
       ...electionSample,
       ballotLayout: 'letter',
-    }).unwrapErr()
+    }).unsafeUnwrapErr()
   ).toMatchInlineSnapshot(`
     [Error: [
       {
@@ -493,7 +494,7 @@ test('parsing validates district references', () => {
     safeParseElection({
       ...electionSample,
       districts: [{ id: 'DIS', name: 'DIS' }],
-    }).unwrapErr()
+    }).unsafeUnwrapErr()
   ).toMatchInlineSnapshot(`
     [Error: [
       {
@@ -515,7 +516,7 @@ test('parsing validates precinct references', () => {
     safeParseElection({
       ...electionSample,
       precincts: [{ id: 'PRE', name: 'PRE' }],
-    }).unwrapErr()
+    }).unsafeUnwrapErr()
   ).toMatchInlineSnapshot(`
     [Error: [
       {
@@ -548,7 +549,7 @@ test('parsing validates contest party references', () => {
         },
         ...remainingContests,
       ],
-    }).unwrapErr()
+    }).unsafeUnwrapErr()
   ).toMatchInlineSnapshot(`
     [Error: [
       {
@@ -586,7 +587,7 @@ test('parsing validates candidate party references', () => {
         },
         ...remainingContests,
       ],
-    }).unwrapErr()
+    }).unsafeUnwrapErr()
   ).toMatchInlineSnapshot(`
     [Error: [
       {
@@ -609,7 +610,7 @@ test('validates uniqueness of district ids', () => {
     safeParseElection({
       ...electionSample,
       districts: [...electionSample.districts, ...electionSample.districts],
-    }).unwrapErr()
+    }).unsafeUnwrapErr()
   ).toMatchInlineSnapshot(`
     [Error: [
       {
@@ -630,7 +631,7 @@ test('validates uniqueness of ballot style ids', () => {
     safeParse(BallotStyles, [
       ...electionSample.ballotStyles,
       ...electionSample.ballotStyles,
-    ]).unwrapErr()
+    ]).unsafeUnwrapErr()
   ).toMatchInlineSnapshot(`
     [Error: [
       {
@@ -650,7 +651,7 @@ test('validates uniqueness of precinct ids', () => {
     safeParseElection({
       ...electionSample,
       precincts: [...electionSample.precincts, ...electionSample.precincts],
-    }).unwrapErr()
+    }).unsafeUnwrapErr()
   ).toMatchInlineSnapshot(`
     [Error: [
       {
@@ -671,7 +672,7 @@ test('validates uniqueness of contest ids', () => {
     safeParseElection({
       ...electionSample,
       contests: [...electionSample.contests, ...electionSample.contests],
-    }).unwrapErr()
+    }).unsafeUnwrapErr()
   ).toMatchInlineSnapshot(`
     [Error: [
       {
@@ -701,7 +702,7 @@ test('validates uniqueness of party ids', () => {
     safeParseElection({
       ...electionSample,
       parties: [...electionSample.parties, ...electionSample.parties],
-    }).unwrapErr()
+    }).unsafeUnwrapErr()
   ).toMatchInlineSnapshot(`
     [Error: [
       {
@@ -724,7 +725,7 @@ test('validates uniqueness of candidate ids within a contest', () => {
     safeParse(CandidateContest, {
       ...contest,
       candidates: [...contest.candidates, ...contest.candidates],
-    }).unwrapErr()
+    }).unsafeUnwrapErr()
   ).toMatchInlineSnapshot(`
     [Error: [
       {
@@ -741,9 +742,10 @@ test('validates uniqueness of candidate ids within a contest', () => {
 })
 
 test('validates admin cards have hex-encoded hashes', () => {
-  safeParse(AdminCardData, { t: 'admin', h: 'd34db33f' }).unwrap()
-  expect(safeParse(AdminCardData, { t: 'admin', h: 'not hex' }).unwrapErr())
-    .toMatchInlineSnapshot(`
+  safeParse(AdminCardData, { t: 'admin', h: 'd34db33f' }).unsafeUnwrap()
+  expect(
+    safeParse(AdminCardData, { t: 'admin', h: 'not hex' }).unsafeUnwrapErr()
+  ).toMatchInlineSnapshot(`
     [Error: [
       {
         "code": "custom",
@@ -758,8 +760,12 @@ test('validates admin cards have hex-encoded hashes', () => {
 
 test('safeParseElectionDefinition computes the election hash', () => {
   expect(
-    safeParseElectionDefinition(electionData).unwrap().electionHash
+    safeParseElectionDefinition(electionData).unsafeUnwrap().electionHash
   ).toMatchInlineSnapshot(
     `"d5366378eeccc2fd38953e6e34c3069dea0dca4b7a8f5c789f3d108dc1807d3c"`
   )
+})
+
+test('safeParseElectionDefinition error result', () => {
+  expect(safeParseElectionDefinition('').err()).toBeDefined()
 })

--- a/libs/types/src/schema.ts
+++ b/libs/types/src/schema.ts
@@ -465,7 +465,13 @@ export function safeParseJSON<T>(
  * @deprecated use `safeParseElection(…)` instead
  */
 export function parseElection(value: unknown): t.Election {
-  return safeParseElection(value).unwrap()
+  const result = safeParseElection(value)
+
+  if (result.isErr()) {
+    throw result.err()
+  }
+
+  return result.ok()
 }
 
 /**
@@ -499,9 +505,12 @@ export function safeParseElection(
 export function safeParseElectionDefinition(
   value: string
 ): Result<t.ElectionDefinition, z.ZodError | SyntaxError> {
-  return safeParseElection(value).map((election) => ({
-    election,
-    electionData: value,
-    electionHash: createHash('sha256').update(value).digest('hex'),
-  }))
+  const result = safeParseElection(value)
+  return result.isErr()
+    ? result
+    : ok({
+        election: result.ok(),
+        electionData: value,
+        electionHash: createHash('sha256').update(value).digest('hex'),
+      })
 }

--- a/libs/types/test/election.ts
+++ b/libs/types/test/election.ts
@@ -67,7 +67,7 @@ export const electionData = `
   ],
   "state": "STATE"
 }`
-export const election: Election = safeParseElection(electionData).unwrap()
+export const election: Election = safeParseElection(electionData).unsafeUnwrap()
 export const primaryElection: Election = {
   ...election,
   ballotStyles: [


### PR DESCRIPTION
Per discussions with @votingworks/eng, I'm trying out a more minimal `Result` type.