### PR TITLE
feat(bmd): allow selection of All Precincts

### DIFF
--- a/apps/bmd/src/AppCardlessVoting.test.tsx
+++ b/apps/bmd/src/AppCardlessVoting.test.tsx
@@ -116,19 +116,19 @@ test('Cardless Voting Flow', async () => {
 
   // ---------------
 
-  // Activate Ballot Style for Cardless Voter
+  // Activate Voter Session for Cardless Voter
   card.insertCard(pollWorkerCard)
   await advanceTimersAndPromises()
-  screen.getByText('Activate Ballot Style')
-  fireEvent.click(within(screen.getByTestId('precincts')).getByText('12'))
-  screen.getByText('Ballot style 12 has been activated.')
+  screen.getByText('Activate Voter Session')
+  fireEvent.click(within(screen.getByTestId('ballot-styles')).getByText('12'))
+  screen.getByText('Voter session activated: 12')
 
   // Poll Worker deactivates ballot style
-  fireEvent.click(screen.getByText('Deactivate Ballot Style 12'))
-  screen.getByText('Activate Ballot Style')
+  fireEvent.click(screen.getByText('Deactivate Voter Session'))
+  screen.getByText('Activate Voter Session')
 
   // Poll Worker reactivates ballot style
-  fireEvent.click(within(screen.getByTestId('precincts')).getByText('12'))
+  fireEvent.click(within(screen.getByTestId('ballot-styles')).getByText('12'))
 
   // Poll Worker removes their card
   card.removeCard()
@@ -152,11 +152,11 @@ test('Cardless Voting Flow', async () => {
   fireEvent.click(screen.getByText('Reset Ballot'))
 
   // Back on Poll Worker screen
-  screen.getByText('Activate Ballot Style')
+  screen.getByText('Activate Voter Session')
 
   // Activates Ballot Style again
-  fireEvent.click(within(screen.getByTestId('precincts')).getByText('12'))
-  screen.getByText('Ballot style 12 has been activated.')
+  fireEvent.click(within(screen.getByTestId('ballot-styles')).getByText('12'))
+  screen.getByText('Voter session activated: 12')
 
   // Poll Worker removes their card
   card.removeCard()
@@ -240,11 +240,11 @@ test('Another Voter submits blank ballot and clicks Done', async () => {
 
   // ====================== END CONTEST SETUP ====================== //
 
-  // Activate Ballot Style for Cardless Voter
+  // Activate Voter Session for Cardless Voter
   card.insertCard(pollWorkerCard)
   await advanceTimersAndPromises()
-  fireEvent.click(within(screen.getByTestId('precincts')).getByText('12'))
-  screen.getByText('Ballot style 12 has been activated.')
+  fireEvent.click(within(screen.getByTestId('ballot-styles')).getByText('12'))
+  screen.getByText('Voter session activated: 12')
 
   // Poll Workder removes their card
   card.removeCard()
@@ -285,5 +285,185 @@ test('Another Voter submits blank ballot and clicks Done', async () => {
 
   // Click "Done" to get back to Insert Card screen
   fireEvent.click(screen.getByText('Done'))
+  screen.getByText('Insert voter card to load ballot.')
+})
+
+test('poll worker must select a precinct first', async () => {
+  const electionDefinition = electionSampleDefinition
+  const { electionData, electionHash } = electionDefinition
+  const card = new MemoryCard()
+  const adminCard = adminCardForElection(electionHash)
+  const pollWorkerCard = pollWorkerCardForElection(electionHash)
+  const hardware = await MemoryHardware.buildStandard()
+  const printer = fakePrinter()
+  const storage = new MemoryStorage()
+  const machineConfig = fakeMachineConfigProvider({
+    appMode: VxMarkPlusVxPrint,
+  })
+  render(
+    <App
+      card={card}
+      hardware={hardware}
+      machineConfig={machineConfig}
+      printer={printer}
+      storage={storage}
+    />
+  )
+  await advanceTimersAndPromises()
+  const getByTextWithMarkup = withMarkup(screen.getByText)
+
+  card.removeCard()
+  await advanceTimersAndPromises()
+
+  // Default Unconfigured
+  screen.getByText('Device Not Configured')
+
+  // ---------------
+
+  // Configure with Admin Card
+  card.insertCard(adminCard, electionData)
+  await advanceTimersAndPromises()
+  fireEvent.click(screen.getByText('Load Election Definition'))
+
+  await advanceTimersAndPromises()
+  screen.getByText('Election definition is loaded.')
+  screen.getByLabelText('Precinct')
+  screen.queryByText(`Election ID: ${electionHash.slice(0, 10)}`)
+
+  // Select precinct
+  screen.getByText('State of Hamilton')
+  const precinctSelect = screen.getByLabelText('Precinct')
+  const precinctId = (within(precinctSelect).getByText(
+    'All Precincts'
+  ) as HTMLOptionElement).value
+  fireEvent.change(precinctSelect, { target: { value: precinctId } })
+  within(screen.getByTestId('election-info')).getByText('All Precincts')
+
+  fireEvent.click(screen.getByText('Live Election Mode'))
+  expect(
+    (screen.getByText('Live Election Mode') as HTMLButtonElement).disabled
+  ).toBeTruthy()
+
+  // Remove card
+  card.removeCard()
+  await advanceTimersAndPromises()
+  screen.getByText('Polls Closed')
+  screen.getByText('Insert Poll Worker card to open.')
+
+  // ---------------
+
+  // Open Polls with Poll Worker Card
+  card.insertCard(pollWorkerCard)
+  await advanceTimersAndPromises()
+  fireEvent.click(screen.getByText('Open Polls for All Precincts'))
+  screen.getByText('Open polls and print Polls Opened report?')
+  fireEvent.click(within(screen.getByTestId('modal')).getByText('Yes'))
+  await advanceTimersAndPromises()
+  screen.getByText('Printing Polls Opened report for All Precincts')
+  await advanceTimersAndPromises(REPORT_PRINTING_TIMEOUT_SECONDS)
+  expect(printer.print).toHaveBeenCalledTimes(1)
+
+  // Remove card
+  card.removeCard()
+  await advanceTimersAndPromises()
+  screen.getByText('Insert voter card to load ballot.')
+
+  // ---------------
+
+  // Activate Voter Session for Cardless Voter
+  card.insertCard(pollWorkerCard)
+  await advanceTimersAndPromises()
+  screen.getByText('Activate Voter Session')
+  fireEvent.click(
+    within(screen.getByTestId('precincts')).getByText('Center Springfield')
+  )
+  fireEvent.click(within(screen.getByTestId('ballot-styles')).getByText('12'))
+  screen.getByText('Voter session activated: 12 @ Center Springfield')
+
+  // Poll Worker deactivates ballot style
+  fireEvent.click(screen.getByText('Deactivate Voter Session'))
+  screen.getByText('Activate Voter Session')
+
+  // Poll Worker reactivates ballot style
+  fireEvent.click(
+    within(screen.getByTestId('precincts')).getByText('Center Springfield')
+  )
+  fireEvent.click(within(screen.getByTestId('ballot-styles')).getByText('12'))
+
+  // Poll Worker removes their card
+  card.removeCard()
+  await advanceTimersAndPromises()
+
+  // Voter Ballot Style is active
+  screen.getByText(/ballot style 12/)
+  getByTextWithMarkup('Your ballot has 21 contests.')
+  fireEvent.click(screen.getByText('Start Voting'))
+
+  // Voter votes in first contest
+  fireEvent.click(screen.getByText(presidentContest.candidates[0].name))
+  fireEvent.click(screen.getByText('Next'))
+
+  // Poll Worker inserts card and sees message that there are votes
+  card.insertCard(pollWorkerCard)
+  await advanceTimersAndPromises()
+  screen.getByText('Ballot Contains Votes')
+
+  // Poll Worker resets ballot to remove votes
+  fireEvent.click(screen.getByText('Reset Ballot'))
+
+  // Back on Poll Worker screen
+  screen.getByText('Activate Voter Session')
+
+  // Activates Ballot Style again
+  fireEvent.click(
+    within(screen.getByTestId('precincts')).getByText('Center Springfield')
+  )
+  fireEvent.click(within(screen.getByTestId('ballot-styles')).getByText('12'))
+  screen.getByText('Voter session activated: 12 @ Center Springfield')
+
+  // Poll Worker removes their card
+  card.removeCard()
+  await advanceTimersAndPromises()
+
+  // Voter Ballot Style is active
+  screen.getByText(/ballot style 12/)
+  getByTextWithMarkup('Your ballot has 21 contests.')
+  fireEvent.click(screen.getByText('Start Voting'))
+
+  // Voter makes selection in first contest and then advances to review screen
+  for (let i = 0; i < voterContests.length; i++) {
+    const { title } = voterContests[i]
+
+    await advanceTimersAndPromises()
+    screen.getByText(title)
+
+    // Vote for a candidate contest
+    if (title === presidentContest.title) {
+      fireEvent.click(screen.getByText(presidentContest.candidates[0].name))
+    }
+
+    fireEvent.click(screen.getByText('Next'))
+  }
+
+  // Advance to print ballot
+  fireEvent.click(getByTextWithMarkup('I’m Ready to Print My Ballot'))
+  screen.getByText('Printing Official Ballot')
+
+  // Trigger seal image loaded
+  fireEvent.load(screen.getByTestId('printed-ballot-seal-image'))
+
+  // Reset ballot
+  await advanceTimersAndPromises()
+
+  // Expire timeout for display of "Printing Ballot" screen
+  await advanceTimersAndPromises(GLOBALS.BALLOT_PRINTING_TIMEOUT_SECONDS)
+
+  // Reset Ballot is called with instructions type "cardless"
+  // Show Verify and Cast Instructions
+  screen.getByText('You’re Almost Done')
+  expect(screen.queryByText('3. Return the card to a poll worker.')).toBeFalsy()
+
+  // Wait for timeout to return to Insert Card screen
+  await advanceTimersAndPromises(GLOBALS.BALLOT_INSTRUCTIONS_TIMEOUT_SECONDS)
   screen.getByText('Insert voter card to load ballot.')
 })

--- a/apps/bmd/src/DemoApp.tsx
+++ b/apps/bmd/src/DemoApp.tsx
@@ -11,7 +11,13 @@ import {
 } from '@votingworks/utils'
 import App, { Props } from './App'
 import utcTimestamp from './utils/utcTimestamp'
-import { MachineConfig, VxMarkPlusVxPrint } from './config/types'
+import {
+  MachineConfig,
+  PrecinctSelectionKind,
+  SerializableActivationData,
+  VxMarkPlusVxPrint,
+} from './config/types'
+import { State } from './AppRoot'
 
 const ballotStyleId = '12'
 const precinctId = '23'
@@ -29,23 +35,28 @@ export function getSampleCard(): Card {
 }
 
 export function getDemoStorage(): Storage {
-  return new MemoryStorage({
-    state: {
-      electionDefinition: electionSampleDefinition,
-      appPrecinctId,
-      ballotsPrintedCount: 0,
-      isLiveMode: true,
-      isPollsOpen: true,
-      ballotStyleId,
-      isCardlessVoter: false,
-      precinctId,
-    },
+  const state: Partial<State> = {
     electionDefinition: electionSampleDefinition,
-    activation: {
-      ballotStyleId,
-      isCardlessVoter: false,
-      precinctId,
+    appPrecinct: {
+      kind: PrecinctSelectionKind.SinglePrecinct,
+      precinctId: appPrecinctId,
     },
+    ballotsPrintedCount: 0,
+    isLiveMode: true,
+    isPollsOpen: true,
+    ballotStyleId,
+    isCardlessVoter: false,
+    precinctId,
+  }
+  const activation: SerializableActivationData = {
+    ballotStyleId,
+    isCardlessVoter: false,
+    precinctId,
+  }
+  return new MemoryStorage({
+    state,
+    electionDefinition: electionSampleDefinition,
+    activation,
   })
 }
 

--- a/apps/bmd/src/components/ElectionInfo.test.tsx
+++ b/apps/bmd/src/components/ElectionInfo.test.tsx
@@ -3,11 +3,15 @@ import { render } from '@testing-library/react'
 
 import ElectionInfo from './ElectionInfo'
 import { electionSampleWithSealDefinition as electionDefinition } from '../data'
+import { PrecinctSelectionKind } from '../config/types'
 
 it('renders horizontal ElectionInfo with hash when specified', () => {
   const { container } = render(
     <ElectionInfo
-      precinctId="23"
+      precinctSelection={{
+        kind: PrecinctSelectionKind.SinglePrecinct,
+        precinctId: '23',
+      }}
       electionDefinition={electionDefinition}
       horizontal
     />
@@ -18,7 +22,10 @@ it('renders horizontal ElectionInfo with hash when specified', () => {
 it('renders horizontal ElectionInfo without hash by default', () => {
   const { container } = render(
     <ElectionInfo
-      precinctId="23"
+      precinctSelection={{
+        kind: PrecinctSelectionKind.SinglePrecinct,
+        precinctId: '23',
+      }}
       electionDefinition={electionDefinition}
       horizontal
     />
@@ -28,14 +35,26 @@ it('renders horizontal ElectionInfo without hash by default', () => {
 
 it('renders vertical ElectionInfo with hash when specified', () => {
   const { container } = render(
-    <ElectionInfo precinctId="23" electionDefinition={electionDefinition} />
+    <ElectionInfo
+      precinctSelection={{
+        kind: PrecinctSelectionKind.SinglePrecinct,
+        precinctId: '23',
+      }}
+      electionDefinition={electionDefinition}
+    />
   )
   expect(container).toMatchSnapshot()
 })
 
 it('renders vertical ElectionInfo without hash by default', () => {
   const { container } = render(
-    <ElectionInfo precinctId="23" electionDefinition={electionDefinition} />
+    <ElectionInfo
+      precinctSelection={{
+        kind: PrecinctSelectionKind.SinglePrecinct,
+        precinctId: '23',
+      }}
+      electionDefinition={electionDefinition}
+    />
   )
   expect(container).toMatchSnapshot()
 })

--- a/apps/bmd/src/components/ElectionInfo.tsx
+++ b/apps/bmd/src/components/ElectionInfo.tsx
@@ -11,6 +11,8 @@ import { formatLongDate } from '@votingworks/utils/build'
 import Seal from './Seal'
 import Prose from './Prose'
 import Text, { NoWrap } from './Text'
+import { PrecinctSelection } from '../config/types'
+import { precinctSelectionName } from '../utils/precinctSelection'
 
 const VerticalContainer = styled.div`
   display: block;
@@ -37,21 +39,23 @@ const HorizontalContainer = styled.div`
 `
 
 interface Props {
-  precinctId?: string
+  precinctSelection?: PrecinctSelection
   ballotStyleId?: string
   electionDefinition: ElectionDefinition
   horizontal?: boolean
 }
 
 const ElectionInfo: React.FC<Props> = ({
-  precinctId,
+  precinctSelection,
   ballotStyleId,
   electionDefinition,
   horizontal = false,
 }) => {
   const { election } = electionDefinition
   const { title: t, state, county, date, seal, sealURL } = election
-  const precinct = election.precincts.find((p) => p.id === precinctId)
+  const precinctName =
+    precinctSelection &&
+    precinctSelectionName(election.precincts, precinctSelection)
   const partyPrimaryAdjective = ballotStyleId
     ? getPartyPrimaryAdjectiveFromBallotStyle({
         election,
@@ -72,9 +76,9 @@ const ElectionInfo: React.FC<Props> = ({
               <NoWrap>{county.name},</NoWrap> <NoWrap>{state}</NoWrap>
             </Text>
             <Text small light>
-              {precinct && (
+              {precinctName && (
                 <NoWrap>
-                  {precinct.name}
+                  {precinctName}
                   {ballotStyleId && ', '}
                 </NoWrap>
               )}{' '}
@@ -97,7 +101,7 @@ const ElectionInfo: React.FC<Props> = ({
           <br />
           {state}
         </p>
-        {precinct && <Text bold>{precinct.name}</Text>}
+        {precinctName && <Text bold>{precinctName}</Text>}
       </Prose>
     </VerticalContainer>
   )

--- a/apps/bmd/src/components/PollsReport.tsx
+++ b/apps/bmd/src/components/PollsReport.tsx
@@ -1,5 +1,6 @@
-import { Election, Precinct } from '@votingworks/types'
+import { Election } from '@votingworks/types'
 import {
+  find,
   formatFullDateTimeZone,
   formatLongDate,
   CardTallyMetadataEntry,
@@ -8,7 +9,12 @@ import {
 import { DateTime } from 'luxon'
 import React from 'react'
 import styled from 'styled-components'
-import { AppModeNames, MachineConfig } from '../config/types'
+import {
+  AppModeNames,
+  MachineConfig,
+  PrecinctSelection,
+  PrecinctSelectionKind,
+} from '../config/types'
 
 import Prose from './Prose'
 import Table from './Table'
@@ -84,7 +90,7 @@ interface Props {
   isPollsOpen: boolean
   machineConfig: MachineConfig
   machineMetadata?: readonly CardTallyMetadataEntry[]
-  precinctId: string
+  precinctSelection: PrecinctSelection
   reportPurpose: string
 }
 
@@ -98,11 +104,14 @@ const PollsReport: React.FC<Props> = ({
   machineConfig,
   machineMetadata,
   sourceMachineType,
-  precinctId,
+  precinctSelection,
   reportPurpose,
 }) => {
   const { title, date, county, precincts, state, seal, sealURL } = election
-  const precinct = precincts.find((p) => p.id === precinctId) as Precinct
+  const precinctName =
+    precinctSelection.kind === PrecinctSelectionKind.AllPrecincts
+      ? 'All Precincts'
+      : find(precincts, (p) => p.id === precinctSelection.precinctId).name
   let machineSection = (
     <React.Fragment>
       <dt>Machine ID</dt>
@@ -176,7 +185,7 @@ const PollsReport: React.FC<Props> = ({
         }
         <Prose className="ballot-header-content">
           <h2>
-            {precinct.name}{' '}
+            {precinctName}{' '}
             {
               /* istanbul ignore next */
               !isLiveMode ? 'Unofficial TEST' : 'Official'

--- a/apps/bmd/src/components/PrecinctTallyReport.tsx
+++ b/apps/bmd/src/components/PrecinctTallyReport.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Precinct, Election } from '@votingworks/types'
+import { Election } from '@votingworks/types'
 import {
+  find,
   Tally,
   CandidateVoteTally,
   YesNoVoteTally,
@@ -14,6 +15,7 @@ import numberWithCommas from '../utils/numberWithCommas'
 import Table, { TD } from './Table'
 import Prose from './Prose'
 import { NoWrap } from './Text'
+import { PrecinctSelection, PrecinctSelectionKind } from '../config/types'
 
 const Report = styled.div`
   margin: 0;
@@ -35,7 +37,7 @@ interface Props {
   election: Election
   isPollsOpen: boolean
   tally: Tally
-  precinctId: string
+  precinctSelection: PrecinctSelection
   reportPurpose: string
 }
 
@@ -46,17 +48,23 @@ const PrecinctTallyReport: React.FC<Props> = ({
   election,
   isPollsOpen,
   tally,
-  precinctId,
+  precinctSelection,
   reportPurpose,
 }) => {
   const { ballotStyles, contests, precincts } = election
-  const precinct = precincts.find((p) => p.id === precinctId) as Precinct
+  const precinctName =
+    precinctSelection.kind === PrecinctSelectionKind.AllPrecincts
+      ? 'All Precincts'
+      : find(precincts, (p) => p.id === precinctSelection.precinctId).name
   const ballotAction =
     sourceMachineType === TallySourceMachineType.BMD ? 'printed' : 'scanned'
 
-  const precinctBallotStyles = ballotStyles.filter((bs) =>
-    bs.precincts.includes(precinctId)
-  )
+  const precinctBallotStyles =
+    precinctSelection.kind === PrecinctSelectionKind.AllPrecincts
+      ? ballotStyles
+      : ballotStyles.filter((bs) =>
+          bs.precincts.includes(precinctSelection.precinctId)
+        )
   const precinctContestIds = contests
     .filter((c) =>
       precinctBallotStyles.find(
@@ -67,7 +75,7 @@ const PrecinctTallyReport: React.FC<Props> = ({
   return (
     <Report>
       <h1>
-        <NoWrap>{precinct.name}</NoWrap> <NoWrap>{election.title}</NoWrap>{' '}
+        <NoWrap>{precinctName}</NoWrap> <NoWrap>{election.title}</NoWrap>{' '}
         <NoWrap>Tally Report</NoWrap>
       </h1>
       <p>

--- a/apps/bmd/src/config/types.ts
+++ b/apps/bmd/src/config/types.ts
@@ -81,6 +81,17 @@ export interface SerializableActivationData {
   precinctId: string
 }
 
+/* this is a bug in eslint */
+/* eslint-disable-next-line no-shadow */
+export enum PrecinctSelectionKind {
+  SinglePrecinct = 'SinglePrecinct',
+}
+
+export type PrecinctSelection = {
+  kind: PrecinctSelectionKind.SinglePrecinct
+  precinctId: Precinct['id']
+}
+
 // Ballot
 export type UpdateVoteFunction = (contestId: string, vote: OptionalVote) => void
 export type MarkVoterCardFunction = () => Promise<boolean>

--- a/apps/bmd/src/config/types.ts
+++ b/apps/bmd/src/config/types.ts
@@ -85,12 +85,12 @@ export interface SerializableActivationData {
 /* eslint-disable-next-line no-shadow */
 export enum PrecinctSelectionKind {
   SinglePrecinct = 'SinglePrecinct',
+  AllPrecincts = 'AllPrecincts',
 }
 
-export type PrecinctSelection = {
-  kind: PrecinctSelectionKind.SinglePrecinct
-  precinctId: Precinct['id']
-}
+export type PrecinctSelection =
+  | { kind: PrecinctSelectionKind.AllPrecincts }
+  | { kind: PrecinctSelectionKind.SinglePrecinct; precinctId: Precinct['id'] }
 
 // Ballot
 export type UpdateVoteFunction = (contestId: string, vote: OptionalVote) => void

--- a/apps/bmd/src/pages/AdminScreen.test.tsx
+++ b/apps/bmd/src/pages/AdminScreen.test.tsx
@@ -218,3 +218,50 @@ test('renders date and time settings modal', async () => {
   // Date is reset to system time after save to kiosk-browser
   screen.getByText(startDate)
 })
+
+test('select All Precincts', async () => {
+  const updateAppPrecinct = jest.fn()
+  render(
+    <AdminScreen
+      ballotsPrintedCount={0}
+      electionDefinition={asElectionDefinition(election)}
+      fetchElection={jest.fn()}
+      isLiveMode
+      updateAppPrecinct={updateAppPrecinct}
+      toggleLiveMode={jest.fn()}
+      unconfigure={jest.fn()}
+      machineConfig={fakeMachineConfig()}
+    />
+  )
+
+  const precinctSelect = screen.getByLabelText('Precinct')
+  const allPrecinctsOption = within(precinctSelect).getByText(
+    'All Precincts'
+  ) as HTMLOptionElement
+  fireEvent.change(precinctSelect, {
+    target: { value: allPrecinctsOption.value },
+  })
+  expect(updateAppPrecinct).toHaveBeenCalledWith({
+    kind: PrecinctSelectionKind.AllPrecincts,
+  })
+})
+
+test('render All Precincts', async () => {
+  const updateAppPrecinct = jest.fn()
+  render(
+    <AdminScreen
+      appPrecinct={{ kind: PrecinctSelectionKind.AllPrecincts }}
+      ballotsPrintedCount={0}
+      electionDefinition={asElectionDefinition(election)}
+      fetchElection={jest.fn()}
+      isLiveMode
+      updateAppPrecinct={updateAppPrecinct}
+      toggleLiveMode={jest.fn()}
+      unconfigure={jest.fn()}
+      machineConfig={fakeMachineConfig()}
+    />
+  )
+
+  const precinctSelect = screen.getByLabelText('Precinct') as HTMLSelectElement
+  expect(precinctSelect.selectedOptions[0].textContent).toEqual('All Precincts')
+})

--- a/apps/bmd/src/pages/AdminScreen.test.tsx
+++ b/apps/bmd/src/pages/AdminScreen.test.tsx
@@ -10,7 +10,7 @@ import { election, defaultPrecinctId } from '../../test/helpers/election'
 import { advanceTimers } from '../../test/helpers/smartcards'
 
 import AdminScreen from './AdminScreen'
-import { VxPrintOnly, VxMarkOnly } from '../config/types'
+import { VxPrintOnly, VxMarkOnly, PrecinctSelectionKind } from '../config/types'
 import fakeMachineConfig from '../../test/helpers/fakeMachineConfig'
 
 MockDate.set('2020-10-31T00:00:00.000Z')
@@ -29,12 +29,15 @@ afterEach(() => {
 test('renders ClerkScreen for VxPrintOnly', async () => {
   render(
     <AdminScreen
-      appPrecinctId={defaultPrecinctId}
+      appPrecinct={{
+        kind: PrecinctSelectionKind.SinglePrecinct,
+        precinctId: defaultPrecinctId,
+      }}
       ballotsPrintedCount={0}
       electionDefinition={asElectionDefinition(election)}
       fetchElection={jest.fn()}
       isLiveMode={false}
-      updateAppPrecinctId={jest.fn()}
+      updateAppPrecinct={jest.fn()}
       toggleLiveMode={jest.fn()}
       unconfigure={jest.fn()}
       machineConfig={fakeMachineConfig({
@@ -69,12 +72,15 @@ test('renders ClerkScreen for VxPrintOnly', async () => {
 test('renders date and time settings modal', async () => {
   render(
     <AdminScreen
-      appPrecinctId={defaultPrecinctId}
+      appPrecinct={{
+        kind: PrecinctSelectionKind.SinglePrecinct,
+        precinctId: defaultPrecinctId,
+      }}
       ballotsPrintedCount={0}
       electionDefinition={asElectionDefinition(election)}
       fetchElection={jest.fn()}
       isLiveMode={false}
-      updateAppPrecinctId={jest.fn()}
+      updateAppPrecinct={jest.fn()}
       toggleLiveMode={jest.fn()}
       unconfigure={jest.fn()}
       machineConfig={fakeMachineConfig({

--- a/apps/bmd/src/pages/AdminScreen.tsx
+++ b/apps/bmd/src/pages/AdminScreen.tsx
@@ -22,6 +22,7 @@ import Select from '../components/Select'
 import VersionsData from '../components/VersionsData'
 import PickDateTimeModal from '../components/PickDateTimeModal'
 import useNow from '../hooks/useNow'
+import { AllPrecinctsDisplayName } from '../utils/precinctSelection'
 
 interface Props {
   appPrecinct?: PrecinctSelection
@@ -34,6 +35,8 @@ interface Props {
   unconfigure: () => Promise<void>
   machineConfig: MachineConfig
 }
+
+const ALL_PRECINCTS_OPTION_VALUE = '_ALL'
 
 const AdminScreen: React.FC<Props> = ({
   appPrecinct,
@@ -48,10 +51,16 @@ const AdminScreen: React.FC<Props> = ({
 }) => {
   const election = electionDefinition?.election
   const changeAppPrecinctId: SelectChangeEventFunction = (event) => {
-    updateAppPrecinct({
-      kind: PrecinctSelectionKind.SinglePrecinct,
-      precinctId: event.currentTarget.value,
-    })
+    const precinctId = event.currentTarget.value
+
+    if (precinctId === ALL_PRECINCTS_OPTION_VALUE) {
+      updateAppPrecinct({ kind: PrecinctSelectionKind.AllPrecincts })
+    } else {
+      updateAppPrecinct({
+        kind: PrecinctSelectionKind.SinglePrecinct,
+        precinctId: event.currentTarget.value,
+      })
+    }
   }
 
   const [isFetchingElection, setIsFetchingElection] = useState(false)
@@ -87,7 +96,7 @@ const AdminScreen: React.FC<Props> = ({
   if (isTestDeck && electionDefinition) {
     return (
       <TestBallotDeckScreen
-        appPrecinctId={appPrecinct?.precinctId}
+        appPrecinct={appPrecinct}
         electionDefinition={electionDefinition}
         hideTestDeck={hideTestDeck}
         machineConfig={machineConfig}
@@ -110,12 +119,19 @@ const AdminScreen: React.FC<Props> = ({
                 <p>
                   <Select
                     id="selectPrecinct"
-                    value={appPrecinct?.precinctId ?? ''}
+                    value={
+                      appPrecinct?.kind === PrecinctSelectionKind.AllPrecincts
+                        ? ALL_PRECINCTS_OPTION_VALUE
+                        : appPrecinct?.precinctId ?? ''
+                    }
                     onBlur={changeAppPrecinctId}
                     onChange={changeAppPrecinctId}
                   >
                     <option value="" disabled>
                       Select a precinct for this device…
+                    </option>
+                    <option value={ALL_PRECINCTS_OPTION_VALUE}>
+                      {AllPrecinctsDisplayName}
                     </option>
                     {[...election.precincts]
                       .sort((a, b) =>
@@ -219,7 +235,7 @@ const AdminScreen: React.FC<Props> = ({
             {electionDefinition && (
               <ElectionInfo
                 electionDefinition={electionDefinition}
-                precinctId={appPrecinct?.precinctId}
+                precinctSelection={appPrecinct}
                 horizontal
               />
             )}

--- a/apps/bmd/src/pages/AdminScreen.tsx
+++ b/apps/bmd/src/pages/AdminScreen.tsx
@@ -4,7 +4,12 @@ import React, { useCallback, useState } from 'react'
 import { ElectionDefinition } from '@votingworks/types'
 import { formatFullDateTimeZone } from '@votingworks/utils'
 import { Button, Main, MainChild, SegmentedButton } from '@votingworks/ui'
-import { MachineConfig, SelectChangeEventFunction } from '../config/types'
+import {
+  MachineConfig,
+  PrecinctSelection,
+  PrecinctSelectionKind,
+  SelectChangeEventFunction,
+} from '../config/types'
 
 import TestBallotDeckScreen from './TestBallotDeckScreen'
 
@@ -19,31 +24,34 @@ import PickDateTimeModal from '../components/PickDateTimeModal'
 import useNow from '../hooks/useNow'
 
 interface Props {
-  appPrecinctId?: string
+  appPrecinct?: PrecinctSelection
   ballotsPrintedCount: number
   electionDefinition?: ElectionDefinition
   isLiveMode: boolean
   fetchElection: VoidFunction
-  updateAppPrecinctId: (appPrecinctId: string) => void
+  updateAppPrecinct: (appPrecinct: PrecinctSelection) => void
   toggleLiveMode: VoidFunction
   unconfigure: () => Promise<void>
   machineConfig: MachineConfig
 }
 
 const AdminScreen: React.FC<Props> = ({
-  appPrecinctId,
+  appPrecinct,
   ballotsPrintedCount,
   electionDefinition,
   isLiveMode,
   fetchElection,
-  updateAppPrecinctId,
+  updateAppPrecinct,
   toggleLiveMode,
   unconfigure,
   machineConfig,
 }) => {
   const election = electionDefinition?.election
   const changeAppPrecinctId: SelectChangeEventFunction = (event) => {
-    updateAppPrecinctId(event.currentTarget.value)
+    updateAppPrecinct({
+      kind: PrecinctSelectionKind.SinglePrecinct,
+      precinctId: event.currentTarget.value,
+    })
   }
 
   const [isFetchingElection, setIsFetchingElection] = useState(false)
@@ -79,7 +87,7 @@ const AdminScreen: React.FC<Props> = ({
   if (isTestDeck && electionDefinition) {
     return (
       <TestBallotDeckScreen
-        appPrecinctId={appPrecinctId}
+        appPrecinctId={appPrecinct?.precinctId}
         electionDefinition={electionDefinition}
         hideTestDeck={hideTestDeck}
         machineConfig={machineConfig}
@@ -102,7 +110,7 @@ const AdminScreen: React.FC<Props> = ({
                 <p>
                   <Select
                     id="selectPrecinct"
-                    value={appPrecinctId ?? ''}
+                    value={appPrecinct?.precinctId ?? ''}
                     onBlur={changeAppPrecinctId}
                     onChange={changeAppPrecinctId}
                   >
@@ -211,7 +219,7 @@ const AdminScreen: React.FC<Props> = ({
             {electionDefinition && (
               <ElectionInfo
                 electionDefinition={electionDefinition}
-                precinctId={appPrecinctId}
+                precinctId={appPrecinct?.precinctId}
                 horizontal
               />
             )}

--- a/apps/bmd/src/pages/ContestPage.test.tsx
+++ b/apps/bmd/src/pages/ContestPage.test.tsx
@@ -15,6 +15,8 @@ it('Renders ContestPage', () => {
     <Route path="/contests/:contestNumber" component={ContestPage} />,
     {
       route: '/contests/0',
+      precinctId: electionSample.precincts[0].id,
+      ballotStyleId: electionSample.ballotStyles[0].id,
     }
   )
   screen.getByText(firstContestTitle)

--- a/apps/bmd/src/pages/ContestPage.tsx
+++ b/apps/bmd/src/pages/ContestPage.tsx
@@ -18,6 +18,7 @@ import YesNoContest from '../components/YesNoContest'
 import SettingsTextSize from '../components/SettingsTextSize'
 import TextIcon from '../components/TextIcon'
 import MsEitherNeitherContest from '../components/MsEitherNeitherContest'
+import { PrecinctSelectionKind } from '../config/types'
 
 interface ContestParams {
   contestNumber: string
@@ -37,6 +38,7 @@ const ContestPage: React.FC<RouteComponentProps<ContestParams>> = (props) => {
     votes,
   } = useContext(BallotContext)
   ok(electionDefinition, 'electionDefinition is required to render ContestPage')
+  ok(precinctId, 'precinctId is required to render ContestPage')
   const { election } = electionDefinition
   const currentContestIndex = parseInt(contestNumber, 10)
   const contest = contests[currentContestIndex]
@@ -113,7 +115,10 @@ const ContestPage: React.FC<RouteComponentProps<ContestParams>> = (props) => {
             <ElectionInfo
               electionDefinition={electionDefinition}
               ballotStyleId={ballotStyleId}
-              precinctId={precinctId}
+              precinctSelection={{
+                kind: PrecinctSelectionKind.SinglePrecinct,
+                precinctId,
+              }}
               horizontal
             />
           </React.Fragment>

--- a/apps/bmd/src/pages/InsertCardScreen.tsx
+++ b/apps/bmd/src/pages/InsertCardScreen.tsx
@@ -9,7 +9,7 @@ import Sidebar from '../components/Sidebar'
 import TestMode from '../components/TestMode'
 import Text from '../components/Text'
 import ElectionInfo from '../components/ElectionInfo'
-import { MachineConfig } from '../config/types'
+import { MachineConfig, PrecinctSelection } from '../config/types'
 import VersionsData from '../components/VersionsData'
 
 const InsertCardImage = styled.img`
@@ -18,7 +18,7 @@ const InsertCardImage = styled.img`
 `
 
 interface Props {
-  appPrecinctId: string
+  appPrecinct: PrecinctSelection
   electionDefinition: ElectionDefinition
   showNoChargerAttachedWarning: boolean
   isLiveMode: boolean
@@ -28,7 +28,7 @@ interface Props {
 }
 
 const InsertCardScreen: React.FC<Props> = ({
-  appPrecinctId,
+  appPrecinct,
   electionDefinition,
   showNoChargerAttachedWarning,
   isLiveMode,
@@ -41,7 +41,7 @@ const InsertCardScreen: React.FC<Props> = ({
       <Sidebar>
         <ElectionInfo
           electionDefinition={electionDefinition}
-          precinctId={appPrecinctId}
+          precinctId={appPrecinct.precinctId}
         />
         <VersionsData
           machineConfig={machineConfig}

--- a/apps/bmd/src/pages/InsertCardScreen.tsx
+++ b/apps/bmd/src/pages/InsertCardScreen.tsx
@@ -41,7 +41,7 @@ const InsertCardScreen: React.FC<Props> = ({
       <Sidebar>
         <ElectionInfo
           electionDefinition={electionDefinition}
-          precinctId={appPrecinct.precinctId}
+          precinctSelection={appPrecinct}
         />
         <VersionsData
           machineConfig={machineConfig}

--- a/apps/bmd/src/pages/PollWorkerScreen.test.tsx
+++ b/apps/bmd/src/pages/PollWorkerScreen.test.tsx
@@ -14,7 +14,7 @@ import {
   TallySourceMachineType,
   CardTally,
 } from '@votingworks/utils'
-import { VxMarkOnly, VxPrintOnly } from '../config/types'
+import { PrecinctSelectionKind, VxMarkOnly, VxPrintOnly } from '../config/types'
 
 import { render } from '../../test/testUtils'
 
@@ -31,10 +31,13 @@ test('renders PollWorkerScreen', async () => {
   const election = electionSampleWithSeal as Election
   render(
     <PollWorkerScreen
-      activateCardlessBallotStyleId={jest.fn()}
-      appPrecinctId={defaultPrecinctId}
+      activateCardlessVoterSession={jest.fn()}
+      resetCardlessVoterSession={jest.fn()}
+      appPrecinct={{
+        kind: PrecinctSelectionKind.SinglePrecinct,
+        precinctId: defaultPrecinctId,
+      }}
       ballotsPrintedCount={0}
-      ballotStyleId=""
       electionDefinition={asElectionDefinition(election)}
       enableLiveMode={jest.fn()}
       hasVotes={false}
@@ -47,7 +50,6 @@ test('renders PollWorkerScreen', async () => {
       saveTallyToCard={jest.fn()}
       talliesOnCard={undefined}
       clearTalliesOnCard={jest.fn()}
-      resetCardlessBallot={jest.fn()}
     />
   )
 
@@ -62,10 +64,13 @@ test('switching out of test mode on election day', async () => {
   const enableLiveMode = jest.fn()
   render(
     <PollWorkerScreen
-      activateCardlessBallotStyleId={jest.fn()}
-      appPrecinctId={defaultPrecinctId}
+      activateCardlessVoterSession={jest.fn()}
+      resetCardlessVoterSession={jest.fn()}
+      appPrecinct={{
+        kind: PrecinctSelectionKind.SinglePrecinct,
+        precinctId: defaultPrecinctId,
+      }}
       ballotsPrintedCount={0}
-      ballotStyleId=""
       electionDefinition={asElectionDefinition(election)}
       enableLiveMode={enableLiveMode}
       hasVotes={false}
@@ -78,7 +83,6 @@ test('switching out of test mode on election day', async () => {
       saveTallyToCard={jest.fn()}
       talliesOnCard={undefined}
       clearTalliesOnCard={jest.fn()}
-      resetCardlessBallot={jest.fn()}
     />
   )
 
@@ -95,10 +99,13 @@ test('keeping test mode on election day', async () => {
   const enableLiveMode = jest.fn()
   render(
     <PollWorkerScreen
-      activateCardlessBallotStyleId={jest.fn()}
-      appPrecinctId={defaultPrecinctId}
+      activateCardlessVoterSession={jest.fn()}
+      resetCardlessVoterSession={jest.fn()}
+      appPrecinct={{
+        kind: PrecinctSelectionKind.SinglePrecinct,
+        precinctId: defaultPrecinctId,
+      }}
       ballotsPrintedCount={0}
-      ballotStyleId=""
       electionDefinition={asElectionDefinition(election)}
       enableLiveMode={enableLiveMode}
       hasVotes={false}
@@ -111,7 +118,6 @@ test('keeping test mode on election day', async () => {
       saveTallyToCard={jest.fn()}
       talliesOnCard={undefined}
       clearTalliesOnCard={jest.fn()}
-      resetCardlessBallot={jest.fn()}
     />
   )
 
@@ -125,10 +131,13 @@ test('live mode on election day', async () => {
   const enableLiveMode = jest.fn()
   render(
     <PollWorkerScreen
-      activateCardlessBallotStyleId={jest.fn()}
-      appPrecinctId={defaultPrecinctId}
+      activateCardlessVoterSession={jest.fn()}
+      resetCardlessVoterSession={jest.fn()}
+      appPrecinct={{
+        kind: PrecinctSelectionKind.SinglePrecinct,
+        precinctId: defaultPrecinctId,
+      }}
       ballotsPrintedCount={0}
-      ballotStyleId=""
       electionDefinition={asElectionDefinition(election)}
       enableLiveMode={enableLiveMode}
       hasVotes={false}
@@ -141,7 +150,6 @@ test('live mode on election day', async () => {
       saveTallyToCard={jest.fn()}
       talliesOnCard={undefined}
       clearTalliesOnCard={jest.fn()}
-      resetCardlessBallot={jest.fn()}
     />
   )
 
@@ -153,10 +161,13 @@ test('results combination option is not shown for a non print machine', async ()
   const enableLiveMode = jest.fn()
   render(
     <PollWorkerScreen
-      activateCardlessBallotStyleId={jest.fn()}
-      appPrecinctId={defaultPrecinctId}
+      activateCardlessVoterSession={jest.fn()}
+      resetCardlessVoterSession={jest.fn()}
+      appPrecinct={{
+        kind: PrecinctSelectionKind.SinglePrecinct,
+        precinctId: defaultPrecinctId,
+      }}
       ballotsPrintedCount={0}
-      ballotStyleId=""
       electionDefinition={asElectionDefinition(election)}
       enableLiveMode={enableLiveMode}
       hasVotes={false}
@@ -169,7 +180,6 @@ test('results combination option is not shown for a non print machine', async ()
       saveTallyToCard={jest.fn()}
       talliesOnCard={undefined}
       clearTalliesOnCard={jest.fn()}
-      resetCardlessBallot={jest.fn()}
     />
   )
 
@@ -183,10 +193,13 @@ test('results combination option is shown for a print machine', async () => {
   const printFn = jest.fn()
   render(
     <PollWorkerScreen
-      activateCardlessBallotStyleId={jest.fn()}
-      appPrecinctId={defaultPrecinctId}
+      activateCardlessVoterSession={jest.fn()}
+      resetCardlessVoterSession={jest.fn()}
+      appPrecinct={{
+        kind: PrecinctSelectionKind.SinglePrecinct,
+        precinctId: defaultPrecinctId,
+      }}
       ballotsPrintedCount={0}
-      ballotStyleId=""
       electionDefinition={asElectionDefinition(election)}
       enableLiveMode={jest.fn()}
       hasVotes={false}
@@ -205,7 +218,6 @@ test('results combination option is shown for a print machine', async () => {
       saveTallyToCard={saveTally}
       talliesOnCard={undefined}
       clearTalliesOnCard={clearTallies}
-      resetCardlessBallot={jest.fn()}
     />
   )
 
@@ -279,10 +291,13 @@ test('results combination option is shown with prior tally results when provided
 
   render(
     <PollWorkerScreen
-      activateCardlessBallotStyleId={jest.fn()}
-      appPrecinctId={defaultPrecinctId}
+      activateCardlessVoterSession={jest.fn()}
+      resetCardlessVoterSession={jest.fn()}
+      appPrecinct={{
+        kind: PrecinctSelectionKind.SinglePrecinct,
+        precinctId: defaultPrecinctId,
+      }}
       ballotsPrintedCount={3}
-      ballotStyleId=""
       electionDefinition={asElectionDefinition(election)}
       enableLiveMode={jest.fn()}
       hasVotes={false}
@@ -301,7 +316,6 @@ test('results combination option is shown with prior tally results when provided
       saveTallyToCard={saveTally}
       talliesOnCard={talliesOnCard}
       clearTalliesOnCard={clearTallies}
-      resetCardlessBallot={jest.fn()}
     />
   )
 
@@ -385,10 +399,13 @@ test('results combination option is shown with prior tally results when results 
 
   render(
     <PollWorkerScreen
-      activateCardlessBallotStyleId={jest.fn()}
-      appPrecinctId={defaultPrecinctId}
+      activateCardlessVoterSession={jest.fn()}
+      resetCardlessVoterSession={jest.fn()}
+      appPrecinct={{
+        kind: PrecinctSelectionKind.SinglePrecinct,
+        precinctId: defaultPrecinctId,
+      }}
       ballotsPrintedCount={3}
-      ballotStyleId=""
       electionDefinition={asElectionDefinition(election)}
       enableLiveMode={jest.fn()}
       hasVotes={false}
@@ -407,7 +424,6 @@ test('results combination option is shown with prior tally results when results 
       saveTallyToCard={saveTally}
       talliesOnCard={talliesOnCard}
       clearTalliesOnCard={clearTallies}
-      resetCardlessBallot={jest.fn()}
     />
   )
 
@@ -474,10 +490,13 @@ test('printing precinct scanner report option is shown when precinct scanner tal
 
   render(
     <PollWorkerScreen
-      activateCardlessBallotStyleId={jest.fn()}
-      appPrecinctId={defaultPrecinctId}
+      activateCardlessVoterSession={jest.fn()}
+      resetCardlessVoterSession={jest.fn()}
+      appPrecinct={{
+        kind: PrecinctSelectionKind.SinglePrecinct,
+        precinctId: defaultPrecinctId,
+      }}
       ballotsPrintedCount={3}
-      ballotStyleId=""
       electionDefinition={asElectionDefinition(election)}
       enableLiveMode={jest.fn()}
       hasVotes={false}
@@ -496,7 +515,6 @@ test('printing precinct scanner report option is shown when precinct scanner tal
       saveTallyToCard={saveTally}
       talliesOnCard={talliesOnCard}
       clearTalliesOnCard={clearTallies}
-      resetCardlessBallot={jest.fn()}
     />
   )
 

--- a/apps/bmd/src/pages/PollWorkerScreen.tsx
+++ b/apps/bmd/src/pages/PollWorkerScreen.tsx
@@ -19,7 +19,7 @@ import {
   combineTallies,
 } from '@votingworks/utils'
 
-import { MachineConfig } from '../config/types'
+import { MachineConfig, PrecinctSelection } from '../config/types'
 
 import Modal from '../components/Modal'
 import Prose from '../components/Prose'
@@ -37,7 +37,7 @@ import VersionsData from '../components/VersionsData'
 interface Props {
   activateCardlessBallotStyleId: (id: string) => void
   resetCardlessBallot: () => void
-  appPrecinctId: string
+  appPrecinct: PrecinctSelection
   ballotsPrintedCount: number
   ballotStyleId?: string
   electionDefinition: ElectionDefinition
@@ -57,7 +57,7 @@ interface Props {
 const PollWorkerScreen: React.FC<Props> = ({
   activateCardlessBallotStyleId,
   resetCardlessBallot,
-  appPrecinctId,
+  appPrecinct,
   ballotsPrintedCount,
   ballotStyleId,
   electionDefinition,
@@ -77,10 +77,10 @@ const PollWorkerScreen: React.FC<Props> = ({
   const electionDate = DateTime.fromISO(electionDefinition.election.date)
   const isElectionDay = electionDate.hasSame(DateTime.now(), 'day')
   const precinct = election.precincts.find(
-    (p) => p.id === appPrecinctId
+    (p) => p.id === appPrecinct.precinctId
   ) as Precinct
   const precinctBallotStyles = election.ballotStyles.filter((bs) =>
-    bs.precincts.includes(appPrecinctId)
+    bs.precincts.includes(appPrecinct.precinctId)
   )
 
   const [isConfirmingPrintReport, setIsConfirmingPrintReport] = useState(false)
@@ -432,7 +432,7 @@ const PollWorkerScreen: React.FC<Props> = ({
             <React.Fragment>
               <ElectionInfo
                 electionDefinition={electionDefinition}
-                precinctId={appPrecinctId}
+                precinctId={appPrecinct.precinctId}
                 horizontal
               />
               <VersionsData
@@ -599,7 +599,7 @@ const PollWorkerScreen: React.FC<Props> = ({
                   isPollsOpen={talliesOnCard.isPollsOpen}
                   machineMetadata={talliesOnCard?.metadata}
                   machineConfig={machineConfig} // not used
-                  precinctId={appPrecinctId}
+                  precinctId={appPrecinct.precinctId}
                   reportPurpose={reportPurpose}
                 />
                 <PrecinctTallyReport
@@ -610,7 +610,7 @@ const PollWorkerScreen: React.FC<Props> = ({
                   election={election}
                   isPollsOpen={talliesOnCard.isPollsOpen}
                   tally={talliesOnCard!.tally}
-                  precinctId={appPrecinctId}
+                  precinctId={appPrecinct.precinctId}
                   reportPurpose={reportPurpose}
                 />
               </React.Fragment>
@@ -630,7 +630,7 @@ const PollWorkerScreen: React.FC<Props> = ({
                   isPollsOpen={false}
                   machineMetadata={machineMetadata}
                   machineConfig={machineConfig}
-                  precinctId={appPrecinctId}
+                  precinctId={appPrecinct.precinctId}
                   reportPurpose={reportPurpose}
                 />
                 <PrecinctTallyReport
@@ -641,7 +641,7 @@ const PollWorkerScreen: React.FC<Props> = ({
                   election={election}
                   isPollsOpen={false}
                   tally={combinedTally}
-                  precinctId={appPrecinctId}
+                  precinctId={appPrecinct.precinctId}
                   reportPurpose={reportPurpose}
                 />
               </React.Fragment>
@@ -661,7 +661,7 @@ const PollWorkerScreen: React.FC<Props> = ({
                 isPollsOpen={!isPollsOpen} // This report is printed just before the value of isPollsOpen is updated when opening/closing polls, so we want to print the report with the toggled value.
                 machineMetadata={undefined}
                 machineConfig={machineConfig}
-                precinctId={appPrecinctId}
+                precinctId={appPrecinct.precinctId}
                 reportPurpose={reportPurpose}
               />
               <PrecinctTallyReport
@@ -672,7 +672,7 @@ const PollWorkerScreen: React.FC<Props> = ({
                 election={election}
                 isPollsOpen={!isPollsOpen}
                 tally={tally}
-                precinctId={appPrecinctId}
+                precinctId={appPrecinct.precinctId}
                 reportPurpose={reportPurpose}
               />
             </React.Fragment>

--- a/apps/bmd/src/pages/PollWorkerScreen.tsx
+++ b/apps/bmd/src/pages/PollWorkerScreen.tsx
@@ -2,7 +2,7 @@ import { DateTime } from 'luxon'
 import React, { useState, useEffect, useCallback } from 'react'
 import pluralize from 'pluralize'
 
-import { Precinct, ElectionDefinition, Optional } from '@votingworks/types'
+import { ElectionDefinition, Optional } from '@votingworks/types'
 import {
   Button,
   ButtonList,
@@ -11,15 +11,21 @@ import {
   Main,
   MainChild,
 } from '@votingworks/ui'
+
 import {
   formatFullDateTimeZone,
   Tally,
   CardTally,
   TallySourceMachineType,
   combineTallies,
+  find,
 } from '@votingworks/utils'
 
-import { MachineConfig, PrecinctSelection } from '../config/types'
+import {
+  MachineConfig,
+  PrecinctSelection,
+  PrecinctSelectionKind,
+} from '../config/types'
 
 import Modal from '../components/Modal'
 import Prose from '../components/Prose'
@@ -35,11 +41,15 @@ import Table from '../components/Table'
 import VersionsData from '../components/VersionsData'
 
 interface Props {
-  activateCardlessBallotStyleId: (id: string) => void
-  resetCardlessBallot: () => void
+  activateCardlessVoterSession: (
+    precinctId: string,
+    ballotStyleId?: string
+  ) => void
+  resetCardlessVoterSession: () => void
   appPrecinct: PrecinctSelection
   ballotsPrintedCount: number
-  ballotStyleId?: string
+  cardlessVoterSessionPrecinctId?: string
+  cardlessVoterSessionBallotStyleId?: string
   electionDefinition: ElectionDefinition
   enableLiveMode: () => void
   hasVotes: boolean
@@ -55,11 +65,15 @@ interface Props {
 }
 
 const PollWorkerScreen: React.FC<Props> = ({
-  activateCardlessBallotStyleId,
-  resetCardlessBallot,
+  activateCardlessVoterSession,
+  resetCardlessVoterSession,
   appPrecinct,
   ballotsPrintedCount,
-  ballotStyleId,
+  cardlessVoterSessionPrecinctId = appPrecinct.kind ===
+  PrecinctSelectionKind.SinglePrecinct
+    ? appPrecinct.precinctId
+    : undefined,
+  cardlessVoterSessionBallotStyleId,
   electionDefinition,
   enableLiveMode,
   isLiveMode,
@@ -76,12 +90,16 @@ const PollWorkerScreen: React.FC<Props> = ({
   const { election } = electionDefinition
   const electionDate = DateTime.fromISO(electionDefinition.election.date)
   const isElectionDay = electionDate.hasSame(DateTime.now(), 'day')
-  const precinct = election.precincts.find(
-    (p) => p.id === appPrecinct.precinctId
-  ) as Precinct
-  const precinctBallotStyles = election.ballotStyles.filter((bs) =>
-    bs.precincts.includes(appPrecinct.precinctId)
-  )
+  const precinctName =
+    appPrecinct.kind === PrecinctSelectionKind.AllPrecincts
+      ? 'All Precincts'
+      : find(election.precincts, (p) => p.id === appPrecinct.precinctId).name
+
+  const precinctBallotStyles = cardlessVoterSessionPrecinctId
+    ? election.ballotStyles.filter((bs) =>
+        bs.precincts.includes(cardlessVoterSessionPrecinctId)
+      )
+    : []
 
   const [isConfirmingPrintReport, setIsConfirmingPrintReport] = useState(false)
   const [isConfirmingEnableLiveMode, setIsConfirmingEnableLiveMode] = useState(
@@ -194,7 +212,7 @@ const PollWorkerScreen: React.FC<Props> = ({
                 Remove card to allow voter to continue voting, or reset ballot.
               </p>
               <p>
-                <Button danger onPress={resetCardlessBallot}>
+                <Button danger onPress={resetCardlessVoterSession}>
                   Reset Ballot
                 </Button>
               </p>
@@ -205,16 +223,21 @@ const PollWorkerScreen: React.FC<Props> = ({
     )
   }
 
-  if (ballotStyleId) {
+  if (cardlessVoterSessionPrecinctId && cardlessVoterSessionBallotStyleId) {
+    const activationPrecinctName = find(
+      election.precincts,
+      (p) => p.id === cardlessVoterSessionPrecinctId
+    ).name
+
     return (
       <Screen>
         <Main>
           <MainChild center narrow>
             <Prose>
-              <h1
-                aria-label={`Ballot style ${ballotStyleId} has been activated.`}
-              >
-                Ballot style {ballotStyleId} has been activated.
+              <h1>
+                {appPrecinct.kind === PrecinctSelectionKind.AllPrecincts
+                  ? `Voter session activated: ${cardlessVoterSessionBallotStyleId} @ ${activationPrecinctName}`
+                  : `Voter session activated: ${cardlessVoterSessionBallotStyleId}`}
               </h1>
               <ol>
                 <li>Remove the poll worker card.</li>
@@ -227,12 +250,10 @@ const PollWorkerScreen: React.FC<Props> = ({
                 </li>
               </ol>
               <HorizontalRule>or</HorizontalRule>
+              <Text center>Deactivate this voter session to start over.</Text>
               <Text center>
-                Deactivate this ballot style to select another ballot style.
-              </Text>
-              <Text center>
-                <Button small onPress={resetCardlessBallot}>
-                  Deactivate Ballot Style {ballotStyleId}
+                <Button small onPress={resetCardlessVoterSession}>
+                  Deactivate Voter Session
                 </Button>
               </Text>
             </Prose>
@@ -338,19 +359,50 @@ const PollWorkerScreen: React.FC<Props> = ({
             {isMarkAndPrintMode && isPollsOpen && (
               <React.Fragment>
                 <Prose>
-                  <h1>Activate Ballot Style</h1>
+                  <h1>Activate Voter Session</h1>
                 </Prose>
-                <ButtonList data-testid="precincts">
-                  {precinctBallotStyles.map((bs) => (
-                    <Button
-                      fullWidth
-                      key={bs.id}
-                      onPress={() => activateCardlessBallotStyleId(bs.id)}
-                    >
-                      {bs.id}
-                    </Button>
-                  ))}
-                </ButtonList>
+                {appPrecinct.kind === PrecinctSelectionKind.AllPrecincts && (
+                  <React.Fragment>
+                    <h3>Choose Precinct</h3>
+                    <ButtonList data-testid="precincts">
+                      {election.precincts.map((precinct) => (
+                        <Button
+                          fullWidth
+                          key={precinct.id}
+                          onPress={() =>
+                            activateCardlessVoterSession(precinct.id)
+                          }
+                          primary={
+                            cardlessVoterSessionPrecinctId === precinct.id
+                          }
+                        >
+                          {precinct.name}
+                        </Button>
+                      ))}
+                    </ButtonList>
+                  </React.Fragment>
+                )}
+                {cardlessVoterSessionPrecinctId && (
+                  <React.Fragment>
+                    <h3>Choose Ballot Style</h3>
+                    <ButtonList data-testid="ballot-styles">
+                      {precinctBallotStyles.map((bs) => (
+                        <Button
+                          fullWidth
+                          key={bs.id}
+                          onPress={() =>
+                            activateCardlessVoterSession(
+                              cardlessVoterSessionPrecinctId,
+                              bs.id
+                            )
+                          }
+                        >
+                          {bs.id}
+                        </Button>
+                      ))}
+                    </ButtonList>
+                  </React.Fragment>
+                )}
               </React.Fragment>
             )}
             <Prose>
@@ -379,8 +431,8 @@ const PollWorkerScreen: React.FC<Props> = ({
               <p>
                 <Button large onPress={togglePolls}>
                   {isPollsOpen
-                    ? `Close Polls for ${precinct.name}`
-                    : `Open Polls for ${precinct.name}`}
+                    ? `Close Polls for ${precinctName}`
+                    : `Open Polls for ${precinctName}`}
                 </Button>
               </p>
               {isPrintMode && isTallyOnCardFromPrecinctScanner && (
@@ -432,7 +484,7 @@ const PollWorkerScreen: React.FC<Props> = ({
             <React.Fragment>
               <ElectionInfo
                 electionDefinition={electionDefinition}
-                precinctId={appPrecinct.precinctId}
+                precinctSelection={appPrecinct}
                 horizontal
               />
               <VersionsData
@@ -475,8 +527,8 @@ const PollWorkerScreen: React.FC<Props> = ({
               <Prose textCenter>
                 <Loading as="p">
                   {isPollsOpen
-                    ? `Printing Polls Closed report for ${precinct.name}`
-                    : `Printing Polls Opened report for ${precinct.name}`}
+                    ? `Printing Polls Closed report for ${precinctName}`
+                    : `Printing Polls Opened report for ${precinctName}`}
                 </Loading>
               </Prose>
             }
@@ -599,7 +651,7 @@ const PollWorkerScreen: React.FC<Props> = ({
                   isPollsOpen={talliesOnCard.isPollsOpen}
                   machineMetadata={talliesOnCard?.metadata}
                   machineConfig={machineConfig} // not used
-                  precinctId={appPrecinct.precinctId}
+                  precinctSelection={appPrecinct}
                   reportPurpose={reportPurpose}
                 />
                 <PrecinctTallyReport
@@ -610,7 +662,7 @@ const PollWorkerScreen: React.FC<Props> = ({
                   election={election}
                   isPollsOpen={talliesOnCard.isPollsOpen}
                   tally={talliesOnCard!.tally}
-                  precinctId={appPrecinct.precinctId}
+                  precinctSelection={appPrecinct}
                   reportPurpose={reportPurpose}
                 />
               </React.Fragment>
@@ -630,7 +682,7 @@ const PollWorkerScreen: React.FC<Props> = ({
                   isPollsOpen={false}
                   machineMetadata={machineMetadata}
                   machineConfig={machineConfig}
-                  precinctId={appPrecinct.precinctId}
+                  precinctSelection={appPrecinct}
                   reportPurpose={reportPurpose}
                 />
                 <PrecinctTallyReport
@@ -641,7 +693,7 @@ const PollWorkerScreen: React.FC<Props> = ({
                   election={election}
                   isPollsOpen={false}
                   tally={combinedTally}
-                  precinctId={appPrecinct.precinctId}
+                  precinctSelection={appPrecinct}
                   reportPurpose={reportPurpose}
                 />
               </React.Fragment>
@@ -661,7 +713,7 @@ const PollWorkerScreen: React.FC<Props> = ({
                 isPollsOpen={!isPollsOpen} // This report is printed just before the value of isPollsOpen is updated when opening/closing polls, so we want to print the report with the toggled value.
                 machineMetadata={undefined}
                 machineConfig={machineConfig}
-                precinctId={appPrecinct.precinctId}
+                precinctSelection={appPrecinct}
                 reportPurpose={reportPurpose}
               />
               <PrecinctTallyReport
@@ -672,7 +724,7 @@ const PollWorkerScreen: React.FC<Props> = ({
                 election={election}
                 isPollsOpen={!isPollsOpen}
                 tally={tally}
-                precinctId={appPrecinct.precinctId}
+                precinctSelection={appPrecinct}
                 reportPurpose={reportPurpose}
               />
             </React.Fragment>

--- a/apps/bmd/src/pages/ReviewPage.tsx
+++ b/apps/bmd/src/pages/ReviewPage.tsx
@@ -17,6 +17,7 @@ import {
   CandidateContestResultInterface,
   EventTargetFunction,
   MsEitherNeitherContestResultInterface,
+  PrecinctSelectionKind,
   Scrollable,
   ScrollDirections,
   ScrollShadows,
@@ -368,6 +369,7 @@ const ReviewPage: React.FC = () => {
     setUserSettings,
   } = context
   ok(electionDefinition, 'electionDefinition is required to render ReviewPage')
+  ok(precinctId, 'precinctId is required to render ReviewPage')
   const { election } = electionDefinition
   const { parties } = election
 
@@ -484,7 +486,10 @@ const ReviewPage: React.FC = () => {
             <ElectionInfo
               electionDefinition={electionDefinition}
               ballotStyleId={ballotStyleId}
-              precinctId={precinctId}
+              precinctSelection={{
+                kind: PrecinctSelectionKind.SinglePrecinct,
+                precinctId,
+              }}
               horizontal
             />
           </React.Fragment>

--- a/apps/bmd/src/pages/StartPage.tsx
+++ b/apps/bmd/src/pages/StartPage.tsx
@@ -13,6 +13,7 @@ import Prose from '../components/Prose'
 import Sidebar from '../components/Sidebar'
 import Screen from '../components/Screen'
 import SettingsTextSize from '../components/SettingsTextSize'
+import { PrecinctSelectionKind } from '../config/types'
 
 const SidebarSpacer = styled.div`
   height: 90px;
@@ -31,6 +32,7 @@ const StartPage: React.FC<Props> = ({ history }) => {
     forceSaveVote,
   } = useContext(BallotContext)
   ok(electionDefinition, 'electionDefinition is required to render StartPage')
+  ok(precinctId, 'precinctId is required to render StartPage')
   ok(ballotStyleId, 'ballotStyleId is required to render StartPage')
   const audioFocus = useRef<HTMLDivElement>(null) // eslint-disable-line no-restricted-syntax
   const { election } = electionDefinition
@@ -83,7 +85,10 @@ const StartPage: React.FC<Props> = ({ history }) => {
             <ElectionInfo
               electionDefinition={electionDefinition}
               ballotStyleId={ballotStyleId}
-              precinctId={precinctId}
+              precinctSelection={{
+                kind: PrecinctSelectionKind.SinglePrecinct,
+                precinctId,
+              }}
               horizontal
             />
           </React.Fragment>

--- a/apps/bmd/src/pages/TestBallotDeckScreen.test.tsx
+++ b/apps/bmd/src/pages/TestBallotDeckScreen.test.tsx
@@ -13,7 +13,7 @@ import { mockOf, render } from '../../test/testUtils'
 import { randomBase64 } from '../utils/random'
 import TestBallotDeckScreen from './TestBallotDeckScreen'
 import fakeMachineConfig from '../../test/helpers/fakeMachineConfig'
-import { VxPrintOnly } from '../config/types'
+import { PrecinctSelectionKind, VxPrintOnly } from '../config/types'
 import fakePrinter from '../../test/helpers/fakePrinter'
 
 // mock the random value so the snapshots match
@@ -25,7 +25,10 @@ it('renders test decks appropriately', async () => {
   const printer = fakePrinter()
   render(
     <TestBallotDeckScreen
-      appPrecinctId="23"
+      appPrecinct={{
+        kind: PrecinctSelectionKind.SinglePrecinct,
+        precinctId: '23',
+      }}
       electionDefinition={asElectionDefinition(parseElection(electionSample))}
       hideTestDeck={jest.fn()}
       machineConfig={fakeMachineConfig({
@@ -73,7 +76,10 @@ it('renders test decks appropriately', async () => {
 it('shows printer not connected when appropriate', async () => {
   render(
     <TestBallotDeckScreen
-      appPrecinctId="23"
+      appPrecinct={{
+        kind: PrecinctSelectionKind.SinglePrecinct,
+        precinctId: '23',
+      }}
       electionDefinition={asElectionDefinition(parseElection(electionSample))}
       machineConfig={fakeMachineConfig({
         appMode: VxPrintOnly,

--- a/apps/bmd/src/pages/TestBallotDeckScreen.tsx
+++ b/apps/bmd/src/pages/TestBallotDeckScreen.tsx
@@ -9,7 +9,11 @@ import {
 } from '@votingworks/types'
 import { Button, ButtonList, Loading, Main, MainChild } from '@votingworks/ui'
 
-import { EventTargetFunction, MachineConfig } from '../config/types'
+import {
+  EventTargetFunction,
+  MachineConfig,
+  PrecinctSelection,
+} from '../config/types'
 
 import ElectionInfo from '../components/ElectionInfo'
 import PrintedBallot from '../components/PrintedBallot'
@@ -106,7 +110,7 @@ interface Precinct {
 }
 
 interface Props {
-  appPrecinctId?: string
+  appPrecinct?: PrecinctSelection
   electionDefinition: ElectionDefinition
   hideTestDeck: () => void
   isLiveMode: boolean
@@ -116,7 +120,7 @@ interface Props {
 const initialPrecinct: Precinct = { id: '', name: '' }
 
 const TestBallotDeckScreen: React.FC<Props> = ({
-  appPrecinctId,
+  appPrecinct,
   electionDefinition,
   hideTestDeck,
   isLiveMode,
@@ -227,7 +231,7 @@ const TestBallotDeckScreen: React.FC<Props> = ({
             election && (
               <ElectionInfo
                 electionDefinition={electionDefinition}
-                precinctId={appPrecinctId}
+                precinctSelection={appPrecinct}
                 horizontal
               />
             )

--- a/apps/bmd/src/pages/__snapshots__/ContestPage.test.tsx.snap
+++ b/apps/bmd/src/pages/__snapshots__/ContestPage.test.tsx.snap
@@ -794,7 +794,19 @@ exports[`Renders ContestPage 1`] = `
               <p
                 class="c26"
               >
+                <span
+                  class="c25"
+                >
+                  Center Springfield
+                  , 
+                </span>
                  
+                <span
+                  class="c25"
+                >
+                  ballot style 
+                  12
+                </span>
               </p>
             </div>
           </div>

--- a/apps/bmd/src/utils/precinctSelection.test.ts
+++ b/apps/bmd/src/utils/precinctSelection.test.ts
@@ -1,0 +1,27 @@
+import { election } from '../../test/helpers/election'
+import { PrecinctSelectionKind } from '../config/types'
+import { precinctSelectionName } from './precinctSelection'
+
+test('single precinct with no matching precincts', () => {
+  expect(() =>
+    precinctSelectionName([], {
+      kind: PrecinctSelectionKind.SinglePrecinct,
+      precinctId: 'nope',
+    })
+  ).toThrow()
+})
+
+test('single precinct with matching precinct', () => {
+  expect(
+    precinctSelectionName(election.precincts, {
+      kind: PrecinctSelectionKind.SinglePrecinct,
+      precinctId: '23',
+    })
+  ).toEqual('Center Springfield')
+})
+
+test('all precincts', () => {
+  expect(
+    precinctSelectionName([], { kind: PrecinctSelectionKind.AllPrecincts })
+  ).toEqual('All Precincts')
+})

--- a/apps/bmd/src/utils/precinctSelection.ts
+++ b/apps/bmd/src/utils/precinctSelection.ts
@@ -1,0 +1,14 @@
+import { Precinct } from '@votingworks/types'
+import { find } from '@votingworks/utils'
+import { PrecinctSelection, PrecinctSelectionKind } from '../config/types'
+
+export const AllPrecinctsDisplayName = 'All Precincts'
+
+export function precinctSelectionName(
+  precincts: readonly Precinct[],
+  selection: PrecinctSelection
+): string {
+  return selection.kind === PrecinctSelectionKind.AllPrecincts
+    ? AllPrecinctsDisplayName
+    : find(precincts, (p) => p.id === selection.precinctId).name
+}

--- a/apps/bmd/test/helpers/election.ts
+++ b/apps/bmd/test/helpers/election.ts
@@ -13,6 +13,7 @@ import {
 import { getZeroTally, Storage } from '@votingworks/utils'
 
 import { electionStorageKey, stateStorageKey, State } from '../../src/AppRoot'
+import { PrecinctSelectionKind } from '../../src/config/types'
 
 const electionSampleData = fs.readFileSync(
   path.resolve(__dirname, '../../src/data/electionSample.json'),
@@ -79,12 +80,16 @@ export const setStateInStorage = async (
   storage: Storage,
   state: Partial<State> = {}
 ): Promise<void> => {
-  await storage.set(stateStorageKey, {
-    appPrecinctId: defaultPrecinctId,
+  const storedState: Partial<State> = {
+    appPrecinct: {
+      kind: PrecinctSelectionKind.SinglePrecinct,
+      precinctId: defaultPrecinctId,
+    },
     ballotsPrintedCount: 0,
     isLiveMode: true,
     isPollsOpen: true,
     tally: getZeroTally(election),
     ...state,
-  })
+  }
+  await storage.set(stateStorageKey, storedState)
 }


### PR DESCRIPTION
Changes most `precinctId` values to be a `PrecinctSelection`, which can either be a single precinct or all precincts. Selecting "All Precincts" requires the cardless voting flow to select both a precinct and a ballot style. Because of that, I changed some of the terminology from e.g. "Activate Ballot Style" to "Activate Voter Session".

Additionally, I left the reports as close to "as-is" as possible. This may not be what we actually want for the "All Precincts" case, as it will print a single combined report. If we want it to print multiple reports we'll have to change it to do so.

Closes #498