### PR TITLE
style(all): `gts-spread-like-types`

### DIFF
--- a/apps/bmd/src/AppRoot.tsx
+++ b/apps/bmd/src/AppRoot.tsx
@@ -325,7 +325,7 @@ function appReducer(state: State, action: AppAction): State {
       return {
         ...state,
         votes: {
-          ...state.votes,
+          ...(state.votes ?? {}),
           [action.contestId]: action.vote,
         },
       };

--- a/apps/bsd/src/components/BallotSheetImage.tsx
+++ b/apps/bsd/src/components/BallotSheetImage.tsx
@@ -94,7 +94,7 @@ export function BallotSheetImage({
                 top: `${scaleY(contestLayout.bounds.y)}px`,
                 width: `${scaleX(contestLayout.bounds.width)}px`,
                 height: `${scaleY(contestLayout.bounds.height)}px`,
-                ...styleForContest?.(contestId),
+                ...(styleForContest?.(contestId) ?? {}),
               }}
             />
           )

--- a/apps/bsd/src/screens/WriteInAdjudicationScreen.tsx
+++ b/apps/bsd/src/screens/WriteInAdjudicationScreen.tsx
@@ -70,7 +70,7 @@ function Stack({
   as = 'div',
   children,
   flexDirection,
-  style,
+  style = {},
 }: {
   as?: string;
   children: React.ReactNode;

--- a/apps/election-manager/src/components/HandMarkedPaperBallot.tsx
+++ b/apps/election-manager/src/components/HandMarkedPaperBallot.tsx
@@ -108,7 +108,7 @@ function dualLanguageComposer(
   locales: BallotLocale,
   separator?: string
 ) {
-  return (key: string, options?: StringMap) => {
+  return (key: string, options: StringMap = {}) => {
     const enTranslation = t(key, {
       ...options,
       lng: locales.primary,

--- a/apps/election-manager/src/screens/ManualDataImportIndexScreen.test.tsx
+++ b/apps/election-manager/src/screens/ManualDataImportIndexScreen.test.tsx
@@ -127,9 +127,10 @@ test('loads prexisting manual data to edit', async () => {
   talliesByPrecinct['23'] = {
     numberOfBallotsCounted: 100,
     contestTallies: {
-      ...talliesByPrecinct['23']?.contestTallies,
+      ...(talliesByPrecinct['23']?.contestTallies ?? {}),
       'county-commissioners': ({
-        ...talliesByPrecinct['23']?.contestTallies['county-commissioners'],
+        ...(talliesByPrecinct['23']?.contestTallies['county-commissioners'] ??
+          {}),
         tallies: {
           argent: ({ tally: 80 } as unknown) as ContestOptionTally,
           '__write-in': ({ tally: 60 } as unknown) as ContestOptionTally,
@@ -138,7 +139,9 @@ test('loads prexisting manual data to edit', async () => {
         metadata: { undervotes: 220, overvotes: 0, ballots: 100 },
       } as unknown) as ContestTally,
       'judicial-robert-demergue': ({
-        ...talliesByPrecinct['23']?.contestTallies['judicial-robert-demergue'],
+        ...(talliesByPrecinct['23']?.contestTallies[
+          'judicial-robert-demergue'
+        ] ?? {}),
         tallies: {
           yes: { option: ['yes'], tally: 40 },
           no: { option: ['no'], tally: 30 },
@@ -150,11 +153,11 @@ test('loads prexisting manual data to edit', async () => {
   talliesByPrecinct['20'] = {
     numberOfBallotsCounted: 50,
     contestTallies: {
-      ...talliesByPrecinct['20']?.contestTallies,
+      ...(talliesByPrecinct['20']?.contestTallies ?? {}),
       'primary-constitution-head-of-party': ({
-        ...talliesByPrecinct['20']?.contestTallies[
+        ...(talliesByPrecinct['20']?.contestTallies[
           'primary-constitution-head-of-party'
-        ],
+        ] ?? {}),
         tallies: {
           alice: ({ tally: 25 } as unknown) as ContestOptionTally,
           bob: ({ tally: 5 } as unknown) as ContestOptionTally,
@@ -166,9 +169,11 @@ test('loads prexisting manual data to edit', async () => {
   talliesByPrecinct['21'] = {
     numberOfBallotsCounted: 7,
     contestTallies: {
-      ...talliesByPrecinct['21']?.contestTallies,
+      ...(talliesByPrecinct['21']?.contestTallies ?? {}),
       'judicial-robert-demergue': ({
-        ...talliesByPrecinct['21']?.contestTallies['judicial-robert-demergue'],
+        ...(talliesByPrecinct['21']?.contestTallies[
+          'judicial-robert-demergue'
+        ] ?? {}),
         tallies: {
           yes: { option: ['yes'], tally: 4 },
           no: { option: ['no'], tally: 3 },

--- a/apps/election-manager/src/screens/ManualDataImportPrecinctScreen.test.tsx
+++ b/apps/election-manager/src/screens/ManualDataImportPrecinctScreen.test.tsx
@@ -301,9 +301,10 @@ test('loads prexisting manual data to edit', async () => {
   talliesByPrecinct['23'] = {
     numberOfBallotsCounted: 100,
     contestTallies: {
-      ...talliesByPrecinct['23']?.contestTallies,
+      ...(talliesByPrecinct['23']?.contestTallies ?? {}),
       'county-commissioners': ({
-        ...talliesByPrecinct['23']?.contestTallies['county-commissioners'],
+        ...(talliesByPrecinct['23']?.contestTallies['county-commissioners'] ??
+          {}),
         tallies: {
           argent: ({ tally: 80 } as unknown) as ContestOptionTally,
           '__write-in': ({ tally: 60 } as unknown) as ContestOptionTally,
@@ -312,7 +313,9 @@ test('loads prexisting manual data to edit', async () => {
         metadata: { undervotes: 220, overvotes: 0, ballots: 100 },
       } as unknown) as ContestTally,
       'judicial-robert-demergue': ({
-        ...talliesByPrecinct['23']?.contestTallies['judicial-robert-demergue'],
+        ...(talliesByPrecinct['23']?.contestTallies[
+          'judicial-robert-demergue'
+        ] ?? {}),
         tallies: {
           yes: { option: ['yes'], tally: 40 },
           no: { option: ['no'], tally: 30 },
@@ -324,11 +327,11 @@ test('loads prexisting manual data to edit', async () => {
   talliesByPrecinct['20'] = {
     numberOfBallotsCounted: 50,
     contestTallies: {
-      ...talliesByPrecinct['20']?.contestTallies,
+      ...(talliesByPrecinct['20']?.contestTallies ?? {}),
       'primary-constitution-head-of-party': ({
-        ...talliesByPrecinct['20']?.contestTallies[
+        ...(talliesByPrecinct['20']?.contestTallies[
           'primary-constitution-head-of-party'
-        ],
+        ] ?? {}),
         tallies: {
           alice: ({ tally: 25 } as unknown) as ContestOptionTally,
           bob: ({ tally: 5 } as unknown) as ContestOptionTally,
@@ -340,9 +343,11 @@ test('loads prexisting manual data to edit', async () => {
   talliesByPrecinct['21'] = {
     numberOfBallotsCounted: 7,
     contestTallies: {
-      ...talliesByPrecinct['21']?.contestTallies,
+      ...(talliesByPrecinct['21']?.contestTallies ?? {}),
       'judicial-robert-demergue': ({
-        ...talliesByPrecinct['21']?.contestTallies['judicial-robert-demergue'],
+        ...(talliesByPrecinct['21']?.contestTallies[
+          'judicial-robert-demergue'
+        ] ?? {}),
         tallies: {
           yes: { option: ['yes'], tally: 4 },
           no: { option: ['no'], tally: 3 },

--- a/apps/election-manager/src/screens/PrintedBallotsReportScreen.tsx
+++ b/apps/election-manager/src/screens/PrintedBallotsReportScreen.tsx
@@ -69,7 +69,7 @@ export function PrintedBallotsReportScreen(): JSX.Element {
     (accumulatedCounts, { precinctId, ballotStyleId, numCopies }) => ({
       ...accumulatedCounts,
       [precinctId]: {
-        ...accumulatedCounts[precinctId],
+        ...(accumulatedCounts[precinctId] ?? {}),
         [ballotStyleId]:
           (accumulatedCounts[precinctId]?.[ballotStyleId] ?? 0) + numCopies,
       },
@@ -81,9 +81,9 @@ export function PrintedBallotsReportScreen(): JSX.Element {
     (accumulatedCounts, { precinctId, ballotStyleId, numCopies, type }) => ({
       ...accumulatedCounts,
       [type]: {
-        ...accumulatedCounts[type],
+        ...(accumulatedCounts[type] ?? {}),
         [precinctId]: {
-          ...accumulatedCounts[type]?.[precinctId],
+          ...(accumulatedCounts[type]?.[precinctId] ?? {}),
           [ballotStyleId]:
             (accumulatedCounts[type]?.[precinctId]?.[ballotStyleId] ?? 0) +
             numCopies,

--- a/apps/module-scan/src/util/marks.ts
+++ b/apps/module-scan/src/util/marks.ts
@@ -22,8 +22,8 @@ export function mergeChanges(
       const contestOptions: MarksByOptionId = result[contestId] ?? {};
 
       for (const optionId of Object.keys({
-        ...original[contestId],
-        ...change[contestId],
+        ...(original[contestId] ?? {}),
+        ...(change[contestId] ?? {}),
       })) {
         const changeMark = change[contestId]?.[optionId];
         const originalMark = original[contestId]?.[optionId];
@@ -63,7 +63,7 @@ export function changesFromMarks(
     }
 
     result[mark.contest.id] = {
-      ...result[mark.contest.id],
+      ...(result[mark.contest.id] ?? {}),
       // mark.option.id works for both candidate and ms-either-neither marks
       [mark.type === 'yesno' ? mark.option : mark.option.id]: getMarkStatus(
         mark,

--- a/apps/precinct-scanner/src/components/ElectionInfoBar.tsx
+++ b/apps/precinct-scanner/src/components/ElectionInfoBar.tsx
@@ -29,7 +29,7 @@ export function ElectionInfoBar({ mode = 'voter' }: Props): JSX.Element {
         })
       : undefined;
   return (
-    <Bar theme={{ ...contrastTheme.dark }}>
+    <Bar theme={{ ...(contrastTheme.dark ?? {}) }}>
       <Prose maxWidth={false} compact>
         <NoWrap as="strong">{electionDefinition.election.title}</NoWrap> —{' '}
         <NoWrap>{electionDate}</NoWrap>

--- a/libs/eslint-plugin-vx/docs/rules/gts-spread-like-types.md
+++ b/libs/eslint-plugin-vx/docs/rules/gts-spread-like-types.md
@@ -1,0 +1,35 @@
+# Requires spreading iterables in arrays and objects in objects (`vx/gts-spread-like-types`)
+
+This rule is from
+[Google TypeScript Style Guide section "Using the spread operator"](https://google.github.io/styleguide/tsguide.html#using-the-spread-operator):
+
+> Using the spread operator `[...foo]; {...bar}` is a convenient shorthand for
+> copying arrays and objects. When using the spread operator on objects, later
+> values replace earlier values at the same key.
+>
+> When using the spread operator, the value being spread must match what is
+> being created. That is, when creating an object, only objects may be used with
+> the spread operator; when creating an array, only spread iterables.
+> Primitives, including `null` and `undefined`, may never be spread.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```ts
+const foo = { num: 7 };
+const bar = { num: 5, ...(shouldUseFoo && foo) }; // might be undefined
+
+// Creates {0: 'a', 1: 'b', 2: 'c'} but has no length
+const fooStrings = ['a', 'b', 'c'];
+const ids = { ...fooStrings };
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+const foo = shouldUseFoo ? { num: 7 } : {};
+const bar = { num: 5, ...foo };
+const fooStrings = ['a', 'b', 'c'];
+const ids = [...fooStrings, 'd', 'e'];
+```

--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -53,6 +53,7 @@ export = {
     'vx/gts-no-unnecessary-has-own-property-check': 'warn',
     'vx/gts-parameter-properties': 'error',
     'vx/gts-safe-number-parse': 'error',
+    'vx/gts-spread-like-types': 'error',
     'vx/gts-use-optionals': 'error',
     'vx/no-array-sort-mutation': 'error',
     'vx/no-assert-truthiness': 'error',

--- a/libs/eslint-plugin-vx/src/rules/gts-no-foreach.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts-no-foreach.ts
@@ -5,28 +5,14 @@ import {
 } from '@typescript-eslint/experimental-utils';
 import { strict as assert } from 'assert';
 import * as ts from 'typescript';
-import { createRule, FunctionType, isBindingName, isFunction } from '../util';
-
-type CollectionType = 'array' | 'set' | 'map';
-
-/**
- * Determines whether `node` is an array or set or map by checking its static
- * type as determined by TypeScript.
- */
-function getCollectionType(
-  checker: ts.TypeChecker,
-  node: ts.Node
-): CollectionType | undefined {
-  const type = checker.getTypeAtLocation(node);
-  const typeName = type.getSymbol()?.getName();
-  return typeName === 'Array' || typeName === 'ReadonlyArray'
-    ? 'array'
-    : typeName === 'Set' || typeName === 'ReadonlySet'
-    ? 'set'
-    : typeName === 'Map' || typeName === 'ReadonlyMap'
-    ? 'map'
-    : undefined;
-}
+import {
+  CollectionType,
+  createRule,
+  FunctionType,
+  getCollectionType,
+  isBindingName,
+  isFunction,
+} from '../util';
 
 /**
  * Contains information about a `forEach` call.

--- a/libs/eslint-plugin-vx/src/rules/gts-spread-like-types.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts-spread-like-types.ts
@@ -1,0 +1,106 @@
+/* eslint-disable no-bitwise */
+import {
+  AST_NODE_TYPES,
+  ESLintUtils,
+  TSESTree,
+} from '@typescript-eslint/experimental-utils';
+import { strict as assert } from 'assert';
+import * as ts from 'typescript';
+import { createRule, getCollectionType } from '../util';
+
+function isIterableType(type: ts.Type): boolean {
+  return type.getProperties().some((p) => p.getName() === '__@iterator');
+}
+
+function isObjectType(type: ts.Type): boolean {
+  if (type.isUnion()) {
+    return type.types.every((subtype) => isObjectType(subtype));
+  }
+
+  if (type.isIntersection()) {
+    return type.types.some((subtype) => isObjectType(subtype));
+  }
+
+  const flags = type.getFlags();
+
+  return (
+    (flags & ts.TypeFlags.Object) === ts.TypeFlags.Object ||
+    (flags & ts.TypeFlags.NonPrimitive) === ts.TypeFlags.NonPrimitive
+  );
+}
+
+export default createRule({
+  name: 'gts-spread-like-types',
+  meta: {
+    docs: {
+      description:
+        'Requires spreading iterables in arrays and objects in objects',
+      category: 'Best Practices',
+      recommended: 'error',
+      suggestion: false,
+      requiresTypeChecking: true,
+    },
+    messages: {
+      requireIterablesInArraySpread: 'Only iterables may be spread into arrays',
+      requireObjectsInObjectSpread: 'Only objects may be spread into objects',
+      requireIterablesInCallSpread:
+        'Only iterables may be spread into arguments',
+    },
+    schema: [],
+    type: 'problem',
+  },
+  defaultOptions: [],
+
+  create(context) {
+    const parserServices = ESLintUtils.getParserServices(context);
+    const checker = parserServices.program.getTypeChecker();
+
+    return {
+      SpreadElement(node: TSESTree.SpreadElement): void {
+        assert(node.parent);
+
+        const spreadArgumentNode = parserServices.esTreeNodeToTSNodeMap.get(
+          node.argument
+        );
+        const spreadArgumentType =
+          checker.getTypeAtLocation(spreadArgumentNode);
+
+        switch (node.parent.type) {
+          case AST_NODE_TYPES.CallExpression:
+          case AST_NODE_TYPES.ArrayExpression: {
+            const isIterable = isIterableType(spreadArgumentType);
+            if (!isIterable) {
+              context.report({
+                messageId:
+                  node.parent.type === AST_NODE_TYPES.ArrayExpression
+                    ? 'requireIterablesInArraySpread'
+                    : 'requireIterablesInCallSpread',
+                node,
+              });
+            }
+            break;
+          }
+
+          case AST_NODE_TYPES.ObjectExpression: {
+            const isObject = isObjectType(spreadArgumentType);
+            const isCollection =
+              isObject && getCollectionType(checker, spreadArgumentNode);
+
+            if (!isObject || isCollection) {
+              context.report({
+                messageId: 'requireObjectsInObjectSpread',
+                node,
+              });
+            }
+            break;
+          }
+
+          default:
+            throw new Error(
+              `unexpected spread element parent: ${node.parent.type}`
+            );
+        }
+      },
+    };
+  },
+});

--- a/libs/eslint-plugin-vx/src/rules/index.ts
+++ b/libs/eslint-plugin-vx/src/rules/index.ts
@@ -16,6 +16,7 @@ import gtsNoReturnTypeOnlyGenerics from './gts-no-return-type-only-generics';
 import gtsNoUnnecessaryHasOwnPropertyCheck from './gts-no-unnecessary-has-own-property-check';
 import gtsParameterProperties from './gts-parameter-properties';
 import gtsSafeNumberParse from './gts-safe-number-parse';
+import gtsSpreadLikeTypes from './gts-spread-like-types';
 import gtsUseOptionals from './gts-use-optionals';
 import noArraySortMutation from './no-array-sort-mutation';
 import noAssertStringOrNumber from './no-assert-truthiness';
@@ -43,6 +44,7 @@ const rules: Record<
     gtsNoUnnecessaryHasOwnPropertyCheck,
   'gts-parameter-properties': gtsParameterProperties,
   'gts-safe-number-parse': gtsSafeNumberParse,
+  'gts-spread-like-types': gtsSpreadLikeTypes,
   'gts-use-optionals': gtsUseOptionals,
   'no-array-sort-mutation': noArraySortMutation,
   'no-assert-truthiness': noAssertStringOrNumber,

--- a/libs/eslint-plugin-vx/src/util/index.ts
+++ b/libs/eslint-plugin-vx/src/util/index.ts
@@ -3,6 +3,7 @@ import {
   ESLintUtils,
   TSESTree,
 } from '@typescript-eslint/experimental-utils';
+import * as ts from 'typescript';
 
 export const createRule = ESLintUtils.RuleCreator(
   (name) =>
@@ -41,4 +42,25 @@ export function isBindingName(
   node: TSESTree.Node
 ): node is TSESTree.BindingName {
   return BINDING_NAME_TYPES.has(node.type);
+}
+
+export type CollectionType = 'array' | 'set' | 'map';
+
+/**
+ * Determines whether `node` is an array or set or map by checking its static
+ * type as determined by TypeScript.
+ */
+export function getCollectionType(
+  checker: ts.TypeChecker,
+  node: ts.Node
+): CollectionType | undefined {
+  const type = checker.getTypeAtLocation(node);
+  const typeName = type.getSymbol()?.getName();
+  return typeName === 'Array' || typeName === 'ReadonlyArray'
+    ? 'array'
+    : typeName === 'Set' || typeName === 'ReadonlySet'
+    ? 'set'
+    : typeName === 'Map' || typeName === 'ReadonlyMap'
+    ? 'map'
+    : undefined;
 }

--- a/libs/eslint-plugin-vx/tests/rules/gts-spread-like-types.test.ts
+++ b/libs/eslint-plugin-vx/tests/rules/gts-spread-like-types.test.ts
@@ -1,0 +1,90 @@
+import { ESLintUtils } from '@typescript-eslint/experimental-utils';
+import { join } from 'path';
+import rule from '../../src/rules/gts-spread-like-types';
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    tsconfigRootDir: join(__dirname, '../fixtures'),
+    project: './tsconfig.json',
+  },
+  parser: '@typescript-eslint/parser',
+});
+
+ruleTester.run('gts-spread-like-types', rule, {
+  valid: [
+    // arrays
+    `[...[]]`,
+    `[...new Set()]`,
+    `[...(a ? [1] : [2])]`,
+    `declare const a: unknown[]; [...a]`,
+
+    // objects
+    `({ ...{} })`,
+    `({ ...(a ? { a } : {}) })`,
+    `declare const a: {} & number; ({ ...a })`,
+    `declare const a: object; ({ ...a })`,
+
+    // calls
+    `a(...[])`,
+  ],
+  invalid: [
+    // arrays
+    {
+      code: `declare const a: unknown; [...a]`,
+      errors: [{ messageId: 'requireIterablesInArraySpread', line: 1 }],
+    },
+    {
+      code: `[...1]`,
+      errors: [{ messageId: 'requireIterablesInArraySpread', line: 1 }],
+    },
+    {
+      code: `[...{}]`,
+      errors: [{ messageId: 'requireIterablesInArraySpread', line: 1 }],
+    },
+    {
+      code: `[...null]`,
+      errors: [{ messageId: 'requireIterablesInArraySpread', line: 1 }],
+    },
+    {
+      code: `[...undefined]`,
+      errors: [{ messageId: 'requireIterablesInArraySpread', line: 1 }],
+    },
+    {
+      code: `[...(a ? [a] : a)]`,
+      errors: [{ messageId: 'requireIterablesInArraySpread', line: 1 }],
+    },
+
+    // objects
+    {
+      code: `({ ...[] })`,
+      errors: [{ messageId: 'requireObjectsInObjectSpread', line: 1 }],
+    },
+    {
+      code: `declare const a: unknown[]; ({ ...a })`,
+      errors: [{ messageId: 'requireObjectsInObjectSpread', line: 1 }],
+    },
+    {
+      code: `declare const a: readonly unknown[]; ({ ...a })`,
+      errors: [{ messageId: 'requireObjectsInObjectSpread', line: 1 }],
+    },
+    {
+      code: `({ ...new Set() })`,
+      errors: [{ messageId: 'requireObjectsInObjectSpread', line: 1 }],
+    },
+    {
+      code: `({ ...null })`,
+      errors: [{ messageId: 'requireObjectsInObjectSpread', line: 1 }],
+    },
+    {
+      code: `({ ...undefined })`,
+      errors: [{ messageId: 'requireObjectsInObjectSpread', line: 1 }],
+    },
+
+    // calls
+    {
+      code: `a(...1)`,
+      errors: [{ messageId: 'requireIterablesInCallSpread', line: 1 }],
+    },
+  ],
+});

--- a/libs/hmpb-interpreter/test/fixtures.ts
+++ b/libs/hmpb-interpreter/test/fixtures.ts
@@ -1,4 +1,8 @@
-import { BallotPageMetadata } from '@votingworks/types';
+import {
+  BallotPageMetadata,
+  BallotPageMetadataSchema,
+  safeParseJSON,
+} from '@votingworks/types';
 import { promises as fs } from 'fs';
 import { join } from 'path';
 import { Input } from '../src';
@@ -33,9 +37,10 @@ export class Fixture implements Input {
     overrides: Partial<BallotPageMetadata> = {}
   ): Promise<BallotPageMetadata> {
     return {
-      ...JSON.parse(
-        await fs.readFile(adjacentMetadataFile(this.filePath()), 'utf8')
-      ),
+      ...safeParseJSON(
+        await fs.readFile(adjacentMetadataFile(this.filePath()), 'utf8'),
+        BallotPageMetadataSchema
+      ).unsafeUnwrap(),
       ...overrides,
     };
   }

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0001-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0001-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "locales": {
     "primary": "en-US"
   },

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0002-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0002-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "locales": {
     "primary": "en-US"
   },

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0003-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0003-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "locales": {
     "primary": "en-US"
   },

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0004-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0004-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "locales": {
     "primary": "en-US"
   },

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0005-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0005-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "locales": {
     "primary": "en-US"
   },

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0006-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0006-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "locales": {
     "primary": "en-US"
   },

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0007-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0007-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "locales": {
     "primary": "en-US"
   },

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0008-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0008-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "ballotStyleId": "77",
   "precinctId": "42",
   "pageNumber": 1,

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0009-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0009-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "ballotStyleId": "77",
   "precinctId": "42",
   "pageNumber": 2,

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0010-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0010-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "ballotStyleId": "77",
   "precinctId": "42",
   "pageNumber": 1,

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0011-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0011-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "ballotStyleId": "77",
   "precinctId": "42",
   "pageNumber": 2,

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0012-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0012-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "ballotStyleId": "77",
   "precinctId": "42",
   "pageNumber": 1,

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0013-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0013-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "ballotStyleId": "77",
   "precinctId": "42",
   "pageNumber": 2,

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0014-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0014-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "ballotStyleId": "77",
   "precinctId": "42",
   "pageNumber": 1,

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0015-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0015-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "ballotStyleId": "77",
   "precinctId": "42",
   "pageNumber": 2,

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0016-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0016-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "ballotStyleId": "77",
   "precinctId": "42",
   "pageNumber": 1,

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0017-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0017-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "ballotStyleId": "77",
   "precinctId": "42",
   "pageNumber": 2,

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0018-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0018-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "ballotStyleId": "77",
   "precinctId": "42",
   "pageNumber": 1,

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0019-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0019-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "ballotStyleId": "77",
   "precinctId": "42",
   "pageNumber": 2,

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0020-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0020-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "ballotStyleId": "77",
   "precinctId": "42",
   "pageNumber": 1,

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0021-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0021-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "ballotStyleId": "77",
   "precinctId": "42",
   "pageNumber": 2,

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0022-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0022-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "ballotStyleId": "77",
   "precinctId": "42",
   "pageNumber": 1,

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0023-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0023-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "ballotStyleId": "77",
   "precinctId": "42",
   "pageNumber": 2,

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0024-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0024-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "ballotStyleId": "77",
   "precinctId": "42",
   "pageNumber": 1,

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0025-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0025-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "ballotStyleId": "77",
   "precinctId": "42",
   "pageNumber": 2,

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0026-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0026-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "ballotStyleId": "77",
   "precinctId": "42",
   "pageNumber": 1,

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0027-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0027-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "ballotStyleId": "77",
   "precinctId": "42",
   "pageNumber": 2,

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0028-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0028-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "ballotStyleId": "77",
   "precinctId": "42",
   "pageNumber": 1,

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0029-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0029-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "ballotStyleId": "77",
   "precinctId": "42",
   "pageNumber": 2,

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0030-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0030-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "ballotStyleId": "77",
   "precinctId": "42",
   "pageNumber": 1,

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0031-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0031-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "ballotStyleId": "77",
   "precinctId": "42",
   "pageNumber": 2,

--- a/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0032-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/28lb-paper/batch-1-20200504_210852-ballot-0032-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "abcdefg",
   "ballotStyleId": "77",
   "precinctId": "42",
   "pageNumber": 1,

--- a/libs/hmpb-interpreter/test/fixtures/election-4e31cb17d8-ballot-style-77-precinct-oaklawn-branch-library/blank-p1-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/election-4e31cb17d8-ballot-style-77-precinct-oaklawn-branch-library/blank-p1-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "e012488b8fd567899e4d1b931343ac74e9a8803e33adf8657ab27bbb4408a492",
   "ballotStyleId": "77",
   "isTestMode": false,
   "pageNumber": 1,

--- a/libs/hmpb-interpreter/test/fixtures/election-4e31cb17d8-ballot-style-77-precinct-oaklawn-branch-library/blank-p2-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/election-4e31cb17d8-ballot-style-77-precinct-oaklawn-branch-library/blank-p2-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "e012488b8fd567899e4d1b931343ac74e9a8803e33adf8657ab27bbb4408a492",
   "ballotStyleId": "77",
   "isTestMode": false,
   "pageNumber": 2,

--- a/libs/hmpb-interpreter/test/fixtures/election-4e31cb17d8-ballot-style-77-precinct-oaklawn-branch-library/filled-in-p1-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/election-4e31cb17d8-ballot-style-77-precinct-oaklawn-branch-library/filled-in-p1-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "e012488b8fd567899e4d1b931343ac74e9a8803e33adf8657ab27bbb4408a492",
   "ballotStyleId": "77",
   "isTestMode": false,
   "pageNumber": 1,

--- a/libs/hmpb-interpreter/test/fixtures/election-4e31cb17d8-ballot-style-77-precinct-oaklawn-branch-library/filled-in-p2-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/election-4e31cb17d8-ballot-style-77-precinct-oaklawn-branch-library/filled-in-p2-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "e012488b8fd567899e4d1b931343ac74e9a8803e33adf8657ab27bbb4408a492",
   "ballotStyleId": "77",
   "isTestMode": false,
   "pageNumber": 2,

--- a/libs/hmpb-interpreter/test/fixtures/election-5c6e578acf-state-of-hamilton-2020/blank-p1-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/election-5c6e578acf-state-of-hamilton-2020/blank-p1-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "a92ddeefed53ce89dc2be541596a1b395fbb39d38f3cdfcc688509b2b56096b2",
   "ballotStyleId": "12",
   "isTestMode": false,
   "locales": {

--- a/libs/hmpb-interpreter/test/fixtures/election-5c6e578acf-state-of-hamilton-2020/blank-p2-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/election-5c6e578acf-state-of-hamilton-2020/blank-p2-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "a92ddeefed53ce89dc2be541596a1b395fbb39d38f3cdfcc688509b2b56096b2",
   "ballotStyleId": "12",
   "isTestMode": false,
   "locales": {

--- a/libs/hmpb-interpreter/test/fixtures/election-5c6e578acf-state-of-hamilton-2020/blank-p3-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/election-5c6e578acf-state-of-hamilton-2020/blank-p3-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "a92ddeefed53ce89dc2be541596a1b395fbb39d38f3cdfcc688509b2b56096b2",
   "ballotStyleId": "12",
   "isTestMode": false,
   "locales": {

--- a/libs/hmpb-interpreter/test/fixtures/election-5c6e578acf-state-of-hamilton-2020/blank-p4-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/election-5c6e578acf-state-of-hamilton-2020/blank-p4-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "a92ddeefed53ce89dc2be541596a1b395fbb39d38f3cdfcc688509b2b56096b2",
   "ballotStyleId": "12",
   "isTestMode": false,
   "locales": {

--- a/libs/hmpb-interpreter/test/fixtures/election-5c6e578acf-state-of-hamilton-2020/blank-p5-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/election-5c6e578acf-state-of-hamilton-2020/blank-p5-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "a92ddeefed53ce89dc2be541596a1b395fbb39d38f3cdfcc688509b2b56096b2",
   "ballotStyleId": "12",
   "isTestMode": false,
   "locales": {

--- a/libs/hmpb-interpreter/test/fixtures/election-5c6e578acf-state-of-hamilton-2020/filled-in-p1-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/election-5c6e578acf-state-of-hamilton-2020/filled-in-p1-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "a92ddeefed53ce89dc2be541596a1b395fbb39d38f3cdfcc688509b2b56096b2",
   "ballotStyleId": "12",
   "isTestMode": false,
   "locales": {

--- a/libs/hmpb-interpreter/test/fixtures/election-5c6e578acf-state-of-hamilton-2020/filled-in-p2-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/election-5c6e578acf-state-of-hamilton-2020/filled-in-p2-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "a92ddeefed53ce89dc2be541596a1b395fbb39d38f3cdfcc688509b2b56096b2",
   "ballotStyleId": "12",
   "isTestMode": false,
   "locales": {

--- a/libs/hmpb-interpreter/test/fixtures/election-5c6e578acf-state-of-hamilton-2020/filled-in-p3-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/election-5c6e578acf-state-of-hamilton-2020/filled-in-p3-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "a92ddeefed53ce89dc2be541596a1b395fbb39d38f3cdfcc688509b2b56096b2",
   "ballotStyleId": "12",
   "isTestMode": false,
   "locales": {

--- a/libs/hmpb-interpreter/test/fixtures/election-5c6e578acf-state-of-hamilton-2020/filled-in-p4-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/election-5c6e578acf-state-of-hamilton-2020/filled-in-p4-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "a92ddeefed53ce89dc2be541596a1b395fbb39d38f3cdfcc688509b2b56096b2",
   "ballotStyleId": "12",
   "isTestMode": false,
   "locales": {

--- a/libs/hmpb-interpreter/test/fixtures/election-5c6e578acf-state-of-hamilton-2020/filled-in-p5-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/election-5c6e578acf-state-of-hamilton-2020/filled-in-p5-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "a92ddeefed53ce89dc2be541596a1b395fbb39d38f3cdfcc688509b2b56096b2",
   "ballotStyleId": "12",
   "isTestMode": false,
   "locales": {

--- a/libs/hmpb-interpreter/test/fixtures/election-5c6e578acf-state-of-hamilton-2020/filled-in-p5-yesno-overvote-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/election-5c6e578acf-state-of-hamilton-2020/filled-in-p5-yesno-overvote-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "a92ddeefed53ce89dc2be541596a1b395fbb39d38f3cdfcc688509b2b56096b2",
   "ballotStyleId": "12",
   "isTestMode": false,
   "locales": {

--- a/libs/hmpb-interpreter/test/fixtures/election-7c61368c3b-choctaw-general-2020/blank-p1-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/election-7c61368c3b-choctaw-general-2020/blank-p1-metadata.json
@@ -2,6 +2,8 @@
   "ballotStyleId": "1",
   "isTestMode": false,
   "pageNumber": 1,
+  "ballotType": 0,
+  "electionHash": "0428fbdfff6eee2364599b650f150e029267109898db7d61db9e3c48209aa72d",
   "precinctId": "6526",
   "locales": {
     "primary": "en-US"

--- a/libs/hmpb-interpreter/test/fixtures/election-7c61368c3b-choctaw-general-2020/blank-p2-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/election-7c61368c3b-choctaw-general-2020/blank-p2-metadata.json
@@ -2,6 +2,8 @@
   "ballotStyleId": "1",
   "isTestMode": false,
   "pageNumber": 2,
+  "ballotType": 0,
+  "electionHash": "0428fbdfff6eee2364599b650f150e029267109898db7d61db9e3c48209aa72d",
   "precinctId": "6526",
   "locales": {
     "primary": "en-US"

--- a/libs/hmpb-interpreter/test/fixtures/election-7c61368c3b-choctaw-general-2020/filled-in-p1-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/election-7c61368c3b-choctaw-general-2020/filled-in-p1-metadata.json
@@ -2,6 +2,8 @@
   "ballotStyleId": "1",
   "isTestMode": false,
   "pageNumber": 1,
+  "ballotType": 0,
+  "electionHash": "0428fbdfff6eee2364599b650f150e029267109898db7d61db9e3c48209aa72d",
   "precinctId": "6526",
   "locales": {
     "primary": "en-US"

--- a/libs/hmpb-interpreter/test/fixtures/election-7c61368c3b-choctaw-general-2020/filled-in-p2-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/election-7c61368c3b-choctaw-general-2020/filled-in-p2-metadata.json
@@ -2,6 +2,8 @@
   "ballotStyleId": "1",
   "isTestMode": false,
   "pageNumber": 2,
+  "ballotType": 0,
+  "electionHash": "0428fbdfff6eee2364599b650f150e029267109898db7d61db9e3c48209aa72d",
   "precinctId": "6526",
   "locales": {
     "primary": "en-US"

--- a/libs/hmpb-interpreter/test/fixtures/election-98f5203139-choctaw-general-2019/blank-p1-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/election-98f5203139-choctaw-general-2019/blank-p1-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "0428fbdfff6eee2364599b650f150e029267109898db7d61db9e3c48209aa72d",
   "locales": {
     "primary": "en-US"
   },

--- a/libs/hmpb-interpreter/test/fixtures/election-98f5203139-choctaw-general-2019/blank-p2-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/election-98f5203139-choctaw-general-2019/blank-p2-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "0428fbdfff6eee2364599b650f150e029267109898db7d61db9e3c48209aa72d",
   "locales": {
     "primary": "en-US"
   },

--- a/libs/hmpb-interpreter/test/fixtures/election-98f5203139-choctaw-general-2019/blank-p3-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/election-98f5203139-choctaw-general-2019/blank-p3-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "0428fbdfff6eee2364599b650f150e029267109898db7d61db9e3c48209aa72d",
   "locales": {
     "primary": "en-US"
   },

--- a/libs/hmpb-interpreter/test/fixtures/election-98f5203139-choctaw-general-2019/border-p1-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/election-98f5203139-choctaw-general-2019/border-p1-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "0428fbdfff6eee2364599b650f150e029267109898db7d61db9e3c48209aa72d",
   "locales": {
     "primary": "en-US"
   },

--- a/libs/hmpb-interpreter/test/fixtures/election-98f5203139-choctaw-general-2019/border-p3-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/election-98f5203139-choctaw-general-2019/border-p3-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "930f1cd04eb5f147ad5f4c3747559174534a5f3989ab18960a8862bebce6050f",
   "locales": {
     "primary": "en-US"
   },

--- a/libs/hmpb-interpreter/test/fixtures/election-98f5203139-choctaw-general-2019/filled-in-p1-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/election-98f5203139-choctaw-general-2019/filled-in-p1-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "930f1cd04eb5f147ad5f4c3747559174534a5f3989ab18960a8862bebce6050f",
   "locales": {
     "primary": "en-US"
   },

--- a/libs/hmpb-interpreter/test/fixtures/election-98f5203139-choctaw-general-2019/filled-in-p2-metadata.json
+++ b/libs/hmpb-interpreter/test/fixtures/election-98f5203139-choctaw-general-2019/filled-in-p2-metadata.json
@@ -1,4 +1,6 @@
 {
+  "ballotType": 0,
+  "electionHash": "930f1cd04eb5f147ad5f4c3747559174534a5f3989ab18960a8862bebce6050f",
   "locales": {
     "primary": "en-US"
   },

--- a/libs/ui/src/hooks/useAutocomplete.ts
+++ b/libs/ui/src/hooks/useAutocomplete.ts
@@ -65,7 +65,7 @@ export function useAutocomplete<Option>({
 
   const getInputProps: Autocomplete['getInputProps'] = useCallback(
     (inputProps) => ({
-      ...inputProps,
+      ...(inputProps ?? {}),
 
       autoComplete: 'off',
 

--- a/libs/utils/src/fetchJSON.ts
+++ b/libs/utils/src/fetchJSON.ts
@@ -3,7 +3,7 @@ export async function fetchJSON(
   init?: RequestInit
 ): Promise<unknown> {
   const response = await fetch(input, {
-    ...init,
+    ...(init ?? {}),
     headers: {
       Accept: 'application/json',
       ...(init?.headers ?? {}),


### PR DESCRIPTION
This rule is from
[Google TypeScript Style Guide section "Using the spread operator"](https://google.github.io/styleguide/tsguide.html#using-the-spread-operator):

> Using the spread operator `[...foo]; {...bar}` is a convenient shorthand for copying arrays and objects. When using the spread operator on objects, later values replace earlier values at the same key.
>
> When using the spread operator, the value being spread must match what is being created. That is, when creating an object, only objects may be used with the spread operator; when creating an array, only spread iterables. Primitives, including `null` and `undefined`, may never be spread.

## Rule Details

Examples of **incorrect** code for this rule:

```ts
const foo = { num: 7 };
const bar = { num: 5, ...(shouldUseFoo && foo) }; // might be undefined

// Creates {0: 'a', 1: 'b', 2: 'c'} but has no length
const fooStrings = ['a', 'b', 'c'];
const ids = { ...fooStrings };
```

Examples of **correct** code for this rule:

```ts
const foo = shouldUseFoo ? { num: 7 } : {};
const bar = { num: 5, ...foo };
const fooStrings = ['a', 'b', 'c'];
const ids = [...fooStrings, 'd', 'e'];
```


Closes #1044 
