### PR TITLE
feat(em) add export logs modal

### DIFF
--- a/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
+++ b/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
@@ -66,6 +66,12 @@ exports[`printing ballots, print report, and test decks 1`] = `
           class="sc-gsDJrp gwgkfw"
           type="button"
         >
+          Export Logs
+        </button>
+        <button
+          class="sc-gsDJrp gwgkfw"
+          type="button"
+        >
           Lock Machine
         </button>
         <button
@@ -83,7 +89,7 @@ exports[`printing ballots, print report, and test decks 1`] = `
         class="sc-dlfnbm kzZCED"
       >
         <div
-          class="sc-hBEYos eoEHwy"
+          class="sc-fFubgz HfZVK"
         >
           <h1>
             Test Deck
@@ -260,6 +266,12 @@ exports[`printing ballots, print report, and test decks 2`] = `
           class="sc-gsDJrp gwgkfw"
           type="button"
         >
+          Export Logs
+        </button>
+        <button
+          class="sc-gsDJrp gwgkfw"
+          type="button"
+        >
           Lock Machine
         </button>
         <button
@@ -284,7 +296,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
           Mock General Election Choctaw 2020
         </div>
         <div
-          class="sc-hBEYos eoEHwy"
+          class="sc-fFubgz HfZVK"
         >
           <h1
             class="sc-dJjZJu boqHgo"
@@ -386,7 +398,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
          Mock General Election Choctaw 2020
       </div>
       <div
-        class="sc-hBEYos eWOkWl"
+        class="sc-fFubgz cZzkcJ"
       >
         <h1
           class="sc-dJjZJu boqHgo"
@@ -1525,7 +1537,7 @@ exports[`tabulating CVRs 1`] = `
     src="/votingworks-wordmark-black.svg"
   />
   <div
-    class="sc-hBEYos eWOkWl"
+    class="sc-fFubgz cZzkcJ"
   >
     <h1>
       Official
@@ -2716,7 +2728,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
     src="/votingworks-wordmark-black.svg"
   />
   <div
-    class="sc-hBEYos eWOkWl"
+    class="sc-fFubgz cZzkcJ"
   >
     <h1>
       Unofficial

--- a/frontends/election-manager/src/components/export_logs_modal.test.tsx
+++ b/frontends/election-manager/src/components/export_logs_modal.test.tsx
@@ -1,0 +1,202 @@
+import React from 'react';
+
+import { fireEvent, waitFor } from '@testing-library/react';
+import {
+  advanceTimersAndPromises,
+  fakeKiosk,
+  fakeUsbDrive,
+} from '@votingworks/test-utils';
+import { usbstick } from '@votingworks/utils';
+
+import { LogEventId, Logger, LogSource } from '@votingworks/logging';
+import { ExportLogsModal } from './export_logs_modal';
+import { renderInAppContext } from '../../test/render_in_app_context';
+
+const { UsbDriveStatus } = usbstick;
+
+const fileSystemEntry: KioskBrowser.FileSystemEntry = {
+  name: 'file',
+  path: 'path',
+  type: 1,
+  size: 1,
+  atime: new Date(),
+  ctime: new Date(2021, 0, 1),
+  mtime: new Date(),
+};
+
+test('renders loading screen when usb drive is mounting or ejecting in export modal', () => {
+  const usbStatuses = [UsbDriveStatus.present, UsbDriveStatus.ejecting];
+
+  for (const status of usbStatuses) {
+    const closeFn = jest.fn();
+    const { getByText, unmount } = renderInAppContext(
+      <ExportLogsModal onClose={closeFn} />,
+      {
+        usbDriveStatus: status,
+      }
+    );
+    getByText('Loading');
+    unmount();
+  }
+});
+
+test('renders no log file found when usb is mounted but no log file on machine', async () => {
+  jest.useFakeTimers();
+  const closeFn = jest.fn();
+  const mockKiosk = fakeKiosk();
+  window.kiosk = mockKiosk;
+  mockKiosk.getFileSystemEntries.mockResolvedValueOnce([
+    { ...fileSystemEntry, name: 'not-the-right-file.log' },
+  ]);
+  mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
+  const logger = new Logger(LogSource.VxAdminApp);
+  const logSpy = jest.spyOn(logger, 'log').mockResolvedValue();
+
+  const { getByText } = renderInAppContext(
+    <ExportLogsModal onClose={closeFn} />,
+    {
+      usbDriveStatus: UsbDriveStatus.mounted,
+      logger,
+    }
+  );
+  getByText('Loading');
+  await advanceTimersAndPromises();
+  getByText('No Log File Present');
+  expect(logSpy).toHaveBeenCalledWith(
+    LogEventId.ExportLogFileFound,
+    'admin',
+    expect.objectContaining({ disposition: 'failure' })
+  );
+});
+
+test('render no usb found screen when there is not a mounted usb drive', async () => {
+  const usbStatuses = [
+    UsbDriveStatus.absent,
+    UsbDriveStatus.notavailable,
+    UsbDriveStatus.recentlyEjected,
+  ];
+  const mockKiosk = fakeKiosk();
+  window.kiosk = mockKiosk;
+  mockKiosk.getFileSystemEntries.mockResolvedValue([
+    { ...fileSystemEntry, name: 'vx-logs.log' },
+  ]);
+
+  for (const status of usbStatuses) {
+    const closeFn = jest.fn();
+    const { getByText, unmount, getByAltText } = renderInAppContext(
+      <ExportLogsModal onClose={closeFn} />,
+      {
+        usbDriveStatus: status,
+      }
+    );
+    getByText('Loading');
+    await advanceTimersAndPromises();
+    getByText('No USB Drive Detected');
+    getByText(
+      'Please insert a USB drive where you would like the save the log file.'
+    );
+    getByAltText('Insert USB Image');
+
+    fireEvent.click(getByText('Cancel'));
+    expect(closeFn).toHaveBeenCalled();
+
+    unmount();
+  }
+});
+
+test('renders save modal when usb is mounted and log file on machine', async () => {
+  jest.useFakeTimers();
+  const closeFn = jest.fn();
+  const mockKiosk = fakeKiosk();
+  window.kiosk = mockKiosk;
+  mockKiosk.getFileSystemEntries.mockResolvedValueOnce([
+    { ...fileSystemEntry, name: 'vx-logs.log' },
+  ]);
+  mockKiosk.readFile.mockResolvedValue('this-is-my-file-content');
+  mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
+  const logger = new Logger(LogSource.VxAdminApp);
+  const logSpy = jest.spyOn(logger, 'log').mockResolvedValue();
+
+  const { getByText } = renderInAppContext(
+    <ExportLogsModal onClose={closeFn} />,
+    {
+      usbDriveStatus: UsbDriveStatus.mounted,
+      logger,
+    }
+  );
+  getByText('Loading');
+  await advanceTimersAndPromises();
+  getByText('Save Logs');
+  expect(logSpy).toHaveBeenCalledWith(
+    LogEventId.ExportLogFileFound,
+    'admin',
+    expect.objectContaining({ disposition: 'success' })
+  );
+
+  fireEvent.click(getByText('Save'));
+  expect(mockKiosk.readFile).toHaveBeenCalled();
+  jest.advanceTimersByTime(2001);
+  await waitFor(() => getByText(/Logs Saved/));
+  await waitFor(() => {
+    expect(mockKiosk.writeFile).toHaveBeenCalledTimes(1);
+    expect(mockKiosk.writeFile).toHaveBeenNthCalledWith(
+      1,
+      'fake mount point/vx-logs.log',
+      'this-is-my-file-content'
+    );
+  });
+
+  fireEvent.click(getByText('Close'));
+  expect(closeFn).toHaveBeenCalled();
+
+  expect(logSpy).toHaveBeenCalledWith(
+    LogEventId.FileSaved,
+    'admin',
+    expect.objectContaining({
+      disposition: 'success',
+      filename: 'vx-logs.log',
+      fileType: 'logs',
+    })
+  );
+});
+
+test('render export modal with errors when appropriate', async () => {
+  const mockKiosk = fakeKiosk();
+  window.kiosk = mockKiosk;
+  mockKiosk.getFileSystemEntries.mockResolvedValueOnce([
+    { ...fileSystemEntry, name: 'vx-logs.log' },
+  ]);
+  const logger = new Logger(LogSource.VxAdminApp);
+  const logSpy = jest.spyOn(logger, 'log').mockResolvedValue();
+
+  mockKiosk.readFile.mockRejectedValueOnce(new Error('this-is-an-error'));
+
+  const closeFn = jest.fn();
+  const { getByText } = renderInAppContext(
+    <ExportLogsModal onClose={closeFn} />,
+    {
+      usbDriveStatus: UsbDriveStatus.mounted,
+      logger,
+    }
+  );
+  getByText('Loading');
+  await advanceTimersAndPromises();
+  getByText('Save Logs');
+
+  fireEvent.click(getByText('Save'));
+  await waitFor(() => getByText(/Failed to Save Logs/));
+  getByText(/Failed to save log file./);
+  getByText(/this-is-an-error/);
+
+  fireEvent.click(getByText('Close'));
+  expect(closeFn).toHaveBeenCalled();
+  expect(logSpy).toHaveBeenCalledWith(
+    LogEventId.FileSaved,
+    'admin',
+    expect.objectContaining({
+      disposition: 'failure',
+      fileType: 'logs',
+      message: 'Error saving log file: this-is-an-error',
+    })
+  );
+});

--- a/frontends/election-manager/src/components/export_logs_modal.tsx
+++ b/frontends/election-manager/src/components/export_logs_modal.tsx
@@ -1,10 +1,7 @@
-import React, { useContext, useState } from 'react';
-import styled from 'styled-components';
+import React, { useContext, useEffect, useState } from 'react';
 import path from 'path';
-import fileDownload from 'js-file-download';
 import { usbstick, throwIllegalValue } from '@votingworks/utils';
 
-import { UsbControllerButton } from '@votingworks/ui';
 import assert from 'assert';
 import { LogEventId } from '@votingworks/logging';
 import { AppContext } from '../contexts/app_context';
@@ -14,29 +11,15 @@ import { Prose } from './prose';
 import { LinkButton } from './link_button';
 import { Loading } from './loading';
 import { MainChild } from './main';
+import { UsbImage } from './save_file_to_usb';
 
 const { UsbDriveStatus } = usbstick;
 
-export const UsbImage = styled.img`
-  margin-right: auto;
-  margin-left: auto;
-  height: 200px;
-`;
-
-export enum FileType {
-  TallyReport = 'TallyReport',
-  TestDeckTallyReport = 'TestDeckTallyReport',
-  Ballot = 'Ballot',
-  Results = 'Results',
-  BatchResultsCsv = 'BatchResultsCSV',
-}
+const LOGS_ROOT_LOCATION = '/var/log';
+const LOG_NAME = 'vx-logs.log';
 
 export interface Props {
   onClose: () => void;
-  generateFileContent: () => Promise<Uint8Array | string>;
-  defaultFilename: string;
-  fileType: FileType;
-  promptToEjectUsb?: boolean;
 }
 
 enum ModalState {
@@ -46,92 +29,92 @@ enum ModalState {
   INIT = 'init',
 }
 
-export function SaveFileToUsb({
-  onClose,
-  generateFileContent,
-  defaultFilename,
-  fileType,
-  promptToEjectUsb = false,
-}: Props): JSX.Element {
-  const {
-    usbDriveStatus,
-    usbDriveEject,
-    isOfficialResults,
-    currentUserSession,
-    logger,
-  } = useContext(AppContext);
+export function ExportLogsModal({ onClose }: Props): JSX.Element {
+  const { usbDriveStatus, currentUserSession, logger } = useContext(AppContext);
   assert(currentUserSession); // TODO(auth) should this check for a specific user type
 
   const [currentState, setCurrentState] = useState(ModalState.INIT);
   const [errorMessage, setErrorMessage] = useState('');
 
   const [savedFilename, setSavedFilename] = useState('');
+  const [foundLogFile, setFoundLogFile] = useState(false);
+  const [isLocatingLogFile, setIsLocatingLogFile] = useState(true);
 
-  let title = ''; // Will be used in headings like Save Title
-  let fileName = ''; // Will be used in sentence like "Would you like to save the title?"
-  switch (fileType) {
-    case FileType.TallyReport:
-      title = `${isOfficialResults ? 'Official' : 'Unofficial'} Tally Report`;
-      fileName = 'tally report';
-      break;
-    case FileType.TestDeckTallyReport:
-      title = 'Test Deck Tally Report';
-      fileName = 'test deck tally report';
-      break;
-    case FileType.Ballot:
-      title = 'Ballot';
-      fileName = 'ballot';
-      break;
-    case FileType.Results:
-      title = 'Results';
-      fileName = 'election results';
-      break;
-    case FileType.BatchResultsCsv:
-      title = 'Batch Results';
-      fileName = 'election batch results';
-      break;
-    default:
-      throwIllegalValue(fileType);
-  }
+  useEffect(() => {
+    async function checkLogFile() {
+      assert(currentUserSession);
+      if (window.kiosk) {
+        const allLogs = await window.kiosk.getFileSystemEntries(
+          LOGS_ROOT_LOCATION
+        );
+        const vxLogFile = allLogs.filter((f) => f.name === LOG_NAME);
+        if (vxLogFile.length > 0) {
+          setFoundLogFile(true);
+          await logger.log(
+            LogEventId.ExportLogFileFound,
+            currentUserSession.type,
+            {
+              disposition: 'success',
+              message:
+                'Successfully located vx-logs.log file on machine to export.',
+            }
+          );
+        } else {
+          setFoundLogFile(false);
+          await logger.log(
+            LogEventId.ExportLogFileFound,
+            currentUserSession.type,
+            {
+              disposition: 'failure',
+              message:
+                'Could not locate vx-logs.log file on machine. Machine is not configured for production use.',
+              result: 'Logs are not exportable.',
+            }
+          );
+        }
+        setIsLocatingLogFile(false);
+      }
+    }
+    void checkLogFile();
+  }, [currentUserSession, logger]);
 
   async function exportResults(openFileDialog: boolean) {
+    assert(window.kiosk);
     assert(currentUserSession); // TODO(auth) should this check for a specific user type
     setCurrentState(ModalState.SAVING);
 
     try {
-      const results = await generateFileContent();
+      const results = await window.kiosk.readFile(
+        `${LOGS_ROOT_LOCATION}/${LOG_NAME}`
+      );
       let filenameLocation = '';
-      if (!window.kiosk) {
-        fileDownload(results, defaultFilename, 'text/csv');
-      } else {
-        const usbPath = await usbstick.getDevicePath();
-        if (openFileDialog) {
-          const fileWriter = await window.kiosk.saveAs({
-            defaultPath: defaultFilename,
-          });
+      const usbPath = await usbstick.getDevicePath();
+      if (openFileDialog) {
+        const fileWriter = await window.kiosk.saveAs({
+          defaultPath: LOG_NAME,
+        });
 
-          if (!fileWriter) {
-            throw new Error('could not begin download; no file was chosen');
-          }
-
-          await fileWriter.write(results);
-          filenameLocation = fileWriter.filename;
-          await fileWriter.end();
-        } else {
-          assert(typeof usbPath !== 'undefined');
-          const pathToFile = path.join(usbPath, defaultFilename);
-          assert(window.kiosk);
-          await window.kiosk.writeFile(pathToFile, results);
-          filenameLocation = defaultFilename;
+        if (!fileWriter) {
+          throw new Error('could not begin download; no file was chosen');
         }
+
+        await fileWriter.write(results);
+        filenameLocation = fileWriter.filename;
+        await fileWriter.end();
+      } else {
+        assert(typeof usbPath !== 'undefined');
+        const pathToFile = path.join(usbPath, LOG_NAME);
+        assert(window.kiosk);
+        await window.kiosk.writeFile(pathToFile, results);
+        filenameLocation = LOG_NAME;
       }
 
       setSavedFilename(filenameLocation);
       await new Promise((resolve) => setTimeout(resolve, 2000));
       await logger.log(LogEventId.FileSaved, currentUserSession.type, {
         disposition: 'success',
-        message: `Successfully saved ${fileName} to ${filenameLocation} on the usb drive.`,
-        fileType,
+        message: `Successfully saved log file to ${filenameLocation} on the usb drive.`,
+        fileType: 'logs',
         filename: filenameLocation,
       });
       setCurrentState(ModalState.DONE);
@@ -139,9 +122,9 @@ export function SaveFileToUsb({
       setErrorMessage(error.message);
       await logger.log(LogEventId.FileSaved, currentUserSession.type, {
         disposition: 'failure',
-        message: `Error saving ${fileName}: ${error.message}`,
+        message: `Error saving log file: ${error.message}`,
         result: 'File not saved, error message shown to user.',
-        fileType,
+        fileType: 'logs',
       });
       setCurrentState(ModalState.ERROR);
     }
@@ -152,10 +135,8 @@ export function SaveFileToUsb({
       <Modal
         content={
           <Prose>
-            <h1>Failed to Save {title}</h1>
-            <p>
-              Failed to save {fileName}. {errorMessage}
-            </p>
+            <h1>Failed to Save Logs</h1>
+            <p>Failed to save log file. {errorMessage}</p>
           </Prose>
         }
         onOverlayClick={onClose}
@@ -165,29 +146,14 @@ export function SaveFileToUsb({
   }
 
   if (currentState === ModalState.DONE) {
-    let actions = <LinkButton onPress={onClose}>Close</LinkButton>;
-    if (promptToEjectUsb && usbDriveStatus !== UsbDriveStatus.recentlyEjected) {
-      actions = (
-        <React.Fragment>
-          <LinkButton onPress={onClose}>Close</LinkButton>
-          <UsbControllerButton
-            small={false}
-            primary
-            usbDriveStatus={usbDriveStatus}
-            usbDriveEject={() => usbDriveEject(currentUserSession.type)}
-          />
-        </React.Fragment>
-      );
-    }
+    const actions = <LinkButton onPress={onClose}>Close</LinkButton>;
     return (
       <Modal
         content={
           <Prose>
-            <h1>{title} Saved</h1>
-            {promptToEjectUsb && <p>You may now eject the USB drive.</p>}
+            <h1>Logs Saved</h1>
             <p>
-              {fileName.charAt(0).toUpperCase() + fileName.slice(1)}{' '}
-              successfully saved{' '}
+              Log file successfully saved{' '}
               {savedFilename !== '' && (
                 <span>
                   as <strong>{savedFilename}</strong>
@@ -204,11 +170,36 @@ export function SaveFileToUsb({
   }
 
   if (currentState === ModalState.SAVING) {
-    return <Modal content={<Loading>Saving {title}</Loading>} />;
+    return <Modal content={<Loading>Saving Logs</Loading>} />;
   }
 
   if (currentState !== ModalState.INIT) {
     throwIllegalValue(currentState);
+  }
+
+  if (isLocatingLogFile) {
+    return (
+      <Modal
+        content={<Loading>Loading</Loading>}
+        onOverlayClick={onClose}
+        actions={<LinkButton onPress={onClose}>Close</LinkButton>}
+      />
+    );
+  }
+
+  if (!window.kiosk || !foundLogFile) {
+    return (
+      <Modal
+        content={
+          <Prose>
+            <h1>No Log File Present</h1>
+            <p>No log file detected on device.</p>
+          </Prose>
+        }
+        onOverlayClick={onClose}
+        actions={<LinkButton onPress={onClose}>Close</LinkButton>}
+      />
+    );
   }
 
   switch (usbDriveStatus) {
@@ -224,8 +215,8 @@ export function SaveFileToUsb({
               <h1>No USB Drive Detected</h1>
               <p>
                 <UsbImage src="/usb-drive.svg" alt="Insert USB Image" />
-                Please insert a USB drive where you would like the save the{' '}
-                {fileName}.
+                Please insert a USB drive where you would like the save the log
+                file.
               </p>
             </Prose>
           }
@@ -233,7 +224,7 @@ export function SaveFileToUsb({
           actions={
             <React.Fragment>
               <LinkButton onPress={onClose}>Cancel</LinkButton>
-              {(!window.kiosk || process.env.NODE_ENV === 'development') && (
+              {process.env.NODE_ENV === 'development' && (
                 <Button
                   data-testid="manual-export"
                   onPress={() => exportResults(true)}
@@ -264,10 +255,10 @@ export function SaveFileToUsb({
           content={
             <MainChild>
               <Prose>
-                <h1>Save {title}</h1>
+                <h1>Save Logs</h1>
                 <p>
-                  Save the {fileName} as <strong>{defaultFilename}</strong>{' '}
-                  directly on the inserted USB drive?
+                  Save the log file as <strong>{LOG_NAME}</strong> directly on
+                  the inserted USB drive?
                 </p>
               </Prose>
             </MainChild>

--- a/frontends/election-manager/src/components/navigation_screen.tsx
+++ b/frontends/election-manager/src/components/navigation_screen.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { Button, UsbControllerButton } from '@votingworks/ui';
@@ -10,6 +10,7 @@ import { Main, MainChild } from './main';
 import { Navigation } from './navigation';
 import { LinkButton } from './link_button';
 import { StatusFooter } from './status_footer';
+import { ExportLogsModal } from './export_logs_modal';
 
 interface Props {
   children: React.ReactNode;
@@ -37,6 +38,7 @@ export function NavigationScreen({
     machineConfig,
     currentUserSession,
   } = useContext(AppContext);
+  const [isExportingLogs, setIsExportingLogs] = useState(false);
   const election = electionDefinition?.election;
   const currentUser = currentUserSession?.type ?? 'unknown';
 
@@ -76,6 +78,9 @@ export function NavigationScreen({
         }
         secondaryNav={
           <React.Fragment>
+            <Button small onPress={() => setIsExportingLogs(true)}>
+              Export Logs
+            </Button>
             {!machineConfig.bypassAuthentication && (
               <Button small onPress={lockMachine}>
                 Lock Machine
@@ -94,6 +99,9 @@ export function NavigationScreen({
         </MainChild>
       </Main>
       <StatusFooter />
+      {isExportingLogs && (
+        <ExportLogsModal onClose={() => setIsExportingLogs(false)} />
+      )}
     </Screen>
   );
 }

--- a/libs/logging/src/log_event_ids.ts
+++ b/libs/logging/src/log_event_ids.ts
@@ -87,6 +87,7 @@ export enum LogEventId {
   ScanBatchContinue = 'scan-batch-continue',
   ScanAdjudicationInfo = 'scan-adjudication-info',
   ScannerConfigReloaded = 'scanner-config-reloaded',
+  ExportLogFileFound = 'export-log-file-found',
 }
 
 export interface LogDetails {
@@ -548,6 +549,13 @@ const ScannerConfigReloaded: LogDetails = {
     'Configuration information for the machine including the election, if the machine is in test mode, and mark threshold override values were reloaded from the backend service storing this information.',
 };
 
+const ExportLogFileFound: LogDetails = {
+  eventId: LogEventId.ExportLogFileFound,
+  eventType: LogEventType.ApplicationStatus,
+  documentationMessage:
+    'When the user is exporting logs, indicates the success/failure of finding the expected log file on the machine.',
+};
+
 export function getDetailsForEventId(eventId: LogEventId): LogDetails {
   switch (eventId) {
     case LogEventId.ElectionConfigured:
@@ -686,6 +694,8 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return ScanAdjudicationInfo;
     case LogEventId.ScannerConfigReloaded:
       return ScannerConfigReloaded;
+    case LogEventId.ExportLogFileFound:
+      return ExportLogFileFound;
     /* istanbul ignore next - compile time check for completeness */
     default:
       throwIllegalValue(eventId);


### PR DESCRIPTION
Adds a simple export logs modal to election manager. 

https://user-images.githubusercontent.com/14897017/144110628-f2752391-4beb-4d5f-a172-d75b21a7ac05.mov

@beausmith currently this just mimicks our other save dialogs but in the future will need to also export in other formats (primarily the CDF format, but we may want others) so would love any thoughts you have on how to extend the design to that. We might also want to allow to export other log files (syslog for example) but we can currently do this in tty2 and this would really only be something we want votingworks employees doing so its probably fine ignoring that for now. 

https://github.com/votingworks/vxsuite/issues/1260

Note: will require followup task in vxsuite-complete-system to update the permissions given to kiosk-browser.

Ideally this would be in the shared UI repo but that is blocked on Modal being there. 