### PR TITLE
feat(utils): improved `throwIllegalValue` error messages

### DIFF
--- a/apps/election-manager/src/lib/votecounting.ts
+++ b/apps/election-manager/src/lib/votecounting.ts
@@ -145,7 +145,7 @@ export function* parseCVRs(
                     break
                   }
                   default:
-                    throwIllegalValue(contest)
+                    throwIllegalValue(contest, 'type')
                 }
               }
             }

--- a/apps/election-manager/src/utils/externalTallies.ts
+++ b/apps/election-manager/src/utils/externalTallies.ts
@@ -296,7 +296,7 @@ export const getEmptyContestTallies = (
         break
       }
       default:
-        throwIllegalValue(contest)
+        throwIllegalValue(contest, 'type')
     }
     contestTallies[contest.id] = {
       contest,

--- a/apps/election-manager/src/utils/semsTallies.ts
+++ b/apps/election-manager/src/utils/semsTallies.ts
@@ -276,7 +276,7 @@ export function parseSEMSFileAndValidateForElection(
           break
         }
         default:
-          throwIllegalValue(contest)
+          throwIllegalValue(contest, 'type')
       }
     }
   }

--- a/apps/module-scan/src/buildCastVoteRecord.test.ts
+++ b/apps/module-scan/src/buildCastVoteRecord.test.ts
@@ -114,7 +114,7 @@ test('getOptionIdsForContestVote', () => {
       } as unknown) as AnyContest,
       {}
     )
-  ).toThrowError('contest type not yet supported: not-supported-type')
+  ).toThrowError('Illegal Value: not-supported-type')
 })
 
 test('generates a CVR from a completed BMD ballot', () => {

--- a/apps/module-scan/src/buildCastVoteRecord.ts
+++ b/apps/module-scan/src/buildCastVoteRecord.ts
@@ -117,8 +117,7 @@ export function getOptionIdsForContestVote(
       >((id) => [contest.pickOneContestId, id]),
     ]
   }
-  // @ts-expect-error -- `contest` has type `never` since all known branches are covered
-  throw new TypeError(`contest type not yet supported: ${contest.type}`)
+  throwIllegalValue(contest, 'type')
 }
 
 export function buildCastVoteRecordVotesEntries(

--- a/apps/module-scan/src/util/allContestOptions.ts
+++ b/apps/module-scan/src/util/allContestOptions.ts
@@ -90,6 +90,6 @@ export default function* allContestOptions(
       optionIndex: 1,
     }
   } else {
-    throwIllegalValue(contest)
+    throwIllegalValue(contest, 'type')
   }
 }

--- a/apps/module-scan/src/util/ballotAdjudicationReasons.ts
+++ b/apps/module-scan/src/util/ballotAdjudicationReasons.ts
@@ -105,7 +105,7 @@ export default function* ballotAdjudicationReasons(
             break
 
           default:
-            throwIllegalValue(contest)
+            throwIllegalValue(contest, 'type')
         }
 
         if (selectedOptions.length < expectedSelectionCount) {

--- a/libs/ui/src/ContestTally.tsx
+++ b/libs/ui/src/ContestTally.tsx
@@ -130,7 +130,7 @@ export const ContestTally = ({
             break
           }
           default:
-            throwIllegalValue(contest)
+            throwIllegalValue(contest, 'type')
         }
 
         return (

--- a/libs/utils/src/cardTallies.ts
+++ b/libs/utils/src/cardTallies.ts
@@ -109,7 +109,7 @@ export const combineTallies = (
         )
         break
       default:
-        throwIllegalValue(contest)
+        throwIllegalValue(contest, 'type')
     }
   }
 
@@ -158,7 +158,7 @@ export const getZeroTally = (election: Election): SerializedTally =>
     }
 
     /* istanbul ignore next - compile time check for completeness */
-    throwIllegalValue(contest)
+    throwIllegalValue(contest, 'type')
   })
 
 export const computeTallyForEitherNeitherContests = ({
@@ -357,6 +357,6 @@ export const serializeTally = (
       }
     }
     /* istanbul ignore next - compile time check for completeness */
-    throwIllegalValue(contest)
+    throwIllegalValue(contest, 'type')
   })
 }

--- a/libs/utils/src/throwIllegalValue.test.ts
+++ b/libs/utils/src/throwIllegalValue.test.ts
@@ -38,3 +38,20 @@ test('invalid example', () => {
       expect(() => throwIllegalValue(abc)).toThrowError('Illegal Value: 2')
   }
 })
+
+test('display name', () => {
+  type Thing = { type: 'car' } | { type: 'dog' } | { type: 'house' }
+
+  const thing = { type: 'hotdog' } as unknown as Thing
+  switch (thing.type) {
+    case 'car':
+    case 'dog':
+    case 'house':
+      break
+
+    default:
+      expect(() => throwIllegalValue(thing, 'type')).toThrowError(
+        'Illegal Value: hotdog'
+      )
+  }
+})

--- a/libs/utils/src/throwIllegalValue.ts
+++ b/libs/utils/src/throwIllegalValue.ts
@@ -1,3 +1,31 @@
-export function throwIllegalValue(s: never): never {
-  throw new Error(`Illegal Value: ${s}`)
+/**
+ * Use as a compile-time check that the type of `value` has been narrowed to
+ * `never`. This is primarily useful when handling cases of a discriminated
+ * union or enum.
+ *
+ * @example
+ *
+ *   enum PageSize { Letter, Legal }
+ *
+ *   function print(pageSize: PageSize): void {
+ *     switch (pageSize) {
+ *       case PageSize.Letter:
+ *         // …
+ *         break
+ *
+ *       case PageSize.Legal:
+ *         // …
+ *         break
+ *
+ *       default:
+ *         throwIllegalValue(pageSize)
+ *     }
+ *   }
+ */
+export function throwIllegalValue(value: never, displayKey?: string): never {
+  throw new Error(
+    `Illegal Value: ${
+      displayKey ? (value as { [key: string]: unknown })[displayKey] : value
+    }`
+  )
 }


### PR DESCRIPTION
A common use case is `throwIllegalValue(contest)`, but then the error message is `Illegal Value: [object Object]`. This way we can now do `throwIllegalValue(contest, 'type')` and get e.g. `Illegal Value: rcv`.