### PR TITLE
fix(ps): use more natural "A and B"

### DIFF
--- a/apps/precinct-scanner/src/utils/toSentence.test.ts
+++ b/apps/precinct-scanner/src/utils/toSentence.test.ts
@@ -1,0 +1,28 @@
+import { toSentence } from './toSentence'
+
+test('empty list', () => {
+  expect(toSentence([])).toEqual([])
+})
+
+test('single-element list', () => {
+  expect(toSentence(['Mayor'])).toEqual(['Mayor'])
+})
+
+test('two-element list', () => {
+  expect(toSentence(['Mayor', 'Senator'])).toEqual([
+    'Mayor',
+    ' and ',
+    'Senator',
+  ])
+})
+
+test('three-element list', () => {
+  expect(toSentence(['Mayor', 'Senator', 'Sheriff'])).toEqual([
+    'Mayor',
+    ', ',
+    'Senator',
+    ', ',
+    ' and ',
+    'Sheriff',
+  ])
+})

--- a/apps/precinct-scanner/src/utils/toSentence.ts
+++ b/apps/precinct-scanner/src/utils/toSentence.ts
@@ -15,9 +15,11 @@ export function toSentence(
     return elements
   }
 
-  return [
-    ...elements.slice(0, -1).flatMap((element) => [element, comma]),
-    and,
-    elements[elements.length - 1],
-  ]
+  if (elements.length === 2) {
+    return [elements[0], and, elements[1]]
+  }
+
+  const head = elements
+  const tail = head.pop()!
+  return [...head.flatMap((element) => [element, comma]), and, tail]
 }


### PR DESCRIPTION
Previously, `toSentence` would render a 2-element list as "A, and B". This isn't typical in English, so this fixes it to be "A and B". A 3-element list still uses an Oxford comma: "A, B, and C".