### PR TITLE
fix(types): correct return types

### DIFF
--- a/apps/bmd/src/pages/PollWorkerScreen.tsx
+++ b/apps/bmd/src/pages/PollWorkerScreen.tsx
@@ -49,9 +49,9 @@ interface Props {
   printer: Printer
   tally: Tally
   togglePollsOpen: () => void
-  saveTallyToCard: (cardTally: CardTally) => void
+  saveTallyToCard: (cardTally: CardTally) => Promise<void>
   talliesOnCard: Optional<CardTally>
-  clearTalliesOnCard: () => void
+  clearTalliesOnCard: () => Promise<void>
 }
 
 const PollWorkerScreen: React.FC<Props> = ({


### PR DESCRIPTION
These functions are actually async, but we weren't typing them as such. We were `await`ing the result correctly so the runtime behavior was correct, but VS Code flagged the `await`s as unnecessary because the return types were wrong.