### PR TITLE
refactor(tally): use discriminated union

### DIFF
--- a/apps/bmd/src/pages/PollWorkerScreen.tsx
+++ b/apps/bmd/src/pages/PollWorkerScreen.tsx
@@ -10,8 +10,6 @@ import {
   Tally,
   CardTally,
   TallySourceMachineType,
-  BMDCardTally,
-  PrecinctScannerCardTally,
   combineTallies,
 } from '@votingworks/utils'
 
@@ -248,7 +246,7 @@ const PollWorkerScreen: React.FC<Props> = ({
 
   const bmdTalliesOnCard =
     talliesOnCard?.tallyMachineType === TallySourceMachineType.BMD
-      ? (talliesOnCard as BMDCardTally)
+      ? talliesOnCard
       : undefined
 
   const isMachineTallySaved =
@@ -285,7 +283,7 @@ const PollWorkerScreen: React.FC<Props> = ({
       tally: combinedTally,
       metadata,
       totalBallotsPrinted: combinedBallotsPrinted,
-    } as BMDCardTally)
+    })
     setIsSavingTally(false)
   }
   const metadataRows: React.ReactChild[] = []
@@ -583,25 +581,22 @@ const PollWorkerScreen: React.FC<Props> = ({
       </Screen>
       {isPrintMode &&
         reportPurposes.map((reportPurpose) => {
-          if (isPrintingPrecinctScannerReport && talliesOnCard) {
+          if (
+            isPrintingPrecinctScannerReport &&
+            talliesOnCard?.tallyMachineType ===
+              TallySourceMachineType.PRECINCT_SCANNER
+          ) {
             return (
               <React.Fragment key={reportPurpose}>
                 <PollsReport
                   key={`polls-report-${reportPurpose}`}
-                  sourceMachineType={TallySourceMachineType.PRECINCT_SCANNER}
+                  sourceMachineType={talliesOnCard.tallyMachineType}
                   appName="Precinct Scanner"
-                  ballotCount={
-                    (talliesOnCard as PrecinctScannerCardTally)
-                      .totalBallotsScanned
-                  }
+                  ballotCount={talliesOnCard.totalBallotsScanned}
                   currentDateTime={currentDateTime}
                   election={election}
-                  isLiveMode={
-                    (talliesOnCard as PrecinctScannerCardTally).isLiveMode
-                  }
-                  isPollsOpen={
-                    (talliesOnCard as PrecinctScannerCardTally).isPollsOpen
-                  }
+                  isLiveMode={talliesOnCard.isLiveMode}
+                  isPollsOpen={talliesOnCard.isPollsOpen}
                   machineMetadata={talliesOnCard?.metadata}
                   machineConfig={machineConfig} // not used
                   precinctId={appPrecinctId}
@@ -609,16 +604,11 @@ const PollWorkerScreen: React.FC<Props> = ({
                 />
                 <PrecinctTallyReport
                   key={`tally-report-${reportPurpose}`}
-                  sourceMachineType={TallySourceMachineType.PRECINCT_SCANNER}
-                  ballotCount={
-                    (talliesOnCard as PrecinctScannerCardTally)
-                      .totalBallotsScanned
-                  }
+                  sourceMachineType={talliesOnCard.tallyMachineType}
+                  ballotCount={talliesOnCard.totalBallotsScanned}
                   currentDateTime={currentDateTime}
                   election={election}
-                  isPollsOpen={
-                    (talliesOnCard as PrecinctScannerCardTally).isPollsOpen
-                  }
+                  isPollsOpen={talliesOnCard.isPollsOpen}
                   tally={talliesOnCard!.tally}
                   precinctId={appPrecinctId}
                   reportPurpose={reportPurpose}

--- a/apps/precinct-scanner/src/screens/PollWorkerScreen.tsx
+++ b/apps/precinct-scanner/src/screens/PollWorkerScreen.tsx
@@ -1,11 +1,9 @@
 import React, { useContext, useState } from 'react'
 import makeDebug from 'debug'
 
-import { Precinct } from '@votingworks/types'
 import { Button, Prose, Loading } from '@votingworks/ui'
 import {
   PrecinctScannerCardTally,
-  CardTallyMetadataEntry,
   TallySourceMachineType,
 } from '@votingworks/utils'
 import { CenteredScreen } from '../components/Layout'
@@ -52,7 +50,7 @@ const PollWorkerScreen: React.FC<Props> = ({
         `Warning, ballots scanned count from status endpoint (${ballotsScannedCount}) does not match number of CVRs (${castVoteRecords.length}) `
       )
     }
-    const cardTally = {
+    await saveTallyToCard({
       tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: castVoteRecords.length,
       isLiveMode,
@@ -63,16 +61,13 @@ const PollWorkerScreen: React.FC<Props> = ({
           machineId: machineConfig.machineId,
           timeSaved: Date.now(),
           ballotCount: castVoteRecords.length,
-        } as CardTallyMetadataEntry,
+        },
       ],
-    } as PrecinctScannerCardTally
-    await saveTallyToCard(cardTally)
+    })
   }
 
   const { election } = electionDefinition!
-  const precinct = election.precincts.find(
-    (p) => p.id === currentPrecinctId
-  ) as Precinct
+  const precinct = election.precincts.find((p) => p.id === currentPrecinctId)
 
   const [confirmOpenPolls, setConfirmOpenPolls] = useState(false)
   const openConfirmOpenPollsModal = () => setConfirmOpenPolls(true)

--- a/libs/utils/src/types.ts
+++ b/libs/utils/src/types.ts
@@ -42,12 +42,6 @@ export interface CardTallyMetadataEntry {
   readonly ballotCount: number
 }
 
-export interface CardTally {
-  readonly tallyMachineType: TallySourceMachineType
-  readonly tally: Tally
-  readonly metadata: readonly CardTallyMetadataEntry[]
-}
-
 export interface BMDCardTally {
   readonly tallyMachineType: TallySourceMachineType.BMD
   readonly tally: Tally
@@ -63,3 +57,5 @@ export interface PrecinctScannerCardTally {
   readonly isLiveMode: boolean
   readonly isPollsOpen: boolean
 }
+
+export type CardTally = BMDCardTally | PrecinctScannerCardTally


### PR DESCRIPTION
Rather than making a "base type" `CardTally` that contains the shared properties for the two "sub type" tally interfaces, just make `CardTally` a discriminated union. This enables us to reduce the amount of casting we need to do since TS can infer from the value of `tallyMachineType` which one we're working with.