### PR TITLE
feat(logging) Scripts to generate documentation as cdf and markdown

### DIFF
--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -1,0 +1,320 @@
+
+# VotingWorks Log Documentation
+## Event Types
+Types are logged with each log line to categorize the log.
+### user-action
+**Description:** A log that results from a user taking an action, i.e. an election admin uploading an election definition to a machine.
+### application-status
+**Description:** Status update or message that the application took without user action.
+### system-action
+**Description:** A log that results from the system taking some action, i.e. the machine booting.
+### system-status
+**Description:** A log that results from the system updating on the status of a process it is running, i.e. completion of machine shutdown or boot.
+### application-action
+**Description:** Action taken by the votingworks application automatically when a certain condition is met. Example: When a new USB drive is detected, the application will automatically mount it.
+## Event IDs
+IDs are logged with each log to identify the log being written.
+### election-configured
+**Type:** [user-action](#user-action)  
+**Description:** The user has configured current machine to a new election definition.  
+**Machines:** All
+### election-unconfigured
+**Type:** [user-action](#user-action)  
+**Description:** The user has unconfigured current machine to remove the current election definition, and all other data.  
+**Machines:** All
+### machine-boot-init
+**Type:** [system-action](#system-action)  
+**Description:** The machine is beginning the boot process.  
+**Machines:** All
+### machine-boot-complete
+**Type:** [system-status](#system-status)  
+**Description:** The machine has completed the boot process.  
+**Machines:** All
+### machine-shutdown-init
+**Type:** [system-action](#system-action)  
+**Description:** The machine is beginning the shutdown process to power down or reboot, as indicated by the message.  
+**Machines:** All
+### machine-shutdown-complete
+**Type:** [system-status](#system-status)  
+**Description:** The machine has completed all the steps to shutdown and will now power down or reboot.  
+**Machines:** All
+### usb-device-change-detected
+**Type:** [system-status](#system-status)  
+**Description:** A message from the machine kernel about an externally-connected USB device, usually when a new device is connected or disconnected.  
+**Machines:** All
+### admin-authentication-2fac
+**Type:** [user-action](#user-action)  
+**Description:** Attempt to authenticate an admin user session with a passcode.  
+**Machines:** All
+### machine-locked
+**Type:** [user-action](#user-action)  
+**Description:** The current user was logged out and the machine was locked.  
+**Machines:** All
+### admin-card-inserted
+**Type:** [user-action](#user-action)  
+**Description:** Admin smartcard inserted, the user will be prompted for passcode to complete authentication.  
+**Machines:** All
+### user-session-activation
+**Type:** [user-action](#user-action)  
+**Description:** A user attempted to authenticate as a new user role, disposition and message clarify the user roles and success/failure.  
+**Machines:** All
+### user-logged-out
+**Type:** [user-action](#user-action)  
+**Description:** User logged out of the current session.  
+**Machines:** All
+### usb-drive-status-update
+**Type:** [application-status](#application-status)  
+**Description:** USB Drive detected a status update. Potential USB statuses are: notavailable - No USB Drive detection is available, absent - No USB identified, present - USB identified but not mounted, mounted - USB mounted on device, ejecting - USB in the process of ejecting.   
+**Machines:** All
+### usb-drive-eject-init
+**Type:** [user-action](#user-action)  
+**Description:** A request to eject the current USB drive was given by the user, the usb drive will now be ejected.  
+**Machines:** All
+### usb-drive-eject-complete
+**Type:** [application-status](#application-status)  
+**Description:** The current USB drive finished attempting to ejected. Success or failure indicated by disposition.  
+**Machines:** All
+### usb-drive-mount-init
+**Type:** [application-action](#application-action)  
+**Description:** The USB Drive is attempting to mount. This action is taken automatically by the application when a new USB drive is detected.  
+**Machines:** All
+### usb-drive-mount-complete
+**Type:** [application-status](#application-status)  
+**Description:** USB Drive mount has completed. Success or failure is indicated by the disposition.  
+**Machines:** All
+### application-startup
+**Type:** [application-status](#application-status)  
+**Description:** Application finished starting up, success or failure indicated by disposition.  
+**Machines:** All
+### printer-config-added
+**Type:** [application-status](#application-status)  
+**Description:** Application saw a printer configuration added to the system, current connection status of that printer is logged.  
+**Machines:** All
+### printer-config-removed
+**Type:** [application-status](#application-status)  
+**Description:** Application saw a printer configuration removed from the system.  
+**Machines:** All
+### printer-connection-update
+**Type:** [application-status](#application-status)  
+**Description:** Application saw a change to the connection status of a given configured printer.  
+**Machines:** All
+### device-attached
+**Type:** [application-status](#application-status)  
+**Description:** Application saw a device attached to the system.  
+**Machines:** All
+### device-unattached
+**Type:** [application-status](#application-status)  
+**Description:** Application saw a device unattached from the system.  
+**Machines:** All
+### load-from-storage
+**Type:** [application-action](#application-action)  
+**Description:** A piece of information (current election, imported CVR files, etc.) is loaded from storage. May happen as an automated action when an application starts up, or as a result of a user action.  
+**Machines:** All
+### save-to-storage
+**Type:** [user-action](#user-action)  
+**Description:** A piece of information is saved to storage, usually resulting from a user action for example a user importing CVR files results in those files being saved to storage.  
+**Machines:** All
+### file-saved
+**Type:** [user-action](#user-action)  
+**Description:** File is saved to a USB drive. Success or failure indicated by disposition. Type of file specified with "fileType" key. For success logs the saved filename specified with "filename" key.  
+**Machines:** All
+### export-ballot-package-init
+**Type:** [user-action](#user-action)  
+**Description:** Exporting the ballot package is initiated.  
+**Machines:** vx-admin-frontend
+### export-ballot-package-complete
+**Type:** [user-action](#user-action)  
+**Description:** Exporting the ballot package completed, success or failure is indicated by the disposition.  
+**Machines:** vx-admin-frontend
+### ballot-printed
+**Type:** [user-action](#user-action)  
+**Description:** One or more copies of a ballot were printed. Success or failure indicated by the disposition. Precinct, ballot style, ballot type, number of copies and other details included in log data.  
+**Machines:** vx-admin-frontend
+### printed-ballot-report-printed
+**Type:** [user-action](#user-action)  
+**Description:** Report of all printed ballots was printed. Success or failure indicated by the disposition.  
+**Machines:** vx-admin-frontend
+### smartcard-program-init
+**Type:** [user-action](#user-action)  
+**Description:** A write to smartcard is being initiated.  
+**Machines:** vx-admin-frontend
+### smartcard-programmed
+**Type:** [user-action](#user-action)  
+**Description:** Smartcard is programmed for a new user type. User type is indicated by the programmedUser key. Success or failure is indicated by the disposition.  
+**Machines:** vx-admin-frontend
+### smartcard-programmed-override-write-protection
+**Type:** [user-action](#user-action)  
+**Description:** Smartcard is programmed to override a flag protecting writes on the card. By default admin cards can not be written unless write protection is first overridden.  
+**Machines:** vx-admin-frontend
+### cvr-imported
+**Type:** [user-action](#user-action)  
+**Description:** User imported CVR to the machine. Success or failure indicated by disposition.  
+**Machines:** vx-admin-frontend
+### cvr-files-read-from-usb
+**Type:** [user-action](#user-action)  
+**Description:** User opened import CVR modal and usb is searched for possible CVR files to import.  
+**Machines:** vx-admin-frontend
+### recompute-tally-init
+**Type:** [user-action](#user-action)  
+**Description:** New cast vote record files seen, initiating recomputation of tally data.  
+**Machines:** vx-admin-frontend
+### recompute-tally-complete
+**Type:** [user-action](#user-action)  
+**Description:** Tally recomputed with new cast vote record files, success or failure indicated by disposition.  
+**Machines:** vx-admin-frontend
+### external-tally-file-imported
+**Type:** [user-action](#user-action)  
+**Description:** User imported external tally file to the machine. File type indicated by fileType key. Success or failure indicated by disposition.  
+**Machines:** vx-admin-frontend
+### manual-tally-data-edited
+**Type:** [user-action](#user-action)  
+**Description:** User added or edited manually entered tally data to be included alongside imported Cvr files.  
+**Machines:** vx-admin-frontend
+### marked-tally-results-official
+**Type:** [user-action](#user-action)  
+**Description:** User marked the tally results as official. This disabled importing any more cvr or other tally data files.  
+**Machines:** vx-admin-frontend
+### removed-tally-file
+**Type:** [user-action](#user-action)  
+**Description:** The user removed Cvr, External Tally data, manually entered tally data, or all tally data. The type of file removed specified by the filetype key.  
+**Machines:** vx-admin-frontend
+### tally-report-previewed
+**Type:** [user-action](#user-action)  
+**Description:** Tally Report previewed and viewed in the app.  
+**Machines:** vx-admin-frontend
+### tally-report-printed
+**Type:** [user-action](#user-action)  
+**Description:** Tally Report printed.  
+**Machines:** vx-admin-frontend
+### converting-to-sems
+**Type:** [user-action](#user-action)  
+**Description:** Initiating conversion of tally results to SEMS file format.  
+**Machines:** vx-admin-frontend
+### test-deck-printed
+**Type:** [user-action](#user-action)  
+**Description:** User printed the test deck. Success or failure indicated by disposition.  
+**Machines:** vx-admin-frontend
+### test-deck-tally-report-printed
+**Type:** [user-action](#user-action)  
+**Description:** User printed the test deck tally report. Success or failure indicated by disposition.  
+**Machines:** vx-admin-frontend
+### toggle-test-mode-init
+**Type:** [user-action](#user-action)  
+**Description:** User has initiated toggling between test mode and live mode in the current application.  
+**Machines:** All
+### toggled-test-mode
+**Type:** [user-action](#user-action)  
+**Description:** User has finished toggling between live mode and test mode in the given application. Success or failure is indicated by the disposition.  
+**Machines:** All
+### clear-ballot-data-init
+**Type:** [user-action](#user-action)  
+**Description:** User has initiated clearing ballot data in the current application.  
+**Machines:** vx-batch-scan-frontend, vx-precinct-scan-frontend
+### clear-ballot-data-complete
+**Type:** [user-action](#user-action)  
+**Description:** User has finished clearing ballot data in the given application. Success or failure is indicated by the disposition.  
+**Machines:** vx-batch-scan-frontend, vx-precinct-scan-frontend
+### override-mark-threshold-init
+**Type:** [user-action](#user-action)  
+**Description:** User has initiated overriding the thresholds of when to count marks seen by the scanning module. New mark thresholds specified in the keys `marginal` `definite` and, if defined, `writeInText`.  
+**Machines:** vx-batch-scan-frontend, vx-precinct-scan-frontend
+### override-mark-thresholds-complete
+**Type:** [user-action](#user-action)  
+**Description:** User has finished overriding the thresholds of when to count marks seen by the scanning module. Success or failure is indicated by the disposition. New mark thresholds specified in the keys `marginal` `definite` and, if defined, `writeInText`.  
+**Machines:** vx-batch-scan-frontend, vx-precinct-scan-frontend
+### download-backup-scan-images
+**Type:** [user-action](#user-action)  
+**Description:** User downloaded a backup file of the scanned ballot image files and CVRs. Success or failure indicated by disposition.  
+**Machines:** vx-batch-scan-frontend, vx-precinct-scan-frontend
+### configure-from-ballot-package-init
+**Type:** [user-action](#user-action)  
+**Description:** User had initiated configuring the machine from a ballot package. The ballot package will be loaded from the USB drive, each ballot will be configured, the scanner will be configured, and then the election configuration will be complete.  
+**Machines:** vx-batch-scan-frontend, vx-precinct-scan-frontend
+### ballot-package-files-read-from-usb
+**Type:** [user-action](#user-action)  
+**Description:** List of ballot packages read from usb and displayed to user to import to machine.  
+**Machines:** vx-batch-scan-frontend, vx-precinct-scan-frontend
+### ballot-package-load-from-usb-complete
+**Type:** [user-action](#user-action)  
+**Description:** The ballot package has been read from the USB drive. Success or failure indicated by disposition.  
+**Machines:** vx-batch-scan-frontend, vx-precinct-scan-frontend
+### ballot-configure-machine-complete
+**Type:** [user-action](#user-action)  
+**Description:** The specified ballot has been configured on the machine. Success or failure indicated by disposition. `ballotStyleId`, `precinctId` and `isLiveMode` keys specify details on the ballot configured.  
+**Machines:** vx-batch-scan-frontend, vx-precinct-scan-frontend
+### scanner-configure-complete
+**Type:** [user-action](#user-action)  
+**Description:** The final configuration steps for the scanner for the ballot package have completed. Success or failure indicated by disposition.  
+**Machines:** vx-batch-scan-frontend, vx-precinct-scan-frontend
+### export-cvr-init
+**Type:** [user-action](#user-action)  
+**Description:** User has initiated exporting CVR file to the USB drive.  
+**Machines:** vx-batch-scan-frontend, vx-precinct-scan-frontend
+### export-cvr-complete
+**Type:** [user-action](#user-action)  
+**Description:** User has finished exporting a CVR file of all results to the USB drive. Success or failure indicated by disposition. On success, number of ballots included in CVR specified by `numberOfBallots`.  
+**Machines:** vx-batch-scan-frontend, vx-precinct-scan-frontend
+### delete-cvr-batch-init
+**Type:** [user-action](#user-action)  
+**Description:** User has initiated deleting a scanning batch. Number of ballots in batch specified by keep `numberOfBallotsInBatch`. Batch ID specified by `batchId`  
+**Machines:** vx-batch-scan-frontend
+### delete-cvr-batch-complete
+**Type:** [user-action](#user-action)  
+**Description:** User has completed deleting a scanning batch. Number of ballots in batch specified by keep `numberOfBallotsInBatch`. Batch ID specified by `batchId`.  
+**Machines:** vx-batch-scan-frontend
+### scan-batch-init
+**Type:** [user-action](#user-action)  
+**Description:** The user has begun scanning a new batch of ballots. Success or failure of beginning the process of scanning indicated by disposition. Batch ID for next scanned batch indicated in batchId.  
+**Machines:** vx-batch-scan-frontend
+### scan-sheet-complete
+**Type:** [user-action](#user-action)  
+**Description:** A single sheet in a batch has completed scanning. Success or failure of the scanning indicated by disposition. Ballots rejected due to being unreadable, configured for the wrong election, needed resolution, etc. marked as `failure`. Current batch specified by `batchId` and sheet in batch specified by `sheetCount`.  
+**Machines:** vx-batch-scan-frontend
+### scan-batch-complete
+**Type:** [user-action](#user-action)  
+**Description:** A batch of scanned sheets has finished scanning. Success or failure indicated by disposition.  
+**Machines:** vx-batch-scan-frontend
+### scan-batch-continue
+**Type:** [user-action](#user-action)  
+**Description:** Scanning continued by user after errors and/or warning stopped scanning. Log will indicate if the sheet was tabulated with warnings, or if the user indicated removing the ballot in order to continue scanning.  
+**Machines:** vx-batch-scan-frontend
+### scan-adjudication-info
+**Type:** [application-status](#application-status)  
+**Description:** Information about a ballot sheet that needs adjudication from the user. The possible unresolvable errors are InvalidTestModePage when a test mode ballot is seen when scanning in live mode or vice versa, InvalidElectionHashPage when a sheet for the wrong election is seen, InvalidPrecinctPage when a sheet for an invalid precinct is seen, UninterpretedHmpbPage for a HMPB ballot that could not be read properly, UnreadablePage for a sheet that is unrecognizable as either a HMPB or BMD ballot, and BlankPage for a blank sheet. Warnings that the user can choose to tabulate with a ballot include MarginalMark, Overvote, Undervote, WriteIn, UnmarkedWriteIn, and BlankBallot (a ballot where there are no votes for any contest).  
+**Machines:** vx-batch-scan-frontend
+### scanner-config-reloaded
+**Type:** [application-status](#application-status)  
+**Description:** Configuration information for the machine including the election, if the machine is in test mode, and mark threshold override values were reloaded from the backend service storing this information.  
+**Machines:** vx-batch-scan-frontend, vx-precinct-scan-frontend
+### export-log-file-found
+**Type:** [application-status](#application-status)  
+**Description:** When the user is exporting logs, indicates the success/failure of finding the expected log file on the machine.  
+**Machines:** All
+### scan-service-config
+**Type:** [application-status](#application-status)  
+**Description:** Message from the scanning service about how it is configured while starting up.  
+**Machines:** vx-batch-scan-frontend, vx-precinct-scan-frontend
+### fujitsu-scan-init
+**Type:** [application-action](#application-action)  
+**Description:** Application is initiating a new scanning batch on the fujitsu scanner.  
+**Machines:** vx-batch-scan-frontend
+### fujitsu-scan-sheet-scanned
+**Type:** [application-status](#application-status)  
+**Description:** A scanned image has returned while scanning from a fujitsu scanner, or an error was seen while scanning. Success or failure indicated by disposition.  
+**Machines:** vx-batch-scan-frontend
+### fujitsu-scan-batch-complete
+**Type:** [application-status](#application-status)  
+**Description:** A batch of sheets has completed scanning on the fujitsu scanner.  
+**Machines:** vx-batch-scan-frontend
+### fujitsu-scan-message
+**Type:** [application-status](#application-status)  
+**Description:** Message from the driver handling the fujitsu scanner regarding scanning progress.  
+**Machines:** vx-batch-scan-frontend
+### convert-log-cdf-complete
+**Type:** [user-action](#user-action)  
+**Description:** The user has converted the log file to a CDF format for export. Success or failure indicated by disposition.  
+**Machines:** All
+### convert-log-cdf-log-line-error
+**Type:** [user-action](#user-action)  
+**Description:** Error seen when converting a single log to the CDF format. This log line will be skipped. Disposition of this log is always failure.  
+**Machines:** All

--- a/libs/logging/package.json
+++ b/libs/logging/package.json
@@ -25,7 +25,7 @@
     "pre-commit": "lint-staged"
   },
   "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
+    "*.+(css|graphql|json|less|mdx|sass|scss|yaml|yml)": [
       "prettier --write"
     ],
     "*.+(js|jsx|ts|tsx)": [
@@ -42,12 +42,14 @@
     "@votingworks/types": "workspace:*",
     "@votingworks/utils": "workspace:*",
     "debug": "^4.3.2",
+    "yargs": "^16.2.0",
     "zod": "3.2.0"
   },
   "devDependencies": {
     "@types/debug": "^4.1.6",
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^27.0.3",
+    "@types/yargs": "^16.0.0",
     "@typescript-eslint/eslint-plugin": "^4.28.4",
     "@typescript-eslint/parser": "^4.28.4",
     "@votingworks/fixtures": "workspace:*",

--- a/libs/logging/scripts/generate_documentation.ts
+++ b/libs/logging/scripts/generate_documentation.ts
@@ -1,0 +1,110 @@
+import { safeParse } from '@votingworks/types';
+import { throwIllegalValue } from '@votingworks/utils';
+import yargs from 'yargs/yargs';
+import * as fs from 'fs';
+import { CLIENT_SIDE_LOG_SOURCES, LogSource, LogSourceSchema } from '../src';
+import {
+  generateCdfLogDocumentationFileContent,
+  generateMarkdownDocumentationContent,
+} from '../src/log_documentation';
+
+const DEFAULT_MARKDOWN_LOCATION = 'VotingWorksLoggingDocumentation.md';
+const VOTING_WORKS = 'VotingWorks';
+
+function writeCdfDocumentationForApp(
+  app: LogSource,
+  modelName: string,
+  outputPath?: string
+) {
+  const fileContent = generateCdfLogDocumentationFileContent(
+    app,
+    modelName,
+    VOTING_WORKS
+  );
+  fs.writeFileSync(
+    outputPath ?? `${app}-cdf-log-documentation.json`,
+    fileContent
+  );
+}
+
+function writeMarkdownDocumentation(outputPath?: string) {
+  const fileContent = generateMarkdownDocumentationContent();
+  fs.writeFileSync(outputPath ?? DEFAULT_MARKDOWN_LOCATION, fileContent);
+}
+
+interface GenerateDocumentationFileArguments {
+  output?: string;
+  format: 'cdf' | 'markdown';
+  frontend?: string;
+  model?: string;
+}
+const args: GenerateDocumentationFileArguments = yargs(
+  process.argv.slice(2)
+).options({
+  output: {
+    type: 'string',
+    alias: 'o',
+    description: 'Path to write output file to',
+  },
+  format: {
+    choices: ['cdf', 'markdown'] as const,
+    alias: 'f',
+    default: 'markdown',
+  },
+  frontend: {
+    type: 'string',
+    description:
+      'When writing in the CDF format you must specify which frontend app to build the documentation for.',
+  },
+  model: {
+    type: 'string',
+    description:
+      'When writing in the CDF format you must specify a model name such as VxAdmin 1.0 .',
+  },
+}).argv as GenerateDocumentationFileArguments;
+
+function validateFrontendInput(frontend?: string): LogSource {
+  if (frontend === undefined) {
+    process.stderr.write(
+      'Specify a frontend app with --frontend when writing in the CDF format.'
+    );
+    process.exit(-1);
+  }
+  const result = safeParse(LogSourceSchema, frontend);
+  if (result.isErr()) {
+    process.stderr.write(
+      `Invalid input for frontend app specified: ${frontend}`
+    );
+    process.exit(-1);
+  }
+  const logSource = result.ok();
+  if (!CLIENT_SIDE_LOG_SOURCES.includes(logSource)) {
+    process.stderr.write(
+      `${frontend} is not a frontend app, documentation can only be generated for valid frontend apps.`
+    );
+    process.exit(-1);
+  }
+  return logSource;
+}
+
+switch (args.format) {
+  case 'cdf': {
+    if (args.model === undefined) {
+      process.stderr.write(
+        'Specify a model name with --model when writing in the CDF format.'
+      );
+      process.exit(-1);
+    }
+    writeCdfDocumentationForApp(
+      validateFrontendInput(args.frontend),
+      args.model,
+      args.output
+    );
+    break;
+  }
+  case 'markdown':
+    writeMarkdownDocumentation(args.output);
+    break;
+  default:
+    throwIllegalValue(args.format);
+}

--- a/libs/logging/src/log_documentation.test.ts
+++ b/libs/logging/src/log_documentation.test.ts
@@ -1,0 +1,101 @@
+import { ElectionEventLogDocumentationSchema } from '@votingworks/cdf-types-election-event-logging';
+import { safeParseJson } from '@votingworks/types';
+import { assert } from '@votingworks/utils';
+import MockDate from 'mockdate';
+import * as fs from 'fs';
+import { LogEventId } from './log_event_ids';
+import {
+  generateCdfLogDocumentationFileContent,
+  generateMarkdownDocumentationContent,
+} from './log_documentation';
+import { LogSource } from './log_source';
+
+MockDate.set('2020-07-24T00:00:00.000Z');
+
+describe('test cdf documentation generation', () => {
+  test('builds expected documentation for VxAdminFrontend', () => {
+    const cdfDocumentationContent = generateCdfLogDocumentationFileContent(
+      LogSource.VxAdminFrontend,
+      'VxAdmin 1.0',
+      'VotingWorks'
+    );
+    const structuredDataResult = safeParseJson(
+      cdfDocumentationContent,
+      ElectionEventLogDocumentationSchema
+    );
+    const structuredData = structuredDataResult.unsafeUnwrap();
+    expect(structuredData.DeviceManufacturer).toBe('VotingWorks');
+    expect(structuredData.DeviceModel).toBe('VxAdmin 1.0');
+    expect(structuredData.GeneratedDate).toBe('2020-07-24T00:00:00.000Z');
+    expect(structuredData.EventTypeDescription).toHaveLength(5);
+    expect(structuredData.EventIdDescription).toHaveLength(51);
+    // Make sure VxAdminFrontend specific logs are included.
+    expect(structuredData.EventIdDescription).toContainEqual(
+      expect.objectContaining({
+        Id: LogEventId.CvrImported,
+      })
+    );
+    // Make sure a generic log to all apps is included
+    expect(structuredData.EventIdDescription).toContainEqual(
+      expect.objectContaining({
+        Id: LogEventId.MachineBootInit,
+      })
+    );
+    // Make sure VxBatchScanFrontend specific logs are NOT included
+    expect(structuredData.EventIdDescription).not.toContainEqual(
+      expect.objectContaining({
+        Id: LogEventId.ScannerConfigured,
+      })
+    );
+  });
+
+  test('builds expected documentation for VxBatchScanFrontend', () => {
+    const cdfDocumentationContent = generateCdfLogDocumentationFileContent(
+      LogSource.VxBatchScanFrontend,
+      'VxScan',
+      'V oting Works'
+    );
+    const structuredDataResult = safeParseJson(
+      cdfDocumentationContent,
+      ElectionEventLogDocumentationSchema
+    );
+    expect(structuredDataResult.isOk()).toBeTruthy();
+    const structuredData = structuredDataResult.ok();
+    assert(structuredData);
+    expect(structuredData.DeviceManufacturer).toBe('V oting Works');
+    expect(structuredData.DeviceModel).toBe('VxScan');
+    expect(structuredData.GeneratedDate).toBe('2020-07-24T00:00:00.000Z');
+    expect(structuredData.EventTypeDescription).toHaveLength(5);
+    expect(structuredData.EventIdDescription).toHaveLength(56);
+    // Make sure VxBatchApp specific logs are included.
+    expect(structuredData.EventIdDescription).toContainEqual(
+      expect.objectContaining({
+        Id: LogEventId.ScannerConfigured,
+      })
+    );
+    // Make sure a generic log to all apps is included
+    expect(structuredData.EventIdDescription).toContainEqual(
+      expect.objectContaining({
+        Id: LogEventId.MachineBootInit,
+      })
+    );
+    // Make sure VxAdminFrontend specific logs are NOT included
+    expect(structuredData.EventIdDescription).not.toContainEqual(
+      expect.objectContaining({
+        Id: LogEventId.CvrImported,
+      })
+    );
+  });
+});
+
+describe('test markdown documentation generation', () => {
+  test('generated documentation is up to date you need to run `pnpx ts-node scripts/generate_documentation.ts` if this fails', () => {
+    const generatedFileContent = generateMarkdownDocumentationContent();
+    const currentDocumentationContent = fs.readFileSync(
+      'VotingWorksLoggingDocumentation.md'
+    );
+    expect(generatedFileContent).toEqual(
+      currentDocumentationContent.toString()
+    );
+  });
+});

--- a/libs/logging/src/log_documentation.ts
+++ b/libs/logging/src/log_documentation.ts
@@ -1,0 +1,83 @@
+import {
+  ElectionEventLogDocumentation,
+  EventIdDescription,
+  EventTypeDescription,
+} from '@votingworks/cdf-types-election-event-logging';
+import { getDetailsForEventId, LogDetails, LogEventId } from './log_event_ids';
+import {
+  getDocumentationForEventType,
+  LogEventType,
+  LogEventTypeDocumentation,
+} from './log_event_types';
+import { LogSource } from './log_source';
+
+export function generateMarkdownDocumentationContent(): string {
+  const allEventTypes: LogEventTypeDocumentation[] = Object.values(
+    LogEventType
+  ).map((eventType) => getDocumentationForEventType(eventType));
+  const allEventIdsForDevice: LogDetails[] = Object.values(LogEventId).map(
+    (eventId) => getDetailsForEventId(eventId)
+  );
+  return `
+# VotingWorks Log Documentation
+## Event Types
+Types are logged with each log line to categorize the log.
+${allEventTypes
+  .map(
+    (details) => `### ${details.eventType}
+**Description:** ${details.documentationMessage}`
+  )
+  .join('\n')}
+## Event IDs
+IDs are logged with each log to identify the log being written.
+${allEventIdsForDevice
+  .map(
+    (details) =>
+      `### ${details.eventId}
+**Type:** [${details.eventType}](#${details.eventType})  
+**Description:** ${details.documentationMessage}  
+**Machines:** ${
+        details.restrictInDocumentationToApps
+          ? details.restrictInDocumentationToApps.join(', ')
+          : 'All'
+      }`
+  )
+  .join('\n')}`;
+}
+
+export function generateCdfLogDocumentationFileContent(
+  appType: LogSource,
+  machineModel: string,
+  machineManufacturer: string
+): string {
+  const allEventTypes: EventTypeDescription[] = Object.values(LogEventType).map(
+    (eventType) => {
+      const eventTypeInformation = getDocumentationForEventType(eventType);
+      return {
+        Description: eventTypeInformation.documentationMessage,
+        Type: eventType,
+      };
+    }
+  );
+  const allEventIdsForDevice: EventIdDescription[] = Object.values(LogEventId)
+    .map((eventId) => getDetailsForEventId(eventId))
+    .filter(
+      (eventIdDetails) =>
+        eventIdDetails.restrictInDocumentationToApps === undefined ||
+        eventIdDetails.restrictInDocumentationToApps.includes(appType)
+    )
+    .map((eventIdDetails) => {
+      return {
+        Id: eventIdDetails.eventId,
+        Description: eventIdDetails.documentationMessage,
+      };
+    });
+  const documentationLog: ElectionEventLogDocumentation = {
+    DeviceManufacturer: machineManufacturer,
+    DeviceModel: machineModel,
+    EventIdDescription: allEventIdsForDevice,
+    EventTypeDescription: allEventTypes,
+    GeneratedDate: new Date().toISOString(),
+  };
+  return JSON.stringify(documentationLog);
+}

--- a/libs/logging/src/log_event_ids.ts
+++ b/libs/logging/src/log_event_ids.ts
@@ -72,7 +72,7 @@ export enum LogEventId {
   ClearedBallotData = 'clear-ballot-data-complete',
   OverridingMarkThresholds = 'override-mark-threshold-init',
   OverrodeMarkThresholds = 'override-mark-thresholds-complete',
-  DownloadedScanImageBackup = 'download-backup-scan-images,',
+  DownloadedScanImageBackup = 'download-backup-scan-images',
   ConfigureFromBallotPackageInit = 'configure-from-ballot-package-init',
   BallotPackageFilesReadFromUsb = 'ballot-package-files-read-from-usb',
   BallotPackagedLoadedFromUsb = 'ballot-package-load-from-usb-complete',

--- a/libs/logging/src/logger.test.ts
+++ b/libs/logging/src/logger.test.ts
@@ -6,10 +6,7 @@ import MockDate from 'mockdate';
 import { join } from 'path';
 import { safeParseJson } from '@votingworks/types';
 import { assert } from '@votingworks/utils';
-import {
-  ElectionEventLogDocumentationSchema,
-  ElectionEventLogSchema,
-} from '@votingworks/cdf-types-election-event-logging';
+import { ElectionEventLogSchema } from '@votingworks/cdf-types-election-event-logging';
 import { LogEventId } from './log_event_ids';
 import { Logger } from './logger';
 import { LogEventType } from './log_event_types';
@@ -398,89 +395,5 @@ describe('test cdf conversion', () => {
         "UserId": "system",
       }
     `);
-  });
-});
-
-describe('test cdf documentation generation', () => {
-  test('builds expected documentation for VxAdminFrontend', () => {
-    const logger = new Logger(LogSource.VxAdminFrontend);
-    const cdfDocumentationContent = logger.buildCDFLogDocumentationFileContent(
-      'machineID1234',
-      'VotingWorks',
-      'VxAdmin 1.0',
-      'codeversion'
-    );
-    const structuredDataResult = safeParseJson(
-      cdfDocumentationContent,
-      ElectionEventLogDocumentationSchema
-    );
-    const structuredData = structuredDataResult.unsafeUnwrap();
-    expect(structuredData.DeviceId).toBe('machineID1234');
-    expect(structuredData.DeviceManufacturer).toBe('VotingWorks');
-    expect(structuredData.DeviceModel).toBe('VxAdmin 1.0');
-    expect(structuredData.DeviceVersion).toBe('codeversion');
-    expect(structuredData.GeneratedDate).toBe('2020-07-24T00:00:00.000Z');
-    expect(structuredData.EventTypeDescription).toHaveLength(5);
-    expect(structuredData.EventIdDescription).toHaveLength(51);
-    // Make sure VxAdminFrontend specific logs are included.
-    expect(structuredData.EventIdDescription).toContainEqual(
-      expect.objectContaining({
-        Id: LogEventId.CvrImported,
-      })
-    );
-    // Make sure a generic log to all apps is included
-    expect(structuredData.EventIdDescription).toContainEqual(
-      expect.objectContaining({
-        Id: LogEventId.MachineBootInit,
-      })
-    );
-    // Make sure VxBatchScanFrontend specific logs are NOT included
-    expect(structuredData.EventIdDescription).not.toContainEqual(
-      expect.objectContaining({
-        Id: LogEventId.ScannerConfigured,
-      })
-    );
-  });
-
-  test('builds expected documentation for VxBatchScanFrontend', () => {
-    const logger = new Logger(LogSource.VxBatchScanFrontend);
-    const cdfDocumentationContent = logger.buildCDFLogDocumentationFileContent(
-      '314159',
-      'V oting Works',
-      'VxScan',
-      'this is code 12.54.12'
-    );
-    const structuredDataResult = safeParseJson(
-      cdfDocumentationContent,
-      ElectionEventLogDocumentationSchema
-    );
-    expect(structuredDataResult.isOk()).toBeTruthy();
-    const structuredData = structuredDataResult.ok();
-    assert(structuredData);
-    expect(structuredData.DeviceId).toBe('314159');
-    expect(structuredData.DeviceManufacturer).toBe('V oting Works');
-    expect(structuredData.DeviceModel).toBe('VxScan');
-    expect(structuredData.DeviceVersion).toBe('this is code 12.54.12');
-    expect(structuredData.GeneratedDate).toBe('2020-07-24T00:00:00.000Z');
-    expect(structuredData.EventTypeDescription).toHaveLength(5);
-    expect(structuredData.EventIdDescription).toHaveLength(56);
-    // Make sure VxBatchApp specific logs are included.
-    expect(structuredData.EventIdDescription).toContainEqual(
-      expect.objectContaining({
-        Id: LogEventId.ScannerConfigured,
-      })
-    );
-    // Make sure a generic log to all apps is included
-    expect(structuredData.EventIdDescription).toContainEqual(
-      expect.objectContaining({
-        Id: LogEventId.MachineBootInit,
-      })
-    );
-    // Make sure VxAdminFrontend specific logs are NOT included
-    expect(structuredData.EventIdDescription).not.toContainEqual(
-      expect.objectContaining({
-        Id: LogEventId.CvrImported,
-      })
-    );
   });
 });

--- a/libs/logging/src/logger.ts
+++ b/libs/logging/src/logger.ts
@@ -10,11 +10,8 @@ import { assert } from '@votingworks/utils';
 import {
   Device,
   ElectionEventLog,
-  ElectionEventLogDocumentation,
   Event,
   EventDispositionType,
-  EventIdDescription,
-  EventTypeDescription,
 } from '@votingworks/cdf-types-election-event-logging';
 import {
   LogLine,
@@ -26,7 +23,6 @@ import {
 } from './types';
 import { CLIENT_SIDE_LOG_SOURCES, LogSource } from './log_source';
 import { LogEventId, getDetailsForEventId } from './log_event_ids';
-import { getDocumentationForEventType, LogEventType } from './log_event_types';
 
 export const LOGS_ROOT_LOCATION = '/var/log';
 export const LOG_NAME = 'vx-logs';
@@ -184,46 +180,5 @@ export class Logger {
       disposition: 'success',
     });
     return JSON.stringify(eventElectionLog);
-  }
-
-  buildCDFLogDocumentationFileContent(
-    // Once we have a common type for MachineConfig with model/manufacturer it will likely make more sense to just pass that in.
-    machineId: string,
-    machineManufacturer: string,
-    machineModel: string,
-    codeVersion: string
-  ): string {
-    const allEventTypes: EventTypeDescription[] = Object.values(
-      LogEventType
-    ).map((eventType) => {
-      const eventTypeInformation = getDocumentationForEventType(eventType);
-      return {
-        Description: eventTypeInformation.documentationMessage,
-        Type: eventType,
-      };
-    });
-    const allEventIdsForDevice: EventIdDescription[] = Object.values(LogEventId)
-      .map((eventId) => getDetailsForEventId(eventId))
-      .filter(
-        (eventIdDetails) =>
-          eventIdDetails.restrictInDocumentationToApps === undefined ||
-          eventIdDetails.restrictInDocumentationToApps.includes(this.source)
-      )
-      .map((eventIdDetails) => {
-        return {
-          Id: eventIdDetails.eventId,
-          Description: eventIdDetails.documentationMessage,
-        };
-      });
-    const documentationLog: ElectionEventLogDocumentation = {
-      DeviceId: machineId,
-      DeviceManufacturer: machineManufacturer,
-      DeviceModel: machineModel,
-      DeviceVersion: codeVersion,
-      EventIdDescription: allEventIdsForDevice,
-      EventTypeDescription: allEventTypes,
-      GeneratedDate: new Date().toISOString(),
-    };
-    return JSON.stringify(documentationLog);
   }
 }

--- a/libs/logging/tsconfig.json
+++ b/libs/logging/tsconfig.json
@@ -15,7 +15,7 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true
   },
-  "include": ["src"],
+  "include": ["src", "scripts"],
   "exclude": [],
   "references": [
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,7 +194,7 @@ importers:
       dompurify: 2.2.6
       fetch-mock: 9.11.0
       history: 4.10.1
-      http-proxy-middleware: 1.0.6_debug@4.3.2
+      http-proxy-middleware: 1.0.6
       lodash.camelcase: 4.3.0
       luxon: 1.26.0
       mockdate: 3.0.2
@@ -542,7 +542,7 @@ importers:
       dompurify: 2.2.6
       fetch-mock: 9.11.0
       history: 4.10.1
-      http-proxy-middleware: 1.0.6_debug@4.3.2
+      http-proxy-middleware: 1.0.6
       i18next: 19.8.4
       js-file-download: 0.4.12
       js-sha256: 0.9.0
@@ -725,7 +725,7 @@ importers:
       base64-js: 1.5.1
       debug: 4.3.1
       fetch-mock: 9.11.0
-      http-proxy-middleware: 1.0.6_debug@4.3.1
+      http-proxy-middleware: 1.0.6
       i18next: 19.8.4
       jest-fetch-mock: 3.0.3
       js-file-download: 0.4.12
@@ -1372,11 +1372,13 @@ importers:
       '@votingworks/types': link:../types
       '@votingworks/utils': link:../utils
       debug: 4.3.2
+      yargs: 16.2.0
       zod: 3.2.0
     devDependencies:
       '@types/debug': 4.1.7
       '@types/fs-extra': 9.0.13
       '@types/jest': 27.0.3
+      '@types/yargs': 16.0.4
       '@typescript-eslint/eslint-plugin': 4.30.0_30d5b6043eb1943afef560c3f2647d4d
       '@typescript-eslint/parser': 4.29.3_eslint@7.29.0+typescript@4.3.5
       '@votingworks/fixtures': link:../fixtures
@@ -1405,6 +1407,7 @@ importers:
       '@types/jest': ^27.0.3
       '@types/kiosk-browser': workspace:*
       '@types/node': ^12.20.11
+      '@types/yargs': ^16.0.0
       '@typescript-eslint/eslint-plugin': ^4.28.4
       '@typescript-eslint/parser': ^4.28.4
       '@votingworks/cdf-types-election-event-logging': workspace:*
@@ -1431,6 +1434,7 @@ importers:
       sort-package-json: ^1.50.0
       ts-jest: ^27.0.7
       typescript: ^4.3.5
+      yargs: ^16.2.0
       zod: 3.2.0
   libs/lsd:
     dependencies:
@@ -5431,7 +5435,7 @@ packages:
       jest-regex-util: 27.0.6
       jest-resolve: 27.3.1
       jest-resolve-dependencies: 27.3.1
-      jest-runner: 27.3.1_canvas@2.6.1
+      jest-runner: 27.3.1
       jest-runtime: 27.3.1
       jest-snapshot: 27.3.1
       jest-util: 27.3.1
@@ -5472,7 +5476,7 @@ packages:
       jest-regex-util: 27.0.6
       jest-resolve: 27.3.1
       jest-resolve-dependencies: 27.3.1
-      jest-runner: 27.3.1_canvas@2.6.1
+      jest-runner: 27.3.1
       jest-runtime: 27.3.1
       jest-snapshot: 27.3.1
       jest-util: 27.3.1
@@ -9541,7 +9545,7 @@ packages:
       integrity: sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA==
   /axios/0.21.1_debug@4.3.1:
     dependencies:
-      follow-redirects: 1.14.1_debug@4.3.1
+      follow-redirects: 1.14.1_debug@4.3.2
     dev: true
     peerDependencies:
       debug: '*'
@@ -15484,6 +15488,7 @@ packages:
   /follow-redirects/1.14.1_debug@4.3.1:
     dependencies:
       debug: 4.3.1
+    dev: false
     engines:
       node: '>=4.0'
     peerDependencies:
@@ -15495,8 +15500,7 @@ packages:
       integrity: sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
   /follow-redirects/1.14.1_debug@4.3.2:
     dependencies:
-      debug: 4.3.2
-    dev: false
+      debug: 4.3.2_supports-color@6.1.0
     engines:
       node: '>=4.0'
     peerDependencies:
@@ -16425,34 +16429,6 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
-  /http-proxy-middleware/1.0.6_debug@4.3.1:
-    dependencies:
-      '@types/http-proxy': 1.17.6
-      http-proxy: 1.18.1_debug@4.3.1
-      is-glob: 4.0.1
-      lodash: 4.17.21
-      micromatch: 4.0.4
-    dev: false
-    engines:
-      node: '>=8.0.0'
-    peerDependencies:
-      debug: '*'
-    resolution:
-      integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
-  /http-proxy-middleware/1.0.6_debug@4.3.2:
-    dependencies:
-      '@types/http-proxy': 1.17.6
-      http-proxy: 1.18.1_debug@4.3.2
-      is-glob: 4.0.1
-      lodash: 4.17.21
-      micromatch: 4.0.4
-    dev: false
-    engines:
-      node: '>=8.0.0'
-    peerDependencies:
-      debug: '*'
-    resolution:
-      integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
   /http-proxy/1.18.1:
     dependencies:
       eventemitter3: 4.0.7
@@ -16461,18 +16437,6 @@ packages:
     dev: false
     engines:
       node: '>=8.0.0'
-    resolution:
-      integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
-  /http-proxy/1.18.1_debug@4.3.1:
-    dependencies:
-      eventemitter3: 4.0.7
-      follow-redirects: 1.14.1_debug@4.3.1
-      requires-port: 1.0.0
-    dev: false
-    engines:
-      node: '>=8.0.0'
-    peerDependencies:
-      debug: '*'
     resolution:
       integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
   /http-proxy/1.18.1_debug@4.3.2:
@@ -17827,7 +17791,7 @@ packages:
       jest-jasmine2: 27.3.1
       jest-regex-util: 27.0.6
       jest-resolve: 27.3.1
-      jest-runner: 27.3.1_canvas@2.6.1
+      jest-runner: 27.3.1
       jest-util: 27.3.1
       jest-validate: 27.3.1
       micromatch: 4.0.4
@@ -17861,7 +17825,7 @@ packages:
       jest-jasmine2: 27.3.1
       jest-regex-util: 27.0.6
       jest-resolve: 27.3.1
-      jest-runner: 27.3.1_canvas@2.6.1
+      jest-runner: 27.3.1
       jest-util: 27.3.1
       jest-validate: 27.3.1
       micromatch: 4.0.4
@@ -18872,37 +18836,6 @@ packages:
     dev: true
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
-    resolution:
-      integrity: sha512-r4W6kBn6sPr3TBwQNmqE94mPlYVn7fLBseeJfo4E2uCTmAyDFm2O5DYAQAFP7Q3YfiA/bMwg8TVsciP7k0xOww==
-  /jest-runner/27.3.1_canvas@2.6.1:
-    dependencies:
-      '@jest/console': 27.3.1
-      '@jest/environment': 27.3.1
-      '@jest/test-result': 27.3.1
-      '@jest/transform': 27.3.1
-      '@jest/types': 27.2.5
-      '@types/node': 15.3.0
-      chalk: 4.1.2
-      emittery: 0.8.1
-      exit: 0.1.2
-      graceful-fs: 4.2.4
-      jest-docblock: 27.0.6
-      jest-environment-jsdom: 27.3.1_canvas@2.6.1
-      jest-environment-node: 27.3.1
-      jest-haste-map: 27.3.1
-      jest-leak-detector: 27.3.1
-      jest-message-util: 27.3.1
-      jest-resolve: 27.3.1
-      jest-runtime: 27.3.1
-      jest-util: 27.3.1
-      jest-worker: 27.3.1
-      source-map-support: 0.5.20
-      throat: 6.0.1
-    dev: true
-    engines:
-      node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
-    peerDependencies:
-      canvas: '*'
     resolution:
       integrity: sha512-r4W6kBn6sPr3TBwQNmqE94mPlYVn7fLBseeJfo4E2uCTmAyDFm2O5DYAQAFP7Q3YfiA/bMwg8TVsciP7k0xOww==
   /jest-runner/27.4.5:


### PR DESCRIPTION
When I build the code for the documentation for logs in CDF format before I assumed it would be included in the CDF export from the apps. However after talking to Monica I realized this is something we will just provide separately for each machine. So I moved that code a bit and made a script to generate those files when we need them. I also added the ability to generate documentation in markdown format, primarily for our internal use but it may be useful more broadly. That generated file is stored in the repo for reference and there is a test to make sure it stays up to date. 