### PR TITLE
test(scan): bump timeouts

### DIFF
--- a/libs/ballot-interpreter-nh/src/convert.test.ts
+++ b/libs/ballot-interpreter-nh/src/convert.test.ts
@@ -19,6 +19,10 @@ import {
 import * as templates from './data/templates';
 import { withSvgDebugger } from './debug';
 
+if (process.env.CI) {
+  jest.setTimeout(10_000);
+}
+
 test('converting a single ballot card definition', async () => {
   const hudsonBallotCardDefinition = await readFixtureBallotCardDefinition(
     HudsonFixtureName

--- a/libs/ballot-interpreter-nh/src/interpret/index.test.ts
+++ b/libs/ballot-interpreter-nh/src/interpret/index.test.ts
@@ -6,6 +6,10 @@ import {
   readFixtureJson,
 } from '../../test/fixtures';
 
+if (process.env.CI) {
+  jest.setTimeout(10_000);
+}
+
 test('interpret marked', async () => {
   const electionDefinition = safeParseElectionDefinition(
     await readFixtureJson(HudsonFixtureName, 'election')


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
These tests can take a while, so let them run longer in CI. [Previous timeout](https://app.circleci.com/pipelines/github/votingworks/vxsuite/3366/workflows/05fed240-399e-43be-a3fb-0377f96074e4/jobs/58877?invite=true#step-108-17).

## Demo Video or Screenshot
n/a

## Testing Plan 
n/a

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
