### PR TITLE
fix(cypress): Increase timeouts in all possible flaky tests

### DIFF
--- a/integration-testing/election-manager/cypress/e2e/candidate_contest_tallies.cy.ts
+++ b/integration-testing/election-manager/cypress/e2e/candidate_contest_tallies.cy.ts
@@ -113,7 +113,7 @@ describe('Election Manager can create SEMS tallies', () => {
       { contents: Cypress.Buffer.from(electionDefinition.electionData) },
       { force: true }
     );
-    cy.contains('Election loading');
+    cy.contains('Election loading', { timeout: 8000 });
     cy.contains(electionDefinition.electionHash.slice(0, 10));
     cy.pause();
     cy.contains('Lock Machine').click();
@@ -232,7 +232,7 @@ describe('Election Manager can create SEMS tallies', () => {
     // Check that the exported SEMS result file as the correct tallies
     cy.contains('Save SEMS Results').click();
     cy.get('[data-testid="manual-export"]').click();
-    cy.contains('Results Saved');
+    cy.contains('Results Saved', { timeout: 8000 });
     cy.task<string>('readMostRecentFile', 'cypress/downloads').then(
       (fileContent) => {
         assertExpectedResultsMatchSEMsFile(

--- a/integration-testing/election-manager/cypress/e2e/configuration.cy.ts
+++ b/integration-testing/election-manager/cypress/e2e/configuration.cy.ts
@@ -19,7 +19,7 @@ describe('Election Manager and Module Converter MS SEMS configuration', () => {
       'cypress/fixtures/semsCandidateMappingFile.txt',
       { force: true }
     );
-    cy.contains('Election loading');
+    cy.contains('Election loading', { timeout: 8000 });
     cy.contains('Special Election for Senate 15');
     cy.contains('0d610ab44c');
     // The page renders twice when first loaded, make sure that is done before we navigate.

--- a/integration-testing/election-manager/cypress/e2e/tallies.cy.ts
+++ b/integration-testing/election-manager/cypress/e2e/tallies.cy.ts
@@ -18,7 +18,7 @@ describe('Election Manager can create SEMS tallies', () => {
       { contents: Cypress.Buffer.from(electionDefinition.electionData) },
       { force: true }
     );
-    cy.contains('Election loading');
+    cy.contains('Election loading', { timeout: 8000 });
     cy.contains(electionDefinition.electionHash.slice(0, 10));
     cy.contains('Lock Machine').click();
     mockElectionManagerCardInsertion(
@@ -39,7 +39,7 @@ describe('Election Manager can create SEMS tallies', () => {
     cy.contains('Reports').click();
     cy.contains('Save SEMS Results').click();
     cy.get('[data-testid="manual-export"]').click();
-    cy.contains('Results Saved');
+    cy.contains('Results Saved', { timeout: 8000 });
     cy.task('readMostRecentFile', 'cypress/downloads').then((fileContent) => {
       const receivedLines = (fileContent as string).split('\r\n');
       for (const [i, expectedLine] of electionMultiPartyPrimaryFixtures.semsData


### PR DESCRIPTION


## Overview
We've seen some flaky election manager integration tests. We fixed specific cases by increasing timeouts. Here, we add those increased timeouts to all the analagous checks in other integration tests, since they have started to flake as well.
## Demo Video or Screenshot
N/A

## Testing Plan 
CI
## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
