### PR TITLE
style(lint): enable react hooks plugin & ignore violations

### DIFF
--- a/apps/bas/package.json
+++ b/apps/bas/package.json
@@ -88,6 +88,7 @@
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-prettier": "^3.4.1",
     "eslint-plugin-react": "^7.21.5",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-vx": "workspace:*",
     "is-ci-cli": "^2.1.2",
     "lint-staged": "^8.1.5",

--- a/apps/bas/src/App.tsx
+++ b/apps/bas/src/App.tsx
@@ -14,6 +14,7 @@ const App = ({ hardware, card = new WebServiceCard() }: Props): JSX.Element => {
       }
     }
     void updateHardware()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hardware])
 
   if (!internalHardware) {

--- a/apps/bas/src/AppRoot.tsx
+++ b/apps/bas/src/AppRoot.tsx
@@ -63,6 +63,7 @@ const AppRoot = ({ card, hardware }: Props): JSX.Element => {
     setPartyId(undefined)
     setIsSinglePrecinctMode(false)
     window.localStorage.clear()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const reset = useCallback(() => {
@@ -70,16 +71,19 @@ const AppRoot = ({ card, hardware }: Props): JSX.Element => {
       setPrecinctId(undefined)
     }
     setBallotStyleId(undefined)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isSinglePrecinctMode])
 
   const setPrecinct = useCallback((id: string) => {
     setPrecinctId(id)
     setPartyId(undefined)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const updatePrecinct: EventTargetFunction = useCallback((event) => {
     const { id } = (event.target as HTMLElement).dataset
     setPrecinctId(id)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   // eslint-disable-next-line @typescript-eslint/no-shadow
@@ -111,6 +115,7 @@ const AppRoot = ({ card, hardware }: Props): JSX.Element => {
     const longValue = (await smartcard?.readLongString())?.unsafeUnwrap()
     setElection(safeParseElection(longValue).unsafeUnwrap())
     setIsLoadingElection(false)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [!smartcard])
 
   const lockScreen = useCallback(() => {
@@ -134,6 +139,7 @@ const AppRoot = ({ card, hardware }: Props): JSX.Element => {
         setIsReadyToRemove(false)
       }
     })()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [!smartcard])
 
   const programCard: EventTargetFunction = useCallback(
@@ -169,6 +175,7 @@ const AppRoot = ({ card, hardware }: Props): JSX.Element => {
         setIsReadyToRemove(true)
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [makeCancelable, reset, !smartcard, precinctId]
   )
 

--- a/apps/bmd/package.json
+++ b/apps/bmd/package.json
@@ -151,6 +151,7 @@
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-react": "^7.22.0",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-vx": "workspace:*",
     "is-ci-cli": "^2.0.0",
     "jest-date-mock": "^1.0.8",

--- a/apps/bmd/src/AppRoot.tsx
+++ b/apps/bmd/src/AppRoot.tsx
@@ -876,10 +876,12 @@ const AppRoot = ({
     }
     await processCard(insertedCard)
   }, GLOBALS.CARD_POLLING_INTERVAL)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const startCardShortValueReadPolling = useCallback(
     cardShortValueReadInterval[0],
     [card]
   )
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const stopCardShortValueReadPolling = useCallback(
     cardShortValueReadInterval[1],
     [card]
@@ -913,6 +915,7 @@ const AppRoot = ({
       dispatchAppState({ type: 'finishWritingLongValue' })
     }
   }, GLOBALS.CARD_POLLING_INTERVAL)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const startLongValueWritePolling = useCallback(longValueWriteInterval[0], [
     card,
   ])
@@ -1041,9 +1044,11 @@ const AppRoot = ({
     GLOBALS.HARDWARE_POLLING_INTERVAL,
     true
   )
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const startHardwareStatusPolling = useCallback(hardwareStatusInterval[0], [
     hardware,
   ])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const stopHardwareStatusPolling = useCallback(hardwareStatusInterval[1], [
     hardware,
   ])

--- a/apps/bmd/src/pages/ExpiredCardScreen.tsx
+++ b/apps/bmd/src/pages/ExpiredCardScreen.tsx
@@ -13,6 +13,7 @@ interface Props {
 const ExpiredCardScreen = ({
   useEffectToggleLargeDisplay,
 }: Props): JSX.Element => {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(useEffectToggleLargeDisplay, [])
   useEffect(triggerAudioFocus, [])
 

--- a/apps/bmd/src/pages/PrintOnlyScreen.tsx
+++ b/apps/bmd/src/pages/PrintOnlyScreen.tsx
@@ -76,6 +76,7 @@ const PrintOnlyScreen = ({
     !isPrinted
 
   // Handle Font Size when voter card is present.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(useEffectToggleLargeDisplay, [isVoterCardPresent])
 
   const printBallot = useCallback(async () => {

--- a/apps/bmd/src/pages/SetupCardReaderPage.tsx
+++ b/apps/bmd/src/pages/SetupCardReaderPage.tsx
@@ -11,6 +11,7 @@ interface Props {
 const SetupCardReaderPage = ({
   useEffectToggleLargeDisplay,
 }: Props): JSX.Element => {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(useEffectToggleLargeDisplay, [])
 
   return (

--- a/apps/bmd/src/pages/SetupPowerPage.tsx
+++ b/apps/bmd/src/pages/SetupPowerPage.tsx
@@ -13,6 +13,7 @@ interface Props {
 const SetupPowerPage = ({
   useEffectToggleLargeDisplay,
 }: Props): JSX.Element => {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(useEffectToggleLargeDisplay, [])
 
   return (

--- a/apps/bmd/src/pages/SetupPrinterPage.tsx
+++ b/apps/bmd/src/pages/SetupPrinterPage.tsx
@@ -12,6 +12,7 @@ interface Props {
 const SetupPrinterPage = ({
   useEffectToggleLargeDisplay,
 }: Props): JSX.Element => {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(useEffectToggleLargeDisplay, [])
 
   return (

--- a/apps/bmd/src/pages/UsedCardScreen.tsx
+++ b/apps/bmd/src/pages/UsedCardScreen.tsx
@@ -13,6 +13,7 @@ interface Props {
 const UsedCardScreen = ({
   useEffectToggleLargeDisplay,
 }: Props): JSX.Element => {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(useEffectToggleLargeDisplay, [])
   useEffect(triggerAudioFocus, [])
 

--- a/apps/bmd/src/pages/WrongElectionScreen.tsx
+++ b/apps/bmd/src/pages/WrongElectionScreen.tsx
@@ -15,6 +15,7 @@ const WrongElectionScreen = ({
   useEffectToggleLargeDisplay,
   isVoterCard,
 }: Props): JSX.Element => {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(useEffectToggleLargeDisplay, [])
   useEffect(triggerAudioFocus, [])
 

--- a/apps/bmd/src/pages/WrongPrecinctScreen.tsx
+++ b/apps/bmd/src/pages/WrongPrecinctScreen.tsx
@@ -13,6 +13,7 @@ interface Props {
 const WrongPrecinctScreen = ({
   useEffectToggleLargeDisplay,
 }: Props): JSX.Element => {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(useEffectToggleLargeDisplay, [])
   useEffect(triggerAudioFocus, [])
 

--- a/apps/bsd/src/AppRoot.tsx
+++ b/apps/bsd/src/AppRoot.tsx
@@ -214,6 +214,7 @@ const App = (): JSX.Element => {
     } catch (error) {
       console.log('failed zeroData()', error) // eslint-disable-line no-console
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [history])
 
   const backup = useCallback(async () => {

--- a/apps/bsd/src/components/BallotSheetImage.tsx
+++ b/apps/bsd/src/components/BallotSheetImage.tsx
@@ -29,6 +29,7 @@ export default function BallotSheetImage({
     const height = imageRef.current.clientHeight
     setXScaleValue(width / layout.ballotImage.imageData.width)
     setYScaleValue(height / layout.ballotImage.imageData.height)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [layout, imageRef.current])
 
   const scaleX = useCallback(

--- a/apps/bsd/src/components/ElectionConfiguration.tsx
+++ b/apps/bsd/src/components/ElectionConfiguration.tsx
@@ -96,12 +96,14 @@ const ElectionConfiguration = ({
         throw err
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [setFoundFilenames, setLoadingFiles, usbDriveStatus])
 
   useEffect(() => {
     if (usbDriveStatus === usbstick.UsbDriveStatus.mounted) {
       void fetchFilenames()
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [usbDriveStatus])
 
   const handleFileInput = async (event: React.FormEvent<HTMLInputElement>) => {

--- a/apps/bsd/src/screens/BallotEjectScreen.tsx
+++ b/apps/bsd/src/screens/BallotEjectScreen.tsx
@@ -74,6 +74,7 @@ const BallotEjectScreen = ({
     })()
   }, [])
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const contestIdsWithIssues = new Set<Contest['id']>()
 
   const styleForContest = useCallback(

--- a/apps/bsd/src/screens/DashboardScreen.tsx
+++ b/apps/bsd/src/screens/DashboardScreen.tsx
@@ -84,6 +84,7 @@ const DashboardScreen = ({
         isMounted = false
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pendingDeleteBatchId, isDeletingBatch, deleteBatch])
 
   return (

--- a/apps/election-manager/package.json
+++ b/apps/election-manager/package.json
@@ -147,7 +147,7 @@
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-prettier": "^3.4.1",
     "eslint-plugin-react": "^7.18.3",
-    "eslint-plugin-react-hooks": "^4.0.5",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-vx": "workspace:*",
     "is-ci-cli": "^2.1.2",
     "jest-environment-jsdom-sixteen": "^1.0.3",

--- a/apps/election-manager/src/AppRoot.tsx
+++ b/apps/election-manager/src/AppRoot.tsx
@@ -211,6 +211,7 @@ const AppRoot = ({ storage, printer }: Props): JSX.Element => {
     if (electionDefinition) {
       computeVoteCounts(castVoteRecordFiles.castVoteRecords)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [computeVoteCounts, castVoteRecordFiles])
 
   const saveExternalTallies = async (
@@ -276,6 +277,7 @@ const AppRoot = ({ storage, printer }: Props): JSX.Element => {
         })
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       storage,
       setIsOfficialResults,

--- a/apps/election-manager/src/components/HandMarkedPaperBallot.tsx
+++ b/apps/election-manager/src/components/HandMarkedPaperBallot.tsx
@@ -570,6 +570,7 @@ const HandMarkedPaperBallot = ({
 
     return () => {
       if (printBallotRef.current) {
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         printBallotRef.current.innerHTML = ''
       }
       document.head

--- a/apps/election-manager/src/components/ImportCVRFilesModal.tsx
+++ b/apps/election-manager/src/components/ImportCVRFilesModal.tsx
@@ -160,6 +160,7 @@ const ImportCVRFilesModal = ({ onClose }: Props): JSX.Element => {
     if (usbDriveStatus === usbstick.UsbDriveStatus.mounted) {
       void fetchFilenames()
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [usbDriveStatus])
 
   if (currentState === ModalState.ERROR) {

--- a/apps/election-manager/src/components/ImportExternalResultsModal.tsx
+++ b/apps/election-manager/src/components/ImportExternalResultsModal.tsx
@@ -76,6 +76,7 @@ const ImportExternalResultsModal = ({
     if (selectedFile !== undefined) {
       void loadFile(selectedFile)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedFile])
 
   const saveImportedFile = async () => {

--- a/apps/election-manager/src/screens/BallotScreen.tsx
+++ b/apps/election-manager/src/screens/BallotScreen.tsx
@@ -159,6 +159,7 @@ const BallotScreen = (): JSX.Element => {
       )[0] as HTMLElement)?.style.getPropertyValue('--pagedjs-page-count') || 0
     )
     setBallotPages(pagedJsPageCount)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ballotPreviewRef])
 
   return (

--- a/apps/election-manager/src/screens/ManualDataImportPrecinctScreen.tsx
+++ b/apps/election-manager/src/screens/ManualDataImportPrecinctScreen.tsx
@@ -172,6 +172,7 @@ const ManualDataImportPrecinctScreen = (): JSX.Element => {
 
   const initialPrecinctTally =
     talliesByPrecinct[currentPrecinctId] ?? getEmptyExternalTally()
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const [currentPrecinctTally, setCurrentPrecinctTally] = useState(
     initialPrecinctTally
   )

--- a/apps/election-manager/src/screens/PrintTestDeckScreen.tsx
+++ b/apps/election-manager/src/screens/PrintTestDeckScreen.tsx
@@ -128,6 +128,7 @@ const PrintTestDeckScreen = (): JSX.Element => {
         setPrecinctIndex(undefined)
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [setPrecinctIndex, precinctIds]
   )
 

--- a/apps/election-manager/src/screens/TallyReportScreen.tsx
+++ b/apps/election-manager/src/screens/TallyReportScreen.tsx
@@ -161,6 +161,7 @@ const TallyReportScreen = (): JSX.Element => {
 
   const generatedAtTime = new Date()
 
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
     if (previewReportRef?.current && printReportRef?.current) {
       previewReportRef.current.innerHTML = printReportRef.current.innerHTML

--- a/apps/precinct-scanner/package.json
+++ b/apps/precinct-scanner/package.json
@@ -132,7 +132,7 @@
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-prettier": "^3.4.1",
     "eslint-plugin-react": "^7.18.3",
-    "eslint-plugin-react-hooks": "^4.0.5",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-vx": "workspace:*",
     "is-ci-cli": "^2.1.2",
     "jest-environment-jsdom-sixteen": "^1.0.3",

--- a/apps/precinct-scanner/src/App.tsx
+++ b/apps/precinct-scanner/src/App.tsx
@@ -36,6 +36,7 @@ const App = ({
       }
     }
     void updateHardware()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hardware])
 
   if (!internalHardware) {

--- a/apps/precinct-scanner/src/AppRoot.tsx
+++ b/apps/precinct-scanner/src/AppRoot.tsx
@@ -386,6 +386,7 @@ const AppRoot = ({
       isTestMode: newIsTestMode,
       currentPrecinctId: newCurrentPrecinctId,
     })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatchAppState])
 
   const dismissCurrentBallotMessage = useCallback((): number => {
@@ -413,6 +414,7 @@ const AppRoot = ({
     return () => {
       printerStatusSubscription.unsubscribe()
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   // Handle Machine Config
@@ -605,6 +607,7 @@ const AppRoot = ({
     } else {
       endBallotStatusPolling()
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isScannerConfigured, electionDefinition, isPollsOpen, hasCardInserted])
 
   const setElectionDefinition = useCallback(
@@ -633,6 +636,7 @@ const AppRoot = ({
     } catch (error) {
       debug('failed unconfigureServer()', error)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatchAppState, refreshConfig])
 
   const processCard = useCallback(
@@ -668,6 +672,7 @@ const AppRoot = ({
         }
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [card, electionDefinition]
   )
 
@@ -681,7 +686,9 @@ const AppRoot = ({
         dispatchAppState({ type: 'cardRemoved' })
       }
     })()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     !smartcard,
     smartcard?.data,
     smartcard?.longValueExists,
@@ -697,6 +704,7 @@ const AppRoot = ({
       return await scan.getExport()
     }
     return []
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [electionDefinition, scannedBallotCount])
 
   const saveTallyToCard = useCallback(
@@ -736,6 +744,7 @@ const AppRoot = ({
 
     void initializeScanner()
     void updateStateFromStorage()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [refreshConfig, storage])
 
   const updatePrecinctId = useCallback(
@@ -754,6 +763,7 @@ const AppRoot = ({
     }
 
     void storeAppState()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isPollsOpen])
 
   const dismissError = () => {

--- a/apps/precinct-scanner/src/components/CalibrateScannerModal.tsx
+++ b/apps/precinct-scanner/src/components/CalibrateScannerModal.tsx
@@ -31,6 +31,7 @@ const CalibrateScannerModal = ({
     } finally {
       setIsCalibrating(false)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [onCalibrate, setIsCalibrating])
 
   const resetAndTryAgain = useCallback(async () => {

--- a/apps/precinct-scanner/src/screens/UnconfiguredElectionScreen.tsx
+++ b/apps/precinct-scanner/src/screens/UnconfiguredElectionScreen.tsx
@@ -119,6 +119,7 @@ const UnconfiguredElectionScreen = ({
 
     // function handles its own errors, so no `.catch` needed
     void attemptToLoadBallotPackageFromUSB()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [usbDriveStatus])
 
   let content = (

--- a/libs/eslint-plugin-vx/src/configs/react.ts
+++ b/libs/eslint-plugin-vx/src/configs/react.ts
@@ -10,6 +10,7 @@ export = {
     ...recommended.extends
       .map((name) => (name === 'airbnb-base' ? 'airbnb' : name))
       .filter((name) => name !== 'plugin:prettier/recommended'),
+    'airbnb/hooks',
     'plugin:react/recommended',
     'plugin:jsx-a11y/recommended',
     'plugin:prettier/recommended', // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -75,7 +75,7 @@
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-react": "^7.18.3",
-    "eslint-plugin-react-hooks": "^4.0.5",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-vx": "workspace:*",
     "jest": "^26.6.3",
     "jest-watch-typeahead": "^0.6.4",

--- a/libs/ui/src/hooks/useSmartcard.test.tsx
+++ b/libs/ui/src/hooks/useSmartcard.test.tsx
@@ -113,6 +113,7 @@ test('writing short value succeeds', async () => {
         )
         setError(result?.err())
       })()
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [!smartcard])
 
     return (
@@ -152,6 +153,7 @@ test('writing short value fails', async () => {
         )
         setError(result?.err())
       })()
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [!smartcard])
 
     return <div>{error?.message}</div>
@@ -183,6 +185,7 @@ test('reading long string value succeeds', async () => {
       void (async () => {
         setLongData((await smartcard?.readLongString())?.ok())
       })()
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [!smartcard])
 
     return <div>{longData}</div>
@@ -215,6 +218,7 @@ test('reading long binary value succeeds', async () => {
       void (async () => {
         setLongData((await smartcard?.readLongUint8Array())?.ok())
       })()
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [!smartcard])
 
     return <div>{longData?.join(',')}</div>
@@ -246,6 +250,7 @@ test('reading long string value fails', async () => {
       void (async () => {
         setError((await smartcard?.readLongString())?.err()?.message)
       })()
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [!smartcard])
 
     return <div>{error}</div>
@@ -273,6 +278,7 @@ test('reading long binary value fails', async () => {
       void (async () => {
         setError((await smartcard?.readLongUint8Array())?.err()?.message)
       })()
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [!smartcard])
 
     return <div>{error}</div>
@@ -301,6 +307,7 @@ test('writing long object value succeeds', async () => {
         ;(await smartcard?.writeLongValue({ some: 'object' }))?.unsafeUnwrap()
         setLongData((await smartcard?.readLongString())?.ok())
       })()
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [!smartcard])
 
     return <div>{longData}</div>
@@ -330,6 +337,7 @@ test('writing long binary value succeeds', async () => {
         )?.unsafeUnwrap()
         setLongData((await smartcard?.readLongUint8Array())?.ok())
       })()
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [!smartcard])
 
     return <div>{longData?.join(',')}</div>
@@ -357,6 +365,7 @@ test('writing long object value fails', async () => {
         const result = await smartcard?.writeLongValue({ some: 'object' })
         setError(result?.err())
       })()
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [!smartcard])
 
     return <div>{error?.message}</div>
@@ -386,6 +395,7 @@ test('writing long binary value fails', async () => {
         )
         setError(result?.err())
       })()
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [!smartcard])
 
     return <div>{error?.message}</div>

--- a/libs/ui/src/hooks/useSmartcard.ts
+++ b/libs/ui/src/hooks/useSmartcard.ts
@@ -101,6 +101,7 @@ export const useSmartcard = ({
     } catch (error) {
       return err(error)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [card, makeCancelable, isWriting])
 
   const readLongString = useCallback(async (): Promise<
@@ -111,6 +112,7 @@ export const useSmartcard = ({
     } catch (error) {
       return err(error)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [card, makeCancelable, isWriting])
 
   const writeShortValue = useCallback(
@@ -125,6 +127,7 @@ export const useSmartcard = ({
         setState((prev) => ({ ...prev, isWriting: false }))
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [card, makeCancelable, isWriting]
   )
 
@@ -144,6 +147,7 @@ export const useSmartcard = ({
         set({ isWriting: false })
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [card, makeCancelable, isWriting]
   )
 
@@ -156,6 +160,7 @@ export const useSmartcard = ({
     return () => {
       hardwareStatusSubscription.unsubscribe()
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hardware])
 
   useInterval(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,7 @@ importers:
       eslint-plugin-no-null: 1.0.2_eslint@7.17.0
       eslint-plugin-prettier: 3.4.1_7c5f1f59332aa465fcd97b1399d2f1c7
       eslint-plugin-react: 7.22.0_eslint@7.17.0
+      eslint-plugin-react-hooks: 4.2.0_eslint@7.17.0
       eslint-plugin-vx: link:../../libs/eslint-plugin-vx
       is-ci-cli: 2.1.2
       lint-staged: 8.2.1
@@ -83,6 +84,7 @@ importers:
       eslint-plugin-no-null: ^1.0.2
       eslint-plugin-prettier: ^3.4.1
       eslint-plugin-react: ^7.21.5
+      eslint-plugin-react-hooks: ^4.2.0
       eslint-plugin-vx: workspace:*
       http-proxy-middleware: 1.0.6
       is-ci-cli: ^2.1.2
@@ -172,7 +174,7 @@ importers:
       chalk: 4.1.2
       cypress: 4.12.1
       eslint: 7.17.0
-      eslint-config-airbnb: 18.2.1_17164872ad1121ab7d92471b0f0a3e4e
+      eslint-config-airbnb: 18.2.1_23e8124c5713df1fe93e7c6a7e9fc690
       eslint-config-prettier: 8.3.0_eslint@7.17.0
       eslint-import-resolver-node: 0.3.4
       eslint-plugin-cypress: 2.11.2_eslint@7.17.0
@@ -181,6 +183,7 @@ importers:
       eslint-plugin-jsx-a11y: 6.4.1_eslint@7.17.0
       eslint-plugin-prettier: 3.3.1_7c5f1f59332aa465fcd97b1399d2f1c7
       eslint-plugin-react: 7.22.0_eslint@7.17.0
+      eslint-plugin-react-hooks: 4.2.0_eslint@7.17.0
       eslint-plugin-vx: link:../../libs/eslint-plugin-vx
       is-ci-cli: 2.1.2
       jest-date-mock: 1.0.8
@@ -244,6 +247,7 @@ importers:
       eslint-plugin-jsx-a11y: ^6.4.1
       eslint-plugin-prettier: ^3.3.1
       eslint-plugin-react: ^7.22.0
+      eslint-plugin-react-hooks: ^4.2.0
       eslint-plugin-vx: workspace:*
       fetch-mock: ^9.5.0
       history: ^4.10.1
@@ -582,7 +586,7 @@ importers:
       eslint-plugin-jsx-a11y: ^6.2.3
       eslint-plugin-prettier: ^3.4.1
       eslint-plugin-react: ^7.18.3
-      eslint-plugin-react-hooks: ^4.0.5
+      eslint-plugin-react-hooks: ^4.2.0
       eslint-plugin-vx: workspace:*
       fetch-mock: ^9.10.7
       history: ^4.10.1
@@ -889,7 +893,7 @@ importers:
       eslint-plugin-jsx-a11y: ^6.2.3
       eslint-plugin-prettier: ^3.4.1
       eslint-plugin-react: ^7.18.3
-      eslint-plugin-react-hooks: ^4.0.5
+      eslint-plugin-react-hooks: ^4.2.0
       eslint-plugin-vx: workspace:*
       fetch-mock: ^9.11.0
       http-proxy-middleware: 1.0.6
@@ -1611,7 +1615,7 @@ importers:
       eslint-plugin-jsx-a11y: ^6.2.3
       eslint-plugin-prettier: ^3.1.2
       eslint-plugin-react: ^7.18.3
-      eslint-plugin-react-hooks: ^4.0.5
+      eslint-plugin-react-hooks: ^4.2.0
       eslint-plugin-vx: workspace:*
       jest: ^26.6.3
       jest-watch-typeahead: ^0.6.4
@@ -14099,26 +14103,6 @@ packages:
       eslint-plugin-react: ^7.14.2
     resolution:
       integrity: sha512-xCu//8a/aWqagKljt+1/qAM62BYZeNq04HmdevG5yUGWpja0I/xhqd6GdLRch5oetEGFiJAnvtGuTEAese53Qg==
-  /eslint-config-airbnb/18.2.1_17164872ad1121ab7d92471b0f0a3e4e:
-    dependencies:
-      eslint: 7.17.0
-      eslint-config-airbnb-base: 14.2.1_860e0a3f1402db18f3476b9d86a8ac51
-      eslint-plugin-import: 2.22.1_eslint@7.17.0+typescript@4.3.5
-      eslint-plugin-jsx-a11y: 6.4.1_eslint@7.17.0
-      eslint-plugin-react: 7.22.0_eslint@7.17.0
-      object.assign: 4.1.2
-      object.entries: 1.1.4
-    dev: true
-    engines:
-      node: '>= 6'
-    peerDependencies:
-      eslint: ^5.16.0 || ^6.8.0 || ^7.2.0
-      eslint-plugin-import: ^2.22.1
-      eslint-plugin-jsx-a11y: ^6.4.1
-      eslint-plugin-react: ^7.21.5
-      eslint-plugin-react-hooks: ^4 || ^3 || ^2.3.0 || ^1.7.0
-    resolution:
-      integrity: sha512-glZNDEZ36VdlZWoxn/bUR1r/sdFKPd1mHPbqUtkctgNG4yT2DLLtJ3D+yCV+jzZCc2V1nBVkmdknOJBZ5Hc0fg==
   /eslint-config-airbnb/18.2.1_23e8124c5713df1fe93e7c6a7e9fc690:
     dependencies:
       eslint: 7.17.0
@@ -16735,7 +16719,7 @@ packages:
       integrity: sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
   /follow-redirects/1.14.1_debug@4.3.1:
     dependencies:
-      debug: 4.3.1
+      debug: 4.3.1_supports-color@6.1.0
     engines:
       node: '>=4.0'
     peerDependencies:


### PR DESCRIPTION
We lost this at some point, maybe #774. For now, this just ignores the existing violations to reduce the risk of breakage. We can fix them one at a time.
