### PR TITLE
feat(bmd): Pollworker system diagnostics screen (computer and printer only)

### DIFF
--- a/frontends/bmd/package.json
+++ b/frontends/bmd/package.json
@@ -128,7 +128,9 @@
   "devDependencies": {
     "@codemod/parser": "^1.0.7",
     "@testing-library/cypress": "^5.3.1",
+    "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^11.2.3",
+    "@testing-library/user-event": "^13.5.0",
     "@types/base64-js": "^1.2.5",
     "@types/debug": "^4.1.6",
     "@types/history": "^4.7.8",

--- a/frontends/bmd/src/app_root.tsx
+++ b/frontends/bmd/src/app_root.tsx
@@ -531,12 +531,13 @@ export function AppRoot({
     []
   );
 
+  const devices = useDevices({ hardware, logger });
   const {
     cardReader,
     printer: printerInfo,
     accessibleController,
     computer,
-  } = useDevices({ hardware, logger });
+  } = devices;
   const usbDrive = useUsbDrive({ logger });
   const displayUsbStatus = usbDrive.status ?? usbstick.UsbDriveStatus.absent;
   const hasPrinterAttached = printerInfo !== undefined;
@@ -1304,6 +1305,7 @@ export function AppRoot({
           isLiveMode={isLiveMode}
           isPollsOpen={isPollsOpen}
           machineConfig={machineConfig}
+          devices={devices}
           printer={printer}
           togglePollsOpen={togglePollsOpen}
           tallyOnCard={tallyOnCard}

--- a/frontends/bmd/src/app_root.tsx
+++ b/frontends/bmd/src/app_root.tsx
@@ -1305,6 +1305,7 @@ export function AppRoot({
           isLiveMode={isLiveMode}
           isPollsOpen={isPollsOpen}
           machineConfig={machineConfig}
+          hardware={hardware}
           devices={devices}
           printer={printer}
           togglePollsOpen={togglePollsOpen}

--- a/frontends/bmd/src/pages/admin_screen.tsx
+++ b/frontends/bmd/src/pages/admin_screen.tsx
@@ -5,7 +5,6 @@ import { Printer } from '@votingworks/utils';
 import {
   Button,
   CurrentDateAndTime,
-  LinkButton,
   Main,
   MainChild,
   SegmentedButton,
@@ -198,16 +197,6 @@ export function AdminScreen({
             <p>
               <SetClockButton>Update Date and Time</SetClockButton>
             </p>
-            <h1>Status</h1>
-            <p>
-              {/* <Text voteIcon style={{ margin: 0 }}>
-                    System check passed at Feb 15, 2021, 10:21am.
-                  </Text> */}
-              <Text warningIcon style={{ margin: 0 }}>
-                System check failed at Feb 15, 2021, 10:21am.
-              </Text>
-            </p>
-            <LinkButton to="nowhere">View System Check Report</LinkButton>
             <h1>Configuration</h1>
             {election ? (
               <p>

--- a/frontends/bmd/src/pages/admin_screen.tsx
+++ b/frontends/bmd/src/pages/admin_screen.tsx
@@ -5,6 +5,7 @@ import { Printer } from '@votingworks/utils';
 import {
   Button,
   CurrentDateAndTime,
+  LinkButton,
   Main,
   MainChild,
   SegmentedButton,
@@ -197,6 +198,16 @@ export function AdminScreen({
             <p>
               <SetClockButton>Update Date and Time</SetClockButton>
             </p>
+            <h1>Status</h1>
+            <p>
+              {/* <Text voteIcon style={{ margin: 0 }}>
+                    System check passed at Feb 15, 2021, 10:21am.
+                  </Text> */}
+              <Text warningIcon style={{ margin: 0 }}>
+                System check failed at Feb 15, 2021, 10:21am.
+              </Text>
+            </p>
+            <LinkButton to="nowhere">View System Check Report</LinkButton>
             <h1>Configuration</h1>
             {election ? (
               <p>

--- a/frontends/bmd/src/pages/diagnostics_screen.test.tsx
+++ b/frontends/bmd/src/pages/diagnostics_screen.test.tsx
@@ -31,7 +31,9 @@ describe('System Diagnostics screen', () => {
       const devices = fakeDevices({
         computer: { batteryLevel: 0.05, batteryIsLow: true },
       });
-      render(<DiagnosticsScreen hardware={hardware} devices={devices} />);
+      const { unmount } = render(
+        <DiagnosticsScreen hardware={hardware} devices={devices} />
+      );
 
       screen.getByRole('heading', { name: 'System Diagnostics' });
 
@@ -48,7 +50,9 @@ describe('System Diagnostics screen', () => {
       );
       expectToHaveSuccessIcon(powerCordText);
 
-      await screen.findByText('Printer status: Ready'); // Wait for printer status request to avoid test error
+      // Explicitly unmount before the printer status has resolved to verify that
+      // we properly cancel the request for printer status.
+      unmount();
     });
 
     it('shows a warning when the power cord is not connected', async () => {
@@ -56,7 +60,9 @@ describe('System Diagnostics screen', () => {
       const devices = fakeDevices({
         computer: { batteryIsCharging: false },
       });
-      render(<DiagnosticsScreen hardware={hardware} devices={devices} />);
+      const { unmount } = render(
+        <DiagnosticsScreen hardware={hardware} devices={devices} />
+      );
 
       const computerSection = screen
         .getByRole('heading', { name: 'Computer' })
@@ -68,7 +74,9 @@ describe('System Diagnostics screen', () => {
       );
       expectToHaveWarningIcon(powerCordText);
 
-      await screen.findByText('Printer status: Ready'); // Wait for printer status request to avoid test error
+      // Explicitly unmount before the printer status has resolved to verify that
+      // we properly cancel the request for printer status.
+      unmount();
     });
   });
 

--- a/frontends/bmd/src/pages/diagnostics_screen.test.tsx
+++ b/frontends/bmd/src/pages/diagnostics_screen.test.tsx
@@ -104,7 +104,7 @@ describe('System Diagnostics screen', () => {
       within(printerSection).getByText('Last updated at 11:23 AM');
 
       hardware.setPrinterIppAttributes({
-        state: 'stopped' as KioskBrowser.IppPrinterState,
+        state: 'stopped',
         stateReasons: ['marker-supply-low-warning'],
         markerInfos: [fakeMarkerInfo({ level: 2 })],
       });
@@ -128,7 +128,7 @@ describe('System Diagnostics screen', () => {
       const hardware = MemoryHardware.buildStandard();
       const devices = fakeDevices();
       hardware.setPrinterIppAttributes({
-        state: 'unknown' as KioskBrowser.IppPrinterState.Unknown,
+        state: 'unknown',
       });
       render(<DiagnosticsScreen hardware={hardware} devices={devices} />);
 
@@ -150,7 +150,7 @@ describe('System Diagnostics screen', () => {
       const hardware = MemoryHardware.buildStandard();
       const devices = fakeDevices();
       hardware.setPrinterIppAttributes({
-        state: 'stopped' as KioskBrowser.IppPrinterState,
+        state: 'stopped',
         stateReasons: [
           'media-empty',
           'marker-supply-low-report',
@@ -174,7 +174,7 @@ describe('System Diagnostics screen', () => {
       const hardware = MemoryHardware.buildStandard();
       const devices = fakeDevices();
       hardware.setPrinterIppAttributes({
-        state: 'stopped' as KioskBrowser.IppPrinterState,
+        state: 'stopped',
         stateReasons: ['some-other-reason-warning'],
         markerInfos: [fakeMarkerInfo()],
       });
@@ -193,7 +193,7 @@ describe('System Diagnostics screen', () => {
       const hardware = MemoryHardware.buildStandard();
       const devices = fakeDevices();
       hardware.setPrinterIppAttributes({
-        state: 'stopped' as KioskBrowser.IppPrinterState,
+        state: 'stopped',
         stateReasons: ['123'],
         markerInfos: [fakeMarkerInfo()],
       });
@@ -212,7 +212,7 @@ describe('System Diagnostics screen', () => {
       const hardware = MemoryHardware.buildStandard();
       const devices = fakeDevices();
       hardware.setPrinterIppAttributes({
-        state: 'idle' as KioskBrowser.IppPrinterState,
+        state: 'idle',
         stateReasons: ['none'],
         markerInfos: [fakeMarkerInfo({ level: -2 })],
       });

--- a/frontends/bmd/src/pages/diagnostics_screen.test.tsx
+++ b/frontends/bmd/src/pages/diagnostics_screen.test.tsx
@@ -120,9 +120,7 @@ describe('System Diagnostics screen', () => {
       const hardware = MemoryHardware.buildStandard();
       const devices = fakeDevices();
       hardware.setPrinterIppAttributes({
-        state: null,
-        stateReasons: [],
-        markerInfos: [],
+        state: 'unknown' as KioskBrowser.IppPrinterState.Unknown,
       });
       render(<DiagnosticsScreen hardware={hardware} devices={devices} />);
 
@@ -216,7 +214,7 @@ describe('System Diagnostics screen', () => {
         .getByRole('heading', { name: 'Printer' })
         .closest('section')!;
       const tonerLevelText = await within(printerSection).findByText(
-        'Toner level: unknown'
+        'Toner level: Unknown'
       );
       expectToHaveWarningIcon(tonerLevelText);
     });

--- a/frontends/bmd/src/pages/diagnostics_screen.test.tsx
+++ b/frontends/bmd/src/pages/diagnostics_screen.test.tsx
@@ -1,0 +1,52 @@
+import { prettyPrinterStateReasons } from './diagnostics_screen';
+
+describe('prettyPrinterStateReasons', () => {
+  it('prints a human-friendly message for known reasons', () => {
+    expect(prettyPrinterStateReasons(['media-needed-warning'])).toEqual(
+      'Warning: The printer is out of paper.'
+    );
+
+    expect(prettyPrinterStateReasons(['door-open-error'])).toEqual(
+      "Error: The printer's door is open."
+    );
+    expect(prettyPrinterStateReasons(['stopping-report'])).toEqual(
+      'The printer is stopping.'
+    );
+    expect(prettyPrinterStateReasons(['sleep-mode'])).toEqual(
+      'The printer is in sleep mode.'
+    );
+  });
+
+  it('selects the highest priority reason', () => {
+    // This is the real reason list you get when the printer is out of paper
+    expect(
+      prettyPrinterStateReasons([
+        'media-empty-error',
+        'media-needed-error',
+        'media-empty-error',
+      ])
+    ).toEqual('Error: The printer is out of paper.');
+    // These are made-up cases
+    expect(
+      prettyPrinterStateReasons([
+        'media-empty-report',
+        'media-needed-warning',
+        'media-jam-error',
+      ])
+    ).toEqual('Error: The printer has a paper jam.');
+    expect(
+      prettyPrinterStateReasons(['media-empty-report', 'media-needed-warning'])
+    ).toEqual('Warning: The printer has a paper jam.');
+  });
+
+  it('returns the plain reason text for unknown reasons', () => {
+    expect(
+      prettyPrinterStateReasons(['custom-reason-we-didnt-prepare-for-warning'])
+    ).toEqual('Warning: custom-reason-we-didnt-prepare-for');
+  });
+
+  it('returns empty string on parsing errors', () => {
+    expect(prettyPrinterStateReasons([''])).toEqual('');
+    expect(prettyPrinterStateReasons(['1234'])).toEqual('');
+  });
+});

--- a/frontends/bmd/src/pages/diagnostics_screen.test.tsx
+++ b/frontends/bmd/src/pages/diagnostics_screen.test.tsx
@@ -89,7 +89,7 @@ describe('System Diagnostics screen', () => {
       const printerSection = screen
         .getByRole('heading', { name: 'Printer' })
         .closest('section')!;
-      within(printerSection).getByText('Loading printer status...');
+      within(printerSection).getByText('Loading printer status…');
 
       let printerStatusText = await within(printerSection).findByText(
         'Printer status: Ready'
@@ -110,7 +110,7 @@ describe('System Diagnostics screen', () => {
       });
       userEvent.click(refreshButton);
 
-      within(printerSection).getByText('Loading printer status...');
+      within(printerSection).getByText('Loading printer status…');
 
       printerStatusText = await within(printerSection).findByText(
         'Printer status: Stopped'

--- a/frontends/bmd/src/pages/diagnostics_screen.tsx
+++ b/frontends/bmd/src/pages/diagnostics_screen.tsx
@@ -1,21 +1,37 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import {
   Devices,
-  Screen,
   Main,
   MainChild,
   Prose,
   Button,
   Text,
+  ComputerStatus as ComputerStatusType,
 } from '@votingworks/ui';
-import { ElectionDefinition, PrecinctSelection } from '@votingworks/types';
+import { Optional } from '@votingworks/types';
 import assert from 'assert';
 import { formatTime, Hardware } from '@votingworks/utils';
 import { DateTime } from 'luxon';
-import { Sidebar } from '../components/sidebar';
-import { ElectionInfo } from '../components/election_info';
-import { VersionsData } from '../components/versions_data';
-import { MachineConfig } from '../config/types';
+
+interface ComputerStatusProps {
+  computer: ComputerStatusType;
+}
+
+function ComputerStatus({ computer }: ComputerStatusProps) {
+  return (
+    <React.Fragment>
+      <Text voteIcon>
+        Battery:{' '}
+        {computer.batteryLevel && `${Math.round(computer.batteryLevel * 100)}%`}
+      </Text>
+      {computer.batteryIsCharging ? (
+        <Text voteIcon>Power cord connected.</Text>
+      ) : (
+        <Text warningIcon>No power cord connected. Connect power cord.</Text>
+      )}
+    </React.Fragment>
+  );
+}
 
 /**
  * IPP printer-state-reasons explain what's going on with a printer in detail.
@@ -29,77 +45,71 @@ import { MachineConfig } from '../config/types';
  * suffix of either: "-report", "-warning", or "-error" (e.g. "media-jam-error").
  */
 const IppPrinterStateReasonMessage: { [reason: string]: string } = {
-  'sleep-mode': 'The printer is in sleep mode.', // Custom reason added by us
-  none: 'The printer is ready.',
-  'media-needed': 'The printer is out of paper.',
-  'media-jam': 'The printer has a paper jam.',
-  'moving-to-paused': 'The printer is pausing.',
-  paused: 'The printer is paused',
-  shutdown: 'The printer is turned off or disconnected.',
-  'timed-out': 'The printer is not responding.',
-  stopping: 'The printer is stopping.',
-  'stopped-partly': 'The printer is stopped.',
-  'toner-low': 'The printer is low on toner.',
-  'toner-empty': 'The printer is out of toner.',
-  'spool-area-full': 'The spool area is full.',
-  'cover-open': "The printer's cover is open.",
-  'interlock-open': "The printer's interlock device is open.",
-  'door-open': "The printer's door is open.",
-  'input-tray-missing': "The printer's input tray is missing.",
-  'media-low': 'The printer is low on paper.',
-  'media-empty': 'The printer is out of paper.',
-  'output-tray-missing': "The printer's output tray is missing.",
-  'output-area-almost-full': "The printer's output tray is almost full.",
-  'output-area-full': "The printer's output tray is full.",
-  'marker-supply-low': 'The printer is low on ink.',
-  'marker-supply-empty': 'The printer is out of ink.',
+  'sleep-mode':
+    'The printer is in sleep mode. Press any button on the printer to wake it, then refresh printer status.', // Custom reason added by us
+  'media-needed': 'The printer is out of paper. Add paper to the printer.',
+  'media-jam': 'The printer has a paper jam. Open cover and remove paper.',
+  'moving-to-paused': 'The printer is pausing. Restart the printer.',
+  paused: 'The printer is paused. Restart the printer.',
+  shutdown: 'The printer is turned off or disconnected. Restart the printer.',
+  'timed-out': 'The printer is not responding. Restart the printer.',
+  stopping: 'The printer is stopping. Restart the printer.',
+  'stopped-partly': 'The printer is stopped. Restart the printer.',
+  'toner-low': 'The printer is low on toner. Replace toner cartridge.',
+  'toner-empty': 'The printer is low on toner. Replace toner cartridge.',
+  'spool-area-full': 'The spool area is full. Restart the printer.',
+  'cover-open': "The printer's cover is open. Close the printer's cover.",
+  'interlock-open': "The printer's door is open. Close the printer's door.",
+  'door-open': "The printer's door is open. Close the printer's door.",
+  'input-tray-missing':
+    "The printer's input tray is missing. Connect the input tray.",
+  'media-low': 'The printer is low on paper. Add paper to the printer.',
+  'media-empty': 'The printer is out of paper. Add paper to the printer.',
+  'output-tray-missing':
+    "The printer's output tray is missing. Connect the output tray.",
+  'output-area-almost-full':
+    "The printer's output tray is almost full. Remove printed documents.",
+  'output-area-full':
+    "The printer's output tray is full. Remove printed documents.",
+  'marker-supply-low': 'The printer is low on toner. Replace toner cartridge.',
+  'marker-supply-empty':
+    'The printer is out of toner. Replace toner cartridge.',
   'marker-waste-almost-full':
-    "The printer's ink waste receptacle is almost full.",
-  'marker-waste-full': "The printer's ink waste receptacle is full.",
-  'fuser-over-temp': "The printer's fuser temperature is above normal.",
-  'fuser-under-temp': "The printer's fuser temperature is below normal.",
-  'opc-near-eol': "The printer's optical photo conductor is near end of life.",
+    "The printer's toner waste cartridge is almost full. Empty the toner waste cartridge.",
+  'marker-waste-full':
+    "The printer's toner waste receptacle is full. Empty the toner waste cartridge.",
+  'fuser-over-temp':
+    "The printer's fuser temperature is above normal. Restart the printer.",
+  'fuser-under-temp':
+    "The printer's fuser temperature is below normal. Restart the printer.",
+  'opc-near-eol':
+    "The printer's optical photo conductor is near end of life. Replace this printer.",
   'opc-life-over':
-    "The printer's optical photo conductor is no longer functioning.",
-  'developer-low': 'The printer is low on developer.',
-  'developer-empty': 'The printer is out of developer.',
-  'interpreter-resource-unavailable': 'An interpreter resource is unavailable.',
+    "The printer's optical photo conductor is no longer functioning. Replace this printer.",
 };
 
-export function prettyPrinterStateReasons(
+function parseHighestPriorityReason(
   printerStateReasons: string[]
-): string {
-  // To make life simpler, just show the highest priority reason
-  const [bestReason, bestReasonLevel] =
-    printerStateReasons
-      .map((printerStateReason) =>
-        Array.from(
-          /^([a-z-]+?)(?:-(report|warning|error))?$/.exec(printerStateReason) ||
-            []
-        ).slice(1)
-      )
-      .sort(([, level1], [, level2]) => {
-        function levelRank(level?: string) {
-          return level === 'error' ? 0 : level === 'warning' ? 1 : 2;
-        }
-        return levelRank(level1) - levelRank(level2);
-      })
-      .pop() || [];
-
-  const prettyReason =
-    (bestReason && IppPrinterStateReasonMessage[bestReason]) ??
-    bestReason ??
-    '';
-  const prettyLevel = {
-    warning: 'Warning: ',
-    error: 'Error: ',
-    report: '',
-  }[bestReasonLevel || 'report'];
-  return `${prettyLevel}${prettyReason}`;
+): Optional<string> {
+  return printerStateReasons
+    .map((printerStateReason) => {
+      const [, reason, level] = Array.from(
+        /^([a-z-]+?)(?:-(report|warning|error))?$/.exec(printerStateReason) ||
+          []
+      );
+      return [reason, level];
+    })
+    .filter(([reason]) => reason)
+    .sort(([, level1], [, level2]) => {
+      function levelRank(level?: string) {
+        return level === 'error' ? 0 : level === 'warning' ? 1 : 2;
+      }
+      return levelRank(level1) - levelRank(level2);
+    })
+    .map(([reason]) => reason)[0];
 }
 
 interface PrinterStatusProps {
-  connectedPrinter: KioskBrowser.PrinterInfo;
   hardware: Hardware;
 }
 
@@ -111,7 +121,7 @@ type PrinterStatusState =
       loadedAt: DateTime;
     };
 
-function PrinterStatus({ connectedPrinter, hardware }: PrinterStatusProps) {
+function PrinterStatus({ hardware }: PrinterStatusProps) {
   const [printerStatus, setPrinterStatus] = useState<PrinterStatusState>({
     isLoading: true,
   });
@@ -119,15 +129,11 @@ function PrinterStatus({ connectedPrinter, hardware }: PrinterStatusProps) {
   // devices.printer only updates when the printer connects/disconnects. We want
   // to load its current status, since it may have changed (e.g. if it ran out
   // of paper).
-  const loadPrinterStatus = useCallback(
-    async () => {
-      setPrinterStatus({ isLoading: true });
-      const printer = await hardware.readPrinterStatus();
-      setPrinterStatus({ isLoading: false, printer, loadedAt: DateTime.now() });
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [hardware, connectedPrinter]
-  );
+  const loadPrinterStatus = useCallback(async () => {
+    setPrinterStatus({ isLoading: true });
+    const printer = await hardware.readPrinterStatus();
+    setPrinterStatus({ isLoading: false, printer, loadedAt: DateTime.now() });
+  }, [hardware]);
 
   useEffect(() => {
     void loadPrinterStatus();
@@ -138,46 +144,57 @@ function PrinterStatus({ connectedPrinter, hardware }: PrinterStatusProps) {
   }
   const { printer, loadedAt } = printerStatus;
 
+  const refreshButton = (
+    <div
+      style={{ display: 'flex', alignItems: 'baseline', marginTop: '0.5em' }}
+    >
+      <Button onPress={loadPrinterStatus}>Refresh Printer Status</Button>
+      {loadedAt && (
+        <div style={{ marginLeft: '0.5em' }}>
+          <Text small>Last updated at {formatTime(loadedAt)}</Text>
+        </div>
+      )}
+    </div>
+  );
+
+  if (!printer || printer.state === null) {
+    return (
+      <React.Fragment>
+        <Text warningIcon>Could not get printer status.</Text>
+        {refreshButton}
+      </React.Fragment>
+    );
+  }
+
+  const bestReason = parseHighestPriorityReason(printer.stateReasons);
+  const marker = printer.markerInfos[0];
+  const markerLow = marker.level <= marker.lowLevel;
+
   return (
     <React.Fragment>
-      {!printer || printer.state === null ? (
-        <Text warningIcon>Could not get printer status.</Text>
-      ) : (
-        <React.Fragment>
-          <Text
-            voteIcon={printer.state !== 'stopped'}
-            warningIcon={printer.state === 'stopped'}
-          >
-            Printer status:{' '}
-            {
-              {
-                idle: 'Ready',
-                processing: 'Processing',
-                stopped: 'Stopped',
-              }[printer.state]
-            }
-          </Text>
-          {printer.stateReasons[0] && printer.stateReasons[0] !== 'none' && (
-            <Text>{prettyPrinterStateReasons(printer.stateReasons)}</Text>
-          )}
-          <Text>
-            Toner level:{' '}
-            {printer.markerInfos[0] && printer.markerInfos[0].level >= 0
-              ? `${printer.markerInfos[0].level}%`
-              : 'unknown'}
-          </Text>
-        </React.Fragment>
-      )}
-      <div
-        style={{ display: 'flex', alignItems: 'baseline', marginTop: '0.5em' }}
+      <Text
+        voteIcon={printer.state !== 'stopped'}
+        warningIcon={printer.state === 'stopped'}
       >
-        <Button onPress={loadPrinterStatus}>Refresh Printer Status</Button>
-        {loadedAt && (
-          <div style={{ marginLeft: '0.5em' }}>
-            <Text small>Last updated at {formatTime(loadedAt)}</Text>
-          </div>
-        )}
-      </div>
+        Printer status:{' '}
+        {
+          {
+            idle: 'Ready',
+            processing: 'Processing',
+            stopped: 'Stopped',
+          }[printer.state]
+        }
+      </Text>
+      {bestReason && bestReason !== 'none' && (
+        <Text warningIcon>
+          Warning: {IppPrinterStateReasonMessage[bestReason] ?? bestReason}
+        </Text>
+      )}
+      <Text voteIcon={!markerLow} warningIcon={markerLow}>
+        Toner level:{' '}
+        {marker && marker.level >= 0 ? `${marker.level}%` : 'unknown'}
+      </Text>
+      {refreshButton}
     </React.Fragment>
   );
 }
@@ -185,71 +202,34 @@ function PrinterStatus({ connectedPrinter, hardware }: PrinterStatusProps) {
 interface DiagnosticsScreenProps {
   hardware: Hardware;
   devices: Devices;
-  onBackButtonPress: () => void;
-  machineConfig: MachineConfig;
-  electionDefinition: ElectionDefinition;
-  appPrecinct: PrecinctSelection;
 }
 
 export function DiagnosticsScreen({
   hardware,
   devices,
-  onBackButtonPress,
-  machineConfig,
-  electionDefinition,
-  appPrecinct,
 }: DiagnosticsScreenProps): JSX.Element {
-  // Can't get to this screen without having the card reader and printer connected
-  assert(devices.cardReader);
+  // Since we show full-screen alerts for specific hardware states, there are
+  // certain cases that we will never see in this screen
   assert(devices.printer);
-
-  const { computer } = devices;
+  assert(
+    !(devices.computer.batteryIsLow && !devices.computer.batteryIsCharging)
+  );
 
   return (
-    <Screen flexDirection="row-reverse" voterMode={false}>
-      <Main padded>
-        <MainChild>
-          <Prose compact>
-            <h1>System Diagnostics</h1>
+    <Main padded>
+      <MainChild>
+        <Prose compact>
+          <h1>System Diagnostics</h1>
+          <section>
             <h2>Computer</h2>
-            <Text warningIcon={computer.batteryIsLow}>
-              Battery:{' '}
-              {computer.batteryLevel &&
-                `${Math.round(computer.batteryLevel * 100)}%`}
-              .{' '}
-              {computer.batteryIsCharging
-                ? 'Power cord connected.'
-                : 'No power cord connected.'}
-            </Text>
+            <ComputerStatus computer={devices.computer} />
+          </section>
+          <section>
             <h2>Printer</h2>
-            <PrinterStatus
-              connectedPrinter={devices.printer}
-              hardware={hardware}
-            />
-          </Prose>
-        </MainChild>
-      </Main>
-      <Sidebar
-        appName={machineConfig.appMode.productName}
-        centerContent
-        title="Poll Worker Actions"
-        screenReaderInstructions="To navigate through the available actions, use the down arrow."
-        footer={
-          <React.Fragment>
-            <ElectionInfo
-              electionDefinition={electionDefinition}
-              precinctSelection={appPrecinct}
-              horizontal
-            />
-            <VersionsData
-              machineConfig={machineConfig}
-              electionHash={electionDefinition.electionHash}
-            />
-          </React.Fragment>
-        }
-      >
-        <Button onPress={onBackButtonPress}>Back</Button>
-      </Sidebar>
-    </Screen>
+            <PrinterStatus hardware={hardware} />
+          </section>
+        </Prose>
+      </MainChild>
+    </Main>
   );
 }

--- a/frontends/bmd/src/pages/diagnostics_screen.tsx
+++ b/frontends/bmd/src/pages/diagnostics_screen.tsx
@@ -66,7 +66,9 @@ const IppPrinterStateReasonMessage: { [reason: string]: string } = {
   'interpreter-resource-unavailable': 'An interpreter resource is unavailable.',
 };
 
-function prettyPrinterStateReasons(printerStateReasons: string[]): string {
+export function prettyPrinterStateReasons(
+  printerStateReasons: string[]
+): string {
   // To make life simpler, just show the highest priority reason
   const [bestReason, bestReasonLevel] =
     printerStateReasons
@@ -201,11 +203,6 @@ export function DiagnosticsScreen({
   assert(devices.cardReader);
   assert(devices.printer);
 
-  // const [diagnostics, setDiagnostics] = useState({ });
-  function onPressRunCardReaderDiagnostic() {
-    // do nothing
-  }
-
   const { computer } = devices;
 
   return (
@@ -224,30 +221,11 @@ export function DiagnosticsScreen({
                 ? 'Power cord connected.'
                 : 'No power cord connected.'}
             </Text>
-            <h2>Card Reader</h2>
-            <Text voteIcon>Test passed at Weds, Feb 16th, 2022, 10:32 AM</Text>
-            <Button
-              style={{ marginTop: '0.5em' }}
-              onPress={onPressRunCardReaderDiagnostic}
-            >
-              Test Card Reader
-            </Button>
             <h2>Printer</h2>
             <PrinterStatus
               connectedPrinter={devices.printer}
               hardware={hardware}
             />
-            <h2>Accessible Controller</h2>
-            {/* <Text warningIcon>Accessible controller is not connected.</Text> */}
-            <Text warningIcon>
-              Test failed at Weds, Feb 16th, 2022, 10:32 AM
-            </Text>
-            <Button
-              style={{ marginTop: '0.5em' }}
-              onPress={onPressRunCardReaderDiagnostic}
-            >
-              Test Accessible Controller
-            </Button>
           </Prose>
         </MainChild>
       </Main>

--- a/frontends/bmd/src/pages/diagnostics_screen.tsx
+++ b/frontends/bmd/src/pages/diagnostics_screen.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   Devices,
   Screen,
@@ -10,12 +10,178 @@ import {
 } from '@votingworks/ui';
 import { ElectionDefinition, PrecinctSelection } from '@votingworks/types';
 import assert from 'assert';
+import { formatTime, Hardware } from '@votingworks/utils';
+import { DateTime } from 'luxon';
 import { Sidebar } from '../components/sidebar';
 import { ElectionInfo } from '../components/election_info';
 import { VersionsData } from '../components/versions_data';
 import { MachineConfig } from '../config/types';
 
-interface Props {
+/**
+ * IPP printer-state-reasons explain what's going on with a printer in detail.
+ * Here, we map them to a human-readable explanation, both for user-friendliness
+ * and developer documentation.
+ * Spec: https://datatracker.ietf.org/doc/html/rfc2911#section-4.4.12
+ * There are more possible reasons than covered in the spec, so this list is not
+ * exhaustive.
+ *
+ * Note that the actual printer-state-reasons sent by the printer may have a
+ * suffix of either: "-report", "-warning", or "-error" (e.g. "media-jam-error").
+ */
+const IppPrinterStateReasonMessage: { [reason: string]: string } = {
+  'sleep-mode': 'The printer is in sleep mode.', // Custom reason added by us
+  none: 'The printer is ready.',
+  'media-needed': 'The printer is out of paper.',
+  'media-jam': 'The printer has a paper jam.',
+  'moving-to-paused': 'The printer is pausing.',
+  paused: 'The printer is paused',
+  shutdown: 'The printer is turned off or disconnected.',
+  'timed-out': 'The printer is not responding.',
+  stopping: 'The printer is stopping.',
+  'stopped-partly': 'The printer is stopped.',
+  'toner-low': 'The printer is low on toner.',
+  'toner-empty': 'The printer is out of toner.',
+  'spool-area-full': 'The spool area is full.',
+  'cover-open': "The printer's cover is open.",
+  'interlock-open': "The printer's interlock device is open.",
+  'door-open': "The printer's door is open.",
+  'input-tray-missing': "The printer's input tray is missing.",
+  'media-low': 'The printer is low on paper.',
+  'media-empty': 'The printer is out of paper.',
+  'output-tray-missing': "The printer's output tray is missing.",
+  'output-area-almost-full': "The printer's output tray is almost full.",
+  'output-area-full': "The printer's output tray is full.",
+  'marker-supply-low': 'The printer is low on ink.',
+  'marker-supply-empty': 'The printer is out of ink.',
+  'marker-waste-almost-full':
+    "The printer's ink waste receptacle is almost full.",
+  'marker-waste-full': "The printer's ink waste receptacle is full.",
+  'fuser-over-temp': "The printer's fuser temperature is above normal.",
+  'fuser-under-temp': "The printer's fuser temperature is below normal.",
+  'opc-near-eol': "The printer's optical photo conductor is near end of life.",
+  'opc-life-over':
+    "The printer's optical photo conductor is no longer functioning.",
+  'developer-low': 'The printer is low on developer.',
+  'developer-empty': 'The printer is out of developer.',
+  'interpreter-resource-unavailable': 'An interpreter resource is unavailable.',
+};
+
+function prettyPrinterStateReasons(printerStateReasons: string[]): string {
+  // To make life simpler, just show the highest priority reason
+  const [bestReason, bestReasonLevel] =
+    printerStateReasons
+      .map((printerStateReason) =>
+        Array.from(
+          /^([a-z-]+?)(?:-(report|warning|error))?$/.exec(printerStateReason) ||
+            []
+        ).slice(1)
+      )
+      .sort(([, level1], [, level2]) => {
+        function levelRank(level?: string) {
+          return level === 'error' ? 0 : level === 'warning' ? 1 : 2;
+        }
+        return levelRank(level1) - levelRank(level2);
+      })
+      .pop() || [];
+
+  const prettyReason =
+    (bestReason && IppPrinterStateReasonMessage[bestReason]) ??
+    bestReason ??
+    '';
+  const prettyLevel = {
+    warning: 'Warning: ',
+    error: 'Error: ',
+    report: '',
+  }[bestReasonLevel || 'report'];
+  return `${prettyLevel}${prettyReason}`;
+}
+
+interface PrinterStatusProps {
+  connectedPrinter: KioskBrowser.PrinterInfo;
+  hardware: Hardware;
+}
+
+type PrinterStatusState =
+  | { isLoading: true }
+  | {
+      isLoading: false;
+      printer?: KioskBrowser.PrinterInfo;
+      loadedAt: DateTime;
+    };
+
+function PrinterStatus({ connectedPrinter, hardware }: PrinterStatusProps) {
+  const [printerStatus, setPrinterStatus] = useState<PrinterStatusState>({
+    isLoading: true,
+  });
+
+  // devices.printer only updates when the printer connects/disconnects. We want
+  // to load its current status, since it may have changed (e.g. if it ran out
+  // of paper).
+  const loadPrinterStatus = useCallback(
+    async () => {
+      setPrinterStatus({ isLoading: true });
+      const printer = await hardware.readPrinterStatus();
+      setPrinterStatus({ isLoading: false, printer, loadedAt: DateTime.now() });
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [hardware, connectedPrinter]
+  );
+
+  useEffect(() => {
+    void loadPrinterStatus();
+  }, [loadPrinterStatus]);
+
+  if (printerStatus.isLoading) {
+    return <Text>Loading printer status...</Text>;
+  }
+  const { printer, loadedAt } = printerStatus;
+
+  return (
+    <React.Fragment>
+      {!printer || printer.state === null ? (
+        <Text warningIcon>Could not get printer status.</Text>
+      ) : (
+        <React.Fragment>
+          <Text
+            voteIcon={printer.state !== 'stopped'}
+            warningIcon={printer.state === 'stopped'}
+          >
+            Printer status:{' '}
+            {
+              {
+                idle: 'Ready',
+                processing: 'Processing',
+                stopped: 'Stopped',
+              }[printer.state]
+            }
+          </Text>
+          {printer.stateReasons[0] && printer.stateReasons[0] !== 'none' && (
+            <Text>{prettyPrinterStateReasons(printer.stateReasons)}</Text>
+          )}
+          <Text>
+            Toner level:{' '}
+            {printer.markerInfos[0] && printer.markerInfos[0].level >= 0
+              ? `${printer.markerInfos[0].level}%`
+              : 'unknown'}
+          </Text>
+        </React.Fragment>
+      )}
+      <div
+        style={{ display: 'flex', alignItems: 'baseline', marginTop: '0.5em' }}
+      >
+        <Button onPress={loadPrinterStatus}>Refresh Printer Status</Button>
+        {loadedAt && (
+          <div style={{ marginLeft: '0.5em' }}>
+            <Text small>Last updated at {formatTime(loadedAt)}</Text>
+          </div>
+        )}
+      </div>
+    </React.Fragment>
+  );
+}
+
+interface DiagnosticsScreenProps {
+  hardware: Hardware;
   devices: Devices;
   onBackButtonPress: () => void;
   machineConfig: MachineConfig;
@@ -23,33 +189,24 @@ interface Props {
   appPrecinct: PrecinctSelection;
 }
 
-// interface Diagnostics {
-//   cardReader?: {
-//     startedAt: DateTime;
-//     endedAt: DateTime;
-//     errorMessage: string;
-//   }
-
-// }
-
 export function DiagnosticsScreen({
+  hardware,
   devices,
   onBackButtonPress,
   machineConfig,
   electionDefinition,
   appPrecinct,
-}: Props): JSX.Element {
-  // const [diagnostics, setDiagnostics] = useState({ });
+}: DiagnosticsScreenProps): JSX.Element {
+  // Can't get to this screen without having the card reader and printer connected
+  assert(devices.cardReader);
+  assert(devices.printer);
 
+  // const [diagnostics, setDiagnostics] = useState({ });
   function onPressRunCardReaderDiagnostic() {
     // do nothing
   }
 
-  const { computer, cardReader, printer } = devices;
-
-  // Can't get to this screen without having the card reader and printer connected
-  assert(cardReader);
-  assert(printer);
+  const { computer } = devices;
 
   return (
     <Screen flexDirection="row-reverse" voterMode={false}>
@@ -76,24 +233,10 @@ export function DiagnosticsScreen({
               Test Card Reader
             </Button>
             <h2>Printer</h2>
-            {printer.state === null ? (
-              <Text warningIcon>Could not get printer status.</Text>
-            ) : (
-              <React.Fragment>
-                <Text>
-                  Toner level:{' '}
-                  {printer.markerInfos[0]
-                    ? `${printer.markerInfos[0].level}%`
-                    : 'unknown'}
-                </Text>
-                {printer.stateReasons[0] &&
-                  printer.stateReasons[0] !== 'none' && (
-                    <Text warningIcon>
-                      Printer status: {printer.stateReasons}
-                    </Text>
-                  )}
-              </React.Fragment>
-            )}
+            <PrinterStatus
+              connectedPrinter={devices.printer}
+              hardware={hardware}
+            />
             <h2>Accessible Controller</h2>
             {/* <Text warningIcon>Accessible controller is not connected.</Text> */}
             <Text warningIcon>

--- a/frontends/bmd/src/pages/diagnostics_screen.tsx
+++ b/frontends/bmd/src/pages/diagnostics_screen.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import {
+  Devices,
+  Screen,
+  Main,
+  MainChild,
+  Prose,
+  Button,
+  Text,
+} from '@votingworks/ui';
+import { ElectionDefinition, PrecinctSelection } from '@votingworks/types';
+import assert from 'assert';
+import { Sidebar } from '../components/sidebar';
+import { ElectionInfo } from '../components/election_info';
+import { VersionsData } from '../components/versions_data';
+import { MachineConfig } from '../config/types';
+
+interface Props {
+  devices: Devices;
+  onBackButtonPress: () => void;
+  machineConfig: MachineConfig;
+  electionDefinition: ElectionDefinition;
+  appPrecinct: PrecinctSelection;
+}
+
+// interface Diagnostics {
+//   cardReader?: {
+//     startedAt: DateTime;
+//     endedAt: DateTime;
+//     errorMessage: string;
+//   }
+
+// }
+
+export function DiagnosticsScreen({
+  devices,
+  onBackButtonPress,
+  machineConfig,
+  electionDefinition,
+  appPrecinct,
+}: Props): JSX.Element {
+  // const [diagnostics, setDiagnostics] = useState({ });
+
+  function onPressRunCardReaderDiagnostic() {
+    // do nothing
+  }
+
+  const { computer, cardReader, printer } = devices;
+
+  // Can't get to this screen without having the card reader and printer connected
+  assert(cardReader);
+  assert(printer);
+
+  return (
+    <Screen flexDirection="row-reverse" voterMode={false}>
+      <Main padded>
+        <MainChild>
+          <Prose compact>
+            <h1>System Diagnostics</h1>
+            <h2>Computer</h2>
+            <Text warningIcon={computer.batteryIsLow}>
+              Battery:{' '}
+              {computer.batteryLevel &&
+                `${Math.round(computer.batteryLevel * 100)}%`}
+              .{' '}
+              {computer.batteryIsCharging
+                ? 'Power cord connected.'
+                : 'No power cord connected.'}
+            </Text>
+            <h2>Card Reader</h2>
+            <Text voteIcon>Test passed at Weds, Feb 16th, 2022, 10:32 AM</Text>
+            <Button
+              style={{ marginTop: '0.5em' }}
+              onPress={onPressRunCardReaderDiagnostic}
+            >
+              Test Card Reader
+            </Button>
+            <h2>Printer</h2>
+            {printer.state === null ? (
+              <Text warningIcon>Could not get printer status.</Text>
+            ) : (
+              <React.Fragment>
+                <Text>
+                  Toner level:{' '}
+                  {printer.markerInfos[0]
+                    ? `${printer.markerInfos[0].level}%`
+                    : 'unknown'}
+                </Text>
+                {printer.stateReasons[0] &&
+                  printer.stateReasons[0] !== 'none' && (
+                    <Text warningIcon>
+                      Printer status: {printer.stateReasons}
+                    </Text>
+                  )}
+              </React.Fragment>
+            )}
+            <h2>Accessible Controller</h2>
+            {/* <Text warningIcon>Accessible controller is not connected.</Text> */}
+            <Text warningIcon>
+              Test failed at Weds, Feb 16th, 2022, 10:32 AM
+            </Text>
+            <Button
+              style={{ marginTop: '0.5em' }}
+              onPress={onPressRunCardReaderDiagnostic}
+            >
+              Test Accessible Controller
+            </Button>
+          </Prose>
+        </MainChild>
+      </Main>
+      <Sidebar
+        appName={machineConfig.appMode.productName}
+        centerContent
+        title="Poll Worker Actions"
+        screenReaderInstructions="To navigate through the available actions, use the down arrow."
+        footer={
+          <React.Fragment>
+            <ElectionInfo
+              electionDefinition={electionDefinition}
+              precinctSelection={appPrecinct}
+              horizontal
+            />
+            <VersionsData
+              machineConfig={machineConfig}
+              electionHash={electionDefinition.electionHash}
+            />
+          </React.Fragment>
+        }
+      >
+        <Button onPress={onBackButtonPress}>Back</Button>
+      </Sidebar>
+    </Screen>
+  );
+}

--- a/frontends/bmd/src/pages/diagnostics_screen.tsx
+++ b/frontends/bmd/src/pages/diagnostics_screen.tsx
@@ -140,7 +140,7 @@ function PrinterStatus({ hardware }: PrinterStatusProps) {
   }, [loadPrinterStatus]);
 
   if (printerStatus.isLoading) {
-    return <Text>Loading printer status...</Text>;
+    return <Text>Loading printer status…</Text>;
   }
   const { printer, loadedAt } = printerStatus;
 

--- a/frontends/bmd/src/pages/diagnostics_screen.tsx
+++ b/frontends/bmd/src/pages/diagnostics_screen.tsx
@@ -157,7 +157,7 @@ function PrinterStatus({ hardware }: PrinterStatusProps) {
     </div>
   );
 
-  if (!printer || printer.state === null) {
+  if (!printer || printer.state === 'unknown') {
     return (
       <React.Fragment>
         <Text warningIcon>Could not get printer status.</Text>
@@ -192,7 +192,7 @@ function PrinterStatus({ hardware }: PrinterStatusProps) {
       )}
       <Text voteIcon={!markerLow} warningIcon={markerLow}>
         Toner level:{' '}
-        {marker && marker.level >= 0 ? `${marker.level}%` : 'unknown'}
+        {marker && marker.level >= 0 ? `${marker.level}%` : 'Unknown'}
       </Text>
       {refreshButton}
     </React.Fragment>

--- a/frontends/bmd/src/pages/diagnostics_screen.tsx
+++ b/frontends/bmd/src/pages/diagnostics_screen.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   Text,
   ComputerStatus as ComputerStatusType,
+  useCancelablePromise,
 } from '@votingworks/ui';
 import { Optional } from '@votingworks/types';
 import assert from 'assert';
@@ -122,6 +123,7 @@ type PrinterStatusState =
     };
 
 function PrinterStatus({ hardware }: PrinterStatusProps) {
+  const makeCancelable = useCancelablePromise();
   const [printerStatus, setPrinterStatus] = useState<PrinterStatusState>({
     isLoading: true,
   });
@@ -131,9 +133,9 @@ function PrinterStatus({ hardware }: PrinterStatusProps) {
   // of paper).
   const loadPrinterStatus = useCallback(async () => {
     setPrinterStatus({ isLoading: true });
-    const printer = await hardware.readPrinterStatus();
+    const printer = await makeCancelable(hardware.readPrinterStatus());
     setPrinterStatus({ isLoading: false, printer, loadedAt: DateTime.now() });
-  }, [hardware]);
+  }, [hardware, makeCancelable]);
 
   useEffect(() => {
     void loadPrinterStatus();

--- a/frontends/bmd/src/pages/poll_worker_screen.test.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.test.tsx
@@ -20,8 +20,10 @@ import {
   TallySourceMachineType,
   PrecinctScannerCardTally,
   typedAs,
+  MemoryHardware,
 } from '@votingworks/utils';
 import { getZeroCompressedTally } from '@votingworks/test-utils';
+import userEvent from '@testing-library/user-event';
 import { PrecinctSelectionKind, MarkOnly, PrintOnly } from '../config/types';
 
 import { render } from '../../test/test_utils';
@@ -32,6 +34,7 @@ import { defaultPrecinctId } from '../../test/helpers/election';
 import { PollWorkerScreen } from './poll_worker_screen';
 import { fakePrinter } from '../../test/helpers/fake_printer';
 import { fakeMachineConfig } from '../../test/helpers/fake_machine_config';
+import { fakeDevices } from '../../test/helpers/fake_devices';
 
 const electionSampleWithSeal = safeParseElection(
   electionSampleWithSealUntyped
@@ -99,6 +102,8 @@ test('renders PollWorkerScreen', async () => {
       isLiveMode={false}
       isPollsOpen
       machineConfig={fakeMachineConfig({ appMode: MarkOnly })}
+      hardware={MemoryHardware.buildStandard()}
+      devices={fakeDevices()}
       printer={fakePrinter()}
       togglePollsOpen={jest.fn()}
       tallyOnCard={undefined}
@@ -130,6 +135,8 @@ test('switching out of test mode on election day', async () => {
       isLiveMode={false}
       isPollsOpen
       machineConfig={fakeMachineConfig({ appMode: MarkOnly })}
+      hardware={MemoryHardware.buildStandard()}
+      devices={fakeDevices()}
       printer={fakePrinter()}
       togglePollsOpen={jest.fn()}
       tallyOnCard={undefined}
@@ -163,6 +170,8 @@ test('keeping test mode on election day', async () => {
       isLiveMode={false}
       isPollsOpen
       machineConfig={fakeMachineConfig({ appMode: MarkOnly })}
+      hardware={MemoryHardware.buildStandard()}
+      devices={fakeDevices()}
       printer={fakePrinter()}
       togglePollsOpen={jest.fn()}
       tallyOnCard={undefined}
@@ -193,6 +202,8 @@ test('live mode on election day', async () => {
       isLiveMode
       isPollsOpen
       machineConfig={fakeMachineConfig({ appMode: MarkOnly })}
+      hardware={MemoryHardware.buildStandard()}
+      devices={fakeDevices()}
       printer={fakePrinter()}
       togglePollsOpen={jest.fn()}
       tallyOnCard={undefined}
@@ -251,6 +262,8 @@ test('printing precinct scanner report works as expected with all precinct data 
         appMode: PrintOnly,
         machineId: '314',
       })}
+      hardware={MemoryHardware.buildStandard()}
+      devices={fakeDevices()}
       printer={{
         ...fakePrinter(),
         print: printFn,
@@ -348,6 +361,8 @@ test('printing precinct scanner report works as expected with single precinct da
         appMode: PrintOnly,
         machineId: '314',
       })}
+      hardware={MemoryHardware.buildStandard()}
+      devices={fakeDevices()}
       printer={{
         ...fakePrinter(),
         print: printFn,
@@ -485,6 +500,8 @@ test('printing precinct scanner report works as expected with all precinct speci
         appMode: PrintOnly,
         machineId: '314',
       })}
+      hardware={MemoryHardware.buildStandard()}
+      devices={fakeDevices()}
       printer={{
         ...fakePrinter(),
         print: printFn,
@@ -806,6 +823,8 @@ test('printing precinct scanner report works as expected with all precinct speci
         appMode: PrintOnly,
         machineId: '314',
       })}
+      hardware={MemoryHardware.buildStandard()}
+      devices={fakeDevices()}
       printer={{
         ...fakePrinter(),
         print: printFn,
@@ -1119,6 +1138,8 @@ test('printing precinct scanner report works as expected with all precinct combi
         appMode: PrintOnly,
         machineId: '314',
       })}
+      hardware={MemoryHardware.buildStandard()}
+      devices={fakeDevices()}
       printer={{
         ...fakePrinter(),
         print: printFn,
@@ -1341,6 +1362,8 @@ test('printing precinct scanner report works as expected with a single precinct 
         appMode: PrintOnly,
         machineId: '314',
       })}
+      hardware={MemoryHardware.buildStandard()}
+      devices={fakeDevices()}
       printer={{
         ...fakePrinter(),
         print: printFn,
@@ -1458,4 +1481,37 @@ test('printing precinct scanner report works as expected with a single precinct 
     },
     { yes: 0, no: 1 }
   );
+});
+
+test('navigates to System Diagnostics screen', async () => {
+  render(
+    <PollWorkerScreen
+      activateCardlessVoterSession={jest.fn()}
+      resetCardlessVoterSession={jest.fn()}
+      appPrecinct={{
+        kind: PrecinctSelectionKind.SinglePrecinct,
+        precinctId: defaultPrecinctId,
+      }}
+      electionDefinition={asElectionDefinition(electionSampleWithSeal)}
+      enableLiveMode={jest.fn()}
+      hasVotes={false}
+      isLiveMode={false}
+      isPollsOpen
+      machineConfig={fakeMachineConfig({ appMode: MarkOnly })}
+      hardware={MemoryHardware.buildStandard()}
+      devices={fakeDevices()}
+      printer={fakePrinter()}
+      togglePollsOpen={jest.fn()}
+      tallyOnCard={undefined}
+      clearTalliesOnCard={jest.fn()}
+      reload={jest.fn()}
+    />
+  );
+
+  userEvent.click(screen.getByRole('button', { name: 'System Diagnostics' }));
+  screen.getByRole('heading', { name: 'System Diagnostics' });
+  await screen.findByText('Printer status: Ready'); // Wait for printer status request to avoid test error
+
+  userEvent.click(screen.getByRole('button', { name: 'Back' }));
+  screen.getByRole('heading', { name: 'Open/Close Polls' });
 });

--- a/frontends/bmd/src/pages/poll_worker_screen.test.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.test.tsx
@@ -1484,7 +1484,7 @@ test('printing precinct scanner report works as expected with a single precinct 
 });
 
 test('navigates to System Diagnostics screen', async () => {
-  render(
+  const { unmount } = render(
     <PollWorkerScreen
       activateCardlessVoterSession={jest.fn()}
       resetCardlessVoterSession={jest.fn()}
@@ -1510,8 +1510,11 @@ test('navigates to System Diagnostics screen', async () => {
 
   userEvent.click(screen.getByRole('button', { name: 'System Diagnostics' }));
   screen.getByRole('heading', { name: 'System Diagnostics' });
-  await screen.findByText('Printer status: Ready'); // Wait for printer status request to avoid test error
 
   userEvent.click(screen.getByRole('button', { name: 'Back' }));
   screen.getByRole('heading', { name: 'Open/Close Polls' });
+
+  // Explicitly unmount before the printer status has resolved to verify that
+  // we properly cancel the request for printer status.
+  unmount();
 });

--- a/frontends/bmd/src/pages/poll_worker_screen.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.tsx
@@ -436,7 +436,9 @@ export function PollWorkerScreen({
               <Button onPress={() => setIsDiagnosticsScreenOpen(true)}>
                 System Diagnostics
               </Button>
-              <Button onPress={reload}>Reset Accessible Controller</Button>
+              <p>
+                <Button onPress={reload}>Reset Accessible Controller</Button>
+              </p>
             </Prose>
           </MainChild>
         </Main>

--- a/frontends/bmd/src/pages/poll_worker_screen.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.tsx
@@ -339,109 +339,182 @@ export function PollWorkerScreen({
     );
   }
 
-  if (isDiagnosticsScreenOpen) {
-    return (
-      <DiagnosticsScreen
-        hardware={hardware}
-        devices={devices}
-        onBackButtonPress={() => setIsDiagnosticsScreenOpen(false)}
-        machineConfig={machineConfig}
-        electionDefinition={electionDefinition}
-        appPrecinct={appPrecinct}
-      />
-    );
-  }
+  const pollworkerMainScreen = (
+    <React.Fragment>
+      <Main padded>
+        <MainChild>
+          {isMarkAndPrintMode && isPollsOpen && (
+            <React.Fragment>
+              <Prose>
+                <h1>Activate Voter Session</h1>
+              </Prose>
+              {appPrecinct.kind === PrecinctSelectionKind.AllPrecincts && (
+                <React.Fragment>
+                  <h3>Choose Precinct</h3>
+                  <ButtonList data-testid="precincts">
+                    {election.precincts.map((precinct) => (
+                      <Button
+                        fullWidth
+                        key={precinct.id}
+                        aria-label={`Activate Voter Session for Precinct ${precinct.name}`}
+                        onPress={() =>
+                          activateCardlessVoterSession(precinct.id)
+                        }
+                        primary={cardlessVoterSessionPrecinctId === precinct.id}
+                      >
+                        {precinct.name}
+                      </Button>
+                    ))}
+                  </ButtonList>
+                </React.Fragment>
+              )}
+              {cardlessVoterSessionPrecinctId && (
+                <React.Fragment>
+                  <h3>Choose Ballot Style</h3>
+                  <ButtonList data-testid="ballot-styles">
+                    {precinctBallotStyles.map((bs) => (
+                      <Button
+                        fullWidth
+                        key={bs.id}
+                        aria-label={`Activate Voter Session for Ballot Style ${bs.id}`}
+                        onPress={() =>
+                          activateCardlessVoterSession(
+                            cardlessVoterSessionPrecinctId,
+                            bs.id
+                          )
+                        }
+                      >
+                        {bs.id}
+                      </Button>
+                    ))}
+                  </ButtonList>
+                </React.Fragment>
+              )}
+            </React.Fragment>
+          )}
+          <Prose>
+            <h1>Open/Close Polls</h1>
+            <Text warningIcon={!isPollsOpen} voteIcon={isPollsOpen}>
+              {isPollsOpen
+                ? 'Polls are currently open.'
+                : 'Polls are currently closed.'}{' '}
+              {isLiveMode ? (
+                <React.Fragment>
+                  Machine is in Live&nbsp;Election&nbsp;Mode.
+                </React.Fragment>
+              ) : (
+                <React.Fragment>
+                  Machine is in Testing&nbsp;Mode.
+                </React.Fragment>
+              )}
+            </Text>
+            <p>
+              <Button primary large onPress={togglePollsOpen}>
+                {isPollsOpen
+                  ? `Close Polls for ${precinctName}`
+                  : `Open Polls for ${precinctName}`}
+              </Button>
+            </p>
+
+            <h1>Advanced</h1>
+            <Button onPress={() => setIsDiagnosticsScreenOpen(true)}>
+              System Diagnostics
+            </Button>
+            <p>
+              <Button onPress={reload}>Reset Accessible Controller</Button>
+            </p>
+          </Prose>
+        </MainChild>
+      </Main>
+      {isConfirmingEnableLiveMode && (
+        <Modal
+          centerContent
+          content={
+            <Prose textCenter id="modalaudiofocus">
+              {isPrintMode ? (
+                <h1>
+                  Switch to Live&nbsp;Election&nbsp;Mode and reset the tally of
+                  printed ballots?
+                </h1>
+              ) : (
+                <h1>Switch to Live&nbsp;Election&nbsp;Mode?</h1>
+              )}
+              <p>
+                Today is Election Day and this machine is in{' '}
+                <strong>Testing&nbsp;Mode.</strong>
+              </p>
+              <p>
+                <em>
+                  Note: Switching back to Testing&nbsp;Mode requires an
+                  Admin&nbsp;Card.
+                </em>
+              </p>
+            </Prose>
+          }
+          actions={
+            <React.Fragment>
+              <Button
+                primary
+                danger={isPrintMode}
+                onPress={confirmEnableLiveMode}
+              >
+                Switch to Live&nbsp;Mode
+              </Button>
+              <Button onPress={cancelEnableLiveMode}>Cancel</Button>
+            </React.Fragment>
+          }
+        />
+      )}
+      {isPrintingPrecinctScannerReport && (
+        <Modal
+          content={
+            <Prose textCenter id="modalaudiofocus">
+              <Loading>Printing tally report</Loading>
+            </Prose>
+          }
+        />
+      )}
+      {isConfirmingPrecinctScannerPrint && !precinctScannerTallyInformation && (
+        <Modal
+          ariaHideApp={false}
+          content={
+            <Prose textCenter id="modalaudiofocus">
+              <Loading />
+            </Prose>
+          }
+        />
+      )}
+      {isConfirmingPrecinctScannerPrint && precinctScannerTallyInformation && (
+        <Modal
+          content={
+            <Prose id="modalaudiofocus">
+              <h1>Tally Report on Card</h1>
+              <p>
+                This poll worker card contains a tally report. The report will
+                be cleared from the card after being printed.
+              </p>
+            </Prose>
+          }
+          actions={
+            <React.Fragment>
+              <Button primary onPress={requestPrintPrecinctScannerReport}>
+                Print Tally Report
+              </Button>
+            </React.Fragment>
+          }
+        />
+      )}
+    </React.Fragment>
+  );
 
   return (
     <React.Fragment>
       <Screen flexDirection="row-reverse" voterMode={false}>
-        <Main padded>
-          <MainChild>
-            {isMarkAndPrintMode && isPollsOpen && (
-              <React.Fragment>
-                <Prose>
-                  <h1>Activate Voter Session</h1>
-                </Prose>
-                {appPrecinct.kind === PrecinctSelectionKind.AllPrecincts && (
-                  <React.Fragment>
-                    <h3>Choose Precinct</h3>
-                    <ButtonList data-testid="precincts">
-                      {election.precincts.map((precinct) => (
-                        <Button
-                          fullWidth
-                          key={precinct.id}
-                          aria-label={`Activate Voter Session for Precinct ${precinct.name}`}
-                          onPress={() =>
-                            activateCardlessVoterSession(precinct.id)
-                          }
-                          primary={
-                            cardlessVoterSessionPrecinctId === precinct.id
-                          }
-                        >
-                          {precinct.name}
-                        </Button>
-                      ))}
-                    </ButtonList>
-                  </React.Fragment>
-                )}
-                {cardlessVoterSessionPrecinctId && (
-                  <React.Fragment>
-                    <h3>Choose Ballot Style</h3>
-                    <ButtonList data-testid="ballot-styles">
-                      {precinctBallotStyles.map((bs) => (
-                        <Button
-                          fullWidth
-                          key={bs.id}
-                          aria-label={`Activate Voter Session for Ballot Style ${bs.id}`}
-                          onPress={() =>
-                            activateCardlessVoterSession(
-                              cardlessVoterSessionPrecinctId,
-                              bs.id
-                            )
-                          }
-                        >
-                          {bs.id}
-                        </Button>
-                      ))}
-                    </ButtonList>
-                  </React.Fragment>
-                )}
-              </React.Fragment>
-            )}
-            <Prose>
-              <h1>Open/Close Polls</h1>
-              <Text warningIcon={!isPollsOpen} voteIcon={isPollsOpen}>
-                {isPollsOpen
-                  ? 'Polls are currently open.'
-                  : 'Polls are currently closed.'}{' '}
-                {isLiveMode ? (
-                  <React.Fragment>
-                    Machine is in Live&nbsp;Election&nbsp;Mode.
-                  </React.Fragment>
-                ) : (
-                  <React.Fragment>
-                    Machine is in Testing&nbsp;Mode.
-                  </React.Fragment>
-                )}
-              </Text>
-              <p>
-                <Button primary large onPress={togglePollsOpen}>
-                  {isPollsOpen
-                    ? `Close Polls for ${precinctName}`
-                    : `Open Polls for ${precinctName}`}
-                </Button>
-              </p>
-
-              <h1>Advanced</h1>
-              <Button onPress={() => setIsDiagnosticsScreenOpen(true)}>
-                System Diagnostics
-              </Button>
-              <p>
-                <Button onPress={reload}>Reset Accessible Controller</Button>
-              </p>
-            </Prose>
-          </MainChild>
-        </Main>
+        {isDiagnosticsScreenOpen ? (
+          <DiagnosticsScreen hardware={hardware} devices={devices} />
+        ) : (
+          pollworkerMainScreen
+        )}
         <Sidebar
           appName={machineConfig.appMode.productName}
           centerContent
@@ -462,87 +535,15 @@ export function PollWorkerScreen({
           }
         >
           <Prose>
-            <Text center>Remove card when finished.</Text>
+            {isDiagnosticsScreenOpen ? (
+              <Button onPress={() => setIsDiagnosticsScreenOpen(false)}>
+                Back
+              </Button>
+            ) : (
+              <Text center>Remove card when finished.</Text>
+            )}
           </Prose>
         </Sidebar>
-        {isConfirmingEnableLiveMode && (
-          <Modal
-            centerContent
-            content={
-              <Prose textCenter id="modalaudiofocus">
-                {isPrintMode ? (
-                  <h1>
-                    Switch to Live&nbsp;Election&nbsp;Mode and reset the tally
-                    of printed ballots?
-                  </h1>
-                ) : (
-                  <h1>Switch to Live&nbsp;Election&nbsp;Mode?</h1>
-                )}
-                <p>
-                  Today is Election Day and this machine is in{' '}
-                  <strong>Testing&nbsp;Mode.</strong>
-                </p>
-                <p>
-                  <em>
-                    Note: Switching back to Testing&nbsp;Mode requires an
-                    Admin&nbsp;Card.
-                  </em>
-                </p>
-              </Prose>
-            }
-            actions={
-              <React.Fragment>
-                <Button
-                  primary
-                  danger={isPrintMode}
-                  onPress={confirmEnableLiveMode}
-                >
-                  Switch to Live&nbsp;Mode
-                </Button>
-                <Button onPress={cancelEnableLiveMode}>Cancel</Button>
-              </React.Fragment>
-            }
-          />
-        )}
-        {isPrintingPrecinctScannerReport && (
-          <Modal
-            content={
-              <Prose textCenter id="modalaudiofocus">
-                <Loading>Printing tally report</Loading>
-              </Prose>
-            }
-          />
-        )}
-        {isConfirmingPrecinctScannerPrint && !precinctScannerTallyInformation && (
-          <Modal
-            ariaHideApp={false}
-            content={
-              <Prose textCenter id="modalaudiofocus">
-                <Loading />
-              </Prose>
-            }
-          />
-        )}
-        {isConfirmingPrecinctScannerPrint && precinctScannerTallyInformation && (
-          <Modal
-            content={
-              <Prose id="modalaudiofocus">
-                <h1>Tally Report on Card</h1>
-                <p>
-                  This poll worker card contains a tally report. The report will
-                  be cleared from the card after being printed.
-                </p>
-              </Prose>
-            }
-            actions={
-              <React.Fragment>
-                <Button primary onPress={requestPrintPrecinctScannerReport}>
-                  Print Tally Report
-                </Button>
-              </React.Fragment>
-            }
-          />
-        )}
       </Screen>
       {tallyOnCard &&
         precinctScannerTallyInformation &&

--- a/frontends/bmd/src/pages/poll_worker_screen.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.tsx
@@ -32,6 +32,7 @@ import {
   readCompressedTally,
   PrecinctScannerCardTally,
   getTallyIdentifier,
+  Hardware,
 } from '@votingworks/utils';
 
 import {
@@ -66,6 +67,7 @@ interface Props {
   isLiveMode: boolean;
   isPollsOpen: boolean;
   machineConfig: MachineConfig;
+  hardware: Hardware;
   devices: Devices;
   printer: Printer;
   togglePollsOpen: () => void;
@@ -96,6 +98,7 @@ export function PollWorkerScreen({
   isLiveMode,
   isPollsOpen,
   machineConfig,
+  hardware,
   devices,
   printer,
   togglePollsOpen,
@@ -339,6 +342,7 @@ export function PollWorkerScreen({
   if (isDiagnosticsScreenOpen) {
     return (
       <DiagnosticsScreen
+        hardware={hardware}
         devices={devices}
         onBackButtonPress={() => setIsDiagnosticsScreenOpen(false)}
         machineConfig={machineConfig}

--- a/frontends/bmd/src/pages/poll_worker_screen.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.tsx
@@ -22,6 +22,7 @@ import {
   PrintableContainer,
   TallyReport,
   Modal,
+  Devices,
 } from '@votingworks/ui';
 
 import {
@@ -48,6 +49,7 @@ import { ElectionInfo } from '../components/election_info';
 import { REPORT_PRINTING_TIMEOUT_SECONDS } from '../config/globals';
 import { VersionsData } from '../components/versions_data';
 import { triggerAudioFocus } from '../utils/trigger_audio_focus';
+import { DiagnosticsScreen } from './diagnostics_screen';
 
 interface Props {
   activateCardlessVoterSession: (
@@ -64,6 +66,7 @@ interface Props {
   isLiveMode: boolean;
   isPollsOpen: boolean;
   machineConfig: MachineConfig;
+  devices: Devices;
   printer: Printer;
   togglePollsOpen: () => void;
   tallyOnCard?: PrecinctScannerCardTally;
@@ -93,6 +96,7 @@ export function PollWorkerScreen({
   isLiveMode,
   isPollsOpen,
   machineConfig,
+  devices,
   printer,
   togglePollsOpen,
   hasVotes,
@@ -134,6 +138,8 @@ export function PollWorkerScreen({
     isPrintingPrecinctScannerReport,
     setIsPrintingPrecinctScannerReport,
   ] = useState(false);
+
+  const [isDiagnosticsScreenOpen, setIsDiagnosticsScreenOpen] = useState(false);
 
   const parties = useMemo(() => getPartyIdsInBallotStyles(election), [
     election,
@@ -330,6 +336,18 @@ export function PollWorkerScreen({
     );
   }
 
+  if (isDiagnosticsScreenOpen) {
+    return (
+      <DiagnosticsScreen
+        devices={devices}
+        onBackButtonPress={() => setIsDiagnosticsScreenOpen(false)}
+        machineConfig={machineConfig}
+        electionDefinition={electionDefinition}
+        appPrecinct={appPrecinct}
+      />
+    );
+  }
+
   return (
     <React.Fragment>
       <Screen flexDirection="row-reverse" voterMode={false}>
@@ -409,7 +427,11 @@ export function PollWorkerScreen({
                     : `Open Polls for ${precinctName}`}
                 </Button>
               </p>
+
               <h1>Advanced</h1>
+              <Button onPress={() => setIsDiagnosticsScreenOpen(true)}>
+                System Diagnostics
+              </Button>
               <Button onPress={reload}>Reset Accessible Controller</Button>
             </Prose>
           </MainChild>

--- a/frontends/bmd/src/setupTests.tsx
+++ b/frontends/bmd/src/setupTests.tsx
@@ -1,6 +1,7 @@
 // https://til.hashrocket.com/posts/hzqwty5ykx-create-react-app-has-a-default-test-setup-file
 
 import 'jest-styled-components';
+import '@testing-library/jest-dom/extend-expect';
 import crypto from 'crypto';
 import fetchMock from 'fetch-mock';
 import { TextDecoder, TextEncoder } from 'util';

--- a/frontends/bmd/test/helpers/fake_devices.ts
+++ b/frontends/bmd/test/helpers/fake_devices.ts
@@ -1,0 +1,18 @@
+import { fakePrinterInfo } from '@votingworks/test-utils';
+import { Devices } from '@votingworks/ui';
+
+interface PartialDevices {
+  printer?: Partial<Devices['printer']>;
+  computer?: Partial<Devices['computer']>;
+}
+export function fakeDevices(devices: PartialDevices = {}): Devices {
+  return {
+    printer: fakePrinterInfo(devices.printer),
+    computer: {
+      batteryLevel: 0.8,
+      batteryIsLow: false,
+      batteryIsCharging: true,
+      ...(devices.computer ?? {}),
+    },
+  };
+}

--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -22,6 +22,7 @@ import {
 import {
   advanceTimersAndPromises,
   fakeKiosk,
+  fakePrinterInfo,
   fakeUsbDrive,
 } from '@votingworks/test-utils';
 import {
@@ -77,13 +78,7 @@ beforeEach(() => {
   mockKiosk = fakeKiosk();
   window.kiosk = mockKiosk;
   mockKiosk.getPrinterInfo.mockResolvedValue([
-    {
-      description: 'VxPrinter',
-      isDefault: false,
-      name: 'VxPrinter',
-      status: 0,
-      connected: true,
-    },
+    fakePrinterInfo({ name: 'VxPrinter', connected: true }),
   ]);
   mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
   MockDate.set(new Date('2020-11-03T22:22:00'));

--- a/frontends/election-manager/src/components/print_button.test.tsx
+++ b/frontends/election-manager/src/components/print_button.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { act, fireEvent, waitFor } from '@testing-library/react';
-import { fakeKiosk } from '@votingworks/test-utils';
+import { fakeKiosk, fakePrinterInfo } from '@votingworks/test-utils';
 
 import { PrintButton } from './print_button';
 import { fakePrinter } from '../../test/helpers/fake_printer';
@@ -17,20 +17,8 @@ afterAll(() => {
 test('if only disconnected printers, show error modal', async () => {
   const mockKiosk = window.kiosk! as jest.Mocked<KioskBrowser.Kiosk>;
   mockKiosk.getPrinterInfo.mockResolvedValue([
-    {
-      description: 'banana',
-      isDefault: true,
-      name: 'banana',
-      status: 1,
-      connected: false,
-    },
-    {
-      description: 'VxPrinter',
-      isDefault: false,
-      name: 'VxPrinter',
-      status: 0,
-      connected: false,
-    },
+    fakePrinterInfo({ connected: false }),
+    fakePrinterInfo({ name: 'VxPrinter', connected: false }),
   ]);
 
   const printer = fakePrinter();
@@ -59,20 +47,8 @@ test('if only disconnected printers, show error modal', async () => {
 test('if connected printers, show printing modal', async () => {
   const mockKiosk = window.kiosk! as jest.Mocked<KioskBrowser.Kiosk>;
   mockKiosk.getPrinterInfo.mockResolvedValue([
-    {
-      description: 'banana',
-      isDefault: true,
-      name: 'banana',
-      status: 1,
-      connected: false,
-    },
-    {
-      description: 'VxPrinter',
-      isDefault: false,
-      name: 'VxPrinter',
-      status: 0,
-      connected: true,
-    },
+    fakePrinterInfo({ connected: false }),
+    fakePrinterInfo({ name: 'VxPrinter', connected: true }),
   ]);
 
   const printer = fakePrinter();

--- a/frontends/election-manager/src/screens/print_test_deck_screen.test.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent, waitFor } from '@testing-library/react';
-import { fakeKiosk } from '@votingworks/test-utils';
+import { fakeKiosk, fakePrinterInfo } from '@votingworks/test-utils';
 import { Route } from 'react-router-dom';
 
 import { PrintTestDeckScreen } from './print_test_deck_screen';
@@ -20,13 +20,7 @@ test('Printing the full test deck sorts precincts', async () => {
   jest.useFakeTimers();
   const mockKiosk = window.kiosk! as jest.Mocked<KioskBrowser.Kiosk>;
   mockKiosk.getPrinterInfo.mockResolvedValue([
-    {
-      description: 'VxPrinter',
-      isDefault: true,
-      name: 'VxPrinter',
-      status: 0,
-      connected: true,
-    },
+    fakePrinterInfo({ name: 'VxPrinter', connected: true }),
   ]);
 
   const { getByText, getByLabelText } = renderInAppContext(

--- a/libs/@types/kiosk-browser/kiosk-browser.d.ts
+++ b/libs/@types/kiosk-browser/kiosk-browser.d.ts
@@ -32,16 +32,6 @@ declare namespace KioskBrowser {
   }
 
   /**
-   * IPP printer-state identifies the basic status of a printer.
-   * Spec: https://datatracker.ietf.org/doc/html/rfc2911#section-4.4.11
-   */
-  export type IppPrinterState =
-    | 'unknown' // We didn't get a response from the printer
-    | 'idle' // 3
-    | 'processing' // 4
-    | 'stopped'; // 5
-
-  /**
    * IPP printer-state-reasons explain what's going on with a printer in detail.
    * Spec: https://datatracker.ietf.org/doc/html/rfc2911#section-4.4.12
    * For a partial list of common printer-state-reasons, see
@@ -64,10 +54,13 @@ declare namespace KioskBrowser {
     level: number; // e.g. 83
   }
 
+  /**
+   * A collection of status info about a printer we get via IPP.
+   */
   export type PrinterIppAttributes =
-    | { state: IppPrinterState.Unknown }
+    | { state: 'unknown' } // We didn't get a response from the printer
     | {
-        state: IppPrinterState;
+        state: 'idle' | 'processing' | 'stopped';
         stateReasons: IppPrinterStateReason[];
         markerInfos: IppMarkerInfo[];
       };
@@ -81,6 +74,10 @@ declare namespace KioskBrowser {
     // Added via kiosk-browser
     connected: boolean;
   }
+  /**
+   * The printer's basic info we get from Electron (e.g. name, description,
+   * options), plus its connection status and IPP attributes.
+   */
   export type PrinterInfo = PrinterInfoBase & PrinterIppAttributes;
 
   export interface Device {

--- a/libs/@types/kiosk-browser/kiosk-browser.d.ts
+++ b/libs/@types/kiosk-browser/kiosk-browser.d.ts
@@ -36,6 +36,7 @@ declare namespace KioskBrowser {
    * Spec: https://datatracker.ietf.org/doc/html/rfc2911#section-4.4.11
    */
   export enum IppPrinterState {
+    Unknown = 'unknown', // We didn't get a response from the printer
     Idle = 'idle', // 3
     Processing = 'processing', // 4
     Stopped = 'stopped', // 5
@@ -63,21 +64,24 @@ declare namespace KioskBrowser {
     level: number; // e.g. 83
   }
 
-  export interface PrinterIppAttributes {
-    state: IppPrinterState | null;
-    stateReasons: string[];
-    markerInfos: IppMarkerInfo[];
-  }
+  export type PrinterIppAttributes =
+    | { state: IppPrinterState.Unknown }
+    | {
+        state: IppPrinterState;
+        stateReasons: IppPrinterStateReason[];
+        markerInfos: IppMarkerInfo[];
+      };
 
-  export interface PrinterInfo extends PrinterIppAttributes {
+  interface PrinterInfoBase {
     // Docs: http://electronjs.org/docs/api/structures/printer-info
     description: string;
     isDefault: boolean;
     name: string;
+    options?: { [key: string]: string };
     // Added via kiosk-browser
     connected: boolean;
-    options?: { [key: string]: string };
   }
+  export type PrinterInfo = PrinterInfoBase & PrinterIppAttributes;
 
   export interface Device {
     locationId: number;

--- a/libs/@types/kiosk-browser/kiosk-browser.d.ts
+++ b/libs/@types/kiosk-browser/kiosk-browser.d.ts
@@ -35,12 +35,12 @@ declare namespace KioskBrowser {
    * IPP printer-state identifies the basic status of a printer.
    * Spec: https://datatracker.ietf.org/doc/html/rfc2911#section-4.4.11
    */
-  export enum IppPrinterState {
-    Unknown = 'unknown', // We didn't get a response from the printer
-    Idle = 'idle', // 3
-    Processing = 'processing', // 4
-    Stopped = 'stopped', // 5
-  }
+  export type IppPrinterState =
+    | 'unknown' // We didn't get a response from the printer
+    | 'idle' // 3
+    | 'processing' // 4
+    | 'stopped'; // 5
+
   /**
    * IPP printer-state-reasons explain what's going on with a printer in detail.
    * Spec: https://datatracker.ietf.org/doc/html/rfc2911#section-4.4.12

--- a/libs/@types/kiosk-browser/kiosk-browser.d.ts
+++ b/libs/@types/kiosk-browser/kiosk-browser.d.ts
@@ -31,15 +31,49 @@ declare namespace KioskBrowser {
     sides?: PrintSides;
   }
 
+  /**
+   * IPP printer-state identifies the basic status of a printer.
+   * Spec: https://datatracker.ietf.org/doc/html/rfc2911#section-4.4.11
+   */
+  export enum IppPrinterState {
+    Idle = 'idle', // 3
+    Processing = 'processing', // 4
+    Stopped = 'stopped', // 5
+  }
+  /**
+   * IPP printer-state-reasons explain what's going on with a printer in detail.
+   * Spec: https://datatracker.ietf.org/doc/html/rfc2911#section-4.4.12
+   * For a partial list of common printer-state-reasons, see
+   * getPrinterIppAttributes.ts in kiosk-browser. Since we don't know all
+   * possible reasons, we just type as string.
+   */
+  export type IppPrinterStateReason = string;
+
+  /**
+   * "Marker" is a general name for ink/toner/etc. CUPS implements a variety of
+   * marker-related IPP attributes prefixed with "marker-", e.g. "marker-levels".
+   * Spec: https://www.cups.org/doc/spec-ipp.html
+   */
+  export interface IppMarkerInfo {
+    name: string; // e.g. "black cartridge"
+    color: string; // e.g. "#000000"
+    type: string; // e.g. "toner-cartridge"
+    lowLevel: number; // e.g. 2
+    highLevel: number; // e.g. 100
+    level: number; // e.g. 83
+  }
+
   export interface PrinterInfo {
     // Docs: http://electronjs.org/docs/api/structures/printer-info
     description: string;
     isDefault: boolean;
     name: string;
-    status: number;
     // Added via kiosk-browser
     connected: boolean;
     options?: { [key: string]: string };
+    state: IppPrinterState | null;
+    stateReasons: string[];
+    markerInfos: IppMarkerInfo[];
   }
 
   export interface Device {

--- a/libs/@types/kiosk-browser/kiosk-browser.d.ts
+++ b/libs/@types/kiosk-browser/kiosk-browser.d.ts
@@ -63,7 +63,13 @@ declare namespace KioskBrowser {
     level: number; // e.g. 83
   }
 
-  export interface PrinterInfo {
+  export interface PrinterIppAttributes {
+    state: IppPrinterState | null;
+    stateReasons: string[];
+    markerInfos: IppMarkerInfo[];
+  }
+
+  export interface PrinterInfo extends PrinterIppAttributes {
     // Docs: http://electronjs.org/docs/api/structures/printer-info
     description: string;
     isDefault: boolean;
@@ -71,9 +77,6 @@ declare namespace KioskBrowser {
     // Added via kiosk-browser
     connected: boolean;
     options?: { [key: string]: string };
-    state: IppPrinterState | null;
-    stateReasons: string[];
-    markerInfos: IppMarkerInfo[];
   }
 
   export interface Device {

--- a/libs/test-utils/src/fake_kiosk.ts
+++ b/libs/test-utils/src/fake_kiosk.ts
@@ -25,14 +25,19 @@ export function fakeUsbDrive(
   };
 }
 
-export const fakeMarkerInfo: KioskBrowser.IppMarkerInfo = {
-  color: '#000000',
-  highLevel: 100,
-  level: 100,
-  lowLevel: 2,
-  name: 'black cartridge',
-  type: 'toner-cartridge',
-};
+export function fakeMarkerInfo(
+  props: Partial<KioskBrowser.IppMarkerInfo> = {}
+): KioskBrowser.IppMarkerInfo {
+  return {
+    color: '#000000',
+    highLevel: 100,
+    level: 100,
+    lowLevel: 2,
+    name: 'black cartridge',
+    type: 'toner-cartridge',
+    ...props,
+  };
+}
 
 export function fakePrinterInfo(
   props: Partial<KioskBrowser.PrinterInfo> = {}
@@ -44,7 +49,7 @@ export function fakePrinterInfo(
     name: 'Fake Printer',
     state: 'idle' as KioskBrowser.IppPrinterState,
     stateReasons: ['none'],
-    markerInfos: [fakeMarkerInfo],
+    markerInfos: [fakeMarkerInfo()],
     ...props,
   };
 }

--- a/libs/test-utils/src/fake_kiosk.ts
+++ b/libs/test-utils/src/fake_kiosk.ts
@@ -47,7 +47,7 @@ export function fakePrinterInfo(
     description: props.name ?? 'Fake Printer',
     isDefault: false,
     name: 'Fake Printer',
-    state: 'idle' as KioskBrowser.IppPrinterState,
+    state: 'idle',
     stateReasons: ['none'],
     markerInfos: [fakeMarkerInfo()],
     ...props,

--- a/libs/test-utils/src/fake_kiosk.ts
+++ b/libs/test-utils/src/fake_kiosk.ts
@@ -31,7 +31,7 @@ export function fakeMarkerInfo(
   return {
     color: '#000000',
     highLevel: 100,
-    level: 100,
+    level: 92,
     lowLevel: 2,
     name: 'black cartridge',
     type: 'toner-cartridge',

--- a/libs/test-utils/src/fake_kiosk.ts
+++ b/libs/test-utils/src/fake_kiosk.ts
@@ -25,6 +25,15 @@ export function fakeUsbDrive(
   };
 }
 
+export const fakeMarkerInfo: KioskBrowser.IppMarkerInfo = {
+  color: '#000000',
+  highLevel: 100,
+  level: 100,
+  lowLevel: 2,
+  name: 'black cartridge',
+  type: 'toner-cartridge',
+};
+
 export function fakePrinterInfo(
   props: Partial<KioskBrowser.PrinterInfo> = {}
 ): KioskBrowser.PrinterInfo {
@@ -33,7 +42,9 @@ export function fakePrinterInfo(
     description: props.name ?? 'Fake Printer',
     isDefault: false,
     name: 'Fake Printer',
-    status: 3, // idle
+    state: 'idle' as KioskBrowser.IppPrinterState,
+    stateReasons: ['none'],
+    markerInfos: [fakeMarkerInfo],
     ...props,
   };
 }

--- a/libs/ui/src/hooks/use_devices.test.ts
+++ b/libs/ui/src/hooks/use_devices.test.ts
@@ -1,5 +1,6 @@
 import { act, renderHook } from '@testing-library/react-hooks';
 import { Logger, LogSource, LogEventId } from '@votingworks/logging';
+import { fakeMarkerInfo } from '@votingworks/test-utils';
 import {
   AccessibleControllerProductId,
   AccessibleControllerVendorId,
@@ -43,7 +44,9 @@ test('can connect printer as expected', () => {
     description: 'Brother',
     isDefault: true,
     name: 'HL-L5100DN_series',
-    status: 0,
+    state: 'idle' as KioskBrowser.IppPrinterState,
+    stateReasons: ['none'],
+    markerInfos: [fakeMarkerInfo()],
   };
 
   act(() => hardware.setPrinterConnected(true));

--- a/libs/ui/src/hooks/use_devices.test.ts
+++ b/libs/ui/src/hooks/use_devices.test.ts
@@ -44,7 +44,7 @@ test('can connect printer as expected', () => {
     description: 'Brother',
     isDefault: true,
     name: 'HL-L5100DN_series',
-    state: 'idle' as KioskBrowser.IppPrinterState,
+    state: 'idle',
     stateReasons: ['none'],
     markerInfos: [fakeMarkerInfo()],
   };

--- a/libs/ui/src/hooks/use_devices.ts
+++ b/libs/ui/src/hooks/use_devices.ts
@@ -62,8 +62,6 @@ export function useDevices({ hardware, logger }: Props): Devices {
   const previousDevices = usePrevious(allDevices);
   const previousPrinters = usePrevious(allPrinters);
 
-  const printer = allPrinters.find((somePrinter) => somePrinter.connected);
-
   const computer: ComputerStatus = {
     batteryLevel: battery?.level,
     batteryIsCharging: battery ? !battery.discharging : true,
@@ -76,7 +74,7 @@ export function useDevices({ hardware, logger }: Props): Devices {
     accessibleController: allDevices.find(isAccessibleController),
     batchScanner: allDevices.find(isBatchScanner),
     precinctScanner: allDevices.find(isPrecinctScanner),
-    printer,
+    printer: allPrinters.find((printer) => printer.connected),
   };
 
   useEffect(() => {

--- a/libs/utils/src/Hardware/kiosk_hardware.test.ts
+++ b/libs/utils/src/Hardware/kiosk_hardware.test.ts
@@ -17,7 +17,9 @@ it('reports printer status as connected if there are any connected printers', as
     fakePrinterInfo({ connected: true }),
   ]);
 
-  expect(await hardware.readPrinterStatus()).toEqual({ connected: true });
+  expect(await hardware.readPrinterStatus()).toEqual(
+    fakePrinterInfo({ connected: true })
+  );
 });
 
 it('reports printer status as not connected if there are no connected printers', async () => {
@@ -28,5 +30,5 @@ it('reports printer status as not connected if there are no connected printers',
     fakePrinterInfo({ connected: false }),
   ]);
 
-  expect(await hardware.readPrinterStatus()).toEqual({ connected: false });
+  expect(await hardware.readPrinterStatus()).toEqual(undefined);
 });

--- a/libs/utils/src/Hardware/kiosk_hardware.ts
+++ b/libs/utils/src/Hardware/kiosk_hardware.ts
@@ -1,4 +1,3 @@
-import { PrinterStatus } from '../types';
 import { MemoryHardware } from './memory_hardware';
 
 /**
@@ -16,13 +15,13 @@ export class KioskHardware extends MemoryHardware {
     return this.kiosk.getBatteryInfo();
   }
 
-  /**
-   * Determines whether there is a configured & connected printer.
-   */
-  async readPrinterStatus(): Promise<PrinterStatus> {
-    const printers = await this.kiosk.getPrinterInfo();
-    return { connected: printers.some((printer) => printer.connected) };
-  }
+  // /**
+  //  * Finds a configured & connected printer and returns its status.
+  //  */
+  // async readPrinterStatus(): Promise<KioskBrowser.PrinterInfo | undefined> {
+  //   const printers = await this.kiosk.getPrinterInfo();
+  //   return printers.find((printer) => printer.connected);
+  // }
 
   /**
    * Gets an observable that yields the current set of connected USB devices as

--- a/libs/utils/src/Hardware/kiosk_hardware.ts
+++ b/libs/utils/src/Hardware/kiosk_hardware.ts
@@ -15,13 +15,13 @@ export class KioskHardware extends MemoryHardware {
     return this.kiosk.getBatteryInfo();
   }
 
-  // /**
-  //  * Finds a configured & connected printer and returns its status.
-  //  */
-  // async readPrinterStatus(): Promise<KioskBrowser.PrinterInfo | undefined> {
-  //   const printers = await this.kiosk.getPrinterInfo();
-  //   return printers.find((printer) => printer.connected);
-  // }
+  /**
+   * Finds a configured & connected printer and returns its status.
+   */
+  async readPrinterStatus(): Promise<KioskBrowser.PrinterInfo | undefined> {
+    const printers = await this.kiosk.getPrinterInfo();
+    return printers.find((printer) => printer.connected);
+  }
 
   /**
    * Gets an observable that yields the current set of connected USB devices as

--- a/libs/utils/src/Hardware/memory_hardware.test.ts
+++ b/libs/utils/src/Hardware/memory_hardware.test.ts
@@ -177,7 +177,7 @@ it('readPrinterStatus returns undefined if there are no connected printers', asy
 it('can set printer IPP attributes', async () => {
   const hardware = MemoryHardware.build({ connectPrinter: true });
   const attributes: KioskBrowser.PrinterIppAttributes = {
-    state: 'unknown' as KioskBrowser.IppPrinterState.Unknown,
+    state: 'unknown',
   };
   hardware.setPrinterIppAttributes(attributes);
   const printer = await hardware.readPrinterStatus();

--- a/libs/utils/src/Hardware/memory_hardware.test.ts
+++ b/libs/utils/src/Hardware/memory_hardware.test.ts
@@ -177,9 +177,7 @@ it('readPrinterStatus returns undefined if there are no connected printers', asy
 it('can set printer IPP attributes', async () => {
   const hardware = MemoryHardware.build({ connectPrinter: true });
   const attributes: KioskBrowser.PrinterIppAttributes = {
-    state: null,
-    stateReasons: [],
-    markerInfos: [],
+    state: 'unknown' as KioskBrowser.IppPrinterState.Unknown,
   };
   hardware.setPrinterIppAttributes(attributes);
   const printer = await hardware.readPrinterStatus();

--- a/libs/utils/src/Hardware/memory_hardware.test.ts
+++ b/libs/utils/src/Hardware/memory_hardware.test.ts
@@ -141,16 +141,49 @@ it('allows unsubscribing from a device subscription', () => {
   expect(callback).not.toHaveBeenCalled();
 });
 
-it('reports printer status as connected if there are any connected printers', async () => {
+it('readPrinterStatus returns printer info for connected printer', async () => {
   const hardware = MemoryHardware.build();
   hardware.setPrinterConnected(true);
-  expect(await hardware.readPrinterStatus()).toEqual({ connected: true });
+  expect(await hardware.readPrinterStatus()).toMatchInlineSnapshot(`
+    Object {
+      "connected": true,
+      "description": "Brother",
+      "isDefault": true,
+      "markerInfos": Array [
+        Object {
+          "color": "#000000",
+          "highLevel": 100,
+          "level": 92,
+          "lowLevel": 2,
+          "name": "black cartridge",
+          "type": "toner-cartridge",
+        },
+      ],
+      "name": "HL-L5100DN_series",
+      "state": "idle",
+      "stateReasons": Array [
+        "none",
+      ],
+    }
+  `);
 });
 
-it('reports printer status as not connected if there are no connected printers', async () => {
+it('readPrinterStatus returns undefined if there are no connected printers', async () => {
   const hardware = MemoryHardware.build();
   hardware.setPrinterConnected(false);
-  expect(await hardware.readPrinterStatus()).toEqual({ connected: false });
+  expect(await hardware.readPrinterStatus()).toBeUndefined();
+});
+
+it('can set printer IPP attributes', async () => {
+  const hardware = MemoryHardware.build({ connectPrinter: true });
+  const attributes: KioskBrowser.PrinterIppAttributes = {
+    state: null,
+    stateReasons: [],
+    markerInfos: [],
+  };
+  hardware.setPrinterIppAttributes(attributes);
+  const printer = await hardware.readPrinterStatus();
+  expect(printer).toMatchObject(attributes);
 });
 
 it('can remove printers', async () => {

--- a/libs/utils/src/Hardware/memory_hardware.ts
+++ b/libs/utils/src/Hardware/memory_hardware.ts
@@ -1,11 +1,10 @@
 import { BehaviorSubject, Observable } from 'rxjs';
-import { Hardware, PrinterStatus } from '../types';
+import { Hardware } from '../types';
 import {
   AccessibleControllerProductId,
   AccessibleControllerVendorId,
   BrotherHll5100DnProductId,
   BrotherHll5100DnVendorId,
-  isPrinter,
   OmniKeyCardReaderDeviceName,
   OmniKeyCardReaderManufacturer,
   OmniKeyCardReaderProductId,
@@ -187,14 +186,14 @@ export class MemoryHardware implements Hardware {
     this.setDeviceConnected(this.cardReader, connected);
   }
 
-  /**
-   * Reads Printer status
-   */
-  async readPrinterStatus(): Promise<PrinterStatus> {
-    return {
-      connected: Array.from(this.connectedDevices).some(isPrinter),
-    };
-  }
+  // /**
+  //  * Reads Printer status
+  //  */
+  // async readPrinterStatus(): Promise<PrinterStatus> {
+  //   return {
+  //     connected: Array.from(this.connectedDevices).some(isPrinter),
+  //   };
+  // }
 
   /**
    * Sets Printer connected
@@ -207,7 +206,18 @@ export class MemoryHardware implements Hardware {
         description: this.printer.manufacturer,
         connected,
         isDefault: true,
-        status: 0,
+        state: 'idle' as KioskBrowser.IppPrinterState,
+        stateReasons: ['none'],
+        markerInfos: [
+          {
+            color: '#000000',
+            highLevel: 100,
+            level: 92,
+            lowLevel: 2,
+            name: 'black cartridge',
+            type: 'toner-cartridge',
+          },
+        ],
       },
     ]);
   }

--- a/libs/utils/src/Hardware/memory_hardware.ts
+++ b/libs/utils/src/Hardware/memory_hardware.ts
@@ -64,6 +64,8 @@ export class MemoryHardware implements Hardware {
     serialNumber: '',
   };
 
+  private printerIppAttributes = DEFAULT_PRINTER_IPP_ATTRIBUTES;
+
   private cardReader: Readonly<KioskBrowser.Device> = {
     deviceAddress: 0,
     deviceName: OmniKeyCardReaderDeviceName,
@@ -213,7 +215,7 @@ export class MemoryHardware implements Hardware {
         name: connectedPrinter.deviceName,
         description: connectedPrinter.manufacturer,
         isDefault: true,
-        ...DEFAULT_PRINTER_IPP_ATTRIBUTES,
+        ...this.printerIppAttributes,
       };
     }
     return undefined;
@@ -230,9 +232,16 @@ export class MemoryHardware implements Hardware {
         description: this.printer.manufacturer,
         connected,
         isDefault: true,
-        ...DEFAULT_PRINTER_IPP_ATTRIBUTES,
+        ...this.printerIppAttributes,
       },
     ]);
+  }
+
+  /**
+   * Sets Printer IPP attributes
+   */
+  setPrinterIppAttributes(attributes: KioskBrowser.PrinterIppAttributes): void {
+    this.printerIppAttributes = attributes;
   }
 
   /**

--- a/libs/utils/src/Hardware/memory_hardware.ts
+++ b/libs/utils/src/Hardware/memory_hardware.ts
@@ -13,11 +13,27 @@ import {
   FujitsuFi7160ScannerProductId,
   PlustekScannerVendorId,
   PlustekVtm300ScannerProductId,
+  isPrinter,
 } from './utils';
 
 const DEFAULT_BATTERY_STATUS: KioskBrowser.BatteryInfo = {
   discharging: false,
   level: 0.8,
+};
+
+const DEFAULT_PRINTER_IPP_ATTRIBUTES: KioskBrowser.PrinterIppAttributes = {
+  state: 'idle' as KioskBrowser.IppPrinterState,
+  stateReasons: ['none'],
+  markerInfos: [
+    {
+      color: '#000000',
+      highLevel: 100,
+      level: 92,
+      lowLevel: 2,
+      name: 'black cartridge',
+      type: 'toner-cartridge',
+    },
+  ],
 };
 
 /**
@@ -186,14 +202,22 @@ export class MemoryHardware implements Hardware {
     this.setDeviceConnected(this.cardReader, connected);
   }
 
-  // /**
-  //  * Reads Printer status
-  //  */
-  // async readPrinterStatus(): Promise<PrinterStatus> {
-  //   return {
-  //     connected: Array.from(this.connectedDevices).some(isPrinter),
-  //   };
-  // }
+  /**
+   * Reads Printer status
+   */
+  async readPrinterStatus(): Promise<KioskBrowser.PrinterInfo | undefined> {
+    const connectedPrinter = Array.from(this.connectedDevices).find(isPrinter);
+    if (connectedPrinter) {
+      return {
+        connected: true,
+        name: connectedPrinter.deviceName,
+        description: connectedPrinter.manufacturer,
+        isDefault: true,
+        ...DEFAULT_PRINTER_IPP_ATTRIBUTES,
+      };
+    }
+    return undefined;
+  }
 
   /**
    * Sets Printer connected
@@ -206,18 +230,7 @@ export class MemoryHardware implements Hardware {
         description: this.printer.manufacturer,
         connected,
         isDefault: true,
-        state: 'idle' as KioskBrowser.IppPrinterState,
-        stateReasons: ['none'],
-        markerInfos: [
-          {
-            color: '#000000',
-            highLevel: 100,
-            level: 92,
-            lowLevel: 2,
-            name: 'black cartridge',
-            type: 'toner-cartridge',
-          },
-        ],
+        ...DEFAULT_PRINTER_IPP_ATTRIBUTES,
       },
     ]);
   }

--- a/libs/utils/src/Hardware/memory_hardware.ts
+++ b/libs/utils/src/Hardware/memory_hardware.ts
@@ -22,7 +22,7 @@ const DEFAULT_BATTERY_STATUS: KioskBrowser.BatteryInfo = {
 };
 
 const DEFAULT_PRINTER_IPP_ATTRIBUTES: KioskBrowser.PrinterIppAttributes = {
-  state: 'idle' as KioskBrowser.IppPrinterState,
+  state: 'idle',
   stateReasons: ['none'],
   markerInfos: [
     {

--- a/libs/utils/src/date.test.ts
+++ b/libs/utils/src/date.test.ts
@@ -2,6 +2,7 @@ import { DateTime } from 'luxon';
 import {
   formatFullDateTimeZone,
   formatLongDate,
+  formatTime,
   formatTimeZoneName,
   getDaysInMonth,
 } from './date';
@@ -67,6 +68,16 @@ test('formatLongDate', () => {
       'America/Chicago'
     )
   ).toEqual('December 31, 2021');
+});
+
+test('formatTime', () => {
+  expect(formatTime(DateTime.fromISO('2021-01-01'))).toEqual('12:00 AM');
+  expect(formatTime(DateTime.fromISO('2021-01-01T01:23:45Z'))).toEqual(
+    '1:23 AM'
+  );
+  expect(formatTime(DateTime.fromISO('2021-01-01T14:41:00Z'))).toEqual(
+    '2:41 PM'
+  );
 });
 
 test('getDaysInMonth', () => {

--- a/libs/utils/src/date.ts
+++ b/libs/utils/src/date.ts
@@ -61,6 +61,14 @@ export function formatLongDate(date: DateTime, timeZone?: string): string {
   }).format(date.toJSDate());
 }
 
+export function formatTime(date: DateTime): string {
+  return new Intl.DateTimeFormat(undefined, {
+    timeZone: date.zoneName,
+    hour: 'numeric',
+    minute: 'numeric',
+  }).format(date.toJSDate());
+}
+
 /**
  * Get days in given month and year.
  */

--- a/libs/utils/src/types.ts
+++ b/libs/utils/src/types.ts
@@ -175,10 +175,10 @@ export interface Hardware {
    */
   readBatteryStatus(): Promise<KioskBrowser.BatteryInfo | undefined>;
 
-  // /**
-  //  * Reads Printer status
-  //  */
-  // readPrinterStatus(): Promise<KioskBrowser.PrinterInfo | undefined>;
+  /**
+   * Reads Printer status
+   */
+  readPrinterStatus(): Promise<KioskBrowser.PrinterInfo | undefined>;
 
   /**
    * Subscribe to USB device updates.

--- a/libs/utils/src/types.ts
+++ b/libs/utils/src/types.ts
@@ -166,10 +166,6 @@ export interface Card {
   writeLongUint8Array(value: Uint8Array): Promise<void>;
 }
 
-export interface PrinterStatus {
-  connected: boolean;
-}
-
 /**
  * Defines the API for accessing hardware status.
  */
@@ -179,10 +175,10 @@ export interface Hardware {
    */
   readBatteryStatus(): Promise<KioskBrowser.BatteryInfo | undefined>;
 
-  /**
-   * Reads Printer status
-   */
-  readPrinterStatus(): Promise<PrinterStatus>;
+  // /**
+  //  * Reads Printer status
+  //  */
+  // readPrinterStatus(): Promise<KioskBrowser.PrinterInfo | undefined>;
 
   /**
    * Subscribe to USB device updates.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,7 +214,9 @@ importers:
     devDependencies:
       '@codemod/parser': 1.1.0
       '@testing-library/cypress': 5.3.1_cypress@4.12.1
+      '@testing-library/jest-dom': 4.2.4
       '@testing-library/react': 11.2.3_react-dom@17.0.1+react@17.0.1
+      '@testing-library/user-event': 13.5.0
       '@types/base64-js': 1.3.0
       '@types/debug': 4.1.6
       '@types/history': 4.7.8
@@ -258,7 +260,9 @@ importers:
       '@codemod/parser': ^1.0.7
       '@rooks/use-interval': ^4.5.0
       '@testing-library/cypress': ^5.3.1
+      '@testing-library/jest-dom': ^4.2.4
       '@testing-library/react': ^11.2.3
+      '@testing-library/user-event': ^13.5.0
       '@types/base64-js': ^1.2.5
       '@types/debug': ^4.1.6
       '@types/dompurify': ^2.0.4
@@ -1689,13 +1693,13 @@ importers:
   libs/res-to-ts:
     dependencies:
       '@votingworks/types': link:../types
-      globby: 11.1.0
+      globby: 11.0.4
       mime: 3.0.0
       tmp: 0.2.1
     devDependencies:
       '@types/jest': 27.4.1
       '@types/mime': 2.0.3
-      '@types/node': 17.0.22
+      '@types/node': 17.0.23
       '@types/tmp': 0.2.3
       '@typescript-eslint/eslint-plugin': 5.16.0_6439597c078d4a15fcc6e7f0ff1a5209
       '@typescript-eslint/parser': 5.16.0_eslint@8.11.0+typescript@4.3.5
@@ -2228,13 +2232,6 @@ importers:
       zod: ^3.2.0
 lockfileVersion: 5.2
 packages:
-  /@ampproject/remapping/2.1.2:
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.4
-    engines:
-      node: '>=6.0.0'
-    resolution:
-      integrity: sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==
   /@antongolub/iso8601/1.2.1:
     dev: false
     resolution:
@@ -2299,11 +2296,6 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q==
-  /@babel/compat-data/7.17.7:
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ==
   /@babel/core/7.12.3:
     dependencies:
       '@babel/code-frame': 7.15.8
@@ -2393,7 +2385,7 @@ packages:
       integrity: sha512-mYZEvshBRHGsIAiyH5PzCFTCfbWfoYbO/jcSdXQSUQu1/pW0xDZAUP7KEc32heqWTAfAHhV9j1vH8Sav7l+JNQ==
   /@babel/core/7.16.5:
     dependencies:
-      '@babel/code-frame': 7.16.0
+      '@babel/code-frame': 7.16.7
       '@babel/generator': 7.16.5
       '@babel/helper-compilation-targets': 7.16.3_@babel+core@7.16.5
       '@babel/helper-module-transforms': 7.16.5
@@ -2412,27 +2404,6 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-wUcenlLzuWMZ9Zt8S0KmFwGlH6QKRh3vsm/dhDA3CHkiTA45YuG1XkHRcNRl73EFPXDp/d5kVOU0/y7x2w6OaQ==
-  /@babel/core/7.17.8:
-    dependencies:
-      '@ampproject/remapping': 2.1.2
-      '@babel/code-frame': 7.16.7
-      '@babel/generator': 7.17.7
-      '@babel/helper-compilation-targets': 7.17.7_@babel+core@7.17.8
-      '@babel/helper-module-transforms': 7.17.7
-      '@babel/helpers': 7.17.8
-      '@babel/parser': 7.17.8
-      '@babel/template': 7.16.7
-      '@babel/traverse': 7.17.3
-      '@babel/types': 7.17.0
-      convert-source-map: 1.8.0
-      debug: 4.3.4
-      gensync: 1.0.0-beta.2
-      json5: 2.2.1
-      semver: 6.3.0
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==
   /@babel/generator/7.12.11:
     dependencies:
       '@babel/types': 7.12.12
@@ -2486,15 +2457,6 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-kIvCdjZqcdKqoDbVVdt5R99icaRtrtYhYK/xux5qiWCBmfdvEYMFZ68QCrpE5cbFM1JsuArUNs1ZkuKtTtUcZA==
-  /@babel/generator/7.17.7:
-    dependencies:
-      '@babel/types': 7.17.0
-      jsesc: 2.5.2
-      source-map: 0.5.7
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==
   /@babel/helper-annotate-as-pure/7.12.10:
     dependencies:
       '@babel/types': 7.12.12
@@ -2581,19 +2543,6 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-vKsoSQAyBmxS35JUOOt+07cLc6Nk/2ljLIHwmq2/NM6hdioUaqEXq/S+nXvbvXbZkNDlWOymPanJGOc4CBjSJA==
-  /@babel/helper-compilation-targets/7.17.7_@babel+core@7.17.8:
-    dependencies:
-      '@babel/compat-data': 7.17.7
-      '@babel/core': 7.17.8
-      '@babel/helper-validator-option': 7.16.7
-      browserslist: 4.20.2
-      semver: 6.3.0
-    engines:
-      node: '>=6.9.0'
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    resolution:
-      integrity: sha512-UFzlz2jjd8kroj0hmCFV5zr+tQPi1dpC2cRsDV/3IEW8bJfCPrPpmcSN6ZS8RqIq4LXcmpipCQFPddyFA5Yc7w==
   /@babel/helper-create-class-features-plugin/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
@@ -2655,13 +2604,6 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-ODQyc5AnxmZWm/R2W7fzhamOk1ey8gSguo5SGvF0zcB3uUzRpTRmM/jmLSm9bDMyPlvbyJ+PwPEK0BWIoZ9wjg==
-  /@babel/helper-environment-visitor/7.16.7:
-    dependencies:
-      '@babel/types': 7.17.0
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==
   /@babel/helper-explode-assignable-expression/7.12.1:
     dependencies:
       '@babel/types': 7.15.6
@@ -2712,15 +2654,6 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==
-  /@babel/helper-function-name/7.16.7:
-    dependencies:
-      '@babel/helper-get-function-arity': 7.16.7
-      '@babel/template': 7.16.7
-      '@babel/types': 7.17.0
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==
   /@babel/helper-get-function-arity/7.12.10:
     dependencies:
       '@babel/types': 7.12.12
@@ -2755,13 +2688,6 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==
-  /@babel/helper-get-function-arity/7.16.7:
-    dependencies:
-      '@babel/types': 7.17.0
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==
   /@babel/helper-hoist-variables/7.14.5:
     dependencies:
       '@babel/types': 7.15.0
@@ -2784,13 +2710,6 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==
-  /@babel/helper-hoist-variables/7.16.7:
-    dependencies:
-      '@babel/types': 7.17.0
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==
   /@babel/helper-member-expression-to-functions/7.14.5:
     dependencies:
       '@babel/types': 7.14.5
@@ -2847,13 +2766,6 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==
-  /@babel/helper-module-imports/7.16.7:
-    dependencies:
-      '@babel/types': 7.17.0
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==
   /@babel/helper-module-transforms/7.14.5:
     dependencies:
       '@babel/helper-module-imports': 7.14.5
@@ -2903,7 +2815,7 @@ packages:
       '@babel/helper-module-imports': 7.16.0
       '@babel/helper-simple-access': 7.16.0
       '@babel/helper-split-export-declaration': 7.16.0
-      '@babel/helper-validator-identifier': 7.15.7
+      '@babel/helper-validator-identifier': 7.16.7
       '@babel/template': 7.16.0
       '@babel/traverse': 7.16.5
       '@babel/types': 7.16.0
@@ -2911,20 +2823,6 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-CkvMxgV4ZyyioElFwcuWnDCcNIeyqTkCm9BxXZi73RR1ozqlpboqsbGUNvRTflgZtFbbJ1v5Emvm+lkjMYY/LQ==
-  /@babel/helper-module-transforms/7.17.7:
-    dependencies:
-      '@babel/helper-environment-visitor': 7.16.7
-      '@babel/helper-module-imports': 7.16.7
-      '@babel/helper-simple-access': 7.17.7
-      '@babel/helper-split-export-declaration': 7.16.7
-      '@babel/helper-validator-identifier': 7.16.7
-      '@babel/template': 7.16.7
-      '@babel/traverse': 7.17.3
-      '@babel/types': 7.17.0
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-VmZD99F3gNTYB7fJRDTi+u6l/zxY0BE6OIxPSU7a50s6ZUQkHwSDmV92FfM+oCG0pZRVojGYhkR8I0OGeCVREw==
   /@babel/helper-optimise-call-expression/7.14.5:
     dependencies:
       '@babel/types': 7.15.0
@@ -2961,11 +2859,6 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-59KHWHXxVA9K4HNF4sbHCf+eJeFe0Te/ZFGqBT4OjXhrwvA04sGfaEGsVTdsjoszq0YTP49RC9UKe5g8uN2RwQ==
-  /@babel/helper-plugin-utils/7.16.7:
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==
   /@babel/helper-remap-async-to-generator/7.12.1:
     dependencies:
       '@babel/helper-annotate-as-pure': 7.12.13
@@ -3027,13 +2920,6 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-o1rjBT/gppAqKsYfUdfHq5Rk03lMQrkPHG1OWzHWpLgVXRH4HnMM9Et9CVdIqwkCQlobnGHEJMsgWP/jE1zUiw==
-  /@babel/helper-simple-access/7.17.7:
-    dependencies:
-      '@babel/types': 7.17.0
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==
   /@babel/helper-skip-transparent-expression-wrappers/7.12.1:
     dependencies:
       '@babel/types': 7.15.6
@@ -3074,13 +2960,6 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==
-  /@babel/helper-split-export-declaration/7.16.7:
-    dependencies:
-      '@babel/types': 7.17.0
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==
   /@babel/helper-validator-identifier/7.12.11:
     resolution:
       integrity: sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
@@ -3112,11 +2991,6 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==
-  /@babel/helper-validator-option/7.16.7:
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==
   /@babel/helper-wrap-function/7.12.3:
     dependencies:
       '@babel/helper-function-name': 7.15.4
@@ -3163,15 +3037,6 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-TLgi6Lh71vvMZGEkFuIxzaPsyeYCHQ5jJOOX1f0xXn0uciFuE8cEk0wyBquMcCxBXZ5BJhE2aUB7pnWTD150Tw==
-  /@babel/helpers/7.17.8:
-    dependencies:
-      '@babel/template': 7.16.7
-      '@babel/traverse': 7.17.3
-      '@babel/types': 7.17.0
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-QcL86FGxpfSJwGtAvv4iG93UL6bmqBdmoVY0CMCU2g+oD2ezQse3PT5Pa+jiD6LJndBQi0EDlpzOWNlLuhz5gw==
   /@babel/highlight/7.13.8:
     dependencies:
       '@babel/helper-validator-identifier': 7.12.11
@@ -3272,12 +3137,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-Gr86ujcNuPDnNOY8mi383Hvi8IYrJVJYuf3XcuBM/Dgd+bINn/7tHqsj+tKkoreMbmGsFLsltI/JJd8fOFWGDQ==
-  /@babel/parser/7.17.8:
-    engines:
-      node: '>=6.0.0'
-    hasBin: true
-    resolution:
-      integrity: sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==
   /@babel/plugin-proposal-async-generator-functions/7.12.12_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
@@ -3615,15 +3474,6 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
-  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.17.8:
-    dependencies:
-      '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.16.5
-    dev: true
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
   /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
@@ -3644,15 +3494,6 @@ packages:
   /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.16.5:
     dependencies:
       '@babel/core': 7.16.5
-      '@babel/helper-plugin-utils': 7.16.5
-    dev: true
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==
-  /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.17.8:
-    dependencies:
-      '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.16.5
     dev: true
     peerDependencies:
@@ -3688,15 +3529,6 @@ packages:
   /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.16.5:
     dependencies:
       '@babel/core': 7.16.5
-      '@babel/helper-plugin-utils': 7.16.5
-    dev: true
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==
-  /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.17.8:
-    dependencies:
-      '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.16.5
     dev: true
     peerDependencies:
@@ -3783,15 +3615,6 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==
-  /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.17.8:
-    dependencies:
-      '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.16.5
-    dev: true
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==
   /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
@@ -3821,15 +3644,6 @@ packages:
   /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.16.5:
     dependencies:
       '@babel/core': 7.16.5
-      '@babel/helper-plugin-utils': 7.16.5
-    dev: true
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
-  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.17.8:
-    dependencies:
-      '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.16.5
     dev: true
     peerDependencies:
@@ -3889,15 +3703,6 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==
-  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.17.8:
-    dependencies:
-      '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.16.5
-    dev: true
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
@@ -3927,15 +3732,6 @@ packages:
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.16.5:
     dependencies:
       '@babel/core': 7.16.5
-      '@babel/helper-plugin-utils': 7.16.5
-    dev: true
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
-  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.17.8:
-    dependencies:
-      '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.16.5
     dev: true
     peerDependencies:
@@ -3977,15 +3773,6 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==
-  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.17.8:
-    dependencies:
-      '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.16.5
-    dev: true
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==
   /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
@@ -4015,15 +3802,6 @@ packages:
   /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.16.5:
     dependencies:
       '@babel/core': 7.16.5
-      '@babel/helper-plugin-utils': 7.16.5
-    dev: true
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
-  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.17.8:
-    dependencies:
-      '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.16.5
     dev: true
     peerDependencies:
@@ -4065,15 +3843,6 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
-  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.17.8:
-    dependencies:
-      '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.16.5
-    dev: true
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
   /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
@@ -4103,15 +3872,6 @@ packages:
   /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.16.5:
     dependencies:
       '@babel/core': 7.16.5
-      '@babel/helper-plugin-utils': 7.16.5
-    dev: true
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
-  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.17.8:
-    dependencies:
-      '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.16.5
     dev: true
     peerDependencies:
@@ -4161,17 +3921,6 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==
-  /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.17.8:
-    dependencies:
-      '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.16.5
-    dev: true
-    engines:
-      node: '>=6.9.0'
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==
   /@babel/plugin-syntax-typescript/7.12.13_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
@@ -4203,17 +3952,6 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-/d4//lZ1Vqb4mZ5xTep3dDK888j7BGM/iKqBmndBaoYAFPlPKrGU608VVBz5JeyAb6YQDjRu1UKqj86UhwWVgw==
-  /@babel/plugin-syntax-typescript/7.16.7_@babel+core@7.17.8:
-    dependencies:
-      '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.16.7
-    dev: true
-    engines:
-      node: '>=6.9.0'
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-YhUIJHHGkqPgEcMYkPCKTyGUdoGKWtopIycQyjJH8OjvRgOYsXsaKehLVPScKJWAULPxMa4N1vCe6szREFlZ7A==
   /@babel/plugin-transform-arrow-functions/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
@@ -5257,6 +4995,7 @@ packages:
   /@babel/runtime/7.16.7:
     dependencies:
       regenerator-runtime: 0.13.9
+    dev: true
     engines:
       node: '>=6.9.0'
     resolution:
@@ -5269,6 +5008,13 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-L6rvG9GDxaLgFjg41K+5Yv9OMrU98sWe+Ykmc6FDJW/+vYZMhdOMKkISgzptMaERHvS2Y2lw9MDRm2gHhlQQoA==
+  /@babel/runtime/7.17.8:
+    dependencies:
+      regenerator-runtime: 0.13.9
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==
   /@babel/template/7.12.13:
     dependencies:
       '@babel/code-frame': 7.12.13
@@ -5306,22 +5052,13 @@ packages:
       integrity: sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==
   /@babel/template/7.16.0:
     dependencies:
-      '@babel/code-frame': 7.16.0
+      '@babel/code-frame': 7.16.7
       '@babel/parser': 7.16.6
       '@babel/types': 7.16.0
     engines:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==
-  /@babel/template/7.16.7:
-    dependencies:
-      '@babel/code-frame': 7.16.7
-      '@babel/parser': 7.17.8
-      '@babel/types': 7.17.0
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==
   /@babel/traverse/7.12.12_supports-color@5.5.0:
     dependencies:
       '@babel/code-frame': 7.12.11
@@ -5417,7 +5154,7 @@ packages:
       integrity: sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==
   /@babel/traverse/7.16.5:
     dependencies:
-      '@babel/code-frame': 7.16.0
+      '@babel/code-frame': 7.16.7
       '@babel/generator': 7.16.5
       '@babel/helper-environment-visitor': 7.16.5
       '@babel/helper-function-name': 7.16.0
@@ -5431,22 +5168,6 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-FOCODAzqUMROikDYLYxl4nmwiLlu85rNqBML/A5hKRVXG2LV8d0iMqgPzdYTcIpjZEBB7D6UDU9vxRZiriASdQ==
-  /@babel/traverse/7.17.3:
-    dependencies:
-      '@babel/code-frame': 7.16.7
-      '@babel/generator': 7.17.7
-      '@babel/helper-environment-visitor': 7.16.7
-      '@babel/helper-function-name': 7.16.7
-      '@babel/helper-hoist-variables': 7.16.7
-      '@babel/helper-split-export-declaration': 7.16.7
-      '@babel/parser': 7.17.8
-      '@babel/types': 7.17.0
-      debug: 4.3.4
-      globals: 11.12.0
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==
   /@babel/types/7.12.12:
     dependencies:
       '@babel/helper-validator-identifier': 7.12.11
@@ -5502,14 +5223,6 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==
-  /@babel/types/7.17.0:
-    dependencies:
-      '@babel/helper-validator-identifier': 7.16.7
-      to-fast-properties: 2.0.0
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==
   /@bcoe/v8-coverage/0.2.3:
     resolution:
       integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
@@ -5701,9 +5414,9 @@ packages:
   /@eslint/eslintrc/1.2.1:
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4
+      debug: 4.3.3
       espree: 9.3.1
-      globals: 13.13.0
+      globals: 13.12.0
       ignore: 5.2.0
       import-fresh: 3.3.0
       js-yaml: 4.1.0
@@ -5769,7 +5482,7 @@ packages:
   /@humanwhocodes/config-array/0.9.5:
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4
+      debug: 4.3.3
       minimatch: 3.1.2
     dev: true
     engines:
@@ -5850,7 +5563,7 @@ packages:
   /@jest/console/27.5.1:
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 17.0.22
+      '@types/node': 17.0.23
       chalk: 4.1.2
       jest-message-util: 27.5.1
       jest-util: 27.5.1
@@ -6144,7 +5857,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.22
+      '@types/node': 17.0.23
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.8.1
@@ -6184,7 +5897,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.22
+      '@types/node': 17.0.23
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.8.1
@@ -6265,7 +5978,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.22
+      '@types/node': 17.0.23
       jest-mock: 27.5.1
     dev: true
     engines:
@@ -6339,7 +6052,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@sinonjs/fake-timers': 8.1.0
-      '@types/node': 17.0.22
+      '@types/node': 17.0.23
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
@@ -6500,7 +6213,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.22
+      '@types/node': 17.0.23
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -6519,7 +6232,7 @@ packages:
       source-map: 0.6.1
       string-length: 4.0.2
       terminal-link: 2.1.1
-      v8-to-istanbul: 8.1.1
+      v8-to-istanbul: 8.1.0
     dev: true
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
@@ -6616,7 +6329,7 @@ packages:
     dependencies:
       '@jest/console': 27.5.1
       '@jest/types': 27.5.1
-      '@types/istanbul-lib-coverage': 2.0.4
+      '@types/istanbul-lib-coverage': 2.0.3
       collect-v8-coverage: 1.0.1
     dev: true
     engines:
@@ -6750,7 +6463,7 @@ packages:
       integrity: sha512-PuMet2UlZtlGzwc6L+aZmR3I7CEBpqadO03pU40l2RNY2fFJ191b9/ITB44LNOhVtsyykx0OZvj0PCyuLm7Eew==
   /@jest/transform/27.5.1:
     dependencies:
-      '@babel/core': 7.17.8
+      '@babel/core': 7.16.5
       '@jest/types': 27.5.1
       babel-plugin-istanbul: 6.1.1
       chalk: 4.1.2
@@ -6761,7 +6474,7 @@ packages:
       jest-regex-util: 27.5.1
       jest-util: 27.5.1
       micromatch: 4.0.4
-      pirates: 4.0.5
+      pirates: 4.0.4
       slash: 3.0.0
       source-map: 0.6.1
       write-file-atomic: 3.0.3
@@ -6849,9 +6562,9 @@ packages:
       integrity: sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==
   /@jest/types/27.5.1:
     dependencies:
-      '@types/istanbul-lib-coverage': 2.0.4
+      '@types/istanbul-lib-coverage': 2.0.3
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 17.0.22
+      '@types/node': 16.11.6
       '@types/yargs': 16.0.4
       chalk: 4.1.2
     dev: true
@@ -6859,20 +6572,6 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==
-  /@jridgewell/resolve-uri/3.0.5:
-    engines:
-      node: '>=6.0.0'
-    resolution:
-      integrity: sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==
-  /@jridgewell/sourcemap-codec/1.4.11:
-    resolution:
-      integrity: sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==
-  /@jridgewell/trace-mapping/0.3.4:
-    dependencies:
-      '@jridgewell/resolve-uri': 3.0.5
-      '@jridgewell/sourcemap-codec': 1.4.11
-    resolution:
-      integrity: sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==
   /@mapbox/node-pre-gyp/1.0.8:
     dependencies:
       detect-libc: 1.0.3
@@ -7342,6 +7041,21 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-GObDVMaI4ARrZEXaRy4moolNAxWPKvEYNV/fa6Uc2eAzR/t4otS6A7EhrntPBIQLeehL9DbVhscvvv7gd6hWqA==
+  /@testing-library/dom/8.11.3:
+    dependencies:
+      '@babel/code-frame': 7.16.7
+      '@babel/runtime': 7.17.8
+      '@types/aria-query': 4.2.2
+      aria-query: 5.0.0
+      chalk: 4.1.2
+      dom-accessibility-api: 0.5.13
+      lz-string: 1.4.4
+      pretty-format: 27.5.1
+    dev: true
+    engines:
+      node: '>=12'
+    resolution:
+      integrity: sha512-9LId28I+lx70wUiZjLvi1DB/WT2zGOxUh46glrSNMaWVx849kKAluezVzZrXJfTKKoQTmEOutLes/bHg4Bj3aA==
   /@testing-library/dom/8.5.0:
     dependencies:
       '@babel/code-frame': 7.14.5
@@ -7359,7 +7073,7 @@ packages:
       integrity: sha512-O0fmHFaPlqaYCpa/cBL0cvroMridb9vZsMLacgIqrlxj+fd+bGF8UfAgwsLCHRF84KLBafWlm9CuOvxeNTlodw==
   /@testing-library/jest-dom/4.2.4:
     dependencies:
-      '@babel/runtime': 7.16.7
+      '@babel/runtime': 7.17.8
       chalk: 2.4.2
       css: 2.2.4
       css.escape: 1.5.1
@@ -7492,6 +7206,16 @@ packages:
       npm: '>=6'
     resolution:
       integrity: sha512-cczlgVl+krjOb3j1625usarNEibI0IFRJrSWX9UsJ1HKYFgCQv9Nb7QAipUDXl3Xdz8NDTsiS78eAkPSxlzTlw==
+  /@testing-library/user-event/13.5.0:
+    dependencies:
+      '@babel/runtime': 7.17.8
+      '@testing-library/dom': 8.11.3
+    dev: true
+    engines:
+      node: '>=10'
+      npm: '>=6'
+    resolution:
+      integrity: sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==
   /@tootallnate/once/1.1.2:
     engines:
       node: '>= 6'
@@ -7546,36 +7270,20 @@ packages:
     dev: true
     resolution:
       integrity: sha512-6zzkezS9QEIL8yCBvXWxPTJPNuMeECJVxSOhxNY/jfq9LxOTHivaYTqr37n9LknWWRTIkzqH2UilS5QFvfa90A==
-  /@types/babel__core/7.1.19:
-    dependencies:
-      '@babel/parser': 7.17.8
-      '@babel/types': 7.17.0
-      '@types/babel__generator': 7.6.4
-      '@types/babel__template': 7.4.1
-      '@types/babel__traverse': 7.14.2
-    dev: true
-    resolution:
-      integrity: sha512-WEOTgRsbYkvA/KCsDwVEGkd7WAr1e3g31VHQ8zy5gul/V1qKullU/BU5I68X5v7V3GnB9eotmom4v5a5gjxorw==
   /@types/babel__generator/7.6.3:
     dependencies:
       '@babel/types': 7.16.0
     resolution:
       integrity: sha512-/GWCmzJWqV7diQW54smJZzWbSFf4QYtF71WCKhcx6Ru/tFyQIY2eiiITcCAeuPbNSvT9YCGkVMqqvSk2Z0mXiA==
-  /@types/babel__generator/7.6.4:
-    dependencies:
-      '@babel/types': 7.17.0
-    dev: true
-    resolution:
-      integrity: sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==
   /@types/babel__template/7.4.1:
     dependencies:
-      '@babel/parser': 7.17.8
-      '@babel/types': 7.17.0
+      '@babel/parser': 7.16.6
+      '@babel/types': 7.16.0
     resolution:
       integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==
   /@types/babel__traverse/7.14.2:
     dependencies:
-      '@babel/types': 7.17.0
+      '@babel/types': 7.16.0
     resolution:
       integrity: sha512-K2waXdXBi2302XUdcHcR1jCeU0LL4TD9HRs/gk0N2Xvrht+G/BfJa4QObBQZfhMdxiCpV3COl5Nfq4uKTeTnJA==
   /@types/base64-js/1.3.0:
@@ -7720,7 +7428,7 @@ packages:
       integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==
   /@types/graceful-fs/4.1.5:
     dependencies:
-      '@types/node': 17.0.22
+      '@types/node': 17.0.23
     resolution:
       integrity: sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==
   /@types/history/4.7.8:
@@ -7749,12 +7457,9 @@ packages:
   /@types/istanbul-lib-coverage/2.0.3:
     resolution:
       integrity: sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==
-  /@types/istanbul-lib-coverage/2.0.4:
-    resolution:
-      integrity: sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==
   /@types/istanbul-lib-report/3.0.0:
     dependencies:
-      '@types/istanbul-lib-coverage': 2.0.4
+      '@types/istanbul-lib-coverage': 2.0.3
     resolution:
       integrity: sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==
   /@types/istanbul-reports/1.1.2:
@@ -7837,10 +7542,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-8JQCjdeAidptSsOcRWk2iTm9wCcwn9l+kRG6k5bzUacrnm1ezV4forq0kWjUih/tumAeoG+OspOvQEbbRucBTw==
-  /@types/json-schema/7.0.10:
-    dev: true
-    resolution:
-      integrity: sha512-BLO9bBq59vW3fxCpD4o0N4U+DXsvwvIcl+jofw0frQo/GrBFC+/jRZj1E7kgp6dvTyNmA4y6JCV5Id/r3mNP5A==
   /@types/json-schema/7.0.6:
     resolution:
       integrity: sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
@@ -8005,9 +7706,9 @@ packages:
   /@types/node/16.11.6:
     resolution:
       integrity: sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w==
-  /@types/node/17.0.22:
+  /@types/node/17.0.23:
     resolution:
-      integrity: sha512-8FwbVoG4fy+ykY86XCAclKZDORttqE5/s7dyWZKLXTdv3vRy5HozBEinG5IqhvPXXzIZEcTVbuHlQEI6iuwcmw==
+      integrity: sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==
   /@types/normalize-package-data/2.4.1:
     resolution:
       integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
@@ -8036,10 +7737,6 @@ packages:
   /@types/prettier/2.4.2:
     resolution:
       integrity: sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA==
-  /@types/prettier/2.4.4:
-    dev: true
-    resolution:
-      integrity: sha512-ReVR2rLTV1kvtlWFyuot+d1pkpG2Fw/XKE3PDAdj57rbM97ttSp9JZ2UsP+2EHTylra9cUf6JA7tGwW1INzUrA==
   /@types/prop-types/15.7.3:
     resolution:
       integrity: sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
@@ -8344,10 +8041,6 @@ packages:
   /@types/yargs-parser/20.2.1:
     resolution:
       integrity: sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==
-  /@types/yargs-parser/21.0.0:
-    dev: true
-    resolution:
-      integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==
   /@types/yargs/13.0.11:
     dependencies:
       '@types/yargs-parser': 20.2.1
@@ -8376,7 +8069,7 @@ packages:
       integrity: sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==
   /@types/yargs/16.0.4:
     dependencies:
-      '@types/yargs-parser': 21.0.0
+      '@types/yargs-parser': 20.2.1
     dev: true
     resolution:
       integrity: sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==
@@ -8634,7 +8327,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.16.0
       '@typescript-eslint/type-utils': 5.16.0_eslint@8.11.0+typescript@4.3.5
       '@typescript-eslint/utils': 5.16.0_eslint@8.11.0+typescript@4.3.5
-      debug: 4.3.4
+      debug: 4.3.3
       eslint: 8.11.0
       functional-red-black-tree: 1.0.1
       ignore: 5.2.0
@@ -9329,7 +9022,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.16.0
       '@typescript-eslint/types': 5.16.0
       '@typescript-eslint/typescript-estree': 5.16.0_typescript@4.3.5
-      debug: 4.3.4
+      debug: 4.3.3
       eslint: 7.32.0
       typescript: 4.3.5
     dev: true
@@ -9348,7 +9041,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.16.0
       '@typescript-eslint/types': 5.16.0
       '@typescript-eslint/typescript-estree': 5.16.0_typescript@4.3.5
-      debug: 4.3.4
+      debug: 4.3.3
       eslint: 8.11.0
       typescript: 4.3.5
     dev: true
@@ -9516,7 +9209,7 @@ packages:
   /@typescript-eslint/type-utils/5.16.0_eslint@8.11.0+typescript@4.3.5:
     dependencies:
       '@typescript-eslint/utils': 5.16.0_eslint@8.11.0+typescript@4.3.5
-      debug: 4.3.4
+      debug: 4.3.3
       eslint: 8.11.0
       tsutils: 3.21.0_typescript@4.3.5
       typescript: 4.3.5
@@ -9770,8 +9463,8 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.16.0
       '@typescript-eslint/visitor-keys': 5.16.0
-      debug: 4.3.4
-      globby: 11.1.0
+      debug: 4.3.3
+      globby: 11.0.4
       is-glob: 4.0.3
       semver: 7.3.5
       tsutils: 3.21.0_typescript@4.3.5
@@ -9864,7 +9557,7 @@ packages:
       integrity: sha512-081rWu2IPKOgTOhHUk/QfxuFog8m4wxW43sXNOMSCdh578tGJ1PAaWPsj42LOa7pguh173tNlMigsbrHvh/mtA==
   /@typescript-eslint/utils/5.16.0_eslint@8.11.0+typescript@4.3.5:
     dependencies:
-      '@types/json-schema': 7.0.10
+      '@types/json-schema': 7.0.9
       '@typescript-eslint/scope-manager': 5.16.0
       '@typescript-eslint/types': 5.16.0
       '@typescript-eslint/typescript-estree': 5.16.0_typescript@4.3.5
@@ -10220,7 +9913,7 @@ packages:
       integrity: sha512-YBrGyT2/uVQ/c6Rr+t6ZJXniY03YtHGMJQYal368burRGYKqhx9qGTWqcBU5s1CwYY9E/ri63RYyG1IacMZtqw==
   /agent-base/6.0.2:
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.3
     engines:
       node: '>= 6.0.0'
     resolution:
@@ -10401,7 +10094,7 @@ packages:
   /anymatch/3.1.2:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.1
+      picomatch: 2.3.0
     engines:
       node: '>= 8'
     resolution:
@@ -10474,6 +10167,12 @@ packages:
       node: '>=6.0'
     resolution:
       integrity: sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
+  /aria-query/5.0.0:
+    dev: true
+    engines:
+      node: '>=6.0'
+    resolution:
+      integrity: sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==
   /arity-n/1.0.4:
     dev: false
     resolution:
@@ -10826,14 +10525,14 @@ packages:
       '@babel/core': ^7.8.0
     resolution:
       integrity: sha512-3uuUTjXbgtODmSv/DXO9nZfD52IyC2OYTFaXGRzL0kpykzroaquCrD5+lZNafTvZlnNqZHt5pb0M08qVBZnsnA==
-  /babel-jest/27.5.1_@babel+core@7.17.8:
+  /babel-jest/27.5.1_@babel+core@7.16.5:
     dependencies:
-      '@babel/core': 7.17.8
+      '@babel/core': 7.16.5
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/babel__core': 7.1.19
+      '@types/babel__core': 7.1.17
       babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 27.5.1_@babel+core@7.17.8
+      babel-preset-jest: 27.5.1_@babel+core@7.16.5
       chalk: 4.1.2
       graceful-fs: 4.2.4
       slash: 3.0.0
@@ -10869,7 +10568,7 @@ packages:
       integrity: sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==
   /babel-plugin-istanbul/6.1.1:
     dependencies:
-      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-plugin-utils': 7.16.5
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-instrument: 5.1.0
@@ -10912,9 +10611,9 @@ packages:
       integrity: sha512-Jcu7qS4OX5kTWBc45Hz7BMmgXuJqRnhatqpUhnzGC3OBYpOmf2tv6jFNwZpwM7wU7MUuv2r9IPS/ZlYOuburVw==
   /babel-plugin-jest-hoist/27.5.1:
     dependencies:
-      '@babel/template': 7.16.7
-      '@babel/types': 7.17.0
-      '@types/babel__core': 7.1.19
+      '@babel/template': 7.16.0
+      '@babel/types': 7.16.0
+      '@types/babel__core': 7.1.17
       '@types/babel__traverse': 7.14.2
     dev: true
     engines:
@@ -11051,26 +10750,6 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==
-  /babel-preset-current-node-syntax/1.0.1_@babel+core@7.17.8:
-    dependencies:
-      '@babel/core': 7.17.8
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.17.8
-      '@babel/plugin-syntax-bigint': 7.8.3_@babel+core@7.17.8
-      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.17.8
-      '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.17.8
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.17.8
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.17.8
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.17.8
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.17.8
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.17.8
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.17.8
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.17.8
-      '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.17.8
-    dev: true
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    resolution:
-      integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==
   /babel-preset-jest/26.6.2_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
@@ -11118,11 +10797,11 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-NK4jGYpnBvNxcGo7/ZpZJr51jCGT+3bwwpVIDY2oNfTxJJldRtB4VAcYdgp1loDE50ODuTu+yBjpMAswv5tlpg==
-  /babel-preset-jest/27.5.1_@babel+core@7.17.8:
+  /babel-preset-jest/27.5.1_@babel+core@7.16.5:
     dependencies:
-      '@babel/core': 7.17.8
+      '@babel/core': 7.16.5
       babel-plugin-jest-hoist: 27.5.1
-      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.17.8
+      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.16.5
     dev: true
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
@@ -11444,18 +11123,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-8ScCzdpPwR2wQh8IT82CA2VgDwjHyqMovPBZSNH54+tm4Jk2pCuv90gmAdH6J84OCRWi0b4gMe6O6XPXuJnjgQ==
-  /browserslist/4.20.2:
-    dependencies:
-      caniuse-lite: 1.0.30001319
-      electron-to-chromium: 1.4.89
-      escalade: 3.1.1
-      node-releases: 2.0.2
-      picocolors: 1.0.0
-    engines:
-      node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7
-    hasBin: true
-    resolution:
-      integrity: sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==
   /bs-logger/0.2.6:
     dependencies:
       fast-json-stable-stringify: 2.1.0
@@ -11686,12 +11353,6 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==
-  /camelcase/6.3.0:
-    dev: true
-    engines:
-      node: '>=10'
-    resolution:
-      integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
   /camelize/1.0.0:
     dev: false
     resolution:
@@ -11718,9 +11379,6 @@ packages:
   /caniuse-lite/1.0.30001282:
     resolution:
       integrity: sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg==
-  /caniuse-lite/1.0.30001319:
-    resolution:
-      integrity: sha512-xjlIAFHucBRSMUo1kb5D4LYgcN1M45qdKP++lhqowDpwJwGkpIRTt5qQqnhxjj1vHcI7nrJxWhCC1ATrCEBTcw==
   /canvas/2.6.1:
     dependencies:
       nan: 2.14.2
@@ -13135,18 +12793,6 @@ packages:
         optional: true
     resolution:
       integrity: sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
-  /debug/4.3.4:
-    dependencies:
-      ms: 2.1.2
-    engines:
-      node: '>=6.0'
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    resolution:
-      integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   /decamelize-keys/1.1.0:
     dependencies:
       decamelize: 1.2.0
@@ -13481,6 +13127,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-PzwHEmsRP3IGY4gv/Ug+rMeaTIyTJvadCb+ujYXYeIylbHJezIyNToe8KfEgHTCEYyC+/bUghYOGg8yMGlZ6vA==
+  /dom-accessibility-api/0.5.13:
+    dev: true
+    resolution:
+      integrity: sha512-R305kwb5CcMDIpSHUnLyIAp7SrSPBx6F0VfQFB3M75xVMHhXJJIdePYgbPPh1o57vCHNu5QztokWUPsLjWzFqw==
   /dom-accessibility-api/0.5.4:
     resolution:
       integrity: sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==
@@ -13611,9 +13261,6 @@ packages:
   /electron-to-chromium/1.3.902:
     resolution:
       integrity: sha512-zFv5jbtyIr+V9FuT9o439isXbkXQ27mJqZfLXpBKzXugWE8+3RotHbXJlli0/r+Rvdlkut0OOMzeOWLAjH0jCw==
-  /electron-to-chromium/1.4.89:
-    resolution:
-      integrity: sha512-z1Axg0Fu54fse8wN4fd+GAINdU5mJmLtcl6bqIcYyzNVGONcfHAeeJi88KYMQVKalhXlYuVPzKkFIU5VD0raUw==
   /elegant-spinner/1.0.1:
     dev: true
     engines:
@@ -13807,7 +13454,7 @@ packages:
       get-intrinsic: 1.1.1
       get-symbol-description: 1.0.0
       has: 1.0.3
-      has-symbols: 1.0.3
+      has-symbols: 1.0.2
       internal-slot: 1.0.3
       is-callable: 1.2.4
       is-negative-zero: 2.0.2
@@ -13815,7 +13462,7 @@ packages:
       is-shared-array-buffer: 1.0.1
       is-string: 1.0.7
       is-weakref: 1.0.2
-      object-inspect: 1.12.0
+      object-inspect: 1.11.1
       object-keys: 1.1.1
       object.assign: 4.1.2
       string.prototype.trimend: 1.0.4
@@ -15636,7 +15283,7 @@ packages:
       minimatch: 3.1.2
       object.values: 1.1.5
       resolve: 1.22.0
-      tsconfig-paths: 3.14.0
+      tsconfig-paths: 3.12.0
     dev: true
     engines:
       node: '>=4'
@@ -15660,7 +15307,7 @@ packages:
       minimatch: 3.1.2
       object.values: 1.1.5
       resolve: 1.22.0
-      tsconfig-paths: 3.14.0
+      tsconfig-paths: 3.12.0
     dev: true
     engines:
       node: '>=4'
@@ -16793,7 +16440,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4
+      debug: 4.3.3
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.1.1
@@ -16806,7 +16453,7 @@ packages:
       file-entry-cache: 6.0.1
       functional-red-black-tree: 1.0.1
       glob-parent: 6.0.2
-      globals: 13.13.0
+      globals: 13.12.0
       ignore: 5.2.0
       import-fresh: 3.3.0
       imurmurhash: 0.1.4
@@ -17273,17 +16920,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
-  /fast-glob/3.2.11:
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.4
-    engines:
-      node: '>=8.6.0'
-    resolution:
-      integrity: sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
   /fast-glob/3.2.5:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -17529,15 +17165,15 @@ packages:
       integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
   /flat-cache/3.0.4:
     dependencies:
-      flatted: 3.2.5
+      flatted: 3.2.4
       rimraf: 3.0.2
     engines:
       node: ^10.12.0 || >=12.0.0
     resolution:
       integrity: sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==
-  /flatted/3.2.5:
+  /flatted/3.2.4:
     resolution:
-      integrity: sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
+      integrity: sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==
   /flatten/1.0.3:
     deprecated: flatten is deprecated in favor of utility frameworks such as lodash.
     dev: false
@@ -17628,7 +17264,7 @@ packages:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
-      mime-types: 2.1.35
+      mime-types: 2.1.34
     engines:
       node: '>= 6'
     resolution:
@@ -17838,7 +17474,7 @@ packages:
     dependencies:
       function-bind: 1.1.1
       has: 1.0.3
-      has-symbols: 1.0.3
+      has-symbols: 1.0.2
     resolution:
       integrity: sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
   /get-own-enumerable-property-symbols/3.0.2:
@@ -18026,14 +17662,6 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==
-  /globals/13.13.0:
-    dependencies:
-      type-fest: 0.20.2
-    dev: true
-    engines:
-      node: '>=8'
-    resolution:
-      integrity: sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==
   /globals/13.8.0:
     dependencies:
       type-fest: 0.20.2
@@ -18113,18 +17741,6 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
-  /globby/11.1.0:
-    dependencies:
-      array-union: 2.1.0
-      dir-glob: 3.0.1
-      fast-glob: 3.2.11
-      ignore: 5.2.0
-      merge2: 1.4.1
-      slash: 3.0.0
-    engines:
-      node: '>=10'
-    resolution:
-      integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
   /globby/6.1.0:
     dependencies:
       array-union: 1.0.2
@@ -18247,14 +17863,9 @@ packages:
       node: '>= 0.4'
     resolution:
       integrity: sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
-  /has-symbols/1.0.3:
-    engines:
-      node: '>= 0.4'
-    resolution:
-      integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
   /has-tostringtag/1.0.0:
     dependencies:
-      has-symbols: 1.0.3
+      has-symbols: 1.0.2
     engines:
       node: '>= 0.4'
     resolution:
@@ -18517,7 +18128,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.3
     engines:
       node: '>= 6'
     resolution:
@@ -18606,7 +18217,7 @@ packages:
   /https-proxy-agent/5.0.0:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.3
     engines:
       node: '>= 6'
     resolution:
@@ -18760,16 +18371,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-bE9iaUY3CXH8Cwfan/abDKAxe1KGT9kyGsBPqf6DMK/z0a2OzAsrukeYNgIH6cH5Xr452jb1TUL8rSfCLjZ9uA==
-  /import-local/3.1.0:
-    dependencies:
-      pkg-dir: 4.2.0
-      resolve-cwd: 3.0.0
-    dev: true
-    engines:
-      node: '>=8'
-    hasBin: true
-    resolution:
-      integrity: sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==
   /imurmurhash/0.1.4:
     engines:
       node: '>=0.8.19'
@@ -19407,7 +19008,7 @@ packages:
       integrity: sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==
   /is-symbol/1.0.4:
     dependencies:
-      has-symbols: 1.0.3
+      has-symbols: 1.0.2
     engines:
       node: '>= 0.4'
     resolution:
@@ -19491,8 +19092,8 @@ packages:
       integrity: sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==
   /istanbul-lib-instrument/5.1.0:
     dependencies:
-      '@babel/core': 7.17.8
-      '@babel/parser': 7.17.8
+      '@babel/core': 7.16.5
+      '@babel/parser': 7.16.6
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
       semver: 6.3.0
@@ -19511,7 +19112,7 @@ packages:
       integrity: sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==
   /istanbul-lib-source-maps/4.0.1:
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.3
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     engines:
@@ -19671,7 +19272,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.22
+      '@types/node': 17.0.23
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -19683,7 +19284,7 @@ packages:
       jest-runtime: 27.5.1
       jest-snapshot: 27.5.1
       jest-util: 27.5.1
-      prettier: 2.6.0
+      prettier: 2.5.1
       pretty-format: 27.5.1
       slash: 3.0.0
       stack-utils: 2.0.5
@@ -19875,7 +19476,7 @@ packages:
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.4
-      import-local: 3.1.0
+      import-local: 3.0.3
       jest-config: 27.5.1
       jest-util: 27.5.1
       jest-validate: 27.5.1
@@ -19900,7 +19501,7 @@ packages:
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.4
-      import-local: 3.1.0
+      import-local: 3.0.3
       jest-config: 27.5.1_canvas@2.9.0
       jest-util: 27.5.1
       jest-validate: 27.5.1
@@ -20152,10 +19753,10 @@ packages:
       integrity: sha512-t+STVJtPt+fpqQ8GBw850NtSQbnDOw/UzdPfzDaHQ48/AylQlW7LHj3dH+ndxhC1UxJ0Q3qkq7IH+nM1skwTwA==
   /jest-config/27.5.1:
     dependencies:
-      '@babel/core': 7.17.8
+      '@babel/core': 7.16.5
       '@jest/test-sequencer': 27.5.1
       '@jest/types': 27.5.1
-      babel-jest: 27.5.1_@babel+core@7.17.8
+      babel-jest: 27.5.1_@babel+core@7.16.5
       chalk: 4.1.2
       ci-info: 3.3.0
       deepmerge: 4.2.2
@@ -20188,10 +19789,10 @@ packages:
       integrity: sha512-5sAsjm6tGdsVbW9ahcChPAFCk4IlkQUknH5AvKjuLTSlcO/wCZKyFdn7Rg0EkC+OGgWODEy2hDpWB1PgzH0JNA==
   /jest-config/27.5.1_canvas@2.9.0:
     dependencies:
-      '@babel/core': 7.17.8
+      '@babel/core': 7.16.5
       '@jest/test-sequencer': 27.5.1
       '@jest/types': 27.5.1
-      babel-jest: 27.5.1_@babel+core@7.17.8
+      babel-jest: 27.5.1_@babel+core@7.16.5
       chalk: 4.1.2
       ci-info: 3.3.0
       deepmerge: 4.2.2
@@ -20483,7 +20084,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.22
+      '@types/node': 17.0.23
       jest-mock: 27.5.1
       jest-util: 27.5.1
       jsdom: 16.7.0
@@ -20497,7 +20098,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.22
+      '@types/node': 17.0.23
       jest-mock: 27.5.1
       jest-util: 27.5.1
       jsdom: 16.7.0_canvas@2.9.0
@@ -20564,7 +20165,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.22
+      '@types/node': 17.0.23
       jest-mock: 27.5.1
       jest-util: 27.5.1
     dev: true
@@ -20685,7 +20286,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@types/graceful-fs': 4.1.5
-      '@types/node': 17.0.22
+      '@types/node': 17.0.23
       anymatch: 3.1.2
       fb-watchman: 2.0.1
       graceful-fs: 4.2.4
@@ -20811,7 +20412,7 @@ packages:
       '@jest/source-map': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.22
+      '@types/node': 17.0.23
       chalk: 4.1.2
       co: 4.6.0
       expect: 27.5.1
@@ -21057,7 +20658,7 @@ packages:
   /jest-mock/27.5.1:
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 17.0.22
+      '@types/node': 17.0.23
     dev: true
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
@@ -21397,7 +20998,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.22
+      '@types/node': 17.0.23
       chalk: 4.1.2
       emittery: 0.8.1
       graceful-fs: 4.2.4
@@ -21614,7 +21215,7 @@ packages:
       integrity: sha512-RDhpcn5f1JYTX2pvJAGDcnsNTnsV9bjYPU8xcV+xPwOXnUPOQwf4ZEuiU6G9H1UztH+OapMgu/ckEVwO87PwnQ==
   /jest-serializer/27.5.1:
     dependencies:
-      '@types/node': 17.0.22
+      '@types/node': 17.0.23
       graceful-fs: 4.2.4
     dev: true
     engines:
@@ -21707,16 +21308,16 @@ packages:
       integrity: sha512-eCi/iM1YJFrJWiT9de4+RpWWWBqsHiYxFG9V9o/n0WXs6GpW4lUt4FAHAgFPTLPqCUVzrMQmSmTZSgQzwqR7IQ==
   /jest-snapshot/27.5.1:
     dependencies:
-      '@babel/core': 7.17.8
-      '@babel/generator': 7.17.7
-      '@babel/plugin-syntax-typescript': 7.16.7_@babel+core@7.17.8
-      '@babel/traverse': 7.17.3
-      '@babel/types': 7.17.0
+      '@babel/core': 7.16.5
+      '@babel/generator': 7.16.5
+      '@babel/plugin-syntax-typescript': 7.16.5_@babel+core@7.16.5
+      '@babel/traverse': 7.16.5
+      '@babel/types': 7.16.0
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
       '@types/babel__traverse': 7.14.2
-      '@types/prettier': 2.4.4
-      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.17.8
+      '@types/prettier': 2.4.2
+      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.16.5
       chalk: 4.1.2
       expect: 27.5.1
       graceful-fs: 4.2.4
@@ -21820,11 +21421,11 @@ packages:
   /jest-util/27.5.1:
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 17.0.22
+      '@types/node': 17.0.23
       chalk: 4.1.2
       ci-info: 3.3.0
       graceful-fs: 4.2.4
-      picomatch: 2.3.1
+      picomatch: 2.3.0
     dev: true
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
@@ -21871,7 +21472,7 @@ packages:
   /jest-validate/27.5.1:
     dependencies:
       '@jest/types': 27.5.1
-      camelcase: 6.3.0
+      camelcase: 6.2.1
       chalk: 4.1.2
       jest-get-type: 27.5.1
       leven: 3.1.0
@@ -21954,8 +21555,8 @@ packages:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest: 27.3.1
-      jest-regex-util: 27.4.0
-      jest-watcher: 27.4.2
+      jest-regex-util: 27.5.1
+      jest-watcher: 27.5.1
       slash: 3.0.0
       string-length: 4.0.2
       strip-ansi: 6.0.1
@@ -21971,8 +21572,8 @@ packages:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest: 27.4.5
-      jest-regex-util: 27.4.0
-      jest-watcher: 27.4.2
+      jest-regex-util: 27.5.1
+      jest-watcher: 27.5.1
       slash: 3.0.0
       string-length: 4.0.2
       strip-ansi: 6.0.1
@@ -21988,8 +21589,8 @@ packages:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest: 27.5.1
-      jest-regex-util: 27.4.0
-      jest-watcher: 27.4.2
+      jest-regex-util: 27.5.1
+      jest-watcher: 27.5.1
       slash: 3.0.0
       string-length: 4.0.2
       strip-ansi: 6.0.1
@@ -22059,7 +21660,7 @@ packages:
     dependencies:
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.22
+      '@types/node': 17.0.23
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest-util: 27.5.1
@@ -22109,7 +21710,7 @@ packages:
       integrity: sha512-f2s8kEdy15cv9r7q4KkzGXvlY0JTcmCbMHZBfSQDwW77REr45IDWwd0lksDFeVHH2jJ5pqb90T77XscrjeGzzg==
   /jest-worker/27.5.1:
     dependencies:
-      '@types/node': 17.0.22
+      '@types/node': 17.0.23
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -22229,7 +21830,7 @@ packages:
   /jest/27.5.1:
     dependencies:
       '@jest/core': 27.5.1
-      import-local: 3.1.0
+      import-local: 3.0.3
       jest-cli: 27.5.1
     dev: true
     engines:
@@ -22245,7 +21846,7 @@ packages:
   /jest/27.5.1_canvas@2.9.0:
     dependencies:
       '@jest/core': 27.5.1_canvas@2.9.0
-      import-local: 3.1.0
+      import-local: 3.0.3
       jest-cli: 27.5.1_canvas@2.9.0
     dev: true
     engines:
@@ -22325,7 +21926,7 @@ packages:
       whatwg-encoding: 1.0.5
       whatwg-mimetype: 2.3.0
       whatwg-url: 8.7.0
-      ws: 7.5.7
+      ws: 7.5.6
       xml-name-validator: 3.0.0
     engines:
       node: '>=10'
@@ -22364,7 +21965,7 @@ packages:
       whatwg-encoding: 1.0.5
       whatwg-mimetype: 2.3.0
       whatwg-url: 8.7.0
-      ws: 7.5.7
+      ws: 7.5.6
       xml-name-validator: 3.0.0
     dev: true
     engines:
@@ -22404,7 +22005,7 @@ packages:
       whatwg-encoding: 1.0.5
       whatwg-mimetype: 2.3.0
       whatwg-url: 8.7.0
-      ws: 7.5.7
+      ws: 7.5.6
       xml-name-validator: 3.0.0
     dev: true
     engines:
@@ -22507,7 +22108,7 @@ packages:
       integrity: sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==
   /json5/1.0.1:
     dependencies:
-      minimist: 1.2.6
+      minimist: 1.2.5
     hasBin: true
     resolution:
       integrity: sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
@@ -22528,12 +22129,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
-  /json5/2.2.1:
-    engines:
-      node: '>=6'
-    hasBin: true
-    resolution:
-      integrity: sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
   /jsonfile/4.0.0:
     optionalDependencies:
       graceful-fs: 4.2.8
@@ -23364,7 +22959,7 @@ packages:
   /micromatch/4.0.4:
     dependencies:
       braces: 3.0.2
-      picomatch: 2.3.1
+      picomatch: 2.3.0
     engines:
       node: '>=8.6'
     resolution:
@@ -23395,16 +22990,10 @@ packages:
     resolution:
       integrity: sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==
   /mime-db/1.51.0:
-    dev: false
     engines:
       node: '>= 0.6'
     resolution:
       integrity: sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
-  /mime-db/1.52.0:
-    engines:
-      node: '>= 0.6'
-    resolution:
-      integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
   /mime-types/2.1.28:
     dependencies:
       mime-db: 1.45.0
@@ -23431,18 +23020,10 @@ packages:
   /mime-types/2.1.34:
     dependencies:
       mime-db: 1.51.0
-    dev: false
     engines:
       node: '>= 0.6'
     resolution:
       integrity: sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==
-  /mime-types/2.1.35:
-    dependencies:
-      mime-db: 1.52.0
-    engines:
-      node: '>= 0.6'
-    resolution:
-      integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
   /mime/1.6.0:
     dev: false
     engines:
@@ -23554,9 +23135,6 @@ packages:
   /minimist/1.2.5:
     resolution:
       integrity: sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
-  /minimist/1.2.6:
-    resolution:
-      integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
   /minipass-collect/1.0.2:
     dependencies:
       minipass: 3.1.3
@@ -23942,9 +23520,6 @@ packages:
   /node-releases/2.0.1:
     resolution:
       integrity: sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==
-  /node-releases/2.0.2:
-    resolution:
-      integrity: sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==
   /nopt/4.0.3:
     dependencies:
       abbrev: 1.1.1
@@ -24141,9 +23716,9 @@ packages:
   /object-inspect/1.11.0:
     resolution:
       integrity: sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==
-  /object-inspect/1.12.0:
+  /object-inspect/1.11.1:
     resolution:
-      integrity: sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==
+      integrity: sha512-If7BjFlpkzzBeV1cqgT3OSWT3azyoxDGajR+iGnFBfVV2EWyDyWaZZW2ERDjUaY2QM8i5jI3Sj7mhsM4DDAqWA==
   /object-inspect/1.9.0:
     dev: true
     resolution:
@@ -24173,7 +23748,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
-      has-symbols: 1.0.3
+      has-symbols: 1.0.2
       object-keys: 1.1.1
     engines:
       node: '>= 0.4'
@@ -24738,11 +24313,6 @@ packages:
       node: '>=8.6'
     resolution:
       integrity: sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
-  /picomatch/2.3.1:
-    engines:
-      node: '>=8.6'
-    resolution:
-      integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
   /pify/2.3.0:
     engines:
       node: '>=0.10.0'
@@ -24783,12 +24353,6 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-ZIrVPH+A52Dw84R0L3/VS9Op04PuQ2SEoJL6bkshmiTic/HldyW9Tf7oH5mhJZBK7NmDx27vSMrYEXPXclpDKw==
-  /pirates/4.0.5:
-    dev: true
-    engines:
-      node: '>= 6'
-    resolution:
-      integrity: sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==
   /pkg-dir/2.0.0:
     dependencies:
       find-up: 2.1.0
@@ -25764,13 +25328,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
-  /prettier/2.6.0:
-    dev: true
-    engines:
-      node: '>=10.13.0'
-    hasBin: true
-    resolution:
-      integrity: sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==
   /pretty-bytes/5.5.0:
     dev: true
     engines:
@@ -27433,7 +26990,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       get-intrinsic: 1.1.1
-      object-inspect: 1.12.0
+      object-inspect: 1.11.1
     resolution:
       integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
   /signal-exit/3.0.3:
@@ -29168,7 +28725,7 @@ packages:
       fast-json-stable-stringify: 2.1.0
       jest: 27.5.1
       jest-util: 27.5.1
-      json5: 2.2.1
+      json5: 2.2.0
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.3.5
@@ -29204,7 +28761,7 @@ packages:
       fast-json-stable-stringify: 2.1.0
       jest: 27.5.1_canvas@2.9.0
       jest-util: 27.5.1
-      json5: 2.2.1
+      json5: 2.2.0
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.3.5
@@ -29285,15 +28842,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==
-  /tsconfig-paths/3.14.0:
-    dependencies:
-      '@types/json5': 0.0.29
-      json5: 1.0.1
-      minimist: 1.2.6
-      strip-bom: 3.0.0
-    dev: true
-    resolution:
-      integrity: sha512-cg/1jAZoL57R39+wiw4u/SCC6Ic9Q5NqjBOb+9xISedOYurfog9ZNmKJSxAnb2m/5Bq4lE9lhUcau33Ml8DM0g==
   /tsconfig-paths/3.9.0:
     dependencies:
       '@types/json5': 0.0.29
@@ -29495,7 +29043,7 @@ packages:
     dependencies:
       function-bind: 1.1.1
       has-bigints: 1.0.1
-      has-symbols: 1.0.3
+      has-symbols: 1.0.2
       which-boxed-primitive: 1.0.2
     resolution:
       integrity: sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==
@@ -29815,16 +29363,6 @@ packages:
       node: '>=10.12.0'
     resolution:
       integrity: sha512-/PRhfd8aTNp9Ggr62HPzXg2XasNFGy5PBt0Rp04du7/8GNNSgxFL6WBTkgMKSL9bFjH+8kKEG3f37FmxiTqUUA==
-  /v8-to-istanbul/8.1.1:
-    dependencies:
-      '@types/istanbul-lib-coverage': 2.0.4
-      convert-source-map: 1.8.0
-      source-map: 0.7.3
-    dev: true
-    engines:
-      node: '>=10.12.0'
-    resolution:
-      integrity: sha512-FGtKtv3xIpR6BYhvgH8MI/y78oT7d8Au3ww4QIxymrCtZEh5b8gCw2siywE+puhEmuWKDtmfrvF5UlB298ut3w==
   /validate-npm-package-license/3.0.4:
     dependencies:
       spdx-correct: 3.1.1
@@ -30480,7 +30018,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
-  /ws/7.5.7:
+  /ws/7.5.6:
     engines:
       node: '>=8.3.0'
     peerDependencies:
@@ -30492,7 +30030,7 @@ packages:
       utf-8-validate:
         optional: true
     resolution:
-      integrity: sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==
+      integrity: sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==
   /ws/8.3.0:
     dev: false
     engines:


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Task: #1417
Depends on: https://github.com/votingworks/kiosk-browser/pull/98

Adds a system diagnostics screen to the BMD pollworker view. The screen is accessed by clicking the "System Diagnostics" button on the pollworker actions screen. To start, it has only two sections:
- Computer: battery and power cord status, which updates automatically every 3 seconds
- Printer: printer status and toner levels, which update when the screen loads or when the user clicks a button to refresh

Future PRs will add sections for the card reader and accessible controller, and also allow this screen to be accessed by the admin user.

## Demo Video or Screenshot

<img width="1156" alt="Screen Shot 2022-03-22 at 2 20 14 PM" src="https://user-images.githubusercontent.com/530106/159579025-5db16722-fc34-4d48-bce2-5e6a21903d80.png">

<img width="1158" alt="Screen Shot 2022-03-22 at 4 57 07 PM" src="https://user-images.githubusercontent.com/530106/159595974-2d439a57-c866-40da-ae64-6d1ed976411f.png">

<img width="1155" alt="Screen Shot 2022-03-22 at 4 58 10 PM" src="https://user-images.githubusercontent.com/530106/159595984-e98adc11-490e-4b52-90bc-4e1ae819bd2e.png">


<img width="1156" alt="Screen Shot 2022-03-22 at 4 59 59 PM" src="https://user-images.githubusercontent.com/530106/159596090-3bd97b17-5f7d-4e58-95b8-9b424ff29fe1.png">



## Testing Plan 
TODO: add full automated tests for this screen
Manually tested extensively with a printer

## Checklist
- ~~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~~ Will revisit logging after finishing all of the features of the diagnostic screen
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
