### PR TITLE
fix(scan): support nullish debug callback return value

### DIFF
--- a/libs/ballot-interpreter-nh/src/debug.ts
+++ b/libs/ballot-interpreter-nh/src/debug.ts
@@ -405,7 +405,7 @@ export function withSvgDebugger<T>(
   let result: T;
   try {
     result = callback(debug);
-    if (typeof result !== 'undefined' && 'then' in result) {
+    if (result && 'then' in result) {
       return (result as unknown as Promise<unknown>).then(
         () => {
           writeFileSync(fileName, root.toString());
@@ -473,7 +473,7 @@ export function withCanvasDebugger<T>(
 
   try {
     result = callback(debug);
-    if ('then' in result) {
+    if (result && 'then' in result) {
       return (result as unknown as Promise<unknown>).then(
         () => {
           writeFileSync(fileName, debug.toBuffer());


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
Using `in` operator on `undefined` or `null` is an error. This change guards against that case.

## Demo Video or Screenshot
n/a

## Testing Plan 
n/a

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
