### PR TITLE
Prepare for ballot package changes

### DIFF
--- a/frontends/election-manager/src/components/__mocks__/hand_marked_paper_ballot.tsx
+++ b/frontends/election-manager/src/components/__mocks__/hand_marked_paper_ballot.tsx
@@ -3,20 +3,22 @@ import { HandMarkedPaperBallotProps } from '../hand_marked_paper_ballot';
 
 export function HandMarkedPaperBallot({
   onRendered,
-  ...rest
+  election,
+  ballotStyleId,
+  precinctId,
+  electionHash,
+  locales,
 }: HandMarkedPaperBallotProps): JSX.Element {
   useEffect(() => {
-    if (!onRendered) {
-      return;
-    }
-
-    const immediate = setImmediate(() => {
-      onRendered(rest);
+    onRendered?.({
+      election,
+      ballotStyleId,
+      precinctId,
+      electionHash,
+      locales,
     });
-    return () => clearImmediate(immediate);
-  }, [onRendered, rest]);
+  }, [ballotStyleId, election, electionHash, locales, onRendered, precinctId]);
 
-  const { election, ballotStyleId, precinctId } = rest;
   return (
     <div>
       <h1>Mocked HMPB</h1>

--- a/frontends/election-manager/src/screens/print_test_deck_screen.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.tsx
@@ -8,7 +8,7 @@ import {
 } from '@votingworks/types';
 import { assert, sleep } from '@votingworks/utils';
 import { LogEventId } from '@votingworks/logging';
-import { Modal } from '@votingworks/ui';
+import { useCancelablePromise, Modal } from '@votingworks/ui';
 import { routerPaths } from '../router_paths';
 
 import { AppContext } from '../contexts/app_context';
@@ -83,6 +83,7 @@ function TestDeckBallots({
 const TestDeckBallotsMemoized = React.memo(TestDeckBallots);
 
 export function PrintTestDeckScreen(): JSX.Element {
+  const makeCancelable = useCancelablePromise();
   const {
     electionDefinition,
     printer,
@@ -159,14 +160,21 @@ export function PrintTestDeckScreen(): JSX.Element {
       if (precinctIndex < precinctIds.length - 1) {
         // wait 5s per ballot printed
         // that's how long printing takes in duplex, no reason to get ahead of it.
-        await sleep(numBallots * 5000);
+        await makeCancelable(sleep(numBallots * 5000));
         setPrecinctIndex(precinctIndex + 1);
       } else {
-        await sleep(3000);
+        await makeCancelable(sleep(3000));
         setPrecinctIndex(undefined);
       }
     },
-    [printer, logger, currentUserType, precinctIds, precinctIndex]
+    [
+      precinctIndex,
+      printer,
+      logger,
+      currentUserType,
+      precinctIds,
+      makeCancelable,
+    ]
   );
 
   const currentPrecinct =

--- a/frontends/election-manager/test/helpers/fake_file_writer.ts
+++ b/frontends/election-manager/test/helpers/fake_file_writer.ts
@@ -9,7 +9,7 @@ export function fakeFileWriter(): jest.Mocked<FakeFileWriter> {
 
   return {
     filename: '/fake/file',
-    write: jest.fn().mockImplementation((chunk) => {
+    write: jest.fn().mockImplementation(async (chunk) => {
       chunks.push(chunk);
     }),
     end: jest.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
In trying to get the tests working for https://github.com/votingworks/vxsuite/pull/1585 I discovered that the way `app.test.tsx` was testing the ballot package export was broken, but only if there were a series of files being added to the package that were non-empty. `zip-stream` appears to operate synchronously when the files added to the zip stream are empty, but asynchronously when there is data to actually compress. Because we'd mocked `printToPDF` to resolve to an empty buffer, the file data has so far been empty. Writing the layout information for each ballot was not empty, and so we triggered the asynchronous behavior of `zip-stream`. This meant that when we tried to check that the download had completed by looking at the calls to `kiosk.log` we would not find it.

I tried a variety of things to get it to wait long enough, but in the end the only thing that worked was to call `jest.advanceTimersByTime(0)` _while fake timers were disabled_. This, of course, made jest issue a warning but it did work. My theory as to why is that when the application is started and interacted with using fake timers, that the `zip-stream` library was caching a reference to the fake `setTimeout` somehow and that, despite calling `jest.useRealTimers` later, it still held on to the fake timer which would still respond to `jest.advanceTimersByTime`. I didn't dig deep enough to prove this, but decided to just cut my losses and remove the ballot package testing from `app.test.tsx` since it's already pretty well tested by its component test. This removes the `jest.useRealTimers` call that was mucking things up, too. In general we should _not_ mix real and fake timers in a single test or, even better, in a single test file.

This PR also includes a few other minor fixes I made along the way.

## Demo Video or Screenshot
n/a

## Testing Plan 
Automated testing.

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
