### PR TITLE
feat(scan): Move ballot layout export behind feature flag

### DIFF
--- a/services/scan/src/config/features.ts
+++ b/services/scan/src/config/features.ts
@@ -10,7 +10,7 @@ import { asBoolean } from '@votingworks/utils';
  * To disable it, remove the line or comment it out. Restarting the server is required.
  *
  */
-export function isWriteInAdjudicationBallotImageExportEnabled(): boolean {
+export function isWriteInAdjudicationBallotImageAndLayoutExportEnabled(): boolean {
   return asBoolean(
     process.env['ENABLE_WRITE_IN_ADJUDICATION_EXPORT_BALLOT_IMAGES']
   );

--- a/services/scan/src/store.test.ts
+++ b/services/scan/src/store.test.ts
@@ -18,7 +18,7 @@ import { v4 as uuid } from 'uuid';
 import * as stateOfHamilton from '../test/fixtures/state-of-hamilton';
 import { zeroRect } from '../test/fixtures/zero_rect';
 import { Store } from './store';
-import { isWriteInAdjudicationBallotImageExportEnabled } from './config/features';
+import { isWriteInAdjudicationBallotImageAndLayoutExportEnabled } from './config/features';
 import * as buildCastVoteRecord from './build_cast_vote_record';
 
 // We pause in some of these tests so we need to increase the timeout
@@ -27,14 +27,14 @@ jest.setTimeout(20000);
 jest.mock('./config/features', (): typeof import('./config/features') => {
   return {
     ...jest.requireActual('./config/features'),
-    isWriteInAdjudicationBallotImageExportEnabled: jest.fn(),
+    isWriteInAdjudicationBallotImageAndLayoutExportEnabled: jest.fn(),
   };
 });
 
 beforeEach(() => {
-  mockOf(isWriteInAdjudicationBallotImageExportEnabled).mockImplementation(
-    () => false
-  );
+  mockOf(
+    isWriteInAdjudicationBallotImageAndLayoutExportEnabled
+  ).mockImplementation(() => false);
 });
 
 test('get/set election', () => {
@@ -515,9 +515,9 @@ test('adjudication', () => {
 });
 
 test('exportCvrs', async () => {
-  mockOf(isWriteInAdjudicationBallotImageExportEnabled).mockImplementation(
-    () => true
-  );
+  mockOf(
+    isWriteInAdjudicationBallotImageAndLayoutExportEnabled
+  ).mockImplementation(() => true);
 
   const buildCastVoteRecordMock = jest.spyOn(
     buildCastVoteRecord,
@@ -721,17 +721,8 @@ test('exportCvrs does not export ballot images when feature flag turned off', as
     expect.anything(),
     expect.anything(),
     expect.anything(),
-    [{ normalized: '' }, { normalized: '' }],
-    expect.arrayContaining([
-      expect.arrayContaining([
-        expect.objectContaining({ contests: [] }),
-        expect.objectContaining({ contests: [] }),
-      ]),
-      expect.arrayContaining([
-        expect.objectContaining({ contests: [] }),
-        expect.objectContaining({ contests: [] }),
-      ]),
-    ])
+    [{ normalized: '' }, { normalized: '' }], // leave ballot images as empty string when feature flag turned off
+    undefined // layouts are undefined when feature flag turned off
   );
 });
 

--- a/services/scan/src/store.ts
+++ b/services/scan/src/store.ts
@@ -46,7 +46,7 @@ import { buildCastVoteRecord } from './build_cast_vote_record';
 import { Bindable, DbClient } from './db_client';
 import { sheetRequiresAdjudication } from './interpreter';
 import { SheetOf } from './types';
-import { isWriteInAdjudicationBallotImageExportEnabled } from './config/features';
+import { isWriteInAdjudicationBallotImageAndLayoutExportEnabled } from './config/features';
 import { normalizeAndJoin } from './util/path';
 
 const debug = makeDebug('scan:store');
@@ -871,7 +871,7 @@ export class Store {
 
       const frontImage: InlineBallotImage = { normalized: '' };
       const backImage: InlineBallotImage = { normalized: '' };
-      if (isWriteInAdjudicationBallotImageExportEnabled()) {
+      if (isWriteInAdjudicationBallotImageAndLayoutExportEnabled()) {
         if (
           frontInterpretation.type === 'InterpretedHmpbPage' ||
           frontInterpretation.type === 'UninterpretedHmpbPage'
@@ -924,8 +924,9 @@ export class Store {
           },
         ],
         [frontImage, backImage],
-        (frontInterpretation.type === 'InterpretedHmpbPage' ||
-          frontInterpretation.type === 'UninterpretedHmpbPage') &&
+        isWriteInAdjudicationBallotImageAndLayoutExportEnabled() &&
+          (frontInterpretation.type === 'InterpretedHmpbPage' ||
+            frontInterpretation.type === 'UninterpretedHmpbPage') &&
           (backInterpretation.type === 'InterpretedHmpbPage' ||
             backInterpretation.type === 'UninterpretedHmpbPage')
           ? [


### PR DESCRIPTION
## Overview
This moves ballot layout export behind a feature flag.

## Demo Video or Screenshot

## Testing Plan 
Updating existing tests.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
