### PR TITLE
Make previously transcribed buttons persist state

### DIFF
--- a/frontends/election-manager/src/screens/write_ins_screen.test.tsx
+++ b/frontends/election-manager/src/screens/write_ins_screen.test.tsx
@@ -19,6 +19,11 @@ describe('Write-in Adjudication screen', () => {
       { id: 'abc', contestId: 'zoo-council-mammal' },
       { id: '456', contestId: 'zoo-council-mammal' },
     ]);
+    fetchMock.get('express:/admin/write-ins/adjudication/:adjudicationId', {
+      id: 'abc',
+      contestId: 'zoo-council-mammal',
+      transcribedValue: 'Mickey Mouse',
+    });
   });
 
   afterEach(() => {

--- a/frontends/election-manager/src/screens/write_ins_screen.tsx
+++ b/frontends/election-manager/src/screens/write_ins_screen.tsx
@@ -102,32 +102,34 @@ export function WriteInsScreen(): JSX.Element {
             </p>
           ))}
         </Prose>
-        {contestBeingAdjudicated && election && (
-          <Modal
-            content={
-              <WriteInsTranscriptionScreen
-                election={election}
-                contest={contestBeingAdjudicated}
-                adjudications={adjudicationsForCurrentContest}
-                paginationIdx={paginationIdx}
-                onClose={() => setContestBeingAdjudicated(undefined)}
-                onListAll={placeholderFn}
-                onClickNext={
-                  paginationIdx < adjudicationsForCurrentContest.length - 1
-                    ? () => setPaginationIdx(paginationIdx + 1)
-                    : undefined
-                }
-                onClickPrevious={
-                  paginationIdx
-                    ? () => setPaginationIdx(paginationIdx - 1)
-                    : undefined
-                }
-                saveTranscribedValue={saveTranscribedValue}
-              />
-            }
-            fullscreen
-          />
-        )}
+        {election &&
+          contestBeingAdjudicated &&
+          adjudicationsForCurrentContest.length && (
+            <Modal
+              content={
+                <WriteInsTranscriptionScreen
+                  election={election}
+                  contest={contestBeingAdjudicated}
+                  adjudications={adjudicationsForCurrentContest}
+                  paginationIdx={paginationIdx}
+                  onClose={() => setContestBeingAdjudicated(undefined)}
+                  onListAll={placeholderFn}
+                  onClickNext={
+                    paginationIdx < adjudicationsForCurrentContest.length - 1
+                      ? () => setPaginationIdx(paginationIdx + 1)
+                      : undefined
+                  }
+                  onClickPrevious={
+                    paginationIdx
+                      ? () => setPaginationIdx(paginationIdx - 1)
+                      : undefined
+                  }
+                  saveTranscribedValue={saveTranscribedValue}
+                />
+              }
+              fullscreen
+            />
+          )}
       </NavigationScreen>
     </React.Fragment>
   );

--- a/services/admin/src/server.test.ts
+++ b/services/admin/src/server.test.ts
@@ -110,8 +110,16 @@ test('GET /admin/write-ins/adjudications/:contestId/', async () => {
     .expect(200, []);
 
   const cvrId = workspace.store.addCvr('test');
-  workspace.store.addAdjudication('mayor', cvrId, 'Minnie Mouse');
-  workspace.store.addAdjudication('mayor', cvrId, 'Goofy');
+  const adjudicationId = workspace.store.addAdjudication(
+    'mayor',
+    cvrId,
+    'Minnie Mouse'
+  );
+  const adjudicationId2 = workspace.store.addAdjudication(
+    'mayor',
+    cvrId,
+    'Goofy'
+  );
   workspace.store.addAdjudication('county-commissioner', cvrId, 'Daffy');
 
   // contestId that does not exist
@@ -126,11 +134,13 @@ test('GET /admin/write-ins/adjudications/:contestId/', async () => {
       {
         contestId: 'mayor',
         cvrId,
+        id: adjudicationId,
         transcribedValue: 'Minnie Mouse',
       },
       {
         contestId: 'mayor',
         cvrId,
+        id: adjudicationId2,
         transcribedValue: 'Goofy',
       },
     ]);

--- a/services/admin/src/store.test.ts
+++ b/services/admin/src/store.test.ts
@@ -39,8 +39,8 @@ test('add/get adjudications', () => {
 test('getAdjudicationsByContestId', () => {
   const store = Store.memoryStore();
   const cvrId = store.addCvr('test');
-  store.addAdjudication('mayor', cvrId, 'Minnie Mouse');
-  store.addAdjudication('mayor', cvrId, 'Goofy');
+  const adjudicationId = store.addAdjudication('mayor', cvrId, 'Minnie Mouse');
+  const adjudicationId2 = store.addAdjudication('mayor', cvrId, 'Goofy');
   store.addAdjudication('assistant-mayor', cvrId, 'Mickey Mouse');
 
   // Does not include duplicates and is in alphabetical order
@@ -48,11 +48,13 @@ test('getAdjudicationsByContestId', () => {
     {
       contestId: 'mayor',
       cvrId,
+      id: adjudicationId,
       transcribedValue: 'Minnie Mouse',
     },
     {
       contestId: 'mayor',
       cvrId,
+      id: adjudicationId2,
       transcribedValue: 'Goofy',
     },
   ]);

--- a/services/admin/src/store.ts
+++ b/services/admin/src/store.ts
@@ -111,7 +111,7 @@ export class Store {
    */
   getAdjudicationsByContestId(contestId: ContestId): Adjudication[] {
     const rows = this.client.all(
-      'select contest_id as contestId, cvr_id as cvrId, transcribed_value as transcribedValue from adjudications where contest_id = ?',
+      'select id, contest_id as contestId, cvr_id as cvrId, transcribed_value as transcribedValue from adjudications where contest_id = ?',
       contestId
     ) as Adjudication[];
 


### PR DESCRIPTION
## Overview
Closes #1936 

## Demo Video or Screenshot

https://user-images.githubusercontent.com/7584833/172689842-2ea4fa6e-7b20-4dff-bb9f-ab73011a746d.mov

## Testing Plan 
Manual QA, will add UI tests once this flow is reviewed/tweaked by Beau.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
