### PR TITLE
refactor(utils): rename ballot package zip function

### DIFF
--- a/frontends/bsd/src/screens/load_election_screen.tsx
+++ b/frontends/bsd/src/screens/load_election_screen.tsx
@@ -3,7 +3,12 @@ import {
   safeParseElectionDefinition,
 } from '@votingworks/types';
 import React, { useContext, useState } from 'react';
-import { assert, BallotPackage, ballotPackageUtils } from '@votingworks/utils';
+import {
+  assert,
+  BallotPackage,
+  readBallotPackageFromFile,
+  readBallotPackageFromFilePointer,
+} from '@votingworks/utils';
 import { LogEventId } from '@votingworks/logging';
 import * as config from '../api/config';
 import { addTemplates, doneTemplates } from '../api/hmpb';
@@ -100,9 +105,7 @@ export function LoadElectionScreen({
       });
     } else {
       try {
-        const ballotPackage = await ballotPackageUtils.readBallotPackageFromFile(
-          file
-        );
+        const ballotPackage = await readBallotPackageFromFile(file);
         await logger.log(
           LogEventId.BallotPackagedLoadedFromUsb,
           currentUserType,
@@ -133,9 +136,7 @@ export function LoadElectionScreen({
   async function onAutomaticFileImport(file: KioskBrowser.FileSystemEntry) {
     // All automatic file imports will be on zip packages
     try {
-      const ballotPackage = await ballotPackageUtils.readBallotPackageFromFilePointer(
-        file
-      );
+      const ballotPackage = await readBallotPackageFromFilePointer(file);
       await logger.log(
         LogEventId.BallotPackagedLoadedFromUsb,
         currentUserType,

--- a/frontends/precinct-scanner/src/screens/unconfigured_election_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/unconfigured_election_screen.tsx
@@ -4,7 +4,11 @@ import {
   OptionalElectionDefinition,
   getPrecinctById,
 } from '@votingworks/types';
-import { assert, ballotPackageUtils, usbstick } from '@votingworks/utils';
+import {
+  assert,
+  readBallotPackageFromFilePointer,
+  usbstick,
+} from '@votingworks/utils';
 import { addTemplates, doneTemplates } from '../api/hmpb';
 import { PRECINCT_SCANNER_FOLDER } from '../config/globals';
 import { CenteredLargeProse, CenteredScreen } from '../components/layout';
@@ -72,7 +76,7 @@ export function UnconfiguredElectionScreen({
         }
 
         // Get the most recently-created ballot package.
-        const ballotPackage = await ballotPackageUtils.readBallotPackageFromFilePointer(
+        const ballotPackage = await readBallotPackageFromFilePointer(
           // eslint-disable-next-line vx/gts-safe-number-parse
           [...ballotPackages].sort((a, b) => +b.ctime - +a.ctime)[0]
         );

--- a/libs/utils/src/ballot_package.ts
+++ b/libs/utils/src/ballot_package.ts
@@ -132,7 +132,7 @@ async function readJsonEntry(zipfile: ZipFile, entry: Entry): Promise<unknown> {
   return JSON.parse(await readTextEntry(zipfile, entry));
 }
 
-async function readBallotPackageFromZip(
+export async function readBallotPackageFromBuffer(
   source: Buffer,
   fileName: string,
   fileSize: number
@@ -191,23 +191,23 @@ async function readBallotPackageFromZip(
   };
 }
 
-async function readBallotPackageFromFile(file: File): Promise<BallotPackage> {
-  return readBallotPackageFromZip(await readFile(file), file.name, file.size);
-}
-
-async function readBallotPackageFromFilePointer(
-  file: KioskBrowser.FileSystemEntry
+export async function readBallotPackageFromFile(
+  file: File
 ): Promise<BallotPackage> {
-  assert(window.kiosk);
-  return readBallotPackageFromZip(
-    Buffer.from(await window.kiosk.readFile(file.path)),
+  return readBallotPackageFromBuffer(
+    await readFile(file),
     file.name,
     file.size
   );
 }
 
-export const ballotPackageUtils = {
-  readBallotPackageFromFile,
-  readBallotPackageFromFilePointer,
-  readBallotPackageFromZip,
-} as const;
+export async function readBallotPackageFromFilePointer(
+  file: KioskBrowser.FileSystemEntry
+): Promise<BallotPackage> {
+  assert(window.kiosk);
+  return readBallotPackageFromBuffer(
+    Buffer.from(await window.kiosk.readFile(file.path)),
+    file.name,
+    file.size
+  );
+}

--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -1,6 +1,6 @@
 /* istanbul ignore file */
 export * from './assert';
-export * as ballotPackageUtils from './ballot_package';
+export * from './ballot_package';
 export * from './Card';
 export * from './compressed_tallies';
 export * from './date';

--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -1,6 +1,6 @@
 /* istanbul ignore file */
 export * from './assert';
-export * from './ballot_package';
+export * as ballotPackageUtils from './ballot_package';
 export * from './Card';
 export * from './compressed_tallies';
 export * from './date';

--- a/services/scan/src/server.ts
+++ b/services/scan/src/server.ts
@@ -55,7 +55,7 @@ import bodyParser from 'body-parser';
 import express, { Application } from 'express';
 import { readFile } from 'fs-extra';
 import multer from 'multer';
-import { assert, ballotPackageUtils } from '@votingworks/utils';
+import { assert, readBallotPackageFromBuffer } from '@votingworks/utils';
 import { backup } from './backup';
 import {
   SCAN_ALWAYS_HOLD_ON_REJECT,
@@ -188,7 +188,7 @@ export function buildApp({ store, importer }: AppOptions): Application {
         return;
       }
 
-      const pkg = await ballotPackageUtils.readBallotPackageFromBuffer(
+      const pkg = await readBallotPackageFromBuffer(
         await readFile(file.path),
         file.filename,
         file.size

--- a/services/scan/src/server.ts
+++ b/services/scan/src/server.ts
@@ -188,7 +188,7 @@ export function buildApp({ store, importer }: AppOptions): Application {
         return;
       }
 
-      const pkg = await ballotPackageUtils.readBallotPackageFromZip(
+      const pkg = await ballotPackageUtils.readBallotPackageFromBuffer(
         await readFile(file.path),
         file.filename,
         file.size


### PR DESCRIPTION
In #1413 I changed the argument type from `ZipFile` to `Buffer` but didn't change the name. To clarify what the argument is I changed it to mirror the `FromFile` variant as `FromBuffer`.

I also added a test for this function specifically and removed the intermediate `ballotPackageUtils` export within the `/utils` package, but preserved it for external consumers.