### PR TITLE
build(ts): all apps/libs depend on `eslint-plugin-vx`

### DIFF
--- a/apps/bas/tsconfig.json
+++ b/apps/bas/tsconfig.json
@@ -18,6 +18,7 @@
   "exclude": ["src/setupProxy.js"],
   "include": ["src"],
   "references": [
+    { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../../libs/types" },
     { "path": "../../libs/ui" },
     { "path": "../../libs/utils" }

--- a/apps/bmd/tsconfig.json
+++ b/apps/bmd/tsconfig.json
@@ -18,6 +18,7 @@
   "include": ["src", "test"],
   "references": [
     { "path": "../../libs/ballot-encoder" },
+    { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../../libs/test-utils" },
     { "path": "../../libs/types" },
     { "path": "../../libs/ui" },

--- a/apps/bsd/tsconfig.json
+++ b/apps/bsd/tsconfig.json
@@ -19,6 +19,7 @@
   "include": ["src", "prodserver", "test", "types"],
   "references": [
     { "path": "../../libs/ballot-encoder" },
+    { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../../libs/hmpb-interpreter" },
     { "path": "../../libs/test-utils" },
     { "path": "../../libs/types" },

--- a/apps/election-manager/tsconfig.json
+++ b/apps/election-manager/tsconfig.json
@@ -19,6 +19,7 @@
   "exclude": ["src/setupProxy.js"],
   "references": [
     { "path": "../../libs/ballot-encoder" },
+    { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../../libs/fixtures" },
     { "path": "../../libs/test-utils" },
     { "path": "../../libs/types" },

--- a/apps/module-scan/tsconfig.test.json
+++ b/apps/module-scan/tsconfig.test.json
@@ -7,6 +7,7 @@
   "exclude": [],
   "references": [
     { "path": "../../libs/ballot-encoder" },
+    { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../../libs/hmpb-interpreter" },
     { "path": "../../libs/plustek-sdk" },
     { "path": "../../libs/types" },

--- a/apps/precinct-scanner/tsconfig.json
+++ b/apps/precinct-scanner/tsconfig.json
@@ -19,6 +19,7 @@
   "exclude": ["src/setupProxy.js"],
   "references": [
     { "path": "../../libs/ballot-encoder" },
+    { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../../libs/hmpb-interpreter" },
     { "path": "../../libs/fixtures" },
     { "path": "../../libs/test-utils" },

--- a/integration-testing/bsd/cypress/tsconfig.json
+++ b/integration-testing/bsd/cypress/tsconfig.json
@@ -23,6 +23,6 @@
   ],
   "references": [
     { "path": "../../../libs/fixtures" },
-    { "path": "../../../libs/eslint-plugin-vx" }
+    { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" }
   ]
 }

--- a/integration-testing/election-manager/cypress/tsconfig.json
+++ b/integration-testing/election-manager/cypress/tsconfig.json
@@ -18,7 +18,7 @@
   },
   "include": ["**/*.ts"],
   "references": [
-    { "path": "../../../libs/eslint-plugin-vx" },
+    { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../../../libs/fixtures" },
     { "path": "../../../libs/test-utils" },
     { "path": "../../../libs/types" }

--- a/libs/fixtures/tsconfig.json
+++ b/libs/fixtures/tsconfig.json
@@ -53,5 +53,8 @@
   },
   "include": ["src", "src/data/*.json", "src/data/**/*.json"],
   "exclude": ["**/*.test.ts"],
-  "references": [{ "path": "../types" }]
+  "references": [
+    { "path": "../eslint-plugin-vx/tsconfig.build.json" },
+    { "path": "../types" }
+  ]
 }

--- a/libs/fixtures/tsconfig.test.json
+++ b/libs/fixtures/tsconfig.test.json
@@ -1,5 +1,14 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src", "src/data/*.json", "src/data/**/*.json", "scripts/**/*.ts"],
-  "exclude": []
+  "include": [
+    "src",
+    "src/data/*.json",
+    "src/data/**/*.json",
+    "scripts/**/*.ts"
+  ],
+  "exclude": [],
+  "references": [
+    { "path": "../eslint-plugin-vx/tsconfig.build.json" },
+    { "path": "../types" }
+  ]
 }

--- a/libs/test-utils/tsconfig.json
+++ b/libs/test-utils/tsconfig.json
@@ -58,5 +58,8 @@
     "skipLibCheck": true /* Skip type checking of declaration files. */,
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   },
-  "references": [{ "path": "../../libs/types" }]
+  "references": [
+    { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
+    { "path": "../../libs/types" }
+  ]
 }


### PR DESCRIPTION
This hasn't been a problem because everything that uses it but doesn't declare it also uses something _else_ that uses it and declares it. But we shouldn't rely on that.