### PR TITLE
refactor(scan): remove `contest` from mark info

### DIFF
--- a/frontends/bsd/src/screens/ballot_eject_screen.test.tsx
+++ b/frontends/bsd/src/screens/ballot_eject_screen.test.tsx
@@ -1,14 +1,14 @@
-import { waitFor, fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { LogEventId, Logger, LogSource } from '@votingworks/logging';
+import { AdjudicationReason, BallotType } from '@votingworks/types';
+import { GetNextReviewSheetResponse } from '@votingworks/types/api/services/scan';
+import { typedAs } from '@votingworks/utils';
 import fetchMock from 'fetch-mock';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import { BallotType, AdjudicationReason, DistrictId } from '@votingworks/types';
-import { typedAs } from '@votingworks/utils';
-import { GetNextReviewSheetResponse } from '@votingworks/types/api/services/scan';
-import { LogEventId, Logger, LogSource } from '@votingworks/logging';
-import { BallotEjectScreen } from './ballot_eject_screen';
 import { renderInAppContext } from '../../test/render_in_app_context';
+import { BallotEjectScreen } from './ballot_eject_screen';
 
 test('says the sheet is unreadable if it is', async () => {
   fetchMock.getOnce(
@@ -717,25 +717,8 @@ test('does NOT say ballot is blank if one side is blank and the other requires w
                       width: 32,
                       height: 22,
                     },
-                    contest: {
-                      id: 'contest1',
-                      districtId: 'district1' as DistrictId,
-                      section: 'testsection',
-                      title: 'President',
-                      type: 'candidate',
-                      seats: 1,
-                      candidates: [
-                        {
-                          id: 'Candidate1',
-                          name: 'Mickey Mouse',
-                        },
-                      ],
-                      allowWriteIns: true,
-                    },
-                    option: {
-                      id: 'Candidate1',
-                      name: 'Mickey Mouse',
-                    },
+                    contestId: 'contest1',
+                    optionId: 'Candidate1',
                     score: 0.78,
                     scoredOffset: {
                       x: 0,

--- a/libs/ballot-interpreter-vx/src/cli/commands/interpret.ts
+++ b/libs/ballot-interpreter-vx/src/cli/commands/interpret.ts
@@ -250,40 +250,15 @@ export async function run(
               metadata: interpreted.metadata,
               votes: interpreted.ballot.votes,
               marks: interpreted.marks
-                .filter((mark) =>
-                  mark.type === 'candidate' || mark.type === 'yesno'
-                    ? mark.score > 0
-                    : true
-                )
-                .map((mark) =>
-                  mark.type === 'candidate'
-                    ? {
-                        type: mark.type,
-                        contest: mark.contest.id,
-                        option: mark.option.id,
-                        score: mark.score,
-                        bounds: mark.bounds,
-                        target: mark.target,
-                      }
-                    : mark.type === 'yesno'
-                    ? {
-                        type: mark.type,
-                        contest: mark.contest.id,
-                        option: mark.option,
-                        score: mark.score,
-                        bounds: mark.bounds,
-                        target: mark.target,
-                      }
-                    : {
-                        type: mark.type,
-                        contest: mark.contest?.id,
-                        option:
-                          typeof mark.option === 'string'
-                            ? mark.option
-                            : mark.option?.id,
-                        bounds: mark.bounds,
-                      }
-                ),
+                .filter((mark) => mark.score > 0)
+                .map((mark) => ({
+                  type: mark.type,
+                  contest: mark.contestId,
+                  option: mark.optionId,
+                  score: mark.score,
+                  bounds: mark.bounds,
+                  target: mark.target,
+                })),
             },
           })),
           undefined,

--- a/libs/ballot-interpreter-vx/src/get_votes_from_marks.test.ts
+++ b/libs/ballot-interpreter-vx/src/get_votes_from_marks.test.ts
@@ -25,8 +25,8 @@ const msEitherNeitherContest = find(
 
 const candidateMark: BallotMark = {
   type: 'candidate',
-  contest: candidateContest,
-  option: candidateContest.candidates[0],
+  contestId: candidateContest.id,
+  optionId: candidateContest.candidates[0].id,
   bounds: { x: 0, y: 0, width: 0, height: 0 },
   score: 0.2,
   scoredOffset: { x: 0, y: 0 },
@@ -38,8 +38,8 @@ const candidateMark: BallotMark = {
 
 const yesnoMark: BallotMark = {
   type: 'yesno',
-  contest: yesnoContest,
-  option: 'yes',
+  contestId: yesnoContest.id,
+  optionId: 'yes',
   bounds: { x: 0, y: 0, width: 0, height: 0 },
   score: 0.2,
   scoredOffset: { x: 0, y: 0 },
@@ -51,8 +51,8 @@ const yesnoMark: BallotMark = {
 
 const msEitherNeitherMark: BallotMark = {
   type: 'ms-either-neither',
-  contest: msEitherNeitherContest,
-  option: msEitherNeitherContest.eitherOption,
+  contestId: msEitherNeitherContest.id,
+  optionId: msEitherNeitherContest.eitherOption.id,
   bounds: { x: 0, y: 0, width: 0, height: 0 },
   score: 0.2,
   scoredOffset: { x: 0, y: 0 },
@@ -64,33 +64,43 @@ const msEitherNeitherMark: BallotMark = {
 
 test('candidate contest', () => {
   expect(
-    getVotesFromMarks([candidateMark], { markScoreVoteThreshold: 0.12 })
+    getVotesFromMarks(election, [candidateMark], {
+      markScoreVoteThreshold: 0.12,
+    })
   ).toEqual({
-    [candidateContest.id]: [candidateMark.option],
+    [candidateContest.id]: [
+      expect.objectContaining({ id: candidateMark.optionId }),
+    ],
   });
   expect(
-    getVotesFromMarks([candidateMark], { markScoreVoteThreshold: 0.6 })
+    getVotesFromMarks(election, [candidateMark], {
+      markScoreVoteThreshold: 0.6,
+    })
   ).toEqual({});
 });
 
 test('yesno contest', () => {
   expect(
-    getVotesFromMarks([yesnoMark], { markScoreVoteThreshold: 0.12 })
+    getVotesFromMarks(election, [yesnoMark], { markScoreVoteThreshold: 0.12 })
   ).toEqual({
-    [yesnoContest.id]: [yesnoMark.option],
+    [yesnoContest.id]: ['yes'],
   });
   expect(
-    getVotesFromMarks([yesnoMark], { markScoreVoteThreshold: 0.6 })
+    getVotesFromMarks(election, [yesnoMark], { markScoreVoteThreshold: 0.6 })
   ).toEqual({});
 });
 
 test('ms-either-neither contest', () => {
   expect(
-    getVotesFromMarks([msEitherNeitherMark], { markScoreVoteThreshold: 0.12 })
+    getVotesFromMarks(election, [msEitherNeitherMark], {
+      markScoreVoteThreshold: 0.12,
+    })
   ).toEqual({
-    [msEitherNeitherContest.eitherNeitherContestId]: [yesnoMark.option],
+    [msEitherNeitherContest.eitherNeitherContestId]: ['yes'],
   });
   expect(
-    getVotesFromMarks([msEitherNeitherMark], { markScoreVoteThreshold: 0.6 })
+    getVotesFromMarks(election, [msEitherNeitherMark], {
+      markScoreVoteThreshold: 0.6,
+    })
   ).toEqual({});
 });

--- a/libs/ballot-interpreter-vx/src/interpreter.test.ts
+++ b/libs/ballot-interpreter-vx/src/interpreter.test.ts
@@ -1568,97 +1568,95 @@ test('interpret votes', async () => {
   `);
 
   expect(
-    marks.map((mark) =>
-      mark.type === 'yesno'
-        ? { type: mark.type, option: mark.option, score: mark.score }
-        : mark.type === 'candidate'
-        ? { type: mark.type, option: mark.option.name, score: mark.score }
-        : { type: mark.type, bounds: mark.bounds }
-    )
+    marks.map((mark) => ({
+      type: mark.type,
+      option: mark.optionId,
+      score: mark.score,
+    }))
   ).toMatchInlineSnapshot(`
     Array [
       Object {
-        "option": "John Cornyn",
+        "option": "john-cornyn",
         "score": 0,
         "type": "candidate",
       },
       Object {
-        "option": "James Brumley",
+        "option": "james-brumley",
         "score": 0,
         "type": "candidate",
       },
       Object {
-        "option": "Cedric Jefferson",
+        "option": "cedric-jefferson",
         "score": 0,
         "type": "candidate",
       },
       Object {
-        "option": "Tim Smith",
+        "option": "tim-smith",
         "score": 0.8765432098765432,
         "type": "candidate",
       },
       Object {
-        "option": "Arjun Srinivasan",
+        "option": "arjun-srinivasan",
         "score": 0.0024630541871921183,
         "type": "candidate",
       },
       Object {
-        "option": "Ricardo Turullols-Bonilla",
+        "option": "ricardo-turullols-bonilla",
         "score": 0.007407407407407408,
         "type": "candidate",
       },
       Object {
-        "option": "Eddie Bernice Johnson",
+        "option": "eddie-bernice-johnson",
         "score": 0.7832512315270936,
         "type": "candidate",
       },
       Object {
-        "option": "Tre Pennie",
+        "option": "tre-pennie",
         "score": 0.0024449877750611247,
         "type": "candidate",
       },
       Object {
-        "option": "Jane Bland",
+        "option": "jane-bland",
         "score": 0.7524509803921569,
         "type": "candidate",
       },
       Object {
-        "option": "Kathy Cheng",
+        "option": "kathy-cheng",
         "score": 0.004889975550122249,
         "type": "candidate",
       },
       Object {
-        "option": "Yvonne Davis",
+        "option": "yvonne-davis",
         "score": 0,
         "type": "candidate",
       },
       Object {
-        "option": "Write-In",
+        "option": "__write-in-0",
         "score": 0.8029556650246306,
         "type": "candidate",
       },
       Object {
-        "option": "John Ames",
+        "option": "john-ames",
         "score": 0.8866995073891626,
         "type": "candidate",
       },
       Object {
-        "option": "Write-In",
+        "option": "__write-in-0",
         "score": 0,
         "type": "candidate",
       },
       Object {
-        "option": "Marian Brown",
+        "option": "marian-brown",
         "score": 0,
         "type": "candidate",
       },
       Object {
-        "option": "Chad Prda",
+        "option": "chad-prda",
         "score": 0.7,
         "type": "candidate",
       },
       Object {
-        "option": "Write-In",
+        "option": "__write-in-0",
         "score": 0,
         "type": "candidate",
       },
@@ -1728,37 +1726,8 @@ test('invalid marks', async () => {
           "x": 67,
           "y": 242,
         },
-        "contest": Object {
-          "allowWriteIns": true,
-          "candidates": Array [
-            Object {
-              "id": "john-wiley-price",
-              "name": "John Wiley Price",
-              "partyId": "2",
-            },
-            Object {
-              "id": "s-t-russell",
-              "name": "S.T. Russell",
-              "partyId": "3",
-            },
-            Object {
-              "id": "andrew-jewell",
-              "name": "Andrew Jewell",
-              "partyId": "7",
-            },
-          ],
-          "districtId": "12",
-          "id": "dallas-county-commissioners-court-pct-3",
-          "seats": 2,
-          "section": "Dallas County",
-          "title": "Member, Dallas County Commissioners Court, Precinct 3",
-          "type": "candidate",
-        },
-        "option": Object {
-          "id": "john-wiley-price",
-          "name": "John Wiley Price",
-          "partyId": "2",
-        },
+        "contestId": "dallas-county-commissioners-court-pct-3",
+        "optionId": "john-wiley-price",
         "score": 0.009950248756218905,
         "scoredOffset": Object {
           "x": 0,
@@ -1788,37 +1757,8 @@ test('invalid marks', async () => {
           "x": 67,
           "y": 320,
         },
-        "contest": Object {
-          "allowWriteIns": true,
-          "candidates": Array [
-            Object {
-              "id": "john-wiley-price",
-              "name": "John Wiley Price",
-              "partyId": "2",
-            },
-            Object {
-              "id": "s-t-russell",
-              "name": "S.T. Russell",
-              "partyId": "3",
-            },
-            Object {
-              "id": "andrew-jewell",
-              "name": "Andrew Jewell",
-              "partyId": "7",
-            },
-          ],
-          "districtId": "12",
-          "id": "dallas-county-commissioners-court-pct-3",
-          "seats": 2,
-          "section": "Dallas County",
-          "title": "Member, Dallas County Commissioners Court, Precinct 3",
-          "type": "candidate",
-        },
-        "option": Object {
-          "id": "s-t-russell",
-          "name": "S.T. Russell",
-          "partyId": "3",
-        },
+        "contestId": "dallas-county-commissioners-court-pct-3",
+        "optionId": "s-t-russell",
         "score": 0,
         "scoredOffset": Object {
           "x": 0,
@@ -1848,37 +1788,8 @@ test('invalid marks', async () => {
           "x": 67,
           "y": 398,
         },
-        "contest": Object {
-          "allowWriteIns": true,
-          "candidates": Array [
-            Object {
-              "id": "john-wiley-price",
-              "name": "John Wiley Price",
-              "partyId": "2",
-            },
-            Object {
-              "id": "s-t-russell",
-              "name": "S.T. Russell",
-              "partyId": "3",
-            },
-            Object {
-              "id": "andrew-jewell",
-              "name": "Andrew Jewell",
-              "partyId": "7",
-            },
-          ],
-          "districtId": "12",
-          "id": "dallas-county-commissioners-court-pct-3",
-          "seats": 2,
-          "section": "Dallas County",
-          "title": "Member, Dallas County Commissioners Court, Precinct 3",
-          "type": "candidate",
-        },
-        "option": Object {
-          "id": "andrew-jewell",
-          "name": "Andrew Jewell",
-          "partyId": "7",
-        },
+        "contestId": "dallas-county-commissioners-court-pct-3",
+        "optionId": "andrew-jewell",
         "score": 0.8271604938271605,
         "scoredOffset": Object {
           "x": 0,
@@ -1908,37 +1819,8 @@ test('invalid marks', async () => {
           "x": 67,
           "y": 476,
         },
-        "contest": Object {
-          "allowWriteIns": true,
-          "candidates": Array [
-            Object {
-              "id": "john-wiley-price",
-              "name": "John Wiley Price",
-              "partyId": "2",
-            },
-            Object {
-              "id": "s-t-russell",
-              "name": "S.T. Russell",
-              "partyId": "3",
-            },
-            Object {
-              "id": "andrew-jewell",
-              "name": "Andrew Jewell",
-              "partyId": "7",
-            },
-          ],
-          "districtId": "12",
-          "id": "dallas-county-commissioners-court-pct-3",
-          "seats": 2,
-          "section": "Dallas County",
-          "title": "Member, Dallas County Commissioners Court, Precinct 3",
-          "type": "candidate",
-        },
-        "option": Object {
-          "id": "__write-in-0",
-          "isWriteIn": true,
-          "name": "Write-In",
-        },
+        "contestId": "dallas-county-commissioners-court-pct-3",
+        "optionId": "__write-in-0",
         "score": 0,
         "scoredOffset": Object {
           "x": 0,
@@ -1968,37 +1850,8 @@ test('invalid marks', async () => {
           "x": 67,
           "y": 526,
         },
-        "contest": Object {
-          "allowWriteIns": true,
-          "candidates": Array [
-            Object {
-              "id": "john-wiley-price",
-              "name": "John Wiley Price",
-              "partyId": "2",
-            },
-            Object {
-              "id": "s-t-russell",
-              "name": "S.T. Russell",
-              "partyId": "3",
-            },
-            Object {
-              "id": "andrew-jewell",
-              "name": "Andrew Jewell",
-              "partyId": "7",
-            },
-          ],
-          "districtId": "12",
-          "id": "dallas-county-commissioners-court-pct-3",
-          "seats": 2,
-          "section": "Dallas County",
-          "title": "Member, Dallas County Commissioners Court, Precinct 3",
-          "type": "candidate",
-        },
-        "option": Object {
-          "id": "__write-in-1",
-          "isWriteIn": true,
-          "name": "Write-In",
-        },
+        "contestId": "dallas-county-commissioners-court-pct-3",
+        "optionId": "__write-in-1",
         "score": 0,
         "scoredOffset": Object {
           "x": 0,
@@ -2028,15 +1881,8 @@ test('invalid marks', async () => {
           "x": 67,
           "y": 869,
         },
-        "contest": Object {
-          "description": "Shall Robert Demergue be retained as Chief Justice of the Dallas County Court of Appeals?",
-          "districtId": "12",
-          "id": "dallas-county-retain-chief-justice",
-          "section": "Dallas County",
-          "title": "Retain Robert Demergue as Chief Justice?",
-          "type": "yesno",
-        },
-        "option": "yes",
+        "contestId": "dallas-county-retain-chief-justice",
+        "optionId": "yes",
         "score": 0.18610421836228289,
         "scoredOffset": Object {
           "x": 0,
@@ -2065,15 +1911,8 @@ test('invalid marks', async () => {
           "x": 67,
           "y": 919,
         },
-        "contest": Object {
-          "description": "Shall Robert Demergue be retained as Chief Justice of the Dallas County Court of Appeals?",
-          "districtId": "12",
-          "id": "dallas-county-retain-chief-justice",
-          "section": "Dallas County",
-          "title": "Retain Robert Demergue as Chief Justice?",
-          "type": "yesno",
-        },
-        "option": "no",
+        "contestId": "dallas-county-retain-chief-justice",
+        "optionId": "no",
         "score": 0,
         "scoredOffset": Object {
           "x": 0,
@@ -2102,15 +1941,8 @@ test('invalid marks', async () => {
           "x": 470,
           "y": 315,
         },
-        "contest": Object {
-          "description": "Shall the Dallas County extend the Recycling Program countywide?",
-          "districtId": "12",
-          "id": "dallas-county-proposition-r",
-          "section": "Dallas County",
-          "title": "Proposition R: Countywide Recycling Program",
-          "type": "yesno",
-        },
-        "option": "yes",
+        "contestId": "dallas-county-proposition-r",
+        "optionId": "yes",
         "score": 0,
         "scoredOffset": Object {
           "x": 0,
@@ -2139,15 +1971,8 @@ test('invalid marks', async () => {
           "x": 470,
           "y": 365,
         },
-        "contest": Object {
-          "description": "Shall the Dallas County extend the Recycling Program countywide?",
-          "districtId": "12",
-          "id": "dallas-county-proposition-r",
-          "section": "Dallas County",
-          "title": "Proposition R: Countywide Recycling Program",
-          "type": "yesno",
-        },
-        "option": "no",
+        "contestId": "dallas-county-proposition-r",
+        "optionId": "no",
         "score": 0.8215158924205379,
         "scoredOffset": Object {
           "x": -1,
@@ -2176,52 +2001,8 @@ test('invalid marks', async () => {
           "x": 470,
           "y": 569,
         },
-        "contest": Object {
-          "allowWriteIns": true,
-          "candidates": Array [
-            Object {
-              "id": "harvey-eagle",
-              "name": "Harvey Eagle",
-              "partyId": "2",
-            },
-            Object {
-              "id": "randall-rupp",
-              "name": "Randall Rupp",
-              "partyId": "2",
-            },
-            Object {
-              "id": "carroll-shry",
-              "name": "Carroll Shry",
-              "partyId": "2",
-            },
-            Object {
-              "id": "beverly-barker",
-              "name": "Beverly Barker",
-              "partyId": "3",
-            },
-            Object {
-              "id": "donald-davis",
-              "name": "Donald Davis",
-              "partyId": "3",
-            },
-            Object {
-              "id": "hugo-smith",
-              "name": "Hugo Smith",
-              "partyId": "3",
-            },
-          ],
-          "districtId": "12",
-          "id": "dallas-city-council",
-          "seats": 3,
-          "section": "City of Dallas",
-          "title": "City Council",
-          "type": "candidate",
-        },
-        "option": Object {
-          "id": "harvey-eagle",
-          "name": "Harvey Eagle",
-          "partyId": "2",
-        },
+        "contestId": "dallas-city-council",
+        "optionId": "harvey-eagle",
         "score": 0,
         "scoredOffset": Object {
           "x": 0,
@@ -2251,52 +2032,8 @@ test('invalid marks', async () => {
           "x": 470,
           "y": 647,
         },
-        "contest": Object {
-          "allowWriteIns": true,
-          "candidates": Array [
-            Object {
-              "id": "harvey-eagle",
-              "name": "Harvey Eagle",
-              "partyId": "2",
-            },
-            Object {
-              "id": "randall-rupp",
-              "name": "Randall Rupp",
-              "partyId": "2",
-            },
-            Object {
-              "id": "carroll-shry",
-              "name": "Carroll Shry",
-              "partyId": "2",
-            },
-            Object {
-              "id": "beverly-barker",
-              "name": "Beverly Barker",
-              "partyId": "3",
-            },
-            Object {
-              "id": "donald-davis",
-              "name": "Donald Davis",
-              "partyId": "3",
-            },
-            Object {
-              "id": "hugo-smith",
-              "name": "Hugo Smith",
-              "partyId": "3",
-            },
-          ],
-          "districtId": "12",
-          "id": "dallas-city-council",
-          "seats": 3,
-          "section": "City of Dallas",
-          "title": "City Council",
-          "type": "candidate",
-        },
-        "option": Object {
-          "id": "randall-rupp",
-          "name": "Randall Rupp",
-          "partyId": "2",
-        },
+        "contestId": "dallas-city-council",
+        "optionId": "randall-rupp",
         "score": 0.1921182266009852,
         "scoredOffset": Object {
           "x": 0,
@@ -2326,52 +2063,8 @@ test('invalid marks', async () => {
           "x": 470,
           "y": 725,
         },
-        "contest": Object {
-          "allowWriteIns": true,
-          "candidates": Array [
-            Object {
-              "id": "harvey-eagle",
-              "name": "Harvey Eagle",
-              "partyId": "2",
-            },
-            Object {
-              "id": "randall-rupp",
-              "name": "Randall Rupp",
-              "partyId": "2",
-            },
-            Object {
-              "id": "carroll-shry",
-              "name": "Carroll Shry",
-              "partyId": "2",
-            },
-            Object {
-              "id": "beverly-barker",
-              "name": "Beverly Barker",
-              "partyId": "3",
-            },
-            Object {
-              "id": "donald-davis",
-              "name": "Donald Davis",
-              "partyId": "3",
-            },
-            Object {
-              "id": "hugo-smith",
-              "name": "Hugo Smith",
-              "partyId": "3",
-            },
-          ],
-          "districtId": "12",
-          "id": "dallas-city-council",
-          "seats": 3,
-          "section": "City of Dallas",
-          "title": "City Council",
-          "type": "candidate",
-        },
-        "option": Object {
-          "id": "carroll-shry",
-          "name": "Carroll Shry",
-          "partyId": "2",
-        },
+        "contestId": "dallas-city-council",
+        "optionId": "carroll-shry",
         "score": 0.0024752475247524753,
         "scoredOffset": Object {
           "x": -1,
@@ -2401,52 +2094,8 @@ test('invalid marks', async () => {
           "x": 470,
           "y": 803,
         },
-        "contest": Object {
-          "allowWriteIns": true,
-          "candidates": Array [
-            Object {
-              "id": "harvey-eagle",
-              "name": "Harvey Eagle",
-              "partyId": "2",
-            },
-            Object {
-              "id": "randall-rupp",
-              "name": "Randall Rupp",
-              "partyId": "2",
-            },
-            Object {
-              "id": "carroll-shry",
-              "name": "Carroll Shry",
-              "partyId": "2",
-            },
-            Object {
-              "id": "beverly-barker",
-              "name": "Beverly Barker",
-              "partyId": "3",
-            },
-            Object {
-              "id": "donald-davis",
-              "name": "Donald Davis",
-              "partyId": "3",
-            },
-            Object {
-              "id": "hugo-smith",
-              "name": "Hugo Smith",
-              "partyId": "3",
-            },
-          ],
-          "districtId": "12",
-          "id": "dallas-city-council",
-          "seats": 3,
-          "section": "City of Dallas",
-          "title": "City Council",
-          "type": "candidate",
-        },
-        "option": Object {
-          "id": "beverly-barker",
-          "name": "Beverly Barker",
-          "partyId": "3",
-        },
+        "contestId": "dallas-city-council",
+        "optionId": "beverly-barker",
         "score": 0.0024752475247524753,
         "scoredOffset": Object {
           "x": -1,
@@ -2476,52 +2125,8 @@ test('invalid marks', async () => {
           "x": 470,
           "y": 881,
         },
-        "contest": Object {
-          "allowWriteIns": true,
-          "candidates": Array [
-            Object {
-              "id": "harvey-eagle",
-              "name": "Harvey Eagle",
-              "partyId": "2",
-            },
-            Object {
-              "id": "randall-rupp",
-              "name": "Randall Rupp",
-              "partyId": "2",
-            },
-            Object {
-              "id": "carroll-shry",
-              "name": "Carroll Shry",
-              "partyId": "2",
-            },
-            Object {
-              "id": "beverly-barker",
-              "name": "Beverly Barker",
-              "partyId": "3",
-            },
-            Object {
-              "id": "donald-davis",
-              "name": "Donald Davis",
-              "partyId": "3",
-            },
-            Object {
-              "id": "hugo-smith",
-              "name": "Hugo Smith",
-              "partyId": "3",
-            },
-          ],
-          "districtId": "12",
-          "id": "dallas-city-council",
-          "seats": 3,
-          "section": "City of Dallas",
-          "title": "City Council",
-          "type": "candidate",
-        },
-        "option": Object {
-          "id": "donald-davis",
-          "name": "Donald Davis",
-          "partyId": "3",
-        },
+        "contestId": "dallas-city-council",
+        "optionId": "donald-davis",
         "score": 0.19801980198019803,
         "scoredOffset": Object {
           "x": -1,
@@ -2551,52 +2156,8 @@ test('invalid marks', async () => {
           "x": 470,
           "y": 959,
         },
-        "contest": Object {
-          "allowWriteIns": true,
-          "candidates": Array [
-            Object {
-              "id": "harvey-eagle",
-              "name": "Harvey Eagle",
-              "partyId": "2",
-            },
-            Object {
-              "id": "randall-rupp",
-              "name": "Randall Rupp",
-              "partyId": "2",
-            },
-            Object {
-              "id": "carroll-shry",
-              "name": "Carroll Shry",
-              "partyId": "2",
-            },
-            Object {
-              "id": "beverly-barker",
-              "name": "Beverly Barker",
-              "partyId": "3",
-            },
-            Object {
-              "id": "donald-davis",
-              "name": "Donald Davis",
-              "partyId": "3",
-            },
-            Object {
-              "id": "hugo-smith",
-              "name": "Hugo Smith",
-              "partyId": "3",
-            },
-          ],
-          "districtId": "12",
-          "id": "dallas-city-council",
-          "seats": 3,
-          "section": "City of Dallas",
-          "title": "City Council",
-          "type": "candidate",
-        },
-        "option": Object {
-          "id": "hugo-smith",
-          "name": "Hugo Smith",
-          "partyId": "3",
-        },
+        "contestId": "dallas-city-council",
+        "optionId": "hugo-smith",
         "score": 0.009950248756218905,
         "scoredOffset": Object {
           "x": 0,
@@ -2626,52 +2187,8 @@ test('invalid marks', async () => {
           "x": 470,
           "y": 1037,
         },
-        "contest": Object {
-          "allowWriteIns": true,
-          "candidates": Array [
-            Object {
-              "id": "harvey-eagle",
-              "name": "Harvey Eagle",
-              "partyId": "2",
-            },
-            Object {
-              "id": "randall-rupp",
-              "name": "Randall Rupp",
-              "partyId": "2",
-            },
-            Object {
-              "id": "carroll-shry",
-              "name": "Carroll Shry",
-              "partyId": "2",
-            },
-            Object {
-              "id": "beverly-barker",
-              "name": "Beverly Barker",
-              "partyId": "3",
-            },
-            Object {
-              "id": "donald-davis",
-              "name": "Donald Davis",
-              "partyId": "3",
-            },
-            Object {
-              "id": "hugo-smith",
-              "name": "Hugo Smith",
-              "partyId": "3",
-            },
-          ],
-          "districtId": "12",
-          "id": "dallas-city-council",
-          "seats": 3,
-          "section": "City of Dallas",
-          "title": "City Council",
-          "type": "candidate",
-        },
-        "option": Object {
-          "id": "__write-in-0",
-          "isWriteIn": true,
-          "name": "Write-In",
-        },
+        "contestId": "dallas-city-council",
+        "optionId": "__write-in-0",
         "score": 0,
         "scoredOffset": Object {
           "x": 0,
@@ -2701,52 +2218,8 @@ test('invalid marks', async () => {
           "x": 470,
           "y": 1087,
         },
-        "contest": Object {
-          "allowWriteIns": true,
-          "candidates": Array [
-            Object {
-              "id": "harvey-eagle",
-              "name": "Harvey Eagle",
-              "partyId": "2",
-            },
-            Object {
-              "id": "randall-rupp",
-              "name": "Randall Rupp",
-              "partyId": "2",
-            },
-            Object {
-              "id": "carroll-shry",
-              "name": "Carroll Shry",
-              "partyId": "2",
-            },
-            Object {
-              "id": "beverly-barker",
-              "name": "Beverly Barker",
-              "partyId": "3",
-            },
-            Object {
-              "id": "donald-davis",
-              "name": "Donald Davis",
-              "partyId": "3",
-            },
-            Object {
-              "id": "hugo-smith",
-              "name": "Hugo Smith",
-              "partyId": "3",
-            },
-          ],
-          "districtId": "12",
-          "id": "dallas-city-council",
-          "seats": 3,
-          "section": "City of Dallas",
-          "title": "City Council",
-          "type": "candidate",
-        },
-        "option": Object {
-          "id": "__write-in-1",
-          "isWriteIn": true,
-          "name": "Write-In",
-        },
+        "contestId": "dallas-city-council",
+        "optionId": "__write-in-1",
         "score": 0.15403422982885084,
         "scoredOffset": Object {
           "x": 0,
@@ -2776,52 +2249,8 @@ test('invalid marks', async () => {
           "x": 470,
           "y": 1137,
         },
-        "contest": Object {
-          "allowWriteIns": true,
-          "candidates": Array [
-            Object {
-              "id": "harvey-eagle",
-              "name": "Harvey Eagle",
-              "partyId": "2",
-            },
-            Object {
-              "id": "randall-rupp",
-              "name": "Randall Rupp",
-              "partyId": "2",
-            },
-            Object {
-              "id": "carroll-shry",
-              "name": "Carroll Shry",
-              "partyId": "2",
-            },
-            Object {
-              "id": "beverly-barker",
-              "name": "Beverly Barker",
-              "partyId": "3",
-            },
-            Object {
-              "id": "donald-davis",
-              "name": "Donald Davis",
-              "partyId": "3",
-            },
-            Object {
-              "id": "hugo-smith",
-              "name": "Hugo Smith",
-              "partyId": "3",
-            },
-          ],
-          "districtId": "12",
-          "id": "dallas-city-council",
-          "seats": 3,
-          "section": "City of Dallas",
-          "title": "City Council",
-          "type": "candidate",
-        },
-        "option": Object {
-          "id": "__write-in-2",
-          "isWriteIn": true,
-          "name": "Write-In",
-        },
+        "contestId": "dallas-city-council",
+        "optionId": "__write-in-2",
         "score": 0.007371007371007371,
         "scoredOffset": Object {
           "x": 0,
@@ -2851,32 +2280,8 @@ test('invalid marks', async () => {
           "x": 872,
           "y": 176,
         },
-        "contest": Object {
-          "allowWriteIns": true,
-          "candidates": Array [
-            Object {
-              "id": "orville-white",
-              "name": "Orville White",
-              "partyId": "2",
-            },
-            Object {
-              "id": "gregory-seldon",
-              "name": "Gregory Seldon",
-              "partyId": "3",
-            },
-          ],
-          "districtId": "12",
-          "id": "dallas-mayor",
-          "seats": 1,
-          "section": "City of Dallas",
-          "title": "Mayor",
-          "type": "candidate",
-        },
-        "option": Object {
-          "id": "orville-white",
-          "name": "Orville White",
-          "partyId": "2",
-        },
+        "contestId": "dallas-mayor",
+        "optionId": "orville-white",
         "score": 0,
         "scoredOffset": Object {
           "x": 0,
@@ -2906,32 +2311,8 @@ test('invalid marks', async () => {
           "x": 872,
           "y": 255,
         },
-        "contest": Object {
-          "allowWriteIns": true,
-          "candidates": Array [
-            Object {
-              "id": "orville-white",
-              "name": "Orville White",
-              "partyId": "2",
-            },
-            Object {
-              "id": "gregory-seldon",
-              "name": "Gregory Seldon",
-              "partyId": "3",
-            },
-          ],
-          "districtId": "12",
-          "id": "dallas-mayor",
-          "seats": 1,
-          "section": "City of Dallas",
-          "title": "Mayor",
-          "type": "candidate",
-        },
-        "option": Object {
-          "id": "gregory-seldon",
-          "name": "Gregory Seldon",
-          "partyId": "3",
-        },
+        "contestId": "dallas-mayor",
+        "optionId": "gregory-seldon",
         "score": 0,
         "scoredOffset": Object {
           "x": 0,
@@ -2961,32 +2342,8 @@ test('invalid marks', async () => {
           "x": 872,
           "y": 333,
         },
-        "contest": Object {
-          "allowWriteIns": true,
-          "candidates": Array [
-            Object {
-              "id": "orville-white",
-              "name": "Orville White",
-              "partyId": "2",
-            },
-            Object {
-              "id": "gregory-seldon",
-              "name": "Gregory Seldon",
-              "partyId": "3",
-            },
-          ],
-          "districtId": "12",
-          "id": "dallas-mayor",
-          "seats": 1,
-          "section": "City of Dallas",
-          "title": "Mayor",
-          "type": "candidate",
-        },
-        "option": Object {
-          "id": "__write-in-0",
-          "isWriteIn": true,
-          "name": "Write-In",
-        },
+        "contestId": "dallas-mayor",
+        "optionId": "__write-in-0",
         "score": 0.0024691358024691358,
         "scoredOffset": Object {
           "x": 0,
@@ -3515,8 +2872,8 @@ test('choctaw 2020 general', async () => {
   );
   expect(
     p1Interpreted.marks.map((mark) => ({
-      contest: mark.contest.id,
-      option: typeof mark.option === 'string' ? mark.option : mark.option.id,
+      contest: mark.contestId,
+      option: mark.optionId,
       score: mark.score,
     }))
   ).toMatchInlineSnapshot(`
@@ -3615,8 +2972,8 @@ test('choctaw 2020 general', async () => {
   );
   expect(
     p2Interpreted.marks.map((mark) => ({
-      contest: mark.contest.id,
-      option: typeof mark.option === 'string' ? mark.option : mark.option.id,
+      contest: mark.contestId,
+      option: mark.optionId,
       score: mark.score,
     }))
   ).toMatchInlineSnapshot(`
@@ -3678,198 +3035,104 @@ test('regression: overvote on choctaw county p1-05', async () => {
     await fixtures.filledInPage1_05.imageData()
   );
 
-  expect(interpretation.marks.map((mark) => [mark.score, mark.option]))
+  expect(interpretation.marks.map((mark) => [mark.score, mark.optionId]))
     .toMatchInlineSnapshot(`
     Array [
       Array [
         0.0053475935828877,
-        Object {
-          "id": "775032091",
-          "name": "Presidential Electors for Joseph R. Biden Jr. for President and Kamala D. Harris for Vice President",
-          "partyId": "2",
-        },
+        "775032091",
       ],
       Array [
         0,
-        Object {
-          "id": "775032092",
-          "name": "Presidential Electors for Donald J. Trump for President and Michael R. Pence for Vice President",
-          "partyId": "3",
-        },
+        "775032092",
       ],
       Array [
         0.002717391304347826,
-        Object {
-          "id": "775032126",
-          "name": "Presidential Electors for Don Blankenship for President and William Mohr for Vice President",
-          "partyId": "775000002",
-        },
+        "775032126",
       ],
       Array [
         0,
-        Object {
-          "id": "775032100",
-          "name": "Presidential Electors for Brian Carroll for President and Amar Patel for Vice President",
-          "partyId": "775000001",
-        },
+        "775032100",
       ],
       Array [
         0.005434782608695652,
-        Object {
-          "id": "775032096",
-          "name": "Presidential Electors for Phil Collins for President and Bill Parker for Vice President",
-          "partyId": "11",
-        },
+        "775032096",
       ],
       Array [
         0.8913043478260869,
-        Object {
-          "id": "775032099",
-          "name": "Presidential Electors for Howie Hawkins for President and Angela Nicole Walker for Vice President",
-          "partyId": "9",
-        },
+        "775032099",
       ],
       Array [
         0,
-        Object {
-          "id": "775032102",
-          "name": "Presidential Electors for Jo Jorgensen for President and Jeremy 'Spike' Cohen for Vice President",
-          "partyId": "4",
-        },
+        "775032102",
       ],
       Array [
         0,
-        Object {
-          "id": "775032117",
-          "name": "Presidential Electors for Brock Pierce for President and Karla Ballard for Vice President",
-          "partyId": "11",
-        },
+        "775032117",
       ],
       Array [
         0.005434782608695652,
-        Object {
-          "id": "775032098",
-          "name": "Presidential Electors for Kanye West for President and Michelle Tidball for Vice President",
-          "partyId": "11",
-        },
+        "775032098",
       ],
       Array [
         0,
-        Object {
-          "id": "__write-in-0",
-          "isWriteIn": true,
-          "name": "Write-In",
-        },
+        "__write-in-0",
       ],
       Array [
         0,
-        Object {
-          "id": "775032093",
-          "name": "Mike Espy",
-          "partyId": "2",
-        },
+        "775032093",
       ],
       Array [
         0.008152173913043478,
-        Object {
-          "id": "775032094",
-          "name": "Cindy Hyde-Smith",
-          "partyId": "3",
-        },
+        "775032094",
       ],
       Array [
         0.8913043478260869,
-        Object {
-          "id": "775032105",
-          "name": "Jimmy L. Edwards",
-          "partyId": "4",
-        },
+        "775032105",
       ],
       Array [
         0,
-        Object {
-          "id": "__write-in-0",
-          "isWriteIn": true,
-          "name": "Write-In",
-        },
+        "__write-in-0",
       ],
       Array [
         0,
-        Object {
-          "id": "775032084",
-          "name": "Antonia Eliason",
-          "partyId": "2",
-        },
+        "775032084",
       ],
       Array [
         0.8913043478260869,
-        Object {
-          "id": "775032085",
-          "name": "Trent Kelly",
-          "partyId": "3",
-        },
+        "775032085",
       ],
       Array [
         0,
-        Object {
-          "id": "__write-in-0",
-          "isWriteIn": true,
-          "name": "Write-In",
-        },
+        "__write-in-0",
       ],
       Array [
         0.002717391304347826,
-        Object {
-          "id": "775032082",
-          "name": "Josiah Dennis Coleman",
-          "partyId": "12",
-        },
+        "775032082",
       ],
       Array [
         0.8913043478260869,
-        Object {
-          "id": "775032110",
-          "name": "Percy L. Lynchard",
-          "partyId": "12",
-        },
+        "775032110",
       ],
       Array [
         0.00267379679144385,
-        Object {
-          "id": "__write-in-0",
-          "isWriteIn": true,
-          "name": "Write-In",
-        },
+        "__write-in-0",
       ],
       Array [
         0.8983957219251337,
-        Object {
-          "id": "775032689",
-          "name": "Wayne McLeod",
-        },
+        "775032689",
       ],
       Array [
         0.008152173913043478,
-        Object {
-          "id": "__write-in-0",
-          "isWriteIn": true,
-          "name": "Write-In",
-        },
+        "__write-in-0",
       ],
       Array [
         0.8913043478260869,
-        Object {
-          "id": "775032690",
-          "name": "Michael D Thomas",
-        },
+        "775032690",
       ],
       Array [
         0,
-        Object {
-          "id": "__write-in-0",
-          "isWriteIn": true,
-          "name": "Write-In",
-        },
+        "__write-in-0",
       ],
     ]
   `);

--- a/libs/ballot-interpreter-vx/src/interpreter.ts
+++ b/libs/ballot-interpreter-vx/src/interpreter.ts
@@ -419,7 +419,9 @@ export class Interpreter {
       ballotType: BallotType.Standard,
       isTestMode: metadata.isTestMode,
       precinctId: metadata.precinctId,
-      votes: getVotesFromMarks(marks, { markScoreVoteThreshold }),
+      votes: getVotesFromMarks(this.election, marks, {
+        markScoreVoteThreshold,
+      }),
     };
   }
 
@@ -513,8 +515,8 @@ export class Interpreter {
       const mark: BallotCandidateTargetMark = {
         type: 'candidate',
         bounds: layout.target.bounds,
-        contest,
-        option,
+        contestId: contest.id,
+        optionId: option.id,
         score,
         scoredOffset: offset,
         target: layout.target,
@@ -526,19 +528,19 @@ export class Interpreter {
     const addYesNoMark = (
       contest: YesNoContest,
       layout: BallotPageContestOptionLayout,
-      option: 'yes' | 'no'
+      optionId: 'yes' | 'no'
     ): void => {
       const { score, offset } = this.targetMarkScore(
         template.ballotImage.imageData,
         mappedBallot,
         layout.target
       );
-      debug(`'${option}' mark score: %d`, score);
+      debug(`'${optionId}' mark score: %d`, score);
       const mark: BallotYesNoTargetMark = {
         type: 'yesno',
         bounds: layout.target.bounds,
-        contest,
-        option,
+        contestId: contest.id,
+        optionId,
         score,
         scoredOffset: offset,
         target: layout.target,
@@ -571,8 +573,8 @@ export class Interpreter {
       const mark: BallotMsEitherNeitherTargetMark = {
         type: 'ms-either-neither',
         bounds: layout.target.bounds,
-        contest,
-        option,
+        contestId: contest.id,
+        optionId: option.id,
         score,
         scoredOffset: offset,
         target: layout.target,

--- a/services/scan/src/build_cast_vote_record.ts
+++ b/services/scan/src/build_cast_vote_record.ts
@@ -191,7 +191,9 @@ export function getContestsFromIds(
   election: Election,
   contestIds: readonly string[]
 ): Contests {
-  return contestIds.map((id) => find(election.contests, (c) => c.id === id));
+  return Array.from(new Set(contestIds)).map((id) =>
+    find(election.contests, (c) => c.id === id)
+  );
 }
 
 export function getContestsForBallotStyle(

--- a/services/scan/src/interpreter.test.ts
+++ b/services/scan/src/interpreter.test.ts
@@ -1,10 +1,9 @@
-import { electionSample } from '@votingworks/fixtures';
 import { metadataFromBytes } from '@votingworks/ballot-interpreter-vx';
+import { electionSample } from '@votingworks/fixtures';
 import {
   AdjudicationReason,
   BallotIdSchema,
   BlankPage,
-  DistrictIdSchema,
   Election,
   InterpretedBmdPage,
   InterpretedHmpbPage,
@@ -13,6 +12,7 @@ import {
   UnreadablePage,
   unsafeParse,
 } from '@votingworks/types';
+import { throwIllegalValue } from '@votingworks/utils';
 import { readFile } from 'fs-extra';
 import { join } from 'path';
 import { election as choctaw2020Election } from '../test/fixtures/2020-choctaw';
@@ -20,8 +20,8 @@ import * as general2020Fixtures from '../test/fixtures/2020-general';
 import * as choctaw2020SpecialFixtures from '../test/fixtures/choctaw-2020-09-22-f30480cc99';
 import { election as stateOfHamiltonElection } from '../test/fixtures/state-of-hamilton';
 import {
-  Interpreter,
   getBallotImageData,
+  Interpreter,
   sheetRequiresAdjudication,
 } from './interpreter';
 import { pdfToImages } from './util/pdf_to_images';
@@ -302,58 +302,8 @@ test('interprets marks on an upside-down HMPB', async () => {
               "x": 451,
               "y": 232,
             },
-            "contest": Object {
-              "_lang": Object {
-                "es-US": Object {
-                  "section": "Estados Unidos",
-                  "title": "Presidente y Vicepresidente",
-                },
-              },
-              "allowWriteIns": false,
-              "candidates": Array [
-                Object {
-                  "id": "barchi-hallaren",
-                  "name": "Joseph Barchi and Joseph Hallaren",
-                  "partyId": "0",
-                },
-                Object {
-                  "id": "cramer-vuocolo",
-                  "name": "Adam Cramer and Greg Vuocolo",
-                  "partyId": "1",
-                },
-                Object {
-                  "id": "court-blumhardt",
-                  "name": "Daniel Court and Amy Blumhardt",
-                  "partyId": "2",
-                },
-                Object {
-                  "id": "boone-lian",
-                  "name": "Alvin Boone and James Lian",
-                  "partyId": "3",
-                },
-                Object {
-                  "id": "hildebrand-garritty",
-                  "name": "Ashley Hildebrand-McDougall and James Garritty",
-                  "partyId": "4",
-                },
-                Object {
-                  "id": "patterson-lariviere",
-                  "name": "Martin Patterson and Clay Lariviere",
-                  "partyId": "5",
-                },
-              ],
-              "districtId": "district-1",
-              "id": "president",
-              "seats": 1,
-              "section": "United States",
-              "title": "President and Vice-President",
-              "type": "candidate",
-            },
-            "option": Object {
-              "id": "barchi-hallaren",
-              "name": "Joseph Barchi and Joseph Hallaren",
-              "partyId": "0",
-            },
+            "contestId": "president",
+            "optionId": "barchi-hallaren",
             "score": 0.6550802139037433,
             "scoredOffset": Object {
               "x": 0,
@@ -383,58 +333,8 @@ test('interprets marks on an upside-down HMPB', async () => {
               "x": 451,
               "y": 334,
             },
-            "contest": Object {
-              "_lang": Object {
-                "es-US": Object {
-                  "section": "Estados Unidos",
-                  "title": "Presidente y Vicepresidente",
-                },
-              },
-              "allowWriteIns": false,
-              "candidates": Array [
-                Object {
-                  "id": "barchi-hallaren",
-                  "name": "Joseph Barchi and Joseph Hallaren",
-                  "partyId": "0",
-                },
-                Object {
-                  "id": "cramer-vuocolo",
-                  "name": "Adam Cramer and Greg Vuocolo",
-                  "partyId": "1",
-                },
-                Object {
-                  "id": "court-blumhardt",
-                  "name": "Daniel Court and Amy Blumhardt",
-                  "partyId": "2",
-                },
-                Object {
-                  "id": "boone-lian",
-                  "name": "Alvin Boone and James Lian",
-                  "partyId": "3",
-                },
-                Object {
-                  "id": "hildebrand-garritty",
-                  "name": "Ashley Hildebrand-McDougall and James Garritty",
-                  "partyId": "4",
-                },
-                Object {
-                  "id": "patterson-lariviere",
-                  "name": "Martin Patterson and Clay Lariviere",
-                  "partyId": "5",
-                },
-              ],
-              "districtId": "district-1",
-              "id": "president",
-              "seats": 1,
-              "section": "United States",
-              "title": "President and Vice-President",
-              "type": "candidate",
-            },
-            "option": Object {
-              "id": "cramer-vuocolo",
-              "name": "Adam Cramer and Greg Vuocolo",
-              "partyId": "1",
-            },
+            "contestId": "president",
+            "optionId": "cramer-vuocolo",
             "score": 0,
             "scoredOffset": Object {
               "x": 0,
@@ -464,58 +364,8 @@ test('interprets marks on an upside-down HMPB', async () => {
               "x": 451,
               "y": 436,
             },
-            "contest": Object {
-              "_lang": Object {
-                "es-US": Object {
-                  "section": "Estados Unidos",
-                  "title": "Presidente y Vicepresidente",
-                },
-              },
-              "allowWriteIns": false,
-              "candidates": Array [
-                Object {
-                  "id": "barchi-hallaren",
-                  "name": "Joseph Barchi and Joseph Hallaren",
-                  "partyId": "0",
-                },
-                Object {
-                  "id": "cramer-vuocolo",
-                  "name": "Adam Cramer and Greg Vuocolo",
-                  "partyId": "1",
-                },
-                Object {
-                  "id": "court-blumhardt",
-                  "name": "Daniel Court and Amy Blumhardt",
-                  "partyId": "2",
-                },
-                Object {
-                  "id": "boone-lian",
-                  "name": "Alvin Boone and James Lian",
-                  "partyId": "3",
-                },
-                Object {
-                  "id": "hildebrand-garritty",
-                  "name": "Ashley Hildebrand-McDougall and James Garritty",
-                  "partyId": "4",
-                },
-                Object {
-                  "id": "patterson-lariviere",
-                  "name": "Martin Patterson and Clay Lariviere",
-                  "partyId": "5",
-                },
-              ],
-              "districtId": "district-1",
-              "id": "president",
-              "seats": 1,
-              "section": "United States",
-              "title": "President and Vice-President",
-              "type": "candidate",
-            },
-            "option": Object {
-              "id": "court-blumhardt",
-              "name": "Daniel Court and Amy Blumhardt",
-              "partyId": "2",
-            },
+            "contestId": "president",
+            "optionId": "court-blumhardt",
             "score": 0,
             "scoredOffset": Object {
               "x": 0,
@@ -545,58 +395,8 @@ test('interprets marks on an upside-down HMPB', async () => {
               "x": 451,
               "y": 538,
             },
-            "contest": Object {
-              "_lang": Object {
-                "es-US": Object {
-                  "section": "Estados Unidos",
-                  "title": "Presidente y Vicepresidente",
-                },
-              },
-              "allowWriteIns": false,
-              "candidates": Array [
-                Object {
-                  "id": "barchi-hallaren",
-                  "name": "Joseph Barchi and Joseph Hallaren",
-                  "partyId": "0",
-                },
-                Object {
-                  "id": "cramer-vuocolo",
-                  "name": "Adam Cramer and Greg Vuocolo",
-                  "partyId": "1",
-                },
-                Object {
-                  "id": "court-blumhardt",
-                  "name": "Daniel Court and Amy Blumhardt",
-                  "partyId": "2",
-                },
-                Object {
-                  "id": "boone-lian",
-                  "name": "Alvin Boone and James Lian",
-                  "partyId": "3",
-                },
-                Object {
-                  "id": "hildebrand-garritty",
-                  "name": "Ashley Hildebrand-McDougall and James Garritty",
-                  "partyId": "4",
-                },
-                Object {
-                  "id": "patterson-lariviere",
-                  "name": "Martin Patterson and Clay Lariviere",
-                  "partyId": "5",
-                },
-              ],
-              "districtId": "district-1",
-              "id": "president",
-              "seats": 1,
-              "section": "United States",
-              "title": "President and Vice-President",
-              "type": "candidate",
-            },
-            "option": Object {
-              "id": "boone-lian",
-              "name": "Alvin Boone and James Lian",
-              "partyId": "3",
-            },
+            "contestId": "president",
+            "optionId": "boone-lian",
             "score": 0,
             "scoredOffset": Object {
               "x": 0,
@@ -626,58 +426,8 @@ test('interprets marks on an upside-down HMPB', async () => {
               "x": 451,
               "y": 613,
             },
-            "contest": Object {
-              "_lang": Object {
-                "es-US": Object {
-                  "section": "Estados Unidos",
-                  "title": "Presidente y Vicepresidente",
-                },
-              },
-              "allowWriteIns": false,
-              "candidates": Array [
-                Object {
-                  "id": "barchi-hallaren",
-                  "name": "Joseph Barchi and Joseph Hallaren",
-                  "partyId": "0",
-                },
-                Object {
-                  "id": "cramer-vuocolo",
-                  "name": "Adam Cramer and Greg Vuocolo",
-                  "partyId": "1",
-                },
-                Object {
-                  "id": "court-blumhardt",
-                  "name": "Daniel Court and Amy Blumhardt",
-                  "partyId": "2",
-                },
-                Object {
-                  "id": "boone-lian",
-                  "name": "Alvin Boone and James Lian",
-                  "partyId": "3",
-                },
-                Object {
-                  "id": "hildebrand-garritty",
-                  "name": "Ashley Hildebrand-McDougall and James Garritty",
-                  "partyId": "4",
-                },
-                Object {
-                  "id": "patterson-lariviere",
-                  "name": "Martin Patterson and Clay Lariviere",
-                  "partyId": "5",
-                },
-              ],
-              "districtId": "district-1",
-              "id": "president",
-              "seats": 1,
-              "section": "United States",
-              "title": "President and Vice-President",
-              "type": "candidate",
-            },
-            "option": Object {
-              "id": "hildebrand-garritty",
-              "name": "Ashley Hildebrand-McDougall and James Garritty",
-              "partyId": "4",
-            },
+            "contestId": "president",
+            "optionId": "hildebrand-garritty",
             "score": 0.00267379679144385,
             "scoredOffset": Object {
               "x": 1,
@@ -707,58 +457,8 @@ test('interprets marks on an upside-down HMPB', async () => {
               "x": 451,
               "y": 742,
             },
-            "contest": Object {
-              "_lang": Object {
-                "es-US": Object {
-                  "section": "Estados Unidos",
-                  "title": "Presidente y Vicepresidente",
-                },
-              },
-              "allowWriteIns": false,
-              "candidates": Array [
-                Object {
-                  "id": "barchi-hallaren",
-                  "name": "Joseph Barchi and Joseph Hallaren",
-                  "partyId": "0",
-                },
-                Object {
-                  "id": "cramer-vuocolo",
-                  "name": "Adam Cramer and Greg Vuocolo",
-                  "partyId": "1",
-                },
-                Object {
-                  "id": "court-blumhardt",
-                  "name": "Daniel Court and Amy Blumhardt",
-                  "partyId": "2",
-                },
-                Object {
-                  "id": "boone-lian",
-                  "name": "Alvin Boone and James Lian",
-                  "partyId": "3",
-                },
-                Object {
-                  "id": "hildebrand-garritty",
-                  "name": "Ashley Hildebrand-McDougall and James Garritty",
-                  "partyId": "4",
-                },
-                Object {
-                  "id": "patterson-lariviere",
-                  "name": "Martin Patterson and Clay Lariviere",
-                  "partyId": "5",
-                },
-              ],
-              "districtId": "district-1",
-              "id": "president",
-              "seats": 1,
-              "section": "United States",
-              "title": "President and Vice-President",
-              "type": "candidate",
-            },
-            "option": Object {
-              "id": "patterson-lariviere",
-              "name": "Martin Patterson and Clay Lariviere",
-              "partyId": "5",
-            },
+            "contestId": "president",
+            "optionId": "patterson-lariviere",
             "score": 0,
             "scoredOffset": Object {
               "x": 0,
@@ -788,63 +488,8 @@ test('interprets marks on an upside-down HMPB', async () => {
               "x": 837,
               "y": 168,
             },
-            "contest": Object {
-              "_lang": Object {
-                "es-US": Object {
-                  "section": "Estados Unidos",
-                  "title": "Senador",
-                },
-              },
-              "allowWriteIns": false,
-              "candidates": Array [
-                Object {
-                  "id": "weiford",
-                  "name": "Dennis Weiford",
-                  "partyId": "0",
-                },
-                Object {
-                  "id": "garriss",
-                  "name": "Lloyd Garriss",
-                  "partyId": "1",
-                },
-                Object {
-                  "id": "wentworthfarthington",
-                  "name": "Sylvia Wentworth-Farthington",
-                  "partyId": "2",
-                },
-                Object {
-                  "id": "hewetson",
-                  "name": "Heather Hewetson",
-                  "partyId": "3",
-                },
-                Object {
-                  "id": "martinez",
-                  "name": "Victor Martinez",
-                  "partyId": "4",
-                },
-                Object {
-                  "id": "brown",
-                  "name": "David Brown",
-                  "partyId": "6",
-                },
-                Object {
-                  "id": "pound",
-                  "name": "David Pound",
-                  "partyId": "6",
-                },
-              ],
-              "districtId": "district-2",
-              "id": "senator",
-              "seats": 1,
-              "section": "United States",
-              "title": "Senator",
-              "type": "candidate",
-            },
-            "option": Object {
-              "id": "weiford",
-              "name": "Dennis Weiford",
-              "partyId": "0",
-            },
+            "contestId": "senator",
+            "optionId": "weiford",
             "score": 0.01358695652173913,
             "scoredOffset": Object {
               "x": 0,
@@ -874,63 +519,8 @@ test('interprets marks on an upside-down HMPB', async () => {
               "x": 837,
               "y": 243,
             },
-            "contest": Object {
-              "_lang": Object {
-                "es-US": Object {
-                  "section": "Estados Unidos",
-                  "title": "Senador",
-                },
-              },
-              "allowWriteIns": false,
-              "candidates": Array [
-                Object {
-                  "id": "weiford",
-                  "name": "Dennis Weiford",
-                  "partyId": "0",
-                },
-                Object {
-                  "id": "garriss",
-                  "name": "Lloyd Garriss",
-                  "partyId": "1",
-                },
-                Object {
-                  "id": "wentworthfarthington",
-                  "name": "Sylvia Wentworth-Farthington",
-                  "partyId": "2",
-                },
-                Object {
-                  "id": "hewetson",
-                  "name": "Heather Hewetson",
-                  "partyId": "3",
-                },
-                Object {
-                  "id": "martinez",
-                  "name": "Victor Martinez",
-                  "partyId": "4",
-                },
-                Object {
-                  "id": "brown",
-                  "name": "David Brown",
-                  "partyId": "6",
-                },
-                Object {
-                  "id": "pound",
-                  "name": "David Pound",
-                  "partyId": "6",
-                },
-              ],
-              "districtId": "district-2",
-              "id": "senator",
-              "seats": 1,
-              "section": "United States",
-              "title": "Senator",
-              "type": "candidate",
-            },
-            "option": Object {
-              "id": "garriss",
-              "name": "Lloyd Garriss",
-              "partyId": "1",
-            },
+            "contestId": "senator",
+            "optionId": "garriss",
             "score": 0.008152173913043478,
             "scoredOffset": Object {
               "x": 0,
@@ -960,63 +550,8 @@ test('interprets marks on an upside-down HMPB', async () => {
               "x": 837,
               "y": 318,
             },
-            "contest": Object {
-              "_lang": Object {
-                "es-US": Object {
-                  "section": "Estados Unidos",
-                  "title": "Senador",
-                },
-              },
-              "allowWriteIns": false,
-              "candidates": Array [
-                Object {
-                  "id": "weiford",
-                  "name": "Dennis Weiford",
-                  "partyId": "0",
-                },
-                Object {
-                  "id": "garriss",
-                  "name": "Lloyd Garriss",
-                  "partyId": "1",
-                },
-                Object {
-                  "id": "wentworthfarthington",
-                  "name": "Sylvia Wentworth-Farthington",
-                  "partyId": "2",
-                },
-                Object {
-                  "id": "hewetson",
-                  "name": "Heather Hewetson",
-                  "partyId": "3",
-                },
-                Object {
-                  "id": "martinez",
-                  "name": "Victor Martinez",
-                  "partyId": "4",
-                },
-                Object {
-                  "id": "brown",
-                  "name": "David Brown",
-                  "partyId": "6",
-                },
-                Object {
-                  "id": "pound",
-                  "name": "David Pound",
-                  "partyId": "6",
-                },
-              ],
-              "districtId": "district-2",
-              "id": "senator",
-              "seats": 1,
-              "section": "United States",
-              "title": "Senator",
-              "type": "candidate",
-            },
-            "option": Object {
-              "id": "wentworthfarthington",
-              "name": "Sylvia Wentworth-Farthington",
-              "partyId": "2",
-            },
+            "contestId": "senator",
+            "optionId": "wentworthfarthington",
             "score": 0.01358695652173913,
             "scoredOffset": Object {
               "x": 0,
@@ -1046,63 +581,8 @@ test('interprets marks on an upside-down HMPB', async () => {
               "x": 837,
               "y": 420,
             },
-            "contest": Object {
-              "_lang": Object {
-                "es-US": Object {
-                  "section": "Estados Unidos",
-                  "title": "Senador",
-                },
-              },
-              "allowWriteIns": false,
-              "candidates": Array [
-                Object {
-                  "id": "weiford",
-                  "name": "Dennis Weiford",
-                  "partyId": "0",
-                },
-                Object {
-                  "id": "garriss",
-                  "name": "Lloyd Garriss",
-                  "partyId": "1",
-                },
-                Object {
-                  "id": "wentworthfarthington",
-                  "name": "Sylvia Wentworth-Farthington",
-                  "partyId": "2",
-                },
-                Object {
-                  "id": "hewetson",
-                  "name": "Heather Hewetson",
-                  "partyId": "3",
-                },
-                Object {
-                  "id": "martinez",
-                  "name": "Victor Martinez",
-                  "partyId": "4",
-                },
-                Object {
-                  "id": "brown",
-                  "name": "David Brown",
-                  "partyId": "6",
-                },
-                Object {
-                  "id": "pound",
-                  "name": "David Pound",
-                  "partyId": "6",
-                },
-              ],
-              "districtId": "district-2",
-              "id": "senator",
-              "seats": 1,
-              "section": "United States",
-              "title": "Senator",
-              "type": "candidate",
-            },
-            "option": Object {
-              "id": "hewetson",
-              "name": "Heather Hewetson",
-              "partyId": "3",
-            },
+            "contestId": "senator",
+            "optionId": "hewetson",
             "score": 0,
             "scoredOffset": Object {
               "x": 0,
@@ -1132,63 +612,8 @@ test('interprets marks on an upside-down HMPB', async () => {
               "x": 837,
               "y": 495,
             },
-            "contest": Object {
-              "_lang": Object {
-                "es-US": Object {
-                  "section": "Estados Unidos",
-                  "title": "Senador",
-                },
-              },
-              "allowWriteIns": false,
-              "candidates": Array [
-                Object {
-                  "id": "weiford",
-                  "name": "Dennis Weiford",
-                  "partyId": "0",
-                },
-                Object {
-                  "id": "garriss",
-                  "name": "Lloyd Garriss",
-                  "partyId": "1",
-                },
-                Object {
-                  "id": "wentworthfarthington",
-                  "name": "Sylvia Wentworth-Farthington",
-                  "partyId": "2",
-                },
-                Object {
-                  "id": "hewetson",
-                  "name": "Heather Hewetson",
-                  "partyId": "3",
-                },
-                Object {
-                  "id": "martinez",
-                  "name": "Victor Martinez",
-                  "partyId": "4",
-                },
-                Object {
-                  "id": "brown",
-                  "name": "David Brown",
-                  "partyId": "6",
-                },
-                Object {
-                  "id": "pound",
-                  "name": "David Pound",
-                  "partyId": "6",
-                },
-              ],
-              "districtId": "district-2",
-              "id": "senator",
-              "seats": 1,
-              "section": "United States",
-              "title": "Senator",
-              "type": "candidate",
-            },
-            "option": Object {
-              "id": "martinez",
-              "name": "Victor Martinez",
-              "partyId": "4",
-            },
+            "contestId": "senator",
+            "optionId": "martinez",
             "score": 0.021739130434782608,
             "scoredOffset": Object {
               "x": 0,
@@ -1218,63 +643,8 @@ test('interprets marks on an upside-down HMPB', async () => {
               "x": 837,
               "y": 570,
             },
-            "contest": Object {
-              "_lang": Object {
-                "es-US": Object {
-                  "section": "Estados Unidos",
-                  "title": "Senador",
-                },
-              },
-              "allowWriteIns": false,
-              "candidates": Array [
-                Object {
-                  "id": "weiford",
-                  "name": "Dennis Weiford",
-                  "partyId": "0",
-                },
-                Object {
-                  "id": "garriss",
-                  "name": "Lloyd Garriss",
-                  "partyId": "1",
-                },
-                Object {
-                  "id": "wentworthfarthington",
-                  "name": "Sylvia Wentworth-Farthington",
-                  "partyId": "2",
-                },
-                Object {
-                  "id": "hewetson",
-                  "name": "Heather Hewetson",
-                  "partyId": "3",
-                },
-                Object {
-                  "id": "martinez",
-                  "name": "Victor Martinez",
-                  "partyId": "4",
-                },
-                Object {
-                  "id": "brown",
-                  "name": "David Brown",
-                  "partyId": "6",
-                },
-                Object {
-                  "id": "pound",
-                  "name": "David Pound",
-                  "partyId": "6",
-                },
-              ],
-              "districtId": "district-2",
-              "id": "senator",
-              "seats": 1,
-              "section": "United States",
-              "title": "Senator",
-              "type": "candidate",
-            },
-            "option": Object {
-              "id": "brown",
-              "name": "David Brown",
-              "partyId": "6",
-            },
+            "contestId": "senator",
+            "optionId": "brown",
             "score": 0.5869565217391305,
             "scoredOffset": Object {
               "x": -1,
@@ -1304,63 +674,8 @@ test('interprets marks on an upside-down HMPB', async () => {
               "x": 837,
               "y": 663,
             },
-            "contest": Object {
-              "_lang": Object {
-                "es-US": Object {
-                  "section": "Estados Unidos",
-                  "title": "Senador",
-                },
-              },
-              "allowWriteIns": false,
-              "candidates": Array [
-                Object {
-                  "id": "weiford",
-                  "name": "Dennis Weiford",
-                  "partyId": "0",
-                },
-                Object {
-                  "id": "garriss",
-                  "name": "Lloyd Garriss",
-                  "partyId": "1",
-                },
-                Object {
-                  "id": "wentworthfarthington",
-                  "name": "Sylvia Wentworth-Farthington",
-                  "partyId": "2",
-                },
-                Object {
-                  "id": "hewetson",
-                  "name": "Heather Hewetson",
-                  "partyId": "3",
-                },
-                Object {
-                  "id": "martinez",
-                  "name": "Victor Martinez",
-                  "partyId": "4",
-                },
-                Object {
-                  "id": "brown",
-                  "name": "David Brown",
-                  "partyId": "6",
-                },
-                Object {
-                  "id": "pound",
-                  "name": "David Pound",
-                  "partyId": "6",
-                },
-              ],
-              "districtId": "district-2",
-              "id": "senator",
-              "seats": 1,
-              "section": "United States",
-              "title": "Senator",
-              "type": "candidate",
-            },
-            "option": Object {
-              "id": "pound",
-              "name": "David Pound",
-              "partyId": "6",
-            },
+            "contestId": "senator",
+            "optionId": "pound",
             "score": 0.016304347826086956,
             "scoredOffset": Object {
               "x": 0,
@@ -1390,53 +705,8 @@ test('interprets marks on an upside-down HMPB', async () => {
               "x": 837,
               "y": 913,
             },
-            "contest": Object {
-              "_lang": Object {
-                "es-US": Object {
-                  "section": "Estados Unidos",
-                  "title": "Representante, Distrito 6",
-                },
-              },
-              "allowWriteIns": false,
-              "candidates": Array [
-                Object {
-                  "id": "plunkard",
-                  "name": "Brad Plunkard",
-                  "partyId": "0",
-                },
-                Object {
-                  "id": "reeder",
-                  "name": "Bruce Reeder",
-                  "partyId": "1",
-                },
-                Object {
-                  "id": "schott",
-                  "name": "Brad Schott",
-                  "partyId": "2",
-                },
-                Object {
-                  "id": "tawney",
-                  "name": "Glen Tawney",
-                  "partyId": "3",
-                },
-                Object {
-                  "id": "forrest",
-                  "name": "Carroll Forrest",
-                  "partyId": "4",
-                },
-              ],
-              "districtId": "district-1",
-              "id": "representative-district-6",
-              "seats": 1,
-              "section": "United States",
-              "title": "Representative, District 6",
-              "type": "candidate",
-            },
-            "option": Object {
-              "id": "plunkard",
-              "name": "Brad Plunkard",
-              "partyId": "0",
-            },
+            "contestId": "representative-district-6",
+            "optionId": "plunkard",
             "score": 0,
             "scoredOffset": Object {
               "x": 1,
@@ -1466,53 +736,8 @@ test('interprets marks on an upside-down HMPB', async () => {
               "x": 837,
               "y": 988,
             },
-            "contest": Object {
-              "_lang": Object {
-                "es-US": Object {
-                  "section": "Estados Unidos",
-                  "title": "Representante, Distrito 6",
-                },
-              },
-              "allowWriteIns": false,
-              "candidates": Array [
-                Object {
-                  "id": "plunkard",
-                  "name": "Brad Plunkard",
-                  "partyId": "0",
-                },
-                Object {
-                  "id": "reeder",
-                  "name": "Bruce Reeder",
-                  "partyId": "1",
-                },
-                Object {
-                  "id": "schott",
-                  "name": "Brad Schott",
-                  "partyId": "2",
-                },
-                Object {
-                  "id": "tawney",
-                  "name": "Glen Tawney",
-                  "partyId": "3",
-                },
-                Object {
-                  "id": "forrest",
-                  "name": "Carroll Forrest",
-                  "partyId": "4",
-                },
-              ],
-              "districtId": "district-1",
-              "id": "representative-district-6",
-              "seats": 1,
-              "section": "United States",
-              "title": "Representative, District 6",
-              "type": "candidate",
-            },
-            "option": Object {
-              "id": "reeder",
-              "name": "Bruce Reeder",
-              "partyId": "1",
-            },
+            "contestId": "representative-district-6",
+            "optionId": "reeder",
             "score": 0,
             "scoredOffset": Object {
               "x": 1,
@@ -1542,53 +767,8 @@ test('interprets marks on an upside-down HMPB', async () => {
               "x": 837,
               "y": 1063,
             },
-            "contest": Object {
-              "_lang": Object {
-                "es-US": Object {
-                  "section": "Estados Unidos",
-                  "title": "Representante, Distrito 6",
-                },
-              },
-              "allowWriteIns": false,
-              "candidates": Array [
-                Object {
-                  "id": "plunkard",
-                  "name": "Brad Plunkard",
-                  "partyId": "0",
-                },
-                Object {
-                  "id": "reeder",
-                  "name": "Bruce Reeder",
-                  "partyId": "1",
-                },
-                Object {
-                  "id": "schott",
-                  "name": "Brad Schott",
-                  "partyId": "2",
-                },
-                Object {
-                  "id": "tawney",
-                  "name": "Glen Tawney",
-                  "partyId": "3",
-                },
-                Object {
-                  "id": "forrest",
-                  "name": "Carroll Forrest",
-                  "partyId": "4",
-                },
-              ],
-              "districtId": "district-1",
-              "id": "representative-district-6",
-              "seats": 1,
-              "section": "United States",
-              "title": "Representative, District 6",
-              "type": "candidate",
-            },
-            "option": Object {
-              "id": "schott",
-              "name": "Brad Schott",
-              "partyId": "2",
-            },
+            "contestId": "representative-district-6",
+            "optionId": "schott",
             "score": 0.8850267379679144,
             "scoredOffset": Object {
               "x": 1,
@@ -1618,53 +798,8 @@ test('interprets marks on an upside-down HMPB', async () => {
               "x": 837,
               "y": 1138,
             },
-            "contest": Object {
-              "_lang": Object {
-                "es-US": Object {
-                  "section": "Estados Unidos",
-                  "title": "Representante, Distrito 6",
-                },
-              },
-              "allowWriteIns": false,
-              "candidates": Array [
-                Object {
-                  "id": "plunkard",
-                  "name": "Brad Plunkard",
-                  "partyId": "0",
-                },
-                Object {
-                  "id": "reeder",
-                  "name": "Bruce Reeder",
-                  "partyId": "1",
-                },
-                Object {
-                  "id": "schott",
-                  "name": "Brad Schott",
-                  "partyId": "2",
-                },
-                Object {
-                  "id": "tawney",
-                  "name": "Glen Tawney",
-                  "partyId": "3",
-                },
-                Object {
-                  "id": "forrest",
-                  "name": "Carroll Forrest",
-                  "partyId": "4",
-                },
-              ],
-              "districtId": "district-1",
-              "id": "representative-district-6",
-              "seats": 1,
-              "section": "United States",
-              "title": "Representative, District 6",
-              "type": "candidate",
-            },
-            "option": Object {
-              "id": "tawney",
-              "name": "Glen Tawney",
-              "partyId": "3",
-            },
+            "contestId": "representative-district-6",
+            "optionId": "tawney",
             "score": 0,
             "scoredOffset": Object {
               "x": 1,
@@ -1694,53 +829,8 @@ test('interprets marks on an upside-down HMPB', async () => {
               "x": 837,
               "y": 1213,
             },
-            "contest": Object {
-              "_lang": Object {
-                "es-US": Object {
-                  "section": "Estados Unidos",
-                  "title": "Representante, Distrito 6",
-                },
-              },
-              "allowWriteIns": false,
-              "candidates": Array [
-                Object {
-                  "id": "plunkard",
-                  "name": "Brad Plunkard",
-                  "partyId": "0",
-                },
-                Object {
-                  "id": "reeder",
-                  "name": "Bruce Reeder",
-                  "partyId": "1",
-                },
-                Object {
-                  "id": "schott",
-                  "name": "Brad Schott",
-                  "partyId": "2",
-                },
-                Object {
-                  "id": "tawney",
-                  "name": "Glen Tawney",
-                  "partyId": "3",
-                },
-                Object {
-                  "id": "forrest",
-                  "name": "Carroll Forrest",
-                  "partyId": "4",
-                },
-              ],
-              "districtId": "district-1",
-              "id": "representative-district-6",
-              "seats": 1,
-              "section": "United States",
-              "title": "Representative, District 6",
-              "type": "candidate",
-            },
-            "option": Object {
-              "id": "forrest",
-              "name": "Carroll Forrest",
-              "partyId": "4",
-            },
+            "contestId": "representative-district-6",
+            "optionId": "forrest",
             "score": 0.00267379679144385,
             "scoredOffset": Object {
               "x": 1,
@@ -1876,32 +966,8 @@ test('interprets marks in PNG ballots', async () => {
                 "x": 451,
                 "y": 166,
               },
-              "contest": Object {
-                "allowWriteIns": true,
-                "candidates": Array [
-                  Object {
-                    "id": "1",
-                    "name": "Joe Biden",
-                    "partyId": "2",
-                  },
-                  Object {
-                    "id": "2",
-                    "name": "Donald Trump",
-                    "partyId": "3",
-                  },
-                ],
-                "districtId": "100000275",
-                "id": "1",
-                "seats": 1,
-                "section": "United States",
-                "title": "United States President",
-                "type": "candidate",
-              },
-              "option": Object {
-                "id": "1",
-                "name": "Joe Biden",
-                "partyId": "2",
-              },
+              "contestId": "1",
+              "optionId": "1",
               "score": 0.4090909090909091,
               "scoredOffset": Object {
                 "x": 1,
@@ -1931,32 +997,8 @@ test('interprets marks in PNG ballots', async () => {
                 "x": 451,
                 "y": 241,
               },
-              "contest": Object {
-                "allowWriteIns": true,
-                "candidates": Array [
-                  Object {
-                    "id": "1",
-                    "name": "Joe Biden",
-                    "partyId": "2",
-                  },
-                  Object {
-                    "id": "2",
-                    "name": "Donald Trump",
-                    "partyId": "3",
-                  },
-                ],
-                "districtId": "100000275",
-                "id": "1",
-                "seats": 1,
-                "section": "United States",
-                "title": "United States President",
-                "type": "candidate",
-              },
-              "option": Object {
-                "id": "2",
-                "name": "Donald Trump",
-                "partyId": "3",
-              },
+              "contestId": "1",
+              "optionId": "2",
               "score": 0,
               "scoredOffset": Object {
                 "x": 0,
@@ -1986,32 +1028,8 @@ test('interprets marks in PNG ballots', async () => {
                 "x": 451,
                 "y": 316,
               },
-              "contest": Object {
-                "allowWriteIns": true,
-                "candidates": Array [
-                  Object {
-                    "id": "1",
-                    "name": "Joe Biden",
-                    "partyId": "2",
-                  },
-                  Object {
-                    "id": "2",
-                    "name": "Donald Trump",
-                    "partyId": "3",
-                  },
-                ],
-                "districtId": "100000275",
-                "id": "1",
-                "seats": 1,
-                "section": "United States",
-                "title": "United States President",
-                "type": "candidate",
-              },
-              "option": Object {
-                "id": "__write-in-0",
-                "isWriteIn": true,
-                "name": "Write-In",
-              },
+              "contestId": "1",
+              "optionId": "__write-in-0",
               "score": 0,
               "scoredOffset": Object {
                 "x": 0,
@@ -2041,37 +1059,8 @@ test('interprets marks in PNG ballots', async () => {
                 "x": 451,
                 "y": 525,
               },
-              "contest": Object {
-                "allowWriteIns": true,
-                "candidates": Array [
-                  Object {
-                    "id": "21",
-                    "name": "Mike Espy",
-                    "partyId": "2",
-                  },
-                  Object {
-                    "id": "22",
-                    "name": "Cindy Hyde-Smith",
-                    "partyId": "3",
-                  },
-                  Object {
-                    "id": "23",
-                    "name": "Jimmy Edwards",
-                    "partyId": "4",
-                  },
-                ],
-                "districtId": "100000275",
-                "id": "2",
-                "seats": 1,
-                "section": "United States",
-                "title": "United States Senate",
-                "type": "candidate",
-              },
-              "option": Object {
-                "id": "21",
-                "name": "Mike Espy",
-                "partyId": "2",
-              },
+              "contestId": "2",
+              "optionId": "21",
               "score": 0.008152173913043478,
               "scoredOffset": Object {
                 "x": 0,
@@ -2101,37 +1090,8 @@ test('interprets marks in PNG ballots', async () => {
                 "x": 451,
                 "y": 600,
               },
-              "contest": Object {
-                "allowWriteIns": true,
-                "candidates": Array [
-                  Object {
-                    "id": "21",
-                    "name": "Mike Espy",
-                    "partyId": "2",
-                  },
-                  Object {
-                    "id": "22",
-                    "name": "Cindy Hyde-Smith",
-                    "partyId": "3",
-                  },
-                  Object {
-                    "id": "23",
-                    "name": "Jimmy Edwards",
-                    "partyId": "4",
-                  },
-                ],
-                "districtId": "100000275",
-                "id": "2",
-                "seats": 1,
-                "section": "United States",
-                "title": "United States Senate",
-                "type": "candidate",
-              },
-              "option": Object {
-                "id": "22",
-                "name": "Cindy Hyde-Smith",
-                "partyId": "3",
-              },
+              "contestId": "2",
+              "optionId": "22",
               "score": 0.010869565217391304,
               "scoredOffset": Object {
                 "x": 0,
@@ -2161,37 +1121,8 @@ test('interprets marks in PNG ballots', async () => {
                 "x": 451,
                 "y": 675,
               },
-              "contest": Object {
-                "allowWriteIns": true,
-                "candidates": Array [
-                  Object {
-                    "id": "21",
-                    "name": "Mike Espy",
-                    "partyId": "2",
-                  },
-                  Object {
-                    "id": "22",
-                    "name": "Cindy Hyde-Smith",
-                    "partyId": "3",
-                  },
-                  Object {
-                    "id": "23",
-                    "name": "Jimmy Edwards",
-                    "partyId": "4",
-                  },
-                ],
-                "districtId": "100000275",
-                "id": "2",
-                "seats": 1,
-                "section": "United States",
-                "title": "United States Senate",
-                "type": "candidate",
-              },
-              "option": Object {
-                "id": "23",
-                "name": "Jimmy Edwards",
-                "partyId": "4",
-              },
+              "contestId": "2",
+              "optionId": "23",
               "score": 0.5706521739130435,
               "scoredOffset": Object {
                 "x": 0,
@@ -2221,37 +1152,8 @@ test('interprets marks in PNG ballots', async () => {
                 "x": 451,
                 "y": 750,
               },
-              "contest": Object {
-                "allowWriteIns": true,
-                "candidates": Array [
-                  Object {
-                    "id": "21",
-                    "name": "Mike Espy",
-                    "partyId": "2",
-                  },
-                  Object {
-                    "id": "22",
-                    "name": "Cindy Hyde-Smith",
-                    "partyId": "3",
-                  },
-                  Object {
-                    "id": "23",
-                    "name": "Jimmy Edwards",
-                    "partyId": "4",
-                  },
-                ],
-                "districtId": "100000275",
-                "id": "2",
-                "seats": 1,
-                "section": "United States",
-                "title": "United States Senate",
-                "type": "candidate",
-              },
-              "option": Object {
-                "id": "__write-in-0",
-                "isWriteIn": true,
-                "name": "Write-In",
-              },
+              "contestId": "2",
+              "optionId": "__write-in-0",
               "score": 0.016304347826086956,
               "scoredOffset": Object {
                 "x": 0,
@@ -2281,32 +1183,8 @@ test('interprets marks in PNG ballots', async () => {
                 "x": 451,
                 "y": 1021,
               },
-              "contest": Object {
-                "allowWriteIns": true,
-                "candidates": Array [
-                  Object {
-                    "id": "31",
-                    "name": "Antonia Eliason",
-                    "partyId": "2",
-                  },
-                  Object {
-                    "id": "32",
-                    "name": "Trent Kelly",
-                    "partyId": "3",
-                  },
-                ],
-                "districtId": "100000275",
-                "id": "3",
-                "seats": 1,
-                "section": "United States",
-                "title": "United States US House of Representatives 1st Congressional District",
-                "type": "candidate",
-              },
-              "option": Object {
-                "id": "31",
-                "name": "Antonia Eliason",
-                "partyId": "2",
-              },
+              "contestId": "3",
+              "optionId": "31",
               "score": 0.00267379679144385,
               "scoredOffset": Object {
                 "x": 0,
@@ -2336,32 +1214,8 @@ test('interprets marks in PNG ballots', async () => {
                 "x": 451,
                 "y": 1096,
               },
-              "contest": Object {
-                "allowWriteIns": true,
-                "candidates": Array [
-                  Object {
-                    "id": "31",
-                    "name": "Antonia Eliason",
-                    "partyId": "2",
-                  },
-                  Object {
-                    "id": "32",
-                    "name": "Trent Kelly",
-                    "partyId": "3",
-                  },
-                ],
-                "districtId": "100000275",
-                "id": "3",
-                "seats": 1,
-                "section": "United States",
-                "title": "United States US House of Representatives 1st Congressional District",
-                "type": "candidate",
-              },
-              "option": Object {
-                "id": "32",
-                "name": "Trent Kelly",
-                "partyId": "3",
-              },
+              "contestId": "3",
+              "optionId": "32",
               "score": 0.8529411764705882,
               "scoredOffset": Object {
                 "x": 0,
@@ -2391,32 +1245,8 @@ test('interprets marks in PNG ballots', async () => {
                 "x": 451,
                 "y": 1171,
               },
-              "contest": Object {
-                "allowWriteIns": true,
-                "candidates": Array [
-                  Object {
-                    "id": "31",
-                    "name": "Antonia Eliason",
-                    "partyId": "2",
-                  },
-                  Object {
-                    "id": "32",
-                    "name": "Trent Kelly",
-                    "partyId": "3",
-                  },
-                ],
-                "districtId": "100000275",
-                "id": "3",
-                "seats": 1,
-                "section": "United States",
-                "title": "United States US House of Representatives 1st Congressional District",
-                "type": "candidate",
-              },
-              "option": Object {
-                "id": "__write-in-0",
-                "isWriteIn": true,
-                "name": "Write-In",
-              },
+              "contestId": "3",
+              "optionId": "__write-in-0",
               "score": 0,
               "scoredOffset": Object {
                 "x": 1,
@@ -2446,32 +1276,8 @@ test('interprets marks in PNG ballots', async () => {
                 "x": 837,
                 "y": 198,
               },
-              "contest": Object {
-                "allowWriteIns": true,
-                "candidates": Array [
-                  Object {
-                    "id": "41",
-                    "name": "Josiah Coleman",
-                    "partyId": "12",
-                  },
-                  Object {
-                    "id": "42",
-                    "name": "Percy L. Lynchard Jr.",
-                    "partyId": "12",
-                  },
-                ],
-                "districtId": "100000285",
-                "id": "4",
-                "seats": 1,
-                "section": "State of Mississippi",
-                "title": "Supreme Court District 3 (Northern) Position 1",
-                "type": "candidate",
-              },
-              "option": Object {
-                "id": "41",
-                "name": "Josiah Coleman",
-                "partyId": "12",
-              },
+              "contestId": "4",
+              "optionId": "41",
               "score": 0.010869565217391304,
               "scoredOffset": Object {
                 "x": 0,
@@ -2501,32 +1307,8 @@ test('interprets marks in PNG ballots', async () => {
                 "x": 837,
                 "y": 285,
               },
-              "contest": Object {
-                "allowWriteIns": true,
-                "candidates": Array [
-                  Object {
-                    "id": "41",
-                    "name": "Josiah Coleman",
-                    "partyId": "12",
-                  },
-                  Object {
-                    "id": "42",
-                    "name": "Percy L. Lynchard Jr.",
-                    "partyId": "12",
-                  },
-                ],
-                "districtId": "100000285",
-                "id": "4",
-                "seats": 1,
-                "section": "State of Mississippi",
-                "title": "Supreme Court District 3 (Northern) Position 1",
-                "type": "candidate",
-              },
-              "option": Object {
-                "id": "42",
-                "name": "Percy L. Lynchard Jr.",
-                "partyId": "12",
-              },
+              "contestId": "4",
+              "optionId": "42",
               "score": 0.01358695652173913,
               "scoredOffset": Object {
                 "x": 0,
@@ -2556,32 +1338,8 @@ test('interprets marks in PNG ballots', async () => {
                 "x": 837,
                 "y": 360,
               },
-              "contest": Object {
-                "allowWriteIns": true,
-                "candidates": Array [
-                  Object {
-                    "id": "41",
-                    "name": "Josiah Coleman",
-                    "partyId": "12",
-                  },
-                  Object {
-                    "id": "42",
-                    "name": "Percy L. Lynchard Jr.",
-                    "partyId": "12",
-                  },
-                ],
-                "districtId": "100000285",
-                "id": "4",
-                "seats": 1,
-                "section": "State of Mississippi",
-                "title": "Supreme Court District 3 (Northern) Position 1",
-                "type": "candidate",
-              },
-              "option": Object {
-                "id": "__write-in-0",
-                "isWriteIn": true,
-                "name": "Write-In",
-              },
+              "contestId": "4",
+              "optionId": "__write-in-0",
               "score": 0.7445652173913043,
               "scoredOffset": Object {
                 "x": 0,
@@ -2611,16 +1369,8 @@ test('interprets marks in PNG ballots', async () => {
                 "x": 837,
                 "y": 705,
               },
-              "contest": Object {
-                "description": "Should Mississippi allow qualified patients with debilitating medical conditions, as certified by Mississippi licensed physicians, to use medical marijuana?",
-                "districtId": "100000275",
-                "id": "initiative-65",
-                "section": "State of Mississippi",
-                "shortTitle": "Initiative 65",
-                "title": "Medical Marijuana Amendment - Initiative 65",
-                "type": "yesno",
-              },
-              "option": "yes",
+              "contestId": "initiative-65",
+              "optionId": "yes",
               "score": 0.6005434782608695,
               "scoredOffset": Object {
                 "x": 0,
@@ -2649,16 +1399,8 @@ test('interprets marks in PNG ballots', async () => {
                 "x": 837,
                 "y": 753,
               },
-              "contest": Object {
-                "description": "Should Mississippi allow qualified patients with debilitating medical conditions, as certified by Mississippi licensed physicians, to use medical marijuana?",
-                "districtId": "100000275",
-                "id": "initiative-65",
-                "section": "State of Mississippi",
-                "shortTitle": "Initiative 65",
-                "title": "Medical Marijuana Amendment - Initiative 65",
-                "type": "yesno",
-              },
-              "option": "no",
+              "contestId": "initiative-65",
+              "optionId": "no",
               "score": 0.41847826086956524,
               "scoredOffset": Object {
                 "x": 1,
@@ -2687,16 +1429,8 @@ test('interprets marks in PNG ballots', async () => {
                 "x": 837,
                 "y": 1080,
               },
-              "contest": Object {
-                "description": "Shall Mississippi establish a program to allow the medical use of marijuana products by qualified persons with debilitating medical conditions?",
-                "districtId": "100000275",
-                "id": "initiative-65-a",
-                "section": "State of Mississippi",
-                "shortTitle": "Initiative 65A",
-                "title": "Medical Marijuana Amendment - Initiative 65A",
-                "type": "yesno",
-              },
-              "option": "yes",
+              "contestId": "initiative-65-a",
+              "optionId": "yes",
               "score": 0.41847826086956524,
               "scoredOffset": Object {
                 "x": 0,
@@ -2725,16 +1459,8 @@ test('interprets marks in PNG ballots', async () => {
                 "x": 837,
                 "y": 1128,
               },
-              "contest": Object {
-                "description": "Shall Mississippi establish a program to allow the medical use of marijuana products by qualified persons with debilitating medical conditions?",
-                "districtId": "100000275",
-                "id": "initiative-65-a",
-                "section": "State of Mississippi",
-                "shortTitle": "Initiative 65A",
-                "title": "Medical Marijuana Amendment - Initiative 65A",
-                "type": "yesno",
-              },
-              "option": "no",
+              "contestId": "initiative-65-a",
+              "optionId": "no",
               "score": 0,
               "scoredOffset": Object {
                 "x": 1,
@@ -2842,18 +1568,8 @@ test('interprets marks in PNG ballots', async () => {
                 "x": 64,
                 "y": 501,
               },
-              "contest": Object {
-                "description": "Shall the State of Mississippi adopt the following proposed state flag to replace the current state flag? 
-
-       <svg xmlns=\\"http://www.w3.org/2000/svg\\" xmlns:xlink=\\"http://www.w3.org/1999/xlink\\" viewBox=\\"0 0 625 375\\"><path fill=\\"#fff\\" d=\\"M0 0v375h625V0z\\"/><path fill=\\"#012369\\" d=\\"M243 243H0V0h243z\\"/><path fill=\\"#bc0a29\\" d=\\"M0 250h625v125H0z\\"/><path fill=\\"#012369\\" d=\\"M625 0v125H250V0z\\"/><path id=\\"a\\" fill=\\"#fff\\" d=\\"M121.499 57.502l3.407 10.716 11.092-.021-8.986 6.602 3.448 10.702-8.961-6.635-8.961 6.635 3.448-10.702L107 68.197l11.091.021z\\"/><use transform=\\"translate(43.298 26.307)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(43.299 76.301)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(0 101.305)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(-43.296 76.301)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(-43.297 26.308)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(-74.06 0.186)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(-89.326 40.456)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(-84.155 83.219)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(-59.667 118.656)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(-21.539 138.691)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(21.54 138.69)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(59.669 118.656)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(84.157 83.219)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(89.327 40.458)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(74.062 0.186)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(41.823 -28.386)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(0 -40)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(-41.822 -29.688)\\" xlink:href=\\"#a\\"/><use transform=\\"scale(1.65) translate(-47.9 2.904)\\" xlink:href=\\"#a\\"/></svg>",
-                "districtId": "100000275",
-                "id": "flag-question",
-                "section": "State of Mississippi",
-                "shortTitle": "Mississippi State Flag Referendum",
-                "title": "Mississippi State Flag Referendum",
-                "type": "yesno",
-              },
-              "option": "yes",
+              "contestId": "flag-question",
+              "optionId": "yes",
               "score": 0.6048387096774194,
               "scoredOffset": Object {
                 "x": 0,
@@ -2882,18 +1598,8 @@ test('interprets marks in PNG ballots', async () => {
                 "x": 64,
                 "y": 549,
               },
-              "contest": Object {
-                "description": "Shall the State of Mississippi adopt the following proposed state flag to replace the current state flag? 
-
-       <svg xmlns=\\"http://www.w3.org/2000/svg\\" xmlns:xlink=\\"http://www.w3.org/1999/xlink\\" viewBox=\\"0 0 625 375\\"><path fill=\\"#fff\\" d=\\"M0 0v375h625V0z\\"/><path fill=\\"#012369\\" d=\\"M243 243H0V0h243z\\"/><path fill=\\"#bc0a29\\" d=\\"M0 250h625v125H0z\\"/><path fill=\\"#012369\\" d=\\"M625 0v125H250V0z\\"/><path id=\\"a\\" fill=\\"#fff\\" d=\\"M121.499 57.502l3.407 10.716 11.092-.021-8.986 6.602 3.448 10.702-8.961-6.635-8.961 6.635 3.448-10.702L107 68.197l11.091.021z\\"/><use transform=\\"translate(43.298 26.307)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(43.299 76.301)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(0 101.305)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(-43.296 76.301)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(-43.297 26.308)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(-74.06 0.186)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(-89.326 40.456)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(-84.155 83.219)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(-59.667 118.656)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(-21.539 138.691)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(21.54 138.69)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(59.669 118.656)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(84.157 83.219)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(89.327 40.458)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(74.062 0.186)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(41.823 -28.386)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(0 -40)\\" xlink:href=\\"#a\\"/><use transform=\\"translate(-41.822 -29.688)\\" xlink:href=\\"#a\\"/><use transform=\\"scale(1.65) translate(-47.9 2.904)\\" xlink:href=\\"#a\\"/></svg>",
-                "districtId": "100000275",
-                "id": "flag-question",
-                "section": "State of Mississippi",
-                "shortTitle": "Mississippi State Flag Referendum",
-                "title": "Mississippi State Flag Referendum",
-                "type": "yesno",
-              },
-              "option": "no",
+              "contestId": "flag-question",
+              "optionId": "no",
               "score": 0.01881720430107527,
               "scoredOffset": Object {
                 "x": 0,
@@ -2922,16 +1628,8 @@ test('interprets marks in PNG ballots', async () => {
                 "x": 451,
                 "y": 597,
               },
-              "contest": Object {
-                "description": "Should the state remove the requirement that a candidate for governor or elected state office receive the most votes in a majority of the state's 122 House of Representatives districts (the electoral vote requirement), remove the role of the Mississippi House of Representatives in choosing a winner if no candidate receives majority approval, and provide that a candidate for governor or state office must receive a majority vote of the people to win and that a runoff election will be held between the two highest vote-getters in the event that no candidate receives a majority vote?",
-                "districtId": "100000275",
-                "id": "runoffs-question",
-                "section": "State of Mississippi",
-                "shortTitle": "Remove Electoral Vote Requirement and Establish Runoffs",
-                "title": "Remove Electoral Vote Requirement and Establish Runoffs for Gubernatorial and State Office Elections",
-                "type": "yesno",
-              },
-              "option": "yes",
+              "contestId": "runoffs-question",
+              "optionId": "yes",
               "score": 0.008064516129032258,
               "scoredOffset": Object {
                 "x": 0,
@@ -2960,16 +1658,8 @@ test('interprets marks in PNG ballots', async () => {
                 "x": 451,
                 "y": 645,
               },
-              "contest": Object {
-                "description": "Should the state remove the requirement that a candidate for governor or elected state office receive the most votes in a majority of the state's 122 House of Representatives districts (the electoral vote requirement), remove the role of the Mississippi House of Representatives in choosing a winner if no candidate receives majority approval, and provide that a candidate for governor or state office must receive a majority vote of the people to win and that a runoff election will be held between the two highest vote-getters in the event that no candidate receives a majority vote?",
-                "districtId": "100000275",
-                "id": "runoffs-question",
-                "section": "State of Mississippi",
-                "shortTitle": "Remove Electoral Vote Requirement and Establish Runoffs",
-                "title": "Remove Electoral Vote Requirement and Establish Runoffs for Gubernatorial and State Office Elections",
-                "type": "yesno",
-              },
-              "option": "no",
+              "contestId": "runoffs-question",
+              "optionId": "no",
               "score": 0.46774193548387094,
               "scoredOffset": Object {
                 "x": 0,
@@ -3094,16 +1784,7 @@ const pageInterpretationBoilerplate: InterpretedHmpbPage = {
           x: 451,
           y: 645,
         },
-        contest: {
-          id: 'contest-id',
-          type: 'candidate',
-          candidates: [],
-          seats: 1,
-          allowWriteIns: true,
-          districtId: unsafeParse(DistrictIdSchema, 'foo'),
-          section: 'section',
-          title: 'contest title',
-        },
+        contestId: 'contest-id',
         target: {
           bounds: {
             height: 20,
@@ -3118,7 +1799,7 @@ const pageInterpretationBoilerplate: InterpretedHmpbPage = {
             y: 647,
           },
         },
-        option: { id: '42', name: 'the meaning of life' },
+        optionId: '42',
         score: 0.8,
         scoredOffset: { x: 0, y: 0 },
       },
@@ -3156,9 +1837,7 @@ function withPageNumber(
       return page;
 
     default:
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-expect-error
-      throw new Error(`unknown page type: ${page.type}`);
+      throwIllegalValue(page, 'type');
   }
 }
 

--- a/services/scan/src/interpreter.ts
+++ b/services/scan/src/interpreter.ts
@@ -20,7 +20,6 @@ import {
   BallotPageLayout,
   BallotPageMetadata,
   BallotType,
-  Contests,
   Election,
   err,
   InterpretedBmdPage,
@@ -30,6 +29,7 @@ import {
   Result,
 } from '@votingworks/types';
 import makeDebug from 'debug';
+import { getContestsFromIds } from './build_cast_vote_record';
 import { BallotPageQrcode, SheetOf } from './types';
 import {
   ballotAdjudicationReasons,
@@ -397,16 +397,14 @@ export class Interpreter {
 
     const allReasonInfos: readonly AdjudicationReasonInfo[] = [
       ...ballotAdjudicationReasons(
-        marks.reduce<Contests>(
-          (contests, mark) =>
-            contests.some(({ id }) => id === mark.contest.id)
-              ? contests
-              : [...contests, mark.contest],
-          []
+        getContestsFromIds(
+          this.election,
+          marks.map((m) => m.contestId)
         ),
         {
           optionMarkStatus: (contestId, optionId) =>
             optionMarkStatus({
+              contests: this.election.contests,
               markThresholds: this.markThresholds,
               marks,
               contestId,

--- a/services/scan/src/store.test.ts
+++ b/services/scan/src/store.test.ts
@@ -261,76 +261,79 @@ test('adjudication', async () => {
   const ballotId = await store.addSheet(
     uuid(),
     batchId,
-    [0, 1].map<PageInterpretationWithFiles>((i) => ({
-      originalFilename: i === 0 ? '/front-original.png' : '/back-original.png',
-      normalizedFilename:
-        i === 0 ? '/front-normalized.png' : '/back-normalized.png',
-      interpretation: {
-        type: 'InterpretedHmpbPage',
-        votes: {},
-        markInfo: {
-          ballotSize: { width: 800, height: 1000 },
-          marks: [
-            {
-              type: 'candidate',
-              contest: candidateContests[i],
-              option: candidateContests[i].candidates[0],
-              score: 0.12, // marginal
-              scoredOffset: { x: 0, y: 0 },
-              bounds: zeroRect,
-              target: {
+    [0, 1].map((i) =>
+      typedAs<PageInterpretationWithFiles>({
+        originalFilename:
+          i === 0 ? '/front-original.png' : '/back-original.png',
+        normalizedFilename:
+          i === 0 ? '/front-normalized.png' : '/back-normalized.png',
+        interpretation: {
+          type: 'InterpretedHmpbPage',
+          votes: {},
+          markInfo: {
+            ballotSize: { width: 800, height: 1000 },
+            marks: [
+              {
+                type: 'candidate',
+                contestId: candidateContests[i].id,
+                optionId: candidateContests[i].candidates[0].id,
+                score: 0.12, // marginal
+                scoredOffset: { x: 0, y: 0 },
                 bounds: zeroRect,
-                inner: zeroRect,
+                target: {
+                  bounds: zeroRect,
+                  inner: zeroRect,
+                },
               },
-            },
-            {
-              type: 'yesno',
-              contest: yesnoContests[i],
-              option: yesnoOption,
-              score: 1, // definite
-              scoredOffset: { x: 0, y: 0 },
-              bounds: zeroRect,
-              target: {
+              {
+                type: 'yesno',
+                contestId: yesnoContests[i].id,
+                optionId: yesnoOption,
+                score: 1, // definite
+                scoredOffset: { x: 0, y: 0 },
                 bounds: zeroRect,
-                inner: zeroRect,
+                target: {
+                  bounds: zeroRect,
+                  inner: zeroRect,
+                },
               },
-            },
-          ],
+            ],
+          },
+          metadata: {
+            electionHash: '',
+            ballotStyleId: '12',
+            precinctId: '23',
+            isTestMode: false,
+            pageNumber: 1,
+            locales: { primary: 'en-US' },
+            ballotType: BallotType.Standard,
+          },
+          adjudicationInfo: {
+            requiresAdjudication: true,
+            enabledReasons: [
+              AdjudicationReason.UninterpretableBallot,
+              AdjudicationReason.MarginalMark,
+            ],
+            enabledReasonInfos: [
+              {
+                type: AdjudicationReason.MarginalMark,
+                contestId: candidateContests[i].id,
+                optionId: candidateContests[i].candidates[0].id,
+                optionIndex: 0,
+              },
+              {
+                type: AdjudicationReason.Undervote,
+                contestId: candidateContests[i].id,
+                expected: 1,
+                optionIds: [],
+                optionIndexes: [],
+              },
+            ],
+            ignoredReasonInfos: [],
+          },
         },
-        metadata: {
-          electionHash: '',
-          ballotStyleId: '12',
-          precinctId: '23',
-          isTestMode: false,
-          pageNumber: 1,
-          locales: { primary: 'en-US' },
-          ballotType: BallotType.Standard,
-        },
-        adjudicationInfo: {
-          requiresAdjudication: true,
-          enabledReasons: [
-            AdjudicationReason.UninterpretableBallot,
-            AdjudicationReason.MarginalMark,
-          ],
-          enabledReasonInfos: [
-            {
-              type: AdjudicationReason.MarginalMark,
-              contestId: candidateContests[i].id,
-              optionId: candidateContests[i].candidates[0].id,
-              optionIndex: 0,
-            },
-            {
-              type: AdjudicationReason.Undervote,
-              contestId: candidateContests[i].id,
-              expected: 1,
-              optionIds: [],
-              optionIndexes: [],
-            },
-          ],
-          ignoredReasonInfos: [],
-        },
-      },
-    })) as SheetOf<PageInterpretationWithFiles>
+      })
+    ) as SheetOf<PageInterpretationWithFiles>
   );
 
   // check the review paths

--- a/services/scan/src/util/marks.test.ts
+++ b/services/scan/src/util/marks.test.ts
@@ -1,9 +1,4 @@
-import {
-  BallotMark,
-  DistrictIdSchema,
-  MarkStatus,
-  unsafeParse,
-} from '@votingworks/types';
+import { BallotMark, MarkStatus } from '@votingworks/types';
 import { changesFromMarks, mergeChanges } from './marks';
 
 test('returns an empty object when no changes are given', () => {
@@ -87,45 +82,12 @@ test('changesFromMarks works with ms-either-neither', () => {
     {
       type: 'ms-either-neither',
       bounds: { x: 50, y: 50, width: 50, height: 50 },
-      contest: {
-        id: 'either-neither-1',
-        section: 'State',
-        districtId: unsafeParse(DistrictIdSchema, '1'),
-        type: 'ms-either-neither',
-        title: 'Ballot Measure 1',
-        eitherNeitherContestId: 'either-neither-id',
-        pickOneContestId: 'pick-one-id',
-        description: 'Blah blah',
-        eitherNeitherLabel: 'VOTE FOR APPROVAL OF EITHER, OR AGAINST BOTH',
-        pickOneLabel: 'AND VOTE FOR ONE',
-        eitherOption: {
-          id: 'either-id',
-          label:
-            'FOR APPROVAL OF EITHER Initiative No. 65 OR Alternative Measure No. 65 A',
-        },
-        neitherOption: {
-          id: 'neither-id',
-          label:
-            'AGAINST BOTH Initiative Measure No. 65 AND Alternative Measure No. 65 A',
-        },
-        firstOption: {
-          id: 'first-id',
-          label: 'FOR Initiative Measure No. 65',
-        },
-        secondOption: {
-          id: 'second-id',
-          label: 'FOR Alternative Measure 65 A',
-        },
-      },
+      contestId: 'either-neither-1',
       target: {
         bounds: { x: 50, y: 50, width: 50, height: 50 },
         inner: { x: 50, y: 50, width: 50, height: 50 },
       },
-      option: {
-        id: 'either-id',
-        label:
-          'FOR APPROVAL OF EITHER Initiative No. 65 OR Alternative Measure No. 65 A',
-      },
+      optionId: 'either-id',
       score: 0.9,
       scoredOffset: { x: 0, y: 0 },
     },

--- a/services/scan/src/util/marks.ts
+++ b/services/scan/src/util/marks.ts
@@ -58,13 +58,9 @@ export function changesFromMarks(
   const result: MarksByContestId = {};
 
   for (const mark of marks) {
-    result[mark.contest.id] = {
-      ...(result[mark.contest.id] ?? {}),
-      // mark.option.id works for both candidate and ms-either-neither marks
-      [mark.type === 'yesno' ? mark.option : mark.option.id]: getMarkStatus(
-        mark,
-        markThresholds
-      ),
+    result[mark.contestId] = {
+      ...(result[mark.contestId] ?? {}),
+      [mark.optionId]: getMarkStatus(mark, markThresholds),
     };
   }
 

--- a/services/scan/src/util/option_mark_status.test.ts
+++ b/services/scan/src/util/option_mark_status.test.ts
@@ -27,14 +27,15 @@ test('a yesno mark', () => {
     (c) => c.type === 'yesno'
   ) as YesNoContest;
   const result = optionMarkStatus({
+    contests: election.contests,
     markThresholds,
     marks: [
       {
         type: 'yesno',
         bounds: defaultShape.bounds,
-        contest,
+        contestId: contest.id,
         target: defaultShape,
-        option: 'yes',
+        optionId: 'yes',
         score: 0.5,
         scoredOffset: { x: 1, y: 1 },
       },
@@ -46,6 +47,7 @@ test('a yesno mark', () => {
   expect(result).toBe(MarkStatus.Marked);
 
   const emptyResult = optionMarkStatus({
+    contests: election.contests,
     markThresholds,
     marks: [],
     contestId: contest.id,
@@ -60,14 +62,15 @@ test('a candidate mark', () => {
     (c) => c.type === 'candidate'
   ) as CandidateContest;
   const result = optionMarkStatus({
+    contests: election.contests,
     markThresholds,
     marks: [
       {
         type: 'candidate',
         bounds: defaultShape.bounds,
-        contest,
+        contestId: contest.id,
         target: defaultShape,
-        option: contest.candidates[2],
+        optionId: contest.candidates[2].id,
         score: 0.5,
         scoredOffset: { x: 1, y: 1 },
       },
@@ -79,6 +82,7 @@ test('a candidate mark', () => {
   expect(result).toBe(MarkStatus.Marked);
 
   const emptyResult = optionMarkStatus({
+    contests: election.contests,
     markThresholds,
     marks: [],
     contestId: contest.id,
@@ -94,18 +98,15 @@ test('a candidate write-in mark', () => {
   ) as CandidateContest;
   const optionId = '__write-in-0';
   const result = optionMarkStatus({
+    contests: election.contests,
     markThresholds,
     marks: [
       {
         type: 'candidate',
         bounds: defaultShape.bounds,
-        contest,
+        contestId: contest.id,
         target: defaultShape,
-        option: {
-          id: optionId,
-          name: 'Write-In',
-          isWriteIn: true,
-        },
+        optionId,
         score: 0,
         scoredOffset: { x: 0, y: 0 },
         writeInTextScore: 0.05,
@@ -123,14 +124,15 @@ test('a ms-either-neither mark', () => {
     (c) => c.type === 'ms-either-neither'
   ) as MsEitherNeitherContest;
   const eitherResult = optionMarkStatus({
+    contests: eitherNeitherElection.contests,
     markThresholds,
     marks: [
       {
         type: 'ms-either-neither',
         bounds: defaultShape.bounds,
-        contest,
+        contestId: contest.id,
         target: defaultShape,
-        option: contest.neitherOption,
+        optionId: contest.neitherOption.id,
         score: 0.5,
         scoredOffset: { x: 1, y: 1 },
       },
@@ -142,14 +144,15 @@ test('a ms-either-neither mark', () => {
   expect(eitherResult).toBe(MarkStatus.Marked);
 
   const pickOneResult = optionMarkStatus({
+    contests: eitherNeitherElection.contests,
     markThresholds,
     marks: [
       {
         type: 'ms-either-neither',
         bounds: defaultShape.bounds,
-        contest,
+        contestId: contest.id,
         target: defaultShape,
-        option: contest.firstOption,
+        optionId: contest.firstOption.id,
         score: 0.5,
         scoredOffset: { x: 1, y: 1 },
       },
@@ -161,6 +164,7 @@ test('a ms-either-neither mark', () => {
   expect(pickOneResult).toBe(MarkStatus.Marked);
 
   const emptyResult = optionMarkStatus({
+    contests: eitherNeitherElection.contests,
     markThresholds,
     marks: [],
     contestId: contest.id,


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
_(There was a ticket to do this at some point, but I can't find it.)_ Adding the `contest` and `option` objects to the mark info creates a lot of cruft in the database and in responses from the scan service. This PR replaces them with `contestId` and `optionId`.

## Demo Video or Screenshot
n/a

## Testing Plan 
In addition to automated testing, I did manual testing of bsd and precinct-scanner with the Union County April 6, 2021 election.

## Checklist
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
- [ ] ~I have added JSDoc comments to any newly introduced exports~
