### PR TITLE
Save All Ballot PDFs

### DIFF
--- a/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
+++ b/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
@@ -125,7 +125,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
         </button>
       </p>
       <div
-        class="sc-fFubgz exWqux"
+        class="sc-idOhPF cPoTOb"
       >
         <button
           class="sc-iBPRYJ gUjZCM"
@@ -1551,7 +1551,7 @@ exports[`L&A (logic and accuracy) flow 2`] = `
         </button>
       </p>
       <div
-        class="sc-fFubgz exWqux"
+        class="sc-idOhPF cPoTOb"
       >
         <button
           class="sc-iBPRYJ gUjZCM"
@@ -3011,7 +3011,7 @@ exports[`L&A (logic and accuracy) flow 3`] = `
         </button>
       </p>
       <div
-        class="sc-fFubgz exWqux"
+        class="sc-idOhPF cPoTOb"
       >
         <button
           class="sc-iBPRYJ gUjZCM"

--- a/frontends/election-manager/src/components/ballot_copies_input.tsx
+++ b/frontends/election-manager/src/components/ballot_copies_input.tsx
@@ -1,0 +1,42 @@
+import { safeParseNumber } from '@votingworks/types';
+import React from 'react';
+import styled from 'styled-components';
+import { InputEventFunction } from '../config/types';
+import { TextInput } from './text_input';
+
+const IncrementInput = styled(TextInput)`
+  width: 4em;
+  &::-webkit-inner-spin-button,
+  &::-webkit-outer-spin-button {
+    opacity: 1;
+  }
+`;
+
+interface Props {
+  ballotCopies: number;
+  setBallotCopies: (ballotCopies: number) => void;
+}
+
+export function BallotCopiesInput({
+  ballotCopies,
+  setBallotCopies,
+}: Props): JSX.Element {
+  const updateBallotCopies: InputEventFunction = (event) => {
+    const { value } = event.currentTarget;
+    const parsedValue = safeParseNumber(value);
+    const copies = parsedValue.isOk() ? parsedValue.ok() : 1;
+    setBallotCopies(copies < 1 ? 1 : copies);
+  };
+
+  return (
+    <IncrementInput
+      name="copies"
+      defaultValue={ballotCopies}
+      type="number"
+      min={1}
+      step={1}
+      pattern="\d*"
+      onChange={updateBallotCopies}
+    />
+  );
+}

--- a/frontends/election-manager/src/components/ballot_mode_toggle.tsx
+++ b/frontends/election-manager/src/components/ballot_mode_toggle.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { BallotMode } from '../config/types';
+import { Button, SegmentedButton } from './button';
+
+interface Props {
+  ballotMode: BallotMode;
+  setBallotMode: (ballotMode: BallotMode) => void;
+}
+
+export function BallotModeToggle({
+  ballotMode,
+  setBallotMode,
+}: Props): JSX.Element {
+  return (
+    <SegmentedButton>
+      <Button
+        disabled={ballotMode === BallotMode.Official}
+        onPress={() => setBallotMode(BallotMode.Official)}
+        small
+      >
+        Official
+      </Button>
+      <Button
+        disabled={ballotMode === BallotMode.Test}
+        onPress={() => setBallotMode(BallotMode.Test)}
+        small
+      >
+        Test
+      </Button>
+      <Button
+        disabled={ballotMode === BallotMode.Sample}
+        onPress={() => setBallotMode(BallotMode.Sample)}
+        small
+      >
+        Sample
+      </Button>
+    </SegmentedButton>
+  );
+}

--- a/frontends/election-manager/src/components/ballot_type_toggle.tsx
+++ b/frontends/election-manager/src/components/ballot_type_toggle.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Button, SegmentedButton } from './button';
+
+interface Props {
+  isAbsentee: boolean;
+  setIsAbsentee: (isAbsentee: boolean) => void;
+}
+
+export function BallotTypeToggle({
+  isAbsentee,
+  setIsAbsentee,
+}: Props): JSX.Element {
+  return (
+    <SegmentedButton>
+      <Button disabled={isAbsentee} onPress={() => setIsAbsentee(true)} small>
+        Absentee
+      </Button>
+      <Button disabled={!isAbsentee} onPress={() => setIsAbsentee(false)} small>
+        Precinct
+      </Button>
+    </SegmentedButton>
+  );
+}

--- a/frontends/election-manager/src/components/ballot_type_toggle.tsx
+++ b/frontends/election-manager/src/components/ballot_type_toggle.tsx
@@ -4,20 +4,35 @@ import { Button, SegmentedButton } from './button';
 interface Props {
   isAbsentee: boolean;
   setIsAbsentee: (isAbsentee: boolean) => void;
+  absenteeFirst?: boolean;
 }
 
 export function BallotTypeToggle({
   isAbsentee,
   setIsAbsentee,
+  absenteeFirst = true,
 }: Props): JSX.Element {
+  const buttons = [
+    <Button
+      disabled={isAbsentee}
+      onPress={() => setIsAbsentee(true)}
+      key="absentee"
+      small
+    >
+      Absentee
+    </Button>,
+    <Button
+      disabled={!isAbsentee}
+      onPress={() => setIsAbsentee(false)}
+      key="precinct"
+      small
+    >
+      Precinct
+    </Button>,
+  ];
   return (
     <SegmentedButton>
-      <Button disabled={isAbsentee} onPress={() => setIsAbsentee(true)} small>
-        Absentee
-      </Button>
-      <Button disabled={!isAbsentee} onPress={() => setIsAbsentee(false)} small>
-        Precinct
-      </Button>
+      {absenteeFirst ? buttons : buttons.reverse()}
     </SegmentedButton>
   );
 }

--- a/frontends/election-manager/src/components/export_ballot_pdfs_button.test.tsx
+++ b/frontends/election-manager/src/components/export_ballot_pdfs_button.test.tsx
@@ -1,0 +1,162 @@
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { fakeLogger, LogEventId } from '@votingworks/logging';
+import { fakeKiosk, fakeUsbDrive } from '@votingworks/test-utils';
+import { assert, usbstick } from '@votingworks/utils';
+import React from 'react';
+import { fakeFileWriter } from '../../test/helpers/fake_file_writer';
+import { renderInAppContext } from '../../test/render_in_app_context';
+import { ExportBallotPdfsButton } from './export_ballot_pdfs_button';
+
+const { UsbDriveStatus } = usbstick;
+
+jest.mock('../components/hand_marked_paper_ballot');
+
+beforeEach(() => {
+  const mockKiosk = fakeKiosk();
+  mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
+  const fileWriter = fakeFileWriter();
+  mockKiosk.saveAs = jest.fn().mockResolvedValue(fileWriter);
+  mockKiosk.writeFile = jest.fn().mockResolvedValue(fileWriter);
+  window.kiosk = mockKiosk;
+});
+
+afterEach(() => {
+  delete window.kiosk;
+});
+
+test('button renders properly when not clicked', () => {
+  renderInAppContext(<ExportBallotPdfsButton />);
+
+  expect(screen.queryByText('Export Ballot PDFs')).toHaveProperty(
+    'type',
+    'button'
+  );
+  expect(screen.queryByRole('alertdialog')).toBeNull();
+});
+
+test('modal renders insert usb screen appropriately', async () => {
+  const usbStatuses = [
+    UsbDriveStatus.absent,
+    UsbDriveStatus.recentlyEjected,
+    UsbDriveStatus.notavailable,
+  ];
+
+  for (const usbStatus of usbStatuses) {
+    const { unmount } = renderInAppContext(<ExportBallotPdfsButton />, {
+      usbDriveStatus: usbStatus,
+    });
+    userEvent.click(screen.getByText('Export Ballot PDFs'));
+
+    const modal = await screen.findByRole('alertdialog');
+    within(modal).getByText('No USB Drive Detected');
+    within(modal).getByAltText('Insert USB Image');
+    userEvent.click(within(modal).getByText('Cancel'));
+
+    expect(screen.queryByRole('alertdialog')).toBeNull();
+    unmount();
+  }
+});
+
+test('modal renders loading screen when usb drive is mounting or ejecting', async () => {
+  const usbStatuses = [UsbDriveStatus.present, UsbDriveStatus.ejecting];
+
+  for (const usbStatus of usbStatuses) {
+    const { unmount } = renderInAppContext(<ExportBallotPdfsButton />, {
+      usbDriveStatus: usbStatus,
+    });
+    userEvent.click(screen.getByText('Export Ballot PDFs'));
+    const modal = await screen.findByRole('alertdialog');
+    within(modal).getByText('Loading');
+
+    unmount();
+  }
+});
+
+test('modal happy path flow works', async () => {
+  const logger = fakeLogger();
+  const ejectFunction = jest.fn();
+  renderInAppContext(<ExportBallotPdfsButton />, {
+    logger,
+    usbDriveStatus: UsbDriveStatus.mounted,
+    usbDriveEject: ejectFunction,
+  });
+
+  userEvent.click(screen.getByText('Export Ballot PDFs'));
+  const modal = await screen.findByRole('alertdialog');
+  userEvent.click(within(modal).getByText('Export'));
+  await within(modal).findByText('Generating Ballot PDFs…');
+  await within(modal).findByText('Finishing Export…');
+  await within(modal).findByText('Export Complete');
+
+  assert(window.kiosk);
+  expect(window.kiosk.makeDirectory).toHaveBeenCalledTimes(1);
+  expect(window.kiosk.writeFile).toHaveBeenCalledTimes(1);
+  expect(window.kiosk.writeFile).toHaveBeenCalledWith(
+    'fake mount point/ballot-pdfs/ballot-pdfs-election-b1e83122e8-live.zip'
+  );
+  expect(logger.log).toHaveBeenCalledWith(
+    LogEventId.FileSaved,
+    'admin',
+    expect.objectContaining({ disposition: 'success' })
+  );
+
+  expect(modal).toBeInTheDocument();
+  userEvent.click(within(modal).getByText('Eject USB'));
+  expect(ejectFunction).toHaveBeenCalledTimes(1);
+  userEvent.click(within(modal).getByText('Close'));
+  expect(screen.queryByRole('alertdialog')).toBeNull();
+});
+
+test('can select options to export different ballots', async () => {
+  renderInAppContext(<ExportBallotPdfsButton />, {
+    usbDriveStatus: UsbDriveStatus.mounted,
+  });
+
+  userEvent.click(screen.getByText('Export Ballot PDFs'));
+  const modal = await screen.findByRole('alertdialog');
+  userEvent.click(within(modal).getByText('Absentee'));
+  userEvent.click(within(modal).getByText('Sample'));
+  userEvent.click(within(modal).getByText('Export'));
+  await within(modal).findByText('Export Complete');
+
+  expect(window.kiosk!.writeFile).toHaveBeenCalledWith(
+    'fake mount point/ballot-pdfs/ballot-pdfs-election-b1e83122e8-sample-absentee.zip'
+  );
+});
+
+test('modal custom flow works', async () => {
+  const logger = fakeLogger();
+  renderInAppContext(<ExportBallotPdfsButton />, {
+    usbDriveStatus: UsbDriveStatus.mounted,
+    logger,
+  });
+  userEvent.click(screen.getByText('Export Ballot PDFs'));
+  const modal = await screen.findByRole('alertdialog');
+
+  userEvent.click(within(modal).getByText('Custom'));
+  await within(modal).findByText('Export Complete');
+  expect(window.kiosk!.saveAs).toHaveBeenCalledTimes(1);
+  expect(logger.log).toHaveBeenCalledWith(
+    LogEventId.FileSaved,
+    'admin',
+    expect.objectContaining({ disposition: 'success' })
+  );
+});
+
+test('modal renders error message appropriately', async () => {
+  // Trigger error by simulating no file chosen at "Save As" prompt
+  window.kiosk!.saveAs = jest.fn().mockResolvedValue(undefined);
+  renderInAppContext(<ExportBallotPdfsButton />, {
+    usbDriveStatus: UsbDriveStatus.mounted,
+  });
+  userEvent.click(screen.getByText('Export Ballot PDFs'));
+  const modal = await screen.findByRole('alertdialog');
+
+  userEvent.click(within(modal).getByText('Custom'));
+
+  await within(modal).findByText('Export Failed');
+  expect(modal).toBeInTheDocument();
+  within(modal).getByText(/An error occurred:/);
+  within(modal).getByText(/could not begin download; no file was chosen/);
+});

--- a/frontends/election-manager/src/components/export_ballot_pdfs_button.tsx
+++ b/frontends/election-manager/src/components/export_ballot_pdfs_button.tsx
@@ -1,0 +1,360 @@
+import { Buffer } from 'buffer';
+import React, { useCallback, useContext, useState, useMemo } from 'react';
+import styled from 'styled-components';
+import { join } from 'path';
+import { BallotLocales } from '@votingworks/types';
+
+import {
+  assert,
+  usbstick,
+  throwIllegalValue,
+  BallotStyleData,
+  BALLOT_PDFS_FOLDER,
+} from '@votingworks/utils';
+import {
+  Modal,
+  Prose,
+  UsbControllerButton,
+  isAdminAuth,
+  isSuperadminAuth,
+} from '@votingworks/ui';
+import { LogEventId } from '@votingworks/logging';
+import {
+  getBallotArchiveFilename,
+  getBallotPath,
+  getBallotStylesData,
+  sortBallotStyleDataByPrecinct,
+} from '../utils/election';
+
+import { AppContext } from '../contexts/app_context';
+import { HandMarkedPaperBallot } from './hand_marked_paper_ballot';
+import { Button } from './button';
+import { LinkButton } from './link_button';
+import { Loading } from './loading';
+
+import { BallotMode } from '../config/types';
+import { DownloadableArchive } from '../utils/downloadable_archive';
+import { BallotTypeToggle } from './ballot_type_toggle';
+import { BallotModeToggle } from './ballot_mode_toggle';
+import { PrintableArea } from './printable_area';
+import { DEFAULT_LOCALE } from '../config/globals';
+import { generatePdfExportMetadataCsv } from '../utils/generate_pdf_export_metadata_csv';
+
+const { UsbDriveStatus } = usbstick;
+const UsbImage = styled.img`
+  margin-right: auto;
+  margin-left: auto;
+  height: 200px;
+`;
+
+const CenteredOptions = styled.div`
+  text-align: center;
+`;
+
+type ModalState =
+  | 'BeforeExport'
+  | 'GeneratingFiles'
+  | 'FinishingExport'
+  | 'Done'
+  | 'Error';
+
+const defaultBallotLocales: BallotLocales = { primary: DEFAULT_LOCALE };
+
+export function ExportBallotPdfsButton(): JSX.Element {
+  const { electionDefinition, usbDriveStatus, usbDriveEject, auth, logger } =
+    useContext(AppContext);
+  assert(electionDefinition);
+  assert(isAdminAuth(auth) || isSuperadminAuth(auth));
+  const userRole = auth.user.role;
+  const { election, electionHash } = electionDefinition;
+
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [modalState, setModalState] = useState<ModalState>('BeforeExport');
+  const [modalError, setModalError] = useState<Error>();
+  const [archive, setArchive] = useState(new DownloadableArchive());
+  const [ballotMode, setBallotMode] = useState(BallotMode.Official);
+  const [isAbsentee, setIsAbsentee] = useState(false);
+  const [ballotIndex, setBallotIndex] = useState(0);
+
+  const defaultArchiveFilename = getBallotArchiveFilename(
+    electionHash,
+    ballotMode,
+    isAbsentee
+  );
+
+  const ballotStyleList = useMemo<BallotStyleData[]>(() => {
+    return sortBallotStyleDataByPrecinct(
+      election,
+      getBallotStylesData(election)
+    );
+  }, [election]);
+
+  const ballotStyle = ballotStyleList[ballotIndex];
+  const ballotFilename = getBallotPath({
+    ballotStyleId: ballotStyle.ballotStyleId,
+    precinctId: ballotStyle.precinctId,
+    ballotMode,
+    isAbsentee,
+    election,
+    electionHash,
+    locales: defaultBallotLocales,
+  });
+
+  const doFileMetadata = useCallback(async () => {
+    const pdfExportMetadataCsv = generatePdfExportMetadataCsv({
+      electionDefinition,
+      ballotMode,
+      isAbsentee,
+      ballotLocales: defaultBallotLocales,
+    });
+    await archive.file(
+      `${defaultArchiveFilename}-metadata.csv`,
+      pdfExportMetadataCsv
+    );
+  }, [
+    archive,
+    ballotMode,
+    defaultArchiveFilename,
+    electionDefinition,
+    isAbsentee,
+  ]);
+
+  const endExport = useCallback(async () => {
+    setModalState('FinishingExport');
+    await doFileMetadata();
+    await archive.end();
+    setModalState('Done');
+    await logger.log(LogEventId.FileSaved, userRole, {
+      disposition: 'success',
+      message: `Successfully saved ${defaultArchiveFilename}.zip to the usb drive.`,
+    });
+  }, [doFileMetadata, archive, logger, userRole, defaultArchiveFilename]);
+
+  const onRendered = useCallback(async () => {
+    assert(window.kiosk);
+    const ballotPdfData = Buffer.from(await window.kiosk.printToPDF());
+    await archive.file(ballotFilename, ballotPdfData);
+
+    if (ballotIndex + 1 === ballotStyleList.length) {
+      await endExport();
+    } else {
+      setBallotIndex(ballotIndex + 1);
+    }
+  }, [archive, ballotIndex, ballotStyleList, ballotFilename, endExport]);
+
+  function closeModal() {
+    setIsModalOpen(false);
+    setModalState('BeforeExport');
+    setModalError(undefined);
+    setArchive(new DownloadableArchive());
+    setBallotIndex(0);
+  }
+
+  // Callback to open the file dialog.
+  async function saveFileCallback(openDialog: boolean) {
+    try {
+      const usbPath = await usbstick.getDevicePath();
+      const pathToFolder = usbPath && join(usbPath, BALLOT_PDFS_FOLDER);
+      const defaultArchiveFilenameWithExtension = `${defaultArchiveFilename}.zip`;
+      const pathToFile = join(
+        pathToFolder ?? '.',
+        defaultArchiveFilenameWithExtension
+      );
+      if (openDialog || !pathToFolder) {
+        await archive.beginWithDialog({
+          defaultPath: pathToFile,
+          filters: [{ name: 'Archive Files', extensions: ['zip'] }],
+        });
+      } else {
+        await archive.beginWithDirectSave(
+          pathToFolder,
+          defaultArchiveFilenameWithExtension
+        );
+      }
+      setModalState('GeneratingFiles');
+    } catch (error) {
+      assert(error instanceof Error);
+      setModalState('Error');
+      setModalError(error);
+      await logger.log(LogEventId.FileSaved, userRole, {
+        disposition: 'failure',
+        message: `Error exporting ballot PDFs: ${error}`,
+        result: 'Ballot PDFs not exported, error shown to user.',
+      });
+    }
+  }
+
+  let mainContent = null;
+  let actions = null;
+
+  switch (modalState) {
+    case 'BeforeExport':
+      switch (usbDriveStatus) {
+        case UsbDriveStatus.absent:
+        case UsbDriveStatus.notavailable:
+        case UsbDriveStatus.recentlyEjected:
+          mainContent = (
+            <Prose>
+              <h1>No USB Drive Detected</h1>
+              <p>
+                <UsbImage
+                  src="/assets/usb-drive.svg"
+                  alt="Insert USB Image"
+                  // hidden feature to export with file dialog by double-clicking
+                  onDoubleClick={() => saveFileCallback(true)}
+                />
+                Please insert a USB drive in order to export the ballot PDF
+                archive.
+              </p>
+            </Prose>
+          );
+          actions = <LinkButton onPress={closeModal}>Cancel</LinkButton>;
+          break;
+        case UsbDriveStatus.ejecting:
+        case UsbDriveStatus.present:
+          mainContent = <Loading />;
+          actions = (
+            <LinkButton onPress={closeModal} disabled>
+              Cancel
+            </LinkButton>
+          );
+          break;
+        case UsbDriveStatus.mounted: {
+          mainContent = (
+            <Prose>
+              <h1>Export Ballot PDFs</h1>
+              <p>
+                The export will include a PDF for each ballot style of the
+                current election. Select the type of ballots you would like to
+                export:
+              </p>
+              <CenteredOptions>
+                <p>
+                  <BallotModeToggle
+                    ballotMode={ballotMode}
+                    setBallotMode={setBallotMode}
+                  />
+                </p>
+                <p>
+                  <BallotTypeToggle
+                    isAbsentee={isAbsentee}
+                    setIsAbsentee={setIsAbsentee}
+                    absenteeFirst={false}
+                  />
+                </p>
+              </CenteredOptions>
+              <p>
+                A zip archive will automatically be saved to the default
+                location on the mounted USB drive. Optionally, you may pick a
+                custom export location.
+              </p>
+            </Prose>
+          );
+          actions = (
+            <React.Fragment>
+              <Button primary onPress={() => saveFileCallback(false)}>
+                Export
+              </Button>
+              <LinkButton onPress={closeModal}>Cancel</LinkButton>
+              <Button onPress={() => saveFileCallback(true)}>Custom</Button>
+            </React.Fragment>
+          );
+          break;
+        }
+
+        default:
+          throwIllegalValue(usbDriveStatus);
+      }
+      break;
+
+    case 'GeneratingFiles': {
+      mainContent = (
+        <React.Fragment>
+          <Prose textCenter>
+            <h1>
+              <strong>Generating Ballot PDFs…</strong>
+            </h1>
+          </Prose>
+          <PrintableArea>
+            <HandMarkedPaperBallot
+              ballotStyleId={ballotStyle.ballotStyleId}
+              election={election}
+              electionHash={electionHash}
+              ballotMode={ballotMode}
+              isAbsentee={isAbsentee}
+              precinctId={ballotStyle.precinctId}
+              onRendered={onRendered}
+              locales={defaultBallotLocales}
+            />
+          </PrintableArea>
+        </React.Fragment>
+      );
+      break;
+    }
+
+    case 'FinishingExport': {
+      mainContent = (
+        <Prose textCenter>
+          <h1>
+            <strong>Finishing Export…</strong>
+          </h1>
+        </Prose>
+      );
+      break;
+    }
+
+    case 'Done': {
+      mainContent = (
+        <Prose>
+          <h1>Export Complete</h1>
+          <p>You may now eject the USB drive.</p>
+        </Prose>
+      );
+      if (usbDriveStatus !== UsbDriveStatus.recentlyEjected) {
+        actions = (
+          <React.Fragment>
+            <UsbControllerButton
+              primary
+              small={false}
+              usbDriveEject={() => usbDriveEject(userRole)}
+              usbDriveStatus={usbDriveStatus}
+            />
+            <LinkButton onPress={closeModal}>Close</LinkButton>
+          </React.Fragment>
+        );
+      } else {
+        actions = <LinkButton onPress={closeModal}>Close</LinkButton>;
+      }
+      break;
+    }
+
+    case 'Error': {
+      mainContent = (
+        <Prose>
+          <h1>Export Failed</h1>
+          <p>An error occurred: {modalError && modalError.message}.</p>
+        </Prose>
+      );
+      actions = <LinkButton onPress={closeModal}>Close</LinkButton>;
+      break;
+    }
+
+    default:
+      throwIllegalValue(modalState);
+  }
+
+  return (
+    <React.Fragment>
+      <LinkButton small onPress={() => setIsModalOpen(true)}>
+        Export Ballot PDFs
+      </LinkButton>
+      {isModalOpen && (
+        <Modal
+          content={mainContent}
+          onOverlayClick={closeModal}
+          actions={actions}
+        />
+      )}
+    </React.Fragment>
+  );
+}

--- a/frontends/election-manager/src/components/export_election_ballot_package_modal_button.tsx
+++ b/frontends/election-manager/src/components/export_election_ballot_package_modal_button.tsx
@@ -39,6 +39,7 @@ import { LinkButton } from './link_button';
 import { Loading } from './loading';
 
 import * as workflow from '../workflows/export_election_ballot_package_workflow';
+import { BallotMode } from '../config/types';
 
 const { UsbDriveStatus } = usbstick;
 const UsbImage = styled.img`
@@ -309,7 +310,7 @@ export function ExportElectionBallotPackageModalButton(): JSX.Element {
             ballotStyleId={ballotStyleId}
             election={election}
             electionHash={electionHash}
-            isLiveMode={isLiveMode}
+            ballotMode={isLiveMode ? BallotMode.Official : BallotMode.Test}
             isAbsentee={isAbsentee}
             precinctId={precinctId}
             onRendered={onRendered}

--- a/frontends/election-manager/src/components/hand_marked_paper_ballot.tsx
+++ b/frontends/election-manager/src/components/hand_marked_paper_ballot.tsx
@@ -11,7 +11,7 @@ import { TFunction, StringMap } from 'i18next';
 import { useTranslation, Trans } from 'react-i18next';
 import {
   AnyContest,
-  BallotLocale,
+  BallotLocales,
   BallotType,
   Candidate,
   CandidateContest,
@@ -124,7 +124,7 @@ function dualPhraseWithSlash(
 
 function dualLanguageComposer(
   t: TFunction,
-  locales: BallotLocale,
+  locales: BallotLocales,
   separator?: string
 ) {
   return (key: string, options: StringMap = {}) => {
@@ -473,7 +473,7 @@ const CandidateDescription = styled.span<{ isSmall?: boolean }>`
 export interface CandidateContestChoicesProps {
   election: Election;
   contest: CandidateContest;
-  locales: BallotLocale;
+  locales: BallotLocales;
   vote?: CandidateVote;
   density?: number;
   targetMarkPosition?: BallotTargetMarkPosition;
@@ -546,7 +546,7 @@ export interface HandMarkedPaperBallotProps {
   ballotMode?: BallotMode;
   isAbsentee?: boolean;
   precinctId: PrecinctId;
-  locales: BallotLocale;
+  locales: BallotLocales;
   ballotId?: BallotId;
   votes?: VotesDict;
   onRendered?(props: Omit<HandMarkedPaperBallotProps, 'onRendered'>): void;

--- a/frontends/election-manager/src/components/save_file_to_usb.tsx
+++ b/frontends/election-manager/src/components/save_file_to_usb.tsx
@@ -40,6 +40,7 @@ export interface Props {
   generateFileContent: () => PromiseOr<Uint8Array | string>;
   defaultFilename: string;
   fileType: FileType;
+  defaultDirectory?: string;
   promptToEjectUsb?: boolean;
 }
 
@@ -55,6 +56,7 @@ export function SaveFileToUsb({
   generateFileContent,
   defaultFilename,
   fileType,
+  defaultDirectory = '',
   promptToEjectUsb = false,
 }: Props): JSX.Element {
   const { usbDriveStatus, usbDriveEject, isOfficialResults, auth, logger } =
@@ -118,8 +120,16 @@ export function SaveFileToUsb({
           await fileWriter.end();
         } else {
           assert(typeof usbPath !== 'undefined');
-          const pathToFile = join(usbPath, defaultFilename);
           assert(window.kiosk);
+
+          if (defaultDirectory) {
+            const pathToFolder = join(usbPath, defaultDirectory);
+            await window.kiosk.makeDirectory(pathToFolder, {
+              recursive: true,
+            });
+          }
+
+          const pathToFile = join(usbPath, defaultDirectory, defaultFilename);
           await window.kiosk.writeFile(pathToFile, results);
           filenameLocation = defaultFilename;
         }
@@ -261,8 +271,8 @@ export function SaveFileToUsb({
             <Prose>
               <h1>Save {title}</h1>
               <p>
-                Save the {fileName} as <strong>{defaultFilename}</strong>{' '}
-                directly on the inserted USB drive?
+                Save the {fileName} as <strong>{defaultFilename}</strong> on the
+                inserted USB drive?
               </p>
             </Prose>
           }

--- a/frontends/election-manager/src/config/types.ts
+++ b/frontends/election-manager/src/config/types.ts
@@ -36,6 +36,12 @@ export const PrintableBallotType = {
 export type PrintableBallotType =
   typeof PrintableBallotType[keyof typeof PrintableBallotType];
 
+export enum BallotMode {
+  Official = 'live',
+  Test = 'test',
+  Sample = 'sample',
+}
+
 export interface PrintedBallot {
   ballotStyleId: BallotStyle['id'];
   precinctId: Precinct['id'];

--- a/frontends/election-manager/src/config/types.ts
+++ b/frontends/election-manager/src/config/types.ts
@@ -1,5 +1,5 @@
 import {
-  BallotLocale,
+  BallotLocales,
   BallotStyle,
   BallotStyleId,
   CastVoteRecord,
@@ -45,7 +45,7 @@ export enum BallotMode {
 export interface PrintedBallot {
   ballotStyleId: BallotStyle['id'];
   precinctId: Precinct['id'];
-  locales: BallotLocale;
+  locales: BallotLocales;
   numCopies: number;
   printedAt: Iso8601Timestamp;
   type: PrintableBallotType;

--- a/frontends/election-manager/src/screens/ballot_list_screen.tsx
+++ b/frontends/election-manager/src/screens/ballot_list_screen.tsx
@@ -16,6 +16,7 @@ import {
 } from '../utils/election';
 import { NavigationScreen } from '../components/navigation_screen';
 import { ExportElectionBallotPackageModalButton } from '../components/export_election_ballot_package_modal_button';
+import { ExportBallotPdfsButton } from '../components/export_ballot_pdfs_button';
 
 const Header = styled.div`
   display: flex;
@@ -49,6 +50,7 @@ export function BallotListScreen(): JSX.Element {
       <Header>
         <Prose maxWidth={false}>
           <p>
+            <ExportBallotPdfsButton />{' '}
             <ExportElectionBallotPackageModalButton />
           </p>
         </Prose>

--- a/frontends/election-manager/src/screens/ballot_screen.tsx
+++ b/frontends/election-manager/src/screens/ballot_screen.tsx
@@ -1,4 +1,4 @@
-import { assert } from '@votingworks/utils';
+import { assert, BALLOT_PDFS_FOLDER } from '@votingworks/utils';
 import React, {
   useCallback,
   useContext,
@@ -300,6 +300,7 @@ export function BallotScreen(): JSX.Element {
           onClose={() => setIsSaveModalOpen(false)}
           generateFileContent={generateFileContentToSaveAsPdf}
           defaultFilename={filename}
+          defaultDirectory={BALLOT_PDFS_FOLDER}
           fileType={FileType.Ballot}
         />
       )}

--- a/frontends/election-manager/src/screens/ballot_screen.tsx
+++ b/frontends/election-manager/src/screens/ballot_screen.tsx
@@ -9,7 +9,7 @@ import React, {
 import { useParams, useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 import {
-  BallotLocale,
+  BallotLocales,
   getBallotStyle,
   getContests,
   getPrecinctById,
@@ -88,7 +88,7 @@ export function BallotScreen(): JSX.Element {
   assert(electionDefinition);
   const { election, electionHash } = electionDefinition;
   const availableLocaleCodes = getElectionLocales(election, DEFAULT_LOCALE);
-  const locales = useMemo<BallotLocale>(
+  const locales = useMemo<BallotLocales>(
     () => ({
       primary: DEFAULT_LOCALE,
       secondary: currentLocaleCode,

--- a/frontends/election-manager/src/screens/ballot_screen.tsx
+++ b/frontends/election-manager/src/screens/ballot_screen.tsx
@@ -27,7 +27,6 @@ import {
 import {
   BallotMode,
   BallotScreenProps,
-  InputEventFunction,
   PrintableBallotType,
 } from '../config/types';
 import { AppContext } from '../contexts/app_context';
@@ -39,19 +38,13 @@ import { getBallotPath, getHumanBallotLanguageFormat } from '../utils/election';
 import { NavigationScreen } from '../components/navigation_screen';
 import { DEFAULT_LOCALE } from '../config/globals';
 import { routerPaths } from '../router_paths';
-import { TextInput } from '../components/text_input';
 import { LinkButton } from '../components/link_button';
 import { getBallotLayoutPageSizeReadableString } from '../utils/get_ballot_layout_page_size';
 import { generateFileContentToSaveAsPdf } from '../utils/save_as_pdf';
 import { SaveFileToUsb, FileType } from '../components/save_file_to_usb';
-
-const BallotCopiesInput = styled(TextInput)`
-  width: 4em;
-  &::-webkit-inner-spin-button,
-  &::-webkit-outer-spin-button {
-    opacity: 1;
-  }
-`;
+import { BallotCopiesInput } from '../components/ballot_copies_input';
+import { BallotModeToggle } from '../components/ballot_mode_toggle';
+import { BallotTypeToggle } from '../components/ballot_type_toggle';
 
 const BallotPreviewHeader = styled.div`
   margin-top: 1rem;
@@ -112,16 +105,8 @@ export function BallotScreen(): JSX.Element {
   const [ballotPages, setBallotPages] = useState(0);
   const [ballotMode, setBallotMode] = useState(BallotMode.Official);
   const [isAbsentee, setIsAbsentee] = useState(true);
-  function toggleIsAbsentee() {
-    return setIsAbsentee((m) => !m);
-  }
   const [ballotCopies, setBallotCopies] = useState(1);
-  const updateBallotCopies: InputEventFunction = (event) => {
-    const { value } = event.currentTarget;
-    // eslint-disable-next-line vx/gts-safe-number-parse
-    const copies = value ? parseInt(value, 10) : 1;
-    setBallotCopies(copies < 1 ? 1 : copies);
-  };
+
   function changeLocale(localeCode: string) {
     return history.replace(
       localeCode === DEFAULT_LOCALE
@@ -204,46 +189,18 @@ export function BallotScreen(): JSX.Element {
             <strong>{pluralize('contest', ballotContests.length, true)}</strong>
           </h1>
           <p>
-            <SegmentedButton>
-              <Button
-                disabled={ballotMode === BallotMode.Official}
-                onPress={() => setBallotMode(BallotMode.Official)}
-                small
-              >
-                Official
-              </Button>
-              <Button
-                disabled={ballotMode === BallotMode.Test}
-                onPress={() => setBallotMode(BallotMode.Test)}
-                small
-              >
-                Test
-              </Button>
-              <Button
-                disabled={ballotMode === BallotMode.Sample}
-                onPress={() => setBallotMode(BallotMode.Sample)}
-                small
-              >
-                Sample
-              </Button>
-            </SegmentedButton>{' '}
-            <SegmentedButton>
-              <Button disabled={isAbsentee} onPress={toggleIsAbsentee} small>
-                Absentee
-              </Button>
-              <Button disabled={!isAbsentee} onPress={toggleIsAbsentee} small>
-                Precinct
-              </Button>
-            </SegmentedButton>{' '}
+            <BallotModeToggle
+              ballotMode={ballotMode}
+              setBallotMode={setBallotMode}
+            />{' '}
+            <BallotTypeToggle
+              isAbsentee={isAbsentee}
+              setIsAbsentee={setIsAbsentee}
+            />{' '}
             Copies{' '}
             <BallotCopiesInput
-              name="copies"
-              defaultValue={ballotCopies}
-              type="number"
-              min={1}
-              step={1}
-              pattern="\d*"
-              onChange={updateBallotCopies}
+              ballotCopies={ballotCopies}
+              setBallotCopies={setBallotCopies}
             />
             {availableLocaleCodes.length > 1 && (
               <React.Fragment>

--- a/frontends/election-manager/src/screens/print_test_deck_screen.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.tsx
@@ -36,6 +36,7 @@ import {
   getBallotLayoutPageSize,
   getBallotLayoutPageSizeReadableString,
 } from '../utils/get_ballot_layout_page_size';
+import { BallotMode } from '../config/types';
 
 export const ONE_SIDED_PAGE_PRINT_TIME_MS = 3000;
 export const TWO_SIDED_PAGE_PRINT_TIME_MS = 5000;
@@ -174,7 +175,7 @@ function HandMarkedPaperBallots({
           ballotStyleId={ballot.ballotStyleId}
           election={election}
           electionHash={electionHash}
-          isLiveMode={false}
+          ballotMode={BallotMode.Test}
           isAbsentee={false}
           precinctId={ballot.precinctId}
           locales={{ primary: 'en-US' }}

--- a/frontends/election-manager/src/utils/election.test.ts
+++ b/frontends/election-manager/src/utils/election.test.ts
@@ -10,6 +10,7 @@ import {
   YesNoVote,
 } from '@votingworks/types';
 import arrayUnique from 'array-unique';
+import { BallotMode } from '../config/types';
 import {
   getBallotPath,
   generateOvervoteBallot,
@@ -27,7 +28,7 @@ test('getBallotPath allows digits in file names', () => {
       ballotStyleId: '77',
       precinctId: '21',
       locales: { primary: 'en-US' },
-      isLiveMode: true,
+      ballotMode: BallotMode.Official,
       isAbsentee: true,
     })
   ).toEqual(

--- a/frontends/election-manager/src/utils/election.ts
+++ b/frontends/election-manager/src/utils/election.ts
@@ -18,6 +18,7 @@ import {
 import { assert, BallotStyleData, find } from '@votingworks/utils';
 import dashify from 'dashify';
 import { LANGUAGES } from '../config/globals';
+import { BallotMode } from '../config/types';
 
 import { sortBy } from './sort_by';
 
@@ -117,7 +118,7 @@ export function getBallotPath({
   electionHash,
   precinctId,
   locales,
-  isLiveMode,
+  ballotMode,
   isAbsentee,
   variant,
   extension = '.pdf',
@@ -127,7 +128,7 @@ export function getBallotPath({
   electionHash: string;
   precinctId: PrecinctId;
   locales: BallotLocale;
-  isLiveMode: boolean;
+  ballotMode: BallotMode;
   isAbsentee: boolean;
   variant?: string;
   extension?: string;
@@ -142,9 +143,9 @@ export function getBallotPath({
     precinctName
   )}-id-${precinctId}-style-${ballotStyleId}-${getHumanBallotLanguageFormat(
     locales
-  ).replace(/[^a-z]+/gi, '-')}-${isLiveMode ? 'live' : 'test'}${
-    isAbsentee ? '-absentee' : ''
-  }${variant ? `-${variant}` : ''}${extension}`;
+  ).replace(/[^a-z]+/gi, '-')}-${ballotMode}${isAbsentee ? '-absentee' : ''}${
+    variant ? `-${variant}` : ''
+  }${extension}`;
 }
 
 export function getAllPossibleCandidatesForCandidateContest(

--- a/frontends/election-manager/src/utils/election.ts
+++ b/frontends/election-manager/src/utils/election.ts
@@ -148,6 +148,16 @@ export function getBallotPath({
   }${extension}`;
 }
 
+export function getBallotArchiveFilename(
+  electionHash: string,
+  ballotMode: BallotMode,
+  isAbsentee: boolean
+): string {
+  return `ballot-pdfs-election-${electionHash.slice(0, 10)}-${ballotMode}${
+    isAbsentee ? '-absentee' : ''
+  }`;
+}
+
 export function getAllPossibleCandidatesForCandidateContest(
   contest: CandidateContest
 ): readonly Candidate[] {

--- a/frontends/election-manager/src/utils/election.ts
+++ b/frontends/election-manager/src/utils/election.ts
@@ -1,6 +1,6 @@
 import {
   AnyContest,
-  BallotLocale,
+  BallotLocales,
   Candidate,
   CandidateContest,
   Election,
@@ -104,7 +104,7 @@ export function getLanguageByLocaleCode(localeCode: string): string {
   return LANGUAGES[localeCode.split('-')[0]] ?? localeCode;
 }
 
-export function getHumanBallotLanguageFormat(locales: BallotLocale): string {
+export function getHumanBallotLanguageFormat(locales: BallotLocales): string {
   return !locales.secondary
     ? getLanguageByLocaleCode(locales.primary)
     : `${getLanguageByLocaleCode(locales.primary)}/${getLanguageByLocaleCode(
@@ -127,7 +127,7 @@ export function getBallotPath({
   election: Election;
   electionHash: string;
   precinctId: PrecinctId;
-  locales: BallotLocale;
+  locales: BallotLocales;
   ballotMode: BallotMode;
   isAbsentee: boolean;
   variant?: string;

--- a/frontends/election-manager/src/utils/generate_pdf_export_metadata_csv.test.ts
+++ b/frontends/election-manager/src/utils/generate_pdf_export_metadata_csv.test.ts
@@ -1,0 +1,47 @@
+import { electionSampleDefinition } from '@votingworks/fixtures';
+import { generatePdfExportMetadataCsv } from './generate_pdf_export_metadata_csv';
+
+import { BallotMode } from '../config/types';
+import { DEFAULT_LOCALE } from '../config/globals';
+
+describe('generatePdfExportMetadataCsv', () => {
+  it('generates an accurate metadata csv', () => {
+    const actualMetadataCsv = generatePdfExportMetadataCsv({
+      electionDefinition: electionSampleDefinition,
+      ballotMode: BallotMode.Official,
+      isAbsentee: false,
+      ballotLocales: { primary: DEFAULT_LOCALE },
+    });
+
+    const expectedMetadataCsv = `Filename,Precinct,Ballot Style
+election-748dc61ad3-precinct-center-springfield-id-23-style-12-English-live.pdf,Center Springfield,12
+election-748dc61ad3-precinct-north-springfield-id-21-style-5-English-live.pdf,North Springfield,5
+election-748dc61ad3-precinct-north-springfield-id-21-style-12-English-live.pdf,North Springfield,12
+election-748dc61ad3-precinct-south-springfield-id-20-style-7C-English-live.pdf,South Springfield,7C`;
+
+    expect(actualMetadataCsv).toEqual(expectedMetadataCsv);
+  });
+
+  it('includes test filenames if the ballot mode is test', () => {
+    const metadataCsv = generatePdfExportMetadataCsv({
+      electionDefinition: electionSampleDefinition,
+      ballotMode: BallotMode.Test,
+      isAbsentee: false,
+      ballotLocales: { primary: DEFAULT_LOCALE },
+    });
+
+    expect(metadataCsv).not.toContain('-live');
+    expect(metadataCsv).toContain('-test');
+  });
+
+  it('includes absentee filenames if ballots are absentee', () => {
+    const metadataCsv = generatePdfExportMetadataCsv({
+      electionDefinition: electionSampleDefinition,
+      ballotMode: BallotMode.Official,
+      isAbsentee: true,
+      ballotLocales: { primary: DEFAULT_LOCALE },
+    });
+
+    expect(metadataCsv).toContain('-absentee');
+  });
+});

--- a/frontends/election-manager/src/utils/generate_pdf_export_metadata_csv.ts
+++ b/frontends/election-manager/src/utils/generate_pdf_export_metadata_csv.ts
@@ -1,0 +1,62 @@
+import {
+  BallotLocales,
+  ElectionDefinition,
+  getPrecinctById,
+} from '@votingworks/types';
+import {
+  getBallotPath,
+  getBallotStylesData,
+  sortBallotStyleDataByPrecinct,
+} from './election';
+import { BallotMode } from '../config/types';
+
+const headers = ['Filename', 'Precinct', 'Ballot Style'];
+
+/**
+ *
+ * Creates a CSV metadata file for ballot PDF export zip archive. Includes a
+ * row for each PDF file included in the zip archive.
+ * @param electionDefinition Contains the election schema and hash
+ * @param ballotMode Identifies the export as for official, test, or sample ballots
+ * @param isAbsentee Identifies the export as for absentee or precinct ballots
+ * @param ballotLocales Identifies the export as for a given BallotLocales
+ * @returns string file content for a CSV file with export metadata
+ */
+export function generatePdfExportMetadataCsv({
+  electionDefinition,
+  ballotMode,
+  isAbsentee,
+  ballotLocales,
+}: {
+  electionDefinition: ElectionDefinition;
+  ballotMode: BallotMode;
+  isAbsentee: boolean;
+  ballotLocales: BallotLocales;
+}): string {
+  const { election, electionHash } = electionDefinition;
+  const ballotStyleList = sortBallotStyleDataByPrecinct(
+    election,
+    getBallotStylesData(election)
+  );
+
+  let finalDataString = headers.join(',');
+  for (const ballotStyle of ballotStyleList) {
+    const filename = getBallotPath({
+      ballotStyleId: ballotStyle.ballotStyleId,
+      precinctId: ballotStyle.precinctId,
+      ballotMode,
+      isAbsentee,
+      election,
+      electionHash,
+      locales: ballotLocales,
+    });
+    const precinctName = getPrecinctById({
+      election,
+      precinctId: ballotStyle.precinctId,
+    })?.name;
+    const row = [filename, precinctName, ballotStyle.ballotStyleId].join(',');
+    finalDataString += `\n${row}`;
+  }
+
+  return finalDataString;
+}

--- a/frontends/election-manager/src/utils/get_all_ballot_configs.ts
+++ b/frontends/election-manager/src/utils/get_all_ballot_configs.ts
@@ -1,6 +1,7 @@
 import { BallotLocales, Election } from '@votingworks/types';
 import { BallotConfig } from '@votingworks/utils';
 import { DEFAULT_LOCALE } from '../config/globals';
+import { BallotMode } from '../config/types';
 import { getBallotPath, getBallotStylesDataByStyle } from './election';
 
 export function getAllBallotConfigs(
@@ -29,7 +30,7 @@ export function getAllBallotConfigs(
             election,
             electionHash,
             locales,
-            isLiveMode,
+            ballotMode: isLiveMode ? BallotMode.Official : BallotMode.Test,
             isAbsentee,
           }),
           layoutFilename: getBallotPath({
@@ -37,7 +38,7 @@ export function getAllBallotConfigs(
             election,
             electionHash,
             locales,
-            isLiveMode,
+            ballotMode: isLiveMode ? BallotMode.Official : BallotMode.Test,
             isAbsentee,
             variant: 'layout',
             extension: '.json',

--- a/libs/utils/src/filenames.ts
+++ b/libs/utils/src/filenames.ts
@@ -13,6 +13,7 @@ const WORD_SEPARATOR = '-';
 const TIME_FORMAT_STRING = `YYYY${WORD_SEPARATOR}MM${WORD_SEPARATOR}DD${SUBSECTION_SEPARATOR}HH${WORD_SEPARATOR}mm${WORD_SEPARATOR}ss`;
 
 export const BALLOT_PACKAGE_FOLDER = 'ballot-packages';
+export const BALLOT_PDFS_FOLDER = 'ballot-pdfs';
 export const SCANNER_RESULTS_FOLDER = 'cast-vote-records';
 export const SCANNER_BACKUPS_FOLDER = 'scanner-backups';
 


### PR DESCRIPTION
## Overview
Closes #2146. Introduces `Export Ballot PDFs` button on the Ballots tab that allows an election administrator to export all the PDFs of a given type & mode at once. The export also includes a `.csv` metadata file that they could edit and use to send a job to their printer.

## Demo Video or Screenshot
[export-ballot-pdfs-rev2.webm](https://user-images.githubusercontent.com/37960853/181384963-c036bbbf-70b5-407d-8fd0-ffabb29d32b1.webm)

## Testing Plan
- Unit testing of new utility function
- Button / Modal Component tests

There are two additional things that would be nice to test but the effort is out of the scope of this PR, unless someone has a better suggestion:
1. Check that the ballot PDFs exported as part of this function match the printed ballots. Ideally we would be generating the ballots for each in a shared place, but that would require a deep dive into changing how we print / PDFize our documents in general. And very ideally, we would be checking that these PDFs work are accepted by our scanning service.
2. Check that the zip archive contains the file entries it is supposed to. Doing this would require an actual file download, meaning Cypress, but Cypress can't use the feature because AFAIK we can't mock USB drive detection in Cypress.

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
