### PR TITLE
Pull in `nh-demo` admin service endpoints and add tests

### DIFF
--- a/services/admin/src/server.test.ts
+++ b/services/admin/src/server.test.ts
@@ -146,6 +146,16 @@ test('GET /admin/write-ins/adjudications/:contestId/', async () => {
     ]);
 });
 
+test('GET /admin/write-ins/adjudications/counts', async () => {
+  workspace.store.getAdjudicationCountsByContestIdAndTranscribedValue =
+    jest.fn();
+
+  await request(app).get('/admin/write-ins/adjudications/counts').expect(200);
+  expect(
+    workspace.store.getAdjudicationCountsByContestIdAndTranscribedValue
+  ).toHaveBeenCalled();
+});
+
 test('GET /admin/write-ins/adjudications/contestId/count', async () => {
   await request(app)
     .get('/admin/write-ins/adjudications/contestId/count')

--- a/services/admin/src/server.test.ts
+++ b/services/admin/src/server.test.ts
@@ -176,6 +176,12 @@ test('GET /admin/write-ins/cvr-files', async () => {
   expect(workspace.store.getAllCvrFiles).toHaveBeenCalled();
 });
 
+test('GET /admin/write-ins/cvr-ballot-ids', async () => {
+  workspace.store.getAllCvrBallotIds = jest.fn();
+  await request(app).get('/admin/write-ins/cvr-ballot-ids').expect(200);
+  expect(workspace.store.getAllCvrBallotIds).toHaveBeenCalled();
+});
+
 test('POST /admin/write-ins/cvrs', async () => {
   const cvrFileId = '2';
   workspace.store.addCvr = jest.fn().mockImplementationOnce(() => '1');

--- a/services/admin/src/server.test.ts
+++ b/services/admin/src/server.test.ts
@@ -198,6 +198,19 @@ test('GET /admin/write-ins/cvrs', async () => {
   expect(workspace.store.getAllCvrs).toHaveBeenCalled();
 });
 
+test('GET /admin/write-ins/adjudication/:id/cvr', async () => {
+  jest
+    .spyOn(workspace.store, 'getCvrByAdjudicationId')
+    .mockImplementationOnce(() => {
+      return 'test CVR';
+    })
+    .mockImplementationOnce(() => {
+      return undefined;
+    });
+  await request(app).get('/admin/write-ins/adjudication/1/cvr').expect(200);
+  await request(app).get('/admin/write-ins/adjudication/2/cvr').expect(404);
+});
+
 test('POST /admin/write-ins/cvrs', async () => {
   const cvrFileId = '2';
   workspace.store.addCvr = jest.fn().mockImplementationOnce(() => '1');

--- a/services/admin/src/server.test.ts
+++ b/services/admin/src/server.test.ts
@@ -170,6 +170,12 @@ test('GET /admin/write-ins/reset', async () => {
   expect(workspace.store.deleteCvrs).toHaveBeenCalled();
 });
 
+test('GET /admin/write-ins/cvr-files', async () => {
+  workspace.store.getAllCvrFiles = jest.fn();
+  await request(app).get('/admin/write-ins/cvr-files').expect(200);
+  expect(workspace.store.getAllCvrFiles).toHaveBeenCalled();
+});
+
 test('POST /admin/write-ins/cvrs', async () => {
   const cvrFileId = '2';
   workspace.store.addCvr = jest.fn().mockImplementationOnce(() => '1');

--- a/services/admin/src/server.test.ts
+++ b/services/admin/src/server.test.ts
@@ -182,6 +182,12 @@ test('GET /admin/write-ins/cvr-ballot-ids', async () => {
   expect(workspace.store.getAllCvrBallotIds).toHaveBeenCalled();
 });
 
+test('GET /admin/write-ins/cvrs', async () => {
+  workspace.store.getAllCvrs = jest.fn();
+  await request(app).get('/admin/write-ins/cvrs').expect(200);
+  expect(workspace.store.getAllCvrs).toHaveBeenCalled();
+});
+
 test('POST /admin/write-ins/cvrs', async () => {
   const cvrFileId = '2';
   workspace.store.addCvr = jest.fn().mockImplementationOnce(() => '1');

--- a/services/admin/src/server.ts
+++ b/services/admin/src/server.ts
@@ -25,6 +25,11 @@ export function buildApp({ store }: { store: Store }): Application {
     response.status(200).json({ status: 'ok' });
   });
 
+  app.get<NoParams>('/admin/write-ins/cvr-files', (_, response) => {
+    const cvrFiles = store.getAllCvrFiles();
+    response.json(cvrFiles);
+  });
+
   app.get('/admin/write-ins/adjudication/:id', (request, response) => {
     const { id } = request.params;
 

--- a/services/admin/src/server.ts
+++ b/services/admin/src/server.ts
@@ -17,7 +17,7 @@ export function buildApp({ store }: { store: Store }): Application {
   const app: Application = express();
 
   app.use(express.raw());
-  app.use(express.json({ limit: '5mb', type: 'application/json' }));
+  app.use(express.json({ limit: '50mb', type: 'application/json' }));
   app.use(express.urlencoded({ extended: false }));
 
   app.get<NoParams>('/admin/write-ins/cvrs/reset', (_, response) => {

--- a/services/admin/src/server.ts
+++ b/services/admin/src/server.ts
@@ -35,6 +35,11 @@ export function buildApp({ store }: { store: Store }): Application {
     response.json(ballotIds);
   });
 
+  app.get<NoParams>('/admin/write-ins/cvrs', (_, response) => {
+    const cvrs = store.getAllCvrs();
+    response.json(cvrs);
+  });
+
   app.get('/admin/write-ins/adjudication/:id', (request, response) => {
     const { id } = request.params;
 

--- a/services/admin/src/server.ts
+++ b/services/admin/src/server.ts
@@ -40,6 +40,18 @@ export function buildApp({ store }: { store: Store }): Application {
     response.json(cvrs);
   });
 
+  app.get('/admin/write-ins/adjudication/:id/cvr', (request, response) => {
+    const { id } = request.params;
+
+    const cvr = store.getCvrByAdjudicationId(id);
+    console.log(cvr);
+    if (cvr) {
+      response.json(cvr);
+    } else {
+      response.status(404).end();
+    }
+  });
+
   app.get('/admin/write-ins/adjudication/:id', (request, response) => {
     const { id } = request.params;
 

--- a/services/admin/src/server.ts
+++ b/services/admin/src/server.ts
@@ -30,6 +30,11 @@ export function buildApp({ store }: { store: Store }): Application {
     response.json(cvrFiles);
   });
 
+  app.get<NoParams>('/admin/write-ins/cvr-ballot-ids', (_, response) => {
+    const ballotIds = store.getAllCvrBallotIds();
+    response.json(ballotIds);
+  });
+
   app.get('/admin/write-ins/adjudication/:id', (request, response) => {
     const { id } = request.params;
 

--- a/services/admin/src/server.ts
+++ b/services/admin/src/server.ts
@@ -167,6 +167,10 @@ export function buildApp({ store }: { store: Store }): Application {
     }
   );
 
+  app.get<NoParams>('/admin/write-ins/adjudications/counts', (_, response) => {
+    response.json(store.getAdjudicationCountsByContestIdAndTranscribedValue());
+  });
+
   app.get('/admin/write-ins/adjudications/:contestId/', (request, response) => {
     const { contestId } = request.params;
     response.json(store.getAdjudicationsByContestId(contestId));

--- a/services/admin/src/server.ts
+++ b/services/admin/src/server.ts
@@ -44,7 +44,6 @@ export function buildApp({ store }: { store: Store }): Application {
     const { id } = request.params;
 
     const cvr = store.getCvrByAdjudicationId(id);
-    console.log(cvr);
     if (cvr) {
       response.json(cvr);
     } else {


### PR DESCRIPTION
## Overview
Closes #2153 

This pulls in the admin service `server.ts` changes from `nh-demo` and adds tests. Branched off of `nh-demo-admin-db` (https://github.com/votingworks/vxsuite/pull/2154)

## Testing Plan 
Automated tests.

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
