### PR TITLE
feat(libs/types) Add util for getting party abbrevation

### DIFF
--- a/libs/types/src/election.test.ts
+++ b/libs/types/src/election.test.ts
@@ -18,6 +18,7 @@ import {
   getContestsFromIds,
   getEitherNeitherContests,
   getElectionLocales,
+  getPartyAbbrevationByPartyId,
   getPartyFullNameFromBallotStyle,
   getPartyPrimaryAdjectiveFromBallotStyle,
   getPrecinctById,
@@ -150,6 +151,22 @@ test('can get a party primary adjective from ballot style', () => {
       election: primaryElection,
     })
   ).toEqual('Democratic');
+});
+
+test('can get a party abbreviation by party ID', () => {
+  expect(
+    getPartyAbbrevationByPartyId({
+      partyId: primaryElection.parties[0].id,
+      election: { ...primaryElection },
+    })
+  ).toEqual('D');
+
+  expect(
+    getPartyAbbrevationByPartyId({
+      partyId: primaryElection.parties[0].id,
+      election: { ...primaryElection, parties: [] },
+    })
+  ).toEqual('');
 });
 
 test('can get a party full name from ballot style', () => {

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -1499,6 +1499,21 @@ export function getPartyFullNameFromBallotStyle({
   return party?.fullName ?? '';
 }
 
+/**
+ * Gets the abbreviation of the political party for a primary election,
+ * e.g. "R" or "D".
+ */
+export function getPartyAbbrevationByPartyId({
+  partyId,
+  election,
+}: {
+  partyId: PartyId;
+  election: Election;
+}): string {
+  const party = election.parties.find((p) => p.id === partyId);
+  return party?.abbrev ?? '';
+}
+
 export function getDistrictIdsForPartyId(
   election: Election,
   partyId: PartyId


### PR DESCRIPTION
## Overview
Closes #1794 

## Demo Video or Screenshot

## Testing Plan 
Added a unit test, manually QA'd in a different write-in adjudication branch.

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
