### PR TITLE
refactor(types): use more specific `Id` types

### DIFF
--- a/libs/ballot-encoder/src/index.ts
+++ b/libs/ballot-encoder/src/index.ts
@@ -1,5 +1,6 @@
 import {
   AnyContest,
+  BallotId,
   BallotLocale,
   BallotStyleId,
   BallotType,
@@ -104,7 +105,7 @@ export function detect(data: Uint8Array): boolean {
  * Data needed to uniquely identify a ballot page, possibly including an ID.
  */
 export interface BallotConfig {
-  ballotId?: string;
+  ballotId?: BallotId;
   ballotStyleId: BallotStyleId;
   ballotType: BallotType;
   isTestMode: boolean;

--- a/libs/test-utils/src/arbitraries.ts
+++ b/libs/test-utils/src/arbitraries.ts
@@ -59,30 +59,51 @@ export function arbitraryId(): fc.Arbitrary<Id> {
   );
 }
 
+/**
+ * Builds values suitable for ballot style IDs.
+ */
 export function arbitraryBallotStyleId(): fc.Arbitrary<BallotStyleId> {
   return arbitraryId();
 }
 
+/**
+ * Builds values suitable for candidate IDs.
+ */
 export function arbitraryCandidateId(): fc.Arbitrary<CandidateId> {
   return arbitraryId();
 }
 
+/**
+ * Builds values suitable for contest IDs.
+ */
 export function arbitraryContestId(): fc.Arbitrary<ContestId> {
   return arbitraryId();
 }
 
+/**
+ * Builds values suitable for county IDs.
+ */
 export function arbitraryCountyId(): fc.Arbitrary<CountyId> {
   return arbitraryId();
 }
 
+/**
+ * Builds values suitable for district IDs.
+ */
 export function arbitraryDistrictId(): fc.Arbitrary<DistrictId> {
   return arbitraryId();
 }
 
+/**
+ * Builds values suitable for party IDs.
+ */
 export function arbitraryPartyId(): fc.Arbitrary<PartyId> {
   return arbitraryId();
 }
 
+/**
+ * Builds values suitable for precinct IDs.
+ */
 export function arbitraryPrecinctId(): fc.Arbitrary<PrecinctId> {
   return arbitraryId();
 }

--- a/libs/types/src/generic.ts
+++ b/libs/types/src/generic.ts
@@ -186,7 +186,7 @@ export function maybeParse<T>(
 }
 
 export type Id = string;
-export const IdSchema = z
+export const IdSchema: z.ZodSchema<Id> = z
   .string()
   .nonempty()
   .refine((id) => !id.startsWith('_'), 'IDs may not start with an underscore')

--- a/libs/utils/src/votes.ts
+++ b/libs/utils/src/votes.ts
@@ -10,7 +10,6 @@ import {
   expandEitherNeitherContests,
   getDistrictIdsForPartyId,
   getEitherNeitherContests,
-  Id,
   Tally,
   VotesDict,
   VotingMethod,
@@ -25,6 +24,7 @@ import {
   writeInCandidate,
   PartyId,
   PrecinctId,
+  CandidateId,
 } from '@votingworks/types';
 import { strict as assert } from 'assert';
 import { find } from './find';
@@ -39,7 +39,7 @@ export function getSingleYesNoVote(vote?: YesNoVote): YesOrNo | undefined {
   return undefined;
 }
 
-export function normalizeWriteInId(candidateId: Id): string {
+export function normalizeWriteInId(candidateId: CandidateId): string {
   if (
     candidateId.startsWith('__writein') ||
     candidateId.startsWith('__write-in') ||


### PR DESCRIPTION
This is to prepare for enforcing that `string` cannot be assigned to `Id` or one of the more specific `Id` types.