### PR TITLE
refactor(precinct-scanner): Remove unnecessary setElection after config

### DIFF
--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -575,17 +575,6 @@ export function AppRoot({
     auth,
   ]);
 
-  const setElectionDefinition = useCallback(
-    async (newElectionDefinition: OptionalElectionDefinition) => {
-      dispatchAppState({
-        type: 'updateElectionDefinition',
-        electionDefinition: newElectionDefinition,
-      });
-      await refreshConfig();
-    },
-    [dispatchAppState, refreshConfig]
-  );
-
   const toggleTestMode = useCallback(async () => {
     await config.setTestMode(!isTestMode);
     dispatchAppState({ type: 'resetPollsToClosed' });
@@ -731,7 +720,7 @@ export function AppRoot({
     return (
       <UnconfiguredElectionScreen
         usbDriveStatus={usbDriveDisplayStatus}
-        setElectionDefinition={setElectionDefinition}
+        refreshConfig={refreshConfig}
       />
     );
   }

--- a/frontends/precinct-scanner/src/screens/unconfigured_election_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/unconfigured_election_screen.tsx
@@ -1,9 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { join } from 'path';
-import {
-  OptionalElectionDefinition,
-  getPrecinctById,
-} from '@votingworks/types';
+import { getPrecinctById } from '@votingworks/types';
 import {
   assert,
   readBallotPackageFromFilePointer,
@@ -22,14 +19,12 @@ import {
 
 interface Props {
   usbDriveStatus: usbstick.UsbDriveStatus;
-  setElectionDefinition: (
-    electionDefinition: OptionalElectionDefinition
-  ) => Promise<void>;
+  refreshConfig: () => Promise<void>;
 }
 
 export function UnconfiguredElectionScreen({
   usbDriveStatus,
-  setElectionDefinition,
+  refreshConfig,
 }: Props): JSX.Element {
   const [errorMessage, setErrorMessage] = useState('');
   const [isLoadingBallotPackage, setIsLoadingBallotPackage] = useState(false);
@@ -110,7 +105,7 @@ export function UnconfiguredElectionScreen({
             setLoadingTemplates(true);
             await doneTemplates();
             setLoadingTemplates(false);
-            await setElectionDefinition(ballotPackage.electionDefinition);
+            await refreshConfig();
           });
       } catch (error) {
         if (error instanceof Error) {
@@ -207,7 +202,7 @@ export function DefaultPreview(): JSX.Element {
   return (
     <UnconfiguredElectionScreen
       usbDriveStatus={usbstick.UsbDriveStatus.notavailable}
-      setElectionDefinition={() => Promise.resolve()}
+      refreshConfig={() => Promise.resolve()}
     />
   );
 }


### PR DESCRIPTION

## Overview
The setElection function was setting the election definition in app state and then calling refreshConfig, which already loads and sets the election definition. I simplified this to just call refreshConfig directly after finishing configuring.

## Demo Video or Screenshot
N/A
## Testing Plan 
- Existing unit tests
- Manually tested configuring
