### PR TITLE
fix(scan): Prevent assertion errors when intepreting blank paper

### DIFF
--- a/services/scan/src/simple_interpreter.ts
+++ b/services/scan/src/simple_interpreter.ts
@@ -86,6 +86,14 @@ function combinePageInterpretationsForSheet(
     };
   }
 
+  // TODO is this the right way to handle a blank sheet of paper?
+  if (frontType === 'BlankPage' && backType === 'BlankPage') {
+    return {
+      type: 'InvalidSheet',
+      reason: 'unreadable',
+    };
+  }
+
   // TODO what does this case actually mean?
   if (
     frontType === 'UninterpretedHmpbPage' ||


### PR DESCRIPTION
## Overview
I had previously made an incorrect assertion in the logic to combine page interpretations. This assertion failed on sheets that were blank on both sides.

I refactored this logic to be a little clearer and have a fallback case so there's no chance to error out.

## Demo Video or Screenshot
N/A

## Testing Plan 
Added a new test for this case

