### PR TITLE
refactor(all): Change types to require admin card passcode

### DIFF
--- a/frontends/precinct-scanner/src/screens/admin_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/admin_screen.tsx
@@ -243,6 +243,7 @@ export function DefaultPreview(): JSX.Element {
           user: {
             role: 'admin',
             electionHash: electionDefinition.electionHash,
+            passcode: '000000',
           },
           card: {
             hasStoredData: false,

--- a/frontends/precinct-scanner/src/screens/unlock_admin_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/unlock_admin_screen.tsx
@@ -83,7 +83,11 @@ export function DefaultPreview(): JSX.Element {
     <UnlockAdminScreen
       auth={{
         status: 'checking_passcode',
-        user: { role: 'admin', electionHash: 'preview-election-hash' },
+        user: {
+          role: 'admin',
+          electionHash: 'preview-election-hash',
+          passcode: '000000',
+        },
         checkPasscode: () => undefined,
       }}
     />

--- a/libs/test-utils/src/smartcard_auth/auth.ts
+++ b/libs/test-utils/src/smartcard_auth/auth.ts
@@ -29,6 +29,7 @@ export function fakeAdminUser(props: Partial<AdminUser> = {}): AdminUser {
   return {
     role: 'admin',
     electionHash: 'election-hash',
+    passcode: '123456',
     ...props,
   };
 }

--- a/libs/types/src/schema.test.ts
+++ b/libs/types/src/schema.test.ts
@@ -777,11 +777,13 @@ test('validates admin cards have hex-encoded hashes', () => {
   unsafeParse(t.AdminCardDataSchema, {
     t: 'admin',
     h: 'd34db33f',
+    p: '123456',
   });
   expect(
     safeParse(t.AdminCardDataSchema, {
       t: 'admin',
       h: 'not hex',
+      p: '123456',
     }).unsafeUnwrapErr()
   ).toMatchInlineSnapshot(`
     [ZodError: [

--- a/libs/types/src/smartcard_auth/auth.ts
+++ b/libs/types/src/smartcard_auth/auth.ts
@@ -10,7 +10,7 @@ export interface SuperadminUser {
 export interface AdminUser {
   readonly role: 'admin';
   readonly electionHash: string;
-  readonly passcode?: string;
+  readonly passcode: string;
 }
 export interface PollworkerUser {
   readonly role: 'pollworker';

--- a/libs/types/src/smartcard_auth/auth.ts
+++ b/libs/types/src/smartcard_auth/auth.ts
@@ -101,13 +101,13 @@ export interface AdminCardData extends CardData {
   /** Election hash */
   readonly h: string;
   /** Card Passcode */
-  readonly p?: string;
+  readonly p: string;
 }
 export const AdminCardDataSchema: z.ZodSchema<AdminCardData> =
   CardDataInternalSchema.extend({
     t: z.literal('admin'),
     h: ElectionHash,
-    p: z.string().optional(),
+    p: z.string(),
   });
 
 /**

--- a/libs/ui/src/hooks/smartcard_auth/use_dipped_smartcard_auth.test.ts
+++ b/libs/ui/src/hooks/smartcard_auth/use_dipped_smartcard_auth.test.ts
@@ -205,7 +205,7 @@ describe('useDippedSmartcardAuth', () => {
     await waitForNextUpdate();
     expect(result.current).toMatchObject({
       status: 'logged_in',
-      user: fakeAdminUser({ electionHash }),
+      user: fakeAdminUser({ electionHash, passcode: '000000' }),
     });
   });
 

--- a/libs/ui/src/hooks/smartcard_auth/use_dipped_smartcard_auth.ts
+++ b/libs/ui/src/hooks/smartcard_auth/use_dipped_smartcard_auth.ts
@@ -132,7 +132,6 @@ function smartcardAuthReducer(
 
     case 'check_passcode': {
       assert(previousState.auth.status === 'checking_passcode');
-      assert(previousState.auth.user.passcode !== undefined);
       return {
         ...previousState,
         auth:

--- a/libs/ui/src/hooks/smartcard_auth/use_dipped_smartcard_auth.ts
+++ b/libs/ui/src/hooks/smartcard_auth/use_dipped_smartcard_auth.ts
@@ -152,7 +152,11 @@ function smartcardAuthReducer(
         ...previousState,
         auth: {
           status: 'logged_in',
-          user: { role: 'admin', electionHash: action.electionHash },
+          user: {
+            role: 'admin',
+            electionHash: action.electionHash,
+            passcode: '000000',
+          },
         },
       };
 

--- a/libs/ui/src/hooks/smartcard_auth/use_inserted_smartcard_auth.ts
+++ b/libs/ui/src/hooks/smartcard_auth/use_inserted_smartcard_auth.ts
@@ -178,7 +178,6 @@ function smartcardAuthReducer(allowedUserRoles: UserRole[], scope: AuthScope) {
 
       case 'check_passcode': {
         assert(previousState.auth.status === 'checking_passcode');
-        assert(previousState.auth.user.passcode !== undefined);
         return {
           ...previousState,
           auth:

--- a/services/smartcards/fixtures/admin/short.json
+++ b/services/smartcards/fixtures/admin/short.json
@@ -1,1 +1,1 @@
-{"t":"admin","h":"{{hash(long)}}"}
+{"t":"admin","h":"{{hash(long)}}","p":"000000"}


### PR DESCRIPTION
## Overview
All machines now require passcode auth for admin cards, so there's no reason to allow/expect admin cards without a passcode.

## Demo Video or Screenshot
N/A

## Testing Plan 
Existing tests

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
