### PR TITLE
fix(scan): reject mismatched pages

### DIFF
--- a/apps/module-scan/src/interpreter.ts
+++ b/apps/module-scan/src/interpreter.ts
@@ -37,10 +37,6 @@ import { loadImageData } from './util/images'
 import optionMarkStatus from './util/optionMarkStatus'
 import { time } from './util/perf'
 import { detectQRCode } from './util/qrcode'
-import {
-  describeValidationError,
-  validateSheetInterpretation,
-} from './validation'
 import * as qrcodeWorker from './workers/qrcode'
 
 const debug = makeDebug('module-scan:interpreter')
@@ -143,16 +139,7 @@ export function sheetRequiresAdjudication([
     return true
   }
 
-  const validationResult = validateSheetInterpretation([front, back])
-
-  if (validationResult.isErr()) {
-    debug(
-      'sheet failed validation: %s',
-      describeValidationError(validationResult.err())
-    )
-  }
-
-  return validationResult.isErr()
+  return false
 }
 
 export interface InterpreterOptions {


### PR DESCRIPTION
I attempted to do this with #589, but that merely triggered the need for adjudication of the sheet. Depending on what other reasons something might have for being adjudicated it could sneak through. Now when the sheet is about to be imported we validate it. If it doesn't pass, the interpretation will be replaced with `UnreadablePage` for both sheets, rendering it impossible to export.

Fixes #941