### PR TITLE
refactor(scan): replace `yauzl` with `jszip`

### DIFF
--- a/frontends/bas/package.json
+++ b/frontends/bas/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@types/jest": "24.0.11",
-    "@types/node": "11.13.7",
+    "@types/node": "12.19.16",
     "@types/pluralize": "^0.0.29",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",

--- a/frontends/bmd/package.json
+++ b/frontends/bmd/package.json
@@ -88,7 +88,7 @@
     "@types/fetch-mock": "^7.3.2",
     "@types/jest": "25.2.2",
     "@types/lodash.camelcase": "^4.3.6",
-    "@types/node": "14.0.1",
+    "@types/node": "12.19.16",
     "@types/pluralize": "^0.0.29",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",

--- a/frontends/bsd/package.json
+++ b/frontends/bsd/package.json
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "@types/jest": "24.0.11",
-    "@types/node": "12.19.3",
+    "@types/node": "12.19.16",
     "@types/pluralize": "^0.0.29",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",

--- a/frontends/bsd/package.json
+++ b/frontends/bsd/package.json
@@ -93,7 +93,6 @@
     "ts-jest": "^26.1.3",
     "typescript": "^4.3.5",
     "use-interval": "^1.2.1",
-    "yauzl": "^2.10.0",
     "zod": "3.2.0"
   },
   "devDependencies": {
@@ -105,7 +104,6 @@
     "@types/kiosk-browser": "workspace:*",
     "@types/pify": "^3.0.2",
     "@types/react-router-dom": "^5.1.5",
-    "@types/yauzl": "^2.9.1",
     "@types/zip-stream": "workspace:*",
     "@typescript-eslint/eslint-plugin": "^4.28.4",
     "@typescript-eslint/parser": "^4.28.4",

--- a/frontends/election-manager/package.json
+++ b/frontends/election-manager/package.json
@@ -80,7 +80,7 @@
     "@types/dompurify": "^2.0.3",
     "@types/fetch-mock": "^7.3.2",
     "@types/jest": "^24.0.0",
-    "@types/node": "^12.0.0",
+    "@types/node": "12.19.16",
     "@types/pluralize": "^0.0.29",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",

--- a/frontends/precinct-scanner/package.json
+++ b/frontends/precinct-scanner/package.json
@@ -77,7 +77,7 @@
     "@testing-library/react": "^11.1.0",
     "@types/jest": "^24.0.0",
     "@types/luxon": "^1.26.5",
-    "@types/node": "^12.20.11",
+    "@types/node": "12.19.16",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "@types/react-router-dom": "^5.1.5",

--- a/libs/ballot-encoder/package.json
+++ b/libs/ballot-encoder/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@types/jest": "^27.0.3",
-    "@types/node": "^14.14.20",
+    "@types/node": "12.19.16",
     "@types/text-encoding": "^0.0.35",
     "@typescript-eslint/eslint-plugin": "^4.29.3",
     "@typescript-eslint/parser": "^4.29.3",

--- a/libs/ballot-interpreter-vx/package.json
+++ b/libs/ballot-interpreter-vx/package.json
@@ -59,7 +59,7 @@
     "@types/jest": "^27.0.3",
     "@types/jsfeat": "workspace:*",
     "@types/memorystream": "^0.3.0",
-    "@types/node": "12.19.3",
+    "@types/node": "12.19.16",
     "@types/node-quirc": "workspace:*",
     "@types/table": "^6.0.0",
     "@types/tmp": "^0.2.0",

--- a/libs/cdf-schema-builder/package.json
+++ b/libs/cdf-schema-builder/package.json
@@ -46,7 +46,7 @@
     "@types/jest": "^27.0.3",
     "@types/jsdom": "^16.2.13",
     "@types/json-schema": "^7.0.9",
-    "@types/node": "^14.14.20",
+    "@types/node": "12.19.16",
     "@typescript-eslint/eslint-plugin": "^4.29.3",
     "@typescript-eslint/parser": "^4.29.3",
     "@votingworks/test-utils": "workspace:*",

--- a/libs/cdf-types-cast-vote-records/package.json
+++ b/libs/cdf-types-cast-vote-records/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@types/jest": "^27.0.3",
-    "@types/node": "^14.14.20",
+    "@types/node": "12.19.16",
     "@types/text-encoding": "^0.0.35",
     "@typescript-eslint/eslint-plugin": "^4.29.3",
     "@typescript-eslint/parser": "^4.29.3",

--- a/libs/cdf-types-election-event-logging/package.json
+++ b/libs/cdf-types-election-event-logging/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@types/jest": "^27.0.3",
-    "@types/node": "^14.14.20",
+    "@types/node": "12.19.16",
     "@types/text-encoding": "^0.0.35",
     "@typescript-eslint/eslint-plugin": "^4.29.3",
     "@typescript-eslint/parser": "^4.29.3",

--- a/libs/fixtures/package.json
+++ b/libs/fixtures/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@types/jest": "^27.0.3",
-    "@types/node": "^14.14.31",
+    "@types/node": "12.19.16",
     "@types/yargs": "^16.0.0",
     "@typescript-eslint/eslint-plugin": "^4.28.4",
     "@typescript-eslint/parser": "^4.28.4",

--- a/libs/logging/package.json
+++ b/libs/logging/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@types/kiosk-browser": "workspace:*",
-    "@types/node": "^12.20.11",
+    "@types/node": "12.19.16",
     "@votingworks/cdf-types-election-event-logging": "workspace:*",
     "@votingworks/types": "workspace:*",
     "@votingworks/utils": "workspace:*",

--- a/libs/lsd/package.json
+++ b/libs/lsd/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@types/bindings": "^1.5.0",
     "@types/jest": "^27.0.3",
-    "@types/node": "^14.14.25",
+    "@types/node": "12.19.16",
     "@typescript-eslint/eslint-plugin": "^4.28.4",
     "@typescript-eslint/parser": "^4.28.4",
     "eslint": "^7.19.0",

--- a/libs/plustek-sdk/package.json
+++ b/libs/plustek-sdk/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@types/debug": "^4.1.5",
     "@types/jest": "^27.0.3",
-    "@types/node": "^15.0.1",
+    "@types/node": "12.19.16",
     "@types/temp": "^0.9.0",
     "@typescript-eslint/eslint-plugin": "^4.28.4",
     "@typescript-eslint/parser": "^4.28.4",

--- a/libs/res-to-ts/package.json
+++ b/libs/res-to-ts/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@types/jest": "^27.4.1",
     "@types/mime": "^2.0.3",
-    "@types/node": "^17.0.22",
+    "@types/node": "12.19.16",
     "@types/tmp": "^0.2.3",
     "@typescript-eslint/eslint-plugin": "^5.16.0",
     "@typescript-eslint/parser": "^5.16.0",

--- a/libs/test-utils/package.json
+++ b/libs/test-utils/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@testing-library/react": "^11.2.6",
-    "@types/node": "^14.14.35",
+    "@types/node": "12.19.16",
     "@votingworks/types": "workspace:*",
     "fast-check": "^2.18.0",
     "luxon": "1.26.0",

--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@types/jest": "^27.0.3",
-    "@types/node": "^14.14.35",
+    "@types/node": "12.19.16",
     "@types/react": "^17.0.4",
     "@typescript-eslint/eslint-plugin": "^4.28.4",
     "@typescript-eslint/parser": "^4.28.4",

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -66,7 +66,7 @@
     "@types/jest": "^27.0.3",
     "@types/kiosk-browser": "workspace:*",
     "@types/luxon": "^1.26.5",
-    "@types/node": "^15.0.0",
+    "@types/node": "12.19.16",
     "@types/pluralize": "^0.0.29",
     "@types/react": "^17.0.4",
     "@types/styled-components": "^5.1.9",

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -36,7 +36,7 @@
     ]
   },
   "dependencies": {
-    "@types/node": "^12.20.11",
+    "@types/node": "12.19.16",
     "@votingworks/types": "workspace:*",
     "base64-js": "^1.3.1",
     "debug": "^4.3.2",

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -43,10 +43,10 @@
     "fast-text-encoding": "^1.0.2",
     "fetch-mock": "^9.11.0",
     "jest-fetch-mock": "^3.0.3",
+    "jszip": "^3.9.1",
     "luxon": "^1.27.0",
     "moment": "^2.29.1",
     "rxjs": "^6.6.6",
-    "yauzl": "^2.10.0",
     "zod": "3.2.0"
   },
   "devDependencies": {
@@ -55,7 +55,6 @@
     "@types/jest": "^27.0.3",
     "@types/kiosk-browser": "workspace:*",
     "@types/luxon": "^1.26.5",
-    "@types/yauzl": "^2.9.1",
     "@typescript-eslint/eslint-plugin": "^4.28.4",
     "@typescript-eslint/parser": "^4.28.4",
     "@votingworks/fixtures": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,7 +69,7 @@ importers:
   frontends/bas:
     dependencies:
       '@types/jest': 24.0.11
-      '@types/node': 11.13.7
+      '@types/node': 12.19.16
       '@types/pluralize': 0.0.29
       '@types/react': 17.0.0
       '@types/react-dom': 17.0.0
@@ -120,7 +120,7 @@ importers:
       '@types/jest': 24.0.11
       '@types/kiosk-browser': workspace:*
       '@types/luxon': ^1.26.5
-      '@types/node': 11.13.7
+      '@types/node': 12.19.16
       '@types/pluralize': ^0.0.29
       '@types/react': ^17.0.0
       '@types/react-dom': ^17.0.0
@@ -176,7 +176,7 @@ importers:
       '@types/fetch-mock': 7.3.3
       '@types/jest': 25.2.2
       '@types/lodash.camelcase': 4.3.6
-      '@types/node': 14.0.1
+      '@types/node': 12.19.16
       '@types/pluralize': 0.0.29
       '@types/react': 17.0.0
       '@types/react-dom': 17.0.0
@@ -195,7 +195,7 @@ importers:
       dompurify: 2.2.6
       fetch-mock: 9.11.0
       history: 4.10.1
-      http-proxy-middleware: 1.0.6_debug@4.3.2
+      http-proxy-middleware: 1.0.6
       lodash.camelcase: 4.3.0
       luxon: 1.26.0
       mockdate: 3.0.2
@@ -275,7 +275,7 @@ importers:
       '@types/kiosk-browser': workspace:*
       '@types/lodash.camelcase': ^4.3.6
       '@types/luxon': ^1.26.2
-      '@types/node': 14.0.1
+      '@types/node': 12.19.16
       '@types/pluralize': ^0.0.29
       '@types/react': ^17.0.0
       '@types/react-dom': ^17.0.0
@@ -357,7 +357,7 @@ importers:
   frontends/bsd:
     dependencies:
       '@types/jest': 24.0.11
-      '@types/node': 12.19.3
+      '@types/node': 12.19.16
       '@types/pluralize': 0.0.29
       '@types/react': 17.0.0
       '@types/react-dom': 17.0.0
@@ -436,7 +436,7 @@ importers:
       '@types/history': ^4.7.8
       '@types/jest': 24.0.11
       '@types/kiosk-browser': workspace:*
-      '@types/node': 12.19.3
+      '@types/node': 12.19.16
       '@types/pify': ^3.0.2
       '@types/pluralize': ^0.0.29
       '@types/react': ^17.0.0
@@ -517,7 +517,7 @@ importers:
       '@types/dompurify': 2.2.1
       '@types/fetch-mock': 7.3.3
       '@types/jest': 24.9.1
-      '@types/node': 12.19.3
+      '@types/node': 12.19.16
       '@types/pluralize': 0.0.29
       '@types/react': 17.0.0
       '@types/react-dom': 17.0.0
@@ -540,7 +540,7 @@ importers:
       dompurify: 2.2.6
       fetch-mock: 9.11.0
       history: 4.10.1
-      http-proxy-middleware: 1.0.6_debug@4.3.2
+      http-proxy-middleware: 1.0.6
       i18next: 19.8.4
       js-file-download: 0.4.12
       js-sha256: 0.9.0
@@ -556,7 +556,7 @@ importers:
       react-dom: 17.0.1_react@17.0.1
       react-i18next: 11.8.5_i18next@19.8.4+react@17.0.1
       react-router-dom: 5.2.0_react@17.0.1
-      react-scripts: 4.0.1_canvas@2.9.0+typescript@4.3.5
+      react-scripts: 4.0.1_typescript@4.3.5
       react-textarea-autosize: 8.3.0_@types+react@17.0.0+react@17.0.1
       rxjs: 6.6.6
       styled-components: 5.2.1_react-dom@17.0.1+react@17.0.1
@@ -618,7 +618,7 @@ importers:
       '@types/jest': ^24.0.0
       '@types/kiosk-browser': workspace:*
       '@types/lodash': ^4.14.168
-      '@types/node': ^12.0.0
+      '@types/node': 12.19.16
       '@types/pdfjs-dist': ^2.1.3
       '@types/pluralize': ^0.0.29
       '@types/react': ^17.0.0
@@ -713,7 +713,7 @@ importers:
       '@testing-library/react': 11.2.3_react-dom@17.0.1+react@17.0.1
       '@types/jest': 24.9.1
       '@types/luxon': 1.26.5
-      '@types/node': 12.20.11
+      '@types/node': 12.19.16
       '@types/react': 17.0.0
       '@types/react-dom': 17.0.0
       '@types/react-router-dom': 5.1.7
@@ -728,7 +728,7 @@ importers:
       base64-js: 1.5.1
       debug: 4.3.1
       fetch-mock: 9.11.0
-      http-proxy-middleware: 1.0.6_debug@4.3.1
+      http-proxy-middleware: 1.0.6
       i18next: 19.8.4
       jest-fetch-mock: 3.0.3
       js-file-download: 0.4.12
@@ -795,7 +795,7 @@ importers:
       '@types/jest': ^24.0.0
       '@types/kiosk-browser': workspace:*
       '@types/luxon': ^1.26.5
-      '@types/node': ^12.20.11
+      '@types/node': 12.19.16
       '@types/pluralize': ^0.0.29
       '@types/react': ^17.0.0
       '@types/react-dom': ^17.0.0
@@ -1001,7 +1001,7 @@ importers:
       zod: 3.2.0
     devDependencies:
       '@types/jest': 27.0.3
-      '@types/node': 14.14.20
+      '@types/node': 12.19.16
       '@types/text-encoding': 0.0.35
       '@typescript-eslint/eslint-plugin': 4.29.3_71b514861f56f635a40af7b2aa83d720
       '@typescript-eslint/parser': 4.29.3_eslint@7.17.0+typescript@4.3.5
@@ -1026,7 +1026,7 @@ importers:
     specifiers:
       '@antongolub/iso8601': ^1.2.1
       '@types/jest': ^27.0.3
-      '@types/node': ^14.14.20
+      '@types/node': 12.19.16
       '@types/text-encoding': ^0.0.35
       '@typescript-eslint/eslint-plugin': ^4.29.3
       '@typescript-eslint/parser': ^4.29.3
@@ -1142,7 +1142,7 @@ importers:
       '@types/jest': 27.0.3
       '@types/jsfeat': link:../@types/jsfeat
       '@types/memorystream': 0.3.0
-      '@types/node': 12.19.3
+      '@types/node': 12.19.16
       '@types/node-quirc': link:../@types/node-quirc
       '@types/table': 6.0.0
       '@types/tmp': 0.2.0
@@ -1178,7 +1178,7 @@ importers:
       '@types/jest': ^27.0.3
       '@types/jsfeat': workspace:*
       '@types/memorystream': ^0.3.0
-      '@types/node': 12.19.3
+      '@types/node': 12.19.16
       '@types/node-quirc': workspace:*
       '@types/table': ^6.0.0
       '@types/tmp': ^0.2.0
@@ -1230,7 +1230,7 @@ importers:
       '@types/jest': 27.0.3
       '@types/jsdom': 16.2.13
       '@types/json-schema': 7.0.9
-      '@types/node': 14.18.0
+      '@types/node': 12.19.16
       '@typescript-eslint/eslint-plugin': 4.33.0_3289a875d95a672b97ebf589745c66ef
       '@typescript-eslint/parser': 4.33.0_eslint@7.32.0+typescript@4.5.4
       '@votingworks/test-utils': link:../test-utils
@@ -1254,7 +1254,7 @@ importers:
       '@types/jest': ^27.0.3
       '@types/jsdom': ^16.2.13
       '@types/json-schema': ^7.0.9
-      '@types/node': ^14.14.20
+      '@types/node': 12.19.16
       '@typescript-eslint/eslint-plugin': ^4.29.3
       '@typescript-eslint/parser': ^4.29.3
       '@votingworks/test-utils': workspace:*
@@ -1284,7 +1284,7 @@ importers:
       zod: 3.2.0
     devDependencies:
       '@types/jest': 27.0.3
-      '@types/node': 14.18.0
+      '@types/node': 12.19.16
       '@types/text-encoding': 0.0.35
       '@typescript-eslint/eslint-plugin': 4.33.0_3289a875d95a672b97ebf589745c66ef
       '@typescript-eslint/parser': 4.33.0_eslint@7.32.0+typescript@4.5.4
@@ -1309,7 +1309,7 @@ importers:
       typescript: 4.5.4
     specifiers:
       '@types/jest': ^27.0.3
-      '@types/node': ^14.14.20
+      '@types/node': 12.19.16
       '@types/text-encoding': ^0.0.35
       '@typescript-eslint/eslint-plugin': ^4.29.3
       '@typescript-eslint/parser': ^4.29.3
@@ -1340,7 +1340,7 @@ importers:
       zod: 3.2.0
     devDependencies:
       '@types/jest': 27.0.3
-      '@types/node': 14.18.0
+      '@types/node': 12.19.16
       '@types/text-encoding': 0.0.35
       '@typescript-eslint/eslint-plugin': 4.33.0_3289a875d95a672b97ebf589745c66ef
       '@typescript-eslint/parser': 4.33.0_eslint@7.32.0+typescript@4.5.4
@@ -1365,7 +1365,7 @@ importers:
       typescript: 4.5.4
     specifiers:
       '@types/jest': ^27.0.3
-      '@types/node': ^14.14.20
+      '@types/node': 12.19.16
       '@types/text-encoding': ^0.0.35
       '@typescript-eslint/eslint-plugin': ^4.29.3
       '@typescript-eslint/parser': ^4.29.3
@@ -1457,7 +1457,7 @@ importers:
       yargs: 16.2.0
     devDependencies:
       '@types/jest': 27.0.3
-      '@types/node': 14.14.34
+      '@types/node': 12.19.16
       '@types/yargs': 16.0.0
       '@typescript-eslint/eslint-plugin': 4.28.4_1d3bd85b4b489d1777514df5fe613e8c
       '@typescript-eslint/parser': 4.28.4_eslint@7.19.0+typescript@4.3.5
@@ -1480,7 +1480,7 @@ importers:
       typescript: 4.3.5
     specifiers:
       '@types/jest': ^27.0.3
-      '@types/node': ^14.14.31
+      '@types/node': 12.19.16
       '@types/yargs': ^16.0.0
       '@typescript-eslint/eslint-plugin': ^4.28.4
       '@typescript-eslint/parser': ^4.28.4
@@ -1509,7 +1509,7 @@ importers:
   libs/logging:
     dependencies:
       '@types/kiosk-browser': link:../@types/kiosk-browser
-      '@types/node': 12.20.15
+      '@types/node': 12.19.16
       '@votingworks/cdf-types-election-event-logging': link:../cdf-types-election-event-logging
       '@votingworks/types': link:../types
       '@votingworks/utils': link:../utils
@@ -1550,7 +1550,7 @@ importers:
       '@types/fs-extra': ^9.0.13
       '@types/jest': ^27.0.3
       '@types/kiosk-browser': workspace:*
-      '@types/node': ^12.20.11
+      '@types/node': 12.19.16
       '@types/yargs': ^16.0.0
       '@typescript-eslint/eslint-plugin': ^4.28.4
       '@typescript-eslint/parser': ^4.28.4
@@ -1591,7 +1591,7 @@ importers:
     devDependencies:
       '@types/bindings': 1.5.0
       '@types/jest': 27.0.3
-      '@types/node': 14.14.25
+      '@types/node': 12.19.16
       '@typescript-eslint/eslint-plugin': 4.28.4_1d3bd85b4b489d1777514df5fe613e8c
       '@typescript-eslint/parser': 4.28.4_eslint@7.19.0+typescript@4.3.5
       eslint: 7.19.0
@@ -1613,7 +1613,7 @@ importers:
     specifiers:
       '@types/bindings': ^1.5.0
       '@types/jest': ^27.0.3
-      '@types/node': ^14.14.25
+      '@types/node': 12.19.16
       '@typescript-eslint/eslint-plugin': ^4.28.4
       '@typescript-eslint/parser': ^4.28.4
       bindings: ^1.5.0
@@ -1646,7 +1646,7 @@ importers:
     devDependencies:
       '@types/debug': 4.1.5
       '@types/jest': 27.0.3
-      '@types/node': 15.0.1
+      '@types/node': 12.19.16
       '@types/temp': 0.9.0
       '@typescript-eslint/eslint-plugin': 4.28.4_9308c3eb0582626d69bb7a7a1fefe80e
       '@typescript-eslint/parser': 4.28.4_eslint@7.25.0+typescript@4.3.5
@@ -1670,7 +1670,7 @@ importers:
     specifiers:
       '@types/debug': ^4.1.5
       '@types/jest': ^27.0.3
-      '@types/node': ^15.0.1
+      '@types/node': 12.19.16
       '@types/temp': ^0.9.0
       '@typescript-eslint/eslint-plugin': ^4.28.4
       '@typescript-eslint/parser': ^4.28.4
@@ -1705,7 +1705,7 @@ importers:
     devDependencies:
       '@types/jest': 27.4.1
       '@types/mime': 2.0.3
-      '@types/node': 17.0.23
+      '@types/node': 12.19.16
       '@types/tmp': 0.2.3
       '@typescript-eslint/eslint-plugin': 5.16.0_6439597c078d4a15fcc6e7f0ff1a5209
       '@typescript-eslint/parser': 5.16.0_eslint@8.11.0+typescript@4.3.5
@@ -1726,7 +1726,7 @@ importers:
     specifiers:
       '@types/jest': ^27.4.1
       '@types/mime': ^2.0.3
-      '@types/node': ^17.0.22
+      '@types/node': 12.19.16
       '@types/tmp': ^0.2.3
       '@typescript-eslint/eslint-plugin': ^5.16.0
       '@typescript-eslint/parser': ^5.16.0
@@ -1751,7 +1751,7 @@ importers:
   libs/test-utils:
     dependencies:
       '@testing-library/react': 11.2.6_react-dom@17.0.1+react@17.0.1
-      '@types/node': 14.14.35
+      '@types/node': 12.19.16
       '@votingworks/types': link:../types
       fast-check: 2.18.0
       luxon: 1.26.0
@@ -1786,7 +1786,7 @@ importers:
       '@types/jest': ^27.0.3
       '@types/kiosk-browser': workspace:*
       '@types/luxon': ^1.26.5
-      '@types/node': ^14.14.35
+      '@types/node': 12.19.16
       '@types/react': ^17.0.4
       '@types/zip-stream': workspace:*
       '@typescript-eslint/eslint-plugin': ^4.28.4
@@ -1818,7 +1818,7 @@ importers:
       zod: 3.2.0
     devDependencies:
       '@types/jest': 27.0.3
-      '@types/node': 14.14.35
+      '@types/node': 12.19.16
       '@types/react': 17.0.19
       '@typescript-eslint/eslint-plugin': 4.28.4_1d3bd85b4b489d1777514df5fe613e8c
       '@typescript-eslint/parser': 4.28.4_eslint@7.19.0+typescript@4.3.5
@@ -1841,7 +1841,7 @@ importers:
     specifiers:
       '@antongolub/iso8601': ^1.2.1
       '@types/jest': ^27.0.3
-      '@types/node': ^14.14.35
+      '@types/node': 12.19.16
       '@types/react': ^17.0.4
       '@typescript-eslint/eslint-plugin': ^4.28.4
       '@typescript-eslint/parser': ^4.28.4
@@ -1892,7 +1892,7 @@ importers:
       '@types/jest': 27.0.3
       '@types/kiosk-browser': link:../@types/kiosk-browser
       '@types/luxon': 1.27.1
-      '@types/node': 15.0.1
+      '@types/node': 12.19.16
       '@types/pluralize': 0.0.29
       '@types/react': 17.0.4
       '@types/styled-components': 5.1.9
@@ -1942,7 +1942,7 @@ importers:
       '@types/jest': ^27.0.3
       '@types/kiosk-browser': workspace:*
       '@types/luxon': ^1.26.5
-      '@types/node': ^15.0.0
+      '@types/node': 12.19.16
       '@types/pluralize': ^0.0.29
       '@types/react': ^17.0.4
       '@types/react-modal': ^3.13.1
@@ -2000,7 +2000,7 @@ importers:
       zod: 3.2.0
   libs/utils:
     dependencies:
-      '@types/node': 12.20.11
+      '@types/node': 12.19.16
       '@votingworks/types': link:../types
       base64-js: 1.5.1
       debug: 4.3.2
@@ -2043,7 +2043,7 @@ importers:
       '@types/jest': ^27.0.3
       '@types/kiosk-browser': workspace:*
       '@types/luxon': ^1.26.5
-      '@types/node': ^12.20.11
+      '@types/node': 12.19.16
       '@typescript-eslint/eslint-plugin': ^4.28.4
       '@typescript-eslint/parser': ^4.28.4
       '@votingworks/fixtures': workspace:*
@@ -2134,7 +2134,7 @@ importers:
       '@types/jest': 26.0.20
       '@types/luxon': 1.26.5
       '@types/multer': 1.4.5
-      '@types/node': 12.19.14
+      '@types/node': 12.19.16
       '@types/pdfjs-dist': 2.1.7
       '@types/supertest': 2.0.10
       '@types/tmp': 0.2.0
@@ -2175,7 +2175,7 @@ importers:
       '@types/jest': ^26.0.6
       '@types/luxon': ^1.26.5
       '@types/multer': ^1.4.3
-      '@types/node': ^12.0.0
+      '@types/node': 12.19.16
       '@types/pdfjs-dist': ^2.1.3
       '@types/supertest': ^2.0.10
       '@types/tmp': ^0.2.0
@@ -6878,43 +6878,6 @@ packages:
       canvas: '*'
     resolution:
       integrity: sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==
-  /@jest/core/26.6.3_canvas@2.9.0:
-    dependencies:
-      '@jest/console': 26.6.2
-      '@jest/reporters': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/transform': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/node': 16.11.6
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.4
-      jest-changed-files: 26.6.2
-      jest-config: 26.6.3_canvas@2.9.0
-      jest-haste-map: 26.6.2
-      jest-message-util: 26.6.2
-      jest-regex-util: 26.0.0
-      jest-resolve: 26.6.2
-      jest-resolve-dependencies: 26.6.3
-      jest-runner: 26.6.3_canvas@2.9.0
-      jest-runtime: 26.6.3_canvas@2.9.0
-      jest-snapshot: 26.6.2
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      jest-watcher: 26.6.2
-      micromatch: 4.0.4
-      p-each-series: 2.2.0
-      rimraf: 3.0.2
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    dev: false
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      canvas: '*'
-    resolution:
-      integrity: sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==
   /@jest/core/27.3.1:
     dependencies:
       '@jest/console': 27.3.1
@@ -6975,7 +6938,7 @@ packages:
       jest-regex-util: 27.0.6
       jest-resolve: 27.3.1
       jest-resolve-dependencies: 27.3.1
-      jest-runner: 27.3.1_canvas@2.6.1
+      jest-runner: 27.3.1
       jest-runtime: 27.3.1
       jest-snapshot: 27.3.1
       jest-util: 27.3.1
@@ -7096,7 +7059,7 @@ packages:
       jest-regex-util: 27.5.1
       jest-resolve: 27.5.1
       jest-resolve-dependencies: 27.5.1
-      jest-runner: 27.5.1_canvas@2.9.0
+      jest-runner: 27.5.1
       jest-runtime: 27.5.1
       jest-snapshot: 27.5.1
       jest-util: 27.5.1
@@ -7542,20 +7505,6 @@ packages:
       jest-runner: 26.6.3_canvas@2.6.1
       jest-runtime: 26.6.3_canvas@2.6.1
     dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      canvas: '*'
-    resolution:
-      integrity: sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==
-  /@jest/test-sequencer/26.6.3_canvas@2.9.0:
-    dependencies:
-      '@jest/test-result': 26.6.2
-      graceful-fs: 4.2.4
-      jest-haste-map: 26.6.2
-      jest-runner: 26.6.3_canvas@2.9.0
-      jest-runtime: 26.6.3_canvas@2.9.0
-    dev: false
     engines:
       node: '>= 10.14.2'
     peerDependencies:
@@ -8884,21 +8833,13 @@ packages:
     dev: true
     resolution:
       integrity: sha512-9b/0a8JyrR0r2nQhL73JR86obWL7cogfX12augvlrvcpciCo/hkvEsgu80Z4S2g2DHGVXHr8pUIi1VhqFJ8Ufw==
-  /@types/node/11.13.7:
-    dev: false
-    resolution:
-      integrity: sha512-suFHr6hcA9mp8vFrZTgrmqW2ZU3mbWsryQtQlY/QvwTISCw7nw/j+bCQPPohqmskhmqa5wLNuMHTTsc+xf1MQg==
   /@types/node/12.19.14:
     dev: true
     resolution:
       integrity: sha512-2U9uLN46+7dv9PiS8VQJcHhuoOjiDPZOLAt0WuA1EanEknIMae+2QbMhayF7cgGqjvRVIfNpt+6jLPczJZFiRw==
-  /@types/node/12.19.3:
+  /@types/node/12.19.16:
     resolution:
-      integrity: sha512-8Jduo8wvvwDzEVJCOvS/G6sgilOLvvhn1eMmK3TW8/T217O7u1jdrK6ImKLv80tVryaPSVeKu6sjDEiFjd4/eg==
-  /@types/node/12.20.11:
-    dev: false
-    resolution:
-      integrity: sha512-gema+apZ6qLQK7k7F0dGkGCWQYsL0qqKORWOQO6tq46q+x+1C0vbOiOqOwRVlh4RAdbQwV/j/ryr3u5NOG1fPQ==
+      integrity: sha512-7xHmXm/QJ7cbK2laF+YYD7gb5MggHIIQwqyjin3bpEGiSuvScMQ5JZZXPvRipi1MwckTQbJZROMns/JxdnIL1Q==
   /@types/node/12.20.15:
     dev: false
     resolution:
@@ -8907,10 +8848,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA==
-  /@types/node/14.0.1:
-    dev: false
-    resolution:
-      integrity: sha512-FAYBGwC+W6F9+huFIDtn43cpy7+SzG+atzRiTfdp3inUKL2hXnd4rG8hylJLIh4+hqrQy1P17kvJByE/z825hA==
   /@types/node/14.14.20:
     dev: true
     resolution:
@@ -8922,11 +8859,8 @@ packages:
     dev: true
     resolution:
       integrity: sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ==
-  /@types/node/14.14.34:
-    dev: true
-    resolution:
-      integrity: sha512-dBPaxocOK6UVyvhbnpFIj2W+S+1cBTkHQbFQfeeJhoKFbzYcVUGHvddeWPSucKATb3F0+pgDq0i6ghEaZjsugA==
   /@types/node/14.14.35:
+    dev: true
     resolution:
       integrity: sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==
   /@types/node/14.18.0:
@@ -19302,19 +19236,6 @@ packages:
         optional: true
     resolution:
       integrity: sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
-  /follow-redirects/1.14.1_debug@4.3.1:
-    dependencies:
-      debug: 4.3.1
-    dev: false
-    engines:
-      node: '>=4.0'
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    resolution:
-      integrity: sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
   /follow-redirects/1.14.1_debug@4.3.2:
     dependencies:
       debug: 4.3.2_supports-color@6.1.0
@@ -20322,34 +20243,6 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
-  /http-proxy-middleware/1.0.6_debug@4.3.1:
-    dependencies:
-      '@types/http-proxy': 1.17.6
-      http-proxy: 1.18.1_debug@4.3.1
-      is-glob: 4.0.1
-      lodash: 4.17.21
-      micromatch: 4.0.4
-    dev: false
-    engines:
-      node: '>=8.0.0'
-    peerDependencies:
-      debug: '*'
-    resolution:
-      integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
-  /http-proxy-middleware/1.0.6_debug@4.3.2:
-    dependencies:
-      '@types/http-proxy': 1.17.6
-      http-proxy: 1.18.1_debug@4.3.2
-      is-glob: 4.0.1
-      lodash: 4.17.21
-      micromatch: 4.0.4
-    dev: false
-    engines:
-      node: '>=8.0.0'
-    peerDependencies:
-      debug: '*'
-    resolution:
-      integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
   /http-proxy/1.18.1:
     dependencies:
       eventemitter3: 4.0.7
@@ -20358,18 +20251,6 @@ packages:
     dev: false
     engines:
       node: '>=8.0.0'
-    resolution:
-      integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
-  /http-proxy/1.18.1_debug@4.3.1:
-    dependencies:
-      eventemitter3: 4.0.7
-      follow-redirects: 1.14.1_debug@4.3.1
-      requires-port: 1.0.0
-    dev: false
-    engines:
-      node: '>=8.0.0'
-    peerDependencies:
-      debug: '*'
     resolution:
       integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
   /http-proxy/1.18.1_debug@4.3.2:
@@ -21417,37 +21298,6 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-L2/Y9szN6FJPWFK8kzWXwfp+FOR7xq0cUL4lIsdbIdwz3Vh6P1nrpcqOleSzr28zOtSHQNV9Z7Tl+KkuK7t5Ng==
-  /jest-circus/26.6.0_canvas@2.9.0:
-    dependencies:
-      '@babel/traverse': 7.15.4
-      '@jest/environment': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/babel__traverse': 7.14.2
-      '@types/node': 16.0.0
-      chalk: 4.1.2
-      co: 4.6.0
-      dedent: 0.7.0
-      expect: 26.6.2
-      is-generator-fn: 2.1.0
-      jest-each: 26.6.2
-      jest-matcher-utils: 26.6.2
-      jest-message-util: 26.6.2
-      jest-runner: 26.6.3_canvas@2.9.0
-      jest-runtime: 26.6.3_canvas@2.9.0
-      jest-snapshot: 26.6.2
-      jest-util: 26.6.2
-      prettier: 2.3.2
-      pretty-format: 26.6.2
-      stack-utils: 2.0.5
-      throat: 5.0.0
-    dev: false
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      canvas: '*'
-    resolution:
-      integrity: sha512-L2/Y9szN6FJPWFK8kzWXwfp+FOR7xq0cUL4lIsdbIdwz3Vh6P1nrpcqOleSzr28zOtSHQNV9Z7Tl+KkuK7t5Ng==
   /jest-circus/27.3.1:
     dependencies:
       '@jest/environment': 27.3.1
@@ -21566,29 +21416,6 @@ packages:
       prompts: 2.4.2
       yargs: 15.4.1
     dev: true
-    engines:
-      node: '>= 10.14.2'
-    hasBin: true
-    peerDependencies:
-      canvas: '*'
-    resolution:
-      integrity: sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
-  /jest-cli/26.6.3_canvas@2.9.0:
-    dependencies:
-      '@jest/core': 26.6.3_canvas@2.9.0
-      '@jest/test-result': 26.6.2
-      '@jest/types': 26.6.2
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.4
-      import-local: 3.0.3
-      is-ci: 2.0.0
-      jest-config: 26.6.3_canvas@2.9.0
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      prompts: 2.4.2
-      yargs: 15.4.1
-    dev: false
     engines:
       node: '>= 10.14.2'
     hasBin: true
@@ -21784,37 +21611,6 @@ packages:
         optional: true
     resolution:
       integrity: sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==
-  /jest-config/26.6.3_canvas@2.9.0:
-    dependencies:
-      '@babel/core': 7.16.0
-      '@jest/test-sequencer': 26.6.3_canvas@2.9.0
-      '@jest/types': 26.6.2
-      babel-jest: 26.6.3_@babel+core@7.16.0
-      chalk: 4.1.2
-      deepmerge: 4.2.2
-      glob: 7.2.0
-      graceful-fs: 4.2.4
-      jest-environment-jsdom: 26.6.2_canvas@2.9.0
-      jest-environment-node: 26.6.2
-      jest-get-type: 26.3.0
-      jest-jasmine2: 26.6.3_canvas@2.9.0
-      jest-regex-util: 26.0.0
-      jest-resolve: 26.6.2
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      micromatch: 4.0.4
-      pretty-format: 26.6.2
-    dev: false
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      canvas: '*'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      ts-node:
-        optional: true
-    resolution:
-      integrity: sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==
   /jest-config/27.3.1:
     dependencies:
       '@babel/core': 7.16.0
@@ -21866,7 +21662,7 @@ packages:
       jest-jasmine2: 27.3.1
       jest-regex-util: 27.0.6
       jest-resolve: 27.3.1
-      jest-runner: 27.3.1_canvas@2.6.1
+      jest-runner: 27.3.1
       jest-util: 27.3.1
       jest-validate: 27.3.1
       micromatch: 4.0.4
@@ -21970,7 +21766,7 @@ packages:
       jest-jasmine2: 27.5.1
       jest-regex-util: 27.5.1
       jest-resolve: 27.5.1
-      jest-runner: 27.5.1_canvas@2.9.0
+      jest-runner: 27.5.1
       jest-util: 27.5.1
       jest-validate: 27.5.1
       micromatch: 4.0.4
@@ -22194,22 +21990,6 @@ packages:
       jest-util: 26.6.2
       jsdom: 16.7.0_canvas@2.6.1
     dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      canvas: '*'
-    resolution:
-      integrity: sha512-jgPqCruTlt3Kwqg5/WVFyHIOJHsiAvhcp2qiR2QQstuG9yWox5+iHpU3ZrcBxW14T4fe5Z68jAfLRh7joCSP2Q==
-  /jest-environment-jsdom/26.6.2_canvas@2.9.0:
-    dependencies:
-      '@jest/environment': 26.6.2
-      '@jest/fake-timers': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/node': 16.11.6
-      jest-mock: 26.6.2
-      jest-util: 26.6.2
-      jsdom: 16.7.0_canvas@2.9.0
-    dev: false
     engines:
       node: '>= 10.14.2'
     peerDependencies:
@@ -22530,33 +22310,6 @@ packages:
       pretty-format: 26.6.2
       throat: 5.0.0
     dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      canvas: '*'
-    resolution:
-      integrity: sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==
-  /jest-jasmine2/26.6.3_canvas@2.9.0:
-    dependencies:
-      '@babel/traverse': 7.16.3
-      '@jest/environment': 26.6.2
-      '@jest/source-map': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/node': 16.11.6
-      chalk: 4.1.2
-      co: 4.6.0
-      expect: 26.6.2
-      is-generator-fn: 2.1.0
-      jest-each: 26.6.2
-      jest-matcher-utils: 26.6.2
-      jest-message-util: 26.6.2
-      jest-runtime: 26.6.3_canvas@2.9.0
-      jest-snapshot: 26.6.2
-      jest-util: 26.6.2
-      pretty-format: 26.6.2
-      throat: 5.0.0
-    dev: false
     engines:
       node: '>= 10.14.2'
     peerDependencies:
@@ -23139,35 +22892,6 @@ packages:
       canvas: '*'
     resolution:
       integrity: sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==
-  /jest-runner/26.6.3_canvas@2.9.0:
-    dependencies:
-      '@jest/console': 26.6.2
-      '@jest/environment': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/node': 16.11.6
-      chalk: 4.1.2
-      emittery: 0.7.2
-      exit: 0.1.2
-      graceful-fs: 4.2.4
-      jest-config: 26.6.3_canvas@2.9.0
-      jest-docblock: 26.0.0
-      jest-haste-map: 26.6.2
-      jest-leak-detector: 26.6.2
-      jest-message-util: 26.6.2
-      jest-resolve: 26.6.2
-      jest-runtime: 26.6.3_canvas@2.9.0
-      jest-util: 26.6.2
-      jest-worker: 26.6.2
-      source-map-support: 0.5.20
-      throat: 5.0.0
-    dev: false
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      canvas: '*'
-    resolution:
-      integrity: sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==
   /jest-runner/27.3.1:
     dependencies:
       '@jest/console': 27.3.1
@@ -23195,37 +22919,6 @@ packages:
     dev: true
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
-    resolution:
-      integrity: sha512-r4W6kBn6sPr3TBwQNmqE94mPlYVn7fLBseeJfo4E2uCTmAyDFm2O5DYAQAFP7Q3YfiA/bMwg8TVsciP7k0xOww==
-  /jest-runner/27.3.1_canvas@2.6.1:
-    dependencies:
-      '@jest/console': 27.3.1
-      '@jest/environment': 27.3.1
-      '@jest/test-result': 27.3.1
-      '@jest/transform': 27.3.1
-      '@jest/types': 27.2.5
-      '@types/node': 15.3.0
-      chalk: 4.1.2
-      emittery: 0.8.1
-      exit: 0.1.2
-      graceful-fs: 4.2.4
-      jest-docblock: 27.0.6
-      jest-environment-jsdom: 27.3.1_canvas@2.6.1
-      jest-environment-node: 27.3.1
-      jest-haste-map: 27.3.1
-      jest-leak-detector: 27.3.1
-      jest-message-util: 27.3.1
-      jest-resolve: 27.3.1
-      jest-runtime: 27.3.1
-      jest-util: 27.3.1
-      jest-worker: 27.3.1
-      source-map-support: 0.5.20
-      throat: 6.0.1
-    dev: true
-    engines:
-      node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
-    peerDependencies:
-      canvas: '*'
     resolution:
       integrity: sha512-r4W6kBn6sPr3TBwQNmqE94mPlYVn7fLBseeJfo4E2uCTmAyDFm2O5DYAQAFP7Q3YfiA/bMwg8TVsciP7k0xOww==
   /jest-runner/27.4.5:
@@ -23283,36 +22976,6 @@ packages:
     dev: true
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
-    resolution:
-      integrity: sha512-g4NPsM4mFCOwFKXO4p/H/kWGdJp9V8kURY2lX8Me2drgXqG7rrZAx5kv+5H7wtt/cdFIjhqYx1HrlqWHaOvDaQ==
-  /jest-runner/27.5.1_canvas@2.9.0:
-    dependencies:
-      '@jest/console': 27.5.1
-      '@jest/environment': 27.5.1
-      '@jest/test-result': 27.5.1
-      '@jest/transform': 27.5.1
-      '@jest/types': 27.5.1
-      '@types/node': 17.0.23
-      chalk: 4.1.2
-      emittery: 0.8.1
-      graceful-fs: 4.2.4
-      jest-docblock: 27.5.1
-      jest-environment-jsdom: 27.5.1_canvas@2.9.0
-      jest-environment-node: 27.5.1
-      jest-haste-map: 27.5.1
-      jest-leak-detector: 27.5.1
-      jest-message-util: 27.5.1
-      jest-resolve: 27.5.1
-      jest-runtime: 27.5.1
-      jest-util: 27.5.1
-      jest-worker: 27.5.1
-      source-map-support: 0.5.21
-      throat: 6.0.1
-    dev: true
-    engines:
-      node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
-    peerDependencies:
-      canvas: '*'
     resolution:
       integrity: sha512-g4NPsM4mFCOwFKXO4p/H/kWGdJp9V8kURY2lX8Me2drgXqG7rrZAx5kv+5H7wtt/cdFIjhqYx1HrlqWHaOvDaQ==
   /jest-runtime/26.6.3:
@@ -23380,43 +23043,6 @@ packages:
       strip-bom: 4.0.0
       yargs: 15.4.1
     dev: true
-    engines:
-      node: '>= 10.14.2'
-    hasBin: true
-    peerDependencies:
-      canvas: '*'
-    resolution:
-      integrity: sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==
-  /jest-runtime/26.6.3_canvas@2.9.0:
-    dependencies:
-      '@jest/console': 26.6.2
-      '@jest/environment': 26.6.2
-      '@jest/fake-timers': 26.6.2
-      '@jest/globals': 26.6.2
-      '@jest/source-map': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/transform': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/yargs': 15.0.14
-      chalk: 4.1.2
-      cjs-module-lexer: 0.6.0
-      collect-v8-coverage: 1.0.1
-      exit: 0.1.2
-      glob: 7.2.0
-      graceful-fs: 4.2.4
-      jest-config: 26.6.3_canvas@2.9.0
-      jest-haste-map: 26.6.2
-      jest-message-util: 26.6.2
-      jest-mock: 26.6.2
-      jest-regex-util: 26.0.0
-      jest-resolve: 26.6.2
-      jest-snapshot: 26.6.2
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      slash: 3.0.0
-      strip-bom: 4.0.0
-      yargs: 15.4.1
-    dev: false
     engines:
       node: '>= 10.14.2'
     hasBin: true
@@ -24061,19 +23687,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-jxTmrvuecVISvKFFhOkjsWRZV7sFqdSUAd1ajOKY+/QE/aLBVstsJ/dX8GczLzwiT6ZEwwmZqtCUHLHHQVzcfA==
-  /jest/26.6.0_canvas@2.9.0:
-    dependencies:
-      '@jest/core': 26.6.3_canvas@2.9.0
-      import-local: 3.0.3
-      jest-cli: 26.6.3_canvas@2.9.0
-    dev: false
-    engines:
-      node: '>= 10.14.2'
-    hasBin: true
-    peerDependencies:
-      canvas: '*'
-    resolution:
-      integrity: sha512-jxTmrvuecVISvKFFhOkjsWRZV7sFqdSUAd1ajOKY+/QE/aLBVstsJ/dX8GczLzwiT6ZEwwmZqtCUHLHHQVzcfA==
   /jest/26.6.3_canvas@2.6.1:
     dependencies:
       '@jest/core': 26.6.3_canvas@2.6.1
@@ -24316,6 +23929,7 @@ packages:
       whatwg-url: 8.7.0
       ws: 7.5.6
       xml-name-validator: 3.0.0
+    dev: true
     engines:
       node: '>=10'
     peerDependencies:
@@ -28378,81 +27992,6 @@ packages:
         optional: true
     resolution:
       integrity: sha512-NnniMSC/wjwhcJAyPJCWtxx6CWONqgvGgV9+QXj1bwoW/JI++YF1eEf3Upf/mQ9KmP57IBdjzWs1XvnPq7qMTQ==
-  /react-scripts/4.0.1_canvas@2.9.0+typescript@4.3.5:
-    dependencies:
-      '@babel/core': 7.12.3
-      '@pmmmwh/react-refresh-webpack-plugin': 0.4.2_d00fcc46a48175a4e289da7534b00e9a
-      '@svgr/webpack': 5.4.0
-      '@typescript-eslint/eslint-plugin': 4.30.0_30d5b6043eb1943afef560c3f2647d4d
-      '@typescript-eslint/parser': 4.29.3_eslint@7.29.0+typescript@4.3.5
-      babel-eslint: 10.1.0_eslint@7.29.0
-      babel-jest: 26.6.3_@babel+core@7.12.3
-      babel-loader: 8.1.0_427212bc1158d185e577033f19ca0757
-      babel-plugin-named-asset-import: 0.3.7_@babel+core@7.12.3
-      babel-preset-react-app: 10.0.0
-      bfj: 7.0.2
-      camelcase: 6.2.0
-      case-sensitive-paths-webpack-plugin: 2.3.0
-      css-loader: 4.3.0_webpack@4.44.2
-      dotenv: 8.2.0
-      dotenv-expand: 5.1.0
-      eslint: 7.29.0
-      eslint-config-react-app: 6.0.0_d4ef662949d0d072f3e3ae2e54a11fae
-      eslint-plugin-flowtype: 5.2.0_eslint@7.29.0
-      eslint-plugin-import: 2.24.2_eslint@7.29.0+typescript@4.3.5
-      eslint-plugin-jest: 24.1.3_eslint@7.29.0+typescript@4.3.5
-      eslint-plugin-jsx-a11y: 6.4.1_eslint@7.29.0
-      eslint-plugin-react: 7.24.0_eslint@7.29.0
-      eslint-plugin-react-hooks: 4.2.0_eslint@7.29.0
-      eslint-plugin-testing-library: 3.10.1_eslint@7.29.0+typescript@4.3.5
-      eslint-webpack-plugin: 2.4.1_eslint@7.29.0+webpack@4.44.2
-      file-loader: 6.1.1_webpack@4.44.2
-      fs-extra: 9.1.0
-      html-webpack-plugin: 4.5.0_webpack@4.44.2
-      identity-obj-proxy: 3.0.0
-      jest: 26.6.0_canvas@2.9.0
-      jest-circus: 26.6.0_canvas@2.9.0
-      jest-resolve: 26.6.0
-      jest-watch-typeahead: 0.6.1_jest@26.6.0
-      mini-css-extract-plugin: 0.11.3_webpack@4.44.2
-      optimize-css-assets-webpack-plugin: 5.0.4_webpack@4.44.2
-      pnp-webpack-plugin: 1.6.4_typescript@4.3.5
-      postcss-flexbugs-fixes: 4.2.1
-      postcss-loader: 3.0.0
-      postcss-normalize: 8.0.1
-      postcss-preset-env: 6.7.0
-      postcss-safe-parser: 5.0.2
-      prompts: 2.4.0
-      react-app-polyfill: 2.0.0
-      react-dev-utils: 11.0.3
-      react-refresh: 0.8.3
-      resolve: 1.18.1
-      resolve-url-loader: 3.1.2
-      sass-loader: 8.0.2_webpack@4.44.2
-      semver: 7.3.2
-      style-loader: 1.3.0_webpack@4.44.2
-      terser-webpack-plugin: 4.2.3_webpack@4.44.2
-      ts-pnp: 1.2.0_typescript@4.3.5
-      typescript: 4.3.5
-      url-loader: 4.1.1_file-loader@6.1.1+webpack@4.44.2
-      webpack: 4.44.2
-      webpack-dev-server: 3.11.0_webpack@4.44.2
-      webpack-manifest-plugin: 2.2.0_webpack@4.44.2
-      workbox-webpack-plugin: 5.1.4_webpack@4.44.2
-    dev: false
-    engines:
-      node: ^10.12.0 || >=12.0.0
-    hasBin: true
-    optionalDependencies:
-      fsevents: 2.3.2
-    peerDependencies:
-      canvas: '*'
-      typescript: ^3.2.1
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    resolution:
-      integrity: sha512-NnniMSC/wjwhcJAyPJCWtxx6CWONqgvGgV9+QXj1bwoW/JI++YF1eEf3Upf/mQ9KmP57IBdjzWs1XvnPq7qMTQ==
   /react-scripts/4.0.1_typescript@4.3.5:
     dependencies:
       '@babel/core': 7.12.3
@@ -31150,7 +30689,7 @@ packages:
       '@types/jest': 27.0.3
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 27.3.1
+      jest: 27.3.1_canvas@2.6.1
       jest-util: 27.3.1
       json5: 2.2.0
       lodash.memoize: 4.1.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -384,7 +384,6 @@ importers:
       ts-jest: 26.5.5_typescript@4.3.5
       typescript: 4.3.5
       use-interval: 1.3.0_react@17.0.1
-      yauzl: 2.10.0
       zod: 3.2.0
     devDependencies:
       '@testing-library/react': 11.2.3_react-dom@17.0.1+react@17.0.1
@@ -395,7 +394,6 @@ importers:
       '@types/kiosk-browser': link:../../libs/@types/kiosk-browser
       '@types/pify': 3.0.2
       '@types/react-router-dom': 5.1.7
-      '@types/yauzl': 2.9.1
       '@types/zip-stream': link:../../libs/@types/zip-stream
       '@typescript-eslint/eslint-plugin': 4.28.4_852673d3af9c7ab8ae779b8d717157c6
       '@typescript-eslint/parser': 4.28.4_eslint@7.17.0+typescript@4.3.5
@@ -445,7 +443,6 @@ importers:
       '@types/react-dom': ^17.0.0
       '@types/react-router-dom': ^5.1.5
       '@types/styled-components': ^5.1.7
-      '@types/yauzl': ^2.9.1
       '@types/zip-stream': workspace:*
       '@typescript-eslint/eslint-plugin': ^4.28.4
       '@typescript-eslint/parser': ^4.28.4
@@ -501,7 +498,6 @@ importers:
       type-fest: ^0.18.0
       typescript: ^4.3.5
       use-interval: ^1.2.1
-      yauzl: ^2.10.0
       zip-stream: ^3.0.1
       zod: 3.2.0
   frontends/bsd/prodserver:
@@ -2011,10 +2007,10 @@ importers:
       fast-text-encoding: 1.0.3
       fetch-mock: 9.11.0
       jest-fetch-mock: 3.0.3
+      jszip: 3.9.1
       luxon: 1.27.0
       moment: 2.29.1
       rxjs: 6.6.6
-      yauzl: 2.10.0
       zod: 3.2.0
     devDependencies:
       '@types/debug': 4.1.7
@@ -2022,7 +2018,6 @@ importers:
       '@types/jest': 27.0.3
       '@types/kiosk-browser': link:../@types/kiosk-browser
       '@types/luxon': 1.26.5
-      '@types/yauzl': 2.9.1
       '@typescript-eslint/eslint-plugin': 4.28.4_ed91d8a9a45fee40b4f28fa6457a3abe
       '@typescript-eslint/parser': 4.28.4_eslint@7.26.0+typescript@4.3.5
       '@votingworks/fixtures': link:../fixtures
@@ -2049,7 +2044,6 @@ importers:
       '@types/kiosk-browser': workspace:*
       '@types/luxon': ^1.26.5
       '@types/node': ^12.20.11
-      '@types/yauzl': ^2.9.1
       '@typescript-eslint/eslint-plugin': ^4.28.4
       '@typescript-eslint/parser': ^4.28.4
       '@votingworks/fixtures': workspace:*
@@ -2070,6 +2064,7 @@ importers:
       jest: ^27.3.1
       jest-fetch-mock: ^3.0.3
       jest-watch-typeahead: ^0.6.4
+      jszip: ^3.9.1
       lint-staged: ^11.0.0
       luxon: ^1.27.0
       moment: ^2.29.1
@@ -2078,7 +2073,6 @@ importers:
       sort-package-json: ^1.50.0
       ts-jest: ^27.0.7
       typescript: ^4.3.5
-      yauzl: ^2.10.0
       zod: 3.2.0
   script:
     dependencies:
@@ -2118,6 +2112,7 @@ importers:
       fs-extra: 9.0.1
       got: 11.8.2
       jest-diff: 26.6.2
+      jszip: 3.9.1
       luxon: 1.27.0
       memory-streams: 0.1.3
       multer: 1.4.2
@@ -2144,7 +2139,6 @@ importers:
       '@types/supertest': 2.0.10
       '@types/tmp': 0.2.0
       '@types/uuid': 8.3.0
-      '@types/yauzl': 2.9.1
       '@types/zip-stream': link:../../libs/@types/zip-stream
       '@typescript-eslint/eslint-plugin': 4.28.4_852673d3af9c7ab8ae779b8d717157c6
       '@typescript-eslint/parser': 4.28.4_eslint@7.17.0+typescript@4.3.5
@@ -2169,7 +2163,6 @@ importers:
       supertest: 6.1.1
       ts-jest: 26.4.4_jest@26.6.3+typescript@4.3.5
       typescript: 4.3.5
-      yauzl: 2.10.0
     specifiers:
       '@types/base64-js': ^1.3.0
       '@types/better-sqlite3': ^7.4.3
@@ -2187,7 +2180,6 @@ importers:
       '@types/supertest': ^2.0.10
       '@types/tmp': ^0.2.0
       '@types/uuid': ^8.3.0
-      '@types/yauzl': ^2.9.1
       '@types/zip-stream': workspace:*
       '@typescript-eslint/eslint-plugin': ^4.28.4
       '@typescript-eslint/parser': ^4.28.4
@@ -2225,6 +2217,7 @@ importers:
       jest: ^26.6.3
       jest-diff: ^26.6.2
       jest-watch-typeahead: ^0.6.4
+      jszip: ^3.9.1
       lint-staged: ^10.5.3
       luxon: ^1.27.0
       memory-streams: ^0.1.3
@@ -2239,7 +2232,6 @@ importers:
       ts-jest: ^26.4.4
       typescript: ^4.3.5
       uuid: ^8.3.2
-      yauzl: ^2.10.0
       zip-stream: ^4.0.4
       zod: ^3.2.0
 lockfileVersion: 5.2
@@ -9335,6 +9327,7 @@ packages:
     dependencies:
       '@types/node': 15.3.0
     dev: true
+    optional: true
     resolution:
       integrity: sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==
   /@typescript-eslint/eslint-plugin/4.28.4_1d3bd85b4b489d1777514df5fe613e8c:
@@ -19091,6 +19084,7 @@ packages:
   /fd-slicer/1.1.0:
     dependencies:
       pend: 1.2.0
+    dev: true
     resolution:
       integrity: sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
   /fetch-mock/9.11.0:
@@ -19323,7 +19317,7 @@ packages:
       integrity: sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
   /follow-redirects/1.14.1_debug@4.3.2:
     dependencies:
-      debug: 4.3.2
+      debug: 4.3.2_supports-color@6.1.0
     engines:
       node: '>=4.0'
     peerDependencies:
@@ -20511,6 +20505,10 @@ packages:
       node: '>= 4'
     resolution:
       integrity: sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
+  /immediate/3.0.6:
+    dev: false
+    resolution:
+      integrity: sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
   /immer/8.0.1:
     resolution:
       integrity: sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
@@ -24479,6 +24477,15 @@ packages:
       node: '>=4.0'
     resolution:
       integrity: sha512-EIsmt3O3ljsU6sot/J4E1zDRxfBNrhjyf/OKjlydwgEimQuznlM4Wv7U+ueONJMyEn1WRE0K8dhi3dVAXYT24Q==
+  /jszip/3.9.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.7
+      set-immediate-shim: 1.0.1
+    dev: false
+    resolution:
+      integrity: sha512-H9A60xPqJ1CuC4Ka6qxzXZeU8aNmgOeP5IFqwJbQQwtu2EUYxota3LdsiZWplF7Wgd9tkAd0mdu36nceSaPuYw==
   /keyv/4.2.2:
     dependencies:
       compress-brotli: 1.3.6
@@ -24571,6 +24578,12 @@ packages:
       node: '>= 0.8.0'
     resolution:
       integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
+  /lie/3.3.0:
+    dependencies:
+      immediate: 3.0.6
+    dev: false
+    resolution:
+      integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==
   /lines-and-columns/1.2.4:
     resolution:
       integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
@@ -26658,6 +26671,7 @@ packages:
     resolution:
       integrity: sha512-yckJEHq3F48hcp6wStEpbN9McOj328Ib09UrBlGAKxvN2k+qYPN5iq6TH6jD1C0pso7zTep+g/CKsYgdrQd5QA==
   /pend/1.2.0:
+    dev: true
     resolution:
       integrity: sha1-elfrVQpng/kRUzH89GY9XI4AelA=
   /performance-now/2.1.0:
@@ -29414,6 +29428,12 @@ packages:
   /set-blocking/2.0.0:
     resolution:
       integrity: sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+  /set-immediate-shim/1.0.1:
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=
   /set-value/2.0.1:
     dependencies:
       extend-shallow: 2.0.1
@@ -31130,7 +31150,7 @@ packages:
       '@types/jest': 27.0.3
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 27.3.1_canvas@2.6.1
+      jest: 27.3.1
       jest-util: 27.3.1
       json5: 2.2.0
       lodash.memoize: 4.1.2
@@ -32688,6 +32708,7 @@ packages:
     dependencies:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
+    dev: true
     resolution:
       integrity: sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=
   /yocto-queue/0.1.0:

--- a/services/scan/package.json
+++ b/services/scan/package.json
@@ -80,7 +80,7 @@
     "@types/jest": "^26.0.6",
     "@types/luxon": "^1.26.5",
     "@types/multer": "^1.4.3",
-    "@types/node": "^12.0.0",
+    "@types/node": "12.19.16",
     "@types/pdfjs-dist": "^2.1.3",
     "@types/supertest": "^2.0.10",
     "@types/tmp": "^0.2.0",

--- a/services/scan/package.json
+++ b/services/scan/package.json
@@ -57,6 +57,7 @@
     "fs-extra": "^9.0.1",
     "got": "^11.8.2",
     "jest-diff": "^26.6.2",
+    "jszip": "^3.9.1",
     "luxon": "^1.27.0",
     "memory-streams": "^0.1.3",
     "multer": "^1.4.2",
@@ -84,7 +85,6 @@
     "@types/supertest": "^2.0.10",
     "@types/tmp": "^0.2.0",
     "@types/uuid": "^8.3.0",
-    "@types/yauzl": "^2.9.1",
     "@types/zip-stream": "workspace:*",
     "@typescript-eslint/eslint-plugin": "^4.28.4",
     "@typescript-eslint/parser": "^4.28.4",
@@ -108,8 +108,7 @@
     "sort-package-json": "^1.50.0",
     "supertest": "^6.0.1",
     "ts-jest": "^26.4.4",
-    "typescript": "^4.3.5",
-    "yauzl": "^2.10.0"
+    "typescript": "^4.3.5"
   },
   "engines": {
     "node": ">= 12"


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
I left most of the structure in place for now even though most of the API of `jszip` is easier to work with and could be inlined. We can change that later if we deem it worthwhile.

Closes #1696

## Demo Video or Screenshot
n/a

## Testing Plan 
Automated testing, plus manually tested uploading a ballot package zip file in `bsd`.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
