### PR TITLE
build(bsd): add `vite` as a dev & build option

### DIFF
--- a/frontends/bsd/.eslintignore
+++ b/frontends/bsd/.eslintignore
@@ -2,3 +2,4 @@
 build
 coverage
 types
+/*.config.ts

--- a/frontends/bsd/index.html
+++ b/frontends/bsd/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="shortcut icon" href="/favicon.ico" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <title>VotingWorks VxCentralScan</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./src/index.tsx"></script>
+  </body>
+</html>

--- a/frontends/bsd/package.json
+++ b/frontends/bsd/package.json
@@ -10,12 +10,14 @@
   "scripts": {
     "type-check": "tsc --build",
     "build": "tsc --build && react-scripts build",
+    "build:vite": "vite build",
     "build:watch": "tsc --build --watch",
     "eject": "react-scripts eject",
     "format": "prettier '**/*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
     "lint": "pnpm type-check && eslint . && pnpm stylelint:run",
     "lint:fix": "pnpm type-check && eslint . --fix && pnpm stylelint:run:fix",
     "start": "react-scripts start",
+    "start:vite": "vite",
     "stylelint:run": "stylelint 'src/**/*.{js,jsx,ts,tsx}' && stylelint 'src/**/*.css' --config .stylelintrc-css.js",
     "stylelint:run:fix": "stylelint 'src/**/*.{js,jsx,ts,tsx}' --fix && stylelint 'src/**/*.css' --config .stylelintrc-css.js --fix",
     "test": "is-ci test:coverage test:watch",
@@ -78,6 +80,7 @@
     "@votingworks/ui": "workspace:*",
     "@votingworks/utils": "workspace:*",
     "buffer": "^6.0.3",
+    "events": "^3.3.0",
     "fast-text-encoding": "^1.0.2",
     "http-proxy-middleware": "1.0.6",
     "js-file-download": "^0.4.6",
@@ -101,6 +104,7 @@
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^12.1.5",
     "@testing-library/user-event": "^13.2.1",
+    "@types/connect": "^3.4.35",
     "@types/fast-text-encoding": "^1.0.1",
     "@types/fetch-mock": "^7.3.2",
     "@types/history": "^4.7.8",
@@ -143,6 +147,7 @@
     "stylelint-config-styled-components": "^0.1.1",
     "stylelint-processor-styled-components": "^1.10.0",
     "type-fest": "^0.18.0",
+    "vite": "^2.9.9",
     "zip-stream": "^3.0.1"
   },
   "vx": {

--- a/frontends/bsd/prodserver/setupProxy.js
+++ b/frontends/bsd/prodserver/setupProxy.js
@@ -8,15 +8,25 @@
 
 const { createProxyMiddleware: proxy } = require('http-proxy-middleware');
 
+/**
+ * @param {import('connect').Server} app
+ */
 module.exports = function (app) {
   app.use(proxy('/card', { target: 'http://localhost:3001/' }));
   app.use(proxy('/scan', { target: 'http://localhost:3002/' }));
   app.use(proxy('/config', { target: 'http://localhost:3002/' }));
 
-  app.get('/machine-config', (req, res) => {
-    res.json({
-      machineId: process.env.VX_MACHINE_ID || '0000',
-      codeVersion: process.env.VX_CODE_VERSION || 'dev',
-    });
+  app.use('/machine-config', (req, res, next) => {
+    if (req.method === 'GET') {
+      res.setHeader('Content-Type', 'application/json');
+      res.end(
+        JSON.stringify({
+          machineId: process.env.VX_MACHINE_ID || '0000',
+          codeVersion: process.env.VX_CODE_VERSION || 'dev',
+        })
+      );
+    } else {
+      next();
+    }
   });
 };

--- a/frontends/bsd/src/index.tsx
+++ b/frontends/bsd/src/index.tsx
@@ -1,4 +1,4 @@
-import 'setimmediate';
+import './polyfills';
 import React from 'react';
 import ReactDom from 'react-dom';
 import { App } from './app';

--- a/frontends/bsd/src/polyfills.ts
+++ b/frontends/bsd/src/polyfills.ts
@@ -1,0 +1,10 @@
+/**
+ * Provides polyfills needed for this application and its dependencies.
+ */
+
+/* istanbul ignore file */
+import { Buffer } from 'buffer';
+import 'setimmediate';
+
+globalThis.global = globalThis;
+globalThis.Buffer = Buffer;

--- a/frontends/bsd/vite.config.ts
+++ b/frontends/bsd/vite.config.ts
@@ -1,0 +1,83 @@
+import { join } from 'path';
+import { defineConfig, loadEnv } from 'vite';
+import { getWorkspacePackageInfo } from '../../script/src/validate-monorepo/pnpm';
+import setupProxy from './prodserver/setupProxy';
+
+export default defineConfig(async (env) => {
+  const workspacePackages = await getWorkspacePackageInfo(
+    join(__dirname, '../..')
+  );
+
+  const envPrefix = 'REACT_APP_';
+  const dotenvValues = loadEnv(env.mode, __dirname, envPrefix);
+  const processEnvDefines = Object.entries(dotenvValues).reduce<
+    Record<string, string>
+  >(
+    (acc, [key, value]) => ({
+      ...acc,
+      [`process.env.${key}`]: JSON.stringify(value),
+    }),
+    {}
+  );
+
+  return {
+    build: {
+      // Write build files to `build` directory.
+      outDir: 'build',
+
+      // Do not minify build files. We don't need the space savings and this is
+      // a minor transparency improvement.
+      minify: false,
+    },
+
+    // Replace some code in Node modules, `#define`-style, to avoid referencing
+    // Node-only globals like `process`.
+    define: {
+      'process.env.NODE_DEBUG': 'undefined',
+
+      // TODO: Replace these with the appropriate `import.meta.env` values (#1907).
+      ...processEnvDefines,
+    },
+
+    resolve: {
+      alias: {
+        // Replace NodeJS built-in modules with polyfills.
+        //
+        // The trailing slash is important, otherwise it will be resolved as a
+        // built-in NodeJS module.
+        buffer: require.resolve('buffer/'),
+
+        // Create aliases for all workspace packages, i.e.
+        //
+        //   {
+        //     '@votingworks/types': '…/libs/types/src/index.ts',
+        //     '@votingworks/utils': '…/libs/utils/src/index.ts',
+        //      …
+        //   }
+        //
+        // This allows re-mapping imports for workspace packages to their
+        // TypeScript source code rather than the built JavaScript.
+        ...Array.from(workspacePackages.values()).reduce<
+          Record<string, string>
+        >(
+          (aliases, { path, name, source }) =>
+            !source ? aliases : { ...aliases, [name]: join(path, source) },
+          {}
+        ),
+      },
+    },
+
+    plugins: [
+      // Setup the proxy to local services, e.g. `smartcards`.
+      {
+        name: 'development-proxy',
+        configureServer: (app) => {
+          setupProxy(app.middlewares);
+        },
+      },
+    ],
+
+    // Pass some environment variables to the client in `import.meta.env`.
+    envPrefix,
+  };
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -555,6 +555,7 @@ importers:
       '@votingworks/ui': link:../../libs/ui
       '@votingworks/utils': link:../../libs/utils
       buffer: 6.0.3
+      events: 3.3.0
       fast-text-encoding: 1.0.3
       http-proxy-middleware: 1.0.6
       js-file-download: 0.4.12
@@ -577,6 +578,7 @@ importers:
       '@testing-library/jest-dom': 5.16.4
       '@testing-library/react': 12.1.5_react-dom@17.0.1+react@17.0.1
       '@testing-library/user-event': 13.2.1
+      '@types/connect': 3.4.35
       '@types/fast-text-encoding': 1.0.1
       '@types/fetch-mock': 7.3.3
       '@types/history': 4.7.8
@@ -619,11 +621,13 @@ importers:
       stylelint-config-styled-components: 0.1.1
       stylelint-processor-styled-components: 1.10.0
       type-fest: 0.18.1
+      vite: 2.9.9
       zip-stream: 3.0.1
     specifiers:
       '@testing-library/jest-dom': ^5.16.4
       '@testing-library/react': ^12.1.5
       '@testing-library/user-event': ^13.2.1
+      '@types/connect': ^3.4.35
       '@types/fast-text-encoding': ^1.0.1
       '@types/fetch-mock': ^7.3.2
       '@types/history': ^4.7.8
@@ -662,6 +666,7 @@ importers:
       eslint-plugin-react: ^7.21.5
       eslint-plugin-react-hooks: ^4.2.0
       eslint-plugin-vx: workspace:*
+      events: ^3.3.0
       fast-text-encoding: ^1.0.2
       fetch-mock: ^9.9.0
       history: ^4.10.1
@@ -696,6 +701,7 @@ importers:
       type-fest: ^0.18.0
       typescript: 4.6.3
       use-interval: ^1.2.1
+      vite: ^2.9.9
       zip-stream: ^3.0.1
       zod: 3.14.4
   frontends/bsd/prodserver:
@@ -8760,7 +8766,7 @@ packages:
       integrity: sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==
   /@types/connect/3.4.35:
     dependencies:
-      '@types/node': 17.0.38
+      '@types/node': 17.0.36
     dev: true
     resolution:
       integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==
@@ -9107,10 +9113,6 @@ packages:
   /@types/node/17.0.36:
     resolution:
       integrity: sha512-V3orv+ggDsWVHP99K3JlwtH20R7J4IhI1Kksgc+64q5VxgfRkQG8Ws3MFm/FZOKDYGy9feGFlZ70/HpCNe9QaA==
-  /@types/node/17.0.38:
-    dev: true
-    resolution:
-      integrity: sha512-5jY9RhV7c0Z4Jy09G+NIDTsCZ5G0L5n+Z+p+Y7t5VJHM30bgwzSjVtlcBxqAj+6L/swIlvtOSzr8rBk/aNyV2g==
   /@types/normalize-package-data/2.4.1:
     resolution:
       integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
@@ -19331,6 +19333,12 @@ packages:
       node: '>=0.8.x'
     resolution:
       integrity: sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==
+  /events/3.3.0:
+    dev: false
+    engines:
+      node: '>=0.8.x'
+    resolution:
+      integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
   /eventsource/1.0.7:
     dependencies:
       original: 1.0.2


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
Progress toward #1314 

This adds `vite` as a dev & prod build option alongside the (un-ejected) CRA dev & build setup. This allows us to test that everything is working well before we fully commit to `vite`. I did this one differently from `bas` and `bmd` because we don't _really_ need to eject to add the `vite` option. As with #1906, I recommend trying these things:
- `pnpm start` should work as it always has
- `pnpm start:vite` should work similarly, but faster
- `pnpm build` should work as it always has
- `pnpm build:vite` should work similarly, but faster

## Demo Video or Screenshot
n/a

## Testing Plan 
Configured `services/scan` via `bsd` UI. Scanned a NH ballot with a real scanner.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
