### PR TITLE
Complete new smartcard programming UIs

### DIFF
--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import MockDate from 'mockdate';
-
 import {
   fireEvent,
   render,
@@ -33,28 +32,17 @@ import {
 } from '@votingworks/test-utils';
 import {
   AdminCardData,
-  ElectionDefinition,
   ExternalTallySourceType,
   PollworkerCardData,
   VotingMethod,
 } from '@votingworks/types';
-
 import { LogEventId } from '@votingworks/logging';
 import { CARD_POLLING_INTERVAL } from '@votingworks/ui';
-import {
-  configuredAtStorageKey,
-  cvrsStorageKey,
-  electionDefinitionStorageKey,
-  externalVoteTalliesFileStorageKey,
-} from './app_root';
 
-import { CastVoteRecordFiles } from './utils/cast_vote_record_files';
-
+import { externalVoteTalliesFileStorageKey } from './app_root';
 import { App } from './app';
-
 import { fakePrinter } from '../test/helpers/fake_printer';
 import { eitherNeitherElectionDefinition } from '../test/render_in_app_context';
-
 import { convertSemsFileToExternalTally } from './utils/sems_tallies';
 import {
   convertExternalTalliesToStorageString,
@@ -63,6 +51,7 @@ import {
 import { MachineConfig } from './config/types';
 import { VxFiles } from './lib/converters';
 import { areVvsg2AuthFlowsEnabled } from './config/features';
+import { createMemoryStorageWith } from '../test/util/create_memory_storage_with';
 
 const EITHER_NEITHER_CVR_DATA = electionWithMsEitherNeitherFixtures.cvrData;
 const EITHER_NEITHER_CVR_FILE = new File([EITHER_NEITHER_CVR_DATA], 'cvrs.txt');
@@ -143,34 +132,12 @@ afterEach(() => {
   MockDate.reset();
 });
 
-async function createMemoryStorageWith({
-  electionDefinition,
-  crvFile,
-}: {
-  electionDefinition: ElectionDefinition;
-  crvFile?: File;
-}) {
-  const storage = new MemoryStorage();
-  await storage.set(electionDefinitionStorageKey, electionDefinition);
-  if (crvFile) {
-    const castVoteRecordFiles = await CastVoteRecordFiles.empty.add(
-      crvFile,
-      electionDefinition.election
-    );
-    await storage.set(cvrsStorageKey, castVoteRecordFiles.export());
-  }
-  await storage.set(configuredAtStorageKey, new Date().toISOString());
-  return storage;
-}
-
 async function authenticateWithAdminCard(card: MemoryCard) {
   // Machine should be locked
   await screen.findByText('VxAdmin is Locked');
-  card.insertCard({
-    t: 'admin',
-    h: eitherNeitherElectionDefinition.electionHash,
-    p: '123456',
-  });
+  card.insertCard(
+    makeAdminCard(eitherNeitherElectionDefinition.electionHash, '123456')
+  );
   jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
   await screen.findByText('Enter the card security code to unlock.');
   fireEvent.click(screen.getByText('1'));
@@ -189,10 +156,7 @@ async function authenticateWithAdminCard(card: MemoryCard) {
 // implemented
 async function authenticateWithSuperAdminCard(card: MemoryCard) {
   await screen.findByText('VxAdmin is Locked');
-  card.insertCard({
-    t: 'superadmin',
-    h: eitherNeitherElectionDefinition.electionHash,
-  });
+  card.insertCard(makeSuperadminCard());
   jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
   await screen.findByText('Remove card to continue.');
   card.removeCard();
@@ -1246,104 +1210,11 @@ test('super admin Smartcards screen navigation', async () => {
   await authenticateWithSuperAdminCard(card);
 
   userEvent.click(screen.getByText('Smartcards'));
-  screen.getByRole('heading', { name: 'Election Cards' });
+  await screen.findByRole('heading', { name: 'Election Cards' });
   userEvent.click(screen.getByText('Create Super Admin Cards'));
-  screen.getByRole('heading', { name: 'Super Admin Cards' });
+  await screen.findByRole('heading', { name: 'Super Admin Cards' });
   userEvent.click(screen.getByText('Create Election Cards'));
-  screen.getByRole('heading', { name: 'Election Cards' });
-});
+  await screen.findByRole('heading', { name: 'Election Cards' });
 
-test('super admin smartcard modal', async () => {
-  jest.useFakeTimers();
-  mockOf(areVvsg2AuthFlowsEnabled).mockImplementation(() => true);
-
-  const card = new MemoryCard();
-  const hardware = MemoryHardware.buildStandard();
-  const storage = await createMemoryStorageWith({
-    electionDefinition: eitherNeitherElectionDefinition,
-  });
-  render(<App card={card} hardware={hardware} storage={storage} />);
-  await authenticateWithSuperAdminCard(card);
-
-  let modal: HTMLElement;
-  const blankCard = undefined;
-  const programmedCard1 = makeAdminCard(
-    eitherNeitherElectionDefinition.electionHash
-  );
-  const programmedCard2 = makeSuperadminCard();
-
-  // The smartcard modal should open on any screen, not just the Smartcards screen
-  await screen.findByRole('heading', { name: 'Election Definition' });
-  card.insertCard(blankCard);
-  modal = await screen.findByRole('alertdialog');
-  within(modal).getByRole('heading', { name: 'Program Election Card' });
-  card.removeCard();
-  await waitFor(() =>
-    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
-  );
-  await screen.findByRole('heading', { name: 'Election Definition' });
-
-  card.insertCard(programmedCard1);
-  modal = await screen.findByRole('alertdialog');
-  within(modal).getByRole('heading', { name: 'Card Details' });
-  card.removeCard();
-  await waitFor(() =>
-    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
-  );
-  await screen.findByRole('heading', { name: 'Election Definition' });
-
-  card.insertCard(programmedCard2);
-  modal = await screen.findByRole('alertdialog');
-  within(modal).getByRole('heading', { name: 'Card Details' });
-  card.removeCard();
-  await waitFor(() =>
-    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
-  );
-  await screen.findByRole('heading', { name: 'Election Definition' });
-
-  userEvent.click(screen.getByText('Smartcards'));
-  userEvent.click(screen.getByText('Create Super Admin Cards'));
-  await screen.findByRole('heading', { name: 'Super Admin Cards' });
-  card.insertCard(blankCard);
-  modal = await screen.findByRole('alertdialog');
-  within(modal).getByRole('heading', { name: 'Program Super Admin Card' });
-  card.removeCard();
-  await waitFor(() =>
-    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
-  );
-  await screen.findByRole('heading', { name: 'Super Admin Cards' });
-
-  card.insertCard(programmedCard1);
-  modal = await screen.findByRole('alertdialog');
-  within(modal).getByRole('heading', { name: 'Card Details' });
-  card.removeCard();
-  await waitFor(() =>
-    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
-  );
-  await screen.findByRole('heading', { name: 'Super Admin Cards' });
-});
-
-test('super admin smartcard modal when no election', async () => {
-  jest.useFakeTimers();
-  mockOf(areVvsg2AuthFlowsEnabled).mockImplementation(() => true);
-
-  const card = new MemoryCard();
-  const hardware = MemoryHardware.buildStandard();
-  const storage = new MemoryStorage();
-  render(<App card={card} hardware={hardware} storage={storage} />);
-  await authenticateWithSuperAdminCard(card);
-
-  const programmedCard = makeAdminCard(
-    eitherNeitherElectionDefinition.electionHash
-  );
-
-  await screen.findByRole('heading', { name: 'Configure VxAdmin' });
-  card.insertCard(programmedCard);
-  const modal = await screen.findByRole('alertdialog');
-  within(modal).getByRole('heading', { name: 'Card Details' });
-  card.removeCard();
-  await waitFor(() =>
-    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
-  );
-  await screen.findByRole('heading', { name: 'Configure VxAdmin' });
+  // The smartcard modal and smartcard programming flows are tested in smartcard_modal.test.tsx
 });

--- a/frontends/election-manager/src/components/smartcard_modal/pins.test.ts
+++ b/frontends/election-manager/src/components/smartcard_modal/pins.test.ts
@@ -1,0 +1,28 @@
+import { generatePin, hyphenatePin } from './pins';
+
+test('generatePin generates PINs', () => {
+  const digitRegex = new RegExp('^[0-9]+$');
+
+  expect(generatePin().length).toEqual(6);
+  expect(generatePin().match(digitRegex)).toBeTruthy();
+
+  expect(generatePin(10).length).toEqual(10);
+  expect(generatePin(10).match(digitRegex)).toBeTruthy();
+
+  expect(() => generatePin(0)).toThrow('PIN length must be greater than 0');
+  expect(() => generatePin(-1)).toThrow('PIN length must be greater than 0');
+});
+
+test('hyphenatePin hyphenates PINs', () => {
+  expect(hyphenatePin('123456')).toEqual('123-456');
+  expect(hyphenatePin('123456', 2)).toEqual('12-34-56');
+  expect(hyphenatePin('123456', 4)).toEqual('1234-56');
+  expect(hyphenatePin('123456', 6)).toEqual('123456');
+
+  expect(() => hyphenatePin('123456', 0)).toThrow(
+    'Segment length must be greater than 0'
+  );
+  expect(() => hyphenatePin('123456', -1)).toThrow(
+    'Segment length must be greater than 0'
+  );
+});

--- a/frontends/election-manager/src/components/smartcard_modal/pins.ts
+++ b/frontends/election-manager/src/components/smartcard_modal/pins.ts
@@ -1,0 +1,30 @@
+/**
+ * generatePin generates a random numeric PIN of the specified length (default = 6)
+ */
+export function generatePin(length = 6): string {
+  if (length < 1) {
+    throw new Error('PIN length must be greater than 0');
+  }
+
+  let pin = '';
+  for (let i = 0; i < length; i += 1) {
+    pin += `${Math.floor(Math.random() * 10)}`;
+  }
+  return pin;
+}
+
+/**
+ * hyphenatePin adds hyphens to the provided pin, creating segments of the specified length
+ * (default = 3), e.g. turning '123456' into '123-456'
+ */
+export function hyphenatePin(pin: string, segmentLength = 3): string {
+  if (segmentLength < 1) {
+    throw new Error('Segment length must be greater than 0');
+  }
+
+  const segments: string[] = [];
+  for (let i = 0; i < pin.length; i += segmentLength) {
+    segments.push(pin.substring(i, i + segmentLength));
+  }
+  return segments.join('-');
+}

--- a/frontends/election-manager/src/components/smartcard_modal/program_election_card_view.tsx
+++ b/frontends/election-manager/src/components/smartcard_modal/program_election_card_view.tsx
@@ -1,38 +1,92 @@
 import React, { useContext } from 'react';
-import { Button } from '@votingworks/ui';
+import { Button, Prose } from '@votingworks/ui';
 import { CardProgramming } from '@votingworks/types';
 
 import { AppContext } from '../../contexts/app_context';
+import { generatePin } from './pins';
+import { SmartcardActionStatus, StatusMessage } from './status_message';
 
 interface Props {
+  actionStatus?: SmartcardActionStatus;
   card: CardProgramming;
+  setActionStatus: (status?: SmartcardActionStatus) => void;
 }
 
-export function ProgramElectionCardView({ card }: Props): JSX.Element {
+export function ProgramElectionCardView({
+  actionStatus,
+  card,
+  setActionStatus,
+}: Props): JSX.Element {
   const { electionDefinition } = useContext(AppContext);
 
+  async function programAdminCard() {
+    if (!electionDefinition) {
+      return;
+    }
+    setActionStatus({
+      action: 'Program',
+      role: 'admin',
+      status: 'InProgress',
+    });
+    const result = await card.programUser({
+      role: 'admin',
+      electionData: electionDefinition.electionData,
+      electionHash: electionDefinition.electionHash,
+      passcode: generatePin(),
+    });
+    setActionStatus({
+      action: 'Program',
+      role: 'admin',
+      status: result.isOk() ? 'Success' : 'Error',
+    });
+  }
+
+  async function programPollWorkerCard() {
+    if (!electionDefinition) {
+      return;
+    }
+    setActionStatus({
+      action: 'Program',
+      role: 'pollworker',
+      status: 'InProgress',
+    });
+    const result = await card.programUser({
+      role: 'pollworker',
+      electionHash: electionDefinition.electionHash,
+    });
+    setActionStatus({
+      action: 'Program',
+      role: 'pollworker',
+      status: result.isOk() ? 'Success' : 'Error',
+    });
+  }
+
   return (
-    <React.Fragment>
+    <Prose textCenter>
       <h2>Program Election Card</h2>
-      <Button
-        disabled={!electionDefinition}
-        onPress={() =>
-          card.programUser({
-            role: 'admin',
-            electionHash: electionDefinition?.electionHash || '',
-            passcode: '000000',
-            electionData: electionDefinition?.electionData || '',
-          })
-        }
-      >
-        Program
-      </Button>
-      {!electionDefinition && (
+      {/* An empty div to maintain space between the header and subsequent p. TODO: Consider adding
+        a `maintainSpaceBelowHeaders` prop to `Prose` */}
+      <div />
+      {actionStatus && <StatusMessage actionStatus={actionStatus} />}
+      {electionDefinition ? (
+        <p>Admin and Poll Worker cards only work for the current election.</p>
+      ) : (
         <p>
           An election must be defined before Admin and Poll Worker cards can be
           programmed.
         </p>
       )}
-    </React.Fragment>
+      <p>Remove card to leave card unprogrammed.</p>
+      <p>
+        <Button disabled={!electionDefinition} onPress={programAdminCard}>
+          Program Admin Card
+        </Button>
+      </p>
+      <p>
+        <Button disabled={!electionDefinition} onPress={programPollWorkerCard}>
+          Program Poll Worker Card
+        </Button>
+      </p>
+    </Prose>
   );
 }

--- a/frontends/election-manager/src/components/smartcard_modal/program_super_admin_card_view.tsx
+++ b/frontends/election-manager/src/components/smartcard_modal/program_super_admin_card_view.tsx
@@ -1,18 +1,51 @@
 import React from 'react';
-import { Button } from '@votingworks/ui';
+import { Button, Prose } from '@votingworks/ui';
 import { CardProgramming } from '@votingworks/types';
 
+import { SmartcardActionStatus, StatusMessage } from './status_message';
+
 interface Props {
+  actionStatus?: SmartcardActionStatus;
   card: CardProgramming;
+  setActionStatus: (status?: SmartcardActionStatus) => void;
 }
 
-export function ProgramSuperAdminCardView({ card }: Props): JSX.Element {
+export function ProgramSuperAdminCardView({
+  actionStatus,
+  card,
+  setActionStatus,
+}: Props): JSX.Element {
+  async function programSuperAdminCard() {
+    setActionStatus({
+      action: 'Program',
+      role: 'superadmin',
+      status: 'InProgress',
+    });
+    const result = await card.programUser({ role: 'superadmin' });
+    setActionStatus({
+      action: 'Program',
+      role: 'superadmin',
+      status: result.isOk() ? 'Success' : 'Error',
+    });
+  }
+
   return (
-    <React.Fragment>
+    <Prose textCenter>
       <h2>Program Super Admin Card</h2>
-      <Button onPress={() => card.programUser({ role: 'superadmin' })}>
-        Program
-      </Button>
-    </React.Fragment>
+      {/* An empty div to maintain space between the header and subsequent p. TODO: Consider adding
+        a `maintainSpaceBelowHeaders` prop to `Prose` */}
+      <div />
+      {actionStatus && <StatusMessage actionStatus={actionStatus} />}
+      <p>
+        This card performs all system actions. Strictly limit the number created
+        and keep all Super Admin cards secure.
+      </p>
+      <p>Remove card to leave card unprogrammed.</p>
+      <p>
+        <Button onPress={programSuperAdminCard}>
+          Program Super Admin Card
+        </Button>
+      </p>
+    </Prose>
   );
 }

--- a/frontends/election-manager/src/components/smartcard_modal/smartcard_modal.test.tsx
+++ b/frontends/election-manager/src/components/smartcard_modal/smartcard_modal.test.tsx
@@ -1,0 +1,631 @@
+import fetchMock from 'fetch-mock';
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { AdminUser, AnyCardData, PollworkerUser } from '@votingworks/types';
+import {
+  assert,
+  MemoryCard,
+  MemoryHardware,
+  MemoryStorage,
+  throwIllegalValue,
+  typedAs,
+} from '@votingworks/utils';
+import {
+  electionSampleDefinition,
+  electionSample2Definition,
+} from '@votingworks/fixtures';
+import {
+  makeAdminCard,
+  makePollWorkerCard,
+  makeSuperadminCard,
+  makeVoterCard,
+  mockOf,
+} from '@votingworks/test-utils';
+import { render, screen, waitFor, within } from '@testing-library/react';
+
+import { App } from '../../app';
+import { areVvsg2AuthFlowsEnabled } from '../../config/features';
+import { createMemoryStorageWith } from '../../../test/util/create_memory_storage_with';
+import { generatePin } from './pins';
+import { MachineConfig } from '../../config/types';
+import { VxFiles } from '../../lib/converters';
+
+jest.mock(
+  '../../config/features',
+  (): typeof import('../../config/features') => {
+    return {
+      ...jest.requireActual('../../config/features'),
+      areVvsg2AuthFlowsEnabled: jest.fn(),
+    };
+  }
+);
+jest.mock('./pins', (): typeof import('./pins') => {
+  return {
+    ...jest.requireActual('./pins'),
+    generatePin: jest.fn(),
+  };
+});
+
+const electionDefinition = electionSampleDefinition;
+const { election, electionData, electionHash } = electionDefinition;
+const otherElectionHash = electionSample2Definition.electionHash;
+
+beforeEach(() => {
+  fetchMock.reset();
+  fetchMock.get(
+    '/convert/election/files',
+    typedAs<VxFiles>({ inputFiles: [], outputFiles: [] })
+  );
+  fetchMock.get(
+    '/machine-config',
+    typedAs<MachineConfig>({ codeVersion: '', machineId: '' })
+  );
+
+  mockOf(areVvsg2AuthFlowsEnabled).mockImplementation(() => true);
+  mockOf(generatePin).mockImplementation(() => '123456');
+});
+
+// TODO: Update this function to check super admin PIN entry once super admin PINs have been
+// implemented
+async function authenticateWithSuperAdminCard(card: MemoryCard) {
+  await screen.findByText('VxAdmin is Locked');
+  card.insertCard(makeSuperadminCard());
+  await screen.findByText('Remove card to continue.');
+  card.removeCard();
+  await screen.findByText('Lock Machine');
+}
+
+test('Smartcard modal displays card details', async () => {
+  const card = new MemoryCard();
+  const hardware = MemoryHardware.buildStandard();
+  const storage = await createMemoryStorageWith({ electionDefinition });
+  render(<App card={card} hardware={hardware} storage={storage} />);
+  await authenticateWithSuperAdminCard(card);
+
+  const testCases: Array<{
+    cardData: AnyCardData;
+    expectedRoleString: string;
+    expectedElectionString: string;
+    shouldResetCardPinButtonBeDisplayed: boolean;
+    shouldUnprogramCardButtonBeDisplayed: boolean;
+  }> = [
+    {
+      cardData: makeSuperadminCard(),
+      expectedRoleString: 'Super Admin',
+      expectedElectionString: 'N/A',
+      shouldResetCardPinButtonBeDisplayed: false,
+      shouldUnprogramCardButtonBeDisplayed: false,
+    },
+    {
+      cardData: makeAdminCard(electionHash),
+      expectedRoleString: 'Admin',
+      expectedElectionString: 'General Election — Tuesday, November 3, 2020',
+      shouldResetCardPinButtonBeDisplayed: true,
+      shouldUnprogramCardButtonBeDisplayed: true,
+    },
+    {
+      cardData: makePollWorkerCard(electionHash),
+      expectedRoleString: 'Poll Worker',
+      expectedElectionString: 'General Election — Tuesday, November 3, 2020',
+      shouldResetCardPinButtonBeDisplayed: false,
+      shouldUnprogramCardButtonBeDisplayed: true,
+    },
+    {
+      cardData: makeVoterCard(election),
+      expectedRoleString: 'Voter',
+      expectedElectionString: 'Unknown',
+      shouldResetCardPinButtonBeDisplayed: false,
+      shouldUnprogramCardButtonBeDisplayed: false,
+    },
+    {
+      cardData: makeAdminCard(otherElectionHash),
+      expectedRoleString: 'Admin',
+      expectedElectionString: 'Unknown',
+      shouldResetCardPinButtonBeDisplayed: false,
+      shouldUnprogramCardButtonBeDisplayed: true,
+    },
+    {
+      cardData: makePollWorkerCard(otherElectionHash),
+      expectedRoleString: 'Poll Worker',
+      expectedElectionString: 'Unknown',
+      shouldResetCardPinButtonBeDisplayed: false,
+      shouldUnprogramCardButtonBeDisplayed: true,
+    },
+  ];
+
+  // The smartcard modal should open on any screen, not just the Smartcards screen
+  await screen.findByRole('heading', { name: 'Election Definition' });
+
+  for (const testCase of testCases) {
+    const {
+      cardData,
+      expectedRoleString,
+      expectedElectionString,
+      shouldResetCardPinButtonBeDisplayed,
+      shouldUnprogramCardButtonBeDisplayed,
+    } = testCase;
+
+    card.insertCard(cardData);
+    const modal = await screen.findByRole('alertdialog');
+    within(modal).getByRole('heading', { name: 'Card Details' });
+    within(modal).getByText(expectedRoleString);
+    within(modal).getByText(expectedElectionString);
+    within(modal).getByText('Remove card to leave this screen.');
+    if (shouldResetCardPinButtonBeDisplayed) {
+      within(modal).getByRole('button', { name: 'Reset Card PIN' });
+    } else {
+      expect(
+        within(modal).queryByRole('button', { name: 'Reset Card PIN' })
+      ).not.toBeInTheDocument();
+    }
+    if (shouldUnprogramCardButtonBeDisplayed) {
+      within(modal).getByRole('button', { name: 'Unprogram Card' });
+    } else {
+      expect(
+        within(modal).queryByRole('button', { name: 'Unprogram Card' })
+      ).not.toBeInTheDocument();
+    }
+    card.removeCard();
+    await waitFor(() =>
+      expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+    );
+    await screen.findByRole('heading', { name: 'Election Definition' });
+  }
+});
+
+test('Smartcard modal displays card details when no election definition on machine', async () => {
+  const card = new MemoryCard();
+  const hardware = MemoryHardware.buildStandard();
+  const storage = new MemoryStorage();
+  render(<App card={card} hardware={hardware} storage={storage} />);
+  await authenticateWithSuperAdminCard(card);
+
+  const testCases: Array<{
+    cardData: AnyCardData;
+    expectedRoleString: string;
+    expectedElectionString: string;
+  }> = [
+    {
+      cardData: makeSuperadminCard(),
+      expectedRoleString: 'Super Admin',
+      expectedElectionString: 'N/A',
+    },
+    {
+      cardData: makeAdminCard(electionHash),
+      expectedRoleString: 'Admin',
+      expectedElectionString: 'Unknown',
+    },
+    {
+      cardData: makePollWorkerCard(electionHash),
+      expectedRoleString: 'Poll Worker',
+      expectedElectionString: 'Unknown',
+    },
+    {
+      cardData: makeVoterCard(election),
+      expectedRoleString: 'Voter',
+      expectedElectionString: 'Unknown',
+    },
+  ];
+
+  await screen.findByRole('heading', { name: 'Configure VxAdmin' });
+
+  for (const testCase of testCases) {
+    const { cardData, expectedRoleString, expectedElectionString } = testCase;
+
+    card.insertCard(cardData);
+    const modal = await screen.findByRole('alertdialog');
+    within(modal).getByRole('heading', { name: 'Card Details' });
+    within(modal).getByText(expectedRoleString);
+    within(modal).getByText(expectedElectionString);
+    within(modal).getByText('Remove card to leave this screen.');
+    expect(within(modal).queryAllByRole('button')).toEqual([]);
+    card.removeCard();
+    await waitFor(() =>
+      expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+    );
+    await screen.findByRole('heading', { name: 'Configure VxAdmin' });
+  }
+});
+
+test('Programming admin and poll worker smartcards', async () => {
+  const card = new MemoryCard();
+  const hardware = MemoryHardware.buildStandard();
+  const storage = await createMemoryStorageWith({ electionDefinition });
+  render(<App card={card} hardware={hardware} storage={storage} />);
+  await authenticateWithSuperAdminCard(card);
+
+  const testCases: Array<{
+    role: AdminUser['role'] | PollworkerUser['role'];
+    expectedProgressText: string;
+    expectedSuccessText: string;
+    shouldCardHavePin: boolean;
+    expectedRoleString: string;
+    expectedCardLongString?: string;
+  }> = [
+    {
+      role: 'admin',
+      expectedProgressText: 'Programming Admin card',
+      expectedSuccessText: 'New Admin card has been programmed.',
+      shouldCardHavePin: true,
+      expectedRoleString: 'Admin',
+      expectedCardLongString: electionData,
+    },
+    {
+      role: 'pollworker',
+      expectedProgressText: 'Programming Poll Worker card',
+      expectedSuccessText: 'New Poll Worker card has been programmed.',
+      shouldCardHavePin: false,
+      expectedRoleString: 'Poll Worker',
+      expectedCardLongString: undefined,
+    },
+  ];
+
+  // The smartcard modal should open on any screen, not just the Smartcards screen
+  await screen.findByRole('heading', { name: 'Election Definition' });
+
+  for (const testCase of testCases) {
+    const {
+      role,
+      expectedProgressText,
+      expectedSuccessText,
+      shouldCardHavePin,
+      expectedRoleString,
+      expectedCardLongString,
+    } = testCase;
+
+    card.insertCard(); // Blank card
+    const modal = await screen.findByRole('alertdialog');
+    within(modal).getByRole('heading', { name: 'Program Election Card' });
+    within(modal).getByText(
+      'Admin and Poll Worker cards only work for the current election.'
+    );
+    within(modal).getByText('Remove card to leave card unprogrammed.');
+    const programAdminCardButton = within(modal).getByRole('button', {
+      name: 'Program Admin Card',
+    });
+    const programPollWorkerCardButton = within(modal).getByRole('button', {
+      name: 'Program Poll Worker Card',
+    });
+    switch (role) {
+      case 'admin': {
+        userEvent.click(programAdminCardButton);
+        break;
+      }
+      case 'pollworker': {
+        userEvent.click(programPollWorkerCardButton);
+        break;
+      }
+      default: {
+        throwIllegalValue(role);
+      }
+    }
+    await screen.findByText(new RegExp(expectedProgressText));
+    await within(modal).findByRole('heading', { name: 'Card Details' });
+    within(modal).getByText(new RegExp(expectedSuccessText));
+    if (shouldCardHavePin) {
+      within(modal).getByText(/The card PIN is 123-456. Write this PIN down./);
+    }
+    within(modal).getByText(expectedRoleString);
+    within(modal).getByText('General Election — Tuesday, November 3, 2020');
+    within(modal).getByText('Remove card to leave this screen.');
+    if (shouldCardHavePin) {
+      // PIN resetting is disabled right after a card has been created
+      expect(
+        within(modal).getByRole('button', { name: 'Reset Card PIN' })
+      ).toHaveAttribute('disabled');
+    } else {
+      expect(
+        within(modal).queryByRole('button', { name: 'Reset Card PIN' })
+      ).not.toBeInTheDocument();
+    }
+    within(modal).getByRole('button', { name: 'Unprogram Card' });
+    expect(await card.readLongString()).toEqual(expectedCardLongString);
+    card.removeCard();
+    await waitFor(() =>
+      expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+    );
+    // For some reason, finding by role doesn't work here, though 'Election Definition' is present
+    // in a heading
+    await screen.findByText('Election Definition');
+  }
+});
+
+test('Programming super admin smartcards', async () => {
+  const card = new MemoryCard();
+  const hardware = MemoryHardware.buildStandard();
+  const storage = await createMemoryStorageWith({ electionDefinition });
+  render(<App card={card} hardware={hardware} storage={storage} />);
+  await authenticateWithSuperAdminCard(card);
+
+  // Programming super admin smartcards requires being on a specific screen
+  userEvent.click(screen.getByText('Smartcards'));
+  userEvent.click(await screen.findByText('Create Super Admin Cards'));
+  await screen.findByRole('heading', { name: 'Super Admin Cards' });
+
+  card.insertCard(); // Blank card
+  const modal = await screen.findByRole('alertdialog');
+  within(modal).getByRole('heading', { name: 'Program Super Admin Card' });
+  within(modal).getByText(
+    'This card performs all system actions. ' +
+      'Strictly limit the number created and keep all Super Admin cards secure.'
+  );
+  within(modal).getByText('Remove card to leave card unprogrammed.');
+  userEvent.click(
+    within(modal).getByRole('button', { name: 'Program Super Admin Card' })
+  );
+  await screen.findByText(/Programming Super Admin card/);
+  await within(modal).findByRole('heading', { name: 'Card Details' });
+  within(modal).getByText(/New Super Admin card has been programmed./);
+  within(modal).getByText('Super Admin');
+  within(modal).getByText('N/A'); // Card election
+  within(modal).getByText('Remove card to leave this screen.');
+  expect(within(modal).queryAllByRole('button')).toEqual([]);
+  card.removeCard();
+  await waitFor(() =>
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+  );
+  // For some reason, finding by role doesn't work here, though 'Super Admin Cards' is present in a
+  // heading
+  await screen.findByText('Super Admin Cards');
+});
+
+test('Programming smartcards when no election definition on machine', async () => {
+  const card = new MemoryCard();
+  const hardware = MemoryHardware.buildStandard();
+  const storage = new MemoryStorage();
+  render(<App card={card} hardware={hardware} storage={storage} />);
+  await authenticateWithSuperAdminCard(card);
+
+  await screen.findByRole('heading', { name: 'Configure VxAdmin' });
+
+  card.insertCard(); // Blank card
+  const modal = await screen.findByRole('alertdialog');
+  within(modal).getByRole('heading', { name: 'Program Election Card' });
+  within(modal).getByText(
+    'An election must be defined before Admin and Poll Worker cards can be programmed.'
+  );
+  within(modal).getByText('Remove card to leave card unprogrammed.');
+  expect(
+    within(modal).getByRole('button', { name: 'Program Admin Card' })
+  ).toHaveAttribute('disabled');
+  expect(
+    within(modal).getByRole('button', { name: 'Program Poll Worker Card' })
+  ).toHaveAttribute('disabled');
+  card.removeCard();
+  await waitFor(() =>
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+  );
+  await screen.findByRole('heading', { name: 'Configure VxAdmin' });
+});
+
+test('Resetting smartcard PINs', async () => {
+  const card = new MemoryCard();
+  const hardware = MemoryHardware.buildStandard();
+  const storage = await createMemoryStorageWith({ electionDefinition });
+  render(<App card={card} hardware={hardware} storage={storage} />);
+  await authenticateWithSuperAdminCard(card);
+
+  const oldPin = '000000';
+  const newPin = '123456';
+  mockOf(generatePin).mockImplementation(() => newPin);
+
+  // The smartcard modal should open on any screen, not just the Smartcards screen
+  await screen.findByRole('heading', { name: 'Election Definition' });
+
+  // Fully mock an admin card
+  card.insertCard(makeAdminCard(electionHash, oldPin));
+  await card.writeLongUint8Array(new TextEncoder().encode(electionData));
+  const summaryBefore = await card.readSummary();
+  const shortValueBefore =
+    summaryBefore.status === 'ready' ? summaryBefore.shortValue : undefined;
+  const longValueBefore = await card.readLongString();
+  expect(shortValueBefore).toContain(oldPin);
+  expect(longValueBefore).toEqual(electionData);
+  assert(shortValueBefore !== undefined);
+  assert(longValueBefore !== undefined);
+
+  const modal = await screen.findByRole('alertdialog');
+  within(modal).getByRole('heading', { name: 'Card Details' });
+  userEvent.click(
+    within(modal).getByRole('button', { name: 'Reset Card PIN' })
+  );
+  await screen.findByText(/Resetting Admin card PIN/);
+  await within(modal).findByText(/Admin card PIN has been reset./);
+  await within(modal).findByText(
+    /The new PIN is 123-456. Write this PIN down./
+  );
+
+  // Verify that the card PIN and nothing else was changed under the hood
+  const summaryAfter = await card.readSummary();
+  const shortValueAfter =
+    summaryAfter.status === 'ready' ? summaryAfter.shortValue : undefined;
+  const longValueAfter = await card.readLongString();
+  expect(shortValueAfter).toEqual(shortValueBefore.replace(oldPin, newPin));
+  expect(longValueAfter).toEqual(longValueBefore);
+
+  card.removeCard();
+  await waitFor(() =>
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+  );
+  // For some reason, finding by role doesn't work here, though 'Election Definition' is present
+  // in a heading
+  await screen.findByText('Election Definition');
+});
+
+test('Unprogramming smartcards', async () => {
+  const card = new MemoryCard();
+  const hardware = MemoryHardware.buildStandard();
+  const storage = await createMemoryStorageWith({ electionDefinition });
+  render(<App card={card} hardware={hardware} storage={storage} />);
+  await authenticateWithSuperAdminCard(card);
+
+  // The smartcard modal should open on any screen, not just the Smartcards screen
+  await screen.findByRole('heading', { name: 'Election Definition' });
+
+  const testCases: Array<{
+    cardData: AnyCardData;
+    expectedConfirmationText: string;
+    expectedSuccessText: string;
+  }> = [
+    {
+      cardData: makeAdminCard(electionHash),
+      expectedConfirmationText:
+        'Are you sure you want to unprogram this Admin card and delete all data on it?',
+      expectedSuccessText: 'Admin card has been unprogrammed.',
+    },
+    {
+      cardData: makePollWorkerCard(electionHash),
+      expectedConfirmationText:
+        'Are you sure you want to unprogram this Poll Worker card and delete all data on it?',
+      expectedSuccessText: 'Poll Worker card has been unprogrammed.',
+    },
+  ];
+
+  for (const testCase of testCases) {
+    const { cardData, expectedConfirmationText, expectedSuccessText } =
+      testCase;
+
+    card.insertCard(cardData);
+    const modal = await screen.findByRole('alertdialog');
+    within(modal).getByRole('heading', { name: 'Card Details' });
+
+    // Cancel the first time
+    userEvent.click(
+      within(modal).getByRole('button', { name: 'Unprogram Card' })
+    );
+    let confirmationModal: HTMLElement = (
+      await screen.findByRole('heading', { name: 'Unprogram Card' })
+    ).closest('[role="alertdialog"]')!;
+    await within(confirmationModal).findByText(expectedConfirmationText);
+    userEvent.click(
+      within(confirmationModal).getByRole('button', { name: 'Cancel' })
+    );
+    await waitFor(() => expect(confirmationModal).not.toBeInTheDocument());
+
+    // Go through with it the second time
+    userEvent.click(
+      within(modal).getByRole('button', { name: 'Unprogram Card' })
+    );
+    confirmationModal = (
+      await screen.findByRole('heading', { name: 'Unprogram Card' })
+    ).closest('[role="alertdialog"]')!;
+    await within(confirmationModal).findByText(expectedConfirmationText);
+    userEvent.click(
+      within(confirmationModal).getByRole('button', { name: 'Yes' })
+    );
+    await within(confirmationModal).findByText(/Deleting all data on card/);
+    await waitFor(() => expect(confirmationModal).not.toBeInTheDocument());
+    await within(modal).findByRole('heading', {
+      name: 'Program Election Card',
+    });
+    within(modal).getByText(expectedSuccessText);
+
+    card.removeCard();
+    await waitFor(() =>
+      expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+    );
+    // For some reason, finding by role doesn't work here, though 'Election Definition' is present
+    // in a heading
+    await screen.findByText('Election Definition');
+  }
+});
+
+test('Error handling', async () => {
+  const card = new MemoryCard();
+  const hardware = MemoryHardware.buildStandard();
+  const storage = await createMemoryStorageWith({ electionDefinition });
+  render(<App card={card} hardware={hardware} storage={storage} />);
+  await authenticateWithSuperAdminCard(card);
+
+  card.overrideWriteProtection = jest.fn();
+  mockOf(card.overrideWriteProtection).mockImplementation(() =>
+    Promise.reject(new Error('Whoa!'))
+  );
+
+  const testCases: Array<{
+    beginFromSuperAdminCardsScreen?: boolean;
+    cardData?: AnyCardData;
+    buttonToPress: string;
+    confirmButtonToPress?: string;
+    expectedProgressText: string;
+    expectedErrorText: string;
+  }> = [
+    {
+      cardData: undefined,
+      buttonToPress: 'Program Admin Card',
+      expectedProgressText: 'Programming Admin card',
+      expectedErrorText: 'Error programming Admin card. Please try again.',
+    },
+    {
+      cardData: undefined,
+      buttonToPress: 'Program Poll Worker Card',
+      expectedProgressText: 'Programming Poll Worker card',
+      expectedErrorText:
+        'Error programming Poll Worker card. Please try again.',
+    },
+    {
+      beginFromSuperAdminCardsScreen: true,
+      cardData: undefined,
+      buttonToPress: 'Program Super Admin Card',
+      expectedProgressText: 'Programming Super Admin card',
+      expectedErrorText:
+        'Error programming Super Admin card. Please try again.',
+    },
+    {
+      cardData: makeAdminCard(electionHash),
+      buttonToPress: 'Reset Card PIN',
+      expectedProgressText: 'Resetting Admin card PIN',
+      expectedErrorText: 'Error resetting Admin card PIN. Please try again.',
+    },
+    {
+      cardData: makeAdminCard(electionHash),
+      buttonToPress: 'Unprogram Card',
+      confirmButtonToPress: 'Yes',
+      expectedProgressText: 'Deleting all data on card',
+      expectedErrorText: 'Error unprogramming Admin card. Please try again.',
+    },
+    {
+      cardData: makePollWorkerCard(electionHash),
+      buttonToPress: 'Unprogram Card',
+      confirmButtonToPress: 'Yes',
+      expectedProgressText: 'Deleting all data on card',
+      expectedErrorText:
+        'Error unprogramming Poll Worker card. Please try again.',
+    },
+  ];
+
+  for (const testCase of testCases) {
+    const {
+      beginFromSuperAdminCardsScreen,
+      cardData,
+      buttonToPress,
+      confirmButtonToPress,
+      expectedProgressText,
+      expectedErrorText,
+    } = testCase;
+
+    if (beginFromSuperAdminCardsScreen) {
+      userEvent.click(screen.getByText('Smartcards'));
+      userEvent.click(await screen.findByText('Create Super Admin Cards'));
+      await screen.findByText('Super Admin Cards');
+    } else {
+      userEvent.click(screen.getByText('Smartcards'));
+      await screen.findByText('Election Cards');
+    }
+
+    card.insertCard(cardData);
+    const modal = await screen.findByRole('alertdialog');
+    userEvent.click(within(modal).getByRole('button', { name: buttonToPress }));
+    if (confirmButtonToPress) {
+      userEvent.click(
+        await screen.findByRole('button', { name: confirmButtonToPress })
+      );
+    }
+    await screen.findByText(new RegExp(expectedProgressText));
+    await within(modal).findByText(expectedErrorText);
+    card.removeCard();
+    await waitFor(() =>
+      expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+    );
+  }
+});

--- a/frontends/election-manager/src/components/smartcard_modal/smartcard_modal.tsx
+++ b/frontends/election-manager/src/components/smartcard_modal/smartcard_modal.tsx
@@ -1,7 +1,7 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { assert } from '@votingworks/utils';
-import { isSuperadminAuth, Modal, Prose } from '@votingworks/ui';
+import { isSuperadminAuth, Modal } from '@votingworks/ui';
 import { useLocation } from 'react-router-dom';
 
 import { AppContext } from '../../contexts/app_context';
@@ -9,6 +9,7 @@ import { CardDetailsView } from './card_details_view';
 import { ProgramElectionCardView } from './program_election_card_view';
 import { ProgramSuperAdminCardView } from './program_super_admin_card_view';
 import { routerPaths } from '../../router_paths';
+import { SmartcardActionStatus } from './status_message';
 
 const ModalContents = styled.div`
   padding: 1rem;
@@ -16,9 +17,16 @@ const ModalContents = styled.div`
 
 export function SmartcardModal(): JSX.Element | null {
   const { auth } = useContext(AppContext);
-  const location = useLocation();
-
   assert(isSuperadminAuth(auth));
+  const location = useLocation();
+  const [actionStatus, setActionStatus] = useState<SmartcardActionStatus>();
+
+  useEffect(() => {
+    // Clear the current status message when the card is removed
+    if (!auth.card) {
+      setActionStatus(undefined);
+    }
+  }, [auth.card]);
 
   // Auto-open the modal when a card is inserted, and auto-close the modal when a card is removed
   if (!auth.card) {
@@ -31,22 +39,31 @@ export function SmartcardModal(): JSX.Element | null {
 
   let contents: JSX.Element;
   if (auth.card.programmedUser) {
-    contents = <CardDetailsView card={auth.card} />;
+    contents = (
+      <CardDetailsView
+        actionStatus={actionStatus}
+        card={auth.card}
+        setActionStatus={setActionStatus}
+      />
+    );
   } else if (onSuperAdminSmartcardsScreen) {
-    contents = <ProgramSuperAdminCardView card={auth.card} />;
+    contents = (
+      <ProgramSuperAdminCardView
+        actionStatus={actionStatus}
+        card={auth.card}
+        setActionStatus={setActionStatus}
+      />
+    );
   } else {
-    contents = <ProgramElectionCardView card={auth.card} />;
+    contents = (
+      <ProgramElectionCardView
+        actionStatus={actionStatus}
+        card={auth.card}
+        setActionStatus={setActionStatus}
+      />
+    );
   }
   return (
-    <Modal
-      content={
-        <ModalContents>
-          <Prose maxWidth={false} textCenter>
-            {contents}
-          </Prose>
-        </ModalContents>
-      }
-      fullscreen
-    />
+    <Modal content={<ModalContents>{contents}</ModalContents>} fullscreen />
   );
 }

--- a/frontends/election-manager/src/components/smartcard_modal/status_message.tsx
+++ b/frontends/election-manager/src/components/smartcard_modal/status_message.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { Loading, Modal, Text } from '@votingworks/ui';
+import { throwIllegalValue } from '@votingworks/utils';
+import { User, UserRole } from '@votingworks/types';
+
+import { hyphenatePin } from './pins';
+import { userRoleToReadableString } from './user_roles';
+
+export interface SmartcardActionStatus {
+  action: 'Program' | 'PinReset' | 'Unprogram';
+  role: UserRole;
+  status: 'Success' | 'Error' | 'InProgress';
+}
+
+interface Props {
+  actionStatus: SmartcardActionStatus;
+  programmedUser?: User;
+}
+
+/**
+ * StatusMessage facilitates display of status messages across smartcard modal views
+ */
+export function StatusMessage({
+  actionStatus,
+  programmedUser,
+}: Props): JSX.Element | null {
+  const { action, status } = actionStatus;
+  const actionRoleReadableString = userRoleToReadableString(actionStatus.role);
+
+  if (status === 'Error') {
+    let text: string;
+    switch (action) {
+      case 'Program': {
+        text = `Error programming ${actionRoleReadableString} card.`;
+        break;
+      }
+      case 'PinReset': {
+        text = `Error resetting ${actionRoleReadableString} card PIN.`;
+        break;
+      }
+      case 'Unprogram': {
+        text = `Error unprogramming ${actionRoleReadableString} card.`;
+        break;
+      }
+      default: {
+        throwIllegalValue(action);
+      }
+    }
+    return <Text error>{text} Please try again.</Text>;
+  }
+
+  if (status === 'InProgress') {
+    let text: string;
+    switch (action) {
+      case 'Program': {
+        text = `Programming ${actionRoleReadableString} card`;
+        break;
+      }
+      case 'PinReset': {
+        text = `Resetting ${actionRoleReadableString} card PIN`;
+        break;
+      }
+      case 'Unprogram': {
+        // Handled in UnprogramCardConfirmationModal
+        return null;
+      }
+      default: {
+        throwIllegalValue(action);
+      }
+    }
+    return <Modal content={<Loading as="p">{text}</Loading>} />;
+  }
+
+  if (action === 'Program' && programmedUser) {
+    return (
+      <Text success>
+        New {actionRoleReadableString} card has been programmed.
+        {'passcode' in programmedUser && (
+          <React.Fragment>
+            <br />
+            The card PIN is {hyphenatePin(programmedUser.passcode)}. Write this
+            PIN down.
+          </React.Fragment>
+        )}
+      </Text>
+    );
+  }
+
+  if (action === 'PinReset' && programmedUser && 'passcode' in programmedUser) {
+    return (
+      <Text success>
+        {actionRoleReadableString} card PIN has been reset.
+        <br />
+        The new PIN is {hyphenatePin(programmedUser.passcode)}. Write this PIN
+        down.
+      </Text>
+    );
+  }
+
+  if (action === 'Unprogram') {
+    return (
+      <Text success>
+        {actionRoleReadableString} card has been unprogrammed.
+      </Text>
+    );
+  }
+
+  return null;
+}

--- a/frontends/election-manager/src/components/smartcard_modal/unprogram_card_confirmation_modal.tsx
+++ b/frontends/election-manager/src/components/smartcard_modal/unprogram_card_confirmation_modal.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { Button, Loading, Modal, Prose } from '@votingworks/ui';
+import { CardProgramming, UserRole } from '@votingworks/types';
+
+import { SmartcardActionStatus } from './status_message';
+import { userRoleToReadableString } from './user_roles';
+
+interface Props {
+  actionStatus?: SmartcardActionStatus;
+  card: CardProgramming;
+  closeModal: () => void;
+  programmedUserRole: UserRole;
+  setActionStatus: (status?: SmartcardActionStatus) => void;
+}
+
+export function UnprogramCardConfirmationModal({
+  actionStatus,
+  card,
+  closeModal,
+  programmedUserRole,
+  setActionStatus,
+}: Props): JSX.Element {
+  async function unprogramCard() {
+    setActionStatus({
+      action: 'Unprogram',
+      role: programmedUserRole,
+      status: 'InProgress',
+    });
+    const result = await card.unprogramUser();
+    setActionStatus({
+      action: 'Unprogram',
+      role: programmedUserRole,
+      status: result.isOk() ? 'Success' : 'Error',
+    });
+    closeModal();
+  }
+
+  if (
+    actionStatus?.action === 'Unprogram' &&
+    actionStatus?.status === 'InProgress'
+  ) {
+    return (
+      <Modal content={<Loading as="p">Deleting all data on card</Loading>} />
+    );
+  }
+
+  return (
+    <Modal
+      content={
+        <Prose textCenter>
+          <h2>Unprogram Card</h2>
+          <p>
+            Are you sure you want to unprogram this{' '}
+            {userRoleToReadableString(programmedUserRole)} card and delete all
+            data on it?
+          </p>
+        </Prose>
+      }
+      actions={
+        <React.Fragment>
+          <Button onPress={closeModal}>Cancel</Button>
+          <Button onPress={unprogramCard} danger>
+            Yes
+          </Button>
+        </React.Fragment>
+      }
+    />
+  );
+}

--- a/frontends/election-manager/src/components/smartcard_modal/user_roles.ts
+++ b/frontends/election-manager/src/components/smartcard_modal/user_roles.ts
@@ -1,0 +1,19 @@
+import { throwIllegalValue } from '@votingworks/utils';
+import { UserRole } from '@votingworks/types';
+
+export function userRoleToReadableString(userRole: UserRole): string {
+  switch (userRole) {
+    case 'superadmin':
+      return 'Super Admin';
+    case 'admin':
+      return 'Admin';
+    case 'pollworker':
+      return 'Poll Worker';
+    case 'voter':
+      return 'Voter';
+    case 'cardless_voter':
+      return 'Cardless Voter';
+    default:
+      throwIllegalValue(userRole);
+  }
+}

--- a/frontends/election-manager/test/util/create_memory_storage_with.ts
+++ b/frontends/election-manager/test/util/create_memory_storage_with.ts
@@ -1,0 +1,29 @@
+import { ElectionDefinition } from '@votingworks/types';
+import { MemoryStorage } from '@votingworks/utils';
+
+import { CastVoteRecordFiles } from '../../src/utils/cast_vote_record_files';
+import {
+  configuredAtStorageKey,
+  cvrsStorageKey,
+  electionDefinitionStorageKey,
+} from '../../src/app_root';
+
+export async function createMemoryStorageWith({
+  electionDefinition,
+  crvFile,
+}: {
+  electionDefinition: ElectionDefinition;
+  crvFile?: File;
+}): Promise<MemoryStorage> {
+  const storage = new MemoryStorage();
+  await storage.set(electionDefinitionStorageKey, electionDefinition);
+  if (crvFile) {
+    const castVoteRecordFiles = await CastVoteRecordFiles.empty.add(
+      crvFile,
+      electionDefinition.election
+    );
+    await storage.set(cvrsStorageKey, castVoteRecordFiles.export());
+  }
+  await storage.set(configuredAtStorageKey, new Date().toISOString());
+  return storage;
+}


### PR DESCRIPTION
_Commit by commit reviewing recommended_

## Overview

Issue link(s): https://github.com/votingworks/vxsuite/issues/1919, https://github.com/votingworks/vxsuite/issues/1920, https://github.com/votingworks/vxsuite/issues/1921

This PR completes the new smartcard programming UIs!

Apologies in advance for the hefty PR! Though it's a lot of lines, the majority of the PR is tests. I'd initially planned to implement each screen (card details, election card programming, and super admin card programming) separately but found that it was helpful to think about them holistically since they share information, e.g. successfully programming a card on a card programming screen drops you on the card details screen with a success message, etc. I've tried to make reviewing as easy as possible by chunking the PR and leaving comments in GitHub to guide reviewing but obviously take your time and let me know if you have any questions!

## Demo screenshots and videos

There are a lot of states that this UI can be in. Below are a video and screenshots that capture many of them, and the tests cover even more states.

https://user-images.githubusercontent.com/12616928/179774513-c93755ce-c21e-4446-86e5-6c0392cdd293.mov

### Smartcard details screens

_Super admin card_

<img src="https://user-images.githubusercontent.com/12616928/179774843-1b7a4d41-868d-473c-9122-f9571ef523c7.png" alt="super-admin" width="600" />

_Admin card_

<img src="https://user-images.githubusercontent.com/12616928/179774840-70fd92fb-06d7-456b-ba7f-de89933d0d70.png" alt="admin" width="600" />

_Poll worker card_

<img src="https://user-images.githubusercontent.com/12616928/179774842-ba71c291-f5ab-473c-b12f-adace8dcfa0a.png" alt="poll-worker" width="600" />

_Admin card programmed for a prior election_

<img src="https://user-images.githubusercontent.com/12616928/179774837-fad08937-aba9-4b80-a74f-9f3a9c2afdb4.png" alt="admin-prior-election" width="600" />

### Smartcard programming screens

_Election card programming_

<img src="https://user-images.githubusercontent.com/12616928/179775550-e9d8bbbc-9edf-405c-9934-9ed674130203.png" alt="election-cards" width="600" />

_Super admin card programming_

<img src="https://user-images.githubusercontent.com/12616928/179775552-dd90a418-1e58-461e-9bdd-00af4abef89c.png" alt="super-admin-cards" width="600" />

_Election card programming when no election definition_

<img src="https://user-images.githubusercontent.com/12616928/179775551-3c614a9d-16b6-4889-863e-5653625bd721.png" alt="no-election-definition" width="600" />

### Smartcard action states

_Program success_

<img src="https://user-images.githubusercontent.com/12616928/179776193-e36f7db6-190d-4da4-86f3-e8e9d3f3db8b.png" alt="program-success" width="600" />

_PIN reset success_

<img src="https://user-images.githubusercontent.com/12616928/179776189-ba90ef1f-9e2f-4469-9eb5-a3b7acdadef9.png" alt="pin-reset-success" width="600" />

_Unprogram success_

<img src="https://user-images.githubusercontent.com/12616928/179776199-5d2dcf73-d93e-40e8-b111-37d99a837801.png" alt="unprogram-success" width="600" />

_Unprogram confirmation modal_

<img src="https://user-images.githubusercontent.com/12616928/179776198-abad6f56-194c-4bb7-9965-b9de8ef43507.png" alt="unprogram-confirmation-modal" width="600" />

_Progress modal_

<img src="https://user-images.githubusercontent.com/12616928/179776196-1f2ec5c9-7a71-479a-9be0-cfb0bb689393.png" alt="progress-modal" width="600" />

_Error_

<img src="https://user-images.githubusercontent.com/12616928/179776191-f7e2386d-54f9-49cc-bca2-0931ad645b53.png" alt="program-error" width="600" />

## Testing

- [x] Added tests covering all possible states (I'm pretty sure but will double check 😝)
- [x] Tested all possible states manually

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced (Covered in a prior lower-level PR: https://github.com/votingworks/vxsuite/pull/2140)
- [x] I have added JSDoc comments to any newly introduced exports
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates