### PR TITLE
feat(eslint): `gts-type-parameters`

### DIFF
--- a/libs/eslint-plugin-vx/docs/rules/gts-type-parameters.md
+++ b/libs/eslint-plugin-vx/docs/rules/gts-type-parameters.md
@@ -1,0 +1,23 @@
+# Requires type parameters are named appropriately (`vx/gts-type-parameters`)
+
+This rule is from
+[Google TypeScript Style Guide section "Identifiers"](https://google.github.io/styleguide/tsguide.html#identifiers):
+
+> Type parameters, like in `Array<T>`, may use a single upper case character
+> (`T`) or `UpperCamelCase`.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```ts
+type Optional<t> = t | undefined;
+type Optional<someType> = someType | undefined;
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+type Optional<T> = T | undefined;
+type Optional<SomeType> = SomeType | undefined;
+```

--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -54,6 +54,7 @@ export = {
     'vx/gts-parameter-properties': 'error',
     'vx/gts-safe-number-parse': 'error',
     'vx/gts-spread-like-types': 'error',
+    'vx/gts-type-parameters': 'error',
     'vx/gts-unicode-escapes': 'error',
     'vx/gts-use-optionals': 'error',
     'vx/no-array-sort-mutation': 'error',

--- a/libs/eslint-plugin-vx/src/rules/gts-type-parameters.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts-type-parameters.ts
@@ -1,0 +1,39 @@
+import { TSESTree } from '@typescript-eslint/experimental-utils';
+import { createRule } from '../util';
+
+function isValidTypeParameterName(name: string): boolean {
+  return /^([A-Z]|([A-Z][a-z\d]+)+)$/.test(name);
+}
+
+export default createRule({
+  name: 'gts-type-parameters',
+  meta: {
+    docs: {
+      description: 'Requires type parameters be named appropriately.',
+      category: 'Best Practices',
+      recommended: 'error',
+      suggestion: false,
+      requiresTypeChecking: false,
+    },
+    messages: {
+      typeParametersMustHaveSingleLetterOrUpperCamelCaseName:
+        'Type parameters, like in Array<T>, may use a single upper case character (T) or UpperCamelCase.',
+    },
+    schema: [],
+    type: 'problem',
+  },
+  defaultOptions: [],
+
+  create(context) {
+    return {
+      TSTypeParameter(node: TSESTree.TSTypeParameter): void {
+        if (!isValidTypeParameterName(node.name.name)) {
+          context.report({
+            node,
+            messageId: 'typeParametersMustHaveSingleLetterOrUpperCamelCaseName',
+          });
+        }
+      },
+    };
+  },
+});

--- a/libs/eslint-plugin-vx/src/rules/index.ts
+++ b/libs/eslint-plugin-vx/src/rules/index.ts
@@ -17,6 +17,7 @@ import gtsNoUnnecessaryHasOwnPropertyCheck from './gts-no-unnecessary-has-own-pr
 import gtsParameterProperties from './gts-parameter-properties';
 import gtsSafeNumberParse from './gts-safe-number-parse';
 import gtsSpreadLikeTypes from './gts-spread-like-types';
+import gtsTypeParameters from './gts-type-parameters';
 import gtsUnicodeEscapes from './gts-unicode-escapes';
 import gtsUseOptionals from './gts-use-optionals';
 import noArraySortMutation from './no-array-sort-mutation';
@@ -46,6 +47,7 @@ const rules: Record<
   'gts-parameter-properties': gtsParameterProperties,
   'gts-safe-number-parse': gtsSafeNumberParse,
   'gts-spread-like-types': gtsSpreadLikeTypes,
+  'gts-type-parameters': gtsTypeParameters,
   'gts-unicode-escapes': gtsUnicodeEscapes,
   'gts-use-optionals': gtsUseOptionals,
   'no-array-sort-mutation': noArraySortMutation,

--- a/libs/eslint-plugin-vx/tests/rules/gts-type-parameters.test.ts
+++ b/libs/eslint-plugin-vx/tests/rules/gts-type-parameters.test.ts
@@ -1,0 +1,58 @@
+import { ESLintUtils } from '@typescript-eslint/experimental-utils';
+import { join } from 'path';
+import rule from '../../src/rules/gts-type-parameters';
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    tsconfigRootDir: join(__dirname, '../fixtures'),
+    project: './tsconfig.json',
+  },
+  parser: '@typescript-eslint/parser',
+});
+
+ruleTester.run('gts-type-parameters', rule, {
+  valid: [
+    `type Optional<T> = T | undefined;`,
+    `type Optional<SomeType> = SomeType | undefined;`,
+    `type Optional<T0> = T0 | undefined;`,
+  ],
+  invalid: [
+    {
+      code: `type Optional<t> = t | undefined;`,
+      errors: [
+        {
+          messageId: 'typeParametersMustHaveSingleLetterOrUpperCamelCaseName',
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: `type Optional<TYPE> = TYPE | undefined;`,
+      errors: [
+        {
+          messageId: 'typeParametersMustHaveSingleLetterOrUpperCamelCaseName',
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: `type Optional<someType> = someType | undefined;`,
+      errors: [
+        {
+          messageId: 'typeParametersMustHaveSingleLetterOrUpperCamelCaseName',
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: `type Optional<Some_Type> = Some_Type | undefined;`,
+      errors: [
+        {
+          messageId: 'typeParametersMustHaveSingleLetterOrUpperCamelCaseName',
+          line: 1,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
Adds a rule to enforce this rule from Google TypeScript Style Guide "Identifiers" section:

> Type parameters, like in `Array<T>`, may use a single upper case character (`T`) or `UpperCamelCase`.

There were no violations.

Closes #1020 