### PR TITLE
fix(bmd): Don't load tally from pollworker card if already loaded

### DIFF
--- a/frontends/bmd/src/pages/poll_worker_screen.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.tsx
@@ -218,8 +218,10 @@ export function PollWorkerScreen({
       }
     }
 
-    void checkCardForTally();
-  }, [pollworkerAuth, election, parties]);
+    if (!precinctScannerTally) {
+      void checkCardForTally();
+    }
+  }, [pollworkerAuth, election, parties, precinctScannerTally]);
 
   const precinctScannerTallyInformation =
     precinctScannerTally &&
@@ -270,6 +272,7 @@ export function PollWorkerScreen({
         await printer.print({ sides: 'one-sided' });
         await sleep(REPORT_PRINTING_TIMEOUT_SECONDS * 1000);
         await resetCardTallyData();
+        setPrecinctScannerTally(undefined);
         printLock.unlock();
       }
     }


### PR DESCRIPTION


## Overview
Task: #2007 

There was a loop happening because the pollworker screen would load the
tally once, then print it, then load it again before clearing it from
the card (due to re-renders triggering the useEffect hook multiple
times).

To fix, we put in a simple guard to make sure we only load the data if
we haven't already loaded it.

## Demo Video or Screenshot

## Testing Plan 
Manually tested

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
