### PR TITLE
fix(ps) fix bug with admin screen relocking unneccessarily

### DIFF
--- a/apps/precinct-scanner/src/AppRoot.tsx
+++ b/apps/precinct-scanner/src/AppRoot.tsx
@@ -306,13 +306,20 @@ const appReducer = (state: State, action: AppAction): State => {
         ...state,
         invalidCardPresent: true,
       }
-    case 'processAdminCard':
+    case 'processAdminCard': {
+      const persistAuthenticatedState =
+        state.currentUserSession?.type === 'admin' &&
+        state.currentUserSession.authenticated
       return {
         ...state,
-        currentUserSession: { type: 'admin', authenticated: false },
+        currentUserSession: {
+          type: 'admin',
+          authenticated: persistAuthenticatedState,
+        },
         invalidCardPresent: false,
         adminCardElectionHash: action.electionHash,
       }
+    }
     case 'processPollWorkerCard':
       return {
         ...state,


### PR DESCRIPTION
When doing things like changing the election or from testing to live mode in precinct scanner the admin card sometimes gets reprocessed and this was resetting the authentication state back to false even when we had already authenticated, making the user enter the PIN again. This fixes that bug by persisting the authenticated state as long as the admin card stays inserted. 