### PR TITLE
fix(types): stop using `as` to the extent possible

### DIFF
--- a/apps/bmd/src/APIMachineConfig.test.tsx
+++ b/apps/bmd/src/APIMachineConfig.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react'
 
 import fetchMock from 'fetch-mock'
 import { Provider } from '@votingworks/types'
-import { MemoryStorage } from '@votingworks/utils'
+import { MemoryStorage, typedAs } from '@votingworks/utils'
 import App from './App'
 
 import {
@@ -19,13 +19,14 @@ beforeEach(() => {
 })
 
 test('machineConfig is fetched from /machine-config by default', async () => {
-  const machineConfigResponse: MachineConfigResponse = {
-    appModeName: VxMarkOnly.name,
-    machineId: '99',
-    codeVersion: 'test',
-  }
-
-  fetchMock.get('/machine-config', () => JSON.stringify(machineConfigResponse))
+  fetchMock.get(
+    '/machine-config',
+    typedAs<MachineConfigResponse>({
+      appModeName: VxMarkOnly.name,
+      machineId: '99',
+      codeVersion: 'test',
+    })
+  )
 
   render(<App storage={new MemoryStorage()} />)
   await advanceTimersAndPromises()
@@ -34,7 +35,7 @@ test('machineConfig is fetched from /machine-config by default', async () => {
 })
 
 test('machineConfig fetch fails', async () => {
-  const machineConfig = {
+  const machineConfig: Provider<MachineConfig> = {
     get: () => Promise.reject(new Error('fetch failed!')),
   }
 
@@ -64,7 +65,7 @@ test('machineId is empty', async () => {
 })
 
 test('machineConfig is empty', async () => {
-  const machineConfig = {
+  const machineConfig: Provider<MachineConfig> = {
     async get() {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return undefined as any

--- a/apps/bmd/src/components/CandidateContest.tsx
+++ b/apps/bmd/src/components/CandidateContest.tsx
@@ -10,7 +10,6 @@ import styled from 'styled-components'
 
 import {
   Candidate,
-  OptionalCandidate,
   CandidateVote,
   CandidateContest as CandidateContestInterface,
   Parties,
@@ -103,11 +102,11 @@ const CandidateContest: React.FC<Props> = ({
   const [
     attemptedOvervoteCandidate,
     setAttemptedOvervoteCandidate,
-  ] = useState<OptionalCandidate>()
+  ] = useState<Candidate>()
   const [
     candidatePendingRemoval,
     setCandidatePendingRemoval,
-  ] = useState<OptionalCandidate>()
+  ] = useState<Candidate>()
   const [isScrollable, setIsScrollable] = useState(false)
   const [isScrollAtBottom, setIsScrollAtBottom] = useState(true)
   const [isScrollAtTop, setIsScrollAtTop] = useState(true)
@@ -187,8 +186,8 @@ const CandidateContest: React.FC<Props> = ({
     }
   }
 
-  const handleChangeVoteAlert = (optionalCandidate: OptionalCandidate) => {
-    setAttemptedOvervoteCandidate(optionalCandidate)
+  const handleChangeVoteAlert = (candidate?: Candidate) => {
+    setAttemptedOvervoteCandidate(candidate)
   }
 
   const closeAttemptedVoteAlert = () => {
@@ -278,7 +277,7 @@ const CandidateContest: React.FC<Props> = ({
     handleChangeVoteAlert({
       id: 'write-in',
       name: 'a write-in candidate',
-    } as Candidate)
+    })
   }
 
   const hasReachedMaxSelections = contest.seats === vote.length

--- a/apps/bmd/src/utils/machineConfig.test.ts
+++ b/apps/bmd/src/utils/machineConfig.test.ts
@@ -1,35 +1,66 @@
 import fetchMock from 'fetch-mock'
+import { typedAs } from '@votingworks/utils'
 import machineConfigProvider from './machineConfig'
-import { VxMarkOnly, VxMarkPlusVxPrint, VxPrintOnly } from '../config/types'
+import {
+  MachineConfig,
+  MachineConfigResponse,
+  VxMarkOnly,
+  VxMarkPlusVxPrint,
+  VxPrintOnly,
+} from '../config/types'
 
 test('successful VxMark fetch from /machine-config', async () => {
-  fetchMock.get('/machine-config', () =>
-    JSON.stringify({ appModeName: 'VxMark', machineId: '1' })
+  fetchMock.get(
+    '/machine-config',
+    typedAs<MachineConfigResponse>({
+      appModeName: 'VxMark',
+      machineId: '1',
+      codeVersion: 'test',
+    })
   )
-  expect(await machineConfigProvider.get()).toEqual({
-    appMode: VxMarkOnly,
-    machineId: '1',
-  })
+  expect(await machineConfigProvider.get()).toEqual(
+    typedAs<MachineConfig>({
+      appMode: VxMarkOnly,
+      machineId: '1',
+      codeVersion: 'test',
+    })
+  )
 })
 
 test('successful VxPrint fetch from /machine-config', async () => {
-  fetchMock.get('/machine-config', () =>
-    JSON.stringify({ appModeName: 'VxPrint', machineId: '1' })
+  fetchMock.get(
+    '/machine-config',
+    typedAs<MachineConfigResponse>({
+      appModeName: 'VxPrint',
+      machineId: '1',
+      codeVersion: 'test',
+    })
   )
-  expect(await machineConfigProvider.get()).toEqual({
-    appMode: VxPrintOnly,
-    machineId: '1',
-  })
+  expect(await machineConfigProvider.get()).toEqual(
+    typedAs<MachineConfig>({
+      appMode: VxPrintOnly,
+      machineId: '1',
+      codeVersion: 'test',
+    })
+  )
 })
 
 test('successful VxMark + VxPrint fetch from /machine-config', async () => {
-  fetchMock.get('/machine-config', () =>
-    JSON.stringify({ appModeName: 'VxMark + VxPrint', machineId: '1' })
+  fetchMock.get(
+    '/machine-config',
+    typedAs<MachineConfigResponse>({
+      appModeName: 'VxMark + VxPrint',
+      machineId: '1',
+      codeVersion: 'test',
+    })
   )
-  expect(await machineConfigProvider.get()).toEqual({
-    appMode: VxMarkPlusVxPrint,
-    machineId: '1',
-  })
+  expect(await machineConfigProvider.get()).toEqual(
+    typedAs<MachineConfig>({
+      appMode: VxMarkPlusVxPrint,
+      machineId: '1',
+      codeVersion: 'test',
+    })
+  )
 })
 
 test('failed fetch from /machine-config', async () => {

--- a/apps/bsd/src/App.test.tsx
+++ b/apps/bsd/src/App.test.tsx
@@ -11,7 +11,7 @@ import { act } from 'react-dom/test-utils'
 import { electionSample, electionSampleDefinition } from '@votingworks/fixtures'
 import fileDownload from 'js-file-download'
 import { fakeKiosk } from '@votingworks/test-utils'
-import { sleep } from '@votingworks/utils'
+import { sleep, typedAs } from '@votingworks/utils'
 import {
   GetElectionConfigResponse,
   GetMarkThresholdOverridesConfigResponse,
@@ -22,19 +22,25 @@ import {
 } from '@votingworks/types/api/module-scan'
 import App from './App'
 import hasTextAcrossElements from '../test/util/hasTextAcrossElements'
+import { MachineConfigResponse } from './config/types'
 
 jest.mock('js-file-download')
 
 beforeEach(() => {
-  const scanStatusResponse: GetScanStatusResponse = {
-    batches: [],
-    adjudication: { adjudicated: 0, remaining: 0 },
-    scanner: ScannerStatus.Unknown,
-  }
-  fetchMock.get('/scan/status', scanStatusResponse)
-  fetchMock.get('/machine-config', {
-    machineId: '0001',
-  })
+  fetchMock.get(
+    '/scan/status',
+    typedAs<GetScanStatusResponse>({
+      batches: [],
+      adjudication: { adjudicated: 0, remaining: 0 },
+      scanner: ScannerStatus.Unknown,
+    })
+  )
+  fetchMock.get(
+    '/machine-config',
+    typedAs<MachineConfigResponse>({
+      machineId: '0001',
+    })
+  )
 
   const oldWindowLocation = window.location
   Object.defineProperty(window, 'location', {

--- a/apps/bsd/src/api/config.test.ts
+++ b/apps/bsd/src/api/config.test.ts
@@ -1,5 +1,10 @@
 import fetchMock from 'fetch-mock'
 import { electionSampleDefinition as testElectionDefinition } from '@votingworks/fixtures'
+import { typedAs } from '@votingworks/utils'
+import {
+  DeleteElectionConfigResponse,
+  PatchElectionConfigResponse,
+} from '@votingworks/types/api/module-scan'
 import * as config from './config'
 
 test('GET /config/election', async () => {
@@ -8,7 +13,9 @@ test('GET /config/election', async () => {
 })
 
 test('PATCH /config/election', async () => {
-  fetchMock.patchOnce('/config/election', JSON.stringify({ status: 'ok' }))
+  fetchMock.patchOnce('/config/election', {
+    body: typedAs<PatchElectionConfigResponse>({ status: 'ok' }),
+  })
   await config.setElection(testElectionDefinition.electionData)
 })
 
@@ -16,10 +23,12 @@ test('PATCH /config/election fails', async () => {
   fetchMock.patchOnce(
     '/config/election',
     new Response(
-      JSON.stringify({
-        status: 'error',
-        errors: [{ type: 'invalid-value', message: 'bad election!' }],
-      }),
+      JSON.stringify(
+        typedAs<PatchElectionConfigResponse>({
+          status: 'error',
+          errors: [{ type: 'invalid-value', message: 'bad election!' }],
+        })
+      ),
       { status: 400 }
     )
   )
@@ -29,6 +38,8 @@ test('PATCH /config/election fails', async () => {
 })
 
 test('DELETE /config/election to delete election', async () => {
-  fetchMock.deleteOnce('/config/election', JSON.stringify({ status: 'ok' }))
+  fetchMock.deleteOnce('/config/election', {
+    body: typedAs<DeleteElectionConfigResponse>({ status: 'ok' }),
+  })
   await config.setElection(undefined)
 })

--- a/apps/bsd/src/config/types.ts
+++ b/apps/bsd/src/config/types.ts
@@ -9,6 +9,10 @@ export interface MachineConfig {
   machineId: string
 }
 
+export interface MachineConfigResponse {
+  machineId: string
+}
+
 // Events
 export type EventTargetFunction = (event: React.FormEvent<EventTarget>) => void
 export type InputEvent = React.FormEvent<EventTarget>

--- a/apps/bsd/src/screens/BallotEjectScreen.test.tsx
+++ b/apps/bsd/src/screens/BallotEjectScreen.test.tsx
@@ -7,22 +7,25 @@ import {
   BallotType,
   AdjudicationReason,
 } from '@votingworks/types'
+import { typedAs } from '@votingworks/utils'
 import BallotEjectScreen from './BallotEjectScreen'
 import renderInAppContext from '../../test/renderInAppContext'
 
 test('says the sheet is unreadable if it is', async () => {
-  const response: BallotSheetInfo = {
-    id: 'mock-sheet-id',
-    front: {
-      image: { url: '/front/url' },
-      interpretation: { type: 'BlankPage' },
-    },
-    back: {
-      image: { url: '/back/url' },
-      interpretation: { type: 'BlankPage' },
-    },
-  }
-  fetchMock.getOnce('/scan/hmpb/review/next-sheet', response)
+  fetchMock.getOnce(
+    '/scan/hmpb/review/next-sheet',
+    typedAs<BallotSheetInfo>({
+      id: 'mock-sheet-id',
+      front: {
+        image: { url: '/front/url' },
+        interpretation: { type: 'BlankPage' },
+      },
+      back: {
+        image: { url: '/back/url' },
+        interpretation: { type: 'BlankPage' },
+      },
+    })
+  )
 
   const continueScanning = jest.fn()
 
@@ -41,67 +44,69 @@ test('says the sheet is unreadable if it is', async () => {
 })
 
 test('says the ballot sheet is overvoted if it is', async () => {
-  const response: BallotSheetInfo = {
-    id: 'mock-sheet-id',
-    front: {
-      image: { url: '/front/url' },
-      interpretation: {
-        type: 'InterpretedHmpbPage',
-        markInfo: {
-          ballotSize: { width: 1, height: 1 },
-          marks: [],
+  fetchMock.getOnce(
+    '/scan/hmpb/review/next-sheet',
+    typedAs<BallotSheetInfo>({
+      id: 'mock-sheet-id',
+      front: {
+        image: { url: '/front/url' },
+        interpretation: {
+          type: 'InterpretedHmpbPage',
+          markInfo: {
+            ballotSize: { width: 1, height: 1 },
+            marks: [],
+          },
+          metadata: {
+            ballotStyleId: '1',
+            precinctId: '1',
+            ballotType: BallotType.Standard,
+            electionHash: '',
+            isTestMode: false,
+            locales: { primary: 'en-US' },
+            pageNumber: 1,
+          },
+          adjudicationInfo: {
+            requiresAdjudication: true,
+            allReasonInfos: [
+              {
+                type: AdjudicationReason.Overvote,
+                contestId: '1',
+                optionIds: ['1', '2'],
+                expected: 1,
+              },
+            ],
+            enabledReasons: [AdjudicationReason.Overvote],
+          },
+          votes: {},
         },
-        metadata: {
-          ballotStyleId: '1',
-          precinctId: '1',
-          ballotType: BallotType.Standard,
-          electionHash: '',
-          isTestMode: false,
-          locales: { primary: 'en-US' },
-          pageNumber: 1,
-        },
-        adjudicationInfo: {
-          requiresAdjudication: true,
-          allReasonInfos: [
-            {
-              type: AdjudicationReason.Overvote,
-              contestId: '1',
-              optionIds: ['1', '2'],
-              expected: 1,
-            },
-          ],
-          enabledReasons: [AdjudicationReason.Overvote],
-        },
-        votes: {},
       },
-    },
-    back: {
-      image: { url: '/back/url' },
-      interpretation: {
-        type: 'InterpretedHmpbPage',
-        markInfo: {
-          ballotSize: { width: 1, height: 1 },
-          marks: [],
+      back: {
+        image: { url: '/back/url' },
+        interpretation: {
+          type: 'InterpretedHmpbPage',
+          markInfo: {
+            ballotSize: { width: 1, height: 1 },
+            marks: [],
+          },
+          metadata: {
+            ballotStyleId: '1',
+            precinctId: '1',
+            ballotType: BallotType.Standard,
+            electionHash: '',
+            isTestMode: false,
+            locales: { primary: 'en-US' },
+            pageNumber: 2,
+          },
+          adjudicationInfo: {
+            requiresAdjudication: false,
+            allReasonInfos: [],
+            enabledReasons: [AdjudicationReason.Overvote],
+          },
+          votes: {},
         },
-        metadata: {
-          ballotStyleId: '1',
-          precinctId: '1',
-          ballotType: BallotType.Standard,
-          electionHash: '',
-          isTestMode: false,
-          locales: { primary: 'en-US' },
-          pageNumber: 2,
-        },
-        adjudicationInfo: {
-          requiresAdjudication: false,
-          allReasonInfos: [],
-          enabledReasons: [AdjudicationReason.Overvote],
-        },
-        votes: {},
       },
-    },
-  }
-  fetchMock.getOnce('/scan/hmpb/review/next-sheet', response)
+    })
+  )
 
   const continueScanning = jest.fn()
 
@@ -127,67 +132,69 @@ test('says the ballot sheet is overvoted if it is', async () => {
 })
 
 test('says the ballot sheet is undervoted if it is', async () => {
-  const response: BallotSheetInfo = {
-    id: 'mock-sheet-id',
-    front: {
-      image: { url: '/front/url' },
-      interpretation: {
-        type: 'InterpretedHmpbPage',
-        markInfo: {
-          ballotSize: { width: 1, height: 1 },
-          marks: [],
+  fetchMock.getOnce(
+    '/scan/hmpb/review/next-sheet',
+    typedAs<BallotSheetInfo>({
+      id: 'mock-sheet-id',
+      front: {
+        image: { url: '/front/url' },
+        interpretation: {
+          type: 'InterpretedHmpbPage',
+          markInfo: {
+            ballotSize: { width: 1, height: 1 },
+            marks: [],
+          },
+          metadata: {
+            ballotStyleId: '1',
+            precinctId: '1',
+            ballotType: BallotType.Standard,
+            electionHash: '',
+            isTestMode: false,
+            locales: { primary: 'en-US' },
+            pageNumber: 1,
+          },
+          adjudicationInfo: {
+            requiresAdjudication: true,
+            allReasonInfos: [
+              {
+                type: AdjudicationReason.Undervote,
+                contestId: '1',
+                optionIds: [],
+                expected: 1,
+              },
+            ],
+            enabledReasons: [AdjudicationReason.Undervote],
+          },
+          votes: {},
         },
-        metadata: {
-          ballotStyleId: '1',
-          precinctId: '1',
-          ballotType: BallotType.Standard,
-          electionHash: '',
-          isTestMode: false,
-          locales: { primary: 'en-US' },
-          pageNumber: 1,
-        },
-        adjudicationInfo: {
-          requiresAdjudication: true,
-          allReasonInfos: [
-            {
-              type: AdjudicationReason.Undervote,
-              contestId: '1',
-              optionIds: [],
-              expected: 1,
-            },
-          ],
-          enabledReasons: [AdjudicationReason.Undervote],
-        },
-        votes: {},
       },
-    },
-    back: {
-      image: { url: '/back/url' },
-      interpretation: {
-        type: 'InterpretedHmpbPage',
-        markInfo: {
-          ballotSize: { width: 1, height: 1 },
-          marks: [],
+      back: {
+        image: { url: '/back/url' },
+        interpretation: {
+          type: 'InterpretedHmpbPage',
+          markInfo: {
+            ballotSize: { width: 1, height: 1 },
+            marks: [],
+          },
+          metadata: {
+            ballotStyleId: '1',
+            precinctId: '1',
+            ballotType: BallotType.Standard,
+            electionHash: '',
+            isTestMode: false,
+            locales: { primary: 'en-US' },
+            pageNumber: 2,
+          },
+          adjudicationInfo: {
+            requiresAdjudication: false,
+            allReasonInfos: [],
+            enabledReasons: [AdjudicationReason.Overvote],
+          },
+          votes: {},
         },
-        metadata: {
-          ballotStyleId: '1',
-          precinctId: '1',
-          ballotType: BallotType.Standard,
-          electionHash: '',
-          isTestMode: false,
-          locales: { primary: 'en-US' },
-          pageNumber: 2,
-        },
-        adjudicationInfo: {
-          requiresAdjudication: false,
-          allReasonInfos: [],
-          enabledReasons: [AdjudicationReason.Overvote],
-        },
-        votes: {},
       },
-    },
-  }
-  fetchMock.getOnce('/scan/hmpb/review/next-sheet', response)
+    })
+  )
 
   const continueScanning = jest.fn()
 
@@ -213,60 +220,62 @@ test('says the ballot sheet is undervoted if it is', async () => {
 })
 
 test('says the ballot sheet is blank if it is', async () => {
-  const response: BallotSheetInfo = {
-    id: 'mock-sheet-id',
-    front: {
-      image: { url: '/front/url' },
-      interpretation: {
-        type: 'InterpretedHmpbPage',
-        markInfo: {
-          ballotSize: { width: 1, height: 1 },
-          marks: [],
+  fetchMock.getOnce(
+    '/scan/hmpb/review/next-sheet',
+    typedAs<BallotSheetInfo>({
+      id: 'mock-sheet-id',
+      front: {
+        image: { url: '/front/url' },
+        interpretation: {
+          type: 'InterpretedHmpbPage',
+          markInfo: {
+            ballotSize: { width: 1, height: 1 },
+            marks: [],
+          },
+          metadata: {
+            ballotStyleId: '1',
+            precinctId: '1',
+            ballotType: BallotType.Standard,
+            electionHash: '',
+            isTestMode: false,
+            locales: { primary: 'en-US' },
+            pageNumber: 1,
+          },
+          adjudicationInfo: {
+            requiresAdjudication: true,
+            allReasonInfos: [{ type: AdjudicationReason.BlankBallot }],
+            enabledReasons: [AdjudicationReason.Overvote],
+          },
+          votes: {},
         },
-        metadata: {
-          ballotStyleId: '1',
-          precinctId: '1',
-          ballotType: BallotType.Standard,
-          electionHash: '',
-          isTestMode: false,
-          locales: { primary: 'en-US' },
-          pageNumber: 1,
-        },
-        adjudicationInfo: {
-          requiresAdjudication: true,
-          allReasonInfos: [{ type: AdjudicationReason.BlankBallot }],
-          enabledReasons: [AdjudicationReason.Overvote],
-        },
-        votes: {},
       },
-    },
-    back: {
-      image: { url: '/back/url' },
-      interpretation: {
-        type: 'InterpretedHmpbPage',
-        markInfo: {
-          ballotSize: { width: 1, height: 1 },
-          marks: [],
+      back: {
+        image: { url: '/back/url' },
+        interpretation: {
+          type: 'InterpretedHmpbPage',
+          markInfo: {
+            ballotSize: { width: 1, height: 1 },
+            marks: [],
+          },
+          metadata: {
+            ballotStyleId: '1',
+            precinctId: '1',
+            ballotType: BallotType.Standard,
+            electionHash: '',
+            isTestMode: false,
+            locales: { primary: 'en-US' },
+            pageNumber: 2,
+          },
+          adjudicationInfo: {
+            requiresAdjudication: false,
+            allReasonInfos: [],
+            enabledReasons: [AdjudicationReason.Overvote],
+          },
+          votes: {},
         },
-        metadata: {
-          ballotStyleId: '1',
-          precinctId: '1',
-          ballotType: BallotType.Standard,
-          electionHash: '',
-          isTestMode: false,
-          locales: { primary: 'en-US' },
-          pageNumber: 2,
-        },
-        adjudicationInfo: {
-          requiresAdjudication: false,
-          allReasonInfos: [],
-          enabledReasons: [AdjudicationReason.Overvote],
-        },
-        votes: {},
       },
-    },
-  }
-  fetchMock.getOnce('/scan/hmpb/review/next-sheet', response)
+    })
+  )
 
   const continueScanning = jest.fn()
 
@@ -292,40 +301,42 @@ test('says the ballot sheet is blank if it is', async () => {
 })
 
 test('calls out live ballot sheets in test mode', async () => {
-  const response: BallotSheetInfo = {
-    id: 'mock-sheet-id',
-    front: {
-      image: { url: '/front/url' },
-      interpretation: {
-        type: 'InvalidTestModePage',
-        metadata: {
-          ballotStyleId: '1',
-          precinctId: '1',
-          ballotType: BallotType.Standard,
-          electionHash: '',
-          isTestMode: false,
-          locales: { primary: 'en-US' },
-          pageNumber: 1,
+  fetchMock.getOnce(
+    '/scan/hmpb/review/next-sheet',
+    typedAs<BallotSheetInfo>({
+      id: 'mock-sheet-id',
+      front: {
+        image: { url: '/front/url' },
+        interpretation: {
+          type: 'InvalidTestModePage',
+          metadata: {
+            ballotStyleId: '1',
+            precinctId: '1',
+            ballotType: BallotType.Standard,
+            electionHash: '',
+            isTestMode: false,
+            locales: { primary: 'en-US' },
+            pageNumber: 1,
+          },
         },
       },
-    },
-    back: {
-      image: { url: '/back/url' },
-      interpretation: {
-        type: 'InvalidTestModePage',
-        metadata: {
-          ballotStyleId: '1',
-          precinctId: '1',
-          ballotType: BallotType.Standard,
-          electionHash: '',
-          isTestMode: false,
-          locales: { primary: 'en-US' },
-          pageNumber: 2,
+      back: {
+        image: { url: '/back/url' },
+        interpretation: {
+          type: 'InvalidTestModePage',
+          metadata: {
+            ballotStyleId: '1',
+            precinctId: '1',
+            ballotType: BallotType.Standard,
+            electionHash: '',
+            isTestMode: false,
+            locales: { primary: 'en-US' },
+            pageNumber: 2,
+          },
         },
       },
-    },
-  }
-  fetchMock.getOnce('/scan/hmpb/review/next-sheet', response)
+    })
+  )
 
   const continueScanning = jest.fn()
 
@@ -344,40 +355,42 @@ test('calls out live ballot sheets in test mode', async () => {
 })
 
 test('calls out test ballot sheets in live mode', async () => {
-  const response: BallotSheetInfo = {
-    id: 'mock-sheet-id',
-    front: {
-      image: { url: '/front/url' },
-      interpretation: {
-        type: 'InvalidTestModePage',
-        metadata: {
-          ballotStyleId: '1',
-          precinctId: '1',
-          ballotType: BallotType.Standard,
-          electionHash: '',
-          isTestMode: false,
-          locales: { primary: 'en-US' },
-          pageNumber: 1,
+  fetchMock.getOnce(
+    '/scan/hmpb/review/next-sheet',
+    typedAs<BallotSheetInfo>({
+      id: 'mock-sheet-id',
+      front: {
+        image: { url: '/front/url' },
+        interpretation: {
+          type: 'InvalidTestModePage',
+          metadata: {
+            ballotStyleId: '1',
+            precinctId: '1',
+            ballotType: BallotType.Standard,
+            electionHash: '',
+            isTestMode: false,
+            locales: { primary: 'en-US' },
+            pageNumber: 1,
+          },
         },
       },
-    },
-    back: {
-      image: { url: '/back/url' },
-      interpretation: {
-        type: 'InvalidTestModePage',
-        metadata: {
-          ballotStyleId: '1',
-          precinctId: '1',
-          ballotType: BallotType.Standard,
-          electionHash: '',
-          isTestMode: false,
-          locales: { primary: 'en-US' },
-          pageNumber: 2,
+      back: {
+        image: { url: '/back/url' },
+        interpretation: {
+          type: 'InvalidTestModePage',
+          metadata: {
+            ballotStyleId: '1',
+            precinctId: '1',
+            ballotType: BallotType.Standard,
+            electionHash: '',
+            isTestMode: false,
+            locales: { primary: 'en-US' },
+            pageNumber: 2,
+          },
         },
       },
-    },
-  }
-  fetchMock.getOnce('/scan/hmpb/review/next-sheet', response)
+    })
+  )
 
   const continueScanning = jest.fn()
 
@@ -432,40 +445,42 @@ test('shows invalid election screen when appropriate', async () => {
 })
 
 test('shows invalid election screen when appropriate', async () => {
-  const response: BallotSheetInfo = {
-    id: 'mock-sheet-id',
-    front: {
-      image: { url: '/front/url' },
-      interpretation: {
-        type: 'InvalidPrecinctPage',
-        metadata: {
-          ballotStyleId: '1',
-          precinctId: '1',
-          ballotType: BallotType.Standard,
-          electionHash: '',
-          isTestMode: false,
-          locales: { primary: 'en-US' },
-          pageNumber: 1,
+  fetchMock.getOnce(
+    '/scan/hmpb/review/next-sheet',
+    typedAs<BallotSheetInfo>({
+      id: 'mock-sheet-id',
+      front: {
+        image: { url: '/front/url' },
+        interpretation: {
+          type: 'InvalidPrecinctPage',
+          metadata: {
+            ballotStyleId: '1',
+            precinctId: '1',
+            ballotType: BallotType.Standard,
+            electionHash: '',
+            isTestMode: false,
+            locales: { primary: 'en-US' },
+            pageNumber: 1,
+          },
         },
       },
-    },
-    back: {
-      image: { url: '/back/url' },
-      interpretation: {
-        type: 'InvalidPrecinctPage',
-        metadata: {
-          ballotStyleId: '1',
-          precinctId: '1',
-          ballotType: BallotType.Standard,
-          electionHash: '',
-          isTestMode: false,
-          locales: { primary: 'en-US' },
-          pageNumber: 2,
+      back: {
+        image: { url: '/back/url' },
+        interpretation: {
+          type: 'InvalidPrecinctPage',
+          metadata: {
+            ballotStyleId: '1',
+            precinctId: '1',
+            ballotType: BallotType.Standard,
+            electionHash: '',
+            isTestMode: false,
+            locales: { primary: 'en-US' },
+            pageNumber: 2,
+          },
         },
       },
-    },
-  }
-  fetchMock.getOnce('/scan/hmpb/review/next-sheet', response)
+    })
+  )
 
   const continueScanning = jest.fn()
 

--- a/apps/election-manager/src/screens/PrintedBallotsReportScreen.tsx
+++ b/apps/election-manager/src/screens/PrintedBallotsReportScreen.tsx
@@ -41,26 +41,28 @@ const PrintedBallotsReportScreen: React.FC = () => {
     .filter((ballot) => ballot.type === PrintableBallotType.Precinct)
     .reduce((count, ballot) => count + ballot.numCopies, 0)
 
-  const zeroCounts = election.precincts.reduce((counts, { id: precinctId }) => {
-    const newCounts = { ...counts }
-    newCounts[precinctId] = election.ballotStyles
-      .filter((bs) => bs.precincts.includes(precinctId))
-      .reduce((bsCounts, { id: ballotStyleId }) => {
-        const newBsCounts = { ...bsCounts }
-        newBsCounts[ballotStyleId] = 0
-        return newBsCounts
-      }, {} as Dictionary<number>)
-    return newCounts
-  }, {} as PrintCounts)
-
-  const zeroCountsByType = Object.values(PrintableBallotType).reduce(
-    (counts, ballotType) => {
+  const zeroCounts = election.precincts.reduce<PrintCounts>(
+    (counts, { id: precinctId }) => {
       const newCounts = { ...counts }
-      newCounts[ballotType] = _.cloneDeep(zeroCounts)
+      newCounts[precinctId] = election.ballotStyles
+        .filter((bs) => bs.precincts.includes(precinctId))
+        .reduce<Dictionary<number>>((bsCounts, { id: ballotStyleId }) => {
+          const newBsCounts = { ...bsCounts }
+          newBsCounts[ballotStyleId] = 0
+          return newBsCounts
+        }, {})
       return newCounts
     },
-    {} as PrintCountsByType
+    {}
   )
+
+  const zeroCountsByType = Object.values(
+    PrintableBallotType
+  ).reduce<PrintCountsByType>((counts, ballotType) => {
+    const newCounts = { ...counts }
+    newCounts[ballotType] = _.cloneDeep(zeroCounts)
+    return newCounts
+  }, {})
 
   const counts: PrintCounts = printedBallots.reduce(
     (accumulatedCounts, { precinctId, ballotStyleId, numCopies }) => {

--- a/apps/election-manager/src/utils/exportableTallies.test.ts
+++ b/apps/election-manager/src/utils/exportableTallies.test.ts
@@ -2,15 +2,10 @@ import {
   electionMultiPartyPrimaryWithDataFiles,
   electionWithMsEitherNeitherWithDataFiles,
 } from '@votingworks/fixtures'
-import {
-  CandidateContest,
-  Dictionary,
-  Election,
-  YesNoContest,
-} from '@votingworks/types'
+import { CandidateContest, Election, YesNoContest } from '@votingworks/types'
 import {
   CastVoteRecord,
-  ContestOptionTally,
+  ContestTally,
   ExportableTallies,
   VotingMethod,
 } from '../config/types'
@@ -93,12 +88,12 @@ describe('getCombinedExportableContestTally', () => {
       tallies: {},
       metadata: { ballots: 0, undervotes: 0, overvotes: 0 },
     }
-    const emptyContestTally = {
+    const emptyContestTally: ContestTally = {
       contest: yesnocontest,
       tallies: {
         yes: { option: ['yes'], tally: 0 },
         no: { option: ['no'], tally: 0 },
-      } as Dictionary<ContestOptionTally>,
+      },
       metadata: { ballots: 0, undervotes: 0, overvotes: 0 },
     }
     expect(
@@ -111,12 +106,12 @@ describe('getCombinedExportableContestTally', () => {
       metadata: { ballots: 0, undervotes: 0, overvotes: 0 },
     })
 
-    const populatedContestTally = {
+    const populatedContestTally: ContestTally = {
       contest: yesnocontest,
       tallies: {
         yes: { option: ['yes'], tally: 3 },
         no: { option: ['no'], tally: 4 },
-      } as Dictionary<ContestOptionTally>,
+      },
       metadata: { ballots: 18, undervotes: 5, overvotes: 6 },
     }
     const results = getCombinedExportableContestTally(
@@ -146,7 +141,7 @@ describe('getCombinedExportableContestTally', () => {
       tallies: {},
       metadata: { ballots: 0, undervotes: 0, overvotes: 0 },
     }
-    const emptyContestTally = {
+    const emptyContestTally: ContestTally = {
       contest: presidentcontest,
       tallies: {
         775031988: {
@@ -161,7 +156,7 @@ describe('getCombinedExportableContestTally', () => {
           )!,
           tally: 0,
         },
-      } as Dictionary<ContestOptionTally>,
+      },
       metadata: { ballots: 0, undervotes: 0, overvotes: 0 },
     }
 
@@ -175,7 +170,7 @@ describe('getCombinedExportableContestTally', () => {
       metadata: { ballots: 0, undervotes: 0, overvotes: 0 },
     })
 
-    const partialContestTally = {
+    const partialContestTally: ContestTally = {
       contest: presidentcontest,
       tallies: {
         775031988: {
@@ -190,7 +185,7 @@ describe('getCombinedExportableContestTally', () => {
           )!,
           tally: 8,
         },
-      } as Dictionary<ContestOptionTally>,
+      },
       metadata: { ballots: 30, undervotes: 6, overvotes: 4 },
     }
     const partialResult = getCombinedExportableContestTally(
@@ -205,7 +200,7 @@ describe('getCombinedExportableContestTally', () => {
       metadata: { ballots: 30, undervotes: 6, overvotes: 4 },
     })
 
-    const tallyForEveryone = {
+    const tallyForEveryone: ContestTally = {
       contest: presidentcontest,
       tallies: {
         775031988: {
@@ -230,7 +225,7 @@ describe('getCombinedExportableContestTally', () => {
           option: writeInCandidate,
           tally: 10,
         },
-      } as Dictionary<ContestOptionTally>,
+      },
       metadata: { ballots: 40, undervotes: 4, overvotes: 6 },
     }
 

--- a/apps/election-manager/src/utils/externalTallies.test.ts
+++ b/apps/election-manager/src/utils/externalTallies.test.ts
@@ -10,6 +10,7 @@ import {
   YesNoContest,
   expandEitherNeitherContests,
 } from '@votingworks/types'
+import { typedAs } from '@votingworks/utils'
 import { buildCandidateTallies } from '../../test/util/buildCandidateTallies'
 
 import {
@@ -85,59 +86,61 @@ function buildExternalTally(
 
 describe('combineContestTallies', () => {
   it('combine yes no tallies with an empty tally', () => {
-    const tally1 = {
+    const tally1: ContestTally = {
       contest: yesnocontest,
       tallies: {
         yes: { option: ['yes'], tally: 12 },
         no: { option: ['no'], tally: 32 },
-      } as Dictionary<ContestOptionTally>,
+      },
       metadata: { overvotes: 3, undervotes: 2, ballots: 49 },
     }
-    const tally2 = {
+    const tally2: ContestTally = {
       contest: yesnocontest,
       tallies: {
         yes: { option: ['yes'], tally: 0 },
         no: { option: ['no'], tally: 0 },
-      } as Dictionary<ContestOptionTally>,
+      },
       metadata: { overvotes: 0, undervotes: 0, ballots: 0 },
     }
     expect(combineContestTallies(tally1, tally2)).toStrictEqual(tally1)
   })
 
   it('combine yes no tallies properly', () => {
-    const tally1 = {
+    const tally1: ContestTally = {
       contest: yesnocontest,
       tallies: {
         yes: { option: ['yes'], tally: 12 },
         no: { option: ['no'], tally: 32 },
-      } as Dictionary<ContestOptionTally>,
+      },
       metadata: { overvotes: 3, undervotes: 2, ballots: 49 },
     }
-    const tally2 = {
+    const tally2: ContestTally = {
       contest: yesnocontest,
       tallies: {
         yes: { option: ['yes'], tally: 26 },
         no: { option: ['no'], tally: 32 },
-      } as Dictionary<ContestOptionTally>,
+      },
       metadata: { overvotes: 1, undervotes: 4, ballots: 63 },
     }
-    expect(combineContestTallies(tally1, tally2)).toStrictEqual({
-      contest: yesnocontest,
-      tallies: {
-        yes: { option: ['yes'], tally: 38 },
-        no: { option: ['no'], tally: 64 },
-      } as Dictionary<ContestOptionTally>,
-      metadata: { overvotes: 4, undervotes: 6, ballots: 112 },
-    })
+    expect(combineContestTallies(tally1, tally2)).toStrictEqual(
+      typedAs<ContestTally>({
+        contest: yesnocontest,
+        tallies: {
+          yes: { option: ['yes'], tally: 38 },
+          no: { option: ['no'], tally: 64 },
+        },
+        metadata: { overvotes: 4, undervotes: 6, ballots: 112 },
+      })
+    )
   })
 
   it('combines candidate tally with empty tally properly', () => {
-    const tally1 = {
+    const tally1: ContestTally = {
       contest: presidentcontest,
       tallies: buildCandidateTallies(1, presidentcontest),
       metadata: { overvotes: 3, undervotes: 2, ballots: 20 },
     }
-    const tally2 = {
+    const tally2: ContestTally = {
       contest: presidentcontest,
       tallies: buildCandidateTallies(0, presidentcontest),
       metadata: { overvotes: 0, undervotes: 0, ballots: 0 },
@@ -146,33 +149,35 @@ describe('combineContestTallies', () => {
   })
 
   it('combines candidate tally with empty tally properly', () => {
-    const tally1 = {
+    const tally1: ContestTally = {
       contest: presidentcontest,
       tallies: buildCandidateTallies(1, presidentcontest),
       metadata: { overvotes: 3, undervotes: 2, ballots: 20 },
     }
-    const tally2 = {
+    const tally2: ContestTally = {
       contest: presidentcontest,
       tallies: buildCandidateTallies(2, presidentcontest),
       metadata: { overvotes: 1, undervotes: 1, ballots: 32 },
     }
-    expect(combineContestTallies(tally1, tally2)).toStrictEqual({
-      contest: presidentcontest,
-      tallies: buildCandidateTallies(3, presidentcontest),
-      metadata: { overvotes: 4, undervotes: 3, ballots: 52 },
-    })
+    expect(combineContestTallies(tally1, tally2)).toStrictEqual(
+      typedAs<ContestTally>({
+        contest: presidentcontest,
+        tallies: buildCandidateTallies(3, presidentcontest),
+        metadata: { overvotes: 4, undervotes: 3, ballots: 52 },
+      })
+    )
   })
 
   it('throws error with mismatched contests', () => {
-    const tally1 = {
+    const tally1: ContestTally = {
       contest: yesnocontest,
       tallies: {
         yes: { option: ['yes'], tally: 12 },
         no: { option: ['no'], tally: 32 },
-      } as Dictionary<ContestOptionTally>,
+      },
       metadata: { overvotes: 3, undervotes: 2, ballots: 49 },
     }
-    const tally2 = {
+    const tally2: ContestTally = {
       contest: presidentcontest,
       tallies: buildCandidateTallies(2, presidentcontest),
       metadata: { overvotes: 1, undervotes: 1, ballots: 32 },
@@ -183,17 +188,17 @@ describe('combineContestTallies', () => {
 
 describe('getTotalNumberOfBallots', () => {
   it('finds correct number of ballots for an election with 1 contest in all ballot styles', () => {
-    const tally1 = {
+    const tally1: ContestTally = {
       contest: presidentcontest,
       tallies: {},
       metadata: { overvotes: 0, undervotes: 0, ballots: 53 },
     }
-    const tally2 = {
+    const tally2: ContestTally = {
       contest: yesnocontest,
       tallies: {},
       metadata: { overvotes: 0, undervotes: 0, ballots: 37 },
     }
-    const contestTallies = {
+    const contestTallies: Dictionary<ContestTally> = {
       president: tally1,
       'question-a': tally2,
     }
@@ -377,7 +382,7 @@ describe('getPrecinctIdsInExternalTally', () => {
       inputSourceName: 'call-it-what-you-want',
       timestampCreated: new Date(1989, 11, 13),
     }
-    // Precincts with 0 votes explictly specified or just missing in the dictionary are not included
+    // Precincts with 0 votes explicitly specified or just missing in the dictionary are not included
     expect(getPrecinctIdsInExternalTally(fullExternalTally)).toStrictEqual([
       '6522',
       '6527',

--- a/apps/module-scan/src/util/marks.test.ts
+++ b/apps/module-scan/src/util/marks.test.ts
@@ -79,7 +79,7 @@ test('removes contests that revert back to the original', () => {
 })
 
 test('changesFromMarks works with ms-either-neither', () => {
-  const marks = [
+  const marks: BallotMark[] = [
     {
       type: 'ms-either-neither',
       bounds: { x: 50, y: 50, width: 50, height: 50 },
@@ -123,7 +123,8 @@ test('changesFromMarks works with ms-either-neither', () => {
           'FOR APPROVAL OF EITHER Initiative No. 65 OR Alternative Measure No. 65 A',
       },
       score: 0.9,
-    } as BallotMark,
+      scoredOffset: { x: 0, y: 0 },
+    },
   ]
 
   expect(changesFromMarks(marks, { marginal: 0.12, definite: 0.2 })).toEqual({

--- a/apps/precinct-scanner/src/AppUnhappyPaths.test.tsx
+++ b/apps/precinct-scanner/src/AppUnhappyPaths.test.tsx
@@ -14,7 +14,12 @@ import {
 import fetchMock from 'fetch-mock'
 import { DateTime } from 'luxon'
 import React from 'react'
-import { MemoryCard, MemoryStorage, MemoryHardware } from '@votingworks/utils'
+import {
+  MemoryCard,
+  MemoryStorage,
+  MemoryHardware,
+  typedAs,
+} from '@votingworks/utils'
 import { interpretedHmpb } from '../test/fixtures'
 import {
   adminCardForElection,
@@ -166,56 +171,59 @@ test('error from module-scan in accepting a reviewable ballot', async () => {
   })
   fetchMock.getOnce(
     '/scan/status',
-    {
-      status: 'ok',
+    typedAs<GetScanStatusResponse>({
       scanner: ScannerStatus.WaitingForPaper,
       batches: [
         {
           id: 'test-batch',
+          label: 'Batch 1',
           count: 1,
           startedAt: DateTime.now().toISO(),
           endedAt: DateTime.now().toISO(),
         },
       ],
       adjudication: { adjudicated: 0, remaining: 1 },
-    } as GetScanStatusResponse,
+    }),
     { overwriteRoutes: false, repeat: 1 }
   )
   fetchMock.get(
     '/scan/status',
-    {
-      status: 'ok',
+    typedAs<GetScanStatusResponse>({
       scanner: ScannerStatus.ReadyToScan,
       batches: [
         {
           id: 'test-batch',
+          label: 'Batch 1',
           count: 1,
           startedAt: DateTime.now().toISO(),
           endedAt: DateTime.now().toISO(),
         },
       ],
       adjudication: { adjudicated: 0, remaining: 1 },
-    } as GetScanStatusResponse,
+    }),
     { overwriteRoutes: false }
   )
-  fetchMock.get('/scan/hmpb/review/next-sheet', {
-    id: 'test-sheet',
-    front: {
-      interpretation: interpretedHmpb({
-        electionDefinition: electionSampleDefinition,
-        pageNumber: 1,
-        adjudicationReason: AdjudicationReason.Overvote,
-      }),
-      image: { url: '/not/real.jpg' },
-    },
-    back: {
-      interpretation: interpretedHmpb({
-        electionDefinition: electionSampleDefinition,
-        pageNumber: 2,
-      }),
-      image: { url: '/not/real.jpg' },
-    },
-  } as BallotSheetInfo)
+  fetchMock.get(
+    '/scan/hmpb/review/next-sheet',
+    typedAs<BallotSheetInfo>({
+      id: 'test-sheet',
+      front: {
+        interpretation: interpretedHmpb({
+          electionDefinition: electionSampleDefinition,
+          pageNumber: 1,
+          adjudicationReason: AdjudicationReason.Overvote,
+        }),
+        image: { url: '/not/real.jpg' },
+      },
+      back: {
+        interpretation: interpretedHmpb({
+          electionDefinition: electionSampleDefinition,
+          pageNumber: 2,
+        }),
+        image: { url: '/not/real.jpg' },
+      },
+    })
+  )
   await advanceTimersAndPromises(1)
   await screen.findByText('Ballot Requires Review')
   expect(fetchMock.calls('scan/scanBatch')).toHaveLength(1)
@@ -263,12 +271,11 @@ test('error from module-scan in ejecting a reviewable ballot', async () => {
 
   fetchMock.getOnce(
     '/scan/status',
-    {
-      status: 'ok',
+    typedAs<GetScanStatusResponse>({
       scanner: ScannerStatus.ReadyToScan,
       batches: [],
       adjudication: { adjudicated: 0, remaining: 0 },
-    } as GetScanStatusResponse,
+    }),
     { overwriteRoutes: true, repeat: 3 }
   )
   fetchMock.post('/scan/scanBatch', {
@@ -276,56 +283,59 @@ test('error from module-scan in ejecting a reviewable ballot', async () => {
   })
   fetchMock.getOnce(
     '/scan/status',
-    {
-      status: 'ok',
+    typedAs<GetScanStatusResponse>({
       scanner: ScannerStatus.WaitingForPaper,
       batches: [
         {
           id: 'test-batch',
+          label: 'Batch 1',
           count: 1,
           startedAt: DateTime.now().toISO(),
           endedAt: DateTime.now().toISO(),
         },
       ],
       adjudication: { adjudicated: 0, remaining: 1 },
-    } as GetScanStatusResponse,
+    }),
     { overwriteRoutes: false, repeat: 1 }
   )
   fetchMock.get(
     '/scan/status',
-    {
-      status: 'ok',
+    typedAs<GetScanStatusResponse>({
       scanner: ScannerStatus.ReadyToScan,
       batches: [
         {
           id: 'test-batch',
+          label: 'Batch 1',
           count: 1,
           startedAt: DateTime.now().toISO(),
           endedAt: DateTime.now().toISO(),
         },
       ],
       adjudication: { adjudicated: 0, remaining: 1 },
-    } as GetScanStatusResponse,
+    }),
     { overwriteRoutes: false }
   )
-  fetchMock.get('/scan/hmpb/review/next-sheet', {
-    id: 'test-sheet',
-    front: {
-      interpretation: interpretedHmpb({
-        electionDefinition: electionSampleDefinition,
-        pageNumber: 1,
-        adjudicationReason: AdjudicationReason.Overvote,
-      }),
-      image: { url: '/not/real.jpg' },
-    },
-    back: {
-      interpretation: interpretedHmpb({
-        electionDefinition: electionSampleDefinition,
-        pageNumber: 2,
-      }),
-      image: { url: '/not/real.jpg' },
-    },
-  } as BallotSheetInfo)
+  fetchMock.get(
+    '/scan/hmpb/review/next-sheet',
+    typedAs<BallotSheetInfo>({
+      id: 'test-sheet',
+      front: {
+        interpretation: interpretedHmpb({
+          electionDefinition: electionSampleDefinition,
+          pageNumber: 1,
+          adjudicationReason: AdjudicationReason.Overvote,
+        }),
+        image: { url: '/not/real.jpg' },
+      },
+      back: {
+        interpretation: interpretedHmpb({
+          electionDefinition: electionSampleDefinition,
+          pageNumber: 2,
+        }),
+        image: { url: '/not/real.jpg' },
+      },
+    })
+  )
   await advanceTimersAndPromises(1)
   await screen.findByText('Ballot Requires Review')
   expect(fetchMock.calls('scan/scanBatch')).toHaveLength(1)
@@ -334,19 +344,19 @@ test('error from module-scan in ejecting a reviewable ballot', async () => {
   })
   fetchMock.get(
     '/scan/status',
-    {
-      status: 'ok',
+    typedAs<GetScanStatusResponse>({
       scanner: ScannerStatus.WaitingForPaper,
       batches: [
         {
           id: 'test-batch',
+          label: 'Batch 1',
           count: 1,
           startedAt: DateTime.now().toISO(),
           endedAt: DateTime.now().toISO(),
         },
       ],
       adjudication: { adjudicated: 0, remaining: 1 },
-    } as GetScanStatusResponse,
+    }),
     { overwriteRoutes: true }
   )
   await advanceTimersAndPromises(1)

--- a/apps/precinct-scanner/src/config/types.ts
+++ b/apps/precinct-scanner/src/config/types.ts
@@ -47,6 +47,11 @@ export interface MachineConfig {
   codeVersion: string
 }
 
+export interface MachineConfigResponse {
+  machineId: string
+  codeVersion: string
+}
+
 // Scanner Types
 export interface CastVoteRecord
   extends Dictionary<string | string[] | boolean> {

--- a/apps/precinct-scanner/src/utils/machineConfig.test.ts
+++ b/apps/precinct-scanner/src/utils/machineConfig.test.ts
@@ -1,14 +1,19 @@
+import { typedAs } from '@votingworks/utils'
 import fetchMock from 'fetch-mock'
+import { MachineConfig, MachineConfigResponse } from '../config/types'
 import machineConfigProvider from './machineConfig'
 
 test('successful fetch from /machine-config', async () => {
-  fetchMock.get('/machine-config', () =>
-    JSON.stringify({ machineId: '1', codeVersion: '3.14' })
+  fetchMock.get(
+    '/machine-config',
+    typedAs<MachineConfigResponse>({ machineId: '1', codeVersion: '3.14' })
   )
-  expect(await machineConfigProvider.get()).toEqual({
-    machineId: '1',
-    codeVersion: '3.14',
-  })
+  expect(await machineConfigProvider.get()).toEqual(
+    typedAs<MachineConfig>({
+      machineId: '1',
+      codeVersion: '3.14',
+    })
+  )
 })
 
 test('failed fetch from /machine-config', async () => {

--- a/libs/test-utils/src/castVoteRecord.ts
+++ b/libs/test-utils/src/castVoteRecord.ts
@@ -50,7 +50,7 @@ export function generateCVR(
     _ballotType,
     _testBallot,
     _scannerId,
-  } as CastVoteRecord
+  }
 }
 
 export function generateFileContentFromCVRs(cvrs: CastVoteRecord[]): string {

--- a/libs/utils/src/Card.test.ts
+++ b/libs/utils/src/Card.test.ts
@@ -1,23 +1,29 @@
 import { fromByteArray, toByteArray } from 'base64-js'
 import fetchMock, { MockRequest } from 'fetch-mock'
 import { z } from 'zod'
-import { MemoryCard, WebServiceCard } from './Card'
+import { CardPresentAPI, MemoryCard, WebServiceCard } from './Card'
+import { typedAs } from './types'
 
 const ABSchema = z.object({ a: z.number(), b: z.number() })
 
 describe('WebServiceCard', () => {
   it('fetches card status and short value from /card/read', async () => {
-    fetchMock.get('/card/read', {
-      present: true,
-      shortValue: 'abc',
-      longValueExists: true,
-    })
+    fetchMock.get(
+      '/card/read',
+      typedAs<CardPresentAPI>({
+        present: true,
+        shortValue: 'abc',
+        longValueExists: true,
+      })
+    )
 
-    expect(await new WebServiceCard().readStatus()).toEqual({
-      present: true,
-      shortValue: 'abc',
-      longValueExists: true,
-    })
+    expect(await new WebServiceCard().readStatus()).toEqual(
+      typedAs<CardPresentAPI>({
+        present: true,
+        shortValue: 'abc',
+        longValueExists: true,
+      })
+    )
   })
 
   it('reads objects from /card/read_long', async () => {

--- a/libs/utils/src/types.ts
+++ b/libs/utils/src/types.ts
@@ -130,3 +130,27 @@ export const CardTallySchema = z.union([
   BMDCardTallySchema,
   PrecinctScannerCardTallySchema,
 ])
+
+/**
+ * Identity function useful for asserting the type of the argument/return value.
+ * Mainly useful with an object literal argument used in a context where a
+ * variable declaration with an explicit type annotation is inelegant, such as
+ * when providing a response to `fetch-mock`.
+ *
+ * @example
+ *
+ * fetchMock.get('/api', typedAs<MyResponseType>({
+ *   status: 'ok',
+ *   value: 42,
+ * }))
+ *
+ * @example
+ *
+ * expect(value).toEqual(typedAs<MyType>({
+ *   a: 1,
+ *   b: 2,
+ * }))
+ */
+export function typedAs<Type>(value: Type): Type {
+  return value
+}

--- a/libs/utils/src/votes.test.ts
+++ b/libs/utils/src/votes.test.ts
@@ -23,7 +23,7 @@ test('normalizeWriteInId', () => {
 })
 
 test('buildVoteFromCvr', () => {
-  const castVoteRecord = {
+  const castVoteRecord: CastVoteRecord = {
     '750000015': ['yes'],
     '750000016': [],
     '750000017': ['no'],
@@ -41,7 +41,7 @@ test('buildVoteFromCvr', () => {
     _scannerId: 'scanner-6',
     _pageNumber: 1,
     _locales: { primary: 'en-US' },
-  } as CastVoteRecord
+  }
   expect(
     buildVoteFromCvr({
       election: electionWithMsEitherNeither,
@@ -97,7 +97,7 @@ test('buildVoteFromCvr', () => {
   `)
 
   // Handles malformed either/neither data as expected.
-  const castVoteRecord2 = {
+  const castVoteRecord2: CastVoteRecord = {
     '750000015': ['yes'],
     '750000017': ['no'],
     '750000018': ['yes'],
@@ -114,7 +114,7 @@ test('buildVoteFromCvr', () => {
     _scannerId: 'scanner-6',
     _pageNumber: 1,
     _locales: { primary: 'en-US' },
-  } as CastVoteRecord
+  }
   const votes = buildVoteFromCvr({
     election: electionWithMsEitherNeither,
     cvr: castVoteRecord2,


### PR DESCRIPTION
My mental model for `as` is that it tells TypeScript "this value isn't quite like this type, but it's close enough so just let me use it kthxbai". In most of the cases we were using it that's not what we meant. Instead, we meant "I'd like to tell you what type this is so you can help me make sure it's right". But because `as` allows for a certain amount of fuzziness in the type matching, we weren't getting the same benefits as an actual type annotation.

So I went through and replaced `as` in most places with an appropriate replacement. Sometimes they could simply be removed with no reduction in type assistance. In places where we do need something, I am now using a trivial utility function called `typedAs` that simply acts as an inline type annotation on a value.