### PR TITLE
fix(ps): Don't crash if card removed during calibration

### DIFF
--- a/frontends/precinct-scanner/src/app.test.tsx
+++ b/frontends/precinct-scanner/src/app.test.tsx
@@ -38,16 +38,14 @@ import {
 import { AdjudicationReason, PrecinctSelectionKind } from '@votingworks/types';
 
 import { mocked } from 'ts-jest/utils';
-import {
-  CARD_POLLING_INTERVAL,
-  areVvsg2AuthFlowsEnabled,
-} from '@votingworks/ui';
+import { areVvsg2AuthFlowsEnabled } from '@votingworks/ui';
 import userEvent from '@testing-library/user-event';
 import { App } from './app';
 
 import { stateStorageKey } from './app_root';
 import { POLLING_INTERVAL_FOR_SCANNER_STATUS_MS } from './config/globals';
 import { MachineConfigResponse } from './config/types';
+import { authenticateAdminCard, scannerStatus } from '../test/helpers/helpers';
 
 jest.setTimeout(20000);
 
@@ -104,17 +102,6 @@ const deleteElectionConfigResponseBody: Scan.DeleteElectionConfigResponse = {
   status: 'ok',
 };
 
-function scannerStatus(
-  props: Partial<Scan.GetPrecinctScannerStatusResponse> = {}
-) {
-  return {
-    state: 'no_paper',
-    ballotsCounted: 0,
-    canUnconfigure: false,
-    ...props,
-  };
-}
-
 const statusNoPaper = scannerStatus({ state: 'no_paper' });
 const statusReadyToScan = scannerStatus({ state: 'ready_to_scan' });
 
@@ -122,18 +109,6 @@ const getPrecinctConfigNoPrecinctResponseBody: Scan.GetCurrentPrecinctConfigResp
   {
     status: 'ok',
   };
-
-async function authenticateAdminCard() {
-  jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
-  await screen.findByText('Enter the card security code to unlock.');
-  fireEvent.click(screen.getByText('1'));
-  fireEvent.click(screen.getByText('2'));
-  fireEvent.click(screen.getByText('3'));
-  fireEvent.click(screen.getByText('4'));
-  fireEvent.click(screen.getByText('5'));
-  fireEvent.click(screen.getByText('6'));
-  screen.getByText('Administrator Settings');
-}
 
 test('shows setup card reader screen when there is no card reader', async () => {
   const card = new MemoryCard();

--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -491,8 +491,6 @@ export function AppRoot({
   }
 
   assert(scannerStatus.state !== 'unconfigured');
-  assert(scannerStatus.state !== 'calibrating');
-  assert(scannerStatus.state !== 'calibrated');
   const voterScreen = (() => {
     switch (scannerStatus.state) {
       case 'connecting':
@@ -556,6 +554,11 @@ export function AppRoot({
             isTestMode={isTestMode}
           />
         );
+      // If an election manager removes their card during calibration, we'll
+      // hit this case. Just show a blank screen for now, since this shouldn't
+      // really happen.
+      case 'calibrating':
+        return null;
       /* istanbul ignore next - compile time check for completeness */
       default:
         throwIllegalValue(scannerStatus.state);

--- a/frontends/precinct-scanner/src/setupTests.ts
+++ b/frontends/precinct-scanner/src/setupTests.ts
@@ -1,5 +1,6 @@
 import fetchMock from 'fetch-mock';
 import jestFetchMock from 'jest-fetch-mock';
+import '@testing-library/jest-dom/extend-expect';
 import { TextDecoder, TextEncoder } from 'util';
 
 beforeEach(() => {

--- a/frontends/precinct-scanner/test/helpers/helpers.ts
+++ b/frontends/precinct-scanner/test/helpers/helpers.ts
@@ -1,0 +1,27 @@
+import userEvent from '@testing-library/user-event';
+import { screen } from '@testing-library/react';
+import { Scan } from '@votingworks/api';
+import { CARD_POLLING_INTERVAL } from '../../src/config/globals';
+
+export async function authenticateAdminCard(): Promise<void> {
+  jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
+  await screen.findByText('Enter the card security code to unlock.');
+  userEvent.click(screen.getByText('1'));
+  userEvent.click(screen.getByText('2'));
+  userEvent.click(screen.getByText('3'));
+  userEvent.click(screen.getByText('4'));
+  userEvent.click(screen.getByText('5'));
+  userEvent.click(screen.getByText('6'));
+  await screen.findByText('Administrator Settings');
+}
+
+export function scannerStatus(
+  props: Partial<Scan.GetPrecinctScannerStatusResponse> = {}
+): Scan.GetPrecinctScannerStatusResponse {
+  return {
+    state: 'no_paper',
+    ballotsCounted: 0,
+    canUnconfigure: false,
+    ...props,
+  };
+}

--- a/libs/api/src/services/scan/index.ts
+++ b/libs/api/src/services/scan/index.ts
@@ -659,7 +659,6 @@ export const PrecinctScannerStateSchema = z.enum([
   'rejecting',
   'rejected',
   'calibrating',
-  'calibrated',
   'jammed',
   'both_sides_have_paper',
   'error',

--- a/services/scan/src/precinct_scanner_state_machine.ts
+++ b/services/scan/src/precinct_scanner_state_machine.ts
@@ -780,8 +780,6 @@ export function createPrecinctScannerStateMachine(
             return 'rejected';
           case state.matches('calibrating'):
             return 'calibrating';
-          case state.matches('calibrated'):
-            return 'calibrated';
           case state.matches('error_jammed'):
             return 'jammed';
           case state.matches('error_both_sides_have_paper'):


### PR DESCRIPTION


## Overview
Fixes: https://github.com/votingworks/vxsuite/issues/2237

Previously, we asserted that the scanner would never be in the `calibrating` state while in voter mode. That's not true - if the election manager removes their card during calibration and the polls are open, it's possible. Since this isn't something we really expect to happen, we just handle it by rendering a blank screen (which will go away when calibration finishes). If we decide we need a screen here, we can come back and add it later. The goal of this PR is to not crash.

## Demo Video or Screenshot

https://user-images.githubusercontent.com/530106/183534955-52309a36-8ec1-47a8-9f18-c6bf98c7ccba.mov



## Testing Plan 
- Manual test
- Added regression test