### PR TITLE
refactor(bmd): Move pollworker tally report printing to separate component

### DIFF
--- a/frontends/bmd/src/pages/poll_worker_screen.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.tsx
@@ -132,6 +132,7 @@ function PrecinctScannerTallyReportModal({
 
   useEffect(() => {
     async function loadTallyFromCard() {
+      if (precinctScannerTally) return;
       setPrecinctScannerTally(
         (
           await pollworkerAuth.card.readStoredObject(

--- a/frontends/bmd/src/pages/poll_worker_screen.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.tsx
@@ -167,6 +167,9 @@ function PrecinctScannerTallyReportModal({
   const currentTime = Date.now();
   const reportPurposes = ['Publicly Posted', 'Officially Filed'];
 
+  if (!precinctScannerTally) return null;
+  assert(precinctScannerTallyInformation);
+
   return (
     <React.Fragment>
       {!isPrinting && (
@@ -198,73 +201,68 @@ function PrecinctScannerTallyReportModal({
           }
         />
       )}
-      {precinctScannerTally &&
-        precinctScannerTallyInformation &&
-        reportPurposes.map((reportPurpose) => {
-          return (
-            <React.Fragment key={reportPurpose}>
-              <PrecinctScannerPollsReport
-                key={`polls-report-${reportPurpose}`}
-                ballotCount={precinctScannerTally.totalBallotsScanned}
-                currentTime={currentTime}
-                election={electionDefinition.election}
-                isLiveMode={precinctScannerTally.isLiveMode}
-                isPollsOpen={precinctScannerTally.isPollsOpen}
-                precinctScannerMachineId={precinctScannerTally.machineId}
-                timeTallySaved={precinctScannerTally.timeSaved}
-                precinctSelection={precinctScannerTally.precinctSelection}
-                reportPurpose={reportPurpose}
-              />
-              <PrintableContainer>
-                <TallyReport>
-                  {precinctScannerTallyInformation.precinctList.map(
-                    (precinctSel) =>
-                      parties.map((partyId) => {
-                        const precinctIdIfDefined =
-                          precinctSel.kind ===
-                          PrecinctSelectionKind.SinglePrecinct
-                            ? precinctSel.precinctId
-                            : undefined;
-                        const tallyForReport =
-                          precinctScannerTallyInformation.subTallies.get(
-                            getTallyIdentifier(partyId, precinctIdIfDefined)
-                          );
-                        assert(tallyForReport);
-                        return (
-                          <PrecinctScannerTallyReport
-                            key={getTallyIdentifier(
-                              partyId,
-                              precinctIdIfDefined
-                            )}
-                            electionDefinition={electionDefinition}
-                            tally={tallyForReport}
-                            precinctSelection={precinctSel}
-                            partyId={partyId}
-                            reportPurpose={reportPurpose}
-                            isPollsOpen={precinctScannerTally.isPollsOpen}
-                            reportSavedTime={precinctScannerTally.timeSaved}
-                          />
+      {reportPurposes.map((reportPurpose) => {
+        return (
+          <React.Fragment key={reportPurpose}>
+            <PrecinctScannerPollsReport
+              key={`polls-report-${reportPurpose}`}
+              ballotCount={precinctScannerTally.totalBallotsScanned}
+              currentTime={currentTime}
+              election={electionDefinition.election}
+              isLiveMode={precinctScannerTally.isLiveMode}
+              isPollsOpen={precinctScannerTally.isPollsOpen}
+              precinctScannerMachineId={precinctScannerTally.machineId}
+              timeTallySaved={precinctScannerTally.timeSaved}
+              precinctSelection={precinctScannerTally.precinctSelection}
+              reportPurpose={reportPurpose}
+            />
+            <PrintableContainer>
+              <TallyReport>
+                {precinctScannerTallyInformation.precinctList.map(
+                  (precinctSel) =>
+                    parties.map((partyId) => {
+                      const precinctIdIfDefined =
+                        precinctSel.kind ===
+                        PrecinctSelectionKind.SinglePrecinct
+                          ? precinctSel.precinctId
+                          : undefined;
+                      const tallyForReport =
+                        precinctScannerTallyInformation.subTallies.get(
+                          getTallyIdentifier(partyId, precinctIdIfDefined)
                         );
-                      })
-                  )}
-                  {precinctScannerTally.totalBallotsScanned > 0 && (
-                    <PrecinctScannerTallyQrCode
-                      electionDefinition={electionDefinition}
-                      signingMachineId={machineConfig.machineId}
-                      compressedTally={
-                        precinctScannerTallyInformation.overallTally
-                      }
-                      reportPurpose={reportPurpose}
-                      isPollsOpen={precinctScannerTally.isPollsOpen}
-                      isLiveMode={precinctScannerTally.isLiveMode}
-                      reportSavedTime={precinctScannerTally.timeSaved}
-                    />
-                  )}
-                </TallyReport>
-              </PrintableContainer>
-            </React.Fragment>
-          );
-        })}
+                      assert(tallyForReport);
+                      return (
+                        <PrecinctScannerTallyReport
+                          key={getTallyIdentifier(partyId, precinctIdIfDefined)}
+                          electionDefinition={electionDefinition}
+                          tally={tallyForReport}
+                          precinctSelection={precinctSel}
+                          partyId={partyId}
+                          reportPurpose={reportPurpose}
+                          isPollsOpen={precinctScannerTally.isPollsOpen}
+                          reportSavedTime={precinctScannerTally.timeSaved}
+                        />
+                      );
+                    })
+                )}
+                {precinctScannerTally.totalBallotsScanned > 0 && (
+                  <PrecinctScannerTallyQrCode
+                    electionDefinition={electionDefinition}
+                    signingMachineId={machineConfig.machineId}
+                    compressedTally={
+                      precinctScannerTallyInformation.overallTally
+                    }
+                    reportPurpose={reportPurpose}
+                    isPollsOpen={precinctScannerTally.isPollsOpen}
+                    isLiveMode={precinctScannerTally.isLiveMode}
+                    reportSavedTime={precinctScannerTally.timeSaved}
+                  />
+                )}
+              </TallyReport>
+            </PrintableContainer>
+          </React.Fragment>
+        );
+      })}
     </React.Fragment>
   );
 }
@@ -353,7 +351,6 @@ export function PollWorkerScreen({
    */
   useEffect(() => {
     if (!isConfirmingEnableLiveMode && !pollworkerCardHasTally) {
-      console.log('trigger audio focus');
       triggerAudioFocus();
     }
   }, [


### PR DESCRIPTION



## Overview
After debugging and fixing #2015, I figured I'd simplify this logic to prevent future bugs.

Factors out and simplifies the logic for loading and printing precinct scanner tally reports from the pollworker card. There were some unnecessarily complicated state variables and it was all being managed in the main PollworkerScreen component mixed in with other stuff.

## Demo Video or Screenshot

## Testing Plan 
- Existing automated tests
- Manual test

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
