### PR TITLE
build(all): allow ES2021 APIs but don't yet target the syntax

### DIFF
--- a/frontends/bas/jest.config.js
+++ b/frontends/bas/jest.config.js
@@ -9,7 +9,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       statements: 50,
-      branches: 14,
+      branches: 15,
       lines: 50,
       functions: 20,
     },

--- a/integration-testing/bsd/cypress/tsconfig.json
+++ b/integration-testing/bsd/cypress/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.shared.json",
   "compilerOptions": {
-    "target": "ES2019",
     "types": ["cypress", "cypress-file-upload"],
     "isolatedModules": false,
     "allowJs": true,

--- a/integration-testing/election-manager/cypress/tsconfig.json
+++ b/integration-testing/election-manager/cypress/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.shared.json",
   "compilerOptions": {
-    "target": "ES2019",
     "types": ["cypress", "cypress-file-upload"],
     "isolatedModules": false,
     "allowJs": true,

--- a/tsconfig.shared.json
+++ b/tsconfig.shared.json
@@ -1,8 +1,10 @@
 {
   "compilerOptions": {
-    // Based on the current version of NodeJS for any backend services and
-    // Electron/NodeJS for frontends.
-    "target": "ES2021",
+    // Allow use of newer APIs since we're in recent enough versions of
+    // NodeJS/Electron, but don't yet target ES2021 syntax since some of our
+    // tooling can't handle it (i.e. react-scripts).
+    "target": "ES2019",
+    "lib": ["ES2021"],
 
     // Enable all strict mode checks
     "strict": true,


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
This reverts commit adc9024681d0b8ea16dbd2f795d7b5466c823182.

Fixes `pnpm start` in `precinct-scanner`, which would have errors like this:

```
Failed to compile.

/home/vx/code/votingworks/vxsuite/libs/ui/build/contest_tally.js 115:54
Module parse failed: Unexpected token (115:54)
File was processed with these loaders:
 * ../../node_modules/.pnpm/@pmmmwh/react-refresh-webpack-plugin@0.4.2_d00fcc46a48175a4e289da7534b00e9a/node_modules/@pmmmwh/react-refresh-webpack-plugin/loader/index.js
 * ../../node_modules/.pnpm/babel-loader@8.1.0_427212bc1158d185e577033f19ca0757/node_modules/babel-loader/lib/index.js
You may need an additional loader to handle the result of these loaders.
|                   narrow: true,
|                   textAlign: "right",
>                   children: talliesRelevant && (tally?.tally ?? 'X')
|                 })]
|               }, key));
```

## Demo Video or Screenshot
n/a

## Testing Plan 
Tested `pnpm start` in `precinct-scanner`.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
