### PR TITLE
test(bmd): use `advanceTimers` from `test-utils`

### DIFF
--- a/apps/bmd/test/helpers/smartcards.ts
+++ b/apps/bmd/test/helpers/smartcards.ts
@@ -1,5 +1,6 @@
-import { act, waitFor } from '@testing-library/react'
+import { waitFor } from '@testing-library/react'
 import { electionSample as election } from '@votingworks/fixtures'
+import * as testUtils from '@votingworks/test-utils'
 import {
   CandidateContest,
   vote,
@@ -181,15 +182,7 @@ export const getUsedVoterCard = (): string =>
   })
 
 export const advanceTimers = (seconds = 0): void => {
-  const maxSeconds = GLOBALS.IDLE_TIMEOUT_SECONDS
-  if (seconds > maxSeconds) {
-    throw new Error(`Seconds value should not be greater than ${maxSeconds}`)
-  }
-  act(() => {
-    jest.advanceTimersByTime(
-      seconds ? seconds * 1000 : GLOBALS.CARD_POLLING_INTERVAL
-    )
-  })
+  testUtils.advanceTimers(seconds || GLOBALS.CARD_POLLING_INTERVAL / 1000)
 }
 
 export const advanceTimersAndPromises = async (seconds = 0): Promise<void> => {

--- a/libs/test-utils/src/advanceTimers.ts
+++ b/libs/test-utils/src/advanceTimers.ts
@@ -1,5 +1,7 @@
-import { waitFor, act } from '@testing-library/react'
+import { act, waitFor } from '@testing-library/react'
+
 export const IDLE_TIMEOUT_SECONDS = 5 * 60 // 5 minute
+
 export const advanceTimers = (seconds = 0): void => {
   const maxSeconds = IDLE_TIMEOUT_SECONDS
   if (seconds > maxSeconds) {


### PR DESCRIPTION
We still have to wrap it because we have a different default `seconds` value in BMD than the default.