### PR TITLE
Store human-readable batch names and export names & ids in the CVR

### DIFF
--- a/apps/bsd/src/App.test.tsx
+++ b/apps/bsd/src/App.test.tsx
@@ -178,7 +178,12 @@ test('clicking export shows modal and makes a request to export', async () => {
   }
   const scanStatusResponseBody: GetScanStatusResponse = {
     batches: [
-      { id: 'test-batch', count: 2, startedAt: '2021-05-13T13:19:42.353Z' },
+      {
+        id: 'test-batch',
+        label: 'Batch 1',
+        count: 2,
+        startedAt: '2021-05-13T13:19:42.353Z',
+      },
     ],
     adjudication: { adjudicated: 0, remaining: 0 },
     scanner: ScannerStatus.Unknown,

--- a/apps/bsd/src/screens/DashboardScreen.tsx
+++ b/apps/bsd/src/screens/DashboardScreen.tsx
@@ -101,7 +101,7 @@ const DashboardScreen: React.FC<Props> = ({
             <Table>
               <thead>
                 <tr>
-                  <th>Batch ID</th>
+                  <th>Batch Name</th>
                   <th>Ballot Count</th>
                   <th>Started At</th>
                   <th>Finished At</th>
@@ -111,7 +111,7 @@ const DashboardScreen: React.FC<Props> = ({
               <tbody>
                 {batches.map((batch) => (
                   <tr key={batch.id}>
-                    <td>{batch.id}</td>
+                    <td>{batch.label}</td>
                     <td>{batch.count}</td>
                     <TD nowrap>
                       <small>{shortDateTime(batch.startedAt)}</small>

--- a/apps/module-scan/schema.sql
+++ b/apps/module-scan/schema.sql
@@ -1,5 +1,6 @@
 create table batches (
-  id varchar(36) primary key,
+  batch_number integer primary key autoincrement,
+  id varchar(36) unique,
   label text,
   started_at datetime default current_timestamp not null,
   ended_at datetime,

--- a/apps/module-scan/schema.sql
+++ b/apps/module-scan/schema.sql
@@ -1,5 +1,6 @@
 create table batches (
   id varchar(36) primary key,
+  label text,
   started_at datetime default current_timestamp not null,
   ended_at datetime,
   error varchar(4000)

--- a/apps/module-scan/src/backup.test.ts
+++ b/apps/module-scan/src/backup.test.ts
@@ -327,8 +327,7 @@ test('has cvrs.jsonl', async () => {
   expect(entries.map(({ fileName }) => fileName)).toContain('cvrs.jsonl')
 
   const cvrsEntry = entries.find(({ fileName }) => fileName === 'cvrs.jsonl')!
-  expect(await readTextEntry(zipfile, cvrsEntry)).toMatchInlineSnapshot(`
-    "{\\"1\\":[],\\"2\\":[],\\"3\\":[],\\"4\\":[],\\"_ballotId\\":\\"abc\\",\\"_ballotStyleId\\":\\"1\\",\\"_ballotType\\":\\"standard\\",\\"_precinctId\\":\\"6522\\",\\"_scannerId\\":\\"000\\",\\"_testBallot\\":false,\\"_locales\\":{\\"primary\\":\\"en-US\\"},\\"initiative-65\\":[],\\"initiative-65-a\\":[],\\"flag-question\\":[\\"yes\\"],\\"runoffs-question\\":[]}
-    "
-  `)
+  expect(await readTextEntry(zipfile, cvrsEntry)).toEqual(
+    `{"1":[],"2":[],"3":[],"4":[],"_ballotId":"abc","_ballotStyleId":"1","_ballotType":"standard","_batchId":"${batchId}","_batchLabel":"Batch 1","_precinctId":"6522","_scannerId":"000","_testBallot":false,"_locales":{"primary":"en-US"},"initiative-65":[],"initiative-65-a":[],"flag-question":["yes"],"runoffs-question":[]}\n`
+  )
 })

--- a/apps/module-scan/src/buildCastVoteRecord.test.ts
+++ b/apps/module-scan/src/buildCastVoteRecord.test.ts
@@ -122,13 +122,15 @@ test('generates a CVR from a completed BMD ballot', () => {
   const ballotId = 'abcdefg'
   const ballotStyleId = '1'
   const precinctId = '6522'
+  const batchId = '1234'
+  const batchLabel = 'Batch 1'
   const ballotStyle = getBallotStyle({ ballotStyleId, election })!
   const contests = getContests({ ballotStyle, election })
 
   const blankPageTypes = ['BlankPage', 'UnreadablePage']
   blankPageTypes.forEach((blankPageType: string) => {
     expect(
-      buildCastVoteRecord(sheetId, ballotId, election, [
+      buildCastVoteRecord(sheetId, batchId, batchLabel, ballotId, election, [
         {
           interpretation: {
             type: 'InterpretedBmdPage',
@@ -167,6 +169,8 @@ test('generates a CVR from a completed BMD ballot', () => {
       "_ballotId": "abcdefg",
       "_ballotStyleId": "1",
       "_ballotType": "standard",
+      "_batchId": "1234",
+      "_batchLabel": "Batch 1",
       "_locales": Object {
         "primary": "en-US",
       },
@@ -189,13 +193,15 @@ test('generates a CVR from a completed BMD ballot with write in and overvotes', 
   const ballotId = 'abcdefg'
   const ballotStyleId = '1'
   const precinctId = '6522'
+  const batchId = '1234'
+  const batchLabel = 'Batch 1'
   const ballotStyle = getBallotStyle({ ballotStyleId, election })!
   const contests = getContests({ ballotStyle, election })
 
   const blankPageTypes = ['BlankPage', 'UnreadablePage']
   blankPageTypes.forEach((blankPageType: string) => {
     expect(
-      buildCastVoteRecord(sheetId, ballotId, election, [
+      buildCastVoteRecord(sheetId, batchId, batchLabel, ballotId, election, [
         {
           interpretation: {
             type: 'InterpretedBmdPage',
@@ -238,6 +244,8 @@ test('generates a CVR from a completed BMD ballot with write in and overvotes', 
       "_ballotId": "abcdefg",
       "_ballotStyleId": "1",
       "_ballotType": "standard",
+      "_batchId": "1234",
+      "_batchLabel": "Batch 1",
       "_locales": Object {
         "primary": "en-US",
       },
@@ -258,11 +266,13 @@ test('generates a CVR from a completed HMPB page', () => {
   const ballotId = 'abcdefg'
   const ballotStyleId = '1'
   const precinctId = '6522'
+  const batchId = '1234'
+  const batchLabel = 'Batch 1'
   const ballotStyle = getBallotStyle({ ballotStyleId, election })!
   const contests = getContests({ ballotStyle, election })
 
   expect(
-    buildCastVoteRecord(sheetId, ballotId, election, [
+    buildCastVoteRecord(sheetId, batchId, batchLabel, ballotId, election, [
       {
         interpretation: {
           type: 'InterpretedHmpbPage',
@@ -326,6 +336,8 @@ test('generates a CVR from a completed HMPB page', () => {
       "_ballotId": "abcdefg",
       "_ballotStyleId": "1",
       "_ballotType": "standard",
+      "_batchId": "1234",
+      "_batchLabel": "Batch 1",
       "_locales": Object {
         "primary": "en-US",
       },
@@ -349,11 +361,13 @@ test('generates a CVR from a completed HMPB page with write in votes and overvot
   const ballotId = 'abcdefg'
   const ballotStyleId = '1'
   const precinctId = '6522'
+  const batchId = '1234'
+  const batchLabel = 'Batch 1'
   const ballotStyle = getBallotStyle({ ballotStyleId, election })!
   const contests = getContests({ ballotStyle, election })
 
   expect(
-    buildCastVoteRecord(sheetId, ballotId, election, [
+    buildCastVoteRecord(sheetId, batchId, batchLabel, ballotId, election, [
       {
         interpretation: {
           type: 'InterpretedHmpbPage',
@@ -418,6 +432,8 @@ test('generates a CVR from a completed HMPB page with write in votes and overvot
       "_ballotId": "abcdefg",
       "_ballotStyleId": "1",
       "_ballotType": "standard",
+      "_batchId": "1234",
+      "_batchLabel": "Batch 1",
       "_locales": Object {
         "primary": "en-US",
       },
@@ -441,11 +457,13 @@ test('generates a CVR from a completed absentee HMPB page', () => {
   const ballotId = 'abcdefg'
   const ballotStyleId = '1'
   const precinctId = '6522'
+  const batchId = '1234'
+  const batchLabel = 'Batch 1'
   const ballotStyle = getBallotStyle({ ballotStyleId, election })!
   const contests = getContests({ ballotStyle, election })
 
   expect(
-    buildCastVoteRecord(sheetId, ballotId, election, [
+    buildCastVoteRecord(sheetId, batchId, batchLabel, ballotId, election, [
       {
         interpretation: {
           type: 'InterpretedHmpbPage',
@@ -509,6 +527,8 @@ test('generates a CVR from a completed absentee HMPB page', () => {
       "_ballotId": "abcdefg",
       "_ballotStyleId": "1",
       "_ballotType": "absentee",
+      "_batchId": "1234",
+      "_batchLabel": "Batch 1",
       "_locales": Object {
         "primary": "en-US",
       },
@@ -532,11 +552,13 @@ test('generates a CVR from an adjudicated HMPB page', () => {
   const ballotId = 'abcdefg'
   const ballotStyleId = '1'
   const precinctId = '6522'
+  const batchId = '1234'
+  const batchLabel = 'Batch 1'
   const ballotStyle = getBallotStyle({ ballotStyleId, election })!
   const contests = getContests({ ballotStyle, election })
 
   expect(
-    buildCastVoteRecord(sheetId, ballotId, election, [
+    buildCastVoteRecord(sheetId, batchId, batchLabel, ballotId, election, [
       {
         interpretation: {
           type: 'InterpretedHmpbPage',
@@ -612,6 +634,8 @@ test('generates a CVR from an adjudicated HMPB page', () => {
       "_ballotId": "abcdefg",
       "_ballotStyleId": "1",
       "_ballotType": "standard",
+      "_batchId": "1234",
+      "_batchLabel": "Batch 1",
       "_locales": Object {
         "primary": "en-US",
       },
@@ -634,9 +658,11 @@ test('fails to generate a CVR from an invalid HMPB sheet with two pages having t
   const ballotId = 'abcdefg'
   const ballotStyleId = '1'
   const precinctId = '6522'
+  const batchId = '1234'
+  const batchLabel = 'Batch 1'
 
   expect(() =>
-    buildCastVoteRecord(sheetId, ballotId, election, [
+    buildCastVoteRecord(sheetId, batchId, batchLabel, ballotId, election, [
       {
         interpretation: {
           type: 'InterpretedHmpbPage',
@@ -686,9 +712,11 @@ test('fails to generate a CVR from an invalid HMPB sheet with two non-consecutiv
   const ballotId = 'abcdefg'
   const ballotStyleId = '1'
   const precinctId = '6522'
+  const batchId = '1234'
+  const batchLabel = 'Batch 1'
 
   expect(() =>
-    buildCastVoteRecord(sheetId, ballotId, election, [
+    buildCastVoteRecord(sheetId, batchId, batchLabel, ballotId, election, [
       {
         interpretation: {
           type: 'InterpretedHmpbPage',
@@ -737,9 +765,11 @@ test('fails to generate a CVR from an invalid HMPB sheet with different ballot s
   const sheetId = 'sheetid'
   const ballotId = 'abcdefg'
   const precinctId = '6522'
+  const batchId = '1234'
+  const batchLabel = 'Batch 1'
 
   expect(() =>
-    buildCastVoteRecord(sheetId, ballotId, election, [
+    buildCastVoteRecord(sheetId, batchId, batchLabel, ballotId, election, [
       {
         interpretation: {
           type: 'InterpretedHmpbPage',
@@ -788,9 +818,11 @@ test('fails to generate a CVR from an invalid HMPB sheet with different precinct
   const sheetId = 'sheetid'
   const ballotId = 'abcdefg'
   const ballotStyleId = '1'
+  const batchId = '1234'
+  const batchLabel = 'Batch 1'
 
   expect(() =>
-    buildCastVoteRecord(sheetId, ballotId, election, [
+    buildCastVoteRecord(sheetId, batchId, batchLabel, ballotId, election, [
       {
         interpretation: {
           type: 'InterpretedHmpbPage',
@@ -840,9 +872,11 @@ test('generates a CVR from an adjudicated uninterpreted HMPB page', () => {
   const ballotId = 'abcdefg'
   const ballotStyleId = '1'
   const precinctId = '6522'
+  const batchId = '1234'
+  const batchLabel = 'Batch 1'
 
   expect(
-    buildCastVoteRecord(sheetId, ballotId, election, [
+    buildCastVoteRecord(sheetId, batchId, batchLabel, ballotId, election, [
       {
         interpretation: {
           type: 'InterpretedHmpbPage',
@@ -911,6 +945,8 @@ test('generates a CVR from an adjudicated uninterpreted HMPB page', () => {
       "_ballotId": "abcdefg",
       "_ballotStyleId": "1",
       "_ballotType": "standard",
+      "_batchId": "1234",
+      "_batchLabel": "Batch 1",
       "_locales": Object {
         "primary": "en-US",
       },
@@ -931,9 +967,11 @@ test('generates a CVR from an adjudicated uninterpreted HMPB page', () => {
 test('fails to generate CVRs from blank pages', () => {
   const sheetId = 'sheetid'
   const ballotId = 'abcdefg'
+  const batchId = '1234'
+  const batchLabel = 'Batch 1'
 
   expect(
-    buildCastVoteRecord(sheetId, ballotId, election, [
+    buildCastVoteRecord(sheetId, batchId, batchLabel, ballotId, election, [
       { interpretation: { type: 'BlankPage' } },
       { interpretation: { type: 'BlankPage' } },
     ])
@@ -945,9 +983,11 @@ test('fails to generate CVRs from invalid test mode pages', () => {
   const ballotId = 'abcdefg'
   const ballotStyleId = '1'
   const precinctId = '6522'
+  const batchId = '1234'
+  const batchLabel = 'Batch 1'
 
   expect(
-    buildCastVoteRecord(sheetId, ballotId, election, [
+    buildCastVoteRecord(sheetId, batchId, batchLabel, ballotId, election, [
       {
         interpretation: {
           type: 'InvalidTestModePage',

--- a/apps/module-scan/src/buildCastVoteRecord.ts
+++ b/apps/module-scan/src/buildCastVoteRecord.ts
@@ -28,12 +28,16 @@ import {
 
 export function buildCastVoteRecordMetadataEntries(
   ballotId: string,
+  batchId: string,
+  batchLabel: string,
   metadata: BallotMetadata
 ): CastVoteRecord {
   return {
     _ballotId: ballotId,
     _ballotStyleId: metadata.ballotStyleId,
     _ballotType: getCVRBallotType(metadata.ballotType),
+    _batchId: batchId,
+    _batchLabel: batchLabel,
     _precinctId: metadata.precinctId,
     _scannerId: VX_MACHINE_ID,
     _testBallot: metadata.isTestMode,
@@ -167,11 +171,18 @@ export function getContestsForBallotStyle(
 
 export function buildCastVoteRecordFromBmdPage(
   ballotId: string,
+  batchId: string,
+  batchLabel: string,
   election: Election,
   interpretation: InterpretedBmdPage
 ): CastVoteRecord {
   return {
-    ...buildCastVoteRecordMetadataEntries(ballotId, interpretation.metadata),
+    ...buildCastVoteRecordMetadataEntries(
+      ballotId,
+      batchId,
+      batchLabel,
+      interpretation.metadata
+    ),
     ...buildCastVoteRecordVotesEntries(
       getContestsForBallotStyle(
         election,
@@ -186,6 +197,8 @@ export function buildCastVoteRecordFromBmdPage(
 function buildCastVoteRecordFromHmpbPage(
   sheetId: string,
   ballotId: string,
+  batchId: string,
+  batchLabel: string,
   election: Election,
   [front, back]: SheetOf<
     BuildCastVoteRecordInput<InterpretedHmpbPage | UninterpretedHmpbPage>
@@ -205,6 +218,8 @@ function buildCastVoteRecordFromHmpbPage(
   return {
     ...buildCastVoteRecordMetadataEntries(
       ballotId,
+      batchId,
+      batchLabel,
       front.interpretation.metadata
     ),
     _pageNumbers: [
@@ -230,6 +245,8 @@ function buildCastVoteRecordFromHmpbPage(
 
 export function buildCastVoteRecord(
   sheetId: string,
+  batchId: string,
+  batchLabel: string,
   ballotId: string,
   election: Election,
   [front, back]: SheetOf<BuildCastVoteRecordInput>
@@ -252,6 +269,8 @@ export function buildCastVoteRecord(
   if (front.interpretation.type === 'InterpretedBmdPage') {
     return buildCastVoteRecordFromBmdPage(
       ballotId,
+      batchId,
+      batchLabel,
       election,
       front.interpretation
     )
@@ -261,11 +280,15 @@ export function buildCastVoteRecord(
     front.interpretation.type === 'InterpretedHmpbPage' ||
     front.interpretation.type === 'UninterpretedHmpbPage'
   ) {
-    return buildCastVoteRecordFromHmpbPage(sheetId, ballotId, election, [
-      front,
-      back,
-    ] as SheetOf<
-      BuildCastVoteRecordInput<InterpretedHmpbPage | UninterpretedHmpbPage>
-    >)
+    return buildCastVoteRecordFromHmpbPage(
+      sheetId,
+      ballotId,
+      batchId,
+      batchLabel,
+      election,
+      [front, back] as SheetOf<
+        BuildCastVoteRecordInput<InterpretedHmpbPage | UninterpretedHmpbPage>
+      >
+    )
   }
 }

--- a/apps/module-scan/src/endToEndHmpb.test.ts
+++ b/apps/module-scan/src/endToEndHmpb.test.ts
@@ -155,46 +155,27 @@ test('going through the whole process works', async () => {
     expect(cvrs).toHaveLength(1)
     const [cvr] = cvrs
     cvr._ballotId = ''
-    expect(cvr).toMatchInlineSnapshot(`
-      Object {
-        "_ballotId": "",
-        "_ballotStyleId": "12",
-        "_ballotType": "standard",
-        "_locales": Object {
-          "primary": "en-US",
-          "secondary": "es-US",
-        },
-        "_pageNumbers": Array [
-          1,
-          2,
-        ],
-        "_precinctId": "23",
-        "_scannerId": "000",
-        "_testBallot": false,
-        "governor": Array [
-          "windbeck",
-        ],
-        "lieutenant-governor": Array [
-          "davis",
-        ],
-        "president": Array [
-          "barchi-hallaren",
-        ],
-        "representative-district-6": Array [
-          "schott",
-        ],
-        "secretary-of-state": Array [
-          "talarico",
-        ],
-        "senator": Array [
-          "brown",
-        ],
-        "state-assembly-district-54": Array [
-          "keller",
-        ],
-        "state-senator-district-31": Array [],
-      }
-    `)
+    expect(cvr).toMatchObject({
+      _ballotId: '',
+      _ballotStyleId: '12',
+      _ballotType: 'standard',
+      _locales: {
+        primary: 'en-US',
+        secondary: 'es-US',
+      },
+      _pageNumbers: [1, 2],
+      _precinctId: '23',
+      _scannerId: '000',
+      _testBallot: false,
+      governor: ['windbeck'],
+      'lieutenant-governor': ['davis'],
+      president: ['barchi-hallaren'],
+      'representative-district-6': ['schott'],
+      'secretary-of-state': ['talarico'],
+      senator: ['brown'],
+      'state-assembly-district-54': ['keller'],
+      'state-senator-district-31': [],
+    })
   }
 })
 
@@ -284,49 +265,28 @@ test('ms-either-neither end-to-end', async () => {
     expect(cvrs).toHaveLength(1)
     const [cvr] = cvrs
     cvr._ballotId = ''
-    expect(cvr).toMatchInlineSnapshot(`
-      Object {
-        "750000015": Array [
-          "yes",
-        ],
-        "750000016": Array [
-          "yes",
-        ],
-        "750000017": Array [
-          "no",
-        ],
-        "750000018": Array [
-          "yes",
-        ],
-        "775020870": Array [
-          "__write-in-0",
-        ],
-        "775020872": Array [
-          "775031978",
-        ],
-        "775020876": Array [
-          "775031988",
-        ],
-        "775020877": Array [
-          "775031986",
-        ],
-        "775020899": Array [
-          "775032015",
-        ],
-        "_ballotId": "",
-        "_ballotStyleId": "4",
-        "_ballotType": "standard",
-        "_locales": Object {
-          "primary": "en-US",
-        },
-        "_pageNumbers": Array [
-          1,
-          2,
-        ],
-        "_precinctId": "6538",
-        "_scannerId": "000",
-        "_testBallot": false,
-      }
-    `)
+    expect(cvr).toMatchObject({
+      '750000015': ['yes'],
+      '750000016': ['yes'],
+      '750000017': ['no'],
+      '750000018': ['yes'],
+      '775020870': ['__write-in-0'],
+      '775020872': ['775031978'],
+      '775020876': ['775031988'],
+      '775020877': ['775031986'],
+      '775020899': ['775032015'],
+      _ballotId: '',
+      _ballotStyleId: '4',
+      _ballotType: 'standard',
+      _batchId: expect.anything(),
+      _batchLabel: 'Batch 1',
+      _locales: {
+        primary: 'en-US',
+      },
+      _pageNumbers: [1, 2],
+      _precinctId: '6538',
+      _scannerId: '000',
+      _testBallot: false,
+    })
   }
 })

--- a/apps/module-scan/src/store.test.ts
+++ b/apps/module-scan/src/store.test.ts
@@ -170,6 +170,25 @@ test('batch cleanup works correctly', async () => {
   const batches = await store.batchStatus()
   expect(batches).toHaveLength(1)
   expect(batches[0].id).toEqual(firstBatchId)
+  expect(batches[0].label).toEqual('Batch 1')
+
+  const thirdBatchId = await store.addBatch()
+  await store.addBatch()
+  await store.finishBatch({ batchId: thirdBatchId })
+  await store.cleanupIncompleteBatches()
+  const updatedBatches = await store.batchStatus()
+  expect(updatedBatches).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        id: firstBatchId,
+        label: 'Batch 1',
+      }),
+      expect.objectContaining({
+        id: thirdBatchId,
+        label: 'Batch 3',
+      }),
+    ])
+  )
 })
 
 test('adjudication', async () => {

--- a/apps/module-scan/src/store.test.ts
+++ b/apps/module-scan/src/store.test.ts
@@ -177,8 +177,8 @@ test('batch cleanup works correctly', async () => {
   await store.finishBatch({ batchId: thirdBatchId })
   await store.cleanupIncompleteBatches()
   const updatedBatches = await store.batchStatus()
-  expect(updatedBatches).toEqual(
-    expect.arrayContaining([
+  expect(updatedBatches.sort((a, b) => a.label.localeCompare(b.label))).toEqual(
+    [
       expect.objectContaining({
         id: firstBatchId,
         label: 'Batch 1',
@@ -187,7 +187,7 @@ test('batch cleanup works correctly', async () => {
         id: thirdBatchId,
         label: 'Batch 3',
       }),
-    ])
+    ]
   )
 })
 

--- a/libs/types/src/api/module-scan.ts
+++ b/libs/types/src/api/module-scan.ts
@@ -30,6 +30,7 @@ export const AdjudicationStatusSchema: z.ZodSchema<AdjudicationStatus> = z.objec
 
 export interface BatchInfo {
   id: string
+  label: string
   startedAt: ISO8601Timestamp
   endedAt?: ISO8601Timestamp
   error?: string
@@ -38,6 +39,7 @@ export interface BatchInfo {
 
 export const BatchInfoSchema: z.ZodSchema<BatchInfo> = z.object({
   id: Id,
+  label: z.string(),
   startedAt: ISO8601TimestampSchema,
   endedAt: z.optional(ISO8601TimestampSchema),
   error: z.optional(z.string()),


### PR DESCRIPTION
Stores a human-readable batch name alongside the batch ID, and exports both in the CVR. I stored the entire name rather than a batch number as an autoincrement column as I was thinking we may want to allow people to custom edit the batch names down the road and this would set up well for doing that, but I may be thinking too far ahead. I also considered still having an autoincrement column in addition to the label column but didn't want to overcomplicate the DB schema. I feel a little iffy about the way I'm tracking the batch number right now though so ... open to suggestion. 

The way this is implemented the batch number will only reset to 0 when a factory reset occurs. So if you toggle to test mode, or remove the ballot data (without a factory reset) the batch numbers will continue to increment. I think this makes some amount of sense as if you scanned some ballots, exported the data, cleared the data, scanned more ballots you would want new batch numbers/names instead of having conflicts with the initial set of results. Also if you delete a batch the number will not be reused. 

Updates bsd to show the batch name rather than the ID. 

IDs are exported alongside the batch labels as the IDs are what will be used to group the tallies in election manager and are guaranteed to be unique across scanners, batch labels may not be unique. 

![Screen Shot 2021-08-12 at 9 28 45 AM](https://user-images.githubusercontent.com/14897017/129268958-86c288a3-a1f7-4248-b3e3-f9c676584c3e.png)
