### PR TITLE
feat(bmd): Update BMD app modes and product names

### DIFF
--- a/frontends/bmd/README.md
+++ b/frontends/bmd/README.md
@@ -9,14 +9,16 @@ then run BMD like so:
 
 ```sh
 # in frontends/bmd
-# Run VxMark by default
+# Run in mark-only mode (when there's a separate standalone printer)
 pnpm start
+# Or to be verbose:
+VX_APP_MODE=MarkOnly pnpm start
 
-# Or run VxPrint
-VX_APP_MODE=VxPrint pnpm start
+# Run in print-only mode (for a standalone printer)
+VX_APP_MODE=PrintOnly pnpm start
 
-# Or run VxMark + VxPrint
-VX_APP_MODE="VxMark + VxPrint" pnpm start
+# Run in mark-and-print mode (for a BMD with its own printer attached)
+VX_APP_MODE=MarkAndPrint pnpm start
 ```
 
 The server will be available at http://localhost:3000/.

--- a/frontends/bmd/README.md
+++ b/frontends/bmd/README.md
@@ -8,17 +8,19 @@ Follow the instructions in the [VxSuite README](../../README.md) to get set up,
 then run BMD like so:
 
 ```sh
-# in frontends/bmd
-# Run in mark-only mode (when there's a separate standalone printer)
-pnpm start
-# Or to be verbose:
+# In frontends/bmd
+# To run in mark-only mode (when there's a separate standalone printer)
 VX_APP_MODE=MarkOnly pnpm start
 
-# Run in print-only mode (for a standalone printer)
+# To run in print-only mode (for a standalone printer)
 VX_APP_MODE=PrintOnly pnpm start
 
-# Run in mark-and-print mode (for a BMD with its own printer attached)
+# To run in mark-and-print mode (for a BMD with its own printer attached)
 VX_APP_MODE=MarkAndPrint pnpm start
+
+# By default, the BMD runs in mark-only mode
+pnpm start
+
 ```
 
 The server will be available at http://localhost:3000/.

--- a/frontends/bmd/prodserver/setupProxy.js
+++ b/frontends/bmd/prodserver/setupProxy.js
@@ -13,7 +13,7 @@ module.exports = function (app) {
 
   app.get('/machine-config', (req, res) => {
     res.json({
-      appModeName: process.env.VX_APP_MODE || 'VxMark',
+      appModeKey: process.env.VX_APP_MODE || 'MarkOnly',
       machineId: process.env.VX_MACHINE_ID || '000',
       codeVersion: process.env.VX_CODE_VERSION || 'dev',
     })

--- a/frontends/bmd/public/index.html
+++ b/frontends/bmd/public/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, user-scalable=no" />
     <meta name="theme-color" content="#000000" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <title>VotingWorks Ballot Marking Device</title>
+    <title>VotingWorks VxMark</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontends/bmd/public/manifest.json
+++ b/frontends/bmd/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "VotingWorks BMD",
-  "name": "VotingWorks Ballot Marking Device",
+  "short_name": "VxMark",
+  "name": "VotingWorks VxMark",
   "icons": [
     {
       "src": "favicon.ico",

--- a/frontends/bmd/src/apimachine_config.test.tsx
+++ b/frontends/bmd/src/apimachine_config.test.tsx
@@ -6,11 +6,7 @@ import { Provider } from '@votingworks/types';
 import { MemoryStorage, typedAs } from '@votingworks/utils';
 import { App } from './app';
 
-import {
-  VxMarkOnly,
-  MachineConfigResponse,
-  MachineConfig,
-} from './config/types';
+import { MarkOnly, MachineConfigResponse, MachineConfig } from './config/types';
 import { advanceTimersAndPromises } from '../test/helpers/smartcards';
 
 beforeEach(() => {
@@ -22,7 +18,7 @@ test('machineConfig is fetched from /machine-config by default', async () => {
   fetchMock.get(
     '/machine-config',
     typedAs<MachineConfigResponse>({
-      appModeName: VxMarkOnly.name,
+      appModeKey: MarkOnly.key,
       machineId: '99',
       codeVersion: 'test',
     })
@@ -57,7 +53,7 @@ test('machineConfig fetch fails', async () => {
 test('machineId is empty', async () => {
   const machineConfig: Provider<MachineConfig> = {
     async get() {
-      return { appMode: VxMarkOnly, machineId: '', codeVersion: 'test' };
+      return { appMode: MarkOnly, machineId: '', codeVersion: 'test' };
     },
   };
 

--- a/frontends/bmd/src/app.test.tsx
+++ b/frontends/bmd/src/app.test.tsx
@@ -10,7 +10,7 @@ import { fakeMachineConfigProvider } from '../test/helpers/fake_machine_config';
 import { advanceTimersAndPromises } from '../test/helpers/smartcards';
 import { render } from '../test/test_utils';
 import { App } from './app';
-import { PrecinctSelectionKind, VxMarkPlusVxPrint } from './config/types';
+import { PrecinctSelectionKind, MarkAndPrint } from './config/types';
 import { electionSampleDefinition } from './data';
 
 beforeEach(() => {
@@ -64,7 +64,7 @@ it('uses window.location.reload by default', async () => {
   const storage = new MemoryStorage();
   const pollWorkerCard = makePollWorkerCard(electionDefinition.electionHash);
   const machineConfig = fakeMachineConfigProvider({
-    appMode: VxMarkPlusVxPrint,
+    appMode: MarkAndPrint,
   });
 
   await setElectionInStorage(storage, electionDefinition);

--- a/frontends/bmd/src/app_card_unhappy_paths.test.tsx
+++ b/frontends/bmd/src/app_card_unhappy_paths.test.tsx
@@ -27,7 +27,7 @@ import {
 } from '../test/helpers/election';
 import { utcTimestamp } from './utils/utc_timestamp';
 import { fakeMachineConfigProvider } from '../test/helpers/fake_machine_config';
-import { VxPrintOnly } from './config/types';
+import { PrintOnly } from './config/types';
 
 beforeEach(() => {
   jest.useFakeTimers();
@@ -190,7 +190,7 @@ test('Inserting pollworker card with invalid long data fall back as if there is 
   const card = new MemoryCard();
   const hardware = await MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
-  const machineConfig = fakeMachineConfigProvider({ appMode: VxPrintOnly });
+  const machineConfig = fakeMachineConfigProvider({ appMode: PrintOnly });
 
   card.removeCard();
 

--- a/frontends/bmd/src/app_cardless_voting.test.tsx
+++ b/frontends/bmd/src/app_cardless_voting.test.tsx
@@ -21,7 +21,7 @@ import { advanceTimersAndPromises } from '../test/helpers/smartcards';
 
 import { fakePrinter } from '../test/helpers/fake_printer';
 import { fakeMachineConfigProvider } from '../test/helpers/fake_machine_config';
-import { VxMarkPlusVxPrint } from './config/types';
+import { MarkAndPrint } from './config/types';
 
 beforeEach(() => {
   jest.useFakeTimers();
@@ -40,7 +40,7 @@ test('Cardless Voting Flow', async () => {
   const printer = fakePrinter();
   const storage = new MemoryStorage();
   const machineConfig = fakeMachineConfigProvider({
-    appMode: VxMarkPlusVxPrint,
+    appMode: MarkAndPrint,
   });
   render(
     <App
@@ -208,7 +208,7 @@ test('Another Voter submits blank ballot and clicks Done', async () => {
   const printer = fakePrinter();
   const storage = new MemoryStorage();
   const machineConfig = fakeMachineConfigProvider({
-    appMode: VxMarkPlusVxPrint,
+    appMode: MarkAndPrint,
   });
 
   card.removeCard();
@@ -292,7 +292,7 @@ test('poll worker must select a precinct first', async () => {
   const printer = fakePrinter();
   const storage = new MemoryStorage();
   const machineConfig = fakeMachineConfigProvider({
-    appMode: VxMarkPlusVxPrint,
+    appMode: MarkAndPrint,
   });
   render(
     <App

--- a/frontends/bmd/src/app_contest_write_in.test.tsx
+++ b/frontends/bmd/src/app_contest_write_in.test.tsx
@@ -24,7 +24,7 @@ import {
   setElectionInStorage,
   setStateInStorage,
 } from '../test/helpers/election';
-import { VxMarkPlusVxPrint } from './config/types';
+import { MarkAndPrint } from './config/types';
 import { fakePrinter } from '../test/helpers/fake_printer';
 import { fakeMachineConfigProvider } from '../test/helpers/fake_machine_config';
 
@@ -41,7 +41,7 @@ it('Single Seat Contest with Write In', async () => {
   const hardware = await MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
   const machineConfig = fakeMachineConfigProvider({
-    appMode: VxMarkPlusVxPrint,
+    appMode: MarkAndPrint,
   });
 
   await setElectionInStorage(storage);

--- a/frontends/bmd/src/app_end_to_end.test.tsx
+++ b/frontends/bmd/src/app_end_to_end.test.tsx
@@ -38,7 +38,7 @@ import {
 } from '../test/helpers/election';
 import { fakePrinter } from '../test/helpers/fake_printer';
 import { fakeMachineConfigProvider } from '../test/helpers/fake_machine_config';
-import { VxMarkPlusVxPrint } from './config/types';
+import { MarkAndPrint } from './config/types';
 import { REPORT_PRINTING_TIMEOUT_SECONDS } from './config/globals';
 
 beforeEach(() => {
@@ -48,14 +48,14 @@ beforeEach(() => {
 
 jest.setTimeout(15000);
 
-it('VxMark+Print end-to-end flow', async () => {
+it('MarkAndPrint end-to-end flow', async () => {
   const electionDefinition = electionSampleDefinition;
   const card = new MemoryCard();
   const hardware = await MemoryHardware.buildStandard();
   const printer = fakePrinter();
   const storage = new MemoryStorage();
   const machineConfig = fakeMachineConfigProvider({
-    appMode: VxMarkPlusVxPrint,
+    appMode: MarkAndPrint,
   });
   const expectedElectionHash = electionDefinition.electionHash.substring(0, 10);
   const writeLongUint8ArrayMock = jest.spyOn(card, 'writeLongUint8Array');

--- a/frontends/bmd/src/app_mark_only.test.tsx
+++ b/frontends/bmd/src/app_mark_only.test.tsx
@@ -31,7 +31,7 @@ beforeEach(() => {
   window.location.href = '/';
 });
 
-it('VxMarkOnly flow', async () => {
+it('MarkOnly flow', async () => {
   const electionDefinition = electionSampleDefinition;
   const card = new MemoryCard();
   const adminCard = makeAdminCard(electionDefinition.electionHash);
@@ -138,7 +138,7 @@ it('VxMarkOnly flow', async () => {
 
   // ---------------
 
-  // Complete VxMark Voter Happy Path
+  // Complete MarkOnly Voter Happy Path
 
   // Insert Voter card
   card.insertCard(makeVoterCard(electionDefinition.election));

--- a/frontends/bmd/src/app_mark_voter_card_invalid.test.tsx
+++ b/frontends/bmd/src/app_mark_voter_card_invalid.test.tsx
@@ -23,7 +23,7 @@ import {
   IDLE_RESET_TIMEOUT_SECONDS,
 } from './config/globals';
 import { fakeMachineConfigProvider } from '../test/helpers/fake_machine_config';
-import { VxMarkPlusVxPrint } from './config/types';
+import { MarkAndPrint } from './config/types';
 
 beforeEach(() => {
   jest.useFakeTimers();
@@ -108,7 +108,7 @@ describe('Mark Card Void when voter is idle too long', () => {
     const hardware = await MemoryHardware.buildStandard();
     const storage = new MemoryStorage();
     const machineConfig = fakeMachineConfigProvider({
-      appMode: VxMarkPlusVxPrint,
+      appMode: MarkAndPrint,
     });
 
     await setElectionInStorage(storage, electionSampleDefinition);

--- a/frontends/bmd/src/app_print_only.test.tsx
+++ b/frontends/bmd/src/app_print_only.test.tsx
@@ -31,7 +31,7 @@ import { withMarkup } from '../test/helpers/with_markup';
 import * as GLOBALS from './config/globals';
 import { fakePrinter } from '../test/helpers/fake_printer';
 import { fakeMachineConfigProvider } from '../test/helpers/fake_machine_config';
-import { VxPrintOnly } from './config/types';
+import { PrintOnly } from './config/types';
 
 beforeEach(() => {
   window.location.href = '/';
@@ -40,7 +40,7 @@ beforeEach(() => {
 
 jest.setTimeout(12000);
 
-test('VxPrintOnly flow', async () => {
+test('PrintOnly flow', async () => {
   const { election, electionData, electionHash } = electionSampleDefinition;
   const card = new MemoryCard();
   const adminCard = makeAdminCard(electionHash);
@@ -48,7 +48,7 @@ test('VxPrintOnly flow', async () => {
   const printer = fakePrinter();
   const hardware = await MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
-  const machineConfig = fakeMachineConfigProvider({ appMode: VxPrintOnly });
+  const machineConfig = fakeMachineConfigProvider({ appMode: PrintOnly });
   render(
     <App
       card={card}
@@ -376,7 +376,7 @@ test('VxPrintOnly flow', async () => {
   screen.getByText('Device Not Configured');
 });
 
-test('VxPrint retains app mode when unconfigured', async () => {
+test('PrintOnly retains app mode when unconfigured', async () => {
   const { electionData, electionHash } = electionSampleDefinition;
   const card = new MemoryCard();
   const adminCard = makeAdminCard(electionHash);
@@ -384,7 +384,7 @@ test('VxPrint retains app mode when unconfigured', async () => {
   const printer = fakePrinter();
   const hardware = await MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
-  const machineConfig = fakeMachineConfigProvider({ appMode: VxPrintOnly });
+  const machineConfig = fakeMachineConfigProvider({ appMode: PrintOnly });
   render(
     <App
       card={card}
@@ -474,7 +474,7 @@ test('VxPrint retains app mode when unconfigured', async () => {
   screen.getByText('Insert Card to print your official ballot.');
 });
 
-test('VxPrint prompts to change to live mode on election day', async () => {
+test('PrintOnly prompts to change to live mode on election day', async () => {
   const electionDefinition = asElectionDefinition({
     ...electionSampleDefinition.election,
     date: new Date().toISOString(),
@@ -485,7 +485,7 @@ test('VxPrint prompts to change to live mode on election day', async () => {
   const printer = fakePrinter();
   const hardware = await MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
-  const machineConfig = fakeMachineConfigProvider({ appMode: VxPrintOnly });
+  const machineConfig = fakeMachineConfigProvider({ appMode: PrintOnly });
   render(
     <App
       card={card}

--- a/frontends/bmd/src/app_root.tsx
+++ b/frontends/bmd/src/app_root.tsx
@@ -55,7 +55,7 @@ import {
   MarkVoterCardFunction,
   PartialUserSettings,
   UserSettings,
-  VxMarkOnly,
+  MarkOnly,
   SerializableActivationData,
   MachineConfig,
   PostVotingInstructions,
@@ -187,7 +187,7 @@ const initialVoterState: Readonly<UserState> = {
 const initialHardwareState: Readonly<HardwareState> = {
   hasChargerAttached: true,
   hasLowBattery: false,
-  machineConfig: { appMode: VxMarkOnly, machineId: '0000', codeVersion: 'dev' },
+  machineConfig: { appMode: MarkOnly, machineId: '0000', codeVersion: 'dev' },
 };
 
 const initialSharedState: Readonly<SharedState> = {
@@ -1267,7 +1267,7 @@ export function AppRoot({
     );
   }
   if (optionalElectionDefinition && appPrecinct) {
-    if (appMode.isVxPrint && !hasPrinterAttached) {
+    if (appMode.isPrint && !hasPrinterAttached) {
       return (
         <SetupPrinterPage
           useEffectToggleLargeDisplay={useEffectToggleLargeDisplay}
@@ -1314,8 +1314,8 @@ export function AppRoot({
     if (
       isPollsOpen &&
       showPostVotingInstructions &&
-      appMode.isVxMark &&
-      appMode.isVxPrint
+      appMode.isMark &&
+      appMode.isPrint
     ) {
       return (
         <CastBallotPage
@@ -1356,7 +1356,7 @@ export function AppRoot({
         );
       }
 
-      if (appMode.isVxPrint && !appMode.isVxMark) {
+      if (appMode.isPrint && !appMode.isMark) {
         return (
           <PrintOnlyScreen
             ballotStyleId={ballotStyleId}
@@ -1415,7 +1415,7 @@ export function AppRoot({
           appPrecinct={appPrecinct}
           electionDefinition={optionalElectionDefinition}
           showNoAccessibleControllerWarning={
-            appMode.isVxMark && !hasAccessibleControllerAttached
+            appMode.isMark && !hasAccessibleControllerAttached
           }
           showNoChargerAttachedWarning={!hasChargerAttached}
           isLiveMode={isLiveMode}

--- a/frontends/bmd/src/app_setup_errors.test.tsx
+++ b/frontends/bmd/src/app_setup_errors.test.tsx
@@ -20,7 +20,7 @@ import {
   HARDWARE_POLLING_INTERVAL,
   LOW_BATTERY_THRESHOLD,
 } from './config/globals';
-import { VxPrintOnly } from './config/types';
+import { PrintOnly } from './config/types';
 
 beforeEach(() => {
   jest.useFakeTimers();
@@ -57,7 +57,7 @@ describe('Displays setup warning messages and errors screens', () => {
     // Let the initial hardware detection run.
     await advanceTimersAndPromises();
 
-    // Start on VxMark Insert Card screen
+    // Start on Insert Card screen
     screen.getByText(insertCardScreenText);
     expect(screen.queryByText(accessibleControllerWarningText)).toBeFalsy();
 
@@ -99,7 +99,7 @@ describe('Displays setup warning messages and errors screens', () => {
     // Let the initial hardware detection run.
     await advanceTimersAndPromises();
 
-    // Start on VxMark Insert Card screen
+    // Start on Insert Card screen
     screen.getByText(insertCardScreenText);
 
     // Disconnect Card Reader
@@ -120,7 +120,7 @@ describe('Displays setup warning messages and errors screens', () => {
   it('Displays error screen if Printer connection is lost', async () => {
     const card = new MemoryCard();
     const storage = new MemoryStorage();
-    const machineConfig = fakeMachineConfigProvider({ appMode: VxPrintOnly });
+    const machineConfig = fakeMachineConfigProvider({ appMode: PrintOnly });
     const hardware = await MemoryHardware.buildStandard();
     await setElectionInStorage(storage);
     await setStateInStorage(storage);
@@ -137,10 +137,10 @@ describe('Displays setup warning messages and errors screens', () => {
     // Let the initial hardware detection run.
     await advanceTimersAndPromises();
 
-    // Start on VxPrint Insert Card screen
-    const vxPrintInsertCardScreenText =
+    // Start on PrintOnly Insert Card screen
+    const printOnlyInsertCardScreenText =
       'Insert Card to print your official ballot.';
-    screen.getByText(vxPrintInsertCardScreenText);
+    screen.getByText(printOnlyInsertCardScreenText);
 
     // Disconnect Printer
     await act(async () => {
@@ -154,13 +154,13 @@ describe('Displays setup warning messages and errors screens', () => {
       await hardware.setPrinterConnected(true);
     });
     await advanceTimersAndPromises(HARDWARE_POLLING_INTERVAL / 1000);
-    screen.getByText(vxPrintInsertCardScreenText);
+    screen.getByText(printOnlyInsertCardScreenText);
   });
 
   it('Displays error screen if Power connection is lost', async () => {
     const card = new MemoryCard();
     const storage = new MemoryStorage();
-    const machineConfig = fakeMachineConfigProvider({ appMode: VxPrintOnly });
+    const machineConfig = fakeMachineConfigProvider({ appMode: PrintOnly });
     const hardware = await MemoryHardware.buildStandard();
     await setElectionInStorage(storage);
     await setStateInStorage(storage);
@@ -177,10 +177,10 @@ describe('Displays setup warning messages and errors screens', () => {
     // Let the initial hardware detection run.
     await advanceTimersAndPromises();
 
-    // Start on VxPrint Insert Card screen
-    const vxPrintInsertCardScreenText =
+    // Start on PrintOnly Insert Card screen
+    const printOnlyInsertCardScreenText =
       'Insert Card to print your official ballot.';
-    screen.getByText(vxPrintInsertCardScreenText);
+    screen.getByText(printOnlyInsertCardScreenText);
 
     // Disconnect Power
     await act(async () => {
@@ -195,7 +195,7 @@ describe('Displays setup warning messages and errors screens', () => {
     });
     await advanceTimersAndPromises(HARDWARE_POLLING_INTERVAL / 1000);
     expect(screen.queryByText(noPowerDetectedWarningText)).toBeFalsy();
-    screen.getByText(vxPrintInsertCardScreenText);
+    screen.getByText(printOnlyInsertCardScreenText);
   });
 
   it('Admin screen trumps "No Printer Detected" error', async () => {
@@ -203,7 +203,7 @@ describe('Displays setup warning messages and errors screens', () => {
     const adminCard = makeAdminCard(electionDefinition.electionHash);
     const storage = new MemoryStorage();
     const machineConfig = fakeMachineConfigProvider({
-      appMode: VxPrintOnly,
+      appMode: PrintOnly,
     });
     const hardware = await MemoryHardware.buildStandard();
     await setElectionInStorage(storage, electionDefinition);
@@ -221,10 +221,10 @@ describe('Displays setup warning messages and errors screens', () => {
     await advanceTimersAndPromises();
 
     // no printer
-    // Start on VxPrint Insert Card screen
-    const vxPrintInsertCardScreenText =
+    // Start on PrintOnly Insert Card screen
+    const printOnlyInsertCardScreenText =
       'Insert Card to print your official ballot.';
-    screen.getByText(vxPrintInsertCardScreenText);
+    screen.getByText(printOnlyInsertCardScreenText);
 
     // Disconnect Printer
     await act(async () => {
@@ -262,7 +262,7 @@ describe('Displays setup warning messages and errors screens', () => {
     // Let the initial hardware detection run.
     await advanceTimersAndPromises();
 
-    // Start on VxMark Insert Card screen
+    // Start on Insert Card screen
     screen.getByText(insertCardScreenText);
 
     // Remove charger and reduce battery level slightly

--- a/frontends/bmd/src/config/types.ts
+++ b/frontends/bmd/src/config/types.ts
@@ -19,30 +19,30 @@ import {
 import { z } from 'zod';
 
 // App
-export const VxPrintOnly = {
-  name: 'VxPrint',
-  isVxMark: false,
-  isVxPrint: true,
+export const PrintOnly = {
+  key: 'PrintOnly',
+  productName: 'VxPrint',
+  isMark: false,
+  isPrint: true,
 } as const;
-export const VxMarkOnly = {
-  name: 'VxMark',
-  isVxMark: true,
-  isVxPrint: false,
+export const MarkOnly = {
+  key: 'MarkOnly',
+  productName: 'VxMark',
+  isMark: true,
+  isPrint: false,
 } as const;
-export const VxMarkPlusVxPrint = {
-  name: 'VxMark + VxPrint',
-  isVxPrint: true,
-  isVxMark: true,
+export const MarkAndPrint = {
+  key: 'MarkAndPrint',
+  productName: 'VxMark',
+  isPrint: true,
+  isMark: true,
 } as const;
-export type AppMode =
-  | typeof VxMarkOnly
-  | typeof VxPrintOnly
-  | typeof VxMarkPlusVxPrint;
-export type AppModeNames = AppMode['name'];
-export const AppModeNamesSchema: z.ZodSchema<AppModeNames> = z.union([
-  z.literal(VxPrintOnly.name),
-  z.literal(VxMarkOnly.name),
-  z.literal(VxMarkPlusVxPrint.name),
+export type AppMode = typeof MarkOnly | typeof PrintOnly | typeof MarkAndPrint;
+export type AppModeKeys = AppMode['key'];
+export const AppModeKeysSchema: z.ZodSchema<AppModeKeys> = z.union([
+  z.literal(PrintOnly.key),
+  z.literal(MarkOnly.key),
+  z.literal(MarkAndPrint.key),
 ]);
 
 export interface MachineConfig {
@@ -53,27 +53,27 @@ export interface MachineConfig {
 
 export interface MachineConfigResponse {
   machineId: string;
-  appModeName: AppModeNames;
+  appModeKey: AppModeKeys;
   codeVersion: string;
 }
 export const MachineConfigResponseSchema: z.ZodSchema<MachineConfigResponse> = z.object(
   {
     machineId: MachineId,
-    appModeName: AppModeNamesSchema,
+    appModeKey: AppModeKeysSchema,
     codeVersion: z.string().nonempty(),
   }
 );
 
-export function getAppMode(name: AppModeNames): AppMode {
-  switch (name) {
-    case VxPrintOnly.name:
-      return VxPrintOnly;
-    case VxMarkOnly.name:
-      return VxMarkOnly;
-    case VxMarkPlusVxPrint.name:
-      return VxMarkPlusVxPrint;
+export function getAppMode(key: AppModeKeys): AppMode {
+  switch (key) {
+    case PrintOnly.key:
+      return PrintOnly;
+    case MarkOnly.key:
+      return MarkOnly;
+    case MarkAndPrint.key:
+      return MarkAndPrint;
     default:
-      throw new Error(`unknown app mode: ${name}`);
+      throw new Error(`unknown app mode: ${key}`);
   }
 }
 

--- a/frontends/bmd/src/contexts/ballot_context.ts
+++ b/frontends/bmd/src/contexts/ballot_context.ts
@@ -5,11 +5,11 @@ import * as GLOBALS from '../config/globals';
 import {
   BallotContextInterface,
   TextSizeSetting,
-  VxMarkOnly,
+  MarkOnly,
 } from '../config/types';
 
 const ballot: BallotContextInterface = {
-  machineConfig: { machineId: '000', appMode: VxMarkOnly, codeVersion: 'dev' },
+  machineConfig: { machineId: '000', appMode: MarkOnly, codeVersion: 'dev' },
   contests: [],
   isCardlessVoter: false,
   isLiveMode: false,

--- a/frontends/bmd/src/demo_app.tsx
+++ b/frontends/bmd/src/demo_app.tsx
@@ -15,7 +15,7 @@ import {
   MachineConfig,
   PrecinctSelectionKind,
   SerializableActivationData,
-  VxMarkPlusVxPrint,
+  MarkAndPrint,
 } from './config/types';
 import { State } from './app_root';
 
@@ -64,7 +64,7 @@ export function getSampleMachineConfigProvider(): Provider<MachineConfig> {
   return {
     async get() {
       return {
-        appMode: VxMarkPlusVxPrint,
+        appMode: MarkAndPrint,
         machineId: '012',
         codeVersion: 'demo',
       };

--- a/frontends/bmd/src/pages/admin_screen.test.tsx
+++ b/frontends/bmd/src/pages/admin_screen.test.tsx
@@ -11,11 +11,7 @@ import { fakePrinter } from '../../test/helpers/fake_printer';
 import { advanceTimers } from '../../test/helpers/smartcards';
 
 import { AdminScreen } from './admin_screen';
-import {
-  VxPrintOnly,
-  VxMarkOnly,
-  PrecinctSelectionKind,
-} from '../config/types';
+import { PrintOnly, MarkOnly, PrecinctSelectionKind } from '../config/types';
 import { fakeMachineConfig } from '../../test/helpers/fake_machine_config';
 import {
   AriaScreenReader,
@@ -34,7 +30,7 @@ afterEach(() => {
   window.kiosk = undefined;
 });
 
-test('renders AdminScreen for VxPrintOnly', async () => {
+test('renders AdminScreen for PrintOnly', async () => {
   render(
     <AdminScreen
       appPrecinct={{
@@ -49,7 +45,7 @@ test('renders AdminScreen for VxPrintOnly', async () => {
       toggleLiveMode={jest.fn()}
       unconfigure={jest.fn()}
       machineConfig={fakeMachineConfig({
-        appMode: VxPrintOnly,
+        appMode: PrintOnly,
         codeVersion: '', // Override default
       })}
       printer={fakePrinter()}
@@ -94,7 +90,7 @@ test('renders date and time settings modal', async () => {
       toggleLiveMode={jest.fn()}
       unconfigure={jest.fn()}
       machineConfig={fakeMachineConfig({
-        appMode: VxMarkOnly,
+        appMode: MarkOnly,
         codeVersion: 'test',
       })}
       printer={fakePrinter()}

--- a/frontends/bmd/src/pages/admin_screen.tsx
+++ b/frontends/bmd/src/pages/admin_screen.tsx
@@ -129,7 +129,7 @@ export function AdminScreen({
     );
   }
 
-  const isTestDecksAvailable = !isLiveMode && machineConfig.appMode.isVxPrint;
+  const isTestDecksAvailable = !isLiveMode && machineConfig.appMode.isPrint;
   return (
     <Screen flexDirection="row-reverse" voterMode={false}>
       <Main padded>
@@ -189,7 +189,7 @@ export function AdminScreen({
                     </Button>
                   </SegmentedButton>
                 </p>
-                {machineConfig.appMode.isVxPrint && (
+                {machineConfig.appMode.isPrint && (
                   <React.Fragment>
                     <p>
                       <Button
@@ -250,7 +250,7 @@ export function AdminScreen({
         </MainChild>
       </Main>
       <Sidebar
-        appName={election ? machineConfig.appMode.name : ''}
+        appName={election ? machineConfig.appMode.productName : ''}
         centerContent
         title="Election Admin Actions"
         footer={

--- a/frontends/bmd/src/pages/poll_worker_screen.test.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.test.tsx
@@ -17,11 +17,7 @@ import {
   PrecinctScannerCardTally,
 } from '@votingworks/utils';
 import { getZeroCompressedTally } from '@votingworks/test-utils';
-import {
-  PrecinctSelectionKind,
-  VxMarkOnly,
-  VxPrintOnly,
-} from '../config/types';
+import { PrecinctSelectionKind, MarkOnly, PrintOnly } from '../config/types';
 
 import { render } from '../../test/test_utils';
 
@@ -90,7 +86,7 @@ test('renders PollWorkerScreen', async () => {
       hasVotes={false}
       isLiveMode={false}
       isPollsOpen
-      machineConfig={fakeMachineConfig({ appMode: VxMarkOnly })}
+      machineConfig={fakeMachineConfig({ appMode: MarkOnly })}
       printer={fakePrinter()}
       togglePollsOpen={jest.fn()}
       tallyOnCard={undefined}
@@ -121,7 +117,7 @@ test('switching out of test mode on election day', async () => {
       hasVotes={false}
       isLiveMode={false}
       isPollsOpen
-      machineConfig={fakeMachineConfig({ appMode: VxMarkOnly })}
+      machineConfig={fakeMachineConfig({ appMode: MarkOnly })}
       printer={fakePrinter()}
       togglePollsOpen={jest.fn()}
       tallyOnCard={undefined}
@@ -154,7 +150,7 @@ test('keeping test mode on election day', async () => {
       hasVotes={false}
       isLiveMode={false}
       isPollsOpen
-      machineConfig={fakeMachineConfig({ appMode: VxMarkOnly })}
+      machineConfig={fakeMachineConfig({ appMode: MarkOnly })}
       printer={fakePrinter()}
       togglePollsOpen={jest.fn()}
       tallyOnCard={undefined}
@@ -184,7 +180,7 @@ test('live mode on election day', async () => {
       hasVotes={false}
       isLiveMode
       isPollsOpen
-      machineConfig={fakeMachineConfig({ appMode: VxMarkOnly })}
+      machineConfig={fakeMachineConfig({ appMode: MarkOnly })}
       printer={fakePrinter()}
       togglePollsOpen={jest.fn()}
       tallyOnCard={undefined}
@@ -229,7 +225,7 @@ test('printing precinct scanner report works as expected with all precinct data 
       isLiveMode
       isPollsOpen={false}
       machineConfig={fakeMachineConfig({
-        appMode: VxPrintOnly,
+        appMode: PrintOnly,
         machineId: '314',
       })}
       printer={{
@@ -310,7 +306,7 @@ test('printing precinct scanner report works as expected with single precinct da
       isLiveMode
       isPollsOpen={false}
       machineConfig={fakeMachineConfig({
-        appMode: VxPrintOnly,
+        appMode: PrintOnly,
         machineId: '314',
       })}
       printer={{
@@ -409,7 +405,7 @@ test('printing precinct scanner report works as expected with all precinct speci
       isLiveMode
       isPollsOpen={false}
       machineConfig={fakeMachineConfig({
-        appMode: VxPrintOnly,
+        appMode: PrintOnly,
         machineId: '314',
       })}
       printer={{
@@ -561,7 +557,7 @@ test('printing precinct scanner report works as expected with all precinct speci
       isLiveMode
       isPollsOpen={false}
       machineConfig={fakeMachineConfig({
-        appMode: VxPrintOnly,
+        appMode: PrintOnly,
         machineId: '314',
       })}
       printer={{
@@ -793,7 +789,7 @@ test('printing precinct scanner report works as expected with all precinct combi
       isLiveMode
       isPollsOpen={false}
       machineConfig={fakeMachineConfig({
-        appMode: VxPrintOnly,
+        appMode: PrintOnly,
         machineId: '314',
       })}
       printer={{
@@ -944,7 +940,7 @@ test('printing precinct scanner report works as expected with a single precinct 
       isLiveMode
       isPollsOpen={false}
       machineConfig={fakeMachineConfig({
-        appMode: VxPrintOnly,
+        appMode: PrintOnly,
         machineId: '314',
       })}
       printer={{

--- a/frontends/bmd/src/pages/poll_worker_screen.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.tsx
@@ -221,9 +221,9 @@ export function PollWorkerScreen({
     isConfirmingEnableLiveMode,
   ]);
 
-  const isPrintMode = machineConfig.appMode.isVxPrint;
+  const isPrintMode = machineConfig.appMode.isPrint;
   const isMarkAndPrintMode =
-    machineConfig.appMode.isVxPrint && machineConfig.appMode.isVxMark;
+    machineConfig.appMode.isPrint && machineConfig.appMode.isMark;
 
   function requestPrintPrecinctScannerReport() {
     setIsPrintingPrecinctScannerReport(true);
@@ -415,7 +415,7 @@ export function PollWorkerScreen({
           </MainChild>
         </Main>
         <Sidebar
-          appName={machineConfig.appMode.name}
+          appName={machineConfig.appMode.productName}
           centerContent
           title="Poll Worker Actions"
           screenReaderInstructions="To navigate through the available actions, use the down arrow."

--- a/frontends/bmd/src/pages/replace_election_screen.tsx
+++ b/frontends/bmd/src/pages/replace_election_screen.tsx
@@ -122,7 +122,7 @@ export function ReplaceElectionScreen({
         </MainChild>
       </Main>
       <Sidebar
-        appName={machineConfig.appMode.name}
+        appName={machineConfig.appMode.productName}
         centerContent
         title="Replace Election"
         footer={

--- a/frontends/bmd/src/pages/review_page.tsx
+++ b/frontends/bmd/src/pages/review_page.tsx
@@ -407,7 +407,7 @@ export function ReviewPage(): JSX.Element {
                 To review your votes, advance through the ballot contests using
                 the up and down buttons. To change your vote in any contest, use
                 the select button to navigate to that contest.
-                {machineConfig.appMode.isVxPrint
+                {machineConfig.appMode.isPrint
                   ? 'When you are finished making your ballot selections and ready to print your ballot, use the right button to print your ballot.'
                   : 'When you are finished making your ballot selections and ready to print your ballot, use the right button to continue.'}
               </span>
@@ -530,7 +530,7 @@ export function ReviewPage(): JSX.Element {
             <LinkButton
               large
               primary
-              to={machineConfig.appMode.isVxPrint ? '/print' : '/save'}
+              to={machineConfig.appMode.isPrint ? '/print' : '/save'}
               id="next"
             >
               I’m Ready to <NoWrap>Print My Ballot</NoWrap>

--- a/frontends/bmd/src/pages/test_ballot_deck_screen.test.tsx
+++ b/frontends/bmd/src/pages/test_ballot_deck_screen.test.tsx
@@ -18,7 +18,7 @@ import { render } from '../../test/test_utils';
 import { randomBase64 } from '../utils/random';
 import { TestBallotDeckScreen } from './test_ballot_deck_screen';
 import { fakeMachineConfig } from '../../test/helpers/fake_machine_config';
-import { PrecinctSelectionKind, VxPrintOnly } from '../config/types';
+import { PrecinctSelectionKind, PrintOnly } from '../config/types';
 import { fakePrinter } from '../../test/helpers/fake_printer';
 
 // mock the random value so the snapshots match
@@ -40,7 +40,7 @@ it('renders test decks appropriately', async () => {
       electionDefinition={asElectionDefinition(parseElection(electionSample))}
       hideTestDeck={jest.fn()}
       machineConfig={fakeMachineConfig({
-        appMode: VxPrintOnly,
+        appMode: PrintOnly,
       })}
       isLiveMode={false}
       printer={printer}
@@ -88,7 +88,7 @@ it('shows printer not connected when appropriate', async () => {
       }}
       electionDefinition={asElectionDefinition(parseElection(electionSample))}
       machineConfig={fakeMachineConfig({
-        appMode: VxPrintOnly,
+        appMode: PrintOnly,
       })}
       hideTestDeck={jest.fn()}
       isLiveMode={false}

--- a/frontends/bmd/src/pages/test_ballot_deck_screen.tsx
+++ b/frontends/bmd/src/pages/test_ballot_deck_screen.tsx
@@ -226,7 +226,7 @@ export function TestBallotDeckScreen({
           </MainChild>
         </Main>
         <Sidebar
-          appName={machineConfig.appMode.name}
+          appName={machineConfig.appMode.productName}
           centerContent
           title="Election Admin Actions"
           footer={

--- a/frontends/bmd/src/utils/machine_config.test.ts
+++ b/frontends/bmd/src/utils/machine_config.test.ts
@@ -4,59 +4,59 @@ import { machineConfigProvider } from './machine_config';
 import {
   MachineConfig,
   MachineConfigResponse,
-  VxMarkOnly,
-  VxMarkPlusVxPrint,
-  VxPrintOnly,
+  MarkOnly,
+  MarkAndPrint,
+  PrintOnly,
 } from '../config/types';
 
-test('successful VxMark fetch from /machine-config', async () => {
+test('successful MarkOnly fetch from /machine-config', async () => {
   fetchMock.get(
     '/machine-config',
     typedAs<MachineConfigResponse>({
-      appModeName: 'VxMark',
+      appModeKey: 'MarkOnly',
       machineId: '1',
       codeVersion: 'test',
     })
   );
   expect(await machineConfigProvider.get()).toEqual(
     typedAs<MachineConfig>({
-      appMode: VxMarkOnly,
+      appMode: MarkOnly,
       machineId: '1',
       codeVersion: 'test',
     })
   );
 });
 
-test('successful VxPrint fetch from /machine-config', async () => {
+test('successful PrintOnly fetch from /machine-config', async () => {
   fetchMock.get(
     '/machine-config',
     typedAs<MachineConfigResponse>({
-      appModeName: 'VxPrint',
+      appModeKey: 'PrintOnly',
       machineId: '1',
       codeVersion: 'test',
     })
   );
   expect(await machineConfigProvider.get()).toEqual(
     typedAs<MachineConfig>({
-      appMode: VxPrintOnly,
+      appMode: PrintOnly,
       machineId: '1',
       codeVersion: 'test',
     })
   );
 });
 
-test('successful VxMark + VxPrint fetch from /machine-config', async () => {
+test('successful MarkAndPrint fetch from /machine-config', async () => {
   fetchMock.get(
     '/machine-config',
     typedAs<MachineConfigResponse>({
-      appModeName: 'VxMark + VxPrint',
+      appModeKey: 'MarkAndPrint',
       machineId: '1',
       codeVersion: 'test',
     })
   );
   expect(await machineConfigProvider.get()).toEqual(
     typedAs<MachineConfig>({
-      appMode: VxMarkPlusVxPrint,
+      appMode: MarkAndPrint,
       machineId: '1',
       codeVersion: 'test',
     })

--- a/frontends/bmd/src/utils/machine_config.ts
+++ b/frontends/bmd/src/utils/machine_config.ts
@@ -8,13 +8,13 @@ import {
 
 export const machineConfigProvider: Provider<MachineConfig> = {
   async get() {
-    const { appModeName, machineId, codeVersion } = unsafeParse(
+    const { appModeKey, machineId, codeVersion } = unsafeParse(
       MachineConfigResponseSchema,
       await fetchJson('/machine-config')
     );
 
     return {
-      appMode: getAppMode(appModeName),
+      appMode: getAppMode(appModeKey),
       machineId,
       codeVersion,
     };

--- a/frontends/bmd/src/utils/voices.ts
+++ b/frontends/bmd/src/utils/voices.ts
@@ -12,7 +12,7 @@ export const getUsEnglishVoice: VoiceSelector = () => {
 
   // Find voices in ranked order.
   return (
-    // Prefer the CMU voices present on VxMark.
+    // Prefer the CMU voices present on the machine.
     voices.find((voice) => voice.name === 'cmu_us_slt_arctic_hts festival') ??
     voices.find(
       (voice) => voice.name === 'cmu_us_slt_arctic_clunits festival'

--- a/frontends/bmd/test/helpers/fake_machine_config.ts
+++ b/frontends/bmd/test/helpers/fake_machine_config.ts
@@ -1,8 +1,8 @@
 import { Provider } from '@votingworks/types';
-import { VxMarkOnly, MachineConfig } from '../../src/config/types';
+import { MarkOnly, MachineConfig } from '../../src/config/types';
 
 export function fakeMachineConfig({
-  appMode = VxMarkOnly,
+  appMode = MarkOnly,
   machineId = '000',
   codeVersion = 'test',
 }: Partial<MachineConfig> = {}): MachineConfig {

--- a/frontends/bmd/test/test_utils.tsx
+++ b/frontends/bmd/test/test_utils.tsx
@@ -24,7 +24,7 @@ import {
   MarkVoterCardFunction,
   Printer,
   TextSizeSetting,
-  VxMarkOnly,
+  MarkOnly,
 } from '../src/config/types';
 
 import { BallotContext } from '../src/contexts/ballot_context';
@@ -45,7 +45,7 @@ export function render(
     history = createMemoryHistory({ initialEntries: [route] }),
     isCardlessVoter = false,
     isLiveMode = false,
-    machineConfig = fakeMachineConfig({ appMode: VxMarkOnly }),
+    machineConfig = fakeMachineConfig({ appMode: MarkOnly }),
     precinctId,
     printer = fakePrinter(),
     resetBallot = jest.fn(),


### PR DESCRIPTION
Task: #1363 

The goal of this update is to make the three app modes show up with the following product names on screen:
- mark-only mode: VxMark
- print-only mode: VxPrint
- mark-and-print mode: VxMark

In order to do this in a way that also prevented confusing these product names within the code base, I also renamed the app modes to the following:
- mark-only mode: MarkOnly (formerly VxMarkOnly)
- print-only mode: PrintOnly (formerly VxPrintOnly)
- mark-and-print mode: MarkAndPrint (formerly VxMark + VxPrint)

My hope is that by avoiding using product names in the code, these three cases can be more easily distinguished.