### PR TITLE
Allow sys admins to unconfigure VxCentralScan without backing up

### DIFF
--- a/frontends/bsd/src/api/config.ts
+++ b/frontends/bsd/src/api/config.ts
@@ -92,9 +92,16 @@ export async function getElectionDefinition(): Promise<
   );
 }
 
-export async function setElection(electionData?: string): Promise<void> {
+export async function setElection(
+  electionData?: string,
+  { ignoreBackupRequirement }: { ignoreBackupRequirement?: boolean } = {}
+): Promise<void> {
   if (typeof electionData === 'undefined') {
-    await del('/config/election');
+    let deletionUrl = '/config/election';
+    if (ignoreBackupRequirement) {
+      deletionUrl += '?ignoreBackupRequirement=true';
+    }
+    await del(deletionUrl);
   } else {
     await patch<Scan.PatchElectionConfigRequest>(
       '/config/election',

--- a/frontends/bsd/src/app.test.tsx
+++ b/frontends/bsd/src/app.test.tsx
@@ -573,7 +573,9 @@ test('system administrator can log in and unconfigure machine', async () => {
     .get('/config/markThresholdOverrides', {
       body: getMarkThresholdOverridesResponseBody,
     })
-    .delete('/config/election', { body: deleteElectionConfigResponseBody });
+    .delete('/config/election?ignoreBackupRequirement=true', {
+      body: deleteElectionConfigResponseBody,
+    });
 
   const card = new MemoryCard();
   const hardware = MemoryHardware.buildStandard();

--- a/frontends/bsd/src/app_root.tsx
+++ b/frontends/bsd/src/app_root.tsx
@@ -251,25 +251,28 @@ export function AppRoot({ card, hardware, logger }: AppRootProps): JSX.Element {
     }
   }, [setStatus]);
 
-  const unconfigureServer = useCallback(async () => {
-    try {
-      await config.setElection(undefined);
-      await refreshConfig();
-      await logger.log(LogEventId.ElectionUnconfigured, userRole, {
-        disposition: 'success',
-        message:
-          'User successfully unconfigured the machine to remove the current election and all current ballot data.',
-      });
-      history.replace('/');
-    } catch (error) {
-      console.log('failed unconfigureServer()', error); // eslint-disable-line no-console
-      await logger.log(LogEventId.ElectionUnconfigured, userRole, {
-        disposition: 'failure',
-        message: 'Error in unconfiguring the current election on the machine',
-        result: 'Election not changed.',
-      });
-    }
-  }, [history, refreshConfig, logger, userRole]);
+  const unconfigureServer = useCallback(
+    async (options: { ignoreBackupRequirement?: boolean } = {}) => {
+      try {
+        await config.setElection(undefined, options);
+        await refreshConfig();
+        await logger.log(LogEventId.ElectionUnconfigured, userRole, {
+          disposition: 'success',
+          message:
+            'User successfully unconfigured the machine to remove the current election and all current ballot data.',
+        });
+        history.replace('/');
+      } catch (error) {
+        console.log('failed unconfigureServer()', error); // eslint-disable-line no-console
+        await logger.log(LogEventId.ElectionUnconfigured, userRole, {
+          disposition: 'failure',
+          message: 'Error in unconfiguring the current election on the machine',
+          result: 'Election not changed.',
+        });
+      }
+    },
+    [history, refreshConfig, logger, userRole]
+  );
 
   const scanBatch = useCallback(async () => {
     setIsScanning(true);
@@ -547,7 +550,9 @@ export function AppRoot({ card, hardware, logger }: AppRootProps): JSX.Element {
                 Election Manager card.
               </React.Fragment>
             }
-            unconfigureMachine={unconfigureServer}
+            unconfigureMachine={() =>
+              unconfigureServer({ ignoreBackupRequirement: true })
+            }
             usbDriveStatus={displayUsbStatus}
           />
           <ElectionInfoBar

--- a/services/scan/src/central_scanner_app.test.ts
+++ b/services/scan/src/central_scanner_app.test.ts
@@ -220,7 +220,7 @@ test('PATCH /config/election', async () => {
     });
 });
 
-test('DELETE /config/election error', async () => {
+test('DELETE /config/election no-backup error', async () => {
   importer.unconfigure.mockResolvedValue();
 
   // Add a new batch that hasn't been backed up yet
@@ -247,6 +247,19 @@ test('DELETE /config/election', async () => {
 
   await request(app)
     .delete('/config/election')
+    .set('Accept', 'application/json')
+    .expect(200, { status: 'ok' });
+  expect(importer.unconfigure).toBeCalled();
+});
+
+test('DELETE /config/election ignores lack of backup when ?ignoreBackupRequirement=true is specified', async () => {
+  importer.unconfigure.mockResolvedValue();
+
+  // Add a new batch that hasn't been backed up yet
+  workspace.store.addBatch();
+
+  await request(app)
+    .delete('/config/election?ignoreBackupRequirement=true')
     .set('Accept', 'application/json')
     .expect(200, { status: 'ok' });
   expect(importer.unconfigure).toBeCalled();

--- a/services/scan/src/central_scanner_app.ts
+++ b/services/scan/src/central_scanner_app.ts
@@ -106,8 +106,11 @@ export async function buildCentralScannerApp({
 
   app.delete<NoParams, Scan.DeleteElectionConfigResponse>(
     '/config/election',
-    async (_request, response) => {
-      if (!store.getCanUnconfigure()) {
+    async (request, response) => {
+      if (
+        !store.getCanUnconfigure() &&
+        request.query['ignoreBackupRequirement'] !== 'true' // A backup is required by default
+      ) {
         response.status(400).json({
           status: 'error',
           errors: [


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/2365

This PR allows system admins to unconfigure VxCentralScan without backing the machine up first. Some additional context from Roe in Slack:

> the original goal of this feature in SA mode was for us in demo'ing to easily reset a machine / unbork a card state

> now this does call into question whether we want to force a sysadmin to take the same pre-unconfigure steps as an election manager (exporting backups). I think we can trust the sysadmin to be responsible as this feature is not going to be the common unconfigure flow.

## Testing

- [x] Updated unit tests
- [x] Tested manually

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A
- [ ] ~I have added JSDoc comments to any newly introduced exports~ N/A
- [ ] ~I have added a screenshot and/or video to this PR to demo the change~ N/A
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates