### PR TITLE
style: configure format-on-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,8 @@
+#!/bin/bash
+. "$(dirname "$0")/_/husky.sh"
+
+# Run `pre-commit` script in packages changed since the last commit.
+pnpm \
+  --workspace-concurrency=1 \
+  --filter='[HEAD]' \
+  run --if-present pre-commit

--- a/apps/bas/package.json
+++ b/apps/bas/package.json
@@ -19,29 +19,23 @@
     "stylelint:run:fix": "stylelint 'src/**/*.{js,jsx,ts,tsx}' --fix && stylelint 'src/**/*.css' --config .stylelintrc-css.js --fix",
     "test": "is-ci test:coverage test:watch",
     "test:watch": "script/react-scripts test",
-    "test:coverage": "script/react-scripts test --coverage --watchAll=false"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "tsc --build && lint-staged"
-    }
+    "test:coverage": "script/react-scripts test --coverage --watchAll=false",
+    "pre-commit": "lint-staged"
   },
   "lint-staged": {
-    "linters": {
-      "*.+(js|jsx|ts|tsx)": [
-        "stylelint --fix",
-        "eslint --quiet --fix",
-        "git add"
-      ],
-      "*.css": [
-        "stylelint --config .stylelintrc-css.js --fix",
-        "git add"
-      ],
-      "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-        "prettier --write",
-        "git add"
-      ]
-    }
+    "*.+(js|jsx|ts|tsx)": [
+      "stylelint --fix",
+      "eslint --quiet --fix"
+    ],
+    "*.css": [
+      "stylelint --config .stylelintrc-css.js --fix"
+    ],
+    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
+      "prettier --write"
+    ],
+    "package.json": [
+      "sort-package-json"
+    ]
   },
   "browserslist": {
     "production": [
@@ -92,10 +86,10 @@
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-vx": "workspace:*",
-    "husky": "^2.1.0",
     "is-ci-cli": "^2.1.2",
     "lint-staged": "^8.1.5",
     "prettier": "^2.1.2",
+    "sort-package-json": "^1.50.0",
     "stylelint": "^13.7.2",
     "stylelint-config-palantir": "^5.0.0",
     "stylelint-config-prettier": "^8.0.2",

--- a/apps/bmd/package.json
+++ b/apps/bmd/package.json
@@ -26,12 +26,8 @@
     "test:e2e:ci": "start-server-and-test start http://localhost:3000 cypress:run",
     "test:e2e:watch": "start-server-and-test start http://localhost:3000 cypress:open",
     "test:update": "TZ=UTC script/react-scripts test -u  --watchAll=false --env=jest-environment-jsdom-sixteen",
-    "test:watch": "TZ=UTC script/react-scripts test --env=jest-environment-jsdom-sixteen"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "tsc --build && lint-staged"
-    }
+    "test:watch": "TZ=UTC script/react-scripts test --env=jest-environment-jsdom-sixteen",
+    "pre-commit": "lint-staged"
   },
   "lint-staged": {
     "*.+(js|jsx|ts|tsx)": [
@@ -43,6 +39,9 @@
     ],
     "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
       "prettier --write"
+    ],
+    "package.json": [
+      "sort-package-json"
     ]
   },
   "browserslist": {
@@ -148,7 +147,6 @@
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-vx": "workspace:*",
-    "husky": "^4.2.5",
     "is-ci-cli": "^2.0.0",
     "jest-date-mock": "^1.0.8",
     "jest-environment-jsdom-sixteen": "^1.0.3",
@@ -157,6 +155,7 @@
     "lint-staged": "^10.2.4",
     "prettier": "^2.1.1",
     "react-dev-utils": "^11.0.3",
+    "sort-package-json": "^1.50.0",
     "start-server-and-test": "^1.11.0",
     "stylelint": "^13.3.3",
     "stylelint-config-palantir": "^4.0.1",

--- a/apps/bsd/package.json
+++ b/apps/bsd/package.json
@@ -20,12 +20,8 @@
     "test": "is-ci test:coverage test:watch",
     "test:watch": "TZ=UTC script/react-scripts test --env=jest-environment-jsdom-sixteen",
     "test:coverage": "TZ=UTC script/react-scripts test --coverage --watchAll=false",
-    "test:debug": "TZ=UTC script/react-scripts --inspect-brk test --runInBand --no-cache"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "tsc && lint-staged"
-    }
+    "test:debug": "TZ=UTC script/react-scripts --inspect-brk test --runInBand --no-cache",
+    "pre-commit": "lint-staged"
   },
   "lint-staged": {
     "*.+(js|jsx|ts|tsx)": [
@@ -37,6 +33,9 @@
     ],
     "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
       "prettier --write"
+    ],
+    "package.json": [
+      "sort-package-json"
     ]
   },
   "browserslist": {
@@ -123,7 +122,6 @@
     "eslint-plugin-vx": "workspace:*",
     "fetch-mock": "^9.9.0",
     "history": "^4.10.1",
-    "husky": "^4.2.5",
     "is-ci-cli": "^2.1.2",
     "jest-environment-jsdom-sixteen": "^1.0.3",
     "jest-fetch-mock": "^3.0.3",
@@ -131,6 +129,7 @@
     "node-fetch": "^2.6.0",
     "prettier": "^2.1.2",
     "react-refresh": "^0.9.0",
+    "sort-package-json": "^1.50.0",
     "stylelint": "^13.4.0",
     "stylelint-config-palantir": "^5.0.0",
     "stylelint-config-prettier": "^8.0.1",

--- a/apps/election-manager/package.json
+++ b/apps/election-manager/package.json
@@ -19,12 +19,8 @@
     "stylelint:run:fix": "stylelint 'src/**/*.{js,jsx,ts,tsx}' --fix && stylelint 'src/**/*.css' --config .stylelintrc-css.js --fix",
     "test": "is-ci test:coverage test:watch",
     "test:watch": "TZ=PST script/react-scripts test --env=jest-environment-jsdom-sixteen",
-    "test:coverage": "TZ=PST script/react-scripts test --coverage --watchAll=false"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "tsc && lint-staged"
-    }
+    "test:coverage": "TZ=PST script/react-scripts test --coverage --watchAll=false",
+    "pre-commit": "lint-staged"
   },
   "lint-staged": {
     "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
@@ -150,14 +146,13 @@
     "eslint-plugin-react": "^7.18.3",
     "eslint-plugin-react-hooks": "^4.0.5",
     "eslint-plugin-vx": "workspace:*",
-    "husky": "^4.2.1",
     "is-ci-cli": "^2.1.2",
     "jest-environment-jsdom-sixteen": "^1.0.3",
     "lint-staged": "^10.0.7",
     "prettier": "^2.0.5",
     "react-refresh": "^0.9.0",
     "react-test-renderer": "^16.13.1",
-    "sort-package-json": "^1.44.0",
+    "sort-package-json": "^1.50.0",
     "stylelint": "^13.1.0",
     "stylelint-config-palantir": "^4.0.1",
     "stylelint-config-prettier": "^8.0.1",

--- a/apps/module-scan/package.json
+++ b/apps/module-scan/package.json
@@ -20,12 +20,8 @@
     "test:coverage": "jest --coverage",
     "test:debug": "node --inspect-brk $(which jest) --runInBand --no-cache",
     "test:watch": "jest --watch",
-    "watch": "tsc --build --watch"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "tsc --build && lint-staged"
-    }
+    "watch": "tsc --build --watch",
+    "pre-commit": "lint-staged"
   },
   "lint-staged": {
     "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
@@ -100,14 +96,13 @@
     "eslint-plugin-jest": "^24.1.3",
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-vx": "workspace:*",
-    "husky": "^4.3.7",
     "is-ci-cli": "^2.1.2",
     "jest": "^26.6.3",
     "jest-watch-typeahead": "^0.6.4",
     "lint-staged": "^10.5.3",
     "nock": "^13.1.0",
     "prettier": "^2.2.1",
-    "sort-package-json": "^1.48.1",
+    "sort-package-json": "^1.50.0",
     "supertest": "^6.0.1",
     "ts-jest": "^26.4.4",
     "ts-node": "^9.1.1",

--- a/apps/module-smartcards/README.md
+++ b/apps/module-smartcards/README.md
@@ -44,7 +44,9 @@ make coverage
 
 ## Mock a Smart Card
 
-Once you're running the server, you can enable a mock card reader with fixture data as in the examples below. Supply your own election definition, or use one of the existing [`fixtures/`](./fixtures).
+Once you're running the server, you can enable a mock card reader with fixture
+data as in the examples below. Supply your own election definition, or use one
+of the existing [`fixtures/`](./fixtures).
 
 ### Using your own election definition
 

--- a/apps/precinct-scanner/package.json
+++ b/apps/precinct-scanner/package.json
@@ -19,12 +19,8 @@
     "stylelint:run:fix": "stylelint 'src/**/*.{js,jsx,ts,tsx}' --fix && stylelint 'src/**/*.css' --config .stylelintrc-css.js --fix",
     "test": "is-ci test:coverage test:watch",
     "test:watch": "TZ=UTC script/react-scripts test --env=jest-environment-jsdom-sixteen",
-    "test:coverage": "TZ=UTC script/react-scripts test --coverage --watchAll=false"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "tsc && lint-staged"
-    }
+    "test:coverage": "TZ=UTC script/react-scripts test --coverage --watchAll=false",
+    "pre-commit": "lint-staged"
   },
   "lint-staged": {
     "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
@@ -135,13 +131,12 @@
     "eslint-plugin-react": "^7.18.3",
     "eslint-plugin-react-hooks": "^4.0.5",
     "eslint-plugin-vx": "workspace:*",
-    "husky": "^4.2.1",
     "is-ci-cli": "^2.1.2",
     "jest-environment-jsdom-sixteen": "^1.0.3",
-    "lint-staged": "^10.0.7",
+    "lint-staged": "^10.5.4",
     "prettier": "^2.0.5",
     "react-refresh": "^0.9.0",
-    "sort-package-json": "^1.44.0",
+    "sort-package-json": "^1.50.0",
     "stylelint": "^13.1.0",
     "stylelint-config-palantir": "^4.0.1",
     "stylelint-config-prettier": "^8.0.1",

--- a/integration-testing/bsd/package.json
+++ b/integration-testing/bsd/package.json
@@ -11,7 +11,19 @@
     "test": "is-ci test:ci test:watch",
     "test:ci": "start-server-and-test start http://localhost:3000 cypress:run",
     "test:watch": "cypress open",
-    "cypress:run": "cypress run --browser chrome"
+    "cypress:run": "cypress run --browser chrome",
+    "pre-commit": "lint-staged"
+  },
+  "lint-staged": {
+    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
+      "prettier --write"
+    ],
+    "*.+(js|jsx|ts|tsx)": [
+      "eslint --quiet --fix"
+    ],
+    "package.json": [
+      "sort-package-json"
+    ]
   },
   "browserslist": {
     "production": [
@@ -43,12 +55,11 @@
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-vx": "workspace:*",
-    "husky": "^4.2.1",
     "is-ci-cli": "^2.1.2",
     "jest-environment-jsdom-sixteen": "^1.0.3",
-    "lint-staged": "^10.0.7",
+    "lint-staged": "^10.5.4",
     "prettier": "^2.0.5",
-    "sort-package-json": "^1.44.0",
+    "sort-package-json": "^1.50.0",
     "start-server-and-test": "^1.12.5",
     "typescript": "^4.2.0"
   }

--- a/integration-testing/election-manager/package.json
+++ b/integration-testing/election-manager/package.json
@@ -11,7 +11,19 @@
     "test": "is-ci test:ci test:watch",
     "test:ci": "start-server-and-test start http://localhost:3000 cypress:run",
     "test:watch": "cypress open",
-    "cypress:run": "cypress run --browser chrome"
+    "cypress:run": "cypress run --browser chrome",
+    "pre-commit": "lint-staged"
+  },
+  "lint-staged": {
+    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
+      "prettier --write"
+    ],
+    "*.+(js|jsx|ts|tsx)": [
+      "eslint --quiet --fix"
+    ],
+    "package.json": [
+      "sort-package-json"
+    ]
   },
   "browserslist": {
     "production": [
@@ -45,8 +57,9 @@
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-vx": "workspace:*",
     "is-ci-cli": "^2.1.2",
+    "lint-staged": "^11.0.0",
     "prettier": "^2.0.5",
-    "sort-package-json": "^1.44.0",
+    "sort-package-json": "^1.50.0",
     "start-server-and-test": "^1.12.5",
     "typescript": "^4.2.0"
   }

--- a/libs/ballot-encoder/package.json
+++ b/libs/ballot-encoder/package.json
@@ -15,25 +15,18 @@
     "test:ci": "jest --ci --coverage",
     "test:coverage": "jest --coverage",
     "test:debug": "node --inspect-brk $(which jest) --runInBand --no-cache",
-    "test:watch": "jest --watch"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
+    "test:watch": "jest --watch",
+    "pre-commit": "lint-staged"
   },
   "lint-staged": {
     "*.(js|ts)": [
-      "eslint --quiet --fix",
-      "git add"
+      "eslint --quiet --fix"
     ],
     "*.md": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ],
     "package.json": [
-      "sort-package-json",
-      "git add"
+      "sort-package-json"
     ]
   },
   "dependencies": {
@@ -57,13 +50,12 @@
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-vx": "workspace:*",
-    "husky": "^4.3.0",
     "jest": "^26.6.2",
     "jest-watch-typeahead": "^0.6.1",
     "lint-staged": "^10.5.1",
     "prettier": "^2.1.2",
     "random-js": "^2.1.0",
-    "sort-package-json": "^1.46.1",
+    "sort-package-json": "^1.50.0",
     "ts-jest": "^26.4.3",
     "typescript": "^4.2.0"
   },

--- a/libs/fixtures/package.json
+++ b/libs/fixtures/package.json
@@ -18,7 +18,19 @@
     "lint:fix": "eslint . --fix",
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "pre-commit": "lint-staged"
+  },
+  "lint-staged": {
+    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
+      "prettier --write"
+    ],
+    "*.+(js|jsx|ts|tsx)": [
+      "eslint --quiet --fix"
+    ],
+    "package.json": [
+      "sort-package-json"
+    ]
   },
   "dependencies": {
     "@votingworks/types": "workspace:*",
@@ -39,7 +51,9 @@
     "eslint-plugin-prettier": "^3.3.1",
     "jest": "^26.6.3",
     "jest-watch-typeahead": "^0.6.4",
+    "lint-staged": "^11.0.0",
     "prettier": "^2.2.1",
+    "sort-package-json": "^1.50.0",
     "ts-jest": "^26.5.0",
     "typescript": "^4.2.0"
   }

--- a/libs/hmpb-interpreter/package.json
+++ b/libs/hmpb-interpreter/package.json
@@ -25,12 +25,8 @@
     "test": "jest",
     "test:all": "REGRESSION_TESTS=1 jest",
     "test:coverage": "jest --coverage",
-    "test:watch": "jest --watch"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "tsc --build --noEmit && lint-staged"
-    }
+    "test:watch": "jest --watch",
+    "pre-commit": "lint-staged"
   },
   "lint-staged": {
     "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
@@ -74,13 +70,12 @@
     "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-vx": "workspace:*",
-    "husky": "^4.3.0",
     "jest": "^26.6.0",
     "jest-watch-typeahead": "^0.6.4",
     "lint-staged": "^10.4.2",
     "memorystream": "^0.3.1",
     "prettier": "^2.1.2",
-    "sort-package-json": "^1.46.1",
+    "sort-package-json": "^1.50.0",
     "tmp": "^0.2.1",
     "ts-jest": "^26.4.1",
     "ts-node": "^9.0.0",

--- a/libs/lsd/package.json
+++ b/libs/lsd/package.json
@@ -20,7 +20,19 @@
     "lint:fix": "eslint . --fix",
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "pre-commit": "lint-staged"
+  },
+  "lint-staged": {
+    "*.(js|ts)": [
+      "eslint --quiet --fix"
+    ],
+    "*.md": [
+      "prettier --write"
+    ],
+    "package.json": [
+      "sort-package-json"
+    ]
   },
   "dependencies": {
     "bindings": "^1.5.0",
@@ -42,8 +54,10 @@
     "eslint-plugin-promise": "^4.2.1",
     "jest": "^26.6.3",
     "jest-watch-typeahead": "^0.6.4",
+    "lint-staged": "^11.0.0",
     "memory-streams": "^0.1.3",
     "prettier": "^2.2.1",
+    "sort-package-json": "^1.50.0",
     "ts-jest": "^26.5.0",
     "typescript": "^4.2.0"
   },

--- a/libs/plustek-sdk/package.json
+++ b/libs/plustek-sdk/package.json
@@ -18,7 +18,13 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint:fix": "eslint . --fix",
+    "pre-commit": "lint-staged"
+  },
+  "lint-staged": {
+    "package.json": "sort-package-json",
+    "**/*.{ts,js,tsx,jsx}": "eslint --fix",
+    "**/*.{md,json}": "prettier --write"
   },
   "dependencies": {
     "@votingworks/types": "workspace:*",
@@ -38,7 +44,9 @@
     "eslint": "^7.25.0",
     "jest": "^26.6.3",
     "jest-watch-typeahead": "^0.6.4",
+    "lint-staged": "^11.0.0",
     "prettier": "^2.2.1",
+    "sort-package-json": "^1.50.0",
     "ts-jest": "^26.5.5",
     "ts-node": "^9.1.1",
     "typescript": "^4.2.4"

--- a/libs/test-utils/package.json
+++ b/libs/test-utils/package.json
@@ -16,7 +16,19 @@
     "lint:fix": "eslint . --fix",
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "pre-commit": "lint-staged"
+  },
+  "lint-staged": {
+    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
+      "prettier --write"
+    ],
+    "*.+(js|jsx|ts|tsx)": [
+      "eslint --quiet --fix"
+    ],
+    "package.json": [
+      "sort-package-json"
+    ]
   },
   "dependencies": {
     "@testing-library/react": "^11.2.6",
@@ -35,9 +47,11 @@
     "eslint": "^7.28.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^3.4.0",
+    "lint-staged": "^11.0.0",
     "prettier": "^2.3.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
+    "sort-package-json": "^1.50.0",
     "typescript": "^4.2.3"
   }
 }

--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -18,7 +18,19 @@
     "lint:fix": "eslint . --fix",
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "pre-commit": "lint-staged"
+  },
+  "lint-staged": {
+    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
+      "prettier --write"
+    ],
+    "*.+(js|jsx|ts|tsx)": [
+      "eslint --quiet --fix"
+    ],
+    "package.json": [
+      "sort-package-json"
+    ]
   },
   "dependencies": {
     "@antongolub/iso8601": "^1.2.1",
@@ -36,7 +48,9 @@
     "eslint-plugin-prettier": "^3.3.1",
     "jest": "^26.6.3",
     "jest-watch-typeahead": "^0.6.4",
+    "lint-staged": "^11.0.0",
     "prettier": "^2.2.1",
+    "sort-package-json": "^1.50.0",
     "ts-jest": "^26.5.0",
     "typescript": "^4.2.0"
   }

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -18,12 +18,8 @@
     "stylelint:run": "stylelint 'src/**/*.{js,jsx,ts,tsx}'",
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "test:watch": "jest --watch"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "tsc && lint-staged"
-    }
+    "test:watch": "jest --watch",
+    "pre-commit": "lint-staged"
   },
   "lint-staged": {
     "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
@@ -68,9 +64,10 @@
     "eslint-plugin-vx": "workspace:*",
     "jest": "^26.6.3",
     "jest-watch-typeahead": "^0.6.4",
+    "lint-staged": "^11.0.0",
     "prettier": "^2.1.1",
     "react": "^17.0.1",
-    "sort-package-json": "^1.44.0",
+    "sort-package-json": "^1.50.0",
     "stylelint": "^13.1.0",
     "stylelint-config-palantir": "^4.0.1",
     "stylelint-config-prettier": "^8.0.1",

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -18,7 +18,19 @@
     "test": "TZ=UTC jest",
     "test:watch": "TZ=UTC jest --watch",
     "test:coverage": "TZ=UTC jest --coverage",
-    "test:ci": "TZ=UTC pnpm build && pnpm test:coverage"
+    "test:ci": "TZ=UTC pnpm build && pnpm test:coverage",
+    "pre-commit": "lint-staged"
+  },
+  "lint-staged": {
+    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
+      "prettier --write"
+    ],
+    "*.+(js|jsx|ts|tsx)": [
+      "eslint --quiet --fix"
+    ],
+    "package.json": [
+      "sort-package-json"
+    ]
   },
   "dependencies": {
     "@types/node": "^12.20.11",
@@ -48,7 +60,9 @@
     "eslint-plugin-vx": "workspace:*",
     "jest": "^26.6.3",
     "jest-watch-typeahead": "^0.6.4",
+    "lint-staged": "^11.0.0",
     "prettier": "^2.3.0",
+    "sort-package-json": "^1.50.0",
     "ts-jest": "^26.5.6",
     "typescript": "^4.2.4"
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,19 @@
 {
   "name": "vxsuite",
   "private": true,
+  "scripts": {
+    "prepare": "husky install"
+  },
+  "lint-staged": {
+    "package.json": "sort-package-json",
+    "*.ts,*.md,*.json": "prettier --write"
+  },
   "devDependencies": {
-    "ora": "^5.2.0"
+    "eslint": "^7.29.0",
+    "husky": "^7.0.0",
+    "lint-staged": "^11.0.0",
+    "ora": "^5.2.0",
+    "prettier": "^2.3.2",
+    "sort-package-json": "^1.50.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,19 @@
 importers:
   .:
     devDependencies:
+      eslint: 7.29.0
+      husky: 7.0.0
+      lint-staged: 11.0.0
       ora: 5.2.0
+      prettier: 2.3.2
+      sort-package-json: 1.50.0
     specifiers:
+      eslint: ^7.29.0
+      husky: ^7.0.0
+      lint-staged: ^11.0.0
       ora: ^5.2.0
+      prettier: ^2.3.2
+      sort-package-json: ^1.50.0
   apps/bas:
     dependencies:
       '@types/jest': 24.0.11
@@ -38,10 +48,10 @@ importers:
       eslint-plugin-prettier: 3.3.1_18bc709ad1b4fcdd674db622dfd1f758
       eslint-plugin-react: 7.22.0_eslint@7.17.0
       eslint-plugin-vx: link:../../libs/eslint-plugin-vx
-      husky: 2.7.0
       is-ci-cli: 2.1.2
       lint-staged: 8.2.1
       prettier: 2.2.1
+      sort-package-json: 1.50.0
       stylelint: 13.8.0
       stylelint-config-palantir: 5.0.0_stylelint@13.8.0
       stylelint-config-prettier: 8.0.2_stylelint@13.8.0
@@ -71,7 +81,6 @@ importers:
       eslint-plugin-react: ^7.21.5
       eslint-plugin-vx: workspace:*
       http-proxy-middleware: 1.0.6
-      husky: ^2.1.0
       is-ci-cli: ^2.1.2
       lint-staged: ^8.1.5
       luxon: ^1.27.0
@@ -81,6 +90,7 @@ importers:
       react: ^17.0.1
       react-dom: ^17.0.1
       react-scripts: 4.0.1
+      sort-package-json: ^1.50.0
       styled-components: ^5.2.1
       stylelint: ^13.7.2
       stylelint-config-palantir: ^5.0.0
@@ -162,7 +172,6 @@ importers:
       eslint-plugin-prettier: 3.3.1_69979e61f6e4e06807b16d761b81a74d
       eslint-plugin-react: 7.22.0_eslint@7.17.0
       eslint-plugin-vx: link:../../libs/eslint-plugin-vx
-      husky: 4.3.7
       is-ci-cli: 2.1.2
       jest-date-mock: 1.0.8
       jest-environment-jsdom-sixteen: 1.0.3
@@ -171,6 +180,7 @@ importers:
       lint-staged: 10.5.3
       prettier: 2.2.1
       react-dev-utils: 11.0.3
+      sort-package-json: 1.50.0
       start-server-and-test: 1.11.7
       stylelint: 13.8.0
       stylelint-config-palantir: 4.0.1_stylelint@13.8.0
@@ -225,7 +235,6 @@ importers:
       fetch-mock: ^9.5.0
       history: ^4.10.1
       http-proxy-middleware: 1.0.6
-      husky: ^4.2.5
       is-ci-cli: ^2.0.0
       jest-date-mock: ^1.0.8
       jest-environment-jsdom-sixteen: ^1.0.3
@@ -248,6 +257,7 @@ importers:
       react-router-dom: ^5.2.0
       react-scripts: 3.4.0
       rxjs: ^6.6.6
+      sort-package-json: ^1.50.0
       start-server-and-test: ^1.11.0
       styled-components: ^4.4.1
       stylelint: ^13.3.3
@@ -323,7 +333,6 @@ importers:
       eslint-plugin-vx: link:../../libs/eslint-plugin-vx
       fetch-mock: 9.11.0
       history: 4.10.1
-      husky: 4.3.7
       is-ci-cli: 2.1.2
       jest-environment-jsdom-sixteen: 1.0.3
       jest-fetch-mock: 3.0.3
@@ -331,6 +340,7 @@ importers:
       node-fetch: 2.6.1
       prettier: 2.2.1
       react-refresh: 0.9.0
+      sort-package-json: 1.50.0
       stylelint: 13.8.0
       stylelint-config-palantir: 5.0.0_stylelint@13.8.0
       stylelint-config-prettier: 8.0.2_stylelint@13.8.0
@@ -379,7 +389,6 @@ importers:
       fetch-mock: ^9.9.0
       history: ^4.10.1
       http-proxy-middleware: 1.0.6
-      husky: ^4.2.5
       is-ci-cli: ^2.1.2
       jest-environment-jsdom-sixteen: ^1.0.3
       jest-fetch-mock: ^3.0.3
@@ -398,6 +407,7 @@ importers:
       react-router-dom: ^5.2.0
       react-scripts: 4.0.1
       rxjs: ^6.6.6
+      sort-package-json: ^1.50.0
       styled-components: ^5.2.1
       stylelint: ^13.4.0
       stylelint-config-palantir: ^5.0.0
@@ -494,14 +504,13 @@ importers:
       eslint-plugin-react: 7.22.0_eslint@7.17.0
       eslint-plugin-react-hooks: 4.2.0_eslint@7.17.0
       eslint-plugin-vx: link:../../libs/eslint-plugin-vx
-      husky: 4.3.7
       is-ci-cli: 2.1.2
       jest-environment-jsdom-sixteen: 1.0.3
       lint-staged: 10.5.3
       prettier: 2.2.1
       react-refresh: 0.9.0
       react-test-renderer: 16.14.0_react@17.0.1
-      sort-package-json: 1.48.1
+      sort-package-json: 1.50.0
       stylelint: 13.8.0
       stylelint-config-palantir: 4.0.1_stylelint@13.8.0
       stylelint-config-prettier: 8.0.2_stylelint@13.8.0
@@ -560,7 +569,6 @@ importers:
       fetch-mock: ^9.10.7
       history: ^4.10.1
       http-proxy-middleware: 1.0.6
-      husky: ^4.2.1
       i18next: ^19.4.5
       is-ci-cli: ^2.1.2
       jest-environment-jsdom-sixteen: ^1.0.3
@@ -585,7 +593,7 @@ importers:
       react-test-renderer: ^16.13.1
       react-textarea-autosize: ^8.2.0
       rxjs: ^6.6.6
-      sort-package-json: ^1.44.0
+      sort-package-json: ^1.50.0
       styled-components: ^5.2.1
       stylelint: ^13.1.0
       stylelint-config-palantir: ^4.0.1
@@ -664,14 +672,13 @@ importers:
       eslint-plugin-jest: 24.1.3_eslint@7.17.0+typescript@4.2.3
       eslint-plugin-prettier: 3.3.1_69979e61f6e4e06807b16d761b81a74d
       eslint-plugin-vx: link:../../libs/eslint-plugin-vx
-      husky: 4.3.7
       is-ci-cli: 2.1.2
       jest: 26.6.3_canvas@2.6.1+ts-node@9.1.1
       jest-watch-typeahead: 0.6.4_jest@26.6.3
       lint-staged: 10.5.3
       nock: 13.1.0
       prettier: 2.2.1
-      sort-package-json: 1.48.1
+      sort-package-json: 1.50.0
       supertest: 6.1.1
       ts-jest: 26.4.4_jest@26.6.3+typescript@4.2.3
       ts-node: 9.1.1_typescript@4.2.3
@@ -724,7 +731,6 @@ importers:
       express: ^4.17.1
       fs-extra: ^9.0.1
       got: ^11.8.2
-      husky: ^4.3.7
       is-ci-cli: ^2.1.2
       jest: ^26.6.3
       jest-diff: ^26.6.2
@@ -739,7 +745,7 @@ importers:
       ora: ^5.2.0
       pdfjs-dist: 2.3.200
       prettier: ^2.2.1
-      sort-package-json: ^1.48.1
+      sort-package-json: ^1.50.0
       sqlite3: ^4.0.8
       supertest: ^6.0.1
       tmp: ^0.2.1
@@ -770,7 +776,7 @@ importers:
       base64-js: 1.5.1
       debug: 4.3.1
       fetch-mock: 9.11.0
-      http-proxy-middleware: 1.0.6
+      http-proxy-middleware: 1.0.6_debug@4.3.1
       i18next: 19.8.4
       jest-fetch-mock: 3.0.3
       js-file-download: 0.4.12
@@ -812,13 +818,12 @@ importers:
       eslint-plugin-react: 7.22.0_eslint@7.25.0
       eslint-plugin-react-hooks: 4.2.0_eslint@7.25.0
       eslint-plugin-vx: link:../../libs/eslint-plugin-vx
-      husky: 4.3.7
       is-ci-cli: 2.1.2
       jest-environment-jsdom-sixteen: 1.0.3
-      lint-staged: 10.5.3
+      lint-staged: 10.5.4
       prettier: 2.2.1
       react-refresh: 0.9.0
-      sort-package-json: 1.48.1
+      sort-package-json: 1.50.0
       stylelint: 13.8.0
       stylelint-config-palantir: 4.0.1_stylelint@13.8.0
       stylelint-config-prettier: 8.0.2_stylelint@13.8.0
@@ -867,14 +872,13 @@ importers:
       eslint-plugin-vx: workspace:*
       fetch-mock: ^9.11.0
       http-proxy-middleware: 1.0.6
-      husky: ^4.2.1
       i18next: ^19.4.5
       is-ci-cli: ^2.1.2
       jest-environment-jsdom-sixteen: ^1.0.3
       jest-fetch-mock: ^3.0.3
       js-file-download: ^0.4.12
       js-sha256: ^0.9.0
-      lint-staged: ^10.0.7
+      lint-staged: ^10.5.4
       luxon: ^1.26.0
       mockdate: ^3.0.5
       normalize.css: ^8.0.1
@@ -887,7 +891,7 @@ importers:
       react-router-dom: ^5.2.0
       react-scripts: 4.0.1
       rxjs: ^6.6.6
-      sort-package-json: ^1.44.0
+      sort-package-json: ^1.50.0
       styled-components: ^5.2.3
       stylelint: ^13.1.0
       stylelint-config-palantir: ^4.0.1
@@ -924,12 +928,11 @@ importers:
       eslint-plugin-jsx-a11y: 6.4.1_eslint@7.28.0
       eslint-plugin-prettier: 3.4.0_9ffac69d7e0f4c6fe45d155d53d9fe41
       eslint-plugin-vx: link:../../libs/eslint-plugin-vx
-      husky: 4.3.7
       is-ci-cli: 2.1.2
       jest-environment-jsdom-sixteen: 1.0.3
-      lint-staged: 10.5.3
+      lint-staged: 10.5.4
       prettier: 2.3.1
-      sort-package-json: 1.48.1
+      sort-package-json: 1.50.0
       start-server-and-test: 1.12.5
       typescript: 4.2.4
     specifiers:
@@ -950,12 +953,11 @@ importers:
       eslint-plugin-jsx-a11y: ^6.2.3
       eslint-plugin-prettier: ^3.1.2
       eslint-plugin-vx: workspace:*
-      husky: ^4.2.1
       is-ci-cli: ^2.1.2
       jest-environment-jsdom-sixteen: ^1.0.3
-      lint-staged: ^10.0.7
+      lint-staged: ^10.5.4
       prettier: ^2.0.5
-      sort-package-json: ^1.44.0
+      sort-package-json: ^1.50.0
       start-server-and-test: ^1.12.5
       typescript: ^4.2.0
   integration-testing/election-manager:
@@ -979,8 +981,9 @@ importers:
       eslint-plugin-prettier: 3.4.0_9ffac69d7e0f4c6fe45d155d53d9fe41
       eslint-plugin-vx: link:../../libs/eslint-plugin-vx
       is-ci-cli: 2.1.2
+      lint-staged: 11.0.0
       prettier: 2.3.1
-      sort-package-json: 1.48.1
+      sort-package-json: 1.50.0
       start-server-and-test: 1.12.5
       typescript: 4.2.4
     specifiers:
@@ -1003,8 +1006,9 @@ importers:
       eslint-plugin-prettier: ^3.1.2
       eslint-plugin-vx: workspace:*
       is-ci-cli: ^2.1.2
+      lint-staged: ^11.0.0
       prettier: ^2.0.5
-      sort-package-json: ^1.44.0
+      sort-package-json: ^1.50.0
       start-server-and-test: ^1.12.5
       typescript: ^4.2.0
   libs/@types/compress-commons:
@@ -1049,13 +1053,12 @@ importers:
       eslint-plugin-no-null: 1.0.2_eslint@7.17.0
       eslint-plugin-prettier: 3.3.1_18bc709ad1b4fcdd674db622dfd1f758
       eslint-plugin-vx: link:../eslint-plugin-vx
-      husky: 4.3.7
       jest: 26.6.3
       jest-watch-typeahead: 0.6.1_jest@26.6.3
       lint-staged: 10.5.3
       prettier: 2.2.1
       random-js: 2.1.0
-      sort-package-json: 1.48.1
+      sort-package-json: 1.50.0
       ts-jest: 26.4.4_jest@26.6.3+typescript@4.2.3
       typescript: 4.2.3
     specifiers:
@@ -1075,14 +1078,13 @@ importers:
       eslint-plugin-no-null: ^1.0.2
       eslint-plugin-prettier: ^3.1.4
       eslint-plugin-vx: workspace:*
-      husky: ^4.3.0
       jest: ^26.6.2
       jest-watch-typeahead: ^0.6.1
       js-sha256: ^0.9.0
       lint-staged: ^10.5.1
       prettier: ^2.1.2
       random-js: ^2.1.0
-      sort-package-json: ^1.46.1
+      sort-package-json: ^1.50.0
       ts-jest: ^26.4.3
       typescript: ^4.2.0
       zod: 3.2.0
@@ -1137,7 +1139,9 @@ importers:
       eslint-plugin-prettier: 3.3.1_ea5601adac11a59dc1e2379624986c36
       jest: 26.6.3_ts-node@9.1.1
       jest-watch-typeahead: 0.6.4_jest@26.6.3
+      lint-staged: 11.0.0
       prettier: 2.2.1
+      sort-package-json: 1.50.0
       ts-jest: 26.5.0_jest@26.6.3+typescript@4.2.3
       typescript: 4.2.3
     specifiers:
@@ -1154,7 +1158,9 @@ importers:
       jest: ^26.6.3
       jest-watch-typeahead: ^0.6.4
       js-sha256: ^0.9.0
+      lint-staged: ^11.0.0
       prettier: ^2.2.1
+      sort-package-json: ^1.50.0
       ts-command-line-args: ^1.8.0
       ts-jest: ^26.5.0
       ts-node: ^9.1.1
@@ -1191,13 +1197,12 @@ importers:
       eslint-config-prettier: 6.15.0_eslint@7.17.0
       eslint-plugin-prettier: 3.3.1_18bc709ad1b4fcdd674db622dfd1f758
       eslint-plugin-vx: link:../eslint-plugin-vx
-      husky: 4.3.7
       jest: 26.6.3_canvas@2.6.1+ts-node@9.1.1
       jest-watch-typeahead: 0.6.4_jest@26.6.3
       lint-staged: 10.5.3
       memorystream: 0.3.1
       prettier: 2.2.1
-      sort-package-json: 1.48.1
+      sort-package-json: 1.50.0
       tmp: 0.2.1
       ts-jest: 26.4.4_jest@26.6.3+typescript@4.2.3
       ts-node: 9.1.1_typescript@4.2.3
@@ -1226,7 +1231,6 @@ importers:
       eslint-config-prettier: ^6.15.0
       eslint-plugin-prettier: ^3.1.4
       eslint-plugin-vx: workspace:*
-      husky: ^4.3.0
       jest: ^26.6.0
       jest-watch-typeahead: ^0.6.4
       jsfeat: ^0.0.8
@@ -1235,7 +1239,7 @@ importers:
       memorystream: ^0.3.1
       node-quirc: ^2.2.1
       prettier: ^2.1.2
-      sort-package-json: ^1.46.1
+      sort-package-json: ^1.50.0
       table: ^6.0.3
       tmp: ^0.2.1
       ts-jest: ^26.4.1
@@ -1262,8 +1266,10 @@ importers:
       eslint-plugin-promise: 4.2.1
       jest: 26.6.3_canvas@2.6.1
       jest-watch-typeahead: 0.6.4_jest@26.6.3
+      lint-staged: 11.0.0
       memory-streams: 0.1.3
       prettier: 2.2.1
+      sort-package-json: 1.50.0
       ts-jest: 26.5.0_jest@26.6.3+typescript@4.2.3
       typescript: 4.2.3
     specifiers:
@@ -1283,9 +1289,11 @@ importers:
       eslint-plugin-promise: ^4.2.1
       jest: ^26.6.3
       jest-watch-typeahead: ^0.6.4
+      lint-staged: ^11.0.0
       memory-streams: ^0.1.3
       node-addon-api: ^3.1.0
       prettier: ^2.2.1
+      sort-package-json: ^1.50.0
       ts-jest: ^26.5.0
       typescript: ^4.2.0
   libs/plustek-sdk:
@@ -1306,7 +1314,9 @@ importers:
       eslint: 7.25.0
       jest: 26.6.3_ts-node@9.1.1
       jest-watch-typeahead: 0.6.4_jest@26.6.3
+      lint-staged: 11.0.0
       prettier: 2.2.1
+      sort-package-json: 1.50.0
       ts-jest: 26.5.5_jest@26.6.3+typescript@4.2.4
       ts-node: 9.1.1_typescript@4.2.4
       typescript: 4.2.4
@@ -1324,7 +1334,9 @@ importers:
       eslint: ^7.25.0
       jest: ^26.6.3
       jest-watch-typeahead: ^0.6.4
+      lint-staged: ^11.0.0
       prettier: ^2.2.1
+      sort-package-json: ^1.50.0
       temp: ^0.9.4
       ts-jest: ^26.5.5
       ts-node: ^9.1.1
@@ -1347,9 +1359,11 @@ importers:
       eslint: 7.28.0
       eslint-config-prettier: 8.3.0_eslint@7.28.0
       eslint-plugin-prettier: 3.4.0_441ef98f5280b4c825fe505e43fc5698
+      lint-staged: 11.0.0
       prettier: 2.3.1
       react: 17.0.1
       react-dom: 17.0.1_react@17.0.1
+      sort-package-json: 1.50.0
       typescript: 4.2.3
     specifiers:
       '@testing-library/react': ^11.2.6
@@ -1364,10 +1378,12 @@ importers:
       eslint: ^7.28.0
       eslint-config-prettier: ^8.3.0
       eslint-plugin-prettier: ^3.4.0
+      lint-staged: ^11.0.0
       prettier: ^2.3.1
       react: ^17.0.1
       react-dom: ^17.0.1
       rxjs: ^6.6.6
+      sort-package-json: ^1.50.0
       typescript: ^4.2.3
       zip-stream: ^4.1.0
   libs/types:
@@ -1386,7 +1402,9 @@ importers:
       eslint-plugin-prettier: 3.3.1_ea5601adac11a59dc1e2379624986c36
       jest: 26.6.3
       jest-watch-typeahead: 0.6.4_jest@26.6.3
+      lint-staged: 11.0.0
       prettier: 2.2.1
+      sort-package-json: 1.50.0
       ts-jest: 26.5.0_jest@26.6.3+typescript@4.2.3
       typescript: 4.2.3
     specifiers:
@@ -1402,7 +1420,9 @@ importers:
       eslint-plugin-prettier: ^3.3.1
       jest: ^26.6.3
       jest-watch-typeahead: ^0.6.4
+      lint-staged: ^11.0.0
       prettier: ^2.2.1
+      sort-package-json: ^1.50.0
       ts-jest: ^26.5.0
       typescript: ^4.2.0
       zod: 3.2.0
@@ -1437,9 +1457,10 @@ importers:
       eslint-plugin-vx: link:../eslint-plugin-vx
       jest: 26.6.3
       jest-watch-typeahead: 0.6.4_jest@26.6.3
+      lint-staged: 11.0.0
       prettier: 2.2.1
       react: 17.0.1
-      sort-package-json: 1.48.1
+      sort-package-json: 1.50.0
       stylelint: 13.8.0
       stylelint-config-palantir: 4.0.1_stylelint@13.8.0
       stylelint-config-prettier: 8.0.2_stylelint@13.8.0
@@ -1474,10 +1495,11 @@ importers:
       eslint-plugin-vx: workspace:*
       jest: ^26.6.3
       jest-watch-typeahead: ^0.6.4
+      lint-staged: ^11.0.0
       prettier: ^2.1.1
       react: ^17.0.1
       react-dom: ^17.0.1
-      sort-package-json: ^1.44.0
+      sort-package-json: ^1.50.0
       styled-components: ^5.2.3
       stylelint: ^13.1.0
       stylelint-config-palantir: ^4.0.1
@@ -1514,7 +1536,9 @@ importers:
       eslint-plugin-vx: link:../eslint-plugin-vx
       jest: 26.6.3
       jest-watch-typeahead: 0.6.4_jest@26.6.3
+      lint-staged: 11.0.0
       prettier: 2.3.0
+      sort-package-json: 1.50.0
       ts-jest: 26.5.6_jest@26.6.3+typescript@4.2.4
       typescript: 4.2.4
     specifiers:
@@ -1539,10 +1563,12 @@ importers:
       jest: ^26.6.3
       jest-fetch-mock: ^3.0.3
       jest-watch-typeahead: ^0.6.4
+      lint-staged: ^11.0.0
       luxon: ^1.27.0
       moment: ^2.29.1
       prettier: ^2.3.0
       rxjs: ^6.6.6
+      sort-package-json: ^1.50.0
       ts-jest: ^26.5.6
       typescript: ^4.2.4
       yauzl: ^2.10.0
@@ -1577,7 +1603,7 @@ packages:
       integrity: sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==
   /@babel/code-frame/7.12.11:
     dependencies:
-      '@babel/highlight': 7.14.0
+      '@babel/highlight': 7.14.5
     resolution:
       integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
   /@babel/code-frame/7.12.13:
@@ -6785,7 +6811,7 @@ packages:
   /@nodelib/fs.walk/1.2.7:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.11.0
+      fastq: 1.11.1
     engines:
       node: '>= 8'
     resolution:
@@ -7738,8 +7764,8 @@ packages:
       integrity: sha512-ecNRHw4clCkowNOBJH1e77nvbPxHYnWIXMv1IAoG/9+MYGkgoyr3Ppxr7XYFNL41V422EDhyV4/4SSK8L2mlig==
   /@types/glob/7.1.3:
     dependencies:
-      '@types/minimatch': 3.0.3
-      '@types/node': 15.12.2
+      '@types/minimatch': 3.0.4
+      '@types/node': 16.0.0
     resolution:
       integrity: sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==
   /@types/graceful-fs/4.1.5:
@@ -7887,9 +7913,9 @@ packages:
     dev: true
     resolution:
       integrity: sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==
-  /@types/minimatch/3.0.3:
+  /@types/minimatch/3.0.4:
     resolution:
-      integrity: sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
+      integrity: sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==
   /@types/minimist/1.2.1:
     dev: true
     resolution:
@@ -7960,6 +7986,9 @@ packages:
   /@types/node/15.6.2:
     resolution:
       integrity: sha512-dxcOx8801kMo3KlU+C+/ctWrzREAH7YvoF3aoVpRdqgs+Kf7flp+PJDN/EX5bME3suDUZHsxes9hpvBmzYlWbA==
+  /@types/node/16.0.0:
+    resolution:
+      integrity: sha512-TmCW5HoZ2o2/z2EYi109jLqIaPIi9y/lc2LmDCWzuCi35bcaQ+OtUh6nwBiFK7SOu25FAU5+YKdqFZUwtqGSdg==
   /@types/normalize-package-data/2.4.0:
     resolution:
       integrity: sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
@@ -11895,6 +11924,12 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
+  /commander/7.2.0:
+    dev: true
+    engines:
+      node: '>= 10'
+    resolution:
+      integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
   /common-tags/1.8.0:
     engines:
       node: '>=4.0.0'
@@ -11904,10 +11939,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
-  /compare-versions/3.6.0:
-    dev: true
-    resolution:
-      integrity: sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==
   /component-emitter/1.3.0:
     resolution:
       integrity: sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
@@ -12120,7 +12151,7 @@ packages:
       import-fresh: 3.3.0
       parse-json: 5.2.0
       path-type: 4.0.0
-      yaml: 1.10.0
+      yaml: 1.10.2
     engines:
       node: '>=10'
     resolution:
@@ -12789,6 +12820,19 @@ packages:
         optional: true
     resolution:
       integrity: sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  /debug/4.3.2:
+    dependencies:
+      ms: 2.1.2
+    dev: true
+    engines:
+      node: '>=6.0'
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    resolution:
+      integrity: sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
   /debug/4.3.2_supports-color@8.1.1:
     dependencies:
       ms: 2.1.2
@@ -12979,12 +13023,12 @@ packages:
     dev: false
     resolution:
       integrity: sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
-  /detect-indent/6.0.0:
+  /detect-indent/6.1.0:
     dev: true
     engines:
       node: '>=8'
     resolution:
-      integrity: sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==
+      integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==
   /detect-libc/1.0.3:
     dev: false
     engines:
@@ -15097,6 +15141,53 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-UMfH0VSjP0G4p3EWirscJEQ/cHqnT/iuH6oNZOB94nBjWbMnhGEPxsZm1eyIW0C/9jLI0Fow4W5DXLjEI7mn1g==
+  /eslint/7.29.0:
+    dependencies:
+      '@babel/code-frame': 7.12.11
+      '@eslint/eslintrc': 0.4.2
+      ajv: 6.12.6
+      chalk: 4.1.1
+      cross-spawn: 7.0.3
+      debug: 4.3.1
+      doctrine: 3.0.0
+      enquirer: 2.3.6
+      escape-string-regexp: 4.0.0
+      eslint-scope: 5.1.1
+      eslint-utils: 2.1.0
+      eslint-visitor-keys: 2.1.0
+      espree: 7.3.1
+      esquery: 1.4.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 6.0.1
+      functional-red-black-tree: 1.0.1
+      glob-parent: 5.1.2
+      globals: 13.9.0
+      ignore: 4.0.6
+      import-fresh: 3.3.0
+      imurmurhash: 0.1.4
+      is-glob: 4.0.1
+      js-yaml: 3.14.1
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash.merge: 4.6.2
+      minimatch: 3.0.4
+      natural-compare: 1.4.0
+      optionator: 0.9.1
+      progress: 2.0.3
+      regexpp: 3.2.0
+      semver: 7.3.5
+      strip-ansi: 6.0.0
+      strip-json-comments: 3.1.1
+      table: 6.7.1
+      text-table: 0.2.0
+      v8-compile-cache: 2.3.0
+    dev: true
+    engines:
+      node: ^10.12.0 || >=12.0.0
+    hasBin: true
+    resolution:
+      integrity: sha512-82G/JToB9qIy/ArBzIWG9xvvwL3R86AlCjtGw+A29OMZDqhTybz/MByORSukGxeI+YPCR4coYyITKk8BFH9nDA==
   /espree/6.2.1:
     dependencies:
       acorn: 7.4.1
@@ -15535,6 +15626,18 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==
+  /fast-glob/3.2.6:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.7
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.4
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==
   /fast-json-stable-stringify/2.1.0:
     resolution:
       integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -15553,11 +15656,11 @@ packages:
     dev: true
     resolution:
       integrity: sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==
-  /fastq/1.11.0:
+  /fastq/1.11.1:
     dependencies:
       reusify: 1.0.4
     resolution:
-      integrity: sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==
+      integrity: sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==
   /faye-websocket/0.10.0:
     dependencies:
       websocket-driver: 0.7.4
@@ -15803,23 +15906,6 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
-  /find-up/5.0.0:
-    dependencies:
-      locate-path: 6.0.0
-      path-exists: 4.0.0
-    dev: true
-    engines:
-      node: '>=10'
-    resolution:
-      integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
-  /find-versions/4.0.0:
-    dependencies:
-      semver-regex: 3.1.2
-    dev: true
-    engines:
-      node: '>=10'
-    resolution:
-      integrity: sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==
   /flat-cache/2.0.1:
     dependencies:
       flatted: 2.0.2
@@ -15832,7 +15918,7 @@ packages:
       integrity: sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==
   /flat-cache/3.0.4:
     dependencies:
-      flatted: 3.1.1
+      flatted: 3.2.0
       rimraf: 3.0.2
     engines:
       node: ^10.12.0 || >=12.0.0
@@ -15842,9 +15928,9 @@ packages:
     dev: false
     resolution:
       integrity: sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
-  /flatted/3.1.1:
+  /flatted/3.2.0:
     resolution:
-      integrity: sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
+      integrity: sha512-XprP7lDrVT+kE2c2YlfiV+IfS9zxukiIOvNamPNsImNhXadSsQEbosItdL9bUQlCZXR13SvPk20BjWSWLA7m4A==
   /flatten/1.0.3:
     dev: false
     resolution:
@@ -16173,12 +16259,6 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
-  /get-stdin/7.0.0:
-    dev: true
-    engines:
-      node: '>=8'
-    resolution:
-      integrity: sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==
   /get-stdin/8.0.0:
     dev: true
     engines:
@@ -16338,7 +16418,7 @@ packages:
       '@types/glob': 7.1.3
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.2.5
+      fast-glob: 3.2.6
       glob: 7.1.7
       ignore: 5.1.8
       merge2: 1.4.1
@@ -16818,6 +16898,20 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
+  /http-proxy-middleware/1.0.6_debug@4.3.1:
+    dependencies:
+      '@types/http-proxy': 1.17.6
+      http-proxy: 1.18.1_debug@4.3.1
+      is-glob: 4.0.1
+      lodash: 4.17.21
+      micromatch: 4.0.4
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    peerDependencies:
+      debug: '*'
+    resolution:
+      integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
   /http-proxy/1.18.1:
     dependencies:
       eventemitter3: 4.0.7
@@ -16883,44 +16977,13 @@ packages:
       node: '>=10.17.0'
     resolution:
       integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
-  /husky/2.7.0:
-    dependencies:
-      cosmiconfig: 5.2.1
-      execa: 1.0.0
-      find-up: 3.0.0
-      get-stdin: 7.0.0
-      is-ci: 2.0.0
-      pkg-dir: 4.2.0
-      please-upgrade-node: 3.2.0
-      read-pkg: 5.2.0
-      run-node: 1.0.0
-      slash: 3.0.0
+  /husky/7.0.0:
     dev: true
     engines:
-      node: '>=8'
+      node: '>=12'
     hasBin: true
-    requiresBuild: true
     resolution:
-      integrity: sha512-LIi8zzT6PyFpcYKdvWRCn/8X+6SuG2TgYYMrM6ckEYhlp44UcEduVymZGIZNLiwOUjrEud+78w/AsAiqJA/kRg==
-  /husky/4.3.7:
-    dependencies:
-      chalk: 4.1.1
-      ci-info: 2.0.0
-      compare-versions: 3.6.0
-      cosmiconfig: 7.0.0
-      find-versions: 4.0.0
-      opencollective-postinstall: 2.0.3
-      pkg-dir: 5.0.0
-      please-upgrade-node: 3.2.0
-      slash: 3.0.0
-      which-pm-runs: 1.0.0
-    dev: true
-    engines:
-      node: '>=10'
-    hasBin: true
-    requiresBuild: true
-    resolution:
-      integrity: sha512-0fQlcCDq/xypoyYSJvEuzbDPHFf8ZF9IXKJxlrnvxABTSzK1VPT2RKYQKrcgJ+YD39swgoB6sbzywUqFxUiqjw==
+      integrity: sha512-xK7lO0EtSzfFPiw+oQncQVy/XqV7UVVjxBByc+Iv5iK3yhW9boDoWgvZy3OGo48QKg/hUtZkzz0hi2HXa0kn7w==
   /i18next/19.8.4:
     dependencies:
       '@babel/runtime': 7.12.5
@@ -17666,6 +17729,12 @@ packages:
   /is-typedarray/1.0.0:
     resolution:
       integrity: sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+  /is-unicode-supported/0.1.0:
+    dev: true
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
   /is-what/3.12.0:
     dev: false
     resolution:
@@ -20285,6 +20354,48 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-TanwFfuqUBLufxCc3RUtFEkFraSPNR3WzWcGF39R3f2J7S9+iF9W0KTVLfSy09lYGmZS5NDCxjNvhGMSJyFCWg==
+  /lint-staged/10.5.4:
+    dependencies:
+      chalk: 4.1.1
+      cli-truncate: 2.1.0
+      commander: 6.2.1
+      cosmiconfig: 7.0.0
+      debug: 4.3.2
+      dedent: 0.7.0
+      enquirer: 2.3.6
+      execa: 4.1.0
+      listr2: 3.10.0_enquirer@2.3.6
+      log-symbols: 4.1.0
+      micromatch: 4.0.4
+      normalize-path: 3.0.0
+      please-upgrade-node: 3.2.0
+      string-argv: 0.3.1
+      stringify-object: 3.3.0
+    dev: true
+    hasBin: true
+    resolution:
+      integrity: sha512-EechC3DdFic/TdOPgj/RB3FicqE6932LTHCUm0Y2fsD9KGlLB+RwJl2q1IYBIvEsKzDOgn0D4gll+YxG5RsrKg==
+  /lint-staged/11.0.0:
+    dependencies:
+      chalk: 4.1.1
+      cli-truncate: 2.1.0
+      commander: 7.2.0
+      cosmiconfig: 7.0.0
+      debug: 4.3.2
+      dedent: 0.7.0
+      enquirer: 2.3.6
+      execa: 5.1.1
+      listr2: 3.10.0_enquirer@2.3.6
+      log-symbols: 4.1.0
+      micromatch: 4.0.4
+      normalize-path: 3.0.0
+      please-upgrade-node: 3.2.0
+      string-argv: 0.3.1
+      stringify-object: 3.3.0
+    dev: true
+    hasBin: true
+    resolution:
+      integrity: sha512-3rsRIoyaE8IphSUtO1RVTFl1e0SLBtxxUOPBtHxQgBHS5/i6nqvjcUfNioMa4BU9yGnPzbO+xkfLtXtxBpCzjw==
   /lint-staged/8.2.1:
     dependencies:
       chalk: 2.4.2
@@ -20485,14 +20596,6 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
-  /locate-path/6.0.0:
-    dependencies:
-      p-locate: 5.0.0
-    dev: true
-    engines:
-      node: '>=10'
-    resolution:
-      integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   /lodash._reinterpolate/3.0.0:
     dev: false
     resolution:
@@ -20599,6 +20702,15 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==
+  /log-symbols/4.1.0:
+    dependencies:
+      chalk: 4.1.1
+      is-unicode-supported: 0.1.0
+    dev: true
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
   /log-update/2.3.0:
     dependencies:
       ansi-escapes: 3.2.0
@@ -21808,11 +21920,6 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
-  /opencollective-postinstall/2.0.3:
-    dev: true
-    hasBin: true
-    resolution:
-      integrity: sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
   /opn/5.5.0:
     dependencies:
       is-wsl: 1.1.0
@@ -21981,6 +22088,7 @@ packages:
   /p-limit/3.1.0:
     dependencies:
       yocto-queue: 0.1.0
+    dev: false
     engines:
       node: '>=10'
     resolution:
@@ -22006,14 +22114,6 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
-  /p-locate/5.0.0:
-    dependencies:
-      p-limit: 3.1.0
-    dev: true
-    engines:
-      node: '>=10'
-    resolution:
-      integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
   /p-map/1.2.0:
     dev: true
     engines:
@@ -22375,14 +22475,6 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
-  /pkg-dir/5.0.0:
-    dependencies:
-      find-up: 5.0.0
-    dev: true
-    engines:
-      node: '>=10'
-    resolution:
-      integrity: sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==
   /pkg-up/3.1.0:
     dependencies:
       find-up: 3.0.0
@@ -23318,6 +23410,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==
+  /prettier/2.3.2:
+    dev: true
+    engines:
+      node: '>=10.13.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
   /pretty-bytes/5.5.0:
     engines:
       node: '>=6'
@@ -24407,6 +24506,12 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
+  /regexpp/3.2.0:
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
   /regexpu-core/4.7.1:
     dependencies:
       regenerate: 1.4.2
@@ -24807,13 +24912,6 @@ packages:
       node: '>=0.12.0'
     resolution:
       integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
-  /run-node/1.0.0:
-    dev: true
-    engines:
-      node: '>=4'
-    hasBin: true
-    resolution:
-      integrity: sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==
   /run-parallel/1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -25017,12 +25115,6 @@ packages:
     dev: true
     resolution:
       integrity: sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
-  /semver-regex/3.1.2:
-    dev: true
-    engines:
-      node: '>=8'
-    resolution:
-      integrity: sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA==
   /semver/5.7.1:
     hasBin: true
     resolution:
@@ -25363,9 +25455,9 @@ packages:
     dev: true
     resolution:
       integrity: sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==
-  /sort-package-json/1.48.1:
+  /sort-package-json/1.50.0:
     dependencies:
-      detect-indent: 6.0.0
+      detect-indent: 6.1.0
       detect-newline: 3.1.0
       git-hooks-list: 1.0.3
       globby: 10.0.0
@@ -25374,7 +25466,7 @@ packages:
     dev: true
     hasBin: true
     resolution:
-      integrity: sha512-YvDm1iBzhphfXtctTS0XIBlIW/2N1DZNHx3YMcZnptpZhchqH4zazUOuEWmjfNXndwamITMt9hFPliqwx1SHvQ==
+      integrity: sha512-qZpqhMU9XTntebgAgc4hv/D6Fzhh7kFnwvV6a7+q8y8J5JoaDqPYQnvXPf7BBqG95tdE8X6JVNo7/jDzcbdfUg==
   /source-list-map/2.0.1:
     dev: false
     resolution:
@@ -28030,10 +28122,6 @@ packages:
   /which-module/2.0.0:
     resolution:
       integrity: sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
-  /which-pm-runs/1.0.0:
-    dev: true
-    resolution:
-      integrity: sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
   /which/1.3.1:
     dependencies:
       isexe: 2.0.0
@@ -28504,10 +28592,16 @@ packages:
     resolution:
       integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
   /yaml/1.10.0:
+    dev: false
     engines:
       node: '>= 6'
     resolution:
       integrity: sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
+  /yaml/1.10.2:
+    engines:
+      node: '>= 6'
+    resolution:
+      integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
   /yargs-parser/11.1.1:
     dependencies:
       camelcase: 5.3.1
@@ -28615,6 +28709,7 @@ packages:
     resolution:
       integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
   /yocto-queue/0.1.0:
+    dev: false
     engines:
       node: '>=10'
     resolution:


### PR DESCRIPTION
This uses `husky` v6 at the root of the workspace and `lint-staged` in each of the projects that need formatting. The lastest `husky` works a little differently than what we were using before (v4). Mostly, it uses the `core.hookspath` git config to point to `.husky/` within the project, setting that config property using a custom `prepare` script at the root. We then have a `pre-commit` script that asks `pnpm` to figure out all the changed packages and runs the `pre-commit` script in each one if it's there.

Closes #683 