### PR TITLE
chore(dev-deps): standardize `@types/react` version

### DIFF
--- a/frontends/bas/package.json
+++ b/frontends/bas/package.json
@@ -57,7 +57,7 @@
     "@types/jest": "24.0.11",
     "@types/node": "16.11.29",
     "@types/pluralize": "^0.0.29",
-    "@types/react": "^17.0.0",
+    "@types/react": "17.0.39",
     "@types/react-dom": "^17.0.0",
     "@types/styled-components": "^5.1.7",
     "@votingworks/logging": "workspace:*",

--- a/frontends/bmd/package.json
+++ b/frontends/bmd/package.json
@@ -89,7 +89,7 @@
     "@types/jest": "25.2.2",
     "@types/lodash.camelcase": "^4.3.6",
     "@types/pluralize": "^0.0.29",
-    "@types/react": "^17.0.0",
+    "@types/react": "17.0.39",
     "@types/react-dom": "^17.0.0",
     "@types/react-router-dom": "^5.1.5",
     "@types/styled-components": "^5.1.7",

--- a/frontends/bsd/package.json
+++ b/frontends/bsd/package.json
@@ -68,7 +68,7 @@
     "@types/jest": "24.0.11",
     "@types/node": "16.11.29",
     "@types/pluralize": "^0.0.29",
-    "@types/react": "^17.0.0",
+    "@types/react": "17.0.39",
     "@types/react-dom": "^17.0.0",
     "@types/styled-components": "^5.1.7",
     "@votingworks/api": "workspace:*",

--- a/frontends/election-manager/package.json
+++ b/frontends/election-manager/package.json
@@ -81,7 +81,7 @@
     "@types/jest": "^24.0.0",
     "@types/node": "16.11.29",
     "@types/pluralize": "^0.0.29",
-    "@types/react": "^17.0.0",
+    "@types/react": "17.0.39",
     "@types/react-dom": "^17.0.0",
     "@types/react-router-dom": "^5.1.5",
     "@types/styled-components": "^5.1.7",

--- a/frontends/precinct-scanner/package.json
+++ b/frontends/precinct-scanner/package.json
@@ -78,7 +78,7 @@
     "@types/jest": "^24.0.0",
     "@types/luxon": "^1.26.5",
     "@types/node": "16.11.29",
-    "@types/react": "^17.0.0",
+    "@types/react": "17.0.39",
     "@types/react-dom": "^17.0.0",
     "@types/react-router-dom": "^5.1.5",
     "@types/styled-components": "^5.1.9",

--- a/libs/test-utils/package.json
+++ b/libs/test-utils/package.json
@@ -48,7 +48,7 @@
     "@types/jest": "^27.0.3",
     "@types/kiosk-browser": "workspace:*",
     "@types/luxon": "^1.26.5",
-    "@types/react": "^17.0.4",
+    "@types/react": "17.0.39",
     "@types/zip-stream": "workspace:*",
     "@typescript-eslint/eslint-plugin": "^5.21.0",
     "@typescript-eslint/parser": "^5.21.0",

--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@types/jest": "^27.0.3",
     "@types/node": "16.11.29",
-    "@types/react": "^17.0.4",
+    "@types/react": "17.0.39",
     "@typescript-eslint/eslint-plugin": "^5.21.0",
     "@typescript-eslint/parser": "^5.21.0",
     "eslint": "^7.19.0",

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -73,7 +73,7 @@
     "@types/luxon": "^1.26.5",
     "@types/node": "16.11.29",
     "@types/pluralize": "^0.0.29",
-    "@types/react": "^17.0.4",
+    "@types/react": "17.0.39",
     "@types/styled-components": "^5.1.9",
     "@types/testing-library__jest-dom": "^5.14.3",
     "@typescript-eslint/eslint-plugin": "^5.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,7 +75,7 @@ importers:
       '@types/jest': 24.0.11
       '@types/node': 16.11.29
       '@types/pluralize': 0.0.29
-      '@types/react': 17.0.0
+      '@types/react': 17.0.39
       '@types/react-dom': 17.0.0
       '@types/styled-components': 5.1.7
       '@votingworks/logging': link:../../libs/logging
@@ -130,7 +130,7 @@ importers:
       '@types/luxon': ^1.26.5
       '@types/node': 16.11.29
       '@types/pluralize': ^0.0.29
-      '@types/react': ^17.0.0
+      '@types/react': 17.0.39
       '@types/react-dom': ^17.0.0
       '@types/styled-components': ^5.1.7
       '@types/testing-library__jest-dom': ^5.14.3
@@ -187,7 +187,7 @@ importers:
       '@types/jest': 25.2.2
       '@types/lodash.camelcase': 4.3.6
       '@types/pluralize': 0.0.29
-      '@types/react': 17.0.0
+      '@types/react': 17.0.39
       '@types/react-dom': 17.0.0
       '@types/react-router-dom': 5.1.7
       '@types/styled-components': 5.1.7
@@ -203,7 +203,7 @@ importers:
       dompurify: 2.2.6
       fetch-mock: 9.11.0
       history: 4.10.1
-      http-proxy-middleware: 1.0.6_debug@4.3.2
+      http-proxy-middleware: 1.0.6
       lodash.camelcase: 4.3.0
       luxon: 1.26.0
       mockdate: 3.0.2
@@ -286,7 +286,7 @@ importers:
       '@types/lodash.camelcase': ^4.3.6
       '@types/luxon': ^1.26.2
       '@types/pluralize': ^0.0.29
-      '@types/react': ^17.0.0
+      '@types/react': 17.0.39
       '@types/react-dom': ^17.0.0
       '@types/react-gamepad': ^1.0.0
       '@types/react-router-dom': ^5.1.5
@@ -371,7 +371,7 @@ importers:
       '@types/jest': 24.0.11
       '@types/node': 16.11.29
       '@types/pluralize': 0.0.29
-      '@types/react': 17.0.0
+      '@types/react': 17.0.39
       '@types/react-dom': 17.0.0
       '@types/styled-components': 5.1.7
       '@votingworks/api': link:../../libs/api
@@ -459,7 +459,7 @@ importers:
       '@types/node': 16.11.29
       '@types/pify': ^3.0.2
       '@types/pluralize': ^0.0.29
-      '@types/react': ^17.0.0
+      '@types/react': 17.0.39
       '@types/react-dom': ^17.0.0
       '@types/react-router-dom': ^5.1.5
       '@types/setimmediate': ^1.0.2
@@ -544,7 +544,7 @@ importers:
       '@types/jest': 24.9.1
       '@types/node': 16.11.29
       '@types/pluralize': 0.0.29
-      '@types/react': 17.0.0
+      '@types/react': 17.0.39
       '@types/react-dom': 17.0.0
       '@types/react-router-dom': 5.1.7
       '@types/styled-components': 5.1.7
@@ -565,7 +565,7 @@ importers:
       dompurify: 2.2.6
       fetch-mock: 9.11.0
       history: 4.10.1
-      http-proxy-middleware: 1.0.6_debug@4.3.2
+      http-proxy-middleware: 1.0.6
       i18next: 19.8.4
       js-file-download: 0.4.12
       js-sha256: 0.9.0
@@ -581,8 +581,8 @@ importers:
       react-dom: 17.0.1_react@17.0.1
       react-i18next: 11.8.5_i18next@19.8.4+react@17.0.1
       react-router-dom: 5.2.0_react@17.0.1
-      react-scripts: 4.0.1_canvas@2.9.1+typescript@4.6.3
-      react-textarea-autosize: 8.3.0_@types+react@17.0.0+react@17.0.1
+      react-scripts: 4.0.1_typescript@4.6.3
+      react-textarea-autosize: 8.3.0_e8f6b04531727420b27210e589e7d031
       rxjs: 6.6.6
       styled-components: 5.2.1_react-dom@17.0.1+react@17.0.1
       typescript: 4.6.3
@@ -649,7 +649,7 @@ importers:
       '@types/node': 16.11.29
       '@types/pdfjs-dist': ^2.1.3
       '@types/pluralize': ^0.0.29
-      '@types/react': ^17.0.0
+      '@types/react': 17.0.39
       '@types/react-dom': ^17.0.0
       '@types/react-router-dom': ^5.1.5
       '@types/readable-stream': ^2.3.5
@@ -744,7 +744,7 @@ importers:
       '@types/jest': 24.9.1
       '@types/luxon': 1.26.5
       '@types/node': 16.11.29
-      '@types/react': 17.0.0
+      '@types/react': 17.0.39
       '@types/react-dom': 17.0.0
       '@types/react-router-dom': 5.1.7
       '@types/styled-components': 5.1.9
@@ -759,7 +759,7 @@ importers:
       buffer: 6.0.3
       debug: 4.3.1
       fetch-mock: 9.11.0
-      http-proxy-middleware: 1.0.6_debug@4.3.1
+      http-proxy-middleware: 1.0.6
       i18next: 19.8.4
       jest-fetch-mock: 3.0.3
       js-file-download: 0.4.12
@@ -832,7 +832,7 @@ importers:
       '@types/luxon': ^1.26.5
       '@types/node': 16.11.29
       '@types/pluralize': ^0.0.29
-      '@types/react': ^17.0.0
+      '@types/react': 17.0.39
       '@types/react-dom': ^17.0.0
       '@types/react-router-dom': ^5.1.5
       '@types/setimmediate': ^1.0.2
@@ -1878,7 +1878,7 @@ importers:
       '@types/jest': 27.0.3
       '@types/kiosk-browser': link:../@types/kiosk-browser
       '@types/luxon': 1.27.1
-      '@types/react': 17.0.4
+      '@types/react': 17.0.39
       '@types/zip-stream': link:../@types/zip-stream
       '@typescript-eslint/eslint-plugin': 5.21.0_fbe1c70003501a3a5208745492f4edde
       '@typescript-eslint/parser': 5.21.0_eslint@7.28.0+typescript@4.6.3
@@ -1905,7 +1905,7 @@ importers:
       '@types/kiosk-browser': workspace:*
       '@types/luxon': ^1.26.5
       '@types/node': 16.11.29
-      '@types/react': ^17.0.4
+      '@types/react': 17.0.39
       '@types/zip-stream': workspace:*
       '@typescript-eslint/eslint-plugin': ^5.21.0
       '@typescript-eslint/parser': ^5.21.0
@@ -1941,7 +1941,7 @@ importers:
     devDependencies:
       '@types/jest': 27.0.3
       '@types/node': 16.11.29
-      '@types/react': 17.0.19
+      '@types/react': 17.0.39
       '@typescript-eslint/eslint-plugin': 5.21.0_94a944f85573090af1491a822dcbe40b
       '@typescript-eslint/parser': 5.21.0_eslint@7.19.0+typescript@4.6.3
       eslint: 7.19.0
@@ -1964,7 +1964,7 @@ importers:
       '@antongolub/iso8601': ^1.2.1
       '@types/jest': ^27.0.3
       '@types/node': 16.11.29
-      '@types/react': ^17.0.4
+      '@types/react': 17.0.39
       '@typescript-eslint/eslint-plugin': ^5.21.0
       '@typescript-eslint/parser': ^5.21.0
       eslint: ^7.19.0
@@ -2022,7 +2022,7 @@ importers:
       '@types/luxon': 1.27.1
       '@types/node': 16.11.29
       '@types/pluralize': 0.0.29
-      '@types/react': 17.0.4
+      '@types/react': 17.0.39
       '@types/styled-components': 5.1.9
       '@types/testing-library__jest-dom': 5.14.3
       '@typescript-eslint/eslint-plugin': 5.21.0_862063063b41111bfe9123e9a3f05250
@@ -2075,7 +2075,7 @@ importers:
       '@types/luxon': ^1.26.5
       '@types/node': 16.11.29
       '@types/pluralize': ^0.0.29
-      '@types/react': ^17.0.4
+      '@types/react': 17.0.39
       '@types/react-modal': ^3.13.1
       '@types/react-router-dom': ^5.1.7
       '@types/styled-components': ^5.1.9
@@ -2367,7 +2367,7 @@ importers:
       eslint-plugin-vx: link:../../libs/eslint-plugin-vx
       fast-check: 2.23.2
       is-ci-cli: 2.1.2
-      jest: 26.6.3_canvas@2.9.1
+      jest: 26.6.3
       jest-watch-typeahead: 0.6.4_jest@26.6.3
       lint-staged: 10.5.3
       nock: 13.1.0
@@ -7184,42 +7184,6 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==
-  /@jest/core/26.6.3_canvas@2.9.1:
-    dependencies:
-      '@jest/console': 26.6.2
-      '@jest/reporters': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/transform': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/node': 16.11.6
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.10
-      jest-changed-files: 26.6.2
-      jest-config: 26.6.3_canvas@2.9.1
-      jest-haste-map: 26.6.2
-      jest-message-util: 26.6.2
-      jest-regex-util: 26.0.0
-      jest-resolve: 26.6.2
-      jest-resolve-dependencies: 26.6.3
-      jest-runner: 26.6.3_canvas@2.9.1
-      jest-runtime: 26.6.3_canvas@2.9.1
-      jest-snapshot: 26.6.2
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      jest-watcher: 26.6.2
-      micromatch: 4.0.4
-      p-each-series: 2.2.0
-      rimraf: 3.0.2
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      canvas: '*'
-    resolution:
-      integrity: sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==
   /@jest/core/27.3.1:
     dependencies:
       '@jest/console': 27.3.1
@@ -7280,7 +7244,7 @@ packages:
       jest-regex-util: 27.0.6
       jest-resolve: 27.3.1
       jest-resolve-dependencies: 27.3.1
-      jest-runner: 27.3.1_canvas@2.9.1
+      jest-runner: 27.3.1
       jest-runtime: 27.3.1
       jest-snapshot: 27.3.1
       jest-util: 27.3.1
@@ -7401,7 +7365,7 @@ packages:
       jest-regex-util: 27.5.1
       jest-resolve: 27.5.1
       jest-resolve-dependencies: 27.5.1
-      jest-runner: 27.5.1_canvas@2.9.1
+      jest-runner: 27.5.1
       jest-runtime: 27.5.1
       jest-snapshot: 27.5.1
       jest-util: 27.5.1
@@ -7836,19 +7800,6 @@ packages:
       jest-runtime: 26.6.3
     engines:
       node: '>= 10.14.2'
-    resolution:
-      integrity: sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==
-  /@jest/test-sequencer/26.6.3_canvas@2.9.1:
-    dependencies:
-      '@jest/test-result': 26.6.2
-      graceful-fs: 4.2.10
-      jest-haste-map: 26.6.2
-      jest-runner: 26.6.3_canvas@2.9.1
-      jest-runtime: 26.6.3_canvas@2.9.1
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      canvas: '*'
     resolution:
       integrity: sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==
   /@jest/test-sequencer/27.3.1:
@@ -9307,14 +9258,6 @@ packages:
       csstype: 3.0.8
     resolution:
       integrity: sha512-D/G3PiuqTfE3IMNjLn/DCp6umjVCSvtZTPdtAFy5+Ved6CsdRvivfKeCzw79W4AatShtU4nGqgvOv5Gro534vQ==
-  /@types/react/17.0.19:
-    dependencies:
-      '@types/prop-types': 15.7.4
-      '@types/scheduler': 0.16.2
-      csstype: 3.0.8
-    dev: true
-    resolution:
-      integrity: sha512-sX1HisdB1/ZESixMTGnMxH9TDe8Sk709734fEQZzCV/4lSu9kJCPbo2PbTRoZM+53Pp0P10hYVyReUueGwUi4A==
   /@types/react/17.0.20:
     dependencies:
       '@types/prop-types': 15.7.4
@@ -9330,6 +9273,13 @@ packages:
       csstype: 3.0.10
     resolution:
       integrity: sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==
+  /@types/react/17.0.39:
+    dependencies:
+      '@types/prop-types': 15.7.4
+      '@types/scheduler': 0.16.2
+      csstype: 3.0.11
+    resolution:
+      integrity: sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==
   /@types/react/17.0.4:
     dependencies:
       '@types/prop-types': 15.7.3
@@ -12134,7 +12084,7 @@ packages:
       integrity: sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA==
   /axios/0.21.1_debug@4.3.1:
     dependencies:
-      follow-redirects: 1.14.1_debug@4.3.1
+      follow-redirects: 1.14.1_debug@4.3.2
     dev: true
     peerDependencies:
       debug: '*'
@@ -17873,7 +17823,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 5.21.0_4059d5ee7aba256d5e330151ee3418c0
       '@typescript-eslint/utils': 5.22.0_eslint@7.17.0+typescript@4.6.3
       eslint: 7.17.0
-      jest: 26.6.3_canvas@2.9.1
+      jest: 26.6.3
     dev: true
     engines:
       node: ^12.22.0 || ^14.17.0 || >=16.0.0
@@ -19926,6 +19876,7 @@ packages:
   /follow-redirects/1.14.1_debug@4.3.1:
     dependencies:
       debug: 4.3.1
+    dev: false
     engines:
       node: '>=4.0'
     peerDependencies:
@@ -19937,8 +19888,7 @@ packages:
       integrity: sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
   /follow-redirects/1.14.1_debug@4.3.2:
     dependencies:
-      debug: 4.3.2
-    dev: false
+      debug: 4.3.2_supports-color@6.1.0
     engines:
       node: '>=4.0'
     peerDependencies:
@@ -20914,34 +20864,6 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
-  /http-proxy-middleware/1.0.6_debug@4.3.1:
-    dependencies:
-      '@types/http-proxy': 1.17.6
-      http-proxy: 1.18.1_debug@4.3.1
-      is-glob: 4.0.1
-      lodash: 4.17.21
-      micromatch: 4.0.4
-    dev: false
-    engines:
-      node: '>=8.0.0'
-    peerDependencies:
-      debug: '*'
-    resolution:
-      integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
-  /http-proxy-middleware/1.0.6_debug@4.3.2:
-    dependencies:
-      '@types/http-proxy': 1.17.6
-      http-proxy: 1.18.1_debug@4.3.2
-      is-glob: 4.0.1
-      lodash: 4.17.21
-      micromatch: 4.0.4
-    dev: false
-    engines:
-      node: '>=8.0.0'
-    peerDependencies:
-      debug: '*'
-    resolution:
-      integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
   /http-proxy/1.18.1:
     dependencies:
       eventemitter3: 4.0.7
@@ -20950,18 +20872,6 @@ packages:
     dev: false
     engines:
       node: '>=8.0.0'
-    resolution:
-      integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
-  /http-proxy/1.18.1_debug@4.3.1:
-    dependencies:
-      eventemitter3: 4.0.7
-      follow-redirects: 1.14.1_debug@4.3.1
-      requires-port: 1.0.0
-    dev: false
-    engines:
-      node: '>=8.0.0'
-    peerDependencies:
-      debug: '*'
     resolution:
       integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
   /http-proxy/1.18.1_debug@4.3.2:
@@ -22009,37 +21919,6 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-L2/Y9szN6FJPWFK8kzWXwfp+FOR7xq0cUL4lIsdbIdwz3Vh6P1nrpcqOleSzr28zOtSHQNV9Z7Tl+KkuK7t5Ng==
-  /jest-circus/26.6.0_canvas@2.9.1:
-    dependencies:
-      '@babel/traverse': 7.15.4
-      '@jest/environment': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/babel__traverse': 7.14.2
-      '@types/node': 16.0.0
-      chalk: 4.1.2
-      co: 4.6.0
-      dedent: 0.7.0
-      expect: 26.6.2
-      is-generator-fn: 2.1.0
-      jest-each: 26.6.2
-      jest-matcher-utils: 26.6.2
-      jest-message-util: 26.6.2
-      jest-runner: 26.6.3_canvas@2.9.1
-      jest-runtime: 26.6.3_canvas@2.9.1
-      jest-snapshot: 26.6.2
-      jest-util: 26.6.2
-      prettier: 2.3.2
-      pretty-format: 26.6.2
-      stack-utils: 2.0.5
-      throat: 5.0.0
-    dev: false
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      canvas: '*'
-    resolution:
-      integrity: sha512-L2/Y9szN6FJPWFK8kzWXwfp+FOR7xq0cUL4lIsdbIdwz3Vh6P1nrpcqOleSzr28zOtSHQNV9Z7Tl+KkuK7t5Ng==
   /jest-circus/27.3.1:
     dependencies:
       '@jest/environment': 27.3.1
@@ -22139,28 +22018,6 @@ packages:
     engines:
       node: '>= 10.14.2'
     hasBin: true
-    resolution:
-      integrity: sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
-  /jest-cli/26.6.3_canvas@2.9.1:
-    dependencies:
-      '@jest/core': 26.6.3_canvas@2.9.1
-      '@jest/test-result': 26.6.2
-      '@jest/types': 26.6.2
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.10
-      import-local: 3.0.3
-      is-ci: 2.0.0
-      jest-config: 26.6.3_canvas@2.9.1
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      prompts: 2.4.2
-      yargs: 15.4.1
-    engines:
-      node: '>= 10.14.2'
-    hasBin: true
-    peerDependencies:
-      canvas: '*'
     resolution:
       integrity: sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
   /jest-cli/27.3.1:
@@ -22319,36 +22176,6 @@ packages:
         optional: true
     resolution:
       integrity: sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==
-  /jest-config/26.6.3_canvas@2.9.1:
-    dependencies:
-      '@babel/core': 7.16.0
-      '@jest/test-sequencer': 26.6.3_canvas@2.9.1
-      '@jest/types': 26.6.2
-      babel-jest: 26.6.3_@babel+core@7.16.0
-      chalk: 4.1.2
-      deepmerge: 4.2.2
-      glob: 7.2.0
-      graceful-fs: 4.2.10
-      jest-environment-jsdom: 26.6.2_canvas@2.9.1
-      jest-environment-node: 26.6.2
-      jest-get-type: 26.3.0
-      jest-jasmine2: 26.6.3_canvas@2.9.1
-      jest-regex-util: 26.0.0
-      jest-resolve: 26.6.2
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      micromatch: 4.0.4
-      pretty-format: 26.6.2
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      canvas: '*'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      ts-node:
-        optional: true
-    resolution:
-      integrity: sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==
   /jest-config/27.3.1:
     dependencies:
       '@babel/core': 7.16.0
@@ -22400,7 +22227,7 @@ packages:
       jest-jasmine2: 27.3.1
       jest-regex-util: 27.0.6
       jest-resolve: 27.3.1
-      jest-runner: 27.3.1_canvas@2.9.1
+      jest-runner: 27.3.1
       jest-util: 27.3.1
       jest-validate: 27.3.1
       micromatch: 4.0.4
@@ -22504,7 +22331,7 @@ packages:
       jest-jasmine2: 27.5.1
       jest-regex-util: 27.5.1
       jest-resolve: 27.5.1
-      jest-runner: 27.5.1_canvas@2.9.1
+      jest-runner: 27.5.1
       jest-util: 27.5.1
       jest-validate: 27.5.1
       micromatch: 4.0.5
@@ -22716,21 +22543,6 @@ packages:
       jsdom: 16.7.0
     engines:
       node: '>= 10.14.2'
-    resolution:
-      integrity: sha512-jgPqCruTlt3Kwqg5/WVFyHIOJHsiAvhcp2qiR2QQstuG9yWox5+iHpU3ZrcBxW14T4fe5Z68jAfLRh7joCSP2Q==
-  /jest-environment-jsdom/26.6.2_canvas@2.9.1:
-    dependencies:
-      '@jest/environment': 26.6.2
-      '@jest/fake-timers': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/node': 16.11.6
-      jest-mock: 26.6.2
-      jest-util: 26.6.2
-      jsdom: 16.7.0_canvas@2.9.1
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      canvas: '*'
     resolution:
       integrity: sha512-jgPqCruTlt3Kwqg5/WVFyHIOJHsiAvhcp2qiR2QQstuG9yWox5+iHpU3ZrcBxW14T4fe5Z68jAfLRh7joCSP2Q==
   /jest-environment-jsdom/27.3.1:
@@ -23024,32 +22836,6 @@ packages:
       throat: 5.0.0
     engines:
       node: '>= 10.14.2'
-    resolution:
-      integrity: sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==
-  /jest-jasmine2/26.6.3_canvas@2.9.1:
-    dependencies:
-      '@babel/traverse': 7.16.3
-      '@jest/environment': 26.6.2
-      '@jest/source-map': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/node': 16.11.6
-      chalk: 4.1.2
-      co: 4.6.0
-      expect: 26.6.2
-      is-generator-fn: 2.1.0
-      jest-each: 26.6.2
-      jest-matcher-utils: 26.6.2
-      jest-message-util: 26.6.2
-      jest-runtime: 26.6.3_canvas@2.9.1
-      jest-snapshot: 26.6.2
-      jest-util: 26.6.2
-      pretty-format: 26.6.2
-      throat: 5.0.0
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      canvas: '*'
     resolution:
       integrity: sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==
   /jest-jasmine2/27.3.1:
@@ -23588,34 +23374,6 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==
-  /jest-runner/26.6.3_canvas@2.9.1:
-    dependencies:
-      '@jest/console': 26.6.2
-      '@jest/environment': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/node': 16.11.6
-      chalk: 4.1.2
-      emittery: 0.7.2
-      exit: 0.1.2
-      graceful-fs: 4.2.10
-      jest-config: 26.6.3_canvas@2.9.1
-      jest-docblock: 26.0.0
-      jest-haste-map: 26.6.2
-      jest-leak-detector: 26.6.2
-      jest-message-util: 26.6.2
-      jest-resolve: 26.6.2
-      jest-runtime: 26.6.3_canvas@2.9.1
-      jest-util: 26.6.2
-      jest-worker: 26.6.2
-      source-map-support: 0.5.20
-      throat: 5.0.0
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      canvas: '*'
-    resolution:
-      integrity: sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==
   /jest-runner/27.3.1:
     dependencies:
       '@jest/console': 27.3.1
@@ -23643,37 +23401,6 @@ packages:
     dev: true
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
-    resolution:
-      integrity: sha512-r4W6kBn6sPr3TBwQNmqE94mPlYVn7fLBseeJfo4E2uCTmAyDFm2O5DYAQAFP7Q3YfiA/bMwg8TVsciP7k0xOww==
-  /jest-runner/27.3.1_canvas@2.9.1:
-    dependencies:
-      '@jest/console': 27.3.1
-      '@jest/environment': 27.3.1
-      '@jest/test-result': 27.3.1
-      '@jest/transform': 27.3.1
-      '@jest/types': 27.2.5
-      '@types/node': 15.3.0
-      chalk: 4.1.2
-      emittery: 0.8.1
-      exit: 0.1.2
-      graceful-fs: 4.2.10
-      jest-docblock: 27.0.6
-      jest-environment-jsdom: 27.3.1_canvas@2.9.1
-      jest-environment-node: 27.3.1
-      jest-haste-map: 27.3.1
-      jest-leak-detector: 27.3.1
-      jest-message-util: 27.3.1
-      jest-resolve: 27.3.1
-      jest-runtime: 27.3.1
-      jest-util: 27.3.1
-      jest-worker: 27.3.1
-      source-map-support: 0.5.20
-      throat: 6.0.1
-    dev: true
-    engines:
-      node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
-    peerDependencies:
-      canvas: '*'
     resolution:
       integrity: sha512-r4W6kBn6sPr3TBwQNmqE94mPlYVn7fLBseeJfo4E2uCTmAyDFm2O5DYAQAFP7Q3YfiA/bMwg8TVsciP7k0xOww==
   /jest-runner/27.4.5:
@@ -23733,36 +23460,6 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-g4NPsM4mFCOwFKXO4p/H/kWGdJp9V8kURY2lX8Me2drgXqG7rrZAx5kv+5H7wtt/cdFIjhqYx1HrlqWHaOvDaQ==
-  /jest-runner/27.5.1_canvas@2.9.1:
-    dependencies:
-      '@jest/console': 27.5.1
-      '@jest/environment': 27.5.1
-      '@jest/test-result': 27.5.1
-      '@jest/transform': 27.5.1
-      '@jest/types': 27.5.1
-      '@types/node': 16.11.29
-      chalk: 4.1.2
-      emittery: 0.8.1
-      graceful-fs: 4.2.10
-      jest-docblock: 27.5.1
-      jest-environment-jsdom: 27.5.1_canvas@2.9.1
-      jest-environment-node: 27.5.1
-      jest-haste-map: 27.5.1
-      jest-leak-detector: 27.5.1
-      jest-message-util: 27.5.1
-      jest-resolve: 27.5.1
-      jest-runtime: 27.5.1
-      jest-util: 27.5.1
-      jest-worker: 27.5.1
-      source-map-support: 0.5.21
-      throat: 6.0.1
-    dev: true
-    engines:
-      node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
-    peerDependencies:
-      canvas: '*'
-    resolution:
-      integrity: sha512-g4NPsM4mFCOwFKXO4p/H/kWGdJp9V8kURY2lX8Me2drgXqG7rrZAx5kv+5H7wtt/cdFIjhqYx1HrlqWHaOvDaQ==
   /jest-runtime/26.6.3:
     dependencies:
       '@jest/console': 26.6.2
@@ -23795,42 +23492,6 @@ packages:
     engines:
       node: '>= 10.14.2'
     hasBin: true
-    resolution:
-      integrity: sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==
-  /jest-runtime/26.6.3_canvas@2.9.1:
-    dependencies:
-      '@jest/console': 26.6.2
-      '@jest/environment': 26.6.2
-      '@jest/fake-timers': 26.6.2
-      '@jest/globals': 26.6.2
-      '@jest/source-map': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/transform': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/yargs': 15.0.14
-      chalk: 4.1.2
-      cjs-module-lexer: 0.6.0
-      collect-v8-coverage: 1.0.1
-      exit: 0.1.2
-      glob: 7.2.0
-      graceful-fs: 4.2.10
-      jest-config: 26.6.3_canvas@2.9.1
-      jest-haste-map: 26.6.2
-      jest-message-util: 26.6.2
-      jest-mock: 26.6.2
-      jest-regex-util: 26.0.0
-      jest-resolve: 26.6.2
-      jest-snapshot: 26.6.2
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      slash: 3.0.0
-      strip-bom: 4.0.0
-      yargs: 15.4.1
-    engines:
-      node: '>= 10.14.2'
-    hasBin: true
-    peerDependencies:
-      canvas: '*'
     resolution:
       integrity: sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==
   /jest-runtime/27.3.1:
@@ -24261,7 +23922,7 @@ packages:
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.1
-      jest: 26.6.3_canvas@2.9.1
+      jest: 26.6.3
       jest-regex-util: 27.0.1
       jest-watcher: 27.0.2
       slash: 3.0.0
@@ -24487,19 +24148,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-jxTmrvuecVISvKFFhOkjsWRZV7sFqdSUAd1ajOKY+/QE/aLBVstsJ/dX8GczLzwiT6ZEwwmZqtCUHLHHQVzcfA==
-  /jest/26.6.0_canvas@2.9.1:
-    dependencies:
-      '@jest/core': 26.6.3_canvas@2.9.1
-      import-local: 3.0.3
-      jest-cli: 26.6.3_canvas@2.9.1
-    dev: false
-    engines:
-      node: '>= 10.14.2'
-    hasBin: true
-    peerDependencies:
-      canvas: '*'
-    resolution:
-      integrity: sha512-jxTmrvuecVISvKFFhOkjsWRZV7sFqdSUAd1ajOKY+/QE/aLBVstsJ/dX8GczLzwiT6ZEwwmZqtCUHLHHQVzcfA==
   /jest/26.6.3:
     dependencies:
       '@jest/core': 26.6.3
@@ -24509,19 +24157,6 @@ packages:
     engines:
       node: '>= 10.14.2'
     hasBin: true
-    resolution:
-      integrity: sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
-  /jest/26.6.3_canvas@2.9.1:
-    dependencies:
-      '@jest/core': 26.6.3_canvas@2.9.1
-      import-local: 3.0.3
-      jest-cli: 26.6.3_canvas@2.9.1
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    hasBin: true
-    peerDependencies:
-      canvas: '*'
     resolution:
       integrity: sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
   /jest/27.3.1:
@@ -24712,6 +24347,7 @@ packages:
       whatwg-url: 8.7.0
       ws: 7.5.7
       xml-name-validator: 3.0.0
+    dev: true
     engines:
       node: '>=10'
     peerDependencies:
@@ -28734,81 +28370,6 @@ packages:
         optional: true
     resolution:
       integrity: sha512-NnniMSC/wjwhcJAyPJCWtxx6CWONqgvGgV9+QXj1bwoW/JI++YF1eEf3Upf/mQ9KmP57IBdjzWs1XvnPq7qMTQ==
-  /react-scripts/4.0.1_canvas@2.9.1+typescript@4.6.3:
-    dependencies:
-      '@babel/core': 7.12.3
-      '@pmmmwh/react-refresh-webpack-plugin': 0.4.2_d00fcc46a48175a4e289da7534b00e9a
-      '@svgr/webpack': 5.4.0
-      '@typescript-eslint/eslint-plugin': 4.30.0_eeb95bb71ac15dd9a2b8f14f691524f8
-      '@typescript-eslint/parser': 4.29.3_eslint@7.29.0+typescript@4.6.3
-      babel-eslint: 10.1.0_eslint@7.29.0
-      babel-jest: 26.6.3_@babel+core@7.12.3
-      babel-loader: 8.1.0_427212bc1158d185e577033f19ca0757
-      babel-plugin-named-asset-import: 0.3.7_@babel+core@7.12.3
-      babel-preset-react-app: 10.0.0
-      bfj: 7.0.2
-      camelcase: 6.2.0
-      case-sensitive-paths-webpack-plugin: 2.3.0
-      css-loader: 4.3.0_webpack@4.44.2
-      dotenv: 8.2.0
-      dotenv-expand: 5.1.0
-      eslint: 7.29.0
-      eslint-config-react-app: 6.0.0_d4ef662949d0d072f3e3ae2e54a11fae
-      eslint-plugin-flowtype: 5.2.0_eslint@7.29.0
-      eslint-plugin-import: 2.24.2_eslint@7.29.0+typescript@4.6.3
-      eslint-plugin-jest: 24.1.3_eslint@7.29.0+typescript@4.6.3
-      eslint-plugin-jsx-a11y: 6.4.1_eslint@7.29.0
-      eslint-plugin-react: 7.24.0_eslint@7.29.0
-      eslint-plugin-react-hooks: 4.2.0_eslint@7.29.0
-      eslint-plugin-testing-library: 3.10.1_eslint@7.29.0+typescript@4.6.3
-      eslint-webpack-plugin: 2.4.1_eslint@7.29.0+webpack@4.44.2
-      file-loader: 6.1.1_webpack@4.44.2
-      fs-extra: 9.1.0
-      html-webpack-plugin: 4.5.0_webpack@4.44.2
-      identity-obj-proxy: 3.0.0
-      jest: 26.6.0_canvas@2.9.1
-      jest-circus: 26.6.0_canvas@2.9.1
-      jest-resolve: 26.6.0
-      jest-watch-typeahead: 0.6.1_jest@26.6.0
-      mini-css-extract-plugin: 0.11.3_webpack@4.44.2
-      optimize-css-assets-webpack-plugin: 5.0.4_webpack@4.44.2
-      pnp-webpack-plugin: 1.6.4_typescript@4.6.3
-      postcss-flexbugs-fixes: 4.2.1
-      postcss-loader: 3.0.0
-      postcss-normalize: 8.0.1
-      postcss-preset-env: 6.7.0
-      postcss-safe-parser: 5.0.2
-      prompts: 2.4.0
-      react-app-polyfill: 2.0.0
-      react-dev-utils: 11.0.3
-      react-refresh: 0.8.3
-      resolve: 1.18.1
-      resolve-url-loader: 3.1.2
-      sass-loader: 8.0.2_webpack@4.44.2
-      semver: 7.3.2
-      style-loader: 1.3.0_webpack@4.44.2
-      terser-webpack-plugin: 4.2.3_webpack@4.44.2
-      ts-pnp: 1.2.0_typescript@4.6.3
-      typescript: 4.6.3
-      url-loader: 4.1.1_file-loader@6.1.1+webpack@4.44.2
-      webpack: 4.44.2
-      webpack-dev-server: 3.11.0_webpack@4.44.2
-      webpack-manifest-plugin: 2.2.0_webpack@4.44.2
-      workbox-webpack-plugin: 5.1.4_webpack@4.44.2
-    dev: false
-    engines:
-      node: ^10.12.0 || >=12.0.0
-    hasBin: true
-    optionalDependencies:
-      fsevents: 2.3.2
-    peerDependencies:
-      canvas: '*'
-      typescript: ^3.2.1
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    resolution:
-      integrity: sha512-NnniMSC/wjwhcJAyPJCWtxx6CWONqgvGgV9+QXj1bwoW/JI++YF1eEf3Upf/mQ9KmP57IBdjzWs1XvnPq7qMTQ==
   /react-scripts/4.0.1_typescript@4.6.3:
     dependencies:
       '@babel/core': 7.12.3
@@ -28895,12 +28456,12 @@ packages:
       react: ^16.14.0
     resolution:
       integrity: sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==
-  /react-textarea-autosize/8.3.0_@types+react@17.0.0+react@17.0.1:
+  /react-textarea-autosize/8.3.0_e8f6b04531727420b27210e589e7d031:
     dependencies:
       '@babel/runtime': 7.12.5
       react: 17.0.1
       use-composed-ref: 1.1.0_react@17.0.1
-      use-latest: 1.2.0_@types+react@17.0.0+react@17.0.1
+      use-latest: 1.2.0_e8f6b04531727420b27210e589e7d031
     dev: false
     engines:
       node: '>=10'
@@ -31461,7 +31022,7 @@ packages:
       bs-logger: 0.2.6
       buffer-from: 1.1.1
       fast-json-stable-stringify: 2.1.0
-      jest: 26.6.3_canvas@2.9.1
+      jest: 26.6.3
       jest-util: 26.6.2
       json5: 2.1.3
       lodash.memoize: 4.1.2
@@ -32272,9 +31833,9 @@ packages:
       react: '>=16.8.0 || ^17'
     resolution:
       integrity: sha512-1betIJun2rXKLxa30AFOBZCeZhsBJoJ/3+gkCeYbJ63lAR//EnAb1NjNeFqzgqeM7zQfR76rrCUaA8DvfgoOpA==
-  /use-isomorphic-layout-effect/1.1.1_@types+react@17.0.0+react@17.0.1:
+  /use-isomorphic-layout-effect/1.1.1_e8f6b04531727420b27210e589e7d031:
     dependencies:
-      '@types/react': 17.0.0
+      '@types/react': 17.0.39
       react: 17.0.1
     dev: false
     peerDependencies:
@@ -32285,11 +31846,11 @@ packages:
         optional: true
     resolution:
       integrity: sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==
-  /use-latest/1.2.0_@types+react@17.0.0+react@17.0.1:
+  /use-latest/1.2.0_e8f6b04531727420b27210e589e7d031:
     dependencies:
-      '@types/react': 17.0.0
+      '@types/react': 17.0.39
       react: 17.0.1
-      use-isomorphic-layout-effect: 1.1.1_@types+react@17.0.0+react@17.0.1
+      use-isomorphic-layout-effect: 1.1.1_e8f6b04531727420b27210e589e7d031
     dev: false
     peerDependencies:
       '@types/react': '*'


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Refs #1314

Switching to a buildless system will mean that TypeScript will see deeper into monorepo dependencies like `/ui` and their `@types/react` dependencies. This means we want the versions to match to avoid incompatibilities when e.g. type checking `bmd` or another frontend.

## Demo Video or Screenshot
n/a

## Testing Plan 
n/a

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
