### PR TITLE
fix(scan): Handle insertion of second ballot while first ballot is accepting

### DIFF
--- a/libs/plustek-sdk/src/mocks.test.ts
+++ b/libs/plustek-sdk/src/mocks.test.ts
@@ -315,6 +315,14 @@ test('paper held at both sides', async () => {
   expect((await mock.getPaperStatus()).ok()).toEqual(
     PaperStatus.VtmReadyToEject
   );
+
+  // Inserting a second sheet during accept
+  const acceptResult = mock.accept();
+  (await mock.simulateLoadSheet(files)).unsafeUnwrap();
+  expect((await acceptResult).err()).toEqual(ScannerError.PaperStatusJam);
+  expect((await mock.getPaperStatus()).ok()).toEqual(
+    PaperStatus.VtmReadyToScan
+  );
 });
 
 test('paper jam', async () => {

--- a/services/scan/src/precinct_scanner_app.test.ts
+++ b/services/scan/src/precinct_scanner_app.test.ts
@@ -21,7 +21,7 @@ import { buildPrecinctScannerApp } from './precinct_scanner_app';
 import { createPrecinctScannerStateMachine } from './precinct_scanner_state_machine';
 import { createWorkspace } from './util/workspace';
 
-jest.setTimeout(10_000);
+jest.setTimeout(15_000);
 
 function get(app: Application, path: string) {
   return request(app).get(path).accept('application/json').expect(200);
@@ -132,7 +132,8 @@ async function createApp() {
     createPlustekClient,
     {
       DELAY_RECONNECT: 100,
-      DELAY_ACCEPTED_RESET_TO_NO_PAPER: 500,
+      DELAY_ACCEPTED_READY_FOR_NEXT_BALLOT: 500,
+      DELAY_ACCEPTED_RESET_TO_NO_PAPER: 1000,
     }
   );
   const app = buildPrecinctScannerApp(precinctScannerMachine, workspace);


### PR DESCRIPTION
## Overview
Task: https://github.com/votingworks/vxsuite/issues/2242

If a second ballot is inserted while the first ballot is in the middle of being accepted (a very short window, but possible), the first ballot is successfully dropped but plustek returns a jam error. By ignoring that error, we can correctly record that the ballot got accepted.

Then, we also add a delay to make sure that the user has time to see the "ballot counted" screen before the second ballot starts scanning.

## Demo Video or Screenshot
Recommend trying it out yourself

## Testing Plan 
- Updated automated tests
- Manually tested

