### PR TITLE
chore(scan): use `esbuild-runner` for `vx` CLI

### DIFF
--- a/libs/ballot-interpreter-vx/bin/ballot-interpreter-vx.js
+++ b/libs/ballot-interpreter-vx/bin/ballot-interpreter-vx.js
@@ -1,9 +1,13 @@
 #!/usr/bin/env node
-const main = require('../dist/src/cli').default
 
-main(process.argv, process.stdin, process.stdout, process.stderr).catch(
-  (error) => {
-    console.error(error)
-    process.exit(1)
-  }
-)
+require('esbuild-runner/register');
+
+require('../src/cli')
+  .main(process.argv, process.stdin, process.stdout, process.stderr)
+  .then((code) => {
+    process.exitCode = code;
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/libs/ballot-interpreter-vx/jest.config.js
+++ b/libs/ballot-interpreter-vx/jest.config.js
@@ -1,4 +1,4 @@
-const shared = require('../../jest.config.shared')
+const shared = require('../../jest.config.shared');
 
 module.exports = {
   ...shared,
@@ -11,4 +11,4 @@ module.exports = {
       lines: 94,
     },
   },
-}
+};

--- a/libs/ballot-interpreter-vx/package.json
+++ b/libs/ballot-interpreter-vx/package.json
@@ -66,6 +66,8 @@
     "@typescript-eslint/eslint-plugin": "^4.28.4",
     "@typescript-eslint/parser": "^4.28.4",
     "benchmark": "^2.1.4",
+    "esbuild": "^0.14.25",
+    "esbuild-runner": "^2.2.1",
     "eslint": "^7.17.0",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-prettier": "^8.3.0",

--- a/libs/ballot-interpreter-vx/src/cli/commands/index.ts
+++ b/libs/ballot-interpreter-vx/src/cli/commands/index.ts
@@ -1,0 +1,27 @@
+import { Command } from '../types';
+import * as helpCommand from './help';
+import * as interpretCommand from './interpret';
+import * as layoutCommand from './layout';
+
+export function get(): Command[] {
+  return [
+    {
+      name: helpCommand.name,
+      description: helpCommand.description,
+      printHelp: helpCommand.printHelp,
+      run: helpCommand.run,
+    },
+    {
+      name: interpretCommand.name,
+      description: interpretCommand.description,
+      printHelp: interpretCommand.printHelp,
+      run: interpretCommand.run,
+    },
+    {
+      name: layoutCommand.name,
+      description: layoutCommand.description,
+      printHelp: layoutCommand.printHelp,
+      run: layoutCommand.run,
+    },
+  ];
+}

--- a/libs/ballot-interpreter-vx/src/cli/index.test.ts
+++ b/libs/ballot-interpreter-vx/src/cli/index.test.ts
@@ -1,0 +1,11 @@
+import { parseGlobalOptions } from '.';
+
+test('unknown option', () => {
+  expect(
+    parseGlobalOptions([
+      'node',
+      'ballot-interpreter-vx',
+      '--nope',
+    ]).unsafeUnwrapErr().message
+  ).toEqual('Unknown global option: --nope');
+});

--- a/libs/ballot-interpreter-vx/src/cli/types.ts
+++ b/libs/ballot-interpreter-vx/src/cli/types.ts
@@ -1,0 +1,20 @@
+export interface Command {
+  name: string;
+  description: string;
+  printHelp(globalOptions: GlobalOptions, out: NodeJS.WritableStream): void;
+  run(
+    commands: readonly Command[],
+    globalOptions: GlobalOptions,
+    stdin: NodeJS.ReadableStream,
+    stdout: NodeJS.WritableStream,
+    stderr: NodeJS.WritableStream
+  ): Promise<number>;
+}
+
+export interface GlobalOptions {
+  nodePath: string;
+  executablePath: string;
+  help: boolean;
+  command: string;
+  commandArgs: readonly string[];
+}

--- a/libs/ballot-interpreter-vx/src/types.ts
+++ b/libs/ballot-interpreter-vx/src/types.ts
@@ -34,6 +34,7 @@ export interface UninterpretedBallot {
 export interface Input {
   id(): string;
   imageData(): Promise<ImageData>;
+  metadataPath(): string;
   metadata?: () => Promise<BallotPageMetadata | undefined>;
 }
 

--- a/libs/ballot-interpreter-vx/test/fixtures.ts
+++ b/libs/ballot-interpreter-vx/test/fixtures.ts
@@ -33,12 +33,16 @@ export class Fixture implements Input {
     return imageData;
   }
 
+  metadataPath(): string {
+    return adjacentMetadataFile(this.filePath());
+  }
+
   async metadata(
     overrides: Partial<BallotPageMetadata> = {}
   ): Promise<BallotPageMetadata> {
     return {
       ...safeParseJson(
-        await fs.readFile(adjacentMetadataFile(this.filePath()), 'utf8'),
+        await fs.readFile(this.metadataPath(), 'utf-8'),
         BallotPageMetadataSchema
       ).unsafeUnwrap(),
       ...overrides,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1061,6 +1061,8 @@ importers:
       '@typescript-eslint/eslint-plugin': 4.28.4_852673d3af9c7ab8ae779b8d717157c6
       '@typescript-eslint/parser': 4.28.4_eslint@7.17.0+typescript@4.3.5
       benchmark: 2.1.4
+      esbuild: 0.14.25
+      esbuild-runner: 2.2.1_esbuild@0.14.25
       eslint: 7.17.0
       eslint-config-airbnb-base: 14.2.1_a48282ca36857a4742d209c622f39c11
       eslint-config-prettier: 8.3.0_eslint@7.17.0
@@ -1101,6 +1103,8 @@ importers:
       canvas: ^2.6.1
       chalk: ^4.1.0
       debug: ^4.2.0
+      esbuild: ^0.14.25
+      esbuild-runner: ^2.2.1
       eslint: ^7.17.0
       eslint-config-airbnb-base: ^14.2.1
       eslint-config-prettier: ^8.3.0
@@ -19705,7 +19709,7 @@ packages:
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.1
-      jest: 27.3.1
+      jest: 27.3.1_canvas@2.6.1+ts-node@9.1.1
       jest-regex-util: 27.0.1
       jest-watcher: 27.0.2
       slash: 3.0.0
@@ -26579,7 +26583,7 @@ packages:
       '@types/jest': 27.0.3
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 27.3.1_canvas@2.6.1
+      jest: 27.3.1_canvas@2.6.1+ts-node@9.1.1
       jest-util: 27.3.1
       json5: 2.2.0
       lodash.memoize: 4.1.2


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
This CLI only worked when the project was built and required a rebuild for changes to the `.ts` files to be reflected. This commit switches to translating to `.js` on the fly using `esbuild-runner`. This would have been a simple change that only touched `bin/ballot-interpreter-vx.js`, but `esbuild` works a little bit differently from `tsc`. In particular, it translates ES imports/exports to CommonJS in a way that makes circular imports not work in some cases where they would with `tsc`. Since the `help` command was referring to `index` and vice versa, this code failed to run correctly under `esbuild-runner`. To fix it I changed the structure to no longer have cycles. While I was in there I improved the tests a bit and stopped throwing exceptions for non-exceptional things like invalid command arguments.

## Demo Video or Screenshot
Output of `layout` command run on one of the fixtures:
![image](https://user-images.githubusercontent.com/1938/157328836-cb2bf394-d532-4e9a-a8b1-0e9a6ae70512.png)

## Testing Plan 
Automated testing, plus a bunch of manual testing.

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] ~I have added JSDoc comments to any newly introduced exports~
