### PR TITLE
Change File Transfer Language

### DIFF
--- a/frontends/bsd/README.md
+++ b/frontends/bsd/README.md
@@ -18,9 +18,9 @@ The server will be available at http://localhost:3000/.
 To set the election configuration you will either need to scan a smartcard (you
 can use the mockCardReader script in
 [services/smartcards](../../services/smartcards) for this), load an
-election.json file, or load a ballot export zip file from
-[election-manager](../election-manager). You should load a ballot export zip if
-you intend to test hand-marked paper ballots (HMPBs).
+election.json file, or load a ballot package from
+[election-manager](../election-manager). You should load a ballot package if you
+intend to test hand-marked paper ballots (HMPBs).
 
 To display a batch of scanned ballots use the `MOCK_SCANNER_FILES` environment
 variable set as described in [`services/scan`](../../services/scan).

--- a/frontends/bsd/src/app.test.tsx
+++ b/frontends/bsd/src/app.test.tsx
@@ -271,7 +271,7 @@ test('clicking Scan Batch will scan a batch', async () => {
   expect(mockAlert).not.toHaveBeenCalled();
 });
 
-test('clicking export shows modal and makes a request to export', async () => {
+test('clicking "Save Results" shows modal and makes a request to export', async () => {
   const getElectionResponseBody: Scan.GetElectionConfigResponse =
     electionSampleDefinition;
   const getTestModeResponseBody: Scan.GetTestModeConfigResponse = {
@@ -323,10 +323,10 @@ test('clicking export shows modal and makes a request to export', async () => {
     // wait for the config to load
     await sleep(500);
 
-    fireEvent.click(getByText('Export'));
+    fireEvent.click(getByText('Save Results'));
     await waitFor(() => getByText(exportingModalText));
     fireEvent.click(getByTestId('manual-export'));
-    await waitFor(() => getByText('Download Complete'));
+    await waitFor(() => getByText('Results Saved'));
     fireEvent.click(getByText('Cancel'));
   });
 

--- a/frontends/bsd/src/app_root.tsx
+++ b/frontends/bsd/src/app_root.tsx
@@ -613,10 +613,10 @@ export function AppRoot({ card, hardware, logger }: AppRootProps): JSX.Element {
     let exportButtonTitle;
     if (adjudication.remaining > 0) {
       exportButtonTitle =
-        'You cannot export results until all ballots have been adjudicated.';
+        'You cannot save results until all ballots have been adjudicated.';
     } else if (status.batches.length === 0) {
       exportButtonTitle =
-        'You cannot export results until you have scanned at least 1 ballot.';
+        'You cannot save results until you have scanned at least 1 ballot.';
     }
 
     return (
@@ -665,7 +665,7 @@ export function AppRoot({ card, hardware, logger }: AppRootProps): JSX.Element {
                   }
                   title={exportButtonTitle}
                 >
-                  Export
+                  Save Results
                 </Button>
                 <ScanButton
                   onPress={scanBatch}

--- a/frontends/bsd/src/components/election_configuration.test.tsx
+++ b/frontends/bsd/src/components/election_configuration.test.tsx
@@ -27,7 +27,7 @@ test('shows loading screen when usb is mounting or ejecting', () => {
   }
 });
 
-test('shows insert usb screen when no usb is present with manual upload button', async () => {
+test('shows insert usb screen when no usb is present with manual load button', async () => {
   const usbStatuses = [
     UsbDriveStatus.absent,
     UsbDriveStatus.notavailable,
@@ -74,9 +74,9 @@ test('reads files from usb when mounted and shows proper display when there are 
     { usbDriveStatus: UsbDriveStatus.mounted }
   );
 
-  await waitFor(() => getByText('No Election Ballot Package Files Found'));
+  await waitFor(() => getByText('No Election Ballot Packages Found'));
   getByText(
-    /There were no Election Ballot Package files automatically found on the inserted USB drive. /
+    /There were no Election Ballot Packages automatically found on the inserted USB drive. /
   );
   getByText('Select File…');
   getByAltText('Insert USB Image');
@@ -142,7 +142,7 @@ test('reads files from usb when mounted and shows list of files', async () => {
   await waitFor(() => expect(manualUpload).toHaveBeenCalledTimes(1));
 });
 
-test('shows errors that occur when importing in file list screen', async () => {
+test('shows errors that occur when loading in file list screen', async () => {
   const file1 =
     'choctaw-county_2020-general-election_a5753d5776__2020-12-02_09-42-50.zip';
   const mockKiosk = fakeKiosk();
@@ -168,12 +168,10 @@ test('shows errors that occur when importing in file list screen', async () => {
   expect(tableRows).toHaveLength(1);
   expect(queryAllByText('FAKE-ERROR')).toHaveLength(0);
   expect(
-    queryAllByText(
-      /An error occurred while importing the election configuration/
-    )
+    queryAllByText(/An error occurred while loading the election configuration/)
   ).toHaveLength(0);
 
   fireEvent.click(domGetByText(tableRows[0], 'Select'));
   await waitFor(() => getByText(/FAKE-ERROR/));
-  getByText(/An error occurred while importing the election configuration/);
+  getByText(/An error occurred while loading the election configuration/);
 });

--- a/frontends/bsd/src/components/election_configuration.tsx
+++ b/frontends/bsd/src/components/election_configuration.tsx
@@ -99,7 +99,7 @@ export function ElectionConfiguration({
       setFoundFilenames(newFoundFilenames);
       await logger.log(LogEventId.BallotPackageFilesReadFromUsb, userRole, {
         disposition: 'success',
-        message: `Automatically found ${newFoundFilenames.length} ballot package files to import to machine. User prompted to select one to import.`,
+        message: `Automatically found ${newFoundFilenames.length} ballot package files to load to machine. User prompted to select one to load.`,
       });
       setLoadingFiles(false);
     } catch (err) {
@@ -110,7 +110,7 @@ export function ElectionConfiguration({
         setLoadingFiles(false);
         await logger.log(LogEventId.BallotPackageFilesReadFromUsb, userRole, {
           disposition: 'success',
-          message: `Automatically found 0 ballot package files to import to machine. User prompted to select file manually to import.`,
+          message: `Automatically found 0 ballot package files to load to machine. User prompted to select file manually to load.`,
         });
       } else if (err instanceof Error) {
         await logger.log(LogEventId.BallotPackageFilesReadFromUsb, userRole, {
@@ -222,12 +222,12 @@ export function ElectionConfiguration({
         <Screen>
           <Main padded>
             <Prose>
-              <h1>No Election Ballot Package Files Found</h1>
+              <h1>No Election Ballot Packages Found</h1>
               <Image src="/assets/usb-drive.svg" alt="Insert USB Image" />
               <Text>
-                There were no Election Ballot Package files automatically found
-                on the inserted USB drive. Use VxAdmin to export Ballot Package
-                files to this USB drive.
+                There were no Election Ballot Packages automatically found on
+                the inserted USB drive. Use VxAdmin to save a Ballot Package to
+                this USB drive.
               </Text>
               <Text>
                 Optionally, you may manually select a file to configure:
@@ -259,15 +259,15 @@ export function ElectionConfiguration({
             </Text>
             {errorMessage !== '' && (
               <Text error>
-                An error occurred while importing the election configuration:{' '}
-                {errorMessage}. Please check the file you are importing and try
+                An error occurred while loading the election configuration:{' '}
+                {errorMessage}. Please check the file you are loading and try
                 again.
               </Text>
             )}
             <Table>
               <thead>
                 <tr>
-                  <th>Export Date</th>
+                  <th>Date Saved</th>
                   <th>County</th>
                   <th>Election Name</th>
                   <th>ID</th>
@@ -311,7 +311,7 @@ export function ElectionConfiguration({
           <ul>
             <ListItem>
               <strong>Insert a USB drive</strong> with election ballot packages
-              exported from VxAdmin.
+              saved from VxAdmin.
             </ListItem>
             <ListItem>
               Manually select a file to configure:{' '}

--- a/frontends/bsd/src/components/export_logs_modal.test.tsx
+++ b/frontends/bsd/src/components/export_logs_modal.test.tsx
@@ -62,7 +62,7 @@ test('renders no log file found when usb is mounted but no log file on machine',
   await advanceTimersAndPromises();
   getByText('No Log File Present');
   expect(logger.log).toHaveBeenCalledWith(
-    LogEventId.ExportLogFileFound,
+    LogEventId.SaveLogFileFound,
     'election_manager',
     expect.objectContaining({ disposition: 'failure' })
   );
@@ -129,7 +129,7 @@ test('renders save modal when usb is mounted and saves log file on machine', asy
   await advanceTimersAndPromises();
   getByText('Save Logs');
   expect(logger.log).toHaveBeenCalledWith(
-    LogEventId.ExportLogFileFound,
+    LogEventId.SaveLogFileFound,
     'election_manager',
     expect.objectContaining({ disposition: 'success' })
   );
@@ -187,7 +187,7 @@ test('renders save modal when usb is mounted and saves cdf log file on machine',
   await advanceTimersAndPromises();
   getByText('Save Logs');
   expect(logger.log).toHaveBeenCalledWith(
-    LogEventId.ExportLogFileFound,
+    LogEventId.SaveLogFileFound,
     'election_manager',
     expect.objectContaining({ disposition: 'success' })
   );

--- a/frontends/bsd/src/components/export_logs_modal.tsx
+++ b/frontends/bsd/src/components/export_logs_modal.tsx
@@ -62,18 +62,18 @@ export function ExportLogsModal({ onClose, logFileType }: Props): JSX.Element {
         const vxLogFile = allLogs.filter((f) => f.name === `${LOG_NAME}.log`);
         if (vxLogFile.length > 0) {
           setFoundLogFile(true);
-          await logger.log(LogEventId.ExportLogFileFound, userRole, {
+          await logger.log(LogEventId.SaveLogFileFound, userRole, {
             disposition: 'success',
             message:
-              'Successfully located vx-logs.log file on machine to export.',
+              'Successfully located vx-logs.log file on machine to save.',
           });
         } else {
           setFoundLogFile(false);
-          await logger.log(LogEventId.ExportLogFileFound, userRole, {
+          await logger.log(LogEventId.SaveLogFileFound, userRole, {
             disposition: 'failure',
             message:
               'Could not locate vx-logs.log file on machine. Machine is not configured for production use.',
-            result: 'Logs are not exportable.',
+            result: 'Logs are not saveable.',
           });
         }
         setIsLocatingLogFile(false);
@@ -117,7 +117,7 @@ export function ExportLogsModal({ onClose, logFileType }: Props): JSX.Element {
         });
 
         if (!fileWriter) {
-          throw new Error('could not begin download; no file was chosen');
+          throw new Error('could not save; no file was chosen');
         }
         await fileWriter.write(results);
 
@@ -227,7 +227,7 @@ export function ExportLogsModal({ onClose, logFileType }: Props): JSX.Element {
     case UsbDriveStatus.absent:
     case UsbDriveStatus.notavailable:
     case UsbDriveStatus.recentlyEjected:
-      // When run not through kiosk mode let the user download the file
+      // When run not through kiosk mode let the user save the file
       // on the machine for internal debugging use
       return (
         <Modal

--- a/frontends/bsd/src/components/export_results_modal.test.tsx
+++ b/frontends/bsd/src/components/export_results_modal.test.tsx
@@ -59,7 +59,7 @@ test('render no usb found screen when there is not a mounted usb drive', () => {
     );
     getByText('No USB Drive Detected');
     getByText(
-      'Please insert a USB drive in order to export the scanner results.'
+      'Please insert a USB drive in order to save the scanner results.'
     );
     getByAltText('Insert USB Image');
 
@@ -94,14 +94,14 @@ test('render export modal when a usb drive is mounted as expected and allows cus
     </Router>,
     { usbDriveStatus: UsbDriveStatus.mounted }
   );
-  getByText('Export Results');
+  getByText('Save Results');
   getByText(
     /A CVR file will automatically be saved to the default location on the mounted USB drive. /
   );
   getByAltText('Insert USB Image');
 
   fireEvent.click(getByText('Custom'));
-  await waitFor(() => getByText(/Download Complete/));
+  await waitFor(() => getByText('Results Saved'));
   await waitFor(() => {
     expect(saveAsFunction).toHaveBeenCalledTimes(1);
   });
@@ -131,10 +131,10 @@ test('render export modal when a usb drive is mounted as expected and allows aut
     />,
     { usbDriveStatus: UsbDriveStatus.mounted, history }
   );
-  getByText('Export Results');
+  getByText('Save Results');
 
-  fireEvent.click(getByText('Export'));
-  await waitFor(() => getByText(/Download Complete/));
+  fireEvent.click(getByText('Save'));
+  await waitFor(() => getByText('Results Saved'));
   await waitFor(() => {
     expect(mockKiosk.makeDirectory).toHaveBeenCalledTimes(1);
   });
@@ -202,11 +202,11 @@ test('render export modal with errors when appropriate', async () => {
     </Router>,
     { usbDriveStatus: UsbDriveStatus.mounted }
   );
-  getByText('Export Results');
+  getByText('Save Results');
 
   mockKiosk.getUsbDrives.mockRejectedValueOnce(new Error('NOPE'));
-  fireEvent.click(getByText('Export'));
-  await waitFor(() => getByText(/Download Failed/));
+  fireEvent.click(getByText('Save'));
+  await waitFor(() => getByText('Failed to Save Results'));
   getByText(/Failed to save results./);
   getByText(/NOPE/);
 

--- a/frontends/bsd/src/components/export_results_modal.tsx
+++ b/frontends/bsd/src/components/export_results_modal.tsx
@@ -66,7 +66,7 @@ export function ExportResultsModal({
     setCurrentState(ModalState.SAVING);
 
     try {
-      await logger.log(LogEventId.ExportCvrInit, userRole);
+      await logger.log(LogEventId.SaveCvrInit, userRole);
       const response = await fetch(`/scan/export`, {
         method: 'post',
       });
@@ -78,11 +78,11 @@ export function ExportResultsModal({
           `Failed to save results. Error retrieving CVRs from the VxCentralScan.`
         );
         setCurrentState(ModalState.ERROR);
-        await logger.log(LogEventId.ExportCvrComplete, userRole, {
+        await logger.log(LogEventId.SaveCvrComplete, userRole, {
           message:
-            'Error exporting CVR file, could not retrieve CVRs from the VxCentralScan.',
+            'Error saving CVR file, could not retrieve CVRs from the VxCentralScan.',
           error: 'Error retrieving CVRs from the VxCentralScan.',
-          result: 'User shown error, CVR file not exported.',
+          result: 'User shown error, CVR file not saved.',
           disposition: 'failure',
         });
         return;
@@ -98,9 +98,7 @@ export function ExportResultsModal({
       if (window.kiosk) {
         const usbPath = await usbstick.getDevicePath();
         if (!usbPath) {
-          throw new Error(
-            'could not begin download; path to usb drive missing'
-          );
+          throw new Error('could not save file; path to usb drive missing');
         }
         const electionFolderName = generateElectionBasedSubfolderName(
           electionDefinition.election,
@@ -118,7 +116,7 @@ export function ExportResultsModal({
           });
 
           if (!fileWriter) {
-            throw new Error('could not begin download; no file was chosen');
+            throw new Error('could not save; no file was chosen');
           }
 
           await fileWriter.write(await blob.text());
@@ -130,8 +128,8 @@ export function ExportResultsModal({
           await window.kiosk.writeFile(pathToFile, await blob.text());
         }
         setCurrentState(ModalState.DONE);
-        await logger.log(LogEventId.ExportCvrComplete, userRole, {
-          message: `Successfully exported CVR file with ${numberOfBallots} ballots.`,
+        await logger.log(LogEventId.SaveCvrComplete, userRole, {
+          message: `Successfully saved CVR file with ${numberOfBallots} ballots.`,
           disposition: 'success',
           numberOfBallots,
         });
@@ -143,10 +141,10 @@ export function ExportResultsModal({
       assert(error instanceof Error);
       setErrorMessage(`Failed to save results. ${error.message}`);
       setCurrentState(ModalState.ERROR);
-      await logger.log(LogEventId.ExportCvrComplete, userRole, {
-        message: 'Error exporting CVR file.',
+      await logger.log(LogEventId.SaveCvrComplete, userRole, {
+        message: 'Error saving CVR file.',
         error: error.message,
-        result: 'User shown error, CVR file not exported.',
+        result: 'User shown error, CVR file not saved.',
         disposition: 'failure',
       });
     }
@@ -157,7 +155,7 @@ export function ExportResultsModal({
       <Modal
         content={
           <Prose>
-            <h1>Download Failed</h1>
+            <h1>Failed to Save Results</h1>
             <p>{errorMessage}</p>
           </Prose>
         }
@@ -173,7 +171,7 @@ export function ExportResultsModal({
         <Modal
           content={
             <Prose>
-              <h1>Download Complete</h1>
+              <h1>Results Saved</h1>
               <p>
                 USB drive successfully ejected, you may now take it to VxAdmin
                 for tabulation.
@@ -189,7 +187,7 @@ export function ExportResultsModal({
       <Modal
         content={
           <Prose>
-            <h1>Download Complete</h1>
+            <h1>Results Saved</h1>
             <p>
               CVR results file saved successfully! You may now eject the USB
               drive and take it to VxAdmin for tabulation.
@@ -224,7 +222,7 @@ export function ExportResultsModal({
     case usbstick.UsbDriveStatus.absent:
     case usbstick.UsbDriveStatus.notavailable:
     case usbstick.UsbDriveStatus.recentlyEjected:
-      // When run not through kiosk mode let the user download the file
+      // When run not through kiosk mode let the user save the file
       // on the machine for internal debugging use
       return (
         <Modal
@@ -237,8 +235,7 @@ export function ExportResultsModal({
                   alt="Insert USB Image"
                   onDoubleClick={() => exportResults(true)}
                 />
-                Please insert a USB drive in order to export the scanner
-                results.
+                Please insert a USB drive in order to save the scanner results.
               </p>
             </Prose>
           }
@@ -250,7 +247,7 @@ export function ExportResultsModal({
                   data-testid="manual-export"
                   onPress={() => exportResults(true)}
                 >
-                  Export
+                  Save
                 </Button>
               )}
               <LinkButton onPress={onClose}>Cancel</LinkButton>
@@ -276,7 +273,7 @@ export function ExportResultsModal({
         <Modal
           content={
             <Prose>
-              <h1>Export Results</h1>
+              <h1>Save Results</h1>
               <UsbImage
                 src="/assets/usb-drive.svg"
                 alt="Insert USB Image"
@@ -284,8 +281,8 @@ export function ExportResultsModal({
               />
               <p>
                 A CVR file will automatically be saved to the default location
-                on the mounted USB drive. Optionally, you may pick a custom
-                export location.
+                on the mounted USB drive. Optionally, you may pick a custom save
+                location.
               </p>
             </Prose>
           }
@@ -293,7 +290,7 @@ export function ExportResultsModal({
           actions={
             <React.Fragment>
               <Button primary onPress={() => exportResults(false)}>
-                Export
+                Save
               </Button>
               <LinkButton onPress={onClose}>Cancel</LinkButton>
               <Button onPress={() => exportResults(true)}>Custom</Button>

--- a/frontends/bsd/src/screens/admin_actions_screen.test.tsx
+++ b/frontends/bsd/src/screens/admin_actions_screen.test.tsx
@@ -30,7 +30,7 @@ function renderScreen(props: Partial<AdminActionScreenProps> = {}) {
   );
 }
 
-test('clicking "Export Backup" shows progress', async () => {
+test('clicking "Save Backup" shows progress', async () => {
   const backup = jest.fn();
   renderScreen({ backup });
 

--- a/frontends/bsd/src/screens/admin_actions_screen.tsx
+++ b/frontends/bsd/src/screens/admin_actions_screen.tsx
@@ -75,17 +75,17 @@ export function AdminActionsScreen({
       setBackupError('');
       setIsBackingUp(true);
       await backup();
-      await logger.log(LogEventId.DownloadedScanImageBackup, userRole, {
+      await logger.log(LogEventId.SavedScanImageBackup, userRole, {
         disposition: 'success',
-        message: 'User successfully downloaded ballot data backup files.',
+        message: 'User successfully saved ballot data backup files.',
       });
     } catch (error) {
       assert(error instanceof Error);
       setBackupError(error.toString());
-      await logger.log(LogEventId.DownloadedScanImageBackup, userRole, {
+      await logger.log(LogEventId.SavedScanImageBackup, userRole, {
         disposition: 'failure',
-        message: `Error downloading ballot data backup: ${error.message}`,
-        result: 'No backup downloaded.',
+        message: `Error saving ballot data backup: ${error.message}`,
+        result: 'No backup saved.',
       });
     } finally {
       setIsBackingUp(false);
@@ -146,10 +146,10 @@ export function AdminActionsScreen({
             </p>
             <p>
               <Button onPress={() => setExportingLogType(LogFileType.Raw)}>
-                Export Logs
+                Save Logs
               </Button>{' '}
               <Button onPress={() => setExportingLogType(LogFileType.Cdf)}>
-                Export Logs as CDF
+                Save Logs as CDF
               </Button>
             </p>
             <p>

--- a/frontends/bsd/src/screens/load_election_screen.tsx
+++ b/frontends/bsd/src/screens/load_election_screen.tsx
@@ -163,7 +163,7 @@ export function LoadElectionScreen({
         <Main padded centerChild>
           <Prose textCenter>
             <h1>
-              Uploading ballot package {currentUploadingBallotIndex + 1} of{' '}
+              Loading ballot package {currentUploadingBallotIndex + 1} of{' '}
               {totalTemplates}
             </h1>
             <ul style={{ textAlign: 'left' }}>

--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -167,19 +167,18 @@ test('create election works', async () => {
   fireEvent.click(getByText('Ballots'));
   fireEvent.click(getAllByText('View Ballot')[0]);
 
-  // You can view the advanced screen and export log files when there is an election.
+  // You can view the advanced screen and save log files when there is an election.
   fireEvent.click(screen.getByText('Advanced'));
-  fireEvent.click(screen.getByText('Export Log File'));
+  fireEvent.click(screen.getByText('Save Log File'));
   await screen.findByText('No Log File Present');
   fireEvent.click(screen.getByText('Close'));
-  fireEvent.click(screen.getByText('Export Log File as CDF'));
+  fireEvent.click(screen.getByText('Save Log File as CDF'));
   await screen.findByText('No Log File Present');
 
   fireEvent.click(getByText('Definition'));
 
   // Verify editing an election is disabled
   fireEvent.click(getByText('View Definition JSON'));
-  expect(queryAllByText('Save').length).toBe(0);
   expect(queryAllByText('Reset').length).toBe(0);
   expect(getByTestId('json-input').hasAttribute('disabled')).toBe(true);
 
@@ -192,13 +191,13 @@ test('create election works', async () => {
     expect.stringContaining(LogEventId.ElectionUnconfigured)
   );
 
-  // You can view the advanced screen and export log files when there is no election.
+  // You can view the advanced screen and save log files when there is no election.
   fireEvent.click(screen.getByText('Advanced'));
-  fireEvent.click(screen.getByText('Export Log File'));
+  fireEvent.click(screen.getByText('Save Log File'));
   await screen.findByText('No Log File Present');
   fireEvent.click(screen.getByText('Close'));
-  fireEvent.click(screen.getByText('Export Log File as CDF'));
-  // You can not export as CDF when there is no election.
+  fireEvent.click(screen.getByText('Save Log File as CDF'));
+  // You can not save as CDF when there is no election.
   expect(screen.queryAllByText('No Log File Present')).toHaveLength(0);
 
   fireEvent.click(screen.getByText('Configure'));
@@ -538,7 +537,7 @@ test('tabulating CVRs', async () => {
 
   fireEvent.click(getByText('Show Results by Batch and Scanner'));
   getByText('Batch Name');
-  fireEvent.click(getByText('Export Batch Results as CSV'));
+  fireEvent.click(getByText('Save Batch Results as CSV'));
   jest.advanceTimersByTime(2000);
   getByText('Save Batch Results');
   getByText(/Save the election batch results as /);
@@ -637,7 +636,7 @@ test('tabulating CVRs', async () => {
   // Confirm that L&A Materials are unavailable after live CVRs have been loaded
   fireEvent.click(getByText('L&A'));
   getByText(
-    'L&A testing documents are not available after official election CVRs have been imported.',
+    'L&A testing documents are not available after official election CVRs have been loaded.',
     { exact: false }
   );
   expect(queryByText('List Precinct L&A Packages')).not.toBeInTheDocument();
@@ -724,7 +723,7 @@ test('tabulating CVRs with SEMS file', async () => {
   ).toMatchSnapshot();
   fireEvent.click(getByText('Back to Reports'));
 
-  // Test exporting the final results
+  // Test saving the final results
   fetchMock.post('/convert/tallies/submitfile', { body: { status: 'ok' } });
   fetchMock.post('/convert/tallies/process', { body: { status: 'ok' } });
 
@@ -1062,7 +1061,7 @@ test('clearing all files after marking as official clears SEMS, CVR, and manual 
   getByText('Official Full Election Tally Report');
 
   fireEvent.click(getByText('Tally'));
-  expect(getByText('Import CVR Files').closest('button')).toBeDisabled();
+  expect(getByText('Load CVR Files').closest('button')).toBeDisabled();
   expect(getByText('Remove CVR Files').closest('button')).toBeDisabled();
   expect(
     getByText('Edit Manually Entered Results').closest('button')
@@ -1075,12 +1074,12 @@ test('clearing all files after marking as official clears SEMS, CVR, and manual 
 
   fireEvent.click(getByText('Clear All Tallies and Results'));
   getByText(
-    'Do you want to remove the 1 uploaded CVR file, the external results file sems-results.csv, and the manually entered data?'
+    'Do you want to remove the 1 loaded CVR file, the external results file sems-results.csv, and the manually entered data?'
   );
   fireEvent.click(getByText('Remove All Data'));
 
   await waitFor(() => {
-    expect(getByText('Import CVR Files').closest('button')).toBeEnabled();
+    expect(getByText('Load CVR Files').closest('button')).toBeEnabled();
   });
   expect(
     getByText('Add Manually Entered Results').closest('button')
@@ -1286,7 +1285,7 @@ test('system administrator Ballots tab and election manager Ballots tab have exp
   );
   screen.getByText('Print All');
   expect(screen.queryByText('Save PDFs')).not.toBeInTheDocument();
-  expect(screen.queryByText('Export Package')).not.toBeInTheDocument();
+  expect(screen.queryByText('Save Package')).not.toBeInTheDocument();
 
   // View super ballot
   userEvent.click(viewBallotButtons[0]);
@@ -1340,7 +1339,7 @@ test('system administrator Ballots tab and election manager Ballots tab have exp
   expect(viewBallotButtons).toHaveLength(numPrecinctBallots);
   screen.getByText('Print All');
   screen.getByText('Save PDFs');
-  screen.getByText('Export Package');
+  screen.getByText('Save Package');
 
   userEvent.click(viewBallotButtons[0]);
   await screen.findByRole('heading', {

--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -1285,7 +1285,7 @@ test('system administrator Ballots tab and election manager Ballots tab have exp
   );
   screen.getByText('Print All');
   expect(screen.queryByText('Save PDFs')).not.toBeInTheDocument();
-  expect(screen.queryByText('Save Package')).not.toBeInTheDocument();
+  expect(screen.queryByText('Save Ballot Package')).not.toBeInTheDocument();
 
   // View super ballot
   userEvent.click(viewBallotButtons[0]);
@@ -1339,7 +1339,7 @@ test('system administrator Ballots tab and election manager Ballots tab have exp
   expect(viewBallotButtons).toHaveLength(numPrecinctBallots);
   screen.getByText('Print All');
   screen.getByText('Save PDFs');
-  screen.getByText('Save Package');
+  screen.getByText('Save Ballot Package');
 
   userEvent.click(viewBallotButtons[0]);
   await screen.findByRole('heading', {

--- a/frontends/election-manager/src/app_root.tsx
+++ b/frontends/election-manager/src/app_root.tsx
@@ -209,7 +209,7 @@ export function AppRoot({
     setIsOfficialResults(true);
     await logger.log(LogEventId.MarkedTallyResultsOfficial, currentUserRole, {
       message:
-        'User has marked the tally results as official, no more Cvr files can be imported.',
+        'User has marked the tally results as official, no more Cvr files can be loaded.',
       disposition: 'success',
     });
     await setStorageKeyAndLog(
@@ -419,12 +419,12 @@ export function AppRoot({
         await setStorageKeyAndLog(
           externalVoteTalliesFileStorageKey,
           convertExternalTalliesToStorageString(externalTallies),
-          'Imported tally data from external file formats'
+          'Loaded tally data from external file formats'
         );
       } else {
         await removeStorageKeyAndLog(
           externalVoteTalliesFileStorageKey,
-          'Imported tally data from external files'
+          'Loaded tally data from external files'
         );
       }
     },

--- a/frontends/election-manager/src/components/confirm_removing_file_modal.tsx
+++ b/frontends/election-manager/src/components/confirm_removing_file_modal.tsx
@@ -42,7 +42,7 @@ export function ConfirmRemovingFileModal({
         <React.Fragment>
           {fileList.length ? (
             <p>
-              Do you want to remove the {fileList.length} uploaded CVR{' '}
+              Do you want to remove the {fileList.length} loaded CVR{' '}
               {pluralize('files', fileList.length)}?
             </p>
           ) : (
@@ -88,7 +88,7 @@ export function ConfirmRemovingFileModal({
       mainContent = (
         <React.Fragment>
           <p>
-            Do you want to remove the {fileList.length} uploaded CVR{' '}
+            Do you want to remove the {fileList.length} loaded CVR{' '}
             {pluralize('files', fileList.length)}
             {externalDetails}?
           </p>

--- a/frontends/election-manager/src/components/export_ballot_pdfs_button.test.tsx
+++ b/frontends/election-manager/src/components/export_ballot_pdfs_button.test.tsx
@@ -81,10 +81,10 @@ test('modal happy path flow works', async () => {
 
   userEvent.click(screen.getByText('Save PDFs'));
   const modal = await screen.findByRole('alertdialog');
-  userEvent.click(within(modal).getByText('Export'));
+  userEvent.click(within(modal).getByText('Save'));
   await within(modal).findByText('Generating Ballot PDFs…');
-  await within(modal).findByText('Finishing Export…');
-  await within(modal).findByText('Export Complete');
+  await within(modal).findByText('Saving…');
+  await within(modal).findByText('Ballot PDFs Saved');
 
   assert(window.kiosk);
   expect(window.kiosk.makeDirectory).toHaveBeenCalledTimes(1);
@@ -105,7 +105,7 @@ test('modal happy path flow works', async () => {
   expect(screen.queryByRole('alertdialog')).toBeNull();
 });
 
-test('can select options to export different ballots', async () => {
+test('can select options to save different ballots', async () => {
   renderInAppContext(<ExportBallotPdfsButton />, {
     usbDriveStatus: UsbDriveStatus.mounted,
   });
@@ -114,8 +114,8 @@ test('can select options to export different ballots', async () => {
   const modal = await screen.findByRole('alertdialog');
   userEvent.click(within(modal).getByText('Absentee'));
   userEvent.click(within(modal).getByText('Sample'));
-  userEvent.click(within(modal).getByText('Export'));
-  await within(modal).findByText('Export Complete');
+  userEvent.click(within(modal).getByText('Save'));
+  await within(modal).findByText('Ballot PDFs Saved');
 
   expect(window.kiosk!.writeFile).toHaveBeenCalledWith(
     'fake mount point/ballot-pdfs/ballot-pdfs-election-b1e83122e8-sample-absentee.zip'
@@ -132,7 +132,7 @@ test('modal custom flow works', async () => {
   const modal = await screen.findByRole('alertdialog');
 
   userEvent.click(within(modal).getByText('Custom'));
-  await within(modal).findByText('Export Complete');
+  await within(modal).findByText('Ballot PDFs Saved');
   expect(window.kiosk!.saveAs).toHaveBeenCalledTimes(1);
   expect(logger.log).toHaveBeenCalledWith(
     LogEventId.FileSaved,
@@ -152,8 +152,8 @@ test('modal renders error message appropriately', async () => {
 
   userEvent.click(within(modal).getByText('Custom'));
 
-  await within(modal).findByText('Export Failed');
+  await within(modal).findByText('Failed to Save Ballot PDFs');
   expect(modal).toBeInTheDocument();
   within(modal).getByText(/An error occurred:/);
-  within(modal).getByText(/could not begin download; no file was chosen/);
+  within(modal).getByText(/could not save; no file was chosen/);
 });

--- a/frontends/election-manager/src/components/export_ballot_pdfs_button.tsx
+++ b/frontends/election-manager/src/components/export_ballot_pdfs_button.tsx
@@ -178,8 +178,8 @@ export function ExportBallotPdfsButton(): JSX.Element {
       setModalError(error);
       await logger.log(LogEventId.FileSaved, userRole, {
         disposition: 'failure',
-        message: `Error exporting ballot PDFs: ${error}`,
-        result: 'Ballot PDFs not exported, error shown to user.',
+        message: `Error saving ballot PDFs: ${error}`,
+        result: 'Ballot PDFs not saved, error shown to user.',
       });
     }
   }
@@ -200,10 +200,10 @@ export function ExportBallotPdfsButton(): JSX.Element {
                 <UsbImage
                   src="/assets/usb-drive.svg"
                   alt="Insert USB Image"
-                  // hidden feature to export with file dialog by double-clicking
+                  // hidden feature to save with file dialog by double-clicking
                   onDoubleClick={() => saveFileCallback(true)}
                 />
-                Please insert a USB drive in order to export the ballot PDF
+                Please insert a USB drive in order to save the ballot PDF
                 archive.
               </p>
             </Prose>
@@ -224,9 +224,9 @@ export function ExportBallotPdfsButton(): JSX.Element {
             <Prose>
               <h1>Save Ballot PDFs</h1>
               <p>
-                The export will include a PDF for each ballot style of the
-                current election. Select the type of ballots you would like to
-                export:
+                The saved zip file will include a PDF for each ballot style of
+                the current election. Select the type of ballots you would like
+                to save:
               </p>
               <CenteredOptions>
                 <p>
@@ -246,14 +246,14 @@ export function ExportBallotPdfsButton(): JSX.Element {
               <p>
                 A zip archive will automatically be saved to the default
                 location on the mounted USB drive. Optionally, you may pick a
-                custom export location.
+                custom save location.
               </p>
             </Prose>
           );
           actions = (
             <React.Fragment>
               <Button primary onPress={() => saveFileCallback(false)}>
-                Export
+                Save
               </Button>
               <LinkButton onPress={closeModal}>Cancel</LinkButton>
               <Button onPress={() => saveFileCallback(true)}>Custom</Button>
@@ -296,7 +296,7 @@ export function ExportBallotPdfsButton(): JSX.Element {
       mainContent = (
         <Prose textCenter>
           <h1>
-            <strong>Finishing Export…</strong>
+            <strong>Saving…</strong>
           </h1>
         </Prose>
       );
@@ -306,7 +306,7 @@ export function ExportBallotPdfsButton(): JSX.Element {
     case 'Done': {
       mainContent = (
         <Prose>
-          <h1>Export Complete</h1>
+          <h1>Ballot PDFs Saved</h1>
           <p>You may now eject the USB drive.</p>
         </Prose>
       );
@@ -331,7 +331,7 @@ export function ExportBallotPdfsButton(): JSX.Element {
     case 'Error': {
       mainContent = (
         <Prose>
-          <h1>Export Failed</h1>
+          <h1>Failed to Save Ballot PDFs</h1>
           <p>An error occurred: {modalError && modalError.message}.</p>
         </Prose>
       );

--- a/frontends/election-manager/src/components/export_batch_tally_results_button.tsx
+++ b/frontends/election-manager/src/components/export_batch_tally_results_button.tsx
@@ -23,7 +23,7 @@ export function ExportBatchTallyResultsButton(): JSX.Element {
   return (
     <React.Fragment>
       <Button small onPress={() => setIsSaveModalOpen(true)}>
-        Export Batch Results as CSV
+        Save Batch Results as CSV
       </Button>
       {isSaveModalOpen && (
         <SaveFileToUsb

--- a/frontends/election-manager/src/components/export_election_ballot_package_modal_button.test.tsx
+++ b/frontends/election-manager/src/components/export_election_ballot_package_modal_button.test.tsx
@@ -84,7 +84,7 @@ test('Button renders properly when not clicked', () => {
     <ExportElectionBallotPackageModalButton />
   );
 
-  expect(queryByText('Save Package')).toHaveProperty('type', 'button');
+  expect(queryByText('Save Ballot Package')).toHaveProperty('type', 'button');
   expect(queryByTestId('modal')).toBeNull();
 });
 
@@ -105,7 +105,7 @@ test('Modal renders insert usb screen appropriately', async () => {
     } = renderInAppContext(<ExportElectionBallotPackageModalButton />, {
       usbDriveStatus: usbStatus,
     });
-    fireEvent.click(getByText('Save Package'));
+    fireEvent.click(getByText('Save Ballot Package'));
     await waitFor(() => getByText('No USB Drive Detected'));
     expect(queryAllByAltText('Insert USB Image')).toHaveLength(1);
     expect(queryAllByTestId('modal')).toHaveLength(1);
@@ -134,7 +134,7 @@ test('Modal renders export confirmation screen when usb detected and manual link
     usbDriveStatus: UsbDriveStatus.mounted,
     logger,
   });
-  fireEvent.click(getByText('Save Package'));
+  fireEvent.click(getByText('Save Ballot Package'));
   await findByText('Save Ballot Package');
   expect(queryAllByAltText('Insert USB Image')).toHaveLength(1);
   expect(queryAllByTestId('modal')).toHaveLength(1);
@@ -184,7 +184,7 @@ test('Modal renders loading screen when usb drive is mounting or ejecting', asyn
         usbDriveStatus: usbStatus,
       }
     );
-    fireEvent.click(getByText('Save Package'));
+    fireEvent.click(getByText('Save Ballot Package'));
     await waitFor(() => getByText('Loading'));
 
     expect(queryAllByTestId('modal')).toHaveLength(1);
@@ -204,7 +204,7 @@ test('Modal renders error message appropriately', async () => {
       logger,
     }
   );
-  fireEvent.click(getByText('Save Package'));
+  fireEvent.click(getByText('Save Ballot Package'));
   await waitFor(() => getByText('Save'));
 
   fireEvent.click(getByText('Custom'));
@@ -236,7 +236,7 @@ test('Modal renders renders loading message while rendering ballots appropriatel
       usbDriveEject: ejectFunction,
     }
   );
-  fireEvent.click(getByText('Save Package'));
+  fireEvent.click(getByText('Save Ballot Package'));
   await waitFor(() => getByText('Save'));
 
   fireEvent.click(getByText('Save'));

--- a/frontends/election-manager/src/components/export_election_ballot_package_modal_button.test.tsx
+++ b/frontends/election-manager/src/components/export_election_ballot_package_modal_button.test.tsx
@@ -84,7 +84,7 @@ test('Button renders properly when not clicked', () => {
     <ExportElectionBallotPackageModalButton />
   );
 
-  expect(queryByText('Export Package')).toHaveProperty('type', 'button');
+  expect(queryByText('Save Package')).toHaveProperty('type', 'button');
   expect(queryByTestId('modal')).toBeNull();
 });
 
@@ -105,13 +105,13 @@ test('Modal renders insert usb screen appropriately', async () => {
     } = renderInAppContext(<ExportElectionBallotPackageModalButton />, {
       usbDriveStatus: usbStatus,
     });
-    fireEvent.click(getByText('Export Package'));
+    fireEvent.click(getByText('Save Package'));
     await waitFor(() => getByText('No USB Drive Detected'));
     expect(queryAllByAltText('Insert USB Image')).toHaveLength(1);
     expect(queryAllByTestId('modal')).toHaveLength(1);
     expect(
       queryAllByText(
-        'Please insert a USB drive in order to export the ballot configuration.'
+        'Please insert a USB drive in order to save the ballot configuration.'
       )
     ).toHaveLength(1);
 
@@ -134,8 +134,8 @@ test('Modal renders export confirmation screen when usb detected and manual link
     usbDriveStatus: UsbDriveStatus.mounted,
     logger,
   });
-  fireEvent.click(getByText('Export Package'));
-  await findByText('Export Ballot Package');
+  fireEvent.click(getByText('Save Package'));
+  await findByText('Save Ballot Package');
   expect(queryAllByAltText('Insert USB Image')).toHaveLength(1);
   expect(queryAllByTestId('modal')).toHaveLength(1);
   expect(
@@ -144,11 +144,11 @@ test('Modal renders export confirmation screen when usb detected and manual link
     )
   ).toHaveLength(1);
   expect(
-    queryAllByText(/Optionally, you may pick a custom export location./)
+    queryAllByText(/Optionally, you may pick a custom save location./)
   ).toHaveLength(1);
 
   fireEvent.click(getByText('Custom'));
-  await waitFor(() => getByText(/Download Complete/));
+  await waitFor(() => getByText('Ballot Package Saved'));
   await waitFor(() => {
     expect(interpretTemplate).toHaveBeenCalledTimes(
       2 /* pages per ballot */ *
@@ -161,11 +161,11 @@ test('Modal renders export confirmation screen when usb detected and manual link
     expect(window.kiosk!.saveAs).toHaveBeenCalledTimes(1);
   });
   expect(logger.log).toHaveBeenCalledWith(
-    LogEventId.ExportBallotPackageInit,
+    LogEventId.SaveBallotPackageInit,
     'election_manager'
   );
   expect(logger.log).toHaveBeenCalledWith(
-    LogEventId.ExportBallotPackageComplete,
+    LogEventId.SaveBallotPackageComplete,
     'election_manager',
     expect.objectContaining({ disposition: 'success' })
   );
@@ -184,7 +184,7 @@ test('Modal renders loading screen when usb drive is mounting or ejecting', asyn
         usbDriveStatus: usbStatus,
       }
     );
-    fireEvent.click(getByText('Export Package'));
+    fireEvent.click(getByText('Save Package'));
     await waitFor(() => getByText('Loading'));
 
     expect(queryAllByTestId('modal')).toHaveLength(1);
@@ -204,26 +204,24 @@ test('Modal renders error message appropriately', async () => {
       logger,
     }
   );
-  fireEvent.click(getByText('Export Package'));
-  await waitFor(() => getByText('Export'));
+  fireEvent.click(getByText('Save Package'));
+  await waitFor(() => getByText('Save'));
 
   fireEvent.click(getByText('Custom'));
 
-  await waitFor(() => getByText(/Download Failed/));
+  await waitFor(() => getByText('Failed to Save Ballot Package'));
   expect(queryAllByTestId('modal')).toHaveLength(1);
   expect(queryAllByText(/An error occurred:/)).toHaveLength(1);
-  expect(
-    queryAllByText(/could not begin download; no file was chosen/)
-  ).toHaveLength(1);
+  expect(queryAllByText(/could not save; no file was chosen/)).toHaveLength(1);
 
   fireEvent.click(getByText('Close'));
   expect(queryAllByTestId('modal')).toHaveLength(0);
   expect(logger.log).toHaveBeenCalledWith(
-    LogEventId.ExportBallotPackageInit,
+    LogEventId.SaveBallotPackageInit,
     'election_manager'
   );
   expect(logger.log).toHaveBeenCalledWith(
-    LogEventId.ExportBallotPackageComplete,
+    LogEventId.SaveBallotPackageComplete,
     'election_manager',
     expect.objectContaining({ disposition: 'failure' })
   );
@@ -238,19 +236,19 @@ test('Modal renders renders loading message while rendering ballots appropriatel
       usbDriveEject: ejectFunction,
     }
   );
-  fireEvent.click(getByText('Export Package'));
-  await waitFor(() => getByText('Export'));
+  fireEvent.click(getByText('Save Package'));
+  await waitFor(() => getByText('Save'));
 
-  fireEvent.click(getByText('Export'));
+  fireEvent.click(getByText('Save'));
 
-  await waitFor(() => getByText(/Download Complete/));
+  await waitFor(() => getByText('Ballot Package Saved'));
   expect(window.kiosk!.writeFile).toHaveBeenCalledTimes(1);
   expect(window.kiosk!.makeDirectory).toHaveBeenCalledTimes(1);
 
   expect(queryAllByTestId('modal')).toHaveLength(1);
   expect(
     queryByText(
-      'You may now eject the USB drive. Use the exported ballot package on this USB drive to configure VxScan or VxCentralScan.'
+      'You may now eject the USB drive. Use the saved ballot package on this USB drive to configure VxScan or VxCentralScan.'
     )
   ).toBeInTheDocument();
 

--- a/frontends/election-manager/src/components/export_election_ballot_package_modal_button.tsx
+++ b/frontends/election-manager/src/components/export_election_ballot_package_modal_button.tsx
@@ -386,7 +386,7 @@ export function ExportElectionBallotPackageModalButton(): JSX.Element {
   return (
     <React.Fragment>
       <LinkButton small onPress={() => setIsModalOpen(true)}>
-        Save Package
+        Save Ballot Package
       </LinkButton>
       {isModalOpen && (
         <Modal

--- a/frontends/election-manager/src/components/export_election_ballot_package_modal_button.tsx
+++ b/frontends/election-manager/src/components/export_election_ballot_package_modal_button.tsx
@@ -78,9 +78,9 @@ export function ExportElectionBallotPackageModalButton(): JSX.Element {
         case 'ArchiveEnd': {
           await state.archive.end();
           setState(workflow.next);
-          await logger.log(LogEventId.ExportBallotPackageComplete, userRole, {
+          await logger.log(LogEventId.SaveBallotPackageComplete, userRole, {
             disposition: 'success',
-            message: 'Finished successfully exporting ballot package.',
+            message: 'Finished successfully saving ballot package.',
           });
           break;
         }
@@ -159,7 +159,7 @@ export function ExportElectionBallotPackageModalButton(): JSX.Element {
     assert(state.type === 'ArchiveBegin');
     // TODO(auth) check proper file permissions
     try {
-      await logger.log(LogEventId.ExportBallotPackageInit, userRole);
+      await logger.log(LogEventId.SaveBallotPackageInit, userRole);
       const usbPath = await usbstick.getDevicePath();
       const pathToFolder = usbPath && join(usbPath, BALLOT_PACKAGE_FOLDER);
       const pathToFile = join(pathToFolder ?? '.', defaultFileName);
@@ -180,10 +180,10 @@ export function ExportElectionBallotPackageModalButton(): JSX.Element {
     } catch (error) {
       assert(error instanceof Error);
       setState(workflow.error(state, error));
-      await logger.log(LogEventId.ExportBallotPackageComplete, userRole, {
+      await logger.log(LogEventId.SaveBallotPackageComplete, userRole, {
         disposition: 'failure',
-        message: `Error exporting ballot package: ${error}`,
-        result: 'Ballot package not exported, error shown to user.',
+        message: `Error saving ballot package: ${error}`,
+        result: 'Ballot package not saved, error shown to user.',
       });
     }
   }
@@ -215,10 +215,10 @@ export function ExportElectionBallotPackageModalButton(): JSX.Element {
                 <UsbImage
                   src="/assets/usb-drive.svg"
                   alt="Insert USB Image"
-                  // hidden feature to export with file dialog by double-clicking
+                  // hidden feature to save with file dialog by double-clicking
                   onDoubleClick={() => saveFileCallback(true)}
                 />
-                Please insert a USB drive in order to export the ballot
+                Please insert a USB drive in order to save the ballot
                 configuration.
               </p>
             </Prose>
@@ -237,7 +237,7 @@ export function ExportElectionBallotPackageModalButton(): JSX.Element {
           actions = (
             <React.Fragment>
               <Button primary onPress={() => saveFileCallback(false)}>
-                Export
+                Save
               </Button>
               <LinkButton onPress={closeModal}>Cancel</LinkButton>
               <Button onPress={() => saveFileCallback(true)}>Custom</Button>
@@ -245,12 +245,12 @@ export function ExportElectionBallotPackageModalButton(): JSX.Element {
           );
           mainContent = (
             <Prose>
-              <h1>Export Ballot Package</h1>
+              <h1>Save Ballot Package</h1>
               <p>
                 <UsbImage src="/assets/usb-drive.svg" alt="Insert USB Image" />A
                 zip archive will automatically be saved to the default location
-                on the mounted USB drive. Optionally, you may pick a custom
-                export location.
+                on the mounted USB drive. Optionally, you may pick a custom save
+                location.
               </p>
             </Prose>
           );
@@ -329,7 +329,7 @@ export function ExportElectionBallotPackageModalButton(): JSX.Element {
       );
       mainContent = (
         <Prose>
-          <h1>Finishing Download…</h1>
+          <h1>Saving…</h1>
           <p>
             Rendered {pluralize('ballot', state.ballotConfigsCount, true)},
             closing zip file.
@@ -357,9 +357,9 @@ export function ExportElectionBallotPackageModalButton(): JSX.Element {
       }
       mainContent = (
         <Prose>
-          <h1>Download Complete</h1>
+          <h1>Ballot Package Saved</h1>
           <p>
-            You may now eject the USB drive. Use the exported ballot package on
+            You may now eject the USB drive. Use the saved ballot package on
             this USB drive to configure VxScan or VxCentralScan.
           </p>
         </Prose>
@@ -371,7 +371,7 @@ export function ExportElectionBallotPackageModalButton(): JSX.Element {
       actions = <LinkButton onPress={closeModal}>Close</LinkButton>;
       mainContent = (
         <Prose>
-          <h1>Download Failed</h1>
+          <h1>Failed to Save Ballot Package</h1>
           <p>An error occurred: {state.message}.</p>
         </Prose>
       );
@@ -386,7 +386,7 @@ export function ExportElectionBallotPackageModalButton(): JSX.Element {
   return (
     <React.Fragment>
       <LinkButton small onPress={() => setIsModalOpen(true)}>
-        Export Package
+        Save Package
       </LinkButton>
       {isModalOpen && (
         <Modal

--- a/frontends/election-manager/src/components/export_logs_modal.test.tsx
+++ b/frontends/election-manager/src/components/export_logs_modal.test.tsx
@@ -62,7 +62,7 @@ test('renders no log file found when usb is mounted but no log file on machine',
   await advanceTimersAndPromises();
   getByText('No Log File Present');
   expect(logger.log).toHaveBeenCalledWith(
-    LogEventId.ExportLogFileFound,
+    LogEventId.SaveLogFileFound,
     'election_manager',
     expect.objectContaining({ disposition: 'failure' })
   );
@@ -129,7 +129,7 @@ test('renders save modal when usb is mounted and saves log file on machine', asy
   await advanceTimersAndPromises();
   getByText('Save Logs');
   expect(logger.log).toHaveBeenCalledWith(
-    LogEventId.ExportLogFileFound,
+    LogEventId.SaveLogFileFound,
     'election_manager',
     expect.objectContaining({ disposition: 'success' })
   );
@@ -187,7 +187,7 @@ test('renders save modal when usb is mounted and saves cdf log file on machine',
   await advanceTimersAndPromises();
   getByText('Save Logs');
   expect(logger.log).toHaveBeenCalledWith(
-    LogEventId.ExportLogFileFound,
+    LogEventId.SaveLogFileFound,
     'election_manager',
     expect.objectContaining({ disposition: 'success' })
   );

--- a/frontends/election-manager/src/components/export_logs_modal.tsx
+++ b/frontends/election-manager/src/components/export_logs_modal.tsx
@@ -62,18 +62,18 @@ export function ExportLogsModal({ onClose, logFileType }: Props): JSX.Element {
         const vxLogFile = allLogs.filter((f) => f.name === `${LOG_NAME}.log`);
         if (vxLogFile.length > 0) {
           setFoundLogFile(true);
-          await logger.log(LogEventId.ExportLogFileFound, userRole, {
+          await logger.log(LogEventId.SaveLogFileFound, userRole, {
             disposition: 'success',
             message:
-              'Successfully located vx-logs.log file on machine to export.',
+              'Successfully located vx-logs.log file on machine to save.',
           });
         } else {
           setFoundLogFile(false);
-          await logger.log(LogEventId.ExportLogFileFound, userRole, {
+          await logger.log(LogEventId.SaveLogFileFound, userRole, {
             disposition: 'failure',
             message:
               'Could not locate vx-logs.log file on machine. Machine is not configured for production use.',
-            result: 'Logs are not exportable.',
+            result: 'Logs are not saveable.',
           });
         }
         setIsLocatingLogFile(false);
@@ -117,7 +117,7 @@ export function ExportLogsModal({ onClose, logFileType }: Props): JSX.Element {
         });
 
         if (!fileWriter) {
-          throw new Error('could not begin download; no file was chosen');
+          throw new Error('could not save; no file was chosen');
         }
         await fileWriter.write(results);
 
@@ -227,7 +227,7 @@ export function ExportLogsModal({ onClose, logFileType }: Props): JSX.Element {
     case UsbDriveStatus.absent:
     case UsbDriveStatus.notavailable:
     case UsbDriveStatus.recentlyEjected:
-      // When run not through kiosk mode let the user download the file
+      // When run not through kiosk mode let the user save the file
       // on the machine for internal debugging use
       return (
         <Modal

--- a/frontends/election-manager/src/components/import_cvrfiles_modal.test.tsx
+++ b/frontends/election-manager/src/components/import_cvrfiles_modal.test.tsx
@@ -94,11 +94,11 @@ describe('Screens display properly when USB is mounted', () => {
     fireEvent.click(getByText('Cancel'));
     expect(closeFn).toHaveBeenCalledTimes(1);
 
-    // You can still manually import files
+    // You can still manually load files
     fireEvent.change(getByTestId('manual-input'), {
       target: { files: [new File([''], 'file.jsonl')] },
     });
-    await waitFor(() => getByText('0 new CVRs Imported'));
+    await waitFor(() => getByText('0 new CVRs Loaded'));
     expect(saveCvr).toHaveBeenCalledTimes(1);
     expect(logger.log).toHaveBeenCalledWith(
       LogEventId.CvrFilesReadFromUsb,
@@ -107,7 +107,7 @@ describe('Screens display properly when USB is mounted', () => {
     );
   });
 
-  test('Import CVR files screen shows table with test and live CVRs', async () => {
+  test('Load CVR files screen shows table with test and live CVRs', async () => {
     const closeFn = jest.fn();
     const saveCvr = jest.fn();
     const fileEntries = [
@@ -139,7 +139,7 @@ describe('Screens display properly when USB is mounted', () => {
         logger,
       }
     );
-    await waitFor(() => getByText('Import CVR Files'));
+    await waitFor(() => getByText('Load CVR Files'));
     getByText(
       /The following CVR files were automatically found on this USB drive./
     );
@@ -148,19 +148,19 @@ describe('Screens display properly when USB is mounted', () => {
     expect(tableRows).toHaveLength(3);
     domGetByText(tableRows[0], '12/09/2020 03:59:32 PM');
     domGetByText(tableRows[0], '0002');
-    expect(
-      domGetByText(tableRows[0], 'Import').closest('button')!.disabled
-    ).toBe(false);
+    expect(domGetByText(tableRows[0], 'Load').closest('button')!.disabled).toBe(
+      false
+    );
     domGetByText(tableRows[1], '12/09/2020 03:49:32 PM');
     domGetByText(tableRows[1], '0001');
-    expect(
-      domGetByText(tableRows[1], 'Import').closest('button')!.disabled
-    ).toBe(false);
+    expect(domGetByText(tableRows[1], 'Load').closest('button')!.disabled).toBe(
+      false
+    );
     domGetByText(tableRows[2], '12/07/2020 03:49:32 PM');
     domGetByText(tableRows[2], '0003');
-    expect(
-      domGetByText(tableRows[2], 'Import').closest('button')!.disabled
-    ).toBe(false);
+    expect(domGetByText(tableRows[2], 'Load').closest('button')!.disabled).toBe(
+      false
+    );
     expect(window.kiosk!.readFile).toHaveBeenCalledTimes(3); // The files should have been read.
     expect(logger.log).toHaveBeenCalledWith(
       LogEventId.CvrFilesReadFromUsb,
@@ -171,15 +171,15 @@ describe('Screens display properly when USB is mounted', () => {
     fireEvent.click(getByText('Cancel'));
     expect(closeFn).toHaveBeenCalledTimes(1);
 
-    fireEvent.click(domGetByText(tableRows[0], 'Import'));
+    fireEvent.click(domGetByText(tableRows[0], 'Load'));
     getByText('Loading');
     await waitFor(() => {
       expect(saveCvr).toHaveBeenCalledTimes(1);
       // We should not need to read the file another time since it was already read.
       expect(window.kiosk!.readFile).toHaveBeenCalledTimes(3);
-      getByText('0 new CVRs Imported');
+      getByText('0 new CVRs Loaded');
       expect(logger.log).toHaveBeenCalledWith(
-        LogEventId.CvrImported,
+        LogEventId.CvrLoaded,
         'election_manager',
         expect.objectContaining({ disposition: 'success' })
       );
@@ -221,8 +221,8 @@ describe('Screens display properly when USB is mounted', () => {
         logger,
       }
     );
-    await waitFor(() => getByText('Import CVR Files'));
-    // If the files can not be parsed properly they are not automatically shown to import.
+    await waitFor(() => getByText('Load CVR Files'));
+    // If the files can not be parsed properly they are not automatically shown to load.
     getByText(
       /There were no new CVR files automatically found on this USB drive./
     );
@@ -239,18 +239,18 @@ describe('Screens display properly when USB is mounted', () => {
     getByText('Loading');
     await waitFor(() => {
       expect(saveCvr).toHaveBeenCalledTimes(1);
-      // There should be an error importing the file.
+      // There should be an error loading the file.
       getByText('Error');
       getByText(/There was an error reading the content of the file/);
       expect(logger.log).toHaveBeenCalledWith(
-        LogEventId.CvrImported,
+        LogEventId.CvrLoaded,
         'election_manager',
         expect.objectContaining({ disposition: 'failure' })
       );
     });
   });
 
-  test('Import CVR files screen locks to test mode when test files have been imported', async () => {
+  test('Load CVR files screen locks to test mode when test files have been loaded', async () => {
     const closeFn = jest.fn();
     const saveCvr = jest.fn();
     const logger = fakeLogger();
@@ -310,7 +310,7 @@ describe('Screens display properly when USB is mounted', () => {
     );
     await waitFor(() =>
       expect(getByTestId('modal-title')).toHaveTextContent(
-        'Import Test Mode CVR Files'
+        'Load Test Mode CVR Files'
       )
     );
 
@@ -319,7 +319,7 @@ describe('Screens display properly when USB is mounted', () => {
     domGetByText(tableRows[0], '12/09/2020 03:49:32 PM');
     domGetByText(tableRows[0], 'abc');
     expect(
-      domGetByText(tableRows[0], 'Imported').closest('button')!.disabled
+      domGetByText(tableRows[0], 'Loaded').closest('button')!.disabled
     ).toBe(true);
     expect(domGetByTestId(tableRows[0], 'new-cvr-count')).toHaveTextContent(
       '0'
@@ -335,32 +335,32 @@ describe('Screens display properly when USB is mounted', () => {
     expect(
       domGetByTestId(tableRows[1], 'imported-cvr-count')
     ).toHaveTextContent('1');
-    expect(
-      domGetByText(tableRows[1], 'Import').closest('button')!.disabled
-    ).toBe(false);
+    expect(domGetByText(tableRows[1], 'Load').closest('button')!.disabled).toBe(
+      false
+    );
 
     expect(window.kiosk!.readFile).toHaveBeenCalledTimes(2);
     fireEvent.click(getByText('Cancel'));
     expect(closeFn).toHaveBeenCalledTimes(1);
 
-    fireEvent.click(domGetByText(tableRows[1], 'Import'));
+    fireEvent.click(domGetByText(tableRows[1], 'Load'));
     getByText('Loading');
     await waitFor(() => {
       expect(saveCvr).toHaveBeenCalledTimes(1);
-      // There should be a message about importing a duplicate file displayed.
+      // There should be a message about loading a duplicate file displayed.
       getByText('Duplicate File');
       getByText(
-        'The selected file was ignored as a duplicate of a previously imported file.'
+        'The selected file was ignored as a duplicate of a previously loaded file.'
       );
       expect(logger.log).toHaveBeenCalledWith(
-        LogEventId.CvrImported,
+        LogEventId.CvrLoaded,
         'election_manager',
         expect.objectContaining({ disposition: 'failure' })
       );
     });
   });
 
-  test('Import CVR files screen locks to live mode when live files have been imported', async () => {
+  test('Load CVR files screen locks to live mode when live files have been loaded', async () => {
     const closeFn = jest.fn();
     const saveCvr = jest.fn();
     const fileEntries = [
@@ -406,29 +406,29 @@ describe('Screens display properly when USB is mounted', () => {
         saveCastVoteRecordFiles: saveCvr,
       }
     );
-    await waitFor(() => getByText('Import Live Mode CVR Files'));
+    await waitFor(() => getByText('Load Live Mode CVR Files'));
 
     const tableRows = getAllByTestId('table-row');
     expect(tableRows).toHaveLength(1);
     domGetByText(tableRows[0], '12/09/2020 03:59:32 PM');
     domGetByText(tableRows[0], '0002');
-    expect(
-      domGetByText(tableRows[0], 'Import').closest('button')!.disabled
-    ).toBe(false);
+    expect(domGetByText(tableRows[0], 'Load').closest('button')!.disabled).toBe(
+      false
+    );
 
     expect(window.kiosk!.readFile).toHaveBeenCalledTimes(3);
     fireEvent.click(getByText('Cancel'));
     expect(closeFn).toHaveBeenCalledTimes(1);
 
-    fireEvent.click(domGetByText(tableRows[0], 'Import'));
+    fireEvent.click(domGetByText(tableRows[0], 'Load'));
     getByText('Loading');
     await waitFor(() => {
       expect(saveCvr).toHaveBeenCalledTimes(1);
-      getByText('0 new CVRs Imported');
+      getByText('0 new CVRs Loaded');
     });
   });
 
-  test('Shows previously imported files when all files have already been imported', async () => {
+  test('Shows previously loaded files when all files have already been loaded', async () => {
     const closeFn = jest.fn();
     const saveCvr = jest.fn();
     const fileEntries = [
@@ -464,7 +464,7 @@ describe('Screens display properly when USB is mounted', () => {
         saveCastVoteRecordFiles: saveCvr,
       }
     );
-    await waitFor(() => getByText('Import Live Mode CVR Files'));
+    await waitFor(() => getByText('Load Live Mode CVR Files'));
     getByText(
       /There were no new Live Mode CVR files automatically found on this USB drive./
     );
@@ -474,7 +474,7 @@ describe('Screens display properly when USB is mounted', () => {
     domGetByText(tableRows[0], '12/09/2020 03:59:32 PM');
     domGetByText(tableRows[0], 'abc');
     expect(
-      domGetByText(tableRows[0], 'Imported').closest('button')!.disabled
+      domGetByText(tableRows[0], 'Loaded').closest('button')!.disabled
     ).toBe(true);
 
     fireEvent.click(getByText('Cancel'));

--- a/frontends/election-manager/src/components/import_cvrfiles_modal.tsx
+++ b/frontends/election-manager/src/components/import_cvrfiles_modal.tsx
@@ -80,7 +80,7 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
     logger,
   } = useContext(AppContext);
   assert(electionDefinition);
-  assert(isElectionManagerAuth(auth) || isSystemAdministratorAuth(auth)); // TODO(auth) check permissions for importing cvr
+  assert(isElectionManagerAuth(auth) || isSystemAdministratorAuth(auth)); // TODO(auth) check permissions for loaded cvr
   const userRole = auth.user.role;
   const [currentState, setCurrentState] = useState(ModalState.INIT);
   const [importedFile, setImportedFile] = useState<CastVoteRecordFile>();
@@ -101,29 +101,29 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
 
     if (newCastVoteRecordFiles.duplicateFiles.includes(fileData.name)) {
       setCurrentState(ModalState.DUPLICATE);
-      await logger.log(LogEventId.CvrImported, userRole, {
+      await logger.log(LogEventId.CvrLoaded, userRole, {
         message:
-          'CVR file was not imported as it is a duplicated of a previously imported file.',
+          'CVR file was not loaded as it is a duplicated of a previously loaded file.',
         disposition: 'failure',
         filename: fileData.name,
-        result: 'File not imported, error shown to user.',
+        result: 'File not loaded, error shown to user.',
       });
     } else if (newCastVoteRecordFiles.lastError?.filename === fileData.name) {
       setCurrentState(ModalState.ERROR);
-      await logger.log(LogEventId.CvrImported, userRole, {
-        message: `Failed to import CVR file: ${newCastVoteRecordFiles.lastError.message}`,
+      await logger.log(LogEventId.CvrLoaded, userRole, {
+        message: `Failed to load CVR file: ${newCastVoteRecordFiles.lastError.message}`,
         disposition: 'failure',
         filename: fileData.name,
         error: newCastVoteRecordFiles.lastError.message,
-        result: 'File not imported, error shown to user.',
+        result: 'File not loaded, error shown to user.',
       });
     } else {
       const file = newCastVoteRecordFiles.fileList.find(
         (f) => f.name === fileData.name
       );
       assert(file);
-      await logger.log(LogEventId.CvrImported, userRole, {
-        message: 'CVR file successfully imported.',
+      await logger.log(LogEventId.CvrLoaded, userRole, {
+        message: 'CVR file successfully loaded.',
         disposition: 'success',
         filename: fileData.name,
         numberOfBallotsImported: file.importedCvrCount,
@@ -153,29 +153,29 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
 
       if (newCastVoteRecordFiles.duplicateFiles.includes(filename)) {
         setCurrentState(ModalState.DUPLICATE);
-        await logger.log(LogEventId.CvrImported, userRole, {
+        await logger.log(LogEventId.CvrLoaded, userRole, {
           message:
-            'CVR file was not imported as it is a duplicated of a previously imported file.',
+            'CVR file was not loaded as it is a duplicated of a previously loaded file.',
           disposition: 'failure',
           filename,
-          result: 'File not imported, error shown to user.',
+          result: 'File not loaded, error shown to user.',
         });
       } else if (newCastVoteRecordFiles.lastError?.filename === files[0].name) {
         setCurrentState(ModalState.ERROR);
-        await logger.log(LogEventId.CvrImported, userRole, {
-          message: `Failed to import CVR file: ${newCastVoteRecordFiles.lastError.message}`,
+        await logger.log(LogEventId.CvrLoaded, userRole, {
+          message: `Failed to load CVR file: ${newCastVoteRecordFiles.lastError.message}`,
           disposition: 'failure',
           filename,
           error: newCastVoteRecordFiles.lastError.message,
-          result: 'File not imported, error shown to user.',
+          result: 'File not loaded, error shown to user.',
         });
       } else {
         const file = newCastVoteRecordFiles.fileList.find(
           (f) => f.name === filename
         );
         assert(file);
-        await logger.log(LogEventId.CvrImported, userRole, {
-          message: 'CVR file successfully imported.',
+        await logger.log(LogEventId.CvrLoaded, userRole, {
+          message: 'CVR file successfully loaded.',
           disposition: 'success',
           filename,
           numberOfBallotsImported: file.importedCvrCount,
@@ -216,7 +216,7 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
       );
       setFoundFiles(parsedFileInformation);
       await logger.log(LogEventId.CvrFilesReadFromUsb, userRole, {
-        message: `Found ${newFoundFiles.length} CVR files on USB drive, user shown option to import.`,
+        message: `Found ${newFoundFiles.length} CVR files on USB drive, user shown option to load.`,
         disposition: 'success',
       });
       setCurrentState(ModalState.INIT);
@@ -228,7 +228,7 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
         setCurrentState(ModalState.INIT);
         await logger.log(LogEventId.CvrFilesReadFromUsb, userRole, {
           message:
-            'No CVR files automatically found on USB drive. User allowed to import manually.',
+            'No CVR files automatically found on USB drive. User allowed to load manually.',
           disposition: 'success',
           result: 'User allowed to manually select files.',
         });
@@ -278,7 +278,7 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
             <h1>Duplicate File</h1>
             <p>
               The selected file was ignored as a duplicate of a previously
-              imported file.
+              loaded file.
             </p>
           </Prose>
         }
@@ -294,7 +294,7 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
       <Modal
         content={
           <Prose>
-            <h1>{importedFile.importedCvrCount} new CVRs Imported</h1>
+            <h1>{importedFile.importedCvrCount} new CVRs Loaded</h1>
             {importedFile.duplicatedCvrCount > 0 && (
               <React.Fragment>
                 <p>
@@ -302,7 +302,7 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
                   {importedFile.importedCvrCount +
                     importedFile.duplicatedCvrCount}{' '}
                   total CVRs in this file, {importedFile.duplicatedCvrCount}{' '}
-                  were previously imported.
+                  were previously loaded.
                 </p>
               </React.Fragment>
             )}
@@ -344,7 +344,7 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
             <h1>No USB Drive Detected</h1>
             <p>
               <UsbImage src="/assets/usb-drive.svg" alt="Insert USB Image" />
-              Please insert a USB drive in order to import CVR files from the
+              Please insert a USB drive in order to load CVR files from the
               scanner.
             </p>
           </Prose>
@@ -368,7 +368,7 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
   }
 
   if (usbDriveStatus === UsbDriveStatus.mounted) {
-    // Determine if we are already locked to a filemode based on previously imported CVRs
+    // Determine if we are already locked to a filemode based on previously loaded CVRs
     const fileMode = castVoteRecordFiles?.fileMode;
     const fileModeLocked = !!fileMode;
 
@@ -410,7 +410,7 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
               small
               primary
             >
-              {canImport ? 'Import' : 'Imported'}
+              {canImport ? 'Load' : 'Loaded'}
             </LinkButton>
           </TD>
         </tr>
@@ -437,22 +437,22 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
       instructionalText = fileModeLocked ? (
         <React.Fragment>
           There were no new {headerModeText} CVR files automatically found on
-          this USB drive. Export CVR files to this USB drive from the scanner.
-          Optionally, you may manually select files to import.
+          this USB drive. Save CVR files to this USB drive from the scanner.
+          Optionally, you may manually select files to load.
         </React.Fragment>
       ) : (
-        'There were no new CVR files automatically found on this USB drive. Export CVR files to this USB drive from the scanner. Optionally, you may manually select files to import.'
+        'There were no new CVR files automatically found on this USB drive. Save CVR files to this USB drive from the scanner. Optionally, you may manually select files to load.'
       );
     } else if (fileModeLocked) {
       instructionalText = (
         <React.Fragment>
           The following {headerModeText} CVR files were automatically found on
-          this USB drive. Previously imported CVR entries will be ignored.
+          this USB drive. Previously loaded CVR entries will be ignored.
         </React.Fragment>
       );
     } else {
       instructionalText =
-        'The following CVR files were automatically found on this USB drive. Previously imported CVR entries will be ignored.';
+        'The following CVR files were automatically found on this USB drive. Previously loaded CVR entries will be ignored.';
     }
 
     return (
@@ -462,7 +462,7 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
           <React.Fragment>
             <Prose maxWidth={false}>
               <h1 data-testid="modal-title">
-                Import {headerModeText} CVR Files{' '}
+                Load {headerModeText} CVR Files{' '}
               </h1>
               <p>{instructionalText}</p>
             </Prose>
@@ -470,10 +470,10 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
               <CvrFileTable>
                 <thead>
                   <tr>
-                    <th>Exported At</th>
+                    <th>Saved At</th>
                     <th>Scanner ID</th>
                     <th>New CVRs</th>
-                    <th>Imported CVRs</th>
+                    <th>Loaded CVRs</th>
                     {!fileModeLocked && <th>Ballot Type</th>}
                     <th />
                   </tr>

--- a/frontends/election-manager/src/components/import_external_results_modal.tsx
+++ b/frontends/election-manager/src/components/import_external_results_modal.tsx
@@ -37,7 +37,7 @@ export function ImportExternalResultsModal({
     logger,
   } = useContext(AppContext);
   assert(electionDefinition);
-  assert(isElectionManagerAuth(auth) || isSystemAdministratorAuth(auth)); // TODO(auth) check permissions for importing cvr
+  assert(isElectionManagerAuth(auth) || isSystemAdministratorAuth(auth)); // TODO(auth) check permissions for loading cvr
   const userRole = auth.user.role;
 
   const [errorMessage, setErrorMessage] = useState('');
@@ -60,13 +60,13 @@ export function ImportExternalResultsModal({
       );
       if (fileErrors.length > 0) {
         setErrorMessage(
-          `Failed to import external file. ${fileErrors.join(' ')}`
+          `Failed to load external file. ${fileErrors.join(' ')}`
         );
         setIsImportingFile(false);
-        await logger.log(LogEventId.ExternalTallyFileImported, userRole, {
+        await logger.log(LogEventId.ExternalTallyFileLoaded, userRole, {
           message:
-            'Failed to import external tally file, file contents not compatible with current election.',
-          result: 'User shown error, file not imported.',
+            'Failed to load external tally file, file contents not compatible with current election.',
+          result: 'User shown error, file not loaded.',
           error: fileErrors.join(' '),
           disposition: 'failure',
           fileType: ExternalTallySourceType.SEMS,
@@ -83,10 +83,10 @@ export function ImportExternalResultsModal({
       setNumberBallotsToImport(tally.overallTally.numberOfBallotsCounted);
     } catch (error) {
       assert(error instanceof Error);
-      setErrorMessage(`Failed to import external file. ${error.message}`);
-      await logger.log(LogEventId.ExternalTallyFileImported, userRole, {
-        message: 'Failed to import external tally file.',
-        result: 'User shown error, file not imported.',
+      setErrorMessage(`Failed to load external file. ${error.message}`);
+      await logger.log(LogEventId.ExternalTallyFileLoaded, userRole, {
+        message: 'Failed to load external tally file.',
+        result: 'User shown error, file not loaded.',
         error: error.message,
         fileType: ExternalTallySourceType.SEMS,
         disposition: 'failure',
@@ -114,8 +114,8 @@ export function ImportExternalResultsModal({
         selectedFile.name,
         new Date(selectedFile.lastModified)
       );
-      await logger.log(LogEventId.ExternalTallyFileImported, userRole, {
-        message: 'External Tally File imported successfully.',
+      await logger.log(LogEventId.ExternalTallyFileLoaded, userRole, {
+        message: 'External Tally File loaded successfully.',
         disposition: 'success',
         fileType: ExternalTallySourceType.SEMS,
         numberOfBallotsImported: tally.overallTally.numberOfBallotsCounted,
@@ -135,7 +135,7 @@ export function ImportExternalResultsModal({
             Close
           </LinkButton>
         }
-        content={<Loading>Importing File</Loading>}
+        content={<Loading>Loading File</Loading>}
       />
     );
   }
@@ -161,7 +161,7 @@ export function ImportExternalResultsModal({
       actions={
         <React.Fragment>
           <LinkButton primary onPress={saveImportedFile}>
-            Import Results
+            Load Results
           </LinkButton>
           <LinkButton onPress={onClose}>Cancel</LinkButton>
         </React.Fragment>

--- a/frontends/election-manager/src/components/save_file_to_usb.tsx
+++ b/frontends/election-manager/src/components/save_file_to_usb.tsx
@@ -112,7 +112,7 @@ export function SaveFileToUsb({
           });
 
           if (!fileWriter) {
-            throw new Error('could not begin download; no file was chosen');
+            throw new Error('could not save; no file was chosen');
           }
 
           await fileWriter.write(results);
@@ -225,7 +225,7 @@ export function SaveFileToUsb({
     case UsbDriveStatus.absent:
     case UsbDriveStatus.notavailable:
     case UsbDriveStatus.recentlyEjected:
-      // When run not through kiosk mode let the user download the file
+      // When run not through kiosk mode let the user save the file
       // on the machine for internal debugging use
       return (
         <Modal

--- a/frontends/election-manager/src/lib/converters/ms_sems_converter_client.ts
+++ b/frontends/election-manager/src/lib/converters/ms_sems_converter_client.ts
@@ -20,7 +20,7 @@ export class MsSemsConverterClient implements ConverterClient {
 
     if (result.status !== 'ok') {
       throw new Error(
-        `failed to upload file named "${name}": ${JSON.stringify(result)}`
+        `failed to load file named "${name}": ${JSON.stringify(result)}`
       );
     }
   }

--- a/frontends/election-manager/src/screens/advanced_screen.tsx
+++ b/frontends/election-manager/src/screens/advanced_screen.tsx
@@ -21,13 +21,13 @@ export function AdvancedScreen(): JSX.Element {
           <h1>Advanced Options</h1>
           <h2>Logs</h2>
           <Button onPress={() => setExportingLogType(LogFileType.Raw)}>
-            Export Log File
+            Save Log File
           </Button>{' '}
           <Button
             onPress={() => setExportingLogType(LogFileType.Cdf)}
             disabled={electionDefinition === undefined} // CDF requires the election being known.
           >
-            Export Log File as CDF
+            Save Log File as CDF
           </Button>
           <h2>Current Date and Time</h2>
           <p>

--- a/frontends/election-manager/src/screens/definition_editor_screen.tsx
+++ b/frontends/election-manager/src/screens/definition_editor_screen.tsx
@@ -116,7 +116,7 @@ export function DefinitionEditorScreen({
           <div />
           <div />
           <Button small disabled={dirty} onPress={downloadElectionDefinition}>
-            Download
+            Save
           </Button>
           <Button
             small

--- a/frontends/election-manager/src/screens/logic_and_accuracy_screen.tsx
+++ b/frontends/election-manager/src/screens/logic_and_accuracy_screen.tsx
@@ -17,7 +17,7 @@ export function LogicAndAccuracyScreen(): JSX.Element {
         {isLiveMode ? (
           <p>
             L&A testing documents are not available after official election CVRs
-            have been imported.
+            have been loaded.
           </p>
         ) : (
           <React.Fragment>

--- a/frontends/election-manager/src/screens/logs_screen.test.tsx
+++ b/frontends/election-manager/src/screens/logs_screen.test.tsx
@@ -16,13 +16,13 @@ beforeEach(() => {
 test('Exporting logs', async () => {
   renderInAppContext(<LogsScreen />);
 
-  // Log exporting is tested fully in src/components/export_logs_modal.test.tsx
-  userEvent.click(screen.getByText('Export Log File'));
+  // Log saving is tested fully in src/components/export_logs_modal.test.tsx
+  userEvent.click(screen.getByText('Save Log File'));
   await screen.findByText('No Log File Present');
   userEvent.click(screen.getByText('Close'));
 
-  // Log exporting is tested fully in src/components/export_logs_modal.test.tsx
-  userEvent.click(screen.getByText('Export Log File as CDF'));
+  // Log saving is tested fully in src/components/export_logs_modal.test.tsx
+  userEvent.click(screen.getByText('Save Log File as CDF'));
   await screen.findByText('No Log File Present');
   userEvent.click(screen.getByText('Close'));
 });
@@ -30,12 +30,12 @@ test('Exporting logs', async () => {
 test('Exporting logs when no election definition', async () => {
   renderInAppContext(<LogsScreen />, { electionDefinition: 'NONE' });
 
-  // Log exporting is tested fully in src/components/export_logs_modal.test.tsx
-  userEvent.click(screen.getByText('Export Log File'));
+  // Log saving is tested fully in src/components/export_logs_modal.test.tsx
+  userEvent.click(screen.getByText('Save Log File'));
   await screen.findByText('No Log File Present');
   userEvent.click(screen.getByText('Close'));
 
   expect(
-    screen.getByText('Export Log File as CDF').closest('button')
+    screen.getByText('Save Log File as CDF').closest('button')
   ).toHaveAttribute('disabled');
 });

--- a/frontends/election-manager/src/screens/logs_screen.tsx
+++ b/frontends/election-manager/src/screens/logs_screen.tsx
@@ -17,13 +17,13 @@ export function LogsScreen(): JSX.Element {
           <h1>Logs</h1>
           <p>
             <Button onPress={() => setLogFileType(LogFileType.Raw)}>
-              Export Log File
+              Save Log File
             </Button>{' '}
             <Button
               disabled={!electionDefinition} // CDF requires the election to be known
               onPress={() => setLogFileType(LogFileType.Cdf)}
             >
-              Export Log File as CDF
+              Save Log File as CDF
             </Button>
           </p>
         </Prose>

--- a/frontends/election-manager/src/screens/reports_screen.tsx
+++ b/frontends/election-manager/src/screens/reports_screen.tsx
@@ -110,7 +110,7 @@ export function ReportsScreen(): JSX.Element {
     );
     await client.process();
 
-    // download the result
+    // save the result
     const results = await client.getOutputFile(resultsFile.name);
 
     // reset files on the server

--- a/frontends/election-manager/src/screens/tally_screen.tsx
+++ b/frontends/election-manager/src/screens/tally_screen.tsx
@@ -90,7 +90,7 @@ export function TallyScreen(): JSX.Element {
   const fileMode = castVoteRecordFiles?.fileMode;
   const fileModeText =
     fileMode === 'test'
-      ? 'Currently tallying test ballots. Once you have completed L&A testing and are ready to start tallying live ballots remove all of the loaded CVR files before importing live ballot results.'
+      ? 'Currently tallying test ballots. Once you have completed L&A testing and are ready to start tallying live ballots remove all of the loaded CVR files before loading live ballot results.'
       : fileMode === 'live'
       ? 'Currently tallying live ballots.'
       : '';
@@ -137,7 +137,7 @@ export function TallyScreen(): JSX.Element {
               disabled={isOfficialResults}
               onPress={() => setIsImportCvrModalOpen(true)}
             >
-              Import CVR Files
+              Load CVR Files
             </Button>{' '}
             <Button
               disabled={!castVoteRecordFiles.wereAdded || isOfficialResults}
@@ -242,7 +242,7 @@ export function TallyScreen(): JSX.Element {
                   data-testid="import-sems-button"
                   disabled={hasExternalSemsFile || isOfficialResults}
                 >
-                  Import External Results File
+                  Load External Results File
                 </FileInputButton>{' '}
                 <Button
                   disabled={!hasExternalSemsFile || isOfficialResults}

--- a/frontends/election-manager/src/screens/write_ins_screen.test.tsx
+++ b/frontends/election-manager/src/screens/write_ins_screen.test.tsx
@@ -38,17 +38,17 @@ describe('Write-in Adjudication screen', () => {
   const { electionDefinition, cvrData } =
     electionMinimalExhaustiveSampleFixtures;
 
-  test('No CVRs imported', async () => {
+  test('No CVRs loaded', async () => {
     renderInAppContext(<WriteInsScreen />, { electionDefinition });
     await waitFor(() => {
-      screen.getByText('Adjudication can begin once CVRs are imported.');
+      screen.getByText('Adjudication can begin once CVRs are loaded.');
     });
     expect(
       screen.getAllByText(/Adjudicate write-ins for “City Zoo Council”/)[0]
     ).toBeDisabled();
   });
 
-  test('CVRs with write-ins imported', async () => {
+  test('CVRs with write-ins loaded', async () => {
     const mockFiles = CastVoteRecordFiles.empty;
     const added = await mockFiles.addAll(
       [new File([cvrData], TEST_FILE1)],

--- a/frontends/election-manager/src/screens/write_ins_screen.tsx
+++ b/frontends/election-manager/src/screens/write_ins_screen.tsx
@@ -69,7 +69,7 @@ export function WriteInsScreen(): JSX.Element {
         <Prose maxWidth={false}>
           <h1>Write-Ins</h1>
           {!castVoteRecordFiles.wereAdded && (
-            <p>Adjudication can begin once CVRs are imported.</p>
+            <p>Adjudication can begin once CVRs are loaded.</p>
           )}
           {contestsWithWriteIns?.map((contest) => (
             <p key={contest.id}>

--- a/frontends/election-manager/src/utils/cast_vote_record_files.test.ts
+++ b/frontends/election-manager/src/utils/cast_vote_record_files.test.ts
@@ -218,7 +218,7 @@ test('can preprocess files to give information about expected duplicates', async
     },
   ]);
 
-  // Can handle a previously imported file properly
+  // Can handle a previously loaded file properly
   window.kiosk.readFile = jest.fn().mockResolvedValue(JSON.stringify(cvr));
   const parsedData2 = await added.parseAllFromFileSystemEntries(
     [
@@ -376,7 +376,7 @@ test('records CVR data errors', async () => {
   });
 });
 
-test('records identical uploaded files', async () => {
+test('records identical loaded files', async () => {
   const cvr: CastVoteRecord = {
     _ballotId: unsafeParse(BallotIdSchema, 'abc'),
     _ballotStyleId: '12',

--- a/frontends/election-manager/src/utils/cast_vote_record_files.ts
+++ b/frontends/election-manager/src/utils/cast_vote_record_files.ts
@@ -218,7 +218,7 @@ export class CastVoteRecordFiles {
           results.push(parsedFile);
         }
       } catch (error) {
-        // The file isn't able to be read or isn't a valid CVR file for import and could not be processed.
+        // The file isn't able to be read or isn't a valid CVR file for loading and could not be processed.
         // Only valid CVR files will be returned by this function so ignore this file and continue processing the rest.
         continue;
       }

--- a/frontends/election-manager/src/utils/downloadable_archive.test.ts
+++ b/frontends/election-manager/src/utils/downloadable_archive.test.ts
@@ -12,7 +12,7 @@ test('file prompt fails', async () => {
 
   kiosk.saveAs.mockResolvedValueOnce(undefined);
   await expect(archive.beginWithDialog()).rejects.toThrowError(
-    'could not begin download; no file was chosen'
+    'could not save; no file was chosen'
   );
 });
 
@@ -23,7 +23,7 @@ test('direct file save fails', async () => {
 
   await expect(
     archive.beginWithDirectSave('/path/to/folder', 'file.zip')
-  ).rejects.toThrowError('could not begin download; an error occurred');
+  ).rejects.toThrowError('could not save file; an error occurred');
 });
 
 test('empty zip file when user is prompted for file location', async () => {

--- a/frontends/election-manager/src/utils/downloadable_archive.ts
+++ b/frontends/election-manager/src/utils/downloadable_archive.ts
@@ -56,7 +56,7 @@ export class DownloadableArchive {
     this.kioskWriter = await this.getKiosk().saveAs(options);
 
     if (!this.kioskWriter) {
-      throw new Error('could not begin download; no file was chosen');
+      throw new Error('could not save; no file was chosen');
     }
 
     this.prepareZip();
@@ -77,7 +77,7 @@ export class DownloadableArchive {
     this.kioskWriter = await this.getKiosk().writeFile(filePath);
 
     if (!this.kioskWriter) {
-      throw new Error('could not begin download; an error occurred');
+      throw new Error('could not save file; an error occurred');
     }
 
     this.prepareZip();

--- a/frontends/election-manager/src/utils/sems_tallies.test.ts
+++ b/frontends/election-manager/src/utils/sems_tallies.test.ts
@@ -197,7 +197,7 @@ describe('getContestTallyForCandidateContest', () => {
     expect(() => {
       getContestTallyForCandidateContest(presidentcontest, rows);
     }).toThrowError(
-      'Imported file has unexpected candidate id eevee for contest president'
+      'Loaded file has unexpected candidate id eevee for contest president'
     );
   });
 });
@@ -255,7 +255,7 @@ describe('getContestTallyForYesNoContest', () => {
     expect(() => {
       getContestTallyForYesNoContest(yesnocontest, rows);
     }).toThrowError(
-      'Imported file has unexpected option id purple for contest 750000018'
+      'Loaded file has unexpected option id purple for contest 750000018'
     );
   });
 });
@@ -585,7 +585,7 @@ describe('parseSemsFileAndValidateForElection', () => {
     ).toEqual([]);
   });
 
-  it('rejects importing a yes/no contest if the yes no options are not specified in the election definition', () => {
+  it('rejects loading a yes/no contest if the yes no options are not specified in the election definition', () => {
     // Write in candidate row for a contest with write ins allowed
     const csvRowRaw2 =
       '"10","23","judicial-robert-demergue","Judicial Robert Demergue","0","NP","1","Over Votes","0","NP","0",';
@@ -625,7 +625,7 @@ describe('parseSemsFileAndValidateForElection', () => {
     expect(
       parseSemsFileAndValidateForElection('', multiPartyPrimaryElection)
     ).toEqual([
-      'No valid CSV data found in imported file. Please check file contents.',
+      'No valid CSV data found in loaded file. Please check file contents.',
     ]);
 
     expect(
@@ -634,7 +634,7 @@ describe('parseSemsFileAndValidateForElection', () => {
         multiPartyPrimaryElection
       )
     ).toEqual([
-      'No valid CSV data found in imported file. Please check file contents.',
+      'No valid CSV data found in loaded file. Please check file contents.',
     ]);
   });
 

--- a/frontends/election-manager/src/utils/sems_tallies.ts
+++ b/frontends/election-manager/src/utils/sems_tallies.ts
@@ -90,7 +90,7 @@ export function getContestTallyForCandidateContest(
       numCandidateVotes += row.numberOfVotes;
     } else {
       throw new Error(
-        `Imported file has unexpected candidate id ${row.candidateId} for contest ${contest.id}`
+        `Loaded file has unexpected candidate id ${row.candidateId} for contest ${contest.id}`
       );
     }
   }
@@ -150,7 +150,7 @@ export function getContestTallyForYesNoContest(
       // Ignore row
     } else {
       throw new Error(
-        `Imported file has unexpected option id ${row.candidateId} for contest ${contest.id}`
+        `Loaded file has unexpected option id ${row.candidateId} for contest ${contest.id}`
       );
     }
   }
@@ -206,7 +206,7 @@ export function parseSemsFileAndValidateForElection(
 
   if (parsedRows.length === 0) {
     return [
-      'No valid CSV data found in imported file. Please check file contents.',
+      'No valid CSV data found in loaded file. Please check file contents.',
     ];
   }
 
@@ -305,7 +305,7 @@ export function convertSemsFileToExternalTally(
 
   for (const precinctId of Object.keys(parsedRowsByPrecinct)) {
     if (!election.precincts.find((p) => p.id === precinctId)) {
-      throw new Error(`Imported file has unexpected PrecinctId: ${precinctId}`);
+      throw new Error(`Loaded file has unexpected PrecinctId: ${precinctId}`);
     }
     const rowsForPrecinct = parsedRowsByPrecinct[precinctId];
 
@@ -313,9 +313,7 @@ export function convertSemsFileToExternalTally(
     const rowsForPrecinctAndContest = _.groupBy(rowsForPrecinct, 'contestId');
     for (const contestId of Object.keys(rowsForPrecinctAndContest)) {
       if (!(contestId in contestsById)) {
-        throw new Error(
-          `Imported file has unexpected PrecinctId: ${contestId}`
-        );
+        throw new Error(`Loaded file has unexpected PrecinctId: ${contestId}`);
       }
       const electionContest = contestsById[contestId];
       assert(electionContest);

--- a/frontends/precinct-scanner/README.md
+++ b/frontends/precinct-scanner/README.md
@@ -18,10 +18,10 @@ pnpm start
 The server will be available at http://localhost:3000/. You may find it easier
 to get to certain states from http://localhost:3000/preview.
 
-To set the election configuration you will need to load a ballot export zip file
-from [election-manager](../election-manager). It should be on a USB drive
-located in the folder `ballot-packages`. There can only be one election ballot
-package in that folder. You'll need to run the application inside
+To set the election configuration you will need to load a ballot package from
+[election-manager](../election-manager). It should be on a USB drive located in
+the folder `ballot-packages`. There can only be one election ballot package in
+that folder. You'll need to run the application inside
 [`kiosk-browser`](https://github.com/votingworks/kiosk-browser).
 
 To use a mock scanner, follow the directions from in

--- a/frontends/precinct-scanner/src/app.test.tsx
+++ b/frontends/precinct-scanner/src/app.test.tsx
@@ -642,22 +642,22 @@ test('voter can cast a ballot that scans successfully ', async () => {
   card.insertCard(electionManagerCard, electionSampleDefinition.electionData);
   await authenticateElectionManagerCard();
   await screen.findByText('Election Manager Settings');
-  fireEvent.click(await screen.findByText('Export Results to USB Drive'));
+  fireEvent.click(await screen.findByText('Save Results to USB Drive'));
   await screen.findByText('No USB Drive Detected');
   fireEvent.click(await screen.findByText('Cancel'));
   expect(screen.queryByText('No USB Drive Detected')).toBeNull();
-  fireEvent.click(await screen.findByText('Export Results to USB Drive'));
+  fireEvent.click(await screen.findByText('Save Results to USB Drive'));
   await screen.findByText('No USB Drive Detected');
   fireEvent.click(await screen.findByText('Cancel'));
   expect(screen.queryByText('No USB Drive Detected')).toBeNull();
   // Insert usb drive
   kiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
   await advanceTimersAndPromises(2);
-  fireEvent.click(await screen.findByText('Export Results to USB Drive'));
+  fireEvent.click(await screen.findByText('Save Results to USB Drive'));
 
-  await screen.findByText('Export Results');
-  fireEvent.click(await screen.findByText('Export'));
-  await screen.findByText('Results Exported to USB Drive');
+  await screen.findByText('Save Results');
+  fireEvent.click(await screen.findByText('Save'));
+  await screen.findByText('Results Saved to USB Drive');
   expect(kiosk.writeFile).toHaveBeenCalledTimes(2);
   expect(kiosk.writeFile).toHaveBeenNthCalledWith(
     2,
@@ -1024,7 +1024,7 @@ test('with printer: poll worker can open and close polls without scanning any ba
   await screen.findByText('Polls Closed');
 });
 
-test('no printer: open polls, scan ballot, close polls, export results', async () => {
+test('no printer: open polls, scan ballot, close polls, save results', async () => {
   const card = new MemoryCard();
   const hardware = MemoryHardware.buildStandard();
   hardware.setPrinterConnected(false);

--- a/frontends/precinct-scanner/src/components/export_backup_modal.test.tsx
+++ b/frontends/precinct-scanner/src/components/export_backup_modal.test.tsx
@@ -227,7 +227,7 @@ test('shows a specific error for file writer failure', async () => {
   );
   fireEvent.click(getByText('Save'));
   await waitFor(() => getByText('Failed to Save Backup'));
-  getByText(/Unable to write file to download location: backup.zip/);
+  getByText(/Unable to write file to save location: backup.zip/);
 
   fireEvent.click(getByText('Close'));
   expect(closeFn).toHaveBeenCalled();

--- a/frontends/precinct-scanner/src/components/export_backup_modal.tsx
+++ b/frontends/precinct-scanner/src/components/export_backup_modal.tsx
@@ -94,7 +94,7 @@ export function ExportBackupModal({ onClose, usbDrive }: Props): JSX.Element {
 
           case DownloadErrorKind.OpenFailed:
             setErrorMessage(
-              `Unable to write file to download location: ${error.path}`
+              `Unable to write file to save location: ${error.path}`
             );
             break;
 
@@ -179,7 +179,7 @@ export function ExportBackupModal({ onClose, usbDrive }: Props): JSX.Element {
     case usbstick.UsbDriveStatus.absent:
     case usbstick.UsbDriveStatus.notavailable:
     case usbstick.UsbDriveStatus.recentlyEjected:
-      // When run not through kiosk mode let the user download the file
+      // When run not through kiosk mode let the user save the file
       // on the machine for internal debugging use
       return (
         <Modal

--- a/frontends/precinct-scanner/src/components/export_results_modal.test.tsx
+++ b/frontends/precinct-scanner/src/components/export_results_modal.test.tsx
@@ -71,7 +71,7 @@ test('render no usb found screen when there is not a mounted usb drive', () => {
       </AppContext.Provider>
     );
     getByText('No USB Drive Detected');
-    getByText('Please insert a USB drive in order to export results.');
+    getByText('Please insert a USB drive in order to save results.');
     getByAltText('Insert USB Image');
 
     fireEvent.click(getByText('Cancel'));
@@ -110,14 +110,14 @@ test('render export modal when a usb drive is mounted as expected and allows cus
       />
     </AppContext.Provider>
   );
-  getByText('Export Results');
+  getByText('Save Results');
   getByText(
     /A CVR file will automatically be saved to the default location on the mounted USB drive. /
   );
   getByAltText('Insert USB Image');
 
   fireEvent.click(getByText('Custom'));
-  await waitFor(() => getByText('Results Exported to USB Drive'));
+  await waitFor(() => getByText('Results Saved to USB Drive'));
   await waitFor(() => {
     expect(saveAsFunction).toHaveBeenCalledTimes(1);
   });
@@ -154,10 +154,10 @@ test('render export modal when a usb drive is mounted as expected and allows aut
       />
     </AppContext.Provider>
   );
-  getByText('Export Results');
+  getByText('Save Results');
 
-  fireEvent.click(getByText('Export'));
-  await waitFor(() => getByText('Results Exported to USB Drive'));
+  fireEvent.click(getByText('Save'));
+  await waitFor(() => getByText('Results Saved to USB Drive'));
   await waitFor(() => {
     expect(mockKiosk.makeDirectory).toHaveBeenCalledTimes(1);
   });
@@ -230,11 +230,11 @@ test('render export modal with errors when appropriate', async () => {
       />
     </AppContext.Provider>
   );
-  getByText('Export Results');
+  getByText('Save Results');
 
   mockKiosk.getUsbDrives.mockRejectedValueOnce(new Error('NOPE'));
-  fireEvent.click(getByText('Export'));
-  await waitFor(() => getByText(/Download Failed/));
+  fireEvent.click(getByText('Save'));
+  await waitFor(() => getByText('Failed to Save Results'));
   getByText(/Failed to save results./);
   getByText(/NOPE/);
 

--- a/frontends/precinct-scanner/src/components/export_results_modal.tsx
+++ b/frontends/precinct-scanner/src/components/export_results_modal.tsx
@@ -74,7 +74,7 @@ export function ExportResultsModal({
       <Modal
         content={
           <Prose>
-            <h1>Download Failed</h1>
+            <h1>Failed to Save Results</h1>
             <p>{errorMessage}</p>
           </Prose>
         }
@@ -103,7 +103,7 @@ export function ExportResultsModal({
       <Modal
         content={
           <Prose>
-            <h1>Results Exported to USB Drive</h1>
+            <h1>Results Saved to USB Drive</h1>
             <p>
               You may now eject the USB drive and take it to VxAdmin for
               tabulation.
@@ -149,7 +149,7 @@ export function ExportResultsModal({
             <Prose textCenter>
               <h1>No USB Drive Detected</h1>
               <p>
-                Please insert a USB drive in order to export results.
+                Please insert a USB drive in order to save results.
                 <UsbImage src="/assets/usb-drive.svg" alt="Insert USB Image" />
               </p>
             </Prose>
@@ -163,7 +163,7 @@ export function ExportResultsModal({
                   data-testid="manual-export"
                   onPress={() => exportResults(true)}
                 >
-                  Export
+                  Save
                 </Button>
               )}{' '}
             </React.Fragment>
@@ -188,12 +188,12 @@ export function ExportResultsModal({
         <Modal
           content={
             <Prose>
-              <h1>Export Results</h1>
+              <h1>Save Results</h1>
               <UsbImage src="/assets/usb-drive.svg" alt="Insert USB Image" />
               <p>
                 A CVR file will automatically be saved to the default location
-                on the mounted USB drive. Optionally, you may pick a custom
-                export location.
+                on the mounted USB drive. Optionally, you may pick a custom save
+                location.
               </p>
             </Prose>
           }
@@ -201,7 +201,7 @@ export function ExportResultsModal({
           actions={
             <React.Fragment>
               <Button primary onPress={() => exportResults(false)}>
-                Export
+                Save
               </Button>
               <Button onPress={onClose}>Cancel</Button>
               <Button onPress={() => exportResults(true)}>Custom</Button>

--- a/frontends/precinct-scanner/src/screens/election_manager_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/election_manager_screen.test.tsx
@@ -144,7 +144,7 @@ test('export from admin screen', () => {
     </AppContext.Provider>
   );
 
-  fireEvent.click(screen.getByText('Export Backup to USB Drive'));
+  fireEvent.click(screen.getByText('Save Backup to USB Drive'));
 });
 
 test('unconfigure ejects a usb drive when it is mounted', () => {

--- a/frontends/precinct-scanner/src/screens/election_manager_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/election_manager_screen.tsx
@@ -172,12 +172,12 @@ export function ElectionManagerScreen({
         </p>
         <p>
           <Button onPress={() => setIsExportingResults(true)}>
-            Export Results to USB Drive
+            Save Results to USB Drive
           </Button>
         </p>
         <p>
           <Button onPress={() => setIsExportingBackup(true)}>
-            Export Backup to USB Drive
+            Save Backup to USB Drive
           </Button>
         </p>
         <p>
@@ -205,7 +205,7 @@ export function ElectionManagerScreen({
         </p>
         {!scannerStatus.canUnconfigure && (
           <p>
-            You must “Export Backup” before you can delete election data from
+            You must “Save Backup” before you can delete election data from
             VxScan.
           </p>
         )}
@@ -223,9 +223,9 @@ export function ElectionManagerScreen({
         <Modal
           content={
             <Prose>
-              <h1>Export Backup to switch to Test Mode</h1>
+              <h1>Save Backup to switch to Test Mode</h1>
               <p>
-                You must &quot;Export Backup&quot; before you may switch to
+                You must &quot;Save Backup&quot; before you may switch to
                 Testing Mode.
               </p>
             </Prose>
@@ -239,7 +239,7 @@ export function ElectionManagerScreen({
                   setIsExportingBackup(true);
                 }}
               >
-                Export Backup
+                Save Backup
               </Button>
               <Button onPress={closeToggleLiveModeWarningModal}>Cancel</Button>
             </React.Fragment>

--- a/frontends/precinct-scanner/src/screens/poll_worker_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/poll_worker_screen.test.tsx
@@ -61,7 +61,7 @@ function renderScreen({
 }
 
 describe('shows Export Results button only when polls are closed and more than 0 ballots have been cast', () => {
-  const exportButtonText = 'Export Results to USB Drive';
+  const exportButtonText = 'Save Results to USB Drive';
 
   test('no ballots and polls closed should not show button', async () => {
     // eslint-disable-next-line @typescript-eslint/require-await
@@ -115,7 +115,7 @@ describe('shows Export Results button only when polls are closed and more than 0
     fireEvent.click(screen.getAllByText('No')[0]);
     await advanceTimersAndPromises(1);
     await advanceTimersAndPromises(1);
-    await screen.findByText('Export Results to USB Drive');
+    await screen.findByText('Save Results to USB Drive');
 
     expect(screen.queryByText(exportButtonText)).toBeTruthy();
   });

--- a/frontends/precinct-scanner/src/screens/poll_worker_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/poll_worker_screen.tsx
@@ -509,7 +509,7 @@ export function PollWorkerScreen({
           {!isPollsOpen && scannedBallotCount > 0 && (
             <p>
               <Button onPress={() => setIsExportingResults(true)}>
-                Export Results to USB Drive
+                Save Results to USB Drive
               </Button>
             </p>
           )}

--- a/frontends/precinct-scanner/src/screens/unconfigured_election_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/unconfigured_election_screen.tsx
@@ -163,7 +163,7 @@ export function UnconfiguredElectionScreen({
         <IndeterminateProgressBar />
         <CenteredLargeProse>
           <h1>
-            Uploading ballot package {currentUploadingBallotIndex + 1} of{' '}
+            Loading ballot package {currentUploadingBallotIndex + 1} of{' '}
             {totalTemplates}
           </h1>
           <ul style={{ textAlign: 'left' }}>

--- a/frontends/precinct-scanner/src/utils/save_cvr_export_to_usb.test.ts
+++ b/frontends/precinct-scanner/src/utils/save_cvr_export_to_usb.test.ts
@@ -51,7 +51,7 @@ test('throws error when there is no usb mounted in kiosk mode', async () => {
       openFilePickerDialog: false,
     })
   ).rejects.toThrowErrorMatchingInlineSnapshot(
-    `"could not begin download; path to usb drive missing"`
+    `"could not save file; path to usb drive missing"`
   );
 });
 
@@ -97,7 +97,7 @@ test('throws error when no file is chosen in file picker', async () => {
       openFilePickerDialog: true,
     })
   ).rejects.toThrowErrorMatchingInlineSnapshot(
-    `"could not begin download; no file was chosen"`
+    `"could not save; no file was chosen"`
   );
 });
 

--- a/frontends/precinct-scanner/src/utils/save_cvr_export_to_usb.ts
+++ b/frontends/precinct-scanner/src/utils/save_cvr_export_to_usb.ts
@@ -41,7 +41,7 @@ export async function saveCvrExportToUsb({
   if (window.kiosk) {
     const usbPath = await usbstick.getDevicePath();
     if (!usbPath) {
-      throw new Error('could not begin download; path to usb drive missing');
+      throw new Error('could not save file; path to usb drive missing');
     }
     const electionFolderName = generateElectionBasedSubfolderName(
       electionDefinition.election,
@@ -59,7 +59,7 @@ export async function saveCvrExportToUsb({
       });
 
       if (!fileWriter) {
-        throw new Error('could not begin download; no file was chosen');
+        throw new Error('could not save; no file was chosen');
       }
 
       await fileWriter.write(cvrFileString);

--- a/integration-testing/bsd/cypress/e2e/configuration.cy.ts
+++ b/integration-testing/bsd/cypress/e2e/configuration.cy.ts
@@ -56,14 +56,14 @@ describe('BSD and services/Scan', () => {
     cy.get('input[type="file"]').attachFile({
       filePath: 'ballot-package.zip',
     });
-    cy.contains('Uploading ballot package 1 of 8', { timeout: 10000 });
-    cy.contains('Uploading ballot package 2 of 8', { timeout: 10000 });
-    cy.contains('Uploading ballot package 3 of 8', { timeout: 10000 });
-    cy.contains('Uploading ballot package 4 of 8', { timeout: 10000 });
-    cy.contains('Uploading ballot package 5 of 8', { timeout: 10000 });
-    cy.contains('Uploading ballot package 6 of 8', { timeout: 10000 });
-    cy.contains('Uploading ballot package 7 of 8', { timeout: 10000 });
-    cy.contains('Uploading ballot package 8 of 8', { timeout: 10000 });
+    cy.contains('Loading ballot package 1 of 8', { timeout: 10000 });
+    cy.contains('Loading ballot package 2 of 8', { timeout: 10000 });
+    cy.contains('Loading ballot package 3 of 8', { timeout: 10000 });
+    cy.contains('Loading ballot package 4 of 8', { timeout: 10000 });
+    cy.contains('Loading ballot package 5 of 8', { timeout: 10000 });
+    cy.contains('Loading ballot package 6 of 8', { timeout: 10000 });
+    cy.contains('Loading ballot package 7 of 8', { timeout: 10000 });
+    cy.contains('Loading ballot package 8 of 8', { timeout: 10000 });
     cy.contains('Preparing VxCentralScan', { timeout: 10000 });
     cy.contains('Successfully Configured', { timeout: 20000 });
     cy.contains('Close').click();
@@ -75,7 +75,7 @@ describe('BSD and services/Scan', () => {
     cy.contains('No ballots have been scanned', { timeout: 30000 });
     cy.contains('Scan New Batch').click();
     cy.contains('A total of 1 ballot has been scanned in 1 batch.');
-    cy.contains('Export').click();
+    cy.contains('Save Results').click();
     cy.get('[data-testid="manual-export"]').click();
     cy.contains('Cancel').click();
     cy.contains('Admin').click();
@@ -84,7 +84,7 @@ describe('BSD and services/Scan', () => {
      * Potential solutions: upgrade to cypress 6.3.0 or intercept the file download? https://docs.cypress.io/faq/questions/using-cypress-faq#Is-there-a-way-to-test-that-a-file-got-downloaded-I-want-to-test-that-a-button-click-triggers-a-download
      * Intercepting the file download will require additional work to mark on the server that a backup happened.
      */
-    // cy.contains('Export Backup').click();
+    // cy.contains('Save Backup').click();
     // cy.contains('Delete Ballot Data').click();
     // cy.contains('Yes, Delete Ballot Data').click();
     // cy.contains('No ballots have been scanned', { timeout: 20000 });
@@ -103,7 +103,7 @@ describe('BSD and services/Scan', () => {
     // cy.contains('Confirm Ballot Removed and Continue Scanning').click();
     // cy.contains('Admin').click();
     // cy.contains('Toggle to Live Mode');
-    // cy.contains('Export Backup').click();
+    // cy.contains('Save Backup').click();
     // cy.contains('Delete Election Data from VxCentralScan').click();
     // cy.contains('Yes, Delete Election Data').click();
     // cy.contains('Are you sure?');

--- a/integration-testing/election-manager/cypress/e2e/candidate_contest_tallies.cy.ts
+++ b/integration-testing/election-manager/cypress/e2e/candidate_contest_tallies.cy.ts
@@ -124,7 +124,7 @@ describe('Election Manager can create SEMS tallies', () => {
     enterPin();
     mockCardRemoval();
     cy.contains('Tally').click();
-    cy.contains('Import CVR Files').click();
+    cy.contains('Load CVR Files').click();
     cy.get('input[data-testid="manual-input"]').attachFile({
       fileContent: new Blob([fakeCvrFileContents]),
       fileName: 'cvrFile.jsonl',
@@ -230,7 +230,7 @@ describe('Election Manager can create SEMS tallies', () => {
     });
     cy.contains('Back to Reports').click();
 
-    // Check that the exported SEMS result file as the correct tallies
+    // Check that the saved SEMS result file as the correct tallies
     cy.contains('Save Results File').click();
     cy.get('[data-testid="manual-export"]').click();
     cy.contains('Results Saved');

--- a/integration-testing/election-manager/cypress/e2e/tallies.cy.ts
+++ b/integration-testing/election-manager/cypress/e2e/tallies.cy.ts
@@ -28,7 +28,7 @@ describe('Election Manager can create SEMS tallies', () => {
     enterPin();
     mockCardRemoval();
     cy.contains('Tally').click();
-    cy.contains('Import CVR Files').click();
+    cy.contains('Load CVR Files').click();
     cy.get('input[data-testid="manual-input"]').attachFile(
       'multiPartyPrimaryCVRResults.jsonl'
     );

--- a/integration-testing/election-manager/cypress/e2e/yes_no_contest_tallies.cy.ts
+++ b/integration-testing/election-manager/cypress/e2e/yes_no_contest_tallies.cy.ts
@@ -175,7 +175,7 @@ describe('Election Manager can create SEMS tallies', () => {
     enterPin();
     mockCardRemoval();
     cy.contains('Tally').click();
-    cy.contains('Import CVR Files').click();
+    cy.contains('Load CVR Files').click();
     cy.get('input[data-testid="manual-input"]').attachFile({
       fileContent: new Blob([fakeCvrFileContents]),
       fileName: 'cvrFile.jsonl',
@@ -500,7 +500,7 @@ describe('Election Manager can create SEMS tallies', () => {
     );
     cy.contains('Back to Reports').click();
 
-    // Check that the exported SEMS result file as the correct tallies
+    // Check that the saved SEMS result file as the correct tallies
     cy.contains('Save Results File').click();
     cy.get('[data-testid="manual-export"]').click();
     cy.contains('Results Saved', { timeout: 8000 });

--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -222,7 +222,7 @@ IDs are logged with each log to identify the log being written.
 **Type:** [user-action](#user-action)  
 **Description:** User has finished overriding the thresholds of when to count marks seen by the scanning module. Success or failure is indicated by the disposition. New mark thresholds specified in the keys `marginal` `definite` and, if defined, `writeInText`.  
 **Machines:** vx-central-scan-frontend, vx-precinct-scan-frontend
-### saved-backup-scan-images
+### saved-scan-image-backup
 **Type:** [user-action](#user-action)  
 **Description:** User saved a backup file of the scanned ballot image files and CVRs. Success or failure indicated by disposition.  
 **Machines:** vx-central-scan-frontend, vx-precinct-scan-frontend

--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -100,23 +100,23 @@ IDs are logged with each log to identify the log being written.
 **Machines:** All
 ### load-from-storage
 **Type:** [application-action](#application-action)  
-**Description:** A piece of information (current election, imported CVR files, etc.) is loaded from storage. May happen as an automated action when an application starts up, or as a result of a user action.  
+**Description:** A piece of information (current election, loaded CVR files, etc.) is loaded from storage. May happen as an automated action when an application starts up, or as a result of a user action.  
 **Machines:** All
 ### save-to-storage
 **Type:** [user-action](#user-action)  
-**Description:** A piece of information is saved to storage, usually resulting from a user action for example a user importing CVR files results in those files being saved to storage.  
+**Description:** A piece of information is saved to storage, usually resulting from a user action for example a user loading CVR files results in those files being saved to storage.  
 **Machines:** All
 ### file-saved
 **Type:** [user-action](#user-action)  
 **Description:** File is saved to a USB drive. Success or failure indicated by disposition. Type of file specified with "fileType" key. For success logs the saved filename specified with "filename" key.  
 **Machines:** All
-### export-ballot-package-init
+### save-ballot-package-init
 **Type:** [user-action](#user-action)  
-**Description:** Exporting the ballot package is initiated.  
+**Description:** Saving the ballot package is initiated.  
 **Machines:** vx-admin-frontend
-### export-ballot-package-complete
+### save-ballot-package-complete
 **Type:** [user-action](#user-action)  
-**Description:** Exporting the ballot package completed, success or failure is indicated by the disposition.  
+**Description:** Saving the ballot package completed, success or failure is indicated by the disposition.  
 **Machines:** vx-admin-frontend
 ### ballot-printed
 **Type:** [user-action](#user-action)  
@@ -146,13 +146,13 @@ IDs are logged with each log to identify the log being written.
 **Type:** [user-action](#user-action)  
 **Description:** Smartcard is programmed to override a flag protecting writes on the card. By default admin cards can not be written unless write protection is first overridden.  
 **Machines:** vx-admin-frontend
-### cvr-imported
+### cvr-loaded
 **Type:** [user-action](#user-action)  
-**Description:** User imported CVR to the machine. Success or failure indicated by disposition.  
+**Description:** User loaded CVR to the machine. Success or failure indicated by disposition.  
 **Machines:** vx-admin-frontend
 ### cvr-files-read-from-usb
 **Type:** [user-action](#user-action)  
-**Description:** User opened import CVR modal and usb is searched for possible CVR files to import.  
+**Description:** User opened load CVR modal and usb is searched for possible CVR files to load.  
 **Machines:** vx-admin-frontend
 ### recompute-tally-init
 **Type:** [user-action](#user-action)  
@@ -162,17 +162,17 @@ IDs are logged with each log to identify the log being written.
 **Type:** [user-action](#user-action)  
 **Description:** Tally recomputed with new cast vote record files, success or failure indicated by disposition.  
 **Machines:** vx-admin-frontend
-### external-tally-file-imported
+### external-tally-file-loaded
 **Type:** [user-action](#user-action)  
-**Description:** User imported external tally file to the machine. File type indicated by fileType key. Success or failure indicated by disposition.  
+**Description:** User loaded external tally file to the machine. File type indicated by fileType key. Success or failure indicated by disposition.  
 **Machines:** vx-admin-frontend
 ### manual-tally-data-edited
 **Type:** [user-action](#user-action)  
-**Description:** User added or edited manually entered tally data to be included alongside imported Cvr files.  
+**Description:** User added or edited manually entered tally data to be included alongside loaded Cvr files.  
 **Machines:** vx-admin-frontend
 ### marked-tally-results-official
 **Type:** [user-action](#user-action)  
-**Description:** User marked the tally results as official. This disabled importing any more cvr or other tally data files.  
+**Description:** User marked the tally results as official. This disabled loading any more cvr or other tally data files.  
 **Machines:** vx-admin-frontend
 ### removed-tally-file
 **Type:** [user-action](#user-action)  
@@ -222,9 +222,9 @@ IDs are logged with each log to identify the log being written.
 **Type:** [user-action](#user-action)  
 **Description:** User has finished overriding the thresholds of when to count marks seen by the scanning module. Success or failure is indicated by the disposition. New mark thresholds specified in the keys `marginal` `definite` and, if defined, `writeInText`.  
 **Machines:** vx-central-scan-frontend, vx-precinct-scan-frontend
-### download-backup-scan-images
+### saved-backup-scan-images
 **Type:** [user-action](#user-action)  
-**Description:** User downloaded a backup file of the scanned ballot image files and CVRs. Success or failure indicated by disposition.  
+**Description:** User saved a backup file of the scanned ballot image files and CVRs. Success or failure indicated by disposition.  
 **Machines:** vx-central-scan-frontend, vx-precinct-scan-frontend
 ### configure-from-ballot-package-init
 **Type:** [user-action](#user-action)  
@@ -232,7 +232,7 @@ IDs are logged with each log to identify the log being written.
 **Machines:** vx-central-scan-frontend, vx-precinct-scan-frontend
 ### ballot-package-files-read-from-usb
 **Type:** [user-action](#user-action)  
-**Description:** List of ballot packages read from usb and displayed to user to import to machine.  
+**Description:** List of ballot packages read from usb and displayed to user to load to machine.  
 **Machines:** vx-central-scan-frontend, vx-precinct-scan-frontend
 ### ballot-package-load-from-usb-complete
 **Type:** [user-action](#user-action)  
@@ -246,13 +246,13 @@ IDs are logged with each log to identify the log being written.
 **Type:** [user-action](#user-action)  
 **Description:** The final configuration steps for the scanner for the ballot package have completed. Success or failure indicated by disposition.  
 **Machines:** vx-central-scan-frontend, vx-precinct-scan-frontend
-### export-cvr-init
+### save-cvr-init
 **Type:** [user-action](#user-action)  
-**Description:** User has initiated exporting CVR file to the USB drive.  
+**Description:** User has initiated saving CVR file to the USB drive.  
 **Machines:** vx-central-scan-frontend, vx-precinct-scan-frontend
-### export-cvr-complete
+### save-cvr-complete
 **Type:** [user-action](#user-action)  
-**Description:** User has finished exporting a CVR file of all results to the USB drive. Success or failure indicated by disposition. On success, number of ballots included in CVR specified by `numberOfBallots`.  
+**Description:** User has finished saving a CVR file of all results to the USB drive. Success or failure indicated by disposition. On success, number of ballots included in CVR specified by `numberOfBallots`.  
 **Machines:** vx-central-scan-frontend, vx-precinct-scan-frontend
 ### delete-cvr-batch-init
 **Type:** [user-action](#user-action)  
@@ -286,9 +286,9 @@ IDs are logged with each log to identify the log being written.
 **Type:** [application-status](#application-status)  
 **Description:** Configuration information for the machine including the election, if the machine is in test mode, and mark threshold override values were reloaded from the backend service storing this information.  
 **Machines:** vx-central-scan-frontend, vx-precinct-scan-frontend
-### export-log-file-found
+### save-log-file-found
 **Type:** [application-status](#application-status)  
-**Description:** When the user is exporting logs, indicates the success/failure of finding the expected log file on the machine.  
+**Description:** When the user is saving logs, indicates the success/failure of finding the expected log file on the machine.  
 **Machines:** All
 ### scan-service-config
 **Type:** [application-status](#application-status)  
@@ -316,7 +316,7 @@ IDs are logged with each log to identify the log being written.
 **Machines:** vx-central-scan-frontend
 ### convert-log-cdf-complete
 **Type:** [user-action](#user-action)  
-**Description:** The user has converted the log file to a CDF format for export. Success or failure indicated by disposition.  
+**Description:** The user has converted the log file to a CDF format for saving. Success or failure indicated by disposition.  
 **Machines:** All
 ### convert-log-cdf-log-line-error
 **Type:** [user-action](#user-action)  

--- a/libs/logging/src/log_documentation.test.ts
+++ b/libs/logging/src/log_documentation.test.ts
@@ -32,7 +32,7 @@ describe('test cdf documentation generation', () => {
     // Make sure VxAdminFrontend specific logs are included.
     expect(structuredData.EventIdDescription).toContainEqual(
       expect.objectContaining({
-        Id: LogEventId.CvrImported,
+        Id: LogEventId.CvrLoaded,
       })
     );
     // Make sure a generic log to all apps is included
@@ -82,7 +82,7 @@ describe('test cdf documentation generation', () => {
     // Make sure VxAdminFrontend specific logs are NOT included
     expect(structuredData.EventIdDescription).not.toContainEqual(
       expect.objectContaining({
-        Id: LogEventId.CvrImported,
+        Id: LogEventId.CvrLoaded,
       })
     );
   });

--- a/libs/logging/src/log_event_ids.ts
+++ b/libs/logging/src/log_event_ids.ts
@@ -74,7 +74,7 @@ export enum LogEventId {
   ClearedBallotData = 'clear-ballot-data-complete',
   OverridingMarkThresholds = 'override-mark-threshold-init',
   OverrodeMarkThresholds = 'override-mark-thresholds-complete',
-  SavedScanImageBackup = 'saved-backup-scan-images',
+  SavedScanImageBackup = 'saved-scan-image-backup',
   ConfigureFromBallotPackageInit = 'configure-from-ballot-package-init',
   BallotPackageFilesReadFromUsb = 'ballot-package-files-read-from-usb',
   BallotPackagedLoadedFromUsb = 'ballot-package-load-from-usb-complete',

--- a/libs/logging/src/log_event_ids.ts
+++ b/libs/logging/src/log_event_ids.ts
@@ -43,8 +43,8 @@ export enum LogEventId {
   SaveToStorage = 'save-to-storage',
   FileSaved = 'file-saved',
   // VxAdmin specific user action logs
-  ExportBallotPackageInit = 'export-ballot-package-init',
-  ExportBallotPackageComplete = 'export-ballot-package-complete',
+  SaveBallotPackageInit = 'save-ballot-package-init',
+  SaveBallotPackageComplete = 'save-ballot-package-complete',
   BallotPrinted = 'ballot-printed',
   PrintedBallotReportPrinted = 'printed-ballot-report-printed',
   SmartcardProgramInit = 'smartcard-program-init',
@@ -54,11 +54,11 @@ export enum LogEventId {
   // TODO(https://github.com/votingworks/vxsuite/issues/2085):
   // Remove SmartcardProgrammedOverrideWriteProtection when removing legacy smartcards screen
   SmartcardProgrammedOverrideWriteProtection = 'smartcard-programmed-override-write-protection',
-  CvrImported = 'cvr-imported',
+  CvrLoaded = 'cvr-loaded',
   CvrFilesReadFromUsb = 'cvr-files-read-from-usb',
   RecomputingTally = 'recompute-tally-init',
   RecomputedTally = 'recompute-tally-complete',
-  ExternalTallyFileImported = 'external-tally-file-imported',
+  ExternalTallyFileLoaded = 'external-tally-file-loaded',
   ManualTallyDataEdited = 'manual-tally-data-edited',
   MarkedTallyResultsOfficial = 'marked-tally-results-official',
   RemovedTallyFile = 'removed-tally-file',
@@ -74,14 +74,14 @@ export enum LogEventId {
   ClearedBallotData = 'clear-ballot-data-complete',
   OverridingMarkThresholds = 'override-mark-threshold-init',
   OverrodeMarkThresholds = 'override-mark-thresholds-complete',
-  DownloadedScanImageBackup = 'download-backup-scan-images',
+  SavedScanImageBackup = 'saved-backup-scan-images',
   ConfigureFromBallotPackageInit = 'configure-from-ballot-package-init',
   BallotPackageFilesReadFromUsb = 'ballot-package-files-read-from-usb',
   BallotPackagedLoadedFromUsb = 'ballot-package-load-from-usb-complete',
   BallotConfiguredOnMachine = 'ballot-configure-machine-complete',
   ScannerConfigured = 'scanner-configure-complete',
-  ExportCvrInit = 'export-cvr-init',
-  ExportCvrComplete = 'export-cvr-complete',
+  SaveCvrInit = 'save-cvr-init',
+  SaveCvrComplete = 'save-cvr-complete',
   DeleteScanBatchInit = 'delete-cvr-batch-init',
   DeleteScanBatchComplete = 'delete-cvr-batch-complete',
   ScanBatchInit = 'scan-batch-init',
@@ -90,7 +90,7 @@ export enum LogEventId {
   ScanBatchContinue = 'scan-batch-continue',
   ScanAdjudicationInfo = 'scan-adjudication-info',
   ScannerConfigReloaded = 'scanner-config-reloaded',
-  ExportLogFileFound = 'export-log-file-found',
+  SaveLogFileFound = 'save-log-file-found',
   ScanServiceConfigurationMessage = 'scan-service-config',
   AdminServiceConfigurationMessage = 'admin-service-config',
   FujitsuScanInit = 'fujitsu-scan-init',
@@ -270,27 +270,27 @@ const LoadFromStorage: LogDetails = {
   eventId: LogEventId.LoadFromStorage,
   eventType: LogEventType.ApplicationAction,
   documentationMessage:
-    'A piece of information (current election, imported CVR files, etc.) is loaded from storage. May happen as an automated action when an application starts up, or as a result of a user action.',
+    'A piece of information (current election, loaded CVR files, etc.) is loaded from storage. May happen as an automated action when an application starts up, or as a result of a user action.',
 };
 const SaveToStorage: LogDetails = {
   eventId: LogEventId.SaveToStorage,
   eventType: LogEventType.UserAction,
   documentationMessage:
-    'A piece of information is saved to storage, usually resulting from a user action for example a user importing CVR files results in those files being saved to storage.',
+    'A piece of information is saved to storage, usually resulting from a user action for example a user loading CVR files results in those files being saved to storage.',
 };
 
-const ExportBallotPackageInit: LogDetails = {
-  eventId: LogEventId.ExportBallotPackageInit,
+const SaveBallotPackageInit: LogDetails = {
+  eventId: LogEventId.SaveBallotPackageInit,
   eventType: LogEventType.UserAction,
-  documentationMessage: 'Exporting the ballot package is initiated.',
-  defaultMessage: 'User initiated exporting the ballot package...',
+  documentationMessage: 'Saving the ballot package is initiated.',
+  defaultMessage: 'User initiated saving the ballot package...',
   restrictInDocumentationToApps: [LogSource.VxAdminFrontend],
 };
-const ExportBallotPackageComplete: LogDetails = {
-  eventId: LogEventId.ExportBallotPackageComplete,
+const SaveBallotPackageComplete: LogDetails = {
+  eventId: LogEventId.SaveBallotPackageComplete,
   eventType: LogEventType.UserAction,
   documentationMessage:
-    'Exporting the ballot package completed, success or failure is indicated by the disposition.',
+    'Saving the ballot package completed, success or failure is indicated by the disposition.',
   restrictInDocumentationToApps: [LogSource.VxAdminFrontend],
 };
 
@@ -351,18 +351,18 @@ const SmartcardProgrammedOverrideWriteProtection: LogDetails = {
     'Smartcard is programmed to override a flag protecting writes on the card. By default admin cards can not be written unless write protection is first overridden.',
   restrictInDocumentationToApps: [LogSource.VxAdminFrontend],
 };
-const CvrImported: LogDetails = {
-  eventId: LogEventId.CvrImported,
+const CvrLoaded: LogDetails = {
+  eventId: LogEventId.CvrLoaded,
   eventType: LogEventType.UserAction,
   documentationMessage:
-    'User imported CVR to the machine. Success or failure indicated by disposition.',
+    'User loaded CVR to the machine. Success or failure indicated by disposition.',
   restrictInDocumentationToApps: [LogSource.VxAdminFrontend],
 };
 const CvrFilesReadFromUsb: LogDetails = {
   eventId: LogEventId.CvrFilesReadFromUsb,
   eventType: LogEventType.UserAction,
   documentationMessage:
-    'User opened import CVR modal and usb is searched for possible CVR files to import.',
+    'User opened load CVR modal and usb is searched for possible CVR files to load.',
   restrictInDocumentationToApps: [LogSource.VxAdminFrontend],
 };
 const RecomputingTally: LogDetails = {
@@ -380,25 +380,25 @@ const RecomputedTally: LogDetails = {
     'Tally recomputed with new cast vote record files, success or failure indicated by disposition.',
   restrictInDocumentationToApps: [LogSource.VxAdminFrontend],
 };
-const ExternalTallyFileImported: LogDetails = {
-  eventId: LogEventId.ExternalTallyFileImported,
+const ExternalTallyFileLoaded: LogDetails = {
+  eventId: LogEventId.ExternalTallyFileLoaded,
   eventType: LogEventType.UserAction,
   documentationMessage:
-    'User imported external tally file to the machine. File type indicated by fileType key. Success or failure indicated by disposition.',
+    'User loaded external tally file to the machine. File type indicated by fileType key. Success or failure indicated by disposition.',
   restrictInDocumentationToApps: [LogSource.VxAdminFrontend],
 };
 const ManualTallyDataEdited: LogDetails = {
   eventId: LogEventId.ManualTallyDataEdited,
   eventType: LogEventType.UserAction,
   documentationMessage:
-    'User added or edited manually entered tally data to be included alongside imported Cvr files.',
+    'User added or edited manually entered tally data to be included alongside loaded Cvr files.',
   restrictInDocumentationToApps: [LogSource.VxAdminFrontend],
 };
 const MarkedTallyResultsOfficial: LogDetails = {
   eventId: LogEventId.MarkedTallyResultsOfficial,
   eventType: LogEventType.UserAction,
   documentationMessage:
-    'User marked the tally results as official. This disabled importing any more cvr or other tally data files.',
+    'User marked the tally results as official. This disabled loading any more cvr or other tally data files.',
   restrictInDocumentationToApps: [LogSource.VxAdminFrontend],
 };
 const RemovedTallyFile: LogDetails = {
@@ -502,11 +502,11 @@ const OverrodeMarkThresholds: LogDetails = {
     LogSource.VxPrecinctScanFrontend,
   ],
 };
-const DownloadedScanImageBackup: LogDetails = {
-  eventId: LogEventId.DownloadedScanImageBackup,
+const SavedScanImageBackup: LogDetails = {
+  eventId: LogEventId.SavedScanImageBackup,
   eventType: LogEventType.UserAction,
   documentationMessage:
-    'User downloaded a backup file of the scanned ballot image files and CVRs. Success or failure indicated by disposition.',
+    'User saved a backup file of the scanned ballot image files and CVRs. Success or failure indicated by disposition.',
   restrictInDocumentationToApps: [
     LogSource.VxCentralScanFrontend,
     LogSource.VxPrecinctScanFrontend,
@@ -558,28 +558,27 @@ const BallotPackageFilesReadFromUsb: LogDetails = {
   eventId: LogEventId.BallotPackageFilesReadFromUsb,
   eventType: LogEventType.UserAction,
   documentationMessage:
-    'List of ballot packages read from usb and displayed to user to import to machine.',
+    'List of ballot packages read from usb and displayed to user to load to machine.',
   restrictInDocumentationToApps: [
     LogSource.VxCentralScanFrontend,
     LogSource.VxPrecinctScanFrontend,
   ],
 };
-const ExportCvrInit: LogDetails = {
-  eventId: LogEventId.ExportCvrInit,
+const SaveCvrInit: LogDetails = {
+  eventId: LogEventId.SaveCvrInit,
   eventType: LogEventType.UserAction,
-  documentationMessage:
-    'User has initiated exporting CVR file to the USB drive.',
-  defaultMessage: 'Exporting CVR file to USB...',
+  documentationMessage: 'User has initiated saving CVR file to the USB drive.',
+  defaultMessage: 'Saving CVR file to USB...',
   restrictInDocumentationToApps: [
     LogSource.VxCentralScanFrontend,
     LogSource.VxPrecinctScanFrontend,
   ],
 };
-const ExportCvrComplete: LogDetails = {
-  eventId: LogEventId.ExportCvrComplete,
+const SaveCvrComplete: LogDetails = {
+  eventId: LogEventId.SaveCvrComplete,
   eventType: LogEventType.UserAction,
   documentationMessage:
-    'User has finished exporting a CVR file of all results to the USB drive. Success or failure indicated by disposition. On success, number of ballots included in CVR specified by `numberOfBallots`.',
+    'User has finished saving a CVR file of all results to the USB drive. Success or failure indicated by disposition. On success, number of ballots included in CVR specified by `numberOfBallots`.',
   restrictInDocumentationToApps: [
     LogSource.VxCentralScanFrontend,
     LogSource.VxPrecinctScanFrontend,
@@ -645,17 +644,17 @@ const ScannerConfigReloaded: LogDetails = {
   ],
 };
 
-const ExportLogFileFound: LogDetails = {
-  eventId: LogEventId.ExportLogFileFound,
+const SaveLogFileFound: LogDetails = {
+  eventId: LogEventId.SaveLogFileFound,
   eventType: LogEventType.ApplicationStatus,
   documentationMessage:
-    'When the user is exporting logs, indicates the success/failure of finding the expected log file on the machine.',
+    'When the user is saving logs, indicates the success/failure of finding the expected log file on the machine.',
 };
 const LogConversionToCdfComplete: LogDetails = {
   eventId: LogEventId.LogConversionToCdfComplete,
   eventType: LogEventType.UserAction,
   documentationMessage:
-    'The user has converted the log file to a CDF format for export. Success or failure indicated by disposition.',
+    'The user has converted the log file to a CDF format for saving. Success or failure indicated by disposition.',
 };
 const LogConversionToCdfLogLineError: LogDetails = {
   eventId: LogEventId.LogConversionToCdfLogLineError,
@@ -792,10 +791,10 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return SaveToStorage;
     case LogEventId.LoadFromStorage:
       return LoadFromStorage;
-    case LogEventId.ExportBallotPackageInit:
-      return ExportBallotPackageInit;
-    case LogEventId.ExportBallotPackageComplete:
-      return ExportBallotPackageComplete;
+    case LogEventId.SaveBallotPackageInit:
+      return SaveBallotPackageInit;
+    case LogEventId.SaveBallotPackageComplete:
+      return SaveBallotPackageComplete;
     case LogEventId.BallotPrinted:
       return BallotPrinted;
     case LogEventId.PrintedBallotReportPrinted:
@@ -814,14 +813,14 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return SmartcardProgrammedOverrideWriteProtection;
     case LogEventId.CvrFilesReadFromUsb:
       return CvrFilesReadFromUsb;
-    case LogEventId.CvrImported:
-      return CvrImported;
+    case LogEventId.CvrLoaded:
+      return CvrLoaded;
     case LogEventId.RecomputingTally:
       return RecomputingTally;
     case LogEventId.RecomputedTally:
       return RecomputedTally;
-    case LogEventId.ExternalTallyFileImported:
-      return ExternalTallyFileImported;
+    case LogEventId.ExternalTallyFileLoaded:
+      return ExternalTallyFileLoaded;
     case LogEventId.ManualTallyDataEdited:
       return ManualTallyDataEdited;
     case LogEventId.MarkedTallyResultsOfficial:
@@ -850,8 +849,8 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return OverridingMarkThresholds;
     case LogEventId.OverrodeMarkThresholds:
       return OverrodeMarkThresholds;
-    case LogEventId.DownloadedScanImageBackup:
-      return DownloadedScanImageBackup;
+    case LogEventId.SavedScanImageBackup:
+      return SavedScanImageBackup;
     case LogEventId.ConfigureFromBallotPackageInit:
       return ConfigureFromBallotPackageInit;
     case LogEventId.BallotPackagedLoadedFromUsb:
@@ -862,10 +861,10 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return ScannerConfigured;
     case LogEventId.BallotPackageFilesReadFromUsb:
       return BallotPackageFilesReadFromUsb;
-    case LogEventId.ExportCvrInit:
-      return ExportCvrInit;
-    case LogEventId.ExportCvrComplete:
-      return ExportCvrComplete;
+    case LogEventId.SaveCvrInit:
+      return SaveCvrInit;
+    case LogEventId.SaveCvrComplete:
+      return SaveCvrComplete;
     case LogEventId.DeleteScanBatchInit:
       return DeleteScanBatchInit;
     case LogEventId.DeleteScanBatchComplete:
@@ -882,8 +881,8 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return ScanAdjudicationInfo;
     case LogEventId.ScannerConfigReloaded:
       return ScannerConfigReloaded;
-    case LogEventId.ExportLogFileFound:
-      return ExportLogFileFound;
+    case LogEventId.SaveLogFileFound:
+      return SaveLogFileFound;
     case LogEventId.ScanServiceConfigurationMessage:
       return ScanServiceConfigurationMessage;
     case LogEventId.AdminServiceConfigurationMessage:


### PR DESCRIPTION
## Overview
Closes #1443. Changes all user-facing (including in logs) file transfer language to be consistent:
- `Export`, `Download` --> `Save`
- `Import`, `Upload` --> `Load`

Touches three apps - `bsd`, `election-manager`, `precinct-scanner`. Also touches logging.

All variable names were left intact to make this a less risky change, with the exception of the `LogEventId` enumeration. So please pay closer attention to `LogEventId`'s in code review.

One copy nit - the `Export Ballot Package` Button was changed to `Export Package` to save screen space, and is now `Save Package`, which seems too vague. Suggest `Export Ballot Package`? 

## Demo Video or Screenshot

<img width="963" alt="Screen Shot 2022-08-12 at 1 48 57 PM" src="https://user-images.githubusercontent.com/37960853/184443352-b5e044b4-a28a-47b5-a380-67586a307973.png">
<img width="961" alt="Screen Shot 2022-08-12 at 1 45 32 PM" src="https://user-images.githubusercontent.com/37960853/184443365-41d30a20-324e-452c-b583-bf4906e590c1.png">
<img width="960" alt="Screen Shot 2022-08-12 at 1 45 43 PM" src="https://user-images.githubusercontent.com/37960853/184443362-9a6136b9-4a6d-401e-afd2-4a12fc9a8963.png">
<img width="959" alt="Screen Shot 2022-08-12 at 1 43 28 PM" src="https://user-images.githubusercontent.com/37960853/184443368-ed28a590-67d5-456e-b21a-6952af092db8.png">
<img width="364" alt="Screen Shot 2022-08-12 at 1 43 16 PM" src="https://user-images.githubusercontent.com/37960853/184443371-b0daaf78-a365-4591-82fa-b7c4b67a2aae.png">
<img width="959" alt="Screen Shot 2022-08-12 at 1 43 05 PM" src="https://user-images.githubusercontent.com/37960853/184443374-86674b05-0e13-4056-974a-8ca3807eb59a.png">

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
