### PR TITLE
feat(bmd): Accessible Controller Diagnostic

### DIFF
--- a/frontends/bmd/src/app_root.tsx
+++ b/frontends/bmd/src/app_root.tsx
@@ -1307,6 +1307,7 @@ export function AppRoot({
           machineConfig={machineConfig}
           hardware={hardware}
           devices={devices}
+          screenReader={screenReader}
           printer={printer}
           togglePollsOpen={togglePollsOpen}
           tallyOnCard={tallyOnCard}

--- a/frontends/bmd/src/components/sidebar.tsx
+++ b/frontends/bmd/src/components/sidebar.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Prose } from './prose';
 import { Text } from './text';
 
-interface Props {
+export interface SidebarProps {
   appName?: string;
   centerContent?: boolean;
   children?: React.ReactNode;
@@ -23,7 +23,7 @@ const Header = styled.div`
   margin: 2rem 1rem 1rem;
 `;
 
-const Content = styled.div<Props>`
+const Content = styled.div<SidebarProps>`
   display: flex;
   flex: 1;
   flex-direction: column;
@@ -46,7 +46,7 @@ export function Sidebar({
   children,
   title,
   screenReaderInstructions,
-}: Props): JSX.Element {
+}: SidebarProps): JSX.Element {
   return (
     <StyledSidebar>
       {title && (

--- a/frontends/bmd/src/pages/accessible_controller_diagnostic_screen.test.tsx
+++ b/frontends/bmd/src/pages/accessible_controller_diagnostic_screen.test.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MockDate from 'mockdate';
+import { DateTime } from 'luxon';
+import { fakeTts } from '../../test/helpers/fake_tts';
+import { AriaScreenReader } from '../utils/ScreenReader';
+import {
+  AccessibleControllerDiagnosticScreen,
+  AccessibleControllerDiagnosticProps,
+} from './accessible_controller_diagnostic_screen';
+
+const now = DateTime.fromISO('2022-03-23T11:23:00.000Z');
+
+function renderScreen(
+  props: Partial<AccessibleControllerDiagnosticProps> = {}
+) {
+  return render(
+    <AccessibleControllerDiagnosticScreen
+      onComplete={jest.fn()}
+      onCancel={jest.fn()}
+      screenReader={new AriaScreenReader(fakeTts())}
+      {...props}
+    />
+  );
+}
+
+describe('Accessible Controller Diagnostic Screen', () => {
+  beforeEach(() => {
+    MockDate.set(now.toISO());
+  });
+
+  it('yields a success result when all steps are completed', async () => {
+    const mockTts = fakeTts();
+    const screenReader = new AriaScreenReader(mockTts);
+    const onComplete = jest.fn();
+    renderScreen({ onComplete, screenReader });
+
+    screen.getByText('Accessible Controller Test');
+
+    screen.getByText(/Step 1 of 6/);
+    screen.getByText('Press the up button.');
+    // Try out pressing an incorrect button to make sure we actually detect the
+    // right button.
+    act(() => void userEvent.keyboard('{ArrowDown}'));
+    screen.getByText(/Step 1 of 6/);
+    // Then press the up button.
+    // We have to wrap key presses in act to avoid a warning. This may be due to
+    // the fact that the keyDown listener is attached to the document instead of
+    // a React component.
+    act(() => void userEvent.keyboard('{ArrowUp}'));
+
+    await screen.findByText(/Step 2 of 6/);
+    screen.getByText('Press the down button.');
+    act(() => void userEvent.keyboard('{ArrowDown}'));
+
+    await screen.findByText(/Step 3 of 6/);
+    screen.getByText('Press the left button.');
+    act(() => void userEvent.keyboard('{ArrowLeft}'));
+
+    await screen.findByText(/Step 4 of 6/);
+    screen.getByText('Press the right button.');
+    act(() => void userEvent.keyboard('{ArrowRight}'));
+
+    await screen.findByText(/Step 5 of 6/);
+    screen.getByText('Press the select button.');
+    act(() => void userEvent.keyboard('{Enter}'));
+
+    await screen.findByText(/Step 6 of 6/);
+    screen.getByText('Confirm sound is working.');
+    // Try pressing the select button before playing sound to make sure it
+    // doesn't work
+    act(() => void userEvent.keyboard('{Enter}'));
+    expect(onComplete).not.toHaveBeenCalled();
+    // Then play sound and confirm
+    act(() => void userEvent.keyboard('{ArrowRight}'));
+    await waitFor(() => expect(mockTts.speak).toHaveBeenCalled());
+    // Should unmute to speak and then restore muted state
+    expect(mockTts.unmute).toHaveBeenCalled();
+    expect(mockTts.toggleMuted).toHaveBeenCalledWith(true);
+    act(() => void userEvent.keyboard('{Enter}'));
+
+    expect(onComplete).toHaveBeenCalledWith({
+      passed: true,
+      completedAt: now,
+    });
+  });
+
+  async function passUntilStep(step: number) {
+    if (step === 1) return;
+    screen.getByText(/Step 1 of 6/);
+    act(() => void userEvent.keyboard('{ArrowUp}'));
+
+    if (step === 2) return;
+    await screen.findByText(/Step 2 of 6/);
+    act(() => void userEvent.keyboard('{ArrowDown}'));
+
+    if (step === 3) return;
+    await screen.findByText(/Step 3 of 6/);
+    act(() => void userEvent.keyboard('{ArrowLeft}'));
+
+    if (step === 4) return;
+    await screen.findByText(/Step 4 of 6/);
+    act(() => void userEvent.keyboard('{ArrowRight}'));
+
+    if (step === 5) return;
+    await screen.findByText(/Step 5 of 6/);
+    act(() => void userEvent.keyboard('{Enter}'));
+
+    if (step === 6) return;
+    throw new Error('Step must be between 1 and 6');
+  }
+
+  const buttons = ['Up', 'Down', 'Left', 'Right', 'Select'];
+  for (const [index, button] of buttons.entries()) {
+    it(`yields a failure result when ${button} button is not working`, async () => {
+      const onComplete = jest.fn();
+      renderScreen({ onComplete });
+
+      await passUntilStep(index + 1);
+      userEvent.click(
+        screen.getByRole('button', { name: `${button} Button is Not Working` })
+      );
+
+      expect(onComplete).toHaveBeenCalledWith({
+        passed: false,
+        completedAt: now,
+        message: `${button} button is not working.`,
+      });
+    });
+  }
+
+  it('yields a failure result when sound is not working', async () => {
+    const onComplete = jest.fn();
+    renderScreen({ onComplete });
+
+    await passUntilStep(6);
+    userEvent.click(
+      screen.getByRole('button', { name: `Sound is Not Working` })
+    );
+
+    expect(onComplete).toHaveBeenCalledWith({
+      passed: false,
+      completedAt: now,
+      message: `Sound is not working.`,
+    });
+  });
+
+  it('cancels the test when the cancel button is pressed', async () => {
+    const onCancel = jest.fn();
+    const onComplete = jest.fn();
+    renderScreen({ onCancel, onComplete });
+
+    userEvent.click(screen.getByRole('button', { name: 'Cancel Test' }));
+    expect(onCancel).toHaveBeenCalled();
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+});

--- a/frontends/bmd/src/pages/accessible_controller_diagnostic_screen.test.tsx
+++ b/frontends/bmd/src/pages/accessible_controller_diagnostic_screen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import MockDate from 'mockdate';
 import { DateTime } from 'luxon';
@@ -38,8 +38,25 @@ describe('Accessible Controller Diagnostic Screen', () => {
 
     screen.getByText('Accessible Controller Test');
 
+    function expectToHaveIllustrationHighlight(
+      highlightTestId: string,
+      hasHeadphones?: boolean
+    ) {
+      const illustration = (screen
+        .getByTitle('Accessible Controller Illustration')
+        .closest('svg') as unknown) as HTMLElement;
+      const path = within(illustration).getByTestId(highlightTestId);
+      expect(path).toHaveAttribute('fill', '#985aa3');
+      if (!hasHeadphones) {
+        expect(
+          within(illustration).queryByTestId('headphones')
+        ).not.toBeInTheDocument();
+      }
+    }
+
     screen.getByText(/Step 1 of 6/);
     screen.getByText('Press the up button.');
+    expectToHaveIllustrationHighlight('up-button');
     // Try out pressing an incorrect button to make sure we actually detect the
     // right button.
     act(() => void userEvent.keyboard('{ArrowDown}'));
@@ -52,22 +69,28 @@ describe('Accessible Controller Diagnostic Screen', () => {
 
     await screen.findByText(/Step 2 of 6/);
     screen.getByText('Press the down button.');
+    expectToHaveIllustrationHighlight('down-button');
     act(() => void userEvent.keyboard('{ArrowDown}'));
 
     await screen.findByText(/Step 3 of 6/);
     screen.getByText('Press the left button.');
+    expectToHaveIllustrationHighlight('left-button');
     act(() => void userEvent.keyboard('{ArrowLeft}'));
 
     await screen.findByText(/Step 4 of 6/);
     screen.getByText('Press the right button.');
+    expectToHaveIllustrationHighlight('right-button');
     act(() => void userEvent.keyboard('{ArrowRight}'));
 
     await screen.findByText(/Step 5 of 6/);
     screen.getByText('Press the select button.');
+    expectToHaveIllustrationHighlight('select-button');
     act(() => void userEvent.keyboard('{Enter}'));
 
     await screen.findByText(/Step 6 of 6/);
     screen.getByText('Confirm sound is working.');
+    expectToHaveIllustrationHighlight('right-button', true);
+    expectToHaveIllustrationHighlight('headphones', true);
     // Try pressing the select button before playing sound to make sure it
     // doesn't work
     act(() => void userEvent.keyboard('{Enter}'));

--- a/frontends/bmd/src/pages/accessible_controller_diagnostic_screen.tsx
+++ b/frontends/bmd/src/pages/accessible_controller_diagnostic_screen.tsx
@@ -51,7 +51,7 @@ interface AccessibleControllerButtonDiagnosticProps {
   buttonName: string;
   buttonKey: string;
   onSuccess: () => void;
-  onFailure: () => void;
+  onFailure: (message: string) => void;
 }
 
 function AccessibleControllerButtonDiagnostic({
@@ -75,8 +75,12 @@ function AccessibleControllerButtonDiagnostic({
   return (
     <StepContainer>
       <div>
-        <h1>Press the {buttonName.toLowerCase()}.</h1>
-        <Button onPress={onFailure}>{buttonName} is Not Working</Button>
+        <h1>Press the {buttonName.toLowerCase()} button.</h1>
+        <Button
+          onPress={() => onFailure(`${buttonName} button is not working.`)}
+        >
+          {buttonName} Button is Not Working
+        </Button>
       </div>
       <img src="/images/controller-up-arrow.png" alt="up" />
     </StepContainer>
@@ -86,7 +90,7 @@ function AccessibleControllerButtonDiagnostic({
 interface AccessibleControllerSoundDiagnosticProps {
   screenReader: ScreenReader;
   onSuccess: () => void;
-  onFailure: () => void;
+  onFailure: (message: string) => void;
 }
 
 function AccessibleControllerSoundDiagnostic({
@@ -126,7 +130,9 @@ function AccessibleControllerSoundDiagnostic({
           <li>Press the right button to play sound.</li>
           <li>Press the select button to confirm sound is working.</li>
         </ol>
-        <Button onPress={onFailure}>Sound is Not Working</Button>
+        <Button onPress={() => onFailure('Sound is not working.')}>
+          Sound is Not Working
+        </Button>
       </div>
       <img src="/images/controller-up-arrow.png" alt="up" />
     </StepContainer>
@@ -144,7 +150,7 @@ export function AccessibleControllerDiagnostic({
   onCancel,
   screenReader,
 }: AccessibleControllerDiagnosticProps): JSX.Element {
-  const [currentStep, setCurrentStep] = useState(0);
+  const [step, setStep] = useState(0);
 
   function passTest() {
     onComplete({ passed: true, completedAt: DateTime.now() });
@@ -154,57 +160,32 @@ export function AccessibleControllerDiagnostic({
   }
 
   function nextStep() {
-    setCurrentStep((previousStep) => previousStep + 1);
+    setStep((previousStep) => previousStep + 1);
   }
 
+  const buttons = [
+    ['Up', 'ArrowUp'],
+    ['Down', 'ArrowDown'],
+    ['Left', 'ArrowLeft'],
+    ['Right', 'ArrowRight'],
+    ['Select', 'Enter'],
+  ];
   const steps = [
-    () => (
+    ...buttons.map(([buttonName, buttonKey]) => (
       <AccessibleControllerButtonDiagnostic
-        buttonName="Up Button"
-        buttonKey="ArrowUp"
+        key={buttonName}
+        buttonName={buttonName}
+        buttonKey={buttonKey}
         onSuccess={nextStep}
-        onFailure={() => failTest('Up button is not working.')}
+        onFailure={failTest}
       />
-    ),
-    () => (
-      <AccessibleControllerButtonDiagnostic
-        buttonName="Down Button"
-        buttonKey="ArrowDown"
-        onSuccess={nextStep}
-        onFailure={() => failTest('Down button is not working.')}
-      />
-    ),
-    () => (
-      <AccessibleControllerButtonDiagnostic
-        buttonName="Left Button"
-        buttonKey="ArrowLeft"
-        onSuccess={nextStep}
-        onFailure={() => failTest('Left button is not working.')}
-      />
-    ),
-    () => (
-      <AccessibleControllerButtonDiagnostic
-        buttonName="Right Button"
-        buttonKey="ArrowRight"
-        onSuccess={nextStep}
-        onFailure={() => failTest('Right button is not working.')}
-      />
-    ),
-    () => (
-      <AccessibleControllerButtonDiagnostic
-        buttonName="Select Button"
-        buttonKey="Enter"
-        onSuccess={nextStep}
-        onFailure={() => failTest('Select button is not working.')}
-      />
-    ),
-    () => (
-      <AccessibleControllerSoundDiagnostic
-        screenReader={screenReader}
-        onSuccess={passTest}
-        onFailure={() => failTest('Sound is not working.')}
-      />
-    ),
+    )),
+    <AccessibleControllerSoundDiagnostic
+      key="sound"
+      screenReader={screenReader}
+      onSuccess={passTest}
+      onFailure={failTest}
+    />,
   ];
 
   return (
@@ -214,11 +195,11 @@ export function AccessibleControllerDiagnostic({
           <Header>
             <Text>
               <strong>Accessible Controller Test</strong> &mdash; Step{' '}
-              {currentStep + 1} of {steps.length}
+              {step + 1} of {steps.length}
             </Text>
             <Button onPress={onCancel}>Cancel Test</Button>
           </Header>
-          {steps[currentStep]()}
+          {steps[step]}
         </MainChild>
       </Main>
     </Screen>

--- a/frontends/bmd/src/pages/accessible_controller_diagnostic_screen.tsx
+++ b/frontends/bmd/src/pages/accessible_controller_diagnostic_screen.tsx
@@ -145,7 +145,7 @@ export interface AccessibleControllerDiagnosticProps {
   screenReader: ScreenReader;
 }
 
-export function AccessibleControllerDiagnostic({
+export function AccessibleControllerDiagnosticScreen({
   onComplete,
   onCancel,
   screenReader,

--- a/frontends/bmd/src/pages/accessible_controller_diagnostic_screen.tsx
+++ b/frontends/bmd/src/pages/accessible_controller_diagnostic_screen.tsx
@@ -5,6 +5,8 @@ import styled from 'styled-components';
 import { Screen } from '../components/screen';
 import { ScreenReader } from '../config/types';
 
+type ButtonName = 'Up' | 'Down' | 'Left' | 'Right' | 'Select';
+
 const Header = styled(Prose).attrs({
   maxWidth: false,
 })`
@@ -16,11 +18,12 @@ const Header = styled(Prose).attrs({
 const StepContainer = styled.div`
   display: grid;
   grid-template-columns: 55% 1fr;
-  flex-grow: 1;
   align-items: center;
+  padding: 0 6em;
 
-  img {
-    justify-self: center;
+  svg {
+    justify-self: flex-end;
+    height: 25em;
   }
 
   button {
@@ -36,19 +39,85 @@ const StepContainer = styled.div`
   }
 `;
 
-export type AccessibleControllerDiagnosticResults =
-  | {
-      passed: true;
-      completedAt: DateTime;
-    }
-  | {
-      passed: false;
-      completedAt: DateTime;
-      message: string;
-    };
+interface AccessibleControllerIllustrationProps {
+  highlight?: ButtonName | 'Headphones';
+}
+
+function AccessibleControllerIllustration({
+  highlight,
+}: AccessibleControllerIllustrationProps) {
+  const defaultFill = '#fff';
+  const highlightFill = '#985aa3';
+  return (
+    <svg
+      version="1.1"
+      xmlns="http://www.w3.org/2000/svg"
+      x="0"
+      y="0"
+      viewBox="0 0 387.15 522"
+      xmlSpace="preserve"
+    >
+      <title>Accessible Controller Illustration</title>
+      <path d="M263.5 522H39.65c-11.21 0-20.63-8.03-22.42-19.1C5.96 433.04 0 354.02 0 274.36 0 183.71 7.6 95.24 21.99 18.52 24 7.79 33.38 0 44.31 0h214.54c10.92 0 20.31 7.79 22.32 18.52 14.38 76.72 21.99 165.19 21.99 255.84 0 79.65-5.96 158.68-17.23 228.54-1.8 11.07-11.23 19.1-22.43 19.1z" />
+      <path
+        fill="#fff"
+        d="M44.31 10a12.72 12.72 0 0 0-12.49 10.36C17.54 96.48 10 184.32 10 274.36c0 79.13 5.91 157.61 17.1 226.95 1 6.2 6.28 10.69 12.55 10.69H263.5c6.27 0 11.55-4.5 12.55-10.69 11.19-69.34 17.1-147.82 17.1-226.95 0-90.05-7.54-177.88-21.82-254-1.12-6-6.38-10.36-12.49-10.36H44.31z"
+      />
+      <circle cx="192.5" cy="342.72" r="20" />
+      <circle fill="#fff" cx="192.5" cy="342.72" r="10" />
+      <path d="m83.97 236.68-47.8-47.8c-4.07-4.07-6.31-9.48-6.31-15.25s2.24-11.18 6.31-15.25l47.8-47.8 30.02 30.02-1.64 3.23c-1.51 2.99-2.28 6.2-2.28 9.55v39.5c0 3.54.88 7.03 2.54 10.1l1.78 3.28-30.42 30.42z" />
+      <path
+        data-testid="left-button"
+        fill={highlight === 'Left' ? highlightFill : defaultFill}
+        d="m83.97 124.73-40.73 40.73c-4.51 4.51-4.51 11.85 0 16.36l40.73 40.73 18.25-18.25c-1.41-3.61-2.15-7.5-2.15-11.41v-39.5c0-3.69.63-7.26 1.88-10.67l-17.98-17.99z"
+      />
+      <path d="m184.2 136.45-3.28-1.78a21.278 21.278 0 0 0-10.09-2.54h-39.51c-3.35 0-6.56.77-9.55 2.28l-3.23 1.63-30.02-30.02 47.8-47.8c4.07-4.07 9.48-6.3 15.25-6.3s11.18 2.24 15.25 6.3l47.8 47.8-30.42 30.43z" />
+      <path
+        data-testid="up-button"
+        fill={highlight === 'Up' ? highlightFill : defaultFill}
+        d="M131.32 122.14h39.51c3.91 0 7.79.74 11.4 2.15l18.25-18.25-40.73-40.74a11.48 11.48 0 0 0-8.18-3.38c-3.1 0-6 1.2-8.18 3.38l-40.73 40.73 17.98 17.98c3.42-1.24 7-1.87 10.68-1.87z"
+      />
+      <path d="M151.58 295.35c-5.77 0-11.19-2.24-15.25-6.31l-47.8-47.8 30.59-30.59 3.18 1.49c2.82 1.33 5.86 2 9.02 2h39.51c3.37 0 6.59-.76 9.56-2.27l3.23-1.63 31 31-47.8 47.8c-4.06 4.07-9.48 6.31-15.24 6.31z" />
+      <path
+        data-testid="down-button"
+        fill={highlight === 'Down' ? highlightFill : defaultFill}
+        d="m102.67 241.24 40.73 40.73a11.48 11.48 0 0 0 8.18 3.38c3.09 0 6-1.2 8.18-3.38l40.73-40.73-18.97-18.97c-3.4 1.24-6.98 1.87-10.68 1.87h-39.51c-3.43 0-6.76-.54-9.94-1.61l-18.72 18.71z"
+      />
+      <path d="m219.18 236.68-31-31.01 1.63-3.23a21.06 21.06 0 0 0 2.27-9.56v-39.51c0-3.17-.67-6.2-2-9.02l-1.49-3.18 30.6-30.6 47.8 47.8c4.07 4.07 6.3 9.48 6.3 15.25s-2.24 11.18-6.3 15.25l-47.81 47.81z" />
+      <path
+        data-testid="right-button"
+        fill={
+          highlight === 'Right' || highlight === 'Headphones'
+            ? highlightFill
+            : defaultFill
+        }
+        d="m200.21 203.57 18.98 18.98 40.73-40.73a11.48 11.48 0 0 0 3.38-8.18c0-3.1-1.2-6-3.38-8.18l-40.73-40.73-18.71 18.71c1.07 3.18 1.61 6.51 1.61 9.94v39.51c-.02 3.7-.64 7.27-1.88 10.68z"
+      />
+      <path d="M169.52 209.42h-36.89c-4.76 0-9.24-1.85-12.61-5.22a17.715 17.715 0 0 1-5.22-12.61V154.7c0-9.83 8-17.83 17.83-17.83h36.89c4.76 0 9.24 1.85 12.61 5.22 3.37 3.37 5.22 7.85 5.22 12.61v36.89c0 4.76-1.85 9.24-5.22 12.61s-7.85 5.22-12.61 5.22z" />
+      <path
+        data-testid="select-button"
+        fill={highlight === 'Select' ? highlightFill : defaultFill}
+        d="M132.63 146.86c-4.32 0-7.83 3.51-7.83 7.83v36.89c0 2.09.81 4.06 2.29 5.54a7.783 7.783 0 0 0 5.54 2.29h36.89c2.09 0 4.06-.81 5.54-2.29s2.29-3.45 2.29-5.54v-36.89c0-2.09-.81-4.06-2.29-5.54a7.783 7.783 0 0 0-5.54-2.29h-36.89z"
+      />
+      <path d="M194.13 466.64h-3.26c-21.76 0-39.47-17.7-39.47-39.47v-86.08c0-21.76 17.7-39.47 39.47-39.47h3.26c21.76 0 39.47 17.7 39.47 39.47v86.08c-.01 21.76-17.71 39.47-39.47 39.47zm-3.27-155.01c-16.25 0-29.47 13.22-29.47 29.47v86.08c0 16.25 13.22 29.47 29.47 29.47h3.26c16.25 0 29.47-13.22 29.47-29.47V341.1c0-16.25-13.22-29.47-29.47-29.47h-3.26z" />
+      <path d="M215.49 424.8c0-12.83-10.44-23.27-23.27-23.27s-23.27 10.44-23.27 23.27c0 6.79 2.93 12.9 7.58 17.16.48 2.61 2.78 4.61 5.52 4.61 3.09 0 5.62-2.53 5.62-5.62v-7.09c0-3.09-2.53-5.62-5.62-5.62-2.53 0-4.69 1.7-5.38 4.01a17.051 17.051 0 0 1-1.72-7.44c0-9.52 7.75-17.27 17.27-17.27s17.27 7.75 17.27 17.27c0 2.67-.62 5.2-1.71 7.46-.69-2.32-2.85-4.03-5.39-4.03-3.09 0-5.62 2.53-5.62 5.62v7.09c0 3.09 2.53 5.62 5.62 5.62 2.75 0 5.04-2 5.52-4.61 4.66-4.26 7.58-10.37 7.58-17.16zM119.87 373.03H87.29c-9.3 0-16.87-7.57-16.87-16.87v-32.57c0-9.3 7.57-16.87 16.87-16.87h32.57c9.3 0 16.87 7.57 16.87 16.87v32.57c.01 9.31-7.56 16.87-16.86 16.87zm-32.58-56.31c-3.79 0-6.87 3.08-6.87 6.87v32.57c0 3.79 3.08 6.87 6.87 6.87h32.57c3.79 0 6.87-3.08 6.87-6.87v-32.57c0-3.79-3.08-6.87-6.87-6.87H87.29z" />
+      <path d="M90.81 357.38c-2.76 0-5-2.24-5-5v-3c0-2.76 2.24-5 5-5s5 2.24 5 5v3c0 2.76-2.24 5-5 5zM103.58 357.38c-2.76 0-5-2.24-5-5v-14c0-2.76 2.24-5 5-5s5 2.24 5 5v14c0 2.76-2.24 5-5 5zM116.35 357.38c-2.76 0-5-2.24-5-5v-25c0-2.76 2.24-5 5-5s5 2.24 5 5v25c0 2.76-2.24 5-5 5z" />
+      {highlight === 'Headphones' && (
+        <g>
+          <path
+            data-testid="headphones"
+            fill={highlightFill}
+            d="m198.68 369.38-19.34-4.36-13.94-27.72 22.78-18.78 19.86 5.02 11.35 25.14 77.63 76.37-20.72 22.52z"
+          />
+          <path d="M361.3 413.79c-8.41 7.93-8.2 20.89-8.02 32.33.21 13.37-.14 21.71-6.77 24.8-13.67 6.37-22.49-1.93-45.98-26.87-1.86-1.97-3.8-4.03-5.81-6.15l2-2c5.26-5.26 5.26-13.82 0-19.08l-75.29-75.29c-.25-7.08-3.06-14.09-8.46-19.49-5.48-5.48-12.76-8.5-20.51-8.5-7.75 0-15.03 3.02-20.51 8.5s-8.5 12.76-8.5 20.51c0 7.75 3.02 15.03 8.5 20.51 5.65 5.65 13.08 8.48 20.51 8.48.08 0 .17-.01.25-.01l74.64 74.64c2.55 2.55 5.94 3.95 9.54 3.95 3.6 0 6.99-1.4 9.54-3.95l1.2-1.2c1.94 2.05 3.81 4.03 5.61 5.94 17.93 19.03 30.27 32.13 44.88 32.13 3.98 0 8.12-.97 12.59-3.05 12.99-6.05 12.75-20.91 12.55-34.02-.15-9.83-.31-19.99 4.89-24.9 3.43-3.24 9.57-4.55 18.25-3.91l.74-9.97c-11.75-.88-20.2 1.28-25.84 6.6zM179.02 329.1c3.71-3.71 8.57-5.56 13.44-5.56 4.87 0 9.73 1.85 13.44 5.56 7.41 7.41 7.41 19.47 0 26.88s-19.47 7.41-26.88 0-7.41-19.47 0-26.88zm110.63 99.72-10.28 10.28c-1.32 1.32-3.62 1.32-4.94 0l-70.1-70.1c3.14-1.4 6.07-3.38 8.64-5.95 2.81-2.81 4.92-6.05 6.33-9.52l70.35 70.35a3.5 3.5 0 0 1 0 4.94z" />
+        </g>
+      )}
+    </svg>
+  );
+}
 
 interface AccessibleControllerButtonDiagnosticProps {
-  buttonName: string;
+  buttonName: ButtonName;
   buttonKey: string;
   onSuccess: () => void;
   onFailure: (message: string) => void;
@@ -82,7 +151,7 @@ function AccessibleControllerButtonDiagnostic({
           {buttonName} Button is Not Working
         </Button>
       </div>
-      <img src="/images/controller-up-arrow.png" alt="up" />
+      <AccessibleControllerIllustration highlight={buttonName} />
     </StepContainer>
   );
 }
@@ -134,10 +203,21 @@ function AccessibleControllerSoundDiagnostic({
           Sound is Not Working
         </Button>
       </div>
-      <img src="/images/controller-up-arrow.png" alt="up" />
+      <AccessibleControllerIllustration highlight="Headphones" />
     </StepContainer>
   );
 }
+
+export type AccessibleControllerDiagnosticResults =
+  | {
+      passed: true;
+      completedAt: DateTime;
+    }
+  | {
+      passed: false;
+      completedAt: DateTime;
+      message: string;
+    };
 
 export interface AccessibleControllerDiagnosticProps {
   onComplete: (results: AccessibleControllerDiagnosticResults) => void;
@@ -163,7 +243,7 @@ export function AccessibleControllerDiagnosticScreen({
     setStep((previousStep) => previousStep + 1);
   }
 
-  const buttons = [
+  const buttons: Array<[ButtonName, string]> = [
     ['Up', 'ArrowUp'],
     ['Down', 'ArrowDown'],
     ['Left', 'ArrowLeft'],
@@ -190,7 +270,7 @@ export function AccessibleControllerDiagnosticScreen({
 
   return (
     <Screen voterMode={false}>
-      <Main style={{ padding: '2em 6em' }}>
+      <Main style={{ padding: '2em 4em' }}>
         <MainChild maxWidth={false} flexContainer>
           <Header>
             <Text>

--- a/frontends/bmd/src/pages/accessible_controller_diagnostic_screen.tsx
+++ b/frontends/bmd/src/pages/accessible_controller_diagnostic_screen.tsx
@@ -7,18 +7,17 @@ import { ScreenReader } from '../config/types';
 
 const Header = styled(Prose).attrs({
   maxWidth: false,
-  // theme: fontSizeTheme.medium,
 })`
   display: flex;
-  justify-content: space-between;
   align-items: baseline;
+  justify-content: space-between;
 `;
 
 const StepContainer = styled.div`
   display: grid;
-  align-items: center;
   grid-template-columns: 55% 1fr;
   flex-grow: 1;
+  align-items: center;
 
   img {
     justify-self: center;
@@ -48,19 +47,19 @@ export type AccessibleControllerDiagnosticResults =
       message: string;
     };
 
-interface AccessibleControllerButtonTestProps {
+interface AccessibleControllerButtonDiagnosticProps {
   buttonName: string;
   buttonKey: string;
   onSuccess: () => void;
   onFailure: () => void;
 }
 
-function AccessibleControllerButtonTest({
+function AccessibleControllerButtonDiagnostic({
   buttonName,
   buttonKey,
   onSuccess,
   onFailure,
-}: AccessibleControllerButtonTestProps) {
+}: AccessibleControllerButtonDiagnosticProps) {
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
       event.stopPropagation();
@@ -84,17 +83,17 @@ function AccessibleControllerButtonTest({
   );
 }
 
-interface AccessibleControllerSoundTestProps {
+interface AccessibleControllerSoundDiagnosticProps {
   screenReader: ScreenReader;
   onSuccess: () => void;
   onFailure: () => void;
 }
 
-function AccessibleControllerSoundTest({
+function AccessibleControllerSoundDiagnostic({
   screenReader,
   onSuccess,
   onFailure,
-}: AccessibleControllerSoundTestProps) {
+}: AccessibleControllerSoundDiagnosticProps) {
   const [hasPlayedAudio, setHasPlayedAudio] = useState(false);
 
   useEffect(() => {
@@ -106,7 +105,7 @@ function AccessibleControllerSoundTest({
         await screenReader.speak(
           'Press the select button to confirm sound is working.'
         );
-        if (wasMuted) screenReader.mute();
+        screenReader.toggleMuted(wasMuted);
         setHasPlayedAudio(true);
       }
       if (event.key === 'Enter' && hasPlayedAudio) {
@@ -134,17 +133,17 @@ function AccessibleControllerSoundTest({
   );
 }
 
-interface AccessibleControllerTestProps {
+export interface AccessibleControllerDiagnosticProps {
   onComplete: (results: AccessibleControllerDiagnosticResults) => void;
   onCancel: () => void;
   screenReader: ScreenReader;
 }
 
-export function AccessibleControllerTest({
+export function AccessibleControllerDiagnostic({
   onComplete,
   onCancel,
   screenReader,
-}: AccessibleControllerTestProps): JSX.Element {
+}: AccessibleControllerDiagnosticProps): JSX.Element {
   const [currentStep, setCurrentStep] = useState(0);
 
   function passTest() {
@@ -160,7 +159,7 @@ export function AccessibleControllerTest({
 
   const steps = [
     () => (
-      <AccessibleControllerButtonTest
+      <AccessibleControllerButtonDiagnostic
         buttonName="Up Button"
         buttonKey="ArrowUp"
         onSuccess={nextStep}
@@ -168,7 +167,7 @@ export function AccessibleControllerTest({
       />
     ),
     () => (
-      <AccessibleControllerButtonTest
+      <AccessibleControllerButtonDiagnostic
         buttonName="Down Button"
         buttonKey="ArrowDown"
         onSuccess={nextStep}
@@ -176,7 +175,7 @@ export function AccessibleControllerTest({
       />
     ),
     () => (
-      <AccessibleControllerButtonTest
+      <AccessibleControllerButtonDiagnostic
         buttonName="Left Button"
         buttonKey="ArrowLeft"
         onSuccess={nextStep}
@@ -184,7 +183,7 @@ export function AccessibleControllerTest({
       />
     ),
     () => (
-      <AccessibleControllerButtonTest
+      <AccessibleControllerButtonDiagnostic
         buttonName="Right Button"
         buttonKey="ArrowRight"
         onSuccess={nextStep}
@@ -192,7 +191,7 @@ export function AccessibleControllerTest({
       />
     ),
     () => (
-      <AccessibleControllerButtonTest
+      <AccessibleControllerButtonDiagnostic
         buttonName="Select Button"
         buttonKey="Enter"
         onSuccess={nextStep}
@@ -200,7 +199,7 @@ export function AccessibleControllerTest({
       />
     ),
     () => (
-      <AccessibleControllerSoundTest
+      <AccessibleControllerSoundDiagnostic
         screenReader={screenReader}
         onSuccess={passTest}
         onFailure={() => failTest('Sound is not working.')}

--- a/frontends/bmd/src/pages/accessible_controller_diagnostic_screen.tsx
+++ b/frontends/bmd/src/pages/accessible_controller_diagnostic_screen.tsx
@@ -18,6 +18,7 @@ const Header = styled(Prose).attrs({
 const StepContainer = styled.div`
   display: grid;
   grid-template-columns: 55% 1fr;
+  flex-grow: 1;
   align-items: center;
   padding: 0 6em;
 

--- a/frontends/bmd/src/pages/accessible_controller_test_screen.tsx
+++ b/frontends/bmd/src/pages/accessible_controller_test_screen.tsx
@@ -1,12 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import {
-  Button,
-  fontSizeTheme,
-  Main,
-  MainChild,
-  Prose,
-  Text,
-} from '@votingworks/ui';
+import { Button, Main, MainChild, Prose, Text } from '@votingworks/ui';
 import { DateTime } from 'luxon';
 import styled from 'styled-components';
 import { Screen } from '../components/screen';
@@ -14,7 +7,7 @@ import { ScreenReader } from '../config/types';
 
 const Header = styled(Prose).attrs({
   maxWidth: false,
-  theme: fontSizeTheme.medium,
+  // theme: fontSizeTheme.medium,
 })`
   display: flex;
   justify-content: space-between;
@@ -26,8 +19,21 @@ const StepContainer = styled.div`
   align-items: center;
   grid-template-columns: 55% 1fr;
   flex-grow: 1;
-  > img {
+
+  img {
     justify-self: center;
+  }
+
+  button {
+    margin-top: 4em;
+  }
+
+  ol {
+    margin-top: 0;
+    padding-left: 1em;
+    li {
+      margin-bottom: 1em;
+    }
   }
 `;
 
@@ -69,36 +75,26 @@ function AccessibleControllerButtonTest({
 
   return (
     <StepContainer>
-      <Prose theme={fontSizeTheme.large}>
+      <div>
         <h1>Press the {buttonName.toLowerCase()}.</h1>
         <Button onPress={onFailure}>{buttonName} is Not Working</Button>
-      </Prose>
+      </div>
       <img src="/images/controller-up-arrow.png" alt="up" />
     </StepContainer>
   );
 }
 
-// // https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm
-// function shuffle<T>(array: T[]): T[] {
-//   const shuffled = array.slice();
-//   for (let i = shuffled.length - 1; i > 0; i -= 1) {
-//     const j = Math.floor(Math.random() * (i + 1));
-//     [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
-//   }
-//   return shuffled;
-// }
-
-interface AccessibleControllerHeadphonesTestProps {
+interface AccessibleControllerSoundTestProps {
   screenReader: ScreenReader;
   onSuccess: () => void;
   onFailure: () => void;
 }
 
-function AccessibleControllerHeadphonesTest({
+function AccessibleControllerSoundTest({
   screenReader,
   onSuccess,
   onFailure,
-}: AccessibleControllerHeadphonesTestProps) {
+}: AccessibleControllerSoundTestProps) {
   const [hasPlayedAudio, setHasPlayedAudio] = useState(false);
 
   useEffect(() => {
@@ -108,7 +104,7 @@ function AccessibleControllerHeadphonesTest({
         const wasMuted = screenReader.isMuted();
         screenReader.unmute();
         await screenReader.speak(
-          'Press the select button to confirm the audio is working.'
+          'Press the select button to confirm sound is working.'
         );
         if (wasMuted) screenReader.mute();
         setHasPlayedAudio(true);
@@ -124,16 +120,15 @@ function AccessibleControllerHeadphonesTest({
 
   return (
     <StepContainer>
-      <Prose theme={fontSizeTheme.large}>
-        <h3>
-          Plug headphones into the accessible controller, then press the right
-          button to play audio.
-        </h3>
-        <Text style={{ marginTop: '1em' }}>
-          Press the select button to confirm the audio is working.
-        </Text>
-        <Button onPress={onFailure}>Audio is Not Working</Button>
-      </Prose>
+      <div>
+        <h1>Confirm sound is working.</h1>
+        <ol>
+          <li>Plug in headphones.</li>
+          <li>Press the right button to play sound.</li>
+          <li>Press the select button to confirm sound is working.</li>
+        </ol>
+        <Button onPress={onFailure}>Sound is Not Working</Button>
+      </div>
       <img src="/images/controller-up-arrow.png" alt="up" />
     </StepContainer>
   );
@@ -205,24 +200,24 @@ export function AccessibleControllerTest({
       />
     ),
     () => (
-      <AccessibleControllerHeadphonesTest
+      <AccessibleControllerSoundTest
         screenReader={screenReader}
         onSuccess={passTest}
-        onFailure={() => failTest('Audio is not working.')}
+        onFailure={() => failTest('Sound is not working.')}
       />
     ),
   ];
 
   return (
     <Screen voterMode={false}>
-      <Main padded style={{ paddingLeft: '3em', paddingRight: '3em' }}>
+      <Main style={{ padding: '2em 6em' }}>
         <MainChild maxWidth={false} flexContainer>
           <Header>
             <Text>
               <strong>Accessible Controller Test</strong> &mdash; Step{' '}
               {currentStep + 1} of {steps.length}
             </Text>
-            <Button onPress={onCancel}>Exit</Button>
+            <Button onPress={onCancel}>Cancel Test</Button>
           </Header>
           {steps[currentStep]()}
         </MainChild>

--- a/frontends/bmd/src/pages/accessible_controller_test_screen.tsx
+++ b/frontends/bmd/src/pages/accessible_controller_test_screen.tsx
@@ -1,0 +1,209 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Button,
+  fontSizeTheme,
+  Main,
+  MainChild,
+  Prose,
+  Text,
+} from '@votingworks/ui';
+import { DateTime } from 'luxon';
+// import styled from 'styled-components';
+import { Screen } from '../components/screen';
+
+export type AccessibleControllerDiagnosticResults =
+  | {
+      passed: true;
+      completedAt: DateTime;
+    }
+  | {
+      passed: false;
+      completedAt: DateTime;
+      message: string;
+    };
+
+interface AccessibleControllerButtonTestProps {
+  buttonName: string;
+  buttonKey: string;
+  onSuccess: () => void;
+  onFailure: () => void;
+}
+
+function AccessibleControllerButtonTest({
+  buttonName,
+  buttonKey,
+  onSuccess,
+  onFailure,
+}: AccessibleControllerButtonTestProps) {
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      event.stopPropagation();
+      if (event.key === buttonKey) {
+        onSuccess();
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown, { capture: true });
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [buttonKey, onSuccess]);
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center' }}>
+      <Prose theme={fontSizeTheme.large} textCenter>
+        <h1 style={{ margin: '2em 2em' }}>Press the {buttonName}</h1>
+        <Button onPress={onFailure}>{buttonName} is Not Working</Button>
+      </Prose>
+      <img src="/images/controller-up-arrow.png" alt="up" />
+    </div>
+  );
+}
+
+// // https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm
+// function shuffle<T>(array: T[]): T[] {
+//   const shuffled = array.slice();
+//   for (let i = shuffled.length - 1; i > 0; i -= 1) {
+//     const j = Math.floor(Math.random() * (i + 1));
+//     [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+//   }
+//   return shuffled;
+// }
+
+interface AccessibleControllerHeadphonesTestProps {
+  onSuccess: () => void;
+  onFailure: () => void;
+}
+
+function AccessibleControllerHeadphonesTest({
+  onSuccess,
+  onFailure,
+}: AccessibleControllerHeadphonesTestProps) {
+  const instructions =
+    'Press the select button to confirm the audio is working.';
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      event.stopPropagation();
+      if (event.key === 'Enter') {
+        // TODO play audio
+        onSuccess();
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown, { capture: true });
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onSuccess]);
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center' }}>
+      <Prose theme={fontSizeTheme.large} textCenter>
+        <h3 style={{ margin: '2em 2em' }}>
+          Plug the Headphones Into the Accessible Controller, Then Press the Up
+          Button to Play Audio.
+        </h3>
+        <Text>{instructions}</Text>
+        <Button onPress={onFailure}>Audio is Not Working</Button>
+      </Prose>
+      <img
+        style={{ display: 'inline' }}
+        src="/images/controller-up-arrow.png"
+        alt="up"
+      />
+    </div>
+  );
+}
+
+interface AccessibleControllerTestProps {
+  onComplete: (results: AccessibleControllerDiagnosticResults) => void;
+  onCancel: () => void;
+}
+
+export function AccessibleControllerTest({
+  onComplete,
+  onCancel,
+}: AccessibleControllerTestProps): JSX.Element {
+  const [currentStep, setCurrentStep] = useState(0);
+
+  function passTest() {
+    onComplete({ passed: true, completedAt: DateTime.now() });
+  }
+  function failTest(message: string) {
+    onComplete({ passed: false, completedAt: DateTime.now(), message });
+  }
+
+  function nextStep() {
+    setCurrentStep((previousStep) => previousStep + 1);
+  }
+
+  const steps = [
+    () => (
+      <AccessibleControllerButtonTest
+        buttonName="Up Button"
+        buttonKey="ArrowUp"
+        onSuccess={nextStep}
+        onFailure={() => failTest('Up button is not working.')}
+      />
+    ),
+    () => (
+      <AccessibleControllerButtonTest
+        buttonName="Down Button"
+        buttonKey="ArrowDown"
+        onSuccess={nextStep}
+        onFailure={() => failTest('Down button is not working.')}
+      />
+    ),
+    () => (
+      <AccessibleControllerButtonTest
+        buttonName="Left Button"
+        buttonKey="ArrowLeft"
+        onSuccess={nextStep}
+        onFailure={() => failTest('Left button is not working.')}
+      />
+    ),
+    () => (
+      <AccessibleControllerButtonTest
+        buttonName="Right Button"
+        buttonKey="ArrowRight"
+        onSuccess={nextStep}
+        onFailure={() => failTest('Right button is not working.')}
+      />
+    ),
+    () => (
+      <AccessibleControllerButtonTest
+        buttonName="Select Button"
+        buttonKey="Enter"
+        onSuccess={nextStep}
+        onFailure={() => failTest('Select button is not working.')}
+      />
+    ),
+    () => (
+      <AccessibleControllerHeadphonesTest
+        onSuccess={passTest}
+        onFailure={() => failTest('Audio is not working.')}
+      />
+    ),
+  ];
+
+  return (
+    <Screen voterMode={false}>
+      <Main padded>
+        <MainChild maxWidth={false}>
+          <Prose
+            maxWidth={false}
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              margin: '0.5em 2em 1em 2em',
+              alignItems: 'baseline',
+            }}
+            theme={fontSizeTheme.medium}
+          >
+            <Text>
+              <strong>Accessible Controller Test</strong> &mdash; Step{' '}
+              {currentStep + 1} of {steps.length}
+            </Text>
+            <Button onPress={onCancel}>Exit</Button>
+          </Prose>
+          {steps[currentStep]()}
+        </MainChild>
+      </Main>
+    </Screen>
+  );
+}

--- a/frontends/bmd/src/pages/diagnostics_screen.test.tsx
+++ b/frontends/bmd/src/pages/diagnostics_screen.test.tsx
@@ -42,7 +42,7 @@ function renderScreen(props: Partial<DiagnosticsScreenProps> = {}) {
 }
 
 describe('System Diagnostics screen', () => {
-  beforeAll(() => {
+  beforeEach(() => {
     MockDate.set('2022-03-23T11:23:00.000Z');
   });
 
@@ -281,6 +281,19 @@ describe('System Diagnostics screen', () => {
         'Test passed.'
       );
       expectToHaveSuccessIcon(testResultText);
+      within(controllerSection).getByText('Last tested at 11:23 AM');
+
+      // Bonus test - if we start a new test and cancel it, last results should still be shown
+      MockDate.set(new Date());
+      userEvent.click(
+        within(controllerSection).getByText('Start Accessible Controller Test')
+      );
+      userEvent.click(screen.getByRole('button', { name: 'Cancel Test' }));
+
+      controllerSection = (
+        await screen.findByRole('heading', { name: 'Accessible Controller' })
+      ).closest('section')!;
+      within(controllerSection).getByText('Test passed.');
       within(controllerSection).getByText('Last tested at 11:23 AM');
 
       unmount();

--- a/frontends/bmd/src/pages/diagnostics_screen.tsx
+++ b/frontends/bmd/src/pages/diagnostics_screen.tsx
@@ -15,12 +15,23 @@ import assert from 'assert';
 import { formatTime, Hardware } from '@votingworks/utils';
 import { DateTime } from 'luxon';
 import { useHistory, Switch, Route } from 'react-router-dom';
+import styled from 'styled-components';
 import {
   AccessibleControllerDiagnosticResults,
   AccessibleControllerTest,
 } from './accessible_controller_test_screen';
 import { Screen } from '../components/screen';
 import { Sidebar, SidebarProps } from '../components/sidebar';
+import { ScreenReader } from '../config/types';
+
+const ButtonAndTimestamp = styled.div`
+  display: flex;
+  align-items: baseline;
+  margin-top: 0.5em;
+  > button {
+    margin-right: 0.5em;
+  }
+`;
 
 interface ComputerStatusProps {
   computer: ComputerStatusType;
@@ -155,16 +166,10 @@ function PrinterStatus({ hardware }: PrinterStatusProps) {
   const { printer, loadedAt } = printerStatus;
 
   const refreshButton = (
-    <div
-      style={{ display: 'flex', alignItems: 'baseline', marginTop: '0.5em' }}
-    >
+    <ButtonAndTimestamp>
       <Button onPress={loadPrinterStatus}>Refresh Printer Status</Button>
-      {loadedAt && (
-        <div style={{ marginLeft: '0.5em' }}>
-          <Text small>Last updated at {formatTime(loadedAt)}</Text>
-        </div>
-      )}
-    </div>
+      {loadedAt && <Text small>Last updated at {formatTime(loadedAt)}</Text>}
+    </ButtonAndTimestamp>
   );
 
   if (!printer || printer.state === 'unknown') {
@@ -231,7 +236,7 @@ function AccessibleControllerStatus({
         ) : (
           <Text warningIcon>Test failed: {diagnosticResults.message}</Text>
         ))}
-      <div style={{ display: 'flex', alignItems: 'baseline' }}>
+      <ButtonAndTimestamp>
         <LinkButton to="/accessible-controller">
           Start Accessible Controller Test
         </LinkButton>
@@ -240,7 +245,7 @@ function AccessibleControllerStatus({
             Last tested at {formatTime(diagnosticResults.completedAt)}
           </Text>
         )}
-      </div>
+      </ButtonAndTimestamp>
     </React.Fragment>
   );
 }
@@ -248,6 +253,7 @@ function AccessibleControllerStatus({
 interface DiagnosticsScreenProps {
   hardware: Hardware;
   devices: Devices;
+  screenReader: ScreenReader;
   onBackButtonPress: () => void;
   sidebarProps: SidebarProps;
 }
@@ -255,6 +261,7 @@ interface DiagnosticsScreenProps {
 export function DiagnosticsScreen({
   hardware,
   devices,
+  screenReader,
   onBackButtonPress,
   sidebarProps,
 }: DiagnosticsScreenProps): JSX.Element {
@@ -307,6 +314,7 @@ export function DiagnosticsScreen({
       </Route>
       <Route path="/accessible-controller">
         <AccessibleControllerTest
+          screenReader={screenReader}
           onComplete={(results) => {
             setAccessibleControllerDiagnosticResults(results);
             history.push('/');

--- a/frontends/bmd/src/pages/diagnostics_screen.tsx
+++ b/frontends/bmd/src/pages/diagnostics_screen.tsx
@@ -17,7 +17,7 @@ import { DateTime } from 'luxon';
 import { useHistory, Switch, Route } from 'react-router-dom';
 import styled from 'styled-components';
 import {
-  AccessibleControllerDiagnostic,
+  AccessibleControllerDiagnosticScreen,
   AccessibleControllerDiagnosticResults,
 } from './accessible_controller_diagnostic_screen';
 import { Screen } from '../components/screen';
@@ -312,7 +312,7 @@ export function DiagnosticsScreen({
         </Screen>
       </Route>
       <Route path="/accessible-controller">
-        <AccessibleControllerDiagnostic
+        <AccessibleControllerDiagnosticScreen
           screenReader={screenReader}
           onComplete={(results) => {
             setAccessibleControllerDiagnosticResults(results);

--- a/frontends/bmd/src/pages/diagnostics_screen.tsx
+++ b/frontends/bmd/src/pages/diagnostics_screen.tsx
@@ -272,7 +272,6 @@ export function DiagnosticsScreen({
     !(devices.computer.batteryIsLow && !devices.computer.batteryIsCharging)
   );
 
-  // TODO hoist so this state persists
   const [
     accessibleControllerDiagnosticResults,
     setAccessibleControllerDiagnosticResults,

--- a/frontends/bmd/src/pages/diagnostics_screen.tsx
+++ b/frontends/bmd/src/pages/diagnostics_screen.tsx
@@ -250,7 +250,7 @@ function AccessibleControllerStatus({
   );
 }
 
-interface DiagnosticsScreenProps {
+export interface DiagnosticsScreenProps {
   hardware: Hardware;
   devices: Devices;
   screenReader: ScreenReader;

--- a/frontends/bmd/src/pages/diagnostics_screen.tsx
+++ b/frontends/bmd/src/pages/diagnostics_screen.tsx
@@ -17,9 +17,9 @@ import { DateTime } from 'luxon';
 import { useHistory, Switch, Route } from 'react-router-dom';
 import styled from 'styled-components';
 import {
+  AccessibleControllerDiagnostic,
   AccessibleControllerDiagnosticResults,
-  AccessibleControllerTest,
-} from './accessible_controller_test_screen';
+} from './accessible_controller_diagnostic_screen';
 import { Screen } from '../components/screen';
 import { Sidebar, SidebarProps } from '../components/sidebar';
 import { ScreenReader } from '../config/types';
@@ -313,7 +313,7 @@ export function DiagnosticsScreen({
         </Screen>
       </Route>
       <Route path="/accessible-controller">
-        <AccessibleControllerTest
+        <AccessibleControllerDiagnostic
           screenReader={screenReader}
           onComplete={(results) => {
             setAccessibleControllerDiagnosticResults(results);

--- a/frontends/bmd/src/pages/poll_worker_screen.test.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.test.tsx
@@ -36,6 +36,8 @@ import { PollWorkerScreen, PollworkerScreenProps } from './poll_worker_screen';
 import { fakePrinter } from '../../test/helpers/fake_printer';
 import { fakeMachineConfig } from '../../test/helpers/fake_machine_config';
 import { fakeDevices } from '../../test/helpers/fake_devices';
+import { AriaScreenReader } from '../utils/ScreenReader';
+import { fakeTts } from '../../test/helpers/fake_tts';
 
 const electionSampleWithSeal = safeParseElection(
   electionSampleWithSealUntyped
@@ -62,6 +64,7 @@ function renderScreen(props: Partial<PollworkerScreenProps> = {}) {
       machineConfig={fakeMachineConfig({ appMode: MarkOnly })}
       hardware={MemoryHardware.buildStandard()}
       devices={fakeDevices()}
+      screenReader={new AriaScreenReader(fakeTts())}
       printer={fakePrinter()}
       togglePollsOpen={jest.fn()}
       tallyOnCard={undefined}

--- a/frontends/bmd/src/pages/poll_worker_screen.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.tsx
@@ -45,7 +45,7 @@ import {
 import { Prose } from '../components/prose';
 import { Screen } from '../components/screen';
 import { Text } from '../components/text';
-import { Sidebar } from '../components/sidebar';
+import { Sidebar, SidebarProps } from '../components/sidebar';
 import { ElectionInfo } from '../components/election_info';
 import { REPORT_PRINTING_TIMEOUT_SECONDS } from '../config/globals';
 import { VersionsData } from '../components/versions_data';
@@ -142,7 +142,7 @@ export function PollWorkerScreen({
     setIsPrintingPrecinctScannerReport,
   ] = useState(false);
 
-  const [isDiagnosticsScreenOpen, setIsDiagnosticsScreenOpen] = useState(false);
+  const [isDiagnosticsScreenOpen, setIsDiagnosticsScreenOpen] = useState(true);
 
   const parties = useMemo(() => getPartyIdsInBallotStyles(election), [
     election,
@@ -339,211 +339,211 @@ export function PollWorkerScreen({
     );
   }
 
-  const pollworkerMainScreen = (
-    <React.Fragment>
-      <Main padded>
-        <MainChild>
-          {isMarkAndPrintMode && isPollsOpen && (
-            <React.Fragment>
-              <Prose>
-                <h1>Activate Voter Session</h1>
-              </Prose>
-              {appPrecinct.kind === PrecinctSelectionKind.AllPrecincts && (
-                <React.Fragment>
-                  <h3>Choose Precinct</h3>
-                  <ButtonList data-testid="precincts">
-                    {election.precincts.map((precinct) => (
-                      <Button
-                        fullWidth
-                        key={precinct.id}
-                        aria-label={`Activate Voter Session for Precinct ${precinct.name}`}
-                        onPress={() =>
-                          activateCardlessVoterSession(precinct.id)
-                        }
-                        primary={cardlessVoterSessionPrecinctId === precinct.id}
-                      >
-                        {precinct.name}
-                      </Button>
-                    ))}
-                  </ButtonList>
-                </React.Fragment>
-              )}
-              {cardlessVoterSessionPrecinctId && (
-                <React.Fragment>
-                  <h3>Choose Ballot Style</h3>
-                  <ButtonList data-testid="ballot-styles">
-                    {precinctBallotStyles.map((bs) => (
-                      <Button
-                        fullWidth
-                        key={bs.id}
-                        aria-label={`Activate Voter Session for Ballot Style ${bs.id}`}
-                        onPress={() =>
-                          activateCardlessVoterSession(
-                            cardlessVoterSessionPrecinctId,
-                            bs.id
-                          )
-                        }
-                      >
-                        {bs.id}
-                      </Button>
-                    ))}
-                  </ButtonList>
-                </React.Fragment>
-              )}
-            </React.Fragment>
-          )}
-          <Prose>
-            <h1>Open/Close Polls</h1>
-            <Text warningIcon={!isPollsOpen} voteIcon={isPollsOpen}>
-              {isPollsOpen
-                ? 'Polls are currently open.'
-                : 'Polls are currently closed.'}{' '}
-              {isLiveMode ? (
-                <React.Fragment>
-                  Machine is in Live&nbsp;Election&nbsp;Mode.
-                </React.Fragment>
-              ) : (
-                <React.Fragment>
-                  Machine is in Testing&nbsp;Mode.
-                </React.Fragment>
-              )}
-            </Text>
-            <p>
-              <Button primary large onPress={togglePollsOpen}>
-                {isPollsOpen
-                  ? `Close Polls for ${precinctName}`
-                  : `Open Polls for ${precinctName}`}
-              </Button>
-            </p>
+  const sidebarProps: SidebarProps = {
+    appName: machineConfig.appMode.productName,
+    centerContent: true,
+    title: 'Poll Worker Actions',
+    screenReaderInstructions:
+      'To navigate through the available actions, use the down arrow.',
+    footer: (
+      <React.Fragment>
+        <ElectionInfo
+          electionDefinition={electionDefinition}
+          precinctSelection={appPrecinct}
+          horizontal
+        />
+        <VersionsData
+          machineConfig={machineConfig}
+          electionHash={electionDefinition.electionHash}
+        />
+      </React.Fragment>
+    ),
+  };
 
-            <h1>Advanced</h1>
-            <Button onPress={() => setIsDiagnosticsScreenOpen(true)}>
-              System Diagnostics
-            </Button>
-            <p>
-              <Button onPress={reload}>Reset Accessible Controller</Button>
-            </p>
-          </Prose>
-        </MainChild>
-      </Main>
-      {isConfirmingEnableLiveMode && (
-        <Modal
-          centerContent
-          content={
-            <Prose textCenter id="modalaudiofocus">
-              {isPrintMode ? (
-                <h1>
-                  Switch to Live&nbsp;Election&nbsp;Mode and reset the tally of
-                  printed ballots?
-                </h1>
-              ) : (
-                <h1>Switch to Live&nbsp;Election&nbsp;Mode?</h1>
-              )}
-              <p>
-                Today is Election Day and this machine is in{' '}
-                <strong>Testing&nbsp;Mode.</strong>
-              </p>
-              <p>
-                <em>
-                  Note: Switching back to Testing&nbsp;Mode requires an
-                  Admin&nbsp;Card.
-                </em>
-              </p>
-            </Prose>
-          }
-          actions={
-            <React.Fragment>
-              <Button
-                primary
-                danger={isPrintMode}
-                onPress={confirmEnableLiveMode}
-              >
-                Switch to Live&nbsp;Mode
-              </Button>
-              <Button onPress={cancelEnableLiveMode}>Cancel</Button>
-            </React.Fragment>
-          }
-        />
-      )}
-      {isPrintingPrecinctScannerReport && (
-        <Modal
-          content={
-            <Prose textCenter id="modalaudiofocus">
-              <Loading>Printing tally report</Loading>
-            </Prose>
-          }
-        />
-      )}
-      {isConfirmingPrecinctScannerPrint && !precinctScannerTallyInformation && (
-        <Modal
-          ariaHideApp={false}
-          content={
-            <Prose textCenter id="modalaudiofocus">
-              <Loading />
-            </Prose>
-          }
-        />
-      )}
-      {isConfirmingPrecinctScannerPrint && precinctScannerTallyInformation && (
-        <Modal
-          content={
-            <Prose id="modalaudiofocus">
-              <h1>Tally Report on Card</h1>
-              <p>
-                This poll worker card contains a tally report. The report will
-                be cleared from the card after being printed.
-              </p>
-            </Prose>
-          }
-          actions={
-            <React.Fragment>
-              <Button primary onPress={requestPrintPrecinctScannerReport}>
-                Print Tally Report
-              </Button>
-            </React.Fragment>
-          }
-        />
-      )}
-    </React.Fragment>
-  );
+  if (isDiagnosticsScreenOpen) {
+    return (
+      <DiagnosticsScreen
+        hardware={hardware}
+        devices={devices}
+        onBackButtonPress={() => setIsDiagnosticsScreenOpen(false)}
+        sidebarProps={sidebarProps}
+      />
+    );
+  }
 
   return (
     <React.Fragment>
       <Screen flexDirection="row-reverse" voterMode={false}>
-        {isDiagnosticsScreenOpen ? (
-          <DiagnosticsScreen hardware={hardware} devices={devices} />
-        ) : (
-          pollworkerMainScreen
-        )}
-        <Sidebar
-          appName={machineConfig.appMode.productName}
-          centerContent
-          title="Poll Worker Actions"
-          screenReaderInstructions="To navigate through the available actions, use the down arrow."
-          footer={
-            <React.Fragment>
-              <ElectionInfo
-                electionDefinition={electionDefinition}
-                precinctSelection={appPrecinct}
-                horizontal
-              />
-              <VersionsData
-                machineConfig={machineConfig}
-                electionHash={electionDefinition.electionHash}
-              />
-            </React.Fragment>
-          }
-        >
-          <Prose>
-            {isDiagnosticsScreenOpen ? (
-              <Button onPress={() => setIsDiagnosticsScreenOpen(false)}>
-                Back
-              </Button>
-            ) : (
-              <Text center>Remove card when finished.</Text>
+        <Main padded>
+          <MainChild>
+            {isMarkAndPrintMode && isPollsOpen && (
+              <React.Fragment>
+                <Prose>
+                  <h1>Activate Voter Session</h1>
+                </Prose>
+                {appPrecinct.kind === PrecinctSelectionKind.AllPrecincts && (
+                  <React.Fragment>
+                    <h3>Choose Precinct</h3>
+                    <ButtonList data-testid="precincts">
+                      {election.precincts.map((precinct) => (
+                        <Button
+                          fullWidth
+                          key={precinct.id}
+                          aria-label={`Activate Voter Session for Precinct ${precinct.name}`}
+                          onPress={() =>
+                            activateCardlessVoterSession(precinct.id)
+                          }
+                          primary={
+                            cardlessVoterSessionPrecinctId === precinct.id
+                          }
+                        >
+                          {precinct.name}
+                        </Button>
+                      ))}
+                    </ButtonList>
+                  </React.Fragment>
+                )}
+                {cardlessVoterSessionPrecinctId && (
+                  <React.Fragment>
+                    <h3>Choose Ballot Style</h3>
+                    <ButtonList data-testid="ballot-styles">
+                      {precinctBallotStyles.map((bs) => (
+                        <Button
+                          fullWidth
+                          key={bs.id}
+                          aria-label={`Activate Voter Session for Ballot Style ${bs.id}`}
+                          onPress={() =>
+                            activateCardlessVoterSession(
+                              cardlessVoterSessionPrecinctId,
+                              bs.id
+                            )
+                          }
+                        >
+                          {bs.id}
+                        </Button>
+                      ))}
+                    </ButtonList>
+                  </React.Fragment>
+                )}
+              </React.Fragment>
             )}
+            <Prose>
+              <h1>Open/Close Polls</h1>
+              <Text warningIcon={!isPollsOpen} voteIcon={isPollsOpen}>
+                {isPollsOpen
+                  ? 'Polls are currently open.'
+                  : 'Polls are currently closed.'}{' '}
+                {isLiveMode ? (
+                  <React.Fragment>
+                    Machine is in Live&nbsp;Election&nbsp;Mode.
+                  </React.Fragment>
+                ) : (
+                  <React.Fragment>
+                    Machine is in Testing&nbsp;Mode.
+                  </React.Fragment>
+                )}
+              </Text>
+              <p>
+                <Button primary large onPress={togglePollsOpen}>
+                  {isPollsOpen
+                    ? `Close Polls for ${precinctName}`
+                    : `Open Polls for ${precinctName}`}
+                </Button>
+              </p>
+
+              <h1>Advanced</h1>
+              <Button onPress={() => setIsDiagnosticsScreenOpen(true)}>
+                System Diagnostics
+              </Button>
+              <p>
+                <Button onPress={reload}>Reset Accessible Controller</Button>
+              </p>
+            </Prose>
+          </MainChild>
+        </Main>
+        <Sidebar {...sidebarProps}>
+          <Prose>
+            <Text center>Remove card when finished.</Text>
           </Prose>
         </Sidebar>
+        {isConfirmingEnableLiveMode && (
+          <Modal
+            centerContent
+            content={
+              <Prose textCenter id="modalaudiofocus">
+                {isPrintMode ? (
+                  <h1>
+                    Switch to Live&nbsp;Election&nbsp;Mode and reset the tally
+                    of printed ballots?
+                  </h1>
+                ) : (
+                  <h1>Switch to Live&nbsp;Election&nbsp;Mode?</h1>
+                )}
+                <p>
+                  Today is Election Day and this machine is in{' '}
+                  <strong>Testing&nbsp;Mode.</strong>
+                </p>
+                <p>
+                  <em>
+                    Note: Switching back to Testing&nbsp;Mode requires an
+                    Admin&nbsp;Card.
+                  </em>
+                </p>
+              </Prose>
+            }
+            actions={
+              <React.Fragment>
+                <Button
+                  primary
+                  danger={isPrintMode}
+                  onPress={confirmEnableLiveMode}
+                >
+                  Switch to Live&nbsp;Mode
+                </Button>
+                <Button onPress={cancelEnableLiveMode}>Cancel</Button>
+              </React.Fragment>
+            }
+          />
+        )}
+        {isPrintingPrecinctScannerReport && (
+          <Modal
+            content={
+              <Prose textCenter id="modalaudiofocus">
+                <Loading>Printing tally report</Loading>
+              </Prose>
+            }
+          />
+        )}
+        {isConfirmingPrecinctScannerPrint && !precinctScannerTallyInformation && (
+          <Modal
+            ariaHideApp={false}
+            content={
+              <Prose textCenter id="modalaudiofocus">
+                <Loading />
+              </Prose>
+            }
+          />
+        )}
+        {isConfirmingPrecinctScannerPrint && precinctScannerTallyInformation && (
+          <Modal
+            content={
+              <Prose id="modalaudiofocus">
+                <h1>Tally Report on Card</h1>
+                <p>
+                  This poll worker card contains a tally report. The report will
+                  be cleared from the card after being printed.
+                </p>
+              </Prose>
+            }
+            actions={
+              <React.Fragment>
+                <Button primary onPress={requestPrintPrecinctScannerReport}>
+                  Print Tally Report
+                </Button>
+              </React.Fragment>
+            }
+          />
+        )}
       </Screen>
       {tallyOnCard &&
         precinctScannerTallyInformation &&

--- a/frontends/bmd/src/pages/poll_worker_screen.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.tsx
@@ -40,6 +40,7 @@ import {
   PrecinctSelection,
   PrecinctSelectionKind,
   Printer,
+  ScreenReader,
 } from '../config/types';
 
 import { Prose } from '../components/prose';
@@ -69,6 +70,7 @@ export interface PollworkerScreenProps {
   machineConfig: MachineConfig;
   hardware: Hardware;
   devices: Devices;
+  screenReader: ScreenReader;
   printer: Printer;
   togglePollsOpen: () => void;
   tallyOnCard?: PrecinctScannerCardTally;
@@ -100,6 +102,7 @@ export function PollWorkerScreen({
   machineConfig,
   hardware,
   devices,
+  screenReader,
   printer,
   togglePollsOpen,
   hasVotes,
@@ -365,6 +368,7 @@ export function PollWorkerScreen({
       <DiagnosticsScreen
         hardware={hardware}
         devices={devices}
+        screenReader={screenReader}
         onBackButtonPress={() => setIsDiagnosticsScreenOpen(false)}
         sidebarProps={sidebarProps}
       />

--- a/frontends/bmd/src/pages/poll_worker_screen.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.tsx
@@ -145,7 +145,7 @@ export function PollWorkerScreen({
     setIsPrintingPrecinctScannerReport,
   ] = useState(false);
 
-  const [isDiagnosticsScreenOpen, setIsDiagnosticsScreenOpen] = useState(true);
+  const [isDiagnosticsScreenOpen, setIsDiagnosticsScreenOpen] = useState(false);
 
   const parties = useMemo(() => getPartyIdsInBallotStyles(election), [
     election,

--- a/frontends/bmd/test/helpers/fake_devices.ts
+++ b/frontends/bmd/test/helpers/fake_devices.ts
@@ -1,9 +1,10 @@
-import { fakePrinterInfo } from '@votingworks/test-utils';
+import { fakeDevice, fakePrinterInfo } from '@votingworks/test-utils';
 import { Devices } from '@votingworks/ui';
 
 interface PartialDevices {
   printer?: Partial<Devices['printer']>;
   computer?: Partial<Devices['computer']>;
+  accessibleController?: Devices['accessibleController'];
 }
 export function fakeDevices(devices: PartialDevices = {}): Devices {
   return {
@@ -14,5 +15,6 @@ export function fakeDevices(devices: PartialDevices = {}): Devices {
       batteryIsCharging: true,
       ...(devices.computer ?? {}),
     },
+    accessibleController: fakeDevice(devices.accessibleController),
   };
 }


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Task: #1417 

Adds a section for the accessible controller to the pollworker System Diagnostics screen, showing:
- Whether the controller is connected or not
- A button to start an interactive diagnostic test
- Results from the last test, if there are any

Note that currently test results only persist as long as the System Diagnostics screen is open. We may want to persist them longer in the future if we get feedback on that from users.

## Demo Video or Screenshot

https://user-images.githubusercontent.com/530106/161169933-14e5d359-a23e-4fb2-b1c1-83f7c5558ef1.mov

![localhost_3000_(Lenovo IdeaPad Flex 14 (FHD))](https://user-images.githubusercontent.com/530106/161170069-1784d373-252b-4d49-b01c-5a321e392c6c.png)


## Testing Plan 
Added automated tests

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
  - will add logging in a follow up PR
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
