### PR TITLE
test(all): move `useFakeTimers` into `beforeEach`

### DIFF
--- a/apps/election-manager/src/screens/ManualDataImportIndexScreen.test.tsx
+++ b/apps/election-manager/src/screens/ManualDataImportIndexScreen.test.tsx
@@ -24,7 +24,9 @@ import {
   getEmptyExternalTally,
 } from '../utils/externalTallies';
 
-jest.useFakeTimers();
+beforeEach(() => {
+  jest.useFakeTimers();
+});
 
 test('can toggle ballot types for data', async () => {
   const saveExternalTallies = jest.fn();

--- a/apps/module-scan/src/cli/util/spinner.test.ts
+++ b/apps/module-scan/src/cli/util/spinner.test.ts
@@ -1,7 +1,9 @@
 import ora from 'ora';
 import Spinner, { countProvider, durationProvider } from './spinner';
 
-jest.useFakeTimers();
+beforeEach(() => {
+  jest.useFakeTimers();
+});
 
 test('durationProvider counts up starting from 3s', () => {
   const duration = durationProvider();

--- a/apps/precinct-scanner/package.json
+++ b/apps/precinct-scanner/package.json
@@ -19,6 +19,7 @@
     "stylelint:run": "stylelint 'src/**/*.{js,jsx,ts,tsx}' && stylelint 'src/**/*.css' --config .stylelintrc-css.js",
     "stylelint:run:fix": "stylelint 'src/**/*.{js,jsx,ts,tsx}' --fix && stylelint 'src/**/*.css' --config .stylelintrc-css.js --fix",
     "test": "is-ci test:coverage test:watch",
+    "test:debug": "TZ=UTC script/react-scripts --inspect-brk test --runInBand --no-cache --env=jest-environment-jsdom-sixteen",
     "test:watch": "TZ=UTC script/react-scripts test --env=jest-environment-jsdom-sixteen",
     "test:coverage": "TZ=UTC script/react-scripts test --coverage --watchAll=false",
     "pre-commit": "lint-staged"

--- a/apps/precinct-scanner/src/screens/AdminScreen.test.tsx
+++ b/apps/precinct-scanner/src/screens/AdminScreen.test.tsx
@@ -7,11 +7,9 @@ import React from 'react';
 import AppContext from '../contexts/AppContext';
 import AdminScreen from './AdminScreen';
 
-MockDate.set('2020-10-31T00:00:00.000Z');
-
-jest.useFakeTimers();
-
 beforeEach(() => {
+  MockDate.set('2020-10-31T00:00:00.000Z');
+  jest.useFakeTimers();
   window.location.href = '/';
   window.kiosk = fakeKiosk();
 });

--- a/libs/utils/src/sleep.test.ts
+++ b/libs/utils/src/sleep.test.ts
@@ -1,6 +1,8 @@
 import { sleep } from './sleep';
 
-jest.useFakeTimers();
+beforeEach(() => {
+  jest.useFakeTimers();
+});
 
 test('sleep', async () => {
   const sleepPromise = sleep(10);


### PR DESCRIPTION
Same rationale as #1114, but these ones apparently weren't affected by the issue because they don't actually rely on fake timers.