### PR TITLE
lint(async): enable `@typescript-eslint/require-await`

### DIFF
--- a/frontends/bas/src/app_root.tsx
+++ b/frontends/bas/src/app_root.tsx
@@ -154,22 +154,20 @@ export function AppRoot({ card, hardware, storage }: Props): JSX.Element {
   }, []);
 
   useEffect(() => {
-    void (async () => {
-      setIsCardPresent(smartcard.status === 'ready');
-      setIsAdminCardPresent(smartcard.data?.t === 'admin');
-      setIsPollWorkerCardPresent(smartcard.data?.t === 'pollworker');
-      setIsWritableCard(smartcard.data?.t === 'voter');
-      setIsLocked((prev) =>
-        smartcard.data?.t === 'admin'
-          ? true
-          : smartcard.data?.t === 'pollworker'
-          ? false
-          : prev
-      );
-      if (!smartcard.data) {
-        setIsReadyToRemove(false);
-      }
-    })();
+    setIsCardPresent(smartcard.status === 'ready');
+    setIsAdminCardPresent(smartcard.data?.t === 'admin');
+    setIsPollWorkerCardPresent(smartcard.data?.t === 'pollworker');
+    setIsWritableCard(smartcard.data?.t === 'voter');
+    setIsLocked((prev) =>
+      smartcard.data?.t === 'admin'
+        ? true
+        : smartcard.data?.t === 'pollworker'
+        ? false
+        : prev
+    );
+    if (!smartcard.data) {
+      setIsReadyToRemove(false);
+    }
   }, [smartcard]);
 
   const programCard: EventTargetFunction = useCallback(

--- a/frontends/bmd/src/apimachine_config.test.tsx
+++ b/frontends/bmd/src/apimachine_config.test.tsx
@@ -59,6 +59,7 @@ test('machineConfig fetch fails', async () => {
 
 test('machineId is empty', async () => {
   const machineConfig: Provider<MachineConfig> = {
+    // eslint-disable-next-line @typescript-eslint/require-await
     async get() {
       return { appMode: MarkOnly, machineId: '', codeVersion: 'test' };
     },
@@ -82,6 +83,7 @@ test('machineId is empty', async () => {
 
 test('machineConfig is empty', async () => {
   const machineConfig: Provider<MachineConfig> = {
+    // eslint-disable-next-line @typescript-eslint/require-await
     async get(): Promise<MachineConfig> {
       // @ts-expect-error - we're mocking an API failure
       return undefined;

--- a/frontends/bmd/src/components/candidate_contest.test.tsx
+++ b/frontends/bmd/src/components/candidate_contest.test.tsx
@@ -67,7 +67,7 @@ describe('supports single-seat contest', () => {
     });
   });
 
-  it("doesn't allow other candidates to be selected when a candidate is selected", async () => {
+  it("doesn't allow other candidates to be selected when a candidate is selected", () => {
     const updateVote = jest.fn();
     renderWithBallotContext(
       <CandidateContest

--- a/frontends/bmd/src/components/focus_manager.test.tsx
+++ b/frontends/bmd/src/components/focus_manager.test.tsx
@@ -7,7 +7,7 @@ import {
   SpeechSynthesisTextToSpeech,
 } from '../utils/ScreenReader';
 
-it('renders FocusManager', async () => {
+it('renders FocusManager', () => {
   const { container } = render(
     <FocusManager
       screenReader={new AriaScreenReader(new SpeechSynthesisTextToSpeech())}

--- a/frontends/bmd/src/components/no_print.test.tsx
+++ b/frontends/bmd/src/components/no_print.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 
 import { NoPrint } from './no_print';
 
-it('renders NoPrint', async () => {
+it('renders NoPrint', () => {
   const { container } = render(<NoPrint>foo</NoPrint>);
   expect(container.firstChild).toMatchSnapshot();
 });

--- a/frontends/bmd/src/components/prose.test.tsx
+++ b/frontends/bmd/src/components/prose.test.tsx
@@ -38,12 +38,12 @@ const proseContent = (
   </React.Fragment>
 );
 
-it('renders Prose defaults', async () => {
+it('renders Prose defaults', () => {
   const { container } = render(<Prose>{proseContent}</Prose>);
   expect(container.firstChild).toMatchSnapshot();
 });
 
-it('renders Prose with compact spacing', async () => {
+it('renders Prose with compact spacing', () => {
   const { container } = render(<Prose compact>{proseContent} </Prose>);
   expect(container.firstChild).toMatchSnapshot();
 });

--- a/frontends/bmd/src/components/select.test.tsx
+++ b/frontends/bmd/src/components/select.test.tsx
@@ -11,12 +11,12 @@ const options = (
   </React.Fragment>
 );
 
-it('Inline select', async () => {
+it('Inline select', () => {
   const { container } = render(<Select>{options}</Select>);
   expect(container.firstChild).toMatchSnapshot();
 });
 
-it('Full-width select', async () => {
+it('Full-width select', () => {
   const { container } = render(<Select fullWidth>{options}</Select>);
   expect(container.firstChild).toMatchSnapshot();
 });

--- a/frontends/bmd/src/components/text.test.tsx
+++ b/frontends/bmd/src/components/text.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 
 import { Text, TextWithLineBreaks } from './text';
 
-it('outputs paragraph tag', async () => {
+it('outputs paragraph tag', () => {
   const text = 'paragraph';
   render(<Text>{text}</Text>);
   const element = screen.getByText(text);
@@ -11,7 +11,7 @@ it('outputs paragraph tag', async () => {
   expect(element).toMatchSnapshot();
 });
 
-it('outputs "span" tag specified by "as" prop', async () => {
+it('outputs "span" tag specified by "as" prop', () => {
   const text = 'Text in a span?';
   render(<Text as="span">{text}</Text>);
   const element = screen.getByText(text);
@@ -19,27 +19,27 @@ it('outputs "span" tag specified by "as" prop', async () => {
   expect(element).toMatchSnapshot();
 });
 
-it('centers centered style', async () => {
+it('centers centered style', () => {
   const { container } = render(<Text center>Centered Text?</Text>);
   expect(container.firstChild).toMatchSnapshot();
 });
 
-it('displays muted style', async () => {
+it('displays muted style', () => {
   const { container } = render(<Text muted>Muted Text?</Text>);
   expect(container.firstChild).toMatchSnapshot();
 });
 
-it('displays error style', async () => {
+it('displays error style', () => {
   const { container } = render(<Text error>Error Text?</Text>);
   expect(container.firstChild).toMatchSnapshot();
 });
 
-it('narrow style', async () => {
+it('narrow style', () => {
   const { container } = render(<Text narrow>Narrow Wrapper</Text>);
   expect(container.firstChild).toMatchSnapshot();
 });
 
-it('renders italic text', async () => {
+it('renders italic text', () => {
   const { container } = render(<Text italic>Italic text</Text>);
   expect(container.firstChild).toMatchSnapshot();
 });

--- a/frontends/bmd/src/contexts/ballot_context.ts
+++ b/frontends/bmd/src/contexts/ballot_context.ts
@@ -13,7 +13,9 @@ const ballot: BallotContextInterface = {
   contests: [],
   isCardlessVoter: false,
   isLiveMode: false,
+  // eslint-disable-next-line @typescript-eslint/require-await
   markVoterCardVoided: async () => false,
+  // eslint-disable-next-line @typescript-eslint/require-await
   markVoterCardPrinted: async () => false,
   printer: new NullPrinter(),
   resetBallot: () => undefined,

--- a/frontends/bmd/src/demo_app.tsx
+++ b/frontends/bmd/src/demo_app.tsx
@@ -62,6 +62,7 @@ export function getDemoStorage(): Storage {
 
 export function getSampleMachineConfigProvider(): Provider<MachineConfig> {
   return {
+    // eslint-disable-next-line @typescript-eslint/require-await
     async get() {
       return {
         appMode: MarkAndPrint,

--- a/frontends/bmd/src/pages/accessible_controller_diagnostic_screen.test.tsx
+++ b/frontends/bmd/src/pages/accessible_controller_diagnostic_screen.test.tsx
@@ -169,7 +169,7 @@ describe('Accessible Controller Diagnostic Screen', () => {
     });
   });
 
-  it('cancels the test when the cancel button is pressed', async () => {
+  it('cancels the test when the cancel button is pressed', () => {
     const onCancel = jest.fn();
     const onComplete = jest.fn();
     renderScreen({ onCancel, onComplete });

--- a/frontends/bmd/src/pages/admin_screen.test.tsx
+++ b/frontends/bmd/src/pages/admin_screen.test.tsx
@@ -30,7 +30,7 @@ afterEach(() => {
   window.kiosk = undefined;
 });
 
-test('renders AdminScreen for PrintOnly', async () => {
+test('renders AdminScreen for PrintOnly', () => {
   render(
     <AdminScreen
       appPrecinct={{
@@ -117,6 +117,7 @@ test('renders date and time settings modal', async () => {
   fireEvent.change(selectYear, { target: { value: optionYear } });
 
   // Save Date and Timezone
+  // eslint-disable-next-line @typescript-eslint/require-await
   await act(async () => {
     fireEvent.click(within(screen.getByTestId('modal')).getByText('Save'));
   });
@@ -130,7 +131,7 @@ test('renders date and time settings modal', async () => {
   screen.getByText(startDate);
 });
 
-test('select All Precincts', async () => {
+test('select All Precincts', () => {
   const updateAppPrecinct = jest.fn();
   render(
     <AdminScreen
@@ -159,7 +160,7 @@ test('select All Precincts', async () => {
   });
 });
 
-test('blur precinct selector without a selection', async () => {
+test('blur precinct selector without a selection', () => {
   const updateAppPrecinct = jest.fn();
   render(
     <AdminScreen
@@ -181,7 +182,7 @@ test('blur precinct selector without a selection', async () => {
   expect(updateAppPrecinct).not.toHaveBeenCalled();
 });
 
-test('render All Precincts', async () => {
+test('render All Precincts', () => {
   const updateAppPrecinct = jest.fn();
   render(
     <AdminScreen

--- a/frontends/bmd/src/pages/diagnostics_screen.test.tsx
+++ b/frontends/bmd/src/pages/diagnostics_screen.test.tsx
@@ -46,7 +46,7 @@ beforeEach(() => {
 });
 
 describe('System Diagnostics screen: Computer section', () => {
-  it('shows the battery level and power cord status', async () => {
+  it('shows the battery level and power cord status', () => {
     const devices = fakeDevices({
       computer: { batteryLevel: 0.05, batteryIsLow: true },
     });
@@ -72,7 +72,7 @@ describe('System Diagnostics screen: Computer section', () => {
     unmount();
   });
 
-  it('shows a warning when the power cord is not connected', async () => {
+  it('shows a warning when the power cord is not connected', () => {
     const devices = fakeDevices({
       computer: { batteryIsCharging: false },
     });
@@ -296,7 +296,7 @@ describe('System Diagnostics screen: Accessible Controller section', () => {
     unmount();
   });
 
-  it('shows when the controller is disconnected', async () => {
+  it('shows when the controller is disconnected', () => {
     const devices = fakeDevices();
     devices.accessibleController = undefined;
     const { unmount } = renderScreen({ devices });

--- a/frontends/bmd/src/pages/poll_worker_screen.test.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.test.tsx
@@ -114,12 +114,12 @@ function expectContestResultsInReport(
   }
 }
 
-test('renders PollWorkerScreen', async () => {
+test('renders PollWorkerScreen', () => {
   renderScreen();
   screen.getByText(/Polls are currently open./);
 });
 
-test('switching out of test mode on election day', async () => {
+test('switching out of test mode on election day', () => {
   const electionDefinition = asElectionDefinition({
     ...electionSampleWithSeal,
     date: new Date().toISOString(),
@@ -132,7 +132,7 @@ test('switching out of test mode on election day', async () => {
   expect(enableLiveMode).toHaveBeenCalled();
 });
 
-test('keeping test mode on election day', async () => {
+test('keeping test mode on election day', () => {
   const electionDefinition = asElectionDefinition({
     ...electionSampleWithSeal,
     date: new Date().toISOString(),
@@ -145,7 +145,7 @@ test('keeping test mode on election day', async () => {
   expect(enableLiveMode).not.toHaveBeenCalled();
 });
 
-test('live mode on election day', async () => {
+test('live mode on election day', () => {
   renderScreen({ isLiveMode: true });
   expect(screen.queryByText('Switch to Live Election Mode?')).toBeNull();
 });
@@ -1171,7 +1171,7 @@ test('printing precinct scanner report works as expected with a single precinct 
   );
 });
 
-test('navigates to System Diagnostics screen', async () => {
+test('navigates to System Diagnostics screen', () => {
   const { unmount } = renderScreen();
 
   userEvent.click(screen.getByRole('button', { name: 'System Diagnostics' }));

--- a/frontends/bmd/src/pages/start_page.test.tsx
+++ b/frontends/bmd/src/pages/start_page.test.tsx
@@ -9,7 +9,7 @@ import {
 } from '../data';
 import { StartPage } from './start_page';
 
-it('renders StartPage', async () => {
+it('renders StartPage', () => {
   const electionDefinition = electionPrimarySampleDefinition;
   const { container } = render(<Route path="/" component={StartPage} />, {
     ballotStyleId: '12D',
@@ -24,7 +24,7 @@ it('renders StartPage', async () => {
   expect(container.firstChild).toMatchSnapshot();
 });
 
-it('renders StartPage with inline SVG', async () => {
+it('renders StartPage with inline SVG', () => {
   const electionDefinition = electionSampleWithSealDefinition;
   const { container } = render(<Route path="/" component={StartPage} />, {
     electionDefinition,
@@ -35,7 +35,7 @@ it('renders StartPage with inline SVG', async () => {
   expect(container.firstChild).toMatchSnapshot();
 });
 
-it('renders StartPage with no seal', async () => {
+it('renders StartPage with no seal', () => {
   const electionDefinition = electionSampleNoSealDefinition;
   const { container } = render(<Route path="/" component={StartPage} />, {
     electionDefinition,

--- a/frontends/bmd/src/setupTests.tsx
+++ b/frontends/bmd/src/setupTests.tsx
@@ -25,6 +25,7 @@ function makeSpeechSynthesisDouble(): typeof speechSynthesis {
     pending: false,
     removeEventListener: jest.fn(),
     resume: jest.fn(),
+    // eslint-disable-next-line @typescript-eslint/require-await
     speak: jest.fn(async (utterance) =>
       utterance.onend?.(new SpeechSynthesisEvent('end', { utterance }))
     ),

--- a/frontends/bmd/src/utils/ScreenReader/aria_screen_reader.ts
+++ b/frontends/bmd/src/utils/ScreenReader/aria_screen_reader.ts
@@ -26,6 +26,7 @@ export class AriaScreenReader implements ScreenReader {
   /**
    * Call this when a page load occurs. Resolves when speaking is done.
    */
+  // eslint-disable-next-line @typescript-eslint/require-await
   async onPageLoad(): Promise<void> {
     this.tts.stop();
   }

--- a/frontends/bmd/test/helpers/fake_machine_config.ts
+++ b/frontends/bmd/test/helpers/fake_machine_config.ts
@@ -14,6 +14,7 @@ export function fakeMachineConfigProvider(
 ): Provider<MachineConfig> {
   const config = fakeMachineConfig(props);
   return {
+    // eslint-disable-next-line @typescript-eslint/require-await
     async get() {
       return config;
     },

--- a/frontends/bsd/src/app_root.tsx
+++ b/frontends/bsd/src/app_root.tsx
@@ -153,7 +153,7 @@ export function AppRoot({ card, hardware }: AppRootProps): JSX.Element {
     });
   }, [logger, currentUserType]);
 
-  async function updateElectionDefinition(e: ElectionDefinition) {
+  function updateElectionDefinition(e: ElectionDefinition) {
     setElectionDefinition(e);
     void logger.log(LogEventId.ElectionConfigured, currentUserType, {
       message: `Machine configured for election with hash: ${e.electionHash}`,

--- a/frontends/bsd/src/components/file_input_button.tsx
+++ b/frontends/bsd/src/components/file_input_button.tsx
@@ -1,3 +1,4 @@
+import { PromiseOr } from '@votingworks/types';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -9,7 +10,7 @@ import {
 
 export type InputEventFunction = (
   event: React.FormEvent<HTMLInputElement>
-) => void | Promise<void>;
+) => PromiseOr<void>;
 
 export const HiddenFileInput = styled.input`
   position: relative;

--- a/frontends/bsd/src/components/set_mark_thresholds_modal.test.tsx
+++ b/frontends/bsd/src/components/set_mark_thresholds_modal.test.tsx
@@ -124,7 +124,7 @@ test('allows users to set thresholds properly', async () => {
   });
 });
 
-test('setting thresholds renders an error if given a non number', async () => {
+test('setting thresholds renders an error if given a non number', () => {
   const closeFn = jest.fn();
   const setThresholds = jest.fn();
   const { getByText, getByTestId } = render(
@@ -152,7 +152,7 @@ test('setting thresholds renders an error if given a non number', async () => {
   expect(closeFn).toHaveBeenCalledTimes(0);
 });
 
-test('setting thresholds renders an error if given a number greater than 1', async () => {
+test('setting thresholds renders an error if given a number greater than 1', () => {
   const closeFn = jest.fn();
   const setThresholds = jest.fn();
   const { getByText, getByTestId } = render(

--- a/frontends/bsd/src/components/toggle_test_mode_button.test.tsx
+++ b/frontends/bsd/src/components/toggle_test_mode_button.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import { ToggleTestModeButton } from './toggle_test_mode_button';
 
-test('shows a button to toggle to live mode when in test mode', async () => {
+test('shows a button to toggle to live mode when in test mode', () => {
   const { getByText } = render(
     <ToggleTestModeButton
       canUnconfigure={false}
@@ -15,7 +15,7 @@ test('shows a button to toggle to live mode when in test mode', async () => {
   getByText('Toggle to Live Mode');
 });
 
-test('shows a button to toggle to test mode when in live mode', async () => {
+test('shows a button to toggle to test mode when in live mode', () => {
   const { getByText } = render(
     <ToggleTestModeButton
       canUnconfigure
@@ -28,7 +28,7 @@ test('shows a button to toggle to test mode when in live mode', async () => {
   getByText('Toggle to Test Mode');
 });
 
-test('shows a disabled button when in live mode but the machine cannot be unconfigured', async () => {
+test('shows a disabled button when in live mode but the machine cannot be unconfigured', () => {
   const { getByText } = render(
     <ToggleTestModeButton
       canUnconfigure={false}
@@ -43,7 +43,7 @@ test('shows a disabled button when in live mode but the machine cannot be unconf
   );
 });
 
-test('shows a disabled button with "Toggling" when toggling', async () => {
+test('shows a disabled button with "Toggling" when toggling', () => {
   const { getByText } = render(
     <ToggleTestModeButton
       canUnconfigure

--- a/frontends/bsd/src/screens/admin_actions_screen.test.tsx
+++ b/frontends/bsd/src/screens/admin_actions_screen.test.tsx
@@ -58,7 +58,7 @@ test('clicking "Export Backup…" shows progress', async () => {
   });
 });
 
-test('"Delete Ballot Data…" and Delete Election Data from VxCentralScan…" disabled when canUnconfigure is falsy', async () => {
+test('"Delete Ballot Data…" and Delete Election Data from VxCentralScan…" disabled when canUnconfigure is falsy', () => {
   const unconfigureServer = jest.fn();
   const zeroData = jest.fn();
   const component = render(
@@ -94,7 +94,7 @@ test('"Delete Ballot Data…" and Delete Election Data from VxCentralScan…" di
   expect(component.queryByText('Delete All Scanned Ballot Data?')).toBeNull();
 });
 
-test('"Delete Ballot Data…" and Delete Election Data from VxCentralScan…" enabled in test mode even if data not backed up', async () => {
+test('"Delete Ballot Data…" and Delete Election Data from VxCentralScan…" enabled in test mode even if data not backed up', () => {
   const component = render(
     <Router history={createMemoryHistory()}>
       <AdminActionsScreen
@@ -222,6 +222,7 @@ test('clicking "Delete Ballot Data…" shows progress', async () => {
 
   resolve();
   // Trigger delete finished, verify back to initial screen.
+  // eslint-disable-next-line @typescript-eslint/require-await
   await waitFor(async () => {
     expect(screen.queryAllByText('Deleting ballot data')).toHaveLength(0);
   });
@@ -273,7 +274,7 @@ test('backup error shows message', async () => {
   });
 });
 
-test('override mark thresholds button shows when there are no overrides', async () => {
+test('override mark thresholds button shows when there are no overrides', () => {
   const backup = jest.fn();
 
   const testCases = [

--- a/frontends/bsd/src/screens/ballot_eject_screen.test.tsx
+++ b/frontends/bsd/src/screens/ballot_eject_screen.test.tsx
@@ -864,6 +864,7 @@ test('does NOT say ballot is blank if one side is blank and the other requires w
 
     // doubly nested acts() because there's setIsSaving(true) and then (false).
     await act(async () => {
+      // eslint-disable-next-line @typescript-eslint/require-await
       await act(async () => {
         userEvent.click(screen.getByText('Save & Continue Scanning'));
       });

--- a/frontends/bsd/src/screens/ballot_eject_screen.tsx
+++ b/frontends/bsd/src/screens/ballot_eject_screen.tsx
@@ -223,11 +223,7 @@ export function BallotEjectScreen({
   }, [reviewInfo, logger, currentUserType]);
 
   const onAdjudicationComplete = useCallback(
-    async (
-      sheetId: string,
-      side: Side,
-      adjudications: MarkAdjudications
-    ): Promise<void> => {
+    (sheetId: string, side: Side, adjudications: MarkAdjudications): void => {
       if (side === 'front') {
         setFrontMarkAdjudications(adjudications);
       } else {

--- a/frontends/bsd/src/screens/load_election_screen.tsx
+++ b/frontends/bsd/src/screens/load_election_screen.tsx
@@ -40,7 +40,7 @@ export function LoadElectionScreen({
   }>();
   const [isLoadingTemplates, setLoadingTemplates] = useState(false);
 
-  async function handleBallotLoading(pkg: BallotPackage) {
+  function handleBallotLoading(pkg: BallotPackage) {
     addTemplates(pkg, logger, currentUserType)
       .on('configuring', () => {
         setCurrentUploadingBallotIndex(0);
@@ -113,7 +113,7 @@ export function LoadElectionScreen({
             disposition: 'success',
           }
         );
-        await handleBallotLoading(ballotPackage);
+        handleBallotLoading(ballotPackage);
       } catch (error) {
         assert(error instanceof Error);
         await logger.log(
@@ -145,7 +145,7 @@ export function LoadElectionScreen({
           disposition: 'success',
         }
       );
-      await handleBallotLoading(ballotPackage);
+      handleBallotLoading(ballotPackage);
     } catch (error) {
       assert(error instanceof Error);
       await logger.log(

--- a/frontends/bsd/src/screens/write_in_adjudication_screen.test.tsx
+++ b/frontends/bsd/src/screens/write_in_adjudication_screen.test.tsx
@@ -66,7 +66,7 @@ test('supports typing in a candidate name', async () => {
       ReturnType<onAdjudicationCompleteType>,
       Parameters<onAdjudicationCompleteType>
     >()
-    .mockResolvedValue();
+    .mockReturnValue();
 
   const writeIns: WriteInAdjudicationReasonInfo[] = [
     {
@@ -155,7 +155,7 @@ test('supports canceling a write-in', async () => {
       ReturnType<onAdjudicationCompleteType>,
       Parameters<onAdjudicationCompleteType>
     >()
-    .mockResolvedValue();
+    .mockReturnValue();
 
   const writeIns: WriteInAdjudicationReasonInfo[] = [
     {
@@ -254,7 +254,7 @@ test('can adjudicate front & back in succession', async () => {
       ReturnType<onAdjudicationCompleteType>,
       Parameters<onAdjudicationCompleteType>
     >()
-    .mockResolvedValue();
+    .mockReturnValue();
 
   const frontWriteIns: WriteInAdjudicationReasonInfo[] = [
     {
@@ -405,7 +405,7 @@ test('can adjudicate front & back in succession', async () => {
   });
 });
 
-test('uses the layout embedded definition to crop the ballot image correctly if available', async () => {
+test('uses the layout embedded definition to crop the ballot image correctly if available', () => {
   const [contest] = contestsWithWriteIns.filter(({ seats }) => seats > 1);
   const options = Array.from(allContestOptions(contest));
   const optionsByIsWriteIn = groupBy(
@@ -438,7 +438,7 @@ test('uses the layout embedded definition to crop the ballot image correctly if 
       ReturnType<onAdjudicationCompleteType>,
       Parameters<onAdjudicationCompleteType>
     >()
-    .mockResolvedValue();
+    .mockReturnValue();
 
   const writeIns: WriteInAdjudicationReasonInfo[] = [
     {

--- a/frontends/bsd/test/helpers/fake_machine_config.ts
+++ b/frontends/bsd/test/helpers/fake_machine_config.ts
@@ -14,6 +14,7 @@ export function fakeMachineConfigProvider(
 ): Provider<MachineConfig> {
   const config = fakeMachineConfig(props);
   return {
+    // eslint-disable-next-line @typescript-eslint/require-await
     async get() {
       return config;
     },

--- a/frontends/election-manager/src/app_root.test.tsx
+++ b/frontends/election-manager/src/app_root.test.tsx
@@ -20,6 +20,7 @@ beforeEach(() => {
 });
 
 test('renders without crashing', async () => {
+  // eslint-disable-next-line @typescript-eslint/require-await
   await act(async () => {
     const storage = new MemoryStorage();
     render(

--- a/frontends/election-manager/src/components/export_batch_tally_results_button.tsx
+++ b/frontends/election-manager/src/components/export_batch_tally_results_button.tsx
@@ -28,7 +28,7 @@ export function ExportBatchTallyResultsButton(): JSX.Element {
       {isSaveModalOpen && (
         <SaveFileToUsb
           onClose={() => setIsSaveModalOpen(false)}
-          generateFileContent={async () =>
+          generateFileContent={() =>
             generateBatchTallyResultsCsv(fullElectionTally, election)
           }
           defaultFilename={defaultFilename}

--- a/frontends/election-manager/src/components/export_election_ballot_package_modal_button.test.tsx
+++ b/frontends/election-manager/src/components/export_election_ballot_package_modal_button.test.tsx
@@ -28,6 +28,7 @@ beforeEach(() => {
   window.kiosk = mockKiosk;
 
   mockOf(pdfToImages).mockImplementation(
+    // eslint-disable-next-line @typescript-eslint/require-await
     async function* pdfToImagesMock(): AsyncGenerator<{
       page: ImageData;
       pageNumber: number;
@@ -51,6 +52,7 @@ beforeEach(() => {
       electionDefinition,
       imageData,
       metadata,
+      // eslint-disable-next-line @typescript-eslint/require-await
     }): Promise<BallotPageLayoutWithImage> => ({
       imageData,
       ballotPageLayout: {
@@ -77,7 +79,7 @@ afterEach(() => {
   delete window.kiosk;
 });
 
-test('Button renders properly when not clicked', async () => {
+test('Button renders properly when not clicked', () => {
   const { queryByText, queryByTestId } = renderInAppContext(
     <ExportElectionBallotPackageModalButton />
   );

--- a/frontends/election-manager/src/components/import_cvrfiles_modal.test.tsx
+++ b/frontends/election-manager/src/components/import_cvrfiles_modal.test.tsx
@@ -24,7 +24,7 @@ const LIVE_FILE1 = 'machine_0002__10_ballots__2020-12-09_15-59-32.jsonl';
 
 const { UsbDriveStatus } = usbstick;
 
-test('No USB screen shows when there is no USB drive', async () => {
+test('No USB screen shows when there is no USB drive', () => {
   const usbStatuses = [
     UsbDriveStatus.absent,
     UsbDriveStatus.recentlyEjected,
@@ -45,7 +45,7 @@ test('No USB screen shows when there is no USB drive', async () => {
   }
 });
 
-test('Loading screen show while usb is mounting or ejecting', async () => {
+test('Loading screen show while usb is mounting or ejecting', () => {
   const usbStatuses = [UsbDriveStatus.present, UsbDriveStatus.ejecting];
 
   for (const usbStatus of usbStatuses) {

--- a/frontends/election-manager/src/components/import_cvrfiles_modal.tsx
+++ b/frontends/election-manager/src/components/import_cvrfiles_modal.tsx
@@ -87,7 +87,7 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
     fileData: CastVoteRecordFilePreprocessedData
   ) {
     setCurrentState(ModalState.LOADING);
-    const newCastVoteRecordFiles = await castVoteRecordFiles.addFromFileData(
+    const newCastVoteRecordFiles = castVoteRecordFiles.addFromFileData(
       fileData,
       election
     );

--- a/frontends/election-manager/src/components/save_file_to_usb.tsx
+++ b/frontends/election-manager/src/components/save_file_to_usb.tsx
@@ -32,7 +32,7 @@ export enum FileType {
 
 export interface Props {
   onClose: () => void;
-  generateFileContent: () => Promise<Uint8Array | string>;
+  generateFileContent: () => Uint8Array | string | Promise<Uint8Array | string>;
   defaultFilename: string;
   fileType: FileType;
   promptToEjectUsb?: boolean;

--- a/frontends/election-manager/src/components/save_file_to_usb.tsx
+++ b/frontends/election-manager/src/components/save_file_to_usb.tsx
@@ -7,6 +7,7 @@ import { assert, usbstick, throwIllegalValue } from '@votingworks/utils';
 import { Modal, UsbControllerButton } from '@votingworks/ui';
 
 import { LogEventId } from '@votingworks/logging';
+import { PromiseOr } from '@votingworks/types';
 import { AppContext } from '../contexts/app_context';
 import { Button } from './button';
 import { Prose } from './prose';
@@ -32,7 +33,7 @@ export enum FileType {
 
 export interface Props {
   onClose: () => void;
-  generateFileContent: () => Uint8Array | string | Promise<Uint8Array | string>;
+  generateFileContent: () => PromiseOr<Uint8Array | string>;
   defaultFilename: string;
   fileType: FileType;
   promptToEjectUsb?: boolean;

--- a/frontends/election-manager/src/config/types.ts
+++ b/frontends/election-manager/src/config/types.ts
@@ -9,6 +9,7 @@ import {
   Optional,
   Precinct,
   PrecinctId,
+  PromiseOr,
   VotingMethod,
 } from '@votingworks/types';
 import { z } from 'zod';
@@ -17,13 +18,13 @@ import { z } from 'zod';
 export type EventTargetFunction = (event: React.FormEvent<EventTarget>) => void;
 export type InputEventFunction = (
   event: React.FormEvent<HTMLInputElement>
-) => void | Promise<void>;
+) => PromiseOr<void>;
 export type TextareaEventFunction = (
   event: React.FormEvent<HTMLTextAreaElement>
-) => void | Promise<void>;
+) => PromiseOr<void>;
 export type ButtonEventFunction = (
   event: React.MouseEvent<HTMLButtonElement>
-) => void | Promise<void>;
+) => PromiseOr<void>;
 
 // Election
 export type SaveElection = (electionJson?: string) => Promise<void>;

--- a/frontends/election-manager/src/contexts/app_context.ts
+++ b/frontends/election-manager/src/contexts/app_context.ts
@@ -57,6 +57,7 @@ export interface AppContextInterface {
   logger: Logger;
 }
 
+/* eslint-disable @typescript-eslint/require-await */
 const appContext: AppContextInterface = {
   castVoteRecordFiles: CastVoteRecordFiles.empty,
   electionDefinition: undefined,
@@ -91,5 +92,6 @@ const appContext: AppContextInterface = {
   hasCardReaderAttached: true,
   logger: new Logger(LogSource.VxAdminFrontend),
 };
+/* eslint-enable @typescript-eslint/require-await */
 
 export const AppContext = createContext(appContext);

--- a/frontends/election-manager/src/demo_app.tsx
+++ b/frontends/election-manager/src/demo_app.tsx
@@ -21,6 +21,7 @@ export function getDemoStorage(): Storage {
 
 export function getSampleMachineConfigProvider(): Provider<MachineConfig> {
   return {
+    // eslint-disable-next-line @typescript-eslint/require-await
     async get() {
       return {
         machineId: '012',

--- a/frontends/election-manager/src/lib/converters/nh_converter_client.test.ts
+++ b/frontends/election-manager/src/lib/converters/nh_converter_client.test.ts
@@ -11,6 +11,7 @@ import { readBlobAsString } from '../blob';
 jest.mock('@votingworks/ballot-interpreter-nh');
 jest.mock('../../utils/pdf_to_images');
 
+/* eslint-disable @typescript-eslint/require-await */
 function makePdfToImagesMockReturnValue({
   pageCount = 2,
 }: { pageCount?: number } = {}): ReturnType<typeof pdfToImages> {
@@ -50,6 +51,7 @@ function makePdfToImagesMockReturnValue({
     },
   };
 }
+/* eslint-enable @typescript-eslint/require-await */
 
 test('display name', () => {
   expect(new NhConverterClient().getDisplayName()).toBe('NH');

--- a/frontends/election-manager/src/lib/converters/nh_converter_client.ts
+++ b/frontends/election-manager/src/lib/converters/nh_converter_client.ts
@@ -18,6 +18,7 @@ const VxElectionDefinitionFile: VxFile = {
   name: 'VX Election Definition',
 };
 
+/* eslint-disable @typescript-eslint/require-await */
 export class NhConverterClient implements ConverterClient {
   private inputFiles: Map<VxFile, File | undefined> = new Map([
     [NhCardDefinitionFile, undefined],
@@ -136,3 +137,4 @@ export class NhConverterClient implements ConverterClient {
     }
   }
 }
+/* eslint-enable @typescript-eslint/require-await */

--- a/frontends/election-manager/src/lib/votecounting.test.ts
+++ b/frontends/election-manager/src/lib/votecounting.test.ts
@@ -36,7 +36,7 @@ export function parseCvrsAndAssertSuccess(
   });
 }
 
-test('tabulating a set of CVRs gives expected output', async () => {
+test('tabulating a set of CVRs gives expected output', () => {
   // get the election
   const election = electionSample2;
 
@@ -85,7 +85,7 @@ test('tabulating a set of CVRs gives expected output', async () => {
   expect(numWriteIns).toBe(260);
 });
 
-test('computeFullTally with no results should produce empty tally objects with contests', async () => {
+test('computeFullTally with no results should produce empty tally objects with contests', () => {
   const election = electionSample2;
 
   const fullTally = computeFullElectionTally(election, new Set());
@@ -319,7 +319,7 @@ test('overvotes counted in single seat contest properly', () => {
   ).toBe(1);
 });
 
-test('overvote report', async () => {
+test('overvote report', () => {
   // get the election
   const election = electionSample2;
 
@@ -719,7 +719,7 @@ test('parsing CVRs with different batch labels in the same id does not error', (
 describe('filterTalliesByParams in a primary election', () => {
   let electionTally: FullElectionTally;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     // get the CVRs
     const cvrsFileContents = electionMultiPartyPrimaryWithDataFiles.cvrData;
     const castVoteRecords = parseCvrsAndAssertSuccess(

--- a/frontends/election-manager/src/screens/manual_data_import_index_screen.test.tsx
+++ b/frontends/election-manager/src/screens/manual_data_import_index_screen.test.tsx
@@ -76,7 +76,7 @@ test('can toggle ballot types for data', async () => {
   getByText('Edit Precinct Results for Precinct 5');
 });
 
-test('precinct table renders properly when there is no data', async () => {
+test('precinct table renders properly when there is no data', () => {
   const saveExternalTallies = jest.fn();
   const history = createMemoryHistory();
   const { getByText, getByTestId } = renderInAppContext(

--- a/frontends/election-manager/src/screens/manual_data_import_precinct_screen.test.tsx
+++ b/frontends/election-manager/src/screens/manual_data_import_precinct_screen.test.tsx
@@ -22,7 +22,7 @@ import {
 } from '../utils/external_tallies';
 import { ManualDataImportPrecinctScreen } from './manual_data_import_precinct_screen';
 
-test('displays error screen for invalid precinct', async () => {
+test('displays error screen for invalid precinct', () => {
   const { getByText } = renderInAppContext(
     <Route path="/tally/manual-data-import/precinct/:precinctId">
       <ManualDataImportPrecinctScreen />
@@ -36,7 +36,7 @@ test('displays error screen for invalid precinct', async () => {
   getByText('Back to Index');
 });
 
-test('displays correct contests for each precinct', async () => {
+test('displays correct contests for each precinct', () => {
   const saveExternalTallies = jest.fn();
   const commissionerRaces = [
     'Election Commissioner 01',
@@ -338,7 +338,7 @@ test('can enter data for yes no contests as expected', async () => {
   ]);
 });
 
-test('loads prexisting manual data to edit', async () => {
+test('loads prexisting manual data to edit', () => {
   const talliesByPrecinct = getEmptyExternalTalliesByPrecinct(
     electionSampleDefinition.election
   );

--- a/frontends/election-manager/src/screens/print_test_deck_screen.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.tsx
@@ -42,7 +42,7 @@ function TestDeckBallots({
   const ballots = generateTestDeckBallots({ election, precinctId });
 
   let numRendered = 0;
-  async function onRendered() {
+  function onRendered() {
     numRendered += 1;
     if (numRendered === ballots.length) {
       onAllRendered(ballots.length);

--- a/frontends/election-manager/src/screens/tally_screen.tsx
+++ b/frontends/election-manager/src/screens/tally_screen.tsx
@@ -120,7 +120,7 @@ export function TallyScreen(): JSX.Element {
   const [externalResultsSelectedFile, setExternalResultsSelectedFile] =
     useState<File>();
 
-  const importExternalSemsFile: InputEventFunction = async (event) => {
+  const importExternalSemsFile: InputEventFunction = (event) => {
     const input = event.currentTarget;
     const files = Array.from(input.files || []);
     if (files.length === 1) {

--- a/frontends/election-manager/src/utils/cast_vote_record_files.ts
+++ b/frontends/election-manager/src/utils/cast_vote_record_files.ts
@@ -208,7 +208,7 @@ export class CastVoteRecordFiles {
         } else {
           assert(window.kiosk);
           const fileContent = await window.kiosk.readFile(file.path, 'utf-8');
-          const parsedFile = await this.parseFromFileContent(
+          const parsedFile = this.parseFromFileContent(
             fileContent,
             file.name,
             parsedFileInfo?.timestamp || new Date(file.mtime),
@@ -232,12 +232,12 @@ export class CastVoteRecordFiles {
    *  Builds a new `CastVoteRecordFiles` object by adding the parsed CVRs from
    * `fileData` to those contained by this `CastVoteRecordFiles` instance.
    */
-  async addFromFileData(
+  addFromFileData(
     fileData: CastVoteRecordFilePreprocessedData,
     election: Election
-  ): Promise<CastVoteRecordFiles> {
+  ): CastVoteRecordFiles {
     assert(window.kiosk);
-    return await this.addFromFileContent(
+    return this.addFromFileContent(
       fileData.fileContent,
       fileData.name,
       fileData.exportTimestamp,
@@ -253,7 +253,7 @@ export class CastVoteRecordFiles {
     try {
       const fileContent = await readFileAsync(file);
       const parsedFileInfo = parseCvrFileInfoFromFilename(file.name);
-      const result = await this.addFromFileContent(
+      const result = this.addFromFileContent(
         fileContent,
         file.name,
         parsedFileInfo?.timestamp || new Date(file.lastModified),
@@ -272,14 +272,14 @@ export class CastVoteRecordFiles {
     }
   }
 
-  private async parseFromFileContent(
+  private parseFromFileContent(
     fileContent: string,
     fileName: string,
     exportTimestamp: Date,
     scannerId: string,
     fallbackTestMode: boolean,
     election: Election
-  ): Promise<CastVoteRecordFilePreprocessedData> {
+  ): CastVoteRecordFilePreprocessedData {
     const fileCastVoteRecords: CastVoteRecord[] = [];
     let testBallotSeen = false;
     let liveBallotSeen = false;
@@ -321,12 +321,12 @@ export class CastVoteRecordFiles {
     };
   }
 
-  private async addFromFileContent(
+  private addFromFileContent(
     fileContent: string,
     fileName: string,
     exportTimestamp: Date,
     election: Election
-  ): Promise<CastVoteRecordFiles> {
+  ): CastVoteRecordFiles {
     try {
       const signature = sha256(fileContent);
 

--- a/frontends/election-manager/src/utils/save_as_pdf.test.ts
+++ b/frontends/election-manager/src/utils/save_as_pdf.test.ts
@@ -1,7 +1,7 @@
 import { electionSample } from '@votingworks/fixtures';
 import { generateDefaultReportFilename } from './save_as_pdf';
 
-test('file path name is generated properly', async () => {
+test('file path name is generated properly', () => {
   const testCases = [
     {
       // The file path should always be lowercased
@@ -48,7 +48,7 @@ test('file path name is generated properly', async () => {
   }
 });
 
-test('precinct name fills in all-precincts as default value', async () => {
+test('precinct name fills in all-precincts as default value', () => {
   expect(generateDefaultReportFilename('test', electionSample)).toBe(
     'test-franklin-county-general-election-all-precincts.pdf'
   );

--- a/frontends/election-manager/src/utils/sems_tallies.test.ts
+++ b/frontends/election-manager/src/utils/sems_tallies.test.ts
@@ -262,7 +262,7 @@ describe('getContestTallyForYesNoContest', () => {
 });
 
 describe('convertSemsFileToExternalTally', () => {
-  it('computes tallies properly on either neither general election', async () => {
+  it('computes tallies properly on either neither general election', () => {
     const convertedTally = convertSemsFileToExternalTally(
       eitherNeitherSemsContent,
       electionWithMsEitherNeither,
@@ -370,7 +370,7 @@ describe('convertSemsFileToExternalTally', () => {
     }
   });
 
-  it('converts primary election sems file properly', async () => {
+  it('converts primary election sems file properly', () => {
     const convertedTally = convertSemsFileToExternalTally(
       primarySemsContent,
       multiPartyPrimaryElection,

--- a/frontends/election-manager/test/helpers/fake_file_writer.ts
+++ b/frontends/election-manager/test/helpers/fake_file_writer.ts
@@ -9,6 +9,7 @@ export function fakeFileWriter(): jest.Mocked<FakeFileWriter> {
 
   return {
     filename: '/fake/file',
+    // eslint-disable-next-line @typescript-eslint/require-await
     write: jest.fn().mockImplementation(async (chunk) => {
       chunks.push(chunk);
     }),

--- a/frontends/election-manager/test/helpers/fake_machine_config.ts
+++ b/frontends/election-manager/test/helpers/fake_machine_config.ts
@@ -15,6 +15,7 @@ export function fakeMachineConfigProvider(
 ): Provider<MachineConfig> {
   const config = fakeMachineConfig(props);
   return {
+    // eslint-disable-next-line @typescript-eslint/require-await
     async get() {
       return config;
     },

--- a/frontends/precinct-scanner/src/components/absolute.test.tsx
+++ b/frontends/precinct-scanner/src/components/absolute.test.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { Absolute } from './absolute';
 
-test('Renders Absolute top right', async () => {
+test('Renders Absolute top right', () => {
   const { container } = render(<Absolute top right padded />);
   expect(container).toMatchSnapshot();
 });
 
-test('Renders Absolute bottom left', async () => {
+test('Renders Absolute bottom left', () => {
   const { container } = render(<Absolute bottom left />);
   expect(container).toMatchSnapshot();
 });

--- a/frontends/precinct-scanner/src/components/calibrate_scanner_modal.tsx
+++ b/frontends/precinct-scanner/src/components/calibrate_scanner_modal.tsx
@@ -33,7 +33,7 @@ export function CalibrateScannerModal({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [onCalibrate, setIsCalibrating]);
 
-  const resetAndTryAgain = useCallback(async () => {
+  const resetAndTryAgain = useCallback(() => {
     setCalibrationSuccess(undefined);
   }, [setCalibrationSuccess]);
 

--- a/frontends/precinct-scanner/src/components/graphics.test.tsx
+++ b/frontends/precinct-scanner/src/components/graphics.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { PlaceholderGraphic } from './graphics';
 
-test('Renders Absolute top right', async () => {
+test('Renders Absolute top right', () => {
   const { container } = render(<PlaceholderGraphic />);
   expect(container).toMatchSnapshot();
 });

--- a/frontends/precinct-scanner/src/hooks/use_precinct_scanner.test.ts
+++ b/frontends/precinct-scanner/src/hooks/use_precinct_scanner.test.ts
@@ -26,7 +26,7 @@ beforeEach(() => {
   jest.useFakeTimers();
 });
 
-test('initial state', async () => {
+test('initial state', () => {
   const { result } = renderHook(() => usePrecinctScanner());
   expect(result.current).toBeUndefined();
 });

--- a/frontends/precinct-scanner/src/screens/admin_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/admin_screen.test.tsx
@@ -61,6 +61,7 @@ test('renders date and time settings modal', async () => {
   fireEvent.change(selectYear, { target: { value: optionYear } });
 
   // Save Date and Timezone
+  // eslint-disable-next-line @typescript-eslint/require-await
   await act(async () => {
     fireEvent.click(within(screen.getByTestId('modal')).getByText('Save'));
   });
@@ -113,7 +114,7 @@ test('setting and un-setting the precinct', async () => {
   expect(updateAppPrecinctId).toHaveBeenNthCalledWith(2, '');
 });
 
-test('export from admin screen', async () => {
+test('export from admin screen', () => {
   render(
     <AppContext.Provider
       value={{
@@ -137,7 +138,7 @@ test('export from admin screen', async () => {
   fireEvent.click(screen.getByText('Export Backup to USB Drive'));
 });
 
-test('unconfigure ejects a usb drive when it is mounted', async () => {
+test('unconfigure ejects a usb drive when it is mounted', () => {
   const ejectFn = jest.fn();
   const unconfigureFn = jest.fn();
   render(

--- a/frontends/precinct-scanner/src/screens/admin_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/admin_screen.tsx
@@ -239,9 +239,11 @@ export function DefaultPreview(): JSX.Element {
       <AdminScreen
         calibrate={() => Promise.resolve(true)}
         isTestMode={isTestMode}
+        // eslint-disable-next-line @typescript-eslint/require-await
         toggleLiveMode={async () => setIsTestMode((prev) => !prev)}
         scannedBallotCount={1234}
         unconfigure={() => Promise.resolve()}
+        // eslint-disable-next-line @typescript-eslint/require-await
         updateAppPrecinctId={async (newPrecinctId) =>
           setPrecinctId(newPrecinctId)
         }

--- a/frontends/precinct-scanner/src/screens/poll_worker_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/poll_worker_screen.test.tsx
@@ -63,6 +63,7 @@ test('shows system authentication code', async () => {
   });
   window.kiosk = mockKiosk;
 
+  // eslint-disable-next-line @typescript-eslint/require-await
   await act(async () => {
     renderScreen({});
     jest.advanceTimersByTime(2000);
@@ -77,6 +78,7 @@ test('shows dashes when no totp', async () => {
   mockOf(mockKiosk.totp.get).mockResolvedValue(undefined);
   window.kiosk = mockKiosk;
 
+  // eslint-disable-next-line @typescript-eslint/require-await
   await act(async () => {
     renderScreen({});
   });
@@ -89,6 +91,7 @@ describe('shows Export Results button only when polls are closed and more than 0
   const exportButtonText = 'Export Results to USB Drive';
 
   test('no ballots and polls closed should not show button', async () => {
+    // eslint-disable-next-line @typescript-eslint/require-await
     await act(async () => {
       renderScreen({
         scannedBallotCount: 0,
@@ -102,6 +105,7 @@ describe('shows Export Results button only when polls are closed and more than 0
   });
 
   test('no ballots and polls open should not show button', async () => {
+    // eslint-disable-next-line @typescript-eslint/require-await
     await act(async () => {
       renderScreen({
         scannedBallotCount: 0,
@@ -113,6 +117,7 @@ describe('shows Export Results button only when polls are closed and more than 0
   });
 
   test('five ballots and polls open should not show button', async () => {
+    // eslint-disable-next-line @typescript-eslint/require-await
     await act(async () => {
       renderScreen({
         scannedBallotCount: 5,
@@ -126,6 +131,7 @@ describe('shows Export Results button only when polls are closed and more than 0
   });
 
   test('five ballots and polls closed should show button', async () => {
+    // eslint-disable-next-line @typescript-eslint/require-await
     await act(async () => {
       renderScreen({
         scannedBallotCount: 5,

--- a/frontends/precinct-scanner/src/screens/scan_warning_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/scan_warning_screen.test.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { AppContext } from '../contexts/app_context';
 import { ScanWarningScreen } from './scan_warning_screen';
 
-test('overvote', async () => {
+test('overvote', () => {
   const acceptBallot = jest.fn();
   const contest = electionSampleDefinition.election.contests.find(
     (c): c is CandidateContest => c.type === 'candidate'
@@ -45,7 +45,7 @@ test('overvote', async () => {
   expect(acceptBallot).toHaveBeenCalledTimes(1);
 });
 
-test('blank ballot', async () => {
+test('blank ballot', () => {
   const acceptBallot = jest.fn();
 
   render(
@@ -71,7 +71,7 @@ test('blank ballot', async () => {
   expect(acceptBallot).toHaveBeenCalledTimes(1);
 });
 
-test('undervote no votes', async () => {
+test('undervote no votes', () => {
   const acceptBallot = jest.fn();
   const contest = electionSampleDefinition.election.contests.find(
     (c): c is CandidateContest => c.type === 'candidate'
@@ -110,7 +110,7 @@ test('undervote no votes', async () => {
   expect(acceptBallot).toHaveBeenCalledTimes(1);
 });
 
-test('undervote by 1', async () => {
+test('undervote by 1', () => {
   const acceptBallot = jest.fn();
   const contest = electionSampleDefinition.election.contests.find(
     (c): c is CandidateContest => c.type === 'candidate' && c.seats > 1
@@ -151,7 +151,7 @@ test('undervote by 1', async () => {
   expect(acceptBallot).toHaveBeenCalledTimes(1);
 });
 
-test('undervote by N', async () => {
+test('undervote by N', () => {
   const acceptBallot = jest.fn();
   const contest = electionSampleDefinition.election.contests.find(
     (c): c is CandidateContest => c.type === 'candidate' && c.seats > 1
@@ -193,7 +193,7 @@ test('undervote by N', async () => {
   expect(acceptBallot).toHaveBeenCalledTimes(1);
 });
 
-test('multiple undervotes', async () => {
+test('multiple undervotes', () => {
   const acceptBallot = jest.fn();
   const contests = electionSampleDefinition.election.contests.filter(
     (c): c is CandidateContest => c.type === 'candidate'
@@ -232,7 +232,7 @@ test('multiple undervotes', async () => {
   expect(acceptBallot).toHaveBeenCalledTimes(1);
 });
 
-test('unreadable', async () => {
+test('unreadable', () => {
   const acceptBallot = jest.fn();
 
   render(

--- a/frontends/precinct-scanner/src/utils/download.test.ts
+++ b/frontends/precinct-scanner/src/utils/download.test.ts
@@ -7,7 +7,7 @@ import {
   readContentDispositionFilename,
 } from './download';
 
-test('readContentDispositionFilename', async () => {
+test('readContentDispositionFilename', () => {
   expect(readContentDispositionFilename('')).toBeUndefined();
   expect(readContentDispositionFilename('attachment')).toBeUndefined();
   expect(readContentDispositionFilename('inline')).toBeUndefined();

--- a/libs/ballot-interpreter-nh/src/interpret/interpret_oval_marks.test.ts
+++ b/libs/ballot-interpreter-nh/src/interpret/interpret_oval_marks.test.ts
@@ -29,14 +29,14 @@ test('interpretOvalMarks unmarked front', async () => {
     HudsonFixtureName,
     'scan-unmarked-back'
   );
-  const frontLayout = await withSvgDebugger(async (debug) => {
+  const frontLayout = withSvgDebugger((debug) => {
     debug.imageData(0, 0, frontImageData);
     return interpretPageLayout(frontImageData, {
       geometry: ScannedBallotCardGeometry8pt5x14,
       debug,
     });
   });
-  const backLayout = await withSvgDebugger(async (debug) => {
+  const backLayout = withSvgDebugger((debug) => {
     debug.imageData(0, 0, backImageData);
     return interpretPageLayout(backImageData, {
       geometry: ScannedBallotCardGeometry8pt5x14,
@@ -142,14 +142,14 @@ test('interpretOvalMarks marked front', async () => {
     HudsonFixtureName,
     'scan-marked-back'
   );
-  const frontLayout = await withSvgDebugger(async (debug) => {
+  const frontLayout = withSvgDebugger((debug) => {
     debug.imageData(0, 0, frontImageData);
     return interpretPageLayout(frontImageData, {
       geometry: ScannedBallotCardGeometry8pt5x14,
       debug,
     });
   });
-  const backLayout = await withSvgDebugger(async (debug) => {
+  const backLayout = withSvgDebugger((debug) => {
     debug.imageData(0, 0, backImageData);
     return interpretPageLayout(backImageData, {
       geometry: ScannedBallotCardGeometry8pt5x14,
@@ -255,14 +255,14 @@ test('interpretOvalMarks marked rotated front', async () => {
     HudsonFixtureName,
     'scan-marked-rotated-back'
   );
-  const frontLayout = await withSvgDebugger(async (debug) => {
+  const frontLayout = withSvgDebugger((debug) => {
     debug.imageData(0, 0, frontImageData);
     return interpretPageLayout(frontImageData, {
       geometry: ScannedBallotCardGeometry8pt5x14,
       debug,
     });
   });
-  const backLayout = await withSvgDebugger(async (debug) => {
+  const backLayout = withSvgDebugger((debug) => {
     debug.imageData(0, 0, backImageData);
     const result = interpretPageLayout(backImageData, {
       geometry: ScannedBallotCardGeometry8pt5x14,

--- a/libs/ballot-interpreter-nh/src/interpret/interpret_page_layout.test.ts
+++ b/libs/ballot-interpreter-nh/src/interpret/interpret_page_layout.test.ts
@@ -13,7 +13,7 @@ test('interpretPageLayout front', async () => {
     HudsonFixtureName,
     'scan-unmarked-front'
   );
-  const frontLayout = await withSvgDebugger(async (debug) => {
+  const frontLayout = withSvgDebugger((debug) => {
     debug.imageData(0, 0, frontImageData);
     return interpretPageLayout(frontImageData, {
       geometry: ScannedBallotCardGeometry8pt5x14,
@@ -46,7 +46,7 @@ test('interpretPageLayout unmarked back', async () => {
     HudsonFixtureName,
     'scan-unmarked-back'
   );
-  const backLayout = await withSvgDebugger(async (debug) => {
+  const backLayout = withSvgDebugger((debug) => {
     debug.imageData(0, 0, backImageData);
     return interpretPageLayout(backImageData, {
       geometry: ScannedBallotCardGeometry8pt5x14,

--- a/libs/ballot-interpreter-vx/src/cli/commands/help.ts
+++ b/libs/ballot-interpreter-vx/src/cli/commands/help.ts
@@ -10,10 +10,10 @@ export interface Options {
   readonly command?: string;
 }
 
-export async function parseOptions({
+export function parseOptions({
   commandArgs,
   executablePath,
-}: GlobalOptions): Promise<Options> {
+}: GlobalOptions): Options {
   const $0 = basename(executablePath);
 
   if (commandArgs.length === 0) {
@@ -85,14 +85,14 @@ export function printHelp(
   out.write(`Print usage information for COMMAND.\n`);
 }
 
-export async function run(
+export function run(
   commands: Command[],
   globalOptions: GlobalOptions,
   _stdin: NodeJS.ReadableStream,
   stdout: NodeJS.WritableStream,
   stderr: NodeJS.WritableStream
-): Promise<number> {
-  const options = await parseOptions(globalOptions);
+): number {
+  const options = parseOptions(globalOptions);
 
   if (options.command) {
     return printCommandHelp(commands, globalOptions, options, stdout, stderr);

--- a/libs/ballot-interpreter-vx/src/cli/commands/interpret.ts
+++ b/libs/ballot-interpreter-vx/src/cli/commands/interpret.ts
@@ -250,7 +250,7 @@ export async function run(
   const ballotInputs = [...options.ballotInputs];
 
   for (const templateInput of options.templateInputs) {
-    await interpreter.addTemplate(
+    interpreter.addTemplate(
       await interpreter.interpretTemplate(
         await templateInput.imageData(),
         await templateInput.metadata?.()

--- a/libs/ballot-interpreter-vx/src/cli/commands/layout.test.ts
+++ b/libs/ballot-interpreter-vx/src/cli/commands/layout.test.ts
@@ -7,18 +7,16 @@ import { loadImageData } from '../../utils/images';
 import { adjacentFile } from '../../utils/path';
 import { parseOptions } from './layout';
 
-test('options', async () => {
+test('options', () => {
   expect(
-    (
-      await parseOptions(
-        parseGlobalOptions([
-          'node',
-          'ballot-interpreter-vx',
-          'layout',
-          'ballot01.png',
-          'ballot02.png',
-        ]).unsafeUnwrap()
-      )
+    parseOptions(
+      parseGlobalOptions([
+        'node',
+        'ballot-interpreter-vx',
+        'layout',
+        'ballot01.png',
+        'ballot02.png',
+      ]).unsafeUnwrap()
     ).unsafeUnwrap()
   ).toEqual({
     help: false,
@@ -26,17 +24,15 @@ test('options', async () => {
   });
 });
 
-test('invalid options', async () => {
+test('invalid options', () => {
   expect(
-    (
-      await parseOptions(
-        parseGlobalOptions([
-          'node',
-          'ballot-interpreter-vx',
-          'layout',
-          '--wrong',
-        ]).unsafeUnwrap()
-      )
+    parseOptions(
+      parseGlobalOptions([
+        'node',
+        'ballot-interpreter-vx',
+        'layout',
+        '--wrong',
+      ]).unsafeUnwrap()
     ).unsafeUnwrapErr().message
   ).toEqual(`unexpected option passed to 'layout': --wrong`);
 });

--- a/libs/ballot-interpreter-vx/src/cli/commands/layout.ts
+++ b/libs/ballot-interpreter-vx/src/cli/commands/layout.ts
@@ -59,9 +59,9 @@ export function printHelp(
   out.write(`${$0} layout ballot*.jpg\n`);
 }
 
-export async function parseOptions({
+export function parseOptions({
   commandArgs: args,
-}: GlobalOptions): Promise<Result<Options, Error>> {
+}: GlobalOptions): Result<Options, Error> {
   let help = false;
   let targetMarkPosition: BallotTargetMarkPosition | undefined;
   const ballotImagePaths: string[] = [];
@@ -229,7 +229,7 @@ export async function run(
   stdout: NodeJS.WritableStream,
   stderr: NodeJS.WritableStream
 ): Promise<number> {
-  const optionsResult = await parseOptions(globalOptions);
+  const optionsResult = parseOptions(globalOptions);
 
   if (optionsResult.isErr()) {
     stderr.write(`${optionsResult.err().message}\n`);

--- a/libs/ballot-interpreter-vx/src/cli/types.ts
+++ b/libs/ballot-interpreter-vx/src/cli/types.ts
@@ -8,7 +8,7 @@ export interface Command {
     stdin: NodeJS.ReadableStream,
     stdout: NodeJS.WritableStream,
     stderr: NodeJS.WritableStream
-  ): Promise<number>;
+  ): number | Promise<number>;
 }
 
 export interface GlobalOptions {

--- a/libs/ballot-interpreter-vx/src/cli/types.ts
+++ b/libs/ballot-interpreter-vx/src/cli/types.ts
@@ -1,3 +1,5 @@
+import { PromiseOr } from '@votingworks/types';
+
 export interface Command {
   name: string;
   description: string;
@@ -8,7 +10,7 @@ export interface Command {
     stdin: NodeJS.ReadableStream,
     stdout: NodeJS.WritableStream,
     stderr: NodeJS.WritableStream
-  ): number | Promise<number>;
+  ): PromiseOr<number>;
 }
 
 export interface GlobalOptions {

--- a/libs/ballot-interpreter-vx/src/interpreter/basics.test.ts
+++ b/libs/ballot-interpreter-vx/src/interpreter/basics.test.ts
@@ -54,12 +54,12 @@ test('rejects an incorrect-but-plausible contest layout', async () => {
     testMode: true,
   });
 
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(
       await fixtures.district5BlankPage1.imageData()
     )
   );
-  const p2 = await interpreter.addTemplate(
+  const p2 = interpreter.addTemplate(
     await interpreter.interpretTemplate(
       await fixtures.district5BlankPage2.imageData()
     )

--- a/libs/ballot-interpreter-vx/src/interpreter/choctaw_2019.test.ts
+++ b/libs/ballot-interpreter-vx/src/interpreter/choctaw_2019.test.ts
@@ -7,13 +7,13 @@ test('choctaw general 2019', async () => {
   const { electionDefinition } = choctaw2019;
   const interpreter = new Interpreter({ electionDefinition });
 
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(
       await choctaw2019.blankPage1.imageData(),
       await choctaw2019.blankPage1.metadata()
     )
   );
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(
       await choctaw2019.blankPage2.imageData(),
       await choctaw2019.blankPage2.metadata()
@@ -126,21 +126,21 @@ test('determining layout of a ballot with borders', async () => {
   const { electionDefinition } = choctaw2019;
   const interpreter = new Interpreter({ electionDefinition });
 
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(
       await choctaw2019.blankPage1.imageData(),
       await choctaw2019.blankPage1.metadata()
     )
   );
 
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(
       await choctaw2019.blankPage2.imageData(),
       await choctaw2019.blankPage2.metadata()
     )
   );
 
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(
       await choctaw2019.blankPage3.imageData(),
       await choctaw2019.blankPage3.metadata()

--- a/libs/ballot-interpreter-vx/src/interpreter/choctaw_2020_general.test.ts
+++ b/libs/ballot-interpreter-vx/src/interpreter/choctaw_2020_general.test.ts
@@ -7,14 +7,14 @@ test('choctaw 2020 general', async () => {
   const { electionDefinition } = choctaw2020;
   const interpreter = new Interpreter({ electionDefinition });
 
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(
       await choctaw2020.blankPage1.imageData(),
       await choctaw2020.blankPage1.metadata()
     )
   );
 
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(
       await choctaw2020.blankPage2.imageData(),
       await choctaw2020.blankPage2.metadata()

--- a/libs/ballot-interpreter-vx/src/interpreter/dual_language_ballots.test.ts
+++ b/libs/ballot-interpreter-vx/src/interpreter/dual_language_ballots.test.ts
@@ -7,7 +7,7 @@ test('dual language ballot', async () => {
   const { electionDefinition } = hamilton;
   const interpreter = new Interpreter({ electionDefinition });
 
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(
       await hamilton.blankPage1.imageData(),
       await hamilton.blankPage1.metadata()

--- a/libs/ballot-interpreter-vx/src/interpreter/enforcing_test_vs_live_mode.test.ts
+++ b/libs/ballot-interpreter-vx/src/interpreter/enforcing_test_vs_live_mode.test.ts
@@ -7,25 +7,22 @@ test('enforcing test vs live mode', async () => {
   const fixtures = oaklawn;
   const { electionDefinition } = fixtures;
   const interpreter = new Interpreter({ electionDefinition });
+  const template = await interpreter.interpretTemplate(
+    await fixtures.blankPage1.imageData(),
+    await fixtures.blankPage1.metadata({ isTestMode: true })
+  );
 
-  await expect(
-    interpreter.addTemplate(
-      await interpreter.interpretTemplate(
-        await fixtures.blankPage1.imageData(),
-        await fixtures.blankPage1.metadata({ isTestMode: true })
-      )
-    )
-  ).rejects.toThrowError(
+  expect(() => interpreter.addTemplate(template)).toThrowError(
     'interpreter configured with testMode=false cannot add templates with isTestMode=true'
   );
 
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(
       await fixtures.blankPage1.imageData(),
       await fixtures.blankPage1.metadata()
     )
   );
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(
       await fixtures.blankPage2.imageData(),
       await fixtures.blankPage2.metadata()

--- a/libs/ballot-interpreter-vx/src/interpreter/handles_lines_connecting_contest_boxes.test.ts
+++ b/libs/ballot-interpreter-vx/src/interpreter/handles_lines_connecting_contest_boxes.test.ts
@@ -14,19 +14,19 @@ test.skip('handles lines connecting contest boxes', async () => {
   const { electionDefinition } = hamilton;
   const interpreter = new Interpreter({ electionDefinition });
 
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(
       await hamilton.blankPage1.imageData(),
       await hamilton.blankPage1.metadata()
     )
   );
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(
       await hamilton.blankPage2.imageData(),
       await hamilton.blankPage2.metadata()
     )
   );
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(
       await hamilton.blankPage3.imageData(),
       await hamilton.blankPage3.metadata()

--- a/libs/ballot-interpreter-vx/src/interpreter/index.ts
+++ b/libs/ballot-interpreter-vx/src/interpreter/index.ts
@@ -117,9 +117,7 @@ export class Interpreter {
    * printed from it. The template is an object describing the layout of the
    * ballot.
    */
-  async addTemplate(
-    template: BallotPageLayoutWithImage
-  ): Promise<BallotPageLayoutWithImage> {
+  addTemplate(template: BallotPageLayoutWithImage): BallotPageLayoutWithImage {
     const effectiveMetadata = template.ballotPageLayout.metadata;
 
     if (effectiveMetadata.isTestMode !== this.testMode) {
@@ -242,18 +240,15 @@ export class Interpreter {
     }
 
     debug('using metadata: %O', normalized.metadata);
-    const marked = await this.findMarks(
-      normalized.imageData,
-      normalized.metadata
-    );
+    const marked = this.findMarks(normalized.imageData, normalized.metadata);
     const ballot = this.interpretMarks(marked, { markScoreVoteThreshold });
     return { ...marked, ballot };
   }
 
-  private async findMarks(
+  private findMarks(
     imageData: ImageData,
     metadata: BallotPageMetadata
-  ): Promise<FindMarksResult> {
+  ): FindMarksResult {
     debug(
       'looking for marks in %d×%d image',
       imageData.width,

--- a/libs/ballot-interpreter-vx/src/interpreter/interpret_empty_ballot.test.ts
+++ b/libs/ballot-interpreter-vx/src/interpreter/interpret_empty_ballot.test.ts
@@ -13,10 +13,10 @@ test('interpret empty ballot', async () => {
   ).rejects.toThrow(
     'Cannot scan ballot because not all required templates have been added'
   );
-  const p1 = await interpreter.addTemplate(
+  const p1 = interpreter.addTemplate(
     await interpreter.interpretTemplate(await fixtures.blankPage1.imageData())
   );
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(await fixtures.blankPage2.imageData())
   );
 

--- a/libs/ballot-interpreter-vx/src/interpreter/interpret_votes.test.ts
+++ b/libs/ballot-interpreter-vx/src/interpreter/interpret_votes.test.ts
@@ -8,7 +8,7 @@ test('interpret votes', async () => {
   const { electionDefinition } = fixtures;
   const interpreter = new Interpreter({ electionDefinition });
 
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(await fixtures.blankPage1.imageData())
   );
 

--- a/libs/ballot-interpreter-vx/src/interpreter/invalid_marks.test.ts
+++ b/libs/ballot-interpreter-vx/src/interpreter/invalid_marks.test.ts
@@ -8,13 +8,13 @@ test('invalid marks', async () => {
   const { electionDefinition } = fixtures;
   const interpreter = new Interpreter({ electionDefinition });
 
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(
       await fixtures.blankPage1.imageData(),
       await fixtures.blankPage1.metadata()
     )
   );
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(
       await fixtures.blankPage2.imageData(),
       await fixtures.blankPage2.metadata()

--- a/libs/ballot-interpreter-vx/src/interpreter/normalizes_intentionally_empty_pages.test.ts
+++ b/libs/ballot-interpreter-vx/src/interpreter/normalizes_intentionally_empty_pages.test.ts
@@ -8,10 +8,10 @@ test('normalizes intentionally-empty pages correctly', async () => {
   const { electionDefinition } = fixtures;
   const interpreter = new Interpreter({ electionDefinition });
 
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(await fixtures.blankPage1.imageData())
   );
-  const page2Template = await interpreter.addTemplate(
+  const page2Template = interpreter.addTemplate(
     await interpreter.interpretTemplate(await fixtures.blankPage2.imageData())
   );
   const { mappedBallot } = await interpreter.interpretBallot(

--- a/libs/ballot-interpreter-vx/src/interpreter/regression_overvote_on_choctaw_county_p1_05.test.ts
+++ b/libs/ballot-interpreter-vx/src/interpreter/regression_overvote_on_choctaw_county_p1_05.test.ts
@@ -8,7 +8,7 @@ test('regression: overvote on choctaw county p1-05', async () => {
   const { electionDefinition } = fixtures;
   const interpreter = new Interpreter({ electionDefinition, testMode: true });
 
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(
       await fixtures.district5BlankPage1.imageData()
     )

--- a/libs/ballot-interpreter-vx/src/interpreter/regression_page_outline.test.ts
+++ b/libs/ballot-interpreter-vx/src/interpreter/regression_page_outline.test.ts
@@ -8,13 +8,13 @@ test('regression: page outline', async () => {
   const { electionDefinition } = fixtures;
   const interpreter = new Interpreter({ electionDefinition });
 
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(
       await fixtures.blankPage1.imageData(),
       await fixtures.blankPage1.metadata()
     )
   );
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(
       await fixtures.blankPage2.imageData(),
       await fixtures.blankPage2.metadata()

--- a/libs/ballot-interpreter-vx/src/interpreter/right_side_targets.test.ts
+++ b/libs/ballot-interpreter-vx/src/interpreter/right_side_targets.test.ts
@@ -10,10 +10,10 @@ import {
 test('interprets ballots with right-side ballot target mark position', async () => {
   const interpreter = new Interpreter({ electionDefinition, testMode: true });
 
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(await blankPage1.imageData())
   );
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(await blankPage2.imageData())
   );
 

--- a/libs/ballot-interpreter-vx/src/interpreter/two_column_template.test.ts
+++ b/libs/ballot-interpreter-vx/src/interpreter/two_column_template.test.ts
@@ -8,7 +8,7 @@ test('interpret two-column template', async () => {
   const interpreter = new Interpreter({ electionDefinition });
 
   {
-    const template = await interpreter.addTemplate(
+    const template = interpreter.addTemplate(
       await interpreter.interpretTemplate(
         await choctawMock2020.blankPage1.imageData(),
         // provide the metadata because the QR code uses raw binary, not base64
@@ -552,7 +552,7 @@ test('interpret two-column template', async () => {
   }
 
   {
-    const template = await interpreter.addTemplate(
+    const template = interpreter.addTemplate(
       await interpreter.interpretTemplate(
         await choctawMock2020.blankPage2.imageData(),
         await choctawMock2020.blankPage2.metadata()

--- a/libs/ballot-interpreter-vx/src/interpreter/upside_down_ballot.test.ts
+++ b/libs/ballot-interpreter-vx/src/interpreter/upside_down_ballot.test.ts
@@ -8,13 +8,13 @@ test('upside-down ballot', async () => {
   const { electionDefinition } = fixtures;
   const interpreter = new Interpreter({ electionDefinition });
 
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(
       await fixtures.blankPage1.imageData(),
       await fixtures.blankPage1.metadata()
     )
   );
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(
       await fixtures.blankPage2.imageData(),
       await fixtures.blankPage2.metadata()

--- a/libs/ballot-interpreter-vx/src/interpreter/yesno_overvotes.test.ts
+++ b/libs/ballot-interpreter-vx/src/interpreter/yesno_overvotes.test.ts
@@ -7,31 +7,31 @@ test('yesno overvotes', async () => {
   const { electionDefinition } = hamilton;
   const interpreter = new Interpreter({ electionDefinition });
 
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(
       await hamilton.blankPage1.imageData(),
       await hamilton.blankPage1.metadata()
     )
   );
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(
       await hamilton.blankPage2.imageData(),
       await hamilton.blankPage2.metadata()
     )
   );
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(
       await hamilton.blankPage3.imageData(),
       await hamilton.blankPage3.metadata()
     )
   );
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(
       await hamilton.blankPage4.imageData(),
       await hamilton.blankPage4.metadata()
     )
   );
-  await interpreter.addTemplate(
+  interpreter.addTemplate(
     await interpreter.interpretTemplate(
       await hamilton.blankPage5.imageData(),
       await hamilton.blankPage5.metadata()

--- a/libs/ballot-interpreter-vx/src/utils/binarize.test.ts
+++ b/libs/ballot-interpreter-vx/src/utils/binarize.test.ts
@@ -2,7 +2,7 @@ import { createImageData } from 'canvas';
 import { croppedQrCode } from '../../test/fixtures';
 import { binarize, RGBA_BLACK, RGBA_WHITE } from './binarize';
 
-test('binarize grayscale', async () => {
+test('binarize grayscale', () => {
   const imageData = createImageData(2, 2);
 
   imageData.data.set([0, 0, 0, 255], 0);
@@ -20,7 +20,7 @@ test('binarize grayscale', async () => {
   ]);
 });
 
-test('binarize color', async () => {
+test('binarize color', () => {
   const imageData = createImageData(2, 2);
 
   imageData.data.set([0, 0, 0, 255], 0);

--- a/libs/ballot-interpreter-vx/src/utils/qrcode.ts
+++ b/libs/ballot-interpreter-vx/src/utils/qrcode.ts
@@ -110,7 +110,7 @@ export async function detect(
   const detectors = [
     {
       name: 'qrdetect',
-      detect: async ({ data, width, height }: ImageData): Promise<Buffer[]> =>
+      detect: ({ data, width, height }: ImageData): Buffer[] =>
         qrdetect(data, width, height).map((symbol) => symbol.data),
     },
     {
@@ -124,7 +124,7 @@ export async function detect(
     },
     {
       name: 'jsQR',
-      detect: async ({ data, width, height }: ImageData): Promise<Buffer[]> => {
+      detect: ({ data, width, height }: ImageData): Buffer[] => {
         const result = jsQr(data, width, height);
         return result ? [Buffer.from(result.binaryData)] : [];
       },

--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -75,6 +75,7 @@ export = {
     '@typescript-eslint/no-unnecessary-type-assertion': 'error',
     '@typescript-eslint/no-unused-vars': 'error',
     '@typescript-eslint/prefer-readonly': 'error',
+    '@typescript-eslint/require-await': 'error',
     'class-methods-use-this': 'off',
     'consistent-return': 'off',
     // be stricter than eslint-config-airbnb which allows `== null`

--- a/libs/logging/src/logger.test.ts
+++ b/libs/logging/src/logger.test.ts
@@ -323,7 +323,7 @@ describe('test cdf conversion', () => {
     expect(cdfLog2.Device?.[0]!.Event).toStrictEqual([]);
   });
 
-  test('read and interpret a real log file as expected', async () => {
+  test('read and interpret a real log file as expected', () => {
     const logFile = readFileSync(join(__dirname, '../fixtures/samplelog.log'));
     const logger = new Logger(LogSource.VxAdminFrontend);
     const cdfLogContent = logger.buildCDFLog(

--- a/libs/plustek-sdk/src/mocks.ts
+++ b/libs/plustek-sdk/src/mocks.ts
@@ -14,6 +14,8 @@ import {
   ScanResult,
 } from './scanner';
 
+/* eslint-disable @typescript-eslint/require-await */
+
 const debug = makeDebug('plustek-sdk:mock-client');
 
 /**

--- a/libs/plustek-sdk/src/plustekctl.test.ts
+++ b/libs/plustek-sdk/src/plustekctl.test.ts
@@ -1,5 +1,0 @@
-import { findBinaryPath } from './plustekctl';
-
-test('plustekctl', async () => {
-  expect((await findBinaryPath()).unsafeUnwrap()).toEqual('plustekctl');
-});

--- a/libs/plustek-sdk/src/plustekctl.ts
+++ b/libs/plustek-sdk/src/plustekctl.ts
@@ -1,9 +1,0 @@
-import { ok, Result } from '@votingworks/types';
-
-/**
- * Locates the `plustekctl` binary.
- */
-export async function findBinaryPath(): Promise<Result<string, Error>> {
-  // TODO: either remove this function or actually validate `plustekctl` exists.
-  return ok('plustekctl');
-}

--- a/libs/types/src/generic.ts
+++ b/libs/types/src/generic.ts
@@ -104,6 +104,11 @@ declare const Unique: unique symbol;
  */
 export type NewType<Base, Tag> = Base & { readonly [Unique]: Tag };
 
+/**
+ * Creates a type that is either `T` or a `Promise` wrapping `T`.
+ */
+export type PromiseOr<T> = T | Promise<T>;
+
 export type Id = string;
 export const IdSchema: z.ZodSchema<Id> = z
   .string()

--- a/libs/ui/src/election_info_bar.test.tsx
+++ b/libs/ui/src/election_info_bar.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 import { electionSampleDefinition } from '@votingworks/fixtures';
 import { ElectionInfoBar } from './election_info_bar';
 
-test('Renders nothing when there is no election', async () => {
+test('Renders nothing when there is no election', () => {
   const { container } = render(
     <ElectionInfoBar
       electionDefinition={undefined}
@@ -15,7 +15,7 @@ test('Renders nothing when there is no election', async () => {
   expect(container).toMatchSnapshot();
 });
 
-test('Renders ElectionInfoBar without precinct information by default', async () => {
+test('Renders ElectionInfoBar without precinct information by default', () => {
   const { container } = render(
     <ElectionInfoBar
       electionDefinition={electionSampleDefinition}
@@ -27,7 +27,7 @@ test('Renders ElectionInfoBar without precinct information by default', async ()
   expect(container).toMatchSnapshot();
 });
 
-test('Renders ElectionInfoBar with all precincts wording', async () => {
+test('Renders ElectionInfoBar with all precincts wording', () => {
   const { container } = render(
     <ElectionInfoBar
       electionDefinition={electionSampleDefinition}
@@ -39,7 +39,7 @@ test('Renders ElectionInfoBar with all precincts wording', async () => {
   expect(container).toMatchSnapshot();
 });
 
-test('Renders admin ElectionInfoBar with precinct set', async () => {
+test('Renders admin ElectionInfoBar with precinct set', () => {
   const { container } = render(
     <ElectionInfoBar
       mode="admin"

--- a/libs/ui/src/hooks/use_autocomplete.test.tsx
+++ b/libs/ui/src/hooks/use_autocomplete.test.tsx
@@ -130,7 +130,7 @@ test('basic autocomplete', async () => {
   expect(onSuggest).toHaveBeenCalledTimes(7);
 });
 
-test('can pass a wrapped onInput through', async () => {
+test('can pass a wrapped onInput through', () => {
   const onInput = jest.fn();
 
   function TestComponent(): JSX.Element {
@@ -157,7 +157,7 @@ test('can pass a wrapped onInput through', async () => {
   expect(onInput).toHaveBeenCalledTimes(7);
 });
 
-test('can pass a wrapped onKeyDown through', async () => {
+test('can pass a wrapped onKeyDown through', () => {
   const onKeyDown = jest.fn();
 
   function TestComponent(): JSX.Element {
@@ -184,7 +184,7 @@ test('can pass a wrapped onKeyDown through', async () => {
   expect(onKeyDown).toHaveBeenCalledTimes(8);
 });
 
-test('does not autocomplete unless typing at the end', async () => {
+test('does not autocomplete unless typing at the end', () => {
   const onSuggest = jest.fn<
     ReturnType<onSuggestType<string>>,
     Parameters<onSuggestType<string>>

--- a/libs/ui/src/hooks/use_mounted_state.test.ts
+++ b/libs/ui/src/hooks/use_mounted_state.test.ts
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { useMountedState } from './use_mounted_state';
 
-test('useMountedState', async () => {
+test('useMountedState', () => {
   const { result, unmount } = renderHook(() => useMountedState());
   const isMounted = result.current;
   expect(isMounted()).toBe(true);

--- a/libs/ui/src/hooks/use_user_session.test.tsx
+++ b/libs/ui/src/hooks/use_user_session.test.tsx
@@ -90,7 +90,7 @@ test('bypass and persist authentication flow', () => {
   expect(logSpy).toHaveBeenCalledTimes(1);
 });
 
-test('bypass authentication flow when not persisting authentication', async () => {
+test('bypass authentication flow when not persisting authentication', () => {
   let smartcard: Smartcard = { status: 'no_card' };
   const fakeLogger = new Logger(LogSource.VxCentralScanFrontend);
   const logSpy = jest.spyOn(fakeLogger, 'log').mockResolvedValue();
@@ -539,7 +539,7 @@ test('basic persist authentication flow works as expected', () => {
   );
 });
 
-test('basic flow with no persistance of authentication works as expected', async () => {
+test('basic flow with no persistance of authentication works as expected', () => {
   let smartcard: Smartcard = { status: 'no_card' };
   const fakeLogger = new Logger(LogSource.VxCentralScanFrontend);
   const logSpy = jest.spyOn(fakeLogger, 'log').mockResolvedValue();

--- a/libs/ui/src/input_group.test.tsx
+++ b/libs/ui/src/input_group.test.tsx
@@ -4,7 +4,7 @@ import { render } from '@testing-library/react';
 import { InputGroup } from './input_group';
 import { Select } from './select';
 
-test('renders InputGroup', async () => {
+test('renders InputGroup', () => {
   const { container } = render(
     <InputGroup>
       <Select>

--- a/libs/ui/src/number_pad.test.tsx
+++ b/libs/ui/src/number_pad.test.tsx
@@ -85,7 +85,7 @@ function sendKey(key: string): void {
   });
 }
 
-test('keyboard interaction', async () => {
+test('keyboard interaction', () => {
   const onPress = jest.fn();
   const onBackspace = jest.fn();
   const onClear = jest.fn();
@@ -127,7 +127,7 @@ test('keyboard interaction', async () => {
   expect(onPress).toHaveBeenCalledTimes(10);
 });
 
-test('keyboard interaction when onEnter is defined', async () => {
+test('keyboard interaction when onEnter is defined', () => {
   const onPress = jest.fn();
   const onBackspace = jest.fn();
   const onClear = jest.fn();

--- a/libs/ui/src/precinct_scanner_tally_qrcode.test.tsx
+++ b/libs/ui/src/precinct_scanner_tally_qrcode.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, act, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import {
   electionSample,
   electionSampleDefinition,
@@ -35,7 +35,7 @@ const cvr: CastVoteRecord = {
   'county-commissioners': ['argent'],
 };
 
-test('renders WITHOUT results reporting when there are CVRs but polls are open', async () => {
+test('renders WITHOUT results reporting when there are CVRs but polls are open', () => {
   const mockKiosk = fakeKiosk();
   mockOf(mockKiosk.sign).mockResolvedValue('FAKESIGNATURE');
   window.kiosk = mockKiosk;
@@ -46,19 +46,17 @@ test('renders WITHOUT results reporting when there are CVRs but polls are open',
   );
   const compressedTally = compressTally(electionSample, tally);
 
-  await act(async () => {
-    render(
-      <PrecinctScannerTallyQrCode
-        reportSavedTime={time}
-        electionDefinition={electionSampleDefinition}
-        reportPurpose="Testing"
-        isPollsOpen
-        isLiveMode
-        compressedTally={compressedTally}
-        signingMachineId="0001"
-      />
-    );
-  });
+  render(
+    <PrecinctScannerTallyQrCode
+      reportSavedTime={time}
+      electionDefinition={electionSampleDefinition}
+      reportPurpose="Testing"
+      isPollsOpen
+      isLiveMode
+      compressedTally={compressedTally}
+      signingMachineId="0001"
+    />
+  );
 
   expect(screen.queryByText('Automatic Election Results Reporting')).toBeNull();
 });
@@ -74,19 +72,17 @@ test('renders with results reporting when there are CVRs and polls are closed', 
   );
   const compressedTally = compressTally(electionSample, tally);
 
-  await act(async () => {
-    render(
-      <PrecinctScannerTallyQrCode
-        reportSavedTime={time}
-        electionDefinition={electionSampleDefinition}
-        reportPurpose="Testing"
-        isPollsOpen={false}
-        isLiveMode
-        compressedTally={compressedTally}
-        signingMachineId="DEMO-0000"
-      />
-    );
-  });
+  render(
+    <PrecinctScannerTallyQrCode
+      reportSavedTime={time}
+      electionDefinition={electionSampleDefinition}
+      reportPurpose="Testing"
+      isPollsOpen={false}
+      isLiveMode
+      compressedTally={compressedTally}
+      signingMachineId="DEMO-0000"
+    />
+  );
 
   const payloadComponents = mockKiosk.sign.mock.calls[0][0].payload.split('.');
   expect(payloadComponents).toEqual([
@@ -97,9 +93,11 @@ test('renders with results reporting when there are CVRs and polls are closed', 
     expect.any(String),
   ]);
 
-  expect(
-    screen.queryByText('Automatic Election Results Reporting')
-  ).toBeTruthy();
+  await waitFor(() =>
+    expect(
+      screen.queryByText('Automatic Election Results Reporting')
+    ).toBeInTheDocument()
+  );
 });
 
 test('renders with results reporting when there are CVRs and polls are closed in testing mode', async () => {
@@ -117,19 +115,17 @@ test('renders with results reporting when there are CVRs and polls are closed in
   );
   const compressedTally = compressTally(electionSample, tally);
 
-  await act(async () => {
-    render(
-      <PrecinctScannerTallyQrCode
-        reportSavedTime={time}
-        electionDefinition={electionSampleDefinition}
-        reportPurpose="Testing"
-        isPollsOpen={false}
-        isLiveMode={false}
-        compressedTally={compressedTally}
-        signingMachineId="DEMO-0000"
-      />
-    );
-  });
+  render(
+    <PrecinctScannerTallyQrCode
+      reportSavedTime={time}
+      electionDefinition={electionSampleDefinition}
+      reportPurpose="Testing"
+      isPollsOpen={false}
+      isLiveMode={false}
+      compressedTally={compressedTally}
+      signingMachineId="DEMO-0000"
+    />
+  );
 
   const payloadComponents = mockKiosk.sign.mock.calls[0][0].payload.split('.');
   expect(payloadComponents).toEqual([
@@ -140,9 +136,11 @@ test('renders with results reporting when there are CVRs and polls are closed in
     expect.any(String),
   ]);
 
-  expect(
-    screen.queryByText('Automatic Election Results Reporting')
-  ).toBeTruthy();
+  await waitFor(() =>
+    expect(
+      screen.queryByText('Automatic Election Results Reporting')
+    ).toBeInTheDocument()
+  );
 });
 
 test('renders with unsigned results reporting when there is no kiosk', async () => {
@@ -153,21 +151,21 @@ test('renders with unsigned results reporting when there is no kiosk', async () 
   );
   const compressedTally = compressTally(electionSample, tally);
 
-  await act(async () => {
-    render(
-      <PrecinctScannerTallyQrCode
-        reportSavedTime={time}
-        electionDefinition={electionSampleDefinition}
-        reportPurpose="Testing"
-        isPollsOpen={false}
-        isLiveMode
-        compressedTally={compressedTally}
-        signingMachineId="DEMO-0000"
-      />
-    );
-  });
+  render(
+    <PrecinctScannerTallyQrCode
+      reportSavedTime={time}
+      electionDefinition={electionSampleDefinition}
+      reportPurpose="Testing"
+      isPollsOpen={false}
+      isLiveMode
+      compressedTally={compressedTally}
+      signingMachineId="DEMO-0000"
+    />
+  );
 
-  expect(
-    screen.queryByText('Automatic Election Results Reporting')
-  ).toBeTruthy();
+  await waitFor(() =>
+    expect(
+      screen.queryByText('Automatic Election Results Reporting')
+    ).toBeInTheDocument()
+  );
 });

--- a/libs/ui/src/precinct_scanner_tally_report.test.tsx
+++ b/libs/ui/src/precinct_scanner_tally_report.test.tsx
@@ -33,7 +33,7 @@ const cvr: CastVoteRecord = {
   'county-commissioners': ['argent'],
 };
 
-test('renders as expected for all precincts in a general election', async () => {
+test('renders as expected for all precincts in a general election', () => {
   const tally = calculateTallyForCastVoteRecords(
     electionSample,
     new Set([cvr])
@@ -74,7 +74,7 @@ test('renders as expected for all precincts in a general election', async () => 
   ).getByText(/0 ballots cast/);
 });
 
-test('renders as expected for a single precinct in a general election', async () => {
+test('renders as expected for a single precinct in a general election', () => {
   const tally = calculateTallyForCastVoteRecords(
     electionSample,
     new Set([cvr])
@@ -133,7 +133,7 @@ const primaryCvr: CastVoteRecord = {
   'new-zoo-pick': ['no'],
 };
 
-test('renders as expected for all precincts in a primary election', async () => {
+test('renders as expected for all precincts in a primary election', () => {
   const party0 = unsafeParse(PartyIdSchema, '0');
   const tally = calculateTallyForCastVoteRecords(
     electionMinimalExhaustiveSampleDefinition.election,
@@ -207,7 +207,7 @@ const primaryCvr2: CastVoteRecord = {
   fishing: ['yes', 'no'],
 };
 
-test('renders as expected for a single precincts in a primary election', async () => {
+test('renders as expected for a single precincts in a primary election', () => {
   const party1 = unsafeParse(PartyIdSchema, '1');
   const tally = calculateTallyForCastVoteRecords(
     electionMinimalExhaustiveSampleDefinition.election,

--- a/libs/ui/src/progress_bar.test.tsx
+++ b/libs/ui/src/progress_bar.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 
 import { ProgressBar } from './progress_bar';
 
-it('renders ProgressBar with defaults', async () => {
+it('renders ProgressBar with defaults', () => {
   const { container } = render(<ProgressBar />);
   expect(container.firstChild).toMatchSnapshot();
 });

--- a/libs/ui/src/prose.test.tsx
+++ b/libs/ui/src/prose.test.tsx
@@ -38,12 +38,12 @@ const proseContent = (
   </React.Fragment>
 );
 describe('renders Prose', () => {
-  test('with defaults', async () => {
+  test('with defaults', () => {
     const { container } = render(<Prose>{proseContent}</Prose>);
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('with with non-default options', async () => {
+  test('with with non-default options', () => {
     const { container } = render(
       <Prose compact textCenter maxWidth={false}>
         {proseContent}
@@ -52,12 +52,12 @@ describe('renders Prose', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('with right-aligned text', async () => {
+  test('with right-aligned text', () => {
     const { container } = render(<Prose textRight>{proseContent}</Prose>);
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('with theme', async () => {
+  test('with theme', () => {
     const { container } = render(
       <Prose
         theme={{

--- a/libs/ui/src/qrcode.test.tsx
+++ b/libs/ui/src/qrcode.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 
 import { QrCode } from './qrcode';
 
-it('renders QRCode', async () => {
+it('renders QRCode', () => {
   const { container } = render(<QrCode value="VX.21.5" />);
   expect(container.firstChild).toMatchSnapshot();
   expect(container.querySelector('path[fill="#000000"]')!)

--- a/libs/ui/src/screen.test.tsx
+++ b/libs/ui/src/screen.test.tsx
@@ -4,7 +4,7 @@ import { render } from '@testing-library/react';
 import { Screen } from './screen';
 
 describe('renders Screen', () => {
-  test('with defaults', async () => {
+  test('with defaults', () => {
     const { container } = render(
       <Screen>
         <div>Hello</div> <div>World</div>
@@ -13,7 +13,7 @@ describe('renders Screen', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('with with all non-default options', async () => {
+  test('with with all non-default options', () => {
     const { container } = render(
       <Screen white voterMode={false}>
         <div>Hello</div> <div>World</div>

--- a/libs/ui/src/select.test.tsx
+++ b/libs/ui/src/select.test.tsx
@@ -4,15 +4,15 @@ import { render } from '@testing-library/react';
 import { Select } from './select';
 
 describe('renders Select', () => {
-  test('large', async () => {
+  test('large', () => {
     const { container } = render(<Select large />);
     expect(container.firstChild).toMatchSnapshot();
   });
-  test('small', async () => {
+  test('small', () => {
     const { container } = render(<Select small />);
     expect(container.firstChild).toMatchSnapshot();
   });
-  test('fullWidth', async () => {
+  test('fullWidth', () => {
     const { container } = render(<Select fullWidth />);
     expect(container.firstChild).toMatchSnapshot();
   });

--- a/libs/ui/src/set_clock.test.tsx
+++ b/libs/ui/src/set_clock.test.tsx
@@ -369,6 +369,7 @@ describe('SetClockButton', () => {
     screen.getByText('Wed, Oct 21, 2020, 11:00 AM');
 
     // Save Date and Timezone
+    // eslint-disable-next-line @typescript-eslint/require-await
     await act(async () => {
       fireEvent.click(within(screen.getByTestId('modal')).getByText('Save'));
     });

--- a/libs/ui/src/set_clock.tsx
+++ b/libs/ui/src/set_clock.tsx
@@ -92,7 +92,7 @@ export function PickDateTimeModal({
     },
     [newValue, setNewValue]
   );
-  async function saveDateAndZone() {
+  function saveDateAndZone() {
     onSave(newValue);
   }
 

--- a/libs/ui/src/setup_card_reader_page.test.tsx
+++ b/libs/ui/src/setup_card_reader_page.test.tsx
@@ -4,12 +4,12 @@ import { render } from '@testing-library/react';
 import { SetupCardReaderPage } from './setup_card_reader_page';
 
 describe('renders SetupCardReaderPage', () => {
-  test('with no useEffect trigger as expected', async () => {
+  test('with no useEffect trigger as expected', () => {
     const { container } = render(<SetupCardReaderPage />);
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('triggers useEffect property', async () => {
+  test('triggers useEffect property', () => {
     const triggerFn = jest.fn();
     const { container } = render(
       <SetupCardReaderPage useEffectToggleLargeDisplay={triggerFn} />
@@ -18,7 +18,7 @@ describe('renders SetupCardReaderPage', () => {
     expect(triggerFn).toHaveBeenCalled();
   });
 
-  test('renders SetupCardReaderPage with usePollWorkerLanguage set to false', async () => {
+  test('renders SetupCardReaderPage with usePollWorkerLanguage set to false', () => {
     const { container } = render(
       <SetupCardReaderPage usePollWorkerLanguage={false} />
     );

--- a/libs/ui/src/test_mode.test.tsx
+++ b/libs/ui/src/test_mode.test.tsx
@@ -4,7 +4,7 @@ import { render } from '@testing-library/react';
 import { TestMode } from './test_mode';
 
 describe('renders TestMode', () => {
-  test('as nothing when not in test mode', async () => {
+  test('as nothing when not in test mode', () => {
     const { container } = render(<TestMode isLiveMode />);
     expect(container).toMatchInlineSnapshot(`<div />`);
   });

--- a/libs/ui/src/text.test.tsx
+++ b/libs/ui/src/text.test.tsx
@@ -5,7 +5,7 @@ import 'jest-styled-components';
 import { Text, TextWithLineBreaks } from './text';
 
 describe('renders Text', () => {
-  test('as paragraph tag', async () => {
+  test('as paragraph tag', () => {
     const text = 'paragraph';
     const { getByText } = render(<Text>{text}</Text>);
     const element = getByText(text);
@@ -13,7 +13,7 @@ describe('renders Text', () => {
     expect(element).toMatchSnapshot();
   });
 
-  test('center muted', async () => {
+  test('center muted', () => {
     const { container } = render(
       <Text center muted>
         center muted?
@@ -22,12 +22,12 @@ describe('renders Text', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('displays error style', async () => {
+  test('displays error style', () => {
     const { container } = render(<Text error>Error Text?</Text>);
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('narrow wordBreak warning', async () => {
+  test('narrow wordBreak warning', () => {
     const { container } = render(
       <Text narrow wordBreak warning>
         narrow wordBreak
@@ -36,17 +36,17 @@ describe('renders Text', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('vote icon', async () => {
+  test('vote icon', () => {
     const { container } = render(<Text voteIcon>vote!</Text>);
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('warning icon', async () => {
+  test('warning icon', () => {
     const { container } = render(<Text warningIcon>Warning</Text>);
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('warning icon/vote icon toggle', async () => {
+  test('warning icon/vote icon toggle', () => {
     const toggle = true;
     let { container } = render(
       <Text warningIcon={toggle} voteIcon={!toggle}>
@@ -76,7 +76,7 @@ describe('renders Text', () => {
     });
   });
 
-  test('align left preLine normal italic', async () => {
+  test('align left preLine normal italic', () => {
     const { container } = render(
       <Text left preLine normal italic>
         align left preLine
@@ -85,7 +85,7 @@ describe('renders Text', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('align right nowrap light', async () => {
+  test('align right nowrap light', () => {
     const { container } = render(
       <Text right noWrap light>
         align right nowrap
@@ -94,7 +94,7 @@ describe('renders Text', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('small white bold', async () => {
+  test('small white bold', () => {
     const { container } = render(
       <Text small white bold>
         small white bold

--- a/libs/utils/src/Card/memory_card.ts
+++ b/libs/utils/src/Card/memory_card.ts
@@ -2,6 +2,8 @@ import { ok, Optional, Result, safeParseJson } from '@votingworks/types';
 import { z } from 'zod';
 import { Card, CardApi } from '../types';
 
+/* eslint-disable @typescript-eslint/require-await */
+
 /**
  * Implements the `Card` API with an in-memory implementation.
  */

--- a/libs/utils/src/Hardware/memory_hardware.ts
+++ b/libs/utils/src/Hardware/memory_hardware.ts
@@ -36,6 +36,8 @@ const DEFAULT_PRINTER_IPP_ATTRIBUTES: KioskBrowser.PrinterIppAttributes = {
   ],
 };
 
+/* eslint-disable @typescript-eslint/require-await */
+
 /**
  * Implements the `Hardware` API with an in-memory implementation.
  */

--- a/libs/utils/src/Printer/local_printer.ts
+++ b/libs/utils/src/Printer/local_printer.ts
@@ -1,6 +1,8 @@
 import makeDebug from 'debug';
 import { Printer, PrintOptions } from '../types';
 
+/* eslint-disable @typescript-eslint/require-await */
+
 const debug = makeDebug('utils:printer');
 
 export class LocalPrinter implements Printer {

--- a/libs/utils/src/Storage/local_storage.ts
+++ b/libs/utils/src/Storage/local_storage.ts
@@ -1,6 +1,8 @@
 import { assert } from '../assert';
 import { Storage } from '../types';
 
+/* eslint-disable @typescript-eslint/require-await */
+
 /**
  * Implements the storage API using `localStorage` as the backing store.
  */

--- a/libs/utils/src/Storage/memory_storage.ts
+++ b/libs/utils/src/Storage/memory_storage.ts
@@ -1,5 +1,7 @@
 import { Storage } from '../types';
 
+/* eslint-disable @typescript-eslint/require-await */
+
 /**
  * Implements the storage API for storing objects in memory. Data stored in
  * this object only lasts as long as the program runs.

--- a/libs/utils/src/deferred.test.ts
+++ b/libs/utils/src/deferred.test.ts
@@ -142,7 +142,7 @@ test('queues can reject all past gets', async () => {
   ]);
 });
 
-test('queues disallow mutation after resolveAll', async () => {
+test('queues disallow mutation after resolveAll', () => {
   const q = deferredQueue<number>();
 
   q.resolveAll(1);
@@ -161,7 +161,7 @@ test('queues disallow mutation after resolveAll', async () => {
   );
 });
 
-test('queues disallow mutation after rejectAll', async () => {
+test('queues disallow mutation after rejectAll', () => {
   const q = deferredQueue<number>();
 
   q.rejectAll();

--- a/libs/utils/src/votes.test.ts
+++ b/libs/utils/src/votes.test.ts
@@ -271,7 +271,7 @@ test('tallyVotesByContest filtered by party', () => {
 describe('filterTalliesByParams fallback to empty tally when the proper category is not computed', () => {
   let electionTally: FullElectionTally;
   let election: Election;
-  beforeEach(async () => {
+  beforeEach(() => {
     election =
       electionMultiPartyPrimaryWithDataFiles.electionDefinition.election;
 
@@ -335,7 +335,7 @@ describe('filterTalliesByParams fallback to empty tally when the proper category
 describe('filterTalliesByParams in a typical election', () => {
   let electionTally: FullElectionTally;
   let election: Election;
-  beforeEach(async () => {
+  beforeEach(() => {
     election = electionSample2;
 
     // get the CVRs
@@ -678,7 +678,7 @@ describe('filterTalliesByParams in a primary election', () => {
     },
   ];
 
-  beforeEach(async () => {
+  beforeEach(() => {
     // get the CVRs
     const cvrsFileContents = electionMultiPartyPrimaryWithDataFiles.cvrData;
     const castVoteRecords = parseCvrs(cvrsFileContents);

--- a/services/scan/src/end_to_end_hmpb.test.ts
+++ b/services/scan/src/end_to_end_hmpb.test.ts
@@ -23,6 +23,7 @@ const electionFixturesRoot = join(
 
 jest.mock('./exec', () => ({
   __esModule: true,
+  // eslint-disable-next-line @typescript-eslint/require-await
   default: async (): Promise<{ stdout: string; stderr: string }> => ({
     stdout: '',
     stderr: '',

--- a/services/scan/src/importer.test.ts
+++ b/services/scan/src/importer.test.ts
@@ -243,6 +243,7 @@ test('manually importing files', async () => {
   const frontImagePath = await makeImageFile();
   const backImagePath = await makeImageFile();
 
+  // eslint-disable-next-line @typescript-eslint/require-await
   workerCall.mockImplementation(async (input) => {
     switch (input.action) {
       case 'configure':
@@ -460,6 +461,7 @@ test('importing a sheet normalizes and orders HMPB pages', async () => {
   importer.configure(electionDefinition);
   jest.spyOn(workspace.store, 'addSheet').mockReturnValueOnce('sheet-id');
 
+  // eslint-disable-next-line @typescript-eslint/require-await
   workerCall.mockImplementationOnce(async (input) => {
     expect(input.action).toEqual('configure');
   });
@@ -481,6 +483,7 @@ test('importing a sheet normalizes and orders HMPB pages', async () => {
   const frontImagePath = await makeImageFile();
   const backImagePath = await makeImageFile();
 
+  // eslint-disable-next-line @typescript-eslint/require-await
   workerCall.mockImplementation(async (input) => {
     switch (input.action) {
       case 'configure':
@@ -587,6 +590,7 @@ test('rejects pages that do not match the current precinct', async () => {
   workspace.store.setCurrentPrecinctId(election.precincts[1].id);
   jest.spyOn(workspace.store, 'addSheet').mockReturnValueOnce('sheet-id');
 
+  // eslint-disable-next-line @typescript-eslint/require-await
   workerCall.mockImplementationOnce(async (input) => {
     expect(input.action).toEqual('configure');
   });
@@ -608,6 +612,7 @@ test('rejects pages that do not match the current precinct', async () => {
   const frontImagePath = await makeImageFile();
   const backImagePath = await makeImageFile();
 
+  // eslint-disable-next-line @typescript-eslint/require-await
   workerCall.mockImplementation(async (input) => {
     switch (input.action) {
       case 'configure':
@@ -717,6 +722,7 @@ test('rejects sheets that would not produce a valid CVR', async () => {
   workspace.store.setCurrentPrecinctId(currentPrecinctId);
   jest.spyOn(workspace.store, 'addSheet').mockReturnValueOnce('sheet-id');
 
+  // eslint-disable-next-line @typescript-eslint/require-await
   workerCall.mockImplementationOnce(async (input) => {
     expect(input.action).toEqual('configure');
   });
@@ -739,6 +745,7 @@ test('rejects sheets that would not produce a valid CVR', async () => {
   const frontImagePath = await makeImageFile();
   const backImagePath = await makeImageFile();
 
+  // eslint-disable-next-line @typescript-eslint/require-await
   workerCall.mockImplementation(async (input) => {
     switch (input.action) {
       case 'configure':

--- a/services/scan/src/importer.ts
+++ b/services/scan/src/importer.ts
@@ -475,7 +475,7 @@ export class Importer {
         }
         await this.continueImport({ forceAccept: false });
       } else {
-        const castability = await this.getNextAdjudicationCastability();
+        const castability = this.getNextAdjudicationCastability();
         if (castability) {
           if (castability === Castability.Uncastable) {
             await this.sheetGenerator.rejectSheet();
@@ -487,7 +487,7 @@ export class Importer {
     }
   }
 
-  async getNextAdjudicationCastability(): Promise<Castability | undefined> {
+  getNextAdjudicationCastability(): Castability | undefined {
     const sheet = this.workspace.store.getNextAdjudicationSheet();
     if (sheet) {
       return checkSheetCastability([

--- a/services/scan/src/index.ts
+++ b/services/scan/src/index.ts
@@ -33,6 +33,7 @@ async function getScanner(): Promise<Scanner | undefined> {
       plustekMockServer(client).listen(port);
       return new PlustekScanner(
         {
+          // eslint-disable-next-line @typescript-eslint/require-await
           get: async (): Promise<Result<ScannerClient, Error>> => ok(client),
         },
         SCAN_ALWAYS_HOLD_ON_REJECT

--- a/services/scan/src/interpreter.test.ts
+++ b/services/scan/src/interpreter.test.ts
@@ -121,9 +121,7 @@ test('interprets marks on a HMPB', async () => {
     await readFile(stateOfHamiltonFixtures.ballotPdf),
     { scale: 2 }
   )) {
-    await interpreter.addHmpbTemplate(
-      await interpreter.interpretHmpbTemplate(page)
-    );
+    interpreter.addHmpbTemplate(await interpreter.interpretHmpbTemplate(page));
 
     if (pageNumber === 1) {
       break;
@@ -180,9 +178,7 @@ test('interprets marks on an upside-down HMPB', async () => {
     await readFile(stateOfHamiltonFixtures.ballotPdf),
     { scale: 2 }
   )) {
-    await interpreter.addHmpbTemplate(
-      await interpreter.interpretHmpbTemplate(page)
-    );
+    interpreter.addHmpbTemplate(await interpreter.interpretHmpbTemplate(page));
 
     if (pageNumber === 1) {
       break;
@@ -835,9 +831,7 @@ test('interprets marks in ballots', async () => {
     await readFile(choctaw2020Fixtures.ballotPdf),
     { scale: 2 }
   )) {
-    await interpreter.addHmpbTemplate(
-      await interpreter.interpretHmpbTemplate(page)
-    );
+    interpreter.addHmpbTemplate(await interpreter.interpretHmpbTemplate(page));
   }
 
   {
@@ -932,9 +926,7 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
     await readFile(stateOfHamiltonFixtures.ballotPdf),
     { scale: 2 }
   )) {
-    await interpreter.addHmpbTemplate(
-      await interpreter.interpretHmpbTemplate(page)
-    );
+    interpreter.addHmpbTemplate(await interpreter.interpretHmpbTemplate(page));
 
     if (pageNumber === 3) {
       break;
@@ -1053,7 +1045,7 @@ function withPageNumber(
   }
 }
 
-test('sheetRequiresAdjudication triggers if front or back requires adjudication', async () => {
+test('sheetRequiresAdjudication triggers if front or back requires adjudication', () => {
   const sideYes: InterpretedHmpbPage = {
     ...pageInterpretationBoilerplate,
     adjudicationInfo: {
@@ -1106,7 +1098,7 @@ test('sheetRequiresAdjudication triggers if front or back requires adjudication'
   ).toBe(false);
 });
 
-test('sheetRequiresAdjudication triggers for HMPB/blank page', async () => {
+test('sheetRequiresAdjudication triggers for HMPB/blank page', () => {
   const hmpbNoVotes: InterpretedHmpbPage = {
     ...pageInterpretationBoilerplate,
     adjudicationInfo: {
@@ -1157,7 +1149,7 @@ test('sheetRequiresAdjudication triggers for HMPB/blank page', async () => {
   expect(sheetRequiresAdjudication([blank, blank])).toBe(true);
 });
 
-test('sheetRequiresAdjudication is happy with a BMD ballot', async () => {
+test('sheetRequiresAdjudication is happy with a BMD ballot', () => {
   const bmd: InterpretedBmdPage = {
     type: 'InterpretedBmdPage',
     ballotId: unsafeParse(BallotIdSchema, '42'),

--- a/services/scan/src/interpreter.ts
+++ b/services/scan/src/interpreter.ts
@@ -183,9 +183,9 @@ export class Interpreter {
     this.adjudicationReasons = adjudicationReasons;
   }
 
-  async addHmpbTemplate(
+  addHmpbTemplate(
     layout: BallotPageLayoutWithImage
-  ): Promise<BallotPageLayoutWithImage> {
+  ): BallotPageLayoutWithImage {
     const interpreter = this.getHmpbInterpreter();
     const { metadata } = layout.ballotPageLayout;
 
@@ -203,7 +203,7 @@ export class Interpreter {
         metadata.isTestMode,
         this.testMode
       );
-      await interpreter.addTemplate(layout);
+      interpreter.addTemplate(layout);
     } else {
       debug(
         'template test mode (%s) does not match current test mode (%s), skipping',
@@ -265,7 +265,7 @@ export class Interpreter {
       }
     }
 
-    const bmdResult = await this.interpretBMDFile(ballotImageData);
+    const bmdResult = this.interpretBMDFile(ballotImageData);
 
     if (bmdResult) {
       const bmdMetadata = (bmdResult.interpretation as InterpretedBmdPage)
@@ -340,9 +340,9 @@ export class Interpreter {
     }
   }
 
-  private async interpretBMDFile({
+  private interpretBMDFile({
     qrcode,
-  }: BallotImageData): Promise<InterpretFileResult | undefined> {
+  }: BallotImageData): InterpretFileResult | undefined {
     if (!detect(qrcode.data)) {
       return;
     }

--- a/services/scan/src/loop_scanner.ts
+++ b/services/scan/src/loop_scanner.ts
@@ -79,6 +79,8 @@ export function parseBatchesFromEnv(env?: string): Batch[] | undefined {
   return parseBatches(env.split(','));
 }
 
+/* eslint-disable @typescript-eslint/require-await */
+
 /**
  * Provides mock scanning services by copying the same set of images over and
  * over again on demand.

--- a/services/scan/src/scanners/fujitsu.test.ts
+++ b/services/scan/src/scanners/fujitsu.test.ts
@@ -44,7 +44,7 @@ test('fujitsu scanner calls scanimage with fujitsu device type', async () => {
   await expect(sheets.scanSheet()).resolves.toBeUndefined();
 });
 
-test('fujitsu scanner can scan with letter size', async () => {
+test('fujitsu scanner can scan with letter size', () => {
   const scanimage = makeMockChildProcess();
   const scanner = new FujitsuScanner({
     logger: new Logger(LogSource.VxScanService),
@@ -67,7 +67,7 @@ test('fujitsu scanner can scan with letter size', async () => {
   );
 });
 
-test('fujitsu scanner can scan with legal size', async () => {
+test('fujitsu scanner can scan with legal size', () => {
   const scanimage = makeMockChildProcess();
   const scanner = new FujitsuScanner({
     logger: new Logger(LogSource.VxScanService),
@@ -90,7 +90,7 @@ test('fujitsu scanner can scan with legal size', async () => {
   );
 });
 
-test('fujitsu scanner does not specify a mode by default', async () => {
+test('fujitsu scanner does not specify a mode by default', () => {
   const scanimage = makeMockChildProcess();
   const scanner = new FujitsuScanner({
     logger: new Logger(LogSource.VxScanService),
@@ -113,7 +113,7 @@ test('fujitsu scanner does not specify a mode by default', async () => {
   );
 });
 
-test('fujitsu scanner can scan with lineart mode', async () => {
+test('fujitsu scanner can scan with lineart mode', () => {
   const scanimage = makeMockChildProcess();
   const scanner = new FujitsuScanner({
     logger: new Logger(LogSource.VxScanService),
@@ -137,7 +137,7 @@ test('fujitsu scanner can scan with lineart mode', async () => {
   );
 });
 
-test('fujitsu scanner can scan with gray mode', async () => {
+test('fujitsu scanner can scan with gray mode', () => {
   const scanimage = makeMockChildProcess();
   const scanner = new FujitsuScanner({
     logger: new Logger(LogSource.VxScanService),
@@ -161,7 +161,7 @@ test('fujitsu scanner can scan with gray mode', async () => {
   );
 });
 
-test('fujitsu scanner can scan with color mode', async () => {
+test('fujitsu scanner can scan with color mode', () => {
   const scanimage = makeMockChildProcess();
   const scanner = new FujitsuScanner({
     logger: new Logger(LogSource.VxScanService),

--- a/services/scan/src/scanners/fujitsu.ts
+++ b/services/scan/src/scanners/fujitsu.ts
@@ -50,6 +50,7 @@ export class FujitsuScanner implements Scanner {
     this.logger = logger;
   }
 
+  // eslint-disable-next-line @typescript-eslint/require-await
   async getStatus(): Promise<ScannerStatus> {
     return ScannerStatus.Unknown;
   }
@@ -184,14 +185,17 @@ export class FujitsuScanner implements Scanner {
         return results.get();
       },
 
+      // eslint-disable-next-line @typescript-eslint/require-await
       acceptSheet: async (): Promise<boolean> => {
         return true;
       },
 
+      // eslint-disable-next-line @typescript-eslint/require-await
       reviewSheet: async (): Promise<boolean> => {
         return false;
       },
 
+      // eslint-disable-next-line @typescript-eslint/require-await
       rejectSheet: async (): Promise<boolean> => {
         return false;
       },
@@ -218,6 +222,7 @@ export class FujitsuScanner implements Scanner {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/require-await
   async calibrate(): Promise<boolean> {
     return false;
   }

--- a/services/scan/src/scanners/plustek.ts
+++ b/services/scan/src/scanners/plustek.ts
@@ -497,6 +497,7 @@ export function withReconnect(
   };
 
   const wrapperProvider: ScannerClientProvider = {
+    // eslint-disable-next-line @typescript-eslint/require-await
     get: async () => ok(wrapper),
   };
 

--- a/services/scan/src/server.ts
+++ b/services/scan/src/server.ts
@@ -104,7 +104,7 @@ export function buildApp({ store, importer }: AppOptions): Application {
 
   app.get<NoParams, GetElectionConfigResponse>(
     '/config/election',
-    async (request, response) => {
+    (request, response) => {
       const electionDefinition = store.getElectionDefinition();
 
       if (request.accepts('application/octet-stream')) {
@@ -240,7 +240,7 @@ export function buildApp({ store, importer }: AppOptions): Application {
 
   app.get<NoParams, GetTestModeConfigResponse>(
     '/config/testMode',
-    async (_request, response) => {
+    (_request, response) => {
       const testMode = store.getTestMode();
       response.json({ status: 'ok', testMode });
     }
@@ -270,7 +270,7 @@ export function buildApp({ store, importer }: AppOptions): Application {
 
   app.get<NoParams, GetCurrentPrecinctConfigResponse>(
     '/config/precinct',
-    async (_request, response) => {
+    (_request, response) => {
       const precinctId = store.getCurrentPrecinctId();
       response.json({ status: 'ok', precinctId });
     }
@@ -280,7 +280,7 @@ export function buildApp({ store, importer }: AppOptions): Application {
     NoParams,
     PutCurrentPrecinctConfigResponse,
     PutCurrentPrecinctConfigRequest
-  >('/config/precinct', async (request, response) => {
+  >('/config/precinct', (request, response) => {
     const bodyParseResult = safeParse(
       PutCurrentPrecinctConfigRequestSchema,
       request.body
@@ -301,7 +301,7 @@ export function buildApp({ store, importer }: AppOptions): Application {
 
   app.delete<NoParams, DeleteCurrentPrecinctConfigResponse>(
     '/config/precinct',
-    async (_request, response) => {
+    (_request, response) => {
       store.setCurrentPrecinctId(undefined);
       response.json({ status: 'ok' });
     }
@@ -309,7 +309,7 @@ export function buildApp({ store, importer }: AppOptions): Application {
 
   app.get<NoParams, GetMarkThresholdOverridesConfigResponse>(
     '/config/markThresholdOverrides',
-    async (_request, response) => {
+    (_request, response) => {
       const markThresholdOverrides = store.getMarkThresholdOverrides();
       response.json({ status: 'ok', markThresholdOverrides });
     }
@@ -562,7 +562,7 @@ export function buildApp({ store, importer }: AppOptions): Application {
 
   app.post<NoParams, ExportResponse, ExportRequest>(
     '/scan/export',
-    async (_request, response) => {
+    (_request, response) => {
       const cvrs = importer.doExport();
       store.setCvrsAsBackedUp();
       response.set('Content-Type', 'text/plain; charset=utf-8');
@@ -600,29 +600,23 @@ export function buildApp({ store, importer }: AppOptions): Application {
     }
   );
 
-  app.get(
-    '/scan/hmpb/ballot/:sheetId/:side/image',
-    async (request, response) => {
-      const { sheetId, side } = request.params;
+  app.get('/scan/hmpb/ballot/:sheetId/:side/image', (request, response) => {
+    const { sheetId, side } = request.params;
 
-      if (
-        typeof sheetId !== 'string' ||
-        (side !== 'front' && side !== 'back')
-      ) {
-        response.status(404);
-        return;
-      }
-
-      response.redirect(
-        301,
-        `/scan/hmpb/ballot/${sheetId}/${side}/image/normalized`
-      );
+    if (typeof sheetId !== 'string' || (side !== 'front' && side !== 'back')) {
+      response.status(404);
+      return;
     }
-  );
+
+    response.redirect(
+      301,
+      `/scan/hmpb/ballot/${sheetId}/${side}/image/normalized`
+    );
+  });
 
   app.get(
     '/scan/hmpb/ballot/:sheetId/:side/image/:version',
-    async (request, response) => {
+    (request, response) => {
       const { sheetId, side, version } = request.params;
 
       if (
@@ -643,7 +637,7 @@ export function buildApp({ store, importer }: AppOptions): Application {
     }
   );
 
-  app.delete('/scan/batch/:batchId', async (request, response) => {
+  app.delete('/scan/batch/:batchId', (request, response) => {
     if (store.deleteBatch(request.params.batchId)) {
       response.json({ status: 'ok' });
     } else {
@@ -653,7 +647,7 @@ export function buildApp({ store, importer }: AppOptions): Application {
 
   app.get<NoParams, GetNextReviewSheetResponse>(
     '/scan/hmpb/review/next-sheet',
-    async (_request, response) => {
+    (_request, response) => {
       const sheet = store.getNextAdjudicationSheet();
 
       if (sheet) {
@@ -725,7 +719,7 @@ export function buildApp({ store, importer }: AppOptions): Application {
     }
   );
 
-  app.get('/scan/backup', async (_request, response) => {
+  app.get('/scan/backup', (_request, response) => {
     const electionDefinition = store.getElectionDefinition();
 
     if (!electionDefinition) {

--- a/services/scan/src/util/stream_lines.test.ts
+++ b/services/scan/src/util/stream_lines.test.ts
@@ -2,7 +2,7 @@ import EventEmitter from 'events';
 import { Readable } from 'stream';
 import { StreamLines } from './stream_lines';
 
-test('streams lines from an input stream', async () => {
+test('streams lines from an input stream', () => {
   const onLine = jest.fn();
   const read = jest.fn();
   const input = new EventEmitter() as Readable;

--- a/services/scan/src/workers/echo.ts
+++ b/services/scan/src/workers/echo.ts
@@ -8,6 +8,7 @@ export type Output = unknown;
 /**
  * Simple worker that simply echoes the input as output.
  */
+// eslint-disable-next-line @typescript-eslint/require-await
 export async function call<I extends Input & Output>(input: I): Promise<I> {
   return input;
 }

--- a/services/scan/src/workers/interpret_vx.ts
+++ b/services/scan/src/workers/interpret_vx.ts
@@ -71,7 +71,7 @@ export async function configure(store: Store): Promise<void> {
   for (const [pdf, layouts] of templates) {
     for await (const { page, pageNumber } of pdfToImages(pdf, { scale: 2 })) {
       const ballotPageLayout = layouts[pageNumber - 1];
-      await interpreter.addHmpbTemplate({
+      interpreter.addHmpbTemplate({
         ballotPageLayout,
         imageData: page,
       });

--- a/services/scan/src/workers/pool.test.ts
+++ b/services/scan/src/workers/pool.test.ts
@@ -188,30 +188,30 @@ test('callAll sends a message to all workers, even if they are busy at first', a
   expect(await callAllPromise).toEqual([-99, -98]);
 });
 
-test('releasing a worker before starting is not allowed', async () => {
+test('releasing a worker before starting is not allowed', () => {
   const ops = makeMockWorkerOps() as jest.Mocked<WorkerOps<number>>;
   const worker = new EventEmitter();
   ops.start.mockReturnValueOnce(worker);
 
   const pool = new WorkerPool<number, number>(ops, 1);
-  await expect(pool['releaseWorker'](worker, 'test')).rejects.toThrowError(
+  expect(() => pool['releaseWorker'](worker, 'test')).toThrowError(
     'not yet started'
   );
 });
 
-test('releasing a non-claimed worker is not allowed', async () => {
+test('releasing a non-claimed worker is not allowed', () => {
   const ops = makeMockWorkerOps() as jest.Mocked<WorkerOps<number>>;
   const worker = new EventEmitter();
   ops.start.mockReturnValueOnce(worker);
 
   const pool = new WorkerPool<number, number>(ops, 1);
   pool.start();
-  await expect(pool['releaseWorker'](worker, 'test')).rejects.toThrowError(
+  expect(() => pool['releaseWorker'](worker, 'test')).toThrowError(
     'worker is not currently claimed'
   );
 });
 
-test('releasing a non-owned worker is not allowed', async () => {
+test('releasing a non-owned worker is not allowed', () => {
   const ops = makeMockWorkerOps() as jest.Mocked<WorkerOps<number>>;
   const worker = new EventEmitter();
   const anotherWorker = new EventEmitter();
@@ -219,9 +219,9 @@ test('releasing a non-owned worker is not allowed', async () => {
 
   const pool = new WorkerPool<number, number>(ops, 1);
   pool.start();
-  await expect(
-    pool['releaseWorker'](anotherWorker, 'test')
-  ).rejects.toThrowError('worker is not owned by this instance');
+  expect(() => pool['releaseWorker'](anotherWorker, 'test')).toThrowError(
+    'worker is not owned by this instance'
+  );
 });
 
 test('child process workers work', async () => {

--- a/services/scan/src/workers/pool/worker_pool.ts
+++ b/services/scan/src/workers/pool/worker_pool.ts
@@ -108,7 +108,7 @@ export class WorkerPool<I, O, W extends EventEmitter = EventEmitter> {
     return worker;
   }
 
-  private async releaseWorker(worker: W, traceId: string): Promise<void> {
+  private releaseWorker(worker: W, traceId: string): void {
     const { workers, claimedWorkers } = this;
 
     if (!workers || !claimedWorkers) {
@@ -238,7 +238,7 @@ export class WorkerPool<I, O, W extends EventEmitter = EventEmitter> {
     } finally {
       worker.off('message', resolve);
       worker.off('error', reject);
-      await this.releaseWorker(worker, traceId);
+      this.releaseWorker(worker, traceId);
     }
   }
 }

--- a/services/scan/test/util/mocks.ts
+++ b/services/scan/test/util/mocks.ts
@@ -132,6 +132,7 @@ export function makeMockScanner(): MockScanner {
         reviewSheet: jest.fn(),
         rejectSheet: jest.fn(),
 
+        // eslint-disable-next-line @typescript-eslint/require-await
         scanSheet: async (): Promise<SheetOf<string>> => {
           const step = session.getStep(stepIndex);
           stepIndex += 1;
@@ -148,12 +149,14 @@ export function makeMockScanner(): MockScanner {
           }
         },
 
+        // eslint-disable-next-line @typescript-eslint/require-await
         endBatch: async (): Promise<void> => {
           stepIndex = Infinity;
         },
       };
     },
 
+    // eslint-disable-next-line @typescript-eslint/require-await
     async calibrate(): Promise<boolean> {
       return true;
     },


### PR DESCRIPTION


## Overview
<!-- add a link to a Github Issue here -->
Fixes a bunch of violations, including those that cascaded from removing the `async` on functions making the calls of those functions no longer requiring `await` etc.

I marked a bunch of `async` without `await` as ignored because they were implementing an interface either as a mock or fake version of something. Others were ignored because of async issues in tests that it was easier to ignore for now.

Closes #1759 

## Demo Video or Screenshot
n/a

## Testing Plan 
Automated.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
