### PR TITLE
feat(smartcards): Detect and expose card connection errors

### DIFF
--- a/frontends/bas/src/app_root.tsx
+++ b/frontends/bas/src/app_root.tsx
@@ -152,15 +152,18 @@ export function AppRoot({ card, hardware, storage }: Props): JSX.Element {
 
   useEffect(() => {
     void (async () => {
-      const { data } = smartcard;
       setIsCardPresent(smartcard.status === 'ready');
-      setIsAdminCardPresent(data?.t === 'admin');
-      setIsPollWorkerCardPresent(data?.t === 'pollworker');
-      setIsWritableCard(data?.t === 'voter');
+      setIsAdminCardPresent(smartcard.data?.t === 'admin');
+      setIsPollWorkerCardPresent(smartcard.data?.t === 'pollworker');
+      setIsWritableCard(smartcard.data?.t === 'voter');
       setIsLocked((prev) =>
-        data?.t === 'admin' ? true : data?.t === 'pollworker' ? false : prev
+        smartcard.data?.t === 'admin'
+          ? true
+          : smartcard.data?.t === 'pollworker'
+          ? false
+          : prev
       );
-      if (!data) {
+      if (!smartcard.data) {
         setIsReadyToRemove(false);
       }
     })();

--- a/frontends/bas/src/app_root.tsx
+++ b/frontends/bas/src/app_root.tsx
@@ -15,7 +15,7 @@ import {
   useSmartcard,
   useStoredState,
 } from '@votingworks/ui';
-import { Card, Hardware, sleep, Storage } from '@votingworks/utils';
+import { assert, Card, Hardware, sleep, Storage } from '@votingworks/utils';
 
 import { z } from 'zod';
 import { EventTargetFunction } from './config/types';
@@ -140,7 +140,8 @@ export function AppRoot({ card, hardware, storage }: Props): JSX.Element {
 
   const fetchElection = useCallback(async () => {
     setIsLoadingElection(true);
-    const longValue = (await smartcard?.readLongString())?.unsafeUnwrap();
+    assert(smartcard.status === 'ready');
+    const longValue = (await smartcard.readLongString()).unsafeUnwrap();
     setElection(safeParseElection(longValue).unsafeUnwrap());
     setIsLoadingElection(false);
   }, [setElection, smartcard]);
@@ -151,18 +152,15 @@ export function AppRoot({ card, hardware, storage }: Props): JSX.Element {
 
   useEffect(() => {
     void (async () => {
-      setIsCardPresent(!!smartcard);
-      setIsAdminCardPresent(smartcard?.data?.t === 'admin');
-      setIsPollWorkerCardPresent(smartcard?.data?.t === 'pollworker');
-      setIsWritableCard(smartcard?.data?.t === 'voter');
+      const { data } = smartcard;
+      setIsCardPresent(smartcard.status === 'ready');
+      setIsAdminCardPresent(data?.t === 'admin');
+      setIsPollWorkerCardPresent(data?.t === 'pollworker');
+      setIsWritableCard(data?.t === 'voter');
       setIsLocked((prev) =>
-        smartcard?.data?.t === 'admin'
-          ? true
-          : smartcard?.data?.t === 'pollworker'
-          ? false
-          : prev
+        data?.t === 'admin' ? true : data?.t === 'pollworker' ? false : prev
       );
-      if (!smartcard?.data) {
+      if (!data) {
         setIsReadyToRemove(false);
       }
     })();
@@ -184,9 +182,10 @@ export function AppRoot({ card, hardware, storage }: Props): JSX.Element {
           pr: precinctId,
           bs: localBallotStyleId,
         };
-        const writeResult = await smartcard?.writeShortValue(
-          JSON.stringify(code)
-        );
+        const writeResult =
+          smartcard.status === 'ready'
+            ? await smartcard.writeShortValue(JSON.stringify(code))
+            : null;
         if (!writeResult?.isOk()) {
           // TODO: UI Notification if unable to write to card
           // https://github.com/votingworks/bas/issues/10

--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -364,6 +364,7 @@ export function AppRoot({
       validUserTypes: VALID_USERS,
     }
   );
+  const hasCardInserted = currentUserSession?.type;
 
   const makeCancelable = useCancelablePromise();
 
@@ -615,14 +616,14 @@ export function AppRoot({
       isScannerConfigured &&
       electionDefinition &&
       isPollsOpen &&
-      smartcard.status === 'no_card'
+      hasCardInserted
     ) {
       startBallotStatusPolling();
     } else {
       endBallotStatusPolling();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isScannerConfigured, electionDefinition, isPollsOpen, smartcard.status]);
+  }, [isScannerConfigured, electionDefinition, isPollsOpen, hasCardInserted]);
 
   const setElectionDefinition = useCallback(
     async (newElectionDefinition: OptionalElectionDefinition) => {

--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -55,7 +55,6 @@ import * as scan from './api/scan';
 import { usePrecinctScanner } from './hooks/use_precinct_scanner';
 import { AdminScreen } from './screens/admin_screen';
 import { InvalidCardScreen } from './screens/invalid_card_screen';
-import { CardErrorScreen } from './screens/card_error_screen';
 import { PollsClosedScreen } from './screens/polls_closed_screen';
 import { PollWorkerScreen } from './screens/poll_worker_screen';
 import { InsertBallotScreen } from './screens/insert_ballot_screen';
@@ -747,10 +746,6 @@ export function AppRoot({
 
   if (!hasCardReaderAttached) {
     return <SetupCardReaderPage />;
-  }
-
-  if (smartcard.status === 'error') {
-    return <CardErrorScreen />;
   }
 
   if (hasLowBattery && !hasChargerAttached) {

--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -55,6 +55,7 @@ import * as scan from './api/scan';
 import { usePrecinctScanner } from './hooks/use_precinct_scanner';
 import { AdminScreen } from './screens/admin_screen';
 import { InvalidCardScreen } from './screens/invalid_card_screen';
+import { CardErrorScreen } from './screens/card_error_screen';
 import { PollsClosedScreen } from './screens/polls_closed_screen';
 import { PollWorkerScreen } from './screens/poll_worker_screen';
 import { InsertBallotScreen } from './screens/insert_ballot_screen';
@@ -364,7 +365,6 @@ export function AppRoot({
       validUserTypes: VALID_USERS,
     }
   );
-  const hasCardInserted = currentUserSession?.type;
 
   const makeCancelable = useCancelablePromise();
 
@@ -616,14 +616,14 @@ export function AppRoot({
       isScannerConfigured &&
       electionDefinition &&
       isPollsOpen &&
-      !hasCardInserted
+      smartcard.status === 'no_card'
     ) {
       startBallotStatusPolling();
     } else {
       endBallotStatusPolling();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isScannerConfigured, electionDefinition, isPollsOpen, hasCardInserted]);
+  }, [isScannerConfigured, electionDefinition, isPollsOpen, smartcard.status]);
 
   const setElectionDefinition = useCallback(
     async (newElectionDefinition: OptionalElectionDefinition) => {
@@ -747,6 +747,10 @@ export function AppRoot({
 
   if (!hasCardReaderAttached) {
     return <SetupCardReaderPage />;
+  }
+
+  if (smartcard.status === 'error') {
+    return <CardErrorScreen />;
   }
 
   if (hasLowBattery && !hasChargerAttached) {

--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -616,7 +616,7 @@ export function AppRoot({
       isScannerConfigured &&
       electionDefinition &&
       isPollsOpen &&
-      hasCardInserted
+      !hasCardInserted
     ) {
       startBallotStatusPolling();
     } else {

--- a/libs/ui/src/hooks/use_smartcard.ts
+++ b/libs/ui/src/hooks/use_smartcard.ts
@@ -29,7 +29,11 @@ interface SmartcardReady {
   writeLongValue(value: unknown | Uint8Array): Promise<Result<void, Error>>;
 }
 
-type SmartcardNotReady = CardApiNotReady;
+interface SmartcardNotReady extends CardApiNotReady {
+  // We make data present even if the card is not ready for easy
+  // nullish-coalescing by consumers.
+  data: undefined;
+}
 
 export type Smartcard = SmartcardReady | SmartcardNotReady;
 

--- a/libs/ui/src/hooks/use_smartcard.ts
+++ b/libs/ui/src/hooks/use_smartcard.ts
@@ -32,7 +32,7 @@ interface SmartcardReady {
 interface SmartcardNotReady extends CardApiNotReady {
   // We make data present even if the card is not ready for easy
   // nullish-coalescing by consumers.
-  data: undefined;
+  data?: undefined;
 }
 
 export type Smartcard = SmartcardReady | SmartcardNotReady;

--- a/libs/ui/src/hooks/use_user_session.ts
+++ b/libs/ui/src/hooks/use_user_session.ts
@@ -16,7 +16,7 @@ import { Smartcard } from '..';
 import { usePrevious } from './use_previous';
 
 export interface UseUserSessionProps {
-  smartcard?: Smartcard;
+  smartcard: Smartcard;
   electionDefinition?: ElectionDefinition;
   persistAuthentication: boolean; // Persist an authenticated admin session when the admin card is removed.
   bypassAuthentication?: boolean; // Always maintain an authenticated admin session for frontends persisting authentication, and remove the need to authenticate admin cards for non-persisting admins.
@@ -180,7 +180,7 @@ export function useUserSession({
           };
         }
 
-        if (smartcard) {
+        if (smartcard.status === 'ready') {
           if (persistAuthentication && previousIsAuthenticatedAdmin) {
             return prev;
           }
@@ -251,7 +251,7 @@ export function useUserSession({
       let isAdminCard = false;
       let passcodeMatches = false;
       // The card must be an admin card to authenticate
-      if (smartcard?.data?.t === 'admin') {
+      if (smartcard.status === 'ready' && smartcard.data?.t === 'admin') {
         isAdminCard = true;
         // There must be an expected passcode on the card to authenticate.
         if (typeof smartcard.data.p === 'string') {

--- a/libs/utils/src/Card/memory_card.test.ts
+++ b/libs/utils/src/Card/memory_card.test.ts
@@ -5,7 +5,7 @@ const AbSchema = z.object({ a: z.number(), b: z.number() });
 
 it('defaults to no card', async () => {
   expect(await new MemoryCard().readStatus()).toEqual({
-    present: false,
+    status: 'no_card',
   });
 });
 
@@ -45,7 +45,7 @@ it('can set a short and long value using #insertCard', async () => {
   const card = new MemoryCard().insertCard('abc', Uint8Array.of(1, 2, 3));
 
   expect(await card.readStatus()).toEqual({
-    present: true,
+    status: 'ready',
     shortValue: 'abc',
     longValueExists: true,
   });
@@ -69,7 +69,7 @@ it('can remove a card using #removeCard', async () => {
     .removeCard();
 
   expect(await card.readStatus()).toEqual({
-    present: false,
+    status: 'no_card',
   });
 });
 

--- a/libs/utils/src/Card/memory_card.ts
+++ b/libs/utils/src/Card/memory_card.ts
@@ -6,7 +6,7 @@ import { Card, CardApi } from '../types';
  * Implements the `Card` API with an in-memory implementation.
  */
 export class MemoryCard implements Card {
-  private present = false;
+  private status: CardApi['status'] = 'no_card';
 
   private shortValue?: string;
 
@@ -17,19 +17,19 @@ export class MemoryCard implements Card {
    * what its short value is and whether it has a long value.
    */
   async readStatus(): Promise<CardApi> {
-    const { present, shortValue } = this;
+    const { status, shortValue } = this;
 
-    if (present) {
+    if (status === 'ready') {
       const longValueExists =
         typeof this.longValue !== 'undefined' && this.longValue.length > 0;
 
       return {
-        present,
+        status,
         shortValue,
         longValueExists,
       };
     }
-    return { present };
+    return { status };
   }
 
   /**
@@ -74,7 +74,7 @@ export class MemoryCard implements Card {
    * Writes a new short value to the card.
    */
   async writeShortValue(value: string): Promise<void> {
-    if (!this.present) {
+    if (this.status !== 'ready') {
       throw new Error('cannot write short value when no card is present');
     }
 
@@ -94,7 +94,7 @@ export class MemoryCard implements Card {
    * Writes binary data to the long value.
    */
   async writeLongUint8Array(value: Uint8Array): Promise<void> {
-    if (!this.present) {
+    if (this.status !== 'ready') {
       throw new Error('cannot write long value when no card is present');
     }
 
@@ -105,7 +105,7 @@ export class MemoryCard implements Card {
    * Removes the simulated in-memory card.
    */
   removeCard(): this {
-    this.present = false;
+    this.status = 'no_card';
     this.shortValue = undefined;
     this.longValue = undefined;
     return this;
@@ -126,7 +126,7 @@ export class MemoryCard implements Card {
         : longValue instanceof Uint8Array
         ? Uint8Array.from(longValue)
         : new TextEncoder().encode(longValue);
-    this.present = true;
+    this.status = 'ready';
     return this;
   }
 }

--- a/libs/utils/src/Card/memory_card.ts
+++ b/libs/utils/src/Card/memory_card.ts
@@ -116,7 +116,8 @@ export class MemoryCard implements Card {
    */
   insertCard(
     shortValue?: string | unknown,
-    longValue?: string | Uint8Array
+    longValue?: string | Uint8Array,
+    status: 'ready' | 'error' = 'ready'
   ): this {
     this.shortValue =
       typeof shortValue === 'string' ? shortValue : JSON.stringify(shortValue);
@@ -126,7 +127,7 @@ export class MemoryCard implements Card {
         : longValue instanceof Uint8Array
         ? Uint8Array.from(longValue)
         : new TextEncoder().encode(longValue);
-    this.status = 'ready';
+    this.status = status;
     return this;
   }
 }

--- a/libs/utils/src/Card/web_service_card.test.ts
+++ b/libs/utils/src/Card/web_service_card.test.ts
@@ -2,23 +2,23 @@ import { fromByteArray, toByteArray } from 'base64-js';
 import fetchMock, { MockRequest } from 'fetch-mock';
 import { z } from 'zod';
 import { WebServiceCard } from '.';
-import { CardPresentApi, typedAs } from '../types';
+import { CardApiReady, typedAs } from '../types';
 
 const AbSchema = z.object({ a: z.number(), b: z.number() });
 
 it('fetches card status and short value from /card/read', async () => {
   fetchMock.get(
     '/card/read',
-    typedAs<CardPresentApi>({
-      present: true,
+    typedAs<CardApiReady>({
+      status: 'ready',
       shortValue: 'abc',
       longValueExists: true,
     })
   );
 
   expect(await new WebServiceCard().readStatus()).toEqual(
-    typedAs<CardPresentApi>({
-      present: true,
+    typedAs<CardApiReady>({
+      status: 'ready',
       shortValue: 'abc',
       longValueExists: true,
     })

--- a/libs/utils/src/types.ts
+++ b/libs/utils/src/types.ts
@@ -97,26 +97,27 @@ export interface Storage {
   clear(): Promise<void>;
 }
 
-export interface CardAbsentApi {
-  present: false;
+export interface CardApiNotReady {
+  status: 'no_card' | 'error';
 }
-export const CardAbsentApiSchema: z.ZodSchema<CardAbsentApi> = z.object({
-  present: z.literal(false),
-});
-export interface CardPresentApi {
-  present: true;
+export interface CardApiReady {
+  status: 'ready';
   shortValue?: string;
   longValueExists?: boolean;
 }
-export const CardPresentApiSchema: z.ZodSchema<CardPresentApi> = z.object({
-  present: z.literal(true),
+export type CardApi = CardApiNotReady | CardApiReady;
+
+export const CardApiNotReadySchema: z.ZodSchema<CardApiNotReady> = z.object({
+  status: z.enum(['no_card', 'error']),
+});
+export const CardApiReadySchema: z.ZodSchema<CardApiReady> = z.object({
+  status: z.literal('ready'),
   shortValue: z.string().optional(),
   longValueExists: z.boolean().optional(),
 });
-export type CardApi = CardAbsentApi | CardPresentApi;
 export const CardApiSchema: z.ZodSchema<CardApi> = z.union([
-  CardAbsentApiSchema,
-  CardPresentApiSchema,
+  CardApiNotReadySchema,
+  CardApiReadySchema,
 ]);
 
 /**

--- a/services/smartcards/smartcards/card.py
+++ b/services/smartcards/smartcards/card.py
@@ -22,6 +22,7 @@
 # <long_value_hash> - 32 bytes
 # <long_value> - up to 16,468 bytes
 
+from enum import Enum
 import smartcard.System
 from smartcard.CardMonitoring import CardMonitor, CardObserver
 from smartcard.ReaderMonitoring import ReaderMonitor, ReaderObserver
@@ -311,6 +312,13 @@ class VXReaderObserver(ReaderObserver):
 SingletonReaderObserver = VXReaderObserver()
 
 
+class CardStatus(str, Enum):
+    NoCard = "no_card"
+    Reading = "reading"
+    Ready = "ready"
+    Error = "error"
+
+
 class VXCardObserver(CardObserver):
     def __init__(self):
         self.card = None
@@ -331,8 +339,15 @@ class VXCardObserver(CardObserver):
         if self.card:
             self.card.override_protection()
 
-    def has_connection_error(self):
-        return self.connection_error is not None
+    def status(self) -> CardStatus:
+        if self.connection_error is not None:
+            return CardStatus.Error
+        elif self.card_ready:
+            return CardStatus.Ready
+        elif self.card is not None:
+            return CardStatus.Reading
+        else:
+            return CardStatus.NoCard
 
     def read(self):
         if self.card and self.card_ready:

--- a/services/smartcards/smartcards/core.py
+++ b/services/smartcards/smartcards/core.py
@@ -26,6 +26,9 @@ def card_reader():
 
 @app.route('/card/read')
 def card_read():
+    if CardInterface.has_connection_error():
+        return json.dumps({"present": True, "connectionError": True})
+
     card_bytes, long_value_exists = CardInterface.read()
     if card_bytes is None:
         return json.dumps({"present": False})
@@ -166,7 +169,8 @@ def update_mock():  # pragma: no cover this is just for testing
             MockInstance.insert_card(
                 short_value,
                 long_value,
-                write_protected
+                write_protected,
+                data.get("connectionError", False),
             )
         else:
             MockInstance.remove_card()

--- a/services/smartcards/smartcards/core.py
+++ b/services/smartcards/smartcards/core.py
@@ -27,16 +27,21 @@ def card_reader():
 @app.route('/card/read')
 def card_read():
     status = CardInterface.status()
-    if status != CardStatus.Ready:
-        return json.dumps({"status": status})
+    # To make things simpler for the client, if we're in the process of reading
+    # the card, we'll treat it like there's no card yet.
+    if status in [CardStatus.NoCard, CardStatus.Reading]:
+        return json.dumps({"status": "no_card"})
+    if status == CardStatus.Error:
+        return json.dumps({"status": "error"})
+    assert status == CardStatus.Ready
 
     card_bytes, long_value_exists = CardInterface.read()
     assert card_bytes is not None
     card_data = card_bytes.decode('utf-8')
     if card_data:
-        return json.dumps({"status": status, "shortValue": card_data, "longValueExists": long_value_exists})
+        return json.dumps({"status": "ready", "shortValue": card_data, "longValueExists": long_value_exists})
     else:
-        return json.dumps({"status": status})
+        return json.dumps({"status": "ready"})
 
 
 @app.route('/card/read_long')

--- a/services/smartcards/smartcards/mockcard.py
+++ b/services/smartcards/smartcards/mockcard.py
@@ -11,6 +11,9 @@ class MockCard:  # pragma: no cover this is just for mocking
     def is_reader_connected(self):
         return True
 
+    def has_connection_error(self):
+        return self.connection_error
+
     def override_protection(self):
         if not self.has_card:
             return
@@ -53,14 +56,16 @@ class MockCard:  # pragma: no cover this is just for mocking
 
         return True
 
-    def insert_card(self, short_value=None, long_value=None, write_protected=False):
-        self.has_card = True
+    def insert_card(self, short_value=None, long_value=None, write_protected=False, connection_error=False):
+        self.connection_error = connection_error
+        self.has_card = not connection_error
         self.short_value = short_value
         self.long_value = long_value
         self.write_protected = write_protected
         return self
 
     def remove_card(self):
+        self.connection_error = False
         self.has_card = False
         self.short_value = None
         self.long_value = None

--- a/services/smartcards/smartcards/mockcard.py
+++ b/services/smartcards/smartcards/mockcard.py
@@ -1,5 +1,7 @@
 import os
 
+from smartcards.card import CardStatus
+
 
 class MockCard:  # pragma: no cover this is just for mocking
     def __init__(self, short_value=None, long_value=None, write_protected=False):
@@ -11,8 +13,13 @@ class MockCard:  # pragma: no cover this is just for mocking
     def is_reader_connected(self):
         return True
 
-    def has_connection_error(self):
-        return self.connection_error
+    def status(self):
+        if self.connection_error:
+            return CardStatus.Error
+        elif self.has_card:
+            return CardStatus.Ready
+        else:
+            return CardStatus.NoCard
 
     def override_protection(self):
         if not self.has_card:

--- a/services/smartcards/tests/test_core.py
+++ b/services/smartcards/tests/test_core.py
@@ -64,6 +64,14 @@ def test_card_read_no_cardreader(client):
     assert rv['present'] == False
 
 
+def test_card_read_connection_error(client):
+    client.put('/mock', data=json.dumps({"connectionError": True}))
+
+    rv = json.loads(client.get("/card/read").data)
+    assert rv['present']
+    assert rv['connectionError']
+
+
 def test_card_read_long(client):
     client.put(
         '/mock', data=json.dumps({'shortValue': 'XYZ', 'longValue': 'Hello 1 2 3'}))

--- a/services/smartcards/tests/test_core.py
+++ b/services/smartcards/tests/test_core.py
@@ -35,9 +35,8 @@ def test_card_read(client):
     client.put('/mock', data=json.dumps({'shortValue': 'XYZ'}))
 
     rv = json.loads(client.get("/card/read").data)
-    assert rv['present']
-    assert rv['shortValue'] == 'XYZ'
-    assert not rv['longValueExists']
+    assert rv == {"status": "ready",
+                  "shortValue": "XYZ", "longValueExists": False}
 
     rv = json.loads(client.get("/card/read_long").data)
     assert rv == {}
@@ -47,29 +46,26 @@ def test_card_read_badcard(client):
     client.put('/mock', data=json.dumps({'shortValue': ''}))
 
     rv = json.loads(client.get("/card/read").data)
-    assert rv['present']
-    assert 'shortValue' not in rv
+    assert rv == {"status": "ready"}
 
 
 def test_card_read_nocard(client):
-    client.put('/mock', data=json.dumps({'shortValue': None}))
+    client.put('/mock', data=json.dumps({'hasCard': False}))
 
     rv = json.loads(client.get("/card/read").data)
-    assert not rv['present']
-    assert 'shortValue' not in rv
+    assert rv == {"status": "no_card"}
 
 
 def test_card_read_no_cardreader(client):
     rv = json.loads(client.get("/card/read").data)
-    assert rv['present'] == False
+    assert rv == {"status": "no_card"}
 
 
 def test_card_read_connection_error(client):
     client.put('/mock', data=json.dumps({"connectionError": True}))
 
     rv = json.loads(client.get("/card/read").data)
-    assert rv['present']
-    assert rv['connectionError']
+    assert rv == {"status": "error"}
 
 
 def test_card_read_long(client):
@@ -77,12 +73,11 @@ def test_card_read_long(client):
         '/mock', data=json.dumps({'shortValue': 'XYZ', 'longValue': 'Hello 1 2 3'}))
 
     rv = json.loads(client.get("/card/read").data)
-    assert rv['present']
-    assert rv['shortValue'] == 'XYZ'
-    assert rv['longValueExists']
+    assert rv == {"status": "ready",
+                  "shortValue": "XYZ", "longValueExists": True}
 
     rv = json.loads(client.get("/card/read_long").data)
-    assert rv['longValue'] == 'Hello 1 2 3'
+    assert rv == {'longValue': 'Hello 1 2 3'}
 
 
 def test_card_write(client):
@@ -170,9 +165,8 @@ def test_mock_card_read_and_write(client):
     print(client.get('/mock'))
 
     rv = json.loads(client.get("/card/read").data)
-    assert rv['present']
-    assert rv['shortValue'] == 'XYZ'
-    assert rv['longValueExists']
+    assert rv == {"status": "ready",
+                  "shortValue": "XYZ", "longValueExists": True}
 
     rv = json.loads(client.get("/card/read_long").data)
     assert rv == {'longValue': 'yeehah'}

--- a/services/smartcards/tests/test_core.py
+++ b/services/smartcards/tests/test_core.py
@@ -46,7 +46,8 @@ def test_card_read_badcard(client):
     client.put('/mock', data=json.dumps({'shortValue': ''}))
 
     rv = json.loads(client.get("/card/read").data)
-    assert rv == {"status": "ready"}
+    assert rv == {"status": "ready",
+                  "shortValue": None, "longValueExists": False}
 
 
 def test_card_read_nocard(client):

--- a/services/smartcards/tests/test_core.py
+++ b/services/smartcards/tests/test_core.py
@@ -46,8 +46,7 @@ def test_card_read_badcard(client):
     client.put('/mock', data=json.dumps({'shortValue': ''}))
 
     rv = json.loads(client.get("/card/read").data)
-    assert rv == {"status": "ready",
-                  "shortValue": None, "longValueExists": False}
+    assert rv == {"status": "ready"}
 
 
 def test_card_read_nocard(client):

--- a/services/smartcards/writeVoterCard.py
+++ b/services/smartcards/writeVoterCard.py
@@ -6,7 +6,8 @@ from smartcards.core import CardInterface
 import time
 time.sleep(2)
 
-short_value = json.dumps({'t': 'voter', 'pr': '23', 'bs': '12'})
+short_value = json.dumps(
+    {'t': 'voter', 'pr': '23', 'bs': '12', 'c': 1643066962})
 
 CardInterface.override_protection()
 CardInterface.write(short_value.encode('utf-8'))


### PR DESCRIPTION
Task: #1349 

When a card is inserted backwards (or is otherwise unreadable), a connection error occurs. We catch that error and expose that it happened in the smartcards API via a new `status` field.

We also update consumers of the API to consume the new field.