### PR TITLE
fix(ui): improve `useStoredState`

### DIFF
--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -52,6 +52,7 @@
   "devDependencies": {
     "@codemod/parser": "^1.0.6",
     "@testing-library/react": "^11.2.6",
+    "@testing-library/react-hooks": "^6.0.0",
     "@testing-library/user-event": "^13.2.1",
     "@types/debug": "^4.1.7",
     "@types/jest": "^26.0.23",

--- a/libs/ui/src/hooks/useStoredState.test.tsx
+++ b/libs/ui/src/hooks/useStoredState.test.tsx
@@ -1,82 +1,85 @@
-import { render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { waitFor } from '@testing-library/react'
+import { act, renderHook } from '@testing-library/react-hooks'
 import { MemoryStorage } from '@votingworks/utils/src'
-import React, { useCallback } from 'react'
 import { z } from 'zod'
-import { Button } from '../Button'
 import { useStoredState } from './useStoredState'
 
 test('no initial value + updates', async () => {
   const storage = new MemoryStorage()
+  const schema = z.number()
 
-  const TestComponent = (): JSX.Element => {
-    const [number, setNumber] = useStoredState(storage, 'test-key', z.number())
+  const { result } = renderHook(() =>
+    useStoredState(storage, 'test-key', schema)
+  )
 
-    const reset = useCallback(() => {
-      setNumber(0)
-    }, [setNumber])
-
-    const increment = useCallback(() => {
-      setNumber((prev = 0) => prev + 1)
-    }, [setNumber])
-
-    return (
-      <div>
-        <span>{typeof number}</span> <span>{number}</span>
-        <Button onPress={reset}>Reset</Button>
-        <Button onPress={increment}>Increment</Button>
-      </div>
-    )
+  // test direct set value
+  {
+    const [number, setNumber] = result.current
+    await waitFor(() => expect(number).toBeUndefined())
+    act(() => setNumber(99))
   }
 
-  render(<TestComponent />)
-  screen.getByText('undefined')
+  // test set via callback
+  {
+    const [number, setNumber] = result.current
+    await waitFor(() => expect(number).toEqual(99))
+    expect(await storage.get('test-key')).toEqual(99)
+    act(() => setNumber((prev = 0) => prev + 1))
+  }
 
-  userEvent.click(screen.getByText('Reset'))
-  screen.getByText('number')
-  screen.getByText('0')
+  // test removal
+  {
+    const [number, setNumber] = result.current
+    await waitFor(() => expect(number).toEqual(100))
+    expect(await storage.get('test-key')).toEqual(100)
+    act(() => setNumber(undefined))
+  }
 
-  userEvent.click(screen.getByText('Increment'))
-  await waitFor(() => screen.getByText('number'))
-  screen.getByText('1')
+  {
+    const [number] = result.current
+    await waitFor(() => expect(number).toBeUndefined())
+    expect(await storage.get('test-key')).toBeUndefined()
+  }
 
-  userEvent.click(screen.getByText('Increment'))
-  await waitFor(() => screen.getByText('number'))
-  screen.getByText('2')
+  const allSetters = result.all.map((errorOrValueAndSetter) => {
+    if (errorOrValueAndSetter instanceof Error) {
+      throw errorOrValueAndSetter
+    }
+
+    return errorOrValueAndSetter[1]
+  })
+
+  // verify that the setter doesn't change
+  expect(allSetters).toHaveLength(4)
+  expect([...new Set(allSetters)]).toHaveLength(1)
 })
 
 test('has initial value + updates', async () => {
   const storage = new MemoryStorage()
+  const schema = z.boolean()
 
-  const TestComponent = (): JSX.Element => {
-    const [boolean, setBoolean] = useStoredState(
-      storage,
-      'test-key',
-      z.boolean(),
-      false
-    )
+  const { result } = renderHook(() =>
+    useStoredState(storage, 'test-key', schema, false)
+  )
 
-    const negate = useCallback(() => {
-      setBoolean((prev) => !prev)
-    }, [setBoolean])
-
-    return (
-      <div>
-        <span>{typeof boolean}</span> <span>{boolean ? 'yes' : 'no'}</span>
-        <Button onPress={negate}>Negate</Button>
-      </div>
-    )
+  {
+    const [boolean, setBoolean] = result.current
+    await waitFor(() => expect(boolean).toEqual(false))
+    act(() => setBoolean(true))
   }
 
-  render(<TestComponent />)
-  await waitFor(() => screen.getByText('boolean'))
-  screen.getByText('no')
+  {
+    const [boolean, setBoolean] = result.current
+    await waitFor(() => expect(boolean).toEqual(true))
+    expect(await storage.get('test-key')).toEqual(true)
+    act(() => setBoolean((prev) => !prev))
+  }
 
-  userEvent.click(screen.getByText('Negate'))
-  await waitFor(() => screen.getByText('yes'))
-
-  userEvent.click(screen.getByText('Negate'))
-  await waitFor(() => screen.getByText('no'))
+  {
+    const [boolean] = result.current
+    await waitFor(() => expect(boolean).toEqual(false))
+    expect(await storage.get('test-key')).toEqual(false)
+  }
 })
 
 test('restores complex object', async () => {
@@ -94,17 +97,61 @@ test('restores complex object', async () => {
 
   await storage.set('test-key', value)
 
-  const TestComponent = (): JSX.Element => {
-    const [storedValue] = useStoredState(storage, 'test-key', schema)
+  const { result } = renderHook(() =>
+    useStoredState(storage, 'test-key', schema)
+  )
+  await waitFor(() => expect(result.current[0]).toEqual(value))
+})
 
-    try {
-      expect(storedValue).toEqual(value)
-      return <div>yes</div>
-    } catch (error) {
-      return <div>no: {error.message}</div>
-    }
-  }
+test('switching storage', async () => {
+  const storage1 = new MemoryStorage()
+  const storage2 = new MemoryStorage()
+  const schema = z.number()
 
-  render(<TestComponent />)
-  await waitFor(() => screen.getByText('yes'))
+  await storage1.set('test-key', 1)
+  await storage2.set('test-key', 2)
+
+  const { result, rerender } = renderHook(
+    ({ storage }) => useStoredState(storage, 'test-key', schema),
+    { initialProps: { storage: storage1 } }
+  )
+  await waitFor(() => expect(result.current[0]).toEqual(1))
+
+  // test that it re-pulls the value
+  rerender({ storage: storage2 })
+  await waitFor(() => expect(result.current[0]).toEqual(2))
+
+  // test that it sets to the new storage
+  const [, setValue] = result.current
+  act(() => setValue(222))
+  await waitFor(async () => {
+    expect(await storage1.get('test-key')).toEqual(1)
+    expect(await storage2.get('test-key')).toEqual(222)
+  })
+})
+
+test('switching keys', async () => {
+  const storage = new MemoryStorage()
+  const schema = z.number()
+
+  await storage.set('test-key1', 1)
+  await storage.set('test-key2', 2)
+
+  const { result, rerender } = renderHook(
+    ({ key }) => useStoredState(storage, key, schema),
+    { initialProps: { key: 'test-key1' } }
+  )
+  await waitFor(() => expect(result.current[0]).toEqual(1))
+
+  // test that it re-pulls the value
+  rerender({ key: 'test-key2' })
+  await waitFor(() => expect(result.current[0]).toEqual(2))
+
+  // test that it sets to the new key
+  const [, setValue] = result.current
+  act(() => setValue(222))
+  await waitFor(async () => {
+    expect(await storage.get('test-key1')).toEqual(1)
+    expect(await storage.get('test-key2')).toEqual(222)
+  })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1552,6 +1552,7 @@ importers:
     devDependencies:
       '@codemod/parser': 1.1.0
       '@testing-library/react': 11.2.6_react-dom@17.0.1+react@17.0.1
+      '@testing-library/react-hooks': 6.0.0_react-dom@17.0.1+react@17.0.1
       '@testing-library/user-event': 13.2.1
       '@types/debug': 4.1.7
       '@types/jest': 26.0.23
@@ -1597,6 +1598,7 @@ importers:
     specifiers:
       '@codemod/parser': ^1.0.6
       '@testing-library/react': ^11.2.6
+      '@testing-library/react-hooks': ^6.0.0
       '@testing-library/user-event': ^13.2.1
       '@types/debug': ^4.1.7
       '@types/jest': ^26.0.23
@@ -8185,6 +8187,30 @@ packages:
       yarn: '>=1'
     resolution:
       integrity: sha512-N9Y82b2Z3j6wzIoAqajlKVF1Zt7sOH0pPee0sUHXHc5cv2Fdn23r+vpWm0MBBoGJtPOly5+Bdx1lnc3CD+A+ow==
+  /@testing-library/react-hooks/6.0.0_react-dom@17.0.1+react@17.0.1:
+    dependencies:
+      '@babel/runtime': 7.15.4
+      '@types/react': 17.0.22
+      '@types/react-dom': 17.0.9
+      '@types/react-test-renderer': 17.0.1
+      filter-console: 0.1.1
+      react: 17.0.1
+      react-dom: 17.0.1_react@17.0.1
+      react-error-boundary: 3.1.3_react@17.0.1
+    dev: true
+    engines:
+      node: '>=12'
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+      react-test-renderer: '>=16.9.0'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-test-renderer:
+        optional: true
+    resolution:
+      integrity: sha512-Y8ayCUFPiNttX9zmwP2bDv4uYzgsgOMHxAsOrD7th7Xuj1j1rHkxf+VzRqdr7zJlSeYPzl67754qAnZ9O1ahYg==
   /@testing-library/react/11.2.3_react-dom@17.0.1+react@17.0.1:
     dependencies:
       '@babel/runtime': 7.12.5
@@ -8759,6 +8785,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-lUqY7OlkF/RbNtD5nIq7ot8NquXrdFrjSOR6+w9a9RFQevGi1oZO1dcJbXMeONAPKtZ2UrZOEJ5UOCVsxbLk/g==
+  /@types/react-dom/17.0.9:
+    dependencies:
+      '@types/react': 17.0.22
+    dev: true
+    resolution:
+      integrity: sha512-wIvGxLfgpVDSAMH5utdL9Ngm5Owu0VsGmldro3ORLXV8CShrL8awVj06NuEXFQ5xyaYfdca7Sgbk/50Ri1GdPg==
   /@types/react-gamepad/1.0.0:
     dependencies:
       '@types/react': 17.0.0
@@ -8790,6 +8822,12 @@ packages:
       '@types/react': 17.0.13
     resolution:
       integrity: sha512-z3UlMG/x91SFEVmmvykk9FLTliDvfdIUky4k2rCfXWQ0NKbrP8o9BTCaCTPuYsB8gDkUnUmkcA2vYlm2DR+HAA==
+  /@types/react-test-renderer/17.0.1:
+    dependencies:
+      '@types/react': 17.0.22
+    dev: true
+    resolution:
+      integrity: sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==
   /@types/react/17.0.0:
     dependencies:
       '@types/prop-types': 15.7.3
@@ -8827,6 +8865,14 @@ packages:
     dev: false
     resolution:
       integrity: sha512-GzzXCpOthOjXvrAUFQwU/svyxu658cwu00Q9ugujS4qc1zXgLFaO0kS2SLOaMWLt2Jik781yuHCWB7UcYdGAeQ==
+  /@types/react/17.0.22:
+    dependencies:
+      '@types/prop-types': 15.7.4
+      '@types/scheduler': 0.16.2
+      csstype: 3.0.9
+    dev: true
+    resolution:
+      integrity: sha512-kq/BMeaAVLJM6Pynh8C2rnr/drCK+/5ksH0ch9asz+8FW3DscYCIEFtCeYTFeIx/ubvOsMXmRfy7qEJ76gM96A==
   /@types/react/17.0.4:
     dependencies:
       '@types/prop-types': 15.7.3
@@ -13394,7 +13440,6 @@ packages:
     resolution:
       integrity: sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==
   /csstype/3.0.9:
-    dev: false
     resolution:
       integrity: sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==
   /csv-writer/1.6.0:
@@ -17032,6 +17077,12 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+  /filter-console/0.1.1:
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-zrXoV1Uaz52DqPs+qEwNJWJFAWZpYJ47UNmpN9q4j+/EYsz85uV0DC9k8tRND5kYmoVzL0W+Y75q4Rg8sRJCdg==
   /finalhandler/1.1.2:
     dependencies:
       debug: 2.6.9
@@ -25162,6 +25213,18 @@ packages:
       react: '>= 16.8'
     resolution:
       integrity: sha512-EGSvK2CxFTuc28WxwuJCICyuYFX8b+sRumwU6Bs6sTbElV2HtQkT0d6C+HEee6XfbjiLIZ+Th9uji27rvo2wGw==
+  /react-error-boundary/3.1.3_react@17.0.1:
+    dependencies:
+      '@babel/runtime': 7.15.4
+      react: 17.0.1
+    dev: true
+    engines:
+      node: '>=10'
+      npm: '>=6'
+    peerDependencies:
+      react: '>=16.13.1'
+    resolution:
+      integrity: sha512-A+F9HHy9fvt9t8SNDlonq01prnU8AmkjvGKV4kk8seB9kU3xMEO8J/PQlLVmoOIDODl5U2kufSBs4vrWIqhsAA==
   /react-error-overlay/6.0.8:
     dev: false
     resolution:


### PR DESCRIPTION
- always set the inner value when initializing; re-initializing because of a storage change should re-pull the value as the inner value is just a cache
- the setter function should not depend on the cached value, since we'd like it to behave like a `useState` setter that is stable over time regardless of the state value
- correct the type of the setter function to return `void`
- bring the name of the cached value in line with its setter function