### PR TITLE
fix(scan): Simplify debug logging

### DIFF
--- a/libs/logging/src/logger.ts
+++ b/libs/logging/src/logger.ts
@@ -58,7 +58,7 @@ export class Logger {
     eventId: LogEventId,
     user: LoggingUserRole,
     logData: LogData = {},
-    outerDebug?: debug.Debugger
+    outerDebug?: (logLine: LogLine) => void
   ): Promise<void> {
     const eventSpecificDetails = getDetailsForEventId(eventId);
     const {

--- a/services/scan/src/precinct_scanner_app.test.ts
+++ b/services/scan/src/precinct_scanner_app.test.ts
@@ -143,13 +143,15 @@ function checkLogs(logger: Logger) {
   expect(logger.log).toHaveBeenCalledWith(
     'scanner-state-machine-transition',
     'system',
-    { message: 'Transitioned to: "checking_initial_paper_status"' }
+    { message: 'Transitioned to: "checking_initial_paper_status"' },
+    expect.any(Function)
   );
   // Make sure we got an event
   expect(logger.log).toHaveBeenCalledWith(
     'scanner-state-machine-event',
     'system',
-    { message: 'Event: SCANNER_NO_PAPER' }
+    { message: 'Event: SCANNER_NO_PAPER' },
+    expect.any(Function)
   );
   // Make sure we got a context update. And make sure we didn't log the votes in
   // the interpretation, just the type, to protect voter privacy.
@@ -161,7 +163,8 @@ function checkLogs(logger: Logger) {
       changedFields: expect.stringMatching(
         /{"interpretation":"(ValidSheet|InvalidSheet|NeedsReviewSheet)"}/
       ),
-    }
+    },
+    expect.any(Function)
   );
 }
 

--- a/services/scan/src/precinct_scanner_state_machine.ts
+++ b/services/scan/src/precinct_scanner_state_machine.ts
@@ -22,7 +22,7 @@ import {
 import { Scan } from '@votingworks/api';
 import makeDebug from 'debug';
 import { waitFor } from 'xstate/lib/waitFor';
-import { LogEventId, Logger } from '@votingworks/logging';
+import { LogEventId, Logger, LogLine } from '@votingworks/logging';
 import {
   SheetInterpretation,
   SimpleInterpreter,
@@ -787,22 +787,22 @@ function setupLogging(
     .onEvent(async (event) => {
       // To protect voter privacy, we only log the event type (since some event
       // objects include ballot interpretations)
-      await logger.log(LogEventId.ScannerEvent, 'system', {
-        message: `Event: ${event.type}`,
-      });
-      debugEvents('Event: %s', event);
+      await logger.log(
+        LogEventId.ScannerEvent,
+        'system',
+        { message: `Event: ${event.type}` },
+        (logLine: LogLine) => debugEvents(logLine.message)
+      );
     })
     .onChange(async (context, previousContext) => {
       if (!previousContext) return;
-      const changed = Object.entries(context).filter(
-        ([key, value]) => previousContext[key as keyof Context] !== value
-      );
-      if (changed.length === 0) return;
-      debug('Context updated: %o', Object.fromEntries(changed));
-      // In prod, we only log fields that are key for understanding state
-      // machine behavior, since others would be too verbose (e.g. Plustek
-      // client object)
-      const changedToLog = changed
+      const changed = Object.entries(context)
+        .filter(
+          ([key, value]) => previousContext[key as keyof Context] !== value
+        )
+        // We only log fields that are key for understanding state
+        // machine behavior, since others would be too verbose (e.g. Plustek
+        // client object)
         .filter(([key]) =>
           [
             'scannedSheet',
@@ -820,18 +820,25 @@ function setupLogging(
           value === undefined ? 'undefined' : value,
         ]);
 
-      if (changedToLog.length === 0) return;
-      await logger.log(LogEventId.ScannerStateChanged, 'system', {
-        message: `Context updated`,
-        changedFields: JSON.stringify(Object.fromEntries(changedToLog)),
-      });
+      if (changed.length === 0) return;
+      await logger.log(
+        LogEventId.ScannerStateChanged,
+        'system',
+        {
+          message: `Context updated`,
+          changedFields: JSON.stringify(Object.fromEntries(changed)),
+        },
+        () => debug('Context updated: %o', Object.fromEntries(changed))
+      );
     })
     .onTransition(async (state) => {
       if (!state.changed) return;
-      await logger.log(LogEventId.ScannerStateChanged, 'system', {
-        message: `Transitioned to: ${JSON.stringify(state.value)}`,
-      });
-      debug('Transitioned to: %s', state.value);
+      await logger.log(
+        LogEventId.ScannerStateChanged,
+        'system',
+        { message: `Transitioned to: ${JSON.stringify(state.value)}` },
+        (logLine: LogLine) => debug(logLine.message)
+      );
     });
 }
 


### PR DESCRIPTION


## Overview
We don't want production logs and debug dev logs showing at the same time in dev, it's TMI. Instead, we use the built in option of the logger to use a debugger instead of logging in dev.

However, in order to get the simple debug messages we had before, I needed to wrap the debugger in a function to take the log line and only pull out the relevant message field.

