### PR TITLE
test(scan): export `election` and `electionDefinition`

### DIFF
--- a/libs/ballot-interpreter-vx/test/fixtures/choctaw-2020-09-22-f30480cc99/index.ts
+++ b/libs/ballot-interpreter-vx/test/fixtures/choctaw-2020-09-22-f30480cc99/index.ts
@@ -1,9 +1,12 @@
-import { parseElection } from '@votingworks/types';
+import { safeParseElectionDefinition } from '@votingworks/types';
 import { join } from 'path';
+import { readFileSync } from 'fs';
 import { Fixture } from '../../fixtures';
-import electionJson from './election.json';
 
-export const election = parseElection(electionJson);
+export const electionDefinition = safeParseElectionDefinition(
+  readFileSync(join(__dirname, 'election.json'), 'utf-8')
+).unsafeUnwrap();
+export const { election } = electionDefinition;
 export const ballotPdf = new Fixture(join(__dirname, 'ballot.pdf'));
 export const blankPage1 = new Fixture(join(__dirname, 'blank-p1.png'));
 export const blankPage2 = new Fixture(join(__dirname, 'blank-p2.png'));

--- a/libs/ballot-interpreter-vx/test/fixtures/choctaw-county-2020-general-election/index.ts
+++ b/libs/ballot-interpreter-vx/test/fixtures/choctaw-county-2020-general-election/index.ts
@@ -1,9 +1,12 @@
-import { parseElection } from '@votingworks/types';
+import { safeParseElectionDefinition } from '@votingworks/types';
 import { join } from 'path';
+import { readFileSync } from 'fs';
 import { Fixture } from '../../fixtures';
-import electionJson from './election.json';
 
-export const election = parseElection(electionJson);
+export const electionDefinition = safeParseElectionDefinition(
+  readFileSync(join(__dirname, 'election.json'), 'utf-8')
+).unsafeUnwrap();
+export const { election } = electionDefinition;
 export const filledInPage1_01 = new Fixture(
   join(__dirname, 'filled-in-p1-01.png')
 );

--- a/libs/ballot-interpreter-vx/test/fixtures/choctaw-county-mock-general-election-choctaw-2020-e87f23ca2c/index.ts
+++ b/libs/ballot-interpreter-vx/test/fixtures/choctaw-county-mock-general-election-choctaw-2020-e87f23ca2c/index.ts
@@ -1,9 +1,12 @@
-import { parseElection } from '@votingworks/types';
+import { safeParseElectionDefinition } from '@votingworks/types';
 import { join } from 'path';
+import { readFileSync } from 'fs';
 import { Fixture } from '../../fixtures';
-import electionJson from './election.json';
 
-export const election = parseElection(electionJson);
+export const electionDefinition = safeParseElectionDefinition(
+  readFileSync(join(__dirname, 'election.json'), 'utf-8')
+).unsafeUnwrap();
+export const { election } = electionDefinition;
 export const blankPage1 = new Fixture(join(__dirname, 'blank-p1.png'));
 export const blankPage2 = new Fixture(join(__dirname, 'blank-p2.png'));
 export const filledInPage1 = new Fixture(join(__dirname, 'filled-in-p1.png'));

--- a/libs/ballot-interpreter-vx/test/fixtures/election-4e31cb17d8-ballot-style-77-precinct-oaklawn-branch-library/index.ts
+++ b/libs/ballot-interpreter-vx/test/fixtures/election-4e31cb17d8-ballot-style-77-precinct-oaklawn-branch-library/index.ts
@@ -1,9 +1,12 @@
-import { parseElection } from '@votingworks/types';
+import { safeParseElectionDefinition } from '@votingworks/types';
+import { readFileSync } from 'fs';
 import { join } from 'path';
 import { Fixture } from '../../fixtures';
-import electionJson from './election.json';
 
-export const election = parseElection(electionJson);
+export const electionDefinition = safeParseElectionDefinition(
+  readFileSync(join(__dirname, 'election.json'), 'utf-8')
+).unsafeUnwrap();
+export const { election } = electionDefinition;
 export const electionPath = join(__dirname, 'election.json');
 export const blankPage1 = new Fixture(join(__dirname, 'blank-p1.jpg'));
 export const blankPage2 = new Fixture(join(__dirname, 'blank-p2.jpg'));

--- a/libs/ballot-interpreter-vx/test/fixtures/election-5c6e578acf-state-of-hamilton-2020/index.ts
+++ b/libs/ballot-interpreter-vx/test/fixtures/election-5c6e578acf-state-of-hamilton-2020/index.ts
@@ -1,9 +1,12 @@
-import { parseElection } from '@votingworks/types';
+import { safeParseElectionDefinition } from '@votingworks/types';
+import { readFileSync } from 'fs';
 import { join } from 'path';
 import { Fixture } from '../../fixtures';
-import electionJson from './election.json';
 
-export const election = parseElection(electionJson);
+export const electionDefinition = safeParseElectionDefinition(
+  readFileSync(join(__dirname, 'election.json'), 'utf-8')
+).unsafeUnwrap();
+export const { election } = electionDefinition;
 export const blankPage1 = new Fixture(join(__dirname, 'blank-p1.jpg'));
 export const blankPage2 = new Fixture(join(__dirname, 'blank-p2.jpg'));
 export const blankPage3 = new Fixture(join(__dirname, 'blank-p3.jpg'));

--- a/libs/ballot-interpreter-vx/test/fixtures/election-7c61368c3b-choctaw-general-2020/index.ts
+++ b/libs/ballot-interpreter-vx/test/fixtures/election-7c61368c3b-choctaw-general-2020/index.ts
@@ -1,9 +1,12 @@
-import { parseElection } from '@votingworks/types';
+import { safeParseElectionDefinition } from '@votingworks/types';
+import { readFileSync } from 'fs';
 import { join } from 'path';
 import { Fixture } from '../../fixtures';
-import electionJson from './election.json';
 
-export const election = parseElection(electionJson);
+export const electionDefinition = safeParseElectionDefinition(
+  readFileSync(join(__dirname, 'election.json'), 'utf-8')
+).unsafeUnwrap();
+export const { election } = electionDefinition;
 export const blankPage1 = new Fixture(join(__dirname, 'blank-p1.png'));
 export const blankPage2 = new Fixture(join(__dirname, 'blank-p2.png'));
 export const filledInPage1 = new Fixture(join(__dirname, 'filled-in-p1.png'));

--- a/libs/ballot-interpreter-vx/test/fixtures/election-98f5203139-choctaw-general-2019/index.ts
+++ b/libs/ballot-interpreter-vx/test/fixtures/election-98f5203139-choctaw-general-2019/index.ts
@@ -1,9 +1,12 @@
-import { parseElection } from '@votingworks/types';
+import { safeParseElectionDefinition } from '@votingworks/types';
+import { readFileSync } from 'fs';
 import { join } from 'path';
 import { Fixture } from '../../fixtures';
-import electionJson from './election.json';
 
-export const election = parseElection(electionJson);
+export const electionDefinition = safeParseElectionDefinition(
+  readFileSync(join(__dirname, 'election.json'), 'utf-8')
+).unsafeUnwrap();
+export const { election } = electionDefinition;
 export const blankPage1 = new Fixture(join(__dirname, 'blank-p1.jpg'));
 export const blankPage2 = new Fixture(join(__dirname, 'blank-p2.jpg'));
 export const blankPage3 = new Fixture(join(__dirname, 'blank-p3.jpg'));


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
There are future changes I'd like to make that need `electionDefinition`. Specifically, I am redoing some of the template scanning stuff to not require the PDFs to interpret a ballot. Doing so in the tests will mean that I need to generate a layout object of some sort based on the PDFs and the election definition (for the election hash).

## Demo Video or Screenshot
n/a

## Testing Plan 
n/a

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
