### PR TITLE
fix(scan): confirm delete batch on enter

### DIFF
--- a/frontends/bsd/src/screens/dashboard_screen.tsx
+++ b/frontends/bsd/src/screens/dashboard_screen.tsx
@@ -170,6 +170,7 @@ export function DashboardScreen({
                 danger
                 onPress={confirmDeleteBatch}
                 disabled={isDeletingBatch}
+                autoFocus
               >
                 {isDeletingBatch ? 'Deleting…' : 'Yes, Delete Batch'}
               </Button>


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
Cause the 'Yes, Delete Batch' button to be focused when showing the modal so that pressing Enter or Space will confirm the delete. Escape already works to dismiss it, but with this change you can also press Tab to focus the Cancel button and select it with Enter or Space.

I only made this change in one place to ask whether this is the way we want to do this. In general I am supportive of using built-in browser features, and this seems to fit the desired behavior. I'm open to alternative suggestions, though.

## Demo Video or Screenshot
https://user-images.githubusercontent.com/1938/160702635-a9cb50da-e4b4-4dab-9aca-8721502d7bfe.mov

## Testing Plan 
Manually tested.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
