### PR TITLE
refactor(bmd): pass reload down

### DIFF
--- a/apps/bmd/src/APIMachineConfig.test.tsx
+++ b/apps/bmd/src/APIMachineConfig.test.tsx
@@ -28,7 +28,7 @@ test('machineConfig is fetched from /machine-config by default', async () => {
     })
   );
 
-  render(<App storage={new MemoryStorage()} />);
+  render(<App storage={new MemoryStorage()} reload={jest.fn()} />);
   await advanceTimersAndPromises();
 
   expect(fetchMock.called('/machine-config')).toBe(true);
@@ -40,7 +40,13 @@ test('machineConfig fetch fails', async () => {
   };
 
   // Render app which gets machineConfig in componentDidMount
-  render(<App storage={new MemoryStorage()} machineConfig={machineConfig} />);
+  render(
+    <App
+      storage={new MemoryStorage()}
+      machineConfig={machineConfig}
+      reload={jest.fn()}
+    />
+  );
   await advanceTimersAndPromises();
 
   // No expect?
@@ -56,7 +62,13 @@ test('machineId is empty', async () => {
   };
 
   // Render app which gets machineConfig in componentDidMount
-  render(<App storage={new MemoryStorage()} machineConfig={machineConfig} />);
+  render(
+    <App
+      storage={new MemoryStorage()}
+      machineConfig={machineConfig}
+      reload={jest.fn()}
+    />
+  );
   await advanceTimersAndPromises();
 
   // No expect?
@@ -73,7 +85,13 @@ test('machineConfig is empty', async () => {
   };
 
   // Render app which gets machineConfig in componentDidMount
-  render(<App storage={new MemoryStorage()} machineConfig={machineConfig} />);
+  render(
+    <App
+      storage={new MemoryStorage()}
+      machineConfig={machineConfig}
+      reload={jest.fn()}
+    />
+  );
   await advanceTimersAndPromises();
 
   // No expect?

--- a/apps/bmd/src/App.test.tsx
+++ b/apps/bmd/src/App.test.tsx
@@ -1,13 +1,26 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { fakeKiosk, makePollWorkerCard } from '@votingworks/test-utils';
+import { MemoryCard, MemoryHardware, MemoryStorage } from '@votingworks/utils';
 import * as React from 'react';
-import { fakeKiosk } from '@votingworks/test-utils';
-import { render } from '../test/testUtils';
-import App from './App';
+import {
+  setElectionInStorage,
+  setStateInStorage,
+} from '../test/helpers/election';
 import { fakeMachineConfigProvider } from '../test/helpers/fakeMachineConfig';
 import { advanceTimersAndPromises } from '../test/helpers/smartcards';
+import { render } from '../test/testUtils';
+import App from './App';
+import { PrecinctSelectionKind, VxMarkPlusVxPrint } from './config/types';
+import { electionSampleDefinition } from './data';
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
 
 it('prevents context menus from appearing', async () => {
-  jest.useFakeTimers();
-  render(<App machineConfig={fakeMachineConfigProvider()} />);
+  render(
+    <App machineConfig={fakeMachineConfigProvider()} reload={jest.fn()} />
+  );
 
   const { oncontextmenu } = window;
 
@@ -24,10 +37,55 @@ it('prevents context menus from appearing', async () => {
 });
 
 it('uses kiosk storage when in kiosk-browser', async () => {
-  jest.useFakeTimers();
   const kiosk = fakeKiosk();
   window.kiosk = kiosk;
-  render(<App machineConfig={fakeMachineConfigProvider()} />);
+  render(
+    <App machineConfig={fakeMachineConfigProvider()} reload={jest.fn()} />
+  );
   await advanceTimersAndPromises();
   expect(kiosk.storage.get).toHaveBeenCalled();
+});
+
+// This test is only really here to provide coverage for the default value for
+// `App`'s `reload` prop.
+it('uses window.location.reload by default', async () => {
+  // Stub location in a way that's good enough for this test, but not good
+  // enough for general `window.location` use.
+  const reload = jest.fn();
+  jest.spyOn(window, 'location', 'get').mockReturnValue({
+    ...window.location,
+    reload,
+  });
+
+  // Set up in an already-configured state.
+  const electionDefinition = electionSampleDefinition;
+  const card = new MemoryCard();
+  const hardware = await MemoryHardware.buildStandard();
+  const storage = new MemoryStorage();
+  const pollWorkerCard = makePollWorkerCard(electionDefinition.electionHash);
+  const machineConfig = fakeMachineConfigProvider({
+    appMode: VxMarkPlusVxPrint,
+  });
+
+  await setElectionInStorage(storage, electionDefinition);
+  await setStateInStorage(storage, {
+    appPrecinct: { kind: PrecinctSelectionKind.AllPrecincts },
+  });
+
+  render(
+    <App
+      card={card}
+      hardware={hardware}
+      machineConfig={machineConfig}
+      storage={storage}
+    />
+  );
+
+  await advanceTimersAndPromises();
+
+  // Force refresh
+  card.insertCard(pollWorkerCard);
+  await advanceTimersAndPromises();
+  fireEvent.click(screen.getByText('Reset Accessible Controller'));
+  expect(reload).toHaveBeenCalledTimes(1);
 });

--- a/apps/bmd/src/App.tsx
+++ b/apps/bmd/src/App.tsx
@@ -35,6 +35,7 @@ export interface Props {
   printer?: AppRootProps['printer'];
   machineConfig?: AppRootProps['machineConfig'];
   screenReader?: ScreenReader;
+  reload?: VoidFunction;
 }
 
 function App({
@@ -47,6 +48,7 @@ function App({
   printer = getPrinter(),
   hardware,
   machineConfig = machineConfigProvider,
+  reload = () => window.location.reload(),
 }: Props): JSX.Element {
   screenReader.mute();
   const [internalHardware, setInternalHardware] = useState(hardware);
@@ -144,6 +146,7 @@ function App({
               storage={storage}
               machineConfig={machineConfig}
               screenReader={screenReader}
+              reload={reload}
               {...props}
             />
           )}

--- a/apps/bmd/src/AppCardUnhappyPaths.test.tsx
+++ b/apps/bmd/src/AppCardUnhappyPaths.test.tsx
@@ -53,6 +53,7 @@ test('Display App Card Unhappy Paths', async () => {
       hardware={hardware}
       storage={storage}
       machineConfig={machineConfig}
+      reload={jest.fn()}
     />
   );
   await advanceTimersAndPromises();
@@ -167,6 +168,7 @@ test('Inserting voter card when machine is unconfigured does nothing', async () 
       hardware={hardware}
       storage={storage}
       machineConfig={machineConfig}
+      reload={jest.fn()}
     />
   );
   await advanceTimersAndPromises();
@@ -203,6 +205,7 @@ test('Inserting pollworker card with invalid long data fall back as if there is 
       hardware={hardware}
       storage={storage}
       machineConfig={machineConfig}
+      reload={jest.fn()}
     />
   );
   await advanceTimersAndPromises();

--- a/apps/bmd/src/AppCardlessVoting.test.tsx
+++ b/apps/bmd/src/AppCardlessVoting.test.tsx
@@ -49,6 +49,7 @@ test('Cardless Voting Flow', async () => {
       machineConfig={machineConfig}
       printer={printer}
       storage={storage}
+      reload={jest.fn()}
     />
   );
   await advanceTimersAndPromises();
@@ -222,6 +223,7 @@ test('Another Voter submits blank ballot and clicks Done', async () => {
       printer={printer}
       storage={storage}
       machineConfig={machineConfig}
+      reload={jest.fn()}
     />
   );
   await advanceTimersAndPromises();
@@ -299,6 +301,7 @@ test('poll worker must select a precinct first', async () => {
       machineConfig={machineConfig}
       printer={printer}
       storage={storage}
+      reload={jest.fn()}
     />
   );
   await advanceTimersAndPromises();

--- a/apps/bmd/src/AppContestCandidateNoParty.test.tsx
+++ b/apps/bmd/src/AppContestCandidateNoParty.test.tsx
@@ -58,6 +58,7 @@ it('Single Seat Contest', async () => {
       hardware={hardware}
       storage={storage}
       machineConfig={machineConfig}
+      reload={jest.fn()}
     />
   );
   await advanceTimersAndPromises();

--- a/apps/bmd/src/AppContestMsEitherNeither.test.tsx
+++ b/apps/bmd/src/AppContestMsEitherNeither.test.tsx
@@ -174,6 +174,7 @@ test('Can vote on a Mississippi Either Neither Contest', async () => {
       hardware={hardware}
       storage={storage}
       machineConfig={machineConfig}
+      reload={jest.fn()}
     />
   );
   await advanceTimersAndPromises();

--- a/apps/bmd/src/AppContestMultiSeat.test.tsx
+++ b/apps/bmd/src/AppContestMultiSeat.test.tsx
@@ -37,6 +37,7 @@ it('Single Seat Contest', async () => {
       hardware={hardware}
       storage={storage}
       machineConfig={machineConfig}
+      reload={jest.fn()}
     />
   );
   await advanceTimersAndPromises();

--- a/apps/bmd/src/AppContestSingleSeat.test.tsx
+++ b/apps/bmd/src/AppContestSingleSeat.test.tsx
@@ -37,6 +37,7 @@ it('Single Seat Contest', async () => {
       hardware={hardware}
       storage={storage}
       machineConfig={machineConfig}
+      reload={jest.fn()}
     />
   );
   await advanceTimersAndPromises();

--- a/apps/bmd/src/AppContestWriteIn.test.tsx
+++ b/apps/bmd/src/AppContestWriteIn.test.tsx
@@ -54,6 +54,7 @@ it('Single Seat Contest with Write In', async () => {
       printer={printer}
       storage={storage}
       machineConfig={machineConfig}
+      reload={jest.fn()}
     />
   );
   await advanceTimersAndPromises();

--- a/apps/bmd/src/AppContestYesNo.test.tsx
+++ b/apps/bmd/src/AppContestYesNo.test.tsx
@@ -39,6 +39,7 @@ it('Single Seat Contest', async () => {
       hardware={hardware}
       storage={storage}
       machineConfig={machineConfig}
+      reload={jest.fn()}
     />
   );
   await advanceTimersAndPromises();

--- a/apps/bmd/src/AppData.test.tsx
+++ b/apps/bmd/src/AppData.test.tsx
@@ -27,6 +27,7 @@ describe('loads election', () => {
         machineConfig={fakeMachineConfigProvider()}
         card={new MemoryCard()}
         hardware={hardware}
+        reload={jest.fn()}
       />
     );
 
@@ -49,6 +50,7 @@ describe('loads election', () => {
         storage={storage}
         machineConfig={machineConfig}
         hardware={hardware}
+        reload={jest.fn()}
       />
     );
 
@@ -61,7 +63,7 @@ describe('loads election', () => {
 
   it('demo app loads election and activates ballot', async () => {
     const storage = getDemoStorage();
-    render(<DemoApp storage={storage} />);
+    render(<DemoApp storage={storage} reload={jest.fn()} />);
 
     // Let the initial hardware detection run.
     await advanceTimersAndPromises();

--- a/apps/bmd/src/AppEndToEnd.test.tsx
+++ b/apps/bmd/src/AppEndToEnd.test.tsx
@@ -59,6 +59,7 @@ it('VxMark+Print end-to-end flow', async () => {
   });
   const expectedElectionHash = electionDefinition.electionHash.substring(0, 10);
   const writeLongUint8ArrayMock = jest.spyOn(card, 'writeLongUint8Array');
+  const reload = jest.fn();
   render(
     <App
       card={card}
@@ -66,6 +67,7 @@ it('VxMark+Print end-to-end flow', async () => {
       machineConfig={machineConfig}
       printer={printer}
       storage={storage}
+      reload={reload}
     />
   );
   await advanceTimersAndPromises();
@@ -142,6 +144,7 @@ it('VxMark+Print end-to-end flow', async () => {
   screen.getByText('Close Polls for Center Springfield');
   // Force refresh
   fireEvent.click(screen.getByText('Reset Accessible Controller'));
+  expect(reload).toHaveBeenCalledTimes(1);
   await screen.findByText('Close Polls for Center Springfield');
 
   // Remove card

--- a/apps/bmd/src/AppMarkOnly.test.tsx
+++ b/apps/bmd/src/AppMarkOnly.test.tsx
@@ -45,6 +45,7 @@ it('VxMarkOnly flow', async () => {
       hardware={hardware}
       storage={storage}
       machineConfig={machineConfig}
+      reload={jest.fn()}
     />
   );
   await advanceTimersAndPromises();

--- a/apps/bmd/src/AppMarkVoterCardInvalid.test.tsx
+++ b/apps/bmd/src/AppMarkVoterCardInvalid.test.tsx
@@ -49,6 +49,7 @@ describe('Mark Card Void when voter is idle too long', () => {
         hardware={hardware}
         storage={storage}
         machineConfig={machineConfig}
+        reload={jest.fn()}
       />
     );
     // Initialize app
@@ -122,6 +123,7 @@ describe('Mark Card Void when voter is idle too long', () => {
         hardware={hardware}
         storage={storage}
         machineConfig={machineConfig}
+        reload={jest.fn()}
       />
     );
     // Initialize app
@@ -193,6 +195,7 @@ describe('Mark Card Void when voter is idle too long', () => {
         hardware={hardware}
         storage={storage}
         machineConfig={machineConfig}
+        reload={jest.fn()}
       />
     );
     // Initialize app

--- a/apps/bmd/src/AppPrintOnly.test.tsx
+++ b/apps/bmd/src/AppPrintOnly.test.tsx
@@ -56,6 +56,7 @@ test('VxPrintOnly flow', async () => {
       storage={storage}
       printer={printer}
       machineConfig={machineConfig}
+      reload={jest.fn()}
     />
   );
   await advanceTimersAndPromises();
@@ -391,6 +392,7 @@ test('VxPrint retains app mode when unconfigured', async () => {
       storage={storage}
       printer={printer}
       machineConfig={machineConfig}
+      reload={jest.fn()}
     />
   );
 
@@ -491,6 +493,7 @@ test('VxPrint prompts to change to live mode on election day', async () => {
       storage={storage}
       printer={printer}
       machineConfig={machineConfig}
+      reload={jest.fn()}
     />
   );
   await advanceTimersAndPromises();

--- a/apps/bmd/src/AppQuitOnIdle.test.tsx
+++ b/apps/bmd/src/AppQuitOnIdle.test.tsx
@@ -44,6 +44,7 @@ test('Insert Card screen idle timeout to quit app', async () => {
       hardware={hardware}
       storage={storage}
       machineConfig={machineConfig}
+      reload={jest.fn()}
     />
   );
 

--- a/apps/bmd/src/AppRefresh.test.tsx
+++ b/apps/bmd/src/AppRefresh.test.tsx
@@ -42,6 +42,7 @@ it('Refresh window and expect to be on same contest', async () => {
       hardware={hardware}
       storage={storage}
       machineConfig={machineConfig}
+      reload={jest.fn()}
     />
   );
   await advanceTimersAndPromises();
@@ -79,6 +80,7 @@ it('Refresh window and expect to be on same contest', async () => {
       hardware={hardware}
       storage={storage}
       machineConfig={machineConfig}
+      reload={jest.fn()}
     />
   ));
 

--- a/apps/bmd/src/AppReplaceElection.test.tsx
+++ b/apps/bmd/src/AppReplaceElection.test.tsx
@@ -35,6 +35,7 @@ test('replacing a loaded election with one from a card', async () => {
       hardware={hardware}
       storage={storage}
       machineConfig={machineConfig}
+      reload={jest.fn()}
     />
   );
 

--- a/apps/bmd/src/AppRoot.tsx
+++ b/apps/bmd/src/AppRoot.tsx
@@ -149,6 +149,7 @@ export interface Props extends RouteComponentProps {
   printer: Printer;
   storage: Storage;
   screenReader: ScreenReader;
+  reload: VoidFunction;
 }
 
 export const electionStorageKey = 'electionDefinition';
@@ -472,6 +473,7 @@ function AppRoot({
   printer,
   screenReader,
   storage,
+  reload,
 }: Props): JSX.Element {
   const PostVotingInstructionsTimeout = useRef(0);
   const [appState, dispatchAppState] = useReducer(appReducer, initialAppState);
@@ -1309,6 +1311,7 @@ function AppRoot({
           tallyOnCard={tallyOnCard}
           clearTalliesOnCard={clearTalliesOnCard}
           hasVotes={!!votes}
+          reload={reload}
         />
       );
     }

--- a/apps/bmd/src/AppSetupErrors.test.tsx
+++ b/apps/bmd/src/AppSetupErrors.test.tsx
@@ -48,6 +48,7 @@ describe('Displays setup warning messages and errors screens', () => {
         hardware={hardware}
         storage={storage}
         machineConfig={machineConfig}
+        reload={jest.fn()}
       />
     );
     const accessibleControllerWarningText =
@@ -91,6 +92,7 @@ describe('Displays setup warning messages and errors screens', () => {
         hardware={hardware}
         storage={storage}
         machineConfig={machineConfig}
+        reload={jest.fn()}
       />
     );
 
@@ -128,6 +130,7 @@ describe('Displays setup warning messages and errors screens', () => {
         hardware={hardware}
         storage={storage}
         machineConfig={machineConfig}
+        reload={jest.fn()}
       />
     );
 
@@ -167,6 +170,7 @@ describe('Displays setup warning messages and errors screens', () => {
         hardware={hardware}
         storage={storage}
         machineConfig={machineConfig}
+        reload={jest.fn()}
       />
     );
 
@@ -210,6 +214,7 @@ describe('Displays setup warning messages and errors screens', () => {
         hardware={hardware}
         storage={storage}
         machineConfig={machineConfig}
+        reload={jest.fn()}
       />
     );
 
@@ -249,6 +254,7 @@ describe('Displays setup warning messages and errors screens', () => {
         hardware={hardware}
         storage={storage}
         machineConfig={machineConfig}
+        reload={jest.fn()}
       />
     );
     const getByTextWithMarkup = withMarkup(screen.getByText);

--- a/apps/bmd/src/AppTestMode.test.tsx
+++ b/apps/bmd/src/AppTestMode.test.tsx
@@ -31,6 +31,7 @@ it('Displays testing message if not live mode', async () => {
       storage={storage}
       machineConfig={machineConfig}
       hardware={hardware}
+      reload={jest.fn()}
     />
   );
 

--- a/apps/bmd/src/lib/gamepad.test.tsx
+++ b/apps/bmd/src/lib/gamepad.test.tsx
@@ -40,6 +40,7 @@ it('gamepad controls work', async () => {
       hardware={hardware}
       storage={storage}
       machineConfig={machineConfig}
+      reload={jest.fn()}
     />
   );
   await advanceTimersAndPromises();

--- a/apps/bmd/src/pages/PollWorkerScreen.test.tsx
+++ b/apps/bmd/src/pages/PollWorkerScreen.test.tsx
@@ -95,6 +95,7 @@ test('renders PollWorkerScreen', async () => {
       togglePollsOpen={jest.fn()}
       tallyOnCard={undefined}
       clearTalliesOnCard={jest.fn()}
+      reload={jest.fn()}
     />
   );
 
@@ -125,6 +126,7 @@ test('switching out of test mode on election day', async () => {
       togglePollsOpen={jest.fn()}
       tallyOnCard={undefined}
       clearTalliesOnCard={jest.fn()}
+      reload={jest.fn()}
     />
   );
 
@@ -157,6 +159,7 @@ test('keeping test mode on election day', async () => {
       togglePollsOpen={jest.fn()}
       tallyOnCard={undefined}
       clearTalliesOnCard={jest.fn()}
+      reload={jest.fn()}
     />
   );
 
@@ -186,6 +189,7 @@ test('live mode on election day', async () => {
       togglePollsOpen={jest.fn()}
       tallyOnCard={undefined}
       clearTalliesOnCard={jest.fn()}
+      reload={jest.fn()}
     />
   );
 
@@ -235,6 +239,7 @@ test('printing precinct scanner report works as expected with all precinct data 
       togglePollsOpen={jest.fn()}
       tallyOnCard={tallyOnCard}
       clearTalliesOnCard={clearTallies}
+      reload={jest.fn()}
     />
   );
 
@@ -315,6 +320,7 @@ test('printing precinct scanner report works as expected with single precinct da
       togglePollsOpen={jest.fn()}
       tallyOnCard={tallyOnCard}
       clearTalliesOnCard={clearTallies}
+      reload={jest.fn()}
     />
   );
 
@@ -413,6 +419,7 @@ test('printing precinct scanner report works as expected with all precinct speci
       togglePollsOpen={jest.fn()}
       tallyOnCard={tallyOnCard}
       clearTalliesOnCard={clearTallies}
+      reload={jest.fn()}
     />
   );
 
@@ -564,6 +571,7 @@ test('printing precinct scanner report works as expected with all precinct speci
       togglePollsOpen={jest.fn()}
       tallyOnCard={tallyOnCard}
       clearTalliesOnCard={clearTallies}
+      reload={jest.fn()}
     />
   );
 
@@ -795,6 +803,7 @@ test('printing precinct scanner report works as expected with all precinct combi
       togglePollsOpen={jest.fn()}
       tallyOnCard={tallyOnCard}
       clearTalliesOnCard={clearTallies}
+      reload={jest.fn()}
     />
   );
 
@@ -945,6 +954,7 @@ test('printing precinct scanner report works as expected with a single precinct 
       togglePollsOpen={jest.fn()}
       tallyOnCard={tallyOnCard}
       clearTalliesOnCard={clearTallies}
+      reload={jest.fn()}
     />
   );
 

--- a/apps/bmd/src/pages/PollWorkerScreen.tsx
+++ b/apps/bmd/src/pages/PollWorkerScreen.tsx
@@ -68,6 +68,7 @@ interface Props {
   togglePollsOpen: () => void;
   tallyOnCard?: PrecinctScannerCardTally;
   clearTalliesOnCard: () => Promise<void>;
+  reload: () => void;
 }
 
 interface DerivedTallyInformationFromCard {
@@ -97,6 +98,7 @@ function PollWorkerScreen({
   hasVotes,
   tallyOnCard,
   clearTalliesOnCard,
+  reload,
 }: Props): JSX.Element {
   const { election } = electionDefinition;
   const electionDate = DateTime.fromISO(electionDefinition.election.date);
@@ -326,10 +328,6 @@ function PollWorkerScreen({
         </Main>
       </Screen>
     );
-  }
-
-  function reload() {
-    window.location.reload();
   }
 
   return (


### PR DESCRIPTION
Calling `window.location.reload` from `PollWorkerScreen` results in an error in our tests that is swallowed, but still printed to stderr:

> Error: Not implemented: navigation (except hash changes)

This is a limitation of JSDOM, but it's a sensible one. To address this problem, this commit modifies `App` to accept a `reload` prop that we mock in all the tests.