### PR TITLE
style(lint): enforce & fix GTS direct module export access

### DIFF
--- a/apps/precinct-scanner/src/PreviewApp.tsx
+++ b/apps/precinct-scanner/src/PreviewApp.tsx
@@ -1,3 +1,5 @@
+// This file is for development purposes only, so linting/coverage is relaxed.
+/* eslint-disable vx/gts-direct-module-export-access-only */
 /* istanbul ignore file */
 
 import {

--- a/libs/eslint-plugin-vx/docs/rules/gts-direct-module-export-access-only.md
+++ b/libs/eslint-plugin-vx/docs/rules/gts-direct-module-export-access-only.md
@@ -1,0 +1,35 @@
+# Enforces using module objects for direct export access only (`vx/gts-direct-module-export-access-only`)
+
+This rule is from
+[Google TypeScript Style Guide section "Optimization compatibility for module object imports"](https://google.github.io/styleguide/tsguide.html#optimization-compatibility-for-module-object-imports):
+
+> When importing a module object, directly access properties on the module
+> object rather than passing it around. This ensures that modules can be
+> analyzed and optimized. Treating module imports as namespaces is fine.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```ts
+import * as utils from 'utils'
+class A {
+  readonly utils = utils
+}
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+import { method1, method2 } from 'utils'
+class A {
+  readonly utils = { method1, method2 }
+}
+```
+
+```ts
+import * as utils from 'utils'
+class A {
+  readonly utils = { method1: utils.method1, method2: utils.method2 }
+}
+```

--- a/libs/eslint-plugin-vx/package.json
+++ b/libs/eslint-plugin-vx/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@types/node": "^15.6.2",
+    "@types/react": "^17.0.20",
     "@typescript-eslint/parser": "^4.26.0",
     "@votingworks/types": "workspace:*",
     "eslint": "^7.27.0",

--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -35,6 +35,7 @@ export = {
   },
   reportUnusedDisableDirectives: true,
   rules: {
+    'vx/gts-direct-module-export-access-only': 'error',
     'vx/gts-no-array-constructor': 'error',
     'vx/gts-no-private-fields': 'error',
     'vx/gts-no-public-modifier': 'error',
@@ -108,6 +109,7 @@ export = {
       rules: {
         '@typescript-eslint/no-non-null-assertion': 'off',
         'no-loop-func': 'off',
+        'vx/gts-direct-module-export-access-only': 'off',
       },
     },
   ],

--- a/libs/eslint-plugin-vx/src/rules/gts-direct-module-export-access-only.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts-direct-module-export-access-only.ts
@@ -1,0 +1,101 @@
+import {
+  AST_NODE_TYPES,
+  ESLintUtils,
+  TSESTree,
+} from '@typescript-eslint/experimental-utils'
+import { strict as assert } from 'assert'
+
+export default ESLintUtils.RuleCreator(
+  () =>
+    'https://github.com/votingworks/vxsuite/blob/main/libs/eslint-plugin-vx/docs/rules/gts-direct-module-export-access-only.md'
+)({
+  name: 'gts-direct-module-export-access-only',
+  meta: {
+    docs: {
+      description:
+        'Directly access module import properties rather than passing it around.',
+      category: 'Best Practices',
+      recommended: 'error',
+      suggestion: false,
+      requiresTypeChecking: false,
+    },
+    messages: {
+      directAccessOnly:
+        'Directly access module import properties rather than passing it around',
+    },
+    schema: [],
+    type: 'problem',
+  },
+  defaultOptions: [],
+
+  create(context) {
+    return {
+      ImportNamespaceSpecifier(node: TSESTree.ImportNamespaceSpecifier): void {
+        const scope = context.getScope()
+        const variable = scope.set.get(node.local.name)
+        assert(variable)
+
+        for (const reference of variable.references) {
+          // A.b
+          if (
+            reference.identifier.parent?.type ===
+              AST_NODE_TYPES.MemberExpression &&
+            reference.identifier.parent.object === reference.identifier
+          ) {
+            continue
+          }
+
+          // let a: A.b
+          if (
+            reference.identifier.parent?.type ===
+              AST_NODE_TYPES.TSQualifiedName &&
+            reference.identifier.parent.left === reference.identifier
+          ) {
+            continue
+          }
+
+          // let a: A['b']
+          if (
+            reference.identifier.parent?.parent?.type ===
+              AST_NODE_TYPES.TSIndexedAccessType &&
+            reference.identifier.parent.parent.objectType.type ===
+              AST_NODE_TYPES.TSTypeReference &&
+            reference.identifier.parent.parent.objectType.typeName ===
+              reference.identifier
+          ) {
+            continue
+          }
+
+          // let a: typeof A['b']
+          if (
+            reference.identifier.parent?.parent?.type ===
+              AST_NODE_TYPES.TSIndexedAccessType &&
+            reference.identifier.parent.parent.objectType.type ===
+              AST_NODE_TYPES.TSTypeQuery &&
+            reference.identifier.parent.parent.objectType.exprName ===
+              reference.identifier
+          ) {
+            continue
+          }
+
+          // import * as React from 'react'
+          // For some reason, this one only happens on some imports.
+          // Specifically, it seems to happen with React. I suspect it's due to
+          // `eslint-plugin-react` marking it as used, but I'm not sure.
+          if (
+            reference.identifier.parent?.type ===
+              AST_NODE_TYPES.ImportNamespaceSpecifier &&
+            reference.identifier.parent.local === reference.identifier
+          ) {
+            continue
+          }
+
+          context.report({
+            node: reference.identifier,
+            messageId: 'directAccessOnly',
+          })
+        }
+      },
+    }
+  },
+})

--- a/libs/eslint-plugin-vx/src/rules/index.ts
+++ b/libs/eslint-plugin-vx/src/rules/index.ts
@@ -1,3 +1,4 @@
+import gtsDirectModuleExportAccessOnly from './gts-direct-module-export-access-only'
 import gtsNoArrayConstructor from './gts-no-array-constructor'
 import gtsNoPrivateFields from './gts-no-private-fields'
 import gtsNoPublicModifier from './gts-no-public-modifier'
@@ -7,6 +8,7 @@ import noAssertStringOrNumber from './no-assert-truthiness'
 import noFloatingVoids from './no-floating-results'
 
 export default {
+  'gts-direct-module-export-access-only': gtsDirectModuleExportAccessOnly,
   'gts-no-array-constructor': gtsNoArrayConstructor,
   'gts-no-private-fields': gtsNoPrivateFields,
   'gts-no-public-modifier': gtsNoPublicModifier,

--- a/libs/eslint-plugin-vx/tests/fixtures/react.tsx
+++ b/libs/eslint-plugin-vx/tests/fixtures/react.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react'
+
+export function Component(): JSX.Element {
+  return <div />
+}

--- a/libs/eslint-plugin-vx/tests/rules/gts-direct-module-export-access-only.test.ts
+++ b/libs/eslint-plugin-vx/tests/rules/gts-direct-module-export-access-only.test.ts
@@ -1,0 +1,88 @@
+import { ESLintUtils } from '@typescript-eslint/experimental-utils'
+import { join } from 'path'
+import rule from '../../src/rules/gts-direct-module-export-access-only'
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    tsconfigRootDir: join(__dirname, '../fixtures'),
+    project: './tsconfig.json',
+  },
+  parser: '@typescript-eslint/parser',
+})
+
+ruleTester.run('gts-direct-namespace-property-access-only', rule, {
+  valid: [
+    {
+      code: `
+        import * as mod from 'mod';
+        mod.exp();
+      `,
+    },
+    {
+      code: `
+        import * as mod from 'mod';
+        console.log(mod['exp']);
+      `,
+    },
+    {
+      code: `
+        import mod from 'mod';
+        console.log(mod);
+      `,
+    },
+    {
+      code: `
+        import * as mod from 'mod';
+        console.log(mod?.exp);
+      `,
+    },
+    {
+      code: `
+        import type * as mod from 'mod';
+        let m: mod.exp;
+      `,
+    },
+    {
+      code: `
+        import type * as mod from 'mod';
+        let m: mod['exp'];
+      `,
+    },
+    {
+      code: `
+        import type * as mod from 'mod';
+        let m: typeof mod['exp'];
+      `,
+    },
+    {
+      code: `
+        import * as React from 'react';
+      `,
+      filename: '../fixtures/react.tsx',
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        import * as mod from 'mod';
+        console.log(mod);
+      `,
+      errors: [{ line: 3, messageId: 'directAccessOnly' }],
+    },
+    {
+      code: `
+        import * as mod from 'mod';
+        mod;
+      `,
+      errors: [{ line: 3, messageId: 'directAccessOnly' }],
+    },
+    {
+      code: `
+        import * as mod from 'mod';
+        obj[mod];
+      `,
+      errors: [{ line: 3, messageId: 'directAccessOnly' }],
+    },
+  ],
+})

--- a/libs/hmpb-interpreter/src/cli/commands/help.ts
+++ b/libs/hmpb-interpreter/src/cli/commands/help.ts
@@ -1,14 +1,12 @@
 import chalk from 'chalk'
 import { basename } from 'path'
-import { GlobalOptions } from '..'
+import { getCommands, GlobalOptions } from '..'
 import * as helpCommand from './help'
 import * as interpretCommand from './interpret'
 import * as layoutCommand from './layout'
 
 export const name = 'help'
 export const description = 'Show help about a command'
-
-const commands = [helpCommand, interpretCommand, layoutCommand] as const
 
 export interface Options {
   readonly $0: string
@@ -34,6 +32,7 @@ function printGlobalHelp(options: Options, out: NodeJS.WritableStream): void {
   out.write(chalk.bold(`Commands:\n`))
   out.write(`\n`)
 
+  const commands = getCommands()
   const commandNameSpace =
     Math.max(...commands.map((command) => command.name.length)) + 3
 

--- a/libs/hmpb-interpreter/src/cli/index.ts
+++ b/libs/hmpb-interpreter/src/cli/index.ts
@@ -5,7 +5,8 @@ import * as layoutCommand from './commands/layout'
 
 export interface Command<O> {
   name: string
-  parseOptions(args: readonly string[]): Promise<O>
+  description: string
+  parseOptions(globalOptions: GlobalOptions): Promise<O>
   run(
     options: O,
     stdin: typeof process.stdin,
@@ -23,7 +24,31 @@ export interface GlobalOptions {
   commandArgs: readonly string[]
 }
 
-export const commands = [helpCommand, interpretCommand, layoutCommand] as const
+export const getCommands = (): [
+  Command<helpCommand.Options>,
+  Command<interpretCommand.Options>,
+  Command<layoutCommand.Options>
+] => [
+  {
+    name: helpCommand.name,
+    description: helpCommand.description,
+    parseOptions: helpCommand.parseOptions,
+    run: helpCommand.run,
+  },
+  {
+    name: interpretCommand.name,
+    description: interpretCommand.description,
+    parseOptions: interpretCommand.parseOptions,
+    run: interpretCommand.run,
+  },
+  {
+    name: layoutCommand.name,
+    description: layoutCommand.description,
+    parseOptions: layoutCommand.parseOptions,
+    run: layoutCommand.run,
+  },
+]
+
 export type Options =
   | {
       command: typeof helpCommand.name

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1138,6 +1138,7 @@ importers:
       typescript: 4.2.3
     devDependencies:
       '@types/node': 15.6.2
+      '@types/react': 17.0.20
       '@typescript-eslint/parser': 4.26.0_eslint@7.27.0+typescript@4.2.3
       '@votingworks/types': link:../types
       eslint: 7.27.0
@@ -1152,6 +1153,7 @@ importers:
       ts-jest: 27.0.2_jest@27.0.3+typescript@4.2.3
     specifiers:
       '@types/node': ^15.6.2
+      '@types/react': ^17.0.20
       '@typescript-eslint/eslint-plugin': ^4.30.0
       '@typescript-eslint/experimental-utils': ^4.30.0
       '@typescript-eslint/parser': ^4.26.0
@@ -8464,6 +8466,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-sX1HisdB1/ZESixMTGnMxH9TDe8Sk709734fEQZzCV/4lSu9kJCPbo2PbTRoZM+53Pp0P10hYVyReUueGwUi4A==
+  /@types/react/17.0.20:
+    dependencies:
+      '@types/prop-types': 15.7.4
+      '@types/scheduler': 0.16.2
+      csstype: 3.0.8
+    dev: true
+    resolution:
+      integrity: sha512-wWZrPlihslrPpcKyCSlmIlruakxr57/buQN1RjlIeaaTWDLtJkTtRW429MoQJergvVKc4IWBpRhWw7YNh/7GVA==
   /@types/react/17.0.4:
     dependencies:
       '@types/prop-types': 15.7.3


### PR DESCRIPTION
https://google.github.io/styleguide/tsguide.html#optimization-compatibility-for-module-object-imports:

> When importing a module object, directly access properties on the module object rather than passing it around. This ensures that modules can be analyzed and optimized. Treating module imports as namespaces is fine.
>
> ```ts
> // good
> import {method1, method2} from 'utils';
> class A {
>   readonly utils = {method1, method2};
> }
> ```
> ```ts
> // bad
> import * as utils from 'utils';
> class A {
>   readonly utils = utils;
> }
> ```

Refs #788 