### PR TITLE
chore(deps): Add fsevents as optionalDependency to fix prod build

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
     "pnpm": "^5.18.10",
     "prettier": "^2.3.2",
     "sort-package-json": "^1.50.0"
+  },
+  "optionalDependencies": {
+    "fsevents": "^2.3.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,8 +8,11 @@ importers:
       pnpm: 5.18.10
       prettier: 2.3.2
       sort-package-json: 1.50.0
+    optionalDependencies:
+      fsevents: 2.3.2
     specifiers:
       eslint: ^7.29.0
+      fsevents: ^2.3.2
       husky: ^7.0.0
       lint-staged: ^11.0.0
       ora: ^5.2.0


### PR DESCRIPTION
## Overview
There was a prod build error that had been ignored for a long time. fsevents is an optional dependency of some vxsuite subdependencies. fsevents is only used on Mac, not Linux, so it should have been skipped, but for some reason the prod build script was trying to install it. This explicitly names it as a top-level optional dependency, which seems to make it get skipped correctly.

## Demo Video or Screenshot
N/A

## Testing Plan 
Manually tested

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
