### PR TITLE
test(ui): upgrade `jest` and `ts-jest`

### DIFF
--- a/libs/ui/jest.config.js
+++ b/libs/ui/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
     ...shared.collectCoverageFrom,
     '!src/ContestTally.tsx',
     '!src/LogoMark.tsx',
+    '!src/NumberPad.tsx',
     '!src/PrecinctScannerPollsReport.tsx',
     '!src/PrecinctScannerTallyReport.tsx',
     '!src/TallyReport.tsx',

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -79,7 +79,7 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-vx": "workspace:*",
     "is-ci-cli": "^2.2.0",
-    "jest": "^26.6.3",
+    "jest": "26",
     "jest-watch-typeahead": "^0.6.4",
     "lint-staged": "^11.0.0",
     "mockdate": "^3.0.5",
@@ -91,7 +91,7 @@
     "stylelint-config-prettier": "^8.0.1",
     "stylelint-config-styled-components": "^0.1.1",
     "stylelint-processor-styled-components": "^1.9.0",
-    "ts-jest": "^26.5.5",
+    "ts-jest": "26",
     "typescript": "^4.3.5"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1587,7 +1587,7 @@ importers:
       stylelint-config-prettier: 8.0.2_stylelint@13.8.0
       stylelint-config-styled-components: 0.1.1
       stylelint-processor-styled-components: 1.10.0
-      ts-jest: 26.5.5_jest@26.6.3+typescript@4.3.5
+      ts-jest: 26.5.6_jest@26.6.3+typescript@4.3.5
       typescript: 4.3.5
     specifiers:
       '@codemod/parser': ^1.0.6
@@ -1624,7 +1624,7 @@ importers:
       eslint-plugin-react-hooks: ^4.2.0
       eslint-plugin-vx: workspace:*
       is-ci-cli: ^2.2.0
-      jest: ^26.6.3
+      jest: '26'
       jest-watch-typeahead: ^0.6.4
       lint-staged: ^11.0.0
       luxon: 1.26.0
@@ -1642,7 +1642,7 @@ importers:
       stylelint-config-prettier: ^8.0.1
       stylelint-config-styled-components: ^0.1.1
       stylelint-processor-styled-components: ^1.9.0
-      ts-jest: ^26.5.5
+      ts-jest: '26'
       typescript: ^4.3.5
       use-interval: ^1.3.0
       zod: 3.2.0
@@ -1781,6 +1781,7 @@ packages:
     resolution:
       integrity: sha512-ltnibHKR1VnrU4ymHyQ/CXtNXI6yZC0oJThyW78Hft8XndANwi+9H+UIklBDraIjFEJzw8wmcM427oDd9KS5wA==
   /@babel/compat-data/7.14.4:
+    dev: true
     resolution:
       integrity: sha512-i2wXrWQNkH6JplJQGn3Rd2I4Pij8GdHkXwHMxm+zV5YG/Jci+bCNrWZEWC4o+umiDkRrRs4dVzH3X4GP7vyjQQ==
   /@babel/compat-data/7.14.5:
@@ -1789,7 +1790,6 @@ packages:
     resolution:
       integrity: sha512-kixrYn4JwfAVPa0f2yfzc2AWti6WRRyO3XjWW5PJAvtE11qhSayrrcrEnee05KAtNaPC+EwehE8Qt1UedEVB8w==
   /@babel/compat-data/7.15.0:
-    dev: false
     engines:
       node: '>=6.9.0'
     resolution:
@@ -1811,6 +1811,7 @@ packages:
       lodash: 4.17.20
       semver: 5.7.1
       source-map: 0.5.7
+    dev: true
     engines:
       node: '>=6.9.0'
     resolution:
@@ -1877,6 +1878,7 @@ packages:
       json5: 2.2.0
       semver: 6.3.0
       source-map: 0.5.7
+    dev: true
     engines:
       node: '>=6.9.0'
     resolution:
@@ -1924,6 +1926,27 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==
+  /@babel/core/7.15.5:
+    dependencies:
+      '@babel/code-frame': 7.14.5
+      '@babel/generator': 7.15.4
+      '@babel/helper-compilation-targets': 7.15.4_@babel+core@7.15.5
+      '@babel/helper-module-transforms': 7.15.4
+      '@babel/helpers': 7.15.4
+      '@babel/parser': 7.15.6
+      '@babel/template': 7.15.4
+      '@babel/traverse': 7.15.4
+      '@babel/types': 7.15.6
+      convert-source-map: 1.8.0
+      debug: 4.3.2
+      gensync: 1.0.0-beta.2
+      json5: 2.2.0
+      semver: 6.3.0
+      source-map: 0.5.7
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==
   /@babel/core/7.8.4:
     dependencies:
       '@babel/code-frame': 7.12.11
@@ -1997,6 +2020,7 @@ packages:
       '@babel/types': 7.14.4
       jsesc: 2.5.2
       source-map: 0.5.7
+    dev: true
     resolution:
       integrity: sha512-bn0S6flG/j0xtQdz3hsjJ624h3W0r3llttBMfyHX3YrZ/KtLYr15bjA0FXkgW7FpvrDuTuElXeVjiKlYRpnOFA==
   /@babel/generator/7.14.5:
@@ -2018,6 +2042,15 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==
+  /@babel/generator/7.15.4:
+    dependencies:
+      '@babel/types': 7.15.6
+      jsesc: 2.5.2
+      source-map: 0.5.7
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==
   /@babel/helper-annotate-as-pure/7.12.10:
     dependencies:
       '@babel/types': 7.12.12
@@ -2092,6 +2125,7 @@ packages:
       '@babel/helper-validator-option': 7.12.17
       browserslist: 4.16.6
       semver: 6.3.0
+    dev: true
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
@@ -2123,6 +2157,19 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==
+  /@babel/helper-compilation-targets/7.15.4_@babel+core@7.15.5:
+    dependencies:
+      '@babel/compat-data': 7.15.0
+      '@babel/core': 7.15.5
+      '@babel/helper-validator-option': 7.14.5
+      browserslist: 4.17.0
+      semver: 6.3.0
+    engines:
+      node: '>=6.9.0'
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    resolution:
+      integrity: sha512-rMWPCirulnPSe4d+gwdWXLfAXTTBj8M3guAf5xFQJ0nvFY7tfNAFnWdqaHegHlgDZOCT4qvhF3BYlSJag8yhqQ==
   /@babel/helper-create-class-features-plugin/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
@@ -2249,6 +2296,7 @@ packages:
       '@babel/helper-get-function-arity': 7.12.13
       '@babel/template': 7.12.13
       '@babel/types': 7.14.4
+    dev: true
     resolution:
       integrity: sha512-NYZlkZRydxw+YT56IlhIcS8PAhb+FEUiOzuhFTfqDyPmzAhRge6ua0dQYT/Uh0t/EDHq05/i+e5M2d4XvjgarQ==
   /@babel/helper-function-name/7.14.5:
@@ -2260,6 +2308,15 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==
+  /@babel/helper-function-name/7.15.4:
+    dependencies:
+      '@babel/helper-get-function-arity': 7.15.4
+      '@babel/template': 7.15.4
+      '@babel/types': 7.15.6
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==
   /@babel/helper-get-function-arity/7.12.10:
     dependencies:
       '@babel/types': 7.12.12
@@ -2277,6 +2334,13 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==
+  /@babel/helper-get-function-arity/7.15.4:
+    dependencies:
+      '@babel/types': 7.15.6
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==
   /@babel/helper-hoist-variables/7.10.4:
     dependencies:
       '@babel/types': 7.13.17
@@ -2290,6 +2354,13 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==
+  /@babel/helper-hoist-variables/7.15.4:
+    dependencies:
+      '@babel/types': 7.15.6
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==
   /@babel/helper-member-expression-to-functions/7.12.7:
     dependencies:
       '@babel/types': 7.12.12
@@ -2315,6 +2386,13 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==
+  /@babel/helper-member-expression-to-functions/7.15.4:
+    dependencies:
+      '@babel/types': 7.15.6
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==
   /@babel/helper-module-imports/7.12.5:
     dependencies:
       '@babel/types': 7.12.12
@@ -2332,6 +2410,13 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==
+  /@babel/helper-module-imports/7.15.4:
+    dependencies:
+      '@babel/types': 7.15.6
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==
   /@babel/helper-module-transforms/7.12.1:
     dependencies:
       '@babel/helper-module-imports': 7.12.5
@@ -2368,6 +2453,7 @@ packages:
       '@babel/template': 7.12.13
       '@babel/traverse': 7.14.2
       '@babel/types': 7.14.4
+    dev: true
     resolution:
       integrity: sha512-OznJUda/soKXv0XhpvzGWDnml4Qnwp16GN+D/kZIdLsWoHj05kyu8Rm5kXmMef+rVJZ0+4pSGLkeixdqNUATDA==
   /@babel/helper-module-transforms/7.14.5:
@@ -2399,6 +2485,20 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==
+  /@babel/helper-module-transforms/7.15.4:
+    dependencies:
+      '@babel/helper-module-imports': 7.15.4
+      '@babel/helper-replace-supers': 7.15.4
+      '@babel/helper-simple-access': 7.15.4
+      '@babel/helper-split-export-declaration': 7.15.4
+      '@babel/helper-validator-identifier': 7.14.9
+      '@babel/template': 7.15.4
+      '@babel/traverse': 7.15.4
+      '@babel/types': 7.15.6
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-9fHHSGE9zTC++KuXLZcB5FKgvlV83Ox+NLUmQTawovwlJ85+QMhk1CnVk406CQVj97LaWod6KVjl2Sfgw9Aktw==
   /@babel/helper-optimise-call-expression/7.12.10:
     dependencies:
       '@babel/types': 7.12.12
@@ -2416,6 +2516,13 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==
+  /@babel/helper-optimise-call-expression/7.15.4:
+    dependencies:
+      '@babel/types': 7.15.6
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==
   /@babel/helper-plugin-utils/7.10.4:
     dev: false
     resolution:
@@ -2423,6 +2530,11 @@ packages:
   /@babel/helper-plugin-utils/7.13.0:
     resolution:
       integrity: sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==
+  /@babel/helper-plugin-utils/7.14.5:
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==
   /@babel/helper-remap-async-to-generator/7.12.1:
     dependencies:
       '@babel/helper-annotate-as-pure': 7.12.13
@@ -2454,6 +2566,7 @@ packages:
       '@babel/helper-optimise-call-expression': 7.12.13
       '@babel/traverse': 7.14.2
       '@babel/types': 7.14.4
+    dev: true
     resolution:
       integrity: sha512-zZ7uHCWlxfEAAOVDYQpEf/uyi1dmeC7fX4nCf2iz9drnCwi1zvwXL3HwWWNXUQEJ1k23yVn3VbddiI9iJEXaTQ==
   /@babel/helper-replace-supers/7.14.5:
@@ -2477,6 +2590,16 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==
+  /@babel/helper-replace-supers/7.15.4:
+    dependencies:
+      '@babel/helper-member-expression-to-functions': 7.15.4
+      '@babel/helper-optimise-call-expression': 7.15.4
+      '@babel/traverse': 7.15.4
+      '@babel/types': 7.15.6
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-/ztT6khaXF37MS47fufrKvIsiQkx1LBRvSJNzRqmbyeZnTwU9qBxXYLaaT/6KaxfKhjs2Wy8kG8ZdsFUuWBjzw==
   /@babel/helper-simple-access/7.12.1:
     dependencies:
       '@babel/types': 7.12.12
@@ -2502,6 +2625,13 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==
+  /@babel/helper-simple-access/7.15.4:
+    dependencies:
+      '@babel/types': 7.15.6
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-UzazrDoIVOZZcTeHHEPYrr1MvTR/K+wgLg6MY6e1CJyaRhbibftF6fR2KU2sFRtI/nERUZR9fBd6aKgBlIBaPg==
   /@babel/helper-skip-transparent-expression-wrappers/7.12.1:
     dependencies:
       '@babel/types': 7.13.17
@@ -2525,6 +2655,13 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==
+  /@babel/helper-split-export-declaration/7.15.4:
+    dependencies:
+      '@babel/types': 7.15.6
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==
   /@babel/helper-validator-identifier/7.12.11:
     resolution:
       integrity: sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
@@ -2582,6 +2719,7 @@ packages:
       '@babel/template': 7.12.13
       '@babel/traverse': 7.14.2
       '@babel/types': 7.14.4
+    dev: true
     resolution:
       integrity: sha512-+ufuXprtQ1D1iZTO/K9+EBRn+qPWMJjZSw/S0KlFrxCw4tkrzv9grgpDHkY9MeQTjTY8i2sp7Jep8DfU6tN9Mg==
   /@babel/helpers/7.14.5:
@@ -2603,6 +2741,15 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-HwJiz52XaS96lX+28Tnbu31VeFSQJGOeKHJeaEPQlTl7PnlhFElWPj8tUXtqFIzeN86XxXoBr+WFAyK2PPVz6g==
+  /@babel/helpers/7.15.4:
+    dependencies:
+      '@babel/template': 7.15.4
+      '@babel/traverse': 7.15.4
+      '@babel/types': 7.15.6
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-V45u6dqEJ3w2rlryYYXf6i9rQ5YMNu4FLS6ngs8ikblhu2VdR1AqAd6aJjBzmf2Qzh6KOLqKHxEN9+TFbAkAVQ==
   /@babel/highlight/7.10.4:
     dependencies:
       '@babel/helper-validator-identifier': 7.12.11
@@ -2679,6 +2826,12 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==
+  /@babel/parser/7.15.6:
+    engines:
+      node: '>=6.0.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-S/TSCcsRuCkmpUuoWijua0Snt+f3ewU/8spLo+4AXJCZfT0bVCzLD5MuOKdrx0mlAptbKzn5AdgEIIKXxXkz9Q==
   /@babel/plugin-proposal-async-generator-functions/7.12.12_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
@@ -3235,6 +3388,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.10
       '@babel/helper-plugin-utils': 7.13.0
+    dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
@@ -3266,6 +3420,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
+  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.15.5:
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
@@ -3288,6 +3450,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.10
       '@babel/helper-plugin-utils': 7.13.0
+    dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
@@ -3310,10 +3473,19 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==
+  /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.15.5:
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==
   /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.12.10:
     dependencies:
       '@babel/core': 7.12.10
       '@babel/helper-plugin-utils': 7.13.0
+    dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
@@ -3332,6 +3504,14 @@ packages:
       '@babel/core': 7.14.3
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==
+  /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.15.5:
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
@@ -3466,6 +3646,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.10
       '@babel/helper-plugin-utils': 7.13.0
+    dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
@@ -3488,10 +3669,19 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==
+  /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.15.5:
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==
   /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.12.10:
     dependencies:
       '@babel/core': 7.12.10
       '@babel/helper-plugin-utils': 7.13.0
+    dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
@@ -3519,6 +3709,14 @@ packages:
       '@babel/core': 7.14.3
       '@babel/helper-plugin-utils': 7.13.0
     dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
+  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.15.5:
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
@@ -3581,6 +3779,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.10
       '@babel/helper-plugin-utils': 7.13.0
+    dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
@@ -3612,6 +3811,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==
+  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.15.5:
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==
   /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
@@ -3625,6 +3832,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.10
       '@babel/helper-plugin-utils': 7.13.0
+    dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
@@ -3656,6 +3864,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
+  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.15.5:
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
@@ -3678,6 +3894,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.10
       '@babel/helper-plugin-utils': 7.13.0
+    dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
@@ -3709,6 +3926,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==
+  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.15.5:
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==
   /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
@@ -3731,6 +3956,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.10
       '@babel/helper-plugin-utils': 7.13.0
+    dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
@@ -3762,6 +3988,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
+  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.15.5:
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
   /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
@@ -3784,6 +4018,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.10
       '@babel/helper-plugin-utils': 7.13.0
+    dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
@@ -3815,6 +4050,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
+  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.15.5:
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
   /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
@@ -3837,6 +4080,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.10
       '@babel/helper-plugin-utils': 7.13.0
+    dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
@@ -3868,6 +4112,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
+  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.15.5:
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
   /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
@@ -3890,6 +4142,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.10
       '@babel/helper-plugin-utils': 7.13.0
+    dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
@@ -3948,6 +4201,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-i7ooMZFS+a/Om0crxZodrTzNEPJHZrlMVGMTEpFAj6rYY/bKCddB0Dk/YxfPuYXOopuhKk/e1jV6h+WUU9XN3A==
+  /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.15.5:
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/helper-plugin-utils': 7.14.5
+    engines:
+      node: '>=6.9.0'
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==
   /@babel/plugin-syntax-typescript/7.12.13_@babel+core@7.14.3:
     dependencies:
       '@babel/core': 7.14.3
@@ -5999,6 +6262,15 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==
+  /@babel/template/7.15.4:
+    dependencies:
+      '@babel/code-frame': 7.14.5
+      '@babel/parser': 7.15.6
+      '@babel/types': 7.15.6
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==
   /@babel/traverse/7.12.12:
     dependencies:
       '@babel/code-frame': 7.12.11
@@ -6066,6 +6338,7 @@ packages:
       '@babel/types': 7.14.4
       debug: 4.3.1
       globals: 11.12.0
+    dev: true
     resolution:
       integrity: sha512-TsdRgvBFHMyHOOzcP9S6QU0QQtjxlRpEYOy3mcCO5RgmC305ki42aSAmfZEMSSYBla2oZ9BMqYlncBaKmD/7iA==
   /@babel/traverse/7.14.5:
@@ -6099,6 +6372,21 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==
+  /@babel/traverse/7.15.4:
+    dependencies:
+      '@babel/code-frame': 7.14.5
+      '@babel/generator': 7.15.4
+      '@babel/helper-function-name': 7.15.4
+      '@babel/helper-hoist-variables': 7.15.4
+      '@babel/helper-split-export-declaration': 7.15.4
+      '@babel/parser': 7.15.6
+      '@babel/types': 7.15.6
+      debug: 4.3.2
+      globals: 11.12.0
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==
   /@babel/types/7.12.12:
     dependencies:
       '@babel/helper-validator-identifier': 7.12.11
@@ -6128,12 +6416,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-O2LVLdcnWplaGxiPBz12d0HcdN8QdxdsWYhz5LSeuukV/5mn2xUUc3gBeU4QBYPJ18g/UToe8F532XJ608prmg==
-  /@babel/types/7.14.2:
-    dependencies:
-      '@babel/helper-validator-identifier': 7.14.0
-      to-fast-properties: 2.0.0
-    resolution:
-      integrity: sha512-SdjAG/3DikRHpUOjxZgnkbR11xUlyDMUFJdvnIgZEE16mqmY0BINMmc4//JMJglEmn6i7sq6p+mGrFWyZ98EEw==
   /@babel/types/7.14.4:
     dependencies:
       '@babel/helper-validator-identifier': 7.14.0
@@ -6156,6 +6438,14 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==
+  /@babel/types/7.15.6:
+    dependencies:
+      '@babel/helper-validator-identifier': 7.14.9
+      to-fast-properties: 2.0.0
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==
   /@bcoe/v8-coverage/0.2.3:
     resolution:
       integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
@@ -6399,8 +6689,8 @@ packages:
   /@jest/console/26.6.2:
     dependencies:
       '@jest/types': 26.6.2
-      '@types/node': 15.3.0
-      chalk: 4.1.1
+      '@types/node': 15.14.9
+      chalk: 4.1.2
       jest-message-util: 26.6.2
       jest-util: 26.6.2
       slash: 3.0.0
@@ -6463,9 +6753,9 @@ packages:
       '@jest/test-result': 26.6.2
       '@jest/transform': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 14.14.21
-      ansi-escapes: 4.3.1
-      chalk: 4.1.0
+      '@types/node': 15.14.9
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.4
       jest-changed-files: 26.6.2
@@ -6481,7 +6771,7 @@ packages:
       jest-util: 26.6.2
       jest-validate: 26.6.2
       jest-watcher: 26.6.2
-      micromatch: 4.0.2
+      micromatch: 4.0.4
       p-each-series: 2.2.0
       rimraf: 3.0.2
       slash: 3.0.0
@@ -6658,7 +6948,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 15.3.0
+      '@types/node': 15.14.9
       jest-mock: 26.6.2
     engines:
       node: '>= 10.14.2'
@@ -6701,7 +6991,7 @@ packages:
     dependencies:
       '@jest/types': 26.6.2
       '@sinonjs/fake-timers': 6.0.1
-      '@types/node': 15.3.0
+      '@types/node': 15.14.9
       jest-message-util: 26.6.2
       jest-mock: 26.6.2
       jest-util: 26.6.2
@@ -6776,7 +7066,7 @@ packages:
       '@jest/test-result': 26.6.2
       '@jest/transform': 26.6.2
       '@jest/types': 26.6.2
-      chalk: 4.1.1
+      chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
       glob: 7.1.7
@@ -6998,11 +7288,11 @@ packages:
       integrity: sha512-TcQUmyNRxV94S0QpMOnZl0++6RMiqpbH/ZMccFB/amku6Uwvyb1cjYX7xkp5nGNkbX4QPH/FcB6q1HBTHynLmQ==
   /@jest/transform/26.6.2:
     dependencies:
-      '@babel/core': 7.14.3
+      '@babel/core': 7.15.5
       '@jest/types': 26.6.2
       babel-plugin-istanbul: 6.0.0
-      chalk: 4.1.1
-      convert-source-map: 1.7.0
+      chalk: 4.1.2
+      convert-source-map: 1.8.0
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.4
       jest-haste-map: 26.6.2
@@ -7062,9 +7352,9 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.3
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 15.12.2
-      '@types/yargs': 15.0.13
-      chalk: 4.1.1
+      '@types/node': 15.14.9
+      '@types/yargs': 15.0.14
+      chalk: 4.1.2
     engines:
       node: '>= 10.14.2'
     resolution:
@@ -7084,7 +7374,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.3
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 12.19.3
+      '@types/node': 16.0.0
       '@types/yargs': 16.0.4
       chalk: 4.1.2
     dev: true
@@ -7946,7 +8236,6 @@ packages:
     resolution:
       integrity: sha512-cczlgVl+krjOb3j1625usarNEibI0IFRJrSWX9UsJ1HKYFgCQv9Nb7QAipUDXl3Xdz8NDTsiS78eAkPSxlzTlw==
   /@tootallnate/once/1.1.2:
-    dev: true
     engines:
       node: '>= 6'
     resolution:
@@ -8011,17 +8300,37 @@ packages:
     dev: true
     resolution:
       integrity: sha512-bxlMKPDbY8x5h6HBwVzEOk2C8fb6SLfYQ5Jw3uBYuYF1lfWk/kbLd81la82vrIkBb0l+JdmrZaDikPrNxpS/Ew==
+  /@types/babel__core/7.1.16:
+    dependencies:
+      '@babel/parser': 7.15.6
+      '@babel/types': 7.15.6
+      '@types/babel__generator': 7.6.3
+      '@types/babel__template': 7.4.1
+      '@types/babel__traverse': 7.14.2
+    resolution:
+      integrity: sha512-EAEHtisTMM+KaKwfWdC3oyllIqswlznXCIVCt7/oRNrh+DhgT4UEBNC/jlADNjvw7UnfbcdkGQcPVZ1xYiLcrQ==
   /@types/babel__generator/7.6.2:
     dependencies:
       '@babel/types': 7.15.0
     resolution:
       integrity: sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==
+  /@types/babel__generator/7.6.3:
+    dependencies:
+      '@babel/types': 7.15.6
+    resolution:
+      integrity: sha512-/GWCmzJWqV7diQW54smJZzWbSFf4QYtF71WCKhcx6Ru/tFyQIY2eiiITcCAeuPbNSvT9YCGkVMqqvSk2Z0mXiA==
   /@types/babel__template/7.4.0:
     dependencies:
       '@babel/parser': 7.14.5
       '@babel/types': 7.15.0
     resolution:
       integrity: sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==
+  /@types/babel__template/7.4.1:
+    dependencies:
+      '@babel/parser': 7.15.6
+      '@babel/types': 7.15.6
+    resolution:
+      integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==
   /@types/babel__traverse/7.11.0:
     dependencies:
       '@babel/types': 7.12.13
@@ -8033,6 +8342,11 @@ packages:
       '@babel/types': 7.15.0
     resolution:
       integrity: sha512-Vs0hm0vPahPMYi9tDjtP66llufgO3ST16WXaSTtDGEl9cewAl3AibmxWw6TINOqHPT9z0uABKAYjT9jNSg4npw==
+  /@types/babel__traverse/7.14.2:
+    dependencies:
+      '@babel/types': 7.15.6
+    resolution:
+      integrity: sha512-K2waXdXBi2302XUdcHcR1jCeU0LL4TD9HRs/gk0N2Xvrht+G/BfJa4QObBQZfhMdxiCpV3COl5Nfq4uKTeTnJA==
   /@types/base64-js/1.3.0:
     dev: true
     resolution:
@@ -8159,7 +8473,7 @@ packages:
       integrity: sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==
   /@types/graceful-fs/4.1.5:
     dependencies:
-      '@types/node': 15.6.2
+      '@types/node': 15.14.9
     resolution:
       integrity: sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==
   /@types/history/4.7.8:
@@ -8341,9 +8655,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-gema+apZ6qLQK7k7F0dGkGCWQYsL0qqKORWOQO6tq46q+x+1C0vbOiOqOwRVlh4RAdbQwV/j/ryr3u5NOG1fPQ==
-  /@types/node/12.20.13:
-    resolution:
-      integrity: sha512-1x8W5OpxPq+T85OUsHRP6BqXeosKmeXRtjoF39STcdf/UWLqUsoehstZKOi0CunhVqHG17AyZgpj20eRVooK6A==
   /@types/node/12.20.15:
     dev: false
     resolution:
@@ -8380,18 +8691,23 @@ packages:
     dev: true
     resolution:
       integrity: sha512-zrNj1+yqYF4WskCMOHwN+w9iuD12+dGm0rQ35HLl9/Ouuq52cEtd0CH9qMgrdNmi5ejC1/V7vKEXYubB+65DkA==
+  /@types/node/15.14.9:
+    resolution:
+      integrity: sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==
   /@types/node/15.3.0:
+    dev: true
     resolution:
       integrity: sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ==
   /@types/node/15.6.2:
+    dev: true
     resolution:
       integrity: sha512-dxcOx8801kMo3KlU+C+/ctWrzREAH7YvoF3aoVpRdqgs+Kf7flp+PJDN/EX5bME3suDUZHsxes9hpvBmzYlWbA==
   /@types/node/16.0.0:
     resolution:
       integrity: sha512-TmCW5HoZ2o2/z2EYi109jLqIaPIi9y/lc2LmDCWzuCi35bcaQ+OtUh6nwBiFK7SOu25FAU5+YKdqFZUwtqGSdg==
-  /@types/normalize-package-data/2.4.0:
+  /@types/normalize-package-data/2.4.1:
     resolution:
-      integrity: sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
+      integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
   /@types/parse-json/4.0.0:
     resolution:
       integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
@@ -8407,8 +8723,12 @@ packages:
     resolution:
       integrity: sha512-BYOID+l2Aco2nBik+iYS4SZX0Lf20KPILP5RGmM1IgzdwNdTs0eebiFriOPcej1sX9mLnSoiNte5zcFxssgpGA==
   /@types/prettier/2.2.3:
+    dev: true
     resolution:
       integrity: sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA==
+  /@types/prettier/2.3.2:
+    resolution:
+      integrity: sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==
   /@types/prop-types/15.7.3:
     resolution:
       integrity: sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
@@ -8563,8 +8883,12 @@ packages:
     resolution:
       integrity: sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
   /@types/stack-utils/2.0.0:
+    dev: true
     resolution:
       integrity: sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
+  /@types/stack-utils/2.0.1:
+    resolution:
+      integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
   /@types/styled-components/5.1.7:
     dependencies:
       '@types/hoist-non-react-statics': 3.3.1
@@ -8675,7 +8999,6 @@ packages:
     resolution:
       integrity: sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==
   /@types/yargs-parser/20.2.1:
-    dev: true
     resolution:
       integrity: sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==
   /@types/yargs/13.0.11:
@@ -8686,6 +9009,7 @@ packages:
   /@types/yargs/15.0.12:
     dependencies:
       '@types/yargs-parser': 20.2.0
+    dev: true
     resolution:
       integrity: sha512-f+fD/fQAo3BCbCDlrUpznF1A5Zp9rB0noS5vnoormHSIPFKL0Z2DcUJ3Gxp5ytH4uLRNxy7AwYUC9exZzqGMAw==
   /@types/yargs/15.0.13:
@@ -8693,6 +9017,11 @@ packages:
       '@types/yargs-parser': 20.2.0
     resolution:
       integrity: sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==
+  /@types/yargs/15.0.14:
+    dependencies:
+      '@types/yargs-parser': 20.2.1
+    resolution:
+      integrity: sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==
   /@types/yargs/16.0.0:
     dependencies:
       '@types/yargs-parser': 20.2.0
@@ -10283,6 +10612,12 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-tqPKHZ5CaBJw0Xmy0ZZvLs1qTV+BNFSyvn77ASXkpBNfIRk8ev26fKrD9iLGwGA9zedPao52GSHzq8lyZG0NUw==
+  /acorn/8.5.0:
+    engines:
+      node: '>=0.4.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==
   /address/1.1.2:
     engines:
       node: '>= 0.12.0'
@@ -10309,8 +10644,7 @@ packages:
       integrity: sha512-YBrGyT2/uVQ/c6Rr+t6ZJXniY03YtHGMJQYal368burRGYKqhx9qGTWqcBU5s1CwYY9E/ri63RYyG1IacMZtqw==
   /agent-base/6.0.2:
     dependencies:
-      debug: 4.3.1
-    dev: true
+      debug: 4.3.2
     engines:
       node: '>= 6.0.0'
     resolution:
@@ -10876,6 +11210,7 @@ packages:
       chalk: 4.1.1
       graceful-fs: 4.2.4
       slash: 3.0.0
+    dev: true
     engines:
       node: '>= 10.14.2'
     peerDependencies:
@@ -10894,6 +11229,23 @@ packages:
       graceful-fs: 4.2.4
       slash: 3.0.0
     dev: false
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    resolution:
+      integrity: sha512-pl4Q+GAVOHwvjrck6jKjvmGhnO3jHX/xuB9d27f+EJZ/6k+6nMuPjorrYp7s++bKKdANwzElBWnLWaObvTnaZA==
+  /babel-jest/26.6.3_@babel+core@7.15.5:
+    dependencies:
+      '@babel/core': 7.15.5
+      '@jest/transform': 26.6.2
+      '@jest/types': 26.6.2
+      '@types/babel__core': 7.1.16
+      babel-plugin-istanbul: 6.0.0
+      babel-preset-jest: 26.6.2_@babel+core@7.15.5
+      chalk: 4.1.2
+      graceful-fs: 4.2.4
+      slash: 3.0.0
     engines:
       node: '>= 10.14.2'
     peerDependencies:
@@ -10970,7 +11322,7 @@ packages:
       integrity: sha512-5LphC0USA8t4i1zCtjbbNb6jJj/9+X6P37Qfirc/70EQ34xKlMW+a1RHGwxGI+SwWpNwZ27HqvzAobeqaXwiZw==
   /babel-plugin-istanbul/6.0.0:
     dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-plugin-utils': 7.14.5
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-instrument: 4.0.3
@@ -10989,10 +11341,10 @@ packages:
       integrity: sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==
   /babel-plugin-jest-hoist/26.6.2:
     dependencies:
-      '@babel/template': 7.12.13
-      '@babel/types': 7.14.2
-      '@types/babel__core': 7.1.14
-      '@types/babel__traverse': 7.11.1
+      '@babel/template': 7.15.4
+      '@babel/types': 7.15.6
+      '@types/babel__core': 7.1.16
+      '@types/babel__traverse': 7.14.2
     engines:
       node: '>= 10.14.2'
     resolution:
@@ -11102,6 +11454,7 @@ packages:
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.12.10
       '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.12.10
       '@babel/plugin-syntax-top-level-await': 7.12.13_@babel+core@7.12.10
+    dev: true
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
@@ -11146,6 +11499,25 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==
+  /babel-preset-current-node-syntax/1.0.1_@babel+core@7.15.5:
+    dependencies:
+      '@babel/core': 7.15.5
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.15.5
+      '@babel/plugin-syntax-bigint': 7.8.3_@babel+core@7.15.5
+      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.15.5
+      '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.15.5
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.15.5
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.15.5
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.15.5
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.15.5
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.15.5
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.15.5
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.15.5
+      '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.15.5
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    resolution:
+      integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==
   /babel-preset-jest/24.9.0_@babel+core@7.8.4:
     dependencies:
       '@babel/core': 7.8.4
@@ -11175,6 +11547,7 @@ packages:
       '@babel/core': 7.12.10
       babel-plugin-jest-hoist: 26.6.2
       babel-preset-current-node-syntax: 1.0.1_@babel+core@7.12.10
+    dev: true
     engines:
       node: '>= 10.14.2'
     peerDependencies:
@@ -11187,6 +11560,17 @@ packages:
       babel-plugin-jest-hoist: 26.6.2
       babel-preset-current-node-syntax: 1.0.1_@babel+core@7.12.3
     dev: false
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    resolution:
+      integrity: sha512-YvdtlVm9t3k777c5NPQIv6cxFFFapys25HiUmuSgHwIZhfifweR5c5Sf5nwE3MAbfu327CYSvps8Yx6ANLyleQ==
+  /babel-preset-jest/26.6.2_@babel+core@7.15.5:
+    dependencies:
+      '@babel/core': 7.15.5
+      babel-plugin-jest-hoist: 26.6.2
+      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.15.5
     engines:
       node: '>= 10.14.2'
     peerDependencies:
@@ -11538,6 +11922,18 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==
+  /browserslist/4.17.0:
+    dependencies:
+      caniuse-lite: 1.0.30001257
+      colorette: 1.4.0
+      electron-to-chromium: 1.3.840
+      escalade: 3.1.1
+      node-releases: 1.1.75
+    engines:
+      node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7
+    hasBin: true
+    resolution:
+      integrity: sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==
   /bs-logger/0.2.6:
     dependencies:
       fast-json-stable-stringify: 2.1.0
@@ -11556,6 +11952,9 @@ packages:
   /buffer-from/1.1.1:
     resolution:
       integrity: sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+  /buffer-from/1.1.2:
+    resolution:
+      integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
   /buffer-indexof/1.1.1:
     dev: false
     resolution:
@@ -11821,6 +12220,9 @@ packages:
   /caniuse-lite/1.0.30001236:
     resolution:
       integrity: sha512-o0PRQSrSCGJKCPZcgMzl5fUaj5xHe8qA2m4QRvnyY4e1lITqoNkr7q/Oh1NcpGSy0Th97UZ35yoKcINPoq7YOQ==
+  /caniuse-lite/1.0.30001257:
+    resolution:
+      integrity: sha512-JN49KplOgHSXpIsVSF+LUyhD8PUp6xPpAXeRrrcBh4KBeP7W864jHn6RvzJgDlrReyeVjMFJL3PLpPvKIxlIHA==
   /canvas/2.6.1:
     dependencies:
       nan: 2.14.2
@@ -11896,7 +12298,6 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-    dev: true
     engines:
       node: '>=10'
     resolution:
@@ -12253,6 +12654,9 @@ packages:
   /colorette/1.2.2:
     resolution:
       integrity: sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
+  /colorette/1.4.0:
+    resolution:
+      integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==
   /colors/1.4.0:
     dev: true
     engines:
@@ -12449,6 +12853,11 @@ packages:
       safe-buffer: 5.1.2
     resolution:
       integrity: sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
+  /convert-source-map/1.8.0:
+    dependencies:
+      safe-buffer: 5.1.2
+    resolution:
+      integrity: sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==
   /cookie-signature/1.0.6:
     dev: false
     resolution:
@@ -13118,7 +13527,7 @@ packages:
     dependencies:
       abab: 2.0.5
       whatwg-mimetype: 2.3.0
-      whatwg-url: 8.5.0
+      whatwg-url: 8.7.0
     engines:
       node: '>=10'
     resolution:
@@ -13250,8 +13659,12 @@ packages:
     resolution:
       integrity: sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
   /decimal.js/10.2.1:
+    dev: true
     resolution:
       integrity: sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==
+  /decimal.js/10.3.1:
+    resolution:
+      integrity: sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==
   /decode-uri-component/0.2.0:
     engines:
       node: '>=0.10'
@@ -13304,6 +13717,9 @@ packages:
   /deep-is/0.1.3:
     resolution:
       integrity: sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+  /deep-is/0.1.4:
+    resolution:
+      integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
   /deepmerge/4.2.2:
     engines:
       node: '>=0.10.0'
@@ -13687,6 +14103,9 @@ packages:
   /electron-to-chromium/1.3.752:
     resolution:
       integrity: sha512-2Tg+7jSl3oPxgsBsWKh5H83QazTkmWG/cnNwJplmyZc7KcN61+I10oUgaXSVk/NwfvN3BdkKDR4FYuRBQQ2v0A==
+  /electron-to-chromium/1.3.840:
+    resolution:
+      integrity: sha512-yRoUmTLDJnkIJx23xLY7GbSvnmDCq++NSuxHDQ0jiyDJ9YZBUGJcrdUqm+ZwZFzMbCciVzfem2N2AWiHJcWlbw==
   /elegant-spinner/1.0.1:
     dev: true
     engines:
@@ -13945,7 +14364,6 @@ packages:
       estraverse: 5.2.0
       esutils: 2.0.3
       optionator: 0.8.3
-    dev: true
     engines:
       node: '>=6.0'
     hasBin: true
@@ -16075,7 +16493,7 @@ packages:
       is-stream: 1.1.0
       npm-run-path: 2.0.2
       p-finally: 1.0.0
-      signal-exit: 3.0.3
+      signal-exit: 3.0.4
       strip-eof: 1.0.0
     engines:
       node: '>=6'
@@ -16103,11 +16521,11 @@ packages:
       cross-spawn: 7.0.3
       get-stream: 5.2.0
       human-signals: 1.1.1
-      is-stream: 2.0.0
+      is-stream: 2.0.1
       merge-stream: 2.0.0
       npm-run-path: 4.0.1
       onetime: 5.1.2
-      signal-exit: 3.0.3
+      signal-exit: 3.0.4
       strip-final-newline: 2.0.0
     engines:
       node: '>=10'
@@ -16822,8 +17240,7 @@ packages:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
-      mime-types: 2.1.31
-    dev: true
+      mime-types: 2.1.32
     engines:
       node: '>= 6'
     resolution:
@@ -17657,8 +18074,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.1
-    dev: true
+      debug: 4.3.2
     engines:
       node: '>= 6'
     resolution:
@@ -17736,8 +18152,7 @@ packages:
   /https-proxy-agent/5.0.0:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.1
-    dev: true
+      debug: 4.3.2
     engines:
       node: '>= 6'
     resolution:
@@ -18455,10 +18870,10 @@ packages:
     resolution:
       integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
   /is-potential-custom-element-name/1.0.0:
+    dev: true
     resolution:
       integrity: sha1-DFLlS8yjkbssSUsh6GJtczbG45c=
   /is-potential-custom-element-name/1.0.1:
-    dev: true
     resolution:
       integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
   /is-promise/2.2.2:
@@ -18514,10 +18929,16 @@ packages:
     resolution:
       integrity: sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
   /is-stream/2.0.0:
+    dev: true
     engines:
       node: '>=8'
     resolution:
       integrity: sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
+  /is-stream/2.0.1:
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
   /is-string/1.0.6:
     engines:
       node: '>= 0.4'
@@ -18630,7 +19051,7 @@ packages:
       integrity: sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==
   /istanbul-lib-instrument/4.0.3:
     dependencies:
-      '@babel/core': 7.14.3
+      '@babel/core': 7.15.5
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.0.0
       semver: 6.3.0
@@ -18671,7 +19092,7 @@ packages:
       integrity: sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==
   /istanbul-lib-source-maps/4.0.0:
     dependencies:
-      debug: 4.3.1
+      debug: 4.3.2
       istanbul-lib-coverage: 3.0.0
       source-map: 0.6.1
     engines:
@@ -18805,7 +19226,7 @@ packages:
       '@jest/core': 26.6.3
       '@jest/test-result': 26.6.2
       '@jest/types': 26.6.2
-      chalk: 4.1.0
+      chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.4
       import-local: 3.0.2
@@ -18813,7 +19234,7 @@ packages:
       jest-config: 26.6.3
       jest-util: 26.6.2
       jest-validate: 26.6.2
-      prompts: 2.4.0
+      prompts: 2.4.1
       yargs: 15.4.1
     engines:
       node: '>= 10.14.2'
@@ -18941,13 +19362,13 @@ packages:
       integrity: sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==
   /jest-config/26.6.3:
     dependencies:
-      '@babel/core': 7.12.10
+      '@babel/core': 7.15.5
       '@jest/test-sequencer': 26.6.3
       '@jest/types': 26.6.2
-      babel-jest: 26.6.3_@babel+core@7.12.10
-      chalk: 4.1.0
+      babel-jest: 26.6.3_@babel+core@7.15.5
+      chalk: 4.1.2
       deepmerge: 4.2.2
-      glob: 7.1.6
+      glob: 7.1.7
       graceful-fs: 4.2.4
       jest-environment-jsdom: 26.6.2
       jest-environment-node: 26.6.2
@@ -18957,7 +19378,7 @@ packages:
       jest-resolve: 26.6.2
       jest-util: 26.6.2
       jest-validate: 26.6.2
-      micromatch: 4.0.2
+      micromatch: 4.0.4
       pretty-format: 26.6.2
     engines:
       node: '>= 10.14.2'
@@ -19179,7 +19600,7 @@ packages:
   /jest-each/26.6.2:
     dependencies:
       '@jest/types': 26.6.2
-      chalk: 4.1.1
+      chalk: 4.1.2
       jest-get-type: 26.3.0
       jest-util: 26.6.2
       pretty-format: 26.6.2
@@ -19239,10 +19660,10 @@ packages:
       '@jest/environment': 26.6.2
       '@jest/fake-timers': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 14.14.21
+      '@types/node': 16.0.0
       jest-mock: 26.6.2
       jest-util: 26.6.2
-      jsdom: 16.4.0
+      jsdom: 16.7.0
     engines:
       node: '>= 10.14.2'
     resolution:
@@ -19294,7 +19715,7 @@ packages:
       '@jest/environment': 26.6.2
       '@jest/fake-timers': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 15.3.0
+      '@types/node': 16.0.0
       jest-mock: 26.6.2
       jest-util: 26.6.2
     engines:
@@ -19366,7 +19787,7 @@ packages:
     dependencies:
       '@jest/types': 26.6.2
       '@types/graceful-fs': 4.1.5
-      '@types/node': 15.3.0
+      '@types/node': 15.14.9
       anymatch: 3.1.2
       fb-watchman: 2.0.1
       graceful-fs: 4.2.4
@@ -19429,13 +19850,13 @@ packages:
       integrity: sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==
   /jest-jasmine2/26.6.3:
     dependencies:
-      '@babel/traverse': 7.12.12
+      '@babel/traverse': 7.15.4
       '@jest/environment': 26.6.2
       '@jest/source-map': 26.6.2
       '@jest/test-result': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 14.14.21
-      chalk: 4.1.0
+      '@types/node': 16.0.0
+      chalk: 4.1.2
       co: 4.6.0
       expect: 26.6.2
       is-generator-fn: 2.1.0
@@ -19597,7 +20018,7 @@ packages:
       integrity: sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==
   /jest-matcher-utils/26.6.2:
     dependencies:
-      chalk: 4.1.1
+      chalk: 4.1.2
       jest-diff: 26.6.2
       jest-get-type: 26.3.0
       pretty-format: 26.6.2
@@ -19648,15 +20069,15 @@ packages:
       integrity: sha512-ezddz3YCT/LT0SKAmylVyWWIGYoKHOFOFXx3/nA4m794lfVUskMcwhip6vTgdVrOtYdjeQeis2ypzes9mZb4EA==
   /jest-message-util/26.6.2:
     dependencies:
-      '@babel/code-frame': 7.12.13
+      '@babel/code-frame': 7.14.5
       '@jest/types': 26.6.2
-      '@types/stack-utils': 2.0.0
-      chalk: 4.1.1
+      '@types/stack-utils': 2.0.1
+      chalk: 4.1.2
       graceful-fs: 4.2.4
       micromatch: 4.0.4
       pretty-format: 26.6.2
       slash: 3.0.0
-      stack-utils: 2.0.3
+      stack-utils: 2.0.4
     engines:
       node: '>= 10.14.2'
     resolution:
@@ -19696,7 +20117,7 @@ packages:
   /jest-mock/26.6.2:
     dependencies:
       '@jest/types': 26.6.2
-      '@types/node': 15.3.0
+      '@types/node': 15.14.9
     engines:
       node: '>= 10.14.2'
     resolution:
@@ -19837,7 +20258,7 @@ packages:
   /jest-resolve/26.6.2:
     dependencies:
       '@jest/types': 26.6.2
-      chalk: 4.1.1
+      chalk: 4.1.2
       graceful-fs: 4.2.4
       jest-pnp-resolver: 1.2.2_jest-resolve@26.6.2
       jest-util: 26.6.2
@@ -19896,8 +20317,8 @@ packages:
       '@jest/environment': 26.6.2
       '@jest/test-result': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 14.14.21
-      chalk: 4.1.0
+      '@types/node': 15.14.9
+      chalk: 4.1.2
       emittery: 0.7.2
       exit: 0.1.2
       graceful-fs: 4.2.4
@@ -19910,7 +20331,7 @@ packages:
       jest-runtime: 26.6.3
       jest-util: 26.6.2
       jest-worker: 26.6.2
-      source-map-support: 0.5.19
+      source-map-support: 0.5.20
       throat: 5.0.0
     engines:
       node: '>= 10.14.2'
@@ -20072,12 +20493,12 @@ packages:
       '@jest/test-result': 26.6.2
       '@jest/transform': 26.6.2
       '@jest/types': 26.6.2
-      '@types/yargs': 15.0.12
-      chalk: 4.1.0
+      '@types/yargs': 15.0.14
+      chalk: 4.1.2
       cjs-module-lexer: 0.6.0
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
-      glob: 7.1.6
+      glob: 7.1.7
       graceful-fs: 4.2.4
       jest-config: 26.6.3
       jest-haste-map: 26.6.2
@@ -20249,7 +20670,7 @@ packages:
       integrity: sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ==
   /jest-serializer/26.6.2:
     dependencies:
-      '@types/node': 15.3.0
+      '@types/node': 15.14.9
       graceful-fs: 4.2.4
     engines:
       node: '>= 10.14.2'
@@ -20286,11 +20707,11 @@ packages:
       integrity: sha512-uI/rszGSs73xCM0l+up7O7a40o90cnrk429LOiK3aeTvfC0HHmldbd81/B7Ix81KSFe1lwkbl7GnBGG4UfuDew==
   /jest-snapshot/26.6.2:
     dependencies:
-      '@babel/types': 7.14.2
+      '@babel/types': 7.15.6
       '@jest/types': 26.6.2
-      '@types/babel__traverse': 7.11.1
-      '@types/prettier': 2.2.3
-      chalk: 4.1.1
+      '@types/babel__traverse': 7.14.2
+      '@types/prettier': 2.3.2
+      chalk: 4.1.2
       expect: 26.6.2
       graceful-fs: 4.2.4
       jest-diff: 26.6.2
@@ -20380,8 +20801,8 @@ packages:
   /jest-util/26.6.2:
     dependencies:
       '@jest/types': 26.6.2
-      '@types/node': 12.20.13
-      chalk: 4.1.1
+      '@types/node': 15.14.9
+      chalk: 4.1.2
       graceful-fs: 4.2.4
       is-ci: 2.0.0
       micromatch: 4.0.4
@@ -20419,7 +20840,7 @@ packages:
     dependencies:
       '@jest/types': 26.6.2
       camelcase: 6.2.0
-      chalk: 4.1.1
+      chalk: 4.1.2
       jest-get-type: 26.3.0
       leven: 3.1.0
       pretty-format: 26.6.2
@@ -20538,9 +20959,9 @@ packages:
     dependencies:
       '@jest/test-result': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 15.3.0
+      '@types/node': 15.14.9
       ansi-escapes: 4.3.2
-      chalk: 4.1.1
+      chalk: 4.1.2
       jest-util: 26.6.2
       string-length: 4.0.2
     engines:
@@ -20581,7 +21002,7 @@ packages:
       integrity: sha512-/dsSmUkIy5EBGfv/IjjqmFxrNAUpBERfGs1oHROyD7yxjG/w+t0GOJDX8O1k32ySmd7+a5IhnJU2qQFcJ4n1vw==
   /jest-worker/26.6.2:
     dependencies:
-      '@types/node': 15.3.0
+      '@types/node': 15.14.9
       merge-stream: 2.0.0
       supports-color: 7.2.0
     engines:
@@ -20785,43 +21206,6 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-O901mfJSuTdwU2w3Sn+74T+RnDVP+FuV5fH8tcPWyqrseRAb0s5xOtPgCFiPOtLcyK7CLIJwPyD83ZqQWvA5ng==
-  /jsdom/16.4.0:
-    dependencies:
-      abab: 2.0.5
-      acorn: 7.4.1
-      acorn-globals: 6.0.0
-      cssom: 0.4.4
-      cssstyle: 2.3.0
-      data-urls: 2.0.0
-      decimal.js: 10.2.1
-      domexception: 2.0.1
-      escodegen: 1.14.3
-      html-encoding-sniffer: 2.0.1
-      is-potential-custom-element-name: 1.0.0
-      nwsapi: 2.2.0
-      parse5: 5.1.1
-      request: 2.88.2
-      request-promise-native: 1.0.9_request@2.88.2
-      saxes: 5.0.1
-      symbol-tree: 3.2.4
-      tough-cookie: 3.0.1
-      w3c-hr-time: 1.0.2
-      w3c-xmlserializer: 2.0.0
-      webidl-conversions: 6.1.0
-      whatwg-encoding: 1.0.5
-      whatwg-mimetype: 2.3.0
-      whatwg-url: 8.4.0
-      ws: 7.4.3
-      xml-name-validator: 3.0.0
-    engines:
-      node: '>=10'
-    peerDependencies:
-      canvas: ^2.5.0
-    peerDependenciesMeta:
-      canvas:
-        optional: true
-    resolution:
-      integrity: sha512-lYMm3wYdgPhrl7pDcRmvzPhhrGVBeVhPIqeHjzeiHN3DFmD1RBpbExbi8vU7BJdH8VAZYovR8DMt0PNNDM7k8w==
   /jsdom/16.4.0_canvas@2.6.1:
     dependencies:
       abab: 2.0.5
@@ -20900,6 +21284,44 @@ packages:
         optional: true
     resolution:
       integrity: sha512-Ty1vmF4NHJkolaEmdjtxTfSfkdb8Ywarwf63f+F8/mDD1uLSSWDxDuMiZxiPhwunLrn9LOSVItWj4bLYsLN3Dg==
+  /jsdom/16.7.0:
+    dependencies:
+      abab: 2.0.5
+      acorn: 8.5.0
+      acorn-globals: 6.0.0
+      cssom: 0.4.4
+      cssstyle: 2.3.0
+      data-urls: 2.0.0
+      decimal.js: 10.3.1
+      domexception: 2.0.1
+      escodegen: 2.0.0
+      form-data: 3.0.1
+      html-encoding-sniffer: 2.0.1
+      http-proxy-agent: 4.0.1
+      https-proxy-agent: 5.0.0
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.0
+      parse5: 6.0.1
+      saxes: 5.0.1
+      symbol-tree: 3.2.4
+      tough-cookie: 4.0.0
+      w3c-hr-time: 1.0.2
+      w3c-xmlserializer: 2.0.0
+      webidl-conversions: 6.1.0
+      whatwg-encoding: 1.0.5
+      whatwg-mimetype: 2.3.0
+      whatwg-url: 8.7.0
+      ws: 7.5.5
+      xml-name-validator: 3.0.0
+    engines:
+      node: '>=10'
+    peerDependencies:
+      canvas: ^2.5.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+    resolution:
+      integrity: sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==
   /jsesc/0.5.0:
     dev: false
     hasBin: true
@@ -21639,7 +22061,7 @@ packages:
       integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
   /makeerror/1.0.11:
     dependencies:
-      tmpl: 1.0.4
+      tmpl: 1.0.5
     resolution:
       integrity: sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=
   /mamacro/0.0.3:
@@ -21870,6 +22292,7 @@ packages:
     dependencies:
       braces: 3.0.2
       picomatch: 2.2.2
+    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -21905,6 +22328,11 @@ packages:
       node: '>= 0.6'
     resolution:
       integrity: sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==
+  /mime-db/1.49.0:
+    engines:
+      node: '>= 0.6'
+    resolution:
+      integrity: sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==
   /mime-types/2.1.28:
     dependencies:
       mime-db: 1.45.0
@@ -21926,6 +22354,13 @@ packages:
       node: '>= 0.6'
     resolution:
       integrity: sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==
+  /mime-types/2.1.32:
+    dependencies:
+      mime-db: 1.49.0
+    engines:
+      node: '>= 0.6'
+    resolution:
+      integrity: sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==
   /mime/1.6.0:
     dev: false
     engines:
@@ -22403,6 +22838,9 @@ packages:
   /node-releases/1.1.73:
     resolution:
       integrity: sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==
+  /node-releases/1.1.75:
+    resolution:
+      integrity: sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==
   /nopt/4.0.3:
     dependencies:
       abbrev: 1.1.1
@@ -22791,7 +23229,7 @@ packages:
       integrity: sha512-wqd6FdI2a5/FdoiCNNkEvLeA//lHHfG24Ln2Xm2qqdIk4aOlsR18jwpyOihqQ8849W3qu2DX8fOYxpvTMj+93A==
   /optionator/0.8.3:
     dependencies:
-      deep-is: 0.1.3
+      deep-is: 0.1.4
       fast-levenshtein: 2.0.6
       levn: 0.3.0
       prelude-ls: 1.1.2
@@ -23096,10 +23534,10 @@ packages:
     resolution:
       integrity: sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==
   /parse5/5.1.1:
+    dev: true
     resolution:
       integrity: sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==
   /parse5/6.0.1:
-    dev: true
     resolution:
       integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
   /parseurl/1.3.3:
@@ -23236,6 +23674,7 @@ packages:
     resolution:
       integrity: sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
   /picomatch/2.2.2:
+    dev: true
     engines:
       node: '>=8.6'
     resolution:
@@ -24369,7 +24808,6 @@ packages:
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
-    dev: true
     engines:
       node: '>= 6'
     resolution:
@@ -25150,7 +25588,7 @@ packages:
       integrity: sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=
   /read-pkg/5.2.0:
     dependencies:
-      '@types/normalize-package-data': 2.4.0
+      '@types/normalize-package-data': 2.4.1
       normalize-package-data: 2.5.0
       parse-json: 5.2.0
       type-fest: 0.6.0
@@ -25783,6 +26221,7 @@ packages:
       micromatch: 3.1.10
       minimist: 1.2.5
       walker: 1.0.7
+    deprecated: some dependency vulnerabilities fixed, support for node < 10 dropped, and newer ECMAScript syntax/features added
     engines:
       node: 6.* || 8.* || >= 10.*
     hasBin: true
@@ -26120,6 +26559,9 @@ packages:
   /signal-exit/3.0.3:
     resolution:
       integrity: sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
+  /signal-exit/3.0.4:
+    resolution:
+      integrity: sha512-rqYhcAnZ6d/vTPGghdrw7iumdcbXpsk1b8IG/rz+VWV51DM0p7XCtMoJ3qhPLIbp3tvyt3pKRbaaEMZYpHto8Q==
   /simple-concat/1.0.1:
     dev: false
     resolution:
@@ -26305,6 +26747,12 @@ packages:
       source-map: 0.6.1
     resolution:
       integrity: sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+  /source-map-support/0.5.20:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+    resolution:
+      integrity: sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==
   /source-map-url/0.4.1:
     resolution:
       integrity: sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==
@@ -26458,6 +26906,14 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==
+  /stack-utils/2.0.4:
+    dependencies:
+      escape-string-regexp: 2.0.0
+      source-map-support: 0.5.20
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-ERg+H//lSSYlZhBIUu+wJnqg30AbyBbpZlIhcshpn7BNzpoRODZgfyr9J+8ERf3ooC6af3u7Lcl01nleau7MrA==
   /stackframe/1.2.0:
     dev: false
     resolution:
@@ -27533,9 +27989,9 @@ packages:
       node: '>=8.17.0'
     resolution:
       integrity: sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
-  /tmpl/1.0.4:
+  /tmpl/1.0.5:
     resolution:
-      integrity: sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=
+      integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==
   /to-arraybuffer/1.0.1:
     dev: false
     resolution:
@@ -27600,6 +28056,7 @@ packages:
       ip-regex: 2.1.0
       psl: 1.8.0
       punycode: 2.1.1
+    dev: true
     engines:
       node: '>=6'
     resolution:
@@ -27609,7 +28066,6 @@ packages:
       psl: 1.8.0
       punycode: 2.1.1
       universalify: 0.1.2
-    dev: true
     engines:
       node: '>=6'
     resolution:
@@ -27622,6 +28078,7 @@ packages:
   /tr46/2.0.2:
     dependencies:
       punycode: 2.1.1
+    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -27757,7 +28214,7 @@ packages:
   /ts-jest/26.5.6_jest@26.6.3+typescript@4.3.5:
     dependencies:
       bs-logger: 0.2.6
-      buffer-from: 1.1.1
+      buffer-from: 1.1.2
       fast-json-stable-stringify: 2.1.0
       jest: 26.6.3
       jest-util: 26.6.2
@@ -27767,7 +28224,7 @@ packages:
       mkdirp: 1.0.4
       semver: 7.3.5
       typescript: 4.3.5
-      yargs-parser: 20.2.7
+      yargs-parser: 20.2.9
     dev: true
     engines:
       node: '>= 10'
@@ -28414,7 +28871,7 @@ packages:
   /v8-to-istanbul/7.1.2:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.3
-      convert-source-map: 1.7.0
+      convert-source-map: 1.8.0
       source-map: 0.7.3
     engines:
       node: '>=10.10.0'
@@ -28880,6 +29337,7 @@ packages:
       lodash.sortby: 4.7.0
       tr46: 2.0.2
       webidl-conversions: 6.1.0
+    dev: true
     engines:
       node: '>=10'
     resolution:
@@ -28889,10 +29347,20 @@ packages:
       lodash: 4.17.21
       tr46: 2.1.0
       webidl-conversions: 6.1.0
+    dev: true
     engines:
       node: '>=10'
     resolution:
       integrity: sha512-fy+R77xWv0AiqfLl4nuGUlQ3/6b5uNfQ4WAbGQVMYshCTCCPK9psC1nWh3XHuxGVCtlcDDQPQW1csmmIQo+fwg==
+  /whatwg-url/8.7.0:
+    dependencies:
+      lodash: 4.17.21
+      tr46: 2.1.0
+      webidl-conversions: 6.1.0
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==
   /which-boxed-primitive/1.0.2:
     dependencies:
       is-bigint: 1.0.4
@@ -29317,6 +29785,7 @@ packages:
     resolution:
       integrity: sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
   /ws/7.4.3:
+    dev: true
     engines:
       node: '>=8.3.0'
     peerDependencies:
@@ -29343,6 +29812,19 @@ packages:
         optional: true
     resolution:
       integrity: sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
+  /ws/7.5.5:
+    engines:
+      node: '>=8.3.0'
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    resolution:
+      integrity: sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==
   /xml-name-validator/3.0.0:
     resolution:
       integrity: sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
@@ -29418,6 +29900,11 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==
+  /yargs-parser/20.2.9:
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
   /yargs/12.0.5:
     dependencies:
       cliui: 4.1.0
@@ -29475,7 +29962,7 @@ packages:
       require-directory: 2.1.1
       string-width: 4.2.2
       y18n: 5.0.8
-      yargs-parser: 20.2.7
+      yargs-parser: 20.2.9
     engines:
       node: '>=10'
     resolution:


### PR DESCRIPTION
This is primarily to upgrade `jsdom` to a version that includes https://github.com/jsdom/jsdom/pull/3038 for `InputEvent#inputType`. This is needed for an upcoming autocomplete feature.