### PR TITLE
feat(scan): gate exporting ballot images behind feature flag

### DIFF
--- a/services/scan/src/config/features.ts
+++ b/services/scan/src/config/features.ts
@@ -1,0 +1,17 @@
+import { asBoolean } from '@votingworks/utils';
+
+/**
+ * Determines whether exporting ballot images for write-in adjudication is enabled.
+ *
+ * To enable exporting ballot images in Store.exportCvrs, add this line to `frontends/election-manager/.env.local`:
+ *
+ *     ENABLE_WRITE_IN_ADJUDICATION_EXPORT_BALLOT_IMAGES=true
+ *
+ * To disable it, remove the line or comment it out. Restarting the server is required.
+ *
+ */
+export function isWriteInAdjudicationBallotImageExportEnabled(): boolean {
+  return asBoolean(
+    process.env['ENABLE_WRITE_IN_ADJUDICATION_EXPORT_BALLOT_IMAGES']
+  );
+}

--- a/services/scan/src/store.test.ts
+++ b/services/scan/src/store.test.ts
@@ -633,7 +633,6 @@ test('exportCvrs', async () => {
 });
 
 test('exportCvrs does not export ballot images when feature flag turned off', async () => {
-  process.env['ENABLE_WRITE_IN_ADJUDICATION_EXPORT_BALLOT_IMAGES'] = 'false';
   const buildCastVoteRecordMock = jest.spyOn(
     buildCastVoteRecord,
     'buildCastVoteRecord'

--- a/services/scan/src/store.test.ts
+++ b/services/scan/src/store.test.ts
@@ -9,6 +9,7 @@ import {
   YesNoContest,
 } from '@votingworks/types';
 import { sleep, typedAs } from '@votingworks/utils';
+import { mockOf } from '@votingworks/test-utils';
 import { Buffer } from 'buffer';
 import { writeFile } from 'fs-extra';
 import * as streams from 'memory-streams';
@@ -17,16 +18,23 @@ import { v4 as uuid } from 'uuid';
 import * as stateOfHamilton from '../test/fixtures/state-of-hamilton';
 import { zeroRect } from '../test/fixtures/zero_rect';
 import { Store } from './store';
+import { isWriteInAdjudicationBallotImageExportEnabled } from './config/features';
 import * as buildCastVoteRecord from './build_cast_vote_record';
 
 // We pause in some of these tests so we need to increase the timeout
 jest.setTimeout(20000);
 
-const ENV = process.env;
+jest.mock('./config/features', (): typeof import('./config/features') => {
+  return {
+    ...jest.requireActual('./config/features'),
+    isWriteInAdjudicationBallotImageExportEnabled: jest.fn(),
+  };
+});
 
 beforeEach(() => {
-  jest.resetModules();
-  process.env = { ...ENV };
+  mockOf(isWriteInAdjudicationBallotImageExportEnabled).mockImplementation(
+    () => false
+  );
 });
 
 test('get/set election', () => {
@@ -507,7 +515,9 @@ test('adjudication', () => {
 });
 
 test('exportCvrs', async () => {
-  process.env['ENABLE_WRITE_IN_ADJUDICATION_EXPORT_BALLOT_IMAGES'] = 'true';
+  mockOf(isWriteInAdjudicationBallotImageExportEnabled).mockImplementation(
+    () => true
+  );
 
   const buildCastVoteRecordMock = jest.spyOn(
     buildCastVoteRecord,

--- a/services/scan/src/store.ts
+++ b/services/scan/src/store.ts
@@ -31,7 +31,7 @@ import {
 } from '@votingworks/types';
 import { Scan } from '@votingworks/api';
 import { Iso8601Timestamp } from '@votingworks/types/src/api';
-import { assert, asBoolean } from '@votingworks/utils';
+import { assert } from '@votingworks/utils';
 import { Buffer } from 'buffer';
 import makeDebug from 'debug';
 import * as fs from 'fs-extra';
@@ -46,6 +46,7 @@ import { buildCastVoteRecord } from './build_cast_vote_record';
 import { Bindable, DbClient } from './db_client';
 import { sheetRequiresAdjudication } from './interpreter';
 import { SheetOf } from './types';
+import { isWriteInAdjudicationBallotImageExportEnabled } from './config/features';
 import { normalizeAndJoin } from './util/path';
 
 const debug = makeDebug('scan:store');
@@ -870,11 +871,7 @@ export class Store {
 
       const frontImage: InlineBallotImage = { normalized: '' };
       const backImage: InlineBallotImage = { normalized: '' };
-      if (
-        asBoolean(
-          process.env['ENABLE_WRITE_IN_ADJUDICATION_EXPORT_BALLOT_IMAGES']
-        )
-      ) {
+      if (isWriteInAdjudicationBallotImageExportEnabled()) {
         if (
           frontInterpretation.type === 'InterpretedHmpbPage' ||
           frontInterpretation.type === 'UninterpretedHmpbPage'

--- a/services/scan/src/store.ts
+++ b/services/scan/src/store.ts
@@ -31,7 +31,7 @@ import {
 } from '@votingworks/types';
 import { Scan } from '@votingworks/api';
 import { Iso8601Timestamp } from '@votingworks/types/src/api';
-import { assert } from '@votingworks/utils';
+import { assert, asBoolean } from '@votingworks/utils';
 import { Buffer } from 'buffer';
 import makeDebug from 'debug';
 import * as fs from 'fs-extra';
@@ -871,22 +871,28 @@ export class Store {
       const frontImage: InlineBallotImage = { normalized: '' };
       const backImage: InlineBallotImage = { normalized: '' };
       if (
-        frontInterpretation.type === 'InterpretedHmpbPage' ||
-        frontInterpretation.type === 'UninterpretedHmpbPage'
+        asBoolean(
+          process.env['ENABLE_WRITE_IN_ADJUDICATION_EXPORT_BALLOT_IMAGES']
+        )
       ) {
-        const frontFilenames = this.getBallotFilenames(id, 'front');
-        if (frontFilenames?.normalized) {
-          frontImage.normalized = fs.readFileSync(
-            frontFilenames.normalized,
-            'base64'
-          );
-        }
-        const backFilenames = this.getBallotFilenames(id, 'back');
-        if (backFilenames?.normalized) {
-          backImage.normalized = fs.readFileSync(
-            backFilenames.normalized,
-            'base64'
-          );
+        if (
+          frontInterpretation.type === 'InterpretedHmpbPage' ||
+          frontInterpretation.type === 'UninterpretedHmpbPage'
+        ) {
+          const frontFilenames = this.getBallotFilenames(id, 'front');
+          if (frontFilenames?.normalized) {
+            frontImage.normalized = fs.readFileSync(
+              frontFilenames.normalized,
+              'base64'
+            );
+          }
+          const backFilenames = this.getBallotFilenames(id, 'back');
+          if (backFilenames?.normalized) {
+            backImage.normalized = fs.readFileSync(
+              backFilenames.normalized,
+              'base64'
+            );
+          }
         }
       }
 


### PR DESCRIPTION
## Overview
Closes #2185 

This gates reading ballot images and exporting them in `Store.exportCvrs` behind a new flag `ENABLE_WRITE_IN_ADJUDICATION_EXPORT_BALLOT_IMAGES`

## Demo Video or Screenshot

## Testing Plan 
Added automated tests.

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
