### PR TITLE
feat(utils): add various cryptography tools

### DIFF
--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -38,13 +38,15 @@
   "dependencies": {
     "@types/node": "^12.20.11",
     "@votingworks/types": "workspace:*",
-    "base64-js": "^1.3.1",
+    "base64-js": "^1.5.1",
     "debug": "^4.3.2",
     "fast-text-encoding": "^1.0.2",
     "fetch-mock": "^9.11.0",
     "jest-fetch-mock": "^3.0.3",
+    "js-sha256": "^0.9.0",
     "luxon": "^1.27.0",
     "moment": "^2.29.1",
+    "pure-rand": "^5.0.0",
     "rxjs": "^6.6.6",
     "yauzl": "^2.10.0",
     "zod": "3.2.0"

--- a/libs/utils/src/crypto.test.ts
+++ b/libs/utils/src/crypto.test.ts
@@ -1,0 +1,123 @@
+import { Buffer } from 'buffer';
+import { createHash, randomBytes } from 'crypto';
+import fc from 'fast-check';
+import { RandomGenerator } from 'pure-rand';
+import { fromBase64, randomBase64, toBase64, sha256 } from '.';
+import { getRandomValues, randomGenerator } from './crypto';
+
+beforeEach(() => {
+  Object.assign(crypto, {
+    getRandomValues: undefined,
+    randomBytes: undefined,
+  });
+});
+
+function incrementingGenerator(seed: number, increment = 1): RandomGenerator {
+  let next = seed;
+
+  return {
+    next: () => {
+      return [next, incrementingGenerator(next + increment, increment)];
+    },
+
+    clone: () => {
+      return incrementingGenerator(next, increment);
+    },
+
+    min: () => {
+      return next;
+    },
+
+    max: () => {
+      return next + increment;
+    },
+
+    unsafeNext: () => {
+      next += increment;
+      return next;
+    },
+  };
+}
+
+test('crypto not available', () => {
+  Object.defineProperty(globalThis, 'crypto', { value: undefined });
+  expect(() => getRandomValues(new Uint8Array(1))).toThrowError(
+    'crypto not available'
+  );
+
+  Object.defineProperty(globalThis, 'crypto', { value: {} });
+  expect(() => getRandomValues(new Uint8Array(1))).toThrowError(
+    'crypto not available'
+  );
+});
+
+test('getRandomValues when crypto.getRandomValues available', () => {
+  crypto.getRandomValues = jest.fn((array) => array);
+  const array = new Uint8Array(1);
+  expect(getRandomValues(array)).toBe(array);
+  expect(crypto.getRandomValues).toHaveBeenCalled();
+});
+
+test('getRandomValues when crypto.randomBytes available', () => {
+  const crypto = globalThis.crypto as unknown as typeof import('crypto');
+  crypto.randomBytes = jest.fn((length) => Buffer.alloc(length).fill(9));
+  expect(getRandomValues(new Uint8Array(1))).toEqual(Uint8Array.of(9));
+  expect(crypto.randomBytes).toHaveBeenCalled();
+});
+
+test('getRandomValues with random generator', () => {
+  expect(getRandomValues(new Uint8Array(5), incrementingGenerator(0))).toEqual(
+    Uint8Array.of(0, 1, 2, 3, 4)
+  );
+});
+
+test('randomGenerator', () => {
+  (crypto as unknown as typeof import('crypto')).randomBytes = randomBytes;
+
+  const generator = randomGenerator();
+  const [value, nextGenerator] = generator.next();
+  expect(value).toBeGreaterThanOrEqual(0);
+  expect(value).toBeLessThanOrEqual(255);
+  expect(nextGenerator).toBeDefined();
+
+  expect(generator.clone()).toBe(generator);
+  expect(generator.min()).toBe(0);
+  expect(generator.max()).toBe(255);
+  expect(generator.next()).toEqual(generator.next());
+
+  expect(typeof generator.unsafeNext()).toBe('number');
+  expect(generator.next()).toEqual(generator.next());
+});
+
+test('randomBase64', () => {
+  (crypto as unknown as typeof import('crypto')).randomBytes = randomBytes;
+
+  fc.assert(
+    fc.property(fc.integer({ min: 1, max: 300 }), (bytes) => {
+      const generator = incrementingGenerator(0);
+      expect(randomBase64(bytes, generator)).toEqual(
+        randomBase64(bytes, generator)
+      );
+    })
+  );
+});
+
+test('toBase64/fromBase64', () => {
+  fc.assert(
+    fc.property(fc.base64String(), (base64) => {
+      expect(fromBase64(toBase64(fromBase64(base64)))).toEqual(
+        fromBase64(base64)
+      );
+    })
+  );
+});
+
+test('sha256', () => {
+  fc.assert(
+    fc.property(fc.string(), (string) => {
+      expect(sha256(string)).toEqual(
+        createHash('sha256').update(string).digest('hex')
+      );
+    })
+  );
+});

--- a/libs/utils/src/crypto.ts
+++ b/libs/utils/src/crypto.ts
@@ -1,0 +1,106 @@
+import {
+  fromByteArray as toBase64,
+  toByteArray as fromBase64,
+} from 'base64-js';
+import { sha256 } from 'js-sha256';
+import { RandomGenerator } from 'pure-rand';
+import { assert } from './assert';
+
+export { sha256, toBase64, fromBase64 };
+
+/**
+ * Get random values to fill a typed array. Modifies the array in place. Uses
+ * crypto from the host environment if available.
+ */
+function getRandomValuesInternal(array: Uint8Array): Uint8Array {
+  if (typeof crypto === 'undefined') {
+    throw new Error('crypto not available');
+  }
+
+  if (typeof crypto.getRandomValues === 'function') {
+    return crypto.getRandomValues(array);
+  }
+
+  const { randomBytes } = crypto as unknown as {
+    randomBytes: typeof import('crypto').randomBytes;
+  };
+  if (typeof randomBytes === 'function') {
+    array.set(randomBytes(array.length));
+    return array;
+  }
+
+  throw new Error('crypto not available');
+}
+
+/**
+ * Gets a random byte value using the host environment's crypto.
+ */
+function randomByte(): number {
+  const bytes = new Uint8Array(1);
+  getRandomValuesInternal(bytes);
+  const byte = bytes[0];
+  assert(typeof byte === 'number');
+  return byte;
+}
+
+/**
+ * Builds a random number generator that returns both a value and the next
+ * random number generator in the sequence.
+ */
+export function randomGenerator(): RandomGenerator {
+  let byte = randomByte();
+  let nextGenerator: RandomGenerator | undefined;
+
+  const result: RandomGenerator = {
+    next: () => {
+      assert(typeof byte === 'number');
+      nextGenerator ??= randomGenerator();
+      return [byte, nextGenerator];
+    },
+
+    clone: () => {
+      return result;
+    },
+
+    min: () => {
+      return 0;
+    },
+
+    max: () => {
+      return 255;
+    },
+
+    unsafeNext: () => {
+      [byte, nextGenerator] = result.next();
+      return byte;
+    },
+  };
+
+  return result;
+}
+
+/**
+ * Get random values to fill a typed array. Modifies the array in place.
+ * Optionally takes a random number generator to possibly make it deterministic.
+ */
+export function getRandomValues(
+  array: Uint8Array,
+  gen = randomGenerator()
+): Uint8Array {
+  let nextByte = 0;
+  let nextGen = gen;
+  for (let i = 0; i < array.length; i += 1) {
+    [nextByte, nextGen] = nextGen.next();
+    array.set([nextByte], i);
+  }
+  return array;
+}
+
+/**
+ * Get random base64 string with `numBytes` bytes. Optionally takes a random
+ * number generator to possibly make it deterministic.
+ */
+export function randomBase64(numBytes: number, gen?: RandomGenerator): string {
+  const array = new Uint8Array(numBytes);
+  return toBase64(getRandomValues(array, gen)).replace(/=+$/, '');
+}

--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -3,6 +3,7 @@ export * from './assert';
 export * from './ballot_package';
 export * from './Card';
 export * from './compressed_tallies';
+export * from './crypto';
 export * from './date';
 export * from './deferred';
 export * from './find';

--- a/libs/utils/src/setupTests.ts
+++ b/libs/utils/src/setupTests.ts
@@ -7,6 +7,11 @@ beforeEach(() => {
   jestFetchMock.enableMocks();
   fetchMock.reset();
   fetchMock.mock();
+
+  globalThis.crypto = {
+    getRandomValues: jest.fn(),
+    randomBytes: jest.fn(),
+  } as unknown as Crypto;
 });
 
 globalThis.clearImmediate = clearImmediate;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,7 +194,7 @@ importers:
       dompurify: 2.2.6
       fetch-mock: 9.11.0
       history: 4.10.1
-      http-proxy-middleware: 1.0.6
+      http-proxy-middleware: 1.0.6_debug@4.3.2
       lodash.camelcase: 4.3.0
       luxon: 1.26.0
       mockdate: 3.0.2
@@ -542,7 +542,7 @@ importers:
       dompurify: 2.2.6
       fetch-mock: 9.11.0
       history: 4.10.1
-      http-proxy-middleware: 1.0.6
+      http-proxy-middleware: 1.0.6_debug@4.3.2
       i18next: 19.8.4
       js-file-download: 0.4.12
       js-sha256: 0.9.0
@@ -725,7 +725,7 @@ importers:
       base64-js: 1.5.1
       debug: 4.3.1
       fetch-mock: 9.11.0
-      http-proxy-middleware: 1.0.6
+      http-proxy-middleware: 1.0.6_debug@4.3.1
       i18next: 19.8.4
       jest-fetch-mock: 3.0.3
       js-file-download: 0.4.12
@@ -1785,8 +1785,10 @@ importers:
       fast-text-encoding: 1.0.3
       fetch-mock: 9.11.0
       jest-fetch-mock: 3.0.3
+      js-sha256: 0.9.0
       luxon: 1.27.0
       moment: 2.29.1
+      pure-rand: 5.0.0
       rxjs: 6.6.6
       yauzl: 2.10.0
       zod: 3.2.0
@@ -1829,7 +1831,7 @@ importers:
       '@votingworks/fixtures': workspace:*
       '@votingworks/test-utils': workspace:*
       '@votingworks/types': workspace:*
-      base64-js: ^1.3.1
+      base64-js: ^1.5.1
       debug: ^4.3.2
       eslint: ^7.26.0
       eslint-config-prettier: ^8.3.0
@@ -1844,10 +1846,12 @@ importers:
       jest: ^27.3.1
       jest-fetch-mock: ^3.0.3
       jest-watch-typeahead: ^0.6.4
+      js-sha256: ^0.9.0
       lint-staged: ^11.0.0
       luxon: ^1.27.0
       moment: ^2.29.1
       prettier: ^2.3.0
+      pure-rand: ^5.0.0
       rxjs: ^6.6.6
       sort-package-json: ^1.50.0
       ts-jest: ^27.0.7
@@ -5423,7 +5427,7 @@ packages:
       jest-regex-util: 27.0.6
       jest-resolve: 27.3.1
       jest-resolve-dependencies: 27.3.1
-      jest-runner: 27.3.1
+      jest-runner: 27.3.1_canvas@2.6.1
       jest-runtime: 27.3.1
       jest-snapshot: 27.3.1
       jest-util: 27.3.1
@@ -5464,7 +5468,7 @@ packages:
       jest-regex-util: 27.0.6
       jest-resolve: 27.3.1
       jest-resolve-dependencies: 27.3.1
-      jest-runner: 27.3.1
+      jest-runner: 27.3.1_canvas@2.6.1
       jest-runtime: 27.3.1
       jest-snapshot: 27.3.1
       jest-util: 27.3.1
@@ -9546,7 +9550,7 @@ packages:
       integrity: sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA==
   /axios/0.21.1_debug@4.3.1:
     dependencies:
-      follow-redirects: 1.14.1_debug@4.3.2
+      follow-redirects: 1.14.1_debug@4.3.1
     dev: true
     peerDependencies:
       debug: '*'
@@ -15552,7 +15556,6 @@ packages:
   /follow-redirects/1.14.1_debug@4.3.1:
     dependencies:
       debug: 4.3.1
-    dev: false
     engines:
       node: '>=4.0'
     peerDependencies:
@@ -15564,7 +15567,8 @@ packages:
       integrity: sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
   /follow-redirects/1.14.1_debug@4.3.2:
     dependencies:
-      debug: 4.3.2_supports-color@6.1.0
+      debug: 4.3.2
+    dev: false
     engines:
       node: '>=4.0'
     peerDependencies:
@@ -16483,6 +16487,34 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
+  /http-proxy-middleware/1.0.6_debug@4.3.1:
+    dependencies:
+      '@types/http-proxy': 1.17.6
+      http-proxy: 1.18.1_debug@4.3.1
+      is-glob: 4.0.1
+      lodash: 4.17.21
+      micromatch: 4.0.4
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    peerDependencies:
+      debug: '*'
+    resolution:
+      integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
+  /http-proxy-middleware/1.0.6_debug@4.3.2:
+    dependencies:
+      '@types/http-proxy': 1.17.6
+      http-proxy: 1.18.1_debug@4.3.2
+      is-glob: 4.0.1
+      lodash: 4.17.21
+      micromatch: 4.0.4
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    peerDependencies:
+      debug: '*'
+    resolution:
+      integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
   /http-proxy/1.18.1:
     dependencies:
       eventemitter3: 4.0.7
@@ -16491,6 +16523,18 @@ packages:
     dev: false
     engines:
       node: '>=8.0.0'
+    resolution:
+      integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
+  /http-proxy/1.18.1_debug@4.3.1:
+    dependencies:
+      eventemitter3: 4.0.7
+      follow-redirects: 1.14.1_debug@4.3.1
+      requires-port: 1.0.0
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    peerDependencies:
+      debug: '*'
     resolution:
       integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
   /http-proxy/1.18.1_debug@4.3.2:
@@ -17839,7 +17883,7 @@ packages:
       jest-jasmine2: 27.3.1
       jest-regex-util: 27.0.6
       jest-resolve: 27.3.1
-      jest-runner: 27.3.1
+      jest-runner: 27.3.1_canvas@2.6.1
       jest-util: 27.3.1
       jest-validate: 27.3.1
       micromatch: 4.0.4
@@ -17873,7 +17917,7 @@ packages:
       jest-jasmine2: 27.3.1
       jest-regex-util: 27.0.6
       jest-resolve: 27.3.1
-      jest-runner: 27.3.1
+      jest-runner: 27.3.1_canvas@2.6.1
       jest-util: 27.3.1
       jest-validate: 27.3.1
       micromatch: 4.0.4
@@ -18884,6 +18928,37 @@ packages:
     dev: true
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
+    resolution:
+      integrity: sha512-r4W6kBn6sPr3TBwQNmqE94mPlYVn7fLBseeJfo4E2uCTmAyDFm2O5DYAQAFP7Q3YfiA/bMwg8TVsciP7k0xOww==
+  /jest-runner/27.3.1_canvas@2.6.1:
+    dependencies:
+      '@jest/console': 27.3.1
+      '@jest/environment': 27.3.1
+      '@jest/test-result': 27.3.1
+      '@jest/transform': 27.3.1
+      '@jest/types': 27.2.5
+      '@types/node': 15.3.0
+      chalk: 4.1.2
+      emittery: 0.8.1
+      exit: 0.1.2
+      graceful-fs: 4.2.4
+      jest-docblock: 27.0.6
+      jest-environment-jsdom: 27.3.1_canvas@2.6.1
+      jest-environment-node: 27.3.1
+      jest-haste-map: 27.3.1
+      jest-leak-detector: 27.3.1
+      jest-message-util: 27.3.1
+      jest-resolve: 27.3.1
+      jest-runtime: 27.3.1
+      jest-util: 27.3.1
+      jest-worker: 27.3.1
+      source-map-support: 0.5.20
+      throat: 6.0.1
+    dev: true
+    engines:
+      node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
+    peerDependencies:
+      canvas: '*'
     resolution:
       integrity: sha512-r4W6kBn6sPr3TBwQNmqE94mPlYVn7fLBseeJfo4E2uCTmAyDFm2O5DYAQAFP7Q3YfiA/bMwg8TVsciP7k0xOww==
   /jest-runner/27.4.5:


### PR DESCRIPTION
Some stuff runs in node and some in the browser, making supporting both a bit annoying and requiring polyfills when we import e.g. `crypto` in the browser. This consolidates SHA256, base64, and seeded/unseeded random number generation in one place.

Because this touches random/crypto stuff in a non-trivial way I'd like to have an approval from @benadida or @umbernhard on that part of it. Anyone else can review for general coding correctness.