### PR TITLE
feat(scan): add default NH adjudication reasons

### DIFF
--- a/libs/ballot-interpreter-nh/src/convert.test.ts
+++ b/libs/ballot-interpreter-nh/src/convert.test.ts
@@ -1,4 +1,9 @@
-import { BallotPaperSize, safeParseElection } from '@votingworks/types';
+import {
+  AdjudicationReason,
+  BallotPaperSize,
+  safeParseElection,
+} from '@votingworks/types';
+import { typedAs } from '@votingworks/utils';
 import {
   HudsonFixtureName,
   readFixtureBallotCardDefinition,
@@ -224,4 +229,32 @@ test('readGridFromElectionDefinition', async () => {
                 O      O             O
     "
   `);
+});
+
+test('default adjudication reasons', async () => {
+  const hudsonBallotCardDefinition = await readFixtureBallotCardDefinition(
+    HudsonFixtureName
+  );
+  const electionDefinition = await withSvgDebugger(async (debug) => {
+    debug.imageData(0, 0, hudsonBallotCardDefinition.front);
+    return convertElectionDefinition(hudsonBallotCardDefinition, {
+      ovalTemplate: await templates.getOvalTemplate(),
+      debug,
+    }).unsafeUnwrap();
+  });
+  expect(electionDefinition.centralScanAdjudicationReasons).toEqual(
+    typedAs<AdjudicationReason[]>([
+      AdjudicationReason.UninterpretableBallot,
+      AdjudicationReason.Overvote,
+      AdjudicationReason.WriteIn,
+      AdjudicationReason.BlankBallot,
+    ])
+  );
+  expect(electionDefinition.precinctScanAdjudicationReasons).toEqual(
+    typedAs<AdjudicationReason[]>([
+      AdjudicationReason.UninterpretableBallot,
+      AdjudicationReason.Overvote,
+      AdjudicationReason.BlankBallot,
+    ])
+  );
 });

--- a/libs/ballot-interpreter-nh/src/convert.ts
+++ b/libs/ballot-interpreter-nh/src/convert.ts
@@ -1,4 +1,5 @@
 import {
+  AdjudicationReason,
   BallotPaperSize,
   Candidate,
   CandidateContest,
@@ -408,6 +409,17 @@ export function convertElectionDefinitionHeader(
               };
         }),
       },
+    ],
+    centralScanAdjudicationReasons: [
+      AdjudicationReason.UninterpretableBallot,
+      AdjudicationReason.Overvote,
+      AdjudicationReason.WriteIn,
+      AdjudicationReason.BlankBallot,
+    ],
+    precinctScanAdjudicationReasons: [
+      AdjudicationReason.UninterpretableBallot,
+      AdjudicationReason.Overvote,
+      AdjudicationReason.BlankBallot,
     ],
   };
 

--- a/libs/ballot-interpreter-nh/src/interpret/index.test.ts
+++ b/libs/ballot-interpreter-nh/src/interpret/index.test.ts
@@ -2354,7 +2354,7 @@ test('interpret', async () => {
         "metadata": Object {
           "ballotStyleId": "card-number-54",
           "ballotType": 0,
-          "electionHash": "24e75b5d29a99d13d7209c413f654f9863a32f5e7b8530ead92bd7cab1974e10",
+          "electionHash": "643bb476f81d952e66afbc2f4e894f58bf86263bf167832b897ced9ebf8da6dc",
           "isTestMode": false,
           "locales": Object {
             "primary": "unknown",
@@ -3503,7 +3503,7 @@ test('interpret', async () => {
         "metadata": Object {
           "ballotStyleId": "card-number-54",
           "ballotType": 0,
-          "electionHash": "24e75b5d29a99d13d7209c413f654f9863a32f5e7b8530ead92bd7cab1974e10",
+          "electionHash": "643bb476f81d952e66afbc2f4e894f58bf86263bf167832b897ced9ebf8da6dc",
           "isTestMode": false,
           "locales": Object {
             "primary": "unknown",

--- a/libs/ballot-interpreter-nh/test/fixtures/hudson-2020-11-03/election.json
+++ b/libs/ballot-interpreter-nh/test/fixtures/hudson-2020-11-03/election.json
@@ -13,6 +13,12 @@
       ]
     }
   ],
+  "centralScanAdjudicationReasons": [
+    "UninterpretableBallot",
+    "Overvote",
+    "WriteIn",
+    "BlankBallot"
+  ],
   "contests": [
     {
       "id": "President-and-Vice-President-of-the-United-States-18d1a55a",
@@ -1062,6 +1068,11 @@
       "fullName": "OC",
       "abbrev": "OC"
     }
+  ],
+  "precinctScanAdjudicationReasons": [
+    "UninterpretableBallot",
+    "Overvote",
+    "BlankBallot"
   ],
   "precincts": [
     {


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
Without these the scanners will never reject a ballot that is actually a timing mark ballot for the election.

## Demo Video or Screenshot
n/a

## Testing Plan 
Manually scanned ballots with overvotes.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
