### PR TITLE
fix(bmd): require removing election to change settings

### DIFF
--- a/apps/bmd/src/AppRefresh.test.tsx
+++ b/apps/bmd/src/AppRefresh.test.tsx
@@ -60,7 +60,7 @@ it('Refresh window and expect to be on same contest', async () => {
 
   getByText(presidentContest.title)
 
-  // Select first candiate
+  // Select first candidate
   fireEvent.click(getByText(candidate0))
   advanceTimers()
   expect(getByText(candidate0).closest('button')!.dataset.selected).toBe('true')

--- a/apps/bmd/src/AppReplaceElection.test.tsx
+++ b/apps/bmd/src/AppReplaceElection.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react'
+import { MemoryCard, MemoryHardware, MemoryStorage } from '@votingworks/utils'
+import { makeAdminCard } from '@votingworks/test-utils'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { electionSample2Definition } from '@votingworks/fixtures'
+import {
+  setElectionInStorage,
+  setStateInStorage,
+} from '../test/helpers/election'
+import { fakeMachineConfigProvider } from '../test/helpers/fakeMachineConfig'
+import { render } from '../test/testUtils'
+import App from './App'
+import { advanceTimersAndPromises } from '../test/helpers/smartcards'
+
+beforeEach(() => {
+  window.location.href = '/'
+})
+
+jest.useFakeTimers()
+jest.setTimeout(15000)
+
+test('replacing a loaded election with one from a card', async () => {
+  const card = new MemoryCard()
+  const hardware = await MemoryHardware.buildStandard()
+  const storage = new MemoryStorage()
+  const machineConfig = fakeMachineConfigProvider()
+
+  // setup with typical election
+  await setElectionInStorage(storage)
+  await setStateInStorage(storage)
+
+  render(
+    <App
+      card={card}
+      hardware={hardware}
+      storage={storage}
+      machineConfig={machineConfig}
+    />
+  )
+
+  // insert admin card with different election
+  card.insertCard(
+    makeAdminCard(electionSample2Definition.electionHash),
+    electionSample2Definition.electionData
+  )
+  await advanceTimersAndPromises()
+  await waitFor(() =>
+    screen.getByText('Admin Card is not configured for this election')
+  )
+
+  // unconfigure
+  fireEvent.click(screen.getByText('Remove Current Election and All Data'))
+  await advanceTimersAndPromises()
+
+  // take out and put card in again to allow loading
+  card.removeCard()
+  await advanceTimersAndPromises()
+  card.insertCard(
+    makeAdminCard(electionSample2Definition.electionHash),
+    electionSample2Definition.electionData
+  )
+  await advanceTimersAndPromises()
+
+  // load new election
+  await waitFor(() => screen.getByText('Election Admin Actions'))
+  fireEvent.click(screen.getByText('Load Election Definition'))
+  await advanceTimersAndPromises()
+  screen.getByText(electionSample2Definition.election.title)
+})

--- a/apps/bmd/src/pages/AdminScreen.test.tsx
+++ b/apps/bmd/src/pages/AdminScreen.test.tsx
@@ -31,7 +31,7 @@ afterEach(() => {
   window.kiosk = undefined
 })
 
-test('renders ClerkScreen for VxPrintOnly', async () => {
+test('renders AdminScreen for VxPrintOnly', async () => {
   render(
     <AdminScreen
       appPrecinct={{

--- a/apps/bmd/src/pages/AdminScreen.tsx
+++ b/apps/bmd/src/pages/AdminScreen.tsx
@@ -229,7 +229,7 @@ const AdminScreen = ({
                 </Button>
               </p>
             ) : isFetchingElection ? (
-              <p>Loading Election Definition from Clerk Card…</p>
+              <p>Loading Election Definition from Admin Card…</p>
             ) : (
               <React.Fragment>
                 <Text warningIcon>Election definition is not Loaded.</Text>

--- a/apps/bmd/src/pages/ReplaceElectionScreen.test.tsx
+++ b/apps/bmd/src/pages/ReplaceElectionScreen.test.tsx
@@ -1,0 +1,100 @@
+import { electionSample2Definition } from '@votingworks/fixtures'
+import React from 'react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { electionDefinition } from '../../test/helpers/election'
+import fakeMachineConfig from '../../test/helpers/fakeMachineConfig'
+import { render } from '../../test/testUtils'
+import ReplaceElectionScreen from './ReplaceElectionScreen'
+import { AriaScreenReader } from '../utils/ScreenReader'
+import fakeTTS from '../../test/helpers/fakeTTS'
+
+const screenReader = new AriaScreenReader(fakeTTS())
+
+test('reads election definition from card', async () => {
+  const getElectionDefinitionFromCard = jest
+    .fn()
+    .mockResolvedValueOnce(electionSample2Definition)
+  const unconfigure = jest.fn()
+
+  render(
+    <ReplaceElectionScreen
+      ballotsPrintedCount={0}
+      electionDefinition={electionDefinition}
+      machineConfig={fakeMachineConfig()}
+      getElectionDefinitionFromCard={getElectionDefinitionFromCard}
+      screenReader={screenReader}
+      unconfigure={unconfigure}
+    />
+  )
+
+  expect(getElectionDefinitionFromCard).toHaveBeenCalled()
+  await waitFor(() =>
+    screen.getByText(electionSample2Definition.election.title)
+  )
+  expect(unconfigure).not.toHaveBeenCalled()
+})
+
+test('allows unconfiguring', async () => {
+  const getElectionDefinitionFromCard = jest
+    .fn()
+    .mockResolvedValueOnce(electionSample2Definition)
+  const unconfigure = jest.fn()
+
+  render(
+    <ReplaceElectionScreen
+      ballotsPrintedCount={0}
+      electionDefinition={electionDefinition}
+      getElectionDefinitionFromCard={getElectionDefinitionFromCard}
+      machineConfig={fakeMachineConfig()}
+      screenReader={screenReader}
+      unconfigure={unconfigure}
+    />
+  )
+
+  expect(getElectionDefinitionFromCard).toHaveBeenCalled()
+  await waitFor(() =>
+    screen.getByText(electionSample2Definition.election.title)
+  )
+  fireEvent.click(screen.getByText('Remove Current Election and All Data'))
+  expect(unconfigure).toHaveBeenCalled()
+})
+
+test('shows count of ballots printed', async () => {
+  const getElectionDefinitionFromCard = jest
+    .fn()
+    .mockResolvedValue(electionSample2Definition)
+  const unconfigure = jest.fn()
+  const machineConfig = fakeMachineConfig()
+
+  const { rerender } = render(
+    <ReplaceElectionScreen
+      ballotsPrintedCount={0}
+      electionDefinition={electionDefinition}
+      getElectionDefinitionFromCard={getElectionDefinitionFromCard}
+      machineConfig={machineConfig}
+      screenReader={screenReader}
+      unconfigure={unconfigure}
+    />
+  )
+
+  expect(getElectionDefinitionFromCard).toHaveBeenCalled()
+  await waitFor(() =>
+    screen.getByText(electionSample2Definition.election.title)
+  )
+  screen.getByText('No ballots have been printed yet.')
+
+  rerender(
+    <ReplaceElectionScreen
+      ballotsPrintedCount={129}
+      electionDefinition={electionDefinition}
+      getElectionDefinitionFromCard={getElectionDefinitionFromCard}
+      machineConfig={machineConfig}
+      screenReader={screenReader}
+      unconfigure={unconfigure}
+    />
+  )
+  await waitFor(() =>
+    screen.getByText(electionSample2Definition.election.title)
+  )
+  screen.getByText('This machine has already printed 129 ballots.')
+})

--- a/apps/bmd/src/pages/ReplaceElectionScreen.tsx
+++ b/apps/bmd/src/pages/ReplaceElectionScreen.tsx
@@ -1,0 +1,151 @@
+import { ElectionDefinition, Optional } from '@votingworks/types'
+import { Button, Main, MainChild, useCancelablePromise } from '@votingworks/ui'
+import { formatLongDate } from '@votingworks/utils'
+import { DateTime } from 'luxon'
+import pluralize from 'pluralize'
+import React, { useEffect, useState } from 'react'
+import ElectionInfo from '../components/ElectionInfo'
+import Prose from '../components/Prose'
+import Screen from '../components/Screen'
+import Sidebar from '../components/Sidebar'
+import Text from '../components/Text'
+import VersionsData from '../components/VersionsData'
+import { MachineConfig, PrecinctSelection, ScreenReader } from '../config/types'
+
+interface Props {
+  appPrecinct?: PrecinctSelection
+  ballotsPrintedCount: number
+  electionDefinition: ElectionDefinition
+  getElectionDefinitionFromCard(): Promise<Optional<ElectionDefinition>>
+  machineConfig: MachineConfig
+  screenReader: ScreenReader
+  unconfigure(): Promise<void>
+}
+
+const BriefElectionDefinitionInfo = ({
+  electionDefinition,
+}: {
+  electionDefinition: ElectionDefinition
+}) => {
+  const { election, electionHash } = electionDefinition
+  const displayElectionHash = electionHash.slice(0, 10)
+  return (
+    <ul>
+      <li>
+        <strong>Title:</strong> {election.title}
+      </li>
+      <li>
+        <strong>County:</strong> {election.county.name}
+      </li>
+      <li>
+        <strong>Date:</strong> {formatLongDate(DateTime.fromISO(election.date))}
+      </li>
+      <li>
+        <strong>Election ID:</strong> {displayElectionHash}
+      </li>
+    </ul>
+  )
+}
+
+const ReplaceElectionScreen = ({
+  appPrecinct,
+  ballotsPrintedCount,
+  electionDefinition,
+  getElectionDefinitionFromCard,
+  machineConfig,
+  screenReader,
+  unconfigure,
+}: Props): JSX.Element => {
+  const makeCancelable = useCancelablePromise()
+  const [
+    cardElectionDefinition,
+    setCardElectionDefinition,
+  ] = useState<ElectionDefinition>()
+
+  useEffect(() => {
+    void (async () => {
+      setCardElectionDefinition(
+        await makeCancelable(getElectionDefinitionFromCard())
+      )
+    })()
+  }, [getElectionDefinitionFromCard, makeCancelable])
+
+  useEffect(() => {
+    const muted = screenReader.isMuted()
+    screenReader.mute()
+    return () => screenReader.toggleMuted(muted)
+  }, [screenReader])
+
+  return (
+    <Screen flexDirection="row-reverse" voterMode={false}>
+      <Main padded>
+        <MainChild maxWidth={false}>
+          <Prose id="audiofocus">
+            <h1>Admin Card is not configured for this election</h1>
+            {!cardElectionDefinition ? (
+              <p>Reading Election Definition from Admin Card…</p>
+            ) : (
+              <React.Fragment>
+                <p>
+                  You may replace the Election Definition on this machine with
+                  the one from the Admin Card. Doing so will replace all data on
+                  this machine.
+                </p>
+                <h3>Current Election Definition:</h3>
+                <BriefElectionDefinitionInfo
+                  electionDefinition={electionDefinition}
+                />
+                <h3> Card Election Definition: </h3>
+                <BriefElectionDefinitionInfo
+                  electionDefinition={cardElectionDefinition}
+                />
+                {ballotsPrintedCount === 0 ? (
+                  <Text>No ballots have been printed yet.</Text>
+                ) : (
+                  <Text>
+                    This machine has already printed{' '}
+                    {pluralize('ballot', ballotsPrintedCount, true)}.
+                  </Text>
+                )}
+                <p>
+                  <Button danger onPress={unconfigure}>
+                    Remove Current Election and All Data
+                  </Button>
+                </p>
+              </React.Fragment>
+            )}
+          </Prose>
+        </MainChild>
+      </Main>
+      <Sidebar
+        appName={machineConfig.appMode.name}
+        centerContent
+        title="Replace Election"
+        footer={
+          <React.Fragment>
+            <ElectionInfo
+              electionDefinition={electionDefinition}
+              precinctSelection={appPrecinct}
+              horizontal
+            />
+            <VersionsData
+              machineConfig={machineConfig}
+              electionHash={electionDefinition.electionHash}
+            />
+          </React.Fragment>
+        }
+      >
+        <Prose>
+          <h2>Instructions</h2>
+          <p>
+            Loading an election definition from the Admin Card will reset all
+            data on this device.
+          </p>
+          <p>Remove Admin Card to cancel.</p>
+        </Prose>
+      </Sidebar>
+    </Screen>
+  )
+}
+
+export default ReplaceElectionScreen


### PR DESCRIPTION
Previously, a configured BMD would show the Admin Screen when any admin card was inserted, whether it was configured for the same election or not. This commit changes that to show a screen that allows you to remove the current election, but not to edit its settings.

![localhost_3000_(Surface Go 2)](https://user-images.githubusercontent.com/1938/136253907-fa740941-ca5e-42a7-ad21-c45e832c2c5c.png)


Closes #955 