### PR TITLE
feat(election-manager): add Adjudicate buttons to write-ins screen

### DIFF
--- a/frontends/election-manager/src/components/write_ins_transcription_screen.tsx
+++ b/frontends/election-manager/src/components/write_ins_transcription_screen.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import { Screen } from '@votingworks/ui';
+import { Main, MainChild } from './main';
+
+export function WriteInsTranscriptionScreen(): JSX.Element {
+  return (
+    <Screen>
+      <Main padded>
+        <MainChild>
+          <h1>Fullscreen Modal Test</h1>
+        </MainChild>
+      </Main>
+    </Screen>
+  );
+}

--- a/frontends/election-manager/src/screens/write_ins_screen.test.tsx
+++ b/frontends/election-manager/src/screens/write_ins_screen.test.tsx
@@ -1,0 +1,12 @@
+import { screen } from '@testing-library/react';
+import React from 'react';
+import { renderInAppContext } from '../../test/render_in_app_context';
+import { WriteInsScreen } from './write_ins_screen';
+
+test('write-ins screen', () => {
+  renderInAppContext(<WriteInsScreen />);
+  screen.getByText('Adjudication can begin once CVRs are imported.');
+  expect(
+    screen.getByText('Adjudicate write-ins for "United States President"')
+  ).toBeDisabled();
+});

--- a/frontends/election-manager/src/screens/write_ins_screen.test.tsx
+++ b/frontends/election-manager/src/screens/write_ins_screen.test.tsx
@@ -7,6 +7,6 @@ test('write-ins screen', () => {
   renderInAppContext(<WriteInsScreen />);
   screen.getByText('Adjudication can begin once CVRs are imported.');
   expect(
-    screen.getByText('Adjudicate write-ins for "United States President"')
+    screen.getByText('Adjudicate write-ins for “United States President”')
   ).toBeDisabled();
 });

--- a/frontends/election-manager/src/screens/write_ins_screen.tsx
+++ b/frontends/election-manager/src/screens/write_ins_screen.tsx
@@ -1,15 +1,89 @@
-import React from 'react';
+import React, { useContext, useState } from 'react';
+
+import { Button, Modal } from '@votingworks/ui';
+import {
+  CandidateContest,
+  getPartyAbbrevationByPartyId,
+} from '@votingworks/types';
 
 import { NavigationScreen } from '../components/navigation_screen';
 import { Prose } from '../components/prose';
+import { WriteInsTranscriptionScreen } from '../components/write_ins_transcription_screen';
+import { AppContext } from '../contexts/app_context';
 
 export function WriteInsScreen(): JSX.Element {
+  const { castVoteRecordFiles, electionDefinition } = useContext(AppContext);
+  const election = electionDefinition?.election;
+  const castVoteRecordFileList = castVoteRecordFiles.fileList;
+  const hasCastVoteRecordFiles =
+    castVoteRecordFileList.length > 0 || !!castVoteRecordFiles.lastError;
+  const contestsWithWriteIns = election?.contests.filter(
+    (contest): contest is CandidateContest =>
+      contest.type === 'candidate' && contest.allowWriteIns
+  );
+
+  // Aggregate write-in count by contest
+  const writeInCountsByContest = new Map();
+  for (const file of castVoteRecordFileList) {
+    for (const cvr of file.allCastVoteRecords) {
+      for (const k of Object.keys(cvr)) {
+        if (Array.isArray(cvr[k])) {
+          const contestId = k;
+          const votes = cvr[contestId] as string[];
+          // TODO: this does not capture all the ways we represente write-ins, must be
+          // updated once https://github.com/votingworks/vxsuite/issues/1793 is complete.
+          const cvrHasWriteIn = votes.find((m) => m.startsWith('write-in'));
+          if (cvrHasWriteIn) {
+            const currCount = writeInCountsByContest.get(contestId) || 0;
+            writeInCountsByContest.set(contestId, currCount + 1);
+          }
+        }
+      }
+    }
+  }
+
+  const [isTranscriptionScreenOpen, setIsTranscriptionScreenOpen] =
+    useState(false);
   return (
     <React.Fragment>
       <NavigationScreen mainChildFlex>
         <Prose maxWidth={false}>
           <h1>Write-Ins</h1>
+          {!hasCastVoteRecordFiles && (
+            <p>Adjudication can begin once CVRs are imported.</p>
+          )}
+          {contestsWithWriteIns?.map((contest) => (
+            <p key={contest.id}>
+              <Button
+                disabled={
+                  !(
+                    hasCastVoteRecordFiles &&
+                    writeInCountsByContest.get(contest.id)
+                  )
+                }
+                onPress={() => setIsTranscriptionScreenOpen(true)}
+              >
+                Adjudicate {writeInCountsByContest.get(contest.id)} write-ins
+                for &quot;{contest.section} {contest.title}
+                &quot;
+                {election && contest.partyId && (
+                  <React.Fragment>
+                    {' '}
+                    (
+                    {getPartyAbbrevationByPartyId({
+                      partyId: contest.partyId,
+                      election,
+                    })}
+                    )
+                  </React.Fragment>
+                )}
+              </Button>
+            </p>
+          ))}
         </Prose>
+        {isTranscriptionScreenOpen && (
+          <Modal content={<WriteInsTranscriptionScreen />} fullscreen />
+        )}
       </NavigationScreen>
     </React.Fragment>
   );

--- a/frontends/election-manager/src/screens/write_ins_screen.tsx
+++ b/frontends/election-manager/src/screens/write_ins_screen.tsx
@@ -64,8 +64,7 @@ export function WriteInsScreen(): JSX.Element {
                 onPress={() => setIsTranscriptionScreenOpen(true)}
               >
                 Adjudicate {writeInCountsByContest.get(contest.id)} write-ins
-                for &quot;{contest.section} {contest.title}
-                &quot;
+                for “{contest.section} {contest.title}”
                 {election && contest.partyId && (
                   <React.Fragment>
                     {' '}


### PR DESCRIPTION
## Overview
#1782 

This implements the "Adjudicate {n} write-ins for {contest}" buttons on the "Write-ins" tab in election manager. It does not wire up the buttons to open the full transcription screen yet, that will come in the next PR.

Buttons are disabled when CVRs have not been imported, or when a given contest does not have any write-ins. 

## Demo Video or Screenshot
![localhost_3000_write-ins (1)](https://user-images.githubusercontent.com/7584833/166968494-ae9a220c-3d8e-4dc2-a981-4a42aff370b6.png)
![localhost_3000_write-ins (2)](https://user-images.githubusercontent.com/7584833/166968572-5448833f-2101-46ea-8caa-7d94111a2563.png)

## Testing Plan 
Manual testing for now, will add comprehensive tests as this feature progresses out of its rough prototype state. Feels counterproductive to do that now.

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
