### PR TITLE
fix(ps) eject usb automatically when unconfigured vxscan

### DIFF
--- a/frontends/precinct-scanner/src/app.test.tsx
+++ b/frontends/precinct-scanner/src/app.test.tsx
@@ -427,6 +427,7 @@ test('admin and pollworker configuration', async () => {
   await waitFor(() =>
     expect(fetchMock.calls('./config/election', { method: 'DELETE' }))
   );
+  expect(window.kiosk.unmountUsbDrive).toHaveBeenCalledTimes(1);
 });
 
 test('voter can cast a ballot that scans successfully ', async () => {

--- a/frontends/precinct-scanner/src/screens/admin_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/admin_screen.test.tsx
@@ -129,3 +129,61 @@ test('export from admin screen', async () => {
 
   fireEvent.click(screen.getByText('Export Backup to USB Drive'));
 });
+
+test('unconfigure ejects a usb drive when it is mounted', async () => {
+  const ejectFn = jest.fn();
+  const unconfigureFn = jest.fn();
+  render(
+    <AppContext.Provider
+      value={{
+        electionDefinition: electionSampleDefinition,
+        machineConfig: { machineId: '0000', codeVersion: 'TEST' },
+        currentUserSession: { type: 'admin', authenticated: true },
+      }}
+    >
+      <AdminScreen
+        scannedBallotCount={10}
+        isTestMode={false}
+        updateAppPrecinctId={jest.fn()}
+        toggleLiveMode={jest.fn()}
+        unconfigure={unconfigureFn}
+        calibrate={jest.fn()}
+        usbDrive={{ status: usbstick.UsbDriveStatus.absent, eject: ejectFn }}
+      />
+    </AppContext.Provider>
+  );
+
+  await fireEvent.click(screen.getByText('Unconfigure Machine'));
+  await fireEvent.click(screen.getByText('Unconfigure'));
+  expect(unconfigureFn).toHaveBeenCalledTimes(1);
+  expect(ejectFn).toHaveBeenCalledTimes(0);
+});
+
+test('unconfigure does not eject a usb drive that is not mounted', async () => {
+  const ejectFn = jest.fn();
+  const unconfigureFn = jest.fn();
+  render(
+    <AppContext.Provider
+      value={{
+        electionDefinition: electionSampleDefinition,
+        machineConfig: { machineId: '0000', codeVersion: 'TEST' },
+        currentUserSession: { type: 'admin', authenticated: true },
+      }}
+    >
+      <AdminScreen
+        scannedBallotCount={10}
+        isTestMode={false}
+        updateAppPrecinctId={jest.fn()}
+        toggleLiveMode={jest.fn()}
+        unconfigure={unconfigureFn}
+        calibrate={jest.fn()}
+        usbDrive={{ status: usbstick.UsbDriveStatus.mounted, eject: ejectFn }}
+      />
+    </AppContext.Provider>
+  );
+
+  await fireEvent.click(screen.getByText('Unconfigure Machine'));
+  await fireEvent.click(screen.getByText('Unconfigure'));
+  expect(unconfigureFn).toHaveBeenCalledTimes(1);
+  expect(ejectFn).toHaveBeenCalledTimes(1);
+});

--- a/frontends/precinct-scanner/src/screens/admin_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/admin_screen.tsx
@@ -43,7 +43,11 @@ export function AdminScreen({
   calibrate,
   usbDrive,
 }: Props): JSX.Element {
-  const { electionDefinition, currentPrecinctId } = useContext(AppContext);
+  const {
+    electionDefinition,
+    currentPrecinctId,
+    currentUserSession,
+  } = useContext(AppContext);
   assert(electionDefinition);
   const { election } = electionDefinition;
 
@@ -82,6 +86,11 @@ export function AdminScreen({
 
   async function handleUnconfigure() {
     setIsLoading(true);
+    assert(currentUserSession);
+    // If there is a mounted usb eject it so that it doesn't auto reconfigure the machine.
+    if (usbDrive.status === usbstick.UsbDriveStatus.mounted) {
+      await usbDrive.eject(currentUserSession.type);
+    }
     await unconfigure();
   }
 


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
https://github.com/votingworks/vxsuite/issues/1475
Since VxScan automatically configures when given a usb configured with the ballot package as expected we want to eject the usb when we unconfigure so it does not automatically reconfigure. 

## Testing Plan 
Added tests to admin_screen.test.tsx, manually tested and saw the usb ejected when mounted (and not when not). 

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
