### PR TITLE
ci: validate and correct config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,6 +291,24 @@ jobs:
           command: |
             pnpm --dir libs/cdf-schema-builder test
 
+  test-libs-cdf-types-cast-vote-records:
+    executor: nodejs
+    resource_class: xlarge
+    steps:
+      - checkout-and-install
+      - run:
+          name: Build
+          command: |
+            pnpm --dir libs/cdf-types-cast-vote-records build
+      - run:
+          name: Lint
+          command: |
+            pnpm --dir libs/cdf-types-cast-vote-records lint
+      - run:
+          name: Test
+          command: |
+            pnpm --dir libs/cdf-types-cast-vote-records test
+
   test-libs-cdf-types-election-event-logging:
     executor: nodejs
     resource_class: xlarge
@@ -578,6 +596,7 @@ workflows:
       - test-libs-ballot-interpreter-nh
       - test-libs-ballot-interpreter-vx
       - test-libs-cdf-schema-builder
+      - test-libs-cdf-types-cast-vote-records
       - test-libs-cdf-types-election-event-logging
       - test-libs-eslint-plugin-vx
       - test-libs-fixtures

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -573,6 +573,7 @@ workflows:
       - test-integration-testing-bmd
       - test-integration-testing-bsd
       - test-integration-testing-election-manager
+      - test-libs-api
       - test-libs-ballot-encoder
       - test-libs-ballot-interpreter-nh
       - test-libs-ballot-interpreter-vx

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2216,6 +2216,7 @@ importers:
   script:
     dependencies:
       resolve-from: 5.0.0
+      yaml: 2.1.0
     devDependencies:
       '@types/node': 16.11.29
       esbuild: 0.13.14
@@ -2229,6 +2230,7 @@ importers:
       prettier: ^2.3.1
       resolve-from: ^5.0.0
       typescript: ^4.3.4
+      yaml: ^2.1.0
   services/scan:
     dependencies:
       '@votingworks/api': link:../../libs/api
@@ -32789,6 +32791,12 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+  /yaml/2.1.0:
+    dev: false
+    engines:
+      node: '>= 14'
+    resolution:
+      integrity: sha512-OuAINfTsoJrY5H7CBWnKZhX6nZciXBydrMtTHr1dC4nP40X5jyTIVlogZHxSlVZM8zSgXRfgZGsaHF4+pV+JRw==
   /yargs-parser/13.1.2:
     dependencies:
       camelcase: 5.3.1

--- a/script/package.json
+++ b/script/package.json
@@ -13,6 +13,7 @@
     "typescript": "^4.3.4"
   },
   "dependencies": {
-    "resolve-from": "^5.0.0"
+    "resolve-from": "^5.0.0",
+    "yaml": "^2.1.0"
   }
 }

--- a/script/src/validate-monorepo/circleci.ts
+++ b/script/src/validate-monorepo/circleci.ts
@@ -1,0 +1,122 @@
+import { readFile } from 'fs/promises';
+import { parse as parseYaml } from 'yaml';
+
+/**
+ * Any kind of validation issue with the CircleCI configuration.
+ */
+export type ValidationIssue = UnusedJobIssue | UntestedPackageIssue;
+
+/**
+ * All the kinds of validation issues for CircleCI configuration.
+ */
+export enum ValidationIssueKind {
+  UnusedJobIssue = 'UnusedJobIssue',
+  UntestedPackageIssue = 'UntestedPackageIssue',
+}
+
+/**
+ * CircleCI job is unused.
+ */
+export interface UnusedJobIssue {
+  kind: ValidationIssueKind.UnusedJobIssue;
+  configPath: string;
+  jobName: string;
+}
+
+/**
+ * CircleCI config has no tests for a package.
+ */
+export interface UntestedPackageIssue {
+  kind: ValidationIssueKind.UntestedPackageIssue;
+  configPath: string;
+  packagePath: string;
+  expectedJobName: string;
+}
+
+/**
+ * CircleCI configuration.
+ */
+export interface Config {
+  version: string;
+  jobs: Record<string, Job>;
+  workflows: Record<string, Workflow>;
+}
+
+/**
+ * CircleCI job. We don't actually need to know anything about the job for now,
+ * so we just ignore its real data type.
+ */
+export type Job = unknown;
+
+/**
+ * CircleCI workflow.
+ */
+export interface Workflow {
+  jobs: string[];
+}
+
+/**
+ * Loads a CircleCI configuration from a file.
+ */
+export async function loadConfig(configPath: string): Promise<Config> {
+  const configData = await readFile(configPath, {
+    encoding: 'utf-8',
+  });
+
+  return parseYaml(configData);
+}
+
+/**
+ * Validates the CircleCI configuration.
+ */
+export function* checkConfig(
+  config: Config,
+  configPath: string,
+  workspacePaths: readonly string[]
+): Generator<ValidationIssue> {
+  const unusedJobs = new Set(Object.keys(config.jobs));
+
+  for (const workflow of Object.values(config.workflows)) {
+    for (const jobName of workflow.jobs) {
+      unusedJobs.delete(jobName);
+    }
+  }
+
+  for (const unusedJob of unusedJobs) {
+    yield {
+      kind: ValidationIssueKind.UnusedJobIssue,
+      configPath,
+      jobName: unusedJob,
+    };
+  }
+
+  for (const workspacePath of workspacePaths) {
+    const match = workspacePath.match(/([^/]+)\/(.+)/);
+    if (match === null) {
+      continue;
+    }
+
+    const [, packageType, packageName] = match;
+
+    // exclude some packages that are intentionally not tested
+    if (
+      (packageType === 'libs' && packageName.startsWith('@types/')) ||
+      packageName.endsWith('/prodserver')
+    ) {
+      continue;
+    }
+
+    const expectedJobName = packageName
+      ? `test-${packageType}-${packageName}`
+      : `test-${packageType}`;
+
+    if (!(expectedJobName in config.jobs)) {
+      yield {
+        kind: ValidationIssueKind.UntestedPackageIssue,
+        configPath,
+        packagePath: workspacePath,
+        expectedJobName,
+      };
+    }
+  }
+}

--- a/script/src/validate-monorepo/pnpm.ts
+++ b/script/src/validate-monorepo/pnpm.ts
@@ -1,0 +1,27 @@
+import { execFile } from 'child_process';
+import { relative } from 'path';
+
+/**
+ * Get all pnpm workspace package paths.
+ */
+export function getWorkspacePackagePaths(root: string): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      'pnpm',
+      ['recursive', 'list', '--depth=-1', '--porcelain'],
+      { cwd: root },
+      (err, stdout) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(
+            stdout
+              .split('\n')
+              .map((line) => relative(root, line))
+              .filter((line) => line.length > 0)
+          );
+        }
+      }
+    );
+  });
+}

--- a/script/src/validate-monorepo/validation.ts
+++ b/script/src/validate-monorepo/validation.ts
@@ -176,7 +176,7 @@ export async function* checkTsconfigMatchesPackageJson(
     );
 
     if (
-      await maybeReadTsconfig(expectedWorkspaceDependencyTsconfigBuildPath) &&
+      (await maybeReadTsconfig(expectedWorkspaceDependencyTsconfigBuildPath)) &&
       !tsconfigReferencesPaths.has(expectedWorkspaceDependencyTsconfigBuildPath)
     ) {
       yield {


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Adds validation to `validate-monorepo` for the CircleCI config. I forgot to add the config for `libs/api` in #1840, and it turns out `cdf-types-cast-vote-records` wasn't being tested either!

## Demo Video or Screenshot
[<img width="535" alt="image" src="https://user-images.githubusercontent.com/1938/169103057-657ce929-d0e4-4371-820d-3acf3d15c3a1.png">](https://app.circleci.com/pipelines/github/votingworks/vxsuite/3875/workflows/c51dd0c9-586e-4527-9761-8e48dc1abe57/jobs/73062)
[<img width="706" alt="image" src="https://user-images.githubusercontent.com/1938/169132462-264ceba1-a78e-413d-a258-6a53b1f15559.png">](https://app.circleci.com/pipelines/github/votingworks/vxsuite/3877/workflows/035a3f04-5014-49a0-ad5b-cfffd4398db4/jobs/73137)

## Testing Plan 
Automated.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
