### PR TITLE
refactor(bsd): don't require CVR export to unconfigure

### DIFF
--- a/services/scan/src/server.test.ts
+++ b/services/scan/src/server.test.ts
@@ -243,8 +243,7 @@ test('DELETE /config/election error', async () => {
 
 test('DELETE /config/election', async () => {
   importer.unconfigure.mockResolvedValue();
-  workspace.store.setBatchesAsBackedUp();
-  workspace.store.setCvrsAsBackedUp();
+  workspace.store.setScannerAsBackedUp();
 
   await request(app)
     .delete('/config/election')
@@ -398,8 +397,7 @@ test('POST /scan/zero error', async () => {
 
 test('POST /scan/zero', async () => {
   importer.doZero.mockResolvedValue();
-  workspace.store.setBatchesAsBackedUp();
-  workspace.store.setCvrsAsBackedUp();
+  workspace.store.setScannerAsBackedUp();
 
   await request(app)
     .post('/scan/zero')

--- a/services/scan/src/server.ts
+++ b/services/scan/src/server.ts
@@ -690,7 +690,7 @@ export function buildApp({ store, importer }: AppOptions): Application {
         });
       })
       .on('end', () => {
-        store.setBatchesAsBackedUp();
+        store.setScannerAsBackedUp();
       })
       .pipe(response);
   });

--- a/services/scan/src/store.test.ts
+++ b/services/scan/src/store.test.ts
@@ -298,8 +298,7 @@ test('canUnconfigure not in test mode', async () => {
 
   // Pause so timestamps are not equal
   await sleep(1000);
-  store.setBatchesAsBackedUp();
-  store.setCvrsAsBackedUp();
+  store.setScannerAsBackedUp();
   expect(store.getCanUnconfigure()).toBe(true);
 
   await sleep(1000);
@@ -325,8 +324,7 @@ test('canUnconfigure not in test mode', async () => {
   expect(store.getCanUnconfigure()).toBe(false);
 
   await sleep(1000);
-  store.setBatchesAsBackedUp();
-  store.setCvrsAsBackedUp();
+  store.setScannerAsBackedUp();
   expect(store.getCanUnconfigure()).toBe(true);
 
   // Delete the sheet, confirm that invalidates the backup/export
@@ -338,8 +336,7 @@ test('canUnconfigure not in test mode', async () => {
   const batchId2 = store.addBatch();
   // Pause before marking as exported so timestamps are not equal
   await sleep(1000);
-  store.setBatchesAsBackedUp();
-  store.setCvrsAsBackedUp();
+  store.setScannerAsBackedUp();
   expect(store.getCanUnconfigure()).toBe(true);
 
   // Delete the second batch, confirm that invalidates the backup/export

--- a/services/scan/src/store.ts
+++ b/services/scan/src/store.ts
@@ -59,7 +59,7 @@ export enum ConfigKey {
 }
 
 export enum BackupKey {
-  Batches = 'batches',
+  Scanner = 'scanner',
   Cvrs = 'cvrs',
 }
 
@@ -381,8 +381,8 @@ export class Store {
   /**
    * Records that batches have been backed up.
    */
-  setBatchesAsBackedUp(): void {
-    this.setBackupTimestamp(BackupKey.Batches);
+  setScannerAsBackedUp(): void {
+    this.setBackupTimestamp(BackupKey.Scanner);
   }
 
   /**
@@ -423,15 +423,14 @@ export class Store {
       return true;
     }
 
-    const batchesBackedUpAt = this.getBackupTimestamp(BackupKey.Batches);
-    const cvrsBackedUpAt = this.getBackupTimestamp(BackupKey.Cvrs);
+    const scannerBackedUpAt = this.getBackupTimestamp(BackupKey.Scanner);
 
     if (!this.batchStatus().length) {
       return true;
     }
 
-    // Require both batches and CVRs to have been backed up
-    if (!(cvrsBackedUpAt && batchesBackedUpAt)) {
+    // Require that a scanner backup has taken place
+    if (!scannerBackedUpAt) {
       return false;
     }
 
@@ -455,11 +454,14 @@ export class Store {
       .filter(Boolean)
       .reduce((max, curr) => (max > curr ? max : curr), '');
 
-    const isCvrsBackupUpToDate =
-      !cvrsLastUpdatedAt || cvrsBackedUpAt >= cvrsLastUpdatedAt;
-    const isBatchBackupUpToDate =
-      !batchesLastUpdatedAt || batchesBackedUpAt >= batchesLastUpdatedAt;
-    return isCvrsBackupUpToDate && isBatchBackupUpToDate;
+    if (!batchesLastUpdatedAt) {
+      return true;
+    }
+
+    const isBackupUpToDate =
+      scannerBackedUpAt >= cvrsLastUpdatedAt &&
+      scannerBackedUpAt >= batchesLastUpdatedAt;
+    return isBackupUpToDate;
   }
 
   addBallotCard(batchId: string): string {


### PR DESCRIPTION
## Overview
Closes #2063. There is a mismatch between our user flow and the `services/scan` logic. The UI indicates that doing an "Export Backup" is required to unconfigure the machine. But in fact, we require an up-to-date scanner backup _and_ an up-to-date CVR backup (a.k.a. a normal export). Because the CVR is already included in the backup, we are switching the logic to match the intended user flow

## Demo Video or Screenshot

### Current Behavior
[screen-capture (3).webm](https://user-images.githubusercontent.com/37960853/180057857-c2deec8a-6038-4f43-8471-c32cc9a2bf0f.webm)

### New Behavior
[screen-capture (4).webm](https://user-images.githubusercontent.com/37960853/180061041-78f4cc9f-6255-4c06-be6b-fa42de40f073.webm)

## Testing Plan 
- Updated test in `scan/services` to expect this behavior
- Manual Testing

## Checklist
- [ ] ~~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~~
- [ ] ~~I have added JSDoc comments to any newly introduced exports~~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
