### PR TITLE
refactor(scan): simplify write-in reason info type

### DIFF
--- a/frontends/bsd/src/screens/ballot_eject_screen.test.tsx
+++ b/frontends/bsd/src/screens/ballot_eject_screen.test.tsx
@@ -668,7 +668,7 @@ test('shows invalid precinct screen when appropriate', async () => {
 
 test('does NOT say ballot is blank if one side is blank and the other requires write-in adjudication (marked or unmarked)', async () => {
   for (const writeInReason of [
-    AdjudicationReason.WriteIn,
+    AdjudicationReason.MarkedWriteIn,
     AdjudicationReason.UnmarkedWriteIn,
   ] as const) {
     fetchMock.getOnce(

--- a/frontends/bsd/src/screens/ballot_eject_screen.tsx
+++ b/frontends/bsd/src/screens/ballot_eject_screen.tsx
@@ -4,7 +4,6 @@ import {
   Contest,
   MarkAdjudications,
   PageInterpretation,
-  UnmarkedWriteInAdjudicationReasonInfo,
   WriteInAdjudicationReasonInfo,
 } from '@votingworks/types';
 import {
@@ -339,17 +338,13 @@ export function BallotEjectScreen({
             isUndervotedSheet = true;
             contestIdsWithIssues.add(adjudicationReason.contestId);
           } else if (
-            adjudicationReason.type === AdjudicationReason.WriteIn ||
+            adjudicationReason.type === AdjudicationReason.MarkedWriteIn ||
             adjudicationReason.type === AdjudicationReason.UnmarkedWriteIn
           ) {
             if (reviewPageInfo.layout && reviewPageInfo.contestIds) {
               const writeIns = reviewPageInfo.interpretation.adjudicationInfo.enabledReasonInfos.filter(
-                (
-                  reason
-                ): reason is
-                  | WriteInAdjudicationReasonInfo
-                  | UnmarkedWriteInAdjudicationReasonInfo =>
-                  reason.type === AdjudicationReason.WriteIn ||
+                (reason): reason is WriteInAdjudicationReasonInfo =>
+                  reason.type === AdjudicationReason.MarkedWriteIn ||
                   reason.type === AdjudicationReason.UnmarkedWriteIn
               );
               return (

--- a/frontends/bsd/src/screens/write_in_adjudication_screen.test.tsx
+++ b/frontends/bsd/src/screens/write_in_adjudication_screen.test.tsx
@@ -2,7 +2,6 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { electionSampleDefinition } from '@votingworks/fixtures';
 import {
-  UnmarkedWriteInAdjudicationReasonInfo,
   AdjudicationReason,
   BallotPageLayout,
   BallotType,
@@ -13,7 +12,6 @@ import {
   WriteInId,
   WriteInIdSchema,
 } from '@votingworks/types';
-
 import {
   allContestOptions,
   assert,
@@ -70,11 +68,9 @@ test('supports typing in a candidate name', async () => {
     >()
     .mockResolvedValue();
 
-  const writeIns: Array<
-    WriteInAdjudicationReasonInfo | UnmarkedWriteInAdjudicationReasonInfo
-  > = [
+  const writeIns: WriteInAdjudicationReasonInfo[] = [
     {
-      type: AdjudicationReason.WriteIn,
+      type: AdjudicationReason.MarkedWriteIn,
       contestId: contest.id,
       optionId,
       optionIndex: 0,
@@ -139,7 +135,7 @@ test('supports typing in a candidate name', async () => {
         'front',
         [
           {
-            type: AdjudicationReason.WriteIn,
+            type: AdjudicationReason.MarkedWriteIn,
             isMarked: true,
             contestId: contest.id,
             optionId,
@@ -161,9 +157,7 @@ test('supports canceling a write-in', async () => {
     >()
     .mockResolvedValue();
 
-  const writeIns: Array<
-    WriteInAdjudicationReasonInfo | UnmarkedWriteInAdjudicationReasonInfo
-  > = [
+  const writeIns: WriteInAdjudicationReasonInfo[] = [
     {
       type: AdjudicationReason.UnmarkedWriteIn,
       contestId: contest.id,
@@ -262,28 +256,24 @@ test('can adjudicate front & back in succession', async () => {
     >()
     .mockResolvedValue();
 
-  const frontWriteIns: Array<
-    WriteInAdjudicationReasonInfo | UnmarkedWriteInAdjudicationReasonInfo
-  > = [
+  const frontWriteIns: WriteInAdjudicationReasonInfo[] = [
     {
-      type: AdjudicationReason.WriteIn,
+      type: AdjudicationReason.MarkedWriteIn,
       contestId: frontContest1.id,
       optionId: frontContest1WriteInId,
       optionIndex: 0,
     },
     {
-      type: AdjudicationReason.WriteIn,
+      type: AdjudicationReason.MarkedWriteIn,
       contestId: frontContest2.id,
       optionId: frontContest2WriteInId,
       optionIndex: 0,
     },
   ];
 
-  const backWriteIns: Array<
-    WriteInAdjudicationReasonInfo | UnmarkedWriteInAdjudicationReasonInfo
-  > = [
+  const backWriteIns: WriteInAdjudicationReasonInfo[] = [
     {
-      type: AdjudicationReason.WriteIn,
+      type: AdjudicationReason.MarkedWriteIn,
       contestId: backContest.id,
       optionId: backContestWriteInId,
       optionIndex: 0,
@@ -450,11 +440,9 @@ test('uses the layout embedded definition to crop the ballot image correctly if 
     >()
     .mockResolvedValue();
 
-  const writeIns: Array<
-    WriteInAdjudicationReasonInfo | UnmarkedWriteInAdjudicationReasonInfo
-  > = [
+  const writeIns: WriteInAdjudicationReasonInfo[] = [
     {
-      type: AdjudicationReason.WriteIn,
+      type: AdjudicationReason.MarkedWriteIn,
       contestId: writeInOption.contestId,
       optionId: writeInOption.id,
       // You'd expect this to be `writeInOption.optionIndex`, but because

--- a/frontends/bsd/src/screens/write_in_adjudication_screen.tsx
+++ b/frontends/bsd/src/screens/write_in_adjudication_screen.tsx
@@ -12,7 +12,6 @@ import {
   ContestId,
   ElectionDefinition,
   Rect,
-  UnmarkedWriteInAdjudicationReasonInfo,
   WriteInAdjudicationReasonInfo,
   WriteInMarkAdjudication,
 } from '@votingworks/types';
@@ -183,9 +182,7 @@ function WriteInLabel({
   writeIn,
 }: {
   contest: CandidateContest;
-  writeIn:
-    | WriteInAdjudicationReasonInfo
-    | UnmarkedWriteInAdjudicationReasonInfo;
+  writeIn: WriteInAdjudicationReasonInfo;
 }) {
   return (
     <HStack>
@@ -227,9 +224,7 @@ function WriteInImage({
 interface ContestOptionAdjudicationProps {
   imageUrl: string;
   contest: CandidateContest;
-  writeIn:
-    | WriteInAdjudicationReasonInfo
-    | UnmarkedWriteInAdjudicationReasonInfo;
+  writeIn: WriteInAdjudicationReasonInfo;
   layout: BallotPageContestLayout;
   adjudications: readonly WriteInMarkAdjudication[];
   onChange?(adjudication: WriteInMarkAdjudication): void;
@@ -372,9 +367,7 @@ interface ContestAdjudicationProps {
   imageUrl: string;
   contest: CandidateContest;
   layout: BallotPageContestLayout;
-  writeInsForContest: ReadonlyArray<
-    WriteInAdjudicationReasonInfo | UnmarkedWriteInAdjudicationReasonInfo
-  >;
+  writeInsForContest: readonly WriteInAdjudicationReasonInfo[];
   onChange?(adjudication: WriteInMarkAdjudication): void;
   adjudications: readonly WriteInMarkAdjudication[];
   writeInPresets: CandidateNamesByContestId;
@@ -430,9 +423,7 @@ export interface Props {
   /**
    * All write-ins flagged for adjudication on this page.
    */
-  writeIns: ReadonlyArray<
-    WriteInAdjudicationReasonInfo | UnmarkedWriteInAdjudicationReasonInfo
-  >;
+  writeIns: readonly WriteInAdjudicationReasonInfo[];
 
   /**
    * Layout of the ballot page being adjudicated. The number of contests in this

--- a/libs/ballot-interpreter-nh/src/convert.test.ts
+++ b/libs/ballot-interpreter-nh/src/convert.test.ts
@@ -250,7 +250,7 @@ test('default adjudication reasons', async () => {
     typedAs<AdjudicationReason[]>([
       AdjudicationReason.UninterpretableBallot,
       AdjudicationReason.Overvote,
-      AdjudicationReason.WriteIn,
+      AdjudicationReason.MarkedWriteIn,
       AdjudicationReason.BlankBallot,
     ])
   );

--- a/libs/ballot-interpreter-nh/src/convert.ts
+++ b/libs/ballot-interpreter-nh/src/convert.ts
@@ -415,7 +415,7 @@ export function convertElectionDefinitionHeader(
     centralScanAdjudicationReasons: [
       AdjudicationReason.UninterpretableBallot,
       AdjudicationReason.Overvote,
-      AdjudicationReason.WriteIn,
+      AdjudicationReason.MarkedWriteIn,
       AdjudicationReason.BlankBallot,
     ],
     precinctScanAdjudicationReasons: [

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -429,7 +429,7 @@ export enum AdjudicationReason {
   MarginalMark = 'MarginalMark',
   Overvote = 'Overvote',
   Undervote = 'Undervote',
-  WriteIn = 'WriteIn',
+  MarkedWriteIn = 'WriteIn',
   UnmarkedWriteIn = 'UnmarkedWriteIn',
   BlankBallot = 'BlankBallot',
 }
@@ -900,27 +900,44 @@ export const UndervoteAdjudicationReasonInfoSchema: z.ZodSchema<UndervoteAdjudic
   }
 );
 
-export interface WriteInAdjudicationReasonInfo {
-  type: AdjudicationReason.WriteIn;
+/**
+ * Information about a write-in whose target was determined to be marked, i.e.
+ * the voter filled in the write-in bubble enough for it to count.
+ */
+export interface MarkedWriteInAdjudicationReasonInfo {
+  type: AdjudicationReason.MarkedWriteIn;
   contestId: ContestId;
   optionId: ContestOptionId;
   optionIndex: number;
 }
-export const WriteInAdjudicationReasonInfoSchema: z.ZodSchema<WriteInAdjudicationReasonInfo> = z.object(
+
+/**
+ * Schema for {@link MarkedWriteInAdjudicationReasonInfo}.
+ */
+export const MarkedWriteInAdjudicationReasonInfoSchema: z.ZodSchema<MarkedWriteInAdjudicationReasonInfo> = z.object(
   {
-    type: z.literal(AdjudicationReason.WriteIn),
+    type: z.literal(AdjudicationReason.MarkedWriteIn),
     contestId: ContestIdSchema,
     optionId: WriteInIdSchema,
     optionIndex: z.number().nonnegative(),
   }
 );
 
+/**
+ * Information about a write-in whose target was determined not to be marked
+ * but where there was sufficient marking in the write-in area, i.e. the voter
+ * wrote a name but didn't fill the bubble.
+ */
 export interface UnmarkedWriteInAdjudicationReasonInfo {
   type: AdjudicationReason.UnmarkedWriteIn;
   contestId: ContestId;
   optionId: ContestOptionId;
   optionIndex: number;
 }
+
+/**
+ * Schema for {@link UnmarkedWriteInAdjudicationReasonInfo}.
+ */
 export const UnmarkedWriteInAdjudicationReasonInfoSchema: z.ZodSchema<UnmarkedWriteInAdjudicationReasonInfo> = z.object(
   {
     type: z.literal(AdjudicationReason.UnmarkedWriteIn),
@@ -928,6 +945,23 @@ export const UnmarkedWriteInAdjudicationReasonInfoSchema: z.ZodSchema<UnmarkedWr
     optionId: WriteInIdSchema,
     optionIndex: z.number().nonnegative(),
   }
+);
+
+/**
+ * Information about a write-in, whether explicitly marked or not.
+ */
+export type WriteInAdjudicationReasonInfo =
+  | MarkedWriteInAdjudicationReasonInfo
+  | UnmarkedWriteInAdjudicationReasonInfo;
+
+/**
+ * Schema for {@link WriteInAdjudicationReasonInfo}.
+ */
+export const WriteInAdjudicationReasonInfoSchema: z.ZodSchema<WriteInAdjudicationReasonInfo> = z.union(
+  [
+    MarkedWriteInAdjudicationReasonInfoSchema,
+    UnmarkedWriteInAdjudicationReasonInfoSchema,
+  ]
 );
 
 export interface BlankBallotAdjudicationReasonInfo {
@@ -944,7 +978,7 @@ export type AdjudicationReasonInfo =
   | MarginalMarkAdjudicationReasonInfo
   | OvervoteAdjudicationReasonInfo
   | UndervoteAdjudicationReasonInfo
-  | WriteInAdjudicationReasonInfo
+  | MarkedWriteInAdjudicationReasonInfo
   | UnmarkedWriteInAdjudicationReasonInfo
   | BlankBallotAdjudicationReasonInfo;
 export const AdjudicationReasonInfoSchema: z.ZodSchema<AdjudicationReasonInfo> = z.union(
@@ -953,7 +987,7 @@ export const AdjudicationReasonInfoSchema: z.ZodSchema<AdjudicationReasonInfo> =
     MarginalMarkAdjudicationReasonInfoSchema,
     OvervoteAdjudicationReasonInfoSchema,
     UndervoteAdjudicationReasonInfoSchema,
-    WriteInAdjudicationReasonInfoSchema,
+    MarkedWriteInAdjudicationReasonInfoSchema,
     UnmarkedWriteInAdjudicationReasonInfoSchema,
     BlankBallotAdjudicationReasonInfoSchema,
   ]

--- a/libs/types/src/hmpb.ts
+++ b/libs/types/src/hmpb.ts
@@ -171,7 +171,7 @@ export const MarginalMarkAdjudicationSchema: z.ZodSchema<MarginalMarkAdjudicatio
 
 export interface WriteInMarkAdjudicationMarked {
   readonly type:
-    | AdjudicationReason.WriteIn
+    | AdjudicationReason.MarkedWriteIn
     | AdjudicationReason.UnmarkedWriteIn;
   readonly isMarked: true;
   readonly contestId: Contest['id'];
@@ -181,7 +181,7 @@ export interface WriteInMarkAdjudicationMarked {
 export const WriteInMarkAdjudicationMarkedSchema: z.ZodSchema<WriteInMarkAdjudicationMarked> = z.object(
   {
     type: z.union([
-      z.literal(AdjudicationReason.WriteIn),
+      z.literal(AdjudicationReason.MarkedWriteIn),
       z.literal(AdjudicationReason.UnmarkedWriteIn),
     ]),
     isMarked: z.literal(true),
@@ -193,7 +193,7 @@ export const WriteInMarkAdjudicationMarkedSchema: z.ZodSchema<WriteInMarkAdjudic
 
 export interface WriteInMarkAdjudicationUnmarked {
   readonly type:
-    | AdjudicationReason.WriteIn
+    | AdjudicationReason.MarkedWriteIn
     | AdjudicationReason.UnmarkedWriteIn;
   readonly isMarked: false;
   readonly contestId: Contest['id'];
@@ -202,7 +202,7 @@ export interface WriteInMarkAdjudicationUnmarked {
 export const WriteInMarkAdjudicationUnmarkedSchema: z.ZodSchema<WriteInMarkAdjudicationUnmarked> = z.object(
   {
     type: z.union([
-      z.literal(AdjudicationReason.WriteIn),
+      z.literal(AdjudicationReason.MarkedWriteIn),
       z.literal(AdjudicationReason.UnmarkedWriteIn),
     ]),
     isMarked: z.literal(false),

--- a/libs/utils/src/hmpb/ballot_adjudication_reasons.test.ts
+++ b/libs/utils/src/hmpb/ballot_adjudication_reasons.test.ts
@@ -233,19 +233,19 @@ test('multiple contests with issues', () => {
         optionIndexes: [],
       },
       {
-        type: AdjudicationReason.WriteIn,
+        type: AdjudicationReason.MarkedWriteIn,
         contestId: zooCouncilMammal.id,
         optionId: '__write-in-0',
         optionIndex: 4,
       },
       {
-        type: AdjudicationReason.WriteIn,
+        type: AdjudicationReason.MarkedWriteIn,
         contestId: zooCouncilMammal.id,
         optionId: '__write-in-1',
         optionIndex: 5,
       },
       {
-        type: AdjudicationReason.WriteIn,
+        type: AdjudicationReason.MarkedWriteIn,
         contestId: zooCouncilMammal.id,
         optionId: '__write-in-2',
         optionIndex: 6,
@@ -318,7 +318,7 @@ test('a ballot with just a write-in', () => {
 
   expect(reasons).toContainEqual(
     typedAs<WriteInAdjudicationReasonInfo>({
-      type: AdjudicationReason.WriteIn,
+      type: AdjudicationReason.MarkedWriteIn,
       contestId: zooCouncilMammal.id,
       optionId: '__write-in-0',
       optionIndex: 4,

--- a/libs/utils/src/hmpb/ballot_adjudication_reasons.ts
+++ b/libs/utils/src/hmpb/ballot_adjudication_reasons.ts
@@ -60,7 +60,7 @@ export function* ballotAdjudicationReasons(
 
             if (option.type === 'candidate' && option.isWriteIn) {
               yield {
-                type: AdjudicationReason.WriteIn,
+                type: AdjudicationReason.MarkedWriteIn,
                 contestId: option.contestId,
                 optionId: option.id,
                 optionIndex: option.optionIndex,
@@ -160,7 +160,7 @@ export function adjudicationReasonDescription(
         reason.expected
       } but got ${optionIdsAsSentence(reason.optionIds)}.`;
 
-    case AdjudicationReason.WriteIn:
+    case AdjudicationReason.MarkedWriteIn:
       return `Contest '${reason.contestId}' has a write-in.`;
 
     case AdjudicationReason.UnmarkedWriteIn:

--- a/services/scan/src/build_cast_vote_record.test.ts
+++ b/services/scan/src/build_cast_vote_record.test.ts
@@ -1005,10 +1005,10 @@ test('generates a CVR from an adjudicated write-in', () => {
           },
           adjudicationInfo: {
             requiresAdjudication: true,
-            enabledReasons: [AdjudicationReason.WriteIn],
+            enabledReasons: [AdjudicationReason.MarkedWriteIn],
             enabledReasonInfos: [
               {
-                type: AdjudicationReason.WriteIn,
+                type: AdjudicationReason.MarkedWriteIn,
                 contestId: '2',
                 optionId: '__write-in-0',
                 optionIndex: 3,
@@ -1031,7 +1031,7 @@ test('generates a CVR from an adjudicated write-in', () => {
         contestIds: ['1', '2'],
         markAdjudications: [
           {
-            type: AdjudicationReason.WriteIn,
+            type: AdjudicationReason.MarkedWriteIn,
             contestId: '2',
             optionId: '__write-in-0',
             isMarked: true,

--- a/services/scan/src/build_cast_vote_record.ts
+++ b/services/scan/src/build_cast_vote_record.ts
@@ -165,7 +165,7 @@ export function buildCastVoteRecordVotesEntries(
         if (markAdjudication.isMarked) {
           resolvedOptionIds.push([
             option.contestId,
-            markAdjudication.type === AdjudicationReason.WriteIn ||
+            markAdjudication.type === AdjudicationReason.MarkedWriteIn ||
             markAdjudication.type === AdjudicationReason.UnmarkedWriteIn
               ? `${option.id}-${markAdjudication.name}`
               : option.id,


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
Uses a named union type to reduce some of the duplication in this file.

## Demo Video or Screenshot
n/a

## Testing Plan 
n/a

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
