### PR TITLE
Populate super admin Settings screen

### DIFF
--- a/frontends/election-manager/src/screens/logic_and_accuracy_screen.tsx
+++ b/frontends/election-manager/src/screens/logic_and_accuracy_screen.tsx
@@ -32,7 +32,9 @@ export function LogicAndAccuracyScreen(): JSX.Element {
                 Print L&amp;A Packages
               </LinkButton>
             </p>
-            <FullTestDeckTallyReportButton />
+            <p>
+              <FullTestDeckTallyReportButton />
+            </p>
           </React.Fragment>
         )}
       </Prose>

--- a/frontends/election-manager/src/screens/logs_screen.test.tsx
+++ b/frontends/election-manager/src/screens/logs_screen.test.tsx
@@ -16,13 +16,13 @@ beforeEach(() => {
 test('Exporting logs', async () => {
   renderInAppContext(<LogsScreen />);
 
-  userEvent.click(await screen.findByText('Export Log File'));
-  // Modal is tested fully in src/components/export_logs_modal.test.tsx
+  // Log exporting is tested fully in src/components/export_logs_modal.test.tsx
+  userEvent.click(screen.getByText('Export Log File'));
   await screen.findByText('No Log File Present');
   userEvent.click(screen.getByText('Close'));
 
-  userEvent.click(await screen.findByText('Export Log File as CDF'));
-  // Modal is tested fully in src/components/export_logs_modal.test.tsx
+  // Log exporting is tested fully in src/components/export_logs_modal.test.tsx
+  userEvent.click(screen.getByText('Export Log File as CDF'));
   await screen.findByText('No Log File Present');
   userEvent.click(screen.getByText('Close'));
 });
@@ -30,12 +30,12 @@ test('Exporting logs', async () => {
 test('Exporting logs when no election definition', async () => {
   renderInAppContext(<LogsScreen />, { electionDefinition: 'NONE' });
 
-  userEvent.click(await screen.findByText('Export Log File'));
-  // Modal is tested fully in src/components/export_logs_modal.test.tsx
+  // Log exporting is tested fully in src/components/export_logs_modal.test.tsx
+  userEvent.click(screen.getByText('Export Log File'));
   await screen.findByText('No Log File Present');
   userEvent.click(screen.getByText('Close'));
 
   expect(
-    (await screen.findByText('Export Log File as CDF')).closest('button')
+    screen.getByText('Export Log File as CDF').closest('button')
   ).toHaveAttribute('disabled');
 });

--- a/frontends/election-manager/src/screens/logs_screen.tsx
+++ b/frontends/election-manager/src/screens/logs_screen.tsx
@@ -15,15 +15,17 @@ export function LogsScreen(): JSX.Element {
       <NavigationScreen>
         <Prose maxWidth={false}>
           <h1>Logs</h1>
-          <Button onPress={() => setLogFileType(LogFileType.Raw)}>
-            Export Log File
-          </Button>{' '}
-          <Button
-            disabled={!electionDefinition} // CDF requires the election to be known
-            onPress={() => setLogFileType(LogFileType.Cdf)}
-          >
-            Export Log File as CDF
-          </Button>
+          <p>
+            <Button onPress={() => setLogFileType(LogFileType.Raw)}>
+              Export Log File
+            </Button>{' '}
+            <Button
+              disabled={!electionDefinition} // CDF requires the election to be known
+              onPress={() => setLogFileType(LogFileType.Cdf)}
+            >
+              Export Log File as CDF
+            </Button>
+          </p>
         </Prose>
       </NavigationScreen>
       {logFileType && (

--- a/frontends/election-manager/src/screens/settings_screen.test.tsx
+++ b/frontends/election-manager/src/screens/settings_screen.test.tsx
@@ -1,0 +1,53 @@
+import MockDate from 'mockdate';
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { fakeKiosk } from '@votingworks/test-utils';
+import { screen, waitFor, within } from '@testing-library/react';
+
+import { renderInAppContext } from '../../test/render_in_app_context';
+import { SettingsScreen } from './settings_screen';
+
+let mockKiosk: jest.Mocked<KioskBrowser.Kiosk>;
+
+beforeEach(() => {
+  MockDate.set('2022-06-22T00:00:00.000Z');
+  mockKiosk = fakeKiosk();
+  window.kiosk = mockKiosk;
+});
+
+test('Setting current date and time', async () => {
+  renderInAppContext(<SettingsScreen />);
+
+  screen.getByRole('heading', { name: 'Current Date and Time' });
+  const startDateTime = 'Wed, Jun 22, 2022, 12:00 AM UTC';
+  screen.getByText(startDateTime);
+
+  // Clock setting is tested fully in libs/ui/src/set_clock.test.tsx
+  userEvent.click(screen.getByRole('button', { name: 'Update Date and Time' }));
+  const modal = screen.getByRole('alertdialog');
+  within(modal).getByText('Wed, Jun 22, 2022, 12:00 AM');
+  userEvent.selectOptions(within(modal).getByTestId('selectYear'), '2023');
+  userEvent.click(within(modal).getByRole('button', { name: 'Save' }));
+  await waitFor(() => {
+    expect(mockKiosk.setClock).toHaveBeenCalledWith({
+      isoDatetime: '2023-06-22T00:00:00.000+00:00',
+      // eslint-disable-next-line vx/gts-identifiers
+      IANAZone: 'UTC',
+    });
+  });
+
+  // Date and time are reset to system time after save to kiosk-browser
+  screen.getByText(startDateTime);
+});
+
+test('Rebooting from USB', async () => {
+  renderInAppContext(<SettingsScreen />);
+
+  screen.getByRole('heading', { name: 'Software Update' });
+
+  // Rebooting from USB is tested fully in libs/ui/src/reboot_from_usb_button.test.tsx
+  userEvent.click(screen.getByRole('button', { name: 'Reboot from USB' }));
+  const modal = await screen.findByRole('alertdialog');
+  within(modal).getByRole('heading', { name: 'No USB Drive Detected' });
+  userEvent.click(within(modal).getByRole('button', { name: 'Cancel' }));
+});

--- a/frontends/election-manager/src/screens/settings_screen.tsx
+++ b/frontends/election-manager/src/screens/settings_screen.tsx
@@ -1,13 +1,32 @@
-import React from 'react';
-import { Prose } from '@votingworks/ui';
+import React, { useContext } from 'react';
+import {
+  CurrentDateAndTime,
+  Prose,
+  RebootFromUsbButton,
+  SetClockButton,
+} from '@votingworks/ui';
 
+import { AppContext } from '../contexts/app_context';
 import { NavigationScreen } from '../components/navigation_screen';
 
 export function SettingsScreen(): JSX.Element {
+  const { logger, usbDriveStatus } = useContext(AppContext);
+
   return (
     <NavigationScreen>
       <Prose maxWidth={false}>
         <h1>Settings</h1>
+        <h2>Current Date and Time</h2>
+        <p>
+          <CurrentDateAndTime />
+        </p>
+        <p>
+          <SetClockButton>Update Date and Time</SetClockButton>
+        </p>
+        <h2>Software Update</h2>
+        {/* Intentionally not wrapping this button in a <p> tag because the default <Prose> spacing
+          of a <p> following an <h2> looks cramped when the <p> contains a button */}
+        <RebootFromUsbButton logger={logger} usbDriveStatus={usbDriveStatus} />
       </Prose>
     </NavigationScreen>
   );


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/1977

This PR populates the super admin Settings screen with existing functionality (and also makes some minor tweaks to other screens I've recently worked on).

## Demo Video or Screenshot

![settings](https://user-images.githubusercontent.com/12616928/175356293-055734bb-2911-4b71-bb5d-c8ff66628933.png)

## Testing Plan 

- [x] Added unit tests
- [x] Tested the screen manually

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ Relying on existing logging
- [ ] ~I have added JSDoc comments to any newly introduced exports~ N/A
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates