### PR TITLE
fix(scan): use newer `libsane` to support fi-7800

### DIFF
--- a/apps/module-scan/Makefile
+++ b/apps/module-scan/Makefile
@@ -6,7 +6,9 @@ TIMESTAMP := $(shell date --iso-8601=seconds --utc | sed 's/+.*$\//g' | tr ':' '
 FORCE:
 
 install:
-	sudo apt install -y build-essential libx11-dev libjpeg-dev libpng-dev
+	sudo add-apt-repository -y ppa:sane-project/sane-release
+	sudo apt-get -y update
+	sudo apt install -y libsane build-essential libx11-dev libjpeg-dev libpng-dev
 
 build: FORCE
 	pnpm install && pnpm build


### PR DESCRIPTION
Apparently support for Fujitsu fi-7800 was added in SANE 1.0.31: https://gitlab.com/sane-project/backends/-/releases/1.0.31. As of now the current version on Ubuntu by default is 1.0.27, and the newest on the `sane-project` repository is 1.0.32.