### PR TITLE
Print All Ballot Styles At Once

### DIFF
--- a/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
+++ b/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
@@ -147,7 +147,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
         </button>
       </p>
       <div
-        class="sc-idOhPF cPoTOb"
+        class="sc-dIUggk diaJDk"
       >
         <button
           class="sc-iBPRYJ gUjZCM"
@@ -1595,7 +1595,7 @@ exports[`L&A (logic and accuracy) flow 2`] = `
         </button>
       </p>
       <div
-        class="sc-idOhPF cPoTOb"
+        class="sc-dIUggk diaJDk"
       >
         <button
           class="sc-iBPRYJ gUjZCM"
@@ -3077,7 +3077,7 @@ exports[`L&A (logic and accuracy) flow 3`] = `
         </button>
       </p>
       <div
-        class="sc-idOhPF cPoTOb"
+        class="sc-dIUggk diaJDk"
       >
         <button
           class="sc-iBPRYJ gUjZCM"

--- a/frontends/election-manager/src/app_root.tsx
+++ b/frontends/election-manager/src/app_root.tsx
@@ -101,7 +101,7 @@ export function AppRoot({
 
   const printBallotRef = useRef<HTMLDivElement>(null);
 
-  const { cardReader } = useDevices({ hardware, logger });
+  const { cardReader, printer: printerInfo } = useDevices({ hardware, logger });
 
   const getElectionDefinition = useCallback(async (): Promise<
     ElectionDefinition | undefined
@@ -641,6 +641,7 @@ export function AppRoot({
         auth,
         machineConfig,
         hasCardReaderAttached: !!cardReader,
+        hasPrinterAttached: !!printerInfo,
         logger,
       }}
     >

--- a/frontends/election-manager/src/components/export_ballot_pdfs_button.test.tsx
+++ b/frontends/election-manager/src/components/export_ballot_pdfs_button.test.tsx
@@ -28,10 +28,7 @@ afterEach(() => {
 test('button renders properly when not clicked', () => {
   renderInAppContext(<ExportBallotPdfsButton />);
 
-  expect(screen.queryByText('Export Ballot PDFs')).toHaveProperty(
-    'type',
-    'button'
-  );
+  expect(screen.queryByText('Save PDFs')).toHaveProperty('type', 'button');
   expect(screen.queryByRole('alertdialog')).toBeNull();
 });
 
@@ -46,7 +43,7 @@ test('modal renders insert usb screen appropriately', async () => {
     const { unmount } = renderInAppContext(<ExportBallotPdfsButton />, {
       usbDriveStatus: usbStatus,
     });
-    userEvent.click(screen.getByText('Export Ballot PDFs'));
+    userEvent.click(screen.getByText('Save PDFs'));
 
     const modal = await screen.findByRole('alertdialog');
     within(modal).getByText('No USB Drive Detected');
@@ -65,7 +62,7 @@ test('modal renders loading screen when usb drive is mounting or ejecting', asyn
     const { unmount } = renderInAppContext(<ExportBallotPdfsButton />, {
       usbDriveStatus: usbStatus,
     });
-    userEvent.click(screen.getByText('Export Ballot PDFs'));
+    userEvent.click(screen.getByText('Save PDFs'));
     const modal = await screen.findByRole('alertdialog');
     within(modal).getByText('Loading');
 
@@ -82,7 +79,7 @@ test('modal happy path flow works', async () => {
     usbDriveEject: ejectFunction,
   });
 
-  userEvent.click(screen.getByText('Export Ballot PDFs'));
+  userEvent.click(screen.getByText('Save PDFs'));
   const modal = await screen.findByRole('alertdialog');
   userEvent.click(within(modal).getByText('Export'));
   await within(modal).findByText('Generating Ballot PDFs…');
@@ -113,7 +110,7 @@ test('can select options to export different ballots', async () => {
     usbDriveStatus: UsbDriveStatus.mounted,
   });
 
-  userEvent.click(screen.getByText('Export Ballot PDFs'));
+  userEvent.click(screen.getByText('Save PDFs'));
   const modal = await screen.findByRole('alertdialog');
   userEvent.click(within(modal).getByText('Absentee'));
   userEvent.click(within(modal).getByText('Sample'));
@@ -131,7 +128,7 @@ test('modal custom flow works', async () => {
     usbDriveStatus: UsbDriveStatus.mounted,
     logger,
   });
-  userEvent.click(screen.getByText('Export Ballot PDFs'));
+  userEvent.click(screen.getByText('Save PDFs'));
   const modal = await screen.findByRole('alertdialog');
 
   userEvent.click(within(modal).getByText('Custom'));
@@ -150,7 +147,7 @@ test('modal renders error message appropriately', async () => {
   renderInAppContext(<ExportBallotPdfsButton />, {
     usbDriveStatus: UsbDriveStatus.mounted,
   });
-  userEvent.click(screen.getByText('Export Ballot PDFs'));
+  userEvent.click(screen.getByText('Save PDFs'));
   const modal = await screen.findByRole('alertdialog');
 
   userEvent.click(within(modal).getByText('Custom'));

--- a/frontends/election-manager/src/components/export_ballot_pdfs_button.tsx
+++ b/frontends/election-manager/src/components/export_ballot_pdfs_button.tsx
@@ -222,7 +222,7 @@ export function ExportBallotPdfsButton(): JSX.Element {
         case UsbDriveStatus.mounted: {
           mainContent = (
             <Prose>
-              <h1>Export Ballot PDFs</h1>
+              <h1>Save Ballot PDFs</h1>
               <p>
                 The export will include a PDF for each ballot style of the
                 current election. Select the type of ballots you would like to
@@ -346,7 +346,7 @@ export function ExportBallotPdfsButton(): JSX.Element {
   return (
     <React.Fragment>
       <LinkButton small onPress={() => setIsModalOpen(true)}>
-        Export Ballot PDFs
+        Save PDFs
       </LinkButton>
       {isModalOpen && (
         <Modal

--- a/frontends/election-manager/src/components/export_election_ballot_package_modal_button.test.tsx
+++ b/frontends/election-manager/src/components/export_election_ballot_package_modal_button.test.tsx
@@ -84,7 +84,7 @@ test('Button renders properly when not clicked', () => {
     <ExportElectionBallotPackageModalButton />
   );
 
-  expect(queryByText('Export Ballot Package')).toHaveProperty('type', 'button');
+  expect(queryByText('Export Package')).toHaveProperty('type', 'button');
   expect(queryByTestId('modal')).toBeNull();
 });
 
@@ -105,7 +105,7 @@ test('Modal renders insert usb screen appropriately', async () => {
     } = renderInAppContext(<ExportElectionBallotPackageModalButton />, {
       usbDriveStatus: usbStatus,
     });
-    fireEvent.click(getByText('Export Ballot Package'));
+    fireEvent.click(getByText('Export Package'));
     await waitFor(() => getByText('No USB Drive Detected'));
     expect(queryAllByAltText('Insert USB Image')).toHaveLength(1);
     expect(queryAllByTestId('modal')).toHaveLength(1);
@@ -124,15 +124,18 @@ test('Modal renders insert usb screen appropriately', async () => {
 
 test('Modal renders export confirmation screen when usb detected and manual link works as expected', async () => {
   const logger = fakeLogger();
-  const { getByText, queryAllByText, queryAllByAltText, queryAllByTestId } =
-    renderInAppContext(<ExportElectionBallotPackageModalButton />, {
-      usbDriveStatus: UsbDriveStatus.mounted,
-      logger,
-    });
-  fireEvent.click(getByText('Export Ballot Package'));
-  await waitFor(() =>
-    expect(queryAllByText('Export Ballot Package')).toHaveLength(2)
-  );
+  const {
+    getByText,
+    findByText,
+    queryAllByText,
+    queryAllByAltText,
+    queryAllByTestId,
+  } = renderInAppContext(<ExportElectionBallotPackageModalButton />, {
+    usbDriveStatus: UsbDriveStatus.mounted,
+    logger,
+  });
+  fireEvent.click(getByText('Export Package'));
+  await findByText('Export Ballot Package');
   expect(queryAllByAltText('Insert USB Image')).toHaveLength(1);
   expect(queryAllByTestId('modal')).toHaveLength(1);
   expect(
@@ -181,7 +184,7 @@ test('Modal renders loading screen when usb drive is mounting or ejecting', asyn
         usbDriveStatus: usbStatus,
       }
     );
-    fireEvent.click(getByText('Export Ballot Package'));
+    fireEvent.click(getByText('Export Package'));
     await waitFor(() => getByText('Loading'));
 
     expect(queryAllByTestId('modal')).toHaveLength(1);
@@ -201,7 +204,7 @@ test('Modal renders error message appropriately', async () => {
       logger,
     }
   );
-  fireEvent.click(getByText('Export Ballot Package'));
+  fireEvent.click(getByText('Export Package'));
   await waitFor(() => getByText('Export'));
 
   fireEvent.click(getByText('Custom'));
@@ -235,7 +238,7 @@ test('Modal renders renders loading message while rendering ballots appropriatel
       usbDriveEject: ejectFunction,
     }
   );
-  fireEvent.click(getByText('Export Ballot Package'));
+  fireEvent.click(getByText('Export Package'));
   await waitFor(() => getByText('Export'));
 
   fireEvent.click(getByText('Export'));

--- a/frontends/election-manager/src/components/export_election_ballot_package_modal_button.tsx
+++ b/frontends/election-manager/src/components/export_election_ballot_package_modal_button.tsx
@@ -386,7 +386,7 @@ export function ExportElectionBallotPackageModalButton(): JSX.Element {
   return (
     <React.Fragment>
       <LinkButton small onPress={() => setIsModalOpen(true)}>
-        Export Ballot Package
+        Export Package
       </LinkButton>
       {isModalOpen && (
         <Modal

--- a/frontends/election-manager/src/components/print_all_ballots_button.test.tsx
+++ b/frontends/election-manager/src/components/print_all_ballots_button.test.tsx
@@ -1,0 +1,253 @@
+import fetchMock from 'fetch-mock';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { electionMinimalExhaustiveSampleDefinition } from '@votingworks/fixtures';
+import { fakeLogger, LogEventId } from '@votingworks/logging';
+import { MemoryCard, MemoryHardware, typedAs } from '@votingworks/utils';
+import React from 'react';
+import { fakeKiosk } from '@votingworks/test-utils';
+import { hasTextAcrossElements } from '../../test/util/has_text_across_elements';
+import { renderInAppContext } from '../../test/render_in_app_context';
+import {
+  authenticateWithAdminCard,
+  authenticateWithSuperAdminCard,
+} from '../../test/util/authenticate';
+import { createMemoryStorageWith } from '../../test/util/create_memory_storage_with';
+import { App } from '../app';
+import {
+  PrintAllBallotsButton,
+  PRINTER_WARMUP_TIME,
+  TWO_SIDED_PRINT_TIME,
+} from './print_all_ballots_button';
+import { MachineConfig } from '../config/types';
+import { fakePrinter } from '../../test/helpers/fake_printer';
+
+jest.mock('../components/hand_marked_paper_ballot');
+
+fetchMock.get(
+  '/machine-config',
+  typedAs<MachineConfig>({
+    machineId: '0000',
+    codeVersion: 'TEST',
+  })
+);
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+test('button renders properly when not clicked', () => {
+  renderInAppContext(<PrintAllBallotsButton />);
+
+  expect(screen.queryByText('Print All')).toHaveProperty('type', 'button');
+  expect(screen.queryByRole('alertdialog')).toBeNull();
+});
+
+test('modal shows "No Printer Detected" if no printer attached', async () => {
+  renderInAppContext(<PrintAllBallotsButton />, { hasPrinterAttached: false });
+
+  userEvent.click(screen.getByText('Print All'));
+
+  const modal = await screen.findByRole('alertdialog');
+  within(modal).getByText('No Printer Detected');
+  userEvent.click(within(modal).getByText('Cancel'));
+
+  expect(screen.queryByRole('alertdialog')).toBeNull();
+});
+
+test('modal allows editing print options', async () => {
+  renderInAppContext(<PrintAllBallotsButton />, {
+    electionDefinition: electionMinimalExhaustiveSampleDefinition,
+  });
+
+  userEvent.click(screen.getByText('Print All'));
+
+  const modal = await screen.findByRole('alertdialog');
+  within(modal).getByText('Print All Ballot Styles');
+  within(modal).getByText(
+    hasTextAcrossElements('Print 4 Official Absentee Ballots')
+  );
+  userEvent.click(within(modal).getByText('Precinct'));
+  userEvent.click(within(modal).getByText('Test'));
+  userEvent.click(within(modal).getByText('Sample'));
+  within(modal).getByText(
+    hasTextAcrossElements('Print 4 Sample Precinct Ballots')
+  );
+  userEvent.type(within(modal).getByRole('spinbutton'), '{backspace}3');
+  within(modal).getByText(
+    hasTextAcrossElements('Print 12 Sample Precinct Ballots')
+  );
+});
+
+test('print sequence proceeds as expected', async () => {
+  const printer = fakePrinter();
+  const logger = fakeLogger();
+  const addPrintedBallot = jest.fn();
+  renderInAppContext(<PrintAllBallotsButton />, {
+    electionDefinition: electionMinimalExhaustiveSampleDefinition,
+    printer,
+    logger,
+    addPrintedBallot,
+  });
+
+  userEvent.click(screen.getByText('Print All'));
+
+  const modal = await screen.findByRole('alertdialog');
+  userEvent.click(
+    within(modal).getByText(
+      hasTextAcrossElements('Print 4 Official Absentee Ballots')
+    )
+  );
+
+  const expectedBallotStyles = [
+    ['Precinct 1', '1M'],
+    ['Precinct 1', '2F'],
+    ['Precinct 2', '1M'],
+    ['Precinct 2', '2F'],
+  ];
+
+  for (const [i, expectedBallotStyle] of expectedBallotStyles.entries()) {
+    await within(modal).findByText(`Printing Official Ballot (${i + 1} of 4)`);
+    within(modal).getByText(
+      hasTextAcrossElements(
+        `Precinct: ${expectedBallotStyle[0]}, Ballot Style: ${expectedBallotStyle[1]}`
+      )
+    );
+    expect(printer.print).toHaveBeenCalledTimes(i + 1);
+    expect(printer.print).toHaveBeenLastCalledWith({
+      sides: 'two-sided-long-edge',
+      copies: 1,
+    });
+    expect(logger.log).toHaveBeenCalledTimes(i + 1);
+    expect(logger.log).toHaveBeenLastCalledWith(
+      LogEventId.BallotPrinted,
+      'admin',
+      expect.objectContaining({
+        disposition: 'success',
+      })
+    );
+    expect(addPrintedBallot).toHaveBeenCalledTimes(i + 1);
+    expect(addPrintedBallot).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        numCopies: 1,
+      })
+    );
+    jest.advanceTimersByTime(TWO_SIDED_PRINT_TIME + PRINTER_WARMUP_TIME);
+  }
+
+  await waitFor(() => {
+    expect(modal).not.toBeInTheDocument();
+  });
+});
+
+test('initial modal state toggles based on printer state', async () => {
+  const card = new MemoryCard();
+  const hardware = MemoryHardware.build({
+    connectCardReader: true,
+  });
+  const storage = await createMemoryStorageWith({
+    electionDefinition: electionMinimalExhaustiveSampleDefinition,
+  });
+  render(<App card={card} hardware={hardware} storage={storage} />);
+
+  await authenticateWithAdminCard(
+    card,
+    electionMinimalExhaustiveSampleDefinition
+  );
+  await screen.findByText('Print All');
+  userEvent.click(screen.getByText('Print All'));
+  const modal = await screen.findByRole('alertdialog');
+  within(modal).getByText('No Printer Detected');
+
+  act(() => hardware.setPrinterConnected(true));
+  await within(modal).findByText('Print All Ballot Styles');
+
+  act(() => hardware.setPrinterConnected(false));
+  await within(modal).findByText('No Printer Detected');
+});
+
+test('modal shows "Printer Disconnected" if printer disconnected while printing', async () => {
+  const mockKiosk = fakeKiosk();
+  window.kiosk = mockKiosk;
+  const card = new MemoryCard();
+  const hardware = MemoryHardware.build({
+    connectCardReader: true,
+    connectPrinter: true,
+  });
+  const storage = await createMemoryStorageWith({
+    electionDefinition: electionMinimalExhaustiveSampleDefinition,
+  });
+  render(<App card={card} hardware={hardware} storage={storage} />);
+
+  await authenticateWithAdminCard(
+    card,
+    electionMinimalExhaustiveSampleDefinition
+  );
+  userEvent.click(await screen.findByText('Print All'));
+  const modal = await screen.findByRole('alertdialog');
+  userEvent.click(
+    within(modal).getByText(
+      hasTextAcrossElements('Print 4 Official Absentee Ballots')
+    )
+  );
+  await within(modal).findByText('Printing Official Ballot (1 of 4)');
+  act(() => hardware.setPrinterConnected(false));
+  jest.advanceTimersByTime(TWO_SIDED_PRINT_TIME + PRINTER_WARMUP_TIME);
+  await within(modal).findByText('Printer Disconnected');
+  expect(mockKiosk.log).toHaveBeenLastCalledWith(
+    expect.stringContaining('Failed to print ballots')
+  );
+
+  delete window.kiosk;
+});
+
+test('modal is different for super admins', async () => {
+  const card = new MemoryCard();
+  const hardware = MemoryHardware.build({
+    connectCardReader: true,
+    connectPrinter: true,
+  });
+  const storage = await createMemoryStorageWith({
+    electionDefinition: electionMinimalExhaustiveSampleDefinition,
+  });
+  render(<App card={card} hardware={hardware} storage={storage} />);
+
+  await authenticateWithAdminCard(
+    card,
+    electionMinimalExhaustiveSampleDefinition
+  );
+  userEvent.click(await screen.findByText('Print All'));
+  let modal = await screen.findByRole('alertdialog');
+  within(modal).getByText(
+    hasTextAcrossElements('Print 4 Official Absentee Ballots')
+  );
+  userEvent.click(within(modal).getByText('Cancel'));
+  userEvent.click(screen.getByText('Lock Machine'));
+
+  const adminOptions = ['Official', 'Test', 'Sample'];
+
+  await authenticateWithSuperAdminCard(card);
+  userEvent.click(await screen.findByText('Print All'));
+  modal = await screen.findByRole('alertdialog');
+  within(modal).getByText(
+    hasTextAcrossElements('Print 4 Draft Absentee Ballots')
+  );
+  for (const adminOption of adminOptions) {
+    expect(within(modal).queryAllByText(adminOption).length).toBe(0);
+  }
+  userEvent.click(within(modal).getByText('Cancel'));
+  userEvent.click(screen.getByText('Lock Machine'));
+
+  await authenticateWithAdminCard(
+    card,
+    electionMinimalExhaustiveSampleDefinition
+  );
+  userEvent.click(await screen.findByText('Print All'));
+  modal = await screen.findByRole('alertdialog');
+  within(modal).getByText(
+    hasTextAcrossElements('Print 4 Official Absentee Ballots')
+  );
+  for (const adminOption of adminOptions) {
+    within(modal).getByText(adminOption);
+  }
+});

--- a/frontends/election-manager/src/components/print_all_ballots_button.tsx
+++ b/frontends/election-manager/src/components/print_all_ballots_button.tsx
@@ -1,0 +1,350 @@
+import React, {
+  useCallback,
+  useContext,
+  useState,
+  useMemo,
+  useEffect,
+} from 'react';
+import styled from 'styled-components';
+import { BallotLocales, getPrecinctById } from '@votingworks/types';
+
+import {
+  assert,
+  throwIllegalValue,
+  BallotStyleData,
+  sleep,
+} from '@votingworks/utils';
+import {
+  Modal,
+  Prose,
+  isAdminAuth,
+  isSuperadminAuth,
+  useCancelablePromise,
+  Loading,
+  useLock,
+} from '@votingworks/ui';
+import { LogEventId } from '@votingworks/logging';
+import pluralize from 'pluralize';
+import {
+  getBallotStylesData,
+  sortBallotStyleDataByPrecinct,
+} from '../utils/election';
+
+import { AppContext } from '../contexts/app_context';
+import { HandMarkedPaperBallot } from './hand_marked_paper_ballot';
+import { Button } from './button';
+import { LinkButton } from './link_button';
+
+import {
+  BallotMode,
+  ballotModeToReadableString,
+  PrintableBallotType,
+} from '../config/types';
+import { BallotTypeToggle } from './ballot_type_toggle';
+import { BallotModeToggle } from './ballot_mode_toggle';
+import { PrintableArea } from './printable_area';
+import { DEFAULT_LOCALE } from '../config/globals';
+import { BallotCopiesInput } from './ballot_copies_input';
+import { PrintBallotButtonText } from './print_ballot_button_text';
+
+export const PRINTER_WARMUP_TIME = 8300;
+export const TWO_SIDED_PRINT_TIME = 3300;
+export const PRINTER_COOLDOWN_TIME = 5000;
+
+const CenteredOptions = styled.div`
+  text-align: center;
+  & > :last-child {
+    margin-bottom: 0;
+  }
+`;
+
+type ModalState = 'no-printer' | 'options' | 'printing';
+
+const defaultBallotLocales: BallotLocales = { primary: DEFAULT_LOCALE };
+
+interface Props {
+  draftMode?: boolean;
+}
+
+export function PrintAllBallotsButton({ draftMode }: Props): JSX.Element {
+  const makeCancelable = useCancelablePromise();
+  const {
+    electionDefinition,
+    auth,
+    logger,
+    hasPrinterAttached,
+    printer,
+    addPrintedBallot,
+  } = useContext(AppContext);
+  assert(electionDefinition);
+  assert(isAdminAuth(auth) || isSuperadminAuth(auth));
+  const userRole = auth.user.role;
+  const { election, electionHash } = electionDefinition;
+
+  const needsPrinter = window.kiosk && !hasPrinterAttached;
+  const initialState: ModalState = needsPrinter ? 'no-printer' : 'options';
+  const printLock = useLock();
+
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [modalState, setModalState] = useState<ModalState>(initialState);
+  const [printFailed, setPrintFailed] = useState(false);
+
+  const [ballotMode, setBallotMode] = useState(
+    draftMode ? BallotMode.Draft : BallotMode.Official
+  );
+  const [isAbsentee, setIsAbsentee] = useState(true);
+  const [ballotCopies, setBallotCopies] = useState(1);
+
+  const [ballotIndex, setBallotIndex] = useState<number>();
+  const ballotStyles = useMemo<BallotStyleData[]>(
+    () =>
+      sortBallotStyleDataByPrecinct(election, getBallotStylesData(election)),
+    [election]
+  );
+
+  useEffect(() => {
+    if (hasPrinterAttached && modalState === 'no-printer') {
+      setModalState('options');
+    } else if (!hasPrinterAttached && modalState === 'options') {
+      setModalState('no-printer');
+    }
+  }, [modalState, hasPrinterAttached]);
+
+  const closeModal = useCallback(() => {
+    setIsModalOpen(false);
+    setModalState(initialState);
+    setBallotIndex(undefined);
+    setPrintFailed(false);
+  }, [initialState]);
+
+  function startPrint() {
+    setBallotIndex(0);
+    setModalState('printing');
+  }
+
+  const logBallotsPrinted = useCallback(async () => {
+    assert(ballotIndex !== undefined);
+    const { precinctId, ballotStyleId } = ballotStyles[ballotIndex];
+
+    await logger.log(LogEventId.BallotPrinted, userRole, {
+      disposition: 'success',
+      message: `${ballotCopies} ${ballotMode} ${
+        isAbsentee ? 'absentee' : 'precinct'
+      } ballots printed for precinct ${precinctId} in ballot style ${ballotStyleId}`,
+      ballotMode,
+      isAbsentee,
+      ballotCopies,
+      ballotStyleId,
+      precinctId,
+    });
+
+    if (ballotMode === BallotMode.Official) {
+      const type = isAbsentee
+        ? PrintableBallotType.Absentee
+        : PrintableBallotType.Precinct;
+      addPrintedBallot({
+        ballotStyleId,
+        precinctId,
+        locales: defaultBallotLocales,
+        numCopies: ballotCopies,
+        printedAt: new Date().toISOString(),
+        type,
+      });
+    }
+  }, [
+    addPrintedBallot,
+    ballotCopies,
+    ballotIndex,
+    ballotMode,
+    ballotStyles,
+    isAbsentee,
+    logger,
+    userRole,
+  ]);
+
+  const advancePrinting = useCallback(async () => {
+    assert(ballotIndex !== undefined);
+    if (ballotIndex < ballotStyles.length - 1) {
+      await makeCancelable(
+        sleep(PRINTER_WARMUP_TIME + ballotCopies * TWO_SIDED_PRINT_TIME)
+      );
+      setBallotIndex(ballotIndex + 1);
+    } else {
+      // For the last print job, rather than waiting for all pages to finish
+      // printing, free up the UI from the print modal
+      await makeCancelable(sleep(PRINTER_COOLDOWN_TIME));
+      closeModal();
+    }
+  }, [
+    ballotCopies,
+    ballotIndex,
+    ballotStyles.length,
+    closeModal,
+    makeCancelable,
+  ]);
+
+  const onPrintError = useCallback(async () => {
+    setPrintFailed(true);
+    setModalState('no-printer');
+    setBallotIndex(undefined);
+    await logger.log(LogEventId.BallotPrinted, userRole, {
+      disposition: 'failure',
+      message:
+        'Failed to print ballots while printing all ballot styles because printer was disconnected.',
+      result: 'User directed to reconnect printer.',
+      error: 'Printer disconnected.',
+    });
+  }, [logger, userRole]);
+
+  const onRendered = useCallback(async () => {
+    assert(ballotIndex !== undefined);
+    if (printLock.lock()) {
+      if (needsPrinter) {
+        printLock.unlock();
+        return onPrintError();
+      }
+      await printer.print({
+        sides: 'two-sided-long-edge',
+        copies: ballotCopies,
+      });
+      await logBallotsPrinted();
+      await advancePrinting();
+      printLock.unlock();
+    }
+  }, [
+    ballotIndex,
+    printLock,
+    needsPrinter,
+    printer,
+    ballotCopies,
+    logBallotsPrinted,
+    advancePrinting,
+    onPrintError,
+  ]);
+
+  let mainContent = null;
+  let actions = null;
+  let onOverlayClick: VoidFunction | undefined = closeModal;
+
+  switch (modalState) {
+    case 'no-printer':
+      mainContent = (
+        <Prose>
+          <h1>
+            {printFailed ? 'Printer Disconnected' : 'No Printer Detected'}
+          </h1>
+          <p>
+            {printFailed
+              ? 'Printing stopped because the printer was disconnected. Reconnect the printer to try again.'
+              : 'Please connect the printer to print all ballot styles.'}
+          </p>
+        </Prose>
+      );
+      actions = <LinkButton onPress={closeModal}>Cancel</LinkButton>;
+      break;
+
+    case 'options':
+      mainContent = (
+        <Prose>
+          <h1>Print All Ballot Styles</h1>
+          <p>Select the ballot type and number of copies to print:</p>
+          <CenteredOptions>
+            {!draftMode && (
+              <p>
+                <BallotModeToggle
+                  ballotMode={ballotMode}
+                  setBallotMode={setBallotMode}
+                />
+              </p>
+            )}
+            <p>
+              <BallotTypeToggle
+                isAbsentee={isAbsentee}
+                setIsAbsentee={setIsAbsentee}
+              />
+            </p>
+            <p>
+              Copies{' '}
+              <BallotCopiesInput
+                ballotCopies={ballotCopies}
+                setBallotCopies={setBallotCopies}
+              />
+            </p>
+          </CenteredOptions>
+        </Prose>
+      );
+      actions = (
+        <React.Fragment>
+          <Button
+            primary
+            onPress={() => startPrint()}
+            warning={!draftMode && ballotMode !== BallotMode.Official}
+          >
+            <PrintBallotButtonText
+              ballotCopies={ballotCopies * ballotStyles.length}
+              ballotMode={ballotMode}
+              isAbsentee={isAbsentee}
+              election={election}
+            />
+          </Button>
+          <LinkButton onPress={closeModal}>Cancel</LinkButton>
+        </React.Fragment>
+      );
+      break;
+
+    case 'printing': {
+      assert(ballotIndex !== undefined);
+      const { ballotStyleId, precinctId } = ballotStyles[ballotIndex];
+      const precinct = getPrecinctById({ election, precinctId });
+      mainContent = (
+        <React.Fragment>
+          <Prose textCenter>
+            <Loading>
+              {`Printing ${ballotModeToReadableString(ballotMode)} ${pluralize(
+                'Ballot',
+                ballotCopies,
+                false
+              )} (${ballotIndex + 1} of ${ballotStyles.length})`}
+            </Loading>
+            <p>
+              Precinct: <strong>{precinct?.name}</strong>, Ballot Style:{' '}
+              <strong>{ballotStyleId}</strong>
+            </p>
+          </Prose>
+          <PrintableArea>
+            <HandMarkedPaperBallot
+              ballotStyleId={ballotStyleId}
+              election={election}
+              electionHash={electionHash}
+              ballotMode={ballotMode}
+              isAbsentee={isAbsentee}
+              precinctId={precinctId}
+              onRendered={onRendered}
+              locales={defaultBallotLocales}
+            />
+          </PrintableArea>
+        </React.Fragment>
+      );
+      onOverlayClick = undefined;
+      break;
+    }
+
+    default:
+      throwIllegalValue(modalState);
+  }
+
+  return (
+    <React.Fragment>
+      <LinkButton small onPress={() => setIsModalOpen(true)}>
+        Print All
+      </LinkButton>
+      {isModalOpen && (
+        <Modal
+          content={mainContent}
+          onOverlayClick={onOverlayClick}
+          actions={actions}
+        />
+      )}
+    </React.Fragment>
+  );
+}

--- a/frontends/election-manager/src/components/print_ballot_button_text.tsx
+++ b/frontends/election-manager/src/components/print_ballot_button_text.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import {
+  BallotLocales,
+  Election,
+  getElectionLocales,
+} from '@votingworks/types';
+import pluralize from 'pluralize';
+import { DEFAULT_LOCALE } from '../config/globals';
+import { BallotMode, ballotModeToReadableString } from '../config/types';
+import { getHumanBallotLanguageFormat } from '../utils/election';
+
+interface Props {
+  ballotCopies: number;
+  ballotMode: BallotMode;
+  isAbsentee: boolean;
+  election: Election;
+  localeCode?: string;
+}
+
+export function PrintBallotButtonText({
+  ballotCopies,
+  ballotMode,
+  isAbsentee,
+  election,
+  localeCode,
+}: Props): JSX.Element {
+  const locales: BallotLocales = {
+    primary: DEFAULT_LOCALE,
+    secondary: localeCode,
+  };
+  const availableLocaleCodes = getElectionLocales(election, DEFAULT_LOCALE);
+  return (
+    <span>
+      Print {ballotCopies}{' '}
+      <strong>
+        {ballotModeToReadableString(ballotMode)}{' '}
+        {isAbsentee ? 'Absentee' : 'Precinct'}
+      </strong>{' '}
+      {pluralize('Ballot', ballotCopies)}
+      {availableLocaleCodes.length > 1 &&
+        localeCode &&
+        ` in ${getHumanBallotLanguageFormat(locales)}`}
+    </span>
+  );
+}

--- a/frontends/election-manager/src/components/smartcard_modal/smartcard_modal.test.tsx
+++ b/frontends/election-manager/src/components/smartcard_modal/smartcard_modal.test.tsx
@@ -29,6 +29,7 @@ import { createMemoryStorageWith } from '../../../test/util/create_memory_storag
 import { generatePin } from './pins';
 import { MachineConfig } from '../../config/types';
 import { VxFiles } from '../../lib/converters';
+import { authenticateWithSuperAdminCard } from '../../../test/util/authenticate';
 
 jest.mock('@votingworks/ui', (): typeof import('@votingworks/ui') => {
   return {
@@ -66,21 +67,6 @@ beforeEach(() => {
   enableVvsg2AuthFlows();
   mockOf(generatePin).mockImplementation(() => '123456');
 });
-
-async function authenticateWithSuperAdminCard(card: MemoryCard) {
-  await screen.findByText('VxAdmin is Locked');
-  card.insertCard(makeSuperadminCard());
-  await screen.findByText('Enter the card security code to unlock.');
-  userEvent.click(screen.getByText('1'));
-  userEvent.click(screen.getByText('2'));
-  userEvent.click(screen.getByText('3'));
-  userEvent.click(screen.getByText('4'));
-  userEvent.click(screen.getByText('5'));
-  userEvent.click(screen.getByText('6'));
-  await screen.findByText('Remove card to continue.');
-  card.removeCard();
-  await screen.findByText('Lock Machine');
-}
 
 test('Smartcard modal displays card details', async () => {
   const card = new MemoryCard();

--- a/frontends/election-manager/src/config/types.ts
+++ b/frontends/election-manager/src/config/types.ts
@@ -12,6 +12,7 @@ import {
   PromiseOr,
   VotingMethod,
 } from '@votingworks/types';
+import { throwIllegalValue } from '@votingworks/utils';
 import { z } from 'zod';
 
 // Events
@@ -45,6 +46,27 @@ export enum BallotMode {
   Sample = 'sample',
   /** Draft ballots to verify that an election definition has been properly configured */
   Draft = 'draft',
+}
+
+export function ballotModeToReadableString(ballotMode: BallotMode): string {
+  switch (ballotMode) {
+    case BallotMode.Draft: {
+      return 'Draft';
+    }
+    case BallotMode.Official: {
+      return 'Official';
+    }
+    case BallotMode.Sample: {
+      return 'Sample';
+    }
+    case BallotMode.Test: {
+      return 'Test';
+    }
+    /* istanbul ignore next: Compile-time check for completeness */
+    default: {
+      throwIllegalValue(ballotMode);
+    }
+  }
 }
 
 export interface PrintedBallot {

--- a/frontends/election-manager/src/contexts/app_context.ts
+++ b/frontends/election-manager/src/contexts/app_context.ts
@@ -58,6 +58,7 @@ export interface AppContextInterface {
   auth: DippedSmartcardAuth.Auth;
   machineConfig: MachineConfig;
   hasCardReaderAttached: boolean;
+  hasPrinterAttached: boolean;
   logger: Logger;
 }
 
@@ -96,6 +97,7 @@ const appContext: AppContextInterface = {
     codeVersion: '',
   },
   hasCardReaderAttached: true,
+  hasPrinterAttached: true,
   logger: new Logger(LogSource.VxAdminFrontend),
 };
 /* eslint-enable @typescript-eslint/require-await */

--- a/frontends/election-manager/src/screens/ballot_list_screen.tsx
+++ b/frontends/election-manager/src/screens/ballot_list_screen.tsx
@@ -17,6 +17,7 @@ import {
 import { NavigationScreen } from '../components/navigation_screen';
 import { ExportElectionBallotPackageModalButton } from '../components/export_election_ballot_package_modal_button';
 import { ExportBallotPdfsButton } from '../components/export_ballot_pdfs_button';
+import { PrintAllBallotsButton } from '../components/print_all_ballots_button';
 
 const Header = styled.div`
   display: flex;
@@ -68,14 +69,18 @@ export function BallotListScreen({ draftMode }: Props): JSX.Element {
             </SegmentedButton>
           </p>
         </Prose>
-        {!draftMode && (
-          <Prose maxWidth={false}>
-            <p>
-              <ExportBallotPdfsButton />{' '}
-              <ExportElectionBallotPackageModalButton />
-            </p>
-          </Prose>
-        )}
+
+        <Prose maxWidth={false}>
+          <p>
+            <PrintAllBallotsButton draftMode={draftMode} />{' '}
+            {!draftMode && (
+              <React.Fragment>
+                <ExportBallotPdfsButton />{' '}
+                <ExportElectionBallotPackageModalButton />
+              </React.Fragment>
+            )}
+          </p>
+        </Prose>
       </Header>
       <Table>
         <thead>

--- a/frontends/election-manager/src/screens/ballot_screen.tsx
+++ b/frontends/election-manager/src/screens/ballot_screen.tsx
@@ -1,8 +1,4 @@
-import {
-  assert,
-  BALLOT_PDFS_FOLDER,
-  throwIllegalValue,
-} from '@votingworks/utils';
+import { assert, BALLOT_PDFS_FOLDER } from '@votingworks/utils';
 import React, {
   useCallback,
   useContext,
@@ -49,6 +45,7 @@ import { SaveFileToUsb, FileType } from '../components/save_file_to_usb';
 import { BallotCopiesInput } from '../components/ballot_copies_input';
 import { BallotModeToggle } from '../components/ballot_mode_toggle';
 import { BallotTypeToggle } from '../components/ballot_type_toggle';
+import { PrintBallotButtonText } from '../components/print_ballot_button_text';
 
 const BallotPreviewHeader = styled.div`
   margin-top: 1rem;
@@ -76,27 +73,6 @@ const BallotPreview = styled.div`
     }
   }
 `;
-
-function ballotModeToReadableString(ballotMode: BallotMode): string {
-  switch (ballotMode) {
-    case BallotMode.Draft: {
-      return 'Draft';
-    }
-    case BallotMode.Official: {
-      return 'Official';
-    }
-    case BallotMode.Sample: {
-      return 'Sample';
-    }
-    case BallotMode.Test: {
-      return 'Test';
-    }
-    /* istanbul ignore next: Compile-time check for completeness */
-    default: {
-      throwIllegalValue(ballotMode);
-    }
-  }
-}
 
 interface Props {
   draftMode?: boolean;
@@ -275,15 +251,13 @@ export function BallotScreen({ draftMode }: Props): JSX.Element {
               sides="two-sided-long-edge"
               warning={ballotMode !== BallotMode.Official}
             >
-              Print {ballotCopies}{' '}
-              <strong>
-                {ballotModeToReadableString(ballotMode)}{' '}
-                {isAbsentee ? 'Absentee' : 'Precinct'}
-              </strong>{' '}
-              {pluralize('Ballot', ballotCopies)}{' '}
-              {availableLocaleCodes.length > 1 &&
-                currentLocaleCode &&
-                ` in ${getHumanBallotLanguageFormat(locales)}`}
+              <PrintBallotButtonText
+                ballotCopies={ballotCopies}
+                ballotMode={ballotMode}
+                isAbsentee={isAbsentee}
+                election={election}
+                localeCode={currentLocaleCode}
+              />
             </PrintButton>
             {window.kiosk && (
               <React.Fragment>

--- a/frontends/election-manager/test/render_in_app_context.tsx
+++ b/frontends/election-manager/test/render_in_app_context.tsx
@@ -70,6 +70,7 @@ interface RenderInAppContextParams {
   auth?: DippedSmartcardAuth.Auth;
   machineConfig?: MachineConfig;
   hasCardReaderAttached?: boolean;
+  hasPrinterAttached?: boolean;
   logger?: Logger;
 }
 
@@ -107,6 +108,7 @@ export function renderInAppContext(
       codeVersion: '',
     },
     hasCardReaderAttached = true,
+    hasPrinterAttached = true,
     logger = new Logger(LogSource.VxAdminFrontend),
   }: RenderInAppContextParams = {}
 ): RenderResult {
@@ -140,6 +142,7 @@ export function renderInAppContext(
         auth,
         machineConfig,
         hasCardReaderAttached,
+        hasPrinterAttached,
         logger,
       }}
     >

--- a/frontends/election-manager/test/util/authenticate.tsx
+++ b/frontends/election-manager/test/util/authenticate.tsx
@@ -1,0 +1,41 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { makeAdminCard, makeSuperadminCard } from '@votingworks/test-utils';
+import { ElectionDefinition } from '@votingworks/types';
+import { MemoryCard } from '@votingworks/utils';
+
+export async function authenticateWithAdminCard(
+  card: MemoryCard,
+  electionDefinition: ElectionDefinition
+): Promise<void> {
+  // Machine should be locked
+  await screen.findByText('VxAdmin is Locked');
+  card.insertCard(makeAdminCard(electionDefinition.electionHash, '123456'));
+  await screen.findByText('Enter the card security code to unlock.');
+  userEvent.click(screen.getByText('1'));
+  userEvent.click(screen.getByText('2'));
+  userEvent.click(screen.getByText('3'));
+  userEvent.click(screen.getByText('4'));
+  userEvent.click(screen.getByText('5'));
+  userEvent.click(screen.getByText('6'));
+  await screen.findByText('Remove card to continue.');
+  card.removeCard();
+  await screen.findByText('Lock Machine');
+}
+
+export async function authenticateWithSuperAdminCard(
+  card: MemoryCard
+): Promise<void> {
+  await screen.findByText('VxAdmin is Locked');
+  card.insertCard(makeSuperadminCard());
+  await screen.findByText('Enter the card security code to unlock.');
+  userEvent.click(screen.getByText('1'));
+  userEvent.click(screen.getByText('2'));
+  userEvent.click(screen.getByText('3'));
+  userEvent.click(screen.getByText('4'));
+  userEvent.click(screen.getByText('5'));
+  userEvent.click(screen.getByText('6'));
+  await screen.findByText('Remove card to continue.');
+  card.removeCard();
+  await screen.findByText('Lock Machine');
+}


### PR DESCRIPTION
_Recommend commit-by-commit review_

## Overview
Closes #2175. Adds feature to the ballot list screen to allow printing all ballot styles for a given ballot type at once.

## Demo Video or Screenshot
Admin Happy Path:
[print-all-ballots-flow.webm](https://user-images.githubusercontent.com/37960853/183234868-d59431b8-3aa8-4177-9f97-cf5bee3b4dd8.webm)

Superadmin Screenshot:
<img width="1512" alt="print-all-draft-ballots" src="https://user-images.githubusercontent.com/37960853/183234878-d80895c5-487d-48fe-af33-e3ef27c9d19c.png">

No Printer Handling:
[print-all-ballots-no-printer.webm](https://user-images.githubusercontent.com/37960853/183234893-4c203c67-59bf-44b7-8a14-cd92ac93f7b4.webm)

## Testing Plan 
- New test suite for new component
- Manual testing

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
