### PR TITLE
refactor(bmd) split integration tests into own circle job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           command: |
             pnpm --dir apps/bas test
 
-  test-bmd:
+  test-bmd-main:
     executor: nodejs-browsers
     resource_class: xlarge
     steps:
@@ -62,6 +62,24 @@ jobs:
           name: Test
           command: |
             pnpm --dir apps/bmd test
+
+  test-bmd-integration:
+    executor: nodejs-browsers
+    resource_class: xlarge
+    steps:
+      - checkout-and-install
+      - run:
+          name: Build
+          command: |
+            pnpm --dir apps/bmd build
+      - run:
+          name: Lint
+          command: |
+            pnpm --dir apps/bmd lint
+      - run:
+          name: Test
+          command: |
+                  pnpm --dir apps/bmd test:e2e
 
   test-bsd:
     executor: nodejs-browsers
@@ -304,7 +322,8 @@ workflows:
     jobs:
       - test-ballot-encoder
       - test-bas
-      - test-bmd
+      - test-bmd-main
+      - test-bmd-integration
       - test-bsd
       - test-election-manager
       - test-eslint-plugin-vx

--- a/apps/bmd/package.json
+++ b/apps/bmd/package.json
@@ -13,7 +13,7 @@
     "start": "script/react-scripts start",
     "stylelint:run": "stylelint 'src/**/*.{js,jsx,ts,tsx}' && stylelint 'src/**/*.css' --config .stylelintrc-css.js",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "TZ=UTC CI=true script/react-scripts test --maxWorkers 2 --env=jest-environment-jsdom-sixteen --coverage && pnpm test:e2e:ci",
+    "test:ci": "TZ=UTC CI=true script/react-scripts test --maxWorkers 2 --env=jest-environment-jsdom-sixteen --coverage",
     "test:coverage": "TZ=UTC script/react-scripts test --coverage --watchAll=false --env=jest-environment-jsdom-sixteen",
     "test:debug": "script/react-scripts --inspect-brk test --runInBand --no-cache --env=jest-environment-jsdom-sixteen",
     "test:e2e": "is-ci \"test:e2e:ci\" \"test:e2e:watch\"",


### PR DESCRIPTION
Creates two circle jobs for bmd one to run the cypress integration tests and one to run the regular tests so that they can be run in parallel. Before this change test-bmd took 5min 45sec or so to complete on circle and now test-bmd-main takes 3 and a half minutes and test-bmd-integration takes a bit over 4 minutes. 

Closes #652 