### PR TITLE
Add Code Owners file for review assignment 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,29 @@
+# VxSuite Code Owners
+
+# These owners are used to automate code reviews, if there is a specific part of the codebase you would like to be tagged on reviews for add yourself as a code owner.
+
+# The order of this file is important. The last matching rule will take precedence.
+
+# By default assign the vxsuite-eng group. Code reviews will be randomly round-robined within this group to assign someone on the team for a general code review.
+* @votingworks/vxsuite-eng
+
+# More specific ownership rules for more knowledge-specific reviews.
+# It is recommended to continue to include the vxsuite-eng group in these so knowledge doesn't get too silod and people gain context on code outside of what they own.
+services/scan/ @eventualbuddha @votingworks/vxsuite-eng
+libs/ballot-encoder/ @eventualbuddha @votingworks/vxsuite-eng
+libs/ballot-interpreter-nh/ @eventualbuddha @votingworks/vxsuite-eng
+libs/ballot-interpreter-vx/ @eventualbuddha @votingworks/vxsuite-eng
+libs/eslint-plugin-vx/ @eventualbuddha @votingworks/vxsuite-eng
+
+libs/ui/**/*.tsx @beausmith @votingworks/vxsuite-eng
+
+frontends/election-manager/src/utils/exportable_tallies* @carolinemodic @votingworks/vxsuite-eng 
+frontends/election-manager/src/utils/external_tallies* @carolinemodic @votingworks/vxsuite-eng
+frontends/election-manager/src/utils/sems_tallies* @carolinemodic @votingworks/vxsuite-eng
+frontends/election-manager/src/lib/votecounting* @carolinemodic @votingworks/vxsuite-eng
+libs/utils/src/tallies* @carolinemodic @votingworks/vxsuite-eng
+libs/utils/src/votes* @carolinemodic @votingworks/vxsuite-eng
+libs/utils/src/compressed_tallies* @carolinemodic @votingworks/vxsuite-eng
+libs/logging/ @carolinemodic @votingworks/vxsuite-eng
+
+.github/ @carolinemodic @votingworks/vxsuite-eng


### PR DESCRIPTION
Adds an initial codeowners file to vxsuite to automate PR assignment. This can grow and evolve overtime, anyone is welcome to add additional rules to route things to themselves as they see fit. Obviously I added more specific rules for myself as I knew best what I wanted to be included on reviews for but wasn't sure about what other people would want so those are left more vague. 
