### PR TITLE
refactor(election-manager) remove deprecated sems combination code

### DIFF
--- a/apps/election-manager/src/lib/ConverterClient.ts
+++ b/apps/election-manager/src/lib/ConverterClient.ts
@@ -59,25 +59,6 @@ export default class ConverterClient {
     return await response.json()
   }
 
-  public async combineResultsFiles(
-    firstFile: File,
-    secondFile: File
-  ): Promise<Blob> {
-    const formData = new FormData()
-    formData.append('firstFile', firstFile)
-    formData.append('secondFile', secondFile)
-
-    const response = await fetch('/convert/results/combine', {
-      method: 'POST',
-      body: formData,
-    })
-
-    if (response.status === 200) {
-      return await response.blob()
-    }
-    throw new Error('Error combining results files')
-  }
-
   public async reset(): Promise<void> {
     await fetch('/convert/reset', { method: 'POST' })
   }

--- a/apps/election-manager/src/routerPaths.ts
+++ b/apps/election-manager/src/routerPaths.ts
@@ -43,7 +43,6 @@ const routerPaths = {
   testDeckResultsReport: ({ precinctId }: PrecinctReportScreenProps): string =>
     `/tally/test-ballot-deck/${precinctId}`,
   overvoteCombinationReport: '/tally/pairs',
-  combineResultsFiles: '/tally/combine-results-files',
 }
 
 export default routerPaths


### PR DESCRIPTION
Removes now unreachable code in election-manager related to combining SEMS file. This is no longer done, instead we precompute a combined tally of all results in election manager (manual data, sems data, cvr data, etc.) and send that tally to module-converter-sems to convert to the sems format. 