### PR TITLE
fix(scan): ensure template images are grayscale

### DIFF
--- a/libs/ballot-interpreter-nh/src/convert.ts
+++ b/libs/ballot-interpreter-nh/src/convert.ts
@@ -29,6 +29,7 @@ import {
   TemplateOval,
 } from './accuvote';
 import { Debugger } from './debug';
+import { convertToGrayscale } from './images';
 import { DefaultMarkThresholds } from './interpret';
 import { findBallotTimingMarks } from './interpret/find_ballot_timing_marks';
 import {
@@ -437,7 +438,8 @@ export function convertElectionDefinition(
 
   const expectedCardGeometry = getTemplateBallotCardGeometry(paperSize);
   debug?.layer('front page');
-  const frontTimingMarks = findBallotTimingMarks(cardDefinition.front, {
+  const cardDefinitionFront = convertToGrayscale(cardDefinition.front);
+  const frontTimingMarks = findBallotTimingMarks(cardDefinitionFront, {
     geometry: expectedCardGeometry,
     debug,
   });
@@ -448,7 +450,8 @@ export function convertElectionDefinition(
   }
 
   debug?.layer('back page');
-  const backTimingMarks = findBallotTimingMarks(cardDefinition.back, {
+  const cardDefinitionBack = convertToGrayscale(cardDefinition.back);
+  const backTimingMarks = findBallotTimingMarks(cardDefinitionBack, {
     geometry: expectedCardGeometry,
     debug,
   });
@@ -500,13 +503,13 @@ export function convertElectionDefinition(
     interpolateMissingTimingMarks(backTimingMarks);
 
   const frontTemplateOvals = findTemplateOvals(
-    cardDefinition.front,
+    cardDefinitionFront,
     ovalTemplate,
     frontCompleteTimingMarks,
     { usableArea: expectedCardGeometry.frontUsableArea, debug }
   );
   const backTemplateOvals = findTemplateOvals(
-    cardDefinition.back,
+    cardDefinitionBack,
     ovalTemplate,
     backCompleteTimingMarks,
     { usableArea: expectedCardGeometry.backUsableArea, debug }

--- a/libs/ballot-interpreter-nh/src/images.ts
+++ b/libs/ballot-interpreter-nh/src/images.ts
@@ -4,6 +4,37 @@ import { otsu } from './otsu';
 import { Point } from './types';
 
 /**
+ * Converts an image to grayscale.
+ */
+export function convertToGrayscale(imageData: ImageData): ImageData {
+  const channels = imageData.data.length / imageData.width / imageData.height;
+
+  if (channels === 1) {
+    return imageData;
+  }
+
+  if (channels !== 4) {
+    throw new Error(`Expected 4 channels, got ${channels}`);
+  }
+
+  const src32 = new Int32Array(imageData.data.buffer);
+  const dst = new Uint8ClampedArray(imageData.width * imageData.height);
+
+  for (let offset = 0, { length } = src32; offset < length; offset += 1) {
+    const px = src32[offset] as number;
+    const r = px & 0xff;
+    const g = (px >>> 8) & 0xff;
+    const b = (px >>> 16) & 0xff;
+
+    // Luminosity grayscale formula.
+    const luminosity = (0.21 * r + 0.72 * g + 0.07 * b) | 0;
+    dst[offset] = luminosity;
+  }
+
+  return { data: dst, width: imageData.width, height: imageData.height };
+}
+
+/**
  * Reads an image in grayscale from a file and scales or resizes to fit if
  * desired. If scaling/resizing, returns the scale that ended up being used
  * when resizing along with the scaled image and the original one. This is
@@ -17,21 +48,7 @@ export async function readGrayscaleImage(path: string): Promise<ImageData> {
   context.drawImage(image, 0, 0, image.width, image.height);
   context.drawImage(image, 0, 0, image.width, image.height);
   const imageData = context.getImageData(0, 0, image.width, image.height);
-  const src32 = new Int32Array(imageData.data.buffer);
-  const dst = new Uint8ClampedArray(image.width * image.height);
-
-  for (let offset = 0, { length } = src32; offset < length; offset += 1) {
-    const px = src32[offset] as number;
-    const r = px & 0xff;
-    const g = (px >>> 8) & 0xff;
-    const b = (px >>> 16) & 0xff;
-
-    // Luminosity grayscale formula.
-    const luminosity = (0.21 * r + 0.72 * g + 0.07 * b) | 0;
-    dst[offset] = luminosity;
-  }
-
-  return createImageData(dst, imageData.width, imageData.height);
+  return convertToGrayscale(imageData);
 }
 
 /**


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
The timing mark-finding code expects grayscale (1-channel) images. This ensures that the template images actually are grayscale.

## Demo Video or Screenshot
n/a

## Testing Plan 
Tested during development of VxAdmin flow for converting from NH election definition files.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
