### PR TITLE
fix: Remove stylelint-processor-styled-components processor

### DIFF
--- a/frontends/bas/.stylelintrc.js
+++ b/frontends/bas/.stylelintrc.js
@@ -1,7 +1,7 @@
 // Config for stylelint parsing CSS in Styled Components
 // Note the `--fix` flag doesn't yet work for CSS-in-JS
 module.exports = {
-  processors: ['stylelint-processor-styled-components'],
+  processors: [],
   extends: [
     'stylelint-config-palantir',
     'stylelint-config-prettier',

--- a/frontends/bas/package.json
+++ b/frontends/bas/package.json
@@ -100,8 +100,7 @@
     "stylelint": "^13.7.2",
     "stylelint-config-palantir": "^5.0.0",
     "stylelint-config-prettier": "^8.0.2",
-    "stylelint-config-styled-components": "^0.1.1",
-    "stylelint-processor-styled-components": "^1.10.0"
+    "stylelint-config-styled-components": "^0.1.1"
   },
   "vx": {
     "isBundled": true,

--- a/frontends/bmd/.stylelintrc.js
+++ b/frontends/bmd/.stylelintrc.js
@@ -6,7 +6,7 @@ const parserPlugins = buildOptions().plugins.filter(plugin => plugin !== 'typesc
 // Config for stylelint parsing CSS in Styled Components
 // Note the `--fix` flag doesn't yet work for CSS-in-JS
 module.exports = {
-  processors: [['stylelint-processor-styled-components', { parserPlugins }]],
+  processors: [],
   extends: [
     'stylelint-config-palantir',
     'stylelint-config-prettier',

--- a/frontends/bmd/.stylelintrc.js
+++ b/frontends/bmd/.stylelintrc.js
@@ -1,8 +1,3 @@
-// Ensure we use all available babel parser plugins, but not the type annotation
-// ones since stylelint handles that itself.
-const { buildOptions } = require('@codemod/parser')
-const parserPlugins = buildOptions().plugins.filter(plugin => plugin !== 'typescript' && plugin !== 'flow')
-
 // Config for stylelint parsing CSS in Styled Components
 // Note the `--fix` flag doesn't yet work for CSS-in-JS
 module.exports = {
@@ -16,4 +11,4 @@ module.exports = {
     'selector-max-id': 1,
     'selector-max-universal': 1,
   },
-}
+};

--- a/frontends/bmd/package.json
+++ b/frontends/bmd/package.json
@@ -166,8 +166,7 @@
     "stylelint": "^13.3.3",
     "stylelint-config-palantir": "^4.0.1",
     "stylelint-config-prettier": "^8.0.1",
-    "stylelint-config-styled-components": "^0.1.1",
-    "stylelint-processor-styled-components": "^1.10.0"
+    "stylelint-config-styled-components": "^0.1.1"
   },
   "engines": {
     "node": ">= 12"

--- a/frontends/bsd/.stylelintrc.js
+++ b/frontends/bsd/.stylelintrc.js
@@ -1,7 +1,7 @@
 // Config for stylelint parsing CSS in Styled Components
 // Note the `--fix` flag doesn't yet work for CSS-in-JS
 module.exports = {
-  processors: ['stylelint-processor-styled-components'],
+  processors: [],
   extends: [
     'stylelint-config-palantir',
     'stylelint-config-prettier',
@@ -12,4 +12,4 @@ module.exports = {
     'selector-max-universal': 1,
     'order/properties-alphabetical-order': null,
   },
-}
+};

--- a/frontends/bsd/package.json
+++ b/frontends/bsd/package.json
@@ -137,7 +137,6 @@
     "stylelint-config-palantir": "^5.0.0",
     "stylelint-config-prettier": "^8.0.1",
     "stylelint-config-styled-components": "^0.1.1",
-    "stylelint-processor-styled-components": "^1.10.0",
     "type-fest": "^0.18.0",
     "zip-stream": "^3.0.1"
   },

--- a/frontends/election-manager/.stylelintrc.js
+++ b/frontends/election-manager/.stylelintrc.js
@@ -1,7 +1,3 @@
-// Ensure we use all available babel parser plugins, but not the type annotation
-// ones since stylelint handles that itself.
-const { buildOptions } = require('@codemod/parser');
-
 // Config for stylelint parsing CSS in Styled Components
 // Note the `--fix` flag doesn't yet work for CSS-in-JS
 module.exports = {

--- a/frontends/election-manager/.stylelintrc.js
+++ b/frontends/election-manager/.stylelintrc.js
@@ -1,12 +1,11 @@
 // Ensure we use all available babel parser plugins, but not the type annotation
 // ones since stylelint handles that itself.
-const { buildOptions } = require('@codemod/parser')
-const parserPlugins = buildOptions().plugins.filter(plugin => plugin !== 'typescript' && plugin !== 'flow')
+const { buildOptions } = require('@codemod/parser');
 
 // Config for stylelint parsing CSS in Styled Components
 // Note the `--fix` flag doesn't yet work for CSS-in-JS
 module.exports = {
-  processors: [['stylelint-processor-styled-components', { parserPlugins }]],
+  processors: [],
   extends: [
     'stylelint-config-palantir',
     'stylelint-config-prettier',
@@ -16,4 +15,4 @@ module.exports = {
     'selector-max-id': 1,
     'selector-max-universal': 1,
   },
-}
+};

--- a/frontends/election-manager/package.json
+++ b/frontends/election-manager/package.json
@@ -160,8 +160,7 @@
     "stylelint": "^13.1.0",
     "stylelint-config-palantir": "^4.0.1",
     "stylelint-config-prettier": "^8.0.1",
-    "stylelint-config-styled-components": "^0.1.1",
-    "stylelint-processor-styled-components": "^1.10.0"
+    "stylelint-config-styled-components": "^0.1.1"
   },
   "vx": {
     "isBundled": true,

--- a/frontends/precinct-scanner/.stylelintrc.js
+++ b/frontends/precinct-scanner/.stylelintrc.js
@@ -1,12 +1,14 @@
 // Ensure we use all available babel parser plugins, but not the type annotation
 // ones since stylelint handles that itself.
-const { buildOptions } = require('@codemod/parser')
-const parserPlugins = buildOptions().plugins.filter(plugin => plugin !== 'typescript' && plugin !== 'flow')
+const { buildOptions } = require('@codemod/parser');
+const parserPlugins = buildOptions().plugins.filter(
+  (plugin) => plugin !== 'typescript' && plugin !== 'flow'
+);
 
 // Config for stylelint parsing CSS in Styled Components
 // Note the `--fix` flag doesn't yet work for CSS-in-JS
 module.exports = {
-  processors: [['stylelint-processor-styled-components', { parserPlugins }]],
+  processors: [],
   extends: [
     'stylelint-config-palantir',
     'stylelint-config-prettier',
@@ -16,4 +18,4 @@ module.exports = {
     'selector-max-id': 1,
     'selector-max-universal': 1,
   },
-}
+};

--- a/frontends/precinct-scanner/.stylelintrc.js
+++ b/frontends/precinct-scanner/.stylelintrc.js
@@ -1,10 +1,3 @@
-// Ensure we use all available babel parser plugins, but not the type annotation
-// ones since stylelint handles that itself.
-const { buildOptions } = require('@codemod/parser');
-const parserPlugins = buildOptions().plugins.filter(
-  (plugin) => plugin !== 'typescript' && plugin !== 'flow'
-);
-
 // Config for stylelint parsing CSS in Styled Components
 // Note the `--fix` flag doesn't yet work for CSS-in-JS
 module.exports = {

--- a/frontends/precinct-scanner/package.json
+++ b/frontends/precinct-scanner/package.json
@@ -146,7 +146,6 @@
     "stylelint-config-palantir": "^4.0.1",
     "stylelint-config-prettier": "^8.0.1",
     "stylelint-config-styled-components": "^0.1.1",
-    "stylelint-processor-styled-components": "^1.9.0",
     "ts-jest": "^26.5.6"
   },
   "vx": {

--- a/libs/ui/.stylelintrc.js
+++ b/libs/ui/.stylelintrc.js
@@ -1,14 +1,11 @@
 // Ensure we use all available babel parser plugins, but not the type annotation
 // ones since stylelint handles that itself.
-const { buildOptions } = require('@codemod/parser')
-const parserPlugins = buildOptions().plugins.filter(
-  (plugin) => plugin !== 'typescript' && plugin !== 'flow'
-)
+const { buildOptions } = require('@codemod/parser');
 
 // Config for stylelint parsing CSS in Styled Components
 // Note the `--fix` flag doesn't yet work for CSS-in-JS
 module.exports = {
-  processors: [['stylelint-processor-styled-components', { parserPlugins }]],
+  processors: [],
   extends: [
     'stylelint-config-palantir',
     'stylelint-config-prettier',
@@ -18,4 +15,4 @@ module.exports = {
     'selector-max-id': 1,
     'selector-max-universal': 1,
   },
-}
+};

--- a/libs/ui/.stylelintrc.js
+++ b/libs/ui/.stylelintrc.js
@@ -1,7 +1,3 @@
-// Ensure we use all available babel parser plugins, but not the type annotation
-// ones since stylelint handles that itself.
-const { buildOptions } = require('@codemod/parser');
-
 // Config for stylelint parsing CSS in Styled Components
 // Note the `--fix` flag doesn't yet work for CSS-in-JS
 module.exports = {

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -101,7 +101,6 @@
     "stylelint-config-palantir": "^4.0.1",
     "stylelint-config-prettier": "^8.0.1",
     "stylelint-config-styled-components": "^0.1.1",
-    "stylelint-processor-styled-components": "^1.9.0",
     "ts-jest": "^27.0.7",
     "typescript": "^4.3.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -415,7 +415,6 @@ importers:
       stylelint-config-palantir: 5.0.0_stylelint@13.8.0
       stylelint-config-prettier: 8.0.2_stylelint@13.8.0
       stylelint-config-styled-components: 0.1.1
-      stylelint-processor-styled-components: 1.10.0
       type-fest: 0.18.1
       zip-stream: 3.0.1
     specifiers:
@@ -484,7 +483,6 @@ importers:
       stylelint-config-palantir: ^5.0.0
       stylelint-config-prettier: ^8.0.1
       stylelint-config-styled-components: ^0.1.1
-      stylelint-processor-styled-components: ^1.10.0
       ts-jest: ^26.1.3
       type-fest: ^0.18.0
       typescript: ^4.3.5
@@ -15946,7 +15944,7 @@ packages:
       integrity: sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
   /follow-redirects/1.14.1_debug@4.3.2:
     dependencies:
-      debug: 4.3.2
+      debug: 4.3.2_supports-color@6.1.0
     engines:
       node: '>=4.0'
     peerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1767,7 +1767,6 @@ importers:
       stylelint-config-palantir: 4.0.1_stylelint@13.8.0
       stylelint-config-prettier: 8.0.2_stylelint@13.8.0
       stylelint-config-styled-components: 0.1.1
-      stylelint-processor-styled-components: 1.10.0
       ts-jest: 27.0.7_9fd3d618a8f56b72434a4d1d442dbc9f
       typescript: 4.3.5
     specifiers:
@@ -1831,7 +1830,6 @@ importers:
       stylelint-config-palantir: ^4.0.1
       stylelint-config-prettier: ^8.0.1
       stylelint-config-styled-components: ^0.1.1
-      stylelint-processor-styled-components: ^1.9.0
       ts-jest: ^27.0.7
       typescript: ^4.3.5
       use-interval: ^1.4.0
@@ -2116,14 +2114,6 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==
-  /@babel/code-frame/7.16.7:
-    dependencies:
-      '@babel/highlight': 7.16.10
-    dev: true
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
   /@babel/compat-data/7.14.5:
     engines:
       node: '>=6.9.0'
@@ -2301,16 +2291,6 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-kIvCdjZqcdKqoDbVVdt5R99icaRtrtYhYK/xux5qiWCBmfdvEYMFZ68QCrpE5cbFM1JsuArUNs1ZkuKtTtUcZA==
-  /@babel/generator/7.17.3:
-    dependencies:
-      '@babel/types': 7.17.0
-      jsesc: 2.5.2
-      source-map: 0.5.7
-    dev: true
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==
   /@babel/helper-annotate-as-pure/7.12.10:
     dependencies:
       '@babel/types': 7.12.12
@@ -2458,14 +2438,6 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-ODQyc5AnxmZWm/R2W7fzhamOk1ey8gSguo5SGvF0zcB3uUzRpTRmM/jmLSm9bDMyPlvbyJ+PwPEK0BWIoZ9wjg==
-  /@babel/helper-environment-visitor/7.16.7:
-    dependencies:
-      '@babel/types': 7.17.0
-    dev: true
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==
   /@babel/helper-explode-assignable-expression/7.12.1:
     dependencies:
       '@babel/types': 7.15.6
@@ -2516,16 +2488,6 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==
-  /@babel/helper-function-name/7.16.7:
-    dependencies:
-      '@babel/helper-get-function-arity': 7.16.7
-      '@babel/template': 7.16.7
-      '@babel/types': 7.17.0
-    dev: true
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==
   /@babel/helper-get-function-arity/7.12.10:
     dependencies:
       '@babel/types': 7.12.12
@@ -2560,14 +2522,6 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==
-  /@babel/helper-get-function-arity/7.16.7:
-    dependencies:
-      '@babel/types': 7.17.0
-    dev: true
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==
   /@babel/helper-hoist-variables/7.14.5:
     dependencies:
       '@babel/types': 7.15.0
@@ -2590,14 +2544,6 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==
-  /@babel/helper-hoist-variables/7.16.7:
-    dependencies:
-      '@babel/types': 7.17.0
-    dev: true
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==
   /@babel/helper-member-expression-to-functions/7.14.5:
     dependencies:
       '@babel/types': 7.14.5
@@ -2848,14 +2794,6 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==
-  /@babel/helper-split-export-declaration/7.16.7:
-    dependencies:
-      '@babel/types': 7.17.0
-    dev: true
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==
   /@babel/helper-validator-identifier/7.12.11:
     resolution:
       integrity: sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
@@ -2877,12 +2815,6 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==
-  /@babel/helper-validator-identifier/7.16.7:
-    dev: true
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
   /@babel/helper-validator-option/7.14.5:
     engines:
       node: '>=6.9.0'
@@ -2966,16 +2898,6 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==
-  /@babel/highlight/7.16.10:
-    dependencies:
-      '@babel/helper-validator-identifier': 7.16.7
-      chalk: 2.4.2
-      js-tokens: 4.0.0
-    dev: true
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==
   /@babel/parser/7.12.11:
     dev: false
     engines:
@@ -3035,13 +2957,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-Gr86ujcNuPDnNOY8mi383Hvi8IYrJVJYuf3XcuBM/Dgd+bINn/7tHqsj+tKkoreMbmGsFLsltI/JJd8fOFWGDQ==
-  /@babel/parser/7.17.3:
-    dev: true
-    engines:
-      node: '>=6.0.0'
-    hasBin: true
-    resolution:
-      integrity: sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==
   /@babel/plugin-proposal-async-generator-functions/7.12.12_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
@@ -4948,16 +4863,6 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==
-  /@babel/template/7.16.7:
-    dependencies:
-      '@babel/code-frame': 7.16.7
-      '@babel/parser': 7.17.3
-      '@babel/types': 7.17.0
-    dev: true
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==
   /@babel/traverse/7.12.12_supports-color@5.5.0:
     dependencies:
       '@babel/code-frame': 7.12.11
@@ -5067,23 +4972,6 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-FOCODAzqUMROikDYLYxl4nmwiLlu85rNqBML/A5hKRVXG2LV8d0iMqgPzdYTcIpjZEBB7D6UDU9vxRZiriASdQ==
-  /@babel/traverse/7.17.3:
-    dependencies:
-      '@babel/code-frame': 7.16.7
-      '@babel/generator': 7.17.3
-      '@babel/helper-environment-visitor': 7.16.7
-      '@babel/helper-function-name': 7.16.7
-      '@babel/helper-hoist-variables': 7.16.7
-      '@babel/helper-split-export-declaration': 7.16.7
-      '@babel/parser': 7.17.3
-      '@babel/types': 7.17.0
-      debug: 4.3.3
-      globals: 11.12.0
-    dev: true
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==
   /@babel/types/7.12.12:
     dependencies:
       '@babel/helper-validator-identifier': 7.12.11
@@ -5139,15 +5027,6 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==
-  /@babel/types/7.17.0:
-    dependencies:
-      '@babel/helper-validator-identifier': 7.16.7
-      to-fast-properties: 2.0.0
-    dev: true
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==
   /@bcoe/v8-coverage/0.2.3:
     resolution:
       integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
@@ -22357,10 +22236,6 @@ packages:
   /performance-now/2.1.0:
     resolution:
       integrity: sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
-  /picocolors/0.2.1:
-    dev: true
-    resolution:
-      integrity: sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==
   /picocolors/1.0.0:
     resolution:
       integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
@@ -23293,15 +23168,6 @@ packages:
       node: '>=6.0.0'
     resolution:
       integrity: sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==
-  /postcss/7.0.39:
-    dependencies:
-      picocolors: 0.2.1
-      source-map: 0.6.1
-    dev: true
-    engines:
-      node: '>=6.0.0'
-    resolution:
-      integrity: sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==
   /postcss/8.2.4:
     dependencies:
       colorette: 1.2.2
@@ -25932,15 +25798,6 @@ packages:
       stylelint: ^10.0.1 || ^11.0.0 || ^12.0.0 || ^13.0.0
     resolution:
       integrity: sha512-sVTikaDvMqg2aJjh4r48jsdfmqLT+nqB1MOsaBnvM3OwLx4S+WXcsxsgk5w18h/OZoxZCxuyXMh61iBHcj9Qiw==
-  /stylelint-processor-styled-components/1.10.0:
-    dependencies:
-      '@babel/parser': 7.17.3
-      '@babel/traverse': 7.17.3
-      micromatch: 4.0.4
-      postcss: 7.0.39
-    dev: true
-    resolution:
-      integrity: sha512-g4HpN9rm0JD0LoHuIOcd/FIjTZCJ0ErQ+dC3VTxp+dSvnkV+MklKCCmCQEdz5K5WxF4vPuzfVgdbSDuPYGZhoA==
   /stylelint-scss/3.18.0_stylelint@13.8.0:
     dependencies:
       lodash: 4.17.21
@@ -26645,7 +26502,7 @@ packages:
       '@types/jest': 27.0.3
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 27.3.1_canvas@2.6.1
+      jest: 27.3.1
       jest-util: 27.3.1
       json5: 2.2.0
       lodash.memoize: 4.1.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -587,7 +587,6 @@ importers:
       stylelint-config-palantir: 4.0.1_stylelint@13.8.0
       stylelint-config-prettier: 8.0.2_stylelint@13.8.0
       stylelint-config-styled-components: 0.1.1
-      stylelint-processor-styled-components: 1.10.0
     specifiers:
       '@codemod/parser': ^1.0.6
       '@testing-library/jest-dom': ^4.2.4
@@ -672,7 +671,6 @@ importers:
       stylelint-config-palantir: ^4.0.1
       stylelint-config-prettier: ^8.0.1
       stylelint-config-styled-components: ^0.1.1
-      stylelint-processor-styled-components: ^1.10.0
       typescript: ^4.3.5
       use-interval: ^1.2.1
       zip-stream: ^3.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -759,7 +759,6 @@ importers:
       stylelint-config-palantir: 4.0.1_stylelint@13.8.0
       stylelint-config-prettier: 8.0.2_stylelint@13.8.0
       stylelint-config-styled-components: 0.1.1
-      stylelint-processor-styled-components: 1.10.0
       ts-jest: 26.5.6_typescript@4.3.5
     specifiers:
       '@codemod/parser': ^1.0.6
@@ -830,7 +829,6 @@ importers:
       stylelint-config-palantir: ^4.0.1
       stylelint-config-prettier: ^8.0.1
       stylelint-config-styled-components: ^0.1.1
-      stylelint-processor-styled-components: ^1.9.0
       ts-jest: ^26.5.6
       typescript: ^4.3.5
       use-interval: ^1.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,7 +191,7 @@ importers:
       dompurify: 2.2.6
       fetch-mock: 9.11.0
       history: 4.10.1
-      http-proxy-middleware: 1.0.6
+      http-proxy-middleware: 1.0.6_debug@4.3.2
       lodash.camelcase: 4.3.0
       luxon: 1.26.0
       mockdate: 3.0.2
@@ -251,7 +251,6 @@ importers:
       stylelint-config-palantir: 4.0.1_stylelint@13.8.0
       stylelint-config-prettier: 8.0.2_stylelint@13.8.0
       stylelint-config-styled-components: 0.1.1
-      stylelint-processor-styled-components: 1.10.0
     specifiers:
       '@codemod/parser': ^1.0.7
       '@rooks/use-interval': ^4.5.0
@@ -333,7 +332,6 @@ importers:
       stylelint-config-palantir: ^4.0.1
       stylelint-config-prettier: ^8.0.1
       stylelint-config-styled-components: ^0.1.1
-      stylelint-processor-styled-components: ^1.10.0
       typescript: ^4.3.5
       use-interval: ^1.2.1
       zod: 3.2.0
@@ -2124,6 +2122,14 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==
+  /@babel/code-frame/7.16.7:
+    dependencies:
+      '@babel/highlight': 7.16.10
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
   /@babel/compat-data/7.14.5:
     engines:
       node: '>=6.9.0'
@@ -2301,6 +2307,16 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-kIvCdjZqcdKqoDbVVdt5R99icaRtrtYhYK/xux5qiWCBmfdvEYMFZ68QCrpE5cbFM1JsuArUNs1ZkuKtTtUcZA==
+  /@babel/generator/7.17.3:
+    dependencies:
+      '@babel/types': 7.17.0
+      jsesc: 2.5.2
+      source-map: 0.5.7
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==
   /@babel/helper-annotate-as-pure/7.12.10:
     dependencies:
       '@babel/types': 7.12.12
@@ -2448,6 +2464,14 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-ODQyc5AnxmZWm/R2W7fzhamOk1ey8gSguo5SGvF0zcB3uUzRpTRmM/jmLSm9bDMyPlvbyJ+PwPEK0BWIoZ9wjg==
+  /@babel/helper-environment-visitor/7.16.7:
+    dependencies:
+      '@babel/types': 7.17.0
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==
   /@babel/helper-explode-assignable-expression/7.12.1:
     dependencies:
       '@babel/types': 7.15.6
@@ -2498,6 +2522,16 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==
+  /@babel/helper-function-name/7.16.7:
+    dependencies:
+      '@babel/helper-get-function-arity': 7.16.7
+      '@babel/template': 7.16.7
+      '@babel/types': 7.17.0
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==
   /@babel/helper-get-function-arity/7.12.10:
     dependencies:
       '@babel/types': 7.12.12
@@ -2532,6 +2566,14 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==
+  /@babel/helper-get-function-arity/7.16.7:
+    dependencies:
+      '@babel/types': 7.17.0
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==
   /@babel/helper-hoist-variables/7.14.5:
     dependencies:
       '@babel/types': 7.15.0
@@ -2554,6 +2596,14 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==
+  /@babel/helper-hoist-variables/7.16.7:
+    dependencies:
+      '@babel/types': 7.17.0
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==
   /@babel/helper-member-expression-to-functions/7.14.5:
     dependencies:
       '@babel/types': 7.14.5
@@ -2804,6 +2854,14 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==
+  /@babel/helper-split-export-declaration/7.16.7:
+    dependencies:
+      '@babel/types': 7.17.0
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==
   /@babel/helper-validator-identifier/7.12.11:
     resolution:
       integrity: sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
@@ -2825,6 +2883,12 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==
+  /@babel/helper-validator-identifier/7.16.7:
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
   /@babel/helper-validator-option/7.14.5:
     engines:
       node: '>=6.9.0'
@@ -2908,6 +2972,16 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==
+  /@babel/highlight/7.16.10:
+    dependencies:
+      '@babel/helper-validator-identifier': 7.16.7
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==
   /@babel/parser/7.12.11:
     dev: false
     engines:
@@ -2967,6 +3041,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-Gr86ujcNuPDnNOY8mi383Hvi8IYrJVJYuf3XcuBM/Dgd+bINn/7tHqsj+tKkoreMbmGsFLsltI/JJd8fOFWGDQ==
+  /@babel/parser/7.17.3:
+    dev: true
+    engines:
+      node: '>=6.0.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==
   /@babel/plugin-proposal-async-generator-functions/7.12.12_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
@@ -4873,6 +4954,16 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==
+  /@babel/template/7.16.7:
+    dependencies:
+      '@babel/code-frame': 7.16.7
+      '@babel/parser': 7.17.3
+      '@babel/types': 7.17.0
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==
   /@babel/traverse/7.12.12_supports-color@5.5.0:
     dependencies:
       '@babel/code-frame': 7.12.11
@@ -4982,6 +5073,23 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-FOCODAzqUMROikDYLYxl4nmwiLlu85rNqBML/A5hKRVXG2LV8d0iMqgPzdYTcIpjZEBB7D6UDU9vxRZiriASdQ==
+  /@babel/traverse/7.17.3:
+    dependencies:
+      '@babel/code-frame': 7.16.7
+      '@babel/generator': 7.17.3
+      '@babel/helper-environment-visitor': 7.16.7
+      '@babel/helper-function-name': 7.16.7
+      '@babel/helper-hoist-variables': 7.16.7
+      '@babel/helper-split-export-declaration': 7.16.7
+      '@babel/parser': 7.17.3
+      '@babel/types': 7.17.0
+      debug: 4.3.3
+      globals: 11.12.0
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==
   /@babel/types/7.12.12:
     dependencies:
       '@babel/helper-validator-identifier': 7.12.11
@@ -5037,6 +5145,15 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==
+  /@babel/types/7.17.0:
+    dependencies:
+      '@babel/helper-validator-identifier': 7.16.7
+      to-fast-properties: 2.0.0
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==
   /@bcoe/v8-coverage/0.2.3:
     resolution:
       integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
@@ -15829,7 +15946,7 @@ packages:
       integrity: sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
   /follow-redirects/1.14.1_debug@4.3.2:
     dependencies:
-      debug: 4.3.2_supports-color@6.1.0
+      debug: 4.3.2
     engines:
       node: '>=4.0'
     peerDependencies:
@@ -16764,6 +16881,20 @@ packages:
     dev: false
     engines:
       node: '>=8.0.0'
+    resolution:
+      integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
+  /http-proxy-middleware/1.0.6_debug@4.3.2:
+    dependencies:
+      '@types/http-proxy': 1.17.6
+      http-proxy: 1.18.1_debug@4.3.2
+      is-glob: 4.0.1
+      lodash: 4.17.21
+      micromatch: 4.0.4
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    peerDependencies:
+      debug: '*'
     resolution:
       integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
   /http-proxy/1.18.1:
@@ -20937,7 +21068,7 @@ packages:
   /micromatch/4.0.4:
     dependencies:
       braces: 3.0.2
-      picomatch: 2.3.0
+      picomatch: 2.3.1
     engines:
       node: '>=8.6'
     resolution:
@@ -22232,6 +22363,10 @@ packages:
   /performance-now/2.1.0:
     resolution:
       integrity: sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
+  /picocolors/0.2.1:
+    dev: true
+    resolution:
+      integrity: sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==
   /picocolors/1.0.0:
     resolution:
       integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
@@ -22240,6 +22375,11 @@ packages:
       node: '>=8.6'
     resolution:
       integrity: sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
+  /picomatch/2.3.1:
+    engines:
+      node: '>=8.6'
+    resolution:
+      integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
   /pify/2.3.0:
     engines:
       node: '>=0.10.0'
@@ -23159,6 +23299,15 @@ packages:
       node: '>=6.0.0'
     resolution:
       integrity: sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==
+  /postcss/7.0.39:
+    dependencies:
+      picocolors: 0.2.1
+      source-map: 0.6.1
+    dev: true
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==
   /postcss/8.2.4:
     dependencies:
       colorette: 1.2.2
@@ -25791,10 +25940,10 @@ packages:
       integrity: sha512-sVTikaDvMqg2aJjh4r48jsdfmqLT+nqB1MOsaBnvM3OwLx4S+WXcsxsgk5w18h/OZoxZCxuyXMh61iBHcj9Qiw==
   /stylelint-processor-styled-components/1.10.0:
     dependencies:
-      '@babel/parser': 7.14.5
-      '@babel/traverse': 7.14.5
+      '@babel/parser': 7.17.3
+      '@babel/traverse': 7.17.3
       micromatch: 4.0.4
-      postcss: 7.0.35
+      postcss: 7.0.39
     dev: true
     resolution:
       integrity: sha512-g4HpN9rm0JD0LoHuIOcd/FIjTZCJ0ErQ+dC3VTxp+dSvnkV+MklKCCmCQEdz5K5WxF4vPuzfVgdbSDuPYGZhoA==

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,7 +112,6 @@ importers:
       stylelint-config-palantir: 5.0.0_stylelint@13.8.0
       stylelint-config-prettier: 8.0.2_stylelint@13.8.0
       stylelint-config-styled-components: 0.1.1
-      stylelint-processor-styled-components: 1.10.0
     specifiers:
       '@types/history': ^4.7.8
       '@types/jest': 24.0.11
@@ -157,7 +156,6 @@ importers:
       stylelint-config-palantir: ^5.0.0
       stylelint-config-prettier: ^8.0.2
       stylelint-config-styled-components: ^0.1.1
-      stylelint-processor-styled-components: ^1.10.0
       typescript: ^4.3.5
       zod: 3.2.0
   frontends/bas/prodserver:
@@ -15818,9 +15816,7 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=
-  /follow-redirects/1.14.1_debug@4.3.1:
-    dependencies:
-      debug: 4.3.1
+  /follow-redirects/1.14.1:
     dev: false
     engines:
       node: '>=4.0'
@@ -16773,7 +16769,7 @@ packages:
   /http-proxy/1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.14.1_debug@4.3.1
+      follow-redirects: 1.14.1
       requires-port: 1.0.0
     dev: false
     engines:


### PR DESCRIPTION
## Overview
Fixes #1529 

The `stylelint-processor-styled-components` processor is no longer necessary as of `stylelint@10`. 

> [](https://github.com/styled-components/stylelint-processor-styled-components#i-dont-want-specified-tagged-template-literal-to-be-parsed-ie-css)What's more, if set syntax: css-in-js in stylelint@10, it can extract styles from styled-components without this processor. Even though there are still lots of differences with this processor, we hope this processor's abilities can be migrated to stylelint totally in the future. [source](https://github.com/styled-components/stylelint-processor-styled-components#why-does-it-throw-unexpected-lint-errors)


## Demo Video or Screenshot
```
> @votingworks/election-manager@0.1.0 pre-commit /home/tara/code/vxsuite/frontends/election-manager
> lint-staged

✔ Preparing...
⚠ Running tasks...
  ✔ Running tasks for *.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)
  ❯ Running tasks for *.+(js|jsx|ts|tsx)
    ✖ stylelint [FAILED]
    ◼ eslint --quiet --fix
  ↓ No staged files match *.css [SKIPPED]
  ✔ Running tasks for package.json
↓ Skipped because of errors from tasks. [SKIPPED]
✔ Reverting to original state because of errors...
✔ Cleaning up...

✖ stylelint:
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating

Deprecation Warning: 'unit-blacklist' has been deprecated. Instead use 'unit-disallowed-list'. See: https://github.com/stylelint/stylelint/blob/13.7.0/lib/rules/unit-blacklist/README.md

src/screens/ballot_list_screen.tsx
 28:10  ✖  Unexpected invalid hex color "#04"   color-no-invalid-hex
```

## Testing Plan 

I have confirmed that with this change: 

1. The pre-commit lint hooks in `frontend/*` pass when trying to commit changes with no linting errors.
2. The pre-commit lint hooks fail with the expected lint failures when trying to commit code with linting errors.

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
