### PR TITLE
Remove pi backup PIN from VxAdmin

### DIFF
--- a/frontends/election-manager/src/screens/unlock_machine_screen.test.tsx
+++ b/frontends/election-manager/src/screens/unlock_machine_screen.test.tsx
@@ -64,29 +64,3 @@ test('authentication', async () => {
 
   expect(screen.queryByText('Invalid code. Please try again.')).toBeNull();
 });
-
-test('Unconfigure VxAdmin from secret menu', async () => {
-  const attemptToAuthenticateAdminUser = jest.fn();
-  const saveElection = jest.fn();
-
-  renderInAppContext(<UnlockMachineScreen />, {
-    attemptToAuthenticateAdminUser,
-    saveElection,
-  });
-
-  attemptToAuthenticateAdminUser.mockReturnValueOnce(false);
-
-  userEvent.click(screen.getByText('3'));
-  userEvent.click(screen.getByText('1'));
-  userEvent.click(screen.getByText('4'));
-  userEvent.click(screen.getByText('1'));
-  userEvent.click(screen.getByText('5'));
-  userEvent.click(screen.getByText('9'));
-
-  await waitFor(() =>
-    expect(attemptToAuthenticateAdminUser).toHaveBeenNthCalledWith(1, '314159')
-  );
-
-  userEvent.click(screen.getByText('Remove Current Election'));
-  expect(saveElection).toHaveBeenCalledWith(undefined);
-});

--- a/frontends/election-manager/src/screens/unlock_machine_screen.tsx
+++ b/frontends/election-manager/src/screens/unlock_machine_screen.tsx
@@ -1,5 +1,4 @@
 import {
-  Button,
   fontSizeTheme,
   Main,
   MainChild,
@@ -35,15 +34,11 @@ export const EnteredCode = styled.div`
 export function UnlockMachineScreen(): JSX.Element {
   const {
     attemptToAuthenticateAdminUser,
-    saveElection,
     electionDefinition,
     machineConfig,
   } = useContext(AppContext);
   const [currentPasscode, setCurrentPasscode] = useState('');
   const [showError, setShowError] = useState(false);
-  // This is temporary while we improve the bootstrapping process. If PI is entered
-  // and that does not unlock the machine, show a button to allow for resetting the machine.
-  const [showFactoryReset, setShowFactoryReset] = useState(false);
   const handleNumberEntry = useCallback((digit: number) => {
     setCurrentPasscode((prev) =>
       `${prev}${digit}`.slice(0, SECURITY_PIN_LENGTH)
@@ -59,17 +54,10 @@ export function UnlockMachineScreen(): JSX.Element {
   useEffect(() => {
     if (currentPasscode.length === SECURITY_PIN_LENGTH) {
       const success = attemptToAuthenticateAdminUser(currentPasscode);
-      // This is temporary while we improve the bootstrapping process. If PI is entered
-      // and that does not unlock the machine, show a button to allow for resetting the machine.
-      setShowFactoryReset(currentPasscode === '314159');
       setShowError(!success);
       setCurrentPasscode('');
     }
   }, [currentPasscode, attemptToAuthenticateAdminUser]);
-
-  const resetMachine = useCallback(async () => {
-    await saveElection(undefined);
-  }, [saveElection]);
 
   const currentPasscodeDisplayString = '•'
     .repeat(currentPasscode.length)
@@ -80,13 +68,7 @@ export function UnlockMachineScreen(): JSX.Element {
   let primarySentence: JSX.Element = (
     <p>Enter the card security code to unlock.</p>
   );
-  if (showFactoryReset) {
-    primarySentence = (
-      <Button small danger onPress={resetMachine}>
-        Remove Current Election
-      </Button>
-    );
-  } else if (showError) {
+  if (showError) {
     primarySentence = <Text warning>Invalid code. Please try again.</Text>;
   }
   return (


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/1453

VxAdmin supports a special backup PIN. If an admin enters pi (314159), they'll be given an option to remove the election definition. This is a fallback for the case that machines need to be set up, and no one knows the PIN. Moving forward, we'll be solving this with a backup admin card sent to customers, so we can remove this special backup PIN.

## Demo videos

### Before

https://user-images.githubusercontent.com/12616928/161155214-e87d2543-e052-4f67-a6c5-6ae6e0f8ef29.mov

### After

https://user-images.githubusercontent.com/12616928/161155210-bbe4fb92-38f5-41f0-9cb3-8821711002c3.mov

## Testing

- [x] Manually verified that the backup PIN no longer works (demoed above)
- [x] Manually verified that a valid PIN still works
- [x] Verified that the pre-existing unit test for the backup PIN now fails (before removing the test)

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A
- [ ] ~I have added JSDoc comments to any newly introduced exports~ N/A
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates