### PR TITLE
feat(ps) use election definition paper size in central scan

### DIFF
--- a/apps/module-scan/src/importer.ts
+++ b/apps/module-scan/src/importer.ts
@@ -476,7 +476,11 @@ export default class Importer {
       this.batchId,
       batchScanDirectory
     )
-    this.sheetGenerator = this.scanner.scanSheets(batchScanDirectory)
+    const ballotPaperSize = await this.workspace.store.getBallotPaperSizeForElection()
+    this.sheetGenerator = this.scanner.scanSheets({
+      directory: batchScanDirectory,
+      pageSize: ballotPaperSize,
+    })
 
     await this.continueImport()
 

--- a/apps/module-scan/src/scanners/fujitsu.test.ts
+++ b/apps/module-scan/src/scanners/fujitsu.test.ts
@@ -1,6 +1,7 @@
+import { BallotPaperSize } from '@votingworks/types'
 import { ScannerStatus } from '@votingworks/types/api/module-scan'
 import { ChildProcess } from 'child_process'
-import { FujitsuScanner, ScannerMode, ScannerPageSize } from '.'
+import { FujitsuScanner, ScannerMode } from '.'
 import { makeMockChildProcess } from '../../test/util/mocks'
 import { streamExecFile } from '../exec'
 
@@ -42,10 +43,10 @@ test('fujitsu scanner calls scanimage with fujitsu device type', async () => {
 
 test('fujitsu scanner can scan with letter size', async () => {
   const scanimage = makeMockChildProcess()
-  const scanner = new FujitsuScanner({ pageSize: ScannerPageSize.Letter })
+  const scanner = new FujitsuScanner()
 
   exec.mockReturnValueOnce(scanimage)
-  scanner.scanSheets()
+  scanner.scanSheets({ pageSize: BallotPaperSize.Letter })
 
   scanimage.stderr.append(
     [
@@ -63,10 +64,10 @@ test('fujitsu scanner can scan with letter size', async () => {
 
 test('fujitsu scanner can scan with legal size', async () => {
   const scanimage = makeMockChildProcess()
-  const scanner = new FujitsuScanner({ pageSize: ScannerPageSize.Legal })
+  const scanner = new FujitsuScanner()
 
   exec.mockReturnValueOnce(scanimage)
-  scanner.scanSheets()
+  scanner.scanSheets({ pageSize: BallotPaperSize.Legal })
 
   scanimage.stderr.append(
     [

--- a/apps/module-scan/src/scanners/index.ts
+++ b/apps/module-scan/src/scanners/index.ts
@@ -1,3 +1,4 @@
+import { BallotPaperSize } from '@votingworks/types'
 import { ScannerStatus } from '@votingworks/types/api/module-scan'
 import { SheetOf } from '../types'
 
@@ -12,20 +13,20 @@ export interface BatchControl {
   endBatch(): Promise<void>
 }
 
+export interface ScanOptions {
+  directory?: string
+  pageSize?: BallotPaperSize
+}
+
 export interface Scanner {
   getStatus(): Promise<ScannerStatus>
-  scanSheets(directory?: string): BatchControl
+  scanSheets(options?: ScanOptions): BatchControl
   calibrate(): Promise<boolean>
 }
 
 export enum ScannerImageFormat {
   JPEG = 'jpeg',
   PNG = 'png',
-}
-
-export enum ScannerPageSize {
-  Letter = 'letter',
-  Legal = 'legal',
 }
 
 export enum ScannerMode {

--- a/apps/module-scan/src/scanners/plustek.ts
+++ b/apps/module-scan/src/scanners/plustek.ts
@@ -10,7 +10,7 @@ import bodyParser from 'body-parser'
 import makeDebug from 'debug'
 import express, { Application } from 'express'
 import * as z from 'zod'
-import { BatchControl, Scanner } from '.'
+import { BatchControl, Scanner, ScanOptions } from '.'
 import { SheetOf } from '../types'
 
 const debug = makeDebug('module-scan:scanner')
@@ -72,8 +72,9 @@ export class PlustekScanner implements Scanner {
     return await this.getHardwareStatus()
   }
 
-  scanSheets(directory?: string): BatchControl {
+  scanSheets({ directory, pageSize }: ScanOptions = {}): BatchControl {
     debug('scanSheets: ignoring directory: %s', directory)
+    debug('scanSheets: ignoring pageSize: %s', pageSize)
 
     const waitForStatus = async (
       client: ScannerClient,

--- a/apps/module-scan/src/store.ts
+++ b/apps/module-scan/src/store.ts
@@ -7,6 +7,7 @@ import {
   BallotMark,
   BallotMetadata,
   BallotPageMetadata,
+  BallotPaperSize,
   BallotSheetInfo,
   BallotTargetMark,
   ElectionDefinition,
@@ -397,6 +398,14 @@ export default class Store {
     return (
       (await this.getMarkThresholdOverrides()) ??
       (await this.getElectionDefinition())?.election.markThresholds
+    )
+  }
+
+  async getBallotPaperSizeForElection(): Promise<BallotPaperSize> {
+    const electionDefinition = await this.getElectionDefinition()
+    return (
+      electionDefinition?.election.ballotLayout?.paperSize ??
+      BallotPaperSize.Letter
     )
   }
 


### PR DESCRIPTION
Use the paper size from the election definition when scanning with the central scanner. 

I removed the old ScannerPageSize enum since it was identical to BallotPageSize which the election definition already types its page size as. 