### PR TITLE
Allow corrupted smartcards to be reprogrammed

### DIFF
--- a/services/smartcards/smartcards/core.py
+++ b/services/smartcards/smartcards/core.py
@@ -31,7 +31,12 @@ def card_read():
 
     card_bytes, long_value_exists = CardInterface.read()
     assert card_bytes is not None
-    card_data = card_bytes.decode('utf-8')
+    try:
+        card_data = card_bytes.decode('utf-8')
+    except UnicodeDecodeError:  # pragma: no cover - Triggering a UnicodeDecodeError is tricky with our current testing setup
+        # If the card data can't be decoded, e.g because the card was removed mid-programming and
+        # corrupted as a result, treat it as a blank card so that it can be reprogrammed
+        card_data = ''
     if card_data:
         return json.dumps({"status": "ready", "shortValue": card_data, "longValueExists": long_value_exists})
     else:


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/2170

If you remove a smartcard mid-programming, you can end up with a corrupted card that has data on it that can't be decoded:

```
127.0.0.1 - - [11/Aug/2022 15:42:06] "GET /card/read HTTP/1.1" 500 -
[2022-08-11 15:42:06,831] ERROR in app: Exception on /card/read [GET]
Traceback (most recent call last):
  File "/home/arsalan/Workspace/code/vxsuite/services/smartcards/.venv/lib/python3.9/site-packages/flask/app.py", line 2077, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/arsalan/Workspace/code/vxsuite/services/smartcards/.venv/lib/python3.9/site-packages/flask/app.py", line 1525, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/arsalan/Workspace/code/vxsuite/services/smartcards/.venv/lib/python3.9/site-packages/flask/app.py", line 1523, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/arsalan/Workspace/code/vxsuite/services/smartcards/.venv/lib/python3.9/site-packages/flask/app.py", line 1509, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
  File "/home/arsalan/Workspace/code/vxsuite/services/smartcards/smartcards/core.py", line 34, in card_read
    card_data = card_bytes.decode('utf-8')
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 67: invalid start byte
```

With old card programming flows, a corrupted card could easily be reprogrammed because we always displayed the options to program cards. Now, those options are only surfaced when a card is actually inserted into the card reader and detected as ready, so inserting a corrupted card results in... nothing (cue sad trombone).

This PR restores the ability to reprogram corrupted cards. A corrupted card is now treated like a blank card, so inserting a corrupted card opens the smartcard modal in the card programming state.

## Testing

Corrupted a card by removing it mid-programming. Then re-inserted it. Verified that the smartcard modal wasn't surfaced with old code and is surfaced with new code. Then successfully reprogrammed the card with new code! :tada: Also verified that smartcards service 500s became 200s under the hood.

I tried to add an automated test, but it's hard to trigger a `UnicodeDecodeError` with our current testing setup, which mocks card data using a JSON API. I'd explore further but am timeboxing so that I can wrap up another task before code freeze.

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A
- [ ] ~I have added JSDoc comments to any newly introduced exports~ N/A
- [ ] ~I have added a screenshot and/or video to this PR to demo the change~ N/A
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates