### PR TITLE
style(ballot-encoder): use `gts-no-default-exports`

### DIFF
--- a/libs/ballot-encoder/.eslintrc.json
+++ b/libs/ballot-encoder/.eslintrc.json
@@ -6,6 +6,7 @@
     "plugin:vx/recommended"
   ],
   "rules": {
-    "no-bitwise": "off"
+    "no-bitwise": "off",
+    "vx/gts-no-default-exports": "error"
   }
 }

--- a/libs/ballot-encoder/src/bits/BitCursor.test.ts
+++ b/libs/ballot-encoder/src/bits/BitCursor.test.ts
@@ -1,4 +1,4 @@
-import BitCursor from './BitCursor';
+import { BitCursor } from './BitCursor';
 
 test('starts with bit offset 0', () => {
   expect(new BitCursor().bitOffset).toBe(0);

--- a/libs/ballot-encoder/src/bits/BitCursor.ts
+++ b/libs/ballot-encoder/src/bits/BitCursor.ts
@@ -1,7 +1,7 @@
 import { Uint8Size, Uint8, Uint1, Uint8Index } from './types';
 import { makeMasks } from './utils';
 
-export default class BitCursor {
+export class BitCursor {
   private offset = 0;
 
   next(): this {

--- a/libs/ballot-encoder/src/bits/BitReader.test.ts
+++ b/libs/ballot-encoder/src/bits/BitReader.test.ts
@@ -1,4 +1,4 @@
-import BitReader from './BitReader';
+import { BitReader } from './BitReader';
 
 test('reads bits in little-endian order', () => {
   const reader = new BitReader(Uint8Array.of(0b11010000));

--- a/libs/ballot-encoder/src/bits/BitReader.ts
+++ b/libs/ballot-encoder/src/bits/BitReader.ts
@@ -1,4 +1,4 @@
-import BitCursor from './BitCursor';
+import { BitCursor } from './BitCursor';
 import { Uint1, Uint8, Uint8Size } from './types';
 import { sizeof, makeMasks, toUint8 } from './utils';
 import { UTF8Encoding, Encoding } from './encoding';
@@ -7,7 +7,7 @@ import { UTF8Encoding, Encoding } from './encoding';
  * Reads structured data from a `Uint8Array`. Data is read in little-endian
  * order.
  */
-export default class BitReader {
+export class BitReader {
   private cursor = new BitCursor();
 
   /**

--- a/libs/ballot-encoder/src/bits/BitWriter.test.ts
+++ b/libs/ballot-encoder/src/bits/BitWriter.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import BitWriter from './BitWriter';
+import { BitWriter } from './BitWriter';
 import { CustomEncoding } from './encoding';
 
 test('can write a bit', () => {

--- a/libs/ballot-encoder/src/bits/BitWriter.ts
+++ b/libs/ballot-encoder/src/bits/BitWriter.ts
@@ -1,4 +1,4 @@
-import BitCursor from './BitCursor';
+import { BitCursor } from './BitCursor';
 import { Encoding, UTF8Encoding } from './encoding';
 import { Uint1, Uint8, Uint8Size } from './types';
 import { inGroupsOf, makeMasks, sizeof, toUint8 } from './utils';
@@ -7,7 +7,7 @@ import { inGroupsOf, makeMasks, sizeof, toUint8 } from './utils';
  * Writes structured data into a `Uint8Array`. Data is written in little-endian
  * order.
  */
-export default class BitWriter {
+export class BitWriter {
   private data = new Uint8Array();
   private cursor = new BitCursor();
   private nextByte: Uint8 = 0b00000000;

--- a/libs/ballot-encoder/src/bits/index.ts
+++ b/libs/ballot-encoder/src/bits/index.ts
@@ -1,5 +1,5 @@
-export { default as BitReader } from './BitReader';
-export { default as BitWriter } from './BitWriter';
+export { BitReader } from './BitReader';
+export { BitWriter } from './BitWriter';
 export * from './encoding';
 export * from './types';
 export * from './utils';


### PR DESCRIPTION
Enables the rule for the package and fixes everything automatically. Nothing required manual fixes.

Refs #1063 