### PR TITLE
Update non-VxAdmin system administrator screens

### DIFF
--- a/frontends/bmd/src/app_root.tsx
+++ b/frontends/bmd/src/app_root.tsx
@@ -737,9 +737,9 @@ export function AppRoot({
   if (isSuperadminAuth(auth)) {
     return (
       <SuperAdminScreen
-        useEffectToggleLargeDisplay={useEffectToggleLargeDisplay}
-        usbDriveStatus={displayUsbStatus}
         logger={logger}
+        unconfigureMachine={unconfigure}
+        usbDriveStatus={displayUsbStatus}
       />
     );
   }

--- a/frontends/bmd/src/pages/admin_screen.tsx
+++ b/frontends/bmd/src/pages/admin_screen.tsx
@@ -208,7 +208,7 @@ export function AdminScreen({
             <p>Loading Election Definition from Admin Card…</p>
           ) : (
             <React.Fragment>
-              <Text warningIcon>Election definition is not Loaded.</Text>
+              <Text warningIcon>Election definition is not loaded.</Text>
               <p>
                 <Button onPress={loadElection}>Load Election Definition</Button>
               </p>

--- a/frontends/bmd/src/pages/superadmin_screen.test.tsx
+++ b/frontends/bmd/src/pages/superadmin_screen.test.tsx
@@ -1,40 +1,24 @@
 import React from 'react';
-import { fireEvent, screen, waitFor } from '@testing-library/react';
-import { fakeKiosk } from '@votingworks/test-utils';
-
+import { fakeLogger } from '@votingworks/logging';
+import { screen } from '@testing-library/react';
 import { usbstick } from '@votingworks/utils';
 
-import { Logger, LogSource } from '@votingworks/logging';
 import { render } from '../../test/test_utils';
-
 import { SuperAdminScreen } from './superadmin_screen';
 
-const logger = new Logger(LogSource.VxBallotMarkingDeviceService);
-
-it('the right buttons and reset calls quit', async () => {
+test('SuperAdminScreen renders expected contents', () => {
+  const logger = fakeLogger();
+  const unconfigureMachine = jest.fn();
   render(
     <SuperAdminScreen
-      usbDriveStatus={usbstick.UsbDriveStatus.absent}
-      useEffectToggleLargeDisplay={jest.fn()}
       logger={logger}
+      unconfigureMachine={unconfigureMachine}
+      usbDriveStatus={usbstick.UsbDriveStatus.absent}
     />
   );
-  screen.getByText('Reboot from USB');
-  screen.getByText('Reboot to BIOS');
-  screen.getByText('Reset');
 
-  // test without kiosk
-  fireEvent.click(screen.getByText('Reset'));
-
-  // test with kiosk
-  window.kiosk = fakeKiosk();
-  fireEvent.click(screen.getByText('Reset'));
-  await waitFor(() => {
-    expect(window.kiosk!.quit).toHaveBeenCalledTimes(1);
-  });
-
-  fireEvent.click(screen.getByText('Reboot to BIOS'));
-  await waitFor(() => {
-    expect(window.kiosk!.rebootToBios).toHaveBeenCalledTimes(1);
-  });
+  // These buttons are further tested in libs/ui
+  screen.getByRole('button', { name: 'Reboot from USB' });
+  screen.getByRole('button', { name: 'Reboot to BIOS' });
+  screen.getByRole('button', { name: 'Unconfigure Machine' });
 });

--- a/frontends/bmd/src/pages/superadmin_screen.tsx
+++ b/frontends/bmd/src/pages/superadmin_screen.tsx
@@ -1,41 +1,38 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
-import {
-  Main,
-  RebootFromUsbButton,
-  RebootToBiosButton,
-  Screen,
-  Button,
-} from '@votingworks/ui';
-
-import { usbstick } from '@votingworks/utils';
 import { Logger } from '@votingworks/logging';
+import { Screen, SystemAdministratorScreenContents } from '@votingworks/ui';
+import { usbstick } from '@votingworks/utils';
 
 interface Props {
-  usbDriveStatus: usbstick.UsbDriveStatus;
-  useEffectToggleLargeDisplay: () => void;
   logger: Logger;
+  unconfigureMachine: () => Promise<void>;
+  usbDriveStatus: usbstick.UsbDriveStatus;
 }
 
 /**
- * Screen when a super admin card is inserted. More functionality will be added to this in the future, for now it just can reboot from usb.
+ * Screen when a super admin card is inserted
  */
 export function SuperAdminScreen({
-  usbDriveStatus,
-  useEffectToggleLargeDisplay,
   logger,
+  unconfigureMachine,
+  usbDriveStatus,
 }: Props): JSX.Element {
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(useEffectToggleLargeDisplay, []);
   return (
     <Screen white>
-      <Main padded centerChild>
-        <RebootFromUsbButton usbDriveStatus={usbDriveStatus} logger={logger} />
-        <br />
-        <RebootToBiosButton logger={logger} />
-        <br />
-        <Button onPress={() => window.kiosk?.quit()}>Reset</Button>
-      </Main>
+      <SystemAdministratorScreenContents
+        displayRemoveCardToLeavePrompt
+        logger={logger}
+        primaryText={
+          <React.Fragment>
+            To adjust settings for the current election,
+            <br />
+            please insert an Election Manager or Poll Worker card.
+          </React.Fragment>
+        }
+        unconfigureMachine={unconfigureMachine}
+        usbDriveStatus={usbDriveStatus}
+      />
     </Screen>
   );
 }

--- a/frontends/bsd/src/app_root.tsx
+++ b/frontends/bsd/src/app_root.tsx
@@ -19,17 +19,15 @@ import {
 } from '@votingworks/utils';
 import {
   ElectionInfoBar,
-  fontSizeTheme,
   isSuperadminAuth,
   Main,
   Prose,
-  RebootFromUsbButton,
-  RebootToBiosButton,
   UnlockMachineScreen,
   InvalidCardScreen,
   RemoveCardScreen,
   Screen,
   SetupCardReaderPage,
+  SystemAdministratorScreenContents,
   Text,
   UsbControllerButton,
   useDevices,
@@ -536,16 +534,17 @@ export function AppRoot({ card, hardware, logger }: AppRootProps): JSX.Element {
     return (
       <AppContext.Provider value={currentContext}>
         <Screen>
-          <Main padded centerChild>
-            <Prose theme={fontSizeTheme.large}>
-              <RebootFromUsbButton
-                usbDriveStatus={displayUsbStatus}
-                logger={logger}
-              />
-              <br />
-              <RebootToBiosButton logger={logger} />
-            </Prose>
-          </Main>
+          <SystemAdministratorScreenContents
+            logger={logger}
+            primaryText={
+              <React.Fragment>
+                To adjust settings for the current election, please insert an
+                Election Manager card.
+              </React.Fragment>
+            }
+            unconfigureMachine={unconfigureServer}
+            usbDriveStatus={displayUsbStatus}
+          />
           <ElectionInfoBar
             mode="admin"
             electionDefinition={electionDefinition}

--- a/frontends/precinct-scanner/jest.config.js
+++ b/frontends/precinct-scanner/jest.config.js
@@ -15,7 +15,7 @@ module.exports = {
     global: {
       statements: 95,
       branches: 88,
-      functions: 88,
+      functions: 87,
       lines: 95,
     },
   },

--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -13,14 +13,12 @@ import {
   useUsbDrive,
   SetupCardReaderPage,
   useDevices,
-  RebootFromUsbButton,
-  RebootToBiosButton,
-  Button,
   UnlockMachineScreen,
   useInsertedSmartcardAuth,
   isSuperadminAuth,
   isAdminAuth,
   isPollworkerAuth,
+  SystemAdministratorScreenContents,
 } from '@votingworks/ui';
 import {
   throwIllegalValue,
@@ -54,7 +52,7 @@ import { AppContext } from './contexts/app_context';
 import { SetupPowerPage } from './screens/setup_power_page';
 import { CardErrorScreen } from './screens/card_error_screen';
 import { SetupScannerScreen } from './screens/setup_scanner_screen';
-import { ScreenMainCenterChild, CenteredLargeProse } from './components/layout';
+import { ScreenMainCenterChild } from './components/layout';
 import { InsertUsbScreen } from './screens/insert_usb_screen';
 import { ScanReturnedBallotScreen } from './screens/scan_returned_ballot_screen';
 import { ScanJamScreen } from './screens/scan_jam_screen';
@@ -370,21 +368,26 @@ export function AppRoot({
     return <SetupPowerPage />;
   }
 
+  if (auth.status === 'checking_passcode' && auth.user.role === 'superadmin') {
+    return <UnlockMachineScreen auth={auth} />;
+  }
+
   if (isSuperadminAuth(auth)) {
     return (
       <ScreenMainCenterChild infoBar>
-        <CenteredLargeProse>
-          <RebootFromUsbButton
-            usbDriveStatus={usbDriveDisplayStatus}
-            logger={logger}
-          />
-          <br />
-          <br />
-          <RebootToBiosButton logger={logger} />
-          <br />
-          <br />
-          <Button onPress={() => window.kiosk?.quit()}>Reset</Button>
-        </CenteredLargeProse>
+        <SystemAdministratorScreenContents
+          displayRemoveCardToLeavePrompt
+          logger={logger}
+          primaryText={
+            <React.Fragment>
+              To adjust settings for the current election,
+              <br />
+              please insert an Election Manager or Poll Worker card.
+            </React.Fragment>
+          }
+          unconfigureMachine={unconfigureServer}
+          usbDriveStatus={usbDriveDisplayStatus}
+        />
       </ScreenMainCenterChild>
     );
   }

--- a/libs/ui/src/config/features.ts
+++ b/libs/ui/src/config/features.ts
@@ -1,5 +1,9 @@
 import { asBoolean } from '@votingworks/utils';
 
+export function isVxDev(): boolean {
+  return asBoolean(process.env.REACT_APP_VX_DEV);
+}
+
 /**
  * Determines whether to actually check for presence of card reader
  *
@@ -11,8 +15,7 @@ import { asBoolean } from '@votingworks/utils';
  */
 export function isCardReaderCheckDisabled(): boolean {
   return (
-    (process.env.NODE_ENV === 'development' ||
-      asBoolean(process.env.REACT_APP_VX_DEV)) &&
+    (process.env.NODE_ENV === 'development' || isVxDev()) &&
     asBoolean(process.env.REACT_APP_VX_DISABLE_CARD_READER_CHECK)
   );
 }
@@ -31,9 +34,7 @@ export function isCardReaderCheckDisabled(): boolean {
  */
 export function areVvsg2AuthFlowsEnabled(): boolean {
   return (
-    (process.env.NODE_ENV === 'development' ||
-      process.env.NODE_ENV === 'test' ||
-      asBoolean(process.env.REACT_APP_VX_DEV)) &&
+    (['development', 'test'].includes(process.env.NODE_ENV) || isVxDev()) &&
     asBoolean(process.env.REACT_APP_VX_ENABLE_VVSG2_AUTH_FLOWS)
   );
 }

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -52,3 +52,5 @@ export * from './remove_card_screen';
 export { InvalidCardScreen } from './invalid_card_screen';
 export * from './unlock_machine_screen';
 export { areVvsg2AuthFlowsEnabled } from './config/features';
+export * from './system_administrator_screen_contents';
+export * from './unconfigure_machine_button';

--- a/libs/ui/src/reboot_to_bios_button.test.tsx
+++ b/libs/ui/src/reboot_to_bios_button.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
-
+import userEvent from '@testing-library/user-event';
 import { fakeKiosk } from '@votingworks/test-utils';
 import { Logger, LogSource } from '@votingworks/logging';
+import { render, screen, waitFor } from '@testing-library/react';
+
 import { RebootToBiosButton } from './reboot_to_bios_button';
 
 beforeEach(() => {
@@ -24,6 +25,10 @@ test('renders as expected.', async () => {
       </button>
     </div>
   `);
-  fireEvent.click(screen.getByText('Reboot to BIOS'));
-  await screen.findByText('Rebooting…');
+
+  userEvent.click(screen.getByText('Reboot to BIOS'));
+  await screen.findByText(/Rebooting/);
+  await waitFor(() =>
+    expect(window.kiosk!.rebootToBios).toHaveBeenCalledTimes(1)
+  );
 });

--- a/libs/ui/src/reboot_to_bios_button.tsx
+++ b/libs/ui/src/reboot_to_bios_button.tsx
@@ -12,8 +12,6 @@ interface Props {
 /**
  * Button that reboots into the BIOS setup.
  */
-
-// eslint-disable-next-line vx/gts-identifiers
 export function RebootToBiosButton({ logger }: Props): JSX.Element {
   const [isRebooting, setIsRebooting] = useState(false);
   async function reboot() {
@@ -22,12 +20,11 @@ export function RebootToBiosButton({ logger }: Props): JSX.Element {
       message: 'User trigged a reboot of the machine to BIOS screen…',
     });
     setIsRebooting(true);
-    // eslint-disable-next-line vx/gts-identifiers
     await window.kiosk.rebootToBios();
   }
 
   if (isRebooting) {
-    return <Modal content={<Loading>Rebooting…</Loading>} />;
+    return <Modal content={<Loading>Rebooting</Loading>} />;
   }
   return <Button onPress={reboot}>Reboot to BIOS</Button>;
 }

--- a/libs/ui/src/system_administrator_screen_contents.test.tsx
+++ b/libs/ui/src/system_administrator_screen_contents.test.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { fakeKiosk, mockOf } from '@votingworks/test-utils';
+import { fakeLogger } from '@votingworks/logging';
+import { render, screen } from '@testing-library/react';
+import { usbstick } from '@votingworks/utils';
+
+import { isVxDev } from './config/features';
+import { SystemAdministratorScreenContents } from './system_administrator_screen_contents';
+
+jest.mock('./config/features', (): typeof import('./config/features') => {
+  return {
+    ...jest.requireActual('./config/features'),
+    isVxDev: jest.fn(),
+  };
+});
+
+beforeEach(() => {
+  mockOf(isVxDev).mockImplementation(() => false);
+  window.kiosk = undefined;
+});
+
+const renderTestCases: Array<{
+  description: string;
+  displayRemoveCardToLeavePromptPropValue?: boolean;
+  simulateVxDev?: boolean;
+  shouldRemoveCardToLeavePromptBeDisplayed: boolean;
+  shouldQuitButtonBeDisplayed: boolean;
+}> = [
+  {
+    description: 'base case',
+    shouldRemoveCardToLeavePromptBeDisplayed: false,
+    shouldQuitButtonBeDisplayed: false,
+  },
+  {
+    description: 'when displayRemoveCardToLeavePrompt is specified',
+    displayRemoveCardToLeavePromptPropValue: true,
+    shouldRemoveCardToLeavePromptBeDisplayed: true,
+    shouldQuitButtonBeDisplayed: false,
+  },
+  {
+    description: 'when on VxDev',
+    simulateVxDev: true,
+    shouldRemoveCardToLeavePromptBeDisplayed: false,
+    shouldQuitButtonBeDisplayed: true,
+  },
+  {
+    description:
+      'when displayRemoveCardToLeavePrompt is specified and on VxDev',
+    displayRemoveCardToLeavePromptPropValue: true,
+    simulateVxDev: true,
+    shouldRemoveCardToLeavePromptBeDisplayed: true,
+    shouldQuitButtonBeDisplayed: true,
+  },
+];
+
+test.each(renderTestCases)(
+  'SystemAdministratorScreenContents renders expected contents ($description)',
+  ({
+    displayRemoveCardToLeavePromptPropValue,
+    simulateVxDev,
+    shouldRemoveCardToLeavePromptBeDisplayed,
+    shouldQuitButtonBeDisplayed,
+  }) => {
+    if (simulateVxDev) {
+      mockOf(isVxDev).mockImplementation(() => true);
+    }
+    const logger = fakeLogger();
+    const unconfigureMachine = jest.fn();
+    render(
+      <SystemAdministratorScreenContents
+        displayRemoveCardToLeavePrompt={displayRemoveCardToLeavePromptPropValue}
+        logger={logger}
+        primaryText="To adjust settings for the current election, please insert an Election Manager card."
+        unconfigureMachine={unconfigureMachine}
+        usbDriveStatus={usbstick.UsbDriveStatus.mounted}
+      />
+    );
+
+    screen.getByText(
+      'To adjust settings for the current election, please insert an Election Manager card.'
+    );
+    if (shouldRemoveCardToLeavePromptBeDisplayed) {
+      screen.getByText(
+        'Remove the System Administrator card to leave this screen.'
+      );
+    } else {
+      expect(
+        screen.queryByText(
+          'Remove the System Administrator card to leave this screen.'
+        )
+      ).not.toBeInTheDocument();
+    }
+
+    // These buttons are all tested further in their respective test files
+    screen.getByRole('button', { name: 'Reboot from USB' });
+    screen.getByRole('button', { name: 'Reboot to BIOS' });
+    screen.getByRole('button', { name: 'Unconfigure Machine' });
+
+    if (shouldQuitButtonBeDisplayed) {
+      screen.getByRole('button', { name: 'Quit' });
+    } else {
+      expect(
+        screen.queryByRole('button', { name: 'Quit' })
+      ).not.toBeInTheDocument();
+    }
+  }
+);
+
+test('Quit button makes expected call', () => {
+  mockOf(isVxDev).mockImplementation(() => true);
+  window.kiosk = fakeKiosk();
+  const logger = fakeLogger();
+  const unconfigureMachine = jest.fn();
+  render(
+    <SystemAdministratorScreenContents
+      logger={logger}
+      primaryText="To adjust settings for the current election, please insert an Election Manager card."
+      unconfigureMachine={unconfigureMachine}
+      usbDriveStatus={usbstick.UsbDriveStatus.mounted}
+    />
+  );
+
+  userEvent.click(screen.getByRole('button', { name: 'Quit' }));
+  expect(window.kiosk.quit).toBeCalledTimes(1);
+});
+
+test('Quit button does nothing when kiosk is undefined', () => {
+  mockOf(isVxDev).mockImplementation(() => true);
+  window.kiosk = undefined;
+  const logger = fakeLogger();
+  const unconfigureMachine = jest.fn();
+  render(
+    <SystemAdministratorScreenContents
+      logger={logger}
+      primaryText="To adjust settings for the current election, please insert an Election Manager card."
+      unconfigureMachine={unconfigureMachine}
+      usbDriveStatus={usbstick.UsbDriveStatus.mounted}
+    />
+  );
+
+  userEvent.click(screen.getByRole('button', { name: 'Quit' }));
+});

--- a/libs/ui/src/system_administrator_screen_contents.tsx
+++ b/libs/ui/src/system_administrator_screen_contents.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Logger } from '@votingworks/logging';
+import { usbstick } from '@votingworks/utils';
+
+import { Button } from './button';
+import { isVxDev } from './config/features';
+import { Main } from './main';
+import { Prose } from './prose';
+import { RebootFromUsbButton } from './reboot_from_usb_button';
+import { RebootToBiosButton } from './reboot_to_bios_button';
+import { UnconfigureMachineButton } from './unconfigure_machine_button';
+
+interface Props {
+  displayRemoveCardToLeavePrompt?: boolean;
+  logger: Logger;
+  primaryText: React.ReactNode;
+  unconfigureMachine: () => Promise<void>;
+  usbDriveStatus: usbstick.UsbDriveStatus;
+}
+
+/**
+ * A component for system administrator (formerly super admin) screen contents on non-VxAdmin
+ * machines
+ */
+export function SystemAdministratorScreenContents({
+  displayRemoveCardToLeavePrompt,
+  logger,
+  primaryText,
+  unconfigureMachine,
+  usbDriveStatus,
+}: Props): JSX.Element {
+  return (
+    <Main padded centerChild>
+      <Prose textCenter>
+        <p>{primaryText}</p>
+        {displayRemoveCardToLeavePrompt && (
+          <p>Remove the System Administrator card to leave this screen.</p>
+        )}
+        <p>
+          <RebootFromUsbButton
+            usbDriveStatus={usbDriveStatus}
+            logger={logger}
+          />
+        </p>
+        <p>
+          <RebootToBiosButton logger={logger} />
+        </p>
+        <p>
+          <UnconfigureMachineButton unconfigureMachine={unconfigureMachine} />
+        </p>
+        {isVxDev() && (
+          <p>
+            <Button onPress={() => window.kiosk?.quit()}>Quit</Button>
+          </p>
+        )}
+      </Prose>
+    </Main>
+  );
+}

--- a/libs/ui/src/unconfigure_machine_button.test.tsx
+++ b/libs/ui/src/unconfigure_machine_button.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import { sleep } from '@votingworks/utils';
+
+import {
+  MIN_TIME_TO_UNCONFIGURE_MACHINE_MS,
+  UnconfigureMachineButton,
+} from './unconfigure_machine_button';
+
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
+  return {
+    ...jest.requireActual('@votingworks/utils'),
+    sleep: jest.fn(),
+  };
+});
+
+test('UnconfigureMachineButton interactions', async () => {
+  const unconfigureMachine = jest.fn();
+  render(<UnconfigureMachineButton unconfigureMachine={unconfigureMachine} />);
+
+  // Cancel the first time
+  userEvent.click(screen.getByRole('button', { name: 'Unconfigure Machine' }));
+  let modal = await screen.findByRole('alertdialog');
+  within(modal).getByRole('heading', {
+    name: 'Delete all election data?',
+  });
+  userEvent.click(within(modal).getByRole('button', { name: 'Cancel' }));
+  await waitFor(() => expect(modal).not.toBeInTheDocument());
+
+  // Proceed the second time
+  userEvent.click(screen.getByRole('button', { name: 'Unconfigure Machine' }));
+  modal = await screen.findByRole('alertdialog');
+  within(modal).getByRole('heading', {
+    name: 'Delete all election data?',
+  });
+  userEvent.click(
+    within(modal).getByRole('button', {
+      name: 'Yes, Delete Election Data',
+    })
+  );
+  await within(modal).findByText(/Deleting election data/);
+  await waitFor(() =>
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+  );
+
+  expect(unconfigureMachine).toHaveBeenCalledTimes(1);
+  expect(sleep).toHaveBeenCalledTimes(1);
+  const sleepTime = (sleep as jest.Mock).mock.calls[0][0];
+  expect(sleepTime).toBeGreaterThan(0);
+  expect(sleepTime).toBeLessThan(MIN_TIME_TO_UNCONFIGURE_MACHINE_MS);
+});
+
+test('UnconfigureMachineButton does not sleep when not necessary', async () => {
+  const unconfigureMachine = jest.fn(async () => {
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, MIN_TIME_TO_UNCONFIGURE_MACHINE_MS);
+    });
+  });
+  render(<UnconfigureMachineButton unconfigureMachine={unconfigureMachine} />);
+
+  userEvent.click(screen.getByRole('button', { name: 'Unconfigure Machine' }));
+  const modal = await screen.findByRole('alertdialog');
+  userEvent.click(
+    within(modal).getByRole('button', {
+      name: 'Yes, Delete Election Data',
+    })
+  );
+  await waitFor(() =>
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+  );
+
+  expect(unconfigureMachine).toHaveBeenCalledTimes(1);
+  expect(sleep).toHaveBeenCalledTimes(0);
+});

--- a/libs/ui/src/unconfigure_machine_button.tsx
+++ b/libs/ui/src/unconfigure_machine_button.tsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react';
+import { sleep } from '@votingworks/utils';
+
+import { Button } from './button';
+import { Loading } from './loading';
+import { Modal } from './modal';
+import { Prose } from './prose';
+
+interface Props {
+  unconfigureMachine: () => Promise<void>;
+}
+
+/**
+ * Because machine unconfiguration can be close to instantaneous on some machines, add an
+ * artificial delay (as needed) such that the "Deleting election data..." text is visible, and
+ * users get proper feedback
+ */
+export const MIN_TIME_TO_UNCONFIGURE_MACHINE_MS = 1000;
+
+/**
+ * A button with a confirmation modal for unconfiguring machines
+ */
+export function UnconfigureMachineButton(props: Props): JSX.Element {
+  const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);
+  const [isUnconfiguringMachine, setIsUnconfiguringMachine] = useState(false);
+
+  function openConfirmationModal() {
+    setIsConfirmationModalOpen(true);
+  }
+
+  function closeConfirmationModal() {
+    setIsConfirmationModalOpen(false);
+  }
+
+  async function unconfigureMachine() {
+    setIsUnconfiguringMachine(true);
+
+    const start = new Date().getTime();
+    await props.unconfigureMachine();
+    const timeToUnconfigureMachineMs = new Date().getTime() - start;
+
+    if (timeToUnconfigureMachineMs < MIN_TIME_TO_UNCONFIGURE_MACHINE_MS) {
+      await sleep(
+        MIN_TIME_TO_UNCONFIGURE_MACHINE_MS - timeToUnconfigureMachineMs
+      );
+    }
+
+    closeConfirmationModal();
+    setIsUnconfiguringMachine(false);
+  }
+
+  return (
+    <React.Fragment>
+      <Button danger onPress={openConfirmationModal}>
+        Unconfigure Machine
+      </Button>
+      {isConfirmationModalOpen && (
+        <Modal
+          content={
+            isUnconfiguringMachine ? (
+              <Loading>Deleting election data</Loading>
+            ) : (
+              <Prose textCenter>
+                <h1>Delete all election data?</h1>
+                <p>
+                  This will delete the election configuration and any
+                  election-specific data on this machine.
+                </p>
+              </Prose>
+            )
+          }
+          actions={
+            !isUnconfiguringMachine && (
+              <React.Fragment>
+                <Button onPress={unconfigureMachine} danger>
+                  Yes, Delete Election Data
+                </Button>
+                <Button onPress={closeConfirmationModal}>Cancel</Button>
+              </React.Fragment>
+            )
+          }
+        />
+      )}
+    </React.Fragment>
+  );
+}

--- a/vxsuite.code-workspace
+++ b/vxsuite.code-workspace
@@ -148,6 +148,7 @@
       "uncastable",
       "unconfigure",
       "unconfigured",
+      "unconfiguring",
       "undervote",
       "undervoted",
       "undervotes",
@@ -155,6 +156,7 @@
       "unprogram",
       "unprogramming",
       "unprograms",
+      "usbstick",
       "votingworks",
       "VVSG",
       "yesno"


### PR DESCRIPTION
_Commit by commit reviewing recommended_

## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/1980 (and also https://github.com/votingworks/vxsuite/issues/2209)

This PR updates the non-VxAdmin system administrator (formerly super admin) screens, specifically:

- Adding instructional copy
- Adding an "Unconfigure Machine" button to remove election data - now more necessary because we check that election manager (formerly admin) card hashes match machine election hashes, making it easier for those users to get locked out
- Updating the "Reset" button to be a "Quit" button and only visible on VxDev

Under the hood, the PR also moves the logic for these screens to a shared location, since they are (and will likely remain) consistent across machines!

## Demo Screenshots and Video

_VxCentralScan_

![vxcentralscan](https://user-images.githubusercontent.com/12616928/181833969-9470f096-6aa5-4592-977f-9e1c04d8a38e.png)

_VxMark_

![vxmark](https://user-images.githubusercontent.com/12616928/181833972-b09312ca-7ecd-4cfd-9d3c-0793bbcd847b.png)

_VxScan_

![vxscan](https://user-images.githubusercontent.com/12616928/181833973-bad993d8-636a-44dc-8874-a4239b69ea5d.png)

_Unconfiguration confirmation modal_

![confirmation-modal](https://user-images.githubusercontent.com/12616928/181834340-8c9aa87b-9131-44d1-b355-2e323a4306ac.png)

_Unconfiguration flow on VxCentralScan_

Description of video
- Election manager is auth'd, and machine is configured
- Election manager locks machine
- System administrator auths in
- System administrator unconfigures machine
- System administrator locks machine
- Election manager auths in, and machine is unconfigrued

https://user-images.githubusercontent.com/12616928/181834375-8db0d14f-eb76-4618-bd5b-028e2b38a605.mov

_Quit button on VxDev_

![vxdev](https://user-images.githubusercontent.com/12616928/181835263-5a9edfdd-a3d6-49e4-8593-1c3924a60806.png)

## Testing Plan 

- [x] Added tests to libs/ui and frontends
- [x] Tested unconfiguration flow on all non-VxAdmin machines manually

## Checklist
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ Relying on existing logging for actions like unconfiguration
- [x] I have added JSDoc comments to any newly introduced exports
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates