### PR TITLE
feat(bsd): Add Lock Machine button for superadmins

### DIFF
--- a/frontends/bsd/src/app_root.tsx
+++ b/frontends/bsd/src/app_root.tsx
@@ -554,6 +554,11 @@ export function AppRoot({ card, hardware }: AppRootProps): JSX.Element {
             codeVersion={machineConfig.codeVersion}
             machineId={machineConfig.machineId}
           />
+          <MainNav>
+            <Button small onPress={() => auth.logOut()}>
+              Lock Machine
+            </Button>
+          </MainNav>
         </Screen>
       </AppContext.Provider>
     );


### PR DESCRIPTION
## Overview
I realized while refactoring that superadmins had no way to log out, and
putting in a new card doesn't do anything, so I added in the standard
lock machine button.

## Demo Video or Screenshot
<img width="1496" alt="Screen Shot 2022-06-28 at 12 31 26 PM" src="https://user-images.githubusercontent.com/530106/176269303-2e267576-0c16-4f14-bd02-a5048fffb267.png">


## Testing Plan 
- Added a unit test
- Manually tested

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
