### PR TITLE
append 2 blank ballots to test deck

### DIFF
--- a/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
+++ b/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
@@ -256,6 +256,32 @@ exports[`L&A (logic and accuracy) flow 1`] = `
       6522
       .
     </div>
+    <div>
+      <h1>
+        Mocked HMPB
+      </h1>
+      Election: 
+      Mock General Election Choctaw 2020
+      <br />
+      Ballot Style 
+      5
+      , precinct 
+      6522
+      .
+    </div>
+    <div>
+      <h1>
+        Mocked HMPB
+      </h1>
+      Election: 
+      Mock General Election Choctaw 2020
+      <br />
+      Ballot Style 
+      5
+      , precinct 
+      6522
+      .
+    </div>
   </div>
   <div />
 </div>

--- a/frontends/election-manager/src/screens/print_test_deck_screen.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.tsx
@@ -39,7 +39,11 @@ function TestDeckBallots({
   precinctId,
   onAllRendered,
 }: TestDeckBallotsParams) {
-  const ballots = generateTestDeckBallots({ election, precinctId });
+  const ballots = generateTestDeckBallots({
+    election,
+    precinctId,
+    numBlanks: 2,
+  });
 
   let numRendered = 0;
   function onRendered() {

--- a/frontends/election-manager/src/screens/print_test_deck_screen.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.tsx
@@ -24,7 +24,10 @@ import { PrecinctReportScreenProps } from '../config/types';
 
 import { HandMarkedPaperBallot } from '../components/hand_marked_paper_ballot';
 
-import { generateTestDeckBallots } from '../utils/election';
+import {
+  generateTestDeckBallots,
+  generateBlankBallots,
+} from '../utils/election';
 
 interface TestDeckBallotsParams {
   election: Election;
@@ -39,11 +42,8 @@ function TestDeckBallots({
   precinctId,
   onAllRendered,
 }: TestDeckBallotsParams) {
-  const ballots = generateTestDeckBallots({
-    election,
-    precinctId,
-    numBlanks: 2,
-  });
+  const ballots = generateTestDeckBallots({ election, precinctId });
+  ballots.push(...generateBlankBallots({ election, precinctId, numBlanks: 2 }));
 
   let numRendered = 0;
   function onRendered() {

--- a/frontends/election-manager/src/utils/election.ts
+++ b/frontends/election-manager/src/utils/election.ts
@@ -172,11 +172,13 @@ export function getContestsForPrecinct(
 interface GenerateTestDeckParams {
   election: Election;
   precinctId?: PrecinctId;
+  numBlanks?: number;
 }
 
 export function generateTestDeckBallots({
   election,
   precinctId,
+  numBlanks,
 }: GenerateTestDeckParams): Array<Dictionary<string | VotesDict>> {
   const precincts: string[] = precinctId
     ? [precinctId]
@@ -230,6 +232,19 @@ export function generateTestDeckBallots({
           precinctId: currentPrecinctId,
           votes,
         });
+      }
+    }
+
+    if (numBlanks && numBlanks > 0) {
+      const blankBallotStyle = precinctBallotStyles[0];
+      if (blankBallotStyle) {
+        for (let blankNum = 0; blankNum < numBlanks; blankNum += 1) {
+          ballots.push({
+            ballotStyleId: blankBallotStyle.id,
+            precinctId: currentPrecinctId,
+            votes: {},
+          });
+        }
       }
     }
   }

--- a/frontends/election-manager/src/utils/election.ts
+++ b/frontends/election-manager/src/utils/election.ts
@@ -172,13 +172,11 @@ export function getContestsForPrecinct(
 interface GenerateTestDeckParams {
   election: Election;
   precinctId?: PrecinctId;
-  numBlanks?: number;
 }
 
 export function generateTestDeckBallots({
   election,
   precinctId,
-  numBlanks,
 }: GenerateTestDeckParams): Array<Dictionary<string | VotesDict>> {
   const precincts: string[] = precinctId
     ? [precinctId]
@@ -234,18 +232,33 @@ export function generateTestDeckBallots({
         });
       }
     }
+  }
 
-    if (numBlanks && numBlanks > 0) {
-      const blankBallotStyle = precinctBallotStyles[0];
-      if (blankBallotStyle) {
-        for (let blankNum = 0; blankNum < numBlanks; blankNum += 1) {
-          ballots.push({
-            ballotStyleId: blankBallotStyle.id,
-            precinctId: currentPrecinctId,
-            votes: {},
-          });
-        }
-      }
+  return ballots;
+}
+
+export function generateBlankBallots({
+  election,
+  precinctId,
+  numBlanks,
+}: {
+  election: Election;
+  precinctId: PrecinctId;
+  numBlanks: number;
+}): Array<Dictionary<string | VotesDict>> {
+  const ballots: Array<Dictionary<string | VotesDict>> = [];
+
+  const blankBallotStyle = election.ballotStyles.find((bs) =>
+    bs.precincts.includes(precinctId)
+  );
+
+  if (blankBallotStyle && numBlanks > 0) {
+    for (let blankNum = 0; blankNum < numBlanks; blankNum += 1) {
+      ballots.push({
+        ballotStyleId: blankBallotStyle.id,
+        precinctId,
+        votes: {},
+      });
     }
   }
 


### PR DESCRIPTION
## Overview
Closes #1712 

Adds 2 blank ballots to the end of each precinct test deck.

## Testing Plan 

Updated test deck snapshot in the L&A test flow 1.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
