### PR TITLE
fix overzealous front-end adjudication

### DIFF
--- a/apps/bsd/src/screens/BallotEjectScreen.test.tsx
+++ b/apps/bsd/src/screens/BallotEjectScreen.test.tsx
@@ -1,4 +1,5 @@
-import { waitFor, fireEvent } from '@testing-library/react'
+import { waitFor, fireEvent, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import fetchMock from 'fetch-mock'
 import React from 'react'
 import { act } from 'react-dom/test-utils'
@@ -542,4 +543,184 @@ test('shows invalid election screen when appropriate', async () => {
 
   fireEvent.click(getByText('Confirm Ballot Removed and Continue Scanning'))
   expect(continueScanning).toHaveBeenCalledWith({ forceAccept: false })
+})
+
+test('does NOT say ballot is blank if one side is blank and the other requires write-in adjudication', async () => {
+  fetchMock.getOnce(
+    '/scan/hmpb/review/next-sheet',
+    typedAs<GetNextReviewSheetResponse>({
+      interpreted: {
+        id: 'mock-sheet-id',
+        front: {
+          image: { url: '/writeinballot/front/url' },
+          interpretation: {
+            type: 'InterpretedHmpbPage',
+            markInfo: {
+              ballotSize: { width: 1, height: 1 },
+              marks: [],
+            },
+            metadata: {
+              ballotStyleId: '1',
+              precinctId: '1',
+              ballotType: BallotType.Standard,
+              electionHash: '',
+              isTestMode: false,
+              locales: { primary: 'en-US' },
+              pageNumber: 1,
+            },
+            adjudicationInfo: {
+              requiresAdjudication: true,
+              allReasonInfos: [{ type: AdjudicationReason.BlankBallot }],
+              enabledReasons: [
+                AdjudicationReason.BlankBallot,
+                AdjudicationReason.WriteIn,
+              ],
+            },
+            votes: {},
+          },
+        },
+        back: {
+          image: { url: '/writeinballot/back/url' },
+          interpretation: {
+            type: 'InterpretedHmpbPage',
+            markInfo: {
+              ballotSize: { width: 1, height: 1 },
+              marks: [],
+            },
+            metadata: {
+              ballotStyleId: '1',
+              precinctId: '1',
+              ballotType: BallotType.Standard,
+              electionHash: '',
+              isTestMode: false,
+              locales: { primary: 'en-US' },
+              pageNumber: 2,
+            },
+            adjudicationInfo: {
+              requiresAdjudication: true,
+              allReasonInfos: [
+                {
+                  type: AdjudicationReason.WriteIn,
+                  contestId: 'county-commissioners',
+                  optionIndex: 0,
+                  optionId: '__write-in-0',
+                },
+              ],
+              enabledReasons: [
+                AdjudicationReason.BlankBallot,
+                AdjudicationReason.WriteIn,
+              ],
+            },
+            votes: {},
+          },
+        },
+      },
+      layouts: {
+        front: {
+          ballotImage: {
+            metadata: {
+              ballotStyleId: '1',
+              precinctId: '1',
+              ballotType: BallotType.Standard,
+              electionHash: '',
+              isTestMode: false,
+              locales: { primary: 'en-US' },
+              pageNumber: 1,
+            },
+            imageData: {
+              width: 20,
+              height: 20,
+            },
+          },
+          contests: [],
+        },
+        back: {
+          ballotImage: {
+            metadata: {
+              ballotStyleId: '1',
+              precinctId: '1',
+              ballotType: BallotType.Standard,
+              electionHash: '',
+              isTestMode: false,
+              locales: { primary: 'en-US' },
+              pageNumber: 2,
+            },
+            imageData: {
+              width: 20,
+              height: 20,
+            },
+          },
+          contests: [
+            {
+              bounds: { x: 0, y: 0, width: 10, height: 10 },
+              corners: [
+                { x: 0, y: 0 },
+                { x: 1, y: 1 },
+                { x: 2, y: 2 },
+                { x: 3, y: 3 },
+              ],
+              options: [
+                {
+                  bounds: { x: 0, y: 0, width: 10, height: 10 },
+                  target: {
+                    bounds: { x: 0, y: 0, width: 10, height: 10 },
+                    inner: { x: 0, y: 0, width: 10, height: 10 },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+      definitions: {
+        front: {
+          contestIds: [],
+        },
+        back: {
+          contestIds: ['county-commissioners'],
+        },
+      },
+    })
+  )
+
+  const continueScanning = jest.fn()
+
+  renderInAppContext(
+    <BallotEjectScreen continueScanning={continueScanning} isTestMode />
+  )
+
+  await act(async () => {
+    await waitFor(() => fetchMock.called)
+  })
+
+  expect(screen.queryByText('Blank Ballot')).toBeNull()
+  expect(screen.queryByText('Unknown Reason')).toBeNull()
+  screen.getByText('Write-In')
+
+  userEvent.type(
+    screen.getByTestId(`write-in-input-__write-in-0`),
+    'Lizard People'
+  )
+
+  // doubly nested acts() because there's setIsSaving(true) and then (false).
+  await act(async () => {
+    await act(async () => {
+      userEvent.click(screen.getByText('Save & Continue Scanning'))
+    })
+  })
+
+  expect(continueScanning).toHaveBeenCalledWith({
+    forceAccept: true,
+    frontMarkAdjudications: [],
+    backMarkAdjudications: [
+      {
+        contestId: 'county-commissioners',
+        isMarked: true,
+        name: 'Lizard People',
+        optionId: '__write-in-0',
+        type: 'WriteIn',
+      },
+    ],
+  })
+  continueScanning.mockClear()
 })

--- a/apps/bsd/src/screens/BallotEjectScreen.tsx
+++ b/apps/bsd/src/screens/BallotEjectScreen.tsx
@@ -104,6 +104,59 @@ const BallotEjectScreen = ({
     setBackMarkAdjudications,
   ] = useState<MarkAdjudications>()
 
+  // with new reviewInfo, mark each side done if nothing to actually adjudicate
+  useEffect(() => {
+    if (!reviewInfo) {
+      return
+    }
+
+    const frontInterpretation = reviewInfo.interpreted.front.interpretation
+    const backInterpretation = reviewInfo.interpreted.back.interpretation
+
+    if (
+      !(
+        frontInterpretation.type === 'InterpretedHmpbPage' &&
+        backInterpretation.type === 'InterpretedHmpbPage'
+      )
+    ) {
+      return
+    }
+
+    const frontAdjudication = frontInterpretation.adjudicationInfo
+    const backAdjudication = backInterpretation.adjudicationInfo
+
+    const isBlank =
+      frontAdjudication.allReasonInfos.some(
+        (info) => info.type === AdjudicationReason.BlankBallot
+      ) &&
+      backAdjudication.allReasonInfos.some(
+        (info) => info.type === AdjudicationReason.BlankBallot
+      )
+
+    if (!isBlank) {
+      if (
+        !frontAdjudication.enabledReasons.some(
+          (reason) =>
+            reason !== AdjudicationReason.BlankBallot &&
+            frontAdjudication.allReasonInfos.some(
+              (info) => info.type === reason
+            )
+        )
+      ) {
+        setFrontMarkAdjudications([])
+      }
+      if (
+        !backAdjudication.enabledReasons.some(
+          (reason) =>
+            reason !== AdjudicationReason.BlankBallot &&
+            backAdjudication.allReasonInfos.some((info) => info.type === reason)
+        )
+      ) {
+        setBackMarkAdjudications([])
+      }
+    }
+  }, [reviewInfo])
+
   const onAdjudicationComplete = useCallback(
     async (
       sheetId: string,

--- a/apps/bsd/src/screens/BallotEjectScreen.tsx
+++ b/apps/bsd/src/screens/BallotEjectScreen.tsx
@@ -202,8 +202,8 @@ const BallotEjectScreen = ({
 
   let isOvervotedSheet = false
   let isUndervotedSheet = false
-  let frontIsBlank = false
-  let backIsBlank = false
+  let isFrontBlank = false
+  let isBackBlank = false
   let isUnreadableSheet = false
   let isInvalidTestModeSheet = false
   let isInvalidElectionHashSheet = false
@@ -286,9 +286,9 @@ const BallotEjectScreen = ({
               adjudicationReason.type === AdjudicationReason.BlankBallot
             ) {
               if (reviewPageInfo.side === 'front') {
-                frontIsBlank = true
+                isFrontBlank = true
               } else {
-                backIsBlank = true
+                isBackBlank = true
               }
             }
           }
@@ -305,7 +305,7 @@ const BallotEjectScreen = ({
     !isInvalidPrecinctSheet &&
     !isUnreadableSheet
 
-  const isBlankSheet = frontIsBlank && backIsBlank
+  const isBlankSheet = isFrontBlank && isBackBlank
 
   return (
     <Screen>

--- a/apps/bsd/src/screens/BallotEjectScreen.tsx
+++ b/apps/bsd/src/screens/BallotEjectScreen.tsx
@@ -170,7 +170,7 @@ const BallotEjectScreen = ({
     {
       side: 'back' as Side,
       imageURL: reviewInfo.interpreted.back.image.url,
-      interpretation: reviewInfo.interpreted.front.interpretation,
+      interpretation: reviewInfo.interpreted.back.interpretation,
       layout: reviewInfo.layouts.back,
       contestIds: reviewInfo.definitions.back?.contestIds,
       adjudicationFinishedAt:

--- a/apps/bsd/src/screens/BallotEjectScreen.tsx
+++ b/apps/bsd/src/screens/BallotEjectScreen.tsx
@@ -149,7 +149,8 @@ const BallotEjectScreen = ({
 
   let isOvervotedSheet = false
   let isUndervotedSheet = false
-  let isBlankSheet = false
+  let frontIsBlank = false
+  let backIsBlank = false
   let isUnreadableSheet = false
   let isInvalidTestModeSheet = false
   let isInvalidElectionHashSheet = false
@@ -231,7 +232,11 @@ const BallotEjectScreen = ({
             } else if (
               adjudicationReason.type === AdjudicationReason.BlankBallot
             ) {
-              isBlankSheet = true
+              if (reviewPageInfo.side === 'front') {
+                frontIsBlank = true
+              } else {
+                backIsBlank = true
+              }
             }
           }
         }
@@ -246,6 +251,8 @@ const BallotEjectScreen = ({
     !isInvalidElectionHashSheet &&
     !isInvalidPrecinctSheet &&
     !isUnreadableSheet
+
+  const isBlankSheet = frontIsBlank && backIsBlank
 
   return (
     <Screen>


### PR DESCRIPTION
This fixes two failures:
- hard crashes in some adjudication cases (see more details below)
- spurious "blank ballot" when one side is blank and there is a needed write-in adjudication anywhere on the ballot.

Root cause here is the mismatch between page-based adjudication (write-in) and sheet-based adjudication (blank).

This targeted fix attempts to be minimal and doesn't create a number of new functions / abstractions so that it is easy to excise later in case we have a better fix. Three fixes all on front-end:

- fixes a typo that sent front adjudication data structure for back page consideration.
- considers both front and back pages before declaring ballot blank. We were already doing this for `needsAdjudication`, but not for the actual front-end adjudication loop.
- when the ballot isn't completely blank, mark a side as adjudicated if there are no enabled adjudication reasons left for that page.

I'm going to see if I can add a quick regression test.

There's one more bug left here, which is likely best fixed on the backend and so will be a separate PR: if a ballot is blank except for a non-bubble write-in, then we get a spurious additional "unreadable ballot" adjudication. This probably requires backend to remove the `BlankBallot` adjudication reason if there is a `UnmarkedWriteIn` adjudication reason for that side, too.