### PR TITLE
feat(admin): Hit /admin/write-ins/transcribe endpoint when clicking previously-transcribed value

### DIFF
--- a/frontends/election-manager/prodserver/setupProxy.js
+++ b/frontends/election-manager/prodserver/setupProxy.js
@@ -14,6 +14,7 @@ const { dirname, join } = require('path');
 module.exports = function (app) {
   app.use(proxy('/card', { target: 'http://localhost:3001/' }));
   app.use(proxy('/convert', { target: 'http://localhost:3003/' }));
+  app.use(proxy('/admin', { target: 'http://localhost:3004/' }));
 
   app.get('/machine-config', (req, res) => {
     res.json({

--- a/frontends/election-manager/src/app_root.tsx
+++ b/frontends/election-manager/src/app_root.tsx
@@ -14,6 +14,8 @@ import {
   LogDispositionStandardTypes,
 } from '@votingworks/logging';
 import {
+  BallotId,
+  ContestId,
   ElectionDefinition,
   safeParseElection,
   FullElectionExternalTally,
@@ -290,6 +292,28 @@ export function AppRoot({
     await savePrintedBallots(ballots);
     setPrintedBallots(ballots);
   }
+
+  const saveTranscribedValue = useCallback(
+    async (
+      ballotId: BallotId,
+      contestId: ContestId,
+      transcribedValue: string
+    ) => {
+      try {
+        await fetch(`/admin/write-ins/transcribe`, {
+          method: 'POST',
+          body: JSON.stringify({ ballotId, contestId, transcribedValue }),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+      } catch (error) {
+        assert(error instanceof Error);
+        throw error;
+      }
+    },
+    []
+  );
 
   useEffect(() => {
     void (async () => {
@@ -615,6 +639,7 @@ export function AppRoot({
         setFullElectionTally,
         fullElectionExternalTallies,
         saveExternalTallies,
+        saveTranscribedValue,
         isTabulationRunning,
         setIsTabulationRunning,
         generateExportableTallies,

--- a/frontends/election-manager/src/contexts/app_context.ts
+++ b/frontends/election-manager/src/contexts/app_context.ts
@@ -1,5 +1,7 @@
 import { createContext, RefObject } from 'react';
 import {
+  BallotId,
+  ContestId,
   ElectionDefinition,
   FullElectionTally,
   FullElectionExternalTally,
@@ -49,6 +51,11 @@ export interface AppContextInterface {
   saveExternalTallies: (
     externalTallies: FullElectionExternalTally[]
   ) => Promise<void>;
+  saveTranscribedValue: (
+    ballotId: BallotId,
+    contestId: ContestId,
+    transcribedValue: string
+  ) => Promise<void>;
   setIsTabulationRunning: React.Dispatch<React.SetStateAction<boolean>>;
   generateExportableTallies: () => ExportableTallies;
   currentUserSession?: UserSession;
@@ -80,6 +87,7 @@ const appContext: AppContextInterface = {
   fullElectionExternalTallies: [],
   setFullElectionTally: () => undefined,
   saveExternalTallies: async () => undefined,
+  saveTranscribedValue: async () => undefined,
   isTabulationRunning: false,
   setIsTabulationRunning: () => undefined,
   generateExportableTallies: getEmptyExportableTallies,

--- a/frontends/election-manager/src/screens/write_ins_screen.tsx
+++ b/frontends/election-manager/src/screens/write_ins_screen.tsx
@@ -14,7 +14,8 @@ import { WriteInsTranscriptionScreen } from './write_ins_transcription_screen';
 import { AppContext } from '../contexts/app_context';
 
 export function WriteInsScreen(): JSX.Element {
-  const { castVoteRecordFiles, electionDefinition } = useContext(AppContext);
+  const { castVoteRecordFiles, electionDefinition, saveTranscribedValue } =
+    useContext(AppContext);
   const election = electionDefinition?.election;
   const castVoteRecordFileList = castVoteRecordFiles.fileList;
   const hasCastVoteRecordFiles =
@@ -130,7 +131,7 @@ export function WriteInsScreen(): JSX.Element {
                         )
                     : undefined
                 }
-                saveTranscribedValue={placeholderFn}
+                saveTranscribedValue={saveTranscribedValue}
               />
             }
             fullscreen

--- a/frontends/election-manager/src/screens/write_ins_transcription_screen.test.tsx
+++ b/frontends/election-manager/src/screens/write_ins_transcription_screen.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react';
 import React from 'react';
 import { electionMinimalExhaustiveSampleDefinition as electionDefinition } from '@votingworks/fixtures';
-import { CandidateContest } from '@votingworks/types';
+import { CandidateContest, CastVoteRecord } from '@votingworks/types';
 import { renderInAppContext } from '../../test/render_in_app_context';
 import { WriteInsTranscriptionScreen } from './write_ins_transcription_screen';
 
@@ -13,12 +13,43 @@ test('write-ins screen', () => {
   const onListAll = jest.fn();
   const saveTranscribedValue = jest.fn();
 
+  const ballotsBeingAdjudicated = [
+    {
+      _ballotId: 'id-174',
+      _ballotType: 'absentee',
+      _precinctId: 'precinct-1',
+      _ballotStyleId: '3C',
+      _testBallot: true,
+      _scannerId: 'scanner-1',
+      _batchId: '1234-1',
+      _batchLabel: 'Batch 1',
+      'governor-contest-constitution': ['write-in-0'],
+      'mayor-contest-constitution': ['write-in-0'],
+      'chief-pokemon-constitution': ['flareon', 'umbreon', 'vaporeon'],
+      'schoolboard-constitution': ['aras-baskauskas', 'yul-kwon', 'earl-cole'],
+    },
+    {
+      _ballotId: 'id-188',
+      _ballotType: 'absentee',
+      _precinctId: 'precinct-1',
+      _ballotStyleId: '3C',
+      _testBallot: true,
+      _scannerId: 'scanner-2',
+      _batchId: '1234-3',
+      _batchLabel: 'Batch 1',
+      'governor-contest-constitution': ['write-in-0'],
+      'mayor-contest-constitution': ['write-in-0'],
+      'chief-pokemon-constitution': ['flareon', 'umbreon', 'vaporeon'],
+      'schoolboard-constitution': ['aras-baskauskas', 'yul-kwon', 'earl-cole'],
+    },
+  ] as unknown as CastVoteRecord[];
+
   renderInAppContext(
     <WriteInsTranscriptionScreen
       election={electionDefinition.election}
       contest={contest}
       ballotIdxBeingAdjudicated={0}
-      ballotsBeingAdjudicated={[]}
+      ballotsBeingAdjudicated={ballotsBeingAdjudicated}
       onClickNext={onClickNext}
       onClickPrevious={onClickPrevious}
       onClose={onClose}
@@ -29,8 +60,13 @@ test('write-ins screen', () => {
   );
   screen.getByText('BALLOT IMAGES GO HERE');
 
+  // Click a previously-saved transcription
   screen.getByText('Mickey Mouse').click();
-  expect(saveTranscribedValue).toHaveBeenCalledWith('Mickey Mouse');
+  expect(saveTranscribedValue).toHaveBeenCalledWith(
+    'id-174',
+    'best-animal-mammal',
+    'Mickey Mouse'
+  );
 
   screen.getByText('List All').click();
   expect(onListAll).toHaveBeenCalledTimes(1);

--- a/frontends/election-manager/src/screens/write_ins_transcription_screen.test.tsx
+++ b/frontends/election-manager/src/screens/write_ins_transcription_screen.test.tsx
@@ -13,9 +13,9 @@ test('write-ins screen', () => {
   const onListAll = jest.fn();
   const saveTranscribedValue = jest.fn();
 
-  const ballotsBeingAdjudicated = [
+  const ballotsBeingAdjudicated: CastVoteRecord[] = [
     {
-      _ballotId: 'id-174',
+      _ballotId: unsafeParse(BallotIdSchema, 'id-174'),
       _ballotType: 'absentee',
       _precinctId: 'precinct-1',
       _ballotStyleId: '3C',
@@ -29,7 +29,7 @@ test('write-ins screen', () => {
       'schoolboard-constitution': ['aras-baskauskas', 'yul-kwon', 'earl-cole'],
     },
     {
-      _ballotId: 'id-188',
+      _ballotId: unsafeParse(BallotIdSchema, 'id-188'),
       _ballotType: 'absentee',
       _precinctId: 'precinct-1',
       _ballotStyleId: '3C',
@@ -42,7 +42,7 @@ test('write-ins screen', () => {
       'chief-pokemon-constitution': ['flareon', 'umbreon', 'vaporeon'],
       'schoolboard-constitution': ['aras-baskauskas', 'yul-kwon', 'earl-cole'],
     },
-  ] as unknown as CastVoteRecord[];
+  ];
 
   renderInAppContext(
     <WriteInsTranscriptionScreen

--- a/frontends/election-manager/src/screens/write_ins_transcription_screen.test.tsx
+++ b/frontends/election-manager/src/screens/write_ins_transcription_screen.test.tsx
@@ -1,7 +1,12 @@
 import { screen } from '@testing-library/react';
 import React from 'react';
 import { electionMinimalExhaustiveSampleDefinition as electionDefinition } from '@votingworks/fixtures';
-import { CandidateContest, CastVoteRecord } from '@votingworks/types';
+import {
+  BallotIdSchema,
+  CandidateContest,
+  CastVoteRecord,
+  unsafeParse,
+} from '@votingworks/types';
 import { renderInAppContext } from '../../test/render_in_app_context';
 import { WriteInsTranscriptionScreen } from './write_ins_transcription_screen';
 

--- a/frontends/election-manager/src/screens/write_ins_transcription_screen.tsx
+++ b/frontends/election-manager/src/screens/write_ins_transcription_screen.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import styled from 'styled-components';
 
 import {
+  BallotId,
+  ContestId,
   CandidateContest,
   CastVoteRecord,
   Election,
@@ -47,35 +49,6 @@ const TranscriptionPaginationContainer = styled.div`
   padding: 0.5rem 1rem;
 `;
 
-function PreviouslyTranscribedValues({
-  saveTranscribedValue,
-}: {
-  saveTranscribedValue: (transcribedValue: string) => void;
-}) {
-  const previouslyTranscribedValues = [
-    'Mickey Mouse',
-    'Mickey M',
-    'Micky',
-    'Donald',
-    'Donald Duck',
-    'Roger Rabbit',
-    'RR',
-    'DD',
-    'M. Mouse',
-  ];
-  return (
-    <PreviouslyTranscribedValuesContainer>
-      {previouslyTranscribedValues.map((transcribedValue) => (
-        <PreviouslyTranscribedValueButtonWrapper key={transcribedValue}>
-          <Button onPress={() => saveTranscribedValue(transcribedValue)}>
-            {transcribedValue}
-          </Button>
-        </PreviouslyTranscribedValueButtonWrapper>
-      ))}
-    </PreviouslyTranscribedValuesContainer>
-  );
-}
-
 /* isntabul ignore next */
 function noop() {
   // nothing to do
@@ -100,10 +73,28 @@ export function WriteInsTranscriptionScreen({
   onClickPrevious?: () => void;
   onClose: () => void;
   onListAll: () => void;
-  saveTranscribedValue: (transcribedValue: string) => void;
+  saveTranscribedValue: (
+    ballotId: BallotId,
+    contestId: ContestId,
+    transcribedValue: string
+  ) => void;
 }): JSX.Element {
+  const previouslyTranscribedValues = [
+    'Mickey Mouse',
+    'Mickey M',
+    'Micky',
+    'Donald',
+    'Donald Duck',
+    'Roger Rabbit',
+    'RR',
+    'DD',
+    'M. Mouse',
+  ];
+
   assert(contest);
   assert(election);
+  const currentBallot = ballotsBeingAdjudicated[ballotIdxBeingAdjudicated];
+  const ballotId = currentBallot._ballotId as BallotId;
   return (
     <Screen>
       <Navigation
@@ -140,24 +131,23 @@ export function WriteInsTranscriptionScreen({
               <label htmlFor="transcription-value">Transcribed Value</label>
             </Text>
             <TextInput id="transcribed-value" name="transcribed-value" />
-            <PreviouslyTranscribedValues
-              saveTranscribedValue={saveTranscribedValue}
-            />
-            <p>Here</p>
-            <p>are</p>
-            <p>a</p>
-            <p>bunch</p>
-            <p>of</p>
-            <p>paragraphs</p>
-            <p>to</p>
-            <p>make</p>
-            <p>the</p>
-            <p>container</p>
-            <p>container</p>
-            <p>container</p>
-            <p>container</p>
-            <p>container</p>
-            <p>overflow.</p>
+            <PreviouslyTranscribedValuesContainer>
+              {previouslyTranscribedValues.map((transcribedValue) => (
+                <PreviouslyTranscribedValueButtonWrapper key={transcribedValue}>
+                  <Button
+                    onPress={() =>
+                      saveTranscribedValue(
+                        ballotId,
+                        contest.id,
+                        transcribedValue
+                      )
+                    }
+                  >
+                    {transcribedValue}
+                  </Button>
+                </PreviouslyTranscribedValueButtonWrapper>
+              ))}
+            </PreviouslyTranscribedValuesContainer>
           </TranscriptionMainContentContainer>
           <TranscriptionPaginationContainer>
             <Button

--- a/frontends/election-manager/test/render_in_app_context.tsx
+++ b/frontends/election-manager/test/render_in_app_context.tsx
@@ -5,6 +5,8 @@ import { render as testRender, RenderResult } from '@testing-library/react';
 
 import { electionWithMsEitherNeitherDefinition } from '@votingworks/fixtures';
 import {
+  BallotId,
+  ContestId,
   ElectionDefinition,
   FullElectionTally,
   FullElectionExternalTally,
@@ -41,6 +43,11 @@ interface RenderInAppContextParams {
   printBallotRef?: RefObject<HTMLElement>;
   saveCastVoteRecordFiles?: SaveCastVoteRecordFiles;
   saveElection?: SaveElection;
+  saveTranscribedValue?: (
+    ballotId: BallotId,
+    contestId: ContestId,
+    transcribedValue: string
+  ) => Promise<void>;
   setCastVoteRecordFiles?: React.Dispatch<
     React.SetStateAction<CastVoteRecordFiles>
   >;
@@ -95,6 +102,7 @@ export function renderInAppContext(
     setIsTabulationRunning = jest.fn(),
     saveExternalTallies = jest.fn(),
     fullElectionExternalTallies = [],
+    saveTranscribedValue = jest.fn(),
     generateExportableTallies = jest.fn(),
     currentUserSession = { type: 'admin', authenticated: true },
     attemptToAuthenticateAdminUser = jest.fn(),
@@ -132,6 +140,7 @@ export function renderInAppContext(
         saveExternalTallies,
         fullElectionExternalTallies,
         generateExportableTallies,
+        saveTranscribedValue,
         currentUserSession,
         attemptToAuthenticateAdminUser,
         lockMachine,


### PR DESCRIPTION
## Overview
Closes #1881 

This wires up the buttons for previously-transcribed values to hit an endpoint in `services/admin` that does not yet exist (forthcoming in #1882).

Once #1882 and #1885 are complete, I will make these buttons retain a selected/pressed state to reflect the current transcribed value for the write-in.

## Demo Video or Screenshot

## Testing Plan 
Manual and added browser tests.

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
