### PR TITLE
test(ballot-encoder): use `fast-check`

### DIFF
--- a/libs/ballot-encoder/package.json
+++ b/libs/ballot-encoder/package.json
@@ -51,11 +51,11 @@
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-vx": "workspace:*",
+    "fast-check": "^2.18.0",
     "jest": "^26.6.2",
     "jest-watch-typeahead": "^0.6.1",
     "lint-staged": "^10.5.1",
     "prettier": "^2.1.2",
-    "random-js": "^2.1.0",
     "sort-package-json": "^1.50.0",
     "ts-jest": "^26.4.3",
     "typescript": "^4.3.5"

--- a/libs/ballot-encoder/src/bits/BitWriter.ts
+++ b/libs/ballot-encoder/src/bits/BitWriter.ts
@@ -95,7 +95,7 @@ export default class BitWriter {
       throw new Error('size cannot be undefined')
     }
 
-    if (number >= 1 << size) {
+    if (number >= 2 ** size) {
       throw new Error(`overflow: ${number} cannot fit in ${size} bits`)
     }
 
@@ -157,7 +157,7 @@ export default class BitWriter {
     string: string,
     {
       encoding = UTF8Encoding,
-      maxLength = (1 << Uint8Size) - 1,
+      maxLength = 2 ** Uint8Size - 1,
       includeLength = true,
       length,
     }: {

--- a/libs/ballot-encoder/src/bits/encoding.ts
+++ b/libs/ballot-encoder/src/bits/encoding.ts
@@ -54,7 +54,7 @@ export class CustomEncoding implements Encoding {
   /**
    * @param chars a string of representable characters without duplicates
    */
-  constructor(private readonly chars: string) {
+  constructor(readonly chars: string) {
     CustomEncoding.validateChars(chars)
     this.bitsPerElement = sizeof(chars.length - 1)
   }

--- a/libs/ballot-encoder/src/types.ts
+++ b/libs/ballot-encoder/src/types.ts
@@ -1,9 +1,0 @@
-// https://medium.com/dailyjs/typescript-create-a-condition-based-subset-types-9d902cea5b8c
-export type FilterFlags<Base, Condition> = {
-  [Key in keyof Base]: Base[Key] extends Condition ? Key : never
-}
-export type AllowedNames<Base, Condition> = FilterFlags<
-  Base,
-  Condition
->[keyof Base]
-export type SubType<Base, Condition> = Pick<Base, AllowedNames<Base, Condition>>

--- a/libs/ballot-encoder/test/fuzz.test.ts
+++ b/libs/ballot-encoder/test/fuzz.test.ts
@@ -1,355 +1,66 @@
-/**
- * This test file is a bit different from the others. It does fuzz testing of
- * `BitReader` and `BitWriter` by ensuring that a random sequence of
- * corresponding write and read actions yields the appropriate values.
- */
+import fc from 'fast-check'
+import { WriteInEncoding } from '../src'
+import { BitReader, BitWriter, toUint8 } from '../src/bits'
+import { anyWritable, doReads, doWrites, writeInChar } from './utils'
 
-/* @typescript-eslint/no-explicit-any */
+test('read/write booleans', () => {
+  fc.assert(
+    fc.property(fc.array(fc.boolean()), (values) => {
+      const writer = new BitWriter()
+      for (const value of values) {
+        writer.writeBoolean(value)
+      }
+      const reader = new BitReader(writer.toUint8Array())
+      for (const value of values) {
+        expect(reader.readBoolean()).toEqual(value)
+      }
+    })
+  )
+})
 
-import { Random } from 'random-js'
-import { inspect } from 'util'
-import {
-  BitReader,
-  BitWriter,
-  CustomEncoding,
-  Uint8Index,
-  Uint8Size,
-} from '../src/bits'
-import { SubType } from '../src/types'
+test('read/write bytes', () => {
+  fc.assert(
+    fc.property(fc.uint8Array(), (values) => {
+      const writer = new BitWriter()
+      writer.writeUint8(...[...values].map(toUint8))
+      const reader = new BitReader(writer.toUint8Array())
+      for (const value of values) {
+        expect(reader.readUint8()).toEqual(value)
+      }
+    })
+  )
+})
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-type BitWriterMethods = SubType<BitWriter, Function>
-interface BitWriterAction<
-  M extends keyof BitWriterMethods = keyof BitWriterMethods
-> {
-  method: M
-  args: Parameters<BitWriterMethods[M]>
-  returnValue?: ReturnType<BitWriterMethods[M]>
-}
+test('read/write strings', () => {
+  fc.assert(
+    fc.property(fc.string(), (value) => {
+      const writer = new BitWriter()
+      writer.writeString(value)
+      const reader = new BitReader(writer.toUint8Array())
+      expect(reader.readString()).toEqual(value)
+    })
+  )
+})
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-type BitReaderMethods = SubType<BitReader, Function>
-interface BitReaderAction<
-  M extends keyof BitReaderMethods = keyof BitReaderMethods
-> {
-  method: M
-  args: Parameters<BitReaderMethods[M]>
-  returnValue?: ReturnType<BitReaderMethods[M]>
-}
+test('read/write write-ins', () => {
+  fc.assert(
+    fc.property(fc.stringOf(writeInChar), (writeIn) => {
+      const writer = new BitWriter()
+      writer.writeString(writeIn, { encoding: WriteInEncoding })
+      const reader = new BitReader(writer.toUint8Array())
+      expect(reader.readString({ encoding: WriteInEncoding })).toEqual(writeIn)
+    })
+  )
+})
 
-type Action<
-  C extends BitWriter | BitReader = BitWriter | BitReader
-> = C extends BitWriter ? BitWriterAction : BitReaderAction
+test('read/write various values', () => {
+  fc.assert(
+    fc.property(fc.array(anyWritable), (writables) => {
+      const writer = new BitWriter()
+      doWrites(writer, writables)
 
-interface PerformedAction<
-  C extends BitWriter | BitReader = BitWriter | BitReader
-> {
-  receiver: C
-  action: Action<C>
-}
-
-const random = new Random()
-
-type ActionsPair = [BitWriterAction[], BitReaderAction[]]
-
-/**
- * Test cases are a pair of lists for write and read actions that should match
- * up together. The idea is to generate random values that will better exercise
- * the range of values and order of operations possible than hardcoded tests can.
- */
-const testCaseFactories = {
-  'vararg booleans': (): ActionsPair => {
-    const argCount = random.integer(0, 10)
-    const args = Array.from<boolean>({ length: argCount }).map(() =>
-      random.bool()
-    )
-
-    return [
-      [{ method: 'writeBoolean', args }],
-      args.map((arg) => ({
-        method: 'readBoolean',
-        args: [],
-        returnValue: arg,
-      })),
-    ]
-  },
-
-  'length-prefixed utf-8 strings': (): ActionsPair => {
-    const length = random.integer(0, 50)
-    const maxLength = random.integer(length, length * 2)
-    const string = random.string(length)
-
-    return [
-      [{ method: 'writeString', args: [string, { maxLength }] }],
-      // This `as any` is here because `readString` is overloaded and TS cannot
-      // infer the parameters correctly in this instance.
-      [
-        {
-          method: 'readString',
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          args: [{ maxLength }] as any,
-          returnValue: string,
-        },
-      ],
-    ]
-  },
-
-  'length-prefixed strings with custom encoding': (): ActionsPair => {
-    const chars = Array.from(
-      new Set(random.string(random.integer(1, 20))).values()
-    ).join('')
-    const string = random.string(random.integer(0, 50), chars)
-    const encoding = new CustomEncoding(chars)
-
-    return [
-      [{ method: 'writeString', args: [string, { encoding }] }],
-      [{ method: 'readString', args: [{ encoding }], returnValue: string }],
-    ]
-  },
-
-  'dynamic size uints': (): ActionsPair => {
-    const useMax = random.bool()
-
-    if (useMax) {
-      const max = random.integer(0, 1 << 30)
-      const number = random.integer(0, max)
-
-      return [
-        [
-          {
-            method: 'writeUint',
-            args: ([number, { max }] as unknown) as Parameters<
-              BitWriter['writeUint']
-            >,
-          },
-        ],
-        [
-          {
-            method: 'readUint',
-            args: ([{ max }] as unknown) as Parameters<BitReader['readUint']>,
-            returnValue: number,
-          },
-        ],
-      ]
-    }
-
-    const size = random.integer(0, 30)
-    const number = random.integer(0, 1 << (size - 1))
-
-    return [
-      [
-        {
-          method: 'writeUint',
-          args: [number, { size }],
-        },
-      ],
-      [
-        {
-          method: 'readUint',
-          args: [{ size }],
-          returnValue: number,
-        },
-      ],
-    ]
-  },
-
-  'vararg uint1s': (): ActionsPair => {
-    const argCount = random.integer(0, 10)
-    const args = Array.from<0 | 1>({ length: argCount })
-      .fill(0)
-      .map(() => random.integer(0, 1))
-
-    return [
-      [
-        {
-          method: 'writeUint1',
-          args: args as Parameters<BitWriter['writeUint1']>,
-        },
-      ],
-      args.map((arg) => ({
-        method: 'readUint1',
-        args: [],
-        returnValue: arg,
-      })),
-    ]
-  },
-
-  'vararg uint8s': (): ActionsPair => {
-    const argCount = random.integer(0, 10)
-    const args = Array.from<Uint8Index>({ length: argCount })
-      .fill(0)
-      .map(() => random.integer(0, Uint8Size - 1))
-
-    return [
-      [
-        {
-          method: 'writeUint8',
-          args: args as Parameters<BitWriter['writeUint8']>,
-        },
-      ],
-      args.map((arg) => ({
-        method: 'readUint8',
-        args: [],
-        returnValue: arg,
-      })),
-    ]
-  },
-}
-
-const codeColor = '\x1b[38;5;202m'
-const dimColor = '\x1b[38;5;240m'
-const resetColor = '\x1b[0m'
-
-/**
- * Formats `action` in pseudocode calling syntax.
- *
- * @example
- *
- * formatAction({ method: 'push', args: [1], receiver: array })               // Array#push(1)
- * formatAction({ method: 'pop', args: [], receiver: array, returnValue: 1 }) // Array#pop() → 1
- */
-function formatAction(
-  { action, receiver }: PerformedAction,
-  includeReturnValue = false
-): string {
-  return `${codeColor}${receiver.constructor.name}#${
-    action.method
-  }(${resetColor}${(action.args as string[])
-    .map((arg) => inspect(arg, { colors: true }))
-    .join(', ')}${codeColor})${resetColor}${
-    includeReturnValue && typeof action.returnValue !== 'undefined'
-      ? ` → ${inspect(action.returnValue, { colors: true })}`
-      : ''
-  }`
-}
-
-/**
- * Formats `actions` in a list, one per line.
- *
- * @example
- *
- * // Formats lists.
- * // - Array#push(1)
- * // - Array#pop() → 1
- * formatActions([
- *   { method: 'push', args: [1], receiver: array },
- *   { method: 'pop', args: [], receiver: array, returnValue: 1 },
- * ])
- *
- * // Has a basic "null" state.
- * // - n/a
- * formatActions([])
- */
-function formatActions(actions: PerformedAction[]): string {
-  if (actions.length === 0) {
-    return `- ${dimColor}n/a${resetColor}`
-  }
-
-  return actions.map((action) => `- ${formatAction(action, true)}`).join('\n')
-}
-
-/**
- * Performs `action` with `instance` and logs it in `performedActions`. This
- * amounts to calling a method on `instance` and optionally checking its return
- * value. If either the method call fails or the return value is not the
- * expected value, an error will be thrown with the log of performed actions
- * that led to this failure.
- */
-function performAction<C extends BitWriter | BitReader>(
-  action: Action<C>,
-  receiver: C,
-  log: PerformedAction<C>[]
-): void {
-  let actualValue: typeof action['returnValue']
-
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    actualValue = (receiver as any)[action.method](...action.args)
-  } catch (error) {
-    error.message = `After performing these actions:\n${formatActions(
-      log
-    )}\n\nAction ${formatAction({ receiver, action })}${
-      typeof action.returnValue === 'undefined'
-        ? ''
-        : ` (expected return ${inspect(action.returnValue, { colors: true })})`
-    } failed with error message: ${error.message}`
-    throw error
-  }
-
-  if (typeof action.returnValue !== 'undefined') {
-    try {
-      expect(actualValue).toEqual(action.returnValue)
-    } catch (error) {
-      error.message = `After performing these actions:\n${formatActions(
-        log
-      )}\n\nAction ${formatAction({
-        receiver,
-        action,
-      })} did not return expected value.\n\n${error.message}`
-      throw error
-    }
-  }
-
-  log.push({ receiver, action })
-}
-/**
- * Runs a sequence of write operations on `BitWriter`, loads the resulting
- * buffer into a `BitReader`, and then runs a series of read operations checking
- * the return values are as expected.
- *
- * @example
- *
- * doWritesAndReads([
- *   [{ method: 'writeBoolean', args: [true] }],
- *   [{ method: 'readBoolean', args: [], returnValue: true }]
- * ])
- */
-function doWritesAndReads([writes, reads]: ActionsPair): void {
-  const performedActions: PerformedAction[] = []
-  const writer = new BitWriter()
-
-  for (const write of writes) {
-    performAction(write, writer, performedActions)
-  }
-
-  const reader = new BitReader(writer.toUint8Array())
-
-  for (const read of reads) {
-    performAction(read, reader, performedActions)
-  }
-}
-
-const testCaseNames = Object.getOwnPropertyNames(
-  testCaseFactories
-) as (keyof typeof testCaseFactories)[]
-
-for (const testCase of testCaseNames) {
-  test(testCase, () => {
-    for (let i = 0; i < 1000; i += 1) {
-      doWritesAndReads(testCaseFactories[testCase]())
-    }
-  })
-}
-
-/**
- * Bring together a bunch of test cases to be run together on the same
- * `BitWriter` and `BitReader`, to test interactions between them.
- */
-test('all together', () => {
-  for (let i = 0; i < 100; i += 1) {
-    const factories = Array.from({ length: 20 })
-      .fill(undefined)
-      .map(() => testCaseFactories[random.pick(testCaseNames)])
-
-    const [writes, reads]: ActionsPair = [[], []]
-
-    for (const factory of factories) {
-      const [w, r] = factory()
-
-      writes.push(...w)
-      reads.push(...r)
-    }
-
-    doWritesAndReads([writes, reads])
-  }
+      const reader = new BitReader(writer.toUint8Array())
+      doReads(reader, writables)
+    })
+  )
 })

--- a/libs/ballot-encoder/test/utils.ts
+++ b/libs/ballot-encoder/test/utils.ts
@@ -1,0 +1,141 @@
+import fc from 'fast-check'
+import { WriteInEncoding } from '../src'
+import { BitReader, BitWriter, toUint8, Uint1, Uint8 } from '../src/bits'
+
+export const writeInChar = fc
+  .integer(0, WriteInEncoding.chars.length)
+  .map((index) => WriteInEncoding.chars[index] ?? '')
+
+export interface BooleanWritable {
+  readonly type: 'boolean'
+  readonly value: boolean
+}
+
+export interface Uint1Writable {
+  readonly type: 'uint1'
+  readonly value: Uint1
+}
+
+export interface Uint8Writable {
+  readonly type: 'uint8'
+  readonly value: Uint8
+}
+
+export interface UintWritable {
+  readonly type: 'uint'
+  readonly value: number
+  readonly max: number
+}
+
+export interface StringWritable {
+  readonly type: 'string'
+  readonly value: string
+  readonly maxLength?: number
+}
+
+export type AnyWritable =
+  | BooleanWritable
+  | Uint1Writable
+  | Uint8Writable
+  | UintWritable
+  | StringWritable
+
+export const writableBoolean = fc
+  .boolean()
+  .map<BooleanWritable>((value) => ({ type: 'boolean', value }))
+export const writableUint1 = fc
+  .boolean()
+  .map<Uint1Writable>((value) => ({ type: 'uint1', value: value ? 1 : 0 }))
+export const writableUint8 = fc
+  .uint8Array({ minLength: 1, maxLength: 1 })
+  .map<Uint8Writable>(([value]) => ({ type: 'uint8', value: toUint8(value) }))
+export const writableUint = fc
+  .tuple(fc.nat(), fc.nat())
+  .map<[number, number]>(([a, b]) => (a <= b ? [a, b] : [b, a]))
+  .map<UintWritable>(([value, max]) => ({ type: 'uint', value, max }))
+export const writableString = fc
+  .tuple(fc.string(), fc.option(fc.nat()))
+  .map<StringWritable>(([value, max]) => ({
+    type: 'string',
+    value,
+    maxLength: max === null ? undefined : Math.max(max, value.length),
+  }))
+export const anyWritable = fc.oneof<fc.Arbitrary<AnyWritable>[]>(
+  writableBoolean,
+  writableUint1,
+  writableUint8,
+  writableUint,
+  writableString
+)
+
+export function doWrites(
+  writer: BitWriter,
+  writables: readonly AnyWritable[]
+): void {
+  for (const writable of writables) {
+    switch (writable.type) {
+      case 'boolean':
+        writer.writeBoolean(writable.value)
+        break
+
+      case 'uint1':
+        writer.writeUint1(writable.value)
+        break
+
+      case 'uint8':
+        writer.writeUint8(writable.value)
+        break
+
+      case 'uint':
+        writer.writeUint(writable.value, { max: writable.max })
+        break
+
+      case 'string':
+        writer.writeString(writable.value, {
+          maxLength: writable.maxLength,
+        })
+        break
+
+      /* istanbul ignore next */
+      default:
+        // @ts-expect-error - compile-time check on `writable`
+        throw new Error(`unknown writable type: ${writable.type}`)
+    }
+  }
+}
+
+export function doReads(
+  reader: BitReader,
+  writables: readonly AnyWritable[]
+): void {
+  for (const writable of writables) {
+    switch (writable.type) {
+      case 'boolean':
+        expect(reader.readBoolean()).toEqual(writable.value)
+        break
+
+      case 'uint1':
+        expect(reader.readUint1()).toEqual(writable.value)
+        break
+
+      case 'uint8':
+        expect(reader.readUint8()).toEqual(writable.value)
+        break
+
+      case 'uint':
+        expect(reader.readUint({ max: writable.max })).toEqual(writable.value)
+        break
+
+      case 'string':
+        expect(reader.readString({ maxLength: writable.maxLength })).toEqual(
+          writable.value
+        )
+        break
+
+      /* istanbul ignore next */
+      default:
+        // @ts-expect-error - compile-time check on `writable`
+        throw new Error(`unknown writable type: ${writable.type}`)
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1101,11 +1101,11 @@ importers:
       eslint-plugin-no-null: 1.0.2_eslint@7.17.0
       eslint-plugin-prettier: 3.3.1_7c5f1f59332aa465fcd97b1399d2f1c7
       eslint-plugin-vx: link:../eslint-plugin-vx
+      fast-check: 2.18.0
       jest: 26.6.3
       jest-watch-typeahead: 0.6.1_jest@26.6.3
       lint-staged: 10.5.3
       prettier: 2.2.1
-      random-js: 2.1.0
       sort-package-json: 1.50.0
       ts-jest: 26.4.4_jest@26.6.3+typescript@4.3.5
       typescript: 4.3.5
@@ -1126,12 +1126,12 @@ importers:
       eslint-plugin-no-null: ^1.0.2
       eslint-plugin-prettier: ^3.1.4
       eslint-plugin-vx: workspace:*
+      fast-check: ^2.18.0
       jest: ^26.6.2
       jest-watch-typeahead: ^0.6.1
       js-sha256: ^0.9.0
       lint-staged: ^10.5.1
       prettier: ^2.1.2
-      random-js: ^2.1.0
       sort-package-json: ^1.50.0
       ts-jest: ^26.4.3
       typescript: ^4.3.5
@@ -16832,6 +16832,14 @@ packages:
       '0': node >=0.6.0
     resolution:
       integrity: sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=
+  /fast-check/2.18.0:
+    dependencies:
+      pure-rand: 5.0.0
+    dev: true
+    engines:
+      node: '>=8.0.0'
+    resolution:
+      integrity: sha512-7KKUw0wtAJOVrJ1DgmFILd9EmeqMLGtfe5HoEtkYZfYIxohm6Zy7zPq1Zl8t6tPL8A3e86YZrheyGg2m5j8cLA==
   /fast-deep-equal/3.1.3:
     resolution:
       integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -24973,6 +24981,10 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+  /pure-rand/5.0.0:
+    dev: true
+    resolution:
+      integrity: sha512-lD2/y78q+7HqBx2SaT6OT4UcwtvXNRfEpzYEzl0EQ+9gZq2Qi3fa0HDnYPeqQwhlHJFBUhT7AO3mLU3+8bynHA==
   /q/1.5.1:
     dev: false
     engines:
@@ -25059,10 +25071,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==
-  /random-js/2.1.0:
-    dev: true
-    resolution:
-      integrity: sha512-CRUyWmnzmZBA7RZSVGq0xMqmgCyPPxbiKNLFA5ud7KenojVX2s7Gv+V7eB52beKTPGxWRnVZ7D/tCIgYJJ8vNQ==
   /randombytes/2.1.0:
     dependencies:
       safe-buffer: 5.2.1


### PR DESCRIPTION
This replaces my homegrown random fuzz tests with ones using `fast-check`. It's much more robust and actually did discover a bug: `writeUint` was doing a bounds check by bit-shifting, but this produced the wrong result when shifting by 31 (`1 << 31` is a negative number in JS because we're working with signed values).