### PR TITLE
refactor(types): make `ContestId` a distinct type

### DIFF
--- a/apps/bmd/src/AppContestCandidateNoParty.test.tsx
+++ b/apps/bmd/src/AppContestCandidateNoParty.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryStorage, MemoryCard, MemoryHardware } from '@votingworks/utils';
 
-import { Election } from '@votingworks/types';
+import { Election, safeParseElection } from '@votingworks/types';
 import { asElectionDefinition } from '@votingworks/fixtures';
 import { makeVoterCard } from '@votingworks/test-utils';
 import App from './App';
@@ -14,7 +14,7 @@ import electionSample from './data/electionSample.json';
 import { electionStorageKey } from './AppRoot';
 import { fakeMachineConfigProvider } from '../test/helpers/fakeMachineConfig';
 
-const election = electionSample as Election;
+const election = safeParseElection(electionSample).unsafeUnwrap();
 const electionWithNoPartyCandidateContests: Election = {
   ...election,
   contests: election.contests.map((contest) => {

--- a/apps/bmd/src/AppRoot.tsx
+++ b/apps/bmd/src/AppRoot.tsx
@@ -3,6 +3,7 @@ import makeDebug from 'debug';
 import {
   BallotType,
   CompletedBallot,
+  ContestId,
   ElectionDefinition,
   OptionalElectionDefinition,
   OptionalVote,
@@ -230,7 +231,7 @@ type AppAction =
   | { type: 'setMachineConfig'; machineConfig: MachineConfig }
   | { type: 'updateLastVoteUpdateAt'; date: number }
   | { type: 'unconfigure' }
-  | { type: 'updateVote'; contestId: string; vote: OptionalVote }
+  | { type: 'updateVote'; contestId: ContestId; vote: OptionalVote }
   | { type: 'forceSaveVote' }
   | { type: 'resetBallot'; showPostVotingInstructions?: PostVotingInstructions }
   | { type: 'setUserSettings'; userSettings: PartialUserSettings }
@@ -602,7 +603,7 @@ function AppRoot({
     history.push('/');
   }, [storage, history]);
 
-  const updateVote = useCallback((contestId: string, vote: OptionalVote) => {
+  const updateVote = useCallback((contestId: ContestId, vote: OptionalVote) => {
     dispatchAppState({ type: 'updateVote', contestId, vote });
   }, []);
 

--- a/apps/bmd/src/components/CandidateContest.test.tsx
+++ b/apps/bmd/src/components/CandidateContest.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 
 import {
   CandidateContest as CandidateContestInterface,
+  ContestIdSchema,
   Parties,
 } from '@votingworks/types';
 
@@ -24,7 +25,7 @@ const contest: CandidateContestInterface = {
     partyId: `party-${i % 2}`,
   })),
   districtId: '7',
-  id: 'contest-id',
+  id: ContestIdSchema.parse('contest-id'),
   seats: 1,
   section: 'City',
   title: 'Mayor',

--- a/apps/bmd/src/components/YesNoContest.test.tsx
+++ b/apps/bmd/src/components/YesNoContest.test.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { YesNoContest as YesNoContestInterface } from '@votingworks/types';
+import {
+  ContestIdSchema,
+  YesNoContest as YesNoContestInterface,
+} from '@votingworks/types';
 
 import YesNoContest from './YesNoContest';
 
@@ -8,7 +11,7 @@ const contest: YesNoContestInterface = {
   description:
     'Institute a garbage collection program that collects garbage on weekdays across the county.',
   districtId: 'district-id',
-  id: 'contest-id',
+  id: ContestIdSchema.parse('contest-id'),
   section: 'County',
   shortTitle: 'Prop 1',
   title: 'Prop 1: Garbage Collection Program',

--- a/apps/bmd/src/config/types.ts
+++ b/apps/bmd/src/config/types.ts
@@ -2,6 +2,7 @@ import {
   BallotStyle,
   CandidateContest,
   CandidateVote,
+  ContestId,
   Contests,
   ElectionDefinition,
   MachineId,
@@ -105,7 +106,7 @@ export type PrecinctSelection =
 
 // Ballot
 export type UpdateVoteFunction = (
-  contestId: string,
+  contestId: ContestId,
   vote: OptionalVote
 ) => void;
 export type MarkVoterCardFunction = () => Promise<boolean>;

--- a/apps/bmd/src/pages/PollWorkerScreen.test.tsx
+++ b/apps/bmd/src/pages/PollWorkerScreen.test.tsx
@@ -5,6 +5,8 @@ import {
 } from '@votingworks/fixtures';
 import {
   CompressedTally,
+  ContestId,
+  ContestIdSchema,
   Dictionary,
   Election,
   safeParseElection,
@@ -51,7 +53,7 @@ function expectBallotCountsInReport(
 
 function expectContestResultsInReport(
   container: HTMLElement,
-  contestId: string,
+  contestId: ContestId,
   ballotsCast: number,
   undervotes: number,
   overvotes: number,
@@ -247,14 +249,21 @@ test('printing precinct scanner report works as expected with all precinct data 
   );
   expect(allPrecinctsReports).toHaveLength(2);
   expectBallotCountsInReport(allPrecinctsReports[0], 20, 5, 25);
-  expectContestResultsInReport(allPrecinctsReports[0], 'president', 34, 6, 0, {
-    'barchi-hallaren': 6,
-    'cramer-vuocolo': 5,
-    'court-blumhardt': 6,
-    'boone-lian': 5,
-    'hildebrand-garritty': 3,
-    'patterson-lariviere': 0,
-  });
+  expectContestResultsInReport(
+    allPrecinctsReports[0],
+    ContestIdSchema.parse('president'),
+    34,
+    6,
+    0,
+    {
+      'barchi-hallaren': 6,
+      'cramer-vuocolo': 5,
+      'court-blumhardt': 6,
+      'boone-lian': 5,
+      'hildebrand-garritty': 3,
+      'patterson-lariviere': 0,
+    }
+  );
   const senatorContest = screen.getAllByTestId('results-table-senator')[0];
   within(senatorContest).getByText(/0 ballots/);
   within(senatorContest).getByText(/0 undervotes/);
@@ -329,7 +338,7 @@ test('printing precinct scanner report works as expected with single precinct da
   expectBallotCountsInReport(centerSpringfieldReports[0], 20, 5, 25);
   expectContestResultsInReport(
     centerSpringfieldReports[0],
-    'president',
+    ContestIdSchema.parse('president'),
     34,
     6,
     0,
@@ -427,7 +436,7 @@ test('printing precinct scanner report works as expected with all precinct speci
   expectBallotCountsInReport(centerSpringfieldReports[0], 10, 0, 10);
   expectContestResultsInReport(
     centerSpringfieldReports[0],
-    'president',
+    ContestIdSchema.parse('president'),
     10,
     1,
     1,
@@ -448,7 +457,7 @@ test('printing precinct scanner report works as expected with all precinct speci
   expectBallotCountsInReport(northSpringfieldReports[0], 10, 5, 15);
   expectContestResultsInReport(
     northSpringfieldReports[0],
-    'president',
+    ContestIdSchema.parse('president'),
     15,
     2,
     3,
@@ -469,7 +478,7 @@ test('printing precinct scanner report works as expected with all precinct speci
   expectBallotCountsInReport(southSpringfieldReports[0], 0, 0, 0);
   expectContestResultsInReport(
     southSpringfieldReports[0],
-    'president',
+    ContestIdSchema.parse('president'),
     0,
     0,
     0,
@@ -585,7 +594,7 @@ test('printing precinct scanner report works as expected with all precinct speci
   ).toHaveLength(0);
   expectContestResultsInReport(
     precinct1MammalReports[0],
-    'best-animal-mammal',
+    ContestIdSchema.parse('best-animal-mammal'),
     1,
     0,
     0,
@@ -593,7 +602,7 @@ test('printing precinct scanner report works as expected with all precinct speci
   );
   expectContestResultsInReport(
     precinct1MammalReports[0],
-    'zoo-council-mammal',
+    ContestIdSchema.parse('zoo-council-mammal'),
     1,
     1,
     0,
@@ -601,7 +610,7 @@ test('printing precinct scanner report works as expected with all precinct speci
   );
   expectContestResultsInReport(
     precinct1MammalReports[0],
-    'new-zoo-either',
+    ContestIdSchema.parse('new-zoo-either'),
     1,
     0,
     0,
@@ -609,14 +618,14 @@ test('printing precinct scanner report works as expected with all precinct speci
   );
   expectContestResultsInReport(
     precinct1MammalReports[0],
-    'new-zoo-pick',
+    ContestIdSchema.parse('new-zoo-pick'),
     1,
     1,
     0,
     { yes: 0, no: 0 }
   );
   // Check that the expected results are on the tally report for Precinct 1 Fish Party
-  const precinct1FishReports = await screen.getAllByTestId(
+  const precinct1FishReports = screen.getAllByTestId(
     'tally-report-1-precinct-1'
   );
   expect(precinct1FishReports).toHaveLength(2);
@@ -628,7 +637,7 @@ test('printing precinct scanner report works as expected with all precinct speci
   ).toHaveLength(0);
   expectContestResultsInReport(
     precinct1FishReports[0],
-    'best-animal-fish',
+    ContestIdSchema.parse('best-animal-fish'),
     0,
     0,
     0,
@@ -636,7 +645,7 @@ test('printing precinct scanner report works as expected with all precinct speci
   );
   expectContestResultsInReport(
     precinct1FishReports[0],
-    'aquarium-council-fish',
+    ContestIdSchema.parse('aquarium-council-fish'),
     0,
     0,
     0,
@@ -648,12 +657,19 @@ test('printing precinct scanner report works as expected with all precinct speci
       '__write-in': 0,
     }
   );
-  expectContestResultsInReport(precinct1FishReports[0], 'fishing', 0, 0, 0, {
-    yes: 0,
-    no: 0,
-  });
+  expectContestResultsInReport(
+    precinct1FishReports[0],
+    ContestIdSchema.parse('fishing'),
+    0,
+    0,
+    0,
+    {
+      yes: 0,
+      no: 0,
+    }
+  );
   // Check that the expected results are on the tally report for Precinct 2 Mammal Party
-  const precinct2MammalReports = await screen.getAllByTestId(
+  const precinct2MammalReports = screen.getAllByTestId(
     'tally-report-0-precinct-2'
   );
   expect(precinct2MammalReports).toHaveLength(2);
@@ -665,7 +681,7 @@ test('printing precinct scanner report works as expected with all precinct speci
   ).toHaveLength(0);
   expectContestResultsInReport(
     precinct2MammalReports[0],
-    'best-animal-mammal',
+    ContestIdSchema.parse('best-animal-mammal'),
     1,
     0,
     1,
@@ -673,7 +689,7 @@ test('printing precinct scanner report works as expected with all precinct speci
   );
   expectContestResultsInReport(
     precinct2MammalReports[0],
-    'zoo-council-mammal',
+    ContestIdSchema.parse('zoo-council-mammal'),
     1,
     2,
     0,
@@ -681,7 +697,7 @@ test('printing precinct scanner report works as expected with all precinct speci
   );
   expectContestResultsInReport(
     precinct2MammalReports[0],
-    'new-zoo-either',
+    ContestIdSchema.parse('new-zoo-either'),
     1,
     0,
     0,
@@ -689,14 +705,14 @@ test('printing precinct scanner report works as expected with all precinct speci
   );
   expectContestResultsInReport(
     precinct2MammalReports[0],
-    'new-zoo-pick',
+    ContestIdSchema.parse('new-zoo-pick'),
     1,
     0,
     0,
     { yes: 0, no: 1 }
   );
   // Check that the expected results are on the tally report for Precinct 2 Fish Party
-  const precinct2FishReports = await screen.getAllByTestId(
+  const precinct2FishReports = screen.getAllByTestId(
     'tally-report-1-precinct-2'
   );
   expect(precinct2FishReports).toHaveLength(2);
@@ -708,7 +724,7 @@ test('printing precinct scanner report works as expected with all precinct speci
   ).toHaveLength(0);
   expectContestResultsInReport(
     precinct2FishReports[0],
-    'best-animal-fish',
+    ContestIdSchema.parse('best-animal-fish'),
     1,
     0,
     0,
@@ -716,7 +732,7 @@ test('printing precinct scanner report works as expected with all precinct speci
   );
   expectContestResultsInReport(
     precinct2FishReports[0],
-    'aquarium-council-fish',
+    ContestIdSchema.parse('aquarium-council-fish'),
     1,
     0,
     0,
@@ -728,10 +744,17 @@ test('printing precinct scanner report works as expected with all precinct speci
       '__write-in': 0,
     }
   );
-  expectContestResultsInReport(precinct2FishReports[0], 'fishing', 1, 0, 0, {
-    yes: 0,
-    no: 1,
-  });
+  expectContestResultsInReport(
+    precinct2FishReports[0],
+    ContestIdSchema.parse('fishing'),
+    1,
+    0,
+    0,
+    {
+      yes: 0,
+      no: 1,
+    }
+  );
 });
 
 test('printing precinct scanner report works as expected with all precinct combined data for primary election', async () => {
@@ -816,7 +839,7 @@ test('printing precinct scanner report works as expected with all precinct combi
   ).toHaveLength(0);
   expectContestResultsInReport(
     allPrecinctMammalReports[0],
-    'best-animal-mammal',
+    ContestIdSchema.parse('best-animal-mammal'),
     2,
     0,
     1,
@@ -824,7 +847,7 @@ test('printing precinct scanner report works as expected with all precinct combi
   );
   expectContestResultsInReport(
     allPrecinctMammalReports[0],
-    'zoo-council-mammal',
+    ContestIdSchema.parse('zoo-council-mammal'),
     2,
     3,
     0,
@@ -832,7 +855,7 @@ test('printing precinct scanner report works as expected with all precinct combi
   );
   expectContestResultsInReport(
     allPrecinctMammalReports[0],
-    'new-zoo-either',
+    ContestIdSchema.parse('new-zoo-either'),
     2,
     0,
     0,
@@ -840,7 +863,7 @@ test('printing precinct scanner report works as expected with all precinct combi
   );
   expectContestResultsInReport(
     allPrecinctMammalReports[0],
-    'new-zoo-pick',
+    ContestIdSchema.parse('new-zoo-pick'),
     2,
     1,
     0,
@@ -859,7 +882,7 @@ test('printing precinct scanner report works as expected with all precinct combi
   ).toHaveLength(0);
   expectContestResultsInReport(
     allPrecinctFishReports[0],
-    'best-animal-fish',
+    ContestIdSchema.parse('best-animal-fish'),
     1,
     0,
     0,
@@ -867,7 +890,7 @@ test('printing precinct scanner report works as expected with all precinct combi
   );
   expectContestResultsInReport(
     allPrecinctFishReports[0],
-    'aquarium-council-fish',
+    ContestIdSchema.parse('aquarium-council-fish'),
     1,
     0,
     0,
@@ -879,10 +902,17 @@ test('printing precinct scanner report works as expected with all precinct combi
       '__write-in': 0,
     }
   );
-  expectContestResultsInReport(allPrecinctFishReports[0], 'fishing', 1, 0, 0, {
-    yes: 0,
-    no: 1,
-  });
+  expectContestResultsInReport(
+    allPrecinctFishReports[0],
+    ContestIdSchema.parse('fishing'),
+    1,
+    0,
+    0,
+    {
+      yes: 0,
+      no: 1,
+    }
+  );
 });
 
 test('printing precinct scanner report works as expected with a single precinct for primary election', async () => {
@@ -966,7 +996,7 @@ test('printing precinct scanner report works as expected with a single precinct 
   ).toHaveLength(0);
   expectContestResultsInReport(
     allPrecinctMammalReports[0],
-    'best-animal-mammal',
+    ContestIdSchema.parse('best-animal-mammal'),
     2,
     0,
     1,
@@ -974,7 +1004,7 @@ test('printing precinct scanner report works as expected with a single precinct 
   );
   expectContestResultsInReport(
     allPrecinctMammalReports[0],
-    'zoo-council-mammal',
+    ContestIdSchema.parse('zoo-council-mammal'),
     2,
     3,
     0,
@@ -982,7 +1012,7 @@ test('printing precinct scanner report works as expected with a single precinct 
   );
   expectContestResultsInReport(
     allPrecinctMammalReports[0],
-    'new-zoo-either',
+    ContestIdSchema.parse('new-zoo-either'),
     2,
     0,
     0,
@@ -990,7 +1020,7 @@ test('printing precinct scanner report works as expected with a single precinct 
   );
   expectContestResultsInReport(
     allPrecinctMammalReports[0],
-    'new-zoo-pick',
+    ContestIdSchema.parse('new-zoo-pick'),
     2,
     1,
     0,
@@ -1009,7 +1039,7 @@ test('printing precinct scanner report works as expected with a single precinct 
   ).toHaveLength(0);
   expectContestResultsInReport(
     allPrecinctFishReports[0],
-    'best-animal-fish',
+    ContestIdSchema.parse('best-animal-fish'),
     1,
     0,
     0,
@@ -1017,7 +1047,7 @@ test('printing precinct scanner report works as expected with a single precinct 
   );
   expectContestResultsInReport(
     allPrecinctFishReports[0],
-    'aquarium-council-fish',
+    ContestIdSchema.parse('aquarium-council-fish'),
     1,
     0,
     0,
@@ -1029,8 +1059,15 @@ test('printing precinct scanner report works as expected with a single precinct 
       '__write-in': 0,
     }
   );
-  expectContestResultsInReport(allPrecinctFishReports[0], 'fishing', 1, 0, 0, {
-    yes: 0,
-    no: 1,
-  });
+  expectContestResultsInReport(
+    allPrecinctFishReports[0],
+    ContestIdSchema.parse('fishing'),
+    1,
+    0,
+    0,
+    {
+      yes: 0,
+      no: 1,
+    }
+  );
 });

--- a/apps/bsd/src/screens/BallotEjectScreen.test.tsx
+++ b/apps/bsd/src/screens/BallotEjectScreen.test.tsx
@@ -3,7 +3,11 @@ import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import { BallotType, AdjudicationReason } from '@votingworks/types';
+import {
+  BallotType,
+  AdjudicationReason,
+  ContestIdSchema,
+} from '@votingworks/types';
 import { typedAs } from '@votingworks/utils';
 import { GetNextReviewSheetResponse } from '@votingworks/types/api/module-scan';
 import BallotEjectScreen from './BallotEjectScreen';
@@ -73,7 +77,7 @@ test('says the ballot sheet is overvoted if it is', async () => {
               enabledReasonInfos: [
                 {
                   type: AdjudicationReason.Overvote,
-                  contestId: '1',
+                  contestId: ContestIdSchema.parse('1'),
                   optionIds: ['1', '2'],
                   optionIndexes: [0, 1],
                   expected: 1,
@@ -172,7 +176,7 @@ test('says the ballot sheet is undervoted if it is', async () => {
               enabledReasonInfos: [
                 {
                   type: AdjudicationReason.Undervote,
-                  contestId: '1',
+                  contestId: ContestIdSchema.parse('1'),
                   optionIds: [],
                   optionIndexes: [],
                   expected: 1,
@@ -271,7 +275,7 @@ test('says the ballot sheet is blank if it is', async () => {
               enabledReasonInfos: [
                 {
                   type: AdjudicationReason.Undervote,
-                  contestId: '1',
+                  contestId: ContestIdSchema.parse('1'),
                   expected: 1,
                   optionIds: [],
                   optionIndexes: [],
@@ -624,7 +628,7 @@ test('does NOT say ballot is blank if one side is blank and the other requires w
                 enabledReasonInfos: [
                   {
                     type: writeInReason,
-                    contestId: 'county-commissioners',
+                    contestId: ContestIdSchema.parse('county-commissioners'),
                     optionIndex: 0,
                     optionId: '__write-in-0',
                   },
@@ -698,7 +702,7 @@ test('does NOT say ballot is blank if one side is blank and the other requires w
             contestIds: [],
           },
           back: {
-            contestIds: ['county-commissioners'],
+            contestIds: [ContestIdSchema.parse('county-commissioners')],
           },
         },
       })
@@ -735,7 +739,7 @@ test('does NOT say ballot is blank if one side is blank and the other requires w
       frontMarkAdjudications: [],
       backMarkAdjudications: [
         {
-          contestId: 'county-commissioners',
+          contestId: ContestIdSchema.parse('county-commissioners'),
           isMarked: true,
           name: 'Lizard People',
           optionId: '__write-in-0',

--- a/apps/election-manager/src/routerPaths.ts
+++ b/apps/election-manager/src/routerPaths.ts
@@ -1,3 +1,4 @@
+import { ContestId } from '@votingworks/types';
 import {
   BallotScreenProps,
   PartyReportScreenProps,

--- a/apps/election-manager/src/screens/DefinitionContestsScreen.tsx
+++ b/apps/election-manager/src/screens/DefinitionContestsScreen.tsx
@@ -9,6 +9,7 @@ import {
   YesNoContest,
   AnyContest,
   MsEitherNeitherContest,
+  ContestId,
 } from '@votingworks/types';
 
 import readFileAsync from '../lib/readFileAsync';
@@ -194,7 +195,7 @@ function DefinitionContestsScreen({
   const { electionDefinition, saveElection } = useContext(AppContext);
   assert(electionDefinition);
   const { election } = electionDefinition;
-  const { contestId } = useParams<{ contestId: string }>();
+  const { contestId } = useParams<{ contestId: ContestId }>();
   const contestIndex = election.contests.findIndex((c) => c.id === contestId);
   const contest = election.contests[contestIndex];
 

--- a/apps/election-manager/src/screens/ManualDataImportPrecinctScreen.tsx
+++ b/apps/election-manager/src/screens/ManualDataImportPrecinctScreen.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import {
   CandidateContest,
   Contest,
+  ContestId,
   Dictionary,
   expandEitherNeitherContests,
   ContestVoteOption,
@@ -259,7 +260,7 @@ function ManualDataImportPrecinctScreen(): JSX.Element {
   }
 
   function getValueForInput(
-    contestId: string,
+    contestId: ContestId,
     dataKey: string
   ): number | EmptyValue {
     const contestTally = currentPrecinctTally.contestTallies[contestId];
@@ -277,7 +278,7 @@ function ManualDataImportPrecinctScreen(): JSX.Element {
   }
 
   function updateContestData(
-    contestId: string,
+    contestId: ContestId,
     dataKey: string,
     event: React.FormEvent<HTMLInputElement>
   ) {

--- a/apps/election-manager/src/utils/externalTallies.ts
+++ b/apps/election-manager/src/utils/externalTallies.ts
@@ -12,6 +12,7 @@ import {
   OptionalFullElectionExternalTally,
   TallyCategory,
   VotingMethod,
+  ContestId,
 } from '@votingworks/types';
 import { throwIllegalValue, combineContestTallies } from '@votingworks/utils';
 
@@ -80,8 +81,8 @@ export function getTotalNumberOfBallots(
 
   // Break the sets of contest IDs into disjoint sets, so contests that are never seen on the same ballot style.
   for (const contest of election.contests) {
-    const combinedSetForContest = new Set<string>();
-    const newListOfContestIdSets: Array<Set<string>> = [];
+    const combinedSetForContest = new Set<ContestId>();
+    const newListOfContestIdSets: Array<Set<ContestId>> = [];
     for (const contestIdSet of contestIdSets) {
       if (contestIdSet.has(contest.id)) {
         for (const id of contestIdSet) combinedSetForContest.add(id);

--- a/apps/election-manager/src/utils/semsTallies.test.ts
+++ b/apps/election-manager/src/utils/semsTallies.test.ts
@@ -11,6 +11,7 @@ import {
   ExternalTallySourceType,
   TallyCategory,
   VotingMethod,
+  ContestIdSchema,
 } from '@votingworks/types';
 import { buildCandidateTallies } from '../../test/util/buildCandidateTallies';
 
@@ -23,10 +24,10 @@ import {
   parseSEMSFileAndValidateForElection,
 } from './semsTallies';
 
-const mockSemsRow = {
+const mockSemsRow: SEMSFileRow = {
   countyId: '',
   precinctId: '',
-  contestId: '',
+  contestId: ContestIdSchema.parse(''),
   contestTitle: '',
   partyId: '',
   partyName: '',
@@ -55,49 +56,49 @@ describe('getContestTallyForCandidateContest', () => {
     const rows: SEMSFileRow[] = [
       {
         ...mockSemsRow,
-        contestId: 'president',
+        contestId: ContestIdSchema.parse('president'),
         candidateId: 'barchi-hallaren',
         numberOfVotes: 0,
       },
       {
         ...mockSemsRow,
-        contestId: 'president',
+        contestId: ContestIdSchema.parse('president'),
         candidateId: 'cramer-vuocolo',
         numberOfVotes: 1,
       },
       {
         ...mockSemsRow,
-        contestId: 'president',
+        contestId: ContestIdSchema.parse('president'),
         candidateId: 'court-blumhardt',
         numberOfVotes: 2,
       },
       {
         ...mockSemsRow,
-        contestId: 'president',
+        contestId: ContestIdSchema.parse('president'),
         candidateId: 'boone-lian',
         numberOfVotes: 3,
       },
       {
         ...mockSemsRow,
-        contestId: 'president',
+        contestId: ContestIdSchema.parse('president'),
         candidateId: 'hildebrand-garritty',
         numberOfVotes: 4,
       },
       {
         ...mockSemsRow,
-        contestId: 'president',
+        contestId: ContestIdSchema.parse('president'),
         candidateId: 'patterson-lariviere',
         numberOfVotes: 5,
       },
       {
         ...mockSemsRow,
-        contestId: 'president',
+        contestId: ContestIdSchema.parse('president'),
         candidateId: '1', // overvotes
         numberOfVotes: 11,
       },
       {
         ...mockSemsRow,
-        contestId: 'president',
+        contestId: ContestIdSchema.parse('president'),
         candidateId: '2', // undervotes
         numberOfVotes: 7,
       },
@@ -188,7 +189,7 @@ describe('getContestTallyForCandidateContest', () => {
     const rows: SEMSFileRow[] = [
       {
         ...mockSemsRow,
-        contestId: 'president',
+        contestId: ContestIdSchema.parse('president'),
         candidateId: 'eevee',
         numberOfVotes: 314,
       },

--- a/apps/election-manager/src/utils/semsTallies.ts
+++ b/apps/election-manager/src/utils/semsTallies.ts
@@ -16,6 +16,8 @@ import {
   FullElectionExternalTally,
   VotingMethod,
   YesNoVoteOption,
+  ContestId,
+  ContestIdSchema,
 } from '@votingworks/types';
 
 import { throwIllegalValue } from '@votingworks/utils';
@@ -38,7 +40,7 @@ const writeInCandidate: Candidate = {
 export interface SEMSFileRow {
   countyId: string;
   precinctId: string;
-  contestId: string;
+  contestId: ContestId;
   contestTitle: string;
   partyId: string;
   partyName: string;
@@ -51,8 +53,8 @@ export interface SEMSFileRow {
 
 // TODO(caro) revisit how to count the total number of ballots for multi seat contests
 // The number of total ballots is undervotes + overvotes + (othervotes / numseats)
-// That formula assumes all votes voted for the maxiumum number of seats allowed which is
-// probably not true in practice. This is irreleveant with the number of seats is 1.
+// That formula assumes all votes voted for the maximum number of seats allowed which is
+// probably not true in practice. This is irrelevant with the number of seats is 1.
 export function getContestTallyForCandidateContest(
   contest: CandidateContest,
   rows: SEMSFileRow[]
@@ -180,7 +182,7 @@ function parseFileContentRows(fileContent: string): SEMSFileRow[] {
       parsedRows.push({
         countyId: entries[0],
         precinctId: entries[1],
-        contestId: entries[2],
+        contestId: ContestIdSchema.parse(entries[2]),
         contestTitle: entries[3],
         partyId: entries[4],
         partyName: entries[5],

--- a/apps/module-scan/src/buildCastVoteRecord.test.ts
+++ b/apps/module-scan/src/buildCastVoteRecord.test.ts
@@ -4,6 +4,7 @@ import {
   AnyContest,
   BallotType,
   CandidateContest,
+  ContestIdSchema,
   getBallotStyle,
   getContests,
   MsEitherNeitherContest,
@@ -584,7 +585,7 @@ test('generates a CVR from an adjudicated HMPB page', () => {
             enabledReasonInfos: [
               {
                 type: AdjudicationReason.Overvote,
-                contestId: 'initiative-65',
+                contestId: ContestIdSchema.parse('initiative-65'),
                 expected: 1,
                 optionIds: ['yes', 'no'],
                 optionIndexes: [0, 1],
@@ -599,7 +600,7 @@ test('generates a CVR from an adjudicated HMPB page', () => {
         markAdjudications: [
           {
             type: AdjudicationReason.Overvote,
-            contestId: 'initiative-65',
+            contestId: ContestIdSchema.parse('initiative-65'),
             optionId: 'no',
             isMarked: false,
           },
@@ -943,7 +944,7 @@ test('generates a CVR from an adjudicated uninterpreted HMPB page', () => {
         markAdjudications: [
           {
             type: AdjudicationReason.UninterpretableBallot,
-            contestId: 'initiative-65',
+            contestId: ContestIdSchema.parse('initiative-65'),
             optionId: 'no',
             isMarked: true,
           },
@@ -1006,7 +1007,7 @@ test('generates a CVR from an adjudicated write-in', () => {
             enabledReasonInfos: [
               {
                 type: AdjudicationReason.WriteIn,
-                contestId: '2',
+                contestId: ContestIdSchema.parse('2'),
                 optionId: '__write-in-0',
                 optionIndex: 3,
               },
@@ -1029,7 +1030,7 @@ test('generates a CVR from an adjudicated write-in', () => {
         markAdjudications: [
           {
             type: AdjudicationReason.WriteIn,
-            contestId: '2',
+            contestId: ContestIdSchema.parse('2'),
             optionId: '__write-in-0',
             isMarked: true,
             name: 'Pikachu',
@@ -1116,7 +1117,7 @@ test('generates a CVR from an adjudicated unmarked write-in', () => {
             enabledReasonInfos: [
               {
                 type: AdjudicationReason.UnmarkedWriteIn,
-                contestId: '2',
+                contestId: ContestIdSchema.parse('2'),
                 optionId: '__write-in-0',
                 optionIndex: 3,
               },
@@ -1133,7 +1134,7 @@ test('generates a CVR from an adjudicated unmarked write-in', () => {
         markAdjudications: [
           {
             type: AdjudicationReason.UnmarkedWriteIn,
-            contestId: '2',
+            contestId: ContestIdSchema.parse('2'),
             optionId: '__write-in-0',
             isMarked: true,
             name: 'Pikachu',

--- a/apps/module-scan/src/endToEndHmpb.test.ts
+++ b/apps/module-scan/src/endToEndHmpb.test.ts
@@ -1,5 +1,9 @@
 import { asElectionDefinition } from '@votingworks/fixtures';
-import { AdjudicationReason, CastVoteRecord } from '@votingworks/types';
+import {
+  AdjudicationReason,
+  CastVoteRecord,
+  ContestIdSchema,
+} from '@votingworks/types';
 import { ScanContinueRequest } from '@votingworks/types/api/module-scan';
 import { BallotPackageManifest, typedAs } from '@votingworks/utils';
 import { EventEmitter } from 'events';
@@ -261,7 +265,7 @@ test('failed scan with QR code can be adjudicated and exported', async () => {
         frontMarkAdjudications: [
           {
             type: AdjudicationReason.UninterpretableBallot,
-            contestId: 'city-mayor',
+            contestId: ContestIdSchema.parse('city-mayor'),
             optionId: 'seldon',
             isMarked: true,
           },
@@ -269,13 +273,13 @@ test('failed scan with QR code can be adjudicated and exported', async () => {
         backMarkAdjudications: [
           {
             type: AdjudicationReason.UninterpretableBallot,
-            contestId: 'question-a',
+            contestId: ContestIdSchema.parse('question-a'),
             optionId: 'no',
             isMarked: true,
           },
           {
             type: AdjudicationReason.UninterpretableBallot,
-            contestId: 'question-b',
+            contestId: ContestIdSchema.parse('question-b'),
             optionId: 'yes',
             isMarked: true,
           },

--- a/apps/module-scan/src/interpreter.test.ts
+++ b/apps/module-scan/src/interpreter.test.ts
@@ -3,6 +3,7 @@ import { metadataFromBytes } from '@votingworks/hmpb-interpreter';
 import {
   AdjudicationReason,
   BlankPage,
+  ContestIdSchema,
   Election,
   InterpretedBmdPage,
   InterpretedHmpbPage,
@@ -3091,7 +3092,7 @@ const pageInterpretationBoilerplate: InterpretedHmpbPage = {
           y: 645,
         },
         contest: {
-          id: 'contest-id',
+          id: ContestIdSchema.parse('contest-id'),
           type: 'candidate',
           candidates: [],
           seats: 1,
@@ -3166,7 +3167,7 @@ test('sheetRequiresAdjudication triggers if front or back requires adjudication'
       enabledReasonInfos: [
         {
           type: AdjudicationReason.Overvote,
-          contestId: '42',
+          contestId: ContestIdSchema.parse('42'),
           optionIds: ['27', '28'],
           optionIndexes: [0, 1],
           expected: 1,

--- a/apps/module-scan/src/util/marks.test.ts
+++ b/apps/module-scan/src/util/marks.test.ts
@@ -1,4 +1,4 @@
-import { BallotMark, MarkStatus } from '@votingworks/types';
+import { BallotMark, ContestIdSchema, MarkStatus } from '@votingworks/types';
 import { changesFromMarks, mergeChanges } from './marks';
 
 test('returns an empty object when no changes are given', () => {
@@ -83,13 +83,13 @@ test('changesFromMarks works with ms-either-neither', () => {
       type: 'ms-either-neither',
       bounds: { x: 50, y: 50, width: 50, height: 50 },
       contest: {
-        id: 'either-neither-1',
+        id: ContestIdSchema.parse('either-neither-1'),
         section: 'State',
         districtId: '1',
         type: 'ms-either-neither',
         title: 'Ballot Measure 1',
-        eitherNeitherContestId: 'either-neither-id',
-        pickOneContestId: 'pick-one-id',
+        eitherNeitherContestId: ContestIdSchema.parse('either-neither-id'),
+        pickOneContestId: ContestIdSchema.parse('pick-one-id'),
         description: 'Blah blah',
         eitherNeitherLabel: 'VOTE FOR APPROVAL OF EITHER, OR AGAINST BOTH',
         pickOneLabel: 'AND VOTE FOR ONE',

--- a/apps/precinct-scanner/src/AppTallyReportPaths.test.tsx
+++ b/apps/precinct-scanner/src/AppTallyReportPaths.test.tsx
@@ -29,6 +29,8 @@ import {
 } from '@votingworks/utils';
 import {
   CompressedTally,
+  ContestId,
+  ContestIdSchema,
   Dictionary,
   err,
   PrecinctSelectionKind,
@@ -86,7 +88,7 @@ function expectBallotCountsInReport(
 
 function expectContestResultsInReport(
   container: HTMLElement,
-  contestId: string,
+  contestId: ContestId,
   ballotsCast: number,
   undervotes: number,
   overvotes: number,
@@ -299,7 +301,7 @@ test('expected tally reports for a primary election with all precincts with CVRs
   ).toHaveLength(0);
   expectContestResultsInReport(
     precinct1MammalReports[0],
-    'best-animal-mammal',
+    ContestIdSchema.parse('best-animal-mammal'),
     1,
     0,
     0,
@@ -307,7 +309,7 @@ test('expected tally reports for a primary election with all precincts with CVRs
   );
   expectContestResultsInReport(
     precinct1MammalReports[0],
-    'zoo-council-mammal',
+    ContestIdSchema.parse('zoo-council-mammal'),
     1,
     1,
     0,
@@ -315,7 +317,7 @@ test('expected tally reports for a primary election with all precincts with CVRs
   );
   expectContestResultsInReport(
     precinct1MammalReports[0],
-    'new-zoo-either',
+    ContestIdSchema.parse('new-zoo-either'),
     1,
     0,
     0,
@@ -323,7 +325,7 @@ test('expected tally reports for a primary election with all precincts with CVRs
   );
   expectContestResultsInReport(
     precinct1MammalReports[0],
-    'new-zoo-pick',
+    ContestIdSchema.parse('new-zoo-pick'),
     1,
     1,
     0,
@@ -342,7 +344,7 @@ test('expected tally reports for a primary election with all precincts with CVRs
   ).toHaveLength(0);
   expectContestResultsInReport(
     precinct1FishReports[0],
-    'best-animal-fish',
+    ContestIdSchema.parse('best-animal-fish'),
     0,
     0,
     0,
@@ -350,7 +352,7 @@ test('expected tally reports for a primary election with all precincts with CVRs
   );
   expectContestResultsInReport(
     precinct1FishReports[0],
-    'aquarium-council-fish',
+    ContestIdSchema.parse('aquarium-council-fish'),
     0,
     0,
     0,
@@ -362,10 +364,17 @@ test('expected tally reports for a primary election with all precincts with CVRs
       '__write-in': 0,
     }
   );
-  expectContestResultsInReport(precinct1FishReports[0], 'fishing', 0, 0, 0, {
-    yes: 0,
-    no: 0,
-  });
+  expectContestResultsInReport(
+    precinct1FishReports[0],
+    ContestIdSchema.parse('fishing'),
+    0,
+    0,
+    0,
+    {
+      yes: 0,
+      no: 0,
+    }
+  );
   // Check that the expected results are on the tally report for Precinct 2 Mammal Party
   const precinct2MammalReports = await screen.getAllByTestId(
     'tally-report-0-precinct-2'
@@ -379,7 +388,7 @@ test('expected tally reports for a primary election with all precincts with CVRs
   ).toHaveLength(0);
   expectContestResultsInReport(
     precinct2MammalReports[0],
-    'best-animal-mammal',
+    ContestIdSchema.parse('best-animal-mammal'),
     1,
     0,
     1,
@@ -387,7 +396,7 @@ test('expected tally reports for a primary election with all precincts with CVRs
   );
   expectContestResultsInReport(
     precinct2MammalReports[0],
-    'zoo-council-mammal',
+    ContestIdSchema.parse('zoo-council-mammal'),
     1,
     2,
     0,
@@ -395,7 +404,7 @@ test('expected tally reports for a primary election with all precincts with CVRs
   );
   expectContestResultsInReport(
     precinct2MammalReports[0],
-    'new-zoo-either',
+    ContestIdSchema.parse('new-zoo-either'),
     1,
     0,
     0,
@@ -403,7 +412,7 @@ test('expected tally reports for a primary election with all precincts with CVRs
   );
   expectContestResultsInReport(
     precinct2MammalReports[0],
-    'new-zoo-pick',
+    ContestIdSchema.parse('new-zoo-pick'),
     1,
     0,
     0,
@@ -422,7 +431,7 @@ test('expected tally reports for a primary election with all precincts with CVRs
   ).toHaveLength(0);
   expectContestResultsInReport(
     precinct2FishReports[0],
-    'best-animal-fish',
+    ContestIdSchema.parse('best-animal-fish'),
     1,
     0,
     0,
@@ -430,7 +439,7 @@ test('expected tally reports for a primary election with all precincts with CVRs
   );
   expectContestResultsInReport(
     precinct2FishReports[0],
-    'aquarium-council-fish',
+    ContestIdSchema.parse('aquarium-council-fish'),
     1,
     0,
     0,
@@ -442,10 +451,17 @@ test('expected tally reports for a primary election with all precincts with CVRs
       '__write-in': 0,
     }
   );
-  expectContestResultsInReport(precinct2FishReports[0], 'fishing', 1, 0, 0, {
-    yes: 0,
-    no: 1,
-  });
+  expectContestResultsInReport(
+    precinct2FishReports[0],
+    ContestIdSchema.parse('fishing'),
+    1,
+    0,
+    0,
+    {
+      yes: 0,
+      no: 1,
+    }
+  );
 
   // Save the tally to card and get the expected tallies
   fireEvent.click(await screen.findByText('Close Polls for All Precincts'));
@@ -683,7 +699,7 @@ test('expected tally reports for a primary election with a single precincts with
   ).toHaveLength(0);
   expectContestResultsInReport(
     precinct1MammalReports[0],
-    'best-animal-mammal',
+    ContestIdSchema.parse('best-animal-mammal'),
     2,
     0,
     1,
@@ -691,7 +707,7 @@ test('expected tally reports for a primary election with a single precincts with
   );
   expectContestResultsInReport(
     precinct1MammalReports[0],
-    'zoo-council-mammal',
+    ContestIdSchema.parse('zoo-council-mammal'),
     2,
     3,
     0,
@@ -699,7 +715,7 @@ test('expected tally reports for a primary election with a single precincts with
   );
   expectContestResultsInReport(
     precinct1MammalReports[0],
-    'new-zoo-either',
+    ContestIdSchema.parse('new-zoo-either'),
     2,
     0,
     0,
@@ -707,7 +723,7 @@ test('expected tally reports for a primary election with a single precincts with
   );
   expectContestResultsInReport(
     precinct1MammalReports[0],
-    'new-zoo-pick',
+    ContestIdSchema.parse('new-zoo-pick'),
     2,
     1,
     0,
@@ -726,7 +742,7 @@ test('expected tally reports for a primary election with a single precincts with
   ).toHaveLength(0);
   expectContestResultsInReport(
     precinct1FishReports[0],
-    'best-animal-fish',
+    ContestIdSchema.parse('best-animal-fish'),
     1,
     0,
     0,
@@ -734,7 +750,7 @@ test('expected tally reports for a primary election with a single precincts with
   );
   expectContestResultsInReport(
     precinct1FishReports[0],
-    'aquarium-council-fish',
+    ContestIdSchema.parse('aquarium-council-fish'),
     1,
     0,
     0,
@@ -746,10 +762,17 @@ test('expected tally reports for a primary election with a single precincts with
       '__write-in': 0,
     }
   );
-  expectContestResultsInReport(precinct1FishReports[0], 'fishing', 1, 0, 0, {
-    yes: 0,
-    no: 1,
-  });
+  expectContestResultsInReport(
+    precinct1FishReports[0],
+    ContestIdSchema.parse('fishing'),
+    1,
+    0,
+    0,
+    {
+      yes: 0,
+      no: 1,
+    }
+  );
 
   // Save the tally to card and get the expected tallies
   fireEvent.click(await screen.findByText('Close Polls for Precinct 1'));
@@ -953,7 +976,7 @@ test('expected tally reports for a general election with all precincts with CVRs
   expectBallotCountsInReport(centerSpringfieldReports[0], 1, 0, 1);
   expectContestResultsInReport(
     centerSpringfieldReports[0],
-    'president',
+    ContestIdSchema.parse('president'),
     1,
     0,
     0,
@@ -966,10 +989,17 @@ test('expected tally reports for a general election with all precincts with CVRs
       '__write-in': 0,
     }
   );
-  expectContestResultsInReport(centerSpringfieldReports[0], 'prop-1', 1, 0, 0, {
-    yes: 1,
-    no: 0,
-  });
+  expectContestResultsInReport(
+    centerSpringfieldReports[0],
+    ContestIdSchema.parse('prop-1'),
+    1,
+    0,
+    0,
+    {
+      yes: 1,
+      no: 0,
+    }
+  );
 
   // Check that the expected results are on the tally report for South Springfield
   const southSpringfieldReports = await screen.getAllByTestId(
@@ -979,7 +1009,7 @@ test('expected tally reports for a general election with all precincts with CVRs
   expectBallotCountsInReport(southSpringfieldReports[0], 0, 0, 0);
   expectContestResultsInReport(
     southSpringfieldReports[0],
-    'president',
+    ContestIdSchema.parse('president'),
     0,
     0,
     0,
@@ -992,10 +1022,17 @@ test('expected tally reports for a general election with all precincts with CVRs
       '__write-in': 0,
     }
   );
-  expectContestResultsInReport(southSpringfieldReports[0], 'prop-1', 0, 0, 0, {
-    yes: 0,
-    no: 0,
-  });
+  expectContestResultsInReport(
+    southSpringfieldReports[0],
+    ContestIdSchema.parse('prop-1'),
+    0,
+    0,
+    0,
+    {
+      yes: 0,
+      no: 0,
+    }
+  );
 
   // Check that the expected results are on the tally report for North Springfield
   const northSpringfieldReports = await screen.getAllByTestId(
@@ -1005,7 +1042,7 @@ test('expected tally reports for a general election with all precincts with CVRs
   expectBallotCountsInReport(northSpringfieldReports[0], 0, 1, 1);
   expectContestResultsInReport(
     northSpringfieldReports[0],
-    'president',
+    ContestIdSchema.parse('president'),
     1,
     0,
     0,
@@ -1018,10 +1055,17 @@ test('expected tally reports for a general election with all precincts with CVRs
       '__write-in': 0,
     }
   );
-  expectContestResultsInReport(northSpringfieldReports[0], 'prop-1', 1, 1, 0, {
-    yes: 0,
-    no: 0,
-  });
+  expectContestResultsInReport(
+    northSpringfieldReports[0],
+    ContestIdSchema.parse('prop-1'),
+    1,
+    1,
+    0,
+    {
+      yes: 0,
+      no: 0,
+    }
+  );
 
   // Save the tally to card and get the expected tallies
   fireEvent.click(await screen.findByText('Close Polls for All Precincts'));
@@ -1219,7 +1263,7 @@ test('expected tally reports for a general election with a single precincts with
   expectBallotCountsInReport(centerSpringfieldReports[0], 1, 1, 2);
   expectContestResultsInReport(
     centerSpringfieldReports[0],
-    'president',
+    ContestIdSchema.parse('president'),
     2,
     0,
     0,
@@ -1232,10 +1276,17 @@ test('expected tally reports for a general election with a single precincts with
       '__write-in': 0,
     }
   );
-  expectContestResultsInReport(centerSpringfieldReports[0], 'prop-1', 2, 1, 0, {
-    yes: 1,
-    no: 0,
-  });
+  expectContestResultsInReport(
+    centerSpringfieldReports[0],
+    ContestIdSchema.parse('prop-1'),
+    2,
+    1,
+    0,
+    {
+      yes: 1,
+      no: 0,
+    }
+  );
 
   // Save the tally to card and get the expected tallies
   fireEvent.click(

--- a/integration-testing/election-manager/cypress/integration/candidateContestTallies.ts
+++ b/integration-testing/election-manager/cypress/integration/candidateContestTallies.ts
@@ -3,9 +3,11 @@ import {
   generateCVR,
   generateFileContentFromCVRs,
 } from '@votingworks/test-utils';
+import { ContestIdSchema } from '@votingworks/types';
 import {
   assertExpectedResultsMatchSEMsFile,
   assertExpectedResultsMatchTallyReport,
+  ExpectedContestResults,
 } from '../support/assertions';
 
 describe('Election Manager can create SEMS tallies', () => {
@@ -81,9 +83,9 @@ describe('Election Manager can create SEMS tallies', () => {
     cy.get('[data-testid="total-ballot-count"]').within(() => cy.contains('5'));
 
     // Check that the internal tally reports have the correct tallies
-    const expectedFullResults = [
+    const expectedFullResults: ExpectedContestResults[] = [
       {
-        contestId: 'governor-contest-liberty',
+        contestId: ContestIdSchema.parse('governor-contest-liberty'),
         metadata: { ballots: 5, undervotes: 1, overvotes: 1 },
         votesByOptionId: {
           'aaron-aligator': 2,
@@ -92,7 +94,7 @@ describe('Election Manager can create SEMS tallies', () => {
         },
       },
       {
-        contestId: 'schoolboard-liberty',
+        contestId: ContestIdSchema.parse('schoolboard-liberty'),
         metadata: { ballots: 5, undervotes: 3, overvotes: 4 },
         votesByOptionId: {
           'amber-brkich': 2,
@@ -104,9 +106,9 @@ describe('Election Manager can create SEMS tallies', () => {
       },
     ];
 
-    const expectedEmptyResults = [
+    const expectedEmptyResults: ExpectedContestResults[] = [
       {
-        contestId: 'governor-contest-liberty',
+        contestId: ContestIdSchema.parse('governor-contest-liberty'),
         metadata: { ballots: 0, undervotes: 0, overvotes: 0 },
         votesByOptionId: {
           'aaron-aligator': 0,
@@ -115,7 +117,7 @@ describe('Election Manager can create SEMS tallies', () => {
         },
       },
       {
-        contestId: 'schoolboard-liberty',
+        contestId: ContestIdSchema.parse('schoolboard-liberty'),
         metadata: { ballots: 0, undervotes: 0, overvotes: 0 },
         votesByOptionId: {
           'amber-brkich': 0,
@@ -184,55 +186,55 @@ describe('Election Manager can create SEMS tallies', () => {
         assertExpectedResultsMatchSEMsFile(
           [
             {
-              contestId: 'governor-contest-liberty',
+              contestId: ContestIdSchema.parse('governor-contest-liberty'),
               precinctId: 'precinct-2',
               candidateId: 'aaron-aligator',
               numberOfVotes: 2,
             },
             {
-              contestId: 'governor-contest-liberty',
+              contestId: ContestIdSchema.parse('governor-contest-liberty'),
               precinctId: 'precinct-2',
               candidateId: 'peter-pigeon',
               numberOfVotes: 1,
             },
             {
-              contestId: 'governor-contest-liberty',
+              contestId: ContestIdSchema.parse('governor-contest-liberty'),
               precinctId: 'precinct-2',
               candidateId: '2', // undervotes
               numberOfVotes: 1,
             },
             {
-              contestId: 'governor-contest-liberty',
+              contestId: ContestIdSchema.parse('governor-contest-liberty'),
               precinctId: 'precinct-2',
               candidateId: '1', // overvotes
               numberOfVotes: 1,
             },
             {
-              contestId: 'schoolboard-liberty',
+              contestId: ContestIdSchema.parse('schoolboard-liberty'),
               precinctId: 'precinct-2',
               candidateId: '2', // undervotes
               numberOfVotes: 3,
             },
             {
-              contestId: 'schoolboard-liberty',
+              contestId: ContestIdSchema.parse('schoolboard-liberty'),
               precinctId: 'precinct-2',
               candidateId: '1', // overvotes
               numberOfVotes: 4,
             },
             {
-              contestId: 'schoolboard-liberty',
+              contestId: ContestIdSchema.parse('schoolboard-liberty'),
               precinctId: 'precinct-2',
               candidateId: 'amber-brkich',
               numberOfVotes: 2,
             },
             {
-              contestId: 'schoolboard-liberty',
+              contestId: ContestIdSchema.parse('schoolboard-liberty'),
               precinctId: 'precinct-2',
               candidateId: 'chris-daugherty',
               numberOfVotes: 1,
             },
             {
-              contestId: 'chief-pokemon-liberty',
+              contestId: ContestIdSchema.parse('chief-pokemon-liberty'),
               precinctId: 'precinct-2',
               candidateId: '2', // undervotes
               numberOfVotes: 5,

--- a/integration-testing/election-manager/cypress/integration/yesNoContestTallies.ts
+++ b/integration-testing/election-manager/cypress/integration/yesNoContestTallies.ts
@@ -3,6 +3,7 @@ import {
   generateCVR,
   generateFileContentFromCVRs,
 } from '@votingworks/test-utils';
+import { ContestIdSchema } from '@votingworks/types';
 import {
   assertExpectedResultsMatchSEMsFile,
   assertExpectedResultsMatchTallyReport,
@@ -127,7 +128,7 @@ describe('Election Manager can create SEMS tallies', () => {
     assertExpectedResultsMatchTallyReport(
       [
         {
-          contestId: '750000017',
+          contestId: ContestIdSchema.parse('750000017'),
           metadata: { ballots: 8, undervotes: 2, overvotes: 1 },
           votesByOptionId: {
             yes: 1,
@@ -135,7 +136,7 @@ describe('Election Manager can create SEMS tallies', () => {
           },
         },
         {
-          contestId: '750000018',
+          contestId: ContestIdSchema.parse('750000018'),
           metadata: { ballots: 8, undervotes: 2, overvotes: 2 },
           votesByOptionId: {
             yes: 2,
@@ -143,7 +144,7 @@ describe('Election Manager can create SEMS tallies', () => {
           },
         },
         {
-          contestId: '750000015',
+          contestId: ContestIdSchema.parse('750000015'),
           metadata: { ballots: 8, undervotes: 1, overvotes: 1 },
           votesByOptionId: {
             yes: 3,
@@ -151,7 +152,7 @@ describe('Election Manager can create SEMS tallies', () => {
           },
         },
         {
-          contestId: '750000016',
+          contestId: ContestIdSchema.parse('750000016'),
           metadata: { ballots: 8, undervotes: 1, overvotes: 1 },
           votesByOptionId: {
             yes: 3,
@@ -166,7 +167,7 @@ describe('Election Manager can create SEMS tallies', () => {
     assertExpectedResultsMatchTallyReport(
       [
         {
-          contestId: '750000017',
+          contestId: ContestIdSchema.parse('750000017'),
           metadata: { ballots: 4, undervotes: 1, overvotes: 0 },
           votesByOptionId: {
             yes: 1,
@@ -174,7 +175,7 @@ describe('Election Manager can create SEMS tallies', () => {
           },
         },
         {
-          contestId: '750000018',
+          contestId: ContestIdSchema.parse('750000018'),
           metadata: { ballots: 4, undervotes: 1, overvotes: 1 },
           votesByOptionId: {
             yes: 2,
@@ -182,7 +183,7 @@ describe('Election Manager can create SEMS tallies', () => {
           },
         },
         {
-          contestId: '750000015',
+          contestId: ContestIdSchema.parse('750000015'),
           metadata: { ballots: 4, undervotes: 0, overvotes: 0 },
           votesByOptionId: {
             yes: 2,
@@ -190,7 +191,7 @@ describe('Election Manager can create SEMS tallies', () => {
           },
         },
         {
-          contestId: '750000016',
+          contestId: ContestIdSchema.parse('750000016'),
           metadata: { ballots: 4, undervotes: 0, overvotes: 0 },
           votesByOptionId: {
             yes: 2,
@@ -205,7 +206,7 @@ describe('Election Manager can create SEMS tallies', () => {
     assertExpectedResultsMatchTallyReport(
       [
         {
-          contestId: '750000017',
+          contestId: ContestIdSchema.parse('750000017'),
           metadata: { ballots: 4, undervotes: 1, overvotes: 1 },
           votesByOptionId: {
             yes: 0,
@@ -213,7 +214,7 @@ describe('Election Manager can create SEMS tallies', () => {
           },
         },
         {
-          contestId: '750000018',
+          contestId: ContestIdSchema.parse('750000018'),
           metadata: { ballots: 4, undervotes: 1, overvotes: 1 },
           votesByOptionId: {
             yes: 0,
@@ -221,7 +222,7 @@ describe('Election Manager can create SEMS tallies', () => {
           },
         },
         {
-          contestId: '750000015',
+          contestId: ContestIdSchema.parse('750000015'),
           metadata: { ballots: 4, undervotes: 1, overvotes: 1 },
           votesByOptionId: {
             yes: 1,
@@ -229,7 +230,7 @@ describe('Election Manager can create SEMS tallies', () => {
           },
         },
         {
-          contestId: '750000016',
+          contestId: ContestIdSchema.parse('750000016'),
           metadata: { ballots: 4, undervotes: 1, overvotes: 1 },
           votesByOptionId: {
             yes: 1,
@@ -244,7 +245,7 @@ describe('Election Manager can create SEMS tallies', () => {
     assertExpectedResultsMatchTallyReport(
       [
         {
-          contestId: '750000017',
+          contestId: ContestIdSchema.parse('750000017'),
           metadata: { ballots: 0, undervotes: 0, overvotes: 0 },
           votesByOptionId: {
             yes: 0,
@@ -252,7 +253,7 @@ describe('Election Manager can create SEMS tallies', () => {
           },
         },
         {
-          contestId: '750000018',
+          contestId: ContestIdSchema.parse('750000018'),
           metadata: { ballots: 0, undervotes: 0, overvotes: 0 },
           votesByOptionId: {
             yes: 0,
@@ -260,7 +261,7 @@ describe('Election Manager can create SEMS tallies', () => {
           },
         },
         {
-          contestId: '750000015',
+          contestId: ContestIdSchema.parse('750000015'),
           metadata: { ballots: 0, undervotes: 0, overvotes: 0 },
           votesByOptionId: {
             yes: 0,
@@ -268,7 +269,7 @@ describe('Election Manager can create SEMS tallies', () => {
           },
         },
         {
-          contestId: '750000016',
+          contestId: ContestIdSchema.parse('750000016'),
           metadata: { ballots: 0, undervotes: 0, overvotes: 0 },
           votesByOptionId: {
             yes: 0,
@@ -283,7 +284,7 @@ describe('Election Manager can create SEMS tallies', () => {
     assertExpectedResultsMatchTallyReport(
       [
         {
-          contestId: '750000017',
+          contestId: ContestIdSchema.parse('750000017'),
           metadata: { ballots: 4, undervotes: 0, overvotes: 0 },
           votesByOptionId: {
             yes: 1,
@@ -291,7 +292,7 @@ describe('Election Manager can create SEMS tallies', () => {
           },
         },
         {
-          contestId: '750000018',
+          contestId: ContestIdSchema.parse('750000018'),
           metadata: { ballots: 4, undervotes: 1, overvotes: 0 },
           votesByOptionId: {
             yes: 1,
@@ -299,7 +300,7 @@ describe('Election Manager can create SEMS tallies', () => {
           },
         },
         {
-          contestId: '750000015',
+          contestId: ContestIdSchema.parse('750000015'),
           metadata: { ballots: 4, undervotes: 1, overvotes: 1 },
           votesByOptionId: {
             yes: 2,
@@ -307,7 +308,7 @@ describe('Election Manager can create SEMS tallies', () => {
           },
         },
         {
-          contestId: '750000016',
+          contestId: ContestIdSchema.parse('750000016'),
           metadata: { ballots: 4, undervotes: 0, overvotes: 0 },
           votesByOptionId: {
             yes: 2,
@@ -322,7 +323,7 @@ describe('Election Manager can create SEMS tallies', () => {
     assertExpectedResultsMatchTallyReport(
       [
         {
-          contestId: '750000017',
+          contestId: ContestIdSchema.parse('750000017'),
           metadata: { ballots: 4, undervotes: 2, overvotes: 1 },
           votesByOptionId: {
             yes: 0,
@@ -330,7 +331,7 @@ describe('Election Manager can create SEMS tallies', () => {
           },
         },
         {
-          contestId: '750000018',
+          contestId: ContestIdSchema.parse('750000018'),
           metadata: { ballots: 4, undervotes: 1, overvotes: 2 },
           votesByOptionId: {
             yes: 1,
@@ -338,7 +339,7 @@ describe('Election Manager can create SEMS tallies', () => {
           },
         },
         {
-          contestId: '750000015',
+          contestId: ContestIdSchema.parse('750000015'),
           metadata: { ballots: 4, undervotes: 0, overvotes: 0 },
           votesByOptionId: {
             yes: 1,
@@ -346,7 +347,7 @@ describe('Election Manager can create SEMS tallies', () => {
           },
         },
         {
-          contestId: '750000016',
+          contestId: ContestIdSchema.parse('750000016'),
           metadata: { ballots: 4, undervotes: 1, overvotes: 1 },
           votesByOptionId: {
             yes: 1,
@@ -361,7 +362,7 @@ describe('Election Manager can create SEMS tallies', () => {
     assertExpectedResultsMatchTallyReport(
       [
         {
-          contestId: '750000017',
+          contestId: ContestIdSchema.parse('750000017'),
           metadata: { ballots: 4, undervotes: 2, overvotes: 1 },
           votesByOptionId: {
             yes: 1,
@@ -369,7 +370,7 @@ describe('Election Manager can create SEMS tallies', () => {
           },
         },
         {
-          contestId: '750000018',
+          contestId: ContestIdSchema.parse('750000018'),
           metadata: { ballots: 4, undervotes: 2, overvotes: 1 },
           votesByOptionId: {
             yes: 1,
@@ -377,7 +378,7 @@ describe('Election Manager can create SEMS tallies', () => {
           },
         },
         {
-          contestId: '750000015',
+          contestId: ContestIdSchema.parse('750000015'),
           metadata: { ballots: 4, undervotes: 0, overvotes: 0 },
           votesByOptionId: {
             yes: 2,
@@ -385,7 +386,7 @@ describe('Election Manager can create SEMS tallies', () => {
           },
         },
         {
-          contestId: '750000016',
+          contestId: ContestIdSchema.parse('750000016'),
           metadata: { ballots: 4, undervotes: 1, overvotes: 1 },
           votesByOptionId: {
             yes: 1,
@@ -400,7 +401,7 @@ describe('Election Manager can create SEMS tallies', () => {
     assertExpectedResultsMatchTallyReport(
       [
         {
-          contestId: '750000017',
+          contestId: ContestIdSchema.parse('750000017'),
           metadata: { ballots: 4, undervotes: 0, overvotes: 0 },
           votesByOptionId: {
             yes: 0,
@@ -408,7 +409,7 @@ describe('Election Manager can create SEMS tallies', () => {
           },
         },
         {
-          contestId: '750000018',
+          contestId: ContestIdSchema.parse('750000018'),
           metadata: { ballots: 4, undervotes: 0, overvotes: 1 },
           votesByOptionId: {
             yes: 1,
@@ -416,7 +417,7 @@ describe('Election Manager can create SEMS tallies', () => {
           },
         },
         {
-          contestId: '750000015',
+          contestId: ContestIdSchema.parse('750000015'),
           metadata: { ballots: 4, undervotes: 1, overvotes: 1 },
           votesByOptionId: {
             yes: 1,
@@ -424,7 +425,7 @@ describe('Election Manager can create SEMS tallies', () => {
           },
         },
         {
-          contestId: '750000016',
+          contestId: ContestIdSchema.parse('750000016'),
           metadata: { ballots: 4, undervotes: 0, overvotes: 0 },
           votesByOptionId: {
             yes: 2,
@@ -445,277 +446,277 @@ describe('Election Manager can create SEMS tallies', () => {
         assertExpectedResultsMatchSEMsFile(
           [
             {
-              contestId: '750000017',
+              contestId: ContestIdSchema.parse('750000017'),
               precinctId: '6522',
               candidateId: '750000094',
               numberOfVotes: 1,
             },
             {
-              contestId: '750000017',
+              contestId: ContestIdSchema.parse('750000017'),
               precinctId: '6522',
               candidateId: '750000095',
               numberOfVotes: 2,
             },
             {
-              contestId: '750000017',
+              contestId: ContestIdSchema.parse('750000017'),
               precinctId: '6522',
               candidateId: '1', // overvotes
               numberOfVotes: 0,
             },
             {
-              contestId: '750000017',
+              contestId: ContestIdSchema.parse('750000017'),
               precinctId: '6522',
               candidateId: '2', // undervotes
               numberOfVotes: 1,
             },
             {
-              contestId: '750000018',
+              contestId: ContestIdSchema.parse('750000018'),
               precinctId: '6522',
               candidateId: '750000092',
               numberOfVotes: 2,
             },
             {
-              contestId: '750000018',
+              contestId: ContestIdSchema.parse('750000018'),
               precinctId: '6522',
               candidateId: '750000093',
               numberOfVotes: 0,
             },
             {
-              contestId: '750000018',
+              contestId: ContestIdSchema.parse('750000018'),
               precinctId: '6522',
               candidateId: '1', // overvotes
               numberOfVotes: 1,
             },
             {
-              contestId: '750000018',
+              contestId: ContestIdSchema.parse('750000018'),
               precinctId: '6522',
               candidateId: '2', // undervotes
               numberOfVotes: 1,
             },
             {
-              contestId: '750000015',
+              contestId: ContestIdSchema.parse('750000015'),
               precinctId: '6522',
               candidateId: '750000088',
               numberOfVotes: 2,
             },
             {
-              contestId: '750000015',
+              contestId: ContestIdSchema.parse('750000015'),
               precinctId: '6522',
               candidateId: '750000089',
               numberOfVotes: 2,
             },
             {
-              contestId: '750000015',
+              contestId: ContestIdSchema.parse('750000015'),
               precinctId: '6522',
               candidateId: '1', // overvotes
               numberOfVotes: 0,
             },
             {
-              contestId: '750000015',
+              contestId: ContestIdSchema.parse('750000015'),
               precinctId: '6522',
               candidateId: '2', // undervotes
               numberOfVotes: 0,
             },
             {
-              contestId: '750000016',
+              contestId: ContestIdSchema.parse('750000016'),
               precinctId: '6522',
               candidateId: '750000090',
               numberOfVotes: 2,
             },
             {
-              contestId: '750000016',
+              contestId: ContestIdSchema.parse('750000016'),
               precinctId: '6522',
               candidateId: '750000091',
               numberOfVotes: 2,
             },
             {
-              contestId: '750000016',
+              contestId: ContestIdSchema.parse('750000016'),
               precinctId: '6522',
               candidateId: '1', // overvotes
               numberOfVotes: 0,
             },
             {
-              contestId: '750000016',
+              contestId: ContestIdSchema.parse('750000016'),
               precinctId: '6522',
               candidateId: '2', // undervotes
               numberOfVotes: 0,
             },
             {
-              contestId: '750000017',
+              contestId: ContestIdSchema.parse('750000017'),
               precinctId: '6538',
               candidateId: '750000094',
               numberOfVotes: 0,
             },
             {
-              contestId: '750000017',
+              contestId: ContestIdSchema.parse('750000017'),
               precinctId: '6538',
               candidateId: '750000095',
               numberOfVotes: 2,
             },
             {
-              contestId: '750000017',
+              contestId: ContestIdSchema.parse('750000017'),
               precinctId: '6538',
               candidateId: '1', // overvotes
               numberOfVotes: 1,
             },
             {
-              contestId: '750000017',
+              contestId: ContestIdSchema.parse('750000017'),
               precinctId: '6538',
               candidateId: '2', // undervotes
               numberOfVotes: 1,
             },
             {
-              contestId: '750000018',
+              contestId: ContestIdSchema.parse('750000018'),
               precinctId: '6538',
               candidateId: '750000092',
               numberOfVotes: 0,
             },
             {
-              contestId: '750000018',
+              contestId: ContestIdSchema.parse('750000018'),
               precinctId: '6538',
               candidateId: '750000093',
               numberOfVotes: 2,
             },
             {
-              contestId: '750000018',
+              contestId: ContestIdSchema.parse('750000018'),
               precinctId: '6538',
               candidateId: '1', // overvotes
               numberOfVotes: 1,
             },
             {
-              contestId: '750000018',
+              contestId: ContestIdSchema.parse('750000018'),
               precinctId: '6538',
               candidateId: '2', // undervotes
               numberOfVotes: 1,
             },
             {
-              contestId: '750000015',
+              contestId: ContestIdSchema.parse('750000015'),
               precinctId: '6538',
               candidateId: '750000088',
               numberOfVotes: 1,
             },
             {
-              contestId: '750000015',
+              contestId: ContestIdSchema.parse('750000015'),
               precinctId: '6538',
               candidateId: '750000089',
               numberOfVotes: 1,
             },
             {
-              contestId: '750000015',
+              contestId: ContestIdSchema.parse('750000015'),
               precinctId: '6538',
               candidateId: '1', // overvotes
               numberOfVotes: 1,
             },
             {
-              contestId: '750000015',
+              contestId: ContestIdSchema.parse('750000015'),
               precinctId: '6538',
               candidateId: '2', // undervotes
               numberOfVotes: 1,
             },
             {
-              contestId: '750000016',
+              contestId: ContestIdSchema.parse('750000016'),
               precinctId: '6538',
               candidateId: '750000090',
               numberOfVotes: 1,
             },
             {
-              contestId: '750000016',
+              contestId: ContestIdSchema.parse('750000016'),
               precinctId: '6538',
               candidateId: '750000091',
               numberOfVotes: 1,
             },
             {
-              contestId: '750000016',
+              contestId: ContestIdSchema.parse('750000016'),
               precinctId: '6538',
               candidateId: '1', // overvotes
               numberOfVotes: 1,
             },
             {
-              contestId: '750000016',
+              contestId: ContestIdSchema.parse('750000016'),
               precinctId: '6538',
               candidateId: '2', // undervotes
               numberOfVotes: 1,
             },
             {
-              contestId: '775020870',
+              contestId: ContestIdSchema.parse('775020870'),
               precinctId: '6538',
               candidateId: '2', // undervotes
               numberOfVotes: 4,
             },
             {
-              contestId: '775020870',
+              contestId: ContestIdSchema.parse('775020870'),
               precinctId: '6522',
               candidateId: '2', // undervotes
               numberOfVotes: 4,
             },
             {
-              contestId: '775020872',
+              contestId: ContestIdSchema.parse('775020872'),
               precinctId: '6538',
               candidateId: '2', // undervotes
               numberOfVotes: 4,
             },
             {
-              contestId: '775020872',
+              contestId: ContestIdSchema.parse('775020872'),
               precinctId: '6522',
               candidateId: '2', // undervotes
               numberOfVotes: 4,
             },
             {
-              contestId: '775020876',
+              contestId: ContestIdSchema.parse('775020876'),
               precinctId: '6538',
               candidateId: '2', // undervotes
               numberOfVotes: 4,
             },
             {
-              contestId: '775020876',
+              contestId: ContestIdSchema.parse('775020876'),
               precinctId: '6522',
               candidateId: '2', // undervotes
               numberOfVotes: 4,
             },
             {
-              contestId: '775020877',
+              contestId: ContestIdSchema.parse('775020877'),
               precinctId: '6538',
               candidateId: '2', // undervotes
               numberOfVotes: 4,
             },
             {
-              contestId: '775020877',
+              contestId: ContestIdSchema.parse('775020877'),
               precinctId: '6522',
               candidateId: '2', // undervotes
               numberOfVotes: 4,
             },
             {
-              contestId: '775020903',
+              contestId: ContestIdSchema.parse('775020903'),
               precinctId: '6538',
               candidateId: '2', // undervotes
               numberOfVotes: 4,
             },
             {
-              contestId: '775020903',
+              contestId: ContestIdSchema.parse('775020903'),
               precinctId: '6522',
               candidateId: '2', // undervotes
               numberOfVotes: 4,
             },
             {
-              contestId: '775020904',
+              contestId: ContestIdSchema.parse('775020904'),
               precinctId: '6538',
               candidateId: '2', // undervotes
               numberOfVotes: 4,
             },
             {
-              contestId: '775020904',
+              contestId: ContestIdSchema.parse('775020904'),
               precinctId: '6522',
               candidateId: '2', // undervotes
               numberOfVotes: 4,
             },
             {
-              contestId: '775020899',
+              contestId: ContestIdSchema.parse('775020899'),
               precinctId: '6538',
               candidateId: '2', // undervotes
               numberOfVotes: 4,
             },
             {
-              contestId: '775020899',
+              contestId: ContestIdSchema.parse('775020899'),
               precinctId: '6522',
               candidateId: '2', // undervotes
               numberOfVotes: 4,

--- a/integration-testing/election-manager/cypress/support/assertions.ts
+++ b/integration-testing/election-manager/cypress/support/assertions.ts
@@ -1,8 +1,8 @@
-import { Dictionary } from '@votingworks/types'
+import { ContestId, Dictionary } from '@votingworks/types'
 
 export interface SingleSEMsResultInfo {
   precinctId: string
-  contestId: string
+  contestId: ContestId
   candidateId: string
   numberOfVotes: number
 }
@@ -39,7 +39,7 @@ export function assertExpectedResultsMatchSEMsFile(
 }
 
 export interface ExpectedContestResults {
-  contestId: string
+  contestId: ContestId
   metadata: { ballots: number; undervotes: number; overvotes: number }
   votesByOptionId: Dictionary<number>
 }

--- a/libs/test-utils/src/arbitraries.ts
+++ b/libs/test-utils/src/arbitraries.ts
@@ -11,6 +11,7 @@ import {
   Candidate,
   CandidateContest,
   CastVoteRecord,
+  ContestId,
   Contests,
   County,
   District,
@@ -56,6 +57,10 @@ export function arbitraryId(): fc.Arbitrary<z.TypeOf<typeof Id>> {
       // make sure IDs don't start with underscore
       .map((value) => (value.startsWith('_') ? `0${value}` : value))
   );
+}
+
+export function arbitraryContestId(): fc.Arbitrary<ContestId> {
+  return arbitraryId() as fc.Arbitrary<ContestId>;
 }
 
 export function arbitraryDateTime({
@@ -120,7 +125,7 @@ export function arbitraryYesNoOption({
  * Builds values for yes/no contests.
  */
 export function arbitraryYesNoContest({
-  id = arbitraryId(),
+  id = arbitraryContestId(),
   districtId = arbitraryId(),
   partyId = arbitraryOptional(arbitraryId()),
 }: {
@@ -170,7 +175,7 @@ export function arbitraryCandidate({
  * Builds values for candidate contest.
  */
 export function arbitraryCandidateContest({
-  id = arbitraryId(),
+  id = arbitraryContestId(),
   districtId = arbitraryId(),
   partyIds = fc.array(arbitraryId(), { minLength: 1 }),
 }: {
@@ -207,16 +212,16 @@ export function arbitraryMsEitherNeitherContest({
 } = {}): fc.Arbitrary<MsEitherNeitherContest> {
   return fc.record({
     type: fc.constant('ms-either-neither'),
-    id: arbitraryId(),
+    id: arbitraryContestId(),
     title: fc.string({ minLength: 1 }),
     section: fc.string({ minLength: 1 }),
     description: fc.string({ minLength: 1 }),
     districtId,
-    eitherNeitherContestId: arbitraryId(),
+    eitherNeitherContestId: arbitraryContestId(),
     eitherNeitherLabel: fc.string({ minLength: 1 }),
     eitherOption: arbitraryYesNoOption(),
     neitherOption: arbitraryYesNoOption(),
-    pickOneContestId: arbitraryId(),
+    pickOneContestId: arbitraryContestId(),
     firstOption: arbitraryYesNoOption(),
     secondOption: arbitraryYesNoOption(),
     pickOneLabel: fc.string({ minLength: 1 }),

--- a/libs/types/src/api/module-scan.ts
+++ b/libs/types/src/api/module-scan.ts
@@ -17,6 +17,7 @@ import {
   BallotSheetInfo,
   BallotSheetInfoSchema,
   Contest,
+  ContestIdSchema,
   ElectionDefinition,
   ElectionDefinitionSchema,
   MarkThresholds,
@@ -617,8 +618,8 @@ export const GetNextReviewSheetResponseSchema: z.ZodSchema<GetNextReviewSheetRes
       back: SerializableBallotPageLayoutSchema.optional(),
     }),
     definitions: z.object({
-      front: z.object({ contestIds: z.array(Id) }).optional(),
-      back: z.object({ contestIds: z.array(Id) }).optional(),
+      front: z.object({ contestIds: z.array(ContestIdSchema) }).optional(),
+      back: z.object({ contestIds: z.array(ContestIdSchema) }).optional(),
     }),
   }
 );

--- a/libs/types/src/generic.ts
+++ b/libs/types/src/generic.ts
@@ -168,6 +168,9 @@ export function safeParseJSON<T>(
   return parser ? safeParse(parser, parsed) : ok(parsed);
 }
 
+declare const Unique: unique symbol;
+export type NewType<T, Tag> = T & { readonly [Unique]: Tag };
+
 export const Id = z
   .string()
   .nonempty()

--- a/libs/types/src/hmpb.ts
+++ b/libs/types/src/hmpb.ts
@@ -3,6 +3,7 @@ import {
   AdjudicationReason,
   Candidate,
   Contest,
+  ContestIdSchema,
   ContestOption,
   HMPBBallotPageMetadata,
   HMPBBallotPageMetadataSchema,
@@ -116,7 +117,7 @@ export interface UninterpretableBallotMarkAdjudication {
 export const UninterpretableBallotMarkAdjudicationSchema: z.ZodSchema<UninterpretableBallotMarkAdjudication> = z.object(
   {
     type: z.literal(AdjudicationReason.UninterpretableBallot),
-    contestId: Id,
+    contestId: ContestIdSchema,
     optionId: Id,
     isMarked: z.boolean(),
   }
@@ -131,7 +132,7 @@ export interface OvervoteMarkAdjudication {
 export const OvervoteMarkAdjudicationSchema: z.ZodSchema<OvervoteMarkAdjudication> = z.object(
   {
     type: z.literal(AdjudicationReason.Overvote),
-    contestId: Id,
+    contestId: ContestIdSchema,
     optionId: Id,
     isMarked: z.boolean(),
   }
@@ -146,7 +147,7 @@ export interface UndervoteMarkAdjudication {
 export const UndervoteMarkAdjudicationSchema: z.ZodSchema<UndervoteMarkAdjudication> = z.object(
   {
     type: z.literal(AdjudicationReason.Undervote),
-    contestId: Id,
+    contestId: ContestIdSchema,
     optionId: Id,
     isMarked: z.boolean(),
   }
@@ -161,7 +162,7 @@ export interface MarginalMarkAdjudication {
 export const MarginalMarkAdjudicationSchema: z.ZodSchema<MarginalMarkAdjudication> = z.object(
   {
     type: z.literal(AdjudicationReason.MarginalMark),
-    contestId: Id,
+    contestId: ContestIdSchema,
     optionId: Id,
     isMarked: z.boolean(),
   }
@@ -183,7 +184,7 @@ export const WriteInMarkAdjudicationMarkedSchema: z.ZodSchema<WriteInMarkAdjudic
       z.literal(AdjudicationReason.UnmarkedWriteIn),
     ]),
     isMarked: z.literal(true),
-    contestId: Id,
+    contestId: ContestIdSchema,
     optionId: WriteInId,
     name: z.string(),
   }
@@ -204,7 +205,7 @@ export const WriteInMarkAdjudicationUnmarkedSchema: z.ZodSchema<WriteInMarkAdjud
       z.literal(AdjudicationReason.UnmarkedWriteIn),
     ]),
     isMarked: z.literal(false),
-    contestId: Id,
+    contestId: ContestIdSchema,
     optionId: WriteInId,
   }
 );

--- a/libs/types/test/election.ts
+++ b/libs/types/test/election.ts
@@ -1,4 +1,4 @@
-import { Election, safeParseElection } from '../src/election';
+import { ContestIdSchema, Election, safeParseElection } from '../src/election';
 
 export const electionData = `
 {
@@ -84,8 +84,16 @@ export const primaryElection: Election = {
     })),
   ],
   contests: [
-    ...election.contests.map((c) => ({ ...c, id: `${c.id}D`, partyId: 'DEM' })),
-    ...election.contests.map((c) => ({ ...c, id: `${c.id}R`, partyId: 'REP' })),
+    ...election.contests.map((c) => ({
+      ...c,
+      id: ContestIdSchema.parse(`${c.id}D`),
+      partyId: 'DEM',
+    })),
+    ...election.contests.map((c) => ({
+      ...c,
+      id: ContestIdSchema.parse(`${c.id}R`),
+      partyId: 'REP',
+    })),
   ],
   parties: [
     { id: 'DEM', name: 'Democrat', abbrev: 'D', fullName: 'Democratic Party' },
@@ -103,12 +111,12 @@ export const electionWithMsEitherNeither: Election = {
     ...election.contests,
     {
       type: 'ms-either-neither',
-      id: 'MSC',
+      id: ContestIdSchema.parse('MSC'),
       title: 'MSC',
       description: 'MSC',
       section: 'SECTION',
       districtId: 'D',
-      eitherNeitherContestId: 'MSEN',
+      eitherNeitherContestId: ContestIdSchema.parse('MSEN'),
       eitherNeitherLabel: 'EITHER NEITHER',
       eitherOption: {
         id: 'EO',
@@ -118,7 +126,7 @@ export const electionWithMsEitherNeither: Election = {
         id: 'NO',
         label: 'NEITHER OPTION',
       },
-      pickOneContestId: 'MSPO',
+      pickOneContestId: ContestIdSchema.parse('MSPO'),
       pickOneLabel: 'PICK ONE',
       firstOption: {
         id: 'FO',

--- a/libs/utils/src/votes.ts
+++ b/libs/utils/src/votes.ts
@@ -21,6 +21,7 @@ import {
   FullElectionTally,
   BatchTally,
   Party,
+  ContestIdSchema,
 } from '@votingworks/types';
 import { strict as assert } from 'assert';
 import { find } from './find';
@@ -431,7 +432,7 @@ export function filterContestTalliesByPartyId(
 
   const filteredContestTallies: Dictionary<ContestTally> = {};
   for (const contestId in contestTallies) {
-    if (contestIds.includes(contestId))
+    if (contestIds.includes(ContestIdSchema.parse(contestId)))
       filteredContestTallies[contestId] = contestTallies[contestId];
   }
   return filteredContestTallies;


### PR DESCRIPTION
## Context
This makes it impossible to use a `string` where a `ContestId` is expected. We do this by making `ContestId` be a string that _also_ has an extra unique property shared by no other types. This doesn't exist at runtime (where contest IDs are just strings), but we can use it to enforce parsing `string` into `ContestId`.

## Why?
Allowing the use of arbitrary strings for contest IDs can cause problems when the string is not a valid contest ID. We'd like it to fail as soon as it comes into the system and fails to parse as a contest ID, rather than causing potentially subtle issues later on.

A next step might be to add `CandidateId` and `WriteInId` types that better model what's allowed there, and would prevent us from using them interchangeably when they are not the same thing.

See https://timhwang21.gitbook.io/index/programming/typescript/newtype for some more why and how.