### PR TITLE
fix(scan): make canvas debug work again

### DIFF
--- a/libs/ballot-interpreter-nh/src/debug.ts
+++ b/libs/ballot-interpreter-nh/src/debug.ts
@@ -460,7 +460,11 @@ export function withCanvasDebugger<T>(
 
     onLayerEnd(layer) {
       let layerFileName = '';
-      for (let parentLayer = layer; parentLayer.parent; ) {
+      for (
+        let parentLayer = layer;
+        parentLayer.parent;
+        parentLayer = parentLayer.parent
+      ) {
         layerFileName = `${parentLayer.name}--${layerFileName}`;
       }
       writeFileSync(


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
It would get stuck in an infinite loop if there were any sub-layers due to a missing parent traversal.

## Demo Video or Screenshot
n/a

## Testing Plan 
Manually tested with the `accuvote.test.ts` file.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
