### PR TITLE
lint(ps): enable `no-floating-promises` rule

### DIFF
--- a/apps/precinct-scanner/.eslintrc.js
+++ b/apps/precinct-scanner/.eslintrc.js
@@ -122,6 +122,7 @@ module.exports = {
     ],
     strict: 'off',
     '@typescript-eslint/explicit-function-return-type': 'off', // Want to use it, but it requires return types for all built-in React lifecycle methods.
+    '@typescript-eslint/no-floating-promises': 'error',
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-use-before-define': ['error', { functions: false }],
     'import/extensions': 'off',
@@ -133,6 +134,7 @@ module.exports = {
           '`null` is generally not what you want outside of React classes, use `undefined` instead',
       },
     ],
+    'no-void': 'off',
   },
   overrides: [
     {

--- a/apps/precinct-scanner/src/App.test.tsx
+++ b/apps/precinct-scanner/src/App.test.tsx
@@ -72,7 +72,7 @@ const getPrecinctConfigNoPrecinctResponseBody: GetCurrentPrecinctConfigResponse 
 test('shows setup card reader screen when there is no card reader', async () => {
   const storage = new MemoryStorage()
   const hardware = await MemoryHardware.buildStandard()
-  hardware.setCardReaderConnected(false)
+  await hardware.setCardReaderConnected(false)
   fetchMock
     .get('/machine-config', { body: getMachineConfigBody })
     .get('/config/election', { body: electionSampleDefinition })

--- a/apps/precinct-scanner/src/App.tsx
+++ b/apps/precinct-scanner/src/App.tsx
@@ -28,7 +28,7 @@ const App: React.FC<Props> = ({
         setInternalHardware(await getHardware())
       }
     }
-    updateHardware()
+    void updateHardware()
   }, [hardware])
 
   if (!internalHardware) {

--- a/apps/precinct-scanner/src/AppRoot.tsx
+++ b/apps/precinct-scanner/src/AppRoot.tsx
@@ -467,7 +467,7 @@ const AppRoot: React.FC<Props> = ({
         // Do nothing if machineConfig fails. Default values will be used.
       }
     }
-    setMachineConfig()
+    void setMachineConfig()
   }, [machineConfigProvider])
 
   const scanDetectedBallot = useCallback(async () => {
@@ -796,7 +796,7 @@ const AppRoot: React.FC<Props> = ({
     })
 
     if (insertedCard.present) {
-      processCard(insertedCard)
+      await processCard(insertedCard)
     } else if (hasCardInserted) {
       dispatchAppState({ type: 'cardRemoved' })
     }
@@ -865,8 +865,8 @@ const AppRoot: React.FC<Props> = ({
       })
     }
 
-    initializeScanner()
-    updateStateFromStorage()
+    void initializeScanner()
+    void updateStateFromStorage()
     startUsbStatusPolling()
     startCardShortValueReadPolling()
     return () => {
@@ -889,13 +889,13 @@ const AppRoot: React.FC<Props> = ({
   )
 
   useEffect(() => {
-    const storeAppState = () => {
-      storage.set(stateStorageKey, {
+    const storeAppState = async () => {
+      await storage.set(stateStorageKey, {
         isPollsOpen,
       })
     }
 
-    storeAppState()
+    void storeAppState()
   }, [isPollsOpen])
 
   const dismissError = () => {

--- a/apps/precinct-scanner/src/api/config.test.ts
+++ b/apps/precinct-scanner/src/api/config.test.ts
@@ -37,9 +37,7 @@ test('DELETE /config/election to delete election', async () => {
 
 test('DELETE /config/election to delete election with bad API response', async () => {
   fetchMock.deleteOnce('/config/election', JSON.stringify({ status: 'not-ok' }))
-  expect(async () => await config.setElection(undefined)).rejects.toThrow(
-    /DELETE/
-  )
+  await expect(config.setElection(undefined)).rejects.toThrow(/DELETE/)
 })
 
 test('GET /config/testMode', async () => {
@@ -87,7 +85,7 @@ test('setCurrentPrecinctId deletes', async () => {
 
 test('setCurrentPrecinctId fails', async () => {
   fetchMock.putOnce('/config/precinct', JSON.stringify({ status: 'error' }))
-  expect(
+  await expect(
     config.setCurrentPrecinctId('23')
   ).rejects.toThrowErrorMatchingInlineSnapshot(
     '"PUT /config/precinct failed: undefined"'

--- a/apps/precinct-scanner/src/api/scan.test.ts
+++ b/apps/precinct-scanner/src/api/scan.test.ts
@@ -23,23 +23,23 @@ const scanStatusReadyToScanResponseBody: GetScanStatusResponse = {
   batches: [],
   adjudication: { adjudicated: 0, remaining: 0 },
 }
-test('scanDetectedSheet throws on bad status', () => {
+test('scanDetectedSheet throws on bad status', async () => {
   fetchMock.postOnce('scan/scanBatch', {
     body: { status: 'error', error: 'hello' },
   })
-  expect(scan.scanDetectedSheet()).rejects.toThrowErrorMatchingInlineSnapshot(
-    '"hello"'
-  )
+  await expect(
+    scan.scanDetectedSheet()
+  ).rejects.toThrowErrorMatchingInlineSnapshot('"hello"')
 })
 
-test('scanDetectedSheet throws on invalid batch', () => {
+test('scanDetectedSheet throws on invalid batch', async () => {
   fetchMock.postOnce('scan/scanBatch', {
     body: { status: 'ok', batchId: 'test-batch' },
   })
   fetchMock.get('/scan/status', scanStatusReadyToScanResponseBody)
-  expect(scan.scanDetectedSheet()).rejects.toThrowErrorMatchingInlineSnapshot(
-    '"batch not found: test-batch"'
-  )
+  await expect(
+    scan.scanDetectedSheet()
+  ).rejects.toThrowErrorMatchingInlineSnapshot('"batch not found: test-batch"')
 })
 
 test('scanDetectedSheet returns rejected ballot if batch has a 0 count', async () => {
@@ -286,8 +286,8 @@ test('getExport returns CVRs on success', async () => {
 })
 
 test('getExport throws on failure', async () => {
-  fetchMock.postOnce('/scan/export', { body: { status: 'error' } })
-  expect(scan.getExport()).rejects.toThrowError(
+  fetchMock.postOnce('/scan/export', { status: 500, body: { status: 'error' } })
+  await expect(scan.getExport()).rejects.toThrowError(
     'failed to generate scan export'
   )
 })

--- a/apps/precinct-scanner/src/screens/ScanErrorScreen.test.tsx
+++ b/apps/precinct-scanner/src/screens/ScanErrorScreen.test.tsx
@@ -27,7 +27,7 @@ test('render correct test ballot error screen when we are in live mode', async (
   )
   await screen.findByText('Scanning Error')
   await screen.findByText('Test ballot detected.')
-  expect(await screen.queryByText('Dismiss Error')).toBeNull()
+  expect(screen.queryByText('Dismiss Error')).toBeNull()
 })
 
 test('render correct invalid precinct screen', async () => {
@@ -41,7 +41,7 @@ test('render correct invalid precinct screen', async () => {
   await screen.findByText(
     'Scanned ballot does not match the precinct this scanner is configured for.'
   )
-  expect(await screen.queryByText('Dismiss Error')).toBeNull()
+  expect(screen.queryByText('Dismiss Error')).toBeNull()
 })
 
 test('render correct test ballot error screen when we are in test mode', async () => {

--- a/apps/precinct-scanner/src/screens/ScanWarningScreen.tsx
+++ b/apps/precinct-scanner/src/screens/ScanWarningScreen.tsx
@@ -28,9 +28,9 @@ const ScanWarningScreen: React.FC<Props> = ({
   const openConfirmTabulateModal = () => setConfirmTabulate(true)
   const closeConfirmTabulateModal = () => setConfirmTabulate(false)
 
-  const tabulateBallot = () => {
+  const tabulateBallot = async () => {
     closeConfirmTabulateModal()
-    acceptBallot()
+    await acceptBallot()
   }
 
   const overvoteReasons = adjudicationReasonInfo.filter(

--- a/apps/precinct-scanner/src/screens/UnconfiguredElectionScreen.tsx
+++ b/apps/precinct-scanner/src/screens/UnconfiguredElectionScreen.tsx
@@ -109,7 +109,8 @@ const UnconfiguredElectionScreen: React.FC<Props> = ({
       }
     }
 
-    attemptToLoadBallotPackageFromUSB()
+    // function handles its own errors, so no `.catch` needed
+    void attemptToLoadBallotPackageFromUSB()
   }, [usbDriveStatus])
 
   let content = (

--- a/apps/precinct-scanner/src/utils/download.ts
+++ b/apps/precinct-scanner/src/utils/download.ts
@@ -107,24 +107,21 @@ async function kioskDownload(
 
   /* istanbul ignore next - fetch-mock does not support fetch Readable/WritableStream APIs */
   if (typeof body.pipeTo === 'function') {
-    await new Promise<void>((resolve, reject) => {
-      body.pipeTo(
-        new WritableStream({
-          abort(error) {
-            reject(error)
-          },
+    await body.pipeTo(
+      new WritableStream({
+        abort(error) {
+          throw error
+        },
 
-          write(chunk) {
-            downloadTarget.write(chunk)
-          },
+        async write(chunk) {
+          await downloadTarget.write(chunk)
+        },
 
-          close() {
-            downloadTarget.end()
-            resolve()
-          },
-        })
-      )
-    })
+        async close() {
+          await downloadTarget.end()
+        },
+      })
+    )
   } else {
     await downloadTarget.write((body as unknown) as Uint8Array)
     await downloadTarget.end()

--- a/apps/precinct-scanner/src/utils/machineConfig.test.ts
+++ b/apps/precinct-scanner/src/utils/machineConfig.test.ts
@@ -11,9 +11,11 @@ test('successful fetch from /machine-config', async () => {
   })
 })
 
-test('failed fetch from /machine-config', () => {
+test('failed fetch from /machine-config', async () => {
   fetchMock.get('/machine-config', {
     throws: new Error('fetch failed!'),
   })
-  expect(machineConfigProvider.get()).rejects.toThrowError('fetch failed!')
+  await expect(machineConfigProvider.get()).rejects.toThrowError(
+    'fetch failed!'
+  )
 })


### PR DESCRIPTION
I noticed a test that should have failed but wasn't because it wasn't properly `await`ing a `Promise`. So I enabled the `no-floating-promises` rule and fixed all the violations.