### PR TITLE
refactor(utils) rename Tally to SerializedTally

### DIFF
--- a/apps/bmd/src/AppRoot.tsx
+++ b/apps/bmd/src/AppRoot.tsx
@@ -35,7 +35,7 @@ import {
   isCardReader,
   getZeroTally,
   calculateTally,
-  Tally,
+  SerializedTally,
   CardTally,
   CardAPI,
   CardPresentAPI,
@@ -120,7 +120,7 @@ interface SharedState {
   electionDefinition: OptionalElectionDefinition
   isLiveMode: boolean
   isPollsOpen: boolean
-  tally: Tally
+  tally: SerializedTally
 }
 
 interface OtherState {

--- a/apps/bmd/src/components/PrecinctTallyReport.tsx
+++ b/apps/bmd/src/components/PrecinctTallyReport.tsx
@@ -3,10 +3,10 @@ import styled from 'styled-components'
 import { Election } from '@votingworks/types'
 import {
   find,
-  Tally,
-  CandidateVoteTally,
-  YesNoVoteTally,
-  MsEitherNeitherTally,
+  SerializedTally,
+  SerializedCandidateVoteTally,
+  SerializedYesNoVoteTally,
+  SerializedMsEitherNeitherTally,
   TallySourceMachineType,
 } from '@votingworks/utils'
 
@@ -36,7 +36,7 @@ interface Props {
   currentDateTime: string
   election: Election
   isPollsOpen: boolean
-  tally: Tally
+  tally: SerializedTally
   precinctSelection: PrecinctSelection
   reportPurpose: string
 }
@@ -110,7 +110,9 @@ const PrecinctTallyReport = ({
                         <TD narrow textAlign="right">
                           {isContestInPrecinct
                             ? numberWithCommas(
-                                (tally[contestIndex] as MsEitherNeitherTally)
+                                (tally[
+                                  contestIndex
+                                ] as SerializedMsEitherNeitherTally)
                                   .eitherOption
                               )
                             : /* istanbul ignore next */
@@ -123,7 +125,9 @@ const PrecinctTallyReport = ({
                           {
                             /* istanbul ignore else */ isContestInPrecinct
                               ? numberWithCommas(
-                                  (tally[contestIndex] as MsEitherNeitherTally)
+                                  (tally[
+                                    contestIndex
+                                  ] as SerializedMsEitherNeitherTally)
                                     .neitherOption
                                 )
                               : /* istanbul ignore next */
@@ -136,8 +140,9 @@ const PrecinctTallyReport = ({
                         <TD narrow textAlign="right">
                           {isContestInPrecinct
                             ? numberWithCommas(
-                                (tally[contestIndex] as MsEitherNeitherTally)
-                                  .firstOption
+                                (tally[
+                                  contestIndex
+                                ] as SerializedMsEitherNeitherTally).firstOption
                               )
                             : /* istanbul ignore next */
                               'X'}
@@ -148,7 +153,9 @@ const PrecinctTallyReport = ({
                         <TD narrow textAlign="right">
                           {isContestInPrecinct
                             ? numberWithCommas(
-                                (tally[contestIndex] as MsEitherNeitherTally)
+                                (tally[
+                                  contestIndex
+                                ] as SerializedMsEitherNeitherTally)
                                   .secondOption
                               )
                             : /* istanbul ignore next */
@@ -164,8 +171,11 @@ const PrecinctTallyReport = ({
                         <TD narrow textAlign="right">
                           {isContestInPrecinct
                             ? numberWithCommas(
-                                (tally[contestIndex] as CandidateVoteTally)
-                                  .candidates[candidateIndex]
+                                (tally[
+                                  contestIndex
+                                ] as SerializedCandidateVoteTally).candidates[
+                                  candidateIndex
+                                ]
                               )
                             : 'X'}
                         </TD>
@@ -179,7 +189,9 @@ const PrecinctTallyReport = ({
                         <TD narrow textAlign="right">
                           {isContestInPrecinct
                             ? numberWithCommas(
-                                (tally[contestIndex] as YesNoVoteTally).yes
+                                (tally[
+                                  contestIndex
+                                ] as SerializedYesNoVoteTally).yes
                               )
                             : 'X'}
                         </TD>
@@ -189,7 +201,9 @@ const PrecinctTallyReport = ({
                         <TD narrow textAlign="right">
                           {isContestInPrecinct
                             ? numberWithCommas(
-                                (tally[contestIndex] as YesNoVoteTally).no
+                                (tally[
+                                  contestIndex
+                                ] as SerializedYesNoVoteTally).no
                               )
                             : 'X'}
                         </TD>

--- a/apps/bmd/src/pages/PollWorkerScreen.tsx
+++ b/apps/bmd/src/pages/PollWorkerScreen.tsx
@@ -14,7 +14,7 @@ import {
 
 import {
   formatFullDateTimeZone,
-  Tally,
+  SerializedTally,
   CardTally,
   TallySourceMachineType,
   combineTallies,
@@ -58,7 +58,7 @@ interface Props {
   isPollsOpen: boolean
   machineConfig: MachineConfig
   printer: Printer
-  tally: Tally
+  tally: SerializedTally
   togglePollsOpen: () => void
   saveTallyToCard: (cardTally: CardTally) => Promise<void>
   talliesOnCard: Optional<CardTally>

--- a/apps/precinct-scanner/src/utils/tallies.ts
+++ b/apps/precinct-scanner/src/utils/tallies.ts
@@ -1,7 +1,7 @@
 import { Election } from '@votingworks/types'
 import {
   buildVoteFromCvr,
-  Tally,
+  SerializedTally,
   getZeroTally,
   calculateTally,
 } from '@votingworks/utils'
@@ -11,7 +11,7 @@ import { CastVoteRecord } from '../config/types'
 export function calculateTallyFromCVRs(
   castVoteRecords: CastVoteRecord[],
   election: Election
-): Tally {
+): SerializedTally {
   let tally = getZeroTally(election)
   for (const cvr of castVoteRecords) {
     const nextVote = buildVoteFromCvr({ election, cvr })

--- a/libs/utils/src/types.ts
+++ b/libs/utils/src/types.ts
@@ -5,14 +5,14 @@ import { z } from 'zod'
 export type TallyCount = number
 export const TallyCountSchema = z.number()
 
-export interface CandidateVoteTally {
+export interface SerializedCandidateVoteTally {
   candidates: TallyCount[]
   writeIns: TallyCount
   undervotes: TallyCount
   overvotes: TallyCount
   ballotsCast: TallyCount
 }
-export const CandidateVoteTallySchema: z.ZodSchema<CandidateVoteTally> =
+export const SerializedCandidateVoteTallySchema: z.ZodSchema<SerializedCandidateVoteTally> =
   z.object({
     candidates: z.array(TallyCountSchema),
     writeIns: TallyCountSchema,
@@ -21,22 +21,23 @@ export const CandidateVoteTallySchema: z.ZodSchema<CandidateVoteTally> =
     ballotsCast: TallyCountSchema,
   })
 
-export interface YesNoVoteTally {
+export interface SerializedYesNoVoteTally {
   yes: TallyCount
   no: TallyCount
   undervotes: TallyCount
   overvotes: TallyCount
   ballotsCast: TallyCount
 }
-export const YesNoVoteTallySchema: z.ZodSchema<YesNoVoteTally> = z.object({
-  yes: TallyCountSchema,
-  no: TallyCountSchema,
-  undervotes: TallyCountSchema,
-  overvotes: TallyCountSchema,
-  ballotsCast: TallyCountSchema,
-})
+export const SerializedYesNoVoteTallySchema: z.ZodSchema<SerializedYesNoVoteTally> =
+  z.object({
+    yes: TallyCountSchema,
+    no: TallyCountSchema,
+    undervotes: TallyCountSchema,
+    overvotes: TallyCountSchema,
+    ballotsCast: TallyCountSchema,
+  })
 
-export interface MsEitherNeitherTally {
+export interface SerializedMsEitherNeitherTally {
   ballotsCast: TallyCount
   eitherOption: TallyCount
   neitherOption: TallyCount
@@ -47,7 +48,7 @@ export interface MsEitherNeitherTally {
   pickOneUndervotes: TallyCount
   pickOneOvervotes: TallyCount
 }
-export const MsEitherNeitherTallySchema: z.ZodSchema<MsEitherNeitherTally> =
+export const SerializedMsEitherNeitherTallySchema: z.ZodSchema<SerializedMsEitherNeitherTally> =
   z.object({
     ballotsCast: TallyCountSchema,
     eitherOption: TallyCountSchema,
@@ -60,16 +61,16 @@ export const MsEitherNeitherTallySchema: z.ZodSchema<MsEitherNeitherTally> =
     pickOneOvervotes: TallyCountSchema,
   })
 
-export type Tally = (
-  | CandidateVoteTally
-  | YesNoVoteTally
-  | MsEitherNeitherTally
+export type SerializedTally = (
+  | SerializedCandidateVoteTally
+  | SerializedYesNoVoteTally
+  | SerializedMsEitherNeitherTally
 )[]
-export const TallySchema: z.ZodSchema<Tally> = z.array(
+export const TallySchema: z.ZodSchema<SerializedTally> = z.array(
   z.union([
-    CandidateVoteTallySchema,
-    YesNoVoteTallySchema,
-    MsEitherNeitherTallySchema,
+    SerializedCandidateVoteTallySchema,
+    SerializedYesNoVoteTallySchema,
+    SerializedMsEitherNeitherTallySchema,
   ])
 )
 
@@ -93,7 +94,7 @@ export const CardTallyMetadataEntrySchema: z.ZodSchema<CardTallyMetadataEntry> =
 
 export interface BMDCardTally {
   readonly tallyMachineType: TallySourceMachineType.BMD
-  readonly tally: Tally
+  readonly tally: SerializedTally
   readonly metadata: readonly CardTallyMetadataEntry[]
   readonly totalBallotsPrinted: number
 }
@@ -108,7 +109,7 @@ export const BMDCardTallySchema: z.ZodSchema<BMDCardTally> = z.object({
 
 export interface PrecinctScannerCardTally {
   readonly tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER
-  readonly tally: Tally
+  readonly tally: SerializedTally
   readonly metadata: readonly CardTallyMetadataEntry[]
   readonly totalBallotsScanned: number
   readonly isLiveMode: boolean


### PR DESCRIPTION
The "Tally" type in /utils refers to the way that bmd and precinct-scanner currently hold tally information. This schema was created to be as minimal as possible to fit on smartcards and in memory efficiently. However that makes the object harder to work with and understand internally, election-manager has a different object it build for tallies that is not as efficient but easier to work with. I think in general we should use the election-manager version of Tally for logic/calculations internally and convert to/from the more efficient, serialized, format for storage. 

This PR renames this "Tally" to "SerializedTally" to prepare for the election-manager version of a "Tally" type to be introduced to /utils which will be necessary to print election-manager style tally reports from precinct-scanner. 

There are a lot of type assertions in this code, it wasn't immediately obvious to me how to fix them but I think it will be easier to avoid these when we are using the other Tally format for some of this logic. A lot of this code will be changed/replaced in future PRs for this task so I didn't want to get bogged down in figuring out a way to fix the type issues here. 