### PR TITLE
Populate super admin Backups tab

### DIFF
--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -1170,11 +1170,11 @@ test('super admin UI has expected nav when no election and VVSG2 auth flows are 
   await authenticateWithSuperAdminCard(card, false);
 
   screen.getByText('Definition');
+  screen.getByText('Backups');
   screen.getByRole('button', { name: 'Settings' });
   screen.getByRole('button', { name: 'Logs' });
   screen.getByRole('button', { name: 'Lock Machine' });
 
   expect(screen.queryByText('Draft Ballots')).not.toBeInTheDocument();
   expect(screen.queryByText('Smartcards')).not.toBeInTheDocument();
-  expect(screen.queryByText('Backups')).not.toBeInTheDocument();
 });

--- a/frontends/election-manager/src/components/election_manager.tsx
+++ b/frontends/election-manager/src/components/election_manager.tsx
@@ -61,12 +61,19 @@ export function ElectionManager(): JSX.Element {
         <Route exact path={routerPaths.root}>
           <UnconfiguredScreen />
         </Route>
-        <Route exact path={routerPaths.advanced}>
-          <AdvancedScreen />
-        </Route>
         <Route exact path={routerPaths.electionDefinition}>
           <UnconfiguredScreen />
         </Route>
+        {!areVvsg2AuthFlowsEnabled() && (
+          <Route exact path={routerPaths.advanced}>
+            <AdvancedScreen />
+          </Route>
+        )}
+        {areVvsg2AuthFlowsEnabled() && (
+          <Route exact path={routerPaths.backups}>
+            <BackupsScreen />
+          </Route>
+        )}
       </Switch>
     );
   }

--- a/frontends/election-manager/src/components/navigation_screen.tsx
+++ b/frontends/election-manager/src/components/navigation_screen.tsx
@@ -70,7 +70,10 @@ export function NavigationScreen({
           { label: 'Smartcards', routerPath: routerPaths.smartcards },
           { label: 'Backups', routerPath: routerPaths.backups },
         ]
-      : [{ label: 'Definition', routerPath: routerPaths.electionDefinition }];
+      : [
+          { label: 'Definition', routerPath: routerPaths.electionDefinition },
+          { label: 'Backups', routerPath: routerPaths.backups },
+        ];
   } else if (currentUserType === 'admin') {
     let primaryNavItemsUnfiltered: Array<NavItem | false> = [];
     if (areVvsg2AuthFlowsEnabled()) {

--- a/frontends/election-manager/src/screens/backups_screen.test.tsx
+++ b/frontends/election-manager/src/screens/backups_screen.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { fakeKiosk } from '@votingworks/test-utils';
+import { screen } from '@testing-library/react';
+
+import { BackupsScreen } from './backups_screen';
+import { renderInAppContext } from '../../test/render_in_app_context';
+
+let mockKiosk: jest.Mocked<KioskBrowser.Kiosk>;
+
+beforeEach(() => {
+  mockKiosk = fakeKiosk();
+  window.kiosk = mockKiosk;
+});
+
+test('Log-file backup', async () => {
+  renderInAppContext(<BackupsScreen />);
+
+  userEvent.click(await screen.findByText('Back Up Log File'));
+  // Modal is tested fully in src/components/export_logs_modal.test.tsx
+  await screen.findByText('No Log File Present');
+  userEvent.click(screen.getByText('Close'));
+
+  userEvent.click(await screen.findByText('Back Up Log File as CDF'));
+  // Modal is tested fully in src/components/export_logs_modal.test.tsx
+  await screen.findByText('No Log File Present');
+  userEvent.click(screen.getByText('Close'));
+});
+
+test('Relevant buttons are disabled when no election definition', async () => {
+  renderInAppContext(<BackupsScreen />, { electionDefinition: 'NONE' });
+
+  userEvent.click(await screen.findByText('Back Up Log File'));
+  // Modal is tested fully in src/components/export_logs_modal.test.tsx
+  await screen.findByText('No Log File Present');
+  userEvent.click(screen.getByText('Close'));
+
+  expect(
+    (await screen.findByText('Back Up Log File as CDF')).closest('button')
+  ).toHaveAttribute('disabled');
+});

--- a/frontends/election-manager/src/screens/backups_screen.tsx
+++ b/frontends/election-manager/src/screens/backups_screen.tsx
@@ -1,14 +1,37 @@
-import React from 'react';
-import { Prose } from '@votingworks/ui';
+import React, { useContext, useState } from 'react';
+import { Button, Prose } from '@votingworks/ui';
+import { LogFileType } from '@votingworks/utils';
 
+import { AppContext } from '../contexts/app_context';
+import { ExportLogsModal } from '../components/export_logs_modal';
 import { NavigationScreen } from '../components/navigation_screen';
 
 export function BackupsScreen(): JSX.Element {
+  const { electionDefinition } = useContext(AppContext);
+  const [logFileType, setLogFileType] = useState<LogFileType>();
+
   return (
-    <NavigationScreen>
-      <Prose maxWidth={false}>
-        <h1>Backups</h1>
-      </Prose>
-    </NavigationScreen>
+    <React.Fragment>
+      <NavigationScreen>
+        <Prose maxWidth={false}>
+          <h1>Backups</h1>
+          <Button onPress={() => setLogFileType(LogFileType.Raw)}>
+            Back Up Log File
+          </Button>{' '}
+          <Button
+            disabled={!electionDefinition} // CDF requires the election to be known
+            onPress={() => setLogFileType(LogFileType.Cdf)}
+          >
+            Back Up Log File as CDF
+          </Button>
+        </Prose>
+      </NavigationScreen>
+      {logFileType && (
+        <ExportLogsModal
+          logFileType={logFileType}
+          onClose={() => setLogFileType(undefined)}
+        />
+      )}
+    </React.Fragment>
   );
 }

--- a/frontends/election-manager/test/render_in_app_context.tsx
+++ b/frontends/election-manager/test/render_in_app_context.tsx
@@ -36,7 +36,7 @@ interface RenderInAppContextParams {
   route?: string;
   history?: MemoryHistory;
   castVoteRecordFiles?: CastVoteRecordFiles;
-  electionDefinition?: ElectionDefinition;
+  electionDefinition?: ElectionDefinition | 'NONE';
   configuredAt?: Iso8601Timestamp;
   isOfficialResults?: boolean;
   printer?: Printer;
@@ -119,7 +119,8 @@ export function renderInAppContext(
     <AppContext.Provider
       value={{
         castVoteRecordFiles,
-        electionDefinition,
+        electionDefinition:
+          electionDefinition === 'NONE' ? undefined : electionDefinition,
         configuredAt,
         isOfficialResults,
         printer,


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/1927

This PR populates the super admin Backups tab with existing log backup functionality from the admin Advanced tab. Since (non-CDF) logs can be backed up even when there's no election definition, I also had to make an update to always display the Backups tab to super admins.

Note that this PR branches off of https://github.com/votingworks/vxsuite/pull/1966, which is still in review.

_Election definition present_

![definition](https://user-images.githubusercontent.com/12616928/174387529-b5d72aee-1c7d-4c5c-8ce9-f486f88d9744.png)

_Election definition not present_

![no-definition](https://user-images.githubusercontent.com/12616928/174387530-cdc5c6a2-f5ea-4158-8f31-0955da0022d0.png)

## Testing

- [x] Tested manually
- [x] Added unit tests

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ Relying on existing logging 
- [ ] ~I have added JSDoc comments to any newly introduced exports~ N/A
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates