### PR TITLE
refactor(bmd): use `undefined` for missing values

### DIFF
--- a/apps/bmd/src/components/ElectionInfo.tsx
+++ b/apps/bmd/src/components/ElectionInfo.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components'
 
 import {
   ElectionDefinition,
-  Precinct,
   getPartyPrimaryAdjectiveFromBallotStyle,
 } from '@votingworks/types'
 import { formatLongDate } from '@votingworks/utils/build'
@@ -38,7 +37,7 @@ const HorizontalContainer = styled.div`
 `
 
 interface Props {
-  precinctId: string
+  precinctId?: string
   ballotStyleId?: string
   electionDefinition: ElectionDefinition
   horizontal?: boolean
@@ -52,9 +51,7 @@ const ElectionInfo: React.FC<Props> = ({
 }) => {
   const { election } = electionDefinition
   const { title: t, state, county, date, seal, sealURL } = election
-  const precinct = election.precincts.find(
-    (p) => p.id === precinctId
-  ) as Precinct
+  const precinct = election.precincts.find((p) => p.id === precinctId)
   const partyPrimaryAdjective = ballotStyleId
     ? getPartyPrimaryAdjectiveFromBallotStyle({
         election,
@@ -100,7 +97,7 @@ const ElectionInfo: React.FC<Props> = ({
           <br />
           {state}
         </p>
-        <Text bold>{precinct.name}</Text>
+        {precinct && <Text bold>{precinct.name}</Text>}
       </Prose>
     </VerticalContainer>
   )

--- a/apps/bmd/src/config/types.ts
+++ b/apps/bmd/src/config/types.ts
@@ -86,14 +86,14 @@ export type UpdateVoteFunction = (contestId: string, vote: OptionalVote) => void
 export type MarkVoterCardFunction = () => Promise<boolean>
 export interface BallotContextInterface {
   machineConfig: MachineConfig
-  ballotStyleId: string
+  ballotStyleId?: string
   contests: Contests
-  readonly electionDefinition: ElectionDefinition
+  readonly electionDefinition?: ElectionDefinition
   isCardlessVoter: boolean
   isLiveMode: boolean
   markVoterCardPrinted: MarkVoterCardFunction
   markVoterCardVoided: MarkVoterCardFunction
-  precinctId: string
+  precinctId?: string
   printer: Printer
   resetBallot: (instructions?: PostVotingInstructions) => void
   setUserSettings: SetUserSettings

--- a/apps/bmd/src/contexts/ballotContext.ts
+++ b/apps/bmd/src/contexts/ballotContext.ts
@@ -1,5 +1,4 @@
 import { createContext } from 'react'
-import { Election, ElectionDefinition } from '@votingworks/types'
 import * as GLOBALS from '../config/globals'
 
 import { NullPrinter } from '../utils/printer'
@@ -11,17 +10,11 @@ import {
 
 const ballot: BallotContextInterface = {
   machineConfig: { machineId: '000', appMode: VxMarkOnly, codeVersion: 'dev' },
-  ballotStyleId: '',
   contests: [],
-  electionDefinition: {
-    election: (undefined as unknown) as Election,
-    electionHash: '',
-  } as ElectionDefinition,
   isCardlessVoter: false,
   isLiveMode: false,
   markVoterCardVoided: async () => false,
   markVoterCardPrinted: async () => false,
-  precinctId: '',
   printer: new NullPrinter(),
   resetBallot: () => undefined,
   setUserSettings: () => undefined,

--- a/apps/bmd/src/pages/AdminScreen.tsx
+++ b/apps/bmd/src/pages/AdminScreen.tsx
@@ -1,7 +1,7 @@
 import { DateTime } from 'luxon'
 import React, { useCallback, useState } from 'react'
 
-import { OptionalElectionDefinition } from '@votingworks/types'
+import { ElectionDefinition } from '@votingworks/types'
 import { formatFullDateTimeZone } from '@votingworks/utils'
 import { Button, SegmentedButton } from '@votingworks/ui'
 import { MachineConfig, SelectChangeEventFunction } from '../config/types'
@@ -20,9 +20,9 @@ import PickDateTimeModal from '../components/PickDateTimeModal'
 import useNow from '../hooks/useNow'
 
 interface Props {
-  appPrecinctId: string
+  appPrecinctId?: string
   ballotsPrintedCount: number
-  electionDefinition: OptionalElectionDefinition
+  electionDefinition?: ElectionDefinition
   isLiveMode: boolean
   fetchElection: VoidFunction
   updateAppPrecinctId: (appPrecinctId: string) => void
@@ -103,7 +103,7 @@ const AdminScreen: React.FC<Props> = ({
                 <p>
                   <Select
                     id="selectPrecinct"
-                    value={appPrecinctId}
+                    value={appPrecinctId ?? ''}
                     onBlur={changeAppPrecinctId}
                     onChange={changeAppPrecinctId}
                   >

--- a/apps/bmd/src/pages/ContestPage.tsx
+++ b/apps/bmd/src/pages/ContestPage.tsx
@@ -1,3 +1,4 @@
+import { ok } from 'assert'
 import React, { useContext, useEffect, useState } from 'react'
 import { RouteComponentProps } from 'react-router-dom'
 import { CandidateVote, OptionalYesNoVote } from '@votingworks/types'
@@ -35,6 +36,7 @@ const ContestPage: React.FC<RouteComponentProps<ContestParams>> = (props) => {
     userSettings,
     votes,
   } = useContext(BallotContext)
+  ok(electionDefinition, 'electionDefinition is required to render ContestPage')
   const { election } = electionDefinition
   const currentContestIndex = parseInt(contestNumber, 10)
   const contest = contests[currentContestIndex]

--- a/apps/bmd/src/pages/PollWorkerScreen.tsx
+++ b/apps/bmd/src/pages/PollWorkerScreen.tsx
@@ -36,9 +36,10 @@ import VersionsData from '../components/VersionsData'
 
 interface Props {
   activateCardlessBallotStyleId: (id: string) => void
+  resetCardlessBallot: () => void
   appPrecinctId: string
   ballotsPrintedCount: number
-  ballotStyleId: string
+  ballotStyleId?: string
   electionDefinition: ElectionDefinition
   enableLiveMode: () => void
   hasVotes: boolean
@@ -55,6 +56,7 @@ interface Props {
 
 const PollWorkerScreen: React.FC<Props> = ({
   activateCardlessBallotStyleId,
+  resetCardlessBallot,
   appPrecinctId,
   ballotsPrintedCount,
   ballotStyleId,
@@ -192,12 +194,7 @@ const PollWorkerScreen: React.FC<Props> = ({
                 Remove card to allow voter to continue voting, or reset ballot.
               </p>
               <p>
-                <Button
-                  danger
-                  onPress={() => {
-                    activateCardlessBallotStyleId('')
-                  }}
-                >
+                <Button danger onPress={resetCardlessBallot}>
                   Reset Ballot
                 </Button>
               </p>
@@ -234,12 +231,7 @@ const PollWorkerScreen: React.FC<Props> = ({
                 Deactivate this ballot style to select another ballot style.
               </Text>
               <Text center>
-                <Button
-                  small
-                  onPress={() => {
-                    activateCardlessBallotStyleId('')
-                  }}
-                >
+                <Button small onPress={resetCardlessBallot}>
                   Deactivate Ballot Style {ballotStyleId}
                 </Button>
               </Text>

--- a/apps/bmd/src/pages/PrintOnlyScreen.tsx
+++ b/apps/bmd/src/pages/PrintOnlyScreen.tsx
@@ -30,13 +30,13 @@ const TopRightContent = styled.div`
 `
 
 interface Props {
-  ballotStyleId: string
+  ballotStyleId?: string
   ballotsPrintedCount: number
   electionDefinition: ElectionDefinition
   isLiveMode: boolean
   isVoterCardPresent: boolean
   markVoterCardPrinted: MarkVoterCardFunction
-  precinctId: string
+  precinctId?: string
   printer: Printer
   useEffectToggleLargeDisplay: () => void
   showNoChargerAttachedWarning: boolean
@@ -209,12 +209,13 @@ const PrintOnlyScreen: React.FC<Props> = ({
         </Main>
       </Screen>
       {isReadyToPrint && (
+        // TODO: remove `!` here once we upgrade to TS 4.4 (https://devblogs.microsoft.com/typescript/announcing-typescript-4-4-beta/#cfa-aliased-conditions)
         <PrintedBallot
-          ballotStyleId={ballotStyleId}
+          ballotStyleId={ballotStyleId!}
           electionDefinition={electionDefinition}
           isLiveMode={isLiveMode}
-          precinctId={precinctId}
-          votes={votes!} // votes exists because isReadyToPrint implies votes!=undefined , but tsc unable to reason about it
+          precinctId={precinctId!}
+          votes={votes!}
         />
       )}
     </React.Fragment>

--- a/apps/bmd/src/pages/PrintPage.tsx
+++ b/apps/bmd/src/pages/PrintPage.tsx
@@ -1,3 +1,4 @@
+import { ok } from 'assert'
 import React, { useCallback, useContext, useEffect, useRef } from 'react'
 import styled from 'styled-components'
 import { ProgressEllipsis } from '@votingworks/ui'
@@ -28,6 +29,9 @@ const PrintPage: React.FC = () => {
     updateTally,
     votes,
   } = useContext(BallotContext)
+  ok(electionDefinition, 'electionDefinition is required to render PrintPage')
+  ok(ballotStyleId, 'ballotStyleId is required to render PrintPage')
+  ok(precinctId, 'precinctId is required to render PrintPage')
   const printerTimer = useRef(0)
 
   const printBallot = useCallback(async () => {

--- a/apps/bmd/src/pages/ReviewPage.tsx
+++ b/apps/bmd/src/pages/ReviewPage.tsx
@@ -1,3 +1,4 @@
+import { ok } from 'assert'
 import pluralize from 'pluralize'
 import React, {
   useCallback,
@@ -368,6 +369,7 @@ const ReviewPage: React.FC = () => {
     userSettings,
     setUserSettings,
   } = context
+  ok(electionDefinition, 'electionDefinition is required to render ReviewPage')
   const { election } = electionDefinition
   const { parties } = election
 

--- a/apps/bmd/src/pages/StartPage.test.tsx
+++ b/apps/bmd/src/pages/StartPage.test.tsx
@@ -34,6 +34,7 @@ it('renders StartPage with inline SVG', async () => {
   )
   const { container } = render(<Route path="/" component={StartPage} />, {
     electionDefinition,
+    ballotStyleId: '12',
     precinctId: '23',
     route: '/',
   })
@@ -46,6 +47,7 @@ it('renders StartPage with no seal', async () => {
   )
   const { container } = render(<Route path="/" component={StartPage} />, {
     electionDefinition,
+    ballotStyleId: '12',
     precinctId: '23',
     route: '/',
   })

--- a/apps/bmd/src/pages/StartPage.tsx
+++ b/apps/bmd/src/pages/StartPage.tsx
@@ -1,3 +1,4 @@
+import { ok } from 'assert'
 import React, { useContext, useEffect, useRef } from 'react'
 import styled from 'styled-components'
 import { RouteComponentProps, withRouter } from 'react-router-dom'
@@ -30,6 +31,8 @@ const StartPage: React.FC<Props> = ({ history }) => {
     userSettings,
     forceSaveVote,
   } = useContext(BallotContext)
+  ok(electionDefinition, 'electionDefinition is required to render StartPage')
+  ok(ballotStyleId, 'ballotStyleId is required to render StartPage')
   const audioFocus = useRef<HTMLDivElement>(null) // eslint-disable-line no-restricted-syntax
   const { election } = electionDefinition
   const { title } = election

--- a/apps/bmd/src/pages/TestBallotDeckScreen.tsx
+++ b/apps/bmd/src/pages/TestBallotDeckScreen.tsx
@@ -109,7 +109,7 @@ interface Precinct {
 }
 
 interface Props {
-  appPrecinctId: string
+  appPrecinctId?: string
   electionDefinition: ElectionDefinition
   hideTestDeck: () => void
   isLiveMode: boolean

--- a/apps/bmd/src/pages/__snapshots__/ContestPage.test.tsx.snap
+++ b/apps/bmd/src/pages/__snapshots__/ContestPage.test.tsx.snap
@@ -806,7 +806,6 @@ exports[`Renders ContestPage 1`] = `
                 class="c27"
               >
                  
-                
               </p>
             </div>
           </div>

--- a/apps/bmd/src/pages/__snapshots__/StartPage.test.tsx.snap
+++ b/apps/bmd/src/pages/__snapshots__/StartPage.test.tsx.snap
@@ -1366,10 +1366,15 @@ exports[`renders StartPage with inline SVG 1`] = `
                 class="c19"
               >
                 Center Springfield
-                
+                , 
               </span>
                
-              
+              <span
+                class="c19"
+              >
+                ballot style 
+                12
+              </span>
             </p>
           </div>
         </div>
@@ -1966,10 +1971,15 @@ exports[`renders StartPage with no seal 1`] = `
                 class="c19"
               >
                 Center Springfield
-                
+                , 
               </span>
                
-              
+              <span
+                class="c19"
+              >
+                ballot style 
+                12
+              </span>
             </p>
           </div>
         </div>

--- a/apps/bmd/test/testUtils.tsx
+++ b/apps/bmd/test/testUtils.tsx
@@ -33,7 +33,7 @@ export function render(
   component: React.ReactNode,
   {
     route = '/',
-    ballotStyleId = '',
+    ballotStyleId,
     electionDefinition = asElectionDefinition(
       parseElection(electionSampleNoSeal)
     ),
@@ -44,7 +44,7 @@ export function render(
     isCardlessVoter = false,
     isLiveMode = false,
     machineConfig = fakeMachineConfig({ appMode: VxMarkOnly }),
-    precinctId = '',
+    precinctId,
     printer = fakePrinter(),
     resetBallot = jest.fn(),
     setUserSettings = jest.fn(),


### PR DESCRIPTION
Rather than using the empty string or similar as a de facto "unset" value, just use `undefined`. This ensures we're more explicit about which components/screens actually require a precinct/ballot style IDs and which do not.