### PR TITLE
feat(ps): give more fine-grained scanner status

### DIFF
--- a/apps/module-scan/src/importer.ts
+++ b/apps/module-scan/src/importer.ts
@@ -4,7 +4,7 @@ import {
   MarkThresholds,
   Optional,
 } from '@votingworks/types'
-import { ScanStatus } from '@votingworks/types/api/module-scan'
+import { ScannerStatus, ScanStatus } from '@votingworks/types/api/module-scan'
 import { sleep } from '@votingworks/utils'
 import makeDebug from 'debug'
 import * as fsExtra from 'fs-extra'
@@ -563,15 +563,19 @@ export default class Importer {
    * Get the imported batches and current election info, if any.
    */
   public async getStatus(): Promise<ScanStatus> {
-    const election = await this.workspace.store.getElectionDefinition()
+    const electionDefinition = await this.workspace.store.getElectionDefinition()
     const batches = await this.workspace.store.batchStatus()
     const adjudication = await this.workspace.store.adjudicationStatus()
     const scanner = await this.scanner.getStatus()
+
     return {
-      electionHash: election?.electionHash,
+      electionHash: electionDefinition?.electionHash,
       batches,
       adjudication,
-      scanner,
+      scanner:
+        adjudication.remaining > 0 && scanner === ScannerStatus.ReadyToScan
+          ? ScannerStatus.Rejected
+          : scanner,
     }
   }
 

--- a/libs/types/src/api/module-scan.ts
+++ b/libs/types/src/api/module-scan.ts
@@ -41,6 +41,12 @@ export const BatchInfoSchema: z.ZodSchema<BatchInfo> = z.object({
 export enum ScannerStatus {
   WaitingForPaper = 'WaitingForPaper',
   ReadyToScan = 'ReadyToScan',
+  Scanning = 'Scanning',
+  Accepting = 'Accepting',
+  Rejecting = 'Rejecting',
+  ReadyToAccept = 'ReadyToAccept',
+  Rejected = 'Rejected',
+  Calibrating = 'Calibrating',
   Error = 'Error',
   Unknown = 'Unknown',
 }


### PR DESCRIPTION
The backend now tracks the current operation and returns a status appropriate to that operation, such as `Scanning`. In particular, when using the precinct scanner, the state of a sheet requiring review having been ejected toward the voter will now be represented as `Rejected` rather than `ReadyToScan`. This will make it much easier in a future change to have the frontend do less of its own state management.

Refs #740 