### PR TITLE
fix(scan): Ignore extraneous commands to precinct scanner state machine

### DIFF
--- a/frontends/precinct-scanner/src/app.test.tsx
+++ b/frontends/precinct-scanner/src/app.test.tsx
@@ -417,7 +417,7 @@ test('admin and pollworker configuration', async () => {
   await authenticateAdminCard();
 
   // Calibrate scanner
-  fetchMock.postOnce('/scanner/calibrate', { body: { status: 'ok' } });
+  fetchMock.post('/scanner/calibrate', { body: { status: 'ok' } });
   fireEvent.click(await screen.findByText('Calibrate Scanner'));
   await screen.findByText('Waiting for Paper');
   fireEvent.click(await screen.findByText('Cancel'));
@@ -434,7 +434,7 @@ test('admin and pollworker configuration', async () => {
   fetchMock.getOnce('/scanner/status', {
     body: { ...statusReadyToScan, state: 'calibrated' },
   });
-  fetchMock.postOnce('/scanner/wait-for-paper', { body: { status: 'ok' } });
+  fetchMock.post('/scanner/wait-for-paper', { body: { status: 'ok' } });
   await advanceTimersAndPromises(1);
   screen.getByText('Calibration succeeded!');
   fireEvent.click(screen.getByRole('button', { name: 'Close' }));
@@ -501,28 +501,22 @@ test('voter can cast a ballot that scans successfully ', async () => {
   await screen.findByText('Election ID');
   await screen.findByText('748dc61ad3');
 
-  // We use a slight delay on post requests to simulate async response, which is
-  // needed to make sure the locking that prevents dup requests works correctly
   fetchMock
     .getOnce('/scanner/status', {
       body: scannerStatus({ state: 'ready_to_scan' }),
     })
-    .postOnce('/scanner/scan', { body: { status: 'ok' } }, { delay: 1 })
+    .post('/scanner/scan', { body: { status: 'ok' } })
     .getOnce('/scanner/status', {
       body: scannerStatus({ state: 'scanning' }),
     })
     .getOnce('/scanner/status', {
       body: scannerStatus({ state: 'ready_to_accept' }),
     })
-    .postOnce('/scanner/accept', { body: { status: 'ok' } }, { delay: 1 })
+    .post('/scanner/accept', { body: { status: 'ok' } })
     .getOnce('/scanner/status', {
       body: scannerStatus({ state: 'accepted' }),
     })
-    .postOnce(
-      '/scanner/wait-for-paper',
-      { body: { status: 'ok' } },
-      { delay: 1 }
-    )
+    .post('/scanner/wait-for-paper', { body: { status: 'ok' } })
     .get('/scanner/status', {
       body: scannerStatus({ state: 'no_paper', ballotsCounted: 1 }),
     });
@@ -672,7 +666,7 @@ test('voter can cast a ballot that needs review and adjudicate as desired', asyn
     .getOnce('/scanner/status', {
       body: scannerStatus({ state: 'ready_to_scan' }),
     })
-    .postOnce('/scanner/scan', { body: { status: 'ok' } }, { delay: 1 })
+    .post('/scanner/scan', { body: { status: 'ok' } })
     .getOnce('/scanner/status', {
       body: scannerStatus({ state: 'scanning' }),
     })
@@ -693,15 +687,11 @@ test('voter can cast a ballot that needs review and adjudicate as desired', asyn
   await screen.findByText('Blank Ballot');
 
   fetchMock
-    .postOnce('/scanner/accept', { body: { status: 'ok' } }, { delay: 1 })
+    .post('/scanner/accept', { body: { status: 'ok' } })
     .getOnce('/scanner/status', {
       body: scannerStatus({ state: 'accepted' }),
     })
-    .postOnce(
-      '/scanner/wait-for-paper',
-      { body: { status: 'ok' } },
-      { delay: 1 }
-    )
+    .post('/scanner/wait-for-paper', { body: { status: 'ok' } })
     .get('/scanner/status', {
       body: scannerStatus({ state: 'no_paper', ballotsCounted: 1 }),
     });
@@ -747,7 +737,7 @@ test('voter can cast a rejected ballot', async () => {
     .getOnce('/scanner/status', {
       body: scannerStatus({ state: 'ready_to_scan' }),
     })
-    .postOnce('/scanner/scan', { body: { status: 'ok' } }, { delay: 1 })
+    .post('/scanner/scan', { body: { status: 'ok' } })
     .getOnce('/scanner/status', {
       body: scannerStatus({ state: 'scanning' }),
     })
@@ -814,7 +804,7 @@ test('voter can cast another ballot while the success screen is showing', async 
     .getOnce('/scanner/status', {
       body: scannerStatus({ state: 'ready_to_scan' }),
     })
-    .postOnce('/scanner/scan', { body: { status: 'ok' } }, { delay: 1 })
+    .post('/scanner/scan', { body: { status: 'ok' } })
     .getOnce('/scanner/status', {
       body: scannerStatus({ state: 'scanning' }),
     })
@@ -1034,22 +1024,18 @@ test('no printer: open polls, scan ballot, close polls, export results', async (
       { body: scannerStatus({ state: 'ready_to_scan' }) },
       { overwriteRoutes: true }
     )
-    .postOnce('/scanner/scan', { body: { status: 'ok' } }, { delay: 1 })
+    .post('/scanner/scan', { body: { status: 'ok' } })
     .getOnce('/scanner/status', {
       body: scannerStatus({ state: 'scanning' }),
     })
     .getOnce('/scanner/status', {
       body: scannerStatus({ state: 'ready_to_accept' }),
     })
-    .postOnce('/scanner/accept', { body: { status: 'ok' } }, { delay: 1 })
+    .post('/scanner/accept', { body: { status: 'ok' } })
     .getOnce('/scanner/status', {
       body: scannerStatus({ state: 'accepted' }),
     })
-    .postOnce(
-      '/scanner/wait-for-paper',
-      { body: { status: 'ok' } },
-      { delay: 1 }
-    )
+    .post('/scanner/wait-for-paper', { body: { status: 'ok' } }, { delay: 1 })
     .get('/scanner/status', {
       body: scannerStatus({ state: 'no_paper', ballotsCounted: 1 }),
     });

--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -21,7 +21,6 @@ import {
   isSuperadminAuth,
   isAdminAuth,
   isPollworkerAuth,
-  useLock,
 } from '@votingworks/ui';
 import {
   throwIllegalValue,
@@ -347,19 +346,13 @@ export function AppRoot({
   // frontend controls when this happens so that ensure we're only scanning when
   // we're in voter mode.
   const voterMode = auth.status === 'logged_out' && auth.reason === 'no_card';
-  const scannerCommandLock = useLock();
   useEffect(() => {
     async function automaticallyScanAndAcceptBallots() {
       if (!(voterMode && isPollsOpen)) return;
-      if (!scannerCommandLock.lock()) return;
-      try {
-        if (scannerStatus?.state === 'ready_to_scan') {
-          await scanner.scanBallot();
-        } else if (scannerStatus?.state === 'ready_to_accept') {
-          await scanner.acceptBallot();
-        }
-      } finally {
-        scannerCommandLock.unlock();
+      if (scannerStatus?.state === 'ready_to_scan') {
+        await scanner.scanBallot();
+      } else if (scannerStatus?.state === 'ready_to_accept') {
+        await scanner.acceptBallot();
       }
     }
     void automaticallyScanAndAcceptBallots();

--- a/services/scan/src/precinct_scanner_state_machine.ts
+++ b/services/scan/src/precinct_scanner_state_machine.ts
@@ -384,9 +384,19 @@ export const machine = createMachine<Context, Event>({
     SCANNER_DISCONNECTED: 'error_disconnected',
     SCANNER_BOTH_SIDES_HAVE_PAPER: 'error_both_sides_have_paper',
     SCANNER_JAM: 'error_jammed',
+    // On unhandled commands, do nothing. This guards against any race
+    // conditions where the frontend has an outdated scanner status and tries to
+    // send a command.
+    SCAN: {},
+    ACCEPT: {},
+    RETURN: {},
+    WAIT_FOR_PAPER: {},
+    CALIBRATE: {},
     SET_INTERPRETATION_MODE: {
       actions: assign({ interpretationMode: (_, event) => event.mode }),
     },
+    // On events that are not handled by a specified transition (e.g. unhandled
+    // paper status), return an error so we can figure out what happened
     '*': {
       target: 'error',
       actions: assign({


### PR DESCRIPTION


## Overview
This prevents race conditions when the frontend has an outdated scanner status and tries to send a command. E.g. if the frontend thinks the scanner is in `ready_to_scan` state but the paper got quickly removed and it's back to `no_paper`, it might still try to send a `SCAN` command.

This also allows the frontend to not have to worry about sending commands multiple times, which makes the frontend logic much simpler.

## Demo Video or Screenshot
N/A

## Testing Plan 
Manual testing
