### PR TITLE
Fix BMD Ballot in VxAdmin

### DIFF
--- a/frontends/bmd/src/App.css
+++ b/frontends/bmd/src/App.css
@@ -80,7 +80,7 @@ html {
   html {
     background: #ffffff;
 
-    /* Adjust printed ballot font-size */
+    /* Adjust printed report font-size */
     font-size: 16px !important; /* stylelint-disable-line declaration-no-important */
   }
 }
@@ -121,7 +121,7 @@ html body .cvox_indicator_container {
   display: none !important; /* stylelint-disable-line declaration-no-important */
 }
 
-/* Adjust printed ballot paper settings */
+/* Adjust printed report paper settings */
 @page {
   margin: 0.375in;
   size: letter portrait;

--- a/frontends/bmd/src/pages/__snapshots__/print_page.test.tsx.snap
+++ b/frontends/bmd/src/pages/__snapshots__/print_page.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`renders PrintPage with votes 1`] = `
 <div
   aria-hidden="true"
-  class="sc-iCfLBT iZWxTt"
+  class="sc-iCfLBT hbmhyi"
 >
   <div
-    class="sc-pVTma kOGGAi"
+    class="sc-pVTma YfIWc"
   >
     <div
       class="sc-jRQAMF boeJiV ballot-header-content"
@@ -28,7 +28,7 @@ exports[`renders PrintPage with votes 1`] = `
       </p>
     </div>
     <div
-      class="sc-jrQzUz lkoXcE"
+      class="sc-jrQzUz cMnZjX"
     >
       <div
         class="sc-gKckTs drvJRF"
@@ -85,10 +85,10 @@ exports[`renders PrintPage with votes 1`] = `
     class="sc-kDThTU eoGbCP"
   >
     <div
-      class="sc-iqsfdx gAnNz"
+      class="sc-iqsfdx fILsYF"
     >
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -110,7 +110,7 @@ exports[`renders PrintPage with votes 1`] = `
         </div>
       </div>
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -126,7 +126,7 @@ exports[`renders PrintPage with votes 1`] = `
         </div>
       </div>
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -148,7 +148,7 @@ exports[`renders PrintPage with votes 1`] = `
         </div>
       </div>
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -164,7 +164,7 @@ exports[`renders PrintPage with votes 1`] = `
         </div>
       </div>
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -180,7 +180,7 @@ exports[`renders PrintPage with votes 1`] = `
         </div>
       </div>
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -196,7 +196,7 @@ exports[`renders PrintPage with votes 1`] = `
         </div>
       </div>
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -212,7 +212,7 @@ exports[`renders PrintPage with votes 1`] = `
         </div>
       </div>
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -230,7 +230,7 @@ exports[`renders PrintPage with votes 1`] = `
         </div>
       </div>
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -248,7 +248,7 @@ exports[`renders PrintPage with votes 1`] = `
         </div>
       </div>
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -264,7 +264,7 @@ exports[`renders PrintPage with votes 1`] = `
         </div>
       </div>
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -324,10 +324,10 @@ exports[`renders PrintPage without votes 1`] = `
 exports[`renders PrintPage without votes and inline seal 1`] = `
 <div
   aria-hidden="true"
-  class="sc-iCfLBT iZWxTt"
+  class="sc-iCfLBT hbmhyi"
 >
   <div
-    class="sc-pVTma kOGGAi"
+    class="sc-pVTma YfIWc"
   >
     <div
       class="seal"
@@ -517,7 +517,7 @@ exports[`renders PrintPage without votes and inline seal 1`] = `
       </p>
     </div>
     <div
-      class="sc-jrQzUz lkoXcE"
+      class="sc-jrQzUz cMnZjX"
     >
       <div
         class="sc-gKckTs drvJRF"
@@ -574,10 +574,10 @@ exports[`renders PrintPage without votes and inline seal 1`] = `
     class="sc-kDThTU eoGbCP"
   >
     <div
-      class="sc-iqsfdx gAnNz"
+      class="sc-iqsfdx fILsYF"
     >
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -593,7 +593,7 @@ exports[`renders PrintPage without votes and inline seal 1`] = `
         </div>
       </div>
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -609,7 +609,7 @@ exports[`renders PrintPage without votes and inline seal 1`] = `
         </div>
       </div>
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -625,7 +625,7 @@ exports[`renders PrintPage without votes and inline seal 1`] = `
         </div>
       </div>
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -641,7 +641,7 @@ exports[`renders PrintPage without votes and inline seal 1`] = `
         </div>
       </div>
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -657,7 +657,7 @@ exports[`renders PrintPage without votes and inline seal 1`] = `
         </div>
       </div>
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -673,7 +673,7 @@ exports[`renders PrintPage without votes and inline seal 1`] = `
         </div>
       </div>
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -689,7 +689,7 @@ exports[`renders PrintPage without votes and inline seal 1`] = `
         </div>
       </div>
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -705,7 +705,7 @@ exports[`renders PrintPage without votes and inline seal 1`] = `
         </div>
       </div>
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -721,7 +721,7 @@ exports[`renders PrintPage without votes and inline seal 1`] = `
         </div>
       </div>
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -737,7 +737,7 @@ exports[`renders PrintPage without votes and inline seal 1`] = `
         </div>
       </div>
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -760,10 +760,10 @@ exports[`renders PrintPage without votes and inline seal 1`] = `
 exports[`renders PrintPage without votes and no seal 1`] = `
 <div
   aria-hidden="true"
-  class="sc-iCfLBT iZWxTt"
+  class="sc-iCfLBT hbmhyi"
 >
   <div
-    class="sc-pVTma kOGGAi"
+    class="sc-pVTma YfIWc"
   >
     <div
       class="sc-jRQAMF boeJiV ballot-header-content"
@@ -785,7 +785,7 @@ exports[`renders PrintPage without votes and no seal 1`] = `
       </p>
     </div>
     <div
-      class="sc-jrQzUz lkoXcE"
+      class="sc-jrQzUz cMnZjX"
     >
       <div
         class="sc-gKckTs drvJRF"
@@ -842,10 +842,10 @@ exports[`renders PrintPage without votes and no seal 1`] = `
     class="sc-kDThTU eoGbCP"
   >
     <div
-      class="sc-iqsfdx gAnNz"
+      class="sc-iqsfdx fILsYF"
     >
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -861,7 +861,7 @@ exports[`renders PrintPage without votes and no seal 1`] = `
         </div>
       </div>
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -877,7 +877,7 @@ exports[`renders PrintPage without votes and no seal 1`] = `
         </div>
       </div>
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -893,7 +893,7 @@ exports[`renders PrintPage without votes and no seal 1`] = `
         </div>
       </div>
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -909,7 +909,7 @@ exports[`renders PrintPage without votes and no seal 1`] = `
         </div>
       </div>
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -925,7 +925,7 @@ exports[`renders PrintPage without votes and no seal 1`] = `
         </div>
       </div>
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -941,7 +941,7 @@ exports[`renders PrintPage without votes and no seal 1`] = `
         </div>
       </div>
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -957,7 +957,7 @@ exports[`renders PrintPage without votes and no seal 1`] = `
         </div>
       </div>
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -973,7 +973,7 @@ exports[`renders PrintPage without votes and no seal 1`] = `
         </div>
       </div>
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -989,7 +989,7 @@ exports[`renders PrintPage without votes and no seal 1`] = `
         </div>
       </div>
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -1005,7 +1005,7 @@ exports[`renders PrintPage without votes and no seal 1`] = `
         </div>
       </div>
       <div
-        class="sc-crHlIS iXsyCY"
+        class="sc-crHlIS esgyjU"
       >
         <div
           class="sc-jRQAMF sc-egiSv crSiLx kigmeq"

--- a/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
+++ b/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
@@ -1710,10 +1710,10 @@ exports[`L&A (logic and accuracy) flow 2`] = `
   >
     <div
       aria-hidden="true"
-      class="sc-iCfLBT iZWxTt"
+      class="sc-iCfLBT hbmhyi"
     >
       <div
-        class="sc-pVTma kOGGAi"
+        class="sc-pVTma YfIWc"
       >
         <div
           class="seal"
@@ -1747,7 +1747,7 @@ exports[`L&A (logic and accuracy) flow 2`] = `
           </p>
         </div>
         <div
-          class="sc-jrQzUz lkoXcE"
+          class="sc-jrQzUz cMnZjX"
         >
           <div
             class="sc-gKckTs drvJRF"
@@ -1804,10 +1804,10 @@ exports[`L&A (logic and accuracy) flow 2`] = `
         class="sc-kDThTU eoGbCP"
       >
         <div
-          class="sc-iqsfdx gAnNz"
+          class="sc-iqsfdx fILsYF"
         >
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -1829,7 +1829,7 @@ exports[`L&A (logic and accuracy) flow 2`] = `
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -1851,7 +1851,7 @@ exports[`L&A (logic and accuracy) flow 2`] = `
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -1873,7 +1873,7 @@ exports[`L&A (logic and accuracy) flow 2`] = `
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -1895,7 +1895,7 @@ exports[`L&A (logic and accuracy) flow 2`] = `
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -1917,7 +1917,7 @@ exports[`L&A (logic and accuracy) flow 2`] = `
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -1938,7 +1938,7 @@ exports[`L&A (logic and accuracy) flow 2`] = `
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -1956,7 +1956,7 @@ House Concurrent Resolution No. 47
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -1974,7 +1974,7 @@ House Bill 1796 - Flag Referendum
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -2003,10 +2003,10 @@ House Bill 1796 - Flag Referendum
     </div>
     <div
       aria-hidden="true"
-      class="sc-iCfLBT iZWxTt"
+      class="sc-iCfLBT hbmhyi"
     >
       <div
-        class="sc-pVTma kOGGAi"
+        class="sc-pVTma YfIWc"
       >
         <div
           class="seal"
@@ -2040,7 +2040,7 @@ House Bill 1796 - Flag Referendum
           </p>
         </div>
         <div
-          class="sc-jrQzUz lkoXcE"
+          class="sc-jrQzUz cMnZjX"
         >
           <div
             class="sc-gKckTs drvJRF"
@@ -2097,10 +2097,10 @@ House Bill 1796 - Flag Referendum
         class="sc-kDThTU eoGbCP"
       >
         <div
-          class="sc-iqsfdx gAnNz"
+          class="sc-iqsfdx fILsYF"
         >
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -2122,7 +2122,7 @@ House Bill 1796 - Flag Referendum
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -2144,7 +2144,7 @@ House Bill 1796 - Flag Referendum
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -2166,7 +2166,7 @@ House Bill 1796 - Flag Referendum
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -2188,7 +2188,7 @@ House Bill 1796 - Flag Referendum
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -2209,7 +2209,7 @@ House Bill 1796 - Flag Referendum
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -2231,7 +2231,7 @@ House Bill 1796 - Flag Referendum
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -2249,7 +2249,7 @@ House Concurrent Resolution No. 47
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -2267,7 +2267,7 @@ House Bill 1796 - Flag Referendum
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -2296,10 +2296,10 @@ House Bill 1796 - Flag Referendum
     </div>
     <div
       aria-hidden="true"
-      class="sc-iCfLBT iZWxTt"
+      class="sc-iCfLBT hbmhyi"
     >
       <div
-        class="sc-pVTma kOGGAi"
+        class="sc-pVTma YfIWc"
       >
         <div
           class="seal"
@@ -2333,7 +2333,7 @@ House Bill 1796 - Flag Referendum
           </p>
         </div>
         <div
-          class="sc-jrQzUz lkoXcE"
+          class="sc-jrQzUz cMnZjX"
         >
           <div
             class="sc-gKckTs drvJRF"
@@ -2390,10 +2390,10 @@ House Bill 1796 - Flag Referendum
         class="sc-kDThTU eoGbCP"
       >
         <div
-          class="sc-iqsfdx gAnNz"
+          class="sc-iqsfdx fILsYF"
         >
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -2415,7 +2415,7 @@ House Bill 1796 - Flag Referendum
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -2437,7 +2437,7 @@ House Bill 1796 - Flag Referendum
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -2459,7 +2459,7 @@ House Bill 1796 - Flag Referendum
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -2481,7 +2481,7 @@ House Bill 1796 - Flag Referendum
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -2503,7 +2503,7 @@ House Bill 1796 - Flag Referendum
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -2524,7 +2524,7 @@ House Bill 1796 - Flag Referendum
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -2542,7 +2542,7 @@ House Concurrent Resolution No. 47
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -2560,7 +2560,7 @@ House Bill 1796 - Flag Referendum
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -2589,10 +2589,10 @@ House Bill 1796 - Flag Referendum
     </div>
     <div
       aria-hidden="true"
-      class="sc-iCfLBT iZWxTt"
+      class="sc-iCfLBT hbmhyi"
     >
       <div
-        class="sc-pVTma kOGGAi"
+        class="sc-pVTma YfIWc"
       >
         <div
           class="seal"
@@ -2626,7 +2626,7 @@ House Bill 1796 - Flag Referendum
           </p>
         </div>
         <div
-          class="sc-jrQzUz lkoXcE"
+          class="sc-jrQzUz cMnZjX"
         >
           <div
             class="sc-gKckTs drvJRF"
@@ -2683,10 +2683,10 @@ House Bill 1796 - Flag Referendum
         class="sc-kDThTU eoGbCP"
       >
         <div
-          class="sc-iqsfdx gAnNz"
+          class="sc-iqsfdx fILsYF"
         >
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -2708,7 +2708,7 @@ House Bill 1796 - Flag Referendum
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -2730,7 +2730,7 @@ House Bill 1796 - Flag Referendum
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -2752,7 +2752,7 @@ House Bill 1796 - Flag Referendum
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -2774,7 +2774,7 @@ House Bill 1796 - Flag Referendum
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -2796,7 +2796,7 @@ House Bill 1796 - Flag Referendum
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -2818,7 +2818,7 @@ House Bill 1796 - Flag Referendum
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -2836,7 +2836,7 @@ House Concurrent Resolution No. 47
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"
@@ -2854,7 +2854,7 @@ House Bill 1796 - Flag Referendum
             </div>
           </div>
           <div
-            class="sc-crHlIS iXsyCY"
+            class="sc-crHlIS esgyjU"
           >
             <div
               class="sc-jRQAMF sc-egiSv crSiLx kigmeq"

--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -53,6 +53,7 @@ import { CastVoteRecordFiles } from './utils/cast_vote_record_files';
 import { App } from './app';
 
 import { fakePrinter } from '../test/helpers/fake_printer';
+import { loadBallotSealImages } from '../test/util/load_ballot_seal_images';
 import { eitherNeitherElectionDefinition } from '../test/render_in_app_context';
 
 import { convertSemsFileToExternalTally } from './utils/sems_tallies';
@@ -398,7 +399,8 @@ test('L&A (logic and accuracy) flow', async () => {
   await screen.findByText('Printing L&A Package for District 5', {
     exact: false,
   });
-  expect(printer.print).toHaveBeenCalledTimes(2);
+  loadBallotSealImages();
+  await waitFor(() => expect(printer.print).toHaveBeenCalledTimes(2));
   await waitFor(() =>
     expect(mockKiosk.log).toHaveBeenCalledWith(
       expect.stringContaining(LogEventId.TestDeckPrinted)

--- a/frontends/election-manager/src/screens/print_test_deck_screen.test.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.test.tsx
@@ -18,6 +18,7 @@ import {
   TWO_SIDED_PAGE_PRINT_TIME_MS,
 } from './print_test_deck_screen';
 import { renderInAppContext } from '../../test/render_in_app_context';
+import { loadBallotSealImages } from '../../test/util/load_ballot_seal_images';
 
 jest.mock('../components/hand_marked_paper_ballot');
 
@@ -64,6 +65,7 @@ test('Printing L&A package for one precinct', async () => {
   jest.advanceTimersByTime(ONE_SIDED_PAGE_PRINT_TIME_MS);
 
   await screen.findByText('Printing L&A Package for District 5');
+  loadBallotSealImages();
   await waitFor(() => expect(mockPrinter.print).toHaveBeenCalledTimes(2));
   expect(mockPrinter.print).toHaveBeenLastCalledWith({ sides: 'one-sided' });
   await waitFor(() =>
@@ -137,6 +139,7 @@ test('Printing L&A packages for all precincts', async () => {
 
     await screen.findByText(`Printing L&A Package for ${precinct}`);
     await screen.findByText(`This is package ${i + 1} of 13.`);
+    loadBallotSealImages();
     await waitFor(() =>
       expect(mockPrinter.print).toHaveBeenCalledTimes(3 * i + 2)
     );
@@ -208,6 +211,7 @@ test('Printing L&A package for one precinct, when HMPBs are not letter-size', as
 
   await screen.findByText('Printing L&A Package for District 5');
   await screen.findByText('Currently printing letter-size pages.');
+  loadBallotSealImages();
   await waitFor(() => expect(mockPrinter.print).toHaveBeenCalledTimes(2));
   expect(mockPrinter.print).toHaveBeenLastCalledWith({ sides: 'one-sided' });
   await waitFor(() =>
@@ -296,6 +300,7 @@ test('Printing L&A packages for all precincts, when HMPBs are not letter-size', 
     await screen.findByText(`Printing L&A Package for ${precinct}`);
     await screen.findByText(`This is package ${i + 1} of 13.`);
     await screen.findByText('Currently printing letter-size pages.');
+    loadBallotSealImages();
     await waitFor(() =>
       expect(mockPrinter.print).toHaveBeenCalledTimes(2 * i + 2)
     );

--- a/frontends/election-manager/src/screens/print_test_deck_screen.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.tsx
@@ -96,9 +96,13 @@ function BmdPaperBallots({
   const { election } = electionDefinition;
   const ballots = generateTestDeckBallots({ election, precinctId });
 
-  useEffect(() => {
-    onAllRendered(ballots.length);
-  }, [ballots, onAllRendered]);
+  let numRendered = 0;
+  function onRendered() {
+    numRendered += 1;
+    if (numRendered === ballots.length) {
+      onAllRendered(ballots.length);
+    }
+  }
 
   return (
     <div className="print-only">
@@ -110,6 +114,7 @@ function BmdPaperBallots({
           key={`ballot-${i}`} // eslint-disable-line react/no-array-index-key
           precinctId={ballot.precinctId}
           votes={ballot.votes}
+          onRendered={onRendered}
         />
       ))}
     </div>

--- a/frontends/election-manager/test/util/load_ballot_seal_images.ts
+++ b/frontends/election-manager/test/util/load_ballot_seal_images.ts
@@ -1,0 +1,8 @@
+import { fireEvent, screen } from '@testing-library/react';
+
+export function loadBallotSealImages(): void {
+  const ballotSealImages = screen.getAllByTestId('printed-ballot-seal-image');
+  for (const ballotSealImage of ballotSealImages) {
+    fireEvent.load(ballotSealImage);
+  }
+}

--- a/libs/ui/src/__snapshots__/bmd_paper_ballot.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/bmd_paper_ballot.test.tsx.snap
@@ -4,10 +4,10 @@ exports[`BmdPaperBallot renders votes for MS either-neither contests 1`] = `
 <div>
   <div
     aria-hidden="true"
-    class="sc-jRQAMF hBQBes"
+    class="sc-jRQAMF bFYiKD"
   >
     <div
-      class="sc-iCfLBT goFFTe"
+      class="sc-iCfLBT cSkaik"
     >
       <div
         class="seal"
@@ -41,7 +41,7 @@ exports[`BmdPaperBallot renders votes for MS either-neither contests 1`] = `
         </p>
       </div>
       <div
-        class="sc-furvIG kvInqJ"
+        class="sc-furvIG cfpKDm"
       >
         <div
           class="sc-eCImvq gScWpb"
@@ -98,10 +98,10 @@ exports[`BmdPaperBallot renders votes for MS either-neither contests 1`] = `
       class="sc-pVTma NVkwn"
     >
       <div
-        class="sc-jrQzUz dWmEa"
+        class="sc-jrQzUz jgYCbw"
       >
         <div
-          class="sc-kDThTU dEPUfB"
+          class="sc-kDThTU gkFLxJ"
         >
           <div
             class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
@@ -117,7 +117,7 @@ exports[`BmdPaperBallot renders votes for MS either-neither contests 1`] = `
           </div>
         </div>
         <div
-          class="sc-kDThTU dEPUfB"
+          class="sc-kDThTU gkFLxJ"
         >
           <div
             class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
@@ -133,7 +133,7 @@ exports[`BmdPaperBallot renders votes for MS either-neither contests 1`] = `
           </div>
         </div>
         <div
-          class="sc-kDThTU dEPUfB"
+          class="sc-kDThTU gkFLxJ"
         >
           <div
             class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
@@ -149,7 +149,7 @@ exports[`BmdPaperBallot renders votes for MS either-neither contests 1`] = `
           </div>
         </div>
         <div
-          class="sc-kDThTU dEPUfB"
+          class="sc-kDThTU gkFLxJ"
         >
           <div
             class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
@@ -165,7 +165,7 @@ exports[`BmdPaperBallot renders votes for MS either-neither contests 1`] = `
           </div>
         </div>
         <div
-          class="sc-kDThTU dEPUfB"
+          class="sc-kDThTU gkFLxJ"
         >
           <div
             class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
@@ -181,7 +181,7 @@ exports[`BmdPaperBallot renders votes for MS either-neither contests 1`] = `
           </div>
         </div>
         <div
-          class="sc-kDThTU dEPUfB"
+          class="sc-kDThTU gkFLxJ"
         >
           <div
             class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
@@ -198,7 +198,7 @@ House Concurrent Resolution No. 47
           </div>
         </div>
         <div
-          class="sc-kDThTU dEPUfB"
+          class="sc-kDThTU gkFLxJ"
         >
           <div
             class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
@@ -215,7 +215,7 @@ House Bill 1796 - Flag Referendum
           </div>
         </div>
         <div
-          class="sc-kDThTU dEPUfB"
+          class="sc-kDThTU gkFLxJ"
         >
           <div
             class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
@@ -249,10 +249,10 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
 <div>
   <div
     aria-hidden="true"
-    class="sc-jRQAMF hBQBes"
+    class="sc-jRQAMF bFYiKD"
   >
     <div
-      class="sc-iCfLBT goFFTe"
+      class="sc-iCfLBT cSkaik"
     >
       <div
         class="seal"
@@ -442,7 +442,7 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
         </p>
       </div>
       <div
-        class="sc-furvIG kvInqJ"
+        class="sc-furvIG cfpKDm"
       >
         <div
           class="sc-eCImvq gScWpb"
@@ -499,10 +499,10 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
       class="sc-pVTma NVkwn"
     >
       <div
-        class="sc-jrQzUz dWmEa"
+        class="sc-jrQzUz jgYCbw"
       >
         <div
-          class="sc-kDThTU dEPUfB"
+          class="sc-kDThTU gkFLxJ"
         >
           <div
             class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
@@ -524,7 +524,7 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
           </div>
         </div>
         <div
-          class="sc-kDThTU dEPUfB"
+          class="sc-kDThTU gkFLxJ"
         >
           <div
             class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
@@ -540,7 +540,7 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
           </div>
         </div>
         <div
-          class="sc-kDThTU dEPUfB"
+          class="sc-kDThTU gkFLxJ"
         >
           <div
             class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
@@ -562,7 +562,7 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
           </div>
         </div>
         <div
-          class="sc-kDThTU dEPUfB"
+          class="sc-kDThTU gkFLxJ"
         >
           <div
             class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
@@ -578,7 +578,7 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
           </div>
         </div>
         <div
-          class="sc-kDThTU dEPUfB"
+          class="sc-kDThTU gkFLxJ"
         >
           <div
             class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
@@ -594,7 +594,7 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
           </div>
         </div>
         <div
-          class="sc-kDThTU dEPUfB"
+          class="sc-kDThTU gkFLxJ"
         >
           <div
             class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
@@ -610,7 +610,7 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
           </div>
         </div>
         <div
-          class="sc-kDThTU dEPUfB"
+          class="sc-kDThTU gkFLxJ"
         >
           <div
             class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
@@ -626,7 +626,7 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
           </div>
         </div>
         <div
-          class="sc-kDThTU dEPUfB"
+          class="sc-kDThTU gkFLxJ"
         >
           <div
             class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
@@ -644,7 +644,7 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
           </div>
         </div>
         <div
-          class="sc-kDThTU dEPUfB"
+          class="sc-kDThTU gkFLxJ"
         >
           <div
             class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
@@ -662,7 +662,7 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
           </div>
         </div>
         <div
-          class="sc-kDThTU dEPUfB"
+          class="sc-kDThTU gkFLxJ"
         >
           <div
             class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
@@ -678,7 +678,7 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
           </div>
         </div>
         <div
-          class="sc-kDThTU dEPUfB"
+          class="sc-kDThTU gkFLxJ"
         >
           <div
             class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"

--- a/libs/ui/src/bmd_paper_ballot.tsx
+++ b/libs/ui/src/bmd_paper_ballot.tsx
@@ -38,9 +38,19 @@ import { Prose } from './prose';
 import { QrCode } from './qrcode';
 
 const Ballot = styled.div`
+  background: #ffffff;
+  line-height: 1;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  font-size: 16px;
   page-break-after: always;
   @media screen {
     display: none;
+  }
+  @page {
+    margin: 0.375in;
+    size: letter portrait;
   }
 `;
 
@@ -52,9 +62,9 @@ const Header = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
-  border-bottom: 0.2rem solid #000000;
+  border-bottom: 0.2em solid #000000;
   & > .seal {
-    margin: 0.25rem 0;
+    margin: 0.25em 0;
     width: 1in;
   }
   & h2 {
@@ -65,7 +75,7 @@ const Header = styled.div`
   }
   & > .ballot-header-content {
     flex: 4;
-    margin: 0 1rem;
+    margin: 0 1em;
     max-width: 100%;
   }
 `;
@@ -74,12 +84,12 @@ const QrCodeContainer = styled.div`
   flex: 3;
   flex-direction: row;
   align-self: flex-end;
-  border: 0.2rem solid #000000;
+  border: 0.2em solid #000000;
   border-bottom: 0;
   max-width: 50%;
-  padding: 0.25rem;
+  padding: 0.25em;
   & > div:first-child {
-    margin-right: 0.25rem;
+    margin-right: 0.25em;
     width: 1.1in;
   }
   & > div:last-child {
@@ -90,15 +100,15 @@ const QrCodeContainer = styled.div`
       flex: 1;
       flex-direction: column;
       align-self: stretch;
-      font-size: 0.8rem;
+      font-size: 0.8em;
       & > div {
-        margin-bottom: 0.75rem;
+        margin-bottom: 0.9375em;
       }
       & > div:last-child {
         margin-bottom: 0;
       }
       & strong {
-        font-size: 1rem;
+        font-size: 1.25em;
         word-break: break-word;
       }
     }
@@ -109,11 +119,11 @@ const Content = styled.div`
 `;
 const BallotSelections = styled.div`
   columns: 2;
-  column-gap: 2rem;
+  column-gap: 2em;
 `;
 const Contest = styled.div`
-  border-bottom: 0.01rem solid #000000;
-  padding: 0.5rem 0;
+  border-bottom: 0.01em solid #000000;
+  padding: 0.5em 0;
   break-inside: avoid;
   page-break-inside: avoid;
 `;

--- a/libs/ui/src/bmd_paper_ballot.tsx
+++ b/libs/ui/src/bmd_paper_ballot.tsx
@@ -1,6 +1,6 @@
 import { fromByteArray } from 'base64-js';
 import { DateTime } from 'luxon';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { encodeBallot } from '@votingworks/ballot-encoder';
@@ -244,6 +244,7 @@ interface Props {
   isLiveMode: boolean;
   precinctId: PrecinctId;
   votes: VotesDict;
+  onRendered?: () => void;
 }
 
 /**
@@ -255,6 +256,7 @@ export function BmdPaperBallot({
   isLiveMode,
   precinctId,
   votes,
+  onRendered,
 }: Props): JSX.Element {
   const ballotId = randomBallotId();
   const {
@@ -280,6 +282,14 @@ export function BmdPaperBallot({
     ballotType: BallotType.Standard,
   });
 
+  const [sealLoaded, setSealLoaded] = useState(false);
+  useEffect(() => {
+    const isRendered = seal || !sealUrl || (sealUrl && sealLoaded);
+    if (isRendered && onRendered) {
+      onRendered();
+    }
+  }, [seal, sealUrl, sealLoaded, onRendered]);
+
   return (
     <Ballot aria-hidden>
       <Header>
@@ -300,6 +310,7 @@ export function BmdPaperBallot({
               src={sealUrl}
               alt=""
               data-testid="printed-ballot-seal-image"
+              onLoad={() => setSealLoaded(true)}
             />
           </div>
         ) : (


### PR DESCRIPTION
## Overview
Closes #1947. The BMD ballots printed from VxAdmin (only in test decks) have not been consistent with the BMD ballots printed from VxMark for two reasons, each addressed by a separate commit in this PR:

1. Seals have been missing on VxAdmin BMD ballots. The document was being printed before the images had an opportunity to load. Now the printing is tied to an `onLoad` trigger.
2. BMD ballots were receiving some of their styling from the top-level `App.css`  files in each app. All relevant styles have been moved into the `BmdPaperBallot` component in `libs/ui`. It makes sense for the styling to exist with the component. Because a lot of the fonts were in `rem`, those have been converted to `em`. 

## Demo Video or Screenshot

Before:
[VxAdminMainActual.pdf](https://github.com/votingworks/vxsuite/files/9134364/VxAdminMainActual.pdf)
<img width="544" alt="Screen Shot 2022-07-18 at 11 20 17 AM" src="https://user-images.githubusercontent.com/37960853/179577005-1eeb862d-3fb5-49be-aa40-07610c4054db.png">


After:
[VxAdminTestDeckLatest.pdf](https://github.com/votingworks/vxsuite/files/9125224/VxAdminTestDeckLatest.pdf)
<img width="544" alt="Screen Shot 2022-07-15 at 10 28 07 PM" src="https://user-images.githubusercontent.com/37960853/179341286-1fc1a10d-313b-47c9-a009-e546d2e0d345.png">


## Testing Plan 
- Used online pdf diff checking tool to confirm VxAdmin test deck ballots are identical in format to VxMark ballots
- Added tests in `libs/ui` for changes to `BmdPaperBallot`
- Updated `election-manager` tests to account for loading images

## Checklist
- [ ] ~~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~~
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
