### PR TITLE
Full Test Deck Tally Report Button

### DIFF
--- a/frontends/election-manager/src/components/full_test_deck_tally_report_button.tsx
+++ b/frontends/election-manager/src/components/full_test_deck_tally_report_button.tsx
@@ -1,0 +1,70 @@
+import React, { useContext, useCallback } from 'react';
+import { assert, tallyVotesByContest } from '@votingworks/utils';
+import { LogEventId } from '@votingworks/logging';
+import { Tally, VotingMethod } from '@votingworks/types';
+
+import { AppContext } from '../contexts/app_context';
+import { PrintButton } from './print_button';
+import { TestDeckTallyReport } from './test_deck_tally_report';
+import { generateTestDeckBallots } from '../utils/election';
+
+export function FullTestDeckTallyReportButton(): JSX.Element {
+  const { currentUserSession, electionDefinition, logger } =
+    useContext(AppContext);
+
+  assert(currentUserSession);
+  const currentUserType = currentUserSession.type;
+
+  assert(electionDefinition);
+  const { election } = electionDefinition;
+
+  const ballots = generateTestDeckBallots({ election });
+  const votes = ballots.map((b) => b.votes);
+
+  // Full test deck tally is 4 times a single test deck tally, because it counts scanning
+  // 2 test decks (BMD + HMPB) in 2 places (VxScan + VxCentralScan)
+  const testDeckTally: Tally = {
+    numberOfBallotsCounted: ballots.length * 4,
+    castVoteRecords: new Set(),
+    contestTallies: tallyVotesByContest({
+      election,
+      votes: [...votes, ...votes, ...votes, ...votes],
+    }),
+    ballotCountsByVotingMethod: { [VotingMethod.Unknown]: ballots.length },
+  };
+
+  const afterPrint = useCallback(() => {
+    void logger.log(LogEventId.TestDeckTallyReportPrinted, currentUserType, {
+      disposition: 'success',
+      message: `User printed the full test deck tally report`,
+    });
+  }, [logger, currentUserType]);
+
+  const afterPrintError = useCallback(
+    (errorMessage: string) => {
+      void logger.log(LogEventId.TestDeckTallyReportPrinted, currentUserType, {
+        disposition: 'failure',
+        errorMessage,
+        message: `Error printing the full test deck tally report: ${errorMessage}`,
+        result: 'User shown error.',
+      });
+    },
+    [logger, currentUserType]
+  );
+
+  const fullTestDeckTallyReport = (
+    <TestDeckTallyReport election={election} electionTally={testDeckTally} />
+  );
+
+  return (
+    <PrintButton
+      afterPrint={afterPrint}
+      afterPrintError={afterPrintError}
+      sides="one-sided"
+      printTarget={fullTestDeckTallyReport}
+      printTargetTestId="full-test-deck-tally-report"
+    >
+      Print Full Test Deck Tally Report
+    </PrintButton>
+  );
+}

--- a/frontends/election-manager/src/components/printable_area.tsx
+++ b/frontends/election-manager/src/components/printable_area.tsx
@@ -3,6 +3,7 @@ import ReactDom from 'react-dom';
 
 interface Props {
   children?: React.ReactNode;
+  'data-testid'?: string;
 }
 
 /**
@@ -10,10 +11,16 @@ interface Props {
  * name (standalone meaning via a React portal to ensure that a parent's CSS styles don't prevent
  * printability)
  */
-export function PrintableArea({ children }: Props): JSX.Element {
+export function PrintableArea({
+  'data-testid': dataTestId,
+  children,
+}: Props): JSX.Element {
   const printableContainerRef = useRef(document.createElement('div'));
   const printableContainer = printableContainerRef.current;
   printableContainer.classList.add('print-only');
+  if (dataTestId) {
+    printableContainer.dataset.testid = dataTestId;
+  }
 
   useEffect(() => {
     document.body.appendChild(printableContainer);

--- a/frontends/election-manager/src/components/zero_report_print_button.tsx
+++ b/frontends/election-manager/src/components/zero_report_print_button.tsx
@@ -7,7 +7,6 @@ import { Text } from '@votingworks/ui';
 import { AppContext } from '../contexts/app_context';
 import { computeFullElectionTally } from '../lib/votecounting';
 import { ElectionManagerTallyReport } from './election_manager_tally_report';
-import { PrintableArea } from './printable_area';
 import { PrintButton } from './print_button';
 
 const ButtonAnnotation = styled(Text)`
@@ -54,12 +53,23 @@ export function ZeroReportPrintButton(): JSX.Element {
     });
   }
 
+  const zeroReport = (
+    <ElectionManagerTallyReport
+      election={election}
+      fullElectionExternalTallies={[]}
+      fullElectionTally={emptyFullElectionTally}
+      isOfficialResults={false}
+    />
+  );
+
   return (
     <React.Fragment>
       <PrintButton
         afterPrint={logZeroReportPrintSuccess}
         afterPrintError={logZeroReportPrintError}
         sides="one-sided"
+        printTarget={zeroReport}
+        printTargetTestId="zero-report"
       >
         {/* Intentionally diverging from our typical title case button text to sentence case for clarity */}
         Print the pre-election Unofficial Full Election Tally Report
@@ -67,14 +77,6 @@ export function ZeroReportPrintButton(): JSX.Element {
       <ButtonAnnotation small>
         This report is referred to as the “Zero Report”.
       </ButtonAnnotation>
-      <PrintableArea>
-        <ElectionManagerTallyReport
-          election={election}
-          fullElectionExternalTallies={[]}
-          fullElectionTally={emptyFullElectionTally}
-          isOfficialResults={false}
-        />
-      </PrintableArea>
     </React.Fragment>
   );
 }

--- a/frontends/election-manager/src/screens/logic_and_accuracy_screen.tsx
+++ b/frontends/election-manager/src/screens/logic_and_accuracy_screen.tsx
@@ -4,6 +4,7 @@ import { LinkButton, Prose } from '@votingworks/ui';
 import { NavigationScreen } from '../components/navigation_screen';
 import { routerPaths } from '../router_paths';
 import { ZeroReportPrintButton } from '../components/zero_report_print_button';
+import { FullTestDeckTallyReportButton } from '../components/full_test_deck_tally_report_button';
 import { AppContext } from '../contexts/app_context';
 
 export function LogicAndAccuracyScreen(): JSX.Element {
@@ -27,6 +28,7 @@ export function LogicAndAccuracyScreen(): JSX.Element {
                 Print L&amp;A Packages
               </LinkButton>
             </p>
+            <FullTestDeckTallyReportButton />
           </React.Fragment>
         )}
       </Prose>


### PR DESCRIPTION
## Overview
Closes #1869. Adds a button to the L&A page which prints a test deck tally report for all precincts. The totals in the report are 4 times the totals of a single test deck, because it is used to compare with results after scanning two precinct test decks at each precinct and two full test decks at the central scanner.

## Demo Video or Screenshot

<img width="1439" alt="Screen Shot 2022-05-24 at 5 35 59 PM" src="https://user-images.githubusercontent.com/37960853/170154196-1f1b9c9a-ad1c-43d7-88d5-afcaa31b7618.png">

![full_test_deck_tally_report](https://user-images.githubusercontent.com/37960853/170154294-dc5eea4a-43d4-42ac-8a6e-8a332b529d46.jpg)

## Testing Plan 

Updated L&A flow to test printing of the report and its totals.

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] ~~I have added JSDoc comments to any newly introduced exports~~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
