### PR TITLE
fix(scan): use correct pluralization

### DIFF
--- a/frontends/bsd/src/screens/dashboard_screen.tsx
+++ b/frontends/bsd/src/screens/dashboard_screen.tsx
@@ -104,10 +104,19 @@ export function DashboardScreen({
         {batchCount ? (
           <React.Fragment>
             <p>
-              A total of{' '}
-              <strong>{pluralize('ballot', ballotCount, true)}</strong> have
-              been scanned in{' '}
-              <strong>{pluralize('batch', batchCount, true)}</strong>.
+              {ballotCount === 1 ? (
+                <React.Fragment>
+                  A total of <strong>1 ballot</strong> has been scanned in{' '}
+                  <strong>{pluralize('batch', batchCount, true)}</strong>.
+                </React.Fragment>
+              ) : (
+                <React.Fragment>
+                  A total of{' '}
+                  <strong>{pluralize('ballot', ballotCount, true)}</strong> have
+                  been scanned in{' '}
+                  <strong>{pluralize('batch', batchCount, true)}</strong>.
+                </React.Fragment>
+              )}
             </p>
             <Table>
               <thead>

--- a/integration-testing/bsd/cypress/integration/configuration.ts
+++ b/integration-testing/bsd/cypress/integration/configuration.ts
@@ -38,13 +38,13 @@ describe('BSD and services/Scan', () => {
       .click();
     cy.contains('No ballots have been scanned', { timeout: 30000 });
     cy.contains('Scan New Batch').click();
-    cy.contains('A total of 1 ballot have been scanned in 1 batch.');
+    cy.contains('A total of 1 ballot has been scanned in 1 batch.');
     cy.contains('Admin').click();
     cy.contains('Delete Ballot Data').click();
     cy.contains('Yes, Delete Ballot Data').click();
     cy.contains('No ballots have been scanned', { timeout: 20000 });
     cy.contains('Scan New Batch').click();
-    cy.contains('A total of 1 ballot have been scanned in 1 batch.');
+    cy.contains('A total of 1 ballot has been scanned in 1 batch.');
     cy.contains('Admin').click();
     cy.contains('Toggle to Test Mode').click();
     cy.get('button[data-testid="confirm-toggle"]')


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
I noticed this while watching the video from https://github.com/votingworks/vxsuite/pull/1646. I opted not to break the sentence up with the condition in the middle because that's problematic for localization tools and I think it makes it harder to read, though at the cost of some duplication.

## Demo Video or Screenshot
<img width="508" alt="image" src="https://user-images.githubusercontent.com/1938/160695675-2c80cd1e-f6f8-4b00-bf03-139c2f45a0bd.png">

## Testing Plan 
Manually tested both 1 and non-1 cases.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
