### PR TITLE
fix(lint): make TS stop complaining

### DIFF
--- a/libs/eslint-plugin-vx/src/rules/gts-direct-module-export-access-only.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts-direct-module-export-access-only.ts
@@ -1,14 +1,8 @@
-import {
-  AST_NODE_TYPES,
-  ESLintUtils,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils'
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/experimental-utils'
 import { strict as assert } from 'assert'
+import { createRule } from '../util'
 
-export default ESLintUtils.RuleCreator(
-  () =>
-    'https://github.com/votingworks/vxsuite/blob/main/libs/eslint-plugin-vx/docs/rules/gts-direct-module-export-access-only.md'
-)({
+export default createRule({
   name: 'gts-direct-module-export-access-only',
   meta: {
     docs: {

--- a/libs/eslint-plugin-vx/src/rules/gts-no-array-constructor.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts-no-array-constructor.ts
@@ -1,15 +1,9 @@
-import {
-  AST_NODE_TYPES,
-  ESLintUtils,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils'
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/experimental-utils'
 import { RuleFix } from '@typescript-eslint/experimental-utils/dist/ts-eslint'
 import { strict as assert } from 'assert'
+import { createRule } from '../util'
 
-export default ESLintUtils.RuleCreator(
-  () =>
-    'https://github.com/votingworks/vxsuite/blob/main/libs/eslint-plugin-vx/docs/rules/gts-no-array-constructor.md'
-)({
+export default createRule({
   name: 'gts-no-array-constructor',
   meta: {
     docs: {

--- a/libs/eslint-plugin-vx/src/rules/gts-no-import-export-type.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts-no-import-export-type.ts
@@ -1,14 +1,8 @@
-import {
-  AST_NODE_TYPES,
-  ESLintUtils,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils'
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/experimental-utils'
 import { strict as assert } from 'assert'
+import { createRule } from '../util'
 
-export default ESLintUtils.RuleCreator(
-  () =>
-    'https://github.com/votingworks/vxsuite/blob/main/libs/eslint-plugin-vx/docs/rules/gts-no-import-export-type.md'
-)({
+export default createRule({
   name: 'gts-no-import-export-type',
   meta: {
     docs: {
@@ -103,7 +97,7 @@ export default ESLintUtils.RuleCreator(
     }
 
     return {
-      ImportDeclaration(node) {
+      ImportDeclaration(node: TSESTree.ImportDeclaration) {
         if (node.importKind !== 'type') {
           return
         }
@@ -133,7 +127,7 @@ export default ESLintUtils.RuleCreator(
         })
       },
 
-      ExportNamedDeclaration(node) {
+      ExportNamedDeclaration(node: TSESTree.ExportNamedDeclaration) {
         // export const foo = 1
         // export type foo = string
         if (node.exportKind !== 'type' || node.declaration) {
@@ -159,7 +153,7 @@ export default ESLintUtils.RuleCreator(
         reportExport(node)
       },
 
-      ExportAllDeclaration(node) {
+      ExportAllDeclaration(node: TSESTree.ExportAllDeclaration) {
         if (node.exportKind !== 'type' || allowReexport) {
           return
         }

--- a/libs/eslint-plugin-vx/src/rules/gts-no-private-fields.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts-no-private-fields.ts
@@ -1,14 +1,12 @@
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils'
+import { TSESTree } from '@typescript-eslint/experimental-utils'
+import { createRule } from '../util'
 
 function isPrivateIdentifier(node: TSESTree.Node): boolean {
   // @ts-expect-error - typescript-eslint v5 will have support for TSPrivateIdentifier or PrivateIdentifier (https://github.com/typescript-eslint/typescript-eslint/issues/3430#issuecomment-907712769)
   return node.type === 'TSPrivateIdentifier'
 }
 
-export default ESLintUtils.RuleCreator(
-  () =>
-    'https://github.com/votingworks/vxsuite/blob/main/libs/eslint-plugin-vx/docs/rules/gts-no-private-fields.md'
-)({
+export default createRule({
   name: 'gts-no-private-fields',
   meta: {
     docs: {
@@ -28,7 +26,7 @@ export default ESLintUtils.RuleCreator(
 
   create(context) {
     return {
-      ClassProperty(node) {
+      ClassProperty(node: TSESTree.ClassProperty) {
         if (isPrivateIdentifier(node.key)) {
           context.report({
             node: node.key,
@@ -37,7 +35,7 @@ export default ESLintUtils.RuleCreator(
         }
       },
 
-      MemberExpression(node) {
+      MemberExpression(node: TSESTree.MemberExpression) {
         if (isPrivateIdentifier(node.property)) {
           context.report({
             node: node.property,
@@ -46,7 +44,7 @@ export default ESLintUtils.RuleCreator(
         }
       },
 
-      MethodDefinition(node) {
+      MethodDefinition(node: TSESTree.MethodDefinition) {
         if (isPrivateIdentifier(node.key)) {
           context.report({
             node: node.key,

--- a/libs/eslint-plugin-vx/src/rules/gts-no-public-modifier.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts-no-public-modifier.ts
@@ -1,14 +1,8 @@
-import {
-  AST_NODE_TYPES,
-  ESLintUtils,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils'
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/experimental-utils'
 import { strict as assert } from 'assert'
+import { createRule } from '../util'
 
-export default ESLintUtils.RuleCreator(
-  () =>
-    'https://github.com/votingworks/vxsuite/blob/main/libs/eslint-plugin-vx/docs/rules/gts-no-public-modifier.md'
-)({
+export default createRule({
   name: 'gts-no-public-modifier',
   meta: {
     docs: {

--- a/libs/eslint-plugin-vx/src/rules/gts-parameter-properties.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts-parameter-properties.ts
@@ -1,8 +1,5 @@
-import {
-  AST_NODE_TYPES,
-  ESLintUtils,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils'
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/experimental-utils'
+import { createRule } from '../util'
 
 function getParamName(param: TSESTree.Parameter): string | undefined {
   switch (param.type) {
@@ -36,10 +33,7 @@ function isPropertyInitializerAssignment(
   )
 }
 
-export default ESLintUtils.RuleCreator(
-  () =>
-    'https://github.com/votingworks/vxsuite/blob/main/libs/eslint-plugin-vx/docs/rules/gts-parameter-properties.md'
-)({
+export default createRule({
   name: 'gts-parameter-properties',
   meta: {
     docs: {
@@ -62,7 +56,7 @@ export default ESLintUtils.RuleCreator(
 
   create(context) {
     return {
-      MethodDefinition(node): void {
+      MethodDefinition(node: TSESTree.MethodDefinition): void {
         if (
           node.key.type !== AST_NODE_TYPES.Identifier ||
           node.key.name !== 'constructor'

--- a/libs/eslint-plugin-vx/src/rules/index.ts
+++ b/libs/eslint-plugin-vx/src/rules/index.ts
@@ -1,3 +1,4 @@
+import { TSESLint } from '@typescript-eslint/experimental-utils'
 import gtsDirectModuleExportAccessOnly from './gts-direct-module-export-access-only'
 import gtsNoArrayConstructor from './gts-no-array-constructor'
 import gtsNoImportExportType from './gts-no-import-export-type'
@@ -18,4 +19,7 @@ export default {
   'no-array-sort-mutation': noArraySortMutation,
   'no-assert-truthiness': noAssertStringOrNumber,
   'no-floating-results': noFloatingVoids,
-}
+} as Record<
+  string,
+  TSESLint.RuleModule<string, readonly unknown[], TSESLint.RuleListener>
+>

--- a/libs/eslint-plugin-vx/src/rules/no-array-sort-mutation.ts
+++ b/libs/eslint-plugin-vx/src/rules/no-array-sort-mutation.ts
@@ -3,6 +3,7 @@ import {
   ESLintUtils,
   TSESTree,
 } from '@typescript-eslint/experimental-utils'
+import { createRule } from '../util'
 
 function isDirectAccess(node: TSESTree.Node): boolean {
   if (node.type === AST_NODE_TYPES.Identifier) {
@@ -16,10 +17,7 @@ function isDirectAccess(node: TSESTree.Node): boolean {
   return false
 }
 
-export default ESLintUtils.RuleCreator(
-  () =>
-    'https://github.com/votingworks/vxsuite/blob/main/libs/eslint-plugin-vx/docs/rules/no-array-sort-mutation.md'
-)({
+export default createRule({
   name: 'no-array-sort-mutation',
   meta: {
     docs: {
@@ -39,7 +37,7 @@ export default ESLintUtils.RuleCreator(
 
   create(context) {
     return {
-      CallExpression({ callee }) {
+      CallExpression({ callee }: TSESTree.CallExpression) {
         if (
           callee.type !== AST_NODE_TYPES.MemberExpression ||
           callee.property.type !== AST_NODE_TYPES.Identifier ||

--- a/libs/eslint-plugin-vx/src/rules/no-assert-truthiness.ts
+++ b/libs/eslint-plugin-vx/src/rules/no-assert-truthiness.ts
@@ -1,8 +1,10 @@
 import {
   AST_NODE_TYPES,
   ESLintUtils,
+  TSESTree,
 } from '@typescript-eslint/experimental-utils'
 import * as ts from 'typescript'
+import { createRule } from '../util'
 
 export interface Options {
   objects: boolean
@@ -37,10 +39,7 @@ function typeIsBoolean(type: ts.Type): boolean {
   return flags === ts.TypeFlags.Boolean || flags === ts.TypeFlags.BooleanLiteral
 }
 
-export default ESLintUtils.RuleCreator(
-  () =>
-    'https://github.com/votingworks/vxsuite/blob/main/libs/eslint-plugin-vx/docs/rules/no-assert-truthiness.md'
-)({
+export default createRule({
   name: 'no-assert-truthiness',
   meta: {
     fixable: 'code',
@@ -81,7 +80,7 @@ export default ESLintUtils.RuleCreator(
     const checker = parserServices.program.getTypeChecker()
 
     return {
-      CallExpression(node): void {
+      CallExpression(node: TSESTree.CallExpression): void {
         if (node.callee.type !== AST_NODE_TYPES.Identifier) {
           return
         }

--- a/libs/eslint-plugin-vx/src/rules/no-floating-results.ts
+++ b/libs/eslint-plugin-vx/src/rules/no-floating-results.ts
@@ -6,6 +6,7 @@ import {
   TSESTree,
 } from '@typescript-eslint/experimental-utils'
 import * as ts from 'typescript'
+import { createRule } from '../util'
 
 interface Options {
   ignoreVoid?: boolean
@@ -54,10 +55,7 @@ function isUnhandledResult(
   return isResultType(checker, parserServices.esTreeNodeToTSNodeMap.get(node))
 }
 
-export default ESLintUtils.RuleCreator(
-  () =>
-    'https://github.com/votingworks/vxsuite/blob/main/libs/eslint-plugin-vx/docs/rules/no-floating-results.md'
-)({
+export default createRule({
   name: 'no-floating-results',
   meta: {
     docs: {
@@ -97,7 +95,7 @@ export default ESLintUtils.RuleCreator(
     const sourceCode = context.getSourceCode()
 
     return {
-      ExpressionStatement(node): void {
+      ExpressionStatement(node: TSESTree.ExpressionStatement): void {
         if (
           isUnhandledResult(checker, parserServices, options, node.expression)
         ) {

--- a/libs/eslint-plugin-vx/src/util/index.ts
+++ b/libs/eslint-plugin-vx/src/util/index.ts
@@ -1,0 +1,6 @@
+import { ESLintUtils } from '@typescript-eslint/experimental-utils'
+
+export const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/votingworks/vxsuite/blob/main/libs/eslint-plugin-vx/docs/rules/${name}.md`
+)


### PR DESCRIPTION
I've been getting errors, but only in VS Code, that the implicit type of the rules referenced a module that wouldn't be available to consumers of the library and that they are therefore not portable. I'm not sure I completely understand the error, but the fix seems to be to provide explicit type annotations for a few things.