### PR TITLE
feat(scan) add blocking no usb drive inserted screen

### DIFF
--- a/frontends/precinct-scanner/src/app.test.tsx
+++ b/frontends/precinct-scanner/src/app.test.tsx
@@ -263,6 +263,9 @@ test('admin and pollworker configuration', async () => {
     });
   render(<App card={card} hardware={hardware} storage={storage} />);
   await advanceTimersAndPromises(1);
+  await screen.findByText('No USB Drive Detected');
+  kiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
+  await advanceTimersAndPromises(1);
   await screen.findByText('Polls Closed');
 
   // Insert a pollworker card
@@ -305,10 +308,6 @@ test('admin and pollworker configuration', async () => {
   await screen.findByText(/State of Hamilton/);
   await screen.findByText('Election ID');
   await screen.findByText('2f6b1553c7');
-
-  // Remove the USB drive
-  kiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
-  await advanceTimersAndPromises(1);
 
   // Admin card with no PIN does NOT require authentication screen.
   const noPinAdminCard = makeAdminCard(electionSampleDefinition.electionHash);
@@ -438,7 +437,7 @@ test('voter can cast a ballot that scans successfully ', async () => {
   await storage.set(stateStorageKey, { isPollsOpen: true });
   const writeLongObjectMock = jest.spyOn(card, 'writeLongObject');
   const kiosk = fakeKiosk();
-  kiosk.getUsbDrives.mockResolvedValue([]);
+  kiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
   window.kiosk = kiosk;
   fetchMock
     .get('/machine-config', { body: getMachineConfigBody })
@@ -511,9 +510,6 @@ test('voter can cast a ballot that scans successfully ', async () => {
   );
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises(1);
-  // Insert usb drive
-  kiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
-  await advanceTimersAndPromises(2);
   await screen.findByText('Do you want to close the polls?');
 
   // Close Polls
@@ -604,6 +600,9 @@ test('voter can cast a ballot that scans successfully ', async () => {
 test('voter can cast a ballot that needs review and adjudicate as desired', async () => {
   const storage = new MemoryStorage();
   await storage.set(stateStorageKey, { isPollsOpen: true });
+  const kiosk = fakeKiosk();
+  kiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
+  window.kiosk = kiosk;
   fetchMock
     .get('/machine-config', { body: getMachineConfigBody })
     .get('/config/election', { body: electionSampleDefinition })
@@ -837,6 +836,9 @@ test('voter can cast a ballot that needs review and adjudicate as desired', asyn
 test('voter can cast a rejected ballot', async () => {
   const storage = new MemoryStorage();
   await storage.set(stateStorageKey, { isPollsOpen: true });
+  const kiosk = fakeKiosk();
+  kiosk.getUsbDrives = jest.fn().mockResolvedValue([fakeUsbDrive()]);
+  window.kiosk = kiosk;
   fetchMock
     .get('/machine-config', { body: getMachineConfigBody })
     .getOnce('/config/election', { body: electionSampleDefinition })
@@ -963,6 +965,9 @@ test('voter can cast another ballot while the success screen is showing', async 
   await storage.set(stateStorageKey, { isPollsOpen: true });
   const card = new MemoryCard();
   const hardware = MemoryHardware.buildStandard();
+  const kiosk = fakeKiosk();
+  kiosk.getUsbDrives = jest.fn().mockResolvedValue([fakeUsbDrive()]);
+  window.kiosk = kiosk;
   fetchMock
     .get('/machine-config', { body: getMachineConfigBody })
     .get('/config/election', { body: electionSampleDefinition })
@@ -1179,7 +1184,7 @@ test('no printer: poll worker can open and close polls without scanning any ball
   const storage = new MemoryStorage();
   await storage.set(stateStorageKey, { isPollsOpen: false });
   const kiosk = fakeKiosk();
-  kiosk.getUsbDrives.mockResolvedValue([]);
+  kiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
   window.kiosk = kiosk;
   fetchMock
     .get('/machine-config', { body: getMachineConfigBody })
@@ -1229,7 +1234,7 @@ test('with printer: poll worker can open and close polls without scanning any ba
   const storage = new MemoryStorage();
   await storage.set(stateStorageKey, { isPollsOpen: false });
   const kiosk = fakeKiosk();
-  kiosk.getUsbDrives.mockResolvedValue([]);
+  kiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
   window.kiosk = kiosk;
   fetchMock
     .get('/machine-config', { body: getMachineConfigBody })

--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -67,6 +67,7 @@ import { UnlockAdminScreen } from './screens/unlock_admin_screen';
 import { CardErrorScreen } from './screens/card_error_screen';
 import { SetupScannerScreen } from './screens/setup_scanner_screen';
 import { CenteredScreen, CenteredLargeProse } from './components/layout';
+import { InsertUsbScreen } from './screens/insert_usb_screen';
 
 const debug = makeDebug('precinct-scanner:app-root');
 
@@ -774,6 +775,10 @@ export function AppRoot({
         )}
       </AppContext.Provider>
     );
+  }
+
+  if (window.kiosk && usbDrive.status !== usbstick.UsbDriveStatus.mounted) {
+    return <InsertUsbScreen />;
   }
 
   if (

--- a/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
+++ b/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
@@ -13,6 +13,7 @@ import {
   advanceTimers,
   advanceTimersAndPromises,
   fakeKiosk,
+  fakeUsbDrive,
   makeAdminCard,
   makePollWorkerCard,
   makeVoterCard,
@@ -482,6 +483,7 @@ test('App shows warning message to connect to power when disconnected', async ()
   hardware.setPrinterConnected(false);
   const storage = new MemoryStorage();
   const kiosk = fakeKiosk();
+  kiosk.getUsbDrives = jest.fn().mockResolvedValue([fakeUsbDrive()]);
   window.kiosk = kiosk;
   fetchMock
     .get('/machine-config', { body: getMachineConfigBody })

--- a/frontends/precinct-scanner/src/screens/insert_usb_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/insert_usb_screen.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { CenteredScreen, CenteredLargeProse } from '../components/layout';
+
+export function InsertUsbScreen(): JSX.Element {
+  return (
+    <CenteredScreen infoBar={false}>
+      <CenteredLargeProse>
+        <h1>No USB Drive Detected</h1>
+        <p>Insert USB drive into the USB hub.</p>
+      </CenteredLargeProse>
+    </CenteredScreen>
+  );
+}
+
+/* istanbul ignore next */
+export function DefaultPreview(): JSX.Element {
+  return <InsertUsbScreen />;
+}


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Adds a blocking screen when there is no usb drive inserted. Election configure flow and admin screen take precedence over this screen. Eventually @beausmith  we might want to rethink/combine this with the election configuration screens and the export modals in the admin screens which have separate messages about there not being a usb drive. 

## Demo Video or Screenshot

https://user-images.githubusercontent.com/14897017/159072752-75daf6f5-9a88-42f0-a35c-5282c394a1c3.mov



## Testing Plan 
Manually tested as shown in video above. Added test that it shows up when polls are closed and there is no usb. 

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
