### PR TITLE
Create new L&A tab in VxAdmin and populate with relevant existing functionality from Tally tab

### DIFF
--- a/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
+++ b/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`printing ballots, print report, and test decks 1`] = `
+exports[`L&A (logic and accuracy) flow 1`] = `
 <div
   aria-hidden="true"
 >
@@ -254,8 +254,10 @@ exports[`printing ballots, print report, and test decks 1`] = `
 </div>
 `;
 
-exports[`printing ballots, print report, and test decks 2`] = `
-<div>
+exports[`L&A (logic and accuracy) flow 2`] = `
+<div
+  aria-hidden="true"
+>
   <div
     class="sc-bdfBwQ eVNwUy"
   >

--- a/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
+++ b/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
@@ -100,7 +100,7 @@ exports[`printing ballots, print report, and test decks 1`] = `
           class="sc-crrsfI vnUTr"
         >
           <h1>
-            Test Deck
+            Test Decks
           </h1>
           <p>
             <strong>
@@ -350,7 +350,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
       >
         <div>
           <strong>
-            Test Ballot Deck Tally
+            Test Deck Tally Reports
           </strong>
            for 
           Mock General Election Choctaw 2020
@@ -496,7 +496,7 @@ exports[`printing ballots, print report, and test decks 2`] = `
       />
       <div>
         <strong>
-          Test Ballot Deck Tally
+          Test Deck Tally Reports
         </strong>
          for 
          Mock General Election Choctaw 2020

--- a/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
+++ b/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
@@ -52,7 +52,14 @@ exports[`printing ballots, print report, and test decks 1`] = `
           Ballots
         </button>
         <button
-          class="sc-jrAGrp iWxjsY active-section"
+          class="sc-jrAGrp hAHAue active-section"
+          role="option"
+          type="button"
+        >
+          L&A
+        </button>
+        <button
+          class="sc-jrAGrp iWxjsY"
           role="option"
           type="button"
         >
@@ -297,7 +304,14 @@ exports[`printing ballots, print report, and test decks 2`] = `
           Ballots
         </button>
         <button
-          class="sc-jrAGrp iWxjsY active-section"
+          class="sc-jrAGrp hAHAue active-section"
+          role="option"
+          type="button"
+        >
+          L&A
+        </button>
+        <button
+          class="sc-jrAGrp iWxjsY"
           role="option"
           type="button"
         >

--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -373,7 +373,7 @@ test('printing ballots, print report, and test decks', async () => {
     expect.stringContaining(LogEventId.PrintedBallotReportPrinted)
   );
 
-  fireEvent.click(getByText('Tally'));
+  fireEvent.click(getByText('L&A'));
   fireEvent.click(getByText('Print Test Decks'));
   getByText('Chester');
   fireEvent.click(getByText('District 5'));
@@ -390,7 +390,7 @@ test('printing ballots, print report, and test decks', async () => {
     expect.stringContaining(LogEventId.TestDeckPrinted)
   );
 
-  fireEvent.click(getByText('Tally'));
+  fireEvent.click(getByText('L&A'));
   fireEvent.click(getByText('View Test Ballot Deck Tally'));
   fireEvent.click(getByText('All Precincts'));
   await screen.findByText('Print Results Report');

--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -11,6 +11,7 @@ import {
   getAllByRole as domGetAllByRole,
   act,
 } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 import { electionWithMsEitherNeitherWithDataFiles } from '@votingworks/fixtures';
 import {
@@ -311,30 +312,32 @@ test('L&A (logic and accuracy) flow', async () => {
   const storage = await createMemoryStorageWith({
     electionDefinition: eitherNeitherElectionDefinition,
   });
-  const { container, findByText, getAllByText, getByText } = render(
+  const { container } = render(
     <App card={card} hardware={hardware} printer={printer} storage={storage} />
   );
   jest.advanceTimersByTime(2001); // Cause the usb drive to be detected
   await authenticateWithAdminCard(card);
 
   // Test printing zero report
-  fireEvent.click(getByText('L&A'));
-  fireEvent.click(
-    getByText('Print the pre-election Unofficial Full Election Tally Report')
+  userEvent.click(screen.getByText('L&A'));
+  userEvent.click(
+    screen.getByText(
+      'Print the pre-election Unofficial Full Election Tally Report'
+    )
   );
-  await findByText('Printing');
+  await screen.findByText('Printing');
   expect(printer.print).toHaveBeenCalledTimes(1);
   expect(mockKiosk.log).toHaveBeenCalledWith(
     expect.stringContaining(LogEventId.TallyReportPrinted)
   );
-  expect(getAllByText('0').length).toBe(40);
+  expect(screen.getAllByText('0').length).toBe(40);
 
   // Test printing test deck
-  fireEvent.click(getByText('L&A'));
-  fireEvent.click(getByText('Print Test Decks'));
-  fireEvent.click(getByText('District 5'));
-  fireEvent.click(getByText('Print Test Deck'));
-  await findByText('Printing Test Deck: District 5', {
+  userEvent.click(screen.getByText('L&A'));
+  userEvent.click(screen.getByText('Print Test Decks'));
+  userEvent.click(screen.getByText('District 5'));
+  userEvent.click(screen.getByText('Print Test Deck'));
+  await screen.findByText('Printing Test Deck: District 5', {
     exact: false,
   });
   expect(printer.print).toHaveBeenCalledTimes(2);
@@ -344,11 +347,11 @@ test('L&A (logic and accuracy) flow', async () => {
   expect(container).toMatchSnapshot();
 
   // Test printing test deck tally report
-  fireEvent.click(getByText('L&A'));
-  fireEvent.click(getByText('Print Test Deck Tally Reports'));
-  fireEvent.click(getByText('All Precincts'));
-  fireEvent.click(getByText('Print Results Report'));
-  await findByText('Printing');
+  userEvent.click(screen.getByText('L&A'));
+  userEvent.click(screen.getByText('Print Test Deck Tally Reports'));
+  userEvent.click(screen.getByText('All Precincts'));
+  userEvent.click(screen.getByText('Print Results Report'));
+  await screen.findByText('Printing');
   expect(printer.print).toHaveBeenCalledTimes(3);
   expect(mockKiosk.log).toHaveBeenCalledWith(
     expect.stringContaining(LogEventId.TestDeckTallyReportPrinted)

--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -419,7 +419,7 @@ test('tabulating CVRs', async () => {
   const card = new MemoryCard();
   const hardware = MemoryHardware.buildStandard();
   const printer = fakePrinter();
-  const { getByText, getAllByText, getByTestId } = render(
+  const { getByText, getAllByText, getByTestId, findByText } = render(
     <App storage={storage} card={card} hardware={hardware} printer={printer} />
   );
   jest.advanceTimersByTime(2001); // Cause the usb drive to be detected
@@ -555,7 +555,7 @@ test('tabulating CVRs', async () => {
       'Print Pre-Election Unofficial Full Election Tally Report (Zero Report)'
     )
   );
-  await waitFor(() => getByText('Printing'));
+  await findByText('Printing');
   expect(printer.print).toHaveBeenCalledTimes(1);
   expect(mockKiosk.log).toHaveBeenCalledWith(
     expect.stringContaining(LogEventId.TallyReportPrinted)

--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -391,7 +391,7 @@ test('printing ballots, print report, and test decks', async () => {
   );
 
   fireEvent.click(getByText('L&A'));
-  fireEvent.click(getByText('View Test Ballot Deck Tally'));
+  fireEvent.click(getByText('Print Test Deck Tally Reports'));
   fireEvent.click(getByText('All Precincts'));
   await screen.findByText('Print Results Report');
   expect(container).toMatchSnapshot();

--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -551,9 +551,7 @@ test('tabulating CVRs', async () => {
   // Check that a zero report can be generated on the L&A tab even after CVRs have been tabulated
   fireEvent.click(getByText('L&A'));
   fireEvent.click(
-    getByText(
-      'Print Pre-Election Unofficial Full Election Tally Report (Zero Report)'
-    )
+    getByText('Print the pre-election Unofficial Full Election Tally Report')
   );
   await findByText('Printing');
   expect(printer.print).toHaveBeenCalledTimes(1);

--- a/frontends/election-manager/src/components/election_manager.tsx
+++ b/frontends/election-manager/src/components/election_manager.tsx
@@ -33,6 +33,7 @@ import { MachineLockedScreen } from '../screens/machine_locked_screen';
 import { InvalidCardScreen } from '../screens/invalid_card_screen';
 import { UnlockMachineScreen } from '../screens/unlock_machine_screen';
 import { AdvancedScreen } from '../screens/advanced_screen';
+import { LogicAndAccuracyScreen } from '../screens/logic_and_accuracy_screen';
 
 export function ElectionManager(): JSX.Element {
   const {
@@ -136,22 +137,6 @@ export function ElectionManager(): JSX.Element {
       </Route>
       <Route
         path={[
-          routerPaths.printOneTestDeck({ precinctId: ':precinctId' }),
-          routerPaths.printTestDecks,
-        ]}
-      >
-        <PrintTestDeckScreen />
-      </Route>
-      <Route
-        path={[
-          routerPaths.testDeckResultsReport({ precinctId: ':precinctId' }),
-          routerPaths.testDecksTally,
-        ]}
-      >
-        <TestDeckScreen />
-      </Route>
-      <Route
-        path={[
           routerPaths.ballotsViewLanguage({
             ballotStyleId: ':ballotStyleId',
             precinctId: ':precinctId',
@@ -212,6 +197,25 @@ export function ElectionManager(): JSX.Element {
       </Route>
       <Route path={routerPaths.overvoteCombinationReport}>
         <OvervoteCombinationReportScreen />
+      </Route>
+      <Route exact path={routerPaths.logicAndAccuracy}>
+        <LogicAndAccuracyScreen />
+      </Route>
+      <Route
+        path={[
+          routerPaths.printOneTestDeck({ precinctId: ':precinctId' }),
+          routerPaths.printTestDecks,
+        ]}
+      >
+        <PrintTestDeckScreen />
+      </Route>
+      <Route
+        path={[
+          routerPaths.testDeckResultsReport({ precinctId: ':precinctId' }),
+          routerPaths.testDecksTally,
+        ]}
+      >
+        <TestDeckScreen />
       </Route>
       <Redirect to={routerPaths.ballotsList} />
     </Switch>

--- a/frontends/election-manager/src/components/election_manager.tsx
+++ b/frontends/election-manager/src/components/election_manager.tsx
@@ -203,16 +203,16 @@ export function ElectionManager(): JSX.Element {
       </Route>
       <Route
         path={[
-          routerPaths.printOneTestDeck({ precinctId: ':precinctId' }),
-          routerPaths.printTestDecks,
+          routerPaths.testDeck({ precinctId: ':precinctId' }),
+          routerPaths.testDecks,
         ]}
       >
         <PrintTestDeckScreen />
       </Route>
       <Route
         path={[
-          routerPaths.testDeckResultsReport({ precinctId: ':precinctId' }),
-          routerPaths.testDecksTally,
+          routerPaths.testDeckTallyReport({ precinctId: ':precinctId' }),
+          routerPaths.testDeckTallyReports,
         ]}
       >
         <TestDeckScreen />

--- a/frontends/election-manager/src/components/navigation_screen.tsx
+++ b/frontends/election-manager/src/components/navigation_screen.tsx
@@ -68,6 +68,12 @@ export function NavigationScreen({
                 Ballots
               </LinkButton>
               <LinkButton
+                to={routerPaths.logicAndAccuracy}
+                className={isActiveSection(routerPaths.logicAndAccuracy)}
+              >
+                L&amp;A
+              </LinkButton>
+              <LinkButton
                 small
                 to={routerPaths.tally}
                 className={isActiveSection(routerPaths.tally)}

--- a/frontends/election-manager/src/components/printable_area.tsx
+++ b/frontends/election-manager/src/components/printable_area.tsx
@@ -1,0 +1,26 @@
+import React, { useEffect, useRef } from 'react';
+import ReactDom from 'react-dom';
+
+interface Props {
+  children?: React.ReactNode;
+}
+
+/**
+ * <PrintableArea> renders the provided children in a standalone div with the .print-only class
+ * name (standalone meaning via a React portal to ensure that a parent's CSS styles don't prevent
+ * printability)
+ */
+export function PrintableArea({ children }: Props): JSX.Element {
+  const printableContainerRef = useRef(document.createElement('div'));
+  const printableContainer = printableContainerRef.current;
+  printableContainer.classList.add('print-only');
+
+  useEffect(() => {
+    document.body.appendChild(printableContainer);
+    return () => {
+      document.body.removeChild(printableContainer);
+    };
+  }, [printableContainer]);
+
+  return ReactDom.createPortal(children, printableContainer);
+}

--- a/frontends/election-manager/src/components/zero_report_print_button.tsx
+++ b/frontends/election-manager/src/components/zero_report_print_button.tsx
@@ -1,12 +1,21 @@
 import React, { useContext, useMemo } from 'react';
+import styled from 'styled-components';
 import { assert } from '@votingworks/utils';
 import { LogEventId } from '@votingworks/logging';
 
+import { Text } from '@votingworks/ui';
 import { AppContext } from '../contexts/app_context';
 import { computeFullElectionTally } from '../lib/votecounting';
 import { ElectionManagerTallyReport } from './election_manager_tally_report';
 import { PrintableArea } from './printable_area';
 import { PrintButton } from './print_button';
+
+const ButtonAnnotation = styled(Text)`
+  &&& {
+    margin-top: 0.5rem;
+    margin-bottom: 1rem;
+  }
+`;
 
 export function ZeroReportPrintButton(): JSX.Element {
   const { currentUserSession, electionDefinition, logger } = useContext(
@@ -53,8 +62,12 @@ export function ZeroReportPrintButton(): JSX.Element {
         afterPrintError={logZeroReportPrintError}
         sides="one-sided"
       >
-        Print {zeroReportTitle}
+        {/* Intentionally diverging from our typical title case button text to sentence case for clarity */}
+        Print the pre-election Unofficial Full Election Tally Report
       </PrintButton>
+      <ButtonAnnotation small>
+        This report is referred to as the “Zero Report”.
+      </ButtonAnnotation>
       <PrintableArea>
         <ElectionManagerTallyReport
           election={election}

--- a/frontends/election-manager/src/components/zero_report_print_button.tsx
+++ b/frontends/election-manager/src/components/zero_report_print_button.tsx
@@ -1,0 +1,68 @@
+import React, { useContext, useMemo } from 'react';
+import { assert } from '@votingworks/utils';
+import { LogEventId } from '@votingworks/logging';
+
+import { AppContext } from '../contexts/app_context';
+import { computeFullElectionTally } from '../lib/votecounting';
+import { ElectionManagerTallyReport } from './election_manager_tally_report';
+import { PrintableArea } from './printable_area';
+import { PrintButton } from './print_button';
+
+export function ZeroReportPrintButton(): JSX.Element {
+  const { currentUserSession, electionDefinition, logger } = useContext(
+    AppContext
+  );
+
+  // In contexts where this component is rendered, these should always be defined
+  assert(currentUserSession);
+  assert(electionDefinition);
+
+  const currentUserType = currentUserSession.type;
+  const { election } = electionDefinition;
+
+  const emptyFullElectionTally = useMemo(
+    () => computeFullElectionTally(election, new Set()),
+    [election]
+  );
+
+  const zeroReportTitle =
+    'Pre-Election Unofficial Full Election Tally Report (Zero Report)';
+
+  function logZeroReportPrintSuccess() {
+    void logger.log(LogEventId.TallyReportPrinted, currentUserType, {
+      disposition: 'success',
+      message: `User printed ${zeroReportTitle}`,
+      tallyReportTitle: zeroReportTitle,
+    });
+  }
+
+  function logZeroReportPrintError(errorMessage: string) {
+    void logger.log(LogEventId.TallyReportPrinted, currentUserType, {
+      disposition: 'failure',
+      errorMessage,
+      message: `Error printing ${zeroReportTitle}: ${errorMessage}`,
+      result: 'User shown error.',
+      tallyReportTitle: zeroReportTitle,
+    });
+  }
+
+  return (
+    <React.Fragment>
+      <PrintButton
+        afterPrint={logZeroReportPrintSuccess}
+        afterPrintError={logZeroReportPrintError}
+        sides="one-sided"
+      >
+        Print {zeroReportTitle}
+      </PrintButton>
+      <PrintableArea>
+        <ElectionManagerTallyReport
+          election={election}
+          fullElectionExternalTallies={[]}
+          fullElectionTally={emptyFullElectionTally}
+          isOfficialResults={false}
+        />
+      </PrintableArea>
+    </React.Fragment>
+  );
+}

--- a/frontends/election-manager/src/router_paths.ts
+++ b/frontends/election-manager/src/router_paths.ts
@@ -48,10 +48,10 @@ export const routerPaths = {
   tallyFullReport: '/tally/full',
   overvoteCombinationReport: '/tally/pairs',
   logicAndAccuracy: '/logic-and-accuracy',
-  printTestDecks: '/logic-and-accuracy/print-test-deck',
-  printOneTestDeck: ({ precinctId }: PrecinctReportScreenProps): string =>
-    `/logic-and-accuracy/print-test-deck/${precinctId}`,
-  testDecksTally: '/logic-and-accuracy/test-ballot-deck',
-  testDeckResultsReport: ({ precinctId }: PrecinctReportScreenProps): string =>
-    `/logic-and-accuracy/test-ballot-deck/${precinctId}`,
+  testDecks: '/logic-and-accuracy/test-decks',
+  testDeck: ({ precinctId }: PrecinctReportScreenProps): string =>
+    `/logic-and-accuracy/test-decks/${precinctId}`,
+  testDeckTallyReports: '/logic-and-accuracy/test-deck-tally-reports',
+  testDeckTallyReport: ({ precinctId }: PrecinctReportScreenProps): string =>
+    `/logic-and-accuracy/test-deck-tally-reports/${precinctId}`,
 } as const;

--- a/frontends/election-manager/src/router_paths.ts
+++ b/frontends/election-manager/src/router_paths.ts
@@ -33,9 +33,6 @@ export const routerPaths = {
     `/tally/manual-data-import/precinct/${precinctId}`,
   printedBallotsReport: '/ballots/printed-report',
   tally: '/tally',
-  printTestDecks: '/tally/print-test-deck',
-  printOneTestDeck: ({ precinctId }: PrecinctReportScreenProps): string =>
-    `/tally/print-test-deck/${precinctId}`,
   tallyPrecinctReport: ({ precinctId }: PrecinctReportScreenProps): string =>
     `/tally/precinct/${precinctId}`,
   tallyPartyReport: ({ partyId }: PartyReportScreenProps): string =>
@@ -49,8 +46,12 @@ export const routerPaths = {
   tallyBatchReport: ({ batchId }: BatchReportScreenProps): string =>
     `/tally/batch/${batchId}`,
   tallyFullReport: '/tally/full',
-  testDecksTally: '/tally/test-ballot-deck',
-  testDeckResultsReport: ({ precinctId }: PrecinctReportScreenProps): string =>
-    `/tally/test-ballot-deck/${precinctId}`,
   overvoteCombinationReport: '/tally/pairs',
+  logicAndAccuracy: '/logic-and-accuracy',
+  printTestDecks: '/logic-and-accuracy/print-test-deck',
+  printOneTestDeck: ({ precinctId }: PrecinctReportScreenProps): string =>
+    `/logic-and-accuracy/print-test-deck/${precinctId}`,
+  testDecksTally: '/logic-and-accuracy/test-ballot-deck',
+  testDeckResultsReport: ({ precinctId }: PrecinctReportScreenProps): string =>
+    `/logic-and-accuracy/test-ballot-deck/${precinctId}`,
 } as const;

--- a/frontends/election-manager/src/screens/logic_and_accuracy_screen.tsx
+++ b/frontends/election-manager/src/screens/logic_and_accuracy_screen.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { LinkButton } from '@votingworks/ui';
+
+import { NavigationScreen } from '../components/navigation_screen';
+import { Prose } from '../components/prose';
+import { routerPaths } from '../router_paths';
+import { ZeroReportPrintButton } from '../components/zero_report_print_button';
+
+export function LogicAndAccuracyScreen(): JSX.Element {
+  return (
+    <NavigationScreen>
+      <Prose maxWidth={false}>
+        <h1>L&amp;A Materials</h1>
+        <p>
+          <ZeroReportPrintButton />
+        </p>
+        <p>
+          <LinkButton to={routerPaths.printTestDecks}>
+            Print Test Decks
+          </LinkButton>{' '}
+          <LinkButton to={routerPaths.testDecksTally}>
+            View Test Ballot Deck Tally
+          </LinkButton>
+        </p>
+      </Prose>
+    </NavigationScreen>
+  );
+}

--- a/frontends/election-manager/src/screens/logic_and_accuracy_screen.tsx
+++ b/frontends/election-manager/src/screens/logic_and_accuracy_screen.tsx
@@ -11,9 +11,7 @@ export function LogicAndAccuracyScreen(): JSX.Element {
     <NavigationScreen>
       <Prose maxWidth={false}>
         <h1>L&amp;A Materials</h1>
-        <p>
-          <ZeroReportPrintButton />
-        </p>
+        <ZeroReportPrintButton />
         <p>
           <LinkButton to={routerPaths.testDecks}>Print Test Decks</LinkButton>
         </p>

--- a/frontends/election-manager/src/screens/logic_and_accuracy_screen.tsx
+++ b/frontends/election-manager/src/screens/logic_and_accuracy_screen.tsx
@@ -15,7 +15,9 @@ export function LogicAndAccuracyScreen(): JSX.Element {
           <ZeroReportPrintButton />
         </p>
         <p>
-          <LinkButton to={routerPaths.testDecks}>Print Test Decks</LinkButton>{' '}
+          <LinkButton to={routerPaths.testDecks}>Print Test Decks</LinkButton>
+        </p>
+        <p>
           <LinkButton to={routerPaths.testDeckTallyReports}>
             Print Test Deck Tally Reports
           </LinkButton>

--- a/frontends/election-manager/src/screens/logic_and_accuracy_screen.tsx
+++ b/frontends/election-manager/src/screens/logic_and_accuracy_screen.tsx
@@ -15,11 +15,9 @@ export function LogicAndAccuracyScreen(): JSX.Element {
           <ZeroReportPrintButton />
         </p>
         <p>
-          <LinkButton to={routerPaths.printTestDecks}>
-            Print Test Decks
-          </LinkButton>{' '}
-          <LinkButton to={routerPaths.testDecksTally}>
-            View Test Ballot Deck Tally
+          <LinkButton to={routerPaths.testDecks}>Print Test Decks</LinkButton>{' '}
+          <LinkButton to={routerPaths.testDeckTallyReports}>
+            Print Test Deck Tally Reports
           </LinkButton>
         </p>
       </Prose>

--- a/frontends/election-manager/src/screens/print_test_deck_screen.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.tsx
@@ -102,7 +102,7 @@ export function PrintTestDeckScreen(): JSX.Element {
   } = useParams<PrecinctReportScreenProps>();
   const precinctId = precinctIdFromParams.trim();
 
-  const pageTitle = 'Test Deck';
+  const pageTitle = 'Test Decks';
   const precinctName =
     precinctId === 'all'
       ? 'All Precincts'
@@ -213,7 +213,7 @@ export function PrintTestDeckScreen(): JSX.Element {
               </Button>
             </p>
             <p>
-              <LinkButton small to={routerPaths.printTestDecks}>
+              <LinkButton small to={routerPaths.testDecks}>
                 Back to Test Deck list
               </LinkButton>
             </p>
@@ -240,10 +240,7 @@ export function PrintTestDeckScreen(): JSX.Element {
         </p>
       </Prose>
       <p>
-        <LinkButton
-          to={routerPaths.printOneTestDeck({ precinctId: 'all' })}
-          fullWidth
-        >
+        <LinkButton to={routerPaths.testDeck({ precinctId: 'all' })} fullWidth>
           <strong>All Precincts</strong>
         </LinkButton>
       </p>
@@ -257,7 +254,7 @@ export function PrintTestDeckScreen(): JSX.Element {
           .map((p) => (
             <LinkButton
               key={p.id}
-              to={routerPaths.printOneTestDeck({ precinctId: p.id })}
+              to={routerPaths.testDeck({ precinctId: p.id })}
               fullWidth
             >
               {p.name}

--- a/frontends/election-manager/src/screens/tally_screen.tsx
+++ b/frontends/election-manager/src/screens/tally_screen.tsx
@@ -28,7 +28,6 @@ import { Loading } from '../components/loading';
 import { NavigationScreen } from '../components/navigation_screen';
 import { routerPaths } from '../router_paths';
 import { LinkButton } from '../components/link_button';
-import { HorizontalRule } from '../components/horizontal_rule';
 import { Prose } from '../components/prose';
 import { ImportCvrFilesModal } from '../components/import_cvrfiles_modal';
 import { BallotCountsTable } from '../components/ballot_counts_table';
@@ -424,20 +423,6 @@ export function TallyScreen(): JSX.Element {
               <Button onPress={() => setIsExportResultsModalOpen(true)}>
                 Save Results File
               </Button>
-            </p>
-          </React.Fragment>
-        )}
-        {!hasCastVoteRecordFiles && (
-          <React.Fragment>
-            <HorizontalRule />
-            <h2>Pre-Election Features</h2>
-            <p>
-              <LinkButton to={routerPaths.printTestDecks}>
-                Print Test Decks
-              </LinkButton>{' '}
-              <LinkButton to={routerPaths.testDecksTally}>
-                View Test Ballot Deck Tally
-              </LinkButton>
             </p>
           </React.Fragment>
         )}

--- a/frontends/election-manager/src/screens/test_deck_screen.tsx
+++ b/frontends/election-manager/src/screens/test_deck_screen.tsx
@@ -93,7 +93,7 @@ export function TestDeckScreen(): JSX.Element {
     precinct?.name
   );
 
-  const pageTitle = 'Test Ballot Deck Tally';
+  const pageTitle = 'Test Deck Tally Reports';
 
   const generatedAtTime = new Date();
 
@@ -149,7 +149,7 @@ export function TestDeckScreen(): JSX.Element {
               </p>
             )}
             <p>
-              <LinkButton small to={routerPaths.testDecksTally}>
+              <LinkButton small to={routerPaths.testDeckTallyReports}>
                 Back to Test Deck list
               </LinkButton>
             </p>
@@ -217,7 +217,7 @@ export function TestDeckScreen(): JSX.Element {
       </Prose>
       <p>
         <LinkButton
-          to={routerPaths.testDeckResultsReport({ precinctId: 'all' })}
+          to={routerPaths.testDeckTallyReport({ precinctId: 'all' })}
           fullWidth
         >
           <strong>All Precincts</strong>
@@ -233,7 +233,7 @@ export function TestDeckScreen(): JSX.Element {
           .map((p) => (
             <LinkButton
               key={p.id}
-              to={routerPaths.testDeckResultsReport({ precinctId: p.id })}
+              to={routerPaths.testDeckTallyReport({ precinctId: p.id })}
               fullWidth
             >
               {p.name}


### PR DESCRIPTION
_Commit-by-commit reviewing recommended_

## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/1689

This PR introduces a new L&A (logic and accuracy) tab to VxAdmin! I've populated the tab with existing L&A functionality from the Tally tab, namely the ability to print a zero report and test decks.

Regarding zero reports, prior to this change, you could only print a zero report on the Tally tab before you'd started tabulating CVRs, through the "View Unofficial Full Election Tally Report" button. Now, you can always print a zero report on the L&A tab, even after you've started tabulating CVRs, through the dedicated "Print the pre-election Unofficial Full Election Tally Report" button.

Now that we have an L&A tab, I've removed the redundant Pre-Election Features section of the Tally tab.

I'll further populate and improve the L&A tab in follow-up PRs.

## Demo screenshots and videos

_New L&A tab_

![l-and-a](https://user-images.githubusercontent.com/12616928/164116824-06f2c308-260e-4e80-9532-79deb02e9ea8.png)

https://user-images.githubusercontent.com/12616928/164116837-2de3ce88-bec9-4f7b-997b-7150a16df4ed.mov

_Tally tab, before (left) and after (right)_

Note the lack of the Pre-Election Features section on the right.

<img src="https://user-images.githubusercontent.com/12616928/164031564-7cc34cde-5d60-42d8-9af1-761248eef05c.png" alt="tally-before" width="400px" /> <img src="https://user-images.githubusercontent.com/12616928/164031561-4573cdc6-8560-465a-9300-c6d00748ea5f.png" alt="tally-after" width="400px" />

## Testing Plan

_Automated testing_

- [x] Updated VxAdmin tests to account for move of test deck functionality
- [x] Updated VxAdmin tests to cover improved zero-report generation

_Manual testing_

- [x] Verified that the L&A tab and Tally tab render as expected
- [x] Verified that zero reports can be generated on the L&A tab even after you've started tabulating CVRs

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates