### PR TITLE
feat(ps) show crashed screen when there is a scanner crash

### DIFF
--- a/apps/precinct-scanner/src/PreviewApp.tsx
+++ b/apps/precinct-scanner/src/PreviewApp.tsx
@@ -16,6 +16,7 @@ import * as LoadingConfigurationScreen from './screens/LoadingConfigurationScree
 import * as PollsClosedScreen from './screens/PollsClosedScreen'
 import * as PollWorkerScreen from './screens/PollWorkerScreen'
 import * as ScanErrorScreen from './screens/ScanErrorScreen'
+import * as ScannerCrashedScreen from './screens/ScannerCrashedScreen'
 import * as ScanProcessingScreen from './screens/ScanProcessingScreen'
 import * as ScanSuccessScreen from './screens/ScanSuccessScreen'
 import * as ScanWarningScreen from './screens/ScanWarningScreen'
@@ -43,6 +44,7 @@ const PreviewApp = (): JSX.Element => {
         ScanProcessingScreen,
         ScanSuccessScreen,
         ScanWarningScreen,
+        ScannerCrashedScreen,
         SetupCardReaderPage,
         SetupPowerPage,
         UnconfiguredElectionScreen,

--- a/apps/precinct-scanner/src/api/scan.ts
+++ b/apps/precinct-scanner/src/api/scan.ts
@@ -71,6 +71,12 @@ export async function scanDetectedSheet(): Promise<ScanningResult> {
       return { resultType: ScanningResultType.Accepted }
     }
 
+    if (status.scanner === ScannerStatus.Crashed) {
+      return {
+        resultType: ScanningResultType.Crashed,
+      }
+    }
+
     const adjudicationReasons: AdjudicationReasonInfo[] = []
     if (status.adjudication.remaining > 0) {
       const sheetInfo = await fetchJSON<GetNextReviewSheetResponse>(

--- a/apps/precinct-scanner/src/config/types.ts
+++ b/apps/precinct-scanner/src/config/types.ts
@@ -7,12 +7,14 @@ export enum BallotState {
   CAST = 'ballot_cast',
   REJECTED = 'ballot_rejected',
   SCANNER_ERROR = 'error',
+  SCANNER_CRASHED = 'scanner_crashed',
 }
 
 export enum ScanningResultType {
   Accepted = 'accepted',
   Rejected = 'rejected',
   NeedsReview = 'needs-review',
+  Crashed = 'crashed',
 }
 
 export enum RejectedScanningReason {
@@ -26,10 +28,15 @@ export enum RejectedScanningReason {
 export type ScanningResult =
   | AcceptedScanningResult
   | RejectedScanningResult
+  | CrashedScanningResult
   | ScanningResultNeedsReview
 
 export interface AcceptedScanningResult {
   resultType: ScanningResultType.Accepted
+}
+
+export interface CrashedScanningResult {
+  resultType: ScanningResultType.Crashed
 }
 
 export interface RejectedScanningResult {

--- a/apps/precinct-scanner/src/screens/ScannerCrashedScreen.test.tsx
+++ b/apps/precinct-scanner/src/screens/ScannerCrashedScreen.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import ScannerCrashedScreen from './ScannerCrashedScreen'
+
+test('render crash screen as expected', async () => {
+  render(<ScannerCrashedScreen />)
+  await screen.findByText('Scanner Reboot Required')
+  await screen.findByText('Ballot will be scanned and counted after reboot.')
+  await screen.findByText('Ask a poll worker for assistance.')
+})

--- a/apps/precinct-scanner/src/screens/ScannerCrashedScreen.tsx
+++ b/apps/precinct-scanner/src/screens/ScannerCrashedScreen.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { Text } from '@votingworks/ui'
+import { TimesCircle } from '../components/Graphics'
+import { CenteredLargeProse, CenteredScreen } from '../components/Layout'
+
+const ScannerCrashedScreen = (): JSX.Element => {
+  return (
+    <CenteredScreen infoBar={false}>
+      <TimesCircle />
+      <CenteredLargeProse>
+        <h1>Scanner Reboot Required</h1>
+        <p>Ballot will be scanned and counted after reboot.</p>
+        <Text italic>Ask a poll worker for assistance.</Text>
+      </CenteredLargeProse>
+    </CenteredScreen>
+  )
+}
+
+export default ScannerCrashedScreen
+
+/* istanbul ignore next */
+export const DefaultPreview = (): JSX.Element => {
+  return <ScannerCrashedScreen />
+}

--- a/libs/types/src/api/module-scan.ts
+++ b/libs/types/src/api/module-scan.ts
@@ -69,6 +69,7 @@ export enum ScannerStatus {
   Calibrating = 'Calibrating',
   Error = 'Error',
   Unknown = 'Unknown',
+  Crashed = 'Crashed',
 }
 
 export const ScannerStatusSchema = z.nativeEnum(ScannerStatus)


### PR DESCRIPTION
Adds a screen to precinct-scanner when the scanner returns a new status of "Crashed" regardless of whether this status is seen during scanning or not. 
<img width="1796" alt="Screen Shot 2021-10-05 at 10 39 02 AM" src="https://user-images.githubusercontent.com/14897017/136080578-0aaf6d97-7854-462a-b88b-7da82b27f135.png">


Note this does NOT yet update module-scan to return this status at any point. 