### PR TITLE
style(lsd): remove `@ts-ignore` directive

### DIFF
--- a/libs/lsd/src/index.test.ts
+++ b/libs/lsd/src/index.test.ts
@@ -50,9 +50,7 @@ test('simple image', () => {
 });
 
 // `global.gc` is only defined when `--expose-gc` is provided to `node`.
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-const gctest = global.gc ? test : test.skip;
+const gctest = (global as { gc?: VoidFunction }).gc ? test : test.skip;
 
 gctest('garbage collection reclaims buffer', () => {
   const iterations = 20;


### PR DESCRIPTION
It's disallowed by `@typescript-eslint/ban-ts-comment` already, and GTS requires that we remove it. Turns out this one is no longer needed. Instead, where needed, we should use `@ts-expect-error`.

Closes #1054 