### PR TITLE
fix(scan): improve the correspondence check

### DIFF
--- a/libs/ballot-interpreter-vx/src/interpreter/basics.test.ts
+++ b/libs/ballot-interpreter-vx/src/interpreter/basics.test.ts
@@ -37,6 +37,13 @@ test('takes the mark score vote threshold from the election definition if presen
   expect(interpreter['markScoreVoteThreshold']).toEqual(0.99);
 });
 
+/**
+ * Because this image has a cropped contest, it should not correspond to the
+ * template. The cropped contest has a correspondence error of ~0.09, which is
+ * higher than the maximum default correspondence error of 0.05.
+ *
+ * @see {@link findBallotLayoutCorrespondence}
+ */
 test('rejects an incorrect-but-plausible contest layout', async () => {
   const fixtures = choctaw2020LegalSize;
   const interpreter = new Interpreter({

--- a/libs/ballot-interpreter-vx/src/utils/geometry.test.ts
+++ b/libs/ballot-interpreter-vx/src/utils/geometry.test.ts
@@ -3,7 +3,6 @@ import { randomInt } from '../../test/utils';
 import {
   angleBetweenPoints,
   flipRectVerticalAndHorizontal,
-  poly4Area,
   rectCenter,
   rectCorners,
   roundPoint,
@@ -137,36 +136,4 @@ test('triangleArea', () => {
   expect(triangleArea({ x: 0, y: 0 }, { x: 3, y: 3 }, { x: 4, y: 0 })).toEqual(
     6
   );
-});
-
-test('poly4area', () => {
-  // simple square
-  expect(
-    poly4Area([
-      { x: 0, y: 0 },
-      { x: 1, y: 0 },
-      { x: 0, y: 1 },
-      { x: 1, y: 1 },
-    ])
-  ).toEqual(1);
-
-  // rotated square
-  expect(
-    poly4Area([
-      { x: 0, y: 2 },
-      { x: 2, y: 4 },
-      { x: 4, y: 2 },
-      { x: 2, y: 0 },
-    ])
-  ).toEqual(8);
-
-  // irregular
-  expect(
-    poly4Area([
-      { x: 2, y: 1 },
-      { x: 7, y: 0 },
-      { x: 0, y: 6 },
-      { x: 5, y: 8 },
-    ])
-  ).toEqual(33.5);
 });

--- a/libs/ballot-interpreter-vx/src/utils/geometry.ts
+++ b/libs/ballot-interpreter-vx/src/utils/geometry.ts
@@ -104,18 +104,3 @@ export function triangleArea(a: Point, b: Point, c: Point): number {
     (a.x * (b.y - c.y) + b.x * (c.y - a.y) + c.x * (a.y - b.y)) / 2
   );
 }
-
-/**
- * Compute the area of a 4-sided polygon.
- */
-export function poly4Area([
-  topLeft,
-  topRight,
-  bottomLeft,
-  bottomRight,
-]: Corners): number {
-  return (
-    triangleArea(topLeft, bottomLeft, bottomRight) +
-    triangleArea(topLeft, topRight, bottomRight)
-  );
-}


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
The previous version was a little too sensitive. I've started updating the fixtures for #1524, but doing so caused a test to fail due to a lack of correspondence. This new algorithm seems to work with both the old and the new fixtures.

## Demo Video or Screenshot
n/a

## Testing Plan 
Manually tested scanning a legal-sized ballot a bunch of times. 

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
