### PR TITLE
feat(em) add logging for tally screen user actions

### DIFF
--- a/apps/election-manager/src/app.test.tsx
+++ b/apps/election-manager/src/app.test.tsx
@@ -400,6 +400,9 @@ test('printing ballots, print report, and test decks', async () => {
   expect(container).toMatchSnapshot();
 
   expect(printer.print).toHaveBeenCalledTimes(5);
+  expect(window.kiosk!.log).toHaveBeenCalledWith(
+    expect.stringContaining(LogEventId.TestDeckPrinted)
+  );
 
   fireEvent.click(getByText('Tally'));
   fireEvent.click(getByText('View Test Ballot Deck Tally'));
@@ -410,6 +413,9 @@ test('printing ballots, print report, and test decks', async () => {
 
   await waitFor(() => getByText('Printing'));
   expect(printer.print).toHaveBeenCalledTimes(6);
+  expect(window.kiosk!.log).toHaveBeenCalledWith(
+    expect.stringContaining(LogEventId.TestDeckTallyReportPrinted)
+  );
 });
 
 test('tabulating CVRs', async () => {
@@ -444,6 +450,9 @@ test('tabulating CVRs', async () => {
   fireEvent.click(getByText('Mark Tally Results as Official…'));
   getByText('Mark Unofficial Tally Results as Official Tally Results?');
   fireEvent.click(getByText('Mark Tally Results as Official'));
+  expect(window.kiosk!.log).toHaveBeenCalledWith(
+    expect.stringContaining(LogEventId.MarkedTallyResultsOfficial)
+  );
 
   fireEvent.click(getByText('View Official Full Election Tally Report'));
 
@@ -453,6 +462,10 @@ test('tabulating CVRs', async () => {
   ).toBe(true);
   // TODO: Snapshots without clear definition of what they are for cause future developers to have to figure out what the test is for each time this test breaks.
   expect(getByTestId('election-full-tally-report')).toMatchSnapshot();
+  fireEvent.click(getByText('Preview Report'));
+  expect(window.kiosk!.log).toHaveBeenCalledWith(
+    expect.stringContaining(LogEventId.TallyReportPreviewed)
+  );
 
   fireEvent.click(getByText('Tally'));
 
@@ -480,6 +493,9 @@ test('tabulating CVRs', async () => {
       )
     );
   });
+  expect(window.kiosk!.log).toHaveBeenCalledWith(
+    expect.stringContaining(LogEventId.FileSaved)
+  );
 
   fireEvent.click(getByText('View Official Batch 2 Tally Report'));
   getByText('Official Batch Tally Report for Batch 2 (Scanner: scanner-1)');
@@ -534,6 +550,9 @@ test('tabulating CVRs', async () => {
       'test-content'
     );
   });
+  expect(window.kiosk!.log).toHaveBeenCalledWith(
+    expect.stringContaining(LogEventId.ConvertingResultsToSemsFormat)
+  );
   expect(fetchMock.called('/convert/tallies/files')).toBe(true);
   expect(fetchMock.called('/convert/tallies/submitfile')).toBe(true);
   expect(fetchMock.called('/convert/tallies/process')).toBe(true);
@@ -547,6 +566,9 @@ test('tabulating CVRs', async () => {
   fireEvent.click(getByText('Remove All Data'));
   await waitFor(() =>
     expect(getByTestId('total-ballot-count').textContent).toEqual('0')
+  );
+  expect(window.kiosk!.log).toHaveBeenCalledWith(
+    expect.stringContaining(LogEventId.RemovedTallyFile)
   );
 
   // When there are no CVRs imported the full tally report is labeled as the zero report
@@ -778,6 +800,7 @@ test('tabulating CVRs with SEMS file and manual data', async () => {
   // Change the manual data to absentee
   fireEvent.click(getByText('Absentee Results'));
 
+  await advanceTimersAndPromises(0);
   // Change to another precinct
   fireEvent.click(getByText('Edit Absentee Results for Panhandle'));
   getByText('Save Absentee Results for Panhandle');

--- a/apps/election-manager/src/screens/manual_data_import_index_screen.test.tsx
+++ b/apps/election-manager/src/screens/manual_data_import_index_screen.test.tsx
@@ -6,7 +6,7 @@ import {
 import { advanceTimersAndPromises } from '@votingworks/test-utils';
 import { createMemoryHistory } from 'history';
 import { Router, Route } from 'react-router-dom';
-import { fireEvent, within } from '@testing-library/react';
+import { fireEvent, waitFor, within } from '@testing-library/react';
 
 import {
   ContestOptionTally,
@@ -57,7 +57,7 @@ test('can toggle ballot types for data', async () => {
   expect(getByTestId('ballottype-absentee').closest('button')).toBeDisabled();
   getByText('Edit Absentee Results for Precinct 5');
 
-  expect(saveExternalTallies).toHaveBeenCalled();
+  await waitFor(() => expect(saveExternalTallies).toHaveBeenCalled());
   expect(saveExternalTallies).toHaveBeenCalledWith([
     expect.objectContaining({
       source: ExternalTallySourceType.Manual,
@@ -66,7 +66,7 @@ test('can toggle ballot types for data', async () => {
   ]);
 
   fireEvent.click(getByTestId('ballottype-precinct'));
-  expect(saveExternalTallies).toHaveBeenCalledTimes(2);
+  await waitFor(() => expect(saveExternalTallies).toHaveBeenCalledTimes(2));
   expect(saveExternalTallies).toHaveBeenCalledWith([
     expect.objectContaining({
       source: ExternalTallySourceType.Manual,

--- a/apps/election-manager/src/screens/manual_data_import_index_screen.tsx
+++ b/apps/election-manager/src/screens/manual_data_import_index_screen.tsx
@@ -9,6 +9,7 @@ import {
   TallyCategory,
   VotingMethod,
 } from '@votingworks/types';
+import { LogEventId } from '@votingworks/logging';
 import { ResultsFileType } from '../config/types';
 import { routerPaths } from '../router_paths';
 
@@ -48,8 +49,12 @@ export function ManualDataImportIndexScreen(): JSX.Element {
     fullElectionExternalTallies,
     saveExternalTallies,
     resetFiles,
+    currentUserSession,
+    logger,
   } = useContext(AppContext);
   assert(electionDefinition);
+  assert(currentUserSession); // TODO(auth) check permissions for adding manual tally data
+  const currentUserType = currentUserSession.type;
   const { election } = electionDefinition;
   const history = useHistory();
 
@@ -89,6 +94,11 @@ export function ManualDataImportIndexScreen(): JSX.Element {
       MANUAL_DATA_NAME,
       new Date()
     );
+    await logger.log(LogEventId.ManualTallyDataEdited, currentUserType, {
+      disposition: 'success',
+      newBallotType,
+      message: `Ballot type for manually entered tally data changed to ${newBallotType}`,
+    });
     // Don't modify any external tallies for non-manual data
     const newTallies = fullElectionExternalTallies.filter(
       (t) => t.source !== ExternalTallySourceType.Manual

--- a/apps/election-manager/src/screens/manual_data_import_precinct_screen.tsx
+++ b/apps/election-manager/src/screens/manual_data_import_precinct_screen.tsx
@@ -19,6 +19,7 @@ import {
 
 import { Table, TD } from '@votingworks/ui';
 
+import { LogEventId } from '@votingworks/logging';
 import { ManualDataPrecinctScreenProps } from '../config/types';
 import { routerPaths } from '../router_paths';
 
@@ -140,8 +141,12 @@ export function ManualDataImportPrecinctScreen(): JSX.Element {
     electionDefinition,
     fullElectionExternalTallies,
     saveExternalTallies,
+    currentUserSession,
+    logger,
   } = useContext(AppContext);
   assert(electionDefinition);
+  assert(currentUserSession); // TODO(auth) check permissions for adding manual tally data
+  const currentUserType = currentUserSession.type;
   const { election } = electionDefinition;
   // TODO export the type for this somewhere
   const {
@@ -249,6 +254,12 @@ export function ManualDataImportPrecinctScreen(): JSX.Element {
       MANUAL_DATA_NAME,
       new Date()
     );
+    await logger.log(LogEventId.ManualTallyDataEdited, currentUserType, {
+      disposition: 'success',
+      message: `Manually entered tally data added or edited for precinct: ${currentPrecinctId}`,
+      numberOfBallotsInPrecinct: currentPrecinctTally.numberOfBallotsCounted,
+      precinctId: currentPrecinctId,
+    });
     // Don't modify any external tallies for non-manual data
     const newTallies = fullElectionExternalTallies.filter(
       (t) => t.source !== ExternalTallySourceType.Manual

--- a/apps/election-manager/src/screens/tally_screen.tsx
+++ b/apps/election-manager/src/screens/tally_screen.tsx
@@ -15,6 +15,7 @@ import {
 } from '@votingworks/utils';
 import { Table, TD } from '@votingworks/ui';
 import { TallyCategory, ExternalTallySourceType } from '@votingworks/types';
+import { LogEventId } from '@votingworks/logging';
 import { InputEventFunction, ResultsFileType } from '../config/types';
 
 import { AppContext } from '../contexts/app_context';
@@ -49,6 +50,8 @@ export function TallyScreen(): JSX.Element {
     fullElectionExternalTallies,
     generateExportableTallies,
     resetFiles,
+    logger,
+    currentUserSession,
   } = useContext(AppContext);
   assert(electionDefinition);
   const { election } = electionDefinition;
@@ -221,6 +224,11 @@ export function TallyScreen(): JSX.Element {
   );
 
   const generateSemsResults = useCallback(async (): Promise<string> => {
+    assert(currentUserSession);
+    await logger.log(
+      LogEventId.ConvertingResultsToSemsFormat,
+      currentUserSession.type
+    );
     const exportableTallies = generateExportableTallies();
     // process on the server
     const client = new ConverterClient('tallies');
@@ -246,7 +254,12 @@ export function TallyScreen(): JSX.Element {
     // reset files on the server
     await client.reset();
     return await results.text();
-  }, [electionDefinition.electionData, generateExportableTallies]);
+  }, [
+    electionDefinition.electionData,
+    generateExportableTallies,
+    logger,
+    currentUserSession,
+  ]);
 
   return (
     <React.Fragment>

--- a/apps/election-manager/src/utils/cast_vote_record_files.ts
+++ b/apps/election-manager/src/utils/cast_vote_record_files.ts
@@ -47,7 +47,12 @@ function mapAdd<K, V>(
   const result = new Map(map);
 
   for (const value of values) {
-    result.set(keyfn(value), value);
+    const newKey = keyfn(value);
+    // If the key is already in the map, remove it before re-adding it.
+    if (result.has(newKey)) {
+      result.delete(newKey);
+    }
+    result.set(newKey, value);
   }
 
   return result;
@@ -222,12 +227,13 @@ export class CastVoteRecordFiles {
     try {
       const fileContent = await readFileAsync(file);
       const parsedFileInfo = parseCvrFileInfoFromFilename(file.name);
-      return await this.addFromFileContent(
+      const result = await this.addFromFileContent(
         fileContent,
         file.name,
         parsedFileInfo?.timestamp || new Date(file.lastModified),
         election
       );
+      return result;
     } catch (error) {
       return new CastVoteRecordFiles(
         this.signatures,

--- a/libs/logging/src/log_event_ids.ts
+++ b/libs/logging/src/log_event_ids.ts
@@ -51,6 +51,19 @@ export enum LogEventId {
   SmartcardProgramInit = 'smartcard-program-init',
   SmartcardProgrammed = 'smartcard-programmed',
   SmartcardProgrammedOverrideWriteProtection = 'smartcard-programmed-override-write-protection',
+  CvrImported = 'cvr-imported',
+  CvrFilesReadFromUsb = 'cvr-files-read-from-usb',
+  RecomputingTally = 'recomputing-tally',
+  RecomputedTally = 'recomputed-tally',
+  ExternalTallyFileImported = 'external-tally-file-imported',
+  ManualTallyDataEdited = 'manual-tally-data-edited',
+  MarkedTallyResultsOfficial = 'marked-tally-results-official',
+  RemovedTallyFile = 'removed-tally-file',
+  TallyReportPreviewed = 'tally-report-previewed',
+  TallyReportPrinted = 'tally-report-printed',
+  ConvertingResultsToSemsFormat = 'converting-to-sems',
+  TestDeckPrinted = 'test-deck-printed',
+  TestDeckTallyReportPrinted = 'test-deck-tally-report-printed',
 }
 
 export interface LogDetails {
@@ -290,6 +303,84 @@ const SmartcardProgrammedOverrideWriteProtection: LogDetails = {
   documentationMessage:
     'Smartcard is programmed to override a flag protecting writes on the card. By default admin cards can not be written unless write protection is first overridden.',
 };
+const CvrImported: LogDetails = {
+  eventId: LogEventId.CvrImported,
+  eventType: LogEventType.UserAction,
+  documentationMessage:
+    'User imported CVR to the machine. Success or failure indicated by disposition.',
+};
+const CvrFilesReadFromUsb: LogDetails = {
+  eventId: LogEventId.CvrFilesReadFromUsb,
+  eventType: LogEventType.UserAction,
+  documentationMessage:
+    'User opened import CVR modal and usb is searched for possible CVR files to import.',
+};
+const RecomputingTally: LogDetails = {
+  eventId: LogEventId.RecomputingTally,
+  eventType: LogEventType.UserAction,
+  documentationMessage:
+    'New cast vote record files seen, initiating recomputation of tally data.',
+  defaultMessage: 'New cast vote record files seen, recomputing tally data...',
+};
+const RecomputedTally: LogDetails = {
+  eventId: LogEventId.RecomputedTally,
+  eventType: LogEventType.UserAction,
+  documentationMessage:
+    'Tally recomputed with new cast vote record files, success or failure indicated by disposition.',
+};
+const ExternalTallyFileImported: LogDetails = {
+  eventId: LogEventId.ExternalTallyFileImported,
+  eventType: LogEventType.UserAction,
+  documentationMessage:
+    'User imported external tally file to the machine. File type indicated by fileType key. Success or failure indicated by disposition.',
+};
+const ManualTallyDataEdited: LogDetails = {
+  eventId: LogEventId.ManualTallyDataEdited,
+  eventType: LogEventType.UserAction,
+  documentationMessage:
+    'User added or edited manually entered tally data to be included alongside imported Cvr files.',
+};
+const MarkedTallyResultsOfficial: LogDetails = {
+  eventId: LogEventId.MarkedTallyResultsOfficial,
+  eventType: LogEventType.UserAction,
+  documentationMessage:
+    'User marked the tally results as official. This disabled importing any more cvr or other tally data files.',
+};
+const RemovedTallyFile: LogDetails = {
+  eventId: LogEventId.RemovedTallyFile,
+  eventType: LogEventType.UserAction,
+  documentationMessage:
+    'The user removed Cvr, External Tally data, manually entered tally data, or all tally data. The type of file removed specified by the filetype key.',
+};
+const TallyReportPrinted: LogDetails = {
+  eventId: LogEventId.TallyReportPrinted,
+  eventType: LogEventType.UserAction,
+  documentationMessage: 'Tally Report printed.',
+};
+const TallyReportPreviewed: LogDetails = {
+  eventId: LogEventId.TallyReportPreviewed,
+  eventType: LogEventType.UserAction,
+  documentationMessage: 'Tally Report previewed and viewed in the app.',
+};
+const ConvertingResultsToSemsFormat: LogDetails = {
+  eventId: LogEventId.ConvertingResultsToSemsFormat,
+  eventType: LogEventType.UserAction,
+  documentationMessage:
+    'Initiating conversion of tally results to SEMS file format.',
+  defaultMessage: 'Converting tally results to SEMS file format...',
+};
+const TestDeckPrinted: LogDetails = {
+  eventId: LogEventId.TestDeckPrinted,
+  eventType: LogEventType.UserAction,
+  documentationMessage:
+    'User printed the test deck. Success or failure indicated by disposition.',
+};
+const TestDeckTallyReportPrinted: LogDetails = {
+  eventId: LogEventId.TestDeckTallyReportPrinted,
+  eventType: LogEventType.UserAction,
+  documentationMessage:
+    'User printed the test deck tally report. Success or failure indicated by disposition.',
+};
 
 export function getDetailsForEventId(eventId: LogEventId): LogDetails {
   switch (eventId) {
@@ -359,6 +450,32 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return SmartcardProgrammedOverrideWriteProtection;
     case LogEventId.SmartcardProgramInit:
       return SmartcardProgramInit;
+    case LogEventId.CvrFilesReadFromUsb:
+      return CvrFilesReadFromUsb;
+    case LogEventId.CvrImported:
+      return CvrImported;
+    case LogEventId.RecomputingTally:
+      return RecomputingTally;
+    case LogEventId.RecomputedTally:
+      return RecomputedTally;
+    case LogEventId.ExternalTallyFileImported:
+      return ExternalTallyFileImported;
+    case LogEventId.ManualTallyDataEdited:
+      return ManualTallyDataEdited;
+    case LogEventId.MarkedTallyResultsOfficial:
+      return MarkedTallyResultsOfficial;
+    case LogEventId.RemovedTallyFile:
+      return RemovedTallyFile;
+    case LogEventId.TallyReportPrinted:
+      return TallyReportPrinted;
+    case LogEventId.TallyReportPreviewed:
+      return TallyReportPreviewed;
+    case LogEventId.ConvertingResultsToSemsFormat:
+      return ConvertingResultsToSemsFormat;
+    case LogEventId.TestDeckPrinted:
+      return TestDeckPrinted;
+    case LogEventId.TestDeckTallyReportPrinted:
+      return TestDeckTallyReportPrinted;
     /* istanbul ignore next - compile time check for completeness */
     default:
       throwIllegalValue(eventId);


### PR DESCRIPTION
Adds logging for all user actions from the tally screen of election-manager. 