### PR TITLE
feat(test-utils): allow specifying whether contests have write-ins

### DIFF
--- a/libs/test-utils/src/arbitraries.test.ts
+++ b/libs/test-utils/src/arbitraries.test.ts
@@ -11,6 +11,7 @@ import { arbitraryDateTime } from '.';
 import {
   arbitraryCastVoteRecord,
   arbitraryCastVoteRecords,
+  arbitraryCandidateContest,
   arbitraryElection,
   arbitraryElectionDefinition,
   arbitraryId,
@@ -106,5 +107,23 @@ test('arbitraryCastVoteRecord(s) makes valid CVRs', () => {
         expect(cvr._testBallot).toBe(testBallot);
       }
     })
+  );
+});
+
+test('arbitraryCandidateContest allows specifying whether it allows write-ins', () => {
+  fc.assert(
+    fc.property(
+      fc.boolean().chain((allowWriteIns) =>
+        fc.tuple(
+          fc.constant(allowWriteIns),
+          arbitraryCandidateContest({
+            allowWriteIns: fc.constant(allowWriteIns),
+          })
+        )
+      ),
+      ([allowWriteIns, contest]) => {
+        expect(contest.allowWriteIns).toBe(allowWriteIns);
+      }
+    )
   );
 });

--- a/libs/test-utils/src/arbitraries.ts
+++ b/libs/test-utils/src/arbitraries.ts
@@ -230,10 +230,12 @@ export function arbitraryCandidateContest({
   id = arbitraryContestId(),
   districtId = arbitraryDistrictId(),
   partyIds = fc.array(arbitraryPartyId(), { minLength: 1 }),
+  allowWriteIns = fc.boolean(),
 }: {
   id?: fc.Arbitrary<CandidateContest['id']>;
   districtId?: fc.Arbitrary<District['id']>;
   partyIds?: fc.Arbitrary<Array<Party['id']>>;
+  allowWriteIns?: fc.Arbitrary<boolean>;
 } = {}): fc.Arbitrary<CandidateContest> {
   return fc.record({
     type: fc.constant('candidate'),
@@ -241,7 +243,7 @@ export function arbitraryCandidateContest({
     title: fc.string({ minLength: 1 }),
     section: fc.string({ minLength: 1 }),
     districtId,
-    allowWriteIns: fc.boolean(),
+    allowWriteIns,
     seats: fc.integer({ min: 1, max: 5 }),
     candidates: fc
       .array(


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
I have a need for this in testing adjudication for New Hampshire work.

## Demo Video or Screenshot
```js
> fc.sample(lib.arbitraryCandidateContest()).map(({ allowWriteIns }) => allowWriteIns)
[
  false, true,  true,  true,  false, false, false, true,  false,
  true,  true,  true,  false, false, true,  false, false, false,
  true,  true,  true,  false, false, false, true,  false, false,
  true,  false, true,  true,  false, true,  false, true,  true,
  true,  true,  false, true,  false, false, true,  false, false,
  true,  true,  false, true,  false, true,  true,  true,  false,
  true,  true,  false, false, true,  false, false, false, true,
  true,  true,  false, true,  false, true,  true,  true,  false,
  false, true,  false, false, true,  false, false, false, true,
  true,  true,  false, true,  false, false, false, true,  false,
  true,  false, true,  false, false, true,  true,  true,  true,
  true
]
> fc.sample(lib.arbitraryCandidateContest({ allowWriteIns: fc.constant(true) })).map(({ allowWriteIns }) => allowWriteIns)
[
  true, true, true, true, true, true, true, true, true,
  true, true, true, true, true, true, true, true, true,
  true, true, true, true, true, true, true, true, true,
  true, true, true, true, true, true, true, true, true,
  true, true, true, true, true, true, true, true, true,
  true, true, true, true, true, true, true, true, true,
  true, true, true, true, true, true, true, true, true,
  true, true, true, true, true, true, true, true, true,
  true, true, true, true, true, true, true, true, true,
  true, true, true, true, true, true, true, true, true,
  true, true, true, true, true, true, true, true, true,
  true
]
> fc.sample(lib.arbitraryCandidateContest({ allowWriteIns: fc.constant(false) })).map(({ allowWriteIns }) => allowWriteIns)
[
  false, false, false, false, false, false, false, false,
  false, false, false, false, false, false, false, false,
  false, false, false, false, false, false, false, false,
  false, false, false, false, false, false, false, false,
  false, false, false, false, false, false, false, false,
  false, false, false, false, false, false, false, false,
  false, false, false, false, false, false, false, false,
  false, false, false, false, false, false, false, false,
  false, false, false, false, false, false, false, false,
  false, false, false, false, false, false, false, false,
  false, false, false, false, false, false, false, false,
  false, false, false, false, false, false, false, false,
  false, false, false, false
]
```

## Testing Plan 
New automated test added.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
