### PR TITLE
refactor(em): move tally file reset out of modal

### DIFF
--- a/apps/election-manager/src/App.test.tsx
+++ b/apps/election-manager/src/App.test.tsx
@@ -731,7 +731,9 @@ test('clearing all files after marking as official clears SEMS, CVR, and manual 
   )
   fireEvent.click(getByText('Remove All Data'))
 
-  expect(getByText('Remove CVR Files…').closest('button')).toBeDisabled()
+  await waitFor(() =>
+    expect(getByText('Remove CVR Files…').closest('button')).toBeDisabled()
+  )
   expect(
     getByText('Remove External Results File…').closest('button')
   ).toBeDisabled()

--- a/apps/election-manager/src/components/ConfirmRemovingFileModal.tsx
+++ b/apps/election-manager/src/components/ConfirmRemovingFileModal.tsx
@@ -10,49 +10,19 @@ import Prose from './Prose'
 import Modal from './Modal'
 
 export interface Props {
-  onClose: () => void
+  onConfirm: (fileType: ResultsFileType) => void
+  onCancel: () => void
   fileType: ResultsFileType
 }
 
 export const ConfirmRemovingFileModal: React.FC<Props> = ({
-  onClose,
+  onConfirm,
+  onCancel,
   fileType,
 }) => {
-  const {
-    castVoteRecordFiles,
-    saveCastVoteRecordFiles,
-    saveExternalTallies,
-    fullElectionExternalTallies,
-  } = useContext(AppContext)
-
-  const resetFiles = (fileType: ResultsFileType) => {
-    switch (fileType) {
-      case ResultsFileType.CastVoteRecord:
-        void saveCastVoteRecordFiles()
-        break
-      case ResultsFileType.SEMS: {
-        const newFiles = fullElectionExternalTallies.filter(
-          (tally) => tally.source !== ExternalTallySourceType.SEMS
-        )
-        void saveExternalTallies(newFiles)
-        break
-      }
-      case ResultsFileType.Manual: {
-        const newFiles = fullElectionExternalTallies.filter(
-          (tally) => tally.source !== ExternalTallySourceType.Manual
-        )
-        void saveExternalTallies(newFiles)
-        break
-      }
-      case ResultsFileType.All:
-        void saveCastVoteRecordFiles()
-        void saveExternalTallies([])
-        break
-      default:
-        throwIllegalValue(fileType)
-    }
-    onClose()
-  }
+  const { castVoteRecordFiles, fullElectionExternalTallies } = useContext(
+    AppContext
+  )
 
   const semsFile = fullElectionExternalTallies.find(
     (t) => t.source === ExternalTallySourceType.SEMS
@@ -137,13 +107,13 @@ export const ConfirmRemovingFileModal: React.FC<Props> = ({
       content={<Prose textCenter>{mainContent}</Prose>}
       actions={
         <React.Fragment>
-          <Button onPress={onClose}>Cancel</Button>
-          <Button danger onPress={() => resetFiles(fileType)}>
+          <Button onPress={onCancel}>Cancel</Button>
+          <Button danger onPress={() => onConfirm(fileType)}>
             Remove {!singleFileRemoval && 'All'} {fileTypeName}
           </Button>
         </React.Fragment>
       }
-      onOverlayClick={onClose}
+      onOverlayClick={onCancel}
     />
   )
 }

--- a/apps/election-manager/src/contexts/AppContext.ts
+++ b/apps/election-manager/src/contexts/AppContext.ts
@@ -8,6 +8,7 @@ import {
   FullElectionTally,
   ExportableTallies,
   FullElectionExternalTally,
+  ResultsFileType,
 } from '../config/types'
 import CastVoteRecordFiles, {
   SaveCastVoteRecordFiles,
@@ -29,6 +30,7 @@ export interface AppContextInterface {
     React.SetStateAction<CastVoteRecordFiles>
   >
   saveIsOfficialResults: () => void
+  resetFiles: (fileType: ResultsFileType) => Promise<void>
   usbDriveStatus: usbstick.UsbDriveStatus
   usbDriveEject: () => Promise<void>
   addPrintedBallot: (printedBallot: PrintedBallot) => void
@@ -55,6 +57,7 @@ const appContext: AppContextInterface = {
   saveElection: async () => undefined,
   setCastVoteRecordFiles: () => undefined,
   saveIsOfficialResults: () => undefined,
+  resetFiles: async () => undefined,
   usbDriveStatus: usbstick.UsbDriveStatus.notavailable,
   usbDriveEject: async () => undefined,
   addPrintedBallot: () => undefined,

--- a/apps/election-manager/src/screens/ManualDataImportIndexScreen.test.tsx
+++ b/apps/election-manager/src/screens/ManualDataImportIndexScreen.test.tsx
@@ -3,10 +3,11 @@ import {
   multiPartyPrimaryElectionDefinition,
   electionSampleDefinition,
 } from '@votingworks/fixtures'
+import { advanceTimersAndPromises } from '@votingworks/test-utils'
+import { createMemoryHistory } from 'history'
 import { Router, Route } from 'react-router-dom'
 import { fireEvent, within } from '@testing-library/react'
 
-import { createMemoryHistory } from 'history'
 import ManualDataImportIndexScreen from './ManualDataImportIndexScreen'
 import renderInAppContext from '../../test/renderInAppContext'
 import {
@@ -14,6 +15,7 @@ import {
   ContestTally,
   ExternalTallySourceType,
   FullElectionExternalTally,
+  ResultsFileType,
   TallyCategory,
   VotingMethod,
 } from '../config/types'
@@ -21,6 +23,8 @@ import {
   getEmptyExternalTalliesByPrecinct,
   getEmptyExternalTally,
 } from '../utils/externalTallies'
+
+jest.useFakeTimers()
 
 test('can toggle ballot types for data', async () => {
   const saveExternalTallies = jest.fn()
@@ -185,7 +189,7 @@ test('loads prexisting manual data to edit', async () => {
     source: ExternalTallySourceType.Manual,
     timestampCreated: new Date(),
   }
-  const saveExternalTallies = jest.fn()
+  const resetFiles = jest.fn()
   const { getByText, getByTestId } = renderInAppContext(
     <Route path="/tally/manual-data-import">
       <ManualDataImportIndexScreen />
@@ -193,7 +197,7 @@ test('loads prexisting manual data to edit', async () => {
     {
       route: '/tally/manual-data-import',
       electionDefinition: electionSampleDefinition,
-      saveExternalTallies,
+      resetFiles,
       fullElectionExternalTallies: [externalTally],
     }
   )
@@ -231,5 +235,7 @@ test('loads prexisting manual data to edit', async () => {
   fireEvent.click(getByText('Clear Manual Data…'))
   fireEvent.click(getByText('Remove Manual Data'))
 
-  expect(saveExternalTallies).toHaveBeenCalledWith([])
+  expect(resetFiles).toHaveBeenCalledWith(ResultsFileType.Manual)
+
+  await advanceTimersAndPromises()
 })

--- a/apps/election-manager/src/screens/ManualDataImportIndexScreen.tsx
+++ b/apps/election-manager/src/screens/ManualDataImportIndexScreen.tsx
@@ -46,6 +46,7 @@ const ManualDataImportIndexScreen: React.FC = () => {
     electionDefinition,
     fullElectionExternalTallies,
     saveExternalTallies,
+    resetFiles,
   } = useContext(AppContext)
   const { election } = electionDefinition!
   const history = useHistory()
@@ -68,6 +69,11 @@ const ManualDataImportIndexScreen: React.FC = () => {
   const [isClearing, setIsClearing] = useState(false)
   const hasManualData = !!existingManualData?.overallTally
     .numberOfBallotsCounted
+
+  const confirmClearManualData = async (fileType: ResultsFileType) => {
+    setIsClearing(false)
+    await resetFiles(fileType)
+  }
 
   const handleSettingBallotType = async (ballotType: VotingMethod) => {
     setBallotType(ballotType)
@@ -198,7 +204,8 @@ const ManualDataImportIndexScreen: React.FC = () => {
       {isClearing && (
         <ConfirmRemovingFileModal
           fileType={ResultsFileType.Manual}
-          onClose={() => setIsClearing(false)}
+          onConfirm={confirmClearManualData}
+          onCancel={() => setIsClearing(false)}
         />
       )}
     </React.Fragment>

--- a/apps/election-manager/test/renderInAppContext.tsx
+++ b/apps/election-manager/test/renderInAppContext.tsx
@@ -44,6 +44,7 @@ interface RenderInAppContextParams {
     React.SetStateAction<CastVoteRecordFiles>
   >
   saveIsOfficialResults?: () => void
+  resetFiles?: () => Promise<void>
   usbDriveStatus?: usbstick.UsbDriveStatus
   usbDriveEject?: () => Promise<void>
   addPrintedBallot?: (printedBallot: PrintedBallot) => void
@@ -74,6 +75,7 @@ export default function renderInAppContext(
     saveElection = jest.fn(),
     setCastVoteRecordFiles = jest.fn(),
     saveIsOfficialResults = jest.fn(),
+    resetFiles = jest.fn(),
     usbDriveStatus = usbstick.UsbDriveStatus.absent,
     usbDriveEject = jest.fn(),
     addPrintedBallot = jest.fn(),
@@ -100,6 +102,7 @@ export default function renderInAppContext(
         saveElection,
         setCastVoteRecordFiles,
         saveIsOfficialResults,
+        resetFiles,
         usbDriveStatus,
         usbDriveEject,
         addPrintedBallot,


### PR DESCRIPTION
Though convenient from a code reuse perspective, putting this code in the modal meant that it was not really possible to perform an asynchronous tally update while also updating the state to avoid rendering the modal with now-invalid tally data. For example, removing the SEMS file and awaiting it properly would trigger a re-render of the modal where the `fileType` was still `SEMS`, but there was no longer and matching file to remove. This was cause an error when rendering.

This commit adds a new context function to do the reset properly, and that function is used alongside the modal to properly set the state to prevent the modal rendering as well as awaiting the tally update.