### PR TITLE
refactor(kiosk): use underlying type

### DIFF
--- a/apps/bmd/src/config/types.ts
+++ b/apps/bmd/src/config/types.ts
@@ -149,7 +149,7 @@ export interface MsEitherNeitherContestResultInterface {
 }
 
 export interface PrintOptions extends KioskBrowser.PrintOptions {
-  sides: Exclude<KioskBrowser.PrintOptions['sides'], undefined>;
+  sides: KioskBrowser.PrintSides;
 }
 export interface Printer {
   print(options: PrintOptions): Promise<void>;

--- a/apps/election-manager/src/config/types.ts
+++ b/apps/election-manager/src/config/types.ts
@@ -52,7 +52,7 @@ export interface PrintedBallot {
 }
 
 export interface PrintOptions extends KioskBrowser.PrintOptions {
-  sides: Exclude<KioskBrowser.PrintOptions['sides'], undefined>;
+  sides: KioskBrowser.PrintSides;
 }
 export interface Printer {
   print(options: PrintOptions): Promise<void>;

--- a/libs/utils/src/types.ts
+++ b/libs/utils/src/types.ts
@@ -195,7 +195,7 @@ export interface Hardware {
 }
 
 export interface PrintOptions extends KioskBrowser.PrintOptions {
-  sides: Exclude<KioskBrowser.PrintOptions['sides'], undefined>;
+  sides: KioskBrowser.PrintSides;
 }
 export interface Printer {
   print(options: PrintOptions): Promise<void>;


### PR DESCRIPTION
Rather than doing gymnastics to alter the `PrintOptions` interface, just get the underlying type for the `sides` property to make it non-optional.