### PR TITLE
chore(all): pin `graceful-fs` to v4.2.10

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6817,7 +6817,7 @@ packages:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       exit: 0.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-changed-files: 26.6.2
       jest-config: 26.6.3
       jest-haste-map: 26.6.2
@@ -6852,7 +6852,7 @@ packages:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       exit: 0.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-changed-files: 26.6.2
       jest-config: 26.6.3_canvas@2.6.1
       jest-haste-map: 26.6.2
@@ -6890,7 +6890,7 @@ packages:
       chalk: 4.1.2
       emittery: 0.8.1
       exit: 0.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-changed-files: 27.3.0
       jest-config: 27.3.1
       jest-haste-map: 27.3.1
@@ -6930,7 +6930,7 @@ packages:
       chalk: 4.1.2
       emittery: 0.8.1
       exit: 0.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-changed-files: 27.3.0
       jest-config: 27.3.1_canvas@2.6.1
       jest-haste-map: 27.3.1
@@ -6971,7 +6971,7 @@ packages:
       chalk: 4.1.2
       emittery: 0.8.1
       exit: 0.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-changed-files: 27.4.2
       jest-config: 27.4.5
       jest-haste-map: 27.4.5
@@ -7011,7 +7011,7 @@ packages:
       chalk: 4.1.2
       emittery: 0.8.1
       exit: 0.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-changed-files: 27.5.1
       jest-config: 27.5.1
       jest-haste-map: 27.5.1
@@ -7051,7 +7051,7 @@ packages:
       chalk: 4.1.2
       emittery: 0.8.1
       exit: 0.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-changed-files: 27.5.1
       jest-config: 27.5.1_canvas@2.9.0
       jest-haste-map: 27.5.1
@@ -7260,7 +7260,7 @@ packages:
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
       glob: 7.2.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       istanbul-lib-coverage: 3.2.0
       istanbul-lib-instrument: 4.0.3
       istanbul-lib-report: 3.0.0
@@ -7293,7 +7293,7 @@ packages:
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
       glob: 7.2.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       istanbul-lib-coverage: 3.2.0
       istanbul-lib-instrument: 4.0.3
       istanbul-lib-report: 3.0.0
@@ -7330,7 +7330,7 @@ packages:
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
       glob: 7.2.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       istanbul-lib-coverage: 3.2.0
       istanbul-lib-instrument: 4.0.3
       istanbul-lib-report: 3.0.0
@@ -7367,7 +7367,7 @@ packages:
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
       glob: 7.2.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       istanbul-lib-coverage: 3.2.0
       istanbul-lib-instrument: 5.1.0
       istanbul-lib-report: 3.0.0
@@ -7395,7 +7395,7 @@ packages:
   /@jest/source-map/26.6.2:
     dependencies:
       callsites: 3.1.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       source-map: 0.6.1
     engines:
       node: '>= 10.14.2'
@@ -7404,7 +7404,7 @@ packages:
   /@jest/source-map/27.0.6:
     dependencies:
       callsites: 3.1.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       source-map: 0.6.1
     dev: true
     engines:
@@ -7414,7 +7414,7 @@ packages:
   /@jest/source-map/27.4.0:
     dependencies:
       callsites: 3.1.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       source-map: 0.6.1
     dev: true
     engines:
@@ -7424,7 +7424,7 @@ packages:
   /@jest/source-map/27.5.1:
     dependencies:
       callsites: 3.1.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       source-map: 0.6.1
     dev: true
     engines:
@@ -7488,7 +7488,7 @@ packages:
   /@jest/test-sequencer/26.6.3:
     dependencies:
       '@jest/test-result': 26.6.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-haste-map: 26.6.2
       jest-runner: 26.6.3
       jest-runtime: 26.6.3
@@ -7500,7 +7500,7 @@ packages:
   /@jest/test-sequencer/26.6.3_canvas@2.6.1:
     dependencies:
       '@jest/test-result': 26.6.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-haste-map: 26.6.2
       jest-runner: 26.6.3_canvas@2.6.1
       jest-runtime: 26.6.3_canvas@2.6.1
@@ -7514,7 +7514,7 @@ packages:
   /@jest/test-sequencer/27.3.1:
     dependencies:
       '@jest/test-result': 27.3.1
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-haste-map: 27.3.1
       jest-runtime: 27.3.1
     dev: true
@@ -7525,7 +7525,7 @@ packages:
   /@jest/test-sequencer/27.4.5:
     dependencies:
       '@jest/test-result': 27.4.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-haste-map: 27.4.5
       jest-runtime: 27.4.5
     dev: true
@@ -7536,7 +7536,7 @@ packages:
   /@jest/test-sequencer/27.5.1:
     dependencies:
       '@jest/test-result': 27.5.1
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-haste-map: 27.5.1
       jest-runtime: 27.5.1
     dev: true
@@ -7552,7 +7552,7 @@ packages:
       chalk: 4.1.2
       convert-source-map: 1.8.0
       fast-json-stable-stringify: 2.1.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-haste-map: 26.6.2
       jest-regex-util: 26.0.0
       jest-util: 26.6.2
@@ -7573,7 +7573,7 @@ packages:
       chalk: 4.1.2
       convert-source-map: 1.8.0
       fast-json-stable-stringify: 2.1.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-haste-map: 27.3.1
       jest-regex-util: 27.0.6
       jest-util: 27.3.1
@@ -7595,7 +7595,7 @@ packages:
       chalk: 4.1.2
       convert-source-map: 1.8.0
       fast-json-stable-stringify: 2.1.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-haste-map: 27.4.5
       jest-regex-util: 27.4.0
       jest-util: 27.4.2
@@ -7617,7 +7617,7 @@ packages:
       chalk: 4.1.2
       convert-source-map: 1.8.0
       fast-json-stable-stringify: 2.1.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-haste-map: 27.5.1
       jest-regex-util: 27.5.1
       jest-util: 27.5.1
@@ -11309,7 +11309,7 @@ packages:
   /archiver-utils/2.1.0:
     dependencies:
       glob: 7.1.6
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       lazystream: 1.0.0
       lodash.defaults: 4.2.0
       lodash.difference: 4.5.0
@@ -11657,7 +11657,7 @@ packages:
       babel-plugin-istanbul: 6.1.1
       babel-preset-jest: 26.6.2_@babel+core@7.12.3
       chalk: 4.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       slash: 3.0.0
     dev: false
     engines:
@@ -11675,7 +11675,7 @@ packages:
       babel-plugin-istanbul: 6.1.1
       babel-preset-jest: 26.6.2_@babel+core@7.16.0
       chalk: 4.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       slash: 3.0.0
     engines:
       node: '>= 10.14.2'
@@ -11692,7 +11692,7 @@ packages:
       babel-plugin-istanbul: 6.1.1
       babel-preset-jest: 27.2.0_@babel+core@7.16.0
       chalk: 4.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       slash: 3.0.0
     dev: true
     engines:
@@ -11710,7 +11710,7 @@ packages:
       babel-plugin-istanbul: 6.1.1
       babel-preset-jest: 27.4.0_@babel+core@7.16.5
       chalk: 4.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       slash: 3.0.0
     dev: true
     engines:
@@ -11728,7 +11728,7 @@ packages:
       babel-plugin-istanbul: 6.1.1
       babel-preset-jest: 27.5.1_@babel+core@7.16.5
       chalk: 4.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       slash: 3.0.0
     dev: true
     engines:
@@ -19350,7 +19350,7 @@ packages:
       integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
   /fs-extra/10.0.0:
     dependencies:
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jsonfile: 6.1.0
       universalify: 2.0.0
     dev: true
@@ -19370,7 +19370,7 @@ packages:
       integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
   /fs-extra/8.1.0:
     dependencies:
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jsonfile: 4.0.0
       universalify: 0.1.2
     engines:
@@ -19380,7 +19380,7 @@ packages:
   /fs-extra/9.0.1:
     dependencies:
       at-least-node: 1.0.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jsonfile: 6.1.0
       universalify: 1.0.0
     dev: false
@@ -19391,7 +19391,7 @@ packages:
   /fs-extra/9.1.0:
     dependencies:
       at-least-node: 1.0.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jsonfile: 6.1.0
       universalify: 2.0.0
     engines:
@@ -19852,9 +19852,6 @@ packages:
   /graceful-fs/4.2.10:
     resolution:
       integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
-  /graceful-fs/4.2.4:
-    resolution:
-      integrity: sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
   /growly/1.3.0:
     optional: true
     resolution:
@@ -21386,7 +21383,7 @@ packages:
       '@jest/types': 26.6.2
       chalk: 4.1.2
       exit: 0.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       import-local: 3.0.3
       is-ci: 2.0.0
       jest-config: 26.6.3
@@ -21407,7 +21404,7 @@ packages:
       '@jest/types': 26.6.2
       chalk: 4.1.2
       exit: 0.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       import-local: 3.0.3
       is-ci: 2.0.0
       jest-config: 26.6.3_canvas@2.6.1
@@ -21430,7 +21427,7 @@ packages:
       '@jest/types': 27.2.5
       chalk: 4.1.2
       exit: 0.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       import-local: 3.0.3
       jest-config: 27.3.1
       jest-util: 27.3.1
@@ -21455,7 +21452,7 @@ packages:
       '@jest/types': 27.2.5
       chalk: 4.1.2
       exit: 0.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       import-local: 3.0.3
       jest-config: 27.3.1_canvas@2.6.1
       jest-util: 27.3.1
@@ -21481,7 +21478,7 @@ packages:
       '@jest/types': 27.4.2
       chalk: 4.1.2
       exit: 0.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       import-local: 3.0.3
       jest-config: 27.4.5
       jest-util: 27.4.2
@@ -21506,7 +21503,7 @@ packages:
       '@jest/types': 27.5.1
       chalk: 4.1.2
       exit: 0.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       import-local: 3.0.3
       jest-config: 27.5.1
       jest-util: 27.5.1
@@ -21531,7 +21528,7 @@ packages:
       '@jest/types': 27.5.1
       chalk: 4.1.2
       exit: 0.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       import-local: 3.0.3
       jest-config: 27.5.1_canvas@2.9.0
       jest-util: 27.5.1
@@ -21559,7 +21556,7 @@ packages:
       chalk: 4.1.2
       deepmerge: 4.2.2
       glob: 7.2.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-environment-jsdom: 26.6.2
       jest-environment-node: 26.6.2
       jest-get-type: 26.3.0
@@ -21589,7 +21586,7 @@ packages:
       chalk: 4.1.2
       deepmerge: 4.2.2
       glob: 7.2.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-environment-jsdom: 26.6.2_canvas@2.6.1
       jest-environment-node: 26.6.2
       jest-get-type: 26.3.0
@@ -21621,7 +21618,7 @@ packages:
       ci-info: 3.2.0
       deepmerge: 4.2.2
       glob: 7.2.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-circus: 27.3.1
       jest-environment-jsdom: 27.3.1
       jest-environment-node: 27.3.1
@@ -21654,7 +21651,7 @@ packages:
       ci-info: 3.2.0
       deepmerge: 4.2.2
       glob: 7.2.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-circus: 27.3.1
       jest-environment-jsdom: 27.3.1_canvas@2.6.1
       jest-environment-node: 27.3.1
@@ -21688,7 +21685,7 @@ packages:
       ci-info: 3.3.0
       deepmerge: 4.2.2
       glob: 7.2.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-circus: 27.4.5
       jest-environment-jsdom: 27.4.4
       jest-environment-node: 27.4.4
@@ -21722,7 +21719,7 @@ packages:
       ci-info: 3.3.0
       deepmerge: 4.2.2
       glob: 7.2.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-circus: 27.5.1
       jest-environment-jsdom: 27.5.1
       jest-environment-node: 27.5.1
@@ -21758,7 +21755,7 @@ packages:
       ci-info: 3.3.0
       deepmerge: 4.2.2
       glob: 7.2.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-circus: 27.5.1
       jest-environment-jsdom: 27.5.1_canvas@2.9.0
       jest-environment-node: 27.5.1
@@ -22187,7 +22184,7 @@ packages:
       '@types/node': 16.11.6
       anymatch: 3.1.2
       fb-watchman: 2.0.1
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-regex-util: 26.0.0
       jest-serializer: 26.6.2
       jest-util: 26.6.2
@@ -22208,7 +22205,7 @@ packages:
       '@types/node': 15.3.0
       anymatch: 3.1.2
       fb-watchman: 2.0.1
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-regex-util: 27.0.6
       jest-serializer: 27.0.6
       jest-util: 27.3.1
@@ -22229,7 +22226,7 @@ packages:
       '@types/node': 16.11.6
       anymatch: 3.1.2
       fb-watchman: 2.0.1
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-regex-util: 27.4.0
       jest-serializer: 27.4.0
       jest-util: 27.4.2
@@ -22250,7 +22247,7 @@ packages:
       '@types/node': 17.0.23
       anymatch: 3.1.2
       fb-watchman: 2.0.1
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-regex-util: 27.5.1
       jest-serializer: 27.5.1
       jest-util: 27.5.1
@@ -22484,7 +22481,7 @@ packages:
       '@jest/types': 25.5.0
       '@types/stack-utils': 1.0.1
       chalk: 3.0.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       micromatch: 4.0.4
       slash: 3.0.0
       stack-utils: 1.0.4
@@ -22499,7 +22496,7 @@ packages:
       '@jest/types': 26.6.2
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       micromatch: 4.0.4
       pretty-format: 26.6.2
       slash: 3.0.0
@@ -22514,7 +22511,7 @@ packages:
       '@jest/types': 27.0.2
       '@types/stack-utils': 2.0.0
       chalk: 4.1.1
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       micromatch: 4.0.4
       pretty-format: 27.0.2
       slash: 3.0.0
@@ -22530,7 +22527,7 @@ packages:
       '@jest/types': 27.2.5
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       micromatch: 4.0.4
       pretty-format: 27.3.1
       slash: 3.0.0
@@ -22546,7 +22543,7 @@ packages:
       '@jest/types': 27.4.2
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       micromatch: 4.0.4
       pretty-format: 27.4.2
       slash: 3.0.0
@@ -22562,7 +22559,7 @@ packages:
       '@jest/types': 27.5.1
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       micromatch: 4.0.4
       pretty-format: 27.5.1
       slash: 3.0.0
@@ -22760,7 +22757,7 @@ packages:
     dependencies:
       '@jest/types': 26.6.2
       chalk: 4.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-pnp-resolver: 1.2.2_jest-resolve@26.6.0
       jest-util: 26.6.2
       read-pkg-up: 7.0.1
@@ -22775,7 +22772,7 @@ packages:
     dependencies:
       '@jest/types': 26.6.2
       chalk: 4.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-pnp-resolver: 1.2.2_jest-resolve@26.6.2
       jest-util: 26.6.2
       read-pkg-up: 7.0.1
@@ -22789,7 +22786,7 @@ packages:
     dependencies:
       '@jest/types': 27.2.5
       chalk: 4.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-haste-map: 27.3.1
       jest-pnp-resolver: 1.2.2_jest-resolve@27.3.1
       jest-util: 27.3.1
@@ -22806,7 +22803,7 @@ packages:
     dependencies:
       '@jest/types': 27.4.2
       chalk: 4.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-haste-map: 27.4.5
       jest-pnp-resolver: 1.2.2_jest-resolve@27.4.5
       jest-util: 27.4.2
@@ -22823,7 +22820,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       chalk: 4.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-haste-map: 27.5.1
       jest-pnp-resolver: 1.2.2_jest-resolve@27.5.1
       jest-util: 27.5.1
@@ -22846,7 +22843,7 @@ packages:
       chalk: 4.1.2
       emittery: 0.7.2
       exit: 0.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-config: 26.6.3
       jest-docblock: 26.0.0
       jest-haste-map: 26.6.2
@@ -22873,7 +22870,7 @@ packages:
       chalk: 4.1.2
       emittery: 0.7.2
       exit: 0.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-config: 26.6.3_canvas@2.6.1
       jest-docblock: 26.0.0
       jest-haste-map: 26.6.2
@@ -22903,7 +22900,7 @@ packages:
       chalk: 4.1.2
       emittery: 0.8.1
       exit: 0.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-docblock: 27.0.6
       jest-environment-jsdom: 27.3.1
       jest-environment-node: 27.3.1
@@ -22932,7 +22929,7 @@ packages:
       chalk: 4.1.2
       emittery: 0.8.1
       exit: 0.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-docblock: 27.4.0
       jest-environment-jsdom: 27.4.4
       jest-environment-node: 27.4.4
@@ -22960,7 +22957,7 @@ packages:
       '@types/node': 17.0.23
       chalk: 4.1.2
       emittery: 0.8.1
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-docblock: 27.5.1
       jest-environment-jsdom: 27.5.1
       jest-environment-node: 27.5.1
@@ -22994,7 +22991,7 @@ packages:
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
       glob: 7.2.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-config: 26.6.3
       jest-haste-map: 26.6.2
       jest-message-util: 26.6.2
@@ -23029,7 +23026,7 @@ packages:
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
       glob: 7.2.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-config: 26.6.3_canvas@2.6.1
       jest-haste-map: 26.6.2
       jest-message-util: 26.6.2
@@ -23066,7 +23063,7 @@ packages:
       execa: 5.1.1
       exit: 0.1.2
       glob: 7.2.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-haste-map: 27.3.1
       jest-message-util: 27.3.1
       jest-mock: 27.3.0
@@ -23099,7 +23096,7 @@ packages:
       execa: 5.1.1
       exit: 0.1.2
       glob: 7.2.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-haste-map: 27.4.5
       jest-message-util: 27.4.2
       jest-mock: 27.4.2
@@ -23130,7 +23127,7 @@ packages:
       collect-v8-coverage: 1.0.1
       execa: 5.1.1
       glob: 7.2.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-haste-map: 27.5.1
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
@@ -23148,7 +23145,7 @@ packages:
   /jest-serializer/26.6.2:
     dependencies:
       '@types/node': 16.11.6
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
     engines:
       node: '>= 10.14.2'
     resolution:
@@ -23156,7 +23153,7 @@ packages:
   /jest-serializer/27.0.6:
     dependencies:
       '@types/node': 15.3.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
     dev: true
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
@@ -23165,7 +23162,7 @@ packages:
   /jest-serializer/27.4.0:
     dependencies:
       '@types/node': 16.11.6
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
     dev: true
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
@@ -23174,7 +23171,7 @@ packages:
   /jest-serializer/27.5.1:
     dependencies:
       '@types/node': 17.0.23
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
     dev: true
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
@@ -23188,7 +23185,7 @@ packages:
       '@types/prettier': 2.4.2
       chalk: 4.1.2
       expect: 26.6.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-diff: 26.6.2
       jest-get-type: 26.3.0
       jest-haste-map: 26.6.2
@@ -23217,7 +23214,7 @@ packages:
       babel-preset-current-node-syntax: 1.0.1_@babel+core@7.16.0
       chalk: 4.1.2
       expect: 27.3.1
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-diff: 27.3.1
       jest-get-type: 27.3.1
       jest-haste-map: 27.3.1
@@ -23248,7 +23245,7 @@ packages:
       babel-preset-current-node-syntax: 1.0.1_@babel+core@7.16.5
       chalk: 4.1.2
       expect: 27.4.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-diff: 27.4.2
       jest-get-type: 27.4.0
       jest-haste-map: 27.4.5
@@ -23278,7 +23275,7 @@ packages:
       babel-preset-current-node-syntax: 1.0.1_@babel+core@7.16.5
       chalk: 4.1.2
       expect: 27.5.1
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       jest-diff: 27.5.1
       jest-get-type: 27.5.1
       jest-haste-map: 27.5.1
@@ -23317,7 +23314,7 @@ packages:
     dependencies:
       '@jest/types': 25.5.0
       chalk: 3.0.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       is-ci: 2.0.0
       make-dir: 3.1.0
     dev: true
@@ -23330,7 +23327,7 @@ packages:
       '@jest/types': 26.6.2
       '@types/node': 16.11.6
       chalk: 4.1.2
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       is-ci: 2.0.0
       micromatch: 4.0.4
     engines:
@@ -23342,7 +23339,7 @@ packages:
       '@jest/types': 27.0.2
       '@types/node': 14.14.21
       chalk: 4.1.1
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       is-ci: 3.0.0
       picomatch: 2.3.0
     dev: true
@@ -23356,7 +23353,7 @@ packages:
       '@types/node': 15.3.0
       chalk: 4.1.2
       ci-info: 3.2.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       picomatch: 2.3.0
     dev: true
     engines:
@@ -23369,7 +23366,7 @@ packages:
       '@types/node': 16.11.6
       chalk: 4.1.2
       ci-info: 3.3.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       picomatch: 2.3.0
     dev: true
     engines:
@@ -23382,7 +23379,7 @@ packages:
       '@types/node': 17.0.23
       chalk: 4.1.2
       ci-info: 3.3.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
       picomatch: 2.3.0
     dev: true
     engines:
@@ -24058,14 +24055,14 @@ packages:
       integrity: sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
   /jsonfile/4.0.0:
     optionalDependencies:
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
     resolution:
       integrity: sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
   /jsonfile/6.1.0:
     dependencies:
       universalify: 2.0.0
     optionalDependencies:
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.10
     resolution:
       integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
   /jsprim/1.4.1:

--- a/pnpmfile.js
+++ b/pnpmfile.js
@@ -112,7 +112,10 @@ function readPackage(pkg, context) {
   if (/^\^?4\.2\./.test(pkg.dependencies['graceful-fs'])) {
     // Object prototype may only be an Object or null: undefined
     // Caused by https://github.com/isaacs/node-graceful-fs/commit/c55c1b8cb32510f92bd33d7c833364ecd3964dea
-    pkg.dependencies['graceful-fs'] = '4.2.4'
+    //
+    // Also avoids the issue fixed by https://github.com/isaacs/node-graceful-fs/pull/220
+    // where jest thinks it cannot find `ts-jest`.
+    pkg.dependencies['graceful-fs'] = '4.2.10'
     context.log(`${pkg.name}@${pkg.version} may use Object.setPrototypeOf with fs.read, which is undefined in the browser, which crashes`)
   }
 


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
Turns out 4.2.4 was sneaking back in after https://github.com/votingworks/vxsuite/pull/1717 because of the override in `pnpmfile.js`. This updates the override to use 4.2.10.

## Demo Video or Screenshot
n/a

## Testing Plan 
n/a

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
