### PR TITLE
refactor(bmd): Separate non-interactive font size state

### DIFF
--- a/frontends/bmd/src/app_root.tsx
+++ b/frontends/bmd/src/app_root.tsx
@@ -369,9 +369,6 @@ function appReducer(state: State, action: AppAction): State {
       if (Object.keys(action.userSettings).join(',') !== 'textSize') {
         throw new Error('unknown userSetting key');
       }
-      if (action.userSettings.textSize === state.userSettings.textSize) {
-        return state;
-      }
       return {
         ...state,
         userSettings: {

--- a/frontends/bmd/src/app_root.tsx
+++ b/frontends/bmd/src/app_root.tsx
@@ -525,7 +525,6 @@ export function AppRoot({
   } = appState;
 
   const { appMode } = machineConfig;
-  const { textSize: userSettingsTextSize } = userSettings;
   const logger = useMemo(
     () => new Logger(LogSource.VxBallotMarkingDeviceFrontend, window.kiosk),
     []
@@ -653,19 +652,16 @@ export function AppRoot({
     []
   );
 
-  const useEffectToggleLargeDisplay = useCallback(() => {
-    setUserSettings({ textSize: GLOBALS.LARGE_DISPLAY_FONT_SIZE });
+  function useEffectToggleLargeDisplay() {
+    document.documentElement.style.fontSize = `${
+      GLOBALS.FONT_SIZES[GLOBALS.LARGE_DISPLAY_FONT_SIZE]
+    }px`;
     return () => {
-      setUserSettings({ textSize: GLOBALS.DEFAULT_FONT_SIZE });
+      document.documentElement.style.fontSize = `${
+        GLOBALS.FONT_SIZES[GLOBALS.DEFAULT_FONT_SIZE]
+      }px`;
     };
-  }, [setUserSettings]);
-
-  // Handle Changes to UserSettings
-  useEffect(() => {
-    document.documentElement.style.fontSize = `${GLOBALS.FONT_SIZES[userSettingsTextSize]}px`;
-    // Trigger application of “See More” buttons based upon scroll-port.
-    window.dispatchEvent(new Event('resize'));
-  }, [userSettingsTextSize]);
+  }
 
   const updateAppPrecinct = useCallback((newAppPrecinct: PrecinctSelection) => {
     dispatchAppState({

--- a/frontends/bmd/src/components/ballot.tsx
+++ b/frontends/bmd/src/components/ballot.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { Route, Switch } from 'react-router-dom';
 import IdleTimer from 'react-idle-timer';
 
@@ -11,10 +11,28 @@ import { SaveCardScreen } from '../pages/save_card_screen';
 import { StartPage } from '../pages/start_page';
 import { RemoveCardScreen } from '../pages/remove_card_screen';
 import { CastBallotPage } from '../pages/cast_ballot_page';
-import { IDLE_TIMEOUT_SECONDS } from '../config/globals';
+import {
+  IDLE_TIMEOUT_SECONDS,
+  FONT_SIZES,
+  DEFAULT_FONT_SIZE,
+} from '../config/globals';
+import { BallotContext } from '../contexts/ballot_context';
 
 export function Ballot(): JSX.Element {
   const [isIdle, setIsIdle] = useState(false);
+
+  // Handle changes to text size user setting
+  const {
+    userSettings: { textSize },
+  } = useContext(BallotContext);
+  useEffect(() => {
+    document.documentElement.style.fontSize = `${FONT_SIZES[textSize]}px`;
+    // Trigger application of “See More” buttons based upon scroll-port.
+    window.dispatchEvent(new Event('resize'));
+    return () => {
+      document.documentElement.style.fontSize = `${FONT_SIZES[DEFAULT_FONT_SIZE]}px`;
+    };
+  }, [textSize]);
 
   function onActive() {
     // Delay to avoid passing tap to next screen


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Currently, BMD uses an app state field `userSettings.fontSize` to control the font size for the entire HTML document. This feature exists so that voters can increase/decrease the font size as needed. However, it's also been used to set a large font size for non-voter specific screens where there's no interactive setting of font size. This is causing unpredictable behavior of the font sizes when refactoring app state for auth changes.

The ideal solution would be for these screens to just have styling that sets their font size. However, all of the styles in BMD use `rem`, which means the font size is tied to the HTML document font size. So fixing that will be a larger change. (https://github.com/votingworks/vxsuite/issues/1734)

For now, this PR separates out the logic for interactive font size changes (which should only apply when the voter-facing UI is rendered) from non-interactive font size changes.


## Demo Video or Screenshot
N/A

## Testing Plan 
- Passes existing automated tests
- Ran the BMD and poked around a bit and fonts sizes looked good

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
