### PR TITLE
chore(precinct-scanner): Make ballots scanned text bigger

### DIFF
--- a/frontends/precinct-scanner/src/components/scanned_ballot_count.tsx
+++ b/frontends/precinct-scanner/src/components/scanned_ballot_count.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Prose } from '@votingworks/ui';
+import { format } from '@votingworks/utils';
+import styled from 'styled-components';
+import { Absolute } from './absolute';
+
+interface Props {
+  count: number;
+}
+
+const BallotsScannedContainer = styled.div`
+  padding: 0.5rem 0.75rem;
+`;
+
+export function ScannedBallotCount({ count }: Props): JSX.Element {
+  return (
+    <Absolute top left>
+      <BallotsScannedContainer>
+        <Prose theme={{ fontSize: '1.25rem' }}>
+          <p>Ballots Scanned</p>
+        </Prose>
+        <Prose theme={{ fontSize: '3.5rem' }}>
+          <p>
+            <strong data-testid="ballot-count">{format.count(count)}</strong>
+          </p>
+        </Prose>
+      </BallotsScannedContainer>
+    </Absolute>
+  );
+}

--- a/frontends/precinct-scanner/src/screens/admin_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/admin_screen.tsx
@@ -19,6 +19,7 @@ import {
 } from '@votingworks/ui';
 import { assert, format, usbstick } from '@votingworks/utils';
 import React, { useCallback, useContext, useState } from 'react';
+import styled from 'styled-components';
 import { Absolute } from '../components/absolute';
 import { CalibrateScannerModal } from '../components/calibrate_scanner_modal';
 import { ExportBackupModal } from '../components/export_backup_modal';
@@ -36,6 +37,10 @@ interface Props {
   calibrate(): Promise<boolean>;
   usbDrive: UsbDrive;
 }
+
+const BallotsScannedText = styled.div`
+  font-size: larger;
+`;
 
 export function AdminScreen({
   scannedBallotCount,
@@ -202,12 +207,12 @@ export function AdminScreen({
       </Prose>
       <Absolute top left>
         <Bar>
-          <div>
+          <BallotsScannedText>
             Ballots Scanned:{' '}
             <strong data-testid="ballot-count">
               {format.count(scannedBallotCount)}
             </strong>{' '}
-          </div>
+          </BallotsScannedText>
         </Bar>
       </Absolute>
       {isShowingToggleLiveModeWarningModal && (

--- a/frontends/precinct-scanner/src/screens/admin_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/admin_screen.tsx
@@ -14,16 +14,14 @@ import {
   Select,
   SetClockButton,
   UsbDrive,
-  Bar,
   isAdminAuth,
 } from '@votingworks/ui';
-import { assert, format, usbstick } from '@votingworks/utils';
+import { assert, usbstick } from '@votingworks/utils';
 import React, { useCallback, useContext, useState } from 'react';
-import styled from 'styled-components';
-import { Absolute } from '../components/absolute';
 import { CalibrateScannerModal } from '../components/calibrate_scanner_modal';
 import { ExportBackupModal } from '../components/export_backup_modal';
 import { ExportResultsModal } from '../components/export_results_modal';
+import { ScannedBallotCount } from '../components/scanned_ballot_count';
 import { ScreenMainCenterChild } from '../components/layout';
 import { AppContext } from '../contexts/app_context';
 
@@ -37,10 +35,6 @@ interface Props {
   calibrate(): Promise<boolean>;
   usbDrive: UsbDrive;
 }
-
-const BallotsScannedText = styled.div`
-  font-size: larger;
-`;
 
 export function AdminScreen({
   scannedBallotCount,
@@ -205,16 +199,7 @@ export function AdminScreen({
           </p>
         )}
       </Prose>
-      <Absolute top left>
-        <Bar>
-          <BallotsScannedText>
-            Ballots Scanned:{' '}
-            <strong data-testid="ballot-count">
-              {format.count(scannedBallotCount)}
-            </strong>{' '}
-          </BallotsScannedText>
-        </Bar>
-      </Absolute>
+      <ScannedBallotCount count={scannedBallotCount} />
       {isShowingToggleLiveModeWarningModal && (
         <Modal
           content={

--- a/frontends/precinct-scanner/src/screens/insert_ballot_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/insert_ballot_screen.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import { format } from '@votingworks/utils';
-import { Text, Bar } from '@votingworks/ui';
-import { Absolute } from '../components/absolute';
+import { Text } from '@votingworks/ui';
 import { InsertBallot } from '../components/graphics';
 import {
   CenteredLargeProse,
   ScreenMainCenterChild,
 } from '../components/layout';
+import { ScannedBallotCount } from '../components/scanned_ballot_count';
 
 interface Props {
   isLiveMode: boolean;
@@ -32,16 +31,7 @@ export function InsertBallotScreen({
         <h1>Insert Your Ballot Below</h1>
         <p>Scan one ballot sheet at a time.</p>
       </CenteredLargeProse>
-      <Absolute top left>
-        <Bar>
-          <div>
-            Ballots Scanned:{' '}
-            <strong data-testid="ballot-count">
-              {format.count(scannedBallotCount)}
-            </strong>
-          </div>
-        </Bar>
-      </Absolute>
+      <ScannedBallotCount count={scannedBallotCount} />
     </ScreenMainCenterChild>
   );
 }

--- a/frontends/precinct-scanner/src/screens/poll_worker_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/poll_worker_screen.tsx
@@ -11,7 +11,6 @@ import {
   PrintableContainer,
   TallyReport,
   UsbDrive,
-  Bar,
   isPollworkerAuth,
 } from '@votingworks/ui';
 import {
@@ -20,7 +19,6 @@ import {
   compressTally,
   computeTallyWithPrecomputedCategories,
   filterTalliesByParams,
-  format,
   getTallyIdentifier,
   PrecinctScannerCardTally,
   Printer,
@@ -43,13 +41,13 @@ import {
   CenteredLargeProse,
   ScreenMainCenterChild,
 } from '../components/layout';
-import { Absolute } from '../components/absolute';
 
 import { ExportResultsModal } from '../components/export_results_modal';
 import { LiveCheckModal } from '../components/live_check_modal';
 
 import { AppContext } from '../contexts/app_context';
 import { IndeterminateProgressBar } from '../components/graphics';
+import { ScannedBallotCount } from '../components/scanned_ballot_count';
 import { saveCvrExportToUsb } from '../utils/save_cvr_export_to_usb';
 
 enum PollWorkerFlowState {
@@ -507,16 +505,7 @@ export function PollWorkerScreen({
             </p>
           )}
         </Prose>
-        <Absolute top left>
-          <Bar>
-            <div>
-              Ballots Scanned:{' '}
-              <strong data-testid="ballot-count">
-                {format.count(scannedBallotCount)}
-              </strong>{' '}
-            </div>
-          </Bar>
-        </Absolute>
+        <ScannedBallotCount count={scannedBallotCount} />
         {isExportingResults && (
           <ExportResultsModal
             onClose={() => setIsExportingResults(false)}

--- a/frontends/precinct-scanner/src/screens/scan_success_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/scan_success_screen.tsx
@@ -7,7 +7,7 @@ import {
   ScreenMainCenterChild,
 } from '../components/layout';
 
-export interface Props {
+interface Props {
   scannedBallotCount: number;
 }
 

--- a/frontends/precinct-scanner/src/screens/scan_success_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/scan_success_screen.tsx
@@ -1,15 +1,13 @@
 import React from 'react';
-import { Prose, Bar } from '@votingworks/ui';
-import { format } from '@votingworks/utils';
-import { Absolute } from '../components/absolute';
 import { CircleCheck } from '../components/graphics';
+import { ScannedBallotCount } from '../components/scanned_ballot_count';
 
 import {
   CenteredLargeProse,
   ScreenMainCenterChild,
 } from '../components/layout';
 
-interface Props {
+export interface Props {
   scannedBallotCount: number;
 }
 
@@ -21,18 +19,7 @@ export function ScanSuccessScreen({ scannedBallotCount }: Props): JSX.Element {
         <h1>Your ballot was counted!</h1>
         <p>Thank you for voting.</p>
       </CenteredLargeProse>
-      <Absolute top left>
-        <Bar>
-          <Prose>
-            <p>
-              Ballots Scanned:{' '}
-              <strong data-testid="ballot-count">
-                {format.count(scannedBallotCount)}
-              </strong>
-            </p>
-          </Prose>
-        </Bar>
-      </Absolute>
+      <ScannedBallotCount count={scannedBallotCount} />
     </ScreenMainCenterChild>
   );
 }


### PR DESCRIPTION
## Overview
Closes #1492 

This makes the "Ballots Scanned" text bigger on VxScan and adds a shared `ScannedBallotCount` component that is used across the various screens where we show this interface.

## Demo Video or Screenshot
**Before**
![localhost_3000_(Vx laptop) (1)](https://user-images.githubusercontent.com/7584833/178309877-a93fc82d-4ff9-44b7-b8eb-df029cb463b0.png)

**After**
<div>
<img width="400" src="https://user-images.githubusercontent.com/7584833/178537680-3da6b4e9-b6a3-41b9-8a65-88d9bc15129c.png" />
<img width="400" src="https://user-images.githubusercontent.com/7584833/178537711-3fb7b85c-fc51-40cf-a9d5-e9845ace5677.png" />
<img width="400" src="https://user-images.githubusercontent.com/7584833/178537719-62bb5eec-05dd-4143-900f-7090abd1e5c6.png" />
<img width="400" src="https://user-images.githubusercontent.com/7584833/178537725-7a7fab09-719f-4d6d-bf53-23f600cc4c1b.png" />
</div>

## Testing Plan

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
