### PR TITLE
refactor(bsd): Use useDippedSmartcardAuth for authentication

### DIFF
--- a/frontends/bsd/src/components/export_results_modal.test.tsx
+++ b/frontends/bsd/src/components/export_results_modal.test.tsx
@@ -6,7 +6,7 @@ import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 import fetchMock from 'fetch-mock';
 
-import { fakeKiosk, fakeUsbDrive } from '@votingworks/test-utils';
+import { Dipped, fakeKiosk, fakeUsbDrive } from '@votingworks/test-utils';
 import { MemoryStorage, usbstick } from '@votingworks/utils';
 import { Logger, LogSource } from '@votingworks/logging';
 import { ExportResultsModal } from './export_results_modal';
@@ -163,8 +163,7 @@ test('render export modal when a usb drive is mounted as expected and allows aut
         usbDriveStatus: UsbDriveStatus.recentlyEjected,
         usbDriveEject: jest.fn(),
         storage: new MemoryStorage(),
-        lockMachine: jest.fn(),
-        currentUserSession: { type: 'admin', authenticated: true },
+        auth: Dipped.fakeAdminAuth(),
         logger: new Logger(LogSource.VxCentralScanFrontend),
       }}
     >

--- a/frontends/bsd/src/contexts/app_context.ts
+++ b/frontends/bsd/src/contexts/app_context.ts
@@ -1,5 +1,5 @@
 import { LoggingUserRole, LogSource, Logger } from '@votingworks/logging';
-import { ElectionDefinition, UserSession } from '@votingworks/types';
+import { DippedSmartcardAuth, ElectionDefinition } from '@votingworks/types';
 import { MemoryStorage, Storage, usbstick } from '@votingworks/utils';
 import { createContext } from 'react';
 import { MachineConfig } from '../config/types';
@@ -11,8 +11,7 @@ export interface AppContextInterface {
   electionDefinition?: ElectionDefinition;
   electionHash?: string;
   storage: Storage;
-  lockMachine: () => void;
-  currentUserSession?: UserSession;
+  auth: DippedSmartcardAuth.Auth;
   logger: Logger;
 }
 
@@ -26,9 +25,12 @@ const appContext: AppContextInterface = {
   electionDefinition: undefined,
   electionHash: undefined,
   storage: new MemoryStorage(),
-  lockMachine: () => undefined,
-  currentUserSession: undefined,
   logger: new Logger(LogSource.VxCentralScanFrontend),
+  auth: {
+    status: 'logged_out',
+    reason: 'machine_locked',
+    bootstrapAuthenticatedAdminSession: () => undefined,
+  },
 };
 
 export const AppContext = createContext(appContext);

--- a/frontends/bsd/test/render_in_app_context.tsx
+++ b/frontends/bsd/test/render_in_app_context.tsx
@@ -1,7 +1,8 @@
 import { render as testRender, RenderResult } from '@testing-library/react';
 import { electionSampleDefinition as testElectionDefinition } from '@votingworks/fixtures';
 import { LogSource, Logger } from '@votingworks/logging';
-import { ElectionDefinition, UserSession } from '@votingworks/types';
+import { Dipped } from '@votingworks/test-utils';
+import { DippedSmartcardAuth, ElectionDefinition } from '@votingworks/types';
 import { MemoryStorage, Storage, usbstick } from '@votingworks/utils';
 import { createMemoryHistory, MemoryHistory } from 'history';
 import React from 'react';
@@ -16,8 +17,7 @@ interface RenderInAppContextParams {
   usbDriveStatus?: usbstick.UsbDriveStatus;
   usbDriveEject?: () => void;
   storage?: Storage;
-  lockMachine?: () => void;
-  currentUserSession?: UserSession;
+  auth?: DippedSmartcardAuth.Auth;
   logger?: Logger;
 }
 
@@ -30,8 +30,7 @@ export function makeAppContext({
   usbDriveStatus = usbstick.UsbDriveStatus.absent,
   usbDriveEject = jest.fn(),
   storage = new MemoryStorage(),
-  lockMachine = jest.fn(),
-  currentUserSession = { type: 'admin', authenticated: true },
+  auth = Dipped.fakeAdminAuth(),
   logger = new Logger(LogSource.VxCentralScanFrontend),
 }: Partial<AppContextInterface> = {}): AppContextInterface {
   return {
@@ -40,8 +39,7 @@ export function makeAppContext({
     usbDriveStatus,
     usbDriveEject,
     storage,
-    lockMachine,
-    currentUserSession,
+    auth,
     logger,
   };
 }
@@ -56,8 +54,7 @@ export function renderInAppContext(
     usbDriveStatus,
     usbDriveEject,
     storage,
-    lockMachine,
-    currentUserSession,
+    auth,
     logger,
   }: RenderInAppContextParams = {}
 ): RenderResult {
@@ -69,8 +66,7 @@ export function renderInAppContext(
         usbDriveStatus,
         usbDriveEject,
         storage,
-        lockMachine,
-        currentUserSession,
+        auth,
         logger,
       })}
     >

--- a/frontends/election-manager/src/screens/unlock_machine_screen.test.tsx
+++ b/frontends/election-manager/src/screens/unlock_machine_screen.test.tsx
@@ -48,7 +48,7 @@ test('Unlock machine screen submits passcode', async () => {
 
 test('If passcode is incorrect, error message is shown', () => {
   const fakeAuth = Dipped.fakeCheckingPasscodeAuth({
-    passcodeError: 'wrong_passcode',
+    wrongPasscodeEntered: true,
   });
   renderInAppContext(<UnlockMachineScreen />, { auth: fakeAuth });
   screen.getByText('Invalid code. Please try again.');

--- a/frontends/election-manager/src/screens/unlock_machine_screen.tsx
+++ b/frontends/election-manager/src/screens/unlock_machine_screen.tsx
@@ -64,7 +64,7 @@ export function UnlockMachineScreen(): JSX.Element {
   let primarySentence: JSX.Element = (
     <p>Enter the card security code to unlock.</p>
   );
-  if (auth.passcodeError === 'wrong_passcode') {
+  if (auth.wrongPasscodeEntered) {
     primarySentence = <Text warning>Invalid code. Please try again.</Text>;
   }
 

--- a/libs/types/src/smartcard_auth/dipped_smartcard_auth.ts
+++ b/libs/types/src/smartcard_auth/dipped_smartcard_auth.ts
@@ -14,7 +14,7 @@ export interface CheckingPasscode {
   readonly status: 'checking_passcode';
   readonly user: AdminUser;
   readonly checkPasscode: (passcode: string) => void;
-  readonly passcodeError?: 'wrong_passcode';
+  readonly wrongPasscodeEntered?: true;
 }
 
 export interface RemoveCard {

--- a/libs/ui/src/hooks/smartcard_auth/use_dipped_smartcard_auth.test.ts
+++ b/libs/ui/src/hooks/smartcard_auth/use_dipped_smartcard_auth.test.ts
@@ -65,7 +65,7 @@ describe('useDippedSmartcardAuth', () => {
     expect(result.current).toEqual({
       status: 'checking_passcode',
       user,
-      passcodeError: undefined,
+      wrongPasscodeEntered: undefined,
       checkPasscode: expect.any(Function),
     });
 
@@ -78,7 +78,7 @@ describe('useDippedSmartcardAuth', () => {
     expect(result.current).toMatchObject({
       status: 'checking_passcode',
       user,
-      passcodeError: 'wrong_passcode',
+      wrongPasscodeEntered: true,
     });
 
     // Check the correct passcode

--- a/libs/ui/src/hooks/smartcard_auth/use_dipped_smartcard_auth.ts
+++ b/libs/ui/src/hooks/smartcard_auth/use_dipped_smartcard_auth.ts
@@ -32,7 +32,7 @@ type AuthState =
   | Pick<DippedSmartcardAuth.LoggedOut, 'status' | 'reason'>
   | Pick<
       DippedSmartcardAuth.CheckingPasscode,
-      'status' | 'user' | 'passcodeError'
+      'status' | 'user' | 'wrongPasscodeEntered'
     >
   | Pick<DippedSmartcardAuth.RemoveCard, 'status' | 'user'>
   | Pick<DippedSmartcardAuth.LoggedIn, 'status' | 'user'>;
@@ -138,7 +138,7 @@ function smartcardAuthReducer(
         auth:
           action.passcode === previousState.auth.user.passcode
             ? { status: 'remove_card', user: previousState.auth.user }
-            : { ...previousState.auth, passcodeError: 'wrong_passcode' },
+            : { ...previousState.auth, wrongPasscodeEntered: true },
       };
     }
 


### PR DESCRIPTION
## Overview
Task: #1682 

Refactors BSD to use useDippedSmartcardAuth. It was pretty straightforward. I also made some small tweaks to the hook, which you can find in a separate commit.

## Demo Video or Screenshot
N/A

## Testing Plan 
- Existing automated tests
- Some basic manual tests

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
