### PR TITLE
feat(bmd) improve audiotrack for pollworker flows

### DIFF
--- a/apps/bmd/src/AppRoot.tsx
+++ b/apps/bmd/src/AppRoot.tsx
@@ -765,7 +765,6 @@ const AppRoot: React.FC<Props> = ({
             isValid && longValueExists
               ? (await card.readLongObject(CardTallySchema)).ok()
               : undefined
-
           dispatchAppState({
             type: 'processPollWorkerCard',
             isPollWorkerCardValid: isValid,

--- a/apps/bmd/src/components/Sidebar.tsx
+++ b/apps/bmd/src/components/Sidebar.tsx
@@ -9,6 +9,7 @@ interface Props {
   children?: React.ReactNode
   footer?: React.ReactNode
   title?: string
+  screenReaderInstructions?: string
 }
 
 const StyledSidebar = styled.nav`
@@ -44,17 +45,23 @@ const Sidebar: React.FC<Props> = ({
   footer,
   children,
   title,
+  screenReaderInstructions,
 }) => {
   return (
     <StyledSidebar>
       {title && (
         <Header>
           <Prose>
-            <Text as="h1" center>
+            <Text as="h1" center id="audiofocus">
               {appName} {appName && ' / '}
               <Text as="span" light noWrap>
                 {title}
               </Text>
+              {screenReaderInstructions && (
+                <span className="screen-reader-only">
+                  {screenReaderInstructions}
+                </span>
+              )}
             </Text>
           </Prose>
         </Header>

--- a/apps/bmd/src/pages/ExpiredCardScreen.tsx
+++ b/apps/bmd/src/pages/ExpiredCardScreen.tsx
@@ -4,6 +4,7 @@ import { Main, MainChild } from '@votingworks/ui'
 
 import Prose from '../components/Prose'
 import Screen from '../components/Screen'
+import triggerAudioFocus from '../utils/triggerAudioFocus'
 
 interface Props {
   useEffectToggleLargeDisplay: () => void
@@ -13,12 +14,13 @@ const ExpiredCardScreen: React.FC<Props> = ({
   useEffectToggleLargeDisplay,
 }: Props) => {
   useEffect(useEffectToggleLargeDisplay, [])
+  useEffect(triggerAudioFocus, [])
 
   return (
     <Screen white>
       <Main>
         <MainChild center>
-          <Prose textCenter>
+          <Prose textCenter id="audiofocus">
             <h1>Expired Card</h1>
             <p>Please ask poll worker for assistance.</p>
           </Prose>

--- a/apps/bmd/src/pages/InsertCardScreen.tsx
+++ b/apps/bmd/src/pages/InsertCardScreen.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import styled from 'styled-components'
 import { ElectionDefinition } from '@votingworks/types'
 import { Main, MainChild } from '@votingworks/ui'
@@ -11,6 +11,7 @@ import Text from '../components/Text'
 import ElectionInfo from '../components/ElectionInfo'
 import { MachineConfig, PrecinctSelection } from '../config/types'
 import VersionsData from '../components/VersionsData'
+import triggerAudioFocus from '../utils/triggerAudioFocus'
 
 const InsertCardImage = styled.img`
   margin: 0 auto -1rem;
@@ -36,6 +37,7 @@ const InsertCardScreen: React.FC<Props> = ({
   showNoAccessibleControllerWarning,
   machineConfig,
 }) => {
+  useEffect(triggerAudioFocus, [])
   return (
     <Screen flexDirection="row-reverse" white>
       <Sidebar>
@@ -50,7 +52,7 @@ const InsertCardScreen: React.FC<Props> = ({
       </Sidebar>
       <Main>
         <MainChild center>
-          <Prose textCenter>
+          <Prose textCenter id="audiofocus">
             <TestMode isLiveMode={isLiveMode} />
             {showNoChargerAttachedWarning && (
               <Text warning small>

--- a/apps/bmd/src/pages/PollWorkerScreen.tsx
+++ b/apps/bmd/src/pages/PollWorkerScreen.tsx
@@ -39,6 +39,7 @@ import PrecinctTallyReport from '../components/PrecinctTallyReport'
 import { REPORT_PRINTING_TIMEOUT_SECONDS } from '../config/globals'
 import Table from '../components/Table'
 import VersionsData from '../components/VersionsData'
+import triggerAudioFocus from '../utils/triggerAudioFocus'
 
 interface Props {
   activateCardlessVoterSession: (
@@ -127,6 +128,32 @@ const PollWorkerScreen: React.FC<Props> = ({
     isPrintingPrecinctScannerReport,
     setIsPrintingPrecinctScannerReport,
   ] = useState(false)
+
+  useEffect(() => {
+    // If none of the modals are open, retrigger audiofocus
+    if (
+      !isConfirmingPrecinctScannerPrint &&
+      !isConfirmingCombinedPrint &&
+      !isPrintingPrecinctScannerReport &&
+      !isPrintingCombinedReport &&
+      !isSavingTally &&
+      !isConfirmingEnableLiveMode &&
+      !isPrintingReport &&
+      !isConfirmingPrintReport
+    ) {
+      triggerAudioFocus()
+    }
+  }, [
+    cardlessVoterSessionBallotStyleId,
+    isConfirmingPrecinctScannerPrint,
+    isConfirmingCombinedPrint,
+    isPrintingPrecinctScannerReport,
+    isPrintingCombinedReport,
+    isSavingTally,
+    isConfirmingEnableLiveMode,
+    isPrintingReport,
+    isConfirmingPrintReport,
+  ])
 
   const requestPrintSingleMachineReport = () => {
     setIsPrintingReport(true)
@@ -233,7 +260,7 @@ const PollWorkerScreen: React.FC<Props> = ({
       <Screen>
         <Main>
           <MainChild center narrow>
-            <Prose>
+            <Prose id="audiofocus">
               <h1>
                 {appPrecinct.kind === PrecinctSelectionKind.AllPrecincts
                   ? `Voter session activated: ${cardlessVoterSessionBallotStyleId} @ ${activationPrecinctName}`
@@ -317,7 +344,11 @@ const PollWorkerScreen: React.FC<Props> = ({
           {' (current machine)'}
         </td>
         <td>
-          <Button small onPress={handleSavingTally}>
+          <Button
+            small
+            onPress={handleSavingTally}
+            aria-label="Save current machine tally to card"
+          >
             Save to Card
           </Button>
         </td>
@@ -369,6 +400,7 @@ const PollWorkerScreen: React.FC<Props> = ({
                         <Button
                           fullWidth
                           key={precinct.id}
+                          aria-label={`Activate Voter Session for Precinct ${precinct.name}`}
                           onPress={() =>
                             activateCardlessVoterSession(precinct.id)
                           }
@@ -390,6 +422,7 @@ const PollWorkerScreen: React.FC<Props> = ({
                         <Button
                           fullWidth
                           key={bs.id}
+                          aria-label={`Activate Voter Session for Ballot Style ${bs.id}`}
                           onPress={() =>
                             activateCardlessVoterSession(
                               cardlessVoterSessionPrecinctId,
@@ -480,6 +513,7 @@ const PollWorkerScreen: React.FC<Props> = ({
           appName={machineConfig.appMode.name}
           centerContent
           title="Poll Worker Actions"
+          screenReaderInstructions="To navigate through the available actions, use the down arrow."
           footer={
             <React.Fragment>
               <ElectionInfo
@@ -502,7 +536,7 @@ const PollWorkerScreen: React.FC<Props> = ({
           <Modal
             centerContent
             content={
-              <Prose textCenter>
+              <Prose textCenter id="modalaudiofocus">
                 <p>
                   {isPollsOpen
                     ? 'Close Polls and print Polls Closed report?'
@@ -524,7 +558,7 @@ const PollWorkerScreen: React.FC<Props> = ({
           <Modal
             centerContent
             content={
-              <Prose textCenter>
+              <Prose textCenter id="modalaudiofocus">
                 <Loading as="p">
                   {isPollsOpen
                     ? `Printing Polls Closed report for ${precinctName}`
@@ -538,7 +572,7 @@ const PollWorkerScreen: React.FC<Props> = ({
           <Modal
             centerContent
             content={
-              <Prose textCenter>
+              <Prose textCenter id="modalaudiofocus">
                 {isPrintMode ? (
                   <h1>
                     Switch to Live&nbsp;Election&nbsp;Mode and reset the tally
@@ -573,19 +607,37 @@ const PollWorkerScreen: React.FC<Props> = ({
             }
           />
         )}
-        {isSavingTally && <Modal content={<Loading>Saving to card</Loading>} />}
+        {isSavingTally && (
+          <Modal
+            content={
+              <Prose textCenter id="modalaudiofocus">
+                <Loading>Saving to card</Loading>
+              </Prose>
+            }
+          />
+        )}
         {isPrintingCombinedReport && (
-          <Modal content={<Loading>Printing combined report</Loading>} />
+          <Modal
+            content={
+              <Prose textCenter id="modalaudiofocus">
+                <Loading>Printing combined report</Loading>
+              </Prose>
+            }
+          />
         )}
         {isPrintingPrecinctScannerReport && (
           <Modal
-            content={<Loading>Printing precinct scanner report</Loading>}
+            content={
+              <Prose textCenter id="modalaudiofocus">
+                <Loading>Printing precinct scanner report</Loading>
+              </Prose>
+            }
           />
         )}
         {isConfirmingCombinedPrint && (
           <Modal
             content={
-              <Prose>
+              <Prose id="modalaudiofocus">
                 <p>
                   Do you want to print the combined results report from the{' '}
                   {pluralize('machine', machineMetadata.length, true)} (
@@ -610,7 +662,7 @@ const PollWorkerScreen: React.FC<Props> = ({
           <Modal
             content={
               <Prose>
-                <p>
+                <p id="modalaudiofocus">
                   Do you want to print the precinct scanner results report and
                   clear tally data from the card?
                 </p>

--- a/apps/bmd/src/pages/TestBallotDeckScreen.tsx
+++ b/apps/bmd/src/pages/TestBallotDeckScreen.tsx
@@ -191,7 +191,7 @@ const TestBallotDeckScreen: React.FC<Props> = ({
               </Prose>
             ) : (
               <React.Fragment>
-                <Prose>
+                <Prose id="audiofocus">
                   <h1>Test Ballot Decks</h1>
                   <p>Select desired precinct.</p>
                 </Prose>

--- a/apps/bmd/src/pages/UsedCardScreen.tsx
+++ b/apps/bmd/src/pages/UsedCardScreen.tsx
@@ -4,6 +4,7 @@ import { Main, MainChild } from '@votingworks/ui'
 
 import Prose from '../components/Prose'
 import Screen from '../components/Screen'
+import triggerAudioFocus from '../utils/triggerAudioFocus'
 
 interface Props {
   useEffectToggleLargeDisplay: () => void
@@ -13,12 +14,13 @@ const UsedCardScreen: React.FC<Props> = ({
   useEffectToggleLargeDisplay,
 }: Props) => {
   useEffect(useEffectToggleLargeDisplay, [])
+  useEffect(triggerAudioFocus, [])
 
   return (
     <Screen white>
       <Main>
         <MainChild center>
-          <Prose textCenter>
+          <Prose textCenter id="audiofocus">
             <h1>Used Card</h1>
             <p>Please return card to a poll worker.</p>
           </Prose>

--- a/apps/bmd/src/pages/WrongElectionScreen.tsx
+++ b/apps/bmd/src/pages/WrongElectionScreen.tsx
@@ -4,6 +4,7 @@ import { Main, MainChild } from '@votingworks/ui'
 
 import Prose from '../components/Prose'
 import Screen from '../components/Screen'
+import triggerAudioFocus from '../utils/triggerAudioFocus'
 
 interface Props {
   useEffectToggleLargeDisplay: () => void
@@ -15,12 +16,13 @@ const WrongElectionScreen: React.FC<Props> = ({
   isVoterCard,
 }: Props) => {
   useEffect(useEffectToggleLargeDisplay, [])
+  useEffect(triggerAudioFocus, [])
 
   return (
     <Screen white>
       <Main>
         <MainChild center>
-          <Prose textCenter>
+          <Prose textCenter id="audiofocus">
             <h1>Invalid Card Data</h1>
             <p>Card is not configured for this election.</p>
             <p>

--- a/apps/bmd/src/pages/WrongPrecinctScreen.tsx
+++ b/apps/bmd/src/pages/WrongPrecinctScreen.tsx
@@ -4,6 +4,7 @@ import { Main, MainChild } from '@votingworks/ui'
 
 import Prose from '../components/Prose'
 import Screen from '../components/Screen'
+import triggerAudioFocus from '../utils/triggerAudioFocus'
 
 interface Props {
   useEffectToggleLargeDisplay: () => void
@@ -13,12 +14,13 @@ const WrongPrecinctScreen: React.FC<Props> = ({
   useEffectToggleLargeDisplay,
 }: Props) => {
   useEffect(useEffectToggleLargeDisplay, [])
+  useEffect(triggerAudioFocus, [])
 
   return (
     <Screen white>
       <Main>
         <MainChild center>
-          <Prose textCenter>
+          <Prose textCenter id="audiofocus">
             <h1>Invalid Card Data</h1>
             <p>Card is not configured for this precinct.</p>
             <p>Please ask poll worker for assistance.</p>

--- a/apps/bmd/src/utils/triggerAudioFocus.ts
+++ b/apps/bmd/src/utils/triggerAudioFocus.ts
@@ -1,0 +1,8 @@
+const triggerAudioFocus = (): void => {
+  const element = document.getElementById('audiofocus')
+  if (element) {
+    element.focus()
+    element.click()
+  }
+}
+export default triggerAudioFocus


### PR DESCRIPTION
Improves the audiotrack experience for pollworker flows. It isn't perfect and requires tasks like inserting the card and dealing with printed documents, but I think this makes the experience significantly better than it was and than having nothing would be, particularly for a low vision user who may just prefer having the audio assistance. 

Note that I'm introducing the ability to trigger the screen to automatically focus on (and read) the element with the ID "audiofocus" through useEffect, currently this only happens when the URL of the page changes in the app. Trying to refactor these screens to have different URL routes didn't seem worthwhile. 

Console is open to show the audio script: 

https://user-images.githubusercontent.com/14897017/128937860-356c45e2-aefe-483b-b02d-cad4eb8efd66.mov



https://zube.io/votingworks/vxsuite/c/3406 
Note: I plan to just turn off the audio for the Admin screen as its more complex but will do in another PR.