### PR TITLE
fix(bmd): Fix path for uploaded cypress artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,9 +85,9 @@ jobs:
           command: |
             pnpm --dir frontends/bmd test:e2e
       - store_artifacts:
-          path: integration-testing/bmd/cypress/screenshots
+          path: frontends/bmd/cypress/screenshots
       - store_artifacts:
-          path: integration-testing/bmd/cypress/videos
+          path: frontends/bmd/cypress/videos
 
   test-frontends-bsd:
     executor: nodejs-browsers


### PR DESCRIPTION
## Overview
Fixes #1720 

## Demo Video or Screenshot
<img width="550" alt="Screen Shot 2022-04-21 at 11 07 40 AM" src="https://user-images.githubusercontent.com/7584833/164490567-763732b8-810a-4da2-a016-08eeaac1b234.png">
<img width="550" alt="Screen Shot 2022-04-21 at 11 13 42 AM" src="https://user-images.githubusercontent.com/7584833/164490572-01607f50-9cb0-46d9-9ee4-45636fbd3055.png">

## Testing Plan 
Confirmed the fix for the `test-integration-testing-bmd` job, and also confirmed the path convention (cypress path should match where the tests are executed from) by intentionally breaking a `test-integration-testing-bsd` cypress test.

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
