### PR TITLE
feat(types): improve `Result` types

### DIFF
--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -9,9 +9,7 @@ import {
   IdSchema,
   Iso8601Date,
   NewType,
-  ok,
   Optional,
-  Result,
   safeParse,
   safeParseJson,
 } from './generic';
@@ -23,6 +21,7 @@ import {
   Size,
   SizeSchema,
 } from './geometry';
+import { ok, Result } from './result';
 
 // Generic
 export type Translations = Record<string, Record<string, string> | undefined>;

--- a/libs/types/src/generic.test.ts
+++ b/libs/types/src/generic.test.ts
@@ -1,60 +1,6 @@
 import { z } from 'zod';
 import { MachineId, safeParse } from '.';
-import { err, maybeParse, ok, unsafeParse } from './generic';
-
-test('ok is Ok', () => {
-  expect(ok(0).isOk()).toBe(true);
-});
-
-test('ok is not Err', () => {
-  expect(ok(0).isErr()).toBe(false);
-});
-
-test('ok has contained value', () => {
-  const value: unknown = {};
-  expect(ok(value).ok()).toBe(value);
-});
-
-test('ok without contained value', () => {
-  expect(ok().ok()).toBeUndefined();
-});
-
-test('ok has no contained error', () => {
-  expect(ok(0).err()).toBeUndefined();
-});
-
-test('ok unsafeUnwrap', () => {
-  expect(ok(0).unsafeUnwrap()).toBe(0);
-});
-
-test('ok unsafeUnwrapErr', () => {
-  expect(() => ok('value').unsafeUnwrapErr()).toThrowError('value');
-});
-
-test('err is Err', () => {
-  expect(err(0).isErr()).toBe(true);
-});
-
-test('err is not Ok', () => {
-  expect(err(0).isOk()).toBe(false);
-});
-
-test('err has contained error', () => {
-  const error: unknown = {};
-  expect(err(error).err()).toBe(error);
-});
-
-test('err has no contained value', () => {
-  expect(err(0).ok()).toBeUndefined();
-});
-
-test('err unsafeUnwrap', () => {
-  expect(() => err('error').unsafeUnwrap()).toThrowError('error');
-});
-
-test('err unsafeUnwrapErr', () => {
-  expect(err('error').unsafeUnwrapErr()).toBe('error');
-});
+import { maybeParse, unsafeParse } from './generic';
 
 test('unsafeParse', () => {
   expect(unsafeParse(z.string(), 'hello world!')).toEqual('hello world!');

--- a/libs/types/src/generic.ts
+++ b/libs/types/src/generic.ts
@@ -1,5 +1,6 @@
 import check8601 from '@antongolub/iso8601';
 import { z } from 'zod';
+import { err, ok, Result } from './result';
 
 export interface Dictionary<T> {
   [key: string]: Optional<T>;
@@ -7,117 +8,6 @@ export interface Dictionary<T> {
 export type Optional<T> = T | undefined;
 export interface Provider<T> {
   get(): Promise<T>;
-}
-
-/**
- * Represents either success with a value `T` or failure with error `E`.
- */
-export type Result<T, E> = Ok<T> | Err<E>;
-
-export interface Ok<T> {
-  /**
-   * Returns `true`.
-   */
-  isOk(): this is Ok<T>;
-
-  /**
-   * Returns `false`.
-   */
-  isErr(): this is Err<never>;
-
-  /**
-   * Returns the contained value.
-   */
-  ok(): T;
-
-  /**
-   * Returns `undefined`.
-   */
-  err(): undefined;
-
-  /**
-   * Returns the contained value.
-   */
-  unsafeUnwrap(): T;
-
-  /**
-   * Throws the contained value.
-   */
-  unsafeUnwrapErr(): never;
-}
-
-export interface Err<E> {
-  /**
-   * Returns `false`.
-   */
-  isOk(): this is Ok<never>;
-
-  /**
-   * Returns `true`.
-   */
-  isErr(): this is Err<E>;
-
-  /**
-   * Returns `undefined`.
-   */
-  ok(): undefined;
-
-  /**
-   * Returns the contained error.
-   */
-  err(): E;
-
-  /**
-   * Throws the contained error.
-   */
-  unsafeUnwrap(): never;
-
-  /**
-   * Returns the contained error.
-   */
-  unsafeUnwrapErr(): E;
-}
-
-/**
- * Returns an empty `Result`.
- */
-// eslint-disable-next-line vx/gts-no-return-type-only-generics
-export function ok<E>(): Result<void, E>;
-
-/**
- * Returns a `Result` containing `value`.
- */
-// eslint-disable-next-line vx/gts-no-return-type-only-generics
-export function ok<T, E>(value: T): Result<T, E>;
-// eslint-disable-next-line vx/gts-no-return-type-only-generics
-export function ok<T, E>(value: T = (undefined as unknown) as T): Result<T, E> {
-  return {
-    isErr: () => false,
-    isOk: () => true,
-    err: () => undefined,
-    ok: () => value,
-    unsafeUnwrap: () => value,
-    unsafeUnwrapErr: () => {
-      throw value;
-    },
-  };
-}
-
-/**
- * Returns a `Result` containing `error`.
- */
-// eslint-disable-next-line vx/gts-no-return-type-only-generics
-export function err<T, E>(error: E): Result<T, E> {
-  return {
-    isErr: () => true,
-    isOk: () => false,
-    err: () => error,
-    ok: () => undefined,
-    unsafeUnwrap: () => {
-      throw error;
-    },
-    unsafeUnwrapErr: () => error,
-  };
 }
 
 /**

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -9,6 +9,7 @@ export * from './geometry';
 export * from './image';
 export * from './numeric';
 export * from './precinct_selection';
+export * from './result';
 export * from './tallies';
 export * from './user_session';
 export * from './voting_method';

--- a/libs/types/src/numeric.ts
+++ b/libs/types/src/numeric.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Result, safeParse } from './generic';
+import { safeParse } from './generic';
+import { Result } from './result';
 
 export interface SafeParseNumberOptions {
   min?: number;

--- a/libs/types/src/result.test.ts
+++ b/libs/types/src/result.test.ts
@@ -1,0 +1,95 @@
+import { inspect } from 'util';
+import { err, isResult, ok } from './result';
+
+test('ok is Ok', () => {
+  expect(ok(0).isOk()).toBe(true);
+});
+
+test('ok is not Err', () => {
+  expect(ok(0).isErr()).toBe(false);
+});
+
+test('ok has contained value', () => {
+  const value: unknown = {};
+  expect(ok(value).ok()).toBe(value);
+});
+
+test('ok without contained value', () => {
+  expect(ok().ok()).toBeUndefined();
+});
+
+test('ok has no contained error', () => {
+  expect(ok(0).err()).toBeUndefined();
+});
+
+test('ok unsafeUnwrap', () => {
+  expect(ok(0).unsafeUnwrap()).toBe(0);
+});
+
+test('ok unsafeUnwrapErr', () => {
+  expect(() => ok('value').unsafeUnwrapErr()).toThrowError();
+});
+
+test('ok is Result', () => {
+  expect(isResult(ok())).toBe(true);
+});
+
+test('ok inspect', () => {
+  expect(inspect(ok(0))).toBe('ok(0)');
+  expect(
+    inspect(
+      ok({
+        a: { nested: { object: 99 } },
+      })
+    )
+  ).toBe('ok({ a: { nested: [Object] } })');
+  expect(inspect(ok(0), undefined, -1)).toBe('ok(…)');
+});
+
+test('err is Err', () => {
+  expect(err(0).isErr()).toBe(true);
+});
+
+test('err is not Ok', () => {
+  expect(err(0).isOk()).toBe(false);
+});
+
+test('err has contained error', () => {
+  const error: unknown = {};
+  expect(err(error).err()).toBe(error);
+});
+
+test('err has no contained value', () => {
+  expect(err(0).ok()).toBeUndefined();
+});
+
+test('err unsafeUnwrap', () => {
+  expect(() => err('error').unsafeUnwrap()).toThrowError();
+});
+
+test('err unsafeUnwrapErr', () => {
+  expect(err('error').unsafeUnwrapErr()).toBe('error');
+});
+
+test('err is Result', () => {
+  expect(isResult(err(0))).toBe(true);
+});
+
+test('non-ok/non-err are not Result', () => {
+  expect(isResult(0)).toBe(false);
+  expect(isResult('')).toBe(false);
+  expect(isResult(undefined)).toBe(false);
+  expect(isResult({})).toBe(false);
+});
+
+test('err inspect', () => {
+  expect(inspect(err(0))).toBe('err(0)');
+  expect(
+    inspect(
+      err({
+        a: { nested: { object: 99 } },
+      })
+    )
+  ).toBe('err({ a: { nested: [Object] } })');
+  expect(inspect(err(0), undefined, -1)).toBe('err(…)');
+});

--- a/libs/types/src/result.ts
+++ b/libs/types/src/result.ts
@@ -1,0 +1,176 @@
+/* eslint-disable max-classes-per-file */
+import { inspect, InspectOptions } from 'util';
+
+/**
+ * Represents a successful result of type `T`.
+ */
+class Ok<T> {
+  constructor(private readonly value: T) {}
+
+  /**
+   * Returns `true`.
+   */
+  isOk(): this is Ok<T> {
+    return true;
+  }
+
+  /**
+   * Returns `false`.
+   */
+  isErr(): this is Err<never> {
+    return false;
+  }
+
+  /**
+   * Returns the contained value.
+   */
+  ok(): T {
+    return this.value;
+  }
+
+  /**
+   * Returns `undefined`.
+   */
+  err(): undefined {
+    return undefined;
+  }
+
+  /**
+   * Returns the contained value.
+   */
+  unsafeUnwrap(): T {
+    return this.value;
+  }
+
+  /**
+   * Throws the contained value.
+   */
+  unsafeUnwrapErr(): never {
+    throw this.value;
+  }
+
+  /**
+   * Provides a custom inspect function for `Ok` values so that `console.log`
+   * and the node REPL will pretty-print the wrapper and value.
+   */
+  private [inspect.custom](depth: number, options: InspectOptions) {
+    if (depth < 0) {
+      return 'ok(…)';
+    }
+
+    return `ok(${inspect(
+      this.value,
+      options.showHidden,
+      depth - 1,
+      options.colors
+    )})`;
+  }
+}
+
+/**
+ * Represents a failed result of type `E`.
+ */
+class Err<E> {
+  constructor(private readonly error: E) {}
+
+  /**
+   * Returns `false`.
+   */
+  isOk(): this is Ok<never> {
+    return false;
+  }
+
+  /**
+   * Returns `true`.
+   */
+  isErr(): this is Err<E> {
+    return true;
+  }
+
+  /**
+   * Returns `undefined`.
+   */
+  ok(): undefined {
+    return undefined;
+  }
+
+  /**
+   * Returns the contained error.
+   */
+  err(): E {
+    return this.error;
+  }
+
+  /**
+   * Throws the contained error.
+   */
+  unsafeUnwrap(): never {
+    throw this.error;
+  }
+
+  /**
+   * Returns the contained error.
+   */
+  unsafeUnwrapErr(): E {
+    return this.error;
+  }
+
+  /**
+   * Provides a custom inspect function for `Err` values so that `console.log`
+   * and the node REPL will pretty-print the wrapper and value.
+   */
+  private [inspect.custom](depth: number, options: InspectOptions) {
+    if (depth < 0) {
+      return 'err(…)';
+    }
+
+    return `err(${inspect(
+      this.error,
+      options.showHidden,
+      depth - 1,
+      options.colors
+    )})`;
+  }
+}
+
+/**
+ * Returns an empty `Result`.
+ */
+// eslint-disable-next-line vx/gts-no-return-type-only-generics
+export function ok<E>(): Result<void, E>;
+
+/**
+ * Returns a `Result` containing `value`.
+ */
+// eslint-disable-next-line vx/gts-no-return-type-only-generics
+export function ok<T, E>(value: T): Result<T, E>;
+// eslint-disable-next-line vx/gts-no-return-type-only-generics
+export function ok<T, E>(value: T = (undefined as unknown) as T): Result<T, E> {
+  return new Ok(value);
+}
+
+/**
+ * Returns a `Result` containing `error`.
+ */
+// eslint-disable-next-line vx/gts-no-return-type-only-generics
+export function err<T, E>(error: E): Result<T, E> {
+  return new Err(error);
+}
+
+// Export just the interfaces, not the classes. This encourages the use of
+// `ok` and `err` constructors instead of the class constructors.
+type OkInterface<T> = Ok<T>;
+type ErrInterface<T> = Err<T>;
+export { OkInterface as Ok, ErrInterface as Err };
+
+/**
+ * Represents either success with a value `T` or failure with error `E`.
+ */
+export type Result<T, E> = Ok<T> | Err<E>;
+
+/**
+ * Determines whether the given value is a `Result`, i.e. `Ok` or `Err`.
+ */
+export function isResult(value: unknown): value is Result<unknown, unknown> {
+  return value instanceof Ok || value instanceof Err;
+}


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
- changes the constructor to use classes
- adds `inspect.custom` method to improve the display of the `Ok` and `Err` types
- moves the `Result` types into their own file
- adds `isResult` to allow checking whether an object is a `Result` 

## Demo Video or Screenshot
### Before
```
> require('.').ok(1)
{
  isErr: [Function: isErr],
  isOk: [Function: isOk],
  err: [Function: err],
  ok: [Function: ok],
  unsafeUnwrap: [Function: unsafeUnwrap],
  unsafeUnwrapErr: [Function: unsafeUnwrapErr]
}
```

### After
```
> require('.').ok(1)
ok(1)
```

## Testing Plan 
Automated testing.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
