### PR TITLE
chore(deps): update to `@testing-library/react` v12

### DIFF
--- a/frontends/bmd/package.json
+++ b/frontends/bmd/package.json
@@ -129,7 +129,7 @@
     "@codemod/parser": "^1.0.7",
     "@testing-library/cypress": "^8.0.2",
     "@testing-library/jest-dom": "^5.16.4",
-    "@testing-library/react": "^11.2.3",
+    "@testing-library/react": "^12.1.5",
     "@testing-library/user-event": "^13.5.0",
     "@types/debug": "^4.1.6",
     "@types/history": "^4.7.8",

--- a/frontends/bmd/src/app_cardless_voting.test.tsx
+++ b/frontends/bmd/src/app_cardless_voting.test.tsx
@@ -76,15 +76,16 @@ test('Cardless Voting Flow', async () => {
   // Select precinct
   screen.getByText('State of Hamilton');
   const precinctSelect = screen.getByLabelText('Precinct');
-  const precinctId = (
-    within(precinctSelect).getByText('Center Springfield') as HTMLOptionElement
-  ).value;
+  const precinctId =
+    within(precinctSelect).getByText<HTMLOptionElement>(
+      'Center Springfield'
+    ).value;
   fireEvent.change(precinctSelect, { target: { value: precinctId } });
   within(screen.getByTestId('election-info')).getByText('Center Springfield');
 
   fireEvent.click(screen.getByText('Live Election Mode'));
   expect(
-    (screen.getByText('Live Election Mode') as HTMLButtonElement).disabled
+    screen.getByText<HTMLButtonElement>('Live Election Mode').disabled
   ).toBeTruthy();
 
   // Remove card
@@ -328,15 +329,14 @@ test('poll worker must select a precinct first', async () => {
   // Select precinct
   screen.getByText('State of Hamilton');
   const precinctSelect = screen.getByLabelText('Precinct');
-  const precinctId = (
-    within(precinctSelect).getByText('All Precincts') as HTMLOptionElement
-  ).value;
+  const precinctId =
+    within(precinctSelect).getByText<HTMLOptionElement>('All Precincts').value;
   fireEvent.change(precinctSelect, { target: { value: precinctId } });
   within(screen.getByTestId('election-info')).getByText('All Precincts');
 
   fireEvent.click(screen.getByText('Live Election Mode'));
   expect(
-    (screen.getByText('Live Election Mode') as HTMLButtonElement).disabled
+    screen.getByText<HTMLButtonElement>('Live Election Mode').disabled
   ).toBeTruthy();
 
   // Remove card

--- a/frontends/bmd/src/app_end_to_end.test.tsx
+++ b/frontends/bmd/src/app_end_to_end.test.tsx
@@ -109,15 +109,16 @@ it('MarkAndPrint end-to-end flow', async () => {
   // Select precinct
   screen.getByText('State of Hamilton');
   const precinctSelect = screen.getByLabelText('Precinct');
-  const precinctId = (
-    within(precinctSelect).getByText('Center Springfield') as HTMLOptionElement
-  ).value;
+  const precinctId =
+    within(precinctSelect).getByText<HTMLOptionElement>(
+      'Center Springfield'
+    ).value;
   fireEvent.change(precinctSelect, { target: { value: precinctId } });
   within(screen.getByTestId('election-info')).getByText('Center Springfield');
 
   fireEvent.click(screen.getByText('Live Election Mode'));
   expect(
-    (screen.getByText('Live Election Mode') as HTMLButtonElement).disabled
+    screen.getByText<HTMLButtonElement>('Live Election Mode').disabled
   ).toBeTruthy();
 
   // Remove card

--- a/frontends/bmd/src/app_mark_only.test.tsx
+++ b/frontends/bmd/src/app_mark_only.test.tsx
@@ -82,15 +82,16 @@ it('MarkOnly flow', async () => {
   // select precinct
   screen.getByText('State of Hamilton');
   const precinctSelect = screen.getByLabelText('Precinct');
-  const precinctId = (
-    within(precinctSelect).getByText('Center Springfield') as HTMLOptionElement
-  ).value;
+  const precinctId =
+    within(precinctSelect).getByText<HTMLOptionElement>(
+      'Center Springfield'
+    ).value;
   fireEvent.change(precinctSelect, { target: { value: precinctId } });
   within(screen.getByTestId('election-info')).getByText('Center Springfield');
 
   fireEvent.click(screen.getByText('Live Election Mode'));
   expect(
-    (screen.getByText('Live Election Mode') as HTMLButtonElement).disabled
+    screen.getByText<HTMLButtonElement>('Live Election Mode').disabled
   ).toBeTruthy();
 
   // Remove card

--- a/frontends/bmd/src/app_print_only.test.tsx
+++ b/frontends/bmd/src/app_print_only.test.tsx
@@ -94,9 +94,10 @@ test('PrintOnly flow', async () => {
   // Select precinct
   screen.getByText('State of Hamilton');
   const precinctSelect = screen.getByLabelText('Precinct');
-  const precinctId = (
-    within(precinctSelect).getByText('Center Springfield') as HTMLOptionElement
-  ).value;
+  const precinctId =
+    within(precinctSelect).getByText<HTMLOptionElement>(
+      'Center Springfield'
+    ).value;
   fireEvent.change(precinctSelect, { target: { value: precinctId } });
   within(screen.getByTestId('election-info')).getByText('Center Springfield');
 
@@ -412,11 +413,10 @@ test('PrintOnly retains app mode when unconfigured', async () => {
     // Select precinct
     screen.getByText('State of Hamilton');
     const precinctSelect = screen.getByLabelText('Precinct');
-    const precinctId = (
-      within(precinctSelect).getByText(
+    const precinctId =
+      within(precinctSelect).getByText<HTMLOptionElement>(
         'Center Springfield'
-      ) as HTMLOptionElement
-    ).value;
+      ).value;
     fireEvent.change(precinctSelect, { target: { value: precinctId } });
     within(screen.getByTestId('election-info')).getByText('Center Springfield');
 
@@ -517,9 +517,10 @@ test('PrintOnly prompts to change to live mode on election day', async () => {
   // Select precinct
   screen.getByText('State of Hamilton');
   const precinctSelect = screen.getByLabelText('Precinct');
-  const precinctId = (
-    within(precinctSelect).getByText('Center Springfield') as HTMLOptionElement
-  ).value;
+  const precinctId =
+    within(precinctSelect).getByText<HTMLOptionElement>(
+      'Center Springfield'
+    ).value;
   fireEvent.change(precinctSelect, { target: { value: precinctId } });
   within(screen.getByTestId('election-info')).getByText('Center Springfield');
 

--- a/frontends/bmd/src/pages/admin_screen.test.tsx
+++ b/frontends/bmd/src/pages/admin_screen.test.tsx
@@ -112,8 +112,8 @@ test('renders date and time settings modal', async () => {
   within(screen.getByTestId('modal')).getByText('Sat, Oct 31, 2020, 12:00 AM');
 
   const selectYear = screen.getByTestId('selectYear');
-  const optionYear = (within(selectYear).getByText('2025') as HTMLOptionElement)
-    .value;
+  const optionYear =
+    within(selectYear).getByText<HTMLOptionElement>('2025').value;
   fireEvent.change(selectYear, { target: { value: optionYear } });
 
   // Save Date and Timezone
@@ -149,9 +149,8 @@ test('select All Precincts', () => {
   );
 
   const precinctSelect = screen.getByLabelText('Precinct');
-  const allPrecinctsOption = within(precinctSelect).getByText(
-    'All Precincts'
-  ) as HTMLOptionElement;
+  const allPrecinctsOption =
+    within(precinctSelect).getByText<HTMLOptionElement>('All Precincts');
   fireEvent.change(precinctSelect, {
     target: { value: allPrecinctsOption.value },
   });
@@ -200,7 +199,7 @@ test('render All Precincts', () => {
     />
   );
 
-  const precinctSelect = screen.getByLabelText('Precinct') as HTMLSelectElement;
+  const precinctSelect = screen.getByLabelText<HTMLSelectElement>('Precinct');
   expect(precinctSelect.selectedOptions[0].textContent).toEqual(
     'All Precincts'
   );

--- a/frontends/bmd/src/pages/poll_worker_screen.test.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.test.tsx
@@ -45,6 +45,7 @@ import { fakeDevices } from '../../test/helpers/fake_devices';
 import { AriaScreenReader } from '../utils/ScreenReader';
 import { fakeTts } from '../../test/helpers/fake_tts';
 import { electionSampleWithSealDefinition } from '../data';
+import { REPORT_PRINTING_TIMEOUT_SECONDS } from '../config/globals';
 
 const electionSampleWithSeal = electionSampleWithSealDefinition.election;
 
@@ -216,10 +217,19 @@ test('printing precinct scanner report works as expected with all precinct data 
   await screen.findByText('Tally Report on Card');
   fireEvent.click(screen.getByText('Print Tally Report'));
 
+  // check that the print started
   await waitFor(() => {
-    expect(pollworkerAuth.card.clearStoredData).toHaveBeenCalledTimes(1);
     expect(printFn).toHaveBeenCalledTimes(1);
   });
+
+  // wait for the print to finish
+  jest.advanceTimersByTime(REPORT_PRINTING_TIMEOUT_SECONDS * 1000);
+
+  // check that the tallies are cleared
+  await waitFor(() => {
+    expect(pollworkerAuth.card.clearStoredData).toHaveBeenCalledTimes(1);
+  });
+
   const allPrecinctsReports = screen.getAllByTestId(
     'tally-report-undefined-undefined'
   );
@@ -294,10 +304,19 @@ test('printing precinct scanner report works as expected with single precinct da
   await screen.findByText('Tally Report on Card');
   fireEvent.click(screen.getByText('Print Tally Report'));
 
+  // check that the print started
   await waitFor(() => {
-    expect(pollworkerAuth.card.clearStoredData).toHaveBeenCalledTimes(1);
     expect(printFn).toHaveBeenCalledTimes(1);
   });
+
+  // wait for the print to finish
+  jest.advanceTimersByTime(REPORT_PRINTING_TIMEOUT_SECONDS * 1000);
+
+  // check that the tallies are cleared
+  await waitFor(() => {
+    expect(pollworkerAuth.card.clearStoredData).toHaveBeenCalledTimes(1);
+  });
+
   const centerSpringfieldReports = screen.getAllByTestId(
     'tally-report-undefined-23'
   );
@@ -401,10 +420,19 @@ test('printing precinct scanner report works as expected with all precinct speci
   await screen.findByText('Tally Report on Card');
   fireEvent.click(screen.getByText('Print Tally Report'));
 
+  // check that the print started
   await waitFor(() => {
-    expect(pollworkerAuth.card.clearStoredData).toHaveBeenCalledTimes(1);
     expect(printFn).toHaveBeenCalledTimes(1);
   });
+
+  // wait for the print to finish
+  jest.advanceTimersByTime(REPORT_PRINTING_TIMEOUT_SECONDS * 1000);
+
+  // check that the tallies are cleared
+  await waitFor(() => {
+    expect(pollworkerAuth.card.clearStoredData).toHaveBeenCalledTimes(1);
+  });
+
   const centerSpringfieldReports = screen.getAllByTestId(
     'tally-report-undefined-23'
   );
@@ -634,9 +662,17 @@ test('printing precinct scanner report works as expected with all precinct speci
   await screen.findByText('Tally Report on Card');
   fireEvent.click(screen.getByText('Print Tally Report'));
 
+  // check that the print started
+  await waitFor(() => {
+    expect(printFn).toHaveBeenCalledTimes(1);
+  });
+
+  // wait for the print to finish
+  jest.advanceTimersByTime(REPORT_PRINTING_TIMEOUT_SECONDS * 1000);
+
+  // check that the tallies are cleared
   await waitFor(() => {
     expect(pollworkerAuth.card.clearStoredData).toHaveBeenCalledTimes(1);
-    expect(printFn).toHaveBeenCalledTimes(1);
   });
 
   // Check that the expected results are on the tally report for Precinct 1 Mammal Party
@@ -911,9 +947,17 @@ test('printing precinct scanner report works as expected with all precinct combi
   await screen.findByText('Tally Report on Card');
   fireEvent.click(screen.getByText('Print Tally Report'));
 
+  // check that the print started
+  await waitFor(() => {
+    expect(printFn).toHaveBeenCalledTimes(1);
+  });
+
+  // wait for the print to finish
+  jest.advanceTimersByTime(REPORT_PRINTING_TIMEOUT_SECONDS * 1000);
+
+  // check that the tallies are cleared
   await waitFor(() => {
     expect(pollworkerAuth.card.clearStoredData).toHaveBeenCalledTimes(1);
-    expect(printFn).toHaveBeenCalledTimes(1);
   });
 
   // Check that the expected results are on the tally report for Precinct 1 Mammal Party
@@ -1097,9 +1141,17 @@ test('printing precinct scanner report works as expected with a single precinct 
   await screen.findByText('Tally Report on Card');
   fireEvent.click(screen.getByText('Print Tally Report'));
 
+  // check that the print started
+  await waitFor(() => {
+    expect(printFn).toHaveBeenCalledTimes(1);
+  });
+
+  // wait for the print to finish
+  jest.advanceTimersByTime(REPORT_PRINTING_TIMEOUT_SECONDS * 1000);
+
+  // check that the tallies are cleared
   await waitFor(() => {
     expect(pollworkerAuth.card.clearStoredData).toHaveBeenCalledTimes(1);
-    expect(printFn).toHaveBeenCalledTimes(1);
   });
 
   // Check that the expected results are on the tally report for Precinct 1 Mammal Party

--- a/frontends/bmd/src/pages/poll_worker_screen.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.tsx
@@ -39,6 +39,7 @@ import {
   Hardware,
   PrecinctScannerCardTallySchema,
   PrecinctScannerCardTally,
+  sleep,
 } from '@votingworks/utils';
 
 import {
@@ -271,10 +272,9 @@ export function PollWorkerScreen({
     async function printReport() {
       if (isPrintingPrecinctScannerReport && printLock.lock()) {
         await printer.print({ sides: 'one-sided' });
-        window.setTimeout(async () => {
-          await resetCardTallyData();
-          printLock.unlock();
-        }, REPORT_PRINTING_TIMEOUT_SECONDS * 1000);
+        await sleep(REPORT_PRINTING_TIMEOUT_SECONDS * 1000);
+        await resetCardTallyData();
+        printLock.unlock();
       }
     }
     void printReport();

--- a/frontends/bmd/test/helpers/with_markup.ts
+++ b/frontends/bmd/test/helpers/with_markup.ts
@@ -1,6 +1,6 @@
 // https://stackoverflow.com/questions/55509875/how-to-query-by-text-string-which-contains-html-tags-using-react-testing-library
 
-import { MatcherFunction, Nullish } from '@testing-library/react';
+import { MatcherFunction } from '@testing-library/react';
 
 type Query<T> = (f: MatcherFunction) => T;
 
@@ -10,7 +10,7 @@ function hasText(text: string, node: HTMLElement) {
 
 export function withMarkup<T>(query: Query<T>) {
   return (text: string): T =>
-    query((content: string, node: Nullish<Element>) => {
+    query((content: string, node: Element | null) => {
       if (!node || !(node instanceof HTMLElement)) return false;
       const childrenDontHaveText = Array.from(node.children).every(
         (child) => !hasText(text, child as HTMLElement)

--- a/frontends/bsd/package.json
+++ b/frontends/bsd/package.json
@@ -100,7 +100,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.4",
-    "@testing-library/react": "^11.2.3",
+    "@testing-library/react": "^12.1.5",
     "@testing-library/user-event": "^13.2.1",
     "@types/fast-text-encoding": "^1.0.1",
     "@types/fetch-mock": "^7.3.2",

--- a/frontends/bsd/src/components/export_logs_modal.test.tsx
+++ b/frontends/bsd/src/components/export_logs_modal.test.tsx
@@ -137,6 +137,7 @@ test('renders save modal when usb is mounted and saves log file on machine', asy
   );
 
   fireEvent.click(getByText('Save'));
+  await waitFor(() => getByText(/Saving Logs/));
   expect(mockKiosk.readFile).toHaveBeenCalled();
   jest.advanceTimersByTime(2001);
   await waitFor(() => getByText(/Logs Saved/));
@@ -195,6 +196,7 @@ test('renders save modal when usb is mounted and saves cdf log file on machine',
   );
 
   fireEvent.click(getByText('Save'));
+  await waitFor(() => getByText(/Saving Logs/));
   expect(mockKiosk.readFile).toHaveBeenCalled();
   jest.advanceTimersByTime(2001);
   await waitFor(() => getByText(/Logs Saved/));
@@ -246,6 +248,7 @@ test('render export modal with errors when appropriate', async () => {
   getByText('Save Logs');
 
   fireEvent.click(getByText('Save'));
+  await waitFor(() => getByText(/Saving Logs/));
   await waitFor(() => getByText(/Failed to Save Logs/));
   getByText(/Failed to save log file./);
   getByText(/this-is-an-error/);

--- a/frontends/bsd/src/components/scan_button.test.tsx
+++ b/frontends/bsd/src/components/scan_button.test.tsx
@@ -5,31 +5,27 @@ import { ScanButton } from './scan_button';
 
 test('is enabled by default when scanner attached', async () => {
   render(<ScanButton onPress={jest.fn()} isScannerAttached />);
-  const button = (await screen.findByText(
-    'Scan New Batch'
-  )) as HTMLButtonElement;
+  const button = await screen.findByText<HTMLButtonElement>('Scan New Batch');
   expect(button.disabled).toBeFalsy();
 });
 
 test('is disabled when scanner not attached', async () => {
   window.kiosk = fakeKiosk();
   render(<ScanButton onPress={jest.fn()} isScannerAttached={false} />);
-  const button = (await screen.findByText('No Scanner')) as HTMLButtonElement;
+  const button = await screen.findByText<HTMLButtonElement>('No Scanner');
   expect(button.disabled).toBeTruthy();
 });
 
 test('is disabled when disabled set to true', async () => {
   window.kiosk = fakeKiosk();
   render(<ScanButton onPress={jest.fn()} disabled isScannerAttached />);
-  const button = (await screen.findByText(
-    'Scan New Batch'
-  )) as HTMLButtonElement;
+  const button = await screen.findByText<HTMLButtonElement>('Scan New Batch');
   expect(button.disabled).toBeTruthy();
 });
 
 test('calls onPress when clicked', async () => {
   const onPress = jest.fn();
   render(<ScanButton onPress={onPress} isScannerAttached />);
-  (await screen.findByText('Scan New Batch')).click();
+  (await screen.findByText<HTMLButtonElement>('Scan New Batch')).click();
   expect(onPress).toHaveBeenCalledTimes(1);
 });

--- a/frontends/bsd/src/screens/write_in_adjudication_screen.test.tsx
+++ b/frontends/bsd/src/screens/write_in_adjudication_screen.test.tsx
@@ -209,9 +209,9 @@ test('supports canceling a write-in', async () => {
   screen.getByText('Write-In Adjudication');
   screen.getByText(contest.title);
 
-  const isNotWriteInCheckbox = screen.getByTestId(
+  const isNotWriteInCheckbox = screen.getByTestId<HTMLInputElement>(
     `write-in-checkbox-${optionId}`
-  ) as HTMLInputElement;
+  );
   expect(isNotWriteInCheckbox.checked).toBe(false);
   userEvent.click(isNotWriteInCheckbox);
 
@@ -347,9 +347,9 @@ test('can adjudicate front & back in succession', async () => {
   screen.getByText(frontContest1.title);
 
   {
-    const isNotWriteInCheckbox = screen.getByTestId(
+    const isNotWriteInCheckbox = screen.getByTestId<HTMLInputElement>(
       `write-in-checkbox-${frontContest1WriteInId}`
-    ) as HTMLInputElement;
+    );
     expect(isNotWriteInCheckbox.checked).toBe(false);
     userEvent.click(isNotWriteInCheckbox);
   }
@@ -358,9 +358,9 @@ test('can adjudicate front & back in succession', async () => {
   screen.getByText(frontContest2.title);
 
   {
-    const isNotWriteInCheckbox = screen.getByTestId(
+    const isNotWriteInCheckbox = screen.getByTestId<HTMLInputElement>(
       `write-in-checkbox-${frontContest1WriteInId}`
-    ) as HTMLInputElement;
+    );
     expect(isNotWriteInCheckbox.checked).toBe(false);
     userEvent.click(isNotWriteInCheckbox);
   }
@@ -391,9 +391,9 @@ test('can adjudicate front & back in succession', async () => {
   });
 
   {
-    const isNotWriteInCheckbox = screen.getByTestId(
+    const isNotWriteInCheckbox = screen.getByTestId<HTMLInputElement>(
       `write-in-checkbox-${backContestWriteInId}`
-    ) as HTMLInputElement;
+    );
     expect(isNotWriteInCheckbox.checked).toBe(false);
     userEvent.click(isNotWriteInCheckbox);
   }

--- a/frontends/bsd/test/util/has_text_across_elements.ts
+++ b/frontends/bsd/test/util/has_text_across_elements.ts
@@ -1,7 +1,7 @@
-import { Matcher, Nullish } from '@testing-library/react';
+import { Matcher } from '@testing-library/react';
 
 export function hasTextAcrossElements(text: string): Matcher {
-  return (content: string, node: Nullish<Element>) => {
+  return (content: string, node: Element | null) => {
     function hasText(n: Element) {
       return n.textContent === text;
     }

--- a/frontends/election-manager/package.json
+++ b/frontends/election-manager/package.json
@@ -72,7 +72,7 @@
     }
   },
   "dependencies": {
-    "@testing-library/react": "^11.2.3",
+    "@testing-library/react": "^12.1.5",
     "@testing-library/user-event": "^12.6.0",
     "@types/array-unique": "^0.3.0",
     "@types/dashify": "^1.0.0",

--- a/frontends/election-manager/src/components/export_logs_modal.test.tsx
+++ b/frontends/election-manager/src/components/export_logs_modal.test.tsx
@@ -137,6 +137,7 @@ test('renders save modal when usb is mounted and saves log file on machine', asy
   );
 
   fireEvent.click(getByText('Save'));
+  await waitFor(() => getByText(/Saving Logs/));
   expect(mockKiosk.readFile).toHaveBeenCalled();
   jest.advanceTimersByTime(2001);
   await waitFor(() => getByText(/Logs Saved/));
@@ -195,6 +196,7 @@ test('renders save modal when usb is mounted and saves cdf log file on machine',
   );
 
   fireEvent.click(getByText('Save'));
+  await waitFor(() => getByText(/Saving Logs/));
   expect(mockKiosk.readFile).toHaveBeenCalled();
   jest.advanceTimersByTime(2001);
   await waitFor(() => getByText(/Logs Saved/));
@@ -246,6 +248,7 @@ test('render export modal with errors when appropriate', async () => {
   getByText('Save Logs');
 
   fireEvent.click(getByText('Save'));
+  await waitFor(() => getByText(/Saving Logs/));
   await waitFor(() => getByText(/Failed to Save Logs/));
   getByText(/Failed to save log file./);
   getByText(/this-is-an-error/);

--- a/frontends/election-manager/src/components/loading.tsx
+++ b/frontends/election-manager/src/components/loading.tsx
@@ -23,7 +23,12 @@ export function Loading({
 }: Props): JSX.Element {
   const content = (
     <Prose>
-      <ProgressEllipsis as={as} aria-label={`${children}.`}>
+      <ProgressEllipsis
+        as={as}
+        aria-label={`${
+          Array.isArray(children) ? children.join('') : children
+        }.`}
+      >
         {children}
       </ProgressEllipsis>
     </Prose>

--- a/frontends/election-manager/src/components/save_file_to_usb.test.tsx
+++ b/frontends/election-manager/src/components/save_file_to_usb.test.tsx
@@ -95,6 +95,7 @@ test('renders save screen when usb is mounted with ballot filetype', async () =>
   getByText('this-is-a-file-name.pdf');
 
   fireEvent.click(getByText('Save'));
+  await waitFor(() => getByText(/Saving Ballot/));
   expect(fileContentFn).toHaveBeenCalled();
   jest.advanceTimersByTime(2001);
   await waitFor(() => getByText(/Ballot Saved/));
@@ -154,6 +155,7 @@ test('renders save screen when usb is mounted with results filetype and prompts 
   getByText('this-is-a-file-name.pdf');
 
   fireEvent.click(getByText('Save'));
+  await waitFor(() => getByText(/Saving Results/));
   expect(fileContentFn).toHaveBeenCalled();
   jest.advanceTimersByTime(2001);
   await waitFor(() => getByText(/Results Saved/));
@@ -208,6 +210,7 @@ test('render export modal with errors when appropriate', async () => {
   getByText('Save Unofficial Tally Report');
 
   fireEvent.click(getByText('Save'));
+  await waitFor(() => getByText(/Saving Unofficial Tally Report/));
   await waitFor(() => getByText(/Failed to Save Unofficial Tally Report/));
   getByText(/Failed to save tally report./);
   getByText(/this-is-an-error/);

--- a/frontends/election-manager/src/components/save_file_to_usb.tsx
+++ b/frontends/election-manager/src/components/save_file_to_usb.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useState } from 'react';
 import styled from 'styled-components';
 import path from 'path';
 import fileDownload from 'js-file-download';
-import { assert, usbstick, throwIllegalValue } from '@votingworks/utils';
+import { assert, usbstick, throwIllegalValue, sleep } from '@votingworks/utils';
 
 import { Modal, UsbControllerButton, Prose } from '@votingworks/ui';
 
@@ -125,7 +125,7 @@ export function SaveFileToUsb({
       }
 
       setSavedFilename(filenameLocation);
-      await new Promise((resolve) => setTimeout(resolve, 2000));
+      await sleep(2000);
       await logger.log(LogEventId.FileSaved, currentUserSession.type, {
         disposition: 'success',
         message: `Successfully saved ${fileName} to ${filenameLocation} on the usb drive.`,

--- a/frontends/election-manager/src/screens/print_test_deck_screen.test.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.test.tsx
@@ -29,53 +29,45 @@ test('Printing the full test deck sorts precincts', async () => {
   fireEvent.click(getByText('All Precincts'));
 
   // Check that the printing modals appear in alphabetical order
-  await waitFor(() => getByLabelText('Printing Test Deck, (1 of 13),: ,Bywy.'));
+  await waitFor(() => getByLabelText('Printing Test Deck (1 of 13): Bywy.'));
+  jest.advanceTimersByTime(30000);
+  await waitFor(() => getByLabelText('Printing Test Deck (2 of 13): Chester.'));
   jest.advanceTimersByTime(30000);
   await waitFor(() =>
-    getByLabelText('Printing Test Deck, (2 of 13),: ,Chester.')
+    getByLabelText('Printing Test Deck (3 of 13): District 5.')
   );
   jest.advanceTimersByTime(30000);
   await waitFor(() =>
-    getByLabelText('Printing Test Deck, (3 of 13),: ,District 5.')
+    getByLabelText('Printing Test Deck (4 of 13): East Weir.')
   );
   jest.advanceTimersByTime(30000);
   await waitFor(() =>
-    getByLabelText('Printing Test Deck, (4 of 13),: ,East Weir.')
+    getByLabelText('Printing Test Deck (5 of 13): Fentress.')
   );
   jest.advanceTimersByTime(30000);
   await waitFor(() =>
-    getByLabelText('Printing Test Deck, (5 of 13),: ,Fentress.')
+    getByLabelText('Printing Test Deck (6 of 13): French Camp.')
+  );
+  jest.advanceTimersByTime(30000);
+  await waitFor(() => getByLabelText('Printing Test Deck (7 of 13): Hebron.'));
+  jest.advanceTimersByTime(30000);
+  await waitFor(() => getByLabelText('Printing Test Deck (8 of 13): Kenego.'));
+  jest.advanceTimersByTime(30000);
+  await waitFor(() =>
+    getByLabelText('Printing Test Deck (9 of 13): Panhandle.')
+  );
+  jest.advanceTimersByTime(30000);
+  await waitFor(() => getByLabelText('Printing Test Deck (10 of 13): Reform.'));
+  jest.advanceTimersByTime(30000);
+  await waitFor(() =>
+    getByLabelText('Printing Test Deck (11 of 13): Sherwood.')
   );
   jest.advanceTimersByTime(30000);
   await waitFor(() =>
-    getByLabelText('Printing Test Deck, (6 of 13),: ,French Camp.')
+    getByLabelText('Printing Test Deck (12 of 13): Southwest Ackerman.')
   );
   jest.advanceTimersByTime(30000);
   await waitFor(() =>
-    getByLabelText('Printing Test Deck, (7 of 13),: ,Hebron.')
-  );
-  jest.advanceTimersByTime(30000);
-  await waitFor(() =>
-    getByLabelText('Printing Test Deck, (8 of 13),: ,Kenego.')
-  );
-  jest.advanceTimersByTime(30000);
-  await waitFor(() =>
-    getByLabelText('Printing Test Deck, (9 of 13),: ,Panhandle.')
-  );
-  jest.advanceTimersByTime(30000);
-  await waitFor(() =>
-    getByLabelText('Printing Test Deck, (10 of 13),: ,Reform.')
-  );
-  jest.advanceTimersByTime(30000);
-  await waitFor(() =>
-    getByLabelText('Printing Test Deck, (11 of 13),: ,Sherwood.')
-  );
-  jest.advanceTimersByTime(30000);
-  await waitFor(() =>
-    getByLabelText('Printing Test Deck, (12 of 13),: ,Southwest Ackerman.')
-  );
-  jest.advanceTimersByTime(30000);
-  await waitFor(() =>
-    getByLabelText('Printing Test Deck, (13 of 13),: ,West Weir.')
+    getByLabelText('Printing Test Deck (13 of 13): West Weir.')
   );
 });

--- a/frontends/election-manager/test/util/has_text_across_elements.tsx
+++ b/frontends/election-manager/test/util/has_text_across_elements.tsx
@@ -1,7 +1,7 @@
-import { Matcher, Nullish } from '@testing-library/react';
+import { Matcher } from '@testing-library/react';
 
 export function hasTextAcrossElements(text: string): Matcher {
-  return (content: string, node: Nullish<Element>) => {
+  return (content: string, node: Element | null) => {
     function hasText(n: Element) {
       return n.textContent === text;
     }

--- a/frontends/precinct-scanner/package.json
+++ b/frontends/precinct-scanner/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@rooks/use-interval": "^4.11.2",
     "@testing-library/jest-dom": "^5.11.4",
-    "@testing-library/react": "^11.1.0",
+    "@testing-library/react": "^12.1.5",
     "@types/jest": "^24.0.0",
     "@types/luxon": "^1.26.5",
     "@types/node": "16.11.29",

--- a/frontends/precinct-scanner/src/api/scan.ts
+++ b/frontends/precinct-scanner/src/api/scan.ts
@@ -39,7 +39,7 @@ export async function getCurrentStatus(): Promise<ScannerStatusDetails> {
 
 export async function scanDetectedSheet(): Promise<ScanningResult> {
   const result = await (
-    await fetch('scan/scanBatch', { method: 'post' })
+    await fetch('/scan/scanBatch', { method: 'post' })
   ).json();
 
   if (result.status === 'error') {

--- a/frontends/precinct-scanner/src/components/calibrate_scanner_modal.test.tsx
+++ b/frontends/precinct-scanner/src/components/calibrate_scanner_modal.test.tsx
@@ -36,8 +36,7 @@ test('waiting for paper', async () => {
   );
 
   expect(
-    ((await screen.findByText('Waiting for Paper')) as HTMLButtonElement)
-      .disabled
+    (await screen.findByText<HTMLButtonElement>('Waiting for Paper')).disabled
   ).toBe(true);
 
   fireEvent.click(await screen.findByText('Cancel'));
@@ -60,8 +59,7 @@ test('scanner not available', async () => {
   );
 
   expect(
-    ((await screen.findByText('Cannot Calibrate')) as HTMLButtonElement)
-      .disabled
+    (await screen.findByText<HTMLButtonElement>('Cannot Calibrate')).disabled
   ).toBe(true);
 
   fireEvent.click(await screen.findByText('Cancel'));

--- a/frontends/precinct-scanner/src/screens/admin_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/admin_screen.test.tsx
@@ -56,8 +56,8 @@ test('renders date and time settings modal', async () => {
   within(screen.getByTestId('modal')).getByText('Sat, Oct 31, 2020, 12:00 AM');
 
   const selectYear = screen.getByTestId('selectYear');
-  const optionYear = (within(selectYear).getByText('2025') as HTMLOptionElement)
-    .value;
+  const optionYear =
+    within(selectYear).getByText<HTMLOptionElement>('2025').value;
   fireEvent.change(selectYear, { target: { value: optionYear } });
 
   // Save Date and Timezone

--- a/libs/test-utils/package.json
+++ b/libs/test-utils/package.json
@@ -34,7 +34,7 @@
     ]
   },
   "dependencies": {
-    "@testing-library/react": "^11.2.6",
+    "@testing-library/react": "^12.1.5",
     "@types/node": "16.11.29",
     "@votingworks/types": "workspace:*",
     "buffer": "^6.0.3",

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -62,7 +62,7 @@
   "devDependencies": {
     "@codemod/parser": "^1.0.6",
     "@testing-library/jest-dom": "^5.16.4",
-    "@testing-library/react": "^11.2.6",
+    "@testing-library/react": "^12.1.5",
     "@testing-library/react-hooks": "^8.0.0-alpha.1",
     "@testing-library/user-event": "^13.2.1",
     "@types/base64-js": "^1.3.0",

--- a/libs/ui/src/hooks/use_autocomplete.test.tsx
+++ b/libs/ui/src/hooks/use_autocomplete.test.tsx
@@ -44,7 +44,7 @@ test('basic autocomplete', async () => {
 
   render(<TestComponent />);
 
-  const input = screen.getByTestId('autocomplete') as HTMLInputElement;
+  const input = screen.getByTestId<HTMLInputElement>('autocomplete');
 
   // start typing something that will match
   userEvent.type(input, 'o');

--- a/libs/ui/src/set_clock.test.tsx
+++ b/libs/ui/src/set_clock.test.tsx
@@ -20,7 +20,7 @@ import {
 } from './set_clock';
 
 function getSelect(testId: string): HTMLSelectElement {
-  return screen.getByTestId(testId) as HTMLSelectElement;
+  return screen.getByTestId(testId);
 }
 
 const aDate = DateTime.fromObject({
@@ -252,16 +252,14 @@ describe('SetClockButton', () => {
       'Sat, Oct 31, 2020, 12:00 AM'
     );
 
-    const selectYear = screen.getByTestId('selectYear');
-    const optionYear = (
-      within(selectYear).getByText('2025') as HTMLOptionElement
-    ).value;
+    const selectYear = screen.getByTestId<HTMLSelectElement>('selectYear');
+    const optionYear =
+      within(selectYear).getByText<HTMLOptionElement>('2025').value;
     fireEvent.change(selectYear, { target: { value: optionYear } });
 
     const selectMonth = screen.getByTestId('selectMonth');
-    const optionMonth = (
-      within(selectMonth).getByText('Feb') as HTMLOptionElement
-    ).value;
+    const optionMonth =
+      within(selectMonth).getByText<HTMLOptionElement>('Feb').value;
     fireEvent.change(selectMonth, { target: { value: optionMonth } });
 
     // Expect day to change because Feb doesn't have 31 days.
@@ -270,36 +268,32 @@ describe('SetClockButton', () => {
     );
 
     const selectDay = screen.getByTestId('selectDay');
-    const optionDay = (within(selectDay).getByText('3') as HTMLOptionElement)
-      .value;
+    const optionDay = within(selectDay).getByText<HTMLOptionElement>('3').value;
     fireEvent.change(selectDay, { target: { value: optionDay } });
 
     const selectHour = screen.getByTestId('selectHour');
-    const optionHour = (within(selectHour).getByText('11') as HTMLOptionElement)
-      .value;
+    const optionHour =
+      within(selectHour).getByText<HTMLOptionElement>('11').value;
     fireEvent.change(selectHour, { target: { value: optionHour } });
 
     const selectMinute = screen.getByTestId('selectMinute');
-    const optionMinute = (
-      within(selectMinute).getByText('21') as HTMLOptionElement
-    ).value;
+    const optionMinute =
+      within(selectMinute).getByText<HTMLOptionElement>('21').value;
     fireEvent.change(selectMinute, { target: { value: optionMinute } });
 
     const selectMeridian = screen.getByTestId('selectMeridian');
-    const optionMeridian = (
-      within(selectMeridian).getByText('PM') as HTMLOptionElement
-    ).value;
+    const optionMeridian =
+      within(selectMeridian).getByText<HTMLOptionElement>('PM').value;
     fireEvent.change(selectMeridian, { target: { value: optionMeridian } });
 
     // Expect day, hour, minute, and meridian to update
     within(screen.getByTestId('modal')).getByText('Mon, Feb 3, 2025, 11:21 PM');
 
-    const selectTimezone = screen.getByTestId(
-      'selectTimezone'
-    ) as HTMLSelectElement;
-    const optionTimezone = within(selectTimezone).getByText(
+    const selectTimezone =
+      screen.getByTestId<HTMLSelectElement>('selectTimezone');
+    const optionTimezone = within(selectTimezone).getByText<HTMLOptionElement>(
       'Central Standard Time (Chicago)'
-    ) as HTMLOptionElement;
+    );
     expect(optionTimezone.selected).toBeFalsy();
     fireEvent.change(selectTimezone, {
       target: { value: optionTimezone.value },
@@ -307,10 +301,8 @@ describe('SetClockButton', () => {
 
     expect(selectTimezone.value).toBe('America/Chicago');
     expect(
-      (
-        within(selectTimezone).getByText(
-          'Central Standard Time (Chicago)'
-        ) as HTMLOptionElement
+      within(selectTimezone).getByText<HTMLOptionElement>(
+        'Central Standard Time (Chicago)'
       ).selected
     ).toBeTruthy();
 
@@ -325,21 +317,19 @@ describe('SetClockButton', () => {
     fireEvent.click(screen.getByText('Update Date and Time'));
 
     const selectDay2 = screen.getByTestId('selectDay');
-    const optionDay2 = (within(selectDay2).getByText('21') as HTMLOptionElement)
-      .value;
+    const optionDay2 =
+      within(selectDay2).getByText<HTMLOptionElement>('21').value;
     fireEvent.change(selectDay2, { target: { value: optionDay2 } });
 
     // Choose PM, then change hours
     const selectMeridian2 = screen.getByTestId('selectMeridian');
-    const optionMeridian2 = (
-      within(selectMeridian2).getByText('PM') as HTMLOptionElement
-    ).value;
+    const optionMeridian2 =
+      within(selectMeridian2).getByText<HTMLOptionElement>('PM').value;
     fireEvent.change(selectMeridian2, { target: { value: optionMeridian2 } });
 
     const selectHour2 = screen.getByTestId('selectHour');
-    const optionHour2 = (
-      within(selectHour2).getByText('11') as HTMLOptionElement
-    ).value;
+    const optionHour2 =
+      within(selectHour2).getByText<HTMLOptionElement>('11').value;
     fireEvent.change(selectHour2, { target: { value: optionHour2 } });
 
     // Expect time to be in PM
@@ -347,20 +337,18 @@ describe('SetClockButton', () => {
 
     // Choose AM, then change hours
     const selectMeridian3 = screen.getByTestId('selectMeridian');
-    const optionMeridian3 = (
-      within(selectMeridian3).getByText('AM') as HTMLOptionElement
-    ).value;
+    const optionMeridian3 =
+      within(selectMeridian3).getByText<HTMLOptionElement>('AM').value;
     fireEvent.change(selectMeridian3, { target: { value: optionMeridian3 } });
 
     // Expect time to be in AM
     screen.getByText('Wed, Oct 21, 2020, 11:00 AM');
 
-    const selectTimezone2 = screen.getByTestId(
-      'selectTimezone'
-    ) as HTMLSelectElement;
-    const optionTimezone2 = within(selectTimezone2).getByText(
-      'Pacific Daylight Time (Los Angeles)'
-    ) as HTMLOptionElement;
+    const selectTimezone2 =
+      screen.getByTestId<HTMLSelectElement>('selectTimezone');
+    const optionTimezone2 = within(
+      selectTimezone2
+    ).getByText<HTMLOptionElement>('Pacific Daylight Time (Los Angeles)');
     expect(optionTimezone2.selected).toBeFalsy();
     fireEvent.change(selectTimezone2, {
       target: { value: optionTimezone2.value },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,7 +226,7 @@ importers:
       '@codemod/parser': 1.1.0
       '@testing-library/cypress': 8.0.2_cypress@9.5.4
       '@testing-library/jest-dom': 5.16.4
-      '@testing-library/react': 11.2.3_react-dom@17.0.1+react@17.0.1
+      '@testing-library/react': 12.1.5_react-dom@17.0.1+react@17.0.1
       '@testing-library/user-event': 13.5.0
       '@types/debug': 4.1.6
       '@types/history': 4.7.8
@@ -275,7 +275,7 @@ importers:
       '@rooks/use-interval': ^4.5.0
       '@testing-library/cypress': ^8.0.2
       '@testing-library/jest-dom': ^5.16.4
-      '@testing-library/react': ^11.2.3
+      '@testing-library/react': ^12.1.5
       '@testing-library/user-event': ^13.5.0
       '@types/debug': ^4.1.6
       '@types/dompurify': ^2.0.4
@@ -402,7 +402,7 @@ importers:
       zod: 3.14.4
     devDependencies:
       '@testing-library/jest-dom': 5.16.4
-      '@testing-library/react': 11.2.3_react-dom@17.0.1+react@17.0.1
+      '@testing-library/react': 12.1.5_react-dom@17.0.1+react@17.0.1
       '@testing-library/user-event': 13.2.1
       '@types/fast-text-encoding': 1.0.1
       '@types/fetch-mock': 7.3.3
@@ -449,7 +449,7 @@ importers:
       zip-stream: 3.0.1
     specifiers:
       '@testing-library/jest-dom': ^5.16.4
-      '@testing-library/react': ^11.2.3
+      '@testing-library/react': ^12.1.5
       '@testing-library/user-event': ^13.2.1
       '@types/fast-text-encoding': ^1.0.1
       '@types/fetch-mock': ^7.3.2
@@ -535,7 +535,7 @@ importers:
       http-proxy-middleware: 1.0.6
   frontends/election-manager:
     dependencies:
-      '@testing-library/react': 11.2.3_react-dom@17.0.1+react@17.0.1
+      '@testing-library/react': 12.1.5_react-dom@17.0.1+react@17.0.1
       '@testing-library/user-event': 12.6.0
       '@types/array-unique': 0.3.0
       '@types/dashify': 1.0.0
@@ -634,7 +634,7 @@ importers:
     specifiers:
       '@codemod/parser': ^1.0.6
       '@testing-library/jest-dom': ^5.16.4
-      '@testing-library/react': ^11.2.3
+      '@testing-library/react': ^12.1.5
       '@testing-library/user-event': ^12.6.0
       '@types/array-unique': ^0.3.0
       '@types/base64-js': ^1.3.0
@@ -740,7 +740,7 @@ importers:
     dependencies:
       '@rooks/use-interval': 4.11.2_react@17.0.1
       '@testing-library/jest-dom': 5.12.0
-      '@testing-library/react': 11.2.3_react-dom@17.0.1+react@17.0.1
+      '@testing-library/react': 12.1.5_react-dom@17.0.1+react@17.0.1
       '@types/jest': 24.9.1
       '@types/luxon': 1.26.5
       '@types/node': 16.11.29
@@ -823,7 +823,7 @@ importers:
       '@codemod/parser': ^1.0.6
       '@rooks/use-interval': ^4.11.2
       '@testing-library/jest-dom': ^5.11.4
-      '@testing-library/react': ^11.1.0
+      '@testing-library/react': ^12.1.5
       '@testing-library/react-hooks': ^7.0.2
       '@testing-library/user-event': ^12.8.3
       '@types/debug': ^4.1.5
@@ -1865,7 +1865,7 @@ importers:
       typescript: 4.6.3
   libs/test-utils:
     dependencies:
-      '@testing-library/react': 11.2.6_react-dom@17.0.1+react@17.0.1
+      '@testing-library/react': 12.1.5_react-dom@17.0.1+react@17.0.1
       '@types/node': 16.11.29
       '@votingworks/types': link:../types
       buffer: 6.0.3
@@ -1900,7 +1900,7 @@ importers:
       ts-jest: 27.0.7_1dcf3a5c8307703c73427a631f3faf30
       typescript: 4.6.3
     specifiers:
-      '@testing-library/react': ^11.2.6
+      '@testing-library/react': ^12.1.5
       '@types/jest': ^27.0.3
       '@types/kiosk-browser': workspace:*
       '@types/luxon': ^1.26.5
@@ -2011,7 +2011,7 @@ importers:
     devDependencies:
       '@codemod/parser': 1.1.0
       '@testing-library/jest-dom': 5.16.4
-      '@testing-library/react': 11.2.6_react-dom@17.0.1+react@17.0.1
+      '@testing-library/react': 12.1.5_react-dom@17.0.1+react@17.0.1
       '@testing-library/react-hooks': 8.0.0-alpha.1_react-dom@17.0.1+react@17.0.1
       '@testing-library/user-event': 13.2.1
       '@types/base64-js': 1.3.0
@@ -2063,7 +2063,7 @@ importers:
     specifiers:
       '@codemod/parser': ^1.0.6
       '@testing-library/jest-dom': ^5.16.4
-      '@testing-library/react': ^11.2.6
+      '@testing-library/react': ^12.1.5
       '@testing-library/react-hooks': ^8.0.0-alpha.1
       '@testing-library/user-event': ^13.2.1
       '@types/base64-js': ^1.3.0
@@ -6425,11 +6425,6 @@ packages:
       regenerator-runtime: 0.13.7
     resolution:
       integrity: sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
-  /@babel/runtime/7.14.0:
-    dependencies:
-      regenerator-runtime: 0.13.7
-    resolution:
-      integrity: sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
   /@babel/runtime/7.14.5:
     dependencies:
       regenerator-runtime: 0.13.7
@@ -6477,7 +6472,6 @@ packages:
   /@babel/runtime/7.17.8:
     dependencies:
       regenerator-runtime: 0.13.9
-    dev: true
     engines:
       node: '>=6.9.0'
     resolution:
@@ -6485,7 +6479,6 @@ packages:
   /@babel/runtime/7.17.9:
     dependencies:
       regenerator-runtime: 0.13.9
-    dev: true
     engines:
       node: '>=6.9.0'
     resolution:
@@ -8519,20 +8512,6 @@ packages:
       cypress: ^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
     resolution:
       integrity: sha512-KVdm7n37sg/A4e3wKMD4zUl0NpzzVhx06V9Tf0hZHZ7nrZ4yFva6Zwg2EFF1VzHkEfN/ahUzRtT1qiW+vuWnJw==
-  /@testing-library/dom/7.29.4:
-    dependencies:
-      '@babel/code-frame': 7.12.11
-      '@babel/runtime': 7.12.5
-      '@types/aria-query': 4.2.1
-      aria-query: 4.2.2
-      chalk: 4.1.0
-      dom-accessibility-api: 0.5.4
-      lz-string: 1.4.4
-      pretty-format: 26.6.2
-    engines:
-      node: '>=10'
-    resolution:
-      integrity: sha512-CtrJRiSYEfbtNGtEsd78mk1n1v2TUbeABlNIcOCJdDfkN5/JTOwQEbbQpoSRxGqzcWPgStMvJ4mNolSuBRv1NA==
   /@testing-library/dom/7.30.4:
     dependencies:
       '@babel/code-frame': 7.14.5
@@ -8557,7 +8536,6 @@ packages:
       dom-accessibility-api: 0.5.13
       lz-string: 1.4.4
       pretty-format: 27.5.1
-    dev: true
     engines:
       node: '>=12'
     resolution:
@@ -8658,32 +8636,20 @@ packages:
         optional: true
     resolution:
       integrity: sha512-YrIrBXQLKcucFuEiSkHEycR7Yk5lOHH8tTxB+km+XdQiN1af0YlblWt+n9Zx6OX1crIN3JNy8hJ7VvdYivriCg==
-  /@testing-library/react/11.2.3_react-dom@17.0.1+react@17.0.1:
+  /@testing-library/react/12.1.5_react-dom@17.0.1+react@17.0.1:
     dependencies:
-      '@babel/runtime': 7.12.5
-      '@testing-library/dom': 7.29.4
+      '@babel/runtime': 7.17.9
+      '@testing-library/dom': 8.11.3
+      '@types/react-dom': 17.0.13
       react: 17.0.1
       react-dom: 17.0.1_react@17.0.1
     engines:
-      node: '>=10'
+      node: '>=12'
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: <18.0.0
+      react-dom: <18.0.0
     resolution:
-      integrity: sha512-BirBUGPkTW28ULuCwIbYo0y2+0aavHczBT6N9r3LrsswEW3pg25l1wgoE7I8QBIy1upXWkwKpYdWY7NYYP0Bxw==
-  /@testing-library/react/11.2.6_react-dom@17.0.1+react@17.0.1:
-    dependencies:
-      '@babel/runtime': 7.14.0
-      '@testing-library/dom': 7.30.4
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
-    engines:
-      node: '>=10'
-    peerDependencies:
-      react: '*'
-      react-dom: '*'
-    resolution:
-      integrity: sha512-TXMCg0jT8xmuU8BkKMtp8l7Z50Ykew5WNX8UoIKTaLFwKkP2+1YDhOLA2Ga3wY4x29jyntk7EWfum0kjlYiSjQ==
+      integrity: sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==
   /@testing-library/user-event/12.6.0:
     dependencies:
       '@babel/runtime': 7.12.5
@@ -8752,7 +8718,6 @@ packages:
     resolution:
       integrity: sha512-S6oPal772qJZHoRZLFc/XoZW2gFvwXusYUmXPXkgxJLuEk2vOt7jc4Yo6z/vtI0EBkbPBVrJJ0B+prLIKiWqHg==
   /@types/aria-query/4.2.2:
-    dev: true
     resolution:
       integrity: sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==
   /@types/array-unique/0.3.0:
@@ -9290,7 +9255,6 @@ packages:
   /@types/react-dom/17.0.13:
     dependencies:
       '@types/react': 17.0.40
-    dev: true
     resolution:
       integrity: sha512-wEP+B8hzvy6ORDv1QBhcQia4j6ea4SFIBttHYpXKPFZRviBvknq0FRh3VrIxeXUmsPkwuXVZrVGG7KUVONmXCQ==
   /@types/react-dom/17.0.9:
@@ -9378,7 +9342,6 @@ packages:
       '@types/prop-types': 15.7.4
       '@types/scheduler': 0.16.2
       csstype: 3.0.11
-    dev: true
     resolution:
       integrity: sha512-UrXhD/JyLH+W70nNSufXqMZNuUD2cXHu6UjCllC6pmOQgBX4SGXOH8fjRka0O0Ee0HrFxapDD8Bwn81Kmiz6jQ==
   /@types/readable-stream/2.3.9:
@@ -11914,7 +11877,6 @@ packages:
     resolution:
       integrity: sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
   /aria-query/5.0.0:
-    dev: true
     engines:
       node: '>=6.0'
     resolution:
@@ -14346,7 +14308,6 @@ packages:
     resolution:
       integrity: sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==
   /csstype/3.0.11:
-    dev: true
     resolution:
       integrity: sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==
   /csstype/3.0.6:
@@ -14936,7 +14897,6 @@ packages:
     resolution:
       integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   /dom-accessibility-api/0.5.13:
-    dev: true
     resolution:
       integrity: sha512-R305kwb5CcMDIpSHUnLyIAp7SrSPBx6F0VfQFB3M75xVMHhXJJIdePYgbPPh1o57vCHNu5QztokWUPsLjWzFqw==
   /dom-accessibility-api/0.5.14:
@@ -28182,7 +28142,6 @@ packages:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
-    dev: true
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
This transitively updates `@testing-library/dom` to v8.x.x, which includes a fix for dealing with Jest fake timers that seems to conflict with either Jest v28 or maybe just modern timers. Calling `waitFor` from `/dom` would accidentally clear the existing timers/intervals in the current fake clock, causing unexpected behavior. It did that by disabling and re-enabling fake timers to check whether fake timers were enabled, but this was destructive.

See https://github.com/testing-library/dom-testing-library/pull/966/files#diff-49ba0c85360693b8e89ae0e0428284a55db749f08f2b9993d26910def646e02f

This was a few levels down the rabbit hole on #1314:
- why are `libs/ui` tests failing in [`build/vite`](https://app.circleci.com/pipelines/github/votingworks/vxsuite/3874/workflows/af6e1e8e-3a8a-43e5-9fc0-abbc3c9b871f/jobs/73036) but only in CI?
- maybe the `jest` config changes broke it?
- upgrade `jest`, see lots of errors. why?
- lots of them seem to be related to timers/async. what is interacting with jest's timers in the failing tests?
- `waitFor`, which is broken in `@testing-library/dom` v7

## Demo Video or Screenshot
n/a

## Testing Plan 
Automated testing.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
