### PR TITLE
fix(scan): increase `pdfToImages` PDF compatibility

### DIFF
--- a/services/scan/src/util/pdf_to_images.test.ts
+++ b/services/scan/src/util/pdf_to_images.test.ts
@@ -14,13 +14,19 @@ async function asyncIterableToArray<T>(
   return result;
 }
 
-const ballotPath = join(
+const ballotNotRequiringPdfjsIntermediateCanvasPath = join(
   __dirname,
   '../../test/fixtures/state-of-hamilton/ballot.pdf'
 );
+const ballotRequiringPdfjsIntermediateCanvasPath = join(
+  __dirname,
+  '../../../../libs/ballot-interpreter-nh/test/fixtures/hudson-2020-11-03/template.pdf'
+);
 
 test('yields the right number of images sized correctly', async () => {
-  const pdfBytes = await fs.readFile(ballotPath);
+  const pdfBytes = await fs.readFile(
+    ballotNotRequiringPdfjsIntermediateCanvasPath
+  );
   const pages = await asyncIterableToArray(pdfToImages(pdfBytes));
   expect(pages.length).toEqual(5);
 
@@ -43,11 +49,21 @@ test('yields the right number of images sized correctly', async () => {
 });
 
 test('can generate images with a different scale', async () => {
-  const pdfBytes = await fs.readFile(ballotPath);
+  const pdfBytes = await fs.readFile(
+    ballotNotRequiringPdfjsIntermediateCanvasPath
+  );
   const [
     {
       page: { width, height },
     },
   ] = await asyncIterableToArray(pdfToImages(pdfBytes, { scale: 2 }));
   expect({ width, height }).toEqual({ width: 1224, height: 1584 });
+});
+
+test('can render a PDF that requires the PDF.js intermediate canvas', async () => {
+  const pdfBytes = await fs.readFile(
+    ballotRequiringPdfjsIntermediateCanvasPath
+  );
+  const pages = await asyncIterableToArray(pdfToImages(pdfBytes));
+  expect(pages.length).toEqual(2);
 });


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
This has probably been broken for a while with certain PDFs. Depending on the features used in the PDFs, different code paths are taken. It just so happens that the PDFs we've used up to now have not required the `canvasFactory` implicitly used by `pdfjs` to actually work, presumably because it could just paint directly on the canvas that was given and it didn't need any intermediate working canvases. The PDFs we got from NH actually do have some feature that requires an intermediate canvas, and so it calls to create a new canvas and fails with "Reference Error: document is not defined". `pdfjs` tries to use the DOM to build `canvas` objects by default, which is sensible. But in NodeJS it just doesn't work. Instead, we now provide a factory that uses the `canvas` NPM package to build canvases.

This bug doesn't affect the _other_ `pdfToImages` implementation in Election Manager because there we actually do have the DOM and the default factory works fine.

## Demo Video or Screenshot
![template-p1](https://user-images.githubusercontent.com/1938/172680987-9e425fbd-3090-46eb-9a2c-9b696313a9b1.jpg)

## Testing Plan 
Tested locally with the PDFs from NH (see image above).

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
