### PR TITLE
feat(bmd): open/close polls when printing report

### DIFF
--- a/frontends/bmd/src/app_end_to_end.test.tsx
+++ b/frontends/bmd/src/app_end_to_end.test.tsx
@@ -394,10 +394,10 @@ it('MarkAndPrint end-to-end flow', async () => {
   );
   expect(writeLongUint8ArrayMock).toHaveBeenCalledTimes(3);
   await advanceTimersAndPromises();
-  await screen.findByText('Tally Report on Card');
-  fireEvent.click(screen.getByText('Print Tally Report'));
+  await screen.findByText('Polls Closed Report on Card');
+  fireEvent.click(screen.getByText('Print Polls Closed Report'));
   await advanceTimersAndPromises();
-  screen.getByText('Printing tally report');
+  screen.getByText('Printing polls closed report');
   await advanceTimersAndPromises(REPORT_PRINTING_TIMEOUT_SECONDS);
   expect(printer.print).toHaveBeenCalledTimes(2);
 

--- a/frontends/bmd/src/app_end_to_end.test.tsx
+++ b/frontends/bmd/src/app_end_to_end.test.tsx
@@ -395,7 +395,7 @@ it('MarkAndPrint end-to-end flow', async () => {
   expect(writeLongUint8ArrayMock).toHaveBeenCalledTimes(3);
   await advanceTimersAndPromises();
   await screen.findByText('Polls Closed Report on Card');
-  fireEvent.click(screen.getByText('Print Polls Closed Report'));
+  fireEvent.click(screen.getByText('Close Polls and Print Report'));
   await advanceTimersAndPromises();
   screen.getByText('Printing polls closed report');
   await advanceTimersAndPromises(REPORT_PRINTING_TIMEOUT_SECONDS);

--- a/frontends/bmd/src/pages/poll_worker_screen.test.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.test.tsx
@@ -148,7 +148,7 @@ function expectContestResultsInReport(
 
 async function printPollsClosedReport() {
   await screen.findByText('Polls Closed Report on Card');
-  fireEvent.click(screen.getByText('Print Polls Closed Report'));
+  fireEvent.click(screen.getByText('Close Polls and Print Report'));
 
   // check that print starts and finishes
   await screen.findByText('Printing polls closed report');
@@ -1243,7 +1243,7 @@ test('printing polls opened report clears card and opens the polls', async () =>
 
   // print report and open polls
   screen.getByText('Polls Opened Report on Card');
-  fireEvent.click(screen.getByText('Print Polls Opened Report'));
+  fireEvent.click(screen.getByText('Open Polls and Print Report'));
 
   // check that the print started
   await waitFor(() => {
@@ -1302,7 +1302,7 @@ test('printing polls closed report clears card and closes the polls', async () =
 
   // print report and close polls
   screen.getByText('Polls Closed Report on Card');
-  fireEvent.click(screen.getByText('Print Polls Closed Report'));
+  fireEvent.click(screen.getByText('Close Polls and Print Report'));
 
   // check that the print started
   await waitFor(() => {

--- a/frontends/bmd/src/pages/poll_worker_screen.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.tsx
@@ -120,11 +120,15 @@ function PrecinctScannerTallyReportModal({
   pollworkerAuth,
   printer,
   machineConfig,
+  isPollsOpen,
+  togglePollsOpen,
 }: {
   electionDefinition: ElectionDefinition;
   pollworkerAuth: InsertedSmartcardAuth.PollworkerLoggedIn;
   printer: Printer;
   machineConfig: MachineConfig;
+  isPollsOpen: boolean;
+  togglePollsOpen: () => void;
 }) {
   const [precinctScannerTally, setPrecinctScannerTally] =
     useState<PrecinctScannerCardTally>();
@@ -153,12 +157,22 @@ function PrecinctScannerTallyReportModal({
       parties
     );
 
-  async function printReport() {
+  function togglePollsToMatchReport() {
+    if (
+      precinctScannerTally &&
+      precinctScannerTally.isPollsOpen !== isPollsOpen
+    ) {
+      togglePollsOpen();
+    }
+  }
+
+  async function printReportAndTogglePolls() {
     setIsPrinting(true);
     try {
       await printer.print({ sides: 'one-sided' });
       await sleep(REPORT_PRINTING_TIMEOUT_SECONDS * 1000);
       await pollworkerAuth.card.clearStoredData();
+      togglePollsToMatchReport();
     } finally {
       setIsPrinting(false);
       setPrecinctScannerTally(undefined);
@@ -177,19 +191,33 @@ function PrecinctScannerTallyReportModal({
         <Modal
           content={
             <Prose id="modalaudiofocus">
-              <h1>Tally Report on Card</h1>
-              <p>
-                This poll worker card contains a tally report. The report will
-                be cleared from the card after being printed.
-              </p>
+              {precinctScannerTally.isPollsOpen ? (
+                <React.Fragment>
+                  <h1>Polls Opened Report on Card</h1>
+                  <p>
+                    This poll worker card contains a polls opened report. After
+                    printing, the report will be cleared from the card and the
+                    polls will be opened on VxMark.
+                  </p>
+                </React.Fragment>
+              ) : (
+                <React.Fragment>
+                  <h1>Polls Closed Report on Card</h1>
+                  <p>
+                    This poll worker card contains a polls closed report. After
+                    printing, the report will be cleared from the card and the
+                    polls will be closed on VxMark.
+                  </p>
+                </React.Fragment>
+              )}
             </Prose>
           }
           actions={
-            <React.Fragment>
-              <Button primary onPress={printReport}>
-                Print Tally Report
-              </Button>
-            </React.Fragment>
+            <Button primary onPress={printReportAndTogglePolls}>
+              {precinctScannerTally.isPollsOpen
+                ? 'Print Polls Opened Report'
+                : 'Print Polls Closed Report'}
+            </Button>
           }
         />
       )}
@@ -197,7 +225,11 @@ function PrecinctScannerTallyReportModal({
         <Modal
           content={
             <Prose textCenter id="modalaudiofocus">
-              <Loading>Printing tally report</Loading>
+              <Loading>
+                {precinctScannerTally.isPollsOpen
+                  ? 'Printing polls opened report'
+                  : 'Printing polls closed report'}
+              </Loading>
             </Prose>
           }
         />
@@ -367,14 +399,6 @@ export function PollWorkerScreen({
     setIsConfirmingEnableLiveMode(false);
   }
 
-  function handleTogglePollsOpen() {
-    if (pollworkerCardHasTally) {
-      togglePollsOpen();
-    } else {
-      setIsShowingVxScanPollsOpenModal(true);
-    }
-  }
-
   if (hasVotes && pollworkerAuth.activatedCardlessVoter) {
     return (
       <Screen>
@@ -540,7 +564,11 @@ export function PollWorkerScreen({
               )}
             </Text>
             <p>
-              <Button primary large onPress={handleTogglePollsOpen}>
+              <Button
+                primary
+                large
+                onPress={() => setIsShowingVxScanPollsOpenModal(true)}
+              >
                 {isPollsOpen
                   ? `Close Polls for ${precinctName}`
                   : `Open Polls for ${precinctName}`}
@@ -651,6 +679,8 @@ export function PollWorkerScreen({
           electionDefinition={electionDefinition}
           machineConfig={machineConfig}
           printer={printer}
+          isPollsOpen={isPollsOpen}
+          togglePollsOpen={togglePollsOpen}
         />
       )}
     </React.Fragment>

--- a/frontends/bmd/src/pages/poll_worker_screen.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.tsx
@@ -215,8 +215,8 @@ function PrecinctScannerTallyReportModal({
           actions={
             <Button primary onPress={printReportAndTogglePolls}>
               {precinctScannerTally.isPollsOpen
-                ? 'Print Polls Opened Report'
-                : 'Print Polls Closed Report'}
+                ? 'Open Polls and Print Report'
+                : 'Close Polls and Print Report'}
             </Button>
           }
         />


### PR DESCRIPTION


## Overview
Closes #1311. When printing the polls opened or polls closed report on VxMark, the polls will open or close accordingly. Adjusted copy to avoid "Tally Report" language and use "Polls Opened Report" or "Polls Closed Report" language.

## Demo Video or Screenshot
<img width="1512" alt="Screen Shot 2022-07-19 at 11 42 47 AM" src="https://user-images.githubusercontent.com/37960853/179825501-a3116ec7-cc4f-46d0-830b-387aa0a2e6a8.png">
<img width="1512" alt="Screen Shot 2022-07-19 at 10 01 12 AM" src="https://user-images.githubusercontent.com/37960853/179808151-74f0afd7-f753-468c-905b-a4adff5d3a5f.png">
<img width="1512" alt="Screen Shot 2022-07-19 at 11 43 10 AM" src="https://user-images.githubusercontent.com/37960853/179825520-4542cf0f-ccce-48bc-b04c-8915db49f8ae.png">
<img width="1512" alt="Screen Shot 2022-07-19 at 10 02 12 AM" src="https://user-images.githubusercontent.com/37960853/179808162-da1076c2-98f5-4e47-aa96-0d05ba518cbf.png">

## Testing Plan 
- Create polls opening and poll closing tests in `poll_worker_screen.tsx`
- Manual testing

## Notes for Code Review
- Removed some logic and testing introduced in #2139 because there should be now no situation where the "Open / Close Polls" button is pressed directly while a tally report is loaded on the card.
- Removed some overly repeated assertions from tests that are covered by the new tests
- Logic is such that VxMark will _not_ toggle polls if the VxMark polls state already matches that of the report it is printing. In other words, it is just updating state to match the report. I thought that as a first pass, this behavior seemed safer. Say for some reason PWs have to reprint the report from VxScan - we wouldn't want it to re-open polls on VxMark.

## Checklist
- [ ] ~~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~~
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
