### PR TITLE
style(module-scan): prefer field initializers

### DIFF
--- a/apps/module-scan/src/workers/pool/inline_worker_ops.ts
+++ b/apps/module-scan/src/workers/pool/inline_worker_ops.ts
@@ -4,11 +4,9 @@ import * as json from '../json_serialization';
 import { WorkerOps } from './types';
 
 export class InlineWorkerOps<I, O> implements WorkerOps<I, EventEmitter> {
-  private workerInstance: EventEmitter;
+  private workerInstance = new EventEmitter();
 
-  constructor(private readonly call: (input: I) => Promise<O>) {
-    this.workerInstance = new EventEmitter();
-  }
+  constructor(private readonly call: (input: I) => Promise<O>) {}
 
   start(): EventEmitter {
     return this.workerInstance;


### PR DESCRIPTION
Fixes the only violation of this GTS rule I could find:

> If a class member is not a parameter, initialize it where it's declared, which sometimes lets you drop the constructor entirely.

I don't believe the cost of implementing an ESLint rule for this is justified by the benefit.

Closes #1040 