### PR TITLE
refactor(scan): extract `DbClient`

### DIFF
--- a/services/scan/src/db_client.test.ts
+++ b/services/scan/src/db_client.test.ts
@@ -1,0 +1,142 @@
+import * as fs from 'fs-extra';
+import * as tmp from 'tmp';
+import { DbClient } from './db_client';
+
+test('file database client', async () => {
+  const dbFile = tmp.fileSync();
+  const client = await DbClient.fileClient(dbFile.name);
+
+  await client.reset();
+  await fs.access(dbFile.name);
+
+  expect(client.getDatabasePath()).toBe(dbFile.name);
+  expect(client.isMemoryDatabase()).toBe(false);
+
+  await client.exec(
+    'create table if not exists muppets (name varchar(255) unique not null)'
+  );
+  await client.run('insert into muppets (name) values (?)', 'Kermit');
+  await client.run('insert into muppets (name) values (?)', 'Fozzie');
+
+  const backupDbFile = tmp.fileSync();
+  await client.backup(backupDbFile.name);
+
+  const clientForBackup = await DbClient.fileClient(backupDbFile.name);
+  expect(await clientForBackup.all('select * from muppets')).toEqual([
+    { name: 'Kermit' },
+    { name: 'Fozzie' },
+  ]);
+
+  await client.destroy();
+  await expect(fs.access(dbFile.name)).rejects.toThrowError('ENOENT');
+});
+
+test('memory database client', async () => {
+  const client = await DbClient.memoryClient();
+
+  await client.reset();
+
+  expect(client.getDatabasePath()).toEqual(':memory:');
+  expect(client.isMemoryDatabase()).toBe(true);
+
+  await client.destroy();
+});
+
+test('read/write', async () => {
+  const client = await DbClient.memoryClient();
+
+  await client.exec(
+    'create table if not exists muppets (name varchar(255) unique not null)'
+  );
+  expect(await client.all('select * from muppets')).toEqual([]);
+  expect(await client.one('select * from muppets')).toBeUndefined();
+
+  await client.run('insert into muppets (name) values (?)', 'Kermit');
+  await client.run('insert into muppets (name) values (?)', 'Fozzie');
+
+  expect(await client.all('select * from muppets')).toEqual([
+    { name: 'Kermit' },
+    { name: 'Fozzie' },
+  ]);
+  expect(await client.one('select * from muppets')).toEqual({ name: 'Kermit' });
+  expect(
+    await client.one('select * from muppets where name != ?', 'Kermit')
+  ).toEqual({ name: 'Fozzie' });
+});
+
+test('transactions', async () => {
+  const client = await DbClient.memoryClient();
+
+  await client.exec(
+    'create table if not exists muppets (name varchar(255) unique not null)'
+  );
+
+  await client.run('insert into muppets (name) values (?)', 'Kermit');
+  expect(await client.one('select count(*) as count from muppets')).toEqual({
+    count: 1,
+  });
+
+  await expect(
+    client.transaction(async () => {
+      await client.run('insert into muppets (name) values (?)', 'Fozzie');
+      expect(
+        await client.one('select count(*) as count from muppets')
+      ).toEqual({ count: 2 });
+      throw new Error('rollback');
+    })
+  ).rejects.toThrow('rollback');
+  expect(await client.one('select count(*) as count from muppets')).toEqual({
+    count: 1,
+  });
+
+  await client.transaction(async () => {
+    await client.run('insert into muppets (name) values (?)', 'Fozzie');
+  });
+  expect(await client.one('select count(*) as count from muppets')).toEqual({
+    count: 2,
+  });
+});
+
+test('schema loading', async () => {
+  const schemaFile = tmp.fileSync();
+  await fs.writeFile(
+    schemaFile.name,
+    `create table if not exists muppets (name varchar(255) unique not null);`
+  );
+
+  const client = await DbClient.memoryClient(schemaFile.name);
+  await client.run('insert into muppets (name) values (?)', 'Kermit');
+});
+
+test('runtime errors', async () => {
+  const client = await DbClient.memoryClient();
+
+  await expect(client.run('select * from muppets')).rejects.toThrow(
+    'SQLITE_ERROR: no such table: muppets'
+  );
+
+  await expect(client.exec('select * from muppets')).rejects.toThrow(
+    'SQLITE_ERROR: no such table: muppets'
+  );
+
+  await expect(client.all('select * from muppets')).rejects.toThrow(
+    'SQLITE_ERROR: no such table: muppets'
+  );
+
+  await expect(client.one('select * from muppets')).rejects.toThrow(
+    'SQLITE_ERROR: no such table: muppets'
+  );
+});
+
+test('connect errors', async () => {
+  const client = await DbClient.fileClient('/not/a/real/path');
+  await expect(client.connect()).rejects.toThrow();
+});
+
+test('destroy errors', async () => {
+  const file = tmp.fileSync();
+  const client = await DbClient.fileClient(file.name);
+  await client.connect();
+  file.removeCallback();
+  await expect(client.destroy()).rejects.toThrow();
+});

--- a/services/scan/src/db_client.ts
+++ b/services/scan/src/db_client.ts
@@ -1,0 +1,311 @@
+import { assert } from '@votingworks/utils';
+import { createHash } from 'crypto';
+import makeDebug from 'debug';
+import { promises as fs } from 'fs';
+import * as sqlite3 from 'sqlite3';
+
+const debug = makeDebug('scan:db-client');
+
+const MEMORY_DB_PATH = ':memory:';
+
+/**
+ * Manages a connection for a SQLite database.
+ */
+export class DbClient {
+  private db?: sqlite3.Database;
+
+  /**
+   * @param dbPath a file system path, or ":memory:" for an in-memory database
+   */
+  private constructor(
+    private readonly dbPath: string,
+    private readonly schemaPath?: string
+  ) {}
+
+  /**
+   * Gets the path to the SQLite database file.
+   */
+  getDatabasePath(): string {
+    return this.dbPath;
+  }
+
+  /**
+   * Determines whether this client is connected to an in-memory database.
+   */
+  isMemoryDatabase(): boolean {
+    return this.dbPath === MEMORY_DB_PATH;
+  }
+
+  /**
+   * Gets the sha256 digest of the current schema file.
+   */
+  private async getSchemaDigest(): Promise<string> {
+    assert(typeof this.schemaPath === 'string', 'schemaPath is required');
+    const schemaSql = await fs.readFile(this.schemaPath, 'utf-8');
+    return createHash('sha256').update(schemaSql).digest('hex');
+  }
+
+  /**
+   * Builds and returns a new client whose data is kept in memory.
+   */
+  static async memoryClient(schemaPath?: string): Promise<DbClient> {
+    const client = new DbClient(MEMORY_DB_PATH, schemaPath);
+    await client.create();
+    return client;
+  }
+
+  /**
+   * Builds and returns a new client at `dbPath`.
+   */
+  static async fileClient(
+    dbPath: string,
+    schemaPath?: string
+  ): Promise<DbClient> {
+    const client = new DbClient(dbPath, schemaPath);
+
+    if (!schemaPath) {
+      return client;
+    }
+
+    const schemaDigestPath = `${dbPath}.digest`;
+    let schemaDigest: string | undefined;
+    try {
+      schemaDigest = (await fs.readFile(schemaDigestPath, 'utf-8')).trim();
+    } catch {
+      debug(
+        'could not read %s, assuming the database needs to be created',
+        schemaDigestPath
+      );
+    }
+    const newSchemaDigest = await client.getSchemaDigest();
+    const shouldResetDatabase = newSchemaDigest !== schemaDigest;
+
+    if (shouldResetDatabase) {
+      debug(
+        'database schema has changed (%s ≉ %s)',
+        schemaDigest,
+        newSchemaDigest
+      );
+      try {
+        const backupPath = `${dbPath}.backup-${new Date()
+          .toISOString()
+          .replace(/[^\d]+/g, '-')
+          .replace(/-+$/, '')}`;
+        await fs.rename(dbPath, backupPath);
+        debug('backed up database to be reset to %s', backupPath);
+      } catch {
+        // ignore for now
+      }
+    }
+
+    if (shouldResetDatabase) {
+      debug('resetting database to updated schema');
+      await client.reset();
+      await fs.writeFile(schemaDigestPath, newSchemaDigest, 'utf-8');
+    } else {
+      debug('database schema appears to be up to date');
+    }
+
+    return client;
+  }
+
+  /**
+   * Gets the underlying sqlite3 database.
+   */
+  private async getDatabase(): Promise<sqlite3.Database> {
+    if (!this.db) {
+      return this.connect();
+    }
+    return this.db;
+  }
+
+  /**
+   * Run {@link fn} within a transaction.
+   */
+  async transaction(fn: () => Promise<void>): Promise<void> {
+    await this.run('begin transaction');
+    try {
+      await fn();
+      await this.run('commit');
+    } catch (err) {
+      await this.run('rollback');
+      throw err;
+    }
+  }
+
+  /**
+   * Runs `sql` with interpolated data.
+   *
+   * @example
+   *
+   * await client.run('insert into muppets (name) values (?)', 'Kermit')
+   */
+  async run<P extends unknown[]>(sql: string, ...params: P): Promise<void> {
+    const db = await this.getDatabase();
+    return new Promise((resolve, reject) => {
+      db.run(sql, ...params, (err: unknown) => {
+        if (err) {
+          debug('failed to execute %s (%o): %s', sql, params, err);
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+
+  /**
+   * Executes `sql`, which can be multiple statements.
+   *
+   * @example
+   *
+   * await client.exec(`
+   *   pragma foreign_keys = 1;
+   *
+   *   create table if not exist muppets (name varchar(255));
+   *   create table if not exist images (url integer unique not null);
+   * `)
+   */
+  async exec(sql: string): Promise<void> {
+    const db = await this.getDatabase();
+    return new Promise((resolve, reject) => {
+      db.exec(sql, (err: unknown) => {
+        if (err) {
+          debug('failed to execute %s (%o): %s', sql, err);
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+
+  /**
+   * Runs `sql` to fetch a list of rows.
+   *
+   * @example
+   *
+   * await client.all('select * from muppets')
+   */
+  async all<P extends unknown[] = []>(
+    sql: string,
+    ...params: P
+  ): Promise<unknown[]> {
+    const db = await this.getDatabase();
+    return new Promise((resolve, reject) => {
+      db.all(sql, params, (err: unknown, rows: unknown[]) => {
+        if (err) {
+          debug('failed to execute %s (%o): %s', sql, params, err);
+          reject(err);
+        } else {
+          resolve(rows);
+        }
+      });
+    });
+  }
+
+  /**
+   * Runs `sql` to fetch a single row.
+   *
+   * @example
+   *
+   * await client.one('select count(*) as count from muppets')
+   */
+  async one<P extends unknown[] = []>(
+    sql: string,
+    ...params: P
+  ): Promise<unknown> {
+    const db = await this.getDatabase();
+    return new Promise<unknown>((resolve, reject) => {
+      db.get(sql, params, (err: unknown, row: unknown) => {
+        if (err) {
+          debug('failed to execute %s (%o): %s', sql, params, err);
+          reject(err);
+        } else {
+          resolve(row);
+        }
+      });
+    });
+  }
+
+  /**
+   * Deletes the entire database, including its on-disk representation.
+   */
+  async destroy(): Promise<void> {
+    const db = await this.getDatabase();
+    return new Promise((resolve, reject) => {
+      db.close(async () => {
+        if (!this.isMemoryDatabase()) {
+          const dbPath = this.getDatabasePath();
+          try {
+            debug('deleting the database file at %s', dbPath);
+            await fs.unlink(dbPath);
+          } catch (error) {
+            debug(
+              'failed to delete database file %s: %s',
+              dbPath,
+              error.message
+            );
+            reject(error);
+          }
+        }
+
+        resolve();
+      });
+    });
+  }
+
+  async connect(): Promise<sqlite3.Database> {
+    debug('connecting to the database at %s', this.getDatabasePath());
+    this.db = await new Promise<sqlite3.Database>((resolve, reject) => {
+      const db = new sqlite3.Database(
+        this.getDatabasePath(),
+        (err: unknown) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(db);
+          }
+        }
+      );
+    });
+
+    // Enforce foreign key constraints. This is not in schema.sql because that
+    // only runs on db creation.
+    await this.run('pragma foreign_keys = 1');
+
+    return this.db;
+  }
+
+  /**
+   * Creates the database including its tables.
+   */
+  async create(): Promise<sqlite3.Database> {
+    debug('creating the database at %s', this.getDatabasePath());
+    const db = await this.connect();
+    if (this.schemaPath) {
+      const schema = await fs.readFile(this.schemaPath, 'utf-8');
+      await this.exec(schema);
+    }
+    return db;
+  }
+
+  /**
+   * Writes a copy of the database to the given path.
+   */
+  async backup(filePath: string): Promise<void> {
+    assert(!this.isMemoryDatabase(), 'cannot backup a memory database');
+    await this.run('vacuum into ?', filePath);
+  }
+
+  /**
+   * Resets the database.
+   */
+  async reset(): Promise<void> {
+    if (this.db) {
+      await this.destroy();
+    }
+
+    await this.create();
+  }
+}

--- a/services/scan/src/store.test.ts
+++ b/services/scan/src/store.test.ts
@@ -8,7 +8,6 @@ import {
   YesNoContest,
 } from '@votingworks/types';
 import { typedAs } from '@votingworks/utils';
-import { promises as fs } from 'fs';
 import * as tmp from 'tmp';
 import { v4 as uuid } from 'uuid';
 import { election } from '../test/fixtures/state-of-hamilton';
@@ -151,17 +150,6 @@ test('HMPB template handling', async () => {
       ],
     ])
   );
-});
-
-test('destroy database', async () => {
-  const dbFile = tmp.fileSync();
-  const store = await Store.fileStore(dbFile.name);
-
-  await store.reset();
-  await fs.access(dbFile.name);
-
-  await store.dbDestroy();
-  await expect(fs.access(dbFile.name)).rejects.toThrowError('ENOENT');
 });
 
 test('batch cleanup works correctly', async () => {


### PR DESCRIPTION

## Overview
`Store` has been responsible for both the business logic and the database access jobs. This commit extracts the database access job into a new class, `DbClient`, and renames its functions to be less namespaced. For now I retained most of the `db*` methods in `Store` to keep the changes to existing files isolated to `store.ts`. At a future time we should remove them and provide more semantic access to the database to any callers using them. This commit also creates new tests for `DbClient`.

## Demo Video or Screenshot
n/a

## Testing Plan 
Tests added for `DbClient`, existing tests cover refactored code.

## Checklist
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
- [x] I have added JSDoc comments to any newly introduced exports
