### PR TITLE
feat(eslint-plugin-vx): upgrade `@typescript-eslint/*` deps

### DIFF
--- a/libs/eslint-plugin-vx/package.json
+++ b/libs/eslint-plugin-vx/package.json
@@ -23,8 +23,8 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^4.30.0",
-    "@typescript-eslint/experimental-utils": "^4.30.0",
+    "@typescript-eslint/eslint-plugin": "^5.8.0",
+    "@typescript-eslint/experimental-utils": "^5.8.0",
     "comment-parser": "^1.2.4",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-airbnb-base": "^14.2.1",
@@ -39,7 +39,7 @@
     "@types/jest": "^27.0.3",
     "@types/node": "^15.6.2",
     "@types/react": "^17.0.20",
-    "@typescript-eslint/parser": "^4.26.0",
+    "@typescript-eslint/parser": "^5.8.0",
     "@votingworks/types": "workspace:*",
     "eslint": "^7.27.0",
     "eslint-config-prettier": "^8.3.0",

--- a/libs/eslint-plugin-vx/src/rules/gts_array_type_style.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_array_type_style.ts
@@ -11,7 +11,6 @@ export default createRule({
     docs: {
       description:
         'Recommends using short form T[] for simple array types (containing only alphanumeric characters and dots). Recommends using long form Array<T> for complex array types.',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: false,
       requiresTypeChecking: false,

--- a/libs/eslint-plugin-vx/src/rules/gts_constants.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_constants.ts
@@ -10,7 +10,6 @@ export default createRule({
   meta: {
     docs: {
       description: 'Enforces GTS JSDoc rules.',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: false,
       requiresTypeChecking: false,

--- a/libs/eslint-plugin-vx/src/rules/gts_direct_module_export_access_only.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_direct_module_export_access_only.ts
@@ -11,7 +11,6 @@ export default createRule({
     docs: {
       description:
         'Directly access module import properties rather than passing it around.',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: false,
       requiresTypeChecking: false,

--- a/libs/eslint-plugin-vx/src/rules/gts_func_style.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_func_style.ts
@@ -20,7 +20,6 @@ export default createRule({
     docs: {
       description:
         'Use `function foo() { ... }` to declare named functions, including functions in nested scopes, e.g. within another function.',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: false,
       requiresTypeChecking: false,

--- a/libs/eslint-plugin-vx/src/rules/gts_identifiers.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_identifiers.ts
@@ -25,7 +25,6 @@ export default createRule({
     docs: {
       description:
         'Disallows use of $ in identifiers, except when aligning with naming conventions for third party frameworks.',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: true,
       requiresTypeChecking: false,

--- a/libs/eslint-plugin-vx/src/rules/gts_jsdoc.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_jsdoc.ts
@@ -18,7 +18,6 @@ export default createRule({
   meta: {
     docs: {
       description: 'Enforces GTS JSDoc rules.',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: false,
       requiresTypeChecking: false,

--- a/libs/eslint-plugin-vx/src/rules/gts_module_snake_case.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_module_snake_case.ts
@@ -23,7 +23,6 @@ export default createRule({
   meta: {
     docs: {
       description: 'Requires the use of `snake_case` for module file names.',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: false,
       requiresTypeChecking: false,

--- a/libs/eslint-plugin-vx/src/rules/gts_no_array_constructor.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_no_array_constructor.ts
@@ -11,7 +11,6 @@ export default createRule({
   meta: {
     docs: {
       description: 'Disallows using the `Array` constructor.',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: false,
       requiresTypeChecking: false,

--- a/libs/eslint-plugin-vx/src/rules/gts_no_const_enum.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_no_const_enum.ts
@@ -7,7 +7,6 @@ export default createRule({
   meta: {
     docs: {
       description: 'Disallows use of `const enum`; use `enum` instead.',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: false,
       requiresTypeChecking: false,

--- a/libs/eslint-plugin-vx/src/rules/gts_no_default_exports.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_no_default_exports.ts
@@ -10,7 +10,6 @@ export default createRule({
   meta: {
     docs: {
       description: 'Disallows default exports',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: false,
       requiresTypeChecking: false,

--- a/libs/eslint-plugin-vx/src/rules/gts_no_for_in_loop.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_no_for_in_loop.ts
@@ -7,7 +7,6 @@ export default createRule({
   meta: {
     docs: {
       description: 'Disallows use of `for-in` loops',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: false,
       requiresTypeChecking: false,

--- a/libs/eslint-plugin-vx/src/rules/gts_no_foreach.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_no_foreach.ts
@@ -88,7 +88,6 @@ export default createRule({
     docs: {
       description:
         'Disallows use of `Array.prototype.forEach`, `Set.prototype.forEach`, and `Map.prototype.forEach`',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: false,
       requiresTypeChecking: true,

--- a/libs/eslint-plugin-vx/src/rules/gts_no_import_export_type.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_no_import_export_type.ts
@@ -10,7 +10,6 @@ export default createRule({
   meta: {
     docs: {
       description: 'Disallows use of `import type` and `export type`',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: false,
       requiresTypeChecking: false,

--- a/libs/eslint-plugin-vx/src/rules/gts_no_private_fields.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_no_private_fields.ts
@@ -1,9 +1,11 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import {
+  AST_NODE_TYPES,
+  TSESTree,
+} from '@typescript-eslint/experimental-utils';
 import { createRule } from '../util';
 
 function isPrivateIdentifier(node: TSESTree.Node): boolean {
-  // @ts-expect-error - typescript-eslint v5 will have support for TSPrivateIdentifier or PrivateIdentifier (https://github.com/typescript-eslint/typescript-eslint/issues/3430#issuecomment-907712769)
-  return node.type === 'TSPrivateIdentifier';
+  return node.type === AST_NODE_TYPES.PrivateIdentifier;
 }
 
 export default createRule({
@@ -11,7 +13,6 @@ export default createRule({
   meta: {
     docs: {
       description: 'Disallows use of private fields aka private identifiers',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: false,
       requiresTypeChecking: false,
@@ -26,7 +27,7 @@ export default createRule({
 
   create(context) {
     return {
-      ClassProperty(node: TSESTree.ClassProperty) {
+      PropertyDefinition(node: TSESTree.PropertyDefinition) {
         if (isPrivateIdentifier(node.key)) {
           context.report({
             node: node.key,

--- a/libs/eslint-plugin-vx/src/rules/gts_no_public_class_fields.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_no_public_class_fields.ts
@@ -6,7 +6,6 @@ export default createRule({
   meta: {
     docs: {
       description: 'Disallows public class fields.',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: false,
       requiresTypeChecking: false,
@@ -22,7 +21,7 @@ export default createRule({
 
   create(context) {
     function check(
-      node: TSESTree.ClassProperty | TSESTree.TSParameterProperty
+      node: TSESTree.PropertyDefinition | TSESTree.TSParameterProperty
     ): void {
       if (
         !node.static &&
@@ -36,7 +35,7 @@ export default createRule({
       }
     }
     return {
-      ClassProperty: check,
+      PropertyDefinition: check,
       TSParameterProperty: check,
     };
   },

--- a/libs/eslint-plugin-vx/src/rules/gts_no_public_modifier.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_no_public_modifier.ts
@@ -11,7 +11,6 @@ export default createRule({
     docs: {
       description:
         'Disallows use of `public` accessibility modifiers on class properties',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: false,
       requiresTypeChecking: false,
@@ -45,7 +44,7 @@ export default createRule({
     }
 
     function processNode(
-      node: TSESTree.ClassProperty | TSESTree.MethodDefinition
+      node: TSESTree.PropertyDefinition | TSESTree.MethodDefinition
     ): void {
       if (node.accessibility === 'public') {
         reportPublicToken(node);
@@ -69,7 +68,7 @@ export default createRule({
     }
 
     return {
-      ClassProperty: processNode,
+      PropertyDefinition: processNode,
       MethodDefinition: processNode,
     };
   },

--- a/libs/eslint-plugin-vx/src/rules/gts_no_return_type_only_generics.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_no_return_type_only_generics.ts
@@ -11,7 +11,6 @@ export default createRule({
     docs: {
       description:
         'Disallows generics in functions where the only use is in the return type',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: true,
       requiresTypeChecking: true,

--- a/libs/eslint-plugin-vx/src/rules/gts_no_unnecessary_has_own_property_check.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_no_unnecessary_has_own_property_check.ts
@@ -7,7 +7,6 @@ export default createRule({
     docs: {
       description:
         'Flags unnecessary `hasOwnProperty` checks inside `for-of` loops',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: false,
       requiresTypeChecking: false,

--- a/libs/eslint-plugin-vx/src/rules/gts_object_literal_types.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_object_literal_types.ts
@@ -11,7 +11,6 @@ export default createRule({
     docs: {
       description:
         'Requires type annotations instead of type assertions on object literals',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: true,
       requiresTypeChecking: false,

--- a/libs/eslint-plugin-vx/src/rules/gts_parameter_properties.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_parameter_properties.ts
@@ -41,7 +41,6 @@ export default createRule({
   meta: {
     docs: {
       description: 'Use parameter properties for concise class initializers',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: false,
       requiresTypeChecking: false,

--- a/libs/eslint-plugin-vx/src/rules/gts_safe_number_parse.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_safe_number_parse.ts
@@ -9,7 +9,6 @@ export default createRule({
   meta: {
     docs: {
       description: 'Requires using a safe number parser',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: false,
       requiresTypeChecking: false,

--- a/libs/eslint-plugin-vx/src/rules/gts_spread_like_types.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_spread_like_types.ts
@@ -35,7 +35,6 @@ export default createRule({
     docs: {
       description:
         'Requires spreading iterables in arrays and objects in objects',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: false,
       requiresTypeChecking: true,

--- a/libs/eslint-plugin-vx/src/rules/gts_type_parameters.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_type_parameters.ts
@@ -10,7 +10,6 @@ export default createRule({
   meta: {
     docs: {
       description: 'Requires type parameters be named appropriately.',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: false,
       requiresTypeChecking: false,

--- a/libs/eslint-plugin-vx/src/rules/gts_unicode_escapes.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_unicode_escapes.ts
@@ -15,7 +15,6 @@ export default createRule({
     docs: {
       description:
         'Requires the use of real Unicode characters when printable, escapes when non-printable.',
-      category: 'Best Practices',
       recommended: 'error',
       requiresTypeChecking: false,
     },

--- a/libs/eslint-plugin-vx/src/rules/gts_use_optionals.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_use_optionals.ts
@@ -47,7 +47,6 @@ export default createRule({
     docs: {
       description:
         'Use optional fields (on interfaces or classes) and parameters rather than a |undefined type.',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: false,
       requiresTypeChecking: false,
@@ -187,7 +186,7 @@ export default createRule({
     }
 
     return {
-      ClassProperty(node: TSESTree.ClassProperty): void {
+      PropertyDefinition(node: TSESTree.PropertyDefinition): void {
         const fix = node.typeAnnotation && getFixFunction(node.typeAnnotation);
         if (fix) {
           context.report({

--- a/libs/eslint-plugin-vx/src/rules/no_array_sort_mutation.ts
+++ b/libs/eslint-plugin-vx/src/rules/no_array_sort_mutation.ts
@@ -21,7 +21,6 @@ export default createRule({
   meta: {
     docs: {
       description: 'Requires `sort` be called on array copies',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: false,
       requiresTypeChecking: false,

--- a/libs/eslint-plugin-vx/src/rules/no_assert_truthiness.ts
+++ b/libs/eslint-plugin-vx/src/rules/no_assert_truthiness.ts
@@ -47,7 +47,6 @@ export default createRule({
     fixable: 'code',
     docs: {
       description: 'Forbids truthiness checks in `assert`',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: true,
       requiresTypeChecking: true,

--- a/libs/eslint-plugin-vx/src/rules/no_floating_results.ts
+++ b/libs/eslint-plugin-vx/src/rules/no_floating_results.ts
@@ -56,7 +56,6 @@ export default createRule({
   meta: {
     docs: {
       description: 'Requires `Result` values to be handled appropriately',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: true,
       requiresTypeChecking: true,

--- a/libs/eslint-plugin-vx/src/rules/no_import_workspace_subfolders.ts
+++ b/libs/eslint-plugin-vx/src/rules/no_import_workspace_subfolders.ts
@@ -10,7 +10,6 @@ export default createRule({
     docs: {
       description:
         'When importing libraries from the VotingWorks workspace, do not include subfolders like /src in the import',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: false,
       requiresTypeChecking: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1162,26 +1162,26 @@ importers:
       zod: 3.2.0
   libs/eslint-plugin-vx:
     dependencies:
-      '@typescript-eslint/eslint-plugin': 4.30.0_942c48837be95e76bb4156c78358cdbe
-      '@typescript-eslint/experimental-utils': 4.30.0_eslint@7.27.0+typescript@4.2.3
+      '@typescript-eslint/eslint-plugin': 5.8.0_258dbe902d5cad7bf407edc4ddffe106
+      '@typescript-eslint/experimental-utils': 5.8.0_eslint@7.32.0+typescript@4.2.3
       comment-parser: 1.2.4
-      eslint-config-airbnb: 18.2.1_74ade7420e0f78ce33d23941f9379dba
-      eslint-config-airbnb-base: 14.2.1_2bfbb5f9d15cdc8811f4d55173efe733
+      eslint-config-airbnb: 18.2.1_2f5861ee8b825437620ff8bf3831cd0a
+      eslint-config-airbnb-base: 14.2.1_b7a4de75e7d0094cbe979e30a9a325ab
       eslint-import-resolver-node: 0.3.6
-      eslint-plugin-cypress: 2.11.3_eslint@7.27.0
-      eslint-plugin-import: 2.24.2_eslint@7.27.0+typescript@4.2.3
-      eslint-plugin-jsx-a11y: 6.4.1_eslint@7.27.0
-      eslint-plugin-react: 7.24.0_eslint@7.27.0
+      eslint-plugin-cypress: 2.11.3_eslint@7.32.0
+      eslint-plugin-import: 2.24.2_eslint@7.32.0+typescript@4.2.3
+      eslint-plugin-jsx-a11y: 6.4.1_eslint@7.32.0
+      eslint-plugin-react: 7.24.0_eslint@7.32.0
       typescript: 4.2.3
     devDependencies:
       '@types/jest': 27.0.3
       '@types/node': 15.6.2
       '@types/react': 17.0.20
-      '@typescript-eslint/parser': 4.26.0_eslint@7.27.0+typescript@4.2.3
+      '@typescript-eslint/parser': 5.8.0_eslint@7.32.0+typescript@4.2.3
       '@votingworks/types': link:../types
-      eslint: 7.27.0
-      eslint-config-prettier: 8.3.0_eslint@7.27.0
-      eslint-plugin-prettier: 3.4.0_beb8ddd1fba5378f74976112c7860a07
+      eslint: 7.32.0
+      eslint-config-prettier: 8.3.0_eslint@7.32.0
+      eslint-plugin-prettier: 3.4.0_39707b7de4180b40645e0fe3095cfe49
       eslint-plugin-vx: 'link:'
       is-ci-cli: 2.2.0
       jest: 27.3.1
@@ -1194,9 +1194,9 @@ importers:
       '@types/jest': ^27.0.3
       '@types/node': ^15.6.2
       '@types/react': ^17.0.20
-      '@typescript-eslint/eslint-plugin': ^4.30.0
-      '@typescript-eslint/experimental-utils': ^4.30.0
-      '@typescript-eslint/parser': ^4.26.0
+      '@typescript-eslint/eslint-plugin': ^5.8.0
+      '@typescript-eslint/experimental-utils': ^5.8.0
+      '@typescript-eslint/parser': ^5.8.0
       '@votingworks/types': workspace:*
       comment-parser: ^1.2.4
       eslint: ^7.27.0
@@ -7697,30 +7697,6 @@ packages:
         optional: true
     resolution:
       integrity: sha512-NgAnqk55RQ/SD+tZFD9aPwNSeHmDHHe5rtUyhIq0ZeCWZEvo4DK9rYz7v9HDuQZFvn320Ot+AikaCKMFKLlD0g==
-  /@typescript-eslint/eslint-plugin/4.30.0_942c48837be95e76bb4156c78358cdbe:
-    dependencies:
-      '@typescript-eslint/experimental-utils': 4.30.0_eslint@7.27.0+typescript@4.2.3
-      '@typescript-eslint/parser': 4.26.0_eslint@7.27.0+typescript@4.2.3
-      '@typescript-eslint/scope-manager': 4.30.0
-      debug: 4.3.2
-      eslint: 7.27.0
-      functional-red-black-tree: 1.0.1
-      regexpp: 3.2.0
-      semver: 7.3.5
-      tsutils: 3.21.0_typescript@4.2.3
-      typescript: 4.2.3
-    dev: false
-    engines:
-      node: ^10.12.0 || >=12.0.0
-    peerDependencies:
-      '@typescript-eslint/parser': ^4.0.0
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    resolution:
-      integrity: sha512-NgAnqk55RQ/SD+tZFD9aPwNSeHmDHHe5rtUyhIq0ZeCWZEvo4DK9rYz7v9HDuQZFvn320Ot+AikaCKMFKLlD0g==
   /@typescript-eslint/eslint-plugin/4.33.0_3289a875d95a672b97ebf589745c66ef:
     dependencies:
       '@typescript-eslint/experimental-utils': 4.33.0_eslint@7.32.0+typescript@4.5.4
@@ -7770,6 +7746,31 @@ packages:
         optional: true
     resolution:
       integrity: sha512-ARUEJHJrq85aaiCqez7SANeahDsJTD3AEua34EoQN9pHS6S5Bq9emcIaGGySt/4X2zSi+vF5hAH52sEen7IO7g==
+  /@typescript-eslint/eslint-plugin/5.8.0_258dbe902d5cad7bf407edc4ddffe106:
+    dependencies:
+      '@typescript-eslint/experimental-utils': 5.8.0_eslint@7.32.0+typescript@4.2.3
+      '@typescript-eslint/parser': 5.8.0_eslint@7.32.0+typescript@4.2.3
+      '@typescript-eslint/scope-manager': 5.8.0
+      debug: 4.3.3
+      eslint: 7.32.0
+      functional-red-black-tree: 1.0.1
+      ignore: 5.2.0
+      regexpp: 3.2.0
+      semver: 7.3.5
+      tsutils: 3.21.0_typescript@4.2.3
+      typescript: 4.2.3
+    dev: false
+    engines:
+      node: ^12.22.0 || ^14.17.0 || >=16.0.0
+    peerDependencies:
+      '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    resolution:
+      integrity: sha512-spu1UW7QuBn0nJ6+psnfCc3iVoQAifjKORgBngKOmC8U/1tbe2YJMzYQqDGYB4JCss7L8+RM2kKLb1B1Aw9BNA==
   /@typescript-eslint/experimental-utils/2.34.0_eslint@7.17.0+typescript@4.3.5:
     dependencies:
       '@types/json-schema': 7.0.7
@@ -7984,23 +7985,6 @@ packages:
       typescript: '*'
     resolution:
       integrity: sha512-ffIvbytTVWz+3keg+Sy94FG1QeOvmV9dP2YSdLFHw/ieLXWCa3U1TYu8IRCOpMv2/SPS8XqhM1+ou1YHsdzKrg==
-  /@typescript-eslint/experimental-utils/4.30.0_eslint@7.27.0+typescript@4.2.3:
-    dependencies:
-      '@types/json-schema': 7.0.9
-      '@typescript-eslint/scope-manager': 4.30.0
-      '@typescript-eslint/types': 4.30.0
-      '@typescript-eslint/typescript-estree': 4.30.0_typescript@4.2.3
-      eslint: 7.27.0
-      eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@7.27.0
-    dev: false
-    engines:
-      node: ^10.12.0 || >=12.0.0
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    resolution:
-      integrity: sha512-K8RNIX9GnBsv5v4TjtwkKtqMSzYpjqAQg/oSphtxf3xxdt6T0owqnpojztjjTcatSteH3hLj3t/kklKx87NPqw==
   /@typescript-eslint/experimental-utils/4.30.0_eslint@7.29.0+typescript@4.3.5:
     dependencies:
       '@types/json-schema': 7.0.9
@@ -8050,6 +8034,23 @@ packages:
       typescript: '*'
     resolution:
       integrity: sha512-NFVxYTjKj69qB0FM+piah1x3G/63WB8vCBMnlnEHUsiLzXSTWb9FmFn36FD9Zb4APKBLY3xRArOGSMQkuzTF1w==
+  /@typescript-eslint/experimental-utils/5.8.0_eslint@7.32.0+typescript@4.2.3:
+    dependencies:
+      '@types/json-schema': 7.0.9
+      '@typescript-eslint/scope-manager': 5.8.0
+      '@typescript-eslint/types': 5.8.0
+      '@typescript-eslint/typescript-estree': 5.8.0_typescript@4.2.3
+      eslint: 7.32.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@7.32.0
+    dev: false
+    engines:
+      node: ^12.22.0 || ^14.17.0 || >=16.0.0
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    resolution:
+      integrity: sha512-KN5FvNH71bhZ8fKtL+lhW7bjm7cxs1nt+hrDZWIqb6ViCffQcWyLunGrgvISgkRojIDcXIsH+xlFfI4RCDA0xA==
   /@typescript-eslint/parser/4.13.0_eslint@7.17.0+typescript@4.3.5:
     dependencies:
       '@typescript-eslint/scope-manager': 4.13.0
@@ -8126,25 +8127,6 @@ packages:
         optional: true
     resolution:
       integrity: sha512-KO0J5SRF08pMXzq9+abyHnaGQgUJZ3Z3ax+pmqz9vl81JxmTTOUfQmq7/4awVfq09b6C4owNlOgOwp61pYRBSg==
-  /@typescript-eslint/parser/4.26.0_eslint@7.27.0+typescript@4.2.3:
-    dependencies:
-      '@typescript-eslint/scope-manager': 4.26.0
-      '@typescript-eslint/types': 4.26.0
-      '@typescript-eslint/typescript-estree': 4.26.0_typescript@4.2.3
-      debug: 4.3.1
-      eslint: 7.27.0
-      typescript: 4.2.3
-    dev: true
-    engines:
-      node: ^10.12.0 || >=12.0.0
-    peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    resolution:
-      integrity: sha512-b4jekVJG9FfmjUfmM4VoOItQhPlnt6MPOBUL0AQbiTmm+SSpSdhHYlwayOm4IW9KLI/4/cRKtQCmDl1oE2OlPg==
   /@typescript-eslint/parser/4.28.4_eslint@7.17.0+typescript@4.3.5:
     dependencies:
       '@typescript-eslint/scope-manager': 4.28.4
@@ -8316,25 +8298,6 @@ packages:
         optional: true
     resolution:
       integrity: sha512-jrHOV5g2u8ROghmspKoW7pN8T/qUzk0+DITun0MELptvngtMrwUJ1tv5zMI04CYVEUsSrN4jV7AKSv+I0y0EfQ==
-  /@typescript-eslint/parser/4.29.3_eslint@7.27.0+typescript@4.2.3:
-    dependencies:
-      '@typescript-eslint/scope-manager': 4.29.3
-      '@typescript-eslint/types': 4.29.3
-      '@typescript-eslint/typescript-estree': 4.29.3_typescript@4.2.3
-      debug: 4.3.2
-      eslint: 7.27.0
-      typescript: 4.2.3
-    dev: false
-    engines:
-      node: ^10.12.0 || >=12.0.0
-    peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    resolution:
-      integrity: sha512-jrHOV5g2u8ROghmspKoW7pN8T/qUzk0+DITun0MELptvngtMrwUJ1tv5zMI04CYVEUsSrN4jV7AKSv+I0y0EfQ==
   /@typescript-eslint/parser/4.29.3_eslint@7.28.0+typescript@4.3.5:
     dependencies:
       '@typescript-eslint/scope-manager': 4.29.3
@@ -8362,6 +8325,25 @@ packages:
       debug: 4.3.2
       eslint: 7.29.0
       typescript: 4.3.5
+    engines:
+      node: ^10.12.0 || >=12.0.0
+    peerDependencies:
+      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    resolution:
+      integrity: sha512-jrHOV5g2u8ROghmspKoW7pN8T/qUzk0+DITun0MELptvngtMrwUJ1tv5zMI04CYVEUsSrN4jV7AKSv+I0y0EfQ==
+  /@typescript-eslint/parser/4.29.3_eslint@7.32.0+typescript@4.2.3:
+    dependencies:
+      '@typescript-eslint/scope-manager': 4.29.3
+      '@typescript-eslint/types': 4.29.3
+      '@typescript-eslint/typescript-estree': 4.29.3_typescript@4.2.3
+      debug: 4.3.2
+      eslint: 7.32.0
+      typescript: 4.2.3
+    dev: false
     engines:
       node: ^10.12.0 || >=12.0.0
     peerDependencies:
@@ -8428,6 +8410,25 @@ packages:
         optional: true
     resolution:
       integrity: sha512-rKu/yAReip7ovx8UwOAszJVO5MgBquo8WjIQcp1gx4pYQCwYzag+I5nVNHO4MqyMkAo0gWt2gWUi+36gWAVKcw==
+  /@typescript-eslint/parser/5.8.0_eslint@7.32.0+typescript@4.2.3:
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.8.0
+      '@typescript-eslint/types': 5.8.0
+      '@typescript-eslint/typescript-estree': 5.8.0_typescript@4.2.3
+      debug: 4.3.3
+      eslint: 7.32.0
+      typescript: 4.2.3
+    dev: true
+    engines:
+      node: ^12.22.0 || ^14.17.0 || >=16.0.0
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    resolution:
+      integrity: sha512-Gleacp/ZhRtJRYs5/T8KQR3pAQjQI89Dn/k+OzyCKOsLiZH2/Vh60cFBTnFsHNI6WAD+lNUo/xGZ4NeA5u0Ipw==
   /@typescript-eslint/scope-manager/4.13.0:
     dependencies:
       '@typescript-eslint/types': 4.13.0
@@ -8436,15 +8437,6 @@ packages:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     resolution:
       integrity: sha512-UpK7YLG2JlTp/9G4CHe7GxOwd93RBf3aHO5L+pfjIrhtBvZjHKbMhBXTIQNkbz7HZ9XOe++yKrXutYm5KmjWgQ==
-  /@typescript-eslint/scope-manager/4.26.0:
-    dependencies:
-      '@typescript-eslint/types': 4.26.0
-      '@typescript-eslint/visitor-keys': 4.26.0
-    dev: true
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    resolution:
-      integrity: sha512-G6xB6mMo4xVxwMt5lEsNTz3x4qGDt0NSGmTBNBPJxNsrTXJSm21c6raeYroS2OwQsOyIXqKZv266L/Gln1BWqg==
   /@typescript-eslint/scope-manager/4.28.4:
     dependencies:
       '@typescript-eslint/types': 4.28.4
@@ -8488,6 +8480,14 @@ packages:
       node: ^12.22.0 || ^14.17.0 || >=16.0.0
     resolution:
       integrity: sha512-22Uic9oRlTsPppy5Tcwfj+QET5RWEnZ5414Prby465XxQrQFZ6nnm5KnXgnsAJefG4hEgMnaxTB3kNEyjdjj6A==
+  /@typescript-eslint/scope-manager/5.8.0:
+    dependencies:
+      '@typescript-eslint/types': 5.8.0
+      '@typescript-eslint/visitor-keys': 5.8.0
+    engines:
+      node: ^12.22.0 || ^14.17.0 || >=16.0.0
+    resolution:
+      integrity: sha512-x82CYJsLOjPCDuFFEbS6e7K1QEWj7u5Wk1alw8A+gnJiYwNnDJk0ib6PCegbaPMjrfBvFKa7SxE3EOnnIQz2Gg==
   /@typescript-eslint/types/3.10.1:
     dev: false
     engines:
@@ -8499,12 +8499,6 @@ packages:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     resolution:
       integrity: sha512-/+aPaq163oX+ObOG00M0t9tKkOgdv9lq0IQv/y4SqGkAXmhFmCfgsELV7kOCTb2vVU5VOmVwXBXJTDr353C1rQ==
-  /@typescript-eslint/types/4.26.0:
-    dev: true
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    resolution:
-      integrity: sha512-rADNgXl1kS/EKnDr3G+m7fB9yeJNnR9kF7xMiXL6mSIWpr3Wg5MhxyfEXy/IlYthsqwBqHOr22boFbf/u6O88A==
   /@typescript-eslint/types/4.28.4:
     dev: true
     engines:
@@ -8533,6 +8527,11 @@ packages:
       node: ^12.22.0 || ^14.17.0 || >=16.0.0
     resolution:
       integrity: sha512-fce5pG41/w8O6ahQEhXmMV+xuh4+GayzqEogN24EK+vECA3I6pUwKuLi5QbXO721EMitpQne5VKXofPonYlAQg==
+  /@typescript-eslint/types/5.8.0:
+    engines:
+      node: ^12.22.0 || ^14.17.0 || >=16.0.0
+    resolution:
+      integrity: sha512-LdCYOqeqZWqCMOmwFnum6YfW9F3nKuxJiR84CdIRN5nfHJ7gyvGpXWqL/AaW0k3Po0+wm93ARAsOdzlZDPCcXg==
   /@typescript-eslint/typescript-estree/2.34.0_typescript@4.3.5:
     dependencies:
       debug: 4.3.1
@@ -8594,26 +8593,6 @@ packages:
         optional: true
     resolution:
       integrity: sha512-9A0/DFZZLlGXn5XA349dWQFwPZxcyYyCFX5X88nWs2uachRDwGeyPz46oTsm9ZJE66EALvEns1lvBwa4d9QxMg==
-  /@typescript-eslint/typescript-estree/4.26.0_typescript@4.2.3:
-    dependencies:
-      '@typescript-eslint/types': 4.26.0
-      '@typescript-eslint/visitor-keys': 4.26.0
-      debug: 4.3.1
-      globby: 11.0.3
-      is-glob: 4.0.1
-      semver: 7.3.5
-      tsutils: 3.21.0_typescript@4.2.3
-      typescript: 4.2.3
-    dev: true
-    engines:
-      node: ^10.12.0 || >=12.0.0
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    resolution:
-      integrity: sha512-GHUgahPcm9GfBuy3TzdsizCcPjKOAauG9xkz9TR8kOdssz2Iz9jRCSQm6+aVFa23d5NcSpo1GdHGSQKe0tlcbg==
   /@typescript-eslint/typescript-estree/4.28.4_typescript@4.3.5:
     dependencies:
       '@typescript-eslint/types': 4.28.4
@@ -8673,26 +8652,6 @@ packages:
         optional: true
     resolution:
       integrity: sha512-45oQJA0bxna4O5TMwz55/TpgjX1YrAPOI/rb6kPgmdnemRZx/dB0rsx+Ku8jpDvqTxcE1C/qEbVHbS3h0hflag==
-  /@typescript-eslint/typescript-estree/4.30.0_typescript@4.2.3:
-    dependencies:
-      '@typescript-eslint/types': 4.30.0
-      '@typescript-eslint/visitor-keys': 4.30.0
-      debug: 4.3.2
-      globby: 11.0.4
-      is-glob: 4.0.1
-      semver: 7.3.5
-      tsutils: 3.21.0_typescript@4.2.3
-      typescript: 4.2.3
-    dev: false
-    engines:
-      node: ^10.12.0 || >=12.0.0
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    resolution:
-      integrity: sha512-6WN7UFYvykr/U0Qgy4kz48iGPWILvYL34xXJxvDQeiRE018B7POspNRVtAZscWntEPZpFCx4hcz/XBT+erenfg==
   /@typescript-eslint/typescript-estree/4.30.0_typescript@4.3.5:
     dependencies:
       '@typescript-eslint/types': 4.30.0
@@ -8772,6 +8731,25 @@ packages:
         optional: true
     resolution:
       integrity: sha512-FJ0nqcaUOpn/6Z4Jwbtf+o0valjBLkqc3MWkMvrhA2TvzFXtcclIM8F4MBEmYa2kgcI8EZeSAzwoSrIC8JYkug==
+  /@typescript-eslint/typescript-estree/5.8.0_typescript@4.2.3:
+    dependencies:
+      '@typescript-eslint/types': 5.8.0
+      '@typescript-eslint/visitor-keys': 5.8.0
+      debug: 4.3.3
+      globby: 11.0.4
+      is-glob: 4.0.3
+      semver: 7.3.5
+      tsutils: 3.21.0_typescript@4.2.3
+      typescript: 4.2.3
+    engines:
+      node: ^12.22.0 || ^14.17.0 || >=16.0.0
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    resolution:
+      integrity: sha512-srfeZ3URdEcUsSLbkOFqS7WoxOqn8JNil2NSLO9O+I2/Uyc85+UlfpEvQHIpj5dVts7KKOZnftoJD/Fdv0L7nQ==
   /@typescript-eslint/visitor-keys/3.10.1:
     dependencies:
       eslint-visitor-keys: 1.3.0
@@ -8788,15 +8766,6 @@ packages:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     resolution:
       integrity: sha512-6RoxWK05PAibukE7jElqAtNMq+RWZyqJ6Q/GdIxaiUj2Ept8jh8+FUVlbq9WxMYxkmEOPvCE5cRSyupMpwW31g==
-  /@typescript-eslint/visitor-keys/4.26.0:
-    dependencies:
-      '@typescript-eslint/types': 4.26.0
-      eslint-visitor-keys: 2.1.0
-    dev: true
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    resolution:
-      integrity: sha512-cw4j8lH38V1ycGBbF+aFiLUls9Z0Bw8QschP3mkth50BbWzgFS33ISIgBzUMuQ2IdahoEv/rXstr8Zhlz4B1Zg==
   /@typescript-eslint/visitor-keys/4.28.4:
     dependencies:
       '@typescript-eslint/types': 4.28.4
@@ -8840,6 +8809,14 @@ packages:
       node: ^12.22.0 || ^14.17.0 || >=16.0.0
     resolution:
       integrity: sha512-oVIAfIQuq0x2TFDNLVavUn548WL+7hdhxYn+9j3YdJJXB7mH9dAmZNJsPDa7Jc+B9WGqoiex7GUDbyMxV0a/aw==
+  /@typescript-eslint/visitor-keys/5.8.0:
+    dependencies:
+      '@typescript-eslint/types': 5.8.0
+      eslint-visitor-keys: 3.1.0
+    engines:
+      node: ^12.22.0 || ^14.17.0 || >=16.0.0
+    resolution:
+      integrity: sha512-+HDIGOEMnqbxdAHegxvnOqESUH6RWFRR2b8qxP1W9CZnnYh4Usz6MBL+2KMAgPk/P0o9c1HqnYtwzVH6GTIqug==
   /@votingworks/qrcode.react/1.0.1_react@17.0.1:
     dependencies:
       '@types/react': 17.0.0
@@ -12837,21 +12814,6 @@ packages:
       eslint-plugin-import: ^2.22.1
     resolution:
       integrity: sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==
-  /eslint-config-airbnb-base/14.2.1_2bfbb5f9d15cdc8811f4d55173efe733:
-    dependencies:
-      confusing-browser-globals: 1.0.10
-      eslint: 7.27.0
-      eslint-plugin-import: 2.24.2_eslint@7.27.0+typescript@4.2.3
-      object.assign: 4.1.2
-      object.entries: 1.1.4
-    dev: false
-    engines:
-      node: '>= 6'
-    peerDependencies:
-      eslint: ^5.16.0 || ^6.8.0 || ^7.2.0
-      eslint-plugin-import: ^2.22.1
-    resolution:
-      integrity: sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==
   /eslint-config-airbnb-base/14.2.1_860e0a3f1402db18f3476b9d86a8ac51:
     dependencies:
       confusing-browser-globals: 1.0.10
@@ -12875,6 +12837,21 @@ packages:
       object.assign: 4.1.2
       object.entries: 1.1.4
     dev: true
+    engines:
+      node: '>= 6'
+    peerDependencies:
+      eslint: ^5.16.0 || ^6.8.0 || ^7.2.0
+      eslint-plugin-import: ^2.22.1
+    resolution:
+      integrity: sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==
+  /eslint-config-airbnb-base/14.2.1_b7a4de75e7d0094cbe979e30a9a325ab:
+    dependencies:
+      confusing-browser-globals: 1.0.10
+      eslint: 7.32.0
+      eslint-plugin-import: 2.24.2_eslint@7.32.0+typescript@4.2.3
+      object.assign: 4.1.2
+      object.entries: 1.1.4
+    dev: false
     engines:
       node: '>= 6'
     peerDependencies:
@@ -12960,13 +12937,13 @@ packages:
       eslint-plugin-react-hooks: ^4 || ^3 || ^2.3.0 || ^1.7.0
     resolution:
       integrity: sha512-glZNDEZ36VdlZWoxn/bUR1r/sdFKPd1mHPbqUtkctgNG4yT2DLLtJ3D+yCV+jzZCc2V1nBVkmdknOJBZ5Hc0fg==
-  /eslint-config-airbnb/18.2.1_74ade7420e0f78ce33d23941f9379dba:
+  /eslint-config-airbnb/18.2.1_2f5861ee8b825437620ff8bf3831cd0a:
     dependencies:
-      eslint: 7.27.0
-      eslint-config-airbnb-base: 14.2.1_2bfbb5f9d15cdc8811f4d55173efe733
-      eslint-plugin-import: 2.24.2_eslint@7.27.0+typescript@4.2.3
-      eslint-plugin-jsx-a11y: 6.4.1_eslint@7.27.0
-      eslint-plugin-react: 7.24.0_eslint@7.27.0
+      eslint: 7.32.0
+      eslint-config-airbnb-base: 14.2.1_b7a4de75e7d0094cbe979e30a9a325ab
+      eslint-plugin-import: 2.24.2_eslint@7.32.0+typescript@4.2.3
+      eslint-plugin-jsx-a11y: 6.4.1_eslint@7.32.0
+      eslint-plugin-react: 7.24.0_eslint@7.32.0
       object.assign: 4.1.2
       object.entries: 1.1.4
     dev: false
@@ -13017,15 +12994,6 @@ packages:
   /eslint-config-prettier/8.3.0_eslint@7.26.0:
     dependencies:
       eslint: 7.26.0
-    dev: true
-    hasBin: true
-    peerDependencies:
-      eslint: '>=7.0.0'
-    resolution:
-      integrity: sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==
-  /eslint-config-prettier/8.3.0_eslint@7.27.0:
-    dependencies:
-      eslint: 7.27.0
     dev: true
     hasBin: true
     peerDependencies:
@@ -13284,19 +13252,6 @@ packages:
       typescript: '*'
     resolution:
       integrity: sha512-QG8pcgThYOuqxupd06oYTZoNOGaUdTY1PqK+oS6ElF6vs4pBdk/aYxFVQQXzcrAqp9m7cl7lb2ubazX+g16k2Q==
-  /eslint-module-utils/2.6.2_eslint@7.27.0+typescript@4.2.3:
-    dependencies:
-      '@typescript-eslint/parser': 4.29.3_eslint@7.27.0+typescript@4.2.3
-      debug: 3.2.7
-      pkg-dir: 2.0.0
-    dev: false
-    engines:
-      node: '>=4'
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    resolution:
-      integrity: sha512-QG8pcgThYOuqxupd06oYTZoNOGaUdTY1PqK+oS6ElF6vs4pBdk/aYxFVQQXzcrAqp9m7cl7lb2ubazX+g16k2Q==
   /eslint-module-utils/2.6.2_eslint@7.28.0+typescript@4.3.5:
     dependencies:
       '@typescript-eslint/parser': 4.29.3_eslint@7.28.0+typescript@4.3.5
@@ -13315,6 +13270,19 @@ packages:
       '@typescript-eslint/parser': 4.29.3_eslint@7.29.0+typescript@4.3.5
       debug: 3.2.7
       pkg-dir: 2.0.0
+    engines:
+      node: '>=4'
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    resolution:
+      integrity: sha512-QG8pcgThYOuqxupd06oYTZoNOGaUdTY1PqK+oS6ElF6vs4pBdk/aYxFVQQXzcrAqp9m7cl7lb2ubazX+g16k2Q==
+  /eslint-module-utils/2.6.2_eslint@7.32.0+typescript@4.2.3:
+    dependencies:
+      '@typescript-eslint/parser': 4.29.3_eslint@7.32.0+typescript@4.2.3
+      debug: 3.2.7
+      pkg-dir: 2.0.0
+    dev: false
     engines:
       node: '>=4'
     peerDependencies:
@@ -13376,9 +13344,9 @@ packages:
       eslint: '>= 3.2.1'
     resolution:
       integrity: sha512-1SergF1sGbVhsf7MYfOLiBhdOg6wqyeV9pXUAIDIffYTGMN3dTBQS9nFAzhLsHhO+Bn0GaVM1Ecm71XUidQ7VA==
-  /eslint-plugin-cypress/2.11.3_eslint@7.27.0:
+  /eslint-plugin-cypress/2.11.3_eslint@7.32.0:
     dependencies:
-      eslint: 7.27.0
+      eslint: 7.32.0
       globals: 11.12.0
     dev: false
     peerDependencies:
@@ -13645,32 +13613,6 @@ packages:
       typescript: '*'
     resolution:
       integrity: sha512-hNVtyhiEtZmpsabL4neEj+6M5DCLgpYyG9nzJY8lZQeQXEn5UPW1DpUdsMHMXsq98dbNm7nt1w9ZMSVpfJdi8Q==
-  /eslint-plugin-import/2.24.2_eslint@7.27.0+typescript@4.2.3:
-    dependencies:
-      array-includes: 3.1.3
-      array.prototype.flat: 1.2.4
-      debug: 2.6.9
-      doctrine: 2.1.0
-      eslint: 7.27.0
-      eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.6.2_eslint@7.27.0+typescript@4.2.3
-      find-up: 2.1.0
-      has: 1.0.3
-      is-core-module: 2.6.0
-      minimatch: 3.0.4
-      object.values: 1.1.4
-      pkg-up: 2.0.0
-      read-pkg-up: 3.0.0
-      resolve: 1.20.0
-      tsconfig-paths: 3.11.0
-    dev: false
-    engines:
-      node: '>=4'
-    peerDependencies:
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0
-      typescript: '*'
-    resolution:
-      integrity: sha512-hNVtyhiEtZmpsabL4neEj+6M5DCLgpYyG9nzJY8lZQeQXEn5UPW1DpUdsMHMXsq98dbNm7nt1w9ZMSVpfJdi8Q==
   /eslint-plugin-import/2.24.2_eslint@7.28.0+typescript@4.3.5:
     dependencies:
       array-includes: 3.1.3
@@ -13715,6 +13657,32 @@ packages:
       read-pkg-up: 3.0.0
       resolve: 1.20.0
       tsconfig-paths: 3.11.0
+    engines:
+      node: '>=4'
+    peerDependencies:
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0
+      typescript: '*'
+    resolution:
+      integrity: sha512-hNVtyhiEtZmpsabL4neEj+6M5DCLgpYyG9nzJY8lZQeQXEn5UPW1DpUdsMHMXsq98dbNm7nt1w9ZMSVpfJdi8Q==
+  /eslint-plugin-import/2.24.2_eslint@7.32.0+typescript@4.2.3:
+    dependencies:
+      array-includes: 3.1.3
+      array.prototype.flat: 1.2.4
+      debug: 2.6.9
+      doctrine: 2.1.0
+      eslint: 7.32.0
+      eslint-import-resolver-node: 0.3.6
+      eslint-module-utils: 2.6.2_eslint@7.32.0+typescript@4.2.3
+      find-up: 2.1.0
+      has: 1.0.3
+      is-core-module: 2.6.0
+      minimatch: 3.0.4
+      object.values: 1.1.4
+      pkg-up: 2.0.0
+      read-pkg-up: 3.0.0
+      resolve: 1.20.0
+      tsconfig-paths: 3.11.0
+    dev: false
     engines:
       node: '>=4'
     peerDependencies:
@@ -13888,27 +13856,6 @@ packages:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7
     resolution:
       integrity: sha512-0rGPJBbwHoGNPU73/QCLP/vveMlM1b1Z9PponxO87jfr6tuH5ligXbDT6nHSSzBC8ovX2Z+BQu7Bk5D/Xgq9zg==
-  /eslint-plugin-jsx-a11y/6.4.1_eslint@7.27.0:
-    dependencies:
-      '@babel/runtime': 7.15.3
-      aria-query: 4.2.2
-      array-includes: 3.1.3
-      ast-types-flow: 0.0.7
-      axe-core: 4.3.3
-      axobject-query: 2.2.0
-      damerau-levenshtein: 1.0.7
-      emoji-regex: 9.2.2
-      eslint: 7.27.0
-      has: 1.0.3
-      jsx-ast-utils: 3.2.0
-      language-tags: 1.0.5
-    dev: false
-    engines:
-      node: '>=4.0'
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7
-    resolution:
-      integrity: sha512-0rGPJBbwHoGNPU73/QCLP/vveMlM1b1Z9PponxO87jfr6tuH5ligXbDT6nHSSzBC8ovX2Z+BQu7Bk5D/Xgq9zg==
   /eslint-plugin-jsx-a11y/6.4.1_eslint@7.28.0:
     dependencies:
       '@babel/runtime': 7.15.3
@@ -13941,6 +13888,27 @@ packages:
       damerau-levenshtein: 1.0.7
       emoji-regex: 9.2.2
       eslint: 7.29.0
+      has: 1.0.3
+      jsx-ast-utils: 3.2.0
+      language-tags: 1.0.5
+    dev: false
+    engines:
+      node: '>=4.0'
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7
+    resolution:
+      integrity: sha512-0rGPJBbwHoGNPU73/QCLP/vveMlM1b1Z9PponxO87jfr6tuH5ligXbDT6nHSSzBC8ovX2Z+BQu7Bk5D/Xgq9zg==
+  /eslint-plugin-jsx-a11y/6.4.1_eslint@7.32.0:
+    dependencies:
+      '@babel/runtime': 7.15.3
+      aria-query: 4.2.2
+      array-includes: 3.1.3
+      ast-types-flow: 0.0.7
+      axe-core: 4.3.3
+      axobject-query: 2.2.0
+      damerau-levenshtein: 1.0.7
+      emoji-regex: 9.2.2
+      eslint: 7.32.0
       has: 1.0.3
       jsx-ast-utils: 3.2.0
       language-tags: 1.0.5
@@ -14041,6 +14009,24 @@ packages:
         optional: true
     resolution:
       integrity: sha512-Rq3jkcFY8RYeQLgk2cCwuc0P7SEFwDravPhsJZOQ5N4YI4DSg50NyqJ/9gdZHzQlHf8MvafSesbNJCcP/FF6pQ==
+  /eslint-plugin-prettier/3.4.0_39707b7de4180b40645e0fe3095cfe49:
+    dependencies:
+      eslint: 7.32.0
+      eslint-config-prettier: 8.3.0_eslint@7.32.0
+      prettier: 2.3.0
+      prettier-linter-helpers: 1.0.0
+    dev: true
+    engines:
+      node: '>=6.0.0'
+    peerDependencies:
+      eslint: '>=5.0.0'
+      eslint-config-prettier: '*'
+      prettier: '>=1.13.0'
+    peerDependenciesMeta:
+      eslint-config-prettier:
+        optional: true
+    resolution:
+      integrity: sha512-UDK6rJT6INSfcOo545jiaOwB701uAIt2/dR7WnFQoGCVl1/EMqdANBmwUaqqQ45aXprsTGzSa39LI1PyuRBxxw==
   /eslint-plugin-prettier/3.4.0_39fed7ca8f33f3403e39ca7e7aa90c0f:
     dependencies:
       eslint: 7.26.0
@@ -14064,24 +14050,6 @@ packages:
       eslint: 7.28.0
       eslint-config-prettier: 8.3.0_eslint@7.28.0
       prettier: 2.3.1
-      prettier-linter-helpers: 1.0.0
-    dev: true
-    engines:
-      node: '>=6.0.0'
-    peerDependencies:
-      eslint: '>=5.0.0'
-      eslint-config-prettier: '*'
-      prettier: '>=1.13.0'
-    peerDependenciesMeta:
-      eslint-config-prettier:
-        optional: true
-    resolution:
-      integrity: sha512-UDK6rJT6INSfcOo545jiaOwB701uAIt2/dR7WnFQoGCVl1/EMqdANBmwUaqqQ45aXprsTGzSa39LI1PyuRBxxw==
-  /eslint-plugin-prettier/3.4.0_beb8ddd1fba5378f74976112c7860a07:
-    dependencies:
-      eslint: 7.27.0
-      eslint-config-prettier: 8.3.0_eslint@7.27.0
-      prettier: 2.3.0
       prettier-linter-helpers: 1.0.0
     dev: true
     engines:
@@ -14296,12 +14264,12 @@ packages:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7
     resolution:
       integrity: sha512-KJJIx2SYx7PBx3ONe/mEeMz4YE0Lcr7feJTCMyyKb/341NcjuAgim3Acgan89GfPv7nxXK2+0slu0CWXYM4x+Q==
-  /eslint-plugin-react/7.24.0_eslint@7.27.0:
+  /eslint-plugin-react/7.24.0_eslint@7.29.0:
     dependencies:
       array-includes: 3.1.3
       array.prototype.flatmap: 1.2.4
       doctrine: 2.1.0
-      eslint: 7.27.0
+      eslint: 7.29.0
       has: 1.0.3
       jsx-ast-utils: 3.2.0
       minimatch: 3.0.4
@@ -14318,12 +14286,12 @@ packages:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7
     resolution:
       integrity: sha512-KJJIx2SYx7PBx3ONe/mEeMz4YE0Lcr7feJTCMyyKb/341NcjuAgim3Acgan89GfPv7nxXK2+0slu0CWXYM4x+Q==
-  /eslint-plugin-react/7.24.0_eslint@7.29.0:
+  /eslint-plugin-react/7.24.0_eslint@7.32.0:
     dependencies:
       array-includes: 3.1.3
       array.prototype.flatmap: 1.2.4
       doctrine: 2.1.0
-      eslint: 7.29.0
+      eslint: 7.32.0
       has: 1.0.3
       jsx-ast-utils: 3.2.0
       minimatch: 3.0.4
@@ -14431,17 +14399,6 @@ packages:
       eslint: '>=5'
     resolution:
       integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
-  /eslint-utils/3.0.0_eslint@7.27.0:
-    dependencies:
-      eslint: 7.27.0
-      eslint-visitor-keys: 2.1.0
-    dev: false
-    engines:
-      node: ^10.0.0 || ^12.0.0 || >= 14.0.0
-    peerDependencies:
-      eslint: '>=5'
-    resolution:
-      integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
   /eslint-utils/3.0.0_eslint@7.28.0:
     dependencies:
       eslint: 7.28.0
@@ -14467,7 +14424,6 @@ packages:
     dependencies:
       eslint: 7.32.0
       eslint-visitor-keys: 2.1.0
-    dev: true
     engines:
       node: ^10.0.0 || ^12.0.0 || >= 14.0.0
     peerDependencies:
@@ -14495,6 +14451,11 @@ packages:
       node: ^12.22.0 || ^14.17.0 || >=16.0.0
     resolution:
       integrity: sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q==
+  /eslint-visitor-keys/3.1.0:
+    engines:
+      node: ^12.22.0 || ^14.17.0 || >=16.0.0
+    resolution:
+      integrity: sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==
   /eslint-webpack-plugin/2.4.1_eslint@7.29.0+webpack@4.44.2:
     dependencies:
       '@types/eslint': 7.2.6
@@ -14692,53 +14653,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-4R1ieRf52/izcZE7AlLy56uIHHDLT74Yzz2Iv2l6kDaYvEu9x+wMB5dZArVL8SYGXSYV2YAg70FcW5Y5nGGNIg==
-  /eslint/7.27.0:
-    dependencies:
-      '@babel/code-frame': 7.12.11
-      '@eslint/eslintrc': 0.4.1
-      ajv: 6.12.6
-      chalk: 4.1.1
-      cross-spawn: 7.0.3
-      debug: 4.3.1
-      doctrine: 3.0.0
-      enquirer: 2.3.6
-      escape-string-regexp: 4.0.0
-      eslint-scope: 5.1.1
-      eslint-utils: 2.1.0
-      eslint-visitor-keys: 2.1.0
-      espree: 7.3.1
-      esquery: 1.4.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 6.0.1
-      functional-red-black-tree: 1.0.1
-      glob-parent: 5.1.2
-      globals: 13.9.0
-      ignore: 4.0.6
-      import-fresh: 3.3.0
-      imurmurhash: 0.1.4
-      is-glob: 4.0.1
-      js-yaml: 3.14.1
-      json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.4.1
-      lodash.merge: 4.6.2
-      minimatch: 3.0.4
-      natural-compare: 1.4.0
-      optionator: 0.9.1
-      progress: 2.0.3
-      regexpp: 3.1.0
-      semver: 7.3.5
-      strip-ansi: 6.0.0
-      strip-json-comments: 3.1.1
-      table: 6.7.1
-      text-table: 0.2.0
-      v8-compile-cache: 2.3.0
-    dev: true
-    engines:
-      node: ^10.12.0 || >=12.0.0
-    hasBin: true
-    resolution:
-      integrity: sha512-JZuR6La2ZF0UD384lcbnd0Cgg6QJjiCwhMD6eU4h/VGPcVGwawNNzKU41tgokGXnfjOOyI6QIffthhJTPzzuRA==
   /eslint/7.28.0:
     dependencies:
       '@babel/code-frame': 7.12.11
@@ -16077,7 +15991,7 @@ packages:
       array-union: 2.1.0
       dir-glob: 3.0.1
       fast-glob: 3.2.7
-      ignore: 5.1.9
+      ignore: 5.2.0
       merge2: 1.4.1
       slash: 3.0.0
     engines:
@@ -16684,10 +16598,16 @@ packages:
     resolution:
       integrity: sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
   /ignore/5.1.9:
+    dev: true
     engines:
       node: '>= 4'
     resolution:
       integrity: sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==
+  /ignore/5.2.0:
+    engines:
+      node: '>= 4'
+    resolution:
+      integrity: sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
   /immer/8.0.1:
     resolution:
       integrity: sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==


### PR DESCRIPTION
They changed how they map a TS AST to an ESTree AST, and also the metadata for a rule. Another even more restricted attempt at #1323.