### PR TITLE
fix(all): reference package, not sub-paths

### DIFF
--- a/apps/module-scan/src/types.ts
+++ b/apps/module-scan/src/types.ts
@@ -7,7 +7,7 @@ import {
   MarkThresholds,
   PageInterpretation,
 } from '@votingworks/types'
-import { BallotStyleData } from '@votingworks/utils/src'
+import { BallotStyleData } from '@votingworks/utils'
 import { MarksByContestId, MarkStatus } from './types/ballot-review'
 
 export type SheetOf<T> = [T, T]

--- a/apps/precinct-scanner/src/components/CalibrateScannerModal.test.tsx
+++ b/apps/precinct-scanner/src/components/CalibrateScannerModal.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { mocked } from 'ts-jest/utils'
 import { ScannerStatus } from '@votingworks/types/api/module-scan'
-import { deferred } from '@votingworks/utils/src'
+import { deferred } from '@votingworks/utils'
 import CalibrateScannerModal from './CalibrateScannerModal'
 import usePrecinctScannerStatus from '../hooks/usePrecinctScannerStatus'
 

--- a/libs/ui/src/hooks/useCancelablePromise.test.tsx
+++ b/libs/ui/src/hooks/useCancelablePromise.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react'
 import { advanceTimersAndPromises } from '@votingworks/test-utils'
-import { sleep } from '@votingworks/utils/src'
+import { sleep } from '@votingworks/utils'
 import React, { useEffect } from 'react'
 import { useCancelablePromise } from './useCancelablePromise'
 

--- a/libs/ui/src/hooks/useUsbDrive.test.tsx
+++ b/libs/ui/src/hooks/useUsbDrive.test.tsx
@@ -6,11 +6,12 @@ import {
   fakeUsbDrive,
 } from '@votingworks/test-utils'
 import { usbstick } from '@votingworks/utils'
-import { UsbDriveStatus } from '@votingworks/utils/src/usbstick'
 import React from 'react'
 import { Button } from '../Button'
 import { USBControllerButton } from '../USBControllerButton'
 import { useUsbDrive, POLLING_INTERVAL_FOR_USB } from './useUsbDrive'
+
+const { UsbDriveStatus } = usbstick
 
 const MOUNTED_DRIVE = fakeUsbDrive()
 const UNMOUNTED_DRIVE = fakeUsbDrive({ mountPoint: undefined })


### PR DESCRIPTION
This happened to work for these because of the way Jest and Webpack/Babel handle imports, but they shouldn't be like this.