### PR TITLE
Force Print Tally Reports from Poll Worker Card

### DIFF
--- a/apps/bmd/src/pages/PollWorkerScreen.test.tsx
+++ b/apps/bmd/src/pages/PollWorkerScreen.test.tsx
@@ -518,23 +518,8 @@ test('printing precinct scanner report option is shown when precinct scanner tal
     />
   )
 
-  screen.getByText('Results Reports')
-  fireEvent.click(screen.getByText('Print Precinct Scanner Tally Report'))
-  await waitFor(() => {
-    screen.getByText(/Do you want to print the precinct scanner results report/)
-  })
-  fireEvent.click(screen.getByText('Close'))
-
-  await waitFor(() => {
-    expect(
-      screen.queryByText(
-        /Do you want to print the precinct scanner results report/
-      )
-    ).toBeNull()
-  })
-
-  fireEvent.click(screen.getByText('Print Precinct Scanner Tally Report'))
-  fireEvent.click(screen.getByText('Print Report'))
+  screen.getByText('Tally Report on Card')
+  fireEvent.click(screen.getByText('Print Tally Report'))
 
   await waitFor(() => {
     expect(clearTallies).toHaveBeenCalledTimes(1)

--- a/apps/bmd/src/pages/PollWorkerScreen.tsx
+++ b/apps/bmd/src/pages/PollWorkerScreen.tsx
@@ -102,6 +102,9 @@ const PollWorkerScreen: React.FC<Props> = ({
       )
     : []
 
+  const isTallyOnCardFromPrecinctScanner =
+    talliesOnCard?.tallyMachineType === TallySourceMachineType.PRECINCT_SCANNER
+
   /*
    * Various state parameters to handle controlling when certain modals on the page are open or not.
    * If you are adding a new modal make sure to add the new parameter to the triggerAudiofocus useEffect
@@ -123,7 +126,7 @@ const PollWorkerScreen: React.FC<Props> = ({
   const [
     isConfirmingPrecinctScannerPrint,
     setIsConfirmingPrecinctScannerPrint,
-  ] = useState(false)
+  ] = useState(isTallyOnCardFromPrecinctScanner)
   const [isPrintingCombinedReport, setIsPrintingCombinedReport] = useState(
     false
   )
@@ -301,9 +304,6 @@ const PollWorkerScreen: React.FC<Props> = ({
     )
   }
 
-  const isTallyOnCardFromPrecinctScanner =
-    talliesOnCard?.tallyMachineType === TallySourceMachineType.PRECINCT_SCANNER
-
   const bmdTalliesOnCard =
     talliesOnCard?.tallyMachineType === TallySourceMachineType.BMD
       ? talliesOnCard
@@ -479,44 +479,30 @@ const PollWorkerScreen: React.FC<Props> = ({
                     : `Open Polls for ${precinctName}`}
                 </Button>
               </p>
-              {isPrintMode && isTallyOnCardFromPrecinctScanner && (
+              {!isPollsOpen && isPrintMode && (
                 <Prose>
-                  <h1> Results Reports </h1>
-                  <Button
-                    onPress={() => setIsConfirmingPrecinctScannerPrint(true)}
-                  >
-                    Print Precinct Scanner Tally Report
-                  </Button>
+                  <h1>Combine Results Reports</h1>
+                  <p>
+                    Combine results from multiple machines in order to print a
+                    single consolidated results report.
+                  </p>
+                  <Table>
+                    <tbody>
+                      <tr>
+                        <th>Machine ID</th>
+                        <th>Saved on Card At</th>
+                      </tr>
+                      {metadataRows}
+                    </tbody>
+                  </Table>
+                  <p>
+                    <Button onPress={() => setIsConfirmingCombinedPrint(true)}>
+                      Print Combined Report for{' '}
+                      {pluralize('Machine', metadataRows.length, true)}
+                    </Button>
+                  </p>
                 </Prose>
               )}
-              {!isPollsOpen &&
-                isPrintMode &&
-                !isTallyOnCardFromPrecinctScanner && (
-                  <Prose>
-                    <h1>Combine Results Reports</h1>
-                    <p>
-                      Combine results from multiple machines in order to print a
-                      single consolidated results report.
-                    </p>
-                    <Table>
-                      <tbody>
-                        <tr>
-                          <th>Machine ID</th>
-                          <th>Saved on Card At</th>
-                        </tr>
-                        {metadataRows}
-                      </tbody>
-                    </Table>
-                    <p>
-                      <Button
-                        onPress={() => setIsConfirmingCombinedPrint(true)}
-                      >
-                        Print Combined Report for{' '}
-                        {pluralize('Machine', metadataRows.length, true)}
-                      </Button>
-                    </p>
-                  </Prose>
-                )}
             </Prose>
           </MainChild>
         </Main>
@@ -640,7 +626,7 @@ const PollWorkerScreen: React.FC<Props> = ({
           <Modal
             content={
               <Prose textCenter id="modalaudiofocus">
-                <Loading>Printing precinct scanner report</Loading>
+                <Loading>Printing tally report</Loading>
               </Prose>
             }
           />
@@ -672,22 +658,18 @@ const PollWorkerScreen: React.FC<Props> = ({
         {isConfirmingPrecinctScannerPrint && (
           <Modal
             content={
-              <Prose>
-                <p id="modalaudiofocus">
-                  Do you want to print the precinct scanner results report and
-                  clear tally data from the card?
+              <Prose id="modalaudiofocus">
+                <h1>Tally Report on Card</h1>
+                <p>
+                  This poll worker card contains a tally report. The report will
+                  be cleared from the card after being printed.
                 </p>
               </Prose>
             }
             actions={
               <React.Fragment>
                 <Button primary onPress={requestPrintPrecinctScannerReport}>
-                  Print Report
-                </Button>
-                <Button
-                  onPress={() => setIsConfirmingPrecinctScannerPrint(false)}
-                >
-                  Close
+                  Print Tally Report
                 </Button>
               </React.Fragment>
             }


### PR DESCRIPTION
When a poll worker card with tally data is inserted into a BMD with printing capabilities, the user will see this screen:
![image](https://user-images.githubusercontent.com/28444/130858287-c636f3cd-2a1f-43c0-be97-1dbf546233f2.png)

After this screen there is a "Printing…" screen, and then back to the Poll Worker screen.

In the context of a poll worker, they are simply printing a tally report. I decided not to refer to this report as a "precinct ballot scanner tally report" in order to keep it simple. (I've also updated the copy around this nameing to be consistent in the `precinct-scanner` as well.)

Resolves #592 