### PR TITLE
fix(scan): Update mock Plustek scanner

### DIFF
--- a/libs/plustek-sdk/package.json
+++ b/libs/plustek-sdk/package.json
@@ -34,6 +34,7 @@
     "@votingworks/utils": "workspace:*",
     "debug": "^4.3.1",
     "temp": "^0.9.4",
+    "xstate": "^4.32.1",
     "zod": "3.14.4"
   },
   "devDependencies": {

--- a/libs/plustek-sdk/src/mocks.ts
+++ b/libs/plustek-sdk/src/mocks.ts
@@ -57,7 +57,7 @@ function assign(arg: Assigner<Context, any> | PropertyAssigner<Context, any>) {
 /**
  * A state machine to model the internal state of the Plustek.
  */
-const plustekMachine = createMachine<Context, Event>({
+const mockPlustekMachine = createMachine<Context, Event>({
   id: 'plustek',
   initial: 'disconnected',
   strict: true,
@@ -222,7 +222,7 @@ export class MockScannerClient implements ScannerClient {
   }: Options = {}) {
     this.toggleHoldDuration = toggleHoldDuration;
     this.machine = interpret(
-      plustekMachine.withConfig({
+      mockPlustekMachine.withConfig({
         delays: {
           SCANNING_DELAY: passthroughDuration,
           ACCEPTING_DELAY: toggleHoldDuration,

--- a/libs/plustek-sdk/src/mocks.ts
+++ b/libs/plustek-sdk/src/mocks.ts
@@ -379,22 +379,27 @@ export class MockScannerClient implements ScannerClient {
       }
       case 'no_paper':
       case 'no_paper_before_hold':
+        debug('no paper');
         return ok(
           Math.random() > 0.5
             ? PaperStatus.VtmDevReadyNoPaper
             : PaperStatus.NoPaperStatus
         );
       case 'ready_to_scan':
+        debug('ready to scan');
         return ok(PaperStatus.VtmReadyToScan);
       case 'ready_to_eject':
+        debug('ready to eject');
         return ok(PaperStatus.VtmReadyToEject);
       case 'jam':
+        debug('jam');
         return ok(
           Math.random() > 0.5
             ? PaperStatus.VtmFrontAndBackSensorHavePaperReady
             : PaperStatus.Jam
         );
       case 'both_sides_have_paper':
+        debug('both sides have paper');
         return ok(PaperStatus.VtmBothSideHavePaper);
       /* istanbul ignore next */
       default:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2106,6 +2106,7 @@ importers:
       '@votingworks/utils': link:../utils
       debug: 4.3.1
       temp: 0.9.4
+      xstate: 4.32.1
       zod: 3.14.4
     devDependencies:
       '@types/debug': 4.1.5
@@ -2163,6 +2164,7 @@ importers:
       temp: ^0.9.4
       ts-jest: ^27.0.7
       typescript: 4.6.3
+      xstate: ^4.32.1
       zod: 3.14.4
   libs/res-to-ts:
     dependencies:
@@ -9036,6 +9038,7 @@ packages:
   /@sideway/address/4.1.0:
     dependencies:
       '@hapi/hoek': 9.1.1
+    dev: false
     resolution:
       integrity: sha512-wAH/JYRXeIFQRsxerIuLjgUu2Xszam+O5xKeatJ4oudShOOirfmsQ1D6LL54XOU2tizpCYku+s1wmU0SYdpoSA==
   /@sideway/address/4.1.4:

--- a/services/scan/jest.config.js
+++ b/services/scan/jest.config.js
@@ -21,7 +21,7 @@ module.exports = {
       statements: 76,
       branches: 64,
       lines: 76,
-      functions: 75,
+      functions: 74,
     },
   },
 };

--- a/services/scan/src/scanners/plustek.ts
+++ b/services/scan/src/scanners/plustek.ts
@@ -69,7 +69,7 @@ export class PlustekScanner implements Scanner {
       paperStatus
     );
     return paperStatus === PaperStatus.VtmDevReadyNoPaper ||
-      paperStatus === PaperStatus.NoPaper
+      paperStatus === PaperStatus.NoPaperStatus
       ? Scan.ScannerStatus.WaitingForPaper
       : paperStatus === PaperStatus.VtmReadyToScan
       ? Scan.ScannerStatus.ReadyToScan


### PR DESCRIPTION
## Overview
In order to write tests for the new precinct scanner API, we first need to update the mock plustek scanner that those tests will rely on.

This PR:
- Integrates the mock plustek scanner with the new scan service precinct scanner API
- Updates the mock scanner to handle more of the edge case behavior of the Plustek by implementing a Plustek-simulator state machine

Recommend reviewing [without whitespace changes](https://github.com/votingworks/vxsuite/pull/2222/files?w=1)

## Demo Video or Screenshot
N/A

## Testing Plan 
- Manually tested the scan service w/ and w/out the mock
- Updated existing tests for the mock scanner