### PR TITLE
fix(script): validate `tsconfig.json` without `tsconfig.build.json`

### DIFF
--- a/frontends/bmd/tsconfig.json
+++ b/frontends/bmd/tsconfig.json
@@ -20,6 +20,7 @@
   "references": [
     { "path": "../../libs/ballot-encoder/tsconfig.build.json" },
     { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
+    { "path": "../../libs/fixtures/tsconfig.build.json" },
     { "path": "../../libs/logging/tsconfig.build.json" },
     { "path": "../../libs/test-utils/tsconfig.build.json" },
     { "path": "../../libs/types/tsconfig.build.json" },


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
Without a `tsconfig.build.json`, the `validate-monorepo` script wasn't validating the references in `tsconfig.json`. This fixes that issue and the missing reference that it uncovered.

## Demo Video or Screenshot
n/a

## Testing Plan 
Tried it manually.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
