### PR TITLE
test(all): ignore build for module resolution

### DIFF
--- a/jest.config.shared.js
+++ b/jest.config.shared.js
@@ -4,6 +4,9 @@ module.exports = {
   testEnvironment: 'node',
   testMatch: ['<rootDir>/{src,test}/**/*.test.{ts,tsx}'],
   watchPathIgnorePatterns: ['<rootDir>/node_modules', '<rootDir>/build'],
+  modulePathIgnorePatterns: [
+    '<rootDir>[/\\\\](build|docs|node_modules|deploy|scripts)[/\\\\]'
+  ],
   collectCoverageFrom: ['{src,test}/**/*.{ts,tsx}', '!src/**/*.d.ts'],
   coverageThreshold: {
     global: {


### PR DESCRIPTION
Without this, jest may find the build products in `build` and consider them a module that could be imported, which confuses `jest-haste-map` and may make it slower to resolve modules.