### PR TITLE
test(bmd) bump timeout on cypress test

### DIFF
--- a/apps/bmd/cypress/tests/scroll-to-contest.ts
+++ b/apps/bmd/cypress/tests/scroll-to-contest.ts
@@ -1,7 +1,7 @@
 /* eslint-disable cypress/no-unnecessary-waiting */
 
 describe('Review Page', () => {
-  const waitTime = 250
+  const waitTime = 500
   const clickThoughPages = new Array(20) // number of contests for activation code 'VX.23.12'
   it('When navigating from contest, scroll to contest and place focus on contest.', () => {
     cy.visit('/#demo')


### PR DESCRIPTION
This was failing for my when running cypress tests locally until I bumped the timeout, the other cypress tests in bmd already use a 500ms timeout rather then 250ms.