### PR TITLE
fix(ps): sync cvr export to disk

### DIFF
--- a/frontends/precinct-scanner/src/utils/save_cvr_export_to_usb.ts
+++ b/frontends/precinct-scanner/src/utils/save_cvr_export_to_usb.ts
@@ -70,6 +70,7 @@ export async function saveCvrExportToUsb({
       });
       await window.kiosk.writeFile(pathToFile, cvrFileString);
     }
+    await usbstick.doSync();
   } else {
     fileDownload(cvrFileString, cvrFilename, 'application/x-jsonlines');
   }

--- a/libs/@types/kiosk-browser/kiosk-browser.d.ts
+++ b/libs/@types/kiosk-browser/kiosk-browser.d.ts
@@ -204,6 +204,7 @@ declare namespace KioskBrowser {
     getUsbDrives(): Promise<UsbDrive[]>;
     mountUsbDrive(device: string): Promise<void>;
     unmountUsbDrive(device: string): Promise<void>;
+    syncUsbDrive(mountPoint: string): Promise<void>;
 
     /**
      * Writes a file to a specified file path

--- a/libs/test-utils/src/fake_kiosk.ts
+++ b/libs/test-utils/src/fake_kiosk.ts
@@ -82,6 +82,7 @@ export function fakeKiosk({
     getUsbDrives: jest.fn().mockResolvedValue([]),
     mountUsbDrive: jest.fn().mockResolvedValue(undefined),
     unmountUsbDrive: jest.fn().mockResolvedValue(undefined),
+    syncUsbDrive: jest.fn().mockResolvedValue(undefined),
     writeFile: jest.fn().mockResolvedValue(undefined),
     readFile: jest.fn().mockResolvedValue(''),
     getFileSystemEntries: jest.fn().mockResolvedValue([]),

--- a/libs/utils/src/usbstick.test.ts
+++ b/libs/utils/src/usbstick.test.ts
@@ -5,6 +5,7 @@ import {
   doMount,
   doUnmount,
   getDevicePath,
+  doSync,
 } from './usbstick';
 
 const mountedDevices = [
@@ -73,6 +74,7 @@ test('without a kiosk, calls do not crash', async () => {
 
   await doMount();
   await doUnmount();
+  await doSync();
 });
 
 test('can get device path', async () => {
@@ -82,4 +84,19 @@ test('can get device path', async () => {
   fKiosk.getUsbDrives.mockResolvedValue(mountedDevices);
 
   expect(await getDevicePath()).toEqual('/media/usb-drive-sdb');
+});
+
+test('doSync triggers a sync', async () => {
+  const fKiosk = fakeKiosk();
+  window.kiosk = fKiosk;
+
+  // try sync without drive mounted
+  await doSync();
+  expect(window.kiosk.syncUsbDrive).not.toBeCalled();
+
+  // try sync with drive mounted
+  fKiosk.getUsbDrives.mockResolvedValue(mountedDevices);
+  await doMount();
+  await doSync();
+  expect(window.kiosk.syncUsbDrive).toBeCalledWith('/media/usb-drive-sdb');
 });

--- a/libs/utils/src/usbstick.ts
+++ b/libs/utils/src/usbstick.ts
@@ -61,3 +61,15 @@ export async function doUnmount(): Promise<void> {
   await window.kiosk.unmountUsbDrive(device.deviceName);
   return await sleep(FLUSH_IO_DELAY_MS);
 }
+
+// Triggers linux 'sync' command which forces any cached file data to be
+// flushed to the removable drive. Used to prevent incomplete file transfers.
+export async function doSync(): Promise<void> {
+  const device = await getDevice();
+  const mountPoint = device?.mountPoint;
+  if (!mountPoint) {
+    return;
+  }
+  assert(window.kiosk);
+  await window.kiosk.syncUsbDrive(mountPoint);
+}


### PR DESCRIPTION
## Overview
Closes #1981. When saving CVRs - whether on polls closed or when exporting from the Admin menu - forces the machine to finish writing the file to disk by calling the `sync` command. This prevents the CVR file from not being saved or being saved improperly. It does slightly increase the delay when closing polls, by a couple of seconds, but that tradeoff is easily worth it.

Depends on [votingworks/kiosk-browser#129](https://github.com/votingworks/kiosk-browser/pull/129) to introduce the `kiosk.syncUsbDrive` API. 

Sidebar: the precinct scanner poll worker flow lacks any logging. Not sure if that's intentional, but I didn't touch it in this PR. 

## Testing Plan
- Manual testing on hardware
- Unit test for `usbstick` util

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
