### PR TITLE
style(all): `gts-constants`

### DIFF
--- a/libs/eslint-plugin-vx/docs/rules/gts-constants.md
+++ b/libs/eslint-plugin-vx/docs/rules/gts-constants.md
@@ -1,0 +1,22 @@
+# Requires that `CONSTANT_CASE` be declared `const` (`vx/gts-constants`)
+
+This rule is from
+[Google TypeScript Style Guide section "Identifiers"](https://google.github.io/styleguide/tsguide.html#identifiers):
+
+> CONSTANT_CASE indicates that a value is intended to not be changed, and may be used for values that can technically be modified (i.e. values that are not deeply frozen) to indicate to users that they must not be modified.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```ts
+let CONSTANT = 1;
+var SOME_VALUE = {};
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+const CONSTANT = 1;
+const SOME_VALUE = {};
+```

--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -36,6 +36,7 @@ export = {
   reportUnusedDisableDirectives: true,
   rules: {
     'vx/gts-array-type-style': 'error',
+    'vx/gts-constants': 'error',
     'vx/gts-direct-module-export-access-only': 'error',
     'vx/gts-func-style': 'error',
     'vx/gts-jsdoc': 'error',

--- a/libs/eslint-plugin-vx/src/rules/gts_constants.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_constants.ts
@@ -1,0 +1,46 @@
+import {
+  AST_NODE_TYPES,
+  TSESTree,
+} from '@typescript-eslint/experimental-utils';
+import { strict as assert } from 'assert';
+import { createRule } from '../util';
+
+export default createRule({
+  name: 'gts-jsdoc',
+  meta: {
+    docs: {
+      description: 'Enforces GTS JSDoc rules.',
+      category: 'Best Practices',
+      recommended: 'error',
+      suggestion: false,
+      requiresTypeChecking: false,
+    },
+    fixable: 'code',
+    messages: {
+      useConstVariableDeclaration:
+        '`CONSTANT_CASE` variables must be declared `const`',
+    },
+    schema: [],
+    type: 'problem',
+  },
+  defaultOptions: [],
+
+  create(context) {
+    return {
+      VariableDeclarator(node: TSESTree.VariableDeclarator): void {
+        /* istanbul ignore next - here for TS type narrowing */
+        assert(node.parent?.type === AST_NODE_TYPES.VariableDeclaration);
+        if (
+          node.id.type === AST_NODE_TYPES.Identifier &&
+          /^[A-Z_\d]+$/.test(node.id.name) &&
+          node.parent.kind !== 'const'
+        ) {
+          context.report({
+            node: node.id,
+            messageId: 'useConstVariableDeclaration',
+          });
+        }
+      },
+    };
+  },
+});

--- a/libs/eslint-plugin-vx/src/rules/index.ts
+++ b/libs/eslint-plugin-vx/src/rules/index.ts
@@ -1,5 +1,6 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 import gtsArrayTypeStyle from './gts_array_type_style';
+import gtsConstants from './gts_constants';
 import gtsDirectModuleExportAccessOnly from './gts_direct_module_export_access_only';
 import gtsFuncStyle from './gts_func_style';
 import gtsIdentifiers from './gts_identifiers';
@@ -32,6 +33,7 @@ const rules: Record<
   TSESLint.RuleModule<string, readonly unknown[], TSESLint.RuleListener>
 > = {
   'gts-array-type-style': gtsArrayTypeStyle,
+  'gts-constants': gtsConstants,
   'gts-direct-module-export-access-only': gtsDirectModuleExportAccessOnly,
   'gts-func-style': gtsFuncStyle,
   'gts-identifiers': gtsIdentifiers,

--- a/libs/eslint-plugin-vx/tests/rules/gts_constants.test.ts
+++ b/libs/eslint-plugin-vx/tests/rules/gts_constants.test.ts
@@ -1,0 +1,30 @@
+import { ESLintUtils } from '@typescript-eslint/experimental-utils';
+import { join } from 'path';
+import rule from '../../src/rules/gts_constants';
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    tsconfigRootDir: join(__dirname, '../fixtures'),
+    project: './tsconfig.json',
+  },
+  parser: '@typescript-eslint/parser',
+});
+
+ruleTester.run('gts-constants', rule, {
+  valid: [
+    `const ONE = 1;`,
+    `const A_CONSTANT_1234 = 1;`,
+    `let ALMOST_CONSTANt = 1;`,
+  ],
+  invalid: [
+    {
+      code: `let A_CONSTANT;`,
+      errors: [{ messageId: 'useConstVariableDeclaration', line: 1 }],
+    },
+    {
+      code: `var A_CONSTANT;`,
+      errors: [{ messageId: 'useConstVariableDeclaration', line: 1 }],
+    },
+  ],
+});


### PR DESCRIPTION
Requires `CONSTANT_CASE` variables to be declared `const`. There were no violations of this rule.

Closes #1023