### PR TITLE
fix(bmd): allow no selection on precinct select blur

### DIFF
--- a/apps/bmd/src/pages/AdminScreen.test.tsx
+++ b/apps/bmd/src/pages/AdminScreen.test.tsx
@@ -257,6 +257,28 @@ test('select All Precincts', async () => {
   })
 })
 
+test('blur precinct selector without a selection', async () => {
+  const updateAppPrecinct = jest.fn()
+  render(
+    <AdminScreen
+      ballotsPrintedCount={0}
+      electionDefinition={asElectionDefinition(election)}
+      fetchElection={jest.fn()}
+      isLiveMode
+      updateAppPrecinct={updateAppPrecinct}
+      toggleLiveMode={jest.fn()}
+      unconfigure={jest.fn()}
+      machineConfig={fakeMachineConfig()}
+      printer={fakePrinter()}
+      screenReader={new AriaScreenReader(new SpeechSynthesisTextToSpeech())}
+    />
+  )
+
+  const precinctSelect = screen.getByLabelText('Precinct')
+  fireEvent.blur(precinctSelect)
+  expect(updateAppPrecinct).not.toHaveBeenCalled()
+})
+
 test('render All Precincts', async () => {
   const updateAppPrecinct = jest.fn()
   render(

--- a/apps/bmd/src/pages/AdminScreen.tsx
+++ b/apps/bmd/src/pages/AdminScreen.tsx
@@ -65,10 +65,10 @@ const AdminScreen = ({
 
     if (precinctId === ALL_PRECINCTS_OPTION_VALUE) {
       updateAppPrecinct({ kind: PrecinctSelectionKind.AllPrecincts })
-    } else {
+    } else if (precinctId) {
       updateAppPrecinct({
         kind: PrecinctSelectionKind.SinglePrecinct,
-        precinctId: event.currentTarget.value,
+        precinctId,
       })
     }
   }


### PR DESCRIPTION
Previously this would throw an error while looking for a precinct with a blank ID (`event.currentTarget.value` is an empty string when the placeholder is selected).