### PR TITLE
fix(scan): Return 404 on unknown route

### DIFF
--- a/services/scan/src/central_scanner_app.test.ts
+++ b/services/scan/src/central_scanner_app.test.ts
@@ -517,7 +517,7 @@ test('GET /scan/hmpb/ballot/:sheetId/image 404', async () => {
 });
 
 test('GET /', async () => {
-  await request(app).get('/').expect(301);
+  await request(app).get('/').expect(404);
 });
 
 test('POST /scan/hmpb/addTemplates bad template', async () => {

--- a/services/scan/src/central_scanner_app.ts
+++ b/services/scan/src/central_scanner_app.ts
@@ -677,12 +677,6 @@ export async function buildCentralScannerApp({
       .pipe(response);
   });
 
-  app.get('/*', (request, response) => {
-    const url = new URL(`http://${request.get('host')}${request.originalUrl}`);
-    url.port = '3000';
-    response.redirect(301, url.toString());
-  });
-
   // NOTE: this appears to cause web requests to block until restoreConfig is done.
   // if restoreConfig ends up on a background thread, we'll want to explicitly
   // return a "status: notready" or something like it.

--- a/services/scan/src/precinct_scanner_app.ts
+++ b/services/scan/src/precinct_scanner_app.ts
@@ -542,11 +542,5 @@ export async function buildPrecinctScannerApp(
     }
   );
 
-  app.get('/*', (request, response) => {
-    const url = new URL(`http://${request.get('host')}${request.originalUrl}`);
-    url.port = '3000';
-    response.redirect(301, url.toString());
-  });
-
   return app;
 }


### PR DESCRIPTION


## Overview
Instead of sending a 301 redirect on unknown routes, just let the default Express handler send a 404. This will make it easier to debug when this occurs, since most people know what 404 means.

## Demo Video or Screenshot
N/A
## Testing Plan 
Manually tested
## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
