### PR TITLE
build: depend on `pnpm`

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "husky": "^7.0.0",
     "lint-staged": "^11.0.0",
     "ora": "^5.2.0",
+    "pnpm": "^5.18.10",
     "prettier": "^2.3.2",
     "sort-package-json": "^1.50.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ importers:
       husky: 7.0.0
       lint-staged: 11.0.0
       ora: 5.2.0
+      pnpm: 5.18.10
       prettier: 2.3.2
       sort-package-json: 1.50.0
     specifiers:
@@ -12,6 +13,7 @@ importers:
       husky: ^7.0.0
       lint-staged: ^11.0.0
       ora: ^5.2.0
+      pnpm: ^5.18.10
       prettier: ^2.3.2
       sort-package-json: ^1.50.0
   codemods:
@@ -20368,6 +20370,13 @@ packages:
       typescript: '*'
     resolution:
       integrity: sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==
+  /pnpm/5.18.10:
+    dev: true
+    engines:
+      node: '>=10.16'
+    hasBin: true
+    resolution:
+      integrity: sha512-M3oH42XqtUZv0Hnfp4A1klTFQT3/9ghBkDrPHh0GTd9nP39I14/GDjN+BiHx95hH60CigOip+oK/h389GhizeQ==
   /portfinder/1.0.28:
     dependencies:
       async: 2.6.3


### PR DESCRIPTION
This will make it easier to ensure we're using the same version of `pnpm`, though we do have a bootstrapping problem. In CI we use pnpm@6 to install pnpm@5 globally. Eventually we'll want to use this more specific locked-down version, but for now this just plants a flag in the ground and allows tooling like this to use the right version within the monorepo: https://github.com/eventualbuddha/dotfiles/pull/4.