### PR TITLE
Update admin (i.e. election manager) card user validation logic

### DIFF
--- a/frontends/bmd/src/app_root.tsx
+++ b/frontends/bmd/src/app_root.tsx
@@ -357,6 +357,9 @@ export function AppRoot({
     ],
     cardApi: card,
     scope: {
+      // The BMD allows admins to update the machine to use the election definition on the card in
+      // this case
+      allowAdminsToAccessMachinesConfiguredForOtherElections: true,
       electionDefinition: optionalElectionDefinition,
       precinct: appPrecinct,
     },

--- a/frontends/bsd/src/app_root.tsx
+++ b/frontends/bsd/src/app_root.tsx
@@ -513,7 +513,15 @@ export function AppRoot({ card, hardware, logger }: AppRootProps): JSX.Element {
         </AppContext.Provider>
       );
     }
-    return <InvalidCardScreen machine="VxCentralScan" reason={auth.reason} />;
+    if (auth.reason === 'machine_not_configured') {
+      return (
+        <InvalidCardScreen
+          reason={auth.reason}
+          recommendedAction="Please insert an Election Manager card."
+        />
+      );
+    }
+    return <InvalidCardScreen reason={auth.reason} />;
   }
 
   if (auth.status === 'checking_passcode') {

--- a/frontends/bsd/src/app_root.tsx
+++ b/frontends/bsd/src/app_root.tsx
@@ -103,7 +103,15 @@ export function AppRoot({ card, hardware, logger }: AppRootProps): JSX.Element {
     hardware,
     logger,
   });
-  const auth = useDippedSmartcardAuth({ cardApi: card, logger });
+  const auth = useDippedSmartcardAuth({
+    cardApi: card,
+    logger,
+    scope: {
+      // By default with dipped smartcard auth, only super admins have this ability
+      allowAdminsToAccessUnconfiguredMachines: true,
+      electionDefinition,
+    },
+  });
   const userRole = auth.status === 'logged_in' ? auth.user.role : 'unknown';
 
   const [isExportingCvrs, setIsExportingCvrs] = useState(false);
@@ -505,7 +513,7 @@ export function AppRoot({ card, hardware, logger }: AppRootProps): JSX.Element {
         </AppContext.Provider>
       );
     }
-    return <InvalidCardScreen />;
+    return <InvalidCardScreen machine="VxCentralScan" reason={auth.reason} />;
   }
 
   if (auth.status === 'checking_passcode') {

--- a/frontends/election-manager/src/app_root.tsx
+++ b/frontends/election-manager/src/app_root.tsx
@@ -31,6 +31,7 @@ import {
   Hardware,
 } from '@votingworks/utils';
 import {
+  areVvsg2AuthFlowsEnabled,
   useUsbDrive,
   useDevices,
   useDippedSmartcardAuth,
@@ -60,7 +61,6 @@ import {
   convertExternalTalliesToStorageString,
   convertStorageStringToExternalTallies,
 } from './utils/external_tallies';
-import { areVvsg2AuthFlowsEnabled } from './config/features';
 
 export interface AppStorage {
   electionDefinition?: ElectionDefinition;
@@ -154,7 +154,11 @@ export function AppRoot({
     codeVersion: '',
   });
 
-  const auth = useDippedSmartcardAuth({ cardApi: card, logger });
+  const auth = useDippedSmartcardAuth({
+    cardApi: card,
+    logger,
+    scope: { electionDefinition },
+  });
   const currentUserRole =
     auth.status === 'logged_in' ? auth.user.role : 'unknown';
 

--- a/frontends/election-manager/src/components/election_manager.tsx
+++ b/frontends/election-manager/src/components/election_manager.tsx
@@ -88,7 +88,15 @@ export function ElectionManager(): JSX.Element {
     if (auth.reason === 'machine_locked') {
       return <MachineLockedScreen />;
     }
-    return <InvalidCardScreen machine="VxAdmin" reason={auth.reason} />;
+    if (auth.reason === 'machine_not_configured') {
+      return (
+        <InvalidCardScreen
+          reason={auth.reason}
+          recommendedAction="Please insert a System Administrator card."
+        />
+      );
+    }
+    return <InvalidCardScreen reason={auth.reason} />;
   }
 
   if (isSuperadminAuth(auth)) {

--- a/frontends/election-manager/src/components/election_manager.tsx
+++ b/frontends/election-manager/src/components/election_manager.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from 'react';
 import { Switch, Route, Redirect } from 'react-router-dom';
-
 import {
   fontSizeTheme,
   ElectionInfoBar,
@@ -14,9 +13,10 @@ import {
   InvalidCardScreen,
   UnlockMachineScreen,
   RemoveCardScreen,
+  areVvsg2AuthFlowsEnabled,
 } from '@votingworks/ui';
-import { AppContext } from '../contexts/app_context';
 
+import { AppContext } from '../contexts/app_context';
 import { routerPaths } from '../router_paths';
 import { DefinitionScreen } from '../screens/definition_screen';
 import { BallotListScreen } from '../screens/ballot_list_screen';
@@ -42,10 +42,7 @@ import { LogsScreen } from '../screens/logs_screen';
 import { ReportsScreen } from '../screens/reports_screen';
 import { SmartcardTypeRegExPattern } from '../config/types';
 import { SmartcardModal } from './smartcard_modal';
-import {
-  areVvsg2AuthFlowsEnabled,
-  isWriteInAdjudicationEnabled,
-} from '../config/features';
+import { isWriteInAdjudicationEnabled } from '../config/features';
 
 export function ElectionManager(): JSX.Element {
   const {
@@ -88,8 +85,10 @@ export function ElectionManager(): JSX.Element {
   }
 
   if (auth.status === 'logged_out') {
-    if (auth.reason === 'machine_locked') return <MachineLockedScreen />;
-    return <InvalidCardScreen />;
+    if (auth.reason === 'machine_locked') {
+      return <MachineLockedScreen />;
+    }
+    return <InvalidCardScreen machine="VxAdmin" reason={auth.reason} />;
   }
 
   if (isSuperadminAuth(auth)) {

--- a/frontends/election-manager/src/components/navigation_screen.tsx
+++ b/frontends/election-manager/src/components/navigation_screen.tsx
@@ -8,11 +8,9 @@ import {
   Main,
   Screen,
   UsbControllerButton,
-} from '@votingworks/ui';
-import {
   areVvsg2AuthFlowsEnabled,
-  isWriteInAdjudicationEnabled,
-} from '../config/features';
+} from '@votingworks/ui';
+import { isWriteInAdjudicationEnabled } from '../config/features';
 import { AppContext } from '../contexts/app_context';
 import { routerPaths } from '../router_paths';
 import { Navigation } from './navigation';

--- a/frontends/election-manager/src/components/smartcard_modal/smartcard_modal.test.tsx
+++ b/frontends/election-manager/src/components/smartcard_modal/smartcard_modal.test.tsx
@@ -2,6 +2,7 @@ import fetchMock from 'fetch-mock';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { AdminUser, AnyCardData, PollworkerUser } from '@votingworks/types';
+import { areVvsg2AuthFlowsEnabled } from '@votingworks/ui';
 import {
   assert,
   MemoryCard,
@@ -24,27 +25,28 @@ import {
 import { render, screen, waitFor, within } from '@testing-library/react';
 
 import { App } from '../../app';
-import { areVvsg2AuthFlowsEnabled } from '../../config/features';
 import { createMemoryStorageWith } from '../../../test/util/create_memory_storage_with';
 import { generatePin } from './pins';
 import { MachineConfig } from '../../config/types';
 import { VxFiles } from '../../lib/converters';
 
-jest.mock(
-  '../../config/features',
-  (): typeof import('../../config/features') => {
-    return {
-      ...jest.requireActual('../../config/features'),
-      areVvsg2AuthFlowsEnabled: jest.fn(),
-    };
-  }
-);
+jest.mock('@votingworks/ui', (): typeof import('@votingworks/ui') => {
+  return {
+    ...jest.requireActual('@votingworks/ui'),
+    areVvsg2AuthFlowsEnabled: jest.fn(),
+  };
+});
 jest.mock('./pins', (): typeof import('./pins') => {
   return {
     ...jest.requireActual('./pins'),
     generatePin: jest.fn(),
   };
 });
+
+function enableVvsg2AuthFlows() {
+  mockOf(areVvsg2AuthFlowsEnabled).mockImplementation(() => true);
+  process.env['REACT_APP_VX_ENABLE_VVSG2_AUTH_FLOWS'] = 'true';
+}
 
 const electionDefinition = electionSampleDefinition;
 const { election, electionData, electionHash } = electionDefinition;
@@ -61,7 +63,7 @@ beforeEach(() => {
     typedAs<MachineConfig>({ codeVersion: '', machineId: '' })
   );
 
-  mockOf(areVvsg2AuthFlowsEnabled).mockImplementation(() => true);
+  enableVvsg2AuthFlows();
   mockOf(generatePin).mockImplementation(() => '123456');
 });
 

--- a/frontends/election-manager/src/config/features.ts
+++ b/frontends/election-manager/src/config/features.ts
@@ -27,25 +27,6 @@ export function isWriteInAdjudicationEnabled(): boolean {
 }
 
 /**
- * Determines whether VVSG2 auth flows are enabled.
- *
- * To enable VVSG2 auth flows, add this line to `frontends/election-manager/.env.local`:
- *
- *     REACT_APP_VX_ENABLE_VVSG2_AUTH_FLOWS=true
- *
- * To disable them, remove the line or comment it out. Restarting the server is required.
- *
- * @see https://create-react-app.dev/docs/adding-custom-environment-variables/
- */
-export function areVvsg2AuthFlowsEnabled(): boolean {
-  return (
-    (process.env.NODE_ENV === 'development' ||
-      asBoolean(process.env.REACT_APP_VX_DEV)) &&
-    asBoolean(process.env.REACT_APP_VX_ENABLE_VVSG2_AUTH_FLOWS)
-  );
-}
-
-/**
  * Determines which converter client to use, if any.
  */
 export function getConverterClientType(): ConverterClientType | undefined {

--- a/frontends/election-manager/src/env.d.ts
+++ b/frontends/election-manager/src/env.d.ts
@@ -4,7 +4,6 @@ declare namespace NodeJS {
     readonly REACT_APP_VX_CODE_VERSION?: string;
     readonly REACT_APP_VX_CONVERTER?: string;
     readonly REACT_APP_VX_DEV?: string;
-    readonly REACT_APP_VX_ENABLE_VVSG2_AUTH_FLOWS?: string;
     readonly REACT_APP_VX_ENABLE_WRITE_IN_ADJUDICATION?: string;
     readonly REACT_APP_VX_MACHINE_ID?: string;
   }

--- a/frontends/election-manager/src/screens/unconfigured_screen.tsx
+++ b/frontends/election-manager/src/screens/unconfigured_screen.tsx
@@ -3,7 +3,12 @@ import { useHistory, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import { safeParseElection } from '@votingworks/types';
 
-import { Modal, useCancelablePromise, Prose } from '@votingworks/ui';
+import {
+  Modal,
+  useCancelablePromise,
+  Prose,
+  areVvsg2AuthFlowsEnabled,
+} from '@votingworks/ui';
 import { assert } from '@votingworks/utils';
 import {
   ConverterClient,
@@ -24,7 +29,6 @@ import { FileInputButton } from '../components/file_input_button';
 import { HorizontalRule } from '../components/horizontal_rule';
 import { Loading } from '../components/loading';
 import { NavigationScreen } from '../components/navigation_screen';
-import { areVvsg2AuthFlowsEnabled } from '../config/features';
 
 const Loaded = styled.p`
   line-height: 2.5rem;

--- a/libs/types/src/smartcard_auth/dipped_smartcard_auth.ts
+++ b/libs/types/src/smartcard_auth/dipped_smartcard_auth.ts
@@ -12,7 +12,9 @@ export interface LoggedOut {
     | 'machine_locked'
     | 'card_error'
     | 'invalid_user_on_card'
-    | 'user_role_not_allowed';
+    | 'user_role_not_allowed'
+    | 'machine_not_configured'
+    | 'admin_wrong_election';
   readonly cardUserRole?: UserRole;
   readonly bootstrapAuthenticatedAdminSession: (electionHash: string) => void;
 }

--- a/libs/types/src/smartcard_auth/inserted_smartcard_auth.ts
+++ b/libs/types/src/smartcard_auth/inserted_smartcard_auth.ts
@@ -19,6 +19,7 @@ export interface LoggedOut {
     | 'invalid_user_on_card'
     | 'user_role_not_allowed'
     | 'machine_not_configured'
+    | 'admin_wrong_election'
     | 'pollworker_wrong_election'
     | 'voter_wrong_election'
     | 'voter_wrong_precinct'

--- a/libs/ui/src/config/features.ts
+++ b/libs/ui/src/config/features.ts
@@ -16,3 +16,24 @@ export function isCardReaderCheckDisabled(): boolean {
     asBoolean(process.env.REACT_APP_VX_DISABLE_CARD_READER_CHECK)
   );
 }
+
+/**
+ * Determines whether VVSG2 auth flows are enabled.
+ *
+ * To enable VVSG2 auth flows, add this line to the relevant frontend app's `.env.local`, e.g.
+ * `frontends/election-manager/.env.local`:
+ *
+ *     REACT_APP_VX_ENABLE_VVSG2_AUTH_FLOWS=true
+ *
+ * To disable them, remove the line or comment it out. Restarting the server is required.
+ *
+ * @see https://create-react-app.dev/docs/adding-custom-environment-variables/
+ */
+export function areVvsg2AuthFlowsEnabled(): boolean {
+  return (
+    (process.env.NODE_ENV === 'development' ||
+      process.env.NODE_ENV === 'test' ||
+      asBoolean(process.env.REACT_APP_VX_DEV)) &&
+    asBoolean(process.env.REACT_APP_VX_ENABLE_VVSG2_AUTH_FLOWS)
+  );
+}

--- a/libs/ui/src/env.d.ts
+++ b/libs/ui/src/env.d.ts
@@ -3,5 +3,6 @@ declare namespace NodeJS {
     readonly NODE_ENV: 'development' | 'production' | 'test';
     readonly REACT_APP_VX_DEV?: string;
     readonly REACT_APP_VX_DISABLE_CARD_READER_CHECK?: string;
+    readonly REACT_APP_VX_ENABLE_VVSG2_AUTH_FLOWS?: string;
   }
 }

--- a/libs/ui/src/hooks/smartcard_auth/auth_helpers.test.ts
+++ b/libs/ui/src/hooks/smartcard_auth/auth_helpers.test.ts
@@ -204,7 +204,11 @@ describe('Card interface', () => {
     const cardApi = new MemoryCard();
     const logger = fakeLogger();
     const { result, waitForNextUpdate } = renderHook(() =>
-      useDippedSmartcardAuth({ cardApi, logger })
+      useDippedSmartcardAuth({
+        cardApi,
+        logger,
+        scope: { electionDefinition },
+      })
     );
 
     // Auth as a super admin
@@ -462,7 +466,11 @@ describe('Card interface', () => {
     const cardApi = new MemoryCard();
     const logger = fakeLogger();
     const { result, waitForNextUpdate } = renderHook(() =>
-      useDippedSmartcardAuth({ cardApi, logger })
+      useDippedSmartcardAuth({
+        cardApi,
+        logger,
+        scope: { electionDefinition },
+      })
     );
 
     // Auth as a super admin
@@ -564,7 +572,11 @@ describe('Card interface', () => {
     const cardApi = new MemoryCard();
     const logger = fakeLogger();
     const { result, waitForNextUpdate } = renderHook(() =>
-      useDippedSmartcardAuth({ cardApi, logger })
+      useDippedSmartcardAuth({
+        cardApi,
+        logger,
+        scope: { electionDefinition },
+      })
     );
 
     // Auth as a super admin
@@ -663,7 +675,11 @@ describe('Card interface', () => {
   it('can program and unprogram cards without a logger', async () => {
     const cardApi = new MemoryCard();
     const { result, waitForNextUpdate } = renderHook(() =>
-      useDippedSmartcardAuth({ cardApi, logger: undefined })
+      useDippedSmartcardAuth({
+        cardApi,
+        logger: undefined,
+        scope: { electionDefinition },
+      })
     );
 
     // Auth as a super admin

--- a/libs/ui/src/hooks/smartcard_auth/auth_helpers.test.ts
+++ b/libs/ui/src/hooks/smartcard_auth/auth_helpers.test.ts
@@ -15,7 +15,6 @@ import {
   isAdminAuth,
   isPollworkerAuth,
   isVoterAuth,
-  CARD_POLLING_INTERVAL,
 } from './auth_helpers';
 import { useDippedSmartcardAuth } from './use_dipped_smartcard_auth';
 import { useInsertedSmartcardAuth } from './use_inserted_smartcard_auth';
@@ -44,7 +43,6 @@ describe('Card interface', () => {
         scope: { electionDefinition },
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     assert(isPollworkerAuth(result.current));
 
@@ -62,7 +60,6 @@ describe('Card interface', () => {
 
     // Try writing an object to the card
     await result.current.card.writeStoredData(electionDefinition);
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
 
     // Now reading should return the written data
@@ -81,7 +78,6 @@ describe('Card interface', () => {
 
     // Try writing a binary value to the card
     await result.current.card.writeStoredData(Uint8Array.of(1, 2, 3));
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
 
     // Reading should return the written data
@@ -99,7 +95,6 @@ describe('Card interface', () => {
 
     // Next, clear the data
     await result.current.card.clearStoredData();
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
 
     // Data should read as undefined again
@@ -125,7 +120,6 @@ describe('Card interface', () => {
         scope: { electionDefinition },
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     assert(isPollworkerAuth(result.current));
 
@@ -169,7 +163,6 @@ describe('Card interface', () => {
         scope: { electionDefinition },
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     assert(isPollworkerAuth(result.current));
 
@@ -213,7 +206,6 @@ describe('Card interface', () => {
 
     // Auth as a super admin
     cardApi.insertCard(makeSuperadminCard());
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current.status).toEqual('checking_passcode');
     act(() => {
@@ -223,14 +215,12 @@ describe('Card interface', () => {
     await waitForNextUpdate();
     expect(result.current.status).toEqual('remove_card');
     cardApi.removeCard();
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     assert(isSuperadminAuth(result.current));
 
     // Insert an unprogrammed card
     expect(result.current.card).not.toBeDefined();
     cardApi.insertCard();
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current.card).toBeDefined();
     let card = result.current.card!;
@@ -244,7 +234,6 @@ describe('Card interface', () => {
         await card.programUser({ role: 'superadmin', passcode: '123456' })
       ).isOk()
     ).toEqual(true);
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current.card).toBeDefined();
     card = result.current.card!;
@@ -275,7 +264,6 @@ describe('Card interface', () => {
 
     // Unprogram the card
     expect((await card.unprogramUser()).isOk()).toEqual(true);
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current.card).toBeDefined();
     card = result.current.card!;
@@ -312,7 +300,6 @@ describe('Card interface', () => {
         })
       ).isOk()
     ).toEqual(true);
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current.card).toBeDefined();
     card = result.current.card!;
@@ -345,7 +332,6 @@ describe('Card interface', () => {
 
     // Unprogram the card
     expect((await card.unprogramUser()).isOk()).toEqual(true);
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current.card).toBeDefined();
     card = result.current.card!;
@@ -375,7 +361,6 @@ describe('Card interface', () => {
     expect(
       (await card.programUser({ role: 'pollworker', electionHash })).isOk()
     ).toEqual(true);
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current.card).toBeDefined();
     card = result.current.card!;
@@ -406,7 +391,6 @@ describe('Card interface', () => {
 
     // Unprogram the card
     expect((await card.unprogramUser()).isOk()).toEqual(true);
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current.card).toBeDefined();
     card = result.current.card!;
@@ -435,7 +419,6 @@ describe('Card interface', () => {
     // Unprogram the card again to verify that attempting to unprogram an already unprogrammed card
     // doesn't cause problems
     expect((await card.unprogramUser()).isOk()).toEqual(true);
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current.card).toBeDefined();
     card = result.current.card!;
@@ -475,7 +458,6 @@ describe('Card interface', () => {
 
     // Auth as a super admin
     cardApi.insertCard(makeSuperadminCard());
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current.status).toEqual('checking_passcode');
     act(() => {
@@ -485,13 +467,11 @@ describe('Card interface', () => {
     await waitForNextUpdate();
     expect(result.current.status).toEqual('remove_card');
     cardApi.removeCard();
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     assert(isSuperadminAuth(result.current));
 
     // Insert an unprogrammed card
     cardApi.insertCard();
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current.card).toBeDefined();
     let card = result.current.card!;
@@ -501,7 +481,6 @@ describe('Card interface', () => {
       card.programUser({ role: 'superadmin', passcode: '123456' }),
       card.programUser({ role: 'pollworker', electionHash }),
     ]);
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current.card).toBeDefined();
     card = result.current.card!;
@@ -524,7 +503,6 @@ describe('Card interface', () => {
       card.unprogramUser(),
       card.unprogramUser(),
     ]);
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current.card).toBeDefined();
     card = result.current.card!;
@@ -548,7 +526,6 @@ describe('Card interface', () => {
         await card.programUser({ role: 'superadmin', passcode: '123456' })
       ).isOk()
     ).toEqual(true);
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current.card).toBeDefined();
     card = result.current.card!;
@@ -581,7 +558,6 @@ describe('Card interface', () => {
 
     // Auth as a super admin
     cardApi.insertCard(makeSuperadminCard());
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current.status).toEqual('checking_passcode');
     act(() => {
@@ -591,13 +567,11 @@ describe('Card interface', () => {
     await waitForNextUpdate();
     expect(result.current.status).toEqual('remove_card');
     cardApi.removeCard();
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     assert(isSuperadminAuth(result.current));
 
     // Insert an unprogrammed card
     cardApi.insertCard();
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current.card).toBeDefined();
     let card = result.current.card!;
@@ -637,7 +611,6 @@ describe('Card interface', () => {
         await card.programUser({ role: 'superadmin', passcode: '123456' })
       ).isOk()
     ).toEqual(true);
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current.card).toBeDefined();
     card = result.current.card!;
@@ -684,7 +657,6 @@ describe('Card interface', () => {
 
     // Auth as a super admin
     cardApi.insertCard(makeSuperadminCard());
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current.status).toEqual('checking_passcode');
     act(() => {
@@ -694,13 +666,11 @@ describe('Card interface', () => {
     await waitForNextUpdate();
     expect(result.current.status).toEqual('remove_card');
     cardApi.removeCard();
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     assert(isSuperadminAuth(result.current));
 
     // Insert an unprogrammed card
     cardApi.insertCard();
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current.card).toBeDefined();
     let card = result.current.card!;
@@ -711,7 +681,6 @@ describe('Card interface', () => {
         await card.programUser({ role: 'superadmin', passcode: '123456' })
       ).isOk()
     ).toEqual(true);
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current.card).toBeDefined();
     card = result.current.card!;
@@ -723,7 +692,6 @@ describe('Card interface', () => {
 
     // Unprogram the card
     expect((await card.unprogramUser()).isOk()).toEqual(true);
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current.card).toBeDefined();
     card = result.current.card!;

--- a/libs/ui/src/hooks/smartcard_auth/use_dipped_smartcard_auth.test.ts
+++ b/libs/ui/src/hooks/smartcard_auth/use_dipped_smartcard_auth.test.ts
@@ -15,7 +15,6 @@ import {
 import { assert, MemoryCard } from '@votingworks/utils';
 
 import { areVvsg2AuthFlowsEnabled } from '../../config/features';
-import { CARD_POLLING_INTERVAL } from './auth_helpers';
 import { useDippedSmartcardAuth } from './use_dipped_smartcard_auth';
 
 const electionDefinition = electionSampleDefinition;
@@ -58,7 +57,6 @@ describe('useDippedSmartcardAuth', () => {
       reason: 'machine_locked',
     });
 
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toMatchObject({
       status: 'logged_out',
@@ -67,7 +65,6 @@ describe('useDippedSmartcardAuth', () => {
 
     // Now remove the card and check again
     cardApi.removeCard();
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toMatchObject({
       status: 'logged_out',
@@ -101,7 +98,6 @@ describe('useDippedSmartcardAuth', () => {
     const passcode = '123456';
     const user = fakeSuperadminUser({ passcode });
     cardApi.insertCard(makeSuperadminCard(passcode));
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toEqual({
       status: 'checking_passcode',
@@ -147,7 +143,6 @@ describe('useDippedSmartcardAuth', () => {
 
     // Remove the card to log in
     cardApi.removeCard();
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toEqual({
       status: 'logged_in',
@@ -158,7 +153,6 @@ describe('useDippedSmartcardAuth', () => {
 
     // Inserting a different card doesn't log out (so card can be programmed)
     cardApi.insertCard(makeAdminCard(electionHash));
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toMatchObject({
       status: 'logged_in',
@@ -230,7 +224,6 @@ describe('useDippedSmartcardAuth', () => {
     const passcode = '123456';
     const user = fakeAdminUser({ electionHash, passcode });
     cardApi.insertCard(makeAdminCard(electionHash, passcode));
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toEqual({
       status: 'checking_passcode',
@@ -276,7 +269,6 @@ describe('useDippedSmartcardAuth', () => {
 
     // Remove the card to log in
     cardApi.removeCard();
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toEqual({
       status: 'logged_in',
@@ -287,7 +279,6 @@ describe('useDippedSmartcardAuth', () => {
 
     // Inserting a different card doesn't log out
     cardApi.insertCard(makeSuperadminCard());
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toMatchObject({
       status: 'logged_in',
@@ -351,12 +342,10 @@ describe('useDippedSmartcardAuth', () => {
         scope: { electionDefinition },
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toMatchObject({ status: 'checking_passcode' });
 
     cardApi.removeCard();
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toMatchObject({
       status: 'logged_out',
@@ -413,7 +402,6 @@ describe('useDippedSmartcardAuth', () => {
         scope: { electionDefinition },
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toMatchObject({
       status: 'logged_out',
@@ -421,10 +409,9 @@ describe('useDippedSmartcardAuth', () => {
     });
 
     cardApi.removeCard();
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
+    await waitForNextUpdate();
 
     cardApi.insertCard('invalid card data');
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toMatchObject({
       status: 'logged_out',
@@ -453,7 +440,6 @@ describe('useDippedSmartcardAuth', () => {
         scope: { electionDefinition },
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toMatchObject({
       status: 'logged_out',
@@ -484,7 +470,6 @@ describe('useDippedSmartcardAuth', () => {
         scope: { electionDefinition: undefined },
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
 
     expect(result.current).toMatchObject({
@@ -519,7 +504,6 @@ describe('useDippedSmartcardAuth', () => {
         },
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
 
     expect(result.current).toMatchObject({
@@ -542,7 +526,6 @@ describe('useDippedSmartcardAuth', () => {
         scope: { electionDefinition },
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
 
     expect(result.current).toMatchObject({

--- a/libs/ui/src/hooks/smartcard_auth/use_inserted_smartcard_auth.test.ts
+++ b/libs/ui/src/hooks/smartcard_auth/use_inserted_smartcard_auth.test.ts
@@ -26,7 +26,6 @@ import { assert, MemoryCard, utcTimestamp } from '@votingworks/utils';
 
 import { areVvsg2AuthFlowsEnabled } from '../../config/features';
 import {
-  CARD_POLLING_INTERVAL,
   isVoterAuth,
   isPollworkerAuth,
   isCardlessVoterAuth,
@@ -87,7 +86,6 @@ describe('useInsertedSmartcardAuth', () => {
     // Default before reading card is logged_out
     expect(result.current).toEqual({ status: 'logged_out', reason: 'no_card' });
 
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toEqual({
       status: 'logged_out',
@@ -96,7 +94,6 @@ describe('useInsertedSmartcardAuth', () => {
 
     // Now remove the card and check again
     cardApi.removeCard();
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toEqual({ status: 'logged_out', reason: 'no_card' });
 
@@ -123,7 +120,6 @@ describe('useInsertedSmartcardAuth', () => {
         logger,
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toEqual({
       status: 'logged_out',
@@ -131,10 +127,9 @@ describe('useInsertedSmartcardAuth', () => {
     });
 
     cardApi.removeCard();
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
+    await waitForNextUpdate();
 
     cardApi.insertCard('invalid card data');
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toEqual({
       status: 'logged_out',
@@ -164,7 +159,6 @@ describe('useInsertedSmartcardAuth', () => {
         logger,
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toEqual({
       status: 'logged_out',
@@ -195,7 +189,6 @@ describe('useInsertedSmartcardAuth', () => {
         logger,
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toEqual({
       status: 'logged_out',
@@ -226,7 +219,6 @@ describe('useInsertedSmartcardAuth', () => {
         logger,
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toEqual({
       status: 'logged_out',
@@ -261,7 +253,6 @@ describe('useInsertedSmartcardAuth', () => {
         logger,
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toEqual({
       status: 'logged_out',
@@ -292,7 +283,6 @@ describe('useInsertedSmartcardAuth', () => {
         logger,
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toEqual({
       status: 'logged_out',
@@ -326,7 +316,6 @@ describe('useInsertedSmartcardAuth', () => {
         logger,
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toEqual({
       status: 'logged_out',
@@ -360,7 +349,6 @@ describe('useInsertedSmartcardAuth', () => {
         logger,
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toEqual({
       status: 'logged_out',
@@ -393,7 +381,6 @@ describe('useInsertedSmartcardAuth', () => {
         logger,
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toEqual({
       status: 'logged_out',
@@ -425,7 +412,6 @@ describe('useInsertedSmartcardAuth', () => {
         },
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toMatchObject({ status: 'logged_in' });
   });
@@ -442,7 +428,6 @@ describe('useInsertedSmartcardAuth', () => {
         logger,
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toEqual({
       status: 'logged_out',
@@ -473,7 +458,6 @@ describe('useInsertedSmartcardAuth', () => {
         logger,
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toEqual({
       status: 'logged_out',
@@ -510,7 +494,6 @@ describe('useInsertedSmartcardAuth', () => {
 
     // Insert a super admin card
     cardApi.insertCard(makeSuperadminCard(passcode));
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toEqual({
       status: 'checking_passcode',
@@ -607,7 +590,6 @@ describe('useInsertedSmartcardAuth', () => {
 
     // Insert an admin card
     cardApi.insertCard(makeAdminCard(electionHash, passcode));
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toEqual({
       status: 'checking_passcode',
@@ -694,12 +676,10 @@ describe('useInsertedSmartcardAuth', () => {
     const { result, waitForNextUpdate } = renderHook(() =>
       useInsertedSmartcardAuth({ cardApi, allowedUserRoles, scope: {}, logger })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toMatchObject({ status: 'checking_passcode' });
 
     cardApi.removeCard();
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toMatchObject({
       status: 'logged_out',
@@ -729,7 +709,6 @@ describe('useInsertedSmartcardAuth', () => {
         logger,
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toMatchObject({
       status: 'logged_in',
@@ -760,7 +739,6 @@ describe('useInsertedSmartcardAuth', () => {
         logger,
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toMatchObject({
       status: 'logged_in',
@@ -797,11 +775,9 @@ describe('useInsertedSmartcardAuth', () => {
         logger,
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     assert(isVoterAuth(result.current));
     await result.current.markCardVoided();
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toEqual({
       status: 'logged_out',
@@ -831,7 +807,6 @@ describe('useInsertedSmartcardAuth', () => {
         scope: { electionDefinition, precinct },
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     assert(isVoterAuth(result.current));
     const error = new Error('test error');
@@ -852,16 +827,13 @@ describe('useInsertedSmartcardAuth', () => {
         logger,
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     assert(isVoterAuth(result.current));
     await result.current.markCardPrinted();
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     // Shouldn't log out until card removed
     expect(result.current.status).toEqual('logged_in');
     cardApi.removeCard();
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current.status).toEqual('logged_out');
 
@@ -884,7 +856,6 @@ describe('useInsertedSmartcardAuth', () => {
         scope: { electionDefinition, precinct },
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     assert(isVoterAuth(result.current));
     const error = new Error('test error');
@@ -905,7 +876,6 @@ describe('useInsertedSmartcardAuth', () => {
         scope: { electionDefinition, precinct },
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     assert(isVoterAuth(result.current));
 
@@ -931,7 +901,6 @@ describe('useInsertedSmartcardAuth', () => {
         logger,
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toMatchObject({
       status: 'logged_in',
@@ -940,7 +909,6 @@ describe('useInsertedSmartcardAuth', () => {
     });
 
     cardApi.removeCard();
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toEqual({ status: 'logged_out', reason: 'no_card' });
 
@@ -964,7 +932,6 @@ describe('useInsertedSmartcardAuth', () => {
         logger,
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     assert(isPollworkerAuth(result.current));
     expect(result.current.activatedCardlessVoter).toBeUndefined();
@@ -986,7 +953,6 @@ describe('useInsertedSmartcardAuth', () => {
 
     // Remove pollworker card to log in cardless voter
     cardApi.removeCard();
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     expect(result.current).toMatchObject({
       status: 'logged_in',
@@ -996,7 +962,6 @@ describe('useInsertedSmartcardAuth', () => {
 
     // Pollworker can deactivate cardless voter, logging them out
     cardApi.insertCard(makePollWorkerCard(electionHash));
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
     act(() => {
       assert(isPollworkerAuth(result.current));
@@ -1014,7 +979,6 @@ describe('useInsertedSmartcardAuth', () => {
       );
     });
     cardApi.removeCard();
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
 
     // Cardless voter can log out themselves
@@ -1072,7 +1036,6 @@ describe('useInsertedSmartcardAuth', () => {
         scope: { electionDefinition: undefined },
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
 
     expect(result.current).toMatchObject({
@@ -1096,7 +1059,6 @@ describe('useInsertedSmartcardAuth', () => {
         scope: { electionDefinition },
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
 
     expect(result.current).toMatchObject({
@@ -1132,7 +1094,6 @@ describe('useInsertedSmartcardAuth', () => {
         },
       })
     );
-    jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
     await waitForNextUpdate();
 
     expect(result.current).toMatchObject({

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -49,6 +49,6 @@ export * from './text';
 export * from './themes';
 export * from './usbcontroller_button';
 export * from './remove_card_screen';
-export * from './invalid_card_screen';
+export { InvalidCardScreen } from './invalid_card_screen';
 export * from './unlock_machine_screen';
 export { areVvsg2AuthFlowsEnabled } from './config/features';

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -51,3 +51,4 @@ export * from './usbcontroller_button';
 export * from './remove_card_screen';
 export * from './invalid_card_screen';
 export * from './unlock_machine_screen';
+export { areVvsg2AuthFlowsEnabled } from './config/features';

--- a/libs/ui/src/invalid_card_screen.test.tsx
+++ b/libs/ui/src/invalid_card_screen.test.tsx
@@ -1,11 +1,71 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
-import { InvalidCardScreen } from './invalid_card_screen';
+import { InvalidCardScreen, Props } from './invalid_card_screen';
 
-describe('InvalidCardScreen', () => {
-  test('says "Invalid Card"', () => {
-    const { getByText } = render(<InvalidCardScreen />);
-    getByText('Invalid Card');
-  });
-});
+const testCases: Array<{
+  description: string;
+  machine: Props['machine'];
+  reason: Props['reason'];
+  expectedText: string;
+}> = [
+  {
+    description: 'VxAdmin not configured',
+    machine: 'VxAdmin',
+    reason: 'machine_not_configured',
+    expectedText:
+      'This machine is unconfigured and cannot be unlocked with this card. ' +
+      'Please insert a System Administrator card.',
+  },
+  {
+    description: 'VxCentralScan not configured',
+    machine: 'VxCentralScan',
+    reason: 'machine_not_configured',
+    expectedText:
+      'This machine is unconfigured and cannot be unlocked with this card. ' +
+      'Please insert an Election Manager card.',
+  },
+  {
+    description:
+      'Election Manager card election hash does not match VxAdmin election hash',
+    machine: 'VxAdmin',
+    reason: 'admin_wrong_election',
+    expectedText:
+      'The inserted Election Manager card is programmed for another election and cannot be used to unlock this machine. ' +
+      'Please insert a valid Election Manager or System Administrator card.',
+  },
+  {
+    description:
+      'Election Manager card election hash does not match VxCentralScan election hash',
+    machine: 'VxCentralScan',
+    reason: 'admin_wrong_election',
+    expectedText:
+      'The inserted Election Manager card is programmed for another election and cannot be used to unlock this machine. ' +
+      'Please insert a valid Election Manager or System Administrator card.',
+  },
+  {
+    description: 'other error on VxAdmin',
+    machine: 'VxAdmin',
+    reason: 'invalid_user_on_card',
+    expectedText:
+      'The inserted card is not valid to unlock this machine. ' +
+      'Please insert a valid Election Manager or System Administrator card.',
+  },
+  {
+    description: 'other error on VxCentralScan',
+    machine: 'VxCentralScan',
+    reason: 'invalid_user_on_card',
+    expectedText:
+      'The inserted card is not valid to unlock this machine. ' +
+      'Please insert a valid Election Manager or System Administrator card.',
+  },
+];
+
+test.each(testCases)(
+  'InvalidCardScreen renders expected text ($description)',
+  ({ machine, reason, expectedText }) => {
+    render(<InvalidCardScreen machine={machine} reason={reason} />);
+
+    screen.getByText(expectedText);
+  }
+);

--- a/libs/ui/src/invalid_card_screen.test.tsx
+++ b/libs/ui/src/invalid_card_screen.test.tsx
@@ -5,55 +5,35 @@ import { InvalidCardScreen, Props } from './invalid_card_screen';
 
 const testCases: Array<{
   description: string;
-  machine: Props['machine'];
   reason: Props['reason'];
+  recommendedAction?: string;
   expectedText: string;
 }> = [
   {
-    description: 'VxAdmin not configured',
-    machine: 'VxAdmin',
+    description: 'machine not configured',
     reason: 'machine_not_configured',
+    expectedText:
+      'This machine is unconfigured and cannot be unlocked with this card. ' +
+      'Please insert a valid Election Manager or System Administrator card.',
+  },
+  {
+    description: 'machine not configured, custom recommended action',
+    reason: 'machine_not_configured',
+    recommendedAction: 'Please insert a System Administrator card.',
     expectedText:
       'This machine is unconfigured and cannot be unlocked with this card. ' +
       'Please insert a System Administrator card.',
   },
   {
-    description: 'VxCentralScan not configured',
-    machine: 'VxCentralScan',
-    reason: 'machine_not_configured',
-    expectedText:
-      'This machine is unconfigured and cannot be unlocked with this card. ' +
-      'Please insert an Election Manager card.',
-  },
-  {
     description:
-      'Election Manager card election hash does not match VxAdmin election hash',
-    machine: 'VxAdmin',
+      'election manager card election hash does not match machine election hash',
     reason: 'admin_wrong_election',
     expectedText:
       'The inserted Election Manager card is programmed for another election and cannot be used to unlock this machine. ' +
       'Please insert a valid Election Manager or System Administrator card.',
   },
   {
-    description:
-      'Election Manager card election hash does not match VxCentralScan election hash',
-    machine: 'VxCentralScan',
-    reason: 'admin_wrong_election',
-    expectedText:
-      'The inserted Election Manager card is programmed for another election and cannot be used to unlock this machine. ' +
-      'Please insert a valid Election Manager or System Administrator card.',
-  },
-  {
-    description: 'other error on VxAdmin',
-    machine: 'VxAdmin',
-    reason: 'invalid_user_on_card',
-    expectedText:
-      'The inserted card is not valid to unlock this machine. ' +
-      'Please insert a valid Election Manager or System Administrator card.',
-  },
-  {
-    description: 'other error on VxCentralScan',
-    machine: 'VxCentralScan',
+    description: 'other error',
     reason: 'invalid_user_on_card',
     expectedText:
       'The inserted card is not valid to unlock this machine. ' +
@@ -63,8 +43,13 @@ const testCases: Array<{
 
 test.each(testCases)(
   'InvalidCardScreen renders expected text ($description)',
-  ({ machine, reason, expectedText }) => {
-    render(<InvalidCardScreen machine={machine} reason={reason} />);
+  ({ reason, recommendedAction, expectedText }) => {
+    render(
+      <InvalidCardScreen
+        reason={reason}
+        recommendedAction={recommendedAction}
+      />
+    );
 
     screen.getByText(expectedText);
   }

--- a/libs/ui/src/invalid_card_screen.tsx
+++ b/libs/ui/src/invalid_card_screen.tsx
@@ -11,12 +11,14 @@ type LoggedOutReason =
   | InsertedSmartcardAuth.LoggedOut['reason'];
 
 export interface Props {
-  // TODO: Update this component to support VxMark and VxScan, too
-  machine: 'VxAdmin' | 'VxCentralScan';
   reason: LoggedOutReason;
+  recommendedAction?: string;
 }
 
-export function InvalidCardScreen({ machine, reason }: Props): JSX.Element {
+export function InvalidCardScreen({
+  reason,
+  recommendedAction,
+}: Props): JSX.Element {
   let errorDescription: string;
   if (reason === 'machine_not_configured') {
     errorDescription =
@@ -29,17 +31,8 @@ export function InvalidCardScreen({ machine, reason }: Props): JSX.Element {
     errorDescription = 'The inserted card is not valid to unlock this machine.';
   }
 
-  let recommendedAction: string;
-  if (reason === 'machine_not_configured') {
-    if (machine === 'VxAdmin') {
-      recommendedAction = 'Please insert a System Administrator card.';
-    } else {
-      recommendedAction = 'Please insert an Election Manager card.';
-    }
-  } else {
-    recommendedAction =
-      'Please insert a valid Election Manager or System Administrator card.';
-  }
+  const defaultRecommendedAction =
+    'Please insert a valid Election Manager or System Administrator card.';
 
   return (
     <Screen white>
@@ -47,7 +40,7 @@ export function InvalidCardScreen({ machine, reason }: Props): JSX.Element {
         <Prose textCenter theme={fontSizeTheme.medium}>
           <h1>Invalid Card</h1>
           <p>
-            {errorDescription} {recommendedAction}
+            {errorDescription} {recommendedAction || defaultRecommendedAction}
           </p>
         </Prose>
       </Main>

--- a/libs/ui/src/invalid_card_screen.tsx
+++ b/libs/ui/src/invalid_card_screen.tsx
@@ -1,18 +1,53 @@
 import React from 'react';
-import { Screen } from './screen';
+import { DippedSmartcardAuth, InsertedSmartcardAuth } from '@votingworks/types';
+
+import { fontSizeTheme } from './themes';
 import { Main } from './main';
 import { Prose } from './prose';
-import { fontSizeTheme } from './themes';
+import { Screen } from './screen';
 
-export function InvalidCardScreen(): JSX.Element {
+type LoggedOutReason =
+  | DippedSmartcardAuth.LoggedOut['reason']
+  | InsertedSmartcardAuth.LoggedOut['reason'];
+
+export interface Props {
+  // TODO: Update this component to support VxMark and VxScan, too
+  machine: 'VxAdmin' | 'VxCentralScan';
+  reason: LoggedOutReason;
+}
+
+export function InvalidCardScreen({ machine, reason }: Props): JSX.Element {
+  let errorDescription: string;
+  if (reason === 'machine_not_configured') {
+    errorDescription =
+      'This machine is unconfigured and cannot be unlocked with this card.';
+  } else if (reason === 'admin_wrong_election') {
+    errorDescription =
+      'The inserted Election Manager card is programmed for another election ' +
+      'and cannot be used to unlock this machine.';
+  } else {
+    errorDescription = 'The inserted card is not valid to unlock this machine.';
+  }
+
+  let recommendedAction: string;
+  if (reason === 'machine_not_configured') {
+    if (machine === 'VxAdmin') {
+      recommendedAction = 'Please insert a System Administrator card.';
+    } else {
+      recommendedAction = 'Please insert an Election Manager card.';
+    }
+  } else {
+    recommendedAction =
+      'Please insert a valid Election Manager or System Administrator card.';
+  }
+
   return (
     <Screen white>
-      <Main centerChild>
-        <Prose textCenter theme={fontSizeTheme.medium} maxWidth={false}>
+      <Main centerChild padded>
+        <Prose textCenter theme={fontSizeTheme.medium}>
           <h1>Invalid Card</h1>
           <p>
-            The inserted card is not valid to unlock this machine. Please insert
-            a valid admin card.
+            {errorDescription} {recommendedAction}
           </p>
         </Prose>
       </Main>


### PR DESCRIPTION
_Commit by commit reviewing recommended_

## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/1928

This PR updates admin (i.e. election manager*) card user validation logic. Specifically, when the VVSG2 auth flows feature flag is active:

- [ _VxAdmin_ ] An election manager can no longer access an unconfigured machine or a machine configured for another election.
- [ _VxCentralScan_ ] An election manager can no longer access a machine configured for another election.
- [ _VxMark_ ] No changes. VxMark already handles the case that the machine is configured for another election by allowing the election manager to re-program the machine with the election on their card.
- [ _VxScan_ ] An election manager can no longer access a machine configured for another election.

*We're [renaming our user roles soon](https://github.com/votingworks/vxsuite/issues/2181).

## Demo Screenshots

_VxAdmin, unconfigured machine_

![example-1](https://user-images.githubusercontent.com/12616928/181560831-2836325e-96ec-4d1e-8deb-a0664ccc7d77.png)

_VxAdmin, machine configured for another election_

![example-2](https://user-images.githubusercontent.com/12616928/181560846-b30a599b-d62e-4fb4-b96b-08d0fd89f93c.png)

I haven't included screenshots for all the other machines, but those are all covered in tests.

## Testing Plan 

- [x] Added tests at various levels in the code
- [x] Tested manually on all 4 machines, with and without the feature flag

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced
- [x] I have added JSDoc comments to any newly introduced exports
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates