### PR TITLE
feat(scan): allow workers to send/receive `Result`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2147,6 +2147,7 @@ importers:
       eslint-plugin-jest: 24.1.3_eslint@7.17.0+typescript@4.3.5
       eslint-plugin-prettier: 3.3.1_7c5f1f59332aa465fcd97b1399d2f1c7
       eslint-plugin-vx: link:../../libs/eslint-plugin-vx
+      fast-check: 2.23.2
       is-ci-cli: 2.1.2
       jest: 26.6.3_canvas@2.6.1+ts-node@9.1.1
       jest-watch-typeahead: 0.6.4_jest@26.6.3
@@ -2206,6 +2207,7 @@ importers:
       eslint-plugin-prettier: ^3.3.1
       eslint-plugin-vx: workspace:*
       express: ^4.17.1
+      fast-check: ^2.23.2
       fs-extra: ^9.0.1
       got: ^11.8.2
       is-ci-cli: ^2.1.2
@@ -16913,6 +16915,14 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-aV1kOi6zUCytkICuhu9s8MBtJjlAos6MIU5NYCcgt5u2UVdgaAsqTI+u0n6Cea1hKFXdfSmfz6wfxce6Ozcj2w==
+  /fast-check/2.23.2:
+    dependencies:
+      pure-rand: 5.0.1
+    dev: true
+    engines:
+      node: '>=8.0.0'
+    resolution:
+      integrity: sha512-ECYuSlp6NLpvOj8eScKsqoz1ihtCpSDuEC2ofdGvgsEu1obHYEGqreJ/iPzkJFy73yoU0kCFea7PHUQDNM0VNg==
   /fast-deep-equal/3.1.3:
     resolution:
       integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -25576,6 +25586,10 @@ packages:
   /pure-rand/5.0.0:
     resolution:
       integrity: sha512-lD2/y78q+7HqBx2SaT6OT4UcwtvXNRfEpzYEzl0EQ+9gZq2Qi3fa0HDnYPeqQwhlHJFBUhT7AO3mLU3+8bynHA==
+  /pure-rand/5.0.1:
+    dev: true
+    resolution:
+      integrity: sha512-ksWccjmXOHU2gJBnH0cK1lSYdvSZ0zLoCMSz/nTGh6hDvCSgcRxDyIcOBD6KNxFz3xhMPm/T267Tbe2JRymKEQ==
   /q/1.5.1:
     dev: false
     engines:

--- a/services/scan/package.json
+++ b/services/scan/package.json
@@ -97,6 +97,7 @@
     "eslint-plugin-jest": "^24.1.3",
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-vx": "workspace:*",
+    "fast-check": "^2.23.2",
     "is-ci-cli": "^2.1.2",
     "jest": "^26.6.3",
     "jest-watch-typeahead": "^0.6.4",

--- a/services/scan/src/workers/json_serialization.test.ts
+++ b/services/scan/src/workers/json_serialization.test.ts
@@ -1,0 +1,93 @@
+import { err, isResult, ok } from '@votingworks/types';
+import { assert } from '@votingworks/utils';
+import * as fc from 'fast-check';
+import {
+  deserialize,
+  serialize,
+  SerializedMessage,
+} from './json_serialization';
+
+function arbitraryMessage(): fc.Arbitrary<SerializedMessage> {
+  const { any } = fc.letrec((tie) => ({
+    any: fc.oneof(
+      tie('string'),
+      tie('number'),
+      tie('boolean'),
+      tie('null'),
+      tie('undefined'),
+      tie('object'),
+      tie('array'),
+      tie('buffer'),
+      tie('uint8array')
+    ),
+    string: fc.string(),
+    number: fc.integer(),
+    boolean: fc.boolean(),
+    null: fc.constant(null),
+    undefined: fc.constant(undefined),
+    object: fc.object({ values: [tie('any')] }),
+    array: fc.array(tie('any')),
+    buffer: fc
+      .array(fc.integer({ min: 0, max: 255 }))
+      .map((arr) => Buffer.from(arr)),
+    uint8array: fc
+      .array(fc.integer({ min: 0, max: 255 }))
+      .map((arr) => Uint8Array.from(arr)),
+  }));
+  return (any as unknown) as fc.Arbitrary<SerializedMessage>;
+}
+
+test('string', () => {
+  fc.assert(
+    fc.property(fc.string(), (str) => {
+      expect(deserialize(serialize(str))).toEqual(str);
+    })
+  );
+});
+
+test('number', () => {
+  fc.assert(
+    fc.property(fc.oneof(fc.integer(), fc.float()), (num) => {
+      expect(deserialize(serialize(num))).toEqual(num);
+    })
+  );
+});
+
+test('result', () => {
+  fc.assert(
+    fc.property(
+      fc
+        .tuple(fc.boolean(), arbitraryMessage())
+        .map(([isOk, value]) => (isOk ? ok(value) : err(value))),
+      (result) => {
+        const roundTripResult = deserialize(serialize(result));
+        assert(isResult(roundTripResult));
+        expect(roundTripResult.isOk()).toEqual(result.isOk());
+        expect(
+          roundTripResult.isOk() ? roundTripResult.ok() : roundTripResult.err()
+        ).toEqual(result.isOk() ? result.ok() : result.err());
+      }
+    )
+  );
+});
+
+test('error', () => {
+  fc.assert(
+    fc.property(
+      fc.string().map((message) => new Error(message)),
+      (error) => {
+        const roundTripError = deserialize(serialize(error)) as Error;
+        expect(roundTripError.message).toEqual(error.message);
+        expect(roundTripError.stack).toEqual(error.stack);
+      }
+    )
+  );
+});
+
+test('any message', () => {
+  fc.assert(
+    fc.property(arbitraryMessage(), (msg) => {
+      expect(deserialize(serialize(msg))).toEqual(msg);
+    })
+  );
+});


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
I plan to make the NH scan result be a `Result`.

## Demo Video or Screenshot
n/a

## Testing Plan 
Automated testing.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
