### PR TITLE
feat(frontends): separate feature flags from machine config

### DIFF
--- a/frontends/bmd/src/utils/machine_config.test.ts
+++ b/frontends/bmd/src/utils/machine_config.test.ts
@@ -71,3 +71,68 @@ test('failed fetch from /machine-config', async () => {
     'fetch failed!'
   );
 });
+
+test('overrides', async () => {
+  const originalProcessEnv = process.env;
+
+  process.env = {
+    ...process.env,
+    NODE_ENV: 'development',
+    REACT_APP_VX_APP_MODE: 'MarkOnly',
+    REACT_APP_VX_MACHINE_ID: '2',
+    REACT_APP_VX_CODE_VERSION: 'test-override',
+  };
+
+  try {
+    fetchMock.get(
+      '/machine-config',
+      typedAs<MachineConfigResponse>({
+        appModeKey: 'PrintOnly',
+        machineId: '1',
+        codeVersion: 'test',
+      })
+    );
+
+    expect(await machineConfigProvider.get()).toEqual(
+      typedAs<MachineConfig>({
+        appMode: MarkOnly,
+        machineId: '2',
+        codeVersion: 'test-override',
+      })
+    );
+  } finally {
+    process.env = originalProcessEnv;
+  }
+});
+
+test('overrides without appMode', async () => {
+  const originalProcessEnv = process.env;
+
+  process.env = {
+    ...process.env,
+    NODE_ENV: 'development',
+    REACT_APP_VX_MACHINE_ID: '2',
+    REACT_APP_VX_CODE_VERSION: 'test-override',
+  };
+
+  try {
+    fetchMock.get(
+      '/machine-config',
+      typedAs<MachineConfigResponse>({
+        appModeKey: 'PrintOnly',
+        machineId: '1',
+        codeVersion: 'test',
+      })
+    );
+
+    expect(await machineConfigProvider.get()).toEqual(
+      typedAs<MachineConfig>({
+        appMode: PrintOnly,
+        machineId: '2',
+        codeVersion: 'test-override',
+      })
+    );
+  } finally {
+    process.env = originalProcessEnv;
+  }
+});

--- a/frontends/bmd/src/utils/machine_config.ts
+++ b/frontends/bmd/src/utils/machine_config.ts
@@ -1,10 +1,28 @@
-import { Provider, unsafeParse } from '@votingworks/types';
+import { Provider, safeParse, unsafeParse } from '@votingworks/types';
 import { fetchJson } from '@votingworks/utils';
 import {
+  AppModeKeysSchema,
   getAppMode,
   MachineConfig,
   MachineConfigResponseSchema,
 } from '../config/types';
+
+/**
+ * Gets values for the machine config that should override those from the
+ * `/machine-config` API. This is only used for development.
+ */
+function getOverrides(): Partial<MachineConfig> {
+  const appModeKey = safeParse(
+    AppModeKeysSchema,
+    process.env.REACT_APP_VX_APP_MODE
+  ).ok();
+
+  return {
+    appMode: appModeKey ? getAppMode(appModeKey) : undefined,
+    machineId: process.env.REACT_APP_VX_MACHINE_ID,
+    codeVersion: process.env.REACT_APP_VX_CODE_VERSION,
+  };
+}
 
 export const machineConfigProvider: Provider<MachineConfig> = {
   async get() {
@@ -13,10 +31,13 @@ export const machineConfigProvider: Provider<MachineConfig> = {
       await fetchJson('/machine-config')
     );
 
+    const overrides =
+      process.env.NODE_ENV === 'development' ? getOverrides() : {};
+
     return {
-      appMode: getAppMode(appModeKey),
-      machineId,
-      codeVersion,
+      appMode: overrides.appMode ?? getAppMode(appModeKey),
+      machineId: overrides.machineId ?? machineId,
+      codeVersion: overrides.codeVersion ?? codeVersion,
     };
   },
 };

--- a/frontends/bsd/prodserver/setupProxy.js
+++ b/frontends/bsd/prodserver/setupProxy.js
@@ -8,35 +8,6 @@
 
 const { createProxyMiddleware: proxy } = require('http-proxy-middleware');
 
-/**
- * @param {string} envVar
- * @param {boolean=} defaultValue
- * @returns {boolean}
- */
-function asBoolean(envVar, defaultValue = false) {
-  switch (envVar && envVar.trim().toLowerCase()) {
-    case undefined:
-    case '':
-      return defaultValue;
-
-    case 'true':
-    case 'yes':
-    case '1':
-      return true;
-
-    case 'false':
-    case 'no':
-    case '0':
-      return false;
-
-    default:
-      console.log(
-        `cannot interpret "${envVar}" as a boolean, expected "true" or "false"; using default value "${defaultValue}""`
-      );
-      return defaultValue;
-  }
-}
-
 module.exports = function (app) {
   app.use(proxy('/card', { target: 'http://localhost:3001/' }));
   app.use(proxy('/scan', { target: 'http://localhost:3002/' }));
@@ -46,7 +17,6 @@ module.exports = function (app) {
     res.json({
       machineId: process.env.VX_MACHINE_ID || '0000',
       codeVersion: process.env.VX_CODE_VERSION || 'dev',
-      bypassAuthentication: asBoolean(process.env.BYPASS_AUTHENTICATION),
     });
   });
 };

--- a/frontends/bsd/src/app.test.tsx
+++ b/frontends/bsd/src/app.test.tsx
@@ -40,7 +40,6 @@ beforeEach(() => {
     typedAs<MachineConfigResponse>({
       machineId: '0001',
       codeVersion: 'TEST',
-      bypassAuthentication: false,
     })
   );
 

--- a/frontends/bsd/src/app.tsx
+++ b/frontends/bsd/src/app.tsx
@@ -5,24 +5,24 @@ import { BrowserRouter } from 'react-router-dom';
 import './App.css';
 
 import { AppRoot, AppRootProps } from './app_root';
+import { isAuthenticationEnabled } from './config/features';
 
 export interface Props {
   card?: AppRootProps['card'];
   hardware?: AppRootProps['hardware'];
+  bypassAuthentication?: AppRootProps['bypassAuthentication'];
 }
 
 export function App({
   hardware,
   card = new WebServiceCard(),
+  bypassAuthentication = !isAuthenticationEnabled(),
 }: Props): JSX.Element {
   const [internalHardware, setInternalHardware] = useState(hardware);
   useEffect(() => {
-    function updateHardware() {
-      const newInternalHardware = getHardware();
-      setInternalHardware((prev) => prev ?? newInternalHardware);
-    }
-    void updateHardware();
-  });
+    const newInternalHardware = getHardware();
+    setInternalHardware((prev) => prev ?? newInternalHardware);
+  }, []);
 
   if (!internalHardware) {
     return <React.Fragment />;
@@ -30,7 +30,11 @@ export function App({
 
   return (
     <BrowserRouter>
-      <AppRoot hardware={internalHardware} card={card} />
+      <AppRoot
+        hardware={internalHardware}
+        card={card}
+        bypassAuthentication={bypassAuthentication}
+      />
     </BrowserRouter>
   );
 }

--- a/frontends/bsd/src/app_root.tsx
+++ b/frontends/bsd/src/app_root.tsx
@@ -79,9 +79,14 @@ const VALID_USERS: readonly UserRole[] = ['admin', 'superadmin'];
 export interface AppRootProps {
   card: Card;
   hardware: Hardware;
+  bypassAuthentication: boolean;
 }
 
-export function AppRoot({ card, hardware }: AppRootProps): JSX.Element {
+export function AppRoot({
+  card,
+  hardware,
+  bypassAuthentication,
+}: AppRootProps): JSX.Element {
   const logger = useMemo(
     () => new Logger(LogSource.VxCentralScanFrontend, window.kiosk),
     []
@@ -107,7 +112,6 @@ export function AppRoot({ card, hardware }: AppRootProps): JSX.Element {
   const [machineConfig, setMachineConfig] = useState<MachineConfig>({
     machineId: '0000',
     codeVersion: '',
-    bypassAuthentication: false,
   });
 
   const usbDrive = useUsbDrive({ logger });
@@ -125,7 +129,7 @@ export function AppRoot({ card, hardware }: AppRootProps): JSX.Element {
       smartcard,
       electionDefinition,
       persistAuthentication: true,
-      bypassAuthentication: machineConfig.bypassAuthentication,
+      bypassAuthentication,
       logger,
       validUserTypes: VALID_USERS,
     });

--- a/frontends/bsd/src/components/export_results_modal.test.tsx
+++ b/frontends/bsd/src/components/export_results_modal.test.tsx
@@ -159,7 +159,6 @@ test('render export modal when a usb drive is mounted as expected and allows aut
         machineConfig: {
           machineId: '0001',
           codeVersion: 'TEST',
-          bypassAuthentication: false,
         },
         usbDriveStatus: UsbDriveStatus.recentlyEjected,
         usbDriveEject: jest.fn(),

--- a/frontends/bsd/src/config/features.ts
+++ b/frontends/bsd/src/config/features.ts
@@ -1,0 +1,19 @@
+import { asBoolean } from '@votingworks/utils';
+
+/**
+ * Determines whether authentication is enabled.
+ *
+ * To disable authentication, add this line to `frontends/bsd/.env.local`:
+ *
+ *     REACT_APP_VX_BYPASS_AUTHENTICATION=true
+ *
+ * To enable it, remove the line or comment it out. Restarting the server is required.
+ *
+ * @see https://create-react-app.dev/docs/adding-custom-environment-variables/
+ */
+export function isAuthenticationEnabled(): boolean {
+  return (
+    process.env.NODE_ENV !== 'development' ||
+    !asBoolean(process.env.REACT_APP_VX_BYPASS_AUTHENTICATION)
+  );
+}

--- a/frontends/bsd/src/config/types.ts
+++ b/frontends/bsd/src/config/types.ts
@@ -13,12 +13,10 @@ import { z } from 'zod';
 export interface MachineConfig {
   machineId: string;
   codeVersion: string;
-  bypassAuthentication: boolean;
 }
 export const MachineConfigSchema: z.ZodSchema<MachineConfig> = z.object({
   machineId: MachineId,
   codeVersion: z.string().nonempty(),
-  bypassAuthentication: z.boolean(),
 });
 
 export type MachineConfigResponse = MachineConfig;

--- a/frontends/bsd/src/contexts/app_context.ts
+++ b/frontends/bsd/src/contexts/app_context.ts
@@ -22,7 +22,6 @@ const appContext: AppContextInterface = {
   machineConfig: {
     machineId: '0000',
     codeVersion: '',
-    bypassAuthentication: false,
   },
   electionDefinition: undefined,
   electionHash: undefined,

--- a/frontends/bsd/test/helpers/fake_machine_config.ts
+++ b/frontends/bsd/test/helpers/fake_machine_config.ts
@@ -4,9 +4,8 @@ import { MachineConfig } from '../../src/config/types';
 export function fakeMachineConfig({
   machineId = '0000',
   codeVersion = 'TEST',
-  bypassAuthentication = true,
 }: Partial<MachineConfig> = {}): MachineConfig {
-  return { machineId, codeVersion, bypassAuthentication };
+  return { machineId, codeVersion };
 }
 
 export function fakeMachineConfigProvider(

--- a/frontends/bsd/test/render_in_app_context.tsx
+++ b/frontends/bsd/test/render_in_app_context.tsx
@@ -17,7 +17,6 @@ interface RenderInAppContextParams {
   usbDriveEject?: () => void;
   storage?: Storage;
   lockMachine?: () => void;
-  bypassAuthentication?: boolean;
   currentUserSession?: UserSession;
   logger?: Logger;
 }
@@ -27,7 +26,6 @@ export function makeAppContext({
   machineConfig = {
     machineId: '0000',
     codeVersion: 'TEST',
-    bypassAuthentication: true,
   },
   usbDriveStatus = usbstick.UsbDriveStatus.absent,
   usbDriveEject = jest.fn(),
@@ -55,7 +53,6 @@ export function renderInAppContext(
     history = createMemoryHistory({ initialEntries: [route] }),
     electionDefinition,
     machineId = '0000',
-    bypassAuthentication = true,
     usbDriveStatus,
     usbDriveEject,
     storage,
@@ -68,7 +65,7 @@ export function renderInAppContext(
     <AppContext.Provider
       value={makeAppContext({
         electionDefinition,
-        machineConfig: { machineId, codeVersion: 'TEST', bypassAuthentication },
+        machineConfig: { machineId, codeVersion: 'TEST' },
         usbDriveStatus,
         usbDriveEject,
         storage,

--- a/frontends/election-manager/.env
+++ b/frontends/election-manager/.env
@@ -1,0 +1,1 @@
+REACT_APP_VX_CONVERTER=ms-sems

--- a/frontends/election-manager/README.md
+++ b/frontends/election-manager/README.md
@@ -17,7 +17,7 @@ The server will be available at http://localhost:3000/.
 ### Choosing a Converter
 
 If you want to run with a particular converter configuration, start the server
-with `VX_CONVERTER` set to the appropriate value:
+with `REACT_APP_VX_CONVERTER` set to the appropriate value:
 
 - **`ms-sems`** (default): uses `services/converter-ms-sems` to convert
   Mississippi SEMS files to the VotingWorks format. Currently, only BMD and
@@ -25,6 +25,9 @@ with `VX_CONVERTER` set to the appropriate value:
 - **`nh-accuvote`**: uses `ballot-interpreter-nh` to convert New Hampshire
   AccuVote files to the VotingWorks format. Currently, only BMD and AccuVote
   timing-mark ballots are supported with this converter.
+
+You may set this value in `.env.local` to make the value persistent on your
+machine.
 
 ### Optional prerequisites
 

--- a/frontends/election-manager/prodserver/setupProxy.js
+++ b/frontends/election-manager/prodserver/setupProxy.js
@@ -11,35 +11,6 @@ const express = require('express');
 const { createProxyMiddleware: proxy } = require('http-proxy-middleware');
 const { dirname, join } = require('path');
 
-/**
- * @param {string} envVar
- * @param {boolean=} defaultValue
- * @returns {boolean}
- */
-function asBoolean(envVar, defaultValue = false) {
-  switch (envVar && envVar.trim().toLowerCase()) {
-    case undefined:
-    case '':
-      return defaultValue;
-
-    case 'true':
-    case 'yes':
-    case '1':
-      return true;
-
-    case 'false':
-    case 'no':
-    case '0':
-      return false;
-
-    default:
-      console.log(
-        `cannot interpret "${envVar}" as a boolean, expected "true" or "false"; using default value "${defaultValue}""`
-      );
-      return defaultValue;
-  }
-}
-
 module.exports = function (app) {
   app.use(proxy('/card', { target: 'http://localhost:3001/' }));
   app.use(proxy('/convert', { target: 'http://localhost:3003/' }));
@@ -48,8 +19,6 @@ module.exports = function (app) {
     res.json({
       machineId: process.env.VX_MACHINE_ID || '0000',
       codeVersion: process.env.VX_CODE_VERSION || 'dev',
-      bypassAuthentication: asBoolean(process.env.BYPASS_AUTHENTICATION),
-      converter: process.env.VX_CONVERTER || 'ms-sems',
     });
   });
 

--- a/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
+++ b/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
@@ -63,13 +63,6 @@ exports[`L&A (logic and accuracy) flow 1`] = `
           role="option"
           type="button"
         >
-          Write-Ins
-        </button>
-        <button
-          class="sc-iBPRYJ bnpNDy"
-          role="option"
-          type="button"
-        >
           Tally
         </button>
         <button
@@ -318,13 +311,6 @@ exports[`L&A (logic and accuracy) flow 2`] = `
           type="button"
         >
           L&A
-        </button>
-        <button
-          class="sc-iBPRYJ bnpNDy"
-          role="option"
-          type="button"
-        >
-          Write-Ins
         </button>
         <button
           class="sc-iBPRYJ bnpNDy"

--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -104,8 +104,6 @@ beforeEach(() => {
     typedAs<MachineConfig>({
       machineId: '0000',
       codeVersion: 'TEST',
-      bypassAuthentication: false,
-      converter: 'ms-sems',
     })
   );
 });
@@ -986,7 +984,12 @@ test('clearing all files after marking as official clears SEMS, CVR, and manual 
   const card = new MemoryCard();
   const hardware = MemoryHardware.buildStandard();
   const { getByText, getByTestId } = render(
-    <App storage={storage} card={card} hardware={hardware} />
+    <App
+      storage={storage}
+      card={card}
+      hardware={hardware}
+      converter="ms-sems"
+    />
   );
   await authenticateWithAdminCard(card);
   await screen.findByText('0 official ballots');

--- a/frontends/election-manager/src/app.tsx
+++ b/frontends/election-manager/src/app.tsx
@@ -13,6 +13,10 @@ import {
 
 import { AppRoot, Props as AppRootProps } from './app_root';
 import { machineConfigProvider } from './utils/machine_config';
+import {
+  getConverterClientType,
+  isAuthenticationEnabled,
+} from './config/features';
 
 export interface Props {
   storage?: AppRootProps['storage'];
@@ -20,6 +24,8 @@ export interface Props {
   hardware?: AppRootProps['hardware'];
   machineConfig?: AppRootProps['machineConfigProvider'];
   card?: AppRootProps['card'];
+  bypassAuthentication?: AppRootProps['bypassAuthentication'];
+  converter?: AppRootProps['converter'];
 }
 
 const defaultStorage = window.kiosk
@@ -32,6 +38,8 @@ export function App({
   storage = defaultStorage,
   printer = getPrinter(),
   machineConfig = machineConfigProvider,
+  bypassAuthentication = !isAuthenticationEnabled(),
+  converter = getConverterClientType(),
 }: Props): JSX.Element {
   const [internalHardware, setInternalHardware] = useState(hardware);
 
@@ -55,6 +63,8 @@ export function App({
         hardware={internalHardware}
         card={card}
         machineConfigProvider={machineConfig}
+        bypassAuthentication={bypassAuthentication}
+        converter={converter}
       />
     </BrowserRouter>
   );

--- a/frontends/election-manager/src/app_root.test.tsx
+++ b/frontends/election-manager/src/app_root.test.tsx
@@ -34,6 +34,7 @@ test('renders without crashing', async () => {
               hardware={new MemoryHardware()}
               card={new MemoryCard()}
               machineConfigProvider={fakeMachineConfigProvider()}
+              bypassAuthentication
               {...props}
             />
           )}

--- a/frontends/election-manager/src/app_root.tsx
+++ b/frontends/election-manager/src/app_root.tsx
@@ -58,6 +58,7 @@ import {
   ResultsFileType,
   MachineConfig,
   CastVoteRecord,
+  ConverterClientType,
 } from './config/types';
 import { getExportableTallies } from './utils/exportable_tallies';
 import {
@@ -80,6 +81,8 @@ export interface Props {
   hardware: Hardware;
   card: Card;
   machineConfigProvider: Provider<MachineConfig>;
+  bypassAuthentication: boolean;
+  converter?: ConverterClientType;
 }
 
 export const electionDefinitionStorageKey = 'electionDefinition';
@@ -97,6 +100,8 @@ export function AppRoot({
   card,
   hardware,
   machineConfigProvider,
+  bypassAuthentication,
+  converter,
 }: Props): JSX.Element {
   const logger = useMemo(
     () => new Logger(LogSource.VxAdminFrontend, window.kiosk),
@@ -154,7 +159,6 @@ export function AppRoot({
   const [isOfficialResults, setIsOfficialResults] = useState(false);
   const [machineConfig, setMachineConfig] = useState<MachineConfig>({
     machineId: '0000',
-    bypassAuthentication: false,
     codeVersion: '',
   });
 
@@ -172,7 +176,7 @@ export function AppRoot({
     electionDefinition,
     persistAuthentication: true,
     logger,
-    bypassAuthentication: machineConfig.bypassAuthentication,
+    bypassAuthentication,
     validUserTypes: VALID_USERS,
   });
 
@@ -594,6 +598,7 @@ export function AppRoot({
         castVoteRecordFiles,
         electionDefinition,
         configuredAt,
+        converter,
         isOfficialResults,
         printer,
         printBallotRef,

--- a/frontends/election-manager/src/components/election_manager.tsx
+++ b/frontends/election-manager/src/components/election_manager.tsx
@@ -35,6 +35,7 @@ import { UnlockMachineScreen } from '../screens/unlock_machine_screen';
 import { AdvancedScreen } from '../screens/advanced_screen';
 import { WriteInsScreen } from '../screens/write_ins_screen';
 import { LogicAndAccuracyScreen } from '../screens/logic_and_accuracy_screen';
+import { isWriteInAdjudicationEnabled } from '../config/features';
 
 export function ElectionManager(): JSX.Element {
   const {
@@ -56,13 +57,13 @@ export function ElectionManager(): JSX.Element {
     return (
       <Switch>
         <Route exact path={routerPaths.root}>
-          <UnconfiguredScreen converter={machineConfig.converter} />
+          <UnconfiguredScreen />
         </Route>
         <Route exact path={routerPaths.advanced}>
           <AdvancedScreen />
         </Route>
         <Route exact path={routerPaths.electionDefinition}>
-          <UnconfiguredScreen converter={machineConfig.converter} />
+          <UnconfiguredScreen />
         </Route>
       </Switch>
     );
@@ -129,9 +130,11 @@ export function ElectionManager(): JSX.Element {
       <Route exact path={routerPaths.manualDataImport}>
         <ManualDataImportIndexScreen />
       </Route>
-      <Route exact path={routerPaths.writeIns}>
-        <WriteInsScreen />
-      </Route>
+      {isWriteInAdjudicationEnabled() && (
+        <Route exact path={routerPaths.writeIns}>
+          <WriteInsScreen />
+        </Route>
+      )}
       <Route
         path={routerPaths.manualDataImportForPrecinct({
           precinctId: ':precinctId',

--- a/frontends/election-manager/src/components/navigation_screen.tsx
+++ b/frontends/election-manager/src/components/navigation_screen.tsx
@@ -9,6 +9,10 @@ import {
   Screen,
   UsbControllerButton,
 } from '@votingworks/ui';
+import {
+  isAuthenticationEnabled,
+  isWriteInAdjudicationEnabled,
+} from '../config/features';
 import { AppContext } from '../contexts/app_context';
 
 import { routerPaths } from '../router_paths';
@@ -78,13 +82,15 @@ export function NavigationScreen({
               >
                 L&amp;A
               </LinkButton>
-              <LinkButton
-                small
-                to={routerPaths.writeIns}
-                className={isActiveSection(routerPaths.writeIns)}
-              >
-                Write-Ins
-              </LinkButton>
+              {isWriteInAdjudicationEnabled() && (
+                <LinkButton
+                  small
+                  to={routerPaths.writeIns}
+                  className={isActiveSection(routerPaths.writeIns)}
+                >
+                  Write-Ins
+                </LinkButton>
+              )}
               <LinkButton
                 small
                 to={routerPaths.tally}
@@ -120,7 +126,7 @@ export function NavigationScreen({
         }
         secondaryNav={
           <React.Fragment>
-            {!machineConfig.bypassAuthentication && (
+            {isAuthenticationEnabled() && (
               <Button small onPress={lockMachine}>
                 Lock Machine
               </Button>

--- a/frontends/election-manager/src/config/features.ts
+++ b/frontends/election-manager/src/config/features.ts
@@ -1,0 +1,57 @@
+import { unsafeParse } from '@votingworks/types';
+import { asBoolean } from '@votingworks/utils';
+import { ConverterClientType, ConverterClientTypeSchema } from './types';
+
+/**
+ * Determines whether authentication is enabled.
+ *
+ * To disable authentication, add this line to `frontends/election-manager/.env.local`:
+ *
+ *     REACT_APP_VX_BYPASS_AUTHENTICATION=true
+ *
+ * To enable it, remove the line or comment it out. Restarting the server is required.
+ *
+ * @see https://create-react-app.dev/docs/adding-custom-environment-variables/
+ */
+export function isAuthenticationEnabled(): boolean {
+  return (
+    process.env.NODE_ENV !== 'development' ||
+    !asBoolean(process.env.REACT_APP_VX_BYPASS_AUTHENTICATION)
+  );
+}
+
+/**
+ * Determines whether write-in adjudication is enabled.
+ *
+ * To enable write-in adjudication, add this line to `frontends/election-manager/.env.local`:
+ *
+ *     REACT_APP_VX_WRITE_IN_ADJUDICATION=true
+ *
+ * To disable it, remove the line or comment it out. Restarting the server is required.
+ *
+ * @see https://create-react-app.dev/docs/adding-custom-environment-variables/
+ */
+export function isWriteInAdjudicationEnabled(): boolean {
+  return (
+    // Bundlers can tell this evaluates to `false` when building for production,
+    // and can inline the function call. Thus, any uses of this function may
+    // also enable further tree shaking when used in a way that the bundler can
+    // understand, e.g. `if (isWriteInAdjudicationEnabled())` or
+    // `isWriteInAdjudicationEnabled() && ...`.
+    process.env.NODE_ENV === 'development' &&
+    asBoolean(process.env.REACT_APP_VX_ENABLE_WRITE_IN_ADJUDICATION)
+  );
+}
+
+/**
+ * Determines which converter client to use, if any.
+ */
+export function getConverterClientType(): ConverterClientType | undefined {
+  const rawConverterClientType = process.env.REACT_APP_VX_CONVERTER;
+
+  if (!rawConverterClientType) {
+    return;
+  }
+
+  return unsafeParse(ConverterClientTypeSchema, rawConverterClientType);
+}

--- a/frontends/election-manager/src/config/types.ts
+++ b/frontends/election-manager/src/config/types.ts
@@ -148,18 +148,17 @@ export type Iso8601Timestamp = string;
 
 export type ConverterClientType = 'ms-sems' | 'nh-accuvote';
 
+export const ConverterClientTypeSchema = z.union([
+  z.literal('ms-sems'),
+  z.literal('nh-accuvote'),
+]);
+
 export interface MachineConfig {
   machineId: string;
   codeVersion: string;
-  bypassAuthentication: boolean;
-  converter?: ConverterClientType;
 }
 
 export const MachineConfigSchema: z.ZodSchema<MachineConfig> = z.object({
   machineId: MachineId,
   codeVersion: z.string().nonempty(),
-  bypassAuthentication: z.boolean(),
-  converter: z
-    .union([z.literal('ms-sems'), z.literal('nh-accuvote')])
-    .optional(),
 });

--- a/frontends/election-manager/src/contexts/app_context.ts
+++ b/frontends/election-manager/src/contexts/app_context.ts
@@ -14,6 +14,7 @@ import {
   ExportableTallies,
   ResultsFileType,
   MachineConfig,
+  ConverterClientType,
 } from '../config/types';
 import {
   CastVoteRecordFiles,
@@ -26,6 +27,7 @@ export interface AppContextInterface {
   castVoteRecordFiles: CastVoteRecordFiles;
   electionDefinition?: ElectionDefinition;
   configuredAt?: Iso8601Timestamp;
+  converter?: ConverterClientType;
   isOfficialResults: boolean;
   printer: Printer;
   printBallotRef?: RefObject<HTMLElement>;
@@ -87,7 +89,6 @@ const appContext: AppContextInterface = {
   machineConfig: {
     machineId: '0000',
     codeVersion: '',
-    bypassAuthentication: false,
   },
   hasCardReaderAttached: true,
   logger: new Logger(LogSource.VxAdminFrontend),

--- a/frontends/election-manager/src/demo_app.tsx
+++ b/frontends/election-manager/src/demo_app.tsx
@@ -26,7 +26,6 @@ export function getSampleMachineConfigProvider(): Provider<MachineConfig> {
       return {
         machineId: '012',
         codeVersion: 'demo',
-        bypassAuthentication: true,
       };
     },
   };
@@ -41,11 +40,8 @@ export function DemoApp({
 }: Props): JSX.Element {
   const [internalHardware, setInternalHardware] = React.useState(hardware);
   React.useEffect(() => {
-    function updateHardware() {
-      setInternalHardware((prev) => prev ?? MemoryHardware.buildDemo());
-    }
-    void updateHardware();
-  });
+    setInternalHardware((prev) => prev ?? MemoryHardware.buildDemo());
+  }, []);
   if (internalHardware === undefined) {
     return <div />;
   }
@@ -55,6 +51,7 @@ export function DemoApp({
       storage={storage}
       machineConfig={machineConfig}
       hardware={internalHardware}
+      bypassAuthentication
       {...rest}
     />
   );

--- a/frontends/election-manager/src/screens/tally_screen.tsx
+++ b/frontends/election-manager/src/screens/tally_screen.tsx
@@ -45,6 +45,7 @@ export function TallyScreen(): JSX.Element {
   const {
     castVoteRecordFiles,
     electionDefinition,
+    converter,
     isOfficialResults,
     saveIsOfficialResults,
     isTabulationRunning,
@@ -53,11 +54,9 @@ export function TallyScreen(): JSX.Element {
     resetFiles,
     logger,
     currentUserSession,
-    machineConfig,
   } = useContext(AppContext);
   assert(electionDefinition);
   const { election } = electionDefinition;
-  const { converter } = machineConfig;
   const isTestMode = castVoteRecordFiles?.fileMode === 'test';
   const externalFileInput = useRef<HTMLInputElement>(null);
 

--- a/frontends/election-manager/src/screens/unconfigured_screen.tsx
+++ b/frontends/election-manager/src/screens/unconfigured_screen.tsx
@@ -12,7 +12,7 @@ import {
 } from '../lib/converters';
 import { readFileAsync } from '../lib/read_file_async';
 
-import { ConverterClientType, InputEventFunction } from '../config/types';
+import { InputEventFunction } from '../config/types';
 
 import defaultElection from '../data/defaultElection.json';
 
@@ -55,16 +55,12 @@ function someFilesExist(files: VxFile[]) {
 
 const newElection = JSON.stringify(defaultElection);
 
-export function UnconfiguredScreen({
-  converter,
-}: {
-  converter?: ConverterClientType;
-}): JSX.Element {
+export function UnconfiguredScreen(): JSX.Element {
   const history = useHistory();
   const location = useLocation();
   const makeCancelable = useCancelablePromise();
 
-  const { saveElection } = useContext(AppContext);
+  const { converter, saveElection } = useContext(AppContext);
 
   const [isUploading, setIsUploading] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);

--- a/frontends/election-manager/src/utils/machine_config.ts
+++ b/frontends/election-manager/src/utils/machine_config.ts
@@ -2,16 +2,30 @@ import { Provider, unsafeParse } from '@votingworks/types';
 import { fetchJson } from '@votingworks/utils';
 import { MachineConfig, MachineConfigSchema } from '../config/types';
 
+/**
+ * Gets values for the machine config that should override those from the
+ * `/machine-config` API. This is only used for development.
+ */
+function getOverrides(): Partial<MachineConfig> {
+  return {
+    machineId: process.env.REACT_APP_VX_MACHINE_ID,
+    codeVersion: process.env.REACT_APP_VX_CODE_VERSION,
+  };
+}
+
 export const machineConfigProvider: Provider<MachineConfig> = {
   async get() {
-    const { machineId, codeVersion, bypassAuthentication, converter } =
-      unsafeParse(MachineConfigSchema, await fetchJson('/machine-config'));
+    const { machineId, codeVersion } = unsafeParse(
+      MachineConfigSchema,
+      await fetchJson('/machine-config')
+    );
+
+    const overrides =
+      process.env.NODE_ENV === 'development' ? getOverrides() : {};
 
     return {
-      machineId,
-      codeVersion,
-      bypassAuthentication,
-      converter,
+      machineId: overrides.machineId ?? machineId,
+      codeVersion: overrides.codeVersion ?? codeVersion,
     };
   },
 };

--- a/frontends/election-manager/test/helpers/fake_machine_config.ts
+++ b/frontends/election-manager/test/helpers/fake_machine_config.ts
@@ -4,10 +4,8 @@ import { MachineConfig } from '../../src/config/types';
 export function fakeMachineConfig({
   machineId = '000',
   codeVersion = 'test',
-  bypassAuthentication = false,
-  converter = 'ms-sems',
 }: Partial<MachineConfig> = {}): MachineConfig {
-  return { machineId, codeVersion, bypassAuthentication, converter };
+  return { machineId, codeVersion };
 }
 
 export function fakeMachineConfigProvider(

--- a/frontends/election-manager/test/render_in_app_context.tsx
+++ b/frontends/election-manager/test/render_in_app_context.tsx
@@ -102,8 +102,6 @@ export function renderInAppContext(
     machineConfig = {
       machineId: '0000',
       codeVersion: '',
-      bypassAuthentication: false,
-      converter: 'ms-sems',
     },
     hasCardReaderAttached = true,
     logger = new Logger(LogSource.VxAdminFrontend),

--- a/frontends/precinct-scanner/prodserver/setupProxy.js
+++ b/frontends/precinct-scanner/prodserver/setupProxy.js
@@ -8,35 +8,6 @@
 
 const { createProxyMiddleware: proxy } = require('http-proxy-middleware');
 
-/**
- * @param {string} envVar
- * @param {boolean=} defaultValue
- * @returns {boolean}
- */
-function asBoolean(envVar, defaultValue = false) {
-  switch (envVar && envVar.trim().toLowerCase()) {
-    case undefined:
-    case '':
-      return defaultValue;
-
-    case 'true':
-    case 'yes':
-    case '1':
-      return true;
-
-    case 'false':
-    case 'no':
-    case '0':
-      return false;
-
-    default:
-      console.log(
-        `cannot interpret "${envVar}" as a boolean, expected "true" or "false"; using default value "${defaultValue}""`
-      );
-      return defaultValue;
-  }
-}
-
 module.exports = function (app) {
   app.use(proxy('/scan', { target: 'http://localhost:3002/' }));
   app.use(proxy('/config', { target: 'http://localhost:3002/' }));
@@ -46,7 +17,6 @@ module.exports = function (app) {
     res.json({
       machineId: process.env.VX_MACHINE_ID || '0000',
       codeVersion: process.env.VX_CODE_VERSION || 'dev',
-      bypassAuthentication: asBoolean(process.env.BYPASS_AUTHENTICATION),
     });
   });
 };

--- a/frontends/precinct-scanner/src/app.tsx
+++ b/frontends/precinct-scanner/src/app.tsx
@@ -13,6 +13,7 @@ import {
 import { AppRoot, Props as AppRootProps } from './app_root';
 
 import { machineConfigProvider } from './utils/machine_config';
+import { isAuthenticationEnabled } from './config/features';
 
 export interface Props {
   hardware?: AppRootProps['hardware'];
@@ -20,6 +21,7 @@ export interface Props {
   card?: AppRootProps['card'];
   machineConfig?: AppRootProps['machineConfig'];
   storage?: AppRootProps['storage'];
+  bypassAuthentication?: AppRootProps['bypassAuthentication'];
 }
 
 export function App({
@@ -28,15 +30,13 @@ export function App({
   storage = window.kiosk ? new KioskStorage(window.kiosk) : new LocalStorage(),
   printer = getPrinter(),
   machineConfig = machineConfigProvider,
+  bypassAuthentication = !isAuthenticationEnabled(),
 }: Props): JSX.Element {
   const [internalHardware, setInternalHardware] = useState(hardware);
   useEffect(() => {
-    function updateHardware() {
-      const newInternalHardware = getHardware();
-      setInternalHardware((prev) => prev ?? newInternalHardware);
-    }
-    void updateHardware();
-  });
+    const newInternalHardware = getHardware();
+    setInternalHardware((prev) => prev ?? newInternalHardware);
+  }, []);
 
   if (!internalHardware) {
     return <BrowserRouter />;
@@ -48,6 +48,7 @@ export function App({
         hardware={internalHardware}
         printer={printer}
         machineConfig={machineConfig}
+        bypassAuthentication={bypassAuthentication}
         storage={storage}
       />
     </BrowserRouter>

--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -83,6 +83,7 @@ export interface Props {
   storage: Storage;
   printer: Printer;
   machineConfig: Provider<MachineConfig>;
+  bypassAuthentication: boolean;
 }
 
 interface HardwareState {
@@ -120,7 +121,6 @@ const initialHardwareState: Readonly<HardwareState> = {
   machineConfig: {
     machineId: '0000',
     codeVersion: 'dev',
-    bypassAuthentication: false,
   },
 };
 
@@ -312,6 +312,7 @@ export function AppRoot({
   printer,
   storage,
   machineConfig: machineConfigProvider,
+  bypassAuthentication,
 }: Props): JSX.Element {
   const [appState, dispatchAppState] = useReducer(appReducer, initialAppState);
   const {
@@ -354,7 +355,7 @@ export function AppRoot({
       smartcard,
       electionDefinition,
       persistAuthentication: false,
-      bypassAuthentication: machineConfig.bypassAuthentication,
+      bypassAuthentication,
       logger,
       validUserTypes: VALID_USERS,
     }

--- a/frontends/precinct-scanner/src/config/features.ts
+++ b/frontends/precinct-scanner/src/config/features.ts
@@ -1,0 +1,19 @@
+import { asBoolean } from '@votingworks/utils';
+
+/**
+ * Determines whether authentication is enabled.
+ *
+ * To disable authentication, add this line to `frontends/bsd/.env.local`:
+ *
+ *     REACT_APP_VX_BYPASS_AUTHENTICATION=true
+ *
+ * To enable it, remove the line or comment it out. Restarting the server is required.
+ *
+ * @see https://create-react-app.dev/docs/adding-custom-environment-variables/
+ */
+export function isAuthenticationEnabled(): boolean {
+  return (
+    process.env.NODE_ENV !== 'development' ||
+    !asBoolean(process.env.REACT_APP_VX_BYPASS_AUTHENTICATION)
+  );
+}

--- a/frontends/precinct-scanner/src/config/types.ts
+++ b/frontends/precinct-scanner/src/config/types.ts
@@ -46,12 +46,10 @@ export interface ScanningResultNeedsReview {
 export interface MachineConfig {
   machineId: string;
   codeVersion: string;
-  bypassAuthentication?: boolean;
 }
 export const MachineConfigSchema: z.ZodSchema<MachineConfig> = z.object({
   machineId: MachineId,
   codeVersion: z.string().nonempty(),
-  bypassAuthentication: z.boolean().optional(),
 });
 
 export type MachineConfigResponse = MachineConfig;

--- a/frontends/precinct-scanner/src/contexts/app_context.ts
+++ b/frontends/precinct-scanner/src/contexts/app_context.ts
@@ -19,7 +19,6 @@ const appContext: AppContextInterface = {
   machineConfig: {
     machineId: '0000',
     codeVersion: '',
-    bypassAuthentication: false,
   },
 };
 

--- a/frontends/precinct-scanner/src/preview_dashboard.tsx
+++ b/frontends/precinct-scanner/src/preview_dashboard.tsx
@@ -140,7 +140,6 @@ export function PreviewDashboard({
         machineConfig: {
           codeVersion: 'preview',
           machineId: '000',
-          bypassAuthentication: false,
         },
         electionDefinition,
       }}

--- a/frontends/precinct-scanner/src/utils/machine_config.test.ts
+++ b/frontends/precinct-scanner/src/utils/machine_config.test.ts
@@ -24,3 +24,34 @@ test('failed fetch from /machine-config', async () => {
     'fetch failed!'
   );
 });
+
+test('overrides', async () => {
+  const originalProcessEnv = process.env;
+
+  process.env = {
+    ...process.env,
+    NODE_ENV: 'development',
+    REACT_APP_VX_APP_MODE: 'MarkOnly',
+    REACT_APP_VX_MACHINE_ID: '2',
+    REACT_APP_VX_CODE_VERSION: 'test-override',
+  };
+
+  try {
+    fetchMock.get(
+      '/machine-config',
+      typedAs<MachineConfigResponse>({
+        machineId: '1',
+        codeVersion: 'test',
+      })
+    );
+
+    expect(await machineConfigProvider.get()).toEqual(
+      typedAs<MachineConfig>({
+        machineId: '2',
+        codeVersion: 'test-override',
+      })
+    );
+  } finally {
+    process.env = originalProcessEnv;
+  }
+});

--- a/frontends/precinct-scanner/src/utils/machine_config.ts
+++ b/frontends/precinct-scanner/src/utils/machine_config.ts
@@ -2,17 +2,30 @@ import { Provider, unsafeParse } from '@votingworks/types';
 import { fetchJson } from '@votingworks/utils';
 import { MachineConfig, MachineConfigResponseSchema } from '../config/types';
 
+/**
+ * Gets values for the machine config that should override those from the
+ * `/machine-config` API. This is only used for development.
+ */
+function getOverrides(): Partial<MachineConfig> {
+  return {
+    machineId: process.env.REACT_APP_VX_MACHINE_ID,
+    codeVersion: process.env.REACT_APP_VX_CODE_VERSION,
+  };
+}
+
 export const machineConfigProvider: Provider<MachineConfig> = {
   async get() {
-    const { machineId, codeVersion, bypassAuthentication } = unsafeParse(
+    const { machineId, codeVersion } = unsafeParse(
       MachineConfigResponseSchema,
       await fetchJson('/machine-config')
     );
 
+    const overrides =
+      process.env.NODE_ENV === 'development' ? getOverrides() : {};
+
     return {
-      machineId,
-      codeVersion,
-      bypassAuthentication,
+      machineId: overrides.machineId ?? machineId,
+      codeVersion: overrides.codeVersion ?? codeVersion,
     };
   },
 };

--- a/integration-testing/bsd/Makefile
+++ b/integration-testing/bsd/Makefile
@@ -3,7 +3,6 @@ SCAN := ../../services/scan
 SMARTCARDS := ../../services/smartcards
 export PIPENV_VENV_IN_PROJECT=1
 export SCAN_WORKSPACE=/tmp
-export BYPASS_AUTHENTICATION=true
 export MOCK_SCANNER_FILES=test/fixtures/hamilton-seal-049e9e66cd/sample-ballot-undervotes-p1.png,test/fixtures/hamilton-seal-049e9e66cd/sample-ballot-undervotes-p2.png
 
 build-bsd:

--- a/integration-testing/bsd/package.json
+++ b/integration-testing/bsd/package.json
@@ -62,5 +62,9 @@
     "sort-package-json": "^1.50.0",
     "start-server-and-test": "^1.12.5",
     "typescript": "4.6.3"
+  },
+  "dependencies": {
+    "buffer": "^6.0.3",
+    "js-sha256": "^0.9.0"
   }
 }

--- a/integration-testing/election-manager/Makefile
+++ b/integration-testing/election-manager/Makefile
@@ -2,7 +2,6 @@ ELECTION_MANAGER := ../../frontends/election-manager
 SMARTCARDS := ../../services/smartcards
 SEMS := ../../services/converter-ms-sems
 export PIPENV_VENV_IN_PROJECT=1
-export BYPASS_AUTHENTICATION=true
 
 clean-downloads:
 	rm cypress/downloads/*

--- a/integration-testing/election-manager/cypress/integration/candidate_contest_tallies.ts
+++ b/integration-testing/election-manager/cypress/integration/candidate_contest_tallies.ts
@@ -99,6 +99,7 @@ describe('Election Manager can create SEMS tallies', () => {
       ),
     ]);
     cy.visit('/');
+    cy.contains('Convert from SEMS files');
     cy.get('input[type="file"]').attachFile(
       'electionMultiPartyPrimarySample.json'
     );

--- a/integration-testing/election-manager/cypress/integration/tallies.ts
+++ b/integration-testing/election-manager/cypress/integration/tallies.ts
@@ -3,6 +3,7 @@ import { electionMultiPartyPrimaryWithDataFiles } from '@votingworks/fixtures';
 describe('Election Manager can create SEMS tallies', () => {
   it('Election Manager can tally results properly', () => {
     cy.visit('/');
+    cy.contains('Convert from SEMS files');
     cy.get('input[type="file"]').attachFile(
       'electionMultiPartyPrimarySample.json'
     );

--- a/integration-testing/election-manager/cypress/integration/yes_no_contest_tallies.ts
+++ b/integration-testing/election-manager/cypress/integration/yes_no_contest_tallies.ts
@@ -150,6 +150,7 @@ describe('Election Manager can create SEMS tallies', () => {
       ),
     ]);
     cy.visit('/');
+    cy.contains('Convert from SEMS files');
     cy.get('input[type="file"]').attachFile('electionWithMsEitherNeither.json');
     cy.contains('Election loading');
     cy.contains('abdfbe6a58');

--- a/libs/utils/src/as_boolean.test.ts
+++ b/libs/utils/src/as_boolean.test.ts
@@ -1,0 +1,20 @@
+import { asBoolean } from './as_boolean';
+
+test('truthy values', () => {
+  expect(asBoolean('true')).toBe(true);
+  expect(asBoolean('true ')).toBe(true);
+  expect(asBoolean('1')).toBe(true);
+  expect(asBoolean('yes')).toBe(true);
+  expect(asBoolean('TRUE')).toBe(true);
+  expect(asBoolean('YES')).toBe(true);
+});
+
+test('falsy values', () => {
+  expect(asBoolean()).toBe(false);
+  expect(asBoolean('')).toBe(false);
+  expect(asBoolean(' ')).toBe(false);
+  expect(asBoolean('0')).toBe(false);
+  expect(asBoolean('false')).toBe(false);
+  expect(asBoolean('no')).toBe(false);
+  expect(asBoolean('FALSE')).toBe(false);
+});

--- a/libs/utils/src/as_boolean.ts
+++ b/libs/utils/src/as_boolean.ts
@@ -1,0 +1,14 @@
+/**
+ * Convert a string value to a boolean, such as from an environment variable.
+ */
+export function asBoolean(value?: string): boolean {
+  switch (value?.toLowerCase().trim()) {
+    case 'true':
+    case 'yes':
+    case '1':
+      return true;
+
+    default:
+      return false;
+  }
+}

--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -1,4 +1,5 @@
 /* istanbul ignore file */
+export * from './as_boolean';
 export * from './assert';
 export * from './ballot_package';
 export * from './Card';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -902,6 +902,9 @@ importers:
       express: ^4.17.1
       http-proxy-middleware: 1.0.6
   integration-testing/bsd:
+    dependencies:
+      buffer: 6.0.3
+      js-sha256: 0.9.0
     devDependencies:
       '@testing-library/cypress': 8.0.2_cypress@9.5.4
       '@typescript-eslint/eslint-plugin': 5.21.0_fbe1c70003501a3a5208745492f4edde
@@ -932,6 +935,7 @@ importers:
       '@typescript-eslint/eslint-plugin': ^5.21.0
       '@typescript-eslint/parser': ^5.21.0
       '@votingworks/fixtures': workspace:*
+      buffer: ^6.0.3
       cypress: ^9.5.4
       cypress-file-upload: ^5.0.7
       eslint: ^7.17.0
@@ -947,6 +951,7 @@ importers:
       eslint-plugin-vx: workspace:*
       is-ci-cli: ^2.1.2
       jest-environment-jsdom-sixteen: ^1.0.3
+      js-sha256: ^0.9.0
       lint-staged: ^10.5.4
       prettier: ^2.6.2
       sort-package-json: ^1.50.0
@@ -11958,7 +11963,7 @@ packages:
       integrity: sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA==
   /axios/0.21.1_debug@4.3.1:
     dependencies:
-      follow-redirects: 1.14.1_debug@4.3.2
+      follow-redirects: 1.14.1_debug@4.3.1
     dev: true
     peerDependencies:
       debug: '*'
@@ -19701,7 +19706,6 @@ packages:
   /follow-redirects/1.14.1_debug@4.3.1:
     dependencies:
       debug: 4.3.1
-    dev: false
     engines:
       node: '>=4.0'
     peerDependencies:
@@ -19714,6 +19718,7 @@ packages:
   /follow-redirects/1.14.1_debug@4.3.2:
     dependencies:
       debug: 4.3.2_supports-color@6.1.0
+    dev: false
     engines:
       node: '>=4.0'
     peerDependencies:


### PR DESCRIPTION

## Overview
- Allows overriding machine config using `.env` files, making persistent local changes easier to manage.
- Hides "Write-Ins" tabe by default. While this feature is in development it'll be hidden by default, but will be easy to persistently enable locally using `.env` files.
- Move `converter` from machine config to a feature flag. This is something that, for now, is part of the build and will not be changed once the machine is built.

As a result of these changes, we can no longer bypass authentication in production builds. Currently, write-in adjudication will also be removed from production builds. This can be changed when the feature becomes ready to ship to a customer by removing the `NODE_ENV` check.

I'd considered doing this using [`import.meta`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import.meta), but it's not easy to augment that with webpack v4 and we cannot use webpack v5 until we upgrade to react-scripts v5 (#1786).

## Demo Video or Screenshot
n/a

## Testing Plan 
Did a fair amount of manual testing and updated cypress to account for the fact that it can no longer bypass authentication.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
