### PR TITLE
feat(scan): add `PUT /config/package`

### DIFF
--- a/libs/types/src/api/services/scan/index.ts
+++ b/libs/types/src/api/services/scan/index.ts
@@ -156,6 +156,32 @@ export type DeleteElectionConfigResponse = OkResponse;
 export const DeleteElectionConfigResponseSchema: z.ZodSchema<DeleteElectionConfigResponse> = OkResponseSchema;
 
 /**
+ * @url /config/package
+ * @method PUT
+ */
+export type PutConfigPackageRequest = never;
+
+/**
+ * @url /config/package
+ * @method PUT
+ */
+export const PutConfigPackageRequestSchema: z.ZodSchema<PutConfigPackageRequest> = z.never();
+
+/**
+ * @url /config/package
+ * @method PUT
+ */
+export type PutConfigPackageResponse = OkResponse | ErrorsResponse;
+
+/**
+ * @url /config/package
+ * @method PUT
+ */
+export const PutConfigPackageResponseSchema: z.ZodSchema<PutConfigPackageResponse> = z.union(
+  [OkResponseSchema, ErrorsResponseSchema]
+);
+
+/**
  * @url /config/testMode
  * @method GET
  */

--- a/libs/utils/src/ballot_package.ts
+++ b/libs/utils/src/ballot_package.ts
@@ -133,10 +133,11 @@ async function readJsonEntry(zipfile: ZipFile, entry: Entry): Promise<unknown> {
 }
 
 async function readBallotPackageFromZip(
-  zipfile: ZipFile,
+  source: Buffer,
   fileName: string,
   fileSize: number
 ): Promise<BallotPackage> {
+  const zipfile = await openZip(source);
   const entries = await getEntries(zipfile);
   const electionEntry = entries.find(
     (entry) => entry.fileName === 'election.json'
@@ -191,19 +192,22 @@ async function readBallotPackageFromZip(
 }
 
 async function readBallotPackageFromFile(file: File): Promise<BallotPackage> {
-  const zipFile = await openZip(await readFile(file));
-  return readBallotPackageFromZip(zipFile, file.name, file.size);
+  return readBallotPackageFromZip(await readFile(file), file.name, file.size);
 }
 
 async function readBallotPackageFromFilePointer(
   file: KioskBrowser.FileSystemEntry
 ): Promise<BallotPackage> {
   assert(window.kiosk);
-  const zipFile = await openZip(await window.kiosk.readFile(file.path));
-  return readBallotPackageFromZip(zipFile, file.name, file.size);
+  return readBallotPackageFromZip(
+    Buffer.from(await window.kiosk.readFile(file.path)),
+    file.name,
+    file.size
+  );
 }
 
 export const ballotPackageUtils = {
   readBallotPackageFromFile,
   readBallotPackageFromFilePointer,
+  readBallotPackageFromZip,
 } as const;


### PR DESCRIPTION
This allows configuring the scan service by `PUT`ting a ballot package zip file directly. This is useful for local testing, but will also be used for NH demo.