### PR TITLE
fix: pages with unmarked write-ins are considered non-blank

### DIFF
--- a/apps/bsd/src/screens/BallotEjectScreen.test.tsx
+++ b/apps/bsd/src/screens/BallotEjectScreen.test.tsx
@@ -3,7 +3,12 @@ import userEvent from '@testing-library/user-event'
 import fetchMock from 'fetch-mock'
 import React from 'react'
 import { act } from 'react-dom/test-utils'
-import { BallotType, AdjudicationReason } from '@votingworks/types'
+import {
+  BallotType,
+  AdjudicationReason,
+  WriteInAdjudicationReasonInfo,
+  UnmarkedWriteInAdjudicationReasonInfo,
+} from '@votingworks/types'
 import { typedAs } from '@votingworks/utils'
 import { GetNextReviewSheetResponse } from '@votingworks/types/api/module-scan'
 import BallotEjectScreen from './BallotEjectScreen'
@@ -545,182 +550,186 @@ test('shows invalid election screen when appropriate', async () => {
   expect(continueScanning).toHaveBeenCalledWith({ forceAccept: false })
 })
 
-test('does NOT say ballot is blank if one side is blank and the other requires write-in adjudication', async () => {
-  fetchMock.getOnce(
-    '/scan/hmpb/review/next-sheet',
-    typedAs<GetNextReviewSheetResponse>({
-      interpreted: {
-        id: 'mock-sheet-id',
-        front: {
-          image: { url: '/writeinballot/front/url' },
-          interpretation: {
-            type: 'InterpretedHmpbPage',
-            markInfo: {
-              ballotSize: { width: 1, height: 1 },
-              marks: [],
+test('does NOT say ballot is blank if one side is blank and the other requires write-in adjudication (marked or unmarked)', async () => {
+  for (const writeInReason of [
+    AdjudicationReason.WriteIn,
+    AdjudicationReason.UnmarkedWriteIn,
+  ]) {
+    fetchMock.getOnce(
+      '/scan/hmpb/review/next-sheet',
+      typedAs<GetNextReviewSheetResponse>({
+        interpreted: {
+          id: 'mock-sheet-id',
+          front: {
+            image: { url: '/writeinballot/front/url' },
+            interpretation: {
+              type: 'InterpretedHmpbPage',
+              markInfo: {
+                ballotSize: { width: 1, height: 1 },
+                marks: [],
+              },
+              metadata: {
+                ballotStyleId: '1',
+                precinctId: '1',
+                ballotType: BallotType.Standard,
+                electionHash: '',
+                isTestMode: false,
+                locales: { primary: 'en-US' },
+                pageNumber: 1,
+              },
+              adjudicationInfo: {
+                requiresAdjudication: true,
+                allReasonInfos: [{ type: AdjudicationReason.BlankBallot }],
+                enabledReasons: [AdjudicationReason.BlankBallot, writeInReason],
+              },
+              votes: {},
             },
-            metadata: {
-              ballotStyleId: '1',
-              precinctId: '1',
-              ballotType: BallotType.Standard,
-              electionHash: '',
-              isTestMode: false,
-              locales: { primary: 'en-US' },
-              pageNumber: 1,
+          },
+          back: {
+            image: { url: '/writeinballot/back/url' },
+            interpretation: {
+              type: 'InterpretedHmpbPage',
+              markInfo: {
+                ballotSize: { width: 1, height: 1 },
+                marks: [],
+              },
+              metadata: {
+                ballotStyleId: '1',
+                precinctId: '1',
+                ballotType: BallotType.Standard,
+                electionHash: '',
+                isTestMode: false,
+                locales: { primary: 'en-US' },
+                pageNumber: 2,
+              },
+              adjudicationInfo: {
+                requiresAdjudication: true,
+                allReasonInfos: [
+                  {
+                    type: writeInReason,
+                    contestId: 'county-commissioners',
+                    optionIndex: 0,
+                    optionId: '__write-in-0',
+                  } as
+                    | WriteInAdjudicationReasonInfo
+                    | UnmarkedWriteInAdjudicationReasonInfo,
+                ],
+                enabledReasons: [AdjudicationReason.BlankBallot, writeInReason],
+              },
+              votes: {},
             },
-            adjudicationInfo: {
-              requiresAdjudication: true,
-              allReasonInfos: [{ type: AdjudicationReason.BlankBallot }],
-              enabledReasons: [
-                AdjudicationReason.BlankBallot,
-                AdjudicationReason.WriteIn,
-              ],
-            },
-            votes: {},
           },
         },
-        back: {
-          image: { url: '/writeinballot/back/url' },
-          interpretation: {
-            type: 'InterpretedHmpbPage',
-            markInfo: {
-              ballotSize: { width: 1, height: 1 },
-              marks: [],
+        layouts: {
+          front: {
+            ballotImage: {
+              metadata: {
+                ballotStyleId: '1',
+                precinctId: '1',
+                ballotType: BallotType.Standard,
+                electionHash: '',
+                isTestMode: false,
+                locales: { primary: 'en-US' },
+                pageNumber: 1,
+              },
+              imageData: {
+                width: 20,
+                height: 20,
+              },
             },
-            metadata: {
-              ballotStyleId: '1',
-              precinctId: '1',
-              ballotType: BallotType.Standard,
-              electionHash: '',
-              isTestMode: false,
-              locales: { primary: 'en-US' },
-              pageNumber: 2,
-            },
-            adjudicationInfo: {
-              requiresAdjudication: true,
-              allReasonInfos: [
-                {
-                  type: AdjudicationReason.WriteIn,
-                  contestId: 'county-commissioners',
-                  optionIndex: 0,
-                  optionId: '__write-in-0',
-                },
-              ],
-              enabledReasons: [
-                AdjudicationReason.BlankBallot,
-                AdjudicationReason.WriteIn,
-              ],
-            },
-            votes: {},
+            contests: [],
           },
-        },
-      },
-      layouts: {
-        front: {
-          ballotImage: {
-            metadata: {
-              ballotStyleId: '1',
-              precinctId: '1',
-              ballotType: BallotType.Standard,
-              electionHash: '',
-              isTestMode: false,
-              locales: { primary: 'en-US' },
-              pageNumber: 1,
+          back: {
+            ballotImage: {
+              metadata: {
+                ballotStyleId: '1',
+                precinctId: '1',
+                ballotType: BallotType.Standard,
+                electionHash: '',
+                isTestMode: false,
+                locales: { primary: 'en-US' },
+                pageNumber: 2,
+              },
+              imageData: {
+                width: 20,
+                height: 20,
+              },
             },
-            imageData: {
-              width: 20,
-              height: 20,
-            },
-          },
-          contests: [],
-        },
-        back: {
-          ballotImage: {
-            metadata: {
-              ballotStyleId: '1',
-              precinctId: '1',
-              ballotType: BallotType.Standard,
-              electionHash: '',
-              isTestMode: false,
-              locales: { primary: 'en-US' },
-              pageNumber: 2,
-            },
-            imageData: {
-              width: 20,
-              height: 20,
-            },
-          },
-          contests: [
-            {
-              bounds: { x: 0, y: 0, width: 10, height: 10 },
-              corners: [
-                { x: 0, y: 0 },
-                { x: 1, y: 1 },
-                { x: 2, y: 2 },
-                { x: 3, y: 3 },
-              ],
-              options: [
-                {
-                  bounds: { x: 0, y: 0, width: 10, height: 10 },
-                  target: {
+            contests: [
+              {
+                bounds: { x: 0, y: 0, width: 10, height: 10 },
+                corners: [
+                  { x: 0, y: 0 },
+                  { x: 1, y: 1 },
+                  { x: 2, y: 2 },
+                  { x: 3, y: 3 },
+                ],
+                options: [
+                  {
                     bounds: { x: 0, y: 0, width: 10, height: 10 },
-                    inner: { x: 0, y: 0, width: 10, height: 10 },
+                    target: {
+                      bounds: { x: 0, y: 0, width: 10, height: 10 },
+                      inner: { x: 0, y: 0, width: 10, height: 10 },
+                    },
                   },
-                },
-              ],
-            },
-          ],
+                ],
+              },
+            ],
+          },
         },
-      },
-      definitions: {
-        front: {
-          contestIds: [],
+        definitions: {
+          front: {
+            contestIds: [],
+          },
+          back: {
+            contestIds: ['county-commissioners'],
+          },
         },
-        back: {
-          contestIds: ['county-commissioners'],
-        },
-      },
-    })
-  )
+      })
+    )
 
-  const continueScanning = jest.fn()
+    const continueScanning = jest.fn()
 
-  renderInAppContext(
-    <BallotEjectScreen continueScanning={continueScanning} isTestMode />
-  )
+    const { unmount } = renderInAppContext(
+      <BallotEjectScreen continueScanning={continueScanning} isTestMode />
+    )
 
-  await act(async () => {
-    await waitFor(() => fetchMock.called)
-  })
-
-  expect(screen.queryByText('Blank Ballot')).toBeNull()
-  expect(screen.queryByText('Unknown Reason')).toBeNull()
-  screen.getByText('Write-In')
-
-  userEvent.type(
-    screen.getByTestId(`write-in-input-__write-in-0`),
-    'Lizard People'
-  )
-
-  // doubly nested acts() because there's setIsSaving(true) and then (false).
-  await act(async () => {
     await act(async () => {
-      userEvent.click(screen.getByText('Save & Continue Scanning'))
+      await waitFor(() => fetchMock.called)
     })
-  })
 
-  expect(continueScanning).toHaveBeenCalledWith({
-    forceAccept: true,
-    frontMarkAdjudications: [],
-    backMarkAdjudications: [
-      {
-        contestId: 'county-commissioners',
-        isMarked: true,
-        name: 'Lizard People',
-        optionId: '__write-in-0',
-        type: 'WriteIn',
-      },
-    ],
-  })
-  continueScanning.mockClear()
+    expect(screen.queryByText('Blank Ballot')).toBeNull()
+    expect(screen.queryByText('Unknown Reason')).toBeNull()
+    screen.getByText('Write-In')
+
+    userEvent.type(
+      screen.getByTestId(`write-in-input-__write-in-0`),
+      'Lizard People'
+    )
+
+    // doubly nested acts() because there's setIsSaving(true) and then (false).
+    await act(async () => {
+      await act(async () => {
+        userEvent.click(screen.getByText('Save & Continue Scanning'))
+      })
+    })
+
+    expect(continueScanning).toHaveBeenCalledWith({
+      forceAccept: true,
+      frontMarkAdjudications: [],
+      backMarkAdjudications: [
+        {
+          contestId: 'county-commissioners',
+          isMarked: true,
+          name: 'Lizard People',
+          optionId: '__write-in-0',
+          type: writeInReason,
+        },
+      ],
+    })
+    continueScanning.mockClear()
+
+    unmount()
+    fetchMock.reset()
+  }
 })

--- a/apps/bsd/src/screens/BallotEjectScreen.tsx
+++ b/apps/bsd/src/screens/BallotEjectScreen.tsx
@@ -125,12 +125,25 @@ const BallotEjectScreen = ({
     const frontAdjudication = frontInterpretation.adjudicationInfo
     const backAdjudication = backInterpretation.adjudicationInfo
 
+    // A ballot is blank if both sides are marked blank
+    // and neither side contains an unmarked write in,
+    // because an unmarked write-in is a sign the page isn't blank.
+    //
+    // One could argue that making this call is the server's job.
+    // We leave that consideration to:
+    // https://github.com/votingworks/vxsuite/issues/902
     const isBlank =
       frontAdjudication.allReasonInfos.some(
         (info) => info.type === AdjudicationReason.BlankBallot
       ) &&
+      !frontAdjudication.allReasonInfos.some(
+        (info) => info.type === AdjudicationReason.UnmarkedWriteIn
+      ) &&
       backAdjudication.allReasonInfos.some(
         (info) => info.type === AdjudicationReason.BlankBallot
+      ) &&
+      !backAdjudication.allReasonInfos.some(
+        (info) => info.type === AdjudicationReason.UnmarkedWriteIn
       )
 
     if (!isBlank) {


### PR DESCRIPTION

If a page has an unmarked write-in and nothing else, the backend calls this a blank page. That's not quite right from the point of view of adjudication. The right fix for this is probably on the server, as the code indicates with a future ticket to tackle.

For the sake of a low-risk change, this PR adds the conditional in the front-end. Includes tests, same as for marked write-in.