### PR TITLE
Remove poll worker language from VxAdmin and add to VxMark

### DIFF
--- a/frontends/bmd/src/app_root.tsx
+++ b/frontends/bmd/src/app_root.tsx
@@ -1208,7 +1208,6 @@ export function AppRoot({
     return (
       <SetupCardReaderPage
         useEffectToggleLargeDisplay={useEffectToggleLargeDisplay}
-        usePollWorkerLanguage={false}
       />
     );
   }

--- a/frontends/election-manager/src/components/election_manager.tsx
+++ b/frontends/election-manager/src/components/election_manager.tsx
@@ -49,7 +49,7 @@ export function ElectionManager(): JSX.Element {
   const election = electionDefinition?.election;
 
   if (!hasCardReaderAttached) {
-    return <SetupCardReaderPage />;
+    return <SetupCardReaderPage usePollWorkerLanguage={false} />;
   }
 
   if (!election || !configuredAt) {


### PR DESCRIPTION
## Overview
Closes #1755

#1556 removed poll worker language from the card reader setup page in VxCentralScan and _VxMark_, rather than VxCentralScan and VxAdmin. This change adds poll worker language back on VxMark and removes it on VxAdmin.

## Demo Video or Screenshot

With Poll Worker Language:
![Screen Shot 2022-05-04 at 1 52 53 PM](https://user-images.githubusercontent.com/37960853/166824243-9d81c019-36eb-48cb-aef4-d2baa4a1eeed.png)

Without Poll Worker Language:
![Screen Shot 2022-05-04 at 1 53 30 PM](https://user-images.githubusercontent.com/37960853/166824248-703201ac-9b5c-48ce-afed-f95414de3db1.png)


## Testing Plan

The snapshot tests from #1556 do not need to be changed. There are no tests confirming the correct version of the language appears in each app - please let me know if that seems necessary.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
