### PR TITLE
fix(smartcards): Clear card correctly in testCardReader.py

### DIFF
--- a/services/smartcards/testCardReader.py
+++ b/services/smartcards/testCardReader.py
@@ -26,12 +26,11 @@ def wait_for_card():
     while True:
         time.sleep(REFRESH_INTERVAL)
         if CardInterface.card:
-            if CardInterface.card.write_enabled:
-                break
-            else:
-                print("Card is write-protected, please use a different card")
-                sys.exit(1)
+            break
     print("Card inserted")
+    if not CardInterface.card.write_enabled:
+        CardInterface.override_protection()
+        print("Overrode write protection")
 
 
 def wait_for_disconnect():
@@ -56,9 +55,8 @@ def check_equal_bytes(wrote, read, label):
 
 def test_card():
     print("Clearing card")
-    CardInterface.write(b"")
-    CardInterface.write_long(b"")
-    check_equal_bytes(b"", CardInterface.read()[0], "Short value")
+    CardInterface.write(b"{}")
+    check_equal_bytes(b"{}", CardInterface.read()[0], "Short value")
     check_equal_bytes(b"", CardInterface.read_long(), "Long value")
 
     print("Testing random bytes")


### PR DESCRIPTION
The card module expects that the short value isn't an empty string when writing a long value, which was causing the testCardReader.py script to crash. I considered changing that assumption, but then I looked at clearCard.py, and realized that "clearing" a card according to this script means writing an empty object, not an empty string. So I updated testCardReader.py accordingly.

I also changed it to override write protection automatically, since if the script fails at any point after writing a long value, it will have write-protected the card, and you won't be able to run the script again with that card unless you override write protection.