### PR TITLE
[bmd] Mute audiotrack on admin screen

### DIFF
--- a/apps/bmd/src/App.tsx
+++ b/apps/bmd/src/App.tsx
@@ -142,6 +142,7 @@ const App: React.FC<Props> = ({
               hardware={internalHardware}
               storage={storage}
               machineConfig={machineConfig}
+              screenReader={screenReader}
               {...props}
             />
           )}

--- a/apps/bmd/src/AppRoot.tsx
+++ b/apps/bmd/src/AppRoot.tsx
@@ -75,6 +75,7 @@ import WrongElectionScreen from './pages/WrongElectionScreen'
 import WrongPrecinctScreen from './pages/WrongPrecinctScreen'
 import { Printer } from './utils/printer'
 import utcTimestamp from './utils/utcTimestamp'
+import { ScreenReader } from './utils/ScreenReader'
 
 const debug = makeDebug('bmd:AppRoot')
 
@@ -146,6 +147,7 @@ export interface Props extends RouteComponentProps {
   machineConfig: Provider<MachineConfig>
   printer: Printer
   storage: Storage
+  screenReader: ScreenReader
 }
 
 export const electionStorageKey = 'electionDefinition'
@@ -473,6 +475,7 @@ const AppRoot: React.FC<Props> = ({
   history,
   machineConfig: machineConfigProvider,
   printer,
+  screenReader,
   storage,
 }) => {
   const PostVotingInstructionsTimeout = useRef(0)
@@ -540,6 +543,18 @@ const AppRoot: React.FC<Props> = ({
     },
     [card]
   )
+
+  // Disable the audiotrack when in admin mode
+  useEffect(() => {
+    const updateScreenReader = async () => {
+      if (isAdminCardPresent) {
+        await screenReader.disable()
+      } else {
+        await screenReader.enable()
+      }
+    }
+    void updateScreenReader()
+  }, [isAdminCardPresent, screenReader])
 
   // Handle Storing Election Locally
   useEffect(() => {

--- a/apps/bmd/src/utils/ScreenReader.ts
+++ b/apps/bmd/src/utils/ScreenReader.ts
@@ -206,7 +206,11 @@ export class AriaScreenReader implements ScreenReader {
     /* istanbul ignore next */
     if (process.env.NODE_ENV === 'development') {
       // eslint-disable-next-line no-console
-      console.log(`[ScreenReader] speak(now: ${options.now || false}) ${text}`)
+      console.log(
+        `[ScreenReader] speak(now: ${
+          options.now || false
+        }) (muted: ${this.isMuted()}) ${text}`
+      )
     }
     await this.tts.speak(text, options)
   }


### PR DESCRIPTION
Turns off the audiotrack in BMD when the admin card is inserted and re-enables it when removed. 