### PR TITLE
Fix various state updates after unmount errors etc

### DIFF
--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -65,8 +65,6 @@ const EITHER_NEITHER_SEMS_DATA =
 jest.mock('./components/hand_marked_paper_ballot');
 
 beforeEach(() => {
-  // we don't care about network errors logged to the console, they're crowding things
-  jest.spyOn(console, 'error').mockImplementation(() => {}); // eslint-disable-line @typescript-eslint/no-empty-function
   Object.defineProperty(window, 'location', {
     writable: true,
     value: { assign: jest.fn() },

--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -153,11 +153,11 @@ test('create election works', async () => {
   fireEvent.click(getByText('English/Spanish'));
 
   // You can view the advanced screen and export log files when there is an election.
-  await fireEvent.click(screen.getByText('Advanced'));
-  await fireEvent.click(screen.getByText('Export Log File'));
+  fireEvent.click(screen.getByText('Advanced'));
+  fireEvent.click(screen.getByText('Export Log File'));
   await screen.findByText('No Log File Present');
-  await fireEvent.click(screen.getByText('Close'));
-  await fireEvent.click(screen.getByText('Export Log File as CDF'));
+  fireEvent.click(screen.getByText('Close'));
+  fireEvent.click(screen.getByText('Export Log File as CDF'));
   await screen.findByText('No Log File Present');
 
   fireEvent.click(getByText('Definition'));
@@ -178,15 +178,15 @@ test('create election works', async () => {
   );
 
   // You can view the advanced screen and export log files when there is no election.
-  await fireEvent.click(screen.getByText('Advanced'));
-  await fireEvent.click(screen.getByText('Export Log File'));
+  fireEvent.click(screen.getByText('Advanced'));
+  fireEvent.click(screen.getByText('Export Log File'));
   await screen.findByText('No Log File Present');
-  await fireEvent.click(screen.getByText('Close'));
-  await fireEvent.click(screen.getByText('Export Log File as CDF'));
+  fireEvent.click(screen.getByText('Close'));
+  fireEvent.click(screen.getByText('Export Log File as CDF'));
   // You can not export as CDF when there is no election.
-  expect(await screen.queryAllByText('No Log File Present')).toHaveLength(0);
+  expect(screen.queryAllByText('No Log File Present')).toHaveLength(0);
 
-  await fireEvent.click(screen.getByText('Configure'));
+  fireEvent.click(screen.getByText('Configure'));
   await screen.findByText('Create New Election Definition');
 });
 

--- a/frontends/election-manager/src/components/__mocks__/hand_marked_paper_ballot.tsx
+++ b/frontends/election-manager/src/components/__mocks__/hand_marked_paper_ballot.tsx
@@ -1,16 +1,22 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { HandMarkedPaperBallotProps } from '../hand_marked_paper_ballot';
 
 export function HandMarkedPaperBallot({
-  ballotStyleId,
-  election,
-  precinctId,
   onRendered,
+  ...rest
 }: HandMarkedPaperBallotProps): JSX.Element {
-  if (onRendered) {
-    setImmediate(onRendered);
-  }
+  useEffect(() => {
+    if (!onRendered) {
+      return;
+    }
 
+    const immediate = setImmediate(() => {
+      onRendered(rest);
+    });
+    return () => clearImmediate(immediate);
+  }, [onRendered, rest]);
+
+  const { election, ballotStyleId, precinctId } = rest;
   return (
     <div>
       <h1>Mocked HMPB</h1>

--- a/frontends/election-manager/src/screens/tally_screen.tsx
+++ b/frontends/election-manager/src/screens/tally_screen.tsx
@@ -13,7 +13,7 @@ import {
   format,
   find,
 } from '@votingworks/utils';
-import { Table, TD, Modal } from '@votingworks/ui';
+import { Table, TD, Modal, useCancelablePromise } from '@votingworks/ui';
 import { TallyCategory, ExternalTallySourceType } from '@votingworks/types';
 import { LogEventId } from '@votingworks/logging';
 import { InputEventFunction, ResultsFileType } from '../config/types';
@@ -40,6 +40,8 @@ import { ImportExternalResultsModal } from '../components/import_external_result
 import { SaveFileToUsb, FileType } from '../components/save_file_to_usb';
 
 export function TallyScreen(): JSX.Element {
+  const makeCancelable = useCancelablePromise();
+
   const {
     castVoteRecordFiles,
     electionDefinition,
@@ -143,13 +145,13 @@ export function TallyScreen(): JSX.Element {
   useEffect(() => {
     void (async () => {
       try {
-        await new ConverterClient('tallies').getFiles();
+        await makeCancelable(new ConverterClient('tallies').getFiles());
         setHasConverter(true);
       } catch {
         setHasConverter(false);
       }
     })();
-  }, []);
+  }, [makeCancelable]);
 
   const fileMode = castVoteRecordFiles?.fileMode;
   const fileModeText =

--- a/frontends/election-manager/src/screens/unconfigured_screen.tsx
+++ b/frontends/election-manager/src/screens/unconfigured_screen.tsx
@@ -3,7 +3,7 @@ import { useHistory, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import { parseElection } from '@votingworks/types';
 
-import { Modal } from '@votingworks/ui';
+import { Modal, useCancelablePromise } from '@votingworks/ui';
 import { ConverterClient, VxFile } from '../lib/converter_client';
 import { readFileAsync } from '../lib/read_file_async';
 
@@ -53,6 +53,7 @@ const newElection = JSON.stringify(defaultElection);
 export function UnconfiguredScreen(): JSX.Element {
   const history = useHistory();
   const location = useLocation();
+  const makeCancelable = useCancelablePromise();
 
   const { saveElection } = useContext(AppContext);
 
@@ -143,7 +144,7 @@ export function UnconfiguredScreen(): JSX.Element {
 
   const updateStatus = useCallback(async () => {
     try {
-      const files = await client.getFiles();
+      const files = await makeCancelable(client.getFiles());
 
       setIsLoading(true);
 
@@ -163,7 +164,7 @@ export function UnconfiguredScreen(): JSX.Element {
     } catch (error) {
       setIsLoading(false);
     }
-  }, [client, getOutputFile, processInputFiles]);
+  }, [client, getOutputFile, makeCancelable, processInputFiles]);
 
   async function submitFile({ file, name }: InputFile) {
     try {

--- a/libs/ui/src/hooks/use_devices.ts
+++ b/libs/ui/src/hooks/use_devices.ts
@@ -10,6 +10,7 @@ import { map } from 'rxjs/operators';
 import { LogEventId, Logger } from '@votingworks/logging';
 import useInterval from 'use-interval';
 import { usePrevious } from '..';
+import { useCancelablePromise } from './use_cancelable_promise';
 
 export const LOW_BATTERY_THRESHOLD = 0.25;
 export const BATTERY_POLLING_INTERVAL = 3000;
@@ -51,6 +52,7 @@ function getDeviceName(device: KioskBrowser.Device) {
 }
 
 export function useDevices({ hardware, logger }: Props): Devices {
+  const makeCancelable = useCancelablePromise();
   const [allDevices, setAllDevices] = useState<KioskBrowser.Device[]>([]);
   const [allPrinters, setAllPrinters] = useState<KioskBrowser.PrinterInfo[]>(
     []
@@ -78,7 +80,7 @@ export function useDevices({ hardware, logger }: Props): Devices {
 
   useInterval(
     async () => {
-      setBattery(await hardware.readBatteryStatus());
+      setBattery(await makeCancelable(hardware.readBatteryStatus()));
     },
     BATTERY_POLLING_INTERVAL,
     true

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -8,6 +8,7 @@ export * from './election_info_bar';
 export * from './hooks/use_autocomplete';
 export * from './hooks/use_cancelable_promise';
 export * from './hooks/use_devices';
+export * from './hooks/use_mounted_state';
 export * from './hooks/use_now';
 export * from './hooks/use_previous';
 export * from './hooks/use_smartcard';


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
In working on a task in `election-manager` I found that my errors were being swallowed. This turned out to be due to `app.test.tsx` ignoring all calls to `console.error`. Upon removing the code that did that, I found there were several update-state-after-unmount errors occurring. This PR re-enables `console.error` and fixes the errors.

## Demo Video or Screenshot
n/a

## Testing Plan 
Automated testing.

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
