### PR TITLE
feat(precinct-scanner): Scanner Not Detected screen

### DIFF
--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -64,6 +64,7 @@ import { AppContext } from './contexts/app_context';
 import { SetupPowerPage } from './screens/setup_power_page';
 import { UnlockAdminScreen } from './screens/unlock_admin_screen';
 import { CardErrorScreen } from './screens/card_error_screen';
+import { SetupScannerScreen } from './screens/setup_scanner_screen';
 
 const debug = makeDebug('precinct-scanner:app-root');
 
@@ -333,7 +334,12 @@ export function AppRoot({
   const usbDriveDisplayStatus =
     usbDrive.status ?? usbstick.UsbDriveStatus.absent;
 
-  const { cardReader, computer, printer: printerInfo } = useDevices({
+  const {
+    cardReader,
+    computer,
+    printer: printerInfo,
+    precinctScanner,
+  } = useDevices({
     hardware,
     logger,
   });
@@ -560,6 +566,7 @@ export function AppRoot({
 
   useEffect(() => {
     if (
+      precinctScanner &&
       isScannerConfigured &&
       electionDefinition &&
       isPollsOpen &&
@@ -570,7 +577,13 @@ export function AppRoot({
       endBallotStatusPolling();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isScannerConfigured, electionDefinition, isPollsOpen, hasCardInserted]);
+  }, [
+    precinctScanner,
+    isScannerConfigured,
+    electionDefinition,
+    isPollsOpen,
+    hasCardInserted,
+  ]);
 
   const setElectionDefinition = useCallback(
     async (newElectionDefinition: OptionalElectionDefinition) => {
@@ -693,6 +706,10 @@ export function AppRoot({
 
   if (computer.batteryIsLow && !computer.batteryIsCharging) {
     return <SetupPowerPage />;
+  }
+
+  if (!precinctScanner) {
+    return <SetupScannerScreen />;
   }
 
   if (!isScannerConfigured) {

--- a/frontends/precinct-scanner/src/preview_app.tsx
+++ b/frontends/precinct-scanner/src/preview_app.tsx
@@ -21,6 +21,7 @@ import * as ScanProcessingScreen from './screens/scan_processing_screen';
 import * as ScanSuccessScreen from './screens/scan_success_screen';
 import * as ScanWarningScreen from './screens/scan_warning_screen';
 import * as SetupPowerPage from './screens/setup_power_page';
+import * as SetupScannerScreen from './screens/setup_scanner_screen';
 import * as UnconfiguredElectionScreen from './screens/unconfigured_election_screen';
 import * as UnlockAdminScreen from './screens/unlock_admin_screen';
 
@@ -45,6 +46,7 @@ export function PreviewApp(): JSX.Element {
         ScanSuccessScreen,
         ScanWarningScreen,
         SetupPowerPage,
+        SetupScannerScreen,
         UnconfiguredElectionScreen,
         UnlockAdminScreen,
       ]}

--- a/frontends/precinct-scanner/src/screens/setup_scanner_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/setup_scanner_screen.tsx
@@ -1,30 +1,18 @@
-import React, { useEffect } from 'react';
-import { fontSizeTheme, Main, MainChild, Prose, Screen } from '@votingworks/ui';
+import React from 'react';
+import { CenteredScreen, CenteredLargeProse } from '../components/layout';
 
-function doNothing() {
-  // do nothing
-}
-
-interface Props {
-  useEffectToggleLargeDisplay?: () => void;
-}
-
-export function SetupScannerScreen({
-  useEffectToggleLargeDisplay = doNothing,
-}: Props): JSX.Element {
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(useEffectToggleLargeDisplay, []);
-
+export function SetupScannerScreen(): JSX.Element {
   return (
-    <Screen white>
-      <Main>
-        <MainChild center maxWidth={false}>
-          <Prose textCenter maxWidth={false} theme={fontSizeTheme.large}>
-            <h1>Scanner Not Detected</h1>
-            <p>Please ask a poll worker to connect scanner.</p>
-          </Prose>
-        </MainChild>
-      </Main>
-    </Screen>
+    <CenteredScreen infoBar={false}>
+      <CenteredLargeProse>
+        <h1>Scanner Not Detected</h1>
+        <p>Please ask a poll worker to connect scanner.</p>
+      </CenteredLargeProse>
+    </CenteredScreen>
   );
+}
+
+/* istanbul ignore next */
+export function DefaultPreview(): JSX.Element {
+  return <SetupScannerScreen />;
 }

--- a/frontends/precinct-scanner/src/screens/setup_scanner_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/setup_scanner_screen.tsx
@@ -1,0 +1,30 @@
+import React, { useEffect } from 'react';
+import { fontSizeTheme, Main, MainChild, Prose, Screen } from '@votingworks/ui';
+
+function doNothing() {
+  // do nothing
+}
+
+interface Props {
+  useEffectToggleLargeDisplay?: () => void;
+}
+
+export function SetupScannerScreen({
+  useEffectToggleLargeDisplay = doNothing,
+}: Props): JSX.Element {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(useEffectToggleLargeDisplay, []);
+
+  return (
+    <Screen white>
+      <Main>
+        <MainChild center maxWidth={false}>
+          <Prose textCenter maxWidth={false} theme={fontSizeTheme.large}>
+            <h1>Scanner Not Detected</h1>
+            <p>Please ask a poll worker to connect scanner.</p>
+          </Prose>
+        </MainChild>
+      </Main>
+    </Screen>
+  );
+}

--- a/libs/utils/src/Hardware/memory_hardware.test.ts
+++ b/libs/utils/src/Hardware/memory_hardware.test.ts
@@ -15,6 +15,7 @@ it('has a standard config with all the typical hardware', async () => {
           'USB Advanced Audio Device',
           'HL-L5100DN_series',
           'Scanner',
+          'Sheetfed Scanner',
         ])
       );
 

--- a/libs/utils/src/Hardware/memory_hardware.ts
+++ b/libs/utils/src/Hardware/memory_hardware.ts
@@ -12,6 +12,8 @@ import {
   OmniKeyCardReaderVendorId,
   FujitsuScannerVendorId,
   FujitsuFi7160ScannerProductId,
+  PlustekScannerVendorId,
+  PlustekVtm300ScannerProductId,
 } from './utils';
 
 const DEFAULT_BATTERY_STATUS: KioskBrowser.BatteryInfo = {
@@ -67,16 +69,28 @@ export class MemoryHardware implements Hardware {
     serialNumber: '',
   };
 
+  private precinctScanner: Readonly<KioskBrowser.Device> = {
+    deviceAddress: 0,
+    deviceName: 'Sheetfed Scanner',
+    locationId: 0,
+    manufacturer: 'Plustek Inc.',
+    vendorId: PlustekScannerVendorId,
+    productId: PlustekVtm300ScannerProductId,
+    serialNumber: '',
+  };
+
   static async build({
     connectPrinter = false,
     connectAccessibleController = false,
     connectCardReader = false,
     connectBatchScanner = false,
+    connectPrecinctScanner = false,
   }: {
     connectPrinter?: boolean;
     connectAccessibleController?: boolean;
     connectCardReader?: boolean;
     connectBatchScanner?: boolean;
+    connectPrecinctScanner?: boolean;
   } = {}): Promise<MemoryHardware> {
     const newMemoryHardware = new MemoryHardware();
     await newMemoryHardware.setPrinterConnected(connectPrinter);
@@ -85,6 +99,7 @@ export class MemoryHardware implements Hardware {
     );
     await newMemoryHardware.setCardReaderConnected(connectCardReader);
     await newMemoryHardware.setBatchScannerConnected(connectBatchScanner);
+    newMemoryHardware.setPrecinctScannerConnected(connectPrecinctScanner);
     return newMemoryHardware;
   }
 
@@ -94,6 +109,7 @@ export class MemoryHardware implements Hardware {
       connectAccessibleController: true,
       connectCardReader: true,
       connectBatchScanner: true,
+      connectPrecinctScanner: true,
     });
   }
 
@@ -103,6 +119,7 @@ export class MemoryHardware implements Hardware {
       connectAccessibleController: false,
       connectCardReader: true,
       connectBatchScanner: true,
+      connectPrecinctScanner: true,
     });
   }
 
@@ -118,6 +135,13 @@ export class MemoryHardware implements Hardware {
    */
   async setBatchScannerConnected(connected: boolean): Promise<void> {
     this.setDeviceConnected(this.batchScanner, connected);
+  }
+
+  /**
+   * Sets Precinct Scanner connected
+   */
+  setPrecinctScannerConnected(connected: boolean): void {
+    this.setDeviceConnected(this.precinctScanner, connected);
   }
 
   /**


### PR DESCRIPTION
## Overview
Task: #1476 

When the precinct scanner is disconnected, show a screen to the user and
don't poll for scanner status. Hopefully this will be a useful reminder
and also prevent making hanging requests to the scan service (which is
non-responsive when the scanner is disconnected - though likely we'll
want to fix that as well).

## Demo Video or Screenshot

<img width="1536" alt="Screen Shot 2022-03-08 at 3 32 00 PM" src="https://user-images.githubusercontent.com/530106/157343561-36c2e14d-fb00-477d-be1e-fc4853b9a233.png">

## Testing Plan 
Added automated test, also manually tested.

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
