### PR TITLE
chore(ps) make save cvrs to usb function

### DIFF
--- a/frontends/precinct-scanner/src/api/scan.test.ts
+++ b/frontends/precinct-scanner/src/api/scan.test.ts
@@ -2,7 +2,11 @@ import {
   electionSampleDefinition,
   electionWithMsEitherNeitherWithDataFiles,
 } from '@votingworks/fixtures';
-import { AdjudicationReason, BallotType } from '@votingworks/types';
+import {
+  AdjudicationReason,
+  BallotType,
+  CastVoteRecord,
+} from '@votingworks/types';
 import {
   GetNextReviewSheetResponse,
   GetScanStatusResponse,
@@ -418,7 +422,11 @@ test('calibrate returns false on failure', async () => {
 test('getExport returns CVRs on success', async () => {
   const fileContent = electionWithMsEitherNeitherWithDataFiles.cvrData;
   fetchMock.postOnce('/scan/export', fileContent);
-  const cvrs = await scan.getExport();
+  const cvrsFileString = await scan.getExport();
+  const lines = cvrsFileString.split('\n');
+  const cvrs = lines.flatMap((line) =>
+    line.length > 0 ? (JSON.parse(line) as CastVoteRecord) : []
+  );
   expect(cvrs).toHaveLength(100);
 });
 

--- a/frontends/precinct-scanner/src/api/scan.ts
+++ b/frontends/precinct-scanner/src/api/scan.ts
@@ -1,6 +1,5 @@
 import {
   AdjudicationReasonInfo,
-  CastVoteRecord,
   safeParseJson,
   unsafeParse,
 } from '@votingworks/types';
@@ -186,7 +185,7 @@ export async function calibrate(): Promise<boolean> {
   );
 }
 
-export async function getExport(): Promise<CastVoteRecord[]> {
+export async function getExport(): Promise<string> {
   const response = await fetch('/scan/export', {
     method: 'post',
   });
@@ -194,11 +193,5 @@ export async function getExport(): Promise<CastVoteRecord[]> {
     debug('failed to get scan export: %o', response);
     throw new Error('failed to generate scan export');
   }
-  const castVoteRecordsString = await response.text();
-  const lines = castVoteRecordsString.split('\n');
-  const cvrs = lines.flatMap((line) =>
-    line.length > 0 ? (JSON.parse(line) as CastVoteRecord) : []
-  );
-  // TODO add more validation of the CVR, move the validation code from election-manager to utils
-  return cvrs.filter((cvr) => cvr._precinctId !== undefined);
+  return await response.text();
 }

--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -619,7 +619,14 @@ export function AppRoot({
 
   const getCvrsFromExport = useCallback(async (): Promise<CastVoteRecord[]> => {
     if (electionDefinition) {
-      return await scan.getExport();
+      const castVoteRecordsString = await scan.getExport();
+
+      const lines = castVoteRecordsString.split('\n');
+      const cvrs = lines.flatMap((line) =>
+        line.length > 0 ? (JSON.parse(line) as CastVoteRecord) : []
+      );
+      // TODO add more validation of the CVR, move the validation code from election-manager to utils
+      return cvrs.filter((cvr) => cvr._precinctId !== undefined);
     }
     return [];
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontends/precinct-scanner/src/components/export_results_modal.tsx
+++ b/frontends/precinct-scanner/src/components/export_results_modal.tsx
@@ -1,7 +1,5 @@
 import React, { useCallback, useContext, useState } from 'react';
 import styled from 'styled-components';
-import fileDownload from 'js-file-download';
-import path from 'path';
 
 import {
   Button,
@@ -11,15 +9,9 @@ import {
   UsbControllerButton,
   UsbDrive,
 } from '@votingworks/ui';
-import {
-  assert,
-  generateElectionBasedSubfolderName,
-  generateFilenameForScanningResults,
-  SCANNER_RESULTS_FOLDER,
-  throwIllegalValue,
-  usbstick,
-} from '@votingworks/utils';
+import { assert, throwIllegalValue, usbstick } from '@votingworks/utils';
 import { AppContext } from '../contexts/app_context';
+import { saveCvrExportToUsb } from '../utils/save_cvr_export_to_usb';
 
 const UsbImage = styled.img`
   margin: 0 auto;
@@ -58,80 +50,21 @@ export function ExportResultsModal({
   const exportResults = useCallback(
     async (openDialog: boolean) => {
       setCurrentState(ModalState.SAVING);
-
       try {
-        const response = await fetch('/scan/export', {
-          method: 'post',
-        });
-
-        const blob = await response.blob();
-
-        if (response.status !== 200) {
-          setErrorMessage(
-            'Failed to save results. Error retrieving CVRs from the scanner.'
-          );
-          setCurrentState(ModalState.ERROR);
-          return;
-        }
-
-        const cvrFilename = generateFilenameForScanningResults(
-          machineConfig.machineId,
+        await saveCvrExportToUsb({
+          electionDefinition,
+          machineConfig,
           scannedBallotCount,
           isTestMode,
-          new Date()
-        );
-
-        if (window.kiosk) {
-          const usbPath = await usbstick.getDevicePath();
-          if (!usbPath) {
-            throw new Error(
-              'could not begin download; path to usb drive missing'
-            );
-          }
-          const electionFolderName = generateElectionBasedSubfolderName(
-            electionDefinition.election,
-            electionDefinition.electionHash
-          );
-          const pathToFolder = path.join(
-            usbPath,
-            SCANNER_RESULTS_FOLDER,
-            electionFolderName
-          );
-          const pathToFile = path.join(pathToFolder, cvrFilename);
-          if (openDialog) {
-            const fileWriter = await window.kiosk.saveAs({
-              defaultPath: pathToFile,
-            });
-
-            if (!fileWriter) {
-              throw new Error('could not begin download; no file was chosen');
-            }
-
-            await fileWriter.write(await blob.text());
-            await fileWriter.end();
-          } else {
-            await window.kiosk.makeDirectory(pathToFolder, {
-              recursive: true,
-            });
-            await window.kiosk.writeFile(pathToFile, await blob.text());
-          }
-          setCurrentState(ModalState.DONE);
-        } else {
-          fileDownload(blob, cvrFilename, 'application/x-jsonlines');
-          setCurrentState(ModalState.DONE);
-        }
+          openFilePickerDialog: openDialog,
+        });
+        setCurrentState(ModalState.DONE);
       } catch (error) {
         setErrorMessage(`Failed to save results. ${error.message}`);
         setCurrentState(ModalState.ERROR);
       }
     },
-    [
-      electionDefinition.election,
-      electionDefinition.electionHash,
-      isTestMode,
-      machineConfig.machineId,
-      scannedBallotCount,
-    ]
+    [electionDefinition, isTestMode, machineConfig, scannedBallotCount]
   );
 
   if (currentState === ModalState.ERROR) {

--- a/frontends/precinct-scanner/src/utils/save_cvr_export_to_usb.test.ts
+++ b/frontends/precinct-scanner/src/utils/save_cvr_export_to_usb.test.ts
@@ -1,0 +1,151 @@
+import { electionMinimalExhaustiveSampleWithDataFiles } from '@votingworks/fixtures';
+import { fakeKiosk, fakeUsbDrive } from '@votingworks/test-utils';
+import fetchMock from 'fetch-mock';
+import fileDownload from 'js-file-download';
+import MockDate from 'mockdate';
+import { fakeFileWriter } from '../../test/helpers/fake_file_writer';
+import { MachineConfig } from '../config/types';
+
+import { saveCvrExportToUsb } from './save_cvr_export_to_usb';
+
+MockDate.set('2020-10-31T00:00:00.000Z');
+jest.mock('js-file-download');
+
+const machineConfig: MachineConfig = {
+  machineId: '0003',
+  codeVersion: 'TEST',
+};
+
+test('throws error when scan service errors', async () => {
+  fetchMock.postOnce('/scan/export', {
+    status: 500,
+    body: { status: 'error' },
+  });
+  await expect(
+    saveCvrExportToUsb({
+      electionDefinition:
+        electionMinimalExhaustiveSampleWithDataFiles.electionDefinition,
+      machineConfig,
+      scannedBallotCount: 0,
+      isTestMode: false,
+      openFilePickerDialog: false,
+    })
+  ).rejects.toThrowErrorMatchingInlineSnapshot(
+    `"failed to generate scan export"`
+  );
+});
+
+test('throws error when there is no usb mounted in kiosk mode', async () => {
+  window.kiosk = fakeKiosk();
+  fetchMock.postOnce(
+    '/scan/export',
+    electionMinimalExhaustiveSampleWithDataFiles.cvrData
+  );
+  await expect(
+    saveCvrExportToUsb({
+      electionDefinition:
+        electionMinimalExhaustiveSampleWithDataFiles.electionDefinition,
+      machineConfig,
+      scannedBallotCount: 0,
+      isTestMode: false,
+      openFilePickerDialog: false,
+    })
+  ).rejects.toThrowErrorMatchingInlineSnapshot(
+    `"could not begin download; path to usb drive missing"`
+  );
+});
+
+test('calls kiosk saveAs when opening file picker dialog', async () => {
+  fetchMock.postOnce(
+    '/scan/export',
+    electionMinimalExhaustiveSampleWithDataFiles.cvrData
+  );
+  const mockKiosk = fakeKiosk();
+  mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
+  const fileWriter = fakeFileWriter();
+  mockKiosk.saveAs = jest.fn().mockResolvedValue(fileWriter);
+  window.kiosk = mockKiosk;
+  await saveCvrExportToUsb({
+    electionDefinition:
+      electionMinimalExhaustiveSampleWithDataFiles.electionDefinition,
+    machineConfig,
+    scannedBallotCount: 0,
+    isTestMode: false,
+    openFilePickerDialog: true,
+  });
+  expect(window.kiosk.saveAs).toHaveBeenCalledWith({
+    defaultPath:
+      'fake mount point/cast-vote-records/sample-county_example-primary-election_147530da13/machine_0003__0_ballots__2020-10-31_00-00-00.jsonl',
+  });
+});
+
+test('throws error when no file is chosen in file picker', async () => {
+  fetchMock.postOnce(
+    '/scan/export',
+    electionMinimalExhaustiveSampleWithDataFiles.cvrData
+  );
+  const mockKiosk = fakeKiosk();
+  mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
+  window.kiosk = mockKiosk;
+  await expect(
+    saveCvrExportToUsb({
+      electionDefinition:
+        electionMinimalExhaustiveSampleWithDataFiles.electionDefinition,
+      machineConfig,
+      scannedBallotCount: 0,
+      isTestMode: false,
+      openFilePickerDialog: true,
+    })
+  ).rejects.toThrowErrorMatchingInlineSnapshot(
+    `"could not begin download; no file was chosen"`
+  );
+});
+
+test('saves file to default location when openFilePicker is false in kiosk mode', async () => {
+  fetchMock.postOnce(
+    '/scan/export',
+    electionMinimalExhaustiveSampleWithDataFiles.cvrData
+  );
+  const mockKiosk = fakeKiosk();
+  mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
+  window.kiosk = mockKiosk;
+  await saveCvrExportToUsb({
+    electionDefinition:
+      electionMinimalExhaustiveSampleWithDataFiles.electionDefinition,
+    machineConfig,
+    scannedBallotCount: 0,
+    isTestMode: false,
+    openFilePickerDialog: false,
+  });
+  expect(window.kiosk.makeDirectory).toHaveBeenCalledWith(
+    'fake mount point/cast-vote-records/sample-county_example-primary-election_147530da13',
+    {
+      recursive: true,
+    }
+  );
+  expect(window.kiosk.writeFile).toHaveBeenCalledWith(
+    'fake mount point/cast-vote-records/sample-county_example-primary-election_147530da13/machine_0003__0_ballots__2020-10-31_00-00-00.jsonl',
+    electionMinimalExhaustiveSampleWithDataFiles.cvrData
+  );
+});
+
+test('calls fileDownload when not in kiosk mode', async () => {
+  window.kiosk = undefined;
+  fetchMock.postOnce(
+    '/scan/export',
+    electionMinimalExhaustiveSampleWithDataFiles.cvrData
+  );
+  await saveCvrExportToUsb({
+    electionDefinition:
+      electionMinimalExhaustiveSampleWithDataFiles.electionDefinition,
+    machineConfig,
+    scannedBallotCount: 0,
+    isTestMode: false,
+    openFilePickerDialog: false,
+  });
+  expect(fileDownload).toHaveBeenCalledWith(
+    electionMinimalExhaustiveSampleWithDataFiles.cvrData,
+    'machine_0003__0_ballots__2020-10-31_00-00-00.jsonl',
+    'application/x-jsonlines'
+  );
+});

--- a/frontends/precinct-scanner/src/utils/save_cvr_export_to_usb.ts
+++ b/frontends/precinct-scanner/src/utils/save_cvr_export_to_usb.ts
@@ -1,0 +1,76 @@
+import { ElectionDefinition } from '@votingworks/types';
+import {
+  generateFilenameForScanningResults,
+  SCANNER_RESULTS_FOLDER,
+  usbstick,
+  generateElectionBasedSubfolderName,
+} from '@votingworks/utils';
+import path from 'path';
+import fileDownload from 'js-file-download';
+import * as scan from '../api/scan';
+import { MachineConfig } from '../config/types';
+
+interface SaveCvrExportToUsbArgs {
+  electionDefinition: ElectionDefinition;
+  machineConfig: MachineConfig;
+  scannedBallotCount: number;
+  isTestMode: boolean;
+  openFilePickerDialog: boolean;
+}
+
+/**
+ * Saves the current results from the scanning service to the usb drive, if present.
+ * @param openFilePickerDialog Toggles whether to open the file picker dialog and allow the user to customize the filename / location to save.
+ */
+export async function saveCvrExportToUsb({
+  electionDefinition,
+  machineConfig,
+  scannedBallotCount,
+  isTestMode,
+  openFilePickerDialog,
+}: SaveCvrExportToUsbArgs): Promise<void> {
+  const cvrFileString = await scan.getExport();
+
+  const cvrFilename = generateFilenameForScanningResults(
+    machineConfig.machineId,
+    scannedBallotCount,
+    isTestMode,
+    new Date()
+  );
+
+  if (window.kiosk) {
+    const usbPath = await usbstick.getDevicePath();
+    if (!usbPath) {
+      throw new Error('could not begin download; path to usb drive missing');
+    }
+    const electionFolderName = generateElectionBasedSubfolderName(
+      electionDefinition.election,
+      electionDefinition.electionHash
+    );
+    const pathToFolder = path.join(
+      usbPath,
+      SCANNER_RESULTS_FOLDER,
+      electionFolderName
+    );
+    const pathToFile = path.join(pathToFolder, cvrFilename);
+    if (openFilePickerDialog) {
+      const fileWriter = await window.kiosk.saveAs({
+        defaultPath: pathToFile,
+      });
+
+      if (!fileWriter) {
+        throw new Error('could not begin download; no file was chosen');
+      }
+
+      await fileWriter.write(cvrFileString);
+      await fileWriter.end();
+    } else {
+      await window.kiosk.makeDirectory(pathToFolder, {
+        recursive: true,
+      });
+      await window.kiosk.writeFile(pathToFile, cvrFileString);
+    }
+  } else {
+    fileDownload(cvrFileString, cvrFilename, 'application/x-jsonlines');
+  }
+}


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Moves the logic to save the CVR export onto the usb drive it's own function. If you are now in kiosk-browser it will just download the file locally. You can call this function with `openFilePickerDialog` set to true to open the file picker dialog (i..e Save As) or false to autosave to the default location. 

## Testing Plan 
Added test for new function, manually exported results. 

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced. - We should add logging to this but skipping for m13 purposes. 
- [x] I have added JSDoc comments to any newly introduced exports
