### PR TITLE
build(frontends): make `build` do both `tsc` and `vite`

### DIFF
--- a/frontends/bas/package.json
+++ b/frontends/bas/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "type-check": "tsc --build",
-    "build": "vite build",
+    "build": "pnpm type-check && vite build",
     "build:watch": "tsc --build --watch",
     "format": "prettier '**/*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
     "lint": "pnpm type-check && eslint . --fix && pnpm stylelint:run",

--- a/frontends/bmd/package.json
+++ b/frontends/bmd/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "type-check": "tsc --build",
-    "build": "vite build",
+    "build": "pnpm type-check && vite build",
     "build:watch": "tsc --build --watch",
     "build:resources": "res-to-ts --rootDir data --outDir src/data 'data/**/*.json'",
     "cypress:open": "cypress open",

--- a/frontends/bsd/package.json
+++ b/frontends/bsd/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "type-check": "tsc --build",
-    "build": "vite build",
+    "build": "pnpm type-check && vite build",
     "build:watch": "tsc --build --watch",
     "format": "prettier '**/*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
     "lint": "pnpm type-check && eslint . && pnpm stylelint:run",

--- a/frontends/election-manager/package.json
+++ b/frontends/election-manager/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "type-check": "tsc --build",
-    "build": "vite build",
+    "build": "pnpm type-check && vite build",
     "build:watch": "tsc --build --watch",
     "build:stubs": "script/build-stubs fs:src/stubs/fs.ts glob:src/stubs/glob.ts os:src/stubs/os.ts",
     "format": "prettier '**/*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",

--- a/frontends/precinct-scanner/package.json
+++ b/frontends/precinct-scanner/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "type-check": "tsc --build",
-    "build": "vite build",
+    "build": "pnpm type-check && vite build",
     "build:stubs": "script/build-stubs fs:src/stubs/fs.ts os:src/stubs/os.ts",
     "build:watch": "tsc --build --watch",
     "format": "prettier '**/*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
While the production build using `vite` does not require any of the libraries to be built in place, the prodserver requires `@votingworks/logging` to be built or starting BMD will fail. There is a different long-term fix for this which will transition us to a more "no builds in dev" and "bundle all the things in prod" system, but for now an easy workaround is just to ensure that both styles of builds are done: `tsc` for in-place building and `vite` for production bundling.

## Demo Video or Screenshot
n/a

## Testing Plan 
Tried it in the context of `vxsuite-complete-system`, and running only `./build.sh bmd` plus `./run.sh bmd` does successfully run BMD.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
