### PR TITLE
Add a results reporting QR code to tally report

### DIFF
--- a/apps/precinct-scanner/package.json
+++ b/apps/precinct-scanner/package.json
@@ -84,6 +84,7 @@
     "@types/styled-components": "^5.1.9",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/hmpb-interpreter": "workspace:*",
+    "@votingworks/qrcode.react": "^1.0.2",
     "@votingworks/types": "workspace:*",
     "@votingworks/ui": "workspace:*",
     "@votingworks/utils": "workspace:*",

--- a/apps/precinct-scanner/src/screens/PollWorkerScreen.tsx
+++ b/apps/precinct-scanner/src/screens/PollWorkerScreen.tsx
@@ -311,7 +311,8 @@ const PollWorkerScreen = ({
                 reportPurpose={reportPurpose}
               />
               <PrecinctScannerTallyReport
-                election={election}
+                electionDefinition={electionDefinition}
+                machineId={machineConfig.machineId}
                 tally={currentTally}
                 precinctSelection={precinctSelection}
                 reportPurpose={reportPurpose}

--- a/libs/@types/kiosk-browser/kiosk-browser.d.ts
+++ b/libs/@types/kiosk-browser/kiosk-browser.d.ts
@@ -121,6 +121,11 @@ declare namespace KioskBrowser {
     code: string
   }
 
+  export interface SignParams {
+    signatureType: string
+    payload: string
+  }
+  
   export interface Kiosk {
     print(options?: PrintOptions): Promise<void>
     getPrinterInfo(): Promise<PrinterInfo[]>
@@ -189,10 +194,11 @@ declare namespace KioskBrowser {
 
     setClock(params: SetClockParams): Promise<void>
 
-    // totp
     totp: {
       get(): Promise<TotpInfo|undefined>
     }
+
+    sign(params: SignParams): Promise<string>
   }
 }
 

--- a/libs/test-utils/src/fakeKiosk.ts
+++ b/libs/test-utils/src/fakeKiosk.ts
@@ -77,5 +77,6 @@ export function fakeKiosk({
     totp: {
       get: jest.fn(),
     },
+    sign: jest.fn(),
   }
 }

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@types/react-router-dom": "^5.1.7",
+    "@votingworks/qrcode.react": "^1.0.2",
     "@votingworks/types": "workspace:*",
     "@votingworks/utils": "workspace:*",
     "debug": "^4.3.2",

--- a/libs/ui/src/PrecinctScannerTallyReport.test.tsx
+++ b/libs/ui/src/PrecinctScannerTallyReport.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react'
+import { render, act, screen } from '@testing-library/react'
+import { electionSample, electionSampleDefinition } from '@votingworks/fixtures'
+import { CastVoteRecord } from '@votingworks/types'
+import { calculateTallyForCastVoteRecords } from '@votingworks/utils'
+import { fakeKiosk, mockOf } from '@votingworks/test-utils'
+
+import { PrecinctSelectionKind } from './PrecinctScannerPollsReport'
+import { PrecinctScannerTallyReport } from './PrecinctScannerTallyReport'
+
+afterEach(() => {
+  window.kiosk = undefined
+})
+
+test('renders without results reporting when no CVRs', async () => {
+  const mockKiosk = fakeKiosk()
+  mockOf(mockKiosk.sign).mockResolvedValue('FAKESIGNATURE')
+  window.kiosk = mockKiosk
+  const tally = calculateTallyForCastVoteRecords(electionSample, new Set([]))
+
+  await act(async () => {
+    render(
+      <PrecinctScannerTallyReport
+        currentDateTime="September 19th, 2021 11:05am"
+        electionDefinition={electionSampleDefinition}
+        machineId="DEMO-0000"
+        precinctSelection={{ kind: PrecinctSelectionKind.AllPrecincts }}
+        reportPurpose="Testing"
+        isPollsOpen={false}
+        tally={tally}
+      />
+    )
+  })
+
+  expect(screen.queryByText('Automatic Election Results Reporting')).toBeNull()
+})
+
+const cvr: CastVoteRecord = {
+  _precinctId: electionSample.precincts[0].id,
+  _ballotId: 'test-123',
+  _ballotStyleId: electionSample.ballotStyles[0].id,
+  _batchId: 'batch-1',
+  _batchLabel: 'batch-1',
+  _ballotType: 'standard',
+  _testBallot: false,
+  _scannerId: 'DEMO-0000',
+  'county-commissioners': ['argent'],
+}
+
+test('renders WITHOUT results reporting when there are CVRs but polls are open', async () => {
+  const mockKiosk = fakeKiosk()
+  mockOf(mockKiosk.sign).mockResolvedValue('FAKESIGNATURE')
+  window.kiosk = mockKiosk
+
+  const tally = calculateTallyForCastVoteRecords(electionSample, new Set([cvr]))
+
+  await act(async () => {
+    render(
+      <PrecinctScannerTallyReport
+        currentDateTime="September 19th, 2021 11:05am"
+        electionDefinition={electionSampleDefinition}
+        machineId="DEMO-0000"
+        precinctSelection={{ kind: PrecinctSelectionKind.AllPrecincts }}
+        reportPurpose="Testing"
+        isPollsOpen
+        tally={tally}
+      />
+    )
+  })
+
+  expect(screen.queryByText('Automatic Election Results Reporting')).toBeNull()
+})
+
+test('renders with results reporting when there are CVRs and polls are closed', async () => {
+  const mockKiosk = fakeKiosk()
+  mockOf(mockKiosk.sign).mockResolvedValue('FAKESIGNATURE')
+  window.kiosk = mockKiosk
+
+  const tally = calculateTallyForCastVoteRecords(electionSample, new Set([cvr]))
+
+  await act(async () => {
+    render(
+      <PrecinctScannerTallyReport
+        currentDateTime="September 19th, 2021 11:05am"
+        electionDefinition={electionSampleDefinition}
+        machineId="DEMO-0000"
+        precinctSelection={{ kind: PrecinctSelectionKind.AllPrecincts }}
+        reportPurpose="Testing"
+        isPollsOpen={false}
+        tally={tally}
+      />
+    )
+  })
+
+  expect(
+    screen.queryByText('Automatic Election Results Reporting')
+  ).toBeTruthy()
+})

--- a/libs/utils/src/types.ts
+++ b/libs/utils/src/types.ts
@@ -74,6 +74,8 @@ export const TallySchema: z.ZodSchema<SerializedTally> = z.array(
   ])
 )
 
+export type CompressedTally = number[][]
+
 export enum TallySourceMachineType {
   BMD = 'bmd',
   PRECINCT_SCANNER = 'precinct_scanner',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -799,13 +799,14 @@ importers:
       '@types/styled-components': 5.1.9
       '@votingworks/fixtures': link:../../libs/fixtures
       '@votingworks/hmpb-interpreter': link:../../libs/hmpb-interpreter
+      '@votingworks/qrcode.react': 1.0.2_react@17.0.1
       '@votingworks/types': link:../../libs/types
       '@votingworks/ui': link:../../libs/ui
       '@votingworks/utils': link:../../libs/utils
       base64-js: 1.5.1
       debug: 4.3.1
       fetch-mock: 9.11.0
-      http-proxy-middleware: 1.0.6
+      http-proxy-middleware: 1.0.6_debug@4.3.1
       i18next: 19.8.4
       jest-fetch-mock: 3.0.3
       js-file-download: 0.4.12
@@ -881,6 +882,7 @@ importers:
       '@typescript-eslint/parser': ^4.28.4
       '@votingworks/fixtures': workspace:*
       '@votingworks/hmpb-interpreter': workspace:*
+      '@votingworks/qrcode.react': ^1.0.2
       '@votingworks/test-utils': workspace:*
       '@votingworks/types': workspace:*
       '@votingworks/ui': workspace:*
@@ -1535,6 +1537,7 @@ importers:
   libs/ui:
     dependencies:
       '@types/react-router-dom': 5.1.7
+      '@votingworks/qrcode.react': 1.0.2_react@17.0.1
       '@votingworks/types': link:../types
       '@votingworks/utils': link:../utils
       debug: 4.3.2
@@ -1607,6 +1610,7 @@ importers:
       '@typescript-eslint/eslint-plugin': ^4.29.3
       '@typescript-eslint/parser': ^4.29.3
       '@votingworks/fixtures': workspace:*
+      '@votingworks/qrcode.react': ^1.0.2
       '@votingworks/test-utils': workspace:*
       '@votingworks/types': workspace:*
       '@votingworks/utils': workspace:*
@@ -8735,7 +8739,6 @@ packages:
     resolution:
       integrity: sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
   /@types/prop-types/15.7.4:
-    dev: true
     resolution:
       integrity: sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
   /@types/q/1.5.4:
@@ -8816,6 +8819,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-wWZrPlihslrPpcKyCSlmIlruakxr57/buQN1RjlIeaaTWDLtJkTtRW429MoQJergvVKc4IWBpRhWw7YNh/7GVA==
+  /@types/react/17.0.21:
+    dependencies:
+      '@types/prop-types': 15.7.4
+      '@types/scheduler': 0.16.2
+      csstype: 3.0.9
+    dev: false
+    resolution:
+      integrity: sha512-GzzXCpOthOjXvrAUFQwU/svyxu658cwu00Q9ugujS4qc1zXgLFaO0kS2SLOaMWLt2Jik781yuHCWB7UcYdGAeQ==
   /@types/react/17.0.4:
     dependencies:
       '@types/prop-types': 15.7.3
@@ -8853,7 +8864,6 @@ packages:
     resolution:
       integrity: sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
   /@types/scheduler/0.16.2:
-    dev: true
     resolution:
       integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
   /@types/serve-static/1.13.9:
@@ -10254,7 +10264,7 @@ packages:
       integrity: sha512-7FqtqYVlsG7LhYkPifNkSOQiJNzqGbdQB6vPC+EXmbBaWkd9rvKX3hTMW8ExLsj5g8OTEi3EKMj2Tkq0w9vuhQ==
   /@votingworks/qrcode.react/1.0.2_react@17.0.1:
     dependencies:
-      '@types/react': 17.0.0
+      '@types/react': 17.0.21
       loose-envify: 1.4.0
       prop-types: 15.7.2
       qr.js: 0.0.0
@@ -13383,6 +13393,10 @@ packages:
   /csstype/3.0.8:
     resolution:
       integrity: sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==
+  /csstype/3.0.9:
+    dev: false
+    resolution:
+      integrity: sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==
   /csv-writer/1.6.0:
     dev: false
     resolution:
@@ -18098,6 +18112,20 @@ packages:
     dev: false
     engines:
       node: '>=8.0.0'
+    resolution:
+      integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
+  /http-proxy-middleware/1.0.6_debug@4.3.1:
+    dependencies:
+      '@types/http-proxy': 1.17.6
+      http-proxy: 1.18.1_debug@4.3.1
+      is-glob: 4.0.1
+      lodash: 4.17.21
+      micromatch: 4.0.4
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    peerDependencies:
+      debug: '*'
     resolution:
       integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
   /http-proxy/1.18.1:
@@ -28167,7 +28195,7 @@ packages:
       bs-logger: 0.2.6
       buffer-from: 1.1.1
       fast-json-stable-stringify: 2.1.0
-      jest: 26.6.3_ts-node@9.1.1
+      jest: 26.6.3
       jest-util: 26.6.2
       json5: 2.2.0
       lodash: 4.17.21


### PR DESCRIPTION
When polls are closed and we can compute a signature on the tally, add an election results reporting QR code in the precinct tally report.

The iffiest part of this PR is the new compressed tally format introduced (the serialized format is not as short as we need). This will require some review, tracking in https://github.com/votingworks/vxsuite/issues/908