### PR TITLE
build(ui): use more specific `eslint-disable` directive

### DIFF
--- a/libs/ui/src/set_clock.tsx
+++ b/libs/ui/src/set_clock.tsx
@@ -40,9 +40,7 @@ export function PickDateTimeModal({
 
   const updateTimePart: SelectChangeEventFunction = (event) => {
     const { name, value: stringValue } = event.currentTarget;
-    // This overly-aggressive directive is because BMD's react-scripts can't load
-    // our custom ESLint config properly. We need to update to react-scripts@4.
-    // eslint-disable-next-line
+    // eslint-disable-next-line vx/gts-safe-number-parse
     const partValue = parseInt(stringValue, 10);
     let { hour } = newValue;
     if (name === 'hour') {


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
Since we no longer use `react-scripts` we no longer have the problem that required the use of a broader `eslint-disable` directive. This commit removes the explanatory comment and updates the directive to disable the specific rule we are targeting.

## Demo Video or Screenshot
n/a

## Testing Plan 
Automated.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
