### PR TITLE
Fix write-in bounds for contests with multiple options

### DIFF
--- a/frontends/election-manager/src/screens/write_ins_transcription_screen.tsx
+++ b/frontends/election-manager/src/screens/write_ins_transcription_screen.tsx
@@ -192,6 +192,7 @@ export function WriteInsTranscriptionScreen({
     election,
   }).map((c) => c.id);
   // Make sure the layouts are ordered by page number.
+  // eslint-disable-next-line
   const layouts = [...cvr._layouts[0]].sort(
     (a: BallotPageLayout, b: BallotPageLayout): number =>
       a.metadata.pageNumber - b.metadata.pageNumber
@@ -204,14 +205,19 @@ export function WriteInsTranscriptionScreen({
   }
 
   const contestLayout = layouts[currentLayoutOptionIdx].contests[contestIdx];
+
+  // Options are laid out from the bottom up, so we reverse write-ins to get the correct bounds
+  const writeInOptions = contestLayout.options
+    .filter((option) => option.definition.id.startsWith('write-in'))
+    .reverse();
+
   // eslint-disable-next-line
   const writeInOptionIndex = Number(
     cvr[contest.id]
       .find((vote: string) => vote.startsWith('write-in'))
       .slice('write-in-'.length)
   );
-  const writeInLayout =
-    contestLayout.options[contest.candidates.length + writeInOptionIndex];
+  const writeInLayout = writeInOptions[writeInOptionIndex];
   const writeInBounds = writeInLayout.bounds;
   const contestBounds = contestLayout.bounds;
   const fullBallotBounds: Rect = {

--- a/frontends/election-manager/src/screens/write_ins_transcription_screen.tsx
+++ b/frontends/election-manager/src/screens/write_ins_transcription_screen.tsx
@@ -59,15 +59,17 @@ function noop() {
   // nothing to do
 }
 
-const EXTRA_WRITE_IN_MARGIN_PERCENTAGE = 0;
+const DEFAULT_EXTRA_WRITE_IN_MARGIN_PERCENTAGE = 0;
 function WriteInImage({
   imageUrl,
   bounds,
   width,
+  margin,
 }: {
   imageUrl: string;
   bounds: Rect;
   width?: string;
+  margin?: number;
 }) {
   return (
     <CroppedImage
@@ -75,9 +77,13 @@ function WriteInImage({
       alt="write-in area"
       crop={{
         x: bounds.x,
-        y: bounds.y - bounds.height * EXTRA_WRITE_IN_MARGIN_PERCENTAGE,
+        y:
+          bounds.y -
+          bounds.height * (margin || DEFAULT_EXTRA_WRITE_IN_MARGIN_PERCENTAGE),
         width: bounds.width,
-        height: bounds.height * (1 + 2 * EXTRA_WRITE_IN_MARGIN_PERCENTAGE),
+        height:
+          bounds.height *
+          (1 + 2 * (margin || DEFAULT_EXTRA_WRITE_IN_MARGIN_PERCENTAGE)),
       }}
       style={{ width: width || '100%' }}
     />
@@ -249,6 +255,7 @@ export function WriteInsTranscriptionScreen({
             // eslint-disable-next-line
             imageUrl={`data:image/png;base64,${cvr._ballotImages[0].normalized}`}
             bounds={writeInBounds}
+            margin={0.2}
           />
           <div style={{ display: 'flex' }}>
             <div>
@@ -257,6 +264,7 @@ export function WriteInsTranscriptionScreen({
                 // eslint-disable-next-line
                 imageUrl={`data:image/png;base64,${cvr._ballotImages[0].normalized}`}
                 bounds={contestBounds}
+                margin={0.1}
               />
             </div>
             <div>


### PR DESCRIPTION
## Overview
Closes #2060 

Options per column are laid out from top to bottom, so the index we were using to get write in option layouts was incorrect. This filters the contest option layouts to just write-in layouts, then reverses them to get the correct one.

I also bumped up the extra margin on the two cropped images just to give us some wiggle room. 

## Demo Video or Screenshot
<img width="600" alt="Screen Shot 2022-07-07 at 5 25 45 PM" src="https://user-images.githubusercontent.com/7584833/177874026-3e3dd5f3-8352-4990-b98e-fa24f2b10d60.png">

## Testing Plan 
Tested manually with contests that have only one option, and contests that have multiple options.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
