### PR TITLE
Print test deck directly

### DIFF
--- a/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
+++ b/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
@@ -100,35 +100,104 @@ exports[`L&A (logic and accuracy) flow 1`] = `
           Test Decks
         </h1>
         <p>
+          Select desired precinct for 
           <strong>
-            Election:
+            Mock General Election Choctaw 2020
           </strong>
-           
-          Mock General Election Choctaw 2020
-          <br />
+          .
+        </p>
+      </div>
+      <p>
+        <button
+          class="sc-iBPRYJ gUjZCM"
+          type="button"
+        >
           <strong>
-            Precinct:
+            All Precincts
           </strong>
-           
+        </button>
+      </p>
+      <div
+        class="sc-dIUggk diaJDk"
+      >
+        <button
+          class="sc-iBPRYJ gUjZCM"
+          type="button"
+        >
+          Bywy
+        </button>
+        <button
+          class="sc-iBPRYJ gUjZCM"
+          type="button"
+        >
+          Chester
+        </button>
+        <button
+          class="sc-iBPRYJ gUjZCM"
+          type="button"
+        >
           District 5
-        </p>
-        <p>
-          <button
-            class="sc-iBPRYJ cWqIfm"
-            type="button"
-          >
-            Print Test Deck
-          </button>
-        </p>
-        <p>
-          <button
-            class="sc-iBPRYJ bnpNDy"
-            role="option"
-            type="button"
-          >
-            Back to Test Deck list
-          </button>
-        </p>
+        </button>
+        <button
+          class="sc-iBPRYJ gUjZCM"
+          type="button"
+        >
+          East Weir
+        </button>
+        <button
+          class="sc-iBPRYJ gUjZCM"
+          type="button"
+        >
+          Fentress
+        </button>
+        <button
+          class="sc-iBPRYJ gUjZCM"
+          type="button"
+        >
+          French Camp
+        </button>
+        <button
+          class="sc-iBPRYJ gUjZCM"
+          type="button"
+        >
+          Hebron
+        </button>
+        <button
+          class="sc-iBPRYJ gUjZCM"
+          type="button"
+        >
+          Kenego
+        </button>
+        <button
+          class="sc-iBPRYJ gUjZCM"
+          type="button"
+        >
+          Panhandle
+        </button>
+        <button
+          class="sc-iBPRYJ gUjZCM"
+          type="button"
+        >
+          Reform
+        </button>
+        <button
+          class="sc-iBPRYJ gUjZCM"
+          type="button"
+        >
+          Sherwood
+        </button>
+        <button
+          class="sc-iBPRYJ gUjZCM"
+          type="button"
+        >
+          Southwest Ackerman
+        </button>
+        <button
+          class="sc-iBPRYJ gUjZCM"
+          type="button"
+        >
+          West Weir
+        </button>
       </div>
     </main>
     <div

--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -335,7 +335,6 @@ test('L&A (logic and accuracy) flow', async () => {
   userEvent.click(screen.getByText('L&A'));
   userEvent.click(screen.getByText('Print Test Decks'));
   userEvent.click(screen.getByText('District 5'));
-  userEvent.click(screen.getByText('Print Test Deck'));
   await screen.findByText('Printing Test Deck: District 5', {
     exact: false,
   });

--- a/frontends/election-manager/src/components/election_manager.tsx
+++ b/frontends/election-manager/src/components/election_manager.tsx
@@ -205,12 +205,7 @@ export function ElectionManager(): JSX.Element {
       <Route exact path={routerPaths.logicAndAccuracy}>
         <LogicAndAccuracyScreen />
       </Route>
-      <Route
-        path={[
-          routerPaths.testDeck({ precinctId: ':precinctId' }),
-          routerPaths.testDecks,
-        ]}
-      >
+      <Route path={[routerPaths.testDecks]}>
         <PrintTestDeckScreen />
       </Route>
       <Route

--- a/frontends/election-manager/src/router_paths.ts
+++ b/frontends/election-manager/src/router_paths.ts
@@ -49,8 +49,6 @@ export const routerPaths = {
   overvoteCombinationReport: '/tally/pairs',
   logicAndAccuracy: '/logic-and-accuracy',
   testDecks: '/logic-and-accuracy/test-decks',
-  testDeck: ({ precinctId }: PrecinctReportScreenProps): string =>
-    `/logic-and-accuracy/test-decks/${precinctId}`,
   testDeckTallyReports: '/logic-and-accuracy/test-deck-tally-reports',
   testDeckTallyReport: ({ precinctId }: PrecinctReportScreenProps): string =>
     `/logic-and-accuracy/test-deck-tally-reports/${precinctId}`,

--- a/frontends/election-manager/src/screens/print_test_deck_screen.test.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { fireEvent, waitFor } from '@testing-library/react';
 import { fakeKiosk, fakePrinterInfo } from '@votingworks/test-utils';
-import { Route } from 'react-router-dom';
 
 import { PrintTestDeckScreen } from './print_test_deck_screen';
 import { renderInAppContext } from '../../test/render_in_app_context';
@@ -24,15 +23,10 @@ test('Printing the full test deck sorts precincts', async () => {
   ]);
 
   const { getByText, getByLabelText } = renderInAppContext(
-    <Route path="/tally/print-test-deck/:precinctId">
-      <PrintTestDeckScreen />
-    </Route>,
-    {
-      route: '/tally/print-test-deck/all',
-    }
+    <PrintTestDeckScreen />
   );
 
-  fireEvent.click(getByText('Print Test Deck'));
+  fireEvent.click(getByText('All Precincts'));
 
   // Check that the printing modals appear in alphabetical order
   await waitFor(() => getByLabelText('Printing Test Deck, (1 of 13),: ,Bywy.'));


### PR DESCRIPTION
## Overview
Closes #1820

Removes the test deck print confirmation screen. Test decks now print immediately when selected from the precinct list screen.

## Demo Video or Screenshot

<img width="1440" alt="Screen Shot 2022-05-16 at 11 35 22 AM" src="https://user-images.githubusercontent.com/37960853/168659727-7ed97704-9a7e-4700-8aee-33d14571310f.png">

## Testing Plan

Updated existing snapshot and testing flow.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
