### PR TITLE
fix(nh): properly flag undervotes for multi-party endorsements

### DIFF
--- a/libs/ballot-interpreter-nh/src/interpret/convert_marks_to_adjudication_info.test.ts
+++ b/libs/ballot-interpreter-nh/src/interpret/convert_marks_to_adjudication_info.test.ts
@@ -1,0 +1,77 @@
+import {
+  AdjudicationInfo,
+  AdjudicationReason,
+  GridPosition,
+  safeParseElection,
+} from '@votingworks/types';
+import { assert, typedAs } from '@votingworks/utils';
+import { AmherstFixtureName, readFixtureJson } from '../../test/fixtures';
+import { makeRect, vec } from '../utils';
+import { convertMarksToAdjudicationInfo } from './convert_marks_to_adjudication_info';
+
+test('multi-party endorsement', async () => {
+  const election = safeParseElection(
+    await readFixtureJson(AmherstFixtureName, 'election')
+  ).unsafeUnwrap();
+  const multiPartyContestId = 'Sheriff-4243fe0b';
+  const multiPartyContest = election.contests.find(
+    (contest) => contest.id === multiPartyContestId
+  )!;
+  const contestGridPositions = election.gridLayouts![0]!.gridPositions.filter(
+    (gridPosition) => gridPosition.contestId === multiPartyContestId
+  );
+  const [
+    candidateGridPositionDemocrat,
+    candidateGridPositionRepublican,
+    writeInGridPosition,
+  ] = contestGridPositions;
+  assert(
+    candidateGridPositionDemocrat &&
+      candidateGridPositionRepublican &&
+      writeInGridPosition
+  );
+  assert(
+    candidateGridPositionDemocrat.type === 'option' &&
+      candidateGridPositionRepublican.type === 'option' &&
+      writeInGridPosition.type === 'write-in' &&
+      candidateGridPositionDemocrat.optionId ===
+        candidateGridPositionRepublican.optionId
+  );
+
+  const validCases: Array<GridPosition[]> = [
+    [candidateGridPositionDemocrat],
+    [candidateGridPositionRepublican],
+    [writeInGridPosition],
+    [candidateGridPositionDemocrat, candidateGridPositionRepublican],
+  ];
+
+  for (const selections of validCases) {
+    expect(
+      convertMarksToAdjudicationInfo({
+        contests: [multiPartyContest],
+        enabledReasons: [
+          AdjudicationReason.Overvote,
+          AdjudicationReason.Undervote,
+          AdjudicationReason.BlankBallot,
+        ],
+        markThresholds: {
+          marginal: 0.08,
+          definite: 0.12,
+        },
+        ovalMarks: contestGridPositions.map((gridPosition) => ({
+          gridPosition,
+          score: selections.includes(gridPosition) ? 0.5 : 0,
+          scoredOffset: vec(0, 0),
+          bounds: makeRect({ minX: 0, minY: 0, maxX: 1, maxY: 1 }),
+        })),
+      })
+    ).toStrictEqual(
+      typedAs<AdjudicationInfo>({
+        requiresAdjudication: false,
+        enabledReasonInfos: [],
+        enabledReasons: expect.any(Array),
+        ignoredReasonInfos: expect.any(Array),
+      })
+    );
+  }
+});


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Closes #2072

The data model was changed in #1984 to support multi-party endorsements, but we weren't properly handling it in the NH code that turns marks into adjudication reasons. The result was that we'd determine that the contest was undervoted if only the second grid position was filled in for a given option. The votes were recorded correctly, but an error would be shown.

The fix is to examine all the grid positions that map to the contest/option and use the most marked one to determine the mark status.

## Demo Video or Screenshot
n/a

## Testing Plan 
Verified with VxScan that an Amherst ballot with the Republican oval for Edward Randolph is properly counted as a vote and that no error screen is shown.

~I did notice that if that oval is the _only_ one on the entire sheet that is filled in that I get a Blank Ballot error, presumably because the front of the sheet is entirely blank. This appears to be an existing bug.~ Yeah, this is https://github.com/votingworks/vxsuite/issues/1638.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
