### PR TITLE
fix(ui): remove mention of poll worker on VxAdmin/VxCentralScan

### DIFF
--- a/frontends/bmd/src/app_root.tsx
+++ b/frontends/bmd/src/app_root.tsx
@@ -1186,6 +1186,7 @@ export function AppRoot({
     return (
       <SetupCardReaderPage
         useEffectToggleLargeDisplay={useEffectToggleLargeDisplay}
+        usePollWorkerLanguage={false}
       />
     );
   }

--- a/frontends/bsd/src/app_root.tsx
+++ b/frontends/bsd/src/app_root.tsx
@@ -507,7 +507,7 @@ export function AppRoot({ card, hardware }: AppRootProps): JSX.Element {
     : new LocalStorage();
 
   if (!cardReader) {
-    return <SetupCardReaderPage />;
+    return <SetupCardReaderPage usePollWorkerLanguage={false} />;
   }
   const currentContext: AppContextInterface = {
     usbDriveStatus: displayUsbStatus,

--- a/libs/ui/src/__snapshots__/setup_card_reader_page.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/setup_card_reader_page.test.tsx.snap
@@ -1,5 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders SetupCardReaderPage renders SetupCardReaderPage with usePollWorkerLanguage set to false 1`] = `
+<div
+  class="sc-hiCivh ePVVDe"
+>
+  <main
+    class="sc-bkkfTU enzCGe"
+  >
+    <div
+      class="sc-ieebsP iIuUkJ"
+    >
+      <div
+        class="sc-jrQzUz dRAoti"
+      >
+        <h1>
+          Card Reader Not Detected
+        </h1>
+        <p>
+          Please connect the card reader to continue.
+        </p>
+      </div>
+    </div>
+  </main>
+</div>
+`;
+
 exports[`renders SetupCardReaderPage triggers useEffect property 1`] = `
 <div
   class="sc-hiCivh ePVVDe"

--- a/libs/ui/src/setup_card_reader_page.test.tsx
+++ b/libs/ui/src/setup_card_reader_page.test.tsx
@@ -17,4 +17,11 @@ describe('renders SetupCardReaderPage', () => {
     expect(container.firstChild).toMatchSnapshot();
     expect(triggerFn).toHaveBeenCalled();
   });
+
+  test('renders SetupCardReaderPage with usePollWorkerLanguage set to false', async () => {
+    const { container } = render(
+      <SetupCardReaderPage usePollWorkerLanguage={false} />
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });

--- a/libs/ui/src/setup_card_reader_page.tsx
+++ b/libs/ui/src/setup_card_reader_page.tsx
@@ -7,13 +7,19 @@ function doNothing() {
 
 interface Props {
   useEffectToggleLargeDisplay?: () => void;
+  usePollWorkerLanguage?: boolean;
 }
 
 export function SetupCardReaderPage({
   useEffectToggleLargeDisplay = doNothing,
+  usePollWorkerLanguage = true,
 }: Props): JSX.Element {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(useEffectToggleLargeDisplay, []);
+
+  const connectMessage = usePollWorkerLanguage
+    ? 'Please ask a poll worker to connect card reader.'
+    : 'Please connect the card reader to continue.';
 
   return (
     <Screen white>
@@ -21,7 +27,7 @@ export function SetupCardReaderPage({
         <MainChild center maxWidth={false}>
           <Prose textCenter maxWidth={false} theme={fontSizeTheme.large}>
             <h1>Card Reader Not Detected</h1>
-            <p>Please ask a poll worker to connect card reader.</p>
+            <p>{connectMessage}</p>
           </Prose>
         </MainChild>
       </Main>


### PR DESCRIPTION
When the card reader is not detected, VxAdmin/VxCentralScan should
not mention a poll worker, instead just prompt for card reader
to be connected by the admin.

## Overview
Fixes #1508

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
