### PR TITLE
ci(all): explicitly type-check when linting

### DIFF
--- a/apps/bas/package.json
+++ b/apps/bas/package.json
@@ -8,12 +8,13 @@
     "prodserver"
   ],
   "scripts": {
+    "type-check": "tsc --build",
     "build": "script/react-scripts build",
     "build:watch": "tsc --build --watch",
     "eject": "script/react-scripts eject",
     "format": "prettier '**/*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
-    "lint": "eslint . --quiet --fix && pnpm stylelint:run",
-    "lint:fix": "eslint . --quiet --fix && pnpm stylelint:run:fix",
+    "lint": "pnpm type-check && eslint . --quiet --fix && pnpm stylelint:run",
+    "lint:fix": "pnpm type-check && eslint . --quiet --fix && pnpm stylelint:run:fix",
     "start": "script/react-scripts start",
     "stylelint:run": "stylelint 'src/**/*.{js,jsx,ts,tsx}' && stylelint 'src/**/*.css' --config .stylelintrc-css.js",
     "stylelint:run:fix": "stylelint 'src/**/*.{js,jsx,ts,tsx}' --fix && stylelint 'src/**/*.css' --config .stylelintrc-css.js --fix",

--- a/apps/bmd/package.json
+++ b/apps/bmd/package.json
@@ -8,13 +8,14 @@
     "prodserver"
   ],
   "scripts": {
+    "type-check": "tsc --build",
     "build": "script/react-scripts build",
     "build:watch": "tsc --build --watch",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run --browser chrome",
     "format": "prettier '**/*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
-    "lint": "eslint . --quiet && pnpm stylelint:run",
-    "lint:fix": "eslint . --fix --quiet && pnpm stylelint:run -- --fix",
+    "lint": "pnpm type-check && eslint . --quiet && pnpm stylelint:run",
+    "lint:fix": "pnpm type-check && eslint . --fix --quiet && pnpm stylelint:run -- --fix",
     "start": "script/react-scripts start",
     "stylelint:run": "stylelint 'src/**/*.{js,jsx,ts,tsx}' && stylelint 'src/**/*.css' --config .stylelintrc-css.js",
     "test": "is-ci test:ci test:watch",

--- a/apps/bsd/package.json
+++ b/apps/bsd/package.json
@@ -8,12 +8,13 @@
     "prodserver"
   ],
   "scripts": {
+    "type-check": "tsc --build",
     "build": "script/react-scripts build",
     "build:watch": "tsc --build --watch",
     "eject": "script/react-scripts eject",
     "format": "prettier '**/*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
-    "lint": "eslint . --quiet && pnpm stylelint:run",
-    "lint:fix": "eslint . --quiet --fix && pnpm stylelint:run:fix",
+    "lint": "pnpm type-check && eslint . --quiet && pnpm stylelint:run",
+    "lint:fix": "pnpm type-check && eslint . --quiet --fix && pnpm stylelint:run:fix",
     "start": "script/react-scripts start",
     "stylelint:run": "stylelint 'src/**/*.{js,jsx,ts,tsx}' && stylelint 'src/**/*.css' --config .stylelintrc-css.js",
     "stylelint:run:fix": "stylelint 'src/**/*.{js,jsx,ts,tsx}' --fix && stylelint 'src/**/*.css' --config .stylelintrc-css.js --fix",

--- a/apps/election-manager/package.json
+++ b/apps/election-manager/package.json
@@ -8,12 +8,13 @@
     "prodserver"
   ],
   "scripts": {
+    "type-check": "tsc --build",
     "build": "script/react-scripts build",
     "build:watch": "tsc --build --watch",
     "eject": "script/react-scripts eject",
     "format": "prettier '**/*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
-    "lint": "eslint . --quiet && pnpm stylelint:run",
-    "lint:fix": "eslint . --fix --quiet && pnpm stylelint:run:fix",
+    "lint": "pnpm type-check && eslint . --quiet && pnpm stylelint:run",
+    "lint:fix": "pnpm type-check && eslint . --fix --quiet && pnpm stylelint:run:fix",
     "start": "script/react-scripts start",
     "stylelint:run": "stylelint 'src/**/*.{js,jsx,ts,tsx}' && stylelint 'src/**/*.css' --config .stylelintrc-css.js",
     "stylelint:run:fix": "stylelint 'src/**/*.{js,jsx,ts,tsx}' --fix && stylelint 'src/**/*.css' --config .stylelintrc-css.js --fix",

--- a/apps/module-scan/package.json
+++ b/apps/module-scan/package.json
@@ -9,12 +9,13 @@
     "schema.sql"
   ],
   "scripts": {
+    "type-check": "tsc --build",
     "build": "tsc --build",
     "build:watch": "tsc --build --watch",
     "dev": "ts-node --transpile-only --files ./src/index.ts",
     "format": "prettier '**/*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
-    "lint": "eslint . --quiet",
-    "lint:fix": "eslint . --quiet --fix",
+    "lint": "pnpm type-check && eslint . --quiet",
+    "lint:fix": "pnpm type-check && eslint . --quiet --fix",
     "start": "node ./build/index.js",
     "test": "is-ci test:coverage test:watch",
     "test:coverage": "jest --coverage",

--- a/apps/precinct-scanner/package.json
+++ b/apps/precinct-scanner/package.json
@@ -8,12 +8,13 @@
     "prodserver"
   ],
   "scripts": {
+    "type-check": "tsc --build",
     "build": "script/react-scripts build",
     "build:watch": "tsc --build --watch",
     "eject": "script/react-scripts eject",
     "format": "prettier '**/*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
-    "lint": "eslint . --quiet && pnpm stylelint:run",
-    "lint:fix": "eslint . --fix --quiet && pnpm stylelint:run:fix",
+    "lint": "pnpm type-check && eslint . --quiet && pnpm stylelint:run",
+    "lint:fix": "pnpm type-check && eslint . --fix --quiet && pnpm stylelint:run:fix",
     "start": "script/react-scripts start",
     "stylelint:run": "stylelint 'src/**/*.{js,jsx,ts,tsx}' && stylelint 'src/**/*.css' --config .stylelintrc-css.js",
     "stylelint:run:fix": "stylelint 'src/**/*.{js,jsx,ts,tsx}' --fix && stylelint 'src/**/*.css' --config .stylelintrc-css.js --fix",

--- a/libs/ballot-encoder/package.json
+++ b/libs/ballot-encoder/package.json
@@ -7,10 +7,11 @@
     "build"
   ],
   "scripts": {
+    "type-check": "tsc --build",
     "build": "tsc --build",
     "build:watch": "tsc --build --watch",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
+    "lint": "pnpm type-check && eslint .",
+    "lint:fix": "pnpm type-check && eslint . --fix",
     "test": "jest",
     "test:ci": "jest --ci --coverage",
     "test:coverage": "jest --coverage",

--- a/libs/eslint-plugin-vx/package.json
+++ b/libs/eslint-plugin-vx/package.json
@@ -11,6 +11,7 @@
     "build"
   ],
   "scripts": {
+    "type-check": "tsc --build",
     "build": "tsc --build tsconfig.build.json",
     "build:watch": "tsc --build --watch tsconfig.build.json",
     "lint": "eslint . --ext ts",

--- a/libs/fixtures/package.json
+++ b/libs/fixtures/package.json
@@ -12,10 +12,11 @@
     "build"
   ],
   "scripts": {
+    "type-check": "tsc --build",
     "build": "tsc --build",
     "build:watch": "tsc --build --watch",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
+    "lint": "pnpm type-check && eslint .",
+    "lint:fix": "pnpm type-check && eslint . --fix",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",

--- a/libs/hmpb-interpreter/package.json
+++ b/libs/hmpb-interpreter/package.json
@@ -17,10 +17,11 @@
     "!build/test"
   ],
   "scripts": {
+    "type-check": "tsc --build",
     "build": "tsc --build",
     "build:watch": "tsc --build --watch",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
+    "lint": "pnpm type-check && eslint .",
+    "lint:fix": "pnpm type-check && eslint . --fix",
     "prepack": "tsc --build",
     "test": "jest",
     "test:all": "REGRESSION_TESTS=1 jest",

--- a/libs/lsd/package.json
+++ b/libs/lsd/package.json
@@ -14,10 +14,11 @@
     "binding.gyp"
   ],
   "scripts": {
+    "type-check": "tsc --build",
     "build": "node-gyp configure build && tsc --build",
     "build:watch": "tsc --build --watch",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
+    "lint": "pnpm type-check && eslint .",
+    "lint:fix": "pnpm type-check && eslint . --fix",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",

--- a/libs/plustek-sdk/package.json
+++ b/libs/plustek-sdk/package.json
@@ -12,13 +12,14 @@
     "build"
   ],
   "scripts": {
+    "type-check": "tsc --build tsconfig.test.json",
     "build": "tsc --build tsconfig.test.json",
     "build:watch": "tsc --build --watch tsconfig.test.json",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
+    "lint": "pnpm type-check && eslint .",
+    "lint:fix": "pnpm type-check && eslint . --fix",
     "pre-commit": "lint-staged"
   },
   "lint-staged": {

--- a/libs/test-utils/package.json
+++ b/libs/test-utils/package.json
@@ -10,10 +10,11 @@
     "build"
   ],
   "scripts": {
+    "type-check": "tsc --build",
     "build": "tsc --build",
     "build:watch": "tsc --build --watch",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
+    "lint": "pnpm type-check && eslint .",
+    "lint:fix": "pnpm type-check && eslint . --fix",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",

--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -12,10 +12,11 @@
     "build"
   ],
   "scripts": {
+    "type-check": "tsc --build",
     "build": "tsc --build",
     "build:watch": "tsc --build --watch",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
+    "lint": "pnpm type-check && eslint .",
+    "lint:fix": "pnpm type-check && eslint . --fix",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -11,10 +11,11 @@
     "build"
   ],
   "scripts": {
+    "type-check": "tsc --build",
     "build": "tsc --build",
     "build:watch": "tsc --build --watch",
-    "lint": "eslint . --quiet && pnpm stylelint:run",
-    "lint:fix": "eslint . --fix --quiet",
+    "lint": "pnpm type-check && eslint . --quiet && pnpm stylelint:run",
+    "lint:fix": "pnpm type-check && eslint . --fix --quiet",
     "stylelint:run": "stylelint 'src/**/*.{js,jsx,ts,tsx}'",
     "test": "TZ=UTC jest",
     "test:coverage": "TZ=UTC jest --coverage",

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -11,10 +11,11 @@
     "build"
   ],
   "scripts": {
+    "type-check": "tsc --build",
     "build": "tsc --build",
     "build:watch": "tsc --build --watch",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
+    "lint": "pnpm type-check && eslint .",
+    "lint:fix": "pnpm type-check && eslint . --fix",
     "test": "TZ=UTC jest",
     "test:watch": "TZ=UTC jest --watch",
     "test:coverage": "TZ=UTC jest --coverage",


### PR DESCRIPTION
We've had a few occasions recently where code that doesn't type-check was merged to `main` because our CI didn't fail. This should make CI fail whenever the code doesn't properly type-check.