### PR TITLE
Move REACT_APP_VX_ENABLE_ALL_ZERO_SMARTCARD_PIN_GENERATION flag

### DIFF
--- a/frontends/election-manager/src/components/smartcard_modal/pins.test.ts
+++ b/frontends/election-manager/src/components/smartcard_modal/pins.test.ts
@@ -1,14 +1,17 @@
-import { isAllZeroSmartcardPinGenerationEnabled } from '@votingworks/ui';
 import { mockOf } from '@votingworks/test-utils';
 
 import { generatePin, hyphenatePin } from './pins';
+import { isAllZeroSmartcardPinGenerationEnabled } from '../../config/features';
 
-jest.mock('@votingworks/ui', (): typeof import('@votingworks/ui') => {
-  return {
-    ...jest.requireActual('@votingworks/ui'),
-    isAllZeroSmartcardPinGenerationEnabled: jest.fn(),
-  };
-});
+jest.mock(
+  '../../config/features',
+  (): typeof import('../../config/features') => {
+    return {
+      ...jest.requireActual('../../config/features'),
+      isAllZeroSmartcardPinGenerationEnabled: jest.fn(),
+    };
+  }
+);
 
 beforeEach(() => {
   mockOf(isAllZeroSmartcardPinGenerationEnabled).mockImplementation(

--- a/frontends/election-manager/src/components/smartcard_modal/pins.ts
+++ b/frontends/election-manager/src/components/smartcard_modal/pins.ts
@@ -1,4 +1,4 @@
-import { isAllZeroSmartcardPinGenerationEnabled } from '@votingworks/ui';
+import { isAllZeroSmartcardPinGenerationEnabled } from '../../config/features';
 
 /**
  * generatePin generates random numeric PINs of the specified length (default = 6).

--- a/frontends/election-manager/src/config/features.ts
+++ b/frontends/election-manager/src/config/features.ts
@@ -2,6 +2,10 @@ import { unsafeParse } from '@votingworks/types';
 import { asBoolean } from '@votingworks/utils';
 import { ConverterClientType, ConverterClientTypeSchema } from './types';
 
+function isVxDev(): boolean {
+  return asBoolean(process.env.REACT_APP_VX_DEV);
+}
+
 /**
  * Determines whether write-in adjudication is enabled.
  *
@@ -20,8 +24,7 @@ export function isWriteInAdjudicationEnabled(): boolean {
     // also enable further tree shaking when used in a way that the bundler can
     // understand, e.g. `if (isWriteInAdjudicationEnabled())` or
     // `isWriteInAdjudicationEnabled() && ...`.
-    (process.env.NODE_ENV === 'development' ||
-      asBoolean(process.env.REACT_APP_VX_DEV)) &&
+    (process.env.NODE_ENV === 'development' || isVxDev()) &&
     asBoolean(process.env.REACT_APP_VX_ENABLE_WRITE_IN_ADJUDICATION)
   );
 }
@@ -37,4 +40,21 @@ export function getConverterClientType(): ConverterClientType | undefined {
   }
 
   return unsafeParse(ConverterClientTypeSchema, rawConverterClientType);
+}
+
+/**
+ * Determines whether generated smartcard PINs are all zeros (000000) instead of random. This can
+ * be useful for local development and demos.
+ *
+ * To enable, add this line to frontends/election-manager/.env.local:
+ *
+ *     REACT_APP_VX_ENABLE_ALL_ZERO_SMARTCARD_PIN_GENERATION=true
+ *
+ * @see https://create-react-app.dev/docs/adding-custom-environment-variables/
+ */
+export function isAllZeroSmartcardPinGenerationEnabled(): boolean {
+  return (
+    (process.env.NODE_ENV === 'development' || isVxDev()) &&
+    asBoolean(process.env.REACT_APP_VX_ENABLE_ALL_ZERO_SMARTCARD_PIN_GENERATION)
+  );
 }

--- a/frontends/election-manager/src/env.d.ts
+++ b/frontends/election-manager/src/env.d.ts
@@ -4,6 +4,7 @@ declare namespace NodeJS {
     readonly REACT_APP_VX_CODE_VERSION?: string;
     readonly REACT_APP_VX_CONVERTER?: string;
     readonly REACT_APP_VX_DEV?: string;
+    readonly REACT_APP_VX_ENABLE_ALL_ZERO_SMARTCARD_PIN_GENERATION?: string;
     readonly REACT_APP_VX_ENABLE_WRITE_IN_ADJUDICATION?: string;
     readonly REACT_APP_VX_MACHINE_ID?: string;
   }

--- a/libs/ui/src/config/features.ts
+++ b/libs/ui/src/config/features.ts
@@ -21,24 +21,6 @@ export function isCardReaderCheckDisabled(): boolean {
 }
 
 /**
- * Determines whether generated smartcard PINs are all zeros (000000) instead of random. This can
- * be useful for local development and demos.
- *
- * To enable, add this line to the relevant frontend app's .env.local, e.g.
- * frontends/election-manager/.env.local:
- *
- *     REACT_APP_VX_ENABLE_ALL_ZERO_SMARTCARD_PIN_GENERATION=true
- *
- * @see https://create-react-app.dev/docs/adding-custom-environment-variables/
- */
-export function isAllZeroSmartcardPinGenerationEnabled(): boolean {
-  return (
-    (process.env.NODE_ENV === 'development' || isVxDev()) &&
-    asBoolean(process.env.REACT_APP_VX_ENABLE_ALL_ZERO_SMARTCARD_PIN_GENERATION)
-  );
-}
-
-/**
  * Determines whether VVSG2 auth flows are enabled.
  *
  * Now enabled by default.

--- a/libs/ui/src/env.d.ts
+++ b/libs/ui/src/env.d.ts
@@ -3,7 +3,6 @@ declare namespace NodeJS {
     readonly NODE_ENV: 'development' | 'production' | 'test';
     readonly REACT_APP_VX_DEV?: string;
     readonly REACT_APP_VX_DISABLE_CARD_READER_CHECK?: string;
-    readonly REACT_APP_VX_ENABLE_ALL_ZERO_SMARTCARD_PIN_GENERATION?: string;
     readonly REACT_APP_VX_ENABLE_VVSG2_AUTH_FLOWS?: string;
   }
 }

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -51,9 +51,6 @@ export * from './usbcontroller_button';
 export * from './remove_card_screen';
 export { InvalidCardScreen } from './invalid_card_screen';
 export * from './unlock_machine_screen';
-export {
-  areVvsg2AuthFlowsEnabled,
-  isAllZeroSmartcardPinGenerationEnabled,
-} from './config/features';
+export { areVvsg2AuthFlowsEnabled } from './config/features';
 export * from './system_administrator_screen_contents';
 export * from './unconfigure_machine_button';


### PR DESCRIPTION
This PR moves the recently added `REACT_APP_VX_ENABLE_ALL_ZERO_SMARTCARD_PIN_GENERATION` feature flag from `libs/ui` to `frontends/election-manager` since that's the only frontend that uses it. I missed this during iteration on https://github.com/votingworks/vxsuite/pull/2255.