### PR TITLE
refactor: improve compressed tally types

### DIFF
--- a/frontends/election-manager/src/utils/election.ts
+++ b/frontends/election-manager/src/utils/election.ts
@@ -9,9 +9,7 @@ import {
   getPrecinctById,
   Party,
   VotesDict,
-  ContestVoteOption,
   writeInCandidate,
-  YesNoVoteOption,
   PartyId,
   BallotStyleId,
   PrecinctId,
@@ -36,22 +34,6 @@ export function getPartiesWithPrimaryElections(election: Election): Party[] {
     .map((bs) => bs.partyId)
     .filter((id): id is PartyId => id !== undefined);
   return election.parties.filter((party) => partyIds.includes(party.id));
-}
-
-export function getContestOptionsForContest(
-  contest: AnyContest
-): readonly ContestVoteOption[] {
-  if (contest.type === 'candidate') {
-    const options = contest.candidates;
-    if (contest.allowWriteIns) {
-      return options.concat(writeInCandidate);
-    }
-    return options;
-  }
-  if (contest.type === 'yesno') {
-    return [['yes'] as YesNoVoteOption, ['no'] as YesNoVoteOption];
-  }
-  throw new Error(`Unexpected contest type: ${contest.type}`);
 }
 
 const sortOptions: Intl.CollatorOptions = {

--- a/frontends/precinct-scanner/src/app_tally_report_paths.test.tsx
+++ b/frontends/precinct-scanner/src/app_tally_report_paths.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import fetchMock from 'fetch-mock';
 import { render, fireEvent, screen, act, within } from '@testing-library/react';
 import {
-  electionMinimalExhaustiveSampleDefintion,
+  electionMinimalExhaustiveSampleDefinition,
   electionSample2Definition,
 } from '@votingworks/fixtures';
 import {
@@ -118,10 +118,12 @@ test('expected tally reports are printed for a primary election with all precinc
   const kiosk = fakeKiosk();
   kiosk.getUsbDrives.mockResolvedValue([]);
   window.kiosk = kiosk;
-  const { election } = electionMinimalExhaustiveSampleDefintion;
+  const { election } = electionMinimalExhaustiveSampleDefinition;
   fetchMock
     .get('/machine-config', { body: getMachineConfigBody })
-    .get('/config/election', { body: electionMinimalExhaustiveSampleDefintion })
+    .get('/config/election', {
+      body: electionMinimalExhaustiveSampleDefinition,
+    })
     .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
     .get('/config/precinct', { body: getPrecinctConfigNoPrecinctResponseBody })
     .get('/scan/status', { body: scanStatusWaitingForPaperResponseBody })
@@ -136,7 +138,7 @@ test('expected tally reports are printed for a primary election with all precinc
   // Insert a pollworker card
   fetchMock.post('/scan/export', {});
   const pollWorkerCard = makePollWorkerCard(
-    electionMinimalExhaustiveSampleDefintion.electionHash
+    electionMinimalExhaustiveSampleDefinition.electionHash
   );
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises(1);
@@ -179,7 +181,7 @@ test('expected tally reports for a primary election with all precincts with CVRs
   const kiosk = fakeKiosk();
   kiosk.getUsbDrives.mockResolvedValue([]);
   window.kiosk = kiosk;
-  const { election } = electionMinimalExhaustiveSampleDefintion;
+  const { election } = electionMinimalExhaustiveSampleDefinition;
 
   const scanStatus: GetScanStatusResponse = {
     scanner: ScannerStatus.WaitingForPaper,
@@ -196,7 +198,9 @@ test('expected tally reports for a primary election with all precincts with CVRs
   };
   fetchMock
     .get('/machine-config', { body: getMachineConfigBody })
-    .get('/config/election', { body: electionMinimalExhaustiveSampleDefintion })
+    .get('/config/election', {
+      body: electionMinimalExhaustiveSampleDefinition,
+    })
     .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
     .get('/config/precinct', { body: getPrecinctConfigNoPrecinctResponseBody })
     .get('/scan/status', { body: scanStatus })
@@ -256,7 +260,7 @@ test('expected tally reports for a primary election with all precincts with CVRs
     ])
   );
   const pollWorkerCard = makePollWorkerCard(
-    electionMinimalExhaustiveSampleDefintion.electionHash
+    electionMinimalExhaustiveSampleDefinition.electionHash
   );
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises(1);
@@ -567,7 +571,7 @@ test('expected tally reports for a primary election with a single precincts with
   const kiosk = fakeKiosk();
   kiosk.getUsbDrives.mockResolvedValue([]);
   window.kiosk = kiosk;
-  const { election } = electionMinimalExhaustiveSampleDefintion;
+  const { election } = electionMinimalExhaustiveSampleDefinition;
 
   const scanStatus: GetScanStatusResponse = {
     scanner: ScannerStatus.WaitingForPaper,
@@ -584,7 +588,9 @@ test('expected tally reports for a primary election with a single precincts with
   };
   fetchMock
     .get('/machine-config', { body: getMachineConfigBody })
-    .get('/config/election', { body: electionMinimalExhaustiveSampleDefintion })
+    .get('/config/election', {
+      body: electionMinimalExhaustiveSampleDefinition,
+    })
     .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
     .get('/config/precinct', { body: getPrecinctConfigPrecinct1ResponseBody })
     .get('/scan/status', { body: scanStatus })
@@ -644,7 +650,7 @@ test('expected tally reports for a primary election with a single precincts with
     ])
   );
   const pollWorkerCard = makePollWorkerCard(
-    electionMinimalExhaustiveSampleDefintion.electionHash
+    electionMinimalExhaustiveSampleDefinition.electionHash
   );
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises(1);

--- a/libs/fixtures/src/index.test.ts
+++ b/libs/fixtures/src/index.test.ts
@@ -35,7 +35,7 @@ test('has various election definitions', () => {
       "electionSampleLongContentDefinition",
       "electionSampleRotationDefinition",
       "electionWithMsEitherNeitherDefinition",
-      "electionMinimalExhaustiveSampleDefintion",
+      "electionMinimalExhaustiveSampleDefinition",
       "electionWithMsEitherNeitherRawData",
       "electionMultiPartyPrimaryWithDataFiles",
       "electionSimplePrimaryWithDataFiles",

--- a/libs/fixtures/src/index.ts
+++ b/libs/fixtures/src/index.ts
@@ -61,7 +61,7 @@ export const electionSampleRotationDefinition = asElectionDefinition(
 export const electionWithMsEitherNeitherDefinition = asElectionDefinition(
   electionWithMsEitherNeither
 );
-export const electionMinimalExhaustiveSampleDefintion = asElectionDefinition(
+export const electionMinimalExhaustiveSampleDefinition = asElectionDefinition(
   electionMinimalExhaustiveSample
 );
 
@@ -97,7 +97,7 @@ export const electionWithMsEitherNeitherWithDataFiles = {
 } as const;
 
 export const electionMinimalExhaustiveSampleWithDataFiles = {
-  electionDefinition: electionMinimalExhaustiveSampleDefintion,
+  electionDefinition: electionMinimalExhaustiveSampleDefinition,
   semsData: electionMinimalExhaustiveSemsData as string,
   cvrData: electionMinimalExhaustiveCvrData as string,
 } as const;

--- a/libs/logging/src/logger.test.ts
+++ b/libs/logging/src/logger.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import { fakeKiosk } from '@votingworks/test-utils';
 import { readFileSync } from 'fs-extra';
-import { electionMinimalExhaustiveSampleDefintion } from '@votingworks/fixtures';
+import { electionMinimalExhaustiveSampleDefinition } from '@votingworks/fixtures';
 import MockDate from 'mockdate';
 import { join } from 'path';
 import { safeParseJson } from '@votingworks/types';
@@ -123,7 +123,7 @@ describe('test cdf conversion', () => {
   test('builds device and election info properly', () => {
     const logger = new Logger(LogSource.VxAdminFrontend);
     const cdfLogContent = logger.buildCDFLog(
-      electionMinimalExhaustiveSampleDefintion,
+      electionMinimalExhaustiveSampleDefinition,
       '',
       '12machine34',
       'thisisacodeversion',
@@ -135,7 +135,7 @@ describe('test cdf conversion', () => {
     assert(cdfLog);
     expect(cdfLog.Device).toHaveLength(1);
     expect(cdfLog.ElectionId).toBe(
-      electionMinimalExhaustiveSampleDefintion.electionHash
+      electionMinimalExhaustiveSampleDefinition.electionHash
     );
     expect(cdfLog.GeneratedTime).toMatchInlineSnapshot(
       `"2020-07-24T00:00:00.000Z"`
@@ -152,7 +152,7 @@ describe('test cdf conversion', () => {
     const logger = new Logger(LogSource.VxAdminFrontend);
     const logSpy = jest.spyOn(logger, 'log').mockResolvedValue();
     const cdfLogContent = logger.buildCDFLog(
-      electionMinimalExhaustiveSampleDefintion,
+      electionMinimalExhaustiveSampleDefinition,
       '{"timeLogWritten":"2021-11-03T16:38:09.384062-07:00","source":"vx-admin-frontend","eventId":"usb-drive-status-update","eventType":"application-status","user":"system","message":"i know the deal","disposition":"na"}',
       '12machine34',
       'thisisacodeversion',
@@ -191,7 +191,7 @@ describe('test cdf conversion', () => {
   test('log with unspecified disposition as expected', () => {
     const logger = new Logger(LogSource.VxAdminFrontend);
     const cdfLogContent = logger.buildCDFLog(
-      electionMinimalExhaustiveSampleDefintion,
+      electionMinimalExhaustiveSampleDefinition,
       '{"timeLogWritten":"2021-11-03T16:38:09.384062-07:00","source":"vx-admin-frontend","eventId":"usb-drive-status-update","eventType":"application-status","user":"system","message":"i know the deal","disposition":""}',
       '12machine34',
       'thisisacodeversion',
@@ -213,7 +213,7 @@ describe('test cdf conversion', () => {
   test('converts log with custom disposition and extra details as expected', () => {
     const logger = new Logger(LogSource.VxAdminFrontend);
     const cdfLogContent = logger.buildCDFLog(
-      electionMinimalExhaustiveSampleDefintion,
+      electionMinimalExhaustiveSampleDefinition,
       '{"timeLogWritten":"2021-11-03T16:38:09.384062-07:00","host":"ubuntu","timeLogInitiated":"1635982689382","source":"vx-admin-frontend","eventId":"usb-drive-status-update","eventType":"application-status","user":"system","message":"glistened as it fell","disposition":"dinosaurs","newStatus":"absent"}',
       '12machine34',
       'thisisacodeversion',
@@ -246,7 +246,7 @@ describe('test cdf conversion', () => {
     const logSpy = jest.spyOn(logger, 'log').mockResolvedValue();
     expect(() =>
       logger.buildCDFLog(
-        electionMinimalExhaustiveSampleDefintion,
+        electionMinimalExhaustiveSampleDefinition,
         '',
         '12machine34',
         'thisisacodeversion',
@@ -280,7 +280,7 @@ describe('test cdf conversion', () => {
       timeLogWritten: '2020-07-24T00:00:00.000Z',
     });
     const output = logger.buildCDFLog(
-      electionMinimalExhaustiveSampleDefintion,
+      electionMinimalExhaustiveSampleDefinition,
       `rawr\n${properLog}\n`,
       '12machine34',
       'thisisacodeversion',
@@ -302,7 +302,7 @@ describe('test cdf conversion', () => {
     expect(cdfLog.Device?.[0]!.Event).toHaveLength(1);
 
     const output2 = logger.buildCDFLog(
-      electionMinimalExhaustiveSampleDefintion,
+      electionMinimalExhaustiveSampleDefinition,
       missingTimeLog,
       '12machine34',
       'thisisacodeversion',
@@ -327,7 +327,7 @@ describe('test cdf conversion', () => {
     const logFile = readFileSync(join(__dirname, '../fixtures/samplelog.log'));
     const logger = new Logger(LogSource.VxAdminFrontend);
     const cdfLogContent = logger.buildCDFLog(
-      electionMinimalExhaustiveSampleDefintion,
+      electionMinimalExhaustiveSampleDefinition,
       logFile.toString(),
       '1234',
       'codeversion',
@@ -339,7 +339,7 @@ describe('test cdf conversion', () => {
     assert(cdfLog);
     expect(cdfLog.Device).toHaveLength(1);
     expect(cdfLog.ElectionId).toBe(
-      electionMinimalExhaustiveSampleDefintion.electionHash
+      electionMinimalExhaustiveSampleDefinition.electionHash
     );
     expect(cdfLog.GeneratedTime).toMatchInlineSnapshot(
       `"2020-07-24T00:00:00.000Z"`

--- a/libs/types/src/tallies.ts
+++ b/libs/types/src/tallies.ts
@@ -86,7 +86,89 @@ export type OptionalExternalTally = Optional<ExternalTally>;
 export type OptionalFullElectionTally = Optional<FullElectionTally>;
 export type OptionalFullElectionExternalTally = Optional<FullElectionExternalTally>;
 
-export type CompressedTally = Array<number[]>;
+const nonnegativeInteger = z.number().nonnegative().int();
+
+export type YesNoContestCompressedTally = [
+  undervotes: number,
+  overvotes: number,
+  ballotsCast: number,
+  yes: number,
+  no: number
+];
+export const YesNoContestCompressedTallySchema: z.ZodSchema<YesNoContestCompressedTally> = z.tuple(
+  [
+    nonnegativeInteger,
+    nonnegativeInteger,
+    nonnegativeInteger,
+    nonnegativeInteger,
+    nonnegativeInteger,
+  ]
+);
+export type CandidateContestWithWriteInsCompressedTally = [
+  undervotes: number,
+  overvotes: number,
+  ballotsCast: number,
+  ...candidates: number[],
+  writeIns: number
+];
+export const CandidateContestWithWriteInsCompressedTallySchema: z.ZodSchema<CandidateContestWithWriteInsCompressedTally> = (z
+  .array(nonnegativeInteger)
+  .min(
+    4
+  ) as unknown) as z.ZodSchema<CandidateContestWithWriteInsCompressedTally>;
+export type CandidateContestWithoutWriteInsCompressedTally = [
+  undervotes: number,
+  overvotes: number,
+  ballotsCast: number,
+  ...candidates: number[]
+];
+export const CandidateContestWithoutWriteInsCompressedTallySchema: z.ZodSchema<CandidateContestWithoutWriteInsCompressedTally> = (z
+  .array(nonnegativeInteger)
+  .min(
+    3
+  ) as unknown) as z.ZodSchema<CandidateContestWithoutWriteInsCompressedTally>;
+export type CandidateContestCompressedTally =
+  | CandidateContestWithWriteInsCompressedTally
+  | CandidateContestWithoutWriteInsCompressedTally;
+export const CandidateContestCompressedTallySchema: z.ZodSchema<CandidateContestCompressedTally> = z.union(
+  [
+    CandidateContestWithWriteInsCompressedTallySchema,
+    CandidateContestWithoutWriteInsCompressedTallySchema,
+  ]
+);
+export type MsEitherNeitherContestCompressedTally = [
+  eitherOption: number,
+  neitherOption: number,
+  eitherNeitherUndervotes: number,
+  eitherNeitherOvervotes: number,
+  firstOption: number,
+  secondOption: number,
+  pickOneUndervotes: number,
+  pickOneOvervotes: number,
+  ballotsCast: number
+];
+export const MsEitherNeitherContestCompressedTallySchema: z.ZodSchema<MsEitherNeitherContestCompressedTally> = z.tuple(
+  [
+    nonnegativeInteger,
+    nonnegativeInteger,
+    nonnegativeInteger,
+    nonnegativeInteger,
+    nonnegativeInteger,
+    nonnegativeInteger,
+    nonnegativeInteger,
+    nonnegativeInteger,
+    nonnegativeInteger,
+  ]
+);
+export type CompressedTallyEntry =
+  | YesNoContestCompressedTally
+  | CandidateContestCompressedTally
+  | MsEitherNeitherContestCompressedTally;
+export type CompressedTally = CompressedTallyEntry[];
 export const CompressedTallySchema: z.ZodSchema<CompressedTally> = z.array(
-  z.array(z.number().nonnegative().int())
+  z.union([
+    YesNoContestCompressedTallySchema,
+    CandidateContestCompressedTallySchema,
+    MsEitherNeitherContestCompressedTallySchema,
+  ])
 );

--- a/libs/ui/src/precinct_scanner_tally_report.test.tsx
+++ b/libs/ui/src/precinct_scanner_tally_report.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, within } from '@testing-library/react';
 import {
-  electionMinimalExhaustiveSampleDefintion,
+  electionMinimalExhaustiveSampleDefinition,
   electionSample,
   electionSampleDefinition,
 } from '@votingworks/fixtures';
@@ -136,14 +136,14 @@ const primaryCvr: CastVoteRecord = {
 test('renders as expected for all precincts in a primary election', async () => {
   const party0 = unsafeParse(PartyIdSchema, '0');
   const tally = calculateTallyForCastVoteRecords(
-    electionMinimalExhaustiveSampleDefintion.election,
+    electionMinimalExhaustiveSampleDefinition.election,
     new Set([primaryCvr]),
     party0
   );
   render(
     <PrecinctScannerTallyReport
       reportSavedTime={time}
-      electionDefinition={electionMinimalExhaustiveSampleDefintion}
+      electionDefinition={electionMinimalExhaustiveSampleDefinition}
       precinctSelection={{
         kind: PrecinctSelectionKind.AllPrecincts,
       }}
@@ -210,14 +210,14 @@ const primaryCvr2: CastVoteRecord = {
 test('renders as expected for a single precincts in a primary election', async () => {
   const party1 = unsafeParse(PartyIdSchema, '1');
   const tally = calculateTallyForCastVoteRecords(
-    electionMinimalExhaustiveSampleDefintion.election,
+    electionMinimalExhaustiveSampleDefinition.election,
     new Set([primaryCvr2]),
     party1
   );
   render(
     <PrecinctScannerTallyReport
       reportSavedTime={time}
-      electionDefinition={electionMinimalExhaustiveSampleDefintion}
+      electionDefinition={electionMinimalExhaustiveSampleDefinition}
       precinctSelection={{
         kind: PrecinctSelectionKind.SinglePrecinct,
         precinctId: 'precinct-1',


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
The tests for the compressed tallies were very hard to read because of the opaque lists of numbers, and to a lesser extent the nonspecific type `number[]` used to represent them.

To improve this I added comments to indicate what each number is for. And the types are now numeric tuples with labeled entries, making it easier to see what field corresponds to what.

## Demo Video or Screenshot
Improved type information:
<img width="713" alt="image" src="https://user-images.githubusercontent.com/1938/154545236-e4a2ff1c-735a-4d01-8433-9655e7b73229.png">

## Testing Plan 
Automated testing.

## Checklist
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
- [ ] ~I have added JSDoc comments to any newly introduced exports~
