### PR TITLE
fix(script): add trailing newline

### DIFF
--- a/script/src/validate-monorepo/index.ts
+++ b/script/src/validate-monorepo/index.ts
@@ -103,7 +103,7 @@ export async function main({ stdout, stderr }: IO): Promise<number> {
   }
 
   stdout.write(
-    `${packageCount} package.json, ${tsconfigCount} tsconfig.json, ${tsconfigBuildCount} tsconfig.build.json, ${errors} error(s)`
+    `${packageCount} package.json, ${tsconfigCount} tsconfig.json, ${tsconfigBuildCount} tsconfig.build.json, ${errors} error(s)\n`
   );
   return errors === 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Might mess with some shells/prompts not to have this.

## Demo Video or Screenshot
```sh
# before
brian@debian ~/code/vxsuite main
❯ ./script/validate-monorepo 
22 package.json, 22 tsconfig.json, 17 tsconfig.build.json, 0 error(s)
brian@debian ~/code/vxsuite main
❯ 

# after
brian@debian ~/code/vxsuite main
❯ ./script/validate-monorepo   
22 package.json, 22 tsconfig.json, 17 tsconfig.build.json, 0 error(s)

brian@debian ~/code/vxsuite main
❯ 
```

## Testing Plan 
n/a

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
