### PR TITLE
fix(em): configuration race condition

### DIFF
--- a/frontends/election-manager/src/app_root.tsx
+++ b/frontends/election-manager/src/app_root.tsx
@@ -149,7 +149,7 @@ export function AppRoot({
     electionDefinition,
     setElectionDefinition,
   ] = useState<ElectionDefinition>();
-  const [configuredAt, setConfiguredAt] = useState<Iso8601Timestamp>('');
+  const [configuredAt, setConfiguredAt] = useState<Iso8601Timestamp>();
 
   const [castVoteRecordFiles, setCastVoteRecordFiles] = useState(
     CastVoteRecordFiles.empty
@@ -300,10 +300,10 @@ export function AppRoot({
       if (!electionDefinition) {
         const storageElectionDefinition = await getElectionDefinition();
         if (storageElectionDefinition) {
-          const configuredAtTime = // TODO: validate this with zod schema
-            ((await storage.get(configuredAtStorageKey)) as
-              | string
-              | undefined) || '';
+          const configuredAtTime = (await storage.get(
+            // TODO: validate this with zod schema
+            configuredAtStorageKey
+          )) as string | undefined;
           setElectionDefinition(storageElectionDefinition);
           setConfiguredAt(configuredAtTime);
           await logger.log(LogEventId.LoadFromStorage, 'system', {

--- a/frontends/election-manager/src/components/election_manager.tsx
+++ b/frontends/election-manager/src/components/election_manager.tsx
@@ -27,6 +27,7 @@ import { UnlockMachineScreen } from '../screens/unlock_machine_screen';
 export function ElectionManager(): JSX.Element {
   const {
     electionDefinition,
+    configuredAt,
     currentUserSession,
     hasCardReaderAttached,
   } = useContext(AppContext);
@@ -36,7 +37,7 @@ export function ElectionManager(): JSX.Element {
     return <SetupCardReaderPage />;
   }
 
-  if (!election) {
+  if (!election || !configuredAt) {
     return <UnconfiguredScreen />;
   }
 

--- a/frontends/election-manager/src/contexts/app_context.ts
+++ b/frontends/election-manager/src/contexts/app_context.ts
@@ -25,7 +25,7 @@ import { getEmptyExportableTallies } from '../utils/exportable_tallies';
 export interface AppContextInterface {
   castVoteRecordFiles: CastVoteRecordFiles;
   electionDefinition?: ElectionDefinition;
-  configuredAt: Iso8601Timestamp;
+  configuredAt?: Iso8601Timestamp;
   isOfficialResults: boolean;
   printer: Printer;
   printBallotRef?: RefObject<HTMLElement>;
@@ -60,7 +60,7 @@ export interface AppContextInterface {
 const appContext: AppContextInterface = {
   castVoteRecordFiles: CastVoteRecordFiles.empty,
   electionDefinition: undefined,
-  configuredAt: '',
+  configuredAt: undefined,
   isOfficialResults: false,
   printer: new NullPrinter(),
   printBallotRef: undefined,

--- a/frontends/election-manager/src/screens/ballot_list_screen.tsx
+++ b/frontends/election-manager/src/screens/ballot_list_screen.tsx
@@ -32,7 +32,7 @@ export function BallotListScreen(): JSX.Element {
   const { electionDefinition, printedBallots, configuredAt } = useContext(
     AppContext
   );
-  assert(electionDefinition);
+  assert(electionDefinition && typeof configuredAt === 'string');
   const { election } = electionDefinition;
 
   const allBallotStyles = getBallotStylesData(election);

--- a/frontends/election-manager/src/screens/definition_screen.tsx
+++ b/frontends/election-manager/src/screens/definition_screen.tsx
@@ -27,7 +27,7 @@ interface ContestSection {
 
 export function DefinitionScreen(): JSX.Element {
   const { electionDefinition, configuredAt } = useContext(AppContext);
-  assert(electionDefinition);
+  assert(electionDefinition && typeof configuredAt === 'string');
   const { election } = electionDefinition;
 
   const [isRemovingElection, setIsRemovingElection] = useState(false);

--- a/frontends/election-manager/src/screens/printed_ballots_report_screen.tsx
+++ b/frontends/election-manager/src/screens/printed_ballots_report_screen.tsx
@@ -31,7 +31,7 @@ export function PrintedBallotsReportScreen(): JSX.Element {
     logger,
     currentUserSession,
   } = useContext(AppContext);
-  assert(electionDefinition);
+  assert(electionDefinition && typeof configuredAt === 'string');
   const { election } = electionDefinition;
 
   const totalBallotsPrinted = printedBallots.reduce(

--- a/frontends/election-manager/test/render_in_app_context.tsx
+++ b/frontends/election-manager/test/render_in_app_context.tsx
@@ -81,7 +81,7 @@ export function renderInAppContext(
     history = createMemoryHistory({ initialEntries: [route] }),
     castVoteRecordFiles = CastVoteRecordFiles.empty,
     electionDefinition = eitherNeitherElectionDefinition,
-    configuredAt = '',
+    configuredAt = new Date().toISOString(),
     isOfficialResults = false,
     printer = new NullPrinter(),
     printBallotRef = undefined,


### PR DESCRIPTION
`saveElection` in `AppRoot` calls `setElectionDefinition`, which triggers an immediate re-render. In this render, `electionDefinition` will be set but `configuredAt` will not. This is a problem if the render path tries to use `configuredAt`. To fix this, we render `UnconfiguredScreen` when either `electionDefinition` or `configuredAt` are unset.

Additionally, this replaces the empty string placeholder value—which is not a valid ISO8601 timestamp—with `undefined` and updates asserts to account for that.