### PR TITLE
feat(all) refactor to useHardware hook and add logging

### DIFF
--- a/apps/bas/package.json
+++ b/apps/bas/package.json
@@ -60,6 +60,7 @@
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "@types/styled-components": "^5.1.7",
+    "@votingworks/logging": "workspace:*",
     "@votingworks/types": "workspace:*",
     "@votingworks/ui": "workspace:*",
     "@votingworks/utils": "workspace:*",

--- a/apps/bas/src/AppRoot.tsx
+++ b/apps/bas/src/AppRoot.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState, useMemo } from 'react';
 import {
   BallotStyle,
   ElectionSchema,
@@ -7,8 +7,10 @@ import {
   safeParseElection,
   VoterCardData,
 } from '@votingworks/types';
+import { Logger, LogSource } from '@votingworks/logging';
 import {
   useCancelablePromise,
+  useHardware,
   useSmartcard,
   useStoredState,
 } from '@votingworks/ui';
@@ -64,6 +66,12 @@ export function AppRoot({ card, hardware, storage }: Props): JSX.Element {
   );
   const [ballotStyleId, setBallotStyleId] = useState<string>();
   const [partyId, setPartyId] = useStoredState(storage, 'partyId', z.string());
+
+  const logger = useMemo(
+    () => new Logger(LogSource.VxBallotActivationApp, window.kiosk),
+    []
+  );
+  const { hasCardReaderAttached } = useHardware({ hardware, logger });
 
   const unconfigure = useCallback(() => {
     setElection(undefined);
@@ -123,7 +131,7 @@ export function AppRoot({ card, hardware, storage }: Props): JSX.Element {
   }
 
   const makeCancelable = useCancelablePromise();
-  const [smartcard] = useSmartcard({ card, hardware });
+  const smartcard = useSmartcard({ card, hasCardReaderAttached });
 
   const fetchElection = useCallback(async () => {
     setIsLoadingElection(true);

--- a/apps/bas/tsconfig.json
+++ b/apps/bas/tsconfig.json
@@ -19,6 +19,7 @@
   "include": ["src"],
   "references": [
     { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
+    { "path": "../../libs/logging" },
     { "path": "../../libs/types" },
     { "path": "../../libs/ui" },
     { "path": "../../libs/utils" }

--- a/apps/bmd/package.json
+++ b/apps/bmd/package.json
@@ -96,6 +96,7 @@
     "@types/styled-components": "^5.1.7",
     "@votingworks/ballot-encoder": "workspace:*",
     "@votingworks/fixtures": "workspace:*",
+    "@votingworks/logging": "workspace:*",
     "@votingworks/qrcode.react": "^1.0.1",
     "@votingworks/types": "workspace:*",
     "@votingworks/ui": "workspace:*",

--- a/apps/bmd/tsconfig.json
+++ b/apps/bmd/tsconfig.json
@@ -20,6 +20,7 @@
   "references": [
     { "path": "../../libs/ballot-encoder" },
     { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
+    { "path": "../../libs/logging" },
     { "path": "../../libs/test-utils" },
     { "path": "../../libs/types" },
     { "path": "../../libs/ui" },

--- a/apps/bsd/src/App.test.tsx
+++ b/apps/bsd/src/App.test.tsx
@@ -332,6 +332,7 @@ test('configuring election from usb ballot package works end to end', async () =
 test('authentication works', async () => {
   const card = new MemoryCard();
   const hardware = await MemoryHardware.buildStandard();
+  await hardware.setBatchScannerConnected(false);
   const getElectionResponseBody: GetElectionConfigResponse = electionSampleDefinition;
   const getTestModeResponseBody: GetTestModeConfigResponse = {
     status: 'ok',

--- a/apps/bsd/src/AppRoot.tsx
+++ b/apps/bsd/src/AppRoot.tsx
@@ -31,6 +31,7 @@ import {
   useSmartcard,
   SetupCardReaderPage,
   useUserSession,
+  useHardware,
 } from '@votingworks/ui';
 import { Logger, LogSource } from '@votingworks/logging';
 import { MachineConfig } from './config/types';
@@ -103,7 +104,11 @@ export function AppRoot({ card, hardware }: AppRootProps): JSX.Element {
 
   const usbDrive = useUsbDrive({ logger });
 
-  const [smartcard, hasCardReaderAttached] = useSmartcard({ card, hardware });
+  const { hasCardReaderAttached, hasBatchScannerAttached } = useHardware({
+    hardware,
+    logger,
+  });
+  const smartcard = useSmartcard({ card, hasCardReaderAttached });
   const {
     currentUserSession,
     attemptToAuthenticateAdminUser,
@@ -512,7 +517,11 @@ export function AppRoot({ card, hardware }: AppRootProps): JSX.Element {
                 >
                   Export
                 </Button>
-                <ScanButton onPress={scanBatch} disabled={isScanning} />
+                <ScanButton
+                  onPress={scanBatch}
+                  disabled={isScanning}
+                  isScannerAttached={hasBatchScannerAttached}
+                />
               </MainNav>
               <StatusFooter />
             </Screen>

--- a/apps/bsd/src/components/ScanButton.tsx
+++ b/apps/bsd/src/components/ScanButton.tsx
@@ -1,33 +1,25 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { Button } from './Button';
 
 export interface Props {
   onPress(): void;
   disabled?: boolean;
+  isScannerAttached: boolean;
 }
 
-export const FUJITSU_VENDOR_ID = 0x4c5;
-
-export function ScanButton({ onPress, disabled }: Props): JSX.Element {
-  const [isScannerConnected, setIsScannerConnected] = useState(!window.kiosk);
-
-  useEffect(() => {
-    const subscription = window.kiosk?.devices.subscribe((devices) => {
-      setIsScannerConnected(
-        [...devices].some((device) => device.vendorId === FUJITSU_VENDOR_ID)
-      );
-    });
-    return () => subscription?.unsubscribe();
-  });
-
+export function ScanButton({
+  onPress,
+  disabled,
+  isScannerAttached,
+}: Props): JSX.Element {
   return (
     <Button
       small
-      disabled={disabled || !isScannerConnected}
+      disabled={disabled || !isScannerAttached}
       primary
       onPress={onPress}
     >
-      {isScannerConnected ? 'Scan New Batch' : 'No Scanner'}
+      {isScannerAttached ? 'Scan New Batch' : 'No Scanner'}
     </Button>
   );
 }

--- a/apps/election-manager/src/AppRoot.tsx
+++ b/apps/election-manager/src/AppRoot.tsx
@@ -33,7 +33,12 @@ import {
   Card,
   Hardware,
 } from '@votingworks/utils';
-import { useSmartcard, useUsbDrive, useUserSession } from '@votingworks/ui';
+import {
+  useSmartcard,
+  useUsbDrive,
+  useUserSession,
+  useHardware,
+} from '@votingworks/ui';
 import {
   computeFullElectionTally,
   getEmptyFullElectionTally,
@@ -101,6 +106,8 @@ export function AppRoot({
   );
 
   const printBallotRef = useRef<HTMLDivElement>(null);
+
+  const { hasCardReaderAttached } = useHardware({ hardware, logger });
 
   const getElectionDefinition = useCallback(async (): Promise<
     ElectionDefinition | undefined
@@ -185,7 +192,7 @@ export function AppRoot({
   const usbDrive = useUsbDrive({ logger });
   const displayUsbStatus = usbDrive.status ?? usbstick.UsbDriveStatus.absent;
 
-  const [smartcard, hasCardReaderAttached] = useSmartcard({ card, hardware });
+  const smartcard = useSmartcard({ card, hasCardReaderAttached });
   const {
     currentUserSession,
     attemptToAuthenticateAdminUser,

--- a/libs/logging/src/logEventIDs.ts
+++ b/libs/logging/src/logEventIDs.ts
@@ -33,6 +33,12 @@ export enum LogEventId {
   USBDriveMounted = 'usb-drive-mount-complete',
   // App Startup
   ApplicationStartup = 'application-startup',
+  // External Device Related Logs
+  PrinterConfigurationAdded = 'printer-config-added',
+  PrinterConfigurationRemoved = 'printer-config-removed',
+  PrinterConnectionUpdate = 'printer-connection-update',
+  DeviceAttached = 'device-attached',
+  DeviceUnattached = 'device-unattached',
 }
 
 export interface LogDetails {
@@ -176,6 +182,39 @@ const ApplicationStartup: LogDetails = {
     'Application finished starting up, success or failure indicated by disposition.',
 };
 
+const PrinterConfigurationAdded: LogDetails = {
+  eventId: LogEventId.PrinterConfigurationAdded,
+  eventType: LogEventType.ApplicationStatus,
+  documentationMessage:
+    'Application saw a printer configuration added to the system, current connection status of that printer is logged.',
+};
+
+const PrinterConfigurationRemoved: LogDetails = {
+  eventId: LogEventId.PrinterConfigurationRemoved,
+  eventType: LogEventType.ApplicationStatus,
+  documentationMessage:
+    'Application saw a printer configuration removed from the system.',
+};
+
+const PrinterConnectionUpdate: LogDetails = {
+  eventId: LogEventId.PrinterConnectionUpdate,
+  eventType: LogEventType.ApplicationStatus,
+  documentationMessage:
+    'Application saw a change to the connection status of a given configured printer.',
+};
+
+const DeviceAttached: LogDetails = {
+  eventId: LogEventId.DeviceAttached,
+  eventType: LogEventType.ApplicationStatus,
+  documentationMessage: 'Application saw a device attached to the system.',
+};
+
+const DeviceUnattached: LogDetails = {
+  eventId: LogEventId.DeviceUnattached,
+  eventType: LogEventType.ApplicationStatus,
+  documentationMessage: 'Application saw a device unattached from the system.',
+};
+
 export function getDetailsForEventId(eventId: LogEventId): LogDetails {
   switch (eventId) {
     case LogEventId.ElectionConfigured:
@@ -214,6 +253,16 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return USBDeviceChangeDetected;
     case LogEventId.ApplicationStartup:
       return ApplicationStartup;
+    case LogEventId.PrinterConfigurationAdded:
+      return PrinterConfigurationAdded;
+    case LogEventId.PrinterConfigurationRemoved:
+      return PrinterConfigurationRemoved;
+    case LogEventId.PrinterConnectionUpdate:
+      return PrinterConnectionUpdate;
+    case LogEventId.DeviceAttached:
+      return DeviceAttached;
+    case LogEventId.DeviceUnattached:
+      return DeviceUnattached;
     /* istanbul ignore next - compile time check for completeness */
     default:
       throwIllegalValue(eventId);

--- a/libs/logging/src/logger.ts
+++ b/libs/logging/src/logger.ts
@@ -12,7 +12,7 @@ import { LogEventId, getDetailsForEventId } from './logEventIDs';
 
 const debug = makeDebug('logger');
 
-interface LogData extends Dictionary<string> {
+interface LogData extends Dictionary<string | boolean | number> {
   message?: string;
   disposition?: LogDisposition;
 }

--- a/libs/logging/src/types.ts
+++ b/libs/logging/src/types.ts
@@ -15,6 +15,8 @@ export enum LogSource {
   VxAdminServer = 'vx-admin-server',
   VxBatchScanApp = 'vx-batch-scan',
   VxPrecinctScanApp = 'vx-precinct-scan',
+  VxBallotMarkingDeviceApp = 'vx-ballot-marking-device',
+  VxBallotActivationApp = 'vx-ballot-activation',
 }
 // The following log sources are client side apps and always expect to log through window.kiosk
 // In various tests window.kiosk may not be defined and we don't want to fallback to logging with console.log
@@ -23,6 +25,8 @@ export const CLIENT_SIDE_LOG_SOURCES = [
   LogSource.VxAdminApp,
   LogSource.VxBatchScanApp,
   LogSource.VxPrecinctScanApp,
+  LogSource.VxBallotMarkingDeviceApp,
+  LogSource.VxBallotActivationApp,
 ];
 
 export interface LogLine extends Dictionary<string> {

--- a/libs/ui/src/hooks/useHardware.test.ts
+++ b/libs/ui/src/hooks/useHardware.test.ts
@@ -1,0 +1,311 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { Logger, LogSource, LogEventId } from '@votingworks/logging';
+import {
+  AccessibleControllerProductId,
+  AccessibleControllerVendorId,
+  FujitsuFi7160ScannerProductId,
+  FujitsuScannerVendorId,
+  MemoryHardware,
+  OmniKeyCardReaderProductId,
+  OmniKeyCardReaderVendorId,
+  PlustekScannerVendorId,
+  PlustekVTM300ScannerProductId,
+} from '@votingworks/utils';
+import { useHardware } from './useHardware';
+
+test('can connect printer as expected', async () => {
+  const hardware = new MemoryHardware();
+  const fakeLogger = new Logger(LogSource.VxBatchScanApp);
+  const logSpy = jest.spyOn(fakeLogger, 'log').mockResolvedValue();
+  const { result, rerender } = renderHook(() =>
+    useHardware({ hardware, logger: fakeLogger })
+  );
+  expect(result.current.hasPrinterAttached).toBe(false);
+  expect(logSpy).toHaveBeenCalledTimes(0);
+
+  await act(async () => await hardware.setPrinterConnected(true));
+  rerender();
+  expect(result.current.hasPrinterAttached).toBe(true);
+  expect(logSpy).toHaveBeenCalledTimes(2);
+  expect(logSpy).toHaveBeenNthCalledWith(
+    1,
+    LogEventId.PrinterConfigurationAdded,
+    'system',
+    expect.objectContaining({
+      message: expect.stringContaining('New printer configured'),
+      connected: true,
+    })
+  );
+  expect(result.current.hasCardReaderAttached).toBe(false);
+  expect(result.current.hasBatchScannerAttached).toBe(false);
+  expect(result.current.hasPrecinctScannerAttached).toBe(false);
+  expect(result.current.hasAccessibleControllerAttached).toBe(false);
+
+  await act(async () => await hardware.setPrinterConnected(false));
+  rerender();
+  expect(result.current.hasPrinterAttached).toBe(false);
+  expect(logSpy).toHaveBeenCalledWith(
+    LogEventId.PrinterConnectionUpdate,
+    'system',
+    expect.objectContaining({
+      message: expect.stringContaining('Printer'),
+      connected: false,
+    })
+  );
+
+  await act(async () => await hardware.setPrinterConnected(true));
+  rerender();
+  expect(result.current.hasPrinterAttached).toBe(true);
+  expect(logSpy).toHaveBeenCalledWith(
+    LogEventId.PrinterConnectionUpdate,
+    'system',
+    expect.objectContaining({
+      message: expect.stringContaining('Printer'),
+      connected: true,
+    })
+  );
+
+  await act(async () => await hardware.detachAllPrinters());
+  rerender();
+  expect(result.current.hasPrinterAttached).toBe(false);
+  expect(logSpy).toHaveBeenCalledWith(
+    LogEventId.PrinterConfigurationRemoved,
+    'system',
+    expect.objectContaining({
+      message: expect.stringContaining('Printer'),
+    })
+  );
+});
+
+test('can connect card reader as expected', async () => {
+  const hardware = new MemoryHardware();
+  const fakeLogger = new Logger(LogSource.VxBatchScanApp);
+  const logSpy = jest.spyOn(fakeLogger, 'log').mockResolvedValue();
+  const { result, rerender } = renderHook(() =>
+    useHardware({ hardware, logger: fakeLogger })
+  );
+  expect(result.current.hasCardReaderAttached).toBe(false);
+  expect(logSpy).toHaveBeenCalledTimes(0);
+
+  await act(async () => await hardware.setCardReaderConnected(true));
+  rerender();
+  expect(result.current.hasCardReaderAttached).toBe(true);
+  expect(logSpy).toHaveBeenCalledTimes(1);
+  expect(logSpy).toHaveBeenCalledWith(
+    LogEventId.DeviceAttached,
+    'system',
+    expect.objectContaining({
+      message: expect.stringContaining('New Card Reader'),
+      productId: OmniKeyCardReaderProductId,
+      vendorId: OmniKeyCardReaderVendorId,
+    })
+  );
+  expect(result.current.hasAccessibleControllerAttached).toBe(false);
+  expect(result.current.hasBatchScannerAttached).toBe(false);
+  expect(result.current.hasPrecinctScannerAttached).toBe(false);
+  expect(result.current.hasPrinterAttached).toBe(false);
+
+  await act(async () => await hardware.setCardReaderConnected(false));
+  rerender();
+  expect(result.current.hasCardReaderAttached).toBe(false);
+  expect(logSpy).toHaveBeenCalledTimes(2);
+  expect(logSpy).toHaveBeenLastCalledWith(
+    LogEventId.DeviceUnattached,
+    'system',
+    expect.objectContaining({
+      message: expect.stringContaining('Card Reader'),
+      productId: OmniKeyCardReaderProductId,
+      vendorId: OmniKeyCardReaderVendorId,
+    })
+  );
+});
+
+test('can connect accessible controller as expected', async () => {
+  const hardware = new MemoryHardware();
+  const fakeLogger = new Logger(LogSource.VxBatchScanApp);
+  const logSpy = jest.spyOn(fakeLogger, 'log').mockResolvedValue();
+  const { result, rerender } = renderHook(() =>
+    useHardware({ hardware, logger: fakeLogger })
+  );
+  expect(result.current.hasAccessibleControllerAttached).toBe(false);
+  expect(logSpy).toHaveBeenCalledTimes(0);
+
+  await act(async () => await hardware.setAccessibleControllerConnected(true));
+  rerender();
+  expect(result.current.hasAccessibleControllerAttached).toBe(true);
+  expect(logSpy).toHaveBeenCalledTimes(1);
+  expect(logSpy).toHaveBeenCalledWith(
+    LogEventId.DeviceAttached,
+    'system',
+    expect.objectContaining({
+      message: expect.stringContaining('New Accessible Controller'),
+      productId: AccessibleControllerProductId,
+      vendorId: AccessibleControllerVendorId,
+    })
+  );
+  expect(result.current.hasCardReaderAttached).toBe(false);
+  expect(result.current.hasBatchScannerAttached).toBe(false);
+  expect(result.current.hasPrecinctScannerAttached).toBe(false);
+  expect(result.current.hasPrinterAttached).toBe(false);
+
+  await act(async () => await hardware.setAccessibleControllerConnected(false));
+  rerender();
+  expect(result.current.hasAccessibleControllerAttached).toBe(false);
+  expect(logSpy).toHaveBeenCalledTimes(2);
+  expect(logSpy).toHaveBeenLastCalledWith(
+    LogEventId.DeviceUnattached,
+    'system',
+    expect.objectContaining({
+      message: expect.stringContaining('Accessible Controller'),
+      productId: AccessibleControllerProductId,
+      vendorId: AccessibleControllerVendorId,
+    })
+  );
+});
+
+test('can connect fujitsu scanner as expected', async () => {
+  const hardware = new MemoryHardware();
+  const fakeLogger = new Logger(LogSource.VxBatchScanApp);
+  const logSpy = jest.spyOn(fakeLogger, 'log').mockResolvedValue();
+  const { result, rerender } = renderHook(() =>
+    useHardware({ hardware, logger: fakeLogger })
+  );
+  expect(result.current.hasBatchScannerAttached).toBe(false);
+  expect(logSpy).toHaveBeenCalledTimes(0);
+
+  await act(async () => await hardware.setBatchScannerConnected(true));
+  rerender();
+  expect(result.current.hasBatchScannerAttached).toBe(true);
+  expect(logSpy).toHaveBeenCalledTimes(1);
+  expect(logSpy).toHaveBeenCalledWith(
+    LogEventId.DeviceAttached,
+    'system',
+    expect.objectContaining({
+      message: expect.stringContaining('New Fujitsu Scanner (Scanner)'),
+      productId: FujitsuFi7160ScannerProductId,
+      vendorId: FujitsuScannerVendorId,
+    })
+  );
+  expect(result.current.hasCardReaderAttached).toBe(false);
+  expect(result.current.hasAccessibleControllerAttached).toBe(false);
+  expect(result.current.hasPrecinctScannerAttached).toBe(false);
+  expect(result.current.hasPrinterAttached).toBe(false);
+
+  await act(async () => await hardware.setBatchScannerConnected(false));
+  rerender();
+  expect(result.current.hasBatchScannerAttached).toBe(false);
+  expect(logSpy).toHaveBeenCalledTimes(2);
+  expect(logSpy).toHaveBeenLastCalledWith(
+    LogEventId.DeviceUnattached,
+    'system',
+    expect.objectContaining({
+      message: expect.stringContaining('Fujitsu Scanner (Scanner)'),
+      productId: FujitsuFi7160ScannerProductId,
+      vendorId: FujitsuScannerVendorId,
+    })
+  );
+});
+
+test('can connect plustek scanner as expected', async () => {
+  const plustekDevice: KioskBrowser.Device = {
+    productId: PlustekVTM300ScannerProductId,
+    vendorId: PlustekScannerVendorId,
+    locationId: 0,
+    deviceAddress: 0,
+    deviceName: 'Sheetfed Scanner',
+    serialNumber: '',
+    manufacturer: 'Plustek',
+  };
+  const hardware = new MemoryHardware();
+  const fakeLogger = new Logger(LogSource.VxBatchScanApp);
+  const logSpy = jest.spyOn(fakeLogger, 'log').mockResolvedValue();
+  const { result, rerender } = renderHook(() =>
+    useHardware({ hardware, logger: fakeLogger })
+  );
+  expect(result.current.hasPrecinctScannerAttached).toBe(false);
+  expect(logSpy).toHaveBeenCalledTimes(0);
+
+  act(() => hardware.addDevice(plustekDevice));
+  rerender();
+  expect(result.current.hasPrecinctScannerAttached).toBe(true);
+  expect(logSpy).toHaveBeenCalledTimes(1);
+  expect(logSpy).toHaveBeenCalledWith(
+    LogEventId.DeviceAttached,
+    'system',
+    expect.objectContaining({
+      message: expect.stringContaining(
+        'New Plustek Scanner (Sheetfed Scanner)'
+      ),
+      productId: PlustekVTM300ScannerProductId,
+      vendorId: PlustekScannerVendorId,
+    })
+  );
+  expect(result.current.hasCardReaderAttached).toBe(false);
+  expect(result.current.hasAccessibleControllerAttached).toBe(false);
+  expect(result.current.hasBatchScannerAttached).toBe(false);
+  expect(result.current.hasPrinterAttached).toBe(false);
+
+  await act(async () => await hardware.removeDevice(plustekDevice));
+  rerender();
+  expect(result.current.hasBatchScannerAttached).toBe(false);
+  expect(logSpy).toHaveBeenCalledTimes(2);
+  expect(logSpy).toHaveBeenLastCalledWith(
+    LogEventId.DeviceUnattached,
+    'system',
+    expect.objectContaining({
+      message: expect.stringContaining('Plustek Scanner (Sheetfed Scanner)'),
+      productId: PlustekVTM300ScannerProductId,
+      vendorId: PlustekScannerVendorId,
+    })
+  );
+});
+
+test('can handle logs for a random device as expected', async () => {
+  const randomDevice: KioskBrowser.Device = {
+    productId: 1234,
+    vendorId: 5678,
+    locationId: 0,
+    deviceAddress: 0,
+    deviceName: 'Giraffe',
+    serialNumber: '',
+    manufacturer: '',
+  };
+  const hardware = new MemoryHardware();
+  const fakeLogger = new Logger(LogSource.VxBatchScanApp);
+  const logSpy = jest.spyOn(fakeLogger, 'log').mockResolvedValue();
+  const { result, rerender } = renderHook(() =>
+    useHardware({ hardware, logger: fakeLogger })
+  );
+  expect(logSpy).toHaveBeenCalledTimes(0);
+
+  act(() => hardware.addDevice(randomDevice));
+  rerender();
+  expect(logSpy).toHaveBeenCalledTimes(1);
+  expect(logSpy).toHaveBeenCalledWith(
+    LogEventId.DeviceAttached,
+    'system',
+    expect.objectContaining({
+      message: expect.stringContaining('New Device (Giraffe)'),
+      productId: 1234,
+      vendorId: 5678,
+    })
+  );
+  expect(result.current.hasCardReaderAttached).toBe(false);
+  expect(result.current.hasAccessibleControllerAttached).toBe(false);
+  expect(result.current.hasBatchScannerAttached).toBe(false);
+  expect(result.current.hasPrecinctScannerAttached).toBe(false);
+  expect(result.current.hasPrinterAttached).toBe(false);
+
+  await act(async () => await hardware.removeDevice(randomDevice));
+  rerender();
+  expect(logSpy).toHaveBeenCalledTimes(2);
+  expect(logSpy).toHaveBeenLastCalledWith(
+    LogEventId.DeviceUnattached,
+    'system',
+    expect.objectContaining({
+      message: expect.stringContaining('Device (Giraffe)'),
+      productId: 1234,
+      vendorId: 5678,
+    })
+  );
+});

--- a/libs/ui/src/hooks/useHardware.ts
+++ b/libs/ui/src/hooks/useHardware.ts
@@ -1,0 +1,175 @@
+import { useEffect, useState } from 'react';
+import {
+  isCardReader,
+  Hardware,
+  isAccessibleController,
+  isPlustekVTM300Scanner,
+  isFujitsuScanner,
+} from '@votingworks/utils';
+import { map } from 'rxjs/operators';
+import { LogEventId, Logger } from '@votingworks/logging';
+import { usePrevious } from '..';
+
+export interface UseHardwareProps {
+  hardware: Hardware;
+  logger: Logger;
+}
+
+export interface UseHardwareResult {
+  hasCardReaderAttached: boolean;
+  hasAccessibleControllerAttached: boolean;
+  hasPrecinctScannerAttached: boolean;
+  hasBatchScannerAttached: boolean;
+  hasPrinterAttached: boolean;
+}
+
+function getDeviceName(device: KioskBrowser.Device) {
+  if (isCardReader(device)) {
+    return `Card Reader (${device.deviceName})`;
+  }
+  if (isAccessibleController(device)) {
+    return `Accessible Controller (${device.deviceName})`;
+  }
+  if (isFujitsuScanner(device)) {
+    return `Fujitsu Scanner (${device.deviceName})`;
+  }
+  if (isPlustekVTM300Scanner(device)) {
+    return `Plustek Scanner (${device.deviceName})`;
+  }
+  return `Device (${device.deviceName})`;
+}
+
+export function useHardware({
+  hardware,
+  logger,
+}: UseHardwareProps): UseHardwareResult {
+  const [hasCardReaderAttached, setHasCardReaderAttached] = useState(false);
+  const [
+    hasAccessibleControllerAttached,
+    setHasAccessibleControllerAttached,
+  ] = useState(false);
+  const [hasPlustekScannerAttached, setHasPlustekScannerAttached] = useState(
+    false
+  );
+  const [hasFujitsuScannerAttached, setHasFujitsuScannerAttached] = useState(
+    false
+  );
+  const [hasPrinterAttached, setHasPrinterAttached] = useState(false);
+  const [allDevices, setAllDevices] = useState<KioskBrowser.Device[]>([]);
+  const [allPrinters, setAllPrinters] = useState<KioskBrowser.PrinterInfo[]>(
+    []
+  );
+  const previousDevices = usePrevious(allDevices);
+  const previousPrinters = usePrevious(allPrinters);
+
+  useEffect(() => {
+    const hardwareStatusSubscription = hardware.devices
+      .pipe(map((devices) => Array.from(devices)))
+      .subscribe(async (devices) => {
+        setHasCardReaderAttached(devices.some(isCardReader));
+        setHasAccessibleControllerAttached(
+          devices.some(isAccessibleController)
+        );
+        setHasPlustekScannerAttached(devices.some(isPlustekVTM300Scanner));
+        setHasFujitsuScannerAttached(devices.some(isFujitsuScanner));
+        setAllDevices(devices);
+      });
+
+    const printerStatusSubscription = hardware.printers
+      .pipe(map((printers) => Array.from(printers)))
+      .subscribe(async (printers) => {
+        const newHasPrinterAttached = printers.some(
+          ({ connected }) => connected
+        );
+        setHasPrinterAttached(newHasPrinterAttached);
+        setAllPrinters(printers);
+      });
+    return () => {
+      hardwareStatusSubscription.unsubscribe();
+      printerStatusSubscription.unsubscribe();
+    };
+  }, [hardware]);
+
+  // Handle logging of printers
+  useEffect(() => {
+    for (const newPrinter of allPrinters) {
+      const previousCopyOfPrinter =
+        previousPrinters &&
+        previousPrinters.find((printer) => printer.name === newPrinter.name);
+      if (!previousCopyOfPrinter) {
+        void logger.log(LogEventId.PrinterConfigurationAdded, 'system', {
+          message: `New printer configured: ${newPrinter.name} with connection status: ${newPrinter.connected}`,
+          printer: newPrinter.name,
+          connected: newPrinter.connected,
+        });
+      } else if (previousCopyOfPrinter.connected !== newPrinter.connected) {
+        void logger.log(LogEventId.PrinterConnectionUpdate, 'system', {
+          message: `Printer ${newPrinter.name} has been ${
+            newPrinter.connected ? 'connected' : 'disconnected'
+          }.`,
+          printer: newPrinter.name,
+          connected: newPrinter.connected,
+        });
+      }
+    }
+    for (const oldPrinter of previousPrinters || []) {
+      const newCopyOfPrinter = allPrinters.find(
+        (printer) => printer.name === oldPrinter.name
+      );
+      if (!newCopyOfPrinter) {
+        void logger.log(LogEventId.PrinterConfigurationRemoved, 'system', {
+          message: `Printer configuration removed: ${oldPrinter.name}}`,
+          printer: oldPrinter.name,
+        });
+      }
+    }
+  }, [previousPrinters, allPrinters, logger]);
+
+  // Handle logging of devices
+  useEffect(() => {
+    for (const newDevice of allDevices) {
+      const previousCopyOfDevice =
+        previousDevices &&
+        previousDevices.find(
+          (device) =>
+            device.productId === newDevice.productId &&
+            device.vendorId === newDevice.vendorId
+        );
+      if (!previousCopyOfDevice) {
+        void logger.log(LogEventId.DeviceAttached, 'system', {
+          message: `New ${getDeviceName(newDevice)} attached. Vendor: ${
+            newDevice.vendorId
+          } , Product: ${newDevice.productId}`,
+          productId: newDevice.productId,
+          vendorId: newDevice.vendorId,
+          deviceName: newDevice.deviceName,
+        });
+      }
+    }
+    for (const oldDevice of previousDevices || []) {
+      const newCopyOfDevice = allDevices.find(
+        (device) =>
+          device.productId === oldDevice.productId &&
+          device.vendorId === oldDevice.vendorId
+      );
+      if (!newCopyOfDevice) {
+        void logger.log(LogEventId.DeviceUnattached, 'system', {
+          message: `${getDeviceName(oldDevice)} unattached. Vendor: ${
+            oldDevice.vendorId
+          } , Product: ${oldDevice.productId}`,
+          productId: oldDevice.productId,
+          vendorId: oldDevice.vendorId,
+          deviceName: oldDevice.deviceName,
+        });
+      }
+    }
+  }, [previousDevices, allDevices, logger]);
+
+  return {
+    hasCardReaderAttached,
+    hasAccessibleControllerAttached,
+    hasBatchScannerAttached: hasFujitsuScannerAttached,
+    hasPrecinctScannerAttached: hasPlustekScannerAttached,
+    hasPrinterAttached,
+  };
+}

--- a/libs/ui/src/hooks/useSmartcard.test.ts
+++ b/libs/ui/src/hooks/useSmartcard.test.ts
@@ -9,7 +9,7 @@ import {
   makePollWorkerCard,
   makeVoterCard,
 } from '@votingworks/test-utils';
-import { MemoryCard, MemoryHardware } from '@votingworks/utils';
+import { MemoryCard } from '@votingworks/utils';
 import { CARD_POLLING_INTERVAL, useSmartcard } from './useSmartcard';
 
 beforeEach(() => {
@@ -18,64 +18,61 @@ beforeEach(() => {
 
 test('no card reader attached', async () => {
   const card = new MemoryCard();
-  const hardware = new MemoryHardware();
 
-  const { result } = renderHook(() => useSmartcard({ card, hardware }));
+  const { result } = renderHook(() =>
+    useSmartcard({ card, hasCardReaderAttached: false })
+  );
   await advanceTimersAndPromises(CARD_POLLING_INTERVAL / 1000);
-  const [smartcard, hasCardReader] = result.current;
-  expect({ smartcard, hasCardReader }).toEqual({
+  const smartcard = result.current;
+  expect({ smartcard }).toEqual({
     smartcard: undefined,
-    hasCardReader: false,
   });
 });
 
 test('with card reader but no card', async () => {
   const card = new MemoryCard();
-  const hardware = new MemoryHardware();
 
-  await hardware.setCardReaderConnected(true);
-
-  const { result } = renderHook(() => useSmartcard({ card, hardware }));
+  const { result } = renderHook(() =>
+    useSmartcard({ card, hasCardReaderAttached: true })
+  );
   await advanceTimersAndPromises(CARD_POLLING_INTERVAL / 1000);
-  const [smartcard, hasCardReader] = result.current;
-  expect({ smartcard, hasCardReader }).toEqual({
+  const smartcard = result.current;
+  expect({ smartcard }).toEqual({
     smartcard: undefined,
-    hasCardReader: true,
   });
 });
 
 test('with card reader and a voter card', async () => {
   const card = new MemoryCard();
-  const hardware = new MemoryHardware();
 
-  await hardware.setCardReaderConnected(true);
   card.insertCard(makeVoterCard(electionSample));
 
-  const { result } = renderHook(() => useSmartcard({ card, hardware }));
+  const { result } = renderHook(() =>
+    useSmartcard({ card, hasCardReaderAttached: true })
+  );
   await advanceTimersAndPromises(CARD_POLLING_INTERVAL / 1000);
-  const [smartcard, hasCardReader] = result.current;
-  expect({ smartcard, hasCardReader }).toEqual({
+  const smartcard = result.current;
+  expect({ smartcard }).toEqual({
     smartcard: expect.objectContaining({
       longValueExists: false,
       data: expect.objectContaining({
         t: 'voter',
       }),
     }),
-    hasCardReader: true,
   });
 });
 
 test('with card reader and a pollworker card', async () => {
   const card = new MemoryCard();
-  const hardware = new MemoryHardware();
 
-  await hardware.setCardReaderConnected(true);
   card.insertCard(makePollWorkerCard(electionSampleDefinition.electionHash));
 
-  const { result } = renderHook(() => useSmartcard({ card, hardware }));
+  const { result } = renderHook(() =>
+    useSmartcard({ card, hasCardReaderAttached: true })
+  );
   await advanceTimersAndPromises(CARD_POLLING_INTERVAL / 1000);
-  const [smartcard, hasCardReader] = result.current;
-  expect({ smartcard, hasCardReader }).toEqual({
+  const smartcard = result.current;
+  expect({ smartcard }).toEqual({
     smartcard: expect.objectContaining({
       longValueExists: false,
       data: expect.objectContaining({
@@ -83,21 +80,20 @@ test('with card reader and a pollworker card', async () => {
         h: electionSampleDefinition.electionHash,
       }),
     }),
-    hasCardReader: true,
   });
 });
 
 test('with card reader and an admin card', async () => {
   const card = new MemoryCard();
-  const hardware = new MemoryHardware();
 
-  await hardware.setCardReaderConnected(true);
   card.insertCard(makeAdminCard(electionSampleDefinition.electionHash));
 
-  const { result } = renderHook(() => useSmartcard({ card, hardware }));
+  const { result } = renderHook(() =>
+    useSmartcard({ card, hasCardReaderAttached: true })
+  );
   await advanceTimersAndPromises(CARD_POLLING_INTERVAL / 1000);
-  const [smartcard, hasCardReader] = result.current;
-  expect({ smartcard, hasCardReader }).toEqual({
+  const smartcard = result.current;
+  expect({ smartcard }).toEqual({
     smartcard: expect.objectContaining({
       longValueExists: false,
       data: expect.objectContaining({
@@ -105,41 +101,39 @@ test('with card reader and an admin card', async () => {
         h: electionSampleDefinition.electionHash,
       }),
     }),
-    hasCardReader: true,
   });
 });
 
 test('with card reader and a gibberish card', async () => {
   const card = new MemoryCard();
-  const hardware = new MemoryHardware();
 
-  await hardware.setCardReaderConnected(true);
   card.insertCard('not JSON');
 
-  const { result } = renderHook(() => useSmartcard({ card, hardware }));
+  const { result } = renderHook(() =>
+    useSmartcard({ card, hasCardReaderAttached: true })
+  );
   await advanceTimersAndPromises(CARD_POLLING_INTERVAL / 1000);
-  const [smartcard, hasCardReader] = result.current;
-  expect({ smartcard, hasCardReader }).toEqual({
+  const smartcard = result.current;
+  expect({ smartcard }).toEqual({
     smartcard: expect.objectContaining({
       data: undefined,
     }),
-    hasCardReader: true,
   });
 });
 
 test('writing short value succeeds', async () => {
   const card = new MemoryCard();
-  const hardware = new MemoryHardware();
 
-  await hardware.setCardReaderConnected(true);
   card.insertCard();
 
-  const { result } = renderHook(() => useSmartcard({ card, hardware }));
+  const { result } = renderHook(() =>
+    useSmartcard({ card, hasCardReaderAttached: true })
+  );
   await advanceTimersAndPromises(CARD_POLLING_INTERVAL / 1000);
 
   const voterCard = makeVoterCard(electionSample);
   {
-    const [smartcard] = result.current;
+    const smartcard = result.current;
     await act(async () => {
       (
         await smartcard!.writeShortValue(JSON.stringify(voterCard))
@@ -156,32 +150,31 @@ test('writing short value succeeds', async () => {
   await advanceTimersAndPromises(CARD_POLLING_INTERVAL / 1000);
 
   {
-    const [smartcard, hasCardReader] = result.current;
-    expect({ smartcard, hasCardReader }).toEqual({
+    const smartcard = result.current;
+    expect({ smartcard }).toEqual({
       smartcard: expect.objectContaining({
         longValueExists: false,
         data: expect.objectContaining({
           t: 'voter',
         }),
       }),
-      hasCardReader: true,
     });
   }
 });
 
 test('writing short value fails', async () => {
   const card = new MemoryCard();
-  const hardware = new MemoryHardware();
 
-  await hardware.setCardReaderConnected(true);
   card.insertCard();
 
-  const { result } = renderHook(() => useSmartcard({ card, hardware }));
+  const { result } = renderHook(() =>
+    useSmartcard({ card, hasCardReaderAttached: true })
+  );
   await advanceTimersAndPromises(CARD_POLLING_INTERVAL / 1000);
 
   jest.spyOn(card, 'writeShortValue').mockRejectedValue(new Error('oh no'));
 
-  const [smartcard] = result.current;
+  const smartcard = result.current;
   await act(async () => {
     expect(
       (
@@ -195,18 +188,18 @@ test('writing short value fails', async () => {
 
 test('writing concurrently fails', async () => {
   const card = new MemoryCard();
-  const hardware = new MemoryHardware();
 
-  await hardware.setCardReaderConnected(true);
   card.insertCard();
 
-  const { result } = renderHook(() => useSmartcard({ card, hardware }));
+  const { result } = renderHook(() =>
+    useSmartcard({ card, hasCardReaderAttached: true })
+  );
   await advanceTimersAndPromises(CARD_POLLING_INTERVAL / 1000);
 
   jest.spyOn(card, 'writeShortValue').mockResolvedValue();
   jest.spyOn(card, 'writeLongUint8Array').mockResolvedValue();
 
-  const [smartcard] = result.current;
+  const smartcard = result.current;
   await act(async () => {
     const [write1Result, write2Result] = await Promise.all([
       smartcard!.writeShortValue('123'),
@@ -236,13 +229,13 @@ test('writing concurrently fails', async () => {
 
 test('reading long string value succeeds', async () => {
   const card = new MemoryCard();
-  const hardware = new MemoryHardware();
 
-  await hardware.setCardReaderConnected(true);
   card.insertCard();
   await card.writeLongObject({ some: 'object' });
 
-  const { result } = renderHook(() => useSmartcard({ card, hardware }));
+  const { result } = renderHook(() =>
+    useSmartcard({ card, hasCardReaderAttached: true })
+  );
 
   // read short
   await advanceTimersAndPromises(CARD_POLLING_INTERVAL / 1000);
@@ -250,7 +243,7 @@ test('reading long string value succeeds', async () => {
   // read long
   await advanceTimersAndPromises(CARD_POLLING_INTERVAL / 1000);
 
-  const [smartcard] = result.current;
+  const smartcard = result.current;
   await act(async () => {
     expect((await smartcard?.readLongString())?.ok()).toEqual(
       JSON.stringify({ some: 'object' })
@@ -260,17 +253,17 @@ test('reading long string value succeeds', async () => {
 
 test('reading long string value fails', async () => {
   const card = new MemoryCard();
-  const hardware = new MemoryHardware();
 
-  await hardware.setCardReaderConnected(true);
   card.insertCard();
 
-  const { result } = renderHook(() => useSmartcard({ card, hardware }));
+  const { result } = renderHook(() =>
+    useSmartcard({ card, hasCardReaderAttached: true })
+  );
   await advanceTimersAndPromises(CARD_POLLING_INTERVAL / 1000);
 
   jest.spyOn(card, 'readLongString').mockRejectedValue(new Error('oh no'));
 
-  const [smartcard] = result.current;
+  const smartcard = result.current;
   await act(async () => {
     expect((await smartcard?.readLongString())?.err()?.message).toEqual(
       'oh no'
@@ -280,13 +273,13 @@ test('reading long string value fails', async () => {
 
 test('reading long binary value succeeds', async () => {
   const card = new MemoryCard();
-  const hardware = new MemoryHardware();
 
-  await hardware.setCardReaderConnected(true);
   card.insertCard();
   await card.writeLongUint8Array(Uint8Array.of(1, 2, 3));
 
-  const { result } = renderHook(() => useSmartcard({ card, hardware }));
+  const { result } = renderHook(() =>
+    useSmartcard({ card, hasCardReaderAttached: true })
+  );
 
   // read short
   await advanceTimersAndPromises(CARD_POLLING_INTERVAL / 1000);
@@ -294,7 +287,7 @@ test('reading long binary value succeeds', async () => {
   // read long
   await advanceTimersAndPromises(CARD_POLLING_INTERVAL / 1000);
 
-  const [smartcard] = result.current;
+  const smartcard = result.current;
   await act(async () => {
     expect((await smartcard?.readLongUint8Array())?.ok()).toEqual(
       Uint8Array.of(1, 2, 3)
@@ -304,17 +297,17 @@ test('reading long binary value succeeds', async () => {
 
 test('reading long binary value fails', async () => {
   const card = new MemoryCard();
-  const hardware = new MemoryHardware();
 
-  await hardware.setCardReaderConnected(true);
   card.insertCard();
 
-  const { result } = renderHook(() => useSmartcard({ card, hardware }));
+  const { result } = renderHook(() =>
+    useSmartcard({ card, hasCardReaderAttached: true })
+  );
   await advanceTimersAndPromises(CARD_POLLING_INTERVAL / 1000);
 
   jest.spyOn(card, 'readLongUint8Array').mockRejectedValue(new Error('oh no'));
 
-  const [smartcard] = result.current;
+  const smartcard = result.current;
   await act(async () => {
     expect((await smartcard?.readLongUint8Array())?.err()?.message).toEqual(
       'oh no'
@@ -324,16 +317,16 @@ test('reading long binary value fails', async () => {
 
 test('writing long object value succeeds', async () => {
   const card = new MemoryCard();
-  const hardware = new MemoryHardware();
 
-  await hardware.setCardReaderConnected(true);
   card.insertCard();
 
-  const { result } = renderHook(() => useSmartcard({ card, hardware }));
+  const { result } = renderHook(() =>
+    useSmartcard({ card, hasCardReaderAttached: true })
+  );
 
   await advanceTimersAndPromises(CARD_POLLING_INTERVAL / 1000);
 
-  const [smartcard] = result.current;
+  const smartcard = result.current;
   await act(async () => {
     (await smartcard?.writeLongValue(Uint8Array.of(1, 2, 3)))?.unsafeUnwrap();
   });
@@ -343,17 +336,17 @@ test('writing long object value succeeds', async () => {
 
 test('writing long object value fails', async () => {
   const card = new MemoryCard();
-  const hardware = new MemoryHardware();
 
-  await hardware.setCardReaderConnected(true);
   card.insertCard();
 
-  const { result } = renderHook(() => useSmartcard({ card, hardware }));
+  const { result } = renderHook(() =>
+    useSmartcard({ card, hasCardReaderAttached: true })
+  );
   await advanceTimersAndPromises(CARD_POLLING_INTERVAL / 1000);
 
   jest.spyOn(card, 'writeLongObject').mockRejectedValue(new Error('oh no'));
 
-  const [smartcard] = result.current;
+  const smartcard = result.current;
   await act(async () => {
     expect((await smartcard?.writeLongValue(''))?.err()?.message).toEqual(
       'oh no'
@@ -363,17 +356,17 @@ test('writing long object value fails', async () => {
 
 test('writing long binary value fails', async () => {
   const card = new MemoryCard();
-  const hardware = new MemoryHardware();
 
-  await hardware.setCardReaderConnected(true);
   card.insertCard();
 
-  const { result } = renderHook(() => useSmartcard({ card, hardware }));
+  const { result } = renderHook(() =>
+    useSmartcard({ card, hasCardReaderAttached: true })
+  );
   await advanceTimersAndPromises(CARD_POLLING_INTERVAL / 1000);
 
   jest.spyOn(card, 'writeLongUint8Array').mockRejectedValue(new Error('oh no'));
 
-  const [smartcard] = result.current;
+  const smartcard = result.current;
   await act(async () => {
     expect(
       (await smartcard?.writeLongValue(Uint8Array.of(1, 2, 3)))?.err()?.message

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -5,6 +5,7 @@ export * from './ButtonList';
 export * from './ContestTally';
 export * from './hooks/useAutocomplete';
 export * from './hooks/useCancelablePromise';
+export * from './hooks/useHardware';
 export * from './hooks/useNow';
 export * from './hooks/usePrevious';
 export * from './hooks/useSmartcard';

--- a/libs/utils/src/Hardware/MemoryHardware.test.ts
+++ b/libs/utils/src/Hardware/MemoryHardware.test.ts
@@ -13,6 +13,7 @@ it('has a standard config with all the typical hardware', async (done) => {
         OmniKeyCardReaderDeviceName,
         'USB Advanced Audio Device',
         'HL-L5100DN_series',
+        'Scanner',
       ])
     );
 
@@ -145,6 +146,16 @@ it('reports printer status as not connected if there are no connected printers',
   const hardware = await MemoryHardware.build();
   await hardware.setPrinterConnected(false);
   expect(await hardware.readPrinterStatus()).toEqual({ connected: false });
+});
+
+it('can remove printers', async (done) => {
+  const hardware = await MemoryHardware.build();
+  await hardware.setPrinterConnected(true);
+  await hardware.detachAllPrinters();
+  hardware.printers.subscribe((printers) => {
+    expect(Array.from(printers)).toEqual([]);
+    done();
+  });
 });
 
 it('can set and read battery level', async () => {

--- a/libs/utils/src/Hardware/MemoryHardware.ts
+++ b/libs/utils/src/Hardware/MemoryHardware.ts
@@ -10,6 +10,8 @@ import {
   OmniKeyCardReaderManufacturer,
   OmniKeyCardReaderProductId,
   OmniKeyCardReaderVendorId,
+  FujitsuScannerVendorId,
+  FujitsuFi7160ScannerProductId,
 } from './utils';
 
 /**
@@ -53,14 +55,26 @@ export class MemoryHardware implements Hardware {
     serialNumber: '',
   };
 
+  private batchScanner: Readonly<KioskBrowser.Device> = {
+    deviceAddress: 0,
+    deviceName: 'Scanner',
+    locationId: 0,
+    manufacturer: 'Fujitsu',
+    vendorId: FujitsuScannerVendorId,
+    productId: FujitsuFi7160ScannerProductId,
+    serialNumber: '',
+  };
+
   static async build({
     connectPrinter = false,
     connectAccessibleController = false,
     connectCardReader = false,
+    connectBatchScanner = false,
   }: {
     connectPrinter?: boolean;
     connectAccessibleController?: boolean;
     connectCardReader?: boolean;
+    connectBatchScanner?: boolean;
   } = {}): Promise<MemoryHardware> {
     const newMemoryHardware = new MemoryHardware();
     await newMemoryHardware.setPrinterConnected(connectPrinter);
@@ -68,6 +82,7 @@ export class MemoryHardware implements Hardware {
       connectAccessibleController
     );
     await newMemoryHardware.setCardReaderConnected(connectCardReader);
+    await newMemoryHardware.setBatchScannerConnected(connectBatchScanner);
     return newMemoryHardware;
   }
 
@@ -76,6 +91,7 @@ export class MemoryHardware implements Hardware {
       connectPrinter: true,
       connectAccessibleController: true,
       connectCardReader: true,
+      connectBatchScanner: true,
     });
   }
 
@@ -84,6 +100,7 @@ export class MemoryHardware implements Hardware {
       connectPrinter: true,
       connectAccessibleController: false,
       connectCardReader: true,
+      connectBatchScanner: true,
     });
   }
 
@@ -92,6 +109,13 @@ export class MemoryHardware implements Hardware {
    */
   async setAccessibleControllerConnected(connected: boolean): Promise<void> {
     this.setDeviceConnected(this.accessibleController, connected);
+  }
+
+  /**
+   * Sets Batch Scanner connected
+   */
+  async setBatchScannerConnected(connected: boolean): Promise<void> {
+    this.setDeviceConnected(this.batchScanner, connected);
   }
 
   /**
@@ -151,6 +175,13 @@ export class MemoryHardware implements Hardware {
         status: 0,
       },
     ]);
+  }
+
+  /**
+   * Detaches all printers
+   */
+  async detachAllPrinters(): Promise<void> {
+    this.printersSubject.next([]);
   }
 
   private devicesSubject = new BehaviorSubject(this.connectedDevices);

--- a/libs/utils/src/Hardware/index.test.ts
+++ b/libs/utils/src/Hardware/index.test.ts
@@ -1,11 +1,18 @@
 import { fakeDevice, fakeKiosk } from '@votingworks/test-utils';
-import { getHardware } from '.';
+import {
+  FujitsuScannerVendorId,
+  getHardware,
+  isFujitsuScanner,
+  PlustekScannerVendorId,
+  PlustekVTM300ScannerProductId,
+} from '.';
 import { KioskHardware } from './KioskHardware';
 import {
   AccessibleControllerProductId,
   AccessibleControllerVendorId,
   isAccessibleController,
   isCardReader,
+  isPlustekVTM300Scanner,
   OmniKeyCardReaderDeviceName,
   OmniKeyCardReaderManufacturer,
   OmniKeyCardReaderProductId,
@@ -75,6 +82,35 @@ it('isAccessibleController matches a device with the right vendor and product id
       fakeDevice({
         vendorId: AccessibleControllerVendorId,
         productId: AccessibleControllerProductId,
+      })
+    )
+  ).toBe(true);
+});
+
+it('isFujitsuScanner does not match just any device', () => {
+  expect(isFujitsuScanner(fakeDevice())).toBe(false);
+});
+
+it('isFujitsuScanner matches a device with the right vendor and product id', () => {
+  expect(
+    isFujitsuScanner(
+      fakeDevice({
+        vendorId: FujitsuScannerVendorId,
+      })
+    )
+  ).toBe(true);
+});
+
+it('isPlustekVTM300Scanner does not match just any device', () => {
+  expect(isPlustekVTM300Scanner(fakeDevice())).toBe(false);
+});
+
+it('isFujitsuScanner matches a device with the right vendor and product id', () => {
+  expect(
+    isPlustekVTM300Scanner(
+      fakeDevice({
+        vendorId: PlustekScannerVendorId,
+        productId: PlustekVTM300ScannerProductId,
       })
     )
   ).toBe(true);

--- a/libs/utils/src/Hardware/utils.ts
+++ b/libs/utils/src/Hardware/utils.ts
@@ -1,9 +1,6 @@
 export const AccessibleControllerVendorId = 0x0d8c;
 export const AccessibleControllerProductId = 0x0170;
 
-export const BrotherHLL5100DNVendorId = 0x04f9;
-export const BrotherHLL5100DNProductId = 0x007f;
-
 /**
  * Determines whether a device is the accessible controller.
  */
@@ -31,6 +28,9 @@ export function isCardReader(device: KioskBrowser.Device): boolean {
   );
 }
 
+export const BrotherHLL5100DNVendorId = 0x04f9;
+export const BrotherHLL5100DNProductId = 0x007f;
+
 /**
  * Determines whether a device is a supported printer.
  */
@@ -38,5 +38,20 @@ export function isPrinter(device: KioskBrowser.Device): boolean {
   return (
     device.vendorId === BrotherHLL5100DNVendorId &&
     device.productId === BrotherHLL5100DNProductId
+  );
+}
+
+export const FujitsuScannerVendorId = 0x4c5;
+export const FujitsuFi7160ScannerProductId = 0x132e;
+export function isFujitsuScanner(device: KioskBrowser.Device): boolean {
+  return device.vendorId === FujitsuScannerVendorId;
+}
+
+export const PlustekScannerVendorId = 0x7b3;
+export const PlustekVTM300ScannerProductId = 0xe37;
+export function isPlustekVTM300Scanner(device: KioskBrowser.Device): boolean {
+  return (
+    device.vendorId === PlustekScannerVendorId &&
+    device.productId === PlustekVTM300ScannerProductId
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,7 @@ importers:
       '@types/react': 17.0.0
       '@types/react-dom': 17.0.0
       '@types/styled-components': 5.1.7
+      '@votingworks/logging': link:../../libs/logging
       '@votingworks/types': link:../../libs/types
       '@votingworks/ui': link:../../libs/ui
       '@votingworks/utils': link:../../libs/utils
@@ -74,6 +75,7 @@ importers:
       '@types/styled-components': ^5.1.7
       '@typescript-eslint/eslint-plugin': ^4.28.4
       '@typescript-eslint/parser': ^4.28.4
+      '@votingworks/logging': workspace:*
       '@votingworks/types': workspace:*
       '@votingworks/ui': workspace:*
       '@votingworks/utils': workspace:*
@@ -131,6 +133,7 @@ importers:
       '@types/styled-components': 5.1.7
       '@votingworks/ballot-encoder': link:../../libs/ballot-encoder
       '@votingworks/fixtures': link:../../libs/fixtures
+      '@votingworks/logging': link:../../libs/logging
       '@votingworks/qrcode.react': 1.0.1_react@17.0.1
       '@votingworks/types': link:../../libs/types
       '@votingworks/ui': link:../../libs/ui
@@ -230,6 +233,7 @@ importers:
       '@typescript-eslint/parser': ^4.28.4
       '@votingworks/ballot-encoder': workspace:*
       '@votingworks/fixtures': workspace:*
+      '@votingworks/logging': workspace:*
       '@votingworks/qrcode.react': ^1.0.1
       '@votingworks/test-utils': workspace:*
       '@votingworks/types': workspace:*


### PR DESCRIPTION
Creates a shared useHardware hook that controls all of the hasXAttached boolean flags for when various devices are attached. I added one for the plustek scanner in case we want that in the future (and to log it) but it isn't used anywhere yet. The Fujitsu scanner one only checks the vendor ID and not the product ID to maintain existing behavior. 

Whenever a new device or printer is attached or removed there are logs associated with it, even if its not a device that we have a specific flag for. 

Note: I had to commit with --no-verify as there was an issue with stylelint in BAS, I'm seeing this issue in main as well. 

Future Work: Add the charger unplugged / low battery logic to this hook.