### PR TITLE
fix(logging) log service logs without newlines

### DIFF
--- a/libs/logging/src/logger.test.ts
+++ b/libs/logging/src/logger.test.ts
@@ -27,15 +27,17 @@ test('logger logs server logs as expected', async () => {
     disposition: LogDispositionStandardTypes.Success,
     reputation: 'callitwhatyouwant',
   });
-  expect(console.log).toHaveBeenCalledWith({
-    source: LogSource.System,
-    eventId: LogEventId.MachineBootInit,
-    eventType: LogEventType.SystemAction,
-    user: 'system',
-    message: 'I come back stronger than a 90s trend',
-    disposition: LogDispositionStandardTypes.Success,
-    reputation: 'callitwhatyouwant',
-  });
+  expect(console.log).toHaveBeenCalledWith(
+    JSON.stringify({
+      source: LogSource.System,
+      eventId: LogEventId.MachineBootInit,
+      eventType: LogEventType.SystemAction,
+      user: 'system',
+      message: 'I come back stronger than a 90s trend',
+      disposition: LogDispositionStandardTypes.Success,
+      reputation: 'callitwhatyouwant',
+    })
+  );
 });
 
 test('logger logs client logs as expected through kiosk browser with overridden message', async () => {
@@ -93,17 +95,19 @@ test('logs unknown disposition as expected', async () => {
     ran: 'with',
     the: 'wolves',
   });
-  expect(console.log).toHaveBeenCalledWith({
-    source: LogSource.System,
-    eventId: LogEventId.MachineBootComplete,
-    eventType: LogEventType.SystemStatus,
-    user: 'system',
-    message: 'threw out our cloaks and our daggers now',
-    disposition: 'daylight',
-    maybe: 'you',
-    ran: 'with',
-    the: 'wolves',
-  });
+  expect(console.log).toHaveBeenCalledWith(
+    JSON.stringify({
+      source: LogSource.System,
+      eventId: LogEventId.MachineBootComplete,
+      eventType: LogEventType.SystemStatus,
+      user: 'system',
+      message: 'threw out our cloaks and our daggers now',
+      disposition: 'daylight',
+      maybe: 'you',
+      ran: 'with',
+      the: 'wolves',
+    })
+  );
 });
 
 test('logging from a client side app without sending window.kiosk does NOT log to console', async () => {

--- a/libs/logging/src/logger.ts
+++ b/libs/logging/src/logger.ts
@@ -95,7 +95,7 @@ export class Logger {
       }
     } else {
       // eslint-disable-next-line no-console
-      console.log(logLine);
+      console.log(JSON.stringify(logLine));
     }
   }
 


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
https://github.com/votingworks/vxsuite/issues/2388
When we log most of our logs we do it through kiosk-browser, we already call JSON.stringify on that log line so that the resulting log to stdout does not have newlines and can be properly matched and sorted as a single log line in rsyslog. However when we added the ability to also have services log directly to their own stdout we forgot to call JSON.stringify on these logs, meaning they had new lines and were just ending up in the syslog. Before Jonah added precinct-scanner logging we had no real logs coming through services so we didn't notice before. 

## Demo Video or Screenshot

## Testing Plan 
Locked down a VM and exported the logs and saw the scan-service logs now properly routed into vx-logs.log and without newlines

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
