### PR TITLE
fix(scan): reorder delete batch modal buttons

### DIFF
--- a/frontends/bsd/src/screens/dashboard_screen.tsx
+++ b/frontends/bsd/src/screens/dashboard_screen.tsx
@@ -166,15 +166,15 @@ export function DashboardScreen({
           }
           actions={
             <React.Fragment>
-              <Button onPress={cancelDeleteBatch} disabled={isDeletingBatch}>
-                Cancel
-              </Button>
               <Button
                 danger
                 onPress={confirmDeleteBatch}
                 disabled={isDeletingBatch}
               >
                 {isDeletingBatch ? 'Deleting…' : 'Yes, Delete Batch'}
+              </Button>
+              <Button onPress={cancelDeleteBatch} disabled={isDeletingBatch}>
+                Cancel
               </Button>
             </React.Fragment>
           }


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
The primary button should go first in the code so it's on the right.

## Demo Video or Screenshot
| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/1938/160027584-d0567055-4624-4aee-91e9-f66c4acb1516.png) | ![image](https://user-images.githubusercontent.com/1938/160027603-3408a8bd-fdfa-4ec5-9084-e4518cf5779c.png) |

## Testing Plan 
Looked at it in the browser.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
