### PR TITLE
Update lock screens to include system name

### DIFF
--- a/frontends/bsd/src/app.test.tsx
+++ b/frontends/bsd/src/app.test.tsx
@@ -60,7 +60,7 @@ afterEach(() => {
 
 async function authenticateWithAdminCard(card: MemoryCard) {
   // Machine should be locked
-  await screen.findByText('Machine Locked');
+  await screen.findByText('VxCentralScan is Locked');
   card.insertCard({
     t: 'admin',
     h: electionSampleDefinition.electionHash,
@@ -369,7 +369,7 @@ test('authentication works', async () => {
 
   render(<App card={card} hardware={hardware} />);
 
-  await screen.findByText('Machine Locked');
+  await screen.findByText('VxCentralScan is Locked');
   const adminCard: AdminCardData = {
     t: 'admin',
     h: electionSampleDefinition.electionHash,
@@ -388,7 +388,7 @@ test('authentication works', async () => {
   act(() => {
     hardware.setCardReaderConnected(true);
   });
-  await screen.findByText('Machine Locked');
+  await screen.findByText('VxCentralScan is Locked');
 
   // Insert an admin card and enter the wrong code.
   card.insertCard(adminCard);
@@ -409,7 +409,7 @@ test('authentication works', async () => {
   await act(async () => {
     await sleep(100);
   });
-  await screen.findByText('Machine Locked');
+  await screen.findByText('VxCentralScan is Locked');
   card.insertCard(pollWorkerCard);
   await act(async () => {
     await sleep(100);
@@ -466,5 +466,5 @@ test('authentication works', async () => {
 
   // Lock the machine
   fireEvent.click(screen.getByText('Lock Machine'));
-  await screen.findByText('Machine Locked');
+  await screen.findByText('VxCentralScan is Locked');
 });

--- a/frontends/bsd/src/screens/machine_locked_screen.tsx
+++ b/frontends/bsd/src/screens/machine_locked_screen.tsx
@@ -20,7 +20,7 @@ export function MachineLockedScreen(): JSX.Element {
         <MainChild maxWidth={false} centerHorizontal centerVertical>
           <LockedImage src="locked.svg" alt="Locked Icon" />
           <Prose textCenter theme={fontSizeTheme.medium} maxWidth={false}>
-            <h1>Machine Locked</h1>
+            <h1>VxCentralScan is Locked</h1>
             <p>Insert an admin card to unlock.</p>
           </Prose>
         </MainChild>

--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -126,7 +126,7 @@ async function createMemoryStorageWith({
 
 async function authenticateWithAdminCard(card: MemoryCard) {
   // Machine should be locked
-  await screen.findByText('Machine Locked');
+  await screen.findByText('VxAdmin is Locked');
   card.insertCard({
     t: 'admin',
     h: eitherNeitherElectionDefinition.electionHash,
@@ -207,7 +207,7 @@ test('authentication works', async () => {
   });
   render(<App card={card} hardware={hardware} storage={storage} />);
 
-  await screen.findByText('Machine Locked');
+  await screen.findByText('VxAdmin is Locked');
   const adminCard: AdminCardData = {
     t: 'admin',
     h: eitherNeitherElectionDefinition.electionHash,
@@ -224,7 +224,7 @@ test('authentication works', async () => {
   await screen.findByText('Card Reader Not Detected');
   act(() => hardware.setCardReaderConnected(true));
   await advanceTimersAndPromises(1);
-  await screen.findByText('Machine Locked');
+  await screen.findByText('VxAdmin is Locked');
 
   // Insert an admin card and enter the wrong code.
   card.insertCard(adminCard);
@@ -247,7 +247,7 @@ test('authentication works', async () => {
   // Remove card and insert a pollworker card.
   card.removeCard();
   await advanceTimersAndPromises(1);
-  await screen.findByText('Machine Locked');
+  await screen.findByText('VxAdmin is Locked');
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises(1);
   await screen.findByText('Invalid Card');
@@ -296,7 +296,7 @@ test('authentication works', async () => {
 
   // Lock the machine
   fireEvent.click(screen.getByText('Lock Machine'));
-  await screen.findByText('Machine Locked');
+  await screen.findByText('VxAdmin is Locked');
   expect(mockKiosk.log).toHaveBeenCalledWith(
     expect.stringContaining(LogEventId.MachineLocked)
   );

--- a/frontends/election-manager/src/screens/machine_locked_screen.tsx
+++ b/frontends/election-manager/src/screens/machine_locked_screen.tsx
@@ -25,7 +25,7 @@ export function MachineLockedScreen(): JSX.Element {
         <MainChild center>
           <LockedImage src="locked.svg" alt="Locked Icon" />
           <Prose textCenter theme={fontSizeTheme.medium} maxWidth={false}>
-            <h1>Machine Locked</h1>
+            <h1>VxAdmin is Locked</h1>
             <p>Insert an admin card to unlock.</p>
           </Prose>
         </MainChild>


### PR DESCRIPTION
## Overview

Issue link: [#1406](https://github.com/votingworks/vxsuite/issues/1406)

This PR updates the VxAdmin and VxCentralScan lock screens to include the system name for clarity. Before this PR, both lock screens read "Machine Locked".

Note that [#1406](https://github.com/votingworks/vxsuite/issues/1406) also recommended adding the election footer to the VxCentralScan lock screen. Turns out, the footer is already there. It just doesn't appear until you've loaded a ballot package, thereby giving the machine an election definition.

## Demo screenshot

![vx-admin](https://user-images.githubusercontent.com/12616928/162838676-43485ffb-79b3-4636-8381-216a1412934d.png)

![vx-central-scan](https://user-images.githubusercontent.com/12616928/162838678-67c24dda-1ee3-4a0e-ae73-404c22340a58.png)

## Testing plan

- [x] Ran VxAdmin manually
- [x] Ran VxCentralScan manually
- [x] Updated unit tests

## Checklist
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A
- [ ] ~I have added JSDoc comments to any newly introduced exports~ N/A
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates