### PR TITLE
feat(types): add validation for explicit write-ins

### DIFF
--- a/libs/test-utils/src/arbitraries.ts
+++ b/libs/test-utils/src/arbitraries.ts
@@ -219,7 +219,6 @@ export function arbitraryCandidate({
   return fc.record({
     id,
     name: fc.string({ minLength: 1 }),
-    isWriteIn: arbitraryOptional(fc.boolean()),
     partyId,
   });
 }

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -187,6 +187,27 @@ export const CandidateContestSchema: z.ZodSchema<CandidateContest> = ContestInte
       message: `Duplicate candidate '${id}' found.`,
     });
   }
+
+  if (!contest.allowWriteIns) {
+    for (const [index, candidate] of contest.candidates.entries()) {
+      if (candidate.isWriteIn) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['candidates', index, 'isWriteIn'],
+          message: `Contest '${contest.id}' does not allow write-ins.`,
+        });
+      }
+    }
+  } else {
+    const writeInsCount = contest.candidates.filter((c) => c.isWriteIn).length;
+    if (writeInsCount > 0 && writeInsCount !== contest.seats) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['candidates'],
+        message: `Contest has ${writeInsCount} write-in candidate(s), but ${contest.seats} seat(s) are available.`,
+      });
+    }
+  }
 });
 
 export type YesNoOptionId = Id;

--- a/libs/types/src/schema.test.ts
+++ b/libs/types/src/schema.test.ts
@@ -808,3 +808,86 @@ test('safeParseElectionDefinition computes the election hash', () => {
 test('safeParseElectionDefinition error result', () => {
   expect(t.safeParseElectionDefinition('').err()).toBeDefined();
 });
+
+test('specifying write-in candidates', () => {
+  const candidateContest: t.CandidateContest = {
+    id: 'CC',
+    type: 'candidate',
+    title: 'CC',
+    section: 'Section',
+    districtId: unsafeParse(t.DistrictIdSchema, 'D'),
+    allowWriteIns: true,
+    seats: 1,
+    candidates: [
+      {
+        id: 'C',
+        name: 'C',
+      },
+      {
+        id: '__write-in-0',
+        name: 'W',
+        isWriteIn: true,
+      },
+    ],
+  };
+
+  unsafeParse(t.CandidateContestSchema, candidateContest);
+});
+
+test('specifying all write-in candidates is required if any are specified', () => {
+  const candidateContest: t.CandidateContest = {
+    id: 'CC',
+    type: 'candidate',
+    title: 'CC',
+    section: 'Section',
+    districtId: unsafeParse(t.DistrictIdSchema, 'D'),
+    allowWriteIns: true,
+    seats: 2,
+    candidates: [
+      {
+        id: 'C',
+        name: 'C',
+      },
+      {
+        id: '__write-in-0',
+        name: 'W',
+        isWriteIn: true,
+      },
+    ],
+  };
+
+  expect(
+    safeParse(t.CandidateContestSchema, candidateContest).unsafeUnwrapErr()
+      .errors[0].message
+  ).toEqual(
+    'Contest has 1 write-in candidate(s), but 2 seat(s) are available.'
+  );
+});
+
+test('no write-in candidates may be specified if write-ins are not allowed', () => {
+  const candidateContest: t.CandidateContest = {
+    id: 'CC',
+    type: 'candidate',
+    title: 'CC',
+    section: 'Section',
+    districtId: unsafeParse(t.DistrictIdSchema, 'D'),
+    allowWriteIns: false,
+    seats: 1,
+    candidates: [
+      {
+        id: 'C',
+        name: 'C',
+      },
+      {
+        id: '__write-in-0',
+        name: 'W',
+        isWriteIn: true,
+      },
+    ],
+  };
+
+  expect(
+    safeParse(t.CandidateContestSchema, candidateContest).unsafeUnwrapErr()
+      .errors[0].message
+  ).toEqual(`Contest 'CC' does not allow write-ins.`);
+});


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Such candidates were already technically allowed, but had and still have undefined behavior in the rest of the system. Now they are only allowed if there is a write-in candidate placeholder for each seat in a contest. Future commits will update the rest of the system to account for their optional presence. Eventually we may choose to make them mandatory.

## Demo Video or Screenshot
n/a

## Testing Plan 
Automated testing.

## Checklist
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
- [ ] ~I have added JSDoc comments to any newly introduced exports~
