### PR TITLE
Populate super admin Logs screen

### DIFF
--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -1131,9 +1131,12 @@ test('admin UI has expected nav when VVSG2 auth flows are enabled', async () => 
   render(<App card={card} hardware={hardware} storage={storage} />);
   await authenticateWithAdminCard(card);
 
-  screen.getByText('Ballots');
-  screen.getByText('L&A');
-  screen.getByText('Tally');
+  userEvent.click(screen.getByText('Ballots'));
+  await screen.findAllByText('View Ballot');
+  userEvent.click(screen.getByText('L&A'));
+  await screen.findByRole('heading', { name: 'L&A Materials' });
+  userEvent.click(screen.getByText('Tally'));
+  await screen.findByRole('heading', { name: 'Election Tally Reports' });
   screen.getByRole('button', { name: 'Lock Machine' });
 
   expect(screen.queryByText('Definition')).not.toBeInTheDocument();
@@ -1153,11 +1156,16 @@ test('super admin UI has expected nav when VVSG2 auth flows are enabled', async 
   render(<App card={card} hardware={hardware} storage={storage} />);
   await authenticateWithSuperAdminCard(card);
 
-  screen.getByText('Definition');
-  screen.getByText('Draft Ballots');
-  screen.getByText('Smartcards');
-  screen.getByText('Settings');
-  screen.getByText('Logs');
+  userEvent.click(screen.getByText('Definition'));
+  await screen.findByRole('heading', { name: 'Election Definition' });
+  userEvent.click(screen.getByText('Draft Ballots'));
+  await screen.findAllByText('View Ballot');
+  userEvent.click(screen.getByText('Smartcards'));
+  await screen.findByRole('heading', { name: 'Smartcards' });
+  userEvent.click(screen.getByText('Settings'));
+  await screen.findByRole('heading', { name: 'Settings' });
+  userEvent.click(screen.getByText('Logs'));
+  await screen.findByRole('heading', { name: 'Logs' });
   screen.getByRole('button', { name: 'Lock Machine' });
 });
 
@@ -1170,9 +1178,12 @@ test('super admin UI has expected nav when no election and VVSG2 auth flows are 
   render(<App card={card} hardware={hardware} />);
   await authenticateWithSuperAdminCard(card, false);
 
-  screen.getByText('Definition');
-  screen.getByText('Settings');
-  screen.getByText('Logs');
+  userEvent.click(screen.getByText('Definition'));
+  await screen.findByRole('heading', { name: 'Configure VxAdmin' });
+  userEvent.click(screen.getByText('Settings'));
+  await screen.findByRole('heading', { name: 'Settings' });
+  userEvent.click(screen.getByText('Logs'));
+  await screen.findByRole('heading', { name: 'Logs' });
   screen.getByRole('button', { name: 'Lock Machine' });
 
   expect(screen.queryByText('Draft Ballots')).not.toBeInTheDocument();

--- a/frontends/election-manager/src/components/election_manager.tsx
+++ b/frontends/election-manager/src/components/election_manager.tsx
@@ -74,12 +74,24 @@ export function ElectionManager(): JSX.Element {
         <Route exact path={routerPaths.root}>
           <UnconfiguredScreen />
         </Route>
-        <Route exact path={routerPaths.advanced}>
-          <AdvancedScreen />
-        </Route>
         <Route exact path={routerPaths.electionDefinition}>
           <UnconfiguredScreen />
         </Route>
+        {!areVvsg2AuthFlowsEnabled() && (
+          <Route exact path={routerPaths.advanced}>
+            <AdvancedScreen />
+          </Route>
+        )}
+        {areVvsg2AuthFlowsEnabled() && (
+          <Route exact path={routerPaths.settings}>
+            <SettingsScreen />
+          </Route>
+        )}
+        {areVvsg2AuthFlowsEnabled() && (
+          <Route exact path={routerPaths.logs}>
+            <LogsScreen />
+          </Route>
+        )}
       </Switch>
     );
   }

--- a/frontends/election-manager/src/screens/logs_screen.test.tsx
+++ b/frontends/election-manager/src/screens/logs_screen.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { fakeKiosk } from '@votingworks/test-utils';
+import { screen } from '@testing-library/react';
+
+import { LogsScreen } from './logs_screen';
+import { renderInAppContext } from '../../test/render_in_app_context';
+
+let mockKiosk: jest.Mocked<KioskBrowser.Kiosk>;
+
+beforeEach(() => {
+  mockKiosk = fakeKiosk();
+  window.kiosk = mockKiosk;
+});
+
+test('Exporting logs', async () => {
+  renderInAppContext(<LogsScreen />);
+
+  userEvent.click(await screen.findByText('Export Log File'));
+  // Modal is tested fully in src/components/export_logs_modal.test.tsx
+  await screen.findByText('No Log File Present');
+  userEvent.click(screen.getByText('Close'));
+
+  userEvent.click(await screen.findByText('Export Log File as CDF'));
+  // Modal is tested fully in src/components/export_logs_modal.test.tsx
+  await screen.findByText('No Log File Present');
+  userEvent.click(screen.getByText('Close'));
+});
+
+test('Exporting logs when no election definition', async () => {
+  renderInAppContext(<LogsScreen />, { electionDefinition: 'NONE' });
+
+  userEvent.click(await screen.findByText('Export Log File'));
+  // Modal is tested fully in src/components/export_logs_modal.test.tsx
+  await screen.findByText('No Log File Present');
+  userEvent.click(screen.getByText('Close'));
+
+  expect(
+    (await screen.findByText('Export Log File as CDF')).closest('button')
+  ).toHaveAttribute('disabled');
+});

--- a/frontends/election-manager/src/screens/logs_screen.tsx
+++ b/frontends/election-manager/src/screens/logs_screen.tsx
@@ -1,14 +1,37 @@
-import React from 'react';
-import { Prose } from '@votingworks/ui';
+import React, { useContext, useState } from 'react';
+import { Button, Prose } from '@votingworks/ui';
+import { LogFileType } from '@votingworks/utils';
 
+import { AppContext } from '../contexts/app_context';
+import { ExportLogsModal } from '../components/export_logs_modal';
 import { NavigationScreen } from '../components/navigation_screen';
 
 export function LogsScreen(): JSX.Element {
+  const { electionDefinition } = useContext(AppContext);
+  const [logFileType, setLogFileType] = useState<LogFileType>();
+
   return (
-    <NavigationScreen>
-      <Prose maxWidth={false}>
-        <h1>Logs</h1>
-      </Prose>
-    </NavigationScreen>
+    <React.Fragment>
+      <NavigationScreen>
+        <Prose maxWidth={false}>
+          <h1>Logs</h1>
+          <Button onPress={() => setLogFileType(LogFileType.Raw)}>
+            Export Log File
+          </Button>{' '}
+          <Button
+            disabled={!electionDefinition} // CDF requires the election to be known
+            onPress={() => setLogFileType(LogFileType.Cdf)}
+          >
+            Export Log File as CDF
+          </Button>
+        </Prose>
+      </NavigationScreen>
+      {logFileType && (
+        <ExportLogsModal
+          logFileType={logFileType}
+          onClose={() => setLogFileType(undefined)}
+        />
+      )}
+    </React.Fragment>
   );
 }

--- a/frontends/election-manager/test/render_in_app_context.tsx
+++ b/frontends/election-manager/test/render_in_app_context.tsx
@@ -37,7 +37,7 @@ interface RenderInAppContextParams {
   route?: string;
   history?: MemoryHistory;
   castVoteRecordFiles?: CastVoteRecordFiles;
-  electionDefinition?: ElectionDefinition;
+  electionDefinition?: ElectionDefinition | 'NONE';
   configuredAt?: Iso8601Timestamp;
   isOfficialResults?: boolean;
   printer?: Printer;
@@ -122,7 +122,8 @@ export function renderInAppContext(
     <AppContext.Provider
       value={{
         castVoteRecordFiles,
-        electionDefinition,
+        electionDefinition:
+          electionDefinition === 'NONE' ? undefined : electionDefinition,
         configuredAt,
         isOfficialResults,
         printer,


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/1978

This PR populates the super admin Logs screen with existing functionality from the admin Advanced tab.

## Demo Video or Screenshot

![logs](https://user-images.githubusercontent.com/12616928/175122709-b9b6e9b1-6215-4d39-b6c2-750cff0a45ae.png)

_When no election definition_

![logs-no-election](https://user-images.githubusercontent.com/12616928/175122720-1c41fb23-a97c-48ee-a97a-ef5af7891461.png)

## Testing Plan

- [x] Added unit tests
- [x] Manually verified that the screen renders as expected, including when there's no election definition

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ Relying on existing logging 
- [ ] ~I have added JSDoc comments to any newly introduced exports~ N/A
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates