### PR TITLE
Support constitutional question scanning

### DIFF
--- a/frontends/bas/jest.config.js
+++ b/frontends/bas/jest.config.js
@@ -9,7 +9,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       statements: 50,
-      branches: 15,
+      branches: 14,
       lines: 50,
       functions: 20,
     },

--- a/integration-testing/bsd/cypress/tsconfig.json
+++ b/integration-testing/bsd/cypress/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.shared.json",
   "compilerOptions": {
+    "target": "ES2019",
     "types": ["cypress", "cypress-file-upload"],
     "isolatedModules": false,
     "allowJs": true,

--- a/integration-testing/election-manager/cypress/tsconfig.json
+++ b/integration-testing/election-manager/cypress/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.shared.json",
   "compilerOptions": {
+    "target": "ES2019",
     "types": ["cypress", "cypress-file-upload"],
     "isolatedModules": false,
     "allowJs": true,

--- a/libs/ballot-interpreter-nh/package.json
+++ b/libs/ballot-interpreter-nh/package.json
@@ -28,6 +28,7 @@
     "canvas": "2.9.1",
     "chalk": "4",
     "debug": "^4.3.3",
+    "he": "^1.2.0",
     "js-sha256": "^0.9.0",
     "luxon": "^2.3.0",
     "tmp": "^0.2.1",
@@ -36,6 +37,7 @@
   "devDependencies": {
     "@jest/types": "^27.5.0",
     "@types/debug": "^4.1.7",
+    "@types/he": "^1.1.2",
     "@types/jest": "^27.4.0",
     "@types/luxon": "^2.0.9",
     "@types/tmp": "^0.2.3",

--- a/libs/ballot-interpreter-nh/src/convert.ts
+++ b/libs/ballot-interpreter-nh/src/convert.ts
@@ -4,8 +4,10 @@ import {
   BallotTargetMarkPosition,
   Candidate,
   CandidateContest,
+  Contests,
   DistrictIdSchema,
   Election,
+  getContests,
   GridPosition,
   GridPositionOption,
   GridPositionWriteIn,
@@ -17,8 +19,15 @@ import {
   unsafeParse,
   YesNoContest,
 } from '@votingworks/types';
-import { assert, groupBy, throwIllegalValue, zipMin } from '@votingworks/utils';
+import {
+  assert,
+  groupBy,
+  throwIllegalValue,
+  zip,
+  zipMin,
+} from '@votingworks/utils';
 import { sha256 } from 'js-sha256';
+import { decode as decodeHtmlEntities } from 'he';
 import { DateTime } from 'luxon';
 import { ZodError } from 'zod';
 import {
@@ -102,7 +111,7 @@ export enum PairColumnEntriesIssueKind {
 /**
  * Errors that can occur during `pairColumnEntries`.
  */
-export type PairColumnEntriesIssue =
+export type PairColumnEntriesIssue<T extends GridEntry, U extends GridEntry> =
   | {
       kind: PairColumnEntriesIssueKind.ColumnCountMismatch;
       message: string;
@@ -113,6 +122,8 @@ export type PairColumnEntriesIssue =
       message: string;
       columnIndex: number;
       columnEntryCounts: [number, number];
+      extraLeftEntries: T[];
+      extraRightEntries: U[];
     };
 
 /**
@@ -128,7 +139,7 @@ export type PairColumnEntriesResult<T extends GridEntry, U extends GridEntry> =
   | {
       readonly success: false;
       readonly pairs: ReadonlyArray<[T, U]>;
-      readonly issues: readonly PairColumnEntriesIssue[];
+      readonly issues: ReadonlyArray<PairColumnEntriesIssue<T, U>>;
     };
 
 /**
@@ -153,7 +164,7 @@ export function pairColumnEntries<T extends GridEntry, U extends GridEntry>(
     // sort by side, row
     .map(([, entries]) => Array.from(entries).sort(compareGridEntry));
   const pairs: Array<[T, U]> = [];
-  const issues: PairColumnEntriesIssue[] = [];
+  const issues: Array<PairColumnEntriesIssue<T, U>> = [];
 
   if (grid1Columns.length !== grid2Columns.length) {
     issues.push({
@@ -171,6 +182,8 @@ export function pairColumnEntries<T extends GridEntry, U extends GridEntry>(
         message: `Columns at index ${columnIndex} disagree on entry count: grid #1 has ${column1.length} entries, but grid #2 has ${column2.length} entries`,
         columnIndex,
         columnEntryCounts: [column1.length, column2.length],
+        extraLeftEntries: column1.slice(column2.length),
+        extraRightEntries: column2.slice(column1.length),
       });
     }
     for (const [entry1, entry2] of zipMin(column1, column2)) {
@@ -182,6 +195,139 @@ export function pairColumnEntries<T extends GridEntry, U extends GridEntry>(
   return issues.length
     ? { success: false, pairs, issues }
     : { success: true, pairs };
+}
+
+/**
+ * Parse constitutional question gibberish. Here's an example:
+ *
+ * ```html
+ * <![CDATA[<div>CONSTITUTIONAL AMENDMENT QUESTION </div><div>Constitutional Amendment Proposed by the General Court</div><div>Question Proposed pursuant to Part II, Article 100 of the New Hampshire Constitution.</div><div> </div><div>"Shall there be a convention to amend or revise the constitution?     YES  <FONT face=Arial> <IMG src="http://ertuat.sos.nh.gov/ballotpaper/assets/images/oval.png""></FONT>                                  NO  <FONT face=Arial> <IMG src="http://ertuat.sos.nh.gov/ballotpaper/assets/images/oval.png""></FONT></div>
+ * ```
+ *
+ * This is not structured data, and isn't even valid HTML. We just strip all the
+ * tags and assume that:
+ *   1. Each question will start with a capital letter in A-Z.
+ *   2. Each question will end with a question mark "?".
+ *   3. Each question will be followed by "YES" and "NO".
+ */
+function parseConstitutionalQuestions(text: string): string[] {
+  const questions: string[] = [];
+
+  let textWithoutTags = text
+    // remove any CDATA structures
+    .replace(/<!\[CDATA\[/i, '')
+    // remove section header
+    .replace('CONSTITUTIONAL AMENDMENT QUESTION', '')
+    // remove useless tags
+    .replaceAll(/<img\b[^>]*>/gi, '');
+
+  // unwrap all tags leaving just text content
+  for (;;) {
+    const nextTextWithoutTags = textWithoutTags.replaceAll(
+      /<([a-z]+)\b[^>]*>(.*?)<\/\1>/gi,
+      ' $2 '
+    );
+
+    if (nextTextWithoutTags === textWithoutTags) {
+      break;
+    }
+
+    textWithoutTags = nextTextWithoutTags;
+  }
+  const cleanedText = textWithoutTags.replaceAll(/\s+/gi, ' ').trim();
+  const questionPattern = /([A-Z][^.]+\?)\s+YES\s+NO\b/g;
+
+  for (;;) {
+    const match = questionPattern.exec(cleanedText);
+    if (!match || !match[1]) {
+      break;
+    }
+    questions.push(match[1]);
+  }
+
+  return questions;
+}
+
+/**
+ * Matches grid positions from the election definition to ovals found in the
+ * template, correcting for missing YES/NO grid positions by assuming they will
+ * appear after all other contests with all YES options in one column and all NO
+ * options in another.
+ */
+function matchContestOptionsOnGrid(
+  contests: Contests,
+  gridPositions: readonly GridPosition[],
+  ovalGrid: readonly TemplateOvalGridEntry[]
+): PairColumnEntriesResult<GridPosition, TemplateOvalGridEntry> {
+  const pairResult = pairColumnEntries(gridPositions, ovalGrid);
+
+  if (pairResult.success || pairResult.issues.length !== 2 /* YES/NO */) {
+    return pairResult;
+  }
+
+  const pairs = [...pairResult.pairs];
+  let [yesColumnIssue, noColumnIssue] = pairResult.issues;
+  const yesNoContests = contests.filter((contest) => contest.type === 'yesno');
+
+  // Ensure we have exactly two columns with the expected number of extra
+  // entries representing the YES/NO options. If not, then just return the
+  // original result.
+  if (
+    yesColumnIssue?.kind !==
+      PairColumnEntriesIssueKind.ColumnEntryCountMismatch ||
+    noColumnIssue?.kind !==
+      PairColumnEntriesIssueKind.ColumnEntryCountMismatch ||
+    yesColumnIssue.extraLeftEntries.length !== 0 ||
+    noColumnIssue.extraLeftEntries.length !== 0 ||
+    yesColumnIssue.extraRightEntries.length !==
+      noColumnIssue.extraRightEntries.length ||
+    yesColumnIssue.extraRightEntries.length !== yesNoContests.length ||
+    noColumnIssue.extraRightEntries.length !== yesNoContests.length
+  ) {
+    return pairResult;
+  }
+
+  // Swap the YES/NO columns if YES is to the right of NO.
+  if (
+    (yesColumnIssue.extraRightEntries[0]?.column ?? 0) >
+    (noColumnIssue.extraRightEntries[0]?.column ?? 0)
+  ) {
+    [yesColumnIssue, noColumnIssue] = [noColumnIssue, yesColumnIssue];
+  }
+
+  // Add the YES/NO options to the grid.
+  for (const [contest, yesGridEntry, noGridEntry] of zip(
+    yesNoContests,
+    yesColumnIssue.extraRightEntries,
+    noColumnIssue.extraRightEntries
+  )) {
+    pairs.push(
+      [
+        {
+          type: 'option',
+          contestId: contest.id,
+          optionId: 'yes',
+          side: yesGridEntry.side,
+          column: yesGridEntry.column,
+          row: yesGridEntry.row,
+        },
+        yesGridEntry,
+      ],
+      [
+        {
+          type: 'option',
+          contestId: contest.id,
+          optionId: 'no',
+          side: noGridEntry.side,
+          column: noGridEntry.column,
+          row: noGridEntry.row,
+        },
+        noGridEntry,
+      ]
+    );
+  }
+
+  return { success: true, pairs };
 }
 
 /**
@@ -251,6 +397,11 @@ export enum ConvertIssueKind {
 }
 
 /**
+ * A grid entry for a specific template oval.
+ */
+export type TemplateOvalGridEntry = TemplateOval & { side: 'front' | 'back' };
+
+/**
  * Issues that can occur when converting a ballot card definition.
  */
 export type ConvertIssue =
@@ -294,7 +445,10 @@ export type ConvertIssue =
   | {
       kind: ConvertIssueKind.MismatchedOvalGrids;
       message: string;
-      pairColumnEntriesIssue: PairColumnEntriesIssue;
+      pairColumnEntriesIssue: PairColumnEntriesIssue<
+        GridPosition,
+        TemplateOvalGridEntry
+      >;
     }
   | {
       kind: ConvertIssueKind.MissingDefinitionProperty;
@@ -641,6 +795,39 @@ export function convertElectionDefinitionHeader(
     });
   }
 
+  const issues: ConvertIssue[] = [];
+  const ballotPaperInfoElement =
+    root.getElementsByTagName('BallotPaperInfo')[0];
+
+  if (ballotPaperInfoElement) {
+    const questionsElement =
+      ballotPaperInfoElement.getElementsByTagName('Questions')[0];
+
+    if (questionsElement) {
+      const questionsTextContent = questionsElement.textContent;
+
+      if (typeof questionsTextContent !== 'string') {
+        issues.push({
+          kind: ConvertIssueKind.MissingDefinitionProperty,
+          message: 'Questions data is invalid',
+          property: 'AVSInterface > BallotPaperInfo > Questions',
+        });
+      } else {
+        const questionsDecoded = decodeHtmlEntities(questionsTextContent);
+        for (const question of parseConstitutionalQuestions(questionsDecoded)) {
+          contests.push({
+            type: 'yesno',
+            id: makeId(question),
+            section: 'Constitutional Amendment Question',
+            title: 'Constitutional Amendment Question',
+            description: question,
+            districtId,
+          });
+        }
+      }
+    }
+  }
+
   const definitionGrid = readGridFromElectionDefinition(root);
 
   const election: Election = {
@@ -738,7 +925,7 @@ export function convertElectionDefinitionHeader(
   return {
     success: true,
     election: parseElectionResult.ok(),
-    issues: [],
+    issues,
   };
 }
 
@@ -937,7 +1124,6 @@ export function convertElectionDefinition(
   const ballotStyle = election.ballotStyles[0];
   assert(ballotStyle, 'ballot style missing');
 
-  type TemplateOvalGridEntry = TemplateOval & { side: 'front' | 'back' };
   const ovalGrid = [
     ...frontTemplateOvals.map<TemplateOvalGridEntry>((oval) => ({
       ...oval,
@@ -949,7 +1135,8 @@ export function convertElectionDefinition(
     })),
   ];
 
-  const pairColumnEntriesResult = pairColumnEntries(
+  const pairColumnEntriesResult = matchContestOptionsOnGrid(
+    getContests({ ballotStyle, election }),
     gridLayout.gridPositions.map<GridPosition>((gridPosition) => ({
       ...gridPosition,
     })),

--- a/libs/ballot-interpreter-nh/test/fixtures/amherst-2022-07-12/election.json
+++ b/libs/ballot-interpreter-nh/test/fixtures/amherst-2022-07-12/election.json
@@ -402,6 +402,14 @@
         }
       ],
       "allowWriteIns": true
+    },
+    {
+      "id": "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc",
+      "districtId": "town-id-00701-precinct-id-",
+      "section": "Constitutional Amendment Question",
+      "title": "Constitutional Amendment Question",
+      "type": "yesno",
+      "description": "Shall there be a convention to amend or revise the constitution?"
     }
   ],
   "gridLayouts": [
@@ -810,6 +818,22 @@
           "row": 19,
           "contestId": "County-Commissioner-d6feed25",
           "writeInIndex": 0
+        },
+        {
+          "type": "option",
+          "contestId": "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc",
+          "optionId": "yes",
+          "side": "back",
+          "column": 26,
+          "row": 24
+        },
+        {
+          "type": "option",
+          "contestId": "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc",
+          "optionId": "no",
+          "side": "back",
+          "column": 32,
+          "row": 24
         }
       ]
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1400,6 +1400,7 @@ importers:
       canvas: 2.9.1
       chalk: 4.1.2
       debug: 4.3.3
+      he: 1.2.0
       js-sha256: 0.9.0
       luxon: 2.3.1
       tmp: 0.2.1
@@ -1407,6 +1408,7 @@ importers:
     devDependencies:
       '@jest/types': 27.5.1
       '@types/debug': 4.1.7
+      '@types/he': 1.1.2
       '@types/jest': 27.4.1
       '@types/luxon': 2.3.0
       '@types/tmp': 0.2.3
@@ -1432,6 +1434,7 @@ importers:
     specifiers:
       '@jest/types': ^27.5.0
       '@types/debug': ^4.1.7
+      '@types/he': ^1.1.2
       '@types/jest': ^27.4.0
       '@types/luxon': ^2.0.9
       '@types/tmp': ^0.2.3
@@ -1456,6 +1459,7 @@ importers:
       eslint-plugin-prettier: ^4.0.0
       eslint-plugin-vx: workspace:*
       fast-check: ^2.21.0
+      he: ^1.2.0
       is-ci-cli: ^2.2.0
       jest: ^27.4.7
       jest-watch-typeahead: ^0.6.4
@@ -7412,7 +7416,7 @@ packages:
       jest-regex-util: 27.5.1
       jest-resolve: 27.5.1
       jest-resolve-dependencies: 27.5.1
-      jest-runner: 27.5.1
+      jest-runner: 27.5.1_canvas@2.9.1
       jest-runtime: 27.5.1
       jest-snapshot: 27.5.1
       jest-util: 27.5.1
@@ -8964,6 +8968,10 @@ packages:
       '@types/node': 17.0.36
     resolution:
       integrity: sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==
+  /@types/he/1.1.2:
+    dev: true
+    resolution:
+      integrity: sha512-kSJPcLO1x+oolc0R89pUl2kozldQ/fVQ1C1p5mp8fPoLdF/ZcBvckaTC2M8xXh3GYendXvCpy5m/a2eSbfgNgw==
   /@types/history/4.7.8:
     resolution:
       integrity: sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA==
@@ -18234,7 +18242,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 5.21.0_bb9518338a760ece3e1b033a5f6af62e
       '@typescript-eslint/utils': 5.22.0_eslint@7.32.0+typescript@4.6.3
       eslint: 7.32.0
-      jest: 27.5.1
+      jest: 27.5.1_canvas@2.9.1
     dev: true
     engines:
       node: ^12.22.0 || ^14.17.0 || >=16.0.0
@@ -22836,7 +22844,7 @@ packages:
       jest-jasmine2: 27.5.1
       jest-regex-util: 27.5.1
       jest-resolve: 27.5.1
-      jest-runner: 27.5.1
+      jest-runner: 27.5.1_canvas@2.9.1
       jest-util: 27.5.1
       jest-validate: 27.5.1
       micromatch: 4.0.5
@@ -23961,6 +23969,36 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-g4NPsM4mFCOwFKXO4p/H/kWGdJp9V8kURY2lX8Me2drgXqG7rrZAx5kv+5H7wtt/cdFIjhqYx1HrlqWHaOvDaQ==
+  /jest-runner/27.5.1_canvas@2.9.1:
+    dependencies:
+      '@jest/console': 27.5.1
+      '@jest/environment': 27.5.1
+      '@jest/test-result': 27.5.1
+      '@jest/transform': 27.5.1
+      '@jest/types': 27.5.1
+      '@types/node': 17.0.36
+      chalk: 4.1.2
+      emittery: 0.8.1
+      graceful-fs: 4.2.10
+      jest-docblock: 27.5.1
+      jest-environment-jsdom: 27.5.1_canvas@2.9.1
+      jest-environment-node: 27.5.1
+      jest-haste-map: 27.5.1
+      jest-leak-detector: 27.5.1
+      jest-message-util: 27.5.1
+      jest-resolve: 27.5.1
+      jest-runtime: 27.5.1
+      jest-util: 27.5.1
+      jest-worker: 27.5.1
+      source-map-support: 0.5.21
+      throat: 6.0.1
+    dev: true
+    engines:
+      node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
+    peerDependencies:
+      canvas: '*'
+    resolution:
+      integrity: sha512-g4NPsM4mFCOwFKXO4p/H/kWGdJp9V8kURY2lX8Me2drgXqG7rrZAx5kv+5H7wtt/cdFIjhqYx1HrlqWHaOvDaQ==
   /jest-runtime/26.6.3:
     dependencies:
       '@jest/console': 26.6.2
@@ -24524,7 +24562,7 @@ packages:
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
-      jest: 27.5.1
+      jest: 27.5.1_canvas@2.9.1
       jest-regex-util: 27.5.1
       jest-watcher: 27.5.1
       slash: 3.0.0

--- a/tsconfig.shared.json
+++ b/tsconfig.shared.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     // Based on the current version of NodeJS for any backend services and
     // Electron/NodeJS for frontends.
-    "target": "ES2019",
+    "target": "ES2021",
 
     // Enable all strict mode checks
     "strict": true,


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Closes #1952 

Pairs the extra ovals found at the end of the ballot with the `yesno` questions parsed from the `<Questions>` element.

## Demo Video or Screenshot
```
❯ grep -C 5 yesno test/fixtures/amherst-2022-07-12/election.json  
    {
      "id": "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc",
      "districtId": "town-id-00701-precinct-id-",
      "section": "Constitutional Amendment Question",
      "title": "Constitutional Amendment Question",
      "type": "yesno",
      "description": "Shall there be a convention to amend or revise the constitution?"
    }
  ],
  "gridLayouts": [
    {
```
![image](https://user-images.githubusercontent.com/1938/174908893-92a521e5-698c-411c-a002-cc0df6837920.png)


## Testing Plan 
Tested with the Amherst ballot for conversion. Scanning still doesn't work.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
