### PR TITLE
fix(scan): Fix blank ballot adjudication reasons

### DIFF
--- a/services/scan/src/precinct_scanner_app.test.ts
+++ b/services/scan/src/precinct_scanner_app.test.ts
@@ -1,7 +1,6 @@
 import { MockScannerClient, ScannerClient } from '@votingworks/plustek-sdk';
 import {
   AdjudicationReason,
-  AdjudicationReasonInfo,
   CastVoteRecord,
   ok,
   Result,
@@ -275,27 +274,9 @@ test('configure and scan bmd ballot', async () => {
   expect(cvrs).toHaveLength(1);
 });
 
-function undervote(contestId: string, expected = 1): AdjudicationReasonInfo {
-  return {
-    type: AdjudicationReason.Undervote,
-    contestId,
-    optionIds: [],
-    optionIndexes: [],
-    expected,
-  };
-}
 const needsReviewInterpretation: Scan.SheetInterpretation = {
   type: 'NeedsReviewSheet',
-  reasons: [
-    undervote('mayor'),
-    undervote('controller'),
-    undervote('attorney'),
-    undervote('public-works-director'),
-    undervote('chief-of-police'),
-    undervote('parks-and-recreation-director'),
-    undervote('board-of-alderman', 4),
-    undervote('city-council', 4),
-  ],
+  reasons: [{ type: AdjudicationReason.BlankBallot }],
 };
 
 test('ballot needs review - return', async () => {

--- a/services/scan/src/simple_interpreter.ts
+++ b/services/scan/src/simple_interpreter.ts
@@ -117,10 +117,12 @@ function combinePageInterpretationsForSheet(
     let reasons: AdjudicationReasonInfo[];
     // If both sides are blank, the ballot is blank
     if (
-      frontReasons.length === 1 &&
-      frontReasons[0].type === AdjudicationReason.BlankBallot &&
-      backReasons.length === 1 &&
-      backReasons[0].type === AdjudicationReason.BlankBallot
+      frontReasons.some(
+        (reason) => reason.type === AdjudicationReason.BlankBallot
+      ) &&
+      backReasons.some(
+        (reason) => reason.type === AdjudicationReason.BlankBallot
+      )
     ) {
       reasons = [{ type: AdjudicationReason.BlankBallot }];
     }


### PR DESCRIPTION
## Overview
Fixes: https://github.com/votingworks/vxsuite/issues/2230
I made a mistake by assuming that a blank ballot would only have one adjudication reason: BlankBallot. Instead, it has Undervotes for each contest followed by a BlankBallot at the end.


## Demo Video or Screenshot
N/A

## Testing Plan 
- Manually tested
- Updated existing integration tests that were just wrong 

