### PR TITLE
fix(utils): improve `find` type

### DIFF
--- a/libs/utils/src/find.ts
+++ b/libs/utils/src/find.ts
@@ -4,14 +4,14 @@
  *
  * @throws when no element matches and no default value is provided
  */
-export function find<T>(
+export function find<T, S extends T>(
   array: readonly T[],
-  predicate: (element: T) => boolean
-): T
+  predicate: (element: T) => element is S
+): S
 export function find<T>(
   array: readonly T[],
   predicate: (element: T) => boolean,
-  defaultValue: T
+  defaultValue?: T
 ): T
 export function find<T>(
   array: readonly T[],


### PR DESCRIPTION
This follows the same pattern used by `Array.prototype.find` to allow a predicate function to refine the type of the return value.

[example](https://www.typescriptlang.org/play?#code/PQKhCgAIUgxBLAdgEwM6QIaMgUwDY4C2OiALpEpAAYYBOtGAnlZKQBYbmGcDGbO6KgAdaOZPB6ccVADSQA9kNLx5iDHjyNIo0gFdaiJAHMoMKshwAzDLrykAaut3SKlyInm4CxMpG6k+AQA6U1NIAAF2WnkAd3QY-mwPLyISLl5+dCxkd08La1tyADcnHAp0EXki+AtkU2BwHAAPIXlacktdRB5lVUhLJGQAHgAVOQBlXCbSEjRIEYA+AAooTHomAC5tHAxkVU15gG0AXRlVkTEJKS2l-FSyLZGASkgAXgWUn3J4dHHwJ62f2arXa-S6PRU2AGKFGy1WdAYjC2ol2+y0IxOZ0gkAu4kkMxudy+jxe70gACN5PICFgsZB8jY7I48M4APyPf4c4FtDrg3pQwawlbYhGbbaoxAHDGnc6iPHXSC3bxpElvD6U6k7RB0hmFZlsjkA+aQADeqx4qlQ5FEqEKbzWiKC0OQS1xVxmT3Aq3gbiWNrtr0DkC6+SQYheZux2J9it1TNKbyDIasYeQEdWUdYbGiMXcOFzAFF6G0lgByLoYckEVieZ2YbBEtJ+DLGTA4uXunClz2ZgC+XszOn02DjDlKq37qyHBm2trs4EnFsQVodTHthwAjHJS+TS8dwEuVwNaFaAHK6QjknC0e3OpaixhyW5Gso-dwXq83smkRhCHDyNwykDV5IFLRAP2vbsvWAYAIlIVAAFpgRwHokOLG8EKzN83ywXB0IpFCbFQMoqGPM8INoFgcOocDL2vKgD0tTUgjweQjCWMjSHPOivyDUsMG7IA)