### PR TITLE
Save Cypress artifacts in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,10 @@ jobs:
           name: Test
           command: |
             pnpm --dir frontends/bmd test
+      - store_artifacts:
+          path: frontends/bmd/cypress/screenshots
+      - store_artifacts:
+          path: frontends/bmd/cypress/videos
 
   test-integration-testing-bmd:
     executor: nodejs-browsers
@@ -80,6 +84,10 @@ jobs:
           name: Test
           command: |
             pnpm --dir frontends/bmd test:e2e
+      - store_artifacts:
+          path: integration-testing/bmd/cypress/screenshots
+      - store_artifacts:
+          path: integration-testing/bmd/cypress/videos
 
   test-frontends-bsd:
     executor: nodejs-browsers
@@ -98,6 +106,10 @@ jobs:
           name: Test
           command: |
             pnpm --dir frontends/bsd test
+      - store_artifacts:
+          path: frontends/bsd/cypress/screenshots
+      - store_artifacts:
+          path: frontends/bsd/cypress/videos
 
   test-frontends-election-manager:
     executor: nodejs-browsers
@@ -116,6 +128,10 @@ jobs:
           name: Test
           command: |
             pnpm --dir frontends/election-manager test
+      - store_artifacts:
+          path: frontends/election-manager/cypress/screenshots
+      - store_artifacts:
+          path: frontends/election-manager/cypress/videos
 
   test-frontends-precinct-scanner:
     executor: nodejs-browsers
@@ -153,6 +169,10 @@ jobs:
           name: Test
           command: |
             pnpm --dir integration-testing/bsd test
+      - store_artifacts:
+          path: integration-testing/bsd/cypress/screenshots
+      - store_artifacts:
+          path: integration-testing/bsd/cypress/videos
 
   test-integration-testing-election-manager:
     docker:
@@ -172,6 +192,10 @@ jobs:
           name: Test
           command: |
             pnpm --dir integration-testing/election-manager test
+      - store_artifacts:
+          path: integration-testing/election-manager/cypress/screenshots
+      - store_artifacts:
+          path: integration-testing/election-manager/cypress/videos
 
   test-libs-ballot-encoder:
     executor: nodejs


### PR DESCRIPTION
## Overview
Closes #1684

Adds a `store_artifacts` entry to each job that runs cypress, so that any resulting cypress `.mp4` or `.png` artifacts can be viewed from the CircleCI "Artifacts" tab.

## Demo Video or Screenshot
<img width="600" alt="Screen Shot 2022-04-13 at 8 05 24 AM" src="https://user-images.githubusercontent.com/7584833/163176460-1859eb02-095e-4d79-8073-991f413baf56.png">

## Testing Plan 
Failed a test on purpose, confirmed that artifacts were saved and viewable from the CircleCI "Artifacts" tab.

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
