### PR TITLE
fix(frontends): ensure `path` is loaded correctly

### DIFF
--- a/frontends/bas/package.json
+++ b/frontends/bas/package.json
@@ -70,6 +70,7 @@
     "luxon": "^1.27.0",
     "mini-css-extract-plugin": "0.11.3",
     "normalize.css": "^8.0.1",
+    "path": "^0.12.7",
     "pluralize": "^8.0.0",
     "prompts": "2.4.0",
     "react": "^17.0.1",

--- a/frontends/bas/vite.config.ts
+++ b/frontends/bas/vite.config.ts
@@ -23,6 +23,8 @@ export default defineConfig(async () => {
     // Node-only globals like `process`.
     define: {
       'process.env.NODE_DEBUG': 'undefined',
+      'process.platform': JSON.stringify('browser'),
+      'process.version': JSON.stringify(process.version),
     },
 
     resolve: {
@@ -32,6 +34,7 @@ export default defineConfig(async () => {
         // The trailing slash is important, otherwise it will be resolved as a
         // built-in NodeJS module.
         { find: 'buffer', replacement: require.resolve('buffer/'), },
+        { find: 'path', replacement: require.resolve('path/'), },
 
         // Create aliases for all workspace packages, i.e.
         //

--- a/frontends/bmd/package.json
+++ b/frontends/bmd/package.json
@@ -108,6 +108,7 @@
     "mini-css-extract-plugin": "0.11.3",
     "mockdate": "^3.0.2",
     "normalize.css": "^8.0.1",
+    "path": "^0.12.7",
     "pluralize": "^8.0.0",
     "postcss-flexbugs-fixes": "4.2.1",
     "postcss-loader": "3.0.0",

--- a/frontends/bmd/vite.config.ts
+++ b/frontends/bmd/vite.config.ts
@@ -35,6 +35,8 @@ export default defineConfig(async (env) => {
     // Node-only globals like `process`.
     define: {
       'process.env.NODE_DEBUG': 'undefined',
+      'process.platform': JSON.stringify('browser'),
+      'process.version': JSON.stringify(process.version),
 
       // TODO: Replace these with the appropriate `import.meta.env` values.
       ...processEnvDefines,
@@ -47,6 +49,7 @@ export default defineConfig(async (env) => {
         // The trailing slash is important, otherwise it will be resolved as a
         // built-in NodeJS module.
         { find: 'buffer', replacement: require.resolve('buffer/'), },
+        { find: 'path', replacement: require.resolve('path/'), },
 
         // Create aliases for all workspace packages, i.e.
         //

--- a/frontends/bsd/package.json
+++ b/frontends/bsd/package.json
@@ -73,6 +73,7 @@
     "mockdate": "^3.0.2",
     "moment": "^2.29.1",
     "normalize.css": "^8.0.1",
+    "path": "^0.12.7",
     "pluralize": "^7.0.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/frontends/bsd/src/components/election_configuration.tsx
+++ b/frontends/bsd/src/components/election_configuration.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect, useContext } from 'react';
-import path from 'path';
+import { join } from 'path';
 
 import styled from 'styled-components';
 import {
@@ -91,7 +91,7 @@ export function ElectionConfiguration({
       assert(typeof usbPath !== 'undefined');
       assert(window.kiosk);
       const files = await window.kiosk.getFileSystemEntries(
-        path.join(usbPath, BALLOT_PACKAGE_FOLDER)
+        join(usbPath, BALLOT_PACKAGE_FOLDER)
       );
       const newFoundFilenames = files.filter(
         (f) => f.type === 1 && f.name.endsWith('.zip')

--- a/frontends/bsd/src/components/export_logs_modal.tsx
+++ b/frontends/bsd/src/components/export_logs_modal.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react';
-import path from 'path';
+import { join } from 'path';
 import { isAdminAuth, isSuperadminAuth, Modal } from '@votingworks/ui';
 import {
   assert,
@@ -122,7 +122,7 @@ export function ExportLogsModal({ onClose, logFileType }: Props): JSX.Element {
         await fileWriter.end();
       } else {
         assert(typeof usbPath !== 'undefined');
-        const pathToFile = path.join(usbPath, defaultFilename);
+        const pathToFile = join(usbPath, defaultFilename);
         await window.kiosk.writeFile(pathToFile, results);
         filenameLocation = defaultFilename;
       }

--- a/frontends/bsd/src/components/export_results_modal.tsx
+++ b/frontends/bsd/src/components/export_results_modal.tsx
@@ -2,7 +2,7 @@ import { ElectionDefinition } from '@votingworks/types';
 import React, { useContext, useState } from 'react';
 import styled from 'styled-components';
 import fileDownload from 'js-file-download';
-import path from 'path';
+import { join } from 'path';
 
 import { isAdminAuth, Modal, UsbControllerButton } from '@votingworks/ui';
 import {
@@ -102,12 +102,12 @@ export function ExportResultsModal({
           electionDefinition.election,
           electionDefinition.electionHash
         );
-        const pathToFolder = path.join(
+        const pathToFolder = join(
           usbPath,
           SCANNER_RESULTS_FOLDER,
           electionFolderName
         );
-        const pathToFile = path.join(pathToFolder, cvrFilename);
+        const pathToFile = join(pathToFolder, cvrFilename);
         if (openDialog) {
           const fileWriter = await window.kiosk.saveAs({
             defaultPath: pathToFile,

--- a/frontends/bsd/vite.config.ts
+++ b/frontends/bsd/vite.config.ts
@@ -35,6 +35,8 @@ export default defineConfig(async (env) => {
     // Node-only globals like `process`.
     define: {
       'process.env.NODE_DEBUG': 'undefined',
+      'process.platform': JSON.stringify('browser'),
+      'process.version': JSON.stringify(process.version),
 
       // TODO: Replace these with the appropriate `import.meta.env` values (#1907).
       ...processEnvDefines,
@@ -47,6 +49,7 @@ export default defineConfig(async (env) => {
         // The trailing slash is important, otherwise it will be resolved as a
         // built-in NodeJS module.
         { find: 'buffer', replacement: require.resolve('buffer/'), },
+        { find: 'path', replacement: require.resolve('path/'), },
 
         // Create aliases for all workspace packages, i.e.
         //

--- a/frontends/election-manager/src/components/export_logs_modal.tsx
+++ b/frontends/election-manager/src/components/export_logs_modal.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react';
-import path from 'path';
+import { join } from 'path';
 import {
   assert,
   usbstick,
@@ -121,7 +121,7 @@ export function ExportLogsModal({ onClose, logFileType }: Props): JSX.Element {
         await fileWriter.end();
       } else {
         assert(typeof usbPath !== 'undefined');
-        const pathToFile = path.join(usbPath, defaultFilename);
+        const pathToFile = join(usbPath, defaultFilename);
         await window.kiosk.writeFile(pathToFile, results);
         filenameLocation = defaultFilename;
       }

--- a/frontends/election-manager/src/components/import_cvrfiles_modal.tsx
+++ b/frontends/election-manager/src/components/import_cvrfiles_modal.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useState } from 'react';
 import styled from 'styled-components';
-import path from 'path';
+import { join } from 'path';
 import moment from 'moment';
 
 import {
@@ -196,7 +196,7 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
       assert(typeof usbPath !== 'undefined');
       assert(window.kiosk);
       const files = await window.kiosk.getFileSystemEntries(
-        path.join(
+        join(
           usbPath,
           SCANNER_RESULTS_FOLDER,
           generateElectionBasedSubfolderName(election, electionHash)

--- a/frontends/election-manager/src/components/save_file_to_usb.tsx
+++ b/frontends/election-manager/src/components/save_file_to_usb.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useState } from 'react';
 import styled from 'styled-components';
-import path from 'path';
+import { join } from 'path';
 import fileDownload from 'js-file-download';
 import { assert, usbstick, throwIllegalValue, sleep } from '@votingworks/utils';
 
@@ -118,7 +118,7 @@ export function SaveFileToUsb({
           await fileWriter.end();
         } else {
           assert(typeof usbPath !== 'undefined');
-          const pathToFile = path.join(usbPath, defaultFilename);
+          const pathToFile = join(usbPath, defaultFilename);
           assert(window.kiosk);
           await window.kiosk.writeFile(pathToFile, results);
           filenameLocation = defaultFilename;

--- a/frontends/election-manager/src/utils/downloadable_archive.ts
+++ b/frontends/election-manager/src/utils/downloadable_archive.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-classes-per-file */
 import { assert } from '@votingworks/utils';
 import { Buffer } from 'buffer';
-import path from 'path';
+import { join } from 'path';
 import { configure, Uint8ArrayReader, ZipWriter, Writer } from '@zip.js/zip.js';
 
 configure({ useWebWorkers: false });
@@ -72,7 +72,7 @@ export class DownloadableArchive {
     await this.getKiosk().makeDirectory(pathToFolder, {
       recursive: true,
     });
-    const filePath = path.join(pathToFolder, filename);
+    const filePath = join(pathToFolder, filename);
     const fileWriter = await this.getKiosk().writeFile(filePath);
 
     if (!fileWriter) {

--- a/frontends/election-manager/vite.config.ts
+++ b/frontends/election-manager/vite.config.ts
@@ -35,6 +35,7 @@ export default defineConfig(async (env) => {
     // Node-only globals like `process`.
     define: {
       'process.env.NODE_DEBUG': JSON.stringify(undefined),
+      'process.platform': JSON.stringify('browser'),
       'process.version': JSON.stringify(process.version),
 
       // TODO: Replace these with the appropriate `import.meta.env` values (#1907).

--- a/frontends/precinct-scanner/src/components/export_backup_modal.tsx
+++ b/frontends/precinct-scanner/src/components/export_backup_modal.tsx
@@ -16,7 +16,7 @@ import {
   throwIllegalValue,
   usbstick,
 } from '@votingworks/utils';
-import path from 'path';
+import { join } from 'path';
 import React, { useCallback, useContext, useState } from 'react';
 import styled from 'styled-components';
 import { AppContext } from '../contexts/app_context';
@@ -64,7 +64,7 @@ export function ExportBackupModal({ onClose, usbDrive }: Props): JSX.Element {
           electionDefinition.election,
           electionDefinition.electionHash
         );
-        const pathToFolder = path.join(
+        const pathToFolder = join(
           usbPath,
           SCANNER_BACKUPS_FOLDER,
           electionFolderName

--- a/frontends/precinct-scanner/src/screens/unconfigured_election_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/unconfigured_election_screen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import path from 'path';
+import { join } from 'path';
 import {
   OptionalElectionDefinition,
   getPrecinctById,
@@ -63,7 +63,7 @@ export function UnconfiguredElectionScreen({
           assert(typeof usbPath !== 'undefined');
           assert(window.kiosk);
           files = await window.kiosk.getFileSystemEntries(
-            path.join(usbPath, PRECINCT_SCANNER_FOLDER)
+            join(usbPath, PRECINCT_SCANNER_FOLDER)
           );
         } catch (error) {
           throw new Error('No ballot package found on the inserted USB drive.');

--- a/frontends/precinct-scanner/src/utils/save_cvr_export_to_usb.ts
+++ b/frontends/precinct-scanner/src/utils/save_cvr_export_to_usb.ts
@@ -5,7 +5,7 @@ import {
   usbstick,
   generateElectionBasedSubfolderName,
 } from '@votingworks/utils';
-import path from 'path';
+import { join } from 'path';
 import fileDownload from 'js-file-download';
 import * as scan from '../api/scan';
 import { MachineConfig } from '../config/types';
@@ -47,12 +47,12 @@ export async function saveCvrExportToUsb({
       electionDefinition.election,
       electionDefinition.electionHash
     );
-    const pathToFolder = path.join(
+    const pathToFolder = join(
       usbPath,
       SCANNER_RESULTS_FOLDER,
       electionFolderName
     );
-    const pathToFile = path.join(pathToFolder, cvrFilename);
+    const pathToFile = join(pathToFolder, cvrFilename);
     if (openFilePickerDialog) {
       const fileWriter = await window.kiosk.saveAs({
         defaultPath: pathToFile,

--- a/frontends/precinct-scanner/vite.config.ts
+++ b/frontends/precinct-scanner/vite.config.ts
@@ -36,6 +36,7 @@ export default defineConfig(async (env) => {
     define: {
       'process.env.NODE_DEBUG': 'undefined',
       'process.platform': JSON.stringify('browser'),
+      'process.version': JSON.stringify(process.version),
 
       // TODO: Replace these with the appropriate `import.meta.env` values.
       ...processEnvDefines,
@@ -48,6 +49,7 @@ export default defineConfig(async (env) => {
         // The trailing slash is important, otherwise it will be resolved as a
         // built-in NodeJS module.
         { find: 'buffer', replacement: require.resolve('buffer/'), },
+        { find: 'path', replacement: require.resolve('path/'), },
 
         // Create aliases for all workspace packages, i.e.
         //

--- a/integration-testing/election-manager/cypress/plugins/index.js
+++ b/integration-testing/election-manager/cypress/plugins/index.js
@@ -1,5 +1,5 @@
-import { promises as fs } from 'fs'
-import path from 'path'
+import { promises as fs } from 'fs';
+import { join } from 'path';
 
 /// <reference types="cypress" />
 // ***********************************************************
@@ -24,14 +24,14 @@ module.exports = (on, config) => {
   // `config` is the resolved Cypress config
   on('task', {
     async readMostRecentFile(directoryPath) {
-      const files = await fs.readdir(directoryPath)
-      const paths = files.map((file) => path.join(directoryPath, file))
+      const files = await fs.readdir(directoryPath);
+      const paths = files.map((file) => join(directoryPath, file));
       const ctimes = await Promise.all(
         paths.map(async (p) => (await fs.stat(p)).ctime.getTime())
-      )
-      const mostRecentCtime = Math.max(...ctimes)
-      const mostRecentPath = paths[ctimes.indexOf(mostRecentCtime)]
-      return await fs.readFile(mostRecentPath, 'utf-8')
+      );
+      const mostRecentCtime = Math.max(...ctimes);
+      const mostRecentPath = paths[ctimes.indexOf(mostRecentCtime)];
+      return await fs.readFile(mostRecentPath, 'utf-8');
     },
-  })
-}
+  });
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,7 @@ importers:
       luxon: 1.27.0
       mini-css-extract-plugin: 0.11.3
       normalize.css: 8.0.1
+      path: 0.12.7
       pluralize: 8.0.0
       prompts: 2.4.0
       react: 17.0.1
@@ -214,6 +215,7 @@ importers:
       luxon: ^1.27.0
       mini-css-extract-plugin: 0.11.3
       normalize.css: ^8.0.1
+      path: ^0.12.7
       pluralize: ^8.0.0
       postcss-flexbugs-fixes: 4.2.1
       postcss-loader: 3.0.0
@@ -292,6 +294,7 @@ importers:
       mini-css-extract-plugin: 0.11.3
       mockdate: 3.0.2
       normalize.css: 8.0.1
+      path: 0.12.7
       pluralize: 8.0.0
       postcss-flexbugs-fixes: 4.2.1
       postcss-loader: 3.0.0
@@ -462,6 +465,7 @@ importers:
       mini-css-extract-plugin: 0.11.3
       mockdate: ^3.0.2
       normalize.css: ^8.0.1
+      path: ^0.12.7
       pluralize: ^8.0.0
       postcss-flexbugs-fixes: 4.2.1
       postcss-loader: 3.0.0
@@ -528,6 +532,7 @@ importers:
       mockdate: 3.0.5
       moment: 2.29.1
       normalize.css: 8.0.1
+      path: 0.12.7
       pluralize: 7.0.0
       react: 17.0.1
       react-dom: 17.0.1_react@17.0.1
@@ -652,6 +657,7 @@ importers:
       moment: ^2.29.1
       node-fetch: ^2.6.0
       normalize.css: ^8.0.1
+      path: ^0.12.7
       pluralize: ^7.0.0
       prettier: ^2.6.2
       react: ^17.0.1
@@ -20560,6 +20566,17 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=
+  /follow-redirects/1.14.1:
+    dev: false
+    engines:
+      node: '>=4.0'
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    resolution:
+      integrity: sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
   /follow-redirects/1.14.1_debug@4.3.1:
     dependencies:
       debug: 4.3.1
@@ -21738,7 +21755,7 @@ packages:
   /http-proxy/1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.14.1_debug@4.3.1
+      follow-redirects: 1.14.1
       requires-port: 1.0.0
     dev: false
     engines:


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
For some reason `import path from 'path'` would get built for production such that `path` was just an empty object. Using named imports makes it break at build time, which is a better outcome. To fix the build, we alias `path` to the one installed from NPM instead of the NodeJS built-in `path` module.

Closes #2045

## Demo Video or Screenshot
<img width="1512" alt="Screen Shot 2022-06-30 at 3 07 19 PM" src="https://user-images.githubusercontent.com/1938/176786965-9dcafcc2-16f3-4f47-aa52-4b97de1308e4.png">

## Testing Plan 
In VxCentralScan in kiosk-browser, inserted a USB drive and verified that it no longer hangs while loading the contents. Though it does [flicker](https://votingworks.slack.com/archives/CEL6D3GAD/p1656625454116639) sometimes for reasons I don't understand yet.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
