### PR TITLE
Address flaky tests by adding/extending waits

### DIFF
--- a/frontends/election-manager/src/components/export_ballot_pdfs_button.test.tsx
+++ b/frontends/election-manager/src/components/export_ballot_pdfs_button.test.tsx
@@ -1,4 +1,4 @@
-import { screen, within } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { fakeLogger, LogEventId } from '@votingworks/logging';
 import { fakeKiosk, fakeUsbDrive } from '@votingworks/test-utils';
@@ -50,7 +50,7 @@ test('modal renders insert usb screen appropriately', async () => {
     within(modal).getByAltText('Insert USB Image');
     userEvent.click(within(modal).getByText('Cancel'));
 
-    expect(screen.queryByRole('alertdialog')).toBeNull();
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
     unmount();
   }
 });
@@ -102,7 +102,7 @@ test('modal happy path flow works', async () => {
   userEvent.click(within(modal).getByText('Eject USB'));
   expect(ejectFunction).toHaveBeenCalledTimes(1);
   userEvent.click(within(modal).getByText('Close'));
-  expect(screen.queryByRole('alertdialog')).toBeNull();
+  await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
 });
 
 test('can select options to save different ballots', async () => {

--- a/frontends/election-manager/src/components/export_election_ballot_package_modal_button.test.tsx
+++ b/frontends/election-manager/src/components/export_election_ballot_package_modal_button.test.tsx
@@ -138,7 +138,9 @@ test('Modal renders export confirmation screen when usb detected and manual link
   within(modal).getByText(/Optionally, you may pick a custom save location./);
 
   fireEvent.click(within(modal).getByText('Custom'));
-  await waitFor(() => within(modal).getByText('Ballot Package Saved'));
+  await within(modal).findByText('Ballot Package Saved', undefined, {
+    timeout: 2000,
+  });
   await waitFor(() => {
     expect(interpretTemplate).toHaveBeenCalledTimes(
       2 /* pages per ballot */ *
@@ -231,7 +233,9 @@ test('Modal renders renders loading message while rendering ballots appropriatel
 
   fireEvent.click(getByText('Save'));
 
-  await waitFor(() => getByText('Ballot Package Saved'));
+  await screen.findByText('Ballot Package Saved', undefined, {
+    timeout: 2000,
+  });
   expect(window.kiosk!.writeFile).toHaveBeenCalledTimes(1);
   expect(window.kiosk!.makeDirectory).toHaveBeenCalledTimes(1);
 


### PR DESCRIPTION
@jonahkagan recently noticed some flaky tests that I believe I've also noticed. While I wasn't able to repro the failures locally, this PR adds/extends waits to make the failures less likely in CI.