### PR TITLE
build(lint): fix `tsconfig.json`

### DIFF
--- a/libs/eslint-plugin-vx/tsconfig.build.json
+++ b/libs/eslint-plugin-vx/tsconfig.build.json
@@ -1,5 +1,10 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "build",
+    "rootDir": "src"
+  },
   "include": ["src"],
   "exclude": []
 }

--- a/libs/eslint-plugin-vx/tsconfig.json
+++ b/libs/eslint-plugin-vx/tsconfig.json
@@ -5,9 +5,8 @@
     "module": "CommonJS",
     "moduleResolution": "Node",
     "esModuleInterop": true,
+    "noEmit": true,
     "composite": true,
-    "outDir": "build",
-    "rootDir": "src",
     "skipLibCheck": true
   },
   "include": ["src", "tests"],


### PR DESCRIPTION
TypeScript was complaining when we included `tests` but it wasn't in `rootDir`, so I moved `rootDir` to `tsconfig.build.json` and tweaked the `noEmit` settings.