### PR TITLE
Augment VxAdmin test decks with VxMark test decks

### DIFF
--- a/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
+++ b/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
@@ -343,7 +343,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
               <span
                 class="sc-hKwCoD kKHUyA"
               >
-                3 ballots
+                6 ballots
                  cast /
               </span>
                
@@ -373,7 +373,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
                   <td
                     class="sc-dJjZJu fKfTwY"
                   >
-                    1
+                    2
                   </td>
                 </tr>
                 <tr
@@ -385,7 +385,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
                   <td
                     class="sc-dJjZJu fKfTwY"
                   >
-                    1
+                    2
                   </td>
                 </tr>
                 <tr
@@ -397,7 +397,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
                   <td
                     class="sc-dJjZJu fKfTwY"
                   >
-                    1
+                    2
                   </td>
                 </tr>
                 <tr
@@ -437,7 +437,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
               <span
                 class="sc-hKwCoD kKHUyA"
               >
-                3 ballots
+                6 ballots
                  cast /
               </span>
                
@@ -467,7 +467,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
                   <td
                     class="sc-dJjZJu fKfTwY"
                   >
-                    1
+                    2
                   </td>
                 </tr>
                 <tr
@@ -479,7 +479,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
                   <td
                     class="sc-dJjZJu fKfTwY"
                   >
-                    1
+                    2
                   </td>
                 </tr>
                 <tr
@@ -491,7 +491,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
                   <td
                     class="sc-dJjZJu fKfTwY"
                   >
-                    1
+                    2
                   </td>
                 </tr>
                 <tr
@@ -531,7 +531,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
               <span
                 class="sc-hKwCoD kKHUyA"
               >
-                3 ballots
+                6 ballots
                  cast /
               </span>
                
@@ -561,7 +561,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
                   <td
                     class="sc-dJjZJu fKfTwY"
                   >
-                    2
+                    4
                   </td>
                 </tr>
                 <tr
@@ -573,7 +573,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
                   <td
                     class="sc-dJjZJu fKfTwY"
                   >
-                    1
+                    2
                   </td>
                 </tr>
                 <tr
@@ -613,7 +613,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
               <span
                 class="sc-hKwCoD kKHUyA"
               >
-                3 ballots
+                6 ballots
                  cast /
               </span>
                
@@ -643,7 +643,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
                   <td
                     class="sc-dJjZJu fKfTwY"
                   >
-                    2
+                    4
                   </td>
                 </tr>
                 <tr
@@ -655,7 +655,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
                   <td
                     class="sc-dJjZJu fKfTwY"
                   >
-                    1
+                    2
                   </td>
                 </tr>
                 <tr
@@ -999,7 +999,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
               <span
                 class="sc-hKwCoD kKHUyA"
               >
-                3 ballots
+                6 ballots
                  cast /
               </span>
                
@@ -1029,7 +1029,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
                   <td
                     class="sc-dJjZJu fKfTwY"
                   >
-                    2
+                    4
                   </td>
                 </tr>
                 <tr
@@ -1041,7 +1041,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
                   <td
                     class="sc-dJjZJu fKfTwY"
                   >
-                    1
+                    2
                   </td>
                 </tr>
                 <tr
@@ -1081,7 +1081,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
               <span
                 class="sc-hKwCoD kKHUyA"
               >
-                3 ballots
+                6 ballots
                  cast /
               </span>
                
@@ -1111,7 +1111,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
                   <td
                     class="sc-dJjZJu fKfTwY"
                   >
-                    3
+                    6
                   </td>
                 </tr>
                 <tr
@@ -1152,7 +1152,7 @@ House Concurrent Resolution No. 47
               <span
                 class="sc-hKwCoD kKHUyA"
               >
-                3 ballots
+                6 ballots
                  cast /
               </span>
                
@@ -1182,7 +1182,7 @@ House Concurrent Resolution No. 47
                   <td
                     class="sc-dJjZJu fKfTwY"
                   >
-                    2
+                    4
                   </td>
                 </tr>
                 <tr
@@ -1194,7 +1194,7 @@ House Concurrent Resolution No. 47
                   <td
                     class="sc-dJjZJu fKfTwY"
                   >
-                    1
+                    2
                   </td>
                 </tr>
               </tbody>
@@ -1223,7 +1223,7 @@ House Bill 1796 - Flag Referendum
               <span
                 class="sc-hKwCoD kKHUyA"
               >
-                3 ballots
+                6 ballots
                  cast /
               </span>
                
@@ -1253,7 +1253,7 @@ House Bill 1796 - Flag Referendum
                   <td
                     class="sc-dJjZJu fKfTwY"
                   >
-                    2
+                    4
                   </td>
                 </tr>
                 <tr
@@ -1265,7 +1265,7 @@ House Bill 1796 - Flag Referendum
                   <td
                     class="sc-dJjZJu fKfTwY"
                   >
-                    1
+                    2
                   </td>
                 </tr>
               </tbody>
@@ -1293,7 +1293,7 @@ House Bill 1796 - Flag Referendum
               <span
                 class="sc-hKwCoD kKHUyA"
               >
-                3 ballots
+                6 ballots
                  cast /
               </span>
                
@@ -1323,7 +1323,7 @@ House Bill 1796 - Flag Referendum
                   <td
                     class="sc-dJjZJu fKfTwY"
                   >
-                    2
+                    4
                   </td>
                 </tr>
                 <tr
@@ -1335,7 +1335,7 @@ House Bill 1796 - Flag Referendum
                   <td
                     class="sc-dJjZJu fKfTwY"
                   >
-                    1
+                    2
                   </td>
                 </tr>
               </tbody>
@@ -1363,7 +1363,7 @@ House Bill 1796 - Flag Referendum
               <span
                 class="sc-hKwCoD kKHUyA"
               >
-                3 ballots
+                6 ballots
                  cast /
               </span>
                
@@ -1393,7 +1393,7 @@ House Bill 1796 - Flag Referendum
                   <td
                     class="sc-dJjZJu fKfTwY"
                   >
-                    2
+                    4
                   </td>
                 </tr>
                 <tr
@@ -1405,7 +1405,7 @@ House Bill 1796 - Flag Referendum
                   <td
                     class="sc-dJjZJu fKfTwY"
                   >
-                    1
+                    2
                   </td>
                 </tr>
               </tbody>
@@ -1420,6 +1420,1164 @@ House Bill 1796 - Flag Referendum
 `;
 
 exports[`L&A (logic and accuracy) flow 2`] = `
+<div
+  aria-hidden="true"
+>
+  <div
+    class="sc-jObXwK fRoQGi"
+  >
+    <nav
+      class="sc-bdfBwQ gqAMTS"
+    >
+      <div
+        class="sc-gsTCUz iTmZjl"
+      >
+        <div
+          class="sc-dlfnbm VzbFO"
+        >
+          Voting
+          <span>
+            Works
+          </span>
+        </div>
+        <div
+          class="sc-hKgILt"
+        >
+          VxAdmin
+        </div>
+      </div>
+      <div
+        class="sc-eCssSg kiVrGp"
+      >
+        <button
+          class="sc-iBPRYJ fvkSI"
+          role="option"
+          type="button"
+        >
+          Definition
+        </button>
+        <button
+          class="sc-iBPRYJ fvkSI"
+          role="option"
+          type="button"
+        >
+          Cards
+        </button>
+        <button
+          class="sc-iBPRYJ fvkSI"
+          role="option"
+          type="button"
+        >
+          Ballots
+        </button>
+        <button
+          class="sc-iBPRYJ fvkSI active-section"
+          role="option"
+          type="button"
+        >
+          L&A
+        </button>
+        <button
+          class="sc-iBPRYJ bnpNDy"
+          role="option"
+          type="button"
+        >
+          Tally
+        </button>
+        <button
+          class="sc-iBPRYJ bnpNDy"
+          role="option"
+          type="button"
+        >
+          Advanced
+        </button>
+      </div>
+      <div
+        class="sc-jSgupP eMSuCK"
+      >
+        <button
+          class="sc-ksdxAp ctUtNB"
+          type="button"
+        >
+          Lock Machine
+        </button>
+        <button
+          class="sc-ksdxAp ctUtNB"
+          type="button"
+        >
+          Eject USB
+        </button>
+      </div>
+    </nav>
+    <main
+      class="sc-llYToB cOKKyR"
+    >
+      <div
+        class="sc-jRQAMF boeJiV"
+      >
+        <h1>
+          L&A Packages
+        </h1>
+        <p>
+          Select desired precinct for 
+          <strong>
+            Mock General Election Choctaw 2020
+          </strong>
+          .
+        </p>
+      </div>
+      <p>
+        <button
+          class="sc-iBPRYJ gUjZCM"
+          type="button"
+        >
+          <strong>
+            All Precincts
+          </strong>
+        </button>
+      </p>
+      <div
+        class="sc-fFubgz exWqux"
+      >
+        <button
+          class="sc-iBPRYJ gUjZCM"
+          type="button"
+        >
+          Bywy
+        </button>
+        <button
+          class="sc-iBPRYJ gUjZCM"
+          type="button"
+        >
+          Chester
+        </button>
+        <button
+          class="sc-iBPRYJ gUjZCM"
+          type="button"
+        >
+          District 5
+        </button>
+        <button
+          class="sc-iBPRYJ gUjZCM"
+          type="button"
+        >
+          East Weir
+        </button>
+        <button
+          class="sc-iBPRYJ gUjZCM"
+          type="button"
+        >
+          Fentress
+        </button>
+        <button
+          class="sc-iBPRYJ gUjZCM"
+          type="button"
+        >
+          French Camp
+        </button>
+        <button
+          class="sc-iBPRYJ gUjZCM"
+          type="button"
+        >
+          Hebron
+        </button>
+        <button
+          class="sc-iBPRYJ gUjZCM"
+          type="button"
+        >
+          Kenego
+        </button>
+        <button
+          class="sc-iBPRYJ gUjZCM"
+          type="button"
+        >
+          Panhandle
+        </button>
+        <button
+          class="sc-iBPRYJ gUjZCM"
+          type="button"
+        >
+          Reform
+        </button>
+        <button
+          class="sc-iBPRYJ gUjZCM"
+          type="button"
+        >
+          Sherwood
+        </button>
+        <button
+          class="sc-iBPRYJ gUjZCM"
+          type="button"
+        >
+          Southwest Ackerman
+        </button>
+        <button
+          class="sc-iBPRYJ gUjZCM"
+          type="button"
+        >
+          West Weir
+        </button>
+      </div>
+    </main>
+    <div
+      class="sc-bdvvaa iyFMHU"
+    >
+      <div
+        class="sc-jRQAMF hrozKq"
+      >
+        <strong
+          class="sc-hKwCoD kKHUyA"
+        >
+          Mock General Election Choctaw 2020
+        </strong>
+         —
+         
+        <span
+          class="sc-hKwCoD kKHUyA"
+        >
+          Wednesday, August 26, 2020
+        </span>
+        <div
+          class="sc-dkPtyc dVpXhv"
+        >
+          <span
+            class="sc-hKwCoD kKHUyA"
+          >
+            Choctaw County
+            ,
+             
+            State of Mississippi
+          </span>
+        </div>
+      </div>
+      <div
+        class="sc-gsDJrp jyOfHF"
+      />
+      <div
+        class="sc-jRQAMF jTERtK"
+      >
+        <div
+          class="sc-dkPtyc dVpXhv"
+        >
+          Software Version
+        </div>
+        <strong>
+          TEST
+        </strong>
+      </div>
+      <div
+        class="sc-jRQAMF jTERtK"
+      >
+        <div
+          class="sc-dkPtyc dVpXhv"
+        >
+          Machine ID
+        </div>
+        <strong>
+          0000
+        </strong>
+      </div>
+      <div
+        class="sc-jRQAMF jTERtK"
+      >
+        <div
+          class="sc-dkPtyc dVpXhv"
+        >
+          Election ID
+        </div>
+        <strong>
+          e45bd83a84
+        </strong>
+      </div>
+    </div>
+  </div>
+  <div
+    class="print-only"
+  >
+    <div
+      aria-hidden="true"
+      class="sc-iCfLBT iZWxTt"
+    >
+      <div
+        class="sc-pVTma kOGGAi"
+      >
+        <div
+          class="seal"
+          data-testid="printed-ballot-seal"
+          id="printedBallotSealContainer"
+        >
+          <img
+            alt=""
+            class="sc-furvIG esRQPz"
+            data-testid="printed-ballot-seal-image"
+            src="/seals/Seal_of_Mississippi_BW.svg"
+          />
+        </div>
+        <div
+          class="sc-jRQAMF boeJiV ballot-header-content"
+        >
+          <h2>
+            Unofficial TEST Ballot
+          </h2>
+          <h3>
+            
+             
+            Mock General Election Choctaw 2020
+          </h3>
+          <p>
+            August 26, 2020
+            <br />
+            Choctaw County
+            , 
+            State of Mississippi
+          </p>
+        </div>
+        <div
+          class="sc-jrQzUz lkoXcE"
+        >
+          <div
+            class="sc-gKckTs drvJRF"
+          >
+            <svg
+              height="128"
+              shape-rendering="crispEdges"
+              viewBox="0 0 33 33"
+              width="128"
+            >
+              <path
+                d="M0,0 h33v33H0z"
+                fill="#FFFFFF"
+              />
+              <path
+                d="M0 0h7v1H0zM8 0h3v1H8zM13 0h1v1H13zM16 0h4v1H16zM21 0h3v1H21zM26,0 h7v1H26zM0 1h1v1H0zM6 1h1v1H6zM8 1h5v1H8zM14 1h1v1H14zM16 1h1v1H16zM19 1h1v1H19zM21 1h1v1H21zM24 1h1v1H24zM26 1h1v1H26zM32,1 h1v1H32zM0 2h1v1H0zM2 2h3v1H2zM6 2h1v1H6zM8 2h1v1H8zM10 2h1v1H10zM14 2h2v1H14zM19 2h1v1H19zM21 2h3v1H21zM26 2h1v1H26zM28 2h3v1H28zM32,2 h1v1H32zM0 3h1v1H0zM2 3h3v1H2zM6 3h1v1H6zM11 3h3v1H11zM15 3h2v1H15zM18 3h2v1H18zM22 3h1v1H22zM26 3h1v1H26zM28 3h3v1H28zM32,3 h1v1H32zM0 4h1v1H0zM2 4h3v1H2zM6 4h1v1H6zM10 4h1v1H10zM12 4h4v1H12zM17 4h2v1H17zM24 4h1v1H24zM26 4h1v1H26zM28 4h3v1H28zM32,4 h1v1H32zM0 5h1v1H0zM6 5h1v1H6zM8 5h1v1H8zM10 5h3v1H10zM14 5h1v1H14zM16 5h1v1H16zM20 5h2v1H20zM26 5h1v1H26zM32,5 h1v1H32zM0 6h7v1H0zM8 6h1v1H8zM10 6h1v1H10zM12 6h1v1H12zM14 6h1v1H14zM16 6h1v1H16zM18 6h1v1H18zM20 6h1v1H20zM22 6h1v1H22zM24 6h1v1H24zM26,6 h7v1H26zM8 7h1v1H8zM10 7h2v1H10zM13 7h1v1H13zM15 7h3v1H15zM19 7h1v1H19zM21 7h1v1H21zM24 7h1v1H24zM2 8h3v1H2zM6 8h1v1H6zM8 8h2v1H8zM11 8h3v1H11zM15 8h1v1H15zM17 8h1v1H17zM24 8h4v1H24zM30,8 h3v1H30zM2 9h3v1H2zM7 9h3v1H7zM12 9h1v1H12zM16 9h5v1H16zM29 9h2v1H29zM32,9 h1v1H32zM0 10h1v1H0zM4 10h4v1H4zM9 10h1v1H9zM15 10h2v1H15zM20 10h1v1H20zM22 10h1v1H22zM25 10h1v1H25zM28 10h2v1H28zM31 10h1v1H31zM1 11h1v1H1zM4 11h2v1H4zM7 11h1v1H7zM9 11h2v1H9zM12 11h1v1H12zM14 11h1v1H14zM17 11h3v1H17zM30,11 h3v1H30zM0 12h2v1H0zM4 12h1v1H4zM6 12h7v1H6zM14 12h1v1H14zM16 12h2v1H16zM19 12h1v1H19zM21 12h5v1H21zM27 12h1v1H27zM29 12h1v1H29zM31,12 h2v1H31zM1 13h1v1H1zM4 13h1v1H4zM9 13h1v1H9zM14 13h1v1H14zM17 13h1v1H17zM19 13h1v1H19zM21 13h1v1H21zM23 13h1v1H23zM28 13h4v1H28zM0 14h1v1H0zM2 14h1v1H2zM4 14h1v1H4zM6 14h1v1H6zM8 14h1v1H8zM11 14h3v1H11zM16 14h2v1H16zM19 14h2v1H19zM22 14h1v1H22zM25 14h1v1H25zM27 14h2v1H27zM31 14h1v1H31zM0 15h3v1H0zM9 15h2v1H9zM13 15h4v1H13zM21 15h1v1H21zM23 15h1v1H23zM28 15h3v1H28zM1 16h1v1H1zM3 16h1v1H3zM5 16h4v1H5zM11 16h1v1H11zM16 16h1v1H16zM19 16h1v1H19zM21 16h5v1H21zM27 16h1v1H27zM31,16 h2v1H31zM0 17h3v1H0zM4 17h2v1H4zM7 17h1v1H7zM12 17h2v1H12zM18 17h2v1H18zM21 17h2v1H21zM25 17h1v1H25zM29 17h3v1H29zM0 18h3v1H0zM4 18h1v1H4zM6 18h2v1H6zM11 18h5v1H11zM18 18h1v1H18zM20 18h1v1H20zM27 18h2v1H27zM31 18h1v1H31zM0 19h1v1H0zM4 19h1v1H4zM7 19h3v1H7zM12 19h1v1H12zM20 19h2v1H20zM25 19h1v1H25zM29 19h3v1H29zM0 20h2v1H0zM6 20h1v1H6zM9 20h1v1H9zM11 20h1v1H11zM13 20h2v1H13zM17 20h2v1H17zM22 20h1v1H22zM24 20h1v1H24zM28 20h1v1H28zM32,20 h1v1H32zM0 21h2v1H0zM3 21h1v1H3zM7 21h3v1H7zM11 21h1v1H11zM16 21h1v1H16zM19 21h2v1H19zM22 21h1v1H22zM25 21h1v1H25zM27 21h1v1H27zM29 21h1v1H29zM32,21 h1v1H32zM0 22h1v1H0zM6 22h1v1H6zM10 22h1v1H10zM14 22h3v1H14zM20 22h1v1H20zM22 22h3v1H22zM27 22h1v1H27zM29 22h1v1H29zM31 22h1v1H31zM0 23h1v1H0zM3 23h1v1H3zM5 23h1v1H5zM8 23h1v1H8zM11 23h1v1H11zM15 23h1v1H15zM17 23h1v1H17zM21 23h3v1H21zM25 23h2v1H25zM29 23h3v1H29zM0 24h1v1H0zM3 24h7v1H3zM12 24h1v1H12zM14 24h2v1H14zM17 24h1v1H17zM22 24h9v1H22zM32,24 h1v1H32zM8 25h4v1H8zM14 25h1v1H14zM18 25h1v1H18zM21 25h2v1H21zM24 25h1v1H24zM28 25h1v1H28zM30 25h1v1H30zM0 26h7v1H0zM9 26h4v1H9zM14 26h1v1H14zM19 26h3v1H19zM24 26h1v1H24zM26 26h1v1H26zM28 26h1v1H28zM30 26h2v1H30zM0 27h1v1H0zM6 27h1v1H6zM9 27h3v1H9zM18 27h2v1H18zM21 27h4v1H21zM28 27h4v1H28zM0 28h1v1H0zM2 28h3v1H2zM6 28h1v1H6zM8 28h2v1H8zM14 28h2v1H14zM17 28h2v1H17zM21 28h1v1H21zM24 28h5v1H24zM30 28h1v1H30zM32,28 h1v1H32zM0 29h1v1H0zM2 29h3v1H2zM6 29h1v1H6zM8 29h1v1H8zM10 29h1v1H10zM14 29h1v1H14zM19 29h1v1H19zM22 29h3v1H22zM27 29h5v1H27zM0 30h1v1H0zM2 30h3v1H2zM6 30h1v1H6zM8 30h2v1H8zM12 30h1v1H12zM14 30h1v1H14zM17 30h1v1H17zM19 30h1v1H19zM21 30h1v1H21zM24 30h3v1H24zM0 31h1v1H0zM6 31h1v1H6zM10 31h1v1H10zM12 31h1v1H12zM14 31h2v1H14zM17 31h1v1H17zM19 31h1v1H19zM21 31h2v1H21zM25 31h3v1H25zM30 31h1v1H30zM0 32h7v1H0zM9 32h1v1H9zM12 32h1v1H12zM15 32h1v1H15zM17 32h1v1H17zM19 32h2v1H19zM22 32h1v1H22zM24 32h1v1H24zM28 32h1v1H28zM30 32h2v1H30z"
+                fill="#000000"
+              />
+            </svg>
+          </div>
+          <div>
+            <div>
+              <div>
+                <div>
+                  Precinct
+                </div>
+                <strong>
+                  District 5
+                </strong>
+              </div>
+              <div>
+                <div>
+                  Ballot Style
+                </div>
+                <strong>
+                  5
+                </strong>
+              </div>
+              <div>
+                <div>
+                  Ballot ID
+                </div>
+                <strong
+                  class="sc-hKwCoD kKHUyA"
+                >
+                  Asdf1234Asdf12
+                </strong>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="sc-kDThTU eoGbCP"
+      >
+        <div
+          class="sc-iqsfdx gAnNz"
+        >
+          <div
+            class="sc-crHlIS iXsyCY"
+          >
+            <div
+              class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
+            >
+              <h3>
+                President
+              </h3>
+              <p
+                class="sc-dkPtyc iuZdud"
+              >
+                <span
+                  class="sc-dkPtyc dwpylT"
+                >
+                  Presidential Electors for Joe Biden for President and Kamala Harris for Vice President
+                </span>
+                 
+                / Democrat
+              </p>
+            </div>
+          </div>
+          <div
+            class="sc-crHlIS iXsyCY"
+          >
+            <div
+              class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
+            >
+              <h3>
+                Senate 
+              </h3>
+              <p
+                class="sc-dkPtyc iuZdud"
+              >
+                <span
+                  class="sc-dkPtyc dwpylT"
+                >
+                  Mike Espy
+                </span>
+                 
+                / Democrat
+              </p>
+            </div>
+          </div>
+          <div
+            class="sc-crHlIS iXsyCY"
+          >
+            <div
+              class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
+            >
+              <h3>
+                1st Congressional District
+              </h3>
+              <p
+                class="sc-dkPtyc iuZdud"
+              >
+                <span
+                  class="sc-dkPtyc dwpylT"
+                >
+                  Antonia Eliason
+                </span>
+                 
+                / Democrat
+              </p>
+            </div>
+          </div>
+          <div
+            class="sc-crHlIS iXsyCY"
+          >
+            <div
+              class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
+            >
+              <h3>
+                Supreme Court District 3(Northern) Position 3
+              </h3>
+              <p
+                class="sc-dkPtyc iuZdud"
+              >
+                <span
+                  class="sc-dkPtyc dwpylT"
+                >
+                  Josiah Dennis Coleman
+                </span>
+                 
+                / Nonpartisan
+              </p>
+            </div>
+          </div>
+          <div
+            class="sc-crHlIS iXsyCY"
+          >
+            <div
+              class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
+            >
+              <h3>
+                Election Commissioner 05
+              </h3>
+              <p
+                class="sc-dkPtyc iuZdud"
+              >
+                <span
+                  class="sc-dkPtyc dwpylT"
+                >
+                  Ouida A Loper
+                </span>
+                 
+                / Independent
+              </p>
+            </div>
+          </div>
+          <div
+            class="sc-crHlIS iXsyCY"
+          >
+            <div
+              class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
+            >
+              <h3>
+                School Board 05
+              </h3>
+              <p
+                class="sc-dkPtyc iuZdud"
+              >
+                <span
+                  class="sc-dkPtyc dwpylT"
+                >
+                  Michael D Thomas
+                </span>
+                 
+              </p>
+            </div>
+          </div>
+          <div
+            class="sc-crHlIS iXsyCY"
+          >
+            <div
+              class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
+            >
+              <h3>
+                Ballot Measure 2
+House Concurrent Resolution No. 47
+              </h3>
+              <p
+                class="sc-dkPtyc gDDfCv"
+              >
+                Yes
+                 
+              </p>
+            </div>
+          </div>
+          <div
+            class="sc-crHlIS iXsyCY"
+          >
+            <div
+              class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
+            >
+              <h3>
+                Ballot Measure 3
+House Bill 1796 - Flag Referendum
+              </h3>
+              <p
+                class="sc-dkPtyc gDDfCv"
+              >
+                Yes
+                 
+              </p>
+            </div>
+          </div>
+          <div
+            class="sc-crHlIS iXsyCY"
+          >
+            <div
+              class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
+            >
+              <h3>
+                Ballot Measure 1
+              </h3>
+              <p
+                class="sc-dkPtyc gDDfCv"
+              >
+                •
+                 
+                FOR APPROVAL OF EITHER Initiative No. 65 OR Alternative Measure No. 65 A
+              </p>
+              <p
+                class="sc-dkPtyc gDDfCv"
+              >
+                •
+                 
+                FOR Initiative Measure No. 65
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      aria-hidden="true"
+      class="sc-iCfLBT iZWxTt"
+    >
+      <div
+        class="sc-pVTma kOGGAi"
+      >
+        <div
+          class="seal"
+          data-testid="printed-ballot-seal"
+          id="printedBallotSealContainer"
+        >
+          <img
+            alt=""
+            class="sc-furvIG esRQPz"
+            data-testid="printed-ballot-seal-image"
+            src="/seals/Seal_of_Mississippi_BW.svg"
+          />
+        </div>
+        <div
+          class="sc-jRQAMF boeJiV ballot-header-content"
+        >
+          <h2>
+            Unofficial TEST Ballot
+          </h2>
+          <h3>
+            
+             
+            Mock General Election Choctaw 2020
+          </h3>
+          <p>
+            August 26, 2020
+            <br />
+            Choctaw County
+            , 
+            State of Mississippi
+          </p>
+        </div>
+        <div
+          class="sc-jrQzUz lkoXcE"
+        >
+          <div
+            class="sc-gKckTs drvJRF"
+          >
+            <svg
+              height="128"
+              shape-rendering="crispEdges"
+              viewBox="0 0 33 33"
+              width="128"
+            >
+              <path
+                d="M0,0 h33v33H0z"
+                fill="#FFFFFF"
+              />
+              <path
+                d="M0 0h7v1H0zM9 0h2v1H9zM13 0h1v1H13zM16 0h4v1H16zM21 0h3v1H21zM26,0 h7v1H26zM0 1h1v1H0zM6 1h1v1H6zM10 1h1v1H10zM15 1h6v1H15zM23 1h1v1H23zM26 1h1v1H26zM32,1 h1v1H32zM0 2h1v1H0zM2 2h3v1H2zM6 2h1v1H6zM9 2h1v1H9zM12 2h3v1H12zM16 2h1v1H16zM18 2h1v1H18zM23 2h2v1H23zM26 2h1v1H26zM28 2h3v1H28zM32,2 h1v1H32zM0 3h1v1H0zM2 3h3v1H2zM6 3h1v1H6zM11 3h3v1H11zM15 3h2v1H15zM18 3h3v1H18zM22 3h1v1H22zM26 3h1v1H26zM28 3h3v1H28zM32,3 h1v1H32zM0 4h1v1H0zM2 4h3v1H2zM6 4h1v1H6zM8 4h3v1H8zM13 4h1v1H13zM21 4h1v1H21zM23 4h1v1H23zM26 4h1v1H26zM28 4h3v1H28zM32,4 h1v1H32zM0 5h1v1H0zM6 5h1v1H6zM9 5h1v1H9zM12 5h3v1H12zM16 5h1v1H16zM18 5h2v1H18zM22 5h1v1H22zM24 5h1v1H24zM26 5h1v1H26zM32,5 h1v1H32zM0 6h7v1H0zM8 6h1v1H8zM10 6h1v1H10zM12 6h1v1H12zM14 6h1v1H14zM16 6h1v1H16zM18 6h1v1H18zM20 6h1v1H20zM22 6h1v1H22zM24 6h1v1H24zM26,6 h7v1H26zM8 7h3v1H8zM13 7h3v1H13zM18 7h1v1H18zM23 7h1v1H23zM2 8h2v1H2zM6 8h3v1H6zM10 8h2v1H10zM15 8h4v1H15zM21 8h2v1H21zM25 8h2v1H25zM28 8h1v1H28zM2 9h3v1H2zM7 9h3v1H7zM12 9h2v1H12zM16 9h5v1H16zM29 9h2v1H29zM32,9 h1v1H32zM2 10h3v1H2zM6 10h3v1H6zM10 10h5v1H10zM16 10h2v1H16zM21 10h8v1H21zM30,10 h3v1H30zM0 11h1v1H0zM3 11h1v1H3zM5 11h1v1H5zM9 11h1v1H9zM14 11h5v1H14zM21 11h2v1H21zM24 11h2v1H24zM27 11h2v1H27zM32,11 h1v1H32zM0 12h2v1H0zM4 12h1v1H4zM6 12h3v1H6zM10 12h4v1H10zM16 12h1v1H16zM18 12h2v1H18zM21 12h5v1H21zM27 12h1v1H27zM29 12h1v1H29zM31,12 h2v1H31zM0 13h2v1H0zM3 13h3v1H3zM7 13h2v1H7zM10 13h3v1H10zM15 13h1v1H15zM19 13h2v1H19zM24 13h1v1H24zM26,13 h7v1H26zM1 14h1v1H1zM6 14h1v1H6zM8 14h4v1H8zM15 14h1v1H15zM17 14h2v1H17zM20 14h2v1H20zM24 14h1v1H24zM29 14h2v1H29zM0 15h3v1H0zM8 15h3v1H8zM13 15h4v1H13zM21 15h1v1H21zM23 15h1v1H23zM28 15h3v1H28zM0 16h3v1H0zM6 16h2v1H6zM9 16h1v1H9zM12 16h1v1H12zM14 16h7v1H14zM22 16h1v1H22zM25 16h2v1H25zM30 16h2v1H30zM2 17h2v1H2zM5 17h1v1H5zM9 17h2v1H9zM15 17h2v1H15zM24 17h1v1H24zM27 17h3v1H27zM31 17h1v1H31zM1 18h2v1H1zM4 18h1v1H4zM6 18h2v1H6zM11 18h5v1H11zM18 18h1v1H18zM20 18h1v1H20zM27 18h2v1H27zM31 18h1v1H31zM1 19h3v1H1zM7 19h1v1H7zM11 19h1v1H11zM14 19h2v1H14zM17 19h2v1H17zM23 19h5v1H23zM32,19 h1v1H32zM0 20h2v1H0zM3 20h1v1H3zM5 20h3v1H5zM10 20h3v1H10zM14 20h4v1H14zM19 20h3v1H19zM25 20h1v1H25zM27 20h1v1H27zM30 20h2v1H30zM0 21h2v1H0zM3 21h1v1H3zM5 21h1v1H5zM7 21h3v1H7zM11 21h2v1H11zM22 21h1v1H22zM25 21h1v1H25zM27 21h1v1H27zM29 21h1v1H29zM32,21 h1v1H32zM2 22h2v1H2zM5 22h2v1H5zM8 22h3v1H8zM12 22h1v1H12zM15 22h1v1H15zM17 22h6v1H17zM26 22h1v1H26zM30,22 h3v1H30zM1 23h1v1H1zM4 23h2v1H4zM7 23h5v1H7zM13 23h1v1H13zM15 23h1v1H15zM17 23h4v1H17zM23 23h2v1H23zM26 23h4v1H26zM0 24h1v1H0zM3 24h7v1H3zM11 24h2v1H11zM14 24h1v1H14zM17 24h1v1H17zM19 24h1v1H19zM22 24h9v1H22zM32,24 h1v1H32zM8 25h1v1H8zM10 25h1v1H10zM12 25h1v1H12zM15 25h1v1H15zM17 25h1v1H17zM20 25h1v1H20zM22 25h3v1H22zM28 25h2v1H28zM32,25 h1v1H32zM0 26h7v1H0zM8 26h1v1H8zM11 26h1v1H11zM13 26h1v1H13zM15 26h3v1H15zM20 26h1v1H20zM22 26h1v1H22zM24 26h1v1H24zM26 26h1v1H26zM28 26h1v1H28zM0 27h1v1H0zM6 27h1v1H6zM10 27h2v1H10zM13 27h2v1H13zM19 27h1v1H19zM21 27h4v1H21zM28 27h4v1H28zM0 28h1v1H0zM2 28h3v1H2zM6 28h1v1H6zM10 28h3v1H10zM14 28h1v1H14zM17 28h1v1H17zM20 28h1v1H20zM23 28h7v1H23zM0 29h1v1H0zM2 29h3v1H2zM6 29h1v1H6zM8 29h3v1H8zM12 29h2v1H12zM15 29h2v1H15zM21 29h1v1H21zM23 29h1v1H23zM25 29h1v1H25zM29 29h1v1H29zM0 30h1v1H0zM2 30h3v1H2zM6 30h1v1H6zM8 30h2v1H8zM12 30h1v1H12zM14 30h1v1H14zM17 30h1v1H17zM19 30h1v1H19zM21 30h1v1H21zM24 30h3v1H24zM29 30h1v1H29zM0 31h1v1H0zM6 31h1v1H6zM9 31h3v1H9zM18 31h3v1H18zM22 31h4v1H22zM29 31h1v1H29zM32,31 h1v1H32zM0 32h7v1H0zM10 32h1v1H10zM13 32h1v1H13zM16 32h3v1H16zM20 32h2v1H20zM25 32h1v1H25zM27 32h1v1H27z"
+                fill="#000000"
+              />
+            </svg>
+          </div>
+          <div>
+            <div>
+              <div>
+                <div>
+                  Precinct
+                </div>
+                <strong>
+                  District 5
+                </strong>
+              </div>
+              <div>
+                <div>
+                  Ballot Style
+                </div>
+                <strong>
+                  5
+                </strong>
+              </div>
+              <div>
+                <div>
+                  Ballot ID
+                </div>
+                <strong
+                  class="sc-hKwCoD kKHUyA"
+                >
+                  Asdf1234Asdf12
+                </strong>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="sc-kDThTU eoGbCP"
+      >
+        <div
+          class="sc-iqsfdx gAnNz"
+        >
+          <div
+            class="sc-crHlIS iXsyCY"
+          >
+            <div
+              class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
+            >
+              <h3>
+                President
+              </h3>
+              <p
+                class="sc-dkPtyc iuZdud"
+              >
+                <span
+                  class="sc-dkPtyc dwpylT"
+                >
+                  Presidential Electors for Donald J. Trump for President and Michael R. Pence for Vice President
+                </span>
+                 
+                / Republican
+              </p>
+            </div>
+          </div>
+          <div
+            class="sc-crHlIS iXsyCY"
+          >
+            <div
+              class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
+            >
+              <h3>
+                Senate 
+              </h3>
+              <p
+                class="sc-dkPtyc iuZdud"
+              >
+                <span
+                  class="sc-dkPtyc dwpylT"
+                >
+                  Cindy Hyde-Smith
+                </span>
+                 
+                / Republican
+              </p>
+            </div>
+          </div>
+          <div
+            class="sc-crHlIS iXsyCY"
+          >
+            <div
+              class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
+            >
+              <h3>
+                1st Congressional District
+              </h3>
+              <p
+                class="sc-dkPtyc iuZdud"
+              >
+                <span
+                  class="sc-dkPtyc dwpylT"
+                >
+                  Trent Kelly
+                </span>
+                 
+                / Republican
+              </p>
+            </div>
+          </div>
+          <div
+            class="sc-crHlIS iXsyCY"
+          >
+            <div
+              class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
+            >
+              <h3>
+                Supreme Court District 3(Northern) Position 3
+              </h3>
+              <p
+                class="sc-dkPtyc iuZdud"
+              >
+                <span
+                  class="sc-dkPtyc dwpylT"
+                >
+                  Percy L. Lynchard
+                </span>
+                 
+                / Nonpartisan
+              </p>
+            </div>
+          </div>
+          <div
+            class="sc-crHlIS iXsyCY"
+          >
+            <div
+              class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
+            >
+              <h3>
+                Election Commissioner 05
+              </h3>
+              <p
+                class="sc-dkPtyc iuZdud"
+              >
+                <span
+                  class="sc-dkPtyc dwpylT"
+                >
+                  Wayne McLeod
+                </span>
+                 
+              </p>
+            </div>
+          </div>
+          <div
+            class="sc-crHlIS iXsyCY"
+          >
+            <div
+              class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
+            >
+              <h3>
+                School Board 05
+              </h3>
+              <p
+                class="sc-dkPtyc iuZdud"
+              >
+                <span
+                  class="sc-dkPtyc dwpylT"
+                >
+                  Michael D Thomas
+                </span>
+                 
+              </p>
+            </div>
+          </div>
+          <div
+            class="sc-crHlIS iXsyCY"
+          >
+            <div
+              class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
+            >
+              <h3>
+                Ballot Measure 2
+House Concurrent Resolution No. 47
+              </h3>
+              <p
+                class="sc-dkPtyc gDDfCv"
+              >
+                No
+                 
+              </p>
+            </div>
+          </div>
+          <div
+            class="sc-crHlIS iXsyCY"
+          >
+            <div
+              class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
+            >
+              <h3>
+                Ballot Measure 3
+House Bill 1796 - Flag Referendum
+              </h3>
+              <p
+                class="sc-dkPtyc gDDfCv"
+              >
+                No
+                 
+              </p>
+            </div>
+          </div>
+          <div
+            class="sc-crHlIS iXsyCY"
+          >
+            <div
+              class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
+            >
+              <h3>
+                Ballot Measure 1
+              </h3>
+              <p
+                class="sc-dkPtyc gDDfCv"
+              >
+                •
+                 
+                AGAINST BOTH Initiative Measure No. 65 AND Alternative Measure No. 65 A
+              </p>
+              <p
+                class="sc-dkPtyc gDDfCv"
+              >
+                •
+                 
+                FOR Alternative Measure 65 A
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      aria-hidden="true"
+      class="sc-iCfLBT iZWxTt"
+    >
+      <div
+        class="sc-pVTma kOGGAi"
+      >
+        <div
+          class="seal"
+          data-testid="printed-ballot-seal"
+          id="printedBallotSealContainer"
+        >
+          <img
+            alt=""
+            class="sc-furvIG esRQPz"
+            data-testid="printed-ballot-seal-image"
+            src="/seals/Seal_of_Mississippi_BW.svg"
+          />
+        </div>
+        <div
+          class="sc-jRQAMF boeJiV ballot-header-content"
+        >
+          <h2>
+            Unofficial TEST Ballot
+          </h2>
+          <h3>
+            
+             
+            Mock General Election Choctaw 2020
+          </h3>
+          <p>
+            August 26, 2020
+            <br />
+            Choctaw County
+            , 
+            State of Mississippi
+          </p>
+        </div>
+        <div
+          class="sc-jrQzUz lkoXcE"
+        >
+          <div
+            class="sc-gKckTs drvJRF"
+          >
+            <svg
+              height="128"
+              shape-rendering="crispEdges"
+              viewBox="0 0 33 33"
+              width="128"
+            >
+              <path
+                d="M0,0 h33v33H0z"
+                fill="#FFFFFF"
+              />
+              <path
+                d="M0 0h7v1H0zM8 0h3v1H8zM13 0h1v1H13zM16 0h4v1H16zM21 0h3v1H21zM26,0 h7v1H26zM0 1h1v1H0zM6 1h1v1H6zM8 1h5v1H8zM14 1h1v1H14zM16 1h1v1H16zM19 1h1v1H19zM21 1h1v1H21zM24 1h1v1H24zM26 1h1v1H26zM32,1 h1v1H32zM0 2h1v1H0zM2 2h3v1H2zM6 2h1v1H6zM8 2h1v1H8zM10 2h1v1H10zM14 2h2v1H14zM19 2h1v1H19zM21 2h3v1H21zM26 2h1v1H26zM28 2h3v1H28zM32,2 h1v1H32zM0 3h1v1H0zM2 3h3v1H2zM6 3h1v1H6zM11 3h1v1H11zM13 3h1v1H13zM15 3h2v1H15zM18 3h2v1H18zM22 3h1v1H22zM26 3h1v1H26zM28 3h3v1H28zM32,3 h1v1H32zM0 4h1v1H0zM2 4h3v1H2zM6 4h1v1H6zM10 4h2v1H10zM13 4h2v1H13zM17 4h2v1H17zM20 4h1v1H20zM24 4h1v1H24zM26 4h1v1H26zM28 4h3v1H28zM32,4 h1v1H32zM0 5h1v1H0zM6 5h1v1H6zM8 5h3v1H8zM14 5h1v1H14zM16 5h6v1H16zM26 5h1v1H26zM32,5 h1v1H32zM0 6h7v1H0zM8 6h1v1H8zM10 6h1v1H10zM12 6h1v1H12zM14 6h1v1H14zM16 6h1v1H16zM18 6h1v1H18zM20 6h1v1H20zM22 6h1v1H22zM24 6h1v1H24zM26,6 h7v1H26zM8 7h3v1H8zM12 7h1v1H12zM14 7h1v1H14zM16 7h1v1H16zM19 7h3v1H19zM24 7h1v1H24zM2 8h3v1H2zM6 8h1v1H6zM8 8h2v1H8zM11 8h1v1H11zM14 8h1v1H14zM16 8h2v1H16zM19 8h2v1H19zM24 8h4v1H24zM30,8 h3v1H30zM2 9h3v1H2zM7 9h2v1H7zM10 9h1v1H10zM12 9h2v1H12zM16 9h1v1H16zM18 9h2v1H18zM29 9h2v1H29zM32,9 h1v1H32zM0 10h1v1H0zM4 10h4v1H4zM10 10h1v1H10zM14 10h2v1H14zM18 10h3v1H18zM22 10h1v1H22zM25 10h1v1H25zM28 10h2v1H28zM31 10h1v1H31zM1 11h1v1H1zM4 11h2v1H4zM7 11h1v1H7zM9 11h2v1H9zM13 11h1v1H13zM16 11h4v1H16zM30,11 h3v1H30zM0 12h2v1H0zM4 12h1v1H4zM6 12h2v1H6zM10 12h4v1H10zM15 12h2v1H15zM18 12h2v1H18zM21 12h5v1H21zM27 12h1v1H27zM29 12h1v1H29zM31,12 h2v1H31zM1 13h1v1H1zM3 13h2v1H3zM7 13h1v1H7zM9 13h2v1H9zM14 13h1v1H14zM17 13h1v1H17zM19 13h1v1H19zM21 13h1v1H21zM23 13h1v1H23zM28 13h1v1H28zM30 13h2v1H30zM6 14h1v1H6zM8 14h1v1H8zM11 14h3v1H11zM16 14h2v1H16zM19 14h2v1H19zM22 14h1v1H22zM25 14h1v1H25zM27 14h5v1H27zM3 15h1v1H3zM5 15h1v1H5zM7 15h4v1H7zM13 15h4v1H13zM21 15h1v1H21zM23 15h1v1H23zM28 15h3v1H28zM0 16h7v1H0zM8 16h1v1H8zM11 16h1v1H11zM16 16h1v1H16zM19 16h1v1H19zM21 16h5v1H21zM27 16h1v1H27zM31,16 h2v1H31zM0 17h1v1H0zM2 17h4v1H2zM12 17h2v1H12zM18 17h2v1H18zM21 17h2v1H21zM25 17h1v1H25zM29,17 h4v1H29zM1 18h2v1H1zM5 18h3v1H5zM11 18h5v1H11zM18 18h1v1H18zM20 18h1v1H20zM27 18h2v1H27zM2 19h1v1H2zM5 19h1v1H5zM9 19h1v1H9zM12 19h1v1H12zM20 19h2v1H20zM25 19h1v1H25zM29,19 h4v1H29zM5 20h2v1H5zM9 20h1v1H9zM11 20h1v1H11zM13 20h2v1H13zM16 20h3v1H16zM22 20h1v1H22zM24 20h1v1H24zM28 20h1v1H28zM32,20 h1v1H32zM0 21h2v1H0zM3 21h1v1H3zM7 21h2v1H7zM11 21h1v1H11zM15 21h3v1H15zM19 21h2v1H19zM22 21h1v1H22zM25 21h1v1H25zM27 21h1v1H27zM29 21h1v1H29zM32,21 h1v1H32zM0 22h1v1H0zM6 22h1v1H6zM9 22h1v1H9zM11 22h2v1H11zM14 22h4v1H14zM20 22h1v1H20zM22 22h3v1H22zM27 22h1v1H27zM29 22h1v1H29zM31 22h1v1H31zM0 23h1v1H0zM3 23h1v1H3zM5 23h1v1H5zM8 23h1v1H8zM13 23h1v1H13zM15 23h1v1H15zM18 23h6v1H18zM25 23h2v1H25zM29 23h3v1H29zM0 24h1v1H0zM3 24h9v1H3zM14 24h1v1H14zM17 24h2v1H17zM20 24h1v1H20zM22 24h9v1H22zM32,24 h1v1H32zM8 25h1v1H8zM14 25h1v1H14zM16 25h1v1H16zM19 25h1v1H19zM21 25h1v1H21zM24 25h1v1H24zM28 25h1v1H28zM30 25h1v1H30zM0 26h7v1H0zM11 26h3v1H11zM17 26h1v1H17zM21 26h1v1H21zM24 26h1v1H24zM26 26h1v1H26zM28 26h1v1H28zM30 26h2v1H30zM0 27h1v1H0zM6 27h1v1H6zM9 27h2v1H9zM16 27h2v1H16zM21 27h4v1H21zM28 27h4v1H28zM0 28h1v1H0zM2 28h3v1H2zM6 28h1v1H6zM8 28h4v1H8zM13 28h3v1H13zM17 28h1v1H17zM21 28h1v1H21zM24 28h5v1H24zM30 28h1v1H30zM32,28 h1v1H32zM0 29h1v1H0zM2 29h3v1H2zM6 29h1v1H6zM8 29h1v1H8zM14 29h1v1H14zM18 29h2v1H18zM22 29h3v1H22zM27 29h5v1H27zM0 30h1v1H0zM2 30h3v1H2zM6 30h1v1H6zM8 30h2v1H8zM12 30h1v1H12zM14 30h1v1H14zM17 30h1v1H17zM19 30h1v1H19zM21 30h1v1H21zM24 30h3v1H24zM0 31h1v1H0zM6 31h1v1H6zM10 31h1v1H10zM12 31h1v1H12zM14 31h2v1H14zM17 31h1v1H17zM19 31h1v1H19zM21 31h2v1H21zM25 31h3v1H25zM30 31h1v1H30zM0 32h7v1H0zM9 32h1v1H9zM12 32h1v1H12zM15 32h1v1H15zM17 32h1v1H17zM19 32h2v1H19zM22 32h1v1H22zM24 32h1v1H24zM28 32h1v1H28zM30 32h2v1H30z"
+                fill="#000000"
+              />
+            </svg>
+          </div>
+          <div>
+            <div>
+              <div>
+                <div>
+                  Precinct
+                </div>
+                <strong>
+                  District 5
+                </strong>
+              </div>
+              <div>
+                <div>
+                  Ballot Style
+                </div>
+                <strong>
+                  5
+                </strong>
+              </div>
+              <div>
+                <div>
+                  Ballot ID
+                </div>
+                <strong
+                  class="sc-hKwCoD kKHUyA"
+                >
+                  Asdf1234Asdf12
+                </strong>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="sc-kDThTU eoGbCP"
+      >
+        <div
+          class="sc-iqsfdx gAnNz"
+        >
+          <div
+            class="sc-crHlIS iXsyCY"
+          >
+            <div
+              class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
+            >
+              <h3>
+                President
+              </h3>
+              <p
+                class="sc-dkPtyc iuZdud"
+              >
+                <span
+                  class="sc-dkPtyc dwpylT"
+                >
+                  Presidential Electors for Phil Collins for President and Bill Parker for Vice President
+                </span>
+                 
+                / Independent
+              </p>
+            </div>
+          </div>
+          <div
+            class="sc-crHlIS iXsyCY"
+          >
+            <div
+              class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
+            >
+              <h3>
+                Senate 
+              </h3>
+              <p
+                class="sc-dkPtyc iuZdud"
+              >
+                <span
+                  class="sc-dkPtyc dwpylT"
+                >
+                  Jimmy Edwards
+                </span>
+                 
+                / Libertarian
+              </p>
+            </div>
+          </div>
+          <div
+            class="sc-crHlIS iXsyCY"
+          >
+            <div
+              class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
+            >
+              <h3>
+                1st Congressional District
+              </h3>
+              <p
+                class="sc-dkPtyc iuZdud"
+              >
+                <span
+                  class="sc-dkPtyc dwpylT"
+                >
+                  Antonia Eliason
+                </span>
+                 
+                / Democrat
+              </p>
+            </div>
+          </div>
+          <div
+            class="sc-crHlIS iXsyCY"
+          >
+            <div
+              class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
+            >
+              <h3>
+                Supreme Court District 3(Northern) Position 3
+              </h3>
+              <p
+                class="sc-dkPtyc iuZdud"
+              >
+                <span
+                  class="sc-dkPtyc dwpylT"
+                >
+                  Josiah Dennis Coleman
+                </span>
+                 
+                / Nonpartisan
+              </p>
+            </div>
+          </div>
+          <div
+            class="sc-crHlIS iXsyCY"
+          >
+            <div
+              class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
+            >
+              <h3>
+                Election Commissioner 05
+              </h3>
+              <p
+                class="sc-dkPtyc iuZdud"
+              >
+                <span
+                  class="sc-dkPtyc dwpylT"
+                >
+                  Ouida A Loper
+                </span>
+                 
+                / Independent
+              </p>
+            </div>
+          </div>
+          <div
+            class="sc-crHlIS iXsyCY"
+          >
+            <div
+              class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
+            >
+              <h3>
+                School Board 05
+              </h3>
+              <p
+                class="sc-dkPtyc iuZdud"
+              >
+                <span
+                  class="sc-dkPtyc dwpylT"
+                >
+                  Michael D Thomas
+                </span>
+                 
+              </p>
+            </div>
+          </div>
+          <div
+            class="sc-crHlIS iXsyCY"
+          >
+            <div
+              class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
+            >
+              <h3>
+                Ballot Measure 2
+House Concurrent Resolution No. 47
+              </h3>
+              <p
+                class="sc-dkPtyc gDDfCv"
+              >
+                Yes
+                 
+              </p>
+            </div>
+          </div>
+          <div
+            class="sc-crHlIS iXsyCY"
+          >
+            <div
+              class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
+            >
+              <h3>
+                Ballot Measure 3
+House Bill 1796 - Flag Referendum
+              </h3>
+              <p
+                class="sc-dkPtyc gDDfCv"
+              >
+                Yes
+                 
+              </p>
+            </div>
+          </div>
+          <div
+            class="sc-crHlIS iXsyCY"
+          >
+            <div
+              class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
+            >
+              <h3>
+                Ballot Measure 1
+              </h3>
+              <p
+                class="sc-dkPtyc gDDfCv"
+              >
+                •
+                 
+                FOR APPROVAL OF EITHER Initiative No. 65 OR Alternative Measure No. 65 A
+              </p>
+              <p
+                class="sc-dkPtyc gDDfCv"
+              >
+                •
+                 
+                FOR Initiative Measure No. 65
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div />
+</div>
+`;
+
+exports[`L&A (logic and accuracy) flow 3`] = `
 <div
   aria-hidden="true"
 >

--- a/frontends/election-manager/src/screens/print_test_deck_screen.test.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.test.tsx
@@ -43,8 +43,7 @@ test('Printing all L&A packages sorts precincts', async () => {
     'Southwest Ackerman',
     'West Weir',
   ];
-  for (let i = 0; i < precinctsInAlphabeticalOrder.length; i += 1) {
-    const precinct = precinctsInAlphabeticalOrder[i];
+  for (const [i, precinct] of precinctsInAlphabeticalOrder.entries()) {
     const printText = `Printing L&A Package (${i + 1} of 13): ${precinct}.`;
     await screen.findByLabelText(printText);
     jest.advanceTimersByTime(5000);

--- a/frontends/election-manager/src/screens/print_test_deck_screen.test.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { fakeKiosk, fakePrinterInfo } from '@votingworks/test-utils';
+import { screen } from '@testing-library/react';
 
 import { PrintTestDeckScreen } from './print_test_deck_screen';
 import { renderInAppContext } from '../../test/render_in_app_context';
@@ -22,110 +23,36 @@ test('Printing all L&A packages sorts precincts', async () => {
     fakePrinterInfo({ name: 'VxPrinter', connected: true }),
   ]);
 
-  const { getByText, getByLabelText } = renderInAppContext(
-    <PrintTestDeckScreen />
-  );
+  renderInAppContext(<PrintTestDeckScreen />);
 
-  fireEvent.click(getByText('All Precincts'));
+  userEvent.click(screen.getByText('All Precincts'));
 
   // Check that the printing modals appear in alphabetical order
-  await waitFor(() => getByLabelText('Printing L&A Package (1 of 13): Bywy.'));
-  jest.advanceTimersByTime(3000);
-  await waitFor(() => getByLabelText('Printing L&A Package (1 of 13): Bywy.'));
-  jest.advanceTimersByTime(30000);
-  await waitFor(() =>
-    getByLabelText('Printing L&A Package (2 of 13): Chester.')
-  );
-  jest.advanceTimersByTime(3000);
-  await waitFor(() =>
-    getByLabelText('Printing L&A Package (2 of 13): Chester.')
-  );
-  jest.advanceTimersByTime(30000);
-  await waitFor(() =>
-    getByLabelText('Printing L&A Package (3 of 13): District 5.')
-  );
-  jest.advanceTimersByTime(3000);
-  await waitFor(() =>
-    getByLabelText('Printing L&A Package (3 of 13): District 5.')
-  );
-  jest.advanceTimersByTime(30000);
-  await waitFor(() =>
-    getByLabelText('Printing L&A Package (4 of 13): East Weir.')
-  );
-  jest.advanceTimersByTime(3000);
-  await waitFor(() =>
-    getByLabelText('Printing L&A Package (4 of 13): East Weir.')
-  );
-  jest.advanceTimersByTime(30000);
-  await waitFor(() =>
-    getByLabelText('Printing L&A Package (5 of 13): Fentress.')
-  );
-  jest.advanceTimersByTime(3000);
-  await waitFor(() =>
-    getByLabelText('Printing L&A Package (5 of 13): Fentress.')
-  );
-  jest.advanceTimersByTime(30000);
-  await waitFor(() =>
-    getByLabelText('Printing L&A Package (6 of 13): French Camp.')
-  );
-  jest.advanceTimersByTime(3000);
-  await waitFor(() =>
-    getByLabelText('Printing L&A Package (6 of 13): French Camp.')
-  );
-  jest.advanceTimersByTime(30000);
-  await waitFor(() =>
-    getByLabelText('Printing L&A Package (7 of 13): Hebron.')
-  );
-  jest.advanceTimersByTime(3000);
-  await waitFor(() =>
-    getByLabelText('Printing L&A Package (7 of 13): Hebron.')
-  );
-  jest.advanceTimersByTime(30000);
-  await waitFor(() =>
-    getByLabelText('Printing L&A Package (8 of 13): Kenego.')
-  );
-  jest.advanceTimersByTime(3000);
-  await waitFor(() =>
-    getByLabelText('Printing L&A Package (8 of 13): Kenego.')
-  );
-  jest.advanceTimersByTime(30000);
-  await waitFor(() =>
-    getByLabelText('Printing L&A Package (9 of 13): Panhandle.')
-  );
-  jest.advanceTimersByTime(3000);
-  await waitFor(() =>
-    getByLabelText('Printing L&A Package (9 of 13): Panhandle.')
-  );
-  jest.advanceTimersByTime(30000);
-  await waitFor(() =>
-    getByLabelText('Printing L&A Package (10 of 13): Reform.')
-  );
-  jest.advanceTimersByTime(3000);
-  await waitFor(() =>
-    getByLabelText('Printing L&A Package (10 of 13): Reform.')
-  );
-  jest.advanceTimersByTime(30000);
-  await waitFor(() =>
-    getByLabelText('Printing L&A Package (11 of 13): Sherwood.')
-  );
-  jest.advanceTimersByTime(3000);
-  await waitFor(() =>
-    getByLabelText('Printing L&A Package (11 of 13): Sherwood.')
-  );
-  jest.advanceTimersByTime(30000);
-  await waitFor(() =>
-    getByLabelText('Printing L&A Package (12 of 13): Southwest Ackerman.')
-  );
-  jest.advanceTimersByTime(3000);
-  await waitFor(() =>
-    getByLabelText('Printing L&A Package (12 of 13): Southwest Ackerman.')
-  );
-  jest.advanceTimersByTime(30000);
-  await waitFor(() =>
-    getByLabelText('Printing L&A Package (13 of 13): West Weir.')
-  );
-  jest.advanceTimersByTime(3000);
-  await waitFor(() =>
-    getByLabelText('Printing L&A Package (13 of 13): West Weir.')
-  );
+  const precinctsInAlphabeticalOrder = [
+    'Bywy',
+    'Chester',
+    'District 5',
+    'East Weir',
+    'Fentress',
+    'French Camp',
+    'Hebron',
+    'Kenego',
+    'Panhandle',
+    'Reform',
+    'Sherwood',
+    'Southwest Ackerman',
+    'West Weir',
+  ];
+  for (let i = 0; i < precinctsInAlphabeticalOrder.length; i += 1) {
+    const precinct = precinctsInAlphabeticalOrder[i];
+    const printText = `Printing L&A Package (${i + 1} of 13): ${precinct}.`;
+    await screen.findByLabelText(printText);
+    jest.advanceTimersByTime(5000);
+    await screen.findByLabelText(printText);
+    jest.advanceTimersByTime(30000);
+    await screen.findByLabelText(printText);
+    jest.advanceTimersByTime(30000);
+  }
+  await screen.findByText('All Precincts');
+  expect(screen.queryByText('Printing')).not.toBeInTheDocument();
 });

--- a/frontends/election-manager/src/screens/print_test_deck_screen.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.tsx
@@ -32,6 +32,7 @@ import {
 
 const ONE_SIDED_PAGE_PRINT_TIME_MS = 3000;
 const TWO_SIDED_PAGE_PRINT_TIME_MS = 5000;
+const LAST_PRINT_JOB_SLEEP_MS = 5000;
 
 interface PrecinctTallyReportProps {
   election: Election;
@@ -292,7 +293,9 @@ export function PrintTestDeckScreen(): JSX.Element {
           component: 'TallyReport',
         });
       } else {
-        await makeCancelable(sleep(numBallots * TWO_SIDED_PAGE_PRINT_TIME_MS));
+        // For the last print job, rather than waiting for all pages to finish printing, free up
+        // the UI from the print modal earlier
+        await makeCancelable(sleep(LAST_PRINT_JOB_SLEEP_MS));
         setPrintIndex(undefined);
         setPrecinctIds([]);
       }

--- a/frontends/election-manager/src/screens/print_test_deck_screen.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.tsx
@@ -2,34 +2,32 @@ import React, { useState, useContext, useCallback, useEffect } from 'react';
 import {
   Election,
   getPrecinctById,
+  Precinct,
   PrecinctId,
-  VotesDict,
   Tally,
   VotingMethod,
 } from '@votingworks/types';
 import { assert, sleep, tallyVotesByContest } from '@votingworks/utils';
 import { LogEventId } from '@votingworks/logging';
-
 import { useCancelablePromise, Modal, Prose } from '@votingworks/ui';
 
 import { AppContext } from '../contexts/app_context';
-
 import { Button } from '../components/button';
 import { ButtonList } from '../components/button_list';
 import { Loading } from '../components/loading';
-
 import { NavigationScreen } from '../components/navigation_screen';
-
 import { HandMarkedPaperBallot } from '../components/hand_marked_paper_ballot';
 import { TestDeckTallyReport } from '../components/test_deck_tally_report';
-
 import {
   generateTestDeckBallots,
   generateBlankBallots,
   generateOvervoteBallot,
 } from '../utils/election';
 
-interface PrecinctTallyReportParams {
+const ONE_SIDED_PAGE_PRINT_TIME_MS = 3000;
+const TWO_SIDED_PAGE_PRINT_TIME_MS = 5000;
+
+interface PrecinctTallyReportProps {
   election: Election;
   precinctId: PrecinctId;
   onRendered: (numPages: number) => void;
@@ -39,16 +37,15 @@ function PrecinctTallyReport({
   election,
   precinctId,
   onRendered,
-}: PrecinctTallyReportParams) {
+}: PrecinctTallyReportProps): JSX.Element {
   const ballots = generateTestDeckBallots({ election, precinctId });
 
-  const votes: VotesDict[] = ballots.map((b) => b.votes as VotesDict);
   const testDeckTally: Tally = {
     numberOfBallotsCounted: ballots.length,
     castVoteRecords: new Set(),
     contestTallies: tallyVotesByContest({
       election,
-      votes,
+      votes: ballots.map((b) => b.votes),
     }),
     ballotCountsByVotingMethod: { [VotingMethod.Unknown]: ballots.length },
   };
@@ -67,7 +64,7 @@ function PrecinctTallyReport({
   );
 }
 
-interface HandMarkedPaperBallotsParams {
+interface HandMarkedPaperBallotsProps {
   election: Election;
   electionHash: string;
   precinctId: PrecinctId;
@@ -79,12 +76,15 @@ function HandMarkedPaperBallots({
   electionHash,
   precinctId,
   onAllRendered,
-}: HandMarkedPaperBallotsParams) {
-  const ballots = generateTestDeckBallots({ election, precinctId });
-  ballots.push(...generateBlankBallots({ election, precinctId, numBlanks: 2 }));
-
+}: HandMarkedPaperBallotsProps): JSX.Element {
+  const ballots = [
+    ...generateTestDeckBallots({ election, precinctId }),
+    ...generateBlankBallots({ election, precinctId, numBlanks: 2 }),
+  ];
   const overvoteBallot = generateOvervoteBallot({ election, precinctId });
-  if (overvoteBallot) ballots.push(overvoteBallot);
+  if (overvoteBallot) {
+    ballots.push(overvoteBallot);
+  }
 
   let numRendered = 0;
   function onRendered() {
@@ -99,14 +99,14 @@ function HandMarkedPaperBallots({
       {ballots.map((ballot, i) => (
         <HandMarkedPaperBallot
           key={`ballot-${i}`} // eslint-disable-line react/no-array-index-key
-          ballotStyleId={ballot.ballotStyleId as string}
+          ballotStyleId={ballot.ballotStyleId}
           election={election}
           electionHash={electionHash}
           isLiveMode={false}
           isAbsentee={false}
-          precinctId={ballot.precinctId as string}
+          precinctId={ballot.precinctId}
           locales={{ primary: 'en-US' }}
-          votes={ballot.votes as VotesDict}
+          votes={ballot.votes}
           onRendered={() => onRendered()}
         />
       ))}
@@ -129,7 +129,7 @@ const HandMarkedPaperBallotsMemoized = React.memo(HandMarkedPaperBallots);
 
 interface PrintIndex {
   precinctIndex: number;
-  component: string;
+  component: 'TallyReport' | 'HandMarkedPaperBallots';
 }
 
 export function PrintTestDeckScreen(): JSX.Element {
@@ -141,7 +141,7 @@ export function PrintTestDeckScreen(): JSX.Element {
   const currentUserType = currentUserSession.type;
   const { election, electionHash } = electionDefinition;
   const [precinctIds, setPrecinctIds] = useState<string[]>([]);
-  const [printIndex, setPrintIndex] = useState<PrintIndex | undefined>();
+  const [printIndex, setPrintIndex] = useState<PrintIndex | null>();
 
   const pageTitle = 'L&A Packages';
 
@@ -163,7 +163,7 @@ export function PrintTestDeckScreen(): JSX.Element {
       const printers = await window.kiosk.getPrinterInfo();
       if (printers.some((p) => p.connected)) {
         setPrecinctIds(generatePrecinctIds(precinctId));
-        setPrintIndex({ precinctIndex: 0, component: 'tally' });
+        setPrintIndex({ precinctIndex: 0, component: 'TallyReport' });
       } else {
         // eslint-disable-next-line no-alert
         window.alert('please connect the printer.');
@@ -176,7 +176,7 @@ export function PrintTestDeckScreen(): JSX.Element {
       }
     } else {
       setPrecinctIds(generatePrecinctIds(precinctId));
-      setPrintIndex({ precinctIndex: 0, component: 'tally' });
+      setPrintIndex({ precinctIndex: 0, component: 'TallyReport' });
     }
   }
 
@@ -186,19 +186,18 @@ export function PrintTestDeckScreen(): JSX.Element {
         return;
       }
 
+      const precinctId = precinctIds[printIndex.precinctIndex];
       await printer.print({ sides: 'one-sided' });
       await logger.log(LogEventId.TestDeckTallyReportPrinted, currentUserType, {
         disposition: 'success',
-        message: `Test deck tally report printed as part of L&A package for precinct id: ${
-          precinctIds[printIndex.precinctIndex]
-        }`,
-        precinctId: precinctIds[printIndex.precinctIndex],
+        message: `Test deck tally report printed as part of L&A package for precinct ID: ${precinctId}`,
+        precinctId,
       });
 
-      await makeCancelable(sleep(numPages * 3000));
+      await makeCancelable(sleep(numPages * ONE_SIDED_PAGE_PRINT_TIME_MS));
       setPrintIndex({
         precinctIndex: printIndex.precinctIndex,
-        component: 'hmpb',
+        component: 'HandMarkedPaperBallots',
       });
     },
     [printIndex, printer, logger, currentUserType, precinctIds, makeCancelable]
@@ -210,43 +209,43 @@ export function PrintTestDeckScreen(): JSX.Element {
         return;
       }
 
+      const precinctId = precinctIds[printIndex.precinctIndex];
       await printer.print({ sides: 'two-sided-long-edge' });
       await logger.log(LogEventId.TestDeckPrinted, currentUserType, {
         disposition: 'success',
-        message: `Hand-marked paper ballot test deck printed as part of L&A package for precinct id: ${
-          precinctIds[printIndex.precinctIndex]
-        }`,
-        precinctId: precinctIds[printIndex.precinctIndex],
+        message: `Hand-marked paper ballot test deck printed as part of L&A package for precinct ID: ${precinctId}`,
+        precinctId,
       });
 
       if (printIndex.precinctIndex < precinctIds.length - 1) {
-        // wait 5s per ballot printed
-        // that's how long printing takes in duplex, no reason to get ahead of it.
-        await makeCancelable(sleep(numBallots * 5000));
+        await makeCancelable(sleep(numBallots * TWO_SIDED_PAGE_PRINT_TIME_MS));
         setPrintIndex({
           precinctIndex: printIndex.precinctIndex + 1,
-          component: 'tally',
+          component: 'TallyReport',
         });
       } else {
-        await makeCancelable(sleep(3000));
-        setPrintIndex(undefined);
+        await makeCancelable(sleep(numBallots * TWO_SIDED_PAGE_PRINT_TIME_MS));
+        setPrintIndex(null);
         setPrecinctIds([]);
       }
     },
     [printIndex, printer, logger, currentUserType, precinctIds, makeCancelable]
   );
 
-  const currentPrecinct =
-    printIndex === undefined
-      ? undefined
-      : getPrecinctById({
-          election,
-          precinctId: precinctIds[printIndex.precinctIndex],
-        });
+  const currentPrecinctId = printIndex
+    ? precinctIds[printIndex.precinctIndex]
+    : '';
+  const currentPrecinct: Precinct | null =
+    (printIndex &&
+      getPrecinctById({
+        election,
+        precinctId: currentPrecinctId,
+      })) ||
+    null;
 
   return (
     <React.Fragment>
-      {printIndex !== undefined && currentPrecinct && (
+      {printIndex && currentPrecinct && (
         <Modal
           centerContent
           content={
@@ -286,21 +285,21 @@ export function PrintTestDeckScreen(): JSX.Element {
             ))}
         </ButtonList>
       </NavigationScreen>
-      {printIndex !== undefined &&
-        (printIndex.component === 'tally' ? (
-          <PrecinctTallyReport
-            election={election}
-            precinctId={precinctIds[printIndex.precinctIndex]}
-            onRendered={onPrecinctTallyReportRendered}
-          />
-        ) : (
-          <HandMarkedPaperBallotsMemoized
-            election={election}
-            electionHash={electionHash}
-            precinctId={precinctIds[printIndex.precinctIndex]}
-            onAllRendered={onAllHandMarkedPaperBallotsRendered}
-          />
-        ))}
+      {printIndex?.component === 'TallyReport' && (
+        <PrecinctTallyReport
+          election={election}
+          precinctId={currentPrecinctId}
+          onRendered={onPrecinctTallyReportRendered}
+        />
+      )}
+      {printIndex?.component === 'HandMarkedPaperBallots' && (
+        <HandMarkedPaperBallotsMemoized
+          election={election}
+          electionHash={electionHash}
+          precinctId={currentPrecinctId}
+          onAllRendered={onAllHandMarkedPaperBallotsRendered}
+        />
+      )}
     </React.Fragment>
   );
 }

--- a/frontends/election-manager/src/screens/print_test_deck_screen.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.tsx
@@ -186,7 +186,7 @@ export function PrintTestDeckScreen(): JSX.Element {
   const currentUserType = currentUserSession.type;
   const { election, electionHash } = electionDefinition;
   const [precinctIds, setPrecinctIds] = useState<string[]>([]);
-  const [printIndex, setPrintIndex] = useState<PrintIndex | null>();
+  const [printIndex, setPrintIndex] = useState<PrintIndex>();
 
   const pageTitle = 'L&A Packages';
 
@@ -293,7 +293,7 @@ export function PrintTestDeckScreen(): JSX.Element {
         });
       } else {
         await makeCancelable(sleep(numBallots * TWO_SIDED_PAGE_PRINT_TIME_MS));
-        setPrintIndex(null);
+        setPrintIndex(undefined);
         setPrecinctIds([]);
       }
     },
@@ -303,13 +303,12 @@ export function PrintTestDeckScreen(): JSX.Element {
   const currentPrecinctId = printIndex
     ? precinctIds[printIndex.precinctIndex]
     : '';
-  const currentPrecinct: Precinct | null =
-    (printIndex &&
-      getPrecinctById({
+  const currentPrecinct: Precinct | undefined = printIndex
+    ? getPrecinctById({
         election,
         precinctId: currentPrecinctId,
-      })) ||
-    null;
+      })
+    : undefined;
 
   return (
     <React.Fragment>

--- a/frontends/election-manager/src/utils/election.test.ts
+++ b/frontends/election-manager/src/utils/election.test.ts
@@ -1,5 +1,5 @@
 import { electionSample } from '@votingworks/fixtures';
-import { CandidateContest, VotesDict } from '@votingworks/types';
+import { CandidateContest } from '@votingworks/types';
 import _ from 'lodash';
 import { getBallotPath, generateOvervoteBallot } from './election';
 
@@ -29,7 +29,7 @@ describe('generateOvervoteBallot', () => {
     });
     expect(overvoteBallot).toBeDefined();
 
-    const votes = overvoteBallot!.votes as VotesDict;
+    const { votes } = overvoteBallot!;
     const presidential = electionSample.contests[0] as CandidateContest;
     expect(votes).toEqual({
       president: [presidential.candidates[0], presidential.candidates[1]],
@@ -48,7 +48,7 @@ describe('generateOvervoteBallot', () => {
     });
     expect(overvoteBallot).toBeDefined();
 
-    const votes = overvoteBallot!.votes as VotesDict;
+    const { votes } = overvoteBallot!;
     expect(votes).toEqual({ 'judicial-robert-demergue': ['yes', 'no'] });
   });
 
@@ -65,14 +65,14 @@ describe('generateOvervoteBallot', () => {
     });
     expect(overvoteBallot).toBeDefined();
 
-    const votes = overvoteBallot!.votes as VotesDict;
+    const { votes } = overvoteBallot!;
     const senatorial = election.contests[1] as CandidateContest;
     expect(votes).toEqual({
       senator: [senatorial.candidates[0], senatorial.candidates[1]],
     });
   });
 
-  test('returns undefined if there are no overvotable contests', () => {
+  test('returns null if there are no overvotable contests', () => {
     const election = _.cloneDeep(electionSample);
 
     // removes all but the first contest
@@ -86,6 +86,6 @@ describe('generateOvervoteBallot', () => {
       election,
       precinctId,
     });
-    expect(overvoteBallot).toBeUndefined();
+    expect(overvoteBallot).toBeNull();
   });
 });

--- a/frontends/election-manager/src/utils/election.test.ts
+++ b/frontends/election-manager/src/utils/election.test.ts
@@ -72,7 +72,7 @@ describe('generateOvervoteBallot', () => {
     });
   });
 
-  test('returns null if there are no overvotable contests', () => {
+  test('returns undefined if there are no overvotable contests', () => {
     const election = _.cloneDeep(electionSample);
 
     // removes all but the first contest
@@ -86,6 +86,6 @@ describe('generateOvervoteBallot', () => {
       election,
       precinctId,
     });
-    expect(overvoteBallot).toBeNull();
+    expect(overvoteBallot).toBeUndefined();
   });
 });

--- a/frontends/election-manager/src/utils/election.ts
+++ b/frontends/election-manager/src/utils/election.ts
@@ -20,8 +20,8 @@ import { LANGUAGES } from '../config/globals';
 import { sortBy } from './sort_by';
 
 export interface Ballot {
-  ballotStyleId: string;
-  precinctId: string;
+  ballotStyleId: BallotStyleId;
+  precinctId: PrecinctId;
   votes: VotesDict;
 }
 

--- a/frontends/election-manager/src/utils/election.ts
+++ b/frontends/election-manager/src/utils/election.ts
@@ -3,7 +3,6 @@ import {
   BallotLocale,
   Candidate,
   CandidateContest,
-  Dictionary,
   Election,
   getContests,
   getPrecinctById,
@@ -19,6 +18,12 @@ import dashify from 'dashify';
 import { LANGUAGES } from '../config/globals';
 
 import { sortBy } from './sort_by';
+
+export interface Ballot {
+  ballotStyleId: string;
+  precinctId: string;
+  votes: VotesDict;
+}
 
 export function getDistrictIdsForPartyId(
   election: Election,
@@ -177,12 +182,12 @@ interface GenerateTestDeckParams {
 export function generateTestDeckBallots({
   election,
   precinctId,
-}: GenerateTestDeckParams): Array<Dictionary<string | VotesDict>> {
+}: GenerateTestDeckParams): Ballot[] {
   const precincts: string[] = precinctId
     ? [precinctId]
     : election.precincts.map((p) => p.id);
 
-  const ballots: Array<Dictionary<string | VotesDict>> = [];
+  const ballots: Ballot[] = [];
 
   for (const currentPrecinctId of precincts) {
     const precinct = find(
@@ -245,8 +250,8 @@ export function generateBlankBallots({
   election: Election;
   precinctId: PrecinctId;
   numBlanks: number;
-}): Array<Dictionary<string | VotesDict>> {
-  const ballots: Array<Dictionary<string | VotesDict>> = [];
+}): Ballot[] {
+  const ballots: Ballot[] = [];
 
   const blankBallotStyle = election.ballotStyles.find((bs) =>
     bs.precincts.includes(precinctId)
@@ -269,23 +274,20 @@ export function generateBlankBallots({
 // overvote is possible. Does not overvote candidate contests where you must select a write-in
 // to overvote. See discussion: https://github.com/votingworks/vxsuite/issues/1711.
 //
-// In cases where it is not possible to overvote a ballot style, returns undefined.
+// In cases where it is not possible to overvote a ballot style, returns null.
 export function generateOvervoteBallot({
   election,
   precinctId,
 }: {
   election: Election;
   precinctId: PrecinctId;
-}): Dictionary<string | VotesDict> | undefined {
+}): Ballot | null {
   const precinctBallotStyles = election.ballotStyles.filter((bs) =>
     bs.precincts.includes(precinctId)
   );
 
-  const ballot: Dictionary<string | VotesDict> = { precinctId };
   const votes: VotesDict = {};
-
   for (const ballotStyle of precinctBallotStyles) {
-    ballot.ballotStyleId = ballotStyle.id;
     const contests = election.contests.filter(
       (c) =>
         ballotStyle.districts.includes(c.districtId) &&
@@ -303,8 +305,11 @@ export function generateOvervoteBallot({
           0,
           candidateContest.seats + 1
         );
-        ballot.votes = votes;
-        return ballot;
+        return {
+          ballotStyleId: ballotStyle.id,
+          precinctId,
+          votes,
+        };
       }
     }
 
@@ -314,8 +319,12 @@ export function generateOvervoteBallot({
       } else if (otherContest.type === 'ms-either-neither') {
         votes[otherContest.eitherNeitherContestId] = ['yes', 'no'];
       }
-      ballot.votes = votes;
-      return ballot;
+      return {
+        ballotStyleId: ballotStyle.id,
+        precinctId,
+        votes,
+      };
     }
   }
+  return null;
 }

--- a/frontends/election-manager/src/utils/election.ts
+++ b/frontends/election-manager/src/utils/election.ts
@@ -274,14 +274,14 @@ export function generateBlankBallots({
 // overvote is possible. Does not overvote candidate contests where you must select a write-in
 // to overvote. See discussion: https://github.com/votingworks/vxsuite/issues/1711.
 //
-// In cases where it is not possible to overvote a ballot style, returns null.
+// In cases where it is not possible to overvote a ballot style, returns undefined.
 export function generateOvervoteBallot({
   election,
   precinctId,
 }: {
   election: Election;
   precinctId: PrecinctId;
-}): Ballot | null {
+}): Ballot | undefined {
   const precinctBallotStyles = election.ballotStyles.filter((bs) =>
     bs.precincts.includes(precinctId)
   );
@@ -326,5 +326,5 @@ export function generateOvervoteBallot({
       };
     }
   }
-  return null;
+  return undefined;
 }


### PR DESCRIPTION
_Commit-by-commit reviewing recommended_

# Overview

Issue link: https://github.com/votingworks/vxsuite/issues/1710

This PR augments the VxAdmin test decks (currently only hand-marked paper ballots) with the VxMark test decks (BMD paper ballots) and updates expected test deck tally reports accordingly (multiplying expected tallies by 2).

Election officials will now be able to print everything they need for L&A from VxAdmin!

We still have a number of additional improvements to make. I've taken note of a few where relevant in GitHub comments.

# Demo video

Demo video for a single precinct. Prints the precinct tally report, BMD test deck, and HMPB test deck (including two blank ballots and one overvoted ballot).

https://user-images.githubusercontent.com/12616928/169854037-e7cadc97-fa00-4b56-898a-906156bfe600.mov

When "All Precincts" is clicked, VxAdmin will print the above for all precincts.

Note that, when using kiosk-browser, users won't see any browser print dialogs. The browser will automatically proceed from print job to print job.

# Testing

- [x] Manually tested single-precinct case
- [x] Manually tested all-precincts case
- [x] Updated tests and snapshots

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced
- [x] I have added JSDoc comments to any newly introduced exports
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates