### PR TITLE
Make various copy updates, primarily focused on using new user role names

### DIFF
--- a/frontends/bmd/src/app_card_unhappy_paths.test.tsx
+++ b/frontends/bmd/src/app_card_unhappy_paths.test.tsx
@@ -180,12 +180,12 @@ test('Inserting voter card when machine is unconfigured does nothing', async () 
   // ====================== END CONTEST SETUP ====================== //
 
   // Default Unconfigured
-  screen.getByText('Device Not Configured');
+  screen.getByText('VxMark is Not Configured');
 
   card.insertCard(makeVoterCard(electionSample));
   await advanceTimersAndPromises();
 
-  screen.getByText('Device Not Configured');
+  screen.getByText('VxMark is Not Configured');
 });
 
 test('Inserting pollworker card with invalid long data fall back as if there is no long data', async () => {

--- a/frontends/bmd/src/app_cardless_voting.test.tsx
+++ b/frontends/bmd/src/app_cardless_voting.test.tsx
@@ -63,7 +63,7 @@ test('Cardless Voting Flow', async () => {
   await advanceTimersAndPromises();
 
   // Default Unconfigured
-  screen.getByText('Device Not Configured');
+  screen.getByText('VxMark is Not Configured');
 
   // ---------------
 
@@ -73,7 +73,7 @@ test('Cardless Voting Flow', async () => {
   fireEvent.click(screen.getByText('Load Election Definition'));
 
   await advanceTimersAndPromises();
-  screen.getByText('Election definition is loaded.');
+  screen.getByText('Election Definition is loaded.');
   screen.getByLabelText('Precinct');
   screen.queryByText(`Election ID: ${electionHash.slice(0, 10)}`);
 
@@ -318,7 +318,7 @@ test('poll worker must select a precinct first', async () => {
   await advanceTimersAndPromises();
 
   // Default Unconfigured
-  screen.getByText('Device Not Configured');
+  screen.getByText('VxMark is Not Configured');
 
   // ---------------
 
@@ -328,7 +328,7 @@ test('poll worker must select a precinct first', async () => {
   fireEvent.click(screen.getByText('Load Election Definition'));
 
   await advanceTimersAndPromises();
-  screen.getByText('Election definition is loaded.');
+  screen.getByText('Election Definition is loaded.');
   screen.getByLabelText('Precinct');
   screen.queryByText(`Election ID: ${electionHash.slice(0, 10)}`);
 

--- a/frontends/bmd/src/app_cardless_voting.test.tsx
+++ b/frontends/bmd/src/app_cardless_voting.test.tsx
@@ -25,7 +25,7 @@ import { advanceTimersAndPromises } from '../test/helpers/smartcards';
 import { fakePrinter } from '../test/helpers/fake_printer';
 import { fakeMachineConfigProvider } from '../test/helpers/fake_machine_config';
 import { MarkAndPrint } from './config/types';
-import { authenticateAdminCard } from '../test/test_utils';
+import { enterPin } from '../test/test_utils';
 
 beforeEach(() => {
   jest.useFakeTimers();
@@ -69,7 +69,7 @@ test('Cardless Voting Flow', async () => {
 
   // Configure with Election Manager Card
   card.insertCard(electionManagerCard, electionData);
-  await authenticateAdminCard();
+  await enterPin();
   fireEvent.click(screen.getByText('Load Election Definition'));
 
   await advanceTimersAndPromises();
@@ -324,7 +324,7 @@ test('poll worker must select a precinct first', async () => {
 
   // Configure with Election Manager Card
   card.insertCard(electionManagerCard, electionData);
-  await authenticateAdminCard();
+  await enterPin();
   fireEvent.click(screen.getByText('Load Election Definition'));
 
   await advanceTimersAndPromises();

--- a/frontends/bmd/src/app_data.test.tsx
+++ b/frontends/bmd/src/app_data.test.tsx
@@ -33,7 +33,7 @@ describe('loads election', () => {
     // Let the initial hardware detection run.
     await advanceTimersAndPromises();
 
-    screen.getByText('Device Not Configured');
+    screen.getByText('VxMark is Not Configured');
   });
 
   it('from storage', async () => {

--- a/frontends/bmd/src/app_end_to_end.test.tsx
+++ b/frontends/bmd/src/app_end_to_end.test.tsx
@@ -49,7 +49,7 @@ import { fakePrinter } from '../test/helpers/fake_printer';
 import { fakeMachineConfigProvider } from '../test/helpers/fake_machine_config';
 import { MarkAndPrint } from './config/types';
 import { REPORT_PRINTING_TIMEOUT_SECONDS } from './config/globals';
-import { authenticateAdminCard } from '../test/test_utils';
+import { enterPin } from '../test/test_utils';
 
 beforeEach(() => {
   jest.useFakeTimers();
@@ -100,7 +100,7 @@ it('MarkAndPrint end-to-end flow', async () => {
 
   // Configure with Election Manager Card
   card.insertCard(electionManagerCard, electionDefinition.electionData);
-  await authenticateAdminCard();
+  await enterPin();
   fireEvent.click(screen.getByText('Load Election Definition'));
 
   await advanceTimersAndPromises();
@@ -122,7 +122,7 @@ it('MarkAndPrint end-to-end flow', async () => {
 
   // Configure election with Election Manager Card
   card.insertCard(electionManagerCard, electionDefinition.electionData);
-  await authenticateAdminCard();
+  await enterPin();
   screen.getByLabelText('Precinct');
   screen.queryByText(`Election ID: ${expectedElectionHash}`);
   screen.queryByText('Machine ID: 000');
@@ -418,7 +418,7 @@ it('MarkAndPrint end-to-end flow', async () => {
 
   // Insert System Administrator card
   card.insertCard(makeSystemAdministratorCard());
-  await authenticateAdminCard();
+  await enterPin();
   await screen.findByText('Reboot from USB');
   card.removeCard();
   await advanceTimersAndPromises();
@@ -427,7 +427,7 @@ it('MarkAndPrint end-to-end flow', async () => {
 
   // Unconfigure with Election Manager Card
   card.insertCard(electionManagerCard, electionDefinition.electionData);
-  await authenticateAdminCard();
+  await enterPin();
   screen.getByText('Election Definition is loaded.');
   fireEvent.click(screen.getByText('Unconfigure Machine'));
   await advanceTimersAndPromises();
@@ -439,7 +439,7 @@ it('MarkAndPrint end-to-end flow', async () => {
 
   // Insert System Administrator card works when unconfigured
   card.insertCard(makeSystemAdministratorCard());
-  await authenticateAdminCard();
+  await enterPin();
   await screen.findByText('Reboot from USB');
   card.removeCard();
   await advanceTimersAndPromises();
@@ -448,7 +448,7 @@ it('MarkAndPrint end-to-end flow', async () => {
 
   // Configure with Election Manager card
   card.insertCard(electionManagerCard, electionDefinition.electionData);
-  await authenticateAdminCard();
+  await enterPin();
   userEvent.click(
     screen.getByRole('button', { name: 'Load Election Definition' })
   );
@@ -458,7 +458,7 @@ it('MarkAndPrint end-to-end flow', async () => {
 
   // Unconfigure with System Administrator card
   card.insertCard(makeSystemAdministratorCard());
-  await authenticateAdminCard();
+  await enterPin();
   userEvent.click(screen.getByRole('button', { name: 'Unconfigure Machine' }));
   const modal = await screen.findByRole('alertdialog');
   userEvent.click(
@@ -476,6 +476,6 @@ it('MarkAndPrint end-to-end flow', async () => {
   // Verify that machine was unconfigured
   screen.getByText('VxMark is Not Configured');
   card.insertCard(electionManagerCard, electionDefinition.electionData);
-  await authenticateAdminCard();
+  await enterPin();
   screen.getByText('Election Definition is not loaded.');
 });

--- a/frontends/bmd/src/app_end_to_end.test.tsx
+++ b/frontends/bmd/src/app_end_to_end.test.tsx
@@ -94,7 +94,7 @@ it('MarkAndPrint end-to-end flow', async () => {
   await advanceTimersAndPromises();
 
   // Default Unconfigured
-  screen.getByText('Device Not Configured');
+  screen.getByText('VxMark is Not Configured');
 
   // ---------------
 
@@ -104,12 +104,12 @@ it('MarkAndPrint end-to-end flow', async () => {
   fireEvent.click(screen.getByText('Load Election Definition'));
 
   await advanceTimersAndPromises();
-  screen.getByText('Election definition is loaded.');
+  screen.getByText('Election Definition is loaded.');
 
   // Remove card and expect not configured because precinct not selected
   card.removeCard();
   await advanceTimersAndPromises();
-  screen.getByText('Device Not Configured');
+  screen.getByText('VxMark is Not Configured');
 
   // Basic auth logging check
   expect(logger.log).toHaveBeenCalledWith(
@@ -428,14 +428,14 @@ it('MarkAndPrint end-to-end flow', async () => {
   // Unconfigure with Election Manager Card
   card.insertCard(electionManagerCard, electionDefinition.electionData);
   await authenticateAdminCard();
-  screen.getByText('Election definition is loaded.');
+  screen.getByText('Election Definition is loaded.');
   fireEvent.click(screen.getByText('Unconfigure Machine'));
   await advanceTimersAndPromises();
 
   // Default Unconfigured
   card.removeCard();
   await advanceTimersAndPromises();
-  screen.getByText('Device Not Configured');
+  screen.getByText('VxMark is Not Configured');
 
   // Insert System Administrator card works when unconfigured
   card.insertCard(makeSystemAdministratorCard());
@@ -452,7 +452,7 @@ it('MarkAndPrint end-to-end flow', async () => {
   userEvent.click(
     screen.getByRole('button', { name: 'Load Election Definition' })
   );
-  await screen.findByText('Election definition is loaded.');
+  await screen.findByText('Election Definition is loaded.');
   card.removeCard();
   await advanceTimersAndPromises();
 
@@ -474,8 +474,8 @@ it('MarkAndPrint end-to-end flow', async () => {
   await advanceTimersAndPromises();
 
   // Verify that machine was unconfigured
-  screen.getByText('Device Not Configured');
+  screen.getByText('VxMark is Not Configured');
   card.insertCard(electionManagerCard, electionDefinition.electionData);
   await authenticateAdminCard();
-  screen.getByText('Election definition is not loaded.');
+  screen.getByText('Election Definition is not loaded.');
 });

--- a/frontends/bmd/src/app_mark_only.test.tsx
+++ b/frontends/bmd/src/app_mark_only.test.tsx
@@ -23,7 +23,7 @@ import {
   voterContests,
 } from '../test/helpers/election';
 import { fakeMachineConfigProvider } from '../test/helpers/fake_machine_config';
-import { authenticateAdminCard } from '../test/test_utils';
+import { enterPin } from '../test/test_utils';
 
 jest.setTimeout(10_000);
 
@@ -64,7 +64,7 @@ it('MarkOnly flow', async () => {
 
   // Configure election with Election Manager Card
   card.insertCard(electionManagerCard, electionDefinition.electionData);
-  await authenticateAdminCard();
+  await enterPin();
   fireEvent.click(screen.getByText('Load Election Definition'));
 
   await advanceTimersAndPromises();
@@ -79,7 +79,7 @@ it('MarkOnly flow', async () => {
 
   // Configure election with Election Manager Card
   card.insertCard(electionManagerCard, electionDefinition.electionData);
-  await authenticateAdminCard();
+  await enterPin();
   screen.getByLabelText('Precinct');
 
   // select precinct
@@ -212,7 +212,7 @@ it('MarkOnly flow', async () => {
 
   // Unconfigure with Election Manager Card
   card.insertCard(electionManagerCard, electionDefinition.electionData);
-  await authenticateAdminCard();
+  await enterPin();
   screen.getByText('Election Definition is loaded.');
   fireEvent.click(screen.getByText('Unconfigure Machine'));
   await advanceTimersAndPromises();

--- a/frontends/bmd/src/app_mark_only.test.tsx
+++ b/frontends/bmd/src/app_mark_only.test.tsx
@@ -58,7 +58,7 @@ it('MarkOnly flow', async () => {
   await advanceTimersAndPromises();
 
   // Default Unconfigured
-  screen.getByText('Device Not Configured');
+  screen.getByText('VxMark is Not Configured');
 
   // ---------------
 
@@ -68,12 +68,12 @@ it('MarkOnly flow', async () => {
   fireEvent.click(screen.getByText('Load Election Definition'));
 
   await advanceTimersAndPromises();
-  screen.getByText('Election definition is loaded.');
+  screen.getByText('Election Definition is loaded.');
 
   // Remove card and expect not configured because precinct not selected
   card.removeCard();
   await advanceTimersAndPromises();
-  screen.getByText('Device Not Configured');
+  screen.getByText('VxMark is Not Configured');
 
   // ---------------
 
@@ -213,12 +213,12 @@ it('MarkOnly flow', async () => {
   // Unconfigure with Election Manager Card
   card.insertCard(electionManagerCard, electionDefinition.electionData);
   await authenticateAdminCard();
-  screen.getByText('Election definition is loaded.');
+  screen.getByText('Election Definition is loaded.');
   fireEvent.click(screen.getByText('Unconfigure Machine'));
   await advanceTimersAndPromises();
 
   // Default Unconfigured
   card.removeCard();
   await advanceTimersAndPromises();
-  screen.getByText('Device Not Configured');
+  screen.getByText('VxMark is Not Configured');
 });

--- a/frontends/bmd/src/app_print_only.test.tsx
+++ b/frontends/bmd/src/app_print_only.test.tsx
@@ -68,7 +68,7 @@ test('PrintOnly flow', async () => {
   await advanceTimersAndPromises();
 
   // Default Unconfigured
-  screen.getByText('Device Not Configured');
+  screen.getByText('VxMark is Not Configured');
 
   // ---------------
 
@@ -78,12 +78,12 @@ test('PrintOnly flow', async () => {
   fireEvent.click(screen.getByText('Load Election Definition'));
 
   await advanceTimersAndPromises();
-  screen.getByText('Election definition is loaded.');
+  screen.getByText('Election Definition is loaded.');
 
   // Remove card
   card.removeCard();
   await advanceTimersAndPromises();
-  screen.getByText('Device Not Configured');
+  screen.getByText('VxMark is Not Configured');
 
   // ---------------
 
@@ -373,14 +373,14 @@ test('PrintOnly flow', async () => {
   // Unconfigure with Election Manager Card
   card.insertCard(electionManagerCard, electionData);
   await authenticateAdminCard();
-  screen.getByText('Election definition is loaded.');
+  screen.getByText('Election Definition is loaded.');
   fireEvent.click(screen.getByText('Unconfigure Machine'));
   await advanceTimersAndPromises();
 
   // Default Unconfigured
   card.removeCard();
   await advanceTimersAndPromises();
-  screen.getByText('Device Not Configured');
+  screen.getByText('VxMark is Not Configured');
 });
 
 test('PrintOnly retains app mode when unconfigured', async () => {
@@ -412,7 +412,7 @@ test('PrintOnly retains app mode when unconfigured', async () => {
     fireEvent.click(screen.getByText('Load Election Definition'));
 
     await advanceTimersAndPromises();
-    screen.getByText('Election definition is loaded.');
+    screen.getByText('Election Definition is loaded.');
 
     // Select precinct
     screen.getByText('State of Hamilton');
@@ -448,20 +448,20 @@ test('PrintOnly retains app mode when unconfigured', async () => {
     // Unconfigure with Election Manager Card
     card.insertCard(electionManagerCard, electionData);
     await authenticateAdminCard();
-    screen.getByText('Election definition is loaded.');
+    screen.getByText('Election Definition is loaded.');
     fireEvent.click(screen.getByText('Unconfigure Machine'));
     await advanceTimersAndPromises();
 
     // Default Unconfigured
     card.removeCard();
     await advanceTimersAndPromises();
-    screen.getByText('Device Not Configured');
+    screen.getByText('VxMark is Not Configured');
   }
 
   // ---------------
 
   // Default Unconfigured
-  screen.getByText('Device Not Configured');
+  screen.getByText('VxMark is Not Configured');
 
   // Do the initial configuration & open polls.
   await configure();
@@ -508,7 +508,7 @@ test('PrintOnly prompts to change to live mode on election day', async () => {
   await advanceTimersAndPromises();
 
   // Default Unconfigured
-  screen.getByText('Device Not Configured');
+  screen.getByText('VxMark is Not Configured');
 
   // ---------------
 
@@ -518,7 +518,7 @@ test('PrintOnly prompts to change to live mode on election day', async () => {
   fireEvent.click(screen.getByText('Load Election Definition'));
 
   await advanceTimersAndPromises();
-  screen.getByText('Election definition is loaded.');
+  screen.getByText('Election Definition is loaded.');
   screen.getByLabelText('Precinct');
 
   // Select precinct

--- a/frontends/bmd/src/app_print_only.test.tsx
+++ b/frontends/bmd/src/app_print_only.test.tsx
@@ -32,7 +32,7 @@ import * as GLOBALS from './config/globals';
 import { fakePrinter } from '../test/helpers/fake_printer';
 import { fakeMachineConfigProvider } from '../test/helpers/fake_machine_config';
 import { PrintOnly } from './config/types';
-import { authenticateAdminCard } from '../test/test_utils';
+import { enterPin } from '../test/test_utils';
 
 beforeEach(() => {
   window.location.href = '/';
@@ -74,7 +74,7 @@ test('PrintOnly flow', async () => {
 
   // Configure with Election Manager Card
   card.insertCard(electionManagerCard, electionData);
-  await authenticateAdminCard();
+  await enterPin();
   fireEvent.click(screen.getByText('Load Election Definition'));
 
   await advanceTimersAndPromises();
@@ -89,7 +89,7 @@ test('PrintOnly flow', async () => {
 
   // Configure election with Election Manager Card
   card.insertCard(electionManagerCard, electionData);
-  await authenticateAdminCard();
+  await enterPin();
   screen.getByLabelText('Precinct');
 
   // Select precinct
@@ -132,7 +132,7 @@ test('PrintOnly flow', async () => {
 
   // Set to Live Mode
   card.insertCard(electionManagerCard, electionData);
-  await authenticateAdminCard();
+  await enterPin();
   expect(window.document.documentElement.style.fontSize).toBe('28px');
   fireEvent.click(screen.getByText('Live Election Mode'));
 
@@ -372,7 +372,7 @@ test('PrintOnly flow', async () => {
 
   // Unconfigure with Election Manager Card
   card.insertCard(electionManagerCard, electionData);
-  await authenticateAdminCard();
+  await enterPin();
   screen.getByText('Election Definition is loaded.');
   fireEvent.click(screen.getByText('Unconfigure Machine'));
   await advanceTimersAndPromises();
@@ -408,7 +408,7 @@ test('PrintOnly retains app mode when unconfigured', async () => {
   async function configure(): Promise<void> {
     // Configure with Election Manager Card
     card.insertCard(electionManagerCard, electionData);
-    await authenticateAdminCard();
+    await enterPin();
     fireEvent.click(screen.getByText('Load Election Definition'));
 
     await advanceTimersAndPromises();
@@ -447,7 +447,7 @@ test('PrintOnly retains app mode when unconfigured', async () => {
   async function unconfigure(): Promise<void> {
     // Unconfigure with Election Manager Card
     card.insertCard(electionManagerCard, electionData);
-    await authenticateAdminCard();
+    await enterPin();
     screen.getByText('Election Definition is loaded.');
     fireEvent.click(screen.getByText('Unconfigure Machine'));
     await advanceTimersAndPromises();
@@ -514,7 +514,7 @@ test('PrintOnly prompts to change to live mode on election day', async () => {
 
   // Configure with Election Manager Card
   card.insertCard(electionManagerCard, electionDefinition.electionData);
-  await authenticateAdminCard();
+  await enterPin();
   fireEvent.click(screen.getByText('Load Election Definition'));
 
   await advanceTimersAndPromises();

--- a/frontends/bmd/src/app_replace_election.test.tsx
+++ b/frontends/bmd/src/app_replace_election.test.tsx
@@ -45,7 +45,9 @@ test('replacing a loaded election with one from a card', async () => {
     electionSample2Definition.electionData
   );
   await authenticateAdminCard();
-  await screen.findByText('Admin Card is not configured for this election');
+  await screen.findByText(
+    'Election Manager card is not configured for this election'
+  );
 
   // unconfigure
   fireEvent.click(screen.getByText('Remove Current Election and All Data'));
@@ -61,7 +63,7 @@ test('replacing a loaded election with one from a card', async () => {
   await authenticateAdminCard();
 
   // load new election
-  await screen.findByText('Election Admin Actions');
+  await screen.findByText('Election Manager Actions');
   fireEvent.click(screen.getByText('Load Election Definition'));
   await advanceTimersAndPromises();
   screen.getByText(electionSample2Definition.election.title);

--- a/frontends/bmd/src/app_replace_election.test.tsx
+++ b/frontends/bmd/src/app_replace_election.test.tsx
@@ -8,7 +8,7 @@ import {
   setStateInStorage,
 } from '../test/helpers/election';
 import { fakeMachineConfigProvider } from '../test/helpers/fake_machine_config';
-import { authenticateAdminCard, render } from '../test/test_utils';
+import { enterPin, render } from '../test/test_utils';
 import { App } from './app';
 import { advanceTimersAndPromises } from '../test/helpers/smartcards';
 
@@ -44,7 +44,7 @@ test('replacing a loaded election with one from a card', async () => {
     makeElectionManagerCard(electionSample2Definition.electionHash),
     electionSample2Definition.electionData
   );
-  await authenticateAdminCard();
+  await enterPin();
   await screen.findByText(
     'Election Manager card is not configured for this election'
   );
@@ -60,7 +60,7 @@ test('replacing a loaded election with one from a card', async () => {
     makeElectionManagerCard(electionSample2Definition.electionHash),
     electionSample2Definition.electionData
   );
-  await authenticateAdminCard();
+  await enterPin();
 
   // load new election
   await screen.findByText('Election Manager Actions');

--- a/frontends/bmd/src/app_setup_errors.test.tsx
+++ b/frontends/bmd/src/app_setup_errors.test.tsx
@@ -241,7 +241,7 @@ describe('Displays setup warning messages and errors screens', () => {
     await authenticateAdminCard();
 
     // expect to see election manager screen
-    screen.getByText('Election Admin Actions');
+    screen.getByText('Election Manager Actions');
   });
 
   it('Displays "discharging battery" warning message and "discharging battery + low battery" error screen', async () => {

--- a/frontends/bmd/src/app_setup_errors.test.tsx
+++ b/frontends/bmd/src/app_setup_errors.test.tsx
@@ -21,7 +21,7 @@ import {
 import { withMarkup } from '../test/helpers/with_markup';
 import { fakeMachineConfigProvider } from '../test/helpers/fake_machine_config';
 import { PrintOnly } from './config/types';
-import { authenticateAdminCard } from '../test/test_utils';
+import { enterPin } from '../test/test_utils';
 
 beforeEach(() => {
   jest.useFakeTimers();
@@ -238,7 +238,7 @@ describe('Displays setup warning messages and errors screens', () => {
 
     // Insert election manager card
     card.insertCard(electionManagerCard, electionSampleDefinition.electionData);
-    await authenticateAdminCard();
+    await enterPin();
 
     // expect to see election manager screen
     screen.getByText('Election Manager Actions');

--- a/frontends/bmd/src/pages/admin_screen.test.tsx
+++ b/frontends/bmd/src/pages/admin_screen.test.tsx
@@ -53,7 +53,7 @@ test('renders AdminScreen for PrintOnly', () => {
     />
   );
 
-  // Configure with Admin Card
+  // Configure with Election Manager Card
   advanceTimers();
 
   // View Test Ballot Decks
@@ -98,7 +98,7 @@ test('renders date and time settings modal', async () => {
     />
   );
 
-  // Configure with Admin Card
+  // Configure with Election Manager Card
   advanceTimers();
 
   // We just do a simple happy path test here, since the libs/ui/set_clock unit

--- a/frontends/bmd/src/pages/admin_screen.tsx
+++ b/frontends/bmd/src/pages/admin_screen.tsx
@@ -198,17 +198,17 @@ export function AdminScreen({
           {election ? (
             <p>
               <Text as="span" voteIcon>
-                Election definition is loaded.
+                Election Definition is loaded.
               </Text>{' '}
               <Button danger small onPress={unconfigure}>
                 Unconfigure Machine
               </Button>
             </p>
           ) : isFetchingElection ? (
-            <p>Loading Election Definition from Admin Card…</p>
+            <p>Loading Election Definition from Election Manager card…</p>
           ) : (
             <React.Fragment>
-              <Text warningIcon>Election definition is not loaded.</Text>
+              <Text warningIcon>Election Definition is not loaded.</Text>
               <p>
                 <Button onPress={loadElection}>Load Election Definition</Button>
               </p>
@@ -219,7 +219,7 @@ export function AdminScreen({
       <Sidebar
         appName={election ? machineConfig.appMode.productName : ''}
         centerContent
-        title="Election Admin Actions"
+        title="Election Manager Actions"
         footer={
           <React.Fragment>
             {electionDefinition && (

--- a/frontends/bmd/src/pages/replace_election_screen.tsx
+++ b/frontends/bmd/src/pages/replace_election_screen.tsx
@@ -86,21 +86,21 @@ export function ReplaceElectionScreen({
     <Screen navLeft>
       <Main padded>
         <Prose id="audiofocus">
-          <h1>Admin Card is not configured for this election</h1>
+          <h1>Election Manager card is not configured for this election</h1>
           {!cardElectionDefinition ? (
-            <p>Reading Election Definition from Admin Card…</p>
+            <p>Reading Election Definition from Election Manager card…</p>
           ) : (
             <React.Fragment>
               <p>
                 You may replace the Election Definition on this machine with the
-                one from the Admin Card. Doing so will replace all data on this
-                machine.
+                one from the Election Manager card. Doing so will replace all
+                data on this machine.
               </p>
               <h3>Current Election Definition:</h3>
               <BriefElectionDefinitionInfo
                 electionDefinition={electionDefinition}
               />
-              <h3> Card Election Definition: </h3>
+              <h3>Card Election Definition:</h3>
               <BriefElectionDefinitionInfo
                 electionDefinition={cardElectionDefinition}
               />
@@ -142,10 +142,10 @@ export function ReplaceElectionScreen({
         <Prose>
           <h2>Instructions</h2>
           <p>
-            Loading an election definition from the Admin Card will reset all
-            data on this device.
+            Loading an Election Definition from the Election Manager card will
+            reset all data on this device.
           </p>
-          <p>Remove Admin Card to cancel.</p>
+          <p>Remove Election Manager card to cancel.</p>
         </Prose>
       </Sidebar>
     </Screen>

--- a/frontends/bmd/src/pages/test_ballot_deck_screen.tsx
+++ b/frontends/bmd/src/pages/test_ballot_deck_screen.tsx
@@ -231,7 +231,7 @@ export function TestBallotDeckScreen({
         <Sidebar
           appName={machineConfig.appMode.productName}
           centerContent
-          title="Election Admin Actions"
+          title="Election Manager Actions"
           footer={
             election && (
               <ElectionInfo

--- a/frontends/bmd/src/pages/unconfigured_screen.tsx
+++ b/frontends/bmd/src/pages/unconfigured_screen.tsx
@@ -7,8 +7,8 @@ export function UnconfiguredScreen(): JSX.Element {
     <Screen>
       <Main centerChild>
         <Prose textCenter>
-          <h1>Device Not Configured</h1>
-          <p>Insert Election Admin card.</p>
+          <h1>VxMark is Not Configured</h1>
+          <p>Insert Election Manager card to configure.</p>
         </Prose>
       </Main>
     </Screen>

--- a/frontends/bmd/test/test_utils.tsx
+++ b/frontends/bmd/test/test_utils.tsx
@@ -100,7 +100,7 @@ export function render(
   };
 }
 
-export async function authenticateAdminCard(): Promise<void> {
+export async function enterPin(): Promise<void> {
   jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
   await screen.findByText('Enter the card security code to unlock.');
   userEvent.click(screen.getByText('1'));

--- a/frontends/bsd/src/app.test.tsx
+++ b/frontends/bsd/src/app.test.tsx
@@ -104,8 +104,22 @@ async function authenticateWithSystemAdministratorCard(card: MemoryCard) {
   await screen.findByText('Lock Machine');
 }
 
-async function authenticateWithElectionManagerCard(card: MemoryCard) {
-  await screen.findByText('VxCentralScan is Locked');
+async function authenticateWithElectionManagerCard(
+  card: MemoryCard,
+  options: { isMachineConfigured?: boolean } = {}
+) {
+  const isMachineConfigured = options.isMachineConfigured ?? true;
+
+  await screen.findByText(
+    isMachineConfigured
+      ? 'VxCentralScan is Locked'
+      : 'VxCentralScan is Not Configured'
+  );
+  await screen.findByText(
+    isMachineConfigured
+      ? 'Insert Election Manager card to unlock.'
+      : 'Insert Election Manager card to configure.'
+  );
   card.insertCard(
     makeElectionManagerCard(electionSampleDefinition.electionHash)
   );
@@ -350,7 +364,9 @@ test('configuring election from usb ballot package works end to end', async () =
   const { getByText, getByTestId } = render(
     <App card={card} hardware={hardware} />
   );
-  await authenticateWithElectionManagerCard(card);
+  await authenticateWithElectionManagerCard(card, {
+    isMachineConfigured: false,
+  });
 
   const mockKiosk = fakeKiosk();
   window.kiosk = mockKiosk;

--- a/frontends/bsd/src/screens/machine_locked_screen.tsx
+++ b/frontends/bsd/src/screens/machine_locked_screen.tsx
@@ -12,7 +12,7 @@ import { AppContext } from '../contexts/app_context';
 
 const LockedImage = styled.img`
   margin-right: auto;
-  margin-bottom: 5px;
+  margin-bottom: 1.25em;
   margin-left: auto;
   height: 20vw;
 `;
@@ -25,8 +25,17 @@ export function MachineLockedScreen(): JSX.Element {
         <div>
           <LockedImage src="/locked.svg" alt="Locked Icon" />
           <Prose textCenter theme={fontSizeTheme.medium} maxWidth={false}>
-            <h1>VxCentralScan is Locked</h1>
-            <p>Insert an admin card to unlock.</p>
+            {electionDefinition ? (
+              <React.Fragment>
+                <h1>VxCentralScan is Locked</h1>
+                <p>Insert Election Manager card to unlock.</p>
+              </React.Fragment>
+            ) : (
+              <React.Fragment>
+                <h1>VxCentralScan is Not Configured</h1>
+                <p>Insert Election Manager card to configure.</p>
+              </React.Fragment>
+            )}
           </Prose>
         </div>
       </Main>

--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -1231,6 +1231,7 @@ test('election manager cannot auth onto unconfigured machine when VVSG2 auth flo
   render(<App card={card} hardware={hardware} storage={storage} />);
 
   await screen.findByText('VxAdmin is Locked');
+  screen.getByText('Insert System Administrator card to unlock.');
   card.insertCard(
     makeElectionManagerCard(eitherNeitherElectionDefinition.electionHash)
   );
@@ -1252,6 +1253,9 @@ test('election manager cannot auth onto machine with different election hash whe
   render(<App card={card} hardware={hardware} storage={storage} />);
 
   await screen.findByText('VxAdmin is Locked');
+  screen.getByText(
+    'Insert System Administrator or Election Manager card to unlock.'
+  );
   card.insertCard(
     makeElectionManagerCard(electionSampleDefinition.electionHash)
   );

--- a/frontends/election-manager/src/components/smartcard_modal/program_system_administrator_card_view.tsx
+++ b/frontends/election-manager/src/components/smartcard_modal/program_system_administrator_card_view.tsx
@@ -54,7 +54,7 @@ export function ProgramSystemAdministratorCardView({
         <h1>Create New System Administrator Card</h1>
         <p>
           This card performs all system actions. Strictly limit the number
-          created and keep all System Administrator Cards secure.
+          created and keep all System Administrator cards secure.
         </p>
 
         <HorizontalRule />

--- a/frontends/election-manager/src/components/smartcard_modal/smartcard_modal.test.tsx
+++ b/frontends/election-manager/src/components/smartcard_modal/smartcard_modal.test.tsx
@@ -289,21 +289,18 @@ test('Programming election manager and poll worker smartcards', async () => {
 
   const testCases: Array<{
     role: ElectionManagerUser['role'] | PollWorkerUser['role'];
-    expectedProgressText: string;
     expectedHeadingAfterProgramming: string;
     expectedSuccessText: Array<string | RegExp>;
     expectedCardLongString?: string;
   }> = [
     {
       role: 'election_manager',
-      expectedProgressText: 'Creating Election Manager Card',
       expectedHeadingAfterProgramming: 'Election Manager Card',
       expectedSuccessText: [/New card PIN is /, '123-456'],
       expectedCardLongString: electionData,
     },
     {
       role: 'poll_worker',
-      expectedProgressText: 'Creating Poll Worker Card',
       expectedHeadingAfterProgramming: 'Poll Worker Card',
       expectedSuccessText: ['New card created.'],
       expectedCardLongString: undefined,
@@ -316,7 +313,6 @@ test('Programming election manager and poll worker smartcards', async () => {
   for (const testCase of testCases) {
     const {
       role,
-      expectedProgressText,
       expectedHeadingAfterProgramming,
       expectedSuccessText,
       expectedCardLongString,
@@ -347,7 +343,7 @@ test('Programming election manager and poll worker smartcards', async () => {
         throwIllegalValue(role);
       }
     }
-    await screen.findByText(new RegExp(expectedProgressText));
+    await screen.findByText(/Programming card/);
     await within(modal).findByRole('heading', {
       name: expectedHeadingAfterProgramming,
     });
@@ -387,14 +383,14 @@ test('Programming system administrator smartcards', async () => {
   });
   within(modal).getByText(
     'This card performs all system actions. ' +
-      'Strictly limit the number created and keep all System Administrator Cards secure.'
+      'Strictly limit the number created and keep all System Administrator cards secure.'
   );
   const systemAdministratorCardButton = within(modal).getByRole('button', {
     name: 'Create System Administrator Card',
   });
   within(modal).getByText('Remove card to cancel.');
   userEvent.click(systemAdministratorCardButton);
-  await screen.findByText(/Creating System Administrator Card/);
+  await screen.findByText(/Programming card/);
   await within(modal).findByRole('heading', {
     name: 'System Administrator Card',
   });
@@ -456,19 +452,16 @@ test('Resetting smartcard PINs', async () => {
     cardData: AnyCardData;
     cardLongValue?: string;
     expectedHeading: string;
-    expectedProgressText: string;
   }> = [
     {
       cardData: makeSystemAdministratorCard(oldPin),
       cardLongValue: undefined,
       expectedHeading: 'System Administrator Card',
-      expectedProgressText: 'Resetting System Administrator Card PIN',
     },
     {
       cardData: makeElectionManagerCard(electionHash, oldPin),
       cardLongValue: electionData,
       expectedHeading: 'Election Manager Card',
-      expectedProgressText: 'Resetting Election Manager Card PIN',
     },
   ];
 
@@ -476,8 +469,7 @@ test('Resetting smartcard PINs', async () => {
   await screen.findByRole('heading', { name: 'Election Definition' });
 
   for (const testCase of testCases) {
-    const { cardData, cardLongValue, expectedHeading, expectedProgressText } =
-      testCase;
+    const { cardData, cardLongValue, expectedHeading } = testCase;
 
     card.insertCard(cardData);
     if (cardLongValue) {
@@ -496,7 +488,7 @@ test('Resetting smartcard PINs', async () => {
     userEvent.click(
       within(modal).getByRole('button', { name: 'Reset Card PIN' })
     );
-    await screen.findByText(new RegExp(expectedProgressText));
+    await screen.findByText(/Resetting card PIN/);
     await within(modal).findByText(/New card PIN is /);
     await within(modal).findByText('123-456');
     within(modal).getByText('Remove card to continue.');
@@ -532,20 +524,17 @@ test('Unprogramming smartcards', async () => {
   const testCases: Array<{
     cardData: AnyCardData;
     expectedHeadingBeforeUnprogramming: string;
-    expectedProgressText: string;
     expectedSuccessText: string;
   }> = [
     {
       cardData: makeElectionManagerCard(electionHash),
       expectedHeadingBeforeUnprogramming: 'Election Manager Card',
-      expectedProgressText: 'Unprogramming Election Manager Card',
-      expectedSuccessText: 'Election Manager Card has been unprogrammed.',
+      expectedSuccessText: 'Election Manager card has been unprogrammed.',
     },
     {
       cardData: makePollWorkerCard(electionHash),
       expectedHeadingBeforeUnprogramming: 'Poll Worker Card',
-      expectedProgressText: 'Unprogramming Poll Worker Card',
-      expectedSuccessText: 'Poll Worker Card has been unprogrammed.',
+      expectedSuccessText: 'Poll Worker card has been unprogrammed.',
     },
   ];
 
@@ -553,7 +542,6 @@ test('Unprogramming smartcards', async () => {
     const {
       cardData,
       expectedHeadingBeforeUnprogramming,
-      expectedProgressText,
       expectedSuccessText,
     } = testCase;
 
@@ -566,7 +554,7 @@ test('Unprogramming smartcards', async () => {
     userEvent.click(
       within(modal).getByRole('button', { name: 'Unprogram Card' })
     );
-    await screen.findByText(new RegExp(expectedProgressText));
+    await screen.findByText(/Unprogramming card/);
     await within(modal).findByRole('heading', {
       name: 'Create New Election Card',
     });
@@ -604,44 +592,44 @@ test('Error handling', async () => {
     {
       cardData: undefined,
       buttonToPress: 'Election Manager Card',
-      expectedProgressText: 'Creating Election Manager Card',
+      expectedProgressText: 'Programming card',
       expectedErrorText:
-        'Error creating Election Manager Card. Please try again.',
+        'Error creating Election Manager card. Please try again.',
     },
     {
       cardData: undefined,
       buttonToPress: 'Poll Worker Card',
-      expectedProgressText: 'Creating Poll Worker Card',
-      expectedErrorText: 'Error creating Poll Worker Card. Please try again.',
+      expectedProgressText: 'Programming card',
+      expectedErrorText: 'Error creating Poll Worker card. Please try again.',
     },
     {
       beginFromSuperAdminCardsScreen: true,
       cardData: undefined,
       buttonToPress: 'Create System Administrator Card',
-      expectedProgressText: 'Creating System Administrator Card',
+      expectedProgressText: 'Programming card',
       expectedErrorText:
-        'Error creating System Administrator Card. Please try again.',
+        'Error creating System Administrator card. Please try again.',
     },
     {
       cardData: makeElectionManagerCard(electionHash),
       buttonToPress: 'Reset Card PIN',
-      expectedProgressText: 'Resetting Election Manager Card PIN',
+      expectedProgressText: 'Resetting card PIN',
       expectedErrorText:
-        'Error resetting Election Manager Card PIN. Please try again.',
+        'Error resetting Election Manager card PIN. Please try again.',
     },
     {
       cardData: makeElectionManagerCard(electionHash),
       buttonToPress: 'Unprogram Card',
-      expectedProgressText: 'Unprogramming Election Manager Card',
+      expectedProgressText: 'Unprogramming card',
       expectedErrorText:
-        'Error unprogramming Election Manager Card. Please try again.',
+        'Error unprogramming Election Manager card. Please try again.',
     },
     {
       cardData: makePollWorkerCard(electionHash),
       buttonToPress: 'Unprogram Card',
-      expectedProgressText: 'Unprogramming Poll Worker Card',
+      expectedProgressText: 'Unprogramming card',
       expectedErrorText:
-        'Error unprogramming Poll Worker Card. Please try again.',
+        'Error unprogramming Poll Worker card. Please try again.',
     },
   ];
 

--- a/frontends/election-manager/src/components/smartcard_modal/status_message.tsx
+++ b/frontends/election-manager/src/components/smartcard_modal/status_message.tsx
@@ -61,15 +61,15 @@ export function SuccessOrErrorStatusMessage({
     let text: string;
     switch (action) {
       case 'Program': {
-        text = `Error creating ${actionRoleReadableString} Card.`;
+        text = `Error creating ${actionRoleReadableString} card.`;
         break;
       }
       case 'PinReset': {
-        text = `Error resetting ${actionRoleReadableString} Card PIN.`;
+        text = `Error resetting ${actionRoleReadableString} card PIN.`;
         break;
       }
       case 'Unprogram': {
-        text = `Error unprogramming ${actionRoleReadableString} Card.`;
+        text = `Error unprogramming ${actionRoleReadableString} card.`;
         break;
       }
       /* istanbul ignore next: Compile-time check for completeness */
@@ -107,7 +107,7 @@ export function SuccessOrErrorStatusMessage({
   if (action === 'Unprogram') {
     return (
       <Text success>
-        {actionRoleReadableString} Card has been unprogrammed.
+        {actionRoleReadableString} card has been unprogrammed.
       </Text>
     );
   }
@@ -126,20 +126,19 @@ export function InProgressStatusMessage({
   actionStatus,
 }: InProgressStatusMessageProps): JSX.Element | null {
   const { action } = actionStatus;
-  const actionRoleReadableString = userRoleToReadableString(actionStatus.role);
 
   let text: string;
   switch (action) {
     case 'Program': {
-      text = `Creating ${actionRoleReadableString} Card`;
+      text = 'Programming card';
       break;
     }
     case 'PinReset': {
-      text = `Resetting ${actionRoleReadableString} Card PIN`;
+      text = 'Resetting card PIN';
       break;
     }
     case 'Unprogram': {
-      text = `Unprogramming ${actionRoleReadableString} Card`;
+      text = 'Unprogramming card';
       break;
     }
     /* istanbul ignore next: Compile-time check for completeness */
@@ -147,7 +146,5 @@ export function InProgressStatusMessage({
       throwIllegalValue(action);
     }
   }
-  return (
-    <Modal centerContent content={<Loading as="strong">{text}</Loading>} />
-  );
+  return <Modal centerContent content={<Loading>{text}</Loading>} />;
 }

--- a/frontends/election-manager/src/screens/machine_locked_screen.tsx
+++ b/frontends/election-manager/src/screens/machine_locked_screen.tsx
@@ -11,7 +11,7 @@ import { AppContext } from '../contexts/app_context';
 
 const LockedImage = styled.img`
   margin-right: auto;
-  margin-bottom: 5px;
+  margin-bottom: 1.25em;
   margin-left: auto;
   height: 20vw;
 `;
@@ -25,7 +25,11 @@ export function MachineLockedScreen(): JSX.Element {
           <LockedImage src="/locked.svg" alt="Locked Icon" />
           <Prose textCenter theme={fontSizeTheme.medium} maxWidth={false}>
             <h1>VxAdmin is Locked</h1>
-            <p>Insert an admin card to unlock.</p>
+            <p>
+              {electionDefinition
+                ? 'Insert System Administrator or Election Manager card to unlock.'
+                : 'Insert System Administrator card to unlock.'}
+            </p>
           </Prose>
         </div>
       </Main>

--- a/frontends/precinct-scanner/src/app.test.tsx
+++ b/frontends/precinct-scanner/src/app.test.tsx
@@ -602,7 +602,7 @@ test('voter can cast a ballot that scans successfully ', async () => {
   );
   card.insertCard(electionManagerCard, electionSampleDefinition.electionData);
   await authenticateAdminCard();
-  await screen.findByText('Administrator Settings');
+  await screen.findByText('Election Manager Settings');
   fireEvent.click(await screen.findByText('Export Results to USB Drive'));
   await screen.findByText('No USB Drive Detected');
   fireEvent.click(await screen.findByText('Cancel'));

--- a/frontends/precinct-scanner/src/app.test.tsx
+++ b/frontends/precinct-scanner/src/app.test.tsx
@@ -45,7 +45,10 @@ import { App } from './app';
 import { stateStorageKey } from './app_root';
 import { POLLING_INTERVAL_FOR_SCANNER_STATUS_MS } from './config/globals';
 import { MachineConfigResponse } from './config/types';
-import { authenticateAdminCard, scannerStatus } from '../test/helpers/helpers';
+import {
+  authenticateElectionManagerCard,
+  scannerStatus,
+} from '../test/helpers/helpers';
 
 jest.setTimeout(20000);
 
@@ -366,7 +369,7 @@ test('election manager and poll worker configuration', async () => {
     '123456'
   );
   card.insertCard(electionManagerCard, electionSampleDefinition.electionData);
-  await authenticateAdminCard();
+  await authenticateElectionManagerCard();
   fireEvent.click(await screen.findByText('Live Election Mode'));
   await screen.findByText('Loading');
   await advanceTimersAndPromises(1);
@@ -392,7 +395,7 @@ test('election manager and poll worker configuration', async () => {
   card.removeCard();
   await advanceTimersAndPromises(1);
   card.insertCard(electionManagerCard, electionSampleDefinition.electionData);
-  await authenticateAdminCard();
+  await authenticateElectionManagerCard();
   // Change precinct
   fireEvent.change(await screen.findByTestId('selectPrecinct'), {
     target: { value: '23' },
@@ -418,7 +421,7 @@ test('election manager and poll worker configuration', async () => {
   card.removeCard();
   await advanceTimersAndPromises(1);
   card.insertCard(electionManagerCard, electionSampleDefinition.electionData);
-  await authenticateAdminCard();
+  await authenticateElectionManagerCard();
 
   // Calibrate scanner
   fetchMock.post('/scanner/calibrate', { body: { status: 'ok' } });
@@ -453,7 +456,7 @@ test('election manager and poll worker configuration', async () => {
   card.removeCard();
   await advanceTimersAndPromises(1);
   card.insertCard(electionManagerCard, electionSampleDefinition.electionData);
-  await authenticateAdminCard();
+  await authenticateElectionManagerCard();
   fireEvent.click(await screen.findByText('Unconfigure Machine'));
   await screen.findByText(
     'Do you want to remove all election information and data from this machine?'
@@ -601,7 +604,7 @@ test('voter can cast a ballot that scans successfully ', async () => {
     '123456'
   );
   card.insertCard(electionManagerCard, electionSampleDefinition.electionData);
-  await authenticateAdminCard();
+  await authenticateElectionManagerCard();
   await screen.findByText('Election Manager Settings');
   fireEvent.click(await screen.findByText('Export Results to USB Drive'));
   await screen.findByText('No USB Drive Detected');

--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -39,7 +39,7 @@ import * as config from './api/config';
 import * as scanner from './api/scan';
 
 import { usePrecinctScannerStatus } from './hooks/use_precinct_scanner_status';
-import { AdminScreen } from './screens/admin_screen';
+import { ElectionManagerScreen } from './screens/election_manager_screen';
 import { InvalidCardScreen } from './screens/invalid_card_screen';
 import { PollsClosedScreen } from './screens/polls_closed_screen';
 import { PollWorkerScreen } from './screens/poll_worker_screen';
@@ -435,7 +435,7 @@ export function AppRoot({
           auth,
         }}
       >
-        <AdminScreen
+        <ElectionManagerScreen
           updateAppPrecinctId={updatePrecinctId}
           scannerStatus={scannerStatus}
           isTestMode={isTestMode}

--- a/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
+++ b/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
@@ -98,7 +98,7 @@ test('services/scan fails to unconfigure', async () => {
   fireEvent.click(screen.getByText('4'));
   fireEvent.click(screen.getByText('5'));
   fireEvent.click(screen.getByText('6'));
-  await screen.findByText('Administrator Settings');
+  await screen.findByText('Election Manager Settings');
 
   fireEvent.click(await screen.findByText('Unconfigure Machine'));
   fireEvent.click(await screen.findByText('Unconfigure'));

--- a/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
+++ b/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
@@ -31,7 +31,10 @@ import {
 import userEvent from '@testing-library/user-event';
 import { App } from './app';
 import { MachineConfigResponse } from './config/types';
-import { authenticateAdminCard, scannerStatus } from '../test/helpers/helpers';
+import {
+  authenticateElectionManagerCard,
+  scannerStatus,
+} from '../test/helpers/helpers';
 
 const getMachineConfigBody: MachineConfigResponse = {
   machineId: '0002',
@@ -345,7 +348,7 @@ test('removing card during calibration', async () => {
     electionSampleDefinition.electionHash
   );
   card.insertCard(electionManagerCard, electionSampleDefinition.electionData);
-  await authenticateAdminCard();
+  await authenticateElectionManagerCard();
 
   const { promise, resolve } = deferred();
   fetchMock.post('/scanner/calibrate', promise);

--- a/frontends/precinct-scanner/src/preview_app.tsx
+++ b/frontends/precinct-scanner/src/preview_app.tsx
@@ -9,8 +9,8 @@ import {
 } from '@votingworks/fixtures';
 import React from 'react';
 import { PreviewDashboard } from './preview_dashboard';
-import * as AdminScreen from './screens/admin_screen';
 import * as CardErrorScreen from './screens/card_error_screen';
+import * as ElectionManagerScreen from './screens/election_manager_screen';
 import * as InsertBallotScreen from './screens/insert_ballot_screen';
 import * as InvalidCardScreen from './screens/invalid_card_screen';
 import * as LoadingConfigurationScreen from './screens/loading_configuration_screen';
@@ -36,8 +36,8 @@ export function PreviewApp(): JSX.Element {
         electionWithMsEitherNeitherDefinition,
       ]}
       modules={[
-        AdminScreen,
         CardErrorScreen,
+        ElectionManagerScreen,
         InsertBallotScreen,
         InvalidCardScreen,
         LoadingConfigurationScreen,

--- a/frontends/precinct-scanner/src/screens/election_manager_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/election_manager_screen.test.tsx
@@ -13,7 +13,7 @@ import { usbstick } from '@votingworks/utils';
 import MockDate from 'mockdate';
 import React from 'react';
 import { AppContext } from '../contexts/app_context';
-import { AdminScreen } from './admin_screen';
+import { ElectionManagerScreen } from './election_manager_screen';
 
 beforeEach(() => {
   MockDate.set('2020-10-31T00:00:00.000Z');
@@ -43,7 +43,7 @@ test('renders date and time settings modal', async () => {
         auth,
       }}
     >
-      <AdminScreen
+      <ElectionManagerScreen
         scannerStatus={scannerStatus}
         isTestMode={false}
         updateAppPrecinctId={jest.fn()}
@@ -94,7 +94,7 @@ test('setting and un-setting the precinct', async () => {
         auth,
       }}
     >
-      <AdminScreen
+      <ElectionManagerScreen
         scannerStatus={scannerStatus}
         isTestMode={false}
         updateAppPrecinctId={updateAppPrecinctId}
@@ -130,7 +130,7 @@ test('export from admin screen', () => {
         auth,
       }}
     >
-      <AdminScreen
+      <ElectionManagerScreen
         scannerStatus={scannerStatus}
         isTestMode={false}
         updateAppPrecinctId={jest.fn()}
@@ -155,7 +155,7 @@ test('unconfigure ejects a usb drive when it is mounted', () => {
         auth,
       }}
     >
-      <AdminScreen
+      <ElectionManagerScreen
         scannerStatus={{ ...scannerStatus, canUnconfigure: true }}
         isTestMode={false}
         updateAppPrecinctId={jest.fn()}
@@ -183,7 +183,7 @@ test('unconfigure does not eject a usb drive that is not mounted', async () => {
         auth,
       }}
     >
-      <AdminScreen
+      <ElectionManagerScreen
         scannerStatus={{ ...scannerStatus, canUnconfigure: true }}
         isTestMode={false}
         updateAppPrecinctId={jest.fn()}
@@ -211,7 +211,7 @@ test('unconfigure button is disabled when the machine cannot be unconfigured', (
         auth,
       }}
     >
-      <AdminScreen
+      <ElectionManagerScreen
         scannerStatus={scannerStatus}
         isTestMode={false}
         updateAppPrecinctId={jest.fn()}
@@ -237,7 +237,7 @@ test('cannot toggle to testing mode when the machine cannot be unconfigured', ()
         auth,
       }}
     >
-      <AdminScreen
+      <ElectionManagerScreen
         scannerStatus={scannerStatus}
         isTestMode={false}
         updateAppPrecinctId={jest.fn()}

--- a/frontends/precinct-scanner/src/screens/election_manager_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/election_manager_screen.tsx
@@ -35,7 +35,7 @@ interface Props {
   usbDrive: UsbDrive;
 }
 
-export function AdminScreen({
+export function ElectionManagerScreen({
   scannerStatus,
   isTestMode,
   updateAppPrecinctId,
@@ -113,7 +113,7 @@ export function AdminScreen({
   return (
     <ScreenMainCenterChild infoBarMode="admin">
       <Prose textCenter>
-        <h1>Administrator Settings</h1>
+        <h1>Election Manager Settings</h1>
         <p>
           <Select
             id="selectPrecinct"
@@ -302,7 +302,7 @@ export function DefaultPreview(): JSX.Element {
         },
       }}
     >
-      <AdminScreen
+      <ElectionManagerScreen
         scannerStatus={{
           state: 'no_paper',
           ballotsCounted: 1234,

--- a/frontends/precinct-scanner/test/helpers/helpers.ts
+++ b/frontends/precinct-scanner/test/helpers/helpers.ts
@@ -12,7 +12,7 @@ export async function authenticateAdminCard(): Promise<void> {
   userEvent.click(screen.getByText('4'));
   userEvent.click(screen.getByText('5'));
   userEvent.click(screen.getByText('6'));
-  await screen.findByText('Administrator Settings');
+  await screen.findByText('Election Manager Settings');
 }
 
 export function scannerStatus(

--- a/frontends/precinct-scanner/test/helpers/helpers.ts
+++ b/frontends/precinct-scanner/test/helpers/helpers.ts
@@ -3,7 +3,7 @@ import { screen } from '@testing-library/react';
 import { Scan } from '@votingworks/api';
 import { CARD_POLLING_INTERVAL } from '../../src/config/globals';
 
-export async function authenticateAdminCard(): Promise<void> {
+export async function authenticateElectionManagerCard(): Promise<void> {
   jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
   await screen.findByText('Enter the card security code to unlock.');
   userEvent.click(screen.getByText('1'));


### PR DESCRIPTION
_Commit-by-commit reviewing recommended_

## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/2181

This PR tackles a number of small copy updates, documented in greater detail in individual commit messages. These include:

- Using the new user role names in a few places that weren't covered in https://github.com/votingworks/vxsuite/pull/2284, e.g. lock screens
- Accounting for whether machines are configured or not on lock screens
- Removing user role from in-progress messages in the smartcard modal so that font size can be increased
- Lower casing "card" even after capitalized user roles for consistency
- Consistently title casing "Election Definition" on VxMark

## Screenshots

### VxAdmin

_Lock screen when election is not defined_ 

![vxadmin-lock-screen-election-not-defined](https://user-images.githubusercontent.com/12616928/183740757-b4535437-f3c3-4f0a-bd72-d835ba3fe00c.png)

_Lock screen when election is defined_ 

![vxadmin-lock-screen-election-defined](https://user-images.githubusercontent.com/12616928/183740755-ee907f78-1633-4d73-b36c-085421562ec5.png)

_Smartcard modal in-progress message (no more user role, larger font size)_ 

![vxadmin-smartcard-modal-in-progress](https://user-images.githubusercontent.com/12616928/183738912-9c3596ba-a3a6-441b-8fc9-f2a71475267a.png)

### VxCentralScan

_Lock screen when machine is unconfigured_

![vxcentralscan-lock-screen-unconfigured](https://user-images.githubusercontent.com/12616928/183741186-fa69f26e-465a-4f4a-bccd-43aadcd3b992.png)

_Lock screen when machine is configured_

![vxcentralscan-lock-screen-configured](https://user-images.githubusercontent.com/12616928/183741182-1687e07c-7795-4f93-a1b3-5233e0374bc2.png)

### VxMark

_Lock screen_

![vxmark-lock-screen](https://user-images.githubusercontent.com/12616928/183738920-66f136a8-80b4-4350-bf97-9758f3a135d6.png)

_Election manager actions_

![vxmark-election-manager-actions](https://user-images.githubusercontent.com/12616928/183738918-dacee4fb-f24b-4bdf-a960-89aba6438769.png)

_Update election_

![vxmark-update-election](https://user-images.githubusercontent.com/12616928/183738923-8a357a4f-59dc-42a3-8a25-e37ca37dbaf4.png)

### VxScan

_Election manager settings_

![vxscan-election-manager-settings](https://user-images.githubusercontent.com/12616928/183746147-a03c9a48-23ed-4161-aa2f-26617904c3c1.png)

## Testing Plan 

- [x] Viewed affected screens manually to make sure new copy wraps well, etc.
- [x] Updated automated tests

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A
- [ ] ~I have added JSDoc comments to any newly introduced exports~ N/A
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates