### PR TITLE
refactor(scan): give `Corners` tuple entries names

### DIFF
--- a/libs/types/src/geometry.ts
+++ b/libs/types/src/geometry.ts
@@ -31,7 +31,12 @@ export const RectSchema: z.ZodSchema<Rect> = z.object({
   height: z.number(),
 });
 
-export type Corners = readonly [Point, Point, Point, Point];
+export type Corners = readonly [
+  topLeft: Point,
+  topRight: Point,
+  bottomLeft: Point,
+  bottomRight: Point
+];
 export const CornersSchema: z.ZodSchema<Corners> = z.tuple([
   PointSchema,
   PointSchema,


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
This should help with making sure we don't get them wrong. Really this should probably just be an object with named keys, but that's a bigger change I didn't want to make right now.

## Demo Video or Screenshot
n/a

## Testing Plan 
n/a
