### PR TITLE
feat(scan): Basic logging for precinct scanner state machine

### DIFF
--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -334,3 +334,11 @@ IDs are logged with each log to identify the log being written.
 **Type:** [user-action](#user-action)  
 **Description:** User has triggered a reboot of the machine.  
 **Machines:** All
+### scanner-state-machine-event
+**Type:** [application-action](#application-action)  
+**Description:** Precinct scanner state machine received an event.  
+**Machines:** vx-scan-service
+### scanner-state-machine-transition
+**Type:** [application-status](#application-status)  
+**Description:** Precinct scanner state machine transitioned states.  
+**Machines:** vx-scan-service

--- a/libs/logging/src/log_event_ids.ts
+++ b/libs/logging/src/log_event_ids.ts
@@ -102,6 +102,9 @@ export enum LogEventId {
   PrepareBootFromUsbInit = 'prepare-boot-from-usb-init',
   PrepareBootFromUsbComplete = 'prepare-boot-from-usb-complete',
   RebootMachine = 'reboot-machine',
+  // VxScan service state machine logs
+  ScannerEvent = 'scanner-state-machine-event',
+  ScannerStateChanged = 'scanner-state-machine-transition',
 }
 
 export interface LogDetails {
@@ -727,6 +730,20 @@ const RebootMachine: LogDetails = {
   documentationMessage: 'User has triggered a reboot of the machine.',
 };
 
+const ScannerEvent: LogDetails = {
+  eventId: LogEventId.ScannerEvent,
+  eventType: LogEventType.ApplicationAction,
+  documentationMessage: 'Precinct scanner state machine received an event.',
+  restrictInDocumentationToApps: [LogSource.VxScanService],
+};
+
+const ScannerStateChanged: LogDetails = {
+  eventId: LogEventId.ScannerStateChanged,
+  eventType: LogEventType.ApplicationStatus,
+  documentationMessage: 'Precinct scanner state machine transitioned states.',
+  restrictInDocumentationToApps: [LogSource.VxScanService],
+};
+
 export function getDetailsForEventId(eventId: LogEventId): LogDetails {
   switch (eventId) {
     case LogEventId.ElectionConfigured:
@@ -889,6 +906,10 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return PrepareBootFromUsbComplete;
     case LogEventId.RebootMachine:
       return RebootMachine;
+    case LogEventId.ScannerEvent:
+      return ScannerEvent;
+    case LogEventId.ScannerStateChanged:
+      return ScannerStateChanged;
     /* istanbul ignore next - compile time check for completeness */
     default:
       throwIllegalValue(eventId);

--- a/libs/logging/src/test_utils.ts
+++ b/libs/logging/src/test_utils.ts
@@ -3,6 +3,6 @@ import { LogSource } from './log_source';
 
 export function fakeLogger(logSource: LogSource = LogSource.System): Logger {
   const logger = new Logger(logSource);
-  jest.spyOn(logger, 'log').mockResolvedValue();
+  logger.log = jest.fn().mockResolvedValue(undefined);
   return logger;
 }

--- a/services/scan/src/server.ts
+++ b/services/scan/src/server.ts
@@ -25,7 +25,6 @@ export interface StartOptions {
   importer: Importer;
   app: Application;
   createPlustekClient: CreatePlustekClient;
-  log(message: string): void; // TODO(caro) Remove once all logging is moved over to logger
   logger: Logger;
   workspace: Workspace;
   machineType: 'bsd' | 'precinct-scanner';
@@ -66,8 +65,10 @@ export async function start({
   let resolvedApp: express.Application;
 
   if (machineType === 'precinct-scanner') {
-    const precinctScannerMachine =
-      createPrecinctScannerStateMachine(createPlustekClient);
+    const precinctScannerMachine = createPrecinctScannerStateMachine(
+      createPlustekClient,
+      logger
+    );
     resolvedApp = buildPrecinctScannerApp(
       precinctScannerMachine,
       resolvedWorkspace


### PR DESCRIPTION
## Overview
Closes #2314 

Adds basic logging to the precinct scanner state machine, logging all machine events and transitions, which basically captures the complete behavior of the machine.

## Demo Video or Screenshot
N/A

## Testing Plan 
- Added some basic checks to the tests
- Some manual testing