### PR TITLE
feat(ps) update expected location of configuration package

### DIFF
--- a/apps/precinct-scanner/README.md
+++ b/apps/precinct-scanner/README.md
@@ -20,8 +20,8 @@ to get to certain states from http://localhost:3000/preview.
 
 To set the election configuration you will need to load a ballot export zip file
 from [election-manager](../election-manager). It should be on a USB drive
-located at `vx-precinct-scanner/ballot-package.zip`. You'll need to run the
-application inside
+located in the folder `ballot-packages`. There can only be one election ballot
+package in that forder. You'll need to run the application inside
 [`kiosk-browser`](https://github.com/votingworks/kiosk-browser).
 
 To use a mock scanner, follow the directions from in

--- a/apps/precinct-scanner/src/App.test.tsx
+++ b/apps/precinct-scanner/src/App.test.tsx
@@ -189,6 +189,7 @@ test('app can load and configure from a usb stick', async () => {
   await advanceTimersAndPromises(2)
   await advanceTimersAndPromises(1)
   await screen.findByText('Polls Closed')
+  expect(kiosk.getFileSystemEntries).toHaveBeenCalledWith('fake mount point/ballot-packages')
   expect(fetchMock.calls('/config/election', { method: 'PATCH' })).toHaveLength(
     1
   )

--- a/apps/precinct-scanner/src/AppUnhappyPaths.test.tsx
+++ b/apps/precinct-scanner/src/AppUnhappyPaths.test.tsx
@@ -3,6 +3,8 @@ import { electionSampleDefinition } from '@votingworks/fixtures'
 import {
   advanceTimers,
   advanceTimersAndPromises,
+  fakeKiosk,
+  fakeUsbDrive,
   makeAdminCard,
   makePollWorkerCard,
   makeVoterCard,
@@ -91,6 +93,43 @@ test('module-scan fails to unconfigure', async () => {
   fireEvent.click(await screen.findByText('Unconfigure'))
 
   await screen.findByText('Loading')
+})
+
+test('Show error if usb drive has multiple zip files', async () => {
+  const storage = new MemoryStorage()
+  const card = new MemoryCard()
+  const hardware = await MemoryHardware.buildStandard()
+  const kiosk = fakeKiosk()
+  kiosk.getUsbDrives.mockResolvedValue([])
+  window.kiosk = kiosk
+  fetchMock
+    .get('/machine-config', { body: getMachineConfigBody })
+    .getOnce('/config/election', new Response('null'))
+    .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
+    .get('/config/precinct', { body: getPrecinctConfigNoPrecinctResponseBody })
+    .get('/scan/status', { body: scanStatusWaitingForPaperResponseBody })
+  render(<App storage={storage} card={card} hardware={hardware} />)
+  await screen.findByText('Loading Configuration…')
+  await advanceTimersAndPromises(1)
+  await screen.findByText('Precinct Scanner is Not Configured')
+  await screen.findByText('Insert USB Drive with configuration.')
+
+  const fakeZipFile = {
+    name: 'ballot-package.zip',
+    path: 'path',
+    type: 1,
+    size: 1,
+    atime: new Date(),
+    ctime: new Date(),
+    mtime: new Date(),
+  }
+
+  kiosk.getFileSystemEntries.mockResolvedValue([fakeZipFile, fakeZipFile])
+  kiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()])
+  await advanceTimersAndPromises(2)
+  await screen.findByText(
+    'Error in configuration: More than one ballot package found on the inserted USB drive, make sure only one is present.'
+  )
 })
 
 test('Show invalid card screen when unsupported cards are given', async () => {

--- a/apps/precinct-scanner/src/config/globals.ts
+++ b/apps/precinct-scanner/src/config/globals.ts
@@ -1,5 +1,4 @@
-export const PRECINCT_SCANNER_FOLDER = 'vx-precinct-scanner'
-export const BALLOT_PACKAGE_FILENAME = 'ballot-package.zip'
+export const PRECINCT_SCANNER_FOLDER = 'ballot-packages'
 
 export const FONT_SIZES = [22, 28, 36, 60]
 export const DEFAULT_FONT_SIZE = 1

--- a/apps/precinct-scanner/src/screens/UnconfiguredElectionScreen.tsx
+++ b/apps/precinct-scanner/src/screens/UnconfiguredElectionScreen.tsx
@@ -4,10 +4,7 @@ import path from 'path'
 import { OptionalElectionDefinition, getPrecinctById } from '@votingworks/types'
 import { ballotPackageUtils, usbstick } from '@votingworks/utils'
 import { addTemplates, doneTemplates } from '../api/hmpb'
-import {
-  PRECINCT_SCANNER_FOLDER,
-  BALLOT_PACKAGE_FILENAME,
-} from '../config/globals'
+import { PRECINCT_SCANNER_FOLDER } from '../config/globals'
 import { CenteredLargeProse, CenteredScreen } from '../components/Layout'
 import {
   QuestionCircle,
@@ -65,12 +62,16 @@ const UnconfiguredElectionScreen = ({
           throw new Error('No ballot package found on the inserted USB drive.')
         }
         const ballotPackages = files.filter(
-          (f) => f.type === 1 && f.name === BALLOT_PACKAGE_FILENAME
+          (f) => f.type === 1 && f.name.endsWith('.zip')
         )
 
         // If there is more then one ballot package in the folder, fail.
         if (ballotPackages.length < 1) {
           throw new Error('No ballot package found on the inserted USB drive.')
+        } else if (ballotPackages.length > 1) {
+          throw new Error(
+            'More than one ballot package found on the inserted USB drive, make sure only one is present.'
+          )
         }
         const ballotPackage = await ballotPackageUtils.readBallotPackageFromFilePointer(
           ballotPackages[0]
@@ -107,7 +108,11 @@ const UnconfiguredElectionScreen = ({
             await setElectionDefinition(ballotPackage.electionDefinition)
           })
       } catch (error) {
-        setErrorMessage(error.message)
+        if (error instanceof Error) {
+          setErrorMessage(error.message)
+        } else {
+          setErrorMessage('Unknown Error')
+        }
         setIsLoadingBallotPackage(false)
       }
     }


### PR DESCRIPTION
Instead of looking for a ballot package at vx-precinct-scanner/ballot-package.zip the precinct scanner will now look for a single ballot package in the ballot-package directory where election-manager writes to. If there is more then one ballot package in this directory an error is shown. Note that election manager does NOT currently prevent you from adding more then one ballot package to this location, so if you get into that state you either need to delete the zip files you have in that folder manually or use a new usb stick. 

Down the road we should improve election-manager and make bsd consistent with how precinct-scanner works but this makes the system much more usable then it is today. 

https://zube.io/votingworks/vxsuite/c/3555