### PR TITLE
feat(em): automatically remove write protection when creating admin cards

### DIFF
--- a/frontends/election-manager/src/screens/smartcards_screen.tsx
+++ b/frontends/election-manager/src/screens/smartcards_screen.tsx
@@ -128,6 +128,9 @@ export function SmartcardsScreen(): JSX.Element {
     setIsProgrammingCard(false);
   }
   async function programAdminCard(passcode: string) {
+    // automatically override write protection when writing a new admin card
+    await overrideWriteProtection();
+
     assert(currentUserSession); // TODO(auth) check permissions for writing smartcards
     await logger.log(LogEventId.SmartcardProgramInit, currentUserSession.type, {
       message: 'Programming an admin card...',


### PR DESCRIPTION

## Overview
automatically calls overrideWriteProtection before writing admin cards,fixes #1466

## Demo Video or Screenshot

## Testing Plan 

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
