### PR TITLE
feat(utils): make memory battery status more realistic

### DIFF
--- a/libs/utils/src/Hardware/memory_hardware.ts
+++ b/libs/utils/src/Hardware/memory_hardware.ts
@@ -124,7 +124,9 @@ export class MemoryHardware implements Hardware {
    * Reads Battery status
    */
   async readBatteryStatus(): Promise<KioskBrowser.BatteryInfo | undefined> {
-    return this.batteryStatus;
+    // Return a copy of the battery status to more realistically simulate the
+    // behavior of `KioskHardware`.
+    return this.batteryStatus ? { ...this.batteryStatus } : undefined;
   }
 
   /**


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Refs #1416 

When polling for battery status in kiosk-browser, the real value returned by `readBatteryStatus` is always a new object. This currently causes `useDevices` to trigger a re-render of its calling component whenever battery status is updated, which is currently every 3s.

However, when runnning in Chrome we're using `MemoryHardware`, a fake hardware interface. Its `readBatteryStatus` method was returning the same object every time unless the battery level changed. This does not mimick the real one, and therefore was a difference in behavior between Chrome and kiosk-browser that can make bugs appear in one and not the other.

This commit fixes the issue by ensuring that the object returned by `MemoryHardware#readBatteryStatus` is always different, just like with the real one. This makes reproducing #1416 in Chrome easy.

## Demo Video or Screenshot
n/a

## Testing Plan 
n/a

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
