### PR TITLE
Proof of concept for defaulting to no precinct selection on VxScan to mirror VxMark

### DIFF
--- a/frontends/precinct-scanner/src/screens/election_manager_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/election_manager_screen.tsx
@@ -28,6 +28,8 @@ import { ScreenMainCenterChild } from '../components/layout';
 import { AppContext } from '../contexts/app_context';
 import { SetMarkThresholdsModal } from '../components/set_mark_thresholds_modal';
 
+export const ALL_PRECINCTS_OPTION_VALUE = 'ALL_PRECINCTS_OPTION_VALUE';
+
 interface Props {
   scannerStatus: Scan.PrecinctScannerStatus;
   isTestMode: boolean;
@@ -125,12 +127,15 @@ export function ElectionManagerScreen({
           <Select
             id="selectPrecinct"
             data-testid="selectPrecinct"
-            value={currentPrecinctId}
+            value={currentPrecinctId ?? ''}
             onBlur={changeAppPrecinctId}
             onChange={changeAppPrecinctId}
             large
           >
-            <option value="">All Precincts</option>
+            <option value="" disabled>
+              Select a precinct for this device…
+            </option>
+            <option value={ALL_PRECINCTS_OPTION_VALUE}>All precincts</option>
             {[...election.precincts]
               .sort((a, b) =>
                 a.name.localeCompare(b.name, undefined, {


### PR DESCRIPTION
Issue link: https://github.com/votingworks/vxsuite/issues/1972

Copying my message from Slack:

> After taking a quick look at https://github.com/votingworks/vxsuite/issues/1972 (VxScan should default to no precinct selection instead of all precincts, to mirror VxMark) and with a few hours before code freeze, I'm hesitating to try to finish it. This change would require a new state/screen where a poll worker, even after inserting their card, can't open polls if a precinct hasn't been selected yet. It'll also require removing the assumption that precinct ID being undefined means that the scanner is configured for all precincts. (This assumption goes pretty deep, e.g. as far as the shared [ElectionInfoBar](https://github.com/votingworks/vxsuite/blob/a2a8af91cc78d63b291bca18ec1facd382064a0f/libs/ui/src/election_info_bar.tsx#L53).) It's not too complex, but there's more to it than meets the eye.

> Working on a proof-of-concept to see how risky it feels before code freeze and how many tests will need updating

This is that proof of concept! I still need to:

- Audit the rest of the codebase for places that infer all precincts from `currentPrecinctId === undefined`
- Update existing tests
- Add new tests for the new poll worker screen
- Get a design sanity check on the new poll worker screen

I also haven't been able to test end-to-end manually yet since I haven't fully configured my VxScan dev setup, i.e. used kiosk-browser and loaded in a ballot package. I've just been using preview screens. Something to clear up next week when we all look at our dev setups!