### PR TITLE
style(lint): enforce & fix GTS rule forbidding "public" modifier

### DIFF
--- a/apps/bmd/src/utils/ScreenReader/AriaScreenReader.ts
+++ b/apps/bmd/src/utils/ScreenReader/AriaScreenReader.ts
@@ -7,26 +7,26 @@ export default class AriaScreenReader implements ScreenReader {
   /**
    * @param tts A text-to-speech engine to use to speak aloud.
    */
-  public constructor(private tts: TextToSpeech) {}
+  constructor(private tts: TextToSpeech) {}
 
   /**
    * Call this with an event target when a focus event occurs. Resolves when speaking is done.
    */
-  public async onFocus(target?: EventTarget): Promise<void> {
+  async onFocus(target?: EventTarget): Promise<void> {
     await this.speakEventTarget(target)
   }
 
   /**
    * Call this with an event target when a click event occurs. Resolves when speaking is done.
    */
-  public async onClick(target?: EventTarget): Promise<void> {
+  async onClick(target?: EventTarget): Promise<void> {
     await this.speakEventTarget(target)
   }
 
   /**
    * Call this when a page load occurs. Resolves when speaking is done.
    */
-  public async onPageLoad(): Promise<void> {
+  async onPageLoad(): Promise<void> {
     this.tts.stop()
   }
 
@@ -34,7 +34,7 @@ export default class AriaScreenReader implements ScreenReader {
    * Enables the screen reader and announces the change. Resolves when speaking
    * is done.
    */
-  public async enable(): Promise<void> {
+  async enable(): Promise<void> {
     this.unmute()
     await this.speak('Screen reader enabled', { now: true })
   }
@@ -43,7 +43,7 @@ export default class AriaScreenReader implements ScreenReader {
    * Disables the screen reader and announces the change. Resolves when speaking
    * is done.
    */
-  public async disable(): Promise<void> {
+  async disable(): Promise<void> {
     await this.speak('Screen reader disabled', { now: true })
     this.mute()
   }
@@ -52,7 +52,7 @@ export default class AriaScreenReader implements ScreenReader {
    * Toggles the screen reader being enabled and announces the change. Resolves
    * when speaking is done.
    */
-  public async toggle(enabled = this.isMuted()): Promise<void> {
+  async toggle(enabled = this.isMuted()): Promise<void> {
     if (enabled) {
       await this.enable()
     } else {
@@ -63,35 +63,35 @@ export default class AriaScreenReader implements ScreenReader {
   /**
    * Prevents any sound from being made but otherwise functions normally.
    */
-  public mute(): void {
+  mute(): void {
     return this.tts.mute()
   }
 
   /**
    * Allows sounds to be made.
    */
-  public unmute(): void {
+  unmute(): void {
     return this.tts.unmute()
   }
 
   /**
    * Checks whether this TTS is muted.
    */
-  public isMuted(): boolean {
+  isMuted(): boolean {
     return this.tts.isMuted()
   }
 
   /**
    * Toggles muted state, or sets it according to the argument.
    */
-  public toggleMuted(muted?: boolean): void {
+  toggleMuted(muted?: boolean): void {
     this.tts.toggleMuted(muted)
   }
 
   /**
    * Directly triggers speech of text. Resolves when speaking is done.
    */
-  public async speak(text: string, options: SpeakOptions = {}): Promise<void> {
+  async speak(text: string, options: SpeakOptions = {}): Promise<void> {
     /* istanbul ignore next */
     if (process.env.NODE_ENV === 'development') {
       // eslint-disable-next-line no-console
@@ -107,7 +107,7 @@ export default class AriaScreenReader implements ScreenReader {
   /**
    * Directly triggers speech of an element. Resolves when speaking is done.
    */
-  public async speakNode(node: Node, options?: SpeakOptions): Promise<void> {
+  async speakNode(node: Node, options?: SpeakOptions): Promise<void> {
     const description = this.describe(node)
     if (description) {
       await this.speak(description, options)
@@ -117,7 +117,7 @@ export default class AriaScreenReader implements ScreenReader {
   /**
    * Directly triggers speech of an event target. Resolves when speaking is done.
    */
-  public async speakEventTarget(
+  async speakEventTarget(
     target?: EventTarget,
     { now = true }: SpeakOptions = {}
   ): Promise<void> {
@@ -129,7 +129,7 @@ export default class AriaScreenReader implements ScreenReader {
   /**
    * Generates a clean text string to be spoken for an element.
    */
-  public describe(node: Node): string | undefined {
+  describe(node: Node): string | undefined {
     return this.cleanDescription(this.describeNode(node))
   }
 

--- a/apps/bmd/src/utils/ScreenReader/SpeechSynthesisTextToSpeech.ts
+++ b/apps/bmd/src/utils/ScreenReader/SpeechSynthesisTextToSpeech.ts
@@ -3,7 +3,7 @@ import { SpeakOptions, TextToSpeech, VoiceSelector } from '../../config/types'
 export default class SpeechSynthesisTextToSpeech implements TextToSpeech {
   private muted = false
 
-  public constructor(private getVoice?: VoiceSelector) {
+  constructor(private getVoice?: VoiceSelector) {
     // Prime the speech synthesis engine. This call will likely return an empty
     // array, but future ones should work properly.
     speechSynthesis.getVoices()
@@ -12,10 +12,7 @@ export default class SpeechSynthesisTextToSpeech implements TextToSpeech {
   /**
    * Directly triggers speech of text. Resolves when speaking is done.
    */
-  public async speak(
-    text: string,
-    { now = false }: SpeakOptions = {}
-  ): Promise<void> {
+  async speak(text: string, { now = false }: SpeakOptions = {}): Promise<void> {
     if (this.isMuted()) {
       return
     }
@@ -51,14 +48,14 @@ export default class SpeechSynthesisTextToSpeech implements TextToSpeech {
   /**
    * Stops any speaking that is currently happening.
    */
-  public stop(): void {
+  stop(): void {
     speechSynthesis.cancel()
   }
 
   /**
    * Prevents any sound from being made but otherwise functions normally.
    */
-  public mute(): void {
+  mute(): void {
     speechSynthesis.cancel()
     this.muted = true
   }
@@ -66,21 +63,21 @@ export default class SpeechSynthesisTextToSpeech implements TextToSpeech {
   /**
    * Allows sounds to be made.
    */
-  public unmute(): void {
+  unmute(): void {
     this.muted = false
   }
 
   /**
    * Checks whether this TTS is muted.
    */
-  public isMuted(): boolean {
+  isMuted(): boolean {
     return this.muted
   }
 
   /**
    * Toggles muted state, or sets it according to the argument.
    */
-  public toggleMuted(muted = !this.isMuted()): void {
+  toggleMuted(muted = !this.isMuted()): void {
     if (muted) {
       this.mute()
     } else {

--- a/apps/election-manager/src/lib/ConverterClient.ts
+++ b/apps/election-manager/src/lib/ConverterClient.ts
@@ -9,9 +9,9 @@ export interface VxFiles {
 }
 
 export default class ConverterClient {
-  public constructor(private readonly target: string) {}
+  constructor(private readonly target: string) {}
 
-  public async setInputFile(name: string, content: File): Promise<void> {
+  async setInputFile(name: string, content: File): Promise<void> {
     const formData = new FormData()
     formData.append('name', name)
     formData.append('file', content)
@@ -29,7 +29,7 @@ export default class ConverterClient {
     }
   }
 
-  public async process(): Promise<void> {
+  async process(): Promise<void> {
     const response = await fetch(`/convert/${this.target}/process`, {
       method: 'POST',
     })
@@ -40,7 +40,7 @@ export default class ConverterClient {
     }
   }
 
-  public async getOutputFile(name: string): Promise<Blob> {
+  async getOutputFile(name: string): Promise<Blob> {
     const response = await fetch(
       `/convert/${this.target}/output?name=${encodeURIComponent(name)}`,
       { cache: 'no-store' }
@@ -48,14 +48,14 @@ export default class ConverterClient {
     return await response.blob()
   }
 
-  public async getFiles(): Promise<VxFiles> {
+  async getFiles(): Promise<VxFiles> {
     const response = await fetch(`/convert/${this.target}/files`, {
       cache: 'no-store',
     })
     return await response.json()
   }
 
-  public async reset(): Promise<void> {
+  async reset(): Promise<void> {
     await fetch('/convert/reset', { method: 'POST' })
   }
 }

--- a/apps/election-manager/src/utils/DownloadableArchive.ts
+++ b/apps/election-manager/src/utils/DownloadableArchive.ts
@@ -11,7 +11,7 @@ export default class DownloadableArchive {
   private zip?: ZipStream
   private endPromise?: Promise<void>
 
-  public constructor(private kiosk = window.kiosk) {}
+  constructor(private kiosk = window.kiosk) {}
 
   private getKiosk(): KioskBrowser.Kiosk {
     assert(this.kiosk)
@@ -23,9 +23,7 @@ export default class DownloadableArchive {
    * making this instance ready to receive files. Resolves when ready to receive
    * files.
    */
-  public async beginWithDialog(
-    options?: KioskBrowser.SaveAsOptions
-  ): Promise<void> {
+  async beginWithDialog(options?: KioskBrowser.SaveAsOptions): Promise<void> {
     const fileWriter = await this.getKiosk().saveAs(options)
 
     if (!fileWriter) {
@@ -45,7 +43,7 @@ export default class DownloadableArchive {
    * Begins downloading an archive to the filePath specified. Resolves when
    * ready to receive files.
    */
-  public async beginWithDirectSave(
+  async beginWithDirectSave(
     pathToFolder: string,
     filename: string
   ): Promise<void> {
@@ -71,7 +69,7 @@ export default class DownloadableArchive {
   /**
    * Writes a file to the archive, resolves when complete.
    */
-  public async file(
+  async file(
     name: string,
     data: Parameters<ZipStream['entry']>[0]
   ): Promise<void> {
@@ -89,7 +87,7 @@ export default class DownloadableArchive {
   /**
    * Finishes the zip archive and ends the download.
    */
-  public async end(): Promise<void> {
+  async end(): Promise<void> {
     if (!this.zip) {
       throw new Error('cannot call end() before begin()')
     }

--- a/apps/module-scan/src/LoopScanner.ts
+++ b/apps/module-scan/src/LoopScanner.ts
@@ -89,16 +89,16 @@ export default class LoopScanner implements Scanner {
   /**
    * @param batches lists of front/back pairs of sheets to scan
    */
-  public constructor(private batches: readonly Batch[]) {}
+  constructor(private batches: readonly Batch[]) {}
 
-  public async getStatus(): Promise<ScannerStatus> {
+  async getStatus(): Promise<ScannerStatus> {
     return ScannerStatus.Unknown
   }
 
   /**
    * "Scans" the next sheet by returning the paths for the next two images.
    */
-  public scanSheets(): BatchControl {
+  scanSheets(): BatchControl {
     const currentBatch = this.batches[this.nextBatchIndex % this.batches.length]
     this.nextBatchIndex += 1
     let sheetIndex = 0
@@ -127,7 +127,7 @@ export default class LoopScanner implements Scanner {
     }
   }
 
-  public async calibrate(): Promise<boolean> {
+  async calibrate(): Promise<boolean> {
     return false
   }
 }

--- a/apps/module-scan/src/backup.ts
+++ b/apps/module-scan/src/backup.ts
@@ -15,17 +15,14 @@ const debug = makeDebug('module-scan:backup')
 export class Backup {
   private readonly entries = new Set<string>()
 
-  public constructor(
-    private readonly zip: ZipStream,
-    private readonly store: Store
-  ) {}
+  constructor(private readonly zip: ZipStream, private readonly store: Store) {}
 
   /**
    * Add an entry to the zip file from a static or stream data source.
    *
    * @param name the path of the file inside the zip file
    */
-  public async addEntry(
+  async addEntry(
     name: string,
     data: string | Buffer | NodeJS.ReadableStream
   ): Promise<void> {
@@ -52,7 +49,7 @@ export class Backup {
    * @param filepath the path to the file to add
    * @param name the path of the file inside the zip file
    */
-  public async addFileEntry(
+  async addFileEntry(
     filepath: string,
     name = basename(filepath)
   ): Promise<void> {
@@ -62,7 +59,7 @@ export class Backup {
   /**
    * Runs the backup.
    */
-  public async backup(): Promise<void> {
+  async backup(): Promise<void> {
     debug('starting a backup')
 
     const electionDefinition = await this.store.getElectionDefinition()

--- a/apps/module-scan/src/cli/util/spinner.ts
+++ b/apps/module-scan/src/cli/util/spinner.ts
@@ -9,7 +9,7 @@ export default class Spinner {
   private readonly parts: readonly TextProvider[]
   private readonly deinits: readonly (() => void)[]
 
-  public constructor(private readonly spinner: Ora, ...parts: TextProvider[]) {
+  constructor(private readonly spinner: Ora, ...parts: TextProvider[]) {
     this.parts = parts
     const update = (): void => this.update()
     this.deinits = parts
@@ -17,11 +17,11 @@ export default class Spinner {
       .filter((deinit): deinit is () => void => !!deinit)
   }
 
-  public update(): void {
+  update(): void {
     this.spinner.text = this.parts.map((part) => part.toString()).join('')
   }
 
-  public succeed(): void {
+  succeed(): void {
     this.spinner.succeed()
     for (const deinit of this.deinits) {
       deinit()

--- a/apps/module-scan/src/importer.ts
+++ b/apps/module-scan/src/importer.ts
@@ -69,7 +69,7 @@ export default class Importer {
   private workerPoolProvider: () => WorkerPool<workers.Input, workers.Output>
   private interpreterReady = true
 
-  public constructor({
+  constructor({
     workspace,
     scanner,
     workerPoolProvider = (): WorkerPool<workers.Input, workers.Output> =>
@@ -101,7 +101,7 @@ export default class Importer {
     return this.workerPool
   }
 
-  public async addHmpbTemplates(
+  async addHmpbTemplates(
     pdf: Buffer,
     metadata: BallotMetadata
   ): Promise<BallotPageLayout[]> {
@@ -152,27 +152,25 @@ export default class Importer {
   /**
    * Tell the importer that we have all the templates
    */
-  public async doneHmpbTemplates(): Promise<void> {
+  async doneHmpbTemplates(): Promise<void> {
     await this.getWorkerPool()
   }
 
   /**
    * Sets the election information used to encode and decode ballots.
    */
-  public async configure(
-    electionDefinition: ElectionDefinition
-  ): Promise<void> {
+  async configure(electionDefinition: ElectionDefinition): Promise<void> {
     await this.workspace.store.setElection(electionDefinition)
   }
 
-  public async setTestMode(testMode: boolean): Promise<void> {
+  async setTestMode(testMode: boolean): Promise<void> {
     debug('setting test mode to %s', testMode)
     await this.doZero()
     await this.workspace.store.setTestMode(testMode)
     await this.restoreConfig()
   }
 
-  public async setSkipElectionHashCheck(
+  async setSkipElectionHashCheck(
     skipElectionHashCheck: boolean
   ): Promise<void> {
     debug(
@@ -182,7 +180,7 @@ export default class Importer {
     await this.workspace.store.setSkipElectionHashCheck(skipElectionHashCheck)
   }
 
-  public async setMarkThresholdOverrides(
+  async setMarkThresholdOverrides(
     markThresholds: Optional<MarkThresholds>
   ): Promise<void> {
     debug('setting mark thresholds overrides to %s', markThresholds)
@@ -193,7 +191,7 @@ export default class Importer {
   /**
    * Restore configuration from the store.
    */
-  public async restoreConfig(): Promise<void> {
+  async restoreConfig(): Promise<void> {
     this.invalidateInterpreterConfig()
     await this.getWorkerPool()
   }
@@ -217,7 +215,7 @@ export default class Importer {
     }
   }
 
-  public async importFile(
+  async importFile(
     batchId: string,
     frontImagePath: string,
     backImagePath: string
@@ -430,9 +428,7 @@ export default class Importer {
     }
   }
 
-  public async getNextAdjudicationCastability(): Promise<
-    Castability | undefined
-  > {
+  async getNextAdjudicationCastability(): Promise<Castability | undefined> {
     const sheet = await this.workspace.store.getNextAdjudicationSheet()
     if (sheet) {
       return checkSheetCastability([
@@ -445,7 +441,7 @@ export default class Importer {
   /**
    * Create a new batch and begin the scanning process
    */
-  public async startImport(): Promise<string> {
+  async startImport(): Promise<string> {
     const election = await this.workspace.store.getElectionDefinition()
 
     if (!election) {
@@ -481,7 +477,7 @@ export default class Importer {
   /**
    * Continue the existing scanning process
    */
-  public async continueImport(override = false): Promise<void> {
+  async continueImport(override = false): Promise<void> {
     const sheet = await this.workspace.store.getNextAdjudicationSheet()
 
     if (sheet) {
@@ -509,7 +505,7 @@ export default class Importer {
   /**
    * this is really for testing
    */
-  public async waitForEndOfBatchOrScanningPause(): Promise<void> {
+  async waitForEndOfBatchOrScanningPause(): Promise<void> {
     if (!this.batchId) {
       return
     }
@@ -528,14 +524,14 @@ export default class Importer {
    *
    * @returns whether the calibration succeeded
    */
-  public async doCalibrate(): Promise<boolean> {
+  async doCalibrate(): Promise<boolean> {
     return await this.scanner.calibrate()
   }
 
   /**
    * Export the current CVRs to a string.
    */
-  public async doExport(): Promise<string> {
+  async doExport(): Promise<string> {
     const election = await this.workspace.store.getElectionDefinition()
 
     if (!election) {
@@ -550,7 +546,7 @@ export default class Importer {
   /**
    * Reset all the data, both in the store and the ballot images.
    */
-  public async doZero(): Promise<void> {
+  async doZero(): Promise<void> {
     await this.workspace.store.zero()
     await this.setMarkThresholdOverrides(undefined)
     fsExtra.emptyDirSync(this.workspace.ballotImagesPath)
@@ -559,7 +555,7 @@ export default class Importer {
   /**
    * Get the imported batches and current election info, if any.
    */
-  public async getStatus(): Promise<ScanStatus> {
+  async getStatus(): Promise<ScanStatus> {
     const electionDefinition = await this.workspace.store.getElectionDefinition()
     const batches = await this.workspace.store.batchStatus()
     const adjudication = await this.workspace.store.adjudicationStatus()
@@ -579,7 +575,7 @@ export default class Importer {
   /**
    * Resets all data like `doZero`, removes election info, and stops importing.
    */
-  public async unconfigure(): Promise<void> {
+  async unconfigure(): Promise<void> {
     this.invalidateInterpreterConfig()
     await this.doZero()
     await this.workspace.store.reset() // destroy all data

--- a/apps/module-scan/src/interpreter.ts
+++ b/apps/module-scan/src/interpreter.ts
@@ -173,7 +173,7 @@ export default class Interpreter {
   private markThresholds: MarkThresholds
   private adjudicationReasons: readonly AdjudicationReason[]
 
-  public constructor({
+  constructor({
     election,
     electionHash,
     testMode,
@@ -240,7 +240,7 @@ export default class Interpreter {
     return layout
   }
 
-  public async interpretFile({
+  async interpretFile({
     ballotImagePath,
     ballotImageFile,
     detectQrcodeResult,

--- a/apps/module-scan/src/scanners/fujitsu.ts
+++ b/apps/module-scan/src/scanners/fujitsu.ts
@@ -43,7 +43,7 @@ export class FujitsuScanner implements Scanner {
   private readonly pageSize: ScannerPageSize
   private readonly mode?: ScannerMode
 
-  public constructor({
+  constructor({
     format = ScannerImageFormat.JPEG,
     pageSize = ScannerPageSize.Letter,
     mode,
@@ -53,11 +53,11 @@ export class FujitsuScanner implements Scanner {
     this.mode = mode
   }
 
-  public async getStatus(): Promise<ScannerStatus> {
+  async getStatus(): Promise<ScannerStatus> {
     return ScannerStatus.Unknown
   }
 
-  public scanSheets(directory = dirSync().name): BatchControl {
+  scanSheets(directory = dirSync().name): BatchControl {
     const args: string[] = [
       '-d',
       'fujitsu',
@@ -168,7 +168,7 @@ export class FujitsuScanner implements Scanner {
     }
   }
 
-  public async calibrate(): Promise<boolean> {
+  async calibrate(): Promise<boolean> {
     return false
   }
 }

--- a/apps/module-scan/src/scanners/plustek.ts
+++ b/apps/module-scan/src/scanners/plustek.ts
@@ -20,7 +20,7 @@ export type ScannerClientProvider = Provider<Result<ScannerClient, Error>>
 export class PlustekScanner implements Scanner {
   private statusOverride?: ScannerStatus
 
-  public constructor(
+  constructor(
     private readonly clientProvider: Provider<Result<ScannerClient, Error>>,
     private readonly alwaysHoldOnReject = false
   ) {}
@@ -59,7 +59,7 @@ export class PlustekScanner implements Scanner {
       : ScannerStatus.Error
   }
 
-  public async getStatus(): Promise<ScannerStatus> {
+  async getStatus(): Promise<ScannerStatus> {
     if (this.statusOverride) {
       debug(
         'PlustekScanner#getStatus: using override status: %s',
@@ -72,7 +72,7 @@ export class PlustekScanner implements Scanner {
     return await this.getHardwareStatus()
   }
 
-  public scanSheets(directory?: string): BatchControl {
+  scanSheets(directory?: string): BatchControl {
     debug('scanSheets: ignoring directory: %s', directory)
 
     const waitForStatus = async (
@@ -263,7 +263,7 @@ export class PlustekScanner implements Scanner {
     }
   }
 
-  public async calibrate(): Promise<boolean> {
+  async calibrate(): Promise<boolean> {
     debug('PlustekScanner#calibrate BEGIN')
     const clientResult = await this.clientProvider.get()
 

--- a/apps/module-scan/src/util/Lines.ts
+++ b/apps/module-scan/src/util/Lines.ts
@@ -23,11 +23,11 @@ interface LineEmitter {
 export default class Lines extends EventEmitter implements LineEmitter {
   private buffer = ''
 
-  public constructor(private readonly terminator = '\n') {
+  constructor(private readonly terminator = '\n') {
     super()
   }
 
-  public add(data: string): void {
+  add(data: string): void {
     let cursor = 0
     let nextTerminator: number
 
@@ -47,7 +47,7 @@ export default class Lines extends EventEmitter implements LineEmitter {
     this.buffer += data.slice(cursor)
   }
 
-  public end(): void {
+  end(): void {
     if (this.buffer.length) {
       this.emit('line', this.buffer)
       this.buffer = ''

--- a/apps/module-scan/src/util/MultiMap.ts
+++ b/apps/module-scan/src/util/MultiMap.ts
@@ -21,7 +21,7 @@ export default class MultiMap<K extends string[] = string[], V = unknown> {
   /**
    * Gets all values for `key`.
    */
-  public get(key: K): Set<V> | undefined {
+  get(key: K): Set<V> | undefined {
     const valueMapKey = this.valueMapKey(key)
     const values = this.valueMap.get(valueMapKey)
     return values && new Set([...values])
@@ -30,7 +30,7 @@ export default class MultiMap<K extends string[] = string[], V = unknown> {
   /**
    * Adds `value` to the list of values for `key`.
    */
-  public set(key: K, value: V): this {
+  set(key: K, value: V): this {
     const valueMapKey = this.valueMapKey(key)
     this.valueMap.set(
       valueMapKey,
@@ -42,14 +42,14 @@ export default class MultiMap<K extends string[] = string[], V = unknown> {
   /**
    * Delete all values for `key`.
    */
-  public delete(key: K): boolean
+  delete(key: K): boolean
 
   /**
    * Delete a single value for `key`.
    */
-  public delete(key: K, value: V): boolean
+  delete(key: K, value: V): boolean
 
-  public delete(key: K, value?: V): boolean {
+  delete(key: K, value?: V): boolean {
     const valueMapKey = this.valueMapKey(key)
     if (typeof value === 'undefined') {
       return this.valueMap.delete(valueMapKey)
@@ -64,28 +64,28 @@ export default class MultiMap<K extends string[] = string[], V = unknown> {
   /**
    * Clear all entries.
    */
-  public clear(): void {
+  clear(): void {
     this.valueMap.clear()
   }
 
   /**
    * The number of unique keys.
    */
-  public get size(): number {
+  get size(): number {
     return this.valueMap.size
   }
 
   /**
    * The number of unique keys.
    */
-  public get keySize(): number {
+  get keySize(): number {
     return this.size
   }
 
   /**
    * The number of values in all keys.
    */
-  public get valueSize(): number {
+  get valueSize(): number {
     return [...this.valueMap.values()].reduce(
       (size, values) => size + values.size,
       0
@@ -95,7 +95,7 @@ export default class MultiMap<K extends string[] = string[], V = unknown> {
   /**
    * Iterates through keys/values in the order in which keys were added.
    */
-  public *[Symbol.iterator](): Generator<[K, Set<V>]> {
+  *[Symbol.iterator](): Generator<[K, Set<V>]> {
     for (const [valueMapKey, values] of this.valueMap) {
       const key = this.keyMap.get(valueMapKey)
       assert(key)

--- a/apps/module-scan/src/util/StreamLines.ts
+++ b/apps/module-scan/src/util/StreamLines.ts
@@ -2,7 +2,7 @@ import { Readable } from 'stream'
 import Lines from './Lines'
 
 export default class StreamLines extends Lines {
-  public constructor(input: Readable, terminator?: string) {
+  constructor(input: Readable, terminator?: string) {
     super(terminator)
 
     input

--- a/apps/module-scan/src/workers/pool/ChildProcessWorkerOps.ts
+++ b/apps/module-scan/src/workers/pool/ChildProcessWorkerOps.ts
@@ -4,21 +4,21 @@ import * as json from '../json-serialization'
 import { WorkerOps } from './types'
 
 export class ChildProcessWorkerOps<I> implements WorkerOps<I, ChildProcess> {
-  public constructor(private readonly main: string) {}
+  constructor(private readonly main: string) {}
 
-  public start(): ChildProcess {
+  start(): ChildProcess {
     return fork(join(__dirname, '../child-process-worker.js'), [this.main])
   }
 
-  public stop(worker: ChildProcess): void {
+  stop(worker: ChildProcess): void {
     worker.kill()
   }
 
-  public send(worker: ChildProcess, message: I): void {
+  send(worker: ChildProcess, message: I): void {
     worker.send(json.serialize(message))
   }
 
-  public describe(worker: ChildProcess): string {
+  describe(worker: ChildProcess): string {
     return `ChildProcess { pid: ${worker.pid} }`
   }
 }

--- a/apps/module-scan/src/workers/pool/InlineWorkerOps.ts
+++ b/apps/module-scan/src/workers/pool/InlineWorkerOps.ts
@@ -6,20 +6,20 @@ import { WorkerOps } from './types'
 export class InlineWorkerOps<I, O> implements WorkerOps<I, EventEmitter> {
   private workerInstance: EventEmitter
 
-  public constructor(private readonly call: (input: I) => Promise<O>) {
+  constructor(private readonly call: (input: I) => Promise<O>) {
     this.workerInstance = new EventEmitter()
   }
 
-  public start(): EventEmitter {
+  start(): EventEmitter {
     return this.workerInstance
   }
 
-  public stop(worker: EventEmitter): void {
+  stop(worker: EventEmitter): void {
     assert.strictEqual(worker, this.workerInstance)
     worker.removeAllListeners()
   }
 
-  public async send(worker: EventEmitter, message: I): Promise<void> {
+  async send(worker: EventEmitter, message: I): Promise<void> {
     assert.strictEqual(worker, this.workerInstance)
     try {
       const output = await this.call(
@@ -31,7 +31,7 @@ export class InlineWorkerOps<I, O> implements WorkerOps<I, EventEmitter> {
     }
   }
 
-  public describe(): string {
+  describe(): string {
     return 'Worker { inline: true }'
   }
 }

--- a/apps/module-scan/src/workers/pool/WorkerPool.ts
+++ b/apps/module-scan/src/workers/pool/WorkerPool.ts
@@ -19,7 +19,7 @@ export default class WorkerPool<I, O, W extends EventEmitter = EventEmitter> {
     private readonly size: number
   ) {}
 
-  public start(): void {
+  start(): void {
     if (this.workers) {
       throw new Error('cannot start when already started')
     }
@@ -37,7 +37,7 @@ export default class WorkerPool<I, O, W extends EventEmitter = EventEmitter> {
     debug('started %d worker(s)', this.workers.size)
   }
 
-  public stop(): void {
+  stop(): void {
     const { workers } = this
 
     if (!workers) {
@@ -169,7 +169,7 @@ export default class WorkerPool<I, O, W extends EventEmitter = EventEmitter> {
     claimedWorkers.delete(worker)
   }
 
-  public async call(input: I): Promise<O> {
+  async call(input: I): Promise<O> {
     const traceId = uuid()
     debug(
       '[%s] call start: input=%s',
@@ -181,7 +181,7 @@ export default class WorkerPool<I, O, W extends EventEmitter = EventEmitter> {
     return await this.callWorker(worker, input, traceId)
   }
 
-  public async callAll(input: I): Promise<O[]> {
+  async callAll(input: I): Promise<O[]> {
     const { workers, claimedWorkers } = this
 
     if (!workers || !claimedWorkers) {

--- a/apps/module-scan/src/workers/pool/WorkerThreadWorkerOps.ts
+++ b/apps/module-scan/src/workers/pool/WorkerThreadWorkerOps.ts
@@ -4,23 +4,23 @@ import { WorkerOps } from './types'
 import * as json from '../json-serialization'
 
 export class WorkerThreadWorkerOps<I> implements WorkerOps<I, Worker> {
-  public constructor(private readonly main: string) {}
+  constructor(private readonly main: string) {}
 
-  public start(): Worker {
+  start(): Worker {
     return new Worker(join(__dirname, '../worker-thread-worker.js'), {
       workerData: { __workerPath: this.main },
     })
   }
 
-  public stop(worker: Worker): void {
+  stop(worker: Worker): void {
     void worker.terminate()
   }
 
-  public send(worker: Worker, message: I): void {
+  send(worker: Worker, message: I): void {
     worker.postMessage(json.serialize(message))
   }
 
-  public describe(worker: Worker): string {
+  describe(worker: Worker): string {
     return `Worker { threadId: ${worker.threadId} }`
   }
 }

--- a/apps/module-scan/test/util/mocks.ts
+++ b/apps/module-scan/test/util/mocks.ts
@@ -46,14 +46,14 @@ class ScannerSessionPlan {
   private steps: ScanSessionStep[] = []
   private ended = false
 
-  public getStep(index: number): ScanSessionStep {
+  getStep(index: number): ScanSessionStep {
     return this.steps[index]
   }
 
   /**
    * Adds a scanning step to the session.
    */
-  public sheet(sheet: SheetOf<string>): this {
+  sheet(sheet: SheetOf<string>): this {
     if (this.ended) {
       throw new Error('cannot add a sheet scan step to an ended session')
     }
@@ -64,7 +64,7 @@ class ScannerSessionPlan {
   /**
    * Adds an error step to the session.
    */
-  public error(error: Error): this {
+  error(error: Error): this {
     if (this.ended) {
       throw new Error('cannot add an error step to an ended session')
     }
@@ -72,7 +72,7 @@ class ScannerSessionPlan {
     return this
   }
 
-  public end(): void {
+  end(): void {
     this.ended = true
   }
 

--- a/libs/ballot-encoder/src/bits/BitCursor.ts
+++ b/libs/ballot-encoder/src/bits/BitCursor.ts
@@ -4,52 +4,52 @@ import { makeMasks } from './utils'
 export default class BitCursor {
   private offset = 0
 
-  public next(): this {
+  next(): this {
     return this.advance(1)
   }
 
-  public prev(): this {
+  prev(): this {
     return this.advance(-1)
   }
 
-  public advance(bitOffset: number): this {
+  advance(bitOffset: number): this {
     this.offset += bitOffset
     return this
   }
 
-  public set(offset: number): this {
+  set(offset: number): this {
     this.offset = offset
     return this
   }
 
-  public get isByteStart(): boolean {
+  get isByteStart(): boolean {
     return this.offset % Uint8Size === 0
   }
 
-  public get combinedBitOffset(): number {
+  get combinedBitOffset(): number {
     return this.offset
   }
 
-  public get bitOffset(): Uint8Index {
+  get bitOffset(): Uint8Index {
     if (this.offset < 0) {
       return (Uint8Size - (-this.offset % Uint8Size)) as Uint8Index
     }
     return (this.offset % Uint8Size) as Uint8Index
   }
 
-  public get byteOffset(): number {
+  get byteOffset(): number {
     return (this.offset - this.bitOffset) / Uint8Size
   }
 
-  public mask(bit: Uint1 = 1): Uint8 {
+  mask(bit: Uint1 = 1): Uint8 {
     return bit ? BitCursor.uint8Masks[this.bitOffset] : 0
   }
 
-  public copy(): BitCursor {
+  copy(): BitCursor {
     return new BitCursor().set(this.combinedBitOffset)
   }
 
-  public static uint8Masks: readonly [
+  static uint8Masks: readonly [
     Uint8,
     Uint8,
     Uint8,

--- a/libs/ballot-encoder/src/bits/BitReader.ts
+++ b/libs/ballot-encoder/src/bits/BitReader.ts
@@ -13,12 +13,12 @@ export default class BitReader {
   /**
    * @param data a buffer to read data from
    */
-  public constructor(private data: Uint8Array) {}
+  constructor(private data: Uint8Array) {}
 
   /**
    * Reads a Uint1 and moves the internal cursor forward one bit.
    */
-  public readUint1(): Uint1 {
+  readUint1(): Uint1 {
     const byte = this.getCurrentByte()
     const mask = this.cursor.mask()
 
@@ -30,14 +30,14 @@ export default class BitReader {
   /**
    * Reads a number by reading 8 bits.
    */
-  public readUint8(): Uint8 {
+  readUint8(): Uint8 {
     return this.readUint({ size: Uint8Size }) as Uint8
   }
 
   /**
    * Reads a boolean by reading a bit and returning whether the bit was set.
    */
-  public readBoolean(): boolean {
+  readBoolean(): boolean {
     return this.readUint1() === 1
   }
 
@@ -57,9 +57,9 @@ export default class BitReader {
    * bits.readUint({ size: 8 })    // reads next 8 bits:  0xf0
    * bits.readUint({ size: 4 })    // reads last 4 bits:  0x0f
    */
-  public readUint({ max }: { max: number }): number
-  public readUint({ size }: { size: number }): number
-  public readUint({ max, size }: { max?: number; size?: number }): number {
+  readUint({ max }: { max: number }): number
+  readUint({ size }: { size: number }): number
+  readUint({ max, size }: { max?: number; size?: number }): number {
     const sizeofUint = this.sizeofUint({ max, size })
 
     // Optimize for the case of reading a byte straight from the underlying buffer.
@@ -111,15 +111,12 @@ export default class BitReader {
    * const bits = new BitReader(Uint8Array.of(104, 105))
    * bits.readString({ length: 2 }) // "hi"
    */
-  public readString(): string
-  public readString(options: { encoding?: Encoding }): string
-  public readString(options: {
-    encoding?: Encoding
-    maxLength?: number
-  }): string
+  readString(): string
+  readString(options: { encoding?: Encoding }): string
+  readString(options: { encoding?: Encoding; maxLength?: number }): string
 
-  public readString(options: { encoding?: Encoding; length?: number }): string
-  public readString({
+  readString(options: { encoding?: Encoding; length?: number }): string
+  readString({
     encoding = UTF8Encoding,
     maxLength = (1 << Uint8Size) - 1,
     length,
@@ -143,11 +140,11 @@ export default class BitReader {
    *
    * @returns true if the uints matched and were skipped, false otherwise
    */
-  public skipUint(expected: number, { max }: { max: number }): boolean
-  public skipUint(expected: number, { size }: { size: number }): boolean
-  public skipUint(expected: number[], { max }: { max: number }): boolean
-  public skipUint(expected: number[], { size }: { size: number }): boolean
-  public skipUint(
+  skipUint(expected: number, { max }: { max: number }): boolean
+  skipUint(expected: number, { size }: { size: number }): boolean
+  skipUint(expected: number[], { max }: { max: number }): boolean
+  skipUint(expected: number[], { size }: { size: number }): boolean
+  skipUint(
     expected: number | number[],
     { max, size }: { max?: number; size?: number }
   ): boolean {
@@ -190,7 +187,7 @@ export default class BitReader {
    *
    * @returns true if the bits matched and were skipped, false otherwise
    */
-  public skipUint1(...uint1s: number[]): boolean {
+  skipUint1(...uint1s: number[]): boolean {
     return this.skipUint(uint1s, { size: 1 })
   }
 
@@ -199,7 +196,7 @@ export default class BitReader {
    *
    * @returns true if the bytes matched and were skipped, false otherwise
    */
-  public skipUint8(...uint8s: number[]): boolean {
+  skipUint8(...uint8s: number[]): boolean {
     return this.skipUint(uint8s, { size: Uint8Size })
   }
 
@@ -207,7 +204,7 @@ export default class BitReader {
    * Determines whether there is any more data to read. If the result is
    * `false`, then any call to read data will throw an exception.
    */
-  public canRead(size = 1): boolean {
+  canRead(size = 1): boolean {
     const totalBits = this.data.length * Uint8Size
     const readBits = this.cursor.combinedBitOffset
     return readBits + size <= totalBits

--- a/libs/ballot-encoder/src/bits/BitWriter.ts
+++ b/libs/ballot-encoder/src/bits/BitWriter.ts
@@ -25,7 +25,7 @@ export default class BitWriter {
   /**
    * Writes bits.
    */
-  public writeUint1(...uint1s: Uint1[]): this {
+  writeUint1(...uint1s: Uint1[]): this {
     for (const uint1 of uint1s) {
       const mask = this.cursor.mask(uint1)
       this.nextByte |= mask
@@ -43,7 +43,7 @@ export default class BitWriter {
   /**
    * Writes `1` if given `true`, `0` otherwise.
    */
-  public writeBoolean(...booleans: boolean[]): this {
+  writeBoolean(...booleans: boolean[]): this {
     for (const boolean of booleans) {
       this.writeUint1(boolean ? 1 : 0)
     }
@@ -54,7 +54,7 @@ export default class BitWriter {
   /**
    * Writes data from a `Uint8` by writing 8 bits.
    */
-  public writeUint8(...uint8s: Uint8[]): this {
+  writeUint8(...uint8s: Uint8[]): this {
     for (const uint8 of uint8s) {
       this.writeUint(uint8, { size: Uint8Size })
     }
@@ -73,9 +73,9 @@ export default class BitWriter {
    * bits.writeUint(23, { max: 30 })  // writes `10111`
    * bits.writeUint(99, { size: 8 })  // writes `01100011`
    */
-  public writeUint(number: number, { max }: { max: number }): this
-  public writeUint(number: number, { size }: { size: number }): this
-  public writeUint(
+  writeUint(number: number, { max }: { max: number }): this
+  writeUint(number: number, { size }: { size: number }): this
+  writeUint(
     number: number,
     { max, size }: { max?: number; size?: number }
   ): this {
@@ -137,14 +137,14 @@ export default class BitWriter {
    *                                                                          ↑ ↑↑
    *                                                                   length=2 'h''i'
    */
-  public writeString(string: string): this
-  public writeString(string: string, options: { encoding?: Encoding }): this
-  public writeString(
+  writeString(string: string): this
+  writeString(string: string, options: { encoding?: Encoding }): this
+  writeString(
     string: string,
     options: { encoding?: Encoding; includeLength: false; length: number }
   ): this
 
-  public writeString(
+  writeString(
     string: string,
     options: {
       encoding?: Encoding
@@ -153,7 +153,7 @@ export default class BitWriter {
     }
   ): this
 
-  public writeString(
+  writeString(
     string: string,
     {
       encoding = UTF8Encoding,
@@ -202,7 +202,7 @@ export default class BitWriter {
    *   .with(writer => encodeSomething(writer))
    *   .writeBoolean(false)
    */
-  public with(callback: (writer: this) => void): this {
+  with(callback: (writer: this) => void): this {
     callback(this)
     return this
   }
@@ -210,7 +210,7 @@ export default class BitWriter {
   /**
    * Converts the data written to this `BitWriter` to a `Uint8Array`.
    */
-  public toUint8Array(): Uint8Array {
+  toUint8Array(): Uint8Array {
     const pendingByte = this.getPendingByte()
 
     if (typeof pendingByte === 'undefined') {
@@ -233,7 +233,7 @@ export default class BitWriter {
     return this.nextByte
   }
 
-  public debug(label?: string): this {
+  debug(label?: string): this {
     if (label) {
       // eslint-disable-next-line no-console
       console.log(label)

--- a/libs/ballot-encoder/src/bits/encoding.ts
+++ b/libs/ballot-encoder/src/bits/encoding.ts
@@ -48,13 +48,13 @@ export class CustomEncoding implements Encoding {
   /**
    * The maximum character code representable by this class.
    */
-  public static MAX_CODE = (1 << (Uint8Array.BYTES_PER_ELEMENT * Uint8Size)) - 1
-  public readonly bitsPerElement: number
+  static MAX_CODE = (1 << (Uint8Array.BYTES_PER_ELEMENT * Uint8Size)) - 1
+  readonly bitsPerElement: number
 
   /**
    * @param chars a string of representable characters without duplicates
    */
-  public constructor(private readonly chars: string) {
+  constructor(private readonly chars: string) {
     CustomEncoding.validateChars(chars)
     this.bitsPerElement = sizeof(chars.length - 1)
   }
@@ -86,7 +86,7 @@ export class CustomEncoding implements Encoding {
    *
    * @param string a string containing only representable characters
    */
-  public encode(string: string): Uint8Array {
+  encode(string: string): Uint8Array {
     const codes = new Uint8Array(string.length)
 
     for (let i = 0; i < string.length; i += 1) {
@@ -113,7 +113,7 @@ export class CustomEncoding implements Encoding {
    *
    * @param data a series of character codes representing characters in this encoding
    */
-  public decode(data: Uint8Array): string {
+  decode(data: Uint8Array): string {
     return Array.from(data)
       .map((code, i) => {
         if (code >= this.chars.length) {

--- a/libs/eslint-plugin-vx/docs/rules/gts-no-public-modifier.md
+++ b/libs/eslint-plugin-vx/docs/rules/gts-no-public-modifier.md
@@ -1,0 +1,30 @@
+# Disallows use of `public` accessibility modifiers on class properties (`vx/gts-no-public-modifiers`)
+
+This rule is from
+[Google TypeScript Style Guide section "Visibility"](https://google.github.io/styleguide/tsguide.html#visibility):
+
+> TypeScript symbols are public by default. Never use the `public` modifier
+> except when declaring non-readonly public parameter properties (in
+> constructors).
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```ts
+class Foo {
+  public bar = new Bar() // BAD: public modifier not needed
+
+  constructor(public readonly baz: Baz) {} // BAD: readonly implies it's a property which defaults to public
+}
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+class Foo {
+  bar = new Bar() // GOOD: public modifier not needed
+
+  constructor(public baz: Baz) {} // public modifier allowed
+}
+```

--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -37,6 +37,7 @@ export = {
   rules: {
     'vx/gts-no-array-constructor': 'error',
     'vx/gts-no-private-fields': 'error',
+    'vx/gts-no-public-modifier': 'error',
     'vx/gts-parameter-properties': 'error',
     'vx/no-array-sort-mutation': 'error',
     'vx/no-assert-truthiness': 'error',

--- a/libs/eslint-plugin-vx/src/rules/gts-no-public-modifier.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts-no-public-modifier.ts
@@ -1,0 +1,79 @@
+import {
+  AST_NODE_TYPES,
+  ESLintUtils,
+  TSESTree,
+} from '@typescript-eslint/experimental-utils'
+import { strict as assert } from 'assert'
+
+export default ESLintUtils.RuleCreator(
+  () =>
+    'https://github.com/votingworks/vxsuite/blob/main/libs/eslint-plugin-vx/docs/rules/gts-no-public-modifier.md'
+)({
+  name: 'gts-no-public-modifier',
+  meta: {
+    docs: {
+      description:
+        'Disallows use of `public` accessibility modifiers on class properties',
+      category: 'Best Practices',
+      recommended: 'error',
+      suggestion: false,
+      requiresTypeChecking: false,
+    },
+    fixable: 'code',
+    messages: {
+      noPublicModifier:
+        'Do not use `public` modifier on class properties; they are already public by default',
+    },
+    schema: [],
+    type: 'problem',
+  },
+  defaultOptions: [],
+
+  create(context) {
+    const sourceCode = context.getSourceCode()
+
+    function reportPublicToken(node: TSESTree.Node): void {
+      const [publicToken, nextToken] = sourceCode.getFirstTokens(node, {
+        count: 2,
+      })
+      assert.equal(publicToken?.value, 'public' as const)
+      assert(nextToken)
+
+      context.report({
+        node: publicToken,
+        messageId: 'noPublicModifier',
+        fix: (fixer) =>
+          fixer.removeRange([publicToken.range[0], nextToken.range[0]]),
+      })
+    }
+
+    function processNode(
+      node: TSESTree.ClassProperty | TSESTree.MethodDefinition
+    ): void {
+      if (node.accessibility === 'public') {
+        reportPublicToken(node)
+      }
+
+      if (
+        node.type === AST_NODE_TYPES.MethodDefinition &&
+        node.key.type === AST_NODE_TYPES.Identifier &&
+        node.key.name === 'constructor'
+      ) {
+        for (const param of node.value.params) {
+          if (
+            param.type === AST_NODE_TYPES.TSParameterProperty &&
+            param.accessibility === 'public' &&
+            param.readonly
+          ) {
+            reportPublicToken(param)
+          }
+        }
+      }
+    }
+
+    return {
+      ClassProperty: processNode,
+      MethodDefinition: processNode,
+    }
+  },
+})

--- a/libs/eslint-plugin-vx/src/rules/index.ts
+++ b/libs/eslint-plugin-vx/src/rules/index.ts
@@ -1,5 +1,6 @@
 import gtsNoArrayConstructor from './gts-no-array-constructor'
 import gtsNoPrivateFields from './gts-no-private-fields'
+import gtsNoPublicModifier from './gts-no-public-modifier'
 import gtsParameterProperties from './gts-parameter-properties'
 import noArraySortMutation from './no-array-sort-mutation'
 import noAssertStringOrNumber from './no-assert-truthiness'
@@ -8,6 +9,7 @@ import noFloatingVoids from './no-floating-results'
 export default {
   'gts-no-array-constructor': gtsNoArrayConstructor,
   'gts-no-private-fields': gtsNoPrivateFields,
+  'gts-no-public-modifier': gtsNoPublicModifier,
   'gts-parameter-properties': gtsParameterProperties,
   'no-array-sort-mutation': noArraySortMutation,
   'no-assert-truthiness': noAssertStringOrNumber,

--- a/libs/eslint-plugin-vx/tests/rules/gts-no-public-modifier.test.ts
+++ b/libs/eslint-plugin-vx/tests/rules/gts-no-public-modifier.test.ts
@@ -1,0 +1,61 @@
+import { ESLintUtils } from '@typescript-eslint/experimental-utils'
+import { join } from 'path'
+import rule from '../../src/rules/gts-no-public-modifier'
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    tsconfigRootDir: join(__dirname, '../fixtures'),
+    project: './tsconfig.json',
+  },
+  parser: '@typescript-eslint/parser',
+})
+
+ruleTester.run('gts-no-public-modifier', rule, {
+  valid: [
+    {
+      code: `class A {}`,
+    },
+    {
+      code: `class A { private a = 1 }`,
+    },
+    {
+      code: `class A { protected a = 1 }`,
+    },
+    {
+      code: `class A { constructor(public a = 1) {} }`,
+    },
+  ],
+  invalid: [
+    {
+      code: `class A { public a = 1 }`,
+      output: `class A { a = 1 }`,
+      errors: [{ line: 1, messageId: 'noPublicModifier' }],
+    },
+    {
+      code: `class A { public readonly a = 1 }`,
+      output: `class A { readonly a = 1 }`,
+      errors: [{ line: 1, messageId: 'noPublicModifier' }],
+    },
+    {
+      code: `class A { public a() {} }`,
+      output: `class A { a() {} }`,
+      errors: [{ line: 1, messageId: 'noPublicModifier' }],
+    },
+    {
+      code: `class A { public get a() {} }`,
+      output: `class A { get a() {} }`,
+      errors: [{ line: 1, messageId: 'noPublicModifier' }],
+    },
+    {
+      code: `class A { public constructor(public a = 1) {} }`,
+      output: `class A { constructor(public a = 1) {} }`,
+      errors: [{ line: 1, messageId: 'noPublicModifier' }],
+    },
+    {
+      code: `class A { constructor(public readonly a = 1) {} }`,
+      output: `class A { constructor(readonly a = 1) {} }`,
+      errors: [{ line: 1, messageId: 'noPublicModifier' }],
+    },
+  ],
+})

--- a/libs/hmpb-interpreter/src/Interpreter.ts
+++ b/libs/hmpb-interpreter/src/Interpreter.ts
@@ -110,9 +110,9 @@ export default class Interpreter {
   private readonly detectQRCode?: DetectQRCode
   private readonly markScoreVoteThreshold: number
 
-  public constructor(election: Election)
-  public constructor(options: Options)
-  public constructor(optionsOrElection: Options | Election) {
+  constructor(election: Election)
+  constructor(options: Options)
+  constructor(optionsOrElection: Options | Election) {
     if ('election' in optionsOrElection) {
       this.election = optionsOrElection.election
       this.detectQRCode =
@@ -136,15 +136,13 @@ export default class Interpreter {
    * printed from it. The template image should be an image of a blank ballot,
    * either scanned or otherwise rendered as an image.
    */
-  public async addTemplate(
+  async addTemplate(
     imageData: ImageData,
     metadata?: BallotPageMetadata,
     { flipped }?: { flipped?: boolean }
   ): Promise<BallotPageLayout>
-  public async addTemplate(
-    template: BallotPageLayout
-  ): Promise<BallotPageLayout>
-  public async addTemplate(
+  async addTemplate(template: BallotPageLayout): Promise<BallotPageLayout>
+  async addTemplate(
     imageDataOrTemplate: ImageData | BallotPageLayout,
     metadata?: BallotPageMetadata,
     { flipped }: { flipped?: boolean } = {}
@@ -197,7 +195,7 @@ export default class Interpreter {
    * from the image. The template image should be an image of a blank ballot,
    * either scanned or otherwise rendered as an image.
    */
-  public async interpretTemplate(
+  async interpretTemplate(
     imageData: ImageData,
     metadata?: BallotPageMetadata,
     { flipped = false } = {}
@@ -263,7 +261,7 @@ export default class Interpreter {
    * Determines whether enough of the template images have been added to allow
    * scanning a ballot with the given metadata.
    */
-  public canScanBallot(metadata: BallotPageMetadata): boolean {
+  canScanBallot(metadata: BallotPageMetadata): boolean {
     debug('canScanBallot metadata=%O', metadata)
 
     for (
@@ -299,7 +297,7 @@ export default class Interpreter {
   /**
    * Interprets an image as a ballot, returning information about the votes cast.
    */
-  public async interpretBallot(
+  async interpretBallot(
     imageData: ImageData,
     metadata?: BallotPageMetadata,
     {

--- a/libs/hmpb-interpreter/src/utils/KeyedMap.ts
+++ b/libs/hmpb-interpreter/src/utils/KeyedMap.ts
@@ -1,22 +1,22 @@
 export default class KeyedMap<Key, Value, ResolvedKey = string> {
   private map = new Map<ResolvedKey, Value>()
 
-  public constructor(private resolveKey: (key: Key) => ResolvedKey) {}
+  constructor(private resolveKey: (key: Key) => ResolvedKey) {}
 
-  public has(key: Key): boolean {
+  has(key: Key): boolean {
     return this.map.has(this.resolveKey(key))
   }
 
-  public get(key: Key): Value | undefined {
+  get(key: Key): Value | undefined {
     return this.map.get(this.resolveKey(key))
   }
 
-  public set(key: Key, value: Value): this {
+  set(key: Key, value: Value): this {
     this.map.set(this.resolveKey(key), value)
     return this
   }
 
-  public delete(key: Key): boolean {
+  delete(key: Key): boolean {
     return this.map.delete(this.resolveKey(key))
   }
 }

--- a/libs/hmpb-interpreter/src/utils/VisitedPoints.ts
+++ b/libs/hmpb-interpreter/src/utils/VisitedPoints.ts
@@ -1,11 +1,11 @@
 export class VisitedPoints {
   private data: Uint8Array[]
 
-  public constructor(private width: number, height: number) {
+  constructor(private width: number, height: number) {
     this.data = Array.from({ length: height })
   }
 
-  public add(x: number, y: number, value = true): boolean {
+  add(x: number, y: number, value = true): boolean {
     let row = this.data[y]
 
     if (!row) {
@@ -22,7 +22,7 @@ export class VisitedPoints {
     return result
   }
 
-  public has(x: number, y: number): boolean {
+  has(x: number, y: number): boolean {
     return this.data[y]?.[x] === 1
   }
 }

--- a/libs/hmpb-interpreter/test/fixtures.ts
+++ b/libs/hmpb-interpreter/test/fixtures.ts
@@ -9,17 +9,17 @@ export const adjacentMetadataFile = (imagePath: string): string =>
   adjacentFile('-metadata', imagePath, '.json')
 
 export class Fixture implements Input {
-  public constructor(private basePath: string) {}
+  constructor(private basePath: string) {}
 
-  public id(): string {
+  id(): string {
     return this.filePath()
   }
 
-  public filePath(): string {
+  filePath(): string {
     return this.basePath
   }
 
-  public async imageData({ flipped = false } = {}): Promise<ImageData> {
+  async imageData({ flipped = false } = {}): Promise<ImageData> {
     const imageData = await loadImageData(this.filePath())
     if (flipped) {
       flipVH(imageData)
@@ -27,7 +27,7 @@ export class Fixture implements Input {
     return imageData
   }
 
-  public async metadata(
+  async metadata(
     overrides: Partial<BallotPageMetadata> = {}
   ): Promise<BallotPageMetadata> {
     return {

--- a/libs/plustek-sdk/src/mocks.ts
+++ b/libs/plustek-sdk/src/mocks.ts
@@ -47,7 +47,7 @@ export class MockScannerClient implements ScannerClient {
   private toggleHoldDuration: number
   private passthroughDuration: number
 
-  public constructor({
+  constructor({
     toggleHoldDuration = 100,
     passthroughDuration = 1000,
   }: Options = {}) {
@@ -58,7 +58,7 @@ export class MockScannerClient implements ScannerClient {
   /**
    * "Connects" to the mock scanner, must be called before other interactions.
    */
-  public async connect(): Promise<void> {
+  async connect(): Promise<void> {
     debug('connecting')
     this.connected = true
   }
@@ -66,7 +66,7 @@ export class MockScannerClient implements ScannerClient {
   /**
    * "Disconnects" from the mock scanner.
    */
-  public async disconnect(): Promise<void> {
+  async disconnect(): Promise<void> {
     debug('disconnecting')
     this.connected = false
   }
@@ -74,7 +74,7 @@ export class MockScannerClient implements ScannerClient {
   /**
    * Loads a sheet with scan images from `files`.
    */
-  public async simulateLoadSheet(
+  async simulateLoadSheet(
     files: readonly string[]
   ): Promise<Result<void, Errors>> {
     debug('manualLoad files=%o', files)
@@ -103,7 +103,7 @@ export class MockScannerClient implements ScannerClient {
   /**
    * Removes a loaded sheet if present.
    */
-  public async simulateRemoveSheet(): Promise<Result<void, Errors>> {
+  async simulateRemoveSheet(): Promise<Result<void, Errors>> {
     debug('manualRemove')
 
     if (this.unresponsive) {
@@ -131,21 +131,21 @@ export class MockScannerClient implements ScannerClient {
    * cable removed or power turned off. Once a scanner is unresponsive it cannot
    * become responsive again, and a new client/connection must be established.
    */
-  public async simulateUnresponsive(): Promise<void> {
+  async simulateUnresponsive(): Promise<void> {
     this.unresponsive = true
   }
 
   /**
    * Determines whether the client is connected.
    */
-  public isConnected(): boolean {
+  isConnected(): boolean {
     return this.connected
   }
 
   /**
    * Gets the current paper status.
    */
-  public async getPaperStatus(): Promise<GetPaperStatusResult> {
+  async getPaperStatus(): Promise<GetPaperStatusResult> {
     debug('getPaperStatus')
 
     if (this.unresponsive) {
@@ -181,7 +181,7 @@ export class MockScannerClient implements ScannerClient {
    * Waits for a given `status` up to `timeout` milliseconds, checking every
    * `interval` milliseconds.
    */
-  public async waitForStatus({
+  async waitForStatus({
     status,
     interval = 50,
     timeout,
@@ -224,7 +224,7 @@ export class MockScannerClient implements ScannerClient {
   /**
    * Scans the currently-loaded sheet if any is present.
    */
-  public async scan(): Promise<ScanResult> {
+  async scan(): Promise<ScanResult> {
     debug('scan')
 
     if (this.unresponsive) {
@@ -263,7 +263,7 @@ export class MockScannerClient implements ScannerClient {
   /**
    * Accepts the currently-loaded sheet if any.
    */
-  public async accept(): Promise<AcceptResult> {
+  async accept(): Promise<AcceptResult> {
     debug('accept')
 
     if (this.unresponsive) {
@@ -301,7 +301,7 @@ export class MockScannerClient implements ScannerClient {
   /**
    * Rejects and optionally holds the currently-loaded sheet if any.
    */
-  public async reject({ hold }: { hold: boolean }): Promise<RejectResult> {
+  async reject({ hold }: { hold: boolean }): Promise<RejectResult> {
     debug('reject hold=%s', hold)
 
     if (this.unresponsive) {
@@ -342,7 +342,7 @@ export class MockScannerClient implements ScannerClient {
     return ok()
   }
 
-  public async calibrate(): Promise<CalibrateResult> {
+  async calibrate(): Promise<CalibrateResult> {
     debug('calibrate')
 
     if (this.unresponsive) {
@@ -380,7 +380,7 @@ export class MockScannerClient implements ScannerClient {
   /**
    * Closes the connection to the mock scanner.
    */
-  public async close(): Promise<CloseResult> {
+  async close(): Promise<CloseResult> {
     debug('close')
     this.connected = false
     return ok()

--- a/libs/utils/src/Card/MemoryCard.ts
+++ b/libs/utils/src/Card/MemoryCard.ts
@@ -16,7 +16,7 @@ export default class MemoryCard implements Card {
    * Reads basic information about the card, including whether one is present,
    * what its short value is and whether it has a long value.
    */
-  public async readStatus(): Promise<CardAPI> {
+  async readStatus(): Promise<CardAPI> {
     const { present, shortValue } = this
 
     if (present) {
@@ -36,7 +36,7 @@ export default class MemoryCard implements Card {
    * Reads the long value as an object, or `undefined` if there is no long
    * value and validates it using `schema`.
    */
-  public async readLongObject<T>(
+  async readLongObject<T>(
     schema: z.ZodSchema<T>
   ): Promise<Result<Optional<T>, SyntaxError | z.ZodError>> {
     const { longValue } = this
@@ -54,7 +54,7 @@ export default class MemoryCard implements Card {
    * Reads the long value as a string, or `undefined` if there is no long
    * value.
    */
-  public async readLongString(): Promise<Optional<string>> {
+  async readLongString(): Promise<Optional<string>> {
     const { longValue } = this
 
     if (!longValue) {
@@ -68,14 +68,14 @@ export default class MemoryCard implements Card {
    * Reads the long value as binary data, or `undefined` if there is no long
    * value.
    */
-  public async readLongUint8Array(): Promise<Optional<Uint8Array>> {
+  async readLongUint8Array(): Promise<Optional<Uint8Array>> {
     return this.longValue
   }
 
   /**
    * Writes a new short value to the card.
    */
-  public async writeShortValue(value: string): Promise<void> {
+  async writeShortValue(value: string): Promise<void> {
     if (!this.present) {
       throw new Error('cannot write short value when no card is present')
     }
@@ -86,7 +86,7 @@ export default class MemoryCard implements Card {
   /**
    * Writes a new long value as a serialized object.
    */
-  public async writeLongObject(value: unknown): Promise<void> {
+  async writeLongObject(value: unknown): Promise<void> {
     await this.writeLongUint8Array(
       new TextEncoder().encode(JSON.stringify(value))
     )
@@ -95,7 +95,7 @@ export default class MemoryCard implements Card {
   /**
    * Writes binary data to the long value.
    */
-  public async writeLongUint8Array(value: Uint8Array): Promise<void> {
+  async writeLongUint8Array(value: Uint8Array): Promise<void> {
     if (!this.present) {
       throw new Error('cannot write long value when no card is present')
     }
@@ -106,7 +106,7 @@ export default class MemoryCard implements Card {
   /**
    * Removes the simulated in-memory card.
    */
-  public removeCard(): this {
+  removeCard(): this {
     this.present = false
     this.shortValue = undefined
     this.longValue = undefined
@@ -116,7 +116,7 @@ export default class MemoryCard implements Card {
   /**
    * Inserts a simulated in-memory card with specified long and short values.
    */
-  public insertCard(
+  insertCard(
     shortValue?: string | unknown,
     longValue?: string | Uint8Array
   ): this {

--- a/libs/utils/src/Card/WebServiceCard.ts
+++ b/libs/utils/src/Card/WebServiceCard.ts
@@ -12,7 +12,7 @@ export default class WebServiceCard implements Card {
    * Reads basic information about the card, including whether one is present,
    * what its short value is and whether it has a long value.
    */
-  public async readStatus(): Promise<CardAPI> {
+  async readStatus(): Promise<CardAPI> {
     return await fetchJSON<CardAPI>('/card/read')
   }
 
@@ -20,7 +20,7 @@ export default class WebServiceCard implements Card {
    * Reads the long value as an object, or `undefined` if there is no long
    * value and validates it using `schema`.
    */
-  public async readLongObject<T>(
+  async readLongObject<T>(
     schema: z.ZodSchema<T>
   ): Promise<Result<Optional<T>, SyntaxError | z.ZodError>> {
     const response = await fetch('/card/read_long')
@@ -32,7 +32,7 @@ export default class WebServiceCard implements Card {
    * Reads the long value as a string, or `undefined` if there is no long
    * value.
    */
-  public async readLongString(): Promise<Optional<string>> {
+  async readLongString(): Promise<Optional<string>> {
     const response = await fetch('/card/read_long')
     const { longValue } = await response.json()
     return longValue || undefined
@@ -42,7 +42,7 @@ export default class WebServiceCard implements Card {
    * Reads the long value as binary data, or `undefined` if there is no long
    * value.
    */
-  public async readLongUint8Array(): Promise<Optional<Uint8Array>> {
+  async readLongUint8Array(): Promise<Optional<Uint8Array>> {
     const response = await fetch('/card/read_long_b64')
     const { longValue } = await response.json()
     return longValue ? toByteArray(longValue) : undefined
@@ -51,7 +51,7 @@ export default class WebServiceCard implements Card {
   /**
    * Writes a new short value to the card.
    */
-  public async writeShortValue(value: string): Promise<void> {
+  async writeShortValue(value: string): Promise<void> {
     await fetch('/card/write', {
       method: 'post',
       body: value,
@@ -62,7 +62,7 @@ export default class WebServiceCard implements Card {
   /**
    * Writes a new long value as a serialized object.
    */
-  public async writeLongObject(value: unknown): Promise<void> {
+  async writeLongObject(value: unknown): Promise<void> {
     await this.writeLongUint8Array(
       new TextEncoder().encode(JSON.stringify(value))
     )
@@ -71,7 +71,7 @@ export default class WebServiceCard implements Card {
   /**
    * Writes binary data to the long value.
    */
-  public async writeLongUint8Array(value: Uint8Array): Promise<void> {
+  async writeLongUint8Array(value: Uint8Array): Promise<void> {
     const longValueBase64 = fromByteArray(value)
     const formData = new FormData()
 

--- a/libs/utils/src/Hardware/KioskHardware.ts
+++ b/libs/utils/src/Hardware/KioskHardware.ts
@@ -5,21 +5,21 @@ import MemoryHardware from './MemoryHardware'
  * Implements the `Hardware` API by accessing it through the kiosk.
  */
 export default class KioskHardware extends MemoryHardware {
-  public constructor(private kiosk: KioskBrowser.Kiosk) {
+  constructor(private kiosk: KioskBrowser.Kiosk) {
     super()
   }
 
   /**
    * Reads Battery status
    */
-  public async readBatteryStatus(): Promise<KioskBrowser.BatteryInfo> {
+  async readBatteryStatus(): Promise<KioskBrowser.BatteryInfo> {
     return this.kiosk.getBatteryInfo()
   }
 
   /**
    * Determines whether there is a configured & connected printer.
    */
-  public async readPrinterStatus(): Promise<PrinterStatus> {
+  async readPrinterStatus(): Promise<PrinterStatus> {
     const printers = await this.kiosk.getPrinterInfo()
     return { connected: printers.some((printer) => printer.connected) }
   }
@@ -33,11 +33,11 @@ export default class KioskHardware extends MemoryHardware {
    * first subscriber receives a new set (e.g. {mouse, keyboard, flash drive}).
    * New subscribers immediately receive the same current set.
    */
-  public devices = this.kiosk.devices
+  devices = this.kiosk.devices
 
   /**
    * Gets an observable that yields the current set of printers as printers are
    * configured or devices are added or removed.
    */
-  public printers = this.kiosk.printers
+  printers = this.kiosk.printers
 }

--- a/libs/utils/src/Hardware/MemoryHardware.ts
+++ b/libs/utils/src/Hardware/MemoryHardware.ts
@@ -53,7 +53,7 @@ export default class MemoryHardware implements Hardware {
     serialNumber: '',
   }
 
-  public static async build({
+  static async build({
     connectPrinter = false,
     connectAccessibleController = false,
     connectCardReader = false,
@@ -71,7 +71,7 @@ export default class MemoryHardware implements Hardware {
     return newMemoryHardware
   }
 
-  public static async buildStandard(): Promise<MemoryHardware> {
+  static async buildStandard(): Promise<MemoryHardware> {
     return await MemoryHardware.build({
       connectPrinter: true,
       connectAccessibleController: true,
@@ -79,7 +79,7 @@ export default class MemoryHardware implements Hardware {
     })
   }
 
-  public static async buildDemo(): Promise<MemoryHardware> {
+  static async buildDemo(): Promise<MemoryHardware> {
     return await MemoryHardware.build({
       connectPrinter: true,
       connectAccessibleController: false,
@@ -90,23 +90,21 @@ export default class MemoryHardware implements Hardware {
   /**
    * Sets Accessible Controller connected
    */
-  public async setAccessibleControllerConnected(
-    connected: boolean
-  ): Promise<void> {
+  async setAccessibleControllerConnected(connected: boolean): Promise<void> {
     this.setDeviceConnected(this.accessibleController, connected)
   }
 
   /**
    * Reads Battery status
    */
-  public async readBatteryStatus(): Promise<KioskBrowser.BatteryInfo> {
+  async readBatteryStatus(): Promise<KioskBrowser.BatteryInfo> {
     return this.batteryStatus
   }
 
   /**
    * Sets Battery discharging
    */
-  public async setBatteryDischarging(discharging: boolean): Promise<void> {
+  async setBatteryDischarging(discharging: boolean): Promise<void> {
     this.batteryStatus = {
       ...this.batteryStatus,
       discharging,
@@ -116,7 +114,7 @@ export default class MemoryHardware implements Hardware {
   /**
    * Sets Battery level. Number between 0–1.
    */
-  public async setBatteryLevel(level: number): Promise<void> {
+  async setBatteryLevel(level: number): Promise<void> {
     this.batteryStatus = {
       ...this.batteryStatus,
       level,
@@ -126,14 +124,14 @@ export default class MemoryHardware implements Hardware {
   /**
    * Sets Card Reader connected
    */
-  public async setCardReaderConnected(connected: boolean): Promise<void> {
+  async setCardReaderConnected(connected: boolean): Promise<void> {
     this.setDeviceConnected(this.cardReader, connected)
   }
 
   /**
    * Reads Printer status
    */
-  public async readPrinterStatus(): Promise<PrinterStatus> {
+  async readPrinterStatus(): Promise<PrinterStatus> {
     return {
       connected: Array.from(this.connectedDevices).some(isPrinter),
     }
@@ -142,7 +140,7 @@ export default class MemoryHardware implements Hardware {
   /**
    * Sets Printer connected
    */
-  public async setPrinterConnected(connected: boolean): Promise<void> {
+  async setPrinterConnected(connected: boolean): Promise<void> {
     this.setDeviceConnected(this.printer, connected)
     this.printersSubject.next([
       {
@@ -160,8 +158,7 @@ export default class MemoryHardware implements Hardware {
   /**
    * Subscribe to USB device updates.
    */
-  public devices: Observable<Iterable<KioskBrowser.Device>> =
-    this.devicesSubject
+  devices: Observable<Iterable<KioskBrowser.Device>> = this.devicesSubject
 
   private printersSubject = new BehaviorSubject<
     Iterable<KioskBrowser.PrinterInfo>
@@ -170,23 +167,20 @@ export default class MemoryHardware implements Hardware {
   /**
    * Subscribe to printer updates.
    */
-  public printers: Observable<Iterable<KioskBrowser.PrinterInfo>> =
+  printers: Observable<Iterable<KioskBrowser.PrinterInfo>> =
     this.printersSubject
 
   /**
    * Determines whether a device is in the list of connected devices.
    */
-  public hasDevice(device: KioskBrowser.Device): boolean {
+  hasDevice(device: KioskBrowser.Device): boolean {
     return this.connectedDevices.has(device)
   }
 
   /**
    * Sets the connection status for a device by adding or removing it as needed.
    */
-  public setDeviceConnected(
-    device: KioskBrowser.Device,
-    connected: boolean
-  ): void {
+  setDeviceConnected(device: KioskBrowser.Device, connected: boolean): void {
     if (connected !== this.hasDevice(device)) {
       if (connected) {
         this.addDevice(device)
@@ -199,7 +193,7 @@ export default class MemoryHardware implements Hardware {
   /**
    * Adds a device to the set of connected devices.
    */
-  public addDevice(device: KioskBrowser.Device): void {
+  addDevice(device: KioskBrowser.Device): void {
     if (this.connectedDevices.has(device)) {
       throw new Error(
         `cannot add device that was already added: ${device.deviceName}`
@@ -213,7 +207,7 @@ export default class MemoryHardware implements Hardware {
   /**
    * Removes a previously-added device from the set of connected devices.
    */
-  public removeDevice(device: KioskBrowser.Device): void {
+  removeDevice(device: KioskBrowser.Device): void {
     const hadDevice = this.connectedDevices.delete(device)
 
     if (!hadDevice) {

--- a/libs/utils/src/Printer/LocalPrinter.ts
+++ b/libs/utils/src/Printer/LocalPrinter.ts
@@ -4,7 +4,7 @@ import { Printer, PrintOptions } from '../types'
 const debug = makeDebug('utils:printer')
 
 export default class LocalPrinter implements Printer {
-  public async print(options: PrintOptions): Promise<void> {
+  async print(options: PrintOptions): Promise<void> {
     debug('ignoring options given to print: %o', options)
     window.print()
   }

--- a/libs/utils/src/Printer/NullPrinter.ts
+++ b/libs/utils/src/Printer/NullPrinter.ts
@@ -1,7 +1,7 @@
 import { Printer } from '../types'
 
 export default class NullPrinter implements Printer {
-  public async print(): Promise<void> {
+  async print(): Promise<void> {
     // do nothing
   }
 }

--- a/libs/utils/src/Storage/KioskStorage.ts
+++ b/libs/utils/src/Storage/KioskStorage.ts
@@ -8,7 +8,7 @@ export default class KioskStorage implements Storage {
   /**
    * Gets an object from storage by key.
    */
-  public async get(key: string): Promise<unknown> {
+  async get(key: string): Promise<unknown> {
     assert(typeof key === 'string')
     assert(window.kiosk)
     return window.kiosk.storage.get(key)
@@ -17,7 +17,7 @@ export default class KioskStorage implements Storage {
   /**
    * Sets an object in storage by key.
    */
-  public async set(key: string, value: unknown): Promise<void> {
+  async set(key: string, value: unknown): Promise<void> {
     assert(typeof key === 'string')
     assert(window.kiosk)
     await window.kiosk.storage.set(key, value)
@@ -26,7 +26,7 @@ export default class KioskStorage implements Storage {
   /**
    * Removes an object in storage by key.
    */
-  public async remove(key: string): Promise<void> {
+  async remove(key: string): Promise<void> {
     assert(typeof key === 'string')
     assert(window.kiosk)
     await window.kiosk.storage.remove(key)
@@ -35,7 +35,7 @@ export default class KioskStorage implements Storage {
   /**
    * Clears all objects out of storage.
    */
-  public async clear(): Promise<void> {
+  async clear(): Promise<void> {
     assert(window.kiosk)
     await window.kiosk.storage.clear()
   }

--- a/libs/utils/src/Storage/LocalStorage.ts
+++ b/libs/utils/src/Storage/LocalStorage.ts
@@ -8,7 +8,7 @@ export default class LocalStorage implements Storage {
   /**
    * Gets an object from storage by key.
    */
-  public async get(key: string): Promise<unknown> {
+  async get(key: string): Promise<unknown> {
     assert(typeof key === 'string')
     const value = window.localStorage.getItem(key)
     return value ? JSON.parse(value) : undefined
@@ -17,7 +17,7 @@ export default class LocalStorage implements Storage {
   /**
    * Sets an object in storage by key.
    */
-  public async set(key: string, value: unknown): Promise<void> {
+  async set(key: string, value: unknown): Promise<void> {
     assert(typeof key === 'string')
     window.localStorage.setItem(key, JSON.stringify(value))
   }
@@ -25,7 +25,7 @@ export default class LocalStorage implements Storage {
   /**
    * Removes an object in storage by key.
    */
-  public async remove(key: string): Promise<void> {
+  async remove(key: string): Promise<void> {
     assert(typeof key === 'string')
     window.localStorage.removeItem(key)
   }
@@ -33,7 +33,7 @@ export default class LocalStorage implements Storage {
   /**
    * Clears all objects out of storage.
    */
-  public async clear(): Promise<void> {
+  async clear(): Promise<void> {
     window.localStorage.clear()
   }
 }

--- a/libs/utils/src/Storage/MemoryStorage.ts
+++ b/libs/utils/src/Storage/MemoryStorage.ts
@@ -10,7 +10,7 @@ export default class MemoryStorage implements Storage {
   /**
    * @param initial data to load into storage
    */
-  public constructor(initial?: Record<string, unknown>) {
+  constructor(initial?: Record<string, unknown>) {
     if (initial) {
       for (const key in initial) {
         /* istanbul ignore else */
@@ -24,7 +24,7 @@ export default class MemoryStorage implements Storage {
   /**
    * Gets an object from storage by key.
    */
-  public async get(key: string): Promise<unknown> {
+  async get(key: string): Promise<unknown> {
     const serialized = this.data.get(key)
 
     if (typeof serialized === 'undefined') {
@@ -37,21 +37,21 @@ export default class MemoryStorage implements Storage {
   /**
    * Sets an object in storage by key.
    */
-  public async set(key: string, value: unknown): Promise<void> {
+  async set(key: string, value: unknown): Promise<void> {
     this.data.set(key, JSON.stringify(value))
   }
 
   /**
    * Removes an object in storage by key.
    */
-  public async remove(key: string): Promise<void> {
+  async remove(key: string): Promise<void> {
     this.data.delete(key)
   }
 
   /**
    * Clears all objects out of storage.
    */
-  public async clear(): Promise<void> {
+  async clear(): Promise<void> {
     this.data.clear()
   }
 }

--- a/libs/utils/src/deferred.ts
+++ b/libs/utils/src/deferred.ts
@@ -42,7 +42,7 @@ class DeferredQueue<T> {
   /**
    * Determines whether any existing values are present.
    */
-  public isEmpty(): boolean {
+  isEmpty(): boolean {
     return this.settlements.length === 0
   }
 
@@ -52,7 +52,7 @@ class DeferredQueue<T> {
    * deferred until a settlement is added. Note that this promise may reject if
    * `reject` or `rejectAll` has been called.
    */
-  public get(): Promise<T> {
+  get(): Promise<T> {
     const nextSettlement = this.settlements.shift()
 
     if (nextSettlement) {
@@ -77,7 +77,7 @@ class DeferredQueue<T> {
   /**
    * Adds a resolution with `value` to the end of the queue.
    */
-  public resolve(value: T): void {
+  resolve(value: T): void {
     this.assertMutable()
     const nextDeferredGet = this.deferredGets.shift()
 
@@ -92,7 +92,7 @@ class DeferredQueue<T> {
    * Once all existing settlements are consumed, all subsequent calls to `get`
    * will be resolved with `value`.
    */
-  public resolveAll(value: T): void {
+  resolveAll(value: T): void {
     this.assertMutable()
     this.settleAllWith = { status: 'fulfilled', value }
 
@@ -106,7 +106,7 @@ class DeferredQueue<T> {
   /**
    * Adds a rejection for `reason` to the end of the queue.
    */
-  public reject(reason?: unknown): void {
+  reject(reason?: unknown): void {
     this.assertMutable()
     const nextDeferredGet = this.deferredGets.shift()
 
@@ -121,7 +121,7 @@ class DeferredQueue<T> {
    * Once all existing settlements are consumed, all subsequent calls to `get`
    * will be rejected for `reason`.
    */
-  public rejectAll(reason?: unknown): void {
+  rejectAll(reason?: unknown): void {
     this.assertMutable()
     this.settleAllWith = { status: 'rejected', reason }
 


### PR DESCRIPTION
https://google.github.io/styleguide/tsguide.html#visibility

> TypeScript symbols are public by default. Never use the `public` modifier except when declaring non-readonly public parameter properties (in constructors).
>
> ```ts
> class Foo {
>   public bar = new Bar();  // BAD: public modifier not needed
>
>   constructor(public readonly baz: Baz) {}  // BAD: readonly implies it's a property which defaults to public
> }
> ```
> ```ts
> class Foo {
>   bar = new Bar();  // GOOD: public modifier not needed
>
>   constructor(public baz: Baz) {}  // public modifier allowed
> }
> ```

Refs #788 