### PR TITLE
fix(scan): correct `median` implementation

### DIFF
--- a/libs/ballot-interpreter-vx/src/utils/geometry.test.ts
+++ b/libs/ballot-interpreter-vx/src/utils/geometry.test.ts
@@ -3,6 +3,7 @@ import { randomInt } from '../../test/utils';
 import {
   angleBetweenPoints,
   flipRectVerticalAndHorizontal,
+  median,
   rectCenter,
   rectCorners,
   roundPoint,
@@ -136,4 +137,12 @@ test('triangleArea', () => {
   expect(triangleArea({ x: 0, y: 0 }, { x: 3, y: 3 }, { x: 4, y: 0 })).toEqual(
     6
   );
+});
+
+test('median', () => {
+  expect(() => median([])).toThrow();
+  expect(median([1])).toEqual(1);
+  expect(median([1, 2])).toEqual(1.5);
+  expect(median([1, 3, 2])).toEqual(2);
+  expect(median([1, 3, 2, 4])).toEqual(2.5);
 });

--- a/libs/ballot-interpreter-vx/src/utils/geometry.ts
+++ b/libs/ballot-interpreter-vx/src/utils/geometry.ts
@@ -74,12 +74,12 @@ export function median(numbers: ArrayLike<number>): number {
 
   const sorted = Array.from(numbers).sort();
 
+  const halfway = Math.ceil(sorted.length / 2 - 1);
   if (sorted.length % 2 === 0) {
-    const halfway = sorted.length / 2;
     return (sorted[halfway] + sorted[halfway + 1]) / 2;
   }
 
-  return sorted[Math.ceil(sorted.length / 2)];
+  return sorted[halfway];
 }
 
 /**


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
There was an off-by-1 bug that meant e.g. `median([1, 2])` would be `NaN` and `median([1, 2, 3])` would be `3`. Whoops. This was never actually a problem for the existing uses of `median` because the size of the arrays and distribution of values in them meant the result was the same with either version of `median`.

## Demo Video or Screenshot
n/a

## Testing Plan 
New tests added.

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
