### PR TITLE
feat(codemods): add `use_utils_assert` codemod

### DIFF
--- a/codemods/src/safe_parse_helpers.test.ts
+++ b/codemods/src/safe_parse_helpers.test.ts
@@ -1,8 +1,5 @@
-import { NodePath, parseSync, transformSync } from '@babel/core';
-import generate from '@babel/generator';
-import traverse from '@babel/traverse';
-import * as t from '@babel/types';
-import plugin, { addSpecifierToImport } from './safe_parse_helpers';
+import { transformSync } from '@babel/core';
+import plugin from './safe_parse_helpers';
 
 function check(input: string, output: string): void {
   expect(
@@ -102,63 +99,5 @@ test('ignores malformed ok call', () => {
   check(
     `safeParse(Parser, value).ok(arg);`,
     `safeParse(Parser, value).ok(arg);`
-  );
-});
-
-test('addSpecifierToImport without specifiers', () => {
-  const ast = parseSync(`import '@votingworks/types';`)!;
-
-  traverse(ast, {
-    ImportDeclaration(path: NodePath<t.ImportDeclaration>): void {
-      addSpecifierToImport(path, 'ok');
-    },
-  });
-
-  expect(generate(ast).code).toEqual(
-    `import { ok } from '@votingworks/types';`
-  );
-});
-
-test('addSpecifierToImport with existing specifiers can insert at the start', () => {
-  const ast = parseSync(`import { ok } from '@votingworks/types';`)!;
-
-  traverse(ast, {
-    ImportDeclaration(path: NodePath<t.ImportDeclaration>): void {
-      addSpecifierToImport(path, 'err');
-    },
-  });
-
-  expect(generate(ast).code).toEqual(
-    `import { err, ok } from '@votingworks/types';`
-  );
-});
-
-test('addSpecifierToImport with existing specifiers can insert at the end', () => {
-  const ast = parseSync(`import { err } from '@votingworks/types';`)!;
-
-  traverse(ast, {
-    ImportDeclaration(path: NodePath<t.ImportDeclaration>): void {
-      addSpecifierToImport(path, 'ok');
-    },
-  });
-
-  expect(generate(ast).code).toEqual(
-    `import { err, ok } from '@votingworks/types';`
-  );
-});
-
-test('addSpecifierToImport with existing specifiers can insert in the middle', () => {
-  const ast = parseSync(
-    `import { Election, Precinct } from '@votingworks/types';`
-  )!;
-
-  traverse(ast, {
-    ImportDeclaration(path: NodePath<t.ImportDeclaration>): void {
-      addSpecifierToImport(path, 'ok');
-    },
-  });
-
-  expect(generate(ast).code).toEqual(
-    `import { Election, ok, Precinct } from '@votingworks/types';`
   );
 });

--- a/codemods/src/safe_parse_helpers.ts
+++ b/codemods/src/safe_parse_helpers.ts
@@ -10,55 +10,7 @@
 import { PluginItem, NodePath } from '@babel/core';
 import * as t from '@babel/types';
 import assert from 'assert';
-
-/**
- * Adds a named import to an existing import declaration.
- *
- * @VisibleForTesting
- */
-export function addSpecifierToImport(
-  path: NodePath<t.ImportDeclaration>,
-  name: string
-): void {
-  const specifiers = path.get('specifiers');
-  const newSpecifier = t.importSpecifier(
-    t.identifier(name),
-    t.identifier(name)
-  );
-
-  if (specifiers.length === 0) {
-    path.replaceWith(
-      t.importDeclaration([newSpecifier], path.get('source').node)
-    );
-  } else {
-    let insertionIndex = 0;
-
-    for (const [i, specifier] of specifiers.entries()) {
-      switch (
-        specifier.node.local.name.localeCompare(name, undefined, {
-          sensitivity: 'base',
-        })
-      ) {
-        case 0:
-          return;
-
-        case -1:
-          insertionIndex = i + 1;
-          break;
-
-        default:
-          // nothing to do
-          break;
-      }
-    }
-
-    if (insertionIndex === 0) {
-      specifiers[0].insertBefore(newSpecifier);
-    } else {
-      specifiers[insertionIndex - 1].insertAfter(newSpecifier);
-    }
-  }
-}
+import { addSpecifierToImport } from './utils';
 
 export default (): PluginItem => {
   return {

--- a/codemods/src/use_utils_assert.test.ts
+++ b/codemods/src/use_utils_assert.test.ts
@@ -1,0 +1,146 @@
+import { transformSync } from '@babel/core';
+import plugin from './use_utils_assert';
+
+function check(input: string, output: string): void {
+  expect(
+    transformSync(input, {
+      plugins: [plugin],
+      parserOpts: { plugins: ['jsx', 'typescript'] },
+    })?.code
+  ).toEqual(output.trim());
+}
+
+test('handles default export', () => {
+  check(
+    `
+import assert from "assert";
+`,
+    `
+import { assert } from "@votingworks/utils";
+`
+  );
+});
+
+test('renames non-assert default export binding', () => {
+  check(
+    `
+import ok from "assert";
+ok(true);
+`,
+    `
+import { assert } from "@votingworks/utils";
+assert(true);
+`
+  );
+});
+
+test('ignores default export helpers', () => {
+  check(
+    `
+import assert from "assert";
+assert.ok(true);
+`,
+    `
+import assert from "assert";
+assert.ok(true);
+`
+  );
+});
+
+test('ignores non-ok named export helpers', () => {
+  check(
+    `
+import { strictEqual } from "assert";
+strictEqual(true, true);
+`,
+    `
+import { strictEqual } from "assert";
+strictEqual(true, true);
+`
+  );
+});
+
+test('ignores non-ok namespace export helpers', () => {
+  check(
+    `
+import { strict as assert } from "assert";
+assert.equal(true, true);
+`,
+    `
+import { strict as assert } from "assert";
+assert.equal(true, true);
+`
+  );
+});
+
+test('ignores namespace imports', () => {
+  check(
+    `
+import * as assert from "assert";
+assert;
+`,
+    `
+import * as assert from "assert";
+assert;
+`
+  );
+});
+
+test('handles ok named export helper', () => {
+  check(
+    `
+import { ok } from "assert";
+ok(true);
+`,
+    `
+import { assert } from "@votingworks/utils";
+assert(true);
+`
+  );
+});
+
+test('handles mix and match', () => {
+  check(
+    `
+import assert, { ok, strict } from "assert";
+assert(true);
+ok(true);
+strict(true);
+`,
+    `
+import { assert } from "@votingworks/utils";
+assert(true);
+assert(true);
+assert(true);
+`
+  );
+});
+
+test('ignores unused import specifiers', () => {
+  check(
+    `
+import { ok } from "assert";
+`,
+    `
+import { assert } from "@votingworks/utils";
+`
+  );
+});
+
+test('adds to an existing import', () => {
+  check(
+    `
+import { foo } from "@votingworks/utils";
+import assert, { ok, strict } from "assert";
+assert(true);
+ok(true);
+strict(true);
+`,
+    `
+import { assert, foo } from "@votingworks/utils";
+assert(true);
+assert(true);
+assert(true);
+`
+  );
+});

--- a/codemods/src/use_utils_assert.ts
+++ b/codemods/src/use_utils_assert.ts
@@ -1,0 +1,103 @@
+/**
+ * Changes imports of `assert` to use `@votingworks/utils` instead.
+ *
+ * ```ts
+ * // broken
+ * import assert from 'assert';
+ *
+ * // fixed
+ * import { assert } from '@votingworks/utils';
+ *
+ *
+ * // broken
+ * import { strict as assert } from 'assert';
+ *
+ * // fixed
+ * import { assert } from '@votingworks/utils';
+ *
+ *
+ * // broken
+ * import { ok } from 'assert';
+ *
+ * // fixed
+ * import { assert } from '@votingworks/utils';
+ * ```
+ *
+ * Run it like so:
+ *
+ * ```sh
+ * $ pnpx codemod -p codemods/src/use_utils_assert.ts --printer prettier frontends/ libs/ services/
+ * ```
+ */
+
+import { PluginItem, NodePath } from '@babel/core';
+import * as t from '@babel/types';
+import assert from 'assert';
+import { addSpecifierToImport } from './utils';
+
+export default (): PluginItem => {
+  return {
+    visitor: {
+      ImportDeclaration(path: NodePath<t.ImportDeclaration>): void {
+        if (path.get('source').node.value === 'assert') {
+          // skip imports that can't be fixed, i.e. use an assert helper like `strictEqual`
+          for (const specifier of path.get('specifiers')) {
+            const binding = path.scope.getBinding(specifier.node.local.name);
+            assert(binding);
+            for (const reference of binding.referencePaths) {
+              assert(reference.parentPath);
+              if (reference.parentPath.isMemberExpression()) {
+                return;
+              }
+            }
+
+            if (specifier.isImportSpecifier()) {
+              const imported = specifier.get('imported');
+              if (
+                imported.isIdentifier() &&
+                imported.node.name !== 'ok' &&
+                imported.node.name !== 'strict'
+              ) {
+                return;
+              }
+            } else if (!specifier.isImportDefaultSpecifier()) {
+              return;
+            }
+          }
+
+          // rename all imported bindings to `assert`
+          for (const specifier of path.get('specifiers')) {
+            path.scope.rename(specifier.node.local.name, 'assert');
+          }
+
+          /* istanbul ignore else */
+          assert(path.parentPath && path.parentPath.isProgram());
+          const existingImport = path.parentPath
+            .get('body')
+            .find(
+              (statement): statement is NodePath<t.ImportDeclaration> =>
+                statement.isImportDeclaration() &&
+                statement.get('source').node.value === '@votingworks/utils'
+            );
+          if (existingImport) {
+            addSpecifierToImport(existingImport, 'assert');
+            path.remove();
+          } else {
+            // replace the whole import since there's only really one form
+            path.replaceWith(
+              t.importDeclaration(
+                [
+                  t.importSpecifier(
+                    t.identifier('assert'),
+                    t.identifier('assert')
+                  ),
+                ],
+                t.stringLiteral('@votingworks/utils')
+              )
+            );
+          }
+        }
+      },
+    },
+  };
+};

--- a/codemods/src/utils.test.ts
+++ b/codemods/src/utils.test.ts
@@ -1,0 +1,63 @@
+import { NodePath, parseSync } from '@babel/core';
+import generate from '@babel/generator';
+import traverse from '@babel/traverse';
+import * as t from '@babel/types';
+import { addSpecifierToImport } from './utils';
+
+test('addSpecifierToImport without specifiers', () => {
+  const ast = parseSync(`import '@votingworks/types';`)!;
+
+  traverse(ast, {
+    ImportDeclaration(path: NodePath<t.ImportDeclaration>): void {
+      addSpecifierToImport(path, 'ok');
+    },
+  });
+
+  expect(generate(ast).code).toEqual(
+    `import { ok } from '@votingworks/types';`
+  );
+});
+
+test('addSpecifierToImport with existing specifiers can insert at the start', () => {
+  const ast = parseSync(`import { ok } from '@votingworks/types';`)!;
+
+  traverse(ast, {
+    ImportDeclaration(path: NodePath<t.ImportDeclaration>): void {
+      addSpecifierToImport(path, 'err');
+    },
+  });
+
+  expect(generate(ast).code).toEqual(
+    `import { err, ok } from '@votingworks/types';`
+  );
+});
+
+test('addSpecifierToImport with existing specifiers can insert at the end', () => {
+  const ast = parseSync(`import { err } from '@votingworks/types';`)!;
+
+  traverse(ast, {
+    ImportDeclaration(path: NodePath<t.ImportDeclaration>): void {
+      addSpecifierToImport(path, 'ok');
+    },
+  });
+
+  expect(generate(ast).code).toEqual(
+    `import { err, ok } from '@votingworks/types';`
+  );
+});
+
+test('addSpecifierToImport with existing specifiers can insert in the middle', () => {
+  const ast = parseSync(
+    `import { Election, Precinct } from '@votingworks/types';`
+  )!;
+
+  traverse(ast, {
+    ImportDeclaration(path: NodePath<t.ImportDeclaration>): void {
+      addSpecifierToImport(path, 'ok');
+    },
+  });
+
+  expect(generate(ast).code).toEqual(
+    `import { Election, ok, Precinct } from '@votingworks/types';`
+  );
+});

--- a/codemods/src/utils.ts
+++ b/codemods/src/utils.ts
@@ -1,0 +1,51 @@
+import { NodePath } from '@babel/core';
+import * as t from '@babel/types';
+
+/**
+ * Adds a named import to an existing import declaration.
+ *
+ * @VisibleForTesting
+ */
+export function addSpecifierToImport(
+  path: NodePath<t.ImportDeclaration>,
+  name: string
+): void {
+  const specifiers = path.get('specifiers');
+  const newSpecifier = t.importSpecifier(
+    t.identifier(name),
+    t.identifier(name)
+  );
+
+  if (specifiers.length === 0) {
+    path.replaceWith(
+      t.importDeclaration([newSpecifier], path.get('source').node)
+    );
+  } else {
+    let insertionIndex = 0;
+
+    for (const [i, specifier] of specifiers.entries()) {
+      switch (
+        specifier.node.local.name.localeCompare(name, undefined, {
+          sensitivity: 'base',
+        })
+      ) {
+        case 0:
+          return;
+
+        case -1:
+          insertionIndex = i + 1;
+          break;
+
+        default:
+          // nothing to do
+          break;
+      }
+    }
+
+    if (insertionIndex === 0) {
+      specifiers[0].insertBefore(newSpecifier);
+    } else {
+      specifiers[insertionIndex - 1].insertAfter(newSpecifier);
+    }
+  }
+}


### PR DESCRIPTION
Transforms uses of `assert` that can be converted automatically to use `@votingworks/utils` instead.

Refs #1314