### PR TITLE
fix(scan): make store.batchStatus query include batches w/deleted sheets

### DIFF
--- a/services/scan/src/store.test.ts
+++ b/services/scan/src/store.test.ts
@@ -217,12 +217,38 @@ test('batchStatus', () => {
       },
     },
   ]);
+
+  // Add a second sheet
+  const sheetId2 = store.addSheet(uuid(), batchId, [
+    {
+      originalFilename: '/tmp/front-page2.png',
+      normalizedFilename: '/tmp/front-normalized-page2.png',
+      interpretation: {
+        type: 'UninterpretedHmpbPage',
+        metadata: frontMetadata,
+      },
+    },
+    {
+      originalFilename: '/tmp/back-page2.png',
+      normalizedFilename: '/tmp/back-normalized-page2.png',
+      interpretation: {
+        type: 'UninterpretedHmpbPage',
+        metadata: backMetadata,
+      },
+    },
+  ]);
   let batches = store.batchStatus();
+  expect(batches).toHaveLength(1);
+  expect(batches[0].count).toEqual(2);
+
+  // Delete one of the sheets
+  store.deleteSheet(sheetId);
+  batches = store.batchStatus();
   expect(batches).toHaveLength(1);
   expect(batches[0].count).toEqual(1);
 
-  // Delete the sheet we created, then confirm that store.batchStatus() results still include the batch
-  store.deleteSheet(sheetId);
+  // Delete the last sheet, then confirm that store.batchStatus() results still include the batch
+  store.deleteSheet(sheetId2);
   batches = store.batchStatus();
   expect(batches).toHaveLength(1);
   expect(batches[0].count).toEqual(0);

--- a/services/scan/src/store.ts
+++ b/services/scan/src/store.ts
@@ -661,8 +661,8 @@ export class Store {
         batches left join sheets
       on
         sheets.batch_id = batches.id
-      where
-        deleted_at is null
+      and
+        sheets.deleted_at is null
       group by
         batches.id,
         batches.started_at,


### PR DESCRIPTION
## Overview
Fixes #1561

## Testing Plan 
Added a test case for `store.batchStatus()`

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
