### PR TITLE
chore(scan): remove `flipped` template option

### DIFF
--- a/libs/ballot-interpreter-vx/src/interpreter/index.ts
+++ b/libs/ballot-interpreter-vx/src/interpreter/index.ts
@@ -168,14 +168,12 @@ export class Interpreter {
    */
   async interpretTemplate(
     imageData: ImageData,
-    metadata?: BallotPageMetadata,
-    { flipped = false } = {}
+    metadata?: BallotPageMetadata
   ): Promise<BallotPageLayoutWithImage> {
     return interpretTemplate({
       election: this.election,
       imageData,
       metadata,
-      flipped,
       detectQrCode: this.detectQrCode,
     });
   }

--- a/libs/ballot-interpreter-vx/src/layout.ts
+++ b/libs/ballot-interpreter-vx/src/layout.ts
@@ -91,13 +91,11 @@ export async function interpretTemplate({
   election,
   imageData,
   metadata,
-  flipped = false,
   detectQrCode,
 }: {
   election: Election;
   imageData: ImageData;
   metadata?: BallotPageMetadata;
-  flipped?: boolean;
   detectQrCode?: DetectQrCode;
 }): Promise<BallotPageLayoutWithImage> {
   debug(
@@ -109,7 +107,6 @@ export async function interpretTemplate({
     election,
     imageData,
     metadata,
-    flipped,
     detectQrCode,
   });
 


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
Template images are never flipped (rotated 180) anymore since we never get them by scanning an unmarked ballot, but instead the template images come from rendering a PDF.

## Demo Video or Screenshot
n/a

## Testing Plan 
Automated testing.

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
