### PR TITLE
fix(em): preserve scanner ID in CVR filename

### DIFF
--- a/libs/types/src/generic.ts
+++ b/libs/types/src/generic.ts
@@ -189,3 +189,10 @@ export const HexString: z.ZodSchema<string> = z
 export const ISO8601Date = z
   .string()
   .refine(check8601, 'dates must be in ISO8601 format')
+export const MachineId = z
+  .string()
+  .nonempty()
+  .refine(
+    (id) => /^[-A-Z\d]+$/.test(id),
+    'Machine IDs may only contain numbers, uppercase letters, and dashes'
+  )

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -64,6 +64,7 @@
     "eslint-plugin-import": "^2.24.2",
     "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-vx": "workspace:*",
+    "fast-check": "^2.18.0",
     "jest": "^26.6.3",
     "jest-watch-typeahead": "^0.6.4",
     "lint-staged": "^11.0.0",

--- a/libs/utils/src/filenames.ts
+++ b/libs/utils/src/filenames.ts
@@ -1,6 +1,11 @@
 import { strict as assert } from 'assert'
 import moment from 'moment'
-import { Election, ElectionDefinition } from '@votingworks/types'
+import {
+  Election,
+  ElectionDefinition,
+  MachineId,
+  safeParse,
+} from '@votingworks/types'
 
 const SECTION_SEPARATOR = '__'
 const SUBSECTION_SEPARATOR = '_'
@@ -91,9 +96,9 @@ export function generateFilenameForScanningResults(
   isTestMode: boolean,
   time: Date = new Date()
 ): string {
-  const machineString = `machine${SUBSECTION_SEPARATOR}${sanitizeString(
-    machineId
-  )}`
+  const machineString = `machine${SUBSECTION_SEPARATOR}${
+    safeParse(MachineId, machineId).ok() ?? sanitizeString(machineId)
+  }`
   const ballotString = `${numBallotsScanned}${SUBSECTION_SEPARATOR}ballots`
   const timeInformation = moment(time).format(TIME_FORMAT_STRING)
   const filename = `${machineString}${SECTION_SEPARATOR}${ballotString}${SECTION_SEPARATOR}${timeInformation}.jsonl`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1685,6 +1685,7 @@ importers:
       eslint-plugin-import: 2.24.2_eslint@7.26.0+typescript@4.3.5
       eslint-plugin-prettier: 3.4.0_39fed7ca8f33f3403e39ca7e7aa90c0f
       eslint-plugin-vx: link:../eslint-plugin-vx
+      fast-check: 2.18.0
       jest: 26.6.3
       jest-watch-typeahead: 0.6.4_jest@26.6.3
       lint-staged: 11.0.0
@@ -1713,6 +1714,7 @@ importers:
       eslint-plugin-import: ^2.24.2
       eslint-plugin-prettier: ^3.4.0
       eslint-plugin-vx: workspace:*
+      fast-check: ^2.18.0
       fast-text-encoding: ^1.0.2
       fetch-mock: ^9.11.0
       jest: ^26.6.3
@@ -16832,6 +16834,14 @@ packages:
       '0': node >=0.6.0
     resolution:
       integrity: sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=
+  /fast-check/2.18.0:
+    dependencies:
+      pure-rand: 5.0.0
+    dev: true
+    engines:
+      node: '>=8.0.0'
+    resolution:
+      integrity: sha512-7KKUw0wtAJOVrJ1DgmFILd9EmeqMLGtfe5HoEtkYZfYIxohm6Zy7zPq1Zl8t6tPL8A3e86YZrheyGg2m5j8cLA==
   /fast-deep-equal/3.1.3:
     resolution:
       integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -24973,6 +24983,10 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+  /pure-rand/5.0.0:
+    dev: true
+    resolution:
+      integrity: sha512-lD2/y78q+7HqBx2SaT6OT4UcwtvXNRfEpzYEzl0EQ+9gZq2Qi3fa0HDnYPeqQwhlHJFBUhT7AO3mLU3+8bynHA==
   /q/1.5.1:
     dev: false
     engines:


### PR DESCRIPTION
When loading a CVR file EM shows the summary by extracting information from the filename. Because the filename has certain delimiters we have to be careful not to allow those characters to sneak in, so we sanitize the parts of the filename. However, this causes the scanner ID to be shown incorrectly because it may contain dashes (removed) and uppercase characters (converted to lowercase).

This commit fixes that by allowing correctly-formatted scanner IDs to be passed through as-is, sanitizing anything else. To make very sure the parsed values match the original values, this commit also adds a property test that tries many different values and ensures they all round-trip successfully.

Fixes #990