### PR TITLE
LinkButton Regression

### DIFF
--- a/apps/bmd/src/pages/ReviewPage.tsx
+++ b/apps/bmd/src/pages/ReviewPage.tsx
@@ -149,7 +149,7 @@ const ScrollableContentWrapper = styled.div<Scrollable>`
       : undefined};
 `
 
-const Contest = styled(LinkButton)`
+const Contest = styled.button`
   display: flex;
   align-items: center;
   margin-bottom: 0.75rem;
@@ -407,7 +407,8 @@ const ReviewPage = (): JSX.Element => {
           >
             <ScrollableContentWrapper isScrollable={isScrollable}>
               {contests.map((contest, i) => (
-                <Contest
+                <LinkButton
+                  component={Contest}
                   id={`contest-${contest.id}`}
                   key={contest.id}
                   to={`/contests/${i}#review`}
@@ -450,7 +451,7 @@ const ReviewPage = (): JSX.Element => {
                       Change
                     </DecoyButton>
                   </ContestActions>
-                </Contest>
+                </LinkButton>
               ))}
             </ScrollableContentWrapper>
           </ScrollContainer>

--- a/libs/ui/src/LinkButton.tsx
+++ b/libs/ui/src/LinkButton.tsx
@@ -1,12 +1,11 @@
 import React from 'react'
 import { RouteComponentProps, withRouter } from 'react-router-dom'
 import { EventTargetFunction } from '@votingworks/types'
-import { Button, ButtonInterface } from './Button'
+import { Button, ButtonProps } from './Button'
 
 export interface LinkButtonProps
-  extends ButtonInterface,
-    RouteComponentProps<Record<string, string | undefined>>,
-    React.PropsWithoutRef<JSX.IntrinsicElements['button']> {
+  extends Omit<ButtonProps, 'onPress'>,
+    RouteComponentProps<Record<string, string | undefined>> {
   goBack?: boolean
   onPress?: EventTargetFunction
   primary?: boolean


### PR DESCRIPTION
Fixes regression caused by css cascade change which occurred when moving components to UI lib. 

![image](https://user-images.githubusercontent.com/28444/134437984-f01986e9-ed5c-42fc-ab75-c11b04ee1c0c.png)