### PR TITLE
fix(types): correct "abbreviation" typo

### DIFF
--- a/frontends/election-manager/src/screens/write_ins_screen.tsx
+++ b/frontends/election-manager/src/screens/write_ins_screen.tsx
@@ -5,7 +5,7 @@ import {
   CandidateContest,
   ContestId,
   ContestOptionId,
-  getPartyAbbrevationByPartyId,
+  getPartyAbbreviationByPartyId,
 } from '@votingworks/types';
 
 import { NavigationScreen } from '../components/navigation_screen';
@@ -71,7 +71,7 @@ export function WriteInsScreen(): JSX.Element {
                   <React.Fragment>
                     {' '}
                     (
-                    {getPartyAbbrevationByPartyId({
+                    {getPartyAbbreviationByPartyId({
                       partyId: contest.partyId,
                       election,
                     })}

--- a/libs/types/src/election.test.ts
+++ b/libs/types/src/election.test.ts
@@ -18,7 +18,7 @@ import {
   getContestsFromIds,
   getEitherNeitherContests,
   getElectionLocales,
-  getPartyAbbrevationByPartyId,
+  getPartyAbbreviationByPartyId,
   getPartyFullNameFromBallotStyle,
   getPartyPrimaryAdjectiveFromBallotStyle,
   getPrecinctById,
@@ -155,14 +155,14 @@ test('can get a party primary adjective from ballot style', () => {
 
 test('can get a party abbreviation by party ID', () => {
   expect(
-    getPartyAbbrevationByPartyId({
+    getPartyAbbreviationByPartyId({
       partyId: primaryElection.parties[0].id,
       election: { ...primaryElection },
     })
   ).toEqual('D');
 
   expect(
-    getPartyAbbrevationByPartyId({
+    getPartyAbbreviationByPartyId({
       partyId: primaryElection.parties[0].id,
       election: { ...primaryElection, parties: [] },
     })

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -1503,7 +1503,7 @@ export function getPartyFullNameFromBallotStyle({
  * Gets the abbreviation of the political party for a primary election,
  * e.g. "R" or "D".
  */
-export function getPartyAbbrevationByPartyId({
+export function getPartyAbbreviationByPartyId({
   partyId,
   election,
 }: {


### PR DESCRIPTION
Pretty straightforward.