### PR TITLE
fix(scan): BMD scanning lag, removing jsQR for now.

### DIFF
--- a/libs/ballot-interpreter-vx/src/interpreter/regression_overvote_on_choctaw_county_p1_05.test.ts
+++ b/libs/ballot-interpreter-vx/src/interpreter/regression_overvote_on_choctaw_county_p1_05.test.ts
@@ -3,7 +3,8 @@ import { Interpreter } from '.';
 
 jest.setTimeout(10000);
 
-test('regression: overvote on choctaw county p1-05', async () => {
+// disabling this test as we've disabled jsQR for now
+test.skip('regression: overvote on choctaw county p1-05', async () => {
   const fixtures = choctaw2020LegalSize;
   const { electionDefinition } = fixtures;
   const interpreter = new Interpreter({ electionDefinition, testMode: true });

--- a/libs/ballot-interpreter-vx/src/utils/qrcode.test.ts
+++ b/libs/ballot-interpreter-vx/src/utils/qrcode.test.ts
@@ -3,7 +3,8 @@ import { hardQrCodePage1 } from '../../test/fixtures/choctaw-2020-09-22-f30480cc
 import { loadImageData } from './images';
 import { detect as detectQrCode, getSearchAreas } from './qrcode';
 
-test('falls back to jsQR if the other QR code readers cannot read them', async () => {
+// disabling this test as we've disabled jsQR for now
+test.skip('falls back to jsQR if the other QR code readers cannot read them', async () => {
   const imageData = await loadImageData(
     join(__dirname, '../../test/fixtures/jsqr-only-qrcode.png')
   );

--- a/libs/ballot-interpreter-vx/src/utils/qrcode.ts
+++ b/libs/ballot-interpreter-vx/src/utils/qrcode.ts
@@ -6,7 +6,7 @@ import { crop } from '@votingworks/image-utils';
 import { Rect, Size } from '@votingworks/types';
 import { Buffer } from 'buffer';
 import makeDebug from 'debug';
-import jsQr from 'jsqr';
+// import jsQr from 'jsqr';
 import { QRCode } from 'node-quirc';
 import { DetectQrCodeResult } from '../types';
 
@@ -230,13 +230,6 @@ export async function detect(
         return results
           .filter((result): result is QRCode => !('err' in result))
           .map((result) => result.data);
-      },
-    },
-    {
-      name: 'jsQR',
-      detect: ({ data, width, height }: ImageData): Buffer[] => {
-        const result = jsQr(data, width, height);
-        return result ? [Buffer.from(result.binaryData)] : [];
       },
     },
   ];


### PR DESCRIPTION
jsQR can be very slow on blank pages without a QR code. That's making BMD ballot scanning sometimes very, very slow. Disabling jsQR for now.

We should consider adding it back: #2316 

