### PR TITLE
Allow vxdev to override wia feature flag

### DIFF
--- a/frontends/election-manager/src/config/features.ts
+++ b/frontends/election-manager/src/config/features.ts
@@ -38,7 +38,8 @@ export function isWriteInAdjudicationEnabled(): boolean {
     // also enable further tree shaking when used in a way that the bundler can
     // understand, e.g. `if (isWriteInAdjudicationEnabled())` or
     // `isWriteInAdjudicationEnabled() && ...`.
-    process.env.NODE_ENV === 'development' &&
+    (process.env.NODE_ENV === 'development' ||
+      asBoolean(process.env.REACT_APP_VX_DEV)) &&
     asBoolean(process.env.REACT_APP_VX_ENABLE_WRITE_IN_ADJUDICATION)
   );
 }


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite-complete-system/issues/185#issuecomment-1127899581
Allows VxDev to override the production check for the write in adjudication feature flag. Will need to make another PR in vxsuite-complete-system to add this environment variable to VxDev. For now people can manually make a .env.local file to otherwise enable the feature if they want. 

## Demo Video or Screenshot
N/A
## Testing Plan 
Ran locally in dev mode, feature flag still worked as it did before. Compiled through vxsuite-complete-system and was able to toggle the write in tab on with the two flags enabled. 

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
