### PR TITLE
feat(scan): allow canceling write-ins during adjudication

### DIFF
--- a/apps/bsd/src/screens/BallotEjectScreen.tsx
+++ b/apps/bsd/src/screens/BallotEjectScreen.tsx
@@ -1,4 +1,8 @@
-import { AdjudicationReason, Contest } from '@votingworks/types'
+import {
+  AdjudicationReason,
+  Contest,
+  WriteInMarkAdjudication,
+} from '@votingworks/types'
 import {
   GetNextReviewSheetResponse,
   Side,
@@ -15,9 +19,7 @@ import Prose from '../components/Prose'
 import Screen from '../components/Screen'
 import StatusFooter from '../components/StatusFooter'
 import Text from '../components/Text'
-import WriteInAdjudicationScreen, {
-  WriteInsByContestAndOption,
-} from './WriteInAdjudicationScreen'
+import WriteInAdjudicationScreen from './WriteInAdjudicationScreen'
 
 const EjectReason = styled.div`
   font-size: 3em;
@@ -96,10 +98,10 @@ const BallotEjectScreen = ({
     async (
       sheetId: string,
       side: Side,
-      writeInValues: WriteInsByContestAndOption
+      adjudications: readonly WriteInMarkAdjudication[]
     ): Promise<void> => {
       // eslint-disable-next-line no-console
-      console.log('ignoring write-ins for now', writeInValues)
+      console.log('ignoring adjudications for now', adjudications)
       await continueScanning(true)
     },
     [continueScanning]

--- a/apps/bsd/src/screens/WriteInAdjudicationScreen.test.tsx
+++ b/apps/bsd/src/screens/WriteInAdjudicationScreen.test.tsx
@@ -5,15 +5,28 @@ import {
   AdjudicationReason,
   BallotType,
   CandidateContest,
+  Contest,
+  ContestOption,
   getContests,
   HMPBBallotPageMetadata,
 } from '@votingworks/types'
-import { find } from '@votingworks/utils'
+import { find, typedAs } from '@votingworks/utils'
 import React from 'react'
 import renderInAppContext from '../../test/renderInAppContext'
-import WriteInAdjudicationScreen from './WriteInAdjudicationScreen'
+import WriteInAdjudicationScreen, {
+  Props as WriteInAdjudicationScreenProps,
+} from './WriteInAdjudicationScreen'
 
-test('presents an adjudication workflow for write-ins', async () => {
+type onAdjudicationCompleteType = Exclude<
+  WriteInAdjudicationScreenProps['onAdjudicationComplete'],
+  undefined
+>
+
+function renderWriteInAdjudicationScreen(): {
+  contest: Contest
+  optionId: ContestOption['id']
+  onAdjudicationComplete: onAdjudicationCompleteType
+} {
   const { election } = electionSampleDefinition
   const ballotStyle = election.ballotStyles[0]
   const precinctId = ballotStyle.precincts[0]
@@ -22,6 +35,7 @@ test('presents an adjudication workflow for write-ins', async () => {
     contests,
     (c): c is CandidateContest => c.type === 'candidate' && c.allowWriteIns
   )
+  const optionId: ContestOption['id'] = '__write-in-0'
   const metadata: HMPBBallotPageMetadata = {
     ballotStyleId: ballotStyle.id,
     precinctId,
@@ -31,7 +45,13 @@ test('presents an adjudication workflow for write-ins', async () => {
     locales: { primary: 'en-US' },
     pageNumber: 1,
   }
-  const onAdjudicationComplete = jest.fn()
+
+  const onAdjudicationComplete = jest
+    .fn<
+      ReturnType<onAdjudicationCompleteType>,
+      Parameters<onAdjudicationCompleteType>
+    >()
+    .mockResolvedValue()
 
   renderInAppContext(
     <WriteInAdjudicationScreen
@@ -52,7 +72,7 @@ test('presents an adjudication workflow for write-ins', async () => {
             {
               type: AdjudicationReason.WriteIn,
               contestId: contest.id,
-              optionId: '__write-in-0',
+              optionId,
               optionIndex: 0,
             },
           ],
@@ -87,11 +107,21 @@ test('presents an adjudication workflow for write-ins', async () => {
     />
   )
 
+  return { contest, optionId, onAdjudicationComplete }
+}
+
+test('supports typing in a candidate name', async () => {
+  const {
+    contest,
+    optionId,
+    onAdjudicationComplete,
+  } = renderWriteInAdjudicationScreen()
+
   screen.getByText('Write-In Adjudication')
   screen.getByText(contest.title)
 
   userEvent.type(
-    screen.getByTestId('write-in-input-__write-in-0'),
+    screen.getByTestId(`write-in-input-${optionId}`),
     'Lizard People'
   )
 
@@ -99,8 +129,57 @@ test('presents an adjudication workflow for write-ins', async () => {
   userEvent.click(screen.getByText('Save & Continue Scanning'))
 
   await waitFor(() => {
-    expect(onAdjudicationComplete).toHaveBeenCalledWith('test-sheet', 'front', {
-      [contest.id]: { '__write-in-0': 'Lizard People' },
-    })
+    expect(onAdjudicationComplete).toHaveBeenCalledWith(
+      ...typedAs<Parameters<onAdjudicationCompleteType>>([
+        'test-sheet',
+        'front',
+        [
+          {
+            type: AdjudicationReason.WriteIn,
+            isWriteIn: true,
+            contestId: contest.id,
+            optionId,
+            name: 'Lizard People',
+          },
+        ],
+      ])
+    )
+  })
+})
+
+test('supports canceling a write-in', async () => {
+  const {
+    contest,
+    optionId,
+    onAdjudicationComplete,
+  } = renderWriteInAdjudicationScreen()
+
+  screen.getByText('Write-In Adjudication')
+  screen.getByText(contest.title)
+
+  const isWriteInCheckbox = screen.getByTestId(
+    `write-in-checkbox-${optionId}`
+  ) as HTMLInputElement
+  expect(isWriteInCheckbox.checked).toBe(true)
+  userEvent.click(isWriteInCheckbox)
+
+  expect(onAdjudicationComplete).not.toHaveBeenCalled()
+  userEvent.click(screen.getByText('Save & Continue Scanning'))
+
+  await waitFor(() => {
+    expect(onAdjudicationComplete).toHaveBeenCalledWith(
+      ...typedAs<Parameters<onAdjudicationCompleteType>>([
+        'test-sheet',
+        'front',
+        [
+          {
+            type: AdjudicationReason.WriteIn,
+            isWriteIn: false,
+            contestId: contest.id,
+            optionId,
+          },
+        ],
+      ])
+    )
   })
 })

--- a/apps/bsd/src/screens/WriteInAdjudicationScreen.test.tsx
+++ b/apps/bsd/src/screens/WriteInAdjudicationScreen.test.tsx
@@ -157,11 +157,11 @@ test('supports canceling a write-in', async () => {
   screen.getByText('Write-In Adjudication')
   screen.getByText(contest.title)
 
-  const isWriteInCheckbox = screen.getByTestId(
+  const isNotWriteInCheckbox = screen.getByTestId(
     `write-in-checkbox-${optionId}`
   ) as HTMLInputElement
-  expect(isWriteInCheckbox.checked).toBe(true)
-  userEvent.click(isWriteInCheckbox)
+  expect(isNotWriteInCheckbox.checked).toBe(false)
+  userEvent.click(isNotWriteInCheckbox)
 
   expect(onAdjudicationComplete).not.toHaveBeenCalled()
   userEvent.click(screen.getByText('Save & Continue Scanning'))

--- a/apps/bsd/src/screens/WriteInAdjudicationScreen.tsx
+++ b/apps/bsd/src/screens/WriteInAdjudicationScreen.tsx
@@ -21,7 +21,6 @@ import { Side } from '@votingworks/types/api/module-scan'
 import { Text, useCancelablePromise } from '@votingworks/ui'
 import { find } from '@votingworks/utils'
 import { strict as assert } from 'assert'
-import pluralize from 'pluralize'
 import React, {
   useCallback,
   useContext,
@@ -297,7 +296,6 @@ const ContestOptionAdjudication = ({
               // eslint-disable-next-line jsx-a11y/no-autofocus
               autoFocus={autoFocus}
             />
-            <Spacer />
           </VStack>
           <label>
             <Checkbox
@@ -307,8 +305,9 @@ const ContestOptionAdjudication = ({
               data-testid={`write-in-checkbox-${writeIn.optionId}`}
               onChange={onCheckboxChange}
             />{' '}
-            this is <strong>not</strong> a write-in
+            This is <strong>not</strong> a write-in.
           </label>
+          <Spacer />
         </VStack>
       </HStack>
     </WriteInAdjudicationBox>
@@ -446,11 +445,8 @@ const WriteInAdjudicationByContest = ({
   return (
     <form onSubmit={goNext}>
       <p>
-        This ballot image has{' '}
-        <strong>{pluralize('contest', contestsWithWriteIns.size, true)}</strong>{' '}
-        with write-ins. Adjudicate each write-in by typing each write-in’s name
-        into the text box next to the image. Click “Next Contest” to move to the
-        next contest.
+        Adjudicate each write-in by typing the name you see, or by indicating it
+        is not a write-in.
       </p>
       <ContestAdjudication
         key={selectedContestId}

--- a/apps/bsd/src/screens/WriteInAdjudicationScreen.tsx
+++ b/apps/bsd/src/screens/WriteInAdjudicationScreen.tsx
@@ -26,6 +26,7 @@ import React, {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
 } from 'react'
@@ -205,6 +206,10 @@ const ContestOptionAdjudication = ({
   )
   const isWriteIn = adjudication?.isWriteIn ?? true
 
+  const [
+    shouldFocusNameOnNextRender,
+    setShouldFocusNameOnNextRender,
+  ] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
 
   const onInput = useCallback(
@@ -237,6 +242,7 @@ const ContestOptionAdjudication = ({
             optionId,
             name: '',
           })
+          setShouldFocusNameOnNextRender(true)
         } else {
           assert(inputRef.current)
           inputRef.current.value = ''
@@ -251,6 +257,13 @@ const ContestOptionAdjudication = ({
     },
     [contest.id, onChange]
   )
+
+  useLayoutEffect(() => {
+    if (shouldFocusNameOnNextRender) {
+      inputRef.current?.focus()
+      setShouldFocusNameOnNextRender(false)
+    }
+  }, [shouldFocusNameOnNextRender])
 
   return (
     <WriteInAdjudicationBox key={writeIn.optionId}>

--- a/apps/bsd/src/screens/WriteInAdjudicationScreen.tsx
+++ b/apps/bsd/src/screens/WriteInAdjudicationScreen.tsx
@@ -137,7 +137,7 @@ const Checkbox = styled.input`
 
 const HIGHLIGHTER_COLOR = '#fbff0016'
 const FOCUS_COLOR = '#fbff007d'
-const EXTRA_WRITE_IN_MARGIN_PERCENTAGE = 0.2
+const EXTRA_WRITE_IN_MARGIN_PERCENTAGE = 0.3
 
 const WriteInAdjudicationBox = styled.div`
   background-color: #ffffff;

--- a/apps/bsd/src/screens/WriteInAdjudicationScreen.tsx
+++ b/apps/bsd/src/screens/WriteInAdjudicationScreen.tsx
@@ -1,8 +1,8 @@
 /**
- * FIXME: This file was written in haste and could use some cleanup.
- * - separate components into multiple files?
- * - use better styling/css?
- * - add more testing
+ * FIXME: This file was written in haste and could use some cleanup:
+ * - https://github.com/votingworks/vxsuite/issues/848
+ * - https://github.com/votingworks/vxsuite/issues/849
+ * - https://github.com/votingworks/vxsuite/issues/850
  */
 
 import {
@@ -10,11 +10,11 @@ import {
   BallotPageContestLayout,
   CandidateContest,
   Contest,
-  ContestOption,
   ElectionDefinition,
   InterpretedHmpbPage,
   Rect,
   SerializableBallotPageLayout,
+  WriteInMarkAdjudication,
   WriteInAdjudicationReasonInfo,
 } from '@votingworks/types'
 import { Side } from '@votingworks/types/api/module-scan'
@@ -22,7 +22,13 @@ import { Text, useCancelablePromise } from '@votingworks/ui'
 import { find } from '@votingworks/utils'
 import { strict as assert } from 'assert'
 import pluralize from 'pluralize'
-import React, { useCallback, useContext, useEffect, useState } from 'react'
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 import styled from 'styled-components'
 import BallotSheetImage from '../components/BallotSheetImage'
 import Button from '../components/Button'
@@ -56,12 +62,18 @@ const VStack = ({
   as,
   children,
   style,
+  reverse,
 }: {
   as?: string
   children: React.ReactNode
   style?: React.CSSProperties
+  reverse?: boolean
 }): JSX.Element => (
-  <Stack as={as} flexDirection="column" style={style}>
+  <Stack
+    as={as}
+    flexDirection={reverse ? 'column-reverse' : 'column'}
+    style={style}
+  >
     {children}
   </Stack>
 )
@@ -70,12 +82,14 @@ const HStack = ({
   as,
   children,
   style,
+  reverse,
 }: {
   as?: string
   children: React.ReactNode
   style?: React.CSSProperties
+  reverse?: boolean
 }): JSX.Element => (
-  <Stack as={as} flexDirection="row" style={style}>
+  <Stack as={as} flexDirection={reverse ? 'row-reverse' : 'row'} style={style}>
     {children}
   </Stack>
 )
@@ -124,9 +138,6 @@ const WriteInAdjudicationBox = styled.div`
   margin: 1em 0;
 `
 
-export type WriteInsByOption = Record<ContestOption['id'], string>
-export type WriteInsByContestAndOption = Record<Contest['id'], WriteInsByOption>
-
 const WriteInLabel = ({
   contest,
   writeIn,
@@ -167,13 +178,131 @@ const WriteInImage = ({
   />
 )
 
+interface ContestOptionAdjudicationProps {
+  imageURL: string
+  contest: CandidateContest
+  writeIn: WriteInAdjudicationReasonInfo
+  layout: BallotPageContestLayout
+  adjudications: readonly WriteInMarkAdjudication[]
+  onChange?(adjudication: WriteInMarkAdjudication): void
+  autoFocus?: boolean
+}
+
+const ContestOptionAdjudication = ({
+  imageURL,
+  contest,
+  writeIn,
+  layout,
+  adjudications,
+  onChange,
+  autoFocus,
+}: ContestOptionAdjudicationProps): JSX.Element => {
+  const writeInIndex = writeIn.optionIndex
+  const { bounds } = layout.options[writeInIndex]
+  const adjudication = adjudications.find(
+    ({ contestId, optionId }) =>
+      contestId === writeIn.contestId && optionId === writeIn.optionId
+  )
+  const isWriteIn = adjudication?.isWriteIn ?? true
+
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const onInput = useCallback(
+    (event: React.FormEvent<HTMLInputElement>) => {
+      const input = event.currentTarget
+      const { optionId } = input.dataset
+      if (optionId) {
+        onChange?.({
+          type: AdjudicationReason.WriteIn,
+          isWriteIn: true,
+          contestId: contest.id,
+          optionId,
+          name: input.value,
+        })
+      }
+    },
+    [contest.id, onChange]
+  )
+
+  const onCheckboxChange = useCallback(
+    (event: React.FormEvent<HTMLInputElement>) => {
+      const input = event.currentTarget
+      const { optionId } = input.dataset
+      if (optionId) {
+        if (input.checked) {
+          onChange?.({
+            type: AdjudicationReason.WriteIn,
+            isWriteIn: true,
+            contestId: contest.id,
+            optionId,
+            name: '',
+          })
+        } else {
+          assert(inputRef.current)
+          inputRef.current.value = ''
+          onChange?.({
+            type: AdjudicationReason.WriteIn,
+            isWriteIn: false,
+            contestId: contest.id,
+            optionId,
+          })
+        }
+      }
+    },
+    [contest.id, onChange]
+  )
+
+  return (
+    <WriteInAdjudicationBox key={writeIn.optionId}>
+      <HStack>
+        <WriteInImage imageURL={imageURL} bounds={bounds} />
+        <Spacer />
+        <VStack>
+          <VStack as="label">
+            <WriteInLabel contest={contest} writeIn={writeIn} />
+            <input
+              type="text"
+              ref={inputRef}
+              placeholder={
+                isWriteIn ? 'type voter write-in here' : 'not a write-in'
+              }
+              autoComplete="off"
+              style={{ width: '450px', fontSize: '1.5em' }}
+              data-option-id={writeIn.optionId}
+              data-testid={`write-in-input-${writeIn.optionId}`}
+              onInput={onInput}
+              disabled={!isWriteIn}
+              defaultValue={
+                adjudication?.isWriteIn ? adjudication.name : undefined
+              }
+              // eslint-disable-next-line jsx-a11y/no-autofocus
+              autoFocus={autoFocus}
+            />
+            <Spacer />
+          </VStack>
+          <label>
+            <input
+              type="checkbox"
+              checked={isWriteIn}
+              data-option-id={writeIn.optionId}
+              data-testid={`write-in-checkbox-${writeIn.optionId}`}
+              onChange={onCheckboxChange}
+            />{' '}
+            This is a write-in
+          </label>
+        </VStack>
+      </HStack>
+    </WriteInAdjudicationBox>
+  )
+}
+
 interface ContestAdjudicationProps {
   imageURL: string
   contest: CandidateContest
   layout: BallotPageContestLayout
   writeInsForContest: readonly WriteInAdjudicationReasonInfo[]
-  onInput?(optionId: ContestOption['id'], value: string): void
-  writeInValues?: WriteInsByOption
+  onChange?(adjudication: WriteInMarkAdjudication): void
+  adjudications: readonly WriteInMarkAdjudication[]
 }
 
 const ContestAdjudication = ({
@@ -181,54 +310,26 @@ const ContestAdjudication = ({
   contest,
   layout,
   writeInsForContest,
-  onInput,
-  writeInValues,
+  onChange,
+  adjudications,
 }: ContestAdjudicationProps): JSX.Element => {
-  const onInputInternal: React.FormEventHandler = useCallback(
-    (event) => {
-      const input = event.currentTarget as HTMLInputElement
-      const { optionId } = input.dataset
-      if (optionId) {
-        onInput?.(optionId, input.value)
-      }
-    },
-    [onInput]
-  )
-
   return (
     <div>
       <HStack style={{ alignItems: 'center' }}>
         <ContestHeader>{contest.title}</ContestHeader>
       </HStack>
-      {writeInsForContest.map((writeIn, i) => {
-        const writeInIndex = writeIn.optionIndex
-        const { bounds } = layout.options[writeInIndex]
-        return (
-          <WriteInAdjudicationBox key={writeIn.optionId}>
-            <HStack>
-              <WriteInImage imageURL={imageURL} bounds={bounds} />
-              <Spacer />
-              <VStack as="label">
-                <WriteInLabel contest={contest} writeIn={writeIn} />
-                <input
-                  type="text"
-                  placeholder="type voter write-in here"
-                  autoComplete="off"
-                  style={{ width: '450px', fontSize: '1.5em' }}
-                  data-option-id={writeIn.optionId}
-                  data-testid={`write-in-input-${writeIn.optionId}`}
-                  onInput={onInputInternal}
-                  defaultValue={writeInValues?.[writeIn.optionId]}
-                  tabIndex={i + 1}
-                  // eslint-disable-next-line jsx-a11y/no-autofocus
-                  autoFocus={i === 0}
-                />
-                <Spacer />
-              </VStack>
-            </HStack>
-          </WriteInAdjudicationBox>
-        )
-      })}
+      {writeInsForContest.map((writeIn, i) => (
+        <ContestOptionAdjudication
+          key={writeIn.optionId}
+          adjudications={adjudications}
+          contest={contest}
+          imageURL={imageURL}
+          layout={layout}
+          writeIn={writeIn}
+          onChange={onChange}
+          autoFocus={i === 0}
+        />
+      ))}
     </div>
   )
 }
@@ -239,9 +340,9 @@ const WriteInAdjudicationByContest = ({
   interpretation,
   layout,
   contestIds,
-  writeInValues,
+  adjudications,
   onContestChange,
-  onWriteInChanged,
+  onAdjudicationChanged,
   onAdjudicationComplete,
 }: {
   electionDefinition: ElectionDefinition
@@ -249,13 +350,9 @@ const WriteInAdjudicationByContest = ({
   interpretation: InterpretedHmpbPage
   layout: SerializableBallotPageLayout
   contestIds: readonly Contest['id'][]
-  writeInValues: WriteInsByContestAndOption
+  adjudications: readonly WriteInMarkAdjudication[]
   onContestChange?(contestId?: Contest['id']): void
-  onWriteInChanged?(
-    contestId: Contest['id'],
-    optionId: ContestOption['id'],
-    value: string
-  ): void
+  onAdjudicationChanged?(adjudication: WriteInMarkAdjudication): void
   onAdjudicationComplete(): Promise<void>
 }): JSX.Element => {
   const makeCancelable = useCancelablePromise()
@@ -275,11 +372,11 @@ const WriteInAdjudicationByContest = ({
   const isLastContestSelected =
     selectedContestIndex === contestsWithWriteInsCount - 1
 
-  const onWriteInInput = useCallback(
-    (optionId: ContestOption['id'], value: string) => {
-      onWriteInChanged?.(selectedContestId, optionId, value)
+  const onAdjudicationChange = useCallback(
+    (adjudication: WriteInMarkAdjudication) => {
+      onAdjudicationChanged?.(adjudication)
     },
-    [onWriteInChanged, selectedContestId]
+    [onAdjudicationChanged]
   )
 
   useEffect(() => {
@@ -298,8 +395,13 @@ const WriteInAdjudicationByContest = ({
     (writeIn) => writeIn.contestId === selectedContestId
   )
   const contestLayout = layout.contests[contestIndex]
-  const allWriteInsHaveValues = writeInsForContest.every(
-    (writeIn) => writeInValues[selectedContestId]?.[writeIn.optionId]
+  const allWriteInsHaveValues = writeInsForContest.every((writeIn) =>
+    adjudications.some(
+      (adjudication) =>
+        adjudication.contestId === writeIn.contestId &&
+        adjudication.optionId === writeIn.optionId &&
+        (!adjudication.isWriteIn || adjudication.name)
+    )
   )
 
   const goPrevious = useCallback(() => {
@@ -337,31 +439,27 @@ const WriteInAdjudicationByContest = ({
         contest={contest}
         writeInsForContest={writeInsForContest}
         layout={contestLayout}
-        onInput={onWriteInInput}
-        writeInValues={writeInValues[selectedContestId]}
+        onChange={onAdjudicationChange}
+        adjudications={adjudications}
       />
-      <HStack>
+      <HStack reverse>
         <Button
-          onPress={goPrevious}
-          disabled={isFirstContestSelected}
-          tabIndex={contestLayout.options.length + 2}
+          onPress={goNext}
+          primary
+          disabled={isSaving || !allWriteInsHaveValues}
         >
-          Previous Contest
+          {!isLastContestSelected ? 'Next Contest' : 'Save & Continue Scanning'}
         </Button>
         <Spacer />
         <Text small style={{ marginLeft: '10px' }}>
           Contest {contestsWithWriteInsIndex + 1} of {contestsWithWriteInsCount}
         </Text>
         <Spacer />
-        <Button
-          onPress={goNext}
-          primary
-          disabled={isSaving || !allWriteInsHaveValues}
-          tabIndex={contestLayout.options.length + 1}
-        >
-          {!isLastContestSelected ? 'Next Contest' : 'Save & Continue Scanning'}
+        <Button onPress={goPrevious} disabled={isFirstContestSelected}>
+          Previous Contest
         </Button>
       </HStack>
+      )
     </form>
   )
 }
@@ -376,7 +474,7 @@ export interface Props {
   onAdjudicationComplete?(
     sheetId: string,
     side: Side,
-    writeInValues: WriteInsByContestAndOption
+    adjudications: readonly WriteInMarkAdjudication[]
   ): Promise<void>
 }
 
@@ -392,10 +490,9 @@ export default function WriteInAdjudicationScreen({
   const { electionDefinition } = useContext(AppContext)
   assert(electionDefinition)
 
-  const [
-    writeInValues,
-    setWriteInValues,
-  ] = useState<WriteInsByContestAndOption>({})
+  const [adjudications, setAdjudications] = useState<
+    readonly WriteInMarkAdjudication[]
+  >([])
   const [selectedContestId, setSelectedContestId] = useState<Contest['id']>()
 
   const writeIns = interpretation.adjudicationInfo.allReasonInfos.filter(
@@ -420,26 +517,25 @@ export default function WriteInAdjudicationScreen({
     setSelectedContestId(contestId)
   }, [])
 
-  const onWriteInChanged = useCallback(
-    (
-      contestId: Contest['id'],
-      optionId: ContestOption['id'],
-      value: string
-    ): void => {
-      setWriteInValues((prev) => ({
-        ...prev,
-        [contestId]: {
-          ...prev[contestId],
-          [optionId]: value,
-        },
-      }))
+  const onAdjudicationChanged = useCallback(
+    (adjudication: WriteInMarkAdjudication): void => {
+      setAdjudications((prev) => [
+        ...prev.filter(
+          ({ contestId, optionId }) =>
+            !(
+              contestId === adjudication.contestId &&
+              optionId === adjudication.optionId
+            )
+        ),
+        adjudication,
+      ])
     },
     []
   )
 
   const onAdjudicationCompleteInternal = useCallback(async (): Promise<void> => {
-    await onAdjudicationComplete?.(sheetId, side, writeInValues)
-  }, [onAdjudicationComplete, sheetId, side, writeInValues])
+    await onAdjudicationComplete?.(sheetId, side, adjudications)
+  }, [onAdjudicationComplete, sheetId, side, adjudications])
 
   return (
     <Screen>
@@ -454,9 +550,9 @@ export default function WriteInAdjudicationScreen({
               interpretation={interpretation}
               layout={layout}
               contestIds={contestIds}
-              writeInValues={writeInValues}
+              adjudications={adjudications}
               onContestChange={onContestChange}
-              onWriteInChanged={onWriteInChanged}
+              onAdjudicationChanged={onAdjudicationChanged}
               onAdjudicationComplete={onAdjudicationCompleteInternal}
             />
           </Prose>

--- a/apps/bsd/src/screens/WriteInAdjudicationScreen.tsx
+++ b/apps/bsd/src/screens/WriteInAdjudicationScreen.tsx
@@ -129,6 +129,12 @@ const MainChildColumns = styled.div`
   }
 `
 
+const Checkbox = styled.input`
+  &:focus {
+    box-shadow: 0 0 0 4px rgba(21, 156, 228, 0.4);
+  }
+`
+
 const HIGHLIGHTER_COLOR = '#fbff0016'
 const FOCUS_COLOR = '#fbff007d'
 const EXTRA_WRITE_IN_MARGIN_PERCENTAGE = 0.2
@@ -294,7 +300,7 @@ const ContestOptionAdjudication = ({
             <Spacer />
           </VStack>
           <label>
-            <input
+            <Checkbox
               type="checkbox"
               checked={!isWriteIn}
               data-option-id={writeIn.optionId}

--- a/apps/bsd/src/screens/WriteInAdjudicationScreen.tsx
+++ b/apps/bsd/src/screens/WriteInAdjudicationScreen.tsx
@@ -229,7 +229,7 @@ const ContestOptionAdjudication = ({
       const input = event.currentTarget
       const { optionId } = input.dataset
       if (optionId) {
-        if (input.checked) {
+        if (!input.checked) {
           onChange?.({
             type: AdjudicationReason.WriteIn,
             isWriteIn: true,
@@ -283,12 +283,12 @@ const ContestOptionAdjudication = ({
           <label>
             <input
               type="checkbox"
-              checked={isWriteIn}
+              checked={!isWriteIn}
               data-option-id={writeIn.optionId}
               data-testid={`write-in-checkbox-${writeIn.optionId}`}
               onChange={onCheckboxChange}
             />{' '}
-            This is a write-in
+            this is <strong>not</strong> a write-in
           </label>
         </VStack>
       </HStack>
@@ -459,7 +459,6 @@ const WriteInAdjudicationByContest = ({
           Previous Contest
         </Button>
       </HStack>
-      )
     </form>
   )
 }

--- a/apps/bsd/src/screens/__snapshots__/BallotEjectScreen.test.tsx.snap
+++ b/apps/bsd/src/screens/__snapshots__/BallotEjectScreen.test.tsx.snap
@@ -44,13 +44,13 @@ exports[`calls out live ballot sheets in test mode 1`] = `
       class="sc-eCssSg jJQcwm"
     >
       <div
-        class="sc-dIUggk gvbXNc"
+        class="sc-hHftDr hXZiDL"
       >
         <div
           class="sc-crrsfI dvOODA"
         >
           <div
-            class="sc-idOhPF eXcWnR"
+            class="sc-dIUggk hZaEGa"
           >
             Live Ballot
           </div>
@@ -66,7 +66,7 @@ exports[`calls out live ballot sheets in test mode 1`] = `
           </p>
         </div>
         <div
-          class="sc-hHftDr kAQrHz"
+          class="sc-dmlrTW esDPKT"
         >
           <div
             style="position: relative;"
@@ -170,13 +170,13 @@ exports[`calls out test ballot sheets in live mode 1`] = `
       class="sc-eCssSg jJQcwm"
     >
       <div
-        class="sc-dIUggk gvbXNc"
+        class="sc-hHftDr hXZiDL"
       >
         <div
           class="sc-crrsfI dvOODA"
         >
           <div
-            class="sc-idOhPF eXcWnR"
+            class="sc-dIUggk hZaEGa"
           >
             Test Ballot
           </div>
@@ -192,7 +192,7 @@ exports[`calls out test ballot sheets in live mode 1`] = `
           </p>
         </div>
         <div
-          class="sc-hHftDr kAQrHz"
+          class="sc-dmlrTW esDPKT"
         >
           <div
             style="position: relative;"
@@ -297,13 +297,13 @@ exports[`says the ballot sheet is blank if it is 1`] = `
       class="sc-eCssSg jJQcwm"
     >
       <div
-        class="sc-dIUggk gvbXNc"
+        class="sc-hHftDr hXZiDL"
       >
         <div
           class="sc-crrsfI dvOODA"
         >
           <div
-            class="sc-idOhPF eXcWnR"
+            class="sc-dIUggk hZaEGa"
           >
             Unknown Reason
           </div>
@@ -342,7 +342,7 @@ exports[`says the ballot sheet is blank if it is 1`] = `
           </p>
         </div>
         <div
-          class="sc-hHftDr kAQrHz"
+          class="sc-dmlrTW esDPKT"
         >
           <div
             style="position: relative;"
@@ -447,13 +447,13 @@ exports[`says the ballot sheet is overvoted if it is 1`] = `
       class="sc-eCssSg jJQcwm"
     >
       <div
-        class="sc-dIUggk gvbXNc"
+        class="sc-hHftDr hXZiDL"
       >
         <div
           class="sc-crrsfI dvOODA"
         >
           <div
-            class="sc-idOhPF eXcWnR"
+            class="sc-dIUggk hZaEGa"
           >
             Overvote
           </div>
@@ -497,7 +497,7 @@ exports[`says the ballot sheet is overvoted if it is 1`] = `
           </p>
         </div>
         <div
-          class="sc-hHftDr kAQrHz"
+          class="sc-dmlrTW esDPKT"
         >
           <div
             style="position: relative;"
@@ -602,13 +602,13 @@ exports[`says the ballot sheet is undervoted if it is 1`] = `
       class="sc-eCssSg jJQcwm"
     >
       <div
-        class="sc-dIUggk gvbXNc"
+        class="sc-hHftDr hXZiDL"
       >
         <div
           class="sc-crrsfI dvOODA"
         >
           <div
-            class="sc-idOhPF eXcWnR"
+            class="sc-dIUggk hZaEGa"
           >
             Undervote
           </div>
@@ -647,7 +647,7 @@ exports[`says the ballot sheet is undervoted if it is 1`] = `
           </p>
         </div>
         <div
-          class="sc-hHftDr kAQrHz"
+          class="sc-dmlrTW esDPKT"
         >
           <div
             style="position: relative;"
@@ -751,13 +751,13 @@ exports[`says the sheet is unreadable if it is 1`] = `
       class="sc-eCssSg jJQcwm"
     >
       <div
-        class="sc-dIUggk gvbXNc"
+        class="sc-hHftDr hXZiDL"
       >
         <div
           class="sc-crrsfI dvOODA"
         >
           <div
-            class="sc-idOhPF eXcWnR"
+            class="sc-dIUggk hZaEGa"
           >
             Unreadable
           </div>
@@ -776,7 +776,7 @@ exports[`says the sheet is unreadable if it is 1`] = `
           </p>
         </div>
         <div
-          class="sc-hHftDr kAQrHz"
+          class="sc-dmlrTW esDPKT"
         >
           <div
             style="position: relative;"

--- a/libs/types/src/hmpb.ts
+++ b/libs/types/src/hmpb.ts
@@ -1,10 +1,15 @@
 import { z } from 'zod'
 import {
+  AdjudicationReason,
+  Candidate,
+  Contest,
+  ContestOption,
   HMPBBallotPageMetadata,
   HMPBBallotPageMetadataSchema,
   TargetShape,
   TargetShapeSchema,
 } from './election'
+import { Id } from './generic'
 import {
   Corners,
   CornersSchema,
@@ -100,3 +105,99 @@ export interface MarksByContestId {
 export const MarksByContestIdSchema: z.ZodSchema<MarksByContestId> = z.record(
   MarksByOptionIdSchema.optional()
 )
+
+export interface OvervoteMarkAdjudication {
+  readonly type: AdjudicationReason.Overvote
+  readonly contestId: Contest['id']
+  readonly optionId: ContestOption['id']
+  readonly isMarked: boolean
+}
+export const OvervoteMarkAdjudicationSchema: z.ZodSchema<OvervoteMarkAdjudication> = z.object(
+  {
+    type: z.literal(AdjudicationReason.Overvote),
+    contestId: Id,
+    optionId: Id,
+    isMarked: z.boolean(),
+  }
+)
+
+export interface UndervoteMarkAdjudication {
+  readonly type: AdjudicationReason.Undervote
+  readonly contestId: Contest['id']
+  readonly optionId: ContestOption['id']
+  readonly isMarked: boolean
+}
+export const UndervoteMarkAdjudicationSchema: z.ZodSchema<UndervoteMarkAdjudication> = z.object(
+  {
+    type: z.literal(AdjudicationReason.Undervote),
+    contestId: Id,
+    optionId: Id,
+    isMarked: z.boolean(),
+  }
+)
+
+export interface MarginalMarkAdjudication {
+  readonly type: AdjudicationReason.MarginalMark
+  readonly contestId: Contest['id']
+  readonly optionId: ContestOption['id']
+  readonly isMarked: boolean
+}
+export const MarginalMarkAdjudicationSchema: z.ZodSchema<MarginalMarkAdjudication> = z.object(
+  {
+    type: z.literal(AdjudicationReason.MarginalMark),
+    contestId: Id,
+    optionId: Id,
+    isMarked: z.boolean(),
+  }
+)
+
+export interface WriteInMarkAdjudicationMarked {
+  readonly type: AdjudicationReason.WriteIn
+  readonly isWriteIn: true
+  readonly contestId: Contest['id']
+  readonly optionId: ContestOption['id']
+  readonly name: Candidate['name']
+}
+export const WriteInMarkAdjudicationMarkedSchema: z.ZodSchema<WriteInMarkAdjudicationMarked> = z.object(
+  {
+    type: z.literal(AdjudicationReason.WriteIn),
+    isWriteIn: z.literal(true),
+    contestId: Id,
+    optionId: Id,
+    name: z.string(),
+  }
+)
+
+export interface WriteInMarkAdjudicationUnmarked {
+  readonly type: AdjudicationReason.WriteIn
+  readonly isWriteIn: false
+  readonly contestId: Contest['id']
+  readonly optionId: ContestOption['id']
+}
+export const WriteInMarkAdjudicationUnmarkedSchema: z.ZodSchema<WriteInMarkAdjudicationUnmarked> = z.object(
+  {
+    type: z.literal(AdjudicationReason.WriteIn),
+    isWriteIn: z.literal(false),
+    contestId: Id,
+    optionId: Id,
+  }
+)
+
+export type WriteInMarkAdjudication =
+  | WriteInMarkAdjudicationMarked
+  | WriteInMarkAdjudicationUnmarked
+export const WriteInMarkAdjudicationSchema: z.ZodSchema<WriteInMarkAdjudication> = z.union(
+  [WriteInMarkAdjudicationMarkedSchema, WriteInMarkAdjudicationUnmarkedSchema]
+)
+
+export type MarkAdjudication =
+  | OvervoteMarkAdjudication
+  | UndervoteMarkAdjudication
+  | MarginalMarkAdjudication
+  | WriteInMarkAdjudication
+export const MarkAdjudicationSchema: z.ZodSchema<MarkAdjudication> = z.union([
+  OvervoteMarkAdjudicationSchema,
+  UndervoteMarkAdjudicationSchema,
+  MarginalMarkAdjudicationSchema,
+  WriteInMarkAdjudicationSchema,
+])


### PR DESCRIPTION


https://user-images.githubusercontent.com/1938/133305914-d9a23f79-3eac-4e02-bbe1-37925e35f78a.mov


Refactors our adjudication data structure to allow specifying whether or not a contest option should be considered marked or not.

Fixes tabbing by re-ordering elements to match the expected tab order, so that explicit `tabIndex` is not needed.

Closes #847