### PR TITLE
style(all): use arrow functions in expressions

### DIFF
--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -111,6 +111,7 @@ export = {
     ],
     'no-void': 'off', // allow silencing `no-floating-promises` with `void`
     'nonblock-statement-body-position': ['error', 'beside'],
+    'prefer-arrow-callback': 'error',
 
     // replace some built-in rules that don't play well with TypeScript
     '@typescript-eslint/no-shadow': 'error',


### PR DESCRIPTION
Uses the built-in ESLint rule [`prefer-arrow-callback`](https://eslint.org/docs/rules/prefer-arrow-callback).

Closes #1049