### PR TITLE
style(plustek-sdk): enable `gts-no-default-exports`

### DIFF
--- a/libs/plustek-sdk/.eslintrc.json
+++ b/libs/plustek-sdk/.eslintrc.json
@@ -2,7 +2,8 @@
   "parserOptions": {
     "project": "./tsconfig.test.json"
   },
-  "extends": [
-    "plugin:vx/recommended"
-  ]
+  "extends": ["plugin:vx/recommended"],
+  "rules": {
+    "vx/gts-no-default-exports": "error"
+  }
 }


### PR DESCRIPTION
There were no violations of this rule.

Refs #1063 