### PR TITLE
style(lint): enforce & fix GTS equality check rule

### DIFF
--- a/apps/election-manager/src/serviceWorker.ts
+++ b/apps/election-manager/src/serviceWorker.ts
@@ -65,7 +65,7 @@ function registerValidSW(swUrl: string, config?: Config) {
     .then((registration) => {
       registration.onupdatefound = () => {
         const installingWorker = registration.installing
-        if (installingWorker == null) {
+        if (!installingWorker) {
           return
         }
         installingWorker.onstatechange = () => {
@@ -109,7 +109,7 @@ function checkValidServiceWorker(swUrl: string, config?: Config) {
       const contentType = response.headers.get('content-type')
       if (
         response.status === 404 ||
-        (contentType != null && contentType.indexOf('javascript') === -1)
+        (contentType !== null && contentType.indexOf('javascript') === -1)
       ) {
         // No service worker found. Probably a different app. Reload the page.
         navigator.serviceWorker.ready.then((registration) => {

--- a/apps/precinct-scanner/src/serviceWorker.ts
+++ b/apps/precinct-scanner/src/serviceWorker.ts
@@ -65,7 +65,7 @@ function registerValidSW(swUrl: string, config?: Config) {
     .then((registration) => {
       registration.onupdatefound = () => {
         const installingWorker = registration.installing
-        if (installingWorker == null) {
+        if (!installingWorker) {
           return
         }
         installingWorker.onstatechange = () => {
@@ -109,7 +109,7 @@ function checkValidServiceWorker(swUrl: string, config?: Config) {
       const contentType = response.headers.get('content-type')
       if (
         response.status === 404 ||
-        (contentType != null && contentType.indexOf('javascript') === -1)
+        (contentType !== null && contentType.indexOf('javascript') === -1)
       ) {
         // No service worker found. Probably a different app. Reload the page.
         navigator.serviceWorker.ready.then((registration) => {

--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -52,6 +52,8 @@ export = {
     '@typescript-eslint/no-unnecessary-type-assertion': 'error',
     'class-methods-use-this': 'off',
     'consistent-return': 'off',
+    // be stricter than eslint-config-airbnb which allows `== null`
+    eqeqeq: ['error', 'always'],
     'import/extensions': 'off',
     'import/no-cycle': 'off',
     'import/no-extraneous-dependencies': [


### PR DESCRIPTION
https://google.github.io/styleguide/tsguide.html#equality-checks:

> Always use triple equals (`===`) and not equals (`!==`). The double equality operators cause error prone type coercions that are hard to understand and slower to implement for JavaScript Virtual Machines.

Refs #788 