### PR TITLE
refactor(types): use shared `PageInterpretationWithFiles`

### DIFF
--- a/services/scan/src/store.test.ts
+++ b/services/scan/src/store.test.ts
@@ -1,20 +1,21 @@
 import {
   AdjudicationReason,
   BallotMetadata,
+  BallotPageLayout,
+  BallotPageMetadata,
   BallotType,
   CandidateContest,
-  BallotPageMetadata,
-  BallotPageLayout,
+  PageInterpretationWithFiles,
   YesNoContest,
 } from '@votingworks/types';
 import { typedAs } from '@votingworks/utils';
+import * as streams from 'memory-streams';
 import * as tmp from 'tmp';
 import { v4 as uuid } from 'uuid';
-import * as streams from 'memory-streams';
 import * as stateOfHamilton from '../test/fixtures/state-of-hamilton';
 import { zeroRect } from '../test/fixtures/zero_rect';
 import { Store } from './store';
-import { PageInterpretationWithFiles, SheetOf } from './types';
+import { SheetOf } from './types';
 
 test('get/set election', () => {
   const store = Store.memoryStore();

--- a/services/scan/src/store.ts
+++ b/services/scan/src/store.ts
@@ -25,6 +25,7 @@ import {
   unsafeParse,
   BallotMetadataSchema,
   BallotPageLayoutSchema,
+  PageInterpretationWithFiles,
 } from '@votingworks/types';
 import {
   AdjudicationStatus,
@@ -44,7 +45,7 @@ import { z } from 'zod';
 import { buildCastVoteRecord } from './build_cast_vote_record';
 import { Bindable, DbClient } from './db_client';
 import { sheetRequiresAdjudication } from './interpreter';
-import { PageInterpretationWithFiles, SheetOf } from './types';
+import { SheetOf } from './types';
 import { normalizeAndJoin } from './util/path';
 
 const debug = makeDebug('scan:store');

--- a/services/scan/src/types.ts
+++ b/services/scan/src/types.ts
@@ -11,12 +11,6 @@ import { BallotStyleData } from '@votingworks/utils';
 
 export type SheetOf<T> = [T, T];
 
-export interface PageInterpretationWithFiles {
-  originalFilename: string;
-  normalizedFilename: string;
-  interpretation: PageInterpretation;
-}
-
 export interface PageInterpretationWithAdjudication<
   T extends PageInterpretation = PageInterpretation
 > {


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
This was duplicated in `services/scan`.

## Demo Video or Screenshot

## Testing Plan 

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
