### PR TITLE
fix(scan): prioritize blank ballot over undervote

### DIFF
--- a/apps/bsd/src/screens/BallotEjectScreen.test.tsx
+++ b/apps/bsd/src/screens/BallotEjectScreen.test.tsx
@@ -264,8 +264,20 @@ test('says the ballot sheet is blank if it is', async () => {
             },
             adjudicationInfo: {
               requiresAdjudication: true,
-              allReasonInfos: [{ type: AdjudicationReason.BlankBallot }],
-              enabledReasons: [AdjudicationReason.Overvote],
+              allReasonInfos: [
+                {
+                  type: AdjudicationReason.Undervote,
+                  contestId: '1',
+                  expected: 1,
+                  optionIds: [],
+                  optionIndexes: [],
+                },
+                { type: AdjudicationReason.BlankBallot },
+              ],
+              enabledReasons: [
+                AdjudicationReason.BlankBallot,
+                AdjudicationReason.Undervote,
+              ],
             },
             votes: {},
           },
@@ -288,9 +300,12 @@ test('says the ballot sheet is blank if it is', async () => {
               pageNumber: 2,
             },
             adjudicationInfo: {
-              requiresAdjudication: false,
-              allReasonInfos: [],
-              enabledReasons: [AdjudicationReason.Overvote],
+              requiresAdjudication: true,
+              allReasonInfos: [{ type: AdjudicationReason.BlankBallot }],
+              enabledReasons: [
+                AdjudicationReason.BlankBallot,
+                AdjudicationReason.Undervote,
+              ],
             },
             votes: {},
           },

--- a/apps/bsd/src/screens/BallotEjectScreen.tsx
+++ b/apps/bsd/src/screens/BallotEjectScreen.tsx
@@ -359,10 +359,10 @@ const BallotEjectScreen = ({
                 ? 'Unreadable'
                 : isOvervotedSheet
                 ? 'Overvote'
-                : isUndervotedSheet
-                ? 'Undervote'
                 : isBlankSheet
                 ? 'Blank Ballot'
+                : isUndervotedSheet
+                ? 'Undervote'
                 : 'Unknown Reason'}
             </EjectReason>
             <p>

--- a/apps/bsd/src/screens/__snapshots__/BallotEjectScreen.test.tsx.snap
+++ b/apps/bsd/src/screens/__snapshots__/BallotEjectScreen.test.tsx.snap
@@ -305,7 +305,7 @@ exports[`says the ballot sheet is blank if it is 1`] = `
           <div
             class="sc-dIUggk hZaEGa"
           >
-            Unknown Reason
+            Blank Ballot
           </div>
           <p>
             This last scanned sheet 
@@ -331,7 +331,11 @@ exports[`says the ballot sheet is blank if it is 1`] = `
             Duplicate Ballot Scan
           </h4>
           <p>
-            Confirm ballot sheet was reviewed by the Resolution Board and tabulate as ballot with issue which could not be determined.
+            Confirm ballot sheet was reviewed by the Resolution Board and tabulate as a 
+            <strong>
+              blank
+            </strong>
+             ballot sheet and has no votes.
             <br />
             <button
               class="sc-gsTCUz ftrorQ"


### PR DESCRIPTION
When there are adjudication reasons for both undervote and blank ballot it makes more sense to present the blank ballot issue than the undervotes.

Closes #864