### PR TITLE
fix(scan): Fix bad state reference

### DIFF
--- a/services/scan/src/precinct_scanner_state_machine.ts
+++ b/services/scan/src/precinct_scanner_state_machine.ts
@@ -378,6 +378,7 @@ function buildMachine(createPlustekClient: CreatePlustekClient) {
           },
         },
         ready_to_scan: {
+          id: 'ready_to_scan',
           entry: [clearError, clearLastScan],
           invoke: pollPaperStatus,
           on: {
@@ -504,7 +505,7 @@ function buildMachine(createPlustekClient: CreatePlustekClient) {
               },
             },
             ready_for_next_ballot: {
-              on: { SCANNER_READY_TO_SCAN: '..ready_to_scan' },
+              on: { SCANNER_READY_TO_SCAN: '#ready_to_scan' },
             },
           },
           after: {


### PR DESCRIPTION


## Overview
It turns out that you can't do relative state names (e.g. `..ready_to_scan`). Usually I get a type error when a state name is invalid, but for some reason this didn't give me one so I thought it worked. Instead, in order to reference a state from a child state, you have to use the `id` property to give it a global name, and then reference it with a `#` (e.g. `#ready_to_scan`).

This makes me less excited about using nested states because it seems error-prone, but for now, starting by just fixing this.

## Demo Video or Screenshot
N/A

## Testing Plan 
Manually tested
