### PR TITLE
test(bmd): bump timeout on `AppContestMsEitherNeither`

### DIFF
--- a/apps/bmd/src/AppContestMsEitherNeither.test.tsx
+++ b/apps/bmd/src/AppContestMsEitherNeither.test.tsx
@@ -28,6 +28,8 @@ import {
 } from '../test/helpers/election'
 import { fakeMachineConfigProvider } from '../test/helpers/fakeMachineConfig'
 
+jest.setTimeout(10_000)
+
 test('Renders Ballot with EitherNeither: blank', async () => {
   const electionDefinition = asElectionDefinition(parseElection(electionSample))
   const { election } = electionDefinition


### PR DESCRIPTION
I was seeing it time out locally sometimes, so let's double the timeout to 10s.