### PR TITLE
fix(ps): Detect Plustek disconnection with scan service, not kiosk browser

### DIFF
--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -255,7 +255,6 @@ export function AppRoot({
     cardReader,
     computer,
     printer: printerInfo,
-    precinctScanner,
   } = useDevices({
     hardware,
     logger,
@@ -446,7 +445,7 @@ export function AppRoot({
     );
   }
 
-  if (!precinctScanner) {
+  if (scannerStatus?.state === 'disconnected') {
     return (
       <SetupScannerScreen
         batteryIsCharging={computer.batteryIsCharging}
@@ -563,10 +562,6 @@ export function AppRoot({
     switch (scannerStatus.state) {
       case 'connecting':
         return null;
-      case 'disconnected':
-        return (
-          <SetupScannerScreen batteryIsCharging={computer.batteryIsCharging} />
-        );
       case 'no_paper':
         return (
           <InsertBallotScreen


### PR DESCRIPTION




## Overview
Fixes #2402 

Currently, we have two ways of telling if the Plustek scanner is disconnected: kiosk browser's USB device list and the scan service scanner status. Kiosk browser can't differentiate between a powered off/unplugged scanner and a crashed scanner, while the scan service can. Here we change the frontend to only check the scan service status and ignore kiosk browser in order to have more precise error messages when the Plustek is not reachable.

When the Plustek has crashed, the scan service will return an "unrecoverable_error" status, at which point we show an error message with instructions to restart (this is already in place).

## Demo Video or Screenshot
N/A

## Testing Plan 
- Since I can't repro a Plustek crash, I simulated one and checked that we show the right screen. I also manually tested that powering off or unplugging the Plustek USB cord works.
- Added a new frontend unit test

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
