### PR TITLE
feat(scan): Continue scanning first ballot after second ballot removed

### DIFF
--- a/services/scan/src/precinct_scanner_state_machine.ts
+++ b/services/scan/src/precinct_scanner_state_machine.ts
@@ -17,7 +17,6 @@ import {
   interpret,
   InvokeConfig,
   PropertyAssigner,
-  send,
 } from 'xstate';
 import { Scan } from '@votingworks/api';
 import makeDebug from 'debug';
@@ -78,11 +77,6 @@ type ScannerStatusEvent =
   | { type: 'SCANNER_JAM' }
   | { type: 'SCANNER_DISCONNECTED' };
 
-interface InterpretationResultEvent {
-  type: 'INTERPRETATION_RESULT';
-  interpretation: InterpretationResult;
-}
-
 type CommandEvent =
   | { type: 'SCAN' }
   | { type: 'ACCEPT' }
@@ -91,7 +85,6 @@ type CommandEvent =
 
 export type Event =
   | ScannerStatusEvent
-  | InterpretationResultEvent
   | CommandEvent
   | ConfigurationEvent
   | { type: 'SET_INTERPRETATION_MODE'; mode: InterpretationMode };
@@ -431,43 +424,52 @@ function buildMachine(createPlustekClient: CreatePlustekClient) {
           },
         },
         interpreting: {
-          invoke: {
-            src: interpretSheet,
-            onDone: {
-              actions: [
-                assign({ interpretation: (_context, event) => event.data }),
-                send((_context, event) => ({
-                  type: 'INTERPRETATION_RESULT',
-                  interpretation: event.data,
-                })),
+          initial: 'starting',
+          states: {
+            starting: {
+              invoke: {
+                src: interpretSheet,
+                onDone: {
+                  target: 'routing_result',
+                  actions: assign({
+                    interpretation: (_context, event) => event.data,
+                  }),
+                },
+                onError: {
+                  target: '#rejecting',
+                  actions: assign((_context, event) => ({ error: event.data })),
+                },
+              },
+            },
+            routing_result: {
+              always: [
+                {
+                  target: '#ready_to_accept',
+                  cond: (context) => {
+                    assert(context.interpretation);
+                    return context.interpretation.type === 'ValidSheet';
+                  },
+                },
+                {
+                  target: '#rejecting',
+                  cond: (context) => {
+                    assert(context.interpretation);
+                    return context.interpretation.type === 'InvalidSheet';
+                  },
+                },
+                {
+                  target: '#needs_review',
+                  cond: (context) => {
+                    assert(context.interpretation);
+                    return context.interpretation.type === 'NeedsReviewSheet';
+                  },
+                },
               ],
             },
-            onError: {
-              target: 'rejecting',
-              actions: assign((_context, event) => ({ error: event.data })),
-            },
-          },
-          on: {
-            INTERPRETATION_RESULT: [
-              {
-                target: 'ready_to_accept',
-                cond: (_context, event) =>
-                  event.interpretation.type === 'ValidSheet',
-              },
-              {
-                target: 'rejecting',
-                cond: (_context, event) =>
-                  event.interpretation.type === 'InvalidSheet',
-              },
-              {
-                target: 'needs_review',
-                cond: (_context, event) =>
-                  event.interpretation.type === 'NeedsReviewSheet',
-              },
-            ],
           },
         },
         ready_to_accept: {
+          id: 'ready_to_accept',
           on: { ACCEPT: 'accepting' },
         },
         accepting: {
@@ -521,6 +523,7 @@ function buildMachine(createPlustekClient: CreatePlustekClient) {
           },
         },
         needs_review: {
+          id: 'needs_review',
           invoke: pollPaperStatus,
           on: {
             ACCEPT: 'accepting',
@@ -561,6 +564,7 @@ function buildMachine(createPlustekClient: CreatePlustekClient) {
           },
         },
         rejecting: {
+          id: 'rejecting',
           invoke: {
             src: reject,
             onDone: 'checking_rejecting_completed',
@@ -620,30 +624,34 @@ function buildMachine(createPlustekClient: CreatePlustekClient) {
             SCANNER_READY_TO_EJECT: { target: 'error_jammed', internal: true },
           },
         },
-        back_to_last_state: {
-          type: 'history',
-        },
         error_both_sides_have_paper: {
+          entry: clearError,
           invoke: pollPaperStatus,
           on: {
             SCANNER_BOTH_SIDES_HAVE_PAPER: { target: undefined }, // Do nothing
-            SCANNER_READY_TO_EJECT: 'back_to_last_state',
-            //     // After the front paper is removed, if we have scanned images from
-            //     // the back paper, try to interpret them
-            //     {
-            //       target: 'interpreting',
-            //       cond: (context) => context.scannedSheet !== undefined,
-            //     },
-            //     // Otherwise, reject the back paper
-            //     {
-            //       target: 'rejecting',
-            //       cond: (context) => context.scannedSheet === undefined,
-            //       actions: assign({
-            //         error: new PrecinctScannerError('both_sides_have_paper'),
-            //       }),
-            //     },
-            //   ],
-            // },
+            // Sometimes we get a no_paper blip when removing the front paper quickly
+            SCANNER_NO_PAPER: { target: undefined }, // Do nothing
+            // After the front paper is removed:
+            SCANNER_READY_TO_EJECT: [
+              // If we already interpreted the paper, go back to routing to the
+              // resulting state for that interpretation
+              {
+                target: 'interpreting.routing_result',
+                cond: (context) => context.interpretation !== undefined,
+              },
+              // Else, if we have scanned images, try to interpret them
+              {
+                target: 'interpreting.starting',
+                cond: (context) => context.scannedSheet !== undefined,
+              },
+              // Otherwise, reject the back paper
+              {
+                target: 'rejecting',
+                actions: assign({
+                  error: new PrecinctScannerError('both_sides_have_paper'),
+                }),
+              },
+            ],
           },
         },
         error: {},


### PR DESCRIPTION
## Overview
Task: #2231 

Previously, whenever a second ballot was inserted while a ballot was already in the scanner, we conservatively rejected the first ballot after the second ballot was removed.

Here, we improve the user experience by:
- Continuing to accept the ballot when possible (Plustek will abort in-progress scans on second ballot insertion)
- Going back to the "needs review" state if a second ballot is inserted during review
- Rejecting the ballot in all other cases

## Demo Video or Screenshot
N/A

## Testing Plan 
- Manual testing
- Updated integration tests
