### PR TITLE
fix(lint): do not flag `Result` assignments

### DIFF
--- a/libs/eslint-plugin-vx/src/rules/no-floating-results.ts
+++ b/libs/eslint-plugin-vx/src/rules/no-floating-results.ts
@@ -84,6 +84,10 @@ export default ESLintUtils.RuleCreator(() => 'https://voting.works/')({
         return node.expressions.some((item) => isUnhandledResult(checker, item))
       }
 
+      if (node.type === AST_NODE_TYPES.AssignmentExpression) {
+        return false
+      }
+
       if (
         !options.ignoreVoid &&
         node.type === AST_NODE_TYPES.UnaryExpression &&

--- a/libs/eslint-plugin-vx/tests/rules/no-floating-results.test.ts
+++ b/libs/eslint-plugin-vx/tests/rules/no-floating-results.test.ts
@@ -29,6 +29,15 @@ ok().ok()
 import { ok } from '@votingworks/types'
 ok().err()
     `,
+    `
+import { ok, Result } from '@votingworks/types'
+let result: Result<void, void>
+if (true) {
+  result = ok()
+} else {
+  result = ok()
+}
+    `,
     {
       options: [{ ignoreVoid: true }],
       code: `


### PR DESCRIPTION
When assigning a `Result` to a variable as a statement, the type of that statement's expression is also `Result` because the value of an assignment is the value of the right-hand side. This triggered the `no-floating-results` rule incorrectly. Now it ignores assignments, assuming that the assigned `Result` will be used later.