### PR TITLE
scanners: encourage user to wait for backup to finish

### DIFF
--- a/frontends/bsd/src/app_root.tsx
+++ b/frontends/bsd/src/app_root.tsx
@@ -391,6 +391,11 @@ export function AppRoot({ card, hardware, logger }: AppRootProps): JSX.Element {
 
   const backup = useCallback(async () => {
     await download('/scan/backup');
+    if (window.kiosk) {
+      // Backups can take several minutes. Ensure the data is flushed to the
+      // usb before prompting the user to eject it.
+      await usbstick.doSync();
+    }
   }, []);
 
   const toggleTestMode = useCallback(async () => {

--- a/frontends/bsd/src/screens/admin_actions_screen.test.tsx
+++ b/frontends/bsd/src/screens/admin_actions_screen.test.tsx
@@ -48,12 +48,17 @@ test('clicking "Export Backup" shows progress', async () => {
     backupButton.click();
     expect(backup).toHaveBeenCalledTimes(1);
 
-    // Verify progress message is shown.
-    await waitFor(() => screen.getByText('Exporting…'));
+    // Verify progress modal is shown.
+    await waitFor(() => {
+      const modal = screen.getByRole('alertdialog');
+      within(modal).getByText('Exporting Backup');
+      screen.getByText('Exporting…');
+    });
 
     // Trigger backup finished, verify back to normal.
     resolve();
     await waitFor(() => screen.getByText('Export Backup'));
+    expect(screen.queryAllByRole('alertdialog').length).toBe(0);
   });
 });
 

--- a/frontends/bsd/src/screens/admin_actions_screen.tsx
+++ b/frontends/bsd/src/screens/admin_actions_screen.tsx
@@ -301,6 +301,9 @@ export function AdminActionsScreen({
           logFileType={exportingLogType}
         />
       )}
+      {isBackingUp && (
+        <Modal centerContent content={<Loading>Exporting Backup</Loading>} />
+      )}
     </React.Fragment>
   );
 }

--- a/frontends/precinct-scanner/src/components/export_backup_modal.test.tsx
+++ b/frontends/precinct-scanner/src/components/export_backup_modal.test.tsx
@@ -158,6 +158,7 @@ test('render export modal when a USB drive is mounted as expected and allows aut
   expect(download).toHaveBeenCalledWith('/scan/backup', {
     into: 'fake mount point/scanner-backups/franklin-county_general-election_748dc61ad3',
   });
+  expect(mockKiosk.syncUsbDrive).toHaveBeenCalledWith('fake mount point');
 
   fireEvent.click(screen.getByText('Eject USB'));
   expect(ejectFn).toHaveBeenCalled();

--- a/frontends/precinct-scanner/src/components/export_backup_modal.tsx
+++ b/frontends/precinct-scanner/src/components/export_backup_modal.tsx
@@ -70,9 +70,14 @@ export function ExportBackupModal({ onClose, usbDrive }: Props): JSX.Element {
           electionFolderName
         );
         result = await download('/scan/backup', { into: pathToFolder });
-        setCurrentState(result.isOk() ? ModalState.DONE : ModalState.ERROR);
       } else {
         result = await download('/scan/backup');
+      }
+
+      if (window.kiosk) {
+        // Backups can take several minutes. Ensure the data is flushed to the
+        // usb before prompting the user to eject it.
+        await usbstick.doSync();
       }
 
       if (result.isOk()) {


### PR DESCRIPTION
## Overview
Closes #2250. The current backup flow makes it easy for the user to take the USB drive out too early. In this change, we call `sync` on the mounted USB drive before allowing the user to eject, ensuring that data is actually flushed to disk. In `bsd`, I introduce a very simple modal to prevent the user from exiting or clicking "Eject" in the corner while exporting a backup. Currently the only indicator is the disabled "Export Backup" button.

## Demo Video or Screenshot

![Screen Shot 2022-08-08 at 3 58 46 PM (2)](https://user-images.githubusercontent.com/37960853/183528618-f3581027-8552-48f6-b772-0aee669864ad.png)

## Testing Plan
- Updated tests in `bsd` and `precinct-scanner`
- Manual Testing (in VM with attached hardware)

Have not manually tested this on full hardware yet, which is important, but I think better to merge and test with a production image on Wednesday. We've used the `sync` API for CVRs in VxScan so I believe it is a safe operation on hardware.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
