### PR TITLE
feat(eslint): `gts-no-const-enum`

### DIFF
--- a/libs/eslint-plugin-vx/docs/rules/gts-no-const-enum.md
+++ b/libs/eslint-plugin-vx/docs/rules/gts-no-const-enum.md
@@ -1,0 +1,28 @@
+# Disallows use of `const enum`; use `enum` instead. (`vx/gts-no-const-enum`)
+
+This rule is from
+[Google TypeScript Style Guide section "Enums"](https://google.github.io/styleguide/tsguide.html#enums):
+
+> Always use `enum` and not `const enum`. TypeScript enums already cannot be
+> mutated; `const enum` is a separate language feature related to optimization
+> that makes the `enum` invisible to JavaScript users of the module.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```ts
+const enum BallotType {
+  Standard = 0,
+  Absentee = 1,
+}
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+enum BallotType {
+  Standard = 0,
+  Absentee = 1,
+}
+```

--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -40,6 +40,7 @@ export = {
     'vx/gts-func-style': 'error',
     'vx/gts-identifiers-use-allowed-character': 'error',
     'vx/gts-no-array-constructor': 'error',
+    'vx/gts-no-const-enum': 'error',
     // TODO: enable this everywhere
     'vx/gts-no-default-exports': 'off',
     'vx/gts-no-dollar-sign-names': 'error',

--- a/libs/eslint-plugin-vx/src/rules/gts-no-const-enum.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts-no-const-enum.ts
@@ -1,0 +1,49 @@
+import { TSESTree } from '@typescript-eslint/experimental-utils';
+import { strict as assert } from 'assert';
+import { createRule } from '../util';
+
+export default createRule({
+  name: 'gts-no-const-enum',
+  meta: {
+    docs: {
+      description: 'Disallows use of `const enum`; use `enum` instead.',
+      category: 'Best Practices',
+      recommended: 'error',
+      suggestion: false,
+      requiresTypeChecking: false,
+    },
+    messages: {
+      noConstEnum: 'Use `enum` instead of `const enum`.',
+    },
+    fixable: 'code',
+    schema: [],
+    type: 'problem',
+  },
+  defaultOptions: [],
+
+  create(context) {
+    const sourceCode = context.getSourceCode();
+
+    return {
+      TSEnumDeclaration(node: TSESTree.TSEnumDeclaration): void {
+        if (node.const) {
+          context.report({
+            node,
+            messageId: 'noConstEnum',
+            fix: (fixer) => {
+              const [constToken, enumToken] = sourceCode.getFirstTokens(node, {
+                count: 2,
+              });
+              assert.equal(constToken?.value, 'const');
+              assert.equal(enumToken?.value, 'enum');
+              return fixer.removeRange([
+                constToken.range[0],
+                enumToken.range[0],
+              ]);
+            },
+          });
+        }
+      },
+    };
+  },
+});

--- a/libs/eslint-plugin-vx/src/rules/index.ts
+++ b/libs/eslint-plugin-vx/src/rules/index.ts
@@ -4,6 +4,7 @@ import gtsDirectModuleExportAccessOnly from './gts-direct-module-export-access-o
 import gtsFuncStyle from './gts-func-style';
 import gtsIdentifiersUseAllowedCharacters from './gts-identifiers-use-allowed-characters';
 import gtsNoArrayConstructor from './gts-no-array-constructor';
+import gtsNoConstEnum from './gts-no-const-enum';
 import gtsNoDefaultExports from './gts-no-default-exports';
 import gtsNoDollarSignNames from './gts-no-dollar-sign-names';
 import gtsNoForInLoop from './gts-no-for-in-loop';
@@ -32,6 +33,7 @@ const rules: Record<
   'gts-func-style': gtsFuncStyle,
   'gts-identifiers-use-allowed-character': gtsIdentifiersUseAllowedCharacters,
   'gts-no-array-constructor': gtsNoArrayConstructor,
+  'gts-no-const-enum': gtsNoConstEnum,
   'gts-no-default-exports': gtsNoDefaultExports,
   'gts-no-dollar-sign-names': gtsNoDollarSignNames,
   'gts-no-foreach': gtsNoForeach,

--- a/libs/eslint-plugin-vx/tests/rules/gts-no-const-enum.test.ts
+++ b/libs/eslint-plugin-vx/tests/rules/gts-no-const-enum.test.ts
@@ -1,0 +1,23 @@
+import { ESLintUtils } from '@typescript-eslint/experimental-utils';
+import { join } from 'path';
+import rule from '../../src/rules/gts-no-const-enum';
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    tsconfigRootDir: join(__dirname, '../fixtures'),
+    project: './tsconfig.json',
+  },
+  parser: '@typescript-eslint/parser',
+});
+
+ruleTester.run('gts-no-const-enum', rule, {
+  valid: [`enum A {};`],
+  invalid: [
+    {
+      code: `const enum A {};`,
+      errors: [{ messageId: 'noConstEnum', line: 1 }],
+      output: `enum A {};`,
+    },
+  ],
+});


### PR DESCRIPTION
Disallows `const enum` per https://google.github.io/styleguide/tsguide.html#enums. We already did not use this.

Closes #1058 