### PR TITLE
refactor(utils): bundle simple `assert`

### DIFF
--- a/libs/utils/src/Storage/kiosk_storage.ts
+++ b/libs/utils/src/Storage/kiosk_storage.ts
@@ -1,4 +1,4 @@
-import { strict as assert } from 'assert';
+import { assert } from '../assert';
 import { Storage } from '../types';
 
 /**

--- a/libs/utils/src/Storage/local_storage.ts
+++ b/libs/utils/src/Storage/local_storage.ts
@@ -1,4 +1,4 @@
-import { strict as assert } from 'assert';
+import { assert } from '../assert';
 import { Storage } from '../types';
 
 /**

--- a/libs/utils/src/assert.test.ts
+++ b/libs/utils/src/assert.test.ts
@@ -1,6 +1,20 @@
-import { throwIllegalValue } from './throw_illegal_value';
+import { assert, fail, throwIllegalValue } from './assert';
 
-test('enum example', () => {
+test('assert', () => {
+  assert(true);
+  expect(() => assert(false, 'message')).toThrow('message');
+
+  // compile-time test checking that `value`'s type is narrowed by TS
+  const value: unknown = 'value';
+  assert(typeof value === 'string');
+  expect(value.startsWith('v')).toBe(true);
+});
+
+test('fail', () => {
+  expect(() => fail('message')).toThrow('message');
+});
+
+test('throwIllegalValue enum example', () => {
   enum ABC {
     A,
     B,
@@ -19,7 +33,7 @@ test('enum example', () => {
   }
 });
 
-test('invalid example', () => {
+test('throwIllegalValue invalid example', () => {
   enum ABC {
     A,
     B,
@@ -39,7 +53,7 @@ test('invalid example', () => {
   }
 });
 
-test('display name', () => {
+test('throwIllegalValue display name', () => {
   type Thing = { type: 'car' } | { type: 'dog' } | { type: 'house' };
 
   const thing = { type: 'hotdog' } as unknown as Thing;

--- a/libs/utils/src/assert.ts
+++ b/libs/utils/src/assert.ts
@@ -1,4 +1,24 @@
 /**
+ * Asserts that `condition` is true. This function exists to avoid a polyfill
+ * for `assert` in the browser.
+ */
+export function assert(
+  condition: unknown,
+  message?: string
+): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+/**
+ * Fail with an optional error message.
+ */
+export function fail(message?: string): never {
+  throw new Error(message);
+}
+
+/**
  * Use as a compile-time check that the type of `value` has been narrowed to
  * `never`. This is primarily useful when handling cases of a discriminated
  * union or enum.

--- a/libs/utils/src/ballot_package.ts
+++ b/libs/utils/src/ballot_package.ts
@@ -1,4 +1,3 @@
-import { strict as assert } from 'assert';
 import {
   BallotStyle,
   Contest,
@@ -9,6 +8,7 @@ import {
 } from '@votingworks/types';
 import 'fast-text-encoding';
 import { Entry, fromBuffer, ZipFile } from 'yauzl';
+import { assert } from './assert';
 
 export interface BallotPackage {
   electionDefinition: ElectionDefinition;

--- a/libs/utils/src/compressed_tallies.test.ts
+++ b/libs/utils/src/compressed_tallies.test.ts
@@ -10,7 +10,6 @@ import {
   VotingMethod,
   writeInCandidate,
 } from '@votingworks/types';
-import { strict as assert } from 'assert';
 import {
   electionMultiPartyPrimaryWithDataFiles,
   electionSampleDefinition,
@@ -18,11 +17,15 @@ import {
 } from '@votingworks/fixtures';
 import { getZeroCompressedTally } from '@votingworks/test-utils';
 
-import { compressTally, readCompressedTally } from './compressed_tallies';
+import {
+  compressTally,
+  readCompressedTally,
+  getTallyIdentifier,
+} from './compressed_tallies';
 
 import { calculateTallyForCastVoteRecords } from './votes';
 import { find } from './find';
-import { getTallyIdentifier } from '.';
+import { assert } from './assert';
 
 describe('compressTally', () => {
   test('compressTally returns empty tally when no contest tallies provided', () => {

--- a/libs/utils/src/compressed_tallies.ts
+++ b/libs/utils/src/compressed_tallies.ts
@@ -12,9 +12,8 @@ import {
   PartyId,
   PrecinctId,
 } from '@votingworks/types';
-import { strict as assert } from 'assert';
 import { BallotCountDetails } from '.';
-import { throwIllegalValue } from './throw_illegal_value';
+import { throwIllegalValue, assert } from './assert';
 import { filterContestTalliesByPartyId } from './votes';
 
 const ALL_PRECINCTS = '__ALL_PRECINCTS';

--- a/libs/utils/src/filenames.ts
+++ b/libs/utils/src/filenames.ts
@@ -1,4 +1,3 @@
-import { strict as assert } from 'assert';
 import moment from 'moment';
 import {
   Election,
@@ -6,6 +5,7 @@ import {
   MachineId,
   maybeParse,
 } from '@votingworks/types';
+import { assert } from './assert';
 
 const SECTION_SEPARATOR = '__';
 const SUBSECTION_SEPARATOR = '_';

--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -1,4 +1,5 @@
 /* istanbul ignore file */
+export * from './assert';
 export * from './ballot_package';
 export * from './Card';
 export * from './compressed_tallies';
@@ -15,7 +16,6 @@ export * from './rotation';
 export * from './sleep';
 export * from './Storage';
 export * from './tallies';
-export * from './throw_illegal_value';
 export * from './types';
 export * from './votes';
 export * as usbstick from './usbstick';

--- a/libs/utils/src/tallies.test.ts
+++ b/libs/utils/src/tallies.test.ts
@@ -1,6 +1,6 @@
 import { electionSample } from '@votingworks/fixtures';
-import { strict as assert } from 'assert';
 import { ContestTally } from '@votingworks/types';
+import { assert } from './assert';
 import { tallyVotesByContest } from './votes';
 import { combineContestTallies } from './tallies';
 

--- a/libs/utils/src/tallies.ts
+++ b/libs/utils/src/tallies.ts
@@ -1,9 +1,9 @@
-import { strict as assert } from 'assert';
 import {
   ContestOptionTally,
   ContestTally,
   Dictionary,
 } from '@votingworks/types';
+import { assert } from './assert';
 
 export function combineContestTallies(
   firstTally: ContestTally,

--- a/libs/utils/src/usbstick.ts
+++ b/libs/utils/src/usbstick.ts
@@ -1,4 +1,4 @@
-import { strict as assert } from 'assert';
+import { assert } from './assert';
 import { sleep } from './sleep';
 
 export const FLUSH_IO_DELAY_MS = 10_000;

--- a/libs/utils/src/votes.test.ts
+++ b/libs/utils/src/votes.test.ts
@@ -23,7 +23,7 @@ import {
   writeInCandidate,
   YesNoContest,
 } from '@votingworks/types';
-import { strict as assert } from 'assert';
+import { assert } from './assert';
 import {
   calculateTallyForCastVoteRecords,
   filterTalliesByParty,

--- a/libs/utils/src/votes.ts
+++ b/libs/utils/src/votes.ts
@@ -29,7 +29,7 @@ import {
   unsafeParse,
   PartyIdSchema,
 } from '@votingworks/types';
-import { strict as assert } from 'assert';
+import { assert } from './assert';
 import { find } from './find';
 import { throwIllegalValue, typedAs } from '.';
 
@@ -110,7 +110,7 @@ export function buildVoteFromCvr({
 export function getContestVoteOptionsForYesNoContest(
   contest: YesNoContest
 ): readonly YesNoVoteId[] {
-  assert.equal(contest.type, 'yesno');
+  assert(contest.type === 'yesno');
   return ['yes', 'no'];
 }
 


### PR DESCRIPTION
Rather than relying on the NodeJS `assert` module or a polyfill in the browser, we can use this simple `assert` function to achieve the same effect. This removes one of the roadblocks toward using a non-webpack dev/build system, once I follow up with a refactor to to use this assert in the rest of the monorepo.

Refs #1314