### PR TITLE
refactor(smartcards): Remove unused /card/reader endpoint

### DIFF
--- a/services/smartcards/smartcards/core.py
+++ b/services/smartcards/smartcards/core.py
@@ -18,12 +18,6 @@ CardInterface = MockInstance if MockInstance.has_card else RealInstance
 app = Flask(__name__)
 
 
-@app.route('/card/reader')
-def card_reader():
-    is_connected = CardInterface.is_reader_connected()
-    return json.dumps({"connected": is_connected})
-
-
 @app.route('/card/read')
 def card_read():
     status = CardInterface.status()

--- a/services/smartcards/tests/test_core.py
+++ b/services/smartcards/tests/test_core.py
@@ -26,11 +26,6 @@ def client():
     # any cleanup goes here
 
 
-def test_card_reader(client):
-    rv = json.loads(client.get('/card/reader').data)
-    assert 'connected' in rv
-
-
 def test_card_read(client):
     client.put('/mock', data=json.dumps({'shortValue': 'XYZ'}))
 


### PR DESCRIPTION
## Overview
Found this while adding a new endpoint for testing the card reader. Didn't seem to be needed for anything, so might as well remove

## Demo Video or Screenshot
N/A

## Testing Plan 
Updated unit tests.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
