### PR TITLE
feat(precinct-scanner): Initialize with stored isPollsOpen state

### DIFF
--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -109,6 +109,7 @@ interface SharedState {
   isStatusPollingEnabled: boolean;
   currentPrecinctId?: PrecinctId;
   isPollsOpen: boolean;
+  initializedFromStorage: boolean;
 }
 
 export interface State
@@ -135,6 +136,7 @@ const initialSharedState: Readonly<SharedState> = {
   isStatusPollingEnabled: true,
   currentPrecinctId: undefined,
   isPollsOpen: false,
+  initializedFromStorage: false,
 };
 
 const initialScanInformationState: Readonly<ScanInformationState> = {
@@ -207,6 +209,7 @@ function appReducer(state: State, action: AppAction): State {
       return {
         ...state,
         isPollsOpen: action.isPollsOpen,
+        initializedFromStorage: true,
       };
     case 'updateElectionDefinition':
       return {
@@ -328,6 +331,7 @@ export function AppRoot({
     isTestMode,
     currentPrecinctId,
     isPollsOpen,
+    initializedFromStorage,
     machineConfig,
   } = appState;
 
@@ -679,14 +683,17 @@ export function AppRoot({
 
   useEffect(() => {
     async function storeAppState() {
-      await storage.set(stateStorageKey, {
-        isPollsOpen,
-      });
+      // only store app state if we've first initialized from the stored state
+      if (initializedFromStorage) {
+        await storage.set(stateStorageKey, {
+          isPollsOpen,
+        });
+      }
     }
 
     void storeAppState();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isPollsOpen]);
+  }, [isPollsOpen, initializedFromStorage]);
 
   function dismissError() {
     /* istanbul ignore next */


### PR DESCRIPTION
## Overview
Closes #1948

This uses stored state to initialize VxScan (which as of now only includes `isPollsOpen`.) The ticket described that this work needed to be done for both VxScan and VxMark, but if I am understanding the code correctly, VxMark already is correctly initialized with stored state.

## Demo Video or Screenshot

## Testing Plan 

Tested manually in VxMark and VxScan, and confirmed that `isPollsOpen` state matches what is stored in `~/.config/kiosk-browser/data/state.json`. I also added a test in VxScan, but interestingly I cannot get it to fail with my change commented out. Manual testing in kiosk-browser reliably reproduces the incorrect behavior, however.

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
