### PR TITLE
refactor(types): consolidate `CastVoteRecord` interface

### DIFF
--- a/frontends/bsd/src/config/types.ts
+++ b/frontends/bsd/src/config/types.ts
@@ -1,13 +1,4 @@
-import {
-  BallotId,
-  BallotPageLayout,
-  BallotStyleId,
-  Dictionary,
-  ElectionDefinition,
-  MachineId,
-  MarkInfo,
-  PrecinctId,
-} from '@votingworks/types';
+import { ElectionDefinition, MachineId } from '@votingworks/types';
 import { z } from 'zod';
 
 export interface MachineConfig {
@@ -24,41 +15,6 @@ export const MachineConfigResponseSchema = MachineConfigSchema;
 
 // Events
 export type EventTargetFunction = (event: React.FormEvent<EventTarget>) => void;
-export type InputEvent = React.FormEvent<EventTarget>;
-export type ButtonEvent = React.MouseEvent<HTMLButtonElement>;
-export type ButtonEventFunction = (event: ButtonEvent) => void;
 
 // Election
 export type SetElectionDefinition = (value: ElectionDefinition) => void;
-
-// Scanner Types
-export interface CastVoteRecord
-  extends Dictionary<string | string[] | boolean> {
-  _precinctId: PrecinctId;
-  _ballotStyleId: BallotStyleId;
-  _ballotType: 'absentee' | 'provisional' | 'standard';
-  _ballotId: BallotId;
-  _testBallot: boolean;
-  _scannerId: string;
-}
-
-export type Ballot = BmdBallotInfo | HmpbBallotInfo | UnreadableBallotInfo;
-
-export interface BmdBallotInfo {
-  id: number;
-  filename: string;
-  cvr: CastVoteRecord;
-}
-
-export interface HmpbBallotInfo {
-  id: number;
-  filename: string;
-  cvr: CastVoteRecord;
-  marks: MarkInfo;
-  layout: BallotPageLayout;
-}
-
-export interface UnreadableBallotInfo {
-  id: number;
-  filename: string;
-}

--- a/frontends/election-manager/src/app_root.tsx
+++ b/frontends/election-manager/src/app_root.tsx
@@ -14,6 +14,7 @@ import {
   LogDispositionStandardTypes,
 } from '@votingworks/logging';
 import {
+  CastVoteRecord,
   ElectionDefinition,
   safeParseElection,
   FullElectionExternalTally,
@@ -52,7 +53,6 @@ import {
   ExportableTallies,
   ResultsFileType,
   MachineConfig,
-  CastVoteRecord,
   ConverterClientType,
 } from './config/types';
 import { getExportableTallies } from './utils/exportable_tallies';

--- a/frontends/election-manager/src/components/import_cvrfiles_modal.test.tsx
+++ b/frontends/election-manager/src/components/import_cvrfiles_modal.test.tsx
@@ -8,7 +8,11 @@ import {
 import { fakeKiosk, fakeUsbDrive } from '@votingworks/test-utils';
 
 import { usbstick } from '@votingworks/utils';
-import { BallotIdSchema, unsafeParse } from '@votingworks/types';
+import {
+  BallotIdSchema,
+  CastVoteRecord,
+  unsafeParse,
+} from '@votingworks/types';
 import { fakeLogger, LogEventId } from '@votingworks/logging';
 import { ImportCvrFilesModal } from './import_cvrfiles_modal';
 import {
@@ -16,7 +20,6 @@ import {
   eitherNeitherElectionDefinition,
 } from '../../test/render_in_app_context';
 import { CastVoteRecordFiles } from '../utils/cast_vote_record_files';
-import { CastVoteRecord } from '../config/types';
 
 const TEST_FILE1 = 'TEST__machine_0001__10_ballots__2020-12-09_15-49-32.jsonl';
 const TEST_FILE2 = 'TEST__machine_0003__5_ballots__2020-12-07_15-49-32.jsonl';

--- a/frontends/election-manager/src/config/types.ts
+++ b/frontends/election-manager/src/config/types.ts
@@ -1,8 +1,8 @@
 import {
-  BallotId,
   BallotLocale,
   BallotStyle,
   BallotStyleId,
+  CastVoteRecord,
   ContestTallyMeta,
   Dictionary,
   MachineId,
@@ -96,30 +96,13 @@ export interface ExternalFileConfiguration {
 }
 
 export enum ResultsFileType {
+  // eslint-disable-next-line @typescript-eslint/no-shadow
   CastVoteRecord = 'cvr',
   SEMS = 'sems',
   All = 'all',
   Manual = 'manual',
 }
 export type OptionalFile = Optional<File>;
-
-// Cast Vote Records
-export interface CastVoteRecord
-  extends Dictionary<
-    string | string[] | boolean | number | number[] | BallotLocale
-  > {
-  readonly _precinctId: PrecinctId;
-  readonly _ballotId: BallotId;
-  readonly _ballotStyleId: BallotStyleId;
-  readonly _ballotType: 'absentee' | 'provisional' | 'standard';
-  readonly _batchId: string;
-  readonly _batchLabel: string;
-  readonly _testBallot: boolean;
-  readonly _scannerId: string;
-  readonly _pageNumber?: number;
-  readonly _pageNumbers?: number[];
-  readonly _locales?: BallotLocale;
-}
 
 export type CastVoteRecordFileMode = 'test' | 'live';
 

--- a/frontends/election-manager/src/lib/votecounting.test.ts
+++ b/frontends/election-manager/src/lib/votecounting.test.ts
@@ -1,5 +1,6 @@
 import {
   BallotIdSchema,
+  CastVoteRecord,
   Election,
   FullElectionTally,
   TallyCategory,
@@ -21,7 +22,6 @@ import {
   getOvervotePairTallies,
   filterTalliesByParamsAndBatchId,
 } from './votecounting';
-import { CastVoteRecord } from '../config/types';
 
 const electionSample2 = electionSample2Fixtures.electionDefinition.election;
 

--- a/frontends/election-manager/src/lib/votecounting.ts
+++ b/frontends/election-manager/src/lib/votecounting.ts
@@ -1,6 +1,7 @@
 import {
   Candidate,
   CandidateContest,
+  CastVoteRecord,
   Contest,
   Election,
   Vote,
@@ -29,8 +30,6 @@ import {
   throwIllegalValue,
   typedAs,
 } from '@votingworks/utils';
-
-import { CastVoteRecord } from '../config/types';
 
 export interface ParseCastVoteRecordResult {
   cvr: CastVoteRecord;

--- a/frontends/election-manager/src/utils/cast_vote_record_files.test.ts
+++ b/frontends/election-manager/src/utils/cast_vote_record_files.test.ts
@@ -1,8 +1,11 @@
 import { electionSample } from '@votingworks/fixtures';
-import { BallotIdSchema, unsafeParse } from '@votingworks/types';
+import {
+  BallotIdSchema,
+  CastVoteRecord,
+  unsafeParse,
+} from '@votingworks/types';
 import { fakeKiosk } from '@votingworks/test-utils';
 import { CastVoteRecordFiles } from './cast_vote_record_files';
-import { CastVoteRecord } from '../config/types';
 
 const TEST_DATE = new Date(2020, 3, 14, 1, 59, 26);
 

--- a/frontends/election-manager/src/utils/cast_vote_record_files.ts
+++ b/frontends/election-manager/src/utils/cast_vote_record_files.ts
@@ -1,9 +1,8 @@
 import arrayUnique from 'array-unique';
 import { sha256 } from 'js-sha256';
-import { Election } from '@votingworks/types';
+import { CastVoteRecord, Election } from '@votingworks/types';
 import { assert, parseCvrFileInfoFromFilename } from '@votingworks/utils';
 import {
-  CastVoteRecord,
   CastVoteRecordFile,
   CastVoteRecordFilePreprocessedData,
   CastVoteRecordFileMode,
@@ -405,10 +404,10 @@ export class CastVoteRecordFiles {
       this.deduplicatedCastVoteRecords
     );
     for (const cvr of castVoteRecords) {
-      if (deduplicatedCastVoteRecords.has(cvr._ballotId)) {
+      if (deduplicatedCastVoteRecords.has(cvr._ballotId as string)) {
         duplicateCount += 1;
       } else {
-        deduplicatedCastVoteRecords.set(cvr._ballotId, cvr);
+        deduplicatedCastVoteRecords.set(cvr._ballotId as string, cvr);
       }
     }
     return [deduplicatedCastVoteRecords, duplicateCount];

--- a/frontends/election-manager/src/utils/exportable_tallies.test.ts
+++ b/frontends/election-manager/src/utils/exportable_tallies.test.ts
@@ -4,17 +4,14 @@ import {
 } from '@votingworks/fixtures';
 import {
   CandidateContest,
-  Election,
-  YesNoContest,
+  CastVoteRecord,
   ContestTally,
+  Election,
   VotingMethod,
   writeInCandidate,
+  YesNoContest,
 } from '@votingworks/types';
-import {
-  CastVoteRecord,
-  ExportableContestTally,
-  ExportableTallies,
-} from '../config/types';
+import { ExportableContestTally, ExportableTallies } from '../config/types';
 import { computeFullElectionTally, parseCvrs } from '../lib/votecounting';
 import {
   getCombinedExportableContestTally,

--- a/services/scan/src/build_cast_vote_record.test.ts
+++ b/services/scan/src/build_cast_vote_record.test.ts
@@ -72,7 +72,7 @@ test('getWriteInOptionIdsForContestVote', () => {
       } as unknown as AnyContest,
       {}
     )
-  ).toThrowError('contest type not yet supported: not-supported-type');
+  ).toThrowError('Illegal Value: not-supported-type');
 });
 
 test('getOptionIdsForContestVote', () => {

--- a/services/scan/src/build_cast_vote_record.ts
+++ b/services/scan/src/build_cast_vote_record.ts
@@ -94,8 +94,7 @@ export function getWriteInOptionIdsForContestVote(
   if (contest.type === 'ms-either-neither') {
     return [];
   }
-  // @ts-expect-error -- `contest` has type `never` since all known branches are covered
-  throw new TypeError(`contest type not yet supported: ${contest.type}`);
+  throwIllegalValue(contest, 'type');
 }
 
 export function getOptionIdsForContestVote(


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
We had three separate `CastVoteRecord` types. This commit consolidates on the one in `/types`. It also makes a couple other small improvements and removes some unused types I noticed along the way.

## Demo Video or Screenshot
n/a

## Testing Plan 
n/a
