### PR TITLE
fix(em) fix bug with import cvr modal width

### DIFF
--- a/frontends/election-manager/src/components/import_cvrfiles_modal.tsx
+++ b/frontends/election-manager/src/components/import_cvrfiles_modal.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import path from 'path';
 import moment from 'moment';
 
-import { Modal, Table, TD } from '@votingworks/ui';
+import { Modal, ModalWidth, Table, TD } from '@votingworks/ui';
 import {
   assert,
   generateElectionBasedSubfolderName,
@@ -46,10 +46,6 @@ const LabelText = styled.span`
 
 const TestMode = styled.span`
   color: #ff8c00;
-`;
-
-const ImportCvrsModalContent = styled.div`
-  max-width: 45rem;
 `;
 
 enum ModalState {
@@ -340,7 +336,7 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
           <Prose>
             <h1>No USB Drive Detected</h1>
             <p>
-              <UsbImage src="usb-drive.svg" alt="Insert USB Image" />
+              <UsbImage src="assets/usb-drive.svg" alt="Insert USB Image" />
               Please insert a USB drive in order to import CVR files from the
               scanner.
             </p>
@@ -454,32 +450,31 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
 
     return (
       <Modal
+        modalWidth={ModalWidth.Wide}
         content={
-          <ImportCvrsModalContent>
-            <MainChild>
-              <Prose maxWidth={false}>
-                <h1 data-testid="modal-title">
-                  Import {headerModeText} CVR Files{' '}
-                </h1>
-                <p>{instructionalText}</p>
-              </Prose>
-              {fileTableRows.length > 0 && (
-                <CvrFileTable>
-                  <thead>
-                    <tr>
-                      <th>Exported At</th>
-                      <th>Scanner ID</th>
-                      <th>New CVRs</th>
-                      <th>Imported CVRs</th>
-                      {!fileModeLocked && <th>Ballot Type</th>}
-                      <th />
-                    </tr>
-                  </thead>
-                  <tbody>{fileTableRows}</tbody>
-                </CvrFileTable>
-              )}
-            </MainChild>
-          </ImportCvrsModalContent>
+          <MainChild>
+            <Prose maxWidth={false}>
+              <h1 data-testid="modal-title">
+                Import {headerModeText} CVR Files{' '}
+              </h1>
+              <p>{instructionalText}</p>
+            </Prose>
+            {fileTableRows.length > 0 && (
+              <CvrFileTable>
+                <thead>
+                  <tr>
+                    <th>Exported At</th>
+                    <th>Scanner ID</th>
+                    <th>New CVRs</th>
+                    <th>Imported CVRs</th>
+                    {!fileModeLocked && <th>Ballot Type</th>}
+                    <th />
+                  </tr>
+                </thead>
+                <tbody>{fileTableRows}</tbody>
+              </CvrFileTable>
+            )}
+          </MainChild>
         }
         onOverlayClick={onClose}
         actions={

--- a/libs/ui/src/modal.test.tsx
+++ b/libs/ui/src/modal.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Modal } from './modal';
+import { Modal, ModalWidth } from './modal';
 import { Button } from './button';
 
 describe('Modal', () => {
@@ -31,10 +31,53 @@ describe('Modal', () => {
     render(<Modal content="Do you want to do the thing?" centerContent />);
 
     const modal = screen.getByRole('alertdialog');
+    expect(modal).toMatchInlineSnapshot(`
+      <div
+        aria-label="Alert Modal"
+        aria-modal="true"
+        class="sc-gsDJrp blYTQX ReactModal__Content _"
+        data-testid="modal"
+        role="alertdialog"
+        tabindex="-1"
+      >
+        <div
+          class="sc-hKwCoD RDMJL"
+        >
+          Do you want to do the thing?
+        </div>
+      </div>
+    `);
     const content = within(modal).getByText('Do you want to do the thing?');
     expect(content).toHaveStyle(`
       align-items: center;
       justify-content: center;
+    `);
+  });
+
+  it('can configure a wider max width', () => {
+    render(
+      <Modal
+        modalWidth={ModalWidth.Wide}
+        content="Do you want to do the thing?"
+      />
+    );
+
+    const modal = screen.getByRole('alertdialog');
+    expect(modal).toMatchInlineSnapshot(`
+      <div
+        aria-label="Alert Modal"
+        aria-modal="true"
+        class="sc-gsDJrp jZBRml ReactModal__Content _"
+        data-testid="modal"
+        role="alertdialog"
+        tabindex="-1"
+      >
+        <div
+          class="sc-hKwCoD kFWWdL"
+        >
+          Do you want to do the thing?
+        </div>
+      </div>
     `);
   });
 

--- a/libs/ui/src/modal.tsx
+++ b/libs/ui/src/modal.tsx
@@ -5,7 +5,18 @@ import styled from 'styled-components';
 
 import { ButtonBar } from './button_bar';
 
-const ReactModalContent = styled.div`
+/**
+ * Controls the maximum width the modal can expand to.
+ */
+export enum ModalWidth {
+  Standard = '30rem',
+  Wide = '45rem',
+}
+
+interface ReactModalContentInterface {
+  modalWidth?: ModalWidth;
+}
+const ReactModalContent = styled('div')<ReactModalContentInterface>`
   display: flex;
   flex-direction: column;
   position: absolute;
@@ -22,7 +33,7 @@ const ReactModalContent = styled.div`
   @media (min-width: 480px) {
     position: static;
     border-radius: 0.25rem;
-    max-width: 30rem;
+    max-width: ${({ modalWidth = ModalWidth.Standard }) => modalWidth};
   }
   @media print {
     display: none;
@@ -86,6 +97,7 @@ interface Props {
   actions?: ReactNode;
   onAfterOpen?: () => void;
   onOverlayClick?: () => void;
+  modalWidth?: ModalWidth;
 }
 
 /* istanbul ignore next - unclear why this isn't covered */
@@ -107,6 +119,7 @@ export function Modal({
   ariaHideApp = true,
   onAfterOpen = focusModalAudio,
   onOverlayClick,
+  modalWidth,
 }: Props): JSX.Element {
   /* istanbul ignore next - can't get document.getElementById working in test */
   const appElement =
@@ -125,7 +138,9 @@ export function Modal({
       onRequestClose={onOverlayClick}
       testId="modal"
       contentElement={(props, children) => (
-        <ReactModalContent {...props}>{children}</ReactModalContent>
+        <ReactModalContent modalWidth={modalWidth} {...props}>
+          {children}
+        </ReactModalContent>
       )}
       overlayElement={(props, contentElement) => (
         <ReactModalOverlay {...props}>{contentElement}</ReactModalOverlay>


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
https://github.com/votingworks/vxsuite/issues/1464
This is actually a bug that was introduced when we got rid of the Modal css files. @beausmith let me know if you think this approach is ok of having a ModalWidth variable to expand the width in specific cases. 

## Demo Video or Screenshot
Before:
![Screen Shot 2022-03-17 at 11 07 22 AM](https://user-images.githubusercontent.com/14897017/158872619-c77a073c-9ba3-498f-a435-983a029c15ef.png)


After:

![Screen Shot 2022-03-17 at 11 33 09 AM](https://user-images.githubusercontent.com/14897017/158872638-9249e06f-184c-40e8-ae6a-2017ebf0a7f4.png)

## Testing Plan 
Loaded and saw wider modal, loaded other modals and they were the same size as before.

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
