### PR TITLE
feat(cdf): add support for relationships

### DIFF
--- a/libs/cdf-schema-builder/.eslintrc.json
+++ b/libs/cdf-schema-builder/.eslintrc.json
@@ -1,3 +1,11 @@
 {
-  "extends": ["plugin:vx/recommended"]
+  "extends": ["plugin:vx/recommended"],
+  "overrides": [
+    {
+      "files": ["**/*.test.ts"],
+      "rules": {
+        "vx/gts-identifiers": ["error", { "allowedNames": ["$schema", "$id", "$ref"] }]
+      }
+    }
+  ]
 }

--- a/libs/cdf-schema-builder/bin/cdf-schema-builder
+++ b/libs/cdf-schema-builder/bin/cdf-schema-builder
@@ -9,11 +9,14 @@ const { buildSchema } = require('..')
  * @param {NodeJS.WritableStream} out
  */
 function usage(out) {
-  out.write(`Usage: cdf-schema-builder SCHEMA_FILE\n`);
+  out.write(`Usage: cdf-schema-builder <schema.xml> <schema.json>\n`);
 }
 
 /** @type {string | undefined} */
-let schemaFilePath;
+let xsdSchemaFilePath;
+
+/** @type {string | undefined} */
+let jsonSchemaFilePath;
 
 for (let i = 2; i < process.argv.length; i++) {
   const arg = process.argv[i];
@@ -27,18 +30,24 @@ for (let i = 2; i < process.argv.length; i++) {
       if (arg.startsWith('-')) {
         process.stderr.write(`error: unknown option: ${arg}\n`);
         usage(process.stderr);
+      } else if (arg.endsWith('.xsd') || arg.endsWith('.xml')) {
+        xsdSchemaFilePath = arg;
+      } else if (arg.endsWith('.json')) {
+        jsonSchemaFilePath = arg;
       } else {
-        schemaFilePath = arg;
+        process.stderr.write(`error: unknown file extension: ${arg}\n`);
+        usage(process.stderr);
       }
     }
   }
 }
 
-if (!schemaFilePath) {
-  process.stderr.write('error: no schema file path specified\n');
+if (!xsdSchemaFilePath || !jsonSchemaFilePath) {
+  process.stderr.write('error: missing XSD or JSON schema file path\n');
   usage(process.stderr);
   process.exit(1);
 }
 
-const schemaFileContents = readFileSync(schemaFilePath, 'utf-8')
-buildSchema(schemaFileContents, process.stdout); 
+const xsdSchemaFileContents = readFileSync(xsdSchemaFilePath, 'utf-8');
+const jsonSchemaFileContents = readFileSync(jsonSchemaFilePath, 'utf-8');
+buildSchema(xsdSchemaFileContents, jsonSchemaFileContents, process.stdout); 

--- a/libs/cdf-schema-builder/package.json
+++ b/libs/cdf-schema-builder/package.json
@@ -39,11 +39,13 @@
   "dependencies": {
     "@votingworks/types": "workspace:*",
     "@votingworks/utils": "workspace:*",
-    "jsdom": "^19.0.0"
+    "jsdom": "^19.0.0",
+    "json-schema": "^0.4.0"
   },
   "devDependencies": {
     "@types/jest": "^27.0.3",
     "@types/jsdom": "^16.2.13",
+    "@types/json-schema": "^7.0.9",
     "@types/node": "^14.14.20",
     "@typescript-eslint/eslint-plugin": "^4.29.3",
     "@typescript-eslint/parser": "^4.29.3",

--- a/libs/cdf-schema-builder/src/docs.test.ts
+++ b/libs/cdf-schema-builder/src/docs.test.ts
@@ -1,0 +1,37 @@
+import { findDocForProperty, findDocForType } from './docs';
+import { DocumentedEntity } from './types';
+
+test('findDocForType', () => {
+  const docs: DocumentedEntity[] = [
+    {
+      kind: 'DocumentedType',
+      type: 'test',
+      documentation: 'test',
+    },
+  ];
+  expect(findDocForType(docs, 'test')).toEqual(docs[0]);
+  expect(findDocForType(docs, 'missing')).toBeUndefined();
+});
+
+test('findDocForProperty', () => {
+  const docs: DocumentedEntity[] = [
+    {
+      kind: 'DocumentedType',
+      type: 'test',
+      documentation: 'test',
+    },
+    {
+      kind: 'DocumentedProperty',
+      type: 'test',
+      name: 'prop',
+      documentation: 'test',
+    },
+    {
+      kind: 'DocumentedType',
+      type: 'subtype',
+      extends: 'test',
+    },
+  ];
+  expect(findDocForProperty(docs, 'test', 'prop')).toEqual(docs[1]);
+  expect(findDocForProperty(docs, 'subtype', 'prop')).toEqual(docs[1]);
+});

--- a/libs/cdf-schema-builder/src/docs.ts
+++ b/libs/cdf-schema-builder/src/docs.ts
@@ -1,0 +1,39 @@
+import { DocumentedEntity, DocumentedProperty, DocumentedType } from './types';
+
+/**
+ * Finds the documentation for a given type.
+ */
+export function findDocForType(
+  docs: DocumentedEntity[],
+  typeName: string
+): DocumentedType | undefined {
+  return docs.find(
+    (doc): doc is DocumentedType =>
+      doc.kind === 'DocumentedType' && doc.type === typeName
+  );
+}
+
+/**
+ * Finds the documentation for a given property.
+ */
+export function findDocForProperty(
+  docs: DocumentedEntity[],
+  typeName: string,
+  propertyName: string
+): DocumentedProperty | undefined {
+  const directDoc = docs.find(
+    (doc): doc is DocumentedProperty =>
+      doc.kind === 'DocumentedProperty' &&
+      doc.type === typeName &&
+      doc.name === propertyName
+  );
+
+  if (directDoc) {
+    return directDoc;
+  }
+
+  const typeDoc = findDocForType(docs, typeName);
+  if (typeDoc?.extends) {
+    return findDocForProperty(docs, typeDoc.extends, propertyName);
+  }
+}

--- a/libs/cdf-schema-builder/src/json_schema.test.ts
+++ b/libs/cdf-schema-builder/src/json_schema.test.ts
@@ -1,0 +1,118 @@
+import { typedAs } from '@votingworks/utils';
+import { JSONSchema4 } from 'json-schema';
+import {
+  convertToGenericType,
+  createEnumFromDefinition,
+  createInterfaceFromDefinition,
+  parseJsonSchema,
+} from './json_schema';
+import { Enum, Interface, Type } from './types';
+
+test('parseJsonSchema', () => {
+  expect(parseJsonSchema(`{`).unsafeUnwrapErr()).toBeInstanceOf(SyntaxError);
+  parseJsonSchema(
+    JSON.stringify(
+      typedAs<JSONSchema4>({
+        $schema: 'http://json-schema.org/draft-04/schema#',
+      })
+    )
+  ).unsafeUnwrap();
+});
+
+test('createEnumFromDefinition', () => {
+  expect(createEnumFromDefinition('foo', {})).toBeUndefined();
+  expect(
+    createEnumFromDefinition('foo', { type: 'string', enum: ['a', 'b'] })
+  ).toEqual(
+    typedAs<Enum>({
+      name: 'foo',
+      values: [
+        {
+          name: 'A',
+          value: 'a',
+        },
+        {
+          name: 'B',
+          value: 'b',
+        },
+      ],
+    })
+  );
+});
+
+test('convertToGenericType', () => {
+  expect(convertToGenericType({ type: 'string' })).toEqual(
+    typedAs<Type>({ kind: 'string' })
+  );
+  expect(convertToGenericType({ type: 'string', enum: ['a', 'b'] })).toEqual(
+    typedAs<Type>({
+      kind: 'union',
+      types: [
+        { kind: 'literal', value: 'a' },
+        { kind: 'literal', value: 'b' },
+      ],
+    })
+  );
+  expect(convertToGenericType({ type: 'boolean' })).toEqual(
+    typedAs<Type>({ kind: 'boolean' })
+  );
+  expect(convertToGenericType({ type: 'integer' })).toEqual(
+    typedAs<Type>({ kind: 'integer' })
+  );
+  expect(convertToGenericType({ type: 'number' })).toEqual(
+    typedAs<Type>({ kind: 'number' })
+  );
+  expect(
+    convertToGenericType({ type: 'array', items: { type: 'string' } })
+  ).toEqual(
+    typedAs<Type>({
+      kind: 'array',
+      items: { kind: 'string' },
+    })
+  );
+  expect(convertToGenericType({ $ref: '#/definitions/foo' })).toEqual({
+    kind: 'reference',
+    name: 'foo',
+  });
+  expect(convertToGenericType({ oneOf: [{ type: 'string' }] })).toEqual({
+    kind: 'union',
+    types: [{ kind: 'string' }],
+  });
+  // @ts-expect-error - validate that 'not a type' is not a valid type
+  expect(() => convertToGenericType({ type: 'not a type' })).toThrow(
+    'Unsupported schema type: not a type'
+  );
+});
+
+test('createInterfaceFromDefinition', () => {
+  expect(
+    createInterfaceFromDefinition('Person', {
+      type: 'object',
+      additionalProperties: false,
+    })
+  ).toEqual(
+    typedAs<Interface>({
+      name: 'Person',
+      properties: [],
+    })
+  );
+  expect(
+    createInterfaceFromDefinition('Person', {
+      type: 'object',
+      additionalProperties: false,
+      required: ['name'],
+      properties: {
+        name: { type: 'string' },
+        age: { type: 'integer' },
+      },
+    })
+  ).toEqual(
+    typedAs<Interface>({
+      name: 'Person',
+      properties: [
+        { name: 'name', type: { kind: 'string' }, required: true },
+        { name: 'age', type: { kind: 'integer' }, required: false },
+      ],
+    })
+  );
+});

--- a/libs/cdf-schema-builder/src/json_schema.ts
+++ b/libs/cdf-schema-builder/src/json_schema.ts
@@ -1,0 +1,126 @@
+import { Result, safeParseJson } from '@votingworks/types';
+import { assert } from '@votingworks/utils';
+import { JSONSchema4 } from 'json-schema';
+import { Enum, EnumValue, Interface, Property, Type } from './types';
+import { makeIdentifier } from './util';
+
+/**
+ * Parse a JSON Schema.
+ *
+ * @see https://json-schema.org
+ */
+export function parseJsonSchema(
+  jsonSchema: string
+): Result<JSONSchema4, SyntaxError> {
+  const jsonParseResult = safeParseJson(jsonSchema);
+  return jsonParseResult as Result<JSONSchema4, SyntaxError>;
+}
+
+/**
+ * Generates an enum type from a JSON schema `enum` property.
+ */
+export function createEnumFromDefinition(
+  name: string,
+  def: JSONSchema4
+): Enum | undefined {
+  if (!def.enum || def.type !== 'string') {
+    return undefined;
+  }
+
+  const values: EnumValue[] = [];
+  for (const value of def.enum) {
+    assert(typeof value === 'string');
+    values.push({
+      name: makeIdentifier(value),
+      value,
+    });
+  }
+
+  return {
+    name,
+    values,
+    documentation: def.description,
+  };
+}
+
+/**
+ * Converts a JSON Schema type to a TypeScript-compatible type.
+ */
+export function convertToGenericType(def: JSONSchema4): Type {
+  switch (def.type) {
+    case 'string': {
+      if (def.enum) {
+        return {
+          kind: 'union',
+          types: def.enum.map((value) => ({
+            kind: 'literal',
+            value: value as string,
+          })),
+        };
+      }
+      return { kind: 'string', pattern: def.pattern, format: def.format };
+    }
+
+    case 'integer':
+    case 'number':
+    case 'boolean': {
+      return { kind: def.type };
+    }
+
+    case 'array': {
+      assert(def.items);
+      return {
+        kind: 'array',
+        items: convertToGenericType(def.items),
+        minItems: def.minItems,
+      };
+    }
+
+    default:
+      if (def.$ref) {
+        const [, name] = def.$ref.split('#/definitions/');
+        assert(typeof name === 'string');
+        return { kind: 'reference', name: name.split('.').pop() as string };
+      }
+
+      if (def.oneOf) {
+        const types: Type[] = [];
+        for (const subDef of def.oneOf) {
+          types.push(convertToGenericType(subDef));
+        }
+        return { kind: 'union', types };
+      }
+
+      throw new Error(`Unsupported schema type: ${def.type}`);
+  }
+}
+
+/**
+ * Creates an interface from a JSON schema definition.
+ */
+export function createInterfaceFromDefinition(
+  name: string,
+  def: JSONSchema4
+): Interface | undefined {
+  assert(def.type === 'object', 'Expected an object schema');
+  assert(
+    def.additionalProperties === false,
+    'Expected no additional properties'
+  );
+
+  const properties: Property[] = [];
+
+  for (const [propertyName, propertyDef] of Object.entries(
+    def.properties ?? []
+  )) {
+    properties.push({
+      name: propertyName,
+      type: convertToGenericType(propertyDef),
+      required:
+        Array.isArray(def.required) && def.required.includes(propertyName),
+      documentation: propertyDef.description,
+    });
+  }
+
+  return { name, properties, documentation: def.description };
+}

--- a/libs/cdf-schema-builder/src/types.ts
+++ b/libs/cdf-schema-builder/src/types.ts
@@ -1,0 +1,84 @@
+/**
+ * A type defined in an XSD file.
+ */
+export interface DocumentedType {
+  kind: 'DocumentedType';
+  type: string;
+  extends?: string;
+  documentation?: string;
+}
+
+/**
+ * A property defined in an XSD file. May be an attribute or an element.
+ */
+export interface DocumentedProperty {
+  kind: 'DocumentedProperty';
+  type: string;
+  name: string;
+  documentation?: string;
+}
+
+/**
+ * A type or property defined in an XSD file.
+ */
+export type DocumentedEntity = DocumentedType | DocumentedProperty;
+
+/**
+ * An enumeration description, i.e. equivalent to a TypeScript enum.
+ */
+export interface Enum {
+  name: string;
+  values: EnumValue[];
+  documentation?: string;
+}
+
+/**
+ * An enumeration value description, i.e. equivalent to a TypeScript enum value.
+ */
+export interface EnumValue {
+  name: string;
+  value: string;
+  documentation?: string;
+}
+
+/**
+ * An interface description, i.e. equivalent to a TypeScript interface.
+ */
+export interface Interface {
+  name: string;
+  properties: Property[];
+  documentation?: string;
+}
+
+/**
+ * An interface property description, i.e. equivalent to a TypeScript property.
+ */
+export interface Property {
+  name: string;
+  type: Type;
+  required: boolean;
+  documentation?: string;
+}
+
+/**
+ * Types representable with JSON Schema.
+ */
+export type Type =
+  | { kind: 'string'; pattern?: string; format?: string }
+  | { kind: 'integer' }
+  | { kind: 'number' }
+  | { kind: 'boolean' }
+  | { kind: 'array'; items: Type; minItems?: number }
+  | { kind: 'literal'; value: string | number | boolean }
+  | { kind: 'reference'; name: string }
+  | { kind: 'union'; types: Type[] };
+
+/**
+ * An alias for `string`, optionally with a pattern restricting its value.
+ */
+export interface StringAlias {
+  kind: 'string';
+  name: string;
+  pattern?: string;
+  documentation?: string;
+}

--- a/libs/cdf-schema-builder/src/util.test.ts
+++ b/libs/cdf-schema-builder/src/util.test.ts
@@ -1,0 +1,96 @@
+import {
+  isValidIdentifier,
+  makeIdentifier,
+  renderTypeAsDeclaration,
+  renderTypeAsZodSchema,
+} from './util';
+
+test('makeIdentifier', () => {
+  expect(makeIdentifier('foo')).toBe('Foo');
+  expect(makeIdentifier('foo-bar')).toBe('FooBar');
+  expect(makeIdentifier('abc-123')).toBe('Abc123');
+  expect(makeIdentifier('123-abc')).toBe('_123Abc');
+  expect(makeIdentifier('1.2.3')).toBe('v1_2_3');
+});
+
+test('isValidIdentifier', () => {
+  expect(isValidIdentifier('foo')).toBe(true);
+  expect(isValidIdentifier('a b')).toBe(false);
+  expect(isValidIdentifier('1ab')).toBe(false);
+});
+
+test('renderTypeAsDeclaration', () => {
+  expect(renderTypeAsDeclaration({ kind: 'string' })).toEqual('string');
+  expect(renderTypeAsDeclaration({ kind: 'string', format: 'foo' })).toEqual(
+    'Foo'
+  );
+  expect(renderTypeAsDeclaration({ kind: 'string', pattern: 'a+' })).toEqual(
+    'string'
+  );
+  expect(renderTypeAsDeclaration({ kind: 'boolean' })).toEqual('boolean');
+  expect(renderTypeAsDeclaration({ kind: 'integer' })).toEqual('integer');
+  expect(renderTypeAsDeclaration({ kind: 'number' })).toEqual('number');
+  expect(renderTypeAsDeclaration({ kind: 'literal', value: 1 })).toEqual('1');
+  expect(renderTypeAsDeclaration({ kind: 'literal', value: 'abc' })).toEqual(
+    "'abc'"
+  );
+  expect(
+    renderTypeAsDeclaration({ kind: 'array', items: { kind: 'string' } })
+  ).toEqual('readonly string[]');
+  expect(
+    renderTypeAsDeclaration({
+      kind: 'array',
+      items: { kind: 'union', types: [{ kind: 'string' }, { kind: 'number' }] },
+    })
+  ).toEqual('ReadonlyArray<string | number>');
+  expect(renderTypeAsDeclaration({ kind: 'reference', name: 'foo' })).toEqual(
+    'foo'
+  );
+
+  // @ts-expect-error - checks for illegal values
+  expect(() => renderTypeAsDeclaration({ kind: 'invalid' })).toThrow();
+});
+
+test('renderTypeAsZodSchema', () => {
+  expect(renderTypeAsZodSchema({ kind: 'string' })).toEqual('z.string()');
+  expect(renderTypeAsZodSchema({ kind: 'string', format: 'foo' })).toEqual(
+    'FooSchema'
+  );
+  expect(renderTypeAsZodSchema({ kind: 'boolean' })).toEqual('z.boolean()');
+  expect(renderTypeAsZodSchema({ kind: 'number' })).toEqual('z.number()');
+  expect(renderTypeAsZodSchema({ kind: 'integer' })).toEqual('integerSchema');
+  expect(renderTypeAsZodSchema({ kind: 'literal', value: 'abc' })).toEqual(
+    `z.literal('abc')`
+  );
+  expect(renderTypeAsZodSchema({ kind: 'literal', value: 1 })).toEqual(
+    'z.literal(1)'
+  );
+  expect(
+    renderTypeAsZodSchema({ kind: 'array', items: { kind: 'string' } })
+  ).toEqual('z.array(z.string())');
+  expect(
+    renderTypeAsZodSchema({
+      kind: 'array',
+      items: { kind: 'string' },
+      minItems: 1,
+    })
+  ).toEqual('z.array(z.string()).min(1)');
+  expect(renderTypeAsZodSchema({ kind: 'reference', name: 'Foo' })).toEqual(
+    'z.lazy(/* istanbul ignore next */ () => FooSchema)'
+  );
+  expect(
+    renderTypeAsZodSchema({
+      kind: 'union',
+      types: [{ kind: 'string' }],
+    })
+  ).toEqual('z.string()');
+  expect(
+    renderTypeAsZodSchema({
+      kind: 'union',
+      types: [{ kind: 'string' }, { kind: 'boolean' }],
+    })
+  ).toEqual('z.union([z.string(), z.boolean()])');
+
+  // @ts-expect-error - checks for illegal values
+  expect(() => renderTypeAsZodSchema({ kind: 'invalid' })).toThrow();
+});

--- a/libs/cdf-schema-builder/src/util.ts
+++ b/libs/cdf-schema-builder/src/util.ts
@@ -1,0 +1,111 @@
+import { throwIllegalValue } from '@votingworks/utils';
+import { Type } from './types';
+
+/**
+ * Determines whether a string matches a semver pattern.
+ */
+export function isVersionString(version: string): boolean {
+  return /^\d+\.\d+\.\d+$/.test(version);
+}
+
+/**
+ * Creates a valid uppercase identifier from a kebab-case string.
+ */
+export function makeIdentifier(kebabCaseString: string): string {
+  if (isVersionString(kebabCaseString)) {
+    return `v${kebabCaseString.replace(/\./g, '_')}`;
+  }
+
+  const result = kebabCaseString
+    .replace(/\./g, '_')
+    .replace(/\b[a-z]/g, (match) => match.toUpperCase())
+    .replace(/[^a-z\d_]/gi, '');
+  return /^\d/.test(result) ? `_${result}` : result;
+}
+
+/**
+ * Determines whether `identifier` is a valid JavaScript identifier.
+ */
+export function isValidIdentifier(identifier: string): boolean {
+  return /^[a-z_$][a-z\d_$]*$/i.test(identifier);
+}
+
+/**
+ * Converts a generic type to a string that can be used in a type declaration.
+ */
+export function renderTypeAsDeclaration(type: Type): string {
+  switch (type.kind) {
+    case 'string':
+      return type.format ? makeIdentifier(type.format) : 'string';
+
+    case 'boolean':
+    case 'integer':
+    case 'number':
+      return type.kind;
+
+    case 'literal':
+      return typeof type.value === 'string'
+        ? `'${type.value}'`
+        : `${type.value}`;
+
+    case 'array': {
+      const item = renderTypeAsDeclaration(type.items);
+      return isValidIdentifier(item)
+        ? `readonly ${item}[]`
+        : `ReadonlyArray<${item}>`;
+    }
+
+    case 'union':
+      return type.types.map(renderTypeAsDeclaration).join(' | ');
+
+    case 'reference':
+      return type.name;
+
+    default:
+      throwIllegalValue(type);
+  }
+}
+
+/**
+ * Converts a generic type to a Zod schema.
+ */
+export function renderTypeAsZodSchema(type: Type): string {
+  switch (type.kind) {
+    case 'string':
+      return type.format
+        ? `${makeIdentifier(type.format)}Schema`
+        : 'z.string()';
+
+    case 'boolean':
+      return 'z.boolean()';
+
+    case 'number':
+      return 'z.number()';
+
+    case 'integer':
+      return 'integerSchema';
+
+    case 'literal':
+      return `z.literal(${
+        typeof type.value === 'string' ? `'${type.value}'` : `${type.value}`
+      })`;
+
+    case 'array':
+      return `z.array(${renderTypeAsZodSchema(type.items)})${
+        type.minItems ? `.min(${type.minItems})` : ''
+      }`;
+
+    case 'union':
+      if (type.types.length === 1) {
+        return renderTypeAsZodSchema(type.types[0] as Type);
+      }
+
+      return `z.union([${type.types.map(renderTypeAsZodSchema).join(', ')}])`;
+
+    case 'reference':
+      return `z.lazy(/* istanbul ignore next */ () => ${type.name}Schema)`;
+
+    default:
+      throwIllegalValue(type);
+  }
+}

--- a/libs/cdf-schema-builder/src/xsd.test.ts
+++ b/libs/cdf-schema-builder/src/xsd.test.ts
@@ -1,0 +1,200 @@
+import { typedAs } from '@votingworks/utils';
+import { DocumentedEntity } from './types';
+import {
+  extractDocumentation,
+  extractDocumentationForSchema,
+  getChildOfType,
+  getChildrenOfType,
+  parseXsdSchema,
+} from './xsd';
+
+let schema: Element;
+
+beforeEach(() => {
+  schema = parseXsdSchema(
+    `<?xml version="1.0" encoding="UTF-8"?>
+   <xsd:schema elementFormDefault="qualified" targetNamespace="http://itl.nist.gov/ns/voting/1500-101/v1" version="1.0.2" xmlns="http://itl.nist.gov/ns/voting/1500-101/v1" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+     <!-- a comment -->
+     <xsd:simpleType name="DayOfWeek">
+       <xsd:annotation>
+         <xsd:documentation>A day of the week.</xsd:documentation>
+       </xsd:annotation>
+       <xsd:restriction base="xsd:string">
+         <xsd:enumeration value="Monday">
+           <xsd:annotation>
+             <xsd:documentation>The first day of the week.</xsd:documentation>
+           </xsd:annotation>
+         </xsd:enumeration>
+         <xsd:enumeration value="Tuesday">
+           <xsd:annotation>
+             <xsd:documentation />
+           </xsd:annotation>
+         </xsd:enumeration>
+         <xsd:enumeration value="Wednesday"/>
+         <xsd:enumeration value="Thursday"/>
+         <xsd:enumeration value="Friday"/>
+         <xsd:enumeration value="Saturday"/>
+         <xsd:enumeration value="Sunday"/>
+       </xsd:restriction>
+     </xsd:simpleType>
+     <xsd:complexType name="Person">
+       <xsd:annotation>
+         <xsd:documentation>A person.</xsd:documentation>
+       </xsd:annotation>
+       <xsd:sequence>
+         <xsd:element name="name" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+         <xsd:element name="birthday" type="xsd:date" minOccurs="1" maxOccurs="1">
+           <xsd:annotation>
+             <xsd:documentation>The person's birthday.</xsd:documentation>
+           </xsd:annotation>
+         </xsd:element>
+       </xsd:sequence>
+     </xsd:complexType>
+     <xsd:complexType name="PersonWithAddress">
+       <xsd:complexContent>
+         <xsd:extension base="Person">
+           <xsd:sequence>
+             <xsd:element name="address" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+           </xsd:sequence>
+         </xsd:extension>
+       </xsd:complexContent>
+     </xsd:complexType>
+     <xsd:complexType name="Employee">
+       <xsd:complexContent>
+         <xsd:extension base="PersonWithAddress" />
+       </xsd:complexContent>
+     </xsd:complexType>
+   </xsd:schema>`
+  );
+});
+
+test('getChildOfType', () => {
+  expect(getChildOfType(schema, 'xsd:simpleType')?.nodeName).toEqual(
+    'xsd:simpleType'
+  );
+  expect(getChildOfType(schema, 'not-there')).toBeUndefined();
+});
+
+test('getChildrenOfType', () => {
+  const simpleTypeElements = getChildrenOfType(schema, 'xsd:simpleType');
+  expect(simpleTypeElements).toHaveLength(1);
+  expect(
+    getChildrenOfType(
+      getChildrenOfType(simpleTypeElements[0]!, 'xsd:restriction')[0]!,
+      'xsd:enumeration'
+    )
+  ).toHaveLength(7);
+  expect(getChildrenOfType(schema, 'not-there')).toHaveLength(0);
+});
+
+test('extractDocumentation', () => {
+  expect(extractDocumentation(schema)).toBeUndefined();
+
+  const dayOfWeekElement = getChildOfType(schema, 'xsd:simpleType')!;
+  expect(extractDocumentation(dayOfWeekElement)).toEqual('A day of the week.');
+
+  const [mondayElement, tuesdayElement] = getChildrenOfType(
+    getChildOfType(dayOfWeekElement, 'xsd:restriction')!,
+    'xsd:enumeration'
+  )!;
+  expect(extractDocumentation(mondayElement!)).toEqual(
+    'The first day of the week.'
+  );
+  expect(extractDocumentation(tuesdayElement!)).toEqual('');
+});
+
+test('extractDocumentationForSchema', () => {
+  expect(extractDocumentationForSchema(schema.firstChild as Element)).toEqual(
+    []
+  );
+
+  expect(extractDocumentationForSchema(schema)).toEqual(
+    typedAs<DocumentedEntity[]>([
+      {
+        kind: 'DocumentedType',
+        type: 'DayOfWeek',
+        documentation: 'A day of the week.',
+      },
+      {
+        kind: 'DocumentedProperty',
+        type: 'DayOfWeek',
+        name: 'Monday',
+        documentation: 'The first day of the week.',
+      },
+      {
+        kind: 'DocumentedProperty',
+        type: 'DayOfWeek',
+        name: 'Tuesday',
+        documentation: '',
+      },
+      {
+        kind: 'DocumentedProperty',
+        type: 'DayOfWeek',
+        name: 'Wednesday',
+      },
+      {
+        kind: 'DocumentedProperty',
+        type: 'DayOfWeek',
+        name: 'Thursday',
+      },
+      {
+        kind: 'DocumentedProperty',
+        type: 'DayOfWeek',
+        name: 'Friday',
+      },
+      {
+        kind: 'DocumentedProperty',
+        type: 'DayOfWeek',
+        name: 'Saturday',
+      },
+      {
+        kind: 'DocumentedProperty',
+        type: 'DayOfWeek',
+        name: 'Sunday',
+      },
+      {
+        kind: 'DocumentedType',
+        type: 'Person',
+        documentation: 'A person.',
+      },
+      {
+        kind: 'DocumentedProperty',
+        type: 'Person',
+        name: 'birthday',
+        documentation: `The person's birthday.`,
+      },
+      {
+        kind: 'DocumentedType',
+        type: 'PersonWithAddress',
+        extends: 'Person',
+      },
+      {
+        kind: 'DocumentedType',
+        type: 'Employee',
+        extends: 'PersonWithAddress',
+      },
+    ])
+  );
+
+  getChildOfType(
+    getChildOfType(schema, 'xsd:simpleType')!,
+    'xsd:restriction'
+  )!.remove();
+
+  for (const complexTypeElement of getChildrenOfType(
+    schema,
+    'xsd:complexType'
+  )) {
+    complexTypeElement.remove();
+  }
+
+  expect(extractDocumentationForSchema(schema)).toEqual(
+    typedAs<DocumentedEntity[]>([
+      {
+        kind: 'DocumentedType',
+        type: 'DayOfWeek',
+        documentation: 'A day of the week.',
+      },
+    ])
+  );
+});

--- a/libs/cdf-schema-builder/src/xsd.ts
+++ b/libs/cdf-schema-builder/src/xsd.ts
@@ -1,0 +1,172 @@
+import { JSDOM } from 'jsdom';
+import { DocumentedEntity } from './types';
+
+/**
+ * Gets the first child element with the given name.
+ */
+export function getChildOfType(
+  element: Element,
+  nodeName: string
+): Element | undefined {
+  for (const child of element.childNodes) {
+    if (child.nodeType !== element.ELEMENT_NODE) {
+      continue;
+    }
+
+    const childElement = child as Element;
+    if (childElement.nodeName === nodeName) {
+      return childElement;
+    }
+  }
+}
+
+/**
+ * Gets all child elements with the given name.
+ */
+export function getChildrenOfType(
+  element: Element,
+  nodeName: string
+): Element[] {
+  const children: Element[] = [];
+  for (const child of element.childNodes) {
+    if (child.nodeType !== element.ELEMENT_NODE) {
+      continue;
+    }
+
+    const childElement = child as Element;
+    if (childElement.nodeName === nodeName) {
+      children.push(childElement);
+    }
+  }
+  return children;
+}
+
+/**
+ * Extracts documentation for an element containing a documentation
+ * `xsd:annotation` element.
+ */
+export function extractDocumentation(element: Element): string | undefined {
+  for (const annotationElements of getChildrenOfType(
+    element,
+    'xsd:annotation'
+  )) {
+    for (const documentationElements of getChildrenOfType(
+      annotationElements,
+      'xsd:documentation'
+    )) {
+      return (
+        documentationElements.textContent ??
+        /* istanbul ignore next - in practice textContent never seems to be `null` */ undefined
+      );
+    }
+  }
+}
+
+/**
+ * Extracts the documentation from an XSD schema.
+ */
+export function extractDocumentationForSchema(
+  schema: Element
+): DocumentedEntity[] {
+  if (schema.nodeName !== 'xsd:schema') {
+    return [];
+  }
+
+  const docs: DocumentedEntity[] = [];
+
+  for (const simpleTypeElement of getChildrenOfType(schema, 'xsd:simpleType')) {
+    const simpleTypeName = simpleTypeElement.getAttribute('name') as string;
+    const documentation = extractDocumentation(simpleTypeElement);
+    docs.push({
+      kind: 'DocumentedType',
+      type: simpleTypeName,
+      documentation,
+    });
+
+    const restrictionElement = getChildOfType(
+      simpleTypeElement,
+      'xsd:restriction'
+    );
+    if (!restrictionElement) {
+      continue;
+    }
+
+    const enumerationElements = getChildrenOfType(
+      restrictionElement,
+      'xsd:enumeration'
+    );
+    for (const enumerationElement of enumerationElements) {
+      const enumerationValue = enumerationElement.getAttribute(
+        'value'
+      ) as string;
+      const valueDocumentation = extractDocumentation(enumerationElement);
+      docs.push({
+        kind: 'DocumentedProperty',
+        type: simpleTypeName,
+        name: enumerationValue,
+        documentation: valueDocumentation,
+      });
+    }
+  }
+
+  for (const complexTypeElement of getChildrenOfType(
+    schema,
+    'xsd:complexType'
+  )) {
+    const complexTypeName = complexTypeElement.getAttribute('name') as string;
+    const documentation = extractDocumentation(complexTypeElement);
+
+    const contentElement =
+      getChildOfType(complexTypeElement, 'xsd:complexContent') ??
+      getChildOfType(complexTypeElement, 'xsd:simpleContent');
+    const extensionElement =
+      contentElement && getChildOfType(contentElement, 'xsd:extension');
+
+    docs.push({
+      kind: 'DocumentedType',
+      type: complexTypeName,
+      extends: extensionElement?.getAttribute('base') ?? undefined,
+      documentation,
+    });
+
+    const sequenceElement = getChildOfType(
+      extensionElement ?? complexTypeElement,
+      'xsd:sequence'
+    );
+
+    const attributeElements = getChildrenOfType(
+      extensionElement ?? complexTypeElement,
+      'xsd:attribute'
+    );
+    const elementElements = sequenceElement
+      ? getChildrenOfType(sequenceElement, 'xsd:element')
+      : [];
+    for (const childElement of [...attributeElements, ...elementElements]) {
+      const childName = childElement.getAttribute('name') as string;
+      const childDocumentation = extractDocumentation(childElement);
+      if (childDocumentation) {
+        docs.push({
+          kind: 'DocumentedProperty',
+          type: complexTypeName,
+          name: childName,
+          documentation: childDocumentation,
+        });
+      }
+    }
+
+    if (!contentElement) {
+      continue;
+    }
+  }
+
+  return docs;
+}
+
+/**
+ * Parses an XSD schema and returns the `xsd:schema` element.
+ */
+export function parseXsdSchema(xsdSchema: string): Element {
+  const dom = new JSDOM(xsdSchema, { contentType: 'text/xml' });
+  const { document } = dom.window;
+  return document.documentElement;
+}

--- a/libs/cdf-types-election-event-logging/data/schema.json
+++ b/libs/cdf-types-election-event-logging/data/schema.json
@@ -1,0 +1,285 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "EventLogging.Device": {
+      "required": [
+        "@type",
+        "Id"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "@type": {
+          "enum": [
+            "EventLogging.Device"
+          ],
+          "type": "string"
+        },
+        "Details": {
+          "type": "string"
+        },
+        "Event": {
+          "items": {
+            "$ref": "#/definitions/EventLogging.Event"
+          },
+          "minItems": 0,
+          "type": "array"
+        },
+        "HashType": {
+          "$ref": "#/definitions/EventLogging.HashType"
+        },
+        "Id": {
+          "type": "string"
+        },
+        "Manufacturer": {
+          "type": "string"
+        },
+        "Model": {
+          "type": "string"
+        },
+        "OtherHashType": {
+          "type": "string"
+        },
+        "OtherType": {
+          "type": "string"
+        },
+        "Type": {
+          "$ref": "#/definitions/EventLogging.DeviceType"
+        },
+        "Version": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "EventLogging.DeviceType": {
+      "enum": [
+        "adjudication",
+        "ballot-activation",
+        "ballot-printing",
+        "blank-ballot-printing",
+        "bmd",
+        "dre",
+        "dre-controller",
+        "electronic-cast",
+        "electronic-cast-paper",
+        "electronic-poll-book",
+        "ems",
+        "other",
+        "scan-batch",
+        "scan-single",
+        "transmission-receiving",
+        "transmission-sending"
+      ],
+      "type": "string"
+    },
+    "EventLogging.ElectionEventLog": {
+      "required": [
+        "@type",
+        "GeneratedTime"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "@type": {
+          "enum": [
+            "EventLogging.ElectionEventLog"
+          ],
+          "type": "string"
+        },
+        "Details": {
+          "type": "string"
+        },
+        "Device": {
+          "items": {
+            "$ref": "#/definitions/EventLogging.Device"
+          },
+          "minItems": 0,
+          "type": "array"
+        },
+        "ElectionId": {
+          "type": "string"
+        },
+        "GeneratedTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "type": "object"
+    },
+    "EventLogging.ElectionEventLogDocumentation": {
+      "required": [
+        "@type",
+        "DeviceManufacturer",
+        "DeviceModel",
+        "EventIdDescription",
+        "EventTypeDescription",
+        "GeneratedDate"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "@type": {
+          "enum": [
+            "EventLogging.ElectionEventLogDocumentation"
+          ],
+          "type": "string"
+        },
+        "DeviceId": {
+          "type": "string"
+        },
+        "DeviceManufacturer": {
+          "type": "string"
+        },
+        "DeviceModel": {
+          "type": "string"
+        },
+        "DeviceVersion": {
+          "type": "string"
+        },
+        "EventIdDescription": {
+          "items": {
+            "$ref": "#/definitions/EventLogging.EventIdDescription"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "EventTypeDescription": {
+          "items": {
+            "$ref": "#/definitions/EventLogging.EventTypeDescription"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "GeneratedDate": {
+          "type": "string",
+          "format": "date"
+        }
+      },
+      "type": "object"
+    },
+    "EventLogging.Event": {
+      "required": [
+        "@type",
+        "Disposition",
+        "Id",
+        "Sequence",
+        "TimeStamp",
+        "Type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "@type": {
+          "enum": [
+            "EventLogging.Event"
+          ],
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Details": {
+          "type": "string"
+        },
+        "Disposition": {
+          "$ref": "#/definitions/EventLogging.EventDispositionType"
+        },
+        "Hash": {
+          "type": "string"
+        },
+        "Id": {
+          "type": "string"
+        },
+        "OtherDisposition": {
+          "type": "string"
+        },
+        "Sequence": {
+          "type": "string"
+        },
+        "Severity": {
+          "type": "string"
+        },
+        "TimeStamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "Type": {
+          "type": "string"
+        },
+        "UserId": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "EventLogging.EventDispositionType": {
+      "enum": [
+        "failure",
+        "na",
+        "other",
+        "success"
+      ],
+      "type": "string"
+    },
+    "EventLogging.EventIdDescription": {
+      "required": [
+        "@type",
+        "Description",
+        "Id"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "@type": {
+          "enum": [
+            "EventLogging.EventIdDescription"
+          ],
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Id": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "EventLogging.EventTypeDescription": {
+      "required": [
+        "@type",
+        "Description",
+        "Type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "@type": {
+          "enum": [
+            "EventLogging.EventTypeDescription"
+          ],
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "EventLogging.HashType": {
+      "enum": [
+        "md6",
+        "other",
+        "sha-256",
+        "sha-512"
+      ],
+      "type": "string"
+    }
+  },
+  "oneOf": [
+    {
+      "$ref": "#/definitions/EventLogging.ElectionEventLog"
+    },
+    {
+      "$ref": "#/definitions/EventLogging.ElectionEventLogDocumentation"
+    }
+  ]
+}

--- a/libs/cdf-types-election-event-logging/package.json
+++ b/libs/cdf-types-election-event-logging/package.json
@@ -13,7 +13,7 @@
     "lint": "pnpm type-check && eslint .",
     "lint:fix": "pnpm type-check && eslint . --fix",
     "pre-commit": "lint-staged",
-    "schema:build": "mkdir -p src && cdf-schema-builder data/schema.xml > src/index.ts",
+    "schema:build": "mkdir -p src && cdf-schema-builder data/schema.json data/schema.xml > src/index.ts",
     "schema:update": "curl -sLo- https://raw.githubusercontent.com/usnistgov/ElectionEventLogging/master/NIST_V1_election_event_logging.xsd > data/schema.xml && pnpm schema:build",
     "test": "is-ci test:ci test:watch",
     "test:ci": "jest --ci --coverage",

--- a/libs/cdf-types-election-event-logging/src/index.test.ts
+++ b/libs/cdf-types-election-event-logging/src/index.test.ts
@@ -19,6 +19,7 @@ import {
 } from '.';
 
 const event: Event = {
+  '@type': 'EventLogging.Event',
   Id: '1',
   Disposition: EventDispositionType.Success,
   Sequence: '1',
@@ -27,6 +28,7 @@ const event: Event = {
 };
 
 const device: Device = {
+  '@type': 'EventLogging.Device',
   Id: '1',
   Event: [event],
   HashType: HashType.Sha256,
@@ -34,21 +36,25 @@ const device: Device = {
 };
 
 const electionEventLog: ElectionEventLog = {
+  '@type': 'EventLogging.ElectionEventLog',
   Device: [device],
   GeneratedTime: '2019-01-01T00:00:00.000Z',
 };
 
 const eventIdDescription: EventIdDescription = {
+  '@type': 'EventLogging.EventIdDescription',
   Id: '1',
   Description: 'test',
 };
 
 const eventTypeDescription: EventTypeDescription = {
+  '@type': 'EventLogging.EventTypeDescription',
   Type: 'test',
   Description: 'test',
 };
 
 const electionEventLogDocumentation: ElectionEventLogDocumentation = {
+  '@type': 'EventLogging.ElectionEventLogDocumentation',
   DeviceManufacturer: 'votingworks',
   DeviceModel: 'test',
   EventIdDescription: [eventIdDescription],
@@ -73,10 +79,11 @@ test('ElectionEventLogDocumentation', () => {
 });
 
 test('schema in sync', () => {
-  const input = readFileSync(join(__dirname, '../data/schema.xml'), 'utf-8');
+  const xsd = readFileSync(join(__dirname, '../data/schema.xml'), 'utf-8');
+  const json = readFileSync(join(__dirname, '../data/schema.json'), 'utf-8');
   const currentOutput = readFileSync(join(__dirname, './index.ts'), 'utf-8');
   const out = fakeWritable();
-  buildSchema(input, out);
+  buildSchema(xsd, json, out);
   const expectedOutput = out.toString();
   expect(currentOutput).toEqual(expectedOutput);
 });

--- a/libs/cdf-types-election-event-logging/src/index.ts
+++ b/libs/cdf-types-election-event-logging/src/index.ts
@@ -7,14 +7,54 @@ import { z } from 'zod';
 import { Iso8601Date } from '@votingworks/types';
 
 /**
- * Schema for xsd:datetime values.
+ * Type for xsd:datetime values.
+ */
+export type DateTime = z.TypeOf<typeof Iso8601Date>;
+
+/**
+ * Schema for {@link DateTime}.
  */
 export const DateTimeSchema = Iso8601Date;
 
 /**
- * Schema for xsd:date values.
+ * Type for xsd:date values.
+ */
+export type Date = z.TypeOf<typeof Iso8601Date>;
+
+/**
+ * Schema {@link Date}.
  */
 export const DateSchema = Iso8601Date;
+
+/**
+ * A URI/URL.
+ */
+export type Uri = string;
+
+/**
+ * Schema for {@link Uri}.
+ */
+export const UriSchema = z.string();
+
+/**
+ * Byte data stored in a string.
+ */
+export type Byte = string;
+
+/**
+ * Schema for {@link Byte}.
+ */
+export const ByteSchema = z.string();
+
+/**
+ * An integer number, i.e. a whole number without fractional part.
+ */
+export type integer = number;
+
+/**
+ * Schema for {@link integer}.
+ */
+export const integerSchema = z.number().int();
 
 /**
  * Used in Device::Type to describe the type or usage of the device generating the event.
@@ -31,11 +71,6 @@ export enum DeviceType {
   BallotActivation = 'ballot-activation',
 
   /**
-   * Ballot marking devices (voter facing).
-   */
-  Bmd = 'bmd',
-
-  /**
    * Marked ballot printing devices (voter facing).
    */
   BallotPrinting = 'ballot-printing',
@@ -44,6 +79,11 @@ export enum DeviceType {
    * On-demand blank ballot printers.
    */
   BlankBallotPrinting = 'blank-ballot-printing',
+
+  /**
+   * Ballot marking devices (voter facing).
+   */
+  Bmd = 'bmd',
 
   /**
    * Electronic voter stations, standalone or daisy chained to a DRE-controller (voter facing).
@@ -76,6 +116,11 @@ export enum DeviceType {
   Ems = 'ems',
 
   /**
+   * Used when no other value in this enumeration applies.
+   */
+  Other = 'other',
+
+  /**
    * Scanning devices for batches of ballots, auto-feeding, e.g., Central Count (poll worker facing).
    */
   ScanBatch = 'scan-batch',
@@ -86,19 +131,14 @@ export enum DeviceType {
   ScanSingle = 'scan-single',
 
   /**
-   * Remote transmission clients, e.g., for sending of unofficial results from a remote location to a central location (sending station).
-   */
-  TransmissionSending = 'transmission-sending',
-
-  /**
    * Remote transmission hosts, e.g., for the receiving of unofficial results at a central location from a remote location (receiving station).
    */
   TransmissionReceiving = 'transmission-receiving',
 
   /**
-   * Used when no other value in this enumeration applies.
+   * Remote transmission clients, e.g., for sending of unofficial results from a remote location to a central location (sending station).
    */
-  Other = 'other',
+  TransmissionSending = 'transmission-sending',
 }
 
 /**
@@ -121,14 +161,14 @@ export enum EventDispositionType {
   Na = 'na',
 
   /**
-   * For a successful disposition.
-   */
-  Success = 'success',
-
-  /**
    * Used when no other value in this enumeration applies.
    */
   Other = 'other',
+
+  /**
+   * For a successful disposition.
+   */
+  Success = 'success',
 }
 
 /**
@@ -146,6 +186,11 @@ export enum HashType {
   Md6 = 'md6',
 
   /**
+   * Used when no other value in this enumeration applies.
+   */
+  Other = 'other',
+
+  /**
    * To indicate that the SHA 256-bit signature is being used.
    */
   Sha256 = 'sha-256',
@@ -154,11 +199,6 @@ export enum HashType {
    * To indicate that the SHA 512-bit (32-byte) signature is being used.
    */
   Sha512 = 'sha-512',
-
-  /**
-   * Used when no other value in this enumeration applies.
-   */
-  Other = 'other',
 }
 
 /**
@@ -170,70 +210,73 @@ export const HashTypeSchema = z.nativeEnum(HashType);
  * Device contains information about the device generating election event logs. Id is the only required attribute, all other attributes are optional.  If the device type is not found in the DeviceType enumeration, Type is 'other' and OtherType contains the appropriate type.
  */
 export interface Device {
+  readonly '@type': 'EventLogging.Device';
+
   /**
    * Used to associate any details with the event log.
    */
-  Details?: string;
+  readonly Details?: string;
 
   /**
    * Used to describe a logged event.
    */
-  Event: Event[];
+  readonly Event?: readonly Event[];
 
   /**
    * The type of the hash, from the HashType enumeration.
    */
-  HashType?: HashType;
-
-  /**
-   * If HashType is 'other', the type of the hash.
-   */
-  OtherHashType?: string;
+  readonly HashType?: HashType;
 
   /**
    * A serial number or otherwise identifier associated with the device.
    */
-  Id: string;
+  readonly Id: string;
 
   /**
    * Manufacturer of the device.
    */
-  Manufacturer?: string;
+  readonly Manufacturer?: string;
 
   /**
    * Model of the device.
    */
-  Model?: string;
+  readonly Model?: string;
 
   /**
-   * Enumerated usage of the device, e.g., ems, scan-single, etc.
+   * If HashType is 'other', the type of the hash.
    */
-  Type?: DeviceType;
+  readonly OtherHashType?: string;
 
   /**
    * Used when Type is 'other'.
    */
-  OtherType?: string;
+  readonly OtherType?: string;
+
+  /**
+   * Enumerated usage of the device, e.g., ems, scan-single, etc.
+   */
+  readonly Type?: DeviceType;
 
   /**
    * Version identification of the device.
    */
-  Version?: string;
+  readonly Version?: string;
 }
 
 /**
  * Schema for {@link Device}.
  */
 export const DeviceSchema: z.ZodSchema<Device> = z.object({
+  '@type': z.literal('EventLogging.Device'),
   Details: z.optional(z.string()),
-  Event: z.array(z.lazy(() => EventSchema)),
-  HashType: z.optional(z.lazy(() => HashTypeSchema)),
-  OtherHashType: z.optional(z.string()),
+  Event: z.optional(z.array(z.lazy(/* istanbul ignore next */ () => EventSchema))),
+  HashType: z.optional(z.lazy(/* istanbul ignore next */ () => HashTypeSchema)),
   Id: z.string(),
   Manufacturer: z.optional(z.string()),
   Model: z.optional(z.string()),
-  Type: z.optional(z.lazy(() => DeviceTypeSchema)),
+  OtherHashType: z.optional(z.string()),
   OtherType: z.optional(z.string()),
+  Type: z.optional(z.lazy(/* istanbul ignore next */ () => DeviceTypeSchema)),
   Version: z.optional(z.string()),
 });
 
@@ -241,33 +284,36 @@ export const DeviceSchema: z.ZodSchema<Device> = z.object({
  * ElectionEventLog is the root class.  It includes Device for identifying the device(s) generating the election events, the date and time when the election event log was created, and an identification of the election. Details is used as needed for additional description/details. HashType is used to specify a cryptographic hash associated with the events, that is, an event log entry, using values from the HashType enumeration.  If the type of hash is not found in the HashType enumeration, HashType is 'other' and OtherHashType contains the type of hash.
  */
 export interface ElectionEventLog {
+  readonly '@type': 'EventLogging.ElectionEventLog';
+
   /**
    * Used to associate any details with the event log.
    */
-  Details?: string;
+  readonly Details?: string;
 
   /**
    * Used to describe the device(s) generating the election events.
    */
-  Device: Device[];
+  readonly Device?: readonly Device[];
 
   /**
    * Identifies the election associated with the log.
    */
-  ElectionId?: string;
+  readonly ElectionId?: string;
 
   /**
    * Identifies the date and time the log was generated.
    */
-  GeneratedTime: string;
+  readonly GeneratedTime: DateTime;
 }
 
 /**
  * Schema for {@link ElectionEventLog}.
  */
 export const ElectionEventLogSchema: z.ZodSchema<ElectionEventLog> = z.object({
+  '@type': z.literal('EventLogging.ElectionEventLog'),
   Details: z.optional(z.string()),
-  Device: z.array(z.lazy(() => DeviceSchema)),
+  Device: z.optional(z.array(z.lazy(/* istanbul ignore next */ () => DeviceSchema))),
   ElectionId: z.optional(z.string()),
   GeneratedTime: DateTimeSchema,
 });
@@ -276,52 +322,55 @@ export const ElectionEventLogSchema: z.ZodSchema<ElectionEventLog> = z.object({
  * ElectionEventLogDocumention is the root class.  It includes EventIdDescription and EventTypeDescription, as well as other information for identifying the specific device associated with the election event documentation.
  */
 export interface ElectionEventLogDocumentation {
+  readonly '@type': 'EventLogging.ElectionEventLogDocumentation';
+
   /**
    * A serial number or otherwise identifier associated with the device.
    */
-  DeviceId?: string;
+  readonly DeviceId?: string;
 
   /**
    * Manufacturer of the device.
    */
-  DeviceManufacturer: string;
+  readonly DeviceManufacturer: string;
 
   /**
    * Model of the device.
    */
-  DeviceModel: string;
+  readonly DeviceModel: string;
 
   /**
    * Version identification of the device.
    */
-  DeviceVersion?: string;
+  readonly DeviceVersion?: string;
 
   /**
    * For associating a description with an event ID.
    */
-  EventIdDescription: EventIdDescription[];
+  readonly EventIdDescription: readonly EventIdDescription[];
 
   /**
    * For associating a description with an event type.
    */
-  EventTypeDescription: EventTypeDescription[];
+  readonly EventTypeDescription: readonly EventTypeDescription[];
 
   /**
    * Identifies the date the documentation report was generated.
    */
-  GeneratedDate: string;
+  readonly GeneratedDate: Date;
 }
 
 /**
  * Schema for {@link ElectionEventLogDocumentation}.
  */
 export const ElectionEventLogDocumentationSchema: z.ZodSchema<ElectionEventLogDocumentation> = z.object({
+  '@type': z.literal('EventLogging.ElectionEventLogDocumentation'),
   DeviceId: z.optional(z.string()),
   DeviceManufacturer: z.string(),
   DeviceModel: z.string(),
   DeviceVersion: z.optional(z.string()),
-  EventIdDescription: z.array(z.lazy(() => EventIdDescriptionSchema)).nonempty(),
-  EventTypeDescription: z.array(z.lazy(() => EventTypeDescriptionSchema)).nonempty(),
+  EventIdDescription: z.array(z.lazy(/* istanbul ignore next */ () => EventIdDescriptionSchema)).min(1),
+  EventTypeDescription: z.array(z.lazy(/* istanbul ignore next */ () => EventTypeDescriptionSchema)).min(1),
   GeneratedDate: DateSchema,
 });
 
@@ -329,72 +378,75 @@ export const ElectionEventLogDocumentationSchema: z.ZodSchema<ElectionEventLogDo
  * Event holds information about a specific event. Severity is an optional attribute for describing a severity indication for the event.  If the event disposition is not found in the EventDispositionType enumeration, Disposition is 'other' and OtherDisposition contains the other disposition.
  */
 export interface Event {
+  readonly '@type': 'EventLogging.Event';
+
   /**
    * Used for a brief description of the event.
    */
-  Description?: string;
+  readonly Description?: string;
 
   /**
    * Used for additional information about the event, e.g., vendor reserved information.
    */
-  Details?: string;
+  readonly Details?: string;
 
   /**
    * The disposition, e.g., success or failure, of the event.
    */
-  Disposition: EventDispositionType;
-
-  /**
-   * Used when Disposition is 'other'.
-   */
-  OtherDisposition?: string;
+  readonly Disposition: EventDispositionType;
 
   /**
    * Contains a cryptographic hash of the event, encoded as a string.
    */
-  Hash?: string;
+  readonly Hash?: string;
 
   /**
    * An identifier associated with the event.
    */
-  Id: string;
+  readonly Id: string;
+
+  /**
+   * Used when Disposition is 'other'.
+   */
+  readonly OtherDisposition?: string;
 
   /**
    * A sequence number/string to uniquely identify the event in the log file.
    */
-  Sequence: string;
+  readonly Sequence: string;
 
   /**
    * Used for an indication of the severity of the event, as determined by the device vendor.
    */
-  Severity?: string;
+  readonly Severity?: string;
 
   /**
    * Identifies the date and time the event was generated.
    */
-  TimeStamp: string;
+  readonly TimeStamp: DateTime;
 
   /**
    * Used for the type of event, as determined by the device vendor.
    */
-  Type: string;
+  readonly Type: string;
 
   /**
    * An identifier associated with a user, as relevant.
    */
-  UserId?: string;
+  readonly UserId?: string;
 }
 
 /**
  * Schema for {@link Event}.
  */
 export const EventSchema: z.ZodSchema<Event> = z.object({
+  '@type': z.literal('EventLogging.Event'),
   Description: z.optional(z.string()),
   Details: z.optional(z.string()),
-  Disposition: z.lazy(() => EventDispositionTypeSchema),
-  OtherDisposition: z.optional(z.string()),
+  Disposition: z.lazy(/* istanbul ignore next */ () => EventDispositionTypeSchema),
   Hash: z.optional(z.string()),
   Id: z.string(),
+  OtherDisposition: z.optional(z.string()),
   Sequence: z.string(),
   Severity: z.optional(z.string()),
   TimeStamp: DateTimeSchema,
@@ -406,21 +458,24 @@ export const EventSchema: z.ZodSchema<Event> = z.object({
  * For associating a brief description with an election event ID, used in ElectionEventLogDocumentation::EventIdDescription.
  */
 export interface EventIdDescription {
+  readonly '@type': 'EventLogging.EventIdDescription';
+
   /**
    * Used for a brief description of the event.
    */
-  Description: string;
+  readonly Description: string;
 
   /**
    * An identifier associated with the event.
    */
-  Id: string;
+  readonly Id: string;
 }
 
 /**
  * Schema for {@link EventIdDescription}.
  */
 export const EventIdDescriptionSchema: z.ZodSchema<EventIdDescription> = z.object({
+  '@type': z.literal('EventLogging.EventIdDescription'),
   Description: z.string(),
   Id: z.string(),
 });
@@ -429,21 +484,24 @@ export const EventIdDescriptionSchema: z.ZodSchema<EventIdDescription> = z.objec
  * For associating a description with an election event log type, used in ElectionEventLogDocumentation::EventTypeDescription.
  */
 export interface EventTypeDescription {
+  readonly '@type': 'EventLogging.EventTypeDescription';
+
   /**
    * Used for a description of the event type.
    */
-  Description: string;
+  readonly Description: string;
 
   /**
    * An identifier associated with the event type.
    */
-  Type: string;
+  readonly Type: string;
 }
 
 /**
  * Schema for {@link EventTypeDescription}.
  */
 export const EventTypeDescriptionSchema: z.ZodSchema<EventTypeDescription> = z.object({
+  '@type': z.literal('EventLogging.EventTypeDescription'),
   Description: z.string(),
   Type: z.string(),
 });

--- a/libs/logging/src/log_documentation.ts
+++ b/libs/logging/src/log_documentation.ts
@@ -54,6 +54,7 @@ export function generateCdfLogDocumentationFileContent(
     (eventType) => {
       const eventTypeInformation = getDocumentationForEventType(eventType);
       return {
+        '@type': 'EventLogging.EventTypeDescription',
         Description: eventTypeInformation.documentationMessage,
         Type: eventType,
       };
@@ -68,11 +69,13 @@ export function generateCdfLogDocumentationFileContent(
     )
     .map((eventIdDetails) => {
       return {
+        '@type': 'EventLogging.EventIdDescription',
         Id: eventIdDetails.eventId,
         Description: eventIdDetails.documentationMessage,
       };
     });
   const documentationLog: ElectionEventLogDocumentation = {
+    '@type': 'EventLogging.ElectionEventLogDocumentation',
     DeviceManufacturer: machineManufacturer,
     DeviceModel: machineModel,
     EventIdDescription: allEventIdsForDevice,

--- a/libs/logging/src/logger.test.ts
+++ b/libs/logging/src/logger.test.ts
@@ -140,7 +140,7 @@ describe('test cdf conversion', () => {
     expect(cdfLog.GeneratedTime).toMatchInlineSnapshot(
       `"2020-07-24T00:00:00.000Z"`
     );
-    const cdfLogDevice = cdfLog.Device[0];
+    const cdfLogDevice = cdfLog.Device?.[0];
     assert(cdfLogDevice);
     expect(cdfLogDevice.Id).toBe('12machine34');
     expect(cdfLogDevice.Version).toBe('thisisacodeversion');
@@ -163,10 +163,10 @@ describe('test cdf conversion', () => {
     const cdfLog = cdfLogResult.ok();
     assert(cdfLog);
     expect(cdfLog.Device).toHaveLength(1);
-    const cdfLogDevice = cdfLog.Device[0];
+    const cdfLogDevice = cdfLog.Device?.[0];
     assert(cdfLogDevice);
     expect(cdfLogDevice.Event).toHaveLength(1);
-    const decodedEvent = cdfLogDevice.Event[0];
+    const decodedEvent = cdfLogDevice.Event?.[0];
     assert(decodedEvent);
     expect(decodedEvent.Id).toBe(LogEventId.UsbDriveStatusUpdate);
     expect(decodedEvent.Disposition).toBe('na');
@@ -202,10 +202,10 @@ describe('test cdf conversion', () => {
     const cdfLog = cdfLogResult.ok();
     assert(cdfLog);
     expect(cdfLog.Device).toHaveLength(1);
-    const cdfLogDevice = cdfLog.Device[0];
+    const cdfLogDevice = cdfLog.Device?.[0];
     assert(cdfLogDevice);
     expect(cdfLogDevice.Event).toHaveLength(1);
-    const decodedEvent = cdfLogDevice.Event[0];
+    const decodedEvent = cdfLogDevice.Event?.[0];
     assert(decodedEvent);
     expect(decodedEvent.Disposition).toBe('na');
   });
@@ -224,10 +224,10 @@ describe('test cdf conversion', () => {
     const cdfLog = cdfLogResult.ok();
     assert(cdfLog);
     expect(cdfLog.Device).toHaveLength(1);
-    const cdfLogDevice = cdfLog.Device[0];
+    const cdfLogDevice = cdfLog.Device?.[0];
     assert(cdfLogDevice);
     expect(cdfLogDevice.Event).toHaveLength(1);
-    const decodedEvent = cdfLogDevice.Event[0];
+    const decodedEvent = cdfLogDevice.Event?.[0];
     assert(decodedEvent);
     expect(decodedEvent.Id).toBe(LogEventId.UsbDriveStatusUpdate);
     expect(decodedEvent.Disposition).toBe('other');
@@ -299,7 +299,7 @@ describe('test cdf conversion', () => {
     expect(cdfLogResult.isOk()).toBeTruthy();
     const cdfLog = cdfLogResult.ok();
     assert(cdfLog);
-    expect(cdfLog.Device[0]!.Event).toHaveLength(1);
+    expect(cdfLog.Device?.[0]!.Event).toHaveLength(1);
 
     const output2 = logger.buildCDFLog(
       electionMinimalExhaustiveSampleDefintion,
@@ -320,13 +320,11 @@ describe('test cdf conversion', () => {
     expect(cdfLogResult2.isOk()).toBeTruthy();
     const cdfLog2 = cdfLogResult2.ok();
     assert(cdfLog2);
-    expect(cdfLog2.Device[0]!.Event).toStrictEqual([]);
+    expect(cdfLog2.Device?.[0]!.Event).toStrictEqual([]);
   });
 
   test('read and interpret a real log file as expected', async () => {
-    const logFile = await readFileSync(
-      join(__dirname, '../fixtures/samplelog.log')
-    );
+    const logFile = readFileSync(join(__dirname, '../fixtures/samplelog.log'));
     const logger = new Logger(LogSource.VxAdminFrontend);
     const cdfLogContent = logger.buildCDFLog(
       electionMinimalExhaustiveSampleDefintion,
@@ -346,12 +344,12 @@ describe('test cdf conversion', () => {
     expect(cdfLog.GeneratedTime).toMatchInlineSnapshot(
       `"2020-07-24T00:00:00.000Z"`
     );
-    const cdfLogDevice = cdfLog.Device[0];
+    const cdfLogDevice = cdfLog.Device?.[0];
     assert(cdfLogDevice);
     expect(cdfLogDevice.Id).toBe('1234');
     expect(cdfLogDevice.Version).toBe('codeversion');
     expect(cdfLogDevice.Type).toBe('ems');
-    const events = cdfLogDevice.Event;
+    const events = cdfLogDevice.Event!;
     // There are 37 log lines in the sample file.
     expect(events).toHaveLength(37);
     // There should be one admin-card-inserted log from the application logging.
@@ -370,6 +368,7 @@ describe('test cdf conversion', () => {
     expect(events.filter((e) => e.Id === LogEventId.MachineLocked)[0])
       .toMatchInlineSnapshot(`
       Object {
+        "@type": "EventLogging.Event",
         "Description": "The current user was logged out and the machine was locked.",
         "Details": "{\\"host\\":\\"ubuntu\\",\\"source\\":\\"vx-admin-frontend\\"}",
         "Disposition": "success",
@@ -385,6 +384,7 @@ describe('test cdf conversion', () => {
     expect(events.filter((e) => e.Id === LogEventId.UsbDeviceChangeDetected)[0])
       .toMatchInlineSnapshot(`
       Object {
+        "@type": "EventLogging.Event",
         "Description": "usblp1: removed",
         "Details": "{\\"host\\":\\"ubuntu\\",\\"source\\":\\"system\\"}",
         "Disposition": "na",

--- a/libs/logging/src/logger.ts
+++ b/libs/logging/src/logger.ts
@@ -145,8 +145,11 @@ export class Logger {
         ? EventDispositionType.Na
         : EventDispositionType.Other;
       const cdfEvent: Event = {
+        '@type': 'EventLogging.Event',
         Id: decodedLog.eventId,
         Disposition: disposition,
+        OtherDisposition:
+          disposition === 'other' ? decodedLog.disposition : undefined,
         Sequence: idx.toString(),
         TimeStamp: decodedLog.timeLogWritten,
         Type: decodedLog.eventType,
@@ -157,19 +160,18 @@ export class Logger {
         }),
         UserId: decodedLog.user,
       };
-      if (disposition === 'other') {
-        cdfEvent.OtherDisposition = decodedLog.disposition;
-      }
       allEvents.push(cdfEvent);
     }
 
     const currentDevice: Device = {
+      '@type': 'EventLogging.Device',
       Type: DEVICE_TYPES_FOR_APP[this.source],
       Id: machineId,
       Version: codeVersion,
       Event: allEvents,
     };
     const eventElectionLog: ElectionEventLog = {
+      '@type': 'EventLogging.ElectionEventLog',
       Device: [currentDevice],
       ElectionId: electionDefinition.electionHash,
       GeneratedTime: new Date().toISOString(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,7 +194,7 @@ importers:
       dompurify: 2.2.6
       fetch-mock: 9.11.0
       history: 4.10.1
-      http-proxy-middleware: 1.0.6
+      http-proxy-middleware: 1.0.6_debug@4.3.2
       lodash.camelcase: 4.3.0
       luxon: 1.26.0
       mockdate: 3.0.2
@@ -542,7 +542,7 @@ importers:
       dompurify: 2.2.6
       fetch-mock: 9.11.0
       history: 4.10.1
-      http-proxy-middleware: 1.0.6
+      http-proxy-middleware: 1.0.6_debug@4.3.2
       i18next: 19.8.4
       js-file-download: 0.4.12
       js-sha256: 0.9.0
@@ -725,7 +725,7 @@ importers:
       base64-js: 1.5.1
       debug: 4.3.1
       fetch-mock: 9.11.0
-      http-proxy-middleware: 1.0.6
+      http-proxy-middleware: 1.0.6_debug@4.3.1
       i18next: 19.8.4
       jest-fetch-mock: 3.0.3
       js-file-download: 0.4.12
@@ -1055,9 +1055,11 @@ importers:
       '@votingworks/types': link:../types
       '@votingworks/utils': link:../utils
       jsdom: 19.0.0
+      json-schema: 0.4.0
     devDependencies:
       '@types/jest': 27.0.3
       '@types/jsdom': 16.2.13
+      '@types/json-schema': 7.0.9
       '@types/node': 14.18.0
       '@typescript-eslint/eslint-plugin': 4.33.0_3289a875d95a672b97ebf589745c66ef
       '@typescript-eslint/parser': 4.33.0_eslint@7.32.0+typescript@4.5.4
@@ -1081,6 +1083,7 @@ importers:
     specifiers:
       '@types/jest': ^27.0.3
       '@types/jsdom': ^16.2.13
+      '@types/json-schema': ^7.0.9
       '@types/node': ^14.14.20
       '@typescript-eslint/eslint-plugin': ^4.29.3
       '@typescript-eslint/parser': ^4.29.3
@@ -1099,6 +1102,7 @@ importers:
       jest: ^27.3.1
       jest-watch-typeahead: ^0.6.1
       jsdom: ^19.0.0
+      json-schema: ^0.4.0
       lint-staged: ^10.5.1
       prettier: ^2.1.2
       sort-package-json: ^1.50.0
@@ -5435,7 +5439,7 @@ packages:
       jest-regex-util: 27.0.6
       jest-resolve: 27.3.1
       jest-resolve-dependencies: 27.3.1
-      jest-runner: 27.3.1
+      jest-runner: 27.3.1_canvas@2.6.1
       jest-runtime: 27.3.1
       jest-snapshot: 27.3.1
       jest-util: 27.3.1
@@ -5476,7 +5480,7 @@ packages:
       jest-regex-util: 27.0.6
       jest-resolve: 27.3.1
       jest-resolve-dependencies: 27.3.1
-      jest-runner: 27.3.1
+      jest-runner: 27.3.1_canvas@2.6.1
       jest-runtime: 27.3.1
       jest-snapshot: 27.3.1
       jest-util: 27.3.1
@@ -9545,7 +9549,7 @@ packages:
       integrity: sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA==
   /axios/0.21.1_debug@4.3.1:
     dependencies:
-      follow-redirects: 1.14.1_debug@4.3.2
+      follow-redirects: 1.14.1_debug@4.3.1
     dev: true
     peerDependencies:
       debug: '*'
@@ -15488,7 +15492,6 @@ packages:
   /follow-redirects/1.14.1_debug@4.3.1:
     dependencies:
       debug: 4.3.1
-    dev: false
     engines:
       node: '>=4.0'
     peerDependencies:
@@ -15500,7 +15503,8 @@ packages:
       integrity: sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
   /follow-redirects/1.14.1_debug@4.3.2:
     dependencies:
-      debug: 4.3.2_supports-color@6.1.0
+      debug: 4.3.2
+    dev: false
     engines:
       node: '>=4.0'
     peerDependencies:
@@ -16429,6 +16433,34 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
+  /http-proxy-middleware/1.0.6_debug@4.3.1:
+    dependencies:
+      '@types/http-proxy': 1.17.6
+      http-proxy: 1.18.1_debug@4.3.1
+      is-glob: 4.0.1
+      lodash: 4.17.21
+      micromatch: 4.0.4
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    peerDependencies:
+      debug: '*'
+    resolution:
+      integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
+  /http-proxy-middleware/1.0.6_debug@4.3.2:
+    dependencies:
+      '@types/http-proxy': 1.17.6
+      http-proxy: 1.18.1_debug@4.3.2
+      is-glob: 4.0.1
+      lodash: 4.17.21
+      micromatch: 4.0.4
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    peerDependencies:
+      debug: '*'
+    resolution:
+      integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
   /http-proxy/1.18.1:
     dependencies:
       eventemitter3: 4.0.7
@@ -16437,6 +16469,18 @@ packages:
     dev: false
     engines:
       node: '>=8.0.0'
+    resolution:
+      integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
+  /http-proxy/1.18.1_debug@4.3.1:
+    dependencies:
+      eventemitter3: 4.0.7
+      follow-redirects: 1.14.1_debug@4.3.1
+      requires-port: 1.0.0
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    peerDependencies:
+      debug: '*'
     resolution:
       integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
   /http-proxy/1.18.1_debug@4.3.2:
@@ -17791,7 +17835,7 @@ packages:
       jest-jasmine2: 27.3.1
       jest-regex-util: 27.0.6
       jest-resolve: 27.3.1
-      jest-runner: 27.3.1
+      jest-runner: 27.3.1_canvas@2.6.1
       jest-util: 27.3.1
       jest-validate: 27.3.1
       micromatch: 4.0.4
@@ -17825,7 +17869,7 @@ packages:
       jest-jasmine2: 27.3.1
       jest-regex-util: 27.0.6
       jest-resolve: 27.3.1
-      jest-runner: 27.3.1
+      jest-runner: 27.3.1_canvas@2.6.1
       jest-util: 27.3.1
       jest-validate: 27.3.1
       micromatch: 4.0.4
@@ -18838,6 +18882,37 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-r4W6kBn6sPr3TBwQNmqE94mPlYVn7fLBseeJfo4E2uCTmAyDFm2O5DYAQAFP7Q3YfiA/bMwg8TVsciP7k0xOww==
+  /jest-runner/27.3.1_canvas@2.6.1:
+    dependencies:
+      '@jest/console': 27.3.1
+      '@jest/environment': 27.3.1
+      '@jest/test-result': 27.3.1
+      '@jest/transform': 27.3.1
+      '@jest/types': 27.2.5
+      '@types/node': 15.3.0
+      chalk: 4.1.2
+      emittery: 0.8.1
+      exit: 0.1.2
+      graceful-fs: 4.2.4
+      jest-docblock: 27.0.6
+      jest-environment-jsdom: 27.3.1_canvas@2.6.1
+      jest-environment-node: 27.3.1
+      jest-haste-map: 27.3.1
+      jest-leak-detector: 27.3.1
+      jest-message-util: 27.3.1
+      jest-resolve: 27.3.1
+      jest-runtime: 27.3.1
+      jest-util: 27.3.1
+      jest-worker: 27.3.1
+      source-map-support: 0.5.20
+      throat: 6.0.1
+    dev: true
+    engines:
+      node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
+    peerDependencies:
+      canvas: '*'
+    resolution:
+      integrity: sha512-r4W6kBn6sPr3TBwQNmqE94mPlYVn7fLBseeJfo4E2uCTmAyDFm2O5DYAQAFP7Q3YfiA/bMwg8TVsciP7k0xOww==
   /jest-runner/27.4.5:
     dependencies:
       '@jest/console': 27.4.2
@@ -19741,6 +19816,10 @@ packages:
     dev: true
     resolution:
       integrity: sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
+  /json-schema/0.4.0:
+    dev: false
+    resolution:
+      integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
   /json-stable-stringify-without-jsonify/1.0.1:
     resolution:
       integrity: sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=


### PR DESCRIPTION
The problem with using only the XSD schema is that it doesn't properly encode entity references, i.e. one "complex type" cannot reference any other type by name. It uses a generic IDREF type that doesn't actually say what type it references. This may be fine for navigating a concrete XML document, but is bad for static generation of code. The JSON schema does actually contain a reference to the type definition, but not the documentation. So this PR combines the two favoring the JSON schema since that's what we're actually going to be using in practice, and just uses the XSD one for documentation.

Building based on the JSON schema changed the structure a little bit, so I had to regenerate the event logging CDF library and fix the fallout from that. Pretty minor, all told.