### PR TITLE
test(bmd): fix race condition in `TestBallotDeckScreen` test

### DIFF
--- a/apps/bmd/src/pages/TestBallotDeckScreen.test.tsx
+++ b/apps/bmd/src/pages/TestBallotDeckScreen.test.tsx
@@ -7,7 +7,12 @@ import {
 import React from 'react';
 import { fireEvent, waitFor, act, screen } from '@testing-library/react';
 import { asElectionDefinition } from '@votingworks/fixtures';
-import { fakeKiosk, fakePrinterInfo, mockOf } from '@votingworks/test-utils';
+import {
+  advanceTimersAndPromises,
+  fakeKiosk,
+  fakePrinterInfo,
+  mockOf,
+} from '@votingworks/test-utils';
 import electionSample from '../data/electionSample.json';
 import { render } from '../../test/testUtils';
 import { randomBase64 } from '../utils/random';
@@ -72,7 +77,6 @@ it('renders test decks appropriately', async () => {
     jest.advanceTimersByTime(66000);
   });
   expect(screen.queryAllByText('Printing Ballots…').length).toBe(0);
-  jest.useRealTimers();
 });
 
 it('shows printer not connected when appropriate', async () => {
@@ -98,6 +102,7 @@ it('shows printer not connected when appropriate', async () => {
   fireEvent.click(screen.getByText('All Precincts'));
 
   fireEvent.click(screen.getByText('Print 63 ballots'));
+  await advanceTimersAndPromises();
 
   expect(kiosk.getPrinterInfo).toHaveBeenCalled();
 


### PR DESCRIPTION
When the test clicks "Print 63 ballots", it calls `handlePrinting` in `TestBallotDeckScreen`. That gets the printer info and determines whether a printer is connected. But the test was not waiting for the async stuff to complete, so sometimes it would before the `waitFor` looking for the error expired and sometimes it wouldn't.