### PR TITLE
style(types): enable `gts-no-default-exports`

### DIFF
--- a/libs/types/.eslintrc.json
+++ b/libs/types/.eslintrc.json
@@ -2,7 +2,8 @@
   "parserOptions": {
     "project": "./tsconfig.test.json"
   },
-  "extends": [
-    "plugin:vx/recommended"
-  ]
+  "extends": ["plugin:vx/recommended"],
+  "rules": {
+    "vx/gts-no-default-exports": "error"
+  }
 }


### PR DESCRIPTION
Just enables for `/types`. There were no violations.

Refs #1063 