### PR TITLE
(fix: precinct-scanner): Show warning when machine needs backup before being unconfigured

### DIFF
--- a/frontends/precinct-scanner/src/api/scan.ts
+++ b/frontends/precinct-scanner/src/api/scan.ts
@@ -18,10 +18,11 @@ export interface ScannerStatusDetails {
   ballotNeedsReview: boolean;
   scannerState: Scan.ScannerStatus;
   ballotCount: number;
+  canUnconfigure?: boolean;
 }
 
 export async function getCurrentStatus(): Promise<ScannerStatusDetails> {
-  const { scanner, batches, adjudication } = unsafeParse(
+  const { scanner, batches, adjudication, canUnconfigure } = unsafeParse(
     Scan.GetScanStatusResponseSchema,
     await fetchJson('/scan/status')
   );
@@ -34,6 +35,7 @@ export async function getCurrentStatus(): Promise<ScannerStatusDetails> {
     ballotNeedsReview: adjudication.remaining > 0,
     scannerState: scanner,
     ballotCount,
+    canUnconfigure,
   };
 }
 

--- a/frontends/precinct-scanner/src/app.test.tsx
+++ b/frontends/precinct-scanner/src/app.test.tsx
@@ -77,14 +77,14 @@ const getTestModeConfigTrueResponseBody: Scan.GetTestModeConfigResponse = {
 
 const scanStatusWaitingForPaperResponseBody: Scan.GetScanStatusResponse = {
   scanner: Scan.ScannerStatus.WaitingForPaper,
-  canUnconfigure: false,
+  canUnconfigure: true,
   batches: [],
   adjudication: { adjudicated: 0, remaining: 0 },
 };
 
 const scanStatusReadyToScanResponseBody: Scan.GetScanStatusResponse = {
   scanner: Scan.ScannerStatus.ReadyToScan,
-  canUnconfigure: false,
+  canUnconfigure: true,
   batches: [],
   adjudication: { adjudicated: 0, remaining: 0 },
 };
@@ -461,7 +461,7 @@ test('voter can cast a ballot that scans successfully ', async () => {
       '/scan/status',
       typedAs<Scan.GetScanStatusResponse>({
         scanner: Scan.ScannerStatus.WaitingForPaper,
-        canUnconfigure: false,
+        canUnconfigure: true,
         batches: [
           {
             id: 'test-batch',

--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -608,6 +608,7 @@ export function AppRoot({
 
   const scanner = usePrecinctScanner();
   const scannedBallotCount = scanner?.status.ballotCount ?? 0;
+  const canUnconfigure = scanner?.status.canUnconfigure ?? false;
 
   const getCvrsFromExport = useCallback(async (): Promise<CastVoteRecord[]> => {
     if (electionDefinition) {
@@ -756,6 +757,7 @@ export function AppRoot({
         <AdminScreen
           updateAppPrecinctId={updatePrecinctId}
           scannedBallotCount={scannedBallotCount}
+          canUnconfigure={canUnconfigure}
           isTestMode={isTestMode}
           toggleLiveMode={toggleTestMode}
           unconfigure={unconfigureServer}

--- a/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
+++ b/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
@@ -46,14 +46,14 @@ const getTestModeConfigTrueResponseBody: Scan.GetTestModeConfigResponse = {
 };
 
 const scanStatusWaitingForPaperResponseBody: Scan.GetScanStatusResponse = {
-  canUnconfigure: false,
+  canUnconfigure: true,
   scanner: Scan.ScannerStatus.WaitingForPaper,
   batches: [],
   adjudication: { adjudicated: 0, remaining: 0 },
 };
 
 const scanStatusReadyToScanResponseBody: Scan.GetScanStatusResponse = {
-  canUnconfigure: false,
+  canUnconfigure: true,
   scanner: Scan.ScannerStatus.ReadyToScan,
   batches: [],
   adjudication: { adjudicated: 0, remaining: 0 },
@@ -252,7 +252,7 @@ test('error from services/scan in accepting a reviewable ballot', async () => {
       '/scan/status',
       typedAs<Scan.GetScanStatusResponse>({
         scanner: Scan.ScannerStatus.ReadyToScan,
-        canUnconfigure: false,
+        canUnconfigure: true,
         batches: [
           {
             id: 'test-batch',
@@ -352,7 +352,7 @@ test('error from services/scan in ejecting a reviewable ballot', async () => {
       '/scan/status',
       typedAs<Scan.GetScanStatusResponse>({
         scanner: Scan.ScannerStatus.ReadyToScan,
-        canUnconfigure: false,
+        canUnconfigure: true,
         batches: [
           {
             id: 'test-batch',
@@ -407,7 +407,7 @@ test('error from services/scan in ejecting a reviewable ballot', async () => {
     '/scan/status',
     typedAs<Scan.GetScanStatusResponse>({
       scanner: Scan.ScannerStatus.WaitingForPaper,
-      canUnconfigure: false,
+      canUnconfigure: true,
       batches: [
         {
           id: 'test-batch',

--- a/frontends/precinct-scanner/src/screens/admin_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/admin_screen.test.tsx
@@ -39,6 +39,7 @@ test('renders date and time settings modal', async () => {
       <AdminScreen
         scannedBallotCount={10}
         isTestMode={false}
+        canUnconfigure
         updateAppPrecinctId={jest.fn()}
         toggleLiveMode={jest.fn()}
         unconfigure={jest.fn()}
@@ -91,6 +92,7 @@ test('setting and un-setting the precinct', async () => {
       <AdminScreen
         scannedBallotCount={10}
         isTestMode={false}
+        canUnconfigure
         updateAppPrecinctId={updateAppPrecinctId}
         toggleLiveMode={jest.fn()}
         unconfigure={jest.fn()}
@@ -128,6 +130,7 @@ test('export from admin screen', () => {
       <AdminScreen
         scannedBallotCount={10}
         isTestMode={false}
+        canUnconfigure
         updateAppPrecinctId={jest.fn()}
         toggleLiveMode={jest.fn()}
         unconfigure={jest.fn()}
@@ -154,6 +157,7 @@ test('unconfigure ejects a usb drive when it is mounted', () => {
       <AdminScreen
         scannedBallotCount={10}
         isTestMode={false}
+        canUnconfigure
         updateAppPrecinctId={jest.fn()}
         toggleLiveMode={jest.fn()}
         unconfigure={unconfigureFn}
@@ -183,6 +187,7 @@ test('unconfigure does not eject a usb drive that is not mounted', async () => {
       <AdminScreen
         scannedBallotCount={10}
         isTestMode={false}
+        canUnconfigure
         updateAppPrecinctId={jest.fn()}
         toggleLiveMode={jest.fn()}
         unconfigure={unconfigureFn}
@@ -198,4 +203,59 @@ test('unconfigure does not eject a usb drive that is not mounted', async () => {
     expect(unconfigureFn).toHaveBeenCalledTimes(1);
     expect(ejectFn).toHaveBeenCalledTimes(1);
   });
+});
+
+test('unconfigure button is disabled when the machine cannot be unconfigured', () => {
+  render(
+    <AppContext.Provider
+      value={{
+        electionDefinition: electionSampleDefinition,
+        machineConfig: { machineId: '0000', codeVersion: 'TEST' },
+        auth,
+      }}
+    >
+      <AdminScreen
+        scannedBallotCount={10}
+        isTestMode={false}
+        canUnconfigure={false}
+        updateAppPrecinctId={jest.fn()}
+        toggleLiveMode={jest.fn()}
+        unconfigure={jest.fn()}
+        calibrate={jest.fn()}
+        usbDrive={{ status: usbstick.UsbDriveStatus.mounted, eject: jest.fn() }}
+      />
+    </AppContext.Provider>
+  );
+
+  fireEvent.click(screen.getByText('Unconfigure Machine'));
+  expect(screen.queryByText('Unconfigure Machine?')).toBeNull();
+});
+
+test('cannot toggle to testing mode when the machine cannot be unconfigured', () => {
+  const toggleLiveModeFn = jest.fn();
+
+  render(
+    <AppContext.Provider
+      value={{
+        electionDefinition: electionSampleDefinition,
+        machineConfig: { machineId: '0000', codeVersion: 'TEST' },
+        auth,
+      }}
+    >
+      <AdminScreen
+        scannedBallotCount={10}
+        isTestMode={false}
+        canUnconfigure={false}
+        updateAppPrecinctId={jest.fn()}
+        toggleLiveMode={toggleLiveModeFn}
+        unconfigure={jest.fn()}
+        calibrate={jest.fn()}
+        usbDrive={{ status: usbstick.UsbDriveStatus.mounted, eject: jest.fn() }}
+      />
+    </AppContext.Provider>
+  );
+
+  fireEvent.click(screen.getByText('Testing Mode'));
+  expect(toggleLiveModeFn).not.toHaveBeenCalled();
+  fireEvent.click(screen.getByText('Cancel'));
 });


### PR DESCRIPTION
## Overview
Fixes #2051 

This disables unconfiguring the machine and switching to testing mode if a machine requires backup. It also adds warning messages to explain that backup is required.

## Demo Video or Screenshot

https://user-images.githubusercontent.com/7584833/177598380-844509a1-a2b5-4383-9cbf-b7938b3cce36.mov

## Testing Plan 
Added tests, manual testing.

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
