### PR TITLE
feat(bsd) add export logs as cdf option

### DIFF
--- a/frontends/bsd/src/app.test.tsx
+++ b/frontends/bsd/src/app.test.tsx
@@ -43,6 +43,7 @@ beforeEach(() => {
     '/machine-config',
     typedAs<MachineConfigResponse>({
       machineId: '0001',
+      codeVersion: 'TEST',
       bypassAuthentication: false,
     })
   );

--- a/frontends/bsd/src/app_root.tsx
+++ b/frontends/bsd/src/app_root.tsx
@@ -103,6 +103,7 @@ export function AppRoot({ card, hardware }: AppRootProps): JSX.Element {
 
   const [machineConfig, setMachineConfig] = useState<MachineConfig>({
     machineId: '0000',
+    codeVersion: '',
     bypassAuthentication: false,
   });
 

--- a/frontends/bsd/src/components/export_results_modal.test.tsx
+++ b/frontends/bsd/src/components/export_results_modal.test.tsx
@@ -158,7 +158,11 @@ test('render export modal when a usb drive is mounted as expected and allows aut
     <AppContext.Provider
       value={{
         electionDefinition,
-        machineConfig: { machineId: '0001', bypassAuthentication: false },
+        machineConfig: {
+          machineId: '0001',
+          codeVersion: 'TEST',
+          bypassAuthentication: false,
+        },
         usbDriveStatus: UsbDriveStatus.recentlyEjected,
         usbDriveEject: jest.fn(),
         storage: new MemoryStorage(),

--- a/frontends/bsd/src/config/types.ts
+++ b/frontends/bsd/src/config/types.ts
@@ -12,10 +12,12 @@ import { z } from 'zod';
 
 export interface MachineConfig {
   machineId: string;
+  codeVersion: string;
   bypassAuthentication: boolean;
 }
 export const MachineConfigSchema: z.ZodSchema<MachineConfig> = z.object({
   machineId: MachineId,
+  codeVersion: z.string().nonempty(),
   bypassAuthentication: z.boolean(),
 });
 

--- a/frontends/bsd/src/contexts/app_context.ts
+++ b/frontends/bsd/src/contexts/app_context.ts
@@ -19,7 +19,11 @@ export interface AppContextInterface {
 const appContext: AppContextInterface = {
   usbDriveStatus: usbstick.UsbDriveStatus.absent,
   usbDriveEject: () => undefined,
-  machineConfig: { machineId: '0000', bypassAuthentication: false },
+  machineConfig: {
+    machineId: '0000',
+    codeVersion: '',
+    bypassAuthentication: false,
+  },
   electionDefinition: undefined,
   electionHash: undefined,
   storage: new MemoryStorage(),

--- a/frontends/bsd/src/screens/advanced_options_screen.tsx
+++ b/frontends/bsd/src/screens/advanced_options_screen.tsx
@@ -1,6 +1,7 @@
 import { ElectionDefinition, MarkThresholds } from '@votingworks/types';
 import React, { useCallback, useEffect, useState, useContext } from 'react';
 import { LogEventId } from '@votingworks/logging';
+import { LogFileType } from '@votingworks/utils';
 import { Button } from '../components/button';
 import { LinkButton } from '../components/link_button';
 import { Main, MainChild } from '../components/main';
@@ -50,7 +51,7 @@ export function AdvancedOptionsScreen({
     return setIsConfirmingFactoryReset((s) => !s);
   }
   const [isConfirmingZero, setIsConfirmingZero] = useState(false);
-  const [isExportingLogs, setIsExportingLogs] = useState(false);
+  const [exportingLogType, setExportingLogType] = useState<LogFileType>();
   const [isSetMarkThresholdModalOpen, setIsMarkThresholdModalOpen] = useState(
     false
   );
@@ -139,8 +140,13 @@ export function AdvancedOptionsScreen({
                 </p>
               )}
               <p>
-                <Button onPress={() => setIsExportingLogs(true)}>
+                <Button onPress={() => setExportingLogType(LogFileType.Raw)}>
                   Export Logs…
+                </Button>
+              </p>
+              <p>
+                <Button onPress={() => setExportingLogType(LogFileType.Cdf)}>
+                  Export Logs as CDF…
                 </Button>
               </p>
             </Prose>
@@ -223,8 +229,11 @@ export function AdvancedOptionsScreen({
           onClose={() => setIsMarkThresholdModalOpen(false)}
         />
       )}
-      {isExportingLogs && (
-        <ExportLogsModal onClose={() => setIsExportingLogs(false)} />
+      {exportingLogType !== undefined && (
+        <ExportLogsModal
+          onClose={() => setExportingLogType(undefined)}
+          logFileType={exportingLogType}
+        />
       )}
     </React.Fragment>
   );

--- a/frontends/bsd/src/util/machine_config.ts
+++ b/frontends/bsd/src/util/machine_config.ts
@@ -4,16 +4,18 @@ import { MachineConfigResponseSchema } from '../config/types';
 
 export const machineConfigProvider: Provider<{
   machineId: string;
+  codeVersion: string;
   bypassAuthentication: boolean;
 }> = {
   async get() {
-    const { machineId, bypassAuthentication } = unsafeParse(
+    const { machineId, codeVersion, bypassAuthentication } = unsafeParse(
       MachineConfigResponseSchema,
       await fetchJson('/machine-config')
     );
 
     return {
       machineId,
+      codeVersion,
       bypassAuthentication,
     };
   },

--- a/frontends/bsd/test/helpers/fake_machine_config.ts
+++ b/frontends/bsd/test/helpers/fake_machine_config.ts
@@ -3,9 +3,10 @@ import { MachineConfig } from '../../src/config/types';
 
 export function fakeMachineConfig({
   machineId = '0000',
+  codeVersion = 'TEST',
   bypassAuthentication = true,
 }: Partial<MachineConfig> = {}): MachineConfig {
-  return { machineId, bypassAuthentication };
+  return { machineId, codeVersion, bypassAuthentication };
 }
 
 export function fakeMachineConfigProvider(

--- a/frontends/bsd/test/render_in_app_context.tsx
+++ b/frontends/bsd/test/render_in_app_context.tsx
@@ -42,7 +42,7 @@ export function renderInAppContext(
     <AppContext.Provider
       value={{
         electionDefinition,
-        machineConfig: { machineId, bypassAuthentication },
+        machineConfig: { machineId, codeVersion: 'TEST', bypassAuthentication },
         usbDriveStatus,
         usbDriveEject,
         storage,


### PR DESCRIPTION
Adds the functionality to export in CDF from https://github.com/votingworks/vxsuite/pull/1328 to BSD. 

The screen with the export buttons in bsd is currently only visible when there is an election configured. Do we need to be able to export on an unconfigured machine? 