### PR TITLE
Best-effort collate L&A packages when HMPBs aren't letter-size

### DIFF
--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -347,7 +347,7 @@ test('L&A (logic and accuracy) flow', async () => {
   userEvent.click(screen.getByText('District 5'));
 
   // L&A package: Tally report
-  await screen.findByText('Printing L&A Package: District 5', {
+  await screen.findByText('Printing L&A Package for District 5', {
     exact: false,
   });
   expect(printer.print).toHaveBeenCalledTimes(2);
@@ -360,7 +360,7 @@ test('L&A (logic and accuracy) flow', async () => {
   jest.advanceTimersByTime(5000);
 
   // L&A package: BMD test deck
-  await screen.findByText('Printing L&A Package: District 5', {
+  await screen.findByText('Printing L&A Package for District 5', {
     exact: false,
   });
   expect(printer.print).toHaveBeenCalledTimes(3);
@@ -376,7 +376,7 @@ test('L&A (logic and accuracy) flow', async () => {
   jest.advanceTimersByTime(30000);
 
   // L&A package: HMPB test deck
-  await screen.findByText('Printing L&A Package: District 5', {
+  await screen.findByText('Printing L&A Package for District 5', {
     exact: false,
   });
   expect(printer.print).toHaveBeenCalledTimes(4);

--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -324,7 +324,7 @@ test('L&A (logic and accuracy) flow', async () => {
   const { container } = render(
     <App card={card} hardware={hardware} printer={printer} storage={storage} />
   );
-  jest.advanceTimersByTime(2001); // Cause the usb drive to be detected
+  jest.advanceTimersByTime(2000); // Cause the usb drive to be detected
   await authenticateWithAdminCard(card);
 
   // Test printing zero report
@@ -403,7 +403,7 @@ test('printing ballots and printed ballots report', async () => {
   const { getByText, getAllByText, queryAllByText, getAllByTestId } = render(
     <App storage={storage} printer={printer} card={card} hardware={hardware} />
   );
-  jest.advanceTimersByTime(2001); // Cause the usb drive to be detected
+  jest.advanceTimersByTime(2000); // Cause the usb drive to be detected
   await authenticateWithAdminCard(card);
 
   await screen.findByText('0 official ballots');
@@ -475,7 +475,7 @@ test('tabulating CVRs', async () => {
   const { getByText, getAllByText, getByTestId, findByText } = render(
     <App storage={storage} card={card} hardware={hardware} printer={printer} />
   );
-  jest.advanceTimersByTime(2001); // Cause the usb drive to be detected
+  jest.advanceTimersByTime(2000); // Cause the usb drive to be detected
   await authenticateWithAdminCard(card);
 
   await screen.findByText('0 official ballots');
@@ -513,7 +513,7 @@ test('tabulating CVRs', async () => {
   fireEvent.click(getByText('Show Results by Batch and Scanner'));
   getByText('Batch Name');
   fireEvent.click(getByText('Export Batch Results as CSV'));
-  jest.advanceTimersByTime(2001);
+  jest.advanceTimersByTime(2000);
   getByText('Save Batch Results');
   getByText(/Save the election batch results as /);
   getByText(
@@ -522,7 +522,7 @@ test('tabulating CVRs', async () => {
 
   fireEvent.click(getByText('Save'));
   await waitFor(() => getByText(/Saving/));
-  jest.advanceTimersByTime(2001);
+  jest.advanceTimersByTime(2000);
   await waitFor(() => getByText(/Batch Results Saved/));
   await waitFor(() => {
     expect(mockKiosk.writeFile).toHaveBeenCalledTimes(1);
@@ -572,7 +572,7 @@ test('tabulating CVRs', async () => {
   fireEvent.click(getByText('Tally'));
   await waitFor(() => getByText('Save Results File'));
   fireEvent.click(getByText('Save Results File'));
-  jest.advanceTimersByTime(2001);
+  jest.advanceTimersByTime(2000);
   getByText('Save Results');
   getByText(/Save the election results as /);
   getByText(
@@ -581,7 +581,7 @@ test('tabulating CVRs', async () => {
 
   fireEvent.click(getByText('Save'));
   await waitFor(() => getByText(/Saving/));
-  jest.advanceTimersByTime(2001);
+  jest.advanceTimersByTime(2000);
   await waitFor(() => getByText(/Results Saved/));
   await waitFor(() => {
     expect(mockKiosk.writeFile).toHaveBeenCalledTimes(2);
@@ -660,7 +660,7 @@ test('tabulating CVRs with SEMS file', async () => {
   const { getByText, getByTestId, getAllByTestId, getAllByText } = render(
     <App storage={storage} card={card} hardware={hardware} />
   );
-  jest.advanceTimersByTime(2001);
+  jest.advanceTimersByTime(2000);
   await authenticateWithAdminCard(card);
 
   await screen.findByText('0 official ballots');
@@ -702,7 +702,7 @@ test('tabulating CVRs with SEMS file', async () => {
   fetchMock.post('/convert/reset', { body: { status: 'ok' } });
   await waitFor(() => getByText('Save Results File'));
   fireEvent.click(getByText('Save Results File'));
-  jest.advanceTimersByTime(2001);
+  jest.advanceTimersByTime(2000);
   getByText('Save Results');
   getByText(/Save the election results as /);
   getByText(
@@ -711,7 +711,7 @@ test('tabulating CVRs with SEMS file', async () => {
 
   fireEvent.click(getByText('Save'));
   await waitFor(() => getByText(/Saving/));
-  jest.advanceTimersByTime(2001);
+  jest.advanceTimersByTime(2000);
   await waitFor(() => getByText(/Results Saved/));
   await waitFor(() => {
     expect(mockKiosk.writeFile).toHaveBeenCalledTimes(1);

--- a/frontends/election-manager/src/components/export_logs_modal.test.tsx
+++ b/frontends/election-manager/src/components/export_logs_modal.test.tsx
@@ -139,7 +139,7 @@ test('renders save modal when usb is mounted and saves log file on machine', asy
   fireEvent.click(getByText('Save'));
   await waitFor(() => getByText(/Saving Logs/));
   expect(mockKiosk.readFile).toHaveBeenCalled();
-  jest.advanceTimersByTime(2001);
+  jest.advanceTimersByTime(2000);
   await waitFor(() => getByText(/Logs Saved/));
   await waitFor(() => {
     expect(mockKiosk.writeFile).toHaveBeenCalledTimes(1);
@@ -198,7 +198,7 @@ test('renders save modal when usb is mounted and saves cdf log file on machine',
   fireEvent.click(getByText('Save'));
   await waitFor(() => getByText(/Saving Logs/));
   expect(mockKiosk.readFile).toHaveBeenCalled();
-  jest.advanceTimersByTime(2001);
+  jest.advanceTimersByTime(2000);
   await waitFor(() => getByText(/Logs Saved/));
   await waitFor(() => {
     expect(mockKiosk.writeFile).toHaveBeenCalledTimes(1);

--- a/frontends/election-manager/src/components/hand_marked_paper_ballot.tsx
+++ b/frontends/election-manager/src/components/hand_marked_paper_ballot.tsx
@@ -48,7 +48,7 @@ import { BubbleMark } from './bubble_mark';
 import { WriteInLine } from './write_in_line';
 import { HorizontalRule } from './horizontal_rule';
 import { ABSENTEE_TINT_COLOR } from '../config/globals';
-import { getBallotLayoutPageSize } from '../utils/get_ballot_layout_page_size';
+import { getBallotLayoutPageSizeStr } from '../utils/get_ballot_layout_page_size';
 import { getBallotLayoutDensity } from '../utils/get_ballot_layout_density';
 
 function hasVote(
@@ -620,7 +620,7 @@ export function HandMarkedPaperBallot({
     }
 
     const ballotStylesheets = [
-      `/ballot/ballot-layout-paper-size-${getBallotLayoutPageSize(
+      `/ballot/ballot-layout-paper-size-${getBallotLayoutPageSizeStr(
         election
       )}.css`,
       '/ballot/ballot.css',

--- a/frontends/election-manager/src/components/hand_marked_paper_ballot.tsx
+++ b/frontends/election-manager/src/components/hand_marked_paper_ballot.tsx
@@ -48,7 +48,7 @@ import { BubbleMark } from './bubble_mark';
 import { WriteInLine } from './write_in_line';
 import { HorizontalRule } from './horizontal_rule';
 import { ABSENTEE_TINT_COLOR } from '../config/globals';
-import { getBallotLayoutPageSizeReadableString } from '../utils/get_ballot_layout_page_size';
+import { getBallotLayoutPageSize } from '../utils/get_ballot_layout_page_size';
 import { getBallotLayoutDensity } from '../utils/get_ballot_layout_density';
 
 function hasVote(
@@ -620,7 +620,7 @@ export function HandMarkedPaperBallot({
     }
 
     const ballotStylesheets = [
-      `/ballot/ballot-layout-paper-size-${getBallotLayoutPageSizeReadableString(
+      `/ballot/ballot-layout-paper-size-${getBallotLayoutPageSize(
         election
       )}.css`,
       '/ballot/ballot.css',

--- a/frontends/election-manager/src/components/hand_marked_paper_ballot.tsx
+++ b/frontends/election-manager/src/components/hand_marked_paper_ballot.tsx
@@ -48,7 +48,7 @@ import { BubbleMark } from './bubble_mark';
 import { WriteInLine } from './write_in_line';
 import { HorizontalRule } from './horizontal_rule';
 import { ABSENTEE_TINT_COLOR } from '../config/globals';
-import { getBallotLayoutPageSizeStr } from '../utils/get_ballot_layout_page_size';
+import { getBallotLayoutPageSizeReadableString } from '../utils/get_ballot_layout_page_size';
 import { getBallotLayoutDensity } from '../utils/get_ballot_layout_density';
 
 function hasVote(
@@ -620,7 +620,7 @@ export function HandMarkedPaperBallot({
     }
 
     const ballotStylesheets = [
-      `/ballot/ballot-layout-paper-size-${getBallotLayoutPageSizeStr(
+      `/ballot/ballot-layout-paper-size-${getBallotLayoutPageSizeReadableString(
         election
       )}.css`,
       '/ballot/ballot.css',

--- a/frontends/election-manager/src/components/loading.tsx
+++ b/frontends/election-manager/src/components/loading.tsx
@@ -14,27 +14,28 @@ interface Props {
   children?: string | string[];
   isFullscreen?: boolean;
   as?: keyof JSX.IntrinsicElements;
+  wrapInProse?: boolean;
 }
 
 export function Loading({
   as = 'h1',
   children = 'Loading',
   isFullscreen = false,
+  wrapInProse = true,
 }: Props): JSX.Element {
-  const content = (
-    <Prose>
-      <ProgressEllipsis
-        as={as}
-        aria-label={`${
-          Array.isArray(children) ? children.join('') : children
-        }.`}
-      >
-        {children}
-      </ProgressEllipsis>
-    </Prose>
+  let content = (
+    <ProgressEllipsis
+      as={as}
+      aria-label={`${Array.isArray(children) ? children.join('') : children}.`}
+    >
+      {children}
+    </ProgressEllipsis>
   );
+  if (wrapInProse) {
+    content = <Prose>{content}</Prose>;
+  }
   if (isFullscreen) {
-    return <Fullscreen>{content}</Fullscreen>;
+    content = <Fullscreen>{content}</Fullscreen>;
   }
   return content;
 }

--- a/frontends/election-manager/src/components/save_file_to_usb.test.tsx
+++ b/frontends/election-manager/src/components/save_file_to_usb.test.tsx
@@ -97,7 +97,7 @@ test('renders save screen when usb is mounted with ballot filetype', async () =>
   fireEvent.click(getByText('Save'));
   await waitFor(() => getByText(/Saving Ballot/));
   expect(fileContentFn).toHaveBeenCalled();
-  jest.advanceTimersByTime(2001);
+  jest.advanceTimersByTime(2000);
   await waitFor(() => getByText(/Ballot Saved/));
   await waitFor(() => {
     expect(mockKiosk.writeFile).toHaveBeenCalledTimes(1);
@@ -157,7 +157,7 @@ test('renders save screen when usb is mounted with results filetype and prompts 
   fireEvent.click(getByText('Save'));
   await waitFor(() => getByText(/Saving Results/));
   expect(fileContentFn).toHaveBeenCalled();
-  jest.advanceTimersByTime(2001);
+  jest.advanceTimersByTime(2000);
   await waitFor(() => getByText(/Results Saved/));
   getByText(/Election results successfully saved/);
   await waitFor(() => {

--- a/frontends/election-manager/src/screens/ballot_screen.tsx
+++ b/frontends/election-manager/src/screens/ballot_screen.tsx
@@ -35,7 +35,7 @@ import { DEFAULT_LOCALE } from '../config/globals';
 import { routerPaths } from '../router_paths';
 import { TextInput } from '../components/text_input';
 import { LinkButton } from '../components/link_button';
-import { getBallotLayoutPageSize } from '../utils/get_ballot_layout_page_size';
+import { getBallotLayoutPageSizeStr } from '../utils/get_ballot_layout_page_size';
 import { generateFileContentToSaveAsPdf } from '../utils/save_as_pdf';
 import { SaveFileToUsb, FileType } from '../components/save_file_to_usb';
 
@@ -327,7 +327,8 @@ export function BallotScreen(): JSX.Element {
               This ballot is <strong>{ballotPages} pages</strong> (printed front
               and back) on{' '}
               <strong>{pluralize('sheets', ballotPages / 2, true)}</strong> of{' '}
-              <strong>{getBallotLayoutPageSize(election)}-size</strong> paper.
+              <strong>{getBallotLayoutPageSizeStr(election)}-size</strong>{' '}
+              paper.
             </p>
           )}
         </Prose>

--- a/frontends/election-manager/src/screens/ballot_screen.tsx
+++ b/frontends/election-manager/src/screens/ballot_screen.tsx
@@ -35,7 +35,7 @@ import { DEFAULT_LOCALE } from '../config/globals';
 import { routerPaths } from '../router_paths';
 import { TextInput } from '../components/text_input';
 import { LinkButton } from '../components/link_button';
-import { getBallotLayoutPageSizeStr } from '../utils/get_ballot_layout_page_size';
+import { getBallotLayoutPageSizeReadableString } from '../utils/get_ballot_layout_page_size';
 import { generateFileContentToSaveAsPdf } from '../utils/save_as_pdf';
 import { SaveFileToUsb, FileType } from '../components/save_file_to_usb';
 
@@ -327,7 +327,9 @@ export function BallotScreen(): JSX.Element {
               This ballot is <strong>{ballotPages} pages</strong> (printed front
               and back) on{' '}
               <strong>{pluralize('sheets', ballotPages / 2, true)}</strong> of{' '}
-              <strong>{getBallotLayoutPageSizeStr(election)}-size</strong>{' '}
+              <strong>
+                {getBallotLayoutPageSizeReadableString(election)}-size
+              </strong>{' '}
               paper.
             </p>
           )}

--- a/frontends/election-manager/src/screens/print_test_deck_screen.test.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.test.tsx
@@ -53,8 +53,7 @@ test('Printing L&A package for one precinct', async () => {
 
   userEvent.click(screen.getByText('District 5'));
 
-  const printText = 'Printing L&A Package: District 5';
-  await screen.findByText(printText);
+  await screen.findByText('Printing L&A Package for District 5');
   await waitFor(() => expect(mockPrinter.print).toHaveBeenCalledTimes(1));
   expect(mockPrinter.print).toHaveBeenLastCalledWith({ sides: 'one-sided' });
   await waitFor(() =>
@@ -64,7 +63,7 @@ test('Printing L&A package for one precinct', async () => {
   );
   jest.advanceTimersByTime(ONE_SIDED_PAGE_PRINT_TIME_MS);
 
-  await screen.findByText(printText);
+  await screen.findByText('Printing L&A Package for District 5');
   await waitFor(() => expect(mockPrinter.print).toHaveBeenCalledTimes(2));
   expect(mockPrinter.print).toHaveBeenLastCalledWith({ sides: 'one-sided' });
   await waitFor(() =>
@@ -77,7 +76,7 @@ test('Printing L&A package for one precinct', async () => {
   );
   jest.advanceTimersByTime(3 * ONE_SIDED_PAGE_PRINT_TIME_MS);
 
-  await screen.findByText(printText);
+  await screen.findByText('Printing L&A Package for District 5');
   await waitFor(() => expect(mockPrinter.print).toHaveBeenCalledTimes(3));
   expect(mockPrinter.print).toHaveBeenLastCalledWith({
     sides: 'two-sided-long-edge',
@@ -123,8 +122,8 @@ test('Printing L&A packages for all precincts', async () => {
   ];
 
   for (const [i, precinct] of precinctsInAlphabeticalOrder.entries()) {
-    const printText = `Printing L&A Package (${i + 1} of 13): ${precinct}`;
-    await screen.findByText(printText);
+    await screen.findByText(`Printing L&A Package for ${precinct}`);
+    await screen.findByText(`This is package ${i + 1} of 13.`);
     await waitFor(() =>
       expect(mockPrinter.print).toHaveBeenCalledTimes(3 * i + 1)
     );
@@ -136,7 +135,8 @@ test('Printing L&A packages for all precincts', async () => {
     );
     jest.advanceTimersByTime(ONE_SIDED_PAGE_PRINT_TIME_MS);
 
-    await screen.findByText(printText);
+    await screen.findByText(`Printing L&A Package for ${precinct}`);
+    await screen.findByText(`This is package ${i + 1} of 13.`);
     await waitFor(() =>
       expect(mockPrinter.print).toHaveBeenCalledTimes(3 * i + 2)
     );
@@ -151,7 +151,8 @@ test('Printing L&A packages for all precincts', async () => {
     );
     jest.advanceTimersByTime(3 * ONE_SIDED_PAGE_PRINT_TIME_MS);
 
-    await screen.findByText(printText);
+    await screen.findByText(`Printing L&A Package for ${precinct}`);
+    await screen.findByText(`This is package ${i + 1} of 13.`);
     await waitFor(() =>
       expect(mockPrinter.print).toHaveBeenCalledTimes(3 * i + 3)
     );
@@ -194,8 +195,8 @@ test('Printing L&A package for one precinct, when HMPBs are not letter-size', as
 
   userEvent.click(screen.getByText('District 5'));
 
-  const printText = 'Printing L&A Package: District 5';
-  await screen.findByText(printText);
+  await screen.findByText('Printing L&A Package for District 5');
+  await screen.findByText('Currently printing letter-size pages');
   await waitFor(() => expect(mockPrinter.print).toHaveBeenCalledTimes(1));
   expect(mockPrinter.print).toHaveBeenLastCalledWith({ sides: 'one-sided' });
   await waitFor(() =>
@@ -205,7 +206,8 @@ test('Printing L&A package for one precinct, when HMPBs are not letter-size', as
   );
   jest.advanceTimersByTime(ONE_SIDED_PAGE_PRINT_TIME_MS);
 
-  await screen.findByText(printText);
+  await screen.findByText('Printing L&A Package for District 5');
+  await screen.findByText('Currently printing letter-size pages');
   await waitFor(() => expect(mockPrinter.print).toHaveBeenCalledTimes(2));
   expect(mockPrinter.print).toHaveBeenLastCalledWith({ sides: 'one-sided' });
   await waitFor(() =>
@@ -222,7 +224,8 @@ test('Printing L&A package for one precinct, when HMPBs are not letter-size', as
     await screen.findByText('Legal Paper Loaded, Continue Printing')
   );
 
-  await screen.findByText(printText);
+  await screen.findByText('Printing L&A Package for District 5');
+  await screen.findByText('Currently printing legal-size pages');
   await waitFor(() => expect(mockPrinter.print).toHaveBeenCalledTimes(3));
   expect(mockPrinter.print).toHaveBeenLastCalledWith({
     sides: 'two-sided-long-edge',
@@ -276,8 +279,9 @@ test('Printing L&A packages for all precincts, when HMPBs are not letter-size', 
   ];
 
   for (const [i, precinct] of precinctsInAlphabeticalOrder.entries()) {
-    const printText = `Printing L&A Package (${i + 1} of 13): ${precinct}`;
-    await screen.findByText(printText);
+    await screen.findByText(`Printing L&A Package for ${precinct}`);
+    await screen.findByText(`This is package ${i + 1} of 13.`);
+    await screen.findByText('Currently printing letter-size pages');
     await waitFor(() =>
       expect(mockPrinter.print).toHaveBeenCalledTimes(2 * i + 1)
     );
@@ -289,7 +293,9 @@ test('Printing L&A packages for all precincts, when HMPBs are not letter-size', 
     );
     jest.advanceTimersByTime(ONE_SIDED_PAGE_PRINT_TIME_MS);
 
-    await screen.findByText(printText);
+    await screen.findByText(`Printing L&A Package for ${precinct}`);
+    await screen.findByText(`This is package ${i + 1} of 13.`);
+    await screen.findByText('Currently printing letter-size pages');
     await waitFor(() =>
       expect(mockPrinter.print).toHaveBeenCalledTimes(2 * i + 2)
     );
@@ -310,8 +316,9 @@ test('Printing L&A packages for all precincts, when HMPBs are not letter-size', 
   );
 
   for (const [i, precinct] of precinctsInAlphabeticalOrder.entries()) {
-    const printText = `Printing L&A Package (${i + 1} of 13): ${precinct}`;
-    await screen.findByText(printText);
+    await screen.findByText(`Printing L&A Package for ${precinct}`);
+    await screen.findByText(`This is package ${i + 1} of 13.`);
+    await screen.findByText('Currently printing legal-size pages');
     await waitFor(() =>
       expect(mockPrinter.print).toHaveBeenCalledTimes(
         2 * precinctsInAlphabeticalOrder.length + i + 1

--- a/frontends/election-manager/src/screens/print_test_deck_screen.test.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.test.tsx
@@ -1,32 +1,104 @@
-import React from 'react';
+import React, { RefObject } from 'react';
 import userEvent from '@testing-library/user-event';
+import _ from 'lodash';
+import { BallotPaperSize } from '@votingworks/types';
+import { electionWithMsEitherNeitherDefinition } from '@votingworks/fixtures';
 import { fakeKiosk, fakePrinterInfo } from '@votingworks/test-utils';
-import { screen } from '@testing-library/react';
+import { LogEventId, Logger, LogSource } from '@votingworks/logging';
+import { Printer } from '@votingworks/utils';
+import { screen, waitFor } from '@testing-library/react';
 
-import { PrintTestDeckScreen } from './print_test_deck_screen';
+import { fakePrinter } from '../../test/helpers/fake_printer';
+import {
+  LAST_PRINT_JOB_SLEEP_MS,
+  ONE_SIDED_PAGE_PRINT_TIME_MS,
+  PrintTestDeckScreen,
+  TWO_SIDED_PAGE_PRINT_TIME_MS,
+} from './print_test_deck_screen';
 import { renderInAppContext } from '../../test/render_in_app_context';
 
 jest.mock('../components/hand_marked_paper_ballot');
 
-beforeAll(() => {
-  window.kiosk = fakeKiosk();
+let mockKiosk: jest.Mocked<KioskBrowser.Kiosk>;
+let mockLogger: Logger;
+let mockPrintBallotRef: RefObject<HTMLElement>;
+let mockPrinter: jest.Mocked<Printer>;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  mockKiosk = fakeKiosk();
+  mockKiosk.getPrinterInfo.mockResolvedValue([
+    fakePrinterInfo({ connected: true, name: 'VxPrinter' }),
+  ]);
+  window.kiosk = mockKiosk;
+  mockLogger = new Logger(LogSource.VxAdminFrontend, mockKiosk);
+  mockPrintBallotRef = {
+    current: document.createElement('div'),
+  };
+  mockPrinter = fakePrinter();
 });
 
 afterAll(() => {
   delete window.kiosk;
 });
 
-test('Printing all L&A packages sorts precincts', async () => {
-  jest.useFakeTimers();
-  const mockKiosk = window.kiosk! as jest.Mocked<KioskBrowser.Kiosk>;
-  mockKiosk.getPrinterInfo.mockResolvedValue([
-    fakePrinterInfo({ name: 'VxPrinter', connected: true }),
-  ]);
-
+test('Printing L&A package for one precinct', async () => {
   renderInAppContext(<PrintTestDeckScreen />, {
-    printBallotRef: {
-      current: document.createElement('div'),
-    },
+    logger: mockLogger,
+    printBallotRef: mockPrintBallotRef,
+    printer: mockPrinter,
+  });
+
+  userEvent.click(screen.getByText('District 5'));
+
+  const printText = 'Printing L&A Package: District 5';
+  await screen.findByText(printText);
+  await waitFor(() => expect(mockPrinter.print).toHaveBeenCalledTimes(1));
+  expect(mockPrinter.print).toHaveBeenLastCalledWith({ sides: 'one-sided' });
+  await waitFor(() =>
+    expect(mockKiosk.log).toHaveBeenLastCalledWith(
+      expect.stringContaining(LogEventId.TestDeckTallyReportPrinted)
+    )
+  );
+  jest.advanceTimersByTime(ONE_SIDED_PAGE_PRINT_TIME_MS + 1);
+
+  await screen.findByText(printText);
+  await waitFor(() => expect(mockPrinter.print).toHaveBeenCalledTimes(2));
+  expect(mockPrinter.print).toHaveBeenLastCalledWith({ sides: 'one-sided' });
+  await waitFor(() =>
+    expect(mockKiosk.log).toHaveBeenLastCalledWith(
+      expect.stringContaining(LogEventId.TestDeckPrinted)
+    )
+  );
+  expect(mockKiosk.log).toHaveBeenLastCalledWith(
+    expect.stringContaining('BMD paper ballot test deck printed')
+  );
+  jest.advanceTimersByTime(3 * ONE_SIDED_PAGE_PRINT_TIME_MS + 1);
+
+  await screen.findByText(printText);
+  await waitFor(() => expect(mockPrinter.print).toHaveBeenCalledTimes(3));
+  expect(mockPrinter.print).toHaveBeenLastCalledWith({
+    sides: 'two-sided-long-edge',
+  });
+  await waitFor(() =>
+    expect(mockKiosk.log).toHaveBeenLastCalledWith(
+      expect.stringContaining(LogEventId.TestDeckPrinted)
+    )
+  );
+  expect(mockKiosk.log).toHaveBeenLastCalledWith(
+    expect.stringContaining('Hand-marked paper ballot test deck printed')
+  );
+  jest.advanceTimersByTime(LAST_PRINT_JOB_SLEEP_MS + 1);
+
+  await screen.findByText('District 5');
+  expect(screen.queryByText('Printing')).not.toBeInTheDocument();
+});
+
+test('Printing L&A packages for all precincts', async () => {
+  renderInAppContext(<PrintTestDeckScreen />, {
+    logger: mockLogger,
+    printBallotRef: mockPrintBallotRef,
+    printer: mockPrinter,
   });
 
   userEvent.click(screen.getByText('All Precincts'));
@@ -47,15 +119,218 @@ test('Printing all L&A packages sorts precincts', async () => {
     'Southwest Ackerman',
     'West Weir',
   ];
+
   for (const [i, precinct] of precinctsInAlphabeticalOrder.entries()) {
-    const printText = `Printing L&A Package (${i + 1} of 13): ${precinct}.`;
-    await screen.findByLabelText(printText);
-    jest.advanceTimersByTime(5000);
-    await screen.findByLabelText(printText);
-    jest.advanceTimersByTime(30000);
-    await screen.findByLabelText(printText);
-    jest.advanceTimersByTime(30000);
+    const printText = `Printing L&A Package (${i + 1} of 13): ${precinct}`;
+    await screen.findByText(printText);
+    await waitFor(() =>
+      expect(mockPrinter.print).toHaveBeenCalledTimes(3 * i + 1)
+    );
+    expect(mockPrinter.print).toHaveBeenLastCalledWith({ sides: 'one-sided' });
+    await waitFor(() =>
+      expect(mockKiosk.log).toHaveBeenLastCalledWith(
+        expect.stringContaining(LogEventId.TestDeckTallyReportPrinted)
+      )
+    );
+    jest.advanceTimersByTime(ONE_SIDED_PAGE_PRINT_TIME_MS + 1);
+
+    await screen.findByText(printText);
+    await waitFor(() =>
+      expect(mockPrinter.print).toHaveBeenCalledTimes(3 * i + 2)
+    );
+    expect(mockPrinter.print).toHaveBeenLastCalledWith({ sides: 'one-sided' });
+    await waitFor(() =>
+      expect(mockKiosk.log).toHaveBeenLastCalledWith(
+        expect.stringContaining(LogEventId.TestDeckPrinted)
+      )
+    );
+    expect(mockKiosk.log).toHaveBeenLastCalledWith(
+      expect.stringContaining('BMD paper ballot test deck printed')
+    );
+    jest.advanceTimersByTime(3 * ONE_SIDED_PAGE_PRINT_TIME_MS + 1);
+
+    await screen.findByText(printText);
+    await waitFor(() =>
+      expect(mockPrinter.print).toHaveBeenCalledTimes(3 * i + 3)
+    );
+    expect(mockPrinter.print).toHaveBeenLastCalledWith({
+      sides: 'two-sided-long-edge',
+    });
+    await waitFor(() =>
+      expect(mockKiosk.log).toHaveBeenLastCalledWith(
+        expect.stringContaining(LogEventId.TestDeckPrinted)
+      )
+    );
+    expect(mockKiosk.log).toHaveBeenLastCalledWith(
+      expect.stringContaining('Hand-marked paper ballot test deck printed')
+    );
+    if (i < precinctsInAlphabeticalOrder.length - 1) {
+      jest.advanceTimersByTime(6 * TWO_SIDED_PAGE_PRINT_TIME_MS + 1);
+    } else {
+      jest.advanceTimersByTime(LAST_PRINT_JOB_SLEEP_MS + 1);
+    }
   }
+
+  await screen.findByText('All Precincts');
+  expect(screen.queryByText('Printing')).not.toBeInTheDocument();
+});
+
+test('Printing L&A package for one precinct, when HMPBs are not letter-size', async () => {
+  const electionWithLegalSizeHmpbsDefinition = _.cloneDeep(
+    electionWithMsEitherNeitherDefinition
+  );
+  electionWithLegalSizeHmpbsDefinition.election.ballotLayout!.paperSize =
+    BallotPaperSize.Legal;
+
+  renderInAppContext(<PrintTestDeckScreen />, {
+    electionDefinition: electionWithLegalSizeHmpbsDefinition,
+    logger: mockLogger,
+    printBallotRef: mockPrintBallotRef,
+    printer: mockPrinter,
+  });
+
+  userEvent.click(screen.getByText('District 5'));
+
+  const printText = 'Printing L&A Package: District 5';
+  await screen.findByText(printText);
+  await waitFor(() => expect(mockPrinter.print).toHaveBeenCalledTimes(1));
+  expect(mockPrinter.print).toHaveBeenLastCalledWith({ sides: 'one-sided' });
+  await waitFor(() =>
+    expect(mockKiosk.log).toHaveBeenLastCalledWith(
+      expect.stringContaining(LogEventId.TestDeckTallyReportPrinted)
+    )
+  );
+  jest.advanceTimersByTime(ONE_SIDED_PAGE_PRINT_TIME_MS + 1);
+
+  await screen.findByText(printText);
+  await waitFor(() => expect(mockPrinter.print).toHaveBeenCalledTimes(2));
+  expect(mockPrinter.print).toHaveBeenLastCalledWith({ sides: 'one-sided' });
+  await waitFor(() =>
+    expect(mockKiosk.log).toHaveBeenLastCalledWith(
+      expect.stringContaining(LogEventId.TestDeckPrinted)
+    )
+  );
+  expect(mockKiosk.log).toHaveBeenLastCalledWith(
+    expect.stringContaining('BMD paper ballot test deck printed')
+  );
+  jest.advanceTimersByTime(3 * ONE_SIDED_PAGE_PRINT_TIME_MS + 1);
+
+  userEvent.click(
+    await screen.findByText('Legal Paper Loaded. Continue Printing')
+  );
+
+  await screen.findByText(printText);
+  await waitFor(() => expect(mockPrinter.print).toHaveBeenCalledTimes(3));
+  expect(mockPrinter.print).toHaveBeenLastCalledWith({
+    sides: 'two-sided-long-edge',
+  });
+  await waitFor(() =>
+    expect(mockKiosk.log).toHaveBeenLastCalledWith(
+      expect.stringContaining(LogEventId.TestDeckPrinted)
+    )
+  );
+  expect(mockKiosk.log).toHaveBeenLastCalledWith(
+    expect.stringContaining('Hand-marked paper ballot test deck printed')
+  );
+  jest.advanceTimersByTime(LAST_PRINT_JOB_SLEEP_MS + 1);
+
+  await screen.findByText('District 5');
+  expect(screen.queryByText('Printing')).not.toBeInTheDocument();
+});
+
+test('Printing L&A packages for all precincts, when HMPBs are not letter-size', async () => {
+  const electionWithLegalSizeHmpbsDefinition = _.cloneDeep(
+    electionWithMsEitherNeitherDefinition
+  );
+  electionWithLegalSizeHmpbsDefinition.election.ballotLayout!.paperSize =
+    BallotPaperSize.Legal;
+
+  renderInAppContext(<PrintTestDeckScreen />, {
+    electionDefinition: electionWithLegalSizeHmpbsDefinition,
+    logger: mockLogger,
+    printBallotRef: mockPrintBallotRef,
+    printer: mockPrinter,
+  });
+
+  userEvent.click(screen.getByText('All Precincts'));
+
+  // Check that the printing modals appear in alphabetical order
+  const precinctsInAlphabeticalOrder = [
+    'Bywy',
+    'Chester',
+    'District 5',
+    'East Weir',
+    'Fentress',
+    'French Camp',
+    'Hebron',
+    'Kenego',
+    'Panhandle',
+    'Reform',
+    'Sherwood',
+    'Southwest Ackerman',
+    'West Weir',
+  ];
+
+  for (const [i, precinct] of precinctsInAlphabeticalOrder.entries()) {
+    const printText = `Printing L&A Package (${i + 1} of 13): ${precinct}`;
+    await screen.findByText(printText);
+    await waitFor(() =>
+      expect(mockPrinter.print).toHaveBeenCalledTimes(2 * i + 1)
+    );
+    expect(mockPrinter.print).toHaveBeenLastCalledWith({ sides: 'one-sided' });
+    await waitFor(() =>
+      expect(mockKiosk.log).toHaveBeenLastCalledWith(
+        expect.stringContaining(LogEventId.TestDeckTallyReportPrinted)
+      )
+    );
+    jest.advanceTimersByTime(ONE_SIDED_PAGE_PRINT_TIME_MS + 1);
+
+    await screen.findByText(printText);
+    await waitFor(() =>
+      expect(mockPrinter.print).toHaveBeenCalledTimes(2 * i + 2)
+    );
+    expect(mockPrinter.print).toHaveBeenLastCalledWith({ sides: 'one-sided' });
+    await waitFor(() =>
+      expect(mockKiosk.log).toHaveBeenLastCalledWith(
+        expect.stringContaining(LogEventId.TestDeckPrinted)
+      )
+    );
+    expect(mockKiosk.log).toHaveBeenLastCalledWith(
+      expect.stringContaining('BMD paper ballot test deck printed')
+    );
+    jest.advanceTimersByTime(3 * ONE_SIDED_PAGE_PRINT_TIME_MS + 1);
+  }
+
+  userEvent.click(
+    await screen.findByText('Legal Paper Loaded. Continue Printing')
+  );
+
+  for (const [i, precinct] of precinctsInAlphabeticalOrder.entries()) {
+    const printText = `Printing L&A Package (${i + 1} of 13): ${precinct}`;
+    await screen.findByText(printText);
+    await waitFor(() =>
+      expect(mockPrinter.print).toHaveBeenCalledTimes(
+        2 * precinctsInAlphabeticalOrder.length + i + 1
+      )
+    );
+    expect(mockPrinter.print).toHaveBeenLastCalledWith({
+      sides: 'two-sided-long-edge',
+    });
+    await waitFor(() =>
+      expect(mockKiosk.log).toHaveBeenLastCalledWith(
+        expect.stringContaining(LogEventId.TestDeckPrinted)
+      )
+    );
+    expect(mockKiosk.log).toHaveBeenLastCalledWith(
+      expect.stringContaining('Hand-marked paper ballot test deck printed')
+    );
+    if (i < precinctsInAlphabeticalOrder.length - 1) {
+      jest.advanceTimersByTime(6 * TWO_SIDED_PAGE_PRINT_TIME_MS + 1);
+    } else {
+      jest.advanceTimersByTime(LAST_PRINT_JOB_SLEEP_MS + 1);
+    }
+  }
+
   await screen.findByText('All Precincts');
   expect(screen.queryByText('Printing')).not.toBeInTheDocument();
 });

--- a/frontends/election-manager/src/screens/print_test_deck_screen.test.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.test.tsx
@@ -216,7 +216,7 @@ test('Printing L&A package for one precinct, when HMPBs are not letter-size', as
   jest.advanceTimersByTime(3 * ONE_SIDED_PAGE_PRINT_TIME_MS + 1);
 
   userEvent.click(
-    await screen.findByText('Legal Paper Loaded. Continue Printing')
+    await screen.findByText('Legal Paper Loaded, Continue Printing')
   );
 
   await screen.findByText(printText);
@@ -302,7 +302,7 @@ test('Printing L&A packages for all precincts, when HMPBs are not letter-size', 
   }
 
   userEvent.click(
-    await screen.findByText('Legal Paper Loaded. Continue Printing')
+    await screen.findByText('Legal Paper Loaded, Continue Printing')
   );
 
   for (const [i, precinct] of precinctsInAlphabeticalOrder.entries()) {

--- a/frontends/election-manager/src/screens/print_test_deck_screen.test.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.test.tsx
@@ -196,7 +196,7 @@ test('Printing L&A package for one precinct, when HMPBs are not letter-size', as
   userEvent.click(screen.getByText('District 5'));
 
   await screen.findByText('Printing L&A Package for District 5');
-  await screen.findByText('Currently printing letter-size pages');
+  await screen.findByText('Currently printing letter-size pages.');
   await waitFor(() => expect(mockPrinter.print).toHaveBeenCalledTimes(1));
   expect(mockPrinter.print).toHaveBeenLastCalledWith({ sides: 'one-sided' });
   await waitFor(() =>
@@ -207,7 +207,7 @@ test('Printing L&A package for one precinct, when HMPBs are not letter-size', as
   jest.advanceTimersByTime(ONE_SIDED_PAGE_PRINT_TIME_MS);
 
   await screen.findByText('Printing L&A Package for District 5');
-  await screen.findByText('Currently printing letter-size pages');
+  await screen.findByText('Currently printing letter-size pages.');
   await waitFor(() => expect(mockPrinter.print).toHaveBeenCalledTimes(2));
   expect(mockPrinter.print).toHaveBeenLastCalledWith({ sides: 'one-sided' });
   await waitFor(() =>
@@ -225,7 +225,7 @@ test('Printing L&A package for one precinct, when HMPBs are not letter-size', as
   );
 
   await screen.findByText('Printing L&A Package for District 5');
-  await screen.findByText('Currently printing legal-size pages');
+  await screen.findByText('Currently printing legal-size pages.');
   await waitFor(() => expect(mockPrinter.print).toHaveBeenCalledTimes(3));
   expect(mockPrinter.print).toHaveBeenLastCalledWith({
     sides: 'two-sided-long-edge',
@@ -281,7 +281,7 @@ test('Printing L&A packages for all precincts, when HMPBs are not letter-size', 
   for (const [i, precinct] of precinctsInAlphabeticalOrder.entries()) {
     await screen.findByText(`Printing L&A Package for ${precinct}`);
     await screen.findByText(`This is package ${i + 1} of 13.`);
-    await screen.findByText('Currently printing letter-size pages');
+    await screen.findByText('Currently printing letter-size pages.');
     await waitFor(() =>
       expect(mockPrinter.print).toHaveBeenCalledTimes(2 * i + 1)
     );
@@ -295,7 +295,7 @@ test('Printing L&A packages for all precincts, when HMPBs are not letter-size', 
 
     await screen.findByText(`Printing L&A Package for ${precinct}`);
     await screen.findByText(`This is package ${i + 1} of 13.`);
-    await screen.findByText('Currently printing letter-size pages');
+    await screen.findByText('Currently printing letter-size pages.');
     await waitFor(() =>
       expect(mockPrinter.print).toHaveBeenCalledTimes(2 * i + 2)
     );
@@ -318,7 +318,7 @@ test('Printing L&A packages for all precincts, when HMPBs are not letter-size', 
   for (const [i, precinct] of precinctsInAlphabeticalOrder.entries()) {
     await screen.findByText(`Printing L&A Package for ${precinct}`);
     await screen.findByText(`This is package ${i + 1} of 13.`);
-    await screen.findByText('Currently printing legal-size pages');
+    await screen.findByText('Currently printing legal-size pages.');
     await waitFor(() =>
       expect(mockPrinter.print).toHaveBeenCalledTimes(
         2 * precinctsInAlphabeticalOrder.length + i + 1

--- a/frontends/election-manager/src/screens/print_test_deck_screen.test.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.test.tsx
@@ -1,8 +1,10 @@
 import React, { RefObject } from 'react';
 import userEvent from '@testing-library/user-event';
-import _ from 'lodash';
 import { BallotPaperSize } from '@votingworks/types';
-import { electionWithMsEitherNeitherDefinition } from '@votingworks/fixtures';
+import {
+  asElectionDefinition,
+  electionWithMsEitherNeitherDefinition,
+} from '@votingworks/fixtures';
 import { fakeKiosk, fakePrinterInfo } from '@votingworks/test-utils';
 import { LogEventId, Logger, LogSource } from '@votingworks/logging';
 import { Printer } from '@votingworks/utils';
@@ -176,11 +178,12 @@ test('Printing L&A packages for all precincts', async () => {
 });
 
 test('Printing L&A package for one precinct, when HMPBs are not letter-size', async () => {
-  const electionWithLegalSizeHmpbsDefinition = _.cloneDeep(
-    electionWithMsEitherNeitherDefinition
-  );
-  electionWithLegalSizeHmpbsDefinition.election.ballotLayout!.paperSize =
-    BallotPaperSize.Legal;
+  const electionWithLegalSizeHmpbsDefinition = asElectionDefinition({
+    ...electionWithMsEitherNeitherDefinition.election,
+    ballotLayout: {
+      paperSize: BallotPaperSize.Legal,
+    },
+  });
 
   renderInAppContext(<PrintTestDeckScreen />, {
     electionDefinition: electionWithLegalSizeHmpbsDefinition,
@@ -239,11 +242,12 @@ test('Printing L&A package for one precinct, when HMPBs are not letter-size', as
 });
 
 test('Printing L&A packages for all precincts, when HMPBs are not letter-size', async () => {
-  const electionWithLegalSizeHmpbsDefinition = _.cloneDeep(
-    electionWithMsEitherNeitherDefinition
-  );
-  electionWithLegalSizeHmpbsDefinition.election.ballotLayout!.paperSize =
-    BallotPaperSize.Legal;
+  const electionWithLegalSizeHmpbsDefinition = asElectionDefinition({
+    ...electionWithMsEitherNeitherDefinition.election,
+    ballotLayout: {
+      paperSize: BallotPaperSize.Legal,
+    },
+  });
 
   renderInAppContext(<PrintTestDeckScreen />, {
     electionDefinition: electionWithLegalSizeHmpbsDefinition,

--- a/frontends/election-manager/src/screens/print_test_deck_screen.test.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.test.tsx
@@ -62,7 +62,7 @@ test('Printing L&A package for one precinct', async () => {
       expect.stringContaining(LogEventId.TestDeckTallyReportPrinted)
     )
   );
-  jest.advanceTimersByTime(ONE_SIDED_PAGE_PRINT_TIME_MS + 1);
+  jest.advanceTimersByTime(ONE_SIDED_PAGE_PRINT_TIME_MS);
 
   await screen.findByText(printText);
   await waitFor(() => expect(mockPrinter.print).toHaveBeenCalledTimes(2));
@@ -75,7 +75,7 @@ test('Printing L&A package for one precinct', async () => {
   expect(mockKiosk.log).toHaveBeenLastCalledWith(
     expect.stringContaining('BMD paper ballot test deck printed')
   );
-  jest.advanceTimersByTime(3 * ONE_SIDED_PAGE_PRINT_TIME_MS + 1);
+  jest.advanceTimersByTime(3 * ONE_SIDED_PAGE_PRINT_TIME_MS);
 
   await screen.findByText(printText);
   await waitFor(() => expect(mockPrinter.print).toHaveBeenCalledTimes(3));
@@ -90,7 +90,7 @@ test('Printing L&A package for one precinct', async () => {
   expect(mockKiosk.log).toHaveBeenLastCalledWith(
     expect.stringContaining('Hand-marked paper ballot test deck printed')
   );
-  jest.advanceTimersByTime(LAST_PRINT_JOB_SLEEP_MS + 1);
+  jest.advanceTimersByTime(LAST_PRINT_JOB_SLEEP_MS);
 
   await screen.findByText('District 5');
   expect(screen.queryByText('Printing')).not.toBeInTheDocument();
@@ -134,7 +134,7 @@ test('Printing L&A packages for all precincts', async () => {
         expect.stringContaining(LogEventId.TestDeckTallyReportPrinted)
       )
     );
-    jest.advanceTimersByTime(ONE_SIDED_PAGE_PRINT_TIME_MS + 1);
+    jest.advanceTimersByTime(ONE_SIDED_PAGE_PRINT_TIME_MS);
 
     await screen.findByText(printText);
     await waitFor(() =>
@@ -149,7 +149,7 @@ test('Printing L&A packages for all precincts', async () => {
     expect(mockKiosk.log).toHaveBeenLastCalledWith(
       expect.stringContaining('BMD paper ballot test deck printed')
     );
-    jest.advanceTimersByTime(3 * ONE_SIDED_PAGE_PRINT_TIME_MS + 1);
+    jest.advanceTimersByTime(3 * ONE_SIDED_PAGE_PRINT_TIME_MS);
 
     await screen.findByText(printText);
     await waitFor(() =>
@@ -167,9 +167,9 @@ test('Printing L&A packages for all precincts', async () => {
       expect.stringContaining('Hand-marked paper ballot test deck printed')
     );
     if (i < precinctsInAlphabeticalOrder.length - 1) {
-      jest.advanceTimersByTime(6 * TWO_SIDED_PAGE_PRINT_TIME_MS + 1);
+      jest.advanceTimersByTime(6 * TWO_SIDED_PAGE_PRINT_TIME_MS);
     } else {
-      jest.advanceTimersByTime(LAST_PRINT_JOB_SLEEP_MS + 1);
+      jest.advanceTimersByTime(LAST_PRINT_JOB_SLEEP_MS);
     }
   }
 
@@ -203,7 +203,7 @@ test('Printing L&A package for one precinct, when HMPBs are not letter-size', as
       expect.stringContaining(LogEventId.TestDeckTallyReportPrinted)
     )
   );
-  jest.advanceTimersByTime(ONE_SIDED_PAGE_PRINT_TIME_MS + 1);
+  jest.advanceTimersByTime(ONE_SIDED_PAGE_PRINT_TIME_MS);
 
   await screen.findByText(printText);
   await waitFor(() => expect(mockPrinter.print).toHaveBeenCalledTimes(2));
@@ -216,7 +216,7 @@ test('Printing L&A package for one precinct, when HMPBs are not letter-size', as
   expect(mockKiosk.log).toHaveBeenLastCalledWith(
     expect.stringContaining('BMD paper ballot test deck printed')
   );
-  jest.advanceTimersByTime(3 * ONE_SIDED_PAGE_PRINT_TIME_MS + 1);
+  jest.advanceTimersByTime(3 * ONE_SIDED_PAGE_PRINT_TIME_MS);
 
   userEvent.click(
     await screen.findByText('Legal Paper Loaded, Continue Printing')
@@ -235,7 +235,7 @@ test('Printing L&A package for one precinct, when HMPBs are not letter-size', as
   expect(mockKiosk.log).toHaveBeenLastCalledWith(
     expect.stringContaining('Hand-marked paper ballot test deck printed')
   );
-  jest.advanceTimersByTime(LAST_PRINT_JOB_SLEEP_MS + 1);
+  jest.advanceTimersByTime(LAST_PRINT_JOB_SLEEP_MS);
 
   await screen.findByText('District 5');
   expect(screen.queryByText('Printing')).not.toBeInTheDocument();
@@ -287,7 +287,7 @@ test('Printing L&A packages for all precincts, when HMPBs are not letter-size', 
         expect.stringContaining(LogEventId.TestDeckTallyReportPrinted)
       )
     );
-    jest.advanceTimersByTime(ONE_SIDED_PAGE_PRINT_TIME_MS + 1);
+    jest.advanceTimersByTime(ONE_SIDED_PAGE_PRINT_TIME_MS);
 
     await screen.findByText(printText);
     await waitFor(() =>
@@ -302,7 +302,7 @@ test('Printing L&A packages for all precincts, when HMPBs are not letter-size', 
     expect(mockKiosk.log).toHaveBeenLastCalledWith(
       expect.stringContaining('BMD paper ballot test deck printed')
     );
-    jest.advanceTimersByTime(3 * ONE_SIDED_PAGE_PRINT_TIME_MS + 1);
+    jest.advanceTimersByTime(3 * ONE_SIDED_PAGE_PRINT_TIME_MS);
   }
 
   userEvent.click(
@@ -329,9 +329,9 @@ test('Printing L&A packages for all precincts, when HMPBs are not letter-size', 
       expect.stringContaining('Hand-marked paper ballot test deck printed')
     );
     if (i < precinctsInAlphabeticalOrder.length - 1) {
-      jest.advanceTimersByTime(6 * TWO_SIDED_PAGE_PRINT_TIME_MS + 1);
+      jest.advanceTimersByTime(6 * TWO_SIDED_PAGE_PRINT_TIME_MS);
     } else {
-      jest.advanceTimersByTime(LAST_PRINT_JOB_SLEEP_MS + 1);
+      jest.advanceTimersByTime(LAST_PRINT_JOB_SLEEP_MS);
     }
   }
 

--- a/frontends/election-manager/src/screens/print_test_deck_screen.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.tsx
@@ -30,7 +30,10 @@ import {
   generateBlankBallots,
   generateOvervoteBallot,
 } from '../utils/election';
-import { getBallotLayoutPageSize } from '../utils/get_ballot_layout_page_size';
+import {
+  getBallotLayoutPageSize,
+  getBallotLayoutPageSizeReadableString,
+} from '../utils/get_ballot_layout_page_size';
 
 export const ONE_SIDED_PAGE_PRINT_TIME_MS = 3000;
 export const TWO_SIDED_PAGE_PRINT_TIME_MS = 5000;
@@ -248,6 +251,7 @@ const HandMarkedPaperBallotsMemoized = React.memo(HandMarkedPaperBallots);
 interface PrintingModalProps {
   advancePrinting: () => void;
   currentPrecinct: Precinct;
+  election: Election;
   precinctIds: string[];
   printIndex: PrintIndex;
 }
@@ -255,6 +259,7 @@ interface PrintingModalProps {
 function PrintingModal({
   advancePrinting,
   currentPrecinct,
+  election,
   precinctIds,
   printIndex,
 }: PrintingModalProps): JSX.Element {
@@ -266,13 +271,20 @@ function PrintingModal({
           <Prose textCenter>
             <h1>Change Paper</h1>
             <p>
-              Load printer with <strong>legal-size paper</strong>.
+              Load printer with{' '}
+              <strong>
+                {getBallotLayoutPageSizeReadableString(election)}-size paper
+              </strong>
+              .
             </p>
           </Prose>
         }
         actions={
           <Button onPress={advancePrinting} primary>
-            Legal Paper Loaded, Continue Printing
+            {getBallotLayoutPageSizeReadableString(election, {
+              capitalize: true,
+            })}{' '}
+            Paper Loaded, Continue Printing
           </Button>
         }
       />
@@ -282,13 +294,28 @@ function PrintingModal({
     <Modal
       centerContent
       content={
-        <Loading as="p">
-          Printing L&amp;A Package
-          {precinctIds.length > 1
-            ? ` (${printIndex.precinctIndex + 1} of ${precinctIds.length})`
-            : ''}
-          : {currentPrecinct.name}
-        </Loading>
+        <Prose textCenter>
+          <p>
+            <Loading as="strong" wrapInProse={false}>
+              {`Printing L&A Package for ${currentPrecinct.name}`}
+            </Loading>
+          </p>
+          {precinctIds.length > 1 && (
+            <p>
+              This is package {printIndex.precinctIndex + 1} of{' '}
+              {precinctIds.length}.
+            </p>
+          )}
+          {getBallotLayoutPageSize(election) !== BallotPaperSize.Letter && (
+            <p>
+              Currently printing{' '}
+              {printIndex.component === 'HandMarkedPaperBallots'
+                ? getBallotLayoutPageSizeReadableString(election)
+                : 'letter'}
+              -size pages
+            </p>
+          )}
+        </Prose>
       }
     />
   );
@@ -538,6 +565,7 @@ export function PrintTestDeckScreen(): JSX.Element {
         <PrintingModal
           advancePrinting={advancePrinting}
           currentPrecinct={currentPrecinct}
+          election={election}
           precinctIds={precinctIds}
           printIndex={printIndex}
         />

--- a/frontends/election-manager/src/screens/print_test_deck_screen.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.tsx
@@ -308,11 +308,11 @@ function PrintingModal({
           )}
           {getBallotLayoutPageSize(election) !== BallotPaperSize.Letter && (
             <p>
-              Currently printing{' '}
               {printIndex.component === 'HandMarkedPaperBallots'
-                ? getBallotLayoutPageSizeReadableString(election)
-                : 'letter'}
-              -size pages
+                ? `Currently printing ${getBallotLayoutPageSizeReadableString(
+                    election
+                  )}-size pages.`
+                : 'Currently printing letter-size pages.'}
             </p>
           )}
         </Prose>

--- a/frontends/election-manager/src/screens/print_test_deck_screen.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.tsx
@@ -264,14 +264,15 @@ function PrintingModal({
         centerContent
         content={
           <Prose textCenter>
+            <h1>Change Paper</h1>
             <p>
-              Load printer with <b>legal-size paper</b>.
+              Load printer with <strong>legal-size paper</strong>.
             </p>
           </Prose>
         }
         actions={
-          <Button onPress={advancePrinting}>
-            Legal Paper Loaded. Continue Printing
+          <Button onPress={advancePrinting} primary>
+            Legal Paper Loaded, Continue Printing
           </Button>
         }
       />

--- a/frontends/election-manager/src/screens/print_test_deck_screen.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.tsx
@@ -198,8 +198,10 @@ function useCreateHmpbTargetElements({
   precinctId: PrecinctId;
   printingHandMarkedPaperBallots: boolean;
 }) {
-  const [hmpbTargetElementsCreated, setHmpbTargetElementsCreated] =
-    useState(false);
+  const [
+    hmpbTargetElementsCreatedForPrecinctId,
+    setHmpbTargetElementsCreatedForPrecinctId,
+  ] = useState<string>();
 
   useEffect(() => {
     const container = containerRef?.current;
@@ -214,19 +216,19 @@ function useCreateHmpbTargetElements({
         hmpbTargetElement.id = generateHmpbTargetElementId(i);
         container.appendChild(hmpbTargetElement);
       }
-      setHmpbTargetElementsCreated(true);
+      setHmpbTargetElementsCreatedForPrecinctId(precinctId);
     }
 
     // Cleanup action: Clear the created elements
     return () => {
       if (container) {
         container.innerHTML = '';
-        setHmpbTargetElementsCreated(false);
+        setHmpbTargetElementsCreatedForPrecinctId(undefined);
       }
     };
   }, [containerRef, election, precinctId, printingHandMarkedPaperBallots]);
 
-  return { hmpbTargetElementsCreated };
+  return { hmpbTargetElementsCreatedForPrecinctId };
 }
 
 // FIXME: We're using `React.memo` to prevent re-rendering `TestDeckBallots`,
@@ -520,13 +522,14 @@ export function PrintTestDeckScreen(): JSX.Element {
       })
     : undefined;
 
-  const { hmpbTargetElementsCreated } = useCreateHmpbTargetElements({
-    containerRef: printBallotRef,
-    election,
-    precinctId: currentPrecinctId,
-    printingHandMarkedPaperBallots:
-      printIndex?.component === 'HandMarkedPaperBallots',
-  });
+  const { hmpbTargetElementsCreatedForPrecinctId } =
+    useCreateHmpbTargetElements({
+      containerRef: printBallotRef,
+      election,
+      precinctId: currentPrecinctId,
+      printingHandMarkedPaperBallots:
+        printIndex?.component === 'HandMarkedPaperBallots',
+    });
 
   return (
     <React.Fragment>
@@ -579,7 +582,7 @@ export function PrintTestDeckScreen(): JSX.Element {
         />
       )}
       {printIndex?.component === 'HandMarkedPaperBallots' &&
-        hmpbTargetElementsCreated && (
+        hmpbTargetElementsCreatedForPrecinctId === currentPrecinctId && (
           <HandMarkedPaperBallotsMemoized
             election={election}
             electionHash={electionHash}

--- a/frontends/election-manager/src/utils/get_ballot_layout_page_size.ts
+++ b/frontends/election-manager/src/utils/get_ballot_layout_page_size.ts
@@ -1,7 +1,9 @@
 import { BallotPaperSize, Election } from '@votingworks/types';
 
-export function getBallotLayoutPageSize(election: Election): string {
-  return (
-    election.ballotLayout?.paperSize || BallotPaperSize.Letter
-  ).toLowerCase();
+export function getBallotLayoutPageSize(election: Election): BallotPaperSize {
+  return election.ballotLayout?.paperSize || BallotPaperSize.Letter;
+}
+
+export function getBallotLayoutPageSizeStr(election: Election): string {
+  return getBallotLayoutPageSize(election).toLowerCase();
 }

--- a/frontends/election-manager/src/utils/get_ballot_layout_page_size.ts
+++ b/frontends/election-manager/src/utils/get_ballot_layout_page_size.ts
@@ -5,7 +5,21 @@ export function getBallotLayoutPageSize(election: Election): BallotPaperSize {
 }
 
 export function getBallotLayoutPageSizeReadableString(
-  election: Election
+  election: Election,
+  options: { capitalize?: boolean } = {}
 ): string {
-  return getBallotLayoutPageSize(election).toLowerCase();
+  const ballotPaperSizeToReadableStringMapping: Record<
+    BallotPaperSize,
+    string
+  > = {
+    [BallotPaperSize.Letter]: 'letter',
+    [BallotPaperSize.Legal]: 'legal',
+    [BallotPaperSize.Custom8Point5X17]: 'custom 8.5x17',
+  };
+  const readableString =
+    ballotPaperSizeToReadableStringMapping[getBallotLayoutPageSize(election)];
+  if (options.capitalize) {
+    return readableString.charAt(0).toUpperCase() + readableString.slice(1);
+  }
+  return readableString;
 }

--- a/frontends/election-manager/src/utils/get_ballot_layout_page_size.ts
+++ b/frontends/election-manager/src/utils/get_ballot_layout_page_size.ts
@@ -4,6 +4,8 @@ export function getBallotLayoutPageSize(election: Election): BallotPaperSize {
   return election.ballotLayout?.paperSize || BallotPaperSize.Letter;
 }
 
-export function getBallotLayoutPageSizeStr(election: Election): string {
+export function getBallotLayoutPageSizeReadableString(
+  election: Election
+): string {
   return getBallotLayoutPageSize(election).toLowerCase();
 }


### PR DESCRIPTION
_Commit-by-commit reviewing recommended_

# Overview

Issue link: https://github.com/votingworks/vxsuite/issues/1873

This PR accounts for the situation that HMPBs aren't letter-size when printing L&A packages, with an approach we're calling "best-effort collation" (TM Ben Adida 😝).

If all content is letter-size, we'll print tally reports, BMD paper ballots, and hand-marked paper ballots grouped by precinct.

If hand-marked paper ballots aren't letter-size (e.g. legal-size), we'll print tally reports and BMD paper ballots grouped by precinct. We'll then prompt the election official to change paper, and we'll print hand-marked paper ballots grouped by precinct.

We previously explored automatically printing from/to separate trays to fully collate in all cases but ultimately decided that this introduced too much product and eng complexity for too little gain. (More on that investigation in https://github.com/votingworks/vxsuite/issues/1861.)

# Demo screenshots and videos

_Best-effort collation flow_

https://user-images.githubusercontent.com/12616928/170511569-5717c6be-7304-4ea0-9a26-dbd82019cf58.mov

![paper-change-modal](https://user-images.githubusercontent.com/12616928/170511712-60a11154-83ed-4db2-a72c-ac60c4e432fa.png)

# Testing

- [x] Updated and added automated tests
- [x] Manually tested single-precinct, letter-size HMPBs case
- [x] Manually tested all-precincts, letter-size HMPBs case
- [x] Manually tested single-precincts, legal-size HMPBs case
- [x] Manually tested all-precincts, legal-size HMPBs case

# Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced
- [ ] ~I have added JSDoc comments to any newly introduced exports~ N/A
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates