### PR TITLE
test(admin): use `unknown` instead of `any`

### DIFF
--- a/services/admin/src/server.test.ts
+++ b/services/admin/src/server.test.ts
@@ -54,7 +54,7 @@ test('errors on start with no workspace', async () => {
       app,
       workspace: undefined,
     });
-  } catch (err: any) {
+  } catch (err: unknown) {
     assert(err instanceof Error);
     expect(err.message).toMatch(
       'workspace path could not be determined; pass a workspace or run with ADMIN_WORKSPACE'


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Mostly there's no good reason to use `any` instead of `unknown`. In particular we're asserting that the error is `Error` immediately, so `unknown` is appropriate here.

## Demo Video or Screenshot
n/a

## Testing Plan 
n/a

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
