### PR TITLE
Add PINs to super admin smartcards

### DIFF
--- a/frontends/bmd/src/app_end_to_end.test.tsx
+++ b/frontends/bmd/src/app_end_to_end.test.tsx
@@ -7,6 +7,7 @@ import {
   makeVoterCard,
   makePollWorkerCard,
   getZeroCompressedTally,
+  makeSuperadminCard,
 } from '@votingworks/test-utils';
 import {
   MemoryStorage,
@@ -407,9 +408,9 @@ it('MarkAndPrint end-to-end flow', async () => {
   await advanceTimersAndPromises();
 
   // Insert SuperAdmin card
-  card.insertCard({ t: 'superadmin' });
-  await advanceTimersAndPromises();
-  screen.getByText('Reboot from USB');
+  card.insertCard(makeSuperadminCard());
+  await authenticateAdminCard();
+  await screen.findByText('Reboot from USB');
   card.removeCard();
   await advanceTimersAndPromises();
 
@@ -428,7 +429,7 @@ it('MarkAndPrint end-to-end flow', async () => {
   screen.getByText('Device Not Configured');
 
   // Insert SuperAdmin card works when unconfigured
-  card.insertCard({ t: 'superadmin' });
-  await advanceTimersAndPromises();
-  screen.getByText('Reboot from USB');
+  card.insertCard(makeSuperadminCard());
+  await authenticateAdminCard();
+  await screen.findByText('Reboot from USB');
 });

--- a/frontends/bsd/src/app.test.tsx
+++ b/frontends/bsd/src/app.test.tsx
@@ -514,8 +514,14 @@ test('superadmin can log in', async () => {
   await screen.findByText('VxCentralScan is Locked');
 
   card.insertCard(makeSuperadminCard());
+  await screen.findByText('Enter the card security code to unlock.');
+  userEvent.click(screen.getByText('1'));
+  userEvent.click(screen.getByText('2'));
+  userEvent.click(screen.getByText('3'));
+  userEvent.click(screen.getByText('4'));
+  userEvent.click(screen.getByText('5'));
+  userEvent.click(screen.getByText('6'));
   await screen.findByText('Remove card to continue.');
-
   card.removeCard();
   await screen.findByText('Lock Machine');
 

--- a/frontends/election-manager/jest.config.js
+++ b/frontends/election-manager/jest.config.js
@@ -22,10 +22,10 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      statements: 77,
-      branches: 64,
-      functions: 74,
-      lines: 77,
+      statements: 80,
+      branches: 69,
+      functions: 76,
+      lines: 79,
     },
   },
   moduleFileExtensions: [

--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -37,7 +37,6 @@ import {
   VotingMethod,
 } from '@votingworks/types';
 import { LogEventId } from '@votingworks/logging';
-import { CARD_POLLING_INTERVAL } from '@votingworks/ui';
 
 import { externalVoteTalliesFileStorageKey } from './app_root';
 import { App } from './app';
@@ -139,29 +138,30 @@ async function authenticateWithAdminCard(card: MemoryCard) {
   card.insertCard(
     makeAdminCard(eitherNeitherElectionDefinition.electionHash, '123456')
   );
-  jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
   await screen.findByText('Enter the card security code to unlock.');
-  fireEvent.click(screen.getByText('1'));
-  fireEvent.click(screen.getByText('2'));
-  fireEvent.click(screen.getByText('3'));
-  fireEvent.click(screen.getByText('4'));
-  fireEvent.click(screen.getByText('5'));
-  fireEvent.click(screen.getByText('6'));
+  userEvent.click(screen.getByText('1'));
+  userEvent.click(screen.getByText('2'));
+  userEvent.click(screen.getByText('3'));
+  userEvent.click(screen.getByText('4'));
+  userEvent.click(screen.getByText('5'));
+  userEvent.click(screen.getByText('6'));
   await screen.findByText('Remove card to continue.');
   card.removeCard();
-  jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
   await screen.findByText('Lock Machine');
 }
 
-// TODO: Update this function to check super admin PIN entry once super admin PINs have been
-// implemented
 async function authenticateWithSuperAdminCard(card: MemoryCard) {
   await screen.findByText('VxAdmin is Locked');
   card.insertCard(makeSuperadminCard());
-  jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
+  await screen.findByText('Enter the card security code to unlock.');
+  userEvent.click(screen.getByText('1'));
+  userEvent.click(screen.getByText('2'));
+  userEvent.click(screen.getByText('3'));
+  userEvent.click(screen.getByText('4'));
+  userEvent.click(screen.getByText('5'));
+  userEvent.click(screen.getByText('6'));
   await screen.findByText('Remove card to continue.');
   card.removeCard();
-  jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
   await screen.findByText('Lock Machine');
 }
 

--- a/frontends/election-manager/src/components/smartcard_modal/card_details_view.tsx
+++ b/frontends/election-manager/src/components/smartcard_modal/card_details_view.tsx
@@ -82,6 +82,7 @@ export function CardDetailsView({
         });
         break;
       }
+      /* istanbul ignore next: Compile-time check for completeness */
       default: {
         throwIllegalValue(role);
       }

--- a/frontends/election-manager/src/components/smartcard_modal/program_election_card_view.tsx
+++ b/frontends/election-manager/src/components/smartcard_modal/program_election_card_view.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react';
+import { assert } from '@votingworks/utils';
 import { Button, Prose } from '@votingworks/ui';
 import { CardProgramming } from '@votingworks/types';
 
@@ -20,9 +21,8 @@ export function ProgramElectionCardView({
   const { electionDefinition } = useContext(AppContext);
 
   async function programAdminCard() {
-    if (!electionDefinition) {
-      return;
-    }
+    assert(electionDefinition);
+
     setActionStatus({
       action: 'Program',
       role: 'admin',
@@ -42,9 +42,8 @@ export function ProgramElectionCardView({
   }
 
   async function programPollWorkerCard() {
-    if (!electionDefinition) {
-      return;
-    }
+    assert(electionDefinition);
+
     setActionStatus({
       action: 'Program',
       role: 'pollworker',

--- a/frontends/election-manager/src/components/smartcard_modal/program_super_admin_card_view.tsx
+++ b/frontends/election-manager/src/components/smartcard_modal/program_super_admin_card_view.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Button, Prose } from '@votingworks/ui';
 import { CardProgramming } from '@votingworks/types';
 
+import { generatePin } from './pins';
 import { SmartcardActionStatus, StatusMessage } from './status_message';
 
 interface Props {
@@ -21,7 +22,10 @@ export function ProgramSuperAdminCardView({
       role: 'superadmin',
       status: 'InProgress',
     });
-    const result = await card.programUser({ role: 'superadmin' });
+    const result = await card.programUser({
+      role: 'superadmin',
+      passcode: generatePin(),
+    });
     setActionStatus({
       action: 'Program',
       role: 'superadmin',

--- a/frontends/election-manager/src/components/smartcard_modal/status_message.tsx
+++ b/frontends/election-manager/src/components/smartcard_modal/status_message.tsx
@@ -42,6 +42,7 @@ export function StatusMessage({
         text = `Error unprogramming ${actionRoleReadableString} card.`;
         break;
       }
+      /* istanbul ignore next: Compile-time check for completeness */
       default: {
         throwIllegalValue(action);
       }
@@ -64,6 +65,7 @@ export function StatusMessage({
         // Handled in UnprogramCardConfirmationModal
         return null;
       }
+      /* istanbul ignore next: Compile-time check for completeness */
       default: {
         throwIllegalValue(action);
       }

--- a/frontends/election-manager/src/components/smartcard_modal/user_roles.ts
+++ b/frontends/election-manager/src/components/smartcard_modal/user_roles.ts
@@ -13,6 +13,7 @@ export function userRoleToReadableString(userRole: UserRole): string {
       return 'Voter';
     case 'cardless_voter':
       return 'Cardless Voter';
+    /* istanbul ignore next: Compile-time check for completeness */
     default:
       throwIllegalValue(userRole);
   }

--- a/frontends/precinct-scanner/src/app.test.tsx
+++ b/frontends/precinct-scanner/src/app.test.tsx
@@ -36,6 +36,7 @@ import { AdjudicationReason, PrecinctSelectionKind } from '@votingworks/types';
 
 import { mocked } from 'ts-jest/utils';
 import { CARD_POLLING_INTERVAL } from '@votingworks/ui';
+import userEvent from '@testing-library/user-event';
 import { App } from './app';
 import { interpretedHmpb } from '../test/fixtures';
 
@@ -1443,15 +1444,16 @@ test('superadmin card', async () => {
     .get('/scan/status', { body: scanStatusWaitingForPaperResponseBody });
   render(<App card={card} storage={storage} hardware={hardware} />);
 
-  const superadmincard = makeSuperadminCard();
+  card.insertCard(makeSuperadminCard());
+  await screen.findByText('Enter the card security code to unlock.');
+  userEvent.click(screen.getByText('1'));
+  userEvent.click(screen.getByText('2'));
+  userEvent.click(screen.getByText('3'));
+  userEvent.click(screen.getByText('4'));
+  userEvent.click(screen.getByText('5'));
+  userEvent.click(screen.getByText('6'));
 
-  await act(async () => {
-    card.insertCard(superadmincard);
-    await advanceTimersAndPromises(1);
-    await advanceTimersAndPromises(1);
-  });
-
-  screen.getByText('Reboot from USB');
+  await screen.findByText('Reboot from USB');
   screen.getByText('Reboot to BIOS');
   screen.getByText('Reset');
   fireEvent.click(screen.getByText('Reset'));

--- a/libs/test-utils/jest.config.js
+++ b/libs/test-utils/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       statements: 52,
-      branches: 42,
+      branches: 41,
       functions: 56,
       lines: 54,
     },

--- a/libs/test-utils/src/smartcard_auth/auth.ts
+++ b/libs/test-utils/src/smartcard_auth/auth.ts
@@ -31,9 +31,13 @@ export function fakeCardProgramming(
   };
 }
 
-export function fakeSuperadminUser(): SuperadminUser {
+export function fakeSuperadminUser(
+  props: Partial<SuperadminUser> = {}
+): SuperadminUser {
   return {
     role: 'superadmin',
+    passcode: '123456',
+    ...props,
   };
 }
 

--- a/libs/test-utils/src/smartcard_auth/inserted.ts
+++ b/libs/test-utils/src/smartcard_auth/inserted.ts
@@ -1,6 +1,7 @@
 import {
   CardStorage,
   InsertedSmartcardAuth,
+  SuperadminUser,
   AdminUser,
   PollworkerUser,
   VoterUser,
@@ -27,11 +28,12 @@ export function fakeCheckingPasscodeAuth(
 }
 
 export function fakeSuperadminAuth(
+  user: Partial<SuperadminUser> = {},
   card: Partial<CardStorage> = {}
 ): InsertedSmartcardAuth.SuperadminLoggedIn {
   return {
     status: 'logged_in',
-    user: fakeSuperadminUser(),
+    user: fakeSuperadminUser(user),
     card: fakeCardStorage(card),
   };
 }

--- a/libs/test-utils/src/smartcards.ts
+++ b/libs/test-utils/src/smartcards.ts
@@ -24,8 +24,11 @@ function assert(condition: unknown, message?: string): asserts condition {
   }
 }
 
-export function makeSuperadminCard(): SuperadminCardData {
-  return { t: 'superadmin' };
+export function makeSuperadminCard(pin?: string): SuperadminCardData {
+  return {
+    t: 'superadmin',
+    p: pin ?? '123456',
+  };
 }
 
 export function makeAdminCard(

--- a/libs/types/src/smartcard_auth/auth.ts
+++ b/libs/types/src/smartcard_auth/auth.ts
@@ -6,6 +6,7 @@ import { Result } from '../result';
 // User data types
 export interface SuperadminUser {
   readonly role: 'superadmin';
+  readonly passcode: string;
 }
 export interface AdminUser {
   readonly role: 'admin';
@@ -116,9 +117,14 @@ export const AdminCardDataSchema: z.ZodSchema<AdminCardData> =
  */
 export interface SuperadminCardData extends CardData {
   readonly t: 'superadmin';
+  /** Card Passcode */
+  readonly p: string;
 }
 export const SuperadminCardDataSchema: z.ZodSchema<SuperadminCardData> =
-  CardDataInternalSchema.extend({ t: z.literal('superadmin') });
+  CardDataInternalSchema.extend({
+    t: z.literal('superadmin'),
+    p: z.string(),
+  });
 
 export type AnyCardData =
   | VoterCardData

--- a/libs/types/src/smartcard_auth/dipped_smartcard_auth.ts
+++ b/libs/types/src/smartcard_auth/dipped_smartcard_auth.ts
@@ -19,7 +19,7 @@ export interface LoggedOut {
 
 export interface CheckingPasscode {
   readonly status: 'checking_passcode';
-  readonly user: AdminUser;
+  readonly user: SuperadminUser | AdminUser;
   readonly checkPasscode: (passcode: string) => void;
   readonly wrongPasscodeEnteredAt?: Date;
 }

--- a/libs/types/src/smartcard_auth/inserted_smartcard_auth.ts
+++ b/libs/types/src/smartcard_auth/inserted_smartcard_auth.ts
@@ -72,7 +72,7 @@ export interface CardlessVoterLoggedIn {
 
 export interface CheckingPasscode {
   readonly status: 'checking_passcode';
-  readonly user: AdminUser;
+  readonly user: SuperadminUser | AdminUser;
   readonly checkPasscode: (passcode: string) => void;
   readonly wrongPasscodeEnteredAt?: Date;
 }

--- a/libs/ui/src/hooks/smartcard_auth/auth_helpers.ts
+++ b/libs/ui/src/hooks/smartcard_auth/auth_helpers.ts
@@ -32,7 +32,7 @@ export function parseUserFromCardSummary(
   if (!cardData) return undefined;
   switch (cardData.t) {
     case 'superadmin':
-      return { role: 'superadmin' };
+      return { role: 'superadmin', passcode: cardData.p };
     case 'admin':
       return { role: 'admin', electionHash: cardData.h, passcode: cardData.p };
     case 'pollworker':
@@ -138,6 +138,7 @@ export function buildCardProgramming(
         case 'superadmin': {
           const cardData: SuperadminCardData = {
             t: 'superadmin',
+            p: userData.passcode,
           };
           await cardApi.overrideWriteProtection();
           await cardApi.writeShortValue(JSON.stringify(cardData));

--- a/libs/ui/src/hooks/smartcard_auth/use_dipped_smartcard_auth.ts
+++ b/libs/ui/src/hooks/smartcard_auth/use_dipped_smartcard_auth.ts
@@ -83,10 +83,6 @@ function smartcardAuthReducer(
                     user &&
                       (user.role === 'superadmin' || user.role === 'admin')
                   );
-                  // TODO: This case can be removed once superadmin cards have passcodes
-                  if (user.role === 'superadmin') {
-                    return { status: 'remove_card', user };
-                  }
                   return { status: 'checking_passcode', user };
                 }
                 return {

--- a/libs/ui/src/hooks/smartcard_auth/use_inserted_smartcard_auth.ts
+++ b/libs/ui/src/hooks/smartcard_auth/use_inserted_smartcard_auth.ts
@@ -159,7 +159,7 @@ function smartcardAuthReducer(allowedUserRoles: UserRole[], scope: AuthScope) {
               if (validationResult.isOk()) {
                 assert(user);
                 if (previousState.auth.status === 'logged_out') {
-                  if (user.role === 'admin') {
+                  if (user.role === 'superadmin' || user.role === 'admin') {
                     return { status: 'checking_passcode', user };
                   }
                   return { status: 'logged_in', user };

--- a/services/smartcards/mockCardReader.py
+++ b/services/smartcards/mockCardReader.py
@@ -148,7 +148,7 @@ def enable_superadmin():
         {
             "enabled": True,
             "shortValue": json.dumps(
-                {"t": "superadmin"}
+                {"t": "superadmin", "p": "000000"}
             ),
             "longValue": None,
         }

--- a/services/smartcards/writeAdminCard.py
+++ b/services/smartcards/writeAdminCard.py
@@ -12,8 +12,11 @@ f = open(sys.argv[1], "rb")
 election_bytes = f.read()
 f.close()
 
-short_value = json.dumps(
-    {'t': 'admin', 'h': hashlib.sha256(election_bytes).hexdigest()})
+short_value = json.dumps({
+    't': 'admin',
+    'h': hashlib.sha256(election_bytes).hexdigest(),
+    'p': '000000',
+})
 
 print(CardInterface.card)
 CardInterface.override_protection()

--- a/services/smartcards/writePollWorkerCard.py
+++ b/services/smartcards/writePollWorkerCard.py
@@ -12,8 +12,10 @@ f = open(sys.argv[1], "rb")
 election_bytes = f.read()
 f.close()
 
-short_value = json.dumps(
-    {'t': 'pollworker', 'h': hashlib.sha256(election_bytes).hexdigest()})
+short_value = json.dumps({
+    't': 'pollworker',
+    'h': hashlib.sha256(election_bytes).hexdigest(),
+})
 
 print(CardInterface.card)
 CardInterface.override_protection()

--- a/services/smartcards/writeSuperAdminCard.py
+++ b/services/smartcards/writeSuperAdminCard.py
@@ -8,9 +8,10 @@ from smartcards.core import CardInterface
 import time
 time.sleep(2)
 
-short_value = json.dumps(
-    {'t': 'superadmin'}
-)
+short_value = json.dumps({
+    't': 'superadmin',
+    'p': '000000',
+})
 
 print(CardInterface.card)
 CardInterface.override_protection()

--- a/services/smartcards/writeToCard.py
+++ b/services/smartcards/writeToCard.py
@@ -11,8 +11,11 @@ election = json.loads(f.read())
 f.close()
 
 election_json_bytes = json.dumps(election).encode('utf-8')
-short_value = json.dumps(
-    {'t': 'admin', 'h': hashlib.sha256(election_json_bytes).hexdigest()})
+short_value = json.dumps({
+    't': 'admin',
+    'h': hashlib.sha256(election_json_bytes).hexdigest(),
+    'p': '000000',
+})
 
 print(CardInterface.card)
 CardInterface.write_short_and_long(

--- a/services/smartcards/writeVoterCard.py
+++ b/services/smartcards/writeVoterCard.py
@@ -6,8 +6,12 @@ from smartcards.core import CardInterface
 import time
 time.sleep(2)
 
-short_value = json.dumps(
-    {'t': 'voter', 'pr': '23', 'bs': '12', 'c': 1643066962})
+short_value = json.dumps({
+    't': 'voter',
+    'pr': '23',
+    'bs': '12',
+    'c': 1643066962,
+})
 
 CardInterface.override_protection()
 CardInterface.write(short_value.encode('utf-8'))


### PR DESCRIPTION
_Commit by commit reviewing recommended_

## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/1976

This PR adds PINs to super admin smartcards! 🔒 The source code changes to accomplish this were simple and minimal; the bulk of the work involved updating tests.

Note that, unlike the rest of the VVSG2 auth project code, this change isn't feature flag gated. I'll share an announcement in #vxsuite-prodeng describing how to create super admin cards with PINs. tldr: You can run the following in `services/smartcards`:

```
python3.9 -m pipenv run python -m writeSuperAdminCard
```

## Demo Videos

_Entering a super admin PIN on VxAdmin (dipped auth)_

https://user-images.githubusercontent.com/12616928/181072946-edd0a718-3c13-4c53-b9ce-459acae0420c.mov

_Entering a super admin PIN on VxMark (inserted auth)_

https://user-images.githubusercontent.com/12616928/181072948-daf2190b-4d40-44f3-97c5-ec1317d25a91.mov

_Resetting a super admin PIN_

https://user-images.githubusercontent.com/12616928/181072949-a25a867b-183c-4a7a-96e3-786343a195a8.mov

## Testing Plan 

- [x] Updated all the automated tests
- [x] Manually tested the super admin card creation script in `services/smartcards`
- [x] Manually tested super admin PIN entry on a dipped-auth machine
- [x] Manually tested super admin PIN entry on an inserted-auth machine
- [x] Manually tested super admin PIN resetting

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ Relying on existing logging logic
- [ ] ~I have added JSDoc comments to any newly introduced exports~ N/A
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates