### PR TITLE
[VxScan] Streamline Polls Open and Polls Close flows

### DIFF
--- a/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
+++ b/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
@@ -511,10 +511,8 @@ test('App shows warning message to connect to power when disconnected', async ()
   );
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises(1);
-  fireEvent.click(await screen.findByText('Open Polls for All Precincts'));
-  fireEvent.click(await screen.findByText('Save Report and Open Polls'));
-  await screen.findByText('Saving to Card');
-  await screen.findByText('Print the Open Polls Report');
+  fireEvent.click(await screen.findByText('Yes, Open the Polls'));
+  await screen.findByText('Polls are open.');
 
   // Remove pollworker card
   card.removeCard();

--- a/frontends/precinct-scanner/src/screens/poll_worker_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/poll_worker_screen.tsx
@@ -317,7 +317,7 @@ export function PollWorkerScreen({
         openFilePickerDialog: false,
       });
     }
-    await sleep(1000);
+    await sleep(4000);
     await usbDrive.eject(currentUserSession.type);
     togglePollsOpen();
     setPollWorkerFlowState(PollWorkerFlowState.CLOSE_POLLS_FLOW__COMPLETE);

--- a/services/smartcards/.gitignore
+++ b/services/smartcards/.gitignore
@@ -4,3 +4,4 @@
 .coverage
 .mypy_cache
 .venv
+Pipfile.lock


### PR DESCRIPTION
Note: First commit (and most of the work) by @beausmith  I just added some tests and tied up the export to usb / eject usb functionality. 
## Overview
<!-- add a link to a Github Issue here -->
https://github.com/votingworks/vxsuite/issues/1433

Streamlines the pollworker opening polls and closing polls flow to be as simple as possible, just one click to handle most things. Opening and Closing polls automatically prints the tally report, when connected to a printer, and saves the tallies to the card when not. Closing the polls also automatically exports the results to the usb drive and ejects the usb drive. 

## Demo Video or Screenshot
Opening Polls:

https://user-images.githubusercontent.com/14897017/158506815-ad03e1b1-bbd9-4233-8d2a-a2d9cbac7604.mov

Closing Polls:

https://user-images.githubusercontent.com/14897017/158506846-0b8b34fb-a1d0-4071-af23-a69ff8fe603b.mov

## Testing Plan 
Manually tested both the printer connected and non printer connected flows. Manually tested printing from VxMark after saving to the card. Updated tests to work with the new flow. 

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced. - Flow did not previously have logging so ignoring for now. 
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
