### PR TITLE
Add new methods to Card interface to support smartcard programming

### DIFF
--- a/libs/utils/src/Card/memory_card.test.ts
+++ b/libs/utils/src/Card/memory_card.test.ts
@@ -9,7 +9,7 @@ it('defaults to no card', async () => {
   });
 });
 
-it('can round-trip a short value', async () => {
+it('can write and read a short value', async () => {
   const card = new MemoryCard().insertCard();
 
   await card.writeShortValue('abc');
@@ -20,7 +20,7 @@ it('can round-trip a short value', async () => {
   );
 });
 
-it('can round-trip an object long value', async () => {
+it('can write and read an object long value', async () => {
   const card = new MemoryCard().insertCard();
 
   await card.writeLongObject({ a: 1, b: 2 });
@@ -34,11 +34,23 @@ it('can read a string long value', async () => {
   expect(await card.readLongString()).toEqual(JSON.stringify({ a: 1 }));
 });
 
-it('can round-trip a binary long value', async () => {
+it('can write and read a binary long value', async () => {
   const card = new MemoryCard().insertCard();
 
   await card.writeLongUint8Array(Uint8Array.of(1, 2, 3));
   expect(await card.readLongUint8Array()).toEqual(Uint8Array.of(1, 2, 3));
+});
+
+it('can write and read short and long values', async () => {
+  const card = new MemoryCard().insertCard();
+
+  await card.writeShortAndLongValues({ shortValue: 'abc', longValue: 'def' });
+  expect(await card.readSummary()).toEqual({
+    status: 'ready',
+    shortValue: 'abc',
+    longValueExists: true,
+  });
+  expect(await card.readLongString()).toEqual('def');
 });
 
 it('can set a short and long value using #insertCard', async () => {

--- a/libs/utils/src/Card/memory_card.ts
+++ b/libs/utils/src/Card/memory_card.ts
@@ -1,6 +1,6 @@
 import { ok, Optional, Result, safeParseJson } from '@votingworks/types';
 import { z } from 'zod';
-import { Card, CardSummary } from '../types';
+import { Card, CardSummary, ShortAndLongValues } from '../types';
 
 /* eslint-disable @typescript-eslint/require-await */
 
@@ -101,6 +101,25 @@ export class MemoryCard implements Card {
     }
 
     this.longValue = Uint8Array.from(value);
+  }
+
+  /**
+   * Writes new short and long values to the card.
+   */
+  async writeShortAndLongValues({
+    shortValue,
+    longValue,
+  }: ShortAndLongValues): Promise<void> {
+    await this.writeShortValue(shortValue);
+    await this.writeLongUint8Array(new TextEncoder().encode(longValue));
+  }
+
+  /* istanbul ignore next: A no-op but necessary to satisfy the Card interface */
+  /**
+   * Overrides card write protection.
+   */
+  async overrideWriteProtection(): Promise<void> {
+    return Promise.resolve();
   }
 
   /**

--- a/libs/utils/src/Card/web_service_card.test.ts
+++ b/libs/utils/src/Card/web_service_card.test.ts
@@ -57,7 +57,11 @@ it('reads binary data from /card/read_long_b64', async () => {
 
 it('writes short value using /card/write', async () => {
   fetchMock.post('/card/write', (url: string, mockRequest: MockRequest) => {
-    expect(url).toBe('/card/write');
+    expect(url).toEqual('/card/write');
+    expect(mockRequest.headers).toEqual({
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    });
     expect(mockRequest.body).toEqual('abc');
     return { success: true };
   });
@@ -65,18 +69,28 @@ it('writes short value using /card/write', async () => {
   await new WebServiceCard().writeShortValue('abc');
 });
 
+it('handles failures to write short value using /card/write', async () => {
+  fetchMock.post('/card/write', { success: false });
+
+  await expect(new WebServiceCard().writeShortValue('abc')).rejects.toThrow(
+    'Failed to write short value'
+  );
+});
+
 it('writes objects using /card/write_long_b64', async () => {
   fetchMock.post(
     '/card/write_long_b64',
     (url: string, mockRequest: MockRequest) => {
-      expect(url).toBe('/card/write_long_b64');
-      const longValue = (mockRequest.body as FormData).get(
-        'long_value'
-      ) as string;
+      expect(url).toEqual('/card/write_long_b64');
+      expect(mockRequest.headers).toEqual({
+        Accept: 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+      });
+      const body = mockRequest.body as string;
+      const longValue = decodeURIComponent(body.replace('long_value=', ''));
       const longObject = JSON.parse(
         new TextDecoder().decode(toByteArray(longValue))
       );
-
       expect(longObject).toEqual({ a: 1 });
       return { success: true };
     }
@@ -85,22 +99,108 @@ it('writes objects using /card/write_long_b64', async () => {
   await new WebServiceCard().writeLongObject({ a: 1 });
 });
 
+it('handles failures to write objects using /card/write_long_b64', async () => {
+  fetchMock.post('/card/write_long_b64', { success: false });
+
+  await expect(new WebServiceCard().writeLongObject({ a: 1 })).rejects.toThrow(
+    'Failed to write long value'
+  );
+});
+
 it('writes binary data using /card/write_long_b64', async () => {
   fetchMock.post(
     '/card/write_long_b64',
     (url: string, mockRequest: MockRequest) => {
-      expect(url).toBe('/card/write_long_b64');
-      const longValue = (mockRequest.body as FormData).get(
-        'long_value'
-      ) as string;
+      expect(url).toEqual('/card/write_long_b64');
+      expect(mockRequest.headers).toEqual({
+        Accept: 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+      });
+      const body = mockRequest.body as string;
+      const longValue = decodeURIComponent(body.replace('long_value=', ''));
       const longObject = toByteArray(longValue);
-
       expect(longObject).toEqual(Uint8Array.of(1, 2, 3));
       return { success: true };
     }
   );
 
   await new WebServiceCard().writeLongUint8Array(Uint8Array.of(1, 2, 3));
+});
+
+it('handles failures to write binary data using /card/write_long_b64', async () => {
+  fetchMock.post('/card/write_long_b64', { success: false });
+
+  await expect(
+    new WebServiceCard().writeLongUint8Array(Uint8Array.of(1, 2, 3))
+  ).rejects.toThrow('Failed to write long value');
+});
+
+it('writes short and long values using /card/write_short_and_long', async () => {
+  fetchMock.post(
+    '/card/write_short_and_long',
+    (url: string, mockRequest: MockRequest) => {
+      expect(url).toEqual('/card/write_short_and_long');
+      expect(mockRequest.headers).toEqual({
+        Accept: 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+      });
+      const body = mockRequest.body as string;
+      const values = body.split('&');
+      expect(values.length).toEqual(2);
+      expect(
+        values[0]?.startsWith('short_value=') &&
+          values[1]?.startsWith('long_value=')
+      ).toEqual(true);
+      const shortValue = decodeURIComponent(
+        values[0]!.replace('short_value=', '')
+      );
+      const longValue = decodeURIComponent(
+        values[1]!.replace('long_value=', '')
+      );
+      expect(shortValue).toEqual('abc');
+      expect(longValue).toEqual('def');
+      return { success: true };
+    }
+  );
+
+  await new WebServiceCard().writeShortAndLongValues({
+    shortValue: 'abc',
+    longValue: 'def',
+  });
+});
+
+it('handles failures to write short and long values using /card/write_short_and_long', async () => {
+  fetchMock.post('/card/write_short_and_long', { success: false });
+
+  await expect(
+    new WebServiceCard().writeShortAndLongValues({
+      shortValue: 'abc',
+      longValue: 'def',
+    })
+  ).rejects.toThrow('Failed to write short and long values');
+});
+
+it('overrides write protection using /card/write_protect_override', async () => {
+  fetchMock.post(
+    '/card/write_protect_override',
+    (url: string, mockRequest: MockRequest) => {
+      expect(url).toEqual('/card/write_protect_override');
+      expect(mockRequest.headers).toEqual({
+        Accept: 'application/json',
+      });
+      return { success: true };
+    }
+  );
+
+  await new WebServiceCard().overrideWriteProtection();
+});
+
+it('handles failures to override write protection using /card/write_protect_override', async () => {
+  fetchMock.post('/card/write_protect_override', { success: false });
+
+  await expect(new WebServiceCard().overrideWriteProtection()).rejects.toThrow(
+    'Failed to override write protection'
+  );
 });
 
 it('gets undefined when reading object value if long value is not set', async () => {

--- a/libs/utils/src/Card/web_service_card.ts
+++ b/libs/utils/src/Card/web_service_card.ts
@@ -8,7 +8,12 @@ import {
 import { fromByteArray, toByteArray } from 'base64-js';
 import { z } from 'zod';
 import { fetchJson } from '../fetch_json';
-import { Card, CardSummary, CardSummarySchema } from '../types';
+import {
+  Card,
+  CardSummary,
+  CardSummarySchema,
+  ShortAndLongValues,
+} from '../types';
 
 interface LongValueResponse {
   longValue?: string;
@@ -102,6 +107,39 @@ export class WebServiceCard implements Card {
     })) as SuccessIndicationResponse;
     if (!success) {
       throw new Error('Failed to write long value');
+    }
+  }
+
+  /**
+   * Writes new short and long values to the card.
+   */
+  async writeShortAndLongValues({
+    shortValue,
+    longValue,
+  }: ShortAndLongValues): Promise<void> {
+    const { success } = (await fetchJson('/card/write_short_and_long', {
+      method: 'post',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+      },
+      body:
+        `short_value=${encodeURIComponent(shortValue)}&` +
+        `long_value=${encodeURIComponent(longValue)}`,
+    })) as SuccessIndicationResponse;
+    if (!success) {
+      throw new Error('Failed to write short and long values');
+    }
+  }
+
+  /**
+   * Overrides card write protection.
+   */
+  async overrideWriteProtection(): Promise<void> {
+    const { success } = (await fetchJson('/card/write_protect_override', {
+      method: 'post',
+    })) as SuccessIndicationResponse;
+    if (!success) {
+      throw new Error('Failed to override write protection');
     }
   }
 }

--- a/libs/utils/src/Card/web_service_card.ts
+++ b/libs/utils/src/Card/web_service_card.ts
@@ -93,13 +93,12 @@ export class WebServiceCard implements Card {
    */
   async writeLongUint8Array(value: Uint8Array): Promise<void> {
     const longValueBase64 = fromByteArray(value);
-    const formData = new FormData();
-
-    formData.append('long_value', longValueBase64);
-
     const { success } = (await fetchJson('/card/write_long_b64', {
       method: 'post',
-      body: formData,
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+      },
+      body: `long_value=${encodeURIComponent(longValueBase64)}`,
     })) as SuccessIndicationResponse;
     if (!success) {
       throw new Error('Failed to write long value');

--- a/libs/utils/src/fetch_json.test.ts
+++ b/libs/utils/src/fetch_json.test.ts
@@ -45,7 +45,7 @@ test('preserves custom headers', async () => {
 test('throws on non-ok response', async () => {
   fetchMock.getOnce('/example', { status: 400 });
   await expect(fetchJson('/example')).rejects.toThrowError(
-    'fetch response is not ok'
+    'Received 400 status code'
   );
 });
 

--- a/libs/utils/src/fetch_json.ts
+++ b/libs/utils/src/fetch_json.ts
@@ -11,7 +11,7 @@ export async function fetchJson(
   });
 
   if (!response.ok) {
-    throw new Error('fetch response is not ok');
+    throw new Error(`Received ${response.status} status code`);
   }
 
   return await response.json();

--- a/libs/utils/src/types.ts
+++ b/libs/utils/src/types.ts
@@ -120,6 +120,11 @@ export const CardSummarySchema: z.ZodSchema<CardSummary> = z.union([
   CardSummaryReadySchema,
 ]);
 
+export interface ShortAndLongValues {
+  shortValue: string;
+  longValue: string;
+}
+
 /**
  * Defines the API for accessing a smart card reader.
  */
@@ -164,6 +169,16 @@ export interface Card {
    * Writes binary data to the long value.
    */
   writeLongUint8Array(value: Uint8Array): Promise<void>;
+
+  /**
+   * Writes new short and long values to the card.
+   */
+  writeShortAndLongValues(values: ShortAndLongValues): Promise<void>;
+
+  /**
+   * Overrides card write protection.
+   */
+  overrideWriteProtection(): Promise<void>;
 }
 
 /**


### PR DESCRIPTION
_Commit-by-commit reviewing recommended_

## Overview

Issue link: Part of https://github.com/votingworks/vxsuite/issues/1919, https://github.com/votingworks/vxsuite/issues/1920, and https://github.com/votingworks/vxsuite/issues/1921

This PR adds new methods to the `Card` interface to support smartcard programming. Smartcard programming currently bypasses this interface and communicates with the services/smartcards API directly, which isn't ideal.

The PR also updates the `WebServiceCard` interface to use x-www-form-urlencoded encoding instead of multipart/form-data (where relevant) since the latter can convert LF line endings to CRLF line endings, resulting in election hash mismatches. See https://github.com/votingworks/vxsuite/pull/1934 for more context.

## Testing 

- [x] Updated automated tests
- [x] Manually used the new methods to successfully program cards
- [ ] Looking into manual testing of existing consumers of `WebServiceCard.writeLongUint8Array` (the method affected by the multipart/form-data to x-www-form-urlencoded switch)

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A
- [x] I have added JSDoc comments to any newly introduced exports