### PR TITLE
add deleting loading screen when deleting ballot data

### DIFF
--- a/frontends/bsd/src/screens/admin_actions_screen.tsx
+++ b/frontends/bsd/src/screens/admin_actions_screen.tsx
@@ -47,6 +47,7 @@ export function AdminActionsScreen({
     setIsDoubleConfirmingUnconfigure,
   ] = useState(false);
   const [isFactoryResetting, setIsFactoryResetting] = useState(false);
+  const [isDeletingBallotData, setIsDeletingBallotData] = useState(false);
   const [isBackingUp, setIsBackingUp] = useState(false);
   const [backupError, setBackupError] = useState('');
   function toggleIsConfirmingUnconfigure() {
@@ -83,6 +84,13 @@ export function AdminActionsScreen({
       setIsBackingUp(false);
     }
   }, [backup, logger, currentUserType]);
+
+  const deleteBallotData = useCallback(async () => {
+    toggleIsConfirmingZero();
+    setIsDeletingBallotData(true);
+    await zeroData();
+    setIsDeletingBallotData(false);
+  }, [zeroData]);
 
   useEffect(() => {
     if (isFactoryResetting) {
@@ -178,7 +186,7 @@ export function AdminActionsScreen({
           actions={
             <React.Fragment>
               <Button onPress={toggleIsConfirmingZero}>Cancel</Button>
-              <Button danger onPress={zeroData}>
+              <Button danger onPress={deleteBallotData}>
                 Yes, Delete Ballot Data
               </Button>
             </React.Fragment>
@@ -247,6 +255,12 @@ export function AdminActionsScreen({
         <Modal
           centerContent
           content={<Loading>Deleting election data</Loading>}
+        />
+      )}
+      {isDeletingBallotData && (
+        <Modal
+          centerContent
+          content={<Loading>Deleting ballot data</Loading>}
         />
       )}
       {isSetMarkThresholdModalOpen && (


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
https://github.com/votingworks/vxsuite/issues/1553
## Demo Video or Screenshot

https://user-images.githubusercontent.com/14897017/159078197-7746c51c-8848-401d-a545-4d529910c3d3.mov


## Testing Plan 
Manually tested as shown in video, added test case. 

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
