### PR TITLE
Fix BMD Audio + Add Volume Button

### DIFF
--- a/frontends/bmd/src/app.tsx
+++ b/frontends/bmd/src/app.tsx
@@ -18,6 +18,7 @@ import {
   ScreenReader,
   AriaScreenReader,
   SpeechSynthesisTextToSpeech,
+  KioskTextToSpeech,
 } from './utils/ScreenReader';
 import { getUsEnglishVoice } from './utils/voices';
 
@@ -42,7 +43,9 @@ export interface Props {
 
 export function App({
   screenReader = new AriaScreenReader(
-    new SpeechSynthesisTextToSpeech(memoize(getUsEnglishVoice))
+    window.kiosk
+      ? new KioskTextToSpeech()
+      : new SpeechSynthesisTextToSpeech(memoize(getUsEnglishVoice))
   ),
 
   card = new WebServiceCard(),

--- a/frontends/bmd/src/app.tsx
+++ b/frontends/bmd/src/app.tsx
@@ -79,11 +79,12 @@ export function App({
     }
   }, [internalHardware, screenReader]);
 
-  /* istanbul ignore next - need to figure out how to test this */
-  const onKeyPress = useCallback(
+  const onKeyDown = useCallback(
     async (event: React.KeyboardEvent) => {
       if (event.key === 'r') {
         await screenReader.toggle();
+      } else if (event.key === 'F17') {
+        screenReader.changeVolume();
       }
     },
     [screenReader]
@@ -137,7 +138,7 @@ export function App({
     <BrowserRouter>
       <FocusManager
         screenReader={screenReader}
-        onKeyPress={onKeyPress}
+        onKeyDown={onKeyDown}
         onClickCapture={onClick}
         onFocusCapture={onFocus}
       >

--- a/frontends/bmd/src/components/focus_manager.tsx
+++ b/frontends/bmd/src/components/focus_manager.tsx
@@ -16,16 +16,16 @@ export interface Props {
   onClickCapture?: React.DOMAttributes<HTMLElement>['onClickCapture'];
   onFocus?: React.DOMAttributes<HTMLElement>['onFocus'];
   onFocusCapture?: React.DOMAttributes<HTMLElement>['onFocusCapture'];
-  onKeyPress?: React.DOMAttributes<HTMLElement>['onKeyPress'];
-  onKeyPressCapture?: React.DOMAttributes<HTMLElement>['onKeyPressCapture'];
+  onKeyDown?: React.DOMAttributes<HTMLElement>['onKeyDown'];
+  onKeyDownCapture?: React.DOMAttributes<HTMLElement>['onKeyDownCapture'];
   screenReader: ScreenReader;
 }
 
 export function FocusManager({
-  onKeyPress,
+  onKeyDown,
   onClick,
   onFocus,
-  onKeyPressCapture,
+  onKeyDownCapture,
   onClickCapture,
   onFocusCapture,
   children,
@@ -58,10 +58,10 @@ export function FocusManager({
     <StyledFocusManager
       ref={screen}
       tabIndex={-1}
-      onKeyPress={onKeyPress}
+      onKeyDown={onKeyDown}
       onClick={onClick}
       onFocus={onFocus}
-      onKeyPressCapture={onKeyPressCapture}
+      onKeyDownCapture={onKeyDownCapture}
       onClickCapture={onClickCapture}
       onFocusCapture={onFocusCapture}
     >

--- a/frontends/bmd/src/config/types.ts
+++ b/frontends/bmd/src/config/types.ts
@@ -199,6 +199,11 @@ export interface TextToSpeech {
    * Toggles muted state, or sets it according to the argument.
    */
   toggleMuted(muted?: boolean): void;
+
+  /**
+   * Changes the current volume setting either up or down.
+   */
+  changeVolume?(): void;
 }
 
 /**
@@ -272,6 +277,11 @@ export interface ScreenReader {
    * Directly triggers speech of an event target. Resolves when speaking is done.
    */
   speakEventTarget(target?: EventTarget, options?: SpeakOptions): Promise<void>;
+
+  /**
+   * Changes the current volume setting either up or down.
+   */
+  changeVolume(): void;
 }
 
 export interface VoiceSelector {

--- a/frontends/bmd/src/index.tsx
+++ b/frontends/bmd/src/index.tsx
@@ -6,6 +6,7 @@ import { App } from './app';
 import {
   AriaScreenReader,
   SpeechSynthesisTextToSpeech,
+  KioskTextToSpeech,
 } from './utils/ScreenReader';
 import { memoize } from './utils/memoize';
 import { getUsEnglishVoice } from './utils/voices';
@@ -15,13 +16,16 @@ import { getUsEnglishVoice } from './utils/voices';
 // since we don't really care about page URLs anyway?
 const readerEnabled =
   new URLSearchParams(window.location.search).get('reader') === 'on';
-const tts = new SpeechSynthesisTextToSpeech(memoize(getUsEnglishVoice));
-const screenReader = new AriaScreenReader(tts);
+const screenReader = new AriaScreenReader(
+  window.kiosk
+    ? new KioskTextToSpeech()
+    : new SpeechSynthesisTextToSpeech(memoize(getUsEnglishVoice))
+);
 
 if (readerEnabled) {
-  tts.unmute();
+  screenReader.unmute();
 } else {
-  tts.mute();
+  screenReader.mute();
 }
 
 ReactDom.render(

--- a/frontends/bmd/src/utils/ScreenReader/aria_screen_reader.ts
+++ b/frontends/bmd/src/utils/ScreenReader/aria_screen_reader.ts
@@ -134,6 +134,12 @@ export class AriaScreenReader implements ScreenReader {
     return this.cleanDescription(this.describeNode(node));
   }
 
+  changeVolume(): void {
+    if (this.tts.changeVolume) {
+      this.tts.changeVolume();
+    }
+  }
+
   /**
    * Assembles all text to be spoken for a node but does not clean it up yet.
    */

--- a/frontends/bmd/src/utils/ScreenReader/index.ts
+++ b/frontends/bmd/src/utils/ScreenReader/index.ts
@@ -1,6 +1,7 @@
 import { SpeechSynthesisTextToSpeech } from './speech_synthesis_text_to_speech';
+import { KioskTextToSpeech } from './kiosk_text_to_speech';
 import { AriaScreenReader } from './aria_screen_reader';
 import type { ScreenReader } from '../../config/types';
 
 export type { ScreenReader };
-export { AriaScreenReader, SpeechSynthesisTextToSpeech };
+export { AriaScreenReader, SpeechSynthesisTextToSpeech, KioskTextToSpeech };

--- a/frontends/bmd/src/utils/ScreenReader/kiosk_text_to_speech.test.ts
+++ b/frontends/bmd/src/utils/ScreenReader/kiosk_text_to_speech.test.ts
@@ -1,0 +1,81 @@
+import { fakeKiosk } from '@votingworks/test-utils';
+import { KioskTextToSpeech } from './kiosk_text_to_speech';
+
+beforeEach(() => {
+  window.kiosk = undefined;
+});
+
+it('speaks an utterance when given text to speak', async () => {
+  window.kiosk = fakeKiosk();
+  const tts = new KioskTextToSpeech();
+
+  await tts.speak('hello world');
+  expect(window.kiosk.cancelSpeak).toHaveBeenCalled();
+  expect(window.kiosk.speak).toHaveBeenCalledWith('hello world', {
+    volume: 50,
+  });
+});
+
+it('delegates `stop` to `KioskBrowser#cancelSpeak`', () => {
+  window.kiosk = fakeKiosk();
+  const tts = new KioskTextToSpeech();
+
+  expect(window.kiosk.cancelSpeak).not.toHaveBeenCalled();
+  tts.stop();
+  expect(window.kiosk.cancelSpeak).toHaveBeenCalled();
+});
+
+it('is unmuted by default, which means utterances are spoken', async () => {
+  window.kiosk = fakeKiosk();
+  const tts = new KioskTextToSpeech();
+
+  expect(tts.isMuted()).toBe(false);
+  await tts.speak('hello world');
+  expect(window.kiosk.speak).toHaveBeenCalledWith('hello world', {
+    volume: 50,
+  });
+});
+
+it('can be muted, which means no utterances are spoken', async () => {
+  window.kiosk = fakeKiosk();
+  const tts = new KioskTextToSpeech();
+
+  tts.mute();
+  expect(tts.isMuted()).toBe(true);
+  await tts.speak('hello world');
+  expect(window.kiosk.speak).not.toHaveBeenCalled();
+});
+
+it('can be muted and then unmuted, which means utterances are spoken', async () => {
+  window.kiosk = fakeKiosk();
+  const tts = new KioskTextToSpeech();
+
+  tts.mute();
+  tts.unmute();
+  await tts.speak('hello world');
+  expect(window.kiosk.speak).toHaveBeenCalledWith('hello world', {
+    volume: 50,
+  });
+});
+
+it('can toggle muting', () => {
+  window.kiosk = fakeKiosk();
+  const tts = new KioskTextToSpeech();
+
+  tts.toggleMuted();
+  expect(tts.isMuted()).toBe(true);
+
+  tts.toggleMuted();
+  expect(tts.isMuted()).toBe(false);
+});
+
+it('can set muted by calling toggle with an argument', () => {
+  window.kiosk = fakeKiosk();
+  const tts = new KioskTextToSpeech();
+
+  tts.toggleMuted(false);
+  expect(tts.isMuted()).toBe(false);
+
+  tts.toggleMuted(true);
+  expect(tts.isMuted()).toBe(true);
+});

--- a/frontends/bmd/src/utils/ScreenReader/kiosk_text_to_speech.ts
+++ b/frontends/bmd/src/utils/ScreenReader/kiosk_text_to_speech.ts
@@ -1,0 +1,71 @@
+import { assert } from '@votingworks/utils';
+import { SpeakOptions, TextToSpeech } from '../../config/types';
+
+export class KioskTextToSpeech implements TextToSpeech {
+  private muted = false;
+  private readonly volume = 50;
+
+  constructor() {
+    assert(window.kiosk, 'KioskTextToSpeech requires window.kiosk');
+  }
+
+  /**
+   * Directly triggers speech of text. Resolves when speaking is finished
+   * or cancelled.
+   */
+  async speak(text: string, { now = true }: SpeakOptions = {}): Promise<void> {
+    assert(now, 'method "speak"  with "options.now = false" is not supported');
+    assert(window.kiosk);
+
+    if (this.isMuted()) {
+      return;
+    }
+
+    if (now) {
+      await window.kiosk.cancelSpeak();
+    }
+
+    await window.kiosk.speak(text, { volume: this.volume });
+  }
+
+  /**
+   * Stops any speaking that is currently happening.
+   */
+  stop(): void {
+    assert(window.kiosk);
+    void window.kiosk.cancelSpeak();
+  }
+
+  /**
+   * Prevents any sound from being made but otherwise functions normally.
+   */
+  mute(): void {
+    this.stop();
+    this.muted = true;
+  }
+
+  /**
+   * Allows sounds to be made.
+   */
+  unmute(): void {
+    this.muted = false;
+  }
+
+  /**
+   * Checks whether this TTS is muted.
+   */
+  isMuted(): boolean {
+    return this.muted;
+  }
+
+  /**
+   * Toggles muted state, or sets it according to the argument.
+   */
+  toggleMuted(muted = !this.isMuted()): void {
+    if (muted) {
+      this.mute();
+    } else {
+      this.unmute();
+    }
+  }
+}

--- a/frontends/bmd/test/helpers/fake_tts.ts
+++ b/frontends/bmd/test/helpers/fake_tts.ts
@@ -19,5 +19,6 @@ export function fakeTts(): jest.Mocked<TextToSpeech> {
     toggleMuted: jest.fn((muted = !isMuted) => {
       isMuted = muted;
     }),
+    changeVolume: jest.fn(),
   };
 }

--- a/libs/@types/kiosk-browser/kiosk-browser.d.ts
+++ b/libs/@types/kiosk-browser/kiosk-browser.d.ts
@@ -107,6 +107,10 @@ declare namespace KioskBrowser {
     mode?: number;
   }
 
+  export interface SpeakOptions {
+    volume: number;
+  }
+
   export interface FileFilter {
     // Docs: http://electronjs.org/docs/api/structures/file-filter
     extensions: string[];
@@ -243,6 +247,10 @@ declare namespace KioskBrowser {
     };
 
     sign(params: SignParams): Promise<string>;
+
+    // speech dispatcher
+    speak(text: string, options: SpeakOptions): Promise<void>;
+    cancelSpeak(): Promise<void>;
 
     reboot(): Promise<void>;
 

--- a/libs/test-utils/src/fake_kiosk.ts
+++ b/libs/test-utils/src/fake_kiosk.ts
@@ -98,6 +98,8 @@ export function fakeKiosk({
       get: jest.fn(),
     },
     sign: jest.fn(),
+    speak: jest.fn().mockResolvedValue(undefined),
+    cancelSpeak: jest.fn().mockResolvedValue(undefined),
     log: jest.fn(),
     reboot: jest.fn(),
     // eslint-disable-next-line vx/gts-identifiers


### PR DESCRIPTION
## Overview
Closes #2117 and makes an initial pass at #1484. Split into three commits:
1. Updates `KioskBrowser` interfaces to include the `speak` APIs introduced in [votingworks/kiosk-broswer#130](https://github.com/votingworks/kiosk-browser/pull/130)
2. Adds `KioskTextToSpeech` class which uses the new `kiosk-browser` APIs, and is active when `window.kiosk` is present. This fixes BMD audio and closes #2117.
3. Adds a preliminary volume control feature. The single volume button on the audio controller will change the volume up and down, cycling. An initial pass at #1484.

I don't have the volumes mapped to decibel levels. I'm yet quite sure how to do that, or if the choice of headphones affects that. But the VVSG range is, I think, an absolute maximum and minimum - not the maximum and minimum we have to use. We can't go outside of the range they specify. Because the VVSG maximum - 100dB - is equivalent to a jet plane taking off or a jackhammer. Perhaps I am misunderstanding something. 

In any case, for this first pass, I think we should just settle on reasonable defaults. In this implementation, there are 10 possible audio levels (1 of 10 to 10 of 10) mapping to an underlying audio setting of 28% to 100% volume. That underlying range is what roughly I think a user might need, and it led to pretty-ish numbers.

## Testing Plan 
- Unit tests for `KioskTextToSpeech`
- Test for the keypress detection in `app.test.tsx`

## Checklist
- [ ] ~~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~~
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
