### PR TITLE
fix(scan): detect BMD ballots scanned as 14/17"

### DIFF
--- a/libs/ballot-interpreter-vx/src/utils/qrcode.test.ts
+++ b/libs/ballot-interpreter-vx/src/utils/qrcode.test.ts
@@ -1,7 +1,7 @@
 import { join } from 'path';
 import { hardQrCodePage1 } from '../../test/fixtures/choctaw-2020-09-22-f30480cc99';
 import { loadImageData } from './images';
-import { detect as detectQrCode } from './qrcode';
+import { detect as detectQrCode, getSearchAreas } from './qrcode';
 
 test('falls back to jsQR if the other QR code readers cannot read them', async () => {
   const imageData = await loadImageData(
@@ -110,4 +110,22 @@ test('decodes QR codes with qrdetect (zbar) by default', async () => {
       "position": "top",
     }
   `);
+});
+
+test('getSearchArea for letter-size image', () => {
+  expect([...getSearchAreas({ width: 85, height: 110 })]).toHaveLength(
+    4 // 2 top, 2 bottom
+  );
+});
+
+test('getSearchArea for legal-size image', () => {
+  expect([...getSearchAreas({ width: 85, height: 140 })]).toHaveLength(
+    8 // 4 top, 4 bottom
+  );
+});
+
+test('getSearchArea for 8.5x17" image', () => {
+  expect([...getSearchAreas({ width: 85, height: 170 })]).toHaveLength(
+    8 // 4 top, 4 bottom
+  );
 });

--- a/libs/ballot-interpreter-vx/src/utils/qrcode.ts
+++ b/libs/ballot-interpreter-vx/src/utils/qrcode.ts
@@ -7,6 +7,9 @@ import { QRCode } from 'node-quirc';
 import { DetectQrCodeResult } from '../types';
 import { crop } from './crop';
 
+const LETTER_WIDTH_TO_HEIGHT_RATIO = 8.5 / 11;
+const LEGAL_WIDTH_TO_HEIGHT_RATIO = 8.5 / 14;
+
 const debug = makeDebug('ballot-interpreter-vx:qrcode');
 
 // Loads these libraries dynamically because they are not available in
@@ -56,15 +59,31 @@ function maybeDecodeBase64(data: Buffer): Buffer {
 export function* getSearchAreas(
   size: Size
 ): Generator<{ position: 'top' | 'bottom'; bounds: Rect }> {
-  // QR code for HMPB is bottom right of legal, so appears bottom right or top left
+  const widthToHeightRatio = size.width / size.height;
+  const isLetter =
+    Math.abs(widthToHeightRatio - LETTER_WIDTH_TO_HEIGHT_RATIO) <
+    Math.abs(widthToHeightRatio - LEGAL_WIDTH_TO_HEIGHT_RATIO);
+
+  // QR code for HMPB is bottom right, so appears bottom right or top left
   const hmpbWidth = Math.round(size.width / 4);
   const hmpbHeight = Math.round(size.height / 8);
-  // We look at the top first because we're assuming people will mostly scan sheets
-  // so they appear right-side up to them, but bottom-side first to the scanner.
+  // We look at the top first because we're assuming people will mostly scan
+  // sheets so they appear right-side up to them, but bottom-side first to the
+  // scanner.
+
+  // ┌─┬─┐
+  // ├─┘ │
+  // │   │
+  // └───┘
   yield {
     position: 'top',
     bounds: { x: 0, y: 0, width: hmpbWidth, height: hmpbHeight },
   };
+
+  // ┌───┐
+  // │   │
+  // │ ┌─┤
+  // └─┴─┘
   yield {
     position: 'bottom',
     bounds: {
@@ -75,11 +94,93 @@ export function* getSearchAreas(
     },
   };
 
-  // QR code for BMD is top right of letter, so appears top right or bottom left
+  // If we're not letter size then the size of the scanned image may be too
+  // large compared to the actual paper size. Instead of looking at the top
+  // right and bottom left we look at the top right and bottom left, but with a
+  // smaller area.
+  if (!isLetter) {
+    const expectedLetterHeight = Math.round(
+      size.width / LETTER_WIDTH_TO_HEIGHT_RATIO
+    );
+    // QR code for BMD is top right, so appears top right or bottom left
+    const bmdWidth = Math.round((size.width * 2) / 5);
+    const bmdHeight = Math.round((expectedLetterHeight * 2) / 5);
+    // We look at the bottom first because we're assuming people will mostly
+    // scan sheets so they appear right-side up to them, but bottom-side first
+    // to the scanner.
+
+    // ┌───┐
+    // │   │
+    // ├─┐ │
+    // │ │ │
+    // └─┴─┘
+    yield {
+      position: 'bottom',
+      bounds: {
+        x: 0,
+        y: size.height - bmdHeight,
+        width: bmdWidth,
+        height: bmdHeight,
+      },
+    };
+
+    // ┌───┐
+    // ├─┐ │
+    // │ │ │
+    // ├─┘ │
+    // └───┘
+    yield {
+      position: 'bottom',
+      bounds: {
+        x: 0,
+        y: expectedLetterHeight - bmdHeight,
+        width: bmdWidth,
+        height: bmdHeight,
+      },
+    };
+
+    // ┌─┬─┐
+    // │ │ │
+    // │ └─┤
+    // │   │
+    // └───┘
+    yield {
+      position: 'top',
+      bounds: {
+        x: size.width - bmdWidth,
+        y: 0,
+        width: bmdWidth,
+        height: bmdHeight,
+      },
+    };
+
+    // ┌───┐
+    // │ ┌─┤
+    // │ │ │
+    // │ └─┤
+    // └───┘
+    yield {
+      position: 'top',
+      bounds: {
+        x: size.width - bmdWidth,
+        y: size.height - expectedLetterHeight,
+        width: bmdWidth,
+        height: bmdHeight,
+      },
+    };
+  }
+
+  // QR code for BMD is top right, so appears top right or bottom left
   const bmdWidth = Math.round((size.width * 2) / 5);
   const bmdHeight = Math.round((size.height * 2) / 5);
-  // We look at the top first because we're assuming people will mostly scan sheets
-  // so they appear right-side up to them, but bottom-side first to the scanner.
+  // We look at the bottom first because we're assuming people will mostly scan
+  // sheets so they appear right-side up to them, but bottom-side first to the
+  // scanner.
+
+  // ┌───┐
+  // │   │
+  // ├─┐ │
+  // └─┴─┘
   yield {
     position: 'bottom',
     bounds: {
@@ -89,6 +190,11 @@ export function* getSearchAreas(
       height: bmdHeight,
     },
   };
+
+  // ┌─┬─┐
+  // │ └─┤
+  // │   │
+  // └───┘
   yield {
     position: 'top',
     bounds: {
@@ -116,8 +222,8 @@ export async function detect(
     },
     {
       name: 'quirc',
-      detect: async ({ data, width, height }: ImageData): Promise<Buffer[]> => {
-        const results = await quircDecode({ data, width, height });
+      detect: async (croppedImage: ImageData): Promise<Buffer[]> => {
+        const results = await quircDecode(croppedImage);
         return results
           .filter((result): result is QRCode => !('err' in result))
           .map((result) => result.data);

--- a/services/scan/bin/read-qrcode
+++ b/services/scan/bin/read-qrcode
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+
+require('esbuild-runner/register');
+
+require('../src/cli/read-qrcode')
+  .main(process.argv, {
+    stdin: process.stdin,
+    stdout: process.stdout,
+    stderr: process.stderr,
+  })
+  .then((code) => {
+    process.exitCode = code;
+  });

--- a/services/scan/src/cli/read-qrcode/index.test.ts
+++ b/services/scan/src/cli/read-qrcode/index.test.ts
@@ -1,0 +1,95 @@
+import { fakeReadable, fakeWritable } from '@votingworks/test-utils';
+import { join, relative } from 'path';
+import { IO, main } from '.';
+
+test('help', async () => {
+  const stdin = fakeReadable();
+  const stdout = fakeWritable();
+  const stderr = fakeWritable();
+  const io: IO = { stdin, stdout, stderr };
+
+  expect(await main(['node', 'read-qrcode', '-h'], io)).toBe(0);
+
+  expect(stdout.toString()).toMatchInlineSnapshot(`
+    "read-qrcode [IMAGE_PATH …]
+    "
+  `);
+});
+
+test('no args', async () => {
+  const stdin = fakeReadable();
+  const stdout = fakeWritable();
+  const stderr = fakeWritable();
+  const io: IO = { stdin, stdout, stderr };
+
+  expect(await main(['node', 'read-qrcode'], io)).toBe(0);
+
+  expect(stdout.toString()).toMatchInlineSnapshot(`""`);
+});
+
+test('invalid option', async () => {
+  const stdin = fakeReadable();
+  const stdout = fakeWritable();
+  const stderr = fakeWritable();
+  const io: IO = { stdin, stdout, stderr };
+
+  expect(await main(['node', 'read-qrcode', '--invalid-option'], io)).toBe(1);
+
+  expect(stdout.toString()).toMatchInlineSnapshot(`""`);
+  expect(stderr.toString()).toMatchInlineSnapshot(`
+    "error: unrecognized option: --invalid-option
+    read-qrcode [IMAGE_PATH …]
+    "
+  `);
+});
+
+test('image with no QR code', async () => {
+  const stdin = fakeReadable();
+  const stdout = fakeWritable();
+  const stderr = fakeWritable();
+  const io: IO = { stdin, stdout, stderr };
+
+  await main(
+    [
+      'node',
+      'read-qrcode',
+      relative(
+        join(__dirname, '../../..'),
+        join(__dirname, '../../../sample-ballot-images/not-a-ballot.jpg')
+      ),
+    ],
+    io
+  );
+
+  expect(stdout.toString()).toMatchInlineSnapshot(`
+    "sample-ballot-images/not-a-ballot.jpg: no QR code detected
+    "
+  `);
+});
+
+test('image with a QR code', async () => {
+  const stdin = fakeReadable();
+  const stdout = fakeWritable();
+  const stderr = fakeWritable();
+  const io: IO = { stdin, stdout, stderr };
+
+  await main(
+    [
+      'node',
+      'read-qrcode',
+      relative(
+        join(__dirname, '../../..'),
+        join(
+          __dirname,
+          '../../../sample-ballot-images/sample-batch-1-ballot-1.png'
+        )
+      ),
+    ],
+    io
+  );
+
+  expect(stdout.toString()).toMatchInlineSnapshot(`
+    "sample-ballot-images/sample-batch-1-ballot-1.png @top via qrdetect: VlgCtS6fRyi7NOf/SAMDFgggAAEA
+    "
+  `);
+});

--- a/services/scan/src/cli/read-qrcode/index.ts
+++ b/services/scan/src/cli/read-qrcode/index.ts
@@ -1,0 +1,65 @@
+import { detectQrCode } from '@votingworks/ballot-interpreter-vx';
+import chalk from 'chalk';
+import { basename } from 'path';
+import { loadImageData } from '../../util/images';
+
+export interface IO {
+  readonly stdin: NodeJS.ReadableStream;
+  readonly stdout: NodeJS.WritableStream;
+  readonly stderr: NodeJS.WritableStream;
+}
+
+function usage(name: string, out: NodeJS.WritableStream): void {
+  out.write(`${name} [IMAGE_PATH …]\n`);
+}
+
+/**
+ * Entry point for `read-qrcode` command. Reads QR code from ballot images and
+ * prints information about the QR code and its position.
+ */
+export async function main(argv: readonly string[], io: IO): Promise<number> {
+  const name = basename(argv[1]);
+  const imagePaths: string[] = [];
+
+  for (const arg of argv.slice(2)) {
+    switch (arg) {
+      case '-h':
+      case '--help': {
+        usage(name, io.stdout);
+        return 0;
+      }
+
+      default: {
+        if (arg.startsWith('-')) {
+          io.stderr.write(`error: unrecognized option: ${arg}\n`);
+          usage(name, io.stderr);
+          return 1;
+        }
+
+        imagePaths.push(arg);
+      }
+    }
+  }
+
+  for (const imagePath of imagePaths) {
+    const imageData = await loadImageData(imagePath);
+    const detectResult = await detectQrCode(imageData);
+
+    if (!detectResult) {
+      io.stdout.write(
+        `${chalk.bold(imagePath)}: ${chalk.red('no QR code detected')}\n`
+      );
+      continue;
+    }
+
+    io.stdout.write(
+      `${chalk.bold(imagePath)} ${chalk.cyan(
+        `@${detectResult.position}`
+      )} via ${chalk.yellow(detectResult.detector)}: ${chalk.italic(
+        detectResult.data.toString('base64')
+      )}\n`
+    );
+  }
+
+  return await Promise.resolve(0);
+}


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
We currently always print BMD ballots on letter-size paper. We scan centrally using a fixed size according to the election definition. Thus, when scanning a BMD ballot in an election configured with non-letter paper we will have images that have extra junk above or below the actual ballot. To account for this, we now check where the QR code could be when printed on letter but scanned as non-letter, but only when scanning non-letter size paper.

Fixes https://github.com/votingworks/vxsuite/issues/911

## Demo Video or Screenshot
```sh
# Before
❯ ./bin/read-qrcode sample-ballot-images/sample-batch-1-ballot-1-*
sample-ballot-images/sample-batch-1-ballot-1-17in-rightside-up-bottom-aligned.png: no QR code detected
sample-ballot-images/sample-batch-1-ballot-1-17in-rightside-up-top-aligned.png @top via qrdetect: VlgCtS6fRyi7NOf/SAMDFgggAAEA
sample-ballot-images/sample-batch-1-ballot-1-17in-upside-down-bottom-aligned.png @bottom via qrdetect: VlgCtS6fRyi7NOf/SAMDFgggAAEA
sample-ballot-images/sample-batch-1-ballot-1-17in-upside-down-top-aligned.png: no QR code detected
sample-ballot-images/sample-batch-1-ballot-1-legal-rightside-up-bottom-aligned.png @top via qrdetect: VlgCtS6fRyi7NOf/SAMDFgggAAEA
sample-ballot-images/sample-batch-1-ballot-1-legal-rightside-up-top-aligned.png @top via qrdetect: VlgCtS6fRyi7NOf/SAMDFgggAAEA
sample-ballot-images/sample-batch-1-ballot-1-legal-upside-down-bottom-aligned.png @bottom via qrdetect: VlgCtS6fRyi7NOf/SAMDFgggAAEA
sample-ballot-images/sample-batch-1-ballot-1-legal-upside-down-top-aligned.png @bottom via qrdetect: VlgCtS6fRyi7NOf/SAMDFgggAAEA
sample-ballot-images/sample-batch-1-ballot-1-letter-rightside-up.png @top via qrdetect: VlgCtS6fRyi7NOf/SAMDFgggAAEA
sample-ballot-images/sample-batch-1-ballot-1-letter-upside-down.png @bottom via qrdetect: VlgCtS6fRyi7NOf/SAMDFgggAAEA

# After
❯ ./bin/read-qrcode sample-ballot-images/sample-batch-1-ballot-1-*
sample-ballot-images/sample-batch-1-ballot-1-17in-rightside-up-bottom-aligned.png @top via qrdetect: VlgCtS6fRyi7NOf/SAMDFgggAAEA
sample-ballot-images/sample-batch-1-ballot-1-17in-rightside-up-top-aligned.png @top via qrdetect: VlgCtS6fRyi7NOf/SAMDFgggAAEA
sample-ballot-images/sample-batch-1-ballot-1-17in-upside-down-bottom-aligned.png @bottom via qrdetect: VlgCtS6fRyi7NOf/SAMDFgggAAEA
sample-ballot-images/sample-batch-1-ballot-1-17in-upside-down-top-aligned.png @bottom via qrdetect: VlgCtS6fRyi7NOf/SAMDFgggAAEA
sample-ballot-images/sample-batch-1-ballot-1-legal-rightside-up-bottom-aligned.png @top via qrdetect: VlgCtS6fRyi7NOf/SAMDFgggAAEA
sample-ballot-images/sample-batch-1-ballot-1-legal-rightside-up-top-aligned.png @top via qrdetect: VlgCtS6fRyi7NOf/SAMDFgggAAEA
sample-ballot-images/sample-batch-1-ballot-1-legal-upside-down-bottom-aligned.png @bottom via qrdetect: VlgCtS6fRyi7NOf/SAMDFgggAAEA
sample-ballot-images/sample-batch-1-ballot-1-legal-upside-down-top-aligned.png @bottom via qrdetect: VlgCtS6fRyi7NOf/SAMDFgggAAEA
sample-ballot-images/sample-batch-1-ballot-1-letter-rightside-up.png @top via qrdetect: VlgCtS6fRyi7NOf/SAMDFgggAAEA
sample-ballot-images/sample-batch-1-ballot-1-letter-upside-down.png @bottom via qrdetect: VlgCtS6fRyi7NOf/SAMDFgggAAEA
```

The two images that previously failed:
| rightside-up-bottom-aligned.png | upside-down-top-aligned.png |
|-|-|
|![sample-batch-1-ballot-1-17in-rightside-up-bottom-aligned](https://user-images.githubusercontent.com/1938/178373294-5f63e322-ace8-46e4-934a-faa0c821321a.png)|![sample-batch-1-ballot-1-17in-upside-down-top-aligned](https://user-images.githubusercontent.com/1938/178373319-6bc78d08-8db9-4481-adf5-cbb239384be4.png)|

## Testing Plan 
Tested with the new `read-qrcode` CLI. Added some automated tests. Tested manually with [this election definition](https://github.com/votingworks/vxsuite/blob/911-vxcentralscan-when-expecting-legal17-ballots-bmd-ballots-will-not-scan-if-qr-code-is-oriented-up/libs/fixtures/data/electionMinimalExhaustiveSample/electionMinimalExhaustiveSample.json) but with the paper size changed to `legal`.