### PR TITLE
fix: check for write-ins on back side of the ballot too

### DIFF
--- a/services/scan/src/build_cast_vote_record.ts
+++ b/services/scan/src/build_cast_vote_record.ts
@@ -256,13 +256,24 @@ function buildCastVoteRecordFromHmpbPage(
     throw new Error(`expected sheet to have contest ids with sheet ${sheetId}`);
   }
 
-  const votesEntries = buildCastVoteRecordVotesEntries(
+  const frontVotesEntries = buildCastVoteRecordVotesEntries(
     getContestsFromIds(election, front.contestIds),
     front.interpretation.type === 'InterpretedHmpbPage'
       ? front.interpretation.votes
       : {},
     front.markAdjudications
   );
+  const backVotesEntries = buildCastVoteRecordVotesEntries(
+    getContestsFromIds(election, back.contestIds),
+    back.interpretation.type === 'InterpretedHmpbPage'
+      ? back.interpretation.votes
+      : {},
+    back.markAdjudications
+  );
+  const votesEntries: Dictionary<string[]> = {
+    ...frontVotesEntries,
+    ...backVotesEntries,
+  };
   let hasWriteIns = false;
   for (const contestId of Object.keys(votesEntries)) {
     if (
@@ -287,13 +298,6 @@ function buildCastVoteRecordFromHmpbPage(
       back.interpretation.metadata.pageNumber,
     ],
     ...votesEntries,
-    ...buildCastVoteRecordVotesEntries(
-      getContestsFromIds(election, back.contestIds),
-      back.interpretation.type === 'InterpretedHmpbPage'
-        ? back.interpretation.votes
-        : {},
-      back.markAdjudications
-    ),
     _ballotImages: hasWriteIns ? [frontImages, backImages] : [],
     _layouts: [frontLayout, backLayout],
   };


### PR DESCRIPTION
## Overview
#2101 

This fixes a bug where we weren't including back vote entries when determining whether to include ballot images.

## Demo Video or Screenshot

## Testing Plan 

Manually tested with offending ballot images, confirmed that ballot images are now included in exported CVRs from scan.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
