### PR TITLE
feat(precinct-scanner): detect when power is connected but scanner is not detected

### DIFF
--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -67,6 +67,7 @@ import { AppContext } from './contexts/app_context';
 import { SetupPowerPage } from './screens/setup_power_page';
 import { CardErrorScreen } from './screens/card_error_screen';
 import { SetupScannerScreen } from './screens/setup_scanner_screen';
+import { SetupScannerInternalWiringScreen } from './screens/setup_scanner_internal_wiring_screen';
 import { ScreenMainCenterChild, CenteredLargeProse } from './components/layout';
 import { InsertUsbScreen } from './screens/insert_usb_screen';
 
@@ -723,6 +724,12 @@ export function AppRoot({
     );
   }
 
+  // If the power cord is plugged in, but we can't detect a scanner, it's an internal wiring issue
+  if (computer.batteryIsCharging && !precinctScanner) {
+    return <SetupScannerInternalWiringScreen />;
+  }
+
+  // Otherwise if we can't detect the scanner, the power cord is likely not plugged in
   if (!precinctScanner) {
     return <SetupScannerScreen />;
   }

--- a/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
+++ b/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
@@ -208,7 +208,7 @@ test('shows internal wiring message when there is no plustek scanner, but tablet
   render(<App card={card} storage={storage} hardware={hardware} />);
   await screen.findByRole('heading', { name: 'Scanner Not Detected' });
   screen.getByText(
-    'There is an internal connection problem, please report to election clerk.'
+    'There is an internal connection problem. Please report to election clerk.'
   );
 });
 

--- a/frontends/precinct-scanner/src/preview_app.tsx
+++ b/frontends/precinct-scanner/src/preview_app.tsx
@@ -21,6 +21,7 @@ import * as ScanProcessingScreen from './screens/scan_processing_screen';
 import * as ScanSuccessScreen from './screens/scan_success_screen';
 import * as ScanWarningScreen from './screens/scan_warning_screen';
 import * as SetupPowerPage from './screens/setup_power_page';
+import * as SetupScannerInternalWiringScreen from './screens/setup_scanner_internal_wiring_screen';
 import * as SetupScannerScreen from './screens/setup_scanner_screen';
 import * as UnconfiguredElectionScreen from './screens/unconfigured_election_screen';
 
@@ -45,6 +46,7 @@ export function PreviewApp(): JSX.Element {
         ScanSuccessScreen,
         ScanWarningScreen,
         SetupPowerPage,
+        SetupScannerInternalWiringScreen,
         SetupScannerScreen,
         UnconfiguredElectionScreen,
       ]}

--- a/frontends/precinct-scanner/src/screens/setup_scanner_internal_wiring_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/setup_scanner_internal_wiring_screen.tsx
@@ -4,14 +4,14 @@ import {
   CenteredLargeProse,
 } from '../components/layout';
 
-export function SetupScannerScreen(): JSX.Element {
+export function SetupScannerInternalWiringScreen(): JSX.Element {
   return (
     <ScreenMainCenterChild infoBar={false}>
       <CenteredLargeProse>
         <h1>Scanner Not Detected</h1>
         <p>
-          Please ask a poll worker to check that the power cable is connected to
-          an outlet.
+          There is an internal connection problem, please report to election
+          clerk.
         </p>
       </CenteredLargeProse>
     </ScreenMainCenterChild>
@@ -20,5 +20,5 @@ export function SetupScannerScreen(): JSX.Element {
 
 /* istanbul ignore next */
 export function DefaultPreview(): JSX.Element {
-  return <SetupScannerScreen />;
+  return <SetupScannerInternalWiringScreen />;
 }

--- a/frontends/precinct-scanner/src/screens/setup_scanner_internal_wiring_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/setup_scanner_internal_wiring_screen.tsx
@@ -10,7 +10,7 @@ export function SetupScannerInternalWiringScreen(): JSX.Element {
       <CenteredLargeProse>
         <h1>Scanner Not Detected</h1>
         <p>
-          There is an internal connection problem, please report to election
+          There is an internal connection problem. Please report to election
           clerk.
         </p>
       </CenteredLargeProse>


### PR DESCRIPTION
## Overview
Closes #1549 

## Demo Video or Screenshot
N/A

## Testing Plan 
Added a test, but unsure how to get my dev environment into the correct state to simulate power cord plugged in, but scanner not connected.

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
