### PR TITLE
Fix flaky test by adding buffer time

### DIFF
--- a/libs/ui/src/unconfigure_machine_button.test.tsx
+++ b/libs/ui/src/unconfigure_machine_button.test.tsx
@@ -52,9 +52,10 @@ test('UnconfigureMachineButton interactions', async () => {
 });
 
 test('UnconfigureMachineButton does not sleep when not necessary', async () => {
+  const bufferTimeMs = 100;
   const unconfigureMachine = jest.fn(async () => {
     await new Promise<void>((resolve) => {
-      setTimeout(resolve, MIN_TIME_TO_UNCONFIGURE_MACHINE_MS);
+      setTimeout(resolve, MIN_TIME_TO_UNCONFIGURE_MACHINE_MS + bufferTimeMs);
     });
   });
   render(<UnconfigureMachineButton unconfigureMachine={unconfigureMachine} />);
@@ -66,8 +67,9 @@ test('UnconfigureMachineButton does not sleep when not necessary', async () => {
       name: 'Yes, Delete Election Data',
     })
   );
-  await waitFor(() =>
-    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+  await waitFor(
+    () => expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument(),
+    { timeout: MIN_TIME_TO_UNCONFIGURE_MACHINE_MS + bufferTimeMs * 2 }
   );
 
   expect(unconfigureMachine).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
A test that I recently added has flaked at least once in CI:

<img width="645" alt="flaky-test" src="https://user-images.githubusercontent.com/12616928/182451537-5266de79-6176-44b1-a3ea-919983f83424.png">

Though I haven't been able to repro a failure locally, adding some buffer time to the `unconfigureMachine` call should guarantee that we don't perform the artificial sleep to hit `MIN_TIME_TO_UNCONFIGURE_MACHINE_MS`.