### PR TITLE
feat(election-manager): add startup log

### DIFF
--- a/apps/election-manager/prodserver/index.js
+++ b/apps/election-manager/prodserver/index.js
@@ -7,10 +7,12 @@
 
 const express = require('express')
 const path = require('path')
+const { Logger, LogSource, LogEventId } = require('@votingworks/logging')
 
 const proxy = require('./setupProxy')
 const app = express()
 const port = 3000
+const logger = new Logger(LogSource.VxAdminServer)
 
 app.use((req, res, next) => {
   res.set('Cache-Control', 'no-store, no-cache, must-revalidate, private')
@@ -24,4 +26,14 @@ app.get('*', (req, res) => {
   res.sendFile(path.join(__dirname, '../build/index.html'))
 })
 
-app.listen(port, () => console.log(`Election Manager running at http://localhost:${port}/`))
+app.listen(port, () => {
+  logger.log(LogEventId.ApplicationStartup, 'system', {
+    message: `Election Manager running at http://localhost:${port}/`,
+    disposition: 'success',
+  })
+}).on('error', error => {
+  logger.log(LogEventId.ApplicationStartup, 'system', {
+    message: `Error in starting Election Manager: ${error.message}`,
+    disposition: 'failure',
+  })
+})

--- a/apps/election-manager/src/AppRoot.tsx
+++ b/apps/election-manager/src/AppRoot.tsx
@@ -99,6 +99,7 @@ export function AppRoot({
     () => new Logger(LogSource.VxAdminApp, window.kiosk),
     []
   );
+
   const printBallotRef = useRef<HTMLDivElement>(null);
 
   const getElectionDefinition = useCallback(async (): Promise<

--- a/libs/logging/src/logEventIDs.ts
+++ b/libs/logging/src/logEventIDs.ts
@@ -31,6 +31,8 @@ export enum LogEventId {
   USBDriveEjected = 'usb-drive-eject-complete',
   USBDriveMountInit = 'usb-drive-mount-init',
   USBDriveMounted = 'usb-drive-mount-complete',
+  // App Startup
+  ApplicationStartup = 'application-startup',
 }
 
 export interface LogDetails {
@@ -167,6 +169,13 @@ const USBDeviceChangeDetected: LogDetails = {
     'A message from the machine kernel about an externally-connected USB device, usually when a new device is connected or disconnected.',
 };
 
+const ApplicationStartup: LogDetails = {
+  eventId: LogEventId.ApplicationStartup,
+  eventType: LogEventType.ApplicationStatus,
+  documentationMessage:
+    'Application finished starting up, success or failure indicated by disposition.',
+};
+
 export function getDetailsForEventId(eventId: LogEventId): LogDetails {
   switch (eventId) {
     case LogEventId.ElectionConfigured:
@@ -203,6 +212,8 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return USBDriveMounted;
     case LogEventId.USBDeviceChangeDetected:
       return USBDeviceChangeDetected;
+    case LogEventId.ApplicationStartup:
+      return ApplicationStartup;
     /* istanbul ignore next - compile time check for completeness */
     default:
       throwIllegalValue(eventId);

--- a/libs/logging/src/types.ts
+++ b/libs/logging/src/types.ts
@@ -12,6 +12,7 @@ export type LogDisposition = LogDispositionStandardTypes | string;
 export enum LogSource {
   System = 'system',
   VxAdminApp = 'vx-admin',
+  VxAdminServer = 'vx-admin-server',
   VxBatchScanApp = 'vx-batch-scan',
   VxPrecinctScanApp = 'vx-precinct-scan',
 }


### PR DESCRIPTION
Adds a startup log for election-manager, I wasn't sure if this was the right place for the log or something that runs in App or AppRoot on the first load, so open to feedback before I implement this in the other apps. I'll also add a similar log in the services (module-scan, module-smartcards) as well. 