### PR TITLE
feat(scan): support unmarked write-in adjudication

### DIFF
--- a/apps/bsd/src/screens/BallotEjectScreen.tsx
+++ b/apps/bsd/src/screens/BallotEjectScreen.tsx
@@ -171,7 +171,10 @@ const BallotEjectScreen = ({
             ) {
               isUndervotedSheet = true
               contestIdsWithIssues.add(adjudicationReason.contestId)
-            } else if (adjudicationReason.type === AdjudicationReason.WriteIn) {
+            } else if (
+              adjudicationReason.type === AdjudicationReason.WriteIn ||
+              adjudicationReason.type === AdjudicationReason.UnmarkedWriteIn
+            ) {
               assert(reviewPageInfo.layout)
               assert(reviewPageInfo.contestIds)
               return (

--- a/apps/bsd/src/screens/WriteInAdjudicationScreen.test.tsx
+++ b/apps/bsd/src/screens/WriteInAdjudicationScreen.test.tsx
@@ -22,7 +22,9 @@ type onAdjudicationCompleteType = Exclude<
   undefined
 >
 
-function renderWriteInAdjudicationScreen(): {
+function renderWriteInAdjudicationScreen(
+  reason: AdjudicationReason.WriteIn | AdjudicationReason.UnmarkedWriteIn
+): {
   contest: Contest
   optionId: ContestOption['id']
   onAdjudicationComplete: onAdjudicationCompleteType
@@ -67,10 +69,10 @@ function renderWriteInAdjudicationScreen(): {
         metadata,
         adjudicationInfo: {
           requiresAdjudication: true,
-          enabledReasons: [AdjudicationReason.WriteIn],
+          enabledReasons: [reason],
           allReasonInfos: [
             {
-              type: AdjudicationReason.WriteIn,
+              type: reason,
               contestId: contest.id,
               optionId,
               optionIndex: 0,
@@ -115,7 +117,7 @@ test('supports typing in a candidate name', async () => {
     contest,
     optionId,
     onAdjudicationComplete,
-  } = renderWriteInAdjudicationScreen()
+  } = renderWriteInAdjudicationScreen(AdjudicationReason.WriteIn)
 
   screen.getByText('Write-In Adjudication')
   screen.getByText(contest.title)
@@ -152,7 +154,7 @@ test('supports canceling a write-in', async () => {
     contest,
     optionId,
     onAdjudicationComplete,
-  } = renderWriteInAdjudicationScreen()
+  } = renderWriteInAdjudicationScreen(AdjudicationReason.UnmarkedWriteIn)
 
   screen.getByText('Write-In Adjudication')
   screen.getByText(contest.title)
@@ -173,7 +175,7 @@ test('supports canceling a write-in', async () => {
         'front',
         [
           {
-            type: AdjudicationReason.WriteIn,
+            type: AdjudicationReason.UnmarkedWriteIn,
             isWriteIn: false,
             contestId: contest.id,
             optionId,

--- a/apps/bsd/src/screens/WriteInAdjudicationScreen.tsx
+++ b/apps/bsd/src/screens/WriteInAdjudicationScreen.tsx
@@ -16,6 +16,7 @@ import {
   SerializableBallotPageLayout,
   WriteInMarkAdjudication,
   WriteInAdjudicationReasonInfo,
+  UnmarkedWriteInAdjudicationReasonInfo,
 } from '@votingworks/types'
 import { Side } from '@votingworks/types/api/module-scan'
 import { Text, useCancelablePromise } from '@votingworks/ui'
@@ -149,7 +150,7 @@ const WriteInLabel = ({
   writeIn,
 }: {
   contest: CandidateContest
-  writeIn: WriteInAdjudicationReasonInfo
+  writeIn: WriteInAdjudicationReasonInfo | UnmarkedWriteInAdjudicationReasonInfo
 }) => (
   <HStack>
     <div>
@@ -187,7 +188,7 @@ const WriteInImage = ({
 interface ContestOptionAdjudicationProps {
   imageURL: string
   contest: CandidateContest
-  writeIn: WriteInAdjudicationReasonInfo
+  writeIn: WriteInAdjudicationReasonInfo | UnmarkedWriteInAdjudicationReasonInfo
   layout: BallotPageContestLayout
   adjudications: readonly WriteInMarkAdjudication[]
   onChange?(adjudication: WriteInMarkAdjudication): void
@@ -223,7 +224,7 @@ const ContestOptionAdjudication = ({
       const { optionId } = input.dataset
       if (optionId) {
         onChange?.({
-          type: AdjudicationReason.WriteIn,
+          type: writeIn.type,
           isWriteIn: true,
           contestId: contest.id,
           optionId,
@@ -231,7 +232,7 @@ const ContestOptionAdjudication = ({
         })
       }
     },
-    [contest.id, onChange]
+    [contest.id, onChange, writeIn.type]
   )
 
   const onCheckboxChange = useCallback(
@@ -241,7 +242,7 @@ const ContestOptionAdjudication = ({
       if (optionId) {
         if (!input.checked) {
           onChange?.({
-            type: AdjudicationReason.WriteIn,
+            type: writeIn.type,
             isWriteIn: true,
             contestId: contest.id,
             optionId,
@@ -252,7 +253,7 @@ const ContestOptionAdjudication = ({
           assert(inputRef.current)
           inputRef.current.value = ''
           onChange?.({
-            type: AdjudicationReason.WriteIn,
+            type: writeIn.type,
             isWriteIn: false,
             contestId: contest.id,
             optionId,
@@ -260,7 +261,7 @@ const ContestOptionAdjudication = ({
         }
       }
     },
-    [contest.id, onChange]
+    [contest.id, onChange, writeIn.type]
   )
 
   useLayoutEffect(() => {
@@ -318,7 +319,10 @@ interface ContestAdjudicationProps {
   imageURL: string
   contest: CandidateContest
   layout: BallotPageContestLayout
-  writeInsForContest: readonly WriteInAdjudicationReasonInfo[]
+  writeInsForContest: readonly (
+    | WriteInAdjudicationReasonInfo
+    | UnmarkedWriteInAdjudicationReasonInfo
+  )[]
   onChange?(adjudication: WriteInMarkAdjudication): void
   adjudications: readonly WriteInMarkAdjudication[]
 }
@@ -378,8 +382,13 @@ const WriteInAdjudicationByContest = ({
   const [selectedContestIndex, setSelectedContestIndex] = useState(0)
 
   const writeIns = interpretation.adjudicationInfo.allReasonInfos.filter(
-    (reason): reason is WriteInAdjudicationReasonInfo =>
-      reason.type === AdjudicationReason.WriteIn
+    (
+      reason
+    ): reason is
+      | WriteInAdjudicationReasonInfo
+      | UnmarkedWriteInAdjudicationReasonInfo =>
+      reason.type === AdjudicationReason.WriteIn ||
+      reason.type === AdjudicationReason.UnmarkedWriteIn
   )
   const contestsWithWriteIns = new Set(
     [...writeIns].map(({ contestId }) => contestId)
@@ -510,8 +519,13 @@ export default function WriteInAdjudicationScreen({
   const [selectedContestId, setSelectedContestId] = useState<Contest['id']>()
 
   const writeIns = interpretation.adjudicationInfo.allReasonInfos.filter(
-    (reason): reason is WriteInAdjudicationReasonInfo =>
-      reason.type === AdjudicationReason.WriteIn
+    (
+      reason
+    ): reason is
+      | WriteInAdjudicationReasonInfo
+      | UnmarkedWriteInAdjudicationReasonInfo =>
+      reason.type === AdjudicationReason.WriteIn ||
+      reason.type === AdjudicationReason.UnmarkedWriteIn
   )
   const styleForContest = useCallback(
     (id: Contest['id']): React.CSSProperties => {

--- a/apps/module-scan/src/interpreter.test.ts
+++ b/apps/module-scan/src/interpreter.test.ts
@@ -369,6 +369,7 @@ test('interprets marks on an upside-down HMPB', async () => {
               },
             },
             "type": "candidate",
+            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -449,6 +450,7 @@ test('interprets marks on an upside-down HMPB', async () => {
               },
             },
             "type": "candidate",
+            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -529,6 +531,7 @@ test('interprets marks on an upside-down HMPB', async () => {
               },
             },
             "type": "candidate",
+            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -609,6 +612,7 @@ test('interprets marks on an upside-down HMPB', async () => {
               },
             },
             "type": "candidate",
+            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -689,6 +693,7 @@ test('interprets marks on an upside-down HMPB', async () => {
               },
             },
             "type": "candidate",
+            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -769,6 +774,7 @@ test('interprets marks on an upside-down HMPB', async () => {
               },
             },
             "type": "candidate",
+            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -854,6 +860,7 @@ test('interprets marks on an upside-down HMPB', async () => {
               },
             },
             "type": "candidate",
+            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -939,6 +946,7 @@ test('interprets marks on an upside-down HMPB', async () => {
               },
             },
             "type": "candidate",
+            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -1024,6 +1032,7 @@ test('interprets marks on an upside-down HMPB', async () => {
               },
             },
             "type": "candidate",
+            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -1109,6 +1118,7 @@ test('interprets marks on an upside-down HMPB', async () => {
               },
             },
             "type": "candidate",
+            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -1194,6 +1204,7 @@ test('interprets marks on an upside-down HMPB', async () => {
               },
             },
             "type": "candidate",
+            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -1279,6 +1290,7 @@ test('interprets marks on an upside-down HMPB', async () => {
               },
             },
             "type": "candidate",
+            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -1364,6 +1376,7 @@ test('interprets marks on an upside-down HMPB', async () => {
               },
             },
             "type": "candidate",
+            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -1439,6 +1452,7 @@ test('interprets marks on an upside-down HMPB', async () => {
               },
             },
             "type": "candidate",
+            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -1514,6 +1528,7 @@ test('interprets marks on an upside-down HMPB', async () => {
               },
             },
             "type": "candidate",
+            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -1589,6 +1604,7 @@ test('interprets marks on an upside-down HMPB', async () => {
               },
             },
             "type": "candidate",
+            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -1664,6 +1680,7 @@ test('interprets marks on an upside-down HMPB', async () => {
               },
             },
             "type": "candidate",
+            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -1739,6 +1756,7 @@ test('interprets marks on an upside-down HMPB', async () => {
               },
             },
             "type": "candidate",
+            "writeInTextScore": undefined,
           },
         ],
       },
@@ -1898,6 +1916,7 @@ test('interprets marks in PNG ballots', async () => {
                 },
               },
               "type": "candidate",
+              "writeInTextScore": undefined,
             },
             Object {
               "bounds": Object {
@@ -1952,6 +1971,7 @@ test('interprets marks in PNG ballots', async () => {
                 },
               },
               "type": "candidate",
+              "writeInTextScore": undefined,
             },
             Object {
               "bounds": Object {
@@ -2006,6 +2026,7 @@ test('interprets marks in PNG ballots', async () => {
                 },
               },
               "type": "candidate",
+              "writeInTextScore": 0.0001403443113772455,
             },
             Object {
               "bounds": Object {
@@ -2065,6 +2086,7 @@ test('interprets marks in PNG ballots', async () => {
                 },
               },
               "type": "candidate",
+              "writeInTextScore": undefined,
             },
             Object {
               "bounds": Object {
@@ -2124,6 +2146,7 @@ test('interprets marks in PNG ballots', async () => {
                 },
               },
               "type": "candidate",
+              "writeInTextScore": undefined,
             },
             Object {
               "bounds": Object {
@@ -2183,6 +2206,7 @@ test('interprets marks in PNG ballots', async () => {
                 },
               },
               "type": "candidate",
+              "writeInTextScore": undefined,
             },
             Object {
               "bounds": Object {
@@ -2242,6 +2266,7 @@ test('interprets marks in PNG ballots', async () => {
                 },
               },
               "type": "candidate",
+              "writeInTextScore": 0.00023761999809904002,
             },
             Object {
               "bounds": Object {
@@ -2296,6 +2321,7 @@ test('interprets marks in PNG ballots', async () => {
                 },
               },
               "type": "candidate",
+              "writeInTextScore": undefined,
             },
             Object {
               "bounds": Object {
@@ -2350,6 +2376,7 @@ test('interprets marks in PNG ballots', async () => {
                 },
               },
               "type": "candidate",
+              "writeInTextScore": undefined,
             },
             Object {
               "bounds": Object {
@@ -2404,6 +2431,7 @@ test('interprets marks in PNG ballots', async () => {
                 },
               },
               "type": "candidate",
+              "writeInTextScore": 0.0005794861889124976,
             },
             Object {
               "bounds": Object {
@@ -2458,6 +2486,7 @@ test('interprets marks in PNG ballots', async () => {
                 },
               },
               "type": "candidate",
+              "writeInTextScore": undefined,
             },
             Object {
               "bounds": Object {
@@ -2512,6 +2541,7 @@ test('interprets marks in PNG ballots', async () => {
                 },
               },
               "type": "candidate",
+              "writeInTextScore": undefined,
             },
             Object {
               "bounds": Object {
@@ -2566,6 +2596,7 @@ test('interprets marks in PNG ballots', async () => {
                 },
               },
               "type": "candidate",
+              "writeInTextScore": 0.0431383764717098,
             },
             Object {
               "bounds": Object {

--- a/apps/module-scan/src/types.ts
+++ b/apps/module-scan/src/types.ts
@@ -46,11 +46,20 @@ export function getMarkStatus(
     return MarkStatus.Marked
   }
 
-  if (mark.score < markThresholds.marginal) {
-    return MarkStatus.Unmarked
+  if (mark.score >= markThresholds.marginal) {
+    return MarkStatus.Marginal
   }
 
-  return MarkStatus.Marginal
+  if (
+    mark.type === 'candidate' &&
+    typeof mark.writeInTextScore === 'number' &&
+    typeof markThresholds.writeInText === 'number' &&
+    mark.writeInTextScore >= markThresholds.writeInText
+  ) {
+    return MarkStatus.UnmarkedWriteIn
+  }
+
+  return MarkStatus.Unmarked
 }
 
 export function isMarginalMark(

--- a/apps/module-scan/src/util/ballotAdjudicationReasons.test.ts
+++ b/apps/module-scan/src/util/ballotAdjudicationReasons.test.ts
@@ -4,6 +4,7 @@ import {
   CandidateContest,
   MarkStatus,
   MsEitherNeitherContest,
+  UnmarkedWriteInAdjudicationReasonInfo,
   WriteInAdjudicationReasonInfo,
   YesNoContest,
 } from '@votingworks/types'
@@ -277,6 +278,29 @@ test('a ballot with just a write-in', () => {
         optionIndex: 3,
       },
     ])
+  )
+})
+
+test('a ballot with just an unmarked write-in', () => {
+  const reasons = [
+    ...ballotAdjudicationReasons([president], {
+      optionMarkStatus: (contestId, optionId) =>
+        contestId === president.id && optionId === '__write-in-0'
+          ? MarkStatus.UnmarkedWriteIn
+          : MarkStatus.Unmarked,
+    }),
+  ]
+
+  const expectedReason: UnmarkedWriteInAdjudicationReasonInfo = {
+    type: AdjudicationReason.UnmarkedWriteIn,
+    contestId: president.id,
+    optionId: '__write-in-0',
+    optionIndex: 3,
+  }
+
+  expect(reasons).toContainEqual(expectedReason)
+  expect(adjudicationReasonDescription(expectedReason)).toMatchInlineSnapshot(
+    `"Contest '775020876' has an unmarked write-in."`
   )
 })
 

--- a/apps/module-scan/src/util/optionMarkStatus.test.ts
+++ b/apps/module-scan/src/util/optionMarkStatus.test.ts
@@ -11,7 +11,11 @@ import optionMarkStatus from './optionMarkStatus'
 import { election } from '../../test/fixtures/state-of-hamilton'
 import { election as eitherNeitherElection } from '../../test/fixtures/choctaw-mock-general-election-2020'
 
-const markThresholds: MarkThresholds = { definite: 0.17, marginal: 0.17 }
+const markThresholds: MarkThresholds = {
+  definite: 0.17,
+  marginal: 0.17,
+  writeInText: 0.01,
+}
 const defaultShape = {
   bounds: { x: 0, y: 0, width: 10, height: 10 },
   inner: { x: 0, y: 0, width: 10, height: 10 },
@@ -81,6 +85,36 @@ test('a candidate mark', () => {
   })
 
   expect(emptyResult).toBe(MarkStatus.Unmarked)
+})
+
+test('a candidate write-in mark', () => {
+  const contest = election.contests.find(
+    (c) => c.type === 'candidate' && c.allowWriteIns
+  ) as CandidateContest
+  const optionId = '__write-in-0'
+  const result = optionMarkStatus({
+    markThresholds,
+    marks: [
+      {
+        type: 'candidate',
+        bounds: defaultShape.bounds,
+        contest,
+        target: defaultShape,
+        option: {
+          id: optionId,
+          name: 'Write-In',
+          isWriteIn: true,
+        },
+        score: 0,
+        scoredOffset: { x: 0, y: 0 },
+        writeInTextScore: 0.05,
+      },
+    ],
+    contestId: contest.id,
+    optionId,
+  })
+
+  expect(result).toBe(MarkStatus.UnmarkedWriteIn)
 })
 
 test('a ms-either-neither mark', () => {

--- a/libs/hmpb-interpreter/src/Interpreter.test.ts
+++ b/libs/hmpb-interpreter/src/Interpreter.test.ts
@@ -1777,6 +1777,7 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
+        "writeInTextScore": undefined,
       },
       Object {
         "bounds": Object {
@@ -1836,6 +1837,7 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
+        "writeInTextScore": undefined,
       },
       Object {
         "bounds": Object {
@@ -1895,6 +1897,7 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
+        "writeInTextScore": undefined,
       },
       Object {
         "bounds": Object {
@@ -1954,6 +1957,7 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
+        "writeInTextScore": 0.002881844380403458,
       },
       Object {
         "bounds": Object {
@@ -2013,6 +2017,7 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
+        "writeInTextScore": 0.002881844380403458,
       },
       Object {
         "bounds": Object {
@@ -2235,6 +2240,7 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
+        "writeInTextScore": undefined,
       },
       Object {
         "bounds": Object {
@@ -2309,6 +2315,7 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
+        "writeInTextScore": undefined,
       },
       Object {
         "bounds": Object {
@@ -2383,6 +2390,7 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
+        "writeInTextScore": undefined,
       },
       Object {
         "bounds": Object {
@@ -2457,6 +2465,7 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
+        "writeInTextScore": undefined,
       },
       Object {
         "bounds": Object {
@@ -2531,6 +2540,7 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
+        "writeInTextScore": undefined,
       },
       Object {
         "bounds": Object {
@@ -2605,6 +2615,7 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
+        "writeInTextScore": undefined,
       },
       Object {
         "bounds": Object {
@@ -2679,6 +2690,7 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
+        "writeInTextScore": 0.00005747126436781609,
       },
       Object {
         "bounds": Object {
@@ -2753,6 +2765,7 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
+        "writeInTextScore": 0.03637931034482759,
       },
       Object {
         "bounds": Object {
@@ -2827,6 +2840,7 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
+        "writeInTextScore": 0.00017241379310344826,
       },
       Object {
         "bounds": Object {
@@ -2881,6 +2895,7 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
+        "writeInTextScore": undefined,
       },
       Object {
         "bounds": Object {
@@ -2935,6 +2950,7 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
+        "writeInTextScore": undefined,
       },
       Object {
         "bounds": Object {
@@ -2989,6 +3005,7 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
+        "writeInTextScore": 0,
       },
     ]
   `)

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -330,6 +330,7 @@ export enum AdjudicationReason {
   Overvote = 'Overvote',
   Undervote = 'Undervote',
   WriteIn = 'WriteIn',
+  UnmarkedWriteIn = 'UnmarkedWriteIn',
   BlankBallot = 'BlankBallot',
 }
 export const AdjudicationReasonSchema: z.ZodSchema<AdjudicationReason> = z.nativeEnum(
@@ -339,11 +340,13 @@ export const AdjudicationReasonSchema: z.ZodSchema<AdjudicationReason> = z.nativ
 export interface MarkThresholds {
   readonly marginal: number
   readonly definite: number
+  readonly writeInText?: number
 }
 export const MarkThresholdsSchema: z.ZodSchema<MarkThresholds> = z
   .object({
     marginal: z.number().min(0).max(1),
     definite: z.number().min(0).max(1),
+    writeInText: z.number().min(0).max(1).optional(),
   })
   .refine(
     ({ marginal, definite }) => marginal <= definite,
@@ -728,6 +731,21 @@ export const WriteInAdjudicationReasonInfoSchema: z.ZodSchema<WriteInAdjudicatio
   }
 )
 
+export interface UnmarkedWriteInAdjudicationReasonInfo {
+  type: AdjudicationReason.UnmarkedWriteIn
+  contestId: Contest['id']
+  optionId: ContestOption['id']
+  optionIndex: number
+}
+export const UnmarkedWriteInAdjudicationReasonInfoSchema: z.ZodSchema<UnmarkedWriteInAdjudicationReasonInfo> = z.object(
+  {
+    type: z.literal(AdjudicationReason.UnmarkedWriteIn),
+    contestId: Id,
+    optionId: Id,
+    optionIndex: z.number().nonnegative(),
+  }
+)
+
 export interface BlankBallotAdjudicationReasonInfo {
   type: AdjudicationReason.BlankBallot
 }
@@ -743,6 +761,7 @@ export type AdjudicationReasonInfo =
   | OvervoteAdjudicationReasonInfo
   | UndervoteAdjudicationReasonInfo
   | WriteInAdjudicationReasonInfo
+  | UnmarkedWriteInAdjudicationReasonInfo
   | BlankBallotAdjudicationReasonInfo
 export const AdjudicationReasonInfoSchema: z.ZodSchema<AdjudicationReasonInfo> = z.union(
   [
@@ -751,6 +770,7 @@ export const AdjudicationReasonInfoSchema: z.ZodSchema<AdjudicationReasonInfo> =
     OvervoteAdjudicationReasonInfoSchema,
     UndervoteAdjudicationReasonInfoSchema,
     WriteInAdjudicationReasonInfoSchema,
+    UnmarkedWriteInAdjudicationReasonInfoSchema,
     BlankBallotAdjudicationReasonInfoSchema,
   ]
 )
@@ -826,6 +846,7 @@ export interface BallotCandidateTargetMark {
   option: Candidate
   score: number
   scoredOffset: Offset
+  writeInTextScore?: number
 }
 export const BallotCandidateTargetMarkSchema: z.ZodSchema<BallotCandidateTargetMark> = z.object(
   {
@@ -834,8 +855,9 @@ export const BallotCandidateTargetMarkSchema: z.ZodSchema<BallotCandidateTargetM
     contest: CandidateContestSchema,
     target: TargetShapeSchema,
     option: CandidateSchema,
-    score: z.number(),
+    score: z.number().min(0).max(1),
     scoredOffset: OffsetSchema,
+    writeInTextScore: z.number().min(0).max(1).optional(),
   }
 )
 

--- a/libs/types/src/hmpb.ts
+++ b/libs/types/src/hmpb.ts
@@ -87,6 +87,7 @@ export enum MarkStatus {
   Marked = 'marked',
   Unmarked = 'unmarked',
   Marginal = 'marginal',
+  UnmarkedWriteIn = 'unmarkedWriteIn',
 }
 export const MarkStatusSchema: z.ZodSchema<MarkStatus> = z.nativeEnum(
   MarkStatus
@@ -152,7 +153,7 @@ export const MarginalMarkAdjudicationSchema: z.ZodSchema<MarginalMarkAdjudicatio
 )
 
 export interface WriteInMarkAdjudicationMarked {
-  readonly type: AdjudicationReason.WriteIn
+  readonly type: AdjudicationReason.WriteIn | AdjudicationReason.UnmarkedWriteIn
   readonly isWriteIn: true
   readonly contestId: Contest['id']
   readonly optionId: ContestOption['id']
@@ -160,7 +161,10 @@ export interface WriteInMarkAdjudicationMarked {
 }
 export const WriteInMarkAdjudicationMarkedSchema: z.ZodSchema<WriteInMarkAdjudicationMarked> = z.object(
   {
-    type: z.literal(AdjudicationReason.WriteIn),
+    type: z.union([
+      z.literal(AdjudicationReason.WriteIn),
+      z.literal(AdjudicationReason.UnmarkedWriteIn),
+    ]),
     isWriteIn: z.literal(true),
     contestId: Id,
     optionId: Id,
@@ -169,14 +173,17 @@ export const WriteInMarkAdjudicationMarkedSchema: z.ZodSchema<WriteInMarkAdjudic
 )
 
 export interface WriteInMarkAdjudicationUnmarked {
-  readonly type: AdjudicationReason.WriteIn
+  readonly type: AdjudicationReason.WriteIn | AdjudicationReason.UnmarkedWriteIn
   readonly isWriteIn: false
   readonly contestId: Contest['id']
   readonly optionId: ContestOption['id']
 }
 export const WriteInMarkAdjudicationUnmarkedSchema: z.ZodSchema<WriteInMarkAdjudicationUnmarked> = z.object(
   {
-    type: z.literal(AdjudicationReason.WriteIn),
+    type: z.union([
+      z.literal(AdjudicationReason.WriteIn),
+      z.literal(AdjudicationReason.UnmarkedWriteIn),
+    ]),
     isWriteIn: z.literal(false),
     contestId: Id,
     optionId: Id,

--- a/libs/types/src/schema.test.ts
+++ b/libs/types/src/schema.test.ts
@@ -418,13 +418,14 @@ test('disallows invalid adjudication reasons', () => {
           "Overvote",
           "Undervote",
           "WriteIn",
+          "UnmarkedWriteIn",
           "BlankBallot"
         ],
         "path": [
           "adjudicationReasons",
           0
         ],
-        "message": "Invalid enum value. Expected 'UninterpretableBallot' | 'MarginalMark' | 'Overvote' | 'Undervote' | 'WriteIn' | 'BlankBallot', received 'abcdefg'"
+        "message": "Invalid enum value. Expected 'UninterpretableBallot' | 'MarginalMark' | 'Overvote' | 'Undervote' | 'WriteIn' | 'UnmarkedWriteIn' | 'BlankBallot', received 'abcdefg'"
       }
     ]]
   `)


### PR DESCRIPTION

![localhost_58709_(Surface Go 2) (12)](https://user-images.githubusercontent.com/1938/133349176-0fb0c261-c404-472d-82df-033f8483c633.png)


This commit makes `hmpb-interpreter` check the write-in area of all write-in options when interpreting ballots. It adds a new score to candidate marks for the write-in area depending on how much of the area is marked compared to the template. The score is calculated similarly to the score for bubbles.

This score is only used if the associated write-in option mark is not a definite or marginal mark. In that case it is compared with the new `writeInText` mark threshold (if present) to determine whether it is an unmarked write-in. If it is considered an unmarked write-in then a new adjudication reason will be used: `AdjudicationReasons.UnmarkedWriteIn`.

Finally, if the `UnmarkedWriteIn` adjudication reason is one of the enabled reasons then contest options flagged as such will trigger the write-in adjudication screen. This can be enabled independent of the `WriteIn` adjudication reason.

To test this you'll need to enable the `UnmarkedWriteIn` adjudication reason. Here's how to do so with an existing development workspace:

```
sqlite3 dev-workspace/ballots.db "update configs set value = (select json_set(value, '$.election.precinctScanAdjudicationReasons', json_array('UninterpretableBallot','Overvote','Undervote','BlankBallot','WriteIn')) from configs where key = 'election' limit 1) where key = 'election'; update configs set value = (select json_set(value, '$.election.centralScanAdjudicationReasons', json_array('UninterpretableBallot','Overvote','Undervote','BlankBallot','WriteIn', 'UnmarkedWriteIn')) from configs where key = 'election' limit 1) where key = 'election';"
```

Similarly, you'l need to set the `writeInText` mark threshold (a value of 1% seems to work well in the testing I've done):

```
sqlite3 dev-workspace/ballots.db "update configs set value = (select json_set(value, '$.election.markThresholds.writeInText', 0.01) from configs where key = 'election' limit 1) where key = 'election';"
```

Once you've updated the configuration be sure to restart `module-scan`.

Closes #794