### PR TITLE
fix(scan): Fail when Plustek only returns one scanned page

### DIFF
--- a/libs/plustek-sdk/src/mocks.ts
+++ b/libs/plustek-sdk/src/mocks.ts
@@ -29,7 +29,7 @@ import {
 const debug = makeDebug('plustek-sdk:mock-client');
 
 interface Context {
-  sheetFiles?: readonly string[];
+  sheetFiles?: readonly [string, string];
   holdAfterReject?: boolean;
   jamOnNextOperation: boolean;
 }
@@ -42,7 +42,7 @@ type Event =
   | { type: 'FREEZE' }
   | {
       type: 'LOAD_SHEET';
-      sheetFiles: readonly string[];
+      sheetFiles: readonly [string, string];
     }
   | { type: 'REMOVE_SHEET' }
   | { type: 'SCAN' }
@@ -279,7 +279,7 @@ export class MockScannerClient implements ScannerClient {
    * Loads a sheet with scan images from `files`.
    */
   async simulateLoadSheet(
-    files: readonly string[]
+    files: readonly [string, string]
   ): Promise<Result<void, Errors>> {
     debug('manualLoad files=%o', files);
 
@@ -545,7 +545,7 @@ export class MockScannerClient implements ScannerClient {
         const files = this.machine.state.context.sheetFiles;
         assert(files);
         debug('scanned files=%o', files);
-        return ok({ files: files.slice() });
+        return ok({ files: [...files] });
       }
       case 'ready_to_eject': {
         debug('cannot scan, paper is held at back');

--- a/libs/plustek-sdk/src/mocks.ts
+++ b/libs/plustek-sdk/src/mocks.ts
@@ -118,7 +118,7 @@ const mockPlustekMachine = createMachine<Context, Event>({
       },
     },
     scanning: {
-      entry: send('CHECK_JAM_FLAG'),
+      entry: [assign({ scanError: undefined }), send('CHECK_JAM_FLAG')],
       after: { SCANNING_DELAY: 'ready_to_eject' },
       on: {
         SCAN_ERROR: [

--- a/libs/plustek-sdk/src/mocks.ts
+++ b/libs/plustek-sdk/src/mocks.ts
@@ -1,5 +1,5 @@
 import { err, ok, Result } from '@votingworks/types';
-import { assert, sleep } from '@votingworks/utils';
+import { assert, sleep, throwIllegalValue } from '@votingworks/utils';
 import makeDebug from 'debug';
 import {
   createMachine,
@@ -19,6 +19,7 @@ import {
   ClientError,
   CloseResult,
   GetPaperStatusResult,
+  InvalidClientResponseError,
   RejectResult,
   ScannerClient,
   ScanResult,
@@ -32,6 +33,7 @@ interface Context {
   sheetFiles?: readonly [string, string];
   holdAfterReject?: boolean;
   jamOnNextOperation: boolean;
+  scanError?: 'error_feeding' | 'bad_scan_result';
 }
 
 type Event =
@@ -49,7 +51,10 @@ type Event =
   | { type: 'ACCEPT' }
   | { type: 'REJECT'; hold: boolean }
   | { type: 'CALIBRATE' }
-  | { type: 'ERROR_FEEDING' }
+  | {
+      type: 'SCAN_ERROR';
+      error: 'error_feeding' | 'bad_scan_result';
+    }
   | { type: 'JAM_ON_NEXT_OPERATION' }
   | { type: 'CHECK_JAM_FLAG' };
 
@@ -116,7 +121,18 @@ const mockPlustekMachine = createMachine<Context, Event>({
       entry: send('CHECK_JAM_FLAG'),
       after: { SCANNING_DELAY: 'ready_to_eject' },
       on: {
-        ERROR_FEEDING: 'ready_to_scan',
+        SCAN_ERROR: [
+          {
+            target: 'ready_to_scan',
+            actions: assign({ scanError: (_context, event) => event.error }),
+            cond: (_context, event) => event.error === 'error_feeding',
+          },
+          {
+            target: 'ready_to_eject',
+            actions: assign({ scanError: (_context, event) => event.error }),
+            cond: (_context, event) => event.error === 'bad_scan_result',
+          },
+        ],
         LOAD_SHEET: 'both_sides_have_paper',
       },
     },
@@ -356,9 +372,9 @@ export class MockScannerClient implements ScannerClient {
   /**
    * Run during a scan operation to simulate an error pulling the paper into the scanner.
    */
-  simulateErrorFeeding(): void {
-    debug('simulating error feeding');
-    this.machine.send({ type: 'ERROR_FEEDING' });
+  simulateScanError(error: 'error_feeding' | 'bad_scan_result'): void {
+    debug('simulating scan error: %o', error);
+    this.machine.send({ type: 'SCAN_ERROR', error });
   }
 
   /**
@@ -521,24 +537,40 @@ export class MockScannerClient implements ScannerClient {
       case 'ready_to_scan': {
         this.machine.send({ type: 'SCAN' });
         await waitFor(this.machine, (state) => state.value !== 'scanning');
-        if ((this.machine.state.value as string) === 'jam') {
+        const {
+          value,
+          context: { scanError },
+        } = this.machine.state;
+        if (scanError) {
+          debug('scan failed, error');
+          switch (scanError) {
+            case 'error_feeding':
+              /* istanbul ignore next - randomness makes this hard to cover */
+              return err(
+                Math.random() > 0.5
+                  ? ScannerError.PaperStatusErrorFeeding
+                  : ScannerError.PaperStatusNoPaper
+              );
+            case 'bad_scan_result':
+              return err(
+                new InvalidClientResponseError(
+                  'expected two files, got [ file1.jpg ]'
+                )
+              );
+            /* istanbul ignore next - compile time check for completeness */
+            default:
+              throwIllegalValue(scanError);
+          }
+        }
+        if ((value as string) === 'jam') {
           debug('scan failed, jam');
           return err(ScannerError.PaperStatusJam);
         }
-        if ((this.machine.state.value as string) === 'ready_to_scan') {
-          debug('scan failed, error feeding');
-          /* istanbul ignore next - randomness makes this hard to cover */
-          return err(
-            Math.random() > 0.5
-              ? ScannerError.PaperStatusErrorFeeding
-              : ScannerError.PaperStatusNoPaper
-          );
-        }
-        if ((this.machine.state.value as string) === 'both_sides_have_paper') {
+        if ((value as string) === 'both_sides_have_paper') {
           debug('scan failed, both sides have paper');
           return err(ScannerError.PaperStatusErrorFeeding);
         }
-        if ((this.machine.state.value as string) === 'powered_off') {
+        if ((value as string) === 'powered_off') {
           debug('scan failed, powered off');
           return err(ScannerError.PaperStatusErrorFeeding);
         }

--- a/services/scan/src/precinct_scanner_state_machine.ts
+++ b/services/scan/src/precinct_scanner_state_machine.ts
@@ -208,8 +208,7 @@ async function scan({ client }: Context): Promise<SheetOf<string>> {
   debug('Scanning');
   const scanResult = await client.scan();
   debug('Scan result: %o', scanResult);
-  const [front, back] = scanResult.unsafeUnwrap().files;
-  return [front, back];
+  return scanResult.unsafeUnwrap().files;
 }
 
 async function calibrate({ client }: Context) {
@@ -557,35 +556,41 @@ function buildMachine(
                 SCANNER_READY_TO_SCAN: 'error_scanning',
               },
             },
-            // If scanning fails, we should retry if the paper is still ready to be
-            // scanned and scanning failed for a known reason. We only retry up to a
-            // certain number of attempts.
             error_scanning: {
-              entry: assign({
-                failedScanAttempts: (context) => {
-                  assert(context.failedScanAttempts !== undefined);
-                  return context.failedScanAttempts + 1;
-                },
-              }),
-              always: {
-                target: '#rejected',
-                actions: assign({
-                  error: new PrecinctScannerError('scanning_failed'),
-                }),
-                cond: (context) => {
-                  assert(context.failedScanAttempts !== undefined);
-                  const gotExpectedScanningError =
-                    context.error === ScannerError.PaperStatusErrorFeeding ||
-                    context.error === ScannerError.PaperStatusNoPaper;
-                  const shouldRetry =
-                    (!context.error || gotExpectedScanningError) &&
-                    context.failedScanAttempts < MAX_FAILED_SCAN_ATTEMPTS;
-                  return !shouldRetry;
-                },
-              },
               invoke: pollPaperStatus,
               on: {
-                SCANNER_READY_TO_SCAN: 'starting_scan',
+                SCANNER_READY_TO_SCAN: [
+                  // If the paper is still in the front due to an error that
+                  // indicates the paper wasn't grabbed or fed through the
+                  // scanner, retry (up to a certain number of attempts).
+                  {
+                    target: 'starting_scan',
+                    cond: (context) => {
+                      assert(context.failedScanAttempts !== undefined);
+                      const gotExpectedScanningError =
+                        context.error ===
+                          ScannerError.PaperStatusErrorFeeding ||
+                        context.error === ScannerError.PaperStatusNoPaper;
+                      const shouldRetry =
+                        (!context.error || gotExpectedScanningError) &&
+                        context.failedScanAttempts < MAX_FAILED_SCAN_ATTEMPTS;
+                      return shouldRetry;
+                    },
+                    actions: assign({
+                      failedScanAttempts: (context) => {
+                        assert(context.failedScanAttempts !== undefined);
+                        return context.failedScanAttempts + 1;
+                      },
+                    }),
+                  },
+                  // Otherwise, give up and ask for the ballot to be removed.
+                  {
+                    target: '#rejected',
+                    actions: assign({
+                      error: new PrecinctScannerError('scanning_failed'),
+                    }),
+                  },
+                ],
                 SCANNER_NO_PAPER: '#no_paper',
                 SCANNER_READY_TO_EJECT: '#rejecting',
               },

--- a/services/scan/src/precinct_scanner_state_machine.ts
+++ b/services/scan/src/precinct_scanner_state_machine.ts
@@ -573,7 +573,8 @@ function buildMachine(
                         context.error === ScannerError.PaperStatusNoPaper;
                       const shouldRetry =
                         (!context.error || gotExpectedScanningError) &&
-                        context.failedScanAttempts < MAX_FAILED_SCAN_ATTEMPTS;
+                        context.failedScanAttempts <
+                          MAX_FAILED_SCAN_ATTEMPTS - 1;
                       return shouldRetry;
                     },
                     actions: assign({

--- a/services/scan/src/scanners/plustek.ts
+++ b/services/scan/src/scanners/plustek.ts
@@ -320,7 +320,7 @@ export class PlustekScanner implements Scanner {
 }
 
 const PutMockRequestSchema = z.object({
-  files: z.array(z.string()),
+  files: z.tuple([z.string(), z.string()]),
 });
 
 export function plustekMockServer(client: MockScannerClient): Application {


### PR DESCRIPTION
## Overview
Fixes: https://github.com/votingworks/vxsuite/issues/2400

Previously, if Plustek only returned one page, the scanner would hang (due to unclear hanging behavior from canvas.loadImage). One contributing factor is that we were converting an array of files returned by plustekctl into a pair of files without checking that the array had exactly two files in it. While we don't know the root cause of why plustekctl only returns one file sometimes, we can at least fail better, rejecting the ballot so it can be scanned again.

Here, we modify plustek-sdk to validate that two files were returned, and fail otherwise. The precinct scanner state machine also needed to be modified to better handle scanning errors, since this particular type of error results in the paper being kept in the back. We hadn't seen this type of scanning error before, so we weren't handling it well (going straight to the `rejected` state, which assumes the ballot is still in the front). Now, we check where the paper is before deciding what state to go to.

## Demo Video or Screenshot
N/A

## Testing Plan 
- I couldn't reproduce the real error, so I tested this by hardcoding bad results into `plustek-sdk` to make sure the state machine handled it well.
- I also added a test in `plustek-sdk` to make sure we parse this case correctly from `plustekctl` output.
- And added a test for the state machine behavior change

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
