### PR TITLE
docs(ui): explain `Modal` action a11y

### DIFF
--- a/libs/ui/src/modal.tsx
+++ b/libs/ui/src/modal.tsx
@@ -75,6 +75,13 @@ interface Props {
    * "Save") should be first under a fragment, and the secondary actions (such
    * as "Cancel") should be after that in the order they should be presented
    * from left to right.
+   *
+   * This ordering is primarily for accessibility. The primary action being
+   * first makes it the easiest one to activate when using an accessible
+   * controller. The first secondary action is likely a cancellation or
+   * dismissal action and is still common, albeit less than the primary
+   * action. Further actions are likely a variation on the primary action
+   * (such as "Save As") and are less common.
    */
   actions?: ReactNode;
   onAfterOpen?: () => void;


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Adds some explanation for why the action buttons are ordered the way they are.

## Demo Video or Screenshot
n/a

## Testing Plan 
n/a

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
