### PR TITLE
fix(scan): Safe scanning retries

### DIFF
--- a/frontends/precinct-scanner/src/screens/scan_error_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/scan_error_screen.tsx
@@ -29,6 +29,7 @@ export function ScanErrorScreen({ error, isTestMode }: Props): JSX.Element {
       case 'unknown':
         return undefined;
       // Precinct scanner error
+      case 'scanning_failed':
       case 'both_sides_have_paper':
       case 'paper_in_front_on_startup':
       case 'paper_in_back_on_startup':

--- a/libs/api/src/services/scan/index.ts
+++ b/libs/api/src/services/scan/index.ts
@@ -704,6 +704,7 @@ export const SheetInterpretationSchema: z.ZodSchema<SheetInterpretation> =
   ]);
 
 export const PrecinctScannerErrorTypeSchema = z.enum([
+  'scanning_failed',
   'both_sides_have_paper',
   'paper_in_back_after_accept',
   'paper_in_front_on_startup',

--- a/services/scan/src/precinct_scanner_state_machine.ts
+++ b/services/scan/src/precinct_scanner_state_machine.ts
@@ -472,6 +472,7 @@ function buildMachine(createPlustekClient: CreatePlustekClient) {
           },
         },
         interpreting: {
+          id: 'interpreting',
           initial: 'starting',
           states: {
             starting: {


### PR DESCRIPTION


## Overview
Tasks: https://github.com/votingworks/vxsuite/issues/2241, https://github.com/votingworks/vxsuite/issues/2240

Addresses a few different issues when attempting to scan:
- When Plustek fails to grab the ballot, we cap the number of times we will retry the scan command and then show an error to remove the ballot.
- We only will retry scanning on known errors (error feeding, error no paper) or when the paper status indicates the paper didn't get scanned. This protects us against both cases from https://github.com/votingworks/vxsuite/issues/2240, in which case the scan command returns a "jam" error even though there's not actually a jam. In the case of any unexpected error from the scan command, we'll treat it like any other unexpected error.

## Demo Video or Screenshot

## Testing Plan 
TODO
