### PR TITLE
fix(scan): handle intentionally blank pages better

### DIFF
--- a/libs/ballot-interpreter-vx/src/index.ts
+++ b/libs/ballot-interpreter-vx/src/index.ts
@@ -6,4 +6,7 @@ export {
 export * from './types';
 export { otsu } from './utils/otsu';
 export { crop } from './utils/crop';
-export { detect as detectQrCode } from './utils/qrcode';
+export {
+  detect as detectQrCode,
+  getSearchAreas as getQrCodeSearchAreas,
+} from './utils/qrcode';

--- a/libs/ballot-interpreter-vx/src/utils/qrcode.ts
+++ b/libs/ballot-interpreter-vx/src/utils/qrcode.ts
@@ -33,7 +33,7 @@ function maybeDecodeBase64(data: Buffer): Buffer {
   }
 }
 
-function* getSearchAreas(
+export function* getSearchAreas(
   size: Size
 ): Generator<{ position: 'top' | 'bottom'; bounds: Rect }> {
   // QR code for HMPB is bottom right of legal, so appears bottom right or top left

--- a/services/scan/src/util/luminosity.ts
+++ b/services/scan/src/util/luminosity.ts
@@ -1,4 +1,5 @@
 import { otsu } from '@votingworks/ballot-interpreter-vx';
+import { Rect } from '@votingworks/types';
 import makeDebug from 'debug';
 
 const debug = makeDebug('scan:threshold');
@@ -19,35 +20,46 @@ export interface LuminosityCounts {
  * foreground or background based on `threshold`.
  */
 export function stats(
-  { data }: ImageData,
-  { threshold = otsu(data) } = {}
+  { data, width, height }: ImageData,
+  {
+    threshold: fixedThreshold,
+    bounds = { x: 0, y: 0, width, height },
+  }: { threshold?: number; bounds?: Rect } = {}
 ): Stats {
   const start = Date.now();
+  const threshold = fixedThreshold ?? otsu(data);
+  const channels = data.length / (width * height);
+  const pixelCount = bounds.width * bounds.height;
 
   let foreground = 0;
-  for (let i = 0; i < data.length; i += 1) {
-    if (data[i] < threshold) {
-      foreground += 1;
+  for (let { x } = bounds; x < bounds.x + bounds.width; x += 1) {
+    for (let { y } = bounds; y < bounds.y + bounds.height; y += 1) {
+      const pixel = data[(y * width + x) * channels];
+      if (pixel < threshold) {
+        foreground += 1;
+      }
     }
   }
-  const background = data.length - foreground;
+
+  const background = pixelCount - foreground;
 
   const result: Stats = {
     threshold,
     foreground: {
       count: foreground,
-      ratio: foreground / data.length,
+      ratio: foreground / pixelCount,
     },
     background: {
       count: background,
-      ratio: background / data.length,
+      ratio: background / pixelCount,
     },
   };
 
   const end = Date.now();
   debug(
-    'computed luminosity stats on %d pixels in %dms: %O',
-    data.length,
+    'computed luminosity stats on %d pixels (%o) in %dms: %O',
+    pixelCount,
+    bounds,
     end - start,
     result
   );


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
If a ballot sheet has contests on only one side then it will have an intentionally blank back page. This page isn't actually blank, but has a sentence explaining that it is being left blank intentionally. It also has a footer with the usual election information and QR code.

Additionally, we have some code that attempts to determine whether a page is blank (in the sense of an empty white page) before trying to look for a QR code. This is partly an optimization and partly to make sure nothing weird ends up on the other side of a BMD ballot.

Putting these together, though, causes a problem. The "blank page" detection works by counting the foreground (dark) vs background (light) pixels and, if the percentage of foreground pixels is less than 0.7% then we consider it truly blank and do not bother looking for a QR code. The threshold of 0.7% is very close to the value for an average "blank" sheet back page of letter size. For legal size, the foreground percent can be even lower.

This hasn't really been a problem because we infer "missing" QR codes when they aren't read properly. However, we can do better. This commit looks in the areas that we would look for QR codes and determines if any of them looks dark enough. If they are dark enough, we treat the page as non-blank and proceed to look for a QR code.

## Demo Video or Screenshot
n/a

## Testing Plan 
- [x] test with BMD ballots
- [x] test with HMPB ballots

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
