### PR TITLE
chore(vscode): Don't auto-delete unreachable code

### DIFF
--- a/vxsuite.code-workspace
+++ b/vxsuite.code-workspace
@@ -110,8 +110,10 @@
     }
   ],
   "settings": {
+    "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-      "source.fixAll": true
+      "source.fixAll.eslint": true,
+      "source.fixAll.stylelint": true
     },
     "cSpell.words": [
       "accuvote",


### PR DESCRIPTION
## Overview
VS Code can detect unreachable code using TS and show a warning. Our current workspace settings have `editor.codeActionsOnSave.source.fixAll: true` which causes this unreachable code to get auto-deleted. I've run into a number of bugs where VS Code aggressively deleted unreachable code because I saved in an intermediate state (intending to trigger auto-formatting via prettier). I think a warning for unreachable code is fine and it doesn't need to be auto-fixed, so I turned off this `fixAll` setting and changed it to fix only eslint and stylelint errors automatically.


## Demo Video or Screenshot
N/A

## Testing Plan 
N/A

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
