### PR TITLE
feat(eslint) add rule for checking allowed characters in identifiers

### DIFF
--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -38,6 +38,7 @@ export = {
     'vx/gts-array-type-style': 'error',
     'vx/gts-direct-module-export-access-only': 'error',
     'vx/gts-func-style': 'error',
+    'vx/gts-identifiers-use-allowed-character': 'error',
     'vx/gts-no-array-constructor': 'error',
     'vx/gts-no-dollar-sign-names': 'error',
     'vx/gts-no-foreach': 'error',

--- a/libs/eslint-plugin-vx/src/rules/gts-identifiers-use-allowed-characters.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts-identifiers-use-allowed-characters.ts
@@ -1,0 +1,35 @@
+import { TSESTree } from '@typescript-eslint/experimental-utils';
+import { createRule } from '../util';
+
+export default createRule({
+  name: 'gts-identifiers-use-allowed-characters',
+  meta: {
+    docs: {
+      description:
+        'Identifiers must use only ASCII letters, digits, underscores, and the "(" sign',
+      category: 'Best Practices',
+      recommended: 'error',
+      suggestion: false,
+      requiresTypeChecking: false,
+    },
+    messages: {
+      identifiersAllowedCharacters: `Identifiers must use only allowed characters: ASCII letters, digits, underscores and the '(' sign`,
+    },
+    schema: [],
+    type: 'problem',
+  },
+  defaultOptions: [],
+
+  create(context) {
+    return {
+      Identifier(node: TSESTree.Identifier): void {
+        if (!/^[$)\w]+$/.test(node.name)) {
+          context.report({
+            messageId: 'identifiersAllowedCharacters',
+            node,
+          });
+        }
+      },
+    };
+  },
+});

--- a/libs/eslint-plugin-vx/src/rules/index.ts
+++ b/libs/eslint-plugin-vx/src/rules/index.ts
@@ -14,11 +14,13 @@ import gtsUseOptionals from './gts-use-optionals';
 import noArraySortMutation from './no-array-sort-mutation';
 import noAssertStringOrNumber from './no-assert-truthiness';
 import noFloatingVoids from './no-floating-results';
+import gtsIdentifiersUseAllowedCharacters from './gts-identifiers-use-allowed-characters';
 
 export default {
   'gts-array-type-style': gtsArrayTypeStyle,
   'gts-direct-module-export-access-only': gtsDirectModuleExportAccessOnly,
   'gts-func-style': gtsFuncStyle,
+  'gts-identifiers-use-allowed-character': gtsIdentifiersUseAllowedCharacters,
   'gts-no-array-constructor': gtsNoArrayConstructor,
   'gts-no-dollar-sign-names': gtsNoDollarSignNames,
   'gts-no-foreach': gtsNoForeach,

--- a/libs/eslint-plugin-vx/tests/rules/gts-identifiers-use-allowed-characters.test.ts
+++ b/libs/eslint-plugin-vx/tests/rules/gts-identifiers-use-allowed-characters.test.ts
@@ -1,0 +1,29 @@
+import { ESLintUtils } from '@typescript-eslint/experimental-utils';
+import { join } from 'path';
+import rule from '../../src/rules/gts-identifiers-use-allowed-characters';
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    tsconfigRootDir: join(__dirname, '../fixtures'),
+    project: './tsconfig.json',
+  },
+  parser: '@typescript-eslint/parser',
+});
+
+ruleTester.run('gts-identifiers-use-allowed-characters', rule, {
+  valid: [
+    { code: `const abc = 12` },
+    { code: `const a_b_c = 12` },
+    { code: `function ab_() {}` },
+    {
+      code: `const $button = $('.button')`,
+    }, // dollar signs are handled by the separate gts-no-dollar-sign-names rule
+  ],
+  invalid: [
+    {
+      code: 'const illegalnÀme = 12',
+      errors: [{ messageId: 'identifiersAllowedCharacters', line: 1 }],
+    },
+  ],
+});


### PR DESCRIPTION
https://google.github.io/styleguide/tsguide.html#identifiers 
I added '$' to the regex in the styleguide since we already have a separate eslint rule for handling dollar signs. 

I wanted to add a test case for the allowed '(' usage but couldn't figure out how to make a parsable expression with that so let me know if you understand why/how '(' is allowed. 

https://zube.io/votingworks/vxsuite/c/3788