### PR TITLE
chore: Fix VS Code workspace TypeScript setting

### DIFF
--- a/vxsuite.code-workspace
+++ b/vxsuite.code-workspace
@@ -138,7 +138,7 @@
       "**/build": true,
       "**/coverage": true
     },
-    "typescript.tsdk": "ballot-encoder/node_modules/typescript/lib"
+    "typescript.tsdk": "libs/types/node_modules/typescript/lib"
   },
   "extensions": {
     "recommendations": [


### PR DESCRIPTION
It was based on an outdated directory structure.