### PR TITLE
scan: Soft delete batches instead of actually deleting them

### DIFF
--- a/services/scan/schema.sql
+++ b/services/scan/schema.sql
@@ -4,6 +4,7 @@ create table batches (
   label text,
   started_at datetime default current_timestamp not null,
   ended_at datetime,
+  deleted_at datetime,
   error varchar(4000)
 );
 

--- a/services/scan/src/store.test.ts
+++ b/services/scan/src/store.test.ts
@@ -253,6 +253,11 @@ test('batchStatus', () => {
   batches = store.batchStatus();
   expect(batches).toHaveLength(1);
   expect(batches[0].count).toEqual(0);
+
+  // Confirm that batches marked as deleted are not included
+  store.deleteBatch(batchId);
+  batches = store.batchStatus();
+  expect(batches).toHaveLength(0);
 });
 
 test('adjudication', () => {

--- a/services/scan/src/store.test.ts
+++ b/services/scan/src/store.test.ts
@@ -10,6 +10,7 @@ import {
 import { typedAs } from '@votingworks/utils';
 import * as tmp from 'tmp';
 import { v4 as uuid } from 'uuid';
+import * as streams from 'memory-streams';
 import * as stateOfHamilton from '../test/fixtures/state-of-hamilton';
 import { zeroRect } from '../test/fixtures/zero_rect';
 import { Store } from './store';
@@ -415,4 +416,84 @@ test('adjudication', () => {
 
   // cleaning up batches now should have no impact
   store.cleanupIncompleteBatches();
+});
+
+test('exportCvrs', () => {
+  const store = Store.memoryStore();
+  store.setElection(stateOfHamilton.electionDefinition);
+
+  // No CVRs, export should be empty
+  let stream = new streams.WritableStream();
+  store.exportCvrs(stream);
+  expect(stream.toString()).toEqual('');
+
+  const metadata: BallotPageMetadata = {
+    locales: { primary: 'en-US' },
+    electionHash: stateOfHamilton.electionDefinition.electionHash,
+    ballotType: BallotType.Standard,
+    ballotStyleId: stateOfHamilton.election.ballotStyles[0].id,
+    precinctId: stateOfHamilton.election.precincts[0].id,
+    isTestMode: false,
+    pageNumber: 1,
+  };
+
+  store.addHmpbTemplate(Buffer.of(1, 2, 3), metadata, [
+    {
+      pageSize: { width: 1, height: 1 },
+      metadata: {
+        ...metadata,
+        pageNumber: 1,
+      },
+      contests: [],
+    },
+    {
+      pageSize: { width: 1, height: 1 },
+      metadata: {
+        ...metadata,
+        pageNumber: 2,
+      },
+      contests: [],
+    },
+  ]);
+
+  // Create CVRs, confirm that they are exported should work
+  const batchId = store.addBatch();
+  const sheetId = store.addSheet(uuid(), batchId, [
+    {
+      originalFilename: '/tmp/front-page.png',
+      normalizedFilename: '/tmp/front-normalized-page.png',
+      interpretation: {
+        type: 'UninterpretedHmpbPage',
+        metadata: {
+          ...metadata,
+          pageNumber: 1,
+        },
+      },
+    },
+    {
+      originalFilename: '/tmp/back-page.png',
+      normalizedFilename: '/tmp/back-normalized-page.png',
+      interpretation: {
+        type: 'UninterpretedHmpbPage',
+        metadata: {
+          ...metadata,
+          pageNumber: 2,
+        },
+      },
+    },
+  ]);
+  store.adjudicateSheet(sheetId, 'front', []);
+  store.adjudicateSheet(sheetId, 'back', []);
+
+  stream = new streams.WritableStream();
+  store.exportCvrs(stream);
+  expect(stream.toString()).toEqual(
+    expect.stringContaining(stateOfHamilton.election.precincts[0].id)
+  );
+
+  // Confirm that deleted batches are not included in exported CVRs
+  stream = new streams.WritableStream();
+  store.deleteBatch(batchId);
+  store.exportCvrs(stream);
+  expect(stream.toString()).toEqual('');
 });


### PR DESCRIPTION
## Overview
#1614

This updates `Store.deleteBatch()` to set `deleted_at` on the batch instead of actually deleting the batch.

Open questions:
- [x] Should `Store.cleanupIncompleteBatches()` do a soft delete?
- [x] Should `Store.zero()` do a soft delete?

I think the answer to both is "no" so I didn't implement soft delete for these, but I wanted to call out that decision to make sure others agree.

## Demo Video or Screenshot

https://user-images.githubusercontent.com/7584833/159945162-7ebf676f-0b13-432d-9f89-49e52751bd49.mov

## Testing Plan 
Manually tested in VxCentralScan, ran existing tests, added an additional test case to existing `Store.batchStatus()` tests.

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
