### PR TITLE
refactor(precinct-scanner): Move getCvrsFromExport function

### DIFF
--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -8,7 +8,6 @@ import {
   AdjudicationReasonInfo,
   OptionalElectionDefinition,
   Provider,
-  CastVoteRecord,
   PrecinctId,
   ElectionDefinition,
 } from '@votingworks/types';
@@ -592,21 +591,6 @@ export function AppRoot({
   const scannedBallotCount = scanner?.status.ballotCount ?? 0;
   const canUnconfigure = scanner?.status.canUnconfigure ?? false;
 
-  const getCvrsFromExport = useCallback(async (): Promise<CastVoteRecord[]> => {
-    if (electionDefinition) {
-      const castVoteRecordsString = await scan.getExport();
-
-      const lines = castVoteRecordsString.split('\n');
-      const cvrs = lines.flatMap((line) =>
-        line.length > 0 ? (JSON.parse(line) as CastVoteRecord) : []
-      );
-      // TODO add more validation of the CVR, move the validation code from election-manager to utils
-      return cvrs.filter((cvr) => cvr._precinctId !== undefined);
-    }
-    return [];
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [electionDefinition, scannedBallotCount]);
-
   // Initialize app state
   useEffect(() => {
     async function initializeScanner() {
@@ -763,7 +747,6 @@ export function AppRoot({
           scannedBallotCount={scannedBallotCount}
           isPollsOpen={isPollsOpen}
           togglePollsOpen={togglePollsOpen}
-          getCvrsFromExport={getCvrsFromExport}
           printer={printer}
           hasPrinterAttached={!!printerInfo}
           isLiveMode={!isTestMode}

--- a/frontends/precinct-scanner/src/screens/poll_worker_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/poll_worker_screen.test.tsx
@@ -6,6 +6,7 @@ import MockDate from 'mockdate';
 import React from 'react';
 import { InsertedSmartcardAuth } from '@votingworks/types';
 import { mocked } from 'ts-jest/utils';
+import fetchMock from 'fetch-mock';
 import { AppContext } from '../contexts/app_context';
 import { PollWorkerScreen } from './poll_worker_screen';
 
@@ -18,6 +19,7 @@ MockDate.set('2020-10-31T00:00:00.000Z');
 beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
+  fetchMock.post('/scan/export', {});
 });
 
 afterEach(() => {
@@ -46,7 +48,6 @@ function renderScreen({
         scannedBallotCount={scannedBallotCount}
         isPollsOpen={isPollsOpen}
         togglePollsOpen={jest.fn()}
-        getCvrsFromExport={jest.fn().mockResolvedValue([])}
         isLiveMode
         hasPrinterAttached={false}
         printer={new NullPrinter()}


### PR DESCRIPTION


## Overview
This function didn't need to be a callback defined in AppRoot for any reason. In fact, it had extra guarding for the no-election-definition case even though it will only be called after configuration. I moved it into the pollworker screen component. More steps towards simplifying AppRoot so I can refactor it without breaking things.
## Demo Video or Screenshot
N/A

## Testing Plan 
- Existing automated tests

