### PR TITLE
doc: how to disable ESLint+React integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Most of the code is written in TypeScript. We follow the
 [Airbnb JavaScript Style Guide](https://airbnb.io/javascript/), with most of it
 enforced by ESLint rules.
 
+By default developing a React app will show ESLint errors while developing. To
+disable this feature, run with this environment variable:
+`ESLINT_NO_DEV_ERRORS=true`. If you always prefer not to have this behavior,
+consider setting that in your shell configuration (e.g. `.bashrc`).
+
 ### Ubuntu Quickstart
 
 This expects Ubuntu 18.0.4, though it may work on other versions. This installs


### PR DESCRIPTION
Someone not using VS Code, or another editor with ESLint integration, would probably want to disable this integration.