### PR TITLE
fix(tests): upping transition time for the mock scanner state machine to address flaky tests

### DIFF
--- a/services/scan/src/precinct_scanner_app.test.ts
+++ b/services/scan/src/precinct_scanner_app.test.ts
@@ -177,7 +177,7 @@ async function createApp(
   const workspace = await createWorkspace(dirSync().name);
   const mockPlustek = new MockScannerClient({
     toggleHoldDuration: 100,
-    passthroughDuration: 100,
+    passthroughDuration: 500,
   });
   async function createPlustekClient(): Promise<Result<ScannerClient, Error>> {
     await mockPlustek.connect();


### PR DESCRIPTION
On CI, seeing a common case where the precinct scanner tests flake:
<img width="721" alt="Screen Shot 2022-08-12 at 10 31 01 AM" src="https://user-images.githubusercontent.com/18057/184376188-fb328029-c1e3-4a3a-bd9e-e040f74bc646.png">

This is likely due to CI running tests a little more slowly, and since we only have 100ms set up for the mock `rejecting` state, by the time we are awaiting status, we've missed it.

Upping the duration that we mock the time it takes for paper to transition through the scanner should solve this, though I'm a little 😢  about upping test duration.
