### PR TITLE
add extralegal paper type and scan on fujitsu appropriately.

### DIFF
--- a/apps/module-scan/src/scanners/fujitsu.ts
+++ b/apps/module-scan/src/scanners/fujitsu.ts
@@ -69,7 +69,9 @@ export class FujitsuScanner implements Scanner {
       `--batch-prompt`,
     ]
 
-    if (pageSize === BallotPaperSize.Legal) {
+    if (pageSize === BallotPaperSize.ExtraLegal) {
+      args.push('--page-width', '215.872', '--page-height', '431.8')
+    } else if (pageSize === BallotPaperSize.Legal) {
       args.push('--page-width', '215.872', '--page-height', '355.6')
     } else if (pageSize === BallotPaperSize.Letter) {
       // this is the default, no changes needed.

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -311,6 +311,7 @@ export const BallotStringsSchema: z.ZodSchema<BallotStrings> = z.record(
 export enum BallotPaperSize {
   Letter = 'letter',
   Legal = 'legal',
+  ExtraLegal = 'extralegal', // we will likely remove this one
 }
 export const BallotPaperSizeSchema: z.ZodSchema<BallotPaperSize> = z.nativeEnum(
   BallotPaperSize

--- a/libs/types/src/schema.test.ts
+++ b/libs/types/src/schema.test.ts
@@ -468,13 +468,14 @@ test('supports ballot layout paper size', () => {
         "code": "invalid_enum_value",
         "options": [
           "letter",
-          "legal"
+          "legal",
+          "extralegal"
         ],
         "path": [
           "ballotLayout",
           "paperSize"
         ],
-        "message": "Invalid enum value. Expected 'letter' | 'legal', received 'A4'"
+        "message": "Invalid enum value. Expected 'letter' | 'legal' | 'extralegal', received 'A4'"
       }
     ]]
   `)


### PR DESCRIPTION
We're likely going to use a different name, but for now enabling `extralegal` through the whole scanning process lets me test with the 8.5x17 ballots I have printed. I think it's safe to merge this and then add more paper types / remove the old ones.