### PR TITLE
feat(em): always show manual select files in dev mode

### DIFF
--- a/apps/election-manager/src/components/ImportCVRFilesModal.tsx
+++ b/apps/election-manager/src/components/ImportCVRFilesModal.tsx
@@ -239,7 +239,7 @@ const ImportCVRFilesModal: React.FC<Props> = ({ onClose }) => {
         actions={
           <React.Fragment>
             <LinkButton onPress={onClose}>Cancel</LinkButton>
-            {!window.kiosk && (
+            {(!window.kiosk || process.env.NODE_ENV === 'development') && (
               <FileInputButton
                 onChange={processCastVoteRecordFileFromFilePicker}
                 data-testid="manual-input"


### PR DESCRIPTION
Small change that makes the manual "select files" button when importing CVR files to always show, even when there is no usb drive and you are in kiosk mode, in dev mode. Convenient for debugging/internal testing. 