### PR TITLE
fix(election-manager): tweak copy in Reports tab to talk about reports, not counts

### DIFF
--- a/frontends/election-manager/src/screens/reports_screen.tsx
+++ b/frontends/election-manager/src/screens/reports_screen.tsx
@@ -127,17 +127,17 @@ export function ReportsScreen(): JSX.Element {
   if (!isTabulationRunning) {
     const resultTables = (
       <React.Fragment>
-        <h2>Ballot Counts by Precinct</h2>
+        <h2>Tally Report by Precinct</h2>
         <BallotCountsTable breakdownCategory={TallyCategory.Precinct} />
-        <h2>Ballot Counts by Voting Method</h2>
+        <h2>Tally Report by Voting Method</h2>
         <BallotCountsTable breakdownCategory={TallyCategory.VotingMethod} />
         {partiesForPrimaries.length > 0 && (
           <React.Fragment>
-            <h2>Ballot Counts by Party</h2>
+            <h2>Tally Report by Party</h2>
             <BallotCountsTable breakdownCategory={TallyCategory.Party} />
           </React.Fragment>
         )}
-        <h2>Ballot Counts by Scanner</h2>
+        <h2>Tally Report by Scanner</h2>
         <Button small onPress={toggleShowingBatchResults}>
           {isShowingBatchResults
             ? 'Show Results by Scanner'


### PR DESCRIPTION

## Overview
https://github.com/votingworks/vxsuite/issues/2318

## Demo Video or Screenshot
<img width="1247" alt="Screen Shot 2022-08-12 at 12 52 38 PM" src="https://user-images.githubusercontent.com/18057/184406788-56baa85e-fc33-4240-9df9-aa7f6263f665.png">

## Testing Plan 
Looked at it.

## Checklist
~- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
~- [ ] I have added JSDoc comments to any newly introduced exports~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [X] I have added a screenshot and/or video to this PR to demo the change
- [X] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
