### PR TITLE
style(logging): enable `gts-no-default-exports`

### DIFF
--- a/libs/logging/.eslintrc.json
+++ b/libs/logging/.eslintrc.json
@@ -2,5 +2,8 @@
   "parserOptions": {
     "project": "./tsconfig.test.json"
   },
-  "extends": ["plugin:vx/recommended"]
+  "extends": ["plugin:vx/recommended"],
+  "rules": {
+    "vx/gts-no-default-exports": "error"
+  }
 }


### PR DESCRIPTION
Enables in `/logging`. There were no violations.

Refs #1063 