### PR TITLE
chore(types): annotate Jest config for autocomplete

### DIFF
--- a/codemods/jest.config.js
+++ b/codemods/jest.config.js
@@ -1,4 +1,6 @@
-/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+/**
+ * @type {import('@jest/types').Config.InitialOptions}
+ */
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
@@ -8,6 +10,6 @@ module.exports = {
       functions: 100,
       lines: 100,
       statements: 100,
-    }
-  }
+    },
+  },
 };

--- a/codemods/package.json
+++ b/codemods/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@babel/generator": "^7.18.2",
     "@babel/traverse": "^7.18.2",
+    "@jest/types": "^28.1.1",
     "@types/babel__core": "^7.1.19",
     "@types/babel__generator": "^7.6.4",
     "@types/babel__traverse": "^7.17.1",

--- a/frontends/election-manager/jest.config.js
+++ b/frontends/election-manager/jest.config.js
@@ -8,6 +8,9 @@ function regexEscape(str) {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+/**
+ * @type {import('@jest/types').Config.InitialOptions}
+ */
 module.exports = {
   collectCoverageFrom: [
     'src/**/*.{js,jsx,ts,tsx}',

--- a/frontends/election-manager/package.json
+++ b/frontends/election-manager/package.json
@@ -156,6 +156,7 @@
   },
   "devDependencies": {
     "@codemod/parser": "^1.0.6",
+    "@jest/types": "^28.1.1",
     "@testing-library/jest-dom": "^5.16.4",
     "@types/babel__core": "^7.1.19",
     "@types/base64-js": "^1.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,7 @@ importers:
     devDependencies:
       '@babel/generator': 7.18.2
       '@babel/traverse': 7.18.2
+      '@jest/types': 28.1.1
       '@types/babel__core': 7.1.19
       '@types/babel__generator': 7.6.4
       '@types/babel__traverse': 7.17.1
@@ -48,6 +49,7 @@ importers:
       '@babel/generator': ^7.18.2
       '@babel/traverse': ^7.18.2
       '@babel/types': ^7.18.2
+      '@jest/types': ^28.1.1
       '@types/babel__core': ^7.1.19
       '@types/babel__generator': ^7.6.4
       '@types/babel__traverse': ^7.17.1
@@ -782,6 +784,7 @@ importers:
       zod: 3.14.4
     devDependencies:
       '@codemod/parser': 1.1.0
+      '@jest/types': 28.1.1
       '@testing-library/jest-dom': 5.16.4
       '@types/babel__core': 7.1.19
       '@types/base64-js': 1.3.0
@@ -832,6 +835,7 @@ importers:
     specifiers:
       '@babel/core': 7.12.3
       '@codemod/parser': ^1.0.6
+      '@jest/types': ^28.1.1
       '@pmmmwh/react-refresh-webpack-plugin': 0.4.2
       '@svgr/webpack': 5.4.0
       '@testing-library/jest-dom': ^5.16.4
@@ -2523,6 +2527,7 @@ importers:
       uuid: 8.3.2
       zod: 3.14.4
     devDependencies:
+      '@jest/types': 28.1.1
       '@types/better-sqlite3': 7.5.0
       '@types/debug': 4.1.7
       '@types/express': 4.17.13
@@ -2557,6 +2562,7 @@ importers:
       ts-jest: 26.5.6_jest@26.6.3+typescript@4.6.3
       typescript: 4.6.3
     specifiers:
+      '@jest/types': ^28.1.1
       '@types/better-sqlite3': ^7.5.0
       '@types/debug': ^4.1.7
       '@types/express': ^4.17.13
@@ -2637,6 +2643,7 @@ importers:
       zip-stream: 4.1.0
       zod: 3.14.4
     devDependencies:
+      '@jest/types': 28.1.1
       '@types/base64-js': 1.3.0
       '@types/better-sqlite3': 7.4.3
       '@types/busboy': 0.2.3
@@ -2677,6 +2684,7 @@ importers:
       ts-jest: 26.4.4_jest@26.6.3+typescript@4.6.3
       typescript: 4.6.3
     specifiers:
+      '@jest/types': ^28.1.1
       '@types/base64-js': ^1.3.0
       '@types/better-sqlite3': ^7.4.3
       '@types/busboy': ^0.2.3
@@ -8158,6 +8166,19 @@ packages:
       node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0
     resolution:
       integrity: sha512-xmEggMPr317MIOjjDoZ4ejCSr9Lpbt/u34+dvc99t7DS8YirW5rwZEhzKPC2BMUFkUhI48qs6qLUSGw5FuL0GA==
+  /@jest/types/28.1.1:
+    dependencies:
+      '@jest/schemas': 28.0.2
+      '@types/istanbul-lib-coverage': 2.0.4
+      '@types/istanbul-reports': 3.0.1
+      '@types/node': 16.11.29
+      '@types/yargs': 17.0.10
+      chalk: 4.1.2
+    dev: true
+    engines:
+      node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0
+    resolution:
+      integrity: sha512-vRXVqSg1VhDnB8bWcmvLzmg0Bt9CRKVgHPXqYwvWMX3TvAjeO+nRuK6+VdTKCtWOvYlmkF/HqNAL/z+N3B53Kw==
   /@jridgewell/gen-mapping/0.1.1:
     dependencies:
       '@jridgewell/set-array': 1.1.1
@@ -24681,7 +24702,7 @@ packages:
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
-      jest: 26.6.0
+      jest: 26.6.0_canvas@2.9.1
       jest-regex-util: 26.0.0
       jest-watcher: 26.6.2
       slash: 3.0.0

--- a/services/admin/jest.config.js
+++ b/services/admin/jest.config.js
@@ -1,5 +1,8 @@
 const shared = require('../../jest.config.shared');
 
+/**
+ * @type {import('@jest/types').Config.InitialOptions}
+ */
 module.exports = {
   ...shared,
   // This is here because jest finds `build/__mocks__`,

--- a/services/admin/package.json
+++ b/services/admin/package.json
@@ -48,6 +48,7 @@
     "zod": "3.14.4"
   },
   "devDependencies": {
+    "@jest/types": "^28.1.1",
     "@types/better-sqlite3": "^7.5.0",
     "@types/debug": "^4.1.7",
     "@types/express": "^4.17.13",

--- a/services/scan/jest.config.js
+++ b/services/scan/jest.config.js
@@ -1,5 +1,8 @@
-const shared = require('../../jest.config.shared')
+const shared = require('../../jest.config.shared');
 
+/**
+ * @type {import('@jest/types').Config.InitialOptions}
+ */
 module.exports = {
   ...shared,
   // This is here because jest finds `build/__mocks__`,
@@ -21,4 +24,4 @@ module.exports = {
       lines: 89,
     },
   },
-}
+};

--- a/services/scan/package.json
+++ b/services/scan/package.json
@@ -72,6 +72,7 @@
     "zod": "3.14.4"
   },
   "devDependencies": {
+    "@jest/types": "^28.1.1",
     "@types/base64-js": "^1.3.0",
     "@types/better-sqlite3": "^7.4.3",
     "@types/busboy": "^0.2.3",


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Standardizing the type annotations for Jest config.

## Demo Video or Screenshot
n/a

## Testing Plan 
n/a

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
