### PR TITLE
fix(scan): Fix empty election hash in interpreted BMD ballot

### DIFF
--- a/libs/types/src/api/services/scan/index.ts
+++ b/libs/types/src/api/services/scan/index.ts
@@ -24,7 +24,7 @@ import {
   PrecinctId,
   PrecinctIdSchema,
 } from '../../../election';
-import { HexString, IdSchema } from '../../../generic';
+import { ElectionHash, IdSchema } from '../../../generic';
 
 export type Side = 'front' | 'back';
 export const SideSchema = z.union([z.literal('front'), z.literal('back')]);
@@ -82,7 +82,7 @@ export interface ScanStatus {
 }
 
 export const ScanStatusSchema: z.ZodSchema<ScanStatus> = z.object({
-  electionHash: z.optional(HexString),
+  electionHash: z.optional(ElectionHash),
   batches: z.array(BatchInfoSchema),
   adjudication: AdjudicationStatusSchema,
   scanner: ScannerStatusSchema,

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -4,7 +4,7 @@ import * as z from 'zod';
 import { Iso8601Timestamp, Iso8601TimestampSchema } from './api';
 import {
   Dictionary,
-  HexString,
+  ElectionHash,
   Id,
   IdSchema,
   Iso8601Date,
@@ -627,7 +627,7 @@ export const ElectionDefinitionSchema: z.ZodSchema<ElectionDefinition> = z.objec
   {
     election: ElectionSchema,
     electionData: z.string().nonempty(),
-    electionHash: HexString,
+    electionHash: ElectionHash,
   }
 );
 export type OptionalElectionDefinition = Optional<ElectionDefinition>;
@@ -901,7 +901,7 @@ export interface HmpbBallotPageMetadata {
 }
 export const HmpbBallotPageMetadataSchema: z.ZodSchema<HmpbBallotPageMetadata> = z.object(
   {
-    electionHash: HexString,
+    electionHash: ElectionHash,
     precinctId: PrecinctIdSchema,
     ballotStyleId: BallotStyleIdSchema,
     locales: BallotLocaleSchema,
@@ -917,7 +917,7 @@ export type BallotMetadata = Omit<
   'pageNumber' | 'ballotId'
 >;
 export const BallotMetadataSchema: z.ZodSchema<BallotMetadata> = z.object({
-  electionHash: HexString,
+  electionHash: ElectionHash,
   precinctId: PrecinctIdSchema,
   ballotStyleId: BallotStyleIdSchema,
   locales: BallotLocaleSchema,
@@ -1246,7 +1246,7 @@ export interface PollworkerCardData extends CardData {
 export const PollworkerCardDataSchema: z.ZodSchema<PollworkerCardData> = CardDataInternalSchema.extend(
   {
     t: z.literal('pollworker'),
-    h: HexString,
+    h: ElectionHash,
   }
 );
 
@@ -1260,7 +1260,7 @@ export interface AdminCardData extends CardData {
 export const AdminCardDataSchema: z.ZodSchema<AdminCardData> = CardDataInternalSchema.extend(
   {
     t: z.literal('admin'),
-    h: HexString,
+    h: ElectionHash,
     p: z.string().optional(),
   }
 );

--- a/libs/types/src/generic.ts
+++ b/libs/types/src/generic.ts
@@ -223,12 +223,12 @@ export const IdSchema: z.ZodSchema<Id> = z
     (id) => /^[-_a-z\d]+$/i.test(id),
     'IDs may only contain letters, numbers, dashes, and underscores'
   );
-export const HexString: z.ZodSchema<string> = z
+export const ElectionHash: z.ZodSchema<string> = z
   .string()
   .nonempty()
   .refine(
-    (hex) => /^[0-9a-f]*$/i.test(hex),
-    'hex strings must contain only 0-9 and a-f'
+    (hash) => /^[0-9a-f]*$/i.test(hash),
+    'Election hashes must be hex strings containing only 0-9 and a-f'
   );
 export const Iso8601Date = z
   .string()

--- a/libs/types/src/schema.test.ts
+++ b/libs/types/src/schema.test.ts
@@ -788,7 +788,7 @@ test('validates admin cards have hex-encoded hashes', () => {
     [Error: [
       {
         "code": "custom",
-        "message": "hex strings must contain only 0-9 and a-f",
+        "message": "Election hashes must be hex strings containing only 0-9 and a-f",
         "path": [
           "h"
         ]

--- a/services/scan/src/interpreter.test.ts
+++ b/services/scan/src/interpreter.test.ts
@@ -81,7 +81,7 @@ test('extracts votes encoded in a QR code', async () => {
       "metadata": Object {
         "ballotStyleId": "12",
         "ballotType": 0,
-        "electionHash": "",
+        "electionHash": "b52e9f4728bb34e7ff48",
         "isTestMode": true,
         "locales": Object {
           "primary": "en-US",

--- a/services/scan/src/interpreter.ts
+++ b/services/scan/src/interpreter.ts
@@ -356,7 +356,7 @@ export class Interpreter {
         type: 'InterpretedBmdPage',
         ballotId: ballot.ballotId,
         metadata: {
-          electionHash: '',
+          electionHash: ballot.electionHash,
           ballotType: BallotType.Standard,
           locales: { primary: 'en-US' },
           ballotStyleId: ballot.ballotStyleId,


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Task: #1461 

This bug surfaced when scanning a live ballot in test mode, since the
adjudication screen tries to parse the interpreted ballot metadata and
the metadata schema expects a non-empty election hash. Since we have
that data available in the interpreter, we can just return it. It seems
like just a weird legacy behavior to return an empty string, as that
code was written a year and a half ago.

Also renames the `HexString` type to `ElectionHash`, since hex strings
could potentially be empty, but election hashes shouldn't be.

## Demo Video or Screenshot
N/A

## Testing Plan 
Updated snapshot in unit test

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
