### PR TITLE
build(vite): enable hot module replacement (HMR)

### DIFF
--- a/frontends/bas/package.json
+++ b/frontends/bas/package.json
@@ -100,6 +100,7 @@
     "@types/testing-library__jest-dom": "^5.14.3",
     "@typescript-eslint/eslint-plugin": "^5.21.0",
     "@typescript-eslint/parser": "^5.21.0",
+    "@vitejs/plugin-react": "^1.3.2",
     "babel-loader": "8.1.0",
     "babel-plugin-named-asset-import": "^0.3.7",
     "babel-preset-react-app": "^10.0.0",

--- a/frontends/bas/vite.config.ts
+++ b/frontends/bas/vite.config.ts
@@ -1,3 +1,4 @@
+import react from '@vitejs/plugin-react';
 import { join } from 'path';
 import { Alias, defineConfig } from 'vite';
 import setupProxy from './prodserver/setupProxy';
@@ -53,6 +54,8 @@ export default defineConfig(async () => {
     },
 
     plugins: [
+      react(),
+
       // Setup the proxy to local services, e.g. `smartcards`.
       {
         name: 'development-proxy',

--- a/frontends/bmd/package.json
+++ b/frontends/bmd/package.json
@@ -153,6 +153,7 @@
     "@types/testing-library__jest-dom": "^5.14.3",
     "@typescript-eslint/eslint-plugin": "^5.21.0",
     "@typescript-eslint/parser": "^5.21.0",
+    "@vitejs/plugin-react": "^1.3.2",
     "@votingworks/res-to-ts": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
     "chalk": "^4.1.2",

--- a/frontends/bmd/vite.config.ts
+++ b/frontends/bmd/vite.config.ts
@@ -1,3 +1,4 @@
+import react from '@vitejs/plugin-react';
 import { join } from 'path';
 import { Alias, defineConfig, loadEnv } from 'vite';
 import { getWorkspacePackageInfo } from '../../script/src/validate-monorepo/pnpm';
@@ -68,6 +69,8 @@ export default defineConfig(async (env) => {
     },
 
     plugins: [
+      react(),
+
       // Setup the proxy to local services, e.g. `smartcards`.
       {
         name: 'development-proxy',

--- a/frontends/bmd/vite.config.ts
+++ b/frontends/bmd/vite.config.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import { defineConfig, loadEnv } from 'vite';
+import { Alias, defineConfig, loadEnv } from 'vite';
 import { getWorkspacePackageInfo } from '../../script/src/validate-monorepo/pnpm';
 import setupProxy from './prodserver/setupProxy';
 
@@ -40,12 +40,12 @@ export default defineConfig(async (env) => {
     },
 
     resolve: {
-      alias: {
+      alias: [
         // Replace NodeJS built-in modules with polyfills.
         //
         // The trailing slash is important, otherwise it will be resolved as a
         // built-in NodeJS module.
-        buffer: require.resolve('buffer/'),
+        { find: 'buffer', replacement: require.resolve('buffer/'), },
 
         // Create aliases for all workspace packages, i.e.
         //
@@ -57,14 +57,14 @@ export default defineConfig(async (env) => {
         //
         // This allows re-mapping imports for workspace packages to their
         // TypeScript source code rather than the built JavaScript.
-        ...Array.from(workspacePackages.values()).reduce<
-          Record<string, string>
-        >(
+        ...Array.from(workspacePackages.values()).reduce<Alias[]>(
           (aliases, { path, name, source }) =>
-            !source ? aliases : { ...aliases, [name]: join(path, source) },
-          {}
+            !source
+              ? aliases
+              : [...aliases, { find: name, replacement: join(path, source) }],
+          []
         ),
-      },
+      ],
     },
 
     plugins: [

--- a/frontends/bsd/package.json
+++ b/frontends/bsd/package.json
@@ -101,6 +101,7 @@
     "@types/zip-stream": "workspace:*",
     "@typescript-eslint/eslint-plugin": "^5.21.0",
     "@typescript-eslint/parser": "^5.21.0",
+    "@vitejs/plugin-react": "^1.3.2",
     "@votingworks/ballot-encoder": "workspace:*",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/test-utils": "workspace:*",

--- a/frontends/bsd/vite.config.ts
+++ b/frontends/bsd/vite.config.ts
@@ -1,3 +1,4 @@
+import react from '@vitejs/plugin-react';
 import { join } from 'path';
 import { Alias, defineConfig, loadEnv } from 'vite';
 import { getWorkspacePackageInfo } from '../../script/src/validate-monorepo/pnpm';
@@ -68,6 +69,8 @@ export default defineConfig(async (env) => {
     },
 
     plugins: [
+      react(),
+
       // Setup the proxy to local services, e.g. `smartcards`.
       {
         name: 'development-proxy',

--- a/frontends/bsd/vite.config.ts
+++ b/frontends/bsd/vite.config.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import { defineConfig, loadEnv } from 'vite';
+import { Alias, defineConfig, loadEnv } from 'vite';
 import { getWorkspacePackageInfo } from '../../script/src/validate-monorepo/pnpm';
 import setupProxy from './prodserver/setupProxy';
 
@@ -40,12 +40,12 @@ export default defineConfig(async (env) => {
     },
 
     resolve: {
-      alias: {
+      alias: [
         // Replace NodeJS built-in modules with polyfills.
         //
         // The trailing slash is important, otherwise it will be resolved as a
         // built-in NodeJS module.
-        buffer: require.resolve('buffer/'),
+        { find: 'buffer', replacement: require.resolve('buffer/'), },
 
         // Create aliases for all workspace packages, i.e.
         //
@@ -57,14 +57,14 @@ export default defineConfig(async (env) => {
         //
         // This allows re-mapping imports for workspace packages to their
         // TypeScript source code rather than the built JavaScript.
-        ...Array.from(workspacePackages.values()).reduce<
-          Record<string, string>
-        >(
+        ...Array.from(workspacePackages.values()).reduce<Alias[]>(
           (aliases, { path, name, source }) =>
-            !source ? aliases : { ...aliases, [name]: join(path, source) },
-          {}
+            !source
+              ? aliases
+              : [...aliases, { find: name, replacement: join(path, source) }],
+          []
         ),
-      },
+      ],
     },
 
     plugins: [

--- a/frontends/election-manager/package.json
+++ b/frontends/election-manager/package.json
@@ -172,6 +172,7 @@
     "@types/zip-stream": "workspace:*",
     "@typescript-eslint/eslint-plugin": "^5.21.0",
     "@typescript-eslint/parser": "^5.21.0",
+    "@vitejs/plugin-react": "^1.3.2",
     "@votingworks/test-utils": "workspace:*",
     "babel-plugin-transform-import-meta": "^2.1.1",
     "eslint": "^7.17.0",

--- a/frontends/election-manager/vite.config.ts
+++ b/frontends/election-manager/vite.config.ts
@@ -1,3 +1,4 @@
+import react from '@vitejs/plugin-react';
 import { join } from 'path';
 import { Alias, defineConfig, loadEnv } from 'vite';
 import { getWorkspacePackageInfo } from '../../script/src/validate-monorepo/pnpm';
@@ -88,6 +89,8 @@ export default defineConfig(async (env) => {
     },
 
     plugins: [
+      react(),
+
       // Setup the proxy to local services, e.g. `smartcards`.
       {
         name: 'development-proxy',

--- a/frontends/precinct-scanner/package.json
+++ b/frontends/precinct-scanner/package.json
@@ -108,6 +108,7 @@
     "@types/testing-library__jest-dom": "^5.14.3",
     "@typescript-eslint/eslint-plugin": "^5.21.0",
     "@typescript-eslint/parser": "^5.21.0",
+    "@vitejs/plugin-react": "^1.3.2",
     "@votingworks/test-utils": "workspace:*",
     "eslint": "^7.17.0",
     "eslint-config-airbnb": "^17.1.1",

--- a/frontends/precinct-scanner/vite.config.ts
+++ b/frontends/precinct-scanner/vite.config.ts
@@ -1,3 +1,4 @@
+import react from '@vitejs/plugin-react';
 import { join } from 'path';
 import { Alias, defineConfig, loadEnv } from 'vite';
 import { getWorkspacePackageInfo } from '../../script/src/validate-monorepo/pnpm';
@@ -69,6 +70,8 @@ export default defineConfig(async (env) => {
     },
 
     plugins: [
+      react(),
+
       // Setup the proxy to local services, e.g. `smartcards`.
       {
         name: 'development-proxy',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,7 @@ importers:
       '@types/testing-library__jest-dom': 5.14.3
       '@typescript-eslint/eslint-plugin': 5.21.0_bb9518338a760ece3e1b033a5f6af62e
       '@typescript-eslint/parser': 5.21.0_eslint@7.32.0+typescript@4.6.3
+      '@vitejs/plugin-react': 1.3.2
       babel-loader: 8.1.0_@babel+core@7.12.3
       babel-plugin-named-asset-import: 0.3.7_@babel+core@7.12.3
       babel-preset-react-app: 10.0.0
@@ -175,6 +176,7 @@ importers:
       '@types/testing-library__jest-dom': ^5.14.3
       '@typescript-eslint/eslint-plugin': ^5.21.0
       '@typescript-eslint/parser': ^5.21.0
+      '@vitejs/plugin-react': ^1.3.2
       '@votingworks/logging': workspace:*
       '@votingworks/types': workspace:*
       '@votingworks/ui': workspace:*
@@ -334,6 +336,7 @@ importers:
       '@types/testing-library__jest-dom': 5.14.3
       '@typescript-eslint/eslint-plugin': 5.21.0_bb9518338a760ece3e1b033a5f6af62e
       '@typescript-eslint/parser': 5.21.0_eslint@7.32.0+typescript@4.6.3
+      '@vitejs/plugin-react': 1.3.2
       '@votingworks/res-to-ts': link:../../libs/res-to-ts
       '@votingworks/test-utils': link:../../libs/test-utils
       chalk: 4.1.2
@@ -401,6 +404,7 @@ importers:
       '@types/testing-library__jest-dom': ^5.14.3
       '@typescript-eslint/eslint-plugin': ^5.21.0
       '@typescript-eslint/parser': ^5.21.0
+      '@vitejs/plugin-react': ^1.3.2
       '@votingworks/ballot-encoder': workspace:*
       '@votingworks/fixtures': workspace:*
       '@votingworks/logging': workspace:*
@@ -551,6 +555,7 @@ importers:
       '@types/zip-stream': link:../../libs/@types/zip-stream
       '@typescript-eslint/eslint-plugin': 5.21.0_4059d5ee7aba256d5e330151ee3418c0
       '@typescript-eslint/parser': 5.21.0_eslint@7.17.0+typescript@4.6.3
+      '@vitejs/plugin-react': 1.3.2
       '@votingworks/ballot-encoder': link:../../libs/ballot-encoder
       '@votingworks/fixtures': link:../../libs/fixtures
       '@votingworks/test-utils': link:../../libs/test-utils
@@ -609,6 +614,7 @@ importers:
       '@types/zip-stream': workspace:*
       '@typescript-eslint/eslint-plugin': ^5.21.0
       '@typescript-eslint/parser': ^5.21.0
+      '@vitejs/plugin-react': ^1.3.2
       '@votingworks/api': workspace:*
       '@votingworks/ballot-encoder': workspace:*
       '@votingworks/ballot-interpreter-vx': workspace:*
@@ -797,6 +803,7 @@ importers:
       '@types/readable-stream': 2.3.9
       '@types/testing-library__jest-dom': 5.14.3
       '@types/zip-stream': link:../../libs/@types/zip-stream
+      '@vitejs/plugin-react': 1.3.2
       '@votingworks/test-utils': link:../../libs/test-utils
       babel-plugin-transform-import-meta: 2.1.1_@babel+core@7.12.3
       eslint: 7.32.0
@@ -866,6 +873,7 @@ importers:
       '@types/zip-stream': workspace:*
       '@typescript-eslint/eslint-plugin': ^4.5.0
       '@typescript-eslint/parser': ^4.5.0
+      '@vitejs/plugin-react': ^1.3.2
       '@votingworks/ballot-encoder': workspace:*
       '@votingworks/ballot-interpreter-nh': workspace:*
       '@votingworks/ballot-interpreter-vx': workspace:*
@@ -1052,6 +1060,7 @@ importers:
       '@types/testing-library__jest-dom': 5.14.3
       '@typescript-eslint/eslint-plugin': 5.21.0_862063063b41111bfe9123e9a3f05250
       '@typescript-eslint/parser': 5.21.0_eslint@7.25.0+typescript@4.6.3
+      '@vitejs/plugin-react': 1.3.2
       '@votingworks/test-utils': link:../../libs/test-utils
       eslint: 7.25.0
       eslint-config-airbnb: 17.1.1_4e7774c97029300fef6198d04be82a60
@@ -1106,6 +1115,7 @@ importers:
       '@types/testing-library__jest-dom': ^5.14.3
       '@typescript-eslint/eslint-plugin': ^5.21.0
       '@typescript-eslint/parser': ^5.21.0
+      '@vitejs/plugin-react': ^1.3.2
       '@votingworks/api': workspace:*
       '@votingworks/ballot-interpreter-vx': workspace:*
       '@votingworks/fixtures': workspace:*
@@ -2766,7 +2776,7 @@ packages:
   /@ampproject/remapping/2.2.0:
     dependencies:
       '@jridgewell/gen-mapping': 0.1.1
-      '@jridgewell/trace-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.14
     engines:
       node: '>=6.0.0'
     resolution:
@@ -2813,6 +2823,14 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
+  /@babel/code-frame/7.18.6:
+    dependencies:
+      '@babel/highlight': 7.18.6
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==
   /@babel/compat-data/7.14.5:
     engines:
       node: '>=6.9.0'
@@ -2829,6 +2847,12 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-GZt/TCsG70Ms19gfZO1tM4CVnXsPgEPBCpJu+Qz3L0LUDsY5nZqFZglIoPC1kIYOtNBZlrnFT+klg12vFGZXrw==
+  /@babel/compat-data/7.18.6:
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-tzulrgDT0QD6U7BJ4TKVk2SDDg7wlP39P9yAx1RfLy7vP/7rsDRlWVfbWxElslu56+r7QOhB2NSDsabYYruoZQ==
   /@babel/core/7.12.3:
     dependencies:
       '@babel/code-frame': 7.16.7
@@ -2937,6 +2961,28 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-A8pri1YJiC5UnkdrWcmfZTJTV85b4UXTAfImGmCfYmax4TR9Cw8sDS0MOk++Gp2mE/BefVJ5nwy5yzqNJbP/DQ==
+  /@babel/core/7.18.6:
+    dependencies:
+      '@ampproject/remapping': 2.2.0
+      '@babel/code-frame': 7.18.6
+      '@babel/generator': 7.18.7
+      '@babel/helper-compilation-targets': 7.18.6_@babel+core@7.18.6
+      '@babel/helper-module-transforms': 7.18.6
+      '@babel/helpers': 7.18.6
+      '@babel/parser': 7.18.6
+      '@babel/template': 7.18.6
+      '@babel/traverse': 7.18.6
+      '@babel/types': 7.18.7
+      convert-source-map: 1.8.0
+      debug: 4.3.4
+      gensync: 1.0.0-beta.2
+      json5: 2.2.1
+      semver: 6.3.0
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-cQbWBpxcbbs/IUredIPkHiAGULLV8iwgNRMFzvbhEXISp4f3rUUXE5+TIw6KwUWUR3DwyI6gmBRnmAtYaWehwQ==
   /@babel/generator/7.12.11:
     dependencies:
       '@babel/types': 7.12.12
@@ -2991,6 +3037,16 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-W1lG5vUwFvfMd8HVXqdfbuG7RuaSrTCCD8cl8fP8wOivdbtbIg2Db3IWUcgvfxKbbn6ZBGYRW/Zk1MIwK49mgw==
+  /@babel/generator/7.18.7:
+    dependencies:
+      '@babel/types': 7.18.7
+      '@jridgewell/gen-mapping': 0.3.2
+      jsesc: 2.5.2
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-shck+7VLlY72a2w9c3zYWuE1pwOKEiQHV7GTUbSnhyl5eu3i04t30tBY82ZRWrDfo3gkakCFtevExnxbkf2a3A==
   /@babel/helper-annotate-as-pure/7.12.10:
     dependencies:
       '@babel/types': 7.12.12
@@ -3004,6 +3060,14 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==
+  /@babel/helper-annotate-as-pure/7.18.6:
+    dependencies:
+      '@babel/types': 7.18.7
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==
   /@babel/helper-builder-binary-assignment-operator-visitor/7.16.7:
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.16.7
@@ -3093,6 +3157,20 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-s1jnPotJS9uQnzFtiZVBUxe67CuBa679oWFHpxYYnTpRL/1ffhyX44R9uYiXoa/pLXcY9H2moJta0iaanlk/rQ==
+  /@babel/helper-compilation-targets/7.18.6_@babel+core@7.18.6:
+    dependencies:
+      '@babel/compat-data': 7.18.6
+      '@babel/core': 7.18.6
+      '@babel/helper-validator-option': 7.18.6
+      browserslist: 4.21.1
+      semver: 6.3.0
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    resolution:
+      integrity: sha512-vFjbfhNCzqdeAtZflUFrG5YIFqGTqsctrtkZ1D/NB0mDW9TwW3GmmUepYY4G9wCET5rY5ugz4OGTcLd614IzQg==
   /@babel/helper-create-class-features-plugin/7.17.9_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
@@ -3230,6 +3308,12 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-14GQKWkX9oJzPiQQ7/J36FTXcD4kSp8egKjO9nINlSKiHITRA9q/R74qu8S9xlc/b/yjsJItQUeeh3xnGN0voQ==
+  /@babel/helper-environment-visitor/7.18.6:
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-8n6gSfn2baOY+qlp+VSzsosjCVGFqWKmDF0cCWOybh52Dw3SEyoWR1KrhMJASjLwIEkkAufZ0xvr+SxLHSpy2Q==
   /@babel/helper-explode-assignable-expression/7.16.7:
     dependencies:
       '@babel/types': 7.18.4
@@ -3280,6 +3364,15 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==
+  /@babel/helper-function-name/7.18.6:
+    dependencies:
+      '@babel/template': 7.18.6
+      '@babel/types': 7.18.7
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-0mWMxV1aC97dhjCah5U5Ua7668r5ZmSC2DLfH2EZnf9c3/dHZKiFa5pRLMH5tjSl471tY6496ZWk/kjNONBxhw==
   /@babel/helper-get-function-arity/7.12.10:
     dependencies:
       '@babel/types': 7.12.12
@@ -3329,6 +3422,14 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==
+  /@babel/helper-hoist-variables/7.18.6:
+    dependencies:
+      '@babel/types': 7.18.7
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==
   /@babel/helper-member-expression-to-functions/7.14.5:
     dependencies:
       '@babel/types': 7.14.5
@@ -3385,6 +3486,14 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==
+  /@babel/helper-module-imports/7.18.6:
+    dependencies:
+      '@babel/types': 7.18.7
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==
   /@babel/helper-module-transforms/7.14.5:
     dependencies:
       '@babel/helper-module-imports': 7.14.5
@@ -3443,6 +3552,21 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-kclUYSUBIjlvnzN2++K9f2qzYKFgjmnmjwL4zlmU5f8ZtzgWe8s0rUPSTGy2HmK4P8T52MQsS+HTQAgZd3dMEA==
+  /@babel/helper-module-transforms/7.18.6:
+    dependencies:
+      '@babel/helper-environment-visitor': 7.18.6
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-simple-access': 7.18.6
+      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/helper-validator-identifier': 7.18.6
+      '@babel/template': 7.18.6
+      '@babel/traverse': 7.18.6
+      '@babel/types': 7.18.7
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-L//phhB4al5uucwzlimruukHB3jRd5JGClwRMD/ROrVjXfLqovYnvQrK/JK36WYyVwGGO7OD3kMyVTjx+WVPhw==
   /@babel/helper-optimise-call-expression/7.14.5:
     dependencies:
       '@babel/types': 7.15.0
@@ -3487,6 +3611,12 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-JDkf04mqtN3y4iAbO1hv9U2ARpPyPL1zqyWs/2WG1pgSq9llHFjStX5jdxb84himgJm+8Ng+x0oiWF/nw/XQKA==
+  /@babel/helper-plugin-utils/7.18.6:
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-gvZnm1YAAxh13eJdkb9EWHBnF3eAub3XTLCZEehHT2kWxiKVRL64+ae5Y6Ivne0mVHmMYKT+xWgZO+gQhuLUBg==
   /@babel/helper-remap-async-to-generator/7.16.8:
     dependencies:
       '@babel/helper-annotate-as-pure': 7.16.7
@@ -3550,6 +3680,14 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==
+  /@babel/helper-simple-access/7.18.6:
+    dependencies:
+      '@babel/types': 7.18.7
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==
   /@babel/helper-skip-transparent-expression-wrappers/7.16.0:
     dependencies:
       '@babel/types': 7.18.4
@@ -3591,6 +3729,14 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==
+  /@babel/helper-split-export-declaration/7.18.6:
+    dependencies:
+      '@babel/types': 7.18.7
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==
   /@babel/helper-validator-identifier/7.12.11:
     dev: false
     resolution:
@@ -3618,6 +3764,12 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
+  /@babel/helper-validator-identifier/7.18.6:
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==
   /@babel/helper-validator-option/7.14.5:
     engines:
       node: '>=6.9.0'
@@ -3628,6 +3780,12 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==
+  /@babel/helper-validator-option/7.18.6:
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==
   /@babel/helper-wrap-function/7.16.8:
     dependencies:
       '@babel/helper-function-name': 7.17.9
@@ -3676,6 +3834,16 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-j+d+u5xT5utcQSzrh9p+PaJX94h++KN+ng9b9WEJq7pkUPAd61FGqhjuUEdfknb3E/uDBb7ruwEeKkIxNJPIrg==
+  /@babel/helpers/7.18.6:
+    dependencies:
+      '@babel/template': 7.18.6
+      '@babel/traverse': 7.18.6
+      '@babel/types': 7.18.7
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-vzSiiqbQOghPngUYt/zWGvK3LAsPhz55vc9XNN0xAl2gV4ieShI2OQli5duxWHD+72PZPTKAcfcZDE1Cwc5zsQ==
   /@babel/highlight/7.14.0:
     dependencies:
       '@babel/helper-validator-identifier': 7.14.0
@@ -3710,6 +3878,16 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-7yykMVF3hfZY2jsHZEEgLc+3x4o1O+fYyULu11GynEUQNwB6lua+IIQn1FiJxNucd5UlyJryrwsOh8PL9Sn8Qg==
+  /@babel/highlight/7.18.6:
+    dependencies:
+      '@babel/helper-validator-identifier': 7.18.6
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==
   /@babel/parser/7.12.11:
     dev: false
     engines:
@@ -3763,6 +3941,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-FDge0dFazETFcxGw/EXzOkN8uJp0PC7Qbm+Pe9T+av2zlBpOgunFHkQPPn+eRuClU73JF+98D531UgayY89tow==
+  /@babel/parser/7.18.6:
+    dev: true
+    engines:
+      node: '>=6.0.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-uQVSa9jJUe/G/304lXspfWVpKpK4euFLgGiMQFOCpM/bgcAdeoHwi/OQz23O9GK2osz26ZiXRRV9aV+Yl1O8tw==
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.16.7_@babel+core@7.16.5:
     dependencies:
       '@babel/core': 7.16.5
@@ -4663,6 +4848,17 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-1yRi7yAtB0ETgxdY9ti/p2TivUxJkTdhu/ZbF9MshVGqOx1TdB3b7xCXs49Fupgg50N45KcAsRP/ZqWjs9SRjg==
+  /@babel/plugin-syntax-jsx/7.18.6_@babel+core@7.18.6:
+    dependencies:
+      '@babel/core': 7.18.6
+      '@babel/helper-plugin-utils': 7.18.6
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==
   /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
@@ -5845,6 +6041,17 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-i1AxnKxHeMxUaWVXQOSIco4tvVvvCxMSfeBMnMM06mpaJt3g+MpxYQQrDfojUQldP1xxraPSJYSMEljoWM/dCg==
+  /@babel/plugin-transform-react-jsx-development/7.18.6_@babel+core@7.18.6:
+    dependencies:
+      '@babel/core': 7.18.6
+      '@babel/plugin-transform-react-jsx': 7.18.6_@babel+core@7.18.6
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==
   /@babel/plugin-transform-react-jsx-self/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
@@ -5853,6 +6060,17 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-FbpL0ieNWiiBB5tCldX17EtXgmzeEZjFrix72rQYeq9X6nUK38HCaxexzVQrZWXanxKJPKVVIU37gFjEQYkPkA==
+  /@babel/plugin-transform-react-jsx-self/7.18.6_@babel+core@7.18.6:
+    dependencies:
+      '@babel/core': 7.18.6
+      '@babel/helper-plugin-utils': 7.18.6
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-A0LQGx4+4Jv7u/tWzoJF7alZwnBDQd6cGLh9P+Ttk4dpiL+J5p7NSNv/9tlEFFJDq3kjxOavWmbm6t0Gk+A3Ig==
   /@babel/plugin-transform-react-jsx-source/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
@@ -5861,6 +6079,17 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-keQ5kBfjJNRc6zZN1/nVHCd6LLIHq4aUKcVnvE/2l+ZZROSbqoiGFRtT5t3Is89XJxBQaP7NLZX2jgGHdZvvFQ==
+  /@babel/plugin-transform-react-jsx-source/7.18.6_@babel+core@7.18.6:
+    dependencies:
+      '@babel/core': 7.18.6
+      '@babel/helper-plugin-utils': 7.18.6
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-utZmlASneDfdaMh0m/WausbjUjEdGrQJz0vFK93d7wD3xf5wBtX219+q6IlCNZeguIcxS2f/CvLZrlLSvSHQXw==
   /@babel/plugin-transform-react-jsx/7.12.12_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
@@ -5886,6 +6115,21 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-JDWGuzGNWscYcq8oJVCtSE61a5+XAOos+V0HrxnDieUus4UMnBEosDnY1VJqU5iZ4pA04QY7l0+JvHL1hZEfsw==
+  /@babel/plugin-transform-react-jsx/7.18.6_@babel+core@7.18.6:
+    dependencies:
+      '@babel/core': 7.18.6
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.18.6
+      '@babel/types': 7.18.7
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-Mz7xMPxoy9kPS/JScj6fJs03TZ/fZ1dJPlMjRAgTaxaS0fUBk8FV/A2rRgfPsVCZqALNwMexD+0Uaf5zlcKPpw==
   /@babel/plugin-transform-react-pure-annotations/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
@@ -6699,6 +6943,16 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==
+  /@babel/template/7.18.6:
+    dependencies:
+      '@babel/code-frame': 7.18.6
+      '@babel/parser': 7.18.6
+      '@babel/types': 7.18.7
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==
   /@babel/traverse/7.12.12_supports-color@5.5.0:
     dependencies:
       '@babel/code-frame': 7.12.11
@@ -6794,6 +7048,23 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-9eNwoeovJ6KH9zcCNnENY7DMFwTU9JdGCFtqNLfUAqtUHRCOsTOqWoffosP8vKmNYeSBUv3yVJXjfd8ucwOjUA==
+  /@babel/traverse/7.18.6:
+    dependencies:
+      '@babel/code-frame': 7.18.6
+      '@babel/generator': 7.18.7
+      '@babel/helper-environment-visitor': 7.18.6
+      '@babel/helper-function-name': 7.18.6
+      '@babel/helper-hoist-variables': 7.18.6
+      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/parser': 7.18.6
+      '@babel/types': 7.18.7
+      debug: 4.3.4
+      globals: 11.12.0
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-zS/OKyqmD7lslOtFqbscH6gMLFYOfG1YPqCKfAW5KrTeolKqvB8UelR49Fpr6y93kYkW2Ik00mT1LOGiAGvizw==
   /@babel/types/7.12.12:
     dependencies:
       '@babel/helper-validator-identifier': 7.12.11
@@ -6858,6 +7129,15 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==
+  /@babel/types/7.18.7:
+    dependencies:
+      '@babel/helper-validator-identifier': 7.18.6
+      to-fast-properties: 2.0.0
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-QG3yxTcTIBoAcQmkCs+wAPYZhu7Dk9rXKacINfNbdJDNERTbLQbHGyVG8q/YGMPeCJRIhSY0+fTc5+xuh6WPSQ==
   /@bcoe/v8-coverage/0.2.3:
     dev: true
     resolution:
@@ -8185,8 +8465,8 @@ packages:
       integrity: sha512-vRXVqSg1VhDnB8bWcmvLzmg0Bt9CRKVgHPXqYwvWMX3TvAjeO+nRuK6+VdTKCtWOvYlmkF/HqNAL/z+N3B53Kw==
   /@jridgewell/gen-mapping/0.1.1:
     dependencies:
-      '@jridgewell/set-array': 1.1.1
-      '@jridgewell/sourcemap-codec': 1.4.13
+      '@jridgewell/set-array': 1.1.2
+      '@jridgewell/sourcemap-codec': 1.4.14
     engines:
       node: '>=6.0.0'
     resolution:
@@ -8200,25 +8480,54 @@ packages:
       node: '>=6.0.0'
     resolution:
       integrity: sha512-GcHwniMlA2z+WFPWuY8lp3fsza0I8xPFMWL5+n8LYyP6PSvPrXf4+n8stDHZY2DM0zy9sVkRDy1jDI4XGzYVqg==
+  /@jridgewell/gen-mapping/0.3.2:
+    dependencies:
+      '@jridgewell/set-array': 1.1.2
+      '@jridgewell/sourcemap-codec': 1.4.14
+      '@jridgewell/trace-mapping': 0.3.14
+    dev: true
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==
   /@jridgewell/resolve-uri/3.0.7:
     engines:
       node: '>=6.0.0'
     resolution:
       integrity: sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==
+  /@jridgewell/resolve-uri/3.0.8:
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-YK5G9LaddzGbcucK4c8h5tWFmMPBvRZ/uyWmN1/SbBdIvqGUdWGkJ5BAaccgs6XbzVLsqbPJrBSFwKv3kT9i7w==
   /@jridgewell/set-array/1.1.1:
     engines:
       node: '>=6.0.0'
     resolution:
       integrity: sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==
+  /@jridgewell/set-array/1.1.2:
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
   /@jridgewell/sourcemap-codec/1.4.13:
     resolution:
       integrity: sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==
+  /@jridgewell/sourcemap-codec/1.4.14:
+    resolution:
+      integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
   /@jridgewell/trace-mapping/0.3.13:
     dependencies:
       '@jridgewell/resolve-uri': 3.0.7
       '@jridgewell/sourcemap-codec': 1.4.13
     resolution:
       integrity: sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==
+  /@jridgewell/trace-mapping/0.3.14:
+    dependencies:
+      '@jridgewell/resolve-uri': 3.0.8
+      '@jridgewell/sourcemap-codec': 1.4.14
+    resolution:
+      integrity: sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==
   /@mapbox/node-pre-gyp/1.0.8:
     dependencies:
       detect-libc: 1.0.3
@@ -8348,6 +8657,15 @@ packages:
       rollup: ^1.20.0||^2.0.0
     resolution:
       integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
+  /@rollup/pluginutils/4.2.1:
+    dependencies:
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+    dev: true
+    engines:
+      node: '>= 8.0.0'
+    resolution:
+      integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==
   /@rooks/use-interval/4.11.2_react@17.0.1:
     dependencies:
       react: 17.0.1
@@ -11213,6 +11531,21 @@ packages:
       node: ^12.22.0 || ^14.17.0 || >=16.0.0
     resolution:
       integrity: sha512-oVIAfIQuq0x2TFDNLVavUn548WL+7hdhxYn+9j3YdJJXB7mH9dAmZNJsPDa7Jc+B9WGqoiex7GUDbyMxV0a/aw==
+  /@vitejs/plugin-react/1.3.2:
+    dependencies:
+      '@babel/core': 7.18.6
+      '@babel/plugin-transform-react-jsx': 7.18.6_@babel+core@7.18.6
+      '@babel/plugin-transform-react-jsx-development': 7.18.6_@babel+core@7.18.6
+      '@babel/plugin-transform-react-jsx-self': 7.18.6_@babel+core@7.18.6
+      '@babel/plugin-transform-react-jsx-source': 7.18.6_@babel+core@7.18.6
+      '@rollup/pluginutils': 4.2.1
+      react-refresh: 0.13.0
+      resolve: 1.22.1
+    dev: true
+    engines:
+      node: '>=12.0.0'
+    resolution:
+      integrity: sha512-aurBNmMo0kz1O4qRoY+FM4epSA39y3ShWGuqfLRA/3z0oEJAdtoSfgA3aO98/PCCHAqMaduLxIxErWrVKIFzXA==
   /@votingworks/qrdetect/1.0.1:
     dependencies:
       '@types/bindings': 1.5.0
@@ -12829,6 +13162,18 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==
+  /browserslist/4.21.1:
+    dependencies:
+      caniuse-lite: 1.0.30001361
+      electron-to-chromium: 1.4.174
+      node-releases: 2.0.5
+      update-browserslist-db: 1.0.4_browserslist@4.21.1
+    dev: true
+    engines:
+      node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7
+    hasBin: true
+    resolution:
+      integrity: sha512-Nq8MFCSrnJXSc88yliwlzQe3qNe3VntIjhsArW9IJOEPSHNx23FalwApUVbzAWABLhYJJ7y8AynWI/XM8OdfjQ==
   /bs-logger/0.2.6:
     dependencies:
       fast-json-stable-stringify: 2.1.0
@@ -13102,6 +13447,10 @@ packages:
   /caniuse-lite/1.0.30001341:
     resolution:
       integrity: sha512-2SodVrFFtvGENGCv0ChVJIDQ0KPaS1cg7/qtfMaICgeMolDdo/Z2OD32F0Aq9yl6F4YFwGPBS5AaPqNYiW4PoA==
+  /caniuse-lite/1.0.30001361:
+    dev: true
+    resolution:
+      integrity: sha512-ybhCrjNtkFji1/Wto6SSJKkWk6kZgVQsDq5QI83SafsF6FXv2JB4df9eEdH6g8sdGgqTXrFLjAxqBGgYoU3azQ==
   /canvas/2.9.1:
     dependencies:
       '@mapbox/node-pre-gyp': 1.0.8
@@ -14936,6 +15285,10 @@ packages:
   /electron-to-chromium/1.4.137:
     resolution:
       integrity: sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==
+  /electron-to-chromium/1.4.174:
+    dev: true
+    resolution:
+      integrity: sha512-JER+w+9MV2MBVFOXxP036bLlNOnzbYAWrWU8sNUwoOO69T3w4564WhM5H5atd8VVS8U4vpi0i0kdoYzm1NPQgQ==
   /elegant-spinner/1.0.1:
     dev: true
     engines:
@@ -18089,7 +18442,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 5.21.0_4059d5ee7aba256d5e330151ee3418c0
       '@typescript-eslint/utils': 5.22.0_eslint@7.17.0+typescript@4.6.3
       eslint: 7.17.0
-      jest: 26.6.3_canvas@2.9.1
+      jest: 26.6.3
     dev: true
     engines:
       node: ^12.22.0 || ^14.17.0 || >=16.0.0
@@ -19459,6 +19812,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
+  /estree-walker/2.0.2:
+    dev: true
+    resolution:
+      integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
   /esutils/2.0.3:
     engines:
       node: '>=0.10.0'
@@ -24767,7 +25124,7 @@ packages:
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
-      jest: 26.6.3_canvas@2.9.1
+      jest: 26.6.3
       jest-regex-util: 27.5.1
       jest-watcher: 27.5.1
       slash: 3.0.0
@@ -26772,6 +27129,10 @@ packages:
   /node-releases/2.0.4:
     resolution:
       integrity: sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==
+  /node-releases/2.0.5:
+    dev: true
+    resolution:
+      integrity: sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q==
   /nopt/5.0.0:
     dependencies:
       abbrev: 1.1.1
@@ -29187,6 +29548,12 @@ packages:
       react-dom: ^0.14.0 || ^15.0.0 || ^16 || ^17
     resolution:
       integrity: sha512-8surmulejafYCH9wfUmFyj4UfbSJwjcgbS9gf3oOItu4Hwd6ivJyVBETI0yHRhpJKCLZMUtnhzk76wXTsNL6Qg==
+  /react-refresh/0.13.0:
+    dev: true
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha512-XP8A9BT0CpRBD+NYLLeIhld/RqG9+gktUjW1FkE+Vm7OCinbG1SshcK5tb9ls4kzvjZr9mOQc7HYgBngEyPAXg==
   /react-refresh/0.8.3:
     dev: false
     engines:
@@ -29677,6 +30044,15 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==
+  /resolve/1.22.1:
+    dependencies:
+      is-core-module: 2.9.0
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+    dev: true
+    hasBin: true
+    resolution:
+      integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
   /resolve/2.0.0-next.3:
     dependencies:
       is-core-module: 2.6.0
@@ -31706,7 +32082,7 @@ packages:
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=
+      integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==
   /to-object-path/0.3.0:
     dependencies:
       kind-of: 3.2.2
@@ -32540,6 +32916,17 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
+  /update-browserslist-db/1.0.4_browserslist@4.21.1:
+    dependencies:
+      browserslist: 4.21.1
+      escalade: 3.1.1
+      picocolors: 1.0.0
+    dev: true
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+    resolution:
+      integrity: sha512-jnmO2BEGUjsMOe/Fg9u0oczOe/ppIDZPebzccl1yDWGLFP16Pa1/RM5wEoKYPG2zstNcDuAStejyxsOuKINdGA==
   /uri-js/4.4.1:
     dependencies:
       punycode: 2.1.1


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
`vite` works just fine with React without any special explicit plugin, but to enable HMR you do need to enable `@vitejs/plugin-react`. This PR does that.

## Demo Video or Screenshot
This video demonstrates that we can now edit a component without the whole app reloading, which would re-lock the app:

https://user-images.githubusercontent.com/1938/176762956-db9b6848-6e27-401e-a362-1ad2884ebf73.mov


## Testing Plan 
Tested manually as shown in the video above.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
