### PR TITLE
Add fullscreen modal variant

### DIFF
--- a/libs/ui/src/modal.test.tsx
+++ b/libs/ui/src/modal.test.tsx
@@ -35,7 +35,7 @@ describe('Modal', () => {
       <div
         aria-label="Alert Modal"
         aria-modal="true"
-        class="sc-gsDJrp blYTQX ReactModal__Content _"
+        class="sc-gsDJrp kSjhGM ReactModal__Content _"
         data-testid="modal"
         role="alertdialog"
         tabindex="-1"
@@ -67,7 +67,7 @@ describe('Modal', () => {
       <div
         aria-label="Alert Modal"
         aria-modal="true"
-        class="sc-gsDJrp jZBRml ReactModal__Content _"
+        class="sc-gsDJrp hCzYbG ReactModal__Content _"
         data-testid="modal"
         role="alertdialog"
         tabindex="-1"

--- a/libs/ui/src/modal.test.tsx
+++ b/libs/ui/src/modal.test.tsx
@@ -81,6 +81,28 @@ describe('Modal', () => {
     `);
   });
 
+  it('can configure fullscreen', () => {
+    render(<Modal fullscreen content="Do you want to do the thing?" />);
+
+    const modal = screen.getByRole('alertdialog');
+    expect(modal).toMatchInlineSnapshot(`
+      <div
+        aria-label="Alert Modal"
+        aria-modal="true"
+        class="sc-gsDJrp hXVzBN ReactModal__Content _"
+        data-testid="modal"
+        role="alertdialog"
+        tabindex="-1"
+      >
+        <div
+          class="sc-hKwCoD kFWWdL"
+        >
+          Do you want to do the thing?
+        </div>
+      </div>
+    `);
+  });
+
   it('handles overlay click', () => {
     const onOverlayClick = jest.fn();
     const { baseElement } = render(

--- a/libs/ui/src/modal.tsx
+++ b/libs/ui/src/modal.tsx
@@ -14,6 +14,7 @@ export enum ModalWidth {
 }
 
 interface ReactModalContentInterface {
+  fullscreen?: boolean;
   modalWidth?: ModalWidth;
 }
 const ReactModalContent = styled('div')<ReactModalContentInterface>`
@@ -32,15 +33,20 @@ const ReactModalContent = styled('div')<ReactModalContentInterface>`
   -webkit-overflow-scrolling: touch;
   @media (min-width: 480px) {
     position: static;
-    border-radius: 0.25rem;
-    max-width: ${({ modalWidth = ModalWidth.Standard }) => modalWidth};
+    border-radius: ${({ fullscreen }) => (fullscreen ? '0' : '0.25rem')};
+    max-width: ${({ fullscreen, modalWidth = ModalWidth.Standard }) =>
+      fullscreen ? '100%' : modalWidth};
+    height: ${({ fullscreen }) => (fullscreen ? '100%' : 'auto')};
   }
   @media print {
     display: none;
   }
 `;
 
-const ReactModalOverlay = styled.div`
+interface ReactModalOverlayInterface {
+  fullscreen?: boolean;
+}
+const ReactModalOverlay = styled('div')<ReactModalOverlayInterface>`
   display: flex;
   position: fixed;
   top: 0;
@@ -50,7 +56,7 @@ const ReactModalOverlay = styled.div`
   z-index: 999; /* Should be above all default UI */
   background: rgba(0, 0, 0, 0.75);
   @media (min-width: 480px) {
-    padding: 0.5rem;
+    padding: ${({ fullscreen }) => (fullscreen ? '0' : '0.5rem')};
   }
   @media print {
     display: none;
@@ -97,6 +103,7 @@ interface Props {
   actions?: ReactNode;
   onAfterOpen?: () => void;
   onOverlayClick?: () => void;
+  fullscreen?: boolean;
   modalWidth?: ModalWidth;
 }
 
@@ -116,6 +123,7 @@ export function Modal({
   ariaLabel = 'Alert Modal',
   centerContent,
   content,
+  fullscreen = false,
   ariaHideApp = true,
   onAfterOpen = focusModalAudio,
   onOverlayClick,
@@ -138,12 +146,18 @@ export function Modal({
       onRequestClose={onOverlayClick}
       testId="modal"
       contentElement={(props, children) => (
-        <ReactModalContent modalWidth={modalWidth} {...props}>
+        <ReactModalContent
+          modalWidth={modalWidth}
+          fullscreen={fullscreen}
+          {...props}
+        >
           {children}
         </ReactModalContent>
       )}
       overlayElement={(props, contentElement) => (
-        <ReactModalOverlay {...props}>{contentElement}</ReactModalOverlay>
+        <ReactModalOverlay fullscreen={fullscreen} {...props}>
+          {contentElement}
+        </ReactModalOverlay>
       )}
       // className properties are required to prevent react-modal
       // from overriding the styles defined in contentElement and overlayElement


### PR DESCRIPTION
## Overview
#1772 

## Demo Video or Screenshot
Non-fullscreen modal
<img width="300" alt="Screen Shot 2022-05-03 at 3 28 40 PM" src="https://user-images.githubusercontent.com/7584833/166552960-f813721f-af72-4a8b-a67d-7616a849f06f.png">

Fullscreen modal
<img width="600" alt="Screen Shot 2022-05-03 at 3 39 48 PM" src="https://user-images.githubusercontent.com/7584833/166553246-d142aa4b-713e-45d4-9133-258beae956b9.png">

## Testing Plan 
Manually QAed the new fullscreen variant and other modals. I added a test to `modal.test.tsx` to satisfy our coverage requirements, but we don't get much real utility out of it. A screenshot test would be awesome here, but afaict we don't have those yet and that is out-of-scope for this issue.

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates]