### PR TITLE
fix(scan): make `retry-scan` more reliable

### DIFF
--- a/services/scan/bin/retry-scan
+++ b/services/scan/bin/retry-scan
@@ -1,5 +1,16 @@
-#!/usr/bin/env bash
+#!/usr/bin/env node
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+require('esbuild-runner/register');
 
-pnpx esr --cache "${DIR}/../src/cli/retry-scan/main" "$@"
+require('../src/cli/retry-scan/main')
+  .main(process.argv.slice(2), {
+    stdout: process.stdout,
+    stderr: process.stderr,
+  })
+  .catch((error) => {
+    process.stderr.write(`CRASH: ${error}\n`);
+    return 1;
+  })
+  .then((code) => {
+    process.exitCode = code;
+  });

--- a/services/scan/src/cli/retry-scan/main.ts
+++ b/services/scan/src/cli/retry-scan/main.ts
@@ -198,15 +198,3 @@ export async function main(
 
   return 0;
 }
-
-/* istanbul ignore next */
-if (require.main === module) {
-  void main(process.argv.slice(2))
-    .catch((error) => {
-      process.stderr.write(`CRASH: ${error}\n`);
-      return 1;
-    })
-    .then((code) => {
-      process.exitCode = code;
-    });
-}


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
Running it with `pnpx esr` does not always work if `pnpx` isn't set up correctly. This new version works no matter how the script is invoked.

## Demo Video or Screenshot
n/a

## Testing Plan 
Automated.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
