### PR TITLE
refactor(ui/hooks): Change use_hardware to return full device info

### DIFF
--- a/frontends/bas/src/app_root.tsx
+++ b/frontends/bas/src/app_root.tsx
@@ -11,7 +11,7 @@ import {
 import { Logger, LogSource } from '@votingworks/logging';
 import {
   useCancelablePromise,
-  useHardware,
+  useDevices,
   useSmartcard,
   useStoredState,
 } from '@votingworks/ui';
@@ -76,7 +76,7 @@ export function AppRoot({ card, hardware, storage }: Props): JSX.Element {
     () => new Logger(LogSource.VxBallotActivationFrontend, window.kiosk),
     []
   );
-  const { hasCardReaderAttached } = useHardware({ hardware, logger });
+  const { cardReader } = useDevices({ hardware, logger });
 
   const unconfigure = useCallback(() => {
     setElection(undefined);
@@ -136,7 +136,10 @@ export function AppRoot({ card, hardware, storage }: Props): JSX.Element {
   }
 
   const makeCancelable = useCancelablePromise();
-  const smartcard = useSmartcard({ card, hasCardReaderAttached });
+  const smartcard = useSmartcard({
+    card,
+    cardReader,
+  });
 
   const fetchElection = useCallback(async () => {
     setIsLoadingElection(true);

--- a/frontends/bmd/src/app_root.tsx
+++ b/frontends/bmd/src/app_root.tsx
@@ -514,9 +514,13 @@ export function AppRoot({
     []
   );
 
-  const devices = useDevices({ hardware, logger });
-  const { battery } = devices.computer;
-  const hasPrinterAttached = devices.printer !== undefined;
+  const {
+    cardReader,
+    printer: printerInfo,
+    accessibleController,
+    computer,
+  } = useDevices({ hardware, logger });
+  const hasPrinterAttached = printerInfo !== undefined;
   const previousHasPrinterAttached = usePrevious(hasPrinterAttached);
 
   const ballotStyle =
@@ -1178,7 +1182,7 @@ export function AppRoot({
     initializedFromStorage,
   ]);
 
-  if (!devices.cardReader) {
+  if (!cardReader) {
     return (
       <SetupCardReaderPage
         useEffectToggleLargeDisplay={useEffectToggleLargeDisplay}
@@ -1192,7 +1196,7 @@ export function AppRoot({
       />
     );
   }
-  if (battery?.isBelowLowBatteryThreshold && battery.discharging) {
+  if (computer.batteryIsLow && !computer.batteryIsCharging) {
     return (
       <SetupPowerPage
         useEffectToggleLargeDisplay={useEffectToggleLargeDisplay}
@@ -1335,7 +1339,7 @@ export function AppRoot({
             precinctId={precinctId}
             printer={printer}
             useEffectToggleLargeDisplay={useEffectToggleLargeDisplay}
-            showNoChargerAttachedWarning={!!battery?.discharging}
+            showNoChargerAttachedWarning={!computer.batteryIsCharging}
             updateTally={updateTally}
             votes={votes}
           />
@@ -1382,9 +1386,9 @@ export function AppRoot({
           appPrecinct={appPrecinct}
           electionDefinition={optionalElectionDefinition}
           showNoAccessibleControllerWarning={
-            appMode.isMark && !devices.accessibleController
+            appMode.isMark && !accessibleController
           }
-          showNoChargerAttachedWarning={!!battery?.discharging}
+          showNoChargerAttachedWarning={!computer.batteryIsCharging}
           isLiveMode={isLiveMode}
           isPollsOpen={isPollsOpen}
           machineConfig={machineConfig}

--- a/frontends/bmd/src/app_root.tsx
+++ b/frontends/bmd/src/app_root.tsx
@@ -48,7 +48,7 @@ import {
 
 import { Logger, LogSource } from '@votingworks/logging';
 
-import { SetupCardReaderPage, useHardware, usePrevious } from '@votingworks/ui';
+import { SetupCardReaderPage, useDevices, usePrevious } from '@votingworks/ui';
 import { Ballot } from './components/ballot';
 import * as GLOBALS from './config/globals';
 import {
@@ -114,8 +114,6 @@ interface UserState {
 }
 
 interface HardwareState {
-  hasChargerAttached: boolean;
-  hasLowBattery: boolean;
   machineConfig: Readonly<MachineConfig>;
 }
 
@@ -188,8 +186,6 @@ const initialVoterState: Readonly<UserState> = {
 };
 
 const initialHardwareState: Readonly<HardwareState> = {
-  hasChargerAttached: true,
-  hasLowBattery: false,
   machineConfig: { appMode: MarkOnly, machineId: '0000', codeVersion: 'dev' },
 };
 
@@ -249,7 +245,6 @@ type AppAction =
   | { type: 'updateElectionDefinition'; electionDefinition: ElectionDefinition }
   | { type: 'startWritingLongValue' }
   | { type: 'finishWritingLongValue' }
-  | { type: 'updateHardwareState'; hardwareState: Partial<HardwareState> }
   | { type: 'initializeAppState'; appState: Partial<State> }
   | { type: 'updateLastCardDataString'; currentCardDataString: string }
   | {
@@ -419,11 +414,6 @@ function appReducer(state: State, action: AppAction): State {
         ...state,
         writingVoteToCard: false,
       };
-    case 'updateHardwareState':
-      return {
-        ...state,
-        ...action.hardwareState,
-      };
     case 'initializeAppState':
       return {
         ...state,
@@ -507,8 +497,6 @@ export function AppRoot({
     lastCardDataString,
     machineConfig,
     pauseProcessingUntilNoCardPresent,
-    hasChargerAttached,
-    hasLowBattery,
     precinctId,
     shortValue,
     showPostVotingInstructions,
@@ -526,11 +514,9 @@ export function AppRoot({
     []
   );
 
-  const {
-    hasCardReaderAttached,
-    hasAccessibleControllerAttached,
-    hasPrinterAttached,
-  } = useHardware({ hardware, logger });
+  const devices = useDevices({ hardware, logger });
+  const { battery } = devices.computer;
+  const hasPrinterAttached = devices.printer !== undefined;
   const previousHasPrinterAttached = usePrevious(hasPrinterAttached);
 
   const ballotStyle =
@@ -1042,45 +1028,6 @@ export function AppRoot({
     writeCard,
   ]);
 
-  const hardwareStatusInterval = useInterval(
-    async () => {
-      const battery = await hardware.readBatteryStatus();
-      if (!battery) {
-        dispatchAppState({
-          type: 'updateHardwareState',
-          hardwareState: {
-            hasChargerAttached: true,
-            hasLowBattery: false,
-          },
-        });
-      } else {
-        const newHasLowBattery = battery.level < GLOBALS.LOW_BATTERY_THRESHOLD;
-        const hasHardwareStateChanged =
-          hasChargerAttached !== !battery.discharging ||
-          hasLowBattery !== newHasLowBattery;
-        if (hasHardwareStateChanged) {
-          dispatchAppState({
-            type: 'updateHardwareState',
-            hardwareState: {
-              hasChargerAttached: !battery.discharging,
-              hasLowBattery: newHasLowBattery,
-            },
-          });
-        }
-      }
-    },
-    GLOBALS.HARDWARE_POLLING_INTERVAL,
-    true
-  );
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const startHardwareStatusPolling = useCallback(hardwareStatusInterval[0], [
-    hardware,
-  ]);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const stopHardwareStatusPolling = useCallback(hardwareStatusInterval[1], [
-    hardware,
-  ]);
-
   // Handle Hardware Observer Subscription
   useEffect(() => {
     async function resetBallotOnPrinterDetach() {
@@ -1181,17 +1128,13 @@ export function AppRoot({
     void updateStorage();
     startCardShortValueReadPolling();
     startLongValueWritePolling();
-    startHardwareStatusPolling();
     return /* istanbul ignore next - triggering keystrokes issue - https://github.com/votingworks/bmd/issues/62 */ () => {
       stopCardShortValueReadPolling();
-      stopHardwareStatusPolling();
     };
   }, [
     startCardShortValueReadPolling,
-    startHardwareStatusPolling,
     startLongValueWritePolling,
     stopCardShortValueReadPolling,
-    stopHardwareStatusPolling,
     storage,
   ]);
 
@@ -1235,7 +1178,7 @@ export function AppRoot({
     initializedFromStorage,
   ]);
 
-  if (!hasCardReaderAttached) {
+  if (!devices.cardReader) {
     return (
       <SetupCardReaderPage
         useEffectToggleLargeDisplay={useEffectToggleLargeDisplay}
@@ -1249,7 +1192,7 @@ export function AppRoot({
       />
     );
   }
-  if (hasLowBattery && !hasChargerAttached) {
+  if (battery?.isBelowLowBatteryThreshold && battery.discharging) {
     return (
       <SetupPowerPage
         useEffectToggleLargeDisplay={useEffectToggleLargeDisplay}
@@ -1392,7 +1335,7 @@ export function AppRoot({
             precinctId={precinctId}
             printer={printer}
             useEffectToggleLargeDisplay={useEffectToggleLargeDisplay}
-            showNoChargerAttachedWarning={!hasChargerAttached}
+            showNoChargerAttachedWarning={!!battery?.discharging}
             updateTally={updateTally}
             votes={votes}
           />
@@ -1439,9 +1382,9 @@ export function AppRoot({
           appPrecinct={appPrecinct}
           electionDefinition={optionalElectionDefinition}
           showNoAccessibleControllerWarning={
-            appMode.isMark && !hasAccessibleControllerAttached
+            appMode.isMark && !devices.accessibleController
           }
-          showNoChargerAttachedWarning={!hasChargerAttached}
+          showNoChargerAttachedWarning={!!battery?.discharging}
           isLiveMode={isLiveMode}
           isPollsOpen={isPollsOpen}
           machineConfig={machineConfig}

--- a/frontends/bmd/src/app_setup_errors.test.tsx
+++ b/frontends/bmd/src/app_setup_errors.test.tsx
@@ -3,6 +3,10 @@ import { act, render, screen } from '@testing-library/react';
 import { makeAdminCard } from '@votingworks/test-utils';
 import { MemoryStorage, MemoryCard, MemoryHardware } from '@votingworks/utils';
 
+import {
+  BATTERY_POLLING_INTERVAL,
+  LOW_BATTERY_THRESHOLD,
+} from '@votingworks/ui';
 import { electionSampleDefinition } from './data';
 
 import { App } from './app';
@@ -16,10 +20,6 @@ import {
 } from '../test/helpers/election';
 import { withMarkup } from '../test/helpers/with_markup';
 import { fakeMachineConfigProvider } from '../test/helpers/fake_machine_config';
-import {
-  HARDWARE_POLLING_INTERVAL,
-  LOW_BATTERY_THRESHOLD,
-} from './config/globals';
 import { PrintOnly } from './config/types';
 
 beforeEach(() => {
@@ -65,7 +65,7 @@ describe('Displays setup warning messages and errors screens', () => {
     await act(async () => {
       await hardware.setAccessibleControllerConnected(false);
     });
-    await advanceTimersAndPromises(HARDWARE_POLLING_INTERVAL / 1000);
+    await advanceTimersAndPromises();
     screen.getByText(accessibleControllerWarningText);
     screen.getByText(insertCardScreenText);
 
@@ -73,7 +73,7 @@ describe('Displays setup warning messages and errors screens', () => {
     await act(async () => {
       await hardware.setAccessibleControllerConnected(true);
     });
-    await advanceTimersAndPromises(HARDWARE_POLLING_INTERVAL / 1000);
+    await advanceTimersAndPromises();
     expect(screen.queryByText(accessibleControllerWarningText)).toBeFalsy();
     screen.getByText(insertCardScreenText);
   });
@@ -146,14 +146,14 @@ describe('Displays setup warning messages and errors screens', () => {
     await act(async () => {
       await hardware.setPrinterConnected(false);
     });
-    await advanceTimersAndPromises(HARDWARE_POLLING_INTERVAL / 1000);
+    await advanceTimersAndPromises();
     screen.getByText('No Printer Detected');
 
     // Reconnect Printer
     await act(async () => {
       await hardware.setPrinterConnected(true);
     });
-    await advanceTimersAndPromises(HARDWARE_POLLING_INTERVAL / 1000);
+    await advanceTimersAndPromises();
     screen.getByText(printOnlyInsertCardScreenText);
   });
 
@@ -186,14 +186,14 @@ describe('Displays setup warning messages and errors screens', () => {
     await act(async () => {
       await hardware.setBatteryDischarging(true);
     });
-    await advanceTimersAndPromises(HARDWARE_POLLING_INTERVAL / 1000);
+    await advanceTimersAndPromises(BATTERY_POLLING_INTERVAL / 1000);
     screen.getByText(noPowerDetectedWarningText);
 
     // Reconnect Power
     await act(async () => {
       await hardware.setBatteryDischarging(false);
     });
-    await advanceTimersAndPromises(HARDWARE_POLLING_INTERVAL / 1000);
+    await advanceTimersAndPromises(BATTERY_POLLING_INTERVAL / 1000);
     expect(screen.queryByText(noPowerDetectedWarningText)).toBeFalsy();
     screen.getByText(printOnlyInsertCardScreenText);
   });
@@ -230,7 +230,7 @@ describe('Displays setup warning messages and errors screens', () => {
     await act(async () => {
       await hardware.setPrinterConnected(false);
     });
-    await advanceTimersAndPromises(HARDWARE_POLLING_INTERVAL / 1000);
+    await advanceTimersAndPromises();
     screen.getByText('No Printer Detected');
 
     // Insert admin card
@@ -270,7 +270,7 @@ describe('Displays setup warning messages and errors screens', () => {
       await hardware.setBatteryDischarging(true);
       await hardware.setBatteryLevel(0.6);
     });
-    await advanceTimersAndPromises(HARDWARE_POLLING_INTERVAL / 1000);
+    await advanceTimersAndPromises(BATTERY_POLLING_INTERVAL / 1000);
     screen.getByText(noPowerDetectedWarningText);
     screen.getByText(insertCardScreenText);
 
@@ -278,14 +278,14 @@ describe('Displays setup warning messages and errors screens', () => {
     await act(async () => {
       await hardware.setBatteryLevel(LOW_BATTERY_THRESHOLD / 2);
     });
-    await advanceTimersAndPromises(HARDWARE_POLLING_INTERVAL / 1000);
+    await advanceTimersAndPromises(BATTERY_POLLING_INTERVAL / 1000);
     getByTextWithMarkup(lowBatteryErrorScreenText);
 
     // Attach charger and back on Insert Card screen
     await act(async () => {
       await hardware.setBatteryDischarging(false);
     });
-    await advanceTimersAndPromises(HARDWARE_POLLING_INTERVAL / 1000);
+    await advanceTimersAndPromises(BATTERY_POLLING_INTERVAL / 1000);
     expect(screen.queryByText(noPowerDetectedWarningText)).toBeFalsy();
     screen.getByText(insertCardScreenText);
 
@@ -293,14 +293,14 @@ describe('Displays setup warning messages and errors screens', () => {
     await act(async () => {
       await hardware.setBatteryDischarging(true);
     });
-    await advanceTimersAndPromises(HARDWARE_POLLING_INTERVAL / 1000);
+    await advanceTimersAndPromises(BATTERY_POLLING_INTERVAL / 1000);
     getByTextWithMarkup(lowBatteryErrorScreenText);
 
     // Remove battery, i.e. we're on a desktop
     await act(async () => {
       await hardware.removeBattery();
     });
-    await advanceTimersAndPromises(HARDWARE_POLLING_INTERVAL / 1000);
+    await advanceTimersAndPromises(BATTERY_POLLING_INTERVAL / 1000);
     expect(screen.queryByText(noPowerDetectedWarningText)).toBeFalsy();
     screen.getByText(insertCardScreenText);
   });

--- a/frontends/bmd/src/config/globals.ts
+++ b/frontends/bmd/src/config/globals.ts
@@ -4,7 +4,6 @@ export const RECENT_PRINT_EXPIRATION_SECONDS = 1 * 60; // 1 minute
 export const CARD_EXPIRATION_SECONDS = 60 * 60; // 1 hour
 export const CARD_POLLING_INTERVAL = 200;
 export const CARD_LONG_VALUE_WRITE_DELAY = 1000;
-export const HARDWARE_POLLING_INTERVAL = 3000;
 export const BALLOT_PRINTING_TIMEOUT_SECONDS = 5;
 export const BALLOT_INSTRUCTIONS_TIMEOUT_SECONDS = 60;
 export const REPORT_PRINTING_TIMEOUT_SECONDS = 4;
@@ -19,5 +18,4 @@ export enum YES_NO_VOTES {
   yes = 'Yes',
 }
 export const WRITE_IN_CANDIDATE_MAX_LENGTH = 40;
-export const LOW_BATTERY_THRESHOLD = 0.25;
 export const QUIT_KIOSK_IDLE_SECONDS = 5 * 60; // 5 minutes

--- a/frontends/bsd/src/app_root.tsx
+++ b/frontends/bsd/src/app_root.tsx
@@ -31,7 +31,7 @@ import {
   useSmartcard,
   SetupCardReaderPage,
   useUserSession,
-  useHardware,
+  useDevices,
   ElectionInfoBar,
 } from '@votingworks/ui';
 import { LogEventId, Logger, LogSource } from '@votingworks/logging';
@@ -109,11 +109,14 @@ export function AppRoot({ card, hardware }: AppRootProps): JSX.Element {
 
   const usbDrive = useUsbDrive({ logger });
 
-  const { hasCardReaderAttached, hasBatchScannerAttached } = useHardware({
+  const { cardReader, batchScanner } = useDevices({
     hardware,
     logger,
   });
-  const smartcard = useSmartcard({ card, hasCardReaderAttached });
+  const smartcard = useSmartcard({
+    card,
+    cardReader,
+  });
   const {
     currentUserSession,
     attemptToAuthenticateAdminUser,
@@ -503,7 +506,7 @@ export function AppRoot({ card, hardware }: AppRootProps): JSX.Element {
     ? new KioskStorage(window.kiosk)
     : new LocalStorage();
 
-  if (!hasCardReaderAttached) {
+  if (!cardReader) {
     return <SetupCardReaderPage />;
   }
   const currentContext: AppContextInterface = {
@@ -650,7 +653,7 @@ export function AppRoot({ card, hardware }: AppRootProps): JSX.Element {
                 <ScanButton
                   onPress={scanBatch}
                   disabled={isScanning}
-                  isScannerAttached={hasBatchScannerAttached}
+                  isScannerAttached={!!batchScanner}
                 />
               </MainNav>
               <ElectionInfoBar

--- a/frontends/election-manager/src/app_root.tsx
+++ b/frontends/election-manager/src/app_root.tsx
@@ -37,7 +37,7 @@ import {
   useSmartcard,
   useUsbDrive,
   useUserSession,
-  useHardware,
+  useDevices,
 } from '@votingworks/ui';
 import {
   computeFullElectionTally,
@@ -107,7 +107,7 @@ export function AppRoot({
 
   const printBallotRef = useRef<HTMLDivElement>(null);
 
-  const { hasCardReaderAttached } = useHardware({ hardware, logger });
+  const { cardReader } = useDevices({ hardware, logger });
 
   const getElectionDefinition = useCallback(async (): Promise<
     ElectionDefinition | undefined
@@ -162,7 +162,10 @@ export function AppRoot({
     codeVersion: '',
   });
 
-  const smartcard = useSmartcard({ card, hasCardReaderAttached });
+  const smartcard = useSmartcard({
+    card,
+    cardReader,
+  });
   const {
     currentUserSession,
     attemptToAuthenticateAdminUser,
@@ -617,7 +620,7 @@ export function AppRoot({
         attemptToAuthenticateAdminUser,
         lockMachine,
         machineConfig,
-        hasCardReaderAttached,
+        hasCardReaderAttached: !!cardReader,
         logger,
       }}
     >

--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -19,7 +19,7 @@ import {
   useUsbDrive,
   SetupCardReaderPage,
   useUserSession,
-  useHardware,
+  useDevices,
 } from '@votingworks/ui';
 import {
   assert,
@@ -45,8 +45,6 @@ import {
 import {
   POLLING_INTERVAL_FOR_SCANNER_STATUS_MS,
   TIME_TO_DISMISS_ERROR_SUCCESS_SCREENS_MS,
-  HARDWARE_POLLING_INTERVAL,
-  LOW_BATTERY_THRESHOLD,
 } from './config/globals';
 
 import * as config from './api/config';
@@ -85,8 +83,6 @@ export interface Props extends RouteComponentProps {
 }
 
 interface HardwareState {
-  hasChargerAttached: boolean;
-  hasLowBattery: boolean;
   adminCardElectionHash: string;
   invalidCardPresent: boolean;
   machineConfig: Readonly<MachineConfig>;
@@ -115,8 +111,6 @@ export interface State
     ScanInformationState {}
 
 const initialHardwareState: Readonly<HardwareState> = {
-  hasChargerAttached: true,
-  hasLowBattery: false,
   adminCardElectionHash: '',
   // TODO add concept for invalid card to current user session object
   invalidCardPresent: false,
@@ -190,8 +184,7 @@ type AppAction =
   | { type: 'enableStatusPolling' }
   | { type: 'updatePrecinctId'; precinctId?: PrecinctId }
   | { type: 'togglePollsOpen' }
-  | { type: 'setMachineConfig'; machineConfig: MachineConfig }
-  | { type: 'updateHardwareState'; hardwareState: Partial<HardwareState> };
+  | { type: 'setMachineConfig'; machineConfig: MachineConfig };
 
 function appReducer(state: State, action: AppAction): State {
   debug(
@@ -305,11 +298,6 @@ function appReducer(state: State, action: AppAction): State {
         machineConfig:
           action.machineConfig ?? initialHardwareState.machineConfig,
       };
-    case 'updateHardwareState':
-      return {
-        ...state,
-        ...action.hardwareState,
-      };
     default:
       throwIllegalValue(action);
   }
@@ -335,8 +323,6 @@ export function AppRoot({
     currentPrecinctId,
     isPollsOpen,
     machineConfig,
-    hasLowBattery,
-    hasChargerAttached,
   } = appState;
 
   const logger = useMemo(
@@ -347,13 +333,14 @@ export function AppRoot({
   const usbDriveDisplayStatus =
     usbDrive.status ?? usbstick.UsbDriveStatus.absent;
 
-  const { hasCardReaderAttached, hasPrinterAttached } = useHardware({
+  const devices = useDevices({
     hardware,
     logger,
   });
+  const { battery } = devices.computer;
   const smartcard = useSmartcard({
     card,
-    hasCardReaderAttached,
+    hasCardReaderAttached: !!devices.cardReader,
   });
   const { currentUserSession, attemptToAuthenticateAdminUser } = useUserSession(
     {
@@ -486,46 +473,6 @@ export function AppRoot({
       });
     }
   }, [dispatchAppState]);
-
-  // Hardware status polling to set hasCharger and hasLowBattery parameters
-  const hardwareStatusInterval = useInterval(
-    async () => {
-      const battery = await hardware.readBatteryStatus();
-      if (!battery) {
-        dispatchAppState({
-          type: 'updateHardwareState',
-          hardwareState: {
-            hasChargerAttached: true,
-            hasLowBattery: false,
-          },
-        });
-      } else {
-        const newHasLowBattery = battery.level < LOW_BATTERY_THRESHOLD;
-        const hasHardwareStateChanged =
-          hasChargerAttached !== !battery.discharging ||
-          hasLowBattery !== newHasLowBattery;
-        if (hasHardwareStateChanged) {
-          dispatchAppState({
-            type: 'updateHardwareState',
-            hardwareState: {
-              hasChargerAttached: !battery.discharging,
-              hasLowBattery: newHasLowBattery,
-            },
-          });
-        }
-      }
-    },
-    HARDWARE_POLLING_INTERVAL,
-    true
-  );
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const startHardwareStatusPolling = useCallback(hardwareStatusInterval[0], [
-    hardware,
-  ]);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const stopHardwareStatusPolling = useCallback(hardwareStatusInterval[1], [
-    hardware,
-  ]);
 
   const [startBallotStatusPolling, endBallotStatusPolling] = useInterval(
     async () => {
@@ -707,17 +654,8 @@ export function AppRoot({
 
     void initializeScanner();
     void updateStateFromStorage();
-    startHardwareStatusPolling();
-    return () => {
-      stopHardwareStatusPolling();
-    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    refreshConfig,
-    storage,
-    startHardwareStatusPolling,
-    stopHardwareStatusPolling,
-  ]);
+  }, [refreshConfig, storage]);
 
   const updatePrecinctId = useCallback(
     async (precinctId: PrecinctId) => {
@@ -746,7 +684,7 @@ export function AppRoot({
     dispatchAppState({ type: 'readyToInsertBallot' });
   }
 
-  if (!hasCardReaderAttached) {
+  if (!devices.cardReader) {
     return <SetupCardReaderPage />;
   }
 
@@ -754,7 +692,7 @@ export function AppRoot({
     return <CardErrorScreen />;
   }
 
-  if (hasLowBattery && !hasChargerAttached) {
+  if (battery?.isBelowLowBatteryThreshold && battery.discharging) {
     return <SetupPowerPage />;
   }
 
@@ -820,7 +758,7 @@ export function AppRoot({
           saveTallyToCard={saveTallyToCard}
           getCvrsFromExport={getCvrsFromExport}
           printer={printer}
-          hasPrinterAttached={hasPrinterAttached}
+          hasPrinterAttached={!!devices.printer}
           isLiveMode={!isTestMode}
           usbDrive={usbDrive}
         />
@@ -841,7 +779,7 @@ export function AppRoot({
   let voterScreen = (
     <PollsClosedScreen
       isLiveMode={!isTestMode}
-      showNoChargerWarning={!hasChargerAttached}
+      showNoChargerWarning={!!battery?.discharging}
     />
   );
 
@@ -853,7 +791,7 @@ export function AppRoot({
           <InsertBallotScreen
             isLiveMode={!isTestMode}
             scannedBallotCount={scannedBallotCount}
-            showNoChargerWarning={!hasChargerAttached}
+            showNoChargerWarning={!!battery?.discharging}
           />
         );
         break;

--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -333,14 +333,13 @@ export function AppRoot({
   const usbDriveDisplayStatus =
     usbDrive.status ?? usbstick.UsbDriveStatus.absent;
 
-  const devices = useDevices({
+  const { cardReader, computer, printer: printerInfo } = useDevices({
     hardware,
     logger,
   });
-  const { battery } = devices.computer;
   const smartcard = useSmartcard({
     card,
-    hasCardReaderAttached: !!devices.cardReader,
+    cardReader,
   });
   const { currentUserSession, attemptToAuthenticateAdminUser } = useUserSession(
     {
@@ -684,7 +683,7 @@ export function AppRoot({
     dispatchAppState({ type: 'readyToInsertBallot' });
   }
 
-  if (!devices.cardReader) {
+  if (!cardReader) {
     return <SetupCardReaderPage />;
   }
 
@@ -692,7 +691,7 @@ export function AppRoot({
     return <CardErrorScreen />;
   }
 
-  if (battery?.isBelowLowBatteryThreshold && battery.discharging) {
+  if (computer.batteryIsLow && !computer.batteryIsCharging) {
     return <SetupPowerPage />;
   }
 
@@ -758,7 +757,7 @@ export function AppRoot({
           saveTallyToCard={saveTallyToCard}
           getCvrsFromExport={getCvrsFromExport}
           printer={printer}
-          hasPrinterAttached={!!devices.printer}
+          hasPrinterAttached={!!printerInfo}
           isLiveMode={!isTestMode}
           usbDrive={usbDrive}
         />
@@ -779,7 +778,7 @@ export function AppRoot({
   let voterScreen = (
     <PollsClosedScreen
       isLiveMode={!isTestMode}
-      showNoChargerWarning={!!battery?.discharging}
+      showNoChargerWarning={!computer.batteryIsCharging}
     />
   );
 
@@ -791,7 +790,7 @@ export function AppRoot({
           <InsertBallotScreen
             isLiveMode={!isTestMode}
             scannedBallotCount={scannedBallotCount}
-            showNoChargerWarning={!!battery?.discharging}
+            showNoChargerWarning={!computer.batteryIsCharging}
           />
         );
         break;

--- a/frontends/precinct-scanner/src/config/globals.ts
+++ b/frontends/precinct-scanner/src/config/globals.ts
@@ -12,8 +12,6 @@ export const POLLING_INTERVAL_FOR_TOTP = 2000;
 export const TIME_TO_DISMISS_ERROR_SUCCESS_SCREENS_MS = 5000;
 export const CARD_POLLING_INTERVAL = 200;
 export const STATUS_POLLING_EXTRA_CHECKS = 2;
-export const HARDWARE_POLLING_INTERVAL = 3000;
-export const LOW_BATTERY_THRESHOLD = 0.25;
 
 export const CHECK_ICON = '✓';
 export const TEXT_SIZE = 1;

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -59,7 +59,7 @@
     "@codemod/parser": "^1.0.6",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^11.2.6",
-    "@testing-library/react-hooks": "^6.0.0",
+    "@testing-library/react-hooks": "^8.0.0-alpha.1",
     "@testing-library/user-event": "^13.2.1",
     "@types/debug": "^4.1.7",
     "@types/deep-eql": "workspace:*",

--- a/libs/ui/src/hooks/use_devices.test.ts
+++ b/libs/ui/src/hooks/use_devices.test.ts
@@ -19,7 +19,9 @@ import { BATTERY_POLLING_INTERVAL, Devices, useDevices } from './use_devices';
 const emptyDevices: Devices = {
   printer: undefined,
   computer: {
-    battery: undefined,
+    batteryLevel: undefined,
+    batteryIsLow: false,
+    batteryIsCharging: true,
   },
   cardReader: undefined,
   accessibleController: undefined,
@@ -352,29 +354,29 @@ test('periodically polls for computer battery status', async () => {
   await waitForNextUpdate();
 
   // Should immediately load the battery status
-  expect(result.current.computer.battery).toEqual({
-    discharging: false,
-    isBelowLowBatteryThreshold: false,
-    level: 0.8,
+  expect(result.current.computer).toEqual({
+    batteryIsCharging: true,
+    batteryIsLow: false,
+    batteryLevel: 0.8,
   });
 
   // Change the battery status to low
   await act(async () => await hardware.setBatteryLevel(0.2));
   advanceTimers(BATTERY_POLLING_INTERVAL / 1000);
   await waitForNextUpdate();
-  expect(result.current.computer.battery).toEqual({
-    discharging: false,
-    isBelowLowBatteryThreshold: true,
-    level: 0.2,
+  expect(result.current.computer).toEqual({
+    batteryIsCharging: true,
+    batteryIsLow: true,
+    batteryLevel: 0.2,
   });
 
   // Disconnect the charger
   await act(async () => await hardware.setBatteryDischarging(true));
   advanceTimers(BATTERY_POLLING_INTERVAL / 1000);
   await waitForNextUpdate();
-  expect(result.current.computer.battery).toEqual({
-    discharging: true,
-    isBelowLowBatteryThreshold: true,
-    level: 0.2,
+  expect(result.current.computer).toEqual({
+    batteryIsCharging: false,
+    batteryIsLow: true,
+    batteryLevel: 0.2,
   });
 });

--- a/libs/ui/src/hooks/use_devices.test.ts
+++ b/libs/ui/src/hooks/use_devices.test.ts
@@ -1,6 +1,5 @@
 import { act, renderHook } from '@testing-library/react-hooks';
 import { Logger, LogSource, LogEventId } from '@votingworks/logging';
-import { advanceTimers } from '@votingworks/test-utils';
 import {
   AccessibleControllerProductId,
   AccessibleControllerVendorId,
@@ -362,7 +361,7 @@ test('periodically polls for computer battery status', async () => {
 
   // Change the battery status to low
   await act(async () => await hardware.setBatteryLevel(0.2));
-  advanceTimers(BATTERY_POLLING_INTERVAL / 1000);
+  jest.advanceTimersByTime(BATTERY_POLLING_INTERVAL);
   await waitForNextUpdate();
   expect(result.current.computer).toEqual({
     batteryIsCharging: true,
@@ -372,7 +371,7 @@ test('periodically polls for computer battery status', async () => {
 
   // Disconnect the charger
   await act(async () => await hardware.setBatteryDischarging(true));
-  advanceTimers(BATTERY_POLLING_INTERVAL / 1000);
+  jest.advanceTimersByTime(BATTERY_POLLING_INTERVAL);
   await waitForNextUpdate();
   expect(result.current.computer).toEqual({
     batteryIsCharging: false,

--- a/libs/ui/src/hooks/use_devices.ts
+++ b/libs/ui/src/hooks/use_devices.ts
@@ -161,7 +161,7 @@ export function useDevices({ hardware, logger }: Props): Devices {
 
   const computer: ComputerStatus = {
     batteryLevel: battery?.level,
-    batteryIsCharging: battery ? battery.discharging : true,
+    batteryIsCharging: battery ? !battery.discharging : true,
     batteryIsLow: battery ? battery.level < LOW_BATTERY_THRESHOLD : false,
   };
 

--- a/libs/ui/src/hooks/use_devices.ts
+++ b/libs/ui/src/hooks/use_devices.ts
@@ -19,12 +19,14 @@ export interface Props {
   logger: Logger;
 }
 
-export interface BatteryStatus extends KioskBrowser.BatteryInfo {
-  isBelowLowBatteryThreshold: boolean;
+export interface ComputerStatus {
+  batteryLevel?: number;
+  batteryIsLow: boolean;
+  batteryIsCharging: boolean;
 }
 
 export interface Devices {
-  computer: { battery?: BatteryStatus };
+  computer: ComputerStatus;
   cardReader?: KioskBrowser.Device;
   accessibleController?: KioskBrowser.Device;
   precinctScanner?: KioskBrowser.Device;
@@ -157,13 +159,14 @@ export function useDevices({ hardware, logger }: Props): Devices {
     }
   }, [previousDevices, allDevices, logger]);
 
-  const batteryStatus = battery && {
-    ...battery,
-    isBelowLowBatteryThreshold: battery.level < LOW_BATTERY_THRESHOLD,
+  const computer: ComputerStatus = {
+    batteryLevel: battery?.level,
+    batteryIsCharging: battery ? battery.discharging : true,
+    batteryIsLow: battery ? battery.level < LOW_BATTERY_THRESHOLD : false,
   };
 
   return {
-    computer: { battery: batteryStatus },
+    computer,
     cardReader: allDevices.find(isCardReader),
     accessibleController: allDevices.find(isAccessibleController),
     batchScanner: allDevices.find(isBatchScanner),

--- a/libs/ui/src/hooks/use_devices.ts
+++ b/libs/ui/src/hooks/use_devices.ts
@@ -3,24 +3,33 @@ import {
   isCardReader,
   Hardware,
   isAccessibleController,
-  isPlustekVtm300Scanner,
-  isFujitsuScanner,
+  isPrecinctScanner,
+  isBatchScanner,
 } from '@votingworks/utils';
 import { map } from 'rxjs/operators';
 import { LogEventId, Logger } from '@votingworks/logging';
+import useInterval from 'use-interval';
 import { usePrevious } from '..';
 
-export interface UseHardwareProps {
+export const LOW_BATTERY_THRESHOLD = 0.25;
+export const BATTERY_POLLING_INTERVAL = 3000;
+
+export interface Props {
   hardware: Hardware;
   logger: Logger;
 }
 
-export interface UseHardwareResult {
-  hasCardReaderAttached: boolean;
-  hasAccessibleControllerAttached: boolean;
-  hasPrecinctScannerAttached: boolean;
-  hasBatchScannerAttached: boolean;
-  hasPrinterAttached: boolean;
+export interface BatteryStatus extends KioskBrowser.BatteryInfo {
+  isBelowLowBatteryThreshold: boolean;
+}
+
+export interface Devices {
+  computer: { battery?: BatteryStatus };
+  cardReader?: KioskBrowser.Device;
+  accessibleController?: KioskBrowser.Device;
+  precinctScanner?: KioskBrowser.Device;
+  batchScanner?: KioskBrowser.Device;
+  printer?: KioskBrowser.PrinterInfo;
 }
 
 function getDeviceName(device: KioskBrowser.Device) {
@@ -30,65 +39,48 @@ function getDeviceName(device: KioskBrowser.Device) {
   if (isAccessibleController(device)) {
     return `Accessible Controller (${device.deviceName})`;
   }
-  if (isFujitsuScanner(device)) {
-    return `Fujitsu Scanner (${device.deviceName})`;
+  if (isBatchScanner(device)) {
+    return `Batch Scanner (${device.deviceName})`;
   }
-  if (isPlustekVtm300Scanner(device)) {
-    return `Plustek Scanner (${device.deviceName})`;
+  if (isPrecinctScanner(device)) {
+    return `Precinct Scanner (${device.deviceName})`;
   }
   return `Device (${device.deviceName})`;
 }
 
-export function useHardware({
-  hardware,
-  logger,
-}: UseHardwareProps): UseHardwareResult {
-  const [hasCardReaderAttached, setHasCardReaderAttached] = useState(false);
-  const [
-    hasAccessibleControllerAttached,
-    setHasAccessibleControllerAttached,
-  ] = useState(false);
-  const [hasPlustekScannerAttached, setHasPlustekScannerAttached] = useState(
-    false
-  );
-  const [hasFujitsuScannerAttached, setHasFujitsuScannerAttached] = useState(
-    false
-  );
-  const [hasPrinterAttached, setHasPrinterAttached] = useState(false);
+export function useDevices({ hardware, logger }: Props): Devices {
   const [allDevices, setAllDevices] = useState<KioskBrowser.Device[]>([]);
   const [allPrinters, setAllPrinters] = useState<KioskBrowser.PrinterInfo[]>(
     []
   );
+  const [battery, setBattery] = useState<
+    KioskBrowser.BatteryInfo | undefined
+  >();
   const previousDevices = usePrevious(allDevices);
   const previousPrinters = usePrevious(allPrinters);
 
   useEffect(() => {
     const hardwareStatusSubscription = hardware.devices
       .pipe(map((devices) => Array.from(devices)))
-      .subscribe(async (devices) => {
-        setHasCardReaderAttached(devices.some(isCardReader));
-        setHasAccessibleControllerAttached(
-          devices.some(isAccessibleController)
-        );
-        setHasPlustekScannerAttached(devices.some(isPlustekVtm300Scanner));
-        setHasFujitsuScannerAttached(devices.some(isFujitsuScanner));
-        setAllDevices(devices);
-      });
+      .subscribe(setAllDevices);
 
     const printerStatusSubscription = hardware.printers
       .pipe(map((printers) => Array.from(printers)))
-      .subscribe(async (printers) => {
-        const newHasPrinterAttached = printers.some(
-          ({ connected }) => connected
-        );
-        setHasPrinterAttached(newHasPrinterAttached);
-        setAllPrinters(printers);
-      });
+      .subscribe(setAllPrinters);
+
     return () => {
       hardwareStatusSubscription.unsubscribe();
       printerStatusSubscription.unsubscribe();
     };
   }, [hardware]);
+
+  useInterval(
+    async () => {
+      setBattery(await hardware.readBatteryStatus());
+    },
+    BATTERY_POLLING_INTERVAL,
+    true
+  );
 
   // Handle logging of printers
   useEffect(() => {
@@ -165,11 +157,17 @@ export function useHardware({
     }
   }, [previousDevices, allDevices, logger]);
 
+  const batteryStatus = battery && {
+    ...battery,
+    isBelowLowBatteryThreshold: battery.level < LOW_BATTERY_THRESHOLD,
+  };
+
   return {
-    hasCardReaderAttached,
-    hasAccessibleControllerAttached,
-    hasBatchScannerAttached: hasFujitsuScannerAttached,
-    hasPrecinctScannerAttached: hasPlustekScannerAttached,
-    hasPrinterAttached,
+    computer: { battery: batteryStatus },
+    cardReader: allDevices.find(isCardReader),
+    accessibleController: allDevices.find(isAccessibleController),
+    batchScanner: allDevices.find(isBatchScanner),
+    precinctScanner: allDevices.find(isPrecinctScanner),
+    printer: allPrinters.find((printer) => printer.connected),
   };
 }

--- a/libs/ui/src/hooks/use_smartcard.ts
+++ b/libs/ui/src/hooks/use_smartcard.ts
@@ -11,12 +11,13 @@ import { Card, CardApi, CardApiNotReady } from '@votingworks/utils';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import useInterval from 'use-interval';
 import { useCancelablePromise } from './use_cancelable_promise';
+import { Devices } from './use_devices';
 
 export const CARD_POLLING_INTERVAL = 100;
 
 export interface UseSmartcardProps {
   card: Card;
-  hasCardReaderAttached: boolean;
+  cardReader?: Devices['cardReader'];
 }
 
 interface SmartcardReady {
@@ -53,10 +54,10 @@ const initialState: State = {
  *
  * @example
  *
- * const { hasCardReaderAttached } = useHardware({ hardware, logger })
- * const smartcard = useSmartcard({ card, hasCardReaderAttached })
+ * const { cardReader } = useDevices({ hardware, logger })
+ * const smartcard = useSmartcard({ card, cardReader })
  * useEffect(() => {
- *    if (!hasCardReaderAttached) {
+ *    if (!cardReader) {
  *      console.log('No card reader')
  *    } else if (smartcard.status === 'ready' && smartcard.data) {
  *      console.log(
@@ -68,11 +69,11 @@ const initialState: State = {
  *    } else {
  *      console.log('No smartcard')
  *    }
- * }, [smartcard, hasCardReaderAttached])
+ * }, [smartcard, cardReader])
  */
 export function useSmartcard({
   card,
-  hasCardReaderAttached,
+  cardReader,
 }: UseSmartcardProps): Smartcard {
   const [
     { cardData, status, lastCardDataString, longValueExists },
@@ -144,7 +145,7 @@ export function useSmartcard({
 
   useInterval(
     async () => {
-      if (isReading.current || isWriting.current || !hasCardReaderAttached) {
+      if (isReading.current || isWriting.current || !cardReader) {
         return;
       }
 

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -7,7 +7,7 @@ export * from './contest_tally';
 export * from './election_info_bar';
 export * from './hooks/use_autocomplete';
 export * from './hooks/use_cancelable_promise';
-export * from './hooks/use_hardware';
+export * from './hooks/use_devices';
 export * from './hooks/use_now';
 export * from './hooks/use_previous';
 export * from './hooks/use_smartcard';

--- a/libs/utils/src/Hardware/index.test.ts
+++ b/libs/utils/src/Hardware/index.test.ts
@@ -1,22 +1,20 @@
 import { fakeDevice, fakeKiosk } from '@votingworks/test-utils';
-import {
-  FujitsuScannerVendorId,
-  getHardware,
-  isFujitsuScanner,
-  PlustekScannerVendorId,
-  PlustekVtm300ScannerProductId,
-} from '.';
+import { getHardware } from '.';
 import { KioskHardware } from './kiosk_hardware';
 import {
   AccessibleControllerProductId,
   AccessibleControllerVendorId,
   isAccessibleController,
   isCardReader,
-  isPlustekVtm300Scanner,
   OmniKeyCardReaderDeviceName,
   OmniKeyCardReaderManufacturer,
   OmniKeyCardReaderProductId,
   OmniKeyCardReaderVendorId,
+  FujitsuScannerVendorId,
+  PlustekScannerVendorId,
+  PlustekVtm300ScannerProductId,
+  isBatchScanner,
+  isPrecinctScanner,
 } from './utils';
 
 it('getHardware returns KioskHardware when window.kiosk is set', async () => {
@@ -87,13 +85,13 @@ it('isAccessibleController matches a device with the right vendor and product id
   ).toBe(true);
 });
 
-it('isFujitsuScanner does not match just any device', () => {
-  expect(isFujitsuScanner(fakeDevice())).toBe(false);
+it('isBatchScanner does not match just any device', () => {
+  expect(isBatchScanner(fakeDevice())).toBe(false);
 });
 
-it('isFujitsuScanner matches a device with the right vendor and product id', () => {
+it('isBatchScanner matches a device with the right vendor and product id', () => {
   expect(
-    isFujitsuScanner(
+    isBatchScanner(
       fakeDevice({
         vendorId: FujitsuScannerVendorId,
       })
@@ -101,13 +99,13 @@ it('isFujitsuScanner matches a device with the right vendor and product id', () 
   ).toBe(true);
 });
 
-it('isPlustekVtm300Scanner does not match just any device', () => {
-  expect(isPlustekVtm300Scanner(fakeDevice())).toBe(false);
+it('isPrecinctScanner does not match just any device', () => {
+  expect(isPrecinctScanner(fakeDevice())).toBe(false);
 });
 
-it('isFujitsuScanner matches a device with the right vendor and product id', () => {
+it('isPrecinctScanner matches a device with the right vendor and product id', () => {
   expect(
-    isPlustekVtm300Scanner(
+    isPrecinctScanner(
       fakeDevice({
         vendorId: PlustekScannerVendorId,
         productId: PlustekVtm300ScannerProductId,

--- a/libs/utils/src/Hardware/utils.ts
+++ b/libs/utils/src/Hardware/utils.ts
@@ -43,13 +43,13 @@ export function isPrinter(device: KioskBrowser.Device): boolean {
 
 export const FujitsuScannerVendorId = 0x4c5;
 export const FujitsuFi7160ScannerProductId = 0x132e;
-export function isFujitsuScanner(device: KioskBrowser.Device): boolean {
+export function isBatchScanner(device: KioskBrowser.Device): boolean {
   return device.vendorId === FujitsuScannerVendorId;
 }
 
 export const PlustekScannerVendorId = 0x7b3;
 export const PlustekVtm300ScannerProductId = 0xe37;
-export function isPlustekVtm300Scanner(device: KioskBrowser.Device): boolean {
+export function isPrecinctScanner(device: KioskBrowser.Device): boolean {
   return (
     device.vendorId === PlustekScannerVendorId &&
     device.productId === PlustekVtm300ScannerProductId

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -442,8 +442,8 @@ importers:
       '@typescript-eslint/eslint-plugin': ^4.28.4
       '@typescript-eslint/parser': ^4.28.4
       '@votingworks/ballot-encoder': workspace:*
-      '@votingworks/fixtures': workspace:*
       '@votingworks/ballot-interpreter-vx': workspace:*
+      '@votingworks/fixtures': workspace:*
       '@votingworks/logging': workspace:*
       '@votingworks/test-utils': workspace:*
       '@votingworks/types': workspace:*
@@ -702,8 +702,8 @@ importers:
       '@types/react-dom': 17.0.0
       '@types/react-router-dom': 5.1.7
       '@types/styled-components': 5.1.9
-      '@votingworks/fixtures': link:../../libs/fixtures
       '@votingworks/ballot-interpreter-vx': link:../../libs/ballot-interpreter-vx
+      '@votingworks/fixtures': link:../../libs/fixtures
       '@votingworks/logging': link:../../libs/logging
       '@votingworks/qrcode.react': 1.0.2_react@17.0.1
       '@votingworks/types': link:../../libs/types
@@ -785,8 +785,8 @@ importers:
       '@types/styled-components': ^5.1.9
       '@typescript-eslint/eslint-plugin': ^4.28.4
       '@typescript-eslint/parser': ^4.28.4
-      '@votingworks/fixtures': workspace:*
       '@votingworks/ballot-interpreter-vx': workspace:*
+      '@votingworks/fixtures': workspace:*
       '@votingworks/logging': workspace:*
       '@votingworks/qrcode.react': ^1.0.2
       '@votingworks/test-utils': workspace:*
@@ -1034,6 +1034,98 @@ importers:
       ts-jest: ^27.0.7
       typescript: ^4.3.5
       zod: 3.2.0
+  libs/ballot-interpreter-vx:
+    dependencies:
+      '@votingworks/ballot-encoder': link:../ballot-encoder
+      '@votingworks/types': link:../types
+      '@votingworks/utils': link:../utils
+      canvas: 2.6.1
+      chalk: 4.1.0
+      debug: 4.3.1
+      jsfeat: 0.0.8
+      jsqr: 1.3.1
+      node-quirc: 2.3.0
+      table: 6.0.7
+      uuid: 8.3.2
+    devDependencies:
+      '@types/benchmark': 1.0.33
+      '@types/debug': 4.1.5
+      '@types/jest': 27.0.3
+      '@types/jsfeat': link:../@types/jsfeat
+      '@types/memorystream': 0.3.0
+      '@types/node': 12.19.3
+      '@types/node-quirc': link:../@types/node-quirc
+      '@types/table': 6.0.0
+      '@types/tmp': 0.2.0
+      '@types/uuid': 8.3.0
+      '@typescript-eslint/eslint-plugin': 4.28.4_852673d3af9c7ab8ae779b8d717157c6
+      '@typescript-eslint/parser': 4.28.4_eslint@7.17.0+typescript@4.3.5
+      benchmark: 2.1.4
+      eslint: 7.17.0
+      eslint-config-airbnb-base: 14.2.1_a48282ca36857a4742d209c622f39c11
+      eslint-config-prettier: 8.3.0_eslint@7.17.0
+      eslint-import-resolver-node: 0.3.6
+      eslint-plugin-import: 2.24.2_eslint@7.17.0+typescript@4.3.5
+      eslint-plugin-jsx-a11y: 6.4.1_eslint@7.17.0
+      eslint-plugin-prettier: 3.3.1_7c5f1f59332aa465fcd97b1399d2f1c7
+      eslint-plugin-react: 7.24.0_eslint@7.17.0
+      eslint-plugin-vx: link:../eslint-plugin-vx
+      is-ci-cli: 2.2.0
+      jest: 27.3.1_canvas@2.6.1+ts-node@9.1.1
+      jest-watch-typeahead: 0.6.4_jest@27.3.1
+      lint-staged: 10.5.3
+      memorystream: 0.3.1
+      prettier: 2.2.1
+      sort-package-json: 1.50.0
+      tmp: 0.2.1
+      ts-jest: 27.0.7_9fd3d618a8f56b72434a4d1d442dbc9f
+      ts-node: 9.1.1_typescript@4.3.5
+      typescript: 4.3.5
+    specifiers:
+      '@types/benchmark': ^1.0.33
+      '@types/debug': ^4.1.5
+      '@types/jest': ^27.0.3
+      '@types/jsfeat': workspace:*
+      '@types/memorystream': ^0.3.0
+      '@types/node': 12.19.3
+      '@types/node-quirc': workspace:*
+      '@types/table': ^6.0.0
+      '@types/tmp': ^0.2.0
+      '@types/uuid': ^8.3.0
+      '@typescript-eslint/eslint-plugin': ^4.28.4
+      '@typescript-eslint/parser': ^4.28.4
+      '@votingworks/ballot-encoder': workspace:*
+      '@votingworks/types': workspace:*
+      '@votingworks/utils': workspace:*
+      benchmark: ^2.1.4
+      canvas: ^2.6.1
+      chalk: ^4.1.0
+      debug: ^4.2.0
+      eslint: ^7.17.0
+      eslint-config-airbnb-base: ^14.2.1
+      eslint-config-prettier: ^8.3.0
+      eslint-import-resolver-node: ^0.3.6
+      eslint-plugin-import: ^2.24.2
+      eslint-plugin-jsx-a11y: ^6.4.1
+      eslint-plugin-prettier: ^3.1.4
+      eslint-plugin-react: ^7.24.0
+      eslint-plugin-vx: workspace:*
+      is-ci-cli: ^2.2.0
+      jest: ^27.3.1
+      jest-watch-typeahead: ^0.6.4
+      jsfeat: ^0.0.8
+      jsqr: ^1.3.1
+      lint-staged: ^10.4.2
+      memorystream: ^0.3.1
+      node-quirc: ^2.2.1
+      prettier: ^2.1.2
+      sort-package-json: ^1.50.0
+      table: ^6.0.3
+      tmp: ^0.2.1
+      ts-jest: ^27.0.7
+      ts-node: ^9.0.0
+      typescript: ^4.3.5
+      uuid: ^8.3.1
   libs/cdf-schema-builder:
     dependencies:
       '@votingworks/types': link:../types
@@ -1316,98 +1408,6 @@ importers:
       ts-node: ^9.1.1
       typescript: ^4.3.5
       yargs: ^16.2.0
-  libs/ballot-interpreter-vx:
-    dependencies:
-      '@votingworks/ballot-encoder': link:../ballot-encoder
-      '@votingworks/types': link:../types
-      '@votingworks/utils': link:../utils
-      canvas: 2.6.1
-      chalk: 4.1.0
-      debug: 4.3.1
-      jsfeat: 0.0.8
-      jsqr: 1.3.1
-      node-quirc: 2.3.0
-      table: 6.0.7
-      uuid: 8.3.2
-    devDependencies:
-      '@types/benchmark': 1.0.33
-      '@types/debug': 4.1.5
-      '@types/jest': 27.0.3
-      '@types/jsfeat': link:../@types/jsfeat
-      '@types/memorystream': 0.3.0
-      '@types/node': 12.19.3
-      '@types/node-quirc': link:../@types/node-quirc
-      '@types/table': 6.0.0
-      '@types/tmp': 0.2.0
-      '@types/uuid': 8.3.0
-      '@typescript-eslint/eslint-plugin': 4.28.4_852673d3af9c7ab8ae779b8d717157c6
-      '@typescript-eslint/parser': 4.28.4_eslint@7.17.0+typescript@4.3.5
-      benchmark: 2.1.4
-      eslint: 7.17.0
-      eslint-config-airbnb-base: 14.2.1_a48282ca36857a4742d209c622f39c11
-      eslint-config-prettier: 8.3.0_eslint@7.17.0
-      eslint-import-resolver-node: 0.3.6
-      eslint-plugin-import: 2.24.2_eslint@7.17.0+typescript@4.3.5
-      eslint-plugin-jsx-a11y: 6.4.1_eslint@7.17.0
-      eslint-plugin-prettier: 3.3.1_7c5f1f59332aa465fcd97b1399d2f1c7
-      eslint-plugin-react: 7.24.0_eslint@7.17.0
-      eslint-plugin-vx: link:../eslint-plugin-vx
-      is-ci-cli: 2.2.0
-      jest: 27.3.1_canvas@2.6.1+ts-node@9.1.1
-      jest-watch-typeahead: 0.6.4_jest@27.3.1
-      lint-staged: 10.5.3
-      memorystream: 0.3.1
-      prettier: 2.2.1
-      sort-package-json: 1.50.0
-      tmp: 0.2.1
-      ts-jest: 27.0.7_9fd3d618a8f56b72434a4d1d442dbc9f
-      ts-node: 9.1.1_typescript@4.3.5
-      typescript: 4.3.5
-    specifiers:
-      '@types/benchmark': ^1.0.33
-      '@types/debug': ^4.1.5
-      '@types/jest': ^27.0.3
-      '@types/jsfeat': workspace:*
-      '@types/memorystream': ^0.3.0
-      '@types/node': 12.19.3
-      '@types/node-quirc': workspace:*
-      '@types/table': ^6.0.0
-      '@types/tmp': ^0.2.0
-      '@types/uuid': ^8.3.0
-      '@typescript-eslint/eslint-plugin': ^4.28.4
-      '@typescript-eslint/parser': ^4.28.4
-      '@votingworks/ballot-encoder': workspace:*
-      '@votingworks/types': workspace:*
-      '@votingworks/utils': workspace:*
-      benchmark: ^2.1.4
-      canvas: ^2.6.1
-      chalk: ^4.1.0
-      debug: ^4.2.0
-      eslint: ^7.17.0
-      eslint-config-airbnb-base: ^14.2.1
-      eslint-config-prettier: ^8.3.0
-      eslint-import-resolver-node: ^0.3.6
-      eslint-plugin-import: ^2.24.2
-      eslint-plugin-jsx-a11y: ^6.4.1
-      eslint-plugin-prettier: ^3.1.4
-      eslint-plugin-react: ^7.24.0
-      eslint-plugin-vx: workspace:*
-      is-ci-cli: ^2.2.0
-      jest: ^27.3.1
-      jest-watch-typeahead: ^0.6.4
-      jsfeat: ^0.0.8
-      jsqr: ^1.3.1
-      lint-staged: ^10.4.2
-      memorystream: ^0.3.1
-      node-quirc: ^2.2.1
-      prettier: ^2.1.2
-      sort-package-json: ^1.50.0
-      table: ^6.0.3
-      tmp: ^0.2.1
-      ts-jest: ^27.0.7
-      ts-node: ^9.0.0
-      typescript: ^4.3.5
-      uuid: ^8.3.1
   libs/logging:
     dependencies:
       '@types/kiosk-browser': link:../@types/kiosk-browser
@@ -1729,7 +1729,7 @@ importers:
       '@codemod/parser': 1.1.0
       '@testing-library/jest-dom': 4.2.4
       '@testing-library/react': 11.2.6_react-dom@17.0.1+react@17.0.1
-      '@testing-library/react-hooks': 6.0.0_react-dom@17.0.1+react@17.0.1
+      '@testing-library/react-hooks': 8.0.0-alpha.1_react-dom@17.0.1+react@17.0.1
       '@testing-library/user-event': 13.2.1
       '@types/debug': 4.1.7
       '@types/deep-eql': link:../@types/deep-eql
@@ -1778,7 +1778,7 @@ importers:
       '@codemod/parser': ^1.0.6
       '@testing-library/jest-dom': ^4.2.4
       '@testing-library/react': ^11.2.6
-      '@testing-library/react-hooks': ^6.0.0
+      '@testing-library/react-hooks': ^8.0.0-alpha.1
       '@testing-library/user-event': ^13.2.1
       '@types/debug': ^4.1.7
       '@types/deep-eql': workspace:*
@@ -1937,8 +1937,8 @@ importers:
   services/scan:
     dependencies:
       '@votingworks/ballot-encoder': link:../../libs/ballot-encoder
-      '@votingworks/fixtures': link:../../libs/fixtures
       '@votingworks/ballot-interpreter-vx': link:../../libs/ballot-interpreter-vx
+      '@votingworks/fixtures': link:../../libs/fixtures
       '@votingworks/logging': link:../../libs/logging
       '@votingworks/plustek-sdk': link:../../libs/plustek-sdk
       '@votingworks/qrdetect': 1.0.1
@@ -2032,8 +2032,8 @@ importers:
       '@typescript-eslint/eslint-plugin': ^4.28.4
       '@typescript-eslint/parser': ^4.28.4
       '@votingworks/ballot-encoder': workspace:*
-      '@votingworks/fixtures': workspace:*
       '@votingworks/ballot-interpreter-vx': workspace:*
+      '@votingworks/fixtures': workspace:*
       '@votingworks/logging': workspace:*
       '@votingworks/plustek-sdk': workspace:*
       '@votingworks/qrdetect': ^1.0.1
@@ -6655,13 +6655,12 @@ packages:
       yarn: '>=1'
     resolution:
       integrity: sha512-N9Y82b2Z3j6wzIoAqajlKVF1Zt7sOH0pPee0sUHXHc5cv2Fdn23r+vpWm0MBBoGJtPOly5+Bdx1lnc3CD+A+ow==
-  /@testing-library/react-hooks/6.0.0_react-dom@17.0.1+react@17.0.1:
+  /@testing-library/react-hooks/8.0.0-alpha.1_react-dom@17.0.1+react@17.0.1:
     dependencies:
-      '@babel/runtime': 7.15.4
-      '@types/react': 17.0.22
+      '@babel/runtime': 7.16.7
+      '@types/react': 17.0.38
       '@types/react-dom': 17.0.9
       '@types/react-test-renderer': 17.0.1
-      filter-console: 0.1.1
       react: 17.0.1
       react-dom: 17.0.1_react@17.0.1
       react-error-boundary: 3.1.3_react@17.0.1
@@ -6678,7 +6677,7 @@ packages:
       react-test-renderer:
         optional: true
     resolution:
-      integrity: sha512-Y8ayCUFPiNttX9zmwP2bDv4uYzgsgOMHxAsOrD7th7Xuj1j1rHkxf+VzRqdr7zJlSeYPzl67754qAnZ9O1ahYg==
+      integrity: sha512-YrIrBXQLKcucFuEiSkHEycR7Yk5lOHH8tTxB+km+XdQiN1af0YlblWt+n9Zx6OX1crIN3JNy8hJ7VvdYivriCg==
   /@testing-library/react/11.2.3_react-dom@17.0.1+react@17.0.1:
     dependencies:
       '@babel/runtime': 7.12.5
@@ -7254,7 +7253,7 @@ packages:
       integrity: sha512-lUqY7OlkF/RbNtD5nIq7ot8NquXrdFrjSOR6+w9a9RFQevGi1oZO1dcJbXMeONAPKtZ2UrZOEJ5UOCVsxbLk/g==
   /@types/react-dom/17.0.9:
     dependencies:
-      '@types/react': 17.0.22
+      '@types/react': 17.0.38
     dev: true
     resolution:
       integrity: sha512-wIvGxLfgpVDSAMH5utdL9Ngm5Owu0VsGmldro3ORLXV8CShrL8awVj06NuEXFQ5xyaYfdca7Sgbk/50Ri1GdPg==
@@ -7285,7 +7284,7 @@ packages:
       integrity: sha512-z3UlMG/x91SFEVmmvykk9FLTliDvfdIUky4k2rCfXWQ0NKbrP8o9BTCaCTPuYsB8gDkUnUmkcA2vYlm2DR+HAA==
   /@types/react-test-renderer/17.0.1:
     dependencies:
-      '@types/react': 17.0.22
+      '@types/react': 17.0.38
     dev: true
     resolution:
       integrity: sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==
@@ -7326,20 +7325,11 @@ packages:
     dev: false
     resolution:
       integrity: sha512-GzzXCpOthOjXvrAUFQwU/svyxu658cwu00Q9ugujS4qc1zXgLFaO0kS2SLOaMWLt2Jik781yuHCWB7UcYdGAeQ==
-  /@types/react/17.0.22:
-    dependencies:
-      '@types/prop-types': 15.7.4
-      '@types/scheduler': 0.16.2
-      csstype: 3.0.9
-    dev: true
-    resolution:
-      integrity: sha512-kq/BMeaAVLJM6Pynh8C2rnr/drCK+/5ksH0ch9asz+8FW3DscYCIEFtCeYTFeIx/ubvOsMXmRfy7qEJ76gM96A==
   /@types/react/17.0.38:
     dependencies:
       '@types/prop-types': 15.7.4
       '@types/scheduler': 0.16.2
       csstype: 3.0.10
-    dev: false
     resolution:
       integrity: sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==
   /@types/react/17.0.4:
@@ -11601,7 +11591,6 @@ packages:
     resolution:
       integrity: sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
   /csstype/3.0.10:
-    dev: false
     resolution:
       integrity: sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==
   /csstype/3.0.6:
@@ -11611,6 +11600,7 @@ packages:
     resolution:
       integrity: sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==
   /csstype/3.0.9:
+    dev: false
     resolution:
       integrity: sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==
   /csv-writer/1.6.0:
@@ -15441,12 +15431,6 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
-  /filter-console/0.1.1:
-    dev: true
-    engines:
-      node: '>=8'
-    resolution:
-      integrity: sha512-zrXoV1Uaz52DqPs+qEwNJWJFAWZpYJ47UNmpN9q4j+/EYsz85uV0DC9k8tRND5kYmoVzL0W+Y75q4Rg8sRJCdg==
   /finalhandler/1.1.2:
     dependencies:
       debug: 2.6.9
@@ -23380,7 +23364,7 @@ packages:
       integrity: sha512-EGSvK2CxFTuc28WxwuJCICyuYFX8b+sRumwU6Bs6sTbElV2HtQkT0d6C+HEee6XfbjiLIZ+Th9uji27rvo2wGw==
   /react-error-boundary/3.1.3_react@17.0.1:
     dependencies:
-      '@babel/runtime': 7.15.4
+      '@babel/runtime': 7.16.7
       react: 17.0.1
     dev: true
     engines:


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Task: #1417 
Preliminary work to set up the data we need for a hardware diagnostic screen.

- Rename use_hardware to use_devices
- Return full device info (instead of just whether or not the device is connected)
- Also add battery status polling to this hook
- Refactor useSmartcard to consume the new output of this hook
- Updates bmd and precinct-scanner to consume the changed hook.

## Demo Video or Screenshot
N/A
## Testing Plan 
Updated unit tests
## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
