### PR TITLE
refactor(logging): Add fakeLogger test util

### DIFF
--- a/frontends/bsd/src/components/export_logs_modal.test.tsx
+++ b/frontends/bsd/src/components/export_logs_modal.test.tsx
@@ -8,7 +8,7 @@ import {
 } from '@votingworks/test-utils';
 import { LogFileType, usbstick } from '@votingworks/utils';
 
-import { LogEventId, Logger, LogSource } from '@votingworks/logging';
+import { fakeLogger, LogEventId } from '@votingworks/logging';
 import { ExportLogsModal } from './export_logs_modal';
 import { renderInAppContext } from '../../test/render_in_app_context';
 
@@ -49,8 +49,7 @@ test('renders no log file found when usb is mounted but no log file on machine',
     { ...fileSystemEntry, name: 'not-the-right-file.log' },
   ]);
   mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
-  const logger = new Logger(LogSource.VxAdminFrontend);
-  const logSpy = jest.spyOn(logger, 'log').mockResolvedValue();
+  const logger = fakeLogger();
 
   const { getByText } = renderInAppContext(
     <ExportLogsModal onClose={closeFn} logFileType={LogFileType.Raw} />,
@@ -62,7 +61,7 @@ test('renders no log file found when usb is mounted but no log file on machine',
   getByText('Loading');
   await advanceTimersAndPromises();
   getByText('No Log File Present');
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.ExportLogFileFound,
     'admin',
     expect.objectContaining({ disposition: 'failure' })
@@ -114,8 +113,7 @@ test('renders save modal when usb is mounted and saves log file on machine', asy
   ]);
   mockKiosk.readFile.mockResolvedValue('this-is-my-file-content');
   mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
-  const logger = new Logger(LogSource.VxAdminFrontend);
-  const logSpy = jest.spyOn(logger, 'log').mockResolvedValue();
+  const logger = fakeLogger();
   const logCdfSpy = jest
     .spyOn(logger, 'buildCDFLog')
     .mockReturnValue('this-is-the-cdf-content');
@@ -130,7 +128,7 @@ test('renders save modal when usb is mounted and saves log file on machine', asy
   getByText('Loading');
   await advanceTimersAndPromises();
   getByText('Save Logs');
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.ExportLogFileFound,
     'admin',
     expect.objectContaining({ disposition: 'success' })
@@ -154,7 +152,7 @@ test('renders save modal when usb is mounted and saves log file on machine', asy
   fireEvent.click(getByText('Close'));
   expect(closeFn).toHaveBeenCalled();
 
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.FileSaved,
     'admin',
     expect.objectContaining({
@@ -175,8 +173,7 @@ test('renders save modal when usb is mounted and saves cdf log file on machine',
   ]);
   mockKiosk.readFile.mockResolvedValue('this-is-my-raw-file-content');
   mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
-  const logger = new Logger(LogSource.VxAdminFrontend);
-  const logSpy = jest.spyOn(logger, 'log').mockResolvedValue();
+  const logger = fakeLogger();
   logger.buildCDFLog = jest.fn().mockReturnValue('this-is-the-cdf-content');
 
   const { getByText } = renderInAppContext(
@@ -189,7 +186,7 @@ test('renders save modal when usb is mounted and saves cdf log file on machine',
   getByText('Loading');
   await advanceTimersAndPromises();
   getByText('Save Logs');
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.ExportLogFileFound,
     'admin',
     expect.objectContaining({ disposition: 'success' })
@@ -213,7 +210,7 @@ test('renders save modal when usb is mounted and saves cdf log file on machine',
   fireEvent.click(getByText('Close'));
   expect(closeFn).toHaveBeenCalled();
 
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.FileSaved,
     'admin',
     expect.objectContaining({
@@ -230,8 +227,7 @@ test('render export modal with errors when appropriate', async () => {
   mockKiosk.getFileSystemEntries.mockResolvedValueOnce([
     { ...fileSystemEntry, name: 'vx-logs.log' },
   ]);
-  const logger = new Logger(LogSource.VxAdminFrontend);
-  const logSpy = jest.spyOn(logger, 'log').mockResolvedValue();
+  const logger = fakeLogger();
 
   mockKiosk.readFile.mockRejectedValueOnce(new Error('this-is-an-error'));
 
@@ -255,7 +251,7 @@ test('render export modal with errors when appropriate', async () => {
 
   fireEvent.click(getByText('Close'));
   expect(closeFn).toHaveBeenCalled();
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.FileSaved,
     'admin',
     expect.objectContaining({

--- a/frontends/bsd/src/screens/ballot_eject_screen.test.tsx
+++ b/frontends/bsd/src/screens/ballot_eject_screen.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { LogEventId, Logger, LogSource } from '@votingworks/logging';
+import { fakeLogger, LogEventId } from '@votingworks/logging';
 import { AdjudicationReason, BallotType } from '@votingworks/types';
 import { Scan } from '@votingworks/api';
 import { typedAs } from '@votingworks/utils';
@@ -30,8 +30,7 @@ test('says the sheet is unreadable if it is', async () => {
     })
   );
 
-  const logger = new Logger(LogSource.VxCentralScanFrontend);
-  const logSpy = jest.spyOn(logger, 'log');
+  const logger = fakeLogger();
   const continueScanning = jest.fn();
 
   const { container, getByText } = renderInAppContext(
@@ -45,8 +44,8 @@ test('says the sheet is unreadable if it is', async () => {
 
   expect(container).toMatchSnapshot();
 
-  expect(logSpy).toHaveBeenCalledTimes(1);
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledTimes(1);
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.ScanAdjudicationInfo,
     'admin',
     expect.objectContaining({
@@ -130,8 +129,7 @@ test('says the ballot sheet is overvoted if it is', async () => {
   );
 
   const continueScanning = jest.fn();
-  const logger = new Logger(LogSource.VxCentralScanFrontend);
-  const logSpy = jest.spyOn(logger, 'log');
+  const logger = fakeLogger();
 
   const { container, getByText } = renderInAppContext(
     <BallotEjectScreen continueScanning={continueScanning} isTestMode />,
@@ -144,8 +142,8 @@ test('says the ballot sheet is overvoted if it is', async () => {
 
   expect(container).toMatchSnapshot();
 
-  expect(logSpy).toHaveBeenCalledTimes(1);
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledTimes(1);
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.ScanAdjudicationInfo,
     'admin',
     expect.objectContaining({
@@ -241,8 +239,7 @@ test('says the ballot sheet is undervoted if it is', async () => {
   );
 
   const continueScanning = jest.fn();
-  const logger = new Logger(LogSource.VxCentralScanFrontend);
-  const logSpy = jest.spyOn(logger, 'log');
+  const logger = fakeLogger();
 
   const { container, getByText } = renderInAppContext(
     <BallotEjectScreen continueScanning={continueScanning} isTestMode />,
@@ -254,8 +251,8 @@ test('says the ballot sheet is undervoted if it is', async () => {
   });
 
   expect(container).toMatchSnapshot();
-  expect(logSpy).toHaveBeenCalledTimes(1);
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledTimes(1);
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.ScanAdjudicationInfo,
     'admin',
     expect.objectContaining({
@@ -358,8 +355,7 @@ test('says the ballot sheet is blank if it is', async () => {
   );
 
   const continueScanning = jest.fn();
-  const logger = new Logger(LogSource.VxCentralScanFrontend);
-  const logSpy = jest.spyOn(logger, 'log');
+  const logger = fakeLogger();
 
   const { container, getByText } = renderInAppContext(
     <BallotEjectScreen continueScanning={continueScanning} isTestMode />,
@@ -371,8 +367,8 @@ test('says the ballot sheet is blank if it is', async () => {
   });
 
   expect(container).toMatchSnapshot();
-  expect(logSpy).toHaveBeenCalledTimes(1);
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledTimes(1);
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.ScanAdjudicationInfo,
     'admin',
     expect.objectContaining({
@@ -438,8 +434,7 @@ test('calls out live ballot sheets in test mode', async () => {
   );
 
   const continueScanning = jest.fn();
-  const logger = new Logger(LogSource.VxCentralScanFrontend);
-  const logSpy = jest.spyOn(logger, 'log');
+  const logger = fakeLogger();
 
   const { container, getByText } = renderInAppContext(
     <BallotEjectScreen continueScanning={continueScanning} isTestMode />,
@@ -451,8 +446,8 @@ test('calls out live ballot sheets in test mode', async () => {
   });
 
   expect(container).toMatchSnapshot();
-  expect(logSpy).toHaveBeenCalledTimes(1);
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledTimes(1);
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.ScanAdjudicationInfo,
     'admin',
     expect.objectContaining({
@@ -507,8 +502,7 @@ test('calls out test ballot sheets in live mode', async () => {
   );
 
   const continueScanning = jest.fn();
-  const logger = new Logger(LogSource.VxCentralScanFrontend);
-  const logSpy = jest.spyOn(logger, 'log');
+  const logger = fakeLogger();
 
   const { container, getByText } = renderInAppContext(
     <BallotEjectScreen
@@ -523,8 +517,8 @@ test('calls out test ballot sheets in live mode', async () => {
   });
 
   expect(container).toMatchSnapshot();
-  expect(logSpy).toHaveBeenCalledTimes(1);
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledTimes(1);
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.ScanAdjudicationInfo,
     'admin',
     expect.objectContaining({
@@ -561,8 +555,7 @@ test('shows invalid election screen when appropriate', async () => {
   );
 
   const continueScanning = jest.fn();
-  const logger = new Logger(LogSource.VxCentralScanFrontend);
-  const logSpy = jest.spyOn(logger, 'log');
+  const logger = fakeLogger();
 
   const { getByText, queryAllByText } = renderInAppContext(
     <BallotEjectScreen
@@ -579,8 +572,8 @@ test('shows invalid election screen when appropriate', async () => {
   getByText('Wrong Election');
   getByText('Ballot Election Hash: this-is-a-');
   expect(queryAllByText('Tabulate Duplicate Ballot').length).toBe(0);
-  expect(logSpy).toHaveBeenCalledTimes(1);
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledTimes(1);
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.ScanAdjudicationInfo,
     'admin',
     expect.objectContaining({
@@ -634,8 +627,7 @@ test('shows invalid precinct screen when appropriate', async () => {
     })
   );
 
-  const logger = new Logger(LogSource.VxCentralScanFrontend);
-  const logSpy = jest.spyOn(logger, 'log');
+  const logger = fakeLogger();
   const continueScanning = jest.fn();
 
   const { getByText, queryAllByText } = renderInAppContext(
@@ -650,8 +642,8 @@ test('shows invalid precinct screen when appropriate', async () => {
     await waitFor(() => fetchMock.called);
   });
 
-  expect(logSpy).toHaveBeenCalledTimes(1);
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledTimes(1);
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.ScanAdjudicationInfo,
     'admin',
     expect.objectContaining({
@@ -832,8 +824,7 @@ test('does NOT say ballot is blank if one side is blank and the other requires w
     );
 
     const continueScanning = jest.fn();
-    const logger = new Logger(LogSource.VxCentralScanFrontend);
-    const logSpy = jest.spyOn(logger, 'log');
+    const logger = fakeLogger();
 
     const { unmount } = renderInAppContext(
       <BallotEjectScreen continueScanning={continueScanning} isTestMode />,
@@ -844,8 +835,8 @@ test('does NOT say ballot is blank if one side is blank and the other requires w
       await waitFor(() => fetchMock.called);
     });
 
-    expect(logSpy).toHaveBeenCalledTimes(1);
-    expect(logSpy).toHaveBeenCalledWith(
+    expect(logger.log).toHaveBeenCalledTimes(1);
+    expect(logger.log).toHaveBeenCalledWith(
       LogEventId.ScanAdjudicationInfo,
       'admin',
       expect.objectContaining({

--- a/frontends/election-manager/src/components/export_election_ballot_package_modal_button.test.tsx
+++ b/frontends/election-manager/src/components/export_election_ballot_package_modal_button.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, waitFor } from '@testing-library/react';
 import { interpretTemplate } from '@votingworks/ballot-interpreter-vx';
-import { LogEventId, Logger, LogSource } from '@votingworks/logging';
+import { fakeLogger, LogEventId } from '@votingworks/logging';
 import { fakeKiosk, fakeUsbDrive, mockOf } from '@votingworks/test-utils';
 import { usbstick } from '@votingworks/utils';
 import React from 'react';
@@ -123,8 +123,7 @@ test('Modal renders insert usb screen appropriately', async () => {
 });
 
 test('Modal renders export confirmation screen when usb detected and manual link works as expected', async () => {
-  const logger = new Logger(LogSource.VxAdminFrontend);
-  const logSpy = jest.spyOn(logger, 'log').mockResolvedValue();
+  const logger = fakeLogger();
   const { getByText, queryAllByText, queryAllByAltText, queryAllByTestId } =
     renderInAppContext(<ExportElectionBallotPackageModalButton />, {
       usbDriveStatus: UsbDriveStatus.mounted,
@@ -158,11 +157,11 @@ test('Modal renders export confirmation screen when usb detected and manual link
     );
     expect(window.kiosk!.saveAs).toHaveBeenCalledTimes(1);
   });
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.ExportBallotPackageInit,
     'admin'
   );
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.ExportBallotPackageComplete,
     'admin',
     expect.objectContaining({ disposition: 'success' })
@@ -193,8 +192,7 @@ test('Modal renders loading screen when usb drive is mounting or ejecting', asyn
 });
 
 test('Modal renders error message appropriately', async () => {
-  const logger = new Logger(LogSource.VxAdminFrontend);
-  const logSpy = jest.spyOn(logger, 'log').mockResolvedValue();
+  const logger = fakeLogger();
   window.kiosk!.saveAs = jest.fn().mockResolvedValue(undefined);
   const { queryAllByTestId, getByText, queryAllByText } = renderInAppContext(
     <ExportElectionBallotPackageModalButton />,
@@ -217,11 +215,11 @@ test('Modal renders error message appropriately', async () => {
 
   fireEvent.click(getByText('Close'));
   expect(queryAllByTestId('modal')).toHaveLength(0);
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.ExportBallotPackageInit,
     'admin'
   );
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.ExportBallotPackageComplete,
     'admin',
     expect.objectContaining({ disposition: 'failure' })

--- a/frontends/election-manager/src/components/export_logs_modal.test.tsx
+++ b/frontends/election-manager/src/components/export_logs_modal.test.tsx
@@ -8,7 +8,7 @@ import {
 } from '@votingworks/test-utils';
 import { LogFileType, usbstick } from '@votingworks/utils';
 
-import { LogEventId, Logger, LogSource } from '@votingworks/logging';
+import { fakeLogger, LogEventId } from '@votingworks/logging';
 import { ExportLogsModal } from './export_logs_modal';
 import { renderInAppContext } from '../../test/render_in_app_context';
 
@@ -49,8 +49,7 @@ test('renders no log file found when usb is mounted but no log file on machine',
     { ...fileSystemEntry, name: 'not-the-right-file.log' },
   ]);
   mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
-  const logger = new Logger(LogSource.VxAdminFrontend);
-  const logSpy = jest.spyOn(logger, 'log').mockResolvedValue();
+  const logger = fakeLogger();
 
   const { getByText } = renderInAppContext(
     <ExportLogsModal onClose={closeFn} logFileType={LogFileType.Raw} />,
@@ -62,7 +61,7 @@ test('renders no log file found when usb is mounted but no log file on machine',
   getByText('Loading');
   await advanceTimersAndPromises();
   getByText('No Log File Present');
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.ExportLogFileFound,
     'admin',
     expect.objectContaining({ disposition: 'failure' })
@@ -114,8 +113,7 @@ test('renders save modal when usb is mounted and saves log file on machine', asy
   ]);
   mockKiosk.readFile.mockResolvedValue('this-is-my-file-content');
   mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
-  const logger = new Logger(LogSource.VxAdminFrontend);
-  const logSpy = jest.spyOn(logger, 'log').mockResolvedValue();
+  const logger = fakeLogger();
   const logCdfSpy = jest
     .spyOn(logger, 'buildCDFLog')
     .mockReturnValue('this-is-the-cdf-content');
@@ -130,7 +128,7 @@ test('renders save modal when usb is mounted and saves log file on machine', asy
   getByText('Loading');
   await advanceTimersAndPromises();
   getByText('Save Logs');
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.ExportLogFileFound,
     'admin',
     expect.objectContaining({ disposition: 'success' })
@@ -154,7 +152,7 @@ test('renders save modal when usb is mounted and saves log file on machine', asy
   fireEvent.click(getByText('Close'));
   expect(closeFn).toHaveBeenCalled();
 
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.FileSaved,
     'admin',
     expect.objectContaining({
@@ -175,8 +173,7 @@ test('renders save modal when usb is mounted and saves cdf log file on machine',
   ]);
   mockKiosk.readFile.mockResolvedValue('this-is-my-raw-file-content');
   mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
-  const logger = new Logger(LogSource.VxAdminFrontend);
-  const logSpy = jest.spyOn(logger, 'log').mockResolvedValue();
+  const logger = fakeLogger();
   logger.buildCDFLog = jest.fn().mockReturnValue('this-is-the-cdf-content');
 
   const { getByText } = renderInAppContext(
@@ -189,7 +186,7 @@ test('renders save modal when usb is mounted and saves cdf log file on machine',
   getByText('Loading');
   await advanceTimersAndPromises();
   getByText('Save Logs');
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.ExportLogFileFound,
     'admin',
     expect.objectContaining({ disposition: 'success' })
@@ -213,7 +210,7 @@ test('renders save modal when usb is mounted and saves cdf log file on machine',
   fireEvent.click(getByText('Close'));
   expect(closeFn).toHaveBeenCalled();
 
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.FileSaved,
     'admin',
     expect.objectContaining({
@@ -230,8 +227,7 @@ test('render export modal with errors when appropriate', async () => {
   mockKiosk.getFileSystemEntries.mockResolvedValueOnce([
     { ...fileSystemEntry, name: 'vx-logs.log' },
   ]);
-  const logger = new Logger(LogSource.VxAdminFrontend);
-  const logSpy = jest.spyOn(logger, 'log').mockResolvedValue();
+  const logger = fakeLogger();
 
   mockKiosk.readFile.mockRejectedValueOnce(new Error('this-is-an-error'));
 
@@ -255,7 +251,7 @@ test('render export modal with errors when appropriate', async () => {
 
   fireEvent.click(getByText('Close'));
   expect(closeFn).toHaveBeenCalled();
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.FileSaved,
     'admin',
     expect.objectContaining({

--- a/frontends/election-manager/src/components/import_cvrfiles_modal.test.tsx
+++ b/frontends/election-manager/src/components/import_cvrfiles_modal.test.tsx
@@ -9,7 +9,7 @@ import { fakeKiosk, fakeUsbDrive } from '@votingworks/test-utils';
 
 import { usbstick } from '@votingworks/utils';
 import { BallotIdSchema, unsafeParse } from '@votingworks/types';
-import { LogEventId, Logger, LogSource } from '@votingworks/logging';
+import { fakeLogger, LogEventId } from '@votingworks/logging';
 import { ImportCvrFilesModal } from './import_cvrfiles_modal';
 import {
   renderInAppContext,
@@ -73,8 +73,7 @@ describe('Screens display properly when USB is mounted', () => {
   test('No files found screen shows when mounted usb has no valid files', async () => {
     const closeFn = jest.fn();
     const saveCvr = jest.fn();
-    const logger = new Logger(LogSource.VxAdminFrontend);
-    const logSpy = jest.spyOn(logger, 'log').mockResolvedValue();
+    const logger = fakeLogger();
     const { getByText, getByTestId } = renderInAppContext(
       <ImportCvrFilesModal onClose={closeFn} />,
       {
@@ -98,7 +97,7 @@ describe('Screens display properly when USB is mounted', () => {
     });
     await waitFor(() => getByText('0 new CVRs Imported'));
     expect(saveCvr).toHaveBeenCalledTimes(1);
-    expect(logSpy).toHaveBeenCalledWith(
+    expect(logger.log).toHaveBeenCalledWith(
       LogEventId.CvrFilesReadFromUsb,
       'admin',
       expect.objectContaining({ disposition: 'success' })
@@ -128,8 +127,7 @@ describe('Screens display properly when USB is mounted', () => {
     window.kiosk!.getFileSystemEntries = jest
       .fn()
       .mockResolvedValue(fileEntries);
-    const logger = new Logger(LogSource.VxAdminFrontend);
-    const logSpy = jest.spyOn(logger, 'log').mockResolvedValue();
+    const logger = fakeLogger();
     const { getByText, getAllByTestId } = renderInAppContext(
       <ImportCvrFilesModal onClose={closeFn} />,
       {
@@ -161,7 +159,7 @@ describe('Screens display properly when USB is mounted', () => {
       domGetByText(tableRows[2], 'Import').closest('button')!.disabled
     ).toBe(false);
     expect(window.kiosk!.readFile).toHaveBeenCalledTimes(3); // The files should have been read.
-    expect(logSpy).toHaveBeenCalledWith(
+    expect(logger.log).toHaveBeenCalledWith(
       LogEventId.CvrFilesReadFromUsb,
       'admin',
       expect.objectContaining({ disposition: 'success' })
@@ -177,7 +175,7 @@ describe('Screens display properly when USB is mounted', () => {
       // We should not need to read the file another time since it was already read.
       expect(window.kiosk!.readFile).toHaveBeenCalledTimes(3);
       getByText('0 new CVRs Imported');
-      expect(logSpy).toHaveBeenCalledWith(
+      expect(logger.log).toHaveBeenCalledWith(
         LogEventId.CvrImported,
         'admin',
         expect.objectContaining({ disposition: 'success' })
@@ -188,8 +186,7 @@ describe('Screens display properly when USB is mounted', () => {
   test('Can handle errors appropriately', async () => {
     const closeFn = jest.fn();
     const saveCvr = jest.fn();
-    const logger = new Logger(LogSource.VxAdminFrontend);
-    const logSpy = jest.spyOn(logger, 'log').mockResolvedValue();
+    const logger = fakeLogger();
     const fileEntries = [
       {
         name: LIVE_FILE1,
@@ -226,7 +223,7 @@ describe('Screens display properly when USB is mounted', () => {
     getByText(
       /There were no new CVR files automatically found on this USB drive./
     );
-    expect(logSpy).toHaveBeenCalledWith(
+    expect(logger.log).toHaveBeenCalledWith(
       LogEventId.CvrFilesReadFromUsb,
       'admin',
       expect.objectContaining({ disposition: 'success' })
@@ -242,7 +239,7 @@ describe('Screens display properly when USB is mounted', () => {
       // There should be an error importing the file.
       getByText('Error');
       getByText(/There was an error reading the content of the file/);
-      expect(logSpy).toHaveBeenCalledWith(
+      expect(logger.log).toHaveBeenCalledWith(
         LogEventId.CvrImported,
         'admin',
         expect.objectContaining({ disposition: 'failure' })
@@ -253,8 +250,7 @@ describe('Screens display properly when USB is mounted', () => {
   test('Import CVR files screen locks to test mode when test files have been imported', async () => {
     const closeFn = jest.fn();
     const saveCvr = jest.fn();
-    const logger = new Logger(LogSource.VxAdminFrontend);
-    const logSpy = jest.spyOn(logger, 'log').mockResolvedValue();
+    const logger = fakeLogger();
     const fileEntries = [
       {
         name: LIVE_FILE1,
@@ -353,7 +349,7 @@ describe('Screens display properly when USB is mounted', () => {
       getByText(
         'The selected file was ignored as a duplicate of a previously imported file.'
       );
-      expect(logSpy).toHaveBeenCalledWith(
+      expect(logger.log).toHaveBeenCalledWith(
         LogEventId.CvrImported,
         'admin',
         expect.objectContaining({ disposition: 'failure' })

--- a/frontends/election-manager/src/components/save_file_to_usb.test.tsx
+++ b/frontends/election-manager/src/components/save_file_to_usb.test.tsx
@@ -4,7 +4,7 @@ import { fireEvent, waitFor } from '@testing-library/react';
 import { fakeKiosk, fakeUsbDrive } from '@votingworks/test-utils';
 import { usbstick } from '@votingworks/utils';
 
-import { LogEventId, Logger, LogSource } from '@votingworks/logging';
+import { fakeLogger, LogEventId } from '@votingworks/logging';
 import { SaveFileToUsb, FileType } from './save_file_to_usb';
 import { renderInAppContext } from '../../test/render_in_app_context';
 
@@ -75,8 +75,7 @@ test('renders save screen when usb is mounted with ballot filetype', async () =>
   const mockKiosk = fakeKiosk();
   window.kiosk = mockKiosk;
   mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
-  const logger = new Logger(LogSource.VxAdminFrontend);
-  const logSpy = jest.spyOn(logger, 'log').mockResolvedValue();
+  const logger = fakeLogger();
 
   const { getByText, queryAllByText } = renderInAppContext(
     <SaveFileToUsb
@@ -114,7 +113,7 @@ test('renders save screen when usb is mounted with ballot filetype', async () =>
   // Does not show eject usb by default
   expect(queryAllByText('You may now eject the USB drive.')).toHaveLength(0);
   expect(queryAllByText('Eject USB')).toHaveLength(0);
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.FileSaved,
     'admin',
     expect.objectContaining({
@@ -134,8 +133,7 @@ test('renders save screen when usb is mounted with results filetype and prompts 
   const mockKiosk = fakeKiosk();
   window.kiosk = mockKiosk;
   mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
-  const logger = new Logger(LogSource.VxAdminFrontend);
-  const logSpy = jest.spyOn(logger, 'log').mockResolvedValue();
+  const logger = fakeLogger();
 
   const { getByText } = renderInAppContext(
     <SaveFileToUsb
@@ -173,7 +171,7 @@ test('renders save screen when usb is mounted with results filetype and prompts 
   expect(closeFn).toHaveBeenCalled();
   getByText('You may now eject the USB drive.');
   getByText('Eject USB');
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.FileSaved,
     'admin',
     expect.objectContaining({
@@ -187,8 +185,7 @@ test('renders save screen when usb is mounted with results filetype and prompts 
 test('render export modal with errors when appropriate', async () => {
   const mockKiosk = fakeKiosk();
   window.kiosk = mockKiosk;
-  const logger = new Logger(LogSource.VxAdminFrontend);
-  const logSpy = jest.spyOn(logger, 'log').mockResolvedValue();
+  const logger = fakeLogger();
 
   const fileContentFn = jest
     .fn()
@@ -217,7 +214,7 @@ test('render export modal with errors when appropriate', async () => {
 
   fireEvent.click(getByText('Close'));
   expect(closeFn).toHaveBeenCalled();
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.FileSaved,
     'admin',
     expect.objectContaining({

--- a/frontends/election-manager/src/screens/manual_data_import_precinct_screen.test.tsx
+++ b/frontends/election-manager/src/screens/manual_data_import_precinct_screen.test.tsx
@@ -14,7 +14,7 @@ import {
   TallyCategory,
   VotingMethod,
 } from '@votingworks/types';
-import { Logger, LogEventId, LogSource } from '@votingworks/logging';
+import { fakeLogger, LogEventId } from '@votingworks/logging';
 import { renderInAppContext } from '../../test/render_in_app_context';
 import {
   getEmptyExternalTalliesByPrecinct,
@@ -106,8 +106,7 @@ test('displays correct contests for each precinct', () => {
 
 test('can enter data for candidate contests as expected', async () => {
   const saveExternalTallies = jest.fn();
-  const logger = new Logger(LogSource.VxAdminFrontend);
-  const logSpy = jest.spyOn(logger, 'log');
+  const logger = fakeLogger();
   const { getByText, queryAllByTestId, getByTestId } = renderInAppContext(
     <Route path="/tally/manual-data-import/precinct/:precinctId">
       <ManualDataImportPrecinctScreen />
@@ -160,7 +159,7 @@ test('can enter data for candidate contests as expected', async () => {
   expect(queryAllByTestId('president-write-in').length).toBe(0);
   fireEvent.click(getByText('Save Precinct Results for Center Springfield'));
   await waitFor(() =>
-    expect(logSpy).toHaveBeenCalledWith(
+    expect(logger.log).toHaveBeenCalledWith(
       LogEventId.ManualTallyDataEdited,
       'admin',
       expect.objectContaining({ disposition: 'success' })
@@ -191,8 +190,7 @@ test('can enter data for candidate contests as expected', async () => {
 
 test('can enter data for candidate contest with a write in row as expected', async () => {
   const saveExternalTallies = jest.fn();
-  const logger = new Logger(LogSource.VxAdminFrontend);
-  const logSpy = jest.spyOn(logger, 'log');
+  const logger = fakeLogger();
   const { getByText, getByTestId } = renderInAppContext(
     <Route path="/tally/manual-data-import/precinct/:precinctId">
       <ManualDataImportPrecinctScreen />
@@ -223,7 +221,7 @@ test('can enter data for candidate contest with a write in row as expected', asy
   );
   fireEvent.click(getByText('Save Precinct Results for Center Springfield'));
   await waitFor(() =>
-    expect(logSpy).toHaveBeenCalledWith(
+    expect(logger.log).toHaveBeenCalledWith(
       LogEventId.ManualTallyDataEdited,
       'admin',
       expect.objectContaining({ disposition: 'success' })
@@ -249,8 +247,7 @@ test('can enter data for candidate contest with a write in row as expected', asy
 
 test('can enter data for yes no contests as expected', async () => {
   const saveExternalTallies = jest.fn();
-  const logger = new Logger(LogSource.VxAdminFrontend);
-  const logSpy = jest.spyOn(logger, 'log');
+  const logger = fakeLogger();
   const { getByText, queryAllByTestId, getByTestId } = renderInAppContext(
     <Route path="/tally/manual-data-import/precinct/:precinctId">
       <ManualDataImportPrecinctScreen />
@@ -313,7 +310,7 @@ test('can enter data for yes no contests as expected', async () => {
   expect(queryAllByTestId('president-write-in').length).toBe(0);
   fireEvent.click(getByText('Save Precinct Results for Center Springfield'));
   await waitFor(() =>
-    expect(logSpy).toHaveBeenCalledWith(
+    expect(logger.log).toHaveBeenCalledWith(
       LogEventId.ManualTallyDataEdited,
       'admin',
       expect.objectContaining({ disposition: 'success' })

--- a/libs/logging/src/index.ts
+++ b/libs/logging/src/index.ts
@@ -4,3 +4,4 @@ export * from './types';
 export * from './log_event_ids';
 export * from './log_event_types';
 export * from './log_source';
+export * from './test_utils';

--- a/libs/logging/src/test_utils.test.ts
+++ b/libs/logging/src/test_utils.test.ts
@@ -1,0 +1,8 @@
+import { LogEventId } from './log_event_ids';
+import { fakeLogger } from './test_utils';
+
+test('fakeLogger returns a logger with a spy on logger.log', async () => {
+  const logger = fakeLogger();
+  await logger.log(LogEventId.MachineBootInit, 'system');
+  expect(logger.log).toHaveBeenCalledWith(LogEventId.MachineBootInit, 'system');
+});

--- a/libs/logging/src/test_utils.ts
+++ b/libs/logging/src/test_utils.ts
@@ -1,0 +1,8 @@
+import { Logger } from './logger';
+import { LogSource } from './log_source';
+
+export function fakeLogger(logSource: LogSource = LogSource.System): Logger {
+  const logger = new Logger(logSource);
+  jest.spyOn(logger, 'log').mockResolvedValue();
+  return logger;
+}

--- a/libs/ui/src/hooks/use_devices.test.ts
+++ b/libs/ui/src/hooks/use_devices.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react-hooks';
-import { Logger, LogSource, LogEventId } from '@votingworks/logging';
+import { LogEventId, fakeLogger } from '@votingworks/logging';
 import { fakeMarkerInfo } from '@votingworks/test-utils';
 import {
   AccessibleControllerProductId,
@@ -31,13 +31,12 @@ const emptyDevices: Devices = {
 
 test('can connect printer as expected', async () => {
   const hardware = new MemoryHardware();
-  const fakeLogger = new Logger(LogSource.VxCentralScanFrontend);
-  const logSpy = jest.spyOn(fakeLogger, 'log').mockResolvedValue();
+  const logger = fakeLogger();
   const { result, rerender, waitForNextUpdate } = renderHook(() =>
-    useDevices({ hardware, logger: fakeLogger })
+    useDevices({ hardware, logger })
   );
   expect(result.current).toEqual(emptyDevices);
-  expect(logSpy).toHaveBeenCalledTimes(0);
+  expect(logger.log).toHaveBeenCalledTimes(0);
 
   const expectedPrinter: Devices['printer'] = {
     connected: true,
@@ -52,8 +51,8 @@ test('can connect printer as expected', async () => {
   act(() => hardware.setPrinterConnected(true));
   rerender();
   expect(result.current.printer).toEqual(expectedPrinter);
-  expect(logSpy).toHaveBeenCalledTimes(2);
-  expect(logSpy).toHaveBeenNthCalledWith(
+  expect(logger.log).toHaveBeenCalledTimes(2);
+  expect(logger.log).toHaveBeenNthCalledWith(
     1,
     LogEventId.PrinterConfigurationAdded,
     'system',
@@ -66,7 +65,7 @@ test('can connect printer as expected', async () => {
   act(() => hardware.setPrinterConnected(false));
   rerender();
   expect(result.current.printer).toBeUndefined();
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.PrinterConnectionUpdate,
     'system',
     expect.objectContaining({
@@ -78,7 +77,7 @@ test('can connect printer as expected', async () => {
   act(() => hardware.setPrinterConnected(true));
   rerender();
   expect(result.current.printer).toEqual(expectedPrinter);
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.PrinterConnectionUpdate,
     'system',
     expect.objectContaining({
@@ -90,7 +89,7 @@ test('can connect printer as expected', async () => {
   act(() => hardware.detachAllPrinters());
   rerender();
   expect(result.current.printer).toBeUndefined();
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.PrinterConfigurationRemoved,
     'system',
     expect.objectContaining({
@@ -104,13 +103,12 @@ test('can connect printer as expected', async () => {
 
 test('can connect card reader as expected', async () => {
   const hardware = new MemoryHardware();
-  const fakeLogger = new Logger(LogSource.VxCentralScanFrontend);
-  const logSpy = jest.spyOn(fakeLogger, 'log').mockResolvedValue();
+  const logger = fakeLogger();
   const { result, rerender, waitForNextUpdate } = renderHook(() =>
-    useDevices({ hardware, logger: fakeLogger })
+    useDevices({ hardware, logger })
   );
   expect(result.current).toEqual(emptyDevices);
-  expect(logSpy).toHaveBeenCalledTimes(0);
+  expect(logger.log).toHaveBeenCalledTimes(0);
 
   const expectedCardReader: Devices['cardReader'] = {
     deviceAddress: 0,
@@ -125,8 +123,8 @@ test('can connect card reader as expected', async () => {
   act(() => hardware.setCardReaderConnected(true));
   rerender();
   expect(result.current.cardReader).toEqual(expectedCardReader);
-  expect(logSpy).toHaveBeenCalledTimes(1);
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledTimes(1);
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.DeviceAttached,
     'system',
     expect.objectContaining({
@@ -139,8 +137,8 @@ test('can connect card reader as expected', async () => {
   act(() => hardware.setCardReaderConnected(false));
   rerender();
   expect(result.current.cardReader).toBeUndefined();
-  expect(logSpy).toHaveBeenCalledTimes(2);
-  expect(logSpy).toHaveBeenLastCalledWith(
+  expect(logger.log).toHaveBeenCalledTimes(2);
+  expect(logger.log).toHaveBeenLastCalledWith(
     LogEventId.DeviceUnattached,
     'system',
     expect.objectContaining({
@@ -156,13 +154,12 @@ test('can connect card reader as expected', async () => {
 
 test('can connect accessible controller as expected', async () => {
   const hardware = new MemoryHardware();
-  const fakeLogger = new Logger(LogSource.VxCentralScanFrontend);
-  const logSpy = jest.spyOn(fakeLogger, 'log').mockResolvedValue();
+  const logger = fakeLogger();
   const { result, rerender, waitForNextUpdate } = renderHook(() =>
-    useDevices({ hardware, logger: fakeLogger })
+    useDevices({ hardware, logger })
   );
   expect(result.current).toEqual(emptyDevices);
-  expect(logSpy).toHaveBeenCalledTimes(0);
+  expect(logger.log).toHaveBeenCalledTimes(0);
 
   const expectedAccessibleController: Devices['accessibleController'] = {
     deviceAddress: 0,
@@ -179,8 +176,8 @@ test('can connect accessible controller as expected', async () => {
   expect(result.current.accessibleController).toEqual(
     expectedAccessibleController
   );
-  expect(logSpy).toHaveBeenCalledTimes(1);
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledTimes(1);
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.DeviceAttached,
     'system',
     expect.objectContaining({
@@ -193,8 +190,8 @@ test('can connect accessible controller as expected', async () => {
   act(() => hardware.setAccessibleControllerConnected(false));
   rerender();
   expect(result.current.accessibleController).toBeUndefined();
-  expect(logSpy).toHaveBeenCalledTimes(2);
-  expect(logSpy).toHaveBeenLastCalledWith(
+  expect(logger.log).toHaveBeenCalledTimes(2);
+  expect(logger.log).toHaveBeenLastCalledWith(
     LogEventId.DeviceUnattached,
     'system',
     expect.objectContaining({
@@ -210,13 +207,12 @@ test('can connect accessible controller as expected', async () => {
 
 test('can connect batch scanner as expected', async () => {
   const hardware = new MemoryHardware();
-  const fakeLogger = new Logger(LogSource.VxCentralScanFrontend);
-  const logSpy = jest.spyOn(fakeLogger, 'log').mockResolvedValue();
+  const logger = fakeLogger();
   const { result, rerender, waitForNextUpdate } = renderHook(() =>
-    useDevices({ hardware, logger: fakeLogger })
+    useDevices({ hardware, logger })
   );
   expect(result.current).toEqual(emptyDevices);
-  expect(logSpy).toHaveBeenCalledTimes(0);
+  expect(logger.log).toHaveBeenCalledTimes(0);
 
   const expectedBatchScanner: Devices['batchScanner'] = {
     deviceAddress: 0,
@@ -231,8 +227,8 @@ test('can connect batch scanner as expected', async () => {
   act(() => hardware.setBatchScannerConnected(true));
   rerender();
   expect(result.current.batchScanner).toEqual(expectedBatchScanner);
-  expect(logSpy).toHaveBeenCalledTimes(1);
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledTimes(1);
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.DeviceAttached,
     'system',
     expect.objectContaining({
@@ -245,8 +241,8 @@ test('can connect batch scanner as expected', async () => {
   act(() => hardware.setBatchScannerConnected(false));
   rerender();
   expect(result.current.batchScanner).toBeUndefined();
-  expect(logSpy).toHaveBeenCalledTimes(2);
-  expect(logSpy).toHaveBeenLastCalledWith(
+  expect(logger.log).toHaveBeenCalledTimes(2);
+  expect(logger.log).toHaveBeenLastCalledWith(
     LogEventId.DeviceUnattached,
     'system',
     expect.objectContaining({
@@ -271,19 +267,18 @@ test('can connect precinct scanner as expected', async () => {
     manufacturer: 'Plustek',
   };
   const hardware = new MemoryHardware();
-  const fakeLogger = new Logger(LogSource.VxCentralScanFrontend);
-  const logSpy = jest.spyOn(fakeLogger, 'log').mockResolvedValue();
+  const logger = fakeLogger();
   const { result, rerender, waitForNextUpdate } = renderHook(() =>
-    useDevices({ hardware, logger: fakeLogger })
+    useDevices({ hardware, logger })
   );
   expect(result.current).toEqual(emptyDevices);
-  expect(logSpy).toHaveBeenCalledTimes(0);
+  expect(logger.log).toHaveBeenCalledTimes(0);
 
   act(() => hardware.addDevice(plustekDevice));
   rerender();
   expect(result.current.precinctScanner).toEqual(plustekDevice);
-  expect(logSpy).toHaveBeenCalledTimes(1);
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledTimes(1);
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.DeviceAttached,
     'system',
     expect.objectContaining({
@@ -298,8 +293,8 @@ test('can connect precinct scanner as expected', async () => {
   act(() => hardware.removeDevice(plustekDevice));
   rerender();
   expect(result.current.batchScanner).toBeUndefined();
-  expect(logSpy).toHaveBeenCalledTimes(2);
-  expect(logSpy).toHaveBeenLastCalledWith(
+  expect(logger.log).toHaveBeenCalledTimes(2);
+  expect(logger.log).toHaveBeenLastCalledWith(
     LogEventId.DeviceUnattached,
     'system',
     expect.objectContaining({
@@ -324,17 +319,16 @@ test('can handle logs for a random device as expected', async () => {
     manufacturer: '',
   };
   const hardware = new MemoryHardware();
-  const fakeLogger = new Logger(LogSource.VxCentralScanFrontend);
-  const logSpy = jest.spyOn(fakeLogger, 'log').mockResolvedValue();
+  const logger = fakeLogger();
   const { result, rerender, waitForNextUpdate } = renderHook(() =>
-    useDevices({ hardware, logger: fakeLogger })
+    useDevices({ hardware, logger })
   );
-  expect(logSpy).toHaveBeenCalledTimes(0);
+  expect(logger.log).toHaveBeenCalledTimes(0);
 
   act(() => hardware.addDevice(randomDevice));
   rerender();
-  expect(logSpy).toHaveBeenCalledTimes(1);
-  expect(logSpy).toHaveBeenCalledWith(
+  expect(logger.log).toHaveBeenCalledTimes(1);
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.DeviceAttached,
     'system',
     expect.objectContaining({
@@ -347,8 +341,8 @@ test('can handle logs for a random device as expected', async () => {
 
   act(() => hardware.removeDevice(randomDevice));
   rerender();
-  expect(logSpy).toHaveBeenCalledTimes(2);
-  expect(logSpy).toHaveBeenLastCalledWith(
+  expect(logger.log).toHaveBeenCalledTimes(2);
+  expect(logger.log).toHaveBeenLastCalledWith(
     LogEventId.DeviceUnattached,
     'system',
     expect.objectContaining({
@@ -365,9 +359,9 @@ test('can handle logs for a random device as expected', async () => {
 test('periodically polls for computer battery status', async () => {
   jest.useFakeTimers();
   const hardware = new MemoryHardware();
-  const fakeLogger = new Logger(LogSource.VxCentralScanFrontend);
+  const logger = fakeLogger();
   const { result, waitForNextUpdate } = renderHook(() =>
-    useDevices({ hardware, logger: fakeLogger })
+    useDevices({ hardware, logger })
   );
   expect(result.current).toEqual(emptyDevices);
 

--- a/services/admin/src/server.test.ts
+++ b/services/admin/src/server.test.ts
@@ -1,4 +1,4 @@
-import { Logger, LogSource } from '@votingworks/logging';
+import { fakeLogger } from '@votingworks/logging';
 import { assert } from '@votingworks/utils';
 import { Application } from 'express';
 import request from 'supertest';
@@ -39,13 +39,12 @@ test('start with config options', async () => {
     onListening?.();
     return undefined as unknown as Server;
   });
-  const fakeLogger = new Logger(LogSource.VxScanService);
-  jest.spyOn(fakeLogger, 'log');
+  const logger = fakeLogger();
 
   // start up the server
-  await start({ app, logger: fakeLogger, workspace });
+  await start({ app, logger, workspace });
 
-  expect(fakeLogger.log).toHaveBeenCalled();
+  expect(logger.log).toHaveBeenCalled();
 });
 
 test('errors on start with no workspace', async () => {

--- a/services/scan/src/server.test.ts
+++ b/services/scan/src/server.test.ts
@@ -1,5 +1,5 @@
 import { electionSampleDefinition as testElectionDefinition } from '@votingworks/fixtures';
-import { Logger, LogSource } from '@votingworks/logging';
+import { fakeLogger } from '@votingworks/logging';
 import * as plusteksdk from '@votingworks/plustek-sdk';
 import {
   AdjudicationReason,
@@ -616,11 +616,10 @@ test('start reloads configuration from the store', async () => {
     onListening?.();
     return undefined as unknown as Server;
   });
-  const fakeLogger = new Logger(LogSource.VxScanService);
-  jest.spyOn(fakeLogger, 'log').mockResolvedValue();
+  const logger = fakeLogger();
 
   // start up the server
-  await start({ importer, app, log: jest.fn(), workspace, logger: fakeLogger });
+  await start({ importer, app, log: jest.fn(), workspace, logger });
 
   // did we load everything from the store?
   expect(importer.restoreConfig).toHaveBeenCalled();
@@ -640,15 +639,14 @@ test('start as precinct-scanner rejects a held sheet at startup', async () => {
   (await mockClient.simulateLoadSheet(['a.jpg', 'b.jpg'])).unsafeUnwrap();
   (await mockClient.scan()).unsafeUnwrap();
   mocked(plusteksdk.createClient).mockResolvedValueOnce(ok(mockClient));
-  const fakeLogger = new Logger(LogSource.VxScanService);
-  jest.spyOn(fakeLogger, 'log').mockResolvedValue();
+  const logger = fakeLogger();
 
   // start up the server
   await start({
     importer,
     app,
     log: jest.fn(),
-    logger: fakeLogger,
+    logger,
     workspace,
     machineType: 'precinct-scanner',
   });


### PR DESCRIPTION

## Overview
Factors out a common pattern into a test util. Had to add this to the logging library not the test-utils library to avoid circular deps.

## Demo Video or Screenshot
N/A
## Testing Plan 
Existing tests
## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
