### PR TITLE
fix(scan): make write-in adjudication work for timing mark ballots

### DIFF
--- a/frontends/bsd/src/components/cropped_image.tsx
+++ b/frontends/bsd/src/components/cropped_image.tsx
@@ -27,5 +27,12 @@ export function CroppedImage({ src, alt, crop, style }: Props): JSX.Element {
     };
   }, [crop.height, crop.width, crop.x, crop.y, src]);
 
-  return <img src={dataUrl} alt={alt} style={style} />;
+  return (
+    <img
+      src={dataUrl}
+      alt={alt}
+      style={style}
+      data-crop={`x=${crop.x}, y=${crop.y}, width=${crop.width}, height=${crop.height}`}
+    />
+  );
 }

--- a/frontends/bsd/src/screens/ballot_eject_screen.tsx
+++ b/frontends/bsd/src/screens/ballot_eject_screen.tsx
@@ -354,6 +354,7 @@ export function BallotEjectScreen({
               );
               return (
                 <WriteInAdjudicationScreen
+                  key={reviewPageInfo.side}
                   sheetId={reviewInfo.interpreted.id}
                   side={reviewPageInfo.side}
                   imageUrl={reviewPageInfo.imageUrl}

--- a/frontends/bsd/src/screens/ballot_eject_screen.tsx
+++ b/frontends/bsd/src/screens/ballot_eject_screen.tsx
@@ -359,7 +359,7 @@ export function BallotEjectScreen({
                   imageUrl={reviewPageInfo.imageUrl}
                   writeIns={writeIns}
                   layout={reviewPageInfo.layout}
-                  contestIds={reviewPageInfo.contestIds}
+                  allContestIds={reviewPageInfo.contestIds}
                   onAdjudicationComplete={onAdjudicationComplete}
                 />
               );

--- a/frontends/bsd/src/screens/write_in_adjudication_screen.test.tsx
+++ b/frontends/bsd/src/screens/write_in_adjudication_screen.test.tsx
@@ -14,7 +14,12 @@ import {
   WriteInIdSchema,
 } from '@votingworks/types';
 
-import { allContestOptions, assert, typedAs } from '@votingworks/utils';
+import {
+  allContestOptions,
+  assert,
+  groupBy,
+  typedAs,
+} from '@votingworks/utils';
 import React from 'react';
 import { makeAppContext } from '../../test/render_in_app_context';
 import { AppContext } from '../contexts/app_context';
@@ -404,4 +409,102 @@ test('can adjudicate front & back in succession', async () => {
   await waitFor(() => {
     expect(onAdjudicationComplete).toHaveBeenCalledTimes(2);
   });
+});
+
+test('uses the layout embedded definition to crop the ballot image correctly if available', async () => {
+  const [contest] = contestsWithWriteIns.filter(({ seats }) => seats > 1);
+  const options = Array.from(allContestOptions(contest));
+  const optionsByIsWriteIn = groupBy(
+    options,
+    (option) => option.type === 'candidate' && option.isWriteIn
+  );
+  const maximumWriteInOptionIndex = Math.max(
+    ...Array.from(optionsByIsWriteIn.get(true)!).map(
+      ({ optionIndex }) => optionIndex
+    )
+  );
+  const optionsWithReversedWriteIns = [...options].sort((a, b) => {
+    if (a.type !== 'candidate' || b.type !== 'candidate') {
+      return -1;
+    }
+
+    if (a.isWriteIn !== b.isWriteIn) {
+      return -1;
+    }
+
+    return b.optionIndex - a.optionIndex;
+  });
+
+  // Use the first write-in space, which is the last one in the definition list.
+  const writeInOption = optionsWithReversedWriteIns.find(
+    (option) => option.type === 'candidate' && option.isWriteIn
+  )!;
+  const onAdjudicationComplete = jest
+    .fn<
+      ReturnType<onAdjudicationCompleteType>,
+      Parameters<onAdjudicationCompleteType>
+    >()
+    .mockResolvedValue();
+
+  const writeIns: Array<
+    WriteInAdjudicationReasonInfo | UnmarkedWriteInAdjudicationReasonInfo
+  > = [
+    {
+      type: AdjudicationReason.WriteIn,
+      contestId: writeInOption.contestId,
+      optionId: writeInOption.id,
+      // You'd expect this to be `writeInOption.optionIndex`, but because
+      // `allContestOptions` doesn't know the write-ins are reversed, it will
+      // return the write-in options in the wrong order. So this is set to the
+      // last write-in option index because that's where `allContestOptions`
+      // puts the write-in we're looking for.
+      optionIndex: maximumWriteInOptionIndex,
+    },
+  ];
+
+  const layout: BallotPageLayout = {
+    pageSize: { width: 1, height: 1 },
+    metadata: buildMetadata({ pageNumber: 1 }),
+    contests: [
+      {
+        bounds: { x: 0, y: 0, width: 100, height: 100 },
+        corners: [
+          { x: 0, y: 0 },
+          { x: 100, y: 0 },
+          { x: 100, y: 100 },
+          { x: 0, y: 100 },
+        ],
+        options: optionsWithReversedWriteIns.map((option, i) => ({
+          definition: option,
+          bounds: { x: 0, y: 200 + 50 * i, width: 100, height: 50 },
+          target: {
+            bounds: { x: 20, y: 200 + 50 * i + 10, width: 20, height: 10 },
+            inner: { x: 22, y: 200 + 50 * i + 12, width: 16, height: 6 },
+          },
+        })),
+      },
+    ],
+  };
+
+  render(
+    <AppContext.Provider value={makeAppContext()}>
+      <WriteInAdjudicationScreen
+        sheetId="test-sheet"
+        side="front"
+        imageUrl="/test-sheet/front.jpg"
+        writeIns={writeIns}
+        layout={layout}
+        allContestIds={[contest.id]}
+        onAdjudicationComplete={onAdjudicationComplete}
+      />
+    </AppContext.Provider>
+  );
+
+  screen.getByText('Write-In Adjudication');
+  screen.getByText(contest.title);
+
+  const writeInImage = screen.getByAltText('write-in area');
+  expect(writeInImage.dataset.crop).toMatchInlineSnapshot(
+    `"x=0, y=185, width=100, height=80"`
+  );
 });

--- a/frontends/bsd/src/screens/write_in_adjudication_screen.test.tsx
+++ b/frontends/bsd/src/screens/write_in_adjudication_screen.test.tsx
@@ -109,7 +109,7 @@ test('supports typing in a candidate name', async () => {
         imageUrl="/test-sheet/front.jpg"
         writeIns={writeIns}
         layout={layout}
-        contestIds={[contest.id]}
+        allContestIds={[contest.id]}
         onAdjudicationComplete={onAdjudicationComplete}
       />
     </AppContext.Provider>
@@ -199,7 +199,7 @@ test('supports canceling a write-in', async () => {
         imageUrl="/test-sheet/front.jpg"
         writeIns={writeIns}
         layout={layout}
-        contestIds={[contest.id]}
+        allContestIds={[contest.id]}
         onAdjudicationComplete={onAdjudicationComplete}
       />
     </AppContext.Provider>
@@ -339,7 +339,7 @@ test('can adjudicate front & back in succession', async () => {
         imageUrl="/test-sheet/front.jpg"
         writeIns={frontWriteIns}
         layout={frontLayout}
-        contestIds={[frontContest1.id, frontContest2.id]}
+        allContestIds={[frontContest1.id, frontContest2.id]}
         onAdjudicationComplete={onAdjudicationComplete}
       />
     </AppContext.Provider>
@@ -381,7 +381,7 @@ test('can adjudicate front & back in succession', async () => {
         imageUrl="/test-sheet/back.jpg"
         writeIns={backWriteIns}
         layout={backLayout}
-        contestIds={[backContest.id]}
+        allContestIds={[backContest.id]}
         onAdjudicationComplete={onAdjudicationComplete}
       />
     </AppContext.Provider>

--- a/frontends/bsd/src/screens/write_in_adjudication_screen.test.tsx
+++ b/frontends/bsd/src/screens/write_in_adjudication_screen.test.tsx
@@ -109,6 +109,7 @@ test('supports typing in a candidate name', async () => {
   render(
     <AppContext.Provider value={makeAppContext()}>
       <WriteInAdjudicationScreen
+        key="front"
         sheetId="test-sheet"
         side="front"
         imageUrl="/test-sheet/front.jpg"
@@ -199,6 +200,7 @@ test('supports canceling a write-in', async () => {
   render(
     <AppContext.Provider value={makeAppContext()}>
       <WriteInAdjudicationScreen
+        key="front"
         sheetId="test-sheet"
         side="front"
         imageUrl="/test-sheet/front.jpg"
@@ -339,6 +341,7 @@ test('can adjudicate front & back in succession', async () => {
   const { rerender } = render(
     <AppContext.Provider value={appContext}>
       <WriteInAdjudicationScreen
+        key="front"
         sheetId="test-sheet"
         side="front"
         imageUrl="/test-sheet/front.jpg"
@@ -381,6 +384,7 @@ test('can adjudicate front & back in succession', async () => {
   rerender(
     <AppContext.Provider value={appContext}>
       <WriteInAdjudicationScreen
+        key="back"
         sheetId="test-sheet"
         side="back"
         imageUrl="/test-sheet/back.jpg"
@@ -489,6 +493,7 @@ test('uses the layout embedded definition to crop the ballot image correctly if 
   render(
     <AppContext.Provider value={makeAppContext()}>
       <WriteInAdjudicationScreen
+        key="front"
         sheetId="test-sheet"
         side="front"
         imageUrl="/test-sheet/front.jpg"

--- a/frontends/bsd/src/screens/write_in_adjudication_screen.tsx
+++ b/frontends/bsd/src/screens/write_in_adjudication_screen.tsx
@@ -409,14 +409,43 @@ function ContestAdjudication({
 }
 
 export interface Props {
+  /**
+   * Database ID of the sheet being adjudicated.
+   */
   sheetId: string;
+
+  /**
+   * Which side of the sheet being adjudicated.
+   */
   side: Side;
+
+  /**
+   * URL of the image to the whole ballot page being adjudicated.
+   */
   imageUrl: string;
+
+  /**
+   * All write-ins flagged for adjudication on this page.
+   */
   writeIns: ReadonlyArray<
     WriteInAdjudicationReasonInfo | UnmarkedWriteInAdjudicationReasonInfo
   >;
+
+  /**
+   * Layout of the ballot page being adjudicated. The number of contests in this
+   * layout must match the number of contests in `allContestIds`.
+   */
   layout: BallotPageLayout;
-  contestIds: readonly ContestId[];
+
+  /**
+   * Contest IDs for every contest on this page, even those without write-ins.
+   */
+  allContestIds: readonly ContestId[];
+
+  /**
+   * Callback for when every contest with write-ins has been adjudicated and
+   * the user has chosen to save their adjudication.
+   */
   onAdjudicationComplete?(
     sheetId: string,
     side: Side,
@@ -430,7 +459,7 @@ export function WriteInAdjudicationScreen({
   imageUrl,
   writeIns,
   layout,
-  contestIds,
+  allContestIds,
   onAdjudicationComplete,
 }: Props): JSX.Element {
   const { electionDefinition, storage } = useContext(AppContext);
@@ -443,11 +472,10 @@ export function WriteInAdjudicationScreen({
   const [selectedContestId, setSelectedContestId] = useState<ContestId>();
   const [isSaving, setIsSaving] = useState(false);
 
-  const contestsWithWriteIns = useMemo(
-    () => new Set([...writeIns].map(({ contestId }) => contestId)),
+  const contestsWithWriteInsIds = useMemo(
+    () => uniq([...writeIns].map(({ contestId }) => contestId)),
     [writeIns]
   );
-  const contestsWithWriteInsCount = contestsWithWriteIns.size;
   const styleForContest = useCallback(
     (contestId: ContestId): React.CSSProperties => {
       return contestId === selectedContestId
@@ -502,13 +530,15 @@ export function WriteInAdjudicationScreen({
     await onAdjudicationComplete?.(sheetId, side, adjudications);
   }, [adjudications, onAdjudicationComplete, setWriteInPresets, sheetId, side]);
 
-  const selectedContestIdOrDefault = selectedContestId ?? contestIds[0];
-  const selectedContestIndex = contestIds.indexOf(selectedContestIdOrDefault);
-  const isFirstContestSelected = selectedContestIndex === 0;
+  const selectedContestIdOrDefault =
+    selectedContestId ?? contestsWithWriteInsIds[0];
+  const isFirstContestSelected =
+    selectedContestIdOrDefault === contestsWithWriteInsIds[0];
   const isLastContestSelected =
-    selectedContestIndex === contestsWithWriteInsCount - 1;
+    selectedContestIdOrDefault ===
+    contestsWithWriteInsIds[contestsWithWriteInsIds.length - 1];
 
-  const contestsWithWriteInsIndex = [...contestsWithWriteIns].findIndex(
+  const contestsWithWriteInsIndex = [...contestsWithWriteInsIds].findIndex(
     (id) => id === selectedContestIdOrDefault
   );
   const contest = find(
@@ -518,7 +548,8 @@ export function WriteInAdjudicationScreen({
   const writeInsForContest = writeIns.filter(
     (writeIn) => writeIn.contestId === selectedContestIdOrDefault
   );
-  const contestLayout = layout.contests[selectedContestIndex];
+  const contestLayout =
+    layout.contests[allContestIds.indexOf(selectedContestIdOrDefault)];
   const allWriteInsHaveValues = writeInsForContest.every((writeIn) =>
     adjudications.some(
       (adjudication) =>
@@ -529,8 +560,12 @@ export function WriteInAdjudicationScreen({
   );
 
   const goPrevious = useCallback(() => {
-    setSelectedContestId(contestIds[selectedContestIndex - 1]);
-  }, [contestIds, selectedContestIndex]);
+    setSelectedContestId(
+      contestsWithWriteInsIds[
+        contestsWithWriteInsIds.indexOf(selectedContestIdOrDefault) - 1
+      ]
+    );
+  }, [contestsWithWriteInsIds, selectedContestIdOrDefault]);
 
   const goNext = useCallback(
     async (event?: React.FormEvent<EventTarget>): Promise<void> => {
@@ -543,15 +578,19 @@ export function WriteInAdjudicationScreen({
           setIsSaving(false);
         }
       } else {
-        setSelectedContestId(contestIds[selectedContestIndex + 1]);
+        setSelectedContestId(
+          contestsWithWriteInsIds[
+            contestsWithWriteInsIds.indexOf(selectedContestIdOrDefault) + 1
+          ]
+        );
       }
     },
     [
-      contestIds,
+      contestsWithWriteInsIds,
       isLastContestSelected,
       makeCancelable,
       onAdjudicationCompleteInternal,
-      selectedContestIndex,
+      selectedContestIdOrDefault,
     ]
   );
 
@@ -590,7 +629,7 @@ export function WriteInAdjudicationScreen({
                 <Spacer />
                 <Text small style={{ marginLeft: '10px' }}>
                   Contest {contestsWithWriteInsIndex + 1} of{' '}
-                  {contestsWithWriteInsCount}
+                  {contestsWithWriteInsIds.length}
                 </Text>
                 <Spacer />
                 <Button onPress={goPrevious} disabled={isFirstContestSelected}>
@@ -602,7 +641,7 @@ export function WriteInAdjudicationScreen({
           <BallotSheetImage
             imageUrl={imageUrl}
             layout={layout}
-            contestIds={contestIds}
+            contestIds={allContestIds}
             styleForContest={styleForContest}
           />
         </MainChildColumns>

--- a/frontends/bsd/src/screens/write_in_adjudication_screen.tsx
+++ b/frontends/bsd/src/screens/write_in_adjudication_screen.tsx
@@ -541,8 +541,8 @@ export function WriteInAdjudicationScreen({
     selectedContestIdOrDefault ===
     contestsWithWriteInsIds[contestsWithWriteInsIds.length - 1];
 
-  const contestsWithWriteInsIndex = [...contestsWithWriteInsIds].findIndex(
-    (id) => id === selectedContestIdOrDefault
+  const selectedContestIdOrDefaultIndex = contestsWithWriteInsIds.indexOf(
+    selectedContestIdOrDefault
   );
   const contest = find(
     electionDefinition.election.contests,
@@ -564,11 +564,9 @@ export function WriteInAdjudicationScreen({
 
   const goPrevious = useCallback(() => {
     setSelectedContestId(
-      contestsWithWriteInsIds[
-        contestsWithWriteInsIds.indexOf(selectedContestIdOrDefault) - 1
-      ]
+      contestsWithWriteInsIds[selectedContestIdOrDefaultIndex - 1]
     );
-  }, [contestsWithWriteInsIds, selectedContestIdOrDefault]);
+  }, [contestsWithWriteInsIds, selectedContestIdOrDefaultIndex]);
 
   const goNext = useCallback(
     async (event?: React.FormEvent<EventTarget>): Promise<void> => {
@@ -582,18 +580,16 @@ export function WriteInAdjudicationScreen({
         }
       } else {
         setSelectedContestId(
-          contestsWithWriteInsIds[
-            contestsWithWriteInsIds.indexOf(selectedContestIdOrDefault) + 1
-          ]
+          contestsWithWriteInsIds[selectedContestIdOrDefaultIndex + 1]
         );
       }
     },
     [
       contestsWithWriteInsIds,
+      selectedContestIdOrDefaultIndex,
       isLastContestSelected,
       makeCancelable,
       onAdjudicationCompleteInternal,
-      selectedContestIdOrDefault,
     ]
   );
 
@@ -631,7 +627,7 @@ export function WriteInAdjudicationScreen({
                 </Button>
                 <Spacer />
                 <Text small style={{ marginLeft: '10px' }}>
-                  Contest {contestsWithWriteInsIndex + 1} of{' '}
+                  Contest {selectedContestIdOrDefaultIndex + 1} of{' '}
                   {contestsWithWriteInsIds.length}
                 </Text>
                 <Spacer />

--- a/frontends/bsd/src/screens/write_in_adjudication_screen.tsx
+++ b/frontends/bsd/src/screens/write_in_adjudication_screen.tsx
@@ -540,9 +540,6 @@ export function WriteInAdjudicationScreen({
     selectedContestId ===
     contestsWithWriteInsIds[contestsWithWriteInsIds.length - 1];
 
-  const selectedContestIdOrDefaultIndex = contestsWithWriteInsIds.indexOf(
-    selectedContestId
-  );
   const contest = find(
     electionDefinition.election.contests,
     (c): c is CandidateContest => c.id === selectedContestId
@@ -616,7 +613,7 @@ export function WriteInAdjudicationScreen({
                 </Button>
                 <Spacer />
                 <Text small style={{ marginLeft: '10px' }}>
-                  Contest {selectedContestIdOrDefaultIndex + 1} of{' '}
+                  Contest {selectedContestIndex + 1} of{' '}
                   {contestsWithWriteInsIds.length}
                 </Text>
                 <Spacer />

--- a/frontends/bsd/src/screens/write_in_adjudication_screen.tsx
+++ b/frontends/bsd/src/screens/write_in_adjudication_screen.tsx
@@ -248,7 +248,10 @@ function ContestOptionAdjudication({
   writeInPresets,
 }: ContestOptionAdjudicationProps): JSX.Element {
   const writeInIndex = writeIn.optionIndex;
-  const { bounds } = layout.options[writeInIndex];
+  const { bounds } =
+    layout.options.find(
+      ({ definition }) => definition?.optionIndex === writeIn.optionIndex
+    ) ?? layout.options[writeInIndex];
   const adjudication = adjudications.find(
     ({ contestId, optionId }) =>
       contestId === writeIn.contestId && optionId === writeIn.optionId

--- a/libs/ballot-interpreter-nh/src/index.ts
+++ b/libs/ballot-interpreter-nh/src/index.ts
@@ -3,3 +3,4 @@
 export { convertElectionDefinition } from './convert';
 export * as templates from './data/templates';
 export { interpret } from './interpret';
+export * from './layout';

--- a/libs/ballot-interpreter-nh/src/layout.test.ts
+++ b/libs/ballot-interpreter-nh/src/layout.test.ts
@@ -3,7 +3,6 @@ import {
   BallotType,
   safeParseElectionDefinition,
 } from '@votingworks/types';
-import { join } from 'path';
 import {
   HudsonFixtureName,
   readFixtureImage,
@@ -44,16 +43,6 @@ test('generateBallotPageLayouts', async () => {
     electionHash: electionDefinition.electionHash,
     locales: { primary: 'en-US' },
   }).unsafeUnwrap();
-
-  await (
-    await import('fs')
-  ).promises.writeFile(
-    join(
-      __dirname,
-      'layout.test.ts-debug-generateLayoutForVxCentralScan-layout.json'
-    ),
-    JSON.stringify(layout, null, 2)
-  );
 
   expect(layout).toHaveLength(2 /* front and back */);
   const [frontLayout, backLayout] = layout as [

--- a/libs/ballot-interpreter-nh/src/layout.test.ts
+++ b/libs/ballot-interpreter-nh/src/layout.test.ts
@@ -4,10 +4,13 @@ import {
   safeParseElectionDefinition,
 } from '@votingworks/types';
 import { join } from 'path';
-import { HudsonFixtureName, readFixtureJson } from '../test/fixtures';
+import {
+  HudsonFixtureName,
+  readFixtureImage,
+  readFixtureJson,
+} from '../test/fixtures';
 import { ScannedBallotCardGeometry8pt5x14 } from './accuvote';
 import { withCanvasDebugger } from './debug';
-import { readGrayscaleImage } from './images';
 import {
   generateBallotPageLayouts,
   layoutTimingMarksForGeometry,
@@ -72,15 +75,12 @@ test('generateBallotPageLayouts', async () => {
   );
 
   // Uncomment this to write debug images for each contest & option:
-  (await import('./debug')).setDebug(true);
+  // (await import('./debug')).setDebug(true);
 
-  const frontImageData = await readGrayscaleImage(
-    '/home/brian/src/vxsuite/services/scan/dev-workspace/ballot-images/batch-d3f53f9b-b25a-4c29-9333-4abb6894ac12/20220302_153423-ballot-0001.jpeg'
+  const frontImageData = await readFixtureImage(
+    HudsonFixtureName,
+    'scan-marked-front'
   );
-  // const frontImageData = await readFixtureImage(
-  //   HudsonFixtureName,
-  //   'scan-marked-front'
-  // );
 
   for (const contest of frontLayout.contests) {
     withCanvasDebugger(contest.bounds.width, contest.bounds.height, (debug) => {

--- a/libs/ballot-interpreter-nh/src/layout.test.ts
+++ b/libs/ballot-interpreter-nh/src/layout.test.ts
@@ -1,0 +1,96 @@
+import {
+  BallotPageLayout,
+  BallotType,
+  safeParseElectionDefinition,
+} from '@votingworks/types';
+import { join } from 'path';
+import { HudsonFixtureName, readFixtureJson } from '../test/fixtures';
+import { ScannedBallotCardGeometry8pt5x14 } from './accuvote';
+import { withCanvasDebugger } from './debug';
+import { readGrayscaleImage } from './images';
+import {
+  generateBallotPageLayouts,
+  layoutTimingMarksForGeometry,
+} from './layout';
+
+test('layoutTimingMarksForGeometry', () => {
+  const layout = layoutTimingMarksForGeometry(ScannedBallotCardGeometry8pt5x14);
+  expect(layout.left).toHaveLength(
+    ScannedBallotCardGeometry8pt5x14.gridSize.height
+  );
+  expect(layout.right).toHaveLength(
+    ScannedBallotCardGeometry8pt5x14.gridSize.height
+  );
+  expect(layout.top).toHaveLength(
+    ScannedBallotCardGeometry8pt5x14.gridSize.width
+  );
+  expect(layout.bottom).toHaveLength(
+    ScannedBallotCardGeometry8pt5x14.gridSize.width
+  );
+});
+
+test('generateBallotPageLayouts', async () => {
+  const electionDefinition = safeParseElectionDefinition(
+    await readFixtureJson(HudsonFixtureName, 'election')
+  ).unsafeUnwrap();
+  const layout = generateBallotPageLayouts(electionDefinition.election, {
+    ballotStyleId: electionDefinition.election.ballotStyles[0]!.id,
+    precinctId: electionDefinition.election.precincts[0]!.id,
+    ballotType: BallotType.Standard,
+    isTestMode: true,
+    electionHash: electionDefinition.electionHash,
+    locales: { primary: 'en-US' },
+  }).unsafeUnwrap();
+
+  await (
+    await import('fs')
+  ).promises.writeFile(
+    join(
+      __dirname,
+      'layout.test.ts-debug-generateLayoutForVxCentralScan-layout.json'
+    ),
+    JSON.stringify(layout, null, 2)
+  );
+
+  expect(layout).toHaveLength(2 /* front and back */);
+  const [frontLayout, backLayout] = layout as [
+    BallotPageLayout,
+    BallotPageLayout
+  ];
+  expect(frontLayout.metadata.pageNumber).toEqual(1);
+  expect(backLayout.metadata.pageNumber).toEqual(2);
+  expect(frontLayout.contests).toHaveLength(
+    7 /* president, governor, senator, representative, councilor, state senator, state representative */
+  );
+  expect(backLayout.contests).toHaveLength(
+    6 /* sheriff, attorney, treasurer, register of deeds, register of probate, county commissioner */
+  );
+
+  const president = frontLayout.contests[0]!;
+  expect(president.options).toHaveLength(
+    4 /* trump, biden, jorgensen, write-in */
+  );
+
+  // Uncomment this to write debug images for each contest & option:
+  (await import('./debug')).setDebug(true);
+
+  const frontImageData = await readGrayscaleImage(
+    '/home/brian/src/vxsuite/services/scan/dev-workspace/ballot-images/batch-d3f53f9b-b25a-4c29-9333-4abb6894ac12/20220302_153423-ballot-0001.jpeg'
+  );
+  // const frontImageData = await readFixtureImage(
+  //   HudsonFixtureName,
+  //   'scan-marked-front'
+  // );
+
+  for (const contest of frontLayout.contests) {
+    withCanvasDebugger(contest.bounds.width, contest.bounds.height, (debug) => {
+      debug.imageData(-contest.bounds.x, -contest.bounds.y, frontImageData);
+    });
+
+    for (const option of contest.options) {
+      withCanvasDebugger(option.bounds.width, option.bounds.height, (debug) => {
+        debug.imageData(-option.bounds.x, -option.bounds.y, frontImageData);
+      });
+    }
+  }
+});

--- a/libs/ballot-interpreter-nh/src/layout.ts
+++ b/libs/ballot-interpreter-nh/src/layout.ts
@@ -1,0 +1,298 @@
+import {
+  BallotMetadata,
+  BallotPageContestLayout,
+  BallotPageContestOptionLayout,
+  BallotPageLayout,
+  Election,
+  err,
+  ok,
+  Result,
+} from '@votingworks/types';
+import { assert, groupBy } from '@votingworks/utils';
+import { BallotCardGeometry, getScannedBallotCardGeometry } from './accuvote';
+import { computeTimingMarkGrid } from './timing_marks';
+import { CompleteTimingMarks, Point, Rect, Size, Vector } from './types';
+import { makeRect, vec } from './utils';
+
+function timingMarkAt(x: number, y: number, timingMarkSize: Size): Rect {
+  return makeRect({
+    minX: x,
+    minY: y,
+    maxX: x + timingMarkSize.width - 1,
+    maxY: y + timingMarkSize.height - 1,
+  });
+}
+
+/**
+ * Generates a timing mark layout for a ballot card geometry.
+ */
+export function layoutTimingMarksForGeometry({
+  contentArea,
+  gridSize,
+  timingMarkSize,
+}: BallotCardGeometry): CompleteTimingMarks {
+  const timingMarkGapSize: Size = {
+    width: timingMarkSize.height,
+    height: timingMarkSize.width,
+  };
+  const maximumHorizontalTimingMarkCount = gridSize.width;
+  const maximumVerticalTimingMarkCount = gridSize.height;
+
+  assert(
+    maximumHorizontalTimingMarkCount > 1,
+    `the ballot card is too small to contain horizontal timing marks`
+  );
+  assert(
+    maximumVerticalTimingMarkCount > 1,
+    `the ballot card is too small to contain vertical timing marks`
+  );
+
+  const remainingHorizontalSpace =
+    contentArea.width -
+    (maximumHorizontalTimingMarkCount * timingMarkSize.width +
+      (maximumHorizontalTimingMarkCount - 1) * timingMarkGapSize.width);
+  const remainingVerticalSpace =
+    contentArea.height -
+    (maximumVerticalTimingMarkCount * timingMarkSize.height +
+      (maximumVerticalTimingMarkCount - 1) * timingMarkGapSize.height);
+
+  assert(remainingHorizontalSpace >= 0, `the ballot card is too small`);
+  assert(remainingVerticalSpace >= 0, `the ballot card is too small`);
+
+  const horizontalInsetLeft = Math.floor(remainingHorizontalSpace / 2);
+  const verticalInsetTop = Math.floor(remainingVerticalSpace / 2);
+
+  const topLeft = timingMarkAt(
+    contentArea.minX + horizontalInsetLeft,
+    contentArea.minY + verticalInsetTop,
+    timingMarkSize
+  );
+  const topRight = timingMarkAt(
+    contentArea.maxX +
+      1 -
+      (remainingHorizontalSpace - horizontalInsetLeft) -
+      timingMarkSize.width,
+    contentArea.minY + verticalInsetTop,
+    timingMarkSize
+  );
+  const bottomLeft = timingMarkAt(
+    topLeft.x,
+    contentArea.maxY +
+      1 -
+      (remainingVerticalSpace - verticalInsetTop) -
+      timingMarkSize.height,
+    timingMarkSize
+  );
+  const bottomRight = timingMarkAt(topRight.x, bottomLeft.y, timingMarkSize);
+
+  assert(
+    topLeft.x +
+      (maximumHorizontalTimingMarkCount - 1) *
+        (timingMarkSize.width + timingMarkGapSize.width) ===
+      topRight.x,
+    `the timing marks are not evenly spaced horizontally: ${topLeft.x} + ${
+      maximumHorizontalTimingMarkCount - 1
+    } * ${timingMarkSize.width + timingMarkGapSize.width} (${
+      topLeft.x +
+      (maximumHorizontalTimingMarkCount - 1) *
+        (timingMarkSize.width + timingMarkGapSize.width)
+    }) !== ${topRight.x}`
+  );
+  assert(
+    topLeft.y +
+      (maximumVerticalTimingMarkCount - 1) *
+        (timingMarkSize.height + timingMarkGapSize.height) ===
+      bottomLeft.y,
+    `the timing marks are not evenly spaced vertically: ${topLeft.y} + ${
+      maximumVerticalTimingMarkCount - 1
+    } * ${timingMarkSize.height + timingMarkGapSize.height} (${
+      topLeft.y +
+      (maximumVerticalTimingMarkCount - 1) *
+        (timingMarkSize.height + timingMarkGapSize.height)
+    }) != ${bottomLeft.y}`
+  );
+
+  const topWithoutCorners: Rect[] = [];
+  const bottomWithoutCorners: Rect[] = [];
+
+  for (
+    let x = topLeft.x + timingMarkSize.width + timingMarkGapSize.width;
+    x < topRight.x;
+    x += timingMarkSize.width + timingMarkGapSize.width
+  ) {
+    topWithoutCorners.push(timingMarkAt(x, topLeft.y, timingMarkSize));
+    bottomWithoutCorners.push(timingMarkAt(x, bottomLeft.y, timingMarkSize));
+  }
+
+  const leftWithoutCorners: Rect[] = [];
+  const rightWithoutCorners: Rect[] = [];
+
+  for (
+    let y = topLeft.y + timingMarkSize.height + timingMarkGapSize.height;
+    y < bottomLeft.y;
+    y += timingMarkSize.height + timingMarkGapSize.height
+  ) {
+    leftWithoutCorners.push(timingMarkAt(topLeft.x, y, timingMarkSize));
+    rightWithoutCorners.push(timingMarkAt(topRight.x, y, timingMarkSize));
+  }
+
+  return {
+    topLeft,
+    topRight,
+    bottomLeft,
+    bottomRight,
+    left: [topLeft, ...leftWithoutCorners, bottomLeft],
+    right: [topRight, ...rightWithoutCorners, bottomRight],
+    top: [topLeft, ...topWithoutCorners, topRight],
+    bottom: [bottomLeft, ...bottomWithoutCorners, bottomRight],
+  };
+}
+
+const EstimatedOptionGridAreaSize: Size = {
+  width: 7,
+  height: 3,
+};
+const EstimatedOptionGridOriginOffset = vec(-6, -1);
+
+/**
+ * Generate ballot page layouts for VxCentralScan adjudication compatibility.
+ */
+export function generateBallotPageLayouts(
+  election: Election,
+  metadata: BallotMetadata,
+  {
+    optionGridSize = EstimatedOptionGridAreaSize,
+    optionGridOriginOffset = EstimatedOptionGridOriginOffset,
+  }: { optionGridSize?: Size; optionGridOriginOffset?: Vector } = {}
+): Result<BallotPageLayout[], Error> {
+  const paperSize = election.ballotLayout?.paperSize;
+
+  if (!paperSize) {
+    return err(new Error('paper size is missing'));
+  }
+
+  const gridLayout = election.gridLayouts?.find(
+    (l) =>
+      l.ballotStyleId === metadata.ballotStyleId &&
+      l.precinctId === metadata.precinctId
+  );
+
+  if (!gridLayout) {
+    return err(
+      new Error(
+        `no grid layout found for ballot style '${metadata.ballotStyleId}' and precinct '${metadata.precinctId}'`
+      )
+    );
+  }
+
+  const geometry = getScannedBallotCardGeometry(paperSize);
+  const timingMarks = layoutTimingMarksForGeometry(geometry);
+  const timingMarkGrid = computeTimingMarkGrid(timingMarks);
+  const layouts: BallotPageLayout[] = [];
+
+  const frontGridPositions = gridLayout.gridPositions.filter(
+    ({ side }) => side === 'front'
+  );
+  const backGridPositions = gridLayout.gridPositions.filter(
+    ({ side }) => side === 'back'
+  );
+
+  const frontGridPositionsByContest = groupBy(
+    frontGridPositions,
+    ({ contestId }) => contestId
+  );
+  const backGridPositionsByContest = groupBy(
+    backGridPositions,
+    ({ contestId }) => contestId
+  );
+
+  function clampRow(row: number): number {
+    return Math.max(0, Math.min(row, geometry.gridSize.height - 1));
+  }
+
+  function clampColumn(column: number): number {
+    return Math.max(0, Math.min(column, geometry.gridSize.width - 1));
+  }
+
+  for (const [i, gridPositionsByContestId] of [
+    frontGridPositionsByContest,
+    backGridPositionsByContest,
+  ].entries()) {
+    const contests: BallotPageContestLayout[] = [];
+
+    for (const gridPositions of gridPositionsByContestId.values()) {
+      const options: BallotPageContestOptionLayout[] = [];
+
+      for (const gridPosition of Array.from(gridPositions)) {
+        const optionTopLeft = timingMarkGrid.rows[
+          clampRow(gridPosition.row + optionGridOriginOffset.y)
+        ]?.[
+          clampColumn(gridPosition.column + optionGridOriginOffset.x)
+        ] as Point;
+        const optionBottomRight = timingMarkGrid.rows[
+          clampRow(
+            gridPosition.row + optionGridOriginOffset.y + optionGridSize.height
+          )
+        ]?.[
+          clampColumn(
+            gridPosition.column +
+              optionGridOriginOffset.x +
+              optionGridSize.width
+          )
+        ] as Point;
+        const ovalCenter = timingMarkGrid.rows[gridPosition.row]?.[
+          gridPosition.column
+        ] as Point;
+
+        const optionBounds = makeRect({
+          minX: optionTopLeft.x,
+          minY: optionTopLeft.y,
+          maxX: optionBottomRight.x,
+          maxY: optionBottomRight.y,
+        });
+        const targetBounds = makeRect({
+          minX: Math.round(ovalCenter.x - geometry.ovalSize.width / 2),
+          minY: Math.round(ovalCenter.y - geometry.ovalSize.height / 2),
+          maxX: Math.round(ovalCenter.x + geometry.ovalSize.width / 2),
+          maxY: Math.round(ovalCenter.y + geometry.ovalSize.height / 2),
+        });
+        options.push({
+          bounds: optionBounds,
+          target: {
+            bounds: targetBounds,
+            inner: targetBounds,
+          },
+        });
+      }
+
+      const minX = Math.min(...options.map((o) => o.bounds.x));
+      const minY = Math.min(...options.map((o) => o.bounds.y));
+      const maxX = Math.max(
+        ...options.map((o) => o.bounds.x + o.bounds.width - 1)
+      );
+      const maxY = Math.max(
+        ...options.map((o) => o.bounds.y + o.bounds.height - 1)
+      );
+      const bounds = makeRect({ minX, minY, maxX, maxY });
+
+      contests.push({
+        options,
+        bounds,
+        corners: [
+          { x: bounds.x, y: bounds.y },
+          { x: bounds.x + bounds.width - 1, y: bounds.y },
+          { x: bounds.x, y: bounds.y + bounds.height - 1 },
+          { x: bounds.x + bounds.width - 1, y: bounds.y + bounds.height - 1 },
+        ],
+      });
+    }
+
+    layouts.push({
+      metadata: { ...metadata, pageNumber: i + 1 },
+      pageSize: geometry.canvasSize,
+      contests,
+    });
+  }
+
+  return ok(layouts);
+}

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -811,7 +811,7 @@ export type ContestOption =
   | CandidateContestOption
   | YesNoContestOption
   | MsEitherNeitherContestOption;
-export const ContestOption: z.ZodSchema<ContestOption> = z.union([
+export const ContestOptionSchema: z.ZodSchema<ContestOption> = z.union([
   CandidateContestOptionSchema,
   YesNoContestOptionSchema,
   MsEitherNeitherContestOptionSchema,

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -110,17 +110,20 @@ export const WriteInIdSchema = z
     (id) => /^(__write-in(-.+)?|write-in__(.+))$/.test(id),
     `Write-In ID does not match expected format.`
   ) as z.ZodSchema<WriteInId>;
-export type CandidateId = Id;
-export const CandidateIdSchema: z.ZodSchema<CandidateId> = IdSchema;
+export type CandidateId = Id | WriteInId;
+export const CandidateIdSchema: z.ZodSchema<CandidateId> = z.union([
+  IdSchema,
+  WriteInIdSchema,
+]);
 export interface Candidate {
-  readonly id: CandidateId | WriteInId;
+  readonly id: CandidateId;
   readonly name: string;
   readonly partyId?: PartyId;
   readonly isWriteIn?: boolean;
 }
 export const CandidateSchema: z.ZodSchema<Candidate> = z.object({
   _lang: TranslationsSchema.optional(),
-  id: z.union([CandidateIdSchema, WriteInIdSchema]),
+  id: CandidateIdSchema,
   name: z.string().nonempty(),
   partyId: PartyIdSchema.optional(),
   isWriteIn: z.boolean().optional(),

--- a/libs/types/src/hmpb.ts
+++ b/libs/types/src/hmpb.ts
@@ -3,7 +3,9 @@ import {
   AdjudicationReason,
   Candidate,
   Contest,
+  ContestId,
   ContestOption,
+  ContestOptionSchema,
   HmpbBallotPageMetadata,
   HmpbBallotPageMetadataSchema,
   TargetShape,
@@ -34,23 +36,27 @@ export const BallotImageSchema: z.ZodSchema<BallotImage> = z.object({
 });
 
 export interface BallotPageContestOptionLayout {
+  definition?: ContestOption;
   bounds: Rect;
   target: TargetShape;
 }
 export const BallotPageContestOptionLayoutSchema: z.ZodSchema<BallotPageContestOptionLayout> = z.object(
   {
+    definition: ContestOptionSchema.optional(),
     bounds: RectSchema,
     target: TargetShapeSchema,
   }
 );
 
 export interface BallotPageContestLayout {
+  contestId?: ContestId;
   bounds: Rect;
   corners: Corners;
   options: readonly BallotPageContestOptionLayout[];
 }
 export const BallotPageContestLayoutSchema: z.ZodSchema<BallotPageContestLayout> = z.object(
   {
+    contestId: IdSchema.optional(),
     bounds: RectSchema,
     corners: CornersSchema,
     options: z.array(BallotPageContestOptionLayoutSchema),

--- a/services/scan/src/server.ts
+++ b/services/scan/src/server.ts
@@ -647,32 +647,21 @@ export function buildApp({ store, importer }: AppOptions): Application {
         if (sheet.front.interpretation.type === 'InterpretedHmpbPage') {
           const front = sheet.front.interpretation;
           const layouts = store.getBallotLayoutsForMetadata(front.metadata);
-
-          if (layouts) {
-            const contestIds = store.getContestIdsForMetadata(front.metadata);
-            if (contestIds) {
-              frontLayout = layouts.find(
-                ({ metadata }) =>
-                  metadata.pageNumber === front.metadata.pageNumber
-              );
-              frontDefinition = { contestIds };
-            }
-          }
+          const contestIds = store.getContestIdsForMetadata(front.metadata);
+          frontLayout = layouts.find(
+            ({ metadata }) => metadata.pageNumber === front.metadata.pageNumber
+          );
+          frontDefinition = { contestIds };
         }
 
         if (sheet.back.interpretation.type === 'InterpretedHmpbPage') {
           const back = sheet.back.interpretation;
           const layouts = store.getBallotLayoutsForMetadata(back.metadata);
-          if (layouts) {
-            const contestIds = store.getContestIdsForMetadata(back.metadata);
-            if (contestIds) {
-              backLayout = layouts.find(
-                ({ metadata }) =>
-                  metadata.pageNumber === back.metadata.pageNumber
-              );
-              backDefinition = { contestIds };
-            }
-          }
+          const contestIds = store.getContestIdsForMetadata(back.metadata);
+          backLayout = layouts.find(
+            ({ metadata }) => metadata.pageNumber === back.metadata.pageNumber
+          );
+          backDefinition = { contestIds };
         }
 
         response.json({

--- a/services/scan/src/server.ts
+++ b/services/scan/src/server.ts
@@ -647,23 +647,32 @@ export function buildApp({ store, importer }: AppOptions): Application {
         if (sheet.front.interpretation.type === 'InterpretedHmpbPage') {
           const front = sheet.front.interpretation;
           const layouts = store.getBallotLayoutsForMetadata(front.metadata);
-          frontLayout = layouts.find(
-            ({ metadata }) => metadata.pageNumber === front.metadata.pageNumber
-          );
-          frontDefinition = {
-            contestIds: store.getContestIdsForMetadata(front.metadata),
-          };
+
+          if (layouts) {
+            const contestIds = store.getContestIdsForMetadata(front.metadata);
+            if (contestIds) {
+              frontLayout = layouts.find(
+                ({ metadata }) =>
+                  metadata.pageNumber === front.metadata.pageNumber
+              );
+              frontDefinition = { contestIds };
+            }
+          }
         }
 
         if (sheet.back.interpretation.type === 'InterpretedHmpbPage') {
           const back = sheet.back.interpretation;
           const layouts = store.getBallotLayoutsForMetadata(back.metadata);
-          backLayout = layouts.find(
-            ({ metadata }) => metadata.pageNumber === back.metadata.pageNumber
-          );
-          backDefinition = {
-            contestIds: store.getContestIdsForMetadata(back.metadata),
-          };
+          if (layouts) {
+            const contestIds = store.getContestIdsForMetadata(back.metadata);
+            if (contestIds) {
+              backLayout = layouts.find(
+                ({ metadata }) =>
+                  metadata.pageNumber === back.metadata.pageNumber
+              );
+              backDefinition = { contestIds };
+            }
+          }
         }
 
         response.json({
@@ -721,6 +730,7 @@ export function buildApp({ store, importer }: AppOptions): Application {
 
     backup(store)
       .on('error', (error: Error) => {
+        debug('backup error: %s', error.stack);
         response.status(500).json({
           errors: [
             {

--- a/services/scan/src/store.ts
+++ b/services/scan/src/store.ts
@@ -899,7 +899,7 @@ export class Store {
 
   getBallotLayoutsForMetadata(
     metadata: BallotPageMetadata
-  ): BallotPageLayout[] | undefined {
+  ): BallotPageLayout[] {
     const electionDefinition = this.getElectionDefinition();
     if (electionDefinition?.election.gridLayouts) {
       return generateBallotPageLayouts(
@@ -947,7 +947,7 @@ export class Store {
 
   getContestIdsForMetadata(
     metadata: BallotPageMetadata
-  ): Array<AnyContest['id']> | undefined {
+  ): Array<AnyContest['id']> {
     const electionDefinition = this.getElectionDefinition();
 
     if (!electionDefinition) {
@@ -956,10 +956,6 @@ export class Store {
 
     const layouts = this.getBallotLayoutsForMetadata(metadata);
     let contestOffset = 0;
-
-    if (!layouts) {
-      return;
-    }
 
     for (const layout of layouts) {
       if (layout.metadata.pageNumber === metadata.pageNumber) {

--- a/services/scan/src/store.ts
+++ b/services/scan/src/store.ts
@@ -901,6 +901,11 @@ export class Store {
     metadata: BallotPageMetadata
   ): BallotPageLayout[] {
     const electionDefinition = this.getElectionDefinition();
+
+    // Handle timing mark ballots differently. We should have the layout from
+    // the scan/interpret process, but since we don't right now we generate it
+    // from what we expect the layout to be instead. This means there could be
+    // some error in the layout, but it's better than nothing.
     if (electionDefinition?.election.gridLayouts) {
       return generateBallotPageLayouts(
         electionDefinition.election,


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Closes https://github.com/votingworks/vxsuite/issues/1658

This is only an approximate fix. It generates the expected layout for the timing mark ballots, but does not base it on the real interpreted ballot. Thus, it's possible for the coordinates to be somewhat off, especially if a slightly incorrect scaling factor was used. In the future, we should generate a layout based on the `interpret` output for timing mark ballots, which should include positional information for the ovals at minimum.

There were actually a couple other bugs that this PR fixes in multiple commits. It's probably best to look one commit at a time.

## Demo Video or Screenshot
![image](https://user-images.githubusercontent.com/1938/161107496-40f67060-8b2d-4607-89c9-ae0a8aa6ab89.png)

## Testing Plan 
Manually tested with a couple different timing mark ballots with write-ins. I was able to get all the way through adjudication and the ballot was accepted.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
