### PR TITLE
fix(all): correct dependencies of various hooks

### DIFF
--- a/apps/bas/src/AppRoot.tsx
+++ b/apps/bas/src/AppRoot.tsx
@@ -122,8 +122,7 @@ const AppRoot = ({ card, hardware, storage }: Props): JSX.Element => {
     const longValue = (await smartcard?.readLongString())?.unsafeUnwrap()
     setElection(safeParseElection(longValue).unsafeUnwrap())
     setIsLoadingElection(false)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [!smartcard])
+  }, [setElection, smartcard])
 
   const lockScreen = useCallback(() => {
     setIsLocked(true)
@@ -146,8 +145,7 @@ const AppRoot = ({ card, hardware, storage }: Props): JSX.Element => {
         setIsReadyToRemove(false)
       }
     })()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [!smartcard])
+  }, [smartcard])
 
   const programCard: EventTargetFunction = useCallback(
     async (event) => {
@@ -182,8 +180,7 @@ const AppRoot = ({ card, hardware, storage }: Props): JSX.Element => {
         setIsReadyToRemove(true)
       }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [makeCancelable, reset, !smartcard, precinctId]
+    [precinctId, smartcard, makeCancelable, reset]
   )
 
   if (isAdminCardPresent) {

--- a/apps/election-manager/src/App.tsx
+++ b/apps/election-manager/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Route } from 'react-router-dom'
 
 import './App.css'
 
+import { useCancelablePromise } from '@votingworks/ui'
 import {
   LocalStorage,
   KioskStorage,
@@ -32,15 +33,15 @@ const App = ({
   machineConfig = machineConfigProvider,
 }: Props): JSX.Element => {
   const [internalHardware, setInternalHardware] = useState(hardware)
+  const makeCancelable = useCancelablePromise()
+
   useEffect(() => {
     const updateHardware = async () => {
-      if (internalHardware === undefined) {
-        setInternalHardware(await getHardware())
-      }
+      const newHardware = await makeCancelable(getHardware())
+      setInternalHardware((prev) => prev ?? newHardware)
     }
     void updateHardware()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hardware])
+  }, [makeCancelable])
 
   if (!internalHardware) {
     return <React.Fragment />

--- a/apps/election-manager/src/AppRoot.test.tsx
+++ b/apps/election-manager/src/AppRoot.test.tsx
@@ -13,6 +13,7 @@ import {
   NullPrinter,
 } from '@votingworks/utils'
 import AppRoot from './AppRoot'
+import { fakeMachineConfigProvider } from '../test/helpers/fakeMachineConfig'
 
 beforeEach(() => {
   fetchMock.get(/^\/convert/, {})
@@ -31,6 +32,7 @@ test('renders without crashing', async () => {
               printer={new NullPrinter()}
               hardware={new MemoryHardware()}
               card={new MemoryCard()}
+              machineConfigProvider={fakeMachineConfigProvider()}
               {...props}
             />
           )}

--- a/apps/election-manager/test/helpers/fakeMachineConfig.ts
+++ b/apps/election-manager/test/helpers/fakeMachineConfig.ts
@@ -1,0 +1,21 @@
+import { Provider } from '@votingworks/types'
+import { MachineConfig } from '../../src/config/types'
+
+export default function fakeMachineConfig({
+  machineId = '000',
+  codeVersion = 'test',
+  bypassAuthentication = false,
+}: Partial<MachineConfig> = {}): MachineConfig {
+  return { machineId, codeVersion, bypassAuthentication }
+}
+
+export function fakeMachineConfigProvider(
+  props: Partial<MachineConfig> = {}
+): Provider<MachineConfig> {
+  const config = fakeMachineConfig(props)
+  return {
+    async get() {
+      return config
+    },
+  }
+}

--- a/apps/precinct-scanner/src/AppRoot.tsx
+++ b/apps/precinct-scanner/src/AppRoot.tsx
@@ -728,8 +728,7 @@ const AppRoot = ({
         }
       }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [card, electionDefinition]
+    [electionDefinition, machineConfig.bypassAuthentication]
   )
 
   const [smartcard, hasCardReaderAttached] = useSmartcard({ card, hardware })
@@ -742,15 +741,7 @@ const AppRoot = ({
         dispatchAppState({ type: 'cardRemoved' })
       }
     })()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    !smartcard,
-    smartcard?.data,
-    smartcard?.longValueExists,
-    hasCardInserted,
-    dispatchAppState,
-  ])
+  }, [smartcard, hasCardInserted, dispatchAppState, processCard])
 
   const attemptToAuthenticateUser = useCallback(
     (passcode: string): boolean => {


### PR DESCRIPTION
Now that #928 fixed `useSmartcard` to return the same object if nothing has changed, we can fix the hooks that depend on its results to use the correct value (i.e. just `smartcard`). Doing so revealed a few other hooks with incorrect dependencies. This commit fixes those as well.

Some of them were such that, if you simply used the ESLint-suggested hook dependencies, you'd get stuck in an infinite-re-render loop. For example, in both BSD and EM there's a `useEffect` to update the current session. It used both `currentUserSession` and `setCurrentUserSession`. In some circumstances it would set the value and re-run the effect, updating the user session and running the effect again. The way out of this is to pass a function to `setCurrentUserSession` and to return the previous value in the situations where it wouldn't previously have been called.

Additionally, there was an unhandled `GET /machine-config` in EM's tests, so now that's handled by passing a machine config provider in the tests and always requiring it be passed to `AppRoot`.