### PR TITLE
build(codemods): ignore build stuff when linting

### DIFF
--- a/codemods/.eslintignore
+++ b/codemods/.eslintignore
@@ -1,0 +1,5 @@
+/coverage
+/build
+/src/**/*.js
+*.d.ts
+jest.config.js


### PR DESCRIPTION
I missed this in #1140.