### PR TITLE
VxAdmin: Move tally report to subcomponent for reuse in zero-report generation button

### DIFF
--- a/frontends/election-manager/src/components/election_manager_tally_report.tsx
+++ b/frontends/election-manager/src/components/election_manager_tally_report.tsx
@@ -1,0 +1,483 @@
+import React, { useContext, useEffect, useRef, useState, useMemo } from 'react';
+import styled from 'styled-components';
+
+import { useParams } from 'react-router-dom';
+import { assert, find, filterTalliesByParams } from '@votingworks/utils';
+import { LogEventId } from '@votingworks/logging';
+import {
+  ExternalTally,
+  VotingMethod,
+  getLabelForVotingMethod,
+  Tally,
+  unsafeParse,
+  PartyIdSchema,
+} from '@votingworks/types';
+import {
+  ContestTally,
+  TallyReport,
+  TallyReportColumns,
+  ReportSection,
+  TallyReportMetadata,
+  TallyReportSummary,
+  LogoMark,
+} from '@votingworks/ui';
+import {
+  generateDefaultReportFilename,
+  generateFileContentToSaveAsPdf,
+} from '../utils/save_as_pdf';
+
+import {
+  PrecinctReportScreenProps,
+  ScannerReportScreenProps,
+  PartyReportScreenProps,
+  BatchReportScreenProps,
+  VotingMethodReportScreenProps,
+} from '../config/types';
+import { AppContext } from '../contexts/app_context';
+
+import { PrintButton } from './print_button';
+import { Button } from './button';
+import { NavigationScreen } from './navigation_screen';
+import { Prose } from './prose';
+import { LinkButton } from './link_button';
+
+import { routerPaths } from '../router_paths';
+import { filterTalliesByParamsAndBatchId } from '../lib/votecounting';
+import { filterExternalTalliesByParams } from '../utils/external_tallies';
+
+import { Text } from './text';
+import { SaveFileToUsb, FileType } from './save_file_to_usb';
+
+const TallyReportPreview = styled(TallyReport)`
+  section {
+    margin: 1rem 0 2rem;
+    background: #ffffff;
+    width: 8.5in;
+    min-height: 11in;
+    padding: 0.5in;
+  }
+`;
+
+export function TallyReportScreen(): JSX.Element {
+  const printReportRef = useRef<HTMLDivElement>(null);
+  const previewReportRef = useRef<HTMLDivElement>(null);
+  const [showPreview, setShowPreview] = useState(false);
+  const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
+  const {
+    precinctId: precinctIdFromProps,
+  } = useParams<PrecinctReportScreenProps>();
+  const { scannerId } = useParams<ScannerReportScreenProps>();
+  const { batchId } = useParams<BatchReportScreenProps>();
+  const { partyId: partyIdFromProps } = useParams<PartyReportScreenProps>();
+  const {
+    votingMethod: votingMethodFromProps,
+  } = useParams<VotingMethodReportScreenProps>();
+  const votingMethod = votingMethodFromProps as VotingMethod;
+  const {
+    electionDefinition,
+    isOfficialResults,
+    fullElectionTally,
+    fullElectionExternalTallies,
+    isTabulationRunning,
+    currentUserSession,
+    logger,
+  } = useContext(AppContext);
+  assert(electionDefinition);
+  assert(currentUserSession); // TODO(auth) check permissions for viewing tally reports.
+  const currentUserType = currentUserSession.type;
+
+  const { election } = electionDefinition;
+  const statusPrefix = isOfficialResults ? 'Official' : 'Unofficial';
+
+  const ballotStylePartyIds =
+    partyIdFromProps !== undefined
+      ? [unsafeParse(PartyIdSchema, partyIdFromProps)]
+      : Array.from(new Set(election.ballotStyles.map((bs) => bs.partyId)));
+
+  const precinctIds =
+    precinctIdFromProps === 'all'
+      ? election.precincts.map((p) => p.id)
+      : [precinctIdFromProps];
+
+  const precinctName =
+    (precinctIdFromProps &&
+      precinctIdFromProps !== 'all' &&
+      find(election.precincts, (p) => p.id === precinctIdFromProps).name) ||
+    undefined;
+
+  const fileSuffix = useMemo(() => {
+    if (scannerId) {
+      return `scanner-${scannerId}`;
+    }
+    if (batchId) {
+      return `batch-${batchId}`;
+    }
+    if (precinctIdFromProps === 'all') {
+      return 'all-precincts';
+    }
+    if (partyIdFromProps) {
+      const party = find(election.parties, (p) => p.id === partyIdFromProps);
+      return party.fullName;
+    }
+    if (votingMethod) {
+      const label = getLabelForVotingMethod(votingMethod);
+      return `${label}-ballots`;
+    }
+    return precinctName;
+  }, [
+    batchId,
+    scannerId,
+    precinctIdFromProps,
+    votingMethod,
+    partyIdFromProps,
+    election.parties,
+    precinctName,
+  ]);
+  const batchLabel = useMemo(() => {
+    if (batchId) {
+      assert(fullElectionTally);
+      const batchTally = filterTalliesByParamsAndBatchId(
+        fullElectionTally,
+        election,
+        batchId,
+        {}
+      );
+      return `${batchTally.batchLabel} (Scanner: ${batchTally.scannerIds.join(
+        ', '
+      )})`;
+    }
+    return '';
+  }, [batchId, fullElectionTally, election]);
+  const reportDisplayTitle = useMemo(() => {
+    if (precinctName) {
+      return `${statusPrefix} Precinct Tally Report for ${precinctName}`;
+    }
+    if (scannerId) {
+      return `${statusPrefix} Scanner Tally Report for Scanner ${scannerId}`;
+    }
+    if (batchId) {
+      return `${statusPrefix} Batch Tally Report for ${batchLabel}`;
+    }
+    if (precinctIdFromProps === 'all') {
+      return `${statusPrefix} ${election.title} Tally Reports for All Precincts`;
+    }
+    if (partyIdFromProps) {
+      const party = find(election.parties, (p) => p.id === partyIdFromProps);
+      return `${statusPrefix} Tally Report for ${party.fullName}`;
+    }
+    if (votingMethod) {
+      const label = getLabelForVotingMethod(votingMethod);
+      return `${statusPrefix} ${label} Ballot Tally Report`;
+    }
+    return `${statusPrefix} ${election.title} Tally Report`;
+  }, [
+    batchId,
+    scannerId,
+    precinctIdFromProps,
+    votingMethod,
+    partyIdFromProps,
+    batchLabel,
+    statusPrefix,
+    election,
+    precinctName,
+  ]);
+
+  useEffect(() => {
+    if (showPreview) {
+      void logger.log(LogEventId.TallyReportPreviewed, currentUserType, {
+        message: `User previewed a ${reportDisplayTitle} to view.`,
+        disposition: 'success',
+        tallyReportTitle: reportDisplayTitle,
+      });
+    }
+  }, [showPreview, logger, reportDisplayTitle, currentUserType]);
+
+  function afterPrint() {
+    void logger.log(LogEventId.TallyReportPrinted, currentUserType, {
+      message: `User printed ${reportDisplayTitle}`,
+      disposition: 'success',
+      tallyReportTitle: reportDisplayTitle,
+    });
+  }
+
+  function afterPrintError(errorMessage: string) {
+    void logger.log(LogEventId.TallyReportPrinted, currentUserType, {
+      message: `Error in attempting to print ${reportDisplayTitle}: ${errorMessage}`,
+      disposition: 'failure',
+      tallyReportTitle: reportDisplayTitle,
+      errorMessage,
+      result: 'User shown error.',
+    });
+  }
+
+  if (isTabulationRunning) {
+    return (
+      <NavigationScreen mainChildCenter>
+        <Prose textCenter>
+          <h1>Building Tabulation Report...</h1>
+          <p>This may take a few seconds.</p>
+        </Prose>
+      </NavigationScreen>
+    );
+  }
+
+  const defaultReportFilename = generateDefaultReportFilename(
+    'tabulation-report',
+    election,
+    fileSuffix
+  );
+
+  function toggleReportPreview() {
+    setShowPreview((s) => !s);
+  }
+
+  const generatedAtTime = new Date();
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  useEffect(() => {
+    if (previewReportRef?.current && printReportRef?.current) {
+      previewReportRef.current.innerHTML = printReportRef.current.innerHTML;
+    }
+  }, [previewReportRef, printReportRef, showPreview]);
+
+  return (
+    <React.Fragment>
+      <NavigationScreen>
+        <Prose>
+          <h1>{reportDisplayTitle}</h1>
+          <TallyReportMetadata
+            generatedAtTime={generatedAtTime}
+            election={election}
+          />
+          <p>
+            <PrintButton
+              afterPrint={afterPrint}
+              afterPrintError={afterPrintError}
+              primary
+              sides="one-sided"
+            >
+              Print Report
+            </PrintButton>{' '}
+            <Button onPress={toggleReportPreview}>
+              {showPreview ? 'Hide Preview' : 'Preview Report'}
+            </Button>{' '}
+            {window.kiosk && (
+              <Button onPress={() => setIsSaveModalOpen(true)}>
+                Save Report as PDF
+              </Button>
+            )}
+          </p>
+          <p>
+            <LinkButton small to={routerPaths.tally}>
+              Back to Tally Index
+            </LinkButton>
+          </p>
+          {showPreview && (
+            <React.Fragment>
+              <h2>Report Preview</h2>
+              <Text italic small>
+                <strong>Note:</strong> Printed reports may be paginated to more
+                than one piece of paper.
+              </Text>
+            </React.Fragment>
+          )}
+        </Prose>
+        {showPreview && <TallyReportPreview ref={previewReportRef} />}
+      </NavigationScreen>
+      {isSaveModalOpen && (
+        <SaveFileToUsb
+          onClose={() => setIsSaveModalOpen(false)}
+          generateFileContent={generateFileContentToSaveAsPdf}
+          defaultFilename={defaultReportFilename}
+          fileType={FileType.TallyReport}
+        />
+      )}
+      <TallyReport ref={printReportRef} className="print-only">
+        {ballotStylePartyIds.map((partyId) =>
+          precinctIds.map((precinctId) => {
+            const party = election.parties.find((p) => p.id === partyId);
+            const electionTitle = party
+              ? `${party.fullName} ${election.title}`
+              : election.title;
+
+            const tallyForReport = filterTalliesByParams(
+              fullElectionTally,
+              election,
+              { precinctId, scannerId, partyId, votingMethod, batchId }
+            );
+            const ballotCountsByVotingMethod: Tally['ballotCountsByVotingMethod'] = {
+              ...tallyForReport.ballotCountsByVotingMethod,
+            };
+            let reportBallotCount = tallyForReport.numberOfBallotsCounted;
+            const externalTalliesForReport: ExternalTally[] = [];
+            for (const t of fullElectionExternalTallies) {
+              const filteredTally = filterExternalTalliesByParams(t, election, {
+                precinctId,
+                partyId,
+                scannerId,
+                batchId,
+                votingMethod,
+              });
+              if (filteredTally !== undefined) {
+                externalTalliesForReport.push(filteredTally);
+                ballotCountsByVotingMethod[t.votingMethod] =
+                  filteredTally.numberOfBallotsCounted +
+                  (ballotCountsByVotingMethod[t.votingMethod] ?? 0);
+                reportBallotCount += filteredTally.numberOfBallotsCounted;
+              }
+            }
+
+            if (precinctId) {
+              const currentPrecinctName = find(
+                election.precincts,
+                (p) => p.id === precinctId
+              ).name;
+              return (
+                <ReportSection key={`${partyId}-${precinctId}`}>
+                  <LogoMark />
+                  <Prose maxWidth={false}>
+                    <h1>
+                      {statusPrefix} Precinct Tally Report for:{' '}
+                      {currentPrecinctName}
+                    </h1>
+                    <h2>{electionTitle}</h2>
+                    <TallyReportMetadata
+                      generatedAtTime={generatedAtTime}
+                      election={election}
+                    />
+                  </Prose>
+                  <TallyReportColumns>
+                    <TallyReportSummary
+                      totalBallotCount={reportBallotCount}
+                      ballotCountsByVotingMethod={ballotCountsByVotingMethod}
+                    />
+                    <ContestTally
+                      election={election}
+                      electionTally={tallyForReport}
+                      externalTallies={externalTalliesForReport}
+                      precinctId={precinctId}
+                    />
+                  </TallyReportColumns>
+                </ReportSection>
+              );
+            }
+
+            if (scannerId) {
+              return (
+                <ReportSection key={`${partyId}-${scannerId}`}>
+                  <LogoMark />
+                  <Prose maxWidth={false}>
+                    <h1>
+                      {statusPrefix} Scanner Tally Report for Scanner:{' '}
+                      {scannerId}
+                    </h1>
+                    <h2>{electionTitle}</h2>
+                    <TallyReportMetadata
+                      generatedAtTime={generatedAtTime}
+                      election={election}
+                    />
+                  </Prose>
+                  <TallyReportColumns>
+                    <TallyReportSummary
+                      totalBallotCount={reportBallotCount}
+                      ballotCountsByVotingMethod={ballotCountsByVotingMethod}
+                    />
+                    <ContestTally
+                      election={election}
+                      electionTally={tallyForReport}
+                      externalTallies={[]}
+                    />
+                  </TallyReportColumns>
+                </ReportSection>
+              );
+            }
+
+            if (batchId) {
+              return (
+                <ReportSection key={`${partyId}-${batchId}`}>
+                  <LogoMark />
+                  <Prose maxWidth={false}>
+                    <h1>
+                      {statusPrefix} Batch Tally Report for {batchLabel}:
+                    </h1>
+                    <h2>{electionTitle}</h2>
+                    <TallyReportMetadata
+                      generatedAtTime={generatedAtTime}
+                      election={election}
+                    />
+                  </Prose>
+                  <TallyReportColumns>
+                    <TallyReportSummary
+                      totalBallotCount={reportBallotCount}
+                      ballotCountsByVotingMethod={ballotCountsByVotingMethod}
+                    />
+                    <ContestTally
+                      election={election}
+                      electionTally={tallyForReport}
+                      externalTallies={[]}
+                    />
+                  </TallyReportColumns>
+                </ReportSection>
+              );
+            }
+
+            if (votingMethod) {
+              const label = getLabelForVotingMethod(votingMethod);
+              return (
+                <ReportSection key={`${partyId}-${votingMethod}`}>
+                  <LogoMark />
+                  <Prose maxWidth={false}>
+                    <h1>
+                      {statusPrefix} “{label}” Ballot Tally Report
+                    </h1>
+                    <h2>{electionTitle}</h2>
+                    <TallyReportMetadata
+                      generatedAtTime={generatedAtTime}
+                      election={election}
+                    />
+                  </Prose>
+                  <TallyReportColumns>
+                    <ContestTally
+                      election={election}
+                      electionTally={tallyForReport}
+                      externalTallies={externalTalliesForReport}
+                    />
+                  </TallyReportColumns>
+                </ReportSection>
+              );
+            }
+
+            return (
+              <ReportSection
+                key={partyId || 'none'}
+                data-testid="election-full-tally-report"
+              >
+                <LogoMark />
+                <Prose maxWidth={false}>
+                  <h1>
+                    {statusPrefix} {electionTitle} Tally Report
+                  </h1>
+                  <TallyReportMetadata
+                    generatedAtTime={generatedAtTime}
+                    election={election}
+                  />
+                </Prose>
+                <TallyReportColumns>
+                  <TallyReportSummary
+                    totalBallotCount={reportBallotCount}
+                    ballotCountsByVotingMethod={ballotCountsByVotingMethod}
+                  />
+                  <ContestTally
+                    election={election}
+                    electionTally={tallyForReport}
+                    externalTallies={externalTalliesForReport}
+                  />
+                </TallyReportColumns>
+              </ReportSection>
+            );
+          })
+        )}
+      </TallyReport>
+    </React.Fragment>
+  );
+}


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/1700

This PR moves the tally report portion of the tally report screen to an `ElectionManagerTallyReport` subcomponent. I plan on using the new subcomponent for the upcoming L&A tab's button to print a pre-election unofficial full election tally report (i.e. zero report) (what a mouthful 😄).

Note that the first commit in this PR just copies an existing file. The second commit actually whittles the copied file down to a new subcomponent. Reviewing commit by commit and specifically the second commit may accordingly make it easier to see that this PR doesn't actually introduce any new logic, just movies it around.

## Demo screenshot

No user facing changes as a result of this change

## Testing plan

_Automated testing_

- [x] Top-level snapshot tests for VxAdmin do cover tally report generation and still pass

_Manual testing_

Manually tested printing and preview functionality, verifying that there were no differences between my locally running code and code running at https://election-manager.votingworks.app, for:

- [x] A single precinct report
- [x] An all precincts report
- [x] A voting method report
- [x] A party report
- [x] A scanner report
- [x] A batch report
- [x] A full report

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A
- [ ] ~I have added JSDoc comments to any newly introduced exports~ N/A
- [ ] ~I have added a screenshot and/or video to this PR to demo the change~ N/A
- [ ] ~I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~ N/A