### PR TITLE
Add lint rule for bad workspace imports

### DIFF
--- a/apps/election-manager/src/lib/votecounting.test.ts
+++ b/apps/election-manager/src/lib/votecounting.test.ts
@@ -8,7 +8,7 @@ import {
   multiPartyPrimaryElection,
 } from '@votingworks/fixtures';
 
-import { filterTalliesByParams } from '@votingworks/utils/src';
+import { filterTalliesByParams } from '@votingworks/utils';
 import {
   parseCvrs,
   computeFullElectionTally,

--- a/apps/module-scan/src/util/luminosity.ts
+++ b/apps/module-scan/src/util/luminosity.ts
@@ -1,4 +1,4 @@
-import { otsu } from '@votingworks/hmpb-interpreter/build/src/utils/otsu';
+import { otsu } from '@votingworks/hmpb-interpreter';
 import makeDebug from 'debug';
 
 const debug = makeDebug('module-scan:threshold');

--- a/apps/module-scan/src/util/qrcode.ts
+++ b/apps/module-scan/src/util/qrcode.ts
@@ -1,6 +1,6 @@
 import { detect } from '@votingworks/ballot-encoder';
 import { Rect, Size } from '@votingworks/types';
-import { crop } from '@votingworks/hmpb-interpreter/build/src/utils/crop';
+import { crop } from '@votingworks/hmpb-interpreter';
 import { detect as qrdetect } from '@votingworks/qrdetect';
 import makeDebug from 'debug';
 import jsQr from 'jsqr';

--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -62,6 +62,7 @@ export = {
     'vx/no-array-sort-mutation': 'error',
     'vx/no-assert-truthiness': 'error',
     'vx/no-floating-results': ['error', { ignoreVoid: true }],
+    'vx/no-import-workspace-subfolders': 'error',
 
     '@typescript-eslint/no-array-constructor': 'off',
     '@typescript-eslint/no-extra-semi': 'off',

--- a/libs/eslint-plugin-vx/src/rules/index.ts
+++ b/libs/eslint-plugin-vx/src/rules/index.ts
@@ -26,6 +26,7 @@ import gtsUseOptionals from './gts_use_optionals';
 import noArraySortMutation from './no_array_sort_mutation';
 import noAssertStringOrNumber from './no_assert_truthiness';
 import noFloatingVoids from './no_floating_results';
+import noImportSubfolders from './no_import_workspace_subfolders';
 
 const rules: Record<
   string,
@@ -59,6 +60,7 @@ const rules: Record<
   'no-array-sort-mutation': noArraySortMutation,
   'no-assert-truthiness': noAssertStringOrNumber,
   'no-floating-results': noFloatingVoids,
+  'no-import-workspace-subfolders': noImportSubfolders,
 };
 
 export default rules;

--- a/libs/eslint-plugin-vx/src/rules/no_import_workspace_subfolders.ts
+++ b/libs/eslint-plugin-vx/src/rules/no_import_workspace_subfolders.ts
@@ -8,7 +8,7 @@ export default createRule({
   meta: {
     docs: {
       description:
-        'When import libraries from the VotingWorks workspace, do not include subfolders like /src in the import',
+        'When importing libraries from the VotingWorks workspace, do not include subfolders like /src in the import',
       category: 'Best Practices',
       recommended: 'error',
       suggestion: false,

--- a/libs/eslint-plugin-vx/src/rules/no_import_workspace_subfolders.ts
+++ b/libs/eslint-plugin-vx/src/rules/no_import_workspace_subfolders.ts
@@ -1,0 +1,51 @@
+import { TSESTree } from '@typescript-eslint/experimental-utils';
+import { createRule } from '../util';
+
+const VOTINGWORKS_WORKSPACE_PREFIX = '@votingworks';
+
+export default createRule({
+  name: 'no-import-workspace-subfolders',
+  meta: {
+    docs: {
+      description:
+        'When import libraries from the VotingWorks workspace, do not include subfolders like /src in the import',
+      category: 'Best Practices',
+      recommended: 'error',
+      suggestion: false,
+      requiresTypeChecking: false,
+    },
+    fixable: 'code',
+    messages: {
+      noImportSubfolders: 'Do not import subfolders of the target library.',
+    },
+    schema: [],
+    type: 'problem',
+  },
+  defaultOptions: [],
+
+  create(context) {
+    return {
+      ImportDeclaration(node: TSESTree.ImportDeclaration) {
+        const importSource = node.source.value;
+        if (typeof importSource !== 'string') {
+          return;
+        }
+        if (importSource.startsWith(VOTINGWORKS_WORKSPACE_PREFIX)) {
+          const folders = importSource.split('/');
+          if (folders.length > 2 && folders[1] !== 'types') {
+            context.report({
+              node,
+              messageId: 'noImportSubfolders',
+              fix: (fixer) => {
+                return fixer.replaceText(
+                  node.source,
+                  `'${folders[0]}/${folders[1]}'`
+                );
+              },
+            });
+          }
+        }
+      },
+    };
+  },
+});

--- a/libs/eslint-plugin-vx/tests/rules/no_import_workspace_subfolders.test.ts
+++ b/libs/eslint-plugin-vx/tests/rules/no_import_workspace_subfolders.test.ts
@@ -1,0 +1,79 @@
+import { ESLintUtils } from '@typescript-eslint/experimental-utils';
+import { join } from 'path';
+import rule from '../../src/rules/no_import_workspace_subfolders';
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    tsconfigRootDir: join(__dirname, '../fixtures'),
+    project: './tsconfig.json',
+  },
+  parser: '@typescript-eslint/parser',
+});
+
+ruleTester.run('no-import-workspace-subfolders', rule, {
+  valid: [
+    {
+      code: `import 'a'`,
+    },
+    {
+      code: `import a from '@votingworks/something'`,
+    },
+    {
+      code: `import { a } from '@votingworks/something'`,
+    },
+    {
+      code: `import * as a from '@votingworks/something'`,
+    },
+    {
+      code: `import a from 'random-library/something'`,
+    },
+    {
+      code: `import { a } from 'random-library'`,
+    },
+    {
+      code: `import * as a from 'random/library/with/many/slashes'`,
+    },
+    {
+      code: `import a from '@votingworks/types/something/else'`,
+    },
+    {
+      code: `import { a } from '@votingworks/types/api/module-scan'`,
+    },
+    {
+      code: `import * as a from '@votingworks/types/a/bunch/of/folders'`,
+    },
+  ],
+  invalid: [
+    {
+      code: `import a from '@votingworks/something/src'`,
+      output: `import a from '@votingworks/something'`,
+      errors: [{ messageId: 'noImportSubfolders', line: 1 }],
+    },
+    {
+      code: `import { a } from '@votingworks/something/src'`,
+      output: `import { a } from '@votingworks/something'`,
+      errors: [{ messageId: 'noImportSubfolders', line: 1 }],
+    },
+    {
+      code: `import * as a from '@votingworks/something/src'`,
+      output: `import * as a from '@votingworks/something'`,
+      errors: [{ messageId: 'noImportSubfolders', line: 1 }],
+    },
+    {
+      code: `import a from '@votingworks/something/utils'`,
+      output: `import a from '@votingworks/something'`,
+      errors: [{ messageId: 'noImportSubfolders', line: 1 }],
+    },
+    {
+      code: `import { a } from '@votingworks/something/src/utils/lib'`,
+      output: `import { a } from '@votingworks/something'`,
+      errors: [{ messageId: 'noImportSubfolders', line: 1 }],
+    },
+    {
+      code: `import * as a from '@votingworks/something/src/utils'`,
+      output: `import * as a from '@votingworks/something'`,
+      errors: [{ messageId: 'noImportSubfolders', line: 1 }],
+    },
+  ],
+});

--- a/libs/hmpb-interpreter/src/index.ts
+++ b/libs/hmpb-interpreter/src/index.ts
@@ -4,3 +4,5 @@ export {
   fromString as metadataFromString,
 } from './metadata';
 export * from './types';
+export { otsu } from './utils/otsu';
+export { crop } from './utils/crop';

--- a/libs/ui/src/hooks/use_stored_state.test.ts
+++ b/libs/ui/src/hooks/use_stored_state.test.ts
@@ -1,6 +1,6 @@
 import { waitFor } from '@testing-library/react';
 import { act, renderHook } from '@testing-library/react-hooks';
-import { MemoryStorage } from '@votingworks/utils/src';
+import { MemoryStorage } from '@votingworks/utils';
 import { z } from 'zod';
 import { useStoredState } from './use_stored_state';
 


### PR DESCRIPTION
Add a lint rule to catch bad imports of workspace libraries. 

I wasn't sure if hmpb-interpreter should be an exception to this rule or if its exports should just be fixed so it can fall in line with this but it was easy enough to just export the two missing things a the top-level, but happy to revert that if that is not how you want to handle hmpb-interpreter @eventualbuddha. 