### PR TITLE
feat(bmd): Prompt pollworker to open/close polls on VxScan if no tally report on card

### DIFF
--- a/frontends/bmd/src/app_cardless_voting.test.tsx
+++ b/frontends/bmd/src/app_cardless_voting.test.tsx
@@ -101,7 +101,7 @@ test('Cardless Voting Flow', async () => {
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises();
   fireEvent.click(screen.getByText('Open Polls for Center Springfield'));
-  fireEvent.click(screen.getByText('Open Polls Now'));
+  fireEvent.click(screen.getByText('Open VxMark Now'));
 
   // Remove card
   card.removeCard();
@@ -354,7 +354,7 @@ test('poll worker must select a precinct first', async () => {
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises();
   fireEvent.click(screen.getByText('Open Polls for All Precincts'));
-  fireEvent.click(screen.getByText('Open Polls Now'));
+  fireEvent.click(screen.getByText('Open VxMark Now'));
 
   // Remove card
   card.removeCard();

--- a/frontends/bmd/src/app_cardless_voting.test.tsx
+++ b/frontends/bmd/src/app_cardless_voting.test.tsx
@@ -101,6 +101,7 @@ test('Cardless Voting Flow', async () => {
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises();
   fireEvent.click(screen.getByText('Open Polls for Center Springfield'));
+  fireEvent.click(screen.getByText('Open Polls Now'));
 
   // Remove card
   card.removeCard();
@@ -353,6 +354,7 @@ test('poll worker must select a precinct first', async () => {
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises();
   fireEvent.click(screen.getByText('Open Polls for All Precincts'));
+  fireEvent.click(screen.getByText('Open Polls Now'));
 
   // Remove card
   card.removeCard();

--- a/frontends/bmd/src/app_end_to_end.test.tsx
+++ b/frontends/bmd/src/app_end_to_end.test.tsx
@@ -154,6 +154,7 @@ it('MarkAndPrint end-to-end flow', async () => {
   await advanceTimersAndPromises();
   screen.queryByText(`Election ID: ${expectedElectionHash}`);
   fireEvent.click(screen.getByText('Open Polls for Center Springfield'));
+  fireEvent.click(screen.getByText('Open Polls Now'));
   screen.getByText('Close Polls for Center Springfield');
   // Force refresh
   fireEvent.click(screen.getByText('Reset Accessible Controller'));
@@ -362,6 +363,7 @@ it('MarkAndPrint end-to-end flow', async () => {
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises();
   fireEvent.click(screen.getByText('Close Polls for Center Springfield'));
+  fireEvent.click(screen.getByText('Close Polls Now'));
   screen.getByText('Open Polls for Center Springfield');
 
   // Remove card

--- a/frontends/bmd/src/app_end_to_end.test.tsx
+++ b/frontends/bmd/src/app_end_to_end.test.tsx
@@ -154,7 +154,7 @@ it('MarkAndPrint end-to-end flow', async () => {
   await advanceTimersAndPromises();
   screen.queryByText(`Election ID: ${expectedElectionHash}`);
   fireEvent.click(screen.getByText('Open Polls for Center Springfield'));
-  fireEvent.click(screen.getByText('Open Polls Now'));
+  fireEvent.click(screen.getByText('Open VxMark Now'));
   screen.getByText('Close Polls for Center Springfield');
   // Force refresh
   fireEvent.click(screen.getByText('Reset Accessible Controller'));
@@ -363,7 +363,7 @@ it('MarkAndPrint end-to-end flow', async () => {
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises();
   fireEvent.click(screen.getByText('Close Polls for Center Springfield'));
-  fireEvent.click(screen.getByText('Close Polls Now'));
+  fireEvent.click(screen.getByText('Close VxMark Now'));
   screen.getByText('Open Polls for Center Springfield');
 
   // Remove card

--- a/frontends/bmd/src/app_mark_only.test.tsx
+++ b/frontends/bmd/src/app_mark_only.test.tsx
@@ -107,7 +107,7 @@ it('MarkOnly flow', async () => {
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises();
   fireEvent.click(screen.getByText('Open Polls for Center Springfield'));
-  fireEvent.click(screen.getByText('Open Polls Now'));
+  fireEvent.click(screen.getByText('Open VxMark Now'));
   screen.getByText('Close Polls for Center Springfield');
 
   // Remove card
@@ -198,7 +198,7 @@ it('MarkOnly flow', async () => {
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises();
   fireEvent.click(screen.getByText('Close Polls for Center Springfield'));
-  fireEvent.click(screen.getByText('Close Polls Now'));
+  fireEvent.click(screen.getByText('Close VxMark Now'));
   screen.getByText('Open Polls for Center Springfield');
 
   // Remove card

--- a/frontends/bmd/src/app_mark_only.test.tsx
+++ b/frontends/bmd/src/app_mark_only.test.tsx
@@ -107,6 +107,7 @@ it('MarkOnly flow', async () => {
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises();
   fireEvent.click(screen.getByText('Open Polls for Center Springfield'));
+  fireEvent.click(screen.getByText('Open Polls Now'));
   screen.getByText('Close Polls for Center Springfield');
 
   // Remove card
@@ -197,6 +198,7 @@ it('MarkOnly flow', async () => {
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises();
   fireEvent.click(screen.getByText('Close Polls for Center Springfield'));
+  fireEvent.click(screen.getByText('Close Polls Now'));
   screen.getByText('Open Polls for Center Springfield');
 
   // Remove card

--- a/frontends/bmd/src/app_print_only.test.tsx
+++ b/frontends/bmd/src/app_print_only.test.tsx
@@ -114,7 +114,7 @@ test('PrintOnly flow', async () => {
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises();
   fireEvent.click(screen.getByText('Open Polls for Center Springfield'));
-  fireEvent.click(screen.getByText('Open Polls Now'));
+  fireEvent.click(screen.getByText('Open VxMark Now'));
   screen.getByText('Close Polls for Center Springfield');
 
   // Remove card
@@ -149,7 +149,7 @@ test('PrintOnly flow', async () => {
 
   // Open Polls with Poll Worker Card
   fireEvent.click(screen.getByText('Open Polls for Center Springfield'));
-  fireEvent.click(screen.getByText('Open Polls Now'));
+  fireEvent.click(screen.getByText('Open VxMark Now'));
   screen.getByText('Close Polls for Center Springfield');
 
   // Remove card
@@ -360,7 +360,7 @@ test('PrintOnly flow', async () => {
 
   // Close Polls
   fireEvent.click(screen.getByText('Close Polls for Center Springfield'));
-  fireEvent.click(screen.getByText('Close Polls Now'));
+  fireEvent.click(screen.getByText('Close VxMark Now'));
   screen.getByText('Open Polls for Center Springfield');
 
   // Remove card
@@ -436,7 +436,7 @@ test('PrintOnly retains app mode when unconfigured', async () => {
     card.insertCard(pollWorkerCard);
     await advanceTimersAndPromises();
     fireEvent.click(screen.getByText('Open Polls for Center Springfield'));
-    fireEvent.click(screen.getByText('Open Polls Now'));
+    fireEvent.click(screen.getByText('Open VxMark Now'));
     screen.getByText('Close Polls for Center Springfield');
 
     // Remove card

--- a/frontends/bmd/src/app_print_only.test.tsx
+++ b/frontends/bmd/src/app_print_only.test.tsx
@@ -114,6 +114,7 @@ test('PrintOnly flow', async () => {
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises();
   fireEvent.click(screen.getByText('Open Polls for Center Springfield'));
+  fireEvent.click(screen.getByText('Open Polls Now'));
   screen.getByText('Close Polls for Center Springfield');
 
   // Remove card
@@ -148,6 +149,7 @@ test('PrintOnly flow', async () => {
 
   // Open Polls with Poll Worker Card
   fireEvent.click(screen.getByText('Open Polls for Center Springfield'));
+  fireEvent.click(screen.getByText('Open Polls Now'));
   screen.getByText('Close Polls for Center Springfield');
 
   // Remove card
@@ -358,6 +360,7 @@ test('PrintOnly flow', async () => {
 
   // Close Polls
   fireEvent.click(screen.getByText('Close Polls for Center Springfield'));
+  fireEvent.click(screen.getByText('Close Polls Now'));
   screen.getByText('Open Polls for Center Springfield');
 
   // Remove card
@@ -433,6 +436,7 @@ test('PrintOnly retains app mode when unconfigured', async () => {
     card.insertCard(pollWorkerCard);
     await advanceTimersAndPromises();
     fireEvent.click(screen.getByText('Open Polls for Center Springfield'));
+    fireEvent.click(screen.getByText('Open Polls Now'));
     screen.getByText('Close Polls for Center Springfield');
 
     // Remove card

--- a/frontends/bmd/src/pages/poll_worker_screen.test.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.test.tsx
@@ -1282,7 +1282,6 @@ test('shows instructions to open/close polls on VxScan if no tally report on car
   screen.getByText('Open Polls on VxScan');
 
   // Clicking Cancel closes the modal
-  fireEvent.click(screen.getByText('Open Polls for Center Springfield'));
   fireEvent.click(screen.getByText('Cancel'));
   screen.getByText('Open Polls for Center Springfield');
 

--- a/frontends/bmd/src/pages/poll_worker_screen.test.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.test.tsx
@@ -1279,15 +1279,15 @@ test('shows instructions to open/close polls on VxScan if no tally report on car
 
   // Should show the modal and not open/close polls
   expect(togglePollsOpen).not.toHaveBeenCalled();
-  screen.getByText('Open Polls on VxScan');
+  screen.getByText('No Polls Opened Report on Card');
 
   // Clicking Cancel closes the modal
   fireEvent.click(screen.getByText('Cancel'));
   screen.getByText('Open Polls for Center Springfield');
 
-  // Clicking Open Polls Now should open/close polls anyway
+  // Clicking Open VxMark Now should open/close polls anyway
   fireEvent.click(screen.getByText('Open Polls for Center Springfield'));
-  fireEvent.click(screen.getByText('Open Polls Now'));
+  fireEvent.click(screen.getByText('Open VxMark Now'));
   expect(togglePollsOpen).toHaveBeenCalled();
 });
 

--- a/frontends/bmd/src/pages/poll_worker_screen.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.tsx
@@ -568,13 +568,19 @@ export function PollWorkerScreen({
               <Prose textCenter id="modalaudiofocus">
                 {isPollsOpen ? (
                   <React.Fragment>
-                    <h1>Close Polls on VxScan</h1>
-                    <p>Close polls on VxScan first before closing VxMark.</p>
+                    <h1>No Polls Closed Report on Card</h1>
+                    <p>
+                      Close polls on VxScan to save the polls closed report
+                      before closing polls on VxMark.
+                    </p>
                   </React.Fragment>
                 ) : (
                   <React.Fragment>
-                    <h1>Open Polls on VxScan</h1>
-                    <p>Open polls on VxScan first before opening VxMark.</p>
+                    <h1>No Polls Opened Report on Card</h1>
+                    <p>
+                      Open polls on VxScan to save the polls opened report
+                      before opening polls on VxMark.
+                    </p>
                   </React.Fragment>
                 )}
               </Prose>
@@ -593,7 +599,7 @@ export function PollWorkerScreen({
                     setIsShowingVxScanPollsOpenModal(false);
                   }}
                 >
-                  {isPollsOpen ? 'Close Polls Now' : 'Open Polls Now'}
+                  {isPollsOpen ? 'Close VxMark Now' : 'Open VxMark Now'}
                 </Button>
               </React.Fragment>
             }

--- a/frontends/bmd/src/pages/poll_worker_screen.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.tsx
@@ -324,6 +324,9 @@ export function PollWorkerScreen({
         ? appPrecinct.precinctId
         : undefined
     );
+  const [isShowingVxScanPollsOpenModal, setIsShowingVxScanPollsOpenModal] =
+    useState(false);
+
   const precinctBallotStyles = selectedCardlessVoterPrecinctId
     ? election.ballotStyles.filter((bs) =>
         bs.precincts.includes(selectedCardlessVoterPrecinctId)
@@ -362,6 +365,14 @@ export function PollWorkerScreen({
   function confirmEnableLiveMode() {
     enableLiveMode();
     setIsConfirmingEnableLiveMode(false);
+  }
+
+  function handleTogglePollsOpen() {
+    if (pollworkerCardHasTally) {
+      togglePollsOpen();
+    } else {
+      setIsShowingVxScanPollsOpenModal(true);
+    }
   }
 
   if (hasVotes && pollworkerAuth.activatedCardlessVoter) {
@@ -529,7 +540,7 @@ export function PollWorkerScreen({
               )}
             </Text>
             <p>
-              <Button primary large onPress={togglePollsOpen}>
+              <Button primary large onPress={handleTogglePollsOpen}>
                 {isPollsOpen
                   ? `Close Polls for ${precinctName}`
                   : `Open Polls for ${precinctName}`}
@@ -550,6 +561,38 @@ export function PollWorkerScreen({
             <Text center>Remove card when finished.</Text>
           </Prose>
         </Sidebar>
+        {isShowingVxScanPollsOpenModal && (
+          <Modal
+            centerContent
+            content={
+              <Prose textCenter id="modalaudiofocus">
+                <h1>{isPollsOpen ? 'Close' : 'Open'} Polls on VxScan</h1>
+                <p>
+                  {isPollsOpen ? 'Close' : 'Open'} polls on VxScan first before{' '}
+                  {isPollsOpen ? 'closing' : 'opening'} VxMark.
+                </p>
+              </Prose>
+            }
+            actions={
+              <React.Fragment>
+                <Button
+                  primary
+                  onPress={() => setIsShowingVxScanPollsOpenModal(false)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  onPress={() => {
+                    togglePollsOpen();
+                    setIsShowingVxScanPollsOpenModal(false);
+                  }}
+                >
+                  {isPollsOpen ? 'Close' : 'Open'} Polls Now
+                </Button>
+              </React.Fragment>
+            }
+          />
+        )}
         {isConfirmingEnableLiveMode && (
           <Modal
             centerContent

--- a/frontends/bmd/src/pages/poll_worker_screen.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.tsx
@@ -566,11 +566,17 @@ export function PollWorkerScreen({
             centerContent
             content={
               <Prose textCenter id="modalaudiofocus">
-                <h1>{isPollsOpen ? 'Close' : 'Open'} Polls on VxScan</h1>
-                <p>
-                  {isPollsOpen ? 'Close' : 'Open'} polls on VxScan first before{' '}
-                  {isPollsOpen ? 'closing' : 'opening'} VxMark.
-                </p>
+                {isPollsOpen ? (
+                  <React.Fragment>
+                    <h1>Close Polls on VxScan</h1>
+                    <p>Close polls on VxScan first before closing VxMark.</p>
+                  </React.Fragment>
+                ) : (
+                  <React.Fragment>
+                    <h1>Open Polls on VxScan</h1>
+                    <p>Open polls on VxScan first before opening VxMark.</p>
+                  </React.Fragment>
+                )}
               </Prose>
             }
             actions={

--- a/frontends/bmd/src/pages/poll_worker_screen.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.tsx
@@ -593,7 +593,7 @@ export function PollWorkerScreen({
                     setIsShowingVxScanPollsOpenModal(false);
                   }}
                 >
-                  {isPollsOpen ? 'Close' : 'Open'} Polls Now
+                  {isPollsOpen ? 'Close Polls Now' : 'Open Polls Now'}
                 </Button>
               </React.Fragment>
             }


### PR DESCRIPTION
## Overview
This completes the first task listed in #1311 

When a pollworker inserts a card _without_ a tally report, when they try to open/close the polls, we first show a modal instructing them to open/close the polls on VxScan.

## Demo Video or Screenshot
<img width="600" src="https://user-images.githubusercontent.com/7584833/179030187-ae3bbfc4-5990-41d1-a5cf-9c0ae80fcec4.png" />
<img width="600" src="https://user-images.githubusercontent.com/7584833/179030191-8dea3e82-18f4-4f7e-ad91-fa607aed4e37.png" />

## Testing Plan 
Manually tested and added a test.

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
