### PR TITLE
feat(scan): Hold paper in front on reboot

### DIFF
--- a/services/scan/src/precinct_scanner_app.test.ts
+++ b/services/scan/src/precinct_scanner_app.test.ts
@@ -499,6 +499,33 @@ test('scanner powered off while returning', async () => {
   await waitForStatus(app, { state: 'jammed' });
 });
 
+test('scanner powered off after returning', async () => {
+  const { app, mockPlustek } = await createApp();
+  await configureApp(app, { addTemplates: true });
+
+  await mockPlustek.simulateLoadSheet(ballotImages.unmarkedHmpb);
+  await waitForStatus(app, { state: 'ready_to_scan' });
+
+  const interpretation = needsReviewInterpretation;
+
+  await post(app, '/scanner/scan');
+  await expectStatus(app, { state: 'scanning' });
+  await waitForStatus(app, { state: 'needs_review', interpretation });
+
+  await post(app, '/scanner/return');
+  await waitForStatus(app, { state: 'returning', interpretation });
+  await waitForStatus(app, { state: 'returned', interpretation });
+
+  mockPlustek.simulatePowerOff();
+  await waitForStatus(app, { state: 'disconnected' });
+
+  mockPlustek.simulatePowerOn('ready_to_scan');
+  await waitForStatus(app, {
+    state: 'rejected',
+    error: 'paper_in_front_on_startup',
+  });
+});
+
 test('insert second ballot while first ballot is scanning', async () => {
   const { app, mockPlustek } = await createApp();
   await configureApp(app);

--- a/services/scan/src/precinct_scanner_state_machine.ts
+++ b/services/scan/src/precinct_scanner_state_machine.ts
@@ -356,7 +356,7 @@ function buildMachine(createPlustekClient: CreatePlustekClient) {
           on: {
             SCANNER_NO_PAPER: 'no_paper',
             SCANNER_READY_TO_SCAN: {
-              target: 'rejecting',
+              target: 'rejected',
               actions: assign({
                 error: new PrecinctScannerError('paper_in_front_on_startup'),
               }),


### PR DESCRIPTION

## Overview
If there's a paper held in the front on startup (e.g. after returning or rejecting a ballot before rebooting), then we shouldn't reject it (which will spit it out completely), but rather just hold it where it is (already rejected). This is consistent with our "always hold papers in front" approach.

## Demo Video or Screenshot
N/A

## Testing Plan 
- Manual test
- Added integration test

