### PR TITLE
fix: make `useDevices` et al work again

### DIFF
--- a/frontends/bmd/package.json
+++ b/frontends/bmd/package.json
@@ -118,7 +118,6 @@
     "react-idle-timer": "4.2.12",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.1",
-    "rxjs": "^6.6.6",
     "setimmediate": "^1.0.5",
     "styled-components": "^4.4.1",
     "typescript": "4.6.3",

--- a/frontends/bmd/src/app.tsx
+++ b/frontends/bmd/src/app.tsx
@@ -64,12 +64,12 @@ export function App({
   /* istanbul ignore next - need to figure out how to test this */
   useEffect(() => {
     if (internalHardware !== undefined) {
-      const subscription = internalHardware.devices.subscribe((devices) =>
+      const unsubscribe = internalHardware.devices.subscribe((devices) =>
         screenReader.toggleMuted(
           !Array.from(devices).some(isAccessibleController)
         )
       );
-      return () => subscription.unsubscribe();
+      return unsubscribe;
     }
   }, [internalHardware, screenReader]);
 

--- a/frontends/bsd/package.json
+++ b/frontends/bsd/package.json
@@ -90,7 +90,6 @@
     "react-dropzone": "^11.2.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.1",
-    "rxjs": "^6.6.6",
     "setimmediate": "^1.0.5",
     "styled-components": "^5.2.1",
     "ts-jest": "^26.1.3",

--- a/frontends/election-manager/package.json
+++ b/frontends/election-manager/package.json
@@ -120,7 +120,6 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.1",
     "react-textarea-autosize": "^8.2.0",
-    "rxjs": "^6.6.6",
     "styled-components": "^5.2.1",
     "typescript": "4.6.3",
     "use-interval": "^1.2.1",

--- a/frontends/precinct-scanner/package.json
+++ b/frontends/precinct-scanner/package.json
@@ -107,7 +107,6 @@
     "react-i18next": "^11.7.3",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.1",
-    "rxjs": "^6.6.6",
     "setimmediate": "^1.0.5",
     "styled-components": "^5.2.3",
     "typescript": "4.6.3",

--- a/libs/@types/kiosk-browser/kiosk-browser.d.ts
+++ b/libs/@types/kiosk-browser/kiosk-browser.d.ts
@@ -164,6 +164,10 @@ declare namespace KioskBrowser {
     payload: string;
   }
 
+  export interface Observable<T> {
+    subscribe(callback: (value: T) => void): () => void;
+  }
+
   export interface Kiosk {
     print(options?: PrintOptions): Promise<void>;
     getPrinterInfo(): Promise<PrinterInfo[]>;
@@ -175,8 +179,8 @@ declare namespace KioskBrowser {
     log(message: string): Promise<void>;
 
     getBatteryInfo(): Promise<BatteryInfo | undefined>;
-    devices: import('rxjs').Observable<Iterable<Device>>;
-    printers: import('rxjs').Observable<Iterable<PrinterInfo>>;
+    devices: Observable<Iterable<Device>>;
+    printers: Observable<Iterable<PrinterInfo>>;
     quit(): void;
 
     /**

--- a/libs/test-utils/package.json
+++ b/libs/test-utils/package.json
@@ -41,7 +41,6 @@
     "fast-check": "^2.18.0",
     "js-sha256": "^0.9.0",
     "luxon": "1.26.0",
-    "rxjs": "^6.6.6",
     "zip-stream": "^4.1.0"
   },
   "devDependencies": {

--- a/libs/test-utils/src/fake_kiosk.ts
+++ b/libs/test-utils/src/fake_kiosk.ts
@@ -1,5 +1,5 @@
 import { Buffer } from 'buffer';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject } from './observable';
 
 export function fakeDevice(
   props: Partial<KioskBrowser.Device> = {}

--- a/libs/test-utils/src/index.ts
+++ b/libs/test-utils/src/index.ts
@@ -4,6 +4,7 @@ export * from './cast_vote_record';
 export * from './child_process';
 export * from './compressed_tallies';
 export * from './fake_kiosk';
+export * from './observable';
 export * from './smartcards';
 export * from './smartcard_auth';
 export * from './zip';

--- a/libs/test-utils/src/observable.test.ts
+++ b/libs/test-utils/src/observable.test.ts
@@ -1,0 +1,38 @@
+import { BehaviorSubject } from './observable';
+
+test('BehaviorSubject', () => {
+  const subject = new BehaviorSubject(1);
+  const subscriber1 = jest.fn();
+  const subscriber2 = jest.fn();
+
+  const unsubscribe1 = subject.subscribe(subscriber1);
+  const unsubscribe2 = subject.subscribe(subscriber2);
+
+  // initial value
+  expect(subscriber1).toHaveBeenCalledWith(1);
+  expect(subscriber2).toHaveBeenCalledWith(1);
+
+  // both subscribed
+  subject.next(2);
+
+  expect(subscriber1).toHaveBeenCalledWith(2);
+  expect(subscriber2).toHaveBeenCalledWith(2);
+
+  // #1 unsubscribed
+  unsubscribe1();
+  subject.next(3);
+
+  expect(subscriber1).not.toHaveBeenCalledWith(3);
+  expect(subscriber2).toHaveBeenCalledWith(3);
+
+  // both unsubscribed
+  unsubscribe2();
+  subject.next(4);
+
+  expect(subscriber1).not.toHaveBeenCalledWith(4);
+  expect(subscriber2).not.toHaveBeenCalledWith(4);
+
+  // unsubscribing again has no effect
+  unsubscribe1();
+  unsubscribe2();
+});

--- a/libs/test-utils/src/observable.ts
+++ b/libs/test-utils/src/observable.ts
@@ -1,0 +1,37 @@
+/**
+ * Alias for `KioskBrowser.Observable`.
+ */
+export type Observable<T> = KioskBrowser.Observable<T>;
+
+/**
+ * A simple `Observable` that allows pushing new values and emits the last value
+ * when a subscriber subscribes.
+ */
+export class BehaviorSubject<T> implements Observable<T> {
+  private currentValue: T;
+  private subscriptions = new Set<(value: T) => void>();
+
+  constructor(initialValue: T) {
+    this.currentValue = initialValue;
+  }
+
+  /**
+   * Push a new value to all subscribers.
+   */
+  next(value: T): void {
+    this.currentValue = value;
+    for (const subscription of this.subscriptions) {
+      subscription(value);
+    }
+  }
+
+  /**
+   * Register a new subscriber. Calls the callback with the current value.
+   * Returns a function to unsubscribe.
+   */
+  subscribe(callback: (value: T) => void): () => void {
+    this.subscriptions.add(callback);
+    callback(this.currentValue);
+    return () => this.subscriptions.delete(callback);
+  }
+}

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -54,7 +54,6 @@
     "react-dom": "^17.0.1",
     "react-modal": "^3.14.4",
     "react-router-dom": "^5.2.0",
-    "rxjs": "6.6.6",
     "styled-components": "^5.2.3",
     "use-interval": "^1.4.0",
     "zod": "3.14.4"

--- a/libs/ui/src/hooks/use_devices.ts
+++ b/libs/ui/src/hooks/use_devices.ts
@@ -7,7 +7,6 @@ import {
   isPrecinctScanner,
 } from '@votingworks/utils';
 import { useEffect, useState } from 'react';
-import { map } from 'rxjs/operators';
 import useInterval from 'use-interval';
 import { useCancelablePromise } from './use_cancelable_promise';
 import { usePrevious } from './use_previous';
@@ -64,17 +63,17 @@ export function useDevices({ hardware, logger }: Props): Devices {
   const previousPrinters = usePrevious(allPrinters);
 
   useEffect(() => {
-    const hardwareStatusSubscription = hardware.devices
-      .pipe(map((devices) => Array.from(devices)))
-      .subscribe(setAllDevices);
+    const unsubscribeDevices = hardware.devices.subscribe((devices) => {
+      setAllDevices(Array.from(devices));
+    });
 
-    const printerStatusSubscription = hardware.printers
-      .pipe(map((printers) => Array.from(printers)))
-      .subscribe(setAllPrinters);
+    const unsubscribePrinters = hardware.printers.subscribe((devices) => {
+      setAllPrinters(Array.from(devices));
+    });
 
     return () => {
-      hardwareStatusSubscription.unsubscribe();
-      printerStatusSubscription.unsubscribe();
+      unsubscribeDevices();
+      unsubscribePrinters();
     };
   }, [hardware]);
 

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -48,7 +48,6 @@
     "luxon": "^1.27.0",
     "moment": "^2.29.1",
     "randombytes": "^2.1.0",
-    "rxjs": "^6.6.6",
     "zod": "3.14.4"
   },
   "devDependencies": {

--- a/libs/utils/src/Hardware/memory_hardware.test.ts
+++ b/libs/utils/src/Hardware/memory_hardware.test.ts
@@ -134,7 +134,8 @@ it('allows unsubscribing from a device subscription', () => {
   const callback = jest.fn();
   const device = fakeDevice();
 
-  hardware.devices.subscribe(callback).unsubscribe();
+  const unsubscribe = hardware.devices.subscribe(callback);
+  unsubscribe();
   callback.mockClear();
 
   hardware.addDevice(device);

--- a/libs/utils/src/Hardware/memory_hardware.ts
+++ b/libs/utils/src/Hardware/memory_hardware.ts
@@ -1,4 +1,4 @@
-import { BehaviorSubject, Observable } from 'rxjs';
+import { BehaviorSubject, Observable } from '../observable';
 import { Hardware } from '../types';
 import {
   AccessibleControllerProductId,

--- a/libs/utils/src/observable.test.ts
+++ b/libs/utils/src/observable.test.ts
@@ -1,0 +1,45 @@
+import { BehaviorSubject } from './observable';
+
+test('BehaviorSubject', () => {
+  const subject = new BehaviorSubject(1);
+  const subscriber1 = jest.fn();
+  const subscriber2 = jest.fn();
+
+  const unsubscribe1 = subject.subscribe(subscriber1);
+  const unsubscribe2 = subject.subscribe(subscriber2);
+
+  // initial value
+  expect(subscriber1).toHaveBeenCalledWith(1);
+  expect(subscriber2).toHaveBeenCalledWith(1);
+
+  // both subscribed
+  subject.next(2);
+
+  expect(subscriber1).toHaveBeenCalledWith(2);
+  expect(subscriber2).toHaveBeenCalledWith(2);
+
+  // #1 unsubscribed
+  unsubscribe1();
+  subject.next(3);
+
+  expect(subscriber1).not.toHaveBeenCalledWith(3);
+  expect(subscriber2).toHaveBeenCalledWith(3);
+
+  // both unsubscribed
+  unsubscribe2();
+  subject.next(4);
+
+  expect(subscriber1).not.toHaveBeenCalledWith(4);
+  expect(subscriber2).not.toHaveBeenCalledWith(4);
+
+  // unsubscribing again has no effect
+  unsubscribe1();
+  unsubscribe2();
+
+  // new subscriber gets last value
+  const subscriber3 = jest.fn();
+  const unsubscribe3 = subject.subscribe(subscriber3);
+
+  expect(subscriber3).toHaveBeenCalledWith(4);
+  unsubscribe3();
+});

--- a/libs/utils/src/observable.ts
+++ b/libs/utils/src/observable.ts
@@ -1,0 +1,37 @@
+/**
+ * Alias for `KioskBrowser.Observable`.
+ */
+export type Observable<T> = KioskBrowser.Observable<T>;
+
+/**
+ * A simple `Observable` that allows pushing new values and emits the last value
+ * when a subscriber subscribes.
+ */
+export class BehaviorSubject<T> implements Observable<T> {
+  private currentValue: T;
+  private subscriptions = new Set<(value: T) => void>();
+
+  constructor(initialValue: T) {
+    this.currentValue = initialValue;
+  }
+
+  /**
+   * Push a new value to all subscribers.
+   */
+  next(value: T): void {
+    this.currentValue = value;
+    for (const subscription of this.subscriptions) {
+      subscription(value);
+    }
+  }
+
+  /**
+   * Register a new subscriber. Calls the callback with the current value.
+   * Returns a function to unsubscribe.
+   */
+  subscribe(callback: (value: T) => void): () => void {
+    this.subscriptions.add(callback);
+    callback(this.currentValue);
+    return () => this.subscriptions.delete(callback);
+  }
+}

--- a/libs/utils/src/types.ts
+++ b/libs/utils/src/types.ts
@@ -8,7 +8,6 @@ import {
   PrecinctSelectionSchema,
   Result,
 } from '@votingworks/types';
-import { Observable } from 'rxjs';
 import { z } from 'zod';
 
 // Currently we only support precinct scanner tallies but this enum exists for future ability to specify different types
@@ -183,12 +182,14 @@ export interface Hardware {
   /**
    * Subscribe to USB device updates.
    */
-  readonly devices: Observable<Iterable<KioskBrowser.Device>>;
+  readonly devices: KioskBrowser.Observable<Iterable<KioskBrowser.Device>>;
 
   /**
    * Subscribe to USB device updates.
    */
-  readonly printers: Observable<Iterable<KioskBrowser.PrinterInfo>>;
+  readonly printers: KioskBrowser.Observable<
+    Iterable<KioskBrowser.PrinterInfo>
+  >;
 }
 
 export interface PrintOptions extends KioskBrowser.PrintOptions {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,7 +203,7 @@ importers:
       dompurify: 2.2.6
       fetch-mock: 9.11.0
       history: 4.10.1
-      http-proxy-middleware: 1.0.6
+      http-proxy-middleware: 1.0.6_debug@4.3.2
       lodash.camelcase: 4.3.0
       luxon: 1.26.0
       mockdate: 3.0.2
@@ -216,7 +216,6 @@ importers:
       react-idle-timer: 4.2.12_react-dom@17.0.1+react@17.0.1
       react-router-dom: 5.2.0_react@17.0.1
       react-scripts: 4.0.1_typescript@4.6.3
-      rxjs: 6.6.6
       setimmediate: 1.0.5
       styled-components: 4.4.1_react-dom@17.0.1+react@17.0.1
       typescript: 4.6.3
@@ -346,7 +345,6 @@ importers:
       react-refresh: ^0.10.0
       react-router-dom: ^5.2.0
       react-scripts: 4.0.1
-      rxjs: ^6.6.6
       setimmediate: ^1.0.5
       sort-package-json: ^1.50.0
       start-server-and-test: ^1.11.0
@@ -393,7 +391,6 @@ importers:
       react-dropzone: 11.2.4_react@17.0.1
       react-router-dom: 5.2.0_react@17.0.1
       react-scripts: 4.0.1_7fefadec3d355f5f7830c5850dacc724
-      rxjs: 6.6.6
       setimmediate: 1.0.5
       styled-components: 5.2.1_react-dom@17.0.1+react@17.0.1
       ts-jest: 26.5.5_jest@27.5.1+typescript@4.6.3
@@ -511,7 +508,6 @@ importers:
       react-refresh: ^0.9.0
       react-router-dom: ^5.2.0
       react-scripts: 4.0.1
-      rxjs: ^6.6.6
       setimmediate: ^1.0.5
       sort-package-json: ^1.50.0
       styled-components: ^5.2.1
@@ -565,7 +561,7 @@ importers:
       dompurify: 2.2.6
       fetch-mock: 9.11.0
       history: 4.10.1
-      http-proxy-middleware: 1.0.6
+      http-proxy-middleware: 1.0.6_debug@4.3.2
       i18next: 19.8.4
       js-file-download: 0.4.12
       js-sha256: 0.9.0
@@ -581,9 +577,8 @@ importers:
       react-dom: 17.0.1_react@17.0.1
       react-i18next: 11.8.5_i18next@19.8.4+react@17.0.1
       react-router-dom: 5.2.0_react@17.0.1
-      react-scripts: 4.0.1_typescript@4.6.3
+      react-scripts: 4.0.1_canvas@2.9.1+typescript@4.6.3
       react-textarea-autosize: 8.3.0_e8f6b04531727420b27210e589e7d031
-      rxjs: 6.6.6
       styled-components: 5.2.1_react-dom@17.0.1+react@17.0.1
       typescript: 4.6.3
       use-interval: 1.3.0_react@17.0.1
@@ -715,7 +710,6 @@ importers:
       react-scripts: 4.0.1
       react-test-renderer: ^16.13.1
       react-textarea-autosize: ^8.2.0
-      rxjs: ^6.6.6
       sort-package-json: ^1.50.0
       styled-components: ^5.2.1
       stylelint: ^13.1.0
@@ -759,7 +753,7 @@ importers:
       buffer: 6.0.3
       debug: 4.3.1
       fetch-mock: 9.11.0
-      http-proxy-middleware: 1.0.6
+      http-proxy-middleware: 1.0.6_debug@4.3.1
       i18next: 19.8.4
       jest-fetch-mock: 3.0.3
       js-file-download: 0.4.12
@@ -773,7 +767,6 @@ importers:
       react-i18next: 11.8.5_i18next@19.8.4+react@17.0.1
       react-router-dom: 5.2.0_react@17.0.1
       react-scripts: 4.0.1_typescript@4.6.3
-      rxjs: 6.6.6
       setimmediate: 1.0.5
       styled-components: 5.2.3_react-dom@17.0.1+react@17.0.1
       typescript: 4.6.3
@@ -886,7 +879,6 @@ importers:
       react-refresh: ^0.9.0
       react-router-dom: ^5.2.0
       react-scripts: 4.0.1
-      rxjs: ^6.6.6
       setimmediate: ^1.0.5
       sort-package-json: ^1.50.0
       styled-components: ^5.2.3
@@ -1872,7 +1864,6 @@ importers:
       fast-check: 2.18.0
       js-sha256: 0.9.0
       luxon: 1.26.0
-      rxjs: 6.6.6
       zip-stream: 4.1.0
     devDependencies:
       '@types/jest': 27.0.3
@@ -1928,7 +1919,6 @@ importers:
       prettier: ^2.6.2
       react: ^17.0.1
       react-dom: ^17.0.1
-      rxjs: ^6.6.6
       sort-package-json: ^1.50.0
       ts-jest: ^27.0.7
       typescript: 4.6.3
@@ -2004,7 +1994,6 @@ importers:
       react-dom: 17.0.1_react@17.0.1
       react-modal: 3.14.4_react-dom@17.0.1+react@17.0.1
       react-router-dom: 5.2.0_react@17.0.1
-      rxjs: 6.6.6
       styled-components: 5.2.3_react-dom@17.0.1+react@17.0.1
       use-interval: 1.4.0_react@17.0.1
       zod: 3.14.4
@@ -2121,7 +2110,6 @@ importers:
       react-dom: ^17.0.1
       react-modal: ^3.14.4
       react-router-dom: ^5.2.0
-      rxjs: 6.6.6
       sort-package-json: ^1.50.0
       styled-components: ^5.2.3
       stylelint: ^13.1.0
@@ -2147,7 +2135,6 @@ importers:
       luxon: 1.27.0
       moment: 2.29.1
       randombytes: 2.1.0
-      rxjs: 6.6.6
       zod: 3.14.4
     devDependencies:
       '@types/debug': 4.1.7
@@ -2212,7 +2199,6 @@ importers:
       moment: ^2.29.1
       prettier: ^2.6.2
       randombytes: ^2.1.0
-      rxjs: ^6.6.6
       sort-package-json: ^1.50.0
       ts-jest: ^27.0.7
       typescript: 4.6.3
@@ -2367,7 +2353,7 @@ importers:
       eslint-plugin-vx: link:../../libs/eslint-plugin-vx
       fast-check: 2.23.2
       is-ci-cli: 2.1.2
-      jest: 26.6.3
+      jest: 26.6.3_canvas@2.9.1
       jest-watch-typeahead: 0.6.4_jest@26.6.3
       lint-staged: 10.5.3
       nock: 13.1.0
@@ -7184,6 +7170,42 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==
+  /@jest/core/26.6.3_canvas@2.9.1:
+    dependencies:
+      '@jest/console': 26.6.2
+      '@jest/reporters': 26.6.2
+      '@jest/test-result': 26.6.2
+      '@jest/transform': 26.6.2
+      '@jest/types': 26.6.2
+      '@types/node': 16.11.6
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.10
+      jest-changed-files: 26.6.2
+      jest-config: 26.6.3_canvas@2.9.1
+      jest-haste-map: 26.6.2
+      jest-message-util: 26.6.2
+      jest-regex-util: 26.0.0
+      jest-resolve: 26.6.2
+      jest-resolve-dependencies: 26.6.3
+      jest-runner: 26.6.3_canvas@2.9.1
+      jest-runtime: 26.6.3_canvas@2.9.1
+      jest-snapshot: 26.6.2
+      jest-util: 26.6.2
+      jest-validate: 26.6.2
+      jest-watcher: 26.6.2
+      micromatch: 4.0.4
+      p-each-series: 2.2.0
+      rimraf: 3.0.2
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      canvas: '*'
+    resolution:
+      integrity: sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==
   /@jest/core/27.3.1:
     dependencies:
       '@jest/console': 27.3.1
@@ -7244,7 +7266,7 @@ packages:
       jest-regex-util: 27.0.6
       jest-resolve: 27.3.1
       jest-resolve-dependencies: 27.3.1
-      jest-runner: 27.3.1
+      jest-runner: 27.3.1_canvas@2.9.1
       jest-runtime: 27.3.1
       jest-snapshot: 27.3.1
       jest-util: 27.3.1
@@ -7365,7 +7387,7 @@ packages:
       jest-regex-util: 27.5.1
       jest-resolve: 27.5.1
       jest-resolve-dependencies: 27.5.1
-      jest-runner: 27.5.1
+      jest-runner: 27.5.1_canvas@2.9.1
       jest-runtime: 27.5.1
       jest-snapshot: 27.5.1
       jest-util: 27.5.1
@@ -7800,6 +7822,19 @@ packages:
       jest-runtime: 26.6.3
     engines:
       node: '>= 10.14.2'
+    resolution:
+      integrity: sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==
+  /@jest/test-sequencer/26.6.3_canvas@2.9.1:
+    dependencies:
+      '@jest/test-result': 26.6.2
+      graceful-fs: 4.2.10
+      jest-haste-map: 26.6.2
+      jest-runner: 26.6.3_canvas@2.9.1
+      jest-runtime: 26.6.3_canvas@2.9.1
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      canvas: '*'
     resolution:
       integrity: sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==
   /@jest/test-sequencer/27.3.1:
@@ -12084,7 +12119,7 @@ packages:
       integrity: sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA==
   /axios/0.21.1_debug@4.3.1:
     dependencies:
-      follow-redirects: 1.14.1_debug@4.3.2
+      follow-redirects: 1.14.1_debug@4.3.1
     dev: true
     peerDependencies:
       debug: '*'
@@ -17823,7 +17858,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 5.21.0_4059d5ee7aba256d5e330151ee3418c0
       '@typescript-eslint/utils': 5.22.0_eslint@7.17.0+typescript@4.6.3
       eslint: 7.17.0
-      jest: 26.6.3
+      jest: 26.6.3_canvas@2.9.1
     dev: true
     engines:
       node: ^12.22.0 || ^14.17.0 || >=16.0.0
@@ -19876,7 +19911,6 @@ packages:
   /follow-redirects/1.14.1_debug@4.3.1:
     dependencies:
       debug: 4.3.1
-    dev: false
     engines:
       node: '>=4.0'
     peerDependencies:
@@ -19888,7 +19922,8 @@ packages:
       integrity: sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
   /follow-redirects/1.14.1_debug@4.3.2:
     dependencies:
-      debug: 4.3.2_supports-color@6.1.0
+      debug: 4.3.2
+    dev: false
     engines:
       node: '>=4.0'
     peerDependencies:
@@ -20864,6 +20899,34 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
+  /http-proxy-middleware/1.0.6_debug@4.3.1:
+    dependencies:
+      '@types/http-proxy': 1.17.6
+      http-proxy: 1.18.1_debug@4.3.1
+      is-glob: 4.0.1
+      lodash: 4.17.21
+      micromatch: 4.0.4
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    peerDependencies:
+      debug: '*'
+    resolution:
+      integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
+  /http-proxy-middleware/1.0.6_debug@4.3.2:
+    dependencies:
+      '@types/http-proxy': 1.17.6
+      http-proxy: 1.18.1_debug@4.3.2
+      is-glob: 4.0.1
+      lodash: 4.17.21
+      micromatch: 4.0.4
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    peerDependencies:
+      debug: '*'
+    resolution:
+      integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
   /http-proxy/1.18.1:
     dependencies:
       eventemitter3: 4.0.7
@@ -20872,6 +20935,18 @@ packages:
     dev: false
     engines:
       node: '>=8.0.0'
+    resolution:
+      integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
+  /http-proxy/1.18.1_debug@4.3.1:
+    dependencies:
+      eventemitter3: 4.0.7
+      follow-redirects: 1.14.1_debug@4.3.1
+      requires-port: 1.0.0
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    peerDependencies:
+      debug: '*'
     resolution:
       integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
   /http-proxy/1.18.1_debug@4.3.2:
@@ -21919,6 +21994,37 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-L2/Y9szN6FJPWFK8kzWXwfp+FOR7xq0cUL4lIsdbIdwz3Vh6P1nrpcqOleSzr28zOtSHQNV9Z7Tl+KkuK7t5Ng==
+  /jest-circus/26.6.0_canvas@2.9.1:
+    dependencies:
+      '@babel/traverse': 7.15.4
+      '@jest/environment': 26.6.2
+      '@jest/test-result': 26.6.2
+      '@jest/types': 26.6.2
+      '@types/babel__traverse': 7.14.2
+      '@types/node': 16.0.0
+      chalk: 4.1.2
+      co: 4.6.0
+      dedent: 0.7.0
+      expect: 26.6.2
+      is-generator-fn: 2.1.0
+      jest-each: 26.6.2
+      jest-matcher-utils: 26.6.2
+      jest-message-util: 26.6.2
+      jest-runner: 26.6.3_canvas@2.9.1
+      jest-runtime: 26.6.3_canvas@2.9.1
+      jest-snapshot: 26.6.2
+      jest-util: 26.6.2
+      prettier: 2.3.2
+      pretty-format: 26.6.2
+      stack-utils: 2.0.5
+      throat: 5.0.0
+    dev: false
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      canvas: '*'
+    resolution:
+      integrity: sha512-L2/Y9szN6FJPWFK8kzWXwfp+FOR7xq0cUL4lIsdbIdwz3Vh6P1nrpcqOleSzr28zOtSHQNV9Z7Tl+KkuK7t5Ng==
   /jest-circus/27.3.1:
     dependencies:
       '@jest/environment': 27.3.1
@@ -22018,6 +22124,28 @@ packages:
     engines:
       node: '>= 10.14.2'
     hasBin: true
+    resolution:
+      integrity: sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
+  /jest-cli/26.6.3_canvas@2.9.1:
+    dependencies:
+      '@jest/core': 26.6.3_canvas@2.9.1
+      '@jest/test-result': 26.6.2
+      '@jest/types': 26.6.2
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.10
+      import-local: 3.0.3
+      is-ci: 2.0.0
+      jest-config: 26.6.3_canvas@2.9.1
+      jest-util: 26.6.2
+      jest-validate: 26.6.2
+      prompts: 2.4.2
+      yargs: 15.4.1
+    engines:
+      node: '>= 10.14.2'
+    hasBin: true
+    peerDependencies:
+      canvas: '*'
     resolution:
       integrity: sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
   /jest-cli/27.3.1:
@@ -22176,6 +22304,36 @@ packages:
         optional: true
     resolution:
       integrity: sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==
+  /jest-config/26.6.3_canvas@2.9.1:
+    dependencies:
+      '@babel/core': 7.16.0
+      '@jest/test-sequencer': 26.6.3_canvas@2.9.1
+      '@jest/types': 26.6.2
+      babel-jest: 26.6.3_@babel+core@7.16.0
+      chalk: 4.1.2
+      deepmerge: 4.2.2
+      glob: 7.2.0
+      graceful-fs: 4.2.10
+      jest-environment-jsdom: 26.6.2_canvas@2.9.1
+      jest-environment-node: 26.6.2
+      jest-get-type: 26.3.0
+      jest-jasmine2: 26.6.3_canvas@2.9.1
+      jest-regex-util: 26.0.0
+      jest-resolve: 26.6.2
+      jest-util: 26.6.2
+      jest-validate: 26.6.2
+      micromatch: 4.0.4
+      pretty-format: 26.6.2
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      canvas: '*'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      ts-node:
+        optional: true
+    resolution:
+      integrity: sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==
   /jest-config/27.3.1:
     dependencies:
       '@babel/core': 7.16.0
@@ -22227,7 +22385,7 @@ packages:
       jest-jasmine2: 27.3.1
       jest-regex-util: 27.0.6
       jest-resolve: 27.3.1
-      jest-runner: 27.3.1
+      jest-runner: 27.3.1_canvas@2.9.1
       jest-util: 27.3.1
       jest-validate: 27.3.1
       micromatch: 4.0.4
@@ -22331,7 +22489,7 @@ packages:
       jest-jasmine2: 27.5.1
       jest-regex-util: 27.5.1
       jest-resolve: 27.5.1
-      jest-runner: 27.5.1
+      jest-runner: 27.5.1_canvas@2.9.1
       jest-util: 27.5.1
       jest-validate: 27.5.1
       micromatch: 4.0.5
@@ -22543,6 +22701,21 @@ packages:
       jsdom: 16.7.0
     engines:
       node: '>= 10.14.2'
+    resolution:
+      integrity: sha512-jgPqCruTlt3Kwqg5/WVFyHIOJHsiAvhcp2qiR2QQstuG9yWox5+iHpU3ZrcBxW14T4fe5Z68jAfLRh7joCSP2Q==
+  /jest-environment-jsdom/26.6.2_canvas@2.9.1:
+    dependencies:
+      '@jest/environment': 26.6.2
+      '@jest/fake-timers': 26.6.2
+      '@jest/types': 26.6.2
+      '@types/node': 16.11.6
+      jest-mock: 26.6.2
+      jest-util: 26.6.2
+      jsdom: 16.7.0_canvas@2.9.1
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      canvas: '*'
     resolution:
       integrity: sha512-jgPqCruTlt3Kwqg5/WVFyHIOJHsiAvhcp2qiR2QQstuG9yWox5+iHpU3ZrcBxW14T4fe5Z68jAfLRh7joCSP2Q==
   /jest-environment-jsdom/27.3.1:
@@ -22836,6 +23009,32 @@ packages:
       throat: 5.0.0
     engines:
       node: '>= 10.14.2'
+    resolution:
+      integrity: sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==
+  /jest-jasmine2/26.6.3_canvas@2.9.1:
+    dependencies:
+      '@babel/traverse': 7.16.3
+      '@jest/environment': 26.6.2
+      '@jest/source-map': 26.6.2
+      '@jest/test-result': 26.6.2
+      '@jest/types': 26.6.2
+      '@types/node': 16.11.6
+      chalk: 4.1.2
+      co: 4.6.0
+      expect: 26.6.2
+      is-generator-fn: 2.1.0
+      jest-each: 26.6.2
+      jest-matcher-utils: 26.6.2
+      jest-message-util: 26.6.2
+      jest-runtime: 26.6.3_canvas@2.9.1
+      jest-snapshot: 26.6.2
+      jest-util: 26.6.2
+      pretty-format: 26.6.2
+      throat: 5.0.0
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      canvas: '*'
     resolution:
       integrity: sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==
   /jest-jasmine2/27.3.1:
@@ -23374,6 +23573,34 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==
+  /jest-runner/26.6.3_canvas@2.9.1:
+    dependencies:
+      '@jest/console': 26.6.2
+      '@jest/environment': 26.6.2
+      '@jest/test-result': 26.6.2
+      '@jest/types': 26.6.2
+      '@types/node': 16.11.6
+      chalk: 4.1.2
+      emittery: 0.7.2
+      exit: 0.1.2
+      graceful-fs: 4.2.10
+      jest-config: 26.6.3_canvas@2.9.1
+      jest-docblock: 26.0.0
+      jest-haste-map: 26.6.2
+      jest-leak-detector: 26.6.2
+      jest-message-util: 26.6.2
+      jest-resolve: 26.6.2
+      jest-runtime: 26.6.3_canvas@2.9.1
+      jest-util: 26.6.2
+      jest-worker: 26.6.2
+      source-map-support: 0.5.20
+      throat: 5.0.0
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      canvas: '*'
+    resolution:
+      integrity: sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==
   /jest-runner/27.3.1:
     dependencies:
       '@jest/console': 27.3.1
@@ -23401,6 +23628,37 @@ packages:
     dev: true
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
+    resolution:
+      integrity: sha512-r4W6kBn6sPr3TBwQNmqE94mPlYVn7fLBseeJfo4E2uCTmAyDFm2O5DYAQAFP7Q3YfiA/bMwg8TVsciP7k0xOww==
+  /jest-runner/27.3.1_canvas@2.9.1:
+    dependencies:
+      '@jest/console': 27.3.1
+      '@jest/environment': 27.3.1
+      '@jest/test-result': 27.3.1
+      '@jest/transform': 27.3.1
+      '@jest/types': 27.2.5
+      '@types/node': 15.3.0
+      chalk: 4.1.2
+      emittery: 0.8.1
+      exit: 0.1.2
+      graceful-fs: 4.2.10
+      jest-docblock: 27.0.6
+      jest-environment-jsdom: 27.3.1_canvas@2.9.1
+      jest-environment-node: 27.3.1
+      jest-haste-map: 27.3.1
+      jest-leak-detector: 27.3.1
+      jest-message-util: 27.3.1
+      jest-resolve: 27.3.1
+      jest-runtime: 27.3.1
+      jest-util: 27.3.1
+      jest-worker: 27.3.1
+      source-map-support: 0.5.20
+      throat: 6.0.1
+    dev: true
+    engines:
+      node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
+    peerDependencies:
+      canvas: '*'
     resolution:
       integrity: sha512-r4W6kBn6sPr3TBwQNmqE94mPlYVn7fLBseeJfo4E2uCTmAyDFm2O5DYAQAFP7Q3YfiA/bMwg8TVsciP7k0xOww==
   /jest-runner/27.4.5:
@@ -23460,6 +23718,36 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-g4NPsM4mFCOwFKXO4p/H/kWGdJp9V8kURY2lX8Me2drgXqG7rrZAx5kv+5H7wtt/cdFIjhqYx1HrlqWHaOvDaQ==
+  /jest-runner/27.5.1_canvas@2.9.1:
+    dependencies:
+      '@jest/console': 27.5.1
+      '@jest/environment': 27.5.1
+      '@jest/test-result': 27.5.1
+      '@jest/transform': 27.5.1
+      '@jest/types': 27.5.1
+      '@types/node': 16.11.29
+      chalk: 4.1.2
+      emittery: 0.8.1
+      graceful-fs: 4.2.10
+      jest-docblock: 27.5.1
+      jest-environment-jsdom: 27.5.1_canvas@2.9.1
+      jest-environment-node: 27.5.1
+      jest-haste-map: 27.5.1
+      jest-leak-detector: 27.5.1
+      jest-message-util: 27.5.1
+      jest-resolve: 27.5.1
+      jest-runtime: 27.5.1
+      jest-util: 27.5.1
+      jest-worker: 27.5.1
+      source-map-support: 0.5.21
+      throat: 6.0.1
+    dev: true
+    engines:
+      node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
+    peerDependencies:
+      canvas: '*'
+    resolution:
+      integrity: sha512-g4NPsM4mFCOwFKXO4p/H/kWGdJp9V8kURY2lX8Me2drgXqG7rrZAx5kv+5H7wtt/cdFIjhqYx1HrlqWHaOvDaQ==
   /jest-runtime/26.6.3:
     dependencies:
       '@jest/console': 26.6.2
@@ -23492,6 +23780,42 @@ packages:
     engines:
       node: '>= 10.14.2'
     hasBin: true
+    resolution:
+      integrity: sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==
+  /jest-runtime/26.6.3_canvas@2.9.1:
+    dependencies:
+      '@jest/console': 26.6.2
+      '@jest/environment': 26.6.2
+      '@jest/fake-timers': 26.6.2
+      '@jest/globals': 26.6.2
+      '@jest/source-map': 26.6.2
+      '@jest/test-result': 26.6.2
+      '@jest/transform': 26.6.2
+      '@jest/types': 26.6.2
+      '@types/yargs': 15.0.14
+      chalk: 4.1.2
+      cjs-module-lexer: 0.6.0
+      collect-v8-coverage: 1.0.1
+      exit: 0.1.2
+      glob: 7.2.0
+      graceful-fs: 4.2.10
+      jest-config: 26.6.3_canvas@2.9.1
+      jest-haste-map: 26.6.2
+      jest-message-util: 26.6.2
+      jest-mock: 26.6.2
+      jest-regex-util: 26.0.0
+      jest-resolve: 26.6.2
+      jest-snapshot: 26.6.2
+      jest-util: 26.6.2
+      jest-validate: 26.6.2
+      slash: 3.0.0
+      strip-bom: 4.0.0
+      yargs: 15.4.1
+    engines:
+      node: '>= 10.14.2'
+    hasBin: true
+    peerDependencies:
+      canvas: '*'
     resolution:
       integrity: sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==
   /jest-runtime/27.3.1:
@@ -23922,7 +24246,7 @@ packages:
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.1
-      jest: 26.6.3
+      jest: 26.6.3_canvas@2.9.1
       jest-regex-util: 27.0.1
       jest-watcher: 27.0.2
       slash: 3.0.0
@@ -24148,6 +24472,19 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-jxTmrvuecVISvKFFhOkjsWRZV7sFqdSUAd1ajOKY+/QE/aLBVstsJ/dX8GczLzwiT6ZEwwmZqtCUHLHHQVzcfA==
+  /jest/26.6.0_canvas@2.9.1:
+    dependencies:
+      '@jest/core': 26.6.3_canvas@2.9.1
+      import-local: 3.0.3
+      jest-cli: 26.6.3_canvas@2.9.1
+    dev: false
+    engines:
+      node: '>= 10.14.2'
+    hasBin: true
+    peerDependencies:
+      canvas: '*'
+    resolution:
+      integrity: sha512-jxTmrvuecVISvKFFhOkjsWRZV7sFqdSUAd1ajOKY+/QE/aLBVstsJ/dX8GczLzwiT6ZEwwmZqtCUHLHHQVzcfA==
   /jest/26.6.3:
     dependencies:
       '@jest/core': 26.6.3
@@ -24157,6 +24494,19 @@ packages:
     engines:
       node: '>= 10.14.2'
     hasBin: true
+    resolution:
+      integrity: sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
+  /jest/26.6.3_canvas@2.9.1:
+    dependencies:
+      '@jest/core': 26.6.3_canvas@2.9.1
+      import-local: 3.0.3
+      jest-cli: 26.6.3_canvas@2.9.1
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    hasBin: true
+    peerDependencies:
+      canvas: '*'
     resolution:
       integrity: sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
   /jest/27.3.1:
@@ -24347,7 +24697,6 @@ packages:
       whatwg-url: 8.7.0
       ws: 7.5.7
       xml-name-validator: 3.0.0
-    dev: true
     engines:
       node: '>=10'
     peerDependencies:
@@ -28370,6 +28719,81 @@ packages:
         optional: true
     resolution:
       integrity: sha512-NnniMSC/wjwhcJAyPJCWtxx6CWONqgvGgV9+QXj1bwoW/JI++YF1eEf3Upf/mQ9KmP57IBdjzWs1XvnPq7qMTQ==
+  /react-scripts/4.0.1_canvas@2.9.1+typescript@4.6.3:
+    dependencies:
+      '@babel/core': 7.12.3
+      '@pmmmwh/react-refresh-webpack-plugin': 0.4.2_d00fcc46a48175a4e289da7534b00e9a
+      '@svgr/webpack': 5.4.0
+      '@typescript-eslint/eslint-plugin': 4.30.0_eeb95bb71ac15dd9a2b8f14f691524f8
+      '@typescript-eslint/parser': 4.29.3_eslint@7.29.0+typescript@4.6.3
+      babel-eslint: 10.1.0_eslint@7.29.0
+      babel-jest: 26.6.3_@babel+core@7.12.3
+      babel-loader: 8.1.0_427212bc1158d185e577033f19ca0757
+      babel-plugin-named-asset-import: 0.3.7_@babel+core@7.12.3
+      babel-preset-react-app: 10.0.0
+      bfj: 7.0.2
+      camelcase: 6.2.0
+      case-sensitive-paths-webpack-plugin: 2.3.0
+      css-loader: 4.3.0_webpack@4.44.2
+      dotenv: 8.2.0
+      dotenv-expand: 5.1.0
+      eslint: 7.29.0
+      eslint-config-react-app: 6.0.0_d4ef662949d0d072f3e3ae2e54a11fae
+      eslint-plugin-flowtype: 5.2.0_eslint@7.29.0
+      eslint-plugin-import: 2.24.2_eslint@7.29.0+typescript@4.6.3
+      eslint-plugin-jest: 24.1.3_eslint@7.29.0+typescript@4.6.3
+      eslint-plugin-jsx-a11y: 6.4.1_eslint@7.29.0
+      eslint-plugin-react: 7.24.0_eslint@7.29.0
+      eslint-plugin-react-hooks: 4.2.0_eslint@7.29.0
+      eslint-plugin-testing-library: 3.10.1_eslint@7.29.0+typescript@4.6.3
+      eslint-webpack-plugin: 2.4.1_eslint@7.29.0+webpack@4.44.2
+      file-loader: 6.1.1_webpack@4.44.2
+      fs-extra: 9.1.0
+      html-webpack-plugin: 4.5.0_webpack@4.44.2
+      identity-obj-proxy: 3.0.0
+      jest: 26.6.0_canvas@2.9.1
+      jest-circus: 26.6.0_canvas@2.9.1
+      jest-resolve: 26.6.0
+      jest-watch-typeahead: 0.6.1_jest@26.6.0
+      mini-css-extract-plugin: 0.11.3_webpack@4.44.2
+      optimize-css-assets-webpack-plugin: 5.0.4_webpack@4.44.2
+      pnp-webpack-plugin: 1.6.4_typescript@4.6.3
+      postcss-flexbugs-fixes: 4.2.1
+      postcss-loader: 3.0.0
+      postcss-normalize: 8.0.1
+      postcss-preset-env: 6.7.0
+      postcss-safe-parser: 5.0.2
+      prompts: 2.4.0
+      react-app-polyfill: 2.0.0
+      react-dev-utils: 11.0.3
+      react-refresh: 0.8.3
+      resolve: 1.18.1
+      resolve-url-loader: 3.1.2
+      sass-loader: 8.0.2_webpack@4.44.2
+      semver: 7.3.2
+      style-loader: 1.3.0_webpack@4.44.2
+      terser-webpack-plugin: 4.2.3_webpack@4.44.2
+      ts-pnp: 1.2.0_typescript@4.6.3
+      typescript: 4.6.3
+      url-loader: 4.1.1_file-loader@6.1.1+webpack@4.44.2
+      webpack: 4.44.2
+      webpack-dev-server: 3.11.0_webpack@4.44.2
+      webpack-manifest-plugin: 2.2.0_webpack@4.44.2
+      workbox-webpack-plugin: 5.1.4_webpack@4.44.2
+    dev: false
+    engines:
+      node: ^10.12.0 || >=12.0.0
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
+    peerDependencies:
+      canvas: '*'
+      typescript: ^3.2.1
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    resolution:
+      integrity: sha512-NnniMSC/wjwhcJAyPJCWtxx6CWONqgvGgV9+QXj1bwoW/JI++YF1eEf3Upf/mQ9KmP57IBdjzWs1XvnPq7qMTQ==
   /react-scripts/4.0.1_typescript@4.6.3:
     dependencies:
       '@babel/core': 7.12.3
@@ -31022,7 +31446,7 @@ packages:
       bs-logger: 0.2.6
       buffer-from: 1.1.1
       fast-json-stable-stringify: 2.1.0
-      jest: 26.6.3
+      jest: 26.6.3_canvas@2.9.1
       jest-util: 26.6.2
       json5: 2.1.3
       lodash.memoize: 4.1.2


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
They were broken by votingworks/kiosk-browser#120. The fix for that bug, votingworks/kiosk-browser#121, changed the API a bit: `kiosk.devices` is no longer an RxJS observable, but a custom simpler object with a similar but smaller API.

## Demo Video or Screenshot
n/a

## Testing Plan 
Tested manually in Election Manager + kiosk-browser with votingworks/kiosk-browser#121.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
