### PR TITLE
fix(scan): correct modal action button order

### DIFF
--- a/frontends/bsd/src/components/export_logs_modal.tsx
+++ b/frontends/bsd/src/components/export_logs_modal.tsx
@@ -179,7 +179,6 @@ export function ExportLogsModal({ onClose, logFileType }: Props): JSX.Element {
   }
 
   if (currentState === ModalState.Done) {
-    const actions = <LinkButton onPress={onClose}>Close</LinkButton>;
     return (
       <Modal
         content={
@@ -197,7 +196,7 @@ export function ExportLogsModal({ onClose, logFileType }: Props): JSX.Element {
           </Prose>
         }
         onOverlayClick={onClose}
-        actions={actions}
+        actions={<LinkButton onPress={onClose}>Close</LinkButton>}
       />
     );
   }
@@ -256,7 +255,6 @@ export function ExportLogsModal({ onClose, logFileType }: Props): JSX.Element {
           onOverlayClick={onClose}
           actions={
             <React.Fragment>
-              <LinkButton onPress={onClose}>Cancel</LinkButton>
               {process.env.NODE_ENV === 'development' && (
                 <Button
                   data-testid="manual-export"
@@ -265,6 +263,7 @@ export function ExportLogsModal({ onClose, logFileType }: Props): JSX.Element {
                   Save
                 </Button>
               )}{' '}
+              <LinkButton onPress={onClose}>Cancel</LinkButton>
             </React.Fragment>
           }
         />
@@ -275,11 +274,7 @@ export function ExportLogsModal({ onClose, logFileType }: Props): JSX.Element {
         <Modal
           content={<Loading />}
           onOverlayClick={onClose}
-          actions={
-            <React.Fragment>
-              <LinkButton onPress={onClose}>Cancel</LinkButton>
-            </React.Fragment>
-          }
+          actions={<LinkButton onPress={onClose}>Cancel</LinkButton>}
         />
       );
     case UsbDriveStatus.mounted: {
@@ -299,11 +294,11 @@ export function ExportLogsModal({ onClose, logFileType }: Props): JSX.Element {
           onOverlayClick={onClose}
           actions={
             <React.Fragment>
-              <LinkButton onPress={onClose}>Cancel</LinkButton>
-              <Button onPress={() => exportResults(true)}>Save As…</Button>
               <Button primary onPress={() => exportResults(false)}>
                 Save
               </Button>
+              <Button onPress={() => exportResults(true)}>Save As…</Button>
+              <LinkButton onPress={onClose}>Cancel</LinkButton>
             </React.Fragment>
           }
         />

--- a/frontends/bsd/src/components/export_results_modal.tsx
+++ b/frontends/bsd/src/components/export_results_modal.tsx
@@ -199,13 +199,13 @@ export function ExportResultsModal({
         onOverlayClick={onClose}
         actions={
           <React.Fragment>
-            <LinkButton onPress={onClose}>Cancel</LinkButton>
             <UsbControllerButton
               small={false}
               primary
               usbDriveStatus={usbDriveStatus}
               usbDriveEject={() => usbDriveEject(currentUserSession.type)}
             />
+            <LinkButton onPress={onClose}>Cancel</LinkButton>
           </React.Fragment>
         }
       />
@@ -292,11 +292,11 @@ export function ExportResultsModal({
           onOverlayClick={onClose}
           actions={
             <React.Fragment>
-              <Button onPress={() => exportResults(true)}>Custom</Button>
-              <LinkButton onPress={onClose}>Cancel</LinkButton>
               <Button primary onPress={() => exportResults(false)}>
                 Export
               </Button>
+              <LinkButton onPress={onClose}>Cancel</LinkButton>
+              <Button onPress={() => exportResults(true)}>Custom</Button>
             </React.Fragment>
           }
         />

--- a/frontends/bsd/src/components/set_mark_thresholds_modal.tsx
+++ b/frontends/bsd/src/components/set_mark_thresholds_modal.tsx
@@ -116,11 +116,7 @@ export function SetMarkThresholdsModal({
             </Prose>
           }
           onOverlayClick={onClose}
-          actions={
-            <React.Fragment>
-              <LinkButton onPress={onClose}>Close</LinkButton>
-            </React.Fragment>
-          }
+          actions={<LinkButton onPress={onClose}>Close</LinkButton>}
         />
       );
     case ModalState.CONFIRM_INTENT:
@@ -139,7 +135,6 @@ export function SetMarkThresholdsModal({
           onOverlayClick={onClose}
           actions={
             <React.Fragment>
-              <LinkButton onPress={onClose}>Close</LinkButton>
               {
                 <Button
                   danger
@@ -148,6 +143,7 @@ export function SetMarkThresholdsModal({
                   Proceed to Override Thresholds
                 </Button>
               }{' '}
+              <LinkButton onPress={onClose}>Close</LinkButton>
             </React.Fragment>
           }
         />
@@ -179,17 +175,15 @@ export function SetMarkThresholdsModal({
           onOverlayClick={onClose}
           actions={
             <React.Fragment>
+              <Button
+                danger
+                onPress={() =>
+                  overrideThresholds(definiteThreshold, marginalThreshold)
+                }
+              >
+                Override Thresholds
+              </Button>{' '}
               <LinkButton onPress={onClose}>Close</LinkButton>
-              {
-                <Button
-                  danger
-                  onPress={() =>
-                    overrideThresholds(definiteThreshold, marginalThreshold)
-                  }
-                >
-                  Override Thresholds
-                </Button>
-              }{' '}
             </React.Fragment>
           }
         />
@@ -225,12 +219,10 @@ export function SetMarkThresholdsModal({
           onOverlayClick={onClose}
           actions={
             <React.Fragment>
+              <Button primary onPress={resetThresholds}>
+                Reset Thresholds
+              </Button>{' '}
               <LinkButton onPress={onClose}>Close</LinkButton>
-              {
-                <Button primary onPress={resetThresholds}>
-                  Reset Thresholds
-                </Button>
-              }{' '}
             </React.Fragment>
           }
         />

--- a/frontends/bsd/src/components/toggle_test_mode_button.tsx
+++ b/frontends/bsd/src/components/toggle_test_mode_button.tsx
@@ -67,7 +67,6 @@ export function ToggleTestModeButton({
           actions={
             !isTogglingTestMode && (
               <React.Fragment>
-                <Button onPress={toggleIsConfirming}>Cancel</Button>
                 <Button
                   data-testid="confirm-toggle"
                   ref={defaultButtonRef}
@@ -76,6 +75,7 @@ export function ToggleTestModeButton({
                 >
                   {isTestMode ? 'Toggle to Live Mode' : 'Toggle to Test Mode'}
                 </Button>
+                <Button onPress={toggleIsConfirming}>Cancel</Button>
               </React.Fragment>
             )
           }

--- a/frontends/bsd/src/screens/admin_actions_screen.tsx
+++ b/frontends/bsd/src/screens/admin_actions_screen.tsx
@@ -50,10 +50,10 @@ export function AdminActionsScreen({
   const [isBackingUp, setIsBackingUp] = useState(false);
   const [backupError, setBackupError] = useState('');
   function toggleIsConfirmingUnconfigure() {
-    return setIsConfirmingUnconfigure((s) => !s);
+    setIsConfirmingUnconfigure((s) => !s);
   }
   function toggleIsDoubleConfirmingUnconfigure() {
-    return setIsDoubleConfirmingUnconfigure((s) => !s);
+    setIsDoubleConfirmingUnconfigure((s) => !s);
   }
   const [isConfirmingZero, setIsConfirmingZero] = useState(false);
   const [exportingLogType, setExportingLogType] = useState<LogFileType>();
@@ -134,11 +134,6 @@ export function AdminActionsScreen({
                   {isBackingUp ? 'Exporting…' : 'Export Backup…'}
                 </Button>
               </p>
-              {process.env.NODE_ENV === 'development' && (
-                <p>
-                  <LinkButton to="/debug">Debug…</LinkButton>
-                </p>
-              )}
               <p>
                 <Button onPress={() => setExportingLogType(LogFileType.Raw)}>
                   Export Logs…
@@ -205,7 +200,6 @@ export function AdminActionsScreen({
           }
           actions={
             <React.Fragment>
-              <Button onPress={toggleIsConfirmingUnconfigure}>Cancel</Button>
               <Button
                 danger
                 onPress={() => {
@@ -215,6 +209,7 @@ export function AdminActionsScreen({
               >
                 Yes, Delete Election Data
               </Button>
+              <Button onPress={toggleIsConfirmingUnconfigure}>Cancel</Button>
             </React.Fragment>
           }
           onOverlayClick={toggleIsConfirmingUnconfigure}
@@ -231,9 +226,6 @@ export function AdminActionsScreen({
           }
           actions={
             <React.Fragment>
-              <Button onPress={toggleIsDoubleConfirmingUnconfigure}>
-                Cancel
-              </Button>
               <Button
                 danger
                 onPress={() => {
@@ -242,6 +234,9 @@ export function AdminActionsScreen({
                 }}
               >
                 I am sure. Delete all election data.
+              </Button>
+              <Button onPress={toggleIsDoubleConfirmingUnconfigure}>
+                Cancel
               </Button>
             </React.Fragment>
           }

--- a/libs/ui/src/modal.tsx
+++ b/libs/ui/src/modal.tsx
@@ -70,6 +70,12 @@ interface Props {
   ariaHideApp?: boolean;
   content?: ReactNode;
   centerContent?: boolean;
+  /**
+   * Modal actions go here, most likely buttons. The primary action (such as
+   * "Save") should be first under a fragment, and the secondary actions (such
+   * as "Cancel") should after that in the order they should be presented from
+   * left to right.
+   */
   actions?: ReactNode;
   onAfterOpen?: () => void;
   onOverlayClick?: () => void;


### PR DESCRIPTION
## Overview
Some of this was fixed in https://github.com/votingworks/vxsuite/pull/1450, but there were still some modals with the wrong order. This fixes the remaining ones I could easily find.

## Demo Video or Screenshot
|Broken|Fixed|
|-|-|
|![image (1)](https://user-images.githubusercontent.com/1938/156270886-15ee0e28-3ce7-417c-82d0-2f1f80d0d578.png)|![image](https://user-images.githubusercontent.com/1938/156270908-aa38ae5d-ba71-49df-bc83-8e0937404a93.png)|


## Testing Plan 
Manual testing of various VxCentralScan screens.

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
