### PR TITLE
Use wrapper divs instead of overriding Prose styles to fix prod styling issue

### DIFF
--- a/frontends/election-manager/src/components/smartcard_modal/card_details_view.tsx
+++ b/frontends/election-manager/src/components/smartcard_modal/card_details_view.tsx
@@ -21,7 +21,7 @@ import {
 import { userRoleToReadableString } from './user_roles';
 
 const StatusMessageContainer = styled.div`
-  margin-bottom: 1.5em;
+  margin-bottom: 2.5em;
 `;
 
 function checkDoesCardElectionHashMatchMachineElectionHash(

--- a/frontends/election-manager/src/components/smartcard_modal/card_details_view.tsx
+++ b/frontends/election-manager/src/components/smartcard_modal/card_details_view.tsx
@@ -20,7 +20,7 @@ import {
 } from './status_message';
 import { userRoleToReadableString } from './user_roles';
 
-const ErrorStatusMessageProse = styled(Prose)`
+const StatusMessageContainer = styled.div`
   margin-bottom: 1.5em;
 `;
 
@@ -189,9 +189,11 @@ export function CardDetailsView({
   return (
     <React.Fragment>
       {actionStatus?.status === 'Error' && (
-        <ErrorStatusMessageProse textCenter theme={fontSizeTheme.medium}>
-          <SuccessOrErrorStatusMessage actionStatus={actionStatus} />
-        </ErrorStatusMessageProse>
+        <StatusMessageContainer>
+          <Prose textCenter theme={fontSizeTheme.medium}>
+            <SuccessOrErrorStatusMessage actionStatus={actionStatus} />
+          </Prose>
+        </StatusMessageContainer>
       )}
 
       <Prose textCenter theme={fontSizeTheme.medium}>

--- a/frontends/election-manager/src/components/smartcard_modal/program_election_card_view.tsx
+++ b/frontends/election-manager/src/components/smartcard_modal/program_election_card_view.tsx
@@ -14,7 +14,7 @@ import {
 } from './status_message';
 
 const StatusMessageContainer = styled.div`
-  margin-bottom: 1.5em;
+  margin-bottom: 2.5em;
 `;
 
 interface Props {

--- a/frontends/election-manager/src/components/smartcard_modal/program_election_card_view.tsx
+++ b/frontends/election-manager/src/components/smartcard_modal/program_election_card_view.tsx
@@ -13,7 +13,7 @@ import {
   SuccessOrErrorStatusMessage,
 } from './status_message';
 
-const StatusMessageProse = styled(Prose)`
+const StatusMessageContainer = styled.div`
   margin-bottom: 1.5em;
 `;
 
@@ -73,9 +73,11 @@ export function ProgramElectionCardView({
   return (
     <React.Fragment>
       {isSmartcardActionComplete(actionStatus) && (
-        <StatusMessageProse textCenter theme={fontSizeTheme.medium}>
-          <SuccessOrErrorStatusMessage actionStatus={actionStatus} />
-        </StatusMessageProse>
+        <StatusMessageContainer>
+          <Prose textCenter theme={fontSizeTheme.medium}>
+            <SuccessOrErrorStatusMessage actionStatus={actionStatus} />
+          </Prose>
+        </StatusMessageContainer>
       )}
 
       <Prose textCenter theme={fontSizeTheme.medium}>

--- a/frontends/election-manager/src/components/smartcard_modal/program_system_administrator_card_view.tsx
+++ b/frontends/election-manager/src/components/smartcard_modal/program_system_administrator_card_view.tsx
@@ -11,7 +11,7 @@ import {
 } from './status_message';
 
 const StatusMessageContainer = styled.div`
-  margin-bottom: 1.5em;
+  margin-bottom: 2.5em;
 `;
 
 interface Props {

--- a/frontends/election-manager/src/components/smartcard_modal/program_system_administrator_card_view.tsx
+++ b/frontends/election-manager/src/components/smartcard_modal/program_system_administrator_card_view.tsx
@@ -10,7 +10,7 @@ import {
   SuccessOrErrorStatusMessage,
 } from './status_message';
 
-const StatusMessageProse = styled(Prose)`
+const StatusMessageContainer = styled.div`
   margin-bottom: 1.5em;
 `;
 
@@ -45,9 +45,11 @@ export function ProgramSystemAdministratorCardView({
   return (
     <React.Fragment>
       {isSmartcardActionComplete(actionStatus) && (
-        <StatusMessageProse textCenter theme={fontSizeTheme.medium}>
-          <SuccessOrErrorStatusMessage actionStatus={actionStatus} />
-        </StatusMessageProse>
+        <StatusMessageContainer>
+          <Prose textCenter theme={fontSizeTheme.medium}>
+            <SuccessOrErrorStatusMessage actionStatus={actionStatus} />
+          </Prose>
+        </StatusMessageContainer>
       )}
 
       <Prose textCenter theme={fontSizeTheme.medium}>


### PR DESCRIPTION
## Overview

We recently found that styles are ordered differently in prod vs. dev, resulting in some styles losing precedence. For example, in prod, the space between smartcard modal status messages and headings is missing. This PR uses wrapper divs instead of overriding `Prose` styles to avoid this issue altogether in the smartcard modal. While we should still get to the bottom of the ordering difference in prod vs. dev, this is a safe and simple patch for m14.

## Screenshots

_Before_

<img width="1624" alt="before" src="https://user-images.githubusercontent.com/12616928/185202520-b15a39ad-a331-4d8c-94c7-2cf8fd7784b9.png">

_After_

<img width="1624" alt="after" src="https://user-images.githubusercontent.com/12616928/185208226-05eda369-fd49-4ffe-be39-752c38139592.png">

## Testing

- [x] Verified that, before this PR, the expected spacing is present when running with `pnpm start` and missing when running with `make -C frontends/election-manager build run`
- [x] Verified that, after this PR, the expected spacing is present both when running with `pnpm start` and when running with `make -C frontends/election-manager build run`

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A
- [ ] ~I have added JSDoc comments to any newly introduced exports~ N/A