### PR TITLE
feat(scan): Record rejected/returned ballots in database

### DIFF
--- a/services/scan/src/precinct_scanner_app.test.ts
+++ b/services/scan/src/precinct_scanner_app.test.ts
@@ -532,13 +532,17 @@ test('scanner powered off while rejecting', async () => {
 
   await post(app, '/scanner/scan');
   await expectStatus(app, { state: 'scanning' });
-  await waitForStatus(app, { state: 'rejecting', interpretation });
+  await waitForStatus(app, {
+    state: 'rejecting',
+    interpretation,
+    canUnconfigure: false,
+  });
 
   mockPlustek.simulatePowerOff();
-  await waitForStatus(app, { state: 'disconnected' });
+  await waitForStatus(app, { state: 'disconnected', canUnconfigure: false });
 
   mockPlustek.simulatePowerOn('jam');
-  await waitForStatus(app, { state: 'jammed' });
+  await waitForStatus(app, { state: 'jammed', canUnconfigure: false });
 });
 
 test('scanner powered off while returning', async () => {
@@ -555,13 +559,17 @@ test('scanner powered off while returning', async () => {
   await waitForStatus(app, { state: 'needs_review', interpretation });
 
   await post(app, '/scanner/return');
-  await waitForStatus(app, { state: 'returning', interpretation });
+  await waitForStatus(app, {
+    state: 'returning',
+    interpretation,
+    canUnconfigure: false,
+  });
 
   mockPlustek.simulatePowerOff();
-  await waitForStatus(app, { state: 'disconnected' });
+  await waitForStatus(app, { state: 'disconnected', canUnconfigure: false });
 
   mockPlustek.simulatePowerOn('jam');
-  await waitForStatus(app, { state: 'jammed' });
+  await waitForStatus(app, { state: 'jammed', canUnconfigure: false });
 });
 
 test('scanner powered off after returning', async () => {
@@ -578,16 +586,26 @@ test('scanner powered off after returning', async () => {
   await waitForStatus(app, { state: 'needs_review', interpretation });
 
   await post(app, '/scanner/return');
-  await waitForStatus(app, { state: 'returning', interpretation });
-  await waitForStatus(app, { state: 'returned', interpretation });
+  await waitForStatus(app, {
+    state: 'returning',
+    interpretation,
+    canUnconfigure: false,
+  });
+  await waitForStatus(app, {
+    state: 'returned',
+    interpretation,
+    canUnconfigure: false,
+  });
 
   mockPlustek.simulatePowerOff();
-  await waitForStatus(app, { state: 'disconnected' });
+  await waitForStatus(app, { state: 'disconnected', canUnconfigure: false });
 
   mockPlustek.simulatePowerOn('ready_to_scan');
   await waitForStatus(app, {
     state: 'rejected',
     error: 'paper_in_front_on_startup',
+
+    canUnconfigure: false,
   });
 });
 
@@ -717,17 +735,33 @@ test('insert second ballot while first ballot is rejecting', async () => {
 
   await post(app, '/scanner/scan');
   await expectStatus(app, { state: 'scanning' });
-  await waitForStatus(app, { state: 'rejecting', interpretation });
+  await waitForStatus(app, {
+    state: 'rejecting',
+    interpretation,
+    canUnconfigure: false,
+  });
 
   await mockPlustek.simulateLoadSheet(ballotImages.wrongElection);
-  await waitForStatus(app, { state: 'both_sides_have_paper', interpretation });
+  await waitForStatus(app, {
+    state: 'both_sides_have_paper',
+    interpretation,
+    canUnconfigure: false,
+  });
 
   await mockPlustek.simulateRemoveSheet();
-  await waitForStatus(app, { state: 'rejecting', interpretation });
-  await waitForStatus(app, { state: 'rejected', interpretation });
+  await waitForStatus(app, {
+    state: 'rejecting',
+    interpretation,
+    canUnconfigure: false,
+  });
+  await waitForStatus(app, {
+    state: 'rejected',
+    interpretation,
+    canUnconfigure: false,
+  });
 
   await mockPlustek.simulateRemoveSheet();
-  await waitForStatus(app, { state: 'no_paper' });
+  await waitForStatus(app, { state: 'no_paper', canUnconfigure: false });
 });
 
 test('insert second ballot while first ballot is returning', async () => {
@@ -744,18 +778,34 @@ test('insert second ballot while first ballot is returning', async () => {
   await waitForStatus(app, { state: 'needs_review', interpretation });
 
   await post(app, '/scanner/return');
-  await waitForStatus(app, { state: 'returning', interpretation });
+  await waitForStatus(app, {
+    state: 'returning',
+    interpretation,
+    canUnconfigure: false,
+  });
 
   await mockPlustek.simulateLoadSheet(ballotImages.unmarkedHmpb);
-  await waitForStatus(app, { state: 'both_sides_have_paper', interpretation });
+  await waitForStatus(app, {
+    state: 'both_sides_have_paper',
+    interpretation,
+    canUnconfigure: false,
+  });
 
   await mockPlustek.simulateRemoveSheet();
-  await waitForStatus(app, { state: 'needs_review', interpretation });
+  await waitForStatus(app, {
+    state: 'needs_review',
+    interpretation,
+    canUnconfigure: false,
+  });
   await post(app, '/scanner/return');
-  await waitForStatus(app, { state: 'returned', interpretation });
+  await waitForStatus(app, {
+    state: 'returned',
+    interpretation,
+    canUnconfigure: false,
+  });
 
   await mockPlustek.simulateRemoveSheet();
-  await waitForStatus(app, { state: 'no_paper' });
+  await waitForStatus(app, { state: 'no_paper', canUnconfigure: false });
 });
 
 test('jam on scan', async () => {
@@ -796,15 +846,17 @@ test('jam on accept', async () => {
     state: 'rejecting',
     interpretation,
     error: 'paper_in_back_after_accept',
+    canUnconfigure: false,
   });
   await waitForStatus(app, {
     state: 'rejected',
     error: 'paper_in_back_after_accept',
     interpretation,
+    canUnconfigure: false,
   });
 
   await mockPlustek.simulateRemoveSheet();
-  await waitForStatus(app, { state: 'no_paper' });
+  await waitForStatus(app, { state: 'no_paper', canUnconfigure: false });
 });
 
 test('jam on return', async () => {
@@ -825,10 +877,11 @@ test('jam on return', async () => {
   await waitForStatus(app, {
     state: 'jammed',
     interpretation,
+    canUnconfigure: false,
   });
 
   await mockPlustek.simulateRemoveSheet();
-  await waitForStatus(app, { state: 'no_paper' });
+  await waitForStatus(app, { state: 'no_paper', canUnconfigure: false });
 });
 
 test('jam on reject', async () => {
@@ -849,10 +902,11 @@ test('jam on reject', async () => {
   await waitForStatus(app, {
     state: 'jammed',
     interpretation,
+    canUnconfigure: false,
   });
 
   await mockPlustek.simulateRemoveSheet();
-  await waitForStatus(app, { state: 'no_paper' });
+  await waitForStatus(app, { state: 'no_paper', canUnconfigure: false });
 });
 
 test('calibrate', async () => {

--- a/services/scan/src/simple_interpreter.ts
+++ b/services/scan/src/simple_interpreter.ts
@@ -318,7 +318,7 @@ export function createInterpreter(
 
 function storeInterpretedSheet(
   store: Store,
-  sheetId: string,
+  sheetId: Id,
   interpretation: SheetInterpretation
 ): Id {
   // TODO instead of one batch per ballot, use one batch per scanning session
@@ -335,7 +335,7 @@ function storeInterpretedSheet(
  */
 export function storeAcceptedSheet(
   store: Store,
-  sheetId: string,
+  sheetId: Id,
   interpretation: SheetInterpretation
 ): void {
   storeInterpretedSheet(store, sheetId, interpretation);
@@ -353,7 +353,7 @@ export function storeAcceptedSheet(
  */
 export function storeRejectedSheet(
   store: Store,
-  sheetId: string,
+  sheetId: Id,
   interpretation: SheetInterpretation
 ): void {
   storeInterpretedSheet(store, sheetId, interpretation);


### PR DESCRIPTION


## Overview
Closes #2300 

If a ballot is interpreted but not cast, we still want to record the interpretation in the db to ensure that we know what happened.

## Demo Video or Screenshot
N/A

## Testing Plan 
Updated tests

