### PR TITLE
style(lint): enforce & fix GTS array constructor rule

### DIFF
--- a/apps/bmd/cypress/tests/scroll-to-contest.ts
+++ b/apps/bmd/cypress/tests/scroll-to-contest.ts
@@ -2,7 +2,7 @@
 
 describe('Review Page', () => {
   const waitTime = 500
-  const clickThoughPages = new Array(20) // number of contests for activation code 'VX.23.12'
+  const clickThoughPages = Array.from({ length: 20 }) // number of contests for activation code 'VX.23.12'
   it('When navigating from contest, scroll to contest and place focus on contest.', () => {
     cy.visit('/#demo')
     cy.wait(waitTime)

--- a/apps/bmd/src/components/PickDateTimeModal.tsx
+++ b/apps/bmd/src/components/PickDateTimeModal.tsx
@@ -107,7 +107,7 @@ const PickDateTimeModal = ({
                   <option value="" disabled>
                     Year
                   </option>
-                  {[...Array(11).keys()].map((i) => (
+                  {[...Array.from({ length: 11 }).keys()].map((i) => (
                     <option key={i} value={2020 + i}>
                       {2020 + i}
                     </option>
@@ -173,7 +173,7 @@ const PickDateTimeModal = ({
                   <option value="" disabled>
                     Hour
                   </option>
-                  {[...Array(12).keys()].map((hour) => (
+                  {[...Array.from({ length: 12 }).keys()].map((hour) => (
                     <option key={hour} value={hour + 1}>
                       {hour + 1}
                     </option>
@@ -193,7 +193,7 @@ const PickDateTimeModal = ({
                   <option value="" disabled>
                     Minute
                   </option>
-                  {[...Array(60).keys()].map((minute) => (
+                  {[...Array.from({ length: 60 }).keys()].map((minute) => (
                     <option key={minute} value={minute}>
                       {minute < 10 ? `0${minute}` : minute}
                     </option>

--- a/apps/election-manager/src/components/HandMarkedPaperBallot.tsx
+++ b/apps/election-manager/src/components/HandMarkedPaperBallot.tsx
@@ -416,7 +416,7 @@ export const CandidateContestChoices = ({
 }: CandidateContestChoicesProps): JSX.Element => {
   const { t } = useTranslation()
   const writeInCandidates = vote?.filter((c) => c.isWriteIn)
-  const remainingChoices = [...Array(contest.seats).keys()]
+  const remainingChoices = [...Array.from({ length: contest.seats }).keys()]
   const dualLanguageWithSlash = dualLanguageComposer(t, locales)
   return (
     <React.Fragment>

--- a/apps/module-scan/src/LoopScanner.test.ts
+++ b/apps/module-scan/src/LoopScanner.test.ts
@@ -8,7 +8,7 @@ function readFiles(paths: readonly string[]): string[] {
 }
 
 test('copies files in pairs', async () => {
-  const [f1, f2, f3, f4] = new Array(4).fill(null).map((_, i) => {
+  const [f1, f2, f3, f4] = Array.from({ length: 4 }, (_, i) => {
     const path = fileSync().name
     writeFileSync(path, i + 1, 'utf8')
     return path

--- a/apps/module-scan/src/util/getBallotPageContests.test.ts
+++ b/apps/module-scan/src/util/getBallotPageContests.test.ts
@@ -18,9 +18,8 @@ function metadataForPage(pageNumber: number): BallotPageMetadata {
 test('gets contests broken across pages according to the layout', () => {
   const ballotStyle = getBallotStyle({ ballotStyleId: '12', election })!
   const allContestsForBallot = getContests({ ballotStyle, election })
-  const layouts = new Array(5)
-    .fill(undefined)
-    .map<SerializableBallotPageLayout>((_, i) => ({
+  const layouts = Array.from({ length: 5 }).map<SerializableBallotPageLayout>(
+    (_, i) => ({
       ballotImage: { metadata: metadataForPage(i) },
       contests: [
         {
@@ -34,7 +33,8 @@ test('gets contests broken across pages according to the layout', () => {
           options: [],
         },
       ],
-    }))
+    })
+  )
 
   for (let pageNumber = 1; pageNumber <= layouts.length; pageNumber += 1) {
     expect(

--- a/apps/precinct-scanner/src/components/PickDateTimeModal.tsx
+++ b/apps/precinct-scanner/src/components/PickDateTimeModal.tsx
@@ -103,7 +103,7 @@ const PickDateTimeModal = ({
                   <option value="" disabled>
                     Year
                   </option>
-                  {[...Array(11).keys()].map((i) => (
+                  {[...Array.from({ length: 11 }).keys()].map((i) => (
                     <option key={i} value={2020 + i}>
                       {2020 + i}
                     </option>
@@ -169,7 +169,7 @@ const PickDateTimeModal = ({
                   <option value="" disabled>
                     Hour
                   </option>
-                  {[...Array(12).keys()].map((hour) => (
+                  {[...Array.from({ length: 12 }).keys()].map((hour) => (
                     <option key={hour} value={hour + 1}>
                       {hour + 1}
                     </option>
@@ -189,7 +189,7 @@ const PickDateTimeModal = ({
                   <option value="" disabled>
                     Minute
                   </option>
-                  {[...Array(60).keys()].map((minute) => (
+                  {[...Array.from({ length: 60 }).keys()].map((minute) => (
                     <option key={minute} value={minute}>
                       {minute < 10 ? `0${minute}` : minute}
                     </option>

--- a/libs/ballot-encoder/src/index.test.ts
+++ b/libs/ballot-encoder/src/index.test.ts
@@ -32,7 +32,7 @@ import {
 } from './index'
 
 function falses(count: number): boolean[] {
-  return new Array(count).fill(false)
+  return Array.from({ length: count }, () => false)
 }
 
 test('can detect an encoded ballot', () => {

--- a/libs/ballot-encoder/src/index.ts
+++ b/libs/ballot-encoder/src/index.ts
@@ -34,7 +34,9 @@ export const ELECTION_HASH_LENGTH = 20
 
 // pad this locale array so the same code can later be upgraded
 // to support other languages without breaking previously printed ballots
-export const SUPPORTED_LOCALES = ['en-US', 'es-US'].concat(new Array(250))
+export const SUPPORTED_LOCALES = ['en-US', 'es-US'].concat(
+  Array.from({ length: 250 })
+)
 
 // TODO: include "magic number" and encoding version
 

--- a/libs/ballot-encoder/test/fuzz.test.ts
+++ b/libs/ballot-encoder/test/fuzz.test.ts
@@ -60,9 +60,9 @@ type ActionsPair = [BitWriterAction[], BitReaderAction[]]
 const testCaseFactories = {
   'vararg booleans': (): ActionsPair => {
     const argCount = random.integer(0, 10)
-    const args = new Array<boolean>(argCount)
-      .fill(false)
-      .map(() => random.bool())
+    const args = Array.from<boolean>({ length: argCount }).map(() =>
+      random.bool()
+    )
 
     return [
       [{ method: 'writeBoolean', args }],
@@ -155,7 +155,7 @@ const testCaseFactories = {
 
   'vararg uint1s': (): ActionsPair => {
     const argCount = random.integer(0, 10)
-    const args = new Array<0 | 1>(argCount)
+    const args = Array.from<0 | 1>({ length: argCount })
       .fill(0)
       .map(() => random.integer(0, 1))
 
@@ -176,7 +176,7 @@ const testCaseFactories = {
 
   'vararg uint8s': (): ActionsPair => {
     const argCount = random.integer(0, 10)
-    const args = new Array<Uint8Index>(argCount)
+    const args = Array.from<Uint8Index>({ length: argCount })
       .fill(0)
       .map(() => random.integer(0, Uint8Size - 1))
 
@@ -337,7 +337,7 @@ for (const testCase of testCaseNames) {
  */
 test('all together', () => {
   for (let i = 0; i < 100; i += 1) {
-    const factories = new Array(20)
+    const factories = Array.from({ length: 20 })
       .fill(undefined)
       .map(() => testCaseFactories[random.pick(testCaseNames)])
 

--- a/libs/eslint-plugin-vx/docs/rules/gts-no-array-constructor.md
+++ b/libs/eslint-plugin-vx/docs/rules/gts-no-array-constructor.md
@@ -1,0 +1,33 @@
+# Disallows using the `Array` constructor. (`vx/gts-no-array-constructor`)
+
+This rule is from
+[Google TypeScript Style Guide section "Array Constructor"](https://google.github.io/styleguide/tsguide.html#array-constructor):
+
+> TypeScript code must not use the `Array()` constructor, with or without `new`.
+> It has confusing and contradictory usage.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```ts
+const a = new Array(2) // [undefined, undefined]
+const b = new Array(2, 3) // [2, 3];
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+const a = [2]
+const b = [2, 3]
+
+// Equivalent to Array(2):
+const c = []
+c.length = 2
+
+// Equivalent to Array(5).fill(0), i.e. [0, 0, 0, 0, 0]:
+Array.from<number>({ length: 5 }).fill(0)
+
+// Equivalent to Array<Uint8>(1, 2, 3):
+const d = Array.of<Uint8>(1, 2, 3)
+```

--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -35,12 +35,14 @@ export = {
   },
   reportUnusedDisableDirectives: true,
   rules: {
+    'vx/gts-no-array-constructor': 'error',
     'vx/gts-no-private-fields': 'error',
     'vx/gts-parameter-properties': 'error',
     'vx/no-array-sort-mutation': 'error',
     'vx/no-assert-truthiness': 'error',
     'vx/no-floating-results': ['error', { ignoreVoid: true }],
 
+    '@typescript-eslint/no-array-constructor': 'off',
     '@typescript-eslint/no-extra-semi': 'off',
     '@typescript-eslint/no-floating-promises': 'error',
     '@typescript-eslint/no-non-null-assertion': 'error',

--- a/libs/eslint-plugin-vx/src/rules/gts-no-array-constructor.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts-no-array-constructor.ts
@@ -1,0 +1,116 @@
+import {
+  AST_NODE_TYPES,
+  ESLintUtils,
+  TSESTree,
+} from '@typescript-eslint/experimental-utils'
+import { RuleFix } from '@typescript-eslint/experimental-utils/dist/ts-eslint'
+import { strict as assert } from 'assert'
+
+export default ESLintUtils.RuleCreator(
+  () =>
+    'https://github.com/votingworks/vxsuite/blob/main/libs/eslint-plugin-vx/docs/rules/gts-no-array-constructor.md'
+)({
+  name: 'gts-no-array-constructor',
+  meta: {
+    docs: {
+      description: 'Disallows using the `Array` constructor.',
+      category: 'Best Practices',
+      recommended: 'error',
+      suggestion: false,
+      requiresTypeChecking: false,
+    },
+    fixable: 'code',
+    messages: {
+      noArrayConstructor:
+        'Do not use the `Array` constructor; use `Array.from` or similar instead.',
+    },
+    schema: [],
+    type: 'problem',
+  },
+  defaultOptions: [],
+
+  create(context) {
+    const sourceCode = context.getSourceCode()
+
+    function processNode(
+      node: TSESTree.CallExpression | TSESTree.NewExpression
+    ): void {
+      if (
+        node.callee.type === AST_NODE_TYPES.Identifier &&
+        node.callee.name === 'Array' &&
+        (node.type !== AST_NODE_TYPES.CallExpression || !node.optional)
+      ) {
+        context.report({
+          node,
+          messageId: 'noArrayConstructor',
+          fix: (fixer) => {
+            const result: RuleFix[] = []
+
+            const leftParen = sourceCode.getTokenAfter(
+              node.typeParameters ?? node.callee
+            )
+            assert.equal(leftParen?.value, '(')
+
+            const rightParen = sourceCode.getLastToken(node)
+            assert.equal(rightParen?.value, ')')
+
+            if (node.type === AST_NODE_TYPES.NewExpression) {
+              const newToken = sourceCode.getFirstToken(node)
+              assert.equal(newToken?.value, 'new')
+              const commentsAfterNew = sourceCode.getCommentsAfter(newToken)
+              result.push(
+                // `new Array()` → `Array()`
+                //  ^^^^
+                fixer.removeRange([
+                  newToken.range[0],
+                  (commentsAfterNew[0] ?? node.callee).range[0],
+                ])
+              )
+            }
+
+            if (node.arguments.length !== 1) {
+              if (node.typeParameters) {
+                result.push(
+                  // `Array<number>()` → `Array.of<number>()`
+                  //                           ^^^
+                  fixer.insertTextAfterRange(node.callee.range, '.of')
+                )
+              } else {
+                result.push(
+                  // `Array(a, b)` → `(a, b)`
+                  //  ^^^^^
+                  fixer.removeRange(node.callee.range),
+                  // `(a, b)` → `[a, b)`
+                  //  ^          ^
+                  fixer.replaceTextRange(leftParen.range, '['),
+                  // `[a, b)` → `[a, b]`
+                  //       ^          ^
+                  fixer.replaceTextRange(rightParen.range, ']')
+                )
+              }
+            } else {
+              result.push(
+                // `Array(5)` → `Array.from(5)`
+                //                    ^^^^^
+                fixer.insertTextAfterRange(node.callee.range, '.from'),
+                // `Array.from(5)` → `Array.from({ length: 5)`
+                //                               ^^^^^^^^^^
+                fixer.insertTextAfterRange(leftParen.range, '{ length: '),
+                // `Array.from({ length: 5)` → `Array.from({ length: 5 })`
+                //                                                    ^^
+                fixer.insertTextBeforeRange(rightParen.range, ' }')
+              )
+            }
+
+            return result
+          },
+        })
+      }
+    }
+
+    return {
+      CallExpression: processNode,
+      NewExpression: processNode,
+    }
+  },
+})

--- a/libs/eslint-plugin-vx/src/rules/index.ts
+++ b/libs/eslint-plugin-vx/src/rules/index.ts
@@ -1,3 +1,4 @@
+import gtsNoArrayConstructor from './gts-no-array-constructor'
 import gtsNoPrivateFields from './gts-no-private-fields'
 import gtsParameterProperties from './gts-parameter-properties'
 import noArraySortMutation from './no-array-sort-mutation'
@@ -5,6 +6,7 @@ import noAssertStringOrNumber from './no-assert-truthiness'
 import noFloatingVoids from './no-floating-results'
 
 export default {
+  'gts-no-array-constructor': gtsNoArrayConstructor,
   'gts-no-private-fields': gtsNoPrivateFields,
   'gts-parameter-properties': gtsParameterProperties,
   'no-array-sort-mutation': noArraySortMutation,

--- a/libs/eslint-plugin-vx/tests/rules/gts-no-array-constructor.test.ts
+++ b/libs/eslint-plugin-vx/tests/rules/gts-no-array-constructor.test.ts
@@ -1,0 +1,95 @@
+import { ESLintUtils } from '@typescript-eslint/experimental-utils'
+import { join } from 'path'
+import rule from '../../src/rules/gts-no-array-constructor'
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    tsconfigRootDir: join(__dirname, '../fixtures'),
+    project: './tsconfig.json',
+  },
+  parser: '@typescript-eslint/parser',
+})
+
+ruleTester.run('gts-no-array-constructor', rule, {
+  valid: [
+    {
+      code: `[]`,
+    },
+    {
+      code: `[1]`,
+    },
+    {
+      code: `Array.from(a)`,
+    },
+    {
+      code: `Array.from({ length: 1 })`,
+    },
+    {
+      code: `Array.of(1)`,
+    },
+    {
+      code: `Array.of(a)`,
+    },
+    {
+      code: `Array?.()`,
+    },
+  ],
+  invalid: [
+    {
+      code: `Array()`,
+      output: `[]`,
+      errors: [{ line: 1, messageId: 'noArrayConstructor' }],
+    },
+    {
+      code: `Array/*a*/(/*b*/)/*c*/`,
+      output: `/*a*/[/*b*/]/*c*/`,
+      errors: [{ line: 1, messageId: 'noArrayConstructor' }],
+    },
+    {
+      code: `Array<number>()`,
+      output: `Array.of<number>()`,
+      errors: [{ line: 1, messageId: 'noArrayConstructor' }],
+    },
+    {
+      code: `Array/*a*/<number>/*b*/(/*c*/)/*d*/`,
+      output: `Array.of/*a*/<number>/*b*/(/*c*/)/*d*/`,
+      errors: [{ line: 1, messageId: 'noArrayConstructor' }],
+    },
+    {
+      code: `new Array()`,
+      output: `[]`,
+      errors: [{ line: 1, messageId: 'noArrayConstructor' }],
+    },
+    {
+      code: `new/*a*/Array/*b*/(/*c*/)/*d*/`,
+      output: `/*a*//*b*/[/*c*/]/*d*/`,
+      errors: [{ line: 1, messageId: 'noArrayConstructor' }],
+    },
+    {
+      code: `Array(1)`,
+      output: `Array.from({ length: 1 })`,
+      errors: [{ line: 1, messageId: 'noArrayConstructor' }],
+    },
+    {
+      code: `new Array(1)`,
+      output: `Array.from({ length: 1 })`,
+      errors: [{ line: 1, messageId: 'noArrayConstructor' }],
+    },
+    {
+      code: `Array(1, 2)`,
+      output: `[1, 2]`,
+      errors: [{ line: 1, messageId: 'noArrayConstructor' }],
+    },
+    {
+      code: `new Array(1, 2)`,
+      output: `[1, 2]`,
+      errors: [{ line: 1, messageId: 'noArrayConstructor' }],
+    },
+    {
+      code: `new Array<1 | 2>(1, 2)`,
+      output: `Array.of<1 | 2>(1, 2)`,
+      errors: [{ line: 1, messageId: 'noArrayConstructor' }],
+    },
+  ],
+})

--- a/libs/hmpb-interpreter/src/utils/VisitedPoints.ts
+++ b/libs/hmpb-interpreter/src/utils/VisitedPoints.ts
@@ -2,7 +2,7 @@ export class VisitedPoints {
   private data: Uint8Array[]
 
   public constructor(private width: number, height: number) {
-    this.data = new Array(height)
+    this.data = Array.from({ length: height })
   }
 
   public add(x: number, y: number, value = true): boolean {

--- a/libs/hmpb-interpreter/src/utils/jsfeat/diff.test.ts
+++ b/libs/hmpb-interpreter/src/utils/jsfeat/diff.test.ts
@@ -33,7 +33,7 @@ const imageData4x4: Readonly<ImageData> = createImageData(
 
 test('images have no diff with themselves', () => {
   expect([...diff(imageData4x4, imageData4x4).data]).toEqual(
-    new Array(imageData4x4.data.length).fill(PIXEL_WHITE)
+    Array.from({ length: imageData4x4.data.length }).fill(PIXEL_WHITE)
   )
 })
 

--- a/libs/lsd/src/index.ts
+++ b/libs/lsd/src/index.ts
@@ -50,7 +50,9 @@ export default function lsd(imageData: ImageData): LineSegment[] {
     'invalid dimension'
   )
 
-  const segments = new Array<LineSegment>(result.length / addon.LSD_RESULT_DIM)
+  const segments = Array.from<LineSegment>({
+    length: result.length / addon.LSD_RESULT_DIM,
+  })
 
   for (
     let ri = 0, si = 0;

--- a/libs/utils/src/cardTallies.test.ts
+++ b/libs/utils/src/cardTallies.test.ts
@@ -225,7 +225,7 @@ test('tallies votes across many contests appropriately', () => {
     ballotsCast: 1,
   })
   expect(tally[getIdxForContestId('governor')]).toEqual({
-    candidates: Array(26).fill(0),
+    candidates: Array.from({ length: 26 }).fill(0),
     writeIns: 0,
     undervotes: 0,
     overvotes: 1,


### PR DESCRIPTION
https://google.github.io/styleguide/tsguide.html#array-constructor

> TypeScript code must not use the `Array()` constructor, with or without `new`. It has confusing and contradictory usage:
>
> ```ts
> const a = new Array(2); // [undefined, undefined]
> const b = new Array(2, 3); // [2, 3];
> ```
> Instead, always use bracket notation to initialize arrays, or `from` to initialize an Array with a certain size:
> 
> ```ts
> const a = [2];
> const b = [2, 3];
> 
> // Equivalent to Array(2):
> const c = [];
> c.length = 2;
> 
> // [0, 0, 0, 0, 0]
> Array.from<number>({length: 5}).fill(0);
> ```

Refs #788 
