### PR TITLE
build(services): update services metadata

### DIFF
--- a/frontends/bas/package.json
+++ b/frontends/bas/package.json
@@ -105,8 +105,8 @@
   },
   "vx": {
     "isBundled": true,
-    "modules": [
-      "../module-smartcards"
+    "services": [
+      "../../services/smartcards"
     ]
   }
 }

--- a/frontends/bmd/package.json
+++ b/frontends/bmd/package.json
@@ -177,8 +177,8 @@
   },
   "vx": {
     "isBundled": true,
-    "modules": [
-      "../module-smartcards"
+    "services": [
+      "../../services/smartcards"
     ]
   }
 }

--- a/frontends/bsd/package.json
+++ b/frontends/bsd/package.json
@@ -144,7 +144,7 @@
   },
   "vx": {
     "isBundled": true,
-    "modules": [
+    "services": [
       "../../services/scan",
       "../../services/smartcards"
     ]

--- a/frontends/election-manager/package.json
+++ b/frontends/election-manager/package.json
@@ -167,9 +167,9 @@
   },
   "vx": {
     "isBundled": true,
-    "modules": [
-      "../module-converter-ms-sems",
-      "../module-smartcards"
+    "services": [
+      "../../services/converter-ms-sems",
+      "../../services/smartcards"
     ]
   }
 }

--- a/frontends/precinct-scanner/package.json
+++ b/frontends/precinct-scanner/package.json
@@ -153,7 +153,7 @@
   },
   "vx": {
     "isBundled": true,
-    "modules": [
+    "services": [
       "../../services/scan",
       "../../services/smartcards"
     ]


### PR DESCRIPTION
Fixes the remaining `vx.modules` metadata in `package.json` files to be `services` and updates the paths. Somehow I missed some of these.