### PR TITLE
Fix occasional test deck misordering

### DIFF
--- a/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
+++ b/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
@@ -2931,7 +2931,26 @@ exports[`L&A (logic and accuracy) flow 3`] = `
       .
     </div>
   </div>
-  <div />
+  <div>
+    <div
+      id="ballot-0"
+    />
+    <div
+      id="ballot-1"
+    />
+    <div
+      id="ballot-2"
+    />
+    <div
+      id="ballot-3"
+    />
+    <div
+      id="ballot-4"
+    />
+    <div
+      id="ballot-5"
+    />
+  </div>
 </div>
 `;
 

--- a/frontends/election-manager/src/components/hand_marked_paper_ballot.tsx
+++ b/frontends/election-manager/src/components/hand_marked_paper_ballot.tsx
@@ -532,6 +532,7 @@ export interface HandMarkedPaperBallotProps {
   ballotId?: BallotId;
   votes?: VotesDict;
   onRendered?(props: Omit<HandMarkedPaperBallotProps, 'onRendered'>): void;
+  targetElementId?: string;
 }
 
 export function HandMarkedPaperBallot({
@@ -546,6 +547,7 @@ export function HandMarkedPaperBallot({
   ballotId,
   votes,
   onRendered,
+  targetElementId,
 }: HandMarkedPaperBallotProps): JSX.Element {
   const layoutDensity = getBallotLayoutDensity(election);
   assert(
@@ -607,7 +609,13 @@ export function HandMarkedPaperBallot({
   const ballotRef = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
-    if (!printBallotRef?.current) {
+    // Render the Paged.js-processed ballot to either the specified target element or to the
+    // element referenced by printBallotRef (default)
+    const targetElement = targetElementId
+      ? document.getElementById(targetElementId)
+      : printBallotRef?.current;
+
+    if (!targetElement) {
       return;
     }
 
@@ -623,7 +631,7 @@ export function HandMarkedPaperBallot({
       await new Previewer().preview(
         ballotRef.current.innerHTML,
         ballotStylesheets,
-        printBallotRef?.current
+        targetElement
       );
       onRendered?.({
         ballotStyleId,
@@ -639,9 +647,8 @@ export function HandMarkedPaperBallot({
     })();
 
     return () => {
-      if (printBallotRef.current) {
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        printBallotRef.current.innerHTML = '';
+      if (targetElement) {
+        targetElement.innerHTML = '';
       }
       document.head
         .querySelectorAll('[data-pagedjs-inserted-styles]')
@@ -659,6 +666,7 @@ export function HandMarkedPaperBallot({
     printBallotRef,
     locales,
     votes,
+    targetElementId,
   ]);
 
   const dualLanguageWithSlash = dualLanguageComposer(t, locales);

--- a/frontends/election-manager/src/screens/print_test_deck_screen.test.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.test.tsx
@@ -23,7 +23,11 @@ test('Printing all L&A packages sorts precincts', async () => {
     fakePrinterInfo({ name: 'VxPrinter', connected: true }),
   ]);
 
-  renderInAppContext(<PrintTestDeckScreen />);
+  renderInAppContext(<PrintTestDeckScreen />, {
+    printBallotRef: {
+      current: document.createElement('div'),
+    },
+  });
 
   userEvent.click(screen.getByText('All Precincts'));
 

--- a/frontends/election-manager/src/screens/print_test_deck_screen.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.tsx
@@ -109,6 +109,28 @@ function BmdPaperBallots({
   );
 }
 
+function generateHandMarkedPaperBallots({
+  election,
+  precinctId,
+}: {
+  election: Election;
+  precinctId: PrecinctId;
+}) {
+  const ballots = [
+    ...generateTestDeckBallots({ election, precinctId }),
+    ...generateBlankBallots({ election, precinctId, numBlanks: 2 }),
+  ];
+  const overvoteBallot = generateOvervoteBallot({ election, precinctId });
+  if (overvoteBallot) {
+    ballots.push(overvoteBallot);
+  }
+  return ballots;
+}
+
+function generateHmpbTargetElementId(ballotIndex: number) {
+  return `ballot-${ballotIndex}`;
+}
+
 interface HandMarkedPaperBallotsProps {
   election: Election;
   electionHash: string;
@@ -122,14 +144,7 @@ function HandMarkedPaperBallots({
   precinctId,
   onAllRendered,
 }: HandMarkedPaperBallotsProps): JSX.Element {
-  const ballots = [
-    ...generateTestDeckBallots({ election, precinctId }),
-    ...generateBlankBallots({ election, precinctId, numBlanks: 2 }),
-  ];
-  const overvoteBallot = generateOvervoteBallot({ election, precinctId });
-  if (overvoteBallot) {
-    ballots.push(overvoteBallot);
-  }
+  const ballots = generateHandMarkedPaperBallots({ election, precinctId });
 
   let numRendered = 0;
   function onRendered() {
@@ -153,10 +168,59 @@ function HandMarkedPaperBallots({
           locales={{ primary: 'en-US' }}
           votes={ballot.votes}
           onRendered={() => onRendered()}
+          targetElementId={generateHmpbTargetElementId(i)}
         />
       ))}
     </div>
   );
+}
+
+/**
+ * Hand-marked paper ballots are post-processed by Paged.js on a per-ballot basis and rendered to a
+ * target element. useCreateHmpbTargetElements creates a set of target elements, one for every
+ * hand-marked paper ballot. In the past, we rendered all test deck hand-marked paper ballots to
+ * the same target element, but this occasionally resulted in a misordered test deck.
+ */
+function useCreateHmpbTargetElements({
+  containerRef,
+  election,
+  precinctId,
+  printingHandMarkedPaperBallots,
+}: {
+  containerRef?: React.RefObject<HTMLElement>;
+  election: Election;
+  precinctId: PrecinctId;
+  printingHandMarkedPaperBallots: boolean;
+}) {
+  const [hmpbTargetElementsCreated, setHmpbTargetElementsCreated] =
+    useState(false);
+
+  useEffect(() => {
+    const container = containerRef?.current;
+
+    if (container && printingHandMarkedPaperBallots) {
+      const numBallots = generateHandMarkedPaperBallots({
+        election,
+        precinctId,
+      }).length;
+      for (let i = 0; i < numBallots; i += 1) {
+        const hmpbTargetElement = document.createElement('div');
+        hmpbTargetElement.id = generateHmpbTargetElementId(i);
+        container.appendChild(hmpbTargetElement);
+      }
+      setHmpbTargetElementsCreated(true);
+    }
+
+    // Cleanup action: Clear the created elements
+    return () => {
+      if (container) {
+        container.innerHTML = '';
+        setHmpbTargetElementsCreated(false);
+      }
+    };
+  }, [containerRef, election, precinctId, printingHandMarkedPaperBallots]);
+
+  return { hmpbTargetElementsCreated };
 }
 
 // FIXME: We're using `React.memo` to prevent re-rendering `TestDeckBallots`,
@@ -180,8 +244,13 @@ interface PrintIndex {
 
 export function PrintTestDeckScreen(): JSX.Element {
   const makeCancelable = useCancelablePromise();
-  const { electionDefinition, printer, currentUserSession, logger } =
-    useContext(AppContext);
+  const {
+    electionDefinition,
+    printer,
+    currentUserSession,
+    logger,
+    printBallotRef,
+  } = useContext(AppContext);
   assert(electionDefinition);
   assert(currentUserSession); // TODO(auth)
   const currentUserType = currentUserSession.type;
@@ -313,6 +382,14 @@ export function PrintTestDeckScreen(): JSX.Element {
       })
     : undefined;
 
+  const { hmpbTargetElementsCreated } = useCreateHmpbTargetElements({
+    containerRef: printBallotRef,
+    election,
+    precinctId: currentPrecinctId,
+    printingHandMarkedPaperBallots:
+      printIndex?.component === 'HandMarkedPaperBallots',
+  });
+
   return (
     <React.Fragment>
       {printIndex && currentPrecinct && (
@@ -369,14 +446,15 @@ export function PrintTestDeckScreen(): JSX.Element {
           precinctId={precinctIds[printIndex.precinctIndex]}
         />
       )}
-      {printIndex?.component === 'HandMarkedPaperBallots' && (
-        <HandMarkedPaperBallotsMemoized
-          election={election}
-          electionHash={electionHash}
-          precinctId={currentPrecinctId}
-          onAllRendered={onAllHandMarkedPaperBallotsRendered}
-        />
-      )}
+      {printIndex?.component === 'HandMarkedPaperBallots' &&
+        hmpbTargetElementsCreated && (
+          <HandMarkedPaperBallotsMemoized
+            election={election}
+            electionHash={electionHash}
+            precinctId={currentPrecinctId}
+            onAllRendered={onAllHandMarkedPaperBallotsRendered}
+          />
+        )}
     </React.Fragment>
   );
 }

--- a/frontends/election-manager/src/screens/print_test_deck_screen.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.tsx
@@ -180,6 +180,10 @@ function HandMarkedPaperBallots({
  * target element. useCreateHmpbTargetElements creates a set of target elements, one for every
  * hand-marked paper ballot. In the past, we rendered all test deck hand-marked paper ballots to
  * the same target element, but this occasionally resulted in a misordered test deck.
+ *
+ * We render the target elements separate from HandMarkedPaperBallot and in this unconventional way
+ * because we need each target element to 1) exist before the corresponding HandMarkedPaperBallot
+ * is rendered and 2) be unaffected by HandMarkedPaperBallot's React lifecycle.
  */
 function useCreateHmpbTargetElements({
   containerRef,


### PR DESCRIPTION
# Overview

Issue link: https://github.com/votingworks/vxsuite/issues/1868

This was a super interesting one. Drew and I were occasionally seeing misordered test decks get generated on our laptops, e.g. ballot styles were interleaved, the first HMPB in the test deck had bubbles other than the first in each contest filled in, etc.

After some investigation, we pinpointed this to an issue with our Paged.js-processing of HMPBs. While the ballots are [originally rendered in the correct order](https://github.com/votingworks/vxsuite/blob/3e1689bdb1db2e7bf9c4e874ab74662d78fd9275/frontends/election-manager/src/screens/print_test_deck_screen.tsx#L144-L157), there's no guarantee that the initial order will be maintained as [each is processed by Paged.js](https://github.com/votingworks/vxsuite/blob/3e1689bdb1db2e7bf9c4e874ab74662d78fd9275/frontends/election-manager/src/components/hand_marked_paper_ballot.tsx#L623-L627). Every ballot processes itself, unaware of the other ballots, and renders its processed self to a shared target element ([the element referenced by `printBallotRef`](https://github.com/votingworks/vxsuite/blob/3e1689bdb1db2e7bf9c4e874ab74662d78fd9275/frontends/election-manager/src/components/hand_marked_paper_ballot.tsx#L626)).

In the screenshot below, for example, you can see that what was originally ballot 22 is the first ballot among the processed ballots.

<img width="400" alt="pagedjs" src="https://user-images.githubusercontent.com/12616928/170106955-8d65bdee-2b46-45fe-a76c-c8d6848c3d1b.png">

To fix this, we now render every processed ballot to a unique target element instead of a shared one. These target elements are created and cleared on the fly as needed.

Below is a (surprisingly relaxing 😌) video demonstrating this in action. Note how processing begins with ballot 22 and loops back to ballot 0 - before this fix, this would've resulted in a misordered test deck!

https://user-images.githubusercontent.com/12616928/170114229-e7e25d1c-8705-4654-8622-c472d623d347.mov

# Testing

- [x] Verified that automated tests still pass (with small expected tweaks to snapshots/mocks)
- [x] Manually tested the single-precinct case
- [x] Manually tested the all-precincts case
- [x] Verified that target elements were created _and cleared_ on the fly, via Chrome dev tools

# Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A
- [ ] ~I have added JSDoc comments to any newly introduced exports~ N/A
- [x] I have added a screenshot and/or video to this PR to demo the change
- [ ] ~I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~ N/A