### PR TITLE
feat(admin) remove paper confirmation step when printing ballots

### DIFF
--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -327,21 +327,16 @@ test('printing ballots, print report, and test decks', async () => {
   fireEvent.click(getByText('Test'));
   fireEvent.click(getByText('Official'));
   fireEvent.click(getByText('Print 1 Official', { exact: false }));
-  fireEvent.click(getByText('Cancel'));
-  fireEvent.click(getByText('Print 1 Official', { exact: false }));
-  fireEvent.click(getByText('Yes, Print'));
   await waitFor(() => getByText('Printing'));
   expect(printer.print).toHaveBeenCalledTimes(1);
   expect(mockKiosk.log).toHaveBeenCalledWith(
     expect.stringContaining(LogEventId.BallotPrinted)
   );
   fireEvent.click(getByText('Print 1 Official', { exact: false }));
-  fireEvent.click(getByText('Yes, Print'));
   await waitFor(() => getByText('Printing'));
   expect(printer.print).toHaveBeenCalledTimes(2);
   fireEvent.click(getByText('Precinct'));
   fireEvent.click(getByText('Print 1 Official', { exact: false }));
-  fireEvent.click(getByText('Yes, Print'));
   await waitFor(() => getByText('Printing'));
   expect(printer.print).toHaveBeenCalledTimes(3);
 

--- a/frontends/election-manager/src/screens/ballot_screen.tsx
+++ b/frontends/election-manager/src/screens/ballot_screen.tsx
@@ -282,18 +282,6 @@ export function BallotScreen(): JSX.Element {
               title={filename}
               afterPrint={() => afterPrint(ballotCopies)}
               afterPrintError={afterPrintError}
-              confirmModal={{
-                content: (
-                  <div>
-                    Is the printer loaded with{' '}
-                    <strong>
-                      {isAbsentee ? 'Absentee' : 'Precinct'} Ballot
-                    </strong>{' '}
-                    paper?
-                  </div>
-                ),
-                confirmButtonLabel: 'Yes, Print',
-              }}
               copies={ballotCopies}
               sides="two-sided-long-edge"
               warning={!isLiveMode || isSampleBallot}


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
https://github.com/votingworks/vxsuite/issues/1551
Removes the "Are you sure you have the right paper" modal when printing ballots

## Demo Video or Screenshot
https://user-images.githubusercontent.com/14897017/159080707-3c167342-187b-450a-a004-a14abd1ecbb4.mov

## Testing Plan 
Printed ballots, didn't see modal. 

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
