### PR TITLE
fix(bmd) fix clearing voter ballot when inactive in cardless voting

### DIFF
--- a/apps/bmd/src/AppMarkVoterCardInvalid.test.tsx
+++ b/apps/bmd/src/AppMarkVoterCardInvalid.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import { fireEvent, render, screen } from '@testing-library/react'
-import { electionSample } from '@votingworks/fixtures'
-import { makeVoterCard } from '@votingworks/test-utils'
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { electionSample, electionSampleDefinition } from '@votingworks/fixtures'
+import { makePollWorkerCard, makeVoterCard } from '@votingworks/test-utils'
 import { MemoryStorage, MemoryCard, MemoryHardware } from '@votingworks/utils'
 
 import App from './App'
@@ -20,6 +20,7 @@ import {
   IDLE_RESET_TIMEOUT_SECONDS,
 } from './config/globals'
 import { fakeMachineConfigProvider } from '../test/helpers/fakeMachineConfig'
+import { VxMarkPlusVxPrint } from './config/types'
 
 beforeEach(() => {
   window.location.href = '/'
@@ -95,6 +96,80 @@ describe('Mark Card Void when voter is idle too long', () => {
 
     // Remove card
     card.removeCard()
+    await advanceTimersAndPromises()
+    screen.getByText('Insert voter card to load ballot.')
+  })
+
+  test('Reset ballot when idle voter times out when cardless voting', async () => {
+    const card = new MemoryCard()
+    const hardware = await MemoryHardware.buildStandard()
+    const storage = new MemoryStorage()
+    const machineConfig = fakeMachineConfigProvider({
+      appMode: VxMarkPlusVxPrint,
+    })
+
+    await setElectionInStorage(storage, electionSampleDefinition)
+    await setStateInStorage(storage)
+    const pollWorkerCard = makePollWorkerCard(
+      electionSampleDefinition.electionHash
+    )
+
+    render(
+      <App
+        card={card}
+        hardware={hardware}
+        storage={storage}
+        machineConfig={machineConfig}
+      />
+    )
+    // Initialize app
+    await advanceTimersAndPromises()
+
+    // Activate Voter Session for Cardless Voter
+    card.insertCard(pollWorkerCard)
+    await advanceTimersAndPromises()
+    screen.getByText('Activate Voter Session')
+    fireEvent.click(within(screen.getByTestId('ballot-styles')).getByText('12'))
+    screen.getByText('Voter session activated: 12')
+
+    card.removeCard()
+    await advanceTimersAndPromises()
+    screen.getByText(/Center Springfield/)
+    screen.getByText('Start Voting')
+
+    // Elapse idle timeout
+    await advanceTimersAndPromises(IDLE_TIMEOUT_SECONDS)
+
+    // Idle Screen is displayed
+    screen.getByText(idleScreenCopy)
+
+    // User action removes Idle Screen
+    fireEvent.click(screen.getByText('Yes, I’m still voting.'))
+    fireEvent.mouseDown(document)
+    await advanceTimersAndPromises()
+    expect(screen.queryByText(idleScreenCopy)).toBeFalsy()
+
+    // Elapse idle timeout
+    await advanceTimersAndPromises(IDLE_TIMEOUT_SECONDS)
+
+    // Idle Screen is displayed
+    screen.getByText(idleScreenCopy)
+
+    // Countdown works
+    const secondsRemaining = 20
+    advanceTimers(IDLE_RESET_TIMEOUT_SECONDS - secondsRemaining)
+    screen.getByText(`${secondsRemaining} seconds`)
+
+    advanceTimers(secondsRemaining)
+    screen.getByText('Clearing ballot')
+
+    // Idle reset timeout expires
+    await advanceTimersAndPromises()
+
+    // Insert voter card screen is displayed.
+    screen.getByText('Insert voter card to load ballot.')
+
+    // Card read again has no impact.
     await advanceTimersAndPromises()
     screen.getByText('Insert voter card to load ballot.')
   })

--- a/apps/bmd/src/AppRoot.tsx
+++ b/apps/bmd/src/AppRoot.tsx
@@ -912,6 +912,9 @@ const AppRoot = ({
   }, [clearLongValue, resetPollWorkerCardTally])
 
   const markVoterCardVoided: MarkVoterCardFunction = useCallback(async () => {
+    if (isCardlessVoter) {
+      return true
+    }
     stopCardShortValueReadPolling()
 
     await clearLongValue()
@@ -953,6 +956,7 @@ const AppRoot = ({
     startCardShortValueReadPolling,
     stopCardShortValueReadPolling,
     writeCard,
+    isCardlessVoter,
   ])
 
   const markVoterCardPrinted: MarkVoterCardFunction = useCallback(async () => {


### PR DESCRIPTION
There was a bug where clearing a ballot after a voter is inactive was hanging indefinitely when in a cardless voting scenario. This was because of an error thrown trying to clear the card data which, doesn't apply in cardless voting. 

https://zube.io/votingworks/vxsuite/c/3733