### PR TITLE
refactor(scan): Make the calibrate API blocking

### DIFF
--- a/frontends/precinct-scanner/src/api/scan.ts
+++ b/frontends/precinct-scanner/src/api/scan.ts
@@ -28,8 +28,12 @@ export async function waitForPaper(): Promise<void> {
   await fetchJson('/scanner/wait-for-paper', { method: 'POST' });
 }
 
-export async function calibrate(): Promise<void> {
-  await fetchJson('/scanner/calibrate', { method: 'POST' });
+export async function calibrate(): Promise<boolean> {
+  const result = unsafeParse(
+    Scan.CalibrateResponseSchema,
+    await fetchJson('/scanner/calibrate', { method: 'POST' })
+  );
+  return result.status === 'ok';
 }
 
 export async function getExport(): Promise<string> {

--- a/frontends/precinct-scanner/src/app.test.tsx
+++ b/frontends/precinct-scanner/src/app.test.tsx
@@ -460,18 +460,12 @@ test('admin and pollworker configuration', async () => {
     { body: statusReadyToScan },
     { overwriteRoutes: true }
   );
-  await advanceTimersAndPromises(1);
+  await advanceTimersAndPromises();
   fireEvent.click(await screen.findByText('Calibrate'));
   expect(fetchMock.calls('/scanner/calibrate')).toHaveLength(1);
-  fetchMock.getOnce('/scanner/status', {
-    body: { ...statusReadyToScan, state: 'calibrated' },
-  });
-  fetchMock.post('/scanner/wait-for-paper', { body: { status: 'ok' } });
-  await advanceTimersAndPromises(1);
-  screen.getByText('Calibration succeeded!');
+  await advanceTimersAndPromises();
+  await screen.findByText('Calibration succeeded!');
   fireEvent.click(screen.getByRole('button', { name: 'Close' }));
-  await screen.findByText('Administrator Settings');
-  expect(fetchMock.calls('/scanner/wait-for-paper')).toHaveLength(1);
 
   // Remove card and insert admin card to unconfigure
   fetchMock

--- a/frontends/precinct-scanner/src/components/calibrate_scanner_modal.tsx
+++ b/frontends/precinct-scanner/src/components/calibrate_scanner_modal.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Scan } from '@votingworks/api';
-import { Button, Modal, Prose } from '@votingworks/ui';
+import { Button, Modal, Prose, useCancelablePromise } from '@votingworks/ui';
+import { assert } from '@votingworks/utils';
 import * as scanner from '../api/scan';
 
 export interface Props {
@@ -12,50 +13,58 @@ function noop() {
   // noop
 }
 
+type CalibrationState = 'ready' | 'calibrating' | 'calibrated' | 'failed';
+
 export function CalibrateScannerModal({
   scannerStatus,
   onCancel,
 }: Props): JSX.Element {
-  async function finish() {
-    await scanner.waitForPaper();
-    onCancel();
+  const [calibrationState, setCalibrationState] =
+    useState<CalibrationState>('ready');
+  const makeCancelable = useCancelablePromise();
+
+  async function calibrate() {
+    setCalibrationState('calibrating');
+    const success = await makeCancelable(scanner.calibrate());
+    setCalibrationState(success ? 'calibrated' : 'failed');
   }
 
-  if (scannerStatus.state === 'calibrating') {
+  if (calibrationState === 'ready') {
     return (
       <Modal
-        centerContent
         content={
-          <Prose textCenter>
-            <h1>Calibrating…</h1>
+          <Prose>
+            <h1>Calibrate Scanner</h1>
+            <p>
+              Insert a <strong>blank sheet of white paper</strong> to calibrate
+              the scanner. The sheet will not be returned out the front of the
+              scanner.
+            </p>
           </Prose>
+        }
+        actions={
+          <React.Fragment>
+            {scannerStatus?.state === 'ready_to_scan' ? (
+              <Button primary onPress={calibrate}>
+                Calibrate
+              </Button>
+            ) : scannerStatus?.state === 'no_paper' ? (
+              <Button disabled onPress={noop}>
+                Waiting for Paper
+              </Button>
+            ) : (
+              <Button disabled onPress={noop}>
+                Cannot Calibrate
+              </Button>
+            )}
+            <Button onPress={onCancel}>Cancel</Button>
+          </React.Fragment>
         }
       />
     );
   }
 
-  if (scannerStatus.state === 'calibrated') {
-    if (scannerStatus.error) {
-      return (
-        <Modal
-          centerContent
-          content={
-            <Prose textCenter>
-              <h1>Calibration failed!</h1>
-              <p>There was an error while calibrating.</p>
-            </Prose>
-          }
-          actions={
-            <React.Fragment>
-              <Button primary onPress={scanner.waitForPaper}>
-                Try again
-              </Button>
-              <Button onPress={finish}>Cancel</Button>
-            </React.Fragment>
-          }
-        />
-      );
-    }
+  if (calibrationState === 'calibrated') {
     return (
       <Modal
         centerContent
@@ -64,40 +73,41 @@ export function CalibrateScannerModal({
             <h1>Calibration succeeded!</h1>
           </Prose>
         }
-        actions={<Button onPress={finish}>Close</Button>}
+        actions={<Button onPress={onCancel}>Close</Button>}
       />
     );
   }
 
+  if (calibrationState === 'failed') {
+    return (
+      <Modal
+        centerContent
+        content={
+          <Prose textCenter>
+            <h1>Calibration failed!</h1>
+            <p>There was an error while calibrating.</p>
+          </Prose>
+        }
+        actions={
+          <React.Fragment>
+            <Button primary onPress={() => setCalibrationState('ready')}>
+              Try again
+            </Button>
+            <Button onPress={onCancel}>Cancel</Button>
+          </React.Fragment>
+        }
+      />
+    );
+  }
+
+  assert(calibrationState === 'calibrating');
   return (
     <Modal
+      centerContent
       content={
-        <Prose>
-          <h1>Calibrate Scanner</h1>
-          <p>
-            Insert a <strong>blank sheet of white paper</strong> to calibrate
-            the scanner. The sheet will not be returned out the front of the
-            scanner.
-          </p>
+        <Prose textCenter>
+          <h1>Calibrating…</h1>
         </Prose>
-      }
-      actions={
-        <React.Fragment>
-          {scannerStatus?.state === 'ready_to_scan' ? (
-            <Button primary onPress={scanner.calibrate}>
-              Calibrate
-            </Button>
-          ) : scannerStatus?.state === 'no_paper' ? (
-            <Button disabled onPress={noop}>
-              Waiting for Paper
-            </Button>
-          ) : (
-            <Button disabled onPress={noop}>
-              Cannot Calibrate
-            </Button>
-          )}
-          <Button onPress={onCancel}>Cancel</Button>
-        </React.Fragment>
       }
     />
   );

--- a/libs/plustek-sdk/src/mocks.ts
+++ b/libs/plustek-sdk/src/mocks.ts
@@ -657,10 +657,7 @@ export class MockScannerClient implements ScannerClient {
       case 'both_sides_have_paper':
       case 'ready_to_scan': {
         this.machine.send({ type: 'CALIBRATE' });
-        await waitFor(
-          this.machine,
-          (state) => state.value === 'no_paper' || state.value === 'jam'
-        );
+        await waitFor(this.machine, (state) => state.value !== 'calibrating');
         if ((this.machine.state.value as string) === 'jam') {
           debug('calibrate failed, jam');
           return err(ScannerError.PaperStatusJam);

--- a/services/scan/src/precinct_scanner_app.ts
+++ b/services/scan/src/precinct_scanner_app.ts
@@ -446,10 +446,20 @@ export function buildPrecinctScannerApp(
     }
   );
 
-  app.post<NoParams, OkResponse>('/scanner/calibrate', (_request, response) => {
-    machine.calibrate();
-    response.json({ status: 'ok' });
-  });
+  app.post<NoParams, Scan.CalibrateResponse>(
+    '/scanner/calibrate',
+    async (_request, response) => {
+      const result = await machine.calibrate();
+      if (result.isOk()) {
+        response.json({ status: 'ok' });
+      } else {
+        response.json({
+          status: 'error',
+          errors: [{ type: 'error', message: result.err() }],
+        });
+      }
+    }
+  );
 
   app.get('/*', (request, response) => {
     const url = new URL(`http://${request.get('host')}${request.originalUrl}`);

--- a/services/scan/src/precinct_scanner_state_machine.ts
+++ b/services/scan/src/precinct_scanner_state_machine.ts
@@ -325,7 +325,10 @@ function buildMachine(createPlustekClient: CreatePlustekClient) {
           src: connectToPlustek(createPlustekClient),
           onDone: {
             target: 'checking_initial_paper_status',
-            actions: assign({ client: (_context, event) => event.data }),
+            actions: assign({
+              client: (_context, event) => event.data,
+              error: undefined,
+            }),
           },
           onError: 'error_disconnected',
         },

--- a/services/scan/src/precinct_scanner_state_machine.ts
+++ b/services/scan/src/precinct_scanner_state_machine.ts
@@ -604,10 +604,7 @@ function buildMachine(createPlustekClient: CreatePlustekClient) {
 }
 
 function errorToString(error: Context['error']) {
-  return (
-    error &&
-    (error instanceof PrecinctScannerError ? error.type : 'plustek_error')
-  );
+  return error instanceof PrecinctScannerError ? error.type : 'plustek_error';
 }
 
 export interface PrecinctScannerStateMachine {
@@ -744,7 +741,7 @@ export function createPrecinctScannerStateMachine(
       return {
         state: scannerState,
         interpretation: interpretationResult,
-        error: errorToString(error),
+        error: error && errorToString(error),
       };
     },
 


### PR DESCRIPTION
## Overview
I had changed the calibrate API to be non-blocking (to be similar to the rest of the scanner commands). However, due to the way that calibrate is actually used in the app (on the admin screen only), I think it makes more sense to have a blocking API call. That way if the admin screen is exited by card removal in the middle of calibration (or after), the frontend doesn't need to make an API request to exit calibration, it will automatically go back to no_paper when its done. This seems less prone to getting stuck in a calibration state if the frontend messes up.

## Demo Video or Screenshot
N/A

## Testing Plan 
- Updated automated tests
- Manually tested calibration


