### PR TITLE
ci(lint): fix merge-conflict violation

### DIFF
--- a/libs/eslint-plugin-vx/src/rules/gts-no-foreach.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts-no-foreach.ts
@@ -4,7 +4,6 @@ import {
   TSESTree,
 } from '@typescript-eslint/experimental-utils';
 import { strict as assert } from 'assert';
-import * as ts from 'typescript';
 import {
   CollectionType,
   createRule,


### PR DESCRIPTION
One PR made unused vars an error, the other introduced one.