### PR TITLE
feat(ui): Prose only centers horizontally with margin

### DIFF
--- a/frontends/bmd/src/components/__snapshots__/election_info.test.tsx.snap
+++ b/frontends/bmd/src/components/__snapshots__/election_info.test.tsx.snap
@@ -722,7 +722,7 @@ exports[`renders vertical ElectionInfo with hash when specified 1`] = `
       </svg>
     </div>
     <div
-      class="sc-jRQAMF huupYJ"
+      class="sc-jRQAMF fJXuaR"
     >
       <h1
         aria-label=" General Election."
@@ -938,7 +938,7 @@ exports[`renders vertical ElectionInfo without hash by default 1`] = `
       </svg>
     </div>
     <div
-      class="sc-jRQAMF huupYJ"
+      class="sc-jRQAMF fJXuaR"
     >
       <h1
         aria-label=" General Election."

--- a/frontends/bmd/src/pages/__snapshots__/cast_ballot_page.test.tsx.snap
+++ b/frontends/bmd/src/pages/__snapshots__/cast_ballot_page.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`renders CastBallotPage 1`] = `
     class="sc-llYToB tCtnT"
   >
     <div
-      class="sc-jRQAMF emGwAi"
+      class="sc-jRQAMF bqXaZe"
       id="audiofocus"
     >
       <h1

--- a/frontends/bmd/src/pages/__snapshots__/not_found_page.test.tsx.snap
+++ b/frontends/bmd/src/pages/__snapshots__/not_found_page.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`renders NotFoundPage 1`] = `
     class="sc-llYToB tCtnT"
   >
     <div
-      class="sc-jRQAMF huupYJ"
+      class="sc-jRQAMF fJXuaR"
     >
       <h1>
         Page Not Found.

--- a/frontends/bmd/src/pages/__snapshots__/print_page.test.tsx.snap
+++ b/frontends/bmd/src/pages/__snapshots__/print_page.test.tsx.snap
@@ -297,7 +297,7 @@ exports[`renders PrintPage without votes 1`] = `
     class="sc-llYToB tCtnT"
   >
     <div
-      class="sc-jRQAMF huupYJ"
+      class="sc-jRQAMF fJXuaR"
       id="audiofocus"
     >
       <p>

--- a/frontends/bmd/src/pages/__snapshots__/start_page.test.tsx.snap
+++ b/frontends/bmd/src/pages/__snapshots__/start_page.test.tsx.snap
@@ -146,7 +146,7 @@ exports[`renders StartPage 1`] = `
     class="sc-llYToB tCtnT"
   >
     <div
-      class="sc-jRQAMF huupYJ"
+      class="sc-jRQAMF fJXuaR"
     >
       <h1
         aria-label="Democratic Primary Election."
@@ -463,7 +463,7 @@ exports[`renders StartPage with inline SVG 1`] = `
     class="sc-llYToB tCtnT"
   >
     <div
-      class="sc-jRQAMF huupYJ"
+      class="sc-jRQAMF fJXuaR"
     >
       <h1
         aria-label=" General Election."
@@ -938,7 +938,7 @@ exports[`renders StartPage with no seal 1`] = `
     class="sc-llYToB tCtnT"
   >
     <div
-      class="sc-jRQAMF huupYJ"
+      class="sc-jRQAMF fJXuaR"
     >
       <h1
         aria-label=" General Election."

--- a/libs/ui/src/__snapshots__/prose.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/prose.test.tsx.snap
@@ -113,7 +113,7 @@ exports[`renders Prose with theme 1`] = `
 
 exports[`renders Prose with with non-default options 1`] = `
 <div
-  class="sc-bdvvaa bAMuWr"
+  class="sc-bdvvaa eVGEzn"
 >
   <h1>
     Heading 1

--- a/libs/ui/src/__snapshots__/setup_card_reader_page.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/setup_card_reader_page.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`renders SetupCardReaderPage renders SetupCardReaderPage with usePollWor
     class="sc-bdvvaa jnfvZB"
   >
     <div
-      class="sc-gsDJrp immFYi"
+      class="sc-gsDJrp fCJDVu"
     >
       <h1>
         Card Reader Not Detected
@@ -29,7 +29,7 @@ exports[`renders SetupCardReaderPage triggers useEffect property 1`] = `
     class="sc-bdvvaa jnfvZB"
   >
     <div
-      class="sc-gsDJrp immFYi"
+      class="sc-gsDJrp fCJDVu"
     >
       <h1>
         Card Reader Not Detected
@@ -50,7 +50,7 @@ exports[`renders SetupCardReaderPage with no useEffect trigger as expected 1`] =
     class="sc-bdvvaa jnfvZB"
   >
     <div
-      class="sc-gsDJrp immFYi"
+      class="sc-gsDJrp fCJDVu"
     >
       <h1>
         Card Reader Not Detected

--- a/libs/ui/src/prose.tsx
+++ b/libs/ui/src/prose.tsx
@@ -10,7 +10,7 @@ export interface ProseProps {
 }
 
 export const Prose = styled('div')<ProseProps>`
-  margin: ${({ textCenter }) => (textCenter ? 'auto' : undefined)};
+  margin: ${({ textCenter }) => (textCenter ? '0 auto' : undefined)};
   max-width: ${({ maxWidth = true }) => (maxWidth ? '66ch' : undefined)};
   text-align: ${({ textCenter, textRight }) =>
     (textCenter && 'center') || (textRight && 'right')};


### PR DESCRIPTION
Related to https://github.com/votingworks/vxsuite-roadmap/issues/44

Problem with `margin: auto` on top and bottom was that when element was in a container with `display: flex` the element would center itself vertically in the available space. Prose is not meant to be used for layout other than the text copy contained within.