### PR TITLE
remove ellipses from buttons

### DIFF
--- a/frontends/bsd/src/app.test.tsx
+++ b/frontends/bsd/src/app.test.tsx
@@ -348,7 +348,7 @@ test('configuring election from usb ballot package works end to end', async () =
     });
   fireEvent.click(getByText('Admin'));
   getByText('Admin Actions');
-  fireEvent.click(getByText('Delete Election Data from VxCentralScan…'));
+  fireEvent.click(getByText('Delete Election Data from VxCentralScan'));
   getByText('Delete all election data?');
   fireEvent.click(getByText('Yes, Delete Election Data'));
   getByText('Are you sure?');

--- a/frontends/bsd/src/screens/admin_actions_screen.test.tsx
+++ b/frontends/bsd/src/screens/admin_actions_screen.test.tsx
@@ -15,7 +15,7 @@ import { fakeKiosk } from '@votingworks/test-utils';
 import userEvent from '@testing-library/user-event';
 import { AdminActionsScreen } from './admin_actions_screen';
 
-test('clicking "Export Backup…" shows progress', async () => {
+test('clicking "Export Backup" shows progress', async () => {
   const backup = jest.fn();
   const component = render(
     <Router history={createMemoryHistory()}>
@@ -44,7 +44,7 @@ test('clicking "Export Backup…" shows progress', async () => {
 
   await act(async () => {
     // Click to backup, verify we got called.
-    const backupButton = component.getByText('Export Backup…');
+    const backupButton = component.getByText('Export Backup');
     expect(backup).not.toHaveBeenCalled();
     backupButton.click();
     expect(backup).toHaveBeenCalledTimes(1);
@@ -54,11 +54,11 @@ test('clicking "Export Backup…" shows progress', async () => {
 
     // Trigger backup finished, verify back to normal.
     resolve();
-    await waitFor(() => component.getByText('Export Backup…'));
+    await waitFor(() => component.getByText('Export Backup'));
   });
 });
 
-test('"Delete Ballot Data…" and Delete Election Data from VxCentralScan…" disabled when canUnconfigure is falsy', () => {
+test('"Delete Ballot Data" and Delete Election Data from VxCentralScan" disabled when canUnconfigure is falsy', () => {
   const unconfigureServer = jest.fn();
   const zeroData = jest.fn();
   const component = render(
@@ -81,20 +81,20 @@ test('"Delete Ballot Data…" and Delete Election Data from VxCentralScan…" di
 
   // Clicking the disabled "Delete Election Data" button should do nothing
   const unconfigureButton = component.getByText(
-    'Delete Election Data from VxCentralScan…'
+    'Delete Election Data from VxCentralScan'
   );
   unconfigureButton.click();
   expect(unconfigureServer).not.toHaveBeenCalled();
   expect(component.queryByText('Delete all election data?')).toBeNull();
 
   // Clicking the disabled "Delete Ballot Data" button should do nothing
-  const deleteBallotsButton = component.getByText('Delete Ballot Data…');
+  const deleteBallotsButton = component.getByText('Delete Ballot Data');
   deleteBallotsButton.click();
   expect(zeroData).not.toHaveBeenCalled();
   expect(component.queryByText('Delete All Scanned Ballot Data?')).toBeNull();
 });
 
-test('"Delete Ballot Data…" and Delete Election Data from VxCentralScan…" enabled in test mode even if data not backed up', () => {
+test('"Delete Ballot Data" and Delete Election Data from VxCentralScan" enabled in test mode even if data not backed up', () => {
   const component = render(
     <Router history={createMemoryHistory()}>
       <AdminActionsScreen
@@ -115,18 +115,18 @@ test('"Delete Ballot Data…" and Delete Election Data from VxCentralScan…" en
 
   // Clicking the disabled "Delete Election Data" button should bring up a confirmation modal
   const unconfigureButton = component.getByText(
-    'Delete Election Data from VxCentralScan…'
+    'Delete Election Data from VxCentralScan'
   );
   unconfigureButton.click();
   component.getByText('Delete all election data?');
 
   // Clicking the disabled "Delete Ballot Data" button should bring up a confirmation modal
-  const deleteBallotsButton = component.getByText('Delete Ballot Data…');
+  const deleteBallotsButton = component.getByText('Delete Ballot Data');
   deleteBallotsButton.click();
   component.getByText('Delete All Scanned Ballot Data?');
 });
 
-test('clicking "Delete Election Data from VxCentralScan…" shows progress', async () => {
+test('clicking "Delete Election Data from VxCentralScan" shows progress', async () => {
   const unconfigureServer = jest.fn();
   const component = render(
     <Router history={createMemoryHistory()}>
@@ -156,7 +156,7 @@ test('clicking "Delete Election Data from VxCentralScan…" shows progress', asy
   // Click to reset.
   expect(unconfigureServer).not.toHaveBeenCalled();
   const resetButton = component.getByText(
-    'Delete Election Data from VxCentralScan…'
+    'Delete Election Data from VxCentralScan'
   );
   resetButton.click();
 
@@ -182,7 +182,7 @@ test('clicking "Delete Election Data from VxCentralScan…" shows progress', asy
   await waitFor(() => !component.getByText('Deleting election data'));
 });
 
-test('clicking "Delete Ballot Data…" shows progress', async () => {
+test('clicking "Delete Ballot Data" shows progress', async () => {
   const zeroData = jest.fn();
   const component = render(
     <Router history={createMemoryHistory()}>
@@ -210,7 +210,7 @@ test('clicking "Delete Ballot Data…" shows progress', async () => {
   );
 
   expect(zeroData).not.toHaveBeenCalled();
-  fireEvent.click(component.getByText('Delete Ballot Data…'));
+  fireEvent.click(component.getByText('Delete Ballot Data'));
 
   expect(zeroData).not.toHaveBeenCalled();
   await screen.findByText('Delete All Scanned Ballot Data?');
@@ -257,7 +257,7 @@ test('backup error shows message', async () => {
 
   await act(async () => {
     // Click to backup, verify we got called.
-    const backupButton = component.getByText('Export Backup…');
+    const backupButton = component.getByText('Export Backup');
     expect(backup).not.toHaveBeenCalled();
     backupButton.click();
     expect(backup).toHaveBeenCalledTimes(1);
@@ -267,7 +267,7 @@ test('backup error shows message', async () => {
 
     // Trigger backup error, verify back to normal with error.
     reject(new Error('two is one and one is none'));
-    await waitFor(() => component.getByText('Export Backup…'));
+    await waitFor(() => component.getByText('Export Backup'));
     await waitFor(() =>
       component.getByText('Error: two is one and one is none')
     );
@@ -281,25 +281,25 @@ test('override mark thresholds button shows when there are no overrides', () => 
     {
       hasBatches: true,
       markThresholds: undefined,
-      expectedText: 'Override Mark Thresholds…',
+      expectedText: 'Override Mark Thresholds',
       expectButtonDisabled: true,
     },
     {
       hasBatches: true,
       markThresholds: { marginal: 0.3, definite: 0.4 },
-      expectedText: 'Reset Mark Thresholds…',
+      expectedText: 'Reset Mark Thresholds',
       expectButtonDisabled: true,
     },
     {
       hasBatches: false,
       markThresholds: undefined,
-      expectedText: 'Override Mark Thresholds…',
+      expectedText: 'Override Mark Thresholds',
       expectButtonDisabled: false,
     },
     {
       hasBatches: false,
       markThresholds: { marginal: 0.3, definite: 0.4 },
-      expectedText: 'Reset Mark Thresholds…',
+      expectedText: 'Reset Mark Thresholds',
       expectButtonDisabled: false,
     },
   ];
@@ -333,7 +333,7 @@ test('override mark thresholds button shows when there are no overrides', () => 
   }
 });
 
-test('clicking "Update Date and Time…" shows modal to set clock', async () => {
+test('clicking "Update Date and Time" shows modal to set clock', async () => {
   MockDate.set('2020-10-31T00:00:00.000Z');
   window.kiosk = fakeKiosk();
 
@@ -359,9 +359,7 @@ test('clicking "Update Date and Time…" shows modal to set clock', async () => 
 
   // We just do a simple happy path test here, since the libs/ui/set_clock unit
   // tests cover full behavior
-  userEvent.click(
-    screen.getByRole('button', { name: 'Update Date and Time…' })
-  );
+  userEvent.click(screen.getByRole('button', { name: 'Update Date and Time' }));
 
   // Open modal
   const modal = screen.getByRole('alertdialog');

--- a/frontends/bsd/src/screens/admin_actions_screen.tsx
+++ b/frontends/bsd/src/screens/admin_actions_screen.tsx
@@ -128,26 +128,26 @@ export function AdminActionsScreen({
                   disabled={hasBatches}
                 >
                   {markThresholds === undefined
-                    ? 'Override Mark Thresholds…'
-                    : 'Reset Mark Thresholds…'}
+                    ? 'Override Mark Thresholds'
+                    : 'Reset Mark Thresholds'}
                 </Button>
               </p>
               {backupError && <p style={{ color: 'red' }}>{backupError}</p>}
               <p>
                 <Button onPress={exportBackup} disabled={isBackingUp}>
-                  {isBackingUp ? 'Exporting…' : 'Export Backup…'}
+                  {isBackingUp ? 'Exporting…' : 'Export Backup'}
                 </Button>
               </p>
               <p>
                 <Button onPress={() => setExportingLogType(LogFileType.Raw)}>
-                  Export Logs…
+                  Export Logs
                 </Button>{' '}
                 <Button onPress={() => setExportingLogType(LogFileType.Cdf)}>
-                  Export Logs as CDF…
+                  Export Logs as CDF
                 </Button>
               </p>
               <p>
-                <SetClockButton>Update Date and Time…</SetClockButton>
+                <SetClockButton>Update Date and Time</SetClockButton>
               </p>
               <p>
                 <Button
@@ -155,7 +155,7 @@ export function AdminActionsScreen({
                   disabled={!hasBatches || (!isTestMode && !canUnconfigure)}
                   onPress={toggleIsConfirmingZero}
                 >
-                  Delete Ballot Data…
+                  Delete Ballot Data
                 </Button>
               </p>
 
@@ -165,7 +165,7 @@ export function AdminActionsScreen({
                   disabled={!canUnconfigure && !isTestMode}
                   onPress={toggleIsConfirmingUnconfigure}
                 >
-                  Delete Election Data from VxCentralScan…
+                  Delete Election Data from VxCentralScan
                 </Button>{' '}
                 {!canUnconfigure && !isTestMode && (
                   <React.Fragment>

--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -10,6 +10,7 @@ import {
   getByText as domGetByText,
   getAllByRole as domGetAllByRole,
   act,
+  within,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
@@ -455,9 +456,10 @@ test('tabulating CVRs', async () => {
   );
 
   getByText('View Unofficial Full Election Tally Report');
-  fireEvent.click(getByText('Mark Tally Results as Official…'));
-  getByText('Mark Unofficial Tally Results as Official Tally Results?');
   fireEvent.click(getByText('Mark Tally Results as Official'));
+  getByText('Mark Unofficial Tally Results as Official Tally Results?');
+  const modal = await screen.findByRole('alertdialog');
+  fireEvent.click(within(modal).getByText('Mark Tally Results as Official'));
   expect(mockKiosk.log).toHaveBeenCalledWith(
     expect.stringContaining(LogEventId.MarkedTallyResultsOfficial)
   );
@@ -583,7 +585,7 @@ test('tabulating CVRs', async () => {
 
   // Clear results
   fireEvent.click(getByText('Tally'));
-  fireEvent.click(getByText('Clear All Results…'));
+  fireEvent.click(getByText('Clear All Results'));
   fireEvent.click(getByText('Remove All Data'));
   await waitFor(() =>
     expect(getByTestId('total-ballot-count').textContent).toEqual('0')
@@ -697,7 +699,7 @@ test('tabulating CVRs with SEMS file', async () => {
   fireEvent.click(getByText('Close'));
 
   // Test removing the SEMS file
-  fireEvent.click(getByText('Remove External Results File…'));
+  fireEvent.click(getByText('Remove External Results File'));
   fireEvent.click(getByText('Remove External Files'));
 
   await waitFor(() =>
@@ -874,10 +876,11 @@ test('tabulating CVRs with SEMS file and manual data', async () => {
 
   // Remove the manual data
   fireEvent.click(getByText('Back to Tally Index'));
-  fireEvent.click(getByText('Remove Manual Data…'));
+  fireEvent.click(getByText('Remove Manual Data'));
 
   getByText('Do you want to remove the manually entered data?');
-  fireEvent.click(getByText('Remove Manual Data'));
+  const modal = await screen.findByRole('alertdialog');
+  fireEvent.click(within(modal).getByText('Remove Manual Data'));
   await waitFor(() => {
     expect(getByTestId('total-ballot-count').textContent).toEqual('200');
   });
@@ -995,24 +998,25 @@ test('clearing all files after marking as official clears SEMS, CVR, and manual 
   );
 
   fireEvent.click(getByText('Tally'));
-  fireEvent.click(getByText('Mark Tally Results as Official…'));
   fireEvent.click(getByText('Mark Tally Results as Official'));
+  const modal = await screen.findByRole('alertdialog');
+  fireEvent.click(within(modal).getByText('Mark Tally Results as Official'));
 
   getByText('View Official Full Election Tally Report');
   expect(getByText('Import CVR Files').closest('button')).toBeDisabled();
   expect(getByTestId('import-sems-button')).toBeDisabled();
 
-  fireEvent.click(getByText('Clear All Results…'));
+  fireEvent.click(getByText('Clear All Results'));
   getByText(
     'Do you want to remove the 1 uploaded CVR file, the external results file sems-results.csv, and the manually entered data?'
   );
   fireEvent.click(getByText('Remove All Data'));
 
   await waitFor(() =>
-    expect(getByText('Remove CVR Files…').closest('button')).toBeDisabled()
+    expect(getByText('Remove CVR Files').closest('button')).toBeDisabled()
   );
   expect(
-    getByText('Remove External Results File…').closest('button')
+    getByText('Remove External Results File').closest('button')
   ).toBeDisabled();
 
   expect(getByText('Import CVR Files').closest('button')).toBeEnabled();

--- a/frontends/election-manager/src/screens/manual_data_import_index_screen.test.tsx
+++ b/frontends/election-manager/src/screens/manual_data_import_index_screen.test.tsx
@@ -240,7 +240,7 @@ test('loads prexisting manual data to edit', async () => {
     '7'
   );
 
-  fireEvent.click(getByText('Clear Manual Data…'));
+  fireEvent.click(getByText('Clear Manual Data'));
   fireEvent.click(getByText('Remove Manual Data'));
 
   expect(resetFiles).toHaveBeenCalledWith(ResultsFileType.Manual);

--- a/frontends/election-manager/src/screens/manual_data_import_index_screen.tsx
+++ b/frontends/election-manager/src/screens/manual_data_import_index_screen.tsx
@@ -207,7 +207,7 @@ export function ManualDataImportIndexScreen(): JSX.Element {
                 disabled={!hasManualData}
                 onPress={() => setIsClearing(true)}
               >
-                Clear Manual Data…
+                Clear Manual Data
               </Button>
             </p>
           </Prose>

--- a/frontends/election-manager/src/screens/tally_screen.tsx
+++ b/frontends/election-manager/src/screens/tally_screen.tsx
@@ -365,7 +365,7 @@ export function TallyScreen(): JSX.Element {
             disabled={!hasCastVoteRecordFiles || isOfficialResults}
             onPress={confirmOfficial}
           >
-            Mark Tally Results as Official…
+            Mark Tally Results as Official
           </Button>
         </p>
         {isOfficialResults ? (
@@ -375,7 +375,7 @@ export function TallyScreen(): JSX.Element {
               disabled={!hasAnyFiles}
               onPress={() => beginConfirmRemoveFiles(ResultsFileType.All)}
             >
-              Clear All Results…
+              Clear All Results
             </Button>
           </p>
         ) : (
@@ -387,7 +387,7 @@ export function TallyScreen(): JSX.Element {
                 beginConfirmRemoveFiles(ResultsFileType.CastVoteRecord)
               }
             >
-              Remove CVR Files…
+              Remove CVR Files
             </Button>{' '}
             {converter === 'ms-sems' && (
               <React.Fragment>
@@ -396,7 +396,7 @@ export function TallyScreen(): JSX.Element {
                   disabled={!hasExternalSemsFile}
                   onPress={() => beginConfirmRemoveFiles(ResultsFileType.SEMS)}
                 >
-                  Remove External Results File…
+                  Remove External Results File
                 </Button>{' '}
               </React.Fragment>
             )}
@@ -405,7 +405,7 @@ export function TallyScreen(): JSX.Element {
               disabled={!hasExternalManualData}
               onPress={() => beginConfirmRemoveFiles(ResultsFileType.Manual)}
             >
-              Remove Manual Data…
+              Remove Manual Data
             </Button>
           </p>
         )}

--- a/integration-testing/bsd/cypress/integration/configuration.ts
+++ b/integration-testing/bsd/cypress/integration/configuration.ts
@@ -48,7 +48,7 @@ describe('BSD and services/Scan', () => {
      * Potential solutions: upgrade to cypress 6.3.0 or intercept the file download? https://docs.cypress.io/faq/questions/using-cypress-faq#Is-there-a-way-to-test-that-a-file-got-downloaded-I-want-to-test-that-a-button-click-triggers-a-download
      * Intercepting the file download will require additional work to mark on the server that a backup happened.
      */
-    // cy.contains('Export Backup…').click();
+    // cy.contains('Export Backup').click();
     // cy.contains('Delete Ballot Data').click();
     // cy.contains('Yes, Delete Ballot Data').click();
     // cy.contains('No ballots have been scanned', { timeout: 20000 });
@@ -67,8 +67,8 @@ describe('BSD and services/Scan', () => {
     // cy.contains('Confirm Ballot Removed and Continue Scanning').click();
     // cy.contains('Admin').click();
     // cy.contains('Toggle to Live Mode');
-    // cy.contains('Export Backup…').click();
-    // cy.contains('Delete Election Data from VxCentralScan…').click();
+    // cy.contains('Export Backup').click();
+    // cy.contains('Delete Election Data from VxCentralScan').click();
     // cy.contains('Yes, Delete Election Data').click();
     // cy.contains('Are you sure?');
     // cy.contains('I am sure. Delete all election data').click();


### PR DESCRIPTION
## Overview
Closes #1748

Removes ellipses in the text of buttons across apps. Ellipses were left in:
- Temporary status button text (e.g. "Exporting...")
- "Save As..." buttons
- "Select a precinct for this device..." dropdown in VxMark
- "Select File..." buttons

## Demo Video or Screenshot
VxCentralScan Admin Screen:
![bsd_admin_after](https://user-images.githubusercontent.com/37960853/167228317-b6bffe4d-9001-4a0c-8e0c-b7330064b566.png)

VxAdmin Tally Screen
![tally_after](https://user-images.githubusercontent.com/37960853/167228325-7e94113f-8652-4aff-bbf9-e00089eebf28.png)

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
