### PR TITLE
fix(scan): respawn `plustekctl` on crash

### DIFF
--- a/apps/module-scan/src/scanners/plustek.test.ts
+++ b/apps/module-scan/src/scanners/plustek.test.ts
@@ -251,7 +251,7 @@ test('withReconnect', async () => {
     toggleHoldDuration: 0,
   })
   await client.connect()
-  await unresponsiveClient.simulateUnresponsive()
+  unresponsiveClient.simulateUnresponsive()
 
   // set up provider to fail before eventually succeeding
   const getClient = jest
@@ -297,7 +297,7 @@ test('withReconnect only re-creates the client once per failure', async () => {
     toggleHoldDuration: 0,
   })
   await client.connect()
-  await unresponsiveClient.simulateUnresponsive()
+  unresponsiveClient.simulateUnresponsive()
 
   // set up provider to once
   const getClient = jest


### PR DESCRIPTION
Sometimes `plustekctl` crashes for an unknown reason. I believe the crash is in the plustek SDK, but I don't know for sure. This tries to make with `withReconnect` wrapper be resilient to this sort of crash in most cases.