### PR TITLE
test(ps): add previews

### DIFF
--- a/apps/precinct-scanner/README.md
+++ b/apps/precinct-scanner/README.md
@@ -15,7 +15,8 @@ then run the app like so:
 pnpm start
 ```
 
-The server will be available at http://localhost:3000/.
+The server will be available at http://localhost:3000/. You may find it easier
+to get to certain states from http://localhost:3000/preview.
 
 To set the election configuration you will need to load a ballot export zip file
 from [election-manager](../election-manager). It should be on a USB drive

--- a/apps/precinct-scanner/package.json
+++ b/apps/precinct-scanner/package.json
@@ -73,7 +73,6 @@
     "@rooks/use-interval": "^4.11.2",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
-    "@testing-library/user-event": "^12.1.10",
     "@types/jest": "^24.0.0",
     "@types/luxon": "^1.26.5",
     "@types/node": "^12.20.11",
@@ -110,6 +109,7 @@
   },
   "devDependencies": {
     "@codemod/parser": "^1.0.6",
+    "@testing-library/user-event": "^12.8.3",
     "@types/debug": "^4.1.5",
     "@types/kiosk-browser": "workspace:*",
     "@typescript-eslint/eslint-plugin": "^4.16.1",

--- a/apps/precinct-scanner/src/PreviewApp.tsx
+++ b/apps/precinct-scanner/src/PreviewApp.tsx
@@ -1,16 +1,26 @@
 /* istanbul ignore file */
 
+import {
+  electionSampleDefinition,
+  electionWithMsEitherNeitherDefinition,
+  primaryElectionSampleDefinition,
+} from '@votingworks/fixtures'
 import React from 'react'
+import PreviewDashboard from './PreviewDashboard'
 import * as AdminScreen from './screens/AdminScreen'
 import * as InsertBallotScreen from './screens/InsertBallotScreen'
 import * as ScanWarningScreen from './screens/ScanWarningScreen'
 import * as SetupCardReaderPage from './screens/SetupCardReaderPage'
 import * as UnconfiguredElectionScreen from './screens/UnconfiguredElectionScreen'
-import PreviewDashboard from './PreviewDashboard'
 
 const PreviewApp: React.FC = () => {
   return (
     <PreviewDashboard
+      electionDefinitions={[
+        electionSampleDefinition,
+        primaryElectionSampleDefinition,
+        electionWithMsEitherNeitherDefinition,
+      ]}
       modules={[
         AdminScreen,
         InsertBallotScreen,

--- a/apps/precinct-scanner/src/PreviewApp.tsx
+++ b/apps/precinct-scanner/src/PreviewApp.tsx
@@ -1,0 +1,25 @@
+/* istanbul ignore file */
+
+import React from 'react'
+import * as AdminScreen from './screens/AdminScreen'
+import * as InsertBallotScreen from './screens/InsertBallotScreen'
+import * as ScanWarningScreen from './screens/ScanWarningScreen'
+import * as SetupCardReaderPage from './screens/SetupCardReaderPage'
+import * as UnconfiguredElectionScreen from './screens/UnconfiguredElectionScreen'
+import PreviewDashboard from './PreviewDashboard'
+
+const PreviewApp: React.FC = () => {
+  return (
+    <PreviewDashboard
+      modules={[
+        AdminScreen,
+        InsertBallotScreen,
+        ScanWarningScreen,
+        SetupCardReaderPage,
+        UnconfiguredElectionScreen,
+      ]}
+    />
+  )
+}
+
+export default PreviewApp

--- a/apps/precinct-scanner/src/PreviewDashboard.tsx
+++ b/apps/precinct-scanner/src/PreviewDashboard.tsx
@@ -34,7 +34,7 @@ export interface ComponentPreview {
 export const PREVIEW_COMPONENT_SUFFIX = 'Preview'
 
 function asTitle(id: string): string {
-  return id.split(/(?=[A-Z])/).join(' ')
+  return id.split(/(?=[A-Z\d]+)/).join(' ')
 }
 
 function getPreviewURL(preview: ComponentPreview): string {

--- a/apps/precinct-scanner/src/PreviewDashboard.tsx
+++ b/apps/precinct-scanner/src/PreviewDashboard.tsx
@@ -1,0 +1,106 @@
+/* istanbul ignore file */
+
+import { electionSampleDefinition } from '@votingworks/fixtures'
+import React from 'react'
+import { BrowserRouter, Link, Route } from 'react-router-dom'
+import AppContext from './contexts/AppContext'
+
+export interface PreviewableModule {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  default: React.FC<any>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: React.FC<any>
+}
+
+export interface PreviewableComponent {
+  componentId: string
+  componentName: string
+  previews: readonly ComponentPreview[]
+}
+
+export interface ComponentPreview {
+  componentId: string
+  componentName: string
+  previewId: string
+  previewName: string
+  previewComponent: React.FC<unknown>
+}
+
+export const PREVIEW_COMPONENT_SUFFIX = 'Preview'
+
+function asTitle(id: string): string {
+  return id.split(/(?=[A-Z])/).join(' ')
+}
+
+function getPreviewURL(preview: ComponentPreview): string {
+  return `/preview/${preview.componentId}/${preview.previewId}`
+}
+
+export function getPreviews(mod: PreviewableModule): PreviewableComponent {
+  const componentId = mod.default.name
+  const previews = Object.keys(mod)
+    .filter((key) => key.endsWith(PREVIEW_COMPONENT_SUFFIX))
+    .map((previewId) => ({
+      componentId,
+      componentName: asTitle(componentId),
+      previewId,
+      previewName: asTitle(
+        previewId.slice(0, -PREVIEW_COMPONENT_SUFFIX.length)
+      ),
+      previewComponent: mod[previewId],
+    }))
+  return { componentId, componentName: asTitle(componentId), previews }
+}
+
+export interface Props {
+  modules: readonly PreviewableModule[]
+}
+
+const PreviewDashboard: React.FC<Props> = ({ modules }) => {
+  const previewables = modules.map(getPreviews)
+
+  return (
+    <AppContext.Provider
+      value={{
+        machineConfig: {
+          codeVersion: 'preview',
+          machineId: '000',
+        },
+        electionDefinition: electionSampleDefinition,
+      }}
+    >
+      <BrowserRouter>
+        <Route path="/preview" exact>
+          <h1>Previews</h1>
+          {previewables.map(({ componentName, previews }) => {
+            return (
+              <React.Fragment key={componentName}>
+                <h2>{componentName}</h2>
+                <ul>
+                  {previews.map((preview) => (
+                    <li key={preview.previewName}>
+                      <Link to={getPreviewURL(preview)}>
+                        {preview.previewName}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </React.Fragment>
+            )
+          })}
+        </Route>
+        {previewables.map((previewable) =>
+          previewable.previews.map((preview) => (
+            <Route
+              key={preview.previewName}
+              path={getPreviewURL(preview)}
+              component={preview.previewComponent}
+            />
+          ))
+        )}
+      </BrowserRouter>
+    </AppContext.Provider>
+  )
+}
+
+export default PreviewDashboard

--- a/apps/precinct-scanner/src/index.tsx
+++ b/apps/precinct-scanner/src/index.tsx
@@ -1,11 +1,17 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './App'
+import PreviewApp from './PreviewApp'
 import * as serviceWorker from './serviceWorker'
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    {process.env.NODE_ENV === 'development' &&
+    window.location.pathname.startsWith('/preview') ? (
+      <PreviewApp />
+    ) : (
+      <App />
+    )}
   </React.StrictMode>,
   document.getElementById('root')
 )

--- a/apps/precinct-scanner/src/screens/AdminScreen.tsx
+++ b/apps/precinct-scanner/src/screens/AdminScreen.tsx
@@ -1,4 +1,4 @@
-import { SelectChangeEventFunction } from '@votingworks/types'
+import { Precinct, SelectChangeEventFunction } from '@votingworks/types'
 import {
   Button,
   Loading,
@@ -244,3 +244,35 @@ const AdminScreen: React.FC<Props> = ({
 }
 
 export default AdminScreen
+
+/* istanbul ignore next */
+export const DefaultPreview: React.FC =
+  process.env.NODE_ENV === 'development'
+    ? () => {
+        const { machineConfig, electionDefinition } = useContext(AppContext)
+        const [isTestMode, setIsTestMode] = useState(false)
+        const [precinctId, setPrecinctId] = useState<Precinct['id']>()
+        return (
+          <AppContext.Provider
+            value={{
+              machineConfig,
+              electionDefinition,
+              currentPrecinctId: precinctId,
+            }}
+          >
+            <AdminScreen
+              calibrate={() => Promise.resolve(true)}
+              isTestMode={isTestMode}
+              toggleLiveMode={async () => setIsTestMode((prev) => !prev)}
+              scannedBallotCount={1234}
+              unconfigure={() => Promise.resolve()}
+              updateAppPrecinctId={async (precinctId) =>
+                setPrecinctId(precinctId)
+              }
+              usbDriveEject={() => Promise.resolve()}
+              usbDriveStatus={usbstick.UsbDriveStatus.notavailable}
+            />
+          </AppContext.Provider>
+        )
+      }
+    : () => null

--- a/apps/precinct-scanner/src/screens/InsertBallotScreen.tsx
+++ b/apps/precinct-scanner/src/screens/InsertBallotScreen.tsx
@@ -31,3 +31,13 @@ const InsertBallotScreen: React.FC<Props> = ({ scannedBallotCount }) => {
   )
 }
 export default InsertBallotScreen
+
+/* istanbul ignore next */
+export const ZeroBallotsScannedPreview: React.FC = () => {
+  return <InsertBallotScreen scannedBallotCount={0} />
+}
+
+/* istanbul ignore next */
+export const ManyBallotsScannedPreview: React.FC = () => {
+  return <InsertBallotScreen scannedBallotCount={1234} />
+}

--- a/apps/precinct-scanner/src/screens/ScanWarningScreen.test.tsx
+++ b/apps/precinct-scanner/src/screens/ScanWarningScreen.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { electionSampleDefinition } from '@votingworks/fixtures'
+import { AdjudicationReason, CandidateContest } from '@votingworks/types'
+import React from 'react'
+import AppContext from '../contexts/AppContext'
+import ScanWarningScreen from './ScanWarningScreen'
+
+test('overvote', async () => {
+  const acceptBallot = jest.fn()
+  const contest = electionSampleDefinition.election.contests.find(
+    (c): c is CandidateContest => c.type === 'candidate'
+  )!
+
+  render(
+    <AppContext.Provider
+      value={{
+        machineConfig: {
+          codeVersion: 'test',
+          machineId: '000',
+        },
+        electionDefinition: electionSampleDefinition,
+      }}
+    >
+      <ScanWarningScreen
+        acceptBallot={acceptBallot}
+        adjudicationReasonInfo={[
+          {
+            type: AdjudicationReason.Overvote,
+            contestId: contest.id,
+            optionIds: contest.candidates.map(({ id }) => id),
+            expected: 1,
+          },
+        ]}
+      />
+    </AppContext.Provider>
+  )
+
+  screen.getByText('Too many marks for:')
+  screen.getByText(contest.title)
+  userEvent.click(screen.getByText('Tabulate Ballot'))
+  userEvent.click(screen.getByText('Yes, Tabulate Ballot'))
+  expect(acceptBallot).toHaveBeenCalledTimes(1)
+})
+
+test('blank ballot', async () => {
+  const acceptBallot = jest.fn()
+
+  render(
+    <AppContext.Provider
+      value={{
+        machineConfig: {
+          codeVersion: 'test',
+          machineId: '000',
+        },
+        electionDefinition: electionSampleDefinition,
+      }}
+    >
+      <ScanWarningScreen
+        acceptBallot={acceptBallot}
+        adjudicationReasonInfo={[{ type: AdjudicationReason.BlankBallot }]}
+      />
+    </AppContext.Provider>
+  )
+
+  screen.getByText('Remove the ballot, fix the issue, then scan again.')
+  userEvent.click(screen.getByText('Tabulate Ballot'))
+  userEvent.click(screen.getByText('Yes, Tabulate Ballot'))
+  expect(acceptBallot).toHaveBeenCalledTimes(1)
+})
+
+test('undervote', async () => {
+  const acceptBallot = jest.fn()
+  const contest = electionSampleDefinition.election.contests.find(
+    (c): c is CandidateContest => c.type === 'candidate'
+  )!
+
+  render(
+    <AppContext.Provider
+      value={{
+        machineConfig: {
+          codeVersion: 'test',
+          machineId: '000',
+        },
+        electionDefinition: electionSampleDefinition,
+      }}
+    >
+      <ScanWarningScreen
+        acceptBallot={acceptBallot}
+        adjudicationReasonInfo={[
+          {
+            type: AdjudicationReason.Undervote,
+            contestId: contest.id,
+            expected: 1,
+            optionIds: [],
+          },
+        ]}
+      />
+    </AppContext.Provider>
+  )
+
+  screen.getByText('Remove the ballot, fix the issue, then scan again.')
+  userEvent.click(screen.getByText('Tabulate Ballot'))
+  userEvent.click(screen.getByText('Yes, Tabulate Ballot'))
+  expect(acceptBallot).toHaveBeenCalledTimes(1)
+})

--- a/apps/precinct-scanner/src/screens/SetupCardReaderPage.tsx
+++ b/apps/precinct-scanner/src/screens/SetupCardReaderPage.tsx
@@ -11,3 +11,8 @@ const SetupCardReaderPage: React.FC = () => (
 )
 
 export default SetupCardReaderPage
+
+/* istanbul ignore next */
+export const DefaultPreview: React.FC = () => {
+  return <SetupCardReaderPage />
+}

--- a/apps/precinct-scanner/src/screens/UnconfiguredElectionScreen.tsx
+++ b/apps/precinct-scanner/src/screens/UnconfiguredElectionScreen.tsx
@@ -187,3 +187,13 @@ const UnconfiguredElectionScreen: React.FC<Props> = ({
 }
 
 export default UnconfiguredElectionScreen
+
+/* istanbul ignore next */
+export const DefaultPreview: React.FC = () => {
+  return (
+    <UnconfiguredElectionScreen
+      usbDriveStatus={usbstick.UsbDriveStatus.notavailable}
+      setElectionDefinition={() => Promise.resolve()}
+    />
+  )
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -773,7 +773,6 @@ importers:
       '@rooks/use-interval': 4.11.2_react@17.0.1
       '@testing-library/jest-dom': 5.12.0
       '@testing-library/react': 11.2.3_react-dom@17.0.1+react@17.0.1
-      '@testing-library/user-event': 12.6.0
       '@types/jest': 24.9.1
       '@types/luxon': 1.26.5
       '@types/node': 12.20.11
@@ -809,6 +808,7 @@ importers:
       web-vitals: 1.1.1
     devDependencies:
       '@codemod/parser': 1.1.0
+      '@testing-library/user-event': 12.8.3
       '@types/debug': 4.1.5
       '@types/kiosk-browser': link:../../libs/@types/kiosk-browser
       '@typescript-eslint/eslint-plugin': 4.22.0_7ef97ee536f89da2106f80dea587ccaa
@@ -847,7 +847,7 @@ importers:
       '@rooks/use-interval': ^4.11.2
       '@testing-library/jest-dom': ^5.11.4
       '@testing-library/react': ^11.1.0
-      '@testing-library/user-event': ^12.1.10
+      '@testing-library/user-event': ^12.8.3
       '@types/debug': ^4.1.5
       '@types/jest': ^24.0.0
       '@types/kiosk-browser': workspace:*
@@ -7525,7 +7525,7 @@ packages:
   /@testing-library/dom/7.30.4:
     dependencies:
       '@babel/code-frame': 7.14.5
-      '@babel/runtime': 7.14.5
+      '@babel/runtime': 7.14.6
       '@types/aria-query': 4.2.1
       aria-query: 4.2.2
       chalk: 4.1.1
@@ -7599,14 +7599,23 @@ packages:
   /@testing-library/user-event/12.6.0:
     dependencies:
       '@babel/runtime': 7.12.5
+      '@testing-library/dom': 7.30.4
     dev: false
     engines:
       node: '>=10'
       npm: '>=6'
-    peerDependencies:
-      '@testing-library/dom': '>=7.21.4'
     resolution:
       integrity: sha512-FNEH/HLmOk5GO70I52tKjs7WvGYckeE/SrnLX/ip7z2IGbffyd5zOUM1tZ10vsTphqm+VbDFI0oaXu0wcfQsAQ==
+  /@testing-library/user-event/12.8.3:
+    dependencies:
+      '@babel/runtime': 7.14.6
+      '@testing-library/dom': 7.30.4
+    dev: true
+    engines:
+      node: '>=10'
+      npm: '>=6'
+    resolution:
+      integrity: sha512-IR0iWbFkgd56Bu5ZI/ej8yQwrkCv8Qydx6RzwbKz9faXazR/+5tvYKsZQgyXJiwgpcva127YO6JcWy7YlCfofQ==
   /@tootallnate/once/1.1.2:
     dev: true
     engines:
@@ -19292,7 +19301,7 @@ packages:
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.1
-      jest: 26.6.3_canvas@2.6.1
+      jest: 26.6.3_ts-node@9.1.1
       jest-regex-util: 27.0.1
       jest-watcher: 27.0.2
       slash: 3.0.0
@@ -26413,7 +26422,7 @@ packages:
       bs-logger: 0.2.6
       buffer-from: 1.1.1
       fast-json-stable-stringify: 2.1.0
-      jest: 26.6.3_canvas@2.6.1
+      jest: 26.6.3_ts-node@9.1.1
       jest-util: 26.6.2
       json5: 2.2.0
       lodash: 4.17.20
@@ -26436,7 +26445,7 @@ packages:
       bs-logger: 0.2.6
       buffer-from: 1.1.1
       fast-json-stable-stringify: 2.1.0
-      jest: 26.6.3_ts-node@9.1.1
+      jest: 26.6.3
       jest-util: 26.6.2
       json5: 2.2.0
       lodash: 4.17.21

--- a/pnpmfile.js
+++ b/pnpmfile.js
@@ -100,6 +100,15 @@ function readPackage(pkg, context) {
     context.log('jest-circus requires prettier to format code for inline snapshots')
   }
 
+  if (pkg.name === '@testing-library/user-event') {
+    // Cannot find module '@testing-library/dom'
+    pkg.dependencies = {
+      ...pkg.dependencies,
+      '@testing-library/dom': '*',
+    }
+    context.log('@testing-library/user-event requires @testing-library/dom')
+  }
+
   if (/^\^?4\.2\./.test(pkg.dependencies['graceful-fs'])) {
     // Object prototype may only be an Object or null: undefined
     // Caused by https://github.com/isaacs/node-graceful-fs/commit/c55c1b8cb32510f92bd33d7c833364ecd3964dea

--- a/vxsuite.code-workspace
+++ b/vxsuite.code-workspace
@@ -79,6 +79,7 @@
       "overvotes",
       "plustek",
       "pollworker",
+      "previewable",
       "qrcode",
       "smartcards",
       "stylelint",


### PR DESCRIPTION
This adds support for viewing previews of various screens to make development easier. Sometimes it's hard to get to a certain state in the app and we have to temporarily hardcode things to make it work the way we want. Instead, this allows a developer to go to `/preview` when running the dev server and get a list of screens that can be previewed in various states. Those previews will live-update the same way anything else does in development.

This is related to #600, but isn't intended to be generic (yet) or show e.g. a component gallery. I decided to build this from scratch because it wasn't that much work and we can customize it to our needs. It follows a pattern similar to [SwiftUI previews](https://www.avanderlee.com/swiftui/previews-different-states/).


https://user-images.githubusercontent.com/1938/128088939-ea37ef39-e1c7-4405-9b0e-2402e90338f2.mov

**Update:** Added the ability to choose which election definition to use:


https://user-images.githubusercontent.com/1938/128098779-5a822866-3b1f-4131-92da-bb3ba1688ec9.mov


