### PR TITLE
chore(scan): Require explicit VX_MACHINE_TYPE

### DIFF
--- a/integration-testing/bsd/Makefile
+++ b/integration-testing/bsd/Makefile
@@ -20,5 +20,6 @@ build: build-scan build-bsd build-smartcards
 
 run:
 	export NODE_ENV=production
+	export VX_MACHINE_TYPE=bsd
 	(trap 'kill 0' SIGINT SIGHUP; make -C $(SMARTCARDS) run & make -C $(SCAN) run & make -C $(BSD) run)
 

--- a/integration-testing/bsd/Makefile
+++ b/integration-testing/bsd/Makefile
@@ -4,6 +4,7 @@ SMARTCARDS := ../../services/smartcards
 export PIPENV_VENV_IN_PROJECT=1
 export SCAN_WORKSPACE=/tmp
 export MOCK_SCANNER_FILES=../../libs/fixtures/data/electionFamousNames2021/sample-ballot-undervotes-p1.jpeg,../../libs/fixtures/data/electionFamousNames2021/sample-ballot-undervotes-p2.jpeg
+export VX_MACHINE_TYPE=bsd
 
 build-bsd:
 	make -C $(BSD) build; \
@@ -20,6 +21,5 @@ build: build-scan build-bsd build-smartcards
 
 run:
 	export NODE_ENV=production
-	export VX_MACHINE_TYPE=bsd
 	(trap 'kill 0' SIGINT SIGHUP; make -C $(SMARTCARDS) run & make -C $(SCAN) run & make -C $(BSD) run)
 

--- a/services/scan/README.md
+++ b/services/scan/README.md
@@ -12,7 +12,10 @@ then run the service like so:
 ```sh
 # in services/scan
 pnpm build:watch &
-pnpm dev
+# For central scanner
+VX_MACHINE_TYPE=bsd pnpm dev
+# For precinct scanner
+VX_MACHINE_TYPE=precinct-scanner pnpm dev
 ```
 
 The server will be available at http://localhost:3002/.
@@ -26,13 +29,13 @@ that's appropriate for you.
 
 ```sh
 # single batch with single sheet
-MOCK_SCANNER_FILES=front.jpeg,back.jpeg pnpm dev
+VX_MACHINE_TYPE=bsd MOCK_SCANNER_FILES=front.jpeg,back.jpeg pnpm dev
 
 # single batch with multiple sheets
-MOCK_SCANNER_FILES=front-01.jpeg,back-01.jpeg,front-02.jpeg,back-02.jpeg pnpm dev
+VX_MACHINE_TYPE=bsd MOCK_SCANNER_FILES=front-01.jpeg,back-01.jpeg,front-02.jpeg,back-02.jpeg pnpm dev
 
 # multiple batches with one sheet each (note ",," batch separator)
-MOCK_SCANNER_FILES=front-01.jpeg,back-01.jpeg,,front-02.jpeg,back-02.jpeg pnpm dev
+VX_MACHINE_TYPE=bsd MOCK_SCANNER_FILES=front-01.jpeg,back-01.jpeg,,front-02.jpeg,back-02.jpeg pnpm dev
 
 # use a manifest file
 cat <<EOS > manifest
@@ -44,11 +47,11 @@ back-01.jpeg
 front-02.jpeg
 back-02.jpeg
 EOS
-MOCK_SCANNER_FILES=@manifest pnpm dev
+VX_MACHINE_TYPE=bsd MOCK_SCANNER_FILES=@manifest pnpm dev
 
 # scanning from an election backup file
 ./bin/extract-backup /path/to/election-backup.zip
-MOCK_SCANNER_FILES=@/path/to/election-backup/manifest pnpm dev
+VX_MACHINE_TYPE=bsd MOCK_SCANNER_FILES=@/path/to/election-backup/manifest pnpm dev
 ```
 
 If you are seeing unhandled promise rejection errors you may have an issue with

--- a/services/scan/src/globals.ts
+++ b/services/scan/src/globals.ts
@@ -41,11 +41,6 @@ export const VX_MACHINE_TYPE = safeParse(
   MachineTypeSchema,
   process.env.VX_MACHINE_TYPE
 ).ok();
-if (!VX_MACHINE_TYPE) {
-  throw new Error(
-    'Environment variable VX_MACHINE_TYPE must be set to "bsd" or "precinct-scanner"'
-  );
-}
 
 export enum ScannerLocation {
   Central = 'Central',

--- a/services/scan/src/globals.ts
+++ b/services/scan/src/globals.ts
@@ -1,4 +1,4 @@
-import { unsafeParse } from '@votingworks/types';
+import { safeParse, unsafeParse } from '@votingworks/types';
 import { join } from 'path';
 import { z } from 'zod';
 
@@ -37,10 +37,15 @@ export const PORT = Number(process.env.PORT || 3002);
 /**
  * Which machine type is this?
  */
-export const VX_MACHINE_TYPE = unsafeParse(
+export const VX_MACHINE_TYPE = safeParse(
   MachineTypeSchema,
-  process.env.VX_MACHINE_TYPE ?? 'bsd'
-);
+  process.env.VX_MACHINE_TYPE
+).ok();
+if (!VX_MACHINE_TYPE) {
+  throw new Error(
+    'Environment variable VX_MACHINE_TYPE must be set to "bsd" or "precinct-scanner"'
+  );
+}
 
 export enum ScannerLocation {
   Central = 'Central',

--- a/services/scan/src/index.ts
+++ b/services/scan/src/index.ts
@@ -38,7 +38,7 @@ const createPlustekClient =
     : undefined;
 
 function getScanner(): Scanner | undefined {
-  if (VX_MACHINE_TYPE === 'precinct-scanner') return undefined;
+  if (VX_MACHINE_TYPE !== 'bsd') return undefined;
 
   const mockScannerFiles = parseBatchesFromEnv(MOCK_SCANNER_FILES);
   if (!mockScannerFiles) return undefined;

--- a/services/scan/src/server.ts
+++ b/services/scan/src/server.ts
@@ -45,6 +45,12 @@ export async function start({
   workspace,
   machineType = VX_MACHINE_TYPE,
 }: Partial<StartOptions> = {}): Promise<void> {
+  if (!VX_MACHINE_TYPE) {
+    throw new Error(
+      'Environment variable VX_MACHINE_TYPE must be set to "bsd" or "precinct-scanner"'
+    );
+  }
+
   let resolvedWorkspace: Workspace;
 
   if (workspace) {

--- a/services/scan/src/server.ts
+++ b/services/scan/src/server.ts
@@ -6,6 +6,7 @@
 import { Logger, LogEventId, LogSource } from '@votingworks/logging';
 import express, { Application } from 'express';
 import { createClient } from '@votingworks/plustek-sdk';
+import { assert } from '@votingworks/utils';
 import { PORT, SCAN_WORKSPACE, VX_MACHINE_TYPE } from './globals';
 import { Importer } from './importer';
 import { FujitsuScanner, Scanner, ScannerMode } from './scanners';
@@ -79,6 +80,7 @@ export async function start({
       resolvedWorkspace
     );
   } else {
+    assert(machineType === 'bsd');
     let resolvedScanner: Scanner;
     if (scanner) {
       resolvedScanner = scanner;


### PR DESCRIPTION


## Overview
A common error when running VxScan is forgetting to set VX_MACHINE_TYPE on services/scan, which will result in running the central scanner service. To prevent that, we fail loud and clear when the env variable is not set.

## Demo Video or Screenshot
N/A

## Testing Plan 
Manual test

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
