### PR TITLE
refactor(routes): prepare for `react-router` v6 upgrade

### DIFF
--- a/frontends/bmd/src/app.tsx
+++ b/frontends/bmd/src/app.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { BrowserRouter, Route } from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 
 import 'normalize.css';
 import './App.css';
@@ -135,20 +135,14 @@ export function App({
         onClickCapture={onClick}
         onFocusCapture={onFocus}
       >
-        <Route
-          path="/"
-          render={(props) => (
-            <AppRoot
-              card={card}
-              printer={printer}
-              hardware={internalHardware}
-              storage={storage}
-              machineConfig={machineConfig}
-              screenReader={screenReader}
-              reload={reload}
-              {...props}
-            />
-          )}
+        <AppRoot
+          card={card}
+          printer={printer}
+          hardware={internalHardware}
+          storage={storage}
+          machineConfig={machineConfig}
+          screenReader={screenReader}
+          reload={reload}
         />
       </FocusManager>
     </BrowserRouter>

--- a/frontends/bmd/src/app_root.tsx
+++ b/frontends/bmd/src/app_root.tsx
@@ -30,7 +30,7 @@ import React, {
   useMemo,
 } from 'react';
 import Gamepad from 'react-gamepad';
-import { RouteComponentProps } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import './App.css';
 import IdleTimer from 'react-idle-timer';
 import useInterval from '@rooks/use-interval';
@@ -152,7 +152,7 @@ export interface AppStorage {
   activation?: SerializableActivationData;
   votes?: VotesDict;
 }
-export interface Props extends RouteComponentProps {
+export interface Props {
   card: Card;
   hardware: Hardware;
   machineConfig: Provider<MachineConfig>;
@@ -480,7 +480,6 @@ function appReducer(state: State, action: AppAction): State {
 export function AppRoot({
   card,
   hardware,
-  history,
   machineConfig: machineConfigProvider,
   printer,
   screenReader,
@@ -521,6 +520,7 @@ export function AppRoot({
     hasCardError,
   } = appState;
 
+  const history = useHistory();
   const { appMode } = machineConfig;
   const logger = useMemo(
     () => new Logger(LogSource.VxBallotMarkingDeviceFrontend, window.kiosk),

--- a/frontends/bmd/src/components/ballot.tsx
+++ b/frontends/bmd/src/components/ballot.tsx
@@ -10,7 +10,6 @@ import { ReviewPage } from '../pages/review_page';
 import { SaveCardScreen } from '../pages/save_card_screen';
 import { StartPage } from '../pages/start_page';
 import { RemoveCardScreen } from '../pages/remove_card_screen';
-import { CastBallotPage } from '../pages/cast_ballot_page';
 import {
   IDLE_TIMEOUT_SECONDS,
   FONT_SIZES,
@@ -57,14 +56,27 @@ export function Ballot(): JSX.Element {
         <IdlePage />
       ) : (
         <Switch>
-          <Route path="/" exact component={StartPage} />
-          <Route path="/contests/:contestNumber" component={ContestPage} />
-          <Route path="/review" component={ReviewPage} />
-          <Route path="/save" component={SaveCardScreen} />
-          <Route path="/remove" component={RemoveCardScreen} />
-          <Route path="/print" component={PrintPage} />
-          <Route path="/cast" component={CastBallotPage} />
-          <Route path="/:path" component={NotFoundPage} />
+          <Route path="/" exact>
+            <StartPage />
+          </Route>
+          <Route path="/contests/:contestNumber">
+            <ContestPage />
+          </Route>
+          <Route path="/review">
+            <ReviewPage />
+          </Route>
+          <Route path="/save">
+            <SaveCardScreen />
+          </Route>
+          <Route path="/remove">
+            <RemoveCardScreen />
+          </Route>
+          <Route path="/print">
+            <PrintPage />
+          </Route>
+          <Route path="/:path">
+            <NotFoundPage />
+          </Route>
         </Switch>
       )}
     </IdleTimer>

--- a/frontends/bmd/src/pages/contest_page.tsx
+++ b/frontends/bmd/src/pages/contest_page.tsx
@@ -1,6 +1,6 @@
 import { assert } from '@votingworks/utils';
 import React, { useContext, useEffect, useState } from 'react';
-import { RouteComponentProps } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { CandidateVote, OptionalYesNoVote } from '@votingworks/types';
 import { LinkButton, Screen, Prose } from '@votingworks/ui';
 
@@ -22,11 +22,8 @@ interface ContestParams {
   contestNumber: string;
 }
 
-export function ContestPage({
-  match: {
-    params: { contestNumber },
-  },
-}: RouteComponentProps<ContestParams>): JSX.Element {
+export function ContestPage(): JSX.Element {
+  const { contestNumber } = useParams<ContestParams>();
   const isReviewMode = window.location.hash === '#review';
   const {
     ballotStyleId,

--- a/frontends/bmd/src/pages/not_found_page.tsx
+++ b/frontends/bmd/src/pages/not_found_page.tsx
@@ -1,12 +1,11 @@
 import React, { useContext } from 'react';
-import { RouteComponentProps } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 
 import { Button, Main, MainChild, Screen, Prose } from '@votingworks/ui';
 import { BallotContext } from '../contexts/ballot_context';
 
-export function NotFoundPage({
-  location: { pathname },
-}: RouteComponentProps): JSX.Element {
+export function NotFoundPage(): JSX.Element {
+  const { pathname } = useLocation();
   const { resetBallot } = useContext(BallotContext);
   function requestResetBallot() {
     resetBallot();

--- a/frontends/bsd/src/app.tsx
+++ b/frontends/bsd/src/app.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { WebServiceCard, getHardware } from '@votingworks/utils';
-import { BrowserRouter, Route } from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 
 import './App.css';
 
@@ -27,11 +27,10 @@ export function App({
   if (!internalHardware) {
     return <React.Fragment />;
   }
+
   return (
     <BrowserRouter>
-      <Route path="/">
-        <AppRoot hardware={internalHardware} card={card} />
-      </Route>
+      <AppRoot hardware={internalHardware} card={card} />
     </BrowserRouter>
   );
 }

--- a/frontends/election-manager/src/app.tsx
+++ b/frontends/election-manager/src/app.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { BrowserRouter, Route } from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 
 import './App.css';
 
@@ -49,18 +49,12 @@ export function App({
 
   return (
     <BrowserRouter>
-      <Route
-        path="/"
-        render={(props) => (
-          <AppRoot
-            storage={storage}
-            printer={printer}
-            hardware={internalHardware}
-            card={card}
-            machineConfigProvider={machineConfig}
-            {...props}
-          />
-        )}
+      <AppRoot
+        storage={storage}
+        printer={printer}
+        hardware={internalHardware}
+        card={card}
+        machineConfigProvider={machineConfig}
       />
     </BrowserRouter>
   );

--- a/frontends/election-manager/src/app_root.tsx
+++ b/frontends/election-manager/src/app_root.tsx
@@ -5,7 +5,6 @@ import React, {
   useCallback,
   useMemo,
 } from 'react';
-import { RouteComponentProps } from 'react-router-dom';
 import 'normalize.css';
 import { sha256 } from 'js-sha256';
 import {
@@ -75,7 +74,7 @@ export interface AppStorage {
   externalVoteTallies?: string;
 }
 
-export interface Props extends RouteComponentProps {
+export interface Props {
   storage: Storage;
   printer: Printer;
   hardware: Hardware;

--- a/frontends/precinct-scanner/src/app.tsx
+++ b/frontends/precinct-scanner/src/app.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { BrowserRouter, Route } from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 
 import './App.css';
 
@@ -43,18 +43,12 @@ export function App({
   }
   return (
     <BrowserRouter>
-      <Route
-        path="/"
-        render={(props) => (
-          <AppRoot
-            card={card}
-            hardware={internalHardware}
-            printer={printer}
-            machineConfig={machineConfig}
-            storage={storage}
-            {...props}
-          />
-        )}
+      <AppRoot
+        card={card}
+        hardware={internalHardware}
+        printer={printer}
+        machineConfig={machineConfig}
+        storage={storage}
       />
     </BrowserRouter>
   );

--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -1,6 +1,5 @@
 import { ScannerStatus } from '@votingworks/types/api/services/scan';
 import React, { useCallback, useEffect, useReducer, useMemo } from 'react';
-import { RouteComponentProps } from 'react-router-dom';
 import useInterval from '@rooks/use-interval';
 import 'normalize.css';
 import makeDebug from 'debug';
@@ -78,7 +77,7 @@ export interface AppStorage {
 export const stateStorageKey = 'state';
 const VALID_USERS: readonly UserRole[] = ['admin', 'pollworker', 'superadmin'];
 
-export interface Props extends RouteComponentProps {
+export interface Props {
   hardware: Hardware;
   card: Card;
   storage: Storage;


### PR DESCRIPTION

## Overview
Per the [upgrade guide](https://reactrouter.com/docs/en/v6/upgrading/v5) for `react-router` v6, we should:
- Use `<Route children>` instead of `<Route render>` and/or `<Route component>` props
- Use our hooks API to access router state like the current location and params
- Replace all uses of withRouter with hooks
- Replace any `<Route>`s that are not inside a `<Switch>` with `useRouteMatch`, or wrap them in a `<Switch>`

Refs https://github.com/votingworks/vxsuite/issues/1805

## Demo Video or Screenshot
n/a
## Testing Plan 
Automated, plus manual smoke testing.
## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
