### PR TITLE
Make unconfigured machine screen default state of super admin Definition tab

### DIFF
--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -187,13 +187,8 @@ async function authenticateWithAdminCard(card: MemoryCard) {
 
 // TODO: Update this function to check super admin PIN entry once super admin PINs have been
 // implemented
-async function authenticateWithSuperAdminCard(
-  card: MemoryCard,
-  expectLockScreenToStart = true
-) {
-  if (expectLockScreenToStart) {
-    await screen.findByText('VxAdmin is Locked');
-  }
+async function authenticateWithSuperAdminCard(card: MemoryCard) {
+  await screen.findByText('VxAdmin is Locked');
   card.insertCard({
     t: 'superadmin',
     h: eitherNeitherElectionDefinition.electionHash,
@@ -1208,8 +1203,9 @@ test('super admin UI has expected nav when no election and VVSG2 auth flows are 
 
   const card = new MemoryCard();
   const hardware = MemoryHardware.buildStandard();
-  render(<App card={card} hardware={hardware} />);
-  await authenticateWithSuperAdminCard(card, false);
+  const storage = new MemoryStorage();
+  render(<App card={card} hardware={hardware} storage={storage} />);
+  await authenticateWithSuperAdminCard(card);
 
   userEvent.click(screen.getByText('Definition'));
   await screen.findByRole('heading', { name: 'Configure VxAdmin' });
@@ -1219,6 +1215,32 @@ test('super admin UI has expected nav when no election and VVSG2 auth flows are 
   await screen.findByRole('heading', { name: 'Logs' });
   screen.getByRole('button', { name: 'Lock Machine' });
 
+  expect(screen.queryByText('Draft Ballots')).not.toBeInTheDocument();
+  expect(screen.queryByText('Smartcards')).not.toBeInTheDocument();
+
+  // Create an election definition and verify that previously hidden tabs appear
+  userEvent.click(screen.getByText('Definition'));
+  await screen.findByRole('heading', { name: 'Configure VxAdmin' });
+  userEvent.click(
+    screen.getByRole('button', { name: 'Create New Election Definition' })
+  );
+  await waitFor(() =>
+    expect(
+      screen.queryByRole('heading', { name: 'Configure VxAdmin' })
+    ).not.toBeInTheDocument()
+  );
+  screen.getByText('Draft Ballots');
+  screen.getByText('Smartcards');
+
+  // Remove the election definition and verify that those same tabs disappear
+  userEvent.click(screen.getByText('Remove Election'));
+  const modal = await screen.findByRole('alertdialog');
+  userEvent.click(
+    within(modal).getByRole('button', { name: 'Remove Election Definition' })
+  );
+  await waitFor(() =>
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+  );
   expect(screen.queryByText('Draft Ballots')).not.toBeInTheDocument();
   expect(screen.queryByText('Smartcards')).not.toBeInTheDocument();
 });
@@ -1233,7 +1255,7 @@ test('super admin Smartcards screen navigation', async () => {
     electionDefinition: eitherNeitherElectionDefinition,
   });
   render(<App card={card} hardware={hardware} storage={storage} />);
-  await authenticateWithSuperAdminCard(card, false);
+  await authenticateWithSuperAdminCard(card);
 
   userEvent.click(screen.getByText('Smartcards'));
   screen.getByRole('heading', { name: 'Smartcards' });

--- a/frontends/election-manager/src/app_root.tsx
+++ b/frontends/election-manager/src/app_root.tsx
@@ -457,7 +457,7 @@ export function AppRoot({
     async (electionJson) => {
       const previousElection = electionDefinition;
       if (previousElection) {
-        void logger.log(LogEventId.ElectionUnconfigured, 'admin', {
+        void logger.log(LogEventId.ElectionUnconfigured, currentUserRole, {
           disposition: LogDispositionStandardTypes.Success,
           previousElectionHash: previousElection.electionHash,
         });
@@ -529,7 +529,6 @@ export function AppRoot({
       setIsOfficialResults,
       setCastVoteRecordFiles,
       setPrintedBallots,
-      setElectionDefinition,
       setElectionDefinition,
       setConfiguredAt,
     ]

--- a/frontends/election-manager/src/app_root.tsx
+++ b/frontends/election-manager/src/app_root.tsx
@@ -20,7 +20,6 @@ import {
   ExternalTallySourceType,
   Provider,
 } from '@votingworks/types';
-
 import {
   assert,
   Storage,
@@ -41,12 +40,10 @@ import {
 } from './lib/votecounting';
 
 import { AppContext } from './contexts/app_context';
-
 import {
   CastVoteRecordFiles,
   SaveCastVoteRecordFiles,
 } from './utils/cast_vote_record_files';
-
 import { ElectionManager } from './components/election_manager';
 import {
   SaveElection,
@@ -63,6 +60,7 @@ import {
   convertExternalTalliesToStorageString,
   convertStorageStringToExternalTallies,
 } from './utils/external_tallies';
+import { areVvsg2AuthFlowsEnabled } from './config/features';
 
 export interface AppStorage {
   electionDefinition?: ElectionDefinition;
@@ -490,9 +488,8 @@ export function AppRoot({
         const electionData = electionJson;
         const electionHash = sha256(electionData);
         const election = safeParseElection(electionData).unsafeUnwrap();
-        // Temporarily bootstrap an authenticated user session. This will be removed
-        // once we have a full story for how to bootstrap the auth process.
-        if (auth.status === 'logged_out') {
+
+        if (!areVvsg2AuthFlowsEnabled() && auth.status === 'logged_out') {
           auth.bootstrapAuthenticatedAdminSession(electionHash);
         }
 

--- a/frontends/election-manager/src/components/election_manager.tsx
+++ b/frontends/election-manager/src/components/election_manager.tsx
@@ -68,7 +68,7 @@ export function ElectionManager(): JSX.Element {
     return <RemoveCardScreen />;
   }
 
-  if (!election || !configuredAt) {
+  if (!areVvsg2AuthFlowsEnabled() && (!election || !configuredAt)) {
     return (
       <Switch>
         <Route exact path={routerPaths.root}>
@@ -77,21 +77,9 @@ export function ElectionManager(): JSX.Element {
         <Route exact path={routerPaths.electionDefinition}>
           <UnconfiguredScreen />
         </Route>
-        {!areVvsg2AuthFlowsEnabled() && (
-          <Route exact path={routerPaths.advanced}>
-            <AdvancedScreen />
-          </Route>
-        )}
-        {areVvsg2AuthFlowsEnabled() && (
-          <Route exact path={routerPaths.settings}>
-            <SettingsScreen />
-          </Route>
-        )}
-        {areVvsg2AuthFlowsEnabled() && (
-          <Route exact path={routerPaths.logs}>
-            <LogsScreen />
-          </Route>
-        )}
+        <Route exact path={routerPaths.advanced}>
+          <AdvancedScreen />
+        </Route>
       </Switch>
     );
   }
@@ -120,6 +108,23 @@ export function ElectionManager(): JSX.Element {
             machineId={machineConfig.machineId}
           />
         </Screen>
+      );
+    }
+
+    if (!election || !configuredAt) {
+      return (
+        <Switch>
+          <Route exact path={routerPaths.electionDefinition}>
+            <UnconfiguredScreen />
+          </Route>
+          <Route exact path={routerPaths.settings}>
+            <SettingsScreen />
+          </Route>
+          <Route exact path={routerPaths.logs}>
+            <LogsScreen />
+          </Route>
+          <Redirect to={routerPaths.electionDefinition} />
+        </Switch>
       );
     }
 

--- a/frontends/election-manager/src/screens/unconfigured_screen.tsx
+++ b/frontends/election-manager/src/screens/unconfigured_screen.tsx
@@ -24,6 +24,7 @@ import { FileInputButton } from '../components/file_input_button';
 import { HorizontalRule } from '../components/horizontal_rule';
 import { Loading } from '../components/loading';
 import { NavigationScreen } from '../components/navigation_screen';
+import { areVvsg2AuthFlowsEnabled } from '../config/features';
 
 const Loaded = styled.p`
   line-height: 2.5rem;
@@ -214,7 +215,7 @@ export function UnconfiguredScreen(): JSX.Element {
   }, [updateStatus]);
 
   useEffect(() => {
-    if (location.pathname !== '/') {
+    if (!areVvsg2AuthFlowsEnabled() && location.pathname !== '/') {
       history.push(routerPaths.root);
     }
   }, [location, history]);


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/1979

This PR irons out the initial election-definition creation flow for super admins, most notably by making the unconfigured machine screen the default state of the super admin Definition tab. This new logic is gated behind the existing VVSG2 auth feature flag.

To configure a machine with an election definition, a super admin must first auth with their card. Only after an election definition is defined are the Draft Ballots and Smartcards tabs displayed.

_After this PR_

https://user-images.githubusercontent.com/12616928/177418842-6a246a52-0cbc-41de-bc9c-ac3f33655bef.mov

Prior to this PR, when the VVSG2 auth feature flag was enabled, this initial state was very incomplete. Machine configuration wasn't gated behind a lock screen, yet authing with a super admin card still changed the state of the page, adding tabs. And after creating an election definition, you were bootstrapped into a (non-super) admin session.

I hesitated to even include a video of this before state since it was so incomplete but here's one anyway 😅

_Before this PR_

https://user-images.githubusercontent.com/12616928/177418849-95fe44ab-302b-4ac9-a78e-489a1d549c6c.mov

## Testing Plan 

- [x] Tested manually
- [x] Updated automated tests

## Checklist

- [x] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ Relying on existing logging
- [x] ~I have added JSDoc comments to any newly introduced exports~ N/A
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates