### PR TITLE
style(all): `readonly` class fields

### DIFF
--- a/apps/bmd/src/utils/ScreenReader/AriaScreenReader.ts
+++ b/apps/bmd/src/utils/ScreenReader/AriaScreenReader.ts
@@ -7,7 +7,7 @@ export class AriaScreenReader implements ScreenReader {
   /**
    * @param tts A text-to-speech engine to use to speak aloud.
    */
-  constructor(private tts: TextToSpeech) {}
+  constructor(private readonly tts: TextToSpeech) {}
 
   /**
    * Call this with an event target when a focus event occurs. Resolves when speaking is done.

--- a/apps/bmd/src/utils/ScreenReader/SpeechSynthesisTextToSpeech.ts
+++ b/apps/bmd/src/utils/ScreenReader/SpeechSynthesisTextToSpeech.ts
@@ -3,7 +3,7 @@ import { SpeakOptions, TextToSpeech, VoiceSelector } from '../../config/types';
 export class SpeechSynthesisTextToSpeech implements TextToSpeech {
   private muted = false;
 
-  constructor(private getVoice?: VoiceSelector) {
+  constructor(private readonly getVoice?: VoiceSelector) {
     // Prime the speech synthesis engine. This call will likely return an empty
     // array, but future ones should work properly.
     speechSynthesis.getVoices();

--- a/apps/election-manager/src/utils/DownloadableArchive.ts
+++ b/apps/election-manager/src/utils/DownloadableArchive.ts
@@ -11,7 +11,7 @@ export class DownloadableArchive {
   private zip?: ZipStream;
   private endPromise?: Promise<void>;
 
-  constructor(private kiosk = window.kiosk) {}
+  constructor(private readonly kiosk = window.kiosk) {}
 
   private getKiosk(): KioskBrowser.Kiosk {
     assert(this.kiosk);

--- a/apps/module-scan/src/LoopScanner.ts
+++ b/apps/module-scan/src/LoopScanner.ts
@@ -89,7 +89,7 @@ export class LoopScanner implements Scanner {
   /**
    * @param batches lists of front/back pairs of sheets to scan
    */
-  constructor(private batches: readonly Batch[]) {}
+  constructor(private readonly batches: readonly Batch[]) {}
 
   async getStatus(): Promise<ScannerStatus> {
     return ScannerStatus.Unknown;

--- a/apps/module-scan/src/cli/render-pages.test.ts
+++ b/apps/module-scan/src/cli/render-pages.test.ts
@@ -149,8 +149,8 @@ test('fails when a DB has no election', async () => {
   await fs.mkdir(tmpDir);
   const store = await Store.fileStore(join(tmpDir, 'ballots.db'));
 
-  expect(await main([store.dbPath], { stdout, stderr })).toEqual(1);
+  expect(await main([store.getDbPath()], { stdout, stderr })).toEqual(1);
   expect(stderr.toString()).toEqual(
-    `✘ ${store.dbPath} has no election definition\n`
+    `✘ ${store.getDbPath()} has no election definition\n`
   );
 });

--- a/apps/module-scan/src/cli/retry-scan/index.ts
+++ b/apps/module-scan/src/cli/retry-scan/index.ts
@@ -132,12 +132,14 @@ export async function retryScan(
 
   await pool.callAll({
     action: 'configure',
-    dbPath: input.store.dbPath,
+    dbPath: input.store.getDbPath(),
   });
   listeners?.interpreterLoaded?.();
 
   function absolutify(path: string): string {
-    return isAbsolute(path) ? path : resolve(input.store.dbPath, '..', path);
+    return isAbsolute(path)
+      ? path
+      : resolve(input.store.getDbPath(), '..', path);
   }
 
   await Promise.all(
@@ -195,7 +197,7 @@ export async function retryScan(
           ].map(async ([scan, qrcode], i) => {
             const imagePath = isAbsolute(scan.originalFilename)
               ? scan.originalFilename
-              : resolve(input.store.dbPath, '..', scan.originalFilename);
+              : resolve(input.store.getDbPath(), '..', scan.originalFilename);
             const rescan = (await pool.call({
               action: 'interpret',
               sheetId: id,

--- a/apps/module-scan/src/importer.test.ts
+++ b/apps/module-scan/src/importer.test.ts
@@ -178,7 +178,7 @@ test('restoreConfig reconfigures the interpreter worker', async () => {
   await importer.restoreConfig();
   expect(workerCall).toHaveBeenCalledWith({
     action: 'configure',
-    dbPath: workspace.store.dbPath,
+    dbPath: workspace.store.getDbPath(),
   });
   await importer.unconfigure();
 });
@@ -307,7 +307,7 @@ test('manually importing files', async () => {
 
   expect(workerCall).toHaveBeenNthCalledWith(1, {
     action: 'configure',
-    dbPath: workspace.store.dbPath,
+    dbPath: workspace.store.getDbPath(),
   });
 
   expect((await workspace.store.getBallotFilenames(sheetId, 'front'))!).toEqual(

--- a/apps/module-scan/src/importer.ts
+++ b/apps/module-scan/src/importer.ts
@@ -99,7 +99,7 @@ export class Importer {
       this.workerPool.start();
       await this.workerPool.callAll({
         action: 'configure',
-        dbPath: this.workspace.store.dbPath,
+        dbPath: this.workspace.store.getDbPath(),
       });
       this.interpreterReady = true;
     }

--- a/apps/module-scan/src/store.ts
+++ b/apps/module-scan/src/store.ts
@@ -73,7 +73,11 @@ export class Store {
   /**
    * @param dbPath a file system path, or ":memory:" for an in-memory database
    */
-  private constructor(readonly dbPath: string) {}
+  private constructor(private readonly dbPath: string) {}
+
+  getDbPath(): string {
+    return this.dbPath;
+  }
 
   /**
    * Gets the sha256 digest of the current schema file.
@@ -254,12 +258,12 @@ export class Store {
     return new Promise((resolve) => {
       db.close(async () => {
         try {
-          debug('deleting the database file at %s', this.dbPath);
-          await fs.unlink(this.dbPath);
+          debug('deleting the database file at %s', this.getDbPath());
+          await fs.unlink(this.getDbPath());
         } catch (error) {
           debug(
             'failed to delete database file %s: %s',
-            this.dbPath,
+            this.getDbPath(),
             error.message
           );
         }
@@ -270,9 +274,9 @@ export class Store {
   }
 
   async dbConnect(): Promise<sqlite3.Database> {
-    debug('connecting to the database at %s', this.dbPath);
+    debug('connecting to the database at %s', this.getDbPath());
     this.db = await new Promise<sqlite3.Database>((resolve, reject) => {
-      const db = new sqlite3.Database(this.dbPath, (err: unknown) => {
+      const db = new sqlite3.Database(this.getDbPath(), (err: unknown) => {
         if (err) {
           reject(err);
         } else {
@@ -292,7 +296,7 @@ export class Store {
    * Creates the database including its tables.
    */
   async dbCreate(): Promise<sqlite3.Database> {
-    debug('creating the database at %s', this.dbPath);
+    debug('creating the database at %s', this.getDbPath());
     const db = await this.dbConnect();
     await this.dbExecAsync(await fs.readFile(SchemaPath, 'utf-8'));
     return db;
@@ -656,8 +660,8 @@ export class Store {
     }
 
     return {
-      original: normalizeAndJoin(dirname(this.dbPath), row.original),
-      normalized: normalizeAndJoin(dirname(this.dbPath), row.normalized),
+      original: normalizeAndJoin(dirname(this.getDbPath()), row.original),
+      normalized: normalizeAndJoin(dirname(this.getDbPath()), row.normalized),
     };
   }
 

--- a/apps/module-scan/src/workers/interpret.ts
+++ b/apps/module-scan/src/workers/interpret.ts
@@ -41,7 +41,7 @@ export let interpreter: Interpreter | undefined;
 export async function configure(store: Store): Promise<void> {
   interpreter = undefined;
 
-  debug('configuring from %s', store.dbPath);
+  debug('configuring from %s', store.getDbPath());
   const electionDefinition = await store.getElectionDefinition();
 
   if (!electionDefinition) {

--- a/libs/ballot-encoder/src/bits/BitCursor.ts
+++ b/libs/ballot-encoder/src/bits/BitCursor.ts
@@ -49,7 +49,7 @@ export class BitCursor {
     return new BitCursor().set(this.combinedBitOffset);
   }
 
-  static uint8Masks = (makeMasks(Uint8Size) as unknown) as readonly [
+  static readonly uint8Masks = (makeMasks(Uint8Size) as unknown) as readonly [
     Uint8,
     Uint8,
     Uint8,

--- a/libs/ballot-encoder/src/bits/BitReader.ts
+++ b/libs/ballot-encoder/src/bits/BitReader.ts
@@ -13,7 +13,7 @@ export class BitReader {
   /**
    * @param data a buffer to read data from
    */
-  constructor(private data: Uint8Array) {}
+  constructor(private readonly data: Uint8Array) {}
 
   /**
    * Reads a Uint1 and moves the internal cursor forward one bit.
@@ -131,7 +131,7 @@ export class BitReader {
     const codes = new Uint8Array(lengthToRead);
 
     for (let i = 0; i < lengthToRead; i += 1) {
-      codes.set([this.readUint({ size: encoding.bitsPerElement })], i);
+      codes.set([this.readUint({ size: encoding.getBitsPerElement() })], i);
     }
 
     return encoding.decode(codes);

--- a/libs/ballot-encoder/src/bits/BitWriter.ts
+++ b/libs/ballot-encoder/src/bits/BitWriter.ts
@@ -186,7 +186,7 @@ export class BitWriter {
 
     // write content
     for (const code of codes) {
-      this.writeUint(code, { size: encoding.bitsPerElement });
+      this.writeUint(code, { size: encoding.getBitsPerElement() });
     }
 
     return this;

--- a/libs/ballot-encoder/src/bits/encoding.ts
+++ b/libs/ballot-encoder/src/bits/encoding.ts
@@ -8,7 +8,7 @@ import { sizeof } from './utils';
  * @see `BitReader#readString`
  */
 export interface Encoding {
-  readonly bitsPerElement: number;
+  getBitsPerElement(): number;
   encode(string: string): Uint8Array;
   decode(data: Uint8Array): string;
 }
@@ -17,7 +17,9 @@ export interface Encoding {
  * Default encoding to use for `BitReader` and `BitWriter`.
  */
 export const UTF8Encoding: Encoding = {
-  bitsPerElement: Uint8Size,
+  getBitsPerElement(): number {
+    return Uint8Size;
+  },
 
   /**
    * Encodes a string as UTF-8 code points.
@@ -49,14 +51,18 @@ export class CustomEncoding implements Encoding {
    * The maximum character code representable by this class.
    */
   static MAX_CODE = (1 << (Uint8Array.BYTES_PER_ELEMENT * Uint8Size)) - 1;
-  readonly bitsPerElement: number;
+  private readonly bitsPerElement: number;
 
   /**
    * @param chars a string of representable characters without duplicates
    */
-  constructor(readonly chars: string) {
+  constructor(private readonly chars: string) {
     CustomEncoding.validateChars(chars);
     this.bitsPerElement = sizeof(chars.length - 1);
+  }
+
+  getChars(): string {
+    return this.chars;
   }
 
   private static validateChars(chars: string): void {
@@ -78,6 +84,10 @@ export class CustomEncoding implements Encoding {
         );
       }
     }
+  }
+
+  getBitsPerElement(): number {
+    return this.bitsPerElement;
   }
 
   /**

--- a/libs/ballot-encoder/test/utils.ts
+++ b/libs/ballot-encoder/test/utils.ts
@@ -3,8 +3,8 @@ import { WriteInEncoding } from '../src';
 import { BitReader, BitWriter, toUint8, Uint1, Uint8 } from '../src/bits';
 
 export const writeInChar = fc
-  .integer(0, WriteInEncoding.chars.length)
-  .map((index) => WriteInEncoding.chars[index] ?? '');
+  .integer(0, WriteInEncoding.getChars().length)
+  .map((index) => WriteInEncoding.getChars()[index] ?? '');
 
 export interface BooleanWritable {
   readonly type: 'boolean';

--- a/libs/eslint-plugin-vx/docs/rules/gts-no-public-class-fields.md
+++ b/libs/eslint-plugin-vx/docs/rules/gts-no-public-class-fields.md
@@ -1,0 +1,40 @@
+# Disallows public class fields. (`vx/gts-no-public-class-fields`)
+
+This rule is derived from
+[Google TypeScript Style Guide section "Class Members"](https://google.github.io/styleguide/tsguide.html#use-readonly):
+
+> Mark properties that are never reassigned outside of the constructor with the
+> readonly modifier (these need not be deeply immutable).
+
+This rule doesn't actually enforce the rule from GTS, but in combination with
+`@typescript-eslint/prefer-readonly` it effectively does.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```ts
+class Box<T> {
+  value?: T;
+
+  constructor(value: T) {
+    this.value = value;
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+class Box<T> {
+  constructor(private value: T) {}
+
+  get(): T {
+    return value;
+  }
+
+  set(newValue: T) {
+    this.value = newValue;
+  }
+}
+```

--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -67,6 +67,7 @@ export = {
     '@typescript-eslint/no-non-null-assertion': 'error',
     '@typescript-eslint/no-unnecessary-type-assertion': 'error',
     '@typescript-eslint/no-unused-vars': 'error',
+    '@typescript-eslint/prefer-readonly': 'error',
     'class-methods-use-this': 'off',
     'consistent-return': 'off',
     // be stricter than eslint-config-airbnb which allows `== null`

--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -48,6 +48,7 @@ export = {
     'vx/gts-no-import-export-type': ['error', { allowReexport: true }],
     'vx/gts-no-object-literal-type-assertions': 'error',
     'vx/gts-no-private-fields': 'error',
+    'vx/gts-no-public-class-fields': 'error',
     'vx/gts-no-public-modifier': 'error',
     'vx/gts-no-return-type-only-generics': 'error',
     'vx/gts-no-unnecessary-has-own-property-check': 'warn',

--- a/libs/eslint-plugin-vx/src/rules/gts-no-public-class-fields.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts-no-public-class-fields.ts
@@ -1,0 +1,43 @@
+import { TSESTree } from '@typescript-eslint/experimental-utils';
+import { createRule } from '../util';
+
+export default createRule({
+  name: 'gts-no-public-class-fields',
+  meta: {
+    docs: {
+      description: 'Disallows public class fields.',
+      category: 'Best Practices',
+      recommended: 'error',
+      suggestion: false,
+      requiresTypeChecking: false,
+    },
+    messages: {
+      noPublicClassFields:
+        'Class fields must be protected or private, not public.',
+    },
+    schema: [],
+    type: 'problem',
+  },
+  defaultOptions: [],
+
+  create(context) {
+    function check(
+      node: TSESTree.ClassProperty | TSESTree.TSParameterProperty
+    ): void {
+      if (
+        !node.static &&
+        node.accessibility !== 'protected' &&
+        node.accessibility !== 'private'
+      ) {
+        context.report({
+          node,
+          messageId: 'noPublicClassFields',
+        });
+      }
+    }
+    return {
+      ClassProperty: check,
+      TSParameterProperty: check,
+    };
+  },
+});

--- a/libs/eslint-plugin-vx/src/rules/index.ts
+++ b/libs/eslint-plugin-vx/src/rules/index.ts
@@ -11,6 +11,7 @@ import gtsNoForeach from './gts-no-foreach';
 import gtsNoImportExportType from './gts-no-import-export-type';
 import gtsNoObjectLiteralTypeAssertions from './gts-no-object-literal-type-assertions';
 import gtsNoPrivateFields from './gts-no-private-fields';
+import gtsNoPublicClassFields from './gts-no-public-class-fields';
 import gtsNoPublicModifier from './gts-no-public-modifier';
 import gtsNoReturnTypeOnlyGenerics from './gts-no-return-type-only-generics';
 import gtsNoUnnecessaryHasOwnPropertyCheck from './gts-no-unnecessary-has-own-property-check';
@@ -39,6 +40,7 @@ const rules: Record<
   'gts-no-import-export-type': gtsNoImportExportType,
   'gts-no-object-literal-type-assertions': gtsNoObjectLiteralTypeAssertions,
   'gts-no-private-fields': gtsNoPrivateFields,
+  'gts-no-public-class-fields': gtsNoPublicClassFields,
   'gts-no-public-modifier': gtsNoPublicModifier,
   'gts-no-return-type-only-generics': gtsNoReturnTypeOnlyGenerics,
   'gts-no-unnecessary-has-own-property-check':

--- a/libs/eslint-plugin-vx/tests/rules/gts-no-public-class-fields.test.ts
+++ b/libs/eslint-plugin-vx/tests/rules/gts-no-public-class-fields.test.ts
@@ -1,0 +1,93 @@
+import { ESLintUtils } from '@typescript-eslint/experimental-utils';
+import { join } from 'path';
+import rule from '../../src/rules/gts-no-public-class-fields';
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    tsconfigRootDir: join(__dirname, '../fixtures'),
+    project: './tsconfig.json',
+  },
+  parser: '@typescript-eslint/parser',
+});
+
+ruleTester.run('gts-no-public-class-fields', rule, {
+  valid: [
+    `class Nothing {}`,
+    `
+      class Box<T> {
+        private value?: T;
+
+        getValue(): T {
+          return this.value;
+        }
+
+        setValue(newValue: T): void {
+          this.value = newValue;
+        }
+      }
+    `,
+    `
+      class Box<T> {
+        protected value?: T;
+
+        getValue(): T {
+          return this.value;
+        }
+
+        setValue(newValue: T): void {
+          this.value = newValue;
+        }
+      }
+    `,
+    `
+      class Box<T> {
+        constructor(private value?: T) {}
+
+        getValue(): T {
+          return this.value;
+        }
+
+        setValue(newValue: T): void {
+          this.value = newValue;
+        }
+      }
+    `,
+    `
+      class Box<T> {
+        constructor(protected value?: T) {}
+
+        getValue(): T {
+          return this.value;
+        }
+
+        setValue(newValue: T): void {
+          this.value = newValue;
+        }
+      }
+    `,
+    `
+    class One {
+      get value() {
+        return 1;
+      }
+
+      getValue() {
+        return 1;
+      }
+
+      static readonly ONE = 1;
+    }
+  `,
+  ],
+  invalid: [
+    {
+      code: `class Box<T> { value?: T }`,
+      errors: [{ messageId: 'noPublicClassFields', line: 1 }],
+    },
+    {
+      code: `class Box<T> { constructor(public value?: T) {} }`,
+      errors: [{ messageId: 'noPublicClassFields', line: 1 }],
+    },
+  ],
+});

--- a/libs/hmpb-interpreter/src/utils/KeyedMap.ts
+++ b/libs/hmpb-interpreter/src/utils/KeyedMap.ts
@@ -1,7 +1,7 @@
 export class KeyedMap<Key, Value, ResolvedKey = string> {
   private map = new Map<ResolvedKey, Value>();
 
-  constructor(private resolveKey: (key: Key) => ResolvedKey) {}
+  constructor(private readonly resolveKey: (key: Key) => ResolvedKey) {}
 
   has(key: Key): boolean {
     return this.map.has(this.resolveKey(key));

--- a/libs/hmpb-interpreter/src/utils/VisitedPoints.ts
+++ b/libs/hmpb-interpreter/src/utils/VisitedPoints.ts
@@ -1,7 +1,7 @@
 export class VisitedPoints {
   private data: Uint8Array[];
 
-  constructor(private width: number, height: number) {
+  constructor(private readonly width: number, height: number) {
     this.data = Array.from({ length: height });
   }
 

--- a/libs/hmpb-interpreter/test/fixtures.ts
+++ b/libs/hmpb-interpreter/test/fixtures.ts
@@ -15,7 +15,7 @@ export function adjacentMetadataFile(imagePath: string): string {
 }
 
 export class Fixture implements Input {
-  constructor(private basePath: string) {}
+  constructor(private readonly basePath: string) {}
 
   id(): string {
     return this.filePath();

--- a/libs/lsd/src/index.test.ts
+++ b/libs/lsd/src/index.test.ts
@@ -50,9 +50,7 @@ test('simple image', () => {
 });
 
 // `global.gc` is only defined when `--expose-gc` is provided to `node`.
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-const gctest = global.gc ? test : test.skip;
+const gctest = (global as { gc?: VoidFunction }).gc ? test : test.skip;
 
 gctest('garbage collection reclaims buffer', () => {
   const iterations = 20;

--- a/libs/utils/src/Hardware/KioskHardware.ts
+++ b/libs/utils/src/Hardware/KioskHardware.ts
@@ -5,7 +5,7 @@ import { MemoryHardware } from './MemoryHardware';
  * Implements the `Hardware` API by accessing it through the kiosk.
  */
 export class KioskHardware extends MemoryHardware {
-  constructor(private kiosk: KioskBrowser.Kiosk) {
+  constructor(private readonly kiosk: KioskBrowser.Kiosk) {
     super();
   }
 
@@ -33,11 +33,13 @@ export class KioskHardware extends MemoryHardware {
    * first subscriber receives a new set (e.g. {mouse, keyboard, flash drive}).
    * New subscribers immediately receive the same current set.
    */
-  devices = this.kiosk.devices;
+  // eslint-disable-next-line vx/gts-no-public-class-fields
+  readonly devices = this.kiosk.devices;
 
   /**
    * Gets an observable that yields the current set of printers as printers are
    * configured or devices are added or removed.
    */
-  printers = this.kiosk.printers;
+  // eslint-disable-next-line vx/gts-no-public-class-fields
+  readonly printers = this.kiosk.printers;
 }

--- a/libs/utils/src/Hardware/MemoryHardware.ts
+++ b/libs/utils/src/Hardware/MemoryHardware.ts
@@ -158,7 +158,9 @@ export class MemoryHardware implements Hardware {
   /**
    * Subscribe to USB device updates.
    */
-  devices: Observable<Iterable<KioskBrowser.Device>> = this.devicesSubject;
+  // eslint-disable-next-line vx/gts-no-public-class-fields
+  readonly devices: Observable<Iterable<KioskBrowser.Device>> =
+    this.devicesSubject;
 
   private printersSubject = new BehaviorSubject<
     Iterable<KioskBrowser.PrinterInfo>
@@ -167,7 +169,8 @@ export class MemoryHardware implements Hardware {
   /**
    * Subscribe to printer updates.
    */
-  printers: Observable<Iterable<KioskBrowser.PrinterInfo>> =
+  // eslint-disable-next-line vx/gts-no-public-class-fields
+  readonly printers: Observable<Iterable<KioskBrowser.PrinterInfo>> =
     this.printersSubject;
 
   /**

--- a/libs/utils/src/Storage/KioskStorage.ts
+++ b/libs/utils/src/Storage/KioskStorage.ts
@@ -5,7 +5,7 @@ import { Storage } from '../types';
  * Implements the storage API using Kiosk Storage as the backing store.
  */
 export class KioskStorage implements Storage {
-  constructor(readonly kiosk: KioskBrowser.Kiosk) {
+  constructor(private readonly kiosk: KioskBrowser.Kiosk) {
     assert(kiosk);
   }
 

--- a/libs/utils/src/types.ts
+++ b/libs/utils/src/types.ts
@@ -186,12 +186,12 @@ export interface Hardware {
   /**
    * Subscribe to USB device updates.
    */
-  devices: Observable<Iterable<KioskBrowser.Device>>;
+  readonly devices: Observable<Iterable<KioskBrowser.Device>>;
 
   /**
    * Subscribe to USB device updates.
    */
-  printers: Observable<Iterable<KioskBrowser.PrinterInfo>>;
+  readonly printers: Observable<Iterable<KioskBrowser.PrinterInfo>>;
 }
 
 export interface PrintOptions extends KioskBrowser.PrintOptions {


### PR DESCRIPTION
This one was a little less straightfoward than usual. I wanted to enforce this:

> Mark properties that are never reassigned outside of the constructor with the `readonly` modifier (these need not be deeply immutable).

But doing that as written is pretty challenging. Instead, I opted to make all class properties be private and then enable the `@typescript-eslint/prefer-readonly` rule which already enforces that private properties are readonly if they are never reassigned.