### PR TITLE
allow long contests on long ballots

### DIFF
--- a/libs/hmpb-interpreter/src/hmpb/findContests.ts
+++ b/libs/hmpb-interpreter/src/hmpb/findContests.ts
@@ -114,7 +114,7 @@ export default function* findContests(
         columns.length
     ),
     minExpectedHeight = Math.floor(0.1 * ballotImage.height),
-    maxExpectedHeight = Math.ceil(0.9 * ballotImage.height),
+    maxExpectedHeight = Math.ceil(0.96 * ballotImage.height),
     errorMargin = Math.ceil(0.025 * ballotImage.width),
   }: Options = {}
 ): Generator<ContestShape> {


### PR DESCRIPTION
max expected height at 90% worked great for letter and legal. For 17", the relative size might be higher, even as the fixed height of the footer remains.