### PR TITLE
style(all): multiline control flow must use blocks

### DIFF
--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -110,6 +110,7 @@ export = {
       },
     ],
     'no-void': 'off', // allow silencing `no-floating-promises` with `void`
+    'nonblock-statement-body-position': ['error', 'beside'],
 
     // replace some built-in rules that don't play well with TypeScript
     '@typescript-eslint/no-shadow': 'error',

--- a/libs/eslint-plugin-vx/src/rules/gts-array-type-style.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts-array-type-style.ts
@@ -61,7 +61,7 @@ export default createRule({
         }
       },
       TSArrayType: (node: TSESTree.TSArrayType) => {
-        if (!isSimpleType(node.elementType))
+        if (!isSimpleType(node.elementType)) {
           context.report({
             messageId: 'useLongArrayType',
             node,
@@ -71,17 +71,19 @@ export default createRule({
               if (
                 node.parent?.type === AST_NODE_TYPES.TSTypeOperator &&
                 node.parent.operator === 'readonly'
-              )
+              ) {
                 return [
                   fixer.replaceText(
                     node.parent,
                     `ReadonlyArray<${text.slice(0, -2)}>`
                   ),
                 ];
+              }
 
               return [fixer.replaceText(node, `Array<${text.slice(0, -2)}>`)];
             },
           });
+        }
       },
     };
   },

--- a/libs/utils/src/votes.ts
+++ b/libs/utils/src/votes.ts
@@ -429,8 +429,9 @@ export function filterContestTalliesByPartyId(
 
   const filteredContestTallies: Dictionary<ContestTally> = {};
   for (const contestId of Object.keys(contestTallies)) {
-    if (contestIds.includes(contestId))
+    if (contestIds.includes(contestId)) {
       filteredContestTallies[contestId] = contestTallies[contestId];
+    }
   }
   return filteredContestTallies;
 }


### PR DESCRIPTION
Uses the built-in [`nonblock-statement-body-position`](https://eslint.org/docs/rules/nonblock-statement-body-position) rule.

Closes #1045 