### PR TITLE
refactor(scan): separate adjudication reason infos

### DIFF
--- a/apps/bsd/src/screens/BallotEjectScreen.test.tsx
+++ b/apps/bsd/src/screens/BallotEjectScreen.test.tsx
@@ -75,7 +75,7 @@ test('says the ballot sheet is overvoted if it is', async () => {
             },
             adjudicationInfo: {
               requiresAdjudication: true,
-              allReasonInfos: [
+              enabledReasonInfos: [
                 {
                   type: AdjudicationReason.Overvote,
                   contestId: '1',
@@ -84,6 +84,7 @@ test('says the ballot sheet is overvoted if it is', async () => {
                   expected: 1,
                 },
               ],
+              ignoredReasonInfos: [],
               enabledReasons: [AdjudicationReason.Overvote],
             },
             votes: {},
@@ -108,7 +109,8 @@ test('says the ballot sheet is overvoted if it is', async () => {
             },
             adjudicationInfo: {
               requiresAdjudication: false,
-              allReasonInfos: [],
+              enabledReasonInfos: [],
+              ignoredReasonInfos: [],
               enabledReasons: [AdjudicationReason.Overvote],
             },
             votes: {},
@@ -172,7 +174,7 @@ test('says the ballot sheet is undervoted if it is', async () => {
             },
             adjudicationInfo: {
               requiresAdjudication: true,
-              allReasonInfos: [
+              enabledReasonInfos: [
                 {
                   type: AdjudicationReason.Undervote,
                   contestId: '1',
@@ -181,6 +183,7 @@ test('says the ballot sheet is undervoted if it is', async () => {
                   expected: 1,
                 },
               ],
+              ignoredReasonInfos: [],
               enabledReasons: [AdjudicationReason.Undervote],
             },
             votes: {},
@@ -205,7 +208,8 @@ test('says the ballot sheet is undervoted if it is', async () => {
             },
             adjudicationInfo: {
               requiresAdjudication: false,
-              allReasonInfos: [],
+              enabledReasonInfos: [],
+              ignoredReasonInfos: [],
               enabledReasons: [AdjudicationReason.Overvote],
             },
             votes: {},
@@ -269,7 +273,7 @@ test('says the ballot sheet is blank if it is', async () => {
             },
             adjudicationInfo: {
               requiresAdjudication: true,
-              allReasonInfos: [
+              enabledReasonInfos: [
                 {
                   type: AdjudicationReason.Undervote,
                   contestId: '1',
@@ -279,6 +283,7 @@ test('says the ballot sheet is blank if it is', async () => {
                 },
                 { type: AdjudicationReason.BlankBallot },
               ],
+              ignoredReasonInfos: [],
               enabledReasons: [
                 AdjudicationReason.BlankBallot,
                 AdjudicationReason.Undervote,
@@ -306,7 +311,8 @@ test('says the ballot sheet is blank if it is', async () => {
             },
             adjudicationInfo: {
               requiresAdjudication: true,
-              allReasonInfos: [{ type: AdjudicationReason.BlankBallot }],
+              enabledReasonInfos: [{ type: AdjudicationReason.BlankBallot }],
+              ignoredReasonInfos: [],
               enabledReasons: [
                 AdjudicationReason.BlankBallot,
                 AdjudicationReason.Undervote,
@@ -594,7 +600,8 @@ test('does NOT say ballot is blank if one side is blank and the other requires w
               },
               adjudicationInfo: {
                 requiresAdjudication: true,
-                allReasonInfos: [{ type: AdjudicationReason.BlankBallot }],
+                enabledReasonInfos: [{ type: AdjudicationReason.BlankBallot }],
+                ignoredReasonInfos: [],
                 enabledReasons: [AdjudicationReason.BlankBallot, writeInReason],
               },
               votes: {},
@@ -619,7 +626,7 @@ test('does NOT say ballot is blank if one side is blank and the other requires w
               },
               adjudicationInfo: {
                 requiresAdjudication: true,
-                allReasonInfos: [
+                enabledReasonInfos: [
                   {
                     type: writeInReason,
                     contestId: 'county-commissioners',
@@ -629,6 +636,7 @@ test('does NOT say ballot is blank if one side is blank and the other requires w
                     | WriteInAdjudicationReasonInfo
                     | UnmarkedWriteInAdjudicationReasonInfo,
                 ],
+                ignoredReasonInfos: [],
                 enabledReasons: [AdjudicationReason.BlankBallot, writeInReason],
               },
               votes: {},

--- a/apps/bsd/src/screens/BallotEjectScreen.tsx
+++ b/apps/bsd/src/screens/BallotEjectScreen.tsx
@@ -133,16 +133,16 @@ const BallotEjectScreen = ({
     // We leave that consideration to:
     // https://github.com/votingworks/vxsuite/issues/902
     const isBlank =
-      frontAdjudication.allReasonInfos.some(
+      frontAdjudication.enabledReasonInfos.some(
         (info) => info.type === AdjudicationReason.BlankBallot
       ) &&
-      !frontAdjudication.allReasonInfos.some(
+      !frontAdjudication.enabledReasonInfos.some(
         (info) => info.type === AdjudicationReason.UnmarkedWriteIn
       ) &&
-      backAdjudication.allReasonInfos.some(
+      backAdjudication.enabledReasonInfos.some(
         (info) => info.type === AdjudicationReason.BlankBallot
       ) &&
-      !backAdjudication.allReasonInfos.some(
+      !backAdjudication.enabledReasonInfos.some(
         (info) => info.type === AdjudicationReason.UnmarkedWriteIn
       )
 
@@ -151,7 +151,7 @@ const BallotEjectScreen = ({
         !frontAdjudication.enabledReasons.some(
           (reason) =>
             reason !== AdjudicationReason.BlankBallot &&
-            frontAdjudication.allReasonInfos.some(
+            frontAdjudication.enabledReasonInfos.some(
               (info) => info.type === reason
             )
         )
@@ -162,7 +162,9 @@ const BallotEjectScreen = ({
         !backAdjudication.enabledReasons.some(
           (reason) =>
             reason !== AdjudicationReason.BlankBallot &&
-            backAdjudication.allReasonInfos.some((info) => info.type === reason)
+            backAdjudication.enabledReasonInfos.some(
+              (info) => info.type === reason
+            )
         )
       ) {
         setBackMarkAdjudications([])
@@ -264,45 +266,37 @@ const BallotEjectScreen = ({
     } else if (reviewPageInfo.interpretation.type === 'InterpretedHmpbPage') {
       if (reviewPageInfo.interpretation.adjudicationInfo.requiresAdjudication) {
         for (const adjudicationReason of reviewPageInfo.interpretation
-          .adjudicationInfo.allReasonInfos) {
-          if (
-            reviewPageInfo.interpretation.adjudicationInfo.enabledReasons.includes(
-              adjudicationReason.type
-            )
+          .adjudicationInfo.enabledReasonInfos) {
+          if (adjudicationReason.type === AdjudicationReason.Overvote) {
+            isOvervotedSheet = true
+            contestIdsWithIssues.add(adjudicationReason.contestId)
+          } else if (adjudicationReason.type === AdjudicationReason.Undervote) {
+            isUndervotedSheet = true
+            contestIdsWithIssues.add(adjudicationReason.contestId)
+          } else if (
+            adjudicationReason.type === AdjudicationReason.WriteIn ||
+            adjudicationReason.type === AdjudicationReason.UnmarkedWriteIn
           ) {
-            if (adjudicationReason.type === AdjudicationReason.Overvote) {
-              isOvervotedSheet = true
-              contestIdsWithIssues.add(adjudicationReason.contestId)
-            } else if (
-              adjudicationReason.type === AdjudicationReason.Undervote
-            ) {
-              isUndervotedSheet = true
-              contestIdsWithIssues.add(adjudicationReason.contestId)
-            } else if (
-              adjudicationReason.type === AdjudicationReason.WriteIn ||
-              adjudicationReason.type === AdjudicationReason.UnmarkedWriteIn
-            ) {
-              assert(reviewPageInfo.layout)
-              assert(reviewPageInfo.contestIds)
-              return (
-                <WriteInAdjudicationScreen
-                  sheetId={reviewInfo.interpreted.id}
-                  side={reviewPageInfo.side}
-                  imageURL={reviewPageInfo.imageURL}
-                  interpretation={reviewPageInfo.interpretation}
-                  layout={reviewPageInfo.layout}
-                  contestIds={reviewPageInfo.contestIds}
-                  onAdjudicationComplete={onAdjudicationComplete}
-                />
-              )
-            } else if (
-              adjudicationReason.type === AdjudicationReason.BlankBallot
-            ) {
-              if (reviewPageInfo.side === 'front') {
-                isFrontBlank = true
-              } else {
-                isBackBlank = true
-              }
+            assert(reviewPageInfo.layout)
+            assert(reviewPageInfo.contestIds)
+            return (
+              <WriteInAdjudicationScreen
+                sheetId={reviewInfo.interpreted.id}
+                side={reviewPageInfo.side}
+                imageURL={reviewPageInfo.imageURL}
+                interpretation={reviewPageInfo.interpretation}
+                layout={reviewPageInfo.layout}
+                contestIds={reviewPageInfo.contestIds}
+                onAdjudicationComplete={onAdjudicationComplete}
+              />
+            )
+          } else if (
+            adjudicationReason.type === AdjudicationReason.BlankBallot
+          ) {
+            if (reviewPageInfo.side === 'front') {
+              isFrontBlank = true
+            } else {
+              isBackBlank = true
             }
           }
         }

--- a/apps/bsd/src/screens/WriteInAdjudicationScreen.test.tsx
+++ b/apps/bsd/src/screens/WriteInAdjudicationScreen.test.tsx
@@ -70,7 +70,7 @@ function renderWriteInAdjudicationScreen(
         adjudicationInfo: {
           requiresAdjudication: true,
           enabledReasons: [reason],
-          allReasonInfos: [
+          enabledReasonInfos: [
             {
               type: reason,
               contestId: contest.id,
@@ -78,6 +78,7 @@ function renderWriteInAdjudicationScreen(
               optionIndex: 0,
             },
           ],
+          ignoredReasonInfos: [],
         },
         votes: {},
       }}

--- a/apps/bsd/src/screens/WriteInAdjudicationScreen.tsx
+++ b/apps/bsd/src/screens/WriteInAdjudicationScreen.tsx
@@ -421,7 +421,7 @@ const WriteInAdjudicationByContest = ({
   const [isSaving, setIsSaving] = useState(false)
   const [selectedContestIndex, setSelectedContestIndex] = useState(0)
 
-  const writeIns = interpretation.adjudicationInfo.allReasonInfos.filter(
+  const writeIns = interpretation.adjudicationInfo.enabledReasonInfos.filter(
     (
       reason
     ): reason is
@@ -559,7 +559,7 @@ export default function WriteInAdjudicationScreen({
   >([])
   const [selectedContestId, setSelectedContestId] = useState<Contest['id']>()
 
-  const writeIns = interpretation.adjudicationInfo.allReasonInfos.filter(
+  const writeIns = interpretation.adjudicationInfo.enabledReasonInfos.filter(
     (
       reason
     ): reason is

--- a/apps/module-scan/src/buildCastVoteRecord.test.ts
+++ b/apps/module-scan/src/buildCastVoteRecord.test.ts
@@ -289,7 +289,8 @@ test('generates a CVR from a completed HMPB page', () => {
           adjudicationInfo: {
             requiresAdjudication: false,
             enabledReasons: [],
-            allReasonInfos: [],
+            enabledReasonInfos: [],
+            ignoredReasonInfos: [],
           },
           votes: vote(contests, {
             '1': '1',
@@ -315,7 +316,8 @@ test('generates a CVR from a completed HMPB page', () => {
           adjudicationInfo: {
             requiresAdjudication: false,
             enabledReasons: [],
-            allReasonInfos: [],
+            enabledReasonInfos: [],
+            ignoredReasonInfos: [],
           },
           votes: vote(contests, {
             'initiative-65': ['yes', 'no'],
@@ -384,7 +386,8 @@ test('generates a CVR from a completed HMPB page with write in votes and overvot
           adjudicationInfo: {
             requiresAdjudication: false,
             enabledReasons: [],
-            allReasonInfos: [],
+            enabledReasonInfos: [],
+            ignoredReasonInfos: [],
           },
           votes: vote(contests, {
             '1': { id: '__write-in-0', name: 'Pikachu', isWriteIn: true },
@@ -410,7 +413,8 @@ test('generates a CVR from a completed HMPB page with write in votes and overvot
           adjudicationInfo: {
             requiresAdjudication: false,
             enabledReasons: [],
-            allReasonInfos: [],
+            enabledReasonInfos: [],
+            ignoredReasonInfos: [],
           },
           votes: vote(contests, {
             'initiative-65': ['yes', 'no'],
@@ -480,7 +484,8 @@ test('generates a CVR from a completed absentee HMPB page', () => {
           adjudicationInfo: {
             requiresAdjudication: false,
             enabledReasons: [],
-            allReasonInfos: [],
+            enabledReasonInfos: [],
+            ignoredReasonInfos: [],
           },
           votes: vote(contests, {
             '1': '1',
@@ -506,7 +511,8 @@ test('generates a CVR from a completed absentee HMPB page', () => {
           adjudicationInfo: {
             requiresAdjudication: false,
             enabledReasons: [],
-            allReasonInfos: [],
+            enabledReasonInfos: [],
+            ignoredReasonInfos: [],
           },
           votes: vote(contests, {
             'initiative-65': ['yes', 'no'],
@@ -575,7 +581,7 @@ test('generates a CVR from an adjudicated HMPB page', () => {
           adjudicationInfo: {
             requiresAdjudication: true,
             enabledReasons: [AdjudicationReason.Overvote],
-            allReasonInfos: [
+            enabledReasonInfos: [
               {
                 type: AdjudicationReason.Overvote,
                 contestId: 'initiative-65',
@@ -584,6 +590,7 @@ test('generates a CVR from an adjudicated HMPB page', () => {
                 optionIndexes: [0, 1],
               },
             ],
+            ignoredReasonInfos: [],
           },
           votes: vote(contests, {
             'initiative-65': ['yes', 'no'],
@@ -616,7 +623,8 @@ test('generates a CVR from an adjudicated HMPB page', () => {
           adjudicationInfo: {
             requiresAdjudication: false,
             enabledReasons: [AdjudicationReason.Overvote],
-            allReasonInfos: [],
+            enabledReasonInfos: [],
+            ignoredReasonInfos: [],
           },
           votes: vote(contests, {
             '1': '1',
@@ -681,7 +689,8 @@ test('fails to generate a CVR from an invalid HMPB sheet with two pages having t
           adjudicationInfo: {
             requiresAdjudication: false,
             enabledReasons: [],
-            allReasonInfos: [],
+            enabledReasonInfos: [],
+            ignoredReasonInfos: [],
           },
           markInfo: {
             marks: [],
@@ -735,7 +744,8 @@ test('fails to generate a CVR from an invalid HMPB sheet with two non-consecutiv
           adjudicationInfo: {
             requiresAdjudication: false,
             enabledReasons: [],
-            allReasonInfos: [],
+            enabledReasonInfos: [],
+            ignoredReasonInfos: [],
           },
           markInfo: {
             marks: [],
@@ -788,7 +798,8 @@ test('fails to generate a CVR from an invalid HMPB sheet with different ballot s
           adjudicationInfo: {
             requiresAdjudication: false,
             enabledReasons: [],
-            allReasonInfos: [],
+            enabledReasonInfos: [],
+            ignoredReasonInfos: [],
           },
           markInfo: {
             marks: [],
@@ -841,7 +852,8 @@ test('fails to generate a CVR from an invalid HMPB sheet with different precinct
           adjudicationInfo: {
             requiresAdjudication: false,
             enabledReasons: [],
-            allReasonInfos: [],
+            enabledReasonInfos: [],
+            ignoredReasonInfos: [],
           },
           markInfo: {
             marks: [],
@@ -895,7 +907,8 @@ test('generates a CVR from an adjudicated uninterpreted HMPB page', () => {
           adjudicationInfo: {
             requiresAdjudication: false,
             enabledReasons: [],
-            allReasonInfos: [],
+            enabledReasonInfos: [],
+            ignoredReasonInfos: [],
           },
           markInfo: {
             marks: [],
@@ -990,7 +1003,7 @@ test('generates a CVR from an adjudicated write-in', () => {
           adjudicationInfo: {
             requiresAdjudication: true,
             enabledReasons: [AdjudicationReason.WriteIn],
-            allReasonInfos: [
+            enabledReasonInfos: [
               {
                 type: AdjudicationReason.WriteIn,
                 contestId: '2',
@@ -998,6 +1011,7 @@ test('generates a CVR from an adjudicated write-in', () => {
                 optionIndex: 3,
               },
             ],
+            ignoredReasonInfos: [],
           },
           markInfo: {
             marks: [],
@@ -1037,7 +1051,8 @@ test('generates a CVR from an adjudicated write-in', () => {
           adjudicationInfo: {
             requiresAdjudication: false,
             enabledReasons: [],
-            allReasonInfos: [],
+            enabledReasonInfos: [],
+            ignoredReasonInfos: [],
           },
           markInfo: {
             marks: [],
@@ -1098,7 +1113,7 @@ test('generates a CVR from an adjudicated unmarked write-in', () => {
           adjudicationInfo: {
             requiresAdjudication: true,
             enabledReasons: [AdjudicationReason.UnmarkedWriteIn],
-            allReasonInfos: [
+            enabledReasonInfos: [
               {
                 type: AdjudicationReason.UnmarkedWriteIn,
                 contestId: '2',
@@ -1106,6 +1121,7 @@ test('generates a CVR from an adjudicated unmarked write-in', () => {
                 optionIndex: 3,
               },
             ],
+            ignoredReasonInfos: [],
           },
           markInfo: {
             marks: [],
@@ -1139,7 +1155,8 @@ test('generates a CVR from an adjudicated unmarked write-in', () => {
           adjudicationInfo: {
             requiresAdjudication: false,
             enabledReasons: [],
-            allReasonInfos: [],
+            enabledReasonInfos: [],
+            ignoredReasonInfos: [],
           },
           markInfo: {
             marks: [],

--- a/apps/module-scan/src/importer.test.ts
+++ b/apps/module-scan/src/importer.test.ts
@@ -530,7 +530,8 @@ test('importing a sheet normalizes and orders HMPB pages', async () => {
             },
             adjudicationInfo: {
               requiresAdjudication: false,
-              allReasonInfos: [],
+              ignoredReasonInfos: [],
+              enabledReasonInfos: [],
               enabledReasons: [],
             },
             votes: {},
@@ -655,7 +656,8 @@ test('rejects pages that do not match the current precinct', async () => {
             },
             adjudicationInfo: {
               requiresAdjudication: false,
-              allReasonInfos: [],
+              ignoredReasonInfos: [],
+              enabledReasonInfos: [],
               enabledReasons: [],
             },
             votes: {},
@@ -784,7 +786,8 @@ test('rejects sheets that would not produce a valid CVR', async () => {
             },
             adjudicationInfo: {
               requiresAdjudication: false,
-              allReasonInfos: [],
+              ignoredReasonInfos: [],
+              enabledReasonInfos: [],
               enabledReasons: [],
             },
             votes: {},

--- a/apps/module-scan/src/interpreter.test.ts
+++ b/apps/module-scan/src/interpreter.test.ts
@@ -280,8 +280,9 @@ test('interprets marks on an upside-down HMPB', async () => {
   ).toMatchInlineSnapshot(`
     Object {
       "adjudicationInfo": Object {
-        "allReasonInfos": Array [],
+        "enabledReasonInfos": Array [],
         "enabledReasons": Array [],
+        "ignoredReasonInfos": Array [],
         "requiresAdjudication": false,
       },
       "markInfo": Object {
@@ -1833,7 +1834,9 @@ test('interprets marks in PNG ballots', async () => {
     ).toMatchInlineSnapshot(`
       Object {
         "adjudicationInfo": Object {
-          "allReasonInfos": Array [
+          "enabledReasonInfos": Array [],
+          "enabledReasons": Array [],
+          "ignoredReasonInfos": Array [
             Object {
               "contestId": "4",
               "optionId": "__write-in-0",
@@ -1854,7 +1857,6 @@ test('interprets marks in PNG ballots', async () => {
               "type": "Overvote",
             },
           ],
-          "enabledReasons": Array [],
           "requiresAdjudication": false,
         },
         "markInfo": Object {
@@ -2818,8 +2820,9 @@ test('interprets marks in PNG ballots', async () => {
     ).toMatchInlineSnapshot(`
       Object {
         "adjudicationInfo": Object {
-          "allReasonInfos": Array [],
+          "enabledReasonInfos": Array [],
           "enabledReasons": Array [],
+          "ignoredReasonInfos": Array [],
           "requiresAdjudication": false,
         },
         "markInfo": Object {
@@ -3119,7 +3122,8 @@ const pageInterpretationBoilerplate: InterpretedHmpbPage = {
   },
   votes: {},
   adjudicationInfo: {
-    allReasonInfos: [],
+    ignoredReasonInfos: [],
+    enabledReasonInfos: [],
     enabledReasons: [],
     requiresAdjudication: false,
   },
@@ -3159,7 +3163,7 @@ test('sheetRequiresAdjudication triggers if front or back requires adjudication'
     ...pageInterpretationBoilerplate,
     adjudicationInfo: {
       ...pageInterpretationBoilerplate.adjudicationInfo,
-      allReasonInfos: [
+      enabledReasonInfos: [
         {
           type: AdjudicationReason.Overvote,
           contestId: '42',
@@ -3168,6 +3172,7 @@ test('sheetRequiresAdjudication triggers if front or back requires adjudication'
           expected: 1,
         },
       ],
+      ignoredReasonInfos: [],
       requiresAdjudication: true,
     },
   }
@@ -3215,7 +3220,8 @@ test('sheetRequiresAdjudication triggers for HMPB/blank page', async () => {
         AdjudicationReason.BlankBallot,
         AdjudicationReason.UninterpretableBallot,
       ],
-      allReasonInfos: [{ type: AdjudicationReason.BlankBallot }],
+      enabledReasonInfos: [{ type: AdjudicationReason.BlankBallot }],
+      ignoredReasonInfos: [],
     },
   }
 
@@ -3228,7 +3234,8 @@ test('sheetRequiresAdjudication triggers for HMPB/blank page', async () => {
     adjudicationInfo: {
       requiresAdjudication: false,
       enabledReasons: [],
-      allReasonInfos: [],
+      enabledReasonInfos: [],
+      ignoredReasonInfos: [],
     },
   }
 

--- a/apps/module-scan/src/server.test.ts
+++ b/apps/module-scan/src/server.test.ts
@@ -373,7 +373,8 @@ test('GET /scan/hmpb/ballot/:ballotId/:side/image', async () => {
         adjudicationInfo: {
           requiresAdjudication: false,
           enabledReasons: [],
-          allReasonInfos: [],
+          enabledReasonInfos: [],
+          ignoredReasonInfos: [],
         },
       },
     },
@@ -399,7 +400,8 @@ test('GET /scan/hmpb/ballot/:ballotId/:side/image', async () => {
         adjudicationInfo: {
           requiresAdjudication: false,
           enabledReasons: [],
-          allReasonInfos: [],
+          enabledReasonInfos: [],
+          ignoredReasonInfos: [],
         },
       },
     },

--- a/apps/module-scan/src/store.test.ts
+++ b/apps/module-scan/src/store.test.ts
@@ -324,7 +324,7 @@ test('adjudication', async () => {
             AdjudicationReason.UninterpretableBallot,
             AdjudicationReason.MarginalMark,
           ],
-          allReasonInfos: [
+          enabledReasonInfos: [
             {
               type: AdjudicationReason.MarginalMark,
               contestId: candidateContests[i].id,
@@ -339,6 +339,7 @@ test('adjudication', async () => {
               optionIndexes: [],
             },
           ],
+          ignoredReasonInfos: [],
         },
       },
     })) as SheetOf<PageInterpretationWithFiles>

--- a/apps/module-scan/src/util/castability.test.ts
+++ b/apps/module-scan/src/util/castability.test.ts
@@ -39,7 +39,8 @@ const interpretedHmpbPage: Readonly<InterpretedHmpbPage> = {
   adjudicationInfo: {
     requiresAdjudication: false,
     enabledReasons: [],
-    allReasonInfos: [],
+    enabledReasonInfos: [],
+    ignoredReasonInfos: [],
   },
   votes: {},
 }

--- a/apps/precinct-scanner/src/api/scan.ts
+++ b/apps/precinct-scanner/src/api/scan.ts
@@ -102,14 +102,8 @@ export async function scanDetectedSheet(): Promise<ScanningResult> {
         if (interpretation.type === 'InterpretedHmpbPage') {
           if (interpretation.adjudicationInfo.requiresAdjudication) {
             for (const reasonInfo of interpretation.adjudicationInfo
-              .allReasonInfos) {
-              if (
-                interpretation.adjudicationInfo.enabledReasons.includes(
-                  reasonInfo.type
-                )
-              ) {
-                adjudicationReasons.push(reasonInfo)
-              }
+              .enabledReasonInfos) {
+              adjudicationReasons.push(reasonInfo)
             }
           }
         } else {

--- a/apps/precinct-scanner/test/fixtures/index.ts
+++ b/apps/precinct-scanner/test/fixtures/index.ts
@@ -21,7 +21,7 @@ export function interpretedHmpb({
     electionDefinition.election.contests,
     (c): c is CandidateContest => c.type === 'candidate'
   )
-  const allReasonInfos: AdjudicationInfo['allReasonInfos'] =
+  const enabledReasonInfos: AdjudicationInfo['enabledReasonInfos'] =
     adjudicationReason === AdjudicationReason.Overvote
       ? [
           {
@@ -38,11 +38,12 @@ export function interpretedHmpb({
   return {
     type: 'InterpretedHmpbPage',
     adjudicationInfo: {
-      allReasonInfos,
+      enabledReasonInfos,
       enabledReasons: [
         AdjudicationReason.Overvote,
         AdjudicationReason.BlankBallot,
       ],
+      ignoredReasonInfos: [],
       requiresAdjudication:
         adjudicationReason === AdjudicationReason.Overvote ||
         adjudicationReason === AdjudicationReason.BlankBallot,

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -934,12 +934,14 @@ export const MarkInfoSchema: z.ZodSchema<MarkInfo> = z.object({
 export interface AdjudicationInfo {
   requiresAdjudication: boolean
   enabledReasons: readonly AdjudicationReason[]
-  allReasonInfos: readonly AdjudicationReasonInfo[]
+  enabledReasonInfos: readonly AdjudicationReasonInfo[]
+  ignoredReasonInfos: readonly AdjudicationReasonInfo[]
 }
 export const AdjudicationInfoSchema: z.ZodSchema<AdjudicationInfo> = z.object({
   requiresAdjudication: z.boolean(),
   enabledReasons: z.array(AdjudicationReasonSchema),
-  allReasonInfos: z.array(AdjudicationReasonInfoSchema),
+  enabledReasonInfos: z.array(AdjudicationReasonInfoSchema),
+  ignoredReasonInfos: z.array(AdjudicationReasonInfoSchema),
 })
 
 export interface BlankPage {


### PR DESCRIPTION
Almost every time we want to look at the adjudication infos we actually just want the subset of them that correspond to the enabled adjudication reasons. This commit makes it so we now store separate lists for the enabled ones and the ignored ones, making it much harder to accidentally use adjudications reason infos that should be ignored.