### PR TITLE
fix(image-utils): ensure `ImageData` instances for `canvas`

### DIFF
--- a/libs/image-utils/src/debug.test.ts
+++ b/libs/image-utils/src/debug.test.ts
@@ -150,6 +150,26 @@ test('imageData', async () => {
   expect([...imageData.data.slice(0, 4)]).toEqual([255, 0, 0, 255]);
 });
 
+test('imageData with non-ImageData object', async () => {
+  const writeFn = jest.fn();
+  const width = 10;
+  const height = 10;
+  const imdebug = canvasDebugger(width, height, {
+    write: writeFn,
+  });
+
+  imdebug.imageData(0, 0, {
+    data: Uint8ClampedArray.of(255, 0, 0, 255),
+    width: 1,
+    height: 1,
+  });
+
+  imdebug.write('test');
+  expect(writeFn).toHaveBeenNthCalledWith(1, ['test'], expect.any(Buffer));
+  const imageData = toImageData(await loadImage(writeFn.mock.calls[0][1]));
+  expect([...imageData.data.slice(0, 4)]).toEqual([255, 0, 0, 255]);
+});
+
 test('noDebug', () => {
   const imdebug = noDebug();
 

--- a/libs/image-utils/src/image_data.ts
+++ b/libs/image-utils/src/image_data.ts
@@ -69,6 +69,18 @@ export const RGB_CHANNEL_COUNT = 3;
 export const RGBA_CHANNEL_COUNT = 4;
 
 /**
+ * Ensures the image data is an instance of ImageData.
+ */
+export function ensureImageData(imageData: ImageData): ImageData {
+  if (imageData instanceof ImageData) {
+    return imageData;
+  }
+
+  const { data, width, height } = imageData as ImageData;
+  return createImageData(data, width, height);
+}
+
+/**
  * Determines the number of channels in an image.
  */
 export function getImageChannelCount(image: ImageData): int {
@@ -179,7 +191,7 @@ export function toRgba(
   imageData: ImageData
 ): Result<ImageData, ImageProcessingError> {
   if (isRgba(imageData)) {
-    return ok(imageData);
+    return ok(ensureImageData(imageData));
   }
 
   if (isGrayscale(imageData)) {


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
When passing image data to the `canvas` APIs we need to ensure it's actually an instance of `ImageData`, not just an object conforming to the interface. This does that transparently so we can pass non-`ImageData` objects that nonetheless have the right properties.

## Demo Video or Screenshot
n/a

## Testing Plan 
Automated.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
