### PR TITLE
style(all): prefer `interface` over `type`

### DIFF
--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -63,6 +63,7 @@ export = {
     'vx/no-assert-truthiness': 'error',
     'vx/no-floating-results': ['error', { ignoreVoid: true }],
 
+    '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
     '@typescript-eslint/no-array-constructor': 'off',
     '@typescript-eslint/no-extra-semi': 'off',
     '@typescript-eslint/no-floating-promises': 'error',

--- a/libs/utils/src/filenames.ts
+++ b/libs/utils/src/filenames.ts
@@ -16,19 +16,19 @@ export const BALLOT_PACKAGE_FOLDER = 'ballot-packages';
 export const SCANNER_RESULTS_FOLDER = 'cast-vote-records';
 export const SCANNER_BACKUPS_FOLDER = 'scanner-backups';
 
-export type ElectionData = {
+export interface ElectionData {
   electionCounty: string;
   electionName: string;
   electionHash: string;
   timestamp: Date;
-};
+}
 
-export type CvrFileData = {
+export interface CvrFileData {
   machineId: string;
   numberOfBallots: number;
   isTestModeResults: boolean;
   timestamp: Date;
-};
+}
 
 function sanitizeString(
   input: string,


### PR DESCRIPTION
Enforces this rule [from GTS](https://google.github.io/styleguide/tsguide.html#interfaces-vs-type-aliases):

> TypeScript supports type aliases for naming a type expression. This can be used to name primitives, unions, tuples, and any other types.
>
> However, when declaring types for objects, use interfaces instead of a type alias for the object literal expression.

Includes autofixes because the changes were so minor.

Closes #1077