### PR TITLE
fix(nh): correct orientation of scanned ballots

### DIFF
--- a/libs/ballot-interpreter-nh/src/cli/interpret/index.ts
+++ b/libs/ballot-interpreter-nh/src/cli/interpret/index.ts
@@ -199,7 +199,7 @@ export async function main(
     return 1;
   }
 
-  const [frontPageInterpretationWithFiles, backPageInterpretationWithFiles] =
+  const [frontPageInterpretationResult, backPageInterpretationResult] =
     interpretResult.ok();
 
   const thresholds =
@@ -211,8 +211,8 @@ export async function main(
     io.stdout.write(
       JSON.stringify(
         {
-          front: frontPageInterpretationWithFiles.interpretation,
-          back: backPageInterpretationWithFiles.interpretation,
+          front: frontPageInterpretationResult.interpretation,
+          back: backPageInterpretationResult.interpretation,
         },
         undefined,
         2
@@ -221,22 +221,18 @@ export async function main(
     return 0;
   }
 
-  for (const pageInterpretation of [
-    frontPageInterpretationWithFiles,
-    backPageInterpretationWithFiles,
-  ]) {
-    io.stdout.write(
-      chalk.bold.underline(`${pageInterpretation.originalFilename}:\n`)
-    );
-    if (pageInterpretation.interpretation.type !== 'InterpretedHmpbPage') {
-      io.stdout.write(
-        `  ${chalk.red(pageInterpretation.interpretation.type)}\n`
-      );
+  for (const [ballotPath, pageInterpretation] of [
+    [frontBallotPath, frontPageInterpretationResult.interpretation],
+    [backBallotPath, backPageInterpretationResult.interpretation],
+  ] as const) {
+    io.stdout.write(chalk.bold.underline(`${ballotPath}:\n`));
+    if (pageInterpretation.type !== 'InterpretedHmpbPage') {
+      io.stdout.write(`  ${chalk.red(pageInterpretation.type)}\n`);
       continue;
     }
 
     const marksByContest = groupBy(
-      pageInterpretation.interpretation.markInfo.marks,
+      pageInterpretation.markInfo.marks,
       (m) => m.contestId
     );
 

--- a/libs/ballot-interpreter-nh/src/interpret/index.ts
+++ b/libs/ballot-interpreter-nh/src/interpret/index.ts
@@ -10,7 +10,7 @@ import {
   InterpretedHmpbPage,
   MarkThresholds,
   ok,
-  PageInterpretationWithFiles,
+  PageInterpretation,
   Result,
 } from '@votingworks/types';
 import { getScannedBallotCardGeometry } from '../accuvote';
@@ -33,6 +33,15 @@ export const DefaultMarkThresholds: MarkThresholds = {
 };
 
 /**
+ * Result of interpretation of a ballot image, optionally with a normalized
+ * image.
+ */
+export interface InterpretFileResult {
+  interpretation: PageInterpretation;
+  normalizedImage?: ImageData;
+}
+
+/**
  * Interpret a ballot scan sheet.
  */
 export async function interpret(
@@ -46,9 +55,7 @@ export async function interpret(
     markThresholds?: MarkThresholds;
     adjudicationReasons?: readonly AdjudicationReason[];
   } = {}
-): Promise<
-  Result<[PageInterpretationWithFiles, PageInterpretationWithFiles], Error>
-> {
+): Promise<Result<[InterpretFileResult, InterpretFileResult], Error>> {
   const paperSize = electionDefinition.election.ballotLayout?.paperSize;
 
   if (!paperSize) {
@@ -243,19 +250,14 @@ export async function interpret(
     layout: backConvertedLayout.ok(),
   };
 
-  const frontPageInterpretationWithFiles: PageInterpretationWithFiles = {
-    originalFilename: frontPage,
-    normalizedFilename: frontPage,
+  const frontPageInterpretationResult: InterpretFileResult = {
     interpretation: frontInterpretation,
+    normalizedImage: frontLayout.imageData,
   };
-  const backPageInterpretationWithFiles: PageInterpretationWithFiles = {
-    originalFilename: backPage,
-    normalizedFilename: backPage,
+  const backPageInterpretationResult: InterpretFileResult = {
     interpretation: backInterpretation,
+    normalizedImage: backLayout.imageData,
   };
 
-  return ok([
-    frontPageInterpretationWithFiles,
-    backPageInterpretationWithFiles,
-  ]);
+  return ok([frontPageInterpretationResult, backPageInterpretationResult]);
 }

--- a/services/scan/src/workers/interpret_nh.test.ts
+++ b/services/scan/src/workers/interpret_nh.test.ts
@@ -1,0 +1,60 @@
+import { dirSync, fileSync } from 'tmp';
+import { join } from 'path';
+import { safeParseElectionDefinition } from '@votingworks/types';
+import { readdir, readFile } from 'fs/promises';
+import { call, InterpretOutput } from './interpret_nh';
+import { Store } from '../store';
+
+const AMHERST_ELECTION = join(
+  __dirname,
+  '../../../../libs/ballot-interpreter-nh/test/fixtures/amherst-2022-07-12/election.json'
+);
+
+const AMHERST_FRONT = join(
+  __dirname,
+  '../../../../libs/ballot-interpreter-nh/test/fixtures/amherst-2022-07-12/scan-marked-front.jpeg'
+);
+
+const AMHERST_BACK = join(
+  __dirname,
+  '../../../../libs/ballot-interpreter-nh/test/fixtures/amherst-2022-07-12/scan-marked-back.jpeg'
+);
+
+test('configure', async () => {
+  const dbPath = fileSync().name;
+  await expect(call({ action: 'configure', dbPath })).resolves.not.toThrow();
+});
+
+test('interpret', async () => {
+  const dbPath = fileSync().name;
+  const ballotImagesPath = dirSync().name;
+  const store = Store.fileStore(dbPath);
+
+  const electionDefinition = safeParseElectionDefinition(
+    await readFile(AMHERST_ELECTION, 'utf8')
+  ).unsafeUnwrap();
+  store.setElection(electionDefinition);
+  await call({ action: 'configure', dbPath });
+
+  const result = (await call({
+    action: 'interpret',
+    frontImagePath: AMHERST_FRONT,
+    backImagePath: AMHERST_BACK,
+    ballotImagesPath,
+    interpreter: 'nh',
+    sheetId: 'test-sheet',
+  })) as InterpretOutput;
+
+  const [frontResult, backResult] = result.unsafeUnwrap();
+
+  expect(frontResult.interpretation.type).toBe('InterpretedHmpbPage');
+  expect(backResult.interpretation.type).toBe('InterpretedHmpbPage');
+
+  const images = (await readdir(ballotImagesPath)).map((filename) =>
+    join(ballotImagesPath, filename)
+  );
+  expect(images).toContain(frontResult.originalFilename);
+  expect(images).toContain(frontResult.normalizedFilename);
+  expect(images).toContain(backResult.originalFilename);
+  expect(images).toContain(backResult.normalizedFilename);
+});

--- a/services/scan/src/workers/interpret_nh.ts
+++ b/services/scan/src/workers/interpret_nh.ts
@@ -2,6 +2,7 @@ import { interpret } from '@votingworks/ballot-interpreter-nh';
 import {
   ElectionDefinition,
   err,
+  ok,
   PageInterpretationWithFiles,
   Result,
 } from '@votingworks/types';
@@ -9,6 +10,7 @@ import { throwIllegalValue } from '@votingworks/utils';
 import { VX_MACHINE_TYPE } from '../globals';
 import { Store } from '../store';
 import { SheetOf } from '../types';
+import { saveSheetImages } from '../util/save_images';
 
 export type Input =
   | { action: 'configure'; dbPath: string }
@@ -55,11 +57,46 @@ export async function call(input: Input): Promise<Output> {
         VX_MACHINE_TYPE === 'bsd'
           ? electionDefinition.election.centralScanAdjudicationReasons
           : electionDefinition.election.precinctScanAdjudicationReasons;
-      return await interpret(
+      const result = await interpret(
         electionDefinition,
         [input.frontImagePath, input.backImagePath],
         { adjudicationReasons }
       );
+
+      if (result.isErr()) {
+        return result;
+      }
+
+      const [frontResult, backResult] = result.ok();
+
+      const frontImages = await saveSheetImages(
+        input.sheetId,
+        input.ballotImagesPath,
+        input.frontImagePath,
+        frontResult.normalizedImage
+      );
+      const backImages = await saveSheetImages(
+        input.sheetId,
+        input.ballotImagesPath,
+        input.backImagePath,
+        backResult.normalizedImage
+      );
+
+      const frontPageInterpretationWithFiles: PageInterpretationWithFiles = {
+        interpretation: frontResult.interpretation,
+        originalFilename: frontImages.original,
+        normalizedFilename: frontImages.normalized,
+      };
+      const backPageInterpretationWithFiles: PageInterpretationWithFiles = {
+        interpretation: backResult.interpretation,
+        originalFilename: backImages.original,
+        normalizedFilename: backImages.normalized,
+      };
+
+      return ok([
+        frontPageInterpretationWithFiles,
+        backPageInterpretationWithFiles,
+      ]);
     }
 
     default:

--- a/services/scan/src/workers/interpret_vx.ts
+++ b/services/scan/src/workers/interpret_vx.ts
@@ -2,12 +2,11 @@ import { AdjudicationReason, PageInterpretation } from '@votingworks/types';
 import { throwIllegalValue } from '@votingworks/utils';
 import makeDebug from 'debug';
 import { readFile } from 'fs-extra';
-import { basename, extname, join } from 'path';
 import { ScannerLocation, SCANNER_LOCATION } from '../globals';
 import { Interpreter, InterpretFileResult } from '../interpreter';
 import { Store } from '../store';
 import { pdfToImages } from '../util/pdf_to_images';
-import { saveImages } from '../util/save_images';
+import { saveSheetImages } from '../util/save_images';
 import * as qrcodeWorker from './qrcode';
 
 const debug = makeDebug('scan:worker:interpret');
@@ -102,19 +101,10 @@ export async function interpret(
     result.interpretation.type,
     ballotImagePath
   );
-  const ext = extname(ballotImagePath);
-  const originalImagePath = join(
+  const images = await saveSheetImages(
+    sheetId,
     ballotImagesPath,
-    `${basename(ballotImagePath, ext)}-${sheetId}-original${ext}`
-  );
-  const normalizedImagePath = join(
-    ballotImagesPath,
-    `${basename(ballotImagePath, ext)}-${sheetId}-normalized${ext}`
-  );
-  const images = await saveImages(
     ballotImagePath,
-    originalImagePath,
-    normalizedImagePath,
     result.normalizedImage
   );
   return {


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Fixes #1893 

We weren't normalizing the NH ballot images at all until https://github.com/votingworks/vxsuite/pull/2037. Now we're rotating them if they come in upside-down, but that data was not being sent to the scan service. Now it is and we're writing the normalized image to disk and recording its location in the database.

## Demo Video or Screenshot
<img width="1407" alt="image" src="https://user-images.githubusercontent.com/1938/177660429-6b3bc9ad-8f8c-494d-b280-421f5d27ef98.png">

## Testing Plan 
Tested with VxScan manually, verified that the database has paths to original and normalized images. I did not try exporting the CVRs with the embedded image data, but I did export a zip backup that had the images correctly.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
