### PR TITLE
feat(bmd): Check passcodes for admin cards

### DIFF
--- a/frontends/bmd/src/app_cardless_voting.test.tsx
+++ b/frontends/bmd/src/app_cardless_voting.test.tsx
@@ -22,6 +22,7 @@ import { advanceTimersAndPromises } from '../test/helpers/smartcards';
 import { fakePrinter } from '../test/helpers/fake_printer';
 import { fakeMachineConfigProvider } from '../test/helpers/fake_machine_config';
 import { MarkAndPrint } from './config/types';
+import { authenticateAdminCard } from '../test/test_utils';
 
 beforeEach(() => {
   jest.useFakeTimers();
@@ -65,7 +66,7 @@ test('Cardless Voting Flow', async () => {
 
   // Configure with Admin Card
   card.insertCard(adminCard, electionData);
-  await advanceTimersAndPromises();
+  await authenticateAdminCard();
   fireEvent.click(screen.getByText('Load Election Definition'));
 
   await advanceTimersAndPromises();
@@ -319,7 +320,7 @@ test('poll worker must select a precinct first', async () => {
 
   // Configure with Admin Card
   card.insertCard(adminCard, electionData);
-  await advanceTimersAndPromises();
+  await authenticateAdminCard();
   fireEvent.click(screen.getByText('Load Election Definition'));
 
   await advanceTimersAndPromises();

--- a/frontends/bmd/src/app_end_to_end.test.tsx
+++ b/frontends/bmd/src/app_end_to_end.test.tsx
@@ -40,6 +40,7 @@ import { fakePrinter } from '../test/helpers/fake_printer';
 import { fakeMachineConfigProvider } from '../test/helpers/fake_machine_config';
 import { MarkAndPrint } from './config/types';
 import { REPORT_PRINTING_TIMEOUT_SECONDS } from './config/globals';
+import { authenticateAdminCard } from '../test/test_utils';
 
 beforeEach(() => {
   jest.useFakeTimers();
@@ -86,7 +87,7 @@ it('MarkAndPrint end-to-end flow', async () => {
 
   // Configure with Admin Card
   card.insertCard(adminCard, electionDefinition.electionData);
-  await advanceTimersAndPromises();
+  await authenticateAdminCard();
   fireEvent.click(screen.getByText('Load Election Definition'));
 
   await advanceTimersAndPromises();
@@ -101,7 +102,7 @@ it('MarkAndPrint end-to-end flow', async () => {
 
   // Configure election with Admin Card
   card.insertCard(adminCard, electionDefinition.electionData);
-  await advanceTimersAndPromises();
+  await authenticateAdminCard();
   screen.getByLabelText('Precinct');
   screen.queryByText(`Election ID: ${expectedElectionHash}`);
   screen.queryByText('Machine ID: 000');
@@ -404,7 +405,7 @@ it('MarkAndPrint end-to-end flow', async () => {
 
   // Unconfigure with Admin Card
   card.insertCard(adminCard, electionDefinition.electionData);
-  await advanceTimersAndPromises();
+  await authenticateAdminCard();
   screen.getByText('Election definition is loaded.');
   fireEvent.click(screen.getByText('Unconfigure Machine'));
   await advanceTimersAndPromises();

--- a/frontends/bmd/src/app_mark_only.test.tsx
+++ b/frontends/bmd/src/app_mark_only.test.tsx
@@ -23,6 +23,7 @@ import {
   voterContests,
 } from '../test/helpers/election';
 import { fakeMachineConfigProvider } from '../test/helpers/fake_machine_config';
+import { authenticateAdminCard } from '../test/test_utils';
 
 jest.setTimeout(10_000);
 
@@ -61,7 +62,7 @@ it('MarkOnly flow', async () => {
 
   // Configure election with Admin Card
   card.insertCard(adminCard, electionDefinition.electionData);
-  await advanceTimersAndPromises();
+  await authenticateAdminCard();
   fireEvent.click(screen.getByText('Load Election Definition'));
 
   await advanceTimersAndPromises();
@@ -76,7 +77,7 @@ it('MarkOnly flow', async () => {
 
   // Configure election with Admin Card
   card.insertCard(adminCard, electionDefinition.electionData);
-  await advanceTimersAndPromises();
+  await authenticateAdminCard();
   screen.getByLabelText('Precinct');
 
   // select precinct
@@ -207,7 +208,7 @@ it('MarkOnly flow', async () => {
 
   // Unconfigure with Admin Card
   card.insertCard(adminCard, electionDefinition.electionData);
-  await advanceTimersAndPromises();
+  await authenticateAdminCard();
   screen.getByText('Election definition is loaded.');
   fireEvent.click(screen.getByText('Unconfigure Machine'));
   await advanceTimersAndPromises();

--- a/frontends/bmd/src/app_mark_voter_card_invalid.test.tsx
+++ b/frontends/bmd/src/app_mark_voter_card_invalid.test.tsx
@@ -70,7 +70,7 @@ describe('Mark Card Void when voter is idle too long', () => {
     // User action removes Idle Screen
     fireEvent.click(screen.getByText('Yes, I’m still voting.'));
     fireEvent.mouseDown(document);
-    await advanceTimersAndPromises();
+    await advanceTimersAndPromises(0.2);
     expect(screen.queryByText(idleScreenCopy)).toBeFalsy();
 
     // Elapse idle timeout
@@ -134,7 +134,7 @@ describe('Mark Card Void when voter is idle too long', () => {
     screen.getByText('Voter session activated: 12');
 
     card.removeCard();
-    await advanceTimersAndPromises();
+    await advanceTimersAndPromises(0.2);
     screen.getByText(/Center Springfield/);
     screen.getByText('Start Voting');
 
@@ -147,7 +147,7 @@ describe('Mark Card Void when voter is idle too long', () => {
     // User action removes Idle Screen
     fireEvent.click(screen.getByText('Yes, I’m still voting.'));
     fireEvent.mouseDown(document);
-    await advanceTimersAndPromises();
+    await advanceTimersAndPromises(0.2);
     expect(screen.queryByText(idleScreenCopy)).toBeFalsy();
 
     // Elapse idle timeout

--- a/frontends/bmd/src/app_print_only.test.tsx
+++ b/frontends/bmd/src/app_print_only.test.tsx
@@ -32,6 +32,7 @@ import * as GLOBALS from './config/globals';
 import { fakePrinter } from '../test/helpers/fake_printer';
 import { fakeMachineConfigProvider } from '../test/helpers/fake_machine_config';
 import { PrintOnly } from './config/types';
+import { authenticateAdminCard } from '../test/test_utils';
 
 beforeEach(() => {
   window.location.href = '/';
@@ -73,7 +74,7 @@ test('PrintOnly flow', async () => {
 
   // Configure with Admin Card
   card.insertCard(adminCard, electionData);
-  await advanceTimersAndPromises();
+  await authenticateAdminCard();
   fireEvent.click(screen.getByText('Load Election Definition'));
 
   await advanceTimersAndPromises();
@@ -88,7 +89,7 @@ test('PrintOnly flow', async () => {
 
   // Configure election with Admin Card
   card.insertCard(adminCard, electionData);
-  await advanceTimersAndPromises();
+  await authenticateAdminCard();
   screen.getByLabelText('Precinct');
 
   // Select precinct
@@ -130,7 +131,7 @@ test('PrintOnly flow', async () => {
 
   // Set to Live Mode
   card.insertCard(adminCard, electionData);
-  await advanceTimersAndPromises();
+  await authenticateAdminCard();
   expect(window.document.documentElement.style.fontSize).toBe('28px');
   fireEvent.click(screen.getByText('Live Election Mode'));
 
@@ -368,7 +369,7 @@ test('PrintOnly flow', async () => {
 
   // Unconfigure with Admin Card
   card.insertCard(adminCard, electionData);
-  await advanceTimersAndPromises();
+  await authenticateAdminCard();
   screen.getByText('Election definition is loaded.');
   fireEvent.click(screen.getByText('Unconfigure Machine'));
   await advanceTimersAndPromises();
@@ -404,7 +405,7 @@ test('PrintOnly retains app mode when unconfigured', async () => {
   async function configure(): Promise<void> {
     // Configure with Admin Card
     card.insertCard(adminCard, electionData);
-    await advanceTimersAndPromises();
+    await authenticateAdminCard();
     fireEvent.click(screen.getByText('Load Election Definition'));
 
     await advanceTimersAndPromises();
@@ -442,7 +443,7 @@ test('PrintOnly retains app mode when unconfigured', async () => {
   async function unconfigure(): Promise<void> {
     // Unconfigure with Admin Card
     card.insertCard(adminCard, electionData);
-    await advanceTimersAndPromises();
+    await authenticateAdminCard();
     screen.getByText('Election definition is loaded.');
     fireEvent.click(screen.getByText('Unconfigure Machine'));
     await advanceTimersAndPromises();
@@ -507,7 +508,7 @@ test('PrintOnly prompts to change to live mode on election day', async () => {
 
   // Configure with Admin Card
   card.insertCard(adminCard, electionDefinition.electionData);
-  await advanceTimersAndPromises();
+  await authenticateAdminCard();
   fireEvent.click(screen.getByText('Load Election Definition'));
 
   await advanceTimersAndPromises();

--- a/frontends/bmd/src/app_replace_election.test.tsx
+++ b/frontends/bmd/src/app_replace_election.test.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { MemoryCard, MemoryHardware, MemoryStorage } from '@votingworks/utils';
 import { makeAdminCard } from '@votingworks/test-utils';
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { electionSample2Definition } from '@votingworks/fixtures';
 import {
   setElectionInStorage,
   setStateInStorage,
 } from '../test/helpers/election';
 import { fakeMachineConfigProvider } from '../test/helpers/fake_machine_config';
-import { render } from '../test/test_utils';
+import { authenticateAdminCard, render } from '../test/test_utils';
 import { App } from './app';
 import { advanceTimersAndPromises } from '../test/helpers/smartcards';
 
@@ -44,10 +44,8 @@ test('replacing a loaded election with one from a card', async () => {
     makeAdminCard(electionSample2Definition.electionHash),
     electionSample2Definition.electionData
   );
-  await advanceTimersAndPromises();
-  await waitFor(() =>
-    screen.getByText('Admin Card is not configured for this election')
-  );
+  await authenticateAdminCard();
+  await screen.findByText('Admin Card is not configured for this election');
 
   // unconfigure
   fireEvent.click(screen.getByText('Remove Current Election and All Data'));
@@ -60,7 +58,7 @@ test('replacing a loaded election with one from a card', async () => {
     makeAdminCard(electionSample2Definition.electionHash),
     electionSample2Definition.electionData
   );
-  await advanceTimersAndPromises();
+  await authenticateAdminCard();
 
   // load new election
   await screen.findByText('Election Admin Actions');

--- a/frontends/bmd/src/app_root.tsx
+++ b/frontends/bmd/src/app_root.tsx
@@ -51,6 +51,7 @@ import {
   usePrevious,
   useInsertedSmartcardAuth,
   useUsbDrive,
+  CARD_POLLING_INTERVAL,
 } from '@votingworks/ui';
 import { Ballot } from './components/ballot';
 import * as GLOBALS from './config/globals';
@@ -85,6 +86,7 @@ import { ScreenReader } from './utils/ScreenReader';
 import { ReplaceElectionScreen } from './pages/replace_election_screen';
 import { CardErrorScreen } from './pages/card_error_screen';
 import { SuperAdminScreen } from './pages/superadmin_screen';
+import { UnlockAdminScreen } from './pages/unlock_admin_screen';
 
 interface UserState {
   userSettings: UserSettings;
@@ -596,7 +598,7 @@ export function AppRoot({
         dispatchAppState({ type: 'finishWritingLongValue' });
       }
     },
-    GLOBALS.CARD_POLLING_INTERVAL,
+    CARD_POLLING_INTERVAL,
     true
   );
 
@@ -732,6 +734,9 @@ export function AppRoot({
         useEffectToggleLargeDisplay={useEffectToggleLargeDisplay}
       />
     );
+  }
+  if (auth.status === 'checking_passcode') {
+    return <UnlockAdminScreen auth={auth} />;
   }
   if (isSuperadminAuth(auth)) {
     return (

--- a/frontends/bmd/src/app_setup_errors.test.tsx
+++ b/frontends/bmd/src/app_setup_errors.test.tsx
@@ -21,6 +21,7 @@ import {
 import { withMarkup } from '../test/helpers/with_markup';
 import { fakeMachineConfigProvider } from '../test/helpers/fake_machine_config';
 import { PrintOnly } from './config/types';
+import { authenticateAdminCard } from '../test/test_utils';
 
 beforeEach(() => {
   jest.useFakeTimers();
@@ -235,7 +236,7 @@ describe('Displays setup warning messages and errors screens', () => {
 
     // Insert admin card
     card.insertCard(adminCard, electionSampleDefinition.electionData);
-    await advanceTimersAndPromises();
+    await authenticateAdminCard();
 
     // expect to see admin screen
     screen.getByText('Election Admin Actions');

--- a/frontends/bmd/src/config/globals.ts
+++ b/frontends/bmd/src/config/globals.ts
@@ -1,7 +1,6 @@
 export const IDLE_TIMEOUT_SECONDS = 5 * 60; // 5 minute
 export const IDLE_RESET_TIMEOUT_SECONDS = 1 * 60; // 1 minute
 export const RECENT_PRINT_EXPIRATION_SECONDS = 1 * 60; // 1 minute
-export const CARD_POLLING_INTERVAL = 200;
 export const CARD_LONG_VALUE_WRITE_DELAY = 1000;
 export const BALLOT_PRINTING_TIMEOUT_SECONDS = 5;
 export const BALLOT_INSTRUCTIONS_TIMEOUT_SECONDS = 60;
@@ -14,3 +13,4 @@ export const LARGE_DISPLAY_FONT_SIZE = 3;
 export const TEXT_SIZE = 1;
 export const WRITE_IN_CANDIDATE_MAX_LENGTH = 40;
 export const QUIT_KIOSK_IDLE_SECONDS = 5 * 60; // 5 minutes
+export const SECURITY_PIN_LENGTH = 6;

--- a/frontends/bmd/src/pages/unlock_admin_screen.test.tsx
+++ b/frontends/bmd/src/pages/unlock_admin_screen.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Inserted } from '@votingworks/test-utils';
+import { UnlockAdminScreen } from './unlock_admin_screen';
+
+test('authentication', async () => {
+  const auth = Inserted.fakeCheckingPasscodeAuth();
+  render(<UnlockAdminScreen auth={auth} />);
+  screen.getByText('- - - - - -');
+
+  userEvent.click(screen.getByText('0'));
+  screen.getByText('• - - - - -');
+
+  userEvent.click(screen.getByText('✖'));
+  screen.getByText('- - - - - -');
+
+  userEvent.click(screen.getByText('0'));
+  screen.getByText('• - - - - -');
+
+  userEvent.click(screen.getByText('1'));
+  screen.getByText('• • - - - -');
+
+  userEvent.click(screen.getByText('2'));
+  screen.getByText('• • • - - -');
+
+  userEvent.click(screen.getByText('3'));
+  screen.getByText('• • • • - -');
+
+  userEvent.click(screen.getByText('4'));
+  screen.getByText('• • • • • -');
+
+  userEvent.click(screen.getByText('⌫'));
+  screen.getByText('• • • • - -');
+
+  userEvent.click(screen.getByText('4'));
+  screen.getByText('• • • • • -');
+
+  userEvent.click(screen.getByText('5'));
+
+  await waitFor(() =>
+    expect(auth.checkPasscode).toHaveBeenNthCalledWith(1, '012345')
+  );
+  screen.getByText('- - - - - -');
+});
+
+test('If passcode is incorrect, error message is shown', () => {
+  const auth = Inserted.fakeCheckingPasscodeAuth({
+    wrongPasscodeEntered: true,
+  });
+  render(<UnlockAdminScreen auth={auth} />);
+  screen.getByText('Invalid code. Please try again.');
+});

--- a/frontends/bmd/src/pages/unlock_admin_screen.tsx
+++ b/frontends/bmd/src/pages/unlock_admin_screen.tsx
@@ -1,0 +1,86 @@
+import {
+  Screen,
+  Main,
+  fontSizeTheme,
+  Prose,
+  Text,
+  NumberPad,
+} from '@votingworks/ui';
+import React, { useState, useEffect, useCallback } from 'react';
+import styled from 'styled-components';
+import { InsertedSmartcardAuth } from '@votingworks/types';
+import { SECURITY_PIN_LENGTH } from '../config/globals';
+
+const NumberPadWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-top: 10px;
+  font-size: 1em;
+  > div {
+    width: 400px;
+  }
+`;
+
+const EnteredCode = styled.div`
+  margin-top: 5px;
+  text-align: center;
+  font-family: monospace;
+  font-size: 1.5em;
+  font-weight: 600;
+`;
+
+interface Props {
+  auth: InsertedSmartcardAuth.CheckingPasscode;
+}
+
+export function UnlockAdminScreen({ auth }: Props): JSX.Element {
+  const [currentPasscode, setCurrentPasscode] = useState('');
+  const handleNumberEntry = useCallback((digit: number) => {
+    setCurrentPasscode((prev) =>
+      `${prev}${digit}`.slice(0, SECURITY_PIN_LENGTH)
+    );
+  }, []);
+  const handleBackspace = useCallback(() => {
+    setCurrentPasscode((prev) => prev.slice(0, -1));
+  }, []);
+  const handleClear = useCallback(() => {
+    setCurrentPasscode('');
+  }, []);
+
+  useEffect(() => {
+    if (currentPasscode.length === SECURITY_PIN_LENGTH) {
+      auth.checkPasscode(currentPasscode);
+      setCurrentPasscode('');
+    }
+  }, [currentPasscode, auth]);
+
+  const currentPasscodeDisplayString = '•'
+    .repeat(currentPasscode.length)
+    .padEnd(SECURITY_PIN_LENGTH, '-')
+    .split('')
+    .join(' ');
+
+  let primarySentence: JSX.Element = (
+    <p>Enter the card security code to unlock.</p>
+  );
+  if (auth.wrongPasscodeEntered) {
+    primarySentence = <Text warning>Invalid code. Please try again.</Text>;
+  }
+  return (
+    <Screen>
+      <Main centerChild>
+        <Prose textCenter theme={fontSizeTheme.medium} maxWidth={false}>
+          {primarySentence}
+          <EnteredCode>{currentPasscodeDisplayString}</EnteredCode>
+          <NumberPadWrapper>
+            <NumberPad
+              onButtonPress={handleNumberEntry}
+              onBackspace={handleBackspace}
+              onClear={handleClear}
+            />
+          </NumberPadWrapper>
+        </Prose>
+      </Main>
+    </Screen>
+  );
+}

--- a/frontends/bmd/test/helpers/smartcards.ts
+++ b/frontends/bmd/test/helpers/smartcards.ts
@@ -15,9 +15,11 @@ import {
   VotesDict,
   VoterCardData,
 } from '@votingworks/types';
-import { VOTER_CARD_EXPIRATION_SECONDS } from '@votingworks/ui';
+import {
+  CARD_POLLING_INTERVAL,
+  VOTER_CARD_EXPIRATION_SECONDS,
+} from '@votingworks/ui';
 import { utcTimestamp } from '@votingworks/utils';
-import * as GLOBALS from '../../src/config/globals';
 
 const contest0 = election.contests[0] as CandidateContest;
 const contest1 = election.contests[1] as CandidateContest;
@@ -154,7 +156,7 @@ export function makeUsedVoterCard(e = election): VoterCardData {
 }
 
 export function advanceTimers(seconds = 0): void {
-  testUtils.advanceTimers(seconds || GLOBALS.CARD_POLLING_INTERVAL / 1000);
+  testUtils.advanceTimers(seconds || CARD_POLLING_INTERVAL / 1000);
 }
 
 export async function advanceTimersAndPromises(seconds = 0): Promise<void> {

--- a/frontends/bmd/test/test_utils.tsx
+++ b/frontends/bmd/test/test_utils.tsx
@@ -1,7 +1,7 @@
 import { createMemoryHistory, History } from 'history';
 import React from 'react';
 import { Router } from 'react-router-dom';
-import { render as testRender } from '@testing-library/react';
+import { render as testRender, screen } from '@testing-library/react';
 import {
   BallotStyleId,
   Contests,
@@ -10,6 +10,8 @@ import {
   VotesDict,
 } from '@votingworks/types';
 
+import userEvent from '@testing-library/user-event';
+import { CARD_POLLING_INTERVAL } from '@votingworks/ui';
 import * as GLOBALS from '../src/config/globals';
 
 import {
@@ -96,4 +98,15 @@ export function render(
       </BallotContext.Provider>
     ),
   };
+}
+
+export async function authenticateAdminCard(): Promise<void> {
+  jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
+  await screen.findByText('Enter the card security code to unlock.');
+  userEvent.click(screen.getByText('1'));
+  userEvent.click(screen.getByText('2'));
+  userEvent.click(screen.getByText('3'));
+  userEvent.click(screen.getByText('4'));
+  userEvent.click(screen.getByText('5'));
+  userEvent.click(screen.getByText('6'));
 }

--- a/libs/test-utils/jest.config.js
+++ b/libs/test-utils/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       statements: 52,
-      branches: 43,
+      branches: 42,
       functions: 56,
       lines: 54,
     },

--- a/libs/test-utils/src/smartcards.ts
+++ b/libs/test-utils/src/smartcards.ts
@@ -35,7 +35,7 @@ export function makeAdminCard(
   return {
     t: 'admin',
     h: electionHash,
-    p: pin,
+    p: pin ?? '123456',
   };
 }
 

--- a/libs/ui/src/hooks/use_user_session.test.tsx
+++ b/libs/ui/src/hooks/use_user_session.test.tsx
@@ -519,24 +519,6 @@ test('basic persist authentication flow works as expected', () => {
       disposition: 'failure',
     })
   );
-
-  // An admin card without a pin is immediately authenticated
-  smartcard = fakeSmartcard({
-    data: makeAdminCard(electionSampleDefinition.electionHash),
-  });
-  rerender();
-  expect(result.current.currentUserSession).toStrictEqual({
-    type: 'admin',
-    authenticated: true,
-  });
-  expect(logSpy).toHaveBeenCalledTimes(14);
-  expect(logSpy).toHaveBeenLastCalledWith(
-    LogEventId.UserSessionActivationAttempt,
-    'admin',
-    expect.objectContaining({
-      disposition: 'success',
-    })
-  );
 });
 
 test('basic flow with no persistance of authentication works as expected', () => {
@@ -858,67 +840,12 @@ test('basic flow with no persistance of authentication works as expected', () =>
     })
   );
 
-  // An admin card without a pin is immediately authenticated
-  smartcard = fakeSmartcard({
-    data: makeAdminCard(electionSampleDefinition.electionHash),
-  });
-  rerender();
-  expect(result.current.currentUserSession).toStrictEqual({
-    type: 'admin',
-    authenticated: true,
+  act(() => {
+    const attemptResult =
+      result.current.attemptToAuthenticateAdminUser('123456');
+    expect(attemptResult).toBe(false);
   });
   expect(logSpy).toHaveBeenCalledTimes(20);
-  expect(logSpy).toHaveBeenLastCalledWith(
-    LogEventId.UserSessionActivationAttempt,
-    'admin',
-    expect.objectContaining({
-      disposition: 'success',
-    })
-  );
-  // Attempting to authenticate an admin card without a pin fails
-  act(() => {
-    const attemptResult =
-      result.current.attemptToAuthenticateAdminUser('123456');
-    expect(attemptResult).toBe(false);
-  });
-  expect(result.current.currentUserSession).toStrictEqual({
-    type: 'admin',
-    authenticated: false,
-  });
-  expect(logSpy).toHaveBeenCalledTimes(22);
-  expect(logSpy).toHaveBeenNthCalledWith(
-    21,
-    LogEventId.AdminAuthenticationTwoFactor,
-    'unknown',
-    expect.objectContaining({
-      disposition: 'failure',
-    })
-  );
-  expect(logSpy).toHaveBeenLastCalledWith(
-    LogEventId.AdminCardInserted,
-    'admin',
-    expect.objectContaining({
-      disposition: 'na',
-    })
-  );
-
-  smartcard = { status: 'no_card' };
-  rerender();
-  expect(result.current.currentUserSession).toStrictEqual(undefined);
-  expect(logSpy).toHaveBeenCalledTimes(23);
-  expect(logSpy).toHaveBeenLastCalledWith(
-    LogEventId.UserLoggedOut,
-    'admin',
-    expect.objectContaining({
-      disposition: 'success',
-    })
-  );
-  act(() => {
-    const attemptResult =
-      result.current.attemptToAuthenticateAdminUser('123456');
-    expect(attemptResult).toBe(false);
-  });
-  expect(logSpy).toHaveBeenCalledTimes(24);
   expect(logSpy).toHaveBeenLastCalledWith(
     LogEventId.AdminAuthenticationTwoFactor,
     'unknown',


### PR DESCRIPTION
## Overview
The useInsertedSmartcardHook requires checking the admin card's pin as of #2031 

Also remove GLOBALS.CARD_POLLING_INTERVAL in favor of the constant from the hook.

## Demo Video or Screenshot

https://user-images.githubusercontent.com/530106/176321511-45b4f1ca-0670-405e-9223-4a056d11e876.mov


## Testing Plan 
- Update existing unit tests
- Some manual testing

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
