### PR TITLE
fix(hardware): account for devices with no battery

### DIFF
--- a/frontends/bmd/src/app_root.tsx
+++ b/frontends/bmd/src/app_root.tsx
@@ -1026,18 +1026,28 @@ export function AppRoot({
   const hardwareStatusInterval = useInterval(
     async () => {
       const battery = await hardware.readBatteryStatus();
-      const newHasLowBattery = battery.level < GLOBALS.LOW_BATTERY_THRESHOLD;
-      const hasHardwareStateChanged =
-        hasChargerAttached !== !battery.discharging ||
-        hasLowBattery !== newHasLowBattery;
-      if (hasHardwareStateChanged) {
+      if (!battery) {
         dispatchAppState({
           type: 'updateHardwareState',
           hardwareState: {
-            hasChargerAttached: !battery.discharging,
-            hasLowBattery: newHasLowBattery,
+            hasChargerAttached: true,
+            hasLowBattery: false,
           },
         });
+      } else {
+        const newHasLowBattery = battery.level < GLOBALS.LOW_BATTERY_THRESHOLD;
+        const hasHardwareStateChanged =
+          hasChargerAttached !== !battery.discharging ||
+          hasLowBattery !== newHasLowBattery;
+        if (hasHardwareStateChanged) {
+          dispatchAppState({
+            type: 'updateHardwareState',
+            hardwareState: {
+              hasChargerAttached: !battery.discharging,
+              hasLowBattery: newHasLowBattery,
+            },
+          });
+        }
       }
     },
     GLOBALS.HARDWARE_POLLING_INTERVAL,

--- a/frontends/bmd/src/app_setup_errors.test.tsx
+++ b/frontends/bmd/src/app_setup_errors.test.tsx
@@ -288,5 +288,20 @@ describe('Displays setup warning messages and errors screens', () => {
     await advanceTimersAndPromises(HARDWARE_POLLING_INTERVAL / 1000);
     expect(screen.queryByText(noPowerDetectedWarningText)).toBeFalsy();
     screen.getByText(insertCardScreenText);
+
+    // Unplug charger and show warning again
+    await act(async () => {
+      await hardware.setBatteryDischarging(true);
+    });
+    await advanceTimersAndPromises(HARDWARE_POLLING_INTERVAL / 1000);
+    getByTextWithMarkup(lowBatteryErrorScreenText);
+
+    // Remove battery, i.e. we're on a desktop
+    await act(async () => {
+      await hardware.removeBattery();
+    });
+    await advanceTimersAndPromises(HARDWARE_POLLING_INTERVAL / 1000);
+    expect(screen.queryByText(noPowerDetectedWarningText)).toBeFalsy();
+    screen.getByText(insertCardScreenText);
   });
 });

--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -490,18 +490,28 @@ export function AppRoot({
   const hardwareStatusInterval = useInterval(
     async () => {
       const battery = await hardware.readBatteryStatus();
-      const newHasLowBattery = battery.level < LOW_BATTERY_THRESHOLD;
-      const hasHardwareStateChanged =
-        hasChargerAttached !== !battery.discharging ||
-        hasLowBattery !== newHasLowBattery;
-      if (hasHardwareStateChanged) {
+      if (!battery) {
         dispatchAppState({
           type: 'updateHardwareState',
           hardwareState: {
-            hasChargerAttached: !battery.discharging,
-            hasLowBattery: newHasLowBattery,
+            hasChargerAttached: true,
+            hasLowBattery: false,
           },
         });
+      } else {
+        const newHasLowBattery = battery.level < LOW_BATTERY_THRESHOLD;
+        const hasHardwareStateChanged =
+          hasChargerAttached !== !battery.discharging ||
+          hasLowBattery !== newHasLowBattery;
+        if (hasHardwareStateChanged) {
+          dispatchAppState({
+            type: 'updateHardwareState',
+            hardwareState: {
+              hasChargerAttached: !battery.discharging,
+              hasLowBattery: newHasLowBattery,
+            },
+          });
+        }
       }
     },
     HARDWARE_POLLING_INTERVAL,

--- a/libs/@types/kiosk-browser/kiosk-browser.d.ts
+++ b/libs/@types/kiosk-browser/kiosk-browser.d.ts
@@ -136,7 +136,7 @@ declare namespace KioskBrowser {
     printToPDF(): Promise<Uint8Array>;
     log(message: string): Promise<void>;
 
-    getBatteryInfo(): Promise<BatteryInfo>;
+    getBatteryInfo(): Promise<BatteryInfo | undefined>;
     devices: import('rxjs').Observable<Iterable<Device>>;
     printers: import('rxjs').Observable<Iterable<PrinterInfo>>;
     quit(): void;

--- a/libs/utils/src/Hardware/kiosk_hardware.ts
+++ b/libs/utils/src/Hardware/kiosk_hardware.ts
@@ -12,7 +12,7 @@ export class KioskHardware extends MemoryHardware {
   /**
    * Reads Battery status
    */
-  async readBatteryStatus(): Promise<KioskBrowser.BatteryInfo> {
+  async readBatteryStatus(): Promise<KioskBrowser.BatteryInfo | undefined> {
     return this.kiosk.getBatteryInfo();
   }
 

--- a/libs/utils/src/Hardware/memory_hardware.test.ts
+++ b/libs/utils/src/Hardware/memory_hardware.test.ts
@@ -180,4 +180,20 @@ it('can set and read battery level', async () => {
     discharging: true,
     level: 0.25,
   });
+
+  await hardware.removeBattery();
+  expect(await hardware.readBatteryStatus()).toBeUndefined();
+  await hardware.setBatteryLevel(0.25);
+  expect(await hardware.readBatteryStatus()).toEqual({
+    discharging: false,
+    level: 0.25,
+  });
+
+  await hardware.removeBattery();
+  expect(await hardware.readBatteryStatus()).toBeUndefined();
+  await hardware.setBatteryDischarging(true);
+  expect(await hardware.readBatteryStatus()).toEqual({
+    discharging: true,
+    level: 0.8,
+  });
 });

--- a/libs/utils/src/Hardware/memory_hardware.ts
+++ b/libs/utils/src/Hardware/memory_hardware.ts
@@ -14,14 +14,16 @@ import {
   FujitsuFi7160ScannerProductId,
 } from './utils';
 
+const DEFAULT_BATTERY_STATUS: KioskBrowser.BatteryInfo = {
+  discharging: false,
+  level: 0.8,
+};
+
 /**
  * Implements the `Hardware` API with an in-memory implementation.
  */
 export class MemoryHardware implements Hardware {
-  private batteryStatus: KioskBrowser.BatteryInfo = {
-    discharging: false,
-    level: 0.8,
-  };
+  private batteryStatus? = DEFAULT_BATTERY_STATUS;
 
   private connectedDevices = new Set<KioskBrowser.Device>();
 
@@ -121,7 +123,7 @@ export class MemoryHardware implements Hardware {
   /**
    * Reads Battery status
    */
-  async readBatteryStatus(): Promise<KioskBrowser.BatteryInfo> {
+  async readBatteryStatus(): Promise<KioskBrowser.BatteryInfo | undefined> {
     return this.batteryStatus;
   }
 
@@ -130,7 +132,7 @@ export class MemoryHardware implements Hardware {
    */
   async setBatteryDischarging(discharging: boolean): Promise<void> {
     this.batteryStatus = {
-      ...this.batteryStatus,
+      ...(this.batteryStatus ?? DEFAULT_BATTERY_STATUS),
       discharging,
     };
   }
@@ -140,9 +142,16 @@ export class MemoryHardware implements Hardware {
    */
   async setBatteryLevel(level: number): Promise<void> {
     this.batteryStatus = {
-      ...this.batteryStatus,
+      ...(this.batteryStatus ?? DEFAULT_BATTERY_STATUS),
       level,
     };
+  }
+
+  /**
+   * Removes the battery from the device.
+   */
+  async removeBattery(): Promise<void> {
+    this.batteryStatus = undefined;
   }
 
   /**

--- a/libs/utils/src/types.ts
+++ b/libs/utils/src/types.ts
@@ -176,7 +176,7 @@ export interface Hardware {
   /**
    * Reads Battery status
    */
-  readBatteryStatus(): Promise<KioskBrowser.BatteryInfo>;
+  readBatteryStatus(): Promise<KioskBrowser.BatteryInfo | undefined>;
 
   /**
    * Reads Printer status


### PR DESCRIPTION
In production all our devices have batteries, but this may not always be true. In addition, running in development on a desktop means there will be no batteries. Frontends will now check that there is a battery before trying to check its status.

Refs https://github.com/votingworks/kiosk-browser/pull/93