### PR TITLE
fix(frontends): do not assume we're at the root

### DIFF
--- a/frontends/bsd/src/components/election_configuration.tsx
+++ b/frontends/bsd/src/components/election_configuration.tsx
@@ -223,7 +223,7 @@ export function ElectionConfiguration({
           <Main padded>
             <Prose>
               <h1>No Election Ballot Package Files Found</h1>
-              <Image src="assets/usb-drive.svg" alt="Insert USB Image" />
+              <Image src="/assets/usb-drive.svg" alt="Insert USB Image" />
               <Text>
                 There were no Election Ballot Package files automatically found
                 on the inserted USB drive. Use VxAdmin to export Ballot Package
@@ -306,7 +306,7 @@ export function ElectionConfiguration({
       <Main padded centerChild>
         <Prose maxWidth={false}>
           <h1>Load Election Configuration</h1>
-          <Image src="assets/usb-drive.svg" alt="Insert USB Image" />
+          <Image src="/assets/usb-drive.svg" alt="Insert USB Image" />
           <p>You may load via the following methods:</p>
           <ul>
             <ListItem>

--- a/frontends/bsd/src/components/export_logs_modal.tsx
+++ b/frontends/bsd/src/components/export_logs_modal.tsx
@@ -232,7 +232,7 @@ export function ExportLogsModal({ onClose, logFileType }: Props): JSX.Element {
             <Prose>
               <h1>No USB Drive Detected</h1>
               <p>
-                <UsbImage src="assets/usb-drive.svg" alt="Insert USB Image" />
+                <UsbImage src="/assets/usb-drive.svg" alt="Insert USB Image" />
                 Please insert a USB drive where you would like the save the log
                 file.
               </p>

--- a/frontends/bsd/src/components/export_results_modal.tsx
+++ b/frontends/bsd/src/components/export_results_modal.tsx
@@ -229,7 +229,7 @@ export function ExportResultsModal({
               <h1>No USB Drive Detected</h1>
               <p>
                 <UsbImage
-                  src="assets/usb-drive.svg"
+                  src="/assets/usb-drive.svg"
                   alt="Insert USB Image"
                   onDoubleClick={() => exportResults(true)}
                 />
@@ -274,7 +274,7 @@ export function ExportResultsModal({
             <Prose>
               <h1>Export Results</h1>
               <UsbImage
-                src="assets/usb-drive.svg"
+                src="/assets/usb-drive.svg"
                 alt="Insert USB Image"
                 onDoubleClick={() => exportResults(true)}
               />

--- a/frontends/bsd/src/screens/machine_locked_screen.tsx
+++ b/frontends/bsd/src/screens/machine_locked_screen.tsx
@@ -23,7 +23,7 @@ export function MachineLockedScreen(): JSX.Element {
     <Screen>
       <Main padded centerChild>
         <div>
-          <LockedImage src="locked.svg" alt="Locked Icon" />
+          <LockedImage src="/locked.svg" alt="Locked Icon" />
           <Prose textCenter theme={fontSizeTheme.medium} maxWidth={false}>
             <h1>VxCentralScan is Locked</h1>
             <p>Insert an admin card to unlock.</p>

--- a/frontends/election-manager/src/components/export_election_ballot_package_modal_button.tsx
+++ b/frontends/election-manager/src/components/export_election_ballot_package_modal_button.tsx
@@ -212,7 +212,7 @@ export function ExportElectionBallotPackageModalButton(): JSX.Element {
               <h1>No USB Drive Detected</h1>
               <p>
                 <UsbImage
-                  src="assets/usb-drive.svg"
+                  src="/assets/usb-drive.svg"
                   alt="Insert USB Image"
                   // hidden feature to export with file dialog by double-clicking
                   onDoubleClick={() => saveFileCallback(true)}
@@ -246,7 +246,7 @@ export function ExportElectionBallotPackageModalButton(): JSX.Element {
             <Prose>
               <h1>Export Ballot Package</h1>
               <p>
-                <UsbImage src="assets/usb-drive.svg" alt="Insert USB Image" />A
+                <UsbImage src="/assets/usb-drive.svg" alt="Insert USB Image" />A
                 zip archive will automatically be saved to the default location
                 on the mounted USB drive. Optionally, you may pick a custom
                 export location.

--- a/frontends/election-manager/src/components/export_logs_modal.tsx
+++ b/frontends/election-manager/src/components/export_logs_modal.tsx
@@ -231,7 +231,7 @@ export function ExportLogsModal({ onClose, logFileType }: Props): JSX.Element {
             <Prose>
               <h1>No USB Drive Detected</h1>
               <p>
-                <UsbImage src="assets/usb-drive.svg" alt="Insert USB Image" />
+                <UsbImage src="/assets/usb-drive.svg" alt="Insert USB Image" />
                 Please insert a USB drive where you would like the save the log
                 file.
               </p>

--- a/frontends/election-manager/src/components/import_cvrfiles_modal.tsx
+++ b/frontends/election-manager/src/components/import_cvrfiles_modal.tsx
@@ -343,7 +343,7 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
           <Prose>
             <h1>No USB Drive Detected</h1>
             <p>
-              <UsbImage src="assets/usb-drive.svg" alt="Insert USB Image" />
+              <UsbImage src="/assets/usb-drive.svg" alt="Insert USB Image" />
               Please insert a USB drive in order to import CVR files from the
               scanner.
             </p>

--- a/frontends/election-manager/src/components/save_file_to_usb.tsx
+++ b/frontends/election-manager/src/components/save_file_to_usb.tsx
@@ -223,7 +223,7 @@ export function SaveFileToUsb({
             <Prose>
               <h1>No USB Drive Detected</h1>
               <p>
-                <UsbImage src="assets/usb-drive.svg" alt="Insert USB Image" />
+                <UsbImage src="/assets/usb-drive.svg" alt="Insert USB Image" />
                 Please insert a USB drive where you would like the save the{' '}
                 {fileName}.
               </p>

--- a/frontends/election-manager/src/screens/machine_locked_screen.tsx
+++ b/frontends/election-manager/src/screens/machine_locked_screen.tsx
@@ -22,7 +22,7 @@ export function MachineLockedScreen(): JSX.Element {
     <Screen>
       <Main centerChild>
         <div>
-          <LockedImage src="locked.svg" alt="Locked Icon" />
+          <LockedImage src="/locked.svg" alt="Locked Icon" />
           <Prose textCenter theme={fontSizeTheme.medium} maxWidth={false}>
             <h1>VxAdmin is Locked</h1>
             <p>Insert an admin card to unlock.</p>

--- a/libs/ui/src/__snapshots__/remove_card_page.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/remove_card_page.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`renders RemoveCardPage 1`] = `
   <img
     alt="Remove Card Icon"
     class="sc-dkPtyc edmGaq"
-    src="assets/remove-card.svg"
+    src="/assets/remove-card.svg"
   />
   <div
     class="sc-gsDJrp gbuPkE"

--- a/libs/ui/src/reboot_from_usb_button.tsx
+++ b/libs/ui/src/reboot_from_usb_button.tsx
@@ -130,7 +130,7 @@ export function RebootFromUsbButton({
           <Prose>
             <h1>No USB Drive Detected</h1>
             <p>
-              <UsbImage src="assets/usb-drive.svg" alt="Insert USB Image" />
+              <UsbImage src="/assets/usb-drive.svg" alt="Insert USB Image" />
               Please insert a USB drive to boot from.
             </p>
           </Prose>

--- a/libs/ui/src/remove_card_page.tsx
+++ b/libs/ui/src/remove_card_page.tsx
@@ -14,7 +14,7 @@ const RemoveCardImage = styled.img`
 export function RemoveCardPage(): JSX.Element {
   return (
     <Main padded centerChild>
-      <RemoveCardImage src="assets/remove-card.svg" alt="Remove Card Icon" />
+      <RemoveCardImage src="/assets/remove-card.svg" alt="Remove Card Icon" />
       <Prose textCenter theme={fontSizeTheme.medium} maxWidth={false}>
         <h1>Successfully Authenticated</h1>
         <p>Remove card.</p>


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
A bunch of asset URLs were set relative to the current URL rather than the root of the domain. This means we'd end up with a broken image if you reload the page when at a path other than `/`.

## Demo Video or Screenshot

https://user-images.githubusercontent.com/1938/176764545-adc9746c-0f3c-4474-a897-592b75304a73.mov

## Testing Plan
Tested as above in the video. 

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
