### PR TITLE
fix(ui) fix bug in mounting usb

### DIFF
--- a/libs/ui/src/hooks/useUsbDrive.test.tsx
+++ b/libs/ui/src/hooks/useUsbDrive.test.tsx
@@ -118,3 +118,20 @@ test('full lifecycle with USBControllerButton', async () => {
   await waitForStatusUpdate()
   screen.getByText('No USB')
 })
+
+test('usb drive gets mounted from undefined state', async () => {
+  render(<TestComponent />)
+  screen.getByText('undefined')
+  const kiosk = fakeKiosk()
+  kiosk.getUsbDrives.mockResolvedValue([])
+  window.kiosk = kiosk
+  kiosk.getUsbDrives.mockResolvedValue([UNMOUNTED_DRIVE])
+  await waitForStatusUpdate()
+  expect(kiosk.mountUsbDrive).toHaveBeenCalled()
+  screen.getByText('present')
+
+  // wait for it to mount
+  kiosk.getUsbDrives.mockResolvedValue([MOUNTED_DRIVE])
+  await waitForStatusUpdate()
+  screen.getByText('mounted')
+})

--- a/libs/ui/src/hooks/useUsbDrive.ts
+++ b/libs/ui/src/hooks/useUsbDrive.ts
@@ -65,7 +65,7 @@ export const useUsbDrive = (): UsbDrive => {
         debug('USB drive removed')
         setRecentlyEjected(false)
       } else if (
-        status === UsbDriveStatus.absent &&
+        (status === UsbDriveStatus.absent || status === undefined) &&
         newStatus === UsbDriveStatus.present
       ) {
         try {


### PR DESCRIPTION
When starting an app with a USB drive connected, but not mounted to the machine the logic in useUsbDrive transitions straight from an undefined state to "present" and currently that does not get mounted and then the usbdrive gets stuck in the "present" state and is never mounted. 