### PR TITLE
feat(eslint): add `gts-no-default-exports` rule

### DIFF
--- a/libs/eslint-plugin-vx/docs/rules/gts-no-default-export.md
+++ b/libs/eslint-plugin-vx/docs/rules/gts-no-default-export.md
@@ -1,0 +1,23 @@
+# Disallows default exports (`vx/gts-no-default-exports`)
+
+This rule is from
+[Google TypeScript Style Guide section "Exports"](https://google.github.io/styleguide/tsguide.html#exports):
+
+> Use named exports in all code. Do not use default exports. This ensures that
+> all imports follow a uniform pattern. Default exports provide no canonical name,
+> which makes central maintenance difficult with relatively little benefit to code
+> owners, including potentially decreased readability.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```ts
+export default class Foo { ... } // BAD!
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+export class Foo { ... } // GOOD!
+```

--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -40,6 +40,8 @@ export = {
     'vx/gts-func-style': 'error',
     'vx/gts-identifiers-use-allowed-character': 'error',
     'vx/gts-no-array-constructor': 'error',
+    // TODO: enable this everywhere
+    'vx/gts-no-default-exports': 'off',
     'vx/gts-no-dollar-sign-names': 'error',
     'vx/gts-no-foreach': 'error',
     'vx/gts-no-for-in-loop': 'error',

--- a/libs/eslint-plugin-vx/src/rules/gts-no-default-exports.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts-no-default-exports.ts
@@ -1,0 +1,216 @@
+import {
+  AST_NODE_TYPES,
+  TSESTree,
+} from '@typescript-eslint/experimental-utils';
+import { strict as assert } from 'assert';
+import { createRule } from '../util';
+
+export default createRule({
+  name: 'gts-no-default-exports',
+  meta: {
+    docs: {
+      description: 'Disallows default exports',
+      category: 'Best Practices',
+      recommended: 'error',
+      suggestion: false,
+      requiresTypeChecking: false,
+    },
+    fixable: 'code',
+    messages: {
+      noDefaultExports:
+        'Do not use default exports; use named exports instead.',
+      noDefaultImports:
+        'Do not use default imports within a package; use named imports instead.',
+    },
+    schema: [],
+    type: 'problem',
+  },
+  defaultOptions: [],
+
+  create(context) {
+    const sourceCode = context.getSourceCode();
+
+    function getNamedExportCandidate(
+      name: string
+    ): TSESTree.Statement | undefined {
+      const defs = context.getScope().set.get(name)?.defs;
+
+      if (!defs || defs.length !== 1) {
+        return undefined;
+      }
+
+      const [def] = defs;
+
+      if (def.node.type === AST_NODE_TYPES.VariableDeclarator) {
+        /* istanbul ignore next - this is for TypeScript type narrowing */
+        assert(def.node.parent?.type === AST_NODE_TYPES.VariableDeclaration);
+        return def.node.parent.declarations.length === 1
+          ? def.node.parent
+          : undefined;
+      }
+
+      if (def.node.type === AST_NODE_TYPES.FunctionDeclaration) {
+        return def.node;
+      }
+    }
+
+    function isImportSourceAllowedToUseDefaultImport(source: string): boolean {
+      const isJsonModule = source.toLowerCase().endsWith('.json');
+
+      if (isJsonModule) {
+        return true;
+      }
+
+      const [firstPathComponent] = source.split('/', 2);
+      const isRelative =
+        firstPathComponent === '.' || firstPathComponent === '..';
+
+      if (!isRelative) {
+        return true;
+      }
+
+      return false;
+    }
+
+    return {
+      ExportSpecifier(node: TSESTree.ExportSpecifier): void {
+        assert(node.parent?.type === AST_NODE_TYPES.ExportNamedDeclaration);
+
+        if (node.local.name === 'default' && node.exported.name !== 'default') {
+          context.report({
+            node: node.parent,
+            messageId: 'noDefaultExports',
+            fix: (fixer) =>
+              // `export { default as a } from './a';` → `export { a } from './a';`
+              //           ^^^^^^^^^^^
+              fixer.removeRange([node.range[0], node.exported.range[0]]),
+          });
+        }
+      },
+
+      ExportDefaultDeclaration(node: TSESTree.ExportDefaultDeclaration): void {
+        switch (node.declaration.type) {
+          case AST_NODE_TYPES.Identifier: {
+            const declaration = getNamedExportCandidate(node.declaration.name);
+
+            context.report({
+              node,
+              messageId: 'noDefaultExports',
+              fix: declaration
+                ? function* getFixes(fixer) {
+                    /* istanbul ignore next - this is for TypeScript type narrowing */
+                    assert(declaration.parent);
+
+                    if (
+                      declaration.parent.type !==
+                      AST_NODE_TYPES.ExportNamedDeclaration
+                    ) {
+                      // `const a = 1;` → `export const a = 1;`
+                      //                   ^^^^^^^
+                      yield fixer.insertTextBefore(declaration, 'export ');
+                    }
+
+                    // `export default a;` → ``
+                    //  ^^^^^^^^^^^^^^^^^
+                    yield fixer.remove(node);
+                  }
+                : undefined,
+            });
+            break;
+          }
+
+          case AST_NODE_TYPES.FunctionDeclaration:
+          case AST_NODE_TYPES.ClassDeclaration: {
+            context.report({
+              node,
+              messageId: 'noDefaultExports',
+              fix: function* getFixes(fixer) {
+                const [exportToken, defaultToken] = sourceCode.getFirstTokens(
+                  node,
+                  { count: 2 }
+                );
+                /* istanbul ignore next - this is for TypeScript type narrowing */
+                assert.equal(exportToken?.value, 'export');
+                /* istanbul ignore next - this is for TypeScript type narrowing */
+                assert.equal(defaultToken?.value, 'default');
+
+                // `export default function a() {}` → `export function a() {}`
+                //        ^^^^^^^^
+                yield fixer.removeRange([
+                  exportToken.range[1],
+                  defaultToken.range[1],
+                ]);
+              },
+            });
+            break;
+          }
+
+          default:
+            context.report({
+              node,
+              messageId: 'noDefaultExports',
+            });
+        }
+      },
+
+      ImportDefaultSpecifier(node: TSESTree.ImportDefaultSpecifier): void {
+        /* istanbul ignore next - this is for TypeScript type narrowing */
+        assert(node.parent?.type === AST_NODE_TYPES.ImportDeclaration);
+        const importDeclaration = node.parent;
+
+        /* istanbul ignore next - this is for TypeScript type narrowing */
+        assert(typeof importDeclaration.source.value === 'string');
+
+        if (
+          isImportSourceAllowedToUseDefaultImport(
+            importDeclaration.source.value
+          )
+        ) {
+          return;
+        }
+
+        context.report({
+          node: importDeclaration,
+          messageId: 'noDefaultImports',
+          fix: function* getFixes(fixer) {
+            if (importDeclaration.specifiers.length === 1) {
+              // `import a from './a';` → `import { a from './a';`
+              //                                  ^^
+              yield fixer.insertTextBefore(node, '{ ');
+              // `import { a from './a';` → `import { a } from './a';`
+              //                                       ^^
+              yield fixer.insertTextAfter(node, ' }');
+            } else {
+              const [commaToken, leftBracketToken, afterLeftBracketToken] =
+                sourceCode.getTokensAfter(node, { count: 3 });
+              /* istanbul ignore next - this is for TypeScript type narrowing */
+              assert(commaToken?.value === ',');
+              /* istanbul ignore next - this is for TypeScript type narrowing */
+              assert(leftBracketToken?.value === '{');
+              /* istanbul ignore next - this is for TypeScript type narrowing */
+              assert(afterLeftBracketToken);
+
+              // `import a, { b } from './a';` → `import a, b } from './a';`
+              //            ^^
+              yield fixer.removeRange([
+                leftBracketToken.range[0],
+                afterLeftBracketToken.range[0],
+              ]);
+              // `import a, b } from './a';` → `import { a, b } from './a';`
+              //                                       ^^
+              yield fixer.insertTextBefore(
+                node,
+                sourceCode
+                  .getText()
+                  .slice(
+                    leftBracketToken.range[0],
+                    afterLeftBracketToken.range[0]
+                  )
+              );
+            }
+          },
+        });
+      },
+    };
+  },
+});

--- a/libs/eslint-plugin-vx/src/rules/index.ts
+++ b/libs/eslint-plugin-vx/src/rules/index.ts
@@ -4,6 +4,7 @@ import gtsDirectModuleExportAccessOnly from './gts-direct-module-export-access-o
 import gtsFuncStyle from './gts-func-style';
 import gtsIdentifiersUseAllowedCharacters from './gts-identifiers-use-allowed-characters';
 import gtsNoArrayConstructor from './gts-no-array-constructor';
+import gtsNoDefaultExports from './gts-no-default-exports';
 import gtsNoDollarSignNames from './gts-no-dollar-sign-names';
 import gtsNoForInLoop from './gts-no-for-in-loop';
 import gtsNoForeach from './gts-no-foreach';
@@ -29,6 +30,7 @@ const rules: Record<
   'gts-func-style': gtsFuncStyle,
   'gts-identifiers-use-allowed-character': gtsIdentifiersUseAllowedCharacters,
   'gts-no-array-constructor': gtsNoArrayConstructor,
+  'gts-no-default-exports': gtsNoDefaultExports,
   'gts-no-dollar-sign-names': gtsNoDollarSignNames,
   'gts-no-foreach': gtsNoForeach,
   'gts-no-for-in-loop': gtsNoForInLoop,

--- a/libs/eslint-plugin-vx/tests/rules/gts-no-default-exports.test.ts
+++ b/libs/eslint-plugin-vx/tests/rules/gts-no-default-exports.test.ts
@@ -1,0 +1,129 @@
+import { ESLintUtils } from '@typescript-eslint/experimental-utils';
+import { join } from 'path';
+import rule from '../../src/rules/gts-no-default-exports';
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    tsconfigRootDir: join(__dirname, '../fixtures'),
+    project: './tsconfig.json',
+  },
+  parser: '@typescript-eslint/parser',
+});
+
+ruleTester.run('gts-no-default-exports', rule, {
+  valid: [
+    `export const a = 1;`,
+    `export function a() {}`,
+    `export { a };`,
+    `import a from 'a';`,
+    `import a from '../data/a.json';`,
+  ],
+  invalid: [
+    {
+      code: `export default 1;`,
+      errors: [{ messageId: 'noDefaultExports', line: 1 }],
+    },
+    {
+      code: `export { default as a } from './a';`,
+      errors: [{ messageId: 'noDefaultExports', line: 1 }],
+      output: `export { a } from './a';`,
+    },
+    {
+      code: `import a from './a';`,
+      errors: [{ messageId: 'noDefaultImports', line: 1 }],
+      output: `import { a } from './a';`,
+    },
+    {
+      code: `import a, { b } from './a';`,
+      errors: [{ messageId: 'noDefaultImports', line: 1 }],
+      output: `import { a, b } from './a';`,
+    },
+    {
+      code: `const a = 1; export default a;`,
+      errors: [
+        {
+          messageId: 'noDefaultExports',
+          line: 1,
+        },
+      ],
+      output: `export const a = 1; `,
+    },
+    {
+      code: `export default class A {};`,
+      errors: [
+        {
+          messageId: 'noDefaultExports',
+          line: 1,
+        },
+      ],
+      output: `export class A {};`,
+    },
+    {
+      code: `export default function a() {};`,
+      errors: [
+        {
+          messageId: 'noDefaultExports',
+          line: 1,
+        },
+      ],
+      output: `export function a() {};`,
+    },
+    {
+      code: `import a from 'a'; export default a;`,
+      errors: [
+        {
+          messageId: 'noDefaultExports',
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: `export const a = 1; export default a;`,
+      errors: [
+        {
+          messageId: 'noDefaultExports',
+          line: 1,
+        },
+      ],
+      output: `export const a = 1; `,
+    },
+    {
+      code: `function a() {}; export default a;`,
+      errors: [
+        {
+          messageId: 'noDefaultExports',
+          line: 1,
+        },
+      ],
+      output: `export function a() {}; `,
+    },
+    {
+      code: `const a = 1, b = 2; export default a;`,
+      errors: [
+        {
+          messageId: 'noDefaultExports',
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: `export default a;`,
+      errors: [
+        {
+          messageId: 'noDefaultExports',
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: `var a = 1; var a = 2; export default a;`,
+      errors: [
+        {
+          messageId: 'noDefaultExports',
+          line: 1,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
Adds an auto-fixing rule to disallow default exports (and imports). The fixes provided by this rule are not always safe, so really they maybe should be suggestions. However, there's no good way to apply suggestions automatically like there is with `--fix`, so here we are. I'm leaving this rule `off` for now just to get it in place, then we can enable it per-package until everything is enabled.

Refs #1063 