### PR TITLE
Add override mark threshold feature to VxScan election manager screen

### DIFF
--- a/frontends/precinct-scanner/src/api/config.test.ts
+++ b/frontends/precinct-scanner/src/api/config.test.ts
@@ -93,3 +93,25 @@ test('setCurrentPrecinctId fails', async () => {
     '"PUT /config/precinct failed: undefined"'
   );
 });
+
+test('PATCH setMarkThresholds', async () => {
+  fetchMock.patchOnce('/config/markThresholdOverrides', {
+    body: { status: 'ok' },
+  });
+  await config.setMarkThresholdOverrides({ definite: 0.25, marginal: 0.5 });
+
+  expect(
+    fetchMock.calls('/config/markThresholdOverrides', { method: 'PATCH' })
+  ).toHaveLength(1);
+});
+
+test('setMarkThresholds deletes', async () => {
+  fetchMock.deleteOnce('/config/markThresholdOverrides', {
+    body: { status: 'ok' },
+  });
+  await config.setMarkThresholdOverrides(undefined);
+
+  expect(
+    fetchMock.calls('/config/markThresholdOverrides', { method: 'DELETE' })
+  ).toHaveLength(1);
+});

--- a/frontends/precinct-scanner/src/api/config.ts
+++ b/frontends/precinct-scanner/src/api/config.ts
@@ -2,6 +2,7 @@ import {
   ElectionDefinition,
   Optional,
   Precinct,
+  MarkThresholds,
   safeParseJson,
 } from '@votingworks/types';
 import { ErrorsResponse, OkResponse, Scan } from '@votingworks/api';
@@ -102,6 +103,30 @@ export async function setTestMode(testMode: boolean): Promise<void> {
   await patch<Scan.PatchTestModeConfigRequest>('/config/testMode', {
     testMode,
   });
+}
+
+export async function getMarkThresholds(): Promise<Optional<MarkThresholds>> {
+  return safeParseJson(
+    await (
+      await fetch('/config/markThresholdOverrides', {
+        headers: { Accept: 'application/json' },
+      })
+    ).text(),
+    Scan.GetMarkThresholdOverridesConfigResponseSchema
+  ).unsafeUnwrap().markThresholdOverrides;
+}
+
+export async function setMarkThresholdOverrides(
+  markThresholdOverrides?: MarkThresholds
+): Promise<void> {
+  if (typeof markThresholdOverrides === 'undefined') {
+    await del('/config/markThresholdOverrides');
+  } else {
+    await patch<Scan.PatchMarkThresholdOverridesConfigRequest>(
+      '/config/markThresholdOverrides',
+      { markThresholdOverrides }
+    );
+  }
 }
 
 export async function getCurrentPrecinctId(): Promise<

--- a/frontends/precinct-scanner/src/app.test.tsx
+++ b/frontends/precinct-scanner/src/app.test.tsx
@@ -113,6 +113,17 @@ const getPrecinctConfigNoPrecinctResponseBody: Scan.GetCurrentPrecinctConfigResp
     status: 'ok',
   };
 
+const getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody: Scan.GetMarkThresholdOverridesConfigResponse =
+  {
+    status: 'ok',
+  };
+
+const getMarkThresholdOverridesConfigResponseBody: Scan.GetMarkThresholdOverridesConfigResponse =
+  {
+    status: 'ok',
+    markThresholdOverrides: { definite: 0.5, marginal: 0.25 },
+  };
+
 test('shows setup card reader screen when there is no card reader', async () => {
   const card = new MemoryCard();
   const storage = new MemoryStorage();
@@ -123,6 +134,9 @@ test('shows setup card reader screen when there is no card reader', async () => 
     .get('/config/election', { body: electionSampleDefinition })
     .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
     .get('/config/precinct', { body: getPrecinctConfigNoPrecinctResponseBody })
+    .get('/config/markThresholdOverrides', {
+      body: getMarkThresholdOverridesConfigResponseBody,
+    })
     .get('/scanner/status', { body: statusNoPaper });
   render(<App storage={storage} hardware={hardware} card={card} />);
   await screen.findByText('Card Reader Not Detected');
@@ -142,6 +156,9 @@ test('initializes app with stored state', async () => {
     .get('/config/election', { body: electionSampleDefinition })
     .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
     .get('/config/precinct', { body: getPrecinctConfigNoPrecinctResponseBody })
+    .get('/config/markThresholdOverrides', {
+      body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
+    })
     .get('/scanner/status', { body: statusNoPaper })
     .patchOnce('/config/testMode', {
       body: typedAs<Scan.PatchTestModeConfigResponse>({ status: 'ok' }),
@@ -177,6 +194,9 @@ test('app can load and configure from a usb stick', async () => {
     .getOnce('/config/election', new Response('null'))
     .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
     .get('/config/precinct', { body: getPrecinctConfigNoPrecinctResponseBody })
+    .get('/config/markThresholdOverrides', {
+      body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
+    })
     .get('/scanner/status', { body: statusNoPaper });
   render(<App storage={storage} card={card} hardware={hardware} />);
   await screen.findByText('Loading Configuration…');
@@ -301,6 +321,9 @@ test('election manager and poll worker configuration', async () => {
     .get('/config/election', { body: electionSampleDefinition })
     .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
     .get('/config/precinct', { body: getPrecinctConfigNoPrecinctResponseBody })
+    .get('/config/markThresholdOverrides', {
+      body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
+    })
     .get('/scanner/status', { body: statusNoPaper })
     .patchOnce('/config/testMode', {
       body: typedAs<Scan.PatchTestModeConfigResponse>({ status: 'ok' }),
@@ -377,6 +400,9 @@ test('election manager and poll worker configuration', async () => {
     1
   );
   fetchMock.putOnce('/config/precinct', { body: { status: 'ok' } });
+  fetchMock.putOnce('/config/markThresholdOverrides', {
+    body: { status: 'ok' },
+  });
 
   // Remove Card and check polls were reset to closed.
   card.removeCard();
@@ -491,6 +517,9 @@ test('voter can cast a ballot that scans successfully ', async () => {
     .get('/config/election', { body: electionSampleDefinition })
     .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
     .get('/config/precinct', { body: getPrecinctConfigNoPrecinctResponseBody })
+    .get('/config/markThresholdOverrides', {
+      body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
+    })
     .getOnce('/scanner/status', { body: statusNoPaper });
   render(<App card={card} hardware={hardware} storage={storage} />);
   await advanceTimersAndPromises(1);
@@ -652,6 +681,9 @@ test('voter can cast a ballot that needs review and adjudicate as desired', asyn
     .get('/config/election', { body: electionSampleDefinition })
     .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
     .get('/config/precinct', { body: getPrecinctConfigNoPrecinctResponseBody })
+    .get('/config/markThresholdOverrides', {
+      body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
+    })
     .getOnce('/scanner/status', { body: statusNoPaper });
   render(<App storage={storage} card={card} hardware={hardware} />);
   await screen.findByText('Insert Your Ballot Below');
@@ -720,6 +752,9 @@ test('voter can cast a rejected ballot', async () => {
     .getOnce('/config/election', { body: electionSampleDefinition })
     .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
     .get('/config/precinct', { body: getPrecinctConfigNoPrecinctResponseBody })
+    .get('/config/markThresholdOverrides', {
+      body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
+    })
     .getOnce('/scanner/status', { body: statusNoPaper });
   const card = new MemoryCard();
   const hardware = MemoryHardware.buildStandard();
@@ -781,6 +816,9 @@ test('voter can cast another ballot while the success screen is showing', async 
     .get('/config/election', { body: electionSampleDefinition })
     .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
     .get('/config/precinct', { body: getPrecinctConfigNoPrecinctResponseBody })
+    .get('/config/markThresholdOverrides', {
+      body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
+    })
     .getOnce('/scanner/status', {
       body: scannerStatus({ state: 'accepted', ballotsCounted: 1 }),
     });
@@ -837,6 +875,9 @@ test('scanning is not triggered when polls closed or cards present', async () =>
     .get('/config/election', { body: electionSampleDefinition })
     .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
     .get('/config/precinct', { body: getPrecinctConfigNoPrecinctResponseBody })
+    .get('/config/markThresholdOverrides', {
+      body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
+    })
     // Set up the status endpoint with 15 ballots scanned
     .get('/scanner/status', {
       body: scannerStatus({ state: 'ready_to_scan', ballotsCounted: 15 }),
@@ -886,6 +927,9 @@ test('no printer: poll worker can open and close polls without scanning any ball
     .get('/config/election', { body: electionSampleDefinition })
     .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
     .get('/config/precinct', { body: getPrecinctConfigNoPrecinctResponseBody })
+    .get('/config/markThresholdOverrides', {
+      body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
+    })
     .get('/scanner/status', { body: statusNoPaper })
     .patchOnce('/config/testMode', {
       body: typedAs<Scan.PatchTestModeConfigResponse>({ status: 'ok' }),
@@ -936,6 +980,9 @@ test('with printer: poll worker can open and close polls without scanning any ba
     .get('/config/election', { body: electionSampleDefinition })
     .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
     .get('/config/precinct', { body: getPrecinctConfigNoPrecinctResponseBody })
+    .get('/config/markThresholdOverrides', {
+      body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
+    })
     .get('/scanner/status', { body: statusNoPaper })
     .patchOnce('/config/testMode', {
       body: typedAs<Scan.PatchTestModeConfigResponse>({ status: 'ok' }),
@@ -986,6 +1033,9 @@ test('no printer: open polls, scan ballot, close polls, export results', async (
     .get('/config/election', { body: electionSampleDefinition })
     .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
     .get('/config/precinct', { body: getPrecinctConfigNoPrecinctResponseBody })
+    .get('/config/markThresholdOverrides', {
+      body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
+    })
     .get('/scanner/status', { body: statusNoPaper })
     .patchOnce('/config/testMode', {
       body: typedAs<Scan.PatchTestModeConfigResponse>({ status: 'ok' }),
@@ -1121,6 +1171,9 @@ test('system administrator can log in and unconfigure machine', async () => {
     .get('/config/election', { body: electionSampleDefinition })
     .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
     .get('/config/precinct', { body: getPrecinctConfigNoPrecinctResponseBody })
+    .get('/config/markThresholdOverrides', {
+      body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
+    })
     .get('/scanner/status', { body: statusNoPaper })
     .delete('/config/election', { body: deleteElectionConfigResponseBody });
   render(<App card={card} storage={storage} hardware={hardware} />);
@@ -1169,6 +1222,9 @@ test('system administrator allowed to log in on unconfigured machine', async () 
     .get('/config/election', { body: null })
     .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
     .get('/config/precinct', { body: getPrecinctConfigNoPrecinctResponseBody })
+    .get('/config/markThresholdOverrides', {
+      body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
+    })
     .get('/scanner/status', { body: statusNoPaper });
 
   render(<App card={card} storage={storage} hardware={hardware} />);
@@ -1194,6 +1250,9 @@ test('election manager cannot auth onto machine with different election hash whe
     .get('/config/election', { body: electionSampleDefinition })
     .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
     .get('/config/precinct', { body: getPrecinctConfigNoPrecinctResponseBody })
+    .get('/config/markThresholdOverrides', {
+      body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
+    })
     .get('/scanner/status', { body: statusNoPaper });
 
   render(<App card={card} storage={storage} hardware={hardware} />);

--- a/frontends/precinct-scanner/src/app.test.tsx
+++ b/frontends/precinct-scanner/src/app.test.tsx
@@ -798,7 +798,6 @@ test('voter can cast a rejected ballot', async () => {
   fetchMock.getOnce('/scanner/status', {
     body: scannerStatus({ state: 'no_paper' }),
   });
-  jest.advanceTimersByTime(POLLING_INTERVAL_FOR_SCANNER_STATUS_MS);
   await screen.findByText('Insert Your Ballot Below');
   expect(fetchMock.done()).toBe(true);
 });

--- a/frontends/precinct-scanner/src/app_tally_report_paths.test.tsx
+++ b/frontends/precinct-scanner/src/app_tally_report_paths.test.tsx
@@ -70,6 +70,17 @@ const getPrecinctConfigPrecinct23ResponseBody: Scan.GetCurrentPrecinctConfigResp
     precinctId: '23',
   };
 
+const getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody: Scan.GetMarkThresholdOverridesConfigResponse =
+  {
+    status: 'ok',
+  };
+
+const getMarkThresholdOverridesConfigResponseBody: Scan.GetMarkThresholdOverridesConfigResponse =
+  {
+    status: 'ok',
+    markThresholdOverrides: { definite: 0.5, marginal: 0.25 },
+  };
+
 const statusNoPaper: Scan.GetPrecinctScannerStatusResponse = {
   state: 'no_paper',
   canUnconfigure: false,
@@ -127,6 +138,9 @@ test('expected tally reports are printed for a primary election with all precinc
       body: electionMinimalExhaustiveSampleDefinition,
     })
     .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
+    .get('/config/markThresholdOverrides', {
+      body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
+    })
     .get('/config/precinct', { body: getPrecinctConfigNoPrecinctResponseBody })
     .get('/scanner/status', { body: statusNoPaper })
     .patchOnce('/config/testMode', {
@@ -191,6 +205,9 @@ test('expected tally reports for a primary election with all precincts with CVRs
     })
     .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
     .get('/config/precinct', { body: getPrecinctConfigNoPrecinctResponseBody })
+    .get('/config/markThresholdOverrides', {
+      body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
+    })
     .get('/scanner/status', { body: { ...statusNoPaper, ballotsCounted: 3 } })
     .patchOnce('/config/testMode', {
       body: typedAs<Scan.PatchTestModeConfigResponse>({ status: 'ok' }),
@@ -559,6 +576,9 @@ test('expected tally reports for a primary election with a single precincts with
     })
     .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
     .get('/config/precinct', { body: getPrecinctConfigPrecinct1ResponseBody })
+    .get('/config/markThresholdOverrides', {
+      body: getMarkThresholdOverridesConfigResponseBody,
+    })
     .get('/scanner/status', { body: { ...statusNoPaper, ballotsCounted: 3 } })
     .patchOnce('/config/testMode', {
       body: typedAs<Scan.PatchTestModeConfigResponse>({ status: 'ok' }),
@@ -839,6 +859,9 @@ test('expected tally reports for a general election with all precincts with CVRs
     .get('/config/election', { body: electionSample2Definition })
     .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
     .get('/config/precinct', { body: getPrecinctConfigNoPrecinctResponseBody })
+    .get('/config/markThresholdOverrides', {
+      body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
+    })
     .get('/scanner/status', { body: { ...statusNoPaper, ballotsCounted: 2 } })
     .patchOnce('/config/testMode', {
       body: typedAs<Scan.PatchTestModeConfigResponse>({ status: 'ok' }),
@@ -1087,6 +1110,9 @@ test('expected tally reports for a general election with a single precincts with
     .get('/config/election', { body: electionSample2Definition })
     .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
     .get('/config/precinct', { body: getPrecinctConfigPrecinct23ResponseBody })
+    .get('/config/markThresholdOverrides', {
+      body: getMarkThresholdOverridesConfigResponseBody,
+    })
     .get('/scanner/status', { body: { ...statusNoPaper, ballotsCounted: 2 } })
     .patchOnce('/config/testMode', {
       body: typedAs<Scan.PatchTestModeConfigResponse>({ status: 'ok' }),

--- a/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
+++ b/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
@@ -57,6 +57,11 @@ const getPrecinctConfigNoPrecinctResponseBody: Scan.GetCurrentPrecinctConfigResp
     status: 'ok',
   };
 
+const getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody: Scan.GetMarkThresholdOverridesConfigResponse =
+  {
+    status: 'ok',
+  };
+
 beforeEach(() => {
   jest.useFakeTimers();
   fetchMock.reset();
@@ -81,6 +86,9 @@ test('services/scan fails to unconfigure', async () => {
     .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
     .get('/config/precinct', {
       body: getPrecinctConfigNoPrecinctResponseBody,
+    })
+    .get('/config/markThresholdOverrides', {
+      body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
     })
     .get('/scanner/status', statusNoPaper)
     .deleteOnce('/config/election', { status: 404 });
@@ -116,6 +124,9 @@ test('Show invalid card screen when unsupported cards are given', async () => {
     .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
     .get('/config/precinct', {
       body: getPrecinctConfigNoPrecinctResponseBody,
+    })
+    .get('/config/markThresholdOverrides', {
+      body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
     })
     .deleteOnce('/config/election', { status: 404 })
     .get('/scanner/status', statusNoPaper);
@@ -170,6 +181,9 @@ test('show card backwards screen when card connection error occurs', async () =>
     .get('/config/precinct', {
       body: getPrecinctConfigNoPrecinctResponseBody,
     })
+    .get('/config/markThresholdOverrides', {
+      body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
+    })
     .deleteOnce('/config/election', { status: 404 })
     .get('/scanner/status', statusNoPaper);
 
@@ -198,6 +212,9 @@ test('shows internal wiring message when there is no plustek scanner, but tablet
     .get('/config/election', { body: electionSampleDefinition })
     .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
     .get('/config/precinct', { body: getPrecinctConfigNoPrecinctResponseBody })
+    .get('/config/markThresholdOverrides', {
+      body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
+    })
     .get('/scanner/status', { ...statusNoPaper, state: 'disconnected' });
   render(<App card={card} storage={storage} hardware={hardware} />);
   await screen.findByRole('heading', { name: 'Internal Connection Problem' });
@@ -215,6 +232,9 @@ test('shows power cable message when there is no plustek scanner and tablet is n
     .get('/config/election', { body: electionSampleDefinition })
     .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
     .get('/config/precinct', { body: getPrecinctConfigNoPrecinctResponseBody })
+    .get('/config/markThresholdOverrides', {
+      body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
+    })
     .get('/scanner/status', { ...statusNoPaper, state: 'disconnected' });
   render(<App card={card} storage={storage} hardware={hardware} />);
   await screen.findByRole('heading', { name: 'No Power Detected' });
@@ -245,6 +265,9 @@ test('App shows message to connect to power when disconnected and battery is low
     .get('/config/election', { body: electionSampleDefinition })
     .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
     .get('/config/precinct', { body: getPrecinctConfigNoPrecinctResponseBody })
+    .get('/config/markThresholdOverrides', {
+      body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
+    })
     .get('/scanner/status', { body: statusNoPaper });
   render(<App card={card} hardware={hardware} storage={storage} />);
   await advanceTimersAndPromises(1);
@@ -270,6 +293,9 @@ test('App shows warning message to connect to power when disconnected', async ()
     .get('/config/election', { body: electionSampleDefinition })
     .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
     .get('/config/precinct', { body: getPrecinctConfigNoPrecinctResponseBody })
+    .get('/config/markThresholdOverrides', {
+      body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
+    })
     .get('/scanner/status', { body: statusNoPaper });
   render(<App card={card} hardware={hardware} storage={storage} />);
   fetchMock.post('/scan/export', {});
@@ -323,6 +349,9 @@ test('removing card during calibration', async () => {
     .get('/config/election', { body: electionSampleDefinition })
     .get('/config/testMode', { body: getTestModeConfigTrueResponseBody })
     .get('/config/precinct', { body: getPrecinctConfigNoPrecinctResponseBody })
+    .get('/config/markThresholdOverrides', {
+      body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
+    })
     .get('/scanner/status', { body: statusNoPaper })
     .post('/scan/export', {});
   render(

--- a/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
+++ b/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
@@ -363,6 +363,7 @@ test('removing card during calibration', async () => {
     electionSampleDefinition.electionHash
   );
   card.insertCard(pollWorkerCard);
+  await advanceTimersAndPromises(1);
   userEvent.click(
     await screen.findByRole('button', { name: 'Yes, Open the Polls' })
   );

--- a/frontends/precinct-scanner/src/components/set_mark_thresholds_modal.test.tsx
+++ b/frontends/precinct-scanner/src/components/set_mark_thresholds_modal.test.tsx
@@ -1,0 +1,171 @@
+import React from 'react';
+
+import {
+  render,
+  fireEvent,
+  getByText as domGetByText,
+  waitFor,
+} from '@testing-library/react';
+import { electionSample } from '@votingworks/fixtures';
+
+import { SetMarkThresholdsModal } from './set_mark_thresholds_modal';
+
+test('renders warning message before allowing overrides to be set', () => {
+  const closeFn = jest.fn();
+  const { getByText } = render(
+    <SetMarkThresholdsModal
+      onClose={closeFn}
+      markThresholds={electionSample.markThresholds}
+      markThresholdOverrides={undefined}
+      setMarkThresholdOverrides={jest.fn()}
+    />
+  );
+  getByText('Override Mark Thresholds');
+  getByText(/WARNING: Do not proceed/);
+  fireEvent.click(getByText('Close'));
+  expect(closeFn).toHaveBeenCalled();
+});
+
+test('renders reset modal when overrides are set', async () => {
+  const closeFn = jest.fn();
+  const setMarkThresholdOverrides = jest.fn().mockResolvedValueOnce('');
+  const { getByText } = render(
+    <SetMarkThresholdsModal
+      onClose={closeFn}
+      markThresholds={electionSample.markThresholds}
+      markThresholdOverrides={{ definite: 0.32, marginal: 0.24 }}
+      setMarkThresholdOverrides={setMarkThresholdOverrides}
+    />
+  );
+  getByText('Reset Mark Thresholds');
+  const currentThresholds = getByText('Current Thresholds');
+  domGetByText(currentThresholds, /Definite: 0.32/);
+  domGetByText(currentThresholds, /Marginal: 0.24/);
+
+  const defaultThresholds = getByText('Default Thresholds');
+  domGetByText(defaultThresholds, /Definite: 0.25/);
+  domGetByText(defaultThresholds, /Marginal: 0.17/);
+
+  fireEvent.click(getByText('Close'));
+  expect(closeFn).toHaveBeenCalled();
+
+  fireEvent.click(getByText('Reset Thresholds'));
+  expect(setMarkThresholdOverrides).toHaveBeenCalledWith(undefined);
+  await waitFor(() => {
+    expect(closeFn).toHaveBeenCalledTimes(2);
+  });
+});
+
+test('reset modal displays errors appropriately', async () => {
+  const closeFn = jest.fn();
+  const setMarkThresholdOverrides = jest
+    .fn()
+    .mockRejectedValueOnce(new Error('Hakuna Matata'));
+  const { getByText } = render(
+    <SetMarkThresholdsModal
+      onClose={closeFn}
+      markThresholds={electionSample.markThresholds}
+      markThresholdOverrides={{ definite: 0.32, marginal: 0.24 }}
+      setMarkThresholdOverrides={setMarkThresholdOverrides}
+    />
+  );
+  getByText('Reset Mark Thresholds');
+  fireEvent.click(getByText('Reset Thresholds'));
+  expect(setMarkThresholdOverrides).toHaveBeenCalledWith(undefined);
+  await waitFor(() => {
+    getByText('Error');
+  });
+  getByText(/Hakuna Matata/);
+  fireEvent.click(getByText('Close'));
+  expect(closeFn).toHaveBeenCalledTimes(1);
+});
+
+test('allows users to set thresholds properly', async () => {
+  const closeFn = jest.fn();
+  const setThresholds = jest.fn();
+  const { getByText, getByTestId } = render(
+    <SetMarkThresholdsModal
+      onClose={closeFn}
+      markThresholds={electionSample.markThresholds}
+      markThresholdOverrides={undefined}
+      setMarkThresholdOverrides={setThresholds}
+    />
+  );
+  getByText('Override Mark Thresholds');
+  getByText(/WARNING: Do not proceed/);
+  fireEvent.click(getByText('Proceed to Override Thresholds'));
+
+  const definiteInput = getByTestId('definite-text-input').closest('input')!;
+  expect(definiteInput.value).toBe('0.25');
+  fireEvent.change(definiteInput, { target: { value: '0.12' } });
+  expect(definiteInput.value).toBe('0.12');
+
+  const marginalInput = getByTestId('marginal-text-input').closest('input')!;
+  expect(marginalInput.value).toBe('0.17');
+  fireEvent.change(marginalInput, { target: { value: '0.21' } });
+  expect(marginalInput.value).toBe('0.21');
+
+  fireEvent.click(getByText('Override Thresholds'));
+  expect(setThresholds).toHaveBeenCalledWith({
+    definite: 0.12,
+    marginal: 0.21,
+  });
+  await waitFor(() => {
+    expect(closeFn).toHaveBeenCalledTimes(1);
+  });
+});
+
+test('setting thresholds renders an error if given a number greater than 1', () => {
+  const closeFn = jest.fn();
+  const setThresholds = jest.fn();
+  const { getByText, getByTestId } = render(
+    <SetMarkThresholdsModal
+      onClose={closeFn}
+      markThresholds={electionSample.markThresholds}
+      markThresholdOverrides={undefined}
+      setMarkThresholdOverrides={setThresholds}
+    />
+  );
+  getByText('Override Mark Thresholds');
+  getByText(/WARNING: Do not proceed/);
+  fireEvent.click(getByText('Proceed to Override Thresholds'));
+
+  const definiteInput = getByTestId('definite-text-input').closest('input')!;
+  fireEvent.change(definiteInput, { target: { value: '314' } });
+  expect(definiteInput.value).toBe('314');
+
+  fireEvent.click(getByText('Override Thresholds'));
+  getByText('Error');
+  getByText(/Inputted definite threshold invalid: 314./);
+  expect(setThresholds).toHaveBeenCalledTimes(0);
+  expect(closeFn).toHaveBeenCalledTimes(0);
+});
+
+test('setting thresholds renders an error if saving throws an error', async () => {
+  const closeFn = jest.fn();
+  const setThresholds = jest
+    .fn()
+    .mockRejectedValueOnce(new Error('Hakuna Matata'));
+  const { getByText } = render(
+    <SetMarkThresholdsModal
+      onClose={closeFn}
+      markThresholds={electionSample.markThresholds}
+      markThresholdOverrides={undefined}
+      setMarkThresholdOverrides={setThresholds}
+    />
+  );
+  getByText('Override Mark Thresholds');
+  getByText(/WARNING: Do not proceed/);
+  fireEvent.click(getByText('Proceed to Override Thresholds'));
+
+  fireEvent.click(getByText('Override Thresholds'));
+  await waitFor(() => {
+    getByText('Error');
+  });
+  getByText(/Hakuna Matata/);
+  expect(setThresholds).toHaveBeenCalledTimes(1);
+  expect(closeFn).toHaveBeenCalledTimes(0);
+
+  fireEvent.click(getByText('Close'));
+  expect(closeFn).toHaveBeenCalledTimes(1);
+});

--- a/frontends/precinct-scanner/src/components/set_mark_thresholds_modal.tsx
+++ b/frontends/precinct-scanner/src/components/set_mark_thresholds_modal.tsx
@@ -1,0 +1,237 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+
+import { MarkThresholds } from '@votingworks/types';
+import {
+  Button,
+  LinkButton,
+  Loading,
+  Modal,
+  Prose,
+  Text,
+} from '@votingworks/ui';
+import { assert, throwIllegalValue } from '@votingworks/utils';
+
+export interface Props {
+  onClose: () => void;
+  markThresholds?: MarkThresholds;
+  markThresholdOverrides?: MarkThresholds;
+  setMarkThresholdOverrides: (markThresholds?: MarkThresholds) => Promise<void>;
+}
+
+const ThresholdColumns = styled.div`
+  display: flex;
+  flex-direction: row;
+  > div {
+    flex: 1;
+  }
+`;
+
+enum ModalState {
+  SAVING = 'saving',
+  RESET_THRESHOLDS = 'reset_thresholds',
+  SET_THRESHOLDS = 'set_thresholds',
+  CONFIRM_INTENT = 'confirm_intent',
+  ERROR = 'error',
+}
+
+export const DefaultMarkThresholds: Readonly<MarkThresholds> = {
+  marginal: 0.17,
+  definite: 0.25,
+};
+
+export function SetMarkThresholdsModal({
+  onClose,
+  markThresholds,
+  markThresholdOverrides,
+  setMarkThresholdOverrides,
+}: Props): JSX.Element {
+  const [currentState, setCurrentState] = useState<ModalState>(
+    markThresholdOverrides === undefined
+      ? ModalState.CONFIRM_INTENT
+      : ModalState.RESET_THRESHOLDS
+  );
+
+  const [errorMessage, setErrorMessage] = useState('');
+  const defaultMarkThresholds = markThresholds ?? DefaultMarkThresholds;
+  const defaultDefiniteThreshold = defaultMarkThresholds.definite;
+  const defaultMarginalThreshold = defaultMarkThresholds.marginal;
+
+  const [definiteThreshold, setDefiniteThreshold] = useState(
+    defaultDefiniteThreshold.toString()
+  );
+  const [marginalThreshold, setMarginalThreshold] = useState(
+    defaultMarginalThreshold.toString()
+  );
+
+  async function overrideThresholds(definite: string, marginal: string) {
+    setCurrentState(ModalState.SAVING);
+    try {
+      // eslint-disable-next-line vx/gts-safe-number-parse
+      const definiteFloat = parseFloat(definite);
+      if (Number.isNaN(definiteFloat) || definiteFloat > 1) {
+        throw new Error(
+          `Inputted definite threshold invalid: ${definite}. Please enter a number from 0 to 1.`
+        );
+      }
+      // eslint-disable-next-line vx/gts-safe-number-parse
+      const marginalFloat = parseFloat(marginal);
+      if (Number.isNaN(marginalFloat) || marginalFloat > 1) {
+        throw new Error(
+          `Inputted marginal threshold invalid: ${marginal}. Please enter a number from 0 to 1.`
+        );
+      }
+      await setMarkThresholdOverrides({
+        definite: definiteFloat,
+        marginal: marginalFloat,
+      });
+      onClose();
+    } catch (error) {
+      assert(error instanceof Error);
+      setCurrentState(ModalState.ERROR);
+      setErrorMessage(`Error setting thresholds: ${error.message}`);
+    }
+  }
+
+  async function resetThresholds() {
+    setCurrentState(ModalState.SAVING);
+    try {
+      await setMarkThresholdOverrides(undefined);
+      onClose();
+    } catch (error) {
+      assert(error instanceof Error);
+      setCurrentState(ModalState.ERROR);
+      setErrorMessage(`Error setting thresholds: ${error.message}`);
+    }
+  }
+
+  switch (currentState) {
+    case ModalState.SAVING:
+      return <Modal content={<Loading />} onOverlayClick={onClose} />;
+    case ModalState.ERROR:
+      return (
+        <Modal
+          content={
+            <Prose>
+              <h1>Error</h1>
+              <p>{errorMessage}</p>
+            </Prose>
+          }
+          onOverlayClick={onClose}
+          actions={<LinkButton onPress={onClose}>Close</LinkButton>}
+        />
+      );
+    case ModalState.CONFIRM_INTENT:
+      return (
+        <Modal
+          content={
+            <Prose>
+              <h1>Override Mark Thresholds</h1>
+              <p>
+                WARNING: Do not proceed unless you have been instructed to do so
+                by a member of VotingWorks staff. Changing mark thresholds will
+                impact the performance of your scanner.
+              </p>
+            </Prose>
+          }
+          onOverlayClick={onClose}
+          actions={
+            <React.Fragment>
+              {
+                <Button
+                  danger
+                  onPress={() => setCurrentState(ModalState.SET_THRESHOLDS)}
+                >
+                  Proceed to Override Thresholds
+                </Button>
+              }{' '}
+              <LinkButton onPress={onClose}>Close</LinkButton>
+            </React.Fragment>
+          }
+        />
+      );
+    case ModalState.SET_THRESHOLDS:
+      return (
+        <Modal
+          content={
+            <Prose>
+              <h1>Override Mark Thresholds</h1>
+              <Text>Definite:</Text>
+              <input
+                type="text"
+                data-testid="definite-text-input"
+                value={definiteThreshold}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setDefiniteThreshold(e.target.value)
+                }
+              />
+              <Text>Marginal:</Text>
+              <input
+                type="text"
+                data-testid="marginal-text-input"
+                value={marginalThreshold}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setMarginalThreshold(e.target.value)
+                }
+              />
+            </Prose>
+          }
+          onOverlayClick={onClose}
+          actions={
+            <React.Fragment>
+              <Button
+                danger
+                onPress={() =>
+                  overrideThresholds(definiteThreshold, marginalThreshold)
+                }
+              >
+                Override Thresholds
+              </Button>{' '}
+              <LinkButton onPress={onClose}>Close</LinkButton>
+            </React.Fragment>
+          }
+        />
+      );
+    case ModalState.RESET_THRESHOLDS:
+      assert(markThresholdOverrides);
+      return (
+        <Modal
+          content={
+            <Prose>
+              <h1>Reset Mark Thresholds</h1>
+              <p>Reset thresholds to the election defaults?</p>
+              <ThresholdColumns>
+                <div>
+                  Current Thresholds
+                  <Text small>
+                    Definite: {markThresholdOverrides.definite}
+                    <br />
+                    Marginal: {markThresholdOverrides.marginal}
+                  </Text>
+                </div>
+                <div>
+                  Default Thresholds
+                  <Text small>
+                    Definite: {defaultMarkThresholds.definite}
+                    <br />
+                    Marginal: {defaultMarkThresholds.marginal}
+                  </Text>
+                </div>
+              </ThresholdColumns>
+            </Prose>
+          }
+          onOverlayClick={onClose}
+          actions={
+            <React.Fragment>
+              <Button primary onPress={resetThresholds}>
+                Reset Thresholds
+              </Button>{' '}
+              <LinkButton onPress={onClose}>Close</LinkButton>
+            </React.Fragment>
+          }
+        />
+      );
+    default:
+      throwIllegalValue(currentState);
+  }
+}

--- a/frontends/precinct-scanner/src/components/set_mark_thresholds_modal.tsx
+++ b/frontends/precinct-scanner/src/components/set_mark_thresholds_modal.tsx
@@ -158,7 +158,8 @@ export function SetMarkThresholdsModal({
               <h1>Override Mark Thresholds</h1>
               <Text>Definite:</Text>
               <input
-                type="text"
+                type="number"
+                step=".005"
                 data-testid="definite-text-input"
                 value={definiteThreshold}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
@@ -167,7 +168,8 @@ export function SetMarkThresholdsModal({
               />
               <Text>Marginal:</Text>
               <input
-                type="text"
+                type="number"
+                step=".005"
                 data-testid="marginal-text-input"
                 value={marginalThreshold}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) =>

--- a/frontends/precinct-scanner/src/contexts/app_context.ts
+++ b/frontends/precinct-scanner/src/contexts/app_context.ts
@@ -2,6 +2,7 @@ import {
   ElectionDefinition,
   InsertedSmartcardAuth,
   PrecinctId,
+  MarkThresholds,
 } from '@votingworks/types';
 import { createContext } from 'react';
 import { MachineConfig } from '../config/types';
@@ -10,12 +11,14 @@ export interface AppContextInterface {
   electionDefinition?: ElectionDefinition;
   machineConfig: Readonly<MachineConfig>;
   currentPrecinctId?: PrecinctId;
+  currentMarkThresholds?: MarkThresholds;
   auth: InsertedSmartcardAuth.Auth;
 }
 
 const appContext: AppContextInterface = {
   electionDefinition: undefined,
   currentPrecinctId: undefined,
+  currentMarkThresholds: undefined,
   machineConfig: {
     machineId: '0000',
     codeVersion: '',

--- a/frontends/precinct-scanner/src/screens/election_manager_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/election_manager_screen.test.tsx
@@ -48,6 +48,7 @@ test('renders date and time settings modal', async () => {
         isTestMode={false}
         updateAppPrecinctId={jest.fn()}
         toggleLiveMode={jest.fn()}
+        setMarkThresholdOverrides={jest.fn()}
         unconfigure={jest.fn()}
         usbDrive={{ status: usbstick.UsbDriveStatus.absent, eject: jest.fn() }}
       />
@@ -99,6 +100,7 @@ test('setting and un-setting the precinct', async () => {
         isTestMode={false}
         updateAppPrecinctId={updateAppPrecinctId}
         toggleLiveMode={jest.fn()}
+        setMarkThresholdOverrides={jest.fn()}
         unconfigure={jest.fn()}
         usbDrive={{ status: usbstick.UsbDriveStatus.absent, eject: jest.fn() }}
       />
@@ -135,6 +137,7 @@ test('export from admin screen', () => {
         isTestMode={false}
         updateAppPrecinctId={jest.fn()}
         toggleLiveMode={jest.fn()}
+        setMarkThresholdOverrides={jest.fn()}
         unconfigure={jest.fn()}
         usbDrive={{ status: usbstick.UsbDriveStatus.absent, eject: jest.fn() }}
       />
@@ -160,6 +163,7 @@ test('unconfigure ejects a usb drive when it is mounted', () => {
         isTestMode={false}
         updateAppPrecinctId={jest.fn()}
         toggleLiveMode={jest.fn()}
+        setMarkThresholdOverrides={jest.fn()}
         unconfigure={unconfigureFn}
         usbDrive={{ status: usbstick.UsbDriveStatus.absent, eject: ejectFn }}
       />
@@ -188,6 +192,7 @@ test('unconfigure does not eject a usb drive that is not mounted', async () => {
         isTestMode={false}
         updateAppPrecinctId={jest.fn()}
         toggleLiveMode={jest.fn()}
+        setMarkThresholdOverrides={jest.fn()}
         unconfigure={unconfigureFn}
         usbDrive={{ status: usbstick.UsbDriveStatus.mounted, eject: ejectFn }}
       />
@@ -216,6 +221,7 @@ test('unconfigure button is disabled when the machine cannot be unconfigured', (
         isTestMode={false}
         updateAppPrecinctId={jest.fn()}
         toggleLiveMode={jest.fn()}
+        setMarkThresholdOverrides={jest.fn()}
         unconfigure={jest.fn()}
         usbDrive={{ status: usbstick.UsbDriveStatus.mounted, eject: jest.fn() }}
       />
@@ -242,6 +248,7 @@ test('cannot toggle to testing mode when the machine cannot be unconfigured', ()
         isTestMode={false}
         updateAppPrecinctId={jest.fn()}
         toggleLiveMode={toggleLiveModeFn}
+        setMarkThresholdOverrides={jest.fn()}
         unconfigure={jest.fn()}
         usbDrive={{ status: usbstick.UsbDriveStatus.mounted, eject: jest.fn() }}
       />
@@ -251,4 +258,42 @@ test('cannot toggle to testing mode when the machine cannot be unconfigured', ()
   fireEvent.click(screen.getByText('Testing Mode'));
   expect(toggleLiveModeFn).not.toHaveBeenCalled();
   fireEvent.click(screen.getByText('Cancel'));
+});
+
+test('Allows overriding mark thresholds', () => {
+  const setMarkThresholdOverridesFn = jest.fn();
+
+  render(
+    <AppContext.Provider
+      value={{
+        electionDefinition: electionSampleDefinition,
+        machineConfig: { machineId: '0000', codeVersion: 'TEST' },
+        auth,
+      }}
+    >
+      <ElectionManagerScreen
+        scannerStatus={scannerStatus}
+        isTestMode={false}
+        updateAppPrecinctId={jest.fn()}
+        toggleLiveMode={jest.fn()}
+        setMarkThresholdOverrides={setMarkThresholdOverridesFn}
+        unconfigure={jest.fn()}
+        usbDrive={{ status: usbstick.UsbDriveStatus.mounted, eject: jest.fn() }}
+      />
+    </AppContext.Provider>
+  );
+
+  fireEvent.click(screen.getByText('Override Mark Thresholds'));
+  fireEvent.click(screen.getByText('Proceed to Override Thresholds'));
+  fireEvent.change(screen.getByTestId('definite-text-input'), {
+    target: { value: '.5' },
+  });
+  fireEvent.change(screen.getByTestId('marginal-text-input'), {
+    target: { value: '.25' },
+  });
+  fireEvent.click(screen.getByText('Override Thresholds'));
+  expect(setMarkThresholdOverridesFn).toHaveBeenCalledWith({
+    definite: 0.5,
+    marginal: 0.25,
+  });
 });

--- a/services/scan/src/precinct_scanner_app.ts
+++ b/services/scan/src/precinct_scanner_app.ts
@@ -228,8 +228,9 @@ export function buildPrecinctScannerApp(
 
   app.delete<NoParams, Scan.DeleteMarkThresholdOverridesConfigResponse>(
     '/config/markThresholdOverrides',
-    (_request, response) => {
+    async (_request, response) => {
       store.setMarkThresholdOverrides(undefined);
+      await configureMachine(machine, workspace);
       response.json({ status: 'ok' });
     }
   );
@@ -238,7 +239,7 @@ export function buildPrecinctScannerApp(
     NoParams,
     Scan.PatchMarkThresholdOverridesConfigResponse,
     Scan.PatchMarkThresholdOverridesConfigRequest
-  >('/config/markThresholdOverrides', (request, response) => {
+  >('/config/markThresholdOverrides', async (request, response) => {
     const bodyParseResult = safeParse(
       Scan.PatchMarkThresholdOverridesConfigRequestSchema,
       request.body
@@ -256,6 +257,7 @@ export function buildPrecinctScannerApp(
     store.setMarkThresholdOverrides(
       bodyParseResult.ok().markThresholdOverrides
     );
+    await configureMachine(machine, workspace);
     response.json({ status: 'ok' });
   });
 

--- a/services/scan/src/precinct_scanner_app.ts
+++ b/services/scan/src/precinct_scanner_app.ts
@@ -39,6 +39,7 @@ async function configureMachine(
     electionDefinition,
     ballotImagesPath: workspace.ballotImagesPath,
     testMode: store.getTestMode(),
+    markThresholdOverrides: store.getMarkThresholdOverrides(),
     layouts,
   });
 

--- a/services/scan/src/precinct_scanner_app.ts
+++ b/services/scan/src/precinct_scanner_app.ts
@@ -218,6 +218,47 @@ export function buildPrecinctScannerApp(
     }
   );
 
+  app.get<NoParams, Scan.GetMarkThresholdOverridesConfigResponse>(
+    '/config/markThresholdOverrides',
+    (_request, response) => {
+      const markThresholdOverrides = store.getMarkThresholdOverrides();
+      response.json({ status: 'ok', markThresholdOverrides });
+    }
+  );
+
+  app.delete<NoParams, Scan.DeleteMarkThresholdOverridesConfigResponse>(
+    '/config/markThresholdOverrides',
+    (_request, response) => {
+      store.setMarkThresholdOverrides(undefined);
+      response.json({ status: 'ok' });
+    }
+  );
+
+  app.patch<
+    NoParams,
+    Scan.PatchMarkThresholdOverridesConfigResponse,
+    Scan.PatchMarkThresholdOverridesConfigRequest
+  >('/config/markThresholdOverrides', (request, response) => {
+    const bodyParseResult = safeParse(
+      Scan.PatchMarkThresholdOverridesConfigRequestSchema,
+      request.body
+    );
+
+    if (bodyParseResult.isErr()) {
+      const error = bodyParseResult.err();
+      response.status(400).json({
+        status: 'error',
+        errors: [{ type: error.name, message: error.message }],
+      });
+      return;
+    }
+
+    store.setMarkThresholdOverrides(
+      bodyParseResult.ok().markThresholdOverrides
+    );
+    response.json({ status: 'ok' });
+  });
+
   app.post<NoParams, Scan.AddTemplatesResponse, Scan.AddTemplatesRequest>(
     '/scan/hmpb/addTemplates',
     upload.fields([

--- a/services/scan/src/simple_interpreter.ts
+++ b/services/scan/src/simple_interpreter.ts
@@ -5,6 +5,7 @@ import {
   BallotPageLayoutWithImage,
   ElectionDefinition,
   Id,
+  MarkThresholds,
   ok,
   PageInterpretationWithFiles,
   Result,
@@ -24,6 +25,7 @@ export interface CreateInterpreterOptions {
   readonly electionDefinition: ElectionDefinition;
   readonly layouts: readonly BallotPageLayoutWithImage[];
   readonly ballotImagesPath: string;
+  readonly markThresholdOverrides?: MarkThresholds;
   readonly testMode: boolean;
 }
 
@@ -159,10 +161,13 @@ function combinePageInterpretationsForSheet(
 function createNhInterpreter(
   options: CreateInterpreterOptions
 ): SimpleInterpreter {
-  const { electionDefinition, ballotImagesPath } = options;
+  const { electionDefinition, ballotImagesPath, markThresholdOverrides } =
+    options;
   return {
     interpret: async (sheetId, sheet) => {
-      const result = await interpretNh(electionDefinition, sheet);
+      const result = await interpretNh(electionDefinition, sheet, {
+        markThresholds: markThresholdOverrides,
+      });
 
       if (result.isErr()) {
         return result;
@@ -206,11 +211,13 @@ function createVxInterpreter({
   electionDefinition,
   ballotImagesPath,
   layouts,
+  markThresholdOverrides,
   testMode,
 }: CreateInterpreterOptions): SimpleInterpreter {
   const vxInterpreter = new VxInterpreter({
     electionDefinition,
     testMode,
+    markThresholdOverrides,
     adjudicationReasons:
       (SCANNER_LOCATION === ScannerLocation.Central
         ? electionDefinition.election.centralScanAdjudicationReasons


### PR DESCRIPTION
## Overview
Closes #1856 

This adds the same override mark thresholds modal from VxCentralScan to the election manager screen in VxScan.

## Demo Video or Screenshot

https://user-images.githubusercontent.com/7584833/184223762-266bb150-f333-4efd-80f3-e75804890763.mov

## Testing Plan 
Manual testing plus automated tests.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
