### PR TITLE
style(test-utils): enable `gts-no-default-exports`

### DIFF
--- a/libs/test-utils/.eslintrc.json
+++ b/libs/test-utils/.eslintrc.json
@@ -1,5 +1,6 @@
 {
-  "extends": [
-    "plugin:vx/recommended"
-  ]
+  "extends": ["plugin:vx/recommended"],
+  "rules": {
+    "vx/gts-no-default-exports": "error"
+  }
 }


### PR DESCRIPTION
No automatic or manual fixes were required.