### PR TITLE
fix(scan): make adjudication work again

### DIFF
--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -109,14 +109,14 @@ export const WriteInIdSchema: z.ZodSchema<WriteInId> = z
 export type CandidateId = Id;
 export const CandidateIdSchema: z.ZodSchema<CandidateId> = IdSchema;
 export interface Candidate {
-  readonly id: CandidateId;
+  readonly id: CandidateId | WriteInId;
   readonly name: string;
   readonly partyId?: PartyId;
   readonly isWriteIn?: boolean;
 }
 export const CandidateSchema: z.ZodSchema<Candidate> = z.object({
   _lang: TranslationsSchema.optional(),
-  id: CandidateIdSchema,
+  id: z.union([CandidateIdSchema, WriteInIdSchema]),
   name: z.string().nonempty(),
   partyId: PartyIdSchema.optional(),
   isWriteIn: z.boolean().optional(),

--- a/services/scan/src/server.test.ts
+++ b/services/scan/src/server.test.ts
@@ -1,4 +1,7 @@
-import { electionSampleDefinition as testElectionDefinition } from '@votingworks/fixtures';
+import {
+  asElectionDefinition,
+  electionSampleDefinition as testElectionDefinition,
+} from '@votingworks/fixtures';
 import { Logger, LogSource } from '@votingworks/logging';
 import * as plusteksdk from '@votingworks/plustek-sdk';
 import { BallotType, ok } from '@votingworks/types';
@@ -33,11 +36,7 @@ let importer: jest.Mocked<Importer>;
 beforeEach(async () => {
   importer = makeMock(Importer);
   workspace = await createWorkspace(dirSync().name);
-  await workspace.store.setElection({
-    election,
-    electionData: JSON.stringify(election),
-    electionHash: '',
-  });
+  await workspace.store.setElection(asElectionDefinition(election));
   await workspace.store.addHmpbTemplate(
     Buffer.of(),
     {

--- a/services/scan/src/server.ts
+++ b/services/scan/src/server.ts
@@ -53,6 +53,7 @@ import bodyParser from 'body-parser';
 import express, { Application } from 'express';
 import { readFile } from 'fs-extra';
 import multer from 'multer';
+import { strict as assert } from 'assert';
 import { backup } from './backup';
 import {
   SCAN_ALWAYS_HOLD_ON_REJECT,
@@ -369,6 +370,8 @@ export function buildApp({ store, importer }: AppOptions): Application {
 
       try {
         const { ballots = [], metadatas = [] } = request.files;
+        const electionDefinition = await store.getElectionDefinition();
+        assert(electionDefinition);
 
         for (let i = 0; i < ballots.length; i += 1) {
           const ballotFile = ballots[i];
@@ -405,7 +408,7 @@ export function buildApp({ store, importer }: AppOptions): Application {
           );
 
           await importer.addHmpbTemplates(await readFile(ballotFile.path), {
-            electionHash: '',
+            electionHash: electionDefinition.electionHash,
             ballotType: BallotType.Standard,
             ballotStyleId: metadata.ballotStyleId,
             precinctId: metadata.precinctId,


### PR DESCRIPTION
While working on verifying that `bsd` still works with Ubuntu 20 for #1278 I discovered that it's actually just broken completely when trying to do adjudication of overvotes/undervotes/etc.

In #1169 [I changed `CandidateSchema`'s `id` to be a `CandidateIdSchema` value rather than a `string` schema](https://github.com/votingworks/vxsuite/commit/29b5e67cb01d8495113b9c0a04a0b3f590bdd6bd#diff-f64086a9f63d69967e91c55e86467e75be5dcb8aa355f76ef921cbd00f529006R118). This was incorrect, as we didn't have separate types for write-in vs non-write-in candidates, and `CandidateIdSchema` rejects write-in IDs. We now allow either `CandidateIdSchema` or `WriteInIdSchema` for `Candidate#id`.

Additionally, we've been hardcoding the `electionHash` stored with the ballot contest layout information to be an empty string. This failed when trying to validate it as a real election hash (which must be non-empty). Now, when adding a template we get the real election hash and store it. However, this whole thing should probably be re-thought. Why are we storing `electionHash` here again?