### PR TITLE
style(lsd): `gts-no-default-exports`

### DIFF
--- a/libs/lsd/.eslintrc.json
+++ b/libs/lsd/.eslintrc.json
@@ -6,6 +6,7 @@
     "plugin:vx/recommended"
   ],
   "rules": {
-    "no-bitwise": "off"
+    "no-bitwise": "off",
+    "vx/gts-no-default-exports": "error"
   }
 }

--- a/libs/lsd/src/cli/index.test.ts
+++ b/libs/lsd/src/cli/index.test.ts
@@ -36,7 +36,7 @@ jest.mock('../util/images', () => ({
 
 jest.mock('..', () => ({
   __esModule: true,
-  default: jest.fn().mockReturnValue([]),
+  lsd: jest.fn().mockReturnValue([]),
 }));
 
 const lsdMock = lsd as jest.MockedFunction<typeof lsd>;

--- a/libs/lsd/src/cli/index.test.ts
+++ b/libs/lsd/src/cli/index.test.ts
@@ -21,7 +21,7 @@ import { PassThrough } from 'stream';
 import { createHash } from 'crypto';
 import { createImageData } from 'canvas';
 import { main } from '.';
-import lsd from '..';
+import { lsd } from '..';
 import { readGrayscaleImage } from '../util/images';
 
 jest.mock('fs');

--- a/libs/lsd/src/cli/index.ts
+++ b/libs/lsd/src/cli/index.ts
@@ -18,7 +18,7 @@
 import { createCanvas } from 'canvas';
 import chalk from 'chalk';
 import { createWriteStream } from 'fs';
-import lsd, { LineSegment } from '..';
+import { lsd, LineSegment } from '..';
 import { distance, Size } from '../util/geometry';
 import { readGrayscaleImage } from '../util/images';
 import { adjacentFile } from '../util/path';

--- a/libs/lsd/src/index.test.ts
+++ b/libs/lsd/src/index.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import lsd from '.';
+import { lsd } from '.';
 
 /**
  * Create a simple image: left half black, right half gray.

--- a/libs/lsd/src/index.ts
+++ b/libs/lsd/src/index.ts
@@ -31,7 +31,7 @@ export interface LineSegment {
   width: number;
 }
 
-export default function lsd(imageData: ImageData): LineSegment[] {
+export function lsd(imageData: ImageData): LineSegment[] {
   const { data, width, height } = imageData;
   const channels = imageData.data.length / imageData.width / imageData.height;
 


### PR DESCRIPTION
This required a tiny bit of manual work. See commit-by-commit.

Refs #1063 