### PR TITLE
build(bmd): add `vite` as dev & build option

### DIFF
--- a/frontends/bmd/.eslintignore
+++ b/frontends/bmd/.eslintignore
@@ -10,3 +10,4 @@
 /scripts/**/*.js
 /config/**/*.js
 /*.config.js
+/*.config.ts

--- a/frontends/bmd/index.html
+++ b/frontends/bmd/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <link rel="shortcut icon" href="/favicon.ico" />
+  <meta name="viewport" content="width=device-width, user-scalable=no" />
+  <meta name="theme-color" content="#000000" />
+  <title>VotingWorks VxMark</title>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="./src/index.tsx"></script>
+</body>
+
+</html>

--- a/frontends/bmd/package.json
+++ b/frontends/bmd/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "type-check": "tsc --build",
     "build": "tsc --build && node scripts/build.js",
+    "build:vite": "vite build",
     "build:watch": "tsc --build --watch",
     "build:resources": "res-to-ts --rootDir data --outDir src/data 'data/**/*.json'",
     "cypress:open": "cypress open",
@@ -18,6 +19,7 @@
     "lint": "pnpm type-check && eslint . && pnpm stylelint:run",
     "lint:fix": "pnpm type-check && eslint . --fix && pnpm stylelint:run -- --fix",
     "start": "node scripts/start.js",
+    "start:vite": "vite",
     "stylelint:run": "stylelint 'src/**/*.{js,jsx,ts,tsx}' && stylelint 'src/**/*.css' --config .stylelintrc-css.js",
     "test": "is-ci test:ci test:watch",
     "test:ci": "TZ=UTC CI=true node scripts/test.js --maxWorkers 2 --env=jest-environment-jsdom-sixteen --coverage && pnpm build:resources -- --check",
@@ -153,6 +155,7 @@
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^12.1.5",
     "@testing-library/user-event": "^13.5.0",
+    "@types/connect": "^3.4.35",
     "@types/debug": "^4.1.6",
     "@types/history": "^4.7.8",
     "@types/kiosk-browser": "workspace:*",
@@ -201,7 +204,8 @@
     "stylelint-config-prettier": "^8.0.1",
     "stylelint-config-styled-components": "^0.1.1",
     "stylelint-processor-styled-components": "^1.10.0",
-    "ts-jest": "26"
+    "ts-jest": "26",
+    "vite": "^2.9.9"
   },
   "engines": {
     "node": ">= 12"

--- a/frontends/bmd/prodserver/setupProxy.js
+++ b/frontends/bmd/prodserver/setupProxy.js
@@ -6,16 +6,26 @@
 /* eslint-disable */
 /* istanbul ignore file */
 
-const { createProxyMiddleware: proxy } = require('http-proxy-middleware')
+const { createProxyMiddleware: proxy } = require('http-proxy-middleware');
 
+/**
+ * @param {import('connect').Server} app
+ */
 module.exports = function (app) {
-  app.use(proxy('/card', { target: 'http://localhost:3001/' }))
+  app.use(proxy('/card', { target: 'http://localhost:3001/' }));
 
-  app.get('/machine-config', (req, res) => {
-    res.json({
-      appModeKey: process.env.VX_APP_MODE || 'MarkAndPrint',
-      machineId: process.env.VX_MACHINE_ID || '000',
-      codeVersion: process.env.VX_CODE_VERSION || 'dev',
-    })
-  })
-}
+  app.use('/machine-config', (req, res, next) => {
+    if (req.method === 'GET') {
+      res.setHeader('Content-Type', 'application/json');
+      res.end(
+        JSON.stringify({
+          appModeKey: process.env.VX_APP_MODE || 'MarkAndPrint',
+          machineId: process.env.VX_MACHINE_ID || '000',
+          codeVersion: process.env.VX_CODE_VERSION || 'dev',
+        })
+      );
+    } else {
+      next();
+    }
+  });
+};

--- a/frontends/bmd/src/index.tsx
+++ b/frontends/bmd/src/index.tsx
@@ -1,5 +1,4 @@
-import 'setimmediate';
-import 'abortcontroller-polyfill/dist/polyfill-patch-fetch';
+import './polyfills';
 import React from 'react';
 import ReactDom from 'react-dom';
 import { App } from './app';

--- a/frontends/bmd/src/polyfills.ts
+++ b/frontends/bmd/src/polyfills.ts
@@ -1,0 +1,11 @@
+/**
+ * Provides polyfills needed for this application and its dependencies.
+ */
+
+/* istanbul ignore file */
+import 'abortcontroller-polyfill/dist/polyfill-patch-fetch';
+import { Buffer } from 'buffer';
+import 'setimmediate';
+
+globalThis.global = globalThis;
+globalThis.Buffer = Buffer;

--- a/frontends/bmd/vite.config.ts
+++ b/frontends/bmd/vite.config.ts
@@ -1,0 +1,83 @@
+import { join } from 'path';
+import { defineConfig, loadEnv } from 'vite';
+import { getWorkspacePackageInfo } from '../../script/src/validate-monorepo/pnpm';
+import setupProxy from './prodserver/setupProxy';
+
+export default defineConfig(async (env) => {
+  const workspacePackages = await getWorkspacePackageInfo(
+    join(__dirname, '../..')
+  );
+
+  const envPrefix = 'REACT_APP_';
+  const dotenvValues = loadEnv(env.mode, __dirname, envPrefix);
+  const processEnvDefines = Object.entries(dotenvValues).reduce<
+    Record<string, string>
+  >(
+    (acc, [key, value]) => ({
+      ...acc,
+      [`process.env.${key}`]: JSON.stringify(value),
+    }),
+    {}
+  );
+
+  return {
+    build: {
+      // Write build files to `build` directory.
+      outDir: 'build',
+
+      // Do not minify build files. We don't need the space savings and this is
+      // a minor transparency improvement.
+      minify: false,
+    },
+
+    // Replace some code in Node modules, `#define`-style, to avoid referencing
+    // Node-only globals like `process`.
+    define: {
+      'process.env.NODE_DEBUG': 'undefined',
+
+      // TODO: Replace these with the appropriate `import.meta.env` values.
+      ...processEnvDefines,
+    },
+
+    resolve: {
+      alias: {
+        // Replace NodeJS built-in modules with polyfills.
+        //
+        // The trailing slash is important, otherwise it will be resolved as a
+        // built-in NodeJS module.
+        buffer: require.resolve('buffer/'),
+
+        // Create aliases for all workspace packages, i.e.
+        //
+        //   {
+        //     '@votingworks/types': '…/libs/types/src/index.ts',
+        //     '@votingworks/utils': '…/libs/utils/src/index.ts',
+        //      …
+        //   }
+        //
+        // This allows re-mapping imports for workspace packages to their
+        // TypeScript source code rather than the built JavaScript.
+        ...Array.from(workspacePackages.values()).reduce<
+          Record<string, string>
+        >(
+          (aliases, { path, name, source }) =>
+            !source ? aliases : { ...aliases, [name]: join(path, source) },
+          {}
+        ),
+      },
+    },
+
+    plugins: [
+      // Setup the proxy to local services, e.g. `smartcards`.
+      {
+        name: 'development-proxy',
+        configureServer: (app) => {
+          setupProxy(app.middlewares);
+        },
+      },
+    ],
+
+    // Pass some environment variables to the client in `import.meta.env`.
+    envPrefix,
+  };
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -352,6 +352,7 @@ importers:
       '@testing-library/jest-dom': 5.16.4
       '@testing-library/react': 12.1.5_react-dom@17.0.1+react@17.0.1
       '@testing-library/user-event': 13.5.0
+      '@types/connect': 3.4.35
       '@types/debug': 4.1.6
       '@types/history': 4.7.8
       '@types/kiosk-browser': link:../../libs/@types/kiosk-browser
@@ -399,6 +400,7 @@ importers:
       stylelint-config-styled-components: 0.1.1
       stylelint-processor-styled-components: 1.10.0
       ts-jest: 26.5.6_jest@26.6.0+typescript@4.6.3
+      vite: 2.9.9
     specifiers:
       '@babel/core': 7.12.3
       '@babel/runtime': ^7.18.3
@@ -410,6 +412,7 @@ importers:
       '@testing-library/jest-dom': ^5.16.4
       '@testing-library/react': ^12.1.5
       '@testing-library/user-event': ^13.5.0
+      '@types/connect': ^3.4.35
       '@types/debug': ^4.1.6
       '@types/dompurify': ^2.0.4
       '@types/fetch-mock': ^7.3.2
@@ -526,6 +529,7 @@ importers:
       typescript: 4.6.3
       url-loader: 4.1.1
       use-interval: ^1.2.1
+      vite: ^2.9.9
       webpack: 4.44.2
       webpack-dev-server: 3.11.0
       zod: 3.14.4
@@ -8756,7 +8760,7 @@ packages:
       integrity: sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==
   /@types/connect/3.4.35:
     dependencies:
-      '@types/node': 16.11.29
+      '@types/node': 17.0.38
     dev: true
     resolution:
       integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==
@@ -9103,6 +9107,10 @@ packages:
   /@types/node/17.0.36:
     resolution:
       integrity: sha512-V3orv+ggDsWVHP99K3JlwtH20R7J4IhI1Kksgc+64q5VxgfRkQG8Ws3MFm/FZOKDYGy9feGFlZ70/HpCNe9QaA==
+  /@types/node/17.0.38:
+    dev: true
+    resolution:
+      integrity: sha512-5jY9RhV7c0Z4Jy09G+NIDTsCZ5G0L5n+Z+p+Y7t5VJHM30bgwzSjVtlcBxqAj+6L/swIlvtOSzr8rBk/aNyV2g==
   /@types/normalize-package-data/2.4.1:
     resolution:
       integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
@@ -28999,7 +29007,7 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==
-  /rollup/2.75.4:
+  /rollup/2.75.5:
     dev: true
     engines:
       node: '>=10.0.0'
@@ -29007,7 +29015,7 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
     resolution:
-      integrity: sha512-JgZiJMJkKImMZJ8ZY1zU80Z2bA/TvrL/7D9qcBCrfl2bP+HUaIw0QHUroB4E3gBpFl6CRFM1YxGbuYGtdAswbQ==
+      integrity: sha512-JzNlJZDison3o2mOxVmb44Oz7t74EfSd1SQrplQk0wSaXV7uLQXtVdHbxlcT3w+8tZ1TL4r/eLfc7nAbz38BBA==
   /rsvp/4.8.5:
     engines:
       node: 6.* || >= 7.*
@@ -31868,7 +31876,7 @@ packages:
       esbuild: 0.14.42
       postcss: 8.4.14
       resolve: 1.22.0
-      rollup: 2.75.4
+      rollup: 2.75.5
     dev: true
     engines:
       node: '>=12.2.0'


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
Progress toward #1314 

This adds `vite` as a dev & prod build option alongside the (ejected) CRA dev & build setup. This allows us to test that everything is working well before we fully commit to `vite`. I recommend trying these things:
- `pnpm start` should work as it always has
- `pnpm start:vite` should work similarly, but faster
- `pnpm build` should work as it always has
- `pnpm build:vite` should work similarly, but faster

## Demo Video or Screenshot
n/a

## Testing Plan 
Tested configuration and voting + generating a ballot.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
