### PR TITLE
fix(scan): Interpret blank BMD pages correctly for precinct scanner

### DIFF
--- a/services/scan/src/interpreter.test.ts
+++ b/services/scan/src/interpreter.test.ts
@@ -109,6 +109,21 @@ test('properly detects test ballot in live mode', async () => {
   );
 });
 
+test('detects a blank page', async () => {
+  const ballotImagePath = join(sampleBallotImagesPath, 'blank-page.png');
+  const interpretationResult = await new Interpreter({
+    electionDefinition: stateOfHamiltonFixtures.electionDefinition,
+    testMode: true,
+    adjudicationReasons: [],
+  }).interpretFile({
+    ballotImagePath,
+    ballotImageFile: await readFile(ballotImagePath),
+    detectQrcodeResult: await detectQrcodeInFilePath(ballotImagePath),
+  });
+
+  expect(interpretationResult.interpretation.type).toEqual('BlankPage');
+});
+
 test('interprets marks on a HMPB', async () => {
   const interpreter = new Interpreter({
     electionDefinition: stateOfHamiltonFixtures.electionDefinition,

--- a/services/scan/src/interpreter.ts
+++ b/services/scan/src/interpreter.ts
@@ -63,7 +63,7 @@ interface BallotImageData {
 export async function getBallotImageData(
   file: Buffer,
   filename: string,
-  detectQrcodeResult: qrcodeWorker.Output
+  detectQrcodeResult: qrcodeWorker.NonBlankPageOutput
 ): Promise<Result<BallotImageData, PageInterpretation>> {
   const { data, width, height } = await loadImageData(file);
   const image: ImageData = {
@@ -72,7 +72,7 @@ export async function getBallotImageData(
     height,
   };
 
-  if (!detectQrcodeResult.blank && detectQrcodeResult.qrcode) {
+  if (detectQrcodeResult.qrcode) {
     return ok({ file, image, qrcode: detectQrcodeResult.qrcode });
   }
 
@@ -230,6 +230,11 @@ export class Interpreter {
     detectQrcodeResult,
   }: InterpretFileParams): Promise<InterpretFileResult> {
     const timer = time(`interpretFile: ${ballotImagePath}`);
+
+    if (detectQrcodeResult.blank) {
+      return { interpretation: { type: 'BlankPage' } };
+    }
+
     const result = await getBallotImageData(
       ballotImageFile,
       ballotImagePath,

--- a/services/scan/src/workers/interpret_vx.ts
+++ b/services/scan/src/workers/interpret_vx.ts
@@ -3,7 +3,7 @@ import { throwIllegalValue } from '@votingworks/utils';
 import makeDebug from 'debug';
 import { readFile } from 'fs-extra';
 import { ScannerLocation, SCANNER_LOCATION } from '../globals';
-import { Interpreter, InterpretFileResult } from '../interpreter';
+import { Interpreter } from '../interpreter';
 import { Store } from '../store';
 import { pdfToImages } from '../util/pdf_to_images';
 import { saveSheetImages } from '../util/save_images';
@@ -89,13 +89,11 @@ export async function interpret(
     throw new Error('cannot interpret ballot with no configured election');
   }
 
-  const result: InterpretFileResult = !detectQrcodeResult.blank
-    ? await interpreter.interpretFile({
-        ballotImagePath,
-        ballotImageFile: await readFile(ballotImagePath),
-        detectQrcodeResult,
-      })
-    : { interpretation: { type: 'BlankPage' } };
+  const result = await interpreter.interpretFile({
+    ballotImagePath,
+    ballotImageFile: await readFile(ballotImagePath),
+    detectQrcodeResult,
+  });
   debug(
     'interpreted ballot image as %s: %s',
     result.interpretation.type,


### PR DESCRIPTION


## Overview
There was a special case to catch blank pages of a BMD ballot (i.e. the back of the ballot) in the interpret_vx worker that wasn't included in the new simple interpreter used by the precinct scanner. I moved the logic into the interpreter itself to make sure both central and precinct scanners can use the same logic.

## Demo Video or Screenshot
N/A

## Testing Plan 
- Scanned a BMD ballot
- Added a new test

