### PR TITLE
test(ps) fix test for pollworker card with bad election hash

### DIFF
--- a/apps/precinct-scanner/src/AppUnhappyPaths.test.tsx
+++ b/apps/precinct-scanner/src/AppUnhappyPaths.test.tsx
@@ -1,5 +1,8 @@
 import { act, fireEvent, render, screen } from '@testing-library/react'
-import { electionSampleDefinition } from '@votingworks/fixtures'
+import {
+  electionSampleDefinition,
+  electionWithMsEitherNeitherDefinition,
+} from '@votingworks/fixtures'
 import {
   advanceTimers,
   advanceTimersAndPromises,
@@ -141,7 +144,7 @@ test('Show invalid card screen when unsupported cards are given', async () => {
   await screen.findByText('Polls Closed')
 
   const pollWorkerCardWrongElection = makePollWorkerCard(
-    'this-is-not-the-right-hash'
+    electionWithMsEitherNeitherDefinition.electionHash
   )
   card.insertCard(pollWorkerCardWrongElection)
   await advanceTimersAndPromises(1)


### PR DESCRIPTION
https://zube.io/votingworks/vxsuite/c/3698

useSmartcard was returning an invalid non-pollworker card to precinct-scanners AppRoot when given a value for election hash that can't possibly be an election hash, so this test was not actually testing the desired condition of having an invalid election hash, leading to a bug accidentally being committed here (see: https://github.com/votingworks/vxsuite/pull/925 )

