### PR TITLE
fix(em): stop ballot flash on # of copies change

### DIFF
--- a/apps/election-manager/src/components/HandMarkedPaperBallot.tsx
+++ b/apps/election-manager/src/components/HandMarkedPaperBallot.tsx
@@ -397,17 +397,17 @@ export interface CandidateContestChoicesProps {
   contest: CandidateContest
   locales: BallotLocale
   parties: Parties
-  vote: CandidateVote
+  vote?: CandidateVote
 }
 
 export const CandidateContestChoices: React.FC<CandidateContestChoicesProps> = ({
   contest,
   locales,
   parties,
-  vote = [],
+  vote,
 }) => {
   const { t } = useTranslation()
-  const writeInCandidates = vote.filter((c) => c.isWriteIn)
+  const writeInCandidates = vote?.filter((c) => c.isWriteIn)
   const remainingChoices = [...Array(contest.seats).keys()]
   const dualLanguageWithSlash = dualLanguageComposer(t, locales)
   return (
@@ -429,7 +429,7 @@ export const CandidateContestChoices: React.FC<CandidateContestChoicesProps> = (
           </BubbleMark>
         </Text>
       ))}
-      {writeInCandidates.map((candidate) => (
+      {writeInCandidates?.map((candidate) => (
         <Text key={candidate.name} bold noWrap>
           <BubbleMark checked>
             <span>
@@ -484,7 +484,7 @@ const HandMarkedPaperBallot: React.FC<HandMarkedPaperBallotProps> = ({
   precinctId,
   locales,
   ballotId,
-  votes = {},
+  votes,
   onRendered,
 }) => {
   assert.notEqual(
@@ -893,7 +893,7 @@ const HandMarkedPaperBallot: React.FC<HandMarkedPaperBallotProps> = ({
                   <CandidateContestChoices
                     contest={contest}
                     parties={parties}
-                    vote={votes[contest.id] as CandidateVote}
+                    vote={votes?.[contest.id] as CandidateVote | undefined}
                     locales={locales}
                   />
                 </React.Fragment>
@@ -966,7 +966,7 @@ const HandMarkedPaperBallot: React.FC<HandMarkedPaperBallotProps> = ({
                       />
                     )}
                     <Text bold noWrap>
-                      <BubbleMark checked={hasVote(votes[contest.id], 'yes')}>
+                      <BubbleMark checked={hasVote(votes?.[contest.id], 'yes')}>
                         <span>
                           {dualLanguageWithSlash(
                             contest.yesOption?.label || 'Yes'
@@ -975,7 +975,7 @@ const HandMarkedPaperBallot: React.FC<HandMarkedPaperBallotProps> = ({
                       </BubbleMark>
                     </Text>
                     <Text bold noWrap>
-                      <BubbleMark checked={hasVote(votes[contest.id], 'no')}>
+                      <BubbleMark checked={hasVote(votes?.[contest.id], 'no')}>
                         <span>
                           {dualLanguageWithSlash(
                             contest.noOption?.label || 'No'
@@ -1010,7 +1010,7 @@ const HandMarkedPaperBallot: React.FC<HandMarkedPaperBallotProps> = ({
                     <Text key={contest.eitherOption.id} bold>
                       <BubbleMark
                         checked={hasVote(
-                          votes[contest.eitherNeitherContestId],
+                          votes?.[contest.eitherNeitherContestId],
                           'yes'
                         )}
                       >
@@ -1022,7 +1022,7 @@ const HandMarkedPaperBallot: React.FC<HandMarkedPaperBallotProps> = ({
                     <Text key={contest.neitherOption.id} bold>
                       <BubbleMark
                         checked={hasVote(
-                          votes[contest.eitherNeitherContestId],
+                          votes?.[contest.eitherNeitherContestId],
                           'no'
                         )}
                       >
@@ -1035,7 +1035,7 @@ const HandMarkedPaperBallot: React.FC<HandMarkedPaperBallotProps> = ({
                     <Text key={contest.firstOption.id} bold>
                       <BubbleMark
                         checked={hasVote(
-                          votes[contest.pickOneContestId],
+                          votes?.[contest.pickOneContestId],
                           'yes'
                         )}
                       >
@@ -1046,7 +1046,10 @@ const HandMarkedPaperBallot: React.FC<HandMarkedPaperBallotProps> = ({
                     </Text>
                     <Text key={contest.secondOption.id} bold>
                       <BubbleMark
-                        checked={hasVote(votes[contest.pickOneContestId], 'no')}
+                        checked={hasVote(
+                          votes?.[contest.pickOneContestId],
+                          'no'
+                        )}
                       >
                         <span>
                           {dualLanguageWithSlash(contest.secondOption.label)}

--- a/apps/election-manager/src/screens/BallotScreen.tsx
+++ b/apps/election-manager/src/screens/BallotScreen.tsx
@@ -1,4 +1,10 @@
-import React, { useContext, useRef, useState } from 'react'
+import React, {
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { useParams, useHistory } from 'react-router-dom'
 import styled from 'styled-components'
 import {
@@ -80,10 +86,13 @@ const BallotScreen: React.FC = () => {
   )
   const { election, electionHash } = electionDefinition!
   const availableLocaleCodes = getElectionLocales(election, DEFAULT_LOCALE)
-  const locales: BallotLocale = {
-    primary: DEFAULT_LOCALE,
-    secondary: currentLocaleCode,
-  }
+  const locales = useMemo<BallotLocale>(
+    () => ({
+      primary: DEFAULT_LOCALE,
+      secondary: currentLocaleCode,
+    }),
+    [currentLocaleCode]
+  )
 
   const precinctName = getPrecinctById({ election, precinctId })?.name
   const ballotStyle = getBallotStyle({ ballotStyleId, election })!
@@ -137,7 +146,7 @@ const BallotScreen: React.FC = () => {
     }
   }
 
-  const onRendered = () => {
+  const onRendered = useCallback(() => {
     if (ballotPreviewRef?.current && printBallotRef?.current) {
       ballotPreviewRef.current.innerHTML = printBallotRef.current.innerHTML
     }
@@ -147,7 +156,7 @@ const BallotScreen: React.FC = () => {
       )[0] as HTMLElement)?.style.getPropertyValue('--pagedjs-page-count') || 0
     )
     setBallotPages(pagedJsPageCount)
-  }
+  }, [ballotPreviewRef])
 
   return (
     <React.Fragment>


### PR DESCRIPTION
When changing the # of copies in a Ballot Preview, the whole ballot would flash. This is because we were unnecessarily re-rendering the whole ballot because the props changed. This fixes it so that the props maintain referential equality when only the number of copies changes.