### PR TITLE
style(ps): `gts-no-default-exports`

### DIFF
--- a/apps/precinct-scanner/.eslintrc.json
+++ b/apps/precinct-scanner/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": ["plugin:vx/react"]
+  "extends": ["plugin:vx/react"],
+  "rules": {
+    "vx/gts-no-default-exports": "error"
+  }
 }

--- a/apps/precinct-scanner/src/App.test.tsx
+++ b/apps/precinct-scanner/src/App.test.tsx
@@ -41,7 +41,7 @@ import { electionSampleDefinition } from '@votingworks/fixtures';
 import { DateTime } from 'luxon';
 import { AdjudicationReason, PrecinctSelectionKind } from '@votingworks/types';
 
-import App from './App';
+import { App } from './App';
 import { interpretedHmpb } from '../test/fixtures';
 
 import { stateStorageKey } from './AppRoot';

--- a/apps/precinct-scanner/src/App.tsx
+++ b/apps/precinct-scanner/src/App.tsx
@@ -10,9 +10,9 @@ import {
   getHardware,
   getPrinter,
 } from '@votingworks/utils';
-import AppRoot, { Props as AppRootProps } from './AppRoot';
+import { AppRoot, Props as AppRootProps } from './AppRoot';
 
-import machineConfigProvider from './utils/machineConfig';
+import { machineConfigProvider } from './utils/machineConfig';
 
 export interface Props {
   hardware?: AppRootProps['hardware'];
@@ -22,7 +22,7 @@ export interface Props {
   storage?: AppRootProps['storage'];
 }
 
-function App({
+export function App({
   hardware,
   card = new WebServiceCard(),
   storage = window.kiosk ? new KioskStorage(window.kiosk) : new LocalStorage(),
@@ -61,5 +61,3 @@ function App({
     </BrowserRouter>
   );
 }
-
-export default App;

--- a/apps/precinct-scanner/src/AppRoot.tsx
+++ b/apps/precinct-scanner/src/AppRoot.tsx
@@ -32,8 +32,8 @@ import {
   PrecinctScannerCardTallySchema,
 } from '@votingworks/utils';
 
-import UnconfiguredElectionScreen from './screens/UnconfiguredElectionScreen';
-import LoadingConfigurationScreen from './screens/LoadingConfigurationScreen';
+import { UnconfiguredElectionScreen } from './screens/UnconfiguredElectionScreen';
+import { LoadingConfigurationScreen } from './screens/LoadingConfigurationScreen';
 import {
   BallotState,
   ScanningResultType,
@@ -50,19 +50,19 @@ import {
 import * as config from './api/config';
 import * as scan from './api/scan';
 
-import usePrecinctScanner from './hooks/usePrecinctScanner';
-import AdminScreen from './screens/AdminScreen';
-import InvalidCardScreen from './screens/InvalidCardScreen';
-import PollsClosedScreen from './screens/PollsClosedScreen';
-import PollWorkerScreen from './screens/PollWorkerScreen';
-import InsertBallotScreen from './screens/InsertBallotScreen';
-import ScanErrorScreen from './screens/ScanErrorScreen';
-import ScanSuccessScreen from './screens/ScanSuccessScreen';
-import ScanWarningScreen from './screens/ScanWarningScreen';
-import ScanProcessingScreen from './screens/ScanProcessingScreen';
-import AppContext from './contexts/AppContext';
-import SetupPowerPage from './screens/SetupPowerPage';
-import UnlockAdminScreen from './screens/UnlockAdminScreen';
+import { usePrecinctScanner } from './hooks/usePrecinctScanner';
+import { AdminScreen } from './screens/AdminScreen';
+import { InvalidCardScreen } from './screens/InvalidCardScreen';
+import { PollsClosedScreen } from './screens/PollsClosedScreen';
+import { PollWorkerScreen } from './screens/PollWorkerScreen';
+import { InsertBallotScreen } from './screens/InsertBallotScreen';
+import { ScanErrorScreen } from './screens/ScanErrorScreen';
+import { ScanSuccessScreen } from './screens/ScanSuccessScreen';
+import { ScanWarningScreen } from './screens/ScanWarningScreen';
+import { ScanProcessingScreen } from './screens/ScanProcessingScreen';
+import { AppContext } from './contexts/AppContext';
+import { SetupPowerPage } from './screens/SetupPowerPage';
+import { UnlockAdminScreen } from './screens/UnlockAdminScreen';
 
 const debug = makeDebug('precinct-scanner:app-root');
 
@@ -313,7 +313,7 @@ function appReducer(state: State, action: AppAction): State {
   }
 }
 
-function AppRoot({
+export function AppRoot({
   hardware,
   card,
   printer,
@@ -903,5 +903,3 @@ function AppRoot({
     </AppContext.Provider>
   );
 }
-
-export default AppRoot;

--- a/apps/precinct-scanner/src/AppTallyReportPaths.test.tsx
+++ b/apps/precinct-scanner/src/AppTallyReportPaths.test.tsx
@@ -35,7 +35,7 @@ import {
   PrecinctSelectionKind,
   VotingMethod,
 } from '@votingworks/types';
-import App from './App';
+import { App } from './App';
 import { stateStorageKey } from './AppRoot';
 
 beforeEach(() => {

--- a/apps/precinct-scanner/src/AppUnhappyPaths.test.tsx
+++ b/apps/precinct-scanner/src/AppUnhappyPaths.test.tsx
@@ -29,7 +29,7 @@ import {
   typedAs,
 } from '@votingworks/utils';
 import { interpretedHmpb } from '../test/fixtures';
-import App from './App';
+import { App } from './App';
 import { stateStorageKey } from './AppRoot';
 
 const getMachineConfigBody = {

--- a/apps/precinct-scanner/src/PreviewApp.tsx
+++ b/apps/precinct-scanner/src/PreviewApp.tsx
@@ -8,7 +8,7 @@ import {
   primaryElectionSampleDefinition,
 } from '@votingworks/fixtures';
 import React from 'react';
-import PreviewDashboard from './PreviewDashboard';
+import { PreviewDashboard } from './PreviewDashboard';
 import * as AdminScreen from './screens/AdminScreen';
 import * as InsertBallotScreen from './screens/InsertBallotScreen';
 import * as InvalidCardScreen from './screens/InvalidCardScreen';
@@ -23,7 +23,7 @@ import * as SetupPowerPage from './screens/SetupPowerPage';
 import * as UnconfiguredElectionScreen from './screens/UnconfiguredElectionScreen';
 import * as UnlockAdminScreen from './screens/UnlockAdminScreen';
 
-function PreviewApp(): JSX.Element {
+export function PreviewApp(): JSX.Element {
   return (
     <PreviewDashboard
       electionDefinitions={[
@@ -49,5 +49,3 @@ function PreviewApp(): JSX.Element {
     />
   );
 }
-
-export default PreviewApp;

--- a/apps/precinct-scanner/src/PreviewDashboard.tsx
+++ b/apps/precinct-scanner/src/PreviewDashboard.tsx
@@ -8,7 +8,7 @@ import { Select } from '@votingworks/ui';
 import React, { useCallback, useRef, useState } from 'react';
 import { BrowserRouter, Link, Route } from 'react-router-dom';
 import styled from 'styled-components';
-import AppContext from './contexts/AppContext';
+import { AppContext } from './contexts/AppContext';
 
 export interface PreviewableModule {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -69,7 +69,7 @@ const ConfigBox = styled.div`
   width: auto;
 `;
 
-function PreviewDashboard({
+export function PreviewDashboard({
   modules,
   electionDefinitions: initialElectionDefinitions,
 }: Props): JSX.Element {
@@ -186,5 +186,3 @@ function PreviewDashboard({
     </AppContext.Provider>
   );
 }
-
-export default PreviewDashboard;

--- a/apps/precinct-scanner/src/components/CalibrateScannerModal.test.tsx
+++ b/apps/precinct-scanner/src/components/CalibrateScannerModal.test.tsx
@@ -3,8 +3,8 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { mocked } from 'ts-jest/utils';
 import { ScannerStatus } from '@votingworks/types/api/module-scan';
 import { deferred } from '@votingworks/utils';
-import CalibrateScannerModal from './CalibrateScannerModal';
-import usePrecinctScanner from '../hooks/usePrecinctScanner';
+import { CalibrateScannerModal } from './CalibrateScannerModal';
+import { usePrecinctScanner } from '../hooks/usePrecinctScanner';
 
 jest.mock('../hooks/usePrecinctScanner');
 

--- a/apps/precinct-scanner/src/components/CalibrateScannerModal.tsx
+++ b/apps/precinct-scanner/src/components/CalibrateScannerModal.tsx
@@ -1,8 +1,8 @@
 import { ScannerStatus } from '@votingworks/types/api/module-scan';
 import { Button, Prose, useCancelablePromise } from '@votingworks/ui';
 import React, { useCallback, useState } from 'react';
-import usePrecinctScanner from '../hooks/usePrecinctScanner';
-import Modal from './Modal';
+import { usePrecinctScanner } from '../hooks/usePrecinctScanner';
+import { Modal } from './Modal';
 
 export interface Props {
   onCalibrate(): Promise<boolean>;
@@ -13,7 +13,10 @@ function noop() {
   // noop
 }
 
-function CalibrateScannerModal({ onCancel, onCalibrate }: Props): JSX.Element {
+export function CalibrateScannerModal({
+  onCancel,
+  onCalibrate,
+}: Props): JSX.Element {
   const makeCancelable = useCancelablePromise();
   const [calibrationSuccess, setCalibrationSuccess] = useState<boolean>();
   const [isCalibrating, setIsCalibrating] = useState(false);
@@ -117,5 +120,3 @@ function CalibrateScannerModal({ onCancel, onCalibrate }: Props): JSX.Element {
     />
   );
 }
-
-export default CalibrateScannerModal;

--- a/apps/precinct-scanner/src/components/ElectionInfoBar.test.tsx
+++ b/apps/precinct-scanner/src/components/ElectionInfoBar.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { electionSampleDefinition } from '@votingworks/fixtures';
-import ElectionInfoBar from './ElectionInfoBar';
-import AppContext from '../contexts/AppContext';
+import { ElectionInfoBar } from './ElectionInfoBar';
+import { AppContext } from '../contexts/AppContext';
 
 test('Renders ElectionInfoBar', async () => {
   const { container } = render(

--- a/apps/precinct-scanner/src/components/ElectionInfoBar.tsx
+++ b/apps/precinct-scanner/src/components/ElectionInfoBar.tsx
@@ -4,14 +4,14 @@ import { Prose, Text, contrastTheme, NoWrap } from '@votingworks/ui';
 import { getPrecinctById } from '@votingworks/types';
 import { format } from '@votingworks/utils';
 import { Bar, BarSpacer } from './Bar';
-import AppContext from '../contexts/AppContext';
+import { AppContext } from '../contexts/AppContext';
 
 export type InfoBarMode = 'voter' | 'pollworker' | 'admin';
 
 interface Props {
   mode?: InfoBarMode;
 }
-function ElectionInfoBar({ mode = 'voter' }: Props): JSX.Element {
+export function ElectionInfoBar({ mode = 'voter' }: Props): JSX.Element {
   const { electionDefinition, currentPrecinctId, machineConfig } = useContext(
     AppContext
   );
@@ -67,5 +67,3 @@ function ElectionInfoBar({ mode = 'voter' }: Props): JSX.Element {
     </Bar>
   );
 }
-
-export default ElectionInfoBar;

--- a/apps/precinct-scanner/src/components/ExportBackupModal.test.tsx
+++ b/apps/precinct-scanner/src/components/ExportBackupModal.test.tsx
@@ -5,9 +5,9 @@ import { err, ok } from '@votingworks/types';
 import { usbstick } from '@votingworks/utils';
 import React from 'react';
 import { mocked } from 'ts-jest/utils';
-import AppContext from '../contexts/AppContext';
+import { AppContext } from '../contexts/AppContext';
 import { download, DownloadErrorKind } from '../utils/download';
-import ExportBackupModal from './ExportBackupModal';
+import { ExportBackupModal } from './ExportBackupModal';
 
 jest.mock('../utils/download');
 

--- a/apps/precinct-scanner/src/components/ExportBackupModal.tsx
+++ b/apps/precinct-scanner/src/components/ExportBackupModal.tsx
@@ -16,9 +16,9 @@ import { strict as assert } from 'assert';
 import path from 'path';
 import React, { useCallback, useContext, useState } from 'react';
 import styled from 'styled-components';
-import AppContext from '../contexts/AppContext';
+import { AppContext } from '../contexts/AppContext';
 import { download, DownloadError, DownloadErrorKind } from '../utils/download';
-import Modal from './Modal';
+import { Modal } from './Modal';
 
 const USBImage = styled.img`
   margin-right: auto;
@@ -38,7 +38,7 @@ enum ModalState {
   INIT = 'init',
 }
 
-function ExportBackupModal({ onClose, usbDrive }: Props): JSX.Element {
+export function ExportBackupModal({ onClose, usbDrive }: Props): JSX.Element {
   const [currentState, setCurrentState] = useState(ModalState.INIT);
   const [errorMessage, setErrorMessage] = useState('');
 
@@ -251,5 +251,3 @@ function ExportBackupModal({ onClose, usbDrive }: Props): JSX.Element {
       throwIllegalValue(usbDrive.status);
   }
 }
-
-export default ExportBackupModal;

--- a/apps/precinct-scanner/src/components/ExportResultsModal.test.tsx
+++ b/apps/precinct-scanner/src/components/ExportResultsModal.test.tsx
@@ -9,9 +9,9 @@ import { usbstick } from '@votingworks/utils';
 import fetchMock from 'fetch-mock';
 
 import { fakeKiosk, fakeUsbDrive } from '@votingworks/test-utils';
-import ExportResultsModal from './ExportResultsModal';
-import fakeFileWriter from '../../test/helpers/fakeFileWriter';
-import AppContext from '../contexts/AppContext';
+import { ExportResultsModal } from './ExportResultsModal';
+import { fakeFileWriter } from '../../test/helpers/fakeFileWriter';
+import { AppContext } from '../contexts/AppContext';
 
 const { UsbDriveStatus } = usbstick;
 

--- a/apps/precinct-scanner/src/components/ExportResultsModal.tsx
+++ b/apps/precinct-scanner/src/components/ExportResultsModal.tsx
@@ -18,8 +18,8 @@ import {
   usbstick,
 } from '@votingworks/utils';
 import { strict as assert } from 'assert';
-import AppContext from '../contexts/AppContext';
-import Modal from './Modal';
+import { AppContext } from '../contexts/AppContext';
+import { Modal } from './Modal';
 
 const USBImage = styled.img`
   margin-right: auto;
@@ -41,7 +41,7 @@ enum ModalState {
   INIT = 'init',
 }
 
-function ExportResultsModal({
+export function ExportResultsModal({
   onClose,
   usbDrive,
   scannedBallotCount,
@@ -286,5 +286,3 @@ function ExportResultsModal({
       throwIllegalValue(usbDrive.status);
   }
 }
-
-export default ExportResultsModal;

--- a/apps/precinct-scanner/src/components/Layout.tsx
+++ b/apps/precinct-scanner/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Screen, Main, MainChild, Prose, fontSizeTheme } from '@votingworks/ui';
-import ElectionInfoBar, { InfoBarMode } from './ElectionInfoBar';
+import { ElectionInfoBar, InfoBarMode } from './ElectionInfoBar';
 
 interface CenteredScreenProps {
   children: React.ReactNode;

--- a/apps/precinct-scanner/src/components/Modal.tsx
+++ b/apps/precinct-scanner/src/components/Modal.tsx
@@ -33,7 +33,7 @@ interface Props {
   onOverlayClick?: () => void;
 }
 
-function Modal({
+export function Modal({
   actions,
   ariaLabel = 'Alert Modal',
   centerContent,
@@ -76,5 +76,3 @@ function Modal({
     </ReactModal>
   );
 }
-
-export default Modal;

--- a/apps/precinct-scanner/src/components/PickDateTimeModal.tsx
+++ b/apps/precinct-scanner/src/components/PickDateTimeModal.tsx
@@ -9,7 +9,7 @@ import {
   getDaysInMonth,
   MONTHS_SHORT,
 } from '@votingworks/utils';
-import Modal from './Modal';
+import { Modal } from './Modal';
 
 export interface Props {
   disabled?: boolean;
@@ -19,7 +19,7 @@ export interface Props {
   value: DateTime;
 }
 
-function PickDateTimeModal({
+export function PickDateTimeModal({
   disabled = false,
   onCancel,
   onSave,
@@ -258,5 +258,3 @@ function PickDateTimeModal({
     />
   );
 }
-
-export default PickDateTimeModal;

--- a/apps/precinct-scanner/src/config/globals.ts
+++ b/apps/precinct-scanner/src/config/globals.ts
@@ -1,6 +1,6 @@
 export const PRECINCT_SCANNER_FOLDER = 'ballot-packages';
 
-export const FONT_SIZES = [22, 28, 36, 60];
+export const FONT_SIZES = [18, 24, 28, 32];
 export const DEFAULT_FONT_SIZE = 1;
 export const LARGE_DISPLAY_FONT_SIZE = 3;
 export const DEFAULT_LOCALE = 'en-US';
@@ -15,12 +15,9 @@ export const STATUS_POLLING_EXTRA_CHECKS = 2;
 export const HARDWARE_POLLING_INTERVAL = 3000;
 export const LOW_BATTERY_THRESHOLD = 0.25;
 
-export default {
-  CHECK_ICON: '✓',
-  FONT_SIZES: [18, 24, 28, 32],
-  TEXT_SIZE: 1,
-  YES_NO_VOTES: {
-    no: 'No',
-    yes: 'Yes',
-  },
+export const CHECK_ICON = '✓';
+export const TEXT_SIZE = 1;
+export const YES_NO_VOTES = {
+  no: 'No',
+  yes: 'Yes',
 };

--- a/apps/precinct-scanner/src/contexts/AppContext.ts
+++ b/apps/precinct-scanner/src/contexts/AppContext.ts
@@ -18,6 +18,4 @@ const appContext: AppContextInterface = {
   },
 };
 
-const AppContext = createContext(appContext);
-
-export default AppContext;
+export const AppContext = createContext(appContext);

--- a/apps/precinct-scanner/src/hooks/usePrecinctScanner.test.tsx
+++ b/apps/precinct-scanner/src/hooks/usePrecinctScanner.test.tsx
@@ -7,7 +7,7 @@ import { sleep } from '@votingworks/utils';
 import React from 'react';
 import fetchMock, { MockResponseFunction } from 'fetch-mock';
 import { advanceTimersAndPromises } from '@votingworks/test-utils';
-import usePrecinctScanner from './usePrecinctScanner';
+import { usePrecinctScanner } from './usePrecinctScanner';
 
 const scanStatusWaitingForPaperResponse: GetScanStatusResponse = {
   adjudication: { adjudicated: 0, remaining: 0 },

--- a/apps/precinct-scanner/src/hooks/usePrecinctScanner.ts
+++ b/apps/precinct-scanner/src/hooks/usePrecinctScanner.ts
@@ -8,7 +8,7 @@ export interface PrecinctScanner {
   status: ScannerStatusDetails;
 }
 
-export default function usePrecinctScanner(
+export function usePrecinctScanner(
   interval: number | false = POLLING_INTERVAL_FOR_SCANNER_STATUS_MS
 ): PrecinctScanner | undefined {
   const [lastStatusString, setLastStatusString] = useState<string>();

--- a/apps/precinct-scanner/src/index.tsx
+++ b/apps/precinct-scanner/src/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import App from './App';
-import PreviewApp from './PreviewApp';
+import { App } from './App';
+import { PreviewApp } from './PreviewApp';
 import * as serviceWorker from './serviceWorker';
 
 ReactDOM.render(

--- a/apps/precinct-scanner/src/screens/AdminScreen.test.tsx
+++ b/apps/precinct-scanner/src/screens/AdminScreen.test.tsx
@@ -4,8 +4,8 @@ import { fakeKiosk } from '@votingworks/test-utils';
 import { usbstick } from '@votingworks/utils';
 import MockDate from 'mockdate';
 import React from 'react';
-import AppContext from '../contexts/AppContext';
-import AdminScreen from './AdminScreen';
+import { AppContext } from '../contexts/AppContext';
+import { AdminScreen } from './AdminScreen';
 
 beforeEach(() => {
   MockDate.set('2020-10-31T00:00:00.000Z');

--- a/apps/precinct-scanner/src/screens/AdminScreen.tsx
+++ b/apps/precinct-scanner/src/screens/AdminScreen.tsx
@@ -18,13 +18,13 @@ import { DateTime } from 'luxon';
 import React, { useCallback, useContext, useState } from 'react';
 import { Absolute } from '../components/Absolute';
 import { Bar } from '../components/Bar';
-import CalibrateScannerModal from '../components/CalibrateScannerModal';
-import ExportBackupModal from '../components/ExportBackupModal';
-import ExportResultsModal from '../components/ExportResultsModal';
+import { CalibrateScannerModal } from '../components/CalibrateScannerModal';
+import { ExportBackupModal } from '../components/ExportBackupModal';
+import { ExportResultsModal } from '../components/ExportResultsModal';
 import { CenteredScreen } from '../components/Layout';
-import Modal from '../components/Modal';
-import PickDateTimeModal from '../components/PickDateTimeModal';
-import AppContext from '../contexts/AppContext';
+import { Modal } from '../components/Modal';
+import { PickDateTimeModal } from '../components/PickDateTimeModal';
+import { AppContext } from '../contexts/AppContext';
 
 interface Props {
   scannedBallotCount: number;
@@ -36,7 +36,7 @@ interface Props {
   usbDrive: UsbDrive;
 }
 
-function AdminScreen({
+export function AdminScreen({
   scannedBallotCount,
   isTestMode,
   updateAppPrecinctId,
@@ -247,8 +247,6 @@ function AdminScreen({
     </CenteredScreen>
   );
 }
-
-export default AdminScreen;
 
 /* istanbul ignore next */
 export const DefaultPreview: React.FC =

--- a/apps/precinct-scanner/src/screens/AdminScreen.tsx
+++ b/apps/precinct-scanner/src/screens/AdminScreen.tsx
@@ -249,35 +249,32 @@ export function AdminScreen({
 }
 
 /* istanbul ignore next */
-export const DefaultPreview: React.FC =
-  process.env.NODE_ENV === 'development'
-    ? () => {
-        const { machineConfig, electionDefinition } = useContext(AppContext);
-        const [isTestMode, setIsTestMode] = useState(false);
-        const [precinctId, setPrecinctId] = useState<Precinct['id']>();
-        return (
-          <AppContext.Provider
-            value={{
-              machineConfig,
-              electionDefinition,
-              currentPrecinctId: precinctId,
-            }}
-          >
-            <AdminScreen
-              calibrate={() => Promise.resolve(true)}
-              isTestMode={isTestMode}
-              toggleLiveMode={async () => setIsTestMode((prev) => !prev)}
-              scannedBallotCount={1234}
-              unconfigure={() => Promise.resolve()}
-              updateAppPrecinctId={async (newPrecinctId) =>
-                setPrecinctId(newPrecinctId)
-              }
-              usbDrive={{
-                status: usbstick.UsbDriveStatus.notavailable,
-                eject: () => Promise.resolve(),
-              }}
-            />
-          </AppContext.Provider>
-        );
-      }
-    : () => null;
+export function DefaultPreview(): JSX.Element {
+  const { machineConfig, electionDefinition } = useContext(AppContext);
+  const [isTestMode, setIsTestMode] = useState(false);
+  const [precinctId, setPrecinctId] = useState<Precinct['id']>();
+  return (
+    <AppContext.Provider
+      value={{
+        machineConfig,
+        electionDefinition,
+        currentPrecinctId: precinctId,
+      }}
+    >
+      <AdminScreen
+        calibrate={() => Promise.resolve(true)}
+        isTestMode={isTestMode}
+        toggleLiveMode={async () => setIsTestMode((prev) => !prev)}
+        scannedBallotCount={1234}
+        unconfigure={() => Promise.resolve()}
+        updateAppPrecinctId={async (newPrecinctId) =>
+          setPrecinctId(newPrecinctId)
+        }
+        usbDrive={{
+          status: usbstick.UsbDriveStatus.notavailable,
+          eject: () => Promise.resolve(),
+        }}
+      />
+    </AppContext.Provider>
+  );
+}

--- a/apps/precinct-scanner/src/screens/InsertBallotScreen.tsx
+++ b/apps/precinct-scanner/src/screens/InsertBallotScreen.tsx
@@ -12,7 +12,7 @@ interface Props {
   showNoChargerWarning: boolean;
 }
 
-function InsertBallotScreen({
+export function InsertBallotScreen({
   isLiveMode,
   scannedBallotCount,
   showNoChargerWarning,
@@ -44,7 +44,6 @@ function InsertBallotScreen({
     </CenteredScreen>
   );
 }
-export default InsertBallotScreen;
 
 /* istanbul ignore next */
 export function ZeroBallotsScannedTestPreview(): JSX.Element {

--- a/apps/precinct-scanner/src/screens/InvalidCardScreen.tsx
+++ b/apps/precinct-scanner/src/screens/InvalidCardScreen.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { CenteredLargeProse, CenteredScreen } from '../components/Layout';
 import { TimesCircle } from '../components/Graphics';
 
-function InvalidCardScreen(): JSX.Element {
+export function InvalidCardScreen(): JSX.Element {
   return (
     <CenteredScreen infoBar={false}>
       <TimesCircle />
@@ -13,8 +13,6 @@ function InvalidCardScreen(): JSX.Element {
     </CenteredScreen>
   );
 }
-
-export default InvalidCardScreen;
 
 /* istanbul ignore next */
 export function DefaultPreview(): JSX.Element {

--- a/apps/precinct-scanner/src/screens/LoadingConfigurationScreen.tsx
+++ b/apps/precinct-scanner/src/screens/LoadingConfigurationScreen.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { CenteredLargeProse, CenteredScreen } from '../components/Layout';
 import { IndeterminateProgressBar } from '../components/Graphics';
 
-function LoadingConfigurationScreen(): JSX.Element {
+export function LoadingConfigurationScreen(): JSX.Element {
   return (
     <CenteredScreen infoBar={false}>
       <IndeterminateProgressBar />
@@ -12,8 +12,6 @@ function LoadingConfigurationScreen(): JSX.Element {
     </CenteredScreen>
   );
 }
-
-export default LoadingConfigurationScreen;
 
 /* istanbul ignore next */
 export function DefaultPreview(): JSX.Element {

--- a/apps/precinct-scanner/src/screens/PollWorkerScreen.test.tsx
+++ b/apps/precinct-scanner/src/screens/PollWorkerScreen.test.tsx
@@ -4,8 +4,8 @@ import { fakeKiosk, mockOf } from '@votingworks/test-utils';
 import { NullPrinter, usbstick } from '@votingworks/utils';
 import MockDate from 'mockdate';
 import React from 'react';
-import AppContext from '../contexts/AppContext';
-import PollWorkerScreen from './PollWorkerScreen';
+import { AppContext } from '../contexts/AppContext';
+import { PollWorkerScreen } from './PollWorkerScreen';
 
 MockDate.set('2020-10-31T00:00:00.000Z');
 

--- a/apps/precinct-scanner/src/screens/PollWorkerScreen.tsx
+++ b/apps/precinct-scanner/src/screens/PollWorkerScreen.tsx
@@ -42,10 +42,10 @@ import { POLLING_INTERVAL_FOR_TOTP } from '../config/globals';
 import { CenteredScreen } from '../components/Layout';
 import { Absolute } from '../components/Absolute';
 import { Bar } from '../components/Bar';
-import ExportResultsModal from '../components/ExportResultsModal';
-import Modal from '../components/Modal';
+import { ExportResultsModal } from '../components/ExportResultsModal';
+import { Modal } from '../components/Modal';
 
-import AppContext from '../contexts/AppContext';
+import { AppContext } from '../contexts/AppContext';
 
 const debug = makeDebug('precinct-scanner:pollworker-screen');
 const reportPurposes = ['Publicly Posted', 'Officially Filed'];
@@ -62,7 +62,7 @@ interface Props {
   usbDrive: UsbDrive;
 }
 
-function PollWorkerScreen({
+export function PollWorkerScreen({
   scannedBallotCount,
   isPollsOpen,
   togglePollsOpen,
@@ -491,5 +491,3 @@ function PollWorkerScreen({
     </React.Fragment>
   );
 }
-
-export default PollWorkerScreen;

--- a/apps/precinct-scanner/src/screens/PollsClosedScreen.tsx
+++ b/apps/precinct-scanner/src/screens/PollsClosedScreen.tsx
@@ -8,7 +8,7 @@ interface Props {
   showNoChargerWarning: boolean;
 }
 
-function PollsClosedScreen({
+export function PollsClosedScreen({
   isLiveMode,
   showNoChargerWarning,
 }: Props): JSX.Element {
@@ -29,8 +29,6 @@ function PollsClosedScreen({
     </CenteredScreen>
   );
 }
-
-export default PollsClosedScreen;
 
 /* istanbul ignore next */
 export function DefaultPreview(): JSX.Element {

--- a/apps/precinct-scanner/src/screens/ScanErrorScreen.test.tsx
+++ b/apps/precinct-scanner/src/screens/ScanErrorScreen.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import ScanErrorScreen from './ScanErrorScreen';
+import { ScanErrorScreen } from './ScanErrorScreen';
 import { RejectedScanningReason } from '../config/types';
 
 test('render correct test ballot error screen when we are in test mode', async () => {

--- a/apps/precinct-scanner/src/screens/ScanErrorScreen.tsx
+++ b/apps/precinct-scanner/src/screens/ScanErrorScreen.tsx
@@ -12,7 +12,7 @@ interface Props {
   isTestMode: boolean;
 }
 
-function ScanErrorScreen({
+export function ScanErrorScreen({
   dismissError,
   rejectionReason,
   isTestMode,
@@ -61,8 +61,6 @@ function ScanErrorScreen({
     </CenteredScreen>
   );
 }
-
-export default ScanErrorScreen;
 
 /* istanbul ignore next */
 export function UnreadablePreview(): JSX.Element {

--- a/apps/precinct-scanner/src/screens/ScanProcessingScreen.tsx
+++ b/apps/precinct-scanner/src/screens/ScanProcessingScreen.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { IndeterminateProgressBar } from '../components/Graphics';
 import { CenteredLargeProse, CenteredScreen } from '../components/Layout';
 
-function ScanProcessingScreen(): JSX.Element {
+export function ScanProcessingScreen(): JSX.Element {
   return (
     <CenteredScreen>
       <IndeterminateProgressBar />
@@ -12,8 +12,6 @@ function ScanProcessingScreen(): JSX.Element {
     </CenteredScreen>
   );
 }
-
-export default ScanProcessingScreen;
 
 /* istanbul ignore next */
 export function DefaultPreview(): JSX.Element {

--- a/apps/precinct-scanner/src/screens/ScanSuccessScreen.tsx
+++ b/apps/precinct-scanner/src/screens/ScanSuccessScreen.tsx
@@ -10,7 +10,7 @@ interface Props {
   scannedBallotCount: number;
 }
 
-function ScanSuccessScreen({ scannedBallotCount }: Props): JSX.Element {
+export function ScanSuccessScreen({ scannedBallotCount }: Props): JSX.Element {
   return (
     <CenteredScreen>
       <CircleCheck />
@@ -33,8 +33,6 @@ function ScanSuccessScreen({ scannedBallotCount }: Props): JSX.Element {
     </CenteredScreen>
   );
 }
-
-export default ScanSuccessScreen;
 
 /* istanbul ignore next */
 export function DefaultPreview(): JSX.Element {

--- a/apps/precinct-scanner/src/screens/ScanWarningScreen.test.tsx
+++ b/apps/precinct-scanner/src/screens/ScanWarningScreen.test.tsx
@@ -4,8 +4,8 @@ import { electionSampleDefinition } from '@votingworks/fixtures';
 import { AdjudicationReason, CandidateContest } from '@votingworks/types';
 import { integers, take } from '@votingworks/utils';
 import React from 'react';
-import AppContext from '../contexts/AppContext';
-import ScanWarningScreen from './ScanWarningScreen';
+import { AppContext } from '../contexts/AppContext';
+import { ScanWarningScreen } from './ScanWarningScreen';
 
 test('overvote', async () => {
   const acceptBallot = jest.fn();

--- a/apps/precinct-scanner/src/screens/ScanWarningScreen.tsx
+++ b/apps/precinct-scanner/src/screens/ScanWarningScreen.tsx
@@ -15,9 +15,9 @@ import { Absolute } from '../components/Absolute';
 import { Bar } from '../components/Bar';
 import { ExclamationTriangle } from '../components/Graphics';
 import { CenteredLargeProse, CenteredScreen } from '../components/Layout';
-import Modal from '../components/Modal';
+import { Modal } from '../components/Modal';
 
-import AppContext from '../contexts/AppContext';
+import { AppContext } from '../contexts/AppContext';
 import { toSentence } from '../utils/toSentence';
 
 export interface Props {
@@ -328,7 +328,7 @@ function OtherReasonWarningScreen({
   );
 }
 
-function ScanWarningScreen({
+export function ScanWarningScreen({
   acceptBallot,
   adjudicationReasonInfo,
 }: Props): JSX.Element {
@@ -375,8 +375,6 @@ function ScanWarningScreen({
 
   return <OtherReasonWarningScreen acceptBallot={acceptBallot} />;
 }
-
-export default ScanWarningScreen;
 
 /* istanbul ignore next */
 export function OvervotePreview(): JSX.Element {

--- a/apps/precinct-scanner/src/screens/SetupPowerPage.tsx
+++ b/apps/precinct-scanner/src/screens/SetupPowerPage.tsx
@@ -4,7 +4,7 @@ import { Main, MainChild, Prose, NoWrap } from '@votingworks/ui';
 
 import { CenteredScreen } from '../components/Layout';
 
-function SetupPowerPage(): JSX.Element {
+export function SetupPowerPage(): JSX.Element {
   return (
     <CenteredScreen>
       <Main padded>
@@ -23,8 +23,6 @@ function SetupPowerPage(): JSX.Element {
     </CenteredScreen>
   );
 }
-
-export default SetupPowerPage;
 
 /* istanbul ignore next */
 export function DefaultPreview(): JSX.Element {

--- a/apps/precinct-scanner/src/screens/UnconfiguredElectionScreen.tsx
+++ b/apps/precinct-scanner/src/screens/UnconfiguredElectionScreen.tsx
@@ -21,7 +21,7 @@ interface Props {
   ) => Promise<void>;
 }
 
-function UnconfiguredElectionScreen({
+export function UnconfiguredElectionScreen({
   usbDriveStatus,
   setElectionDefinition,
 }: Props): JSX.Element {
@@ -195,8 +195,6 @@ function UnconfiguredElectionScreen({
 
   return <CenteredScreen infoBar={false}>{content}</CenteredScreen>;
 }
-
-export default UnconfiguredElectionScreen;
 
 /* istanbul ignore next */
 export function DefaultPreview(): JSX.Element {

--- a/apps/precinct-scanner/src/screens/UnlockAdminScreen.test.tsx
+++ b/apps/precinct-scanner/src/screens/UnlockAdminScreen.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import UnlockAdminScreen from './UnlockAdminScreen';
+import { UnlockAdminScreen } from './UnlockAdminScreen';
 
 test('authentication', async () => {
   const attemptToAuthenticateUser = jest.fn();

--- a/apps/precinct-scanner/src/screens/UnlockAdminScreen.tsx
+++ b/apps/precinct-scanner/src/screens/UnlockAdminScreen.tsx
@@ -33,7 +33,9 @@ interface Props {
   attemptToAuthenticateUser: (passcode: string) => boolean;
 }
 
-function UnlockAdminScreen({ attemptToAuthenticateUser }: Props): JSX.Element {
+export function UnlockAdminScreen({
+  attemptToAuthenticateUser,
+}: Props): JSX.Element {
   const [currentPasscode, setCurrentPasscode] = useState('');
   const [showError, setShowError] = useState(false);
   const handleNumberEntry = useCallback((digit: number) => {
@@ -88,8 +90,6 @@ function UnlockAdminScreen({ attemptToAuthenticateUser }: Props): JSX.Element {
     </CenteredScreen>
   );
 }
-
-export default UnlockAdminScreen;
 
 /* istanbul ignore next */
 export function DefaultPreview(): JSX.Element {

--- a/apps/precinct-scanner/src/utils/download.test.ts
+++ b/apps/precinct-scanner/src/utils/download.test.ts
@@ -1,6 +1,6 @@
 import { fakeKiosk } from '@votingworks/test-utils';
 import fetchMock from 'fetch-mock';
-import fakeFileWriter from '../../test/helpers/fakeFileWriter';
+import { fakeFileWriter } from '../../test/helpers/fakeFileWriter';
 import {
   download,
   DownloadErrorKind,

--- a/apps/precinct-scanner/src/utils/machineConfig.test.ts
+++ b/apps/precinct-scanner/src/utils/machineConfig.test.ts
@@ -1,7 +1,7 @@
 import { typedAs } from '@votingworks/utils';
 import fetchMock from 'fetch-mock';
 import { MachineConfig, MachineConfigResponse } from '../config/types';
-import machineConfigProvider from './machineConfig';
+import { machineConfigProvider } from './machineConfig';
 
 test('successful fetch from /machine-config', async () => {
   fetchMock.get(

--- a/apps/precinct-scanner/src/utils/machineConfig.ts
+++ b/apps/precinct-scanner/src/utils/machineConfig.ts
@@ -2,7 +2,7 @@ import { Provider, safeParse } from '@votingworks/types';
 import { fetchJSON } from '@votingworks/utils';
 import { MachineConfig, MachineConfigResponseSchema } from '../config/types';
 
-const machineConfigProvider: Provider<MachineConfig> = {
+export const machineConfigProvider: Provider<MachineConfig> = {
   async get() {
     const { machineId, codeVersion, bypassAuthentication } = safeParse(
       MachineConfigResponseSchema,
@@ -16,5 +16,3 @@ const machineConfigProvider: Provider<MachineConfig> = {
     };
   },
 };
-
-export default machineConfigProvider;

--- a/apps/precinct-scanner/test/helpers/fakeFileWriter.ts
+++ b/apps/precinct-scanner/test/helpers/fakeFileWriter.ts
@@ -1,6 +1,6 @@
 export type Chunk = Parameters<KioskBrowser.FileWriter['write']>[0];
 
-export default function fakeFileWriter(): jest.Mocked<
+export function fakeFileWriter(): jest.Mocked<
   KioskBrowser.FileWriter & { chunks: readonly Chunk[] }
 > {
   const chunks: Chunk[] = [];


### PR DESCRIPTION
Enabled, autofixed, and some manual cleanup. More significant manual fixes in the preview stuff because of how it assumed the component would be the default export of the module.

Refs #1063 