### PR TITLE
chore(test-utils): enable `noUncheckedIndexedAccess`

### DIFF
--- a/libs/test-utils/src/arbitraries.test.ts
+++ b/libs/test-utils/src/arbitraries.test.ts
@@ -16,6 +16,7 @@ import {
   arbitraryId,
   arbitraryYesNoOption,
 } from './arbitraries';
+import { assert } from './assert';
 
 test('arbitraryId', () => {
   fc.assert(
@@ -76,6 +77,7 @@ test('arbitraryCastVoteRecord(s) makes valid CVRs', () => {
   fc.assert(
     fc.property(arbitraryCastVoteRecord(), (cvr) => {
       const [frontPage, backPage] = cvr._pageNumbers!;
+      assert(typeof frontPage === 'number' && typeof backPage === 'number');
       expect(backPage - frontPage).toEqual(1);
     })
   );
@@ -91,8 +93,8 @@ test('arbitraryCastVoteRecord(s) makes valid CVRs', () => {
   );
 
   // specify the election
-  const election = fc.sample(arbitraryElection(), 1)[0];
-  const testBallot = fc.sample(fc.boolean())[0];
+  const election = fc.sample(arbitraryElection(), 1)[0]!;
+  const testBallot = fc.sample(fc.boolean())[0]!;
   fc.assert(
     fc.property(arbitraryCastVoteRecords({ election, testBallot }), (cvrs) => {
       for (const cvr of cvrs) {

--- a/libs/test-utils/src/assert.test.ts
+++ b/libs/test-utils/src/assert.test.ts
@@ -1,0 +1,7 @@
+import { assert } from './assert';
+
+test('assert', () => {
+  expect(() => assert(true, 'true')).not.toThrow();
+  expect(() => assert(false, 'false')).toThrow('false');
+  expect(() => assert(!{})).toThrow('Assertion failed');
+});

--- a/libs/test-utils/src/assert.ts
+++ b/libs/test-utils/src/assert.ts
@@ -1,0 +1,13 @@
+/**
+ * Asserts that {@param condition} is truthy.
+ *
+ * This is here to avoid depending on `@votingworks/utils` and creating a cycle.
+ */
+export function assert(
+  condition: unknown,
+  message?: string
+): asserts condition {
+  if (!condition) {
+    throw new Error(message || 'Assertion failed');
+  }
+}

--- a/libs/test-utils/src/cast_vote_record.ts
+++ b/libs/test-utils/src/cast_vote_record.ts
@@ -9,6 +9,7 @@ import {
   getContests,
   PrecinctId,
 } from '@votingworks/types';
+import { assert } from './assert';
 
 export interface CastVoteRecordOptions {
   readonly precinctId?: PrecinctId;
@@ -27,8 +28,8 @@ export function generateCvr(
   options: CastVoteRecordOptions
 ): CastVoteRecord {
   // If precinctId or ballotStyleId are not provided default to the first in the election
-  const precinctId = options.precinctId ?? election.precincts[0].id;
-  const ballotStyleId = options.ballotStyleId ?? election.ballotStyles[0].id;
+  const precinctId = options.precinctId ?? election.precincts[0]?.id;
+  const ballotStyleId = options.ballotStyleId ?? election.ballotStyles[0]?.id;
   const { ballotId } = options;
   const ballotType = options.ballotType ?? 'standard';
   const testBallot = !!options.testBallot; // default to false
@@ -36,12 +37,16 @@ export function generateCvr(
   const batchId = options.batchId ?? 'batch-1';
   const batchLabel = options.batchLabel ?? 'Batch 1';
 
+  assert(typeof precinctId === 'string');
+  assert(typeof ballotStyleId === 'string');
+
   // Add in blank votes for any contest in the ballot style not specified.
   const ballotStyle =
     getBallotStyle({
       ballotStyleId,
       election,
-    }) || election.ballotStyles[0];
+    }) ?? election.ballotStyles[0];
+  assert(ballotStyle);
   const contestsInBallot = expandEitherNeitherContests(
     getContests({ ballotStyle, election })
   );

--- a/libs/test-utils/tsconfig.json
+++ b/libs/test-utils/tsconfig.json
@@ -8,7 +8,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "noUncheckedIndexedAccess": false
+    "noUncheckedIndexedAccess": true
   },
   "references": [
     { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
We're going to have to enable this in all the libraries to support a build-less Jest config using `moduleNameMapper` and `ts-jest`. That's because _some_ libraries enable it, which cascades to the dependencies when testing this way.

Refs #1314 

## Demo Video or Screenshot

## Testing Plan 

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
