### PR TITLE
refactor(types): remove unneeded `JSON.parse`

### DIFF
--- a/frontends/election-manager/src/screens/unconfigured_screen.tsx
+++ b/frontends/election-manager/src/screens/unconfigured_screen.tsx
@@ -83,7 +83,7 @@ export function UnconfiguredScreen(): JSX.Element {
 
   const saveElectionAndShowSuccess = useCallback(
     (electionJson: string) => {
-      safeParseElection(JSON.parse(electionJson)).unsafeUnwrap();
+      safeParseElection(electionJson).unsafeUnwrap();
       setShowSuccess(true);
       setTimeout(async () => {
         setShowSuccess(false);

--- a/libs/fixtures/scripts/generate_sample_cvr_file.ts
+++ b/libs/fixtures/scripts/generate_sample_cvr_file.ts
@@ -303,7 +303,7 @@ const testMode = !(args.liveBallots ?? false);
 const scannerNames = (args.scannerNames ?? ['scanner']).map((s) => `${s}`);
 
 const electionRawData = fs.readFileSync(args.electionPath, 'utf8');
-const election = safeParseElection(JSON.parse(electionRawData)).unsafeUnwrap();
+const election = safeParseElection(electionRawData).unsafeUnwrap();
 
 const castVoteRecords = [...generateCvrs(election, scannerNames, testMode)];
 


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
`safeParseElection` can already handle parsing from JSON strings.

## Demo Video or Screenshot
n/a

## Testing Plan 
Automated.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
