### PR TITLE
fix(bmd): Fix Text component icon props

### DIFF
--- a/frontends/bmd/src/components/text.tsx
+++ b/frontends/bmd/src/components/text.tsx
@@ -27,7 +27,7 @@ const iconStyles = css<Props>`
     margin-right: 0.25rem;
     border-radius: ${({ warningIcon }) => warningIcon && '50%'};
     background: ${({ warningIcon, voteIcon }) =>
-      (warningIcon && 'darkorange') ?? (voteIcon && '#028099')};
+      (warningIcon && 'darkorange') || (voteIcon && '#028099')};
     width: 1rem;
     height: 1rem;
     vertical-align: middle;
@@ -37,7 +37,7 @@ const iconStyles = css<Props>`
     font-size: 90%;
     font-weight: 800;
     content: ${({ warningIcon, voteIcon }) =>
-      (warningIcon && "'!'") ?? (voteIcon && `'${GLOBALS.CHECK_ICON}'`)};
+      (warningIcon && "'!'") || (voteIcon && `'${GLOBALS.CHECK_ICON}'`)};
   }
 `;
 
@@ -65,7 +65,7 @@ export const Text = styled('p')<Props>`
   font-style: ${({ italic }) => (italic ? 'italic' : undefined)};
   word-break: ${({ wordBreak }) => (wordBreak ? 'break-word' : undefined)};
   /* stylelint-disable-next-line value-keyword-case, order/properties-order */
-  ${({ warningIcon, voteIcon }) => (warningIcon ?? voteIcon) && iconStyles}
+  ${({ warningIcon, voteIcon }) => (warningIcon || voteIcon) && iconStyles}
 `;
 
 interface TextWithLineBreaksProps extends Props {

--- a/frontends/election-manager/src/components/text.tsx
+++ b/frontends/election-manager/src/components/text.tsx
@@ -31,7 +31,7 @@ const iconStyles = css<Props>`
     margin-right: 0.25em;
     border-radius: ${({ warningIcon }) => warningIcon && '50%'};
     background: ${({ warningIcon, voteIcon }) =>
-      (warningIcon && 'darkorange') ?? (voteIcon && '#028099')};
+      (warningIcon && 'darkorange') || (voteIcon && '#028099')};
     width: 1em;
     height: 1em;
     vertical-align: middle;
@@ -41,7 +41,7 @@ const iconStyles = css<Props>`
     font-size: 90%;
     font-weight: 800;
     content: ${({ warningIcon, voteIcon }) =>
-      (warningIcon && "'!'") ?? (voteIcon && `'${GLOBALS.CHECK_ICON}'`)};
+      (warningIcon && "'!'") || (voteIcon && `'${GLOBALS.CHECK_ICON}'`)};
   }
 `;
 
@@ -76,7 +76,7 @@ export const Text = styled('p')<Props>`
   font-style: ${({ italic }) => (italic ? 'italic' : undefined)};
   word-break: ${({ wordBreak }) => (wordBreak ? 'break-word' : undefined)};
   /* stylelint-disable-next-line value-keyword-case, order/properties-order */
-  ${({ warningIcon, voteIcon }) => (warningIcon ?? voteIcon) && iconStyles}
+  ${({ warningIcon, voteIcon }) => (warningIcon || voteIcon) && iconStyles}
 `;
 
 export function TextWithLineBreaks({ text }: { text: string }): JSX.Element {

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -91,6 +91,7 @@
     "fast-check": "2.18.0",
     "is-ci-cli": "^2.2.0",
     "jest": "^27.3.1",
+    "jest-styled-components": "^7.0.8",
     "jest-watch-typeahead": "^0.6.4",
     "lint-staged": "^11.0.0",
     "mockdate": "^3.0.5",

--- a/libs/ui/src/__snapshots__/text.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/text.test.tsx.snap
@@ -1,72 +1,185 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders Text align left preLine normal italic 1`] = `
+.c0 {
+  text-align: left;
+  white-space: pre-line;
+  font-weight: 400;
+  font-style: italic;
+}
+
+@media print {
+
+}
+
 <p
-  class="sc-bdvvaa gaMBRT"
+  class="c0"
 >
   align left preLine
 </p>
 `;
 
 exports[`renders Text align right nowrap light 1`] = `
+.c0 {
+  text-align: right;
+  white-space: nowrap;
+  font-weight: 300;
+}
+
+@media print {
+
+}
+
 <p
-  class="sc-bdvvaa kSkmOo"
+  class="c0"
 >
   align right nowrap
 </p>
 `;
 
 exports[`renders Text as paragraph tag 1`] = `
+@media print {
+
+}
+
 <p
-  class="sc-bdvvaa NLRzK"
+  class=""
 >
   paragraph
 </p>
 `;
 
 exports[`renders Text center muted 1`] = `
+.c0 {
+  text-align: center;
+  color: gray;
+}
+
+@media print {
+  .c0 {
+    color: black;
+  }
+}
+
 <p
-  class="sc-bdvvaa gNjqFD"
+  class="c0"
 >
   center muted?
 </p>
 `;
 
 exports[`renders Text displays error style 1`] = `
+.c0 {
+  color: red;
+}
+
+@media print {
+  .c0 {
+    color: black;
+  }
+}
+
 <p
-  class="sc-bdvvaa fqphgu"
+  class="c0"
 >
   Error Text?
 </p>
 `;
 
 exports[`renders Text narrow wordBreak warning 1`] = `
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  max-width: 33ch;
+  color: darkorange;
+  word-break: break-word;
+}
+
+@media print {
+  .c0 {
+    color: black;
+  }
+}
+
 <p
-  class="sc-bdvvaa gaOGIS"
+  class="c0"
 >
   narrow wordBreak
 </p>
 `;
 
 exports[`renders Text small white bold 1`] = `
+.c0 {
+  color: #FFFFFF;
+  font-size: 0.8em;
+  font-weight: 600;
+}
+
+@media print {
+  .c0 {
+    color: #FFFFFF;
+  }
+}
+
 <p
-  class="sc-bdvvaa bvaQuG"
+  class="c0"
 >
   small white bold
 </p>
 `;
 
 exports[`renders Text vote icon 1`] = `
+.c0::before {
+  display: inline-block;
+  margin-top: -0.3em;
+  margin-right: 0.25em;
+  background: #028099;
+  width: 1em;
+  height: 1em;
+  vertical-align: middle;
+  text-align: center;
+  line-height: 1.1;
+  color: #ffffff;
+  font-size: 90%;
+  font-weight: 800;
+  content: '✓';
+}
+
+@media print {
+
+}
+
 <p
-  class="sc-bdvvaa jElMFl"
+  class="c0"
 >
   vote!
 </p>
 `;
 
 exports[`renders Text warning icon 1`] = `
+.c0::before {
+  display: inline-block;
+  margin-top: -0.3em;
+  margin-right: 0.25em;
+  border-radius: 50%;
+  background: darkorange;
+  width: 1em;
+  height: 1em;
+  vertical-align: middle;
+  text-align: center;
+  line-height: 1.1;
+  color: #ffffff;
+  font-size: 90%;
+  font-weight: 800;
+  content: '!';
+}
+
+@media print {
+
+}
+
 <p
-  class="sc-bdvvaa gOYdAO"
+  class="c0"
 >
   Warning
 </p>

--- a/libs/ui/src/text.test.tsx
+++ b/libs/ui/src/text.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import 'jest-styled-components';
 
 import { Text, TextWithLineBreaks } from './text';
 
@@ -43,6 +44,36 @@ describe('renders Text', () => {
   test('warning icon', async () => {
     const { container } = render(<Text warningIcon>Warning</Text>);
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('warning icon/vote icon toggle', async () => {
+    const toggle = true;
+    let { container } = render(
+      <Text warningIcon={toggle} voteIcon={!toggle}>
+        Warning
+      </Text>
+    );
+    expect(container.firstChild).toHaveStyleRule('content', "'!'", {
+      modifier: '::before',
+    });
+    expect(container.firstChild).toHaveStyleRule('background', 'darkorange', {
+      modifier: '::before',
+    });
+    expect(container.firstChild).toHaveStyleRule('border-radius', '50%', {
+      modifier: '::before',
+    });
+
+    ({ container } = render(
+      <Text warningIcon={!toggle} voteIcon={toggle}>
+        Success
+      </Text>
+    ));
+    expect(container.firstChild).toHaveStyleRule('content', "'✓'", {
+      modifier: '::before',
+    });
+    expect(container.firstChild).toHaveStyleRule('background', '#028099', {
+      modifier: '::before',
+    });
   });
 
   test('align left preLine normal italic', async () => {

--- a/libs/ui/src/text.tsx
+++ b/libs/ui/src/text.tsx
@@ -31,7 +31,7 @@ const iconStyles = css<Props>`
     margin-right: 0.25em;
     border-radius: ${({ warningIcon }) => warningIcon && '50%'};
     background: ${({ warningIcon, voteIcon }) =>
-      (warningIcon && 'darkorange') ?? (voteIcon && '#028099')};
+      (warningIcon && 'darkorange') || (voteIcon && '#028099')};
     width: 1em;
     height: 1em;
     vertical-align: middle;
@@ -41,7 +41,7 @@ const iconStyles = css<Props>`
     font-size: 90%;
     font-weight: 800;
     content: ${({ warningIcon, voteIcon }) =>
-      (warningIcon && "'!'") ?? (voteIcon && `'${GLOBALS.CHECK_ICON}'`)};
+      (warningIcon && "'!'") || (voteIcon && `'${GLOBALS.CHECK_ICON}'`)};
   }
 `;
 
@@ -76,7 +76,7 @@ export const Text = styled('p')<Props>`
   font-style: ${({ italic }) => (italic ? 'italic' : undefined)};
   word-break: ${({ wordBreak }) => (wordBreak ? 'break-word' : undefined)};
   /* stylelint-disable-next-line value-keyword-case, order/properties-order */
-  ${({ warningIcon, voteIcon }) => (warningIcon ?? voteIcon) && iconStyles}
+  ${({ warningIcon, voteIcon }) => (warningIcon || voteIcon) && iconStyles}
 `;
 
 export function TextWithLineBreaks({ text }: { text: string }): JSX.Element {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1779,6 +1779,7 @@ importers:
       fast-check: 2.18.0
       is-ci-cli: 2.2.0
       jest: 27.3.1
+      jest-styled-components: 7.0.8_styled-components@5.2.3
       jest-watch-typeahead: 0.6.4_jest@27.3.1
       lint-staged: 11.0.0
       mockdate: 3.0.5
@@ -1836,6 +1837,7 @@ importers:
       fast-check: 2.18.0
       is-ci-cli: ^2.2.0
       jest: ^27.3.1
+      jest-styled-components: ^7.0.8
       jest-watch-typeahead: ^0.6.4
       lint-staged: ^11.0.0
       luxon: 1.26.0
@@ -11649,7 +11651,6 @@ packages:
       inherits: 2.0.4
       source-map: 0.6.1
       source-map-resolve: 0.6.0
-    dev: false
     resolution:
       integrity: sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==
   /cssdb/4.4.0:
@@ -19934,6 +19935,17 @@ packages:
       styled-components: ^2 || ^3 || ^4
     resolution:
       integrity: sha512-dc32l0/6n3FtsILODpvKNz6SLg50OmbJ/3r3oRh9jc2VIPPGZT5jWv7BKIcNCYH7E38ZK7uejNl3zJsCOIenng==
+  /jest-styled-components/7.0.8_styled-components@5.2.3:
+    dependencies:
+      css: 3.0.0
+      styled-components: 5.2.3_react-dom@17.0.1+react@17.0.1
+    dev: true
+    engines:
+      node: '>= 12'
+    peerDependencies:
+      styled-components: '>= 5'
+    resolution:
+      integrity: sha512-0KE54d0yIzKcvtOv8eikyjG3rFRtKYUyQovaoha3nondtZzXYGB3bhsvYgEegU08Iry0ndWx2+g9f5ZzD4I+0Q==
   /jest-util/25.5.0:
     dependencies:
       '@jest/types': 25.5.0
@@ -25756,7 +25768,6 @@ packages:
       atob: 2.1.2
       decode-uri-component: 0.2.0
     deprecated: See https://github.com/lydell/source-map-resolve#deprecated
-    dev: false
     resolution:
       integrity: sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==
   /source-map-support/0.5.19:
@@ -27200,7 +27211,7 @@ packages:
       '@types/jest': 27.0.3
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 27.3.1_canvas@2.6.1
+      jest: 27.3.1
       jest-util: 27.3.1
       json5: 2.2.0
       lodash.memoize: 4.1.2


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
When passing `warningIcon={false}` and `voteIcon={true}`, the vote icon
wouldn't be rendered. I found this issue in a number of text components in different frontends and libs/ui. 

## Demo Video or Screenshot

## Testing Plan 
Added regression test in libs/ui, since that's probably the component consolidate around in the future. Also found a great new library to improve testing with styled-components.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
