### PR TITLE
fix(em) fixes bug when exporting ballot package

### DIFF
--- a/frontends/election-manager/src/components/hand_marked_paper_ballot.tsx
+++ b/frontends/election-manager/src/components/hand_marked_paper_ballot.tsx
@@ -544,7 +544,7 @@ export function HandMarkedPaperBallot({
 }: HandMarkedPaperBallotProps): JSX.Element {
   const layoutDensity = getBallotLayoutDensity(election);
   assert(
-    locales.primary === locales.secondary,
+    locales.primary !== locales.secondary,
     'rendering a dual-language ballot with both languages the same is not allowed'
   );
 


### PR DESCRIPTION
In https://github.com/votingworks/vxsuite/commit/ae047790b7216c1a6d84b8cc1e128215c89fded1 we migrated to a new version of assert and accidently changed this assert from an assert.notEqual to an assert checking equality. Noticed that I couldn't export any ballot packages because of this throwing and then found the mis-translation from that PR. This updates it to check that it is not equal as intended. 

cc @eventualbuddha 