### PR TITLE
feat(integration) add integration test for yesno eitherneither tallies

### DIFF
--- a/integration-testing/election-manager/cypress/fixtures/electionWithMsEitherNeither.json
+++ b/integration-testing/election-manager/cypress/fixtures/electionWithMsEitherNeither.json
@@ -1,0 +1,533 @@
+{
+  "title": "Mock General Election Choctaw 2020",
+  "state": "State of Mississippi",
+  "county": {
+    "id": "10",
+    "name": "Choctaw County"
+  },
+  "date": "2020-08-26T00:00:00-10:00",
+  "ballotLayout": {
+    "paperSize": "letter"
+  },
+  "parties": [
+    {
+      "id": "2",
+      "name": "Democrat",
+      "fullName": "Democratic Party",
+      "abbrev": "D"
+    },
+    {
+      "id": "3",
+      "name": "Republican",
+      "fullName": "Republican Party",
+      "abbrev": "R"
+    },
+    {
+      "id": "4",
+      "name": "Libertarian",
+      "fullName": "Libertarian Party",
+      "abbrev": "L"
+    },
+    {
+      "id": "5",
+      "name": "Reform",
+      "fullName": "Reform Party",
+      "abbrev": "REF"
+    },
+    {
+      "id": "6",
+      "name": "Natural Law",
+      "fullName": "Natural Law Party",
+      "abbrev": "N"
+    },
+    {
+      "id": "8",
+      "name": "Constitution",
+      "fullName": "Constitution Party",
+      "abbrev": "C"
+    },
+    {
+      "id": "9",
+      "name": "Green",
+      "fullName": "Green Party",
+      "abbrev": "G"
+    },
+    {
+      "id": "10",
+      "name": "America First",
+      "fullName": "America First Party",
+      "abbrev": "A"
+    },
+    {
+      "id": "11",
+      "name": "Independent",
+      "fullName": "Independent Party",
+      "abbrev": "I"
+    },
+    {
+      "id": "12",
+      "name": "Nonpartisan",
+      "fullName": "Nonpartisan",
+      "abbrev": "NP"
+    },
+    {
+      "id": "575000001",
+      "name": "Justice",
+      "fullName": "Justice Party",
+      "abbrev": "JUS"
+    },
+    {
+      "id": "575000002",
+      "name": "Prohibition",
+      "fullName": "Prohibition Party",
+      "abbrev": "PRO"
+    },
+    {
+      "id": "575000003",
+      "name": "American Delta",
+      "fullName": "American Delta Party",
+      "abbrev": "ADP"
+    },
+    {
+      "id": "575000004",
+      "name": "Veterans",
+      "fullName": "Veterans Party",
+      "abbrev": "VET"
+    }
+  ],
+  "contests": [
+    {
+      "id": "775020876",
+      "section": "United States",
+      "districtId": "1",
+      "type": "candidate",
+      "title": "President",
+      "seats": 1,
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "775031988",
+          "name": "Presidential Electors for Joe Biden for President and Kamala Harris for Vice President",
+          "partyId": "2"
+        },
+        {
+          "id": "775031987",
+          "name": "Presidential Electors for Donald J. Trump for President and Michael R. Pence for Vice President",
+          "partyId": "3"
+        },
+        {
+          "id": "775031989",
+          "name": "Presidential Electors for Phil Collins for President and Bill Parker for Vice President",
+          "partyId": "11"
+        }
+      ]
+    },
+    {
+      "id": "775020877",
+      "section": "United States",
+      "districtId": "1",
+      "type": "candidate",
+      "title": "Senate ",
+      "seats": 1,
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "775031985",
+          "name": "Mike Espy",
+          "partyId": "2"
+        },
+        {
+          "id": "775031986",
+          "name": "Cindy Hyde-Smith",
+          "partyId": "3"
+        },
+        {
+          "id": "775031990",
+          "name": "Jimmy Edwards",
+          "partyId": "4"
+        }
+      ]
+    },
+    {
+      "id": "775020872",
+      "section": "US House Of Representatives",
+      "districtId": "100000047",
+      "type": "candidate",
+      "title": "1st Congressional District",
+      "seats": 1,
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "775031978",
+          "name": "Antonia Eliason",
+          "partyId": "2"
+        },
+        {
+          "id": "775031979",
+          "name": "Trent Kelly",
+          "partyId": "3"
+        }
+      ]
+    },
+    {
+      "id": "775020870",
+      "section": "Northern District",
+      "districtId": "100000174",
+      "type": "candidate",
+      "title": "Supreme Court District 3(Northern) Position 3",
+      "seats": 1,
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "775031976",
+          "name": "Josiah Dennis Coleman",
+          "partyId": "12"
+        },
+        {
+          "id": "775031993",
+          "name": "Percy L. Lynchard",
+          "partyId": "12"
+        }
+      ]
+    },
+    {
+      "id": "775020899",
+      "section": "Election Commissioner 01",
+      "districtId": "575000501",
+      "type": "candidate",
+      "title": "Election Commissioner  01",
+      "seats": 1,
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "775032015",
+          "name": "Glynda Chaney Fulce"
+        }
+      ]
+    },
+    {
+      "id": "775020900",
+      "section": "Election Commissioner 02",
+      "districtId": "575000502",
+      "type": "candidate",
+      "title": "Election Commissioner 02",
+      "seats": 1,
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "775032016",
+          "name": "Charles Beck"
+        },
+        {
+          "id": "775032017",
+          "name": "Sharon Brooks"
+        }
+      ]
+    },
+    {
+      "id": "775020901",
+      "section": "Election Commissioner 03",
+      "districtId": "575000503",
+      "type": "candidate",
+      "title": "Election Commissioner 03",
+      "seats": 1,
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "775032018",
+          "name": "Dorothy Anderson"
+        }
+      ]
+    },
+    {
+      "id": "775020902",
+      "section": "Election Commissioner 04",
+      "districtId": "575000504",
+      "type": "candidate",
+      "title": "Election Commissioner 04",
+      "seats": 1,
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "775032019",
+          "name": "Willie Mae Guillory"
+        },
+        {
+          "id": "775032020",
+          "name": "Lewis Wright"
+        }
+      ]
+    },
+    {
+      "id": "775020903",
+      "section": "Election Commissioner 05",
+      "districtId": "575000505",
+      "type": "candidate",
+      "title": "Election Commissioner 05",
+      "seats": 1,
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "775032021",
+          "name": "Ouida A Loper",
+          "partyId": "11"
+        },
+        {
+          "id": "775032022",
+          "name": "Wayne McLeod"
+        }
+      ]
+    },
+    {
+      "id": "775020904",
+      "section": "School Board District 5",
+      "districtId": "575000084",
+      "type": "candidate",
+      "title": "School Board 05",
+      "seats": 1,
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "775032023",
+          "name": "Michael D Thomas"
+        }
+      ]
+    },
+    {
+      "id": "750000017",
+      "section": "State Of Mississippi",
+      "districtId": "100000275",
+      "type": "yesno",
+      "title": "Ballot Measure 2\nHouse Concurrent Resolution No. 47",
+      "description": "This amendment provides that to be elected Governor, or to any other statewide office, a candidate must receive a majority of the votes in the general election. If no candidate receives a majority of the votes, then a runoff election shall be held as provided by general law. The requirement of receiving the most votes in a majority of Mississippi House of Representative\u2019s districts is removed.",
+      "yesOption": {
+        "id": "750000094",
+        "label": "YES"
+      },
+      "noOption": {
+        "id": "750000095",
+        "label": "NO"
+      }
+    },
+    {
+      "id": "750000018",
+      "section": "State Of Mississippi",
+      "districtId": "100000275",
+      "type": "yesno",
+      "title": "Ballot Measure 3\nHouse Bill 1796 - Flag Referendum",
+      "description": "Please vote \u2018Yes\u2019 or \u2018No\u2019 on whether the following design shall be the official Mississippi State Flag",
+      "yesOption": {
+        "id": "750000092",
+        "label": "YES"
+      },
+      "noOption": {
+        "id": "750000093",
+        "label": "NO"
+      }
+    },
+    {
+      "id": "750000015-either-neither",
+      "section": "State Of Mississippi",
+      "districtId": "100000275",
+      "type": "ms-either-neither",
+      "title": "Ballot Measure 1",
+      "eitherNeitherContestId": "750000015",
+      "pickOneContestId": "750000016",
+      "description": "<b>Initiated by Petition and Alternative by Legislature</b>\n\nInitiative Measure No. 65, Should Mississippi allow qualified patients with debilitating medical conditions, as certified by Mississippi licensed physicians, to use medical marijuana?\n\nLegislative Budget Office Fiscal Analysis: The anticipated expenses for year one (1) to implement a medical marijuana program is $24,068,150 (Plants \u2013 seeds to Sale: $5,000,000; Licensing, Monitoring, Inspection: $16,220,150; and Cost to Collect Revenue: $2,848,000). The anticipated revenue is $13,000,000 (User ID Cards: $2,500,000; Commercial Licenses: $500,000 and Tax Revenue at 7 percent: $10,000,000). The overall cost for year one (1) is anticipated to be $11,068,150.\n\nLegislative Budget Office Fiscal Analysis: The anticipated expenses for year after the first for a medical marijuana program is $15,338,000 (Plants \u2013 seeds to Sale: $5,000,000; Licensing, Monitoring, Inspection: $8,756,000; and Cost to Collect Revenue: $1,582,000). The anticipated revenue is $26,000,000 (User ID Cards: $5,000,000; Commercial Licenses: $1,000,000 and Tax Revenue at 7 percent: $20,000,000). The overall annual revenue is anticipated to be $10,662.000.\n\nAlternative Measure No. 65 A, Shall Mississippi establish a program to allow the medical use of marijuana products by qualified persons with debilitating medical conditions?\n\nLegislative Budget Office Fiscal Analysis: There is no determinable cost or revenue impact associated with this initiative.",
+      "eitherNeitherLabel": "VOTE FOR APPROVAL OF EITHER, OR AGAINST BOTH",
+      "pickOneLabel": "AND VOTE FOR ONE",
+      "eitherOption": {
+        "id": "750000088",
+        "label": "FOR APPROVAL OF EITHER Initiative No. 65 OR Alternative Measure No. 65 A"
+      },
+      "neitherOption": {
+        "id": "750000089",
+        "label": "AGAINST BOTH Initiative Measure No. 65 AND Alternative Measure No. 65 A"
+      },
+      "firstOption": {
+        "id": "750000090",
+        "label": "FOR Initiative Measure No. 65"
+      },
+      "secondOption": {
+        "id": "750000091",
+        "label": "FOR Alternative Measure 65 A"
+      }
+    }
+  ],
+  "districts": [
+    {
+      "id": "1",
+      "name": "United States"
+    },
+    {
+      "id": "100000275",
+      "name": "State Of Mississippi"
+    },
+    {
+      "id": "100000047",
+      "name": "US House Of Representatives"
+    },
+    {
+      "id": "100000174",
+      "name": "Northern District"
+    },
+    {
+      "id": "575000501",
+      "name": "Election Commissioner 01"
+    },
+    {
+      "id": "575000502",
+      "name": "Election Commissioner 02"
+    },
+    {
+      "id": "575000503",
+      "name": "Election Commissioner 03"
+    },
+    {
+      "id": "575000504",
+      "name": "Election Commissioner 04"
+    },
+    {
+      "id": "575000505",
+      "name": "Election Commissioner 05"
+    },
+    {
+      "id": "575000084",
+      "name": "School Board District 5"
+    }
+  ],
+  "precincts": [
+    {
+      "id": "6522",
+      "name": "District 5"
+    },
+    {
+      "id": "6524",
+      "name": "Chester"
+    },
+    {
+      "id": "6525",
+      "name": "East Weir"
+    },
+    {
+      "id": "6526",
+      "name": "French Camp"
+    },
+    {
+      "id": "6527",
+      "name": "Fentress"
+    },
+    {
+      "id": "6528",
+      "name": "Hebron"
+    },
+    {
+      "id": "6529",
+      "name": "Kenego"
+    },
+    {
+      "id": "6532",
+      "name": "Panhandle"
+    },
+    {
+      "id": "6534",
+      "name": "Reform"
+    },
+    {
+      "id": "6536",
+      "name": "Sherwood"
+    },
+    {
+      "id": "6537",
+      "name": "Southwest Ackerman"
+    },
+    {
+      "id": "6538",
+      "name": "Bywy"
+    },
+    {
+      "id": "6539",
+      "name": "West Weir"
+    }
+  ],
+  "ballotStyles": [
+    {
+      "id": "4",
+      "precincts": [
+        "6538",
+        "6524",
+        "6527"
+      ],
+      "districts": [
+        "1",
+        "100000047",
+        "100000174",
+        "100000275",
+        "575000501"
+      ]
+    },
+    {
+      "id": "5",
+      "precincts": [
+        "6522"
+      ],
+      "districts": [
+        "1",
+        "100000047",
+        "100000174",
+        "100000275",
+        "575000084",
+        "575000505"
+      ]
+    },
+    {
+      "id": "1",
+      "precincts": [
+        "6525",
+        "6532",
+        "6537"
+      ],
+      "districts": [
+        "1",
+        "100000047",
+        "100000174",
+        "100000275",
+        "575000504"
+      ]
+    },
+    {
+      "id": "2",
+      "precincts": [
+        "6526",
+        "6529",
+        "6539"
+      ],
+      "districts": [
+        "1",
+        "100000047",
+        "100000174",
+        "100000275",
+        "575000503"
+      ]
+    },
+    {
+      "id": "3",
+      "precincts": [
+        "6528",
+        "6534",
+        "6536"
+      ],
+      "districts": [
+        "1",
+        "100000047",
+        "100000174",
+        "100000275",
+        "575000502"
+      ]
+    }
+  ],
+  "sealURL": "/seals/Seal_of_Mississippi_BW.svg",
+  "ballotStrings": {
+    "officialInitials": "Initialing Manager"
+  }
+}

--- a/integration-testing/election-manager/cypress/integration/candidateContestTallies.ts
+++ b/integration-testing/election-manager/cypress/integration/candidateContestTallies.ts
@@ -3,7 +3,10 @@ import {
   generateCVR,
   generateFileContentFromCVRs,
 } from '@votingworks/test-utils'
-import { assertExpectedResultsMatchSEMsFile } from '../support/assertions'
+import {
+  assertExpectedResultsMatchSEMsFile,
+  assertExpectedResultsMatchTallyReport,
+} from '../support/assertions'
 
 describe('Election Manager can create SEMS tallies', () => {
   it('Tallies for candidate contests compute end to end as expected', () => {
@@ -78,113 +81,98 @@ describe('Election Manager can create SEMS tallies', () => {
     cy.get('[data-testid="total-ballot-count"]').within(() => cy.contains('5'))
 
     // Check that the internal tally reports have the correct tallies
-    const assertTallyReportHasFullTally = () => {
-      cy.contains('Preview Report').click()
-      cy.get('[data-testid="absentee"]').within(() => cy.contains('0'))
-      cy.get('[data-testid="standard"]').within(() => cy.contains('5'))
-      cy.get('[data-testid="total"]').within(() => cy.contains('5'))
-      cy.get('[data-testid="results-table-governor-contest-liberty').within(
-        () => {
-          cy.contains('5 ballots cast')
-          cy.contains('1 overvote')
-          cy.contains('1 undervote')
-        }
-      )
-      cy.get('[data-testid="governor-contest-liberty-aaron-aligator"]').within(
-        () => cy.contains('2')
-      )
-      cy.get('[data-testid="governor-contest-liberty-peter-pigeon"]').within(
-        () => cy.contains('1')
-      )
-      cy.get('[data-testid="governor-contest-liberty-__write-in"]').within(() =>
-        cy.contains('0')
-      )
-      cy.get('[data-testid="results-table-schoolboard-liberty').within(() => {
-        cy.contains('5 ballots cast')
-        cy.contains('4 overvotes')
-        cy.contains('3 undervotes')
-      })
-      cy.get('[data-testid="schoolboard-liberty-amber-brkich"]').within(() =>
-        cy.contains('2')
-      )
-      cy.get('[data-testid="schoolboard-liberty-chris-daugherty"]').within(() =>
-        cy.contains('1')
-      )
-      cy.get('[data-testid="schoolboard-liberty-tom-westman"]').within(() =>
-        cy.contains('0')
-      )
-      cy.get('[data-testid="schoolboard-liberty-danni-boatwright"]').within(
-        () => cy.contains('0')
-      )
-      cy.get('[data-testid="schoolboard-liberty-__write-in"]').within(() =>
-        cy.contains('0')
-      )
-    }
-    const assertTallyReportHasEmptyTally = () => {
-      cy.contains('Preview Report').click()
-      cy.get('[data-testid="absentee"]').within(() => cy.contains('0'))
-      cy.get('[data-testid="standard"]').within(() => cy.contains('0'))
-      cy.get('[data-testid="total"]').within(() => cy.contains('0'))
-      cy.get('[data-testid="results-table-governor-contest-liberty').within(
-        () => {
-          cy.contains('0 ballots cast')
-          cy.contains('0 overvotes')
-          cy.contains('0 undervotes')
-        }
-      )
-      cy.get('[data-testid="governor-contest-liberty-aaron-aligator"]').within(
-        () => cy.contains('0')
-      )
-      cy.get('[data-testid="governor-contest-liberty-peter-pigeon"]').within(
-        () => cy.contains('0')
-      )
-      cy.get('[data-testid="governor-contest-liberty-__write-in"]').within(() =>
-        cy.contains('0')
-      )
-      cy.get('[data-testid="results-table-schoolboard-liberty').within(() => {
-        cy.contains('0 ballots cast')
-        cy.contains('0 overvotes')
-        cy.contains('0 undervotes')
-      })
-      cy.get('[data-testid="schoolboard-liberty-amber-brkich"]').within(() =>
-        cy.contains('0')
-      )
-      cy.get('[data-testid="schoolboard-liberty-chris-daugherty"]').within(() =>
-        cy.contains('0')
-      )
-      cy.get('[data-testid="schoolboard-liberty-tom-westman"]').within(() =>
-        cy.contains('0')
-      )
-      cy.get('[data-testid="schoolboard-liberty-danni-boatwright"]').within(
-        () => cy.contains('0')
-      )
-      cy.get('[data-testid="schoolboard-liberty-__write-in"]').within(() =>
-        cy.contains('0')
-      )
-    }
+    const expectedFullResults = [
+      {
+        contestId: 'governor-contest-liberty',
+        metadata: { ballots: 5, undervotes: 1, overvotes: 1 },
+        votesByOptionId: {
+          'aaron-aligator': 2,
+          'peter-pigeon': 1,
+          '__write-in': 0,
+        },
+      },
+      {
+        contestId: 'schoolboard-liberty',
+        metadata: { ballots: 5, undervotes: 3, overvotes: 4 },
+        votesByOptionId: {
+          'amber-brkich': 2,
+          'chris-daugherty': 1,
+          'tom-westman': 0,
+          'danni-boatwright': 0,
+          '__write-in': 0,
+        },
+      },
+    ]
+
+    const expectedEmptyResults = [
+      {
+        contestId: 'governor-contest-liberty',
+        metadata: { ballots: 0, undervotes: 0, overvotes: 0 },
+        votesByOptionId: {
+          'aaron-aligator': 0,
+          'peter-pigeon': 0,
+          '__write-in': 0,
+        },
+      },
+      {
+        contestId: 'schoolboard-liberty',
+        metadata: { ballots: 0, undervotes: 0, overvotes: 0 },
+        votesByOptionId: {
+          'amber-brkich': 0,
+          'chris-daugherty': 0,
+          'tom-westman': 0,
+          'danni-boatwright': 0,
+          '__write-in': 0,
+        },
+      },
+    ]
     cy.contains('View Unofficial Full Election Tally Report').click()
-    assertTallyReportHasFullTally()
+    assertExpectedResultsMatchTallyReport(expectedFullResults, {
+      absentee: 0,
+      precinct: 5,
+    })
     cy.contains('Back to Tally Index').click()
     cy.contains('View Unofficial Precinct 2 Tally Report').click()
-    assertTallyReportHasFullTally()
+    assertExpectedResultsMatchTallyReport(expectedFullResults, {
+      absentee: 0,
+      precinct: 5,
+    })
     cy.contains('Back to Tally Index').click()
     cy.contains('View Unofficial Precinct 1 Tally Report').click()
-    assertTallyReportHasEmptyTally()
+    assertExpectedResultsMatchTallyReport(expectedEmptyResults, {
+      absentee: 0,
+      precinct: 0,
+    })
     cy.contains('Back to Tally Index').click()
     cy.contains('View Unofficial Precinct 3 Tally Report').click()
-    assertTallyReportHasEmptyTally()
+    assertExpectedResultsMatchTallyReport(expectedEmptyResults, {
+      absentee: 0,
+      precinct: 0,
+    })
     cy.contains('Back to Tally Index').click()
     cy.contains('View Unofficial Precinct 4 Tally Report').click()
-    assertTallyReportHasEmptyTally()
+    assertExpectedResultsMatchTallyReport(expectedEmptyResults, {
+      absentee: 0,
+      precinct: 0,
+    })
     cy.contains('Back to Tally Index').click()
     cy.contains('View Unofficial Precinct 5 Tally Report').click()
-    assertTallyReportHasEmptyTally()
+    assertExpectedResultsMatchTallyReport(expectedEmptyResults, {
+      absentee: 0,
+      precinct: 0,
+    })
     cy.contains('Back to Tally Index').click()
     cy.contains('View Unofficial Liberty Party Tally Report').click()
-    assertTallyReportHasFullTally()
+    assertExpectedResultsMatchTallyReport(expectedFullResults, {
+      absentee: 0,
+      precinct: 5,
+    })
     cy.contains('Back to Tally Index').click()
     cy.contains('View Unofficial Scanner scanner-1 Tally Report').click()
-    assertTallyReportHasFullTally()
+    assertExpectedResultsMatchTallyReport(expectedFullResults, {
+      absentee: 0,
+      precinct: 5,
+    })
     cy.contains('Back to Tally Index').click()
 
     // Check that the exported SEMS result file as the correct tallies

--- a/integration-testing/election-manager/cypress/integration/yesNoContestTallies.ts
+++ b/integration-testing/election-manager/cypress/integration/yesNoContestTallies.ts
@@ -1,0 +1,729 @@
+import { electionWithMsEitherNeither } from '@votingworks/fixtures'
+import {
+  generateCVR,
+  generateFileContentFromCVRs,
+} from '@votingworks/test-utils'
+import {
+  assertExpectedResultsMatchSEMsFile,
+  assertExpectedResultsMatchTallyReport,
+} from '../support/assertions'
+
+describe('Election Manager can create SEMS tallies', () => {
+  it('Tallies for yes no and either neither contests compute end to end as expected', () => {
+    // Generate a CVR file with votes in the president contest.
+    const fakeCVRFileContents = generateFileContentFromCVRs([
+      generateCVR(
+        electionWithMsEitherNeither,
+        {
+          '750000017': ['yes'],
+          '750000018': [],
+          '750000015': ['yes'],
+          '750000016': ['no'],
+        },
+        { _precinctId: '6522', _ballotStyleId: '5', _ballotType: 'absentee' }
+      ),
+      generateCVR(
+        electionWithMsEitherNeither,
+        {
+          '750000017': ['no'],
+          '750000018': ['yes'],
+          '750000015': ['yes'],
+          '750000016': ['yes'],
+        },
+        {
+          _precinctId: '6522',
+          _ballotStyleId: '5',
+          _ballotType: 'absentee',
+          _scannerId: 'scanner-2',
+        }
+      ),
+      generateCVR(
+        electionWithMsEitherNeither,
+        {
+          '750000017': ['no'],
+          '750000018': ['yes', 'no'],
+          '750000015': ['no'],
+          '750000016': ['no'],
+        },
+        { _precinctId: '6522', _ballotStyleId: '5', _scannerId: 'scanner-2' }
+      ),
+      generateCVR(
+        electionWithMsEitherNeither,
+        {
+          '750000017': [],
+          '750000018': ['yes'],
+          '750000015': ['no'],
+          '750000016': ['yes'],
+        },
+        { _precinctId: '6522', _ballotStyleId: '5' }
+      ),
+      generateCVR(
+        electionWithMsEitherNeither,
+        {
+          '750000017': ['no'],
+          '750000018': ['no'],
+          '750000015': [],
+          '750000016': ['yes'],
+        },
+        {
+          _precinctId: '6538',
+          _ballotStyleId: '4',
+          _ballotType: 'absentee',
+          _scannerId: 'scanner-2',
+        }
+      ),
+      generateCVR(
+        electionWithMsEitherNeither,
+        {
+          '750000017': ['no'],
+          '750000018': ['no'],
+          '750000015': ['yes', 'no'],
+          '750000016': ['no'],
+        },
+        {
+          _precinctId: '6538',
+          _ballotStyleId: '4',
+          _ballotType: 'absentee',
+          _scannerId: 'scanner-2',
+        }
+      ),
+      generateCVR(
+        electionWithMsEitherNeither,
+        {
+          '750000017': [],
+          '750000018': [],
+          '750000015': ['yes'],
+          '750000016': [],
+        },
+        { _precinctId: '6538', _ballotStyleId: '4' }
+      ),
+      generateCVR(
+        electionWithMsEitherNeither,
+        {
+          '750000017': ['yes', 'no'],
+          '750000018': ['no', 'yes'],
+          '750000015': ['no'],
+          '750000016': ['yes', 'no'],
+        },
+        { _precinctId: '6538', _ballotStyleId: '4' }
+      ),
+    ])
+    cy.visit('/')
+    cy.get('input[type="file"]').attachFile('electionWithMsEitherNeither.json')
+    cy.contains('Election loading')
+    cy.contains('Election Hash: abdfbe6a58')
+    cy.contains('Tally').click()
+    cy.contains('Import CVR Files').click()
+    cy.get('input[data-testid="manual-input"]').attachFile({
+      fileContent: new Blob([fakeCVRFileContents]),
+      fileName: 'cvrFile.jsonl',
+      mimeType: 'text/plain',
+      encoding: 'utf-8',
+    })
+    cy.get('[data-testid="total-ballot-count"]').within(() => cy.contains('8'))
+
+    // Check that the internal tally reports have the correct tallies
+    cy.contains('View Unofficial Full Election Tally Report').click()
+    assertExpectedResultsMatchTallyReport(
+      [
+        {
+          contestId: '750000017',
+          metadata: { ballots: 8, undervotes: 2, overvotes: 1 },
+          votesByOptionId: {
+            yes: 1,
+            no: 4,
+          },
+        },
+        {
+          contestId: '750000018',
+          metadata: { ballots: 8, undervotes: 2, overvotes: 2 },
+          votesByOptionId: {
+            yes: 2,
+            no: 2,
+          },
+        },
+        {
+          contestId: '750000015',
+          metadata: { ballots: 8, undervotes: 1, overvotes: 1 },
+          votesByOptionId: {
+            yes: 3,
+            no: 3,
+          },
+        },
+        {
+          contestId: '750000016',
+          metadata: { ballots: 8, undervotes: 1, overvotes: 1 },
+          votesByOptionId: {
+            yes: 3,
+            no: 3,
+          },
+        },
+      ],
+      { absentee: 4, precinct: 4 }
+    )
+    cy.contains('Back to Tally Index').click()
+    cy.contains('View Unofficial District 5 Tally Report').click()
+    assertExpectedResultsMatchTallyReport(
+      [
+        {
+          contestId: '750000017',
+          metadata: { ballots: 4, undervotes: 1, overvotes: 0 },
+          votesByOptionId: {
+            yes: 1,
+            no: 2,
+          },
+        },
+        {
+          contestId: '750000018',
+          metadata: { ballots: 4, undervotes: 1, overvotes: 1 },
+          votesByOptionId: {
+            yes: 2,
+            no: 0,
+          },
+        },
+        {
+          contestId: '750000015',
+          metadata: { ballots: 4, undervotes: 0, overvotes: 0 },
+          votesByOptionId: {
+            yes: 2,
+            no: 2,
+          },
+        },
+        {
+          contestId: '750000016',
+          metadata: { ballots: 4, undervotes: 0, overvotes: 0 },
+          votesByOptionId: {
+            yes: 2,
+            no: 2,
+          },
+        },
+      ],
+      { absentee: 2, precinct: 2 }
+    )
+    cy.contains('Back to Tally Index').click()
+    cy.contains('View Unofficial Bywy Tally Report').click()
+    assertExpectedResultsMatchTallyReport(
+      [
+        {
+          contestId: '750000017',
+          metadata: { ballots: 4, undervotes: 1, overvotes: 1 },
+          votesByOptionId: {
+            yes: 0,
+            no: 2,
+          },
+        },
+        {
+          contestId: '750000018',
+          metadata: { ballots: 4, undervotes: 1, overvotes: 1 },
+          votesByOptionId: {
+            yes: 0,
+            no: 2,
+          },
+        },
+        {
+          contestId: '750000015',
+          metadata: { ballots: 4, undervotes: 1, overvotes: 1 },
+          votesByOptionId: {
+            yes: 1,
+            no: 1,
+          },
+        },
+        {
+          contestId: '750000016',
+          metadata: { ballots: 4, undervotes: 1, overvotes: 1 },
+          votesByOptionId: {
+            yes: 1,
+            no: 1,
+          },
+        },
+      ],
+      { absentee: 2, precinct: 2 }
+    )
+    cy.contains('Back to Tally Index').click()
+    cy.contains('View Unofficial Panhandle Tally Report').click()
+    assertExpectedResultsMatchTallyReport(
+      [
+        {
+          contestId: '750000017',
+          metadata: { ballots: 0, undervotes: 0, overvotes: 0 },
+          votesByOptionId: {
+            yes: 0,
+            no: 0,
+          },
+        },
+        {
+          contestId: '750000018',
+          metadata: { ballots: 0, undervotes: 0, overvotes: 0 },
+          votesByOptionId: {
+            yes: 0,
+            no: 0,
+          },
+        },
+        {
+          contestId: '750000015',
+          metadata: { ballots: 0, undervotes: 0, overvotes: 0 },
+          votesByOptionId: {
+            yes: 0,
+            no: 0,
+          },
+        },
+        {
+          contestId: '750000016',
+          metadata: { ballots: 0, undervotes: 0, overvotes: 0 },
+          votesByOptionId: {
+            yes: 0,
+            no: 0,
+          },
+        },
+      ],
+      { absentee: 0, precinct: 0 }
+    )
+    cy.contains('Back to Tally Index').click()
+    cy.contains('View Unofficial Absentee Ballot Tally Report').click()
+    assertExpectedResultsMatchTallyReport(
+      [
+        {
+          contestId: '750000017',
+          metadata: { ballots: 4, undervotes: 0, overvotes: 0 },
+          votesByOptionId: {
+            yes: 1,
+            no: 3,
+          },
+        },
+        {
+          contestId: '750000018',
+          metadata: { ballots: 4, undervotes: 1, overvotes: 0 },
+          votesByOptionId: {
+            yes: 1,
+            no: 2,
+          },
+        },
+        {
+          contestId: '750000015',
+          metadata: { ballots: 4, undervotes: 1, overvotes: 1 },
+          votesByOptionId: {
+            yes: 2,
+            no: 0,
+          },
+        },
+        {
+          contestId: '750000016',
+          metadata: { ballots: 4, undervotes: 0, overvotes: 0 },
+          votesByOptionId: {
+            yes: 2,
+            no: 2,
+          },
+        },
+      ],
+      { hide: true }
+    )
+    cy.contains('Back to Tally Index').click()
+    cy.contains('View Unofficial Precinct Ballot Tally Report').click()
+    assertExpectedResultsMatchTallyReport(
+      [
+        {
+          contestId: '750000017',
+          metadata: { ballots: 4, undervotes: 2, overvotes: 1 },
+          votesByOptionId: {
+            yes: 0,
+            no: 1,
+          },
+        },
+        {
+          contestId: '750000018',
+          metadata: { ballots: 4, undervotes: 1, overvotes: 2 },
+          votesByOptionId: {
+            yes: 1,
+            no: 0,
+          },
+        },
+        {
+          contestId: '750000015',
+          metadata: { ballots: 4, undervotes: 0, overvotes: 0 },
+          votesByOptionId: {
+            yes: 1,
+            no: 3,
+          },
+        },
+        {
+          contestId: '750000016',
+          metadata: { ballots: 4, undervotes: 1, overvotes: 1 },
+          votesByOptionId: {
+            yes: 1,
+            no: 1,
+          },
+        },
+      ],
+      { hide: true }
+    )
+    cy.contains('Back to Tally Index').click()
+    cy.contains('View Unofficial Scanner scanner-1 Tally Report').click()
+    assertExpectedResultsMatchTallyReport(
+      [
+        {
+          contestId: '750000017',
+          metadata: { ballots: 4, undervotes: 2, overvotes: 1 },
+          votesByOptionId: {
+            yes: 1,
+            no: 0,
+          },
+        },
+        {
+          contestId: '750000018',
+          metadata: { ballots: 4, undervotes: 2, overvotes: 1 },
+          votesByOptionId: {
+            yes: 1,
+            no: 0,
+          },
+        },
+        {
+          contestId: '750000015',
+          metadata: { ballots: 4, undervotes: 0, overvotes: 0 },
+          votesByOptionId: {
+            yes: 2,
+            no: 2,
+          },
+        },
+        {
+          contestId: '750000016',
+          metadata: { ballots: 4, undervotes: 1, overvotes: 1 },
+          votesByOptionId: {
+            yes: 1,
+            no: 1,
+          },
+        },
+      ],
+      { absentee: 1, precinct: 3 }
+    )
+    cy.contains('Back to Tally Index').click()
+    cy.contains('View Unofficial Scanner scanner-2 Tally Report').click()
+    assertExpectedResultsMatchTallyReport(
+      [
+        {
+          contestId: '750000017',
+          metadata: { ballots: 4, undervotes: 0, overvotes: 0 },
+          votesByOptionId: {
+            yes: 0,
+            no: 4,
+          },
+        },
+        {
+          contestId: '750000018',
+          metadata: { ballots: 4, undervotes: 0, overvotes: 1 },
+          votesByOptionId: {
+            yes: 1,
+            no: 2,
+          },
+        },
+        {
+          contestId: '750000015',
+          metadata: { ballots: 4, undervotes: 1, overvotes: 1 },
+          votesByOptionId: {
+            yes: 1,
+            no: 1,
+          },
+        },
+        {
+          contestId: '750000016',
+          metadata: { ballots: 4, undervotes: 0, overvotes: 0 },
+          votesByOptionId: {
+            yes: 2,
+            no: 2,
+          },
+        },
+      ],
+      { absentee: 3, precinct: 1 }
+    )
+    cy.contains('Back to Tally Index').click()
+
+    // Check that the exported SEMS result file as the correct tallies
+    cy.contains('Save Results File').click()
+    cy.get('[data-testid="manual-export"]').click()
+    cy.contains('Results Saved')
+    cy.task<string>('readMostRecentFile', 'cypress/downloads').then(
+      (fileContent) => {
+        assertExpectedResultsMatchSEMsFile(
+          [
+            {
+              contestId: '750000017',
+              precinctId: '6522',
+              candidateId: '750000094',
+              numberOfVotes: 1,
+            },
+            {
+              contestId: '750000017',
+              precinctId: '6522',
+              candidateId: '750000095',
+              numberOfVotes: 2,
+            },
+            {
+              contestId: '750000017',
+              precinctId: '6522',
+              candidateId: '1', // overvotes
+              numberOfVotes: 0,
+            },
+            {
+              contestId: '750000017',
+              precinctId: '6522',
+              candidateId: '2', // undervotes
+              numberOfVotes: 1,
+            },
+            {
+              contestId: '750000018',
+              precinctId: '6522',
+              candidateId: '750000092',
+              numberOfVotes: 2,
+            },
+            {
+              contestId: '750000018',
+              precinctId: '6522',
+              candidateId: '750000093',
+              numberOfVotes: 0,
+            },
+            {
+              contestId: '750000018',
+              precinctId: '6522',
+              candidateId: '1', // overvotes
+              numberOfVotes: 1,
+            },
+            {
+              contestId: '750000018',
+              precinctId: '6522',
+              candidateId: '2', // undervotes
+              numberOfVotes: 1,
+            },
+            {
+              contestId: '750000015',
+              precinctId: '6522',
+              candidateId: '750000088',
+              numberOfVotes: 2,
+            },
+            {
+              contestId: '750000015',
+              precinctId: '6522',
+              candidateId: '750000089',
+              numberOfVotes: 2,
+            },
+            {
+              contestId: '750000015',
+              precinctId: '6522',
+              candidateId: '1', // overvotes
+              numberOfVotes: 0,
+            },
+            {
+              contestId: '750000015',
+              precinctId: '6522',
+              candidateId: '2', // undervotes
+              numberOfVotes: 0,
+            },
+            {
+              contestId: '750000016',
+              precinctId: '6522',
+              candidateId: '750000090',
+              numberOfVotes: 2,
+            },
+            {
+              contestId: '750000016',
+              precinctId: '6522',
+              candidateId: '750000091',
+              numberOfVotes: 2,
+            },
+            {
+              contestId: '750000016',
+              precinctId: '6522',
+              candidateId: '1', // overvotes
+              numberOfVotes: 0,
+            },
+            {
+              contestId: '750000016',
+              precinctId: '6522',
+              candidateId: '2', // undervotes
+              numberOfVotes: 0,
+            },
+            {
+              contestId: '750000017',
+              precinctId: '6538',
+              candidateId: '750000094',
+              numberOfVotes: 0,
+            },
+            {
+              contestId: '750000017',
+              precinctId: '6538',
+              candidateId: '750000095',
+              numberOfVotes: 2,
+            },
+            {
+              contestId: '750000017',
+              precinctId: '6538',
+              candidateId: '1', // overvotes
+              numberOfVotes: 1,
+            },
+            {
+              contestId: '750000017',
+              precinctId: '6538',
+              candidateId: '2', // undervotes
+              numberOfVotes: 1,
+            },
+            {
+              contestId: '750000018',
+              precinctId: '6538',
+              candidateId: '750000092',
+              numberOfVotes: 0,
+            },
+            {
+              contestId: '750000018',
+              precinctId: '6538',
+              candidateId: '750000093',
+              numberOfVotes: 2,
+            },
+            {
+              contestId: '750000018',
+              precinctId: '6538',
+              candidateId: '1', // overvotes
+              numberOfVotes: 1,
+            },
+            {
+              contestId: '750000018',
+              precinctId: '6538',
+              candidateId: '2', // undervotes
+              numberOfVotes: 1,
+            },
+            {
+              contestId: '750000015',
+              precinctId: '6538',
+              candidateId: '750000088',
+              numberOfVotes: 1,
+            },
+            {
+              contestId: '750000015',
+              precinctId: '6538',
+              candidateId: '750000089',
+              numberOfVotes: 1,
+            },
+            {
+              contestId: '750000015',
+              precinctId: '6538',
+              candidateId: '1', // overvotes
+              numberOfVotes: 1,
+            },
+            {
+              contestId: '750000015',
+              precinctId: '6538',
+              candidateId: '2', // undervotes
+              numberOfVotes: 1,
+            },
+            {
+              contestId: '750000016',
+              precinctId: '6538',
+              candidateId: '750000090',
+              numberOfVotes: 1,
+            },
+            {
+              contestId: '750000016',
+              precinctId: '6538',
+              candidateId: '750000091',
+              numberOfVotes: 1,
+            },
+            {
+              contestId: '750000016',
+              precinctId: '6538',
+              candidateId: '1', // overvotes
+              numberOfVotes: 1,
+            },
+            {
+              contestId: '750000016',
+              precinctId: '6538',
+              candidateId: '2', // undervotes
+              numberOfVotes: 1,
+            },
+            {
+              contestId: '775020870',
+              precinctId: '6538',
+              candidateId: '2', // undervotes
+              numberOfVotes: 4,
+            },
+            {
+              contestId: '775020870',
+              precinctId: '6522',
+              candidateId: '2', // undervotes
+              numberOfVotes: 4,
+            },
+            {
+              contestId: '775020872',
+              precinctId: '6538',
+              candidateId: '2', // undervotes
+              numberOfVotes: 4,
+            },
+            {
+              contestId: '775020872',
+              precinctId: '6522',
+              candidateId: '2', // undervotes
+              numberOfVotes: 4,
+            },
+            {
+              contestId: '775020876',
+              precinctId: '6538',
+              candidateId: '2', // undervotes
+              numberOfVotes: 4,
+            },
+            {
+              contestId: '775020876',
+              precinctId: '6522',
+              candidateId: '2', // undervotes
+              numberOfVotes: 4,
+            },
+            {
+              contestId: '775020877',
+              precinctId: '6538',
+              candidateId: '2', // undervotes
+              numberOfVotes: 4,
+            },
+            {
+              contestId: '775020877',
+              precinctId: '6522',
+              candidateId: '2', // undervotes
+              numberOfVotes: 4,
+            },
+            {
+              contestId: '775020903',
+              precinctId: '6538',
+              candidateId: '2', // undervotes
+              numberOfVotes: 4,
+            },
+            {
+              contestId: '775020903',
+              precinctId: '6522',
+              candidateId: '2', // undervotes
+              numberOfVotes: 4,
+            },
+            {
+              contestId: '775020904',
+              precinctId: '6538',
+              candidateId: '2', // undervotes
+              numberOfVotes: 4,
+            },
+            {
+              contestId: '775020904',
+              precinctId: '6522',
+              candidateId: '2', // undervotes
+              numberOfVotes: 4,
+            },
+            {
+              contestId: '775020899',
+              precinctId: '6538',
+              candidateId: '2', // undervotes
+              numberOfVotes: 4,
+            },
+            {
+              contestId: '775020899',
+              precinctId: '6522',
+              candidateId: '2', // undervotes
+              numberOfVotes: 4,
+            },
+          ],
+          fileContent
+        )
+      }
+    )
+  })
+})

--- a/integration-testing/election-manager/cypress/tsconfig.json
+++ b/integration-testing/election-manager/cypress/tsconfig.json
@@ -21,6 +21,7 @@
   "include": ["**/*.ts"],
   "references": [
     { "path": "../../../libs/fixtures" },
-    { "path": "../../../libs/test-utils" }
+    { "path": "../../../libs/test-utils" },
+    { "path": "../../../libs/types" }
   ]
 }

--- a/integration-testing/election-manager/package.json
+++ b/integration-testing/election-manager/package.json
@@ -43,6 +43,7 @@
     "@typescript-eslint/parser": "^4.16.1",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
+    "@votingworks/types": "workspace:*",
     "cypress": "^7.5.0",
     "cypress-file-upload": "^5.0.7",
     "eslint": "^7.17.0",

--- a/libs/test-utils/src/castVoteRecord.ts
+++ b/libs/test-utils/src/castVoteRecord.ts
@@ -2,6 +2,7 @@ import {
   CastVoteRecord,
   Dictionary,
   Election,
+  expandEitherNeitherContests,
   getBallotStyle,
   getContests,
 } from '@votingworks/types'
@@ -25,7 +26,7 @@ export function generateCVR(
   const _ballotStyleId = options._ballotStyleId ?? election.ballotStyles[0].id
   const _ballotId = options._ballotId ?? ''
   const _ballotType = options._ballotType ?? 'standard'
-  const _testBallot = !!options._ballotType // default to false
+  const _testBallot = !!options._testBallot // default to false
   const _scannerId = options._scannerId ?? 'scanner-1'
 
   // Add in blank votes for any contest in the ballot style not specified.
@@ -34,7 +35,9 @@ export function generateCVR(
       ballotStyleId: _ballotStyleId,
       election,
     }) || election.ballotStyles[0]
-  const contestsInBallot = getContests({ ballotStyle, election })
+  const contestsInBallot = expandEitherNeitherContests(
+    getContests({ ballotStyle, election })
+  )
   const allVotes: Dictionary<string[]> = {}
   contestsInBallot.forEach((contest) => {
     allVotes[contest.id] = contest.id in votes ? votes[contest.id] : []

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -967,6 +967,7 @@ importers:
       '@typescript-eslint/parser': 4.26.1_eslint@7.28.0+typescript@4.2.4
       '@votingworks/fixtures': link:../../libs/fixtures
       '@votingworks/test-utils': link:../../libs/test-utils
+      '@votingworks/types': link:../../libs/types
       cypress: 7.5.0
       cypress-file-upload: 5.0.7_cypress@7.5.0
       eslint: 7.28.0
@@ -992,6 +993,7 @@ importers:
       '@typescript-eslint/parser': ^4.16.1
       '@votingworks/fixtures': workspace:*
       '@votingworks/test-utils': workspace:*
+      '@votingworks/types': workspace:*
       cypress: ^7.5.0
       cypress-file-upload: ^5.0.7
       eslint: ^7.17.0


### PR DESCRIPTION
Adds an integration test for tallying yes/no and either/neither contests. This test has more splits across different precincts/ballot types/scanners then the candidate contest integration test so it also tests that the tally report breakdowns all work as expected. 

Video (not really sure why this is in a weird aspect ratio) 

https://user-images.githubusercontent.com/14897017/124307404-a47aa380-db1c-11eb-8d1d-8e1f9d6b5d63.mp4


