### PR TITLE
Fix testCardReader script

### DIFF
--- a/services/smartcards/testCardReader.py
+++ b/services/smartcards/testCardReader.py
@@ -64,12 +64,12 @@ def test_card():
     check_equal_bytes(short_bytes, observer.read()[0], "Short value")
     check_equal_bytes(long_bytes, observer.read_long(), "Long value")
 
-    print("Testing admin card")
-    with open("fixtures/admin/long.json", "r") as long_file:
+    print("Testing election manager card")
+    with open("fixtures/election_manager/long.json", "r") as long_file:
         long = json.loads(long_file.read())
         del long["seal"]
         long_bytes = json.dumps(long).encode('utf-8')
-    with open("fixtures/admin/short.json", "r") as short_file:
+    with open("fixtures/election_manager/short.json", "r") as short_file:
         short_bytes = re.sub(
             r"{{hash\(long\)}}",
             hashlib.sha256(long_bytes).hexdigest(),


### PR DESCRIPTION
Quick fix! I just missed this script when I was updating our user role names in https://github.com/votingworks/vxsuite/pull/2284.

_Before_

```
$ python3.9 -m pipenv run python -m testCardReader
Card reader connected
Card inserted
Clearing card
Testing random bytes
Testing admin card
Traceback (most recent call last):
  File "/usr/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/arsalan/Workspace/code/vxsuite/services/smartcards/testCardReader.py", line 94, in <module>
    test_card()
  File "/home/arsalan/Workspace/code/vxsuite/services/smartcards/testCardReader.py", line 68, in test_card
    with open("fixtures/admin/long.json", "r") as long_file:
FileNotFoundError: [Errno 2] No such file or directory: 'fixtures/admin/long.json'
```

_After_

```
$ python3.9 -m pipenv run python -m testCardReader
Insert card reader
Card reader connected
Card inserted
Clearing card
Testing random bytes
Testing election manager card
✅ Test passed
```