### PR TITLE
refactor(bmd): Use useSmartcardAuth for voters

### DIFF
--- a/frontends/bmd/src/app_card_unhappy_paths.test.tsx
+++ b/frontends/bmd/src/app_card_unhappy_paths.test.tsx
@@ -17,9 +17,9 @@ import {
   utcTimestamp,
 } from '@votingworks/utils';
 
+import { VOTER_CARD_EXPIRATION_SECONDS } from '@votingworks/ui';
 import { App } from './app';
 
-import { CARD_EXPIRATION_SECONDS } from './config/globals';
 import {
   advanceTimersAndPromises,
   makeExpiredVoterCard,
@@ -102,7 +102,7 @@ test('Display App Card Unhappy Paths', async () => {
 
   // Voter Card which eventually expires
   const expiringCard = makeVoterCard(electionSample, {
-    c: utcTimestamp() - CARD_EXPIRATION_SECONDS + 5 * 60, // 5 minutes until expiration
+    c: utcTimestamp() - VOTER_CARD_EXPIRATION_SECONDS + 5 * 60, // 5 minutes until expiration
   });
 
   // First Insert is Good

--- a/frontends/bmd/src/app_card_unhappy_paths.test.tsx
+++ b/frontends/bmd/src/app_card_unhappy_paths.test.tsx
@@ -10,7 +10,12 @@ import {
   makeVoterCard,
   makePollWorkerCard,
 } from '@votingworks/test-utils';
-import { MemoryStorage, MemoryCard, MemoryHardware } from '@votingworks/utils';
+import {
+  MemoryStorage,
+  MemoryCard,
+  MemoryHardware,
+  utcTimestamp,
+} from '@votingworks/utils';
 
 import { App } from './app';
 
@@ -25,7 +30,6 @@ import {
   setElectionInStorage,
   setStateInStorage,
 } from '../test/helpers/election';
-import { utcTimestamp } from './utils/utc_timestamp';
 import { fakeMachineConfigProvider } from '../test/helpers/fake_machine_config';
 import { PrintOnly } from './config/types';
 

--- a/frontends/bmd/src/app_cardless_voting.test.tsx
+++ b/frontends/bmd/src/app_cardless_voting.test.tsx
@@ -280,6 +280,7 @@ test('Another Voter submits blank ballot and clicks Done', async () => {
 
   // Click "Done" to get back to Insert Card screen
   fireEvent.click(screen.getByText('Done'));
+  await advanceTimersAndPromises();
   screen.getByText('Insert voter card to load ballot.');
 });
 

--- a/frontends/bmd/src/app_data.test.tsx
+++ b/frontends/bmd/src/app_data.test.tsx
@@ -4,7 +4,7 @@ import { MemoryStorage, MemoryCard, MemoryHardware } from '@votingworks/utils';
 
 import { App } from './app';
 import { DemoApp, getDemoStorage } from './demo_app';
-import { activationStorageKey, electionStorageKey } from './app_root';
+import { electionStorageKey } from './app_root';
 
 import {
   election,
@@ -73,6 +73,5 @@ describe('loads election', () => {
     screen.getByText(/Center Springfield/);
     screen.getByText(/ballot style 12/);
     expect(storage.get(electionStorageKey)).toBeTruthy();
-    expect(storage.get(activationStorageKey)).toBeTruthy();
   });
 });

--- a/frontends/bmd/src/app_end_to_end.test.tsx
+++ b/frontends/bmd/src/app_end_to_end.test.tsx
@@ -136,6 +136,7 @@ it('MarkAndPrint end-to-end flow', async () => {
   screen.getByText('Card is not configured for this election.');
   screen.getByText('Please ask admin for assistance.');
   card.removeCard();
+  await advanceTimersAndPromises();
 
   // Open Polls with Poll Worker Card
   card.insertCard(pollWorkerCard);
@@ -389,11 +390,15 @@ it('MarkAndPrint end-to-end flow', async () => {
 
   expect(writeLongUint8ArrayMock).toHaveBeenCalledTimes(4);
   expect(writeLongUint8ArrayMock).toHaveBeenNthCalledWith(4, new Uint8Array());
+  card.removeCard();
+  await advanceTimersAndPromises();
 
   // Insert SuperAdmin card
   card.insertCard({ t: 'superadmin' });
   await advanceTimersAndPromises();
   screen.getByText('Reboot from USB');
+  card.removeCard();
+  await advanceTimersAndPromises();
 
   // ---------------
 

--- a/frontends/bmd/src/app_mark_voter_card_invalid.test.tsx
+++ b/frontends/bmd/src/app_mark_voter_card_invalid.test.tsx
@@ -89,11 +89,6 @@ describe('Mark Card Void when voter is idle too long', () => {
 
     // Idle reset timeout expires
     await advanceTimersAndPromises();
-
-    // Insert Card screen displays while card is read again.
-    screen.getByText('Insert Card');
-
-    // Card read again and now displays expired msg.
     await advanceTimersAndPromises();
     screen.getByText('Expired Card');
 
@@ -166,11 +161,8 @@ describe('Mark Card Void when voter is idle too long', () => {
     advanceTimers(IDLE_RESET_TIMEOUT_SECONDS - secondsRemaining);
     screen.getByText(`${secondsRemaining} seconds`);
 
-    advanceTimers(secondsRemaining);
-    screen.getByText('Clearing ballot');
-
     // Idle reset timeout expires
-    await advanceTimersAndPromises();
+    advanceTimers(secondsRemaining);
 
     // Insert voter card screen is displayed.
     screen.getByText('Insert voter card to load ballot.');

--- a/frontends/bmd/src/app_refresh.test.tsx
+++ b/frontends/bmd/src/app_refresh.test.tsx
@@ -85,8 +85,6 @@ it('Refresh window and expect to be on same contest', async () => {
   ));
 
   await advanceTimersAndPromises();
-  await advanceTimersAndPromises(1);
-  advanceTimers();
 
   // App is on first contest
   await waitFor(() => getByText(presidentContest.title));

--- a/frontends/bmd/src/app_root.tsx
+++ b/frontends/bmd/src/app_root.tsx
@@ -88,7 +88,6 @@ import { UnconfiguredScreen } from './pages/unconfigured_screen';
 import { UsedCardScreen } from './pages/used_card_screen';
 import { WrongElectionScreen } from './pages/wrong_election_screen';
 import { WrongPrecinctScreen } from './pages/wrong_precinct_screen';
-import { utcTimestamp } from './utils/utc_timestamp';
 import { ScreenReader } from './utils/ScreenReader';
 import { ReplaceElectionScreen } from './pages/replace_election_screen';
 import { CardErrorScreen } from './pages/card_error_screen';

--- a/frontends/bmd/src/components/__snapshots__/focus_manager.test.tsx.snap
+++ b/frontends/bmd/src/components/__snapshots__/focus_manager.test.tsx.snap
@@ -9,10 +9,14 @@ exports[`renders FocusManager 1`] = `
   outline: none;
 }
 
-<div
-  class="c0"
-  tabindex="-1"
->
-  foo
+<div>
+  <div
+    class="c0"
+    tabindex="-1"
+  >
+    <div>
+      foo
+    </div>
+  </div>
 </div>
 `;

--- a/frontends/bmd/src/components/focus_manager.test.tsx
+++ b/frontends/bmd/src/components/focus_manager.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
 import { render } from '../../test/test_utils';
 
 import { FocusManager } from './focus_manager';
@@ -12,8 +13,23 @@ it('renders FocusManager', () => {
     <FocusManager
       screenReader={new AriaScreenReader(new SpeechSynthesisTextToSpeech())}
     >
-      foo
+      <div>foo</div>
     </FocusManager>
   );
-  expect(container.firstChild).toMatchSnapshot();
+  expect(container).toMatchSnapshot();
+});
+
+it('focuses the element with id audiofocus', async () => {
+  render(
+    <FocusManager
+      screenReader={new AriaScreenReader(new SpeechSynthesisTextToSpeech())}
+    >
+      <button type="button">dont focus me</button>
+      <button type="button" id="audiofocus">
+        focus me
+      </button>
+    </FocusManager>
+  );
+  await waitFor(() => expect(screen.getByText('focus me')).toHaveFocus());
+  expect(screen.getByText('dont focus me')).not.toHaveFocus();
 });

--- a/frontends/bmd/src/components/focus_manager.tsx
+++ b/frontends/bmd/src/components/focus_manager.tsx
@@ -45,8 +45,10 @@ export function FocusManager({
       window.setTimeout(() => {
         const elementToFocus =
           document.getElementById('audiofocus') ?? screen.current;
-        elementToFocus?.focus();
-        elementToFocus?.click();
+        /* istanbul ignore next */
+        if (!elementToFocus) return;
+        elementToFocus.focus();
+        elementToFocus.click();
       }, 150);
     }
     onPageLoad();

--- a/frontends/bmd/src/config/globals.ts
+++ b/frontends/bmd/src/config/globals.ts
@@ -1,7 +1,6 @@
 export const IDLE_TIMEOUT_SECONDS = 5 * 60; // 5 minute
 export const IDLE_RESET_TIMEOUT_SECONDS = 1 * 60; // 1 minute
 export const RECENT_PRINT_EXPIRATION_SECONDS = 1 * 60; // 1 minute
-export const CARD_EXPIRATION_SECONDS = 60 * 60; // 1 hour
 export const CARD_POLLING_INTERVAL = 200;
 export const CARD_LONG_VALUE_WRITE_DELAY = 1000;
 export const BALLOT_PRINTING_TIMEOUT_SECONDS = 5;

--- a/frontends/bmd/src/config/types.ts
+++ b/frontends/bmd/src/config/types.ts
@@ -1,5 +1,4 @@
 import {
-  BallotStyle,
   BallotStyleId,
   CandidateContest,
   CandidateVote,
@@ -88,17 +87,6 @@ export type SelectChangeEventFunction =
   React.ChangeEventHandler<HTMLSelectElement>;
 
 // Election
-export interface ActivationData {
-  ballotStyle: BallotStyle;
-  precinct: Precinct;
-}
-
-export interface SerializableActivationData {
-  ballotStyleId: BallotStyleId;
-  isCardlessVoter: boolean;
-  precinctId: PrecinctId;
-}
-
 export enum PrecinctSelectionKind {
   SinglePrecinct = 'SinglePrecinct',
   AllPrecincts = 'AllPrecincts',

--- a/frontends/bmd/src/demo_app.tsx
+++ b/frontends/bmd/src/demo_app.tsx
@@ -14,7 +14,6 @@ import { App, Props } from './app';
 import {
   MachineConfig,
   PrecinctSelectionKind,
-  SerializableActivationData,
   MarkAndPrint,
 } from './config/types';
 import { State } from './app_root';
@@ -44,19 +43,10 @@ export function getDemoStorage(): Storage {
     ballotsPrintedCount: 0,
     isLiveMode: true,
     isPollsOpen: true,
-    ballotStyleId,
-    isCardlessVoter: false,
-    precinctId,
-  };
-  const activation: SerializableActivationData = {
-    ballotStyleId,
-    isCardlessVoter: false,
-    precinctId,
   };
   return new MemoryStorage({
     state,
     electionDefinition: electionSampleDefinition,
-    activation,
   });
 }
 

--- a/frontends/bmd/src/demo_app.tsx
+++ b/frontends/bmd/src/demo_app.tsx
@@ -8,9 +8,9 @@ import {
   Storage,
   MemoryStorage,
   MemoryHardware,
+  utcTimestamp,
 } from '@votingworks/utils';
 import { App, Props } from './app';
-import { utcTimestamp } from './utils/utc_timestamp';
 import {
   MachineConfig,
   PrecinctSelectionKind,

--- a/frontends/bmd/src/pages/idle_page.tsx
+++ b/frontends/bmd/src/pages/idle_page.tsx
@@ -30,8 +30,8 @@ export function IdlePage(): JSX.Element {
       await markVoterCardVoided();
       resetBallot();
     }
-    if (countdown === 0) void reset();
-  }, [countdown, markVoterCardVoided, resetBallot]);
+    if (countdown === 0 && !isLoading) void reset();
+  }, [countdown, markVoterCardVoided, resetBallot, isLoading]);
 
   useInterval(() => {
     setCountdown((previous) => previous - 1);

--- a/frontends/bmd/src/pages/print_only_screen.tsx
+++ b/frontends/bmd/src/pages/print_only_screen.tsx
@@ -110,6 +110,7 @@ export function PrintOnlyScreen({
     }
   }, [isVoterCardPresent, okToPrint, setOkToPrint]);
 
+  // Make sure we clean up any pending timeout on unmount
   useEffect(() => {
     return () => {
       clearTimeout(printerTimer.current);

--- a/frontends/bmd/src/pages/print_page.tsx
+++ b/frontends/bmd/src/pages/print_page.tsx
@@ -76,10 +76,14 @@ export function PrintPage(): JSX.Element {
         void printBallot();
       });
     }
+  }, [printBallot, votes]);
+
+  // Make sure we clean up any pending timeout on unmount
+  useEffect(() => {
     return () => {
       clearTimeout(printerTimer.current);
     };
-  }, [printBallot, votes]);
+  }, []);
 
   return (
     <React.Fragment>

--- a/frontends/bmd/src/utils/utc_timestamp.ts
+++ b/frontends/bmd/src/utils/utc_timestamp.ts
@@ -1,7 +1,0 @@
-/**
- * Returns current UTC unix timestamp (epoch) in seconds
- */
-
-export function utcTimestamp(): number {
-  return Math.round(Date.now() / 1000);
-}

--- a/frontends/bmd/test/helpers/smartcards.ts
+++ b/frontends/bmd/test/helpers/smartcards.ts
@@ -15,6 +15,7 @@ import {
   VotesDict,
   VoterCardData,
 } from '@votingworks/types';
+import { VOTER_CARD_EXPIRATION_SECONDS } from '@votingworks/ui';
 import { utcTimestamp } from '@votingworks/utils';
 import * as GLOBALS from '../../src/config/globals';
 
@@ -144,7 +145,7 @@ export function makeOtherElectionVoterCard(
 
 export function makeExpiredVoterCard(e = election): VoterCardData {
   return makeVoterCard(e, {
-    c: utcTimestamp() - GLOBALS.CARD_EXPIRATION_SECONDS,
+    c: utcTimestamp() - VOTER_CARD_EXPIRATION_SECONDS,
   });
 }
 

--- a/frontends/bmd/test/helpers/smartcards.ts
+++ b/frontends/bmd/test/helpers/smartcards.ts
@@ -15,8 +15,8 @@ import {
   VotesDict,
   VoterCardData,
 } from '@votingworks/types';
+import { utcTimestamp } from '@votingworks/utils';
 import * as GLOBALS from '../../src/config/globals';
-import { utcTimestamp } from '../../src/utils/utc_timestamp';
 
 const contest0 = election.contests[0] as CandidateContest;
 const contest1 = election.contests[1] as CandidateContest;

--- a/libs/test-utils/src/smartcard_auth.ts
+++ b/libs/test-utils/src/smartcard_auth.ts
@@ -9,6 +9,8 @@ import {
   PollworkerLoggedInAuth,
   VoterLoggedInAuth,
   LoggedOutAuth,
+  CardlessVoterUser,
+  CardlessVoterLoggedInAuth,
 } from '@votingworks/types';
 
 export function fakeCardStorage(props: Partial<CardStorage> = {}): CardStorage {
@@ -57,6 +59,17 @@ export function fakeVoterUser(props: Partial<VoterUser> = {}): VoterUser {
   };
 }
 
+export function fakeCardlessVoterUser(
+  props: Partial<CardlessVoterUser> = {}
+): CardlessVoterUser {
+  return {
+    role: 'cardless_voter',
+    ballotStyleId: 'fake-ballot-style-id',
+    precinctId: 'fake-precinct-id',
+    ...props,
+  };
+}
+
 export function fakeSuperadminAuth(
   card: Partial<CardStorage> = {}
 ): SuperadminLoggedInAuth {
@@ -86,6 +99,8 @@ export function fakePollworkerAuth(
     status: 'logged_in',
     user: fakePollworkerUser(user),
     card: fakeCardStorage(card),
+    activateCardlessVoter: jest.fn(),
+    deactivateCardlessVoter: jest.fn(),
   };
 }
 
@@ -97,6 +112,18 @@ export function fakeVoterAuth(
     status: 'logged_in',
     user: fakeVoterUser(user),
     card: fakeCardStorage(card),
+    markCardVoided: jest.fn(),
+    markCardPrinted: jest.fn(),
+  };
+}
+
+export function fakeCardlessVoterAuth(
+  user: Partial<CardlessVoterUser> = {}
+): CardlessVoterLoggedInAuth {
+  return {
+    status: 'logged_in',
+    user: fakeCardlessVoterUser(user),
+    logOut: jest.fn(),
   };
 }
 

--- a/libs/types/src/smartcard_auth.ts
+++ b/libs/types/src/smartcard_auth.ts
@@ -181,6 +181,10 @@ export interface PollworkerLoggedInAuth {
   readonly status: 'logged_in';
   readonly user: PollworkerUser;
   readonly card: CardStorage;
+  // A pollworker can "activate" a cardless voter session by selecting a
+  // precinct and ballot style. The activated cardless voter session begins when
+  // the pollworker removes their card, at which point the auth switches to
+  // CardlessVoterLoggedInAuth.
   readonly activateCardlessVoter: (
     precinctId: PrecinctId,
     ballotStyleId: BallotStyleId

--- a/libs/types/src/smartcard_auth.ts
+++ b/libs/types/src/smartcard_auth.ts
@@ -1,4 +1,5 @@
 import * as z from 'zod';
+import { BallotStyleId, PrecinctId } from './election';
 import { ElectionHash, IdSchema, Optional } from './generic';
 import { Result } from './result';
 
@@ -25,7 +26,17 @@ export interface VoterUser {
   readonly updatedAt?: number;
   readonly markMachineId?: string;
 }
-export type User = SuperadminUser | AdminUser | PollworkerUser | VoterUser;
+export interface CardlessVoterUser {
+  readonly role: 'cardless_voter';
+  readonly ballotStyleId: BallotStyleId;
+  readonly precinctId: PrecinctId;
+}
+export type User =
+  | SuperadminUser
+  | AdminUser
+  | PollworkerUser
+  | VoterUser
+  | CardlessVoterUser;
 
 export type UserRole = User['role'];
 export const UserRoleSchema: z.ZodSchema<UserRole> = z.union([
@@ -146,7 +157,12 @@ export interface LoggedOutAuth {
     | 'invalid_user_on_card'
     | 'user_role_not_allowed'
     | 'machine_not_configured'
-    | 'pollworker_election_hash_mismatch';
+    | 'pollworker_wrong_election'
+    | 'voter_wrong_election'
+    | 'voter_wrong_precinct'
+    | 'voter_card_expired'
+    | 'voter_card_voided'
+    | 'voter_card_printed';
 }
 
 export interface SuperadminLoggedInAuth {
@@ -165,18 +181,33 @@ export interface PollworkerLoggedInAuth {
   readonly status: 'logged_in';
   readonly user: PollworkerUser;
   readonly card: CardStorage;
+  readonly activateCardlessVoter: (
+    precinctId: PrecinctId,
+    ballotStyleId: BallotStyleId
+  ) => void;
+  readonly deactivateCardlessVoter: () => void;
+  readonly activatedCardlessVoter?: CardlessVoterUser;
 }
 
 export interface VoterLoggedInAuth {
   readonly status: 'logged_in';
   readonly user: VoterUser;
   readonly card: CardStorage;
+  readonly markCardVoided: () => Promise<Result<void, Error>>;
+  readonly markCardPrinted: () => Promise<Result<void, Error>>;
+}
+
+export interface CardlessVoterLoggedInAuth {
+  readonly status: 'logged_in';
+  readonly user: CardlessVoterUser;
+  readonly logOut: () => void;
 }
 
 export type LoggedInAuth =
   | SuperadminLoggedInAuth
   | AdminLoggedInAuth
   | PollworkerLoggedInAuth
-  | VoterLoggedInAuth;
+  | VoterLoggedInAuth
+  | CardlessVoterLoggedInAuth;
 
 export type SmartcardAuth = LoggedOutAuth | LoggedInAuth;

--- a/libs/ui/src/hooks/use_smartcard_auth.test.ts
+++ b/libs/ui/src/hooks/use_smartcard_auth.test.ts
@@ -1,7 +1,8 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
 import {
   electionSample2Definition,
   electionSampleDefinition,
+  electionMinimalExhaustiveSampleDefinition,
 } from '@votingworks/fixtures';
 import {
   fakeSuperadminAuth,
@@ -17,16 +18,25 @@ import {
   fakePollworkerUser,
   makeVoterCard,
   fakeVoterUser,
+  fakeCardlessVoterUser,
 } from '@votingworks/test-utils';
-import { ElectionDefinitionSchema, err, UserRole } from '@votingworks/types';
-import { assert, MemoryCard } from '@votingworks/utils';
+import {
+  ElectionDefinitionSchema,
+  err,
+  PrecinctSelection,
+  PrecinctSelectionKind,
+  UserRole,
+} from '@votingworks/types';
+import { assert, MemoryCard, utcTimestamp } from '@votingworks/utils';
 import { CARD_POLLING_INTERVAL } from './use_smartcard';
 import {
   isAdminAuth,
+  isCardlessVoterAuth,
   isPollworkerAuth,
   isSuperadminAuth,
   isVoterAuth,
   useSmartcardAuth,
+  VOTER_CARD_EXPIRATION_SECONDS,
 } from './use_smartcard_auth';
 
 const allowedUserRoles: UserRole[] = [
@@ -34,10 +44,16 @@ const allowedUserRoles: UserRole[] = [
   'admin',
   'pollworker',
   'voter',
+  'cardless_voter',
 ];
 
 const electionDefinition = electionSampleDefinition;
 const { electionHash, election } = electionDefinition;
+const precinct: PrecinctSelection = {
+  kind: PrecinctSelectionKind.SinglePrecinct,
+  precinctId: election.precincts[0].id,
+};
+const ballotStyle = election.ballotStyles[0];
 
 describe('useSmartcardAuth', () => {
   beforeEach(() => jest.useFakeTimers());
@@ -46,7 +62,7 @@ describe('useSmartcardAuth', () => {
     const cardApi = new MemoryCard();
     cardApi.insertCard(undefined, undefined, 'error');
     const { result, waitForNextUpdate } = renderHook(() =>
-      useSmartcardAuth({ cardApi, allowedUserRoles })
+      useSmartcardAuth({ cardApi, allowedUserRoles, scope: {} })
     );
     // Default before reading card is logged_out
     expect(result.current).toEqual({ status: 'logged_out', reason: 'no_card' });
@@ -69,7 +85,7 @@ describe('useSmartcardAuth', () => {
     const cardApi = new MemoryCard();
     cardApi.insertCard();
     const { result, waitForNextUpdate } = renderHook(() =>
-      useSmartcardAuth({ cardApi, allowedUserRoles })
+      useSmartcardAuth({ cardApi, allowedUserRoles, scope: {} })
     );
     jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
@@ -93,8 +109,8 @@ describe('useSmartcardAuth', () => {
     const { result, waitForNextUpdate } = renderHook(() =>
       useSmartcardAuth({
         cardApi,
-        electionDefinition,
         allowedUserRoles: ['superadmin', 'admin'],
+        scope: { electionDefinition },
       })
     );
     jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
@@ -111,8 +127,8 @@ describe('useSmartcardAuth', () => {
     const { result, waitForNextUpdate } = renderHook(() =>
       useSmartcardAuth({
         cardApi,
-        electionDefinition,
         allowedUserRoles: ['superadmin', 'admin'],
+        scope: { electionDefinition },
       })
     );
     jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
@@ -127,7 +143,7 @@ describe('useSmartcardAuth', () => {
     const cardApi = new MemoryCard();
     cardApi.insertCard(makePollWorkerCard(electionHash));
     const { result, waitForNextUpdate } = renderHook(() =>
-      useSmartcardAuth({ cardApi, allowedUserRoles })
+      useSmartcardAuth({ cardApi, allowedUserRoles, scope: {} })
     );
     jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
@@ -144,14 +160,166 @@ describe('useSmartcardAuth', () => {
       useSmartcardAuth({
         cardApi,
         allowedUserRoles,
-        electionDefinition: electionSample2Definition,
+        scope: { electionDefinition: electionSample2Definition },
       })
     );
     jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toEqual({
       status: 'logged_out',
-      reason: 'pollworker_election_hash_mismatch',
+      reason: 'pollworker_wrong_election',
+    });
+  });
+
+  it('returns logged_out auth when using a voter card that has expired', async () => {
+    const cardApi = new MemoryCard();
+    cardApi.insertCard(
+      makeVoterCard(election, {
+        c: utcTimestamp() - VOTER_CARD_EXPIRATION_SECONDS,
+      })
+    );
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useSmartcardAuth({
+        cardApi,
+        allowedUserRoles,
+        scope: { electionDefinition, precinct },
+      })
+    );
+    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
+    await waitForNextUpdate();
+    expect(result.current).toEqual({
+      status: 'logged_out',
+      reason: 'voter_card_expired',
+    });
+  });
+
+  it('returns logged_out auth when using a voter card if the machine is not configured', async () => {
+    const cardApi = new MemoryCard();
+    cardApi.insertCard(makeVoterCard(election));
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useSmartcardAuth({ cardApi, allowedUserRoles, scope: {} })
+    );
+    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
+    await waitForNextUpdate();
+    expect(result.current).toEqual({
+      status: 'logged_out',
+      reason: 'machine_not_configured',
+    });
+  });
+
+  it('returns logged_out auth when using a voter card with a ballot style that doesnt match the configured election', async () => {
+    const cardApi = new MemoryCard();
+    cardApi.insertCard(makeVoterCard(election));
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useSmartcardAuth({
+        cardApi,
+        allowedUserRoles,
+        scope: {
+          electionDefinition: electionMinimalExhaustiveSampleDefinition,
+          precinct,
+        },
+      })
+    );
+    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
+    await waitForNextUpdate();
+    expect(result.current).toEqual({
+      status: 'logged_out',
+      reason: 'voter_wrong_election',
+    });
+  });
+
+  it('returns logged_out auth when using a voter card with a precinct that doesnt match the configured election', async () => {
+    const cardApi = new MemoryCard();
+    cardApi.insertCard(makeVoterCard(election));
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useSmartcardAuth({
+        cardApi,
+        allowedUserRoles,
+        scope: {
+          electionDefinition: electionMinimalExhaustiveSampleDefinition,
+          precinct,
+        },
+      })
+    );
+    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
+    await waitForNextUpdate();
+    expect(result.current).toEqual({
+      status: 'logged_out',
+      reason: 'voter_wrong_election',
+    });
+  });
+
+  it('returns logged_out auth when using a voter card with a precinct that doesnt match the configured precinct', async () => {
+    const cardApi = new MemoryCard();
+    cardApi.insertCard(
+      makeVoterCard(election, { pr: election.precincts[1].id })
+    );
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useSmartcardAuth({
+        cardApi,
+        allowedUserRoles,
+        scope: { electionDefinition, precinct },
+      })
+    );
+    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
+    await waitForNextUpdate();
+    expect(result.current).toEqual({
+      status: 'logged_out',
+      reason: 'voter_wrong_precinct',
+    });
+  });
+
+  it('returns logged_in auth when using a voter card and all precincts are configured', async () => {
+    const cardApi = new MemoryCard();
+    cardApi.insertCard(makeVoterCard(election));
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useSmartcardAuth({
+        cardApi,
+        allowedUserRoles,
+        scope: {
+          electionDefinition,
+          precinct: { kind: PrecinctSelectionKind.AllPrecincts },
+        },
+      })
+    );
+    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
+    await waitForNextUpdate();
+    expect(result.current).toMatchObject({ status: 'logged_in' });
+  });
+
+  it('returns logged_out auth for a voided voter card', async () => {
+    const cardApi = new MemoryCard();
+    cardApi.insertCard(makeVoterCard(election, { uz: 1 }));
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useSmartcardAuth({
+        cardApi,
+        allowedUserRoles,
+        scope: { electionDefinition, precinct },
+      })
+    );
+    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
+    await waitForNextUpdate();
+    expect(result.current).toEqual({
+      status: 'logged_out',
+      reason: 'voter_card_voided',
+    });
+  });
+
+  it('returns logged_out auth for a printed voter card', async () => {
+    const cardApi = new MemoryCard();
+    cardApi.insertCard(makeVoterCard(election, { bp: 1 }));
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useSmartcardAuth({
+        cardApi,
+        allowedUserRoles,
+        scope: { electionDefinition, precinct },
+      })
+    );
+    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
+    await waitForNextUpdate();
+    expect(result.current).toEqual({
+      status: 'logged_out',
+      reason: 'voter_card_printed',
     });
   });
 
@@ -159,7 +327,7 @@ describe('useSmartcardAuth', () => {
     const cardApi = new MemoryCard();
     cardApi.insertCard(makeSuperadminCard());
     const { result, waitForNextUpdate } = renderHook(() =>
-      useSmartcardAuth({ cardApi, allowedUserRoles })
+      useSmartcardAuth({ cardApi, allowedUserRoles, scope: {} })
     );
     jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
@@ -174,7 +342,7 @@ describe('useSmartcardAuth', () => {
     const cardApi = new MemoryCard();
     cardApi.insertCard(makeAdminCard(electionHash));
     const { result, waitForNextUpdate } = renderHook(() =>
-      useSmartcardAuth({ cardApi, allowedUserRoles })
+      useSmartcardAuth({ cardApi, allowedUserRoles, scope: {} })
     );
     jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
@@ -189,7 +357,11 @@ describe('useSmartcardAuth', () => {
     const cardApi = new MemoryCard();
     cardApi.insertCard(makePollWorkerCard(electionHash));
     const { result, waitForNextUpdate } = renderHook(() =>
-      useSmartcardAuth({ cardApi, allowedUserRoles, electionDefinition })
+      useSmartcardAuth({
+        cardApi,
+        allowedUserRoles,
+        scope: { electionDefinition },
+      })
     );
     jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
@@ -205,7 +377,11 @@ describe('useSmartcardAuth', () => {
     const voterCard = makeVoterCard(election);
     cardApi.insertCard(voterCard);
     const { result, waitForNextUpdate } = renderHook(() =>
-      useSmartcardAuth({ cardApi, allowedUserRoles, electionDefinition })
+      useSmartcardAuth({
+        cardApi,
+        allowedUserRoles,
+        scope: { electionDefinition, precinct },
+      })
     );
     jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
@@ -217,14 +393,129 @@ describe('useSmartcardAuth', () => {
         createdAt: voterCard.c,
       }),
       card: expect.any(Object),
+      markCardVoided: expect.any(Function),
+      markCardPrinted: expect.any(Function),
     });
+  });
+
+  it('for a logged in voter, marks the voter card voided', async () => {
+    const cardApi = new MemoryCard();
+    const voterCard = makeVoterCard(election);
+    cardApi.insertCard(voterCard);
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useSmartcardAuth({
+        cardApi,
+        allowedUserRoles,
+        scope: { electionDefinition, precinct },
+      })
+    );
+    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
+    await waitForNextUpdate();
+    assert(isVoterAuth(result.current));
+    await result.current.markCardVoided();
+    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
+    await waitForNextUpdate();
+    expect(result.current).toEqual({
+      status: 'logged_out',
+      reason: 'voter_card_voided',
+    });
+  });
+
+  it('for a logged in voter, handles an error marking the voter card voided', async () => {
+    const cardApi = new MemoryCard();
+    const voterCard = makeVoterCard(election);
+    cardApi.insertCard(voterCard);
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useSmartcardAuth({
+        cardApi,
+        allowedUserRoles,
+        scope: { electionDefinition, precinct },
+      })
+    );
+    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
+    await waitForNextUpdate();
+    assert(isVoterAuth(result.current));
+    const error = new Error('test error');
+    jest.spyOn(cardApi, 'writeShortValue').mockRejectedValue(error);
+    expect((await result.current.markCardVoided()).err()).toEqual(error);
+  });
+
+  it('for a logged in voter, marks the voter card printed', async () => {
+    const cardApi = new MemoryCard();
+    const voterCard = makeVoterCard(election);
+    cardApi.insertCard(voterCard);
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useSmartcardAuth({
+        cardApi,
+        allowedUserRoles,
+        scope: { electionDefinition, precinct },
+      })
+    );
+    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
+    await waitForNextUpdate();
+    assert(isVoterAuth(result.current));
+    await result.current.markCardPrinted();
+    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
+    await waitForNextUpdate();
+    // Shouldn't log out until card removed
+    expect(result.current.status).toEqual('logged_in');
+    cardApi.removeCard();
+    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
+    await waitForNextUpdate();
+    expect(result.current.status).toEqual('logged_out');
+  });
+
+  it('for a logged in voter, handles an error marking the voter card printed', async () => {
+    const cardApi = new MemoryCard();
+    const voterCard = makeVoterCard(election);
+    cardApi.insertCard(voterCard);
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useSmartcardAuth({
+        cardApi,
+        allowedUserRoles,
+        scope: { electionDefinition, precinct },
+      })
+    );
+    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
+    await waitForNextUpdate();
+    assert(isVoterAuth(result.current));
+    const error = new Error('test error');
+    jest.spyOn(cardApi, 'writeShortValue').mockRejectedValue(error);
+    expect((await result.current.markCardPrinted()).err()).toEqual(error);
+  });
+
+  // There's one lock applied to voiding, printing, and all long value writes,
+  // but here we just test voiding/printing and cover long value writes below.
+  it('raises an error on concurrent voiding/printing', async () => {
+    const cardApi = new MemoryCard();
+    const voterCard = makeVoterCard(election);
+    cardApi.insertCard(voterCard);
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useSmartcardAuth({
+        cardApi,
+        allowedUserRoles,
+        scope: { electionDefinition, precinct },
+      })
+    );
+    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
+    await waitForNextUpdate();
+    assert(isVoterAuth(result.current));
+
+    const [voidResult, printResult] = await Promise.all([
+      result.current.markCardVoided(),
+      result.current.markCardPrinted(),
+    ]);
+
+    expect(voidResult.isErr()).toBe(false);
+    expect(printResult.isErr()).toBe(true);
+    expect(printResult.err()?.message).toEqual('Card write in progress');
   });
 
   it('logs out user when card is removed', async () => {
     const cardApi = new MemoryCard();
     cardApi.insertCard(makeSuperadminCard());
     const { result, waitForNextUpdate } = renderHook(() =>
-      useSmartcardAuth({ cardApi, allowedUserRoles })
+      useSmartcardAuth({ cardApi, allowedUserRoles, scope: {} })
     );
     jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
@@ -239,6 +530,78 @@ describe('useSmartcardAuth', () => {
     await waitForNextUpdate();
     expect(result.current).toEqual({ status: 'logged_out', reason: 'no_card' });
   });
+
+  it('for a logged in pollworker, activates and deactivates a cardless voter session', async () => {
+    const cardApi = new MemoryCard();
+    cardApi.insertCard(makePollWorkerCard(electionHash));
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useSmartcardAuth({
+        cardApi,
+        allowedUserRoles,
+        scope: { electionDefinition },
+      })
+    );
+    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
+    await waitForNextUpdate();
+    assert(isPollworkerAuth(result.current));
+    expect(result.current.activatedCardlessVoter).toBeUndefined();
+
+    // Activate cardless voter
+    const cardlessVoter = fakeCardlessVoterUser({
+      precinctId: precinct.precinctId,
+      ballotStyleId: ballotStyle.id,
+    });
+    act(() => {
+      assert(isPollworkerAuth(result.current));
+      result.current.activateCardlessVoter(
+        cardlessVoter.precinctId,
+        cardlessVoter.ballotStyleId
+      );
+    });
+    await waitForNextUpdate();
+    expect(result.current.activatedCardlessVoter).toMatchObject(cardlessVoter);
+
+    // Remove pollworker card to log in cardless voter
+    cardApi.removeCard();
+    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
+    await waitForNextUpdate();
+    expect(result.current).toMatchObject({
+      status: 'logged_in',
+      user: cardlessVoter,
+      logOut: expect.any(Function),
+    });
+
+    // Pollworker can deactivate cardless voter, logging them out
+    cardApi.insertCard(makePollWorkerCard(electionHash));
+    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
+    await waitForNextUpdate();
+    act(() => {
+      assert(isPollworkerAuth(result.current));
+      result.current.deactivateCardlessVoter();
+    });
+    await waitForNextUpdate();
+    expect(result.current.activatedCardlessVoter).toBeUndefined();
+
+    // Re-log-in cardless voter
+    act(() => {
+      assert(isPollworkerAuth(result.current));
+      result.current.activateCardlessVoter(
+        cardlessVoter.precinctId,
+        cardlessVoter.ballotStyleId
+      );
+    });
+    cardApi.removeCard();
+    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
+    await waitForNextUpdate();
+
+    // Cardless voter can log out themselves
+    act(() => {
+      assert(isCardlessVoterAuth(result.current));
+      result.current.logOut();
+    });
+    await waitForNextUpdate();
+    expect(result.current).toEqual({ status: 'logged_out', reason: 'no_card' });
+  });
 });
 
 describe('Card interface', () => {
@@ -246,11 +609,11 @@ describe('Card interface', () => {
     const cardApi = new MemoryCard();
     cardApi.insertCard(makeSuperadminCard());
     const { result, waitForNextUpdate } = renderHook(() =>
-      useSmartcardAuth({ cardApi, allowedUserRoles })
+      useSmartcardAuth({ cardApi, allowedUserRoles, scope: {} })
     );
     jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
-    assert(result.current.status === 'logged_in');
+    assert(isSuperadminAuth(result.current));
 
     // Initially, there's no data stored on the card, so reading should return undefined
     expect(result.current.card.hasStoredData).toBe(false);
@@ -323,11 +686,11 @@ describe('Card interface', () => {
     const cardApi = new MemoryCard();
     cardApi.insertCard(makeSuperadminCard());
     const { result, waitForNextUpdate } = renderHook(() =>
-      useSmartcardAuth({ cardApi, allowedUserRoles })
+      useSmartcardAuth({ cardApi, allowedUserRoles, scope: {} })
     );
     jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
-    assert(result.current.status === 'logged_in');
+    assert(isSuperadminAuth(result.current));
 
     const error = new Error('test error');
 
@@ -363,11 +726,11 @@ describe('Card interface', () => {
     const cardApi = new MemoryCard();
     cardApi.insertCard(makeSuperadminCard());
     const { result, waitForNextUpdate } = renderHook(() =>
-      useSmartcardAuth({ cardApi, allowedUserRoles })
+      useSmartcardAuth({ cardApi, allowedUserRoles, scope: {} })
     );
     jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
-    assert(result.current.status === 'logged_in');
+    assert(isSuperadminAuth(result.current));
 
     const [write1, write2] = await Promise.all([
       result.current.card.writeStoredData(electionDefinition),

--- a/libs/ui/src/hooks/use_smartcard_auth.ts
+++ b/libs/ui/src/hooks/use_smartcard_auth.ts
@@ -4,7 +4,6 @@ import {
   User,
   safeParseJson,
   AnyCardDataSchema,
-  AnyCardData,
   CardStorage,
   ok,
   err,
@@ -17,6 +16,17 @@ import {
   SuperadminLoggedInAuth,
   VoterLoggedInAuth,
   wrapException,
+  getBallotStyle,
+  getPrecinctById,
+  PrecinctSelectionKind,
+  PrecinctSelection,
+  VoterCardData,
+  VoterCardDataSchema,
+  Optional,
+  PrecinctId,
+  BallotStyleId,
+  CardlessVoterUser,
+  CardlessVoterLoggedInAuth,
 } from '@votingworks/types';
 import {
   assert,
@@ -24,17 +34,54 @@ import {
   CardApi,
   CardApiReady,
   throwIllegalValue,
+  utcTimestamp,
 } from '@votingworks/utils';
-import { useReducer } from 'react';
+import { useReducer, useState } from 'react';
 import useInterval from 'use-interval';
 import deepEqual from 'deep-eql';
 import { CARD_POLLING_INTERVAL } from './use_smartcard';
 import { Lock, useLock } from './use_lock';
 
-interface UseSmartcardAuthArgs {
-  cardApi: Card;
+export const VOTER_CARD_EXPIRATION_SECONDS = 60 * 60; // 1 hour
+
+// Below, we define some useful type guards for checking who's logged in.
+
+export function isSuperadminAuth(
+  auth: SmartcardAuth
+): auth is SuperadminLoggedInAuth {
+  return auth.status === 'logged_in' && auth.user.role === 'superadmin';
+}
+
+export function isAdminAuth(auth: SmartcardAuth): auth is AdminLoggedInAuth {
+  return auth.status === 'logged_in' && auth.user.role === 'admin';
+}
+
+export function isPollworkerAuth(
+  auth: SmartcardAuth
+): auth is PollworkerLoggedInAuth {
+  return auth.status === 'logged_in' && auth.user.role === 'pollworker';
+}
+
+export function isVoterAuth(auth: SmartcardAuth): auth is VoterLoggedInAuth {
+  return auth.status === 'logged_in' && auth.user.role === 'voter';
+}
+
+export function isCardlessVoterAuth(
+  auth: SmartcardAuth
+): auth is CardlessVoterLoggedInAuth {
+  return auth.status === 'logged_in' && auth.user.role === 'cardless_voter';
+}
+
+// Types for the useSmartcardAuth hook
+interface AuthScope {
   electionDefinition?: ElectionDefinition;
+  precinct?: PrecinctSelection;
+}
+
+export interface UseSmartcardAuthArgs {
+  cardApi: Card;
   allowedUserRoles: UserRole[];
+  scope: AuthScope;
 }
 
 type AuthState =
@@ -53,7 +100,10 @@ interface SmartcardAuthAction {
   card: CardApi;
 }
 
-function cardDataToUser(cardData: AnyCardData): User {
+function parseUserFromCard(card: CardApiReady): Optional<User> {
+  if (!card.shortValue) return undefined;
+  const cardData = safeParseJson(card.shortValue, AnyCardDataSchema).ok();
+  if (!cardData) return undefined;
   switch (cardData.t) {
     case 'superadmin':
       return { role: 'superadmin' };
@@ -78,45 +128,68 @@ function cardDataToUser(cardData: AnyCardData): User {
   }
 }
 
-function parseUserFromCard(card: CardApiReady): User | undefined {
-  if (!card.shortValue) return undefined;
-  const cardData = safeParseJson(card.shortValue, AnyCardDataSchema).ok();
-  return cardData && cardDataToUser(cardData);
-}
-
 function attemptLogin(
+  previousAuth: AuthState,
   card: CardApiReady,
   allowedUserRoles: UserRole[],
-  electionDefinition?: ElectionDefinition
+  scope: AuthScope
 ): Result<User, LoggedOutAuth['reason']> {
   const user = parseUserFromCard(card);
   if (!user) return err('invalid_user_on_card');
   if (!allowedUserRoles.includes(user.role)) {
     return err('user_role_not_allowed');
   }
+
   if (user.role === 'pollworker') {
-    if (!electionDefinition) return err('machine_not_configured');
-    if (user.electionHash !== electionDefinition.electionHash) {
-      return err('pollworker_election_hash_mismatch');
+    if (!scope.electionDefinition) return err('machine_not_configured');
+    if (user.electionHash !== scope.electionDefinition.electionHash) {
+      return err('pollworker_wrong_election');
+    }
+  }
+
+  if (user.role === 'voter') {
+    if (!scope.electionDefinition || !scope.precinct) {
+      return err('machine_not_configured');
+    }
+    if (utcTimestamp() >= user.createdAt + VOTER_CARD_EXPIRATION_SECONDS) {
+      return err('voter_card_expired');
+    }
+    if (user.voidedAt) {
+      return err('voter_card_voided');
+    }
+    // After a voter's ballot is printed, we don't want to log them out until
+    // they remove their card
+    if (user.ballotPrintedAt && previousAuth.status !== 'logged_in') {
+      return err('voter_card_printed');
+    }
+    const ballotStyle = getBallotStyle({
+      election: scope.electionDefinition.election,
+      ballotStyleId: user.ballotStyleId,
+    });
+    const precinct = getPrecinctById({
+      election: scope.electionDefinition.election,
+      precinctId: user.precinctId,
+    });
+    if (!ballotStyle || !precinct) {
+      return err('voter_wrong_election');
+    }
+    if (
+      scope.precinct.kind === PrecinctSelectionKind.SinglePrecinct &&
+      precinct.id !== scope.precinct.precinctId
+    ) {
+      return err('voter_wrong_precinct');
     }
   }
   return ok(user);
 }
 
-function smartcardAuthReducer(
-  allowedUserRoles: UserRole[],
-  electionDefinition?: ElectionDefinition
-) {
+function smartcardAuthReducer(allowedUserRoles: UserRole[], scope: AuthScope) {
   return (
-    prev: SmartcardAuthState,
+    previousState: SmartcardAuthState,
     action: SmartcardAuthAction
   ): SmartcardAuthState => {
     switch (action.type) {
       case 'card_read': {
-        // Only update card/auth state if the card actually changed.
-        // This is just an optimization to prevent unnecessary re-renders.
-        if (deepEqual(prev.card, action.card)) return prev;
-
         const newAuth = ((): AuthState => {
           switch (action.card.status) {
             case 'no_card':
@@ -125,9 +198,10 @@ function smartcardAuthReducer(
               return { status: 'logged_out', reason: 'card_error' };
             case 'ready': {
               const loginResult = attemptLogin(
+                previousState.auth,
                 action.card,
                 allowedUserRoles,
-                electionDefinition
+                scope
               );
               if (loginResult.isOk()) {
                 return { status: 'logged_in', user: loginResult.ok() };
@@ -139,8 +213,17 @@ function smartcardAuthReducer(
               throwIllegalValue(action.card, 'status');
           }
         })();
-        return { card: action.card, auth: newAuth };
+
+        // Optimization: if the card and auth state didn't change, then we can
+        // return the previous state, which will cause React to not rerender.
+        // https://reactjs.org/docs/hooks-reference.html#bailing-out-of-a-dispatch
+        const newState: SmartcardAuthState = {
+          auth: newAuth,
+          card: action.card,
+        };
+        return deepEqual(newState, previousState) ? previousState : newState;
       }
+
       /* istanbul ignore next - compile time check for completeness */
       default:
         throwIllegalValue(action.type);
@@ -210,18 +293,99 @@ function buildCardStorage(
   };
 }
 
+function buildPollworkerCardlessVoterProps(
+  activatedCardlessVoter: CardlessVoterUser | undefined,
+  setActivatedCardlessVoter: (cardlessVoter?: CardlessVoterUser) => void
+): Pick<
+  PollworkerLoggedInAuth,
+  'activateCardlessVoter' | 'deactivateCardlessVoter' | 'activatedCardlessVoter'
+> {
+  return {
+    activateCardlessVoter: (
+      precinctId: PrecinctId,
+      ballotStyleId: BallotStyleId
+    ) => {
+      setActivatedCardlessVoter({
+        role: 'cardless_voter',
+        precinctId,
+        ballotStyleId,
+      });
+    },
+    deactivateCardlessVoter: () => {
+      setActivatedCardlessVoter(undefined);
+    },
+    activatedCardlessVoter,
+  };
+}
+
+function buildVoterCardMethods(
+  card: CardApiReady,
+  cardApi: Card,
+  cardWriteLock: Lock
+): Pick<VoterLoggedInAuth, 'markCardVoided' | 'markCardPrinted'> {
+  async function writeVoterCardData(
+    cardData: VoterCardData
+  ): Promise<Result<void, Error>> {
+    if (!cardWriteLock.lock()) {
+      return err(new Error('Card write in progress'));
+    }
+    try {
+      await cardApi.writeShortValue(JSON.stringify(cardData));
+      return ok();
+    } catch (error) {
+      return wrapException(error);
+    } finally {
+      cardWriteLock.unlock();
+    }
+  }
+
+  return {
+    markCardVoided: () => {
+      assert(card.shortValue !== undefined);
+      const cardData = safeParseJson(card.shortValue, VoterCardDataSchema).ok();
+      assert(cardData);
+      return writeVoterCardData({
+        ...cardData,
+        uz: utcTimestamp(),
+      });
+    },
+
+    markCardPrinted: () => {
+      assert(card.shortValue !== undefined);
+      const cardData = safeParseJson(card.shortValue, VoterCardDataSchema).ok();
+      assert(cardData);
+      return writeVoterCardData({
+        ...cardData,
+        bp: utcTimestamp(),
+      });
+    },
+  };
+}
+
+/**
+ * Polls the smartcard reader and returns an auth session based on the inserted
+ * card. If a card is inserted, an auth session for the user represented by the
+ * card, as well as an interface for reading/writing data to the card for
+ * storage. If no card is inserted or the card is invalid, returns a logged out
+ * state with a reason.
+ */
 export function useSmartcardAuth({
   cardApi,
-  electionDefinition,
   allowedUserRoles,
+  scope,
 }: UseSmartcardAuthArgs): SmartcardAuth {
   const [{ card, auth }, dispatch] = useReducer(
-    smartcardAuthReducer(allowedUserRoles, electionDefinition),
+    smartcardAuthReducer(allowedUserRoles, scope),
     {
       card: { status: 'no_card' },
       auth: { status: 'logged_out', reason: 'no_card' },
     }
   );
+  // Store cardless voter session separately from the smartcard auth, since it
+  // changes independently of the card.
+  const [activatedCardlessVoter, setActivatedCardlessVoter] = useState<
+    CardlessVoterUser | undefined
+  >();
   // Use a lock to guard against concurrent writes to the card
   const cardWriteLock = useLock();
 
@@ -236,26 +400,56 @@ export function useSmartcardAuth({
 
   switch (auth.status) {
     case 'logged_out':
+      if (
+        auth.reason === 'no_card' &&
+        activatedCardlessVoter &&
+        allowedUserRoles.includes('cardless_voter')
+      ) {
+        return {
+          status: 'logged_in',
+          user: activatedCardlessVoter,
+          logOut: () => setActivatedCardlessVoter(undefined),
+        };
+      }
       return auth;
 
     case 'logged_in': {
+      const { status, user } = auth;
       assert(card.status === 'ready');
       const cardStorage = buildCardStorage(card, cardApi, cardWriteLock);
-      // For now, all roles receive the same auth object, but will get different
-      // functionality as this hook gets fleshed out.
-      const { status, user } = auth;
       switch (user.role) {
-        case 'superadmin':
+        case 'superadmin': {
           return { status, user, card: cardStorage };
+        }
 
-        case 'admin':
+        case 'admin': {
           return { status, user, card: cardStorage };
+        }
 
-        case 'pollworker':
-          return { status, user, card: cardStorage };
+        case 'pollworker': {
+          return {
+            status,
+            user,
+            card: cardStorage,
+            ...buildPollworkerCardlessVoterProps(
+              activatedCardlessVoter,
+              setActivatedCardlessVoter
+            ),
+          };
+        }
 
-        case 'voter':
-          return { status, user, card: cardStorage };
+        case 'voter': {
+          return {
+            status,
+            user,
+            card: cardStorage,
+            ...buildVoterCardMethods(card, cardApi, cardWriteLock),
+          };
+        }
+
+        /* istanbul ignore next */
+        case 'cardless_voter':
+          throw new Error('Cardless voter can never log in with card');
 
         /* istanbul ignore next - compile time check for completeness */
         default:
@@ -267,26 +461,4 @@ export function useSmartcardAuth({
     default:
       throwIllegalValue(auth, 'status');
   }
-}
-
-// Some useful type guards for checking who's logged in
-
-export function isSuperadminAuth(
-  auth: SmartcardAuth
-): auth is SuperadminLoggedInAuth {
-  return auth.status === 'logged_in' && auth.user.role === 'superadmin';
-}
-
-export function isAdminAuth(auth: SmartcardAuth): auth is AdminLoggedInAuth {
-  return auth.status === 'logged_in' && auth.user.role === 'admin';
-}
-
-export function isPollworkerAuth(
-  auth: SmartcardAuth
-): auth is PollworkerLoggedInAuth {
-  return auth.status === 'logged_in' && auth.user.role === 'pollworker';
-}
-
-export function isVoterAuth(auth: SmartcardAuth): auth is VoterLoggedInAuth {
-  return auth.status === 'logged_in' && auth.user.role === 'voter';
 }

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -73,6 +73,7 @@
     "jest": "^27.3.1",
     "jest-watch-typeahead": "^0.6.4",
     "lint-staged": "^11.0.0",
+    "mockdate": "^3.0.5",
     "prettier": "^2.6.2",
     "sort-package-json": "^1.50.0",
     "ts-jest": "^27.0.7",

--- a/libs/utils/src/date.test.ts
+++ b/libs/utils/src/date.test.ts
@@ -1,10 +1,12 @@
 import { DateTime } from 'luxon';
+import MockDate from 'mockdate';
 import {
   formatFullDateTimeZone,
   formatLongDate,
   formatTime,
   formatTimeZoneName,
   getDaysInMonth,
+  utcTimestamp,
 } from './date';
 
 test('formatTimeZoneName', () => {
@@ -88,4 +90,12 @@ test('getDaysInMonth', () => {
   const februaryDays = getDaysInMonth(2021, 2);
   expect(februaryDays).toHaveLength(28);
   expect(februaryDays[0]).toEqual(DateTime.fromISO('2021-02-01'));
+});
+
+test('utcTimestamp', () => {
+  const now = DateTime.fromISO('2022-03-23T11:23:00.000Z');
+  MockDate.set(now.toISO());
+  expect(utcTimestamp()).toEqual(Math.round(DateTime.utc().toSeconds()));
+  expect(utcTimestamp()).toMatchInlineSnapshot(`1648034580`);
+  MockDate.reset();
 });

--- a/libs/utils/src/date.ts
+++ b/libs/utils/src/date.ts
@@ -81,3 +81,10 @@ export function getDaysInMonth(year: number, month: number): DateTime[] {
   }
   return days;
 }
+
+/**
+ * Returns current UTC unix timestamp (epoch) in seconds
+ */
+export function utcTimestamp(): number {
+  return Math.round(Date.now() / 1000);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2431,6 +2431,7 @@ importers:
       jest: 27.3.1
       jest-watch-typeahead: 0.6.4_jest@27.3.1
       lint-staged: 11.0.0
+      mockdate: 3.0.5
       prettier: 2.6.2
       sort-package-json: 1.50.0
       ts-jest: 27.0.7_1dcf3a5c8307703c73427a631f3faf30
@@ -2468,6 +2469,7 @@ importers:
       jszip: ^3.9.1
       lint-staged: ^11.0.0
       luxon: ^1.27.0
+      mockdate: ^3.0.5
       moment: ^2.29.1
       prettier: ^2.6.2
       randombytes: ^2.1.0
@@ -7416,7 +7418,7 @@ packages:
       jest-regex-util: 27.5.1
       jest-resolve: 27.5.1
       jest-resolve-dependencies: 27.5.1
-      jest-runner: 27.5.1_canvas@2.9.1
+      jest-runner: 27.5.1
       jest-runtime: 27.5.1
       jest-snapshot: 27.5.1
       jest-util: 27.5.1
@@ -11962,7 +11964,7 @@ packages:
       integrity: sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA==
   /axios/0.21.1_debug@4.3.1:
     dependencies:
-      follow-redirects: 1.14.1_debug@4.3.1
+      follow-redirects: 1.14.1_debug@4.3.4
     dev: true
     peerDependencies:
       debug: '*'
@@ -11970,7 +11972,7 @@ packages:
       integrity: sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
   /axios/0.21.1_debug@4.3.2:
     dependencies:
-      follow-redirects: 1.14.1_debug@4.3.4
+      follow-redirects: 1.14.1_debug@4.3.2
     dev: true
     peerDependencies:
       debug: '*'
@@ -18242,7 +18244,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 5.21.0_bb9518338a760ece3e1b033a5f6af62e
       '@typescript-eslint/utils': 5.22.0_eslint@7.32.0+typescript@4.6.3
       eslint: 7.32.0
-      jest: 27.5.1_canvas@2.9.1
+      jest: 27.5.1
     dev: true
     engines:
       node: ^12.22.0 || ^14.17.0 || >=16.0.0
@@ -20329,6 +20331,20 @@ packages:
   /follow-redirects/1.14.1_debug@4.3.1:
     dependencies:
       debug: 4.3.1
+    dev: false
+    engines:
+      node: '>=4.0'
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    resolution:
+      integrity: sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
+  /follow-redirects/1.14.1_debug@4.3.2:
+    dependencies:
+      debug: 4.3.2
+    dev: true
     engines:
       node: '>=4.0'
     peerDependencies:
@@ -22844,7 +22860,7 @@ packages:
       jest-jasmine2: 27.5.1
       jest-regex-util: 27.5.1
       jest-resolve: 27.5.1
-      jest-runner: 27.5.1_canvas@2.9.1
+      jest-runner: 27.5.1
       jest-util: 27.5.1
       jest-validate: 27.5.1
       micromatch: 4.0.5
@@ -23969,36 +23985,6 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-g4NPsM4mFCOwFKXO4p/H/kWGdJp9V8kURY2lX8Me2drgXqG7rrZAx5kv+5H7wtt/cdFIjhqYx1HrlqWHaOvDaQ==
-  /jest-runner/27.5.1_canvas@2.9.1:
-    dependencies:
-      '@jest/console': 27.5.1
-      '@jest/environment': 27.5.1
-      '@jest/test-result': 27.5.1
-      '@jest/transform': 27.5.1
-      '@jest/types': 27.5.1
-      '@types/node': 17.0.36
-      chalk: 4.1.2
-      emittery: 0.8.1
-      graceful-fs: 4.2.10
-      jest-docblock: 27.5.1
-      jest-environment-jsdom: 27.5.1_canvas@2.9.1
-      jest-environment-node: 27.5.1
-      jest-haste-map: 27.5.1
-      jest-leak-detector: 27.5.1
-      jest-message-util: 27.5.1
-      jest-resolve: 27.5.1
-      jest-runtime: 27.5.1
-      jest-util: 27.5.1
-      jest-worker: 27.5.1
-      source-map-support: 0.5.21
-      throat: 6.0.1
-    dev: true
-    engines:
-      node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
-    peerDependencies:
-      canvas: '*'
-    resolution:
-      integrity: sha512-g4NPsM4mFCOwFKXO4p/H/kWGdJp9V8kURY2lX8Me2drgXqG7rrZAx5kv+5H7wtt/cdFIjhqYx1HrlqWHaOvDaQ==
   /jest-runtime/26.6.3:
     dependencies:
       '@jest/console': 26.6.2
@@ -24562,7 +24548,7 @@ packages:
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
-      jest: 27.5.1_canvas@2.9.1
+      jest: 27.5.1
       jest-regex-util: 27.5.1
       jest-watcher: 27.5.1
       slash: 3.0.0


### PR DESCRIPTION
## Overview
Task: #1682 

_I suggest commit-by-commit reviewing_

Continues the refactor of BMD to use the useSmartcardAuth hook for voters. There are two types of voter auth:
- Voter cards
- Cardless voters, which are activated by pollworkers

Also in this PR, I removed local storage of voter sessions in development, since it would have been pretty complicated to refactor into this new approach, and it's not a crucial feature.

I generally tried to keep the changes as minimal as possible, but I do think there's still a lot of possibility to make app_root.tsx clearer now that a lot of the complexity has been factored out.

## Demo Video or Screenshot
N/A

## Testing Plan 
- Existing automated tests
- New unit tests for useSmartcardAuth

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
