### PR TITLE
Distinguish Draft Ballots tab from Ballots tab

### DIFF
--- a/frontends/election-manager/src/components/election_manager.tsx
+++ b/frontends/election-manager/src/components/election_manager.tsx
@@ -159,10 +159,7 @@ export function ElectionManager(): JSX.Element {
             <DefinitionContestsScreen allowEditing={false} />
           </Route>
           <Route exact path={routerPaths.ballotsList}>
-            <BallotListScreen />
-          </Route>
-          <Route exact path={routerPaths.printedBallotsReport}>
-            <PrintedBallotsReportScreen />
+            <BallotListScreen draftMode />
           </Route>
           <Route
             exact
@@ -178,7 +175,7 @@ export function ElectionManager(): JSX.Element {
               }),
             ]}
           >
-            <BallotScreen />
+            <BallotScreen draftMode />
           </Route>
           <Route exact path={routerPaths.smartcards}>
             <Redirect

--- a/frontends/election-manager/src/components/hand_marked_paper_ballot.tsx
+++ b/frontends/election-manager/src/components/hand_marked_paper_ballot.tsx
@@ -1,4 +1,4 @@
-import { assert, integers, take } from '@votingworks/utils';
+import { assert, integers, take, throwIllegalValue } from '@votingworks/utils';
 import React, { useLayoutEffect, useRef, useContext } from 'react';
 import ReactDom from 'react-dom';
 import styled from 'styled-components';
@@ -147,6 +147,27 @@ function dualLanguageComposer(
       normal: true,
     });
   };
+}
+
+function ballotModeToBallotTitle(ballotMode: BallotMode): string {
+  switch (ballotMode) {
+    case BallotMode.Draft: {
+      return 'DRAFT BALLOT';
+    }
+    case BallotMode.Official: {
+      return 'Official Ballot';
+    }
+    case BallotMode.Sample: {
+      return 'SAMPLE BALLOT';
+    }
+    case BallotMode.Test: {
+      return 'TEST BALLOT';
+    }
+    /* istanbul ignore next: Compile-time check for completeness */
+    default: {
+      throwIllegalValue(ballotMode);
+    }
+  }
 }
 
 const qrCodeTargetClassName = 'qr-code-target';
@@ -823,6 +844,11 @@ export function HandMarkedPaperBallot({
             <div>SAMPLE</div>
           </Watermark>
         )}
+        {ballotMode === BallotMode.Draft && (
+          <Watermark>
+            <div>DRAFT</div>
+          </Watermark>
+        )}
       </div>
 
       <Content>
@@ -851,11 +877,9 @@ export function HandMarkedPaperBallot({
               )}
               <HandMarkedPaperBallotProse>
                 <h2>
-                  {ballotMode === BallotMode.Official
-                    ? t('Official Ballot', { lng: locales.primary })
-                    : ballotMode === BallotMode.Test
-                    ? t('TEST BALLOT', { lng: locales.primary })
-                    : t('SAMPLE BALLOT', { lng: locales.primary })}
+                  {t(ballotModeToBallotTitle(ballotMode), {
+                    lng: locales.primary,
+                  })}
                 </h2>
                 <h3>
                   {ballotStyle.partyId && primaryPartyName} {title}
@@ -870,13 +894,9 @@ export function HandMarkedPaperBallot({
                 {localeElection && locales.secondary && (
                   <p>
                     <strong>
-                      {ballotMode === BallotMode.Official
-                        ? t('Official Ballot', { lng: locales.secondary })
-                        : ballotMode === BallotMode.Test
-                        ? t('TEST BALLOT', { lng: locales.secondary })
-                        : t('SAMPLE BALLOT', {
-                            lng: locales.secondary,
-                          })}
+                      {t(ballotModeToBallotTitle(ballotMode), {
+                        lng: locales.secondary,
+                      })}
                     </strong>
                     <br />
                     <strong>

--- a/frontends/election-manager/src/config/types.ts
+++ b/frontends/election-manager/src/config/types.ts
@@ -40,6 +40,7 @@ export enum BallotMode {
   Official = 'live',
   Test = 'test',
   Sample = 'sample',
+  Draft = 'draft',
 }
 
 export interface PrintedBallot {

--- a/frontends/election-manager/src/config/types.ts
+++ b/frontends/election-manager/src/config/types.ts
@@ -37,9 +37,13 @@ export type PrintableBallotType =
   typeof PrintableBallotType[keyof typeof PrintableBallotType];
 
 export enum BallotMode {
+  /** Real ballots to be used and scanned during an election */
   Official = 'live',
+  /** Test ballots to be used and scanned during pre-election testing / L&A */
   Test = 'test',
+  /** Sample ballots to be provided to voters ahead of an election */
   Sample = 'sample',
+  /** Draft ballots to verify that an election definition has been properly configured */
   Draft = 'draft',
 }
 

--- a/frontends/election-manager/src/screens/ballot_list_screen.tsx
+++ b/frontends/election-manager/src/screens/ballot_list_screen.tsx
@@ -20,12 +20,15 @@ import { ExportBallotPdfsButton } from '../components/export_ballot_pdfs_button'
 
 const Header = styled.div`
   display: flex;
-  flex-direction: row-reverse;
   justify-content: space-between;
   margin-bottom: 1rem;
 `;
 
-export function BallotListScreen(): JSX.Element {
+interface Props {
+  draftMode?: boolean;
+}
+
+export function BallotListScreen({ draftMode }: Props): JSX.Element {
   const { electionDefinition, configuredAt } = useContext(AppContext);
   assert(electionDefinition && typeof configuredAt === 'string');
   const { election } = electionDefinition;
@@ -50,12 +53,6 @@ export function BallotListScreen(): JSX.Element {
       <Header>
         <Prose maxWidth={false}>
           <p>
-            <ExportBallotPdfsButton />{' '}
-            <ExportElectionBallotPackageModalButton />
-          </p>
-        </Prose>
-        <Prose maxWidth={false}>
-          <p>
             {`Sort ${pluralize('ballot', ballots.length, true)} by: `}
             <SegmentedButton>
               <Button
@@ -71,6 +68,14 @@ export function BallotListScreen(): JSX.Element {
             </SegmentedButton>
           </p>
         </Prose>
+        {!draftMode && (
+          <Prose maxWidth={false}>
+            <p>
+              <ExportBallotPdfsButton />{' '}
+              <ExportElectionBallotPackageModalButton />
+            </p>
+          </Prose>
+        )}
       </Header>
       <Table>
         <thead>


### PR DESCRIPTION
_Commit-by-commit reviewing recommended_

## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/1975

This PR distinguishes the system admin (super admin) Draft Ballots tab from the election manager (admin) Ballots tab. On the Draft Ballots tab, you can only print draft ballots.

## Demo Screenshots

_Draft Ballots tab on left vs. Ballots tab on right_

<img alt="draft-ballots-1" src="https://user-images.githubusercontent.com/12616928/182436697-40584540-5fc2-4e50-b870-fbc037d0de85.png" width=400 /> <img alt="ballots-1" src="https://user-images.githubusercontent.com/12616928/182436761-c8502102-f62b-4809-b6ef-6828513f8eef.png" width=400 />
<img alt="draft-ballots-2" src="https://user-images.githubusercontent.com/12616928/182436698-f9a8237e-d9fe-488c-9d3a-ff4306837feb.png" width=400 /> <img alt="ballots-2" src="https://user-images.githubusercontent.com/12616928/182436764-4ff8347a-d812-4b31-af79-e699bc18fb54.png" width=400 />

## Testing Plan 

- [x] Added an automated test
- [x] Tested manually

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A
- [x] I have added JSDoc comments to any newly introduced exports
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates