### PR TITLE
test(em): annotate responses with types

### DIFF
--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -13,7 +13,12 @@ import {
 } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import { electionWithMsEitherNeitherWithDataFiles } from '@votingworks/fixtures';
-import { MemoryStorage, MemoryCard, MemoryHardware } from '@votingworks/utils';
+import {
+  MemoryStorage,
+  MemoryCard,
+  MemoryHardware,
+  typedAs,
+} from '@votingworks/utils';
 import {
   advanceTimersAndPromises,
   fakeKiosk,
@@ -48,6 +53,8 @@ import {
   convertExternalTalliesToStorageString,
   convertTalliesByPrecinctToFullExternalTally,
 } from './utils/external_tallies';
+import { MachineConfig } from './config/types';
+import { VxFiles } from './lib/converters';
 
 const EITHER_NEITHER_CVR_DATA =
   electionWithMsEitherNeitherWithDataFiles.cvrData;
@@ -81,19 +88,28 @@ beforeEach(() => {
   mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
   MockDate.set(new Date('2020-11-03T22:22:00'));
   fetchMock.reset();
-  fetchMock.get('/convert/election/files', {
-    inputFiles: [{ name: 'name' }, { name: 'name' }],
-    outputFiles: [{ name: 'name' }],
-  });
-  fetchMock.get('/convert/tallies/files', {
-    inputFiles: [{ name: 'name' }, { name: 'name' }],
-    outputFiles: [{ name: 'name' }],
-  });
-  fetchMock.get('/machine-config', {
-    machineId: '0000',
-    codeVersion: 'TEST',
-    bypassAuthentication: false,
-  });
+  fetchMock.get(
+    '/convert/election/files',
+    typedAs<VxFiles>({
+      inputFiles: [{ name: 'name' }, { name: 'name' }],
+      outputFiles: [{ name: 'name' }],
+    })
+  );
+  fetchMock.get(
+    '/convert/tallies/files',
+    typedAs<VxFiles>({
+      inputFiles: [{ name: 'name' }, { name: 'name' }],
+      outputFiles: [{ name: 'name' }],
+    })
+  );
+  fetchMock.get(
+    '/machine-config',
+    typedAs<MachineConfig>({
+      machineId: '0000',
+      codeVersion: 'TEST',
+      bypassAuthentication: false,
+    })
+  );
 });
 
 afterEach(() => {


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
This allows us to find them with "Find References" in IDEs, type check them in the event of incompatible changes, support renames, etc. It also is a form of documentation.

## Demo Video or Screenshot
n/a

## Testing Plan 
n/a

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
