### PR TITLE
fix(smartcard): write pw card script

### DIFF
--- a/services/smartcards/writePollWorkerCard.py
+++ b/services/smartcards/writePollWorkerCard.py
@@ -13,7 +13,7 @@ election_bytes = f.read()
 f.close()
 
 short_value = json.dumps({
-    't': 'pollworker',
+    't': 'poll_worker',
     'h': hashlib.sha256(election_bytes).hexdigest(),
 })
 


### PR DESCRIPTION
`writePollWorkerCard.py` is not writing well-formed poll worker cards, because the `type` (`t`) field is incorrect. This single character PR fixes that.