### PR TITLE
fix(scan): ignore mismatched XML/PDF ballot size

### DIFF
--- a/frontends/election-manager/src/lib/converters/nh_converter_client.ts
+++ b/frontends/election-manager/src/lib/converters/nh_converter_client.ts
@@ -88,11 +88,11 @@ export class NhConverterClient implements ConverterClient {
       { ovalTemplate: await templates.getOvalTemplate() }
     );
 
-    if (convertResult.isErr()) {
-      throw convertResult.err();
+    if (!convertResult.success) {
+      throw convertResult;
     }
 
-    const election = convertResult.ok();
+    const { election } = convertResult;
 
     this.outputFiles.set(
       VxElectionDefinitionFile,

--- a/libs/ballot-interpreter-nh/src/accuvote.test.ts
+++ b/libs/ballot-interpreter-nh/src/accuvote.test.ts
@@ -195,7 +195,7 @@ test('hudson template', async () => {
   `);
 
   const grid = readGridFromElectionDefinition(hudson.definition);
-  const paired = pairColumnEntries(
+  const pairResult = pairColumnEntries(
     grid.map((entry) => ({ ...entry, side: 'front' as const })),
     [
       ...frontTemplateOvals.map((oval) => ({
@@ -207,8 +207,9 @@ test('hudson template', async () => {
         side: 'back' as const,
       })),
     ]
-  ).unsafeUnwrap();
-  expect(paired).toHaveLength(
+  );
+  expect(pairResult.success).toBe(true);
+  expect(pairResult.pairs).toHaveLength(
     frontTemplateOvals.length + backTemplateOvals.length
   );
 

--- a/libs/ballot-interpreter-nh/src/index.ts
+++ b/libs/ballot-interpreter-nh/src/index.ts
@@ -2,8 +2,8 @@
 
 export {
   convertElectionDefinition,
-  ConvertErrorKind,
-  type ConvertError,
+  ConvertIssueKind,
+  type ConvertIssue,
 } from './convert';
 export * as templates from './data/templates';
 export { interpret } from './interpret';

--- a/libs/ballot-interpreter-nh/test/fixtures/amherst-2022-07-12/election.json
+++ b/libs/ballot-interpreter-nh/test/fixtures/amherst-2022-07-12/election.json
@@ -1,868 +1,866 @@
 {
-  "value": {
-    "ballotLayout": {
-      "paperSize": "legal",
-      "targetMarkPosition": "right"
+  "ballotLayout": {
+    "paperSize": "legal",
+    "targetMarkPosition": "right"
+  },
+  "ballotStyles": [
+    {
+      "id": "card-number-3",
+      "precincts": [
+        "town-id-00701-precinct-id-"
+      ],
+      "districts": [
+        "town-id-00701-precinct-id-"
+      ]
+    }
+  ],
+  "centralScanAdjudicationReasons": [
+    "UninterpretableBallot",
+    "Overvote",
+    "WriteIn",
+    "BlankBallot"
+  ],
+  "contests": [
+    {
+      "id": "Governor-061a401b",
+      "districtId": "town-id-00701-precinct-id-",
+      "section": "Governor",
+      "title": "Governor",
+      "type": "candidate",
+      "seats": 1,
+      "candidates": [
+        {
+          "id": "Josiah-Bartlett-1bb99985",
+          "name": "Josiah Bartlett",
+          "partyIds": [
+            "Democratic-aea20adb"
+          ]
+        },
+        {
+          "id": "Hannah-Dustin-ab4ef7c8",
+          "name": "Hannah Dustin",
+          "partyIds": [
+            "Republican-f0167ce7"
+          ]
+        },
+        {
+          "id": "John-Spencer-9ffb5970",
+          "name": "John Spencer",
+          "partyIds": [
+            "OC-3a386d2b"
+          ]
+        }
+      ],
+      "allowWriteIns": true
     },
-    "ballotStyles": [
-      {
-        "id": "default",
-        "precincts": [
-          "town-id-00701-precinct-id-"
-        ],
-        "districts": [
-          "town-id-00701-precinct-id-"
-        ]
-      }
-    ],
-    "centralScanAdjudicationReasons": [
-      "UninterpretableBallot",
-      "Overvote",
-      "WriteIn",
-      "BlankBallot"
-    ],
-    "contests": [
-      {
-        "id": "Governor-061a401b",
-        "districtId": "town-id-00701-precinct-id-",
-        "section": "Governor",
-        "title": "Governor",
-        "type": "candidate",
-        "seats": 1,
-        "candidates": [
-          {
-            "id": "Josiah-Bartlett-1bb99985",
-            "name": "Josiah Bartlett",
-            "partyIds": [
-              "Democratic-aea20adb"
-            ]
-          },
-          {
-            "id": "Hannah-Dustin-ab4ef7c8",
-            "name": "Hannah Dustin",
-            "partyIds": [
-              "Republican-f0167ce7"
-            ]
-          },
-          {
-            "id": "John-Spencer-9ffb5970",
-            "name": "John Spencer",
-            "partyIds": [
-              "OC-3a386d2b"
-            ]
-          }
-        ],
-        "allowWriteIns": true
-      },
-      {
-        "id": "United-States-Senator-d3f1c75b",
-        "districtId": "town-id-00701-precinct-id-",
-        "section": "United States Senator",
-        "title": "United States Senator",
-        "type": "candidate",
-        "seats": 1,
-        "candidates": [
-          {
-            "id": "John-Langdon-5951c8e1",
-            "name": "John Langdon",
-            "partyIds": [
-              "Democratic-aea20adb"
-            ]
-          },
-          {
-            "id": "William-Preston-3778fcd5",
-            "name": "William Preston",
-            "partyIds": [
-              "Republican-f0167ce7"
-            ]
-          }
-        ],
-        "allowWriteIns": true
-      },
-      {
-        "id": "Representative-in-Congress-24683b44",
-        "districtId": "town-id-00701-precinct-id-",
-        "section": "Representative in Congress",
-        "title": "Representative in Congress",
-        "type": "candidate",
-        "seats": 1,
-        "candidates": [
-          {
-            "id": "Jeremiah-Smith-469560c9",
-            "name": "Jeremiah Smith",
-            "partyIds": [
-              "Democratic-aea20adb"
-            ]
-          },
-          {
-            "id": "Nicholas-Gilman-1791aed7",
-            "name": "Nicholas Gilman",
-            "partyIds": [
-              "Republican-f0167ce7"
-            ]
-          },
-          {
-            "id": "Richard-Coote-b9095636",
-            "name": "Richard Coote",
-            "partyIds": [
-              "OC-3a386d2b"
-            ]
-          }
-        ],
-        "allowWriteIns": true
-      },
-      {
-        "id": "Executive-Councilor-bb22557f",
-        "districtId": "town-id-00701-precinct-id-",
-        "section": "Executive Councilor",
-        "title": "Executive Councilor",
-        "type": "candidate",
-        "seats": 1,
-        "candidates": [
-          {
-            "id": "Anne-Waldron-ee0cbc85",
-            "name": "Anne Waldron",
-            "partyIds": [
-              "Democratic-aea20adb"
-            ]
-          },
-          {
-            "id": "Daniel-Webster-13f77b2d",
-            "name": "Daniel Webster",
-            "partyIds": [
-              "Republican-f0167ce7"
-            ]
-          }
-        ],
-        "allowWriteIns": true
-      },
-      {
-        "id": "State-Senator-391381f8",
-        "districtId": "town-id-00701-precinct-id-",
-        "section": "State Senator",
-        "title": "State Senator",
-        "type": "candidate",
-        "seats": 1,
-        "candidates": [
-          {
-            "id": "James-Poole-db5ef4bd",
-            "name": "James Poole",
-            "partyIds": [
-              "Democratic-aea20adb"
-            ]
-          },
-          {
-            "id": "Matthew-Thornton-f66fec5e",
-            "name": "Matthew Thornton",
-            "partyIds": [
-              "Republican-f0167ce7"
-            ]
-          }
-        ],
-        "allowWriteIns": true
-      },
-      {
-        "id": "State-Representatives-Hillsborough-District-34-b1012d38",
-        "districtId": "town-id-00701-precinct-id-",
-        "section": "State Representatives  Hillsborough District 34",
-        "title": "State Representatives  Hillsborough District 34",
-        "type": "candidate",
-        "seats": 3,
-        "candidates": [
-          {
-            "id": "Obadiah-Carrigan-5c95145a",
-            "name": "Obadiah Carrigan",
-            "partyIds": [
-              "Democratic-aea20adb"
-            ]
-          },
-          {
-            "id": "Mary-Baker-Eddy-350785d5",
-            "name": "Mary Baker Eddy",
-            "partyIds": [
-              "Democratic-aea20adb"
-            ]
-          },
-          {
-            "id": "Samuel-Bell-17973275",
-            "name": "Samuel Bell",
-            "partyIds": [
-              "Democratic-aea20adb"
-            ]
-          },
-          {
-            "id": "Samuel-Livermore-f927fef1",
-            "name": "Samuel Livermore",
-            "partyIds": [
-              "Republican-f0167ce7"
-            ]
-          },
-          {
-            "id": "Elijah-Miller-a52e6988",
-            "name": "Elijah Miller",
-            "partyIds": [
-              "Republican-f0167ce7"
-            ]
-          },
-          {
-            "id": "Isaac-Hill-d6c9deeb",
-            "name": "Isaac Hill",
-            "partyIds": [
-              "Republican-f0167ce7"
-            ]
-          },
-          {
-            "id": "Abigail-Bartlett-4e46c9d4",
-            "name": "Abigail Bartlett",
-            "partyIds": [
-              "OC-3a386d2b"
-            ]
-          },
-          {
-            "id": "Jacob-Freese-b5146505",
-            "name": "Jacob Freese",
-            "partyIds": [
-              "OC-3a386d2b"
-            ]
-          }
-        ],
-        "allowWriteIns": true
-      },
-      {
-        "id": "State-Representative-Hillsborough-District-37-f3bde894",
-        "districtId": "town-id-00701-precinct-id-",
-        "section": "State Representative  Hillsborough District 37",
-        "title": "State Representative  Hillsborough District 37",
-        "type": "candidate",
-        "seats": 1,
-        "candidates": [
-          {
-            "id": "Abeil-Foster-ded38e36",
-            "name": "Abeil Foster",
-            "partyIds": [
-              "Democratic-aea20adb"
-            ]
-          },
-          {
-            "id": "Charles-H-Hersey-096286a4",
-            "name": "Charles H. Hersey",
-            "partyIds": [
-              "Republican-f0167ce7"
-            ]
-          },
-          {
-            "id": "William-Lovejoy-fde3c2df",
-            "name": "William Lovejoy",
-            "partyIds": [
-              "OC-3a386d2b"
-            ]
-          }
-        ],
-        "allowWriteIns": true
-      },
-      {
-        "id": "Sheriff-4243fe0b",
-        "districtId": "town-id-00701-precinct-id-",
-        "section": "Sheriff",
-        "title": "Sheriff",
-        "type": "candidate",
-        "seats": 1,
-        "candidates": [
-          {
-            "id": "Edward-Randolph-bf4c848a",
-            "name": "Edward Randolph",
-            "partyIds": [
-              "Democratic-aea20adb",
-              "Republican-f0167ce7"
-            ]
-          }
-        ],
-        "allowWriteIns": true
-      },
-      {
-        "id": "County-Attorney-133f910f",
-        "districtId": "town-id-00701-precinct-id-",
-        "section": "County Attorney",
-        "title": "County Attorney",
-        "type": "candidate",
-        "seats": 1,
-        "candidates": [
-          {
-            "id": "Ezra-Bartlett-8f95223c",
-            "name": "Ezra Bartlett",
-            "partyIds": [
-              "Democratic-aea20adb"
-            ]
-          },
-          {
-            "id": "Mary-Woolson-dc0b854a",
-            "name": "Mary Woolson",
-            "partyIds": [
-              "Republican-f0167ce7"
-            ]
-          }
-        ],
-        "allowWriteIns": true
-      },
-      {
-        "id": "County-Treasurer-87d25a31",
-        "districtId": "town-id-00701-precinct-id-",
-        "section": "County Treasurer",
-        "title": "County Treasurer",
-        "type": "candidate",
-        "seats": 1,
-        "candidates": [
-          {
-            "id": "John-Smith-ef61a579",
-            "name": "John Smith",
-            "partyIds": [
-              "Democratic-aea20adb"
-            ]
-          },
-          {
-            "id": "Jane-Jones-9caa141f",
-            "name": "Jane Jones",
-            "partyIds": [
-              "Republican-f0167ce7"
-            ]
-          }
-        ],
-        "allowWriteIns": true
-      },
-      {
-        "id": "Register-of-Deeds-a1278df2",
-        "districtId": "town-id-00701-precinct-id-",
-        "section": "Register of Deeds",
-        "title": "Register of Deeds",
-        "type": "candidate",
-        "seats": 1,
-        "candidates": [
-          {
-            "id": "John-Mann-b56bbdd3",
-            "name": "John Mann",
-            "partyIds": [
-              "Democratic-aea20adb"
-            ]
-          },
-          {
-            "id": "Ellen-A-Stileman-14408737",
-            "name": "Ellen A. Stileman",
-            "partyIds": [
-              "Republican-f0167ce7"
-            ]
-          }
-        ],
-        "allowWriteIns": true
-      },
-      {
-        "id": "Register-of-Probate-a4117da8",
-        "districtId": "town-id-00701-precinct-id-",
-        "section": "Register of Probate",
-        "title": "Register of Probate",
-        "type": "candidate",
-        "seats": 1,
-        "candidates": [
-          {
-            "id": "Nathaniel-Parker-56a06c29",
-            "name": "Nathaniel Parker",
-            "partyIds": [
-              "Democratic-aea20adb"
-            ]
-          },
-          {
-            "id": "Claire-Cutts-07a436e7",
-            "name": "Claire Cutts",
-            "partyIds": [
-              "Republican-f0167ce7"
-            ]
-          }
-        ],
-        "allowWriteIns": true
-      },
-      {
-        "id": "County-Commissioner-d6feed25",
-        "districtId": "town-id-00701-precinct-id-",
-        "section": "County Commissioner",
-        "title": "County Commissioner",
-        "type": "candidate",
-        "seats": 1,
-        "candidates": [
-          {
-            "id": "Ichabod-Goodwin-55e8de1f",
-            "name": "Ichabod Goodwin",
-            "partyIds": [
-              "Democratic-aea20adb"
-            ]
-          },
-          {
-            "id": "Valbe-Cady-ba3af3af",
-            "name": "Valbe Cady",
-            "partyIds": [
-              "Republican-f0167ce7"
-            ]
-          }
-        ],
-        "allowWriteIns": true
-      }
-    ],
-    "gridLayouts": [
-      {
-        "precinctId": "town-id-00701-precinct-id-",
-        "ballotStyleId": "default",
-        "columns": 34,
-        "rows": 53,
-        "gridPositions": [
-          {
-            "type": "option",
-            "side": "front",
-            "column": 12,
-            "row": 9,
-            "contestId": "Governor-061a401b",
-            "optionId": "Josiah-Bartlett-1bb99985"
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 19,
-            "row": 9,
-            "contestId": "Governor-061a401b",
-            "optionId": "Hannah-Dustin-ab4ef7c8"
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 26,
-            "row": 9,
-            "contestId": "Governor-061a401b",
-            "optionId": "John-Spencer-9ffb5970"
-          },
-          {
-            "type": "write-in",
-            "side": "front",
-            "column": 33,
-            "row": 9,
-            "contestId": "Governor-061a401b",
-            "writeInIndex": 0
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 12,
-            "row": 13,
-            "contestId": "United-States-Senator-d3f1c75b",
-            "optionId": "John-Langdon-5951c8e1"
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 19,
-            "row": 13,
-            "contestId": "United-States-Senator-d3f1c75b",
-            "optionId": "William-Preston-3778fcd5"
-          },
-          {
-            "type": "write-in",
-            "side": "front",
-            "column": 33,
-            "row": 13,
-            "contestId": "United-States-Senator-d3f1c75b",
-            "writeInIndex": 0
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 12,
-            "row": 17,
-            "contestId": "Representative-in-Congress-24683b44",
-            "optionId": "Jeremiah-Smith-469560c9"
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 19,
-            "row": 17,
-            "contestId": "Representative-in-Congress-24683b44",
-            "optionId": "Nicholas-Gilman-1791aed7"
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 26,
-            "row": 17,
-            "contestId": "Representative-in-Congress-24683b44",
-            "optionId": "Richard-Coote-b9095636"
-          },
-          {
-            "type": "write-in",
-            "side": "front",
-            "column": 33,
-            "row": 19,
-            "contestId": "Representative-in-Congress-24683b44",
-            "writeInIndex": 0
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 12,
-            "row": 23,
-            "contestId": "Executive-Councilor-bb22557f",
-            "optionId": "Anne-Waldron-ee0cbc85"
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 19,
-            "row": 23,
-            "contestId": "Executive-Councilor-bb22557f",
-            "optionId": "Daniel-Webster-13f77b2d"
-          },
-          {
-            "type": "write-in",
-            "side": "front",
-            "column": 33,
-            "row": 23,
-            "contestId": "Executive-Councilor-bb22557f",
-            "writeInIndex": 0
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 12,
-            "row": 27,
-            "contestId": "State-Senator-391381f8",
-            "optionId": "James-Poole-db5ef4bd"
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 19,
-            "row": 27,
-            "contestId": "State-Senator-391381f8",
-            "optionId": "Matthew-Thornton-f66fec5e"
-          },
-          {
-            "type": "write-in",
-            "side": "front",
-            "column": 33,
-            "row": 27,
-            "contestId": "State-Senator-391381f8",
-            "writeInIndex": 0
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 12,
-            "row": 31,
-            "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
-            "optionId": "Obadiah-Carrigan-5c95145a"
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 12,
-            "row": 33,
-            "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
-            "optionId": "Mary-Baker-Eddy-350785d5"
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 12,
-            "row": 35,
-            "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
-            "optionId": "Samuel-Bell-17973275"
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 19,
-            "row": 31,
-            "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
-            "optionId": "Samuel-Livermore-f927fef1"
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 19,
-            "row": 33,
-            "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
-            "optionId": "Elijah-Miller-a52e6988"
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 19,
-            "row": 35,
-            "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
-            "optionId": "Isaac-Hill-d6c9deeb"
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 26,
-            "row": 31,
-            "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
-            "optionId": "Abigail-Bartlett-4e46c9d4"
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 26,
-            "row": 35,
-            "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
-            "optionId": "Jacob-Freese-b5146505"
-          },
-          {
-            "type": "write-in",
-            "side": "front",
-            "column": 33,
-            "row": 35,
-            "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
-            "writeInIndex": 0
-          },
-          {
-            "type": "write-in",
-            "side": "front",
-            "column": 33,
-            "row": 33,
-            "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
-            "writeInIndex": 1
-          },
-          {
-            "type": "write-in",
-            "side": "front",
-            "column": 33,
-            "row": 31,
-            "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
-            "writeInIndex": 2
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 12,
-            "row": 41,
-            "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
-            "optionId": "Abeil-Foster-ded38e36"
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 19,
-            "row": 41,
-            "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
-            "optionId": "Charles-H-Hersey-096286a4"
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 26,
-            "row": 41,
-            "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
-            "optionId": "William-Lovejoy-fde3c2df"
-          },
-          {
-            "type": "write-in",
-            "side": "front",
-            "column": 33,
-            "row": 41,
-            "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
-            "writeInIndex": 0
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 12,
-            "row": 45,
-            "contestId": "Sheriff-4243fe0b",
-            "optionId": "Edward-Randolph-bf4c848a"
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 19,
-            "row": 45,
-            "contestId": "Sheriff-4243fe0b",
-            "optionId": "Edward-Randolph-bf4c848a"
-          },
-          {
-            "type": "write-in",
-            "side": "front",
-            "column": 33,
-            "row": 45,
-            "contestId": "Sheriff-4243fe0b",
-            "writeInIndex": 0
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 12,
-            "row": 49,
-            "contestId": "County-Attorney-133f910f",
-            "optionId": "Ezra-Bartlett-8f95223c"
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 19,
-            "row": 49,
-            "contestId": "County-Attorney-133f910f",
-            "optionId": "Mary-Woolson-dc0b854a"
-          },
-          {
-            "type": "write-in",
-            "side": "front",
-            "column": 33,
-            "row": 49,
-            "contestId": "County-Attorney-133f910f",
-            "writeInIndex": 0
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 12,
-            "row": 53,
-            "contestId": "County-Treasurer-87d25a31",
-            "optionId": "John-Smith-ef61a579"
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 19,
-            "row": 53,
-            "contestId": "County-Treasurer-87d25a31",
-            "optionId": "Jane-Jones-9caa141f"
-          },
-          {
-            "type": "write-in",
-            "side": "front",
-            "column": 33,
-            "row": 53,
-            "contestId": "County-Treasurer-87d25a31",
-            "writeInIndex": 0
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 12,
-            "row": 57,
-            "contestId": "Register-of-Deeds-a1278df2",
-            "optionId": "John-Mann-b56bbdd3"
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 19,
-            "row": 57,
-            "contestId": "Register-of-Deeds-a1278df2",
-            "optionId": "Ellen-A-Stileman-14408737"
-          },
-          {
-            "type": "write-in",
-            "side": "front",
-            "column": 33,
-            "row": 57,
-            "contestId": "Register-of-Deeds-a1278df2",
-            "writeInIndex": 0
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 12,
-            "row": 61,
-            "contestId": "Register-of-Probate-a4117da8",
-            "optionId": "Nathaniel-Parker-56a06c29"
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 19,
-            "row": 61,
-            "contestId": "Register-of-Probate-a4117da8",
-            "optionId": "Claire-Cutts-07a436e7"
-          },
-          {
-            "type": "write-in",
-            "side": "front",
-            "column": 33,
-            "row": 61,
-            "contestId": "Register-of-Probate-a4117da8",
-            "writeInIndex": 0
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 12,
-            "row": 65,
-            "contestId": "County-Commissioner-d6feed25",
-            "optionId": "Ichabod-Goodwin-55e8de1f"
-          },
-          {
-            "type": "option",
-            "side": "front",
-            "column": 19,
-            "row": 65,
-            "contestId": "County-Commissioner-d6feed25",
-            "optionId": "Valbe-Cady-ba3af3af"
-          },
-          {
-            "type": "write-in",
-            "side": "front",
-            "column": 33,
-            "row": 65,
-            "contestId": "County-Commissioner-d6feed25",
-            "writeInIndex": 0
-          }
-        ]
-      }
-    ],
-    "county": {
-      "id": "00701",
+    {
+      "id": "United-States-Senator-d3f1c75b",
+      "districtId": "town-id-00701-precinct-id-",
+      "section": "United States Senator",
+      "title": "United States Senator",
+      "type": "candidate",
+      "seats": 1,
+      "candidates": [
+        {
+          "id": "John-Langdon-5951c8e1",
+          "name": "John Langdon",
+          "partyIds": [
+            "Democratic-aea20adb"
+          ]
+        },
+        {
+          "id": "William-Preston-3778fcd5",
+          "name": "William Preston",
+          "partyIds": [
+            "Republican-f0167ce7"
+          ]
+        }
+      ],
+      "allowWriteIns": true
+    },
+    {
+      "id": "Representative-in-Congress-24683b44",
+      "districtId": "town-id-00701-precinct-id-",
+      "section": "Representative in Congress",
+      "title": "Representative in Congress",
+      "type": "candidate",
+      "seats": 1,
+      "candidates": [
+        {
+          "id": "Jeremiah-Smith-469560c9",
+          "name": "Jeremiah Smith",
+          "partyIds": [
+            "Democratic-aea20adb"
+          ]
+        },
+        {
+          "id": "Nicholas-Gilman-1791aed7",
+          "name": "Nicholas Gilman",
+          "partyIds": [
+            "Republican-f0167ce7"
+          ]
+        },
+        {
+          "id": "Richard-Coote-b9095636",
+          "name": "Richard Coote",
+          "partyIds": [
+            "OC-3a386d2b"
+          ]
+        }
+      ],
+      "allowWriteIns": true
+    },
+    {
+      "id": "Executive-Councilor-bb22557f",
+      "districtId": "town-id-00701-precinct-id-",
+      "section": "Executive Councilor",
+      "title": "Executive Councilor",
+      "type": "candidate",
+      "seats": 1,
+      "candidates": [
+        {
+          "id": "Anne-Waldron-ee0cbc85",
+          "name": "Anne Waldron",
+          "partyIds": [
+            "Democratic-aea20adb"
+          ]
+        },
+        {
+          "id": "Daniel-Webster-13f77b2d",
+          "name": "Daniel Webster",
+          "partyIds": [
+            "Republican-f0167ce7"
+          ]
+        }
+      ],
+      "allowWriteIns": true
+    },
+    {
+      "id": "State-Senator-391381f8",
+      "districtId": "town-id-00701-precinct-id-",
+      "section": "State Senator",
+      "title": "State Senator",
+      "type": "candidate",
+      "seats": 1,
+      "candidates": [
+        {
+          "id": "James-Poole-db5ef4bd",
+          "name": "James Poole",
+          "partyIds": [
+            "Democratic-aea20adb"
+          ]
+        },
+        {
+          "id": "Matthew-Thornton-f66fec5e",
+          "name": "Matthew Thornton",
+          "partyIds": [
+            "Republican-f0167ce7"
+          ]
+        }
+      ],
+      "allowWriteIns": true
+    },
+    {
+      "id": "State-Representatives-Hillsborough-District-34-b1012d38",
+      "districtId": "town-id-00701-precinct-id-",
+      "section": "State Representatives  Hillsborough District 34",
+      "title": "State Representatives  Hillsborough District 34",
+      "type": "candidate",
+      "seats": 3,
+      "candidates": [
+        {
+          "id": "Obadiah-Carrigan-5c95145a",
+          "name": "Obadiah Carrigan",
+          "partyIds": [
+            "Democratic-aea20adb"
+          ]
+        },
+        {
+          "id": "Mary-Baker-Eddy-350785d5",
+          "name": "Mary Baker Eddy",
+          "partyIds": [
+            "Democratic-aea20adb"
+          ]
+        },
+        {
+          "id": "Samuel-Bell-17973275",
+          "name": "Samuel Bell",
+          "partyIds": [
+            "Democratic-aea20adb"
+          ]
+        },
+        {
+          "id": "Samuel-Livermore-f927fef1",
+          "name": "Samuel Livermore",
+          "partyIds": [
+            "Republican-f0167ce7"
+          ]
+        },
+        {
+          "id": "Elijah-Miller-a52e6988",
+          "name": "Elijah Miller",
+          "partyIds": [
+            "Republican-f0167ce7"
+          ]
+        },
+        {
+          "id": "Isaac-Hill-d6c9deeb",
+          "name": "Isaac Hill",
+          "partyIds": [
+            "Republican-f0167ce7"
+          ]
+        },
+        {
+          "id": "Abigail-Bartlett-4e46c9d4",
+          "name": "Abigail Bartlett",
+          "partyIds": [
+            "OC-3a386d2b"
+          ]
+        },
+        {
+          "id": "Jacob-Freese-b5146505",
+          "name": "Jacob Freese",
+          "partyIds": [
+            "OC-3a386d2b"
+          ]
+        }
+      ],
+      "allowWriteIns": true
+    },
+    {
+      "id": "State-Representative-Hillsborough-District-37-f3bde894",
+      "districtId": "town-id-00701-precinct-id-",
+      "section": "State Representative  Hillsborough District 37",
+      "title": "State Representative  Hillsborough District 37",
+      "type": "candidate",
+      "seats": 1,
+      "candidates": [
+        {
+          "id": "Abeil-Foster-ded38e36",
+          "name": "Abeil Foster",
+          "partyIds": [
+            "Democratic-aea20adb"
+          ]
+        },
+        {
+          "id": "Charles-H-Hersey-096286a4",
+          "name": "Charles H. Hersey",
+          "partyIds": [
+            "Republican-f0167ce7"
+          ]
+        },
+        {
+          "id": "William-Lovejoy-fde3c2df",
+          "name": "William Lovejoy",
+          "partyIds": [
+            "OC-3a386d2b"
+          ]
+        }
+      ],
+      "allowWriteIns": true
+    },
+    {
+      "id": "Sheriff-4243fe0b",
+      "districtId": "town-id-00701-precinct-id-",
+      "section": "Sheriff",
+      "title": "Sheriff",
+      "type": "candidate",
+      "seats": 1,
+      "candidates": [
+        {
+          "id": "Edward-Randolph-bf4c848a",
+          "name": "Edward Randolph",
+          "partyIds": [
+            "Democratic-aea20adb",
+            "Republican-f0167ce7"
+          ]
+        }
+      ],
+      "allowWriteIns": true
+    },
+    {
+      "id": "County-Attorney-133f910f",
+      "districtId": "town-id-00701-precinct-id-",
+      "section": "County Attorney",
+      "title": "County Attorney",
+      "type": "candidate",
+      "seats": 1,
+      "candidates": [
+        {
+          "id": "Ezra-Bartlett-8f95223c",
+          "name": "Ezra Bartlett",
+          "partyIds": [
+            "Democratic-aea20adb"
+          ]
+        },
+        {
+          "id": "Mary-Woolson-dc0b854a",
+          "name": "Mary Woolson",
+          "partyIds": [
+            "Republican-f0167ce7"
+          ]
+        }
+      ],
+      "allowWriteIns": true
+    },
+    {
+      "id": "County-Treasurer-87d25a31",
+      "districtId": "town-id-00701-precinct-id-",
+      "section": "County Treasurer",
+      "title": "County Treasurer",
+      "type": "candidate",
+      "seats": 1,
+      "candidates": [
+        {
+          "id": "John-Smith-ef61a579",
+          "name": "John Smith",
+          "partyIds": [
+            "Democratic-aea20adb"
+          ]
+        },
+        {
+          "id": "Jane-Jones-9caa141f",
+          "name": "Jane Jones",
+          "partyIds": [
+            "Republican-f0167ce7"
+          ]
+        }
+      ],
+      "allowWriteIns": true
+    },
+    {
+      "id": "Register-of-Deeds-a1278df2",
+      "districtId": "town-id-00701-precinct-id-",
+      "section": "Register of Deeds",
+      "title": "Register of Deeds",
+      "type": "candidate",
+      "seats": 1,
+      "candidates": [
+        {
+          "id": "John-Mann-b56bbdd3",
+          "name": "John Mann",
+          "partyIds": [
+            "Democratic-aea20adb"
+          ]
+        },
+        {
+          "id": "Ellen-A-Stileman-14408737",
+          "name": "Ellen A. Stileman",
+          "partyIds": [
+            "Republican-f0167ce7"
+          ]
+        }
+      ],
+      "allowWriteIns": true
+    },
+    {
+      "id": "Register-of-Probate-a4117da8",
+      "districtId": "town-id-00701-precinct-id-",
+      "section": "Register of Probate",
+      "title": "Register of Probate",
+      "type": "candidate",
+      "seats": 1,
+      "candidates": [
+        {
+          "id": "Nathaniel-Parker-56a06c29",
+          "name": "Nathaniel Parker",
+          "partyIds": [
+            "Democratic-aea20adb"
+          ]
+        },
+        {
+          "id": "Claire-Cutts-07a436e7",
+          "name": "Claire Cutts",
+          "partyIds": [
+            "Republican-f0167ce7"
+          ]
+        }
+      ],
+      "allowWriteIns": true
+    },
+    {
+      "id": "County-Commissioner-d6feed25",
+      "districtId": "town-id-00701-precinct-id-",
+      "section": "County Commissioner",
+      "title": "County Commissioner",
+      "type": "candidate",
+      "seats": 1,
+      "candidates": [
+        {
+          "id": "Ichabod-Goodwin-55e8de1f",
+          "name": "Ichabod Goodwin",
+          "partyIds": [
+            "Democratic-aea20adb"
+          ]
+        },
+        {
+          "id": "Valbe-Cady-ba3af3af",
+          "name": "Valbe Cady",
+          "partyIds": [
+            "Republican-f0167ce7"
+          ]
+        }
+      ],
+      "allowWriteIns": true
+    }
+  ],
+  "gridLayouts": [
+    {
+      "precinctId": "town-id-00701-precinct-id-",
+      "ballotStyleId": "card-number-3",
+      "columns": 34,
+      "rows": 53,
+      "gridPositions": [
+        {
+          "type": "option",
+          "side": "front",
+          "column": 12,
+          "row": 8,
+          "contestId": "Governor-061a401b",
+          "optionId": "Josiah-Bartlett-1bb99985"
+        },
+        {
+          "type": "option",
+          "side": "front",
+          "column": 12,
+          "row": 11,
+          "contestId": "United-States-Senator-d3f1c75b",
+          "optionId": "John-Langdon-5951c8e1"
+        },
+        {
+          "type": "option",
+          "side": "front",
+          "column": 12,
+          "row": 14,
+          "contestId": "Representative-in-Congress-24683b44",
+          "optionId": "Jeremiah-Smith-469560c9"
+        },
+        {
+          "type": "option",
+          "side": "front",
+          "column": 12,
+          "row": 17,
+          "contestId": "Executive-Councilor-bb22557f",
+          "optionId": "Anne-Waldron-ee0cbc85"
+        },
+        {
+          "type": "option",
+          "side": "front",
+          "column": 12,
+          "row": 20,
+          "contestId": "State-Senator-391381f8",
+          "optionId": "James-Poole-db5ef4bd"
+        },
+        {
+          "type": "option",
+          "side": "front",
+          "column": 12,
+          "row": 24,
+          "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+          "optionId": "Obadiah-Carrigan-5c95145a"
+        },
+        {
+          "type": "option",
+          "side": "front",
+          "column": 12,
+          "row": 26,
+          "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+          "optionId": "Mary-Baker-Eddy-350785d5"
+        },
+        {
+          "type": "option",
+          "side": "front",
+          "column": 12,
+          "row": 28,
+          "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+          "optionId": "Samuel-Bell-17973275"
+        },
+        {
+          "type": "option",
+          "side": "front",
+          "column": 12,
+          "row": 32,
+          "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
+          "optionId": "Abeil-Foster-ded38e36"
+        },
+        {
+          "type": "option",
+          "side": "back",
+          "column": 12,
+          "row": 4,
+          "contestId": "Sheriff-4243fe0b",
+          "optionId": "Edward-Randolph-bf4c848a"
+        },
+        {
+          "type": "option",
+          "side": "back",
+          "column": 12,
+          "row": 7,
+          "contestId": "County-Attorney-133f910f",
+          "optionId": "Ezra-Bartlett-8f95223c"
+        },
+        {
+          "type": "option",
+          "side": "back",
+          "column": 12,
+          "row": 10,
+          "contestId": "County-Treasurer-87d25a31",
+          "optionId": "John-Smith-ef61a579"
+        },
+        {
+          "type": "option",
+          "side": "back",
+          "column": 12,
+          "row": 13,
+          "contestId": "Register-of-Deeds-a1278df2",
+          "optionId": "John-Mann-b56bbdd3"
+        },
+        {
+          "type": "option",
+          "side": "back",
+          "column": 12,
+          "row": 16,
+          "contestId": "Register-of-Probate-a4117da8",
+          "optionId": "Nathaniel-Parker-56a06c29"
+        },
+        {
+          "type": "option",
+          "side": "back",
+          "column": 12,
+          "row": 19,
+          "contestId": "County-Commissioner-d6feed25",
+          "optionId": "Ichabod-Goodwin-55e8de1f"
+        },
+        {
+          "type": "option",
+          "side": "front",
+          "column": 19,
+          "row": 8,
+          "contestId": "Governor-061a401b",
+          "optionId": "Hannah-Dustin-ab4ef7c8"
+        },
+        {
+          "type": "option",
+          "side": "front",
+          "column": 19,
+          "row": 11,
+          "contestId": "United-States-Senator-d3f1c75b",
+          "optionId": "William-Preston-3778fcd5"
+        },
+        {
+          "type": "option",
+          "side": "front",
+          "column": 19,
+          "row": 14,
+          "contestId": "Representative-in-Congress-24683b44",
+          "optionId": "Nicholas-Gilman-1791aed7"
+        },
+        {
+          "type": "option",
+          "side": "front",
+          "column": 19,
+          "row": 17,
+          "contestId": "Executive-Councilor-bb22557f",
+          "optionId": "Daniel-Webster-13f77b2d"
+        },
+        {
+          "type": "option",
+          "side": "front",
+          "column": 19,
+          "row": 20,
+          "contestId": "State-Senator-391381f8",
+          "optionId": "Matthew-Thornton-f66fec5e"
+        },
+        {
+          "type": "option",
+          "side": "front",
+          "column": 19,
+          "row": 23,
+          "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+          "optionId": "Samuel-Livermore-f927fef1"
+        },
+        {
+          "type": "option",
+          "side": "front",
+          "column": 19,
+          "row": 25,
+          "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+          "optionId": "Elijah-Miller-a52e6988"
+        },
+        {
+          "type": "option",
+          "side": "front",
+          "column": 19,
+          "row": 27,
+          "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+          "optionId": "Isaac-Hill-d6c9deeb"
+        },
+        {
+          "type": "option",
+          "side": "front",
+          "column": 19,
+          "row": 32,
+          "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
+          "optionId": "Charles-H-Hersey-096286a4"
+        },
+        {
+          "type": "option",
+          "side": "back",
+          "column": 19,
+          "row": 4,
+          "contestId": "Sheriff-4243fe0b",
+          "optionId": "Edward-Randolph-bf4c848a"
+        },
+        {
+          "type": "option",
+          "side": "back",
+          "column": 19,
+          "row": 7,
+          "contestId": "County-Attorney-133f910f",
+          "optionId": "Mary-Woolson-dc0b854a"
+        },
+        {
+          "type": "option",
+          "side": "back",
+          "column": 19,
+          "row": 10,
+          "contestId": "County-Treasurer-87d25a31",
+          "optionId": "Jane-Jones-9caa141f"
+        },
+        {
+          "type": "option",
+          "side": "back",
+          "column": 19,
+          "row": 13,
+          "contestId": "Register-of-Deeds-a1278df2",
+          "optionId": "Ellen-A-Stileman-14408737"
+        },
+        {
+          "type": "option",
+          "side": "back",
+          "column": 19,
+          "row": 16,
+          "contestId": "Register-of-Probate-a4117da8",
+          "optionId": "Claire-Cutts-07a436e7"
+        },
+        {
+          "type": "option",
+          "side": "back",
+          "column": 19,
+          "row": 19,
+          "contestId": "County-Commissioner-d6feed25",
+          "optionId": "Valbe-Cady-ba3af3af"
+        },
+        {
+          "type": "option",
+          "side": "front",
+          "column": 26,
+          "row": 8,
+          "contestId": "Governor-061a401b",
+          "optionId": "John-Spencer-9ffb5970"
+        },
+        {
+          "type": "option",
+          "side": "front",
+          "column": 26,
+          "row": 14,
+          "contestId": "Representative-in-Congress-24683b44",
+          "optionId": "Richard-Coote-b9095636"
+        },
+        {
+          "type": "option",
+          "side": "front",
+          "column": 26,
+          "row": 24,
+          "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+          "optionId": "Abigail-Bartlett-4e46c9d4"
+        },
+        {
+          "type": "option",
+          "side": "front",
+          "column": 26,
+          "row": 26,
+          "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+          "optionId": "Jacob-Freese-b5146505"
+        },
+        {
+          "type": "option",
+          "side": "front",
+          "column": 26,
+          "row": 32,
+          "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
+          "optionId": "William-Lovejoy-fde3c2df"
+        },
+        {
+          "type": "write-in",
+          "side": "front",
+          "column": 32,
+          "row": 8,
+          "contestId": "Governor-061a401b",
+          "writeInIndex": 0
+        },
+        {
+          "type": "write-in",
+          "side": "front",
+          "column": 32,
+          "row": 11,
+          "contestId": "United-States-Senator-d3f1c75b",
+          "writeInIndex": 0
+        },
+        {
+          "type": "write-in",
+          "side": "front",
+          "column": 32,
+          "row": 14,
+          "contestId": "Representative-in-Congress-24683b44",
+          "writeInIndex": 0
+        },
+        {
+          "type": "write-in",
+          "side": "front",
+          "column": 32,
+          "row": 17,
+          "contestId": "Executive-Councilor-bb22557f",
+          "writeInIndex": 0
+        },
+        {
+          "type": "write-in",
+          "side": "front",
+          "column": 32,
+          "row": 20,
+          "contestId": "State-Senator-391381f8",
+          "writeInIndex": 0
+        },
+        {
+          "type": "write-in",
+          "side": "front",
+          "column": 32,
+          "row": 23,
+          "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+          "writeInIndex": 2
+        },
+        {
+          "type": "write-in",
+          "side": "front",
+          "column": 32,
+          "row": 25,
+          "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+          "writeInIndex": 1
+        },
+        {
+          "type": "write-in",
+          "side": "front",
+          "column": 32,
+          "row": 27,
+          "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+          "writeInIndex": 0
+        },
+        {
+          "type": "write-in",
+          "side": "front",
+          "column": 32,
+          "row": 32,
+          "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
+          "writeInIndex": 0
+        },
+        {
+          "type": "write-in",
+          "side": "back",
+          "column": 32,
+          "row": 4,
+          "contestId": "Sheriff-4243fe0b",
+          "writeInIndex": 0
+        },
+        {
+          "type": "write-in",
+          "side": "back",
+          "column": 32,
+          "row": 7,
+          "contestId": "County-Attorney-133f910f",
+          "writeInIndex": 0
+        },
+        {
+          "type": "write-in",
+          "side": "back",
+          "column": 32,
+          "row": 10,
+          "contestId": "County-Treasurer-87d25a31",
+          "writeInIndex": 0
+        },
+        {
+          "type": "write-in",
+          "side": "back",
+          "column": 32,
+          "row": 13,
+          "contestId": "Register-of-Deeds-a1278df2",
+          "writeInIndex": 0
+        },
+        {
+          "type": "write-in",
+          "side": "back",
+          "column": 32,
+          "row": 16,
+          "contestId": "Register-of-Probate-a4117da8",
+          "writeInIndex": 0
+        },
+        {
+          "type": "write-in",
+          "side": "back",
+          "column": 32,
+          "row": 19,
+          "contestId": "County-Commissioner-d6feed25",
+          "writeInIndex": 0
+        }
+      ]
+    }
+  ],
+  "county": {
+    "id": "00701",
+    "name": "Test Ballot"
+  },
+  "date": "2022-07-12T12:00:00.000-04:00",
+  "districts": [
+    {
+      "id": "town-id-00701-precinct-id-",
       "name": "Test Ballot"
+    }
+  ],
+  "markThresholds": {
+    "marginal": 0.1,
+    "definite": 0.12
+  },
+  "parties": [
+    {
+      "id": "Democratic-aea20adb",
+      "name": "Democratic",
+      "fullName": "Democratic",
+      "abbrev": "Democratic"
     },
-    "date": "2022-07-12T12:00:00.000-04:00",
-    "districts": [
-      {
-        "id": "town-id-00701-precinct-id-",
-        "name": "Test Ballot"
-      }
-    ],
-    "markThresholds": {
-      "marginal": 0.1,
-      "definite": 0.12
+    {
+      "id": "Republican-f0167ce7",
+      "name": "Republican",
+      "fullName": "Republican",
+      "abbrev": "Republican"
     },
-    "parties": [
-      {
-        "id": "Democratic-aea20adb",
-        "name": "Democratic",
-        "fullName": "Democratic",
-        "abbrev": "Democratic"
-      },
-      {
-        "id": "Republican-f0167ce7",
-        "name": "Republican",
-        "fullName": "Republican",
-        "abbrev": "Republican"
-      },
-      {
-        "id": "OC-3a386d2b",
-        "name": "OC",
-        "fullName": "OC",
-        "abbrev": "OC"
-      }
-    ],
-    "precinctScanAdjudicationReasons": [
-      "UninterpretableBallot",
-      "Overvote",
-      "BlankBallot"
-    ],
-    "precincts": [
-      {
-        "id": "town-id-00701-precinct-id-",
-        "name": "Test Ballot"
-      }
-    ],
-    "sealUrl": "/seals/Seal_of_New_Hampshire.svg",
-    "state": "NH",
-    "title": "General Election"
-  }
+    {
+      "id": "OC-3a386d2b",
+      "name": "OC",
+      "fullName": "OC",
+      "abbrev": "OC"
+    }
+  ],
+  "precinctScanAdjudicationReasons": [
+    "UninterpretableBallot",
+    "Overvote",
+    "BlankBallot"
+  ],
+  "precincts": [
+    {
+      "id": "town-id-00701-precinct-id-",
+      "name": "Test Ballot"
+    }
+  ],
+  "sealUrl": "/seals/Seal_of_New_Hampshire.svg",
+  "state": "NH",
+  "title": "General Election"
 }


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Rather than simply removing the error condition for the mismatched ballot size, I opted to make the conversion process a bit more error-tolerant while still surfacing the errors. Now it'll build the election definition as much as it can while also collecting issues as it sees them, returning the issues along with the (potentially) partial election definition. We consider the mismatched ballot size to be a non-fatal issue, so if that's the only issue then `success` will be `true`. All other issues are, for now, fatal but will no longer block generating an election definition.

This commit also updates the Amherst election definition to be as complete as it can be at this point, which means excluding the constitutional question. But that means ballots should now be scannable, just without the constitutional question.

Fixes #1987

## Demo Video or Screenshot
```
❯ ./bin/convert -o test/fixtures/amherst-2022-07-12/election.json test/fixtures/amherst-2022-07-12/{definition.xml,template-front.jpeg,template-back.jpeg}
error: conversion completed with issues:
- Ballot image size mismatch: XML definition is legal-size, or 684x1080, but front image is 684x864
- Ballot image size mismatch: XML definition is legal-size, or 684x1080, but back image is 684x864
- XML definition and ballot images have different number of entries in column 2: 5 vs 6
- XML definition and ballot images have different number of entries in column 3: 15 vs 16
```

## Testing Plan 
Some manual testing of `./bin/convert`, but didn't actually try scanning the Amherst ballot yet.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
