### PR TITLE
feat(scan): record and use write-in adjudications

### DIFF
--- a/apps/bsd/src/AppRoot.tsx
+++ b/apps/bsd/src/AppRoot.tsx
@@ -178,15 +178,14 @@ const App = (): JSX.Element => {
     }
   }, [])
 
-  const continueScanning = useCallback(async (override = false) => {
+  const continueScanning = useCallback(async (request: ScanContinueRequest) => {
     setIsScanning(true)
     try {
-      const body: ScanContinueRequest = { override }
       safeParseJSON(
         await (
           await fetch('/scan/scanContinue', {
             method: 'post',
-            body: JSON.stringify(body),
+            body: JSON.stringify(request),
             headers: {
               'Content-Type': 'application/json',
             },

--- a/apps/bsd/src/screens/BallotEjectScreen.test.tsx
+++ b/apps/bsd/src/screens/BallotEjectScreen.test.tsx
@@ -41,7 +41,7 @@ test('says the sheet is unreadable if it is', async () => {
   expect(container).toMatchSnapshot()
 
   fireEvent.click(getByText('Confirm Ballot Removed and Continue Scanning'))
-  expect(continueScanning).toHaveBeenCalledWith()
+  expect(continueScanning).toHaveBeenCalledWith({ forceAccept: false })
 })
 
 test('says the ballot sheet is overvoted if it is', async () => {
@@ -128,13 +128,17 @@ test('says the ballot sheet is overvoted if it is', async () => {
 
   fireEvent.click(getByText('Original Ballot Removed'))
   fireEvent.click(getByText('Confirm Ballot Removed and Continue Scanning'))
-  expect(continueScanning).toHaveBeenCalledWith()
+  expect(continueScanning).toHaveBeenCalledWith({ forceAccept: false })
 
   continueScanning.mockClear()
 
   fireEvent.click(getByText('Tabulate Duplicate Ballot'))
   fireEvent.click(getByText('Tabulate Ballot and Continue Scanning'))
-  expect(continueScanning).toHaveBeenCalledWith(true)
+  expect(continueScanning).toHaveBeenCalledWith({
+    forceAccept: true,
+    frontMarkAdjudications: [],
+    backMarkAdjudications: [],
+  })
 })
 
 test('says the ballot sheet is undervoted if it is', async () => {
@@ -221,13 +225,17 @@ test('says the ballot sheet is undervoted if it is', async () => {
 
   fireEvent.click(getByText('Original Ballot Removed'))
   fireEvent.click(getByText('Confirm Ballot Removed and Continue Scanning'))
-  expect(continueScanning).toHaveBeenCalledWith()
+  expect(continueScanning).toHaveBeenCalledWith({ forceAccept: false })
 
   continueScanning.mockClear()
 
   fireEvent.click(getByText('Tabulate Duplicate Ballot'))
   fireEvent.click(getByText('Tabulate Ballot and Continue Scanning'))
-  expect(continueScanning).toHaveBeenCalledWith(true)
+  expect(continueScanning).toHaveBeenCalledWith({
+    forceAccept: true,
+    frontMarkAdjudications: [],
+    backMarkAdjudications: [],
+  })
 })
 
 test('says the ballot sheet is blank if it is', async () => {
@@ -306,13 +314,17 @@ test('says the ballot sheet is blank if it is', async () => {
 
   fireEvent.click(getByText('Original Ballot Removed'))
   fireEvent.click(getByText('Confirm Ballot Removed and Continue Scanning'))
-  expect(continueScanning).toHaveBeenCalledWith()
+  expect(continueScanning).toHaveBeenCalledWith({ forceAccept: false })
 
   continueScanning.mockClear()
 
   fireEvent.click(getByText('Tabulate Duplicate Ballot'))
   fireEvent.click(getByText('Tabulate Ballot and Continue Scanning'))
-  expect(continueScanning).toHaveBeenCalledWith(true)
+  expect(continueScanning).toHaveBeenCalledWith({
+    forceAccept: true,
+    frontMarkAdjudications: [],
+    backMarkAdjudications: [],
+  })
 })
 
 test('calls out live ballot sheets in test mode', async () => {
@@ -370,7 +382,7 @@ test('calls out live ballot sheets in test mode', async () => {
   expect(container).toMatchSnapshot()
 
   fireEvent.click(getByText('Confirm Ballot Removed and Continue Scanning'))
-  expect(continueScanning).toHaveBeenCalledWith()
+  expect(continueScanning).toHaveBeenCalledWith({ forceAccept: false })
 })
 
 test('calls out test ballot sheets in live mode', async () => {
@@ -428,7 +440,7 @@ test('calls out test ballot sheets in live mode', async () => {
   expect(container).toMatchSnapshot()
 
   fireEvent.click(getByText('Confirm Ballot Removed and Continue Scanning'))
-  expect(continueScanning).toHaveBeenCalledWith()
+  expect(continueScanning).toHaveBeenCalledWith({ forceAccept: false })
 })
 
 test('shows invalid election screen when appropriate', async () => {
@@ -470,7 +482,7 @@ test('shows invalid election screen when appropriate', async () => {
   expect(queryAllByText('Tabulate Duplicate Ballot').length).toBe(0)
 
   fireEvent.click(getByText('Confirm Ballot Removed and Continue Scanning'))
-  expect(continueScanning).toHaveBeenCalledWith()
+  expect(continueScanning).toHaveBeenCalledWith({ forceAccept: false })
 })
 
 test('shows invalid election screen when appropriate', async () => {
@@ -529,5 +541,5 @@ test('shows invalid election screen when appropriate', async () => {
   expect(queryAllByText('Tabulate Duplicate Ballot').length).toBe(0)
 
   fireEvent.click(getByText('Confirm Ballot Removed and Continue Scanning'))
-  expect(continueScanning).toHaveBeenCalledWith()
+  expect(continueScanning).toHaveBeenCalledWith({ forceAccept: false })
 })

--- a/apps/bsd/src/screens/WriteInAdjudicationScreen.test.tsx
+++ b/apps/bsd/src/screens/WriteInAdjudicationScreen.test.tsx
@@ -138,7 +138,7 @@ test('supports typing in a candidate name', async () => {
         [
           {
             type: AdjudicationReason.WriteIn,
-            isWriteIn: true,
+            isMarked: true,
             contestId: contest.id,
             optionId,
             name: 'Lizard People',
@@ -176,7 +176,7 @@ test('supports canceling a write-in', async () => {
         [
           {
             type: AdjudicationReason.UnmarkedWriteIn,
-            isWriteIn: false,
+            isMarked: false,
             contestId: contest.id,
             optionId,
           },

--- a/apps/bsd/src/screens/WriteInAdjudicationScreen.tsx
+++ b/apps/bsd/src/screens/WriteInAdjudicationScreen.tsx
@@ -238,7 +238,7 @@ const ContestOptionAdjudication = ({
     ({ contestId, optionId }) =>
       contestId === writeIn.contestId && optionId === writeIn.optionId
   )
-  const isWriteIn = adjudication?.isWriteIn ?? true
+  const isWriteIn = adjudication?.isMarked ?? true
 
   const [
     shouldFocusNameOnNextRender,
@@ -250,7 +250,7 @@ const ContestOptionAdjudication = ({
     (name: string): void => {
       onChange?.({
         type: writeIn.type,
-        isWriteIn: true,
+        isMarked: true,
         contestId: contest.id,
         optionId: writeIn.optionId,
         name,
@@ -273,7 +273,7 @@ const ContestOptionAdjudication = ({
       if (!input.checked) {
         onChange?.({
           type: writeIn.type,
-          isWriteIn: true,
+          isMarked: true,
           contestId: contest.id,
           optionId: writeIn.optionId,
           name: '',
@@ -284,7 +284,7 @@ const ContestOptionAdjudication = ({
         inputRef.current.value = ''
         onChange?.({
           type: writeIn.type,
-          isWriteIn: false,
+          isMarked: false,
           contestId: contest.id,
           optionId: writeIn.optionId,
         })
@@ -328,7 +328,7 @@ const ContestOptionAdjudication = ({
               data-testid={`write-in-input-${writeIn.optionId}`}
               disabled={!isWriteIn}
               defaultValue={
-                adjudication?.isWriteIn ? adjudication.name : undefined
+                adjudication?.isMarked ? adjudication.name : undefined
               }
               // eslint-disable-next-line jsx-a11y/no-autofocus
               autoFocus={autoFocus}
@@ -467,7 +467,7 @@ const WriteInAdjudicationByContest = ({
       (adjudication) =>
         adjudication.contestId === writeIn.contestId &&
         adjudication.optionId === writeIn.optionId &&
-        (!adjudication.isWriteIn || adjudication.name)
+        (!adjudication.isMarked || adjudication.name)
     )
   )
 
@@ -613,7 +613,7 @@ export default function WriteInAdjudicationScreen({
     setStoredWriteIns((prev) =>
       adjudications.reduce(
         (newStoredWriteIns, adjudication) =>
-          adjudication.isWriteIn
+          adjudication.isMarked
             ? {
                 ...newStoredWriteIns,
                 [adjudication.contestId]: uniq([

--- a/apps/module-scan/schema.sql
+++ b/apps/module-scan/schema.sql
@@ -27,7 +27,7 @@ create table sheets (
 
   -- Changes made in adjudication, should be applied on top of the original CVR.
   -- Updated as the sheet is adjudicated.
-  -- @type {MarksByContestId}
+  -- @type {readonly MarkAdjudication[]}
   front_adjudication_json text,
   back_adjudication_json text,
 

--- a/apps/module-scan/src/importer.test.ts
+++ b/apps/module-scan/src/importer.test.ts
@@ -350,7 +350,7 @@ test('scanning pauses on adjudication then continues', async () => {
   await importer.configure(asElectionDefinition(election))
 
   jest.spyOn(workspace.store, 'deleteSheet')
-  jest.spyOn(workspace.store, 'saveBallotAdjudication')
+  jest.spyOn(workspace.store, 'adjudicateSheet')
 
   jest
     .spyOn(workspace.store, 'addSheet')
@@ -416,7 +416,7 @@ test('scanning pauses on adjudication then continues', async () => {
       return { adjudicated: 0, remaining: 0 }
     })
 
-  await importer.continueImport()
+  await importer.continueImport({ forceAccept: false })
   await importer.waitForEndOfBatchOrScanningPause()
 
   expect(workspace.store.addSheet).toHaveBeenCalledTimes(3)
@@ -432,12 +432,16 @@ test('scanning pauses on adjudication then continues', async () => {
       return { adjudicated: 0, remaining: 0 }
     })
 
-  await importer.continueImport(true) // override
+  await importer.continueImport({
+    forceAccept: true,
+    frontMarkAdjudications: [],
+    backMarkAdjudications: [],
+  })
   await importer.waitForEndOfBatchOrScanningPause()
 
   expect(workspace.store.addSheet).toHaveBeenCalledTimes(3) // no more of these
   expect(workspace.store.deleteSheet).toHaveBeenCalledTimes(1) // no more deletes
-  expect(workspace.store.saveBallotAdjudication).toHaveBeenCalledTimes(2)
+  expect(workspace.store.adjudicateSheet).toHaveBeenCalledTimes(2)
 })
 
 test('importing a sheet normalizes and orders HMPB pages', async () => {

--- a/apps/module-scan/src/server.test.ts
+++ b/apps/module-scan/src/server.test.ts
@@ -4,6 +4,7 @@ import { BallotType, ok } from '@votingworks/types'
 import {
   GetNextReviewSheetResponse,
   GetScanStatusResponse,
+  ScanContinueRequest,
   ScannerStatus,
 } from '@votingworks/types/api/module-scan'
 import { typedAs } from '@votingworks/utils'
@@ -291,6 +292,9 @@ test('POST /scan/scanContinue', async () => {
   importer.continueImport.mockResolvedValue(undefined)
   await request(app)
     .post('/scan/scanContinue')
+    .send(
+      typedAs<ScanContinueRequest>({ forceAccept: false })
+    )
     .set('Accept', 'application/json')
     .expect(200, { status: 'ok' })
   expect(importer.continueImport).toBeCalled()

--- a/apps/module-scan/src/types.ts
+++ b/apps/module-scan/src/types.ts
@@ -2,7 +2,7 @@ import {
   BallotLocales,
   BallotMark,
   BallotTargetMark,
-  MarksByContestId,
+  MarkAdjudications,
   MarkStatus,
   MarkThresholds,
   PageInterpretation,
@@ -22,7 +22,7 @@ export interface PageInterpretationWithAdjudication<
 > {
   interpretation: T
   contestIds?: readonly string[]
-  adjudication?: MarksByContestId
+  markAdjudications?: MarkAdjudications
 }
 
 export interface BallotPageQrcode {

--- a/apps/module-scan/src/util/allContestOptions.ts
+++ b/apps/module-scan/src/util/allContestOptions.ts
@@ -21,7 +21,7 @@ export default function* allContestOptions(
     }
 
     if (contest.allowWriteIns) {
-      if (writeInOptionIds !== undefined) {
+      if (writeInOptionIds?.length) {
         for (const [writeInIndex, writeInId] of writeInOptionIds.entries()) {
           yield {
             type: 'candidate',

--- a/apps/precinct-scanner/src/api/scan.ts
+++ b/apps/precinct-scanner/src/api/scan.ts
@@ -130,7 +130,11 @@ export async function scanDetectedSheet(): Promise<ScanningResult> {
 }
 
 export async function acceptBallotAfterReview(): Promise<boolean> {
-  const body: ScanContinueRequest = { override: true }
+  const body: ScanContinueRequest = {
+    forceAccept: true,
+    frontMarkAdjudications: [],
+    backMarkAdjudications: [],
+  }
   const result = await (
     await fetch('/scan/scanContinue', {
       method: 'post',
@@ -150,8 +154,17 @@ export async function acceptBallotAfterReview(): Promise<boolean> {
 export async function endBatch(): Promise<boolean> {
   // calling scanContinue will "naturally" end the batch because module-scan
   // will see there's no more paper
+  const body: ScanContinueRequest = {
+    forceAccept: false,
+  }
   const result = await (
-    await fetch('/scan/scanContinue', { method: 'post' })
+    await fetch('/scan/scanContinue', {
+      method: 'post',
+      body: JSON.stringify(body),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
   ).json()
   if (result.status !== 'ok') {
     debug('failed to end batch: %o', result)

--- a/libs/types/src/api/module-scan.ts
+++ b/libs/types/src/api/module-scan.ts
@@ -8,8 +8,8 @@ import {
   OkResponseSchema,
 } from '.'
 import {
-  MarksByContestId,
-  MarksByContestIdSchema,
+  MarkAdjudications,
+  MarkAdjudicationsSchema,
   SerializableBallotPageLayout,
   SerializableBallotPageLayoutSchema,
 } from '../hmpb'
@@ -399,18 +399,27 @@ export const ScanBatchResponseSchema: z.ZodSchema<ScanBatchResponse> = z.union([
  * @url /scan/scanContinue
  * @method POST
  */
-export interface ScanContinueRequest {
-  override?: boolean
-}
+export type ScanContinueRequest =
+  | { forceAccept: false }
+  | {
+      forceAccept: true
+      frontMarkAdjudications: MarkAdjudications
+      backMarkAdjudications: MarkAdjudications
+    }
 
 /**
  * @url /scan/scanContinue
  * @method POST
  */
-export const ScanContinueRequestSchema: z.ZodSchema<ScanContinueRequest> = z.object(
-  {
-    override: z.optional(z.boolean()),
-  }
+export const ScanContinueRequestSchema: z.ZodSchema<ScanContinueRequest> = z.union(
+  [
+    z.object({ forceAccept: z.literal(false) }),
+    z.object({
+      forceAccept: z.literal(true),
+      frontMarkAdjudications: MarkAdjudicationsSchema,
+      backMarkAdjudications: MarkAdjudicationsSchema,
+    }),
+  ]
 )
 
 /**
@@ -610,50 +619,4 @@ export const GetNextReviewSheetResponseSchema: z.ZodSchema<GetNextReviewSheetRes
       back: z.object({ contestIds: z.array(Id) }),
     }),
   }
-)
-
-/**
- * @url /scan/hmpb/ballot/:sheetId/:side
- * @method PATCH
- */
-export interface PatchBallotPageAdjudicationParams {
-  sheetId: string
-  side: Side
-}
-
-/**
- * @url /scan/hmpb/ballot/:sheetId/:side
- * @method PATCH
- */
-export const PatchBallotPageAdjudicationParamsSchema: z.ZodSchema<PatchBallotPageAdjudicationParams> = z.object(
-  {
-    sheetId: z.string(),
-    side: SideSchema,
-  }
-)
-
-/**
- * @url /scan/hmpb/ballot/:sheetId/:side
- * @method PATCH
- */
-export type PatchBallotPageAdjudicationRequest = MarksByContestId
-
-/**
- * @url /scan/hmpb/ballot/:sheetId/:side
- * @method PATCH
- */
-export const PatchBallotPageAdjudicationRequestSchema: z.ZodSchema<PatchBallotPageAdjudicationRequest> = MarksByContestIdSchema
-
-/**
- * @url /scan/hmpb/ballot/:sheetId/:side
- * @method PATCH
- */
-export type PatchBallotPageAdjudicationResponse = OkResponse | ErrorsResponse
-
-/**
- * @url /scan/hmpb/ballot/:sheetId/:side
- * @method PATCH
- */
-export const PatchBallotPageAdjudicationResponseSchema: z.ZodSchema<PatchBallotPageAdjudicationResponse> = z.union(
-  [OkResponseSchema, ErrorsResponseSchema]
 )

--- a/libs/types/src/generic.ts
+++ b/libs/types/src/generic.ts
@@ -172,6 +172,13 @@ export const Id = z
     (id) => /^[-_a-z\d]+$/i.test(id),
     'IDs may only contain letters, numbers, dashes, and underscores'
   )
+export const WriteInId = z
+  .string()
+  .nonempty()
+  .refine(
+    (id) => id.startsWith('__write-in'),
+    'Write-In IDs must start with __write-in'
+  )
 export const HexString: z.ZodSchema<string> = z
   .string()
   .nonempty()

--- a/libs/types/src/hmpb.ts
+++ b/libs/types/src/hmpb.ts
@@ -9,7 +9,7 @@ import {
   TargetShape,
   TargetShapeSchema,
 } from './election'
-import { Id } from './generic'
+import { Id, WriteInId } from './generic'
 import {
   Corners,
   CornersSchema,
@@ -107,6 +107,21 @@ export const MarksByContestIdSchema: z.ZodSchema<MarksByContestId> = z.record(
   MarksByOptionIdSchema.optional()
 )
 
+export interface UninterpretableBallotMarkAdjudication {
+  readonly type: AdjudicationReason.UninterpretableBallot
+  readonly contestId: Contest['id']
+  readonly optionId: ContestOption['id']
+  readonly isMarked: boolean
+}
+export const UninterpretableBallotMarkAdjudicationSchema: z.ZodSchema<UninterpretableBallotMarkAdjudication> = z.object(
+  {
+    type: z.literal(AdjudicationReason.UninterpretableBallot),
+    contestId: Id,
+    optionId: Id,
+    isMarked: z.boolean(),
+  }
+)
+
 export interface OvervoteMarkAdjudication {
   readonly type: AdjudicationReason.Overvote
   readonly contestId: Contest['id']
@@ -154,7 +169,7 @@ export const MarginalMarkAdjudicationSchema: z.ZodSchema<MarginalMarkAdjudicatio
 
 export interface WriteInMarkAdjudicationMarked {
   readonly type: AdjudicationReason.WriteIn | AdjudicationReason.UnmarkedWriteIn
-  readonly isWriteIn: true
+  readonly isMarked: true
   readonly contestId: Contest['id']
   readonly optionId: ContestOption['id']
   readonly name: Candidate['name']
@@ -165,16 +180,16 @@ export const WriteInMarkAdjudicationMarkedSchema: z.ZodSchema<WriteInMarkAdjudic
       z.literal(AdjudicationReason.WriteIn),
       z.literal(AdjudicationReason.UnmarkedWriteIn),
     ]),
-    isWriteIn: z.literal(true),
+    isMarked: z.literal(true),
     contestId: Id,
-    optionId: Id,
+    optionId: WriteInId,
     name: z.string(),
   }
 )
 
 export interface WriteInMarkAdjudicationUnmarked {
   readonly type: AdjudicationReason.WriteIn | AdjudicationReason.UnmarkedWriteIn
-  readonly isWriteIn: false
+  readonly isMarked: false
   readonly contestId: Contest['id']
   readonly optionId: ContestOption['id']
 }
@@ -184,9 +199,9 @@ export const WriteInMarkAdjudicationUnmarkedSchema: z.ZodSchema<WriteInMarkAdjud
       z.literal(AdjudicationReason.WriteIn),
       z.literal(AdjudicationReason.UnmarkedWriteIn),
     ]),
-    isWriteIn: z.literal(false),
+    isMarked: z.literal(false),
     contestId: Id,
-    optionId: Id,
+    optionId: WriteInId,
   }
 )
 
@@ -198,13 +213,20 @@ export const WriteInMarkAdjudicationSchema: z.ZodSchema<WriteInMarkAdjudication>
 )
 
 export type MarkAdjudication =
+  | UninterpretableBallotMarkAdjudication
   | OvervoteMarkAdjudication
   | UndervoteMarkAdjudication
   | MarginalMarkAdjudication
   | WriteInMarkAdjudication
 export const MarkAdjudicationSchema: z.ZodSchema<MarkAdjudication> = z.union([
+  UninterpretableBallotMarkAdjudicationSchema,
   OvervoteMarkAdjudicationSchema,
   UndervoteMarkAdjudicationSchema,
   MarginalMarkAdjudicationSchema,
   WriteInMarkAdjudicationSchema,
 ])
+
+export type MarkAdjudications = readonly MarkAdjudication[]
+export const MarkAdjudicationsSchema: z.ZodSchema<MarkAdjudications> = z.array(
+  MarkAdjudicationSchema
+)


### PR DESCRIPTION
`bsd` now submits write-in adjudications to `module-scan`, which records them and uses them when exporting CVRs. Write-in CVR entries will now look like `__write-in-INDEX-NAME`, e.g. `__write-in-0-Bob Barker`. `election-manager` will lump anything that starts with `__write-in` into a single write-in tally, but we can change that later. Here's an example ballot page and CVR with several adjudicated write-ins:

![PIC-1631837505-001-9f4007db-e639-43c5-bce1-77ccf5d7a632-normalized](https://user-images.githubusercontent.com/1938/133704728-306d6c90-945b-4bb2-8ef8-3c2c7ddface5.jpg)

```json
{
  "775021789": ["__write-in-0-Lizard People"],
  "775021791": [
    "775033361",
    "775033362",
    "__write-in-0-Mario",
    "__write-in-2-Luigi"
  ],
  "775021795": ["775033091", "775033186", "__write-in-0-Bill & Ted"],
  "_ballotId": "f03d4622-4aaa-4265-90fa-e6bd024d925e",
  "_ballotStyleId": "2D",
  "_ballotType": "absentee",
  "_batchId": "424ff08b-195d-46a2-a4c8-f3408f4c7024",
  "_batchLabel": "Batch 10",
  "_precinctId": "775001535",
  "_scannerId": "000",
  "_testBallot": true,
  "_locales": { "primary": "en-US" },
  "_pageNumbers": [1, 2]
}
```

Refs #802 