### PR TITLE
Drew/backup logs

### DIFF
--- a/frontends/bsd/src/components/export_logs_modal.tsx
+++ b/frontends/bsd/src/components/export_logs_modal.tsx
@@ -13,7 +13,12 @@ import {
   LogFileType,
 } from '@votingworks/utils';
 
-import { LogEventId } from '@votingworks/logging';
+import {
+  LogEventId,
+  LOGS_ROOT_LOCATION,
+  LOG_NAME,
+  FULL_LOG_PATH,
+} from '@votingworks/logging';
 import { AppContext } from '../contexts/app_context';
 import { Button } from './button';
 import { Prose } from './prose';
@@ -22,9 +27,6 @@ import { Loading } from './loading';
 import { UsbImage } from './export_results_modal';
 
 const { UsbDriveStatus } = usbstick;
-
-const LOGS_ROOT_LOCATION = '/var/log';
-const LOG_NAME = 'vx-logs';
 
 export interface Props {
   onClose: () => void;
@@ -86,10 +88,7 @@ export function ExportLogsModal({ onClose, logFileType }: Props): JSX.Element {
     setCurrentState(ModalState.Saving);
 
     try {
-      const rawLogFile = await window.kiosk.readFile(
-        `${LOGS_ROOT_LOCATION}/${LOG_NAME}.log`,
-        'utf8'
-      );
+      const rawLogFile = await window.kiosk.readFile(FULL_LOG_PATH, 'utf8');
       let results = '';
       switch (logFileType) {
         case LogFileType.Raw:

--- a/frontends/election-manager/src/components/export_logs_modal.tsx
+++ b/frontends/election-manager/src/components/export_logs_modal.tsx
@@ -8,7 +8,12 @@ import {
   LogFileType,
 } from '@votingworks/utils';
 
-import { LogEventId } from '@votingworks/logging';
+import {
+  LogEventId,
+  LOGS_ROOT_LOCATION,
+  LOG_NAME,
+  FULL_LOG_PATH,
+} from '@votingworks/logging';
 import {
   isElectionManagerAuth,
   isSystemAdministratorAuth,
@@ -22,9 +27,6 @@ import { Loading } from './loading';
 import { UsbImage } from './save_file_to_usb';
 
 const { UsbDriveStatus } = usbstick;
-
-const LOGS_ROOT_LOCATION = '/var/log';
-const LOG_NAME = 'vx-logs';
 
 export interface Props {
   onClose: () => void;
@@ -86,10 +88,7 @@ export function ExportLogsModal({ onClose, logFileType }: Props): JSX.Element {
     setCurrentState(ModalState.Saving);
 
     try {
-      const rawLogFile = await window.kiosk.readFile(
-        `${LOGS_ROOT_LOCATION}/${LOG_NAME}.log`,
-        'utf8'
-      );
+      const rawLogFile = await window.kiosk.readFile(FULL_LOG_PATH, 'utf8');
       let results = '';
       switch (logFileType) {
         case LogFileType.Raw:

--- a/libs/logging/src/logger.ts
+++ b/libs/logging/src/logger.ts
@@ -26,6 +26,7 @@ import { LogEventId, getDetailsForEventId } from './log_event_ids';
 
 export const LOGS_ROOT_LOCATION = '/var/log';
 export const LOG_NAME = 'vx-logs';
+export const FULL_LOG_PATH = `${LOGS_ROOT_LOCATION}/${LOG_NAME}.log`;
 
 const debug = makeDebug('logger');
 

--- a/services/scan/src/backup.ts
+++ b/services/scan/src/backup.ts
@@ -1,11 +1,12 @@
 import { Buffer } from 'buffer';
 import makeDebug from 'debug';
-import { createReadStream } from 'fs-extra';
+import { createReadStream, existsSync } from 'fs-extra';
 import { WritableStream } from 'memory-streams';
 import { basename } from 'path';
 import Database from 'better-sqlite3';
 import { fileSync } from 'tmp';
 import ZipStream from 'zip-stream';
+import { FULL_LOG_PATH } from '@votingworks/logging';
 import { Store } from './store';
 
 const debug = makeDebug('scan:backup');
@@ -87,6 +88,10 @@ export class Backup {
       await this.addFileEntry(sheet.front.normalized);
       await this.addFileEntry(sheet.back.original);
       await this.addFileEntry(sheet.back.normalized);
+    }
+
+    if (existsSync(FULL_LOG_PATH)) {
+      await this.addFileEntry(FULL_LOG_PATH);
     }
 
     this.zip.finalize();


### PR DESCRIPTION
## Overview
Closes #1490 by adding logs to our scanner backups.

## Testing Plan
- Unit Tests
- Manual Testing (still needs to be done)

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
