### PR TITLE
Add super ballot to system admin Ballots tab

### DIFF
--- a/frontends/election-manager/src/components/election_manager.tsx
+++ b/frontends/election-manager/src/components/election_manager.tsx
@@ -159,7 +159,7 @@ export function ElectionManager(): JSX.Element {
             <DefinitionContestsScreen allowEditing={false} />
           </Route>
           <Route exact path={routerPaths.ballotsList}>
-            <BallotListScreen draftMode />
+            <BallotListScreen />
           </Route>
           <Route
             exact
@@ -175,7 +175,7 @@ export function ElectionManager(): JSX.Element {
               }),
             ]}
           >
-            <BallotScreen draftMode />
+            <BallotScreen />
           </Route>
           <Route exact path={routerPaths.smartcards}>
             <Redirect

--- a/frontends/election-manager/src/components/hand_marked_paper_ballot.tsx
+++ b/frontends/election-manager/src/components/hand_marked_paper_ballot.tsx
@@ -35,6 +35,7 @@ import {
   BallotId,
   BallotTargetMarkPosition,
   getCandidatePartiesDescription,
+  BallotStyle,
 } from '@votingworks/types';
 import { QrCode, HandMarkedPaperBallotProse, Text } from '@votingworks/ui';
 
@@ -49,6 +50,7 @@ import { ABSENTEE_TINT_COLOR } from '../config/globals';
 import { getBallotLayoutPageSize } from '../utils/get_ballot_layout_page_size';
 import { getBallotLayoutDensity } from '../utils/get_ballot_layout_density';
 import { BallotMode } from '../config/types';
+import { isSuperBallotStyle } from '../utils/election';
 
 function hasVote(
   vote: Vote | undefined,
@@ -607,22 +609,33 @@ export function HandMarkedPaperBallot({
       localeElection.ballotStrings
     );
   }
-  const primaryPartyName = getPartyFullNameFromBallotStyle({
-    ballotStyleId,
-    election,
-  });
+  const primaryPartyName = !isSuperBallotStyle(ballotStyleId)
+    ? getPartyFullNameFromBallotStyle({
+        ballotStyleId,
+        election,
+      })
+    : undefined;
   const localePrimaryPartyName =
-    localeElection &&
-    getPartyFullNameFromBallotStyle({
-      ballotStyleId,
-      election: localeElection,
-    });
-  const ballotStyle = getBallotStyle({ ballotStyleId, election });
-  assert(ballotStyle);
-  const contests = getContests({ ballotStyle, election });
+    !isSuperBallotStyle(ballotStyleId) && localeElection
+      ? getPartyFullNameFromBallotStyle({
+          ballotStyleId,
+          election: localeElection,
+        })
+      : undefined;
+  let ballotStyle: BallotStyle | undefined;
+  if (isSuperBallotStyle(ballotStyleId)) {
+    ballotStyle = undefined;
+  } else {
+    ballotStyle = getBallotStyle({ ballotStyleId, election });
+    assert(ballotStyle);
+  }
+  const contests = ballotStyle
+    ? getContests({ ballotStyle, election })
+    : election.contests;
   const candidateContests = contests.filter((c) => c.type === 'candidate');
   const otherContests = contests.filter((c) => c.type !== 'candidate');
   const localeContestsById =
+    ballotStyle &&
     localeElection &&
     getContests({ ballotStyle, election: localeElection }).reduce<
       Dictionary<AnyContest>
@@ -633,7 +646,9 @@ export function HandMarkedPaperBallot({
       }),
       {}
     );
-  const precinct = getPrecinctById({ election, precinctId });
+  const precinct = isSuperBallotStyle(ballotStyleId)
+    ? { id: precinctId, name: 'All' }
+    : getPrecinctById({ election, precinctId });
   assert(precinct);
 
   const ballotRef = useRef<HTMLDivElement>(null);
@@ -750,7 +765,7 @@ export function HandMarkedPaperBallot({
                 <Text small right as="div">
                   {dualLanguageWithBreak('Style')}
                 </Text>
-                <Text as="h2">{ballotStyle.id}</Text>
+                <Text as="h2">{ballotStyle?.id || 'All'}</Text>
               </div>
               <div />
               <div>
@@ -770,11 +785,11 @@ export function HandMarkedPaperBallot({
             <PageFooterRow>
               <div>
                 <Text small left as="div">
-                  {ballotStyle.partyId &&
+                  {ballotStyle?.partyId &&
                   primaryPartyName &&
                   localePrimaryPartyName
                     ? dualPhraseWithBreak(
-                        `${ballotStyle.partyId && primaryPartyName} ${title}`,
+                        `${ballotStyle?.partyId && primaryPartyName} ${title}`,
                         localeElection &&
                           t('{{primaryPartyName}} {{electionTitle}}', {
                             lng: locales.secondary,
@@ -882,7 +897,7 @@ export function HandMarkedPaperBallot({
                   })}
                 </h2>
                 <h3>
-                  {ballotStyle.partyId && primaryPartyName} {title}
+                  {ballotStyle?.partyId && primaryPartyName} {title}
                 </h3>
                 <p>
                   {state}
@@ -900,7 +915,7 @@ export function HandMarkedPaperBallot({
                     </strong>
                     <br />
                     <strong>
-                      {ballotStyle.partyId && primaryPartyName
+                      {ballotStyle?.partyId && primaryPartyName
                         ? t('{{primaryPartyName}} {{electionTitle}}', {
                             lng: locales.secondary,
                             primaryPartyName: localePrimaryPartyName,

--- a/frontends/election-manager/src/components/hand_marked_paper_ballot.tsx
+++ b/frontends/election-manager/src/components/hand_marked_paper_ballot.tsx
@@ -814,7 +814,7 @@ export function HandMarkedPaperBallot({
               </div>
             </PageFooterRow>
           </PageFooterMain>
-          {ballotMode === BallotMode.Sample ? (
+          {[BallotMode.Draft, BallotMode.Sample].includes(ballotMode) ? (
             <PageFooterQrCodeOutline />
           ) : (
             <PageFooterQrCode
@@ -839,14 +839,14 @@ export function HandMarkedPaperBallot({
       </div>
 
       <div className="watermark">
-        {ballotMode === BallotMode.Sample && (
-          <Watermark>
-            <div>SAMPLE</div>
-          </Watermark>
-        )}
         {ballotMode === BallotMode.Draft && (
           <Watermark>
             <div>DRAFT</div>
+          </Watermark>
+        )}
+        {ballotMode === BallotMode.Sample && (
+          <Watermark>
+            <div>SAMPLE</div>
           </Watermark>
         )}
       </div>

--- a/frontends/election-manager/src/components/navigation_screen.tsx
+++ b/frontends/election-manager/src/components/navigation_screen.tsx
@@ -59,7 +59,7 @@ export function NavigationScreen({
     primaryNavItems = election
       ? [
           { label: 'Definition', routerPath: routerPaths.electionDefinition },
-          { label: 'Draft Ballots', routerPath: routerPaths.ballotsList },
+          { label: 'Ballots', routerPath: routerPaths.ballotsList },
           { label: 'Smartcards', routerPath: routerPaths.smartcards },
         ]
       : [{ label: 'Definition', routerPath: routerPaths.electionDefinition }];

--- a/frontends/election-manager/src/components/print_all_ballots_button.test.tsx
+++ b/frontends/election-manager/src/components/print_all_ballots_button.test.tsx
@@ -229,10 +229,12 @@ test('modal is different for system administrators', async () => {
   userEvent.click(await screen.findByText('Print All'));
   modal = await screen.findByRole('alertdialog');
   within(modal).getByText(
-    hasTextAcrossElements('Print 4 Draft Absentee Ballots')
+    hasTextAcrossElements('Print 5 Sample Absentee Ballots')
   );
   for (const electionManagerOption of electionManagerOptions) {
-    expect(within(modal).queryAllByText(electionManagerOption).length).toBe(0);
+    expect(
+      within(modal).queryByText(electionManagerOption)
+    ).not.toBeInTheDocument();
   }
   userEvent.click(within(modal).getByText('Cancel'));
   userEvent.click(screen.getByText('Lock Machine'));

--- a/frontends/election-manager/src/components/print_all_ballots_button.tsx
+++ b/frontends/election-manager/src/components/print_all_ballots_button.tsx
@@ -62,11 +62,7 @@ type ModalState = 'no-printer' | 'options' | 'printing';
 
 const defaultBallotLocales: BallotLocales = { primary: DEFAULT_LOCALE };
 
-interface Props {
-  draftMode?: boolean;
-}
-
-export function PrintAllBallotsButton({ draftMode }: Props): JSX.Element {
+export function PrintAllBallotsButton(): JSX.Element {
   const makeCancelable = useCancelablePromise();
   const {
     electionDefinition,
@@ -90,7 +86,7 @@ export function PrintAllBallotsButton({ draftMode }: Props): JSX.Element {
   const [printFailed, setPrintFailed] = useState(false);
 
   const [ballotMode, setBallotMode] = useState(
-    draftMode ? BallotMode.Draft : BallotMode.Official
+    isSystemAdministratorAuth(auth) ? BallotMode.Sample : BallotMode.Official
   );
   const [isAbsentee, setIsAbsentee] = useState(true);
   const [ballotCopies, setBallotCopies] = useState(1);
@@ -249,7 +245,7 @@ export function PrintAllBallotsButton({ draftMode }: Props): JSX.Element {
           <h1>Print All Ballot Styles</h1>
           <p>Select the ballot type and number of copies to print:</p>
           <CenteredOptions>
-            {!draftMode && (
+            {isElectionManagerAuth(auth) && (
               <p>
                 <BallotModeToggle
                   ballotMode={ballotMode}
@@ -278,7 +274,9 @@ export function PrintAllBallotsButton({ draftMode }: Props): JSX.Element {
           <Button
             primary
             onPress={() => startPrint()}
-            warning={!draftMode && ballotMode !== BallotMode.Official}
+            warning={
+              isElectionManagerAuth(auth) && ballotMode !== BallotMode.Official
+            }
           >
             <PrintBallotButtonText
               ballotCopies={ballotCopies * ballotStyles.length}

--- a/frontends/election-manager/src/screens/ballot_list_screen.tsx
+++ b/frontends/election-manager/src/screens/ballot_list_screen.tsx
@@ -3,7 +3,13 @@ import styled from 'styled-components';
 import pluralize from 'pluralize';
 
 import { assert, find } from '@votingworks/utils';
-import { NoWrap, Prose, Table, TD } from '@votingworks/ui';
+import {
+  isElectionManagerAuth,
+  NoWrap,
+  Prose,
+  Table,
+  TD,
+} from '@votingworks/ui';
 import { AppContext } from '../contexts/app_context';
 
 import { routerPaths } from '../router_paths';
@@ -25,12 +31,8 @@ const Header = styled.div`
   margin-bottom: 1rem;
 `;
 
-interface Props {
-  draftMode?: boolean;
-}
-
-export function BallotListScreen({ draftMode }: Props): JSX.Element {
-  const { electionDefinition, configuredAt } = useContext(AppContext);
+export function BallotListScreen(): JSX.Element {
+  const { auth, electionDefinition, configuredAt } = useContext(AppContext);
   assert(electionDefinition && typeof configuredAt === 'string');
   const { election } = electionDefinition;
 
@@ -72,8 +74,8 @@ export function BallotListScreen({ draftMode }: Props): JSX.Element {
 
         <Prose maxWidth={false}>
           <p>
-            <PrintAllBallotsButton draftMode={draftMode} />{' '}
-            {!draftMode && (
+            <PrintAllBallotsButton />{' '}
+            {isElectionManagerAuth(auth) && (
               <React.Fragment>
                 <ExportBallotPdfsButton />{' '}
                 <ExportElectionBallotPackageModalButton />

--- a/frontends/election-manager/src/screens/ballot_list_screen.tsx
+++ b/frontends/election-manager/src/screens/ballot_list_screen.tsx
@@ -5,6 +5,7 @@ import pluralize from 'pluralize';
 import { assert, find } from '@votingworks/utils';
 import {
   isElectionManagerAuth,
+  isSystemAdministratorAuth,
   NoWrap,
   Prose,
   Table,
@@ -17,6 +18,8 @@ import { Button, SegmentedButton } from '../components/button';
 import { LinkButton } from '../components/link_button';
 import {
   getBallotStylesData,
+  getSuperBallotStyleData,
+  isSuperBallotStyle,
   sortBallotStyleDataByPrecinct,
   sortBallotStyleDataByStyle,
 } from '../utils/election';
@@ -41,6 +44,11 @@ export function BallotListScreen(): JSX.Element {
     sortBallotStyleDataByStyle(election, allBallotStyles),
     sortBallotStyleDataByPrecinct(election, allBallotStyles),
   ];
+  if (isSystemAdministratorAuth(auth)) {
+    const superBallotStyleData = getSuperBallotStyleData(election);
+    ballotLists[0].unshift(superBallotStyleData);
+    ballotLists[1].unshift(superBallotStyleData);
+  }
   const [ballotView, setBallotView] = useState(1);
   function sortByStyle() {
     return setBallotView(0);
@@ -95,10 +103,10 @@ export function BallotListScreen(): JSX.Element {
         </thead>
         <tbody>
           {ballots.map((ballot) => {
-            const precinctName = find(
-              election.precincts,
-              (p) => p.id === ballot.precinctId
-            ).name;
+            const precinctName = isSuperBallotStyle(ballot.ballotStyleId)
+              ? 'All'
+              : find(election.precincts, (p) => p.id === ballot.precinctId)
+                  .name;
             return (
               <tr key={ballot.ballotStyleId + ballot.precinctId}>
                 <TD textAlign="right" nowrap>
@@ -113,7 +121,11 @@ export function BallotListScreen(): JSX.Element {
                 <TD>
                   <NoWrap>{precinctName}</NoWrap>
                 </TD>
-                <TD>{ballot.ballotStyleId}</TD>
+                <TD>
+                  {isSuperBallotStyle(ballot.ballotStyleId)
+                    ? 'All'
+                    : ballot.ballotStyleId}
+                </TD>
                 <TD>{ballot.contestIds.length}</TD>
               </tr>
             );

--- a/frontends/election-manager/src/screens/ballot_screen.tsx
+++ b/frontends/election-manager/src/screens/ballot_screen.tsx
@@ -74,11 +74,7 @@ const BallotPreview = styled.div`
   }
 `;
 
-interface Props {
-  draftMode?: boolean;
-}
-
-export function BallotScreen({ draftMode }: Props): JSX.Element {
+export function BallotScreen(): JSX.Element {
   const history = useHistory();
   const ballotPreviewRef = useRef<HTMLDivElement>(null);
   const {
@@ -109,7 +105,7 @@ export function BallotScreen({ draftMode }: Props): JSX.Element {
   const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
   const [ballotPages, setBallotPages] = useState(0);
   const [ballotMode, setBallotMode] = useState(
-    draftMode ? BallotMode.Draft : BallotMode.Official
+    isSystemAdministratorAuth(auth) ? BallotMode.Sample : BallotMode.Official
   );
   const [isAbsentee, setIsAbsentee] = useState(true);
   const [ballotCopies, setBallotCopies] = useState(1);
@@ -196,7 +192,7 @@ export function BallotScreen({ draftMode }: Props): JSX.Element {
             <strong>{pluralize('contest', ballotContests.length, true)}</strong>
           </h1>
           <p>
-            {!draftMode && (
+            {isElectionManagerAuth(auth) && (
               <React.Fragment>
                 <BallotModeToggle
                   ballotMode={ballotMode}
@@ -276,7 +272,7 @@ export function BallotScreen({ draftMode }: Props): JSX.Element {
               Back to List Ballots
             </LinkButton>
           </p>
-          {!draftMode && (
+          {isElectionManagerAuth(auth) && (
             <p>
               Ballot Package Filename: <Monospace>{filename}</Monospace>
             </p>

--- a/frontends/election-manager/src/screens/ballot_screen.tsx
+++ b/frontends/election-manager/src/screens/ballot_screen.tsx
@@ -14,6 +14,7 @@ import {
   getContests,
   getPrecinctById,
   getElectionLocales,
+  BallotStyle,
 } from '@votingworks/types';
 import pluralize from 'pluralize';
 
@@ -34,7 +35,11 @@ import { AppContext } from '../contexts/app_context';
 import { Button, SegmentedButton } from '../components/button';
 import { PrintButton } from '../components/print_button';
 import { HandMarkedPaperBallot } from '../components/hand_marked_paper_ballot';
-import { getBallotPath, getHumanBallotLanguageFormat } from '../utils/election';
+import {
+  getBallotPath,
+  getHumanBallotLanguageFormat,
+  isSuperBallotStyle,
+} from '../utils/election';
 import { NavigationScreen } from '../components/navigation_screen';
 import { DEFAULT_LOCALE } from '../config/globals';
 import { routerPaths } from '../router_paths';
@@ -97,10 +102,19 @@ export function BallotScreen(): JSX.Element {
     [currentLocaleCode]
   );
 
-  const precinctName = getPrecinctById({ election, precinctId })?.name;
-  const ballotStyle = getBallotStyle({ ballotStyleId, election });
-  assert(ballotStyle);
-  const ballotContests = getContests({ ballotStyle, election });
+  const precinctName = isSuperBallotStyle(ballotStyleId)
+    ? 'All'
+    : getPrecinctById({ election, precinctId })?.name;
+  let ballotStyle: BallotStyle | undefined;
+  if (isSuperBallotStyle(ballotStyleId)) {
+    ballotStyle = undefined;
+  } else {
+    ballotStyle = getBallotStyle({ ballotStyleId, election });
+    assert(ballotStyle);
+  }
+  const ballotContests = ballotStyle
+    ? getContests({ ballotStyle, election })
+    : election.contests;
 
   const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
   const [ballotPages, setBallotPages] = useState(0);
@@ -187,10 +201,22 @@ export function BallotScreen(): JSX.Element {
     <React.Fragment>
       <NavigationScreen>
         <Prose maxWidth={false}>
-          <h1>
-            Ballot Style <strong>{ballotStyleId}</strong> for {precinctName} has{' '}
-            <strong>{pluralize('contest', ballotContests.length, true)}</strong>
-          </h1>
+          {isSuperBallotStyle(ballotStyleId) ? (
+            <h1>
+              Ballot Style <strong>All</strong> has{' '}
+              <strong>
+                {pluralize('contest', ballotContests.length, true)}
+              </strong>
+            </h1>
+          ) : (
+            <h1>
+              Ballot Style <strong>{ballotStyleId}</strong> for {precinctName}{' '}
+              has{' '}
+              <strong>
+                {pluralize('contest', ballotContests.length, true)}
+              </strong>
+            </h1>
+          )}
           <p>
             {isElectionManagerAuth(auth) && (
               <React.Fragment>

--- a/frontends/election-manager/src/utils/election.ts
+++ b/frontends/election-manager/src/utils/election.ts
@@ -59,6 +59,29 @@ export function getBallotStylesData(election: Election): BallotStyleData[] {
   );
 }
 
+const superBallotStyleId = 'vx-super-ballot';
+const superBallotStylePrecinctId = 'vx-all-precincts';
+
+/**
+ * Generates the data necessary to render a super ballot, a special ballot only available to system
+ * admins that includes all contests across all precincts
+ */
+export function getSuperBallotStyleData(election: Election): BallotStyleData {
+  return {
+    ballotStyleId: superBallotStyleId,
+    contestIds: election.contests.map((c) => c.id),
+    precinctId: superBallotStylePrecinctId,
+  };
+}
+
+/**
+ * Returns whether a ballot style ID corresponds to the super ballot, a special ballot only
+ * available to system admins that includes all contests across all precincts
+ */
+export function isSuperBallotStyle(ballotStyleId: string): boolean {
+  return ballotStyleId === superBallotStyleId;
+}
+
 function ballotStyleComparator(a: BallotStyleData, b: BallotStyleData) {
   return a.ballotStyleId.localeCompare(b.ballotStyleId, undefined, sortOptions);
 }
@@ -133,10 +156,9 @@ export function getBallotPath({
   variant?: string;
   extension?: string;
 }): string {
-  const precinctName = getPrecinctById({
-    election,
-    precinctId,
-  })?.name;
+  const precinctName = isSuperBallotStyle(ballotStyleId)
+    ? 'All'
+    : getPrecinctById({ election, precinctId })?.name;
   assert(typeof precinctName !== 'undefined');
 
   return `election-${electionHash.slice(0, 10)}-precinct-${dashify(


### PR DESCRIPTION
_Commit by commit reviewing recommended_

## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/1594

Presenting the system admin super ballot 🦸 - a special sample ballot that includes all contests across all precincts. System admins will be able to use this ballot to easily verify that their election definition is configured properly. They'll also be able to post this ballot on election websites and mail it out to voters ahead of an election to inform them of upcoming contests.

As part of this PR, we've also updated system admin ballots to be sample ballots instead of draft ballots. The draft ballot concept will eventually become relevant, once we allow system admins to actually edit and lock election definitions. Before locking, ballots will be draft ballots, and after locking, ballots will be sample ballots. For now though, since we don't yet support editing and locking, all system admin ballots are sample ballots from the get-go.

## Screenshots, video, and PDF

_System admin Ballots tab_

![ballots-tab-1](https://user-images.githubusercontent.com/12616928/184402796-d865b902-f6cf-4e21-8776-fc2ed5c058bd.png)

![ballots-tab-2](https://user-images.githubusercontent.com/12616928/184402802-2e9cb9f8-1c71-4807-9f90-a82471076219.png)

_In action_

https://user-images.githubusercontent.com/12616928/184402125-3bc0a3d6-4980-4c62-aa87-9b3ba2a37dba.mov

_Sample super ballot_

[super-ballot.pdf](https://github.com/votingworks/vxsuite/files/9327966/super-ballot.pdf)

## Testing

- [x] Updated automated tests to verify that system admin and election manager Ballots tabs differ as expected
- [x] Manually tested system admin Ballots tab
- [x] Manually tested election manager Ballots tab (to verify that it's unchanged)
- [x] Manually verified that a super ballot has the expected contents
- [x] Manually verified that a precinct ballot has the expected (unchanged) contents

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ Relying on existing logging
- [x] I have added JSDoc comments to any newly introduced exports
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates