### PR TITLE
fix(ui): prevent re-renders due to `useSmartcard`

### DIFF
--- a/libs/ui/src/hooks/useSmartcard.test.tsx
+++ b/libs/ui/src/hooks/useSmartcard.test.tsx
@@ -113,8 +113,7 @@ test('writing short value succeeds', async () => {
         )
         setError(result?.err())
       })()
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [!smartcard])
+    }, [smartcard])
 
     return (
       <div>
@@ -153,8 +152,7 @@ test('writing short value fails', async () => {
         )
         setError(result?.err())
       })()
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [!smartcard])
+    }, [smartcard])
 
     return <div>{error?.message}</div>
   }
@@ -185,8 +183,7 @@ test('reading long string value succeeds', async () => {
       void (async () => {
         setLongData((await smartcard?.readLongString())?.ok())
       })()
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [!smartcard])
+    }, [smartcard])
 
     return <div>{longData}</div>
   }
@@ -218,8 +215,7 @@ test('reading long binary value succeeds', async () => {
       void (async () => {
         setLongData((await smartcard?.readLongUint8Array())?.ok())
       })()
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [!smartcard])
+    }, [smartcard])
 
     return <div>{longData?.join(',')}</div>
   }
@@ -250,8 +246,7 @@ test('reading long string value fails', async () => {
       void (async () => {
         setError((await smartcard?.readLongString())?.err()?.message)
       })()
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [!smartcard])
+    }, [smartcard])
 
     return <div>{error}</div>
   }
@@ -278,8 +273,7 @@ test('reading long binary value fails', async () => {
       void (async () => {
         setError((await smartcard?.readLongUint8Array())?.err()?.message)
       })()
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [!smartcard])
+    }, [smartcard])
 
     return <div>{error}</div>
   }
@@ -307,8 +301,7 @@ test('writing long object value succeeds', async () => {
         ;(await smartcard?.writeLongValue({ some: 'object' }))?.unsafeUnwrap()
         setLongData((await smartcard?.readLongString())?.ok())
       })()
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [!smartcard])
+    }, [smartcard])
 
     return <div>{longData}</div>
   }
@@ -337,8 +330,7 @@ test('writing long binary value succeeds', async () => {
         )?.unsafeUnwrap()
         setLongData((await smartcard?.readLongUint8Array())?.ok())
       })()
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [!smartcard])
+    }, [smartcard])
 
     return <div>{longData?.join(',')}</div>
   }
@@ -365,8 +357,7 @@ test('writing long object value fails', async () => {
         const result = await smartcard?.writeLongValue({ some: 'object' })
         setError(result?.err())
       })()
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [!smartcard])
+    }, [smartcard])
 
     return <div>{error?.message}</div>
   }
@@ -395,8 +386,7 @@ test('writing long binary value fails', async () => {
         )
         setError(result?.err())
       })()
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [!smartcard])
+    }, [smartcard])
 
     return <div>{error?.message}</div>
   }


### PR DESCRIPTION
`useSmartcard` was always returning new objects, so using its results as hook dependencies caused a whole bunch of unneeded re-renders. This uses `useMemo` to ensure we always get the same object when the constituent parts haven't changed.