### PR TITLE
Split Reports & Tally screen

### DIFF
--- a/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
+++ b/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
@@ -70,6 +70,13 @@ exports[`L&A (logic and accuracy) flow 1`] = `
           role="option"
           type="button"
         >
+          Reports
+        </button>
+        <button
+          class="sc-iBPRYJ fvkSI"
+          role="option"
+          type="button"
+        >
           Advanced
         </button>
       </div>
@@ -1489,6 +1496,13 @@ exports[`L&A (logic and accuracy) flow 2`] = `
           role="option"
           type="button"
         >
+          Reports
+        </button>
+        <button
+          class="sc-iBPRYJ fvkSI"
+          role="option"
+          type="button"
+        >
           Advanced
         </button>
       </div>
@@ -2641,6 +2655,13 @@ exports[`L&A (logic and accuracy) flow 3`] = `
           type="button"
         >
           Tally
+        </button>
+        <button
+          class="sc-iBPRYJ fvkSI"
+          role="option"
+          type="button"
+        >
+          Reports
         </button>
         <button
           class="sc-iBPRYJ fvkSI"

--- a/frontends/election-manager/src/components/ballot_counts_table.test.tsx
+++ b/frontends/election-manager/src/components/ballot_counts_table.test.tsx
@@ -90,7 +90,7 @@ describe('Ballot Counts by Precinct', () => {
       expect(tableRow).toBeDefined();
       expect(domGetByText(tableRow!, 0)).toBeInTheDocument();
       expect(
-        domGetByText(tableRow!, `View Unofficial ${precinct.name} Tally Report`)
+        domGetByText(tableRow!, `Unofficial ${precinct.name} Tally Report`)
       ).toBeInTheDocument();
     }
     getByText('Total Ballot Count');
@@ -98,7 +98,7 @@ describe('Ballot Counts by Precinct', () => {
     expect(tableRow).toBeDefined();
     expect(domGetByText(tableRow!, 0)).toBeInTheDocument();
     expect(
-      domGetByText(tableRow!, 'View Unofficial Tally Reports for All Precincts')
+      domGetByText(tableRow!, 'Unofficial Tally Reports for All Precincts')
     ).toBeInTheDocument();
 
     // There should be 2 more rows then the number of precincts (header row and totals row)
@@ -125,7 +125,7 @@ describe('Ballot Counts by Precinct', () => {
         domGetByText(tableRow!, expectedNumberOfBallots)
       ).toBeInTheDocument();
       expect(
-        domGetByText(tableRow!, `View Unofficial ${precinct.name} Tally Report`)
+        domGetByText(tableRow!, `Unofficial ${precinct.name} Tally Report`)
       ).toBeInTheDocument();
     }
     getByText('Total Ballot Count');
@@ -133,7 +133,7 @@ describe('Ballot Counts by Precinct', () => {
     expect(tableRow).toBeDefined();
     expect(domGetByText(tableRow!, 77)).toBeInTheDocument();
     expect(
-      domGetByText(tableRow!, 'View Unofficial Tally Reports for All Precincts')
+      domGetByText(tableRow!, 'Unofficial Tally Reports for All Precincts')
     ).toBeInTheDocument();
 
     // There should be 2 more rows then the number of precincts (header row and totals row)
@@ -162,7 +162,7 @@ describe('Ballot Counts by Precinct', () => {
         domGetByText(tableRow!, expectedNumberOfBallots)
       ).toBeInTheDocument();
       expect(
-        domGetByText(tableRow!, `View Unofficial ${precinct.name} Tally Report`)
+        domGetByText(tableRow!, `Unofficial ${precinct.name} Tally Report`)
       ).toBeInTheDocument();
     }
     getByText('Total Ballot Count');
@@ -170,7 +170,7 @@ describe('Ballot Counts by Precinct', () => {
     expect(tableRow).toBeDefined();
     expect(domGetByText(tableRow!, 131)).toBeInTheDocument();
     expect(
-      domGetByText(tableRow!, 'View Unofficial Tally Reports for All Precincts')
+      domGetByText(tableRow!, 'Unofficial Tally Reports for All Precincts')
     ).toBeInTheDocument();
 
     // There should be 2 more rows then the number of precincts (header row and totals row)
@@ -250,7 +250,7 @@ describe('Ballot Counts by Scanner', () => {
         expect(
           domGetByText(
             tableRow!,
-            `View Unofficial Scanner ${scannerId} Tally Report`
+            `Unofficial Scanner ${scannerId} Tally Report`
           )
         ).toBeInTheDocument();
       }
@@ -288,7 +288,7 @@ describe('Ballot Counts by Scanner', () => {
         expect(
           domGetByText(
             tableRow!,
-            `View Unofficial Scanner ${scannerId} Tally Report`
+            `Unofficial Scanner ${scannerId} Tally Report`
           )
         ).toBeInTheDocument();
       }
@@ -386,7 +386,7 @@ describe('Ballots Counts by Party', () => {
       expect(tableRow).toBeDefined();
       expect(domGetByText(tableRow!, 0)).toBeInTheDocument();
       expect(
-        domGetByText(tableRow!, `View Unofficial ${partyName} Tally Report`)
+        domGetByText(tableRow!, `Unofficial ${partyName} Tally Report`)
       ).toBeInTheDocument();
     }
 
@@ -394,9 +394,6 @@ describe('Ballots Counts by Party', () => {
     const tableRow = getByText('Total Ballot Count').closest('tr');
     expect(tableRow).toBeDefined();
     expect(domGetByText(tableRow!, 0)).toBeInTheDocument();
-    expect(
-      domGetByText(tableRow!, 'View Unofficial Full Election Tally Report')
-    ).toBeInTheDocument();
 
     expect(getAllByTestId('table-row').length).toBe(expectedParties.length + 2);
   });
@@ -428,7 +425,7 @@ describe('Ballots Counts by Party', () => {
         domGetByText(tableRow!, expectedNumberOfBallots)
       ).toBeInTheDocument();
       expect(
-        domGetByText(tableRow!, `View Unofficial ${partyName} Tally Report`)
+        domGetByText(tableRow!, `Unofficial ${partyName} Tally Report`)
       ).toBeInTheDocument();
     }
 
@@ -436,9 +433,6 @@ describe('Ballots Counts by Party', () => {
     const tableRow = getByText('Total Ballot Count').closest('tr');
     expect(tableRow).toBeDefined();
     expect(domGetByText(tableRow!, 77)).toBeInTheDocument();
-    expect(
-      domGetByText(tableRow!, 'View Unofficial Full Election Tally Report')
-    ).toBeInTheDocument();
 
     expect(getAllByTestId('table-row').length).toBe(expectedParties.length + 2);
   });
@@ -472,7 +466,7 @@ describe('Ballots Counts by Party', () => {
         domGetByText(tableRow!, expectedNumberOfBallots)
       ).toBeInTheDocument();
       expect(
-        domGetByText(tableRow!, `View Unofficial ${partyName} Tally Report`)
+        domGetByText(tableRow!, `Unofficial ${partyName} Tally Report`)
       ).toBeInTheDocument();
     }
 
@@ -480,9 +474,6 @@ describe('Ballots Counts by Party', () => {
     const tableRow = getByText('Total Ballot Count').closest('tr');
     expect(tableRow).toBeDefined();
     expect(domGetByText(tableRow!, 131)).toBeInTheDocument();
-    expect(
-      domGetByText(tableRow!, 'View Unofficial Full Election Tally Report')
-    ).toBeInTheDocument();
 
     expect(getAllByTestId('table-row').length).toBe(expectedParties.length + 2);
   });
@@ -536,7 +527,7 @@ describe('Ballots Counts by VotingMethod', () => {
       expect(tableRow).toBeDefined();
       expect(domGetByText(tableRow!, 0)).toBeInTheDocument();
       expect(
-        domGetByText(tableRow!, `View Unofficial ${label} Ballot Tally Report`)
+        domGetByText(tableRow!, `Unofficial ${label} Ballot Tally Report`)
       ).toBeInTheDocument();
     }
 
@@ -572,7 +563,7 @@ describe('Ballots Counts by VotingMethod', () => {
         domGetByText(tableRow!, expectedNumberOfBallots)
       ).toBeInTheDocument();
       expect(
-        domGetByText(tableRow!, `View Unofficial ${label} Ballot Tally Report`)
+        domGetByText(tableRow!, `Unofficial ${label} Ballot Tally Report`)
       ).toBeInTheDocument();
     }
 
@@ -616,7 +607,7 @@ describe('Ballots Counts by VotingMethod', () => {
         domGetByText(tableRow!, expectedNumberOfBallots)
       ).toBeInTheDocument();
       expect(
-        domGetByText(tableRow!, `View Unofficial ${label} Ballot Tally Report`)
+        domGetByText(tableRow!, `Unofficial ${label} Ballot Tally Report`)
       ).toBeInTheDocument();
     }
 
@@ -736,7 +727,7 @@ describe('Ballots Counts by Batch', () => {
       ).toBeInTheDocument();
       expect(domGetByText(tableRow, scannerLabel)).toBeInTheDocument();
       expect(
-        domGetByText(tableRow, `View Unofficial ${label} Tally Report`)
+        domGetByText(tableRow, `Unofficial ${label} Tally Report`)
       ).toBeInTheDocument();
     }
 
@@ -790,7 +781,7 @@ describe('Ballots Counts by Batch', () => {
       domGetByText(tableRow!, label);
       domGetByText(tableRow!, expectedNumberOfBallots);
       domGetByText(tableRow!, scannerLabel);
-      domGetByText(tableRow!, `View Unofficial ${label} Tally Report`);
+      domGetByText(tableRow!, `Unofficial ${label} Tally Report`);
     }
 
     const externalTableRow = getAllByTestId('batch-external')[0].closest('tr');

--- a/frontends/election-manager/src/components/ballot_counts_table.tsx
+++ b/frontends/election-manager/src/components/ballot_counts_table.tsx
@@ -59,7 +59,7 @@ export function BallotCountsTable({ breakdownCategory }: Props): JSX.Element {
                 Precinct
               </TD>
               <TD as="th">Ballot Count</TD>
-              <TD as="th">View Tally</TD>
+              <TD as="th">Report</TD>
             </tr>
             {[...election.precincts]
               .sort((a, b) =>
@@ -98,7 +98,7 @@ export function BallotCountsTable({ breakdownCategory }: Props): JSX.Element {
                           precinctId: precinct.id,
                         })}
                       >
-                        View {statusPrefix} {precinct.name} Tally Report
+                        {statusPrefix} {precinct.name} Tally Report
                       </LinkButton>
                     </TD>
                   </tr>
@@ -117,12 +117,13 @@ export function BallotCountsTable({ breakdownCategory }: Props): JSX.Element {
               </TD>
               <TD>
                 <LinkButton
+                  primary
                   small
                   to={routerPaths.tallyPrecinctReport({
                     precinctId: 'all',
                   })}
                 >
-                  View {statusPrefix} Tally Reports for All Precincts
+                  {statusPrefix} Tally Reports for All Precincts
                 </LinkButton>
               </TD>
             </tr>
@@ -143,7 +144,7 @@ export function BallotCountsTable({ breakdownCategory }: Props): JSX.Element {
                   Scanner ID
                 </TD>
                 <TD as="th">Ballot Count</TD>
-                <TD as="th">View Tally</TD>
+                <TD as="th">Report</TD>
               </tr>
               {Object.keys(resultsByScanner)
                 .sort((a, b) =>
@@ -169,7 +170,7 @@ export function BallotCountsTable({ breakdownCategory }: Props): JSX.Element {
                               scannerId,
                             })}
                           >
-                            View {statusPrefix} Scanner {scannerId} Tally Report
+                            {statusPrefix} Scanner {scannerId} Tally Report
                           </LinkButton>
                         )}
                       </TD>
@@ -222,7 +223,7 @@ export function BallotCountsTable({ breakdownCategory }: Props): JSX.Element {
                 Party
               </TD>
               <TD as="th">Ballot Count</TD>
-              <TD as="th">View Tally</TD>
+              <TD as="th">Report</TD>
             </tr>
             {[...partiesForPrimaries]
               .sort((a, b) =>
@@ -256,7 +257,7 @@ export function BallotCountsTable({ breakdownCategory }: Props): JSX.Element {
                           partyId: party.id,
                         })}
                       >
-                        View {statusPrefix} {party.fullName} Tally Report
+                        {statusPrefix} {party.fullName} Tally Report
                       </LinkButton>
                     </TD>
                   </tr>
@@ -273,11 +274,7 @@ export function BallotCountsTable({ breakdownCategory }: Props): JSX.Element {
                   )}
                 </strong>
               </TD>
-              <TD>
-                <LinkButton small to={routerPaths.tallyFullReport}>
-                  View {statusPrefix} Full Election Tally Report
-                </LinkButton>
-              </TD>
+              <TD />
             </tr>
           </tbody>
         </Table>
@@ -295,7 +292,7 @@ export function BallotCountsTable({ breakdownCategory }: Props): JSX.Element {
                 Voting Method
               </TD>
               <TD as="th">Ballot Count</TD>
-              <TD as="th">View Tally</TD>
+              <TD as="th">Report</TD>
             </tr>
             {Object.values(VotingMethod).map((votingMethod) => {
               const initialBallotsCountedByVotingMethod =
@@ -330,7 +327,7 @@ export function BallotCountsTable({ breakdownCategory }: Props): JSX.Element {
                         votingMethod,
                       })}
                     >
-                      View {statusPrefix} {label} Ballot Tally Report
+                      {statusPrefix} {label} Ballot Tally Report
                     </LinkButton>
                   </TD>
                 </tr>
@@ -366,7 +363,7 @@ export function BallotCountsTable({ breakdownCategory }: Props): JSX.Element {
               </TD>
               <TD as="th">Scanner</TD>
               <TD as="th">Ballot Count</TD>
-              <TD as="th">View Tally</TD>
+              <TD as="th">Report</TD>
             </tr>
             {Object.keys(resultsByBatch).map((batchId) => {
               const batchTally = resultsByBatch[batchId] as BatchTally;
@@ -387,7 +384,7 @@ export function BallotCountsTable({ breakdownCategory }: Props): JSX.Element {
                           batchId,
                         })}
                       >
-                        View {statusPrefix} {batchTally.batchLabel} Tally Report
+                        {statusPrefix} {batchTally.batchLabel} Tally Report
                       </LinkButton>
                     )}
                   </TD>
@@ -399,6 +396,7 @@ export function BallotCountsTable({ breakdownCategory }: Props): JSX.Element {
                 <TD narrow nowrap data-testid="batch-external">
                   External Results ({t.inputSourceName})
                 </TD>
+                <TD />
                 <TD>{format.count(t.overallTally.numberOfBallotsCounted)}</TD>
                 <TD />
               </tr>
@@ -407,6 +405,7 @@ export function BallotCountsTable({ breakdownCategory }: Props): JSX.Element {
               <TD narrow nowrap>
                 <strong>Total Ballot Count</strong>
               </TD>
+              <TD />
               <TD>
                 <strong>
                   {format.count(
@@ -414,7 +413,6 @@ export function BallotCountsTable({ breakdownCategory }: Props): JSX.Element {
                   )}
                 </strong>
               </TD>
-              <TD />
               <TD>
                 <ExportBatchTallyResultsButton />
               </TD>

--- a/frontends/election-manager/src/components/election_manager.tsx
+++ b/frontends/election-manager/src/components/election_manager.tsx
@@ -39,6 +39,7 @@ import { WriteInsScreen } from '../screens/write_ins_screen';
 import { LogicAndAccuracyScreen } from '../screens/logic_and_accuracy_screen';
 import { SettingsScreen } from '../screens/settings_screen';
 import { LogsScreen } from '../screens/logs_screen';
+import { ReportsScreen } from '../screens/reports_screen';
 import {
   areVvsg2AuthFlowsEnabled,
   isWriteInAdjudicationEnabled,
@@ -254,6 +255,9 @@ export function ElectionManager(): JSX.Element {
       </Route>
       <Route exact path={routerPaths.tally}>
         <TallyScreen />
+      </Route>
+      <Route exact path={routerPaths.reports}>
+        <ReportsScreen />
       </Route>
       <Route
         exact

--- a/frontends/election-manager/src/components/navigation_screen.tsx
+++ b/frontends/election-manager/src/components/navigation_screen.tsx
@@ -72,11 +72,12 @@ export function NavigationScreen({
         ? [
             { label: 'Ballots', routerPath: routerPaths.ballotsList },
             { label: 'L&A', routerPath: routerPaths.logicAndAccuracy },
+            { label: 'Tally', routerPath: routerPaths.tally },
             isWriteInAdjudicationEnabled() && {
               label: 'Write-Ins',
               routerPath: routerPaths.writeIns,
             },
-            { label: 'Tally', routerPath: routerPaths.tally },
+            { label: 'Reports', routerPath: routerPaths.reports },
           ]
         : [];
     } else {
@@ -86,11 +87,12 @@ export function NavigationScreen({
             { label: 'Smartcards', routerPath: routerPaths.smartcards },
             { label: 'Ballots', routerPath: routerPaths.ballotsList },
             { label: 'L&A', routerPath: routerPaths.logicAndAccuracy },
+            { label: 'Tally', routerPath: routerPaths.tally },
             isWriteInAdjudicationEnabled() && {
               label: 'Write-Ins',
               routerPath: routerPaths.writeIns,
             },
-            { label: 'Tally', routerPath: routerPaths.tally },
+            { label: 'Reports', routerPath: routerPaths.reports },
             { label: 'Advanced', routerPath: routerPaths.advanced },
           ]
         : [

--- a/frontends/election-manager/src/router_paths.ts
+++ b/frontends/election-manager/src/router_paths.ts
@@ -33,22 +33,22 @@ export const routerPaths = {
     precinctId,
   }: ManualDataPrecinctScreenProps): string =>
     `/tally/manual-data-import/precinct/${precinctId}`,
-  printedBallotsReport: '/reports/printed-report',
+  printedBallotsReport: '/reports/printed-ballots-report',
   reports: '/reports',
   tally: '/tally',
   tallyPrecinctReport: ({ precinctId }: PrecinctReportScreenProps): string =>
-    `/reports/precinct/${precinctId}`,
+    `/reports/tally-reports/precincts/${precinctId}`,
   tallyPartyReport: ({ partyId }: PartyReportScreenProps): string =>
-    `/reports/party/${partyId}`,
+    `/reports/tally-reports/parties/${partyId}`,
   tallyVotingMethodReport: ({
     votingMethod,
   }: VotingMethodReportScreenProps): string =>
-    `/reports/votingmethod/${votingMethod}`,
+    `/reports/tally-reports/votingmethods/${votingMethod}`,
   tallyScannerReport: ({ scannerId }: ScannerReportScreenProps): string =>
-    `/reports/scanner/${scannerId}`,
+    `/reports/tally-reports/scanners/${scannerId}`,
   tallyBatchReport: ({ batchId }: BatchReportScreenProps): string =>
-    `/reports/batch/${batchId}`,
-  tallyFullReport: '/reports/full',
+    `/reports/tally-reports/batches/${batchId}`,
+  tallyFullReport: '/reports/tally-reports/full',
   overvoteCombinationReport: '/tally/pairs',
   logicAndAccuracy: '/logic-and-accuracy',
   testDecks: '/logic-and-accuracy/test-decks',

--- a/frontends/election-manager/src/router_paths.ts
+++ b/frontends/election-manager/src/router_paths.ts
@@ -33,21 +33,22 @@ export const routerPaths = {
     precinctId,
   }: ManualDataPrecinctScreenProps): string =>
     `/tally/manual-data-import/precinct/${precinctId}`,
-  printedBallotsReport: '/ballots/printed-report',
+  printedBallotsReport: '/reports/printed-report',
+  reports: '/reports',
   tally: '/tally',
   tallyPrecinctReport: ({ precinctId }: PrecinctReportScreenProps): string =>
-    `/tally/precinct/${precinctId}`,
+    `/reports/precinct/${precinctId}`,
   tallyPartyReport: ({ partyId }: PartyReportScreenProps): string =>
-    `/tally/party/${partyId}`,
+    `/reports/party/${partyId}`,
   tallyVotingMethodReport: ({
     votingMethod,
   }: VotingMethodReportScreenProps): string =>
-    `/tally/votingmethod/${votingMethod}`,
+    `/reports/votingmethod/${votingMethod}`,
   tallyScannerReport: ({ scannerId }: ScannerReportScreenProps): string =>
-    `/tally/scanner/${scannerId}`,
+    `/reports/scanner/${scannerId}`,
   tallyBatchReport: ({ batchId }: BatchReportScreenProps): string =>
-    `/tally/batch/${batchId}`,
-  tallyFullReport: '/tally/full',
+    `/reports/batch/${batchId}`,
+  tallyFullReport: '/reports/full',
   overvoteCombinationReport: '/tally/pairs',
   logicAndAccuracy: '/logic-and-accuracy',
   testDecks: '/logic-and-accuracy/test-decks',

--- a/frontends/election-manager/src/screens/ballot_list_screen.tsx
+++ b/frontends/election-manager/src/screens/ballot_list_screen.tsx
@@ -1,7 +1,6 @@
 import React, { useContext, useState } from 'react';
 import styled from 'styled-components';
 import pluralize from 'pluralize';
-import moment from 'moment';
 
 import { assert, find } from '@votingworks/utils';
 import { NoWrap, Prose, Table, TD } from '@votingworks/ui';
@@ -26,8 +25,7 @@ const Header = styled.div`
 `;
 
 export function BallotListScreen(): JSX.Element {
-  const { electionDefinition, printedBallots, configuredAt } =
-    useContext(AppContext);
+  const { electionDefinition, configuredAt } = useContext(AppContext);
   assert(electionDefinition && typeof configuredAt === 'string');
   const { election } = electionDefinition;
 
@@ -46,24 +44,11 @@ export function BallotListScreen(): JSX.Element {
 
   const ballots = ballotLists[ballotView];
 
-  const numBallotsPrinted = printedBallots.reduce(
-    (count, ballot) => count + ballot.numCopies,
-    0
-  );
-
   return (
     <NavigationScreen>
       <Header>
         <Prose maxWidth={false}>
           <p>
-            <strong>
-              {pluralize('official ballot', numBallotsPrinted, true)}{' '}
-            </strong>{' '}
-            printed since configuration at{' '}
-            {moment(new Date(configuredAt)).format('MMM D, YYYY [at] h:mma')}.{' '}
-            <LinkButton small to={routerPaths.printedBallotsReport}>
-              Printed Ballots Report
-            </LinkButton>{' '}
             <ExportElectionBallotPackageModalButton />
           </p>
         </Prose>

--- a/frontends/election-manager/src/screens/printed_ballots_report_screen.tsx
+++ b/frontends/election-manager/src/screens/printed_ballots_report_screen.tsx
@@ -150,8 +150,8 @@ export function PrintedBallotsReportScreen(): JSX.Element {
         </PrintButton>
       </p>
       <p className="no-print">
-        <LinkButton small to={routerPaths.ballotsList}>
-          Back to List Ballots
+        <LinkButton small to={routerPaths.reports}>
+          Back to Reports
         </LinkButton>
       </p>
 

--- a/frontends/election-manager/src/screens/reports_screen.tsx
+++ b/frontends/election-manager/src/screens/reports_screen.tsx
@@ -57,10 +57,6 @@ export function ReportsScreen(): JSX.Element {
 
   const partiesForPrimaries = getPartiesWithPrimaryElections(election);
 
-  const castVoteRecordFileList = castVoteRecordFiles.fileList;
-  const hasCastVoteRecordFiles =
-    castVoteRecordFileList.length > 0 || !!castVoteRecordFiles.lastError;
-
   const totalBallotCountInternal =
     fullElectionTally?.overallTally.numberOfBallotsCounted ?? 0;
   const totalBallotCountExternal = fullElectionExternalTallies.reduce(
@@ -188,7 +184,7 @@ export function ReportsScreen(): JSX.Element {
             <LinkButton primary to={routerPaths.tallyFullReport}>
               {statusPrefix} Full Election Tally Report
             </LinkButton>{' '}
-            {hasConverter && hasCastVoteRecordFiles && (
+            {hasConverter && castVoteRecordFiles.wereAdded && (
               <Button onPress={() => setIsExportResultsModalOpen(true)}>
                 Save Results File
               </Button>

--- a/frontends/election-manager/src/screens/reports_screen.tsx
+++ b/frontends/election-manager/src/screens/reports_screen.tsx
@@ -1,0 +1,220 @@
+import React, { useContext, useState, useEffect, useCallback } from 'react';
+import pluralize from 'pluralize';
+
+import {
+  assert,
+  generateFinalExportDefaultFilename,
+  format,
+} from '@votingworks/utils';
+import { Prose, useCancelablePromise, isAdminAuth } from '@votingworks/ui';
+import { TallyCategory } from '@votingworks/types';
+import { LogEventId } from '@votingworks/logging';
+
+import { AppContext } from '../contexts/app_context';
+import { MsSemsConverterClient } from '../lib/converters/ms_sems_converter_client';
+
+import { Button } from '../components/button';
+import { Loading } from '../components/loading';
+import { NavigationScreen } from '../components/navigation_screen';
+import { routerPaths } from '../router_paths';
+import { LinkButton } from '../components/link_button';
+import { BallotCountsTable } from '../components/ballot_counts_table';
+import { getPartiesWithPrimaryElections } from '../utils/election';
+import { SaveFileToUsb, FileType } from '../components/save_file_to_usb';
+import { getTallyConverterClient } from '../lib/converters';
+
+export function ReportsScreen(): JSX.Element {
+  const makeCancelable = useCancelablePromise();
+
+  const {
+    castVoteRecordFiles,
+    electionDefinition,
+    converter,
+    isOfficialResults,
+    isTabulationRunning,
+    generateExportableTallies,
+    fullElectionTally,
+    fullElectionExternalTallies,
+    printedBallots,
+    configuredAt,
+    logger,
+    auth,
+  } = useContext(AppContext);
+  assert(isAdminAuth(auth));
+  const userRole = auth.user.role;
+  assert(electionDefinition && typeof configuredAt === 'string');
+  const { election } = electionDefinition;
+
+  const [isExportResultsModalOpen, setIsExportResultsModalOpen] =
+    useState(false);
+
+  const [isShowingBatchResults, setIsShowingBatchResults] = useState(false);
+  const toggleShowingBatchResults = useCallback(() => {
+    setIsShowingBatchResults(!isShowingBatchResults);
+  }, [isShowingBatchResults, setIsShowingBatchResults]);
+
+  const statusPrefix = isOfficialResults ? 'Official' : 'Unofficial';
+
+  const partiesForPrimaries = getPartiesWithPrimaryElections(election);
+
+  const castVoteRecordFileList = castVoteRecordFiles.fileList;
+  const hasCastVoteRecordFiles =
+    castVoteRecordFileList.length > 0 || !!castVoteRecordFiles.lastError;
+
+  const totalBallotCountInternal =
+    fullElectionTally?.overallTally.numberOfBallotsCounted ?? 0;
+  const totalBallotCountExternal = fullElectionExternalTallies.reduce(
+    (prev, tally) => prev + tally.overallTally.numberOfBallotsCounted,
+    0
+  );
+  const totalBallotCount = totalBallotCountInternal + totalBallotCountExternal;
+
+  const totalBallotsPrinted = printedBallots.reduce(
+    (count, ballot) => count + ballot.numCopies,
+    0
+  );
+
+  const [hasConverter, setHasConverter] = useState(false);
+  useEffect(() => {
+    void (async () => {
+      try {
+        const client = getTallyConverterClient(converter);
+        if (client) {
+          await makeCancelable(client.getFiles());
+          setHasConverter(true);
+        }
+      } catch {
+        setHasConverter(false);
+      }
+    })();
+  }, [converter, makeCancelable]);
+
+  const generateSemsResults = useCallback(async (): Promise<string> => {
+    await logger.log(LogEventId.ConvertingResultsToSemsFormat, userRole);
+    const exportableTallies = generateExportableTallies();
+    // process on the server
+    const client = new MsSemsConverterClient('tallies');
+    const { inputFiles, outputFiles } = await client.getFiles();
+    const [electionDefinitionFile, talliesFile] = inputFiles;
+    const resultsFile = outputFiles[0];
+
+    await client.setInputFile(
+      electionDefinitionFile.name,
+      new File([electionDefinition.electionData], electionDefinitionFile.name, {
+        type: 'application/json',
+      })
+    );
+    await client.setInputFile(
+      talliesFile.name,
+      new File([JSON.stringify(exportableTallies)], 'tallies')
+    );
+    await client.process();
+
+    // download the result
+    const results = await client.getOutputFile(resultsFile.name);
+
+    // reset files on the server
+    await client.reset();
+    return await results.text();
+  }, [
+    electionDefinition.electionData,
+    generateExportableTallies,
+    logger,
+    userRole,
+  ]);
+
+  let tallyResultsInfo = <Loading>Tabulating Results…</Loading>;
+  if (!isTabulationRunning) {
+    const resultTables = (
+      <React.Fragment>
+        <h2>Ballot Counts by Precinct</h2>
+        <BallotCountsTable breakdownCategory={TallyCategory.Precinct} />
+        <h2>Ballot Counts by Voting Method</h2>
+        <BallotCountsTable breakdownCategory={TallyCategory.VotingMethod} />
+        {partiesForPrimaries.length > 0 && (
+          <React.Fragment>
+            <h2>Ballot Counts by Party</h2>
+            <BallotCountsTable breakdownCategory={TallyCategory.Party} />
+          </React.Fragment>
+        )}
+        <h2>Ballot Counts by Scanner</h2>
+        <Button small onPress={toggleShowingBatchResults}>
+          {isShowingBatchResults
+            ? 'Show Results by Scanner'
+            : 'Show Results by Batch and Scanner'}
+        </Button>
+        <br />
+        <br />
+        {isShowingBatchResults ? (
+          <BallotCountsTable breakdownCategory={TallyCategory.Batch} />
+        ) : (
+          <BallotCountsTable breakdownCategory={TallyCategory.Scanner} />
+        )}
+      </React.Fragment>
+    );
+
+    tallyResultsInfo = <React.Fragment>{resultTables}</React.Fragment>;
+  }
+
+  const fileMode = castVoteRecordFiles?.fileMode;
+  const ballotCountSummaryText = (
+    <p>
+      <strong>
+        {format.count(totalBallotCount)}
+        {fileMode ? ` ${fileMode} ` : ' '}
+        {pluralize('ballot', totalBallotCount, false)}{' '}
+      </strong>{' '}
+      have been counted for <strong>{electionDefinition.election.title}</strong>
+      .
+    </p>
+  );
+
+  const ballotPrintingSummaryText = (
+    <p>
+      <strong>
+        {pluralize('official ballot', totalBallotsPrinted, true)}{' '}
+      </strong>{' '}
+      have been printed.
+    </p>
+  );
+
+  return (
+    <React.Fragment>
+      <NavigationScreen>
+        <Prose maxWidth={false}>
+          <h1>Election Reports</h1>
+          {ballotCountSummaryText}
+          <p>
+            <LinkButton primary to={routerPaths.tallyFullReport}>
+              {statusPrefix} Full Election Tally Report
+            </LinkButton>{' '}
+            {hasConverter && hasCastVoteRecordFiles && (
+              <Button onPress={() => setIsExportResultsModalOpen(true)}>
+                Save Results File
+              </Button>
+            )}
+          </p>
+          {ballotPrintingSummaryText}
+          <p>
+            <LinkButton to={routerPaths.printedBallotsReport}>
+              Printed Ballots Report
+            </LinkButton>
+          </p>
+          {tallyResultsInfo}
+        </Prose>
+      </NavigationScreen>
+      {isExportResultsModalOpen && (
+        <SaveFileToUsb
+          onClose={() => setIsExportResultsModalOpen(false)}
+          generateFileContent={generateSemsResults}
+          defaultFilename={generateFinalExportDefaultFilename(
+            fileMode === 'test',
+            electionDefinition.election
+          )}
+          fileType={FileType.Results}
+          promptToEjectUsb
+        />
+      )}
+    </React.Fragment>
+  );
+}

--- a/frontends/election-manager/src/screens/tally_report_screen.tsx
+++ b/frontends/election-manager/src/screens/tally_report_screen.tsx
@@ -52,7 +52,7 @@ export function TallyReportScreen(): JSX.Element {
   const printReportRef = useRef<HTMLDivElement>(null);
   const previewReportRef = useRef<HTMLDivElement>(null);
   const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
-  const [isConfirmingOfficial, setIsConfirmingOfficial] = useState(false);
+  const [isMarkOfficialModalOpen, setIsMarkOfficialModalOpen] = useState(false);
   const { precinctId } = useParams<PrecinctReportScreenProps>();
   const { scannerId } = useParams<ScannerReportScreenProps>();
   const { batchId } = useParams<BatchReportScreenProps>();
@@ -79,10 +79,6 @@ export function TallyReportScreen(): JSX.Element {
 
   const { election } = electionDefinition;
   const statusPrefix = isOfficialResults ? 'Official' : 'Unofficial';
-
-  const castVoteRecordFileList = castVoteRecordFiles.fileList;
-  const hasCastVoteRecordFiles =
-    castVoteRecordFileList.length > 0 || !!castVoteRecordFiles.lastError;
 
   const precinctName =
     (precinctId &&
@@ -193,14 +189,14 @@ export function TallyReportScreen(): JSX.Element {
     });
   }
 
-  function cancelConfirmingOfficial() {
-    setIsConfirmingOfficial(false);
+  function closeMarkOfficialModal() {
+    setIsMarkOfficialModalOpen(false);
   }
-  function confirmOfficial() {
-    setIsConfirmingOfficial(true);
+  function openMarkOfficialModal() {
+    setIsMarkOfficialModalOpen(true);
   }
-  async function setOfficial() {
-    setIsConfirmingOfficial(false);
+  async function markOfficial() {
+    setIsMarkOfficialModalOpen(false);
     await saveIsOfficialResults();
   }
 
@@ -254,11 +250,11 @@ export function TallyReportScreen(): JSX.Element {
               </Button>
             )}
           </p>
-          {location.pathname === '/reports/full' && (
+          {location.pathname === routerPaths.tallyFullReport && (
             <p>
               <Button
-                disabled={!hasCastVoteRecordFiles || isOfficialResults}
-                onPress={confirmOfficial}
+                disabled={!castVoteRecordFiles.wereAdded || isOfficialResults}
+                onPress={openMarkOfficialModal}
               >
                 Mark Tally Results as Official
               </Button>
@@ -287,7 +283,7 @@ export function TallyReportScreen(): JSX.Element {
           fileType={FileType.TallyReport}
         />
       )}
-      {isConfirmingOfficial && (
+      {isMarkOfficialModalOpen && (
         <Modal
           centerContent
           content={
@@ -303,13 +299,13 @@ export function TallyReportScreen(): JSX.Element {
           }
           actions={
             <React.Fragment>
-              <Button primary onPress={setOfficial}>
+              <Button primary onPress={markOfficial}>
                 Mark Tally Results as Official
               </Button>
-              <Button onPress={cancelConfirmingOfficial}>Cancel</Button>
+              <Button onPress={closeMarkOfficialModal}>Cancel</Button>
             </React.Fragment>
           }
-          onOverlayClick={cancelConfirmingOfficial}
+          onOverlayClick={closeMarkOfficialModal}
         />
       )}
       <PrintableArea data-testid="printable-area">

--- a/frontends/election-manager/src/screens/tally_screen.tsx
+++ b/frontends/election-manager/src/screens/tally_screen.tsx
@@ -1,83 +1,42 @@
-import React, {
-  useContext,
-  useState,
-  useEffect,
-  useRef,
-  useCallback,
-} from 'react';
+import React, { useContext, useState, useRef } from 'react';
 import moment from 'moment';
 
-import {
-  assert,
-  generateFinalExportDefaultFilename,
-  format,
-  find,
-} from '@votingworks/utils';
-import {
-  isAdminAuth,
-  Modal,
-  Prose,
-  Table,
-  TD,
-  Text,
-  useCancelablePromise,
-} from '@votingworks/ui';
-import { TallyCategory, ExternalTallySourceType } from '@votingworks/types';
-import { LogEventId } from '@votingworks/logging';
+import { assert, format, find } from '@votingworks/utils';
+import { isAdminAuth, Prose, Table, TD, Text } from '@votingworks/ui';
+import { ExternalTallySourceType } from '@votingworks/types';
 import { InputEventFunction, ResultsFileType } from '../config/types';
 
 import { AppContext } from '../contexts/app_context';
-import { MsSemsConverterClient } from '../lib/converters/ms_sems_converter_client';
 import { getPrecinctIdsInExternalTally } from '../utils/external_tallies';
 
 import { Button } from '../components/button';
-import { Loading } from '../components/loading';
 import { NavigationScreen } from '../components/navigation_screen';
 import { routerPaths } from '../router_paths';
 import { LinkButton } from '../components/link_button';
 import { ImportCvrFilesModal } from '../components/import_cvrfiles_modal';
-import { BallotCountsTable } from '../components/ballot_counts_table';
 import { FileInputButton } from '../components/file_input_button';
 import { ConfirmRemovingFileModal } from '../components/confirm_removing_file_modal';
 import { TIME_FORMAT } from '../config/globals';
-import { getPartiesWithPrimaryElections } from '../utils/election';
 import { ImportExternalResultsModal } from '../components/import_external_results_modal';
-import { SaveFileToUsb, FileType } from '../components/save_file_to_usb';
-import { getTallyConverterClient } from '../lib/converters';
 
 export function TallyScreen(): JSX.Element {
-  const makeCancelable = useCancelablePromise();
-
   const {
     castVoteRecordFiles,
     electionDefinition,
     converter,
     isOfficialResults,
-    saveIsOfficialResults,
-    isTabulationRunning,
     fullElectionExternalTallies,
-    generateExportableTallies,
     resetFiles,
-    logger,
     auth,
   } = useContext(AppContext);
   assert(electionDefinition);
   assert(isAdminAuth(auth));
-  const userRole = auth.user.role;
   const { election } = electionDefinition;
-  const isTestMode = castVoteRecordFiles?.fileMode === 'test';
   const externalFileInput = useRef<HTMLInputElement>(null);
 
   const [confirmingRemoveFileType, setConfirmingRemoveFileType] =
     useState<ResultsFileType>();
   const [isImportCvrModalOpen, setIsImportCvrModalOpen] = useState(false);
-  const [isExportResultsModalOpen, setIsExportResultsModalOpen] =
-    useState(false);
-
-  const [isShowingBatchResults, setIsShowingBatchResults] = useState(false);
-  const toggleShowingBatchResults = useCallback(() => {
-    setIsShowingBatchResults(!isShowingBatchResults);
-  }, [isShowingBatchResults, setIsShowingBatchResults]);
 
   function beginConfirmRemoveFiles(fileType: ResultsFileType) {
     setConfirmingRemoveFileType(fileType);
@@ -90,25 +49,11 @@ export function TallyScreen(): JSX.Element {
     await resetFiles(fileType);
   }
 
-  const statusPrefix = isOfficialResults ? 'Official' : 'Unofficial';
-  const [isConfirmingOfficial, setIsConfirmingOfficial] = useState(false);
-  function cancelConfirmingOfficial() {
-    setIsConfirmingOfficial(false);
-  }
-  function confirmOfficial() {
-    setIsConfirmingOfficial(true);
-  }
-  async function setOfficial() {
-    setIsConfirmingOfficial(false);
-    await saveIsOfficialResults();
-  }
-
   function getPrecinctNames(precinctIds: readonly string[]) {
     return precinctIds
       .map((id) => find(election.precincts, (p) => p.id === id).name)
       .join(', ');
   }
-  const partiesForPrimaries = getPartiesWithPrimaryElections(election);
 
   const castVoteRecordFileList = castVoteRecordFiles.fileList;
   const hasCastVoteRecordFiles =
@@ -144,21 +89,6 @@ export function TallyScreen(): JSX.Element {
     }
   }
 
-  const [hasConverter, setHasConverter] = useState(false);
-  useEffect(() => {
-    void (async () => {
-      try {
-        const client = getTallyConverterClient(converter);
-        if (client) {
-          await makeCancelable(client.getFiles());
-          setHasConverter(true);
-        }
-      } catch {
-        setHasConverter(false);
-      }
-    })();
-  }, [converter, makeCancelable]);
-
   const fileMode = castVoteRecordFiles?.fileMode;
   const fileModeText =
     fileMode === 'test'
@@ -166,49 +96,6 @@ export function TallyScreen(): JSX.Element {
       : fileMode === 'live'
       ? 'Currently tallying live ballots.'
       : '';
-
-  let tallyResultsInfo = <Loading>Tabulating Results…</Loading>;
-  if (!isTabulationRunning) {
-    const resultTables = (
-      <React.Fragment>
-        <h2>Ballot Counts by Precinct</h2>
-        <BallotCountsTable breakdownCategory={TallyCategory.Precinct} />
-        <h2>Ballot Counts by Voting Method</h2>
-        <BallotCountsTable breakdownCategory={TallyCategory.VotingMethod} />
-        {partiesForPrimaries.length > 0 && (
-          <React.Fragment>
-            <h2>Ballot Counts by Party</h2>
-            <BallotCountsTable breakdownCategory={TallyCategory.Party} />
-          </React.Fragment>
-        )}
-        <h2>Ballot Counts by Scanner</h2>
-        <Button small onPress={toggleShowingBatchResults}>
-          {isShowingBatchResults
-            ? 'Show Results by Scanner'
-            : 'Show Results by Batch and Scanner'}
-        </Button>
-        <br />
-        <br />
-        {isShowingBatchResults ? (
-          <BallotCountsTable breakdownCategory={TallyCategory.Batch} />
-        ) : (
-          <BallotCountsTable breakdownCategory={TallyCategory.Scanner} />
-        )}
-      </React.Fragment>
-    );
-
-    tallyResultsInfo = (
-      <React.Fragment>
-        {resultTables}
-        <h2>{statusPrefix} Tally Reports</h2>
-        <p>
-          <LinkButton to={routerPaths.tallyFullReport}>
-            View {statusPrefix} Full Election Tally Report
-          </LinkButton>
-        </p>
-      </React.Fragment>
-    );
-  }
 
   const externalTallyRows = fullElectionExternalTallies.map((t) => {
     const precinctsInExternalFile = getPrecinctIdsInExternalTally(t);
@@ -230,199 +117,145 @@ export function TallyScreen(): JSX.Element {
     0
   );
 
-  const generateSemsResults = useCallback(async (): Promise<string> => {
-    await logger.log(LogEventId.ConvertingResultsToSemsFormat, userRole);
-    const exportableTallies = generateExportableTallies();
-    // process on the server
-    const client = new MsSemsConverterClient('tallies');
-    const { inputFiles, outputFiles } = await client.getFiles();
-    const [electionDefinitionFile, talliesFile] = inputFiles;
-    const resultsFile = outputFiles[0];
-
-    await client.setInputFile(
-      electionDefinitionFile.name,
-      new File([electionDefinition.electionData], electionDefinitionFile.name, {
-        type: 'application/json',
-      })
-    );
-    await client.setInputFile(
-      talliesFile.name,
-      new File([JSON.stringify(exportableTallies)], 'tallies')
-    );
-    await client.process();
-
-    // download the result
-    const results = await client.getOutputFile(resultsFile.name);
-
-    // reset files on the server
-    await client.reset();
-    return await results.text();
-  }, [
-    electionDefinition.electionData,
-    generateExportableTallies,
-    logger,
-    userRole,
-  ]);
-
   return (
     <React.Fragment>
       <NavigationScreen>
-        <h1>Election Tally Reports</h1>
-        <h2>Cast Vote Record (CVR) files</h2>
-        <Text>{fileModeText}</Text>
-        <Table data-testid="loaded-file-table">
-          <tbody>
-            {hasAnyFiles ? (
-              <React.Fragment>
-                <tr>
-                  <TD as="th" narrow nowrap>
-                    File Exported At
-                  </TD>
-                  <TD as="th" nowrap>
-                    CVR Count
-                  </TD>
-                  <TD as="th" narrow nowrap>
-                    Scanner ID
-                  </TD>
-                  <TD as="th" nowrap>
-                    Precinct
-                  </TD>
-                </tr>
-                {castVoteRecordFileList.map(
-                  ({
-                    name,
-                    exportTimestamp,
-                    importedCvrCount,
-                    scannerIds,
-                    precinctIds,
-                  }) => (
-                    <tr key={name}>
-                      <TD narrow nowrap>
-                        {moment(exportTimestamp).format(
-                          'MM/DD/YYYY hh:mm:ss A'
-                        )}
-                      </TD>
-                      <TD nowrap>{format.count(importedCvrCount)} </TD>
-                      <TD narrow nowrap>
-                        {scannerIds.join(', ')}
-                      </TD>
-                      <TD>{getPrecinctNames(precinctIds)}</TD>
-                    </tr>
-                  )
-                )}
-                {externalTallyRows}
-                <tr>
-                  <TD as="th" narrow nowrap>
-                    Total CVRs Count
-                  </TD>
-                  <TD as="th" narrow>
-                    {format.count(
-                      castVoteRecordFileList.reduce(
-                        (prev, curr) => prev + curr.importedCvrCount,
-                        0
-                      ) + externalFileBallotCount
-                    )}
-                  </TD>
-                  <TD />
-                  <TD as="th" />
-                </tr>
-              </React.Fragment>
-            ) : (
-              <tr>
-                <TD colSpan={2}>
-                  <em>No CVR files loaded.</em>
-                </TD>
-              </tr>
-            )}
-          </tbody>
-        </Table>
-        <p>
-          <Button
-            onPress={() => setIsImportCvrModalOpen(true)}
-            disabled={isOfficialResults}
-          >
-            Import CVR Files
-          </Button>{' '}
-          {converter === 'ms-sems' && (
-            <React.Fragment>
-              <FileInputButton
-                innerRef={externalFileInput}
-                onChange={importExternalSemsFile}
-                accept="*"
-                data-testid="import-sems-button"
-                disabled={hasExternalSemsFile || isOfficialResults}
-              >
-                Import External Results File
-              </FileInputButton>{' '}
-            </React.Fragment>
-          )}
-          <LinkButton
-            to={routerPaths.manualDataImport}
-            disabled={isOfficialResults}
-          >
-            {hasExternalManualData
-              ? 'Edit Manually Entered Results'
-              : 'Add Manually Entered Results'}
-          </LinkButton>{' '}
-          <Button
-            disabled={!hasCastVoteRecordFiles || isOfficialResults}
-            onPress={confirmOfficial}
-          >
-            Mark Tally Results as Official
-          </Button>
-        </p>
-        {isOfficialResults ? (
-          <p>
+        <Prose maxWidth={false}>
+          <h1>Cast Vote Record (CVR) Management</h1>
+          <Text>{fileModeText}</Text>
+          {isOfficialResults && (
             <Button
               danger
               disabled={!hasAnyFiles}
               onPress={() => beginConfirmRemoveFiles(ResultsFileType.All)}
             >
-              Clear All Results
+              Clear All Tallies and Results
             </Button>
-          </p>
-        ) : (
+          )}
+
           <p>
             <Button
-              danger
-              disabled={!hasCastVoteRecordFiles}
+              primary
+              disabled={isOfficialResults}
+              onPress={() => setIsImportCvrModalOpen(true)}
+            >
+              Import CVR Files
+            </Button>{' '}
+            <Button
+              disabled={!hasCastVoteRecordFiles || isOfficialResults}
               onPress={() =>
                 beginConfirmRemoveFiles(ResultsFileType.CastVoteRecord)
               }
             >
               Remove CVR Files
-            </Button>{' '}
-            {converter === 'ms-sems' && (
-              <React.Fragment>
-                <Button
-                  danger
-                  disabled={!hasExternalSemsFile}
-                  onPress={() => beginConfirmRemoveFiles(ResultsFileType.SEMS)}
-                >
-                  Remove External Results File
-                </Button>{' '}
-              </React.Fragment>
-            )}
+            </Button>
+          </p>
+          <Table data-testid="loaded-file-table">
+            <tbody>
+              {hasAnyFiles ? (
+                <React.Fragment>
+                  <tr>
+                    <TD as="th" narrow nowrap>
+                      File Exported At
+                    </TD>
+                    <TD as="th" nowrap>
+                      CVR Count
+                    </TD>
+                    <TD as="th" narrow nowrap>
+                      Scanner ID
+                    </TD>
+                    <TD as="th" nowrap>
+                      Precinct
+                    </TD>
+                  </tr>
+                  {castVoteRecordFileList.map(
+                    ({
+                      name,
+                      exportTimestamp,
+                      importedCvrCount,
+                      scannerIds,
+                      precinctIds,
+                    }) => (
+                      <tr key={name}>
+                        <TD narrow nowrap>
+                          {moment(exportTimestamp).format(
+                            'MM/DD/YYYY hh:mm:ss A'
+                          )}
+                        </TD>
+                        <TD nowrap>{format.count(importedCvrCount)} </TD>
+                        <TD narrow nowrap>
+                          {scannerIds.join(', ')}
+                        </TD>
+                        <TD>{getPrecinctNames(precinctIds)}</TD>
+                      </tr>
+                    )
+                  )}
+                  {externalTallyRows}
+                  <tr>
+                    <TD as="th" narrow nowrap>
+                      Total CVRs Count
+                    </TD>
+                    <TD as="th" narrow data-testid="total-cvr-count">
+                      {format.count(
+                        castVoteRecordFileList.reduce(
+                          (prev, curr) => prev + curr.importedCvrCount,
+                          0
+                        ) + externalFileBallotCount
+                      )}
+                    </TD>
+                    <TD />
+                    <TD as="th" />
+                  </tr>
+                </React.Fragment>
+              ) : (
+                <tr>
+                  <TD colSpan={2}>
+                    <em>No CVR files loaded.</em>
+                  </TD>
+                </tr>
+              )}
+            </tbody>
+          </Table>
+          <h2>Manually Entered Results</h2>
+          <p>
+            <LinkButton
+              to={routerPaths.manualDataImport}
+              disabled={isOfficialResults}
+            >
+              {hasExternalManualData
+                ? 'Edit Manually Entered Results'
+                : 'Add Manually Entered Results'}
+            </LinkButton>{' '}
             <Button
-              danger
-              disabled={!hasExternalManualData}
+              disabled={!hasExternalManualData || isOfficialResults}
               onPress={() => beginConfirmRemoveFiles(ResultsFileType.Manual)}
             >
               Remove Manual Data
             </Button>
           </p>
-        )}
-        {tallyResultsInfo}
-        {hasConverter && hasCastVoteRecordFiles && (
-          <React.Fragment>
-            <h2>Export Options</h2>
-            <p>
-              <Button onPress={() => setIsExportResultsModalOpen(true)}>
-                Save Results File
-              </Button>
-            </p>
-          </React.Fragment>
-        )}
+          {converter === 'ms-sems' && (
+            <React.Fragment>
+              <h2>External Results</h2>
+              <p>
+                <FileInputButton
+                  innerRef={externalFileInput}
+                  onChange={importExternalSemsFile}
+                  accept="*"
+                  data-testid="import-sems-button"
+                  disabled={hasExternalSemsFile || isOfficialResults}
+                >
+                  Import External Results File
+                </FileInputButton>{' '}
+                <Button
+                  disabled={!hasExternalSemsFile || isOfficialResults}
+                  onPress={() => beginConfirmRemoveFiles(ResultsFileType.SEMS)}
+                >
+                  Remove External Results File
+                </Button>
+              </p>
+            </React.Fragment>
+          )}
+        </Prose>
       </NavigationScreen>
       {confirmingRemoveFileType && (
         <ConfirmRemovingFileModal
@@ -431,52 +264,14 @@ export function TallyScreen(): JSX.Element {
           onCancel={cancelConfirmingRemoveFiles}
         />
       )}
-      {isConfirmingOfficial && (
-        <Modal
-          centerContent
-          content={
-            <Prose textCenter>
-              <h1>Mark Unofficial Tally Results as Official Tally Results?</h1>
-              <p>
-                Have all CVR and external results files been loaded? Once
-                results are marked as official, no additional CVR or external
-                files can be loaded.
-              </p>
-              <p>Have all unofficial tally reports been reviewed?</p>
-            </Prose>
-          }
-          actions={
-            <React.Fragment>
-              <Button primary onPress={setOfficial}>
-                Mark Tally Results as Official
-              </Button>
-              <Button onPress={cancelConfirmingOfficial}>Cancel</Button>
-            </React.Fragment>
-          }
-          onOverlayClick={cancelConfirmingOfficial}
-        />
-      )}
       {isImportExternalModalOpen && (
         <ImportExternalResultsModal
           onClose={closeExternalFileImport}
           selectedFile={externalResultsSelectedFile}
         />
       )}
-
       {isImportCvrModalOpen && (
         <ImportCvrFilesModal onClose={() => setIsImportCvrModalOpen(false)} />
-      )}
-      {isExportResultsModalOpen && (
-        <SaveFileToUsb
-          onClose={() => setIsExportResultsModalOpen(false)}
-          generateFileContent={generateSemsResults}
-          defaultFilename={generateFinalExportDefaultFilename(
-            isTestMode,
-            electionDefinition.election
-          )}
-          fileType={FileType.Results}
-          promptToEjectUsb
-        />
       )}
     </React.Fragment>
   );

--- a/frontends/election-manager/src/screens/tally_screen.tsx
+++ b/frontends/election-manager/src/screens/tally_screen.tsx
@@ -56,10 +56,8 @@ export function TallyScreen(): JSX.Element {
   }
 
   const castVoteRecordFileList = castVoteRecordFiles.fileList;
-  const hasCastVoteRecordFiles =
-    castVoteRecordFileList.length > 0 || !!castVoteRecordFiles.lastError;
   const hasAnyFiles =
-    hasCastVoteRecordFiles || fullElectionExternalTallies.length > 0;
+    castVoteRecordFiles.wereAdded || fullElectionExternalTallies.length > 0;
   const hasExternalSemsFile = fullElectionExternalTallies.some(
     (t) => t.source === ExternalTallySourceType.SEMS
   );
@@ -142,7 +140,7 @@ export function TallyScreen(): JSX.Element {
               Import CVR Files
             </Button>{' '}
             <Button
-              disabled={!hasCastVoteRecordFiles || isOfficialResults}
+              disabled={!castVoteRecordFiles.wereAdded || isOfficialResults}
               onPress={() =>
                 beginConfirmRemoveFiles(ResultsFileType.CastVoteRecord)
               }

--- a/frontends/election-manager/src/screens/write_ins_screen.tsx
+++ b/frontends/election-manager/src/screens/write_ins_screen.tsx
@@ -16,9 +16,6 @@ export function WriteInsScreen(): JSX.Element {
   const { castVoteRecordFiles, electionDefinition, saveTranscribedValue } =
     useContext(AppContext);
   const election = electionDefinition?.election;
-  const castVoteRecordFileList = castVoteRecordFiles.fileList;
-  const hasCastVoteRecordFiles =
-    castVoteRecordFileList.length > 0 || !!castVoteRecordFiles.lastError;
   const contestsWithWriteIns = election?.contests.filter(
     (contest): contest is CandidateContest =>
       contest.type === 'candidate' && contest.allowWriteIns
@@ -71,7 +68,7 @@ export function WriteInsScreen(): JSX.Element {
       <NavigationScreen>
         <Prose maxWidth={false}>
           <h1>Write-Ins</h1>
-          {!hasCastVoteRecordFiles && (
+          {!castVoteRecordFiles.wereAdded && (
             <p>Adjudication can begin once CVRs are imported.</p>
           )}
           {contestsWithWriteIns?.map((contest) => (
@@ -79,7 +76,7 @@ export function WriteInsScreen(): JSX.Element {
               <Button
                 disabled={
                   !(
-                    hasCastVoteRecordFiles &&
+                    castVoteRecordFiles.wereAdded &&
                     writeInCountsByContest?.get(contest.id)
                   )
                 }

--- a/frontends/election-manager/src/utils/cast_vote_record_files.ts
+++ b/frontends/election-manager/src/utils/cast_vote_record_files.ts
@@ -456,6 +456,13 @@ export class CastVoteRecordFiles {
     }
     return liveSeen ? 'live' : undefined;
   }
+
+  /**
+   * Whether CVR files were added, even if adding failed with an error.
+   */
+  get wereAdded(): boolean {
+    return this.fileList.length > 0 || Boolean(this.lastError);
+  }
 }
 
 export type SaveCastVoteRecordFiles = (

--- a/integration-testing/election-manager/cypress/integration/candidate_contest_tallies.ts
+++ b/integration-testing/election-manager/cypress/integration/candidate_contest_tallies.ts
@@ -114,7 +114,7 @@ describe('Election Manager can create SEMS tallies', () => {
       encoding: 'utf-8',
     });
     cy.contains('Close').click();
-    cy.get('[data-testid="total-ballot-count"]').within(() => cy.contains('5'));
+    cy.get('[data-testid="total-cvr-count"]').within(() => cy.contains('5'));
 
     // Check that the internal tally reports have the correct tallies
     const expectedFullResults = [
@@ -162,54 +162,55 @@ describe('Election Manager can create SEMS tallies', () => {
         },
       },
     ];
-    cy.contains('View Unofficial Full Election Tally Report').click();
+    cy.contains('Reports').click();
+    cy.contains('Unofficial Full Election Tally Report').click();
     assertExpectedResultsMatchTallyReport(expectedFullResults, {
       absentee: 0,
       precinct: 5,
     });
-    cy.contains('Back to Tally Index').click();
-    cy.contains('View Unofficial Precinct 2 Tally Report').click();
+    cy.contains('Back to Reports').click();
+    cy.contains('Unofficial Precinct 2 Tally Report').click();
     assertExpectedResultsMatchTallyReport(expectedFullResults, {
       absentee: 0,
       precinct: 5,
     });
-    cy.contains('Back to Tally Index').click();
-    cy.contains('View Unofficial Precinct 1 Tally Report').click();
+    cy.contains('Back to Reports').click();
+    cy.contains('Unofficial Precinct 1 Tally Report').click();
     assertExpectedResultsMatchTallyReport(expectedEmptyResults, {
       absentee: 0,
       precinct: 0,
     });
-    cy.contains('Back to Tally Index').click();
-    cy.contains('View Unofficial Precinct 3 Tally Report').click();
+    cy.contains('Back to Reports').click();
+    cy.contains('Unofficial Precinct 3 Tally Report').click();
     assertExpectedResultsMatchTallyReport(expectedEmptyResults, {
       absentee: 0,
       precinct: 0,
     });
-    cy.contains('Back to Tally Index').click();
-    cy.contains('View Unofficial Precinct 4 Tally Report').click();
+    cy.contains('Back to Reports').click();
+    cy.contains('Unofficial Precinct 4 Tally Report').click();
     assertExpectedResultsMatchTallyReport(expectedEmptyResults, {
       absentee: 0,
       precinct: 0,
     });
-    cy.contains('Back to Tally Index').click();
-    cy.contains('View Unofficial Precinct 5 Tally Report').click();
+    cy.contains('Back to Reports').click();
+    cy.contains('Unofficial Precinct 5 Tally Report').click();
     assertExpectedResultsMatchTallyReport(expectedEmptyResults, {
       absentee: 0,
       precinct: 0,
     });
-    cy.contains('Back to Tally Index').click();
-    cy.contains('View Unofficial Liberty Party Tally Report').click();
+    cy.contains('Back to Reports').click();
+    cy.contains('Unofficial Liberty Party Tally Report').click();
     assertExpectedResultsMatchTallyReport(expectedFullResults, {
       absentee: 0,
       precinct: 5,
     });
-    cy.contains('Back to Tally Index').click();
-    cy.contains('View Unofficial Scanner scanner-1 Tally Report').click();
+    cy.contains('Back to Reports').click();
+    cy.contains('Unofficial Scanner scanner-1 Tally Report').click();
     assertExpectedResultsMatchTallyReport(expectedFullResults, {
       absentee: 0,
       precinct: 5,
     });
-    cy.contains('Back to Tally Index').click();
+    cy.contains('Back to Reports').click();
 
     // Check that the exported SEMS result file as the correct tallies
     cy.contains('Save Results File').click();

--- a/integration-testing/election-manager/cypress/integration/tallies.ts
+++ b/integration-testing/election-manager/cypress/integration/tallies.ts
@@ -15,9 +15,10 @@ describe('Election Manager can create SEMS tallies', () => {
       'multiPartyPrimaryCVRResults.jsonl'
     );
     cy.contains('Close').click();
-    cy.get('[data-testid="total-ballot-count"]').within(() =>
+    cy.get('[data-testid="total-cvr-count"]').within(() =>
       cy.contains('4,530')
     );
+    cy.contains('Reports').click();
     cy.contains('Save Results File').click();
     cy.get('[data-testid="manual-export"]').click();
     cy.contains('Results Saved');

--- a/integration-testing/election-manager/cypress/integration/yes_no_contest_tallies.ts
+++ b/integration-testing/election-manager/cypress/integration/yes_no_contest_tallies.ts
@@ -163,10 +163,11 @@ describe('Election Manager can create SEMS tallies', () => {
       encoding: 'utf-8',
     });
     cy.contains('Close').click();
-    cy.get('[data-testid="total-ballot-count"]').within(() => cy.contains('8'));
+    cy.get('[data-testid="total-cvr-count"]').within(() => cy.contains('8'));
 
     // Check that the internal tally reports have the correct tallies
-    cy.contains('View Unofficial Full Election Tally Report').click();
+    cy.contains('Reports').click();
+    cy.contains('Unofficial Full Election Tally Report').click();
     assertExpectedResultsMatchTallyReport(
       [
         {
@@ -204,8 +205,8 @@ describe('Election Manager can create SEMS tallies', () => {
       ],
       { absentee: 4, precinct: 4 }
     );
-    cy.contains('Back to Tally Index').click();
-    cy.contains('View Unofficial District 5 Tally Report').click();
+    cy.contains('Back to Reports').click();
+    cy.contains('Unofficial District 5 Tally Report').click();
     assertExpectedResultsMatchTallyReport(
       [
         {
@@ -243,8 +244,8 @@ describe('Election Manager can create SEMS tallies', () => {
       ],
       { absentee: 2, precinct: 2 }
     );
-    cy.contains('Back to Tally Index').click();
-    cy.contains('View Unofficial Bywy Tally Report').click();
+    cy.contains('Back to Reports').click();
+    cy.contains('Unofficial Bywy Tally Report').click();
     assertExpectedResultsMatchTallyReport(
       [
         {
@@ -282,8 +283,8 @@ describe('Election Manager can create SEMS tallies', () => {
       ],
       { absentee: 2, precinct: 2 }
     );
-    cy.contains('Back to Tally Index').click();
-    cy.contains('View Unofficial Panhandle Tally Report').click();
+    cy.contains('Back to Reports').click();
+    cy.contains('Unofficial Panhandle Tally Report').click();
     assertExpectedResultsMatchTallyReport(
       [
         {
@@ -321,8 +322,8 @@ describe('Election Manager can create SEMS tallies', () => {
       ],
       { absentee: 0, precinct: 0 }
     );
-    cy.contains('Back to Tally Index').click();
-    cy.contains('View Unofficial Absentee Ballot Tally Report').click();
+    cy.contains('Back to Reports').click();
+    cy.contains('Unofficial Absentee Ballot Tally Report').click();
     assertExpectedResultsMatchTallyReport(
       [
         {
@@ -360,8 +361,8 @@ describe('Election Manager can create SEMS tallies', () => {
       ],
       { hide: true }
     );
-    cy.contains('Back to Tally Index').click();
-    cy.contains('View Unofficial Precinct Ballot Tally Report').click();
+    cy.contains('Back to Reports').click();
+    cy.contains('Unofficial Precinct Ballot Tally Report').click();
     assertExpectedResultsMatchTallyReport(
       [
         {
@@ -399,8 +400,8 @@ describe('Election Manager can create SEMS tallies', () => {
       ],
       { hide: true }
     );
-    cy.contains('Back to Tally Index').click();
-    cy.contains('View Unofficial Scanner scanner-1 Tally Report').click();
+    cy.contains('Back to Reports').click();
+    cy.contains('Unofficial Scanner scanner-1 Tally Report').click();
     assertExpectedResultsMatchTallyReport(
       [
         {
@@ -438,8 +439,8 @@ describe('Election Manager can create SEMS tallies', () => {
       ],
       { absentee: 1, precinct: 3 }
     );
-    cy.contains('Back to Tally Index').click();
-    cy.contains('View Unofficial Scanner scanner-2 Tally Report').click();
+    cy.contains('Back to Reports').click();
+    cy.contains('Unofficial Scanner scanner-2 Tally Report').click();
     assertExpectedResultsMatchTallyReport(
       [
         {
@@ -477,7 +478,7 @@ describe('Election Manager can create SEMS tallies', () => {
       ],
       { absentee: 3, precinct: 1 }
     );
-    cy.contains('Back to Tally Index').click();
+    cy.contains('Back to Reports').click();
 
     // Check that the exported SEMS result file as the correct tallies
     cy.contains('Save Results File').click();


### PR DESCRIPTION
## Overview
Closes #1739 by splitting the Tally tab into a Tally and a separate Reports tab, with rearranged content.

## Demo Video or Screenshot
[split-tally-rab-rev4.webm](https://user-images.githubusercontent.com/37960853/177841505-ed0b25d4-07fe-45ef-98f4-7e16e949a9f5.webm)

## Testing Plan 
- [x] Update frontend and integration tests to account for the separate screens and rearranged buttons.

## Checklist
- [ ] ~~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~~
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
