### PR TITLE
First pass at module documentation

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,0 +1,136 @@
+# VotingWorks Modules
+
+The VotingWorks source code, which implements every component of the
+voting system, is organized into modules as detailed below.
+
+## Libraries
+
+Programmatic libraries that are used across VotingWorks subsystems are organized within the `/libs` directory.
+
+### Ballot Encoder
+
+Utilities for encoding a ballot as a compact bitstring and decoding a
+bitstring back into a ballot. This is used notably to encode a voter's
+choices in a QR code on a BMD summary ballot.
+
+### ESLint Plugin Vx
+
+A code linter that implements our coding styleguide.
+
+### Fixtures
+
+Test data structures, i.e. sample elections and CVRs, for various
+types of elections, used in automated testing.
+
+### HMPB Interpreter
+
+A library for interpreting images of hand-marked paper ballots.
+
+### Logging
+
+A library that handles all logging across VotingWorks components.
+
+### LSD (Line Segment Detector)
+
+A library used for detecting line segments in images, used as one of the tools by HMPB Interpreter to interpret hand-marked paper ballot images.
+
+### Plustek SDK
+
+A programmatic interface to the Plustek scanning hardware module,
+which we use in our precinct scanner.
+
+### Test Utils
+
+Utilities used in tests across the VotingWorks systems.
+
+### Types
+
+The common data types used across VotingWorks applications,
+e.g. election, cast-vote record, tallies, etc.
+
+### UI
+
+Common user-interface components used across the VotingWorks voting
+system, including some low-level components like button, button bar,
+number pad, progress bar, and some higher-level components like tally
+report summary, tally reports, tally QR codes.
+
+### Utils
+
+Utility functions used across VotingWorks components, including
+notably working with ballot packages, dates, tallies, USB stick
+interfaces.
+
+## Apps
+
+VotingWorks Apps are standalone programs that run as part of a
+VotingWorks component. They are organized inside the `/apps`
+directory.
+
+There are two kinds of apps: frontends, and modules.
+
+* Frontends correspond to components that are distinct to the user,
+  for example "Precinct Scanner" is one frontend, and "BMD" is
+  another.
+  
+* Modules (we may want to rename this) are services that run as part
+  of individual components and provide functionality that may be used
+  by more than one component. For example, "Module: Scan" is a service
+  that interfaces with our scanning hardware, processes ballots, and
+  produces cast-vote records. "Module: Scan" is used by two frontends:
+  "Precinct Scanner" and "Ballot Scanning Device" (which is our
+  central scanner).
+
+### Frontend: Ballot Activation System
+
+The vote-card encoding system used in vote-center configurations.
+
+### Frontend: Ballot Marking Device
+
+The ballot-marking device.
+
+### Frontend: Ballot Scanning Device
+
+The central scanner.
+
+### Frontend: Election Manager
+
+The election manager that manages the election definition and results
+from all scanners.
+
+### Frontend: Precinct Scanner
+
+The precinct scanner.
+
+### Module: Converter SEMS Ms
+
+The service that converts election definitions and cast-vote records
+to and from Mississippi's State Election Management System.
+
+Used by:
+* Election Manager.
+
+### Module: Scan
+
+The service that interfaces with the scanning hardware, interprets
+ballots, and produces cast-vote records.
+
+Used by:
+* Ballot Scanning Device
+* Precinct Scanner
+
+### Module: Smartcards
+
+The service that interfaces with smart cards.
+
+Used by:
+* Election Manager
+* Ballot Scanning Device
+* Precinct Scanner
+* Ballot Marking Device
+* Ballot Activation System
+
+## Integration Testing
+
+Integration tests that test whole components (e.g. Election Manager,
+or BMD) are located in the `/integration-testing` directory.


### PR DESCRIPTION
very first high-level pass at our modules.

Leading me to think that we should come up with a better taxonomy that is VVSG compatible. I suggest:

- *subsystem*: independent hardware component, like the BMD, or the Precinct Scanner.
- *frontend*: a frontend process
- *service*: a backend process
- *module*: as per VVSG, a chunk of thematically consistent code.