### PR TITLE
test(ci): run cypress tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
       - run:
           name: Run Front-End Test and Coverage
           command: |
-            pnpm --dir apps/bmd test:coverage
+            pnpm --dir apps/bmd test
 
   test-bsd:
     executor: nodejs-browsers

--- a/apps/bmd/cypress/tests/font-settings.ts
+++ b/apps/bmd/cypress/tests/font-settings.ts
@@ -3,7 +3,7 @@ describe('Font Settings', () => {
   const label = 'Change Text Size'
   const buttons = '[data-testid="change-text-size-buttons"]'
   it('Voter can adjust font settings', () => {
-    cy.visit('/#sample')
+    cy.visit('/#demo')
 
     // Default font size
     cy.contains(label)

--- a/apps/bmd/cypress/tests/scroll-buttons.ts
+++ b/apps/bmd/cypress/tests/scroll-buttons.ts
@@ -3,7 +3,7 @@ describe('Scroll Buttons', () => {
   const waitTime = 500
 
   it('Scroll buttons appear and function correctly', () => {
-    cy.visit('/#sample')
+    cy.visit('/#demo')
     cy.wait(waitTime)
     cy.get('nav').contains('Start Voting').click()
     cy.contains('Next').click()

--- a/apps/bmd/cypress/tests/scroll-to-contest.ts
+++ b/apps/bmd/cypress/tests/scroll-to-contest.ts
@@ -4,7 +4,7 @@ describe('Review Page', () => {
   const waitTime = 250
   const clickThoughPages = new Array(20) // number of contests for activation code 'VX.23.12'
   it('When navigating from contest, scroll to contest and place focus on contest.', () => {
-    cy.visit('/#sample')
+    cy.visit('/#demo')
     cy.wait(waitTime)
     cy.get('nav').contains('Start Voting').click()
     cy.wrap(clickThoughPages).each(() => {

--- a/apps/bmd/src/AppRoot.tsx
+++ b/apps/bmd/src/AppRoot.tsx
@@ -462,7 +462,6 @@ const AppRoot: React.FC<Props> = ({
   const PostVotingInstructionsTimeout = useRef(0)
   const [appState, dispatchAppState] = useReducer(appReducer, initialAppState)
   const {
-    adminCardElectionHash,
     appPrecinctId,
     ballotsPrintedCount,
     ballotStyleId,
@@ -661,7 +660,7 @@ const AppRoot: React.FC<Props> = ({
         electionDefinition: electionDefinitionResult.unsafeUnwrap(),
       })
     }
-  }, [card, adminCardElectionHash])
+  }, [card])
 
   const activateCardlessBallotStyleId = (ballotStyleId: string) => {
     dispatchAppState({


### PR DESCRIPTION
As far as I can tell, this was broken from the moment BMD moved into the monorepo. We stopped running the `test` command and started running `test:coverage`, which in BMD didn't run the Cypress tests.

I changed from `/#sample` to `/#demo` at some point, but the Cypress tests were never updated. This commit fixes that too.