### PR TITLE
feat(scan): Timeouts, retries, and automatic reconnect

### DIFF
--- a/frontends/precinct-scanner/src/screens/scan_error_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/scan_error_screen.tsx
@@ -35,6 +35,7 @@ export function ScanErrorScreen({ error, isTestMode }: Props): JSX.Element {
       case 'paper_in_back_on_startup':
       case 'paper_in_back_after_accept':
         return 'Take your ballot out of the tray and try again.';
+      case 'scanning_timed_out':
       case 'unexpected_paper_status':
       case 'unexpected_event':
       case 'plustek_error':

--- a/frontends/precinct-scanner/src/screens/scan_error_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/scan_error_screen.tsx
@@ -29,6 +29,7 @@ export function ScanErrorScreen({ error, isTestMode }: Props): JSX.Element {
       case 'unknown':
         return undefined;
       // Precinct scanner error
+      case 'scanning_failed':
       case 'both_sides_have_paper':
       case 'paper_in_front_on_startup':
       case 'paper_in_back_on_startup':

--- a/libs/api/src/services/scan/index.ts
+++ b/libs/api/src/services/scan/index.ts
@@ -704,6 +704,7 @@ export const SheetInterpretationSchema: z.ZodSchema<SheetInterpretation> =
   ]);
 
 export const PrecinctScannerErrorTypeSchema = z.enum([
+  'scanning_timed_out',
   'scanning_failed',
   'both_sides_have_paper',
   'paper_in_back_after_accept',

--- a/libs/api/src/services/scan/index.ts
+++ b/libs/api/src/services/scan/index.ts
@@ -704,6 +704,7 @@ export const SheetInterpretationSchema: z.ZodSchema<SheetInterpretation> =
   ]);
 
 export const PrecinctScannerErrorTypeSchema = z.enum([
+  'scanning_failed',
   'both_sides_have_paper',
   'paper_in_back_after_accept',
   'paper_in_front_on_startup',

--- a/libs/plustek-sdk/src/mocks.test.ts
+++ b/libs/plustek-sdk/src/mocks.test.ts
@@ -391,6 +391,26 @@ test('paper jam', async () => {
   expectNoPaper((await mock.getPaperStatus()).ok());
 });
 
+test('scanning error feeding', async () => {
+  const mock = new MockScannerClient({
+    toggleHoldDuration: 0,
+    passthroughDuration: 0,
+  });
+  await mock.connect();
+
+  (await mock.simulateLoadSheet(files)).unsafeUnwrap();
+  const scanResult = mock.scan();
+  mock.simulateErrorFeeding();
+  expect([
+    ScannerError.PaperStatusErrorFeeding,
+    ScannerError.PaperStatusNoPaper,
+  ]).toContain((await scanResult).err());
+
+  expect((await mock.getPaperStatus()).ok()).toEqual(
+    PaperStatus.VtmReadyToScan
+  );
+});
+
 test('close', async () => {
   const mock = new MockScannerClient({
     toggleHoldDuration: 0,

--- a/libs/plustek-sdk/src/mocks.ts
+++ b/libs/plustek-sdk/src/mocks.ts
@@ -494,6 +494,7 @@ export class MockScannerClient implements ScannerClient {
         }
         if ((this.machine.state.value as string) === 'ready_to_scan') {
           debug('scan failed, error feeding');
+          /* istanbul ignore next - randomness makes this hard to cover */
           return err(
             Math.random() > 0.5
               ? ScannerError.PaperStatusErrorFeeding

--- a/services/scan/src/precinct_scanner_app.test.ts
+++ b/services/scan/src/precinct_scanner_app.test.ts
@@ -394,7 +394,7 @@ test('scanner powered off while scanning', async () => {
   await post(app, '/scanner/scan');
   await expectStatus(app, { state: 'scanning' });
   mockPlustek.simulatePowerOff();
-  await waitForStatus(app, { state: 'disconnected', error: 'plustek_error' });
+  await waitForStatus(app, { state: 'disconnected' });
 
   mockPlustek.simulatePowerOn('jam');
   await waitForStatus(app, { state: 'jammed' });
@@ -416,10 +416,7 @@ test('scanner powered off while accepting', async () => {
   await waitForStatus(app, { state: 'ready_to_accept', interpretation });
   mockPlustek.simulatePowerOff();
   await post(app, '/scanner/accept');
-  await waitForStatus(app, {
-    state: 'disconnected',
-    error: 'plustek_error',
-  });
+  await waitForStatus(app, { state: 'disconnected' });
 
   mockPlustek.simulatePowerOn('ready_to_eject');
   await waitForStatus(app, {
@@ -616,7 +613,6 @@ test('insert second ballot while first ballot is accepting', async () => {
 
   await waitForStatus(app, {
     state: 'accepted',
-    error: 'plustek_error',
     interpretation,
     ballotsCounted: 1,
   });
@@ -717,7 +713,7 @@ test('jam on scan', async () => {
 
   mockPlustek.simulateJamOnNextOperation();
   await post(app, '/scanner/scan');
-  await waitForStatus(app, { state: 'jammed', error: 'scanning_failed' });
+  await waitForStatus(app, { state: 'jammed' });
 
   await mockPlustek.simulateRemoveSheet();
   await waitForStatus(app, { state: 'no_paper' });
@@ -834,7 +830,7 @@ test('jam on calibrate', async () => {
       status: 'error',
       errors: [{ type: 'error', message: 'plustek_error' }],
     });
-  await expectStatus(app, { state: 'jammed', error: 'plustek_error' });
+  await expectStatus(app, { state: 'jammed' });
 });
 
 test('scan fails and retries', async () => {
@@ -890,4 +886,5 @@ test('scanning time out', async () => {
   await waitForStatus(app, { state: 'no_paper' });
 });
 
+// TODO
 // test('paper status time out', async () => {});

--- a/services/scan/src/precinct_scanner_state_machine.ts
+++ b/services/scan/src/precinct_scanner_state_machine.ts
@@ -472,6 +472,7 @@ function buildMachine(createPlustekClient: CreatePlustekClient) {
           },
         },
         interpreting: {
+          id: 'interpreting',
           initial: 'starting',
           states: {
             starting: {


### PR DESCRIPTION

## Overview
A bundle of resiliency improvements for the precinct scanner service:
- When Plustek fails to grab the ballot, we cap the number of times we will retry the scan command and then show an error to remove the ballot.
- We only will retry scanning on known errors (error feeding, error no paper) or when the paper status indicates the paper didn't get scanned.
- Sometimes the `scan` command will lag for a long time (up to 20s in some cases, triggering an internal Plustek timeout, or even infinitely if the scanner is in some sort of broken state). I've also seen some lag on the `get paper status` command. We timeout these commands after 10s.
- After an unexpected error (e.g. unexpected paper status, timeouts), try to close our connection to Plustek and then reconnect after a cooling off period.


