### PR TITLE
fix(bmd): validate card tally

### DIFF
--- a/apps/bmd/src/AppRoot.tsx
+++ b/apps/bmd/src/AppRoot.tsx
@@ -38,6 +38,7 @@ import {
   CardTally,
   CardAPI,
   CardPresentAPI,
+  CardTallySchema,
 } from '@votingworks/utils'
 
 import Ballot from './components/Ballot'
@@ -651,10 +652,10 @@ const AppRoot: React.FC<Props> = ({
   }, [])
 
   const resetPollWorkerCardTally = useCallback(async () => {
-    const possibleCardTally = (await card.readLongObject()) as Optional<CardTally>
+    const possibleCardTally = await card.readLongObject(CardTallySchema)
     dispatchAppState({
       type: 'updatePollWorkerCardTally',
-      talliesOnCard: possibleCardTally,
+      talliesOnCard: possibleCardTally.ok(),
     })
   }, [card])
 
@@ -757,19 +758,10 @@ const AppRoot: React.FC<Props> = ({
           const isValid =
             cardData.h === optionalElectionDefinition?.electionHash
 
-          let possibleCardTally: Optional<CardTally> =
+          const possibleCardTally =
             isValid && longValueExists
-              ? ((await card.readLongObject()) as Optional<CardTally>)
+              ? (await card.readLongObject(CardTallySchema)).ok()
               : undefined
-
-          // Handle a possible invalid object in the card long value
-          if (
-            possibleCardTally?.metadata === undefined ||
-            possibleCardTally?.tally === undefined ||
-            possibleCardTally?.tallyMachineType === undefined
-          ) {
-            possibleCardTally = undefined
-          }
 
           dispatchAppState({
             type: 'processPollWorkerCard',

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -42,7 +42,8 @@
     "luxon": "^1.27.0",
     "moment": "^2.29.1",
     "rxjs": "^6.6.6",
-    "yauzl": "^2.10.0"
+    "yauzl": "^2.10.0",
+    "zod": "3.2.0"
   },
   "devDependencies": {
     "@types/fast-text-encoding": "^1.0.1",

--- a/libs/utils/src/types.ts
+++ b/libs/utils/src/types.ts
@@ -1,4 +1,8 @@
+import { z } from 'zod'
+
 export type TallyCount = number
+export const TallyCountSchema = z.number()
+
 export interface CandidateVoteTally {
   candidates: TallyCount[]
   writeIns: TallyCount
@@ -6,6 +10,15 @@ export interface CandidateVoteTally {
   overvotes: TallyCount
   ballotsCast: TallyCount
 }
+export const CandidateVoteTallySchema: z.ZodSchema<CandidateVoteTally> =
+  z.object({
+    candidates: z.array(TallyCountSchema),
+    writeIns: TallyCountSchema,
+    undervotes: TallyCountSchema,
+    overvotes: TallyCountSchema,
+    ballotsCast: TallyCountSchema,
+  })
+
 export interface YesNoVoteTally {
   yes: TallyCount
   no: TallyCount
@@ -13,6 +26,14 @@ export interface YesNoVoteTally {
   overvotes: TallyCount
   ballotsCast: TallyCount
 }
+export const YesNoVoteTallySchema: z.ZodSchema<YesNoVoteTally> = z.object({
+  yes: TallyCountSchema,
+  no: TallyCountSchema,
+  undervotes: TallyCountSchema,
+  overvotes: TallyCountSchema,
+  ballotsCast: TallyCountSchema,
+})
+
 export interface MsEitherNeitherTally {
   ballotsCast: TallyCount
   eitherOption: TallyCount
@@ -24,23 +45,49 @@ export interface MsEitherNeitherTally {
   pickOneUndervotes: TallyCount
   pickOneOvervotes: TallyCount
 }
+export const MsEitherNeitherTallySchema: z.ZodSchema<MsEitherNeitherTally> =
+  z.object({
+    ballotsCast: TallyCountSchema,
+    eitherOption: TallyCountSchema,
+    neitherOption: TallyCountSchema,
+    eitherNeitherUndervotes: TallyCountSchema,
+    eitherNeitherOvervotes: TallyCountSchema,
+    firstOption: TallyCountSchema,
+    secondOption: TallyCountSchema,
+    pickOneUndervotes: TallyCountSchema,
+    pickOneOvervotes: TallyCountSchema,
+  })
 
 export type Tally = (
   | CandidateVoteTally
   | YesNoVoteTally
   | MsEitherNeitherTally
 )[]
+export const TallySchema: z.ZodSchema<Tally> = z.array(
+  z.union([
+    CandidateVoteTallySchema,
+    YesNoVoteTallySchema,
+    MsEitherNeitherTallySchema,
+  ])
+)
 
 export enum TallySourceMachineType {
   BMD = 'bmd',
   PRECINCT_SCANNER = 'precinct_scanner',
 }
+export const TallySourceMachineTypeSchema = z.nativeEnum(TallySourceMachineType)
 
 export interface CardTallyMetadataEntry {
   readonly machineId: string
   readonly timeSaved: number
   readonly ballotCount: number
 }
+export const CardTallyMetadataEntrySchema: z.ZodSchema<CardTallyMetadataEntry> =
+  z.object({
+    machineId: z.string(),
+    timeSaved: z.number(),
+    ballotCount: z.number(),
+  })
 
 export interface BMDCardTally {
   readonly tallyMachineType: TallySourceMachineType.BMD
@@ -48,6 +95,14 @@ export interface BMDCardTally {
   readonly metadata: readonly CardTallyMetadataEntry[]
   readonly totalBallotsPrinted: number
 }
+export const BMDCardTallySchema: z.ZodSchema<BMDCardTally> = z.object({
+  tallyMachineType: TallySourceMachineTypeSchema.refine(
+    (tallyMachineType) => tallyMachineType === TallySourceMachineType.BMD
+  ) as z.ZodSchema<TallySourceMachineType.BMD>,
+  tally: TallySchema,
+  metadata: z.array(CardTallyMetadataEntrySchema),
+  totalBallotsPrinted: z.number(),
+})
 
 export interface PrecinctScannerCardTally {
   readonly tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER
@@ -57,5 +112,21 @@ export interface PrecinctScannerCardTally {
   readonly isLiveMode: boolean
   readonly isPollsOpen: boolean
 }
+export const PrecinctScannerCardTallySchema: z.ZodSchema<PrecinctScannerCardTally> =
+  z.object({
+    tallyMachineType: TallySourceMachineTypeSchema.refine(
+      (tallyMachineType) =>
+        tallyMachineType === TallySourceMachineType.PRECINCT_SCANNER
+    ) as z.ZodSchema<TallySourceMachineType.PRECINCT_SCANNER>,
+    tally: TallySchema,
+    metadata: z.array(CardTallyMetadataEntrySchema),
+    totalBallotsScanned: z.number(),
+    isLiveMode: z.boolean(),
+    isPollsOpen: z.boolean(),
+  })
 
 export type CardTally = BMDCardTally | PrecinctScannerCardTally
+export const CardTallySchema = z.union([
+  BMDCardTallySchema,
+  PrecinctScannerCardTallySchema,
+])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,7 +131,7 @@ importers:
       dompurify: 2.2.6
       fetch-mock: 9.11.0
       history: 4.10.1
-      http-proxy-middleware: 1.0.6
+      http-proxy-middleware: 1.0.6_debug@4.3.2
       lodash.camelcase: 4.3.0
       luxon: 1.26.0
       mockdate: 3.0.2
@@ -465,7 +465,7 @@ importers:
       dompurify: 2.2.6
       fetch-mock: 9.11.0
       history: 4.10.1
-      http-proxy-middleware: 1.0.6
+      http-proxy-middleware: 1.0.6_debug@4.3.2
       i18next: 19.8.4
       js-file-download: 0.4.12
       js-sha256: 0.9.0
@@ -788,7 +788,7 @@ importers:
       base64-js: 1.5.1
       debug: 4.3.1
       fetch-mock: 9.11.0
-      http-proxy-middleware: 1.0.6
+      http-proxy-middleware: 1.0.6_debug@4.3.1
       i18next: 19.8.4
       jest-fetch-mock: 3.0.3
       js-file-download: 0.4.12
@@ -1538,6 +1538,7 @@ importers:
       moment: 2.29.1
       rxjs: 6.6.6
       yauzl: 2.10.0
+      zod: 3.2.0
     devDependencies:
       '@types/fast-text-encoding': 1.0.1
       '@types/jest': 26.0.23
@@ -1590,6 +1591,7 @@ importers:
       ts-jest: ^26.5.6
       typescript: ^4.3.5
       yauzl: ^2.10.0
+      zod: 3.2.0
   script:
     dependencies:
       resolve-from: 5.0.0
@@ -15543,6 +15545,19 @@ packages:
         optional: true
     resolution:
       integrity: sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
+  /follow-redirects/1.14.1_debug@4.3.2:
+    dependencies:
+      debug: 4.3.2
+    dev: false
+    engines:
+      node: '>=4.0'
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    resolution:
+      integrity: sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
   /for-each/0.3.3:
     dependencies:
       is-callable: 1.2.2
@@ -16481,6 +16496,34 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
+  /http-proxy-middleware/1.0.6_debug@4.3.1:
+    dependencies:
+      '@types/http-proxy': 1.17.6
+      http-proxy: 1.18.1_debug@4.3.1
+      is-glob: 4.0.1
+      lodash: 4.17.21
+      micromatch: 4.0.4
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    peerDependencies:
+      debug: '*'
+    resolution:
+      integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
+  /http-proxy-middleware/1.0.6_debug@4.3.2:
+    dependencies:
+      '@types/http-proxy': 1.17.6
+      http-proxy: 1.18.1_debug@4.3.2
+      is-glob: 4.0.1
+      lodash: 4.17.21
+      micromatch: 4.0.4
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    peerDependencies:
+      debug: '*'
+    resolution:
+      integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
   /http-proxy/1.18.1:
     dependencies:
       eventemitter3: 4.0.7
@@ -16495,6 +16538,18 @@ packages:
     dependencies:
       eventemitter3: 4.0.7
       follow-redirects: 1.14.1_debug@4.3.1
+      requires-port: 1.0.0
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    peerDependencies:
+      debug: '*'
+    resolution:
+      integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
+  /http-proxy/1.18.1_debug@4.3.2:
+    dependencies:
+      eventemitter3: 4.0.7
+      follow-redirects: 1.14.1_debug@4.3.2
       requires-port: 1.0.0
     dev: false
     engines:


### PR DESCRIPTION
Refactors `Card#readLongObject` to only work by accepting a `ZodSchema` to validate the JSON against, then uses this when reading a `CardTally`. This way we can be sure the object matches the structure we expect.