### PR TITLE
fix(lint): correct rule name

### DIFF
--- a/libs/eslint-plugin-vx/src/rules/gts-no-private-fields.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts-no-private-fields.ts
@@ -7,9 +7,9 @@ function isPrivateIdentifier(node: TSESTree.Node): boolean {
 
 export default ESLintUtils.RuleCreator(
   () =>
-    'https://github.com/votingworks/vxsuite/blob/main/libs/eslint-plugin-vx/docs/rules/gts-no-private.md'
+    'https://github.com/votingworks/vxsuite/blob/main/libs/eslint-plugin-vx/docs/rules/gts-no-private-fields.md'
 )({
-  name: 'gts-no-private',
+  name: 'gts-no-private-fields',
   meta: {
     docs: {
       description: 'Disallows use of private fields aka private identifiers',

--- a/libs/eslint-plugin-vx/tests/rules/gts-no-private-fields.test.ts
+++ b/libs/eslint-plugin-vx/tests/rules/gts-no-private-fields.test.ts
@@ -11,7 +11,7 @@ const ruleTester = new ESLintUtils.RuleTester({
   parser: '@typescript-eslint/parser',
 })
 
-ruleTester.run('gts-no-private', rule, {
+ruleTester.run('gts-no-private-fields', rule, {
   valid: [
     {
       code: `class A {}`,


### PR DESCRIPTION
An earlier version was called `gts-no-private`, but I changed it to `gts-no-private-fields`. Looks like I missed a few spots.