### PR TITLE
feat(eslint): `gts-no-jsdoc-override`

### DIFF
--- a/libs/eslint-plugin-vx/docs/rules/gts-no-jsdoc-override.md
+++ b/libs/eslint-plugin-vx/docs/rules/gts-no-jsdoc-override.md
@@ -1,0 +1,35 @@
+# Disallows `@override` JSDoc directive (`vx/gts-no-jsdoc-override`)
+
+This rule is from
+[Google TypeScript Style Guide section "Documentation & Comments"](https://google.github.io/styleguide/tsguide.html#do-not-use-override):
+
+> Do not use `@override` in TypeScript source code.
+>
+> `@override` is not enforced by the compiler, which is surprising and leads to
+> annotations and implementation going out of sync. Including it purely for
+> documentation purposes is confusing.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```ts
+class Foo extends Bar {
+  /**
+   * @override
+   */
+  doSomething(): void {
+    // …
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+class Foo extends Bar {
+  override doSomething(): void {
+    // …
+  }
+}
+```

--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -46,6 +46,7 @@ export = {
     'vx/gts-no-foreach': 'error',
     'vx/gts-no-for-in-loop': 'error',
     'vx/gts-no-import-export-type': ['error', { allowReexport: true }],
+    'vx/gts-no-jsdoc-override': 'error',
     'vx/gts-no-object-literal-type-assertions': 'error',
     'vx/gts-no-private-fields': 'error',
     'vx/gts-no-public-modifier': 'error',

--- a/libs/eslint-plugin-vx/src/rules/gts-no-jsdoc-override.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts-no-jsdoc-override.ts
@@ -1,0 +1,43 @@
+import { AST_TOKEN_TYPES } from '@typescript-eslint/experimental-utils';
+import { createRule } from '../util';
+
+export default createRule({
+  name: 'gts-no-jsdoc-override',
+  meta: {
+    docs: {
+      description: 'Disallows JSDoc `@override` directive.',
+      category: 'Best Practices',
+      recommended: 'error',
+      suggestion: false,
+      requiresTypeChecking: false,
+    },
+    fixable: 'code',
+    messages: {
+      noJSDocOverride:
+        'Do not use `@override`; if applicable, use the TypeScript `override` keyword.',
+    },
+    schema: [],
+    type: 'problem',
+  },
+  defaultOptions: [],
+
+  create(context) {
+    const sourceCode = context.getSourceCode();
+
+    return {
+      Program(): void {
+        for (const comment of sourceCode.getAllComments()) {
+          if (
+            comment.type === AST_TOKEN_TYPES.Block &&
+            comment.value.includes('@override')
+          ) {
+            context.report({
+              node: comment,
+              messageId: 'noJSDocOverride',
+            });
+          }
+        }
+      },
+    };
+  },
+});

--- a/libs/eslint-plugin-vx/src/rules/index.ts
+++ b/libs/eslint-plugin-vx/src/rules/index.ts
@@ -9,6 +9,7 @@ import gtsNoDollarSignNames from './gts-no-dollar-sign-names';
 import gtsNoForInLoop from './gts-no-for-in-loop';
 import gtsNoForeach from './gts-no-foreach';
 import gtsNoImportExportType from './gts-no-import-export-type';
+import gtsNoJsdocOverride from './gts-no-jsdoc-override';
 import gtsNoObjectLiteralTypeAssertions from './gts-no-object-literal-type-assertions';
 import gtsNoPrivateFields from './gts-no-private-fields';
 import gtsNoPublicModifier from './gts-no-public-modifier';
@@ -37,6 +38,7 @@ const rules: Record<
   'gts-no-foreach': gtsNoForeach,
   'gts-no-for-in-loop': gtsNoForInLoop,
   'gts-no-import-export-type': gtsNoImportExportType,
+  'gts-no-jsdoc-override': gtsNoJsdocOverride,
   'gts-no-object-literal-type-assertions': gtsNoObjectLiteralTypeAssertions,
   'gts-no-private-fields': gtsNoPrivateFields,
   'gts-no-public-modifier': gtsNoPublicModifier,

--- a/libs/eslint-plugin-vx/tests/rules/gts-no-jsdoc-override.test.ts
+++ b/libs/eslint-plugin-vx/tests/rules/gts-no-jsdoc-override.test.ts
@@ -1,0 +1,40 @@
+import { ESLintUtils } from '@typescript-eslint/experimental-utils';
+import * as ts from 'typescript';
+import { join } from 'path';
+import rule from '../../src/rules/gts-no-jsdoc-override';
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    tsconfigRootDir: join(__dirname, '../fixtures'),
+    project: './tsconfig.json',
+  },
+  parser: '@typescript-eslint/parser',
+});
+
+const tsSupportsOverride = 'OverrideKeyword' in ts.SyntaxKind;
+
+ruleTester.run('gts-no-jsdoc-override', rule, {
+  valid: [
+    tsSupportsOverride
+      ? `
+      class Foo extends Bar {
+        override doSomething() {}
+      }
+    `
+      : `
+      class Foo extends bar {
+        doSomething() {}
+      }
+    `,
+    `
+      // ignore line comments @override
+    `,
+  ],
+  invalid: [
+    {
+      code: '/** @override */',
+      errors: [{ messageId: 'noJSDocOverride', line: 1 }],
+    },
+  ],
+});


### PR DESCRIPTION
Enforces [this GTS rule from "Comments & Documentation"](https://google.github.io/styleguide/tsguide.html#do-not-use-override):

> Do not use `@override` in TypeScript source code.
>
> `@override` is not enforced by the compiler, which is surprising and leads to annotations and implementation going out of sync. Including it purely for documentation purposes is confusing.

Closes #1032