### PR TITLE
style(lint): enforce and fix violations of section 8.2

### DIFF
--- a/apps/bas/src/screens/InsertCardScreen.tsx
+++ b/apps/bas/src/screens/InsertCardScreen.tsx
@@ -16,27 +16,25 @@ interface Props {
   lockScreen: () => void
 }
 
-const InsertCardScreen = ({ lockScreen }: Props): JSX.Element => {
-  return (
-    <Screen>
-      <Main>
-        <MainChild center>
-          <Prose textCenter>
-            <InsertCardImage
-              src="/images/insert-card.svg"
-              alt="Insert Card Diagram"
-            />
-            <h1>Insert a Voter Card</h1>
-          </Prose>
-        </MainChild>
-      </Main>
-      <MainNav>
-        <Button small onPress={lockScreen}>
-          Lock
-        </Button>
-      </MainNav>
-    </Screen>
-  )
-}
+const InsertCardScreen = ({ lockScreen }: Props): JSX.Element => (
+  <Screen>
+    <Main>
+      <MainChild center>
+        <Prose textCenter>
+          <InsertCardImage
+            src="/images/insert-card.svg"
+            alt="Insert Card Diagram"
+          />
+          <h1>Insert a Voter Card</h1>
+        </Prose>
+      </MainChild>
+    </Main>
+    <MainNav>
+      <Button small onPress={lockScreen}>
+        Lock
+      </Button>
+    </MainNav>
+  </Screen>
+)
 
 export default InsertCardScreen

--- a/apps/bas/src/screens/LoadElectionScreen.tsx
+++ b/apps/bas/src/screens/LoadElectionScreen.tsx
@@ -5,20 +5,18 @@ import Main, { MainChild } from '../components/Main'
 import MainNav from '../components/MainNav'
 import Screen from '../components/Screen'
 
-const LoadElectionScreen = (): JSX.Element => {
-  return (
-    <Screen>
-      <Main>
-        <MainChild center>
-          <Prose textCenter>
-            <h1>Not Configured</h1>
-            <p>Insert Election Admin card.</p>
-          </Prose>
-        </MainChild>
-      </Main>
-      <MainNav />
-    </Screen>
-  )
-}
+const LoadElectionScreen = (): JSX.Element => (
+  <Screen>
+    <Main>
+      <MainChild center>
+        <Prose textCenter>
+          <h1>Not Configured</h1>
+          <p>Insert Election Admin card.</p>
+        </Prose>
+      </MainChild>
+    </Main>
+    <MainNav />
+  </Screen>
+)
 
 export default LoadElectionScreen

--- a/apps/bas/src/screens/LockedScreen.tsx
+++ b/apps/bas/src/screens/LockedScreen.tsx
@@ -5,20 +5,18 @@ import Main, { MainChild } from '../components/Main'
 import MainNav from '../components/MainNav'
 import Screen from '../components/Screen'
 
-const LockedScreen = (): JSX.Element => {
-  return (
-    <Screen>
-      <Main>
-        <MainChild center>
-          <Prose textCenter>
-            <h1>Screen Locked</h1>
-            <p>Insert Poll Worker card.</p>
-          </Prose>
-        </MainChild>
-      </Main>
-      <MainNav />
-    </Screen>
-  )
-}
+const LockedScreen = (): JSX.Element => (
+  <Screen>
+    <Main>
+      <MainChild center>
+        <Prose textCenter>
+          <h1>Screen Locked</h1>
+          <p>Insert Poll Worker card.</p>
+        </Prose>
+      </MainChild>
+    </Main>
+    <MainNav />
+  </Screen>
+)
 
 export default LockedScreen

--- a/apps/bas/src/screens/NonWritableCardScreen.tsx
+++ b/apps/bas/src/screens/NonWritableCardScreen.tsx
@@ -10,23 +10,21 @@ interface Props {
   lockScreen: () => void
 }
 
-const NonWritableCardScreen = ({ lockScreen }: Props): JSX.Element => {
-  return (
-    <Screen>
-      <Main>
-        <MainChild center>
-          <Prose textCenter>
-            <h1>Non-Writable Card</h1>
-          </Prose>
-        </MainChild>
-      </Main>
-      <MainNav>
-        <Button small onPress={lockScreen}>
-          Lock
-        </Button>
-      </MainNav>
-    </Screen>
-  )
-}
+const NonWritableCardScreen = ({ lockScreen }: Props): JSX.Element => (
+  <Screen>
+    <Main>
+      <MainChild center>
+        <Prose textCenter>
+          <h1>Non-Writable Card</h1>
+        </Prose>
+      </MainChild>
+    </Main>
+    <MainNav>
+      <Button small onPress={lockScreen}>
+        Lock
+      </Button>
+    </MainNav>
+  </Screen>
+)
 
 export default NonWritableCardScreen

--- a/apps/bas/src/screens/PollWorkerScreen.tsx
+++ b/apps/bas/src/screens/PollWorkerScreen.tsx
@@ -10,24 +10,22 @@ interface Props {
   lockScreen: () => void
 }
 
-const PollWorkerScreen = ({ lockScreen }: Props): JSX.Element => {
-  return (
-    <Screen>
-      <Main>
-        <MainChild center>
-          <Prose textCenter>
-            <h1>Screen Unlocked</h1>
-            <p>Remove Poll Worker card to continue.</p>
-          </Prose>
-        </MainChild>
-      </Main>
-      <MainNav>
-        <Button small onPress={lockScreen}>
-          Lock
-        </Button>
-      </MainNav>
-    </Screen>
-  )
-}
+const PollWorkerScreen = ({ lockScreen }: Props): JSX.Element => (
+  <Screen>
+    <Main>
+      <MainChild center>
+        <Prose textCenter>
+          <h1>Screen Unlocked</h1>
+          <p>Remove Poll Worker card to continue.</p>
+        </Prose>
+      </MainChild>
+    </Main>
+    <MainNav>
+      <Button small onPress={lockScreen}>
+        Lock
+      </Button>
+    </MainNav>
+  </Screen>
+)
 
 export default PollWorkerScreen

--- a/apps/bas/src/screens/PrecinctsScreen.tsx
+++ b/apps/bas/src/screens/PrecinctsScreen.tsx
@@ -24,42 +24,40 @@ const PrecinctsScreen = ({
   lockScreen,
   precincts,
   updatePrecinct,
-}: Props): JSX.Element => {
-  return (
-    <Screen>
-      <Main>
-        <MainChild maxWidth={false}>
-          <Heading>
-            <Prose>
-              <h1>
-                Precincts{' '}
-                <Text as="span" light>
-                  for {countyName}
-                </Text>
-              </h1>
-            </Prose>
-          </Heading>
-          <ButtonList columns={2}>
-            {precincts.map((p) => (
-              <Button
-                data-id={p.id}
-                fullWidth
-                key={p.id}
-                onPress={updatePrecinct}
-              >
-                {p.name}
-              </Button>
-            ))}
-          </ButtonList>
-        </MainChild>
-      </Main>
-      <MainNav>
-        <Button small onPress={lockScreen}>
-          Lock
-        </Button>
-      </MainNav>
-    </Screen>
-  )
-}
+}: Props): JSX.Element => (
+  <Screen>
+    <Main>
+      <MainChild maxWidth={false}>
+        <Heading>
+          <Prose>
+            <h1>
+              Precincts{' '}
+              <Text as="span" light>
+                for {countyName}
+              </Text>
+            </h1>
+          </Prose>
+        </Heading>
+        <ButtonList columns={2}>
+          {precincts.map((p) => (
+            <Button
+              data-id={p.id}
+              fullWidth
+              key={p.id}
+              onPress={updatePrecinct}
+            >
+              {p.name}
+            </Button>
+          ))}
+        </ButtonList>
+      </MainChild>
+    </Main>
+    <MainNav>
+      <Button small onPress={lockScreen}>
+        Lock
+      </Button>
+    </MainNav>
+  </Screen>
+)
 
 export default PrecinctsScreen

--- a/apps/bas/src/screens/RemoveCardScreen.tsx
+++ b/apps/bas/src/screens/RemoveCardScreen.tsx
@@ -22,30 +22,28 @@ const RemoveCardScreen = ({
   ballotStyleId,
   lockScreen,
   precinctName,
-}: Props): JSX.Element => {
-  return (
-    <Screen>
-      <Main>
-        <MainChild center>
-          <Prose textCenter>
-            <RemoveCardImage
-              src="/images/remove-card.svg"
-              alt="Remove Card Diagram"
-            />
-            <h1>Hand Card to Voter</h1>
-            <p>
-              {precinctName} / {ballotStyleId}
-            </p>
-          </Prose>
-        </MainChild>
-      </Main>
-      <MainNav>
-        <Button small onPress={lockScreen}>
-          Lock
-        </Button>
-      </MainNav>
-    </Screen>
-  )
-}
+}: Props): JSX.Element => (
+  <Screen>
+    <Main>
+      <MainChild center>
+        <Prose textCenter>
+          <RemoveCardImage
+            src="/images/remove-card.svg"
+            alt="Remove Card Diagram"
+          />
+          <h1>Hand Card to Voter</h1>
+          <p>
+            {precinctName} / {ballotStyleId}
+          </p>
+        </Prose>
+      </MainChild>
+    </Main>
+    <MainNav>
+      <Button small onPress={lockScreen}>
+        Lock
+      </Button>
+    </MainNav>
+  </Screen>
+)
 
 export default RemoveCardScreen

--- a/apps/bmd/src/AppRoot.tsx
+++ b/apps/bmd/src/AppRoot.tsx
@@ -544,9 +544,10 @@ const AppRoot = ({
         })
       : []
 
-  const readCard = useCallback(async (): Promise<CardAPI> => {
-    return await card.readStatus()
-  }, [card])
+  const readCard = useCallback(
+    async (): Promise<CardAPI> => await card.readStatus(),
+    [card]
+  )
 
   const writeCard = useCallback(
     async (cardData: VoterCardData) => {

--- a/apps/bmd/src/components/CandidateContest.tsx
+++ b/apps/bmd/src/components/CandidateContest.tsx
@@ -369,24 +369,22 @@ const CandidateContest = ({
                 {contest.allowWriteIns &&
                   vote
                     .filter((c) => c.isWriteIn)
-                    .map((candidate) => {
-                      return (
-                        <ChoiceButton
-                          key={candidate.id}
-                          isSelected
-                          choice={candidate.id}
-                          onPress={handleUpdateSelection}
-                        >
-                          <Prose>
-                            <p
-                              aria-label={`Selected, write-in: ${candidate.name}.`}
-                            >
-                              <strong>{candidate.name}</strong>
-                            </p>
-                          </Prose>
-                        </ChoiceButton>
-                      )
-                    })}
+                    .map((candidate) => (
+                      <ChoiceButton
+                        key={candidate.id}
+                        isSelected
+                        choice={candidate.id}
+                        onPress={handleUpdateSelection}
+                      >
+                        <Prose>
+                          <p
+                            aria-label={`Selected, write-in: ${candidate.name}.`}
+                          >
+                            <strong>{candidate.name}</strong>
+                          </p>
+                        </Prose>
+                      </ChoiceButton>
+                    ))}
                 {contest.allowWriteIns && (
                   <ChoiceButton
                     choice="write-in"

--- a/apps/bmd/src/components/ChoiceButton.tsx
+++ b/apps/bmd/src/components/ChoiceButton.tsx
@@ -52,15 +52,13 @@ const StyledChoiceButton = styled('button').attrs((props) => ({
   }
 `
 
-const ChoiceButton = ({ choice, ...rest }: Props): JSX.Element => {
-  return (
-    <Button
-      {...rest}
-      component={StyledChoiceButton}
-      data-choice={choice}
-      data-selected={rest.isSelected}
-    />
-  )
-}
+const ChoiceButton = ({ choice, ...rest }: Props): JSX.Element => (
+  <Button
+    {...rest}
+    component={StyledChoiceButton}
+    data-choice={choice}
+    data-selected={rest.isSelected}
+  />
+)
 
 export default ChoiceButton

--- a/apps/bmd/src/components/Seal.tsx
+++ b/apps/bmd/src/components/Seal.tsx
@@ -16,16 +16,14 @@ interface Props {
   sealURL?: string
 }
 
-const Seal = ({ seal, sealURL }: Props): JSX.Element => {
-  return (
-    <SealContainer
-      aria-hidden
-      dangerouslySetInnerHTML={seal ? { __html: seal } : undefined}
-    >
-      {(!seal && sealURL && <SealImage alt="state seal" src={sealURL} />) ||
-        undefined}
-    </SealContainer>
-  )
-}
+const Seal = ({ seal, sealURL }: Props): JSX.Element => (
+  <SealContainer
+    aria-hidden
+    dangerouslySetInnerHTML={seal ? { __html: seal } : undefined}
+  >
+    {(!seal && sealURL && <SealImage alt="state seal" src={sealURL} />) ||
+      undefined}
+  </SealContainer>
+)
 
 export default Seal

--- a/apps/bmd/src/components/Sidebar.tsx
+++ b/apps/bmd/src/components/Sidebar.tsx
@@ -46,30 +46,28 @@ const Sidebar = ({
   children,
   title,
   screenReaderInstructions,
-}: Props): JSX.Element => {
-  return (
-    <StyledSidebar>
-      {title && (
-        <Header>
-          <Prose>
-            <Text as="h1" center id="audiofocus">
-              {appName} {appName && ' / '}
-              <Text as="span" light noWrap>
-                {title}
-              </Text>
-              {screenReaderInstructions && (
-                <span className="screen-reader-only">
-                  {screenReaderInstructions}
-                </span>
-              )}
+}: Props): JSX.Element => (
+  <StyledSidebar>
+    {title && (
+      <Header>
+        <Prose>
+          <Text as="h1" center id="audiofocus">
+            {appName} {appName && ' / '}
+            <Text as="span" light noWrap>
+              {title}
             </Text>
-          </Prose>
-        </Header>
-      )}
-      <Content centerContent={centerContent}>{children}</Content>
-      {footer && <Footer>{footer}</Footer>}
-    </StyledSidebar>
-  )
-}
+            {screenReaderInstructions && (
+              <span className="screen-reader-only">
+                {screenReaderInstructions}
+              </span>
+            )}
+          </Text>
+        </Prose>
+      </Header>
+    )}
+    <Content centerContent={centerContent}>{children}</Content>
+    {footer && <Footer>{footer}</Footer>}
+  </StyledSidebar>
+)
 
 export default Sidebar

--- a/apps/bmd/src/components/VirtualKeyboard.tsx
+++ b/apps/bmd/src/components/VirtualKeyboard.tsx
@@ -110,23 +110,21 @@ const VirtualKeyboard = ({
   keyMap = US_ENGLISH_KEYMAP,
 }: Props): JSX.Element => (
   <Keyboard data-testid="virtual-keyboard">
-    {keyMap.rows.map((row) => {
-      return (
-        <div key={`row-${row.map((key) => key.label).join()}`}>
-          {row.map(({ label, ariaLabel }) => (
-            <Button
-              key={label}
-              data-key={label}
-              aria-label={ariaLabel ?? label.toLowerCase()}
-              onPress={onKeyPress}
-              disabled={keyDisabled?.(label)}
-            >
-              {label}
-            </Button>
-          ))}
-        </div>
-      )
-    })}
+    {keyMap.rows.map((row) => (
+      <div key={`row-${row.map((key) => key.label).join()}`}>
+        {row.map(({ label, ariaLabel }) => (
+          <Button
+            key={label}
+            data-key={label}
+            aria-label={ariaLabel ?? label.toLowerCase()}
+            onPress={onKeyPress}
+            disabled={keyDisabled?.(label)}
+          >
+            {label}
+          </Button>
+        ))}
+      </div>
+    ))}
   </Keyboard>
 )
 

--- a/apps/bmd/src/pages/PrintOnlyScreen.tsx
+++ b/apps/bmd/src/pages/PrintOnlyScreen.tsx
@@ -109,11 +109,12 @@ const PrintOnlyScreen = ({
     }
   }, [isVoterCardPresent, okToPrint, setOkToPrint])
 
-  useEffect(() => {
-    return () => {
+  useEffect(
+    () => () => {
       clearTimeout(printerTimer.current)
-    }
-  }, [])
+    },
+    []
+  )
 
   const renderContent = () => {
     if (isVoterCardPresent && isCardVotesEmpty) {

--- a/apps/bmd/src/pages/TestBallotDeckScreen.tsx
+++ b/apps/bmd/src/pages/TestBallotDeckScreen.tsx
@@ -56,8 +56,8 @@ const generateTestDeckBallots = ({
       )
 
       const numBallots = Math.max(
-        ...contests.map((c) => {
-          return c.type === 'yesno'
+        ...contests.map((c) =>
+          c.type === 'yesno'
             ? 2
             : c.type === 'candidate'
             ? c.candidates.length
@@ -65,7 +65,7 @@ const generateTestDeckBallots = ({
             ? 2
             : /* istanbul ignore next - compile time check for completeness */
               throwIllegalValue(c)
-        })
+        )
       )
 
       for (let ballotNum = 0; ballotNum < numBallots; ballotNum += 1) {

--- a/apps/bmd/src/utils/find.ts
+++ b/apps/bmd/src/utils/find.ts
@@ -3,6 +3,4 @@ import { Parties, Party } from '@votingworks/types'
 export const findPartyById = (
   parties: Parties,
   id: string
-): Party | undefined => {
-  return parties.find((p) => p.id === id)
-}
+): Party | undefined => parties.find((p) => p.id === id)

--- a/apps/bsd/src/components/ElectionConfiguration.tsx
+++ b/apps/bsd/src/components/ElectionConfiguration.tsx
@@ -141,12 +141,10 @@ const ElectionConfiguration = ({
   if (usbDriveStatus === usbstick.UsbDriveStatus.mounted && !loadingFiles) {
     // Parse information from the file names and sort by export date.
     const parsedFileInformation = foundFilenames
-      .map((f) => {
-        return {
-          parsedInfo: parseBallotExportPackageInfoFromFilename(f.name),
-          fileEntry: f,
-        }
-      })
+      .map((f) => ({
+        parsedInfo: parseBallotExportPackageInfoFromFilename(f.name),
+        fileEntry: f,
+      }))
       .filter(
         (
           f

--- a/apps/election-manager/src/AppRoot.tsx
+++ b/apps/election-manager/src/AppRoot.tsx
@@ -123,18 +123,14 @@ const AppRoot = ({ storage, printer }: Props): JSX.Element => {
     PrintedBallot[] | undefined
   >(undefined)
 
-  const getPrintedBallots = async (): Promise<PrintedBallot[]> => {
+  const getPrintedBallots = async (): Promise<PrintedBallot[]> =>
     // TODO: validate this with zod schema
-    return (
-      ((await storage.get(printedBallotsStorageKey)) as
-        | PrintedBallot[]
-        | undefined) || []
-    )
-  }
+    ((await storage.get(printedBallotsStorageKey)) as
+      | PrintedBallot[]
+      | undefined) || []
 
-  const savePrintedBallots = async (printedBallotsToStore: PrintedBallot[]) => {
-    return await storage.set(printedBallotsStorageKey, printedBallotsToStore)
-  }
+  const savePrintedBallots = async (printedBallotsToStore: PrintedBallot[]) =>
+    await storage.set(printedBallotsStorageKey, printedBallotsToStore)
 
   const addPrintedBallot = async (printedBallot: PrintedBallot) => {
     const ballots = await getPrintedBallots()

--- a/apps/election-manager/src/components/BallotCountsTable.tsx
+++ b/apps/election-manager/src/components/BallotCountsTable.tsx
@@ -68,13 +68,10 @@ const BallotCountsTable = ({ breakdownCategory }: Props): JSX.Element => {
                 const precinctBallotsCount =
                   resultsByPrecinct[precinct.id]?.numberOfBallotsCounted ?? 0
                 const externalPrecinctBallotsCount = externalResultsByPrecinct.reduce(
-                  (prev, talliesByPrecinct) => {
-                    return (
-                      prev +
-                      (talliesByPrecinct[precinct.id]?.numberOfBallotsCounted ??
-                        0)
-                    )
-                  },
+                  (prev, talliesByPrecinct) =>
+                    prev +
+                    (talliesByPrecinct[precinct.id]?.numberOfBallotsCounted ??
+                      0),
                   0
                 )
                 return (

--- a/apps/election-manager/src/components/Navigation.tsx
+++ b/apps/election-manager/src/components/Navigation.tsx
@@ -70,19 +70,17 @@ const SecondaryNav = styled.div`
   }
 `
 
-const Navigation = ({ primaryNav, secondaryNav }: Props): JSX.Element => {
-  return (
-    <NavBar>
-      <Brand>
-        <MakeName>
-          Voting<span>Works</span>
-        </MakeName>
-        <ModelName>Election Manager</ModelName>
-      </Brand>
-      <PrimaryNav>{primaryNav}</PrimaryNav>
-      {secondaryNav && <SecondaryNav>{secondaryNav}</SecondaryNav>}
-    </NavBar>
-  )
-}
+const Navigation = ({ primaryNav, secondaryNav }: Props): JSX.Element => (
+  <NavBar>
+    <Brand>
+      <MakeName>
+        Voting<span>Works</span>
+      </MakeName>
+      <ModelName>Election Manager</ModelName>
+    </Brand>
+    <PrimaryNav>{primaryNav}</PrimaryNav>
+    {secondaryNav && <SecondaryNav>{secondaryNav}</SecondaryNav>}
+  </NavBar>
+)
 
 export default Navigation

--- a/apps/election-manager/src/components/TallyReportSummary.tsx
+++ b/apps/election-manager/src/components/TallyReportSummary.tsx
@@ -28,41 +28,39 @@ interface Props {
 const TallyReportSummary = ({
   totalBallotCount,
   ballotCountsByVotingMethod,
-}: Props): JSX.Element => {
-  return (
-    <BallotSummary>
-      <h3>Ballots by Voting Method</h3>
-      <Table data-testid="voting-method-table">
-        <tbody>
-          {Object.keys(ballotCountsByVotingMethod).map((votingMethod) => {
-            // Hide the "Other" row when it does not apply to any CVRs
-            if (
-              votingMethod === VotingMethod.Unknown &&
-              ballotCountsByVotingMethod[votingMethod] === 0
-            ) {
-              return null
-            }
-            return (
-              <tr key={votingMethod} data-testid={votingMethod}>
-                <TD>{getLabelForVotingMethod(votingMethod as VotingMethod)}</TD>
-                <TD textAlign="right">
-                  {format.count(ballotCountsByVotingMethod[votingMethod] ?? 0)}
-                </TD>
-              </tr>
-            )
-          })}
-          <tr data-testid="total">
-            <TD>
-              <strong>Total Ballots Cast</strong>
-            </TD>
-            <TD textAlign="right">
-              <strong>{format.count(totalBallotCount)}</strong>
-            </TD>
-          </tr>
-        </tbody>
-      </Table>
-    </BallotSummary>
-  )
-}
+}: Props): JSX.Element => (
+  <BallotSummary>
+    <h3>Ballots by Voting Method</h3>
+    <Table data-testid="voting-method-table">
+      <tbody>
+        {Object.keys(ballotCountsByVotingMethod).map((votingMethod) => {
+          // Hide the "Other" row when it does not apply to any CVRs
+          if (
+            votingMethod === VotingMethod.Unknown &&
+            ballotCountsByVotingMethod[votingMethod] === 0
+          ) {
+            return null
+          }
+          return (
+            <tr key={votingMethod} data-testid={votingMethod}>
+              <TD>{getLabelForVotingMethod(votingMethod as VotingMethod)}</TD>
+              <TD textAlign="right">
+                {format.count(ballotCountsByVotingMethod[votingMethod] ?? 0)}
+              </TD>
+            </tr>
+          )
+        })}
+        <tr data-testid="total">
+          <TD>
+            <strong>Total Ballots Cast</strong>
+          </TD>
+          <TD textAlign="right">
+            <strong>{format.count(totalBallotCount)}</strong>
+          </TD>
+        </tr>
+      </tbody>
+    </Table>
+  </BallotSummary>
+)
 
 export default TallyReportSummary

--- a/apps/election-manager/src/lib/votecounting.test.ts
+++ b/apps/election-manager/src/lib/votecounting.test.ts
@@ -438,13 +438,11 @@ describe('filterTalliesByParams in a primary election', () => {
       )
       // Filtering by party just filters down the contests in contestTallies
       expect(
-        Object.values(filteredResults.contestTallies).map((c) => {
-          return {
-            contestId: c!.contest.id,
-            tallies: c!.tallies,
-            metadata: c!.metadata,
-          }
-        })
+        Object.values(filteredResults.contestTallies).map((c) => ({
+          contestId: c!.contest.id,
+          tallies: c!.tallies,
+          metadata: c!.metadata,
+        }))
       ).toMatchSnapshot()
     }
 
@@ -565,13 +563,11 @@ describe('filterTalliesByParams in a primary election', () => {
       [VotingMethod.Unknown]: 282,
     })
     expect(
-      Object.values(filterParty5Precinct1.contestTallies).map((c) => {
-        return {
-          contestId: c!.contest.id,
-          tallies: c!.tallies,
-          metadata: c!.metadata,
-        }
-      })
+      Object.values(filterParty5Precinct1.contestTallies).map((c) => ({
+        contestId: c!.contest.id,
+        tallies: c!.tallies,
+        metadata: c!.metadata,
+      }))
     ).toMatchSnapshot()
 
     const filterParty5Precinct5 = filterTalliesByParams(
@@ -589,13 +585,11 @@ describe('filterTalliesByParams in a primary election', () => {
       [VotingMethod.Unknown]: 387,
     })
     expect(
-      Object.values(filterParty5Precinct5.contestTallies).map((c) => {
-        return {
-          contestId: c!.contest.id,
-          tallies: c!.tallies,
-          metadata: c!.metadata,
-        }
-      })
+      Object.values(filterParty5Precinct5.contestTallies).map((c) => ({
+        contestId: c!.contest.id,
+        tallies: c!.tallies,
+        metadata: c!.metadata,
+      }))
     ).toMatchSnapshot()
 
     const filterParty5InvalidPrecinct = filterTalliesByParams(
@@ -650,13 +644,11 @@ describe('filterTalliesByParams in a primary election', () => {
       expectedParty0Info.contestIds
     )
     expect(
-      Object.values(filteredResultsScanner1.contestTallies).map((c) => {
-        return {
-          contestId: c!.contest.id,
-          tallies: c!.tallies,
-          metadata: c!.metadata,
-        }
-      })
+      Object.values(filteredResultsScanner1.contestTallies).map((c) => ({
+        contestId: c!.contest.id,
+        tallies: c!.tallies,
+        metadata: c!.metadata,
+      }))
     ).toMatchSnapshot()
 
     expect(filteredResultsScanner1.numberOfBallotsCounted).toBe(570)

--- a/apps/election-manager/src/utils/externalTallies.ts
+++ b/apps/election-manager/src/utils/externalTallies.ts
@@ -28,13 +28,11 @@ export function convertExternalTalliesToStorageString(
   tallies: FullElectionExternalTally[]
 ): string {
   return JSON.stringify(
-    tallies.map((tally) => {
-      return {
-        ...tally,
-        resultsByCategory: Array.from(tally.resultsByCategory.entries()),
-        timestampCreated: tally.timestampCreated.getTime(),
-      }
-    })
+    tallies.map((tally) => ({
+      ...tally,
+      resultsByCategory: Array.from(tally.resultsByCategory.entries()),
+      timestampCreated: tally.timestampCreated.getTime(),
+    }))
   )
 }
 
@@ -99,14 +97,15 @@ export function getTotalNumberOfBallots(
 ): number {
   // Get Separate Ballot Style Sets
   // Get Contest IDs by Ballot Style
-  let contestIdSets = election.ballotStyles.map((bs) => {
-    return new Set(
-      getContests({
-        ballotStyle: bs,
-        election,
-      }).map((c) => c.id)
-    )
-  })
+  let contestIdSets = election.ballotStyles.map(
+    (bs) =>
+      new Set(
+        getContests({
+          ballotStyle: bs,
+          election,
+        }).map((c) => c.id)
+      )
+  )
 
   // Break the sets of contest IDs into disjoint sets, so contests that are never seen on the same ballot style.
   for (const contest of election.contests) {

--- a/apps/election-manager/src/utils/findPartyById.ts
+++ b/apps/election-manager/src/utils/findPartyById.ts
@@ -1,7 +1,6 @@
 import { Parties, Party } from '@votingworks/types'
 
-const findPartyById = (parties: Parties, id: string): Party | undefined => {
-  return parties.find((p) => p.id === id)
-}
+const findPartyById = (parties: Parties, id: string): Party | undefined =>
+  parties.find((p) => p.id === id)
 
 export default findPartyById

--- a/apps/module-scan/src/importer.test.ts
+++ b/apps/module-scan/src/importer.test.ts
@@ -325,19 +325,17 @@ test('scanning pauses on adjudication then continues', async () => {
     scanSheets: jest.fn(),
     calibrate: jest.fn(),
   }
-  const mockGetNextAdjudicationSheet = async (): Promise<BallotSheetInfo> => {
-    return {
-      id: 'mock-sheet-id',
-      front: {
-        image: { url: '/url/front' },
-        interpretation: { type: 'BlankPage' },
-      },
-      back: {
-        image: { url: '/url/back' },
-        interpretation: { type: 'BlankPage' },
-      },
-    }
-  }
+  const mockGetNextAdjudicationSheet = async (): Promise<BallotSheetInfo> => ({
+    id: 'mock-sheet-id',
+    front: {
+      image: { url: '/url/front' },
+      interpretation: { type: 'BlankPage' },
+    },
+    back: {
+      image: { url: '/url/back' },
+      interpretation: { type: 'BlankPage' },
+    },
+  })
 
   const importer = new Importer({
     workspace,
@@ -351,23 +349,17 @@ test('scanning pauses on adjudication then continues', async () => {
 
   jest
     .spyOn(workspace.store, 'addSheet')
-    .mockImplementationOnce(async () => {
-      return 'sheet-1'
-    })
+    .mockImplementationOnce(async () => 'sheet-1')
     .mockImplementationOnce(async () => {
       jest
         .spyOn(workspace.store, 'adjudicationStatus')
-        .mockImplementation(async () => {
-          return { adjudicated: 0, remaining: 1 }
-        })
+        .mockImplementation(async () => ({ adjudicated: 0, remaining: 1 }))
       return 'sheet-2'
     })
     .mockImplementationOnce(async () => {
       jest
         .spyOn(workspace.store, 'adjudicationStatus')
-        .mockImplementation(async () => {
-          return { adjudicated: 0, remaining: 1 }
-        })
+        .mockImplementation(async () => ({ adjudicated: 0, remaining: 1 }))
       return 'sheet-3'
     })
 
@@ -409,9 +401,7 @@ test('scanning pauses on adjudication then continues', async () => {
 
   jest
     .spyOn(workspace.store, 'adjudicationStatus')
-    .mockImplementation(async () => {
-      return { adjudicated: 0, remaining: 0 }
-    })
+    .mockImplementation(async () => ({ adjudicated: 0, remaining: 0 }))
 
   await importer.continueImport()
   await importer.waitForEndOfBatchOrScanningPause()
@@ -425,9 +415,7 @@ test('scanning pauses on adjudication then continues', async () => {
 
   jest
     .spyOn(workspace.store, 'adjudicationStatus')
-    .mockImplementation(async () => {
-      return { adjudicated: 0, remaining: 0 }
-    })
+    .mockImplementation(async () => ({ adjudicated: 0, remaining: 0 }))
 
   await importer.continueImport(true) // override
   await importer.waitForEndOfBatchOrScanningPause()

--- a/apps/module-scan/src/scanners/fujitsu.ts
+++ b/apps/module-scan/src/scanners/fujitsu.ts
@@ -139,17 +139,11 @@ export class FujitsuScanner implements Scanner {
         return results.get()
       },
 
-      acceptSheet: async (): Promise<boolean> => {
-        return true
-      },
+      acceptSheet: async (): Promise<boolean> => true,
 
-      reviewSheet: async (): Promise<boolean> => {
-        return false
-      },
+      reviewSheet: async (): Promise<boolean> => false,
 
-      rejectSheet: async (): Promise<boolean> => {
-        return false
-      },
+      rejectSheet: async (): Promise<boolean> => false,
 
       endBatch: async (): Promise<void> => {
         if (!done) {

--- a/apps/module-scan/src/scanners/plustek.ts
+++ b/apps/module-scan/src/scanners/plustek.ts
@@ -396,9 +396,7 @@ export function withReconnect(
       }
     },
 
-    close: async () => {
-      return (await (await clientPromise)?.close()) ?? ok()
-    },
+    close: async () => (await (await clientPromise)?.close()) ?? ok(),
 
     getPaperStatus: async () => {
       debug('withReconnect: getPaperStatus')
@@ -418,9 +416,7 @@ export function withReconnect(
       }
     },
 
-    isConnected: () => {
-      return client?.isConnected() ?? false
-    },
+    isConnected: () => client?.isConnected() ?? false,
 
     reject: async ({ hold }) => {
       for (;;) {

--- a/apps/module-scan/src/server.test.ts
+++ b/apps/module-scan/src/server.test.ts
@@ -570,19 +570,17 @@ test('start as precinct-scanner rejects a held sheet at startup', async () => {
 test('get next sheet', async () => {
   jest
     .spyOn(workspace.store, 'getNextAdjudicationSheet')
-    .mockImplementationOnce(async () => {
-      return {
-        id: 'mock-review-sheet',
-        front: {
-          image: { url: '/url/front' },
-          interpretation: { type: 'BlankPage' },
-        },
-        back: {
-          image: { url: '/url/back' },
-          interpretation: { type: 'BlankPage' },
-        },
-      }
-    })
+    .mockImplementationOnce(async () => ({
+      id: 'mock-review-sheet',
+      front: {
+        image: { url: '/url/front' },
+        interpretation: { type: 'BlankPage' },
+      },
+      back: {
+        image: { url: '/url/back' },
+        interpretation: { type: 'BlankPage' },
+      },
+    }))
 
   await request(app)
     .get(`/scan/hmpb/review/next-sheet`)

--- a/apps/precinct-scanner/src/AppRoot.tsx
+++ b/apps/precinct-scanner/src/AppRoot.tsx
@@ -377,12 +377,14 @@ const AppRoot = ({
     })
   }, [dispatchAppState])
 
-  const dismissCurrentBallotMessage = useCallback((): number => {
-    return window.setTimeout(
-      () => dispatchAppState({ type: 'readyToInsertBallot' }),
-      TIME_TO_DISMISS_ERROR_SUCCESS_SCREENS_MS
-    )
-  }, [dispatchAppState])
+  const dismissCurrentBallotMessage = useCallback(
+    (): number =>
+      window.setTimeout(
+        () => dispatchAppState({ type: 'readyToInsertBallot' }),
+        TIME_TO_DISMISS_ERROR_SUCCESS_SCREENS_MS
+      ),
+    [dispatchAppState]
+  )
 
   // Handle Machine Config
   useEffect(() => {

--- a/apps/precinct-scanner/src/PreviewApp.tsx
+++ b/apps/precinct-scanner/src/PreviewApp.tsx
@@ -20,30 +20,28 @@ import * as ScanWarningScreen from './screens/ScanWarningScreen'
 import * as SetupCardReaderPage from './screens/SetupCardReaderPage'
 import * as UnconfiguredElectionScreen from './screens/UnconfiguredElectionScreen'
 
-const PreviewApp = (): JSX.Element => {
-  return (
-    <PreviewDashboard
-      electionDefinitions={[
-        electionSampleDefinition,
-        primaryElectionSampleDefinition,
-        electionWithMsEitherNeitherDefinition,
-      ]}
-      modules={[
-        AdminScreen,
-        InsertBallotScreen,
-        InvalidCardScreen,
-        LoadingConfigurationScreen,
-        PollsClosedScreen,
-        PollWorkerScreen,
-        ScanErrorScreen,
-        ScanProcessingScreen,
-        ScanSuccessScreen,
-        ScanWarningScreen,
-        SetupCardReaderPage,
-        UnconfiguredElectionScreen,
-      ]}
-    />
-  )
-}
+const PreviewApp = (): JSX.Element => (
+  <PreviewDashboard
+    electionDefinitions={[
+      electionSampleDefinition,
+      primaryElectionSampleDefinition,
+      electionWithMsEitherNeitherDefinition,
+    ]}
+    modules={[
+      AdminScreen,
+      InsertBallotScreen,
+      InvalidCardScreen,
+      LoadingConfigurationScreen,
+      PollsClosedScreen,
+      PollWorkerScreen,
+      ScanErrorScreen,
+      ScanProcessingScreen,
+      ScanSuccessScreen,
+      ScanWarningScreen,
+      SetupCardReaderPage,
+      UnconfiguredElectionScreen,
+    ]}
+  />
+)
 
 export default PreviewApp

--- a/apps/precinct-scanner/src/PreviewDashboard.tsx
+++ b/apps/precinct-scanner/src/PreviewDashboard.tsx
@@ -122,22 +122,20 @@ const PreviewDashboard = ({
         <Route path="/preview" exact>
           <h1>Previews</h1>
           <div style={{ columns: '3' }}>
-            {previewables.map(({ componentName, previews }) => {
-              return (
-                <div key={componentName} style={{ breakInside: 'avoid' }}>
-                  <h4 style={{ marginBottom: '2px' }}>{componentName}</h4>
-                  <ul style={{ marginTop: '0' }}>
-                    {previews.map((preview) => (
-                      <li key={preview.previewName}>
-                        <Link to={getPreviewURL(preview)}>
-                          {preview.previewName}
-                        </Link>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )
-            })}
+            {previewables.map(({ componentName, previews }) => (
+              <div key={componentName} style={{ breakInside: 'avoid' }}>
+                <h4 style={{ marginBottom: '2px' }}>{componentName}</h4>
+                <ul style={{ marginTop: '0' }}>
+                  {previews.map((preview) => (
+                    <li key={preview.previewName}>
+                      <Link to={getPreviewURL(preview)}>
+                        {preview.previewName}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
           </div>
           <ConfigBox>
             <Select

--- a/apps/precinct-scanner/src/hooks/usePrecinctScanner.test.tsx
+++ b/apps/precinct-scanner/src/hooks/usePrecinctScanner.test.tsx
@@ -23,13 +23,11 @@ const scanStatusReadyToScanResponse: GetScanStatusResponse = {
 
 const TestComponent: React.FC<{ interval?: number | false }> = ({
   interval = 1,
-} = {}) => {
-  return (
-    <React.Fragment>
-      {usePrecinctScanner(interval)?.status.scannerState ?? 'none'}
-    </React.Fragment>
-  )
-}
+} = {}) => (
+  <React.Fragment>
+    {usePrecinctScanner(interval)?.status.scannerState ?? 'none'}
+  </React.Fragment>
+)
 
 beforeEach(() => {
   jest.useFakeTimers()

--- a/apps/precinct-scanner/src/screens/InsertBallotScreen.tsx
+++ b/apps/precinct-scanner/src/screens/InsertBallotScreen.tsx
@@ -9,35 +9,33 @@ interface Props {
   scannedBallotCount: number
 }
 
-const InsertBallotScreen = ({ scannedBallotCount }: Props): JSX.Element => {
-  return (
-    <CenteredScreen>
-      <InsertBallot />
-      <CenteredLargeProse>
-        <h1>Insert Your Ballot Below</h1>
-        <p>Scan one ballot sheet at a time.</p>
-      </CenteredLargeProse>
-      <Absolute top left>
-        <Bar>
-          <div>
-            Ballots Scanned:{' '}
-            <strong data-testid="ballot-count">
-              {format.count(scannedBallotCount)}
-            </strong>
-          </div>
-        </Bar>
-      </Absolute>
-    </CenteredScreen>
-  )
-}
+const InsertBallotScreen = ({ scannedBallotCount }: Props): JSX.Element => (
+  <CenteredScreen>
+    <InsertBallot />
+    <CenteredLargeProse>
+      <h1>Insert Your Ballot Below</h1>
+      <p>Scan one ballot sheet at a time.</p>
+    </CenteredLargeProse>
+    <Absolute top left>
+      <Bar>
+        <div>
+          Ballots Scanned:{' '}
+          <strong data-testid="ballot-count">
+            {format.count(scannedBallotCount)}
+          </strong>
+        </div>
+      </Bar>
+    </Absolute>
+  </CenteredScreen>
+)
 export default InsertBallotScreen
 
 /* istanbul ignore next */
-export const ZeroBallotsScannedPreview = (): JSX.Element => {
-  return <InsertBallotScreen scannedBallotCount={0} />
-}
+export const ZeroBallotsScannedPreview = (): JSX.Element => (
+  <InsertBallotScreen scannedBallotCount={0} />
+)
 
 /* istanbul ignore next */
-export const ManyBallotsScannedPreview = (): JSX.Element => {
-  return <InsertBallotScreen scannedBallotCount={1234} />
-}
+export const ManyBallotsScannedPreview = (): JSX.Element => (
+  <InsertBallotScreen scannedBallotCount={1234} />
+)

--- a/apps/precinct-scanner/src/screens/InvalidCardScreen.tsx
+++ b/apps/precinct-scanner/src/screens/InvalidCardScreen.tsx
@@ -15,6 +15,4 @@ const InvalidCardScreen = (): JSX.Element => (
 export default InvalidCardScreen
 
 /* istanbul ignore next */
-export const DefaultPreview = (): JSX.Element => {
-  return <InvalidCardScreen />
-}
+export const DefaultPreview = (): JSX.Element => <InvalidCardScreen />

--- a/apps/precinct-scanner/src/screens/LoadingConfigurationScreen.tsx
+++ b/apps/precinct-scanner/src/screens/LoadingConfigurationScreen.tsx
@@ -14,6 +14,4 @@ const LoadingConfigurationScreen = (): JSX.Element => (
 export default LoadingConfigurationScreen
 
 /* istanbul ignore next */
-export const DefaultPreview = (): JSX.Element => {
-  return <LoadingConfigurationScreen />
-}
+export const DefaultPreview = (): JSX.Element => <LoadingConfigurationScreen />

--- a/apps/precinct-scanner/src/screens/PollsClosedScreen.tsx
+++ b/apps/precinct-scanner/src/screens/PollsClosedScreen.tsx
@@ -2,21 +2,17 @@ import React from 'react'
 import { DoNotEnter } from '../components/Graphics'
 import { CenteredLargeProse, CenteredScreen } from '../components/Layout'
 
-const PollsClosedScreen = (): JSX.Element => {
-  return (
-    <CenteredScreen>
-      <DoNotEnter />
-      <CenteredLargeProse>
-        <h1>Polls Closed</h1>
-        <p>Insert a Poll Worker Card to Open Polls.</p>
-      </CenteredLargeProse>
-    </CenteredScreen>
-  )
-}
+const PollsClosedScreen = (): JSX.Element => (
+  <CenteredScreen>
+    <DoNotEnter />
+    <CenteredLargeProse>
+      <h1>Polls Closed</h1>
+      <p>Insert a Poll Worker Card to Open Polls.</p>
+    </CenteredLargeProse>
+  </CenteredScreen>
+)
 
 export default PollsClosedScreen
 
 /* istanbul ignore next */
-export const DefaultPreview = (): JSX.Element => {
-  return <PollsClosedScreen />
-}
+export const DefaultPreview = (): JSX.Element => <PollsClosedScreen />

--- a/apps/precinct-scanner/src/screens/ScanErrorScreen.tsx
+++ b/apps/precinct-scanner/src/screens/ScanErrorScreen.tsx
@@ -65,61 +65,49 @@ const ScanErrorScreen = ({
 export default ScanErrorScreen
 
 /* istanbul ignore next */
-export const UnreadablePreview = (): JSX.Element => {
-  return (
-    <ScanErrorScreen
-      isTestMode={false}
-      rejectionReason={RejectedScanningReason.Unreadable}
-    />
-  )
-}
+export const UnreadablePreview = (): JSX.Element => (
+  <ScanErrorScreen
+    isTestMode={false}
+    rejectionReason={RejectedScanningReason.Unreadable}
+  />
+)
 
 /* istanbul ignore next */
-export const InvalidElectionHashPreview = (): JSX.Element => {
-  return (
-    <ScanErrorScreen
-      isTestMode={false}
-      rejectionReason={RejectedScanningReason.InvalidElectionHash}
-    />
-  )
-}
+export const InvalidElectionHashPreview = (): JSX.Element => (
+  <ScanErrorScreen
+    isTestMode={false}
+    rejectionReason={RejectedScanningReason.InvalidElectionHash}
+  />
+)
 
 /* istanbul ignore next */
-export const InvalidTestModeBallotPreview = (): JSX.Element => {
-  return (
-    <ScanErrorScreen
-      isTestMode={false}
-      rejectionReason={RejectedScanningReason.InvalidTestMode}
-    />
-  )
-}
+export const InvalidTestModeBallotPreview = (): JSX.Element => (
+  <ScanErrorScreen
+    isTestMode={false}
+    rejectionReason={RejectedScanningReason.InvalidTestMode}
+  />
+)
 
 /* istanbul ignore next */
-export const InvalidLiveModeBallotPreview = (): JSX.Element => {
-  return (
-    <ScanErrorScreen
-      isTestMode
-      rejectionReason={RejectedScanningReason.InvalidTestMode}
-    />
-  )
-}
+export const InvalidLiveModeBallotPreview = (): JSX.Element => (
+  <ScanErrorScreen
+    isTestMode
+    rejectionReason={RejectedScanningReason.InvalidTestMode}
+  />
+)
 
 /* istanbul ignore next */
-export const InvalidPrecinctPreview = (): JSX.Element => {
-  return (
-    <ScanErrorScreen
-      isTestMode={false}
-      rejectionReason={RejectedScanningReason.InvalidPrecinct}
-    />
-  )
-}
+export const InvalidPrecinctPreview = (): JSX.Element => (
+  <ScanErrorScreen
+    isTestMode={false}
+    rejectionReason={RejectedScanningReason.InvalidPrecinct}
+  />
+)
 
 /* istanbul ignore next */
-export const UnknownErrorPreview = (): JSX.Element => {
-  return (
-    <ScanErrorScreen
-      isTestMode={false}
-      rejectionReason={RejectedScanningReason.Unknown}
-    />
-  )
-}
+export const UnknownErrorPreview = (): JSX.Element => (
+  <ScanErrorScreen
+    isTestMode={false}
+    rejectionReason={RejectedScanningReason.Unknown}
+  />
+)

--- a/apps/precinct-scanner/src/screens/ScanProcessingScreen.tsx
+++ b/apps/precinct-scanner/src/screens/ScanProcessingScreen.tsx
@@ -14,6 +14,4 @@ const ScanProcessingScreen = (): JSX.Element => (
 export default ScanProcessingScreen
 
 /* istanbul ignore next */
-export const DefaultPreview = (): JSX.Element => {
-  return <ScanProcessingScreen />
-}
+export const DefaultPreview = (): JSX.Element => <ScanProcessingScreen />

--- a/apps/precinct-scanner/src/screens/ScanSuccessScreen.tsx
+++ b/apps/precinct-scanner/src/screens/ScanSuccessScreen.tsx
@@ -10,33 +10,31 @@ interface Props {
   scannedBallotCount: number
 }
 
-const ScanSuccessScreen = ({ scannedBallotCount }: Props): JSX.Element => {
-  return (
-    <CenteredScreen>
-      <CircleCheck />
-      <CenteredLargeProse>
-        <h1>Your ballot was counted!</h1>
-        <p>Thank you for voting.</p>
-      </CenteredLargeProse>
-      <Absolute top left>
-        <Bar>
-          <Prose>
-            <p>
-              Ballots Scanned:{' '}
-              <strong data-testid="ballot-count">
-                {format.count(scannedBallotCount)}
-              </strong>
-            </p>
-          </Prose>
-        </Bar>
-      </Absolute>
-    </CenteredScreen>
-  )
-}
+const ScanSuccessScreen = ({ scannedBallotCount }: Props): JSX.Element => (
+  <CenteredScreen>
+    <CircleCheck />
+    <CenteredLargeProse>
+      <h1>Your ballot was counted!</h1>
+      <p>Thank you for voting.</p>
+    </CenteredLargeProse>
+    <Absolute top left>
+      <Bar>
+        <Prose>
+          <p>
+            Ballots Scanned:{' '}
+            <strong data-testid="ballot-count">
+              {format.count(scannedBallotCount)}
+            </strong>
+          </p>
+        </Prose>
+      </Bar>
+    </Absolute>
+  </CenteredScreen>
+)
 
 export default ScanSuccessScreen
 
 /* istanbul ignore next */
-export const DefaultPreview = (): JSX.Element => {
-  return <ScanSuccessScreen scannedBallotCount={1} />
-}
+export const DefaultPreview = (): JSX.Element => (
+  <ScanSuccessScreen scannedBallotCount={1} />
+)

--- a/apps/precinct-scanner/src/screens/ScanWarningScreen.tsx
+++ b/apps/precinct-scanner/src/screens/ScanWarningScreen.tsx
@@ -510,23 +510,19 @@ export const MultipleUndervotesPreview = (): JSX.Element => {
 }
 
 /* istanbul ignore next */
-export const BlankBallotPreview = (): JSX.Element => {
-  return (
-    <ScanWarningScreen
-      acceptBallot={() => Promise.resolve()}
-      adjudicationReasonInfo={[{ type: AdjudicationReason.BlankBallot }]}
-    />
-  )
-}
+export const BlankBallotPreview = (): JSX.Element => (
+  <ScanWarningScreen
+    acceptBallot={() => Promise.resolve()}
+    adjudicationReasonInfo={[{ type: AdjudicationReason.BlankBallot }]}
+  />
+)
 
 /* istanbul ignore next */
-export const UninterpretableBallotPreview = (): JSX.Element => {
-  return (
-    <ScanWarningScreen
-      acceptBallot={() => Promise.resolve()}
-      adjudicationReasonInfo={[
-        { type: AdjudicationReason.UninterpretableBallot },
-      ]}
-    />
-  )
-}
+export const UninterpretableBallotPreview = (): JSX.Element => (
+  <ScanWarningScreen
+    acceptBallot={() => Promise.resolve()}
+    adjudicationReasonInfo={[
+      { type: AdjudicationReason.UninterpretableBallot },
+    ]}
+  />
+)

--- a/apps/precinct-scanner/src/screens/SetupCardReaderPage.tsx
+++ b/apps/precinct-scanner/src/screens/SetupCardReaderPage.tsx
@@ -13,6 +13,4 @@ const SetupCardReaderPage = (): JSX.Element => (
 export default SetupCardReaderPage
 
 /* istanbul ignore next */
-export const DefaultPreview = (): JSX.Element => {
-  return <SetupCardReaderPage />
-}
+export const DefaultPreview = (): JSX.Element => <SetupCardReaderPage />

--- a/apps/precinct-scanner/src/screens/UnconfiguredElectionScreen.tsx
+++ b/apps/precinct-scanner/src/screens/UnconfiguredElectionScreen.tsx
@@ -192,11 +192,9 @@ const UnconfiguredElectionScreen = ({
 export default UnconfiguredElectionScreen
 
 /* istanbul ignore next */
-export const DefaultPreview = (): JSX.Element => {
-  return (
-    <UnconfiguredElectionScreen
-      usbDriveStatus={usbstick.UsbDriveStatus.notavailable}
-      setElectionDefinition={() => Promise.resolve()}
-    />
-  )
-}
+export const DefaultPreview = (): JSX.Element => (
+  <UnconfiguredElectionScreen
+    usbDriveStatus={usbstick.UsbDriveStatus.notavailable}
+    setElectionDefinition={() => Promise.resolve()}
+  />
+)

--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -44,6 +44,7 @@ export = {
     '@typescript-eslint/no-floating-promises': 'error',
     '@typescript-eslint/no-non-null-assertion': 'error',
     '@typescript-eslint/no-unnecessary-type-assertion': 'error',
+    'arrow-body-style': 'error',
     'class-methods-use-this': 'off',
     'consistent-return': 'off',
     'import/extensions': 'off',

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -1092,16 +1092,15 @@ export const getContests = ({
  */
 export const getEitherNeitherContests = (
   contests: Contests
-): MsEitherNeitherContest[] => {
-  return contests.filter(
+): MsEitherNeitherContest[] =>
+  contests.filter(
     (c): c is MsEitherNeitherContest => c.type === 'ms-either-neither'
   )
-}
 
 export const expandEitherNeitherContests = (
   contests: Contests
-): Exclude<AnyContest, MsEitherNeitherContest>[] => {
-  return contests.flatMap((contest) =>
+): Exclude<AnyContest, MsEitherNeitherContest>[] =>
+  contests.flatMap((contest) =>
     contest.type !== 'ms-either-neither'
       ? [contest]
       : [
@@ -1127,7 +1126,6 @@ export const expandEitherNeitherContests = (
           },
         ]
   )
-}
 
 /**
  * Retrieves a precinct by id.
@@ -1162,14 +1160,13 @@ export const findContest = ({
 }: {
   contests: Contests
   contestId: string
-}): AnyContest | undefined => {
-  return contests.find((c) =>
+}): AnyContest | undefined =>
+  contests.find((c) =>
     c.type === 'ms-either-neither'
       ? c.eitherNeitherContestId === contestId ||
         c.pickOneContestId === contestId
       : c.id === contestId
   )
-}
 
 /**
  * Validates the votes for a given ballot style in a given election.

--- a/libs/ui/src/Button.test.tsx
+++ b/libs/ui/src/Button.test.tsx
@@ -3,13 +3,13 @@ import { fireEvent, render } from '@testing-library/react'
 
 import { Button, DecoyButton } from './Button'
 
-const createTouchStartEventProperties = (x: number, y: number) => {
-  return { touches: [{ clientX: x, clientY: y }] }
-}
+const createTouchStartEventProperties = (x: number, y: number) => ({
+  touches: [{ clientX: x, clientY: y }],
+})
 
-const createTouchEndEventProperties = (x: number, y: number) => {
-  return { changedTouches: [{ clientX: x, clientY: y }] }
-}
+const createTouchEndEventProperties = (x: number, y: number) => ({
+  changedTouches: [{ clientX: x, clientY: y }],
+})
 
 describe('renders Button', () => {
   test('with defaults', () => {

--- a/libs/utils/src/cardTallies.test.ts
+++ b/libs/utils/src/cardTallies.test.ts
@@ -11,9 +11,8 @@ import electionSample from './data/electionSample.json'
 
 const election = electionSample as Election
 
-const getIdxForContestId = (contestId: string) => {
-  return election.contests.findIndex((c) => c.id === contestId)
-}
+const getIdxForContestId = (contestId: string) =>
+  election.contests.findIndex((c) => c.id === contestId)
 
 test('counts missing votes counts as undervotes for appropriate ballot style', () => {
   const zeroTally = getZeroTally(election)

--- a/libs/utils/src/cardTallies.ts
+++ b/libs/utils/src/cardTallies.ts
@@ -38,34 +38,30 @@ const combineCandidateTallies = (
 const combineYesNoTallies = (
   tally1: YesNoVoteTally,
   tally2: YesNoVoteTally
-): YesNoVoteTally => {
-  return {
-    yes: tally1.yes + tally2.yes,
-    no: tally1.no + tally2.no,
-    overvotes: tally1.overvotes + tally2.overvotes,
-    undervotes: tally1.undervotes + tally2.undervotes,
-    ballotsCast: tally1.ballotsCast + tally2.ballotsCast,
-  }
-}
+): YesNoVoteTally => ({
+  yes: tally1.yes + tally2.yes,
+  no: tally1.no + tally2.no,
+  overvotes: tally1.overvotes + tally2.overvotes,
+  undervotes: tally1.undervotes + tally2.undervotes,
+  ballotsCast: tally1.ballotsCast + tally2.ballotsCast,
+})
 
 const combineEitherNeitherTallies = (
   tally1: MsEitherNeitherTally,
   tally2: MsEitherNeitherTally
-): MsEitherNeitherTally => {
-  return {
-    eitherOption: tally1.eitherOption + tally2.eitherOption,
-    neitherOption: tally1.neitherOption + tally2.neitherOption,
-    eitherNeitherUndervotes:
-      tally1.eitherNeitherUndervotes + tally2.eitherNeitherUndervotes,
-    eitherNeitherOvervotes:
-      tally1.eitherNeitherOvervotes + tally2.eitherNeitherOvervotes,
-    firstOption: tally1.firstOption + tally2.firstOption,
-    secondOption: tally1.secondOption + tally2.secondOption,
-    pickOneUndervotes: tally1.pickOneUndervotes + tally2.pickOneUndervotes,
-    pickOneOvervotes: tally1.pickOneOvervotes + tally2.pickOneOvervotes,
-    ballotsCast: tally1.ballotsCast + tally2.ballotsCast,
-  }
-}
+): MsEitherNeitherTally => ({
+  eitherOption: tally1.eitherOption + tally2.eitherOption,
+  neitherOption: tally1.neitherOption + tally2.neitherOption,
+  eitherNeitherUndervotes:
+    tally1.eitherNeitherUndervotes + tally2.eitherNeitherUndervotes,
+  eitherNeitherOvervotes:
+    tally1.eitherNeitherOvervotes + tally2.eitherNeitherOvervotes,
+  firstOption: tally1.firstOption + tally2.firstOption,
+  secondOption: tally1.secondOption + tally2.secondOption,
+  pickOneUndervotes: tally1.pickOneUndervotes + tally2.pickOneUndervotes,
+  pickOneOvervotes: tally1.pickOneOvervotes + tally2.pickOneOvervotes,
+  ballotsCast: tally1.ballotsCast + tally2.ballotsCast,
+})
 
 export const combineTallies = (
   election: Election,

--- a/libs/utils/src/usbstick.ts
+++ b/libs/utils/src/usbstick.ts
@@ -3,9 +3,7 @@ import { sleep } from './sleep'
 
 export const FLUSH_IO_DELAY_MS = 10_000
 
-const isAvailable = () => {
-  return !!window.kiosk
-}
+const isAvailable = () => !!window.kiosk
 
 export enum UsbDriveStatus {
   notavailable = 'notavailable',
@@ -16,9 +14,8 @@ export enum UsbDriveStatus {
   ejecting = 'ejecting',
 }
 
-const getDevice = async (): Promise<KioskBrowser.UsbDrive | undefined> => {
-  return (await window.kiosk?.getUsbDrives())?.[0]
-}
+const getDevice = async (): Promise<KioskBrowser.UsbDrive | undefined> =>
+  (await window.kiosk?.getUsbDrives())?.[0]
 
 export const getDevicePath = async (): Promise<string | undefined> => {
   const device = await getDevice()


### PR DESCRIPTION
`eslint-config-prettier` disables `arrow-body-style`, so we explicitly re-enable it to be in compliance with Section 8.2:

> If the function body consists of a single statement returning an expression without side effects, omit the braces and use the implicit return. Otherwise, keep the braces and use a return statement.