### PR TITLE
Bump timeouts in VxAdmin integration test to minimize flakiness

### DIFF
--- a/integration-testing/election-manager/cypress/e2e/yes_no_contest_tallies.cy.ts
+++ b/integration-testing/election-manager/cypress/e2e/yes_no_contest_tallies.cy.ts
@@ -164,7 +164,7 @@ describe('Election Manager can create SEMS tallies', () => {
     mockCardRemoval();
     cy.contains('Convert from SEMS files');
     cy.get('input[type="file"]').attachFile('electionWithMsEitherNeither.json');
-    cy.contains('Election loading');
+    cy.contains('Election loading', { timeout: 8000 });
     cy.contains(electionWithMsEitherNeitherCypressHash.slice(0, 10));
     cy.pause();
     cy.contains('Lock Machine').click();
@@ -503,7 +503,7 @@ describe('Election Manager can create SEMS tallies', () => {
     // Check that the exported SEMS result file as the correct tallies
     cy.contains('Save Results File').click();
     cy.get('[data-testid="manual-export"]').click();
-    cy.contains('Results Saved');
+    cy.contains('Results Saved', { timeout: 8000 });
     cy.task<string>('readMostRecentFile', 'cypress/downloads').then(
       (fileContent) => {
         assertExpectedResultsMatchSEMsFile(


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/1749

Some things are meant to be flaky 😋

<img src="https://user-images.githubusercontent.com/12616928/183521563-cc3d48de-207b-4c1a-89ce-f9ff29a640a8.png" alt="pie" width=200 />

Others are not 🙅

<img src="https://user-images.githubusercontent.com/12616928/183521745-79fc6842-843d-4409-b859-1390b29f2cd9.png" alt="failure-1" />

<img src="https://user-images.githubusercontent.com/12616928/183521665-b1749734-20b4-404a-abc9-b56b12124347.png" alt="failure-2" />

There are at least two different points in this VxAdmin integration test that occasionally (actually fairly frequently) time out. The default Cypress timeout is 4 seconds, so I've doubled to 8 seconds at these two points.

I haven't been able to repro the error locally, so I won't close the linked issue until some time passes and no one sees this test fail in CI!