### PR TITLE
Hide focus outlines on VxMark PIN screen, at least for now

### DIFF
--- a/frontends/bmd/src/App.css
+++ b/frontends/bmd/src/App.css
@@ -44,6 +44,10 @@ img {
   outline: rgb(77, 144, 254) dashed 0.25rem;
 }
 
+.hide-focus-outlines *:focus {
+  outline: none;
+}
+
 select:disabled {
   opacity: 1;
 }

--- a/frontends/bmd/src/app_root.tsx
+++ b/frontends/bmd/src/app_root.tsx
@@ -737,7 +737,12 @@ export function AppRoot({
     );
   }
   if (auth.status === 'checking_passcode') {
-    return <UnlockAdminScreen auth={auth} />;
+    return (
+      <UnlockAdminScreen
+        areFocusOutlinesVisible={Boolean(accessibleController)}
+        auth={auth}
+      />
+    );
   }
   if (isSystemAdministratorAuth(auth)) {
     return (

--- a/frontends/bmd/src/app_root.tsx
+++ b/frontends/bmd/src/app_root.tsx
@@ -737,12 +737,7 @@ export function AppRoot({
     );
   }
   if (auth.status === 'checking_passcode') {
-    return (
-      <UnlockAdminScreen
-        areFocusOutlinesVisible={Boolean(accessibleController)}
-        auth={auth}
-      />
-    );
+    return <UnlockAdminScreen auth={auth} />;
   }
   if (isSystemAdministratorAuth(auth)) {
     return (

--- a/frontends/bmd/src/pages/unlock_admin_screen.test.tsx
+++ b/frontends/bmd/src/pages/unlock_admin_screen.test.tsx
@@ -51,3 +51,27 @@ test('If passcode is incorrect, error message is shown', () => {
   render(<UnlockAdminScreen auth={auth} />);
   screen.getByText('Invalid code. Please try again.');
 });
+
+test('Hides focus outlines when necessary', () => {
+  const auth = Inserted.fakeCheckingPasscodeAuth();
+  const hideFocusOutlinesCssClass = '.hide-focus-outlines';
+
+  let renderResult = render(
+    <UnlockAdminScreen areFocusOutlinesVisible={false} auth={auth} />
+  );
+  expect(document.querySelector(hideFocusOutlinesCssClass)).toBeInTheDocument();
+  renderResult.unmount();
+
+  renderResult = render(
+    <UnlockAdminScreen areFocusOutlinesVisible auth={auth} />
+  );
+  expect(
+    document.querySelector(hideFocusOutlinesCssClass)
+  ).not.toBeInTheDocument();
+  renderResult.unmount();
+
+  render(<UnlockAdminScreen auth={auth} />);
+  expect(
+    document.querySelector(hideFocusOutlinesCssClass)
+  ).not.toBeInTheDocument();
+});

--- a/frontends/bmd/src/pages/unlock_admin_screen.test.tsx
+++ b/frontends/bmd/src/pages/unlock_admin_screen.test.tsx
@@ -52,26 +52,8 @@ test('If passcode is incorrect, error message is shown', () => {
   screen.getByText('Invalid code. Please try again.');
 });
 
-test('Hides focus outlines when necessary', () => {
+test('Hides focus outlines', () => {
   const auth = Inserted.fakeCheckingPasscodeAuth();
-  const hideFocusOutlinesCssClass = '.hide-focus-outlines';
-
-  let renderResult = render(
-    <UnlockAdminScreen areFocusOutlinesVisible={false} auth={auth} />
-  );
-  expect(document.querySelector(hideFocusOutlinesCssClass)).toBeInTheDocument();
-  renderResult.unmount();
-
-  renderResult = render(
-    <UnlockAdminScreen areFocusOutlinesVisible auth={auth} />
-  );
-  expect(
-    document.querySelector(hideFocusOutlinesCssClass)
-  ).not.toBeInTheDocument();
-  renderResult.unmount();
-
   render(<UnlockAdminScreen auth={auth} />);
-  expect(
-    document.querySelector(hideFocusOutlinesCssClass)
-  ).not.toBeInTheDocument();
+  expect(document.querySelector('.hide-focus-outlines')).toBeInTheDocument();
 });

--- a/frontends/bmd/src/pages/unlock_admin_screen.tsx
+++ b/frontends/bmd/src/pages/unlock_admin_screen.tsx
@@ -30,14 +30,10 @@ const EnteredCode = styled.div`
 `;
 
 interface Props {
-  areFocusOutlinesVisible?: boolean;
   auth: InsertedSmartcardAuth.CheckingPasscode;
 }
 
-export function UnlockAdminScreen({
-  areFocusOutlinesVisible = true,
-  auth,
-}: Props): JSX.Element {
+export function UnlockAdminScreen({ auth }: Props): JSX.Element {
   const [currentPasscode, setCurrentPasscode] = useState('');
   const handleNumberEntry = useCallback((digit: number) => {
     setCurrentPasscode((prev) =>
@@ -71,9 +67,7 @@ export function UnlockAdminScreen({
     primarySentence = <Text warning>Invalid code. Please try again.</Text>;
   }
   return (
-    <Screen
-      className={!areFocusOutlinesVisible ? 'hide-focus-outlines' : undefined}
-    >
+    <Screen className="hide-focus-outlines">
       <Main centerChild>
         <Prose textCenter theme={fontSizeTheme.medium} maxWidth={false}>
           {primarySentence}

--- a/frontends/bmd/src/pages/unlock_admin_screen.tsx
+++ b/frontends/bmd/src/pages/unlock_admin_screen.tsx
@@ -30,10 +30,14 @@ const EnteredCode = styled.div`
 `;
 
 interface Props {
+  areFocusOutlinesVisible?: boolean;
   auth: InsertedSmartcardAuth.CheckingPasscode;
 }
 
-export function UnlockAdminScreen({ auth }: Props): JSX.Element {
+export function UnlockAdminScreen({
+  areFocusOutlinesVisible = true,
+  auth,
+}: Props): JSX.Element {
   const [currentPasscode, setCurrentPasscode] = useState('');
   const handleNumberEntry = useCallback((digit: number) => {
     setCurrentPasscode((prev) =>
@@ -67,7 +71,9 @@ export function UnlockAdminScreen({ auth }: Props): JSX.Element {
     primarySentence = <Text warning>Invalid code. Please try again.</Text>;
   }
   return (
-    <Screen>
+    <Screen
+      className={!areFocusOutlinesVisible ? 'hide-focus-outlines' : undefined}
+    >
       <Main centerChild>
         <Prose textCenter theme={fontSizeTheme.medium} maxWidth={false}>
           {primarySentence}


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/2260

We have extra visible focus outlines on VxMark for accessible controller navigation. These outlines are applied globally, but there are certain circumstances where we don't need them, most notably on the System Administrator / Election Manager PIN screen. In fact, we've received feedback that the outlines make that screen feel broken. There's an ongoing discussion about where else these outlines are and aren't needed, but for m14, let's just disable the outlines on the VxMark PIN screen.

## Screenshots

Before on the left, after on the right

<img src="https://user-images.githubusercontent.com/12616928/183940676-4b04f11a-47e6-4b37-8dd8-0c45830cf28d.png" alt="outlines-before" width=400 /> <img src="https://user-images.githubusercontent.com/12616928/183940674-ae425e0a-e6f4-4440-bde4-3e2679c869b5.png" alt="outlines-after" width=400 />

## Testing

- [x] Tested manually
- [x] Added rudimentary unit test

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A
- [ ] ~I have added JSDoc comments to any newly introduced exports~ N/A
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates