### PR TITLE
feat(em) update UI entrypoint to batch results

### DIFF
--- a/apps/election-manager/src/App.test.tsx
+++ b/apps/election-manager/src/App.test.tsx
@@ -276,8 +276,8 @@ test('tabulating CVRs', async () => {
 
   fireEvent.click(getByText('Tally'))
 
-  fireEvent.click(getByText('Batch Counts'))
-  getByText('Ballot Counts by Batch')
+  fireEvent.click(getByText('Show Results by Batch and Scanner'))
+  getByText('Batch Name')
   fireEvent.click(getByText('Export Batch Results as CSV'))
   jest.advanceTimersByTime(2001)
   getByText('Save Batch Results')

--- a/apps/election-manager/src/screens/TallyScreen.tsx
+++ b/apps/election-manager/src/screens/TallyScreen.tsx
@@ -1,8 +1,13 @@
-import React, { useContext, useState, useEffect, useRef } from 'react'
+import React, {
+  useContext,
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+} from 'react'
 import moment from 'moment'
 
 import { generateFinalExportDefaultFilename, format } from '@votingworks/utils'
-import { SegmentedButton } from '@votingworks/ui'
 import {
   TallyCategory,
   InputEventFunction,
@@ -58,6 +63,9 @@ const TallyScreen: React.FC = () => {
   )
 
   const [isShowingBatchResults, setIsShowingBatchResults] = useState(false)
+  const toggleShowingBatchResults = useCallback(() => {
+    setIsShowingBatchResults(!isShowingBatchResults)
+  }, [isShowingBatchResults, setIsShowingBatchResults])
 
   const beginConfirmRemoveFiles = (fileType: ResultsFileType) => {
     setConfirmingRemoveFileType(fileType)
@@ -148,12 +156,7 @@ const TallyScreen: React.FC = () => {
 
   let tallyResultsInfo = <Loading>Tabulating Results…</Loading>
   if (!isTabulationRunning) {
-    const resultTables = isShowingBatchResults ? (
-      <React.Fragment>
-        <h2>Ballot Counts by Batch</h2>
-        <BallotCountsTable breakdownCategory={TallyCategory.Batch} />
-      </React.Fragment>
-    ) : (
+    const resultTables = (
       <React.Fragment>
         <h2>Ballot Counts by Precinct</h2>
         <BallotCountsTable breakdownCategory={TallyCategory.Precinct} />
@@ -166,26 +169,23 @@ const TallyScreen: React.FC = () => {
           </React.Fragment>
         )}
         <h2>Ballot Counts by Scanner</h2>
-        <BallotCountsTable breakdownCategory={TallyCategory.Scanner} />
+        <Button small onPress={toggleShowingBatchResults}>
+          {isShowingBatchResults
+            ? 'Show Results by Scanner'
+            : 'Show Results by Batch and Scanner'}
+        </Button>
+        <br />
+        <br />
+        {isShowingBatchResults ? (
+          <BallotCountsTable breakdownCategory={TallyCategory.Batch} />
+        ) : (
+          <BallotCountsTable breakdownCategory={TallyCategory.Scanner} />
+        )}
       </React.Fragment>
     )
 
     tallyResultsInfo = (
       <React.Fragment>
-        <SegmentedButton>
-          <Button
-            disabled={!isShowingBatchResults}
-            onPress={() => setIsShowingBatchResults(false)}
-          >
-            Ballot Counts
-          </Button>
-          <Button
-            disabled={isShowingBatchResults}
-            onPress={() => setIsShowingBatchResults(true)}
-          >
-            Batch Counts
-          </Button>
-        </SegmentedButton>
         {resultTables}
         <h2>{statusPrefix} Tally Reports</h2>
         <p>


### PR DESCRIPTION
Updates the entrypoint to viewing batch results to the UI @beausmith and I discussed yesterday. 

Happy to make copy changes on the button, I don't feel strongly about it. I did put the CSV export button inside the batch-breakdown table before but I'm a little torn if that is the right place for it to live or if it should be pulled out and go with the "View Full Tally Report" and "Save Results File" buttons that show up regardless of whether we're toggling to batch counts or scanner counts. So curious if you have thoughts on that @beausmith 


https://user-images.githubusercontent.com/14897017/130830328-c38dc428-a82f-4990-8af8-f8ea6ef5ac4d.mov

