### PR TITLE
perf(module-scan/ps) dont wait for ballot to be ejected to show succe…

### DIFF
--- a/apps/module-scan/schema.sql
+++ b/apps/module-scan/schema.sql
@@ -2,6 +2,7 @@ create table batches (
   id varchar(36) primary key,
   started_at datetime default current_timestamp not null,
   ended_at datetime,
+  scanning_complete_at datetime,
   error varchar(4000)
 );
 

--- a/apps/module-scan/src/importer.ts
+++ b/apps/module-scan/src/importer.ts
@@ -396,6 +396,15 @@ export default class Importer {
     }
   }
 
+  private async setScanningComplete(error?: string): Promise<void> {
+    if (this.batchId) {
+      await this.workspace.store.setScanningCompleteForBatch({
+        batchId: this.batchId,
+        error,
+      })
+    }
+  }
+
   /**
    * Scan a single sheet and see how it looks
    */
@@ -416,6 +425,7 @@ export default class Importer {
 
       const adjudicationStatus = await this.workspace.store.adjudicationStatus()
       if (adjudicationStatus.remaining === 0) {
+        await this.setScanningComplete()
         if (!(await this.sheetGenerator.acceptSheet())) {
           debug('failed to accept interpreted sheet: %s', sheetId)
         }
@@ -423,6 +433,7 @@ export default class Importer {
       } else {
         const castability = await this.getNextAdjudicationCastability()
         if (castability) {
+          await this.setScanningComplete()
           if (castability === Castability.Uncastable) {
             await this.sheetGenerator.rejectSheet()
           } else {

--- a/apps/precinct-scanner/src/api/scan.ts
+++ b/apps/precinct-scanner/src/api/scan.ts
@@ -58,7 +58,10 @@ export async function scanDetectedSheet(): Promise<ScanningResult> {
       throw new Error(`batch not found: ${batchId}`)
     }
 
-    if (batch.endedAt && status.adjudication.remaining === 0) {
+    if (
+      (batch.scanningCompleteAt || batch.endedAt) &&
+      status.adjudication.remaining === 0
+    ) {
       if (batch.count === 0) {
         // This can happen if the paper is yanked out during scanning.
         return {

--- a/libs/types/src/api/module-scan.ts
+++ b/libs/types/src/api/module-scan.ts
@@ -26,6 +26,7 @@ export interface BatchInfo {
   id: string
   startedAt: ISO8601Timestamp
   endedAt?: ISO8601Timestamp
+  scanningCompleteAt?: ISO8601Timestamp
   error?: string
   count: number
 }


### PR DESCRIPTION
This updates precinct-scanner and module-scan to not block on ejecting a successful ballot to the back in order to show the success screen. In practice, this does not have a noticeable impact on the speediness of scanning and saves at most 1 round of the polling interval in precinct-scanner (100ms), so I'm not sure this is worth committing as this also feels like a bit of a hack. But curious what you all think. 

Tested by adding a sleep in the plustek implementation of acceptSheet and seeing that before the change it waits for the sleep and ballot ejection before showing the success screen and after the change it does not. 