### PR TITLE
refactor(all): `safeParse` helpers

### DIFF
--- a/apps/bmd/src/utils/machine_config.ts
+++ b/apps/bmd/src/utils/machine_config.ts
@@ -1,4 +1,4 @@
-import { Provider, safeParse } from '@votingworks/types';
+import { Provider, unsafeParse } from '@votingworks/types';
 import { fetchJson } from '@votingworks/utils';
 import {
   getAppMode,
@@ -8,10 +8,10 @@ import {
 
 export const machineConfigProvider: Provider<MachineConfig> = {
   async get() {
-    const { appModeName, machineId, codeVersion } = safeParse(
+    const { appModeName, machineId, codeVersion } = unsafeParse(
       MachineConfigResponseSchema,
       await fetchJson('/machine-config')
-    ).unsafeUnwrap();
+    );
 
     return {
       appMode: getAppMode(appModeName),

--- a/apps/bsd/src/api/config.ts
+++ b/apps/bsd/src/api/config.ts
@@ -3,8 +3,8 @@ import {
   MarkThresholds,
   Optional,
   Precinct,
-  safeParse,
   safeParseJson,
+  unsafeParse,
 } from '@votingworks/types';
 import {
   GetCurrentPrecinctResponseSchema,
@@ -126,10 +126,10 @@ export async function setTestMode(testMode: boolean): Promise<void> {
 export async function getMarkThresholdOverrides(): Promise<
   MarkThresholds | undefined
 > {
-  const { markThresholdOverrides } = safeParse(
+  const { markThresholdOverrides } = unsafeParse(
     GetMarkThresholdOverridesConfigResponseSchema,
     await fetchJson('/config/markThresholdOverrides')
-  ).unsafeUnwrap();
+  );
   return markThresholdOverrides;
 }
 

--- a/apps/bsd/src/api/hmpb.ts
+++ b/apps/bsd/src/api/hmpb.ts
@@ -1,4 +1,4 @@
-import { ElectionDefinition, safeParse } from '@votingworks/types';
+import { ElectionDefinition, unsafeParse } from '@votingworks/types';
 import { EventEmitter } from 'events';
 import {
   fetchJson,
@@ -97,10 +97,10 @@ export async function fetchNextBallotSheetToReview(): Promise<
   GetNextReviewSheetResponse | undefined
 > {
   try {
-    return safeParse(
+    return unsafeParse(
       GetNextReviewSheetResponseSchema,
       await fetchJson('/scan/hmpb/review/next-sheet')
-    ).unsafeUnwrap();
+    );
   } catch {
     return undefined;
   }

--- a/apps/bsd/src/util/machine_config.ts
+++ b/apps/bsd/src/util/machine_config.ts
@@ -1,4 +1,4 @@
-import { Provider, safeParse } from '@votingworks/types';
+import { Provider, unsafeParse } from '@votingworks/types';
 import { fetchJson } from '@votingworks/utils';
 import { MachineConfigResponseSchema } from '../config/types';
 
@@ -7,10 +7,10 @@ export const machineConfigProvider: Provider<{
   bypassAuthentication: boolean;
 }> = {
   async get() {
-    const { machineId, bypassAuthentication } = safeParse(
+    const { machineId, bypassAuthentication } = unsafeParse(
       MachineConfigResponseSchema,
       await fetchJson('/machine-config')
-    ).unsafeUnwrap();
+    );
 
     return {
       machineId,

--- a/apps/election-manager/src/utils/machine_config.ts
+++ b/apps/election-manager/src/utils/machine_config.ts
@@ -1,13 +1,13 @@
-import { Provider, safeParse } from '@votingworks/types';
+import { Provider, unsafeParse } from '@votingworks/types';
 import { fetchJson } from '@votingworks/utils';
 import { MachineConfig, MachineConfigSchema } from '../config/types';
 
 export const machineConfigProvider: Provider<MachineConfig> = {
   async get() {
-    const { machineId, codeVersion, bypassAuthentication } = safeParse(
+    const { machineId, codeVersion, bypassAuthentication } = unsafeParse(
       MachineConfigSchema,
       await fetchJson('/machine-config')
-    ).unsafeUnwrap();
+    );
 
     return {
       machineId,

--- a/apps/module-scan/src/globals.ts
+++ b/apps/module-scan/src/globals.ts
@@ -1,4 +1,4 @@
-import { safeParse } from '@votingworks/types';
+import { unsafeParse } from '@votingworks/types';
 import { join } from 'path';
 import { z } from 'zod';
 
@@ -37,10 +37,10 @@ export const MODULE_SCAN_PORT = Number(process.env.PORT || 3002);
 /**
  * Which machine type is this?
  */
-export const VX_MACHINE_TYPE = safeParse(
+export const VX_MACHINE_TYPE = unsafeParse(
   MachineTypeSchema,
   process.env.VX_MACHINE_TYPE ?? 'bsd'
-).unsafeUnwrap();
+);
 
 export enum ScannerLocation {
   Central = 'Central',
@@ -60,10 +60,10 @@ export const VX_MACHINE_ID = process.env.VX_MACHINE_ID ?? '000';
 /**
  * Which node environment is this?
  */
-export const NODE_ENV = safeParse(
+export const NODE_ENV = unsafeParse(
   NodeEnvSchema,
   process.env.NODE_ENV ?? 'development'
-).unsafeUnwrap();
+);
 
 /**
  * Where should the database and image files etc go?

--- a/apps/precinct-scanner/src/api/scan.ts
+++ b/apps/precinct-scanner/src/api/scan.ts
@@ -1,8 +1,8 @@
 import {
   AdjudicationReasonInfo,
   CastVoteRecord,
-  safeParse,
   safeParseJson,
+  unsafeParse,
 } from '@votingworks/types';
 import {
   CalibrateResponseSchema,
@@ -28,10 +28,10 @@ export interface ScannerStatusDetails {
 }
 
 export async function getCurrentStatus(): Promise<ScannerStatusDetails> {
-  const { scanner, batches, adjudication } = safeParse(
+  const { scanner, batches, adjudication } = unsafeParse(
     GetScanStatusResponseSchema,
     await fetchJson('/scan/status')
-  ).unsafeUnwrap();
+  );
   const ballotCount =
     batches &&
     batches
@@ -56,10 +56,10 @@ export async function scanDetectedSheet(): Promise<ScanningResult> {
   const { batchId } = result;
 
   for (;;) {
-    const status = safeParse(
+    const status = unsafeParse(
       GetScanStatusResponseSchema,
       await fetchJson('/scan/status')
-    ).unsafeUnwrap();
+    );
     const batch = status.batches.find(({ id }) => id === batchId);
 
     if (!batch) {
@@ -79,10 +79,10 @@ export async function scanDetectedSheet(): Promise<ScanningResult> {
 
     const adjudicationReasons: AdjudicationReasonInfo[] = [];
     if (status.adjudication.remaining > 0) {
-      const sheetInfo = safeParse(
+      const sheetInfo = unsafeParse(
         GetNextReviewSheetResponseSchema,
         await fetchJson('/scan/hmpb/review/next-sheet')
-      ).unsafeUnwrap();
+      );
 
       for (const { interpretation } of [
         sheetInfo.interpreted.front,

--- a/apps/precinct-scanner/src/utils/machine_config.ts
+++ b/apps/precinct-scanner/src/utils/machine_config.ts
@@ -1,13 +1,13 @@
-import { Provider, safeParse } from '@votingworks/types';
+import { Provider, unsafeParse } from '@votingworks/types';
 import { fetchJson } from '@votingworks/utils';
 import { MachineConfig, MachineConfigResponseSchema } from '../config/types';
 
 export const machineConfigProvider: Provider<MachineConfig> = {
   async get() {
-    const { machineId, codeVersion, bypassAuthentication } = safeParse(
+    const { machineId, codeVersion, bypassAuthentication } = unsafeParse(
       MachineConfigResponseSchema,
       await fetchJson('/machine-config')
-    ).unsafeUnwrap();
+    );
 
     return {
       machineId,

--- a/codemods/package.json
+++ b/codemods/package.json
@@ -14,11 +14,15 @@
   },
   "dependencies": {
     "@babel/core": "^7.16.0",
-    "@babel/types": "^7.15.0",
+    "@babel/types": "^7.16.0",
     "ts-morph": "^12.2.0"
   },
   "devDependencies": {
+    "@babel/generator": "^7.16.0",
+    "@babel/traverse": "^7.16.0",
     "@types/babel__core": "^7.1.16",
+    "@types/babel__generator": "^7.6.3",
+    "@types/babel__traverse": "^7.14.2",
     "@types/jest": "^27.0.2",
     "@types/node": "^16.11.6",
     "@typescript-eslint/eslint-plugin": "^5.3.0",

--- a/codemods/src/safeParseHelpers.test.ts
+++ b/codemods/src/safeParseHelpers.test.ts
@@ -1,0 +1,164 @@
+import { NodePath, parseSync, transformSync } from '@babel/core';
+import generate from '@babel/generator';
+import traverse from '@babel/traverse';
+import * as t from '@babel/types';
+import plugin, { addSpecifierToImport } from './safeParseHelpers';
+
+function check(input: string, output: string): void {
+  expect(
+    transformSync(input, {
+      plugins: [plugin],
+      parserOpts: { plugins: ['jsx', 'typescript'] },
+    })?.code
+  ).toEqual(output.trim());
+}
+
+test('transforms to unsafeParse', () => {
+  check(
+    `safeParse(Parser, value).unsafeUnwrap();`,
+    `unsafeParse(Parser, value);`
+  );
+});
+
+test('transforms to unsafeParse with imports', () => {
+  check(
+    [
+      `import { safeParse, Translations } from '@votingworks/types';`,
+      `safeParse(Parser, value).unsafeUnwrap();`,
+    ].join('\n'),
+    [
+      `import { Translations, unsafeParse } from '@votingworks/types';`,
+      `unsafeParse(Parser, value);`,
+    ].join('\n')
+  );
+});
+
+test('does not add duplicate imports', () => {
+  check(
+    [
+      `import { safeParse, unsafeParse } from '@votingworks/types';`,
+      `safeParse(Parser, value).unsafeUnwrap();`,
+    ].join('\n'),
+    [
+      `import { unsafeParse } from '@votingworks/types';`,
+      `unsafeParse(Parser, value);`,
+    ].join('\n')
+  );
+
+  check(
+    [
+      `import { safeParse } from '@votingworks/types';`,
+      `safeParse(Parser, value).unsafeUnwrap();`,
+      `safeParse(Parser, value).unsafeUnwrap();`,
+    ].join('\n'),
+    [
+      `import { unsafeParse } from '@votingworks/types';`,
+      `unsafeParse(Parser, value);`,
+      `unsafeParse(Parser, value);`,
+    ].join('\n')
+  );
+});
+
+test('ignores malformed safeParse call', () => {
+  check(
+    `safeParse(Parser).unsafeUnwrap();`,
+    `safeParse(Parser).unsafeUnwrap();`
+  );
+});
+
+test('ignores malformed unsafeUnwrap call', () => {
+  check(
+    `safeParse(Parser, value).unsafeUnwrap(arg);`,
+    `safeParse(Parser, value).unsafeUnwrap(arg);`
+  );
+});
+
+test('transforms to maybeParse', () => {
+  check(`safeParse(Parser, value).ok();`, `maybeParse(Parser, value);`);
+});
+
+test('transforms to maybeParse with imports', () => {
+  check(
+    [
+      `import { safeParse } from '@votingworks/types';`,
+      `safeParse(Parser, value).ok();`,
+    ].join('\n'),
+    [
+      `import { maybeParse } from '@votingworks/types';`,
+      `maybeParse(Parser, value);`,
+    ].join('\n')
+  );
+});
+
+test('ignores other safeParse uses', () => {
+  check(`safeParse(Parser, value).err();`, `safeParse(Parser, value).err();`);
+});
+
+test('ignores malformed safeParse call', () => {
+  check(`safeParse(Parser).ok();`, `safeParse(Parser).ok();`);
+});
+
+test('ignores malformed ok call', () => {
+  check(
+    `safeParse(Parser, value).ok(arg);`,
+    `safeParse(Parser, value).ok(arg);`
+  );
+});
+
+test('addSpecifierToImport without specifiers', () => {
+  const ast = parseSync(`import '@votingworks/types';`)!;
+
+  traverse(ast, {
+    ImportDeclaration(path: NodePath<t.ImportDeclaration>): void {
+      addSpecifierToImport(path, 'ok');
+    },
+  });
+
+  expect(generate(ast).code).toEqual(
+    `import { ok } from '@votingworks/types';`
+  );
+});
+
+test('addSpecifierToImport with existing specifiers can insert at the start', () => {
+  const ast = parseSync(`import { ok } from '@votingworks/types';`)!;
+
+  traverse(ast, {
+    ImportDeclaration(path: NodePath<t.ImportDeclaration>): void {
+      addSpecifierToImport(path, 'err');
+    },
+  });
+
+  expect(generate(ast).code).toEqual(
+    `import { err, ok } from '@votingworks/types';`
+  );
+});
+
+test('addSpecifierToImport with existing specifiers can insert at the end', () => {
+  const ast = parseSync(`import { err } from '@votingworks/types';`)!;
+
+  traverse(ast, {
+    ImportDeclaration(path: NodePath<t.ImportDeclaration>): void {
+      addSpecifierToImport(path, 'ok');
+    },
+  });
+
+  expect(generate(ast).code).toEqual(
+    `import { err, ok } from '@votingworks/types';`
+  );
+});
+
+test('addSpecifierToImport with existing specifiers can insert in the middle', () => {
+  const ast = parseSync(
+    `import { Election, Precinct } from '@votingworks/types';`
+  )!;
+
+  traverse(ast, {
+    ImportDeclaration(path: NodePath<t.ImportDeclaration>): void {
+      addSpecifierToImport(path, 'ok');
+    },
+  });
+
+  expect(generate(ast).code).toEqual(
+    `import { Election, ok, Precinct } from '@votingworks/types';`
+  );
+});

--- a/codemods/src/safeParseHelpers.ts
+++ b/codemods/src/safeParseHelpers.ts
@@ -1,0 +1,130 @@
+/**
+ * Refactors a few uses of `safeParse` to use more specific helper functions.
+ *
+ * Run it like so:
+ *
+ * ```sh
+ * $ pnpx codemod -p codemods/src/safeParseHelpers.ts --printer prettier apps/ libs/
+ * ```
+ */
+import { PluginItem, NodePath } from '@babel/core';
+import * as t from '@babel/types';
+import assert from 'assert';
+
+/**
+ * Adds a named import to an existing import declaration.
+ *
+ * @VisibleForTesting
+ */
+export function addSpecifierToImport(
+  path: NodePath<t.ImportDeclaration>,
+  name: string
+): void {
+  const specifiers = path.get('specifiers');
+  const newSpecifier = t.importSpecifier(
+    t.identifier(name),
+    t.identifier(name)
+  );
+
+  if (specifiers.length === 0) {
+    path.replaceWith(
+      t.importDeclaration([newSpecifier], path.get('source').node)
+    );
+  } else {
+    let insertionIndex = 0;
+
+    for (const [i, specifier] of specifiers.entries()) {
+      switch (
+        specifier.node.local.name.localeCompare(name, undefined, {
+          sensitivity: 'base',
+        })
+      ) {
+        case 0:
+          return;
+
+        case -1:
+          insertionIndex = i + 1;
+          break;
+
+        default:
+          // nothing to do
+          break;
+      }
+    }
+
+    if (insertionIndex === 0) {
+      specifiers[0].insertBefore(newSpecifier);
+    } else {
+      specifiers[insertionIndex - 1].insertAfter(newSpecifier);
+    }
+  }
+}
+
+export default (): PluginItem => {
+  return {
+    visitor: {
+      CallExpression(path: NodePath<t.CallExpression>): void {
+        const callee = path.get('callee');
+
+        if (!callee.isMemberExpression() || path.get('arguments').length > 0) {
+          return;
+        }
+
+        const object = callee.get('object');
+        const property = callee.get('property');
+
+        if (
+          callee.node.computed ||
+          !property.isIdentifier() ||
+          !object.isCallExpression() ||
+          !object.get('callee').isIdentifier({ name: 'safeParse' }) ||
+          object.get('arguments').length !== 2
+        ) {
+          return;
+        }
+
+        const replacementHelper =
+          property.node.name === 'unsafeUnwrap'
+            ? 'unsafeParse'
+            : property.node.name === 'ok'
+            ? 'maybeParse'
+            : undefined;
+
+        if (replacementHelper) {
+          const binding = path.scope.getBinding('safeParse');
+
+          if (binding) {
+            if (binding.path.isImportSpecifier()) {
+              /* istanbul ignore next - helps TS with type narrowing */
+              assert(binding.path.parentPath?.isImportDeclaration());
+              addSpecifierToImport(binding.path.parentPath, replacementHelper);
+            }
+          }
+
+          path.replaceWith(
+            t.callExpression(
+              t.identifier(replacementHelper),
+              object.node.arguments
+            )
+          );
+        }
+      },
+
+      Program: {
+        // Clean up any `safeParse` imports that aren't used anymore.
+        exit(path: NodePath<t.Program>): void {
+          path.scope.crawl();
+
+          const binding = path.scope.getBinding('safeParse');
+          if (
+            binding &&
+            !binding.referenced &&
+            binding.path.isImportSpecifier()
+          ) {
+            binding.path.remove();
+          }
+        },
+      },
+    },
+  };
+};

--- a/libs/test-utils/src/arbitraries.test.ts
+++ b/libs/test-utils/src/arbitraries.test.ts
@@ -1,8 +1,8 @@
 import {
   IdSchema,
-  safeParse,
   safeParseElection,
   safeParseElectionDefinition,
+  unsafeParse,
   YesNoOptionSchema,
 } from '@votingworks/types';
 import { strict as assert } from 'assert';
@@ -20,7 +20,7 @@ import {
 test('arbitraryId', () => {
   fc.assert(
     fc.property(arbitraryId(), (id) => {
-      safeParse(IdSchema, id).unsafeUnwrap();
+      unsafeParse(IdSchema, id);
     })
   );
 });
@@ -41,7 +41,7 @@ test('arbitraryDateTime', () => {
 test('arbitraryYesNoOption', () => {
   fc.assert(
     fc.property(arbitraryYesNoOption(), (option) => {
-      safeParse(YesNoOptionSchema, option).unsafeUnwrap();
+      unsafeParse(YesNoOptionSchema, option);
     })
   );
 

--- a/libs/types/src/api/index.test.ts
+++ b/libs/types/src/api/index.test.ts
@@ -1,15 +1,15 @@
-import { safeParse } from '..';
+import { safeParse, unsafeParse } from '..';
 import { ErrorsResponseSchema, OkResponseSchema } from '.';
 
 test('OkResponse', () => {
-  safeParse(OkResponseSchema, { status: 'ok' }).unsafeUnwrap();
+  unsafeParse(OkResponseSchema, { status: 'ok' });
   safeParse(OkResponseSchema, {}).unsafeUnwrapErr();
 });
 
 test('ErrorsResponse', () => {
-  safeParse(ErrorsResponseSchema, {
+  unsafeParse(ErrorsResponseSchema, {
     status: 'error',
     errors: [],
-  }).unsafeUnwrap();
+  });
   safeParse(ErrorsResponseSchema, { status: 'ok' }).unsafeUnwrapErr();
 });

--- a/libs/types/src/election.test.ts
+++ b/libs/types/src/election.test.ts
@@ -20,7 +20,7 @@ import {
   withLocale,
   YesNoContest,
 } from './election';
-import { safeParse } from './generic';
+import { unsafeParse } from './generic';
 
 test('can build votes from a candidate ID', () => {
   const contests = election.contests.filter((c) => c.id === 'CC');
@@ -289,13 +289,13 @@ test('pulls translation keys from nested objects', () => {
       {
         ...election,
         parties: [
-          safeParse(PartySchema, {
+          unsafeParse(PartySchema, {
             id: 'FED',
             name: 'Federalist',
             abbrev: 'FED',
             fullName: 'Federalist',
             _lang: { 'es-US': { name: 'Federalista' } },
-          }).unsafeUnwrap(),
+          }),
         ],
         _lang: { 'es-US': {} },
       },

--- a/libs/types/src/generic.test.ts
+++ b/libs/types/src/generic.test.ts
@@ -1,4 +1,5 @@
-import { err, ok } from './generic';
+import { z } from 'zod';
+import { err, maybeParse, ok, unsafeParse } from './generic';
 
 test('ok is Ok', () => {
   expect(ok(0).isOk()).toBe(true);
@@ -52,4 +53,14 @@ test('err unsafeUnwrap', () => {
 
 test('err unsafeUnwrapErr', () => {
   expect(err('error').unsafeUnwrapErr()).toBe('error');
+});
+
+test('unsafeParse', () => {
+  expect(unsafeParse(z.string(), 'hello world!')).toEqual('hello world!');
+  expect(() => unsafeParse(z.string(), 99)).toThrowError();
+});
+
+test('maybeParse', () => {
+  expect(maybeParse(z.string(), 'hello world!')).toEqual('hello world!');
+  expect(maybeParse(z.string(), 99)).toBeUndefined();
 });

--- a/libs/types/src/generic.ts
+++ b/libs/types/src/generic.ts
@@ -168,6 +168,23 @@ export function safeParseJson<T>(
   return parser ? safeParse(parser, parsed) : ok(parsed);
 }
 
+/**
+ * Parse `value` using `parser` or throw an exception if parsing fails.
+ */
+export function unsafeParse<T>(parser: z.ZodType<T>, value: unknown): T {
+  return safeParse(parser, value).unsafeUnwrap();
+}
+
+/**
+ * Parser `value` using `parser` or return `undefined` if parsing fails.
+ */
+export function maybeParse<T>(
+  parser: z.ZodType<T>,
+  value: unknown
+): T | undefined {
+  return safeParse(parser, value).ok();
+}
+
 export type Id = string;
 export const IdSchema = z
   .string()

--- a/libs/types/src/schema.test.ts
+++ b/libs/types/src/schema.test.ts
@@ -4,7 +4,7 @@ import {
   electionWithMsEitherNeither,
 } from '../test/election';
 import * as t from './election';
-import { safeParse, safeParseJson } from './generic';
+import { safeParse, safeParseJson, unsafeParse } from './generic';
 
 test('parseElection', () => {
   expect(() => t.parseElection({})).toThrowError();
@@ -775,10 +775,10 @@ test('validates uniqueness of candidate ids within a contest', () => {
 });
 
 test('validates admin cards have hex-encoded hashes', () => {
-  safeParse(t.AdminCardDataSchema, {
+  unsafeParse(t.AdminCardDataSchema, {
     t: 'admin',
     h: 'd34db33f',
-  }).unsafeUnwrap();
+  });
   expect(
     safeParse(t.AdminCardDataSchema, {
       t: 'admin',

--- a/libs/ui/src/hooks/use_stored_state.ts
+++ b/libs/ui/src/hooks/use_stored_state.ts
@@ -1,4 +1,4 @@
-import { Optional, safeParse } from '@votingworks/types';
+import { Optional, unsafeParse } from '@votingworks/types';
 import { Storage } from '@votingworks/utils';
 import {
   Dispatch,
@@ -42,9 +42,7 @@ export function useStoredState<S>(
     void (async () => {
       const valueItem = await makeCancelable(storage.get(key));
       setInnerValue((prev) =>
-        typeof valueItem !== 'undefined'
-          ? safeParse(schema, valueItem).unsafeUnwrap()
-          : prev
+        typeof valueItem !== 'undefined' ? unsafeParse(schema, valueItem) : prev
       );
     })();
   }, [key, makeCancelable, schema, storage]);

--- a/libs/utils/src/Card/web_service_card.ts
+++ b/libs/utils/src/Card/web_service_card.ts
@@ -2,8 +2,8 @@ import {
   ok,
   Optional,
   Result,
-  safeParse,
   safeParseJson,
+  unsafeParse,
 } from '@votingworks/types';
 import { fromByteArray, toByteArray } from 'base64-js';
 import { z } from 'zod';
@@ -19,10 +19,7 @@ export class WebServiceCard implements Card {
    * what its short value is and whether it has a long value.
    */
   async readStatus(): Promise<CardApi> {
-    return safeParse(
-      CardApiSchema,
-      await fetchJson('/card/read')
-    ).unsafeUnwrap();
+    return unsafeParse(CardApiSchema, await fetchJson('/card/read'));
   }
 
   /**

--- a/libs/utils/src/filenames.ts
+++ b/libs/utils/src/filenames.ts
@@ -4,7 +4,7 @@ import {
   Election,
   ElectionDefinition,
   MachineId,
-  safeParse,
+  maybeParse,
 } from '@votingworks/types';
 
 const SECTION_SEPARATOR = '__';
@@ -104,7 +104,7 @@ export function generateFilenameForScanningResults(
   time: Date = new Date()
 ): string {
   const machineString = `machine${SUBSECTION_SEPARATOR}${
-    safeParse(MachineId, machineId).ok() ?? sanitizeString(machineId)
+    maybeParse(MachineId, machineId) ?? sanitizeString(machineId)
   }`;
   const ballotString = `${numBallotsScanned}${SUBSECTION_SEPARATOR}ballots`;
   const timeInformation = moment(time).format(TIME_FORMAT_STRING);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,7 +144,7 @@ importers:
       dompurify: 2.2.6
       fetch-mock: 9.11.0
       history: 4.10.1
-      http-proxy-middleware: 1.0.6
+      http-proxy-middleware: 1.0.6_debug@4.3.2
       lodash.camelcase: 4.3.0
       luxon: 1.26.0
       mockdate: 3.0.2
@@ -492,7 +492,7 @@ importers:
       dompurify: 2.2.6
       fetch-mock: 9.11.0
       history: 4.10.1
-      http-proxy-middleware: 1.0.6
+      http-proxy-middleware: 1.0.6_debug@4.3.2
       i18next: 19.8.4
       js-file-download: 0.4.12
       js-sha256: 0.9.0
@@ -823,7 +823,7 @@ importers:
       base64-js: 1.5.1
       debug: 4.3.1
       fetch-mock: 9.11.0
-      http-proxy-middleware: 1.0.6
+      http-proxy-middleware: 1.0.6_debug@4.3.1
       i18next: 19.8.4
       jest-fetch-mock: 3.0.3
       js-file-download: 0.4.12
@@ -966,10 +966,14 @@ importers:
   codemods:
     dependencies:
       '@babel/core': 7.16.0
-      '@babel/types': 7.15.0
+      '@babel/types': 7.16.0
       ts-morph: 12.2.0
     devDependencies:
+      '@babel/generator': 7.16.0
+      '@babel/traverse': 7.16.0
       '@types/babel__core': 7.1.16
+      '@types/babel__generator': 7.6.3
+      '@types/babel__traverse': 7.14.2
       '@types/jest': 27.0.2
       '@types/node': 16.11.6
       '@typescript-eslint/eslint-plugin': 5.3.0_d773de83a864dc4fb868a604260b2afa
@@ -986,8 +990,12 @@ importers:
       typescript: 4.3.5
     specifiers:
       '@babel/core': ^7.16.0
-      '@babel/types': ^7.15.0
+      '@babel/generator': ^7.16.0
+      '@babel/traverse': ^7.16.0
+      '@babel/types': ^7.16.0
       '@types/babel__core': ^7.1.16
+      '@types/babel__generator': ^7.6.3
+      '@types/babel__traverse': ^7.14.2
       '@types/jest': ^27.0.2
       '@types/node': ^16.11.6
       '@typescript-eslint/eslint-plugin': ^5.3.0
@@ -2037,7 +2045,7 @@ packages:
       '@babel/helper-compilation-targets': 7.16.0_@babel+core@7.16.0
       '@babel/helper-module-transforms': 7.16.0
       '@babel/helpers': 7.16.0
-      '@babel/parser': 7.16.0
+      '@babel/parser': 7.16.2
       '@babel/template': 7.16.0
       '@babel/traverse': 7.16.0
       '@babel/types': 7.16.0
@@ -2178,7 +2186,7 @@ packages:
       '@babel/compat-data': 7.16.0
       '@babel/core': 7.16.0
       '@babel/helper-validator-option': 7.14.5
-      browserslist: 4.17.5
+      browserslist: 4.17.6
       semver: 6.3.0
     engines:
       node: '>=6.9.0'
@@ -2756,11 +2764,18 @@ packages:
     resolution:
       integrity: sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==
   /@babel/parser/7.16.0:
+    dev: true
     engines:
       node: '>=6.0.0'
     hasBin: true
     resolution:
       integrity: sha512-TEHWXf0xxpi9wKVyBCmRcSSDjbJ/cl6LUdlbYUHEaNQUJGhreJbZrXT6sR4+fZLxVUJqNRB4KyOvjuy/D9009A==
+  /@babel/parser/7.16.2:
+    engines:
+      node: '>=6.0.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw==
   /@babel/plugin-proposal-async-generator-functions/7.12.12_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
@@ -4668,7 +4683,7 @@ packages:
   /@babel/template/7.16.0:
     dependencies:
       '@babel/code-frame': 7.16.0
-      '@babel/parser': 7.16.0
+      '@babel/parser': 7.16.2
       '@babel/types': 7.16.0
     engines:
       node: '>=6.9.0'
@@ -4755,7 +4770,7 @@ packages:
       '@babel/helper-function-name': 7.16.0
       '@babel/helper-hoist-variables': 7.16.0
       '@babel/helper-split-export-declaration': 7.16.0
-      '@babel/parser': 7.16.0
+      '@babel/parser': 7.16.2
       '@babel/types': 7.16.0
       debug: 4.3.2
       globals: 11.12.0
@@ -6626,7 +6641,7 @@ packages:
       integrity: sha512-zGZJzzBUVDo/eV6KgbE0f0ZI7dInEYvo12Rb70uNQDshC3SkRMb67ja0GgRHZgAX3Za6rhaWlvbDO8rrGyAb1g==
   /@types/babel__core/7.1.16:
     dependencies:
-      '@babel/parser': 7.16.0
+      '@babel/parser': 7.16.2
       '@babel/types': 7.16.0
       '@types/babel__generator': 7.6.3
       '@types/babel__template': 7.4.1
@@ -6653,7 +6668,7 @@ packages:
       integrity: sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==
   /@types/babel__template/7.4.1:
     dependencies:
-      '@babel/parser': 7.16.0
+      '@babel/parser': 7.16.2
       '@babel/types': 7.16.0
     resolution:
       integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==
@@ -9297,7 +9312,7 @@ packages:
       integrity: sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA==
   /axios/0.21.1_debug@4.3.1:
     dependencies:
-      follow-redirects: 1.14.1_debug@4.3.2
+      follow-redirects: 1.14.1_debug@4.3.1
     dev: true
     peerDependencies:
       debug: '*'
@@ -9962,10 +9977,10 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-Zg7RpbZpIJRW3am9Lyckue7PLytvVxxhJj1CaJVlCWENsGEAOlnlt8X0ZxGRPp7Bt9o8tIRM5SEXy4BCPMJjLQ==
-  /browserslist/4.17.5:
+  /browserslist/4.17.6:
     dependencies:
-      caniuse-lite: 1.0.30001274
-      electron-to-chromium: 1.3.886
+      caniuse-lite: 1.0.30001278
+      electron-to-chromium: 1.3.890
       escalade: 3.1.1
       node-releases: 2.0.1
       picocolors: 1.0.0
@@ -9973,7 +9988,7 @@ packages:
       node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7
     hasBin: true
     resolution:
-      integrity: sha512-I3ekeB92mmpctWBoLXe0d5wPS2cBuRvvW0JyyJHMrk9/HmP2ZjrTboNAZ8iuGqaEIlKguljbQY32OkOJIRrgoA==
+      integrity: sha512-uPgz3vyRTlEiCv4ee9KlsKgo2V6qPk7Jsn0KAn2OBqbqKo3iNcPEC1Ti6J4dwnz+aIRfEEEuOzC9IBk8tXUomw==
   /bs-logger/0.2.6:
     dependencies:
       fast-json-stable-stringify: 2.1.0
@@ -10220,9 +10235,9 @@ packages:
   /caniuse-lite/1.0.30001265:
     resolution:
       integrity: sha512-YzBnspggWV5hep1m9Z6sZVLOt7vrju8xWooFAgN6BA5qvy98qPAPb7vNUzypFaoh2pb3vlfzbDO8tB57UPGbtw==
-  /caniuse-lite/1.0.30001274:
+  /caniuse-lite/1.0.30001278:
     resolution:
-      integrity: sha512-+Nkvv0fHyhISkiMIjnyjmf5YJcQ1IQHZN6U9TLUMroWR38FNwpsC51Gb68yueafX1V6ifOisInSgP9WJFS13ew==
+      integrity: sha512-mpF9KeH8u5cMoEmIic/cr7PNS+F5LWBk0t2ekGT60lFf0Wq+n9LspAj0g3P+o7DQhD3sUdlMln4YFAWhFYn9jg==
   /canvas/2.6.1:
     dependencies:
       nan: 2.14.2
@@ -12004,9 +12019,9 @@ packages:
   /electron-to-chromium/1.3.867:
     resolution:
       integrity: sha512-WbTXOv7hsLhjJyl7jBfDkioaY++iVVZomZ4dU6TMe/SzucV6mUAs2VZn/AehBwuZMiNEQDaPuTGn22YK5o+aDw==
-  /electron-to-chromium/1.3.886:
+  /electron-to-chromium/1.3.890:
     resolution:
-      integrity: sha512-+vYdeBosI63VkCtNWnEVFjgNd/IZwvnsWkKyPtWAvrhA+XfByKoBJcbsMgudVU/bUcGAF9Xp3aXn96voWlc3oQ==
+      integrity: sha512-VWlVXSkv0cA/OOehrEyqjUTHwV8YXCPTfPvbtoeU2aHR21vI4Ejh5aC4AxUwOmbLbBgb6Gd3URZahoCxtBqCYQ==
   /elegant-spinner/1.0.1:
     dev: true
     engines:
@@ -14934,8 +14949,9 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=
-  /follow-redirects/1.14.1:
-    dev: false
+  /follow-redirects/1.14.1_debug@4.3.1:
+    dependencies:
+      debug: 4.3.1
     engines:
       node: '>=4.0'
     peerDependencies:
@@ -14947,7 +14963,8 @@ packages:
       integrity: sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
   /follow-redirects/1.14.1_debug@4.3.2:
     dependencies:
-      debug: 4.3.2_supports-color@6.1.0
+      debug: 4.3.2
+    dev: false
     engines:
       node: '>=4.0'
     peerDependencies:
@@ -15830,14 +15847,54 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
+  /http-proxy-middleware/1.0.6_debug@4.3.1:
+    dependencies:
+      '@types/http-proxy': 1.17.6
+      http-proxy: 1.18.1_debug@4.3.1
+      is-glob: 4.0.1
+      lodash: 4.17.21
+      micromatch: 4.0.4
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    peerDependencies:
+      debug: '*'
+    resolution:
+      integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
+  /http-proxy-middleware/1.0.6_debug@4.3.2:
+    dependencies:
+      '@types/http-proxy': 1.17.6
+      http-proxy: 1.18.1_debug@4.3.2
+      is-glob: 4.0.1
+      lodash: 4.17.21
+      micromatch: 4.0.4
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    peerDependencies:
+      debug: '*'
+    resolution:
+      integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
   /http-proxy/1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.14.1
+      follow-redirects: 1.14.1_debug@4.3.1
       requires-port: 1.0.0
     dev: false
     engines:
       node: '>=8.0.0'
+    resolution:
+      integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
+  /http-proxy/1.18.1_debug@4.3.1:
+    dependencies:
+      eventemitter3: 4.0.7
+      follow-redirects: 1.14.1_debug@4.3.1
+      requires-port: 1.0.0
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    peerDependencies:
+      debug: '*'
     resolution:
       integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
   /http-proxy/1.18.1_debug@4.3.2:


### PR DESCRIPTION
It's a little weird to have `safeParse(…).unsafeUnwrap()` when we don't ever intend to handle the failure "safely". Instead, it's better to just be explicit about it by calling `unsafeParse`, a helper function that does the same thing.

Similarly, `maybeParse` better communicates that we expect that the parse could fail, but that's fine and we just want the value if it parses successfully.

This PR adds these these helpers, a codemod to do some automated refactoring to use them, and the result of running that codemod.