### PR TITLE
chore: sort all `package.json` files

### DIFF
--- a/codemods/package.json
+++ b/codemods/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@votingworks/codemods",
   "private": true,
-  "author": "VotingWorks Eng <eng@voting.works>",
   "license": "GPL-3.0",
+  "author": "VotingWorks Eng <eng@voting.works>",
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "build:watch": "tsc --build --watch tsconfig.build.json",

--- a/integration-testing/bsd/package.json
+++ b/integration-testing/bsd/package.json
@@ -37,6 +37,10 @@
       "last 1 safari version"
     ]
   },
+  "dependencies": {
+    "buffer": "^6.0.3",
+    "js-sha256": "^0.9.0"
+  },
   "devDependencies": {
     "@testing-library/cypress": "^8.0.2",
     "@typescript-eslint/eslint-plugin": "^5.21.0",
@@ -62,9 +66,5 @@
     "sort-package-json": "^1.50.0",
     "start-server-and-test": "^1.12.5",
     "typescript": "4.6.3"
-  },
-  "dependencies": {
-    "buffer": "^6.0.3",
-    "js-sha256": "^0.9.0"
   }
 }

--- a/script/package.json
+++ b/script/package.json
@@ -1,19 +1,19 @@
 {
   "name": "script",
-  "private": true,
   "version": "0.0.1-development",
+  "private": true,
   "description": "",
-  "author": "VotingWorks Eng <eng@voting.works>",
   "license": "GPL-3.0",
+  "author": "VotingWorks Eng <eng@voting.works>",
+  "dependencies": {
+    "resolve-from": "^5.0.0",
+    "yaml": "^2.1.0"
+  },
   "devDependencies": {
     "@types/node": "^16.11.29",
     "esbuild": "^0.13.13",
     "esbuild-runner": "^2.2.1",
     "prettier": "^2.3.1",
     "typescript": "^4.3.4"
-  },
-  "dependencies": {
-    "resolve-from": "^5.0.0",
-    "yaml": "^2.1.0"
   }
 }


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
`pnpx sort-package-json **/package.json`

This should happen for some/most of our packages on commit, but these ones don't have that. ¯\_(ツ)_/¯ 

## Demo Video or Screenshot
n/a

## Testing Plan 
n/a

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
