### PR TITLE
fix(ps): Don't show scanning screen on accept after review

### DIFF
--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -580,9 +580,6 @@ export function AppRoot({
       case 'scanning':
       case 'ready_to_accept':
       case 'accepting':
-        // TODO if you review a ballot and choose to accept it, then we show
-        // this same scan processing screen, which is a little weird since we're
-        // not checking their ballot for errors anymore, we've already done that
         return <ScanProcessingScreen />;
       case 'accepted':
         return (
@@ -591,6 +588,7 @@ export function AppRoot({
           />
         );
       case 'needs_review':
+      case 'accepting_after_review':
         assert(scannerStatus.interpretation?.type === 'NeedsReviewSheet');
         return (
           <ScanWarningScreen

--- a/frontends/precinct-scanner/src/screens/scan_warning_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/scan_warning_screen.test.tsx
@@ -51,9 +51,11 @@ test('overvote', () => {
     )
   );
   userEvent.click(screen.getByRole('button', { name: 'Cast Ballot As Is' }));
-  userEvent.click(
-    screen.getByRole('button', { name: 'Yes, Cast Ballot As Is' })
-  );
+  const confirmButton = screen.getByRole('button', {
+    name: 'Yes, Cast Ballot As Is',
+  });
+  userEvent.click(confirmButton);
+  expect(confirmButton).toBeDisabled();
   expect(fetchMock.done()).toBe(true);
 });
 
@@ -68,9 +70,11 @@ test('blank ballot', () => {
   });
   screen.getByText('No votes were found when scanning this ballot.');
   userEvent.click(screen.getByRole('button', { name: 'Cast Ballot As Is' }));
-  userEvent.click(
-    screen.getByRole('button', { name: 'Yes, count blank ballot' })
-  );
+  const confirmButton = screen.getByRole('button', {
+    name: 'Yes, Cast Ballot As Is',
+  });
+  userEvent.click(confirmButton);
+  expect(confirmButton).toBeDisabled();
   expect(fetchMock.done()).toBe(true);
 });
 
@@ -95,9 +99,11 @@ test('undervote no votes', () => {
   screen.getByRole('heading', { name: 'Review Your Ballot' });
   screen.getByText(new RegExp(`No votes detected for: ${contest.title}.`));
   userEvent.click(screen.getByRole('button', { name: 'Cast Ballot As Is' }));
-  userEvent.click(
-    screen.getByRole('button', { name: 'Yes, Cast Ballot As Is' })
-  );
+  const confirmButton = screen.getByRole('button', {
+    name: 'Yes, Cast Ballot As Is',
+  });
+  userEvent.click(confirmButton);
+  expect(confirmButton).toBeDisabled();
   expect(fetchMock.done()).toBe(true);
 });
 
@@ -174,8 +180,10 @@ test('unreadable', () => {
 
   screen.getByRole('heading', { name: 'Scanning Failed' });
   userEvent.click(screen.getByRole('button', { name: 'Cast Ballot As Is' }));
-  userEvent.click(
-    screen.getByRole('button', { name: 'Yes, Cast Ballot As Is' })
-  );
+  const confirmButton = screen.getByRole('button', {
+    name: 'Yes, Cast Ballot As Is',
+  });
+  userEvent.click(confirmButton);
+  expect(confirmButton).toBeDisabled();
   expect(fetchMock.done()).toBe(true);
 });

--- a/frontends/precinct-scanner/src/screens/scan_warning_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/scan_warning_screen.tsx
@@ -30,6 +30,42 @@ import { AppContext } from '../contexts/app_context';
 import { toSentence } from '../utils/to_sentence';
 import { useSound } from '../hooks/use_sound';
 
+interface ConfirmModalProps {
+  content?: React.ReactNode;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+function ConfirmModal({ content, onConfirm, onCancel }: ConfirmModalProps) {
+  const [confirmed, setConfirmed] = useState(false);
+
+  return (
+    <Modal
+      theme={fontSizeTheme.large}
+      modalWidth={ModalWidth.Wide}
+      content={content}
+      actions={
+        <React.Fragment>
+          <Button
+            primary
+            onPress={() => {
+              setConfirmed(true);
+              onConfirm();
+            }}
+            disabled={confirmed}
+          >
+            Yes, Cast Ballot As Is
+          </Button>
+          <Button onPress={onCancel} disabled={confirmed}>
+            Cancel
+          </Button>
+        </React.Fragment>
+      }
+      onOverlayClick={onCancel}
+    />
+  );
+}
+
 interface OvervoteWarningScreenProps {
   electionDefinition: ElectionDefinition;
   overvotes: readonly OvervoteAdjudicationReasonInfo[];
@@ -77,9 +113,7 @@ function OvervoteWarningScreen({
         </Text>
       </CenteredLargeProse>
       {confirmTabulate && (
-        <Modal
-          theme={fontSizeTheme.large}
-          modalWidth={ModalWidth.Wide}
+        <ConfirmModal
           content={
             <Prose textCenter>
               <h1>Are you sure?</h1>
@@ -89,15 +123,8 @@ function OvervoteWarningScreen({
               </p>
             </Prose>
           }
-          actions={
-            <React.Fragment>
-              <Button primary onPress={scanner.acceptBallot}>
-                Yes, Cast Ballot As Is
-              </Button>
-              <Button onPress={() => setConfirmTabulate(false)}>Cancel</Button>
-            </React.Fragment>
-          }
-          onOverlayClick={() => setConfirmTabulate(false)}
+          onConfirm={scanner.acceptBallot}
+          onCancel={() => setConfirmTabulate(false)}
         />
       )}
     </ScreenMainCenterChild>
@@ -171,9 +198,7 @@ function UndervoteWarningScreen({
         </Text>
       </CenteredLargeProse>
       {confirmTabulate && (
-        <Modal
-          theme={fontSizeTheme.large}
-          modalWidth={ModalWidth.Wide}
+        <ConfirmModal
           content={
             <Prose textCenter>
               <h1>Are you sure?</h1>
@@ -197,20 +222,13 @@ function UndervoteWarningScreen({
                   </span>
                 )}
               </p>
-              <Text italic>
+              <Text italic small>
                 Your votes will count, even if you leave some blank.
               </Text>
             </Prose>
           }
-          actions={
-            <React.Fragment>
-              <Button primary onPress={scanner.acceptBallot}>
-                Yes, Cast Ballot As Is
-              </Button>
-              <Button onPress={() => setConfirmTabulate(false)}>Cancel</Button>
-            </React.Fragment>
-          }
-          onOverlayClick={() => setConfirmTabulate(false)}
+          onConfirm={scanner.acceptBallot}
+          onCancel={() => setConfirmTabulate(false)}
         />
       )}
     </ScreenMainCenterChild>
@@ -241,24 +259,15 @@ function BlankBallotWarningScreen(): JSX.Element {
         </Text>
       </CenteredLargeProse>
       {confirmTabulate && (
-        <Modal
-          theme={fontSizeTheme.large}
-          modalWidth={ModalWidth.Wide}
+        <ConfirmModal
           content={
             <Prose textCenter>
               <h1>Are you sure?</h1>
               <p>No votes will be counted from this ballot.</p>
             </Prose>
           }
-          actions={
-            <React.Fragment>
-              <Button primary onPress={scanner.acceptBallot}>
-                Yes, count blank ballot
-              </Button>
-              <Button onPress={() => setConfirmTabulate(false)}>Cancel</Button>
-            </React.Fragment>
-          }
-          onOverlayClick={() => setConfirmTabulate(false)}
+          onConfirm={scanner.acceptBallot}
+          onCancel={() => setConfirmTabulate(false)}
         />
       )}
     </ScreenMainCenterChild>
@@ -287,24 +296,15 @@ function OtherReasonWarningScreen(): JSX.Element {
         </Text>
       </CenteredLargeProse>
       {confirmTabulate && (
-        <Modal
-          theme={fontSizeTheme.large}
-          modalWidth={ModalWidth.Wide}
+        <ConfirmModal
           content={
             <Prose textCenter>
               <h1>Are you sure?</h1>
               <p>No votes will be recorded for this ballot.</p>
             </Prose>
           }
-          actions={
-            <React.Fragment>
-              <Button primary onPress={scanner.acceptBallot}>
-                Yes, Cast Ballot As Is
-              </Button>
-              <Button onPress={() => setConfirmTabulate(false)}>Cancel</Button>
-            </React.Fragment>
-          }
-          onOverlayClick={() => setConfirmTabulate(false)}
+          onConfirm={scanner.acceptBallot}
+          onCancel={() => setConfirmTabulate(false)}
         />
       )}
     </ScreenMainCenterChild>

--- a/libs/api/src/services/scan/index.ts
+++ b/libs/api/src/services/scan/index.ts
@@ -654,6 +654,7 @@ export const PrecinctScannerStateSchema = z.enum([
   'accepting',
   'accepted',
   'needs_review',
+  'accepting_after_review',
   'returning',
   'returned',
   'rejecting',

--- a/services/scan/src/precinct_scanner_app.test.ts
+++ b/services/scan/src/precinct_scanner_app.test.ts
@@ -389,7 +389,7 @@ test('ballot needs review - accept', async () => {
 
   await post(app, '/scanner/accept');
   await expectStatus(app, {
-    state: 'accepting',
+    state: 'accepting_after_review',
     interpretation,
   });
   await waitForStatus(app, {


### PR DESCRIPTION


## Overview
Accepting a ballot after review only takes about half a second. Previously, we showed the "Please wait, checking your ballot" screen, since it used the same code path as a ballot that didn't need review.

To fix this, we add a new state `accepting_after_review` to the state machine (which uses the same implementation as `accepting` - finally figured out how to reuse state machine logic).

The frontend is updated to disable the buttons in the modal for that half second, which provides enough visual feedback that the button press actually did something without being too disruptive.

## Demo Video or Screenshot

https://user-images.githubusercontent.com/530106/184453020-343fc88f-8f17-4e0f-9b79-036eefb6d82c.mov



## Testing Plan 
- Updated existing tests
- Manually tested with ballots of each review type

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
