### PR TITLE
lint(jest): enable a couple more rules

### DIFF
--- a/frontends/election-manager/src/components/ballot_counts_table.test.tsx
+++ b/frontends/election-manager/src/components/ballot_counts_table.test.tsx
@@ -88,18 +88,18 @@ describe('Ballot Counts by Precinct', () => {
       getByText(precinct.name);
       const tableRow = getByText(precinct.name).closest('tr');
       expect(tableRow).toBeDefined();
-      expect(domGetByText(tableRow!, 0));
+      expect(domGetByText(tableRow!, 0)).toBeInTheDocument();
       expect(
         domGetByText(tableRow!, `View Unofficial ${precinct.name} Tally Report`)
-      );
+      ).toBeInTheDocument();
     }
     getByText('Total Ballot Count');
     const tableRow = getByText('Total Ballot Count').closest('tr');
     expect(tableRow).toBeDefined();
-    expect(domGetByText(tableRow!, 0));
+    expect(domGetByText(tableRow!, 0)).toBeInTheDocument();
     expect(
       domGetByText(tableRow!, 'View Unofficial Tally Reports for All Precincts')
-    );
+    ).toBeInTheDocument();
 
     // There should be 2 more rows then the number of precincts (header row and totals row)
     expect(getAllByTestId('table-row').length).toBe(
@@ -121,18 +121,20 @@ describe('Ballot Counts by Precinct', () => {
       getByText(precinct.name);
       const tableRow = getByText(precinct.name).closest('tr');
       expect(tableRow).toBeDefined();
-      expect(domGetByText(tableRow!, expectedNumberOfBallots));
+      expect(
+        domGetByText(tableRow!, expectedNumberOfBallots)
+      ).toBeInTheDocument();
       expect(
         domGetByText(tableRow!, `View Unofficial ${precinct.name} Tally Report`)
-      );
+      ).toBeInTheDocument();
     }
     getByText('Total Ballot Count');
     const tableRow = getByText('Total Ballot Count').closest('tr');
     expect(tableRow).toBeDefined();
-    expect(domGetByText(tableRow!, 77));
+    expect(domGetByText(tableRow!, 77)).toBeInTheDocument();
     expect(
       domGetByText(tableRow!, 'View Unofficial Tally Reports for All Precincts')
-    );
+    ).toBeInTheDocument();
 
     // There should be 2 more rows then the number of precincts (header row and totals row)
     expect(getAllByTestId('table-row').length).toBe(
@@ -156,18 +158,20 @@ describe('Ballot Counts by Precinct', () => {
       getByText(precinct.name);
       const tableRow = getByText(precinct.name).closest('tr');
       expect(tableRow).toBeDefined();
-      expect(domGetByText(tableRow!, expectedNumberOfBallots));
+      expect(
+        domGetByText(tableRow!, expectedNumberOfBallots)
+      ).toBeInTheDocument();
       expect(
         domGetByText(tableRow!, `View Unofficial ${precinct.name} Tally Report`)
-      );
+      ).toBeInTheDocument();
     }
     getByText('Total Ballot Count');
     const tableRow = getByText('Total Ballot Count').closest('tr');
     expect(tableRow).toBeDefined();
-    expect(domGetByText(tableRow!, 131));
+    expect(domGetByText(tableRow!, 131)).toBeInTheDocument();
     expect(
       domGetByText(tableRow!, 'View Unofficial Tally Reports for All Precincts')
-    );
+    ).toBeInTheDocument();
 
     // There should be 2 more rows then the number of precincts (header row and totals row)
     expect(getAllByTestId('table-row').length).toBe(
@@ -216,7 +220,7 @@ describe('Ballot Counts by Scanner', () => {
     getByText('Total Ballot Count');
     const tableRow = getByText('Total Ballot Count').closest('tr');
     expect(tableRow).toBeDefined();
-    expect(domGetByText(tableRow!, 0));
+    expect(domGetByText(tableRow!, 0)).toBeInTheDocument();
 
     // There should be 2 rows in the table, the header row and the totals row.
     expect(getAllByTestId('table-row').length).toBe(2);
@@ -239,20 +243,22 @@ describe('Ballot Counts by Scanner', () => {
       getByText(scannerId);
       const tableRow = getByText(scannerId).closest('tr');
       expect(tableRow).toBeDefined();
-      expect(domGetByText(tableRow!, expectedNumberOfBallots));
+      expect(
+        domGetByText(tableRow!, expectedNumberOfBallots)
+      ).toBeInTheDocument();
       if (expectedNumberOfBallots > 0) {
         expect(
           domGetByText(
             tableRow!,
             `View Unofficial Scanner ${scannerId} Tally Report`
           )
-        );
+        ).toBeInTheDocument();
       }
     }
     getByText('Total Ballot Count');
     const tableRow = getByText('Total Ballot Count').closest('tr');
     expect(tableRow).toBeDefined();
-    expect(domGetByText(tableRow!, 77));
+    expect(domGetByText(tableRow!, 77)).toBeInTheDocument();
 
     expect(getAllByTestId('table-row').length).toBe(scannerIds.length + 2);
   });
@@ -275,14 +281,16 @@ describe('Ballot Counts by Scanner', () => {
       getByText(scannerId);
       const tableRow = getByText(scannerId).closest('tr');
       expect(tableRow).toBeDefined();
-      expect(domGetByText(tableRow!, expectedNumberOfBallots));
+      expect(
+        domGetByText(tableRow!, expectedNumberOfBallots)
+      ).toBeInTheDocument();
       if (expectedNumberOfBallots > 0) {
         expect(
           domGetByText(
             tableRow!,
             `View Unofficial Scanner ${scannerId} Tally Report`
           )
-        );
+        ).toBeInTheDocument();
       }
     }
 
@@ -291,12 +299,12 @@ describe('Ballot Counts by Scanner', () => {
       'External Results (imported-file-name.csv)'
     ).closest('tr');
     expect(tableRow).toBeDefined();
-    expect(domGetByText(tableRow!, 54));
+    expect(domGetByText(tableRow!, 54)).toBeInTheDocument();
 
     getByText('Total Ballot Count');
     tableRow = getByText('Total Ballot Count').closest('tr');
     expect(tableRow).toBeDefined();
-    expect(domGetByText(tableRow!, 131));
+    expect(domGetByText(tableRow!, 131)).toBeInTheDocument();
 
     expect(getAllByTestId('table-row').length).toBe(scannerIds.length + 3);
   });
@@ -376,19 +384,19 @@ describe('Ballots Counts by Party', () => {
       getByText(partyName);
       const tableRow = getByText(partyName).closest('tr');
       expect(tableRow).toBeDefined();
-      expect(domGetByText(tableRow!, 0));
+      expect(domGetByText(tableRow!, 0)).toBeInTheDocument();
       expect(
         domGetByText(tableRow!, `View Unofficial ${partyName} Tally Report`)
-      );
+      ).toBeInTheDocument();
     }
 
     getByText('Total Ballot Count');
     const tableRow = getByText('Total Ballot Count').closest('tr');
     expect(tableRow).toBeDefined();
-    expect(domGetByText(tableRow!, 0));
+    expect(domGetByText(tableRow!, 0)).toBeInTheDocument();
     expect(
       domGetByText(tableRow!, 'View Unofficial Full Election Tally Report')
-    );
+    ).toBeInTheDocument();
 
     expect(getAllByTestId('table-row').length).toBe(expectedParties.length + 2);
   });
@@ -416,19 +424,21 @@ describe('Ballots Counts by Party', () => {
       getByText(partyName);
       const tableRow = getByText(partyName).closest('tr');
       expect(tableRow).toBeDefined();
-      expect(domGetByText(tableRow!, expectedNumberOfBallots));
+      expect(
+        domGetByText(tableRow!, expectedNumberOfBallots)
+      ).toBeInTheDocument();
       expect(
         domGetByText(tableRow!, `View Unofficial ${partyName} Tally Report`)
-      );
+      ).toBeInTheDocument();
     }
 
     getByText('Total Ballot Count');
     const tableRow = getByText('Total Ballot Count').closest('tr');
     expect(tableRow).toBeDefined();
-    expect(domGetByText(tableRow!, 77));
+    expect(domGetByText(tableRow!, 77)).toBeInTheDocument();
     expect(
       domGetByText(tableRow!, 'View Unofficial Full Election Tally Report')
-    );
+    ).toBeInTheDocument();
 
     expect(getAllByTestId('table-row').length).toBe(expectedParties.length + 2);
   });
@@ -458,19 +468,21 @@ describe('Ballots Counts by Party', () => {
       getByText(partyName);
       const tableRow = getByText(partyName).closest('tr');
       expect(tableRow).toBeDefined();
-      expect(domGetByText(tableRow!, expectedNumberOfBallots));
+      expect(
+        domGetByText(tableRow!, expectedNumberOfBallots)
+      ).toBeInTheDocument();
       expect(
         domGetByText(tableRow!, `View Unofficial ${partyName} Tally Report`)
-      );
+      ).toBeInTheDocument();
     }
 
     getByText('Total Ballot Count');
     const tableRow = getByText('Total Ballot Count').closest('tr');
     expect(tableRow).toBeDefined();
-    expect(domGetByText(tableRow!, 131));
+    expect(domGetByText(tableRow!, 131)).toBeInTheDocument();
     expect(
       domGetByText(tableRow!, 'View Unofficial Full Election Tally Report')
-    );
+    ).toBeInTheDocument();
 
     expect(getAllByTestId('table-row').length).toBe(expectedParties.length + 2);
   });
@@ -522,16 +534,16 @@ describe('Ballots Counts by VotingMethod', () => {
       getByText(label);
       const tableRow = getByText(label).closest('tr');
       expect(tableRow).toBeDefined();
-      expect(domGetByText(tableRow!, 0));
+      expect(domGetByText(tableRow!, 0)).toBeInTheDocument();
       expect(
         domGetByText(tableRow!, `View Unofficial ${label} Ballot Tally Report`)
-      );
+      ).toBeInTheDocument();
     }
 
     getByText('Total Ballot Count');
     const tableRow = getByText('Total Ballot Count').closest('tr');
     expect(tableRow).toBeDefined();
-    expect(domGetByText(tableRow!, 0));
+    expect(domGetByText(tableRow!, 0)).toBeInTheDocument();
 
     expect(getAllByTestId('table-row').length).toBe(expectedLabels.length + 2);
   });
@@ -556,16 +568,18 @@ describe('Ballots Counts by VotingMethod', () => {
       getByText(label);
       const tableRow = getByText(label).closest('tr');
       expect(tableRow).toBeDefined();
-      expect(domGetByText(tableRow!, expectedNumberOfBallots));
+      expect(
+        domGetByText(tableRow!, expectedNumberOfBallots)
+      ).toBeInTheDocument();
       expect(
         domGetByText(tableRow!, `View Unofficial ${label} Ballot Tally Report`)
-      );
+      ).toBeInTheDocument();
     }
 
     getByText('Total Ballot Count');
     const tableRow = getByText('Total Ballot Count').closest('tr');
     expect(tableRow).toBeDefined();
-    expect(domGetByText(tableRow!, 77));
+    expect(domGetByText(tableRow!, 77)).toBeInTheDocument();
 
     expect(getAllByTestId('table-row').length).toBe(expectedLabels.length + 2);
   });
@@ -598,16 +612,18 @@ describe('Ballots Counts by VotingMethod', () => {
       getByText(label);
       const tableRow = getByText(label).closest('tr');
       expect(tableRow).toBeDefined();
-      expect(domGetByText(tableRow!, expectedNumberOfBallots));
+      expect(
+        domGetByText(tableRow!, expectedNumberOfBallots)
+      ).toBeInTheDocument();
       expect(
         domGetByText(tableRow!, `View Unofficial ${label} Ballot Tally Report`)
-      );
+      ).toBeInTheDocument();
     }
 
     getByText('Total Ballot Count');
     const tableRow = getByText('Total Ballot Count').closest('tr');
     expect(tableRow).toBeDefined();
-    expect(domGetByText(tableRow!, 131));
+    expect(domGetByText(tableRow!, 131)).toBeInTheDocument();
 
     expect(getAllByTestId('table-row').length).toBe(expectedLabels.length + 2);
   });
@@ -676,7 +692,7 @@ describe('Ballots Counts by Batch', () => {
     getByText('Total Ballot Count');
     const tableRow = getByText('Total Ballot Count').closest('tr');
     expect(tableRow).toBeDefined();
-    expect(domGetByText(tableRow!, 0));
+    expect(domGetByText(tableRow!, 0)).toBeInTheDocument();
 
     expect(getAllByTestId('table-row').length).toBe(2);
   });
@@ -714,16 +730,20 @@ describe('Ballots Counts by Batch', () => {
         resultsByBatch[batchId]?.numberOfBallotsCounted ?? 0;
       const tableRow = getAllByTestId(`batch-${batchId}`)[0].closest('tr');
       assert(tableRow);
-      expect(domGetByText(tableRow, label));
-      expect(domGetByText(tableRow, expectedNumberOfBallots));
-      expect(domGetByText(tableRow, scannerLabel));
-      expect(domGetByText(tableRow, `View Unofficial ${label} Tally Report`));
+      expect(domGetByText(tableRow, label)).toBeInTheDocument();
+      expect(
+        domGetByText(tableRow, expectedNumberOfBallots)
+      ).toBeInTheDocument();
+      expect(domGetByText(tableRow, scannerLabel)).toBeInTheDocument();
+      expect(
+        domGetByText(tableRow, `View Unofficial ${label} Tally Report`)
+      ).toBeInTheDocument();
     }
 
     getByText('Total Ballot Count');
     const tableRow = getByText('Total Ballot Count').closest('tr');
     expect(tableRow).toBeDefined();
-    expect(domGetByText(tableRow!, 122));
+    expect(domGetByText(tableRow!, 122)).toBeInTheDocument();
 
     // There should be 2 extra table rows in addition to the batches, one for the headers, and one for the total row.
     expect(getAllByTestId('table-row').length).toBe(expectedLabels.length + 2);

--- a/frontends/election-manager/src/components/export_election_ballot_package_modal_button.test.tsx
+++ b/frontends/election-manager/src/components/export_election_ballot_package_modal_button.test.tsx
@@ -228,7 +228,7 @@ test('Modal renders error message appropriately', async () => {
 
 test('Modal renders renders loading message while rendering ballots appropriately', async () => {
   const ejectFunction = jest.fn();
-  const { queryAllByTestId, getByText, queryAllByText } = renderInAppContext(
+  const { queryAllByTestId, getByText, queryByText } = renderInAppContext(
     <ExportElectionBallotPackageModalButton />,
     {
       usbDriveStatus: UsbDriveStatus.mounted,
@@ -246,12 +246,12 @@ test('Modal renders renders loading message while rendering ballots appropriatel
 
   expect(queryAllByTestId('modal')).toHaveLength(1);
   expect(
-    queryAllByText(
-      /You may now eject the USB device and connect it with your ballot scanning machine to configure it./
+    queryByText(
+      'You may now eject the USB drive. Use the exported ballot package on this USB drive to configure VxScan or VxCentralScan.'
     )
-  );
+  ).toBeInTheDocument();
 
-  expect(queryAllByText('Eject USB')).toHaveLength(1);
+  expect(queryByText('Eject USB')).toBeInTheDocument();
   fireEvent.click(getByText('Eject USB'));
   expect(ejectFunction).toHaveBeenCalledTimes(1);
 

--- a/frontends/election-manager/src/utils/exportable_tallies.test.ts
+++ b/frontends/election-manager/src/utils/exportable_tallies.test.ts
@@ -54,7 +54,7 @@ function assertTalliesAreIdenticalMultiples(
     Object.keys(multipleTally.talliesByPrecinct)
   );
   for (const precinctId of Object.keys(baseTally.talliesByPrecinct)) {
-    expect(precinctId in multipleTally.talliesByPrecinct);
+    expect(precinctId in multipleTally.talliesByPrecinct).toBeTruthy();
     const baseForPrecinct = baseTally.talliesByPrecinct[precinctId];
     const multipleForPrecinct = multipleTally.talliesByPrecinct[precinctId];
     // Both tallies should have the same contests defined
@@ -62,7 +62,7 @@ function assertTalliesAreIdenticalMultiples(
       Object.keys(multipleForPrecinct!)
     );
     for (const contestId of Object.keys(baseForPrecinct!)) {
-      expect(contestId in multipleForPrecinct!);
+      expect(contestId in multipleForPrecinct!).toBeTruthy();
       const baseContestTally = baseForPrecinct![contestId]!;
       const multipleContestTally = multipleForPrecinct![contestId]!;
       // Metadata should be mulitiplied

--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -147,6 +147,7 @@ export = {
       rules: {
         'jest/max-nested-describe': ['error', { max: 1 }],
         'jest/no-identical-title': 'error',
+        'jest/no-focused-tests': 'error',
       },
     },
   ],

--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -148,6 +148,7 @@ export = {
         'jest/max-nested-describe': ['error', { max: 1 }],
         'jest/no-identical-title': 'error',
         'jest/no-focused-tests': 'error',
+        'jest/valid-expect': ['error', { alwaysAwait: true }],
       },
     },
   ],

--- a/libs/types/src/election.test.ts
+++ b/libs/types/src/election.test.ts
@@ -122,8 +122,8 @@ test('can expand ms-either-neither contests into yes no contests in a primary', 
     } else {
       expect(expandedContests[i].type).toBe('yesno');
       expect(expandedContests[i + 1].type).toBe('yesno');
-      expect(expandedContests[i].partyId === originalContest.partyId);
-      expect(expandedContests[i + 1].partyId === originalContest.partyId);
+      expect(expandedContests[i].partyId).toEqual(originalContest.partyId);
+      expect(expandedContests[i + 1].partyId).toEqual(originalContest.partyId);
     }
   }
 });

--- a/libs/utils/src/deferred.test.ts
+++ b/libs/utils/src/deferred.test.ts
@@ -19,7 +19,7 @@ test('queue isEmpty', async () => {
   expect(q.isEmpty()).toBeTruthy();
   q.resolve(1);
   expect(q.isEmpty()).toBeFalsy();
-  expect(await q.get());
+  expect(await q.get()).toEqual(1);
   expect(q.isEmpty()).toBeTruthy();
 });
 


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Enables `no-focused-test` and `valid-expect`, the latter of which required some fixes.

## Demo Video or Screenshot
n/a

## Testing Plan 
Automated.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
