### PR TITLE
fix(bmd): do not enable screen reader on leaving admin screen

### DIFF
--- a/apps/bmd/src/AppRoot.tsx
+++ b/apps/bmd/src/AppRoot.tsx
@@ -555,18 +555,6 @@ const AppRoot = ({
     [card]
   )
 
-  // Disable the audiotrack when in admin mode
-  useEffect(() => {
-    const updateScreenReader = async () => {
-      if (isAdminCardPresent) {
-        await screenReader.disable()
-      } else {
-        await screenReader.enable()
-      }
-    }
-    void updateScreenReader()
-  }, [isAdminCardPresent, screenReader])
-
   // Handle Storing Election Locally
   useEffect(() => {
     const storeElection = async (electionDefinition: ElectionDefinition) => {
@@ -1253,6 +1241,7 @@ const AppRoot = ({
         unconfigure={unconfigure}
         machineConfig={machineConfig}
         printer={printer}
+        screenReader={screenReader}
       />
     )
   }

--- a/apps/bmd/src/pages/AdminScreen.test.tsx
+++ b/apps/bmd/src/pages/AdminScreen.test.tsx
@@ -13,6 +13,10 @@ import { advanceTimers } from '../../test/helpers/smartcards'
 import AdminScreen from './AdminScreen'
 import { VxPrintOnly, VxMarkOnly, PrecinctSelectionKind } from '../config/types'
 import fakeMachineConfig from '../../test/helpers/fakeMachineConfig'
+import {
+  AriaScreenReader,
+  SpeechSynthesisTextToSpeech,
+} from '../utils/ScreenReader'
 
 MockDate.set('2020-10-31T00:00:00.000Z')
 
@@ -46,6 +50,7 @@ test('renders ClerkScreen for VxPrintOnly', async () => {
         codeVersion: '', // Override default
       })}
       printer={fakePrinter()}
+      screenReader={new AriaScreenReader(new SpeechSynthesisTextToSpeech())}
     />
   )
 
@@ -90,6 +95,7 @@ test('renders date and time settings modal', async () => {
         codeVersion: 'test',
       })}
       printer={fakePrinter()}
+      screenReader={new AriaScreenReader(new SpeechSynthesisTextToSpeech())}
     />
   )
 
@@ -235,6 +241,7 @@ test('select All Precincts', async () => {
       unconfigure={jest.fn()}
       machineConfig={fakeMachineConfig()}
       printer={fakePrinter()}
+      screenReader={new AriaScreenReader(new SpeechSynthesisTextToSpeech())}
     />
   )
 
@@ -264,6 +271,7 @@ test('render All Precincts', async () => {
       unconfigure={jest.fn()}
       machineConfig={fakeMachineConfig()}
       printer={fakePrinter()}
+      screenReader={new AriaScreenReader(new SpeechSynthesisTextToSpeech())}
     />
   )
 

--- a/apps/bmd/src/pages/AdminScreen.tsx
+++ b/apps/bmd/src/pages/AdminScreen.tsx
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 
 import { ElectionDefinition } from '@votingworks/types'
 import { formatFullDateTimeZone, Printer } from '@votingworks/utils'
@@ -14,6 +14,7 @@ import {
   MachineConfig,
   PrecinctSelection,
   PrecinctSelectionKind,
+  ScreenReader,
   SelectChangeEventFunction,
 } from '../config/types'
 
@@ -40,6 +41,7 @@ interface Props {
   unconfigure: () => Promise<void>
   machineConfig: MachineConfig
   printer: Printer
+  screenReader: ScreenReader
 }
 
 const ALL_PRECINCTS_OPTION_VALUE = '_ALL'
@@ -55,6 +57,7 @@ const AdminScreen = ({
   unconfigure,
   machineConfig,
   printer,
+  screenReader,
 }: Props): JSX.Element => {
   const election = electionDefinition?.election
   const changeAppPrecinctId: SelectChangeEventFunction = (event) => {
@@ -99,6 +102,13 @@ const AdminScreen = ({
     },
     [setIsSettingClock, setIsSystemDateModalActive]
   )
+
+  // Disable the audiotrack when in admin mode
+  useEffect(() => {
+    const initialMuted = screenReader.isMuted()
+    screenReader.mute()
+    return () => screenReader.toggleMuted(initialMuted)
+  }, [screenReader])
 
   if (isTestDeck && electionDefinition) {
     return (


### PR DESCRIPTION
First, there's no need to enable/disable the screen reader. We can simply mute/unmute instead. Second, we don't want to unconditionally unmute. Instead, we want to restore the muted value as it was when we entered the admin screen. To do that, store the value in a `useEffect` closure.

Fixes #921 