### PR TITLE
feat(ps): add backup feature

### DIFF
--- a/apps/precinct-scanner/src/components/ExportBackupModal.test.tsx
+++ b/apps/precinct-scanner/src/components/ExportBackupModal.test.tsx
@@ -1,0 +1,230 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { electionSampleDefinition } from '@votingworks/fixtures'
+import { fakeKiosk, fakeUsbDrive } from '@votingworks/test-utils'
+import { err, ok } from '@votingworks/types'
+import { usbstick } from '@votingworks/utils'
+import React from 'react'
+import { mocked } from 'ts-jest/utils'
+import AppContext from '../contexts/AppContext'
+import { download, DownloadErrorKind } from '../utils/download'
+import ExportBackupModal from './ExportBackupModal'
+
+jest.mock('../utils/download')
+
+const { UsbDriveStatus } = usbstick
+
+const machineConfig = { machineId: '0003', codeVersion: 'TEST' }
+
+test('renders loading screen when USB drive is mounting or ejecting in export modal', () => {
+  const usbStatuses = [UsbDriveStatus.present, UsbDriveStatus.ejecting]
+
+  for (const status of usbStatuses) {
+    const closeFn = jest.fn()
+    const { unmount } = render(
+      <AppContext.Provider
+        value={{ electionDefinition: electionSampleDefinition, machineConfig }}
+      >
+        <ExportBackupModal
+          onClose={closeFn}
+          usbDriveStatus={status}
+          usbDriveEject={jest.fn()}
+        />
+      </AppContext.Provider>
+    )
+    screen.getByText('Loading')
+    unmount()
+  }
+})
+
+test('render no USB found screen when there is not a mounted USB drive', () => {
+  const usbStatuses = [
+    UsbDriveStatus.absent,
+    UsbDriveStatus.notavailable,
+    UsbDriveStatus.recentlyEjected,
+  ]
+
+  for (const status of usbStatuses) {
+    const closeFn = jest.fn()
+    const { unmount } = render(
+      <AppContext.Provider
+        value={{ electionDefinition: electionSampleDefinition, machineConfig }}
+      >
+        <ExportBackupModal
+          onClose={closeFn}
+          usbDriveStatus={status}
+          usbDriveEject={jest.fn()}
+        />
+      </AppContext.Provider>
+    )
+    screen.getByText('No USB Drive Detected')
+    screen.getByText(
+      'Please insert a USB drive in order to export the scanner backup.'
+    )
+    screen.getByAltText('Insert USB Image')
+
+    fireEvent.click(screen.getByText('Cancel'))
+    expect(closeFn).toHaveBeenCalled()
+
+    unmount()
+  }
+})
+
+test('render export modal when a USB drive is mounted as expected and allows custom export', async () => {
+  const mockKiosk = fakeKiosk()
+  window.kiosk = mockKiosk
+  mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()])
+  mocked(download).mockResolvedValueOnce(ok())
+
+  const closeFn = jest.fn()
+  render(
+    <AppContext.Provider
+      value={{ electionDefinition: electionSampleDefinition, machineConfig }}
+    >
+      <ExportBackupModal
+        onClose={closeFn}
+        usbDriveStatus={UsbDriveStatus.mounted}
+        usbDriveEject={jest.fn()}
+      />
+    </AppContext.Provider>
+  )
+  screen.getByText('Export Backup')
+  screen.getByText(
+    /A ZIP file will automatically be saved to the default location on the mounted USB drive./
+  )
+  screen.getByAltText('Insert USB Image')
+
+  fireEvent.click(screen.getByText('Custom'))
+  await waitFor(() => screen.getByText(/Download Complete/))
+  expect(download).toHaveBeenCalledWith('/scan/backup')
+
+  fireEvent.click(screen.getByText('Cancel'))
+  expect(closeFn).toHaveBeenCalled()
+})
+
+test('render export modal when a USB drive is mounted as expected and allows automatic export', async () => {
+  const mockKiosk = fakeKiosk()
+  window.kiosk = mockKiosk
+  mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()])
+  mocked(download).mockResolvedValueOnce(ok())
+
+  const closeFn = jest.fn()
+  const ejectFn = jest.fn()
+  render(
+    <AppContext.Provider
+      value={{ electionDefinition: electionSampleDefinition, machineConfig }}
+    >
+      <ExportBackupModal
+        onClose={closeFn}
+        usbDriveStatus={UsbDriveStatus.mounted}
+        usbDriveEject={ejectFn}
+      />
+    </AppContext.Provider>
+  )
+  screen.getByText('Export Backup')
+
+  fireEvent.click(screen.getByText('Export'))
+  await waitFor(() => screen.getByText(/Download Complete/))
+  expect(download).toHaveBeenCalledWith('/scan/backup', {
+    into:
+      'fake mount point/scanner-backups/franklin-county_general-election_2f6b1553c7',
+  })
+
+  fireEvent.click(screen.getByText('Eject USB'))
+  expect(ejectFn).toHaveBeenCalled()
+  fireEvent.click(screen.getByText('Cancel'))
+  expect(closeFn).toHaveBeenCalled()
+})
+
+test('handles no USB drives', async () => {
+  const mockKiosk = fakeKiosk()
+  window.kiosk = mockKiosk
+
+  const closeFn = jest.fn()
+  const { getByText } = render(
+    <AppContext.Provider
+      value={{ electionDefinition: electionSampleDefinition, machineConfig }}
+    >
+      <ExportBackupModal
+        onClose={closeFn}
+        usbDriveStatus={UsbDriveStatus.mounted}
+        usbDriveEject={jest.fn()}
+      />
+    </AppContext.Provider>
+  )
+  getByText('Export Backup')
+
+  mockKiosk.getUsbDrives.mockResolvedValueOnce([])
+  fireEvent.click(getByText('Export'))
+  await waitFor(() => getByText(/Download Failed/))
+  getByText(/No USB drive found./)
+
+  fireEvent.click(getByText('Close'))
+  expect(closeFn).toHaveBeenCalled()
+})
+
+test('shows a specific error for file writer failure', async () => {
+  const mockKiosk = fakeKiosk()
+  window.kiosk = mockKiosk
+
+  const closeFn = jest.fn()
+  const { getByText } = render(
+    <AppContext.Provider
+      value={{ electionDefinition: electionSampleDefinition, machineConfig }}
+    >
+      <ExportBackupModal
+        onClose={closeFn}
+        usbDriveStatus={UsbDriveStatus.mounted}
+        usbDriveEject={jest.fn()}
+      />
+    </AppContext.Provider>
+  )
+  getByText('Export Backup')
+
+  mockKiosk.getUsbDrives.mockResolvedValueOnce([fakeUsbDrive()])
+  mocked(download).mockResolvedValueOnce(
+    err({
+      kind: DownloadErrorKind.OpenFailed,
+      path: 'backup.zip',
+      error: new Error('NOPE'),
+    })
+  )
+  fireEvent.click(getByText('Export'))
+  await waitFor(() => getByText(/Download Failed/))
+  getByText(/Unable to write file to download location: backup.zip/)
+
+  fireEvent.click(getByText('Close'))
+  expect(closeFn).toHaveBeenCalled()
+})
+
+test('shows a specific error for fetch failure', async () => {
+  const mockKiosk = fakeKiosk()
+  window.kiosk = mockKiosk
+
+  const closeFn = jest.fn()
+  render(
+    <AppContext.Provider
+      value={{ electionDefinition: electionSampleDefinition, machineConfig }}
+    >
+      <ExportBackupModal
+        onClose={closeFn}
+        usbDriveStatus={UsbDriveStatus.mounted}
+        usbDriveEject={jest.fn()}
+      />
+    </AppContext.Provider>
+  )
+  screen.getByText('Export Backup')
+
+  mockKiosk.getUsbDrives.mockResolvedValueOnce([fakeUsbDrive()])
+  mocked(download).mockResolvedValueOnce(
+    err({
+      kind: DownloadErrorKind.FetchFailed,
+      response: new Response('', { status: 504, statusText: 'Bad Gateway' }),
+    })
+  )
+  fireEvent.click(screen.getByText('Export'))
+  await waitFor(() => screen.getByText('Download Failed'))
+  screen.getByText('Unable to get backup: FetchFailed (status=Bad Gateway)')
+
+  fireEvent.click(screen.getByText('Close'))
+  expect(closeFn).toHaveBeenCalled()
+})

--- a/apps/precinct-scanner/src/components/ExportBackupModal.tsx
+++ b/apps/precinct-scanner/src/components/ExportBackupModal.tsx
@@ -1,0 +1,239 @@
+import { Result } from '@votingworks/types'
+import { Button, Loading, Prose, USBControllerButton } from '@votingworks/ui'
+import {
+  generateElectionBasedSubfolderName,
+  SCANNER_BACKUPS_FOLDER,
+  usbstick,
+} from '@votingworks/utils'
+import path from 'path'
+import React, { useContext, useState } from 'react'
+import styled from 'styled-components'
+import AppContext from '../contexts/AppContext'
+import { download, DownloadError, DownloadErrorKind } from '../utils/download'
+import Modal from './Modal'
+
+function throwBadStatus(s: never): never {
+  throw new Error(`Bad status: ${s}`)
+}
+
+const USBImage = styled.img`
+  margin-right: auto;
+  margin-left: auto;
+  height: 200px;
+`
+
+export interface Props {
+  onClose: () => void
+  usbDriveStatus: usbstick.UsbDriveStatus
+  usbDriveEject: () => void
+}
+
+enum ModalState {
+  ERROR = 'error',
+  SAVING = 'saving',
+  DONE = 'done',
+  INIT = 'init',
+}
+
+const ExportBackupModal: React.FC<Props> = ({
+  onClose,
+  usbDriveStatus,
+  usbDriveEject,
+}) => {
+  const [currentState, setCurrentState] = useState(ModalState.INIT)
+  const [errorMessage, setErrorMessage] = useState('')
+
+  const { electionDefinition } = useContext(AppContext)
+
+  const exportBackup = async (openDialog: boolean) => {
+    setCurrentState(ModalState.SAVING)
+
+    let result: Result<void, DownloadError>
+    if (window.kiosk && !openDialog) {
+      const usbPath = await usbstick.getDevicePath()
+      if (!usbPath) {
+        setErrorMessage('No USB drive found.')
+        setCurrentState(ModalState.ERROR)
+        return
+      }
+      const electionFolderName = generateElectionBasedSubfolderName(
+        electionDefinition!.election,
+        electionDefinition!.electionHash
+      )
+      const pathToFolder = path.join(
+        usbPath,
+        SCANNER_BACKUPS_FOLDER,
+        electionFolderName
+      )
+      result = await download('/scan/backup', { into: pathToFolder })
+      setCurrentState(result.isOk() ? ModalState.DONE : ModalState.ERROR)
+    } else {
+      result = await download('/scan/backup')
+    }
+
+    if (result.isOk()) {
+      setCurrentState(ModalState.DONE)
+    } else {
+      const error = result.err()
+      switch (error.kind) {
+        case DownloadErrorKind.FetchFailed:
+        case DownloadErrorKind.FileMissing:
+          setErrorMessage(
+            `Unable to get backup: ${error.kind} (status=${error.response.statusText})`
+          )
+          break
+
+        case DownloadErrorKind.OpenFailed:
+          setErrorMessage(
+            `Unable to write file to download location: ${error.path}`
+          )
+          break
+      }
+      setCurrentState(ModalState.ERROR)
+    }
+  }
+
+  if (currentState === ModalState.ERROR) {
+    return (
+      <Modal
+        content={
+          <Prose>
+            <h1>Download Failed</h1>
+            <p>{errorMessage}</p>
+          </Prose>
+        }
+        onOverlayClick={onClose}
+        actions={<Button onPress={onClose}>Close</Button>}
+      />
+    )
+  }
+
+  if (currentState === ModalState.DONE) {
+    let actions = (
+      <React.Fragment>
+        <Button onPress={onClose}>Cancel</Button>
+        <USBControllerButton
+          small={false}
+          primary
+          usbDriveStatus={usbDriveStatus}
+          usbDriveEject={usbDriveEject}
+        />
+      </React.Fragment>
+    )
+
+    if (usbDriveStatus === usbstick.UsbDriveStatus.recentlyEjected) {
+      actions = <Button onPress={onClose}>Close</Button>
+    }
+
+    return (
+      <Modal
+        content={
+          <Prose>
+            <h1>Download Complete</h1>
+            <p>
+              Backup file saved successfully! You may now eject the USB drive.
+            </p>
+          </Prose>
+        }
+        onOverlayClick={onClose}
+        actions={actions}
+      />
+    )
+  }
+
+  if (currentState === ModalState.SAVING) {
+    return <Modal content={<Loading />} onOverlayClick={onClose} />
+  }
+
+  /* istanbul ignore next */
+  if (currentState !== ModalState.INIT) {
+    throwBadStatus(currentState) // Creates a compile time check that all states are being handled.
+  }
+
+  switch (usbDriveStatus) {
+    case usbstick.UsbDriveStatus.absent:
+    case usbstick.UsbDriveStatus.notavailable:
+    case usbstick.UsbDriveStatus.recentlyEjected:
+      // When run not through kiosk mode let the user download the file
+      // on the machine for internal debugging use
+      return (
+        <Modal
+          content={
+            <Prose>
+              <h1>No USB Drive Detected</h1>
+              <p>
+                <USBImage
+                  src={`${process.env.PUBLIC_URL}/assets/usb-stick.svg`}
+                  onDoubleClick={() => exportBackup(true)}
+                  alt="Insert USB Image"
+                />
+                Please insert a USB drive in order to export the scanner backup.
+              </p>
+            </Prose>
+          }
+          onOverlayClick={onClose}
+          actions={
+            <React.Fragment>
+              <Button onPress={onClose}>Cancel</Button>
+              {!window.kiosk && (
+                <Button
+                  data-testid="manual-export"
+                  onPress={() => exportBackup(true)}
+                >
+                  Export
+                </Button>
+              )}{' '}
+            </React.Fragment>
+          }
+        />
+      )
+    case usbstick.UsbDriveStatus.ejecting:
+    case usbstick.UsbDriveStatus.present:
+      return (
+        <Modal
+          content={<Loading />}
+          onOverlayClick={onClose}
+          actions={
+            <React.Fragment>
+              <Button onPress={onClose}>Cancel</Button>
+            </React.Fragment>
+          }
+        />
+      )
+    case usbstick.UsbDriveStatus.mounted:
+      return (
+        <Modal
+          content={
+            <Prose>
+              <h1>Export Backup</h1>
+              <USBImage
+                src={`${process.env.PUBLIC_URL}/assets/usb-stick.svg`}
+                onDoubleClick={() => exportBackup(true)}
+                alt="Insert USB Image"
+              />
+              <p>
+                A ZIP file will automatically be saved to the default location
+                on the mounted USB drive. Optionally, you may pick a custom
+                export location.
+              </p>
+            </Prose>
+          }
+          onOverlayClick={onClose}
+          actions={
+            <React.Fragment>
+              <Button primary onPress={() => exportBackup(false)}>
+                Export
+              </Button>
+              <Button onPress={onClose}>Cancel</Button>
+              <Button onPress={() => exportBackup(true)}>Custom</Button>
+            </React.Fragment>
+          }
+        />
+      )
+    default:
+      // Creates a compile time check to make sure this switch statement includes all enum values for UsbDriveStatus
+      throwBadStatus(usbDriveStatus)
+  }
+}
+
+export default ExportBackupModal

--- a/apps/precinct-scanner/src/screens/AdminScreen.test.tsx
+++ b/apps/precinct-scanner/src/screens/AdminScreen.test.tsx
@@ -1,12 +1,11 @@
-import React from 'react'
-import { act, fireEvent, screen, within, render } from '@testing-library/react'
-import MockDate from 'mockdate'
-
-import { fakeKiosk } from '@votingworks/test-utils'
+import { act, fireEvent, render, screen, within } from '@testing-library/react'
 import { electionSampleDefinition } from '@votingworks/fixtures'
+import { fakeKiosk } from '@votingworks/test-utils'
 import { usbstick } from '@votingworks/utils'
-import AdminScreen from './AdminScreen'
+import MockDate from 'mockdate'
+import React from 'react'
 import AppContext from '../contexts/AppContext'
+import AdminScreen from './AdminScreen'
 
 MockDate.set('2020-10-31T00:00:00.000Z')
 
@@ -201,4 +200,28 @@ test('setting and un-setting the precinct', async () => {
     target: { value: '' },
   })
   expect(updateAppPrecinctId).toHaveBeenNthCalledWith(2, '')
+})
+
+test('export from admin screen', async () => {
+  render(
+    <AppContext.Provider
+      value={{
+        electionDefinition: electionSampleDefinition,
+        machineConfig: { machineId: '0000', codeVersion: 'TEST' },
+      }}
+    >
+      <AdminScreen
+        scannedBallotCount={10}
+        isTestMode={false}
+        updateAppPrecinctId={jest.fn()}
+        toggleLiveMode={jest.fn()}
+        unconfigure={jest.fn()}
+        calibrate={jest.fn()}
+        usbDriveEject={jest.fn()}
+        usbDriveStatus={usbstick.UsbDriveStatus.absent}
+      />
+    </AppContext.Provider>
+  )
+
+  fireEvent.click(screen.getByText('Export Backup to USB'))
 })

--- a/apps/precinct-scanner/src/screens/AdminScreen.tsx
+++ b/apps/precinct-scanner/src/screens/AdminScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useContext } from 'react'
+import { SelectChangeEventFunction } from '@votingworks/types'
 import {
   Button,
   Loading,
@@ -6,19 +6,19 @@ import {
   SegmentedButton,
   Select,
 } from '@votingworks/ui'
-import { SelectChangeEventFunction } from '@votingworks/types'
-
-import { DateTime } from 'luxon'
 import { formatFullDateTimeZone, usbstick } from '@votingworks/utils'
-import { CenteredScreen } from '../components/Layout'
-import useNow from '../hooks/useNow'
-import PickDateTimeModal from '../components/PickDateTimeModal'
+import { DateTime } from 'luxon'
+import React, { useCallback, useContext, useState } from 'react'
 import { Absolute } from '../components/Absolute'
 import { Bar } from '../components/Bar'
-import Modal from '../components/Modal'
 import CalibrateScannerModal from '../components/CalibrateScannerModal'
-import AppContext from '../contexts/AppContext'
+import ExportBackupModal from '../components/ExportBackupModal'
 import ExportResultsModal from '../components/ExportResultsModal'
+import { CenteredScreen } from '../components/Layout'
+import Modal from '../components/Modal'
+import PickDateTimeModal from '../components/PickDateTimeModal'
+import AppContext from '../contexts/AppContext'
+import useNow from '../hooks/useNow'
 
 interface Props {
   scannedBallotCount: number
@@ -49,6 +49,7 @@ const AdminScreen: React.FC<Props> = ({
   const [isSettingClock, setIsSettingClock] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   const [isExportingResults, setIsExportingResults] = useState(false)
+  const [isExportingBackup, setIsExportingBackup] = useState(false)
 
   const setClock = useCallback(
     async (date: DateTime) => {
@@ -160,6 +161,11 @@ const AdminScreen: React.FC<Props> = ({
           </Button>
         </p>
         <p>
+          <Button onPress={() => setIsExportingBackup(true)}>
+            Export Backup to USB
+          </Button>
+        </p>
+        <p>
           <Button onPress={openCalibrateScannerModal}>Calibrate Scanner</Button>
         </p>
         <p>
@@ -224,6 +230,13 @@ const AdminScreen: React.FC<Props> = ({
           usbDriveEject={usbDriveEject}
           isTestMode={isTestMode}
           scannedBallotCount={scannedBallotCount}
+        />
+      )}
+      {isExportingBackup && (
+        <ExportBackupModal
+          onClose={() => setIsExportingBackup(false)}
+          usbDriveStatus={usbDriveStatus}
+          usbDriveEject={usbDriveEject}
         />
       )}
     </CenteredScreen>

--- a/apps/precinct-scanner/src/utils/download.test.ts
+++ b/apps/precinct-scanner/src/utils/download.test.ts
@@ -1,0 +1,191 @@
+import { fakeKiosk } from '@votingworks/test-utils'
+import fetchMock from 'fetch-mock'
+import fakeFileWriter from '../../test/helpers/fakeFileWriter'
+import {
+  download,
+  DownloadErrorKind,
+  readContentDispositionFilename,
+} from './download'
+
+test('readContentDispositionFilename', async () => {
+  expect(readContentDispositionFilename('')).toBeUndefined()
+  expect(readContentDispositionFilename('attachment')).toBeUndefined()
+  expect(readContentDispositionFilename('inline')).toBeUndefined()
+  expect(
+    readContentDispositionFilename('attachment: filename=file.txt')
+  ).toEqual('file.txt')
+  expect(
+    readContentDispositionFilename(
+      'attachment: filename="file with spaces.txt"'
+    )
+  ).toEqual('file with spaces.txt')
+})
+
+test('download without kiosk-browser', async () => {
+  delete window.kiosk
+
+  const location: Location = {
+    ...window.location,
+    assign: jest.fn(),
+  }
+
+  jest.spyOn(window, 'location', 'get').mockReturnValue(location)
+  ;(await download('/file.txt')).unsafeUnwrap()
+  expect(window.location.assign).toHaveBeenCalledWith('/file.txt')
+})
+
+test('download with kiosk-browser and status!=200', async () => {
+  const kiosk = fakeKiosk()
+  window.kiosk = kiosk
+
+  fetchMock.getOnce('/file.txt', { status: 404, body: '' })
+
+  const result = await download('/file.txt')
+  expect(result.err()).toEqual({
+    kind: DownloadErrorKind.FetchFailed,
+    response: expect.any(Response),
+  })
+})
+
+test('download with kiosk-browser and no content-disposition', async () => {
+  const kiosk = fakeKiosk()
+  window.kiosk = kiosk
+
+  fetchMock.getOnce('/file.txt', { status: 200, body: '', headers: {} })
+
+  const result = await download('/file.txt')
+  expect(result.err()).toEqual({
+    kind: DownloadErrorKind.FileMissing,
+    response: expect.any(Response),
+  })
+})
+
+test('download with kiosk-browser and no body', async () => {
+  const kiosk = fakeKiosk()
+  window.kiosk = kiosk
+
+  fetchMock.getOnce('/file.txt', {
+    status: 200,
+    body: undefined,
+    headers: { 'Content-Disposition': 'attachment; filename=abc.txt' },
+  })
+
+  const result = await download('/file.txt')
+  expect(result.err()).toEqual({
+    kind: DownloadErrorKind.FileMissing,
+    response: expect.any(Response),
+  })
+})
+
+test('download with kiosk-browser and no content-disposition filename', async () => {
+  const kiosk = fakeKiosk()
+  window.kiosk = kiosk
+
+  fetchMock.getOnce('/file.txt', {
+    status: 200,
+    body: '',
+    headers: { 'Content-Disposition': 'inline' },
+  })
+
+  const result = await download('/file.txt')
+  expect(result.err()).toEqual({
+    kind: DownloadErrorKind.FileMissing,
+    response: expect.any(Response),
+  })
+})
+
+test('download with kiosk-browser and a content-disposition filename', async () => {
+  const kiosk = fakeKiosk()
+  window.kiosk = kiosk
+
+  fetchMock.getOnce('/file.txt', {
+    status: 200,
+    body: '',
+    headers: { 'Content-Disposition': 'attachment; filename=abc.txt' },
+  })
+
+  kiosk.saveAs.mockResolvedValueOnce(undefined)
+  const result = await download('/file.txt')
+  expect(result.err()).toEqual({
+    kind: DownloadErrorKind.NoFileChosen,
+  })
+})
+
+test('download with kiosk-browser and chosen file path is un-writable', async () => {
+  const kiosk = fakeKiosk()
+  window.kiosk = kiosk
+
+  fetchMock.getOnce('/file.txt', {
+    status: 200,
+    body: '',
+    headers: { 'Content-Disposition': 'attachment; filename=abc.txt' },
+  })
+
+  kiosk.saveAs.mockRejectedValueOnce(new Error('EPERM'))
+  const result = await download('/file.txt')
+  expect(result.err()).toEqual({
+    kind: DownloadErrorKind.OpenFailed,
+    path: 'abc.txt',
+    error: new Error('EPERM'),
+  })
+})
+
+test('download with kiosk-browser and chosen file path is writable', async () => {
+  const kiosk = fakeKiosk()
+  window.kiosk = kiosk
+
+  fetchMock.getOnce('/file.txt', {
+    status: 200,
+    body: 'a file body',
+    headers: { 'Content-Disposition': 'attachment; filename=abc.txt' },
+  })
+
+  const fileWriter = fakeFileWriter()
+  kiosk.saveAs.mockResolvedValueOnce(fileWriter)
+  const result = await download('/file.txt')
+  result.unsafeUnwrap()
+  expect(fileWriter.write).toHaveBeenCalledWith(Buffer.from('a file body'))
+  expect(fileWriter.end).toHaveBeenCalled()
+})
+
+test('download with kiosk-browser with a target directory', async () => {
+  const kiosk = fakeKiosk()
+  window.kiosk = kiosk
+
+  fetchMock.getOnce('/file.txt', {
+    status: 200,
+    body: 'a file body',
+    headers: { 'Content-Disposition': 'attachment; filename=abc.txt' },
+  })
+
+  const fileWriter = fakeFileWriter()
+  // `writeFile` is overloaded in such a way to have different return types,
+  // which confuses TS. There's no good way around this that I can find.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  kiosk.writeFile.mockResolvedValueOnce(fileWriter as any)
+  const result = await download('/file.txt', { into: '/some/directory' })
+  result.unsafeUnwrap()
+  expect(kiosk.makeDirectory).toHaveBeenCalledWith('/some/directory', {
+    recursive: true,
+  })
+  expect(kiosk.writeFile).toHaveBeenCalledWith('/some/directory/abc.txt')
+})
+
+test('download with kiosk-browser with a target directory and un-writable path', async () => {
+  const kiosk = fakeKiosk()
+  window.kiosk = kiosk
+
+  fetchMock.getOnce('/file.txt', {
+    status: 200,
+    body: 'a file body',
+    headers: { 'Content-Disposition': 'attachment; filename=abc.txt' },
+  })
+
+  kiosk.writeFile.mockRejectedValueOnce(new Error('EPERM'))
+  const result = await download('/file.txt', { into: '/some/directory' })
+  expect(result.err()).toEqual({
+    kind: DownloadErrorKind.OpenFailed,
+    path: '/some/directory/abc.txt',
+    error: new Error('EPERM'),
+  })
+})

--- a/apps/precinct-scanner/src/utils/download.ts
+++ b/apps/precinct-scanner/src/utils/download.ts
@@ -1,0 +1,134 @@
+import { err, ok, Result } from '@votingworks/types'
+import { join } from 'path'
+
+/**
+ * Extract the filename from a `Content-Disposition` header.
+ *
+ * @example
+ *
+ * readContentDispositionFilename('Content-Disposition: attachment; filename="cool.html"')
+ * // returns 'cool.html'
+ *
+ * readContentDispositionFilename('Content-Disposition: attachment')
+ * // returns undefined
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition
+ */
+export function readContentDispositionFilename(
+  header: string
+): string | undefined {
+  const match = header.match(/filename=(?:"([^"]+)"|(\S+))\s*$/)
+
+  if (match) {
+    const [, quoted, unquoted] = match
+    return quoted || unquoted
+  }
+}
+
+export enum DownloadErrorKind {
+  FetchFailed = 'FetchFailed',
+  FileMissing = 'FileMissing',
+  OpenFailed = 'OpenFailed',
+  NoFileChosen = 'NoFileChosen',
+}
+
+export type DownloadError =
+  | { kind: DownloadErrorKind.FetchFailed; response: Response }
+  | { kind: DownloadErrorKind.FileMissing; response: Response }
+  | { kind: DownloadErrorKind.OpenFailed; path: string; error: Error }
+  | { kind: DownloadErrorKind.NoFileChosen }
+
+/**
+ * Download data from `url`. By default, this will either use the browser's
+ * native download functionality or show kiosk-browser's file picker. If inside
+ * kiosk-browser, a target directory may be specified for a UI-less experience.
+ */
+export async function download(
+  url: string,
+  { into: directory }: { into?: string } = {}
+): Promise<Result<void, DownloadError>> {
+  if (window.kiosk) {
+    return kioskDownload(window.kiosk, url, directory)
+  }
+
+  window.location.assign(url)
+  return ok()
+}
+
+async function kioskDownload(
+  kiosk: KioskBrowser.Kiosk,
+  url: string,
+  directory?: string
+): Promise<Result<void, DownloadError>> {
+  const abortController = new AbortController()
+  const response = await fetch(url, { signal: abortController.signal })
+
+  if (response.status !== 200) {
+    return err({ kind: DownloadErrorKind.FetchFailed, response })
+  }
+
+  const contentDisposition = response.headers.get('content-disposition')
+  const filename =
+    contentDisposition && readContentDispositionFilename(contentDisposition)
+
+  if (!filename) {
+    return err({ kind: DownloadErrorKind.FileMissing, response })
+  }
+
+  const { body } = response
+
+  if (!body) {
+    abortController.abort()
+    return err({ kind: DownloadErrorKind.FileMissing, response })
+  }
+
+  let downloadTarget: KioskBrowser.FileWriter
+  if (directory) {
+    await kiosk.makeDirectory(directory, { recursive: true })
+    const path = join(directory, filename)
+    try {
+      downloadTarget = await kiosk.writeFile(path)
+    } catch (error) {
+      return err({ kind: DownloadErrorKind.OpenFailed, path, error })
+    }
+  } else {
+    try {
+      const saveAsTarget = await kiosk.saveAs({ defaultPath: filename })
+
+      if (!saveAsTarget) {
+        return err({ kind: DownloadErrorKind.NoFileChosen })
+      }
+
+      downloadTarget = saveAsTarget
+    } catch (error) {
+      return err({ kind: DownloadErrorKind.OpenFailed, path: filename, error })
+    }
+  }
+
+  /* istanbul ignore next - fetch-mock does not support fetch Readable/WritableStream APIs */
+  if (typeof body.pipeTo === 'function') {
+    await new Promise<void>((resolve, reject) => {
+      body.pipeTo(
+        new WritableStream({
+          abort(error) {
+            reject(error)
+          },
+
+          write(chunk) {
+            downloadTarget.write(chunk)
+          },
+
+          close() {
+            downloadTarget.end()
+            resolve()
+          },
+        })
+      )
+    })
+  } else {
+    await downloadTarget.write((body as unknown) as Uint8Array)
+    await downloadTarget.end()
+  }
+
+  return ok()
+}

--- a/libs/utils/src/filenames.ts
+++ b/libs/utils/src/filenames.ts
@@ -8,6 +8,7 @@ const TIME_FORMAT_STRING = `YYYY${WORD_SEPARATOR}MM${WORD_SEPARATOR}DD${SUBSECTI
 
 export const BALLOT_PACKAGE_FOLDER = 'ballot-packages'
 export const SCANNER_RESULTS_FOLDER = 'cast-vote-records'
+export const SCANNER_BACKUPS_FOLDER = 'scanner-backups'
 
 export type ElectionData = {
   electionCounty: string


### PR DESCRIPTION
This adds a "Export Backup to USB" button to the Admin screen. It's a little too close to "Export Results to USB" for me to be comfortable with it, so I think we should fix the UI before really putting this on a customer device.

![image](https://user-images.githubusercontent.com/1938/124792874-6c5bd200-df1b-11eb-8777-a3fa2ea1a523.png)

Closes #670 