### PR TITLE
fix(bmd): make tally report printable

### DIFF
--- a/frontends/bmd/src/pages/poll_worker_screen.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.tsx
@@ -644,15 +644,15 @@ export function PollWorkerScreen({
             }
           />
         )}
-        {pollworkerCardHasTally && (
-          <PrecinctScannerTallyReportModal
-            pollworkerAuth={pollworkerAuth}
-            electionDefinition={electionDefinition}
-            machineConfig={machineConfig}
-            printer={printer}
-          />
-        )}
       </Screen>
+      {pollworkerCardHasTally && (
+        <PrecinctScannerTallyReportModal
+          pollworkerAuth={pollworkerAuth}
+          electionDefinition={electionDefinition}
+          machineConfig={machineConfig}
+          printer={printer}
+        />
+      )}
     </React.Fragment>
   );
 }


### PR DESCRIPTION
## Overview
Currently on `main`, printing a tally report results in printing only a blank page. In the refactor in #2017, the printed components were moved such that they were being treated as `display: none;`. This PR moves a component to fix that.

Our tests don't catch this sort of thing - they check that _something_ was printed and that the right thing is _in the DOM_, but it doesn't check that the right thing was printed from the DOM. At a first glance it looks like it would be hard to check this, and manual testing is necessary.

As far as I know, we don't have a good means of manual testing for printing tally reports. I worked some up locally and may make a PR for that. 

## Before
<img width="1512" alt="Screen Shot 2022-07-19 at 8 22 39 AM" src="https://user-images.githubusercontent.com/37960853/179787986-68de0bd0-174d-4082-bce1-41305d073f8b.png">

## After
<img width="1511" alt="Screen Shot 2022-07-19 at 8 22 21 AM" src="https://user-images.githubusercontent.com/37960853/179787997-cd812ef9-a101-49fe-8dba-e8280e01b637.png">
