### PR TITLE
Fetch previously transcribed values from the DB instead of using mock data

### DIFF
--- a/frontends/election-manager/src/screens/write_ins_screen.test.tsx
+++ b/frontends/election-manager/src/screens/write_ins_screen.test.tsx
@@ -24,6 +24,11 @@ describe('Write-in Adjudication screen', () => {
       contestId: 'zoo-council-mammal',
       transcribedValue: 'Mickey Mouse',
     });
+    fetchMock.get('/admin/write-ins/transcribed-values', [
+      'Daffy',
+      'Mickey Mouse',
+      'Minnie',
+    ]);
   });
 
   afterEach(() => {

--- a/frontends/election-manager/src/screens/write_ins_transcription_screen.test.tsx
+++ b/frontends/election-manager/src/screens/write_ins_transcription_screen.test.tsx
@@ -1,11 +1,12 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import React from 'react';
+import fetchMock from 'fetch-mock';
 import { electionMinimalExhaustiveSampleDefinition as electionDefinition } from '@votingworks/fixtures';
 import { CandidateContest } from '@votingworks/types';
 import { renderInAppContext } from '../../test/render_in_app_context';
 import { WriteInsTranscriptionScreen } from './write_ins_transcription_screen';
 
-test('write-ins screen', () => {
+describe('write-ins screen', () => {
   const contest = electionDefinition.election.contests[0] as CandidateContest;
   const onClickNext = jest.fn();
   const onClickPrevious = jest.fn();
@@ -13,37 +14,63 @@ test('write-ins screen', () => {
   const onListAll = jest.fn();
   const saveTranscribedValue = jest.fn();
 
-  renderInAppContext(
-    <WriteInsTranscriptionScreen
-      election={electionDefinition.election}
-      contest={contest}
-      paginationIdx={0}
-      adjudications={[
-        { contestId: 'best-animal-mammal', transcribedValue: '', id: 'id-174' },
-      ]}
-      onClickNext={onClickNext}
-      onClickPrevious={onClickPrevious}
-      onClose={onClose}
-      onListAll={onListAll}
-      saveTranscribedValue={saveTranscribedValue}
-    />,
-    { electionDefinition }
-  );
-  screen.getByText('BALLOT IMAGES GO HERE');
+  beforeEach(() => {
+    fetchMock.mock();
+    fetchMock.get('/admin/write-ins/adjudications/contestId/count', [
+      { contestId: 'zoo-council-mammal', adjudicationCount: 3 },
+    ]);
+    fetchMock.get('/admin/write-ins/transcribed-values', [
+      'Daffy',
+      'Mickey Mouse',
+    ]);
+    fetchMock.get('/admin/write-ins/adjudication/id-174', [
+      {
+        contestId: 'best-animal-mammal',
+        transcribedValue: '',
+        id: 'id-174',
+      },
+    ]);
+  });
 
-  // Click a previously-saved transcription
-  screen.getByText('Mickey Mouse').click();
-  expect(saveTranscribedValue).toHaveBeenCalledWith('id-174', 'Mickey Mouse');
+  test('clicking a previously-saved value', async () => {
+    renderInAppContext(
+      <WriteInsTranscriptionScreen
+        election={electionDefinition.election}
+        contest={contest}
+        paginationIdx={0}
+        adjudications={[
+          {
+            contestId: 'best-animal-mammal',
+            transcribedValue: '',
+            id: 'id-174',
+          },
+        ]}
+        onClickNext={onClickNext}
+        onClickPrevious={onClickPrevious}
+        onClose={onClose}
+        onListAll={onListAll}
+        saveTranscribedValue={saveTranscribedValue}
+      />,
+      { electionDefinition }
+    );
+    screen.getByText('BALLOT IMAGES GO HERE');
 
-  screen.getByText('List All').click();
-  expect(onListAll).toHaveBeenCalledTimes(1);
+    // Click a previously-saved transcription
+    await waitFor(() => {
+      screen.getByText('Mickey Mouse').click();
+    });
+    expect(saveTranscribedValue).toHaveBeenCalledWith('id-174', 'Mickey Mouse');
 
-  screen.getByText('Previous').click();
-  expect(onClickPrevious).toHaveBeenCalledTimes(1);
+    screen.getByText('List All').click();
+    expect(onListAll).toHaveBeenCalledTimes(1);
 
-  screen.getByText('Next').click();
-  expect(onClickNext).toHaveBeenCalledTimes(1);
+    screen.getByText('Previous').click();
+    expect(onClickPrevious).toHaveBeenCalledTimes(1);
 
-  screen.getByText('Exit').click();
-  expect(onClose).toHaveBeenCalledTimes(1);
+    screen.getByText('Next').click();
+    expect(onClickNext).toHaveBeenCalledTimes(1);
+
+    screen.getByText('Exit').click();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontends/election-manager/src/screens/write_ins_transcription_screen.tsx
+++ b/frontends/election-manager/src/screens/write_ins_transcription_screen.tsx
@@ -80,19 +80,8 @@ export function WriteInsTranscriptionScreen({
   const [currentTranscribedValue, setCurrentTranscribedValue] = useState('');
   const [isTranscribedValueInputVisible, setIsTranscribedValueInputVisible] =
     useState(false);
-  // TODO: initialize these with values from the DB
   const [previouslyTranscribedValues, setPreviouslyTranscribedValues] =
-    useState([
-      'Mickey Mouse',
-      'Mickey M',
-      'Micky',
-      'Donald',
-      'Donald Duck',
-      'Roger Rabbit',
-      'RR',
-      'DD',
-      'M. Mouse',
-    ]);
+    useState<string[]>([]);
 
   const transcribedValueInput = useRef<HTMLInputElement>(null);
 
@@ -119,6 +108,14 @@ export function WriteInsTranscriptionScreen({
     }
     void getTranscribedValue(adjudicationId || '');
   }, [adjudicationId]);
+
+  useEffect(() => {
+    async function getPreviouslyTranscribedValues(): Promise<void> {
+      const res = await fetch('/admin/write-ins/transcribed-values');
+      setPreviouslyTranscribedValues(await res.json());
+    }
+    void getPreviouslyTranscribedValues();
+  }, []);
 
   return (
     <Screen>

--- a/frontends/election-manager/src/screens/write_ins_transcription_screen.tsx
+++ b/frontends/election-manager/src/screens/write_ins_transcription_screen.tsx
@@ -104,7 +104,7 @@ export function WriteInsTranscriptionScreen({
 
   function onPressSetTranscribedValue(val: string): void {
     setCurrentTranscribedValue(val);
-    saveTranscribedValue(adjudicationId || '', val);
+    saveTranscribedValue(adjudicationId, val);
   }
 
   useEffect(() => {

--- a/services/admin/src/server.test.ts
+++ b/services/admin/src/server.test.ts
@@ -231,3 +231,15 @@ test('POST /admin/write-ins/cvrs', async () => {
     JSON.stringify(cvrs[1])
   );
 });
+
+test('GET /admin/write-ins/transcribed-values', async () => {
+  await request(app).get('/admin/write-ins/transcribed-values').expect(200, []);
+
+  const cvrId = workspace.store.addCvr('test');
+
+  workspace.store.addAdjudication('mayor', cvrId, 'Mickey Mouse');
+  workspace.store.addAdjudication('county-commissioner', cvrId, 'Daffy');
+  await request(app)
+    .get('/admin/write-ins/transcribed-values')
+    .expect(200, ['Mickey Mouse', 'Daffy']);
+});

--- a/services/admin/src/server.test.ts
+++ b/services/admin/src/server.test.ts
@@ -241,5 +241,5 @@ test('GET /admin/write-ins/transcribed-values', async () => {
   workspace.store.addAdjudication('county-commissioner', cvrId, 'Daffy');
   await request(app)
     .get('/admin/write-ins/transcribed-values')
-    .expect(200, ['Mickey Mouse', 'Daffy']);
+    .expect(200, ['Daffy', 'Mickey Mouse']);
 });

--- a/services/admin/src/server.ts
+++ b/services/admin/src/server.ts
@@ -122,6 +122,11 @@ export function buildApp({ store }: { store: Store }): Application {
     response.json(store.getAdjudicationsByContestId(contestId));
   });
 
+  app.get<NoParams>('/admin/write-ins/transcribed-values', (_, response) => {
+    const transcribedValues = store.getAllTranscribedValues();
+    response.json(transcribedValues);
+  });
+
   return app;
 }
 

--- a/services/admin/src/store.test.ts
+++ b/services/admin/src/store.test.ts
@@ -97,10 +97,10 @@ test('getAllTranscribedValues', () => {
   store.addAdjudication('assistant-mayor', 'Mickey Mouse');
   store.addAdjudication('county-commissioner', 'Daffy');
 
-  // Does not include duplicates
-  expect(store.getAllTranscribedValues()).toEqual(['Mickey Mouse', 'Daffy']);
+  // Does not include duplicates and is in alphabetical order
+  expect(store.getAllTranscribedValues()).toEqual(['Daffy', 'Mickey Mouse']);
 
   // Does not include empty strings
   store.addAdjudication('chief-of-staff', '');
-  expect(store.getAllTranscribedValues()).toEqual(['Mickey Mouse', 'Daffy']);
+  expect(store.getAllTranscribedValues()).toEqual(['Daffy', 'Mickey Mouse']);
 });

--- a/services/admin/src/store.test.ts
+++ b/services/admin/src/store.test.ts
@@ -96,5 +96,11 @@ test('getAllTranscribedValues', () => {
   store.addAdjudication('mayor', 'Mickey Mouse');
   store.addAdjudication('assistant-mayor', 'Mickey Mouse');
   store.addAdjudication('county-commissioner', 'Daffy');
+
+  // Does not include duplicates
+  expect(store.getAllTranscribedValues()).toEqual(['Mickey Mouse', 'Daffy']);
+
+  // Does not include empty strings
+  store.addAdjudication('chief-of-staff', '');
   expect(store.getAllTranscribedValues()).toEqual(['Mickey Mouse', 'Daffy']);
 });

--- a/services/admin/src/store.test.ts
+++ b/services/admin/src/store.test.ts
@@ -93,14 +93,15 @@ test('deleteCvrs', () => {
 
 test('getAllTranscribedValues', () => {
   const store = Store.memoryStore();
-  store.addAdjudication('mayor', 'Mickey Mouse');
-  store.addAdjudication('assistant-mayor', 'Mickey Mouse');
-  store.addAdjudication('county-commissioner', 'Daffy');
+  const cvrId = store.addCvr('test');
+  store.addAdjudication('mayor', cvrId, 'Mickey Mouse');
+  store.addAdjudication('assistant-mayor', cvrId, 'Mickey Mouse');
+  store.addAdjudication('county-commissioner', cvrId, 'Daffy');
 
   // Does not include duplicates and is in alphabetical order
   expect(store.getAllTranscribedValues()).toEqual(['Daffy', 'Mickey Mouse']);
 
   // Does not include empty strings
-  store.addAdjudication('chief-of-staff', '');
+  store.addAdjudication('chief-of-staff', cvrId, '');
   expect(store.getAllTranscribedValues()).toEqual(['Daffy', 'Mickey Mouse']);
 });

--- a/services/admin/src/store.test.ts
+++ b/services/admin/src/store.test.ts
@@ -90,3 +90,11 @@ test('deleteCvrs', () => {
   store.deleteCvrs();
   expect(store.getAdjudicationsByContestId('mayor')).toHaveLength(0);
 });
+
+test('getAllTranscribedValues', () => {
+  const store = Store.memoryStore();
+  store.addAdjudication('mayor', 'Mickey Mouse');
+  store.addAdjudication('assistant-mayor', 'Mickey Mouse');
+  store.addAdjudication('county-commissioner', 'Daffy');
+  expect(store.getAllTranscribedValues()).toEqual(['Mickey Mouse', 'Daffy']);
+});

--- a/services/admin/src/store.ts
+++ b/services/admin/src/store.ts
@@ -123,7 +123,7 @@ export class Store {
    */
   getAllTranscribedValues(): string[] {
     const rows = this.client.all(
-      'select distinct transcribed_value as transcribedValue from adjudications'
+      'select distinct transcribed_value as transcribedValue from adjudications order by transcribedValue asc'
     ) as Array<{ transcribedValue: string }>;
 
     return rows.map((r) => r.transcribedValue).filter(Boolean);

--- a/services/admin/src/store.ts
+++ b/services/admin/src/store.ts
@@ -126,6 +126,6 @@ export class Store {
       'select distinct transcribed_value as transcribedValue from adjudications'
     ) as Array<{ transcribedValue: string }>;
 
-    return rows.map((r) => r.transcribedValue);
+    return rows.map((r) => r.transcribedValue).filter(Boolean);
   }
 }

--- a/services/admin/src/store.ts
+++ b/services/admin/src/store.ts
@@ -117,4 +117,15 @@ export class Store {
 
     return rows;
   }
+
+  /**
+   * Returns a unique list of values for adjudications.transcribed_values.
+   */
+  getAllTranscribedValues(): string[] {
+    const rows = this.client.all(
+      'select distinct transcribed_value as transcribedValue from adjudications'
+    ) as Array<{ transcribedValue: string }>;
+
+    return rows.map((r) => r.transcribedValue);
+  }
 }


### PR DESCRIPTION
## Overview
Closes #1944 

## Demo Video or Screenshot

https://user-images.githubusercontent.com/7584833/172705530-891c1c1c-4fa4-4584-af0c-cc762b219834.mov

## Testing Plan 

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
