### PR TITLE
fix(ui) fix bug when usb is removed while ejecting

### DIFF
--- a/libs/ui/src/hooks/use_usb_drive.ts
+++ b/libs/ui/src/hooks/use_usb_drive.ts
@@ -85,7 +85,8 @@ export function useUsbDrive({ logger }: UsbDriveProps): UsbDrive {
         newStatus,
       });
       if (
-        status === UsbDriveStatus.present &&
+        (status === UsbDriveStatus.present ||
+          status === UsbDriveStatus.ejecting) &&
         newStatus === UsbDriveStatus.absent
       ) {
         debug('USB drive removed');


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
https://github.com/votingworks/vxsuite/issues/1517
I saw how to fix this while working on a different task. Basically when a usb drive was removed while it was in the middle of ejecting (which currently includes a 10 second sleep) it gets stuck in the "ejected" state and then when you put a usb back in it won't try to mount it. This updates the usb logic to allow a transition from the "ejecting" state to the "absent" state for when the usb is remove mid-ejection. This means that the usb will then properly be in the "absent" state and allow for remounting when a usb is plugged back in. 

## Demo Video or Screenshot

## Testing Plan 
Manually tested through kiosk-browser and added a test case to cover this scenario. 

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
