### PR TITLE
feat(election-manager): add basic screen for write-ins tab

### DIFF
--- a/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
+++ b/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
@@ -63,6 +63,13 @@ exports[`L&A (logic and accuracy) flow 1`] = `
           role="option"
           type="button"
         >
+          Write-Ins
+        </button>
+        <button
+          class="sc-jrAGrp iWxjsY"
+          role="option"
+          type="button"
+        >
           Tally
         </button>
         <button
@@ -71,13 +78,6 @@ exports[`L&A (logic and accuracy) flow 1`] = `
           type="button"
         >
           Advanced
-        </button>
-        <button
-          class="sc-jrAGrp iWxjsY"
-          role="option"
-          type="button"
-        >
-          Write-Ins
         </button>
       </div>
       <div
@@ -324,6 +324,13 @@ exports[`L&A (logic and accuracy) flow 2`] = `
           role="option"
           type="button"
         >
+          Write-Ins
+        </button>
+        <button
+          class="sc-jrAGrp iWxjsY"
+          role="option"
+          type="button"
+        >
           Tally
         </button>
         <button
@@ -332,13 +339,6 @@ exports[`L&A (logic and accuracy) flow 2`] = `
           type="button"
         >
           Advanced
-        </button>
-        <button
-          class="sc-jrAGrp iWxjsY"
-          role="option"
-          type="button"
-        >
-          Write-Ins
         </button>
       </div>
       <div
@@ -375,7 +375,7 @@ exports[`L&A (logic and accuracy) flow 2`] = `
           class="sc-crrsfI vnUTr"
         >
           <h1
-            class="sc-ikJzcn hrFjNm"
+            class="sc-jJoQpE dXTmzO"
             style="margin-bottom: 0.75em; margin-top: 0.25em;"
           >
             
@@ -503,7 +503,7 @@ exports[`L&A (logic and accuracy) flow 2`] = `
     class="print-only"
   >
     <section
-      class="sc-kLwgWK fnXcLU"
+      class="sc-ikJzcn gFcHpk"
     >
       <img
         alt="VotingWorks logo"
@@ -521,7 +521,7 @@ exports[`L&A (logic and accuracy) flow 2`] = `
         class="sc-crrsfI kVGBFI"
       >
         <h1
-          class="sc-ikJzcn hrFjNm"
+          class="sc-jJoQpE dXTmzO"
           style="margin-bottom: 0.75em; margin-top: 0.25em;"
         >
           
@@ -547,7 +547,7 @@ exports[`L&A (logic and accuracy) flow 2`] = `
         </p>
       </div>
       <div
-        class="sc-jJoQpE Icimc"
+        class="sc-hiCivh hqTCjy"
       >
         <div
           class="sc-hGPAah dymfDz"
@@ -1648,7 +1648,7 @@ House Bill 1796 - Flag Referendum
 
 exports[`tabulating CVRs 1`] = `
 <section
-  class="sc-kLwgWK fnXcLU"
+  class="sc-ikJzcn gFcHpk"
   data-testid="election-full-tally-report"
 >
   <img
@@ -1681,10 +1681,10 @@ exports[`tabulating CVRs 1`] = `
     </p>
   </div>
   <div
-    class="sc-jJoQpE Icimc"
+    class="sc-hiCivh hqTCjy"
   >
     <div
-      class="sc-iAKVOt kfoWZP"
+      class="sc-efQUeY fyTYfm"
     >
       <h3>
         Ballots by Voting Method
@@ -2839,7 +2839,7 @@ House Bill 1796 - Flag Referendum
 
 exports[`tabulating CVRs with SEMS file 1`] = `
 <section
-  class="sc-kLwgWK fnXcLU"
+  class="sc-ikJzcn gFcHpk"
   data-testid="election-full-tally-report"
 >
   <img
@@ -2872,10 +2872,10 @@ exports[`tabulating CVRs with SEMS file 1`] = `
     </p>
   </div>
   <div
-    class="sc-jJoQpE Icimc"
+    class="sc-hiCivh hqTCjy"
   >
     <div
-      class="sc-iAKVOt kfoWZP"
+      class="sc-efQUeY fyTYfm"
     >
       <h3>
         Ballots by Voting Method

--- a/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
+++ b/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
@@ -72,6 +72,13 @@ exports[`L&A (logic and accuracy) flow 1`] = `
         >
           Advanced
         </button>
+        <button
+          class="sc-jrAGrp iWxjsY"
+          role="option"
+          type="button"
+        >
+          Write-Ins
+        </button>
       </div>
       <div
         class="sc-fubCfw kBiVZq"
@@ -325,6 +332,13 @@ exports[`L&A (logic and accuracy) flow 2`] = `
           type="button"
         >
           Advanced
+        </button>
+        <button
+          class="sc-jrAGrp iWxjsY"
+          role="option"
+          type="button"
+        >
+          Write-Ins
         </button>
       </div>
       <div

--- a/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
+++ b/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
@@ -375,7 +375,7 @@ exports[`L&A (logic and accuracy) flow 2`] = `
           class="sc-crrsfI vnUTr"
         >
           <h1
-            class="sc-jJoQpE dXTmzO"
+            class="sc-ikJzcn hrFjNm"
             style="margin-bottom: 0.75em; margin-top: 0.25em;"
           >
             
@@ -503,7 +503,7 @@ exports[`L&A (logic and accuracy) flow 2`] = `
     class="print-only"
   >
     <section
-      class="sc-ikJzcn gFcHpk"
+      class="sc-kLwgWK fnXcLU"
     >
       <img
         alt="VotingWorks logo"
@@ -521,7 +521,7 @@ exports[`L&A (logic and accuracy) flow 2`] = `
         class="sc-crrsfI kVGBFI"
       >
         <h1
-          class="sc-jJoQpE dXTmzO"
+          class="sc-ikJzcn hrFjNm"
           style="margin-bottom: 0.75em; margin-top: 0.25em;"
         >
           
@@ -547,7 +547,7 @@ exports[`L&A (logic and accuracy) flow 2`] = `
         </p>
       </div>
       <div
-        class="sc-hiCivh hqTCjy"
+        class="sc-jJoQpE Icimc"
       >
         <div
           class="sc-hGPAah dymfDz"
@@ -1648,7 +1648,7 @@ House Bill 1796 - Flag Referendum
 
 exports[`tabulating CVRs 1`] = `
 <section
-  class="sc-ikJzcn gFcHpk"
+  class="sc-kLwgWK fnXcLU"
   data-testid="election-full-tally-report"
 >
   <img
@@ -1681,10 +1681,10 @@ exports[`tabulating CVRs 1`] = `
     </p>
   </div>
   <div
-    class="sc-hiCivh hqTCjy"
+    class="sc-jJoQpE Icimc"
   >
     <div
-      class="sc-efQUeY fyTYfm"
+      class="sc-iAKVOt kfoWZP"
     >
       <h3>
         Ballots by Voting Method
@@ -2839,7 +2839,7 @@ House Bill 1796 - Flag Referendum
 
 exports[`tabulating CVRs with SEMS file 1`] = `
 <section
-  class="sc-ikJzcn gFcHpk"
+  class="sc-kLwgWK fnXcLU"
   data-testid="election-full-tally-report"
 >
   <img
@@ -2872,10 +2872,10 @@ exports[`tabulating CVRs with SEMS file 1`] = `
     </p>
   </div>
   <div
-    class="sc-hiCivh hqTCjy"
+    class="sc-jJoQpE Icimc"
   >
     <div
-      class="sc-efQUeY fyTYfm"
+      class="sc-iAKVOt kfoWZP"
     >
       <h3>
         Ballots by Voting Method

--- a/frontends/election-manager/src/components/election_manager.tsx
+++ b/frontends/election-manager/src/components/election_manager.tsx
@@ -33,6 +33,7 @@ import { MachineLockedScreen } from '../screens/machine_locked_screen';
 import { InvalidCardScreen } from '../screens/invalid_card_screen';
 import { UnlockMachineScreen } from '../screens/unlock_machine_screen';
 import { AdvancedScreen } from '../screens/advanced_screen';
+import { WriteInsScreen } from '../screens/write_ins_screen';
 import { LogicAndAccuracyScreen } from '../screens/logic_and_accuracy_screen';
 
 export function ElectionManager(): JSX.Element {
@@ -127,6 +128,9 @@ export function ElectionManager(): JSX.Element {
       </Route>
       <Route exact path={routerPaths.manualDataImport}>
         <ManualDataImportIndexScreen />
+      </Route>
+      <Route exact path={routerPaths.writeIns}>
+        <WriteInsScreen />
       </Route>
       <Route
         path={routerPaths.manualDataImportForPrecinct({

--- a/frontends/election-manager/src/components/navigation_screen.tsx
+++ b/frontends/election-manager/src/components/navigation_screen.tsx
@@ -87,6 +87,13 @@ export function NavigationScreen({
               >
                 Advanced
               </LinkButton>
+              <LinkButton
+                small
+                to={routerPaths.writeIns}
+                className={isActiveSection(routerPaths.writeIns)}
+              >
+                Write-Ins
+              </LinkButton>
             </React.Fragment>
           ) : (
             <React.Fragment>

--- a/frontends/election-manager/src/components/navigation_screen.tsx
+++ b/frontends/election-manager/src/components/navigation_screen.tsx
@@ -75,6 +75,13 @@ export function NavigationScreen({
               </LinkButton>
               <LinkButton
                 small
+                to={routerPaths.writeIns}
+                className={isActiveSection(routerPaths.writeIns)}
+              >
+                Write-Ins
+              </LinkButton>
+              <LinkButton
+                small
                 to={routerPaths.tally}
                 className={isActiveSection(routerPaths.tally)}
               >
@@ -86,13 +93,6 @@ export function NavigationScreen({
                 className={isActiveSection(routerPaths.advanced)}
               >
                 Advanced
-              </LinkButton>
-              <LinkButton
-                small
-                to={routerPaths.writeIns}
-                className={isActiveSection(routerPaths.writeIns)}
-              >
-                Write-Ins
               </LinkButton>
             </React.Fragment>
           ) : (

--- a/frontends/election-manager/src/router_paths.ts
+++ b/frontends/election-manager/src/router_paths.ts
@@ -54,4 +54,5 @@ export const routerPaths = {
   testDeckTallyReports: '/logic-and-accuracy/test-deck-tally-reports',
   testDeckTallyReport: ({ precinctId }: PrecinctReportScreenProps): string =>
     `/logic-and-accuracy/test-deck-tally-reports/${precinctId}`,
+  writeIns: '/write-ins',
 } as const;

--- a/frontends/election-manager/src/screens/write_ins_screen.tsx
+++ b/frontends/election-manager/src/screens/write_ins_screen.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import { NavigationScreen } from '../components/navigation_screen';
+import { Prose } from '../components/prose';
+
+export function WriteInsScreen(): JSX.Element {
+  return (
+    <React.Fragment>
+      <NavigationScreen mainChildFlex>
+        <Prose maxWidth={false}>
+          <h1>Write-Ins</h1>
+        </Prose>
+      </NavigationScreen>
+    </React.Fragment>
+  );
+}


### PR DESCRIPTION
## Overview

Closes #1770 

Sets up a blank screen for the write-ins tab on VxAdmin.

## Demo Video or Screenshot
<img width="500" alt="Screen Shot 2022-05-03 at 9 04 10 AM" src="https://user-images.githubusercontent.com/7584833/166457938-8c6f6e8c-c4d0-426d-8c54-adbf05e4f966.png">

## Testing Plan 

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
