### PR TITLE
Fix bug with resetting sys admin card PIN when there's no election definition

### DIFF
--- a/frontends/election-manager/src/components/smartcard_modal/card_details_view.tsx
+++ b/frontends/election-manager/src/components/smartcard_modal/card_details_view.tsx
@@ -58,7 +58,6 @@ export function CardDetailsView({
     );
 
   async function resetCardPin() {
-    assert(electionDefinition);
     assert(role === 'system_administrator' || role === 'election_manager');
 
     setActionStatus({
@@ -76,6 +75,7 @@ export function CardDetailsView({
         break;
       }
       case 'election_manager': {
+        assert(electionDefinition);
         result = await card.programUser({
           role: 'election_manager',
           electionData: electionDefinition.electionData,


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/2392

During m14 QA, we identified a bug with resetting system admin card PINs when there's no election definition. Clicking the button does nothing and results in an error under the hood. This PR implements a 1-line fix and adds a test to cover this case!

<img width="1624" alt="error" src="https://user-images.githubusercontent.com/12616928/185002880-2022824f-bed3-416c-afac-2408dedbbaaa.png">

## Testing Plan 

- [x] Added automated test
- [x] Tested manually

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A
- [ ] ~I have added JSDoc comments to any newly introduced exports~ N/A
- [ ] ~I have added a screenshot and/or video to this PR to demo the change~ N/A
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates