### PR TITLE
feat(em): convert from NH definition

### DIFF
--- a/frontends/election-manager/README.md
+++ b/frontends/election-manager/README.md
@@ -14,6 +14,18 @@ pnpm start
 
 The server will be available at http://localhost:3000/.
 
+### Choosing a Converter
+
+If you want to run with a particular converter configuration, start the server
+with `VX_CONVERTER` set to the appropriate value:
+
+- **`ms-sems`** (default): uses `services/converter-ms-sems` to convert
+  Mississippi SEMS files to the VotingWorks format. Currently, only BMD and
+  VotingWorks-style hand-marked paper ballots are supported with this converter.
+- **`nh-accuvote`**: uses `ballot-interpreter-nh` to convert New Hampshire
+  AccuVote files to the VotingWorks format. Currently, only BMD and AccuVote
+  timing-mark ballots are supported with this converter.
+
 ### Optional prerequisites
 
 - If you want to program smartcards, start

--- a/frontends/election-manager/package.json
+++ b/frontends/election-manager/package.json
@@ -87,6 +87,7 @@
     "@types/react-router-dom": "^5.1.5",
     "@types/styled-components": "^5.1.7",
     "@votingworks/ballot-encoder": "workspace:*",
+    "@votingworks/ballot-interpreter-nh": "workspace:*",
     "@votingworks/ballot-interpreter-vx": "workspace:*",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/logging": "workspace:*",

--- a/frontends/election-manager/prodserver/setupProxy.js
+++ b/frontends/election-manager/prodserver/setupProxy.js
@@ -49,7 +49,7 @@ module.exports = function (app) {
       machineId: process.env.VX_MACHINE_ID || '0000',
       codeVersion: process.env.VX_CODE_VERSION || 'dev',
       bypassAuthentication: asBoolean(process.env.BYPASS_AUTHENTICATION),
-      converter: process.env.VX_CONVERTER || 'ms',
+      converter: process.env.VX_CONVERTER || 'ms-sems',
     });
   });
 

--- a/frontends/election-manager/prodserver/setupProxy.js
+++ b/frontends/election-manager/prodserver/setupProxy.js
@@ -49,6 +49,7 @@ module.exports = function (app) {
       machineId: process.env.VX_MACHINE_ID || '0000',
       codeVersion: process.env.VX_CODE_VERSION || 'dev',
       bypassAuthentication: asBoolean(process.env.BYPASS_AUTHENTICATION),
+      converter: process.env.VX_CONVERTER || 'ms',
     });
   });
 

--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -108,6 +108,7 @@ beforeEach(() => {
       machineId: '0000',
       codeVersion: 'TEST',
       bypassAuthentication: false,
+      converter: 'ms',
     })
   );
 });

--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -13,7 +13,12 @@ import {
 } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import { electionWithMsEitherNeitherWithDataFiles } from '@votingworks/fixtures';
-import { MemoryStorage, MemoryCard, MemoryHardware } from '@votingworks/utils';
+import {
+  MemoryStorage,
+  MemoryCard,
+  MemoryHardware,
+  typedAs,
+} from '@votingworks/utils';
 import {
   advanceTimersAndPromises,
   fakeKiosk,
@@ -48,6 +53,8 @@ import {
   convertExternalTalliesToStorageString,
   convertTalliesByPrecinctToFullExternalTally,
 } from './utils/external_tallies';
+import { MachineConfig } from './config/types';
+import { VxFiles } from './lib/converters';
 
 const EITHER_NEITHER_CVR_DATA =
   electionWithMsEitherNeitherWithDataFiles.cvrData;
@@ -81,19 +88,28 @@ beforeEach(() => {
   mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
   MockDate.set(new Date('2020-11-03T22:22:00'));
   fetchMock.reset();
-  fetchMock.get('/convert/election/files', {
-    inputFiles: [{ name: 'name' }, { name: 'name' }],
-    outputFiles: [{ name: 'name' }],
-  });
-  fetchMock.get('/convert/tallies/files', {
-    inputFiles: [{ name: 'name' }, { name: 'name' }],
-    outputFiles: [{ name: 'name' }],
-  });
-  fetchMock.get('/machine-config', {
-    machineId: '0000',
-    codeVersion: 'TEST',
-    bypassAuthentication: false,
-  });
+  fetchMock.get(
+    '/convert/election/files',
+    typedAs<VxFiles>({
+      inputFiles: [{ name: 'name' }, { name: 'name' }],
+      outputFiles: [{ name: 'name' }],
+    })
+  );
+  fetchMock.get(
+    '/convert/tallies/files',
+    typedAs<VxFiles>({
+      inputFiles: [{ name: 'name' }, { name: 'name' }],
+      outputFiles: [{ name: 'name' }],
+    })
+  );
+  fetchMock.get(
+    '/machine-config',
+    typedAs<MachineConfig>({
+      machineId: '0000',
+      codeVersion: 'TEST',
+      bypassAuthentication: false,
+    })
+  );
 });
 
 afterEach(() => {

--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -108,7 +108,7 @@ beforeEach(() => {
       machineId: '0000',
       codeVersion: 'TEST',
       bypassAuthentication: false,
-      converter: 'ms',
+      converter: 'ms-sems',
     })
   );
 });

--- a/frontends/election-manager/src/components/election_manager.tsx
+++ b/frontends/election-manager/src/components/election_manager.tsx
@@ -54,13 +54,13 @@ export function ElectionManager(): JSX.Element {
     return (
       <Switch>
         <Route exact path={routerPaths.root}>
-          <UnconfiguredScreen />
+          <UnconfiguredScreen converter={machineConfig.converter} />
         </Route>
         <Route exact path={routerPaths.advanced}>
           <AdvancedScreen />
         </Route>
         <Route exact path={routerPaths.electionDefinition}>
-          <UnconfiguredScreen />
+          <UnconfiguredScreen converter={machineConfig.converter} />
         </Route>
       </Switch>
     );

--- a/frontends/election-manager/src/config/types.ts
+++ b/frontends/election-manager/src/config/types.ts
@@ -144,14 +144,18 @@ export type OptionalVoteCounts = Optional<Dictionary<Dictionary<number>>>;
 
 export type Iso8601Timestamp = string;
 
+export type ConverterClientType = 'ms' | 'nh';
+
 export interface MachineConfig {
   machineId: string;
   codeVersion: string;
   bypassAuthentication: boolean;
+  converter?: ConverterClientType;
 }
 
 export const MachineConfigSchema: z.ZodSchema<MachineConfig> = z.object({
   machineId: MachineId,
   codeVersion: z.string().nonempty(),
   bypassAuthentication: z.boolean(),
+  converter: z.union([z.literal('ms'), z.literal('nh')]).optional(),
 });

--- a/frontends/election-manager/src/config/types.ts
+++ b/frontends/election-manager/src/config/types.ts
@@ -144,7 +144,7 @@ export type OptionalVoteCounts = Optional<Dictionary<Dictionary<number>>>;
 
 export type Iso8601Timestamp = string;
 
-export type ConverterClientType = 'ms' | 'nh';
+export type ConverterClientType = 'ms-sems' | 'nh-accuvote';
 
 export interface MachineConfig {
   machineId: string;
@@ -157,5 +157,7 @@ export const MachineConfigSchema: z.ZodSchema<MachineConfig> = z.object({
   machineId: MachineId,
   codeVersion: z.string().nonempty(),
   bypassAuthentication: z.boolean(),
-  converter: z.union([z.literal('ms'), z.literal('nh')]).optional(),
+  converter: z
+    .union([z.literal('ms-sems'), z.literal('nh-accuvote')])
+    .optional(),
 });

--- a/frontends/election-manager/src/lib/blob.ts
+++ b/frontends/election-manager/src/lib/blob.ts
@@ -1,0 +1,25 @@
+/**
+ * Reads a Blob as an ArrayBuffer. Though Chrome supports reading Blobs as
+ * ArrayBuffers using `Blob#arrayBuffer()`, this is not supported by Jest/jsdom.
+ */
+export function readBlobAsArrayBuffer(blob: Blob): Promise<ArrayBuffer> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as ArrayBuffer);
+    reader.onerror = reject;
+    reader.readAsArrayBuffer(blob);
+  });
+}
+
+/**
+ * Reads a Blob as a string. Though Chrome supports reading Blobs as text using
+ * `Blob#text()`, this is not supported by Jest/jsdom.
+ */
+export function readBlobAsString(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = reject;
+    reader.readAsText(blob);
+  });
+}

--- a/frontends/election-manager/src/lib/converters/index.ts
+++ b/frontends/election-manager/src/lib/converters/index.ts
@@ -1,0 +1,47 @@
+import { throwIllegalValue } from '@votingworks/utils';
+import { ConverterClientType } from '../../config/types';
+import { MsSemsConverterClient } from './ms_sems_converter_client';
+import { NhConverterClient } from './nh_converter_client';
+import { ConverterClient } from './types';
+
+export * from './types';
+export { MsSemsConverterClient };
+export { NhConverterClient };
+
+export function getElectionDefinitionConverterClient(
+  converter?: ConverterClientType
+): ConverterClient | undefined {
+  switch (converter) {
+    case undefined:
+      return undefined;
+
+    case 'ms':
+      return new MsSemsConverterClient('election');
+
+    case 'nh':
+      return new NhConverterClient();
+
+    /* istanbul ignore next */
+    default:
+      throwIllegalValue(converter);
+  }
+}
+
+export function getTallyConverterClient(
+  converter?: ConverterClientType
+): ConverterClient | undefined {
+  switch (converter) {
+    case undefined:
+      return undefined;
+
+    case 'ms':
+      return new MsSemsConverterClient('tallies');
+
+    case 'nh':
+      return undefined;
+
+    /* istanbul ignore next */
+    default:
+      throwIllegalValue(converter);
+  }
+}

--- a/frontends/election-manager/src/lib/converters/index.ts
+++ b/frontends/election-manager/src/lib/converters/index.ts
@@ -15,10 +15,10 @@ export function getElectionDefinitionConverterClient(
     case undefined:
       return undefined;
 
-    case 'ms':
+    case 'ms-sems':
       return new MsSemsConverterClient('election');
 
-    case 'nh':
+    case 'nh-accuvote':
       return new NhConverterClient();
 
     /* istanbul ignore next */
@@ -34,10 +34,10 @@ export function getTallyConverterClient(
     case undefined:
       return undefined;
 
-    case 'ms':
+    case 'ms-sems':
       return new MsSemsConverterClient('tallies');
 
-    case 'nh':
+    case 'nh-accuvote':
       return undefined;
 
     /* istanbul ignore next */

--- a/frontends/election-manager/src/lib/converters/ms_sems_converter_client.ts
+++ b/frontends/election-manager/src/lib/converters/ms_sems_converter_client.ts
@@ -1,15 +1,11 @@
-export interface VxFile {
-  name: string;
-  path: string;
-}
+import { ConverterClient, VxFiles } from './types';
 
-export interface VxFiles {
-  inputFiles: VxFile[];
-  outputFiles: VxFile[];
-}
-
-export class ConverterClient {
+export class MsSemsConverterClient implements ConverterClient {
   constructor(private readonly target: string) {}
+
+  getDisplayName(): string {
+    return 'SEMS';
+  }
 
   async setInputFile(name: string, content: File): Promise<void> {
     const formData = new FormData();

--- a/frontends/election-manager/src/lib/converters/nh_converter_client.test.ts
+++ b/frontends/election-manager/src/lib/converters/nh_converter_client.test.ts
@@ -1,0 +1,220 @@
+import { typedAs } from '@votingworks/utils';
+import { mockOf } from '@votingworks/test-utils';
+import { convertElectionDefinition } from '@votingworks/ballot-interpreter-nh';
+import { err, ok, safeParseElection } from '@votingworks/types';
+import { electionMinimalExhaustiveSample } from '@votingworks/fixtures';
+import { NhConverterClient } from './nh_converter_client';
+import { VxFiles } from './types';
+import { pdfToImages } from '../../utils/pdf_to_images';
+import { readBlobAsString } from '../blob';
+
+jest.mock('@votingworks/ballot-interpreter-nh');
+jest.mock('../../utils/pdf_to_images');
+
+function makePdfToImagesMockReturnValue({
+  pageCount = 2,
+}: { pageCount?: number } = {}): ReturnType<typeof pdfToImages> {
+  let pageNumber = 0;
+
+  return {
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+
+    async next() {
+      if (pageNumber >= pageCount) {
+        return { value: undefined, done: true };
+      }
+
+      pageNumber += 1;
+      return {
+        value: {
+          pageNumber,
+          pageCount,
+          page: {
+            data: Uint8ClampedArray.of(0, 0, 0, 0),
+            width: 1,
+            height: 1,
+          },
+        },
+        done: false,
+      };
+    },
+
+    async return() {
+      return { value: undefined, done: true };
+    },
+
+    async throw(error: Error) {
+      throw error;
+    },
+  };
+}
+
+test('display name', () => {
+  expect(new NhConverterClient().getDisplayName()).toBe('NH');
+});
+
+test('initial files', async () => {
+  const client = new NhConverterClient();
+  const files = await client.getFiles();
+
+  expect(files).toEqual(
+    typedAs<VxFiles>({
+      inputFiles: [
+        {
+          name: 'NH Card Definition (XML)',
+        },
+        {
+          name: 'NH Card Ballot (PDF)',
+        },
+      ],
+      outputFiles: [
+        {
+          name: 'VX Election Definition',
+        },
+      ],
+    })
+  );
+});
+
+test('reset', async () => {
+  const client = new NhConverterClient();
+
+  await client.setInputFile(
+    'NH Card Definition (XML)',
+    new File([], 'file.xml')
+  );
+  await client.setInputFile('NH Card Ballot (PDF)', new File([], 'file.pdf'));
+
+  expect((await client.getFiles()).inputFiles).toEqual(
+    typedAs<VxFiles['inputFiles']>([
+      { name: 'NH Card Definition (XML)', path: expect.any(String) },
+      { name: 'NH Card Ballot (PDF)', path: expect.any(String) },
+    ])
+  );
+
+  await client.reset();
+
+  expect((await client.getFiles()).inputFiles).toEqual(
+    typedAs<VxFiles['inputFiles']>([
+      { name: 'NH Card Definition (XML)' },
+      { name: 'NH Card Ballot (PDF)' },
+    ])
+  );
+});
+
+test('unknown files', async () => {
+  const client = new NhConverterClient();
+
+  await expect(
+    client.setInputFile('unknown', new File([], 'file.pdf'))
+  ).rejects.toThrow('input file "unknown" not found');
+
+  await expect(client.getOutputFile('unknown')).rejects.toThrow(
+    'output file "unknown" not found'
+  );
+});
+
+test('process without card definition', async () => {
+  const client = new NhConverterClient();
+
+  await expect(client.process()).rejects.toThrow(
+    'input file "NH Card Definition (XML)" not found'
+  );
+});
+
+test('process without card ballot', async () => {
+  const client = new NhConverterClient();
+
+  await client.setInputFile(
+    'NH Card Definition (XML)',
+    new File([], 'definition.xml')
+  );
+  await expect(client.process()).rejects.toThrow(
+    'input file "NH Card Ballot (PDF)" not found'
+  );
+});
+
+test('conversion fails', async () => {
+  const client = new NhConverterClient();
+
+  mockOf(convertElectionDefinition).mockReturnValue(
+    err(new Error('ElectionID is required'))
+  );
+  mockOf(pdfToImages).mockReturnValue(makePdfToImagesMockReturnValue());
+
+  await client.setInputFile(
+    'NH Card Definition (XML)',
+    new File(['NOT XML'], 'definition.xml')
+  );
+  await client.setInputFile(
+    'NH Card Ballot (PDF)',
+    new File(['%PDF'], 'ballot.pdf')
+  );
+
+  await expect(client.process()).rejects.toThrow('ElectionID is required');
+});
+
+test('too many PDF pages', async () => {
+  const client = new NhConverterClient();
+
+  mockOf(pdfToImages).mockReturnValue(
+    makePdfToImagesMockReturnValue({ pageCount: 3 })
+  );
+
+  await client.setInputFile(
+    'NH Card Definition (XML)',
+    new File([], 'definition.xml')
+  );
+  await client.setInputFile('NH Card Ballot (PDF)', new File([], 'ballot.pdf'));
+
+  await expect(client.process()).rejects.toThrow(
+    'Expected exactly 2 pages in NH card ballot, but got 3'
+  );
+});
+
+test('process success', async () => {
+  const client = new NhConverterClient();
+
+  mockOf(convertElectionDefinition).mockReturnValue(
+    ok(electionMinimalExhaustiveSample)
+  );
+  mockOf(pdfToImages).mockReturnValue(makePdfToImagesMockReturnValue());
+
+  await client.setInputFile(
+    'NH Card Definition (XML)',
+    new File([`<election id="123" />`], 'definition.xml')
+  );
+  await client.setInputFile(
+    'NH Card Ballot (PDF)',
+    new File(['%PDF'], 'ballot.pdf')
+  );
+
+  await client.process();
+  const electionBlob = await client.getOutputFile('VX Election Definition');
+  expect(
+    safeParseElection(await readBlobAsString(electionBlob)).unsafeUnwrap()
+  ).toEqual(electionMinimalExhaustiveSample);
+
+  expect(await client.getFiles()).toEqual(
+    typedAs<VxFiles>({
+      inputFiles: [
+        {
+          name: 'NH Card Definition (XML)',
+          path: expect.any(String),
+        },
+        {
+          name: 'NH Card Ballot (PDF)',
+          path: expect.any(String),
+        },
+      ],
+      outputFiles: [
+        {
+          name: 'VX Election Definition',
+          path: expect.any(String),
+        },
+      ],
+    })
+  );
+});

--- a/frontends/election-manager/src/lib/converters/nh_converter_client.test.ts
+++ b/frontends/election-manager/src/lib/converters/nh_converter_client.test.ts
@@ -64,9 +64,11 @@ test('initial files', async () => {
       inputFiles: [
         {
           name: 'NH Card Definition (XML)',
+          accept: 'application/xml',
         },
         {
           name: 'NH Card Ballot (PDF)',
+          accept: 'application/pdf',
         },
       ],
       outputFiles: [
@@ -89,8 +91,16 @@ test('reset', async () => {
 
   expect((await client.getFiles()).inputFiles).toEqual(
     typedAs<VxFiles['inputFiles']>([
-      { name: 'NH Card Definition (XML)', path: expect.any(String) },
-      { name: 'NH Card Ballot (PDF)', path: expect.any(String) },
+      {
+        name: 'NH Card Definition (XML)',
+        accept: 'application/xml',
+        path: expect.any(String),
+      },
+      {
+        name: 'NH Card Ballot (PDF)',
+        accept: 'application/pdf',
+        path: expect.any(String),
+      },
     ])
   );
 
@@ -98,8 +108,8 @@ test('reset', async () => {
 
   expect((await client.getFiles()).inputFiles).toEqual(
     typedAs<VxFiles['inputFiles']>([
-      { name: 'NH Card Definition (XML)' },
-      { name: 'NH Card Ballot (PDF)' },
+      { name: 'NH Card Definition (XML)', accept: 'application/xml' },
+      { name: 'NH Card Ballot (PDF)', accept: 'application/pdf' },
     ])
   );
 });
@@ -202,10 +212,12 @@ test('process success', async () => {
       inputFiles: [
         {
           name: 'NH Card Definition (XML)',
+          accept: 'application/xml',
           path: expect.any(String),
         },
         {
           name: 'NH Card Ballot (PDF)',
+          accept: 'application/pdf',
           path: expect.any(String),
         },
       ],

--- a/frontends/election-manager/src/lib/converters/nh_converter_client.ts
+++ b/frontends/election-manager/src/lib/converters/nh_converter_client.ts
@@ -2,21 +2,29 @@ import {
   convertElectionDefinition,
   templates,
 } from '@votingworks/ballot-interpreter-nh';
-import { ConverterClient, VxFiles } from './types';
+import { ConverterClient, VxFile, VxFiles } from './types';
 import { pdfToImages } from '../../utils/pdf_to_images';
 import { readBlobAsArrayBuffer, readBlobAsString } from '../blob';
 
-const NhCardDefinitionFileName = 'NH Card Definition (XML)';
-const NhCardBallotFileName = 'NH Card Ballot (PDF)';
-const VxElectionDefinitionFileName = 'VX Election Definition';
+const NhCardDefinitionFile: VxFile = {
+  name: 'NH Card Definition (XML)',
+  accept: 'application/xml',
+};
+const NhCardBallotFile: VxFile = {
+  name: 'NH Card Ballot (PDF)',
+  accept: 'application/pdf',
+};
+const VxElectionDefinitionFile: VxFile = {
+  name: 'VX Election Definition',
+};
 
 export class NhConverterClient implements ConverterClient {
-  private inputFiles: Map<string, File | undefined> = new Map([
-    [NhCardDefinitionFileName, undefined],
-    [NhCardBallotFileName, undefined],
+  private inputFiles: Map<VxFile, File | undefined> = new Map([
+    [NhCardDefinitionFile, undefined],
+    [NhCardBallotFile, undefined],
   ]);
-  private outputFiles: Map<string, Blob | undefined> = new Map([
-    [VxElectionDefinitionFileName, undefined],
+  private outputFiles: Map<VxFile, Blob | undefined> = new Map([
+    [VxElectionDefinitionFile, undefined],
   ]);
 
   getDisplayName(): string {
@@ -25,7 +33,7 @@ export class NhConverterClient implements ConverterClient {
 
   async setInputFile(name: string, content: File): Promise<void> {
     for (const key of this.inputFiles.keys()) {
-      if (key === name) {
+      if (key.name === name) {
         this.inputFiles.set(key, content);
         return;
       }
@@ -35,15 +43,15 @@ export class NhConverterClient implements ConverterClient {
   }
 
   async process(): Promise<void> {
-    const nhCardDefinitionFile = this.inputFiles.get(NhCardDefinitionFileName);
-    const nhCardBallotFile = this.inputFiles.get(NhCardBallotFileName);
+    const nhCardDefinitionFile = this.inputFiles.get(NhCardDefinitionFile);
+    const nhCardBallotFile = this.inputFiles.get(NhCardBallotFile);
 
     if (!nhCardDefinitionFile) {
-      throw new Error(`input file "${NhCardDefinitionFileName}" not found`);
+      throw new Error(`input file "${NhCardDefinitionFile.name}" not found`);
     }
 
     if (!nhCardBallotFile) {
-      throw new Error(`input file "${NhCardBallotFileName}" not found`);
+      throw new Error(`input file "${NhCardBallotFile.name}" not found`);
     }
 
     const nhCardBallotImages: ImageData[] = [];
@@ -64,7 +72,7 @@ export class NhConverterClient implements ConverterClient {
     const parser = new DOMParser();
     const definition = parser.parseFromString(
       await readBlobAsString(nhCardDefinitionFile),
-      'text/xml'
+      'application/xml'
     ).documentElement;
 
     const [front, back] = nhCardBallotImages;
@@ -85,13 +93,16 @@ export class NhConverterClient implements ConverterClient {
     const election = convertResult.ok();
 
     this.outputFiles.set(
-      VxElectionDefinitionFileName,
+      VxElectionDefinitionFile,
       new Blob([JSON.stringify(election, null, 2)])
     );
   }
 
   async getOutputFile(name: string): Promise<Blob> {
-    const outputBlob = this.outputFiles.get(name);
+    const [, outputBlob] =
+      [...this.outputFiles].find(
+        ([{ name: outputName }]) => outputName === name
+      ) ?? [];
 
     if (!outputBlob) {
       throw new Error(`output file "${name}" not found`);
@@ -102,11 +113,14 @@ export class NhConverterClient implements ConverterClient {
 
   async getFiles(): Promise<VxFiles> {
     return {
-      inputFiles: [...this.inputFiles.entries()].map(([name, file]) => ({
-        name,
-        path: file ? name : undefined,
-      })),
-      outputFiles: [...this.outputFiles.entries()].map(([name, blob]) => ({
+      inputFiles: [...this.inputFiles.entries()].map(
+        ([{ name, accept }, file]) => ({
+          name,
+          accept,
+          path: file ? name : undefined,
+        })
+      ),
+      outputFiles: [...this.outputFiles.entries()].map(([{ name }, blob]) => ({
         name,
         path: blob ? name : undefined,
       })),

--- a/frontends/election-manager/src/lib/converters/nh_converter_client.ts
+++ b/frontends/election-manager/src/lib/converters/nh_converter_client.ts
@@ -1,0 +1,124 @@
+import {
+  convertElectionDefinition,
+  templates,
+} from '@votingworks/ballot-interpreter-nh';
+import { ConverterClient, VxFiles } from './types';
+import { pdfToImages } from '../../utils/pdf_to_images';
+import { readBlobAsArrayBuffer, readBlobAsString } from '../blob';
+
+const NhCardDefinitionFileName = 'NH Card Definition (XML)';
+const NhCardBallotFileName = 'NH Card Ballot (PDF)';
+const VxElectionDefinitionFileName = 'VX Election Definition';
+
+export class NhConverterClient implements ConverterClient {
+  private inputFiles: Map<string, File | undefined> = new Map([
+    [NhCardDefinitionFileName, undefined],
+    [NhCardBallotFileName, undefined],
+  ]);
+  private outputFiles: Map<string, Blob | undefined> = new Map([
+    [VxElectionDefinitionFileName, undefined],
+  ]);
+
+  getDisplayName(): string {
+    return 'NH';
+  }
+
+  async setInputFile(name: string, content: File): Promise<void> {
+    for (const key of this.inputFiles.keys()) {
+      if (key === name) {
+        this.inputFiles.set(key, content);
+        return;
+      }
+    }
+
+    throw new Error(`input file "${name}" not found`);
+  }
+
+  async process(): Promise<void> {
+    const nhCardDefinitionFile = this.inputFiles.get(NhCardDefinitionFileName);
+    const nhCardBallotFile = this.inputFiles.get(NhCardBallotFileName);
+
+    if (!nhCardDefinitionFile) {
+      throw new Error(`input file "${NhCardDefinitionFileName}" not found`);
+    }
+
+    if (!nhCardBallotFile) {
+      throw new Error(`input file "${NhCardBallotFileName}" not found`);
+    }
+
+    const nhCardBallotImages: ImageData[] = [];
+
+    for await (const { page, pageCount } of pdfToImages(
+      Buffer.from(await readBlobAsArrayBuffer(nhCardBallotFile)),
+      { scale: 1 }
+    )) {
+      if (pageCount > 2) {
+        throw new Error(
+          `Expected exactly 2 pages in NH card ballot, but got ${pageCount}`
+        );
+      }
+
+      nhCardBallotImages.push(page);
+    }
+
+    const parser = new DOMParser();
+    const definition = parser.parseFromString(
+      await readBlobAsString(nhCardDefinitionFile),
+      'text/xml'
+    ).documentElement;
+
+    const [front, back] = nhCardBallotImages;
+
+    const convertResult = convertElectionDefinition(
+      {
+        definition,
+        front,
+        back,
+      },
+      { ovalTemplate: await templates.getOvalTemplate() }
+    );
+
+    if (convertResult.isErr()) {
+      throw convertResult.err();
+    }
+
+    const election = convertResult.ok();
+
+    this.outputFiles.set(
+      VxElectionDefinitionFileName,
+      new Blob([JSON.stringify(election, null, 2)])
+    );
+  }
+
+  async getOutputFile(name: string): Promise<Blob> {
+    const outputBlob = this.outputFiles.get(name);
+
+    if (!outputBlob) {
+      throw new Error(`output file "${name}" not found`);
+    }
+
+    return outputBlob;
+  }
+
+  async getFiles(): Promise<VxFiles> {
+    return {
+      inputFiles: [...this.inputFiles.entries()].map(([name, file]) => ({
+        name,
+        path: file ? name : undefined,
+      })),
+      outputFiles: [...this.outputFiles.entries()].map(([name, blob]) => ({
+        name,
+        path: blob ? name : undefined,
+      })),
+    };
+  }
+
+  async reset(): Promise<void> {
+    for (const name of this.inputFiles.keys()) {
+      this.inputFiles.set(name, undefined);
+    }
+    for (const name of this.outputFiles.keys()) {
+      this.outputFiles.set(name, undefined);
+    }
+  }
+}

--- a/frontends/election-manager/src/lib/converters/types.ts
+++ b/frontends/election-manager/src/lib/converters/types.ts
@@ -1,0 +1,41 @@
+export interface VxFile {
+  name: string;
+  path?: string;
+}
+
+export interface VxFiles {
+  inputFiles: VxFile[];
+  outputFiles: VxFile[];
+}
+
+export interface ConverterClient {
+  /**
+   * Gets the name of this converter for display purposes.
+   */
+  getDisplayName(): string;
+
+  /**
+   * Stores a file in the converter for later processing.
+   */
+  setInputFile(name: string, content: File): Promise<void>;
+
+  /**
+   * Processes the files that have been stored, generating output files.
+   */
+  process(): Promise<void>;
+
+  /**
+   * Gets the output file with the given name.
+   */
+  getOutputFile(name: string): Promise<Blob>;
+
+  /**
+   * Gets the lists of input and output files.
+   */
+  getFiles(): Promise<VxFiles>;
+
+  /**
+   * Resets the converter, discarding all files.
+   */
+  reset(): Promise<void>;
+}

--- a/frontends/election-manager/src/lib/converters/types.ts
+++ b/frontends/election-manager/src/lib/converters/types.ts
@@ -1,5 +1,6 @@
 export interface VxFile {
   name: string;
+  accept?: string;
   path?: string;
 }
 

--- a/frontends/election-manager/src/screens/tally_screen.tsx
+++ b/frontends/election-manager/src/screens/tally_screen.tsx
@@ -347,7 +347,7 @@ export function TallyScreen(): JSX.Element {
           >
             Import CVR Files
           </Button>{' '}
-          {converter === 'ms' && (
+          {converter === 'ms-sems' && (
             <React.Fragment>
               <FileInputButton
                 innerRef={externalFileInput}
@@ -396,7 +396,7 @@ export function TallyScreen(): JSX.Element {
             >
               Remove CVR Files…
             </Button>{' '}
-            {converter === 'ms' && (
+            {converter === 'ms-sems' && (
               <React.Fragment>
                 <Button
                   danger

--- a/frontends/election-manager/src/screens/tally_screen.tsx
+++ b/frontends/election-manager/src/screens/tally_screen.tsx
@@ -19,7 +19,7 @@ import { LogEventId } from '@votingworks/logging';
 import { InputEventFunction, ResultsFileType } from '../config/types';
 
 import { AppContext } from '../contexts/app_context';
-import { ConverterClient } from '../lib/converter_client';
+import { MsSemsConverterClient } from '../lib/converters/ms_sems_converter_client';
 import { getPrecinctIdsInExternalTally } from '../utils/external_tallies';
 
 import { Button } from '../components/button';
@@ -38,6 +38,7 @@ import { TIME_FORMAT } from '../config/globals';
 import { getPartiesWithPrimaryElections } from '../utils/election';
 import { ImportExternalResultsModal } from '../components/import_external_results_modal';
 import { SaveFileToUsb, FileType } from '../components/save_file_to_usb';
+import { getTallyConverterClient } from '../lib/converters';
 
 export function TallyScreen(): JSX.Element {
   const makeCancelable = useCancelablePromise();
@@ -53,9 +54,11 @@ export function TallyScreen(): JSX.Element {
     resetFiles,
     logger,
     currentUserSession,
+    machineConfig,
   } = useContext(AppContext);
   assert(electionDefinition);
   const { election } = electionDefinition;
+  const { converter } = machineConfig;
   const isTestMode = castVoteRecordFiles?.fileMode === 'test';
   const externalFileInput = useRef<HTMLInputElement>(null);
 
@@ -145,13 +148,16 @@ export function TallyScreen(): JSX.Element {
   useEffect(() => {
     void (async () => {
       try {
-        await makeCancelable(new ConverterClient('tallies').getFiles());
-        setHasConverter(true);
+        const client = getTallyConverterClient(converter);
+        if (client) {
+          await makeCancelable(client.getFiles());
+          setHasConverter(true);
+        }
       } catch {
         setHasConverter(false);
       }
     })();
-  }, [makeCancelable]);
+  }, [converter, makeCancelable]);
 
   const fileMode = castVoteRecordFiles?.fileMode;
   const fileModeText =
@@ -232,7 +238,7 @@ export function TallyScreen(): JSX.Element {
     );
     const exportableTallies = generateExportableTallies();
     // process on the server
-    const client = new ConverterClient('tallies');
+    const client = new MsSemsConverterClient('tallies');
     const { inputFiles, outputFiles } = await client.getFiles();
     const [electionDefinitionFile, talliesFile] = inputFiles;
     const resultsFile = outputFiles[0];
@@ -341,15 +347,19 @@ export function TallyScreen(): JSX.Element {
           >
             Import CVR Files
           </Button>{' '}
-          <FileInputButton
-            innerRef={externalFileInput}
-            onChange={importExternalSemsFile}
-            accept="*"
-            data-testid="import-sems-button"
-            disabled={hasExternalSemsFile || isOfficialResults}
-          >
-            Import External Results File
-          </FileInputButton>{' '}
+          {converter === 'ms' && (
+            <React.Fragment>
+              <FileInputButton
+                innerRef={externalFileInput}
+                onChange={importExternalSemsFile}
+                accept="*"
+                data-testid="import-sems-button"
+                disabled={hasExternalSemsFile || isOfficialResults}
+              >
+                Import External Results File
+              </FileInputButton>{' '}
+            </React.Fragment>
+          )}
           <LinkButton
             to={routerPaths.manualDataImport}
             disabled={isOfficialResults}
@@ -386,13 +396,17 @@ export function TallyScreen(): JSX.Element {
             >
               Remove CVR Files…
             </Button>{' '}
-            <Button
-              danger
-              disabled={!hasExternalSemsFile}
-              onPress={() => beginConfirmRemoveFiles(ResultsFileType.SEMS)}
-            >
-              Remove External Results File…
-            </Button>{' '}
+            {converter === 'ms' && (
+              <React.Fragment>
+                <Button
+                  danger
+                  disabled={!hasExternalSemsFile}
+                  onPress={() => beginConfirmRemoveFiles(ResultsFileType.SEMS)}
+                >
+                  Remove External Results File…
+                </Button>{' '}
+              </React.Fragment>
+            )}
             <Button
               danger
               disabled={!hasExternalManualData}

--- a/frontends/election-manager/src/screens/unconfigured_screen.tsx
+++ b/frontends/election-manager/src/screens/unconfigured_screen.tsx
@@ -259,7 +259,7 @@ export function UnconfiguredScreen({
             ) : (
               <p key={file.name}>
                 <FileInputButton
-                  // accept=".txt"
+                  accept={file.accept}
                   buttonProps={{
                     fullWidth: true,
                   }}

--- a/frontends/election-manager/src/utils/machine_config.ts
+++ b/frontends/election-manager/src/utils/machine_config.ts
@@ -4,15 +4,18 @@ import { MachineConfig, MachineConfigSchema } from '../config/types';
 
 export const machineConfigProvider: Provider<MachineConfig> = {
   async get() {
-    const { machineId, codeVersion, bypassAuthentication } = unsafeParse(
-      MachineConfigSchema,
-      await fetchJson('/machine-config')
-    );
+    const {
+      machineId,
+      codeVersion,
+      bypassAuthentication,
+      converter,
+    } = unsafeParse(MachineConfigSchema, await fetchJson('/machine-config'));
 
     return {
       machineId,
       codeVersion,
       bypassAuthentication,
+      converter,
     };
   },
 };

--- a/frontends/election-manager/test/helpers/fake_machine_config.ts
+++ b/frontends/election-manager/test/helpers/fake_machine_config.ts
@@ -5,8 +5,9 @@ export function fakeMachineConfig({
   machineId = '000',
   codeVersion = 'test',
   bypassAuthentication = false,
+  converter = 'ms',
 }: Partial<MachineConfig> = {}): MachineConfig {
-  return { machineId, codeVersion, bypassAuthentication };
+  return { machineId, codeVersion, bypassAuthentication, converter };
 }
 
 export function fakeMachineConfigProvider(

--- a/frontends/election-manager/test/helpers/fake_machine_config.ts
+++ b/frontends/election-manager/test/helpers/fake_machine_config.ts
@@ -5,7 +5,7 @@ export function fakeMachineConfig({
   machineId = '000',
   codeVersion = 'test',
   bypassAuthentication = false,
-  converter = 'ms',
+  converter = 'ms-sems',
 }: Partial<MachineConfig> = {}): MachineConfig {
   return { machineId, codeVersion, bypassAuthentication, converter };
 }

--- a/frontends/election-manager/test/render_in_app_context.tsx
+++ b/frontends/election-manager/test/render_in_app_context.tsx
@@ -108,7 +108,7 @@ export function renderInAppContext(
       machineId: '0000',
       codeVersion: '',
       bypassAuthentication: false,
-      converter: 'ms',
+      converter: 'ms-sems',
     },
     hasCardReaderAttached = true,
     logger = new Logger(LogSource.VxAdminFrontend),

--- a/frontends/election-manager/test/render_in_app_context.tsx
+++ b/frontends/election-manager/test/render_in_app_context.tsx
@@ -108,6 +108,7 @@ export function renderInAppContext(
       machineId: '0000',
       codeVersion: '',
       bypassAuthentication: false,
+      converter: 'ms',
     },
     hasCardReaderAttached = true,
     logger = new Logger(LogSource.VxAdminFrontend),

--- a/frontends/election-manager/tsconfig.json
+++ b/frontends/election-manager/tsconfig.json
@@ -19,6 +19,7 @@
   "exclude": ["src/setupProxy.js"],
   "references": [
     { "path": "../../libs/ballot-encoder/tsconfig.build.json" },
+    { "path": "../../libs/ballot-interpreter-nh/tsconfig.build.json" },
     { "path": "../../libs/ballot-interpreter-vx/tsconfig.build.json" },
     { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../../libs/fixtures/tsconfig.build.json" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -520,6 +520,7 @@ importers:
       '@types/react-router-dom': 5.1.7
       '@types/styled-components': 5.1.7
       '@votingworks/ballot-encoder': link:../../libs/ballot-encoder
+      '@votingworks/ballot-interpreter-nh': link:../../libs/ballot-interpreter-nh
       '@votingworks/ballot-interpreter-vx': link:../../libs/ballot-interpreter-vx
       '@votingworks/fixtures': link:../../libs/fixtures
       '@votingworks/logging': link:../../libs/logging
@@ -625,6 +626,7 @@ importers:
       '@typescript-eslint/eslint-plugin': ^4.28.4
       '@typescript-eslint/parser': ^4.28.4
       '@votingworks/ballot-encoder': workspace:*
+      '@votingworks/ballot-interpreter-nh': workspace:*
       '@votingworks/ballot-interpreter-vx': workspace:*
       '@votingworks/fixtures': workspace:*
       '@votingworks/logging': workspace:*

--- a/services/converter-ms-sems/converter/core.py
+++ b/services/converter-ms-sems/converter/core.py
@@ -15,8 +15,8 @@ app = Flask(__name__)
 # paths
 ELECTION_FILES = {
     "inputFiles": [
-        {"name": "SEMS main file", "path": None},
-        {"name": "SEMS candidate mapping file", "path": None}
+        {"name": "SEMS main file", "accept": ".txt,text/plain", "path": None},
+        {"name": "SEMS candidate mapping file", "accept": ".txt,text/plain", "path": None}
     ],
     "outputFiles": [
         {"name": "Vx Election Definition", "path": None}
@@ -25,8 +25,8 @@ ELECTION_FILES = {
 
 RESULTS_FILES = {
     "inputFiles": [
-        {"name": "Vx Election Definition", "path": None},
-        {"name": "Vx CVRs", "path": None}
+        {"name": "Vx Election Definition", "accept": ".json,application/json", "path": None},
+        {"name": "Vx CVRs", "accept": ".jsonl,application/jsonlines", "path": None}
     ],
     "outputFiles": [
         {"name": "SEMS Results", "path": None}
@@ -35,8 +35,8 @@ RESULTS_FILES = {
 
 RESULT_TALLIES_FILES = {
     "inputFiles": [
-        {"name": "Vx Election Definition", "path": None},
-        {"name": "Vx Tallies", "path": None}
+        {"name": "Vx Election Definition", "accept": ".json,application/json", "path": None},
+        {"name": "Vx Tallies", "accept": ".json,application/json", "path": None}
     ],
     "outputFiles": [
         {"name": "SEMS Results", "path": None}


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
[](https://github.com/eventualbuddha)Allows running VxAdmin with `VX_CONVERTER=nh`, which replaces the MS SEMS election definition converter with one for NH. Doing so will present a form with file fields for the XML and PDF files needed to convert to our election format. Once both have been entered, the conversion will happen and the election will be loaded.

Unfortunately, this doesn't handle errors very well right now since the existing infrastructure didn't. We should come back to that and make it capable of showing errors that occurred during conversion.

## Demo Video or Screenshot

https://user-images.githubusercontent.com/1938/159815594-ffaf55c7-9935-4420-afcf-a3ed6a935c5e.mov


## Testing Plan 
Manually tested with one election definition. Added some automated testing.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
