### PR TITLE
fix(scan): use the paper size of the NH PDF

### DIFF
--- a/libs/ballot-interpreter-nh/src/accuvote.ts
+++ b/libs/ballot-interpreter-nh/src/accuvote.ts
@@ -792,3 +792,26 @@ export function getTemplateBallotCardGeometry(
       throw new Error(`unexpected ballot size: ${paperSize}`);
   }
 }
+
+/**
+ * Determine the ballot paper size from the template canvas size.
+ */
+export function getTemplateBallotPaperSize(
+  canvasSize: Size
+): BallotPaperSize | undefined {
+  if (
+    canvasSize.width === TemplateBallotCardGeometry8pt5x11.canvasSize.width &&
+    canvasSize.height === TemplateBallotCardGeometry8pt5x11.canvasSize.height
+  ) {
+    return BallotPaperSize.Letter;
+  }
+
+  if (
+    canvasSize.width === TemplateBallotCardGeometry8pt5x14.canvasSize.width &&
+    canvasSize.height === TemplateBallotCardGeometry8pt5x14.canvasSize.height
+  ) {
+    return BallotPaperSize.Legal;
+  }
+
+  return undefined;
+}

--- a/libs/ballot-interpreter-nh/src/convert.test.ts
+++ b/libs/ballot-interpreter-nh/src/convert.test.ts
@@ -96,13 +96,11 @@ test('mismatched ballot image size', async () => {
   ).toEqual(
     expect.arrayContaining([
       typedAs<ConvertIssue>({
-        kind: ConvertIssueKind.MismatchedBallotImageSize,
-        message:
-          'Ballot image size mismatch: XML definition is letter-size, or 684x864, but front image is 684x1080',
-        side: 'front',
-        ballotPaperSize: BallotPaperSize.Letter,
-        expectedImageSize: { width: 684, height: 864 },
-        actualImageSize: { width: 684, height: 1080 },
+        kind: ConvertIssueKind.InvalidTemplateSize,
+        message: 'Template images do not match expected sizes.',
+        paperSize: BallotPaperSize.Letter,
+        frontTemplateSize: { width: 684, height: 1080 },
+        backTemplateSize: { width: 684, height: 1080 },
       }),
     ])
   );

--- a/libs/ballot-interpreter-nh/test/fixtures/amherst-2022-07-12/election.json
+++ b/libs/ballot-interpreter-nh/test/fixtures/amherst-2022-07-12/election.json
@@ -1,6 +1,6 @@
 {
   "ballotLayout": {
-    "paperSize": "legal",
+    "paperSize": "letter",
     "targetMarkPosition": "right"
   },
   "ballotStyles": [


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
We already didn't fail on a mismatch, but now we'll use the PDF image size rather than the XML ballot size since the XML is apparently sometimes wrong.

Refs #1987 

## Demo Video or Screenshot
n/a

## Testing Plan 
This was blocking the ability to scan the Amherst ballot. It still doesn't work, but for different reasons.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
