### PR TITLE
feat(scan) adds logs to fujitsu scanner

### DIFF
--- a/libs/logging/src/log_event_ids.ts
+++ b/libs/logging/src/log_event_ids.ts
@@ -88,6 +88,11 @@ export enum LogEventId {
   ScanAdjudicationInfo = 'scan-adjudication-info',
   ScannerConfigReloaded = 'scanner-config-reloaded',
   ExportLogFileFound = 'export-log-file-found',
+  ScanServiceConfigurationMessage = 'scan-service-config',
+  FujitsuScanInit = 'fujitsu-scan-init',
+  FujitsuScanImageScanned = 'fujitsu-scan-sheet-scanned',
+  FujitsuScanBatchComplete = 'fujitsu-scan-batch-complete',
+  FujitsuScanMessage = 'fujitsu-scan-message',
 }
 
 export interface LogDetails {
@@ -556,6 +561,38 @@ const ExportLogFileFound: LogDetails = {
     'When the user is exporting logs, indicates the success/failure of finding the expected log file on the machine.',
 };
 
+const ScanServiceConfigurationMessage: LogDetails = {
+  eventId: LogEventId.ScanServiceConfigurationMessage,
+  eventType: LogEventType.ApplicationStatus,
+  documentationMessage:
+    'Message from the scanning service about how it is configured while starting up.',
+};
+
+const FujitsuScanInit: LogDetails = {
+  eventId: LogEventId.FujitsuScanInit,
+  eventType: LogEventType.ApplicationAction,
+  documentationMessage:
+    'Application is initiating a new scanning batch on the fujitsu scanner.',
+};
+const FujitsuScanImageScanned: LogDetails = {
+  eventId: LogEventId.FujitsuScanImageScanned,
+  eventType: LogEventType.ApplicationStatus,
+  documentationMessage:
+    'A scanned image has returned while scanning from a fujitsu scanner, or an error was seen while scanning. Success or failure indicated by disposition.',
+};
+const FujitsuScanBatchComplete: LogDetails = {
+  eventId: LogEventId.FujitsuScanBatchComplete,
+  eventType: LogEventType.ApplicationStatus,
+  documentationMessage:
+    'A batch of sheets has completed scanning on the fujitsu scanner.',
+};
+const FujitsuScanMessage: LogDetails = {
+  eventId: LogEventId.FujitsuScanMessage,
+  eventType: LogEventType.ApplicationStatus,
+  documentationMessage:
+    'Message from the driver handling the fujitsu scanner regarding scanning progress.',
+};
+
 export function getDetailsForEventId(eventId: LogEventId): LogDetails {
   switch (eventId) {
     case LogEventId.ElectionConfigured:
@@ -696,6 +733,16 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return ScannerConfigReloaded;
     case LogEventId.ExportLogFileFound:
       return ExportLogFileFound;
+    case LogEventId.ScanServiceConfigurationMessage:
+      return ScanServiceConfigurationMessage;
+    case LogEventId.FujitsuScanInit:
+      return FujitsuScanInit;
+    case LogEventId.FujitsuScanMessage:
+      return FujitsuScanMessage;
+    case LogEventId.FujitsuScanImageScanned:
+      return FujitsuScanImageScanned;
+    case LogEventId.FujitsuScanBatchComplete:
+      return FujitsuScanBatchComplete;
     /* istanbul ignore next - compile time check for completeness */
     default:
       throwIllegalValue(eventId);

--- a/libs/logging/src/logger.ts
+++ b/libs/logging/src/logger.ts
@@ -26,7 +26,8 @@ export class Logger {
   async log(
     eventId: LogEventId,
     user: LoggingUserRole,
-    logData: LogData = {}
+    logData: LogData = {},
+    outerDebug?: debug.Debugger
   ): Promise<void> {
     const eventSpecificDetails = getDetailsForEventId(eventId);
     const {
@@ -43,6 +44,14 @@ export class Logger {
       disposition,
       ...additionalData,
     };
+    // If the caller is passing in a debug instance, and we are not in production log to the debugger rather then through the normal logging pipeline.
+    // This is to make logs more manageable in development, so a developer can toggle what logs to view with the normal debug namespaces.
+    /* istanbul ignore next - figure out how to test this */
+    if (outerDebug && process.env.NODE_ENV !== 'production') {
+      outerDebug(logLine);
+      return;
+    }
+
     if (CLIENT_SIDE_LOG_SOURCES.includes(this.source)) {
       debug(logLine); // for internal debugging use log to the console
       if (this.kiosk) {

--- a/services/scan/src/scanners/fujitsu.test.ts
+++ b/services/scan/src/scanners/fujitsu.test.ts
@@ -1,3 +1,4 @@
+import { Logger, LogSource } from '@votingworks/logging';
 import { BallotPaperSize } from '@votingworks/types';
 import { ScannerStatus } from '@votingworks/types/api/services/scan';
 import { ChildProcess } from 'child_process';
@@ -13,7 +14,9 @@ const exec = (streamExecFile as unknown) as jest.MockedFunction<
 
 test('fujitsu scanner calls scanimage with fujitsu device type', async () => {
   const scanimage = makeMockChildProcess();
-  const scanner = new FujitsuScanner();
+  const scanner = new FujitsuScanner({
+    logger: new Logger(LogSource.VxScanService),
+  });
 
   exec.mockReturnValueOnce(scanimage);
   const sheets = scanner.scanSheets();
@@ -43,7 +46,9 @@ test('fujitsu scanner calls scanimage with fujitsu device type', async () => {
 
 test('fujitsu scanner can scan with letter size', async () => {
   const scanimage = makeMockChildProcess();
-  const scanner = new FujitsuScanner();
+  const scanner = new FujitsuScanner({
+    logger: new Logger(LogSource.VxScanService),
+  });
 
   exec.mockReturnValueOnce(scanimage);
   scanner.scanSheets({ pageSize: BallotPaperSize.Letter });
@@ -64,7 +69,9 @@ test('fujitsu scanner can scan with letter size', async () => {
 
 test('fujitsu scanner can scan with legal size', async () => {
   const scanimage = makeMockChildProcess();
-  const scanner = new FujitsuScanner();
+  const scanner = new FujitsuScanner({
+    logger: new Logger(LogSource.VxScanService),
+  });
 
   exec.mockReturnValueOnce(scanimage);
   scanner.scanSheets({ pageSize: BallotPaperSize.Legal });
@@ -85,7 +92,9 @@ test('fujitsu scanner can scan with legal size', async () => {
 
 test('fujitsu scanner does not specify a mode by default', async () => {
   const scanimage = makeMockChildProcess();
-  const scanner = new FujitsuScanner();
+  const scanner = new FujitsuScanner({
+    logger: new Logger(LogSource.VxScanService),
+  });
 
   exec.mockReturnValueOnce(scanimage);
   scanner.scanSheets();
@@ -106,7 +115,10 @@ test('fujitsu scanner does not specify a mode by default', async () => {
 
 test('fujitsu scanner can scan with lineart mode', async () => {
   const scanimage = makeMockChildProcess();
-  const scanner = new FujitsuScanner({ mode: ScannerMode.Lineart });
+  const scanner = new FujitsuScanner({
+    logger: new Logger(LogSource.VxScanService),
+    mode: ScannerMode.Lineart,
+  });
 
   exec.mockReturnValueOnce(scanimage);
   scanner.scanSheets();
@@ -127,7 +139,10 @@ test('fujitsu scanner can scan with lineart mode', async () => {
 
 test('fujitsu scanner can scan with gray mode', async () => {
   const scanimage = makeMockChildProcess();
-  const scanner = new FujitsuScanner({ mode: ScannerMode.Gray });
+  const scanner = new FujitsuScanner({
+    logger: new Logger(LogSource.VxScanService),
+    mode: ScannerMode.Gray,
+  });
 
   exec.mockReturnValueOnce(scanimage);
   scanner.scanSheets();
@@ -148,7 +163,10 @@ test('fujitsu scanner can scan with gray mode', async () => {
 
 test('fujitsu scanner can scan with color mode', async () => {
   const scanimage = makeMockChildProcess();
-  const scanner = new FujitsuScanner({ mode: ScannerMode.Color });
+  const scanner = new FujitsuScanner({
+    logger: new Logger(LogSource.VxScanService),
+    mode: ScannerMode.Color,
+  });
 
   exec.mockReturnValueOnce(scanimage);
   scanner.scanSheets();
@@ -169,7 +187,9 @@ test('fujitsu scanner can scan with color mode', async () => {
 
 test('fujitsu scanner requests two images at a time from scanimage', async () => {
   const scanimage = makeMockChildProcess();
-  const scanner = new FujitsuScanner();
+  const scanner = new FujitsuScanner({
+    logger: new Logger(LogSource.VxScanService),
+  });
 
   exec.mockReturnValueOnce(scanimage);
   const sheets = scanner.scanSheets();
@@ -203,8 +223,9 @@ test('fujitsu scanner requests two images at a time from scanimage', async () =>
 
 test('fujitsu scanner ends the scanimage process on generator return', async () => {
   const scanimage = makeMockChildProcess();
-  const scanner = new FujitsuScanner();
-
+  const scanner = new FujitsuScanner({
+    logger: new Logger(LogSource.VxScanService),
+  });
   exec.mockReturnValueOnce(scanimage);
   const sheets = scanner.scanSheets();
 
@@ -223,8 +244,9 @@ test('fujitsu scanner ends the scanimage process on generator return', async () 
 test('fujitsu scanner fails if scanSheet fails', async () => {
   const scanimage = makeMockChildProcess();
   exec.mockReturnValueOnce(scanimage);
-
-  const scanner = new FujitsuScanner();
+  const scanner = new FujitsuScanner({
+    logger: new Logger(LogSource.VxScanService),
+  });
   const sheets = scanner.scanSheets();
 
   scanimage.emit('exit', 1, null);
@@ -232,14 +254,17 @@ test('fujitsu scanner fails if scanSheet fails', async () => {
 });
 
 test('fujitsu scanner status is always unknown', async () => {
-  const scanner = new FujitsuScanner();
+  const scanner = new FujitsuScanner({
+    logger: new Logger(LogSource.VxScanService),
+  });
   expect(await scanner.getStatus()).toEqual(ScannerStatus.Unknown);
 });
 
 test('fujitsu scanner accept/reject/review are no-ops', async () => {
   const scanimage = makeMockChildProcess();
-  const scanner = new FujitsuScanner();
-
+  const scanner = new FujitsuScanner({
+    logger: new Logger(LogSource.VxScanService),
+  });
   exec.mockReturnValueOnce(scanimage);
   const sheets = scanner.scanSheets();
 
@@ -249,6 +274,8 @@ test('fujitsu scanner accept/reject/review are no-ops', async () => {
 });
 
 test('fujitsu scanner calibrate is a no-op', async () => {
-  const scanner = new FujitsuScanner();
+  const scanner = new FujitsuScanner({
+    logger: new Logger(LogSource.VxScanService),
+  });
   expect(await scanner.calibrate()).toEqual(false);
 });

--- a/services/scan/src/scanners/fujitsu.ts
+++ b/services/scan/src/scanners/fujitsu.ts
@@ -5,6 +5,7 @@ import makeDebug from 'debug';
 import { join } from 'path';
 import { dirSync } from 'tmp';
 import { BallotPaperSize } from '@votingworks/types';
+import { LogEventId, Logger } from '@votingworks/logging';
 import {
   BatchControl,
   Scanner,
@@ -21,6 +22,7 @@ const debug = makeDebug('scan:scanner');
 export interface Options {
   format?: ScannerImageFormat;
   mode?: ScannerMode;
+  logger: Logger;
 }
 
 function zeroPad(number: number, maxLength = 2): string {
@@ -41,10 +43,12 @@ function dateStamp(date: Date = new Date()): string {
 export class FujitsuScanner implements Scanner {
   private readonly format: ScannerImageFormat;
   private readonly mode?: ScannerMode;
+  private readonly logger: Logger;
 
-  constructor({ format = ScannerImageFormat.JPEG, mode }: Options = {}) {
+  constructor({ format = ScannerImageFormat.JPEG, logger, mode }: Options) {
     this.format = format;
     this.mode = mode;
+    this.logger = logger;
   }
 
   async getStatus(): Promise<ScannerStatus> {
@@ -83,11 +87,15 @@ export class FujitsuScanner implements Scanner {
       args.push('--mode', this.mode);
     }
 
-    debug(
-      'Calling scanimage to scan into %s in format %s; %s',
-      directory,
-      this.format,
-      `scanimage ${args.map((arg) => `'${arg}'`).join(' ')}`
+    void this.logger.log(
+      LogEventId.FujitsuScanInit,
+      'system',
+      {
+        message: `Calling scanimage to scan into ${directory} in format ${
+          this.format
+        }; scanimage ${args.map((arg) => `'${arg}'`).join(' ')}`,
+      },
+      debug
     );
 
     const scannedFiles: string[] = [];
@@ -95,15 +103,26 @@ export class FujitsuScanner implements Scanner {
     let done = false;
     const scanimage = streamExecFile('scanimage', args);
 
-    debug('scanimage [pid=%d] started', scanimage.pid);
+    void this.logger.log(
+      LogEventId.FujitsuScanInit,
+      'system',
+      {
+        message: `'scanimage [pid=${scanimage.pid}] started'`,
+      },
+      debug
+    );
 
     assert(scanimage.stdout);
     new StreamLines(scanimage.stdout).on('line', (line: string) => {
       const path = line.trim();
-      debug(
-        'scanimage [pid=%d] reported a scanned file: %s',
-        scanimage.pid,
-        path
+      void this.logger.log(
+        LogEventId.FujitsuScanImageScanned,
+        'system',
+        {
+          message: `scanimage [pid=${scanimage.pid}] reported a scanned file: ${path}`,
+          disposition: 'success',
+        },
+        debug
       );
 
       scannedFiles.push(path);
@@ -116,15 +135,39 @@ export class FujitsuScanner implements Scanner {
 
     assert(scanimage.stderr);
     new StreamLines(scanimage.stderr).on('line', (line: string) => {
-      debug('scanimage [pid=%d] stderr: %s', scanimage.pid, line.trim());
+      void this.logger.log(
+        LogEventId.FujitsuScanMessage,
+        'system',
+        {
+          message: `scanimage [pid=${scanimage.pid}] msg: ${line.trim()}`,
+        },
+        debug
+      );
     });
 
     scanimage.once('exit', (code) => {
-      debug('scanimage [pid=%d] exited with code %d', scanimage.pid, code);
       done = true;
       if (code !== 0) {
+        void this.logger.log(
+          LogEventId.FujitsuScanBatchComplete,
+          'system',
+          {
+            message: `scanimage [pid=${scanimage.pid}] exited with code ${code}`,
+            disposition: 'failure',
+          },
+          debug
+        );
         results.rejectAll(new Error(`scanimage exited with code=${code}`));
       } else {
+        void this.logger.log(
+          LogEventId.FujitsuScanBatchComplete,
+          'system',
+          {
+            message: `scanimage [pid=${scanimage.pid}] exited with code 0`,
+            disposition: 'success',
+          },
+          debug
+        );
         results.resolveAll(Promise.resolve(undefined));
       }
     });
@@ -157,9 +200,14 @@ export class FujitsuScanner implements Scanner {
       endBatch: async (): Promise<void> => {
         if (!done) {
           done = true;
-          debug(
-            'scanimage [pid=%d] stopping scan by closing stdin',
-            scanimage.pid
+          void this.logger.log(
+            LogEventId.FujitsuScanBatchComplete,
+            'system',
+            {
+              message: `scanimage [pid=${scanimage.pid}] stopping scan by closing stdin`,
+              disposition: 'success',
+            },
+            debug
           );
           await new Promise<void>((resolve) => {
             scanimage.stdin?.end(() => {


### PR DESCRIPTION
Adds logs to the fujitsu scanner, @eventualbuddha curious to your thoughts on this approach of wrapping around the debug, I figured it would be super annoying to not be able to turn off these logs in module-scan, but they need to always print in production so this way in dev you can use the normal ways of controlling them with debug to turn on/off. 

Future work is to do a similar thing in the plustek class, and probably also other places of module-scan.