### PR TITLE
feat(scan): add New Hampshire seal

### DIFF
--- a/libs/ballot-interpreter-nh/src/convert.ts
+++ b/libs/ballot-interpreter-nh/src/convert.ts
@@ -421,6 +421,8 @@ export function convertElectionDefinitionHeader(
       AdjudicationReason.Overvote,
       AdjudicationReason.BlankBallot,
     ],
+    // eslint-disable-next-line vx/gts-identifiers
+    sealURL: '/seals/Seal_of_New_Hampshire.svg',
   };
 
   return safeParseElection(election);

--- a/libs/ballot-interpreter-nh/src/interpret/index.test.ts
+++ b/libs/ballot-interpreter-nh/src/interpret/index.test.ts
@@ -2354,7 +2354,7 @@ test('interpret', async () => {
         "metadata": Object {
           "ballotStyleId": "card-number-54",
           "ballotType": 0,
-          "electionHash": "643bb476f81d952e66afbc2f4e894f58bf86263bf167832b897ced9ebf8da6dc",
+          "electionHash": "7d7ec52509d0b37c73e19b9059c0794c6011d2dd02051aecc8e536e965be401c",
           "isTestMode": false,
           "locales": Object {
             "primary": "unknown",
@@ -3503,7 +3503,7 @@ test('interpret', async () => {
         "metadata": Object {
           "ballotStyleId": "card-number-54",
           "ballotType": 0,
-          "electionHash": "643bb476f81d952e66afbc2f4e894f58bf86263bf167832b897ced9ebf8da6dc",
+          "electionHash": "7d7ec52509d0b37c73e19b9059c0794c6011d2dd02051aecc8e536e965be401c",
           "isTestMode": false,
           "locales": Object {
             "primary": "unknown",

--- a/libs/ballot-interpreter-nh/test/fixtures/hudson-2020-11-03/election.json
+++ b/libs/ballot-interpreter-nh/test/fixtures/hudson-2020-11-03/election.json
@@ -1080,6 +1080,7 @@
       "name": "Hudson"
     }
   ],
+  "sealURL": "/seals/Seal_of_New_Hampshire.svg",
   "state": "NH",
   "title": "General Election"
 }


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Adds the `sealURL` pointing to the New Hampshire ballot. This won't be used for now, but felt like a good thing to add.

## Demo Video or Screenshot
n/a

## Testing Plan 
n/a

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
