### PR TITLE
Change calibration success modal button copy from Back to Close

### DIFF
--- a/frontends/precinct-scanner/src/components/calibrate_scanner_modal.test.tsx
+++ b/frontends/precinct-scanner/src/components/calibrate_scanner_modal.test.tsx
@@ -92,7 +92,7 @@ test('calibrate success', async () => {
   await screen.findByText('Calibration succeeded!');
 
   // finish
-  fireEvent.click(await screen.findByText('Back'));
+  fireEvent.click(await screen.findByText('Close'));
   expect(onCancel).toHaveBeenCalled();
 });
 
@@ -160,6 +160,6 @@ test('calibrate error & try again', async () => {
   await screen.findByText('Calibration succeeded!');
 
   // finish
-  fireEvent.click(await screen.findByText('Back'));
+  fireEvent.click(await screen.findByText('Close'));
   expect(onCancel).toHaveBeenCalled();
 });

--- a/frontends/precinct-scanner/src/components/calibrate_scanner_modal.tsx
+++ b/frontends/precinct-scanner/src/components/calibrate_scanner_modal.tsx
@@ -59,7 +59,7 @@ export function CalibrateScannerModal({
             <h1>Calibration succeeded!</h1>
           </Prose>
         }
-        actions={<Button onPress={onCancel}>Back</Button>}
+        actions={<Button onPress={onCancel}>Close</Button>}
       />
     );
   }


### PR DESCRIPTION
## Overview

A simple copy change on the calibration success modal for clarity! Issue link: https://github.com/votingworks/vxsuite/issues/1462

## Demo screenshots

Before and after

<img src="https://user-images.githubusercontent.com/12616928/160894205-dfdb4b6b-9729-4f7b-aa19-12c77394a057.png" alt="before" width="400" /> <img src="https://user-images.githubusercontent.com/12616928/160894210-a665c8d5-7876-4118-b03e-4dcb8e75428b.png" alt="after" width="400" />

## Testing plan

Ran the precinct-scanner module locally and used the preview screens plus the mock scanner to make it to the screen of interest. Also updated corresponding unit tests.

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A
- [ ] ~I have added JSDoc comments to any newly introduced exports~ N/A
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates