### PR TITLE
fix(em): prevent accidental/broken prints of test decks

### DIFF
--- a/frontends/election-manager/src/screens/print_test_deck_screen.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.tsx
@@ -78,6 +78,8 @@ function TestDeckBallots({
 // What happens if we remove `React.memo`? See https://github.com/votingworks/vxsuite/issues/1416.
 // We need to figure out a better way to handle renders that happen at times we
 // don't expect, not by preventing them but by being resilient to them.
+//
+// https://github.com/votingworks/vxsuite/issues/1531
 const TestDeckBallotsMemoized = React.memo(TestDeckBallots);
 
 export function PrintTestDeckScreen(): JSX.Element {

--- a/frontends/election-manager/src/screens/print_test_deck_screen.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.tsx
@@ -69,6 +69,15 @@ function TestDeckBallots({
   );
 }
 
+// FIXME: We're using `React.memo` to prevent re-rendering `TestDeckBallots`,
+// but this is explicitly against the React docs: https://reactjs.org/docs/react-api.html#reactmemo
+//
+// > This method only exists as a performance optimization. Do not rely on it to
+// > “prevent” a render, as this can lead to bugs.
+//
+// What happens if we remove `React.memo`? See https://github.com/votingworks/vxsuite/issues/1416.
+// We need to figure out a better way to handle renders that happen at times we
+// don't expect, not by preventing them but by being resilient to them.
 const TestDeckBallotsMemoized = React.memo(TestDeckBallots);
 
 export function PrintTestDeckScreen(): JSX.Element {
@@ -133,26 +142,29 @@ export function PrintTestDeckScreen(): JSX.Element {
   }
 
   const onAllRendered = useCallback(
-    async (pIndex, numBallots) => {
+    async (numBallots) => {
+      if (typeof precinctIndex !== 'number') {
+        return;
+      }
+
       await printer.print({ sides: 'two-sided-long-edge' });
       await logger.log(LogEventId.TestDeckPrinted, currentUserType, {
         disposition: 'success',
-        message: `Test Deck printed for precinct id: ${precinctIds[pIndex]}`,
-        precinctId: precinctIds[pIndex],
+        message: `Test Deck printed for precinct id: ${precinctIds[precinctIndex]}`,
+        precinctId: precinctIds[precinctIndex],
       });
 
-      if (pIndex < precinctIds.length - 1) {
+      if (precinctIndex < precinctIds.length - 1) {
         // wait 5s per ballot printed
         // that's how long printing takes in duplex, no reason to get ahead of it.
         await sleep(numBallots * 5000);
-        setPrecinctIndex(pIndex + 1);
+        setPrecinctIndex(precinctIndex + 1);
       } else {
         await sleep(3000);
         setPrecinctIndex(undefined);
       }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [setPrecinctIndex, precinctIds]
+    [printer, logger, currentUserType, precinctIds, precinctIndex]
   );
 
   const currentPrecinct =
@@ -202,9 +214,7 @@ export function PrintTestDeckScreen(): JSX.Element {
             election={election}
             electionHash={electionHash}
             precinctId={precinctIds[precinctIndex]}
-            onAllRendered={(numBallots) =>
-              onAllRendered(precinctIndex, numBallots)
-            }
+            onAllRendered={onAllRendered}
           />
         )}
       </React.Fragment>


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
Fixes #1416

We're using `React.memo` to prevent re-rendering `TestDeckBallots`, but this is explicitly against the React docs: https://reactjs.org/docs/react-api.html#reactmemo
> This method only exists as a performance optimization. Do not rely on it to “prevent” a render, as this can lead to bugs.

We need to figure out a better way to handle renders that happen at times we don't expect, not by preventing them but by being resilient to them.

## Demo Video or Screenshot
https://user-images.githubusercontent.com/1938/157502915-05b550aa-33da-48fa-9fe3-47b76ced5946.mov

## Testing Plan 
- [x] Manual testing with single precinct in Chrome
- [x] Manual testing with 13-precinct test deck in Chrome
- [x] Manual testing on real hardware (@benadida)

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
