### PR TITLE
fix(scan): ensure write-in adjudication works front & back

### DIFF
--- a/frontends/bsd/test/render_in_app_context.tsx
+++ b/frontends/bsd/test/render_in_app_context.tsx
@@ -6,7 +6,7 @@ import { MemoryStorage, Storage, usbstick } from '@votingworks/utils';
 import { createMemoryHistory, MemoryHistory } from 'history';
 import React from 'react';
 import { Router } from 'react-router-dom';
-import { AppContext } from '../src/contexts/app_context';
+import { AppContext, AppContextInterface } from '../src/contexts/app_context';
 
 interface RenderInAppContextParams {
   route?: string;
@@ -22,25 +22,51 @@ interface RenderInAppContextParams {
   logger?: Logger;
 }
 
+export function makeAppContext({
+  electionDefinition = testElectionDefinition,
+  machineConfig = {
+    machineId: '0000',
+    codeVersion: 'TEST',
+    bypassAuthentication: true,
+  },
+  usbDriveStatus = usbstick.UsbDriveStatus.absent,
+  usbDriveEject = jest.fn(),
+  storage = new MemoryStorage(),
+  lockMachine = jest.fn(),
+  currentUserSession = { type: 'admin', authenticated: true },
+  logger = new Logger(LogSource.VxCentralScanFrontend),
+}: Partial<AppContextInterface> = {}): AppContextInterface {
+  return {
+    electionDefinition,
+    machineConfig,
+    usbDriveStatus,
+    usbDriveEject,
+    storage,
+    lockMachine,
+    currentUserSession,
+    logger,
+  };
+}
+
 export function renderInAppContext(
   component: React.ReactNode,
   {
     route = '/',
     history = createMemoryHistory({ initialEntries: [route] }),
-    electionDefinition = testElectionDefinition,
+    electionDefinition,
     machineId = '0000',
     bypassAuthentication = true,
-    usbDriveStatus = usbstick.UsbDriveStatus.absent,
-    usbDriveEject = jest.fn(),
-    storage = new MemoryStorage(),
-    lockMachine = jest.fn(),
-    currentUserSession = { type: 'admin', authenticated: true },
-    logger = new Logger(LogSource.VxCentralScanFrontend),
+    usbDriveStatus,
+    usbDriveEject,
+    storage,
+    lockMachine,
+    currentUserSession,
+    logger,
   }: RenderInAppContextParams = {}
 ): RenderResult {
   return testRender(
     <AppContext.Provider
-      value={{
+      value={makeAppContext({
         electionDefinition,
         machineConfig: { machineId, codeVersion: 'TEST', bypassAuthentication },
         usbDriveStatus,
@@ -49,7 +75,7 @@ export function renderInAppContext(
         lockMachine,
         currentUserSession,
         logger,
-      }}
+      })}
     >
       <Router history={history}>{component}</Router>
     </AppContext.Provider>


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
There was an outstanding bug with write-in adjudication where if both the front and back had write-ins to adjudicate _and_ the front had more contests with write-ins than the back then it would crash. Even if the front had the same or fewer it still wouldn't behave correctly, and would instead start at the index of the last contest on the front when adjudicating the back.

The problem was that we were managing the `selectedContestId` at the wrong level of the component hierarchy. This changes it to manage the selected contest ID at the `WriteInAdjudicationScreen` level so that it can reset it properly when finishing a contest rather than letting a stale value from the previous page's contest list stay in state.

## Demo Video or Screenshot

https://user-images.githubusercontent.com/1938/160939334-9527a1e5-0fef-45eb-86ea-ec5a87b987b4.mov



## Testing Plan 
Tested manually, updated automated tests.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
