### PR TITLE
refactor(precinct-scanner): Clean up card auth

### DIFF
--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -26,13 +26,11 @@ import {
 } from '@votingworks/ui';
 import {
   throwIllegalValue,
-  PrecinctScannerCardTally,
   Card,
   Hardware,
   Storage,
   usbstick,
   Printer,
-  PrecinctScannerCardTallySchema,
   assert,
 } from '@votingworks/utils';
 import { Logger } from '@votingworks/logging';
@@ -625,17 +623,6 @@ export function AppRoot({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [electionDefinition, scannedBallotCount]);
 
-  const saveTallyToCard = useCallback(
-    async (cardTally: PrecinctScannerCardTally): Promise<boolean> => {
-      await card.writeLongObject(cardTally);
-      const possibleTally = await card.readLongObject(
-        PrecinctScannerCardTallySchema
-      );
-      return possibleTally.ok()?.timeSaved === cardTally.timeSaved;
-    },
-    [card]
-  );
-
   // Initialize app state
   useEffect(() => {
     async function initializeScanner() {
@@ -795,7 +782,6 @@ export function AppRoot({
           scannedBallotCount={scannedBallotCount}
           isPollsOpen={isPollsOpen}
           togglePollsOpen={togglePollsOpen}
-          saveTallyToCard={saveTallyToCard}
           getCvrsFromExport={getCvrsFromExport}
           printer={printer}
           hasPrinterAttached={!!printerInfo}

--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -89,8 +89,6 @@ export interface Props {
 }
 
 interface HardwareState {
-  adminCardElectionHash: string;
-  invalidCardPresent: boolean;
   machineConfig: Readonly<MachineConfig>;
 }
 
@@ -118,9 +116,6 @@ export interface State
     ScanInformationState {}
 
 const initialHardwareState: Readonly<HardwareState> = {
-  adminCardElectionHash: '',
-  // TODO add concept for invalid card to current user session object
-  invalidCardPresent: false,
   machineConfig: {
     machineId: '0000',
     codeVersion: 'dev',

--- a/frontends/precinct-scanner/src/screens/poll_worker_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/poll_worker_screen.test.tsx
@@ -47,7 +47,6 @@ function renderScreen({
         isPollsOpen={isPollsOpen}
         togglePollsOpen={jest.fn()}
         getCvrsFromExport={jest.fn().mockResolvedValue([])}
-        saveTallyToCard={jest.fn()}
         isLiveMode
         hasPrinterAttached={false}
         printer={new NullPrinter()}


### PR DESCRIPTION
## Overview
Two small changes related to card auth that I ran across:
- There are two unused app state fields probably related to an older iteration of card auth
- When writing the tally to the pollworker card, we used the `Card` interface directly instead of using the new smartcard auth interface

## Demo Video or Screenshot
N/A

## Testing Plan 
- Existing automated tests

