### PR TITLE
feat(ps/bsd) add clearer text after ejecting usb when exporting

### DIFF
--- a/apps/bsd/src/components/ExportResultsModal.tsx
+++ b/apps/bsd/src/components/ExportResultsModal.tsx
@@ -139,19 +139,22 @@ const ExportResultsModal = ({
   }
 
   if (currentState === ModalState.DONE) {
-    let actions = (
-      <React.Fragment>
-        <LinkButton onPress={onClose}>Cancel</LinkButton>
-        <USBControllerButton
-          small={false}
-          primary
-          usbDriveStatus={usbDriveStatus}
-          usbDriveEject={usbDriveEject}
-        />
-      </React.Fragment>
-    )
     if (usbDriveStatus === usbstick.UsbDriveStatus.recentlyEjected) {
-      actions = <LinkButton onPress={onClose}>Close</LinkButton>
+      return (
+        <Modal
+          content={
+            <Prose>
+              <h1>Download Complete</h1>
+              <p>
+                USB drive successfully ejected, you may now take it to VxAdmin
+                for tabulation.
+              </p>
+            </Prose>
+          }
+          onOverlayClick={onClose}
+          actions={<Button onPress={onClose}>Close</Button>}
+        />
+      )
     }
     return (
       <Modal
@@ -160,12 +163,22 @@ const ExportResultsModal = ({
             <h1>Download Complete</h1>
             <p>
               CVR results file saved successfully! You may now eject the USB
-              drive and take it to Election Manager for tabulation.
+              drive and take it to VxAdmin for tabulation.
             </p>
           </Prose>
         }
         onOverlayClick={onClose}
-        actions={actions}
+        actions={
+          <React.Fragment>
+            <LinkButton onPress={onClose}>Cancel</LinkButton>
+            <USBControllerButton
+              small={false}
+              primary
+              usbDriveStatus={usbDriveStatus}
+              usbDriveEject={usbDriveEject}
+            />
+          </React.Fragment>
+        }
       />
     )
   }

--- a/apps/precinct-scanner/src/components/ExportBackupModal.test.tsx
+++ b/apps/precinct-scanner/src/components/ExportBackupModal.test.tsx
@@ -74,7 +74,7 @@ test('render export modal when a USB drive is mounted as expected and allows cus
   mocked(download).mockResolvedValueOnce(ok())
 
   const closeFn = jest.fn()
-  render(
+  const { rerender } = render(
     <AppContext.Provider
       value={{ electionDefinition: electionSampleDefinition, machineConfig }}
     >
@@ -96,6 +96,17 @@ test('render export modal when a USB drive is mounted as expected and allows cus
 
   fireEvent.click(screen.getByText('Cancel'))
   expect(closeFn).toHaveBeenCalled()
+  rerender(
+    <AppContext.Provider
+      value={{ electionDefinition: electionSampleDefinition, machineConfig }}
+    >
+      <ExportBackupModal
+        onClose={closeFn}
+        usbDrive={{ status: UsbDriveStatus.recentlyEjected, eject: jest.fn() }}
+      />
+    </AppContext.Provider>
+  )
+  screen.getByText('USB drive successfully ejected.')
 })
 
 test('render export modal when a USB drive is mounted as expected and allows automatic export', async () => {

--- a/apps/precinct-scanner/src/components/ExportBackupModal.tsx
+++ b/apps/precinct-scanner/src/components/ExportBackupModal.tsx
@@ -113,20 +113,19 @@ const ExportBackupModal = ({ onClose, usbDrive }: Props): JSX.Element => {
   }
 
   if (currentState === ModalState.DONE) {
-    let actions = (
-      <React.Fragment>
-        <Button onPress={onClose}>Cancel</Button>
-        <USBControllerButton
-          small={false}
-          primary
-          usbDriveStatus={usbDrive.status ?? usbstick.UsbDriveStatus.absent}
-          usbDriveEject={usbDrive.eject}
-        />
-      </React.Fragment>
-    )
-
     if (usbDrive.status === usbstick.UsbDriveStatus.recentlyEjected) {
-      actions = <Button onPress={onClose}>Close</Button>
+      return (
+        <Modal
+          content={
+            <Prose>
+              <h1>Download Complete</h1>
+              <p>USB drive successfully ejected.</p>
+            </Prose>
+          }
+          onOverlayClick={onClose}
+          actions={<Button onPress={onClose}>Close</Button>}
+        />
+      )
     }
 
     return (
@@ -140,7 +139,17 @@ const ExportBackupModal = ({ onClose, usbDrive }: Props): JSX.Element => {
           </Prose>
         }
         onOverlayClick={onClose}
-        actions={actions}
+        actions={
+          <React.Fragment>
+            <Button onPress={onClose}>Cancel</Button>
+            <USBControllerButton
+              small={false}
+              primary
+              usbDriveStatus={usbDrive.status ?? usbstick.UsbDriveStatus.absent}
+              usbDriveEject={usbDrive.eject}
+            />
+          </React.Fragment>
+        }
       />
     )
   }

--- a/apps/precinct-scanner/src/components/ExportResultsModal.test.tsx
+++ b/apps/precinct-scanner/src/components/ExportResultsModal.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { render, fireEvent, waitFor } from '@testing-library/react'
+import fileDownload from 'js-file-download'
 import {
   electionSampleDefinition as electionDefinition,
   electionSampleDefinition,
@@ -126,7 +127,7 @@ test('render export modal when a usb drive is mounted as expected and allows aut
 
   const closeFn = jest.fn()
   const ejectFn = jest.fn()
-  const { getByText } = render(
+  const { getByText, rerender } = render(
     <AppContext.Provider
       value={{ electionDefinition: electionSampleDefinition, machineConfig }}
     >
@@ -170,6 +171,23 @@ test('render export modal when a usb drive is mounted as expected and allows aut
   expect(ejectFn).toHaveBeenCalled()
   fireEvent.click(getByText('Cancel'))
   expect(closeFn).toHaveBeenCalled()
+
+  rerender(
+    <AppContext.Provider
+      value={{ electionDefinition: electionSampleDefinition, machineConfig }}
+    >
+      <ExportResultsModal
+        onClose={closeFn}
+        usbDrive={{ status: UsbDriveStatus.recentlyEjected, eject: ejectFn }}
+        scannedBallotCount={5}
+        isTestMode
+      />
+    </AppContext.Provider>
+  )
+  getByText('Download Complete')
+  getByText(
+    'USB drive successfully ejected, you may now take it to VxAdmin for tabulation.'
+  )
 })
 
 test('render export modal with errors when appropriate', async () => {

--- a/apps/precinct-scanner/src/components/ExportResultsModal.tsx
+++ b/apps/precinct-scanner/src/components/ExportResultsModal.tsx
@@ -137,21 +137,22 @@ const ExportResultsModal = ({
   }
 
   if (currentState === ModalState.DONE) {
-    let actions = (
-      <React.Fragment>
-        <Button onPress={onClose}>Cancel</Button>
-        <USBControllerButton
-          small={false}
-          primary
-          usbDriveStatus={
-            usbDrive.status ?? usbstick.UsbDriveStatus.notavailable
-          }
-          usbDriveEject={usbDrive.eject}
-        />
-      </React.Fragment>
-    )
     if (usbDrive.status === usbstick.UsbDriveStatus.recentlyEjected) {
-      actions = <Button onPress={onClose}>Close</Button>
+      return (
+        <Modal
+          content={
+            <Prose>
+              <h1>Download Complete</h1>
+              <p>
+                USB drive successfully ejected, you may now take it to VxAdmin
+                for tabulation.
+              </p>
+            </Prose>
+          }
+          onOverlayClick={onClose}
+          actions={<Button onPress={onClose}>Close</Button>}
+        />
+      )
     }
     return (
       <Modal
@@ -160,12 +161,24 @@ const ExportResultsModal = ({
             <h1>Download Complete</h1>
             <p>
               CVR results file saved successfully! You may now eject the USB
-              drive and take it to Election Manager for tabulation.
+              drive and take it to VxAdmin for tabulation.
             </p>
           </Prose>
         }
         onOverlayClick={onClose}
-        actions={actions}
+        actions={
+          <React.Fragment>
+            <Button onPress={onClose}>Cancel</Button>
+            <USBControllerButton
+              small={false}
+              primary
+              usbDriveStatus={
+                usbDrive.status ?? usbstick.UsbDriveStatus.notavailable
+              }
+              usbDriveEject={usbDrive.eject}
+            />
+          </React.Fragment>
+        }
       />
     )
   }


### PR DESCRIPTION
https://zube.io/votingworks/vxsuite/c/3732

Updated the Export Results modals in precinct-scanner and bsd, and the Export Backup modal in precinct-scanner to update the text in the final dialog when the usb drive is ejected. 

Screenshots from precinct-scanner export results: 
Before Ejecting (unchanged other then 'Election Manager' -> VxAdmin)
<img width="930" alt="Screen Shot 2021-10-04 at 4 44 57 PM" src="https://user-images.githubusercontent.com/14897017/135939017-33a85cff-da14-4c7b-8f8e-530cdc2ec7ec.png">

While Ejecting (unchanged)
<img width="913" alt="Screen Shot 2021-10-04 at 4 45 02 PM" src="https://user-images.githubusercontent.com/14897017/135939029-cca77000-da9f-4aa9-90c7-694a9ec7de74.png">

After Ejecting (new) 
<img width="886" alt="Screen Shot 2021-10-04 at 4 48 19 PM" src="https://user-images.githubusercontent.com/14897017/135939254-cb139202-83fa-48a8-b30a-b25488b6ccde.png">

