### PR TITLE
style(all): `gts-unicode-escapes`

### DIFF
--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -54,6 +54,7 @@ export = {
     'vx/gts-parameter-properties': 'error',
     'vx/gts-safe-number-parse': 'error',
     'vx/gts-spread-like-types': 'error',
+    'vx/gts-unicode-escapes': 'error',
     'vx/gts-use-optionals': 'error',
     'vx/no-array-sort-mutation': 'error',
     'vx/no-assert-truthiness': 'error',

--- a/libs/eslint-plugin-vx/src/rules/gts-unicode-escapes.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts-unicode-escapes.ts
@@ -1,0 +1,134 @@
+import { TSESTree } from '@typescript-eslint/experimental-utils';
+import {
+  createRule,
+  enumerateCharacterCodeEscapes,
+  enumerateNonPrintableCharacters,
+  hasAttachedComment,
+  isNonPrintableCharacter,
+} from '../util';
+
+const QUOTE_LENGTH = '"'.length;
+
+export default createRule({
+  name: 'gts-unicode-escapes',
+  meta: {
+    docs: {
+      description:
+        'Requires the use of real Unicode characters when printable, escapes when non-printable.',
+      category: 'Best Practices',
+      recommended: 'error',
+      requiresTypeChecking: false,
+    },
+    messages: {
+      escapeSequenceMissingComment:
+        'Escape sequence ‘{{escaped}}’ is missing an explanatory comment.',
+      useLiteralPrintableCharacter:
+        'Unnecessary escape sequence ‘{{escaped}}’ for a printable character; use ‘{{char}}’ directly.',
+      useEscapeSequenceForNonPrintableCharacter:
+        'Use the escape sequence ‘{{escaped}}’ for the non-printable character.',
+    },
+    schema: [],
+    type: 'problem',
+    fixable: 'code',
+  },
+  defaultOptions: [],
+
+  create(context) {
+    const sourceCode = context.getSourceCode();
+
+    function checkNonPrintableCharacters(
+      node: TSESTree.Node,
+      raw: string,
+      startIndex: number
+    ): void {
+      for (const {
+        nonPrintableCharacter,
+        index,
+      } of enumerateNonPrintableCharacters(raw)) {
+        const matchIndex = startIndex + index;
+        const nonPrintableCharacterCode = nonPrintableCharacter.charCodeAt(0);
+        const escaped = `\\u${nonPrintableCharacterCode
+          .toString(16)
+          .padStart(4, '0')}`;
+
+        context.report({
+          node,
+          messageId: 'useEscapeSequenceForNonPrintableCharacter',
+          data: { escaped },
+          fix: (fixer) =>
+            fixer.replaceTextRange(
+              [matchIndex, matchIndex + nonPrintableCharacter.length],
+              escaped
+            ),
+        });
+      }
+    }
+
+    function checkEscapes(
+      node: TSESTree.Node,
+      raw: string,
+      startIndex: number
+    ): void {
+      for (const {
+        escapeSequence,
+        char,
+        index,
+      } of enumerateCharacterCodeEscapes(raw)) {
+        const matchIndex = startIndex + index;
+        const escaped = escapeSequence;
+        const isAllowedEscapeSequence =
+          isNonPrintableCharacter(char) || char === '\n' || char === '\r';
+
+        if (isAllowedEscapeSequence) {
+          if (!hasAttachedComment(sourceCode, node)) {
+            context.report({
+              node,
+              messageId: 'escapeSequenceMissingComment',
+              data: { escaped },
+            });
+          }
+        } else {
+          context.report({
+            node,
+            messageId: 'useLiteralPrintableCharacter',
+            data: { escaped, char },
+            fix: (fixer) =>
+              fixer.replaceTextRange(
+                [matchIndex, matchIndex + escaped.length],
+                char
+              ),
+          });
+        }
+      }
+    }
+
+    function check(node: TSESTree.Node, raw: string, startIndex: number): void {
+      checkNonPrintableCharacters(node, raw, startIndex);
+      checkEscapes(node, raw, startIndex);
+    }
+
+    return {
+      Literal(node: TSESTree.Literal): void {
+        if (typeof node.value !== 'string') {
+          return;
+        }
+
+        check(
+          node,
+          node.raw.slice(QUOTE_LENGTH, -QUOTE_LENGTH),
+          node.range[0] + QUOTE_LENGTH
+        );
+      },
+
+      TemplateLiteral(node: TSESTree.TemplateLiteral): void {
+        for (const [i, quasi] of node.quasis.entries()) {
+          check(
+            node,
+            quasi.value.raw,
+            quasi.range[0] + (i === 0 ? QUOTE_LENGTH : 0)
+          );
+        }
+      },
+    };
+  },
+});

--- a/libs/eslint-plugin-vx/src/rules/index.ts
+++ b/libs/eslint-plugin-vx/src/rules/index.ts
@@ -17,6 +17,7 @@ import gtsNoUnnecessaryHasOwnPropertyCheck from './gts-no-unnecessary-has-own-pr
 import gtsParameterProperties from './gts-parameter-properties';
 import gtsSafeNumberParse from './gts-safe-number-parse';
 import gtsSpreadLikeTypes from './gts-spread-like-types';
+import gtsUnicodeEscapes from './gts-unicode-escapes';
 import gtsUseOptionals from './gts-use-optionals';
 import noArraySortMutation from './no-array-sort-mutation';
 import noAssertStringOrNumber from './no-assert-truthiness';
@@ -45,6 +46,7 @@ const rules: Record<
   'gts-parameter-properties': gtsParameterProperties,
   'gts-safe-number-parse': gtsSafeNumberParse,
   'gts-spread-like-types': gtsSpreadLikeTypes,
+  'gts-unicode-escapes': gtsUnicodeEscapes,
   'gts-use-optionals': gtsUseOptionals,
   'no-array-sort-mutation': noArraySortMutation,
   'no-assert-truthiness': noAssertStringOrNumber,

--- a/libs/eslint-plugin-vx/src/util/index.ts
+++ b/libs/eslint-plugin-vx/src/util/index.ts
@@ -3,6 +3,8 @@ import {
   ESLintUtils,
   TSESTree,
 } from '@typescript-eslint/experimental-utils';
+import { strict as assert } from 'assert';
+import { SourceCode } from '@typescript-eslint/experimental-utils/dist/ts-eslint';
 import * as ts from 'typescript';
 
 export const createRule = ESLintUtils.RuleCreator(
@@ -63,4 +65,147 @@ export function getCollectionType(
     : typeName === 'Map' || typeName === 'ReadonlyMap'
     ? 'map'
     : undefined;
+}
+
+/**
+ * Determines whether there is a comment attached to `node`.
+ */
+export function hasAttachedComment(
+  sourceCode: SourceCode,
+  node: TSESTree.Node | TSESTree.Token
+): boolean {
+  function hasAttachedCommentInner(
+    inner: TSESTree.Node | TSESTree.Token
+  ): boolean {
+    if (
+      sourceCode
+        .getCommentsBefore(inner)
+        .some((comment) => comment.loc.end.line >= node.loc.start.line - 1) ||
+      sourceCode
+        .getCommentsAfter(inner)
+        .some((comment) => comment.loc.start.line === node.loc.end.line)
+    ) {
+      return true;
+    }
+
+    if (!('parent' in inner)) {
+      return false;
+    }
+
+    if (inner.type === AST_NODE_TYPES.ExpressionStatement) {
+      return false;
+    }
+
+    switch (inner.parent?.type) {
+      case AST_NODE_TYPES.VariableDeclarator:
+      case AST_NODE_TYPES.AssignmentExpression:
+        return hasAttachedCommentInner(inner.parent);
+
+      case AST_NODE_TYPES.Property: {
+        const commaToken = sourceCode.getTokenAfter(inner.parent);
+        assert.equal(commaToken?.value, ',');
+        return (
+          hasAttachedCommentInner(inner.parent) ||
+          hasAttachedCommentInner(commaToken)
+        );
+      }
+
+      case AST_NODE_TYPES.VariableDeclaration:
+        return (
+          inner.parent.declarations[0] === inner &&
+          hasAttachedCommentInner(inner.parent)
+        );
+
+      default:
+        return !!inner.parent && hasAttachedCommentInner(inner.parent);
+    }
+  }
+
+  return hasAttachedCommentInner(node);
+}
+
+/**
+ * Enumerates over all matches for non-printable characters in `string`. The
+ * definition for printable characters is taken from this StackOverflow answer:
+ *
+ *   https://stackoverflow.com/a/53450014/549363
+ *
+ * The short version is that that's no agreed-upon definition because it depends
+ * on the context. This answer shows what golang uses and, since it seems sane,
+ * that's what we're using here. We also include CR & LF because we want those
+ * to be allowed in template strings.
+ */
+export function* enumerateNonPrintableCharacters(
+  string: string
+): IterableIterator<{ nonPrintableCharacter: string; index: number }> {
+  const NonPrintableCharactersPattern =
+    /[^\r\n\p{Letter}\p{Mark}\p{Number}\p{Punctuation}\p{Symbol}\p{Space_Separator}]/gu;
+  for (const match of string.matchAll(NonPrintableCharactersPattern)) {
+    assert(typeof match.index === 'number');
+    yield { nonPrintableCharacter: match[0], index: match.index };
+  }
+}
+
+/**
+ * Determines whether `char` is non-printable.
+ *
+ * @see {enumerateNonPrintableCharacters}
+ */
+export function isNonPrintableCharacter(char: string): boolean {
+  return !enumerateNonPrintableCharacters(char).next().done;
+}
+
+/**
+ * Determines whether an escape sequence starts at `index` in `string`.
+ */
+export function isStartOfEscapeSequence(
+  string: string,
+  index: number
+): boolean {
+  if (string[index] !== '\\') {
+    return false;
+  }
+
+  let indexOfFirstSlash = index;
+
+  while (string[indexOfFirstSlash - 1] === '\\') {
+    indexOfFirstSlash -= 1;
+  }
+
+  return (index - indexOfFirstSlash) % 2 === 0;
+}
+
+export interface CharacterCodeEscape {
+  readonly escapeSequence: string;
+  readonly hexString: string;
+  readonly charCode: number;
+  readonly char: string;
+  readonly index: number;
+}
+
+/**
+ * Enumerates over all escape sequences in `string` that use a character code.
+ * These could be hex (e.g. `\x0a`) or unicode (e.g. `\u000a` or `\u{a}`).
+ */
+export function* enumerateCharacterCodeEscapes(
+  string: string
+): IterableIterator<CharacterCodeEscape> {
+  const CharacterEscapeSequencePattern =
+    /(?:\\u([a-fA-F\d]{4})|\\u\{([a-fA-F\d]+)\}|\\x([a-fA-F\d]{2}))/gu;
+  for (const match of string.matchAll(CharacterEscapeSequencePattern)) {
+    assert(typeof match.index === 'number');
+    if (isStartOfEscapeSequence(string, match.index)) {
+      const hexString = match[1] ?? match[2] ?? match[3];
+      const charCode = parseInt(hexString, 16);
+      assert(!Number.isNaN(charCode) && Number.isFinite(charCode));
+      const char = String.fromCharCode(charCode);
+      yield {
+        escapeSequence: match[0],
+        hexString,
+        charCode,
+        char,
+        index: match.index,
+      };
+    }
+  }
 }

--- a/libs/eslint-plugin-vx/tests/rules/gts-unicode-escapes.test.ts
+++ b/libs/eslint-plugin-vx/tests/rules/gts-unicode-escapes.test.ts
@@ -1,0 +1,92 @@
+import { ESLintUtils } from '@typescript-eslint/experimental-utils';
+import { join } from 'path';
+import rule from '../../src/rules/gts-unicode-escapes';
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    tsconfigRootDir: join(__dirname, '../fixtures'),
+    project: './tsconfig.json',
+  },
+  parser: '@typescript-eslint/parser',
+});
+
+ruleTester.run('gts-unicode-escapes', rule, {
+  valid: [
+    `''`,
+    '``',
+    `'∞'`,
+    `'👍'`,
+    '"hello world"',
+    `'\\x00' // null byte`,
+    `'\\u{0}' // null byte`,
+    `const nil = '\\u0000'; // raw NULL byte`,
+    `
+      const chars = {
+        nil: '\\u0000', // raw NULL byte
+      };
+    `,
+    `'\\n'`,
+    '`\n`',
+    `
+      // escaped slash does not start escape sequence
+      '\\\\x40'
+    `,
+    `
+      // allow escaped newline
+      '\\u000a'
+    `,
+    `
+      // allow escaped carriage return
+      '\\u000d'
+    `,
+    `expect(output).toEqual('\\x00'); // raw NULL byte`,
+  ],
+  invalid: [
+    {
+      code: `'\u0000'`, // raw NULL byte
+      errors: [
+        { messageId: 'useEscapeSequenceForNonPrintableCharacter', line: 1 },
+      ],
+      output: `'\\u0000'`,
+    },
+    {
+      code: `'\\u221e'`,
+      errors: [{ messageId: 'useLiteralPrintableCharacter', line: 1 }],
+      output: `'∞'`,
+    },
+    {
+      code: `'\\x40'`,
+      errors: [{ messageId: 'useLiteralPrintableCharacter', line: 1 }],
+      output: `'@'`,
+    },
+    {
+      code: `'\\\\\\x40'`,
+      errors: [{ messageId: 'useLiteralPrintableCharacter', line: 1 }],
+      output: `'\\\\@'`,
+    },
+    {
+      code: '`\\u221e123`',
+      errors: [{ messageId: 'useLiteralPrintableCharacter', line: 1 }],
+      output: '`∞123`',
+    },
+    {
+      code: '`\\u{40}`',
+      errors: [{ messageId: 'useLiteralPrintableCharacter', line: 1 }],
+      output: '`@`',
+    },
+    {
+      code: '`\\x00`',
+      errors: [{ messageId: 'escapeSequenceMissingComment', line: 1 }],
+    },
+    {
+      code: `
+        const nil = '\\x00';
+
+        // do something with it
+        console.log(nil);
+      `,
+      errors: [{ messageId: 'escapeSequenceMissingComment', line: 2 }],
+    },
+  ],
+});

--- a/libs/eslint-plugin-vx/tsconfig.json
+++ b/libs/eslint-plugin-vx/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.shared.json",
   "compilerOptions": {
     "target": "ES2019",
-    "lib": ["ES2019"],
+    "lib": ["ES2020"],
     "module": "CommonJS",
     "moduleResolution": "Node",
     "esModuleInterop": true,

--- a/libs/lsd/src/cli/index.test.ts
+++ b/libs/lsd/src/cli/index.test.ts
@@ -15,6 +15,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+// Jest writes out ESC into the inline snapshots for ANSI terminal style.
+/* eslint-disable vx/gts-unicode-escapes */
+
 import { WritableStream } from 'memory-streams';
 import * as fs from 'fs';
 import { PassThrough } from 'stream';

--- a/libs/test-utils/src/child_process.test.ts
+++ b/libs/test-utils/src/child_process.test.ts
@@ -50,11 +50,11 @@ test('fakeWritable', async () => {
 
   writable.write(Buffer.of(1, 2, 3));
   expect(writable.toBuffer()).toEqual(Buffer.of(1, 2, 3));
-  expect(writable.toString()).toEqual('\x01\x02\x03');
+  expect(writable.toString()).toEqual('\x01\x02\x03'); // mirrors `Buffer.of(1, 2, 3)`
 
   writable.write('hi!', 'ascii');
   expect(writable.toBuffer()).toEqual(Buffer.of(1, 2, 3, 104, 105, 33));
-  expect(writable.toString()).toEqual('\x01\x02\x03hi!');
+  expect(writable.toString()).toEqual('\x01\x02\x03hi!'); // mirrors `Buffer.of(1, 2, 3, 104, 105, 33)`
 
   {
     const writeCallback = jest.fn();


### PR DESCRIPTION
Comes from [Google TypeScript Style Guide on "File encoding: UTF-8"](https://google.github.io/styleguide/tsguide.html#file-encoding-utf-8):

> For non-ASCII characters, use the actual Unicode character (e.g. `∞`). For non-printable characters, the equivalent hex or Unicode escapes (e.g. `\u221e`) can be used along with an explanatory comment.

Closes #1027 