### PR TITLE
chore(scan): remove duplicate draw code

### DIFF
--- a/libs/ballot-interpreter-nh/src/images.ts
+++ b/libs/ballot-interpreter-nh/src/images.ts
@@ -46,7 +46,6 @@ export async function readGrayscaleImage(path: string): Promise<ImageData> {
   const canvas = createCanvas(image.width, image.height);
   const context = canvas.getContext('2d');
   context.drawImage(image, 0, 0, image.width, image.height);
-  context.drawImage(image, 0, 0, image.width, image.height);
   const imageData = context.getImageData(0, 0, image.width, image.height);
   return convertToGrayscale(imageData);
 }


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
From [@benadida in Slack](https://votingworks.slack.com/archives/CEL6D3GAD/p1654717222779769):
> reading through some interpreter code, wondering if this is an unnecessary double-drawing

## Demo Video or Screenshot
n/a

## Testing Plan 
n/a

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
