### PR TITLE
Add Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Description
+A clear and concise description of what the bug is.
+
+## Repro
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected behavior
+A clear and concise description of what you expected to happen.
+
+## Screenshots
+If applicable, add screenshots to help explain your problem.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,16 @@
+---
+name: Feature
+about: for product-level features that are tracked in the product board
+title: ''
+labels: feature
+assignees: ''
+
+---
+
+## Summary
+
+## Requirements
+
+## Non-Requirements
+
+## Tasks


### PR DESCRIPTION
Simple feature and bug issue templates to help with our GitHub projects organization.

The main point here is to automatically label `feature` something that is a product-level feature, which might have sub-issues, too.