### PR TITLE
feat(em) add advanced screen with log export as cdf option

### DIFF
--- a/frontends/bsd/src/components/export_logs_modal.tsx
+++ b/frontends/bsd/src/components/export_logs_modal.tsx
@@ -5,6 +5,7 @@ import {
   usbstick,
   throwIllegalValue,
   generateLogFilename,
+  LogFileType,
 } from '@votingworks/utils';
 
 import { LogEventId } from '@votingworks/logging';
@@ -81,7 +82,7 @@ export function ExportLogsModal({ onClose }: Props): JSX.Element {
     }
     void checkLogFile();
   }, [currentUserSession, logger]);
-  const defaultFilename = generateLogFilename('vx-logs');
+  const defaultFilename = generateLogFilename('vx-logs', LogFileType.Raw);
 
   async function exportResults(openFileDialog: boolean) {
     assert(window.kiosk);

--- a/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
+++ b/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
@@ -58,16 +58,17 @@ exports[`printing ballots, print report, and test decks 1`] = `
         >
           Tally
         </button>
+        <button
+          class="sc-jrAGrp iWxjsY"
+          role="option"
+          type="button"
+        >
+          Advanced
+        </button>
       </div>
       <div
         class="sc-fubCfw kBiVZq"
       >
-        <button
-          class="sc-gsDJrp gwgkfw"
-          type="button"
-        >
-          Export Logs
-        </button>
         <button
           class="sc-gsDJrp gwgkfw"
           type="button"
@@ -89,7 +90,7 @@ exports[`printing ballots, print report, and test decks 1`] = `
         class="sc-dlfnbm kzZCED"
       >
         <div
-          class="sc-fFubgz HfZVK"
+          class="sc-hBEYos eoEHwy"
         >
           <h1>
             Test Deck
@@ -258,16 +259,17 @@ exports[`printing ballots, print report, and test decks 2`] = `
         >
           Tally
         </button>
+        <button
+          class="sc-jrAGrp iWxjsY"
+          role="option"
+          type="button"
+        >
+          Advanced
+        </button>
       </div>
       <div
         class="sc-fubCfw kBiVZq"
       >
-        <button
-          class="sc-gsDJrp gwgkfw"
-          type="button"
-        >
-          Export Logs
-        </button>
         <button
           class="sc-gsDJrp gwgkfw"
           type="button"
@@ -296,7 +298,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
           Mock General Election Choctaw 2020
         </div>
         <div
-          class="sc-fFubgz HfZVK"
+          class="sc-hBEYos eoEHwy"
         >
           <h1
             class="sc-dJjZJu boqHgo"
@@ -398,7 +400,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
          Mock General Election Choctaw 2020
       </div>
       <div
-        class="sc-fFubgz cZzkcJ"
+        class="sc-hBEYos eWOkWl"
       >
         <h1
           class="sc-dJjZJu boqHgo"
@@ -1537,7 +1539,7 @@ exports[`tabulating CVRs 1`] = `
     src="/votingworks-wordmark-black.svg"
   />
   <div
-    class="sc-fFubgz cZzkcJ"
+    class="sc-hBEYos eWOkWl"
   >
     <h1>
       Official
@@ -2728,7 +2730,7 @@ exports[`tabulating CVRs with SEMS file 1`] = `
     src="/votingworks-wordmark-black.svg"
   />
   <div
-    class="sc-fFubgz cZzkcJ"
+    class="sc-hBEYos eWOkWl"
   >
     <h1>
       Unofficial

--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -66,7 +66,10 @@ jest.mock('./components/hand_marked_paper_ballot');
 beforeEach(() => {
   // we don't care about network errors logged to the console, they're crowding things
   jest.spyOn(console, 'error').mockImplementation(() => {}); // eslint-disable-line @typescript-eslint/no-empty-function
-
+  Object.defineProperty(window, 'location', {
+    writable: true,
+    value: { assign: jest.fn() },
+  });
   window.location.href = '/';
   const mockKiosk = fakeKiosk();
   window.kiosk = mockKiosk;
@@ -138,7 +141,6 @@ test('create election works', async () => {
   const { getByText, getAllByText, queryAllByText, getByTestId } = render(
     <App card={card} hardware={hardware} />
   );
-
   await screen.findByText('Create New Election Definition');
   fireEvent.click(getByText('Create New Election Definition'));
 
@@ -150,6 +152,14 @@ test('create election works', async () => {
   fireEvent.click(getByText('Ballots'));
   fireEvent.click(getAllByText('View Ballot')[0]);
   fireEvent.click(getByText('English/Spanish'));
+
+  // You can view the advanced screen and export log files when there is an election.
+  await fireEvent.click(screen.getByText('Advanced'));
+  await fireEvent.click(screen.getByText('Export Log File'));
+  await screen.findByText('No Log File Present');
+  await fireEvent.click(screen.getByText('Close'));
+  await fireEvent.click(screen.getByText('Export Log File as CDF'));
+  await screen.findByText('No Log File Present');
 
   fireEvent.click(getByText('Definition'));
 
@@ -167,6 +177,18 @@ test('create election works', async () => {
   expect(window.kiosk!.log).toHaveBeenCalledWith(
     expect.stringContaining(LogEventId.ElectionUnconfigured)
   );
+
+  // You can view the advanced screen and export log files when there is no election.
+  await fireEvent.click(screen.getByText('Advanced'));
+  await fireEvent.click(screen.getByText('Export Log File'));
+  await screen.findByText('No Log File Present');
+  await fireEvent.click(screen.getByText('Close'));
+  await fireEvent.click(screen.getByText('Export Log File as CDF'));
+  // You can not export as CDF when there is no election.
+  expect(await screen.queryAllByText('No Log File Present')).toHaveLength(0);
+
+  await fireEvent.click(screen.getByText('Configure'));
+  await screen.findByText('Create New Election Definition');
 });
 
 test('authentication works', async () => {

--- a/frontends/election-manager/src/components/election_manager.tsx
+++ b/frontends/election-manager/src/components/election_manager.tsx
@@ -23,6 +23,7 @@ import { SmartcardsScreen } from '../screens/smartcards_screen';
 import { MachineLockedScreen } from '../screens/machine_locked_screen';
 import { InvalidCardScreen } from '../screens/invalid_card_screen';
 import { UnlockMachineScreen } from '../screens/unlock_machine_screen';
+import { AdvancedScreen } from '../screens/advanced_screen';
 
 export function ElectionManager(): JSX.Element {
   const {
@@ -38,7 +39,19 @@ export function ElectionManager(): JSX.Element {
   }
 
   if (!election || !configuredAt) {
-    return <UnconfiguredScreen />;
+    return (
+      <Switch>
+        <Route exact path={routerPaths.root}>
+          <UnconfiguredScreen />
+        </Route>
+        <Route exact path={routerPaths.advanced}>
+          <AdvancedScreen />
+        </Route>
+        <Route exact path={routerPaths.electionDefinition}>
+          <UnconfiguredScreen />
+        </Route>
+      </Switch>
+    );
   }
 
   if (!currentUserSession) {
@@ -55,6 +68,9 @@ export function ElectionManager(): JSX.Element {
 
   return (
     <Switch>
+      <Route exact path={routerPaths.advanced}>
+        <AdvancedScreen />
+      </Route>
       <Route exact path={routerPaths.electionDefinition}>
         <DefinitionScreen />
       </Route>

--- a/frontends/election-manager/src/components/export_logs_modal.tsx
+++ b/frontends/election-manager/src/components/export_logs_modal.tsx
@@ -5,6 +5,7 @@ import {
   usbstick,
   throwIllegalValue,
   generateLogFilename,
+  LogFileType,
 } from '@votingworks/utils';
 
 import { LogEventId } from '@votingworks/logging';
@@ -24,6 +25,7 @@ const LOG_NAME = 'vx-logs';
 
 export interface Props {
   onClose: () => void;
+  logFileType: LogFileType;
 }
 
 enum ModalState {
@@ -33,8 +35,14 @@ enum ModalState {
   Init = 'init',
 }
 
-export function ExportLogsModal({ onClose }: Props): JSX.Element {
-  const { usbDriveStatus, currentUserSession, logger } = useContext(AppContext);
+export function ExportLogsModal({ onClose, logFileType }: Props): JSX.Element {
+  const {
+    usbDriveStatus,
+    currentUserSession,
+    logger,
+    electionDefinition,
+    machineConfig,
+  } = useContext(AppContext);
   assert(currentUserSession); // TODO(auth) should this check for a specific user type
 
   const [currentState, setCurrentState] = useState(ModalState.Init);
@@ -81,7 +89,7 @@ export function ExportLogsModal({ onClose }: Props): JSX.Element {
     }
     void checkLogFile();
   }, [currentUserSession, logger]);
-  const defaultFilename = generateLogFilename('vx-logs');
+  const defaultFilename = generateLogFilename('vx-logs', logFileType);
 
   async function exportResults(openFileDialog: boolean) {
     assert(window.kiosk);
@@ -89,9 +97,30 @@ export function ExportLogsModal({ onClose }: Props): JSX.Element {
     setCurrentState(ModalState.Saving);
 
     try {
-      const results = await window.kiosk.readFile(
-        `${LOGS_ROOT_LOCATION}/${LOG_NAME}.log`
+      const rawLogFile = await window.kiosk.readFile(
+        `${LOGS_ROOT_LOCATION}/${LOG_NAME}.log`,
+        'utf8'
       );
+      let results = '';
+      switch (logFileType) {
+        case LogFileType.Raw:
+          results = rawLogFile;
+          break;
+        case LogFileType.Cdf: {
+          assert(electionDefinition !== undefined);
+          results = logger.buildCDFLog(
+            electionDefinition,
+            rawLogFile,
+            machineConfig.machineId,
+            machineConfig.codeVersion,
+            currentUserSession.type
+          );
+          break;
+        }
+        /* istanbul ignore next - compile time check for completeness */
+        default:
+          throwIllegalValue(logFileType);
+      }
       let filenameLocation = '';
       const usbPath = await usbstick.getDevicePath();
       if (openFileDialog) {
@@ -102,8 +131,8 @@ export function ExportLogsModal({ onClose }: Props): JSX.Element {
         if (!fileWriter) {
           throw new Error('could not begin download; no file was chosen');
         }
-
         await fileWriter.write(results);
+
         filenameLocation = fileWriter.filename;
         await fileWriter.end();
       } else {

--- a/frontends/election-manager/src/components/navigation_screen.tsx
+++ b/frontends/election-manager/src/components/navigation_screen.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { Button, UsbControllerButton } from '@votingworks/ui';
@@ -10,7 +10,6 @@ import { Main, MainChild } from './main';
 import { Navigation } from './navigation';
 import { LinkButton } from './link_button';
 import { StatusFooter } from './status_footer';
-import { ExportLogsModal } from './export_logs_modal';
 
 interface Props {
   children: React.ReactNode;
@@ -24,7 +23,11 @@ export function NavigationScreen({
   mainChildFlex = false,
 }: Props): JSX.Element {
   const location = useLocation();
+
   function isActiveSection(path: string) {
+    if (path === '/') {
+      return location.pathname === '/' ? 'active-section' : '';
+    }
     return new RegExp(`^${path}`).test(location.pathname)
       ? 'active-section'
       : '';
@@ -38,7 +41,6 @@ export function NavigationScreen({
     machineConfig,
     currentUserSession,
   } = useContext(AppContext);
-  const [isExportingLogs, setIsExportingLogs] = useState(false);
   const election = electionDefinition?.election;
   const currentUser = currentUserSession?.type ?? 'unknown';
 
@@ -46,7 +48,7 @@ export function NavigationScreen({
     <Screen>
       <Navigation
         primaryNav={
-          election && (
+          election ? (
             <React.Fragment>
               <LinkButton
                 to={routerPaths.electionDefinition}
@@ -73,14 +75,34 @@ export function NavigationScreen({
               >
                 Tally
               </LinkButton>
+              <LinkButton
+                small
+                to={routerPaths.advanced}
+                className={isActiveSection(routerPaths.advanced)}
+              >
+                Advanced
+              </LinkButton>
+            </React.Fragment>
+          ) : (
+            <React.Fragment>
+              <LinkButton
+                to={routerPaths.root}
+                className={isActiveSection(routerPaths.root)}
+              >
+                Configure
+              </LinkButton>
+              <LinkButton
+                small
+                to={routerPaths.advanced}
+                className={isActiveSection(routerPaths.advanced)}
+              >
+                Advanced
+              </LinkButton>
             </React.Fragment>
           )
         }
         secondaryNav={
           <React.Fragment>
-            <Button small onPress={() => setIsExportingLogs(true)}>
-              Export Logs
-            </Button>
             {!machineConfig.bypassAuthentication && (
               <Button small onPress={lockMachine}>
                 Lock Machine
@@ -99,9 +121,6 @@ export function NavigationScreen({
         </MainChild>
       </Main>
       <StatusFooter />
-      {isExportingLogs && (
-        <ExportLogsModal onClose={() => setIsExportingLogs(false)} />
-      )}
     </Screen>
   );
 }

--- a/frontends/election-manager/src/router_paths.ts
+++ b/frontends/election-manager/src/router_paths.ts
@@ -11,6 +11,7 @@ import {
 
 export const routerPaths = {
   root: '/',
+  advanced: '/advanced',
   electionDefinition: '/definition',
   definitionEditor: '/definition/editor',
   definitionContest: ({ contestId }: { contestId: ContestId }): string =>

--- a/frontends/election-manager/src/screens/advanced_screen.tsx
+++ b/frontends/election-manager/src/screens/advanced_screen.tsx
@@ -1,0 +1,38 @@
+import React, { useContext, useState } from 'react';
+import { Button } from '@votingworks/ui';
+import { LogFileType } from '@votingworks/utils';
+
+import { NavigationScreen } from '../components/navigation_screen';
+import { Prose } from '../components/prose';
+import { AppContext } from '../contexts/app_context';
+import { ExportLogsModal } from '../components/export_logs_modal';
+
+export function AdvancedScreen(): JSX.Element {
+  const { electionDefinition } = useContext(AppContext);
+  const [exportingLogType, setExportingLogType] = useState<LogFileType>();
+  return (
+    <React.Fragment>
+      <NavigationScreen mainChildFlex>
+        <Prose maxWidth={false}>
+          <h1>Advanced Options</h1>
+          <h2>Logs</h2>
+          <Button onPress={() => setExportingLogType(LogFileType.Raw)}>
+            Export Log File
+          </Button>{' '}
+          <Button
+            onPress={() => setExportingLogType(LogFileType.Cdf)}
+            disabled={electionDefinition === undefined} // CDF requires the election being known.
+          >
+            Export Log File as CDF
+          </Button>
+        </Prose>
+      </NavigationScreen>
+      {exportingLogType !== undefined && (
+        <ExportLogsModal
+          onClose={() => setExportingLogType(undefined)}
+          logFileType={exportingLogType}
+        />
+      )}
+    </React.Fragment>
+  );
+}

--- a/libs/logging/src/types.ts
+++ b/libs/logging/src/types.ts
@@ -5,8 +5,9 @@ import {
 } from '@votingworks/types';
 import { z } from 'zod';
 import { DeviceType } from '@votingworks/cdf-types-election-event-logging';
-import { LogEventId, LogEventType } from '.';
+import { LogEventId } from './log_event_ids';
 import { LogSource } from './log_source';
+import { LogEventType } from './log_event_types';
 
 export enum LogDispositionStandardTypes {
   Success = 'success',

--- a/libs/utils/src/filenames.test.ts
+++ b/libs/utils/src/filenames.test.ts
@@ -16,6 +16,7 @@ import {
   generateFilenameForBallotExportPackageFromElectionData,
   generateBatchResultsDefaultFilename,
   generateLogFilename,
+  LogFileType,
 } from './filenames';
 import { typedAs } from './types';
 
@@ -509,9 +510,12 @@ test('generateLogFilename', () => {
       arbitrarySafeName(),
       fc.oneof(fc.constant(undefined), arbitraryTimestampDate()),
       (logName, time) => {
-        const name = generateLogFilename(logName, time);
+        const name = generateLogFilename(logName, LogFileType.Raw, time);
         expect(name).toMatch(/^.*_\d\d\d\d-\d\d-\d\d_\d\d-\d\d-\d\d.log$/);
         expect(name).toContain(logName);
+        const cdfName = generateLogFilename(logName, LogFileType.Cdf, time);
+        expect(cdfName).toMatch(/^.*_\d\d\d\d-\d\d-\d\d_\d\d-\d\d-\d\d.json$/);
+        expect(cdfName).toContain(logName);
       }
     )
   );

--- a/libs/utils/src/filenames.ts
+++ b/libs/utils/src/filenames.ts
@@ -5,7 +5,7 @@ import {
   MachineId,
   maybeParse,
 } from '@votingworks/types';
-import { assert } from './assert';
+import { assert, throwIllegalValue } from './assert';
 
 const SECTION_SEPARATOR = '__';
 const SUBSECTION_SEPARATOR = '_';
@@ -238,6 +238,12 @@ export function generateBatchResultsDefaultFilename(
   return `votingworks${WORD_SEPARATOR}${filemode}${WORD_SEPARATOR}batch-results${SUBSECTION_SEPARATOR}${electionName}${SUBSECTION_SEPARATOR}${timeInformation}.csv`;
 }
 
+/* Describes different formats of the log file. */
+export enum LogFileType {
+  Raw = 'raw',
+  Cdf = 'cdf',
+}
+
 /**
  * Generates a filename for the logs file.
  * @param logFileName Name of the log file being exported
@@ -246,8 +252,17 @@ export function generateBatchResultsDefaultFilename(
  */
 export function generateLogFilename(
   logFileName: string,
+  fileType: LogFileType,
   time: Date = new Date()
 ): string {
   const timeInformation = moment(time).format(TIME_FORMAT_STRING);
-  return `${logFileName}${SUBSECTION_SEPARATOR}${timeInformation}.log`;
+  switch (fileType) {
+    case LogFileType.Raw:
+      return `${logFileName}${SUBSECTION_SEPARATOR}${timeInformation}.log`;
+    case LogFileType.Cdf:
+      return `${logFileName}${WORD_SEPARATOR}cdf${SUBSECTION_SEPARATOR}${timeInformation}.json`;
+    /* istanbul ignore next - compile time check for completeness */
+    default:
+      throwIllegalValue(fileType);
+  }
 }


### PR DESCRIPTION
Adds an advanced screen to election manager with options to export the logs file and export the logs file in CDF format. I include the advanced screen where there is no election but don't allow the log export in CDF as the CDF format requires an election defined. 

Video: 

https://user-images.githubusercontent.com/14897017/148472024-5233a760-25b5-44a5-bcd3-91c6f43507da.mov



Will migrate the new version of ExportLogsModal to bsd in a followup PR (note: this is not in the shared components library as it is blocked on Modal being there). 