### PR TITLE
fix(scan): copy images if we cannot link them

### DIFF
--- a/services/scan/src/util/save_images.ts
+++ b/services/scan/src/util/save_images.ts
@@ -10,6 +10,18 @@ interface SaveImagesResult {
   normalized: string;
 }
 
+/**
+ * Links {@link src} to {@link dest} if both paths are on the same file system,
+ * otherwise does a file copy.
+ */
+async function linkOrCopy(src: string, dest: string): Promise<void> {
+  try {
+    await fsExtra.link(src, dest);
+  } catch {
+    await fsExtra.copy(src, dest);
+  }
+}
+
 export async function saveImages(
   imagePath: string,
   originalImagePath: string,
@@ -18,7 +30,7 @@ export async function saveImages(
 ): Promise<SaveImagesResult> {
   if (imagePath !== originalImagePath) {
     debug('linking image file %s from %s', imagePath, originalImagePath);
-    await fsExtra.link(imagePath, originalImagePath);
+    await linkOrCopy(imagePath, originalImagePath);
   }
 
   if (normalizedImage) {


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
We link instead of copy to save space, but if the source and destination are on different partitions or physical disks we cannot link them. If the link fails, just do a copy.

## Demo Video or Screenshot
n/a

## Testing Plan 
Automated testing.
