### PR TITLE
feat(all) add application logging for usb state changes

### DIFF
--- a/apps/bsd/src/AppRoot.tsx
+++ b/apps/bsd/src/AppRoot.tsx
@@ -101,7 +101,7 @@ export function AppRoot({ card, hardware }: AppRootProps): JSX.Element {
     bypassAuthentication: false,
   });
 
-  const usbDrive = useUsbDrive();
+  const usbDrive = useUsbDrive({ logger });
 
   const [smartcard, hasCardReaderAttached] = useSmartcard({ card, hardware });
   const {
@@ -329,6 +329,7 @@ export function AppRoot({ card, hardware }: AppRootProps): JSX.Element {
           machineConfig,
           storage,
           lockMachine,
+          currentUserSession,
         }}
       >
         <MachineLockedScreen />
@@ -346,6 +347,7 @@ export function AppRoot({ card, hardware }: AppRootProps): JSX.Element {
           machineConfig,
           storage,
           lockMachine,
+          currentUserSession,
         }}
       >
         <InvalidCardScreen />
@@ -363,6 +365,7 @@ export function AppRoot({ card, hardware }: AppRootProps): JSX.Element {
           machineConfig,
           storage,
           lockMachine,
+          currentUserSession,
         }}
       >
         <UnlockMachineScreen
@@ -383,6 +386,7 @@ export function AppRoot({ card, hardware }: AppRootProps): JSX.Element {
             electionDefinition,
             storage,
             lockMachine,
+            currentUserSession,
           }}
         >
           <Screen>
@@ -403,7 +407,9 @@ export function AppRoot({ card, hardware }: AppRootProps): JSX.Element {
                     small={false}
                     primary
                     usbDriveStatus={displayUsbStatus}
-                    usbDriveEject={usbDrive.eject}
+                    usbDriveEject={() =>
+                      usbDrive.eject(currentUserSession.type)
+                    }
                   />
                 </Buttons>
               </MainChild>
@@ -427,6 +433,7 @@ export function AppRoot({ card, hardware }: AppRootProps): JSX.Element {
             machineConfig,
             storage,
             lockMachine,
+            currentUserSession,
           }}
         >
           <BallotEjectScreen
@@ -455,6 +462,7 @@ export function AppRoot({ card, hardware }: AppRootProps): JSX.Element {
           machineConfig,
           storage,
           lockMachine,
+          currentUserSession,
         }}
       >
         <Switch>
@@ -486,7 +494,7 @@ export function AppRoot({ card, hardware }: AppRootProps): JSX.Element {
               <MainNav isTestMode={isTestMode}>
                 <USBControllerButton
                   usbDriveStatus={displayUsbStatus}
-                  usbDriveEject={usbDrive.eject}
+                  usbDriveEject={() => usbDrive.eject(currentUserSession.type)}
                 />
                 <Button small onPress={lockMachine}>
                   Lock Machine
@@ -535,6 +543,7 @@ export function AppRoot({ card, hardware }: AppRootProps): JSX.Element {
           electionDefinition,
           storage,
           lockMachine,
+          currentUserSession,
         }}
       >
         <LoadElectionScreen setElectionDefinition={updateElectionDefinition} />

--- a/apps/bsd/src/components/ElectionConfiguration.tsx
+++ b/apps/bsd/src/components/ElectionConfiguration.tsx
@@ -53,7 +53,13 @@ export function ElectionConfiguration({
   >([]);
   const [loadingFiles, setLoadingFiles] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
-  const { usbDriveStatus, usbDriveEject, lockMachine } = useContext(AppContext);
+  const {
+    usbDriveStatus,
+    usbDriveEject,
+    lockMachine,
+    currentUserSession,
+  } = useContext(AppContext);
+  assert(currentUserSession); // TODO(auth) should this assert that the user is an admin
 
   async function acceptAutomaticallyChosenFile(
     file: KioskBrowser.FileSystemEntry
@@ -120,7 +126,7 @@ export function ElectionConfiguration({
         Lock Machine
       </Button>
       <USBControllerButton
-        usbDriveEject={usbDriveEject}
+        usbDriveEject={() => usbDriveEject(currentUserSession.type)}
         usbDriveStatus={usbDriveStatus}
       />
     </MainNav>

--- a/apps/bsd/src/components/ExportResultsModal.test.tsx
+++ b/apps/bsd/src/components/ExportResultsModal.test.tsx
@@ -162,6 +162,7 @@ test('render export modal when a usb drive is mounted as expected and allows aut
         usbDriveEject: jest.fn(),
         storage: new MemoryStorage(),
         lockMachine: jest.fn(),
+        currentUserSession: { type: 'admin', authenticated: true },
       }}
     >
       <Router history={history}>

--- a/apps/bsd/src/components/ExportResultsModal.tsx
+++ b/apps/bsd/src/components/ExportResultsModal.tsx
@@ -11,6 +11,7 @@ import {
   usbstick,
 } from '@votingworks/utils';
 import { USBControllerButton } from '@votingworks/ui';
+import { strict as assert } from 'assert';
 import { AppContext } from '../contexts/AppContext';
 import { Modal } from './Modal';
 import { Button } from './Button';
@@ -51,9 +52,13 @@ export function ExportResultsModal({
   const [currentState, setCurrentState] = useState<ModalState>(ModalState.INIT);
   const [errorMessage, setErrorMessage] = useState('');
 
-  const { machineConfig, usbDriveEject, usbDriveStatus } = useContext(
-    AppContext
-  );
+  const {
+    machineConfig,
+    usbDriveEject,
+    usbDriveStatus,
+    currentUserSession,
+  } = useContext(AppContext);
+  assert(currentUserSession); // TODO(auth) should this check that the current user is an admin
 
   async function exportResults(openDialog: boolean) {
     setCurrentState(ModalState.SAVING);
@@ -177,7 +182,7 @@ export function ExportResultsModal({
               small={false}
               primary
               usbDriveStatus={usbDriveStatus}
-              usbDriveEject={usbDriveEject}
+              usbDriveEject={() => usbDriveEject(currentUserSession.type)}
             />
           </React.Fragment>
         }

--- a/apps/bsd/src/contexts/AppContext.ts
+++ b/apps/bsd/src/contexts/AppContext.ts
@@ -1,16 +1,18 @@
-import { ElectionDefinition } from '@votingworks/types';
+import { LoggingUserRole } from '@votingworks/logging/src';
+import { ElectionDefinition, UserSession } from '@votingworks/types';
 import { MemoryStorage, Storage, usbstick } from '@votingworks/utils';
 import { createContext } from 'react';
 import { MachineConfig } from '../config/types';
 
 interface AppContextInterface {
   usbDriveStatus: usbstick.UsbDriveStatus;
-  usbDriveEject: () => void;
+  usbDriveEject: (currentUser: LoggingUserRole) => void;
   machineConfig: MachineConfig;
   electionDefinition?: ElectionDefinition;
   electionHash?: string;
   storage: Storage;
   lockMachine: () => void;
+  currentUserSession?: UserSession;
 }
 
 const appContext: AppContextInterface = {
@@ -21,6 +23,7 @@ const appContext: AppContextInterface = {
   electionHash: undefined,
   storage: new MemoryStorage(),
   lockMachine: () => undefined,
+  currentUserSession: undefined,
 };
 
 export const AppContext = createContext(appContext);

--- a/apps/bsd/src/screens/LoadElectionScreen.test.tsx
+++ b/apps/bsd/src/screens/LoadElectionScreen.test.tsx
@@ -1,9 +1,9 @@
-import { render } from '@testing-library/react';
 import React from 'react';
+import { renderInAppContext } from '../../test/renderInAppContext';
 import { LoadElectionScreen } from './LoadElectionScreen';
 
 test('shows a message that there is no election configuration', () => {
-  const { getByText } = render(
+  const { getByText } = renderInAppContext(
     <LoadElectionScreen setElectionDefinition={jest.fn()} />
   );
 

--- a/apps/bsd/test/renderInAppContext.tsx
+++ b/apps/bsd/test/renderInAppContext.tsx
@@ -1,6 +1,6 @@
 import { render as testRender, RenderResult } from '@testing-library/react';
 import { electionSampleDefinition as testElectionDefinition } from '@votingworks/fixtures';
-import { ElectionDefinition } from '@votingworks/types';
+import { ElectionDefinition, UserSession } from '@votingworks/types';
 import { MemoryStorage, Storage, usbstick } from '@votingworks/utils';
 import { createMemoryHistory, MemoryHistory } from 'history';
 import React from 'react';
@@ -17,6 +17,7 @@ interface RenderInAppContextParams {
   storage?: Storage;
   lockMachine?: () => void;
   bypassAuthentication?: boolean;
+  currentUserSession?: UserSession;
 }
 
 export function renderInAppContext(
@@ -31,6 +32,7 @@ export function renderInAppContext(
     usbDriveEject = jest.fn(),
     storage = new MemoryStorage(),
     lockMachine = jest.fn(),
+    currentUserSession = { type: 'admin', authenticated: true },
   }: RenderInAppContextParams = {}
 ): RenderResult {
   return testRender(
@@ -42,6 +44,7 @@ export function renderInAppContext(
         usbDriveEject,
         storage,
         lockMachine,
+        currentUserSession,
       }}
     >
       <Router history={history}>{component}</Router>

--- a/apps/election-manager/src/AppRoot.tsx
+++ b/apps/election-manager/src/AppRoot.tsx
@@ -181,7 +181,7 @@ export function AppRoot({
     })();
   }, [machineConfigProvider]);
 
-  const usbDrive = useUsbDrive();
+  const usbDrive = useUsbDrive({ logger });
   const displayUsbStatus = usbDrive.status ?? usbstick.UsbDriveStatus.absent;
 
   const [smartcard, hasCardReaderAttached] = useSmartcard({ card, hardware });

--- a/apps/election-manager/src/components/ExportElectionBallotPackageModalButton.tsx
+++ b/apps/election-manager/src/components/ExportElectionBallotPackageModalButton.tsx
@@ -34,10 +34,14 @@ const USBImage = styled.img`
 `;
 
 export function ExportElectionBallotPackageModalButton(): JSX.Element {
-  const { electionDefinition, usbDriveStatus, usbDriveEject } = useContext(
-    AppContext
-  );
+  const {
+    electionDefinition,
+    usbDriveStatus,
+    usbDriveEject,
+    currentUserSession,
+  } = useContext(AppContext);
   assert(electionDefinition);
+  assert(currentUserSession); // TODO(auth) should this make sure we have an admin
   const { election, electionData, electionHash } = electionDefinition;
   const electionLocaleCodes = getElectionLocales(election, DEFAULT_LOCALE);
 
@@ -306,7 +310,7 @@ export function ExportElectionBallotPackageModalButton(): JSX.Element {
             <USBControllerButton
               primary
               small={false}
-              usbDriveEject={usbDriveEject}
+              usbDriveEject={() => usbDriveEject(currentUserSession.type)}
               usbDriveStatus={usbDriveStatus}
             />
           </React.Fragment>

--- a/apps/election-manager/src/components/NavigationScreen.tsx
+++ b/apps/election-manager/src/components/NavigationScreen.tsx
@@ -35,8 +35,10 @@ export function NavigationScreen({
     usbDriveStatus,
     lockMachine,
     machineConfig,
+    currentUserSession,
   } = useContext(AppContext);
   const election = electionDefinition?.election;
+  const currentUser = currentUserSession?.type ?? 'unknown';
 
   return (
     <Screen>
@@ -80,7 +82,7 @@ export function NavigationScreen({
               </Button>
             )}
             <USBControllerButton
-              usbDriveEject={usbDriveEject}
+              usbDriveEject={() => usbDriveEject(currentUser)}
               usbDriveStatus={usbDriveStatus}
             />
           </React.Fragment>

--- a/apps/election-manager/src/components/SaveFileToUSB.tsx
+++ b/apps/election-manager/src/components/SaveFileToUSB.tsx
@@ -52,9 +52,13 @@ export function SaveFileToUSB({
   fileType,
   promptToEjectUSB = false,
 }: Props): JSX.Element {
-  const { usbDriveStatus, usbDriveEject, isOfficialResults } = useContext(
-    AppContext
-  );
+  const {
+    usbDriveStatus,
+    usbDriveEject,
+    isOfficialResults,
+    currentUserSession,
+  } = useContext(AppContext);
+  assert(currentUserSession); // TODO(auth) should this check for a specific user type
 
   const [currentState, setCurrentState] = useState(ModalState.INIT);
   const [errorMessage, setErrorMessage] = useState('');
@@ -153,7 +157,7 @@ export function SaveFileToUSB({
             small={false}
             primary
             usbDriveStatus={usbDriveStatus}
-            usbDriveEject={usbDriveEject}
+            usbDriveEject={() => usbDriveEject(currentUserSession.type)}
           />
         </React.Fragment>
       );

--- a/apps/election-manager/src/contexts/AppContext.ts
+++ b/apps/election-manager/src/contexts/AppContext.ts
@@ -6,6 +6,7 @@ import {
   UserSession,
 } from '@votingworks/types';
 import { usbstick, NullPrinter, Printer } from '@votingworks/utils';
+import { LoggingUserRole } from '@votingworks/logging/src';
 import {
   SaveElection,
   PrintedBallot,
@@ -36,7 +37,7 @@ export interface AppContextInterface {
   saveIsOfficialResults: () => Promise<void>;
   resetFiles: (fileType: ResultsFileType) => Promise<void>;
   usbDriveStatus: usbstick.UsbDriveStatus;
-  usbDriveEject: () => Promise<void>;
+  usbDriveEject: (currentUser: LoggingUserRole) => Promise<void>;
   addPrintedBallot: (printedBallot: PrintedBallot) => void;
   printedBallots: PrintedBallot[];
   fullElectionTally: FullElectionTally;

--- a/apps/precinct-scanner/src/AppRoot.tsx
+++ b/apps/precinct-scanner/src/AppRoot.tsx
@@ -345,7 +345,7 @@ export function AppRoot({
     () => new Logger(LogSource.VxPrecinctScanApp, window.kiosk),
     []
   );
-  const usbDrive = useUsbDrive();
+  const usbDrive = useUsbDrive({ logger });
   const usbDriveDisplayStatus =
     usbDrive.status ?? usbstick.UsbDriveStatus.absent;
 
@@ -780,6 +780,7 @@ export function AppRoot({
           electionDefinition,
           currentPrecinctId,
           machineConfig,
+          currentUserSession,
         }}
       >
         {currentUserSession.authenticated ? (
@@ -811,6 +812,7 @@ export function AppRoot({
           electionDefinition,
           currentPrecinctId,
           machineConfig,
+          currentUserSession,
         }}
       >
         <PollWorkerScreen
@@ -906,6 +908,7 @@ export function AppRoot({
         electionDefinition,
         machineConfig,
         currentPrecinctId,
+        currentUserSession,
       }}
     >
       {voterScreen}

--- a/apps/precinct-scanner/src/components/ExportBackupModal.test.tsx
+++ b/apps/precinct-scanner/src/components/ExportBackupModal.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { electionSampleDefinition } from '@votingworks/fixtures';
 import { fakeKiosk, fakeUsbDrive } from '@votingworks/test-utils';
-import { err, ok } from '@votingworks/types';
+import { err, ok, UserSession } from '@votingworks/types';
 import { usbstick } from '@votingworks/utils';
 import React from 'react';
 import { mocked } from 'ts-jest/utils';
@@ -14,6 +14,7 @@ jest.mock('../utils/download');
 const { UsbDriveStatus } = usbstick;
 
 const machineConfig = { machineId: '0003', codeVersion: 'TEST' };
+const currentUserSession: UserSession = { type: 'admin', authenticated: true };
 
 test('renders loading screen when USB drive is mounting or ejecting in export modal', () => {
   const usbStatuses = [UsbDriveStatus.present, UsbDriveStatus.ejecting];
@@ -22,7 +23,11 @@ test('renders loading screen when USB drive is mounting or ejecting in export mo
     const closeFn = jest.fn();
     const { unmount } = render(
       <AppContext.Provider
-        value={{ electionDefinition: electionSampleDefinition, machineConfig }}
+        value={{
+          electionDefinition: electionSampleDefinition,
+          machineConfig,
+          currentUserSession,
+        }}
       >
         <ExportBackupModal
           onClose={closeFn}
@@ -46,7 +51,11 @@ test('render no USB found screen when there is not a mounted USB drive', () => {
     const closeFn = jest.fn();
     const { unmount } = render(
       <AppContext.Provider
-        value={{ electionDefinition: electionSampleDefinition, machineConfig }}
+        value={{
+          electionDefinition: electionSampleDefinition,
+          machineConfig,
+          currentUserSession,
+        }}
       >
         <ExportBackupModal
           onClose={closeFn}
@@ -76,7 +85,11 @@ test('render export modal when a USB drive is mounted as expected and allows cus
   const closeFn = jest.fn();
   const { rerender } = render(
     <AppContext.Provider
-      value={{ electionDefinition: electionSampleDefinition, machineConfig }}
+      value={{
+        electionDefinition: electionSampleDefinition,
+        machineConfig,
+        currentUserSession,
+      }}
     >
       <ExportBackupModal
         onClose={closeFn}
@@ -98,7 +111,11 @@ test('render export modal when a USB drive is mounted as expected and allows cus
   expect(closeFn).toHaveBeenCalled();
   rerender(
     <AppContext.Provider
-      value={{ electionDefinition: electionSampleDefinition, machineConfig }}
+      value={{
+        electionDefinition: electionSampleDefinition,
+        machineConfig,
+        currentUserSession,
+      }}
     >
       <ExportBackupModal
         onClose={closeFn}
@@ -119,7 +136,11 @@ test('render export modal when a USB drive is mounted as expected and allows aut
   const ejectFn = jest.fn();
   render(
     <AppContext.Provider
-      value={{ electionDefinition: electionSampleDefinition, machineConfig }}
+      value={{
+        electionDefinition: electionSampleDefinition,
+        machineConfig,
+        currentUserSession,
+      }}
     >
       <ExportBackupModal
         onClose={closeFn}
@@ -149,7 +170,11 @@ test('handles no USB drives', async () => {
   const closeFn = jest.fn();
   const { getByText } = render(
     <AppContext.Provider
-      value={{ electionDefinition: electionSampleDefinition, machineConfig }}
+      value={{
+        electionDefinition: electionSampleDefinition,
+        machineConfig,
+        currentUserSession,
+      }}
     >
       <ExportBackupModal
         onClose={closeFn}
@@ -175,7 +200,11 @@ test('shows a specific error for file writer failure', async () => {
   const closeFn = jest.fn();
   const { getByText } = render(
     <AppContext.Provider
-      value={{ electionDefinition: electionSampleDefinition, machineConfig }}
+      value={{
+        electionDefinition: electionSampleDefinition,
+        machineConfig,
+        currentUserSession,
+      }}
     >
       <ExportBackupModal
         onClose={closeFn}
@@ -208,7 +237,11 @@ test('shows a specific error for fetch failure', async () => {
   const closeFn = jest.fn();
   render(
     <AppContext.Provider
-      value={{ electionDefinition: electionSampleDefinition, machineConfig }}
+      value={{
+        electionDefinition: electionSampleDefinition,
+        machineConfig,
+        currentUserSession,
+      }}
     >
       <ExportBackupModal
         onClose={closeFn}

--- a/apps/precinct-scanner/src/components/ExportBackupModal.tsx
+++ b/apps/precinct-scanner/src/components/ExportBackupModal.tsx
@@ -42,8 +42,9 @@ export function ExportBackupModal({ onClose, usbDrive }: Props): JSX.Element {
   const [currentState, setCurrentState] = useState(ModalState.INIT);
   const [errorMessage, setErrorMessage] = useState('');
 
-  const { electionDefinition } = useContext(AppContext);
+  const { electionDefinition, currentUserSession } = useContext(AppContext);
   assert(electionDefinition);
+  assert(currentUserSession); // TODO(auth) should assert this is an admin or pollworker?
 
   const exportBackup = useCallback(
     async (openDialog: boolean) => {
@@ -149,7 +150,7 @@ export function ExportBackupModal({ onClose, usbDrive }: Props): JSX.Element {
               small={false}
               primary
               usbDriveStatus={usbDrive.status ?? usbstick.UsbDriveStatus.absent}
-              usbDriveEject={usbDrive.eject}
+              usbDriveEject={() => usbDrive.eject(currentUserSession.type)}
             />
           </React.Fragment>
         }

--- a/apps/precinct-scanner/src/components/ExportResultsModal.test.tsx
+++ b/apps/precinct-scanner/src/components/ExportResultsModal.test.tsx
@@ -9,6 +9,7 @@ import { usbstick } from '@votingworks/utils';
 import fetchMock from 'fetch-mock';
 
 import { fakeKiosk, fakeUsbDrive } from '@votingworks/test-utils';
+import { UserSession } from '@votingworks/types';
 import { ExportResultsModal } from './ExportResultsModal';
 import { fakeFileWriter } from '../../test/helpers/fakeFileWriter';
 import { AppContext } from '../contexts/AppContext';
@@ -16,6 +17,7 @@ import { AppContext } from '../contexts/AppContext';
 const { UsbDriveStatus } = usbstick;
 
 const machineConfig = { machineId: '0003', codeVersion: 'TEST' };
+const currentUserSession: UserSession = { type: 'admin', authenticated: true };
 
 test('renders loading screen when usb drive is mounting or ejecting in export modal', () => {
   const usbStatuses = [UsbDriveStatus.present, UsbDriveStatus.ejecting];
@@ -24,7 +26,11 @@ test('renders loading screen when usb drive is mounting or ejecting in export mo
     const closeFn = jest.fn();
     const { getByText, unmount } = render(
       <AppContext.Provider
-        value={{ electionDefinition: electionSampleDefinition, machineConfig }}
+        value={{
+          electionDefinition: electionSampleDefinition,
+          machineConfig,
+          currentUserSession,
+        }}
       >
         <ExportResultsModal
           onClose={closeFn}
@@ -50,7 +56,11 @@ test('render no usb found screen when there is not a mounted usb drive', () => {
     const closeFn = jest.fn();
     const { getByText, unmount, getByAltText } = render(
       <AppContext.Provider
-        value={{ electionDefinition: electionSampleDefinition, machineConfig }}
+        value={{
+          electionDefinition: electionSampleDefinition,
+          machineConfig,
+          currentUserSession,
+        }}
       >
         <ExportResultsModal
           onClose={closeFn}
@@ -88,7 +98,11 @@ test('render export modal when a usb drive is mounted as expected and allows cus
   const closeFn = jest.fn();
   const { getByText, getByAltText } = render(
     <AppContext.Provider
-      value={{ electionDefinition: electionSampleDefinition, machineConfig }}
+      value={{
+        electionDefinition: electionSampleDefinition,
+        machineConfig,
+        currentUserSession,
+      }}
     >
       <ExportResultsModal
         onClose={closeFn}
@@ -128,7 +142,11 @@ test('render export modal when a usb drive is mounted as expected and allows aut
   const ejectFn = jest.fn();
   const { getByText, rerender } = render(
     <AppContext.Provider
-      value={{ electionDefinition: electionSampleDefinition, machineConfig }}
+      value={{
+        electionDefinition: electionSampleDefinition,
+        machineConfig,
+        currentUserSession,
+      }}
     >
       <ExportResultsModal
         onClose={closeFn}
@@ -173,7 +191,11 @@ test('render export modal when a usb drive is mounted as expected and allows aut
 
   rerender(
     <AppContext.Provider
-      value={{ electionDefinition: electionSampleDefinition, machineConfig }}
+      value={{
+        electionDefinition: electionSampleDefinition,
+        machineConfig,
+        currentUserSession,
+      }}
     >
       <ExportResultsModal
         onClose={closeFn}
@@ -200,7 +222,11 @@ test('render export modal with errors when appropriate', async () => {
   const closeFn = jest.fn();
   const { getByText } = render(
     <AppContext.Provider
-      value={{ electionDefinition: electionSampleDefinition, machineConfig }}
+      value={{
+        electionDefinition: electionSampleDefinition,
+        machineConfig,
+        currentUserSession,
+      }}
     >
       <ExportResultsModal
         onClose={closeFn}

--- a/apps/precinct-scanner/src/components/ExportResultsModal.tsx
+++ b/apps/precinct-scanner/src/components/ExportResultsModal.tsx
@@ -50,8 +50,11 @@ export function ExportResultsModal({
   const [currentState, setCurrentState] = useState<ModalState>(ModalState.INIT);
   const [errorMessage, setErrorMessage] = useState('');
 
-  const { electionDefinition, machineConfig } = useContext(AppContext);
+  const { electionDefinition, machineConfig, currentUserSession } = useContext(
+    AppContext
+  );
   assert(electionDefinition);
+  assert(currentUserSession); // TODO(auth) should assert this is an admin or pollworker?
 
   const exportResults = useCallback(
     async (openDialog: boolean) => {
@@ -186,7 +189,7 @@ export function ExportResultsModal({
               usbDriveStatus={
                 usbDrive.status ?? usbstick.UsbDriveStatus.notavailable
               }
-              usbDriveEject={usbDrive.eject}
+              usbDriveEject={() => usbDrive.eject(currentUserSession.type)}
             />
           </React.Fragment>
         }

--- a/apps/precinct-scanner/src/contexts/AppContext.ts
+++ b/apps/precinct-scanner/src/contexts/AppContext.ts
@@ -1,4 +1,8 @@
-import { ElectionDefinition, PrecinctId } from '@votingworks/types';
+import {
+  ElectionDefinition,
+  PrecinctId,
+  UserSession,
+} from '@votingworks/types';
 import { createContext } from 'react';
 import { MachineConfig } from '../config/types';
 
@@ -6,6 +10,7 @@ export interface AppContextInterface {
   electionDefinition?: ElectionDefinition;
   machineConfig: Readonly<MachineConfig>;
   currentPrecinctId?: PrecinctId;
+  currentUserSession?: UserSession;
 }
 
 const appContext: AppContextInterface = {

--- a/apps/precinct-scanner/src/screens/AdminScreen.test.tsx
+++ b/apps/precinct-scanner/src/screens/AdminScreen.test.tsx
@@ -24,6 +24,7 @@ test('renders date and time settings modal', async () => {
       value={{
         electionDefinition: electionSampleDefinition,
         machineConfig: { machineId: '0000', codeVersion: 'TEST' },
+        currentUserSession: { type: 'admin', authenticated: true },
       }}
     >
       <AdminScreen
@@ -168,6 +169,7 @@ test('setting and un-setting the precinct', async () => {
       value={{
         electionDefinition: electionSampleDefinition,
         machineConfig: { machineId: '0000', codeVersion: 'TEST' },
+        currentUserSession: { type: 'admin', authenticated: true },
       }}
     >
       <AdminScreen
@@ -204,6 +206,7 @@ test('export from admin screen', async () => {
       value={{
         electionDefinition: electionSampleDefinition,
         machineConfig: { machineId: '0000', codeVersion: 'TEST' },
+        currentUserSession: { type: 'admin', authenticated: true },
       }}
     >
       <AdminScreen

--- a/libs/logging/src/logEventIDs.ts
+++ b/libs/logging/src/logEventIDs.ts
@@ -22,6 +22,12 @@ export enum LogEventId {
   AdminCardInserted = 'admin-card-inserted',
   UserSessionActivationAttempt = 'user-session-activation',
   UserLoggedOut = 'user-logged-out',
+  // USB related logs
+  USBDriveStatusUpdate = 'usb-drive-status-update',
+  USBDriveEjectInit = 'usb-drive-eject-init',
+  USBDriveEjected = 'usb-drive-eject-complete',
+  USBDriveMountInit = 'usb-drive-mount-init',
+  USBDriveMounted = 'usb-drive-mount-complete',
 }
 
 export interface LogDetails {
@@ -112,6 +118,45 @@ const UserLoggedOutEvent: LogDetails = {
   defaultMessage: 'User logged out of the current session.',
 };
 
+const USBDriveEjectInit: LogDetails = {
+  eventId: LogEventId.USBDriveEjectInit,
+  eventType: LogEventType.UserAction,
+  documentationMessage:
+    'A request to eject the current USB drive was given by the user, the usb drive will now be ejected.',
+  defaultMessage:
+    'The current USB drive was requested to eject, application will now eject...',
+};
+
+const USBDriveEjected: LogDetails = {
+  eventId: LogEventId.USBDriveEjected,
+  eventType: LogEventType.ApplicationStatus,
+  documentationMessage:
+    'The current USB drive finished attempting to ejected. Success or failure indicated by disposition.',
+};
+
+const USBDriveStatusUpdate: LogDetails = {
+  eventId: LogEventId.USBDriveStatusUpdate,
+  eventType: LogEventType.ApplicationStatus,
+  documentationMessage:
+    'USB Drive detected a status update. Potential USB statuses are: notavailable - No USB Drive detection is available, absent - No USB identified, present - USB identified but not mounted, mounted - USB mounted on device, ejecting - USB in the process of ejecting. ',
+};
+
+const USBDriveMountInit: LogDetails = {
+  eventId: LogEventId.USBDriveMountInit,
+  eventType: LogEventType.ApplicationAction,
+  documentationMessage:
+    'The USB Drive is attempting to mount. This action is taken automatically by the application when a new USB drive is detected.',
+  defaultMessage:
+    'The USB Drive is attempting to mount. This action is taken automatically by the application when a new USB drive is detected.',
+};
+
+const USBDriveMounted: LogDetails = {
+  eventId: LogEventId.USBDriveMounted,
+  eventType: LogEventType.ApplicationStatus,
+  documentationMessage:
+    'USB Drive mount has completed. Success or failure is indicated by the disposition.',
+};
+
 export function getDetailsForEventId(eventId: LogEventId): LogDetails {
   switch (eventId) {
     case LogEventId.ElectionConfigured:
@@ -136,6 +181,16 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return UserSessionActivationAttemptEvent;
     case LogEventId.UserLoggedOut:
       return UserLoggedOutEvent;
+    case LogEventId.USBDriveEjectInit:
+      return USBDriveEjectInit;
+    case LogEventId.USBDriveEjected:
+      return USBDriveEjected;
+    case LogEventId.USBDriveStatusUpdate:
+      return USBDriveStatusUpdate;
+    case LogEventId.USBDriveMountInit:
+      return USBDriveMountInit;
+    case LogEventId.USBDriveMounted:
+      return USBDriveMounted;
     /* istanbul ignore next - compile time check for completeness */
     default:
       throwIllegalValue(eventId);

--- a/libs/logging/src/logEventTypes.ts
+++ b/libs/logging/src/logEventTypes.ts
@@ -13,6 +13,7 @@ export enum LogEventType {
   ApplicationStatus = 'application-status',
   SystemAction = 'system-action',
   SystemStatus = 'system-status',
+  ApplicationAction = 'application-action',
 }
 
 export interface LogEventTypeDocumentation {
@@ -44,6 +45,12 @@ const ApplicationStatusEventDocumentation: LogEventTypeDocumentation = {
     'Status update or message that the application took without user action.',
 };
 
+const ApplicationActionEventDocumentation: LogEventTypeDocumentation = {
+  eventType: LogEventType.ApplicationAction,
+  documentationMessage:
+    'Action taken by the votingworks application automatically when a certain condition is met. Example: When a new USB drive is detected, the application will automatically mount it.',
+};
+
 export function getDocumentationForEventType(
   eventType: LogEventType
 ): LogEventTypeDocumentation {
@@ -56,6 +63,8 @@ export function getDocumentationForEventType(
       return SystemStatusEventDocumentation;
     case LogEventType.ApplicationStatus:
       return ApplicationStatusEventDocumentation;
+    case LogEventType.ApplicationAction:
+      return ApplicationActionEventDocumentation;
     /* istanbul ignore next - compile time check for completeness */
     default:
       throwIllegalValue(eventType);

--- a/libs/logging/src/logger.test.ts
+++ b/libs/logging/src/logger.test.ts
@@ -94,3 +94,10 @@ test('logs unknown disposition as expected', async () => {
     the: 'wolves',
   });
 });
+
+test('logging from a client side app without sending window.kiosk does NOT log to console', async () => {
+  console.log = jest.fn();
+  const logger = new Logger(LogSource.VxAdminApp);
+  await logger.log(LogEventId.AdminCardInserted, 'admin');
+  expect(console.log).not.toHaveBeenCalled();
+});

--- a/libs/logging/src/logger.ts
+++ b/libs/logging/src/logger.ts
@@ -1,16 +1,16 @@
 import makeDebug from 'debug';
 import { Dictionary } from '@votingworks/types';
-import { getDetailsForEventId, LogLine } from '.';
-import { LogEventId } from './logEventIDs';
 import {
+  CLIENT_SIDE_LOG_SOURCES,
+  LogLine,
   LogDisposition,
   LogDispositionStandardTypes,
   LoggingUserRole,
   LogSource,
 } from './types';
+import { LogEventId, getDetailsForEventId } from './logEventIDs';
 
 const debug = makeDebug('logger');
-makeDebug.enable('logger');
 
 interface LogData extends Dictionary<string> {
   message?: string;
@@ -43,14 +43,16 @@ export class Logger {
       disposition,
       ...additionalData,
     };
-    if (this.kiosk) {
+    if (CLIENT_SIDE_LOG_SOURCES.includes(this.source)) {
       debug(logLine); // for internal debugging use log to the console
-      await this.kiosk.log(
-        JSON.stringify({
-          timeLogInitiated: Date.now().toString(),
-          ...logLine,
-        })
-      );
+      if (this.kiosk) {
+        await this.kiosk.log(
+          JSON.stringify({
+            timeLogInitiated: Date.now().toString(),
+            ...logLine,
+          })
+        );
+      }
     } else {
       // eslint-disable-next-line no-console
       console.log(logLine);

--- a/libs/logging/src/types.ts
+++ b/libs/logging/src/types.ts
@@ -15,6 +15,14 @@ export enum LogSource {
   VxBatchScanApp = 'vx-batch-scan',
   VxPrecinctScanApp = 'vx-precinct-scan',
 }
+// The following log sources are client side apps and always expect to log through window.kiosk
+// In various tests window.kiosk may not be defined and we don't want to fallback to logging with console.log
+// to avoid unnecessary log spew in the test runs.
+export const CLIENT_SIDE_LOG_SOURCES = [
+  LogSource.VxAdminApp,
+  LogSource.VxBatchScanApp,
+  LogSource.VxPrecinctScanApp,
+];
 
 export interface LogLine extends Dictionary<string> {
   source: LogSource;

--- a/libs/ui/src/hooks/useUsbDrive.test.tsx
+++ b/libs/ui/src/hooks/useUsbDrive.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
 import userEvent from '@testing-library/user-event';
+import { LogEventId, Logger, LogSource } from '@votingworks/logging';
 import {
   advanceTimersAndPromises,
   fakeKiosk,
@@ -24,22 +25,35 @@ async function waitForIOFlush(): Promise<void> {
   await advanceTimersAndPromises(usbstick.FLUSH_IO_DELAY_MS / 1000);
 }
 
+const fakeLogger = new Logger(LogSource.VxAdminApp);
+let logSpy: jest.SpyInstance;
+
 beforeEach(() => {
   delete window.kiosk;
   jest.useFakeTimers('legacy');
+  logSpy = jest.spyOn(fakeLogger, 'log').mockResolvedValue();
 });
 
 test('returns undefined status at first', async () => {
-  const { result } = renderHook(() => useUsbDrive());
+  const { result } = renderHook(() => useUsbDrive({ logger: fakeLogger }));
   expect(result.current.status).toBeUndefined();
 
   await waitForStatusUpdate();
 });
 
 test('returns notavailable if no kiosk', async () => {
-  const { result } = renderHook(() => useUsbDrive());
+  const { result } = renderHook(() => useUsbDrive({ logger: fakeLogger }));
   await waitForStatusUpdate();
   expect(result.current.status).toEqual(usbstick.UsbDriveStatus.notavailable);
+  expect(logSpy).toHaveBeenCalled();
+  expect(logSpy).toHaveBeenLastCalledWith(
+    LogEventId.USBDriveStatusUpdate,
+    'system',
+    expect.objectContaining({
+      previousStatus: undefined,
+      newStatus: 'notavailable',
+    })
+  );
 });
 
 test('returns the status after the first tick', async () => {
@@ -47,18 +61,27 @@ test('returns the status after the first tick', async () => {
   kiosk.getUsbDrives.mockResolvedValue([MOUNTED_DRIVE]);
   window.kiosk = kiosk;
 
-  const { result } = renderHook(() => useUsbDrive());
+  const { result } = renderHook(() => useUsbDrive({ logger: fakeLogger }));
   await waitForStatusUpdate();
   expect(result.current.status).toEqual(usbstick.UsbDriveStatus.mounted);
+  expect(logSpy).toHaveBeenCalled();
+  expect(logSpy).toHaveBeenLastCalledWith(
+    LogEventId.USBDriveStatusUpdate,
+    'system',
+    expect.objectContaining({
+      previousStatus: undefined,
+      newStatus: 'mounted',
+    })
+  );
 });
 
 test('full lifecycle with USBControllerButton', async () => {
   function ThisTestComponent() {
-    const usbDrive = useUsbDrive();
+    const usbDrive = useUsbDrive({ logger: fakeLogger });
     return (
       <USBControllerButton
         usbDriveStatus={usbDrive.status ?? UsbDriveStatus.absent}
-        usbDriveEject={usbDrive.eject}
+        usbDriveEject={() => usbDrive.eject('admin')}
       />
     );
   }
@@ -71,6 +94,15 @@ test('full lifecycle with USBControllerButton', async () => {
   render(<ThisTestComponent />);
   await waitForStatusUpdate();
   screen.getByText('No USB');
+  expect(logSpy).toHaveBeenCalledTimes(2);
+  expect(logSpy).toHaveBeenLastCalledWith(
+    LogEventId.USBDriveStatusUpdate,
+    'system',
+    expect.objectContaining({
+      previousStatus: undefined,
+      newStatus: 'absent',
+    })
+  );
 
   // let some time go by
   await waitForStatusUpdate();
@@ -81,15 +113,55 @@ test('full lifecycle with USBControllerButton', async () => {
   await waitForStatusUpdate();
   expect(kiosk.mountUsbDrive).toHaveBeenCalled();
   screen.getByText('Connecting…');
+  expect(logSpy).toHaveBeenCalledTimes(5);
+  expect(logSpy).toHaveBeenNthCalledWith(
+    3,
+    LogEventId.USBDriveStatusUpdate,
+    'system',
+    expect.objectContaining({
+      previousStatus: 'absent',
+      newStatus: 'present',
+    })
+  );
+  expect(logSpy).toHaveBeenNthCalledWith(
+    4,
+    LogEventId.USBDriveMountInit,
+    'system'
+  );
+  expect(logSpy).toHaveBeenNthCalledWith(
+    5,
+    LogEventId.USBDriveMounted,
+    'system',
+    expect.objectContaining({
+      disposition: 'success',
+    })
+  );
 
   // wait for it to mount
   kiosk.getUsbDrives.mockResolvedValue([MOUNTED_DRIVE]);
   await waitForStatusUpdate();
   screen.getByText('Eject USB');
+  expect(logSpy).toHaveBeenCalledTimes(6);
+  expect(logSpy).toHaveBeenNthCalledWith(
+    6,
+    LogEventId.USBDriveStatusUpdate,
+    'system',
+    expect.objectContaining({
+      previousStatus: 'present',
+      newStatus: 'mounted',
+    })
+  );
 
   // begin eject
   userEvent.click(screen.getByText('Eject USB'));
   screen.getByText('Ejecting…');
+  expect(logSpy).toHaveBeenCalledTimes(7);
+  expect(logSpy).toHaveBeenNthCalledWith(
+    7,
+    LogEventId.USBDriveEjectInit,
+    'admin'
+  );
+  await advanceTimersAndPromises();
 
   // ejecting unmounts but does not remove USB drives
   kiosk.getUsbDrives.mockResolvedValue([UNMOUNTED_DRIVE]);
@@ -97,20 +169,47 @@ test('full lifecycle with USBControllerButton', async () => {
 
   await waitForStatusUpdate();
   expect(kiosk.unmountUsbDrive).toHaveBeenCalled();
-
+  await waitForStatusUpdate();
+  await advanceTimersAndPromises();
   await waitForIOFlush();
 
   await waitForStatusUpdate();
   screen.getByText('Ejected');
+  expect(logSpy).toHaveBeenCalledTimes(9);
+  expect(logSpy).toHaveBeenNthCalledWith(
+    8,
+    LogEventId.USBDriveEjected,
+    'admin',
+    expect.objectContaining({ disposition: 'success' })
+  );
+  expect(logSpy).toHaveBeenNthCalledWith(
+    9,
+    LogEventId.USBDriveStatusUpdate,
+    'system',
+    expect.objectContaining({
+      previousStatus: 'ejecting',
+      newStatus: 'present',
+    })
+  );
 
   // remove the USB drive
   kiosk.getUsbDrives.mockResolvedValue([]);
   await waitForStatusUpdate();
   screen.getByText('No USB');
+  expect(logSpy).toHaveBeenCalledTimes(10);
+  expect(logSpy).toHaveBeenNthCalledWith(
+    10,
+    LogEventId.USBDriveStatusUpdate,
+    'system',
+    expect.objectContaining({
+      previousStatus: 'present',
+      newStatus: 'absent',
+    })
+  );
 });
 
 test('usb drive gets mounted from undefined state', async () => {
-  const { result } = renderHook(() => useUsbDrive());
+  const { result } = renderHook(() => useUsbDrive({ logger: fakeLogger }));
   expect(result.current.status).toBeUndefined();
   const kiosk = fakeKiosk();
   kiosk.getUsbDrives.mockResolvedValue([]);
@@ -124,4 +223,94 @@ test('usb drive gets mounted from undefined state', async () => {
   kiosk.getUsbDrives.mockResolvedValue([MOUNTED_DRIVE]);
   await waitForStatusUpdate();
   expect(result.current.status).toEqual(usbstick.UsbDriveStatus.mounted);
+  expect(logSpy).toHaveBeenCalledTimes(5);
+  expect(logSpy).toHaveBeenNthCalledWith(
+    2,
+    LogEventId.USBDriveStatusUpdate,
+    'system',
+    expect.objectContaining({ previousStatus: undefined, newStatus: 'present' })
+  );
+  expect(logSpy).toHaveBeenNthCalledWith(
+    3,
+    LogEventId.USBDriveMountInit,
+    'system'
+  );
+  expect(logSpy).toHaveBeenNthCalledWith(
+    4,
+    LogEventId.USBDriveMounted,
+    'system',
+    expect.objectContaining({ disposition: 'success' })
+  );
+  expect(logSpy).toHaveBeenNthCalledWith(
+    5,
+    LogEventId.USBDriveStatusUpdate,
+    'system',
+    expect.objectContaining({ previousStatus: 'present', newStatus: 'mounted' })
+  );
+});
+
+test('error in mounting gets logged as expected', async () => {
+  const { result } = renderHook(() => useUsbDrive({ logger: fakeLogger }));
+  expect(result.current.status).toBeUndefined();
+  const kiosk = fakeKiosk();
+  kiosk.getUsbDrives.mockResolvedValue([]);
+  window.kiosk = kiosk;
+  kiosk.mountUsbDrive.mockRejectedValueOnce({
+    message: 'autumn leaves falling',
+  });
+  kiosk.getUsbDrives.mockResolvedValue([UNMOUNTED_DRIVE]);
+  await waitForStatusUpdate();
+  expect(kiosk.mountUsbDrive).toHaveBeenCalled();
+  expect(result.current.status).toEqual(usbstick.UsbDriveStatus.present);
+
+  await waitForStatusUpdate();
+  expect(logSpy).toHaveBeenCalledWith(
+    LogEventId.USBDriveMounted,
+    'system',
+    expect.objectContaining({
+      disposition: 'failure',
+      error: 'autumn leaves falling',
+    })
+  );
+});
+
+test('error in unmounting gets logged as expected', async () => {
+  function ThisTestComponent() {
+    const usbDrive = useUsbDrive({ logger: fakeLogger });
+    return (
+      <USBControllerButton
+        usbDriveStatus={usbDrive.status ?? UsbDriveStatus.absent}
+        usbDriveEject={() => usbDrive.eject('pollworker')}
+      />
+    );
+  }
+  render(<ThisTestComponent />);
+  const kiosk = fakeKiosk();
+  kiosk.getUsbDrives.mockResolvedValue([]);
+  window.kiosk = kiosk;
+  kiosk.getUsbDrives.mockResolvedValue([UNMOUNTED_DRIVE]);
+  await waitForStatusUpdate();
+  expect(kiosk.mountUsbDrive).toHaveBeenCalled();
+  screen.getByText('Connecting…');
+
+  // wait for it to mount
+  kiosk.getUsbDrives.mockResolvedValue([MOUNTED_DRIVE]);
+  await waitForStatusUpdate();
+  screen.getByText('Eject USB');
+  kiosk.unmountUsbDrive.mockRejectedValue({
+    message: 'like pieces into place',
+  });
+  userEvent.click(screen.getByText('Eject USB'));
+
+  await advanceTimersAndPromises();
+  await waitForStatusUpdate();
+
+  expect(logSpy).toHaveBeenCalledWith(
+    LogEventId.USBDriveEjected,
+    'pollworker',
+    expect.objectContaining({
+      disposition: 'failure',
+      error: 'like pieces into place',
+    })
+  );
 });


### PR DESCRIPTION
Adds logging for usb-related things from the application side. Separately I'll also add system level logging when a new device is noticed. 

Since I log specific events related to mount/unmount AND I have a catchall log when the state changes some things get double logged, like after mounting there are the following three logs:
usb-drive-mount-init - when the mounting begins
usb-drive-mount-complete - when the mounting completes has a success or failure disposition
usb-drive-status-update - Status update changed from present to mounted. 

But I'm erring on the side of sometimes having excessive logs to sometimes having missed logs.

For some reason the useInterval loop in useUsbDrive sometimes runs multiple times (in the tests its consistently twice) when it first starts causing there to be multiple logs of the status changing from undefined to present, or whatever the first status change is. I'm not really sure why this happens but its somewhat out of scope of this change, and ultimately I don't think its a huge deal to have a log like that appear multiple times on occasion. 