### PR TITLE
style(lint): enable `await-thenable` rule

### DIFF
--- a/frontends/bmd/src/app_card_unhappy_paths.test.tsx
+++ b/frontends/bmd/src/app_card_unhappy_paths.test.tsx
@@ -222,7 +222,7 @@ test('Inserting pollworker card with invalid long data fall back as if there is 
   screen.getByText('Open/Close Polls');
 
   // No prompt to print precinct tally report
-  expect(await screen.queryAllByText('Tally Report on Card')).toHaveLength(0);
+  expect(screen.queryAllByText('Tally Report on Card')).toHaveLength(0);
 });
 
 test('Shows card backwards screen when card connection error occurs', async () => {

--- a/frontends/bmd/src/app_contest_write_in.test.tsx
+++ b/frontends/bmd/src/app_contest_write_in.test.tsx
@@ -147,7 +147,7 @@ it('Single Seat Contest with Write In', async () => {
   }
 
   // Review Screen
-  await waitFor(() => screen.getByText('Review Your Votes'));
+  await screen.findByText('Review Your Votes');
   expect(screen.getByText('SAL')).toBeTruthy();
   expect(screen.getByText('(write-in)')).toBeTruthy();
 

--- a/frontends/bmd/src/app_end_to_end.test.tsx
+++ b/frontends/bmd/src/app_end_to_end.test.tsx
@@ -380,7 +380,7 @@ it('MarkAndPrint end-to-end flow', async () => {
   expect(writeLongUint8ArrayMock).toHaveBeenCalledTimes(3);
   await advanceTimersAndPromises();
   await screen.findByText('Tally Report on Card');
-  await fireEvent.click(screen.getByText('Print Tally Report'));
+  fireEvent.click(screen.getByText('Print Tally Report'));
   await advanceTimersAndPromises();
   screen.getByText('Printing tally report');
   await advanceTimersAndPromises(REPORT_PRINTING_TIMEOUT_SECONDS);
@@ -392,7 +392,7 @@ it('MarkAndPrint end-to-end flow', async () => {
   // Insert SuperAdmin card
   card.insertCard({ t: 'superadmin' });
   await advanceTimersAndPromises();
-  await screen.getByText('Reboot from USB');
+  screen.getByText('Reboot from USB');
 
   // ---------------
 
@@ -409,5 +409,5 @@ it('MarkAndPrint end-to-end flow', async () => {
   // Insert SuperAdmin card works when unconfigured
   card.insertCard({ t: 'superadmin' });
   await advanceTimersAndPromises();
-  await screen.getByText('Reboot from USB');
+  screen.getByText('Reboot from USB');
 });

--- a/frontends/bmd/src/app_replace_election.test.tsx
+++ b/frontends/bmd/src/app_replace_election.test.tsx
@@ -63,7 +63,7 @@ test('replacing a loaded election with one from a card', async () => {
   await advanceTimersAndPromises();
 
   // load new election
-  await waitFor(() => screen.getByText('Election Admin Actions'));
+  await screen.findByText('Election Admin Actions');
   fireEvent.click(screen.getByText('Load Election Definition'));
   await advanceTimersAndPromises();
   screen.getByText(electionSample2Definition.election.title);

--- a/frontends/bsd/src/screens/admin_actions_screen.test.tsx
+++ b/frontends/bsd/src/screens/admin_actions_screen.test.tsx
@@ -210,11 +210,11 @@ test('clicking "Delete Ballot Data…" shows progress', async () => {
   );
 
   expect(zeroData).not.toHaveBeenCalled();
-  await fireEvent.click(component.getByText('Delete Ballot Data…'));
+  fireEvent.click(component.getByText('Delete Ballot Data…'));
 
   expect(zeroData).not.toHaveBeenCalled();
   await screen.findByText('Delete All Scanned Ballot Data?');
-  await fireEvent.click(screen.getByText('Yes, Delete Ballot Data'));
+  fireEvent.click(screen.getByText('Yes, Delete Ballot Data'));
   expect(zeroData).toHaveBeenCalledTimes(1);
 
   // Verify progress message is shown.
@@ -223,7 +223,7 @@ test('clicking "Delete Ballot Data…" shows progress', async () => {
   resolve();
   // Trigger delete finished, verify back to initial screen.
   await waitFor(async () => {
-    expect(await screen.queryAllByText('Deleting ballot data')).toHaveLength(0);
+    expect(screen.queryAllByText('Deleting ballot data')).toHaveLength(0);
   });
 });
 

--- a/frontends/bsd/src/screens/dashboard_screen.test.tsx
+++ b/frontends/bsd/src/screens/dashboard_screen.test.tsx
@@ -178,7 +178,7 @@ test('allows deleting a batch', async () => {
   await screen.findByText('Deleting…');
   expect(deleteBatch).toHaveBeenNthCalledWith(2, status.batches[1].id);
   act(() => deleteBatch2Reject(new Error('batch is a teapot')));
-  await waitFor(() => screen.getByText('batch is a teapot'));
+  await screen.findByText('batch is a teapot');
 
   // Try again.
   userEvent.click(screen.getByText('Yes, Delete Batch'));

--- a/frontends/precinct-scanner/src/app.test.tsx
+++ b/frontends/precinct-scanner/src/app.test.tsx
@@ -1178,7 +1178,7 @@ test('scanning is not triggered when polls closed or cards present', async () =>
   await advanceTimersAndPromises(1);
   await screen.findByText('Do you want to open the polls?');
   // We should see 15 ballots were scanned
-  fireEvent.click(await screen.getAllByText('No')[0]);
+  fireEvent.click(screen.getAllByText('No')[0]);
   expect((await screen.findByTestId('ballot-count')).textContent).toBe('15');
   // Make sure we haven't tried to scan
   await advanceTimersAndPromises(1);
@@ -1289,7 +1289,7 @@ test('with printer: poll worker can open and close polls without scanning any ba
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises(1);
   await screen.findByText('Do you want to close the polls?');
-  fireEvent.click(await screen.getAllByText('No')[0]);
+  fireEvent.click(screen.getAllByText('No')[0]);
   fireEvent.click(await screen.findByText('Close Polls for All Precincts'));
   await screen.findByText('Polls are closed.');
   await screen.findByText('Remove the poll worker card.');

--- a/frontends/precinct-scanner/src/app_tally_report_paths.test.tsx
+++ b/frontends/precinct-scanner/src/app_tally_report_paths.test.tsx
@@ -762,7 +762,7 @@ test('expected tally reports for a primary election with a single precincts with
   act(() => {
     hardware.setPrinterConnected(false);
   });
-  fireEvent.click(await screen.getAllByText('No')[0]);
+  fireEvent.click(screen.getAllByText('No')[0]);
   fireEvent.click(await screen.findByText('Close Polls for Precinct 1'));
   await screen.findByText('Polls are closed.');
   card.removeCard();
@@ -810,7 +810,7 @@ test('expected tally reports for a primary election with a single precincts with
     .mockResolvedValue(err(new Error('bad read')));
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises(1);
-  fireEvent.click(await screen.getAllByText('No')[0]);
+  fireEvent.click(screen.getAllByText('No')[0]);
   fireEvent.click(await screen.findByText('Open Polls for Precinct 1'));
   await screen.findByText('Polls are open.');
   expect(writeLongObjectMock).toHaveBeenCalledTimes(3);

--- a/frontends/precinct-scanner/src/components/export_backup_modal.test.tsx
+++ b/frontends/precinct-scanner/src/components/export_backup_modal.test.tsx
@@ -106,7 +106,7 @@ test('render export modal when a USB drive is mounted as expected and allows cus
   screen.getByAltText('Insert USB Image');
 
   fireEvent.click(screen.getByText('Custom'));
-  await waitFor(() => screen.getByText(/Download Complete/));
+  await screen.findByText(/Download Complete/);
   expect(download).toHaveBeenCalledWith('/scan/backup');
 
   fireEvent.click(screen.getByText('Cancel'));
@@ -153,7 +153,7 @@ test('render export modal when a USB drive is mounted as expected and allows aut
   screen.getByText('Export Backup');
 
   fireEvent.click(screen.getByText('Export'));
-  await waitFor(() => screen.getByText(/Download Complete/));
+  await screen.findByText(/Download Complete/);
   expect(download).toHaveBeenCalledWith('/scan/backup', {
     into: 'fake mount point/scanner-backups/franklin-county_general-election_b52e9f4728',
   });
@@ -260,7 +260,7 @@ test('shows a specific error for fetch failure', async () => {
     })
   );
   fireEvent.click(screen.getByText('Export'));
-  await waitFor(() => screen.getByText('Download Failed'));
+  await screen.findByText('Download Failed');
   screen.getByText('Unable to get backup: FetchFailed (status=Bad Gateway)');
 
   fireEvent.click(screen.getByText('Close'));

--- a/frontends/precinct-scanner/src/screens/admin_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/admin_screen.test.tsx
@@ -1,4 +1,11 @@
-import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import { electionSampleDefinition } from '@votingworks/fixtures';
 import { fakeKiosk } from '@votingworks/test-utils';
 import { usbstick } from '@votingworks/utils';
@@ -153,8 +160,8 @@ test('unconfigure ejects a usb drive when it is mounted', async () => {
     </AppContext.Provider>
   );
 
-  await fireEvent.click(screen.getByText('Unconfigure Machine'));
-  await fireEvent.click(screen.getByText('Unconfigure'));
+  fireEvent.click(screen.getByText('Unconfigure Machine'));
+  fireEvent.click(screen.getByText('Unconfigure'));
   expect(unconfigureFn).toHaveBeenCalledTimes(1);
   expect(ejectFn).toHaveBeenCalledTimes(0);
 });
@@ -182,8 +189,10 @@ test('unconfigure does not eject a usb drive that is not mounted', async () => {
     </AppContext.Provider>
   );
 
-  await fireEvent.click(screen.getByText('Unconfigure Machine'));
-  await fireEvent.click(screen.getByText('Unconfigure'));
-  expect(unconfigureFn).toHaveBeenCalledTimes(1);
-  expect(ejectFn).toHaveBeenCalledTimes(1);
+  fireEvent.click(screen.getByText('Unconfigure Machine'));
+  fireEvent.click(screen.getByText('Unconfigure'));
+  await waitFor(() => {
+    expect(unconfigureFn).toHaveBeenCalledTimes(1);
+    expect(ejectFn).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontends/precinct-scanner/src/screens/poll_worker_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/poll_worker_screen.test.tsx
@@ -67,7 +67,7 @@ test('shows system authentication code', async () => {
     renderScreen({});
     jest.advanceTimersByTime(2000);
   });
-  await fireEvent.click(screen.getAllByText('No')[0]);
+  fireEvent.click(screen.getAllByText('No')[0]);
 
   screen.getByText('System Authentication Code: 123·456');
 });
@@ -80,7 +80,7 @@ test('shows dashes when no totp', async () => {
   await act(async () => {
     renderScreen({});
   });
-  await fireEvent.click(screen.getAllByText('No')[0]);
+  fireEvent.click(screen.getAllByText('No')[0]);
 
   screen.getByText('System Authentication Code: ---·---');
 });
@@ -96,7 +96,7 @@ describe('shows Export Results button only when polls are closed and more than 0
       });
       jest.advanceTimersByTime(2000);
     });
-    await fireEvent.click(screen.getAllByText('No')[0]);
+    fireEvent.click(screen.getAllByText('No')[0]);
 
     expect(screen.queryByText(exportButtonText)).toBeNull();
   });
@@ -108,7 +108,7 @@ describe('shows Export Results button only when polls are closed and more than 0
         isPollsOpen: true,
       });
     });
-    await fireEvent.click(screen.getAllByText('No')[0]);
+    fireEvent.click(screen.getAllByText('No')[0]);
     expect(screen.queryByText(exportButtonText)).toBeNull();
   });
 
@@ -120,7 +120,7 @@ describe('shows Export Results button only when polls are closed and more than 0
       });
       jest.advanceTimersByTime(2000);
     });
-    await fireEvent.click(screen.getAllByText('No')[0]);
+    fireEvent.click(screen.getAllByText('No')[0]);
 
     expect(screen.queryByText(exportButtonText)).toBeNull();
   });
@@ -133,7 +133,7 @@ describe('shows Export Results button only when polls are closed and more than 0
       });
       jest.advanceTimersByTime(2000);
     });
-    await fireEvent.click(screen.getAllByText('No')[0]);
+    fireEvent.click(screen.getAllByText('No')[0]);
     await advanceTimersAndPromises(1);
     await advanceTimersAndPromises(1);
     await screen.findByText('Export Results to USB Drive');

--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -65,6 +65,7 @@ export = {
     'vx/no-floating-results': ['error', { ignoreVoid: true }],
     'vx/no-import-workspace-subfolders': 'error',
 
+    '@typescript-eslint/await-thenable': 'error',
     '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
     '@typescript-eslint/explicit-module-boundary-types': 'error',
     '@typescript-eslint/no-array-constructor': 'off',

--- a/libs/ui/src/hooks/use_usb_drive.test.tsx
+++ b/libs/ui/src/hooks/use_usb_drive.test.tsx
@@ -258,7 +258,7 @@ test('usb drive that is removed while being ejected is updated to absent', async
   // Updates to No USB state as expected
   await waitForIoFlush();
   await waitForStatusUpdate();
-  await screen.getByText('No USB');
+  screen.getByText('No USB');
 
   expect(logSpy).toHaveBeenCalledTimes(5);
   expect(logSpy).toHaveBeenNthCalledWith(

--- a/libs/ui/src/hooks/use_usb_drive.ts
+++ b/libs/ui/src/hooks/use_usb_drive.ts
@@ -60,7 +60,7 @@ export function useUsbDrive({ logger }: UsbDriveProps): UsbDrive {
           result: 'USB drive not ejected.',
         });
       } finally {
-        await setIsMountingOrUnmounting(false);
+        setIsMountingOrUnmounting(false);
       }
     },
     [makeCancelable, logger]

--- a/libs/ui/src/reboot_from_usb_button.test.tsx
+++ b/libs/ui/src/reboot_from_usb_button.test.tsx
@@ -34,9 +34,7 @@ test('renders without a USB drive as expected.', async () => {
       </button>
     </div>
   `);
-  await act(
-    async () => await fireEvent.click(screen.getByText('Reboot from USB'))
-  );
+  await act(async () => fireEvent.click(screen.getByText('Reboot from USB')));
   screen.getByText('No USB Drive Detected');
 });
 
@@ -48,9 +46,7 @@ test('renders with a non-bootable USB as expected', async () => {
       logger={new Logger(LogSource.VxAdminFrontend)}
     />
   );
-  await act(
-    async () => await fireEvent.click(screen.getByText('Reboot from USB'))
-  );
+  await act(async () => fireEvent.click(screen.getByText('Reboot from USB')));
   await waitFor(() =>
     screen.getByText(
       /The USB Drive was not found in the list of bootable devices./
@@ -58,22 +54,20 @@ test('renders with a non-bootable USB as expected', async () => {
   );
   expect(window.kiosk!.prepareToBootFromUsb).toHaveBeenCalledTimes(1);
   expect(window.kiosk!.reboot).toHaveBeenCalledTimes(0);
-  await fireEvent.click(screen.getByText('Close'));
+  fireEvent.click(screen.getByText('Close'));
   expect(
     screen.queryAllByText(
       /The USB Drive was not found in the list of bootable devices./
     )
   ).toHaveLength(0);
-  await act(
-    async () => await fireEvent.click(screen.getByText('Reboot from USB'))
-  );
+  await act(async () => fireEvent.click(screen.getByText('Reboot from USB')));
   await waitFor(() =>
     screen.getByText(
       /The USB Drive was not found in the list of bootable devices./
     )
   );
-  await act(async () => await fireEvent.click(screen.getByText('Reboot')));
-  await screen.getByText('Rebooting…');
+  await act(async () => fireEvent.click(screen.getByText('Reboot')));
+  screen.getByText('Rebooting…');
   expect(window.kiosk!.reboot).toHaveBeenCalledTimes(1);
 });
 
@@ -85,9 +79,7 @@ test('reboots automatically when clicked with a bootable USB', async () => {
       logger={new Logger(LogSource.VxAdminFrontend)}
     />
   );
-  await act(
-    async () => await fireEvent.click(screen.getByText('Reboot from USB'))
-  );
+  await act(async () => fireEvent.click(screen.getByText('Reboot from USB')));
   await waitFor(() => screen.getByText('Rebooting…'));
   expect(window.kiosk!.prepareToBootFromUsb).toHaveBeenCalledTimes(1);
   expect(window.kiosk!.reboot).toHaveBeenCalledTimes(1);
@@ -101,9 +93,7 @@ test('modal state updates when USB drive is inserted.', async () => {
       logger={new Logger(LogSource.VxAdminFrontend)}
     />
   );
-  await act(
-    async () => await fireEvent.click(screen.getByText('Reboot from USB'))
-  );
+  await act(async () => fireEvent.click(screen.getByText('Reboot from USB')));
   await waitFor(() => screen.getByText('No USB Drive Detected'));
   rerender(
     <RebootFromUsbButton

--- a/libs/ui/src/reboot_from_usb_button.test.tsx
+++ b/libs/ui/src/reboot_from_usb_button.test.tsx
@@ -1,11 +1,5 @@
 import React from 'react';
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import { usbstick } from '@votingworks/utils';
 import { fakeKiosk } from '@votingworks/test-utils';
@@ -34,8 +28,8 @@ test('renders without a USB drive as expected.', async () => {
       </button>
     </div>
   `);
-  await act(async () => fireEvent.click(screen.getByText('Reboot from USB')));
-  screen.getByText('No USB Drive Detected');
+  fireEvent.click(screen.getByText('Reboot from USB'));
+  await screen.findByText('No USB Drive Detected');
 });
 
 test('renders with a non-bootable USB as expected', async () => {
@@ -46,11 +40,9 @@ test('renders with a non-bootable USB as expected', async () => {
       logger={new Logger(LogSource.VxAdminFrontend)}
     />
   );
-  await act(async () => fireEvent.click(screen.getByText('Reboot from USB')));
-  await waitFor(() =>
-    screen.getByText(
-      /The USB Drive was not found in the list of bootable devices./
-    )
+  fireEvent.click(screen.getByText('Reboot from USB'));
+  await screen.findByText(
+    /The USB Drive was not found in the list of bootable devices./
   );
   expect(window.kiosk!.prepareToBootFromUsb).toHaveBeenCalledTimes(1);
   expect(window.kiosk!.reboot).toHaveBeenCalledTimes(0);
@@ -60,14 +52,12 @@ test('renders with a non-bootable USB as expected', async () => {
       /The USB Drive was not found in the list of bootable devices./
     )
   ).toHaveLength(0);
-  await act(async () => fireEvent.click(screen.getByText('Reboot from USB')));
-  await waitFor(() =>
-    screen.getByText(
-      /The USB Drive was not found in the list of bootable devices./
-    )
+  fireEvent.click(screen.getByText('Reboot from USB'));
+  await screen.findByText(
+    /The USB Drive was not found in the list of bootable devices./
   );
-  await act(async () => fireEvent.click(screen.getByText('Reboot')));
-  screen.getByText('Rebooting…');
+  fireEvent.click(screen.getByText('Reboot'));
+  await screen.findByText('Rebooting…');
   expect(window.kiosk!.reboot).toHaveBeenCalledTimes(1);
 });
 
@@ -79,8 +69,8 @@ test('reboots automatically when clicked with a bootable USB', async () => {
       logger={new Logger(LogSource.VxAdminFrontend)}
     />
   );
-  await act(async () => fireEvent.click(screen.getByText('Reboot from USB')));
-  await waitFor(() => screen.getByText('Rebooting…'));
+  fireEvent.click(screen.getByText('Reboot from USB'));
+  await screen.findByText('Rebooting…');
   expect(window.kiosk!.prepareToBootFromUsb).toHaveBeenCalledTimes(1);
   expect(window.kiosk!.reboot).toHaveBeenCalledTimes(1);
 });
@@ -93,15 +83,15 @@ test('modal state updates when USB drive is inserted.', async () => {
       logger={new Logger(LogSource.VxAdminFrontend)}
     />
   );
-  await act(async () => fireEvent.click(screen.getByText('Reboot from USB')));
-  await waitFor(() => screen.getByText('No USB Drive Detected'));
+  fireEvent.click(screen.getByText('Reboot from USB'));
+  await screen.findByText('No USB Drive Detected');
   rerender(
     <RebootFromUsbButton
       usbDriveStatus={usbstick.UsbDriveStatus.mounted}
       logger={new Logger(LogSource.VxAdminFrontend)}
     />
   );
-  await waitFor(() => screen.getByText(/The USB Drive was not found/));
+  await screen.findByText(/The USB Drive was not found/);
   expect(window.kiosk!.prepareToBootFromUsb).toHaveBeenCalledTimes(1);
   expect(window.kiosk!.reboot).toHaveBeenCalledTimes(0);
 });

--- a/services/scan/src/cli/retry-scan/index.ts
+++ b/services/scan/src/cli/retry-scan/index.ts
@@ -216,7 +216,7 @@ export async function retryScan(
         );
 
         if (front && back) {
-          await output.store.addSheet(id, outputBatchId, [front, back]);
+          output.store.addSheet(id, outputBatchId, [front, back]);
         }
       }
     )

--- a/services/scan/src/server.test.ts
+++ b/services/scan/src/server.test.ts
@@ -377,7 +377,7 @@ test('POST /scan/zero error', async () => {
   importer.doZero.mockResolvedValue();
 
   // Add a new batch that hasn't been backed up yet
-  await workspace.store.addBatch();
+  workspace.store.addBatch();
 
   await request(app)
     .post('/scan/zero')

--- a/services/scan/src/server.ts
+++ b/services/scan/src/server.ts
@@ -563,7 +563,7 @@ export function buildApp({ store, importer }: AppOptions): Application {
   app.post<NoParams, ExportResponse, ExportRequest>(
     '/scan/export',
     async (_request, response) => {
-      const cvrs = await importer.doExport();
+      const cvrs = importer.doExport();
       store.setCvrsAsBackedUp();
       response.set('Content-Type', 'text/plain; charset=utf-8');
       response.send(cvrs);
@@ -885,7 +885,7 @@ export async function start({
   await resolvedImporter.restoreConfig();
 
   // cleanup incomplete batches from before
-  await resolvedWorkspace.store.cleanupIncompleteBatches();
+  resolvedWorkspace.store.cleanupIncompleteBatches();
 
   if (usingPrecinctScanner && plustekScannerClientProvider) {
     if (


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
This rule prohibits using `await` on anything that isn't a thenable (i.e. `Promise`-like).

## Demo Video or Screenshot
<img width="744" alt="image" src="https://user-images.githubusercontent.com/1938/165861291-abf45bb4-3e31-4b95-aad0-18f4262bd3e6.png">

## Testing Plan 
Automated.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
