### PR TITLE
feat(ps) add mute sounds button

### DIFF
--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -93,6 +93,7 @@ interface FrontendState {
   isPollsOpen: boolean;
   ballotCountWhenBallotBagLastReplaced: number;
   initializedFromStorage: boolean;
+  isSoundMuted: boolean;
 }
 
 export interface State
@@ -119,6 +120,7 @@ const initialAppState: Readonly<FrontendState> = {
   isPollsOpen: false,
   ballotCountWhenBallotBagLastReplaced: 0,
   initializedFromStorage: false,
+  isSoundMuted: false,
 };
 
 const initialState: Readonly<State> = {
@@ -149,6 +151,7 @@ type AppAction =
   | { type: 'updatePrecinctId'; precinctId?: PrecinctId }
   | { type: 'updateMarkThresholds'; markThresholds?: MarkThresholds }
   | { type: 'togglePollsOpen' }
+  | { type: 'toggleIsSoundMuted' }
   | { type: 'ballotBagReplaced'; currentBallotCount: number }
   | { type: 'setMachineConfig'; machineConfig: MachineConfig };
 
@@ -211,6 +214,11 @@ function appReducer(state: State, action: AppAction): State {
         ...state,
         isPollsOpen: !state.isPollsOpen,
       };
+    case 'toggleIsSoundMuted':
+      return {
+        ...state,
+        isSoundMuted: !state.isSoundMuted,
+      };
     case 'ballotBagReplaced':
       return {
         ...state,
@@ -245,6 +253,7 @@ export function AppRoot({
     isPollsOpen,
     initializedFromStorage,
     machineConfig,
+    isSoundMuted,
   } = appState;
 
   const usbDrive = useUsbDrive({ logger });
@@ -361,6 +370,10 @@ export function AppRoot({
     dispatchAppState({ type: 'resetPollsToClosed' });
     await refreshConfig();
   }, [refreshConfig, isTestMode]);
+
+  const toggleIsSoundMuted = useCallback(() => {
+    dispatchAppState({ type: 'toggleIsSoundMuted' });
+  }, []);
 
   const unconfigureServer = useCallback(
     async (options: { ignoreBackupRequirement?: boolean } = {}) => {
@@ -483,6 +496,7 @@ export function AppRoot({
           currentMarkThresholds,
           machineConfig,
           auth,
+          isSoundMuted,
         }}
       >
         <ElectionManagerScreen
@@ -493,6 +507,7 @@ export function AppRoot({
           setMarkThresholdOverrides={updateMarkThresholds}
           unconfigure={unconfigureServer}
           usbDrive={usbDrive}
+          toggleIsSoundMuted={toggleIsSoundMuted}
         />
       </AppContext.Provider>
     );
@@ -526,6 +541,7 @@ export function AppRoot({
           currentMarkThresholds,
           machineConfig,
           auth,
+          isSoundMuted,
         }}
       >
         <PollWorkerScreen
@@ -640,6 +656,7 @@ export function AppRoot({
         currentMarkThresholds,
         machineConfig,
         auth,
+        isSoundMuted,
       }}
     >
       {voterScreen}

--- a/frontends/precinct-scanner/src/components/export_backup_modal.test.tsx
+++ b/frontends/precinct-scanner/src/components/export_backup_modal.test.tsx
@@ -31,6 +31,7 @@ test('renders loading screen when USB drive is mounting or ejecting in export mo
         value={{
           electionDefinition: electionSampleDefinition,
           machineConfig,
+          isSoundMuted: false,
           auth,
         }}
       >
@@ -59,6 +60,7 @@ test('render no USB found screen when there is not a mounted USB drive', () => {
         value={{
           electionDefinition: electionSampleDefinition,
           machineConfig,
+          isSoundMuted: false,
           auth,
         }}
       >
@@ -91,6 +93,7 @@ test('render export modal when a USB drive is mounted as expected and allows cus
       value={{
         electionDefinition: electionSampleDefinition,
         machineConfig,
+        isSoundMuted: false,
         auth,
       }}
     >
@@ -117,6 +120,7 @@ test('render export modal when a USB drive is mounted as expected and allows cus
       value={{
         electionDefinition: electionSampleDefinition,
         machineConfig,
+        isSoundMuted: false,
         auth,
       }}
     >
@@ -141,6 +145,7 @@ test('render export modal when a USB drive is mounted as expected and allows aut
     <AppContext.Provider
       value={{
         electionDefinition: electionSampleDefinition,
+        isSoundMuted: false,
         machineConfig,
         auth,
       }}
@@ -175,6 +180,7 @@ test('handles no USB drives', async () => {
     <AppContext.Provider
       value={{
         electionDefinition: electionSampleDefinition,
+        isSoundMuted: false,
         machineConfig,
         auth,
       }}
@@ -207,6 +213,7 @@ test('shows a specific error for file writer failure', async () => {
         electionDefinition: electionSampleDefinition,
         machineConfig,
         auth,
+        isSoundMuted: false,
       }}
     >
       <ExportBackupModal
@@ -243,6 +250,7 @@ test('shows a specific error for fetch failure', async () => {
       value={{
         electionDefinition: electionSampleDefinition,
         machineConfig,
+        isSoundMuted: false,
         auth,
       }}
     >

--- a/frontends/precinct-scanner/src/components/export_results_modal.test.tsx
+++ b/frontends/precinct-scanner/src/components/export_results_modal.test.tsx
@@ -29,6 +29,7 @@ test('renders loading screen when usb drive is mounting or ejecting in export mo
         value={{
           electionDefinition: electionSampleDefinition,
           machineConfig,
+          isSoundMuted: false,
           auth,
         }}
       >
@@ -58,6 +59,7 @@ test('render no usb found screen when there is not a mounted usb drive', () => {
       <AppContext.Provider
         value={{
           electionDefinition: electionSampleDefinition,
+          isSoundMuted: false,
           machineConfig,
           auth,
         }}
@@ -99,6 +101,7 @@ test('render export modal when a usb drive is mounted as expected and allows cus
       value={{
         electionDefinition: electionSampleDefinition,
         machineConfig,
+        isSoundMuted: false,
         auth,
       }}
     >
@@ -142,6 +145,7 @@ test('render export modal when a usb drive is mounted as expected and allows aut
     <AppContext.Provider
       value={{
         electionDefinition: electionSampleDefinition,
+        isSoundMuted: false,
         machineConfig,
         auth,
       }}
@@ -189,6 +193,7 @@ test('render export modal when a usb drive is mounted as expected and allows aut
     <AppContext.Provider
       value={{
         electionDefinition: electionSampleDefinition,
+        isSoundMuted: false,
         machineConfig,
         auth,
       }}
@@ -219,6 +224,7 @@ test('render export modal with errors when appropriate', async () => {
       value={{
         electionDefinition: electionSampleDefinition,
         machineConfig,
+        isSoundMuted: false,
         auth,
       }}
     >

--- a/frontends/precinct-scanner/src/components/live_check_modal.test.tsx
+++ b/frontends/precinct-scanner/src/components/live_check_modal.test.tsx
@@ -27,6 +27,7 @@ test('renders livecheck screen', async () => {
       value={{
         electionDefinition,
         machineConfig,
+        isSoundMuted: false,
         auth,
       }}
     >

--- a/frontends/precinct-scanner/src/contexts/app_context.ts
+++ b/frontends/precinct-scanner/src/contexts/app_context.ts
@@ -13,12 +13,14 @@ export interface AppContextInterface {
   currentPrecinctId?: PrecinctId;
   currentMarkThresholds?: MarkThresholds;
   auth: InsertedSmartcardAuth.Auth;
+  isSoundMuted: boolean;
 }
 
 const appContext: AppContextInterface = {
   electionDefinition: undefined,
   currentPrecinctId: undefined,
   currentMarkThresholds: undefined,
+  isSoundMuted: false,
   machineConfig: {
     machineId: '0000',
     codeVersion: '',

--- a/frontends/precinct-scanner/src/hooks/use_sound.ts
+++ b/frontends/precinct-scanner/src/hooks/use_sound.ts
@@ -1,6 +1,13 @@
+import { useContext } from 'react';
 import useSoundLib from 'use-sound';
+import { AppContext } from '../contexts/app_context';
 
 export function useSound(sound: 'success' | 'warning' | 'error'): () => void {
   const [playSound] = useSoundLib(`/sounds/${sound}.mp3`);
+  const { isSoundMuted } = useContext(AppContext);
+  if (isSoundMuted) {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    return () => {};
+  }
   return playSound;
 }

--- a/frontends/precinct-scanner/src/preview_dashboard.tsx
+++ b/frontends/precinct-scanner/src/preview_dashboard.tsx
@@ -143,6 +143,7 @@ export function PreviewDashboard({
         },
         electionDefinition,
         auth: { status: 'logged_out', reason: 'no_card' },
+        isSoundMuted: false,
       }}
     >
       <BrowserRouter>

--- a/frontends/precinct-scanner/src/screens/election_manager_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/election_manager_screen.test.tsx
@@ -39,6 +39,7 @@ test('renders date and time settings modal', async () => {
     <AppContext.Provider
       value={{
         electionDefinition: electionSampleDefinition,
+        isSoundMuted: false,
         machineConfig: { machineId: '0000', codeVersion: 'TEST' },
         auth,
       }}
@@ -51,6 +52,7 @@ test('renders date and time settings modal', async () => {
         setMarkThresholdOverrides={jest.fn()}
         unconfigure={jest.fn()}
         usbDrive={{ status: usbstick.UsbDriveStatus.absent, eject: jest.fn() }}
+        toggleIsSoundMuted={jest.fn()}
       />
     </AppContext.Provider>
   );
@@ -92,6 +94,7 @@ test('setting and un-setting the precinct', async () => {
       value={{
         electionDefinition: electionSampleDefinition,
         machineConfig: { machineId: '0000', codeVersion: 'TEST' },
+        isSoundMuted: false,
         auth,
       }}
     >
@@ -102,6 +105,7 @@ test('setting and un-setting the precinct', async () => {
         toggleLiveMode={jest.fn()}
         setMarkThresholdOverrides={jest.fn()}
         unconfigure={jest.fn()}
+        toggleIsSoundMuted={jest.fn()}
         usbDrive={{ status: usbstick.UsbDriveStatus.absent, eject: jest.fn() }}
       />
     </AppContext.Provider>
@@ -129,6 +133,7 @@ test('export from admin screen', () => {
       value={{
         electionDefinition: electionSampleDefinition,
         machineConfig: { machineId: '0000', codeVersion: 'TEST' },
+        isSoundMuted: false,
         auth,
       }}
     >
@@ -139,6 +144,7 @@ test('export from admin screen', () => {
         toggleLiveMode={jest.fn()}
         setMarkThresholdOverrides={jest.fn()}
         unconfigure={jest.fn()}
+        toggleIsSoundMuted={jest.fn()}
         usbDrive={{ status: usbstick.UsbDriveStatus.absent, eject: jest.fn() }}
       />
     </AppContext.Provider>
@@ -155,6 +161,7 @@ test('unconfigure ejects a usb drive when it is mounted', () => {
       value={{
         electionDefinition: electionSampleDefinition,
         machineConfig: { machineId: '0000', codeVersion: 'TEST' },
+        isSoundMuted: false,
         auth,
       }}
     >
@@ -165,6 +172,7 @@ test('unconfigure ejects a usb drive when it is mounted', () => {
         toggleLiveMode={jest.fn()}
         setMarkThresholdOverrides={jest.fn()}
         unconfigure={unconfigureFn}
+        toggleIsSoundMuted={jest.fn()}
         usbDrive={{ status: usbstick.UsbDriveStatus.absent, eject: ejectFn }}
       />
     </AppContext.Provider>
@@ -184,6 +192,7 @@ test('unconfigure does not eject a usb drive that is not mounted', async () => {
       value={{
         electionDefinition: electionSampleDefinition,
         machineConfig: { machineId: '0000', codeVersion: 'TEST' },
+        isSoundMuted: false,
         auth,
       }}
     >
@@ -194,6 +203,7 @@ test('unconfigure does not eject a usb drive that is not mounted', async () => {
         toggleLiveMode={jest.fn()}
         setMarkThresholdOverrides={jest.fn()}
         unconfigure={unconfigureFn}
+        toggleIsSoundMuted={jest.fn()}
         usbDrive={{ status: usbstick.UsbDriveStatus.mounted, eject: ejectFn }}
       />
     </AppContext.Provider>
@@ -213,6 +223,7 @@ test('unconfigure button is disabled when the machine cannot be unconfigured', (
       value={{
         electionDefinition: electionSampleDefinition,
         machineConfig: { machineId: '0000', codeVersion: 'TEST' },
+        isSoundMuted: false,
         auth,
       }}
     >
@@ -223,6 +234,7 @@ test('unconfigure button is disabled when the machine cannot be unconfigured', (
         toggleLiveMode={jest.fn()}
         setMarkThresholdOverrides={jest.fn()}
         unconfigure={jest.fn()}
+        toggleIsSoundMuted={jest.fn()}
         usbDrive={{ status: usbstick.UsbDriveStatus.mounted, eject: jest.fn() }}
       />
     </AppContext.Provider>
@@ -240,6 +252,7 @@ test('cannot toggle to testing mode when the machine cannot be unconfigured', ()
       value={{
         electionDefinition: electionSampleDefinition,
         machineConfig: { machineId: '0000', codeVersion: 'TEST' },
+        isSoundMuted: false,
         auth,
       }}
     >
@@ -250,6 +263,7 @@ test('cannot toggle to testing mode when the machine cannot be unconfigured', ()
         toggleLiveMode={toggleLiveModeFn}
         setMarkThresholdOverrides={jest.fn()}
         unconfigure={jest.fn()}
+        toggleIsSoundMuted={jest.fn()}
         usbDrive={{ status: usbstick.UsbDriveStatus.mounted, eject: jest.fn() }}
       />
     </AppContext.Provider>
@@ -267,6 +281,7 @@ test('Allows overriding mark thresholds', () => {
     <AppContext.Provider
       value={{
         electionDefinition: electionSampleDefinition,
+        isSoundMuted: false,
         machineConfig: { machineId: '0000', codeVersion: 'TEST' },
         auth,
       }}
@@ -278,6 +293,7 @@ test('Allows overriding mark thresholds', () => {
         toggleLiveMode={jest.fn()}
         setMarkThresholdOverrides={setMarkThresholdOverridesFn}
         unconfigure={jest.fn()}
+        toggleIsSoundMuted={jest.fn()}
         usbDrive={{ status: usbstick.UsbDriveStatus.mounted, eject: jest.fn() }}
       />
     </AppContext.Provider>

--- a/frontends/precinct-scanner/src/screens/election_manager_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/election_manager_screen.tsx
@@ -34,6 +34,7 @@ interface Props {
   updateAppPrecinctId(appPrecinctId: PrecinctId): Promise<void>;
   setMarkThresholdOverrides: (markThresholds?: MarkThresholds) => Promise<void>;
   toggleLiveMode(): Promise<void>;
+  toggleIsSoundMuted(): void;
   unconfigure(): Promise<void>;
   usbDrive: UsbDrive;
 }
@@ -43,12 +44,18 @@ export function ElectionManagerScreen({
   isTestMode,
   updateAppPrecinctId,
   toggleLiveMode,
+  toggleIsSoundMuted,
   setMarkThresholdOverrides,
   unconfigure,
   usbDrive,
 }: Props): JSX.Element {
-  const { electionDefinition, currentPrecinctId, currentMarkThresholds, auth } =
-    useContext(AppContext);
+  const {
+    electionDefinition,
+    currentPrecinctId,
+    currentMarkThresholds,
+    auth,
+    isSoundMuted,
+  } = useContext(AppContext);
   assert(electionDefinition);
   const { election } = electionDefinition;
   assert(isElectionManagerAuth(auth));
@@ -171,9 +178,7 @@ export function ElectionManagerScreen({
           </SetClockButton>
         </p>
         <p>
-          <Button onPress={() => setIsExportingResults(true)}>Save CVRs</Button>
-        </p>
-        <p>
+          <Button onPress={() => setIsExportingResults(true)}>Save CVRs</Button>{' '}
           <Button onPress={() => setIsExportingBackup(true)}>
             Save Backup
           </Button>
@@ -187,6 +192,11 @@ export function ElectionManagerScreen({
         </p>
         <p>
           <Button onPress={openCalibrateScannerModal}>Calibrate Scanner</Button>
+        </p>
+        <p>
+          <Button onPress={toggleIsSoundMuted}>
+            {isSoundMuted ? 'Unmute' : 'Mute'} Sounds
+          </Button>
         </p>
         <p>
           <Button
@@ -296,6 +306,7 @@ export function ElectionManagerScreen({
 export function DefaultPreview(): JSX.Element {
   const { machineConfig, electionDefinition } = useContext(AppContext);
   const [isTestMode, setIsTestMode] = useState(false);
+  const [isSoundMuted, setIsSoundMuted] = useState(false);
   const [precinctId, setPrecinctId] = useState<Precinct['id']>();
   assert(electionDefinition);
   return (
@@ -305,6 +316,7 @@ export function DefaultPreview(): JSX.Element {
         electionDefinition,
         currentPrecinctId: precinctId,
         currentMarkThresholds: undefined,
+        isSoundMuted,
         auth: {
           status: 'logged_in',
           user: {
@@ -332,6 +344,7 @@ export function DefaultPreview(): JSX.Element {
         isTestMode={isTestMode}
         // eslint-disable-next-line @typescript-eslint/require-await
         toggleLiveMode={async () => setIsTestMode((prev) => !prev)}
+        toggleIsSoundMuted={() => setIsSoundMuted((prev) => !prev)}
         unconfigure={() => Promise.resolve()}
         setMarkThresholdOverrides={() => Promise.resolve()}
         // eslint-disable-next-line @typescript-eslint/require-await

--- a/frontends/precinct-scanner/src/screens/poll_worker_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/poll_worker_screen.test.tsx
@@ -41,6 +41,7 @@ function renderScreen({
       value={{
         electionDefinition: electionSampleDefinition,
         machineConfig: { machineId: '0000', codeVersion: 'TEST' },
+        isSoundMuted: false,
         auth,
       }}
     >

--- a/frontends/precinct-scanner/src/screens/scan_warning_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/scan_warning_screen.test.tsx
@@ -19,6 +19,7 @@ function renderScreen(props: Props) {
         },
         electionDefinition: electionSampleDefinition,
         auth: Inserted.fakeLoggedOutAuth(),
+        isSoundMuted: false,
       }}
     >
       <ScanWarningScreen {...props} />


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Adds a button to toggle muting/enabling sounds on VxScan. Long term we should have a way to control the audio volume and do this through muting the actual speaker but this will help allow muting if the sounds annoy people for now. 

## Demo Video or Screenshot
![Screen Shot 2022-08-19 at 5 01 30 PM](https://user-images.githubusercontent.com/14897017/185807651-d6d70ce1-b27f-47d5-8c19-53c3ce1a410c.png)


## Testing Plan 
Scanned a ballot - heard sound
Muted sound
Scanned a ballot - no sound
Enabled sound
Scanned a ballot - heard sound

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
