### PR TITLE
style(all): `@typescript-eslint/no-explicit-any`

### DIFF
--- a/apps/bmd/src/APIMachineConfig.test.tsx
+++ b/apps/bmd/src/APIMachineConfig.test.tsx
@@ -78,9 +78,9 @@ test('machineId is empty', async () => {
 
 test('machineConfig is empty', async () => {
   const machineConfig: Provider<MachineConfig> = {
-    async get() {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return undefined as any;
+    async get(): Promise<MachineConfig> {
+      // @ts-expect-error - we're mocking an API failure
+      return undefined;
     },
   };
 

--- a/apps/bsd/src/components/Loading.tsx
+++ b/apps/bsd/src/components/Loading.tsx
@@ -24,9 +24,7 @@ export function Loading({
 }: Props): JSX.Element {
   const content = (
     <Prose>
-      {/* FIXME: Workaround for https://github.com/jamesmfriedman/rmwc/issues/501 */}
-      {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-      <ProgressEllipsis as={as as any} aria-label={`${children}.`}>
+      <ProgressEllipsis as={as} aria-label={`${children}.`}>
         {children}
       </ProgressEllipsis>
     </Prose>

--- a/apps/bsd/test/renderInAppContext.tsx
+++ b/apps/bsd/test/renderInAppContext.tsx
@@ -9,7 +9,7 @@ import { AppContext } from '../src/contexts/AppContext';
 
 interface RenderInAppContextParams {
   route?: string;
-  history?: MemoryHistory<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+  history?: MemoryHistory;
   electionDefinition?: ElectionDefinition;
   machineId?: string;
   usbDriveStatus?: usbstick.UsbDriveStatus;

--- a/apps/election-manager/src/components/Loading.tsx
+++ b/apps/election-manager/src/components/Loading.tsx
@@ -24,9 +24,7 @@ export function Loading({
 }: Props): JSX.Element {
   const content = (
     <Prose>
-      {/* FIXME: Workaround for https://github.com/jamesmfriedman/rmwc/issues/501 */}
-      {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-      <ProgressEllipsis as={as as any} aria-label={`${children}.`}>
+      <ProgressEllipsis as={as} aria-label={`${children}.`}>
         {children}
       </ProgressEllipsis>
     </Prose>

--- a/apps/election-manager/test/renderInAppContext.tsx
+++ b/apps/election-manager/test/renderInAppContext.tsx
@@ -36,7 +36,7 @@ export const eitherNeitherElectionDefinition = {
 
 interface RenderInAppContextParams {
   route?: string;
-  history?: MemoryHistory<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+  history?: MemoryHistory;
   castVoteRecordFiles?: CastVoteRecordFiles;
   electionDefinition?: ElectionDefinition;
   configuredAt?: ISO8601Timestamp;

--- a/apps/precinct-scanner/src/utils/download.test.ts
+++ b/apps/precinct-scanner/src/utils/download.test.ts
@@ -161,8 +161,9 @@ test('download with kiosk-browser with a target directory', async () => {
   const fileWriter = fakeFileWriter();
   // `writeFile` is overloaded in such a way to have different return types,
   // which confuses TS. There's no good way around this that I can find.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  kiosk.writeFile.mockResolvedValueOnce(fileWriter as any);
+  kiosk.writeFile.mockResolvedValueOnce(
+    (fileWriter as unknown) as ReturnType<KioskBrowser.Kiosk['writeFile']>
+  );
   const result = await download('/file.txt', { into: '/some/directory' });
   result.unsafeUnwrap();
   expect(kiosk.makeDirectory).toHaveBeenCalledWith('/some/directory', {

--- a/libs/test-utils/src/mockOf.ts
+++ b/libs/test-utils/src/mockOf.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+
 /**
  * Returns a properly-typed mock for an already-mocked function.
  *
@@ -14,4 +15,3 @@ export function mockOf<T extends (...args: any[]) => any>(
 ): jest.MockedFunction<T> {
   return fn as jest.MockedFunction<T>;
 }
-/* eslint-enable @typescript-eslint/no-explicit-any */


### PR DESCRIPTION
We already enable this rule, but we had several exceptions in the code. This removes those exceptions and replaces them with a better approach if needed.