### PR TITLE
fix(bmd): print full tallies, no more X's

### DIFF
--- a/apps/bmd/src/AppPrintOnly.test.tsx
+++ b/apps/bmd/src/AppPrintOnly.test.tsx
@@ -390,11 +390,11 @@ test('VxPrintOnly flow', async () => {
   expect(
     getAllByText('Franklin County, Measure 666: The Question No One Gets To')[0]
       .nextSibling!.textContent
-  ).toBe('YesXNoX')
+  ).toBe('Yes0No0')
   expect(
     getAllByText('Franklin County, Head of Constitution Party')[0].nextSibling!
       .textContent
-  ).toBe('Alice JonesXBob SmithX')
+  ).toBe('Alice Jones0Bob Smith0')
 
   // Close Polls
   fireEvent.click(getByText('Close Polls for Center Springfield'))

--- a/apps/bmd/src/components/PrecinctTallyReport.tsx
+++ b/apps/bmd/src/components/PrecinctTallyReport.tsx
@@ -49,21 +49,11 @@ const PrecinctTallyReport: React.FC<Props> = ({
   precinctId,
   reportPurpose,
 }) => {
-  const { ballotStyles, contests, precincts } = election
+  const { contests, precincts } = election
   const precinct = precincts.find((p) => p.id === precinctId) as Precinct
   const ballotAction =
     sourceMachineType === TallySourceMachineType.BMD ? 'printed' : 'scanned'
 
-  const precinctBalotStyles = ballotStyles.filter((bs) =>
-    bs.precincts.includes(precinctId)
-  )
-  const precinctContestIds = contests
-    .filter((c) =>
-      precinctBalotStyles.find(
-        (bs) => bs.partyId === c.partyId && bs.districts.includes(c.districtId)
-      )
-    )
-    .map((c) => c.id)
   return (
     <Report>
       <h1>
@@ -81,7 +71,6 @@ const PrecinctTallyReport: React.FC<Props> = ({
         Ballots {ballotAction} count: <strong>{ballotCount}</strong>
       </p>
       {contests.map((contest, contestIndex) => {
-        const isContestInPrecinct = precinctContestIds.includes(contest.id)
         const candidateContest = contest.type === 'candidate' && contest
         const yesnoContest = contest.type === 'yesno' && contest
         const eitherNeitherContest =
@@ -104,13 +93,8 @@ const PrecinctTallyReport: React.FC<Props> = ({
                           }
                         </td>
                         <TD narrow textAlign="right">
-                          {isContestInPrecinct
-                            ? numberWithCommas(
-                                (tally[contestIndex] as MsEitherNeitherTally)
-                                  .eitherOption
-                              )
-                            : /* istanbul ignore next */
-                              'X'}
+                          numberWithCommas( (tally[contestIndex] as
+                          MsEitherNeitherTally) .eitherOption )
                         </TD>
                       </tr>
                       <tr>
@@ -121,15 +105,10 @@ const PrecinctTallyReport: React.FC<Props> = ({
                           }
                         </td>
                         <TD narrow textAlign="right">
-                          {
-                            /* istanbul ignore else */ isContestInPrecinct
-                              ? numberWithCommas(
-                                  (tally[contestIndex] as MsEitherNeitherTally)
-                                    .neitherOption
-                                )
-                              : /* istanbul ignore next */
-                                'X'
-                          }
+                          {numberWithCommas(
+                            (tally[contestIndex] as MsEitherNeitherTally)
+                              .neitherOption
+                          )}
                         </TD>
                       </tr>
                       <tr>
@@ -140,13 +119,10 @@ const PrecinctTallyReport: React.FC<Props> = ({
                           }
                         </td>
                         <TD narrow textAlign="right">
-                          {isContestInPrecinct
-                            ? numberWithCommas(
-                                (tally[contestIndex] as MsEitherNeitherTally)
-                                  .firstOption
-                              )
-                            : /* istanbul ignore next */
-                              'X'}
+                          {numberWithCommas(
+                            (tally[contestIndex] as MsEitherNeitherTally)
+                              .firstOption
+                          )}
                         </TD>
                       </tr>
                       <tr>
@@ -157,13 +133,10 @@ const PrecinctTallyReport: React.FC<Props> = ({
                           }
                         </td>
                         <TD narrow textAlign="right">
-                          {isContestInPrecinct
-                            ? numberWithCommas(
-                                (tally[contestIndex] as MsEitherNeitherTally)
-                                  .secondOption
-                              )
-                            : /* istanbul ignore next */
-                              'X'}
+                          {numberWithCommas(
+                            (tally[contestIndex] as MsEitherNeitherTally)
+                              .secondOption
+                          )}
                         </TD>
                       </tr>
                     </React.Fragment>
@@ -174,12 +147,10 @@ const PrecinctTallyReport: React.FC<Props> = ({
                         <tr key={candidate.id}>
                           <td>{candidate.name}</td>
                           <TD narrow textAlign="right">
-                            {isContestInPrecinct
-                              ? numberWithCommas(
-                                  (tally[contestIndex] as CandidateVoteTally)
-                                    .candidates[candidateIndex]
-                                )
-                              : 'X'}
+                            {numberWithCommas(
+                              (tally[contestIndex] as CandidateVoteTally)
+                                .candidates[candidateIndex]
+                            )}
                           </TD>
                         </tr>
                       )
@@ -189,21 +160,17 @@ const PrecinctTallyReport: React.FC<Props> = ({
                       <tr>
                         <td>Yes</td>
                         <TD narrow textAlign="right">
-                          {isContestInPrecinct
-                            ? numberWithCommas(
-                                (tally[contestIndex] as YesNoVoteTally).yes
-                              )
-                            : 'X'}
+                          {numberWithCommas(
+                            (tally[contestIndex] as YesNoVoteTally).yes
+                          )}
                         </TD>
                       </tr>
                       <tr>
                         <td>No</td>
                         <TD narrow textAlign="right">
-                          {isContestInPrecinct
-                            ? numberWithCommas(
-                                (tally[contestIndex] as YesNoVoteTally).no
-                              )
-                            : 'X'}
+                          {numberWithCommas(
+                            (tally[contestIndex] as YesNoVoteTally).no
+                          )}
                         </TD>
                       </tr>
                     </React.Fragment>


### PR DESCRIPTION
To date, we've had the VxMark+Print and VxPrint print "X" in the tally for candidates of contests that are not in that precinct, just to make it clear that those contests don't matter in this precinct.

This breaks down when we're trying to print a tally report for a precinct scanner that is configured to accept ballots for any precinct in the county. A larger more complete fix may want to consider whether we should special case the precinct-scanner report, or maybe whether the BMD needs to have a all-precincts configuration option.

This fix is minimal, it just prints the actual tally instead of "X" for all tabulation reports printed by VxMark+Print or VxPrint. Note that the tallying of ballots was happening no matter what precinct they belong to, this is purely a display tweak.