### PR TITLE
Highlight contests with issues

### DIFF
--- a/apps/bsd/src/api/hmpb.test.ts
+++ b/apps/bsd/src/api/hmpb.test.ts
@@ -100,6 +100,8 @@ test('can fetch the next ballot sheet needing review', async () => {
         interpretation: { type: 'UnreadablePage' },
       },
     },
+    layouts: {},
+    definitions: {},
   }
   fetchMock.getOnce('/scan/hmpb/review/next-sheet', {
     status: 200,

--- a/apps/bsd/src/api/hmpb.test.ts
+++ b/apps/bsd/src/api/hmpb.test.ts
@@ -1,5 +1,6 @@
 import { electionSampleDefinition as electionDefinition } from '@votingworks/fixtures'
 import fetchMock from 'fetch-mock'
+import { GetNextReviewSheetResponse } from '@votingworks/types/api/module-scan'
 import { addTemplates, fetchNextBallotSheetToReview } from './hmpb'
 import * as config from './config'
 
@@ -87,11 +88,27 @@ test('emits error on API failure', async () => {
 })
 
 test('can fetch the next ballot sheet needing review', async () => {
-  fetchMock.getOnce('/scan/hmpb/review/next-sheet', { status: 200, body: {} })
+  const response: GetNextReviewSheetResponse = {
+    interpreted: {
+      id: 'test-sheet',
+      front: {
+        image: { url: '/' },
+        interpretation: { type: 'UnreadablePage' },
+      },
+      back: {
+        image: { url: '/' },
+        interpretation: { type: 'UnreadablePage' },
+      },
+    },
+  }
+  fetchMock.getOnce('/scan/hmpb/review/next-sheet', {
+    status: 200,
+    body: response,
+  })
   await expect(fetchNextBallotSheetToReview()).resolves.toBeDefined()
 })
 
 test('returns undefined if there are no ballot sheets to review', async () => {
-  fetchMock.getOnce('/scan/hmpb/review/next-sheet', { status: 404, body: {} })
+  fetchMock.getOnce('/scan/hmpb/review/next-sheet', { status: 404, body: '' })
   await expect(fetchNextBallotSheetToReview()).resolves.toBeUndefined()
 })

--- a/apps/bsd/src/api/hmpb.ts
+++ b/apps/bsd/src/api/hmpb.ts
@@ -1,10 +1,11 @@
-import { ElectionDefinition, BallotSheetInfo } from '@votingworks/types'
+import { ElectionDefinition } from '@votingworks/types'
 import { EventEmitter } from 'events'
 import {
   fetchJSON,
   BallotPackage,
   BallotPackageEntry,
 } from '@votingworks/utils'
+import { GetNextReviewSheetResponse } from '@votingworks/types/api/module-scan'
 import { setElection } from './config'
 
 export interface AddTemplatesEvents extends EventEmitter {
@@ -90,10 +91,12 @@ export async function doneTemplates(): Promise<void> {
 }
 
 export async function fetchNextBallotSheetToReview(): Promise<
-  BallotSheetInfo | undefined
+  GetNextReviewSheetResponse | undefined
 > {
   try {
-    return await fetchJSON<BallotSheetInfo>('/scan/hmpb/review/next-sheet')
+    return await fetchJSON<GetNextReviewSheetResponse>(
+      '/scan/hmpb/review/next-sheet'
+    )
   } catch {
     return undefined
   }

--- a/apps/bsd/src/components/BallotSheetImage.tsx
+++ b/apps/bsd/src/components/BallotSheetImage.tsx
@@ -1,0 +1,71 @@
+import { Contest, SerializableBallotPageLayout } from '@votingworks/types'
+import { zip } from '@votingworks/utils'
+import React, { useCallback, useRef, useState } from 'react'
+
+export interface Props {
+  imageURL: string
+  layout?: SerializableBallotPageLayout
+  contestIds?: readonly Contest['id'][]
+  styleForContest?(contestId: Contest['id']): React.CSSProperties
+}
+
+export default function BallotSheetImage({
+  imageURL,
+  layout,
+  contestIds,
+  styleForContest,
+}: Props): JSX.Element {
+  const imageRef = useRef<HTMLImageElement>(null)
+
+  const [xScaleValue, setXScaleValue] = useState(0)
+  const [yScaleValue, setYScaleValue] = useState(0)
+
+  const recalculateScale = useCallback(() => {
+    if (!layout || !imageRef.current || imageRef.current.clientWidth === 0) {
+      return
+    }
+
+    const width = imageRef.current.clientWidth
+    const height = imageRef.current.clientHeight
+    setXScaleValue(width / layout.ballotImage.imageData.width)
+    setYScaleValue(height / layout.ballotImage.imageData.height)
+  }, [layout, imageRef.current])
+
+  const scaleX = useCallback(
+    (ballotLength: number): number => ballotLength * xScaleValue,
+    [xScaleValue]
+  )
+
+  const scaleY = useCallback(
+    (ballotLength: number): number => ballotLength * yScaleValue,
+    [yScaleValue]
+  )
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <img
+        ref={imageRef}
+        src={imageURL}
+        alt="front"
+        onLoad={recalculateScale}
+      />
+      {layout &&
+        contestIds &&
+        [...zip(layout.contests, contestIds)].map(
+          ([contestLayout, contestId]) => (
+            <div
+              key={contestId}
+              style={{
+                position: 'absolute',
+                left: `${scaleX(contestLayout.bounds.x)}px`,
+                top: `${scaleY(contestLayout.bounds.y)}px`,
+                width: `${scaleX(contestLayout.bounds.width)}px`,
+                height: `${scaleY(contestLayout.bounds.height)}px`,
+                ...styleForContest?.(contestId),
+              }}
+            />
+          )
+        )}
+    </div>
+  )
+}

--- a/apps/bsd/src/config/types.ts
+++ b/apps/bsd/src/config/types.ts
@@ -1,5 +1,9 @@
-import { BallotPageLayout } from '@votingworks/hmpb-interpreter'
-import { Dictionary, ElectionDefinition, MarkInfo } from '@votingworks/types'
+import {
+  Dictionary,
+  ElectionDefinition,
+  MarkInfo,
+  SerializableBallotPageLayout,
+} from '@votingworks/types'
 
 export interface MachineConfig {
   machineId: string
@@ -48,11 +52,4 @@ export interface HmpbBallotInfo {
 export interface UnreadableBallotInfo {
   id: number
   filename: string
-}
-
-export type SerializableBallotPageLayout = Omit<
-  BallotPageLayout,
-  'ballotImage'
-> & {
-  ballotImage: Omit<BallotPageLayout['ballotImage'], 'imageData'>
 }

--- a/apps/bsd/src/screens/BallotEjectScreen.test.tsx
+++ b/apps/bsd/src/screens/BallotEjectScreen.test.tsx
@@ -23,6 +23,8 @@ test('says the sheet is unreadable if it is', async () => {
           interpretation: { type: 'BlankPage' },
         },
       },
+      layouts: {},
+      definitions: {},
     })
   )
 
@@ -106,6 +108,8 @@ test('says the ballot sheet is overvoted if it is', async () => {
           },
         },
       },
+      layouts: {},
+      definitions: {},
     })
   )
 
@@ -196,6 +200,8 @@ test('says the ballot sheet is undervoted if it is', async () => {
           },
         },
       },
+      layouts: {},
+      definitions: {},
     })
   )
 
@@ -279,6 +285,8 @@ test('says the ballot sheet is blank if it is', async () => {
           },
         },
       },
+      layouts: {},
+      definitions: {},
     })
   )
 
@@ -342,6 +350,8 @@ test('calls out live ballot sheets in test mode', async () => {
           },
         },
       },
+      layouts: {},
+      definitions: {},
     })
   )
 
@@ -398,6 +408,8 @@ test('calls out test ballot sheets in live mode', async () => {
           },
         },
       },
+      layouts: {},
+      definitions: {},
     })
   )
 
@@ -436,6 +448,8 @@ test('shows invalid election screen when appropriate', async () => {
           interpretation: { type: 'BlankPage' },
         },
       },
+      layouts: {},
+      definitions: {},
     })
   )
 
@@ -494,6 +508,8 @@ test('shows invalid election screen when appropriate', async () => {
           },
         },
       },
+      layouts: {},
+      definitions: {},
     })
   )
 

--- a/apps/bsd/src/screens/BallotEjectScreen.test.tsx
+++ b/apps/bsd/src/screens/BallotEjectScreen.test.tsx
@@ -2,27 +2,26 @@ import { waitFor, fireEvent } from '@testing-library/react'
 import fetchMock from 'fetch-mock'
 import React from 'react'
 import { act } from 'react-dom/test-utils'
-import {
-  BallotSheetInfo,
-  BallotType,
-  AdjudicationReason,
-} from '@votingworks/types'
+import { BallotType, AdjudicationReason } from '@votingworks/types'
 import { typedAs } from '@votingworks/utils'
+import { GetNextReviewSheetResponse } from '@votingworks/types/api/module-scan'
 import BallotEjectScreen from './BallotEjectScreen'
 import renderInAppContext from '../../test/renderInAppContext'
 
 test('says the sheet is unreadable if it is', async () => {
   fetchMock.getOnce(
     '/scan/hmpb/review/next-sheet',
-    typedAs<BallotSheetInfo>({
-      id: 'mock-sheet-id',
-      front: {
-        image: { url: '/front/url' },
-        interpretation: { type: 'BlankPage' },
-      },
-      back: {
-        image: { url: '/back/url' },
-        interpretation: { type: 'BlankPage' },
+    typedAs<GetNextReviewSheetResponse>({
+      interpreted: {
+        id: 'mock-sheet-id',
+        front: {
+          image: { url: '/front/url' },
+          interpretation: { type: 'BlankPage' },
+        },
+        back: {
+          image: { url: '/back/url' },
+          interpretation: { type: 'BlankPage' },
+        },
       },
     })
   )
@@ -46,63 +45,65 @@ test('says the sheet is unreadable if it is', async () => {
 test('says the ballot sheet is overvoted if it is', async () => {
   fetchMock.getOnce(
     '/scan/hmpb/review/next-sheet',
-    typedAs<BallotSheetInfo>({
-      id: 'mock-sheet-id',
-      front: {
-        image: { url: '/front/url' },
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          markInfo: {
-            ballotSize: { width: 1, height: 1 },
-            marks: [],
+    typedAs<GetNextReviewSheetResponse>({
+      interpreted: {
+        id: 'mock-sheet-id',
+        front: {
+          image: { url: '/front/url' },
+          interpretation: {
+            type: 'InterpretedHmpbPage',
+            markInfo: {
+              ballotSize: { width: 1, height: 1 },
+              marks: [],
+            },
+            metadata: {
+              ballotStyleId: '1',
+              precinctId: '1',
+              ballotType: BallotType.Standard,
+              electionHash: '',
+              isTestMode: false,
+              locales: { primary: 'en-US' },
+              pageNumber: 1,
+            },
+            adjudicationInfo: {
+              requiresAdjudication: true,
+              allReasonInfos: [
+                {
+                  type: AdjudicationReason.Overvote,
+                  contestId: '1',
+                  optionIds: ['1', '2'],
+                  expected: 1,
+                },
+              ],
+              enabledReasons: [AdjudicationReason.Overvote],
+            },
+            votes: {},
           },
-          metadata: {
-            ballotStyleId: '1',
-            precinctId: '1',
-            ballotType: BallotType.Standard,
-            electionHash: '',
-            isTestMode: false,
-            locales: { primary: 'en-US' },
-            pageNumber: 1,
-          },
-          adjudicationInfo: {
-            requiresAdjudication: true,
-            allReasonInfos: [
-              {
-                type: AdjudicationReason.Overvote,
-                contestId: '1',
-                optionIds: ['1', '2'],
-                expected: 1,
-              },
-            ],
-            enabledReasons: [AdjudicationReason.Overvote],
-          },
-          votes: {},
         },
-      },
-      back: {
-        image: { url: '/back/url' },
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          markInfo: {
-            ballotSize: { width: 1, height: 1 },
-            marks: [],
+        back: {
+          image: { url: '/back/url' },
+          interpretation: {
+            type: 'InterpretedHmpbPage',
+            markInfo: {
+              ballotSize: { width: 1, height: 1 },
+              marks: [],
+            },
+            metadata: {
+              ballotStyleId: '1',
+              precinctId: '1',
+              ballotType: BallotType.Standard,
+              electionHash: '',
+              isTestMode: false,
+              locales: { primary: 'en-US' },
+              pageNumber: 2,
+            },
+            adjudicationInfo: {
+              requiresAdjudication: false,
+              allReasonInfos: [],
+              enabledReasons: [AdjudicationReason.Overvote],
+            },
+            votes: {},
           },
-          metadata: {
-            ballotStyleId: '1',
-            precinctId: '1',
-            ballotType: BallotType.Standard,
-            electionHash: '',
-            isTestMode: false,
-            locales: { primary: 'en-US' },
-            pageNumber: 2,
-          },
-          adjudicationInfo: {
-            requiresAdjudication: false,
-            allReasonInfos: [],
-            enabledReasons: [AdjudicationReason.Overvote],
-          },
-          votes: {},
         },
       },
     })
@@ -134,63 +135,65 @@ test('says the ballot sheet is overvoted if it is', async () => {
 test('says the ballot sheet is undervoted if it is', async () => {
   fetchMock.getOnce(
     '/scan/hmpb/review/next-sheet',
-    typedAs<BallotSheetInfo>({
-      id: 'mock-sheet-id',
-      front: {
-        image: { url: '/front/url' },
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          markInfo: {
-            ballotSize: { width: 1, height: 1 },
-            marks: [],
+    typedAs<GetNextReviewSheetResponse>({
+      interpreted: {
+        id: 'mock-sheet-id',
+        front: {
+          image: { url: '/front/url' },
+          interpretation: {
+            type: 'InterpretedHmpbPage',
+            markInfo: {
+              ballotSize: { width: 1, height: 1 },
+              marks: [],
+            },
+            metadata: {
+              ballotStyleId: '1',
+              precinctId: '1',
+              ballotType: BallotType.Standard,
+              electionHash: '',
+              isTestMode: false,
+              locales: { primary: 'en-US' },
+              pageNumber: 1,
+            },
+            adjudicationInfo: {
+              requiresAdjudication: true,
+              allReasonInfos: [
+                {
+                  type: AdjudicationReason.Undervote,
+                  contestId: '1',
+                  optionIds: [],
+                  expected: 1,
+                },
+              ],
+              enabledReasons: [AdjudicationReason.Undervote],
+            },
+            votes: {},
           },
-          metadata: {
-            ballotStyleId: '1',
-            precinctId: '1',
-            ballotType: BallotType.Standard,
-            electionHash: '',
-            isTestMode: false,
-            locales: { primary: 'en-US' },
-            pageNumber: 1,
-          },
-          adjudicationInfo: {
-            requiresAdjudication: true,
-            allReasonInfos: [
-              {
-                type: AdjudicationReason.Undervote,
-                contestId: '1',
-                optionIds: [],
-                expected: 1,
-              },
-            ],
-            enabledReasons: [AdjudicationReason.Undervote],
-          },
-          votes: {},
         },
-      },
-      back: {
-        image: { url: '/back/url' },
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          markInfo: {
-            ballotSize: { width: 1, height: 1 },
-            marks: [],
+        back: {
+          image: { url: '/back/url' },
+          interpretation: {
+            type: 'InterpretedHmpbPage',
+            markInfo: {
+              ballotSize: { width: 1, height: 1 },
+              marks: [],
+            },
+            metadata: {
+              ballotStyleId: '1',
+              precinctId: '1',
+              ballotType: BallotType.Standard,
+              electionHash: '',
+              isTestMode: false,
+              locales: { primary: 'en-US' },
+              pageNumber: 2,
+            },
+            adjudicationInfo: {
+              requiresAdjudication: false,
+              allReasonInfos: [],
+              enabledReasons: [AdjudicationReason.Overvote],
+            },
+            votes: {},
           },
-          metadata: {
-            ballotStyleId: '1',
-            precinctId: '1',
-            ballotType: BallotType.Standard,
-            electionHash: '',
-            isTestMode: false,
-            locales: { primary: 'en-US' },
-            pageNumber: 2,
-          },
-          adjudicationInfo: {
-            requiresAdjudication: false,
-            allReasonInfos: [],
-            enabledReasons: [AdjudicationReason.Overvote],
-          },
-          votes: {},
         },
       },
     })
@@ -222,56 +225,58 @@ test('says the ballot sheet is undervoted if it is', async () => {
 test('says the ballot sheet is blank if it is', async () => {
   fetchMock.getOnce(
     '/scan/hmpb/review/next-sheet',
-    typedAs<BallotSheetInfo>({
-      id: 'mock-sheet-id',
-      front: {
-        image: { url: '/front/url' },
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          markInfo: {
-            ballotSize: { width: 1, height: 1 },
-            marks: [],
+    typedAs<GetNextReviewSheetResponse>({
+      interpreted: {
+        id: 'mock-sheet-id',
+        front: {
+          image: { url: '/front/url' },
+          interpretation: {
+            type: 'InterpretedHmpbPage',
+            markInfo: {
+              ballotSize: { width: 1, height: 1 },
+              marks: [],
+            },
+            metadata: {
+              ballotStyleId: '1',
+              precinctId: '1',
+              ballotType: BallotType.Standard,
+              electionHash: '',
+              isTestMode: false,
+              locales: { primary: 'en-US' },
+              pageNumber: 1,
+            },
+            adjudicationInfo: {
+              requiresAdjudication: true,
+              allReasonInfos: [{ type: AdjudicationReason.BlankBallot }],
+              enabledReasons: [AdjudicationReason.Overvote],
+            },
+            votes: {},
           },
-          metadata: {
-            ballotStyleId: '1',
-            precinctId: '1',
-            ballotType: BallotType.Standard,
-            electionHash: '',
-            isTestMode: false,
-            locales: { primary: 'en-US' },
-            pageNumber: 1,
-          },
-          adjudicationInfo: {
-            requiresAdjudication: true,
-            allReasonInfos: [{ type: AdjudicationReason.BlankBallot }],
-            enabledReasons: [AdjudicationReason.Overvote],
-          },
-          votes: {},
         },
-      },
-      back: {
-        image: { url: '/back/url' },
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          markInfo: {
-            ballotSize: { width: 1, height: 1 },
-            marks: [],
+        back: {
+          image: { url: '/back/url' },
+          interpretation: {
+            type: 'InterpretedHmpbPage',
+            markInfo: {
+              ballotSize: { width: 1, height: 1 },
+              marks: [],
+            },
+            metadata: {
+              ballotStyleId: '1',
+              precinctId: '1',
+              ballotType: BallotType.Standard,
+              electionHash: '',
+              isTestMode: false,
+              locales: { primary: 'en-US' },
+              pageNumber: 2,
+            },
+            adjudicationInfo: {
+              requiresAdjudication: false,
+              allReasonInfos: [],
+              enabledReasons: [AdjudicationReason.Overvote],
+            },
+            votes: {},
           },
-          metadata: {
-            ballotStyleId: '1',
-            precinctId: '1',
-            ballotType: BallotType.Standard,
-            electionHash: '',
-            isTestMode: false,
-            locales: { primary: 'en-US' },
-            pageNumber: 2,
-          },
-          adjudicationInfo: {
-            requiresAdjudication: false,
-            allReasonInfos: [],
-            enabledReasons: [AdjudicationReason.Overvote],
-          },
-          votes: {},
         },
       },
     })
@@ -303,35 +308,37 @@ test('says the ballot sheet is blank if it is', async () => {
 test('calls out live ballot sheets in test mode', async () => {
   fetchMock.getOnce(
     '/scan/hmpb/review/next-sheet',
-    typedAs<BallotSheetInfo>({
-      id: 'mock-sheet-id',
-      front: {
-        image: { url: '/front/url' },
-        interpretation: {
-          type: 'InvalidTestModePage',
-          metadata: {
-            ballotStyleId: '1',
-            precinctId: '1',
-            ballotType: BallotType.Standard,
-            electionHash: '',
-            isTestMode: false,
-            locales: { primary: 'en-US' },
-            pageNumber: 1,
+    typedAs<GetNextReviewSheetResponse>({
+      interpreted: {
+        id: 'mock-sheet-id',
+        front: {
+          image: { url: '/front/url' },
+          interpretation: {
+            type: 'InvalidTestModePage',
+            metadata: {
+              ballotStyleId: '1',
+              precinctId: '1',
+              ballotType: BallotType.Standard,
+              electionHash: '',
+              isTestMode: false,
+              locales: { primary: 'en-US' },
+              pageNumber: 1,
+            },
           },
         },
-      },
-      back: {
-        image: { url: '/back/url' },
-        interpretation: {
-          type: 'InvalidTestModePage',
-          metadata: {
-            ballotStyleId: '1',
-            precinctId: '1',
-            ballotType: BallotType.Standard,
-            electionHash: '',
-            isTestMode: false,
-            locales: { primary: 'en-US' },
-            pageNumber: 2,
+        back: {
+          image: { url: '/back/url' },
+          interpretation: {
+            type: 'InvalidTestModePage',
+            metadata: {
+              ballotStyleId: '1',
+              precinctId: '1',
+              ballotType: BallotType.Standard,
+              electionHash: '',
+              isTestMode: false,
+              locales: { primary: 'en-US' },
+              pageNumber: 2,
+            },
           },
         },
       },
@@ -357,35 +364,37 @@ test('calls out live ballot sheets in test mode', async () => {
 test('calls out test ballot sheets in live mode', async () => {
   fetchMock.getOnce(
     '/scan/hmpb/review/next-sheet',
-    typedAs<BallotSheetInfo>({
-      id: 'mock-sheet-id',
-      front: {
-        image: { url: '/front/url' },
-        interpretation: {
-          type: 'InvalidTestModePage',
-          metadata: {
-            ballotStyleId: '1',
-            precinctId: '1',
-            ballotType: BallotType.Standard,
-            electionHash: '',
-            isTestMode: false,
-            locales: { primary: 'en-US' },
-            pageNumber: 1,
+    typedAs<GetNextReviewSheetResponse>({
+      interpreted: {
+        id: 'mock-sheet-id',
+        front: {
+          image: { url: '/front/url' },
+          interpretation: {
+            type: 'InvalidTestModePage',
+            metadata: {
+              ballotStyleId: '1',
+              precinctId: '1',
+              ballotType: BallotType.Standard,
+              electionHash: '',
+              isTestMode: false,
+              locales: { primary: 'en-US' },
+              pageNumber: 1,
+            },
           },
         },
-      },
-      back: {
-        image: { url: '/back/url' },
-        interpretation: {
-          type: 'InvalidTestModePage',
-          metadata: {
-            ballotStyleId: '1',
-            precinctId: '1',
-            ballotType: BallotType.Standard,
-            electionHash: '',
-            isTestMode: false,
-            locales: { primary: 'en-US' },
-            pageNumber: 2,
+        back: {
+          image: { url: '/back/url' },
+          interpretation: {
+            type: 'InvalidTestModePage',
+            metadata: {
+              ballotStyleId: '1',
+              precinctId: '1',
+              ballotType: BallotType.Standard,
+              electionHash: '',
+              isTestMode: false,
+              locales: { primary: 'en-US' },
+              pageNumber: 2,
+            },
           },
         },
       },
@@ -409,22 +418,26 @@ test('calls out test ballot sheets in live mode', async () => {
 })
 
 test('shows invalid election screen when appropriate', async () => {
-  const response: BallotSheetInfo = {
-    id: 'mock-sheet-id',
-    front: {
-      image: { url: '/front/url' },
-      interpretation: {
-        type: 'InvalidElectionHashPage',
-        actualElectionHash: 'this-is-a-hash-hooray',
-        expectedElectionHash: 'something',
+  fetchMock.getOnce(
+    '/scan/hmpb/review/next-sheet',
+    typedAs<GetNextReviewSheetResponse>({
+      interpreted: {
+        id: 'mock-sheet-id',
+        front: {
+          image: { url: '/front/url' },
+          interpretation: {
+            type: 'InvalidElectionHashPage',
+            actualElectionHash: 'this-is-a-hash-hooray',
+            expectedElectionHash: 'something',
+          },
+        },
+        back: {
+          image: { url: '/back/url' },
+          interpretation: { type: 'BlankPage' },
+        },
       },
-    },
-    back: {
-      image: { url: '/back/url' },
-      interpretation: { type: 'BlankPage' },
-    },
-  }
-  fetchMock.getOnce('/scan/hmpb/review/next-sheet', response)
+    })
+  )
 
   const continueScanning = jest.fn()
 
@@ -447,35 +460,37 @@ test('shows invalid election screen when appropriate', async () => {
 test('shows invalid election screen when appropriate', async () => {
   fetchMock.getOnce(
     '/scan/hmpb/review/next-sheet',
-    typedAs<BallotSheetInfo>({
-      id: 'mock-sheet-id',
-      front: {
-        image: { url: '/front/url' },
-        interpretation: {
-          type: 'InvalidPrecinctPage',
-          metadata: {
-            ballotStyleId: '1',
-            precinctId: '1',
-            ballotType: BallotType.Standard,
-            electionHash: '',
-            isTestMode: false,
-            locales: { primary: 'en-US' },
-            pageNumber: 1,
+    typedAs<GetNextReviewSheetResponse>({
+      interpreted: {
+        id: 'mock-sheet-id',
+        front: {
+          image: { url: '/front/url' },
+          interpretation: {
+            type: 'InvalidPrecinctPage',
+            metadata: {
+              ballotStyleId: '1',
+              precinctId: '1',
+              ballotType: BallotType.Standard,
+              electionHash: '',
+              isTestMode: false,
+              locales: { primary: 'en-US' },
+              pageNumber: 1,
+            },
           },
         },
-      },
-      back: {
-        image: { url: '/back/url' },
-        interpretation: {
-          type: 'InvalidPrecinctPage',
-          metadata: {
-            ballotStyleId: '1',
-            precinctId: '1',
-            ballotType: BallotType.Standard,
-            electionHash: '',
-            isTestMode: false,
-            locales: { primary: 'en-US' },
-            pageNumber: 2,
+        back: {
+          image: { url: '/back/url' },
+          interpretation: {
+            type: 'InvalidPrecinctPage',
+            metadata: {
+              ballotStyleId: '1',
+              precinctId: '1',
+              ballotType: BallotType.Standard,
+              electionHash: '',
+              isTestMode: false,
+              locales: { primary: 'en-US' },
+              pageNumber: 2,
+            },
           },
         },
       },

--- a/apps/bsd/src/screens/BallotEjectScreen.tsx
+++ b/apps/bsd/src/screens/BallotEjectScreen.tsx
@@ -53,7 +53,7 @@ interface Props {
   isTestMode: boolean
 }
 
-type EjectState = undefined | 'removeBallot' | 'acceptBallot'
+type EjectState = 'removeBallot' | 'acceptBallot'
 
 const doNothing = () => {
   console.log('disabled') // eslint-disable-line no-console
@@ -65,7 +65,7 @@ const BallotEjectScreen = ({
 }: Props): JSX.Element => {
   const [sheetInfo, setSheetInfo] = useState<BallotSheetInfo>()
 
-  const [ballotState, setBallotState] = useState<EjectState>(undefined)
+  const [ballotState, setBallotState] = useState<EjectState>()
 
   useEffect(() => {
     void (async () => {

--- a/apps/bsd/src/screens/BallotEjectScreen.tsx
+++ b/apps/bsd/src/screens/BallotEjectScreen.tsx
@@ -69,7 +69,7 @@ const BallotEjectScreen = ({
 
   useEffect(() => {
     void (async () => {
-      setSheetInfo(await fetchNextBallotSheetToReview())
+      setSheetInfo((await fetchNextBallotSheetToReview())?.interpreted)
     })()
   }, [setSheetInfo])
 

--- a/apps/bsd/src/screens/__snapshots__/BallotEjectScreen.test.tsx.snap
+++ b/apps/bsd/src/screens/__snapshots__/BallotEjectScreen.test.tsx.snap
@@ -3,19 +3,19 @@
 exports[`calls out live ballot sheets in test mode 1`] = `
 <div>
   <div
-    class="sc-bqyKva dgfgdQ"
+    class="sc-dQppl CqIxD"
   >
     <div
-      class="sc-fubCfw iyxBWV"
+      class="sc-gKsewC eUhhMQ"
     >
       <div
-        class="sc-pFZIQ hrSaSI"
+        class="sc-iBPRYJ hPAooK"
       >
         <div
-          class="sc-jrAGrp bYvxaX"
+          class="sc-fubCfw hAIFcM"
         >
           <div
-            class="sc-kEjbxe bgYkJF"
+            class="sc-pFZIQ Korzq"
           >
             Voting
             <span>
@@ -23,16 +23,16 @@ exports[`calls out live ballot sheets in test mode 1`] = `
             </span>
           </div>
           <div
-            class="sc-iqHYGH"
+            class="sc-jrAGrp"
           >
             Ballot Scanner
           </div>
         </div>
         <div
-          class="sc-crrsfI dGHIEc"
+          class="sc-kEjbxe eDKgHQ"
         >
           <button
-            class="sc-eCssSg czdiXU"
+            class="sc-gsTCUz bQMNvi"
             type="button"
           >
             Confirm Ballot Removed and Continue Scanning
@@ -41,13 +41,13 @@ exports[`calls out live ballot sheets in test mode 1`] = `
       </div>
     </div>
     <main
-      class="sc-bdfBwQ jA-DOsk"
+      class="sc-eCssSg jJQcwm"
     >
       <div
         class="sc-fodVxV czxgUa"
       >
         <div
-          class="sc-dlfnbm ddzYNI"
+          class="sc-crrsfI dvOODA"
         >
           <div
             class="sc-hBEYos ceYTYH"
@@ -68,15 +68,19 @@ exports[`calls out live ballot sheets in test mode 1`] = `
         <div
           class="sc-fFubgz iIcvCZ"
         >
-          <div>
+          <div
+            style="position: relative;"
+          >
             <img
               alt="front"
               src="/front/url"
             />
           </div>
-          <div>
+          <div
+            style="position: relative;"
+          >
             <img
-              alt="back"
+              alt="front"
               src="/back/url"
             />
           </div>
@@ -87,7 +91,7 @@ exports[`calls out live ballot sheets in test mode 1`] = `
       class="sc-kstrdz kvxcls"
     >
       <div
-        class="sc-iBPRYJ dBXfiC"
+        class="sc-bqyKva kbFFdu"
       >
         Scanner ID: 
         <strong>
@@ -95,7 +99,7 @@ exports[`calls out live ballot sheets in test mode 1`] = `
         </strong>
       </div>
       <div
-        class="sc-iBPRYJ dBXfiC"
+        class="sc-bqyKva kbFFdu"
       >
         <strong>
           General Election
@@ -123,19 +127,19 @@ exports[`calls out live ballot sheets in test mode 1`] = `
 exports[`calls out test ballot sheets in live mode 1`] = `
 <div>
   <div
-    class="sc-bqyKva dgfgdQ"
+    class="sc-dQppl CqIxD"
   >
     <div
-      class="sc-fubCfw iyxBWV"
+      class="sc-gKsewC eUhhMQ"
     >
       <div
-        class="sc-pFZIQ hrSaSI"
+        class="sc-iBPRYJ hPAooK"
       >
         <div
-          class="sc-jrAGrp bYvxaX"
+          class="sc-fubCfw hAIFcM"
         >
           <div
-            class="sc-kEjbxe bgYkJF"
+            class="sc-pFZIQ Korzq"
           >
             Voting
             <span>
@@ -143,16 +147,16 @@ exports[`calls out test ballot sheets in live mode 1`] = `
             </span>
           </div>
           <div
-            class="sc-iqHYGH"
+            class="sc-jrAGrp"
           >
             Ballot Scanner
           </div>
         </div>
         <div
-          class="sc-crrsfI dGHIEc"
+          class="sc-kEjbxe eDKgHQ"
         >
           <button
-            class="sc-eCssSg czdiXU"
+            class="sc-gsTCUz bQMNvi"
             type="button"
           >
             Confirm Ballot Removed and Continue Scanning
@@ -161,13 +165,13 @@ exports[`calls out test ballot sheets in live mode 1`] = `
       </div>
     </div>
     <main
-      class="sc-bdfBwQ jA-DOsk"
+      class="sc-eCssSg jJQcwm"
     >
       <div
         class="sc-fodVxV czxgUa"
       >
         <div
-          class="sc-dlfnbm ddzYNI"
+          class="sc-crrsfI dvOODA"
         >
           <div
             class="sc-hBEYos ceYTYH"
@@ -188,15 +192,19 @@ exports[`calls out test ballot sheets in live mode 1`] = `
         <div
           class="sc-fFubgz iIcvCZ"
         >
-          <div>
+          <div
+            style="position: relative;"
+          >
             <img
               alt="front"
               src="/front/url"
             />
           </div>
-          <div>
+          <div
+            style="position: relative;"
+          >
             <img
-              alt="back"
+              alt="front"
               src="/back/url"
             />
           </div>
@@ -207,7 +215,7 @@ exports[`calls out test ballot sheets in live mode 1`] = `
       class="sc-kstrdz kvxcls"
     >
       <div
-        class="sc-iBPRYJ dBXfiC"
+        class="sc-bqyKva kbFFdu"
       >
         Scanner ID: 
         <strong>
@@ -215,7 +223,7 @@ exports[`calls out test ballot sheets in live mode 1`] = `
         </strong>
       </div>
       <div
-        class="sc-iBPRYJ dBXfiC"
+        class="sc-bqyKva kbFFdu"
       >
         <strong>
           General Election
@@ -243,19 +251,19 @@ exports[`calls out test ballot sheets in live mode 1`] = `
 exports[`says the ballot sheet is blank if it is 1`] = `
 <div>
   <div
-    class="sc-bqyKva dgfgdQ"
+    class="sc-dQppl CqIxD"
   >
     <div
-      class="sc-fubCfw iyxBWV"
+      class="sc-gKsewC eUhhMQ"
     >
       <div
-        class="sc-pFZIQ hrSaSI"
+        class="sc-iBPRYJ hPAooK"
       >
         <div
-          class="sc-jrAGrp bYvxaX"
+          class="sc-fubCfw hAIFcM"
         >
           <div
-            class="sc-kEjbxe bgYkJF"
+            class="sc-pFZIQ Korzq"
           >
             Voting
             <span>
@@ -263,16 +271,16 @@ exports[`says the ballot sheet is blank if it is 1`] = `
             </span>
           </div>
           <div
-            class="sc-iqHYGH"
+            class="sc-jrAGrp"
           >
             Ballot Scanner
           </div>
         </div>
         <div
-          class="sc-crrsfI dGHIEc"
+          class="sc-kEjbxe eDKgHQ"
         >
           <button
-            class="sc-eCssSg fEkUoC"
+            class="sc-gsTCUz iulVCQ"
             disabled=""
             type="button"
           >
@@ -282,13 +290,13 @@ exports[`says the ballot sheet is blank if it is 1`] = `
       </div>
     </div>
     <main
-      class="sc-bdfBwQ jA-DOsk"
+      class="sc-eCssSg jJQcwm"
     >
       <div
         class="sc-fodVxV czxgUa"
       >
         <div
-          class="sc-dlfnbm ddzYNI"
+          class="sc-crrsfI dvOODA"
         >
           <div
             class="sc-hBEYos ceYTYH"
@@ -309,7 +317,7 @@ exports[`says the ballot sheet is blank if it is 1`] = `
             Remove ballot and create a duplicate ballot for the Resolution Board to review.
             <br />
             <button
-              class="sc-eCssSg bFFZjC"
+              class="sc-gsTCUz ftrorQ"
               type="button"
             >
               Original Ballot Removed
@@ -322,7 +330,7 @@ exports[`says the ballot sheet is blank if it is 1`] = `
             Confirm ballot sheet was reviewed by the Resolution Board and tabulate as ballot with issue which could not be determined.
             <br />
             <button
-              class="sc-eCssSg bFFZjC"
+              class="sc-gsTCUz ftrorQ"
               type="button"
             >
               Tabulate Duplicate Ballot
@@ -332,15 +340,19 @@ exports[`says the ballot sheet is blank if it is 1`] = `
         <div
           class="sc-fFubgz iIcvCZ"
         >
-          <div>
+          <div
+            style="position: relative;"
+          >
             <img
               alt="front"
               src="/front/url"
             />
           </div>
-          <div>
+          <div
+            style="position: relative;"
+          >
             <img
-              alt="back"
+              alt="front"
               src="/back/url"
             />
           </div>
@@ -351,7 +363,7 @@ exports[`says the ballot sheet is blank if it is 1`] = `
       class="sc-kstrdz kvxcls"
     >
       <div
-        class="sc-iBPRYJ dBXfiC"
+        class="sc-bqyKva kbFFdu"
       >
         Scanner ID: 
         <strong>
@@ -359,7 +371,7 @@ exports[`says the ballot sheet is blank if it is 1`] = `
         </strong>
       </div>
       <div
-        class="sc-iBPRYJ dBXfiC"
+        class="sc-bqyKva kbFFdu"
       >
         <strong>
           General Election
@@ -387,19 +399,19 @@ exports[`says the ballot sheet is blank if it is 1`] = `
 exports[`says the ballot sheet is overvoted if it is 1`] = `
 <div>
   <div
-    class="sc-bqyKva dgfgdQ"
+    class="sc-dQppl CqIxD"
   >
     <div
-      class="sc-fubCfw iyxBWV"
+      class="sc-gKsewC eUhhMQ"
     >
       <div
-        class="sc-pFZIQ hrSaSI"
+        class="sc-iBPRYJ hPAooK"
       >
         <div
-          class="sc-jrAGrp bYvxaX"
+          class="sc-fubCfw hAIFcM"
         >
           <div
-            class="sc-kEjbxe bgYkJF"
+            class="sc-pFZIQ Korzq"
           >
             Voting
             <span>
@@ -407,16 +419,16 @@ exports[`says the ballot sheet is overvoted if it is 1`] = `
             </span>
           </div>
           <div
-            class="sc-iqHYGH"
+            class="sc-jrAGrp"
           >
             Ballot Scanner
           </div>
         </div>
         <div
-          class="sc-crrsfI dGHIEc"
+          class="sc-kEjbxe eDKgHQ"
         >
           <button
-            class="sc-eCssSg fEkUoC"
+            class="sc-gsTCUz iulVCQ"
             disabled=""
             type="button"
           >
@@ -426,13 +438,13 @@ exports[`says the ballot sheet is overvoted if it is 1`] = `
       </div>
     </div>
     <main
-      class="sc-bdfBwQ jA-DOsk"
+      class="sc-eCssSg jJQcwm"
     >
       <div
         class="sc-fodVxV czxgUa"
       >
         <div
-          class="sc-dlfnbm ddzYNI"
+          class="sc-crrsfI dvOODA"
         >
           <div
             class="sc-hBEYos ceYTYH"
@@ -453,7 +465,7 @@ exports[`says the ballot sheet is overvoted if it is 1`] = `
             Remove ballot and create a duplicate ballot for the Resolution Board to review.
             <br />
             <button
-              class="sc-eCssSg bFFZjC"
+              class="sc-gsTCUz ftrorQ"
               type="button"
             >
               Original Ballot Removed
@@ -471,7 +483,7 @@ exports[`says the ballot sheet is overvoted if it is 1`] = `
             .
             <br />
             <button
-              class="sc-eCssSg bFFZjC"
+              class="sc-gsTCUz ftrorQ"
               type="button"
             >
               Tabulate Duplicate Ballot
@@ -481,15 +493,19 @@ exports[`says the ballot sheet is overvoted if it is 1`] = `
         <div
           class="sc-fFubgz iIcvCZ"
         >
-          <div>
+          <div
+            style="position: relative;"
+          >
             <img
               alt="front"
               src="/front/url"
             />
           </div>
-          <div>
+          <div
+            style="position: relative;"
+          >
             <img
-              alt="back"
+              alt="front"
               src="/back/url"
             />
           </div>
@@ -500,7 +516,7 @@ exports[`says the ballot sheet is overvoted if it is 1`] = `
       class="sc-kstrdz kvxcls"
     >
       <div
-        class="sc-iBPRYJ dBXfiC"
+        class="sc-bqyKva kbFFdu"
       >
         Scanner ID: 
         <strong>
@@ -508,7 +524,7 @@ exports[`says the ballot sheet is overvoted if it is 1`] = `
         </strong>
       </div>
       <div
-        class="sc-iBPRYJ dBXfiC"
+        class="sc-bqyKva kbFFdu"
       >
         <strong>
           General Election
@@ -536,19 +552,19 @@ exports[`says the ballot sheet is overvoted if it is 1`] = `
 exports[`says the ballot sheet is undervoted if it is 1`] = `
 <div>
   <div
-    class="sc-bqyKva dgfgdQ"
+    class="sc-dQppl CqIxD"
   >
     <div
-      class="sc-fubCfw iyxBWV"
+      class="sc-gKsewC eUhhMQ"
     >
       <div
-        class="sc-pFZIQ hrSaSI"
+        class="sc-iBPRYJ hPAooK"
       >
         <div
-          class="sc-jrAGrp bYvxaX"
+          class="sc-fubCfw hAIFcM"
         >
           <div
-            class="sc-kEjbxe bgYkJF"
+            class="sc-pFZIQ Korzq"
           >
             Voting
             <span>
@@ -556,16 +572,16 @@ exports[`says the ballot sheet is undervoted if it is 1`] = `
             </span>
           </div>
           <div
-            class="sc-iqHYGH"
+            class="sc-jrAGrp"
           >
             Ballot Scanner
           </div>
         </div>
         <div
-          class="sc-crrsfI dGHIEc"
+          class="sc-kEjbxe eDKgHQ"
         >
           <button
-            class="sc-eCssSg fEkUoC"
+            class="sc-gsTCUz iulVCQ"
             disabled=""
             type="button"
           >
@@ -575,13 +591,13 @@ exports[`says the ballot sheet is undervoted if it is 1`] = `
       </div>
     </div>
     <main
-      class="sc-bdfBwQ jA-DOsk"
+      class="sc-eCssSg jJQcwm"
     >
       <div
         class="sc-fodVxV czxgUa"
       >
         <div
-          class="sc-dlfnbm ddzYNI"
+          class="sc-crrsfI dvOODA"
         >
           <div
             class="sc-hBEYos ceYTYH"
@@ -602,7 +618,7 @@ exports[`says the ballot sheet is undervoted if it is 1`] = `
             Remove ballot and create a duplicate ballot for the Resolution Board to review.
             <br />
             <button
-              class="sc-eCssSg bFFZjC"
+              class="sc-gsTCUz ftrorQ"
               type="button"
             >
               Original Ballot Removed
@@ -615,7 +631,7 @@ exports[`says the ballot sheet is undervoted if it is 1`] = `
             Confirm ballot sheet was reviewed by the Resolution Board and tabulate as ballot with issue which could not be determined.
             <br />
             <button
-              class="sc-eCssSg bFFZjC"
+              class="sc-gsTCUz ftrorQ"
               type="button"
             >
               Tabulate Duplicate Ballot
@@ -625,15 +641,19 @@ exports[`says the ballot sheet is undervoted if it is 1`] = `
         <div
           class="sc-fFubgz iIcvCZ"
         >
-          <div>
+          <div
+            style="position: relative;"
+          >
             <img
               alt="front"
               src="/front/url"
             />
           </div>
-          <div>
+          <div
+            style="position: relative;"
+          >
             <img
-              alt="back"
+              alt="front"
               src="/back/url"
             />
           </div>
@@ -644,7 +664,7 @@ exports[`says the ballot sheet is undervoted if it is 1`] = `
       class="sc-kstrdz kvxcls"
     >
       <div
-        class="sc-iBPRYJ dBXfiC"
+        class="sc-bqyKva kbFFdu"
       >
         Scanner ID: 
         <strong>
@@ -652,7 +672,7 @@ exports[`says the ballot sheet is undervoted if it is 1`] = `
         </strong>
       </div>
       <div
-        class="sc-iBPRYJ dBXfiC"
+        class="sc-bqyKva kbFFdu"
       >
         <strong>
           General Election
@@ -680,19 +700,19 @@ exports[`says the ballot sheet is undervoted if it is 1`] = `
 exports[`says the sheet is unreadable if it is 1`] = `
 <div>
   <div
-    class="sc-bqyKva dgfgdQ"
+    class="sc-dQppl CqIxD"
   >
     <div
-      class="sc-fubCfw iyxBWV"
+      class="sc-gKsewC eUhhMQ"
     >
       <div
-        class="sc-pFZIQ hrSaSI"
+        class="sc-iBPRYJ hPAooK"
       >
         <div
-          class="sc-jrAGrp bYvxaX"
+          class="sc-fubCfw hAIFcM"
         >
           <div
-            class="sc-kEjbxe bgYkJF"
+            class="sc-pFZIQ Korzq"
           >
             Voting
             <span>
@@ -700,16 +720,16 @@ exports[`says the sheet is unreadable if it is 1`] = `
             </span>
           </div>
           <div
-            class="sc-iqHYGH"
+            class="sc-jrAGrp"
           >
             Ballot Scanner
           </div>
         </div>
         <div
-          class="sc-crrsfI dGHIEc"
+          class="sc-kEjbxe eDKgHQ"
         >
           <button
-            class="sc-eCssSg czdiXU"
+            class="sc-gsTCUz bQMNvi"
             type="button"
           >
             Confirm Ballot Removed and Continue Scanning
@@ -718,13 +738,13 @@ exports[`says the sheet is unreadable if it is 1`] = `
       </div>
     </div>
     <main
-      class="sc-bdfBwQ jA-DOsk"
+      class="sc-eCssSg jJQcwm"
     >
       <div
         class="sc-fodVxV czxgUa"
       >
         <div
-          class="sc-dlfnbm ddzYNI"
+          class="sc-crrsfI dvOODA"
         >
           <div
             class="sc-hBEYos ceYTYH"
@@ -748,15 +768,19 @@ exports[`says the sheet is unreadable if it is 1`] = `
         <div
           class="sc-fFubgz iIcvCZ"
         >
-          <div>
+          <div
+            style="position: relative;"
+          >
             <img
               alt="front"
               src="/front/url"
             />
           </div>
-          <div>
+          <div
+            style="position: relative;"
+          >
             <img
-              alt="back"
+              alt="front"
               src="/back/url"
             />
           </div>
@@ -767,7 +791,7 @@ exports[`says the sheet is unreadable if it is 1`] = `
       class="sc-kstrdz kvxcls"
     >
       <div
-        class="sc-iBPRYJ dBXfiC"
+        class="sc-bqyKva kbFFdu"
       >
         Scanner ID: 
         <strong>
@@ -775,7 +799,7 @@ exports[`says the sheet is unreadable if it is 1`] = `
         </strong>
       </div>
       <div
-        class="sc-iBPRYJ dBXfiC"
+        class="sc-bqyKva kbFFdu"
       >
         <strong>
           General Election

--- a/apps/module-scan/src/cli/render-pages.test.ts
+++ b/apps/module-scan/src/cli/render-pages.test.ts
@@ -88,8 +88,20 @@ test('generates one image per PDF page per DB', async () => {
     precinctId: '6538',
   }
   await store.addHmpbTemplate(await fs.readFile(ballotPdf), metadata, [
-    { ballotImage: { metadata: { ...metadata, pageNumber: 1 } }, contests: [] },
-    { ballotImage: { metadata: { ...metadata, pageNumber: 2 } }, contests: [] },
+    {
+      ballotImage: {
+        imageData: { width: 1, height: 1 },
+        metadata: { ...metadata, pageNumber: 1 },
+      },
+      contests: [],
+    },
+    {
+      ballotImage: {
+        imageData: { width: 1, height: 1 },
+        metadata: { ...metadata, pageNumber: 2 },
+      },
+      contests: [],
+    },
   ])
 
   const stdout = fakeOutput()

--- a/apps/module-scan/src/importer.test.ts
+++ b/apps/module-scan/src/importer.test.ts
@@ -3,8 +3,11 @@ import {
   asElectionDefinition,
   electionSample as election,
 } from '@votingworks/fixtures'
-import { BallotPageMetadata } from '@votingworks/hmpb-interpreter'
-import { BallotSheetInfo, BallotType } from '@votingworks/types'
+import {
+  BallotPageMetadata,
+  BallotSheetInfo,
+  BallotType,
+} from '@votingworks/types'
 import { sleep } from '@votingworks/utils'
 import * as fs from 'fs-extra'
 import { join } from 'path'

--- a/apps/module-scan/src/importer.ts
+++ b/apps/module-scan/src/importer.ts
@@ -1,6 +1,7 @@
-import { BallotPageLayout, Interpreter } from '@votingworks/hmpb-interpreter'
+import { Interpreter } from '@votingworks/hmpb-interpreter'
 import {
   BallotMetadata,
+  BallotPageLayout,
   ElectionDefinition,
   MarkThresholds,
   Optional,
@@ -139,6 +140,10 @@ export default class Importer {
       result.map((layout) => ({
         ...layout,
         ballotImage: {
+          imageData: {
+            width: layout.ballotImage.imageData.width,
+            height: layout.ballotImage.imageData.height,
+          },
           metadata: layout.ballotImage.metadata,
         },
       }))

--- a/apps/module-scan/src/interpreter.ts
+++ b/apps/module-scan/src/interpreter.ts
@@ -10,14 +10,14 @@ import {
   ELECTION_HASH_LENGTH,
 } from '@votingworks/ballot-encoder'
 import {
-  BallotPageLayout,
-  BallotPageMetadata,
   DetectQRCodeResult,
   Interpreter as HMPBInterpreter,
   metadataFromBytes,
 } from '@votingworks/hmpb-interpreter'
 import {
   AdjudicationReason,
+  BallotPageLayout,
+  BallotPageMetadata,
   BallotType,
   Contests,
   Election,

--- a/apps/module-scan/src/server.test.ts
+++ b/apps/module-scan/src/server.test.ts
@@ -49,6 +49,7 @@ beforeEach(async () => {
     [
       {
         ballotImage: {
+          imageData: { width: 1, height: 1 },
           metadata: {
             locales: { primary: 'en-US' },
             electionHash: '',
@@ -63,6 +64,7 @@ beforeEach(async () => {
       },
       {
         ballotImage: {
+          imageData: { width: 1, height: 1 },
           metadata: {
             locales: { primary: 'en-US' },
             electionHash: '',
@@ -602,6 +604,8 @@ test('get next sheet', async () => {
             interpretation: { type: 'BlankPage' },
           },
         },
+        layouts: {},
+        definitions: {},
       })
     )
 })

--- a/apps/module-scan/src/server.test.ts
+++ b/apps/module-scan/src/server.test.ts
@@ -2,9 +2,11 @@ import { electionSampleDefinition as testElectionDefinition } from '@votingworks
 import * as plusteksdk from '@votingworks/plustek-sdk'
 import { BallotType, ok } from '@votingworks/types'
 import {
+  GetNextReviewSheetResponse,
   GetScanStatusResponse,
   ScannerStatus,
 } from '@votingworks/types/api/module-scan'
+import { typedAs } from '@votingworks/utils/build'
 import { Application } from 'express'
 import { promises as fs } from 'fs'
 import { Server } from 'http'
@@ -586,17 +588,22 @@ test('get next sheet', async () => {
 
   await request(app)
     .get(`/scan/hmpb/review/next-sheet`)
-    .expect(200, {
-      id: 'mock-review-sheet',
-      front: {
-        image: { url: '/url/front' },
-        interpretation: { type: 'BlankPage' },
-      },
-      back: {
-        image: { url: '/url/back' },
-        interpretation: { type: 'BlankPage' },
-      },
-    })
+    .expect(
+      200,
+      typedAs<GetNextReviewSheetResponse>({
+        interpreted: {
+          id: 'mock-review-sheet',
+          front: {
+            image: { url: '/url/front' },
+            interpretation: { type: 'BlankPage' },
+          },
+          back: {
+            image: { url: '/url/back' },
+            interpretation: { type: 'BlankPage' },
+          },
+        },
+      })
+    )
 })
 
 test('calibrate success', async () => {

--- a/apps/module-scan/src/server.ts
+++ b/apps/module-scan/src/server.ts
@@ -22,6 +22,7 @@ import {
   GetCurrentPrecinctConfigResponse,
   GetElectionConfigResponse,
   GetMarkThresholdOverridesConfigResponse,
+  GetNextReviewSheetResponse,
   GetScanStatusResponse,
   GetTestModeConfigResponse,
   PatchElectionConfigRequest,
@@ -511,15 +512,20 @@ export function buildApp({ store, importer }: AppOptions): Application {
     }
   })
 
-  app.get('/scan/hmpb/review/next-sheet', async (_request, response) => {
-    const sheet = await store.getNextAdjudicationSheet()
+  app.get<NoParams, GetNextReviewSheetResponse>(
+    '/scan/hmpb/review/next-sheet',
+    async (_request, response) => {
+      const sheet = await store.getNextAdjudicationSheet()
 
-    if (sheet) {
-      response.json(sheet)
-    } else {
-      response.status(404).end()
+      if (sheet) {
+        response.json({
+          interpreted: sheet,
+        })
+      } else {
+        response.status(404).end()
+      }
     }
-  })
+  )
 
   app.post<NoParams, ZeroResponse, ZeroRequest>(
     '/scan/zero',

--- a/apps/module-scan/src/store.test.ts
+++ b/apps/module-scan/src/store.test.ts
@@ -4,8 +4,10 @@ import {
   BallotMetadata,
   BallotType,
   CandidateContest,
+  SerializableBallotPageLayout,
   YesNoContest,
 } from '@votingworks/types'
+import { typedAs } from '@votingworks/utils/build'
 import { promises as fs } from 'fs'
 import * as tmp from 'tmp'
 import { v4 as uuid } from 'uuid'
@@ -90,6 +92,7 @@ test('HMPB template handling', async () => {
   await store.addHmpbTemplate(Buffer.of(1, 2, 3), metadata, [
     {
       ballotImage: {
+        imageData: { width: 1, height: 1 },
         metadata: {
           ...metadata,
           pageNumber: 1,
@@ -99,6 +102,7 @@ test('HMPB template handling', async () => {
     },
     {
       ballotImage: {
+        imageData: { width: 1, height: 1 },
         metadata: {
           ...metadata,
           pageNumber: 2,
@@ -108,41 +112,45 @@ test('HMPB template handling', async () => {
     },
   ])
 
-  expect(await store.getHmpbTemplates()).toEqual([
-    [
-      Buffer.of(1, 2, 3),
+  expect(await store.getHmpbTemplates()).toEqual(
+    typedAs<[Buffer, SerializableBallotPageLayout[]][]>([
       [
-        {
-          ballotImage: {
-            metadata: {
-              electionHash: '',
-              ballotType: BallotType.Standard,
-              locales: { primary: 'en-US' },
-              ballotStyleId: '12',
-              precinctId: '23',
-              isTestMode: false,
-              pageNumber: 1,
+        Buffer.of(1, 2, 3),
+        [
+          {
+            ballotImage: {
+              imageData: { width: 1, height: 1 },
+              metadata: {
+                electionHash: '',
+                ballotType: BallotType.Standard,
+                locales: { primary: 'en-US' },
+                ballotStyleId: '12',
+                precinctId: '23',
+                isTestMode: false,
+                pageNumber: 1,
+              },
             },
+            contests: [],
           },
-          contests: [],
-        },
-        {
-          ballotImage: {
-            metadata: {
-              electionHash: '',
-              ballotType: BallotType.Standard,
-              locales: { primary: 'en-US' },
-              ballotStyleId: '12',
-              precinctId: '23',
-              isTestMode: false,
-              pageNumber: 2,
+          {
+            ballotImage: {
+              imageData: { width: 1, height: 1 },
+              metadata: {
+                electionHash: '',
+                ballotType: BallotType.Standard,
+                locales: { primary: 'en-US' },
+                ballotStyleId: '12',
+                precinctId: '23',
+                isTestMode: false,
+                pageNumber: 2,
+              },
             },
+            contests: [],
           },
-          contests: [],
-        },
+        ],
       ],
-    ],
-  ])
+    ])
+  )
 })
 
 test('destroy database', async () => {
@@ -215,6 +223,7 @@ test('adjudication', async () => {
     metadata,
     [1, 2].map((pageNumber) => ({
       ballotImage: {
+        imageData: { width: 1, height: 1 },
         metadata: {
           ...metadata,
           pageNumber,

--- a/apps/module-scan/src/store.ts
+++ b/apps/module-scan/src/store.ts
@@ -2,12 +2,11 @@
 // The durable datastore for CVRs and configuration info.
 //
 
-import { strict as assert } from 'assert'
-import { BallotPageMetadata } from '@votingworks/hmpb-interpreter'
 import {
   AnyContest,
   BallotMark,
   BallotMetadata,
+  BallotPageMetadata,
   BallotSheetInfo,
   BallotTargetMark,
   ElectionDefinition,
@@ -20,11 +19,13 @@ import {
   PageInterpretation,
   Precinct,
   safeParseJSON,
+  SerializableBallotPageLayout,
 } from '@votingworks/types'
 import {
   AdjudicationStatus,
   BatchInfo,
 } from '@votingworks/types/api/module-scan'
+import { strict as assert } from 'assert'
 import { createHash } from 'crypto'
 import makeDebug from 'debug'
 import { promises as fs } from 'fs'
@@ -40,7 +41,6 @@ import { sheetRequiresAdjudication } from './interpreter'
 import {
   isMarginalMark,
   PageInterpretationWithFiles,
-  SerializableBallotPageLayout,
   SheetOf,
   Side,
 } from './types'
@@ -1055,6 +1055,7 @@ export default class Store {
         layouts.map((layout, i) => ({
           ...layout,
           ballotImage: {
+            ...layout.ballotImage,
             metadata: {
               ...metadata,
               pageNumber: i + 1,

--- a/apps/module-scan/src/types.ts
+++ b/apps/module-scan/src/types.ts
@@ -1,4 +1,3 @@
-import { BallotPageLayout } from '@votingworks/hmpb-interpreter'
 import {
   BallotLocales,
   BallotMark,
@@ -44,13 +43,6 @@ export interface CastVoteRecord
 export interface BallotPageQrcode {
   data: Uint8Array
   position: 'top' | 'bottom'
-}
-
-export type SerializableBallotPageLayout = Omit<
-  BallotPageLayout,
-  'ballotImage'
-> & {
-  ballotImage: Omit<BallotPageLayout['ballotImage'], 'imageData'>
 }
 
 export interface BallotConfig extends BallotStyleData {

--- a/apps/module-scan/src/util/getBallotPageContests.test.ts
+++ b/apps/module-scan/src/util/getBallotPageContests.test.ts
@@ -1,7 +1,11 @@
-import { BallotType, getBallotStyle, getContests } from '@votingworks/types'
-import { BallotPageMetadata } from '@votingworks/hmpb-interpreter'
+import {
+  BallotPageMetadata,
+  BallotType,
+  getBallotStyle,
+  getContests,
+  SerializableBallotPageLayout,
+} from '@votingworks/types'
 import { election } from '../../test/fixtures/state-of-hamilton'
-import { SerializableBallotPageLayout } from '../types'
 import getBallotPageContests from './getBallotPageContests'
 
 function metadataForPage(pageNumber: number): BallotPageMetadata {
@@ -20,7 +24,10 @@ test('gets contests broken across pages according to the layout', () => {
   const allContestsForBallot = getContests({ ballotStyle, election })
   const layouts = Array.from({ length: 5 }).map<SerializableBallotPageLayout>(
     (_, i) => ({
-      ballotImage: { metadata: metadataForPage(i) },
+      ballotImage: {
+        imageData: { width: 1, height: 1 },
+        metadata: metadataForPage(i),
+      },
       contests: [
         {
           bounds: { x: 0, y: 0, width: 0, height: 0 },

--- a/apps/module-scan/src/util/getBallotPageContests.ts
+++ b/apps/module-scan/src/util/getBallotPageContests.ts
@@ -1,12 +1,12 @@
 import { strict as assert } from 'assert'
 import {
+  BallotPageMetadata,
   Contests,
   Election,
   getBallotStyle,
   getContests,
+  SerializableBallotPageLayout,
 } from '@votingworks/types'
-import { BallotPageMetadata } from '@votingworks/hmpb-interpreter'
-import { SerializableBallotPageLayout } from '../types'
 
 /**
  * Gets the contests that appear on a given paper ballot page.

--- a/apps/module-scan/src/util/metadata.test.ts
+++ b/apps/module-scan/src/util/metadata.test.ts
@@ -1,10 +1,13 @@
-import { BallotMetadata, BallotType } from '@votingworks/types'
+import {
+  BallotMetadata,
+  BallotPageMetadata,
+  BallotType,
+} from '@votingworks/types'
 import {
   encodeBallot,
   encodeHMPBBallotPageMetadata,
 } from '@votingworks/ballot-encoder'
 import { electionSampleDefinition as electionDefinition } from '@votingworks/fixtures'
-import { BallotPageMetadata } from '@votingworks/hmpb-interpreter'
 import { BallotPageQrcode } from '../types'
 import { normalizeSheetMetadata } from './metadata'
 

--- a/apps/module-scan/src/util/metadata.ts
+++ b/apps/module-scan/src/util/metadata.ts
@@ -1,9 +1,6 @@
 import { encodeHMPBBallotPageMetadata } from '@votingworks/ballot-encoder'
-import {
-  BallotPageMetadata,
-  metadataFromBytes,
-} from '@votingworks/hmpb-interpreter'
-import { Election } from '@votingworks/types'
+import { metadataFromBytes } from '@votingworks/hmpb-interpreter'
+import { BallotPageMetadata, Election } from '@votingworks/types'
 import { BallotPageQrcode, SheetOf } from '../types'
 
 function tryMetadataFromBytes(

--- a/apps/precinct-scanner/src/App.test.tsx
+++ b/apps/precinct-scanner/src/App.test.tsx
@@ -1,6 +1,3 @@
-/* eslint-disable */
-// import debug from 'debug'
-// debug.enable('precinct-scanner:*')
 import React from 'react'
 import fetchMock from 'fetch-mock'
 import { promises as fs } from 'fs'
@@ -632,6 +629,8 @@ test('voter can cast a ballot that needs review and adjudicate as desired', asyn
           image: { url: '/not/real.jpg' },
         },
       },
+      layouts: {},
+      definitions: {},
     })
   )
   await advanceTimersAndPromises(1)
@@ -862,6 +861,8 @@ test('voter can cast a rejected ballot', async () => {
           image: { url: '/not/real.jpg' },
         },
       },
+      layouts: {},
+      definitions: {},
     })
   )
   await advanceTimersAndPromises(1)
@@ -1001,6 +1002,8 @@ test('voter can cast another ballot while the success screen is showing', async 
               image: { url: '/not/real.jpg' },
             },
           },
+          layouts: {},
+          definitions: {},
         }),
         { overwriteRoutes: true }
       )

--- a/apps/precinct-scanner/src/App.test.tsx
+++ b/apps/precinct-scanner/src/App.test.tsx
@@ -12,6 +12,7 @@ import {
   PatchTestModeConfigResponse,
   PatchElectionConfigResponse,
   BatchInfo,
+  GetNextReviewSheetResponse,
 } from '@votingworks/types/api/module-scan'
 import {
   TallySourceMachineType,
@@ -35,7 +36,7 @@ import { join } from 'path'
 import { electionSampleDefinition } from '@votingworks/fixtures'
 
 import { DateTime } from 'luxon'
-import { AdjudicationReason, BallotSheetInfo } from '@votingworks/types'
+import { AdjudicationReason } from '@votingworks/types'
 
 import App from './App'
 import { interpretedHmpb } from '../test/fixtures'
@@ -189,7 +190,9 @@ test('app can load and configure from a usb stick', async () => {
   await advanceTimersAndPromises(2)
   await advanceTimersAndPromises(1)
   await screen.findByText('Polls Closed')
-  expect(kiosk.getFileSystemEntries).toHaveBeenCalledWith('fake mount point/ballot-packages')
+  expect(kiosk.getFileSystemEntries).toHaveBeenCalledWith(
+    'fake mount point/ballot-packages'
+  )
   expect(fetchMock.calls('/config/election', { method: 'PATCH' })).toHaveLength(
     1
   )
@@ -610,22 +613,24 @@ test('voter can cast a ballot that needs review and adjudicate as desired', asyn
   )
   fetchMock.get(
     '/scan/hmpb/review/next-sheet',
-    typedAs<BallotSheetInfo>({
-      id: 'test-sheet',
-      front: {
-        interpretation: interpretedHmpb({
-          electionDefinition: electionSampleDefinition,
-          pageNumber: 1,
-          adjudicationReason: AdjudicationReason.Overvote,
-        }),
-        image: { url: '/not/real.jpg' },
-      },
-      back: {
-        interpretation: interpretedHmpb({
-          electionDefinition: electionSampleDefinition,
-          pageNumber: 2,
-        }),
-        image: { url: '/not/real.jpg' },
+    typedAs<GetNextReviewSheetResponse>({
+      interpreted: {
+        id: 'test-sheet',
+        front: {
+          interpretation: interpretedHmpb({
+            electionDefinition: electionSampleDefinition,
+            pageNumber: 1,
+            adjudicationReason: AdjudicationReason.Overvote,
+          }),
+          image: { url: '/not/real.jpg' },
+        },
+        back: {
+          interpretation: interpretedHmpb({
+            electionDefinition: electionSampleDefinition,
+            pageNumber: 2,
+          }),
+          image: { url: '/not/real.jpg' },
+        },
       },
     })
   )
@@ -838,22 +843,24 @@ test('voter can cast a rejected ballot', async () => {
   )
   fetchMock.getOnce(
     '/scan/hmpb/review/next-sheet',
-    typedAs<BallotSheetInfo>({
-      id: 'test-sheet',
-      front: {
-        interpretation: {
-          type: 'InvalidElectionHashPage',
-          expectedElectionHash: 'a',
-          actualElectionHash: 'b',
+    typedAs<GetNextReviewSheetResponse>({
+      interpreted: {
+        id: 'test-sheet',
+        front: {
+          interpretation: {
+            type: 'InvalidElectionHashPage',
+            expectedElectionHash: 'a',
+            actualElectionHash: 'b',
+          },
+          image: { url: '/not/real.jpg' },
         },
-        image: { url: '/not/real.jpg' },
-      },
-      back: {
-        interpretation: interpretedHmpb({
-          electionDefinition: electionSampleDefinition,
-          pageNumber: 2,
-        }),
-        image: { url: '/not/real.jpg' },
+        back: {
+          interpretation: interpretedHmpb({
+            electionDefinition: electionSampleDefinition,
+            pageNumber: 2,
+          }),
+          image: { url: '/not/real.jpg' },
+        },
       },
     })
   )
@@ -975,22 +982,24 @@ test('voter can cast another ballot while the success screen is showing', async 
       )
       fetchMock.getOnce(
         '/scan/hmpb/review/next-sheet',
-        typedAs<BallotSheetInfo>({
-          id: 'test-sheet',
-          front: {
-            interpretation: interpretedHmpb({
-              electionDefinition: electionSampleDefinition,
-              pageNumber: 1,
-              adjudicationReason: AdjudicationReason.BlankBallot,
-            }),
-            image: { url: '/not/real.jpg' },
-          },
-          back: {
-            interpretation: interpretedHmpb({
-              electionDefinition: electionSampleDefinition,
-              pageNumber: 2,
-            }),
-            image: { url: '/not/real.jpg' },
+        typedAs<GetNextReviewSheetResponse>({
+          interpreted: {
+            id: 'test-sheet',
+            front: {
+              interpretation: interpretedHmpb({
+                electionDefinition: electionSampleDefinition,
+                pageNumber: 1,
+                adjudicationReason: AdjudicationReason.BlankBallot,
+              }),
+              image: { url: '/not/real.jpg' },
+            },
+            back: {
+              interpretation: interpretedHmpb({
+                electionDefinition: electionSampleDefinition,
+                pageNumber: 2,
+              }),
+              image: { url: '/not/real.jpg' },
+            },
           },
         }),
         { overwriteRoutes: true }
@@ -1020,7 +1029,9 @@ test('voter can cast another ballot while the success screen is showing', async 
     { overwriteRoutes: true }
   )
   // Even after the timeout to expire the success screen occurs we stay on the review screen.
-  await advanceTimersAndPromises(TIME_TO_DISMISS_ERROR_SUCCESS_SCREENS_MS / 1000)
+  await advanceTimersAndPromises(
+    TIME_TO_DISMISS_ERROR_SUCCESS_SCREENS_MS / 1000
+  )
   await screen.findByText('Blank Ballot')
   // No more ballots have scanned even though the scanner is ready to scan
   expect(fetchMock.calls('/scan/scanBatch')).toHaveLength(2)

--- a/apps/precinct-scanner/src/AppUnhappyPaths.test.tsx
+++ b/apps/precinct-scanner/src/AppUnhappyPaths.test.tsx
@@ -262,6 +262,8 @@ test('error from module-scan in accepting a reviewable ballot', async () => {
           image: { url: '/not/real.jpg' },
         },
       },
+      layouts: {},
+      definitions: {},
     })
   )
   await advanceTimersAndPromises(1)
@@ -376,6 +378,8 @@ test('error from module-scan in ejecting a reviewable ballot', async () => {
           image: { url: '/not/real.jpg' },
         },
       },
+      layouts: {},
+      definitions: {},
     })
   )
   await advanceTimersAndPromises(1)

--- a/apps/precinct-scanner/src/AppUnhappyPaths.test.tsx
+++ b/apps/precinct-scanner/src/AppUnhappyPaths.test.tsx
@@ -9,9 +9,10 @@ import {
   makePollWorkerCard,
   makeVoterCard,
 } from '@votingworks/test-utils'
-import { AdjudicationReason, BallotSheetInfo } from '@votingworks/types'
+import { AdjudicationReason } from '@votingworks/types'
 import {
   GetCurrentPrecinctConfigResponse,
+  GetNextReviewSheetResponse,
   GetScanStatusResponse,
   GetTestModeConfigResponse,
   ScannerStatus,
@@ -242,22 +243,24 @@ test('error from module-scan in accepting a reviewable ballot', async () => {
   )
   fetchMock.get(
     '/scan/hmpb/review/next-sheet',
-    typedAs<BallotSheetInfo>({
-      id: 'test-sheet',
-      front: {
-        interpretation: interpretedHmpb({
-          electionDefinition: electionSampleDefinition,
-          pageNumber: 1,
-          adjudicationReason: AdjudicationReason.Overvote,
-        }),
-        image: { url: '/not/real.jpg' },
-      },
-      back: {
-        interpretation: interpretedHmpb({
-          electionDefinition: electionSampleDefinition,
-          pageNumber: 2,
-        }),
-        image: { url: '/not/real.jpg' },
+    typedAs<GetNextReviewSheetResponse>({
+      interpreted: {
+        id: 'test-sheet',
+        front: {
+          interpretation: interpretedHmpb({
+            electionDefinition: electionSampleDefinition,
+            pageNumber: 1,
+            adjudicationReason: AdjudicationReason.Overvote,
+          }),
+          image: { url: '/not/real.jpg' },
+        },
+        back: {
+          interpretation: interpretedHmpb({
+            electionDefinition: electionSampleDefinition,
+            pageNumber: 2,
+          }),
+          image: { url: '/not/real.jpg' },
+        },
       },
     })
   )
@@ -354,22 +357,24 @@ test('error from module-scan in ejecting a reviewable ballot', async () => {
   )
   fetchMock.get(
     '/scan/hmpb/review/next-sheet',
-    typedAs<BallotSheetInfo>({
-      id: 'test-sheet',
-      front: {
-        interpretation: interpretedHmpb({
-          electionDefinition: electionSampleDefinition,
-          pageNumber: 1,
-          adjudicationReason: AdjudicationReason.Overvote,
-        }),
-        image: { url: '/not/real.jpg' },
-      },
-      back: {
-        interpretation: interpretedHmpb({
-          electionDefinition: electionSampleDefinition,
-          pageNumber: 2,
-        }),
-        image: { url: '/not/real.jpg' },
+    typedAs<GetNextReviewSheetResponse>({
+      interpreted: {
+        id: 'test-sheet',
+        front: {
+          interpretation: interpretedHmpb({
+            electionDefinition: electionSampleDefinition,
+            pageNumber: 1,
+            adjudicationReason: AdjudicationReason.Overvote,
+          }),
+          image: { url: '/not/real.jpg' },
+        },
+        back: {
+          interpretation: interpretedHmpb({
+            electionDefinition: electionSampleDefinition,
+            pageNumber: 2,
+          }),
+          image: { url: '/not/real.jpg' },
+        },
       },
     })
   )

--- a/apps/precinct-scanner/src/api/scan.test.ts
+++ b/apps/precinct-scanner/src/api/scan.test.ts
@@ -132,6 +132,8 @@ test('scanDetectedSheet returns rejected ballot on invalid test mode', async () 
           image: { url: '/not/real.jpg' },
         },
       },
+      layouts: {},
+      definitions: {},
     })
   )
   const result = await scan.scanDetectedSheet()
@@ -188,6 +190,8 @@ test('scanDetectedSheet returns rejected ballot on invalid precinct', async () =
           image: { url: '/not/real.jpg' },
         },
       },
+      layouts: {},
+      definitions: {},
     })
   )
   const result = await scan.scanDetectedSheet()
@@ -237,6 +241,8 @@ test('scanDetectedSheet returns rejected ballot on invalid election hash', async
           image: { url: '/not/real.jpg' },
         },
       },
+      layouts: {},
+      definitions: {},
     })
   )
   const result = await scan.scanDetectedSheet()
@@ -284,6 +290,8 @@ test('scanDetectedSheet returns rejected ballot on unreadable', async () => {
           image: { url: '/not/real.jpg' },
         },
       },
+      layouts: {},
+      definitions: {},
     })
   )
   const result = await scan.scanDetectedSheet()
@@ -333,6 +341,8 @@ test('scanDetectedSheet returns ballot needs review on adjudication', async () =
           image: { url: '/not/real.jpg' },
         },
       },
+      layouts: {},
+      definitions: {},
     })
   )
   const result = await scan.scanDetectedSheet()

--- a/apps/precinct-scanner/src/api/scan.test.ts
+++ b/apps/precinct-scanner/src/api/scan.test.ts
@@ -2,12 +2,9 @@ import {
   electionSampleDefinition,
   electionWithMsEitherNeitherWithDataFiles,
 } from '@votingworks/fixtures'
+import { AdjudicationReason, BallotType } from '@votingworks/types'
 import {
-  AdjudicationReason,
-  BallotSheetInfo,
-  BallotType,
-} from '@votingworks/types'
-import {
+  GetNextReviewSheetResponse,
   GetScanStatusResponse,
   ScannerStatus,
 } from '@votingworks/types/src/api/module-scan'
@@ -109,29 +106,31 @@ test('scanDetectedSheet returns rejected ballot on invalid test mode', async () 
   })
   fetchMock.getOnce(
     '/scan/hmpb/review/next-sheet',
-    typedAs<BallotSheetInfo>({
-      id: 'test-sheet',
-      front: {
-        interpretation: {
-          type: 'InvalidTestModePage',
-          metadata: {
-            ballotStyleId: '12',
-            ballotType: BallotType.Standard,
-            electionHash: 'abcdef',
-            isTestMode: true,
-            locales: { primary: 'en-US' },
-            pageNumber: 1,
-            precinctId: '23',
+    typedAs<GetNextReviewSheetResponse>({
+      interpreted: {
+        id: 'test-sheet',
+        front: {
+          interpretation: {
+            type: 'InvalidTestModePage',
+            metadata: {
+              ballotStyleId: '12',
+              ballotType: BallotType.Standard,
+              electionHash: 'abcdef',
+              isTestMode: true,
+              locales: { primary: 'en-US' },
+              pageNumber: 1,
+              precinctId: '23',
+            },
           },
+          image: { url: '/not/real.jpg' },
         },
-        image: { url: '/not/real.jpg' },
-      },
-      back: {
-        interpretation: interpretedHmpb({
-          electionDefinition: electionSampleDefinition,
-          pageNumber: 2,
-        }),
-        image: { url: '/not/real.jpg' },
+        back: {
+          interpretation: interpretedHmpb({
+            electionDefinition: electionSampleDefinition,
+            pageNumber: 2,
+          }),
+          image: { url: '/not/real.jpg' },
+        },
       },
     })
   )
@@ -163,29 +162,31 @@ test('scanDetectedSheet returns rejected ballot on invalid precinct', async () =
   )
   fetchMock.getOnce(
     '/scan/hmpb/review/next-sheet',
-    typedAs<BallotSheetInfo>({
-      id: 'test-sheet',
-      front: {
-        interpretation: {
-          type: 'InvalidPrecinctPage',
-          metadata: {
-            ballotStyleId: '12',
-            ballotType: BallotType.Standard,
-            electionHash: 'abcdef',
-            isTestMode: true,
-            locales: { primary: 'en-US' },
-            pageNumber: 1,
-            precinctId: '23',
+    typedAs<GetNextReviewSheetResponse>({
+      interpreted: {
+        id: 'test-sheet',
+        front: {
+          interpretation: {
+            type: 'InvalidPrecinctPage',
+            metadata: {
+              ballotStyleId: '12',
+              ballotType: BallotType.Standard,
+              electionHash: 'abcdef',
+              isTestMode: true,
+              locales: { primary: 'en-US' },
+              pageNumber: 1,
+              precinctId: '23',
+            },
           },
+          image: { url: '/not/real.jpg' },
         },
-        image: { url: '/not/real.jpg' },
-      },
-      back: {
-        interpretation: interpretedHmpb({
-          electionDefinition: electionSampleDefinition,
-          pageNumber: 2,
-        }),
-        image: { url: '/not/real.jpg' },
+        back: {
+          interpretation: interpretedHmpb({
+            electionDefinition: electionSampleDefinition,
+            pageNumber: 2,
+          }),
+          image: { url: '/not/real.jpg' },
+        },
       },
     })
   )
@@ -217,22 +218,24 @@ test('scanDetectedSheet returns rejected ballot on invalid election hash', async
   )
   fetchMock.getOnce(
     '/scan/hmpb/review/next-sheet',
-    typedAs<BallotSheetInfo>({
-      id: 'test-sheet',
-      front: {
-        interpretation: {
-          type: 'InvalidElectionHashPage',
-          actualElectionHash: 'abcdef',
-          expectedElectionHash: 'fedcba',
+    typedAs<GetNextReviewSheetResponse>({
+      interpreted: {
+        id: 'test-sheet',
+        front: {
+          interpretation: {
+            type: 'InvalidElectionHashPage',
+            actualElectionHash: 'abcdef',
+            expectedElectionHash: 'fedcba',
+          },
+          image: { url: '/not/real.jpg' },
         },
-        image: { url: '/not/real.jpg' },
-      },
-      back: {
-        interpretation: interpretedHmpb({
-          electionDefinition: electionSampleDefinition,
-          pageNumber: 2,
-        }),
-        image: { url: '/not/real.jpg' },
+        back: {
+          interpretation: interpretedHmpb({
+            electionDefinition: electionSampleDefinition,
+            pageNumber: 2,
+          }),
+          image: { url: '/not/real.jpg' },
+        },
       },
     })
   )
@@ -264,20 +267,22 @@ test('scanDetectedSheet returns rejected ballot on unreadable', async () => {
   )
   fetchMock.getOnce(
     '/scan/hmpb/review/next-sheet',
-    typedAs<BallotSheetInfo>({
-      id: 'test-sheet',
-      front: {
-        interpretation: {
-          type: 'UnreadablePage',
+    typedAs<GetNextReviewSheetResponse>({
+      interpreted: {
+        id: 'test-sheet',
+        front: {
+          interpretation: {
+            type: 'UnreadablePage',
+          },
+          image: { url: '/not/real.jpg' },
         },
-        image: { url: '/not/real.jpg' },
-      },
-      back: {
-        interpretation: interpretedHmpb({
-          electionDefinition: electionSampleDefinition,
-          pageNumber: 2,
-        }),
-        image: { url: '/not/real.jpg' },
+        back: {
+          interpretation: interpretedHmpb({
+            electionDefinition: electionSampleDefinition,
+            pageNumber: 2,
+          }),
+          image: { url: '/not/real.jpg' },
+        },
       },
     })
   )
@@ -309,22 +314,24 @@ test('scanDetectedSheet returns ballot needs review on adjudication', async () =
   )
   fetchMock.getOnce(
     '/scan/hmpb/review/next-sheet',
-    typedAs<BallotSheetInfo>({
-      id: 'test-sheet',
-      front: {
-        interpretation: interpretedHmpb({
-          electionDefinition: electionSampleDefinition,
-          pageNumber: 2,
-          adjudicationReason: AdjudicationReason.Overvote,
-        }),
-        image: { url: '/not/real.jpg' },
-      },
-      back: {
-        interpretation: interpretedHmpb({
-          electionDefinition: electionSampleDefinition,
-          pageNumber: 2,
-        }),
-        image: { url: '/not/real.jpg' },
+    typedAs<GetNextReviewSheetResponse>({
+      interpreted: {
+        id: 'test-sheet',
+        front: {
+          interpretation: interpretedHmpb({
+            electionDefinition: electionSampleDefinition,
+            pageNumber: 2,
+            adjudicationReason: AdjudicationReason.Overvote,
+          }),
+          image: { url: '/not/real.jpg' },
+        },
+        back: {
+          interpretation: interpretedHmpb({
+            electionDefinition: electionSampleDefinition,
+            pageNumber: 2,
+          }),
+          image: { url: '/not/real.jpg' },
+        },
       },
     })
   )

--- a/apps/precinct-scanner/src/api/scan.ts
+++ b/apps/precinct-scanner/src/api/scan.ts
@@ -1,8 +1,4 @@
-import {
-  AdjudicationReasonInfo,
-  BallotSheetInfo,
-  safeParseJSON,
-} from '@votingworks/types'
+import { AdjudicationReasonInfo, safeParseJSON } from '@votingworks/types'
 import {
   CalibrateResponseSchema,
   GetNextReviewSheetResponse,

--- a/apps/precinct-scanner/src/api/scan.ts
+++ b/apps/precinct-scanner/src/api/scan.ts
@@ -5,6 +5,7 @@ import {
 } from '@votingworks/types'
 import {
   CalibrateResponseSchema,
+  GetNextReviewSheetResponse,
   GetScanStatusResponse,
   ScanContinueRequest,
   ScannerStatus,
@@ -73,11 +74,14 @@ export async function scanDetectedSheet(): Promise<ScanningResult> {
 
     const adjudicationReasons: AdjudicationReasonInfo[] = []
     if (status.adjudication.remaining > 0) {
-      const sheetInfo = await fetchJSON<BallotSheetInfo>(
+      const sheetInfo = await fetchJSON<GetNextReviewSheetResponse>(
         '/scan/hmpb/review/next-sheet'
       )
 
-      for (const { interpretation } of [sheetInfo.front, sheetInfo.back]) {
+      for (const { interpretation } of [
+        sheetInfo.interpreted.front,
+        sheetInfo.interpreted.back,
+      ]) {
         if (interpretation.type === 'InvalidTestModePage') {
           return {
             resultType: ScanningResultType.Rejected,

--- a/libs/hmpb-interpreter/src/Interpreter.ts
+++ b/libs/hmpb-interpreter/src/Interpreter.ts
@@ -3,6 +3,9 @@ import {
   BallotLocales,
   BallotMark,
   BallotMsEitherNeitherTargetMark,
+  BallotPageContestOptionLayout,
+  BallotPageLayout,
+  BallotPageMetadata,
   BallotType,
   BallotYesNoTargetMark,
   Candidate,
@@ -35,14 +38,7 @@ import findContests, {
 } from './hmpb/findContests'
 import findTargets from './hmpb/findTargets'
 import { detect } from './metadata'
-import {
-  BallotPageContestOptionLayout,
-  BallotPageLayout,
-  BallotPageMetadata,
-  DetectQRCode,
-  FindMarksResult,
-  Interpreted,
-} from './types'
+import { DetectQRCode, FindMarksResult, Interpreted } from './types'
 import { binarize, PIXEL_BLACK, PIXEL_WHITE } from './utils/binarize'
 import crop from './utils/crop'
 import defined from './utils/defined'

--- a/libs/hmpb-interpreter/src/hmpb/findContestOptions.ts
+++ b/libs/hmpb-interpreter/src/hmpb/findContestOptions.ts
@@ -1,5 +1,9 @@
-import { Corners, Rect, TargetShape } from '@votingworks/types'
-import { BallotPageContestLayout } from '../types'
+import {
+  BallotPageContestLayout,
+  Corners,
+  Rect,
+  TargetShape,
+} from '@votingworks/types'
 
 /**
  * Finds contest choice areas based on the contest box bounds and the contest

--- a/libs/hmpb-interpreter/src/hmpb/findContests.ts
+++ b/libs/hmpb-interpreter/src/hmpb/findContests.ts
@@ -1,7 +1,13 @@
-import { AnyContest, Contests, Corners, Rect } from '@votingworks/types'
+import {
+  AnyContest,
+  Contests,
+  Corners,
+  Rect,
+  BallotPageContestLayout,
+  BallotPageLayout,
+} from '@votingworks/types'
 import { zip } from '@votingworks/utils'
 import makeDebug from 'debug'
-import { BallotPageContestLayout, BallotPageLayout } from '../types'
 import { PIXEL_BLACK } from '../utils/binarize'
 import { getCorners } from '../utils/corners'
 import { euclideanDistance, poly4Area } from '../utils/geometry'

--- a/libs/hmpb-interpreter/src/metadata.ts
+++ b/libs/hmpb-interpreter/src/metadata.ts
@@ -1,6 +1,11 @@
 import { decodeHMPBBallotPageMetadata } from '@votingworks/ballot-encoder'
-import { BallotLocales, BallotType, Election } from '@votingworks/types'
-import { BallotPageMetadata, DetectQRCode } from './types'
+import {
+  BallotLocales,
+  BallotPageMetadata,
+  BallotType,
+  Election,
+} from '@votingworks/types'
+import { DetectQRCode } from './types'
 import defined from './utils/defined'
 import * as qrcode from './utils/qrcode'
 

--- a/libs/hmpb-interpreter/src/types.ts
+++ b/libs/hmpb-interpreter/src/types.ts
@@ -1,34 +1,11 @@
 import {
+  BallotImage,
   BallotMark,
+  BallotPageLayout,
+  BallotPageMetadata,
   CompletedBallot,
-  Corners,
-  HMPBBallotPageMetadata,
-  Rect,
-  TargetShape,
+  ImageData,
 } from '@votingworks/types'
-
-export type BallotPageMetadata = HMPBBallotPageMetadata
-
-export interface BallotImage {
-  imageData: ImageData
-  metadata: BallotPageMetadata
-}
-
-export interface BallotPageContestOptionLayout {
-  bounds: Rect
-  target: TargetShape
-}
-
-export interface BallotPageContestLayout {
-  bounds: Rect
-  corners: Corners
-  options: readonly BallotPageContestOptionLayout[]
-}
-
-export interface BallotPageLayout {
-  ballotImage: BallotImage
-  contests: readonly BallotPageContestLayout[]
-}
 
 export interface GetBallotOptions {
   markScoreVoteThreshold: number

--- a/libs/hmpb-interpreter/src/utils/templateMap.test.ts
+++ b/libs/hmpb-interpreter/src/utils/templateMap.test.ts
@@ -1,5 +1,4 @@
-import { BallotType } from '@votingworks/types'
-import { BallotPageLayout } from '../types'
+import { BallotType, BallotPageLayout } from '@votingworks/types'
 import { createImageData } from './canvas'
 import templateMap, { TemplateMapKey } from './templateMap'
 

--- a/libs/hmpb-interpreter/src/utils/templateMap.ts
+++ b/libs/hmpb-interpreter/src/utils/templateMap.ts
@@ -1,5 +1,8 @@
-import { BallotLocales } from '@votingworks/types'
-import { BallotPageLayout, BallotPageMetadata } from '../types'
+import {
+  BallotLocales,
+  BallotPageLayout,
+  BallotPageMetadata,
+} from '@votingworks/types'
 import KeyedMap from './KeyedMap'
 
 export type TemplateMapKey = [

--- a/libs/hmpb-interpreter/test/fixtures.ts
+++ b/libs/hmpb-interpreter/test/fixtures.ts
@@ -1,6 +1,7 @@
+import { BallotPageMetadata } from '@votingworks/types'
 import { promises as fs } from 'fs'
 import { join } from 'path'
-import { BallotPageMetadata, Input } from '../src'
+import { Input } from '../src'
 import { vh as flipVH } from '../src/utils/flip'
 import { loadImageData } from '../src/utils/images'
 import { adjacentFile } from '../src/utils/path'

--- a/libs/types/src/api/module-scan.ts
+++ b/libs/types/src/api/module-scan.ts
@@ -8,6 +8,8 @@ import {
   OkResponseSchema,
 } from '.'
 import {
+  BallotSheetInfo,
+  BallotSheetInfoSchema,
   ElectionDefinition,
   ElectionDefinitionSchema,
   MarkThresholds,
@@ -561,3 +563,21 @@ export const CalibrateResponseSchema: z.ZodSchema<CalibrateResponse> = z.union([
   OkResponseSchema,
   ErrorsResponseSchema,
 ])
+
+/**
+ * @url /scan/hmpb/review/next-sheet
+ * @method GET
+ */
+export interface GetNextReviewSheetResponse {
+  interpreted: BallotSheetInfo
+}
+
+/**
+ * @url /scan/hmpb/review/next-sheet
+ * @method GET
+ */
+export const GetNextReviewSheetResponseSchema: z.ZodSchema<GetNextReviewSheetResponse> = z.object(
+  {
+    interpreted: BallotSheetInfoSchema,
+  }
+)

--- a/libs/types/src/api/module-scan.ts
+++ b/libs/types/src/api/module-scan.ts
@@ -8,8 +8,13 @@ import {
   OkResponseSchema,
 } from '.'
 import {
+  SerializableBallotPageLayout,
+  SerializableBallotPageLayoutSchema,
+} from '../ballotPageLayout'
+import {
   BallotSheetInfo,
   BallotSheetInfoSchema,
+  Contest,
   ElectionDefinition,
   ElectionDefinitionSchema,
   MarkThresholds,
@@ -570,6 +575,18 @@ export const CalibrateResponseSchema: z.ZodSchema<CalibrateResponse> = z.union([
  */
 export interface GetNextReviewSheetResponse {
   interpreted: BallotSheetInfo
+  layouts: {
+    front?: SerializableBallotPageLayout
+    back?: SerializableBallotPageLayout
+  }
+  definitions: {
+    front?: {
+      contestIds: readonly Contest['id'][]
+    }
+    back?: {
+      contestIds: readonly Contest['id'][]
+    }
+  }
 }
 
 /**
@@ -579,5 +596,13 @@ export interface GetNextReviewSheetResponse {
 export const GetNextReviewSheetResponseSchema: z.ZodSchema<GetNextReviewSheetResponse> = z.object(
   {
     interpreted: BallotSheetInfoSchema,
+    layouts: z.object({
+      front: SerializableBallotPageLayoutSchema.optional(),
+      back: SerializableBallotPageLayoutSchema.optional(),
+    }),
+    definitions: z.object({
+      front: z.object({ contestIds: z.array(Id) }),
+      back: z.object({ contestIds: z.array(Id) }),
+    }),
   }
 )

--- a/libs/types/src/ballotPageLayout.ts
+++ b/libs/types/src/ballotPageLayout.ts
@@ -1,0 +1,79 @@
+import { z } from 'zod'
+import {
+  HMPBBallotPageMetadata,
+  HMPBBallotPageMetadataSchema,
+  TargetShape,
+  TargetShapeSchema,
+} from './election'
+import {
+  Corners,
+  CornersSchema,
+  Rect,
+  RectSchema,
+  Size,
+  SizeSchema,
+} from './geometry'
+import { ImageData, ImageDataSchema } from './image'
+
+export type BallotPageMetadata = HMPBBallotPageMetadata
+export const BallotPageMetadataSchema = HMPBBallotPageMetadataSchema
+
+export interface BallotImage {
+  imageData: ImageData
+  metadata: BallotPageMetadata
+}
+export const BallotImageSchema: z.ZodSchema<BallotImage> = z.object({
+  imageData: ImageDataSchema,
+  metadata: BallotPageMetadataSchema,
+})
+
+export interface BallotPageContestOptionLayout {
+  bounds: Rect
+  target: TargetShape
+}
+export const BallotPageContestOptionLayoutSchema: z.ZodSchema<BallotPageContestOptionLayout> = z.object(
+  {
+    bounds: RectSchema,
+    target: TargetShapeSchema,
+  }
+)
+
+export interface BallotPageContestLayout {
+  bounds: Rect
+  corners: Corners
+  options: readonly BallotPageContestOptionLayout[]
+}
+export const BallotPageContestLayoutSchema: z.ZodSchema<BallotPageContestLayout> = z.object(
+  {
+    bounds: RectSchema,
+    corners: CornersSchema,
+    options: z.array(BallotPageContestOptionLayoutSchema),
+  }
+)
+
+export interface BallotPageLayout {
+  ballotImage: BallotImage
+  contests: readonly BallotPageContestLayout[]
+}
+export const BallotPageLayoutSchema: z.ZodSchema<BallotPageLayout> = z.object({
+  ballotImage: BallotImageSchema,
+  contests: z.array(BallotPageContestLayoutSchema),
+})
+
+export type SerializableBallotPageLayout = Omit<
+  BallotPageLayout,
+  'ballotImage'
+> & {
+  ballotImage: Omit<BallotPageLayout['ballotImage'], 'imageData'> & {
+    imageData: Size
+  }
+}
+export const SerializableBallotPageLayoutSchema: z.ZodSchema<SerializableBallotPageLayout> = z.object(
+  {
+    ballotImage: z.object({
+      imageData: SizeSchema,
+      metadata: BallotPageMetadataSchema,
+    }),
+    contests: z.array(BallotPageContestLayoutSchema),
+  }
+)

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -932,36 +932,78 @@ export interface InterpretedHmpbPage {
   votes: VotesDict
   adjudicationInfo: AdjudicationInfo
 }
+export const InterpretedHmpbPageSchema: z.ZodSchema<InterpretedHmpbPage> = z.object(
+  {
+    type: z.literal('InterpretedHmpbPage'),
+    ballotId: z.string().optional(),
+    metadata: HMPBBallotPageMetadataSchema,
+    markInfo: MarkInfoSchema,
+    votes: VotesDictSchema,
+    adjudicationInfo: AdjudicationInfoSchema,
+  }
+)
 
 export interface InvalidElectionHashPage {
   type: 'InvalidElectionHashPage'
   expectedElectionHash: string
   actualElectionHash: string
 }
+export const InvalidElectionHashPageSchema: z.ZodSchema<InvalidElectionHashPage> = z.object(
+  {
+    type: z.literal('InvalidElectionHashPage'),
+    expectedElectionHash: z.string(),
+    actualElectionHash: z.string(),
+  }
+)
 
 export interface InvalidTestModePage {
   type: 'InvalidTestModePage'
   metadata: BallotMetadata | HMPBBallotPageMetadata
 }
+export const InvalidTestModePageSchema: z.ZodSchema<InvalidTestModePage> = z.object(
+  {
+    type: z.literal('InvalidTestModePage'),
+    metadata: z.union([BallotMetadataSchema, HMPBBallotPageMetadataSchema]),
+  }
+)
 
 export interface InvalidPrecinctPage {
   type: 'InvalidPrecinctPage'
   metadata: BallotMetadata | HMPBBallotPageMetadata
 }
+export const InvalidPrecinctPageSchema: z.ZodSchema<InvalidPrecinctPage> = z.object(
+  {
+    type: z.literal('InvalidPrecinctPage'),
+    metadata: z.union([BallotMetadataSchema, HMPBBallotPageMetadataSchema]),
+  }
+)
 
 export interface UninterpretedHmpbPage {
   type: 'UninterpretedHmpbPage'
   metadata: HMPBBallotPageMetadata
 }
+export const UninterpretedHmpbPageSchema: z.ZodSchema<UninterpretedHmpbPage> = z.object(
+  {
+    type: z.literal('UninterpretedHmpbPage'),
+    metadata: HMPBBallotPageMetadataSchema,
+  }
+)
 
 export interface UnreadablePage {
   type: 'UnreadablePage'
   reason?: string
 }
+export const UnreadablePageSchema: z.ZodSchema<UnreadablePage> = z.object({
+  type: z.literal('UnreadablePage'),
+  reason: z.string().optional(),
+})
 
 export interface ImageInfo {
   url: string
 }
+export const ImageInfoSchema: z.ZodSchema<ImageInfo> = z.object({
+  url: z.string(),
+})
 
 export type PageInterpretation =
   | BlankPage
@@ -972,11 +1014,27 @@ export type PageInterpretation =
   | InvalidPrecinctPage
   | UninterpretedHmpbPage
   | UnreadablePage
+export const PageInterpretationSchema: z.ZodSchema<PageInterpretation> = z.union(
+  [
+    BlankPageSchema,
+    InterpretedBmdPageSchema,
+    InterpretedHmpbPageSchema,
+    InvalidElectionHashPageSchema,
+    InvalidTestModePageSchema,
+    InvalidPrecinctPageSchema,
+    UninterpretedHmpbPageSchema,
+    UnreadablePageSchema,
+  ]
+)
 
 export interface BallotPageInfo {
   image: ImageInfo
   interpretation: PageInterpretation
 }
+export const BallotPageInfoSchema: z.ZodSchema<BallotPageInfo> = z.object({
+  image: ImageInfoSchema,
+  interpretation: PageInterpretationSchema,
+})
 
 export interface BallotSheetInfo {
   id: string
@@ -984,6 +1042,12 @@ export interface BallotSheetInfo {
   back: BallotPageInfo
   adjudicationReason?: AdjudicationReason
 }
+export const BallotSheetInfoSchema: z.ZodSchema<BallotSheetInfo> = z.object({
+  id: Id,
+  front: BallotPageInfoSchema,
+  back: BallotPageInfoSchema,
+  adjudicationReason: AdjudicationReasonSchema.optional(),
+})
 
 export interface CompletedBallot {
   readonly electionHash: string

--- a/libs/types/src/image.ts
+++ b/libs/types/src/image.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod'
+
+export interface ImageData {
+  width: number
+  height: number
+  data: Uint8ClampedArray
+}
+export const ImageDataSchema: z.ZodSchema<ImageData> = z.object({
+  width: z.number().nonnegative(),
+  height: z.number().nonnegative(),
+  data: z.instanceof(Uint8ClampedArray),
+})

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -1,7 +1,9 @@
 /* istanbul ignore file */
+export * from './ballotLocales'
+export * from './ballotPageLayout'
+export * from './castVoteRecord'
 export * from './dom'
+export * from './election'
 export * from './generic'
 export * from './geometry'
-export * from './election'
-export * from './castVoteRecord'
-export * from './ballotLocales'
+export * from './image'


### PR DESCRIPTION
When there's an adjudication reason that flags a specific contest this will now flag that contest by highlighting it in yellow (think highlighter color).

![localhost_58709_(Surface Go)](https://user-images.githubusercontent.com/1938/132422320-64418164-a7e0-49c4-a50a-19fa3d916c22.png)

Most of the changes here are really in support of write-in adjudication, but this is a good stepping stone on the way.

Refs #802 