### PR TITLE
Export write-in ballot images from scan and rough layout of write-in ballot images

### DIFF
--- a/frontends/election-manager/src/components/cropped_image.tsx
+++ b/frontends/election-manager/src/components/cropped_image.tsx
@@ -1,0 +1,38 @@
+import { Rect } from '@votingworks/types';
+import React, { useEffect, useState } from 'react';
+
+export interface Props {
+  src: string;
+  alt: string;
+  crop: Rect;
+  style?: React.CSSProperties;
+}
+
+export function CroppedImage({ src, alt, crop, style }: Props): JSX.Element {
+  const [dataUrl, setDataUrl] = useState<string>();
+
+  useEffect(() => {
+    const image = new Image();
+    image.src = src;
+    image.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = crop.width;
+      canvas.height = crop.height;
+      const context = canvas.getContext('2d');
+
+      if (context) {
+        context.drawImage(image, -crop.x, -crop.y);
+        setDataUrl(canvas.toDataURL());
+      }
+    };
+  }, [crop.height, crop.width, crop.x, crop.y, src]);
+
+  return (
+    <img
+      src={dataUrl}
+      alt={alt}
+      style={style}
+      data-crop={`x=${crop.x}, y=${crop.y}, width=${crop.width}, height=${crop.height}`}
+    />
+  );
+}

--- a/libs/types/src/cast_vote_record.ts
+++ b/libs/types/src/cast_vote_record.ts
@@ -1,6 +1,6 @@
 import {
-  Adjudication,
   BallotId,
+  BallotImage,
   BallotLocale,
   BallotStyleId,
   PrecinctId,
@@ -15,10 +15,11 @@ export interface CastVoteRecord
     | number
     | number[]
     | BallotLocale
-    | Adjudication[]
+    | BallotImage[]
   > {
   readonly _precinctId: PrecinctId;
   readonly _ballotId?: BallotId;
+  readonly _ballotImages?: BallotImage[];
   readonly _ballotStyleId: BallotStyleId;
   readonly _ballotType: 'absentee' | 'provisional' | 'standard';
   readonly _batchId: string;

--- a/libs/types/src/cast_vote_record.ts
+++ b/libs/types/src/cast_vote_record.ts
@@ -5,6 +5,7 @@ import {
   InlineBallotImage,
   PrecinctId,
 } from './election';
+import { BallotPageLayout } from './hmpb';
 import { Dictionary } from './generic';
 
 export interface CastVoteRecord
@@ -29,5 +30,6 @@ export interface CastVoteRecord
   readonly _scannerId: string;
   readonly _pageNumber?: number;
   readonly _pageNumbers?: number[];
+  readonly _layouts?: Array<BallotPageLayout[]>;
   readonly _locales?: BallotLocale;
 }

--- a/libs/types/src/cast_vote_record.ts
+++ b/libs/types/src/cast_vote_record.ts
@@ -1,8 +1,8 @@
 import {
   BallotId,
-  BallotImage,
   BallotLocale,
   BallotStyleId,
+  InlineBallotImage,
   PrecinctId,
 } from './election';
 import { Dictionary } from './generic';
@@ -15,11 +15,12 @@ export interface CastVoteRecord
     | number
     | number[]
     | BallotLocale
-    | BallotImage[]
+    | InlineBallotImage[]
+    | Array<BallotPageLayout[]>
   > {
   readonly _precinctId: PrecinctId;
   readonly _ballotId?: BallotId;
-  readonly _ballotImages?: BallotImage[];
+  readonly _ballotImages?: InlineBallotImage[];
   readonly _ballotStyleId: BallotStyleId;
   readonly _ballotType: 'absentee' | 'provisional' | 'standard';
   readonly _batchId: string;

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -1221,6 +1221,15 @@ export const PageInterpretationWithFilesSchema: z.ZodSchema<PageInterpretationWi
     interpretation: PageInterpretationSchema,
   });
 
+export interface BallotImage {
+  original: string;
+  normalized: string;
+}
+export const BallotImageSchema: z.ZodSchema<BallotImage> = z.object({
+  original: z.string(),
+  normalized: z.string(),
+});
+
 export interface BallotPageInfo {
   image: ImageInfo;
   interpretation: PageInterpretation;

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -1222,11 +1222,9 @@ export const PageInterpretationWithFilesSchema: z.ZodSchema<PageInterpretationWi
   });
 
 export interface BallotImage {
-  original: string;
   normalized: string;
 }
 export const BallotImageSchema: z.ZodSchema<BallotImage> = z.object({
-  original: z.string(),
   normalized: z.string(),
 });
 

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -1221,12 +1221,14 @@ export const PageInterpretationWithFilesSchema: z.ZodSchema<PageInterpretationWi
     interpretation: PageInterpretationSchema,
   });
 
-export interface BallotImage {
+export interface InlineBallotImage {
   normalized: string;
 }
-export const BallotImageSchema: z.ZodSchema<BallotImage> = z.object({
-  normalized: z.string(),
-});
+export const InlineBallotImageSchema: z.ZodSchema<InlineBallotImage> = z.object(
+  {
+    normalized: z.string(),
+  }
+);
 
 export interface BallotPageInfo {
   image: ImageInfo;

--- a/services/admin/src/server.ts
+++ b/services/admin/src/server.ts
@@ -62,7 +62,7 @@ export function buildApp({ store }: { store: Store }): Application {
         for (const cvr of f.allCastVoteRecords) {
           const cvrId = store.addCvr(JSON.stringify(cvr));
           for (const [key, value] of Object.entries(cvr)) {
-            if (Array.isArray(value)) {
+            if (!key.startsWith('_') && Array.isArray(value)) {
               const contestId = key;
               const votes = value as ContestOptionId[];
               for (const vote of votes) {

--- a/services/scan/src/build_cast_vote_record.test.ts
+++ b/services/scan/src/build_cast_vote_record.test.ts
@@ -374,6 +374,10 @@ test('generates a CVR from a completed HMPB page', () => {
       "_ballotType": "standard",
       "_batchId": "1234",
       "_batchLabel": "Batch 1",
+      "_layouts": Array [
+        undefined,
+        undefined,
+      ],
       "_locales": Object {
         "primary": "en-US",
       },
@@ -488,6 +492,10 @@ test('generates a CVR from a completed HMPB page with write in votes and overvot
       "_ballotType": "standard",
       "_batchId": "1234",
       "_batchLabel": "Batch 1",
+      "_layouts": Array [
+        undefined,
+        undefined,
+      ],
       "_locales": Object {
         "primary": "en-US",
       },
@@ -601,6 +609,10 @@ test('generates a CVR from a completed absentee HMPB page', () => {
       "_ballotType": "absentee",
       "_batchId": "1234",
       "_batchLabel": "Batch 1",
+      "_layouts": Array [
+        undefined,
+        undefined,
+      ],
       "_locales": Object {
         "primary": "en-US",
       },
@@ -730,6 +742,10 @@ test('generates a CVR from an adjudicated HMPB page', () => {
       "_ballotType": "standard",
       "_batchId": "1234",
       "_batchLabel": "Batch 1",
+      "_layouts": Array [
+        undefined,
+        undefined,
+      ],
       "_locales": Object {
         "primary": "en-US",
       },
@@ -1092,6 +1108,10 @@ test('generates a CVR from an adjudicated uninterpreted HMPB page', () => {
       "_ballotType": "standard",
       "_batchId": "1234",
       "_batchLabel": "Batch 1",
+      "_layouts": Array [
+        undefined,
+        undefined,
+      ],
       "_locales": Object {
         "primary": "en-US",
       },
@@ -1221,6 +1241,10 @@ test('generates a CVR from an adjudicated write-in', () => {
       "_ballotType": "standard",
       "_batchId": "1234",
       "_batchLabel": "Batch 1",
+      "_layouts": Array [
+        undefined,
+        undefined,
+      ],
       "_locales": Object {
         "primary": "en-US",
       },
@@ -1341,6 +1365,10 @@ test('generates a CVR from an adjudicated unmarked write-in', () => {
       "_ballotType": "standard",
       "_batchId": "1234",
       "_batchLabel": "Batch 1",
+      "_layouts": Array [
+        undefined,
+        undefined,
+      ],
       "_locales": Object {
         "primary": "en-US",
       },

--- a/services/scan/src/build_cast_vote_record.test.ts
+++ b/services/scan/src/build_cast_vote_record.test.ts
@@ -132,32 +132,40 @@ test('generates a CVR from a completed BMD ballot', () => {
   const blankPageTypes = ['BlankPage', 'UnreadablePage'];
   for (const blankPageType of blankPageTypes) {
     expect(
-      buildCastVoteRecord(sheetId, batchId, batchLabel, ballotId, election, [
-        {
-          interpretation: {
-            type: 'InterpretedBmdPage',
-            ballotId,
-            metadata: {
-              locales: { primary: 'en-US' },
-              electionHash: electionDefinition.electionHash,
-              ballotType: BallotType.Standard,
-              ballotStyleId,
-              precinctId,
-              isTestMode: false,
+      buildCastVoteRecord(
+        sheetId,
+        batchId,
+        batchLabel,
+        ballotId,
+        election,
+        [
+          {
+            interpretation: {
+              type: 'InterpretedBmdPage',
+              ballotId,
+              metadata: {
+                locales: { primary: 'en-US' },
+                electionHash: electionDefinition.electionHash,
+                ballotType: BallotType.Standard,
+                ballotStyleId,
+                precinctId,
+                isTestMode: false,
+              },
+              votes: vote(contests, {
+                '1': '1',
+                '2': '22',
+                'initiative-65': ['yes', 'no'],
+              }),
             },
-            votes: vote(contests, {
-              '1': '1',
-              '2': '22',
-              'initiative-65': ['yes', 'no'],
-            }),
           },
-        },
-        {
-          interpretation: {
-            type: blankPageType as 'BlankPage' | 'UnreadablePage',
+          {
+            interpretation: {
+              type: blankPageType as 'BlankPage' | 'UnreadablePage',
+            },
           },
-        },
-      ])
+        ],
+        []
+      )
     ).toMatchInlineSnapshot(`
           Object {
             "1": Array [
@@ -203,35 +211,46 @@ test('generates a CVR from a completed BMD ballot with write in and overvotes', 
   const blankPageTypes = ['BlankPage', 'UnreadablePage'];
   for (const blankPageType of blankPageTypes) {
     expect(
-      buildCastVoteRecord(sheetId, batchId, batchLabel, ballotId, election, [
-        {
-          interpretation: {
-            type: 'InterpretedBmdPage',
-            ballotId,
-            metadata: {
-              locales: { primary: 'en-US' },
-              electionHash: electionDefinition.electionHash,
-              ballotType: BallotType.Standard,
-              ballotStyleId,
-              precinctId,
-              isTestMode: false,
-            },
-            votes: vote(contests, {
-              '1': {
-                id: 'write-in-PIKACHU',
-                name: 'Pikachu',
-                isWriteIn: true,
+      buildCastVoteRecord(
+        sheetId,
+        batchId,
+        batchLabel,
+        ballotId,
+        election,
+        [
+          {
+            interpretation: {
+              type: 'InterpretedBmdPage',
+              ballotId,
+              metadata: {
+                locales: { primary: 'en-US' },
+                electionHash: electionDefinition.electionHash,
+                ballotType: BallotType.Standard,
+                ballotStyleId,
+                precinctId,
+                isTestMode: false,
               },
-              '2': ['21', '22'],
-            }),
+              votes: vote(contests, {
+                '1': {
+                  id: 'write-in-PIKACHU',
+                  name: 'Pikachu',
+                  isWriteIn: true,
+                },
+                '2': ['21', '22'],
+              }),
+            },
           },
-        },
-        {
-          interpretation: {
-            type: blankPageType as 'BlankPage' | 'UnreadablePage',
+          {
+            interpretation: {
+              type: blankPageType as 'BlankPage' | 'UnreadablePage',
+            },
           },
-        },
-      ])
+        ],
+        [
+          { normalized: 'normalized front', original: 'original front' },
+          { normalized: 'normalized back', original: 'original back' },
+        ]
+      )
     ).toMatchInlineSnapshot(`
           Object {
             "1": Array [
@@ -274,61 +293,72 @@ test('generates a CVR from a completed HMPB page', () => {
   const contests = getContests({ ballotStyle, election });
 
   expect(
-    buildCastVoteRecord(sheetId, batchId, batchLabel, ballotId, election, [
-      {
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          ballotId,
-          metadata: {
-            locales: { primary: 'en-US' },
-            electionHash: electionDefinition.electionHash,
-            ballotType: BallotType.Standard,
-            ballotStyleId,
-            precinctId,
-            isTestMode: false,
-            pageNumber: 1,
+    buildCastVoteRecord(
+      sheetId,
+      batchId,
+      batchLabel,
+      ballotId,
+      election,
+      [
+        {
+          interpretation: {
+            type: 'InterpretedHmpbPage',
+            ballotId,
+            metadata: {
+              locales: { primary: 'en-US' },
+              electionHash: electionDefinition.electionHash,
+              ballotType: BallotType.Standard,
+              ballotStyleId,
+              precinctId,
+              isTestMode: false,
+              pageNumber: 1,
+            },
+            markInfo: { marks: [], ballotSize: { width: 1, height: 1 } },
+            adjudicationInfo: {
+              requiresAdjudication: false,
+              enabledReasons: [],
+              enabledReasonInfos: [],
+              ignoredReasonInfos: [],
+            },
+            votes: vote(contests, {
+              '1': '1',
+              '2': '22',
+            }),
           },
-          markInfo: { marks: [], ballotSize: { width: 1, height: 1 } },
-          adjudicationInfo: {
-            requiresAdjudication: false,
-            enabledReasons: [],
-            enabledReasonInfos: [],
-            ignoredReasonInfos: [],
-          },
-          votes: vote(contests, {
-            '1': '1',
-            '2': '22',
-          }),
+          contestIds: ['1', '2'],
         },
-        contestIds: ['1', '2'],
-      },
-      {
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          ballotId,
-          metadata: {
-            locales: { primary: 'en-US' },
-            electionHash: electionDefinition.electionHash,
-            ballotType: BallotType.Standard,
-            ballotStyleId,
-            precinctId,
-            isTestMode: false,
-            pageNumber: 2,
+        {
+          interpretation: {
+            type: 'InterpretedHmpbPage',
+            ballotId,
+            metadata: {
+              locales: { primary: 'en-US' },
+              electionHash: electionDefinition.electionHash,
+              ballotType: BallotType.Standard,
+              ballotStyleId,
+              precinctId,
+              isTestMode: false,
+              pageNumber: 2,
+            },
+            markInfo: { marks: [], ballotSize: { width: 1, height: 1 } },
+            adjudicationInfo: {
+              requiresAdjudication: false,
+              enabledReasons: [],
+              enabledReasonInfos: [],
+              ignoredReasonInfos: [],
+            },
+            votes: vote(contests, {
+              'initiative-65': ['yes', 'no'],
+            }),
           },
-          markInfo: { marks: [], ballotSize: { width: 1, height: 1 } },
-          adjudicationInfo: {
-            requiresAdjudication: false,
-            enabledReasons: [],
-            enabledReasonInfos: [],
-            ignoredReasonInfos: [],
-          },
-          votes: vote(contests, {
-            'initiative-65': ['yes', 'no'],
-          }),
+          contestIds: ['initiative-65'],
         },
-        contestIds: ['initiative-65'],
-      },
-    ])
+      ],
+      [
+        { normalized: 'normalized front', original: 'original front' },
+        { normalized: 'normalized back', original: 'original back' },
+      ]
+    )
   ).toMatchInlineSnapshot(`
     Object {
       "1": Array [
@@ -338,6 +368,16 @@ test('generates a CVR from a completed HMPB page', () => {
         "22",
       ],
       "_ballotId": "abcdefg",
+      "_ballotImages": Array [
+        Object {
+          "normalized": "normalized front",
+          "original": "original front",
+        },
+        Object {
+          "normalized": "normalized back",
+          "original": "original back",
+        },
+      ],
       "_ballotStyleId": "1",
       "_ballotType": "standard",
       "_batchId": "1234",
@@ -371,61 +411,72 @@ test('generates a CVR from a completed HMPB page with write in votes and overvot
   const contests = getContests({ ballotStyle, election });
 
   expect(
-    buildCastVoteRecord(sheetId, batchId, batchLabel, ballotId, election, [
-      {
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          ballotId,
-          metadata: {
-            locales: { primary: 'en-US' },
-            electionHash: electionDefinition.electionHash,
-            ballotType: BallotType.Standard,
-            ballotStyleId,
-            precinctId,
-            isTestMode: false,
-            pageNumber: 1,
+    buildCastVoteRecord(
+      sheetId,
+      batchId,
+      batchLabel,
+      ballotId,
+      election,
+      [
+        {
+          interpretation: {
+            type: 'InterpretedHmpbPage',
+            ballotId,
+            metadata: {
+              locales: { primary: 'en-US' },
+              electionHash: electionDefinition.electionHash,
+              ballotType: BallotType.Standard,
+              ballotStyleId,
+              precinctId,
+              isTestMode: false,
+              pageNumber: 1,
+            },
+            markInfo: { marks: [], ballotSize: { width: 1, height: 1 } },
+            adjudicationInfo: {
+              requiresAdjudication: false,
+              enabledReasons: [],
+              enabledReasonInfos: [],
+              ignoredReasonInfos: [],
+            },
+            votes: vote(contests, {
+              '1': { id: 'write-in-0', name: 'Pikachu', isWriteIn: true },
+              '2': ['21', '22'],
+            }),
           },
-          markInfo: { marks: [], ballotSize: { width: 1, height: 1 } },
-          adjudicationInfo: {
-            requiresAdjudication: false,
-            enabledReasons: [],
-            enabledReasonInfos: [],
-            ignoredReasonInfos: [],
-          },
-          votes: vote(contests, {
-            '1': { id: 'write-in-0', name: 'Pikachu', isWriteIn: true },
-            '2': ['21', '22'],
-          }),
+          contestIds: ['1', '2'],
         },
-        contestIds: ['1', '2'],
-      },
-      {
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          ballotId,
-          metadata: {
-            locales: { primary: 'en-US' },
-            electionHash: electionDefinition.electionHash,
-            ballotType: BallotType.Standard,
-            ballotStyleId,
-            precinctId,
-            isTestMode: false,
-            pageNumber: 2,
+        {
+          interpretation: {
+            type: 'InterpretedHmpbPage',
+            ballotId,
+            metadata: {
+              locales: { primary: 'en-US' },
+              electionHash: electionDefinition.electionHash,
+              ballotType: BallotType.Standard,
+              ballotStyleId,
+              precinctId,
+              isTestMode: false,
+              pageNumber: 2,
+            },
+            markInfo: { marks: [], ballotSize: { width: 1, height: 1 } },
+            adjudicationInfo: {
+              requiresAdjudication: false,
+              enabledReasons: [],
+              enabledReasonInfos: [],
+              ignoredReasonInfos: [],
+            },
+            votes: vote(contests, {
+              'initiative-65': ['yes', 'no'],
+            }),
           },
-          markInfo: { marks: [], ballotSize: { width: 1, height: 1 } },
-          adjudicationInfo: {
-            requiresAdjudication: false,
-            enabledReasons: [],
-            enabledReasonInfos: [],
-            ignoredReasonInfos: [],
-          },
-          votes: vote(contests, {
-            'initiative-65': ['yes', 'no'],
-          }),
+          contestIds: ['initiative-65'],
         },
-        contestIds: ['initiative-65'],
-      },
-    ])
+      ],
+      [
+        { normalized: 'normalized front', original: 'original front' },
+        { normalized: 'normalized back', original: 'original back' },
+      ]
+    )
   ).toMatchInlineSnapshot(`
     Object {
       "1": Array [
@@ -436,6 +487,16 @@ test('generates a CVR from a completed HMPB page with write in votes and overvot
         "22",
       ],
       "_ballotId": "abcdefg",
+      "_ballotImages": Array [
+        Object {
+          "normalized": "normalized front",
+          "original": "original front",
+        },
+        Object {
+          "normalized": "normalized back",
+          "original": "original back",
+        },
+      ],
       "_ballotStyleId": "1",
       "_ballotType": "standard",
       "_batchId": "1234",
@@ -469,61 +530,72 @@ test('generates a CVR from a completed absentee HMPB page', () => {
   const contests = getContests({ ballotStyle, election });
 
   expect(
-    buildCastVoteRecord(sheetId, batchId, batchLabel, ballotId, election, [
-      {
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          ballotId,
-          metadata: {
-            locales: { primary: 'en-US' },
-            electionHash: electionDefinition.electionHash,
-            ballotType: BallotType.Absentee,
-            ballotStyleId,
-            precinctId,
-            isTestMode: false,
-            pageNumber: 1,
+    buildCastVoteRecord(
+      sheetId,
+      batchId,
+      batchLabel,
+      ballotId,
+      election,
+      [
+        {
+          interpretation: {
+            type: 'InterpretedHmpbPage',
+            ballotId,
+            metadata: {
+              locales: { primary: 'en-US' },
+              electionHash: electionDefinition.electionHash,
+              ballotType: BallotType.Absentee,
+              ballotStyleId,
+              precinctId,
+              isTestMode: false,
+              pageNumber: 1,
+            },
+            markInfo: { marks: [], ballotSize: { width: 1, height: 1 } },
+            adjudicationInfo: {
+              requiresAdjudication: false,
+              enabledReasons: [],
+              enabledReasonInfos: [],
+              ignoredReasonInfos: [],
+            },
+            votes: vote(contests, {
+              '1': '1',
+              '2': '22',
+            }),
           },
-          markInfo: { marks: [], ballotSize: { width: 1, height: 1 } },
-          adjudicationInfo: {
-            requiresAdjudication: false,
-            enabledReasons: [],
-            enabledReasonInfos: [],
-            ignoredReasonInfos: [],
-          },
-          votes: vote(contests, {
-            '1': '1',
-            '2': '22',
-          }),
+          contestIds: ['1', '2'],
         },
-        contestIds: ['1', '2'],
-      },
-      {
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          ballotId,
-          metadata: {
-            locales: { primary: 'en-US' },
-            electionHash: electionDefinition.electionHash,
-            ballotType: BallotType.Absentee,
-            ballotStyleId,
-            precinctId,
-            isTestMode: false,
-            pageNumber: 2,
+        {
+          interpretation: {
+            type: 'InterpretedHmpbPage',
+            ballotId,
+            metadata: {
+              locales: { primary: 'en-US' },
+              electionHash: electionDefinition.electionHash,
+              ballotType: BallotType.Absentee,
+              ballotStyleId,
+              precinctId,
+              isTestMode: false,
+              pageNumber: 2,
+            },
+            markInfo: { marks: [], ballotSize: { width: 1, height: 1 } },
+            adjudicationInfo: {
+              requiresAdjudication: false,
+              enabledReasons: [],
+              enabledReasonInfos: [],
+              ignoredReasonInfos: [],
+            },
+            votes: vote(contests, {
+              'initiative-65': ['yes', 'no'],
+            }),
           },
-          markInfo: { marks: [], ballotSize: { width: 1, height: 1 } },
-          adjudicationInfo: {
-            requiresAdjudication: false,
-            enabledReasons: [],
-            enabledReasonInfos: [],
-            ignoredReasonInfos: [],
-          },
-          votes: vote(contests, {
-            'initiative-65': ['yes', 'no'],
-          }),
+          contestIds: ['initiative-65'],
         },
-        contestIds: ['initiative-65'],
-      },
-    ])
+      ],
+      [
+        { normalized: 'front normalized', original: 'front original' },
+        { normalized: 'back normalized', original: 'back original' },
+      ]
+    )
   ).toMatchInlineSnapshot(`
     Object {
       "1": Array [
@@ -533,6 +605,16 @@ test('generates a CVR from a completed absentee HMPB page', () => {
         "22",
       ],
       "_ballotId": "abcdefg",
+      "_ballotImages": Array [
+        Object {
+          "normalized": "front normalized",
+          "original": "front original",
+        },
+        Object {
+          "normalized": "back normalized",
+          "original": "back original",
+        },
+      ],
       "_ballotStyleId": "1",
       "_ballotType": "absentee",
       "_batchId": "1234",
@@ -566,77 +648,88 @@ test('generates a CVR from an adjudicated HMPB page', () => {
   const contests = getContests({ ballotStyle, election });
 
   expect(
-    buildCastVoteRecord(sheetId, batchId, batchLabel, ballotId, election, [
-      {
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          ballotId,
-          metadata: {
-            locales: { primary: 'en-US' },
-            electionHash: electionDefinition.electionHash,
-            ballotType: BallotType.Standard,
-            ballotStyleId,
-            precinctId,
-            isTestMode: false,
-            pageNumber: 2,
+    buildCastVoteRecord(
+      sheetId,
+      batchId,
+      batchLabel,
+      ballotId,
+      election,
+      [
+        {
+          interpretation: {
+            type: 'InterpretedHmpbPage',
+            ballotId,
+            metadata: {
+              locales: { primary: 'en-US' },
+              electionHash: electionDefinition.electionHash,
+              ballotType: BallotType.Standard,
+              ballotStyleId,
+              precinctId,
+              isTestMode: false,
+              pageNumber: 2,
+            },
+            markInfo: { marks: [], ballotSize: { width: 1, height: 1 } },
+            adjudicationInfo: {
+              requiresAdjudication: true,
+              enabledReasons: [AdjudicationReason.Overvote],
+              enabledReasonInfos: [
+                {
+                  type: AdjudicationReason.Overvote,
+                  contestId: 'initiative-65',
+                  expected: 1,
+                  optionIds: ['yes', 'no'],
+                  optionIndexes: [0, 1],
+                },
+              ],
+              ignoredReasonInfos: [],
+            },
+            votes: vote(contests, {
+              'initiative-65': ['yes', 'no'],
+            }),
           },
-          markInfo: { marks: [], ballotSize: { width: 1, height: 1 } },
-          adjudicationInfo: {
-            requiresAdjudication: true,
-            enabledReasons: [AdjudicationReason.Overvote],
-            enabledReasonInfos: [
-              {
-                type: AdjudicationReason.Overvote,
-                contestId: 'initiative-65',
-                expected: 1,
-                optionIds: ['yes', 'no'],
-                optionIndexes: [0, 1],
-              },
-            ],
-            ignoredReasonInfos: [],
-          },
-          votes: vote(contests, {
-            'initiative-65': ['yes', 'no'],
-          }),
+          markAdjudications: [
+            {
+              type: AdjudicationReason.Overvote,
+              contestId: 'initiative-65',
+              optionId: 'no',
+              isMarked: false,
+            },
+          ],
+          contestIds: ['initiative-65'],
         },
-        markAdjudications: [
-          {
-            type: AdjudicationReason.Overvote,
-            contestId: 'initiative-65',
-            optionId: 'no',
-            isMarked: false,
+        {
+          interpretation: {
+            type: 'InterpretedHmpbPage',
+            ballotId,
+            metadata: {
+              locales: { primary: 'en-US' },
+              electionHash: electionDefinition.electionHash,
+              ballotType: BallotType.Standard,
+              ballotStyleId,
+              precinctId,
+              isTestMode: false,
+              pageNumber: 1,
+            },
+            markInfo: { marks: [], ballotSize: { width: 1, height: 1 } },
+            adjudicationInfo: {
+              requiresAdjudication: false,
+              enabledReasons: [AdjudicationReason.Overvote],
+              enabledReasonInfos: [],
+              ignoredReasonInfos: [],
+            },
+            votes: vote(contests, {
+              '1': '1',
+              '2': '22',
+            }),
           },
-        ],
-        contestIds: ['initiative-65'],
-      },
-      {
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          ballotId,
-          metadata: {
-            locales: { primary: 'en-US' },
-            electionHash: electionDefinition.electionHash,
-            ballotType: BallotType.Standard,
-            ballotStyleId,
-            precinctId,
-            isTestMode: false,
-            pageNumber: 1,
-          },
-          markInfo: { marks: [], ballotSize: { width: 1, height: 1 } },
-          adjudicationInfo: {
-            requiresAdjudication: false,
-            enabledReasons: [AdjudicationReason.Overvote],
-            enabledReasonInfos: [],
-            ignoredReasonInfos: [],
-          },
-          votes: vote(contests, {
-            '1': '1',
-            '2': '22',
-          }),
+          contestIds: ['1', '2'],
         },
-        contestIds: ['1', '2'],
-      },
-    ])
+      ],
+      [
+        { normalized: 'normalized front', original: 'original front' },
+        { normalized: 'normalized back', original: 'original back' },
+      ]
+    )
   ).toMatchInlineSnapshot(`
     Object {
       "1": Array [
@@ -646,6 +739,16 @@ test('generates a CVR from an adjudicated HMPB page', () => {
         "22",
       ],
       "_ballotId": "abcdefg",
+      "_ballotImages": Array [
+        Object {
+          "normalized": "normalized back",
+          "original": "original back",
+        },
+        Object {
+          "normalized": "normalized front",
+          "original": "original front",
+        },
+      ],
       "_ballotStyleId": "1",
       "_ballotType": "standard",
       "_batchId": "1234",
@@ -676,47 +779,58 @@ test('fails to generate a CVR from an invalid HMPB sheet with two pages having t
   const batchLabel = 'Batch 1';
 
   expect(() =>
-    buildCastVoteRecord(sheetId, batchId, batchLabel, ballotId, election, [
-      {
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          metadata: {
-            locales: { primary: 'en-US' },
-            electionHash: electionDefinition.electionHash,
-            ballotType: BallotType.Standard,
-            ballotStyleId,
-            precinctId,
-            isTestMode: false,
-            pageNumber: 1,
-          },
-          adjudicationInfo: {
-            requiresAdjudication: false,
-            enabledReasons: [],
-            enabledReasonInfos: [],
-            ignoredReasonInfos: [],
-          },
-          markInfo: {
-            marks: [],
-            ballotSize: { width: 1, height: 1 },
-          },
-          votes: {},
-        },
-      },
-      {
-        interpretation: {
-          type: 'UninterpretedHmpbPage',
-          metadata: {
-            locales: { primary: 'en-US' },
-            electionHash: electionDefinition.electionHash,
-            ballotType: BallotType.Standard,
-            ballotStyleId,
-            precinctId,
-            isTestMode: false,
-            pageNumber: 1,
+    buildCastVoteRecord(
+      sheetId,
+      batchId,
+      batchLabel,
+      ballotId,
+      election,
+      [
+        {
+          interpretation: {
+            type: 'InterpretedHmpbPage',
+            metadata: {
+              locales: { primary: 'en-US' },
+              electionHash: electionDefinition.electionHash,
+              ballotType: BallotType.Standard,
+              ballotStyleId,
+              precinctId,
+              isTestMode: false,
+              pageNumber: 1,
+            },
+            adjudicationInfo: {
+              requiresAdjudication: false,
+              enabledReasons: [],
+              enabledReasonInfos: [],
+              ignoredReasonInfos: [],
+            },
+            markInfo: {
+              marks: [],
+              ballotSize: { width: 1, height: 1 },
+            },
+            votes: {},
           },
         },
-      },
-    ])
+        {
+          interpretation: {
+            type: 'UninterpretedHmpbPage',
+            metadata: {
+              locales: { primary: 'en-US' },
+              electionHash: electionDefinition.electionHash,
+              ballotType: BallotType.Standard,
+              ballotStyleId,
+              precinctId,
+              isTestMode: false,
+              pageNumber: 1,
+            },
+          },
+        },
+      ],
+      [
+        { normalized: 'normalized front', original: 'original front' },
+        { normalized: 'normalized back', original: 'original back' },
+      ]
+    )
   ).toThrowError(
     'expected a sheet to have consecutive page numbers, but got front=1 back=1'
   );
@@ -731,47 +845,58 @@ test('fails to generate a CVR from an invalid HMPB sheet with two non-consecutiv
   const batchLabel = 'Batch 1';
 
   expect(() =>
-    buildCastVoteRecord(sheetId, batchId, batchLabel, ballotId, election, [
-      {
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          metadata: {
-            locales: { primary: 'en-US' },
-            electionHash: electionDefinition.electionHash,
-            ballotType: BallotType.Standard,
-            ballotStyleId,
-            precinctId,
-            isTestMode: false,
-            pageNumber: 1,
-          },
-          adjudicationInfo: {
-            requiresAdjudication: false,
-            enabledReasons: [],
-            enabledReasonInfos: [],
-            ignoredReasonInfos: [],
-          },
-          markInfo: {
-            marks: [],
-            ballotSize: { width: 1, height: 1 },
-          },
-          votes: {},
-        },
-      },
-      {
-        interpretation: {
-          type: 'UninterpretedHmpbPage',
-          metadata: {
-            locales: { primary: 'en-US' },
-            electionHash: electionDefinition.electionHash,
-            ballotType: BallotType.Standard,
-            ballotStyleId,
-            precinctId,
-            isTestMode: false,
-            pageNumber: 3,
+    buildCastVoteRecord(
+      sheetId,
+      batchId,
+      batchLabel,
+      ballotId,
+      election,
+      [
+        {
+          interpretation: {
+            type: 'InterpretedHmpbPage',
+            metadata: {
+              locales: { primary: 'en-US' },
+              electionHash: electionDefinition.electionHash,
+              ballotType: BallotType.Standard,
+              ballotStyleId,
+              precinctId,
+              isTestMode: false,
+              pageNumber: 1,
+            },
+            adjudicationInfo: {
+              requiresAdjudication: false,
+              enabledReasons: [],
+              enabledReasonInfos: [],
+              ignoredReasonInfos: [],
+            },
+            markInfo: {
+              marks: [],
+              ballotSize: { width: 1, height: 1 },
+            },
+            votes: {},
           },
         },
-      },
-    ])
+        {
+          interpretation: {
+            type: 'UninterpretedHmpbPage',
+            metadata: {
+              locales: { primary: 'en-US' },
+              electionHash: electionDefinition.electionHash,
+              ballotType: BallotType.Standard,
+              ballotStyleId,
+              precinctId,
+              isTestMode: false,
+              pageNumber: 3,
+            },
+          },
+        },
+      ],
+      [
+        { normalized: 'normalized front', original: 'original front' },
+        { normalized: 'normalized back', original: 'original back' },
+      ]
+    )
   ).toThrowError(
     'expected a sheet to have consecutive page numbers, but got front=1 back=3'
   );
@@ -785,47 +910,58 @@ test('fails to generate a CVR from an invalid HMPB sheet with different ballot s
   const batchLabel = 'Batch 1';
 
   expect(() =>
-    buildCastVoteRecord(sheetId, batchId, batchLabel, ballotId, election, [
-      {
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          metadata: {
-            locales: { primary: 'en-US' },
-            electionHash: electionDefinition.electionHash,
-            ballotType: BallotType.Standard,
-            ballotStyleId: '1',
-            precinctId,
-            isTestMode: false,
-            pageNumber: 1,
-          },
-          adjudicationInfo: {
-            requiresAdjudication: false,
-            enabledReasons: [],
-            enabledReasonInfos: [],
-            ignoredReasonInfos: [],
-          },
-          markInfo: {
-            marks: [],
-            ballotSize: { width: 1, height: 1 },
-          },
-          votes: {},
-        },
-      },
-      {
-        interpretation: {
-          type: 'UninterpretedHmpbPage',
-          metadata: {
-            locales: { primary: 'en-US' },
-            electionHash: electionDefinition.electionHash,
-            ballotType: BallotType.Standard,
-            ballotStyleId: '2',
-            precinctId,
-            isTestMode: false,
-            pageNumber: 2,
+    buildCastVoteRecord(
+      sheetId,
+      batchId,
+      batchLabel,
+      ballotId,
+      election,
+      [
+        {
+          interpretation: {
+            type: 'InterpretedHmpbPage',
+            metadata: {
+              locales: { primary: 'en-US' },
+              electionHash: electionDefinition.electionHash,
+              ballotType: BallotType.Standard,
+              ballotStyleId: '1',
+              precinctId,
+              isTestMode: false,
+              pageNumber: 1,
+            },
+            adjudicationInfo: {
+              requiresAdjudication: false,
+              enabledReasons: [],
+              enabledReasonInfos: [],
+              ignoredReasonInfos: [],
+            },
+            markInfo: {
+              marks: [],
+              ballotSize: { width: 1, height: 1 },
+            },
+            votes: {},
           },
         },
-      },
-    ])
+        {
+          interpretation: {
+            type: 'UninterpretedHmpbPage',
+            metadata: {
+              locales: { primary: 'en-US' },
+              electionHash: electionDefinition.electionHash,
+              ballotType: BallotType.Standard,
+              ballotStyleId: '2',
+              precinctId,
+              isTestMode: false,
+              pageNumber: 2,
+            },
+          },
+        },
+      ],
+      [
+        { normalized: 'normalized front', original: 'original front' },
+        { normalized: 'normalized back', original: 'original back' },
+      ]
+    )
   ).toThrowError(
     'expected a sheet to have the same ballot style, but got front=1 back=2'
   );
@@ -839,47 +975,58 @@ test('fails to generate a CVR from an invalid HMPB sheet with different precinct
   const batchLabel = 'Batch 1';
 
   expect(() =>
-    buildCastVoteRecord(sheetId, batchId, batchLabel, ballotId, election, [
-      {
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          metadata: {
-            locales: { primary: 'en-US' },
-            electionHash: electionDefinition.electionHash,
-            ballotType: BallotType.Standard,
-            ballotStyleId,
-            precinctId: '6522',
-            isTestMode: false,
-            pageNumber: 1,
-          },
-          adjudicationInfo: {
-            requiresAdjudication: false,
-            enabledReasons: [],
-            enabledReasonInfos: [],
-            ignoredReasonInfos: [],
-          },
-          markInfo: {
-            marks: [],
-            ballotSize: { width: 1, height: 1 },
-          },
-          votes: {},
-        },
-      },
-      {
-        interpretation: {
-          type: 'UninterpretedHmpbPage',
-          metadata: {
-            locales: { primary: 'en-US' },
-            electionHash: electionDefinition.electionHash,
-            ballotType: BallotType.Standard,
-            ballotStyleId,
-            precinctId: '6523',
-            isTestMode: false,
-            pageNumber: 2,
+    buildCastVoteRecord(
+      sheetId,
+      batchId,
+      batchLabel,
+      ballotId,
+      election,
+      [
+        {
+          interpretation: {
+            type: 'InterpretedHmpbPage',
+            metadata: {
+              locales: { primary: 'en-US' },
+              electionHash: electionDefinition.electionHash,
+              ballotType: BallotType.Standard,
+              ballotStyleId,
+              precinctId: '6522',
+              isTestMode: false,
+              pageNumber: 1,
+            },
+            adjudicationInfo: {
+              requiresAdjudication: false,
+              enabledReasons: [],
+              enabledReasonInfos: [],
+              ignoredReasonInfos: [],
+            },
+            markInfo: {
+              marks: [],
+              ballotSize: { width: 1, height: 1 },
+            },
+            votes: {},
           },
         },
-      },
-    ])
+        {
+          interpretation: {
+            type: 'UninterpretedHmpbPage',
+            metadata: {
+              locales: { primary: 'en-US' },
+              electionHash: electionDefinition.electionHash,
+              ballotType: BallotType.Standard,
+              ballotStyleId,
+              precinctId: '6523',
+              isTestMode: false,
+              pageNumber: 2,
+            },
+          },
+        },
+      ],
+      [
+        { normalized: 'normalized front', original: 'original front' },
+        { normalized: 'normalized back', original: 'original back' },
+      ]
+    )
   ).toThrowError(
     'expected a sheet to have the same precinct, but got front=6522 back=6523'
   );
@@ -894,65 +1041,76 @@ test('generates a CVR from an adjudicated uninterpreted HMPB page', () => {
   const batchLabel = 'Batch 1';
 
   expect(
-    buildCastVoteRecord(sheetId, batchId, batchLabel, ballotId, election, [
-      {
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          metadata: {
-            locales: { primary: 'en-US' },
-            electionHash: electionDefinition.electionHash,
-            ballotType: BallotType.Standard,
-            ballotStyleId,
-            precinctId,
-            isTestMode: false,
-            pageNumber: 1,
+    buildCastVoteRecord(
+      sheetId,
+      batchId,
+      batchLabel,
+      ballotId,
+      election,
+      [
+        {
+          interpretation: {
+            type: 'InterpretedHmpbPage',
+            metadata: {
+              locales: { primary: 'en-US' },
+              electionHash: electionDefinition.electionHash,
+              ballotType: BallotType.Standard,
+              ballotStyleId,
+              precinctId,
+              isTestMode: false,
+              pageNumber: 1,
+            },
+            adjudicationInfo: {
+              requiresAdjudication: false,
+              enabledReasons: [],
+              enabledReasonInfos: [],
+              ignoredReasonInfos: [],
+            },
+            markInfo: {
+              marks: [],
+              ballotSize: { width: 1, height: 1 },
+            },
+            votes: {
+              '2': [
+                {
+                  id: '23',
+                  name: 'Jimmy Edwards',
+                  partyIds: [unsafeParse(PartyIdSchema, '4')],
+                },
+              ],
+            },
           },
-          adjudicationInfo: {
-            requiresAdjudication: false,
-            enabledReasons: [],
-            enabledReasonInfos: [],
-            ignoredReasonInfos: [],
-          },
-          markInfo: {
-            marks: [],
-            ballotSize: { width: 1, height: 1 },
-          },
-          votes: {
-            '2': [
-              {
-                id: '23',
-                name: 'Jimmy Edwards',
-                partyIds: [unsafeParse(PartyIdSchema, '4')],
-              },
-            ],
-          },
+          contestIds: ['1', '2'],
         },
-        contestIds: ['1', '2'],
-      },
-      {
-        interpretation: {
-          type: 'UninterpretedHmpbPage',
-          metadata: {
-            locales: { primary: 'en-US' },
-            electionHash: electionDefinition.electionHash,
-            ballotType: BallotType.Standard,
-            ballotStyleId,
-            precinctId,
-            isTestMode: false,
-            pageNumber: 2,
+        {
+          interpretation: {
+            type: 'UninterpretedHmpbPage',
+            metadata: {
+              locales: { primary: 'en-US' },
+              electionHash: electionDefinition.electionHash,
+              ballotType: BallotType.Standard,
+              ballotStyleId,
+              precinctId,
+              isTestMode: false,
+              pageNumber: 2,
+            },
           },
+          contestIds: ['initiative-65'],
+          markAdjudications: [
+            {
+              type: AdjudicationReason.UninterpretableBallot,
+              contestId: 'initiative-65',
+              optionId: 'no',
+              isMarked: true,
+            },
+          ],
         },
-        contestIds: ['initiative-65'],
-        markAdjudications: [
-          {
-            type: AdjudicationReason.UninterpretableBallot,
-            contestId: 'initiative-65',
-            optionId: 'no',
-            isMarked: true,
-          },
-        ],
-      },
-    ])
+      ],
+      [
+        { normalized: 'normalized front', original: 'original front' },
+        { normalized: 'normalized back', original: 'original back' },
+      ]
+    )
   ).toMatchInlineSnapshot(`
     Object {
       "1": Array [],
@@ -960,6 +1118,16 @@ test('generates a CVR from an adjudicated uninterpreted HMPB page', () => {
         "23",
       ],
       "_ballotId": "abcdefg",
+      "_ballotImages": Array [
+        Object {
+          "normalized": "normalized front",
+          "original": "original front",
+        },
+        Object {
+          "normalized": "normalized back",
+          "original": "original back",
+        },
+      ],
       "_ballotStyleId": "1",
       "_ballotType": "standard",
       "_batchId": "1234",
@@ -990,82 +1158,93 @@ test('generates a CVR from an adjudicated write-in', () => {
   const batchLabel = 'Batch 1';
 
   expect(
-    buildCastVoteRecord(sheetId, batchId, batchLabel, ballotId, election, [
-      {
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          metadata: {
-            locales: { primary: 'en-US' },
-            electionHash: electionDefinition.electionHash,
-            ballotType: BallotType.Standard,
-            ballotStyleId,
-            precinctId,
-            isTestMode: false,
-            pageNumber: 1,
-          },
-          adjudicationInfo: {
-            requiresAdjudication: true,
-            enabledReasons: [AdjudicationReason.MarkedWriteIn],
-            enabledReasonInfos: [
-              {
-                type: AdjudicationReason.MarkedWriteIn,
-                contestId: '2',
-                optionId: 'write-in-0',
-                optionIndex: 3,
-              },
-            ],
-            ignoredReasonInfos: [],
-          },
-          markInfo: {
-            marks: [],
-            ballotSize: { width: 1, height: 1 },
-          },
-          votes: vote(election.contests, {
-            '2': {
-              id: 'write-in-0',
-              isWriteIn: true,
-              name: '',
+    buildCastVoteRecord(
+      sheetId,
+      batchId,
+      batchLabel,
+      ballotId,
+      election,
+      [
+        {
+          interpretation: {
+            type: 'InterpretedHmpbPage',
+            metadata: {
+              locales: { primary: 'en-US' },
+              electionHash: electionDefinition.electionHash,
+              ballotType: BallotType.Standard,
+              ballotStyleId,
+              precinctId,
+              isTestMode: false,
+              pageNumber: 1,
             },
-          }),
+            adjudicationInfo: {
+              requiresAdjudication: true,
+              enabledReasons: [AdjudicationReason.MarkedWriteIn],
+              enabledReasonInfos: [
+                {
+                  type: AdjudicationReason.MarkedWriteIn,
+                  contestId: '2',
+                  optionId: 'write-in-0',
+                  optionIndex: 3,
+                },
+              ],
+              ignoredReasonInfos: [],
+            },
+            markInfo: {
+              marks: [],
+              ballotSize: { width: 1, height: 1 },
+            },
+            votes: vote(election.contests, {
+              '2': {
+                id: 'write-in-0',
+                isWriteIn: true,
+                name: '',
+              },
+            }),
+          },
+          contestIds: ['1', '2'],
+          markAdjudications: [
+            {
+              type: AdjudicationReason.MarkedWriteIn,
+              contestId: '2',
+              optionId: 'write-in-0',
+              isMarked: true,
+              name: 'Pikachu',
+            },
+          ],
         },
-        contestIds: ['1', '2'],
-        markAdjudications: [
-          {
-            type: AdjudicationReason.MarkedWriteIn,
-            contestId: '2',
-            optionId: 'write-in-0',
-            isMarked: true,
-            name: 'Pikachu',
+        {
+          interpretation: {
+            type: 'InterpretedHmpbPage',
+            metadata: {
+              locales: { primary: 'en-US' },
+              electionHash: electionDefinition.electionHash,
+              ballotType: BallotType.Standard,
+              ballotStyleId,
+              precinctId,
+              isTestMode: false,
+              pageNumber: 2,
+            },
+            adjudicationInfo: {
+              requiresAdjudication: false,
+              enabledReasons: [],
+              enabledReasonInfos: [],
+              ignoredReasonInfos: [],
+            },
+            markInfo: {
+              marks: [],
+              ballotSize: { width: 1, height: 1 },
+            },
+            votes: {},
           },
-        ],
-      },
-      {
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          metadata: {
-            locales: { primary: 'en-US' },
-            electionHash: electionDefinition.electionHash,
-            ballotType: BallotType.Standard,
-            ballotStyleId,
-            precinctId,
-            isTestMode: false,
-            pageNumber: 2,
-          },
-          adjudicationInfo: {
-            requiresAdjudication: false,
-            enabledReasons: [],
-            enabledReasonInfos: [],
-            ignoredReasonInfos: [],
-          },
-          markInfo: {
-            marks: [],
-            ballotSize: { width: 1, height: 1 },
-          },
-          votes: {},
+          contestIds: [],
         },
-        contestIds: [],
-      },
-    ])
+      ],
+      [
+        { normalized: 'normalized front', original: 'original front' },
+        { normalized: 'normalized back', original: 'original back' },
+      ]
+    )
   ).toMatchInlineSnapshot(`
     Object {
       "1": Array [],
@@ -1073,6 +1252,16 @@ test('generates a CVR from an adjudicated write-in', () => {
         "write-in-0-Pikachu",
       ],
       "_ballotId": "abcdefg",
+      "_ballotImages": Array [
+        Object {
+          "normalized": "normalized front",
+          "original": "original front",
+        },
+        Object {
+          "normalized": "normalized back",
+          "original": "original back",
+        },
+      ],
       "_ballotStyleId": "1",
       "_ballotType": "standard",
       "_batchId": "1234",
@@ -1100,76 +1289,87 @@ test('generates a CVR from an adjudicated unmarked write-in', () => {
   const batchLabel = 'Batch 1';
 
   expect(
-    buildCastVoteRecord(sheetId, batchId, batchLabel, ballotId, election, [
-      {
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          metadata: {
-            locales: { primary: 'en-US' },
-            electionHash: electionDefinition.electionHash,
-            ballotType: BallotType.Standard,
-            ballotStyleId,
-            precinctId,
-            isTestMode: false,
-            pageNumber: 1,
+    buildCastVoteRecord(
+      sheetId,
+      batchId,
+      batchLabel,
+      ballotId,
+      election,
+      [
+        {
+          interpretation: {
+            type: 'InterpretedHmpbPage',
+            metadata: {
+              locales: { primary: 'en-US' },
+              electionHash: electionDefinition.electionHash,
+              ballotType: BallotType.Standard,
+              ballotStyleId,
+              precinctId,
+              isTestMode: false,
+              pageNumber: 1,
+            },
+            adjudicationInfo: {
+              requiresAdjudication: true,
+              enabledReasons: [AdjudicationReason.UnmarkedWriteIn],
+              enabledReasonInfos: [
+                {
+                  type: AdjudicationReason.UnmarkedWriteIn,
+                  contestId: '2',
+                  optionId: 'write-in-0',
+                  optionIndex: 3,
+                },
+              ],
+              ignoredReasonInfos: [],
+            },
+            markInfo: {
+              marks: [],
+              ballotSize: { width: 1, height: 1 },
+            },
+            votes: {},
           },
-          adjudicationInfo: {
-            requiresAdjudication: true,
-            enabledReasons: [AdjudicationReason.UnmarkedWriteIn],
-            enabledReasonInfos: [
-              {
-                type: AdjudicationReason.UnmarkedWriteIn,
-                contestId: '2',
-                optionId: 'write-in-0',
-                optionIndex: 3,
-              },
-            ],
-            ignoredReasonInfos: [],
-          },
-          markInfo: {
-            marks: [],
-            ballotSize: { width: 1, height: 1 },
-          },
-          votes: {},
+          contestIds: ['1', '2'],
+          markAdjudications: [
+            {
+              type: AdjudicationReason.UnmarkedWriteIn,
+              contestId: '2',
+              optionId: 'write-in-0',
+              isMarked: true,
+              name: 'Pikachu',
+            },
+          ],
         },
-        contestIds: ['1', '2'],
-        markAdjudications: [
-          {
-            type: AdjudicationReason.UnmarkedWriteIn,
-            contestId: '2',
-            optionId: 'write-in-0',
-            isMarked: true,
-            name: 'Pikachu',
+        {
+          interpretation: {
+            type: 'InterpretedHmpbPage',
+            metadata: {
+              locales: { primary: 'en-US' },
+              electionHash: electionDefinition.electionHash,
+              ballotType: BallotType.Standard,
+              ballotStyleId,
+              precinctId,
+              isTestMode: false,
+              pageNumber: 2,
+            },
+            adjudicationInfo: {
+              requiresAdjudication: false,
+              enabledReasons: [],
+              enabledReasonInfos: [],
+              ignoredReasonInfos: [],
+            },
+            markInfo: {
+              marks: [],
+              ballotSize: { width: 1, height: 1 },
+            },
+            votes: {},
           },
-        ],
-      },
-      {
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          metadata: {
-            locales: { primary: 'en-US' },
-            electionHash: electionDefinition.electionHash,
-            ballotType: BallotType.Standard,
-            ballotStyleId,
-            precinctId,
-            isTestMode: false,
-            pageNumber: 2,
-          },
-          adjudicationInfo: {
-            requiresAdjudication: false,
-            enabledReasons: [],
-            enabledReasonInfos: [],
-            ignoredReasonInfos: [],
-          },
-          markInfo: {
-            marks: [],
-            ballotSize: { width: 1, height: 1 },
-          },
-          votes: {},
+          contestIds: [],
         },
-        contestIds: [],
-      },
-    ])
+      ],
+      [
+        { normalized: 'normalized front', original: 'original front' },
+        { normalized: 'normalized back', original: 'original back' },
+      ]
+    )
   ).toMatchInlineSnapshot(`
     Object {
       "1": Array [],
@@ -1177,6 +1377,16 @@ test('generates a CVR from an adjudicated unmarked write-in', () => {
         "write-in-0-Pikachu",
       ],
       "_ballotId": "abcdefg",
+      "_ballotImages": Array [
+        Object {
+          "normalized": "normalized front",
+          "original": "original front",
+        },
+        Object {
+          "normalized": "normalized back",
+          "original": "original back",
+        },
+      ],
       "_ballotStyleId": "1",
       "_ballotType": "standard",
       "_batchId": "1234",
@@ -1202,10 +1412,21 @@ test('fails to generate CVRs from blank pages', () => {
   const batchLabel = 'Batch 1';
 
   expect(
-    buildCastVoteRecord(sheetId, batchId, batchLabel, ballotId, election, [
-      { interpretation: { type: 'BlankPage' } },
-      { interpretation: { type: 'BlankPage' } },
-    ])
+    buildCastVoteRecord(
+      sheetId,
+      batchId,
+      batchLabel,
+      ballotId,
+      election,
+      [
+        { interpretation: { type: 'BlankPage' } },
+        { interpretation: { type: 'BlankPage' } },
+      ],
+      [
+        { normalized: '', original: '' },
+        { normalized: '', original: '' },
+      ]
+    )
   ).toBeUndefined();
 });
 
@@ -1218,21 +1439,32 @@ test('fails to generate CVRs from invalid test mode pages', () => {
   const batchLabel = 'Batch 1';
 
   expect(
-    buildCastVoteRecord(sheetId, batchId, batchLabel, ballotId, election, [
-      {
-        interpretation: {
-          type: 'InvalidTestModePage',
-          metadata: {
-            locales: { primary: 'en-US' },
-            electionHash: electionDefinition.electionHash,
-            ballotType: BallotType.Standard,
-            ballotStyleId,
-            precinctId,
-            isTestMode: false,
+    buildCastVoteRecord(
+      sheetId,
+      batchId,
+      batchLabel,
+      ballotId,
+      election,
+      [
+        {
+          interpretation: {
+            type: 'InvalidTestModePage',
+            metadata: {
+              locales: { primary: 'en-US' },
+              electionHash: electionDefinition.electionHash,
+              ballotType: BallotType.Standard,
+              ballotStyleId,
+              precinctId,
+              isTestMode: false,
+            },
           },
         },
-      },
-      { interpretation: { type: 'BlankPage' } },
-    ])
+        { interpretation: { type: 'BlankPage' } },
+      ],
+      [
+        { normalized: 'normalized front', original: 'original front' },
+        { normalized: 'normalized back', original: 'original back' },
+      ]
+    )
   ).toBeUndefined();
 });

--- a/services/scan/src/build_cast_vote_record.test.ts
+++ b/services/scan/src/build_cast_vote_record.test.ts
@@ -362,14 +362,7 @@ test('generates a CVR from a completed HMPB page', () => {
         "22",
       ],
       "_ballotId": "abcdefg",
-      "_ballotImages": Array [
-        Object {
-          "normalized": "normalized front",
-        },
-        Object {
-          "normalized": "normalized back",
-        },
-      ],
+      "_ballotImages": Array [],
       "_ballotStyleId": "1",
       "_ballotType": "standard",
       "_batchId": "1234",
@@ -597,14 +590,7 @@ test('generates a CVR from a completed absentee HMPB page', () => {
         "22",
       ],
       "_ballotId": "abcdefg",
-      "_ballotImages": Array [
-        Object {
-          "normalized": "front normalized",
-        },
-        Object {
-          "normalized": "back normalized",
-        },
-      ],
+      "_ballotImages": Array [],
       "_ballotStyleId": "1",
       "_ballotType": "absentee",
       "_batchId": "1234",
@@ -730,14 +716,7 @@ test('generates a CVR from an adjudicated HMPB page', () => {
         "22",
       ],
       "_ballotId": "abcdefg",
-      "_ballotImages": Array [
-        Object {
-          "normalized": "normalized back",
-        },
-        Object {
-          "normalized": "normalized front",
-        },
-      ],
+      "_ballotImages": Array [],
       "_ballotStyleId": "1",
       "_ballotType": "standard",
       "_batchId": "1234",
@@ -1096,14 +1075,7 @@ test('generates a CVR from an adjudicated uninterpreted HMPB page', () => {
         "23",
       ],
       "_ballotId": "abcdefg",
-      "_ballotImages": Array [
-        Object {
-          "normalized": "normalized front",
-        },
-        Object {
-          "normalized": "normalized back",
-        },
-      ],
+      "_ballotImages": Array [],
       "_ballotStyleId": "1",
       "_ballotType": "standard",
       "_batchId": "1234",

--- a/services/scan/src/build_cast_vote_record.test.ts
+++ b/services/scan/src/build_cast_vote_record.test.ts
@@ -246,10 +246,7 @@ test('generates a CVR from a completed BMD ballot with write in and overvotes', 
             },
           },
         ],
-        [
-          { normalized: 'normalized front', original: 'original front' },
-          { normalized: 'normalized back', original: 'original back' },
-        ]
+        [{ normalized: 'normalized front' }, { normalized: 'normalized back' }]
       )
     ).toMatchInlineSnapshot(`
           Object {
@@ -354,10 +351,7 @@ test('generates a CVR from a completed HMPB page', () => {
           contestIds: ['initiative-65'],
         },
       ],
-      [
-        { normalized: 'normalized front', original: 'original front' },
-        { normalized: 'normalized back', original: 'original back' },
-      ]
+      [{ normalized: 'normalized front' }, { normalized: 'normalized back' }]
     )
   ).toMatchInlineSnapshot(`
     Object {
@@ -371,11 +365,9 @@ test('generates a CVR from a completed HMPB page', () => {
       "_ballotImages": Array [
         Object {
           "normalized": "normalized front",
-          "original": "original front",
         },
         Object {
           "normalized": "normalized back",
-          "original": "original back",
         },
       ],
       "_ballotStyleId": "1",
@@ -472,10 +464,7 @@ test('generates a CVR from a completed HMPB page with write in votes and overvot
           contestIds: ['initiative-65'],
         },
       ],
-      [
-        { normalized: 'normalized front', original: 'original front' },
-        { normalized: 'normalized back', original: 'original back' },
-      ]
+      [{ normalized: 'normalized front' }, { normalized: 'normalized back' }]
     )
   ).toMatchInlineSnapshot(`
     Object {
@@ -490,11 +479,9 @@ test('generates a CVR from a completed HMPB page with write in votes and overvot
       "_ballotImages": Array [
         Object {
           "normalized": "normalized front",
-          "original": "original front",
         },
         Object {
           "normalized": "normalized back",
-          "original": "original back",
         },
       ],
       "_ballotStyleId": "1",
@@ -591,10 +578,7 @@ test('generates a CVR from a completed absentee HMPB page', () => {
           contestIds: ['initiative-65'],
         },
       ],
-      [
-        { normalized: 'front normalized', original: 'front original' },
-        { normalized: 'back normalized', original: 'back original' },
-      ]
+      [{ normalized: 'front normalized' }, { normalized: 'back normalized' }]
     )
   ).toMatchInlineSnapshot(`
     Object {
@@ -608,11 +592,9 @@ test('generates a CVR from a completed absentee HMPB page', () => {
       "_ballotImages": Array [
         Object {
           "normalized": "front normalized",
-          "original": "front original",
         },
         Object {
           "normalized": "back normalized",
-          "original": "back original",
         },
       ],
       "_ballotStyleId": "1",
@@ -725,10 +707,7 @@ test('generates a CVR from an adjudicated HMPB page', () => {
           contestIds: ['1', '2'],
         },
       ],
-      [
-        { normalized: 'normalized front', original: 'original front' },
-        { normalized: 'normalized back', original: 'original back' },
-      ]
+      [{ normalized: 'normalized front' }, { normalized: 'normalized back' }]
     )
   ).toMatchInlineSnapshot(`
     Object {
@@ -742,11 +721,9 @@ test('generates a CVR from an adjudicated HMPB page', () => {
       "_ballotImages": Array [
         Object {
           "normalized": "normalized back",
-          "original": "original back",
         },
         Object {
           "normalized": "normalized front",
-          "original": "original front",
         },
       ],
       "_ballotStyleId": "1",
@@ -826,10 +803,7 @@ test('fails to generate a CVR from an invalid HMPB sheet with two pages having t
           },
         },
       ],
-      [
-        { normalized: 'normalized front', original: 'original front' },
-        { normalized: 'normalized back', original: 'original back' },
-      ]
+      [{ normalized: 'normalized front' }, { normalized: 'normalized back' }]
     )
   ).toThrowError(
     'expected a sheet to have consecutive page numbers, but got front=1 back=1'
@@ -892,10 +866,7 @@ test('fails to generate a CVR from an invalid HMPB sheet with two non-consecutiv
           },
         },
       ],
-      [
-        { normalized: 'normalized front', original: 'original front' },
-        { normalized: 'normalized back', original: 'original back' },
-      ]
+      [{ normalized: 'normalized front' }, { normalized: 'normalized back' }]
     )
   ).toThrowError(
     'expected a sheet to have consecutive page numbers, but got front=1 back=3'
@@ -957,10 +928,7 @@ test('fails to generate a CVR from an invalid HMPB sheet with different ballot s
           },
         },
       ],
-      [
-        { normalized: 'normalized front', original: 'original front' },
-        { normalized: 'normalized back', original: 'original back' },
-      ]
+      [{ normalized: 'normalized front' }, { normalized: 'normalized back' }]
     )
   ).toThrowError(
     'expected a sheet to have the same ballot style, but got front=1 back=2'
@@ -1022,10 +990,7 @@ test('fails to generate a CVR from an invalid HMPB sheet with different precinct
           },
         },
       ],
-      [
-        { normalized: 'normalized front', original: 'original front' },
-        { normalized: 'normalized back', original: 'original back' },
-      ]
+      [{ normalized: 'normalized front' }, { normalized: 'normalized back' }]
     )
   ).toThrowError(
     'expected a sheet to have the same precinct, but got front=6522 back=6523'
@@ -1106,10 +1071,7 @@ test('generates a CVR from an adjudicated uninterpreted HMPB page', () => {
           ],
         },
       ],
-      [
-        { normalized: 'normalized front', original: 'original front' },
-        { normalized: 'normalized back', original: 'original back' },
-      ]
+      [{ normalized: 'normalized front' }, { normalized: 'normalized back' }]
     )
   ).toMatchInlineSnapshot(`
     Object {
@@ -1121,11 +1083,9 @@ test('generates a CVR from an adjudicated uninterpreted HMPB page', () => {
       "_ballotImages": Array [
         Object {
           "normalized": "normalized front",
-          "original": "original front",
         },
         Object {
           "normalized": "normalized back",
-          "original": "original back",
         },
       ],
       "_ballotStyleId": "1",
@@ -1240,10 +1200,7 @@ test('generates a CVR from an adjudicated write-in', () => {
           contestIds: [],
         },
       ],
-      [
-        { normalized: 'normalized front', original: 'original front' },
-        { normalized: 'normalized back', original: 'original back' },
-      ]
+      [{ normalized: 'normalized front' }, { normalized: 'normalized back' }]
     )
   ).toMatchInlineSnapshot(`
     Object {
@@ -1255,11 +1212,9 @@ test('generates a CVR from an adjudicated write-in', () => {
       "_ballotImages": Array [
         Object {
           "normalized": "normalized front",
-          "original": "original front",
         },
         Object {
           "normalized": "normalized back",
-          "original": "original back",
         },
       ],
       "_ballotStyleId": "1",
@@ -1365,10 +1320,7 @@ test('generates a CVR from an adjudicated unmarked write-in', () => {
           contestIds: [],
         },
       ],
-      [
-        { normalized: 'normalized front', original: 'original front' },
-        { normalized: 'normalized back', original: 'original back' },
-      ]
+      [{ normalized: 'normalized front' }, { normalized: 'normalized back' }]
     )
   ).toMatchInlineSnapshot(`
     Object {
@@ -1380,11 +1332,9 @@ test('generates a CVR from an adjudicated unmarked write-in', () => {
       "_ballotImages": Array [
         Object {
           "normalized": "normalized front",
-          "original": "original front",
         },
         Object {
           "normalized": "normalized back",
-          "original": "original back",
         },
       ],
       "_ballotStyleId": "1",
@@ -1422,10 +1372,7 @@ test('fails to generate CVRs from blank pages', () => {
         { interpretation: { type: 'BlankPage' } },
         { interpretation: { type: 'BlankPage' } },
       ],
-      [
-        { normalized: '', original: '' },
-        { normalized: '', original: '' },
-      ]
+      [{ normalized: '' }, { normalized: '' }]
     )
   ).toBeUndefined();
 });
@@ -1461,10 +1408,7 @@ test('fails to generate CVRs from invalid test mode pages', () => {
         },
         { interpretation: { type: 'BlankPage' } },
       ],
-      [
-        { normalized: 'normalized front', original: 'original front' },
-        { normalized: 'normalized back', original: 'original back' },
-      ]
+      [{ normalized: 'normalized front' }, { normalized: 'normalized back' }]
     )
   ).toBeUndefined();
 });

--- a/services/scan/src/build_cast_vote_record.ts
+++ b/services/scan/src/build_cast_vote_record.ts
@@ -2,6 +2,7 @@ import {
   AdjudicationReason,
   AnyContest,
   BallotId,
+  BallotPageLayout,
   BallotMetadata,
   BallotType,
   CandidateVote,
@@ -233,7 +234,7 @@ function buildCastVoteRecordFromHmpbPage(
     BuildCastVoteRecordInput<InterpretedHmpbPage | UninterpretedHmpbPage>
   >,
   [frontImages, backImages]: InlineBallotImage[],
-  [frontLayout, backLayout]: BallotPageLayout[][]
+  [frontLayout, backLayout]: Array<BallotPageLayout[]>
 ): CastVoteRecord {
   if (
     front.interpretation.metadata.pageNumber >
@@ -246,7 +247,8 @@ function buildCastVoteRecordFromHmpbPage(
       batchLabel,
       election,
       [back, front],
-      [backImages, frontImages]
+      [backImages, frontImages],
+      [backLayout, frontLayout]
     );
   }
 
@@ -280,6 +282,7 @@ function buildCastVoteRecordFromHmpbPage(
       back.markAdjudications
     ),
     _ballotImages: [frontImages, backImages],
+    _layouts: [frontLayout, backLayout],
   };
 }
 
@@ -291,7 +294,7 @@ export function buildCastVoteRecord(
   election: Election,
   [front, back]: SheetOf<BuildCastVoteRecordInput>,
   [frontImage, backImage]: InlineBallotImage[],
-  [frontLayout, backLayout]: BallotPageLayout[][] = []
+  [frontLayout, backLayout]: Array<BallotPageLayout[]> = []
 ): CastVoteRecord | undefined {
   const validationResult = validateSheetInterpretation([
     front.interpretation,

--- a/services/scan/src/build_cast_vote_record.ts
+++ b/services/scan/src/build_cast_vote_record.ts
@@ -230,7 +230,8 @@ function buildCastVoteRecordFromHmpbPage(
   election: Election,
   [front, back]: SheetOf<
     BuildCastVoteRecordInput<InterpretedHmpbPage | UninterpretedHmpbPage>
-  >
+  >,
+  [frontImages, backImages]: any
 ): CastVoteRecord {
   if (
     front.interpretation.metadata.pageNumber >
@@ -242,7 +243,8 @@ function buildCastVoteRecordFromHmpbPage(
       batchId,
       batchLabel,
       election,
-      [back, front]
+      [back, front],
+      [backImages, frontImages]
     );
   }
 
@@ -275,6 +277,7 @@ function buildCastVoteRecordFromHmpbPage(
         : {},
       back.markAdjudications
     ),
+    _ballotImages: [frontImages, backImages],
   };
 }
 
@@ -284,7 +287,8 @@ export function buildCastVoteRecord(
   batchLabel: string,
   ballotId: BallotId,
   election: Election,
-  [front, back]: SheetOf<BuildCastVoteRecordInput>
+  [front, back]: SheetOf<BuildCastVoteRecordInput>,
+  [frontImages, backImages]: any // istanbul ignore line
 ): CastVoteRecord | undefined {
   const validationResult = validateSheetInterpretation([
     front.interpretation,
@@ -307,7 +311,8 @@ export function buildCastVoteRecord(
       batchLabel,
       ballotId,
       election,
-      [back, front]
+      [back, front],
+      [frontImages, backImages]
     );
   }
 
@@ -333,7 +338,8 @@ export function buildCastVoteRecord(
       election,
       [front, back] as SheetOf<
         BuildCastVoteRecordInput<InterpretedHmpbPage | UninterpretedHmpbPage>
-      >
+      >,
+      [frontImages, backImages]
     );
   }
 }

--- a/services/scan/src/build_cast_vote_record.ts
+++ b/services/scan/src/build_cast_vote_record.ts
@@ -13,6 +13,7 @@ import {
   getBallotStyle,
   getContests,
   getContestsFromIds,
+  InlineBallotImage,
   InterpretedBmdPage,
   InterpretedHmpbPage,
   MarkAdjudications,
@@ -231,7 +232,8 @@ function buildCastVoteRecordFromHmpbPage(
   [front, back]: SheetOf<
     BuildCastVoteRecordInput<InterpretedHmpbPage | UninterpretedHmpbPage>
   >,
-  [frontImages, backImages]: any
+  [frontImages, backImages]: InlineBallotImage[],
+  [frontLayout, backLayout]: BallotPageLayout[][]
 ): CastVoteRecord {
   if (
     front.interpretation.metadata.pageNumber >
@@ -288,7 +290,8 @@ export function buildCastVoteRecord(
   ballotId: BallotId,
   election: Election,
   [front, back]: SheetOf<BuildCastVoteRecordInput>,
-  [frontImages, backImages]: any // istanbul ignore line
+  [frontImage, backImage]: InlineBallotImage[],
+  [frontLayout, backLayout]: BallotPageLayout[][] = []
 ): CastVoteRecord | undefined {
   const validationResult = validateSheetInterpretation([
     front.interpretation,
@@ -312,7 +315,7 @@ export function buildCastVoteRecord(
       ballotId,
       election,
       [back, front],
-      [frontImages, backImages]
+      [frontImage, backImage]
     );
   }
 
@@ -339,7 +342,8 @@ export function buildCastVoteRecord(
       [front, back] as SheetOf<
         BuildCastVoteRecordInput<InterpretedHmpbPage | UninterpretedHmpbPage>
       >,
-      [frontImages, backImages]
+      [frontImage, backImage],
+      [frontLayout, backLayout]
     );
   }
 }

--- a/services/scan/src/store.test.ts
+++ b/services/scan/src/store.test.ts
@@ -540,18 +540,31 @@ test('exportCvrs', async () => {
         ...metadata,
         pageNumber: 2,
       },
-      contests: [],
+      contests: [
+        {
+          bounds: { x: 0, y: 0, width: 100, height: 100 },
+          corners: [
+            { x: 0, y: 0 },
+            { x: 100, y: 0 },
+            { x: 100, y: 100 },
+            { x: 0, y: 100 },
+          ],
+          options: [
+            {
+              bounds: { x: 0, y: 50, width: 100, height: 50 },
+              target: {
+                bounds: { x: 20, y: 60, width: 20, height: 10 },
+                inner: { x: 22, y: 62, width: 16, height: 6 },
+              },
+            },
+          ],
+        },
+      ],
     },
   ]);
 
-  const frontOriginalFile = tmp.fileSync();
-  await writeFile(frontOriginalFile.fd, 'front original');
-
   const frontNormalizedFile = tmp.fileSync();
   await writeFile(frontNormalizedFile.fd, 'front normalized');
-
-  const backOriginalFile = tmp.fileSync();
-  await writeFile(backOriginalFile.fd, 'back original');
 
   const backNormalizedFile = tmp.fileSync();
   await writeFile(backNormalizedFile.fd, 'back normalized');
@@ -560,7 +573,7 @@ test('exportCvrs', async () => {
   const batchId = store.addBatch();
   const sheetId = store.addSheet(uuid(), batchId, [
     {
-      originalFilename: frontOriginalFile.name,
+      originalFilename: '/tmp/front-page.png',
       normalizedFilename: frontNormalizedFile.name,
       interpretation: {
         type: 'UninterpretedHmpbPage',
@@ -571,7 +584,7 @@ test('exportCvrs', async () => {
       },
     },
     {
-      originalFilename: backOriginalFile.name,
+      originalFilename: '/tmp/back-page.png',
       normalizedFilename: backNormalizedFile.name,
       interpretation: {
         type: 'UninterpretedHmpbPage',

--- a/services/scan/src/store.test.ts
+++ b/services/scan/src/store.test.ts
@@ -532,7 +532,26 @@ test('exportCvrs', async () => {
         ...metadata,
         pageNumber: 1,
       },
-      contests: [],
+      contests: [
+        {
+          bounds: { x: 0, y: 0, width: 100, height: 100 },
+          corners: [
+            { x: 0, y: 0 },
+            { x: 100, y: 0 },
+            { x: 100, y: 100 },
+            { x: 0, y: 100 },
+          ],
+          options: [
+            {
+              bounds: { x: 0, y: 50, width: 100, height: 50 },
+              target: {
+                bounds: { x: 20, y: 60, width: 20, height: 10 },
+                inner: { x: 22, y: 62, width: 16, height: 6 },
+              },
+            },
+          ],
+        },
+      ],
     },
     {
       pageSize: { width: 1, height: 1 },
@@ -604,7 +623,10 @@ test('exportCvrs', async () => {
     expect.stringContaining(stateOfHamilton.election.precincts[0].id)
   );
   expect(stream.toString()).toEqual(
-    expect.stringContaining('front normalized')
+    expect.stringContaining('front normalized') &&
+      expect.stringContaining(
+        '{"bounds":{"x":0,"y":50,"width":100,"height":50}'
+      )
   );
 
   // Confirm that deleted batches are not included in exported CVRs

--- a/services/scan/src/store.ts
+++ b/services/scan/src/store.ts
@@ -916,7 +916,16 @@ export class Store {
             markAdjudications: backAdjudications,
           },
         ],
-        [frontImages, backImages]
+        [frontImage, backImage],
+        (frontInterpretation.type === 'InterpretedHmpbPage' ||
+          frontInterpretation.type === 'UninterpretedHmpbPage') &&
+          (backInterpretation.type === 'InterpretedHmpbPage' ||
+            backInterpretation.type === 'UninterpretedHmpbPage')
+          ? [
+              this.getBallotLayoutsForMetadata(frontInterpretation.metadata),
+              this.getBallotLayoutsForMetadata(backInterpretation.metadata),
+            ]
+          : undefined
       );
 
       if (cvr) {

--- a/services/scan/src/store.ts
+++ b/services/scan/src/store.ts
@@ -862,6 +862,37 @@ export class Store {
       const backAdjudications = backAdjudicationJson
         ? safeParseJson(backAdjudicationJson, MarkAdjudicationsSchema).ok()
         : undefined;
+
+      const frontImages = [];
+      const backImages = [];
+      if (
+        frontInterpretation.type === 'InterpretedHmpbPage' ||
+        frontInterpretation.type === 'UninterpretedHmpbPage'
+      ) {
+        const frontFilenames = this.getBallotFilenames(id, 'front');
+        if (frontFilenames?.normalized) {
+          frontImages.push({
+            normalized: fs.readFileSync(frontFilenames.normalized, 'utf-8'),
+          });
+        }
+        if (frontFilenames?.original) {
+          frontImages.push({
+            original: fs.readFileSync(frontFilenames.original, 'utf-8'),
+          });
+        }
+        const backFilenames = this.getBallotFilenames(id, 'back');
+        if (backFilenames?.normalized) {
+          backImages.push({
+            normalized: fs.readFileSync(backFilenames.normalized, 'utf-8'),
+          });
+        }
+        if (backFilenames?.original) {
+          backImages.push({
+            original: fs.readFileSync(backFilenames.original, 'utf-8'),
+          });
+        }
+      }
+
       const cvr = buildCastVoteRecord(
         id,
         batchId,
@@ -891,7 +922,8 @@ export class Store {
                 : undefined,
             markAdjudications: backAdjudications,
           },
-        ]
+        ],
+        [frontImages, backImages]
       );
 
       if (cvr) {

--- a/services/scan/src/store.ts
+++ b/services/scan/src/store.ts
@@ -875,20 +875,10 @@ export class Store {
             normalized: fs.readFileSync(frontFilenames.normalized, 'utf-8'),
           });
         }
-        if (frontFilenames?.original) {
-          frontImages.push({
-            original: fs.readFileSync(frontFilenames.original, 'utf-8'),
-          });
-        }
         const backFilenames = this.getBallotFilenames(id, 'back');
         if (backFilenames?.normalized) {
           backImages.push({
             normalized: fs.readFileSync(backFilenames.normalized, 'utf-8'),
-          });
-        }
-        if (backFilenames?.original) {
-          backImages.push({
-            original: fs.readFileSync(backFilenames.original, 'utf-8'),
           });
         }
       }

--- a/services/scan/src/store.ts
+++ b/services/scan/src/store.ts
@@ -874,14 +874,14 @@ export class Store {
         if (frontFilenames?.normalized) {
           frontImage.normalized = fs.readFileSync(
             frontFilenames.normalized,
-            'utf-8'
+            'base64'
           );
         }
         const backFilenames = this.getBallotFilenames(id, 'back');
         if (backFilenames?.normalized) {
           backImage.normalized = fs.readFileSync(
             backFilenames.normalized,
-            'utf-8'
+            'base64'
           );
         }
       }

--- a/services/scan/src/store.ts
+++ b/services/scan/src/store.ts
@@ -17,6 +17,7 @@ import {
   ElectionDefinitionSchema,
   getBallotStyle,
   getContests,
+  InlineBallotImage,
   MarkAdjudication,
   MarkAdjudicationsSchema,
   MarkThresholds,
@@ -863,23 +864,25 @@ export class Store {
         ? safeParseJson(backAdjudicationJson, MarkAdjudicationsSchema).ok()
         : undefined;
 
-      const frontImages = [];
-      const backImages = [];
+      const frontImage: InlineBallotImage = { normalized: '' };
+      const backImage: InlineBallotImage = { normalized: '' };
       if (
         frontInterpretation.type === 'InterpretedHmpbPage' ||
         frontInterpretation.type === 'UninterpretedHmpbPage'
       ) {
         const frontFilenames = this.getBallotFilenames(id, 'front');
         if (frontFilenames?.normalized) {
-          frontImages.push({
-            normalized: fs.readFileSync(frontFilenames.normalized, 'utf-8'),
-          });
+          frontImage.normalized = fs.readFileSync(
+            frontFilenames.normalized,
+            'utf-8'
+          );
         }
         const backFilenames = this.getBallotFilenames(id, 'back');
         if (backFilenames?.normalized) {
-          backImages.push({
-            normalized: fs.readFileSync(backFilenames.normalized, 'utf-8'),
-          });
+          backImage.normalized = fs.readFileSync(
+            backFilenames.normalized,
+            'utf-8'
+          );
         }
       }
 


### PR DESCRIPTION
## Overview
This exports ballot images and their layouts from `services/scan` for write-ins, and then is a hacky implementation of importing and displaying them in VxAdmin (it relies on the imported CVRs still being stored in `localStorage`, which will no longer be the case once Caroline's changes are merged and we instead store ballot image data in the sqlite db.)

This is quite sloppy and there are many improvements to be made. I'll specifically call out that I have [not yet figured out how](https://github.com/votingworks/vxsuite/pull/2052/files#diff-abb77c3417aaa6a6956486027a0ea65dffe593ccc14965570408026bfabd26c2R129) we associate a given write-in to the correct layout in `cvr._layouts`. This example hard codes the correct layout for the CVRs I was testing. (The first layout in `cvr._layouts` is the front, the second is the back, but beyond that I don't know how to identify which of those layouts corresponds to the given contest.

## Demo Video or Screenshot
<img width="1440" alt="Screen Shot 2022-06-30 at 3 09 03 PM" src="https://user-images.githubusercontent.com/7584833/176800596-93071762-19d7-476b-a02f-9a9723293c22.png">

## Testing Plan 

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
