### PR TITLE
feat(test-utils): add election arbitraries for property testing

### DIFF
--- a/libs/test-utils/jest.config.js
+++ b/libs/test-utils/jest.config.js
@@ -4,10 +4,10 @@ module.exports = {
   ...shared,
   coverageThreshold: {
     global: {
-      statements: 38,
-      branches: 33,
-      functions: 33,
-      lines: 41,
+      statements: 52,
+      branches: 45,
+      functions: 61,
+      lines: 54,
     },
   },
 }

--- a/libs/test-utils/package.json
+++ b/libs/test-utils/package.json
@@ -36,6 +36,7 @@
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "@votingworks/types": "workspace:*",
+    "fast-check": "^2.18.0",
     "rxjs": "^6.6.6",
     "zip-stream": "^4.1.0"
   },
@@ -60,6 +61,7 @@
     "react-dom": "^17.0.1",
     "sort-package-json": "^1.50.0",
     "ts-jest": "26",
-    "typescript": "^4.3.5"
+    "typescript": "^4.3.5",
+    "zod": "3.2.0"
   }
 }

--- a/libs/test-utils/src/arbitraries.test.ts
+++ b/libs/test-utils/src/arbitraries.test.ts
@@ -1,0 +1,96 @@
+import {
+  Id,
+  safeParse,
+  safeParseElection,
+  safeParseElectionDefinition,
+  YesNoOptionSchema,
+} from '@votingworks/types'
+import { strict as assert } from 'assert'
+import fc from 'fast-check'
+import {
+  arbitraryCastVoteRecord,
+  arbitraryCastVoteRecords,
+  arbitraryElection,
+  arbitraryElectionDefinition,
+  arbitraryId,
+  arbitraryYesNoOption,
+} from './arbitraries'
+
+test('arbitraryId', () => {
+  fc.assert(
+    fc.property(arbitraryId(), (id) => {
+      safeParse(Id, id).unsafeUnwrap()
+    })
+  )
+})
+
+test('arbitraryYesNoOption', () => {
+  fc.assert(
+    fc.property(arbitraryYesNoOption(), (option) => {
+      safeParse(YesNoOptionSchema, option).unsafeUnwrap()
+    })
+  )
+
+  // specify the ID
+  fc.assert(
+    fc.property(arbitraryYesNoOption({ id: fc.constant('YEP') }), (option) => {
+      expect(option.id).toEqual('YEP')
+    })
+  )
+})
+
+test('arbitraryElection makes valid elections', () => {
+  fc.assert(
+    fc.property(arbitraryElection(), (election) => {
+      safeParseElection(election).unsafeUnwrap()
+    })
+  )
+})
+
+test('arbitraryElectionDefinition makes valid election definitions', () => {
+  fc.assert(
+    fc.property(arbitraryElectionDefinition(), (electionDefinition) => {
+      const parsed = safeParseElectionDefinition(
+        electionDefinition.electionData
+      ).unsafeUnwrap()
+      expect(parsed).toEqual(electionDefinition)
+    })
+  )
+})
+
+test('arbitraryCastVoteRecord(s) makes valid CVRs', () => {
+  fc.assert(
+    fc.property(arbitraryCastVoteRecord(), (cvr) => {
+      assert(cvr._pageNumbers)
+      const [frontPage, backPage] = cvr._pageNumbers
+      expect(backPage - frontPage).toEqual(1)
+    })
+  )
+
+  // specify whether it's a test ballot
+  fc.assert(
+    fc.property(
+      arbitraryCastVoteRecord({ testBallot: fc.constant(true) }),
+      (cvr) => {
+        expect(cvr._testBallot).toBe(true)
+      }
+    )
+  )
+
+  // specify the election
+  const election = fc.sample(arbitraryElection(), 1)[0]
+  const testBallot = fc.sample(fc.boolean())[0]
+  fc.assert(
+    fc.property(arbitraryCastVoteRecords({ election, testBallot }), (cvrs) => {
+      for (const cvr of cvrs) {
+        expect(election.precincts.map(({ id }) => id)).toContain(
+          cvr._precinctId
+        )
+        expect(election.ballotStyles.map(({ id }) => id)).toContain(
+          cvr._ballotStyleId
+        )
+        expect(cvr._testBallot).toBe(testBallot)
+      }
+    })
+  )
+})

--- a/libs/test-utils/src/arbitraries.ts
+++ b/libs/test-utils/src/arbitraries.ts
@@ -1,0 +1,393 @@
+/**
+ * Defines election arbitraries for `fast-check` property tests.
+ */
+
+import fc from 'fast-check'
+import {
+  BallotLayout,
+  BallotPaperSize,
+  BallotStyle,
+  Candidate,
+  CandidateContest,
+  CastVoteRecord,
+  Contests,
+  County,
+  District,
+  Election,
+  ElectionDefinition,
+  Id,
+  MsEitherNeitherContest,
+  Party,
+  Precinct,
+  YesNoContest,
+  YesNoOption,
+} from '@votingworks/types'
+import { createHash } from 'crypto'
+
+// We're only importing this for the types and we can't use `import type`.
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { z } from 'zod'
+
+/**
+ * Wraps another arbitrary, making the value possibly missing.
+ */
+export function arbitraryOptional<T>(
+  arbitrary: fc.Arbitrary<T>
+): fc.Arbitrary<T | undefined> {
+  return fc.oneof(fc.constant(undefined), arbitrary)
+}
+
+function hasUniqueIds<T extends { id: z.TypeOf<typeof Id> }>(
+  values: readonly T[]
+): boolean {
+  return new Set(values.map(({ id }) => id)).size === values.length
+}
+
+/**
+ * Builds values suitable for use as IDs.
+ */
+export function arbitraryId(): fc.Arbitrary<z.TypeOf<typeof Id>> {
+  return (
+    fc
+      .stringOf(fc.constantFrom(...'0123456789abcdefghijklmnopqrstuvwxyz-_'), {
+        minLength: 1,
+      })
+      // make sure IDs don't start with underscore
+      .map((value) => (value.startsWith('_') ? `0${value}` : value))
+  )
+}
+
+/**
+ * Builds values for use as "yes" or "no" options on ballots.
+ */
+export function arbitraryYesNoOption({
+  id,
+}: { id?: fc.Arbitrary<YesNoOption['id']> } = {}): fc.Arbitrary<YesNoOption> {
+  return (id ?? fc.constantFrom('yes', 'no')).chain((yesNoID) =>
+    fc.record({
+      id: fc.constant(yesNoID),
+      label:
+        yesNoID === 'yes'
+          ? fc.constantFrom('Yes', 'Yep', 'Uh-huh')
+          : yesNoID === 'no'
+          ? fc.constantFrom('No', 'Nope', 'Nuh-uh')
+          : fc.string({ minLength: 1 }),
+    })
+  )
+}
+
+/**
+ * Builds values for yes/no contests.
+ */
+export function arbitraryYesNoContest({
+  id = arbitraryId(),
+  districtId = arbitraryId(),
+  partyId = arbitraryOptional(arbitraryId()),
+}: {
+  id?: fc.Arbitrary<YesNoContest['id']>
+  districtId?: fc.Arbitrary<District['id']>
+  partyId?: fc.Arbitrary<Party['id'] | undefined>
+} = {}): fc.Arbitrary<YesNoContest> {
+  return fc.boolean().chain((hasCustomOptions) =>
+    fc.record({
+      type: fc.constant('yesno'),
+      title: fc.string({ minLength: 1 }),
+      shortTitle: fc.string({ minLength: 1 }),
+      section: fc.string({ minLength: 1 }),
+      description: fc.string({ minLength: 1 }),
+      id,
+      districtId,
+      partyId,
+      yesOption: hasCustomOptions
+        ? arbitraryYesNoOption({ id: fc.constant('yes') })
+        : fc.constant(undefined),
+      noOption: hasCustomOptions
+        ? arbitraryYesNoOption({ id: fc.constant('no') })
+        : fc.constant(undefined),
+    })
+  )
+}
+
+/**
+ * Builds candidate values for candidate contests.
+ */
+export function arbitraryCandidate({
+  id = arbitraryId(),
+  partyId = fc.constant(undefined),
+}: {
+  id?: fc.Arbitrary<Candidate['id']>
+  partyId?: fc.Arbitrary<Party['id'] | undefined>
+} = {}): fc.Arbitrary<Candidate> {
+  return fc.record({
+    id,
+    name: fc.string({ minLength: 1 }),
+    isWriteIn: arbitraryOptional(fc.boolean()),
+    partyId,
+  })
+}
+
+/**
+ * Builds values for candidate contest.
+ */
+export function arbitraryCandidateContest({
+  id = arbitraryId(),
+  districtId = arbitraryId(),
+  partyIds = fc.array(arbitraryId(), { minLength: 1 }),
+}: {
+  id?: fc.Arbitrary<CandidateContest['id']>
+  districtId?: fc.Arbitrary<District['id']>
+  partyIds?: fc.Arbitrary<Party['id'][]>
+} = {}): fc.Arbitrary<CandidateContest> {
+  return fc.record({
+    type: fc.constant('candidate'),
+    id,
+    title: fc.string({ minLength: 1 }),
+    section: fc.string({ minLength: 1 }),
+    districtId,
+    allowWriteIns: fc.boolean(),
+    seats: fc.integer({ min: 1, max: 5 }),
+    candidates: fc
+      .array(
+        partyIds
+          .chain((ids) =>
+            ids.length ? fc.constantFrom(...ids) : fc.constant(undefined)
+          )
+          .chain((partyId) =>
+            arbitraryCandidate({ partyId: fc.constant(partyId) })
+          )
+      )
+      .filter(hasUniqueIds),
+  })
+}
+
+export function arbitraryMsEitherNeitherContest({
+  districtId = arbitraryId(),
+}: {
+  districtId?: fc.Arbitrary<District['id']>
+} = {}): fc.Arbitrary<MsEitherNeitherContest> {
+  return fc.record({
+    type: fc.constant('ms-either-neither'),
+    id: arbitraryId(),
+    title: fc.string({ minLength: 1 }),
+    section: fc.string({ minLength: 1 }),
+    description: fc.string({ minLength: 1 }),
+    districtId,
+    eitherNeitherContestId: arbitraryId(),
+    eitherNeitherLabel: fc.string({ minLength: 1 }),
+    eitherOption: arbitraryYesNoOption(),
+    neitherOption: arbitraryYesNoOption(),
+    pickOneContestId: arbitraryId(),
+    firstOption: arbitraryYesNoOption(),
+    secondOption: arbitraryYesNoOption(),
+    pickOneLabel: fc.string({ minLength: 1 }),
+  })
+}
+
+export function arbitraryContests({
+  partyIds,
+}: { partyIds?: fc.Arbitrary<Party['id'][]> } = {}): fc.Arbitrary<Contests> {
+  return fc
+    .tuple(
+      fc.array(arbitraryCandidateContest({ partyIds })),
+      fc.array(
+        fc.oneof(arbitraryYesNoContest(), arbitraryMsEitherNeitherContest())
+      )
+    )
+    .map(([candidateContests, otherContests]) => [
+      ...candidateContests,
+      ...otherContests,
+    ])
+    .filter((contests) => contests.length > 0)
+    .filter(hasUniqueIds)
+}
+
+export function arbitraryDistrict({
+  id = arbitraryId(),
+}: { id?: fc.Arbitrary<District['id']> } = {}): fc.Arbitrary<District> {
+  return fc.record({
+    id,
+    name: fc.string({ minLength: 1 }),
+  })
+}
+
+export function arbitraryPrecinct({
+  id = arbitraryId(),
+}: { id?: fc.Arbitrary<Precinct['id']> } = {}): fc.Arbitrary<Precinct> {
+  return fc.record({
+    id,
+    name: fc.string({ minLength: 1 }),
+  })
+}
+
+export function arbitraryBallotStyle({
+  id = arbitraryId(),
+  districtIds = fc.array(arbitraryId()),
+  precinctIds = fc.array(arbitraryId()),
+}: {
+  id?: fc.Arbitrary<BallotStyle['id']>
+  districtIds?: fc.Arbitrary<District['id'][]>
+  precinctIds?: fc.Arbitrary<Precinct['id'][]>
+} = {}): fc.Arbitrary<BallotStyle> {
+  return fc.record({
+    id,
+    districts: districtIds,
+    precincts: precinctIds,
+  })
+}
+
+export function arbitraryCounty({
+  id = arbitraryId(),
+}: { id?: fc.Arbitrary<County['id']> } = {}): fc.Arbitrary<County> {
+  return fc.record({ id, name: fc.string({ minLength: 1 }) })
+}
+
+export function arbitraryParty({
+  id = arbitraryId(),
+}: { id?: fc.Arbitrary<Party['id']> } = {}): fc.Arbitrary<Party> {
+  return fc
+    .record({
+      id,
+      abbrev: fc.string({ minLength: 1 }),
+      name: fc.string({ minLength: 1 }),
+    })
+    .map((party) => ({ ...party, fullName: `${party.name} Party` }))
+}
+
+export function arbitraryBallotLayout(): fc.Arbitrary<BallotLayout> {
+  return fc.record({
+    paperSize: fc.constantFrom(...Object.values(BallotPaperSize)),
+  })
+}
+
+export function arbitraryElection(): fc.Arbitrary<Election> {
+  return (
+    fc
+      .record({
+        districts: fc
+          .array(arbitraryDistrict(), { minLength: 1 })
+          .filter(hasUniqueIds),
+        precincts: fc
+          .array(arbitraryPrecinct(), { minLength: 1 })
+          .filter(hasUniqueIds),
+        parties: fc.array(arbitraryParty()).filter(hasUniqueIds),
+      })
+      .chain(({ districts, precincts, parties }) =>
+        fc.record<Election>({
+          title: fc.string({ minLength: 1 }),
+          county: arbitraryCounty(),
+          state: fc.string({ minLength: 2, maxLength: 2 }),
+          date: fc.date().map((date) => date.toISOString()),
+          parties: fc.constant(parties),
+          contests: arbitraryContests({
+            partyIds: fc.constant(parties.map(({ id }) => id)),
+          }),
+          ballotStyles: fc
+            .array(
+              arbitraryBallotStyle({
+                districtIds: fc
+                  .shuffledSubarray(districts, { minLength: 1 })
+                  .map((values) => values.map(({ id }) => id)),
+                precinctIds: fc
+                  .shuffledSubarray(precincts, { minLength: 1 })
+                  .map((values) => values.map(({ id }) => id)),
+              }),
+              { minLength: 1 }
+            )
+            .filter(hasUniqueIds),
+          districts: fc.constant(districts),
+          precincts: fc.constant(precincts),
+          ballotLayout: arbitraryBallotLayout(),
+        })
+      )
+      // performing a shrink on this data structure takes forever
+      .noShrink()
+  )
+}
+
+/**
+ * Build an entire valid election definition.
+ *
+ * @example
+ *
+ *   test('rendering ballots does not crash', () => {
+ *     fc.assert(
+ *       fc.property(
+ *         arbitraryElectionDefinition(),
+ *         (electionDefinition) => {
+ *           render(
+ *             <HandMarkedPaperBallot
+ *               electionDefinition={electionDefinition}
+ *             />
+ *           )
+ *           screen.getByText(electionDefinition.election.title)
+ *         }
+ *       )
+ *     )
+ *   })
+ */
+export function arbitraryElectionDefinition(): fc.Arbitrary<ElectionDefinition> {
+  return arbitraryElection()
+    .map((election) => ({
+      election,
+      electionData: JSON.stringify(election, undefined, 2),
+    }))
+    .map(({ election, electionData }) => ({
+      election,
+      electionData,
+      electionHash: createHash('sha256').update(electionData).digest('hex'),
+    }))
+}
+
+/**
+ * Builds valid cast-vote records. To build multiple for a single election,
+ * you may find it easier to use {@see arbitraryCastVoteRecords}.
+ */
+export function arbitraryCastVoteRecord({
+  election = arbitraryElection(),
+  testBallot = fc.boolean(),
+}: {
+  election?: fc.Arbitrary<Election>
+  testBallot?: fc.Arbitrary<boolean>
+} = {}): fc.Arbitrary<CastVoteRecord> {
+  return election.chain((e) =>
+    fc.record({
+      _precinctId: fc.constantFrom(...e.precincts.map(({ id }) => id)),
+      _ballotId: arbitraryId(),
+      _ballotStyleId: fc.constantFrom(...e.ballotStyles.map(({ id }) => id)),
+      _ballotType: fc.constantFrom('absentee', 'provisional', 'standard'),
+      _batchId: arbitraryId(),
+      _batchLabel: fc.string({ minLength: 1 }),
+      _testBallot: testBallot,
+      _scannerId: arbitraryId(),
+      _pageNumbers: fc
+        .integer({ min: 0, max: 3 })
+        .map((index) => [index * 2 + 1, index * 2 + 2]),
+      _locales: arbitraryOptional(
+        fc.record({ primary: fc.constantFrom('en-US') })
+      ),
+    })
+  )
+}
+
+/**
+ * Builds valid cast-vote record lists given an election and test/live setting.
+ */
+export function arbitraryCastVoteRecords({
+  election,
+  testBallot,
+  minLength,
+  maxLength,
+}: {
+  election: Election
+  testBallot: boolean
+  minLength?: number
+  maxLength?: number
+}): fc.Arbitrary<CastVoteRecord[]> {
+  return fc.array(
+    arbitraryCastVoteRecord({
+      election: fc.constant(election),
+      testBallot: fc.constant(testBallot),
+    }),
+    { minLength, maxLength }
+  )
+}

--- a/libs/test-utils/src/index.ts
+++ b/libs/test-utils/src/index.ts
@@ -1,4 +1,5 @@
 export * from './advanceTimers'
+export * from './arbitraries'
 export * from './castVoteRecord'
 export * from './child_process'
 export * from './compressedTallies'

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -205,6 +205,7 @@ export const BallotStyleSchema: z.ZodSchema<BallotStyle> = z.object({
 })
 export const BallotStylesSchema = z
   .array(BallotStyleSchema)
+  .nonempty()
   .superRefine((ballotStyles, ctx) => {
     for (const [index, id] of findDuplicateIds(ballotStyles)) {
       ctx.addIssue({
@@ -253,6 +254,7 @@ export const PrecinctSchema: z.ZodSchema<Precinct> = z.object({
 })
 export const PrecinctsSchema = z
   .array(PrecinctSchema)
+  .nonempty()
   .superRefine((precincts, ctx) => {
     for (const [index, id] of findDuplicateIds(precincts)) {
       ctx.addIssue({
@@ -274,6 +276,7 @@ export const DistrictSchema: z.ZodSchema<District> = z.object({
 })
 export const DistrictsSchema = z
   .array(DistrictSchema)
+  .nonempty()
   .superRefine((districts, ctx) => {
     for (const [index, id] of findDuplicateIds(districts)) {
       ctx.addIssue({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1444,6 +1444,7 @@ importers:
       '@types/jest': 26.0.21
       '@types/node': 14.14.35
       '@votingworks/types': link:../types
+      fast-check: 2.18.0
       rxjs: 6.6.6
       zip-stream: 4.1.0
     devDependencies:
@@ -1468,6 +1469,7 @@ importers:
       sort-package-json: 1.50.0
       ts-jest: 26.5.6_jest@26.6.3+typescript@4.3.5
       typescript: 4.3.5
+      zod: 3.2.0
     specifiers:
       '@testing-library/react': ^11.2.6
       '@types/jest': ^26.0.21
@@ -1484,6 +1486,7 @@ importers:
       eslint-plugin-import: ^2.24.2
       eslint-plugin-prettier: ^3.4.0
       eslint-plugin-vx: workspace:*
+      fast-check: ^2.18.0
       is-ci-cli: ^2.2.0
       jest: '26'
       jest-watch-typeahead: ^0.6.4
@@ -1496,6 +1499,7 @@ importers:
       ts-jest: '26'
       typescript: ^4.3.5
       zip-stream: ^4.1.0
+      zod: 3.2.0
   libs/types:
     dependencies:
       '@antongolub/iso8601': 1.2.1
@@ -16892,7 +16896,6 @@ packages:
   /fast-check/2.18.0:
     dependencies:
       pure-rand: 5.0.0
-    dev: true
     engines:
       node: '>=8.0.0'
     resolution:
@@ -25172,7 +25175,6 @@ packages:
     resolution:
       integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
   /pure-rand/5.0.0:
-    dev: true
     resolution:
       integrity: sha512-lD2/y78q+7HqBx2SaT6OT4UcwtvXNRfEpzYEzl0EQ+9gZq2Qi3fa0HDnYPeqQwhlHJFBUhT7AO3mLU3+8bynHA==
   /q/1.5.1:
@@ -30325,7 +30327,6 @@ packages:
     resolution:
       integrity: sha512-zshzwQW7gG7hjpBlgeQP9RuyPGNxvJdzR8SUM3QhxCnLjWN2E7j3dOvpeDcQoETfHx0urRS7EtmVToql7YpU4A==
   /zod/3.2.0:
-    dev: false
     resolution:
       integrity: sha512-yvcO3FZ8URR+LliMGqaW7tlVOOTzmup3vzKEe9Ds7twyJtdhvYa7dIYr0FbD1wVfWC1OuS83vZfHtCKslPuRhA==
   /zwitch/1.0.5:


### PR DESCRIPTION
## Context

An "arbitrary" is what `fast-check` calls a random value generator for a specific type of value. It [ships with a bunch of basic ones](https://github.com/dubzzz/fast-check/blob/main/documentation/Arbitraries.md) like `fc.boolean()`, `fc.integer()`, `fc.string()`, etc. Arbitraries can be composed with some useful utilities like `fc.array()`, `fc.oneof()`, `fc.map()`, and `fc.chain()`.

When writing property-based tests you pass one or more `fc.Arbitrary` instances to `fc.assert` and it will call your check function with many generated values until it finds one that fails or it hits the maximum number of tries. If it finds a failing case it'll try to shrink it down to a minimal test case and show the error along with the minimal example.

## How this applies to vxsuite

We've got many different possible values for everything defining an election and the results and we can't easily test a wide variety of them. Property testing is one tool, in addition to the concrete hardcoded tests we have now, that allows us to widen the example space to find areas our code does not handle. It may mean that we write fewer tests with hardcoded values, but those will still have their place.

## What this commit adds

You'll now be able to import arbitraries for building entire `ElectionDefinition` objects or some part of them. This could be used  to test component rendering of election contests or metadata, to check tally code, etc.