### PR TITLE
fix(bmd): avoid saying "1 contests"

### DIFF
--- a/frontends/bmd/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
+++ b/frontends/bmd/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
@@ -459,8 +459,8 @@ exports[`Single Seat Contest 1`] = `
             </strong>
              of
              
-            21
-             contests.
+            21 contests
+            .
           </p>
           <p>
             <button

--- a/frontends/bmd/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
+++ b/frontends/bmd/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
@@ -743,8 +743,8 @@ exports[`Single Seat Contest 1`] = `
             </strong>
              of
              
-            21
-             contests.
+            21 contests
+            .
           </p>
           <p>
             <button

--- a/frontends/bmd/src/__snapshots__/app_contest_single_seat.test.tsx.snap
+++ b/frontends/bmd/src/__snapshots__/app_contest_single_seat.test.tsx.snap
@@ -526,8 +526,8 @@ exports[`Single Seat Contest 1`] = `
             </strong>
              of
              
-            21
-             contests.
+            21 contests
+            .
           </p>
           <p>
             <button

--- a/frontends/bmd/src/__snapshots__/app_contest_write_in.test.tsx.snap
+++ b/frontends/bmd/src/__snapshots__/app_contest_write_in.test.tsx.snap
@@ -380,8 +380,8 @@ exports[`Single Seat Contest with Write In 1`] = `
             </strong>
              of
              
-            21
-             contests.
+            21 contests
+            .
           </p>
           <p>
             <button

--- a/frontends/bmd/src/pages/__snapshots__/contest_page.test.tsx.snap
+++ b/frontends/bmd/src/pages/__snapshots__/contest_page.test.tsx.snap
@@ -456,8 +456,8 @@ exports[`Renders ContestPage 1`] = `
             </strong>
              of
              
-            22
-             contests.
+            22 contests
+            .
           </p>
           <p>
             <button

--- a/frontends/bmd/src/pages/contest_page.tsx
+++ b/frontends/bmd/src/pages/contest_page.tsx
@@ -1,8 +1,9 @@
-import { assert } from '@votingworks/utils';
-import React, { useContext, useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
 import { CandidateVote, OptionalYesNoVote } from '@votingworks/types';
 import { LinkButton, Screen, Prose, Text } from '@votingworks/ui';
+import { assert } from '@votingworks/utils';
+import pluralize from 'pluralize';
+import React, { useContext, useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
 
 import { ordinal } from '../utils/ordinal';
 
@@ -131,7 +132,7 @@ export function ContestPage(): JSX.Element {
         <Prose>
           <Text center>
             This is the <strong>{ordinal(currentContestIndex + 1)}</strong> of{' '}
-            {contests.length} contests.
+            {pluralize('contest', contests.length, true)}.
           </Text>
           {isReviewMode ? (
             <React.Fragment>


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
Properly (de-)pluralizes "contest" when there's only one.

## Demo Video or Screenshot
![localhost_3000_(Lenovo 14_)](https://user-images.githubusercontent.com/1938/174145231-c36626f2-2fd1-4d25-8327-14b7e92f01ae.png)

## Testing Plan 
Manually tested with a single-contest election.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
