### PR TITLE
center number pad icons

### DIFF
--- a/libs/ui/src/__snapshots__/number_pad.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/number_pad.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`snapshot 1`] = `
 <div
-  class="sc-eCImvq htBhMB"
+  class="sc-eCImvq lhLApJ"
   tabindex="0"
 >
   <button

--- a/libs/ui/src/number_pad.tsx
+++ b/libs/ui/src/number_pad.tsx
@@ -7,6 +7,8 @@ export const NumberPadContainer = styled.div`
   flex-wrap: wrap;
   justify-content: center;
   > button {
+    display: flex;
+    justify-content: center;
     margin: 2px;
     width: 26%;
   }


### PR DESCRIPTION
Icons in the number auth number pad were not centered. This style tweak centers them.

### Before
<img width="398" alt="Screen Shot 2022-08-12 at 1 41 25 PM" src="https://user-images.githubusercontent.com/37960853/184445305-891b3e7a-83d4-4267-8191-6151d966bf6c.png">


### After
<img width="365" alt="Screen Shot 2022-08-12 at 2 08 49 PM" src="https://user-images.githubusercontent.com/37960853/184445258-2c221481-6fd0-4b7d-aba4-8c6e3014da49.png">
