### PR TITLE
fix(ps): allow selecting "All Precincts"

### DIFF
--- a/apps/precinct-scanner/src/App.test.tsx
+++ b/apps/precinct-scanner/src/App.test.tsx
@@ -262,7 +262,7 @@ test('admin and pollworker configuration', async () => {
   card.insertCard(adminCard, JSON.stringify(electionSampleDefinition))
   await advanceTimersAndPromises(1)
   await screen.findByText('Administrator Settings')
-  await fireEvent.click(await screen.findByText('Live Election Mode'))
+  fireEvent.click(await screen.findByText('Live Election Mode'))
   await screen.findByText('Loading')
   await advanceTimersAndPromises(1)
   expect(fetchMock.calls('/config/testMode', { method: 'PATCH' })).toHaveLength(
@@ -289,7 +289,7 @@ test('admin and pollworker configuration', async () => {
   await advanceTimersAndPromises(1)
   await screen.findByText('Administrator Settings')
   // Change precinct
-  fireEvent.change(await screen.getByTestId('selectPrecinct'), {
+  fireEvent.change(await screen.findByTestId('selectPrecinct'), {
     target: { value: '23' },
   })
   expect(fetchMock.calls('/config/precinct', { method: 'PUT' })).toHaveLength(1)

--- a/apps/precinct-scanner/src/api/config.test.ts
+++ b/apps/precinct-scanner/src/api/config.test.ts
@@ -69,11 +69,20 @@ test('PATCH /config/testMode', async () => {
   )
 })
 
-test('setCurrentPrecinctId suceeds', async () => {
+test('setCurrentPrecinctId updates', async () => {
   fetchMock.putOnce('/config/precinct', JSON.stringify({ status: 'ok' }))
   await config.setCurrentPrecinctId('23')
 
   expect(fetchMock.calls('/config/precinct', { method: 'PUT' })).toHaveLength(1)
+})
+
+test('setCurrentPrecinctId deletes', async () => {
+  fetchMock.deleteOnce('/config/precinct', { body: { status: 'ok' } })
+  await config.setCurrentPrecinctId(undefined)
+
+  expect(
+    fetchMock.calls('/config/precinct', { method: 'DELETE' })
+  ).toHaveLength(1)
 })
 
 test('setCurrentPrecinctId fails', async () => {

--- a/apps/precinct-scanner/src/api/config.ts
+++ b/apps/precinct-scanner/src/api/config.ts
@@ -125,7 +125,13 @@ export async function getCurrentPrecinctId(): Promise<
 }
 
 export async function setCurrentPrecinctId(
-  precinctId: Precinct['id']
+  precinctId: Precinct['id'] | undefined
 ): Promise<void> {
-  await put<PutCurrentPrecinctConfigRequest>('/config/precinct', { precinctId })
+  if (!precinctId) {
+    await del('/config/precinct')
+  } else {
+    await put<PutCurrentPrecinctConfigRequest>('/config/precinct', {
+      precinctId,
+    })
+  }
 }

--- a/apps/precinct-scanner/src/screens/AdminScreen.test.tsx
+++ b/apps/precinct-scanner/src/screens/AdminScreen.test.tsx
@@ -163,3 +163,42 @@ test('renders date and time settings modal', async () => {
   // Date is reset to system time after save to kiosk-browser
   getByText(startDate)
 })
+
+test('setting and un-setting the precinct', async () => {
+  const updateAppPrecinctId = jest.fn()
+
+  render(
+    <AppContext.Provider
+      value={{
+        electionDefinition: electionSampleDefinition,
+        machineConfig: { machineId: '0000', codeVersion: 'TEST' },
+      }}
+    >
+      <AdminScreen
+        scannedBallotCount={10}
+        isTestMode={false}
+        updateAppPrecinctId={updateAppPrecinctId}
+        toggleLiveMode={jest.fn()}
+        unconfigure={jest.fn()}
+        calibrate={jest.fn()}
+        usbDriveEject={jest.fn()}
+        usbDriveStatus={usbstick.UsbDriveStatus.absent}
+      />
+    </AppContext.Provider>
+  )
+
+  const precinct = electionSampleDefinition.election.precincts[0]
+  const selectPrecinct = await screen.findByTestId('selectPrecinct')
+
+  // set precinct
+  fireEvent.change(selectPrecinct, {
+    target: { value: electionSampleDefinition.election.precincts[0].id },
+  })
+  expect(updateAppPrecinctId).toHaveBeenNthCalledWith(1, precinct.id)
+
+  // unset precinct
+  fireEvent.change(selectPrecinct, {
+    target: { value: '' },
+  })
+  expect(updateAppPrecinctId).toHaveBeenNthCalledWith(2, '')
+})

--- a/apps/precinct-scanner/src/screens/AdminScreen.tsx
+++ b/apps/precinct-scanner/src/screens/AdminScreen.tsx
@@ -23,9 +23,9 @@ import ExportResultsModal from '../components/ExportResultsModal'
 interface Props {
   scannedBallotCount: number
   isTestMode: boolean
-  updateAppPrecinctId: (appPrecinctId: string) => void
-  toggleLiveMode: VoidFunction
-  unconfigure: VoidFunction
+  updateAppPrecinctId(appPrecinctId: string): Promise<void>
+  toggleLiveMode(): Promise<void>
+  unconfigure(): Promise<void>
   calibrate(): Promise<boolean>
   usbDriveStatus: usbstick.UsbDriveStatus
   usbDriveEject: () => void
@@ -114,9 +114,7 @@ const AdminScreen: React.FC<Props> = ({
             onChange={changeAppPrecinctId}
             large
           >
-            <option value="" disabled>
-              Select precinct…
-            </option>
+            <option value="">All Precincts</option>
             {[...election.precincts]
               .sort((a, b) =>
                 a.name.localeCompare(b.name, undefined, {


### PR DESCRIPTION
Previously the default setting for the precinct scanner was to allow sheets from all precincts. However, if you changed it, you'd be unable to change it back to All Precincts. This adds an option called "All Precincts" and makes it the default.

<img width="505" alt="image" src="https://user-images.githubusercontent.com/1938/121449348-dc942980-c956-11eb-9641-448cdfff313c.png">
