### PR TITLE
fix(scan): show overvote/blank sheet as overvote

### DIFF
--- a/frontends/precinct-scanner/src/app.test.tsx
+++ b/frontends/precinct-scanner/src/app.test.tsx
@@ -1036,6 +1036,7 @@ test('voter can cast another ballot while the success screen is showing', async 
               interpretation: interpretedHmpb({
                 electionDefinition: electionSampleDefinition,
                 pageNumber: 2,
+                adjudicationReason: AdjudicationReason.BlankBallot,
               }),
               image: { url: '/not/real.jpg' },
             },

--- a/frontends/precinct-scanner/src/utils/build_scanning_result.test.ts
+++ b/frontends/precinct-scanner/src/utils/build_scanning_result.test.ts
@@ -1,0 +1,587 @@
+import {
+  AdjudicationReason,
+  BallotMetadata,
+  BallotPageInfo,
+  BallotType,
+} from '@votingworks/types';
+import { typedAs } from '@votingworks/utils';
+import {
+  RejectedScanningReason,
+  ScanningResult,
+  ScanningResultType,
+} from '../config/types';
+import { buildScanningResult } from './build_scanning_result';
+
+function tryBothOrderings<T>(
+  front: T,
+  back: T,
+  fn: (front: T, back: T) => void
+) {
+  fn(front, back);
+  fn(back, front);
+}
+
+const metadata: BallotMetadata = {
+  ballotStyleId: 'ballot-style-id',
+  precinctId: 'precinct-id',
+  ballotType: BallotType.Standard,
+  electionHash: 'abcdef',
+  isTestMode: true,
+  locales: { primary: 'en-US' },
+};
+
+test('invalid election hash', () => {
+  const page1: BallotPageInfo = {
+    interpretation: {
+      type: 'InvalidElectionHashPage',
+      expectedElectionHash: 'abcdef',
+      actualElectionHash: '123456',
+    },
+    image: {
+      url: 'front-url',
+    },
+  };
+  const page2: BallotPageInfo = {
+    interpretation: {
+      type: 'InvalidElectionHashPage',
+      expectedElectionHash: 'abcdef',
+      actualElectionHash: '123456',
+    },
+    image: {
+      url: 'back-url',
+    },
+  };
+
+  tryBothOrderings(page1, page2, (front, back) => {
+    expect(
+      buildScanningResult({
+        id: 'sheet-id',
+        front,
+        back,
+      })
+    ).toStrictEqual(
+      typedAs<ScanningResult>({
+        resultType: ScanningResultType.Rejected,
+        rejectionReason: RejectedScanningReason.InvalidElectionHash,
+      })
+    );
+  });
+});
+
+test('invalid test mode', () => {
+  const page1: BallotPageInfo = {
+    interpretation: {
+      type: 'InvalidTestModePage',
+      metadata: {
+        ...metadata,
+        pageNumber: 1,
+      },
+    },
+    image: {
+      url: 'front-url',
+    },
+  };
+  const page2: BallotPageInfo = {
+    interpretation: {
+      type: 'InvalidTestModePage',
+      metadata: {
+        ...metadata,
+        pageNumber: 2,
+      },
+    },
+    image: {
+      url: 'back-url',
+    },
+  };
+
+  tryBothOrderings(page1, page2, (front, back) => {
+    expect(
+      buildScanningResult({
+        id: 'sheet-id',
+        front,
+        back,
+      })
+    ).toStrictEqual(
+      typedAs<ScanningResult>({
+        resultType: ScanningResultType.Rejected,
+        rejectionReason: RejectedScanningReason.InvalidTestMode,
+      })
+    );
+  });
+});
+
+test('unreadable', () => {
+  const page1: BallotPageInfo = {
+    interpretation: {
+      type: 'UnreadablePage',
+    },
+    image: {
+      url: 'front-url',
+    },
+  };
+  const page2: BallotPageInfo = {
+    interpretation: {
+      type: 'UnreadablePage',
+    },
+    image: {
+      url: 'back-url',
+    },
+  };
+
+  tryBothOrderings(page1, page2, (front, back) => {
+    expect(
+      buildScanningResult({
+        id: 'sheet-id',
+        front,
+        back,
+      })
+    ).toStrictEqual(
+      typedAs<ScanningResult>({
+        resultType: ScanningResultType.Rejected,
+        rejectionReason: RejectedScanningReason.Unreadable,
+      })
+    );
+  });
+});
+
+test('invalid precinct', () => {
+  const page1: BallotPageInfo = {
+    interpretation: {
+      type: 'InvalidPrecinctPage',
+      metadata: {
+        ...metadata,
+        pageNumber: 1,
+      },
+    },
+    image: {
+      url: 'front-url',
+    },
+  };
+  const page2: BallotPageInfo = {
+    interpretation: {
+      type: 'InvalidPrecinctPage',
+      metadata: {
+        ...metadata,
+        pageNumber: 2,
+      },
+    },
+    image: {
+      url: 'back-url',
+    },
+  };
+
+  tryBothOrderings(page1, page2, (front, back) => {
+    expect(
+      buildScanningResult({
+        id: 'sheet-id',
+        front,
+        back,
+      })
+    ).toStrictEqual(
+      typedAs<ScanningResult>({
+        resultType: ScanningResultType.Rejected,
+        rejectionReason: RejectedScanningReason.InvalidPrecinct,
+      })
+    );
+  });
+});
+
+test('BMD ballot', () => {
+  const page1: BallotPageInfo = {
+    interpretation: {
+      type: 'InterpretedBmdPage',
+      metadata,
+      votes: {},
+    },
+    image: {
+      url: 'front-url',
+    },
+  };
+  const page2: BallotPageInfo = {
+    interpretation: {
+      type: 'BlankPage',
+    },
+    image: {
+      url: 'back-url',
+    },
+  };
+
+  tryBothOrderings(page1, page2, (front, back) => {
+    expect(
+      buildScanningResult({
+        id: 'sheet-id',
+        front,
+        back,
+      })
+    ).toStrictEqual(
+      typedAs<ScanningResult>({
+        resultType: ScanningResultType.Accepted,
+      })
+    );
+  });
+});
+
+test('BMD + HMPB nonsense ballot', () => {
+  const page1: BallotPageInfo = {
+    interpretation: {
+      type: 'InterpretedBmdPage',
+      metadata,
+      votes: {},
+    },
+    image: {
+      url: 'front-url',
+    },
+  };
+  const page2: BallotPageInfo = {
+    interpretation: {
+      type: 'InterpretedHmpbPage',
+      metadata: {
+        ...metadata,
+        pageNumber: 1,
+      },
+      markInfo: {
+        ballotSize: { width: 0, height: 0 },
+        marks: [],
+      },
+      votes: {},
+      adjudicationInfo: {
+        requiresAdjudication: false,
+        enabledReasons: [],
+        enabledReasonInfos: [],
+        ignoredReasonInfos: [],
+      },
+    },
+    image: {
+      url: 'front-url',
+    },
+  };
+
+  tryBothOrderings(page1, page2, (front, back) => {
+    expect(
+      buildScanningResult({
+        id: 'sheet-id',
+        front,
+        back,
+      })
+    ).toStrictEqual(
+      typedAs<ScanningResult>({
+        resultType: ScanningResultType.Rejected,
+        rejectionReason: RejectedScanningReason.Unknown,
+      })
+    );
+  });
+});
+
+test('HMPB blank ballot', () => {
+  const page1: BallotPageInfo = {
+    interpretation: {
+      type: 'InterpretedHmpbPage',
+      metadata: {
+        ...metadata,
+        pageNumber: 1,
+      },
+      markInfo: {
+        ballotSize: { width: 0, height: 0 },
+        marks: [],
+      },
+      votes: {},
+      adjudicationInfo: {
+        requiresAdjudication: true,
+        enabledReasons: [AdjudicationReason.BlankBallot],
+        enabledReasonInfos: [{ type: AdjudicationReason.BlankBallot }],
+        ignoredReasonInfos: [],
+      },
+    },
+    image: {
+      url: 'front-url',
+    },
+  };
+  const page2: BallotPageInfo = {
+    interpretation: {
+      type: 'InterpretedHmpbPage',
+      metadata: {
+        ...metadata,
+        pageNumber: 1,
+      },
+      markInfo: {
+        ballotSize: { width: 0, height: 0 },
+        marks: [],
+      },
+      votes: {},
+      adjudicationInfo: {
+        requiresAdjudication: true,
+        enabledReasons: [AdjudicationReason.BlankBallot],
+        enabledReasonInfos: [{ type: AdjudicationReason.BlankBallot }],
+        ignoredReasonInfos: [],
+      },
+    },
+    image: {
+      url: 'back-url',
+    },
+  };
+
+  tryBothOrderings(page1, page2, (front, back) => {
+    expect(
+      buildScanningResult({
+        id: 'sheet-id',
+        front,
+        back,
+      })
+    ).toStrictEqual(
+      typedAs<ScanningResult>({
+        resultType: ScanningResultType.NeedsReview,
+        adjudicationReasonInfo: [{ type: AdjudicationReason.BlankBallot }],
+      })
+    );
+  });
+});
+
+test('HMPB without issues', () => {
+  const page1: BallotPageInfo = {
+    interpretation: {
+      type: 'InterpretedHmpbPage',
+      metadata: {
+        ...metadata,
+        pageNumber: 1,
+      },
+      markInfo: {
+        ballotSize: { width: 0, height: 0 },
+        marks: [],
+      },
+      votes: {},
+      adjudicationInfo: {
+        requiresAdjudication: false,
+        enabledReasons: [],
+        enabledReasonInfos: [],
+        ignoredReasonInfos: [],
+      },
+    },
+    image: {
+      url: 'front-url',
+    },
+  };
+  const page2: BallotPageInfo = {
+    interpretation: {
+      type: 'InterpretedHmpbPage',
+      metadata: {
+        ...metadata,
+        pageNumber: 1,
+      },
+      markInfo: {
+        ballotSize: { width: 0, height: 0 },
+        marks: [],
+      },
+      votes: {},
+      adjudicationInfo: {
+        requiresAdjudication: false,
+        enabledReasons: [],
+        enabledReasonInfos: [],
+        ignoredReasonInfos: [],
+      },
+    },
+    image: {
+      url: 'back-url',
+    },
+  };
+
+  tryBothOrderings(page1, page2, (front, back) => {
+    expect(
+      buildScanningResult({
+        id: 'sheet-id',
+        front,
+        back,
+      })
+    ).toStrictEqual(
+      typedAs<ScanningResult>({
+        resultType: ScanningResultType.Accepted,
+      })
+    );
+  });
+});
+
+test('HMPB with overvoted p1 & blank p2', () => {
+  const page1: BallotPageInfo = {
+    interpretation: {
+      type: 'InterpretedHmpbPage',
+      metadata: {
+        ...metadata,
+        pageNumber: 1,
+      },
+      markInfo: {
+        ballotSize: { width: 0, height: 0 },
+        marks: [],
+      },
+      votes: {},
+      adjudicationInfo: {
+        requiresAdjudication: true,
+        enabledReasons: [
+          AdjudicationReason.Overvote,
+          AdjudicationReason.BlankBallot,
+        ],
+        enabledReasonInfos: [
+          {
+            type: AdjudicationReason.Overvote,
+            contestId: 'contest-id',
+            expected: 1,
+            optionIds: ['option-1', 'option-2'],
+            optionIndexes: [0, 1],
+          },
+        ],
+        ignoredReasonInfos: [],
+      },
+    },
+    image: {
+      url: 'front-url',
+    },
+  };
+  const page2: BallotPageInfo = {
+    interpretation: {
+      type: 'InterpretedHmpbPage',
+      metadata: {
+        ...metadata,
+        pageNumber: 1,
+      },
+      markInfo: {
+        ballotSize: { width: 0, height: 0 },
+        marks: [],
+      },
+      votes: {},
+      adjudicationInfo: {
+        requiresAdjudication: true,
+        enabledReasons: [
+          AdjudicationReason.Overvote,
+          AdjudicationReason.BlankBallot,
+        ],
+        enabledReasonInfos: [{ type: AdjudicationReason.BlankBallot }],
+        ignoredReasonInfos: [],
+      },
+    },
+    image: {
+      url: 'back-url',
+    },
+  };
+
+  tryBothOrderings(page1, page2, (front, back) => {
+    expect(
+      buildScanningResult({
+        id: 'sheet-id',
+        front,
+        back,
+      })
+    ).toStrictEqual(
+      typedAs<ScanningResult>({
+        resultType: ScanningResultType.NeedsReview,
+        adjudicationReasonInfo: [
+          {
+            type: AdjudicationReason.Overvote,
+            contestId: 'contest-id',
+            expected: 1,
+            optionIds: ['option-1', 'option-2'],
+            optionIndexes: [0, 1],
+          },
+        ],
+      })
+    );
+  });
+});
+
+test('HMPB with undervotes', () => {
+  const page1: BallotPageInfo = {
+    interpretation: {
+      type: 'InterpretedHmpbPage',
+      metadata: {
+        ...metadata,
+        pageNumber: 1,
+      },
+      markInfo: {
+        ballotSize: { width: 0, height: 0 },
+        marks: [],
+      },
+      votes: {},
+      adjudicationInfo: {
+        requiresAdjudication: true,
+        enabledReasons: [
+          AdjudicationReason.Overvote,
+          AdjudicationReason.Undervote,
+        ],
+        enabledReasonInfos: [
+          {
+            type: AdjudicationReason.Undervote,
+            contestId: 'page1-contest-id',
+            expected: 1,
+            optionIds: [],
+            optionIndexes: [],
+          },
+        ],
+        ignoredReasonInfos: [],
+      },
+    },
+    image: {
+      url: 'front-url',
+    },
+  };
+  const page2: BallotPageInfo = {
+    interpretation: {
+      type: 'InterpretedHmpbPage',
+      metadata: {
+        ...metadata,
+        pageNumber: 1,
+      },
+      markInfo: {
+        ballotSize: { width: 0, height: 0 },
+        marks: [],
+      },
+      votes: {},
+      adjudicationInfo: {
+        requiresAdjudication: true,
+        enabledReasons: [
+          AdjudicationReason.Overvote,
+          AdjudicationReason.Undervote,
+        ],
+        enabledReasonInfos: [
+          {
+            type: AdjudicationReason.Undervote,
+            contestId: 'page2-contest-id',
+            expected: 1,
+            optionIds: [],
+            optionIndexes: [],
+          },
+        ],
+        ignoredReasonInfos: [],
+      },
+    },
+    image: {
+      url: 'back-url',
+    },
+  };
+
+  tryBothOrderings(page1, page2, (front, back) => {
+    expect(
+      buildScanningResult({
+        id: 'sheet-id',
+        front,
+        back,
+      })
+    ).toStrictEqual(
+      typedAs<ScanningResult>({
+        resultType: ScanningResultType.NeedsReview,
+        adjudicationReasonInfo: expect.arrayContaining([
+          {
+            type: AdjudicationReason.Undervote,
+            contestId: 'page1-contest-id',
+            expected: 1,
+            optionIds: [],
+            optionIndexes: [],
+          },
+          {
+            type: AdjudicationReason.Undervote,
+            contestId: 'page2-contest-id',
+            expected: 1,
+            optionIds: [],
+            optionIndexes: [],
+          },
+        ]),
+      })
+    );
+  });
+});

--- a/frontends/precinct-scanner/src/utils/build_scanning_result.ts
+++ b/frontends/precinct-scanner/src/utils/build_scanning_result.ts
@@ -1,0 +1,119 @@
+import {
+  AdjudicationReason,
+  AdjudicationReasonInfo,
+  BallotSheetInfo,
+} from '@votingworks/types';
+import {
+  RejectedScanningReason,
+  ScanningResult,
+  ScanningResultType,
+} from '../config/types';
+
+function isReasonBlankBallot(reason: AdjudicationReasonInfo): boolean {
+  return reason.type === AdjudicationReason.BlankBallot;
+}
+
+/**
+ * Determines the scanning result of a ballot sheet. Primarily, this function
+ * must decide whether a ballot sheet is acceptable or not. If so, it may need
+ * review by the voter.
+ */
+export function buildScanningResult(
+  interpreted: BallotSheetInfo
+): ScanningResult {
+  if (
+    interpreted.front.interpretation.type === 'InvalidElectionHashPage' ||
+    interpreted.back.interpretation.type === 'InvalidElectionHashPage'
+  ) {
+    return {
+      resultType: ScanningResultType.Rejected,
+      rejectionReason: RejectedScanningReason.InvalidElectionHash,
+    };
+  }
+
+  if (
+    interpreted.front.interpretation.type === 'InvalidTestModePage' ||
+    interpreted.back.interpretation.type === 'InvalidTestModePage'
+  ) {
+    return {
+      resultType: ScanningResultType.Rejected,
+      rejectionReason: RejectedScanningReason.InvalidTestMode,
+    };
+  }
+
+  if (
+    interpreted.front.interpretation.type === 'InvalidPrecinctPage' ||
+    interpreted.back.interpretation.type === 'InvalidPrecinctPage'
+  ) {
+    return {
+      resultType: ScanningResultType.Rejected,
+      rejectionReason: RejectedScanningReason.InvalidPrecinct,
+    };
+  }
+
+  if (
+    interpreted.front.interpretation.type === 'UnreadablePage' ||
+    interpreted.back.interpretation.type === 'UnreadablePage'
+  ) {
+    return {
+      resultType: ScanningResultType.Rejected,
+      rejectionReason: RejectedScanningReason.Unreadable,
+    };
+  }
+
+  if (
+    (interpreted.front.interpretation.type === 'InterpretedBmdPage' &&
+      interpreted.back.interpretation.type === 'BlankPage') ||
+    (interpreted.front.interpretation.type === 'BlankPage' &&
+      interpreted.back.interpretation.type === 'InterpretedBmdPage')
+  ) {
+    return {
+      resultType: ScanningResultType.Accepted,
+    };
+  }
+
+  if (
+    interpreted.front.interpretation.type === 'InterpretedHmpbPage' &&
+    interpreted.back.interpretation.type === 'InterpretedHmpbPage'
+  ) {
+    const frontAdjudicationInfo =
+      interpreted.front.interpretation.adjudicationInfo;
+    const backAdjudicationInfo =
+      interpreted.back.interpretation.adjudicationInfo;
+
+    if (
+      !frontAdjudicationInfo.requiresAdjudication &&
+      !backAdjudicationInfo.requiresAdjudication
+    ) {
+      return { resultType: ScanningResultType.Accepted };
+    }
+
+    // the sheet is blank if BOTH sides are blank
+    if (
+      frontAdjudicationInfo.enabledReasonInfos.some(isReasonBlankBallot) &&
+      backAdjudicationInfo.enabledReasonInfos.some(isReasonBlankBallot)
+    ) {
+      return {
+        resultType: ScanningResultType.NeedsReview,
+        adjudicationReasonInfo: [{ type: AdjudicationReason.BlankBallot }],
+      };
+    }
+
+    return {
+      resultType: ScanningResultType.NeedsReview,
+      adjudicationReasonInfo: [
+        ...frontAdjudicationInfo.enabledReasonInfos.filter(
+          (r) => !isReasonBlankBallot(r)
+        ),
+        ...backAdjudicationInfo.enabledReasonInfos.filter(
+          (r) => !isReasonBlankBallot(r)
+        ),
+      ],
+    };
+  }
+
+  return {
+    resultType: ScanningResultType.Rejected,
+    rejectionReason: RejectedScanningReason.Unknown,
+  };
+}


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Closes #1638

Since each side of the sheet has adjudication reasons generated separately they can have a `BlankBallot` adjudication reason even though the ballot as a whole may not be blank. To work around this we process the whole sheet together when building the scanner result. This really should be done on the backend, but this is a sufficient temporary fix.

## Demo Video or Screenshot
| Front | Back | VxScan Screen |
|-|-|-|
|![overvote-blank-front](https://user-images.githubusercontent.com/1938/177843024-9bf6cb63-13ba-4278-8d2b-338755abf1be.jpeg)|![overvote-blank-back](https://user-images.githubusercontent.com/1938/177843049-3302601f-4492-481e-9ef3-a05410e33e81.jpeg)|![localhost_3000_(Lenovo 14_) (1)](https://user-images.githubusercontent.com/1938/177843101-5dafba2e-b180-46c9-96ee-3509308882ac.png)|

## Testing Plan 
Added tests for the new function. Tested VxScan manually with a) blank ballot b) blank/properly marked c) blank/overvoted.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
