### PR TITLE
VxAdmin Allow enter to submit programming admin card

### DIFF
--- a/frontends/election-manager/src/screens/smartcards_screen.tsx
+++ b/frontends/election-manager/src/screens/smartcards_screen.tsx
@@ -202,6 +202,8 @@ export function SmartcardsScreen(): JSX.Element {
     .padEnd(SECURITY_PIN_LENGTH, '-')
     .split('')
     .join(' ');
+  const readyToProgramAdminCard =
+    currentPasscode.length === SECURITY_PIN_LENGTH;
 
   return (
     <React.Fragment>
@@ -262,6 +264,9 @@ export function SmartcardsScreen(): JSX.Element {
                   onButtonPress={addNumberToPin}
                   onBackspace={deleteFromEndOfPin}
                   onClear={clearPin}
+                  onEnter={() =>
+                    readyToProgramAdminCard && programAdminCard(currentPasscode)
+                  }
                 />
               </NumberPadWrapper>
               <p>This code will be required when using the new card.</p>
@@ -271,7 +276,7 @@ export function SmartcardsScreen(): JSX.Element {
             <React.Fragment>
               <Button
                 primary
-                disabled={currentPasscode.length !== SECURITY_PIN_LENGTH}
+                disabled={!readyToProgramAdminCard}
                 onPress={() => programAdminCard(currentPasscode)}
               >
                 Create Card

--- a/libs/ui/src/number_pad.test.tsx
+++ b/libs/ui/src/number_pad.test.tsx
@@ -119,4 +119,55 @@ test('keyboard interaction', async () => {
 
   sendKey('x');
   expect(onClear).toHaveBeenCalledTimes(1);
+
+  sendKey('Enter');
+  // nothing should happen
+  expect(onClear).toHaveBeenCalledTimes(1);
+  expect(onBackspace).toHaveBeenCalledTimes(1);
+  expect(onPress).toHaveBeenCalledTimes(10);
+});
+
+test('keyboard interaction when onEnter is defined', async () => {
+  const onPress = jest.fn();
+  const onBackspace = jest.fn();
+  const onClear = jest.fn();
+  const onEnter = jest.fn();
+  const { container } = render(
+    <NumberPad
+      onButtonPress={onPress}
+      onBackspace={onBackspace}
+      onClear={onClear}
+      onEnter={onEnter}
+    />
+  );
+  container.focus();
+
+  // some keys should be ignored
+  sendKey('z');
+  expect(onPress).not.toHaveBeenCalled();
+  expect(onBackspace).not.toHaveBeenCalled();
+  expect(onClear).not.toHaveBeenCalled();
+  expect(onEnter).not.toHaveBeenCalled();
+
+  for (let digit = 0; digit <= 9; digit += 1) {
+    sendKey(`${digit}`);
+  }
+
+  for (let digit = 0; digit <= 9; digit += 1) {
+    expect(onPress).toHaveBeenCalledWith(digit);
+  }
+
+  expect(onPress).toHaveBeenCalledTimes(10);
+
+  sendKey('Backspace');
+  expect(onBackspace).toHaveBeenCalledTimes(1);
+
+  sendKey('x');
+  expect(onClear).toHaveBeenCalledTimes(1);
+
+  sendKey('Enter');
+  expect(onEnter).toHaveBeenCalledTimes(1);
+  expect(onClear).toHaveBeenCalledTimes(1);
+  expect(onBackspace).toHaveBeenCalledTimes(1);
+  expect(onPress).toHaveBeenCalledTimes(10);
 });

--- a/libs/ui/src/number_pad.tsx
+++ b/libs/ui/src/number_pad.tsx
@@ -17,12 +17,14 @@ export interface NumberPadProps {
   onButtonPress: (buttonValue: number) => void;
   onBackspace: () => void;
   onClear: () => void;
+  onEnter?: () => void;
 }
 
 export function NumberPad({
   onButtonPress,
   onBackspace,
   onClear,
+  onEnter,
 }: NumberPadProps): JSX.Element {
   const container = useRef<HTMLDivElement>(null);
   const onKeyPress: React.KeyboardEventHandler = useCallback(
@@ -32,9 +34,11 @@ export function NumberPad({
         onButtonPress(Number(event.key));
       } else if (event.key === 'x') {
         onClear();
+      } else if (onEnter !== undefined && event.key === 'Enter') {
+        onEnter();
       }
     },
-    [onButtonPress, onClear]
+    [onButtonPress, onClear, onEnter]
   );
   const onKeyDown: React.KeyboardEventHandler = useCallback(
     (event) => {


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
https://github.com/votingworks/vxsuite/issues/1494

## Testing Plan 
Used modal, typed numbers and pressed enter and it submitted the modal. 

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
