### PR TITLE
feat(ps): guide poll workers after open/close polls

### DIFF
--- a/frontends/precinct-scanner/src/app_tally_report_paths.test.tsx
+++ b/frontends/precinct-scanner/src/app_tally_report_paths.test.tsx
@@ -460,7 +460,9 @@ test('expected tally reports for a primary election with all precincts with CVRs
 
   fireEvent.click(await screen.findByText('Save Report and Close Polls'));
   await screen.findByText('Saving to Card');
-  await screen.findByText('Open Polls for All Precincts');
+  await screen.findByText('Export Results to USB Drive');
+  card.removeCard();
+  await advanceTimersAndPromises(1);
   const expectedCombinedTally: CompressedTally = [
     [0, 1, 2, 0, 1, 0, 0], // best animal mammal
     [0, 0, 1, 1, 0, 0], // best animal fish
@@ -516,10 +518,12 @@ test('expected tally reports for a primary election with all precincts with CVRs
   jest
     .spyOn(card, 'readLongObject')
     .mockResolvedValue(err(new Error('bad read')));
+  card.insertCard(pollWorkerCard);
+  await advanceTimersAndPromises(1);
   fireEvent.click(await screen.findByText('Open Polls for All Precincts'));
   fireEvent.click(await screen.findByText('Save Report and Open Polls'));
   await screen.findByText('Saving to Card');
-  await screen.findByText('Close Polls for All Precincts');
+  await screen.findByText('Print the Open Polls Report');
   expect(writeLongObjectMock).toHaveBeenCalledTimes(3);
   expect(writeLongObjectMock).toHaveBeenNthCalledWith(
     2,
@@ -764,7 +768,9 @@ test('expected tally reports for a primary election with a single precincts with
 
   fireEvent.click(await screen.findByText('Save Report and Close Polls'));
   await screen.findByText('Saving to Card');
-  await screen.findByText('Open Polls for Precinct 1');
+  await screen.findByText('Export Results to USB Drive');
+  card.removeCard();
+  await advanceTimersAndPromises(1);
   const expectedCombinedTally: CompressedTally = [
     [0, 1, 2, 0, 1, 0, 0], // best animal mammal
     [0, 0, 1, 1, 0, 0], // best animal fish
@@ -806,10 +812,12 @@ test('expected tally reports for a primary election with a single precincts with
   jest
     .spyOn(card, 'readLongObject')
     .mockResolvedValue(err(new Error('bad read')));
+  card.insertCard(pollWorkerCard);
+  await advanceTimersAndPromises(1);
   fireEvent.click(await screen.findByText('Open Polls for Precinct 1'));
   fireEvent.click(await screen.findByText('Save Report and Open Polls'));
   await screen.findByText('Saving to Card');
-  await screen.findByText('Close Polls for Precinct 1');
+  await screen.findByText('Print the Open Polls Report');
   expect(writeLongObjectMock).toHaveBeenCalledTimes(3);
   expect(writeLongObjectMock).toHaveBeenNthCalledWith(
     2,
@@ -1036,7 +1044,9 @@ test('expected tally reports for a general election with all precincts with CVRs
 
   fireEvent.click(await screen.findByText('Save Report and Close Polls'));
   await screen.findByText('Saving to Card');
-  await screen.findByText('Open Polls for All Precincts');
+  await screen.findByText('Export Results to USB Drive');
+  card.removeCard();
+  await advanceTimersAndPromises(1);
   const expectedCombinedTally = election.contests.map(() => expect.anything());
   expectedCombinedTally[0] = [0, 0, 2, 1, 0, 0, 1, 0, 0]; // president
   const index102 = election.contests.findIndex((c) => c.id === 'prop-1');
@@ -1078,10 +1088,12 @@ test('expected tally reports for a general election with all precincts with CVRs
   jest
     .spyOn(card, 'readLongObject')
     .mockResolvedValue(err(new Error('bad read')));
+  card.insertCard(pollWorkerCard);
+  await advanceTimersAndPromises(1);
   fireEvent.click(await screen.findByText('Open Polls for All Precincts'));
   fireEvent.click(await screen.findByText('Save Report and Open Polls'));
   await screen.findByText('Saving to Card');
-  await screen.findByText('Close Polls for All Precincts');
+  await screen.findByText('Print the Open Polls Report');
   expect(writeLongObjectMock).toHaveBeenCalledTimes(3);
   expect(writeLongObjectMock).toHaveBeenNthCalledWith(
     2,
@@ -1252,7 +1264,9 @@ test('expected tally reports for a general election with a single precincts with
 
   fireEvent.click(await screen.findByText('Save Report and Close Polls'));
   await screen.findByText('Saving to Card');
-  await screen.findByText('Open Polls for Center Springfield');
+  await screen.findByText('Export Results to USB Drive');
+  card.removeCard();
+  await advanceTimersAndPromises(1);
   const expectedCombinedTally = election.contests.map(() => expect.anything());
   expectedCombinedTally[0] = [0, 0, 2, 1, 0, 0, 1, 0, 0]; // president
   const index102 = election.contests.findIndex((c) => c.id === 'prop-1');
@@ -1287,10 +1301,12 @@ test('expected tally reports for a general election with a single precincts with
   jest
     .spyOn(card, 'readLongObject')
     .mockResolvedValue(err(new Error('bad read')));
+  card.insertCard(pollWorkerCard);
+  await advanceTimersAndPromises(1);
   fireEvent.click(await screen.findByText('Open Polls for Center Springfield'));
   fireEvent.click(await screen.findByText('Save Report and Open Polls'));
   await screen.findByText('Saving to Card');
-  await screen.findByText('Close Polls for Center Springfield');
+  await screen.findByText('Print the Open Polls Report');
   expect(writeLongObjectMock).toHaveBeenCalledTimes(3);
   expect(writeLongObjectMock).toHaveBeenNthCalledWith(
     2,

--- a/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
+++ b/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
@@ -483,7 +483,7 @@ test('App shows warning message to connect to power when disconnected', async ()
   fireEvent.click(await screen.findByText('Open Polls for All Precincts'));
   fireEvent.click(await screen.findByText('Save Report and Open Polls'));
   await screen.findByText('Saving to Card');
-  await screen.findByText('Close Polls for All Precincts');
+  await screen.findByText('Print the Open Polls Report');
 
   // Remove pollworker card
   card.removeCard();

--- a/frontends/precinct-scanner/src/components/export_backup_modal.test.tsx
+++ b/frontends/precinct-scanner/src/components/export_backup_modal.test.tsx
@@ -68,9 +68,7 @@ test('render no USB found screen when there is not a mounted USB drive', () => {
       </AppContext.Provider>
     );
     screen.getByText('No USB Drive Detected');
-    screen.getByText(
-      'Please insert a USB drive in order to export the scanner backup.'
-    );
+    screen.getByText('Please insert a USB drive to export the backup.');
     screen.getByAltText('Insert USB Image');
 
     fireEvent.click(screen.getByText('Cancel'));

--- a/frontends/precinct-scanner/src/components/export_backup_modal.tsx
+++ b/frontends/precinct-scanner/src/components/export_backup_modal.tsx
@@ -21,8 +21,7 @@ import { download, DownloadError, DownloadErrorKind } from '../utils/download';
 import { Modal } from './modal';
 
 const UsbImage = styled.img`
-  margin-right: auto;
-  margin-left: auto;
+  margin: 0 auto;
   height: 200px;
 `;
 
@@ -180,12 +179,12 @@ export function ExportBackupModal({ onClose, usbDrive }: Props): JSX.Element {
             <Prose>
               <h1>No USB Drive Detected</h1>
               <p>
+                Please insert a USB drive to export the backup.
                 <UsbImage
                   src={`${process.env.PUBLIC_URL}/assets/usb-stick.svg`}
                   onDoubleClick={() => exportBackup(true)}
                   alt="Insert USB Image"
                 />
-                Please insert a USB drive in order to export the scanner backup.
               </p>
             </Prose>
           }

--- a/frontends/precinct-scanner/src/components/export_results_modal.test.tsx
+++ b/frontends/precinct-scanner/src/components/export_results_modal.test.tsx
@@ -118,7 +118,7 @@ test('render export modal when a usb drive is mounted as expected and allows cus
   getByAltText('Insert USB Image');
 
   fireEvent.click(getByText('Custom'));
-  await waitFor(() => getByText(/Download Complete/));
+  await waitFor(() => getByText('Results Exported to USB Drive'));
   await waitFor(() => {
     expect(saveAsFunction).toHaveBeenCalledTimes(1);
   });
@@ -158,7 +158,7 @@ test('render export modal when a usb drive is mounted as expected and allows aut
   getByText('Export Results');
 
   fireEvent.click(getByText('Export'));
-  await waitFor(() => getByText(/Download Complete/));
+  await waitFor(() => getByText('Results Exported to USB Drive'));
   await waitFor(() => {
     expect(mockKiosk.makeDirectory).toHaveBeenCalledTimes(1);
   });
@@ -204,10 +204,8 @@ test('render export modal when a usb drive is mounted as expected and allows aut
       />
     </AppContext.Provider>
   );
-  getByText('Download Complete');
-  getByText(
-    'USB drive successfully ejected, you may now take it to VxAdmin for tabulation.'
-  );
+  getByText('USB Drive Ejected');
+  getByText('You may now take the USB Drive to VxAdmin for tabulation.');
 });
 
 test('render export modal with errors when appropriate', async () => {

--- a/frontends/precinct-scanner/src/components/export_results_modal.test.tsx
+++ b/frontends/precinct-scanner/src/components/export_results_modal.test.tsx
@@ -72,9 +72,7 @@ test('render no usb found screen when there is not a mounted usb drive', () => {
       </AppContext.Provider>
     );
     getByText('No USB Drive Detected');
-    getByText(
-      'Please insert a USB drive in order to export the scanner results.'
-    );
+    getByText('Please insert a USB drive in order to export results.');
     getByAltText('Insert USB Image');
 
     fireEvent.click(getByText('Cancel'));

--- a/frontends/precinct-scanner/src/components/export_results_modal.tsx
+++ b/frontends/precinct-scanner/src/components/export_results_modal.tsx
@@ -22,8 +22,7 @@ import { AppContext } from '../contexts/app_context';
 import { Modal } from './modal';
 
 const UsbImage = styled.img`
-  margin-right: auto;
-  margin-left: auto;
+  margin: 0 auto;
   height: 200px;
 `;
 
@@ -156,11 +155,8 @@ export function ExportResultsModal({
         <Modal
           content={
             <Prose>
-              <h1>Download Complete</h1>
-              <p>
-                USB drive successfully ejected, you may now take it to VxAdmin
-                for tabulation.
-              </p>
+              <h1>USB Drive Ejected</h1>
+              <p>You may now take the USB Drive to VxAdmin for tabulation.</p>
             </Prose>
           }
           onOverlayClick={onClose}
@@ -172,10 +168,10 @@ export function ExportResultsModal({
       <Modal
         content={
           <Prose>
-            <h1>Download Complete</h1>
+            <h1>Results Exported to USB Drive</h1>
             <p>
-              CVR results file saved successfully! You may now eject the USB
-              drive and take it to VxAdmin for tabulation.
+              You may now eject the USB drive and take it to VxAdmin for
+              tabulation.
             </p>
           </Prose>
         }
@@ -215,15 +211,14 @@ export function ExportResultsModal({
       return (
         <Modal
           content={
-            <Prose>
+            <Prose textCenter>
               <h1>No USB Drive Detected</h1>
               <p>
+                Please insert a USB drive in order to export results.
                 <UsbImage
                   src={`${process.env.PUBLIC_URL}/assets/usb-stick.svg`}
                   alt="Insert USB Image"
                 />
-                Please insert a USB drive in order to export the scanner
-                results.
               </p>
             </Prose>
           }

--- a/frontends/precinct-scanner/src/screens/admin_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/admin_screen.test.tsx
@@ -221,5 +221,5 @@ test('export from admin screen', async () => {
     </AppContext.Provider>
   );
 
-  fireEvent.click(screen.getByText('Export Backup to USB'));
+  fireEvent.click(screen.getByText('Export Backup to USB Drive'));
 });

--- a/frontends/precinct-scanner/src/screens/admin_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/admin_screen.tsx
@@ -168,12 +168,12 @@ export function AdminScreen({
         </p>
         <p>
           <Button onPress={() => setIsExportingResults(true)}>
-            Export Results to USB
+            Export Results to USB Drive
           </Button>
         </p>
         <p>
           <Button onPress={() => setIsExportingBackup(true)}>
-            Export Backup to USB
+            Export Backup to USB Drive
           </Button>
         </p>
         <p>

--- a/frontends/precinct-scanner/src/screens/poll_worker_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/poll_worker_screen.test.tsx
@@ -80,7 +80,7 @@ test('shows dashes when no totp', async () => {
 });
 
 test('shows Export Results button only when polls are closed and more than 0 ballots have been cast', async () => {
-  const exportButtonText = 'Export Results to USB';
+  const exportButtonText = 'Export Results to USB Drive';
 
   await act(async () => {
     renderScreen({

--- a/frontends/precinct-scanner/src/screens/polls_closed_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/polls_closed_screen.tsx
@@ -24,7 +24,7 @@ export function PollsClosedScreen({
       <DoNotEnter />
       <CenteredLargeProse>
         <h1>Polls Closed</h1>
-        <p>Insert a Poll Worker Card to Open Polls.</p>
+        <p>Insert a poll worker card to open polls.</p>
       </CenteredLargeProse>
     </CenteredScreen>
   );


### PR DESCRIPTION
This screen share shows the flow: open polls, scan a ballot, close polls, export results to usb…
https://user-images.githubusercontent.com/28444/150447871-f6d0ad0f-805e-45c7-995e-92fbdeddf43c.mov

