### PR TITLE
fix: add status for both sides having sheets

### DIFF
--- a/libs/plustek-sdk/src/errors.ts
+++ b/libs/plustek-sdk/src/errors.ts
@@ -6,6 +6,7 @@ export enum ScannerError {
   VtmScanOvertime = 'PLKSS_ERRCODE_VTM_SCAN_OVERTIME',
   VtmGratingSensorNotMove = 'PLKSS_ERRCODE_VTM_GRATING_SENSOR_NOT_MOVE',
   VtmNoDevicesAfterEject = 'PLKSS_ERRCODE_VTM_NO_DEVICES_AFTER_EJECT',
+  VtmBothSideHavePaper = 'PLKSS_ERRCODE_VTM_BOTH_SIDE_HAVE_PAPER',
   /*CallBack STATUS*/
   CbStatusIlReadImageFail = 'PLKSS_ERRCODE_CB_STATUS_IL_READ_IMAGE_FAIL',
   CbStatusIlAutoDeskewExFail = 'PLKSS_ERRCODE_CB_STATUS_IL_AUTO_DESKEW_EX_FAIL',

--- a/libs/plustek-sdk/src/mocks.test.ts
+++ b/libs/plustek-sdk/src/mocks.test.ts
@@ -204,6 +204,34 @@ test('calibrate', async () => {
   )
 })
 
+test('paper held at both sides', async () => {
+  const mock = new MockScannerClient({
+    toggleHoldDuration: 0,
+    passthroughDuration: 0,
+  })
+  expect((await mock.scan()).err()).toEqual(ScannerError.NoDevices)
+  await mock.connect()
+
+  expect((await mock.scan()).err()).toEqual(ScannerError.VtmPsDevReadyNoPaper)
+  await mock.simulateLoadSheet(files)
+  expect((await mock.scan()).ok()).toEqual({ files })
+  expect((await mock.getPaperStatus()).ok()).toEqual(
+    PaperStatus.VtmReadyToEject
+  )
+
+  await mock.simulateLoadSheet(files)
+  expect((await mock.getPaperStatus()).ok()).toEqual(PaperStatus.VtmBothSideHavePaper)
+  expect((await mock.scan()).err()).toEqual(ScannerError.VtmBothSideHavePaper)
+  expect((await mock.accept()).err()).toEqual(ScannerError.VtmBothSideHavePaper)
+  expect((await mock.reject({ hold: false })).err()).toEqual(ScannerError.VtmBothSideHavePaper)
+  expect((await mock.reject({ hold: true })).err()).toEqual(ScannerError.VtmBothSideHavePaper)
+  expect((await mock.calibrate()).err()).toEqual(ScannerError.VtmBothSideHavePaper)
+  await mock.simulateRemoveSheet()
+  expect((await mock.getPaperStatus()).ok()).toEqual(
+    PaperStatus.VtmReadyToEject
+  )
+})
+
 test('waitForStatus', async () => {
   const mock = new MockScannerClient({
     toggleHoldDuration: 0,

--- a/libs/plustek-sdk/src/paper-status.ts
+++ b/libs/plustek-sdk/src/paper-status.ts
@@ -18,6 +18,7 @@ export enum PaperStatus {
   VtmReadyToScan = 'PLKSS_ERRCODE_VTM_PS_READY_TO_SCAN',
   VtmReadyToEject = 'PLKSS_ERRCODE_VTM_PS_READY_TO_EJECT',
   VtmFrontAndBackSensorHavePaperReady = 'PLKSS_ERRCODE_VTM_PS_FRONT_AND_BACK_SENSOR_HAVE_PAPER_READY',
+  VtmBothSideHavePaper = 'PLKSS_ERRCODE_VTM_BOTH_SIDE_HAVE_PAPER',
 }
 
 export const PaperStatusSchema = z.nativeEnum(PaperStatus)


### PR DESCRIPTION
Updates the mock to account for the possibility that both front and back have a sheet loaded. This does not actually update the UI in any way and it's still broken when trying to feed a second sheet, but this moves us in the right direction.

Refs #671 