### PR TITLE
feat(bsd): reset batch count on mode toggle

### DIFF
--- a/services/scan/src/store.test.ts
+++ b/services/scan/src/store.test.ts
@@ -584,3 +584,31 @@ test('exportCvrs', () => {
   store.exportCvrs(stream);
   expect(stream.toString()).toEqual('');
 });
+
+test('zero', () => {
+  const dbFile = tmp.fileSync();
+  const store = Store.fileStore(dbFile.name);
+
+  store.addBatch();
+  store.addBatch();
+  expect(
+    store
+      .batchStatus()
+      .map((batch) => batch.label)
+      .sort((a, b) => a.localeCompare(b))
+  ).toEqual(['Batch 1', 'Batch 2']);
+
+  // zero should clear all batches
+  store.zero();
+  expect(store.batchStatus()).toEqual([]);
+
+  // zero should reset the autoincrement in the batch label
+  store.addBatch();
+  store.addBatch();
+  expect(
+    store
+      .batchStatus()
+      .map((batch) => batch.label)
+      .sort((a, b) => a.localeCompare(b))
+  ).toEqual(['Batch 1', 'Batch 2']);
+});

--- a/services/scan/src/store.ts
+++ b/services/scan/src/store.ts
@@ -555,6 +555,8 @@ export class Store {
 
   zero(): void {
     this.client.run('delete from batches');
+    // reset autoincrementing key on "batches" table
+    this.client.run("delete from sqlite_sequence where name = 'batches'");
   }
 
   getBallotFilenames(


### PR DESCRIPTION
## Overview
Closes #1610. When mode is toggled from live to test or vice versa, the incrementing number in the batch labels (e.g. 'Batch **2**') are reset to start at 1 again.

## Demo Video or Screenshot

### Previous Behavior
[batch-numbers-no-reset.webm](https://user-images.githubusercontent.com/37960853/179927518-71faa052-e4c6-4218-8405-9a3523b80267.webm)


### New Behavior
[batch-numbers-reset.webm](https://user-images.githubusercontent.com/37960853/179927532-42191d9f-5310-4384-85de-cbce0e5949eb.webm)


## Testing Plan 

## Checklist
- [ ] ~~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~~
- [ ] ~~I have added JSDoc comments to any newly introduced exports~~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
