### PR TITLE
fix(smartcards): Fix race condition in testCardReader.py

### DIFF
--- a/services/smartcards/testCardReader.py
+++ b/services/smartcards/testCardReader.py
@@ -25,7 +25,7 @@ def wait_for_card():
         print("Insert card")
     while True:
         time.sleep(REFRESH_INTERVAL)
-        if CardInterface.card:
+        if CardInterface.card and CardInterface.card_ready:
             break
     print("Card inserted")
     if not CardInterface.card.write_enabled:


### PR DESCRIPTION
## Overview
The card observer class secretly runs a separate thread, so all of the
class methods are not guaranteed to block the main thread. My script
assumed that the main thread would block.

The CardObserver class's `update` method sets `self.card`, then does an initial read, then sets `self.card_ready`. I was checking `self.card`, thinking that would
only be non-null once the entire method had run, which was not true.

## Demo Video or Screenshot
N/A
## Testing Plan 
Manual test
## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
