### PR TITLE
refactor(scan): Combine page interpretations in SimpleInterpreter

### DIFF
--- a/frontends/precinct-scanner/src/app.test.tsx
+++ b/frontends/precinct-scanner/src/app.test.tsx
@@ -706,7 +706,7 @@ test('voter can cast a ballot that needs review and adjudicate as desired', asyn
       body: scannerStatus({
         state: 'needs_review',
         interpretation: {
-          type: 'INTERPRETATION_NEEDS_REVIEW',
+          type: 'NeedsReviewSheet',
           reasons: [{ type: AdjudicationReason.BlankBallot }],
         },
       }),
@@ -777,7 +777,7 @@ test('voter can cast a rejected ballot', async () => {
       body: scannerStatus({
         state: 'rejected',
         interpretation: {
-          type: 'INTERPRETATION_INVALID',
+          type: 'InvalidSheet',
           reason: 'invalid_election_hash',
         },
       }),
@@ -844,7 +844,7 @@ test('voter can cast another ballot while the success screen is showing', async 
       body: scannerStatus({
         state: 'needs_review',
         interpretation: {
-          type: 'INTERPRETATION_NEEDS_REVIEW',
+          type: 'NeedsReviewSheet',
           reasons: [{ type: AdjudicationReason.BlankBallot }],
         },
       }),

--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -517,9 +517,7 @@ export function AppRoot({
           />
         );
       case 'needs_review':
-        assert(
-          scannerStatus.interpretation?.type === 'INTERPRETATION_NEEDS_REVIEW'
-        );
+        assert(scannerStatus.interpretation?.type === 'NeedsReviewSheet');
         return (
           <ScanWarningScreen
             adjudicationReasonInfo={scannerStatus.interpretation.reasons}
@@ -533,7 +531,7 @@ export function AppRoot({
         return (
           <ScanErrorScreen
             error={
-              scannerStatus.interpretation?.type === 'INTERPRETATION_INVALID'
+              scannerStatus.interpretation?.type === 'InvalidSheet'
                 ? scannerStatus.interpretation.reason
                 : scannerStatus.error
             }

--- a/libs/api/src/services/scan/index.ts
+++ b/libs/api/src/services/scan/index.ts
@@ -677,29 +677,29 @@ export type InvalidInterpretationReason = z.infer<
   typeof InvalidInterpretationReasonSchema
 >;
 
-export type InterpretationResult =
+export type SheetInterpretation =
   | {
-      type: 'INTERPRETATION_VALID';
+      type: 'ValidSheet';
     }
   | {
-      type: 'INTERPRETATION_INVALID';
+      type: 'InvalidSheet';
       reason: InvalidInterpretationReason;
     }
   | {
-      type: 'INTERPRETATION_NEEDS_REVIEW';
+      type: 'NeedsReviewSheet';
       reasons: AdjudicationReasonInfo[];
     };
-export const InterpretationResultSchema: z.ZodSchema<InterpretationResult> =
+export const SheetInterpretationSchema: z.ZodSchema<SheetInterpretation> =
   z.union([
     z.object({
-      type: z.literal('INTERPRETATION_VALID'),
+      type: z.literal('ValidSheet'),
     }),
     z.object({
-      type: z.literal('INTERPRETATION_INVALID'),
+      type: z.literal('InvalidSheet'),
       reason: InvalidInterpretationReasonSchema,
     }),
     z.object({
-      type: z.literal('INTERPRETATION_NEEDS_REVIEW'),
+      type: z.literal('NeedsReviewSheet'),
       reasons: z.array(AdjudicationReasonInfoSchema),
     }),
   ]);
@@ -719,7 +719,7 @@ export type PrecinctScannerErrorType = z.infer<
 
 export interface PrecinctScannerMachineStatus {
   state: PrecinctScannerState;
-  interpretation?: InterpretationResult;
+  interpretation?: SheetInterpretation;
   error?: PrecinctScannerErrorType;
 }
 export interface PrecinctScannerStatus extends PrecinctScannerMachineStatus {
@@ -730,7 +730,7 @@ export interface PrecinctScannerStatus extends PrecinctScannerMachineStatus {
 export const PrecinctScannerStatusSchema: z.ZodSchema<PrecinctScannerStatus> =
   z.object({
     state: PrecinctScannerStateSchema,
-    interpretation: InterpretationResultSchema.optional(),
+    interpretation: SheetInterpretationSchema.optional(),
     error: PrecinctScannerErrorTypeSchema.optional(),
     ballotsCounted: z.number(),
     canUnconfigure: z.boolean(),

--- a/services/scan/src/precinct_scanner_app.test.ts
+++ b/services/scan/src/precinct_scanner_app.test.ts
@@ -188,8 +188,8 @@ test('configure and scan hmpb', async () => {
   await mockPlustek.simulateLoadSheet(ballotImages.completeHmpb);
   await waitForStatus(app, { state: 'ready_to_scan' });
 
-  const interpretation: Scan.InterpretationResult = {
-    type: 'INTERPRETATION_VALID',
+  const interpretation: Scan.SheetInterpretation = {
+    type: 'ValidSheet',
   };
 
   await post(app, '/scanner/scan');
@@ -220,8 +220,8 @@ test('configure and scan bmd ballot', async () => {
   await mockPlustek.simulateLoadSheet(ballotImages.completeBmd);
   await waitForStatus(app, { state: 'ready_to_scan' });
 
-  const interpretation: Scan.InterpretationResult = {
-    type: 'INTERPRETATION_VALID',
+  const interpretation: Scan.SheetInterpretation = {
+    type: 'ValidSheet',
   };
 
   await post(app, '/scanner/scan');
@@ -254,8 +254,8 @@ function undervote(contestId: string, expected = 1): AdjudicationReasonInfo {
     expected,
   };
 }
-const needsReviewInterpretation: Scan.InterpretationResult = {
-  type: 'INTERPRETATION_NEEDS_REVIEW',
+const needsReviewInterpretation: Scan.SheetInterpretation = {
+  type: 'NeedsReviewSheet',
   reasons: [
     undervote('mayor'),
     undervote('controller'),
@@ -333,8 +333,8 @@ test('invalid ballot rejected', async () => {
   await mockPlustek.simulateLoadSheet(ballotImages.wrongElection);
   await waitForStatus(app, { state: 'ready_to_scan' });
 
-  const interpretation: Scan.InterpretationResult = {
-    type: 'INTERPRETATION_INVALID',
+  const interpretation: Scan.SheetInterpretation = {
+    type: 'InvalidSheet',
     reason: 'invalid_election_hash',
   };
 
@@ -388,8 +388,8 @@ test('scanner powered off while accepting', async () => {
   await mockPlustek.simulateLoadSheet(ballotImages.completeBmd);
   await waitForStatus(app, { state: 'ready_to_scan' });
 
-  const interpretation: Scan.InterpretationResult = {
-    type: 'INTERPRETATION_VALID',
+  const interpretation: Scan.SheetInterpretation = {
+    type: 'ValidSheet',
   };
 
   await post(app, '/scanner/scan');
@@ -425,8 +425,8 @@ test('scanner powered off after accepting', async () => {
   await mockPlustek.simulateLoadSheet(ballotImages.completeBmd);
   await waitForStatus(app, { state: 'ready_to_scan' });
 
-  const interpretation: Scan.InterpretationResult = {
-    type: 'INTERPRETATION_VALID',
+  const interpretation: Scan.SheetInterpretation = {
+    type: 'ValidSheet',
   };
 
   await post(app, '/scanner/scan');
@@ -461,8 +461,8 @@ test('scanner powered off while rejecting', async () => {
   await mockPlustek.simulateLoadSheet(ballotImages.wrongElection);
   await waitForStatus(app, { state: 'ready_to_scan' });
 
-  const interpretation: Scan.InterpretationResult = {
-    type: 'INTERPRETATION_INVALID',
+  const interpretation: Scan.SheetInterpretation = {
+    type: 'InvalidSheet',
     reason: 'invalid_election_hash',
   };
 
@@ -537,8 +537,8 @@ test('insert second ballot before first ballot accept', async () => {
   await mockPlustek.simulateLoadSheet(ballotImages.completeBmd);
   await waitForStatus(app, { state: 'ready_to_scan' });
 
-  const interpretation: Scan.InterpretationResult = {
-    type: 'INTERPRETATION_VALID',
+  const interpretation: Scan.SheetInterpretation = {
+    type: 'ValidSheet',
   };
 
   await post(app, '/scanner/scan');
@@ -582,8 +582,8 @@ test('insert second ballot while first ballot is rejecting', async () => {
   await mockPlustek.simulateLoadSheet(ballotImages.wrongElection);
   await waitForStatus(app, { state: 'ready_to_scan' });
 
-  const interpretation: Scan.InterpretationResult = {
-    type: 'INTERPRETATION_INVALID',
+  const interpretation: Scan.SheetInterpretation = {
+    type: 'InvalidSheet',
     reason: 'invalid_election_hash',
   };
 
@@ -675,8 +675,8 @@ test('jam on accept', async () => {
   await mockPlustek.simulateLoadSheet(ballotImages.completeBmd);
   await waitForStatus(app, { state: 'ready_to_scan' });
 
-  const interpretation: Scan.InterpretationResult = {
-    type: 'INTERPRETATION_VALID',
+  const interpretation: Scan.SheetInterpretation = {
+    type: 'ValidSheet',
   };
 
   await post(app, '/scanner/scan');


### PR DESCRIPTION


## Overview
Instead of combining the interpretations for the two pages of a ballot in the state machine module, we do it behind the interface of the interpreter. This will allow easier mocking of the interpreter in tests.

I also changed the types so that the state machine event type isn't reused as the interpretation result type. Instead, I created a new type to represent the interpretation of a ballot sheet.

## Demo Video or Screenshot
N/A

## Testing Plan 
Existing tests

