### PR TITLE
doc(scan): Add build instruction to README

### DIFF
--- a/services/scan/README.md
+++ b/services/scan/README.md
@@ -11,6 +11,7 @@ then run the service like so:
 
 ```sh
 # in services/scan
+pnpm build:watch
 pnpm dev
 ```
 

--- a/services/scan/README.md
+++ b/services/scan/README.md
@@ -11,7 +11,7 @@ then run the service like so:
 
 ```sh
 # in services/scan
-pnpm build:watch
+pnpm build:watch &
 pnpm dev
 ```
 


### PR DESCRIPTION


## Overview
I found that when I tried to run `pnpm dev` in `services/scan` without first building the scan service, I would get an error about the plustek module not being built.
