### PR TITLE
feat(election-manager): change create election definition to load demo election definition

### DIFF
--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -156,8 +156,8 @@ test('create election works', async () => {
   const { getByText, getAllByText, queryAllByText, getByTestId } = render(
     <App card={card} hardware={hardware} />
   );
-  await screen.findByText('Create New Election Definition');
-  fireEvent.click(getByText('Create New Election Definition'));
+  await screen.findByText('Load Demo Election Definition');
+  fireEvent.click(getByText('Load Demo Election Definition'));
 
   await screen.findByText('Ballots');
   expect(mockKiosk.log).toHaveBeenCalledWith(
@@ -203,7 +203,7 @@ test('create election works', async () => {
   expect(screen.queryAllByText('No Log File Present')).toHaveLength(0);
 
   fireEvent.click(screen.getByText('Configure'));
-  await screen.findByText('Create New Election Definition');
+  await screen.findByText('Load Demo Election Definition');
 });
 
 test('authentication works', async () => {
@@ -1000,7 +1000,7 @@ test('changing election resets sems, cvr, and manual data files', async () => {
   fireEvent.click(getByText('Remove Election'));
   fireEvent.click(getByText('Remove Election Definition'));
   await waitFor(() => {
-    fireEvent.click(getByText('Create New Election Definition'));
+    fireEvent.click(getByText('Load Demo Election Definition'));
   });
 
   fireEvent.click(getByText('Tally'));
@@ -1178,7 +1178,7 @@ test('system administrator UI has expected nav when no election and VVSG2 auth f
   userEvent.click(screen.getByText('Definition'));
   await screen.findByRole('heading', { name: 'Configure VxAdmin' });
   userEvent.click(
-    screen.getByRole('button', { name: 'Create New Election Definition' })
+    screen.getByRole('button', { name: 'Load Demo Election Definition' })
   );
   await waitFor(() =>
     expect(

--- a/frontends/election-manager/src/screens/unconfigured_screen.tsx
+++ b/frontends/election-manager/src/screens/unconfigured_screen.tsx
@@ -3,6 +3,8 @@ import { useHistory, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import { safeParseElection } from '@votingworks/types';
 
+import { electionSampleDefinition } from '@votingworks/fixtures';
+
 import {
   Modal,
   useCancelablePromise,
@@ -18,8 +20,6 @@ import {
 import { readFileAsync } from '../lib/read_file_async';
 
 import { InputEventFunction } from '../config/types';
-
-import defaultElection from '../data/defaultElection.json';
 
 import { AppContext } from '../contexts/app_context';
 
@@ -57,7 +57,7 @@ function someFilesExist(files: VxFile[]) {
   return files.some((f) => f.path);
 }
 
-const newElection = JSON.stringify(defaultElection);
+const demoElection = electionSampleDefinition.electionData;
 
 export function UnconfiguredScreen(): JSX.Element {
   const history = useHistory();
@@ -81,8 +81,8 @@ export function UnconfiguredScreen(): JSX.Element {
     setClient(getElectionDefinitionConverterClient(converter));
   }, [converter]);
 
-  async function createNewElection() {
-    await saveElection(newElection);
+  async function loadDemoElection() {
+    await saveElection(demoElection);
     history.push(routerPaths.electionDefinition);
   }
 
@@ -299,13 +299,6 @@ export function UnconfiguredScreen(): JSX.Element {
       <Prose textCenter>
         <h1>Configure VxAdmin</h1>
         <p>How would you like to start?</p>
-        <p>
-          <Button onPress={createNewElection}>
-            Create New Election Definition
-          </Button>
-        </p>
-        <HorizontalRule>or</HorizontalRule>
-
         {vxElectionFileIsInvalid && (
           <Invalid>Invalid Vx Election Definition file.</Invalid>
         )}
@@ -328,6 +321,12 @@ export function UnconfiguredScreen(): JSX.Element {
             )}
           </React.Fragment>
         )}
+        <HorizontalRule>or</HorizontalRule>
+        <p>
+          <Button onPress={loadDemoElection}>
+            Load Demo Election Definition
+          </Button>
+        </p>
       </Prose>
     </NavigationScreen>
   );


### PR DESCRIPTION
## Overview
fixes https://github.com/votingworks/vxsuite/issues/2277

## Demo Video or Screenshot
<img width="723" alt="Screen Shot 2022-08-11 at 6 16 43 PM" src="https://user-images.githubusercontent.com/18057/184251884-e598918d-4705-4ee3-aa9a-724d99e38dcc.png">

## Testing Plan 
Manually tested, made sure automated tests pass.

## Checklist
- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
- ~[ ] I have added JSDoc comments to any newly introduced exports~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [X] I have added a screenshot and/or video to this PR to demo the change
- [X] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
