### PR TITLE
refactor(types): make `PartyId` a new type

### DIFF
--- a/frontends/bas/src/app_root.tsx
+++ b/frontends/bas/src/app_root.tsx
@@ -3,6 +3,7 @@ import {
   BallotStyle,
   ElectionSchema,
   PartyId,
+  PartyIdSchema,
   PrecinctId,
   safeParseElection,
   VoterCardData,
@@ -65,7 +66,11 @@ export function AppRoot({ card, hardware, storage }: Props): JSX.Element {
     z.string()
   );
   const [ballotStyleId, setBallotStyleId] = useState<string>();
-  const [partyId, setPartyId] = useStoredState(storage, 'partyId', z.string());
+  const [partyId, setPartyId] = useStoredState(
+    storage,
+    'partyId',
+    PartyIdSchema
+  );
 
   const logger = useMemo(
     () => new Logger(LogSource.VxBallotActivationApp, window.kiosk),

--- a/frontends/bas/src/screens/admin_screen.tsx
+++ b/frontends/bas/src/screens/admin_screen.tsx
@@ -6,7 +6,9 @@ import {
   BallotStyle,
   OptionalElection,
   PartyId,
+  PartyIdSchema,
   PrecinctId,
+  unsafeParse,
 } from '@votingworks/types';
 import { formatFullDateTimeZone } from '@votingworks/utils';
 
@@ -28,7 +30,7 @@ interface Props {
   partyName?: string;
   precinctId?: PrecinctId;
   precinctName?: string;
-  setParty: (id: string) => void;
+  setParty: (id?: PartyId) => void;
   setPrecinct: (id: string) => void;
   unconfigure: () => void;
   isSinglePrecinctMode: boolean;
@@ -55,7 +57,7 @@ export function AdminScreen({
   const precincts = election ? [...election.precincts].sort(compareName) : [];
   const parties = election ? [...election.parties].sort(compareName) : [];
   function onChangeParty(event: React.FormEvent<HTMLSelectElement>) {
-    setParty(event.currentTarget.value);
+    setParty(unsafeParse(PartyIdSchema, event.currentTarget.value));
   }
   function onChangePrecinct(event: React.FormEvent<HTMLSelectElement>) {
     const { value } = event.currentTarget;
@@ -64,7 +66,7 @@ export function AdminScreen({
   }
   function reset() {
     setPrecinct('');
-    setParty('');
+    setParty(undefined);
     setIsSinglePrecinctMode(false);
   }
   const ballotStyles = partyId

--- a/frontends/election-manager/src/config/types.ts
+++ b/frontends/election-manager/src/config/types.ts
@@ -7,7 +7,6 @@ import {
   Dictionary,
   MachineId,
   Optional,
-  PartyId,
   Precinct,
   PrecinctId,
   VotingMethod,
@@ -75,7 +74,7 @@ export interface BatchReportScreenProps {
   batchId: string;
 }
 export interface PartyReportScreenProps {
-  partyId: PartyId;
+  partyId: string;
 }
 export interface VotingMethodReportScreenProps {
   votingMethod: string;

--- a/frontends/election-manager/src/screens/tally_report_screen.tsx
+++ b/frontends/election-manager/src/screens/tally_report_screen.tsx
@@ -10,6 +10,8 @@ import {
   VotingMethod,
   getLabelForVotingMethod,
   Tally,
+  unsafeParse,
+  PartyIdSchema,
 } from '@votingworks/types';
 import {
   ContestTally,
@@ -90,7 +92,7 @@ export function TallyReportScreen(): JSX.Element {
 
   const ballotStylePartyIds =
     partyIdFromProps !== undefined
-      ? [partyIdFromProps]
+      ? [unsafeParse(PartyIdSchema, partyIdFromProps)]
       : Array.from(new Set(election.ballotStyles.map((bs) => bs.partyId)));
 
   const precinctIds =

--- a/frontends/election-manager/src/utils/election.ts
+++ b/frontends/election-manager/src/utils/election.ts
@@ -35,7 +35,7 @@ export function getDistrictIdsForPartyId(
 export function getPartiesWithPrimaryElections(election: Election): Party[] {
   const partyIds = election.ballotStyles
     .map((bs) => bs.partyId)
-    .filter((id): id is string => id !== undefined);
+    .filter((id): id is PartyId => id !== undefined);
   return election.parties.filter((party) => partyIds.includes(party.id));
 }
 

--- a/frontends/election-manager/src/utils/external_tallies.test.ts
+++ b/frontends/election-manager/src/utils/external_tallies.test.ts
@@ -16,6 +16,8 @@ import {
   FullElectionExternalTally,
   TallyCategory,
   VotingMethod,
+  unsafeParse,
+  PartyIdSchema,
 } from '@votingworks/types';
 import { typedAs, combineContestTallies } from '@votingworks/utils';
 import { buildCandidateTallies } from '../../test/util/build_candidate_tallies';
@@ -507,6 +509,9 @@ describe('filterExternalTalliesByParams', () => {
   });
 
   it('filters by party as expected', () => {
+    const libertyPartyId = unsafeParse(PartyIdSchema, '0');
+    const constitutionPartyId = unsafeParse(PartyIdSchema, '3');
+    const federalistPartyId = unsafeParse(PartyIdSchema, '4');
     const singleVotesPrimary = buildExternalTally(
       multiPartyPrimaryElection,
       1,
@@ -529,7 +534,7 @@ describe('filterExternalTalliesByParams', () => {
       fullTallySems,
       multiPartyPrimaryElection,
       {
-        partyId: '0', // Liberty
+        partyId: libertyPartyId,
       }
     );
     expect(
@@ -551,7 +556,7 @@ describe('filterExternalTalliesByParams', () => {
       fullTallySems,
       multiPartyPrimaryElection,
       {
-        partyId: '3', // Constitution
+        partyId: constitutionPartyId,
       }
     );
     expect(
@@ -572,7 +577,7 @@ describe('filterExternalTalliesByParams', () => {
       fullTallySems,
       multiPartyPrimaryElection,
       {
-        partyId: '4', // Federalist
+        partyId: federalistPartyId,
       }
     );
     expect(
@@ -593,13 +598,13 @@ describe('filterExternalTalliesByParams', () => {
     // Filtering by voting method with party works as expected
     expect(
       filterExternalTalliesByParams(fullTallySems, multiPartyPrimaryElection, {
-        partyId: '4', // Federalist
+        partyId: federalistPartyId,
         votingMethod: VotingMethod.Precinct,
       })
     ).toStrictEqual(getEmptyExternalTally());
     expect(
       filterExternalTalliesByParams(fullTallySems, multiPartyPrimaryElection, {
-        partyId: '4', // Federalist
+        partyId: federalistPartyId,
         votingMethod: VotingMethod.Absentee,
       })
     ).toStrictEqual(federalistResults);
@@ -633,7 +638,7 @@ describe('filterExternalTalliesByParams', () => {
       multiPartyPrimaryElection,
       {
         precinctId: 'precinct-1',
-        partyId: '0',
+        partyId: libertyPartyId,
         votingMethod: VotingMethod.Precinct,
       }
     );
@@ -643,7 +648,7 @@ describe('filterExternalTalliesByParams', () => {
       multiPartyPrimaryElection,
       {
         precinctId: 'precinct-3',
-        partyId: '0',
+        partyId: libertyPartyId,
         votingMethod: VotingMethod.Precinct,
       }
     );
@@ -653,6 +658,9 @@ describe('filterExternalTalliesByParams', () => {
 
 describe('convertTalliesByPrecinctToFullExternalTally', () => {
   it('combines precincts as expected', () => {
+    const libertyPartyId = unsafeParse(PartyIdSchema, '0');
+    const constitutionPartyId = unsafeParse(PartyIdSchema, '3');
+    const federalistPartyId = unsafeParse(PartyIdSchema, '4');
     // Contests to populate for the purposes of these tests.
     const contestIds = [
       'governor-contest-liberty',
@@ -706,15 +714,27 @@ describe('convertTalliesByPrecinctToFullExternalTally', () => {
     );
     const resultsByParty = results.resultsByCategory.get(TallyCategory.Party);
     expect(resultsByParty).toStrictEqual({
-      '0': filterExternalTalliesByParams(results, multiPartyPrimaryElection, {
-        partyId: '0',
-      }),
-      '3': filterExternalTalliesByParams(results, multiPartyPrimaryElection, {
-        partyId: '3',
-      }),
-      '4': filterExternalTalliesByParams(results, multiPartyPrimaryElection, {
-        partyId: '4',
-      }),
+      [libertyPartyId]: filterExternalTalliesByParams(
+        results,
+        multiPartyPrimaryElection,
+        {
+          partyId: libertyPartyId,
+        }
+      ),
+      [constitutionPartyId]: filterExternalTalliesByParams(
+        results,
+        multiPartyPrimaryElection,
+        {
+          partyId: constitutionPartyId,
+        }
+      ),
+      [federalistPartyId]: filterExternalTalliesByParams(
+        results,
+        multiPartyPrimaryElection,
+        {
+          partyId: federalistPartyId,
+        }
+      ),
     });
   });
 });

--- a/frontends/election-manager/src/utils/sems_tallies.test.ts
+++ b/frontends/election-manager/src/utils/sems_tallies.test.ts
@@ -12,6 +12,8 @@ import {
   TallyCategory,
   VotingMethod,
   writeInCandidate,
+  unsafeParse,
+  PartyIdSchema,
 } from '@votingworks/types';
 import { buildCandidateTallies } from '../../test/util/build_candidate_tallies';
 
@@ -22,20 +24,6 @@ import {
   convertSemsFileToExternalTally,
   parseSemsFileAndValidateForElection,
 } from './sems_tallies';
-
-const mockSemsRow: SemsFileRow = {
-  countyId: '',
-  precinctId: '',
-  contestId: '',
-  contestTitle: '',
-  partyId: '',
-  partyName: '',
-  candidateId: '',
-  candidateName: '',
-  candidatePartyId: '',
-  candidatePartyName: '',
-  numberOfVotes: 0,
-};
 
 const multiPartyPrimaryElection =
   electionMultiPartyPrimaryWithDataFiles.electionDefinition.election;
@@ -49,6 +37,20 @@ const primarySemsContent = electionMultiPartyPrimaryWithDataFiles.semsData;
 const presidentcontest = electionSample.contests.find(
   (c) => c.id === 'president'
 ) as CandidateContest;
+
+const mockSemsRow: SemsFileRow = {
+  countyId: '',
+  precinctId: '',
+  contestId: '',
+  contestTitle: '',
+  partyId: unsafeParse(PartyIdSchema, 'placeholder-party-id'),
+  partyName: '',
+  candidateId: '',
+  candidateName: '',
+  candidatePartyId: unsafeParse(PartyIdSchema, 'placeholder-party-id'),
+  candidatePartyName: '',
+  numberOfVotes: 0,
+};
 
 describe('getContestTallyForCandidateContest', () => {
   it('computes ContestTally properly for file rows', () => {

--- a/frontends/election-manager/src/utils/sems_tallies.ts
+++ b/frontends/election-manager/src/utils/sems_tallies.ts
@@ -21,6 +21,8 @@ import {
   ContestId,
   PartyId,
   CandidateId,
+  unsafeParse,
+  PartyIdSchema,
 } from '@votingworks/types';
 
 import { throwIllegalValue } from '@votingworks/utils';
@@ -181,11 +183,11 @@ function parseFileContentRows(fileContent: string): SemsFileRow[] {
         precinctId: entries[1],
         contestId: entries[2],
         contestTitle: entries[3],
-        partyId: entries[4],
+        partyId: unsafeParse(PartyIdSchema, entries[4]),
         partyName: entries[5],
         candidateId: entries[6],
         candidateName: entries[7],
-        candidatePartyId: entries[8],
+        candidatePartyId: unsafeParse(PartyIdSchema, entries[8]),
         candidatePartyName: entries[9],
         // eslint-disable-next-line vx/gts-safe-number-parse
         numberOfVotes: parseInt(entries[10], 10),

--- a/libs/test-utils/src/arbitraries.ts
+++ b/libs/test-utils/src/arbitraries.ts
@@ -106,7 +106,7 @@ export function arbitraryDistrictId(): fc.Arbitrary<DistrictId> {
  * Builds values suitable for party IDs.
  */
 export function arbitraryPartyId(): fc.Arbitrary<PartyId> {
-  return arbitraryId();
+  return arbitraryId() as fc.Arbitrary<PartyId>;
 }
 
 /**

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -44,8 +44,8 @@ function* findDuplicateIds<T extends { id: unknown }>(
   }
 }
 
-export type PartyId = Id;
-export const PartyIdSchema: z.ZodSchema<PartyId> = IdSchema;
+export type PartyId = NewType<string, 'PartyId'>;
+export const PartyIdSchema = (IdSchema as unknown) as z.ZodSchema<PartyId>;
 export interface Party {
   readonly id: PartyId;
   readonly name: string;

--- a/libs/types/test/election.ts
+++ b/libs/types/test/election.ts
@@ -1,4 +1,9 @@
-import { DistrictIdSchema, Election, safeParseElection } from '../src/election';
+import {
+  DistrictIdSchema,
+  Election,
+  PartyIdSchema,
+  safeParseElection,
+} from '../src/election';
 import { unsafeParse } from '../src/generic';
 
 export const electionData = `
@@ -70,28 +75,43 @@ export const electionData = `
 export const election: Election = safeParseElection(
   electionData
 ).unsafeUnwrap();
+const democraticPartyId = unsafeParse(PartyIdSchema, 'DEM');
+const republicanPartyId = unsafeParse(PartyIdSchema, 'REP');
 export const primaryElection: Election = {
   ...election,
   ballotStyles: [
     ...election.ballotStyles.map((bs) => ({
       ...bs,
       id: `${bs.id}D`,
-      partyId: 'DEM',
+      partyId: democraticPartyId,
     })),
     ...election.ballotStyles.map((bs) => ({
       ...bs,
       id: `${bs.id}R`,
-      partyId: 'REP',
+      partyId: republicanPartyId,
     })),
   ],
   contests: [
-    ...election.contests.map((c) => ({ ...c, id: `${c.id}D`, partyId: 'DEM' })),
-    ...election.contests.map((c) => ({ ...c, id: `${c.id}R`, partyId: 'REP' })),
+    ...election.contests.map((c) => ({
+      ...c,
+      id: `${c.id}D`,
+      partyId: democraticPartyId,
+    })),
+    ...election.contests.map((c) => ({
+      ...c,
+      id: `${c.id}R`,
+      partyId: republicanPartyId,
+    })),
   ],
   parties: [
-    { id: 'DEM', name: 'Democrat', abbrev: 'D', fullName: 'Democratic Party' },
     {
-      id: 'REP',
+      id: democraticPartyId,
+      name: 'Democrat',
+      abbrev: 'D',
+      fullName: 'Democratic Party',
+    },
+    {
+      id: republicanPartyId,
       name: 'Republican',
       abbrev: 'R',
       fullName: 'Republican Party',

--- a/libs/ui/src/precinct_scanner_tally_report.test.tsx
+++ b/libs/ui/src/precinct_scanner_tally_report.test.tsx
@@ -8,6 +8,7 @@ import {
 import {
   BallotIdSchema,
   CastVoteRecord,
+  PartyIdSchema,
   PrecinctSelectionKind,
   unsafeParse,
 } from '@votingworks/types';
@@ -133,10 +134,11 @@ const primaryCvr: CastVoteRecord = {
 };
 
 test('renders as expected for all precincts in a primary election', async () => {
+  const party0 = unsafeParse(PartyIdSchema, '0');
   const tally = calculateTallyForCastVoteRecords(
     electionMinimalExhaustiveSampleDefintion.election,
     new Set([primaryCvr]),
-    '0'
+    party0
   );
   render(
     <PrecinctScannerTallyReport
@@ -148,7 +150,7 @@ test('renders as expected for all precincts in a primary election', async () => 
       reportPurpose="Testing"
       isPollsOpen
       tally={tally}
-      partyId="0"
+      partyId={party0}
     />
   );
   screen.getByText('All Precincts Polls Opened Tally Report');
@@ -206,10 +208,11 @@ const primaryCvr2: CastVoteRecord = {
 };
 
 test('renders as expected for a single precincts in a primary election', async () => {
+  const party1 = unsafeParse(PartyIdSchema, '1');
   const tally = calculateTallyForCastVoteRecords(
     electionMinimalExhaustiveSampleDefintion.election,
     new Set([primaryCvr2]),
-    '1'
+    party1
   );
   render(
     <PrecinctScannerTallyReport
@@ -222,7 +225,7 @@ test('renders as expected for a single precincts in a primary election', async (
       reportPurpose="Testing"
       isPollsOpen={false}
       tally={tally}
-      partyId="1"
+      partyId={party1}
     />
   );
   screen.getByText('Precinct 1 Polls Closed Tally Report');

--- a/libs/utils/src/compressed_tallies.test.ts
+++ b/libs/utils/src/compressed_tallies.test.ts
@@ -4,7 +4,9 @@ import {
   ContestOptionTally,
   Dictionary,
   expandEitherNeitherContests,
+  PartyIdSchema,
   Tally,
+  unsafeParse,
   VotingMethod,
   writeInCandidate,
 } from '@votingworks/types';
@@ -505,10 +507,11 @@ test('multi party primary tally can compress and be read back and end with the o
     expectedTally.contestTallies
   );
 
+  const party0 = unsafeParse(PartyIdSchema, '0');
   const expectedLibertyTally = calculateTallyForCastVoteRecords(
     electionMultiParty,
     new Set(castVoteRecords),
-    '0'
+    party0
   );
   // can read for a specific party id
   const processedLibertyTally = readCompressedTally(
@@ -520,7 +523,7 @@ test('multi party primary tally can compress and be read back and end with the o
       expectedLibertyTally.ballotCountsByVotingMethod[VotingMethod.Absentee] ??
         0,
     ],
-    '0'
+    party0
   );
   delete expectedLibertyTally.ballotCountsByVotingMethod[VotingMethod.Unknown];
   expect(processedLibertyTally.ballotCountsByVotingMethod).toStrictEqual(
@@ -535,8 +538,10 @@ test('multi party primary tally can compress and be read back and end with the o
 });
 
 describe('getTallyIdentifier', () => {
+  const party1 = unsafeParse(PartyIdSchema, 'party1');
+
   test('returns expected identifier with a party and precinct', () => {
-    expect(getTallyIdentifier('party1', 'precinct1')).toBe('party1,precinct1');
+    expect(getTallyIdentifier(party1, 'precinct1')).toBe('party1,precinct1');
   });
 
   test('returns expected identifier with no party and a precinct', () => {
@@ -546,7 +551,7 @@ describe('getTallyIdentifier', () => {
   });
 
   test('returns expected identifier with a party and no precinct', () => {
-    expect(getTallyIdentifier('party1')).toBe('party1,__ALL_PRECINCTS');
+    expect(getTallyIdentifier(party1)).toBe('party1,__ALL_PRECINCTS');
   });
 
   test('returns expected identifier with no party and no precinct', () => {

--- a/libs/utils/src/votes.test.ts
+++ b/libs/utils/src/votes.test.ts
@@ -14,6 +14,7 @@ import {
   FullElectionTally,
   Id,
   Party,
+  PartyIdSchema,
   PrecinctId,
   Tally,
   TallyCategory,
@@ -43,6 +44,10 @@ import {
 
 const multiPartyPrimaryElection =
   electionMultiPartyPrimaryWithDataFiles.electionDefinition.election;
+const party0 = unsafeParse(PartyIdSchema, '0');
+const party2 = unsafeParse(PartyIdSchema, '2');
+const party3 = unsafeParse(PartyIdSchema, '3');
+const party4 = unsafeParse(PartyIdSchema, '4');
 
 export function parseCvrs(cvrsFileContents: string): CastVoteRecord[] {
   const lines = cvrsFileContents.split('\n');
@@ -303,7 +308,7 @@ describe('filterTalliesByParams fallback to empty tally when the proper category
 
   test('when filtering by party', () => {
     expect(
-      filterTalliesByParams(electionTally, election, { partyId: '0' })
+      filterTalliesByParams(electionTally, election, { partyId: party0 })
     ).toStrictEqual(getEmptyTally());
   });
 
@@ -320,7 +325,7 @@ describe('filterTalliesByParams fallback to empty tally when the proper category
       precinctId: 'precinct-1',
       scannerId: 'scanner-1',
       votingMethod: VotingMethod.Precinct,
-      partyId: '0',
+      partyId: party0,
       batchId: '1234-1',
     });
     expectAllEmptyTallies(filteredTally);
@@ -626,7 +631,7 @@ describe('filterTalliesByParams in a primary election', () => {
 
   const expectedPartyInformation = [
     {
-      partyId: '0',
+      partyId: party0,
       contestIds: [
         'governor-contest-liberty',
         'mayor-contest-liberty',
@@ -642,7 +647,7 @@ describe('filterTalliesByParams in a primary election', () => {
       },
     },
     {
-      partyId: '3',
+      partyId: party3,
       contestIds: [
         'governor-contest-constitution',
         'mayor-contest-constitution',
@@ -657,7 +662,7 @@ describe('filterTalliesByParams in a primary election', () => {
       },
     },
     {
-      partyId: '4',
+      partyId: party4,
       contestIds: [
         'governor-contest-federalist',
         'mayor-contest-federalist',
@@ -728,7 +733,7 @@ describe('filterTalliesByParams in a primary election', () => {
     const filteredResults2 = filterTalliesByParams(
       electionTally,
       multiPartyPrimaryElection,
-      { partyId: '2' }
+      { partyId: party2 }
     );
     expectAllEmptyTallies(filteredResults2);
     expect(filteredResults2.contestTallies).toStrictEqual({});
@@ -822,7 +827,7 @@ describe('filterTalliesByParams in a primary election', () => {
       const filteredResults = filterTalliesByParams(
         electionTally,
         multiPartyPrimaryElection,
-        { partyId: '4', precinctId }
+        { partyId: party4, precinctId }
       );
       expect(Object.keys(filteredResults.contestTallies)).toStrictEqual(
         expectedParty4Info.contestIds
@@ -833,7 +838,7 @@ describe('filterTalliesByParams in a primary election', () => {
     const filterParty5Precinct1 = filterTalliesByParams(
       electionTally,
       multiPartyPrimaryElection,
-      { partyId: '4', precinctId: 'precinct-1' }
+      { partyId: party4, precinctId: 'precinct-1' }
     );
     expect(filterParty5Precinct1.numberOfBallotsCounted).toBe(300);
     expect(Object.keys(filterParty5Precinct1.contestTallies)).toStrictEqual(
@@ -857,7 +862,7 @@ describe('filterTalliesByParams in a primary election', () => {
     const filterParty5Precinct5 = filterTalliesByParams(
       electionTally,
       multiPartyPrimaryElection,
-      { partyId: '4', precinctId: 'precinct-5' }
+      { partyId: party4, precinctId: 'precinct-5' }
     );
     expect(filterParty5Precinct5.numberOfBallotsCounted).toBe(420);
     expect(Object.keys(filterParty5Precinct5.contestTallies)).toStrictEqual(
@@ -881,7 +886,7 @@ describe('filterTalliesByParams in a primary election', () => {
     const filterParty5InvalidPrecinct = filterTalliesByParams(
       electionTally,
       multiPartyPrimaryElection,
-      { partyId: '4', precinctId: 'not-a-real-precinct' }
+      { partyId: party4, precinctId: 'not-a-real-precinct' }
     );
     expect(Object.keys(filterParty5Precinct5.contestTallies)).toStrictEqual(
       expectedParty4Info.contestIds
@@ -896,17 +901,17 @@ describe('filterTalliesByParams in a primary election', () => {
     const filteredResultsScanner1 = filterTalliesByParams(
       electionTally,
       multiPartyPrimaryElection,
-      { scannerId: 'scanner-1', partyId: '0' }
+      { scannerId: 'scanner-1', partyId: party0 }
     );
     const filteredResultsScanner2 = filterTalliesByParams(
       electionTally,
       multiPartyPrimaryElection,
-      { scannerId: 'scanner-2', partyId: '0' }
+      { scannerId: 'scanner-2', partyId: party0 }
     );
     const filteredResultsScanner3 = filterTalliesByParams(
       electionTally,
       multiPartyPrimaryElection,
-      { scannerId: 'scanner-3', partyId: '0' }
+      { scannerId: 'scanner-3', partyId: party0 }
     );
 
     // All three scanners have identical copies of results, but the CVRs are different due to the scanner and ballot ids
@@ -954,7 +959,7 @@ describe('filterTalliesByParams in a primary election', () => {
     const filteredResultsInvalidScanner = filterTalliesByParams(
       electionTally,
       multiPartyPrimaryElection,
-      { scannerId: 'not-a-scanner', partyId: '0' }
+      { scannerId: 'not-a-scanner', partyId: party0 }
     );
     expect(
       Object.keys(filteredResultsInvalidScanner.contestTallies)
@@ -966,7 +971,7 @@ describe('filterTalliesByParams in a primary election', () => {
     const filteredResultsLibertyAbsentee = filterTalliesByParams(
       electionTally,
       multiPartyPrimaryElection,
-      { votingMethod: VotingMethod.Absentee, partyId: '0' }
+      { votingMethod: VotingMethod.Absentee, partyId: party0 }
     );
     expect(filteredResultsLibertyAbsentee.numberOfBallotsCounted).toBe(342);
     expect(
@@ -980,7 +985,7 @@ describe('filterTalliesByParams in a primary election', () => {
     const filteredResultsLibertyPrecinct = filterTalliesByParams(
       electionTally,
       multiPartyPrimaryElection,
-      { votingMethod: VotingMethod.Precinct, partyId: '0' }
+      { votingMethod: VotingMethod.Precinct, partyId: party0 }
     );
     expect(filteredResultsLibertyPrecinct.numberOfBallotsCounted).toBe(0);
     expect(
@@ -994,7 +999,7 @@ describe('filterTalliesByParams in a primary election', () => {
     const filteredResultsConstitutionPrecinct = filterTalliesByParams(
       electionTally,
       multiPartyPrimaryElection,
-      { votingMethod: VotingMethod.Precinct, partyId: '3' }
+      { votingMethod: VotingMethod.Precinct, partyId: party3 }
     );
     expect(filteredResultsConstitutionPrecinct.numberOfBallotsCounted).toBe(
       292
@@ -1010,7 +1015,7 @@ describe('filterTalliesByParams in a primary election', () => {
     const filteredResultsConstitutionAbsentee = filterTalliesByParams(
       electionTally,
       multiPartyPrimaryElection,
-      { votingMethod: VotingMethod.Absentee, partyId: '3' }
+      { votingMethod: VotingMethod.Absentee, partyId: party3 }
     );
     expect(filteredResultsConstitutionAbsentee.numberOfBallotsCounted).toBe(93);
     expect(
@@ -1024,7 +1029,7 @@ describe('filterTalliesByParams in a primary election', () => {
     const filteredResultsUnknownAbsentee = filterTalliesByParams(
       electionTally,
       multiPartyPrimaryElection,
-      { votingMethod: VotingMethod.Unknown, partyId: '0' }
+      { votingMethod: VotingMethod.Unknown, partyId: party0 }
     );
     expect(filteredResultsUnknownAbsentee.numberOfBallotsCounted).toBe(1368);
     expect(
@@ -1040,7 +1045,7 @@ describe('filterTalliesByParams in a primary election', () => {
     expect(
       filterTalliesByParams(electionTally, multiPartyPrimaryElection, {
         precinctId: 'not-a-precinct',
-        partyId: 'not-a-party',
+        partyId: unsafeParse(PartyIdSchema, 'not-a-party'),
         batchId: 'not-a-batch',
         scannerId: 'not-a-scanner',
         votingMethod: VotingMethod.Unknown,
@@ -1095,7 +1100,7 @@ describe('filterTalliesByParty', () => {
     const libertyPartyTally = calculateTallyForCastVoteRecords(
       election,
       new Set(castVoteRecords),
-      '0'
+      party0
     );
 
     const filteredTally = filterTalliesByParty({

--- a/libs/utils/src/votes.ts
+++ b/libs/utils/src/votes.ts
@@ -26,6 +26,8 @@ import {
   PrecinctId,
   CandidateId,
   ContestTallyMeta,
+  unsafeParse,
+  PartyIdSchema,
 } from '@votingworks/types';
 import { strict as assert } from 'assert';
 import { find } from './find';
@@ -137,7 +139,7 @@ export function getVotingMethodForCastVoteRecord(
 interface TallyParams {
   election: Election;
   votes: VotesDict[];
-  filterContestsByParty?: string;
+  filterContestsByParty?: PartyId;
 }
 export function tallyVotesByContest({
   election,
@@ -234,7 +236,7 @@ export function tallyVotesByContest({
 export function calculateTallyForCastVoteRecords(
   election: Election,
   castVoteRecords: ReadonlySet<CastVoteRecord>,
-  filterContestsByParty?: string
+  filterContestsByParty?: PartyId
 ): Tally {
   const allVotes: VotesDict[] = [];
   const ballotCountsByVotingMethod: Dictionary<number> = {};
@@ -401,7 +403,9 @@ export function computeTallyWithPrecomputedCategories(
       tallyResults[key] = calculateTallyForCastVoteRecords(
         election,
         cvrs,
-        tallyCategory === TallyCategory.Party ? key : undefined
+        tallyCategory === TallyCategory.Party
+          ? unsafeParse(PartyIdSchema, key)
+          : undefined
       );
     }
     resultsByCategory.set(tallyCategory, tallyResults);

--- a/services/scan/src/build_cast_vote_record.test.ts
+++ b/services/scan/src/build_cast_vote_record.test.ts
@@ -8,6 +8,7 @@ import {
   getBallotStyle,
   getContests,
   MsEitherNeitherContest,
+  PartyIdSchema,
   unsafeParse,
   vote,
   YesNoContest,
@@ -921,7 +922,7 @@ test('generates a CVR from an adjudicated uninterpreted HMPB page', () => {
               {
                 id: '23',
                 name: 'Jimmy Edwards',
-                partyId: '4',
+                partyId: unsafeParse(PartyIdSchema, '4'),
               },
             ],
           },


### PR DESCRIPTION
This means we can no longer assign an arbitrary string to a `PartyId` without validating it first.