### PR TITLE
fix(ui) make TallyReportSummary order consistent

### DIFF
--- a/libs/ui/src/TallyReportSummary.tsx
+++ b/libs/ui/src/TallyReportSummary.tsx
@@ -35,7 +35,10 @@ export const TallyReportSummary = ({
       <h3>Ballots by Voting Method</h3>
       <Table data-testid="voting-method-table">
         <tbody>
-          {Object.keys(ballotCountsByVotingMethod).map((votingMethod) => {
+          {Object.values(VotingMethod).map((votingMethod: VotingMethod) => {
+            if (!(votingMethod in ballotCountsByVotingMethod)) {
+              return null
+            }
             // Hide the "Other" row when it does not apply to any CVRs
             if (
               votingMethod === VotingMethod.Unknown &&
@@ -45,7 +48,7 @@ export const TallyReportSummary = ({
             }
             return (
               <tr key={votingMethod} data-testid={votingMethod}>
-                <TD>{getLabelForVotingMethod(votingMethod as VotingMethod)}</TD>
+                <TD>{getLabelForVotingMethod(votingMethod)}</TD>
                 <TD textAlign="right">
                   {format.count(
                     ballotCountsByVotingMethod[votingMethod] ??


### PR DESCRIPTION
I noticed in testing that whether we show absentee or precinct ballots first in the Ballots by Voting Method tables on the Tally Report is inconsistent. This is because we were using the order of the given dictionary of values which could be in any order. This updates to instead use the order from the enum VotingMethod so that it stays in a consistent order. 