### PR TITLE
fix(nh): let CLIs exit naturally

### DIFF
--- a/libs/ballot-interpreter-nh/bin/convert
+++ b/libs/ballot-interpreter-nh/bin/convert
@@ -5,7 +5,7 @@ require('esbuild-runner/register');
 require('../src/cli/convert')
   .main(process.argv.slice(2))
   .then((code) => {
-    process.exit(code);
+    process.exitCode = code;
   })
   .catch((err) => {
     console.error(err.stack);

--- a/libs/ballot-interpreter-nh/bin/interpret
+++ b/libs/ballot-interpreter-nh/bin/interpret
@@ -5,7 +5,7 @@ require('esbuild-runner/register');
 require('../src/cli/interpret')
   .main(process.argv.slice(2))
   .then((code) => {
-    process.exit(code);
+    process.exitCode = code;
   })
   .catch((err) => {
     console.error(err.stack);


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
Without this, piping the output of either CLI may not work properly as the process exits before it can flush its IO buffers.

## Demo Video or Screenshot
n/a

## Testing Plan 
Tried piping `./bin/interpret … --json` to a file and previously it was truncated. Now it contains the whole JSON data.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
