### PR TITLE
Allow sys admins to unconfigure VxScan without backing up

### DIFF
--- a/frontends/precinct-scanner/src/api/config.test.ts
+++ b/frontends/precinct-scanner/src/api/config.test.ts
@@ -32,6 +32,14 @@ test('DELETE /config/election to delete election', async () => {
   await config.setElection(undefined);
 });
 
+test('DELETE /config/election ?ignoreBackupRequirement query param', async () => {
+  fetchMock.deleteOnce(
+    '/config/election?ignoreBackupRequirement=true',
+    JSON.stringify({ status: 'ok' })
+  );
+  await config.setElection(undefined, { ignoreBackupRequirement: true });
+});
+
 test('DELETE /config/election to delete election with bad API response', async () => {
   fetchMock.deleteOnce(
     '/config/election',

--- a/frontends/precinct-scanner/src/api/config.ts
+++ b/frontends/precinct-scanner/src/api/config.ts
@@ -83,9 +83,16 @@ export async function getElectionDefinition(): Promise<
   );
 }
 
-export async function setElection(electionData?: string): Promise<void> {
+export async function setElection(
+  electionData?: string,
+  { ignoreBackupRequirement }: { ignoreBackupRequirement?: boolean } = {}
+): Promise<void> {
   if (typeof electionData === 'undefined') {
-    await del('/config/election');
+    let deletionUrl = '/config/election';
+    if (ignoreBackupRequirement) {
+      deletionUrl += '?ignoreBackupRequirement=true';
+    }
+    await del(deletionUrl);
   } else {
     // TODO(528) add proper typing here
     await patch('/config/election', electionData);

--- a/frontends/precinct-scanner/src/app.test.tsx
+++ b/frontends/precinct-scanner/src/app.test.tsx
@@ -1182,7 +1182,9 @@ test('system administrator can log in and unconfigure machine', async () => {
       body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
     })
     .get('/scanner/status', { body: statusNoPaper })
-    .delete('/config/election', { body: deleteElectionConfigResponseBody });
+    .delete('/config/election?ignoreBackupRequirement=true', {
+      body: deleteElectionConfigResponseBody,
+    });
   render(<App card={card} storage={storage} hardware={hardware} />);
 
   card.insertCard(makeSystemAdministratorCard());

--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -363,15 +363,18 @@ export function AppRoot({
     await refreshConfig();
   }, [refreshConfig, isTestMode]);
 
-  const unconfigureServer = useCallback(async () => {
-    try {
-      await config.setElection(undefined);
-      dispatchAppState({ type: 'resetPollsToClosed' });
-      await refreshConfig();
-    } catch (error) {
-      debug('failed unconfigureServer()', error);
-    }
-  }, [refreshConfig]);
+  const unconfigureServer = useCallback(
+    async (options: { ignoreBackupRequirement?: boolean } = {}) => {
+      try {
+        await config.setElection(undefined, options);
+        dispatchAppState({ type: 'resetPollsToClosed' });
+        await refreshConfig();
+      } catch (error) {
+        debug('failed unconfigureServer()', error);
+      }
+    },
+    [refreshConfig]
+  );
 
   async function updatePrecinctId(precinctId: PrecinctId) {
     dispatchAppState({ type: 'updatePrecinctId', precinctId });
@@ -434,7 +437,9 @@ export function AppRoot({
               please insert an Election Manager or Poll Worker card.
             </React.Fragment>
           }
-          unconfigureMachine={unconfigureServer}
+          unconfigureMachine={() =>
+            unconfigureServer({ ignoreBackupRequirement: true })
+          }
           usbDriveStatus={usbDriveDisplayStatus}
         />
       </ScreenMainCenterChild>

--- a/services/scan/src/precinct_scanner_app.ts
+++ b/services/scan/src/precinct_scanner_app.ts
@@ -123,8 +123,11 @@ export function buildPrecinctScannerApp(
 
   app.delete<NoParams, Scan.DeleteElectionConfigResponse>(
     '/config/election',
-    (_request, response) => {
-      if (!store.getCanUnconfigure()) {
+    (request, response) => {
+      if (
+        !store.getCanUnconfigure() &&
+        request.query['ignoreBackupRequirement'] !== 'true'
+      ) {
         response.status(400).json({
           status: 'error',
           errors: [


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/2365

This PR allows system admins to unconfigure VxScan without backing the machine up first. This is the same change as https://github.com/votingworks/vxsuite/pull/2378 but for VxScan instead of VxCentralScan.

## Testing

- [x] Updated unit tests
- [ ] Tested manually (in-progress)

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A
- [ ] ~I have added JSDoc comments to any newly introduced exports~
- [ ] ~I have added a screenshot and/or video to this PR to demo the change~
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates