### PR TITLE
feat(scan): allow debug images in interpretation

### DIFF
--- a/services/scan/src/interpreter.ts
+++ b/services/scan/src/interpreter.ts
@@ -13,6 +13,7 @@ import {
   Interpreter as HmpbInterpreter,
   metadataFromBytes,
 } from '@votingworks/ballot-interpreter-vx';
+import { imageDebugger } from '@votingworks/image-utils';
 import {
   AdjudicationReason,
   AdjudicationReasonInfo,
@@ -291,7 +292,10 @@ export class Interpreter {
     }
 
     try {
-      const hmpbResult = await this.interpretHMPBFile(ballotImageData);
+      const hmpbResult = await this.interpretHMPBFile(
+        ballotImagePath,
+        ballotImageData
+      );
 
       if (hmpbResult) {
         timer.end();
@@ -374,16 +378,19 @@ export class Interpreter {
     };
   }
 
-  private async interpretHMPBFile({
-    image,
-    qrcode,
-  }: BallotImageData): Promise<InterpretFileResult | undefined> {
+  private async interpretHMPBFile(
+    ballotImagePath: string,
+    { image, qrcode }: BallotImageData
+  ): Promise<InterpretFileResult | undefined> {
     const hmpbInterpreter = this.getHmpbInterpreter();
     const { ballot, marks, mappedBallot, metadata } =
       await hmpbInterpreter.interpretBallot(
         image,
         metadataFromBytes(this.electionDefinition, Buffer.from(qrcode.data)),
-        { flipped: qrcode.position === 'top' }
+        {
+          flipped: qrcode.position === 'top',
+          imdebug: imageDebugger(ballotImagePath, image),
+        }
       );
     const { votes } = ballot;
 


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
Passes an `ImageDebugger` to `ballot-interpreter-vx` based on the `DEBUG` environment variable, allowing optional generation of debug images when running interpretation from the scan service.

## Demo Video or Screenshot
n/a

## Testing Plan 
Automated

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
