### PR TITLE
feat(ui): improve `NumberPad`

### DIFF
--- a/apps/bsd/src/screens/UnlockMachineScreen.tsx
+++ b/apps/bsd/src/screens/UnlockMachineScreen.tsx
@@ -1,5 +1,5 @@
 import { fontSizeTheme, Prose, Text, NumberPad } from '@votingworks/ui'
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import styled from 'styled-components'
 import Screen from '../components/Screen'
 import Main, { MainChild } from '../components/Main'
@@ -33,21 +33,23 @@ export const UnlockMachineScreen = ({
 }: Props): JSX.Element => {
   const [currentPasscode, setCurrentPasscode] = useState('')
   const [showError, setShowError] = useState(false)
-  const handleNumberEntry = (passcodeNumber: string) => {
-    if (currentPasscode.length >= GLOBALS.SECURITY_PIN_LENGTH) {
-      // do nothing
-      return
-    }
-    setCurrentPasscode((prev) => prev + passcodeNumber)
-  }
+  const handleNumberEntry = useCallback((digit: number) => {
+    setCurrentPasscode((prev) =>
+      `${prev}${digit}`.slice(0, GLOBALS.SECURITY_PIN_LENGTH)
+    )
+  }, [])
+  const handleBackspace = useCallback(() => {
+    setCurrentPasscode((prev) => prev.slice(0, -1))
+  }, [])
+  const handleClear = useCallback(() => {
+    setCurrentPasscode('')
+  }, [])
 
   useEffect(() => {
     if (currentPasscode.length === GLOBALS.SECURITY_PIN_LENGTH) {
       const success = attemptToAuthenticateUser(currentPasscode)
-      if (!success) {
-        setShowError(true)
-        setCurrentPasscode('')
-      }
+      setShowError(!success)
+      setCurrentPasscode('')
     }
   }, [currentPasscode, attemptToAuthenticateUser])
 
@@ -71,7 +73,11 @@ export const UnlockMachineScreen = ({
             {primarySentence}
             <EnteredCode>{currentPasscodeDisplayString}</EnteredCode>
             <NumberPadWrapper>
-              <NumberPad onButtonPress={handleNumberEntry} />
+              <NumberPad
+                onButtonPress={handleNumberEntry}
+                onBackspace={handleBackspace}
+                onClear={handleClear}
+              />
             </NumberPadWrapper>
           </Prose>
         </MainChild>

--- a/apps/election-manager/src/screens/SmartcardsScreen.tsx
+++ b/apps/election-manager/src/screens/SmartcardsScreen.tsx
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert'
-import React, { useContext, useState } from 'react'
+import React, { useCallback, useContext, useState } from 'react'
 
 import { NumberPad, useCancelablePromise } from '@votingworks/ui'
 import styled from 'styled-components'
@@ -101,13 +101,19 @@ const DefinitionScreen = (): JSX.Element => {
     setIsPromptingForAdminPasscode(true)
   }
 
-  const addNumberToPin = (passcode: string) => {
-    if (currentPasscode.length >= SECURITY_PIN_LENGTH) {
-      // do nothing
-      return
-    }
-    setCurrentPasscode((prev) => prev + passcode)
-  }
+  const addNumberToPin = useCallback((digit: number) => {
+    setCurrentPasscode((prev) =>
+      prev.length >= SECURITY_PIN_LENGTH ? prev : `${prev}${digit}`
+    )
+  }, [])
+
+  const deleteFromEndOfPin = useCallback(() => {
+    setCurrentPasscode((prev) => prev.slice(0, -1))
+  }, [])
+
+  const clearPin = useCallback(() => {
+    setCurrentPasscode('')
+  }, [])
 
   // Add hyphens for any missing digits in the pin and separate all characters with a space.
   const pinDisplayString = currentPasscode
@@ -170,7 +176,11 @@ const DefinitionScreen = (): JSX.Element => {
               <h1>Create Card Security Code</h1>
               <Passcode>{pinDisplayString}</Passcode>
               <NumberPadWrapper>
-                <NumberPad onButtonPress={addNumberToPin} />
+                <NumberPad
+                  onButtonPress={addNumberToPin}
+                  onBackspace={deleteFromEndOfPin}
+                  onClear={clearPin}
+                />
               </NumberPadWrapper>
               <p>This code will be required when using the new card.</p>
             </Prose>

--- a/apps/election-manager/src/screens/UnlockMachineScreen.test.tsx
+++ b/apps/election-manager/src/screens/UnlockMachineScreen.test.tsx
@@ -1,0 +1,90 @@
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import renderInAppContext from '../../test/renderInAppContext'
+import { UnlockMachineScreen } from './UnlockMachineScreen'
+
+test('authentication', async () => {
+  const attemptToAuthenticateUser = jest.fn()
+
+  renderInAppContext(<UnlockMachineScreen />, { attemptToAuthenticateUser })
+  screen.getByText('- - - - - -')
+
+  // set up a failed attempt
+  attemptToAuthenticateUser.mockReturnValueOnce(false)
+
+  userEvent.click(screen.getByText('0'))
+  screen.getByText('• - - - - -')
+
+  userEvent.click(screen.getByText('✖'))
+  screen.getByText('- - - - - -')
+
+  userEvent.click(screen.getByText('0'))
+  screen.getByText('• - - - - -')
+
+  userEvent.click(screen.getByText('1'))
+  screen.getByText('• • - - - -')
+
+  userEvent.click(screen.getByText('2'))
+  screen.getByText('• • • - - -')
+
+  userEvent.click(screen.getByText('3'))
+  screen.getByText('• • • • - -')
+
+  userEvent.click(screen.getByText('4'))
+  screen.getByText('• • • • • -')
+
+  userEvent.click(screen.getByText('⌫'))
+  screen.getByText('• • • • - -')
+
+  userEvent.click(screen.getByText('4'))
+  screen.getByText('• • • • • -')
+
+  userEvent.click(screen.getByText('5'))
+  screen.getByText('• • • • • •')
+
+  await waitFor(() =>
+    expect(attemptToAuthenticateUser).toHaveBeenNthCalledWith(1, '012345')
+  )
+
+  screen.getByText('Invalid code. Please try again.')
+
+  // set up a successful attempt
+  attemptToAuthenticateUser.mockReturnValueOnce(true)
+
+  for (let i = 0; i < 6; i += 1) {
+    userEvent.click(screen.getByText('0'))
+  }
+
+  await waitFor(() =>
+    expect(attemptToAuthenticateUser).toHaveBeenNthCalledWith(2, '000000')
+  )
+
+  expect(screen.queryByText('Invalid code. Please try again.')).toBeNull()
+})
+
+test('factory reset', async () => {
+  const attemptToAuthenticateUser = jest.fn()
+  const saveElection = jest.fn()
+
+  renderInAppContext(<UnlockMachineScreen />, {
+    attemptToAuthenticateUser,
+    saveElection,
+  })
+
+  attemptToAuthenticateUser.mockReturnValueOnce(false)
+
+  userEvent.click(screen.getByText('3'))
+  userEvent.click(screen.getByText('1'))
+  userEvent.click(screen.getByText('4'))
+  userEvent.click(screen.getByText('1'))
+  userEvent.click(screen.getByText('5'))
+  userEvent.click(screen.getByText('9'))
+
+  await waitFor(() =>
+    expect(attemptToAuthenticateUser).toHaveBeenNthCalledWith(1, '314159')
+  )
+
+  userEvent.click(screen.getByText('Factory Reset'))
+  expect(saveElection).toHaveBeenCalledWith(undefined)
+})

--- a/apps/precinct-scanner/src/screens/UnlockAdminScreen.test.tsx
+++ b/apps/precinct-scanner/src/screens/UnlockAdminScreen.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import UnlockAdminScreen from './UnlockAdminScreen'
+
+test('authentication', async () => {
+  const attemptToAuthenticateUser = jest.fn()
+
+  render(
+    <UnlockAdminScreen attemptToAuthenticateUser={attemptToAuthenticateUser} />
+  )
+  screen.getByText('- - - - - -')
+
+  // set up a failed attempt
+  attemptToAuthenticateUser.mockReturnValueOnce(false)
+
+  userEvent.click(screen.getByText('0'))
+  screen.getByText('• - - - - -')
+
+  userEvent.click(screen.getByText('✖'))
+  screen.getByText('- - - - - -')
+
+  userEvent.click(screen.getByText('0'))
+  screen.getByText('• - - - - -')
+
+  userEvent.click(screen.getByText('1'))
+  screen.getByText('• • - - - -')
+
+  userEvent.click(screen.getByText('2'))
+  screen.getByText('• • • - - -')
+
+  userEvent.click(screen.getByText('3'))
+  screen.getByText('• • • • - -')
+
+  userEvent.click(screen.getByText('4'))
+  screen.getByText('• • • • • -')
+
+  userEvent.click(screen.getByText('⌫'))
+  screen.getByText('• • • • - -')
+
+  userEvent.click(screen.getByText('4'))
+  screen.getByText('• • • • • -')
+
+  userEvent.click(screen.getByText('5'))
+  screen.getByText('• • • • • •')
+
+  await waitFor(() =>
+    expect(attemptToAuthenticateUser).toHaveBeenNthCalledWith(1, '012345')
+  )
+
+  screen.getByText('Invalid code. Please try again.')
+
+  // set up a successful attempt
+  attemptToAuthenticateUser.mockReturnValueOnce(true)
+
+  for (let i = 0; i < 6; i += 1) {
+    userEvent.click(screen.getByText('0'))
+  }
+
+  await waitFor(() =>
+    expect(attemptToAuthenticateUser).toHaveBeenNthCalledWith(2, '000000')
+  )
+
+  expect(screen.queryByText('Invalid code. Please try again.')).toBeNull()
+})

--- a/libs/ui/src/NumberPad.test.tsx
+++ b/libs/ui/src/NumberPad.test.tsx
@@ -1,32 +1,109 @@
 import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import { NumberPad } from './NumberPad'
 
-test('Click all pad buttons', () => {
-  const onPress = jest.fn()
-  const { container, getByText } = render(<NumberPad onButtonPress={onPress} />)
-  const button0 = getByText('0')
-  fireEvent.click(button0)
-  const button1 = getByText('1')
-  fireEvent.click(button1)
-  const button2 = getByText('2')
-  fireEvent.click(button2)
-  const button3 = getByText('3')
-  fireEvent.click(button3)
-  const button4 = getByText('4')
-  fireEvent.click(button4)
-  const button5 = getByText('5')
-  fireEvent.click(button5)
-  const button6 = getByText('6')
-  fireEvent.click(button6)
-  const button7 = getByText('7')
-  fireEvent.click(button7)
-  const button8 = getByText('8')
-  fireEvent.click(button8)
-  const button9 = getByText('9')
-  fireEvent.click(button9)
-  expect(onPress).toHaveBeenCalledTimes(10)
+test('snapshot', () => {
+  const { container } = render(
+    <NumberPad
+      onButtonPress={jest.fn()}
+      onBackspace={jest.fn()}
+      onClear={jest.fn()}
+    />
+  )
 
   expect(container.firstChild).toMatchSnapshot()
+})
+
+test('click all pad buttons', () => {
+  const onPress = jest.fn()
+  const onBackspace = jest.fn()
+  const onClear = jest.fn()
+  const { getByText } = render(
+    <NumberPad
+      onButtonPress={onPress}
+      onBackspace={onBackspace}
+      onClear={onClear}
+    />
+  )
+  const button0 = getByText('0')
+  userEvent.click(button0)
+  const button1 = getByText('1')
+  userEvent.click(button1)
+  const button2 = getByText('2')
+  userEvent.click(button2)
+  const button3 = getByText('3')
+  userEvent.click(button3)
+  const button4 = getByText('4')
+  userEvent.click(button4)
+  const button5 = getByText('5')
+  userEvent.click(button5)
+  const button6 = getByText('6')
+  userEvent.click(button6)
+  const button7 = getByText('7')
+  userEvent.click(button7)
+  const button8 = getByText('8')
+  userEvent.click(button8)
+  const button9 = getByText('9')
+  userEvent.click(button9)
+  for (let digit = 0; digit <= 9; digit += 1) {
+    expect(onPress).toHaveBeenCalledWith(digit)
+  }
+  expect(onPress).toHaveBeenCalledTimes(10)
+
+  const backspaceButton = getByText('⌫')
+  userEvent.click(backspaceButton)
+  expect(onBackspace).toHaveBeenCalledTimes(1)
+
+  const clearButton = getByText('✖')
+  userEvent.click(clearButton)
+  expect(onClear).toHaveBeenCalledTimes(1)
+})
+
+test('keyboard interaction', async () => {
+  const onPress = jest.fn()
+  const onBackspace = jest.fn()
+  const onClear = jest.fn()
+  const { container } = render(
+    <NumberPad
+      onButtonPress={onPress}
+      onBackspace={onBackspace}
+      onClear={onClear}
+    />
+  )
+  container.focus()
+
+  // FIXME: It'd be great to use `userEvent.keyboard`, but it doesn't work.
+  // Maybe because the focused element is a `div`? But if it has a tab index
+  // then it should work? ¯\_(ツ)_/¯
+  //
+  //   userEvent.keyboard('0123456789')
+  //
+  for (let digit = 0; digit <= 9; digit += 1) {
+    fireEvent.keyPress(document.activeElement ?? document.body, {
+      key: `${digit}`,
+      charCode: 49 + digit,
+    })
+  }
+
+  for (let digit = 0; digit <= 9; digit += 1) {
+    expect(onPress).toHaveBeenCalledWith(digit)
+  }
+
+  expect(onPress).toHaveBeenCalledTimes(10)
+
+  fireEvent.keyDown(document.activeElement ?? document.body, {
+    key: 'Backspace',
+  })
+
+  expect(onBackspace).toHaveBeenCalledTimes(1)
+
+  // NOTE: Similar to above, I'd expect to use `userEvent.keyboard('x')`.
+  fireEvent.keyPress(document.activeElement ?? document.body, {
+    key: 'x',
+    charCode: 120,
+  })
+
+  expect(onClear).toHaveBeenCalledTimes(1)
 })

--- a/libs/ui/src/NumberPad.tsx
+++ b/libs/ui/src/NumberPad.tsx
@@ -13,39 +13,88 @@ export const NumberPadContainer = styled.div`
 `
 
 const DIGITS = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
-interface NumberPadProps {
-  onButtonPress: (buttonValue: string) => void
+export interface NumberPadProps {
+  onButtonPress: (buttonValue: number) => void
+  onBackspace: () => void
+  onClear: () => void
 }
 
-export const NumberPad = ({ onButtonPress }: NumberPadProps): JSX.Element => {
+export const NumberPad = ({
+  onButtonPress,
+  onBackspace,
+  onClear,
+}: NumberPadProps): JSX.Element => {
   const container = useRef<HTMLDivElement>(null)
-  const onKeyPress = useCallback(
-    (event: React.KeyboardEvent) => {
+  const onKeyPress: React.KeyboardEventHandler = useCallback(
+    (event) => {
       if (DIGITS.includes(event.key)) {
-        onButtonPress(event.key)
+        onButtonPress(Number(event.key))
+      } else if (event.key === 'x') {
+        onClear()
       }
     },
-    [onButtonPress]
+    [onButtonPress, onClear]
+  )
+  const onKeyDown: React.KeyboardEventHandler = useCallback(
+    (event) => {
+      if (event.key === 'Backspace') {
+        onBackspace()
+      }
+    },
+    [onBackspace]
   )
 
   useEffect(() => {
-    if (container.current) {
-      container.current.focus()
-    }
-  }, [container])
+    container.current?.focus()
+  }, [])
 
   return (
-    <NumberPadContainer tabIndex={0} ref={container} onKeyPress={onKeyPress}>
-      <Button onPress={() => onButtonPress('1')}>1</Button>
-      <Button onPress={() => onButtonPress('2')}>2</Button>
-      <Button onPress={() => onButtonPress('3')}>3</Button>
-      <Button onPress={() => onButtonPress('4')}>4</Button>
-      <Button onPress={() => onButtonPress('5')}>5</Button>
-      <Button onPress={() => onButtonPress('6')}>6</Button>
-      <Button onPress={() => onButtonPress('7')}>7</Button>
-      <Button onPress={() => onButtonPress('8')}>8</Button>
-      <Button onPress={() => onButtonPress('9')}>9</Button>
-      <Button onPress={() => onButtonPress('0')}>0</Button>
+    <NumberPadContainer
+      tabIndex={0}
+      ref={container}
+      onKeyPress={onKeyPress}
+      onKeyDown={onKeyDown}
+    >
+      <Button onPress={useCallback(() => onButtonPress(1), [onButtonPress])}>
+        1
+      </Button>
+      <Button onPress={useCallback(() => onButtonPress(2), [onButtonPress])}>
+        2
+      </Button>
+      <Button onPress={useCallback(() => onButtonPress(3), [onButtonPress])}>
+        3
+      </Button>
+      <Button onPress={useCallback(() => onButtonPress(4), [onButtonPress])}>
+        4
+      </Button>
+      <Button onPress={useCallback(() => onButtonPress(5), [onButtonPress])}>
+        5
+      </Button>
+      <Button onPress={useCallback(() => onButtonPress(6), [onButtonPress])}>
+        6
+      </Button>
+      <Button onPress={useCallback(() => onButtonPress(7), [onButtonPress])}>
+        7
+      </Button>
+      <Button onPress={useCallback(() => onButtonPress(8), [onButtonPress])}>
+        8
+      </Button>
+      <Button onPress={useCallback(() => onButtonPress(9), [onButtonPress])}>
+        9
+      </Button>
+      <Button onPress={onClear}>
+        <span role="img" aria-label="clear">
+          ✖
+        </span>
+      </Button>
+      <Button onPress={useCallback(() => onButtonPress(0), [onButtonPress])}>
+        0
+      </Button>
+      <Button onPress={onBackspace}>
+        <span role="img" aria-label="backspace">
+          ⌫
+        </span>
+      </Button>
     </NumberPadContainer>
   )
 }

--- a/libs/ui/src/__snapshots__/NumberPad.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/NumberPad.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Click all pad buttons 1`] = `
+exports[`snapshot 1`] = `
 <div
   class="sc-eCImvq htBhMB"
   tabindex="0"
@@ -63,7 +63,29 @@ exports[`Click all pad buttons 1`] = `
     class="sc-gsDJrp dmKzwC"
     type="button"
   >
+    <span
+      aria-label="clear"
+      role="img"
+    >
+      ✖
+    </span>
+  </button>
+  <button
+    class="sc-gsDJrp dmKzwC"
+    type="button"
+  >
     0
+  </button>
+  <button
+    class="sc-gsDJrp dmKzwC"
+    type="button"
+  >
+    <span
+      aria-label="backspace"
+      role="img"
+    >
+      ⌫
+    </span>
   </button>
 </div>
 `;


### PR DESCRIPTION


https://user-images.githubusercontent.com/1938/134229314-90e64b8b-38d4-4575-8617-fa08a86a275e.mov



- Uses a bullet `•`, instead of an asterisk, like password fields do.
- Adds backspace and clear buttons plus keyboard handling for both (backspace and 'x', respectively).
- Adds tests for keyboard interactions.