### PR TITLE
fix: reenable printing for test deck in BMD.

### DIFF
--- a/apps/bmd/src/AppRoot.tsx
+++ b/apps/bmd/src/AppRoot.tsx
@@ -1252,6 +1252,7 @@ const AppRoot = ({
         toggleLiveMode={toggleLiveMode}
         unconfigure={unconfigure}
         machineConfig={machineConfig}
+        printer={printer}
       />
     )
   }

--- a/apps/bmd/src/pages/AdminScreen.test.tsx
+++ b/apps/bmd/src/pages/AdminScreen.test.tsx
@@ -7,6 +7,7 @@ import { fakeKiosk } from '@votingworks/test-utils'
 import { render } from '../../test/testUtils'
 import { election, defaultPrecinctId } from '../../test/helpers/election'
 
+import fakePrinter from '../../test/helpers/fakePrinter'
 import { advanceTimers } from '../../test/helpers/smartcards'
 
 import AdminScreen from './AdminScreen'
@@ -44,6 +45,7 @@ test('renders ClerkScreen for VxPrintOnly', async () => {
         appMode: VxPrintOnly,
         codeVersion: '', // Override default
       })}
+      printer={fakePrinter()}
     />
   )
 
@@ -87,6 +89,7 @@ test('renders date and time settings modal', async () => {
         appMode: VxMarkOnly,
         codeVersion: 'test',
       })}
+      printer={fakePrinter()}
     />
   )
 
@@ -231,6 +234,7 @@ test('select All Precincts', async () => {
       toggleLiveMode={jest.fn()}
       unconfigure={jest.fn()}
       machineConfig={fakeMachineConfig()}
+      printer={fakePrinter()}
     />
   )
 
@@ -259,6 +263,7 @@ test('render All Precincts', async () => {
       toggleLiveMode={jest.fn()}
       unconfigure={jest.fn()}
       machineConfig={fakeMachineConfig()}
+      printer={fakePrinter()}
     />
   )
 

--- a/apps/bmd/src/pages/AdminScreen.tsx
+++ b/apps/bmd/src/pages/AdminScreen.tsx
@@ -2,7 +2,7 @@ import { DateTime } from 'luxon'
 import React, { useCallback, useState } from 'react'
 
 import { ElectionDefinition } from '@votingworks/types'
-import { formatFullDateTimeZone } from '@votingworks/utils'
+import { formatFullDateTimeZone, Printer } from '@votingworks/utils'
 import {
   Button,
   Main,
@@ -39,6 +39,7 @@ interface Props {
   toggleLiveMode: VoidFunction
   unconfigure: () => Promise<void>
   machineConfig: MachineConfig
+  printer: Printer
 }
 
 const ALL_PRECINCTS_OPTION_VALUE = '_ALL'
@@ -53,6 +54,7 @@ const AdminScreen = ({
   toggleLiveMode,
   unconfigure,
   machineConfig,
+  printer,
 }: Props): JSX.Element => {
   const election = electionDefinition?.election
   const changeAppPrecinctId: SelectChangeEventFunction = (event) => {
@@ -106,6 +108,7 @@ const AdminScreen = ({
         hideTestDeck={hideTestDeck}
         machineConfig={machineConfig}
         isLiveMode={false} // always false for Test Mode
+        printer={printer}
       />
     )
   }

--- a/apps/bmd/src/pages/AdminScreen.tsx
+++ b/apps/bmd/src/pages/AdminScreen.tsx
@@ -191,8 +191,7 @@ const AdminScreen = ({
                     </p>
                     <Text as="h1">Stats</Text>
                     <Text>
-                      Printed and Tallied Ballots:{' '}
-                      <strong>{ballotsPrintedCount}</strong>{' '}
+                      Printed Ballots: <strong>{ballotsPrintedCount}</strong>{' '}
                     </Text>
                   </React.Fragment>
                 )}
@@ -258,8 +257,7 @@ const AdminScreen = ({
           <Prose>
             <h2>Instructions</h2>
             <p>
-              Switching Precinct or Live Mode will reset tally and printed
-              ballots count.
+              Switching Precinct or Live Mode will reset printed ballots count.
             </p>
             <p>Remove card when finished.</p>
           </Prose>

--- a/apps/bmd/src/pages/TestBallotDeckScreen.test.tsx
+++ b/apps/bmd/src/pages/TestBallotDeckScreen.test.tsx
@@ -35,8 +35,8 @@ it('renders test decks appropriately', async () => {
         appMode: VxPrintOnly,
       })}
       isLiveMode={false}
-    />,
-    { printer }
+      printer={printer}
+    />
   )
 
   fireEvent.click(screen.getByText('All Precincts'))
@@ -86,6 +86,7 @@ it('shows printer not connected when appropriate', async () => {
       })}
       hideTestDeck={jest.fn()}
       isLiveMode={false}
+      printer={fakePrinter()}
     />
   )
 

--- a/apps/bmd/src/pages/TestBallotDeckScreen.tsx
+++ b/apps/bmd/src/pages/TestBallotDeckScreen.tsx
@@ -1,9 +1,9 @@
-import React, { useContext, useState } from 'react'
+import React, { useState } from 'react'
 import pluralize from 'pluralize'
 
 import { VotesDict, Election, ElectionDefinition } from '@votingworks/types'
 import { Button, ButtonList, Loading, Main, MainChild } from '@votingworks/ui'
-import { find, throwIllegalValue } from '@votingworks/utils'
+import { find, throwIllegalValue, Printer } from '@votingworks/utils'
 
 import {
   EventTargetFunction,
@@ -18,7 +18,6 @@ import Sidebar from '../components/Sidebar'
 import Screen from '../components/Screen'
 import Modal from '../components/Modal'
 import { TEST_DECK_PRINTING_TIMEOUT_SECONDS } from '../config/globals'
-import BallotContext from '../contexts/ballotContext'
 
 interface Ballot {
   ballotId?: string
@@ -111,6 +110,7 @@ interface Props {
   hideTestDeck: () => void
   isLiveMode: boolean
   machineConfig: MachineConfig
+  printer: Printer
 }
 
 const initialPrecinct: Precinct = { id: '', name: '' }
@@ -121,8 +121,8 @@ const TestBallotDeckScreen = ({
   hideTestDeck,
   isLiveMode,
   machineConfig,
+  printer,
 }: Props): JSX.Element => {
-  const { printer } = useContext(BallotContext)
   const { election } = electionDefinition
   const [ballots, setBallots] = useState<Ballot[]>([])
   const [precinct, setPrecinct] = useState<Precinct>(initialPrecinct)


### PR DESCRIPTION
Printing the test deck was not working in BMD.

A refactor in July moved test deck printing to using the ballot context... but the admin screen and thus the test deck is never rendered with a ballot context, and I suspect there is a debate as to whether there should be a ballot context around the admin screen -- rather than solve that larger question, made a more surgical fix here by passing down `printer` into `AdminScreen` and then `TestBallotDeckScreen`, which is still better than what we had prior to July cause we can still dependency-inject, but maybe not as good as if we had a context.