### PR TITLE
fix(scan) reject ballots with the wrong precinct

### DIFF
--- a/services/scan/src/interpreter.test.ts
+++ b/services/scan/src/interpreter.test.ts
@@ -133,6 +133,66 @@ test('properly detects test ballot in live mode', async () => {
   );
 });
 
+test('properly detects bmd ballot with wrong precinct', async () => {
+  const ballotImagePath = join(
+    sampleBallotImagesPath,
+    'sample-batch-1-ballot-1.png'
+  );
+  const interpretationResult = await new Interpreter({
+    electionDefinition: {
+      ...electionSampleDefinition,
+      election: {
+        ...electionSampleDefinition.election,
+        markThresholds: { definite: 0.2, marginal: 0.17 },
+      },
+    },
+    testMode: true,
+    // TODO: remove this once the QR code is fixed (https://github.com/votingworks/vxsuite/issues/1524)
+    skipElectionHashCheck: true,
+    currentPrecinctId: '20',
+    adjudicationReasons:
+      electionSampleDefinition.election.centralScanAdjudicationReasons ?? [],
+  }).interpretFile({
+    ballotImagePath,
+    ballotImageFile: await readFile(ballotImagePath),
+    detectQrcodeResult: await detectQrcodeInFilePath(ballotImagePath),
+  });
+
+  expect(interpretationResult.interpretation.type).toEqual(
+    'InvalidPrecinctPage'
+  );
+});
+
+test('properly detects bmd ballot with correct precinct', async () => {
+  const ballotImagePath = join(
+    sampleBallotImagesPath,
+    'sample-batch-1-ballot-1.png'
+  );
+  const interpretationResult = await new Interpreter({
+    electionDefinition: {
+      ...electionSampleDefinition,
+      election: {
+        ...electionSampleDefinition.election,
+        markThresholds: { definite: 0.2, marginal: 0.17 },
+      },
+    },
+    testMode: true,
+    // TODO: remove this once the QR code is fixed (https://github.com/votingworks/vxsuite/issues/1524)
+    skipElectionHashCheck: true,
+    currentPrecinctId: '23',
+    adjudicationReasons:
+      electionSampleDefinition.election.centralScanAdjudicationReasons ?? [],
+  }).interpretFile({
+    ballotImagePath,
+    ballotImageFile: await readFile(ballotImagePath),
+    detectQrcodeResult: await detectQrcodeInFilePath(ballotImagePath),
+  });
+
+  expect(interpretationResult.interpretation.type).toEqual(
+    'InterpretedBmdPage'
+  );
+});
+
 test('detects a blank page', async () => {
   const ballotImagePath = join(sampleBallotImagesPath, 'blank-page.png');
   const interpretationResult = await new Interpreter({

--- a/services/scan/src/precinct_scanner_interpreter.ts
+++ b/services/scan/src/precinct_scanner_interpreter.ts
@@ -26,6 +26,7 @@ export interface InterpreterConfig {
   readonly ballotImagesPath: string;
   readonly markThresholdOverrides?: MarkThresholds;
   readonly testMode: boolean;
+  readonly currentPrecinctId?: string;
 }
 
 /**
@@ -219,12 +220,14 @@ async function vxInterpret(
     ballotImagesPath,
     layouts,
     markThresholdOverrides,
+    currentPrecinctId,
     testMode,
   } = config;
   const vxInterpreter = new VxInterpreter({
     electionDefinition,
     testMode,
     markThresholdOverrides,
+    currentPrecinctId,
     adjudicationReasons:
       (SCANNER_LOCATION === ScannerLocation.Central
         ? electionDefinition.election.centralScanAdjudicationReasons


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Implements enforcing the precinct that gets set when scanning for VxScan. 

@jonahkagan I didn't really understand the layout of the code here and what is for precinct-scanner or the general interpreter so I easily may have done this in the wrong spot. 

Will make a seperate PR for the merge to m14-release-branch as there are an annoying amount of conflicts. 
https://github.com/votingworks/vxsuite/issues/2438
## Demo Video or Screenshot

## Testing Plan 
Added automated tests
Manually tests configuring for a precinct verifying that precinct ballots (bmd and hmpb) can scan and other precincts can not. Changed precinct to a different precinct, repeated. Changed back to all precincts and verified everything could scan. Also tested that killing and restarting the app didn't change how things worked. 

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
