### PR TITLE
fix(eslint): correct error message copy

### DIFF
--- a/libs/eslint-plugin-vx/src/rules/gts_object_literal_types.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_object_literal_types.ts
@@ -17,7 +17,7 @@ export default createRule({
     },
     messages: {
       noObjectLiteralTypeAssertions:
-        'Do not use type assertions on object literals; prefer type assertions instead',
+        'Do not use type assertions on object literals; prefer type annotations instead',
       useTypeAnnotation:
         'Type literal must be declared with a type annotation or `as const`.',
       convertToTypeAnnotation: 'Convert to type annotation',


### PR DESCRIPTION
In the old message it said both to use and not use "type assertions". It should say to use "type annotations".