### PR TITLE
feat(bmd): add TOTP code to poll worker screen

### DIFF
--- a/frontends/bmd/src/config/globals.ts
+++ b/frontends/bmd/src/config/globals.ts
@@ -19,3 +19,4 @@ export enum YES_NO_VOTES {
 }
 export const WRITE_IN_CANDIDATE_MAX_LENGTH = 40;
 export const QUIT_KIOSK_IDLE_SECONDS = 5 * 60; // 5 minutes
+export const POLLING_INTERVAL_FOR_TOTP = 2000;


### PR DESCRIPTION
## Overview
adds TOTP to VxMark (part of #1452)

## Demo Video or Screenshot

Wanted to confirm this is the right screen & placement.  Wasn't entirely clear on where TOTP codes are used so far.

<img width="1620" alt="Screen Shot 2022-03-14 at 9 57 20 AM" src="https://user-images.githubusercontent.com/8034/158187784-d3819888-0ee5-4e10-b965-4fa81fdb0542.png">

If this is correct, I'll update to also include other components.


## Testing Plan 

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
