### PR TITLE
fix(ps): expand conditional button titles

### DIFF
--- a/frontends/precinct-scanner/src/screens/election_manager_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/election_manager_screen.tsx
@@ -195,7 +195,7 @@ export function ElectionManagerScreen({
         </p>
         <p>
           <Button onPress={toggleIsSoundMuted}>
-            {isSoundMuted ? 'Unmute' : 'Mute'} Sounds
+            {isSoundMuted ? 'Unmute Sounds' : 'Mute Sounds'}
           </Button>
         </p>
         <p>


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
A quick follow up to #2443 that puts the full possible titles of the Mute/Unmute button in both branches. I prefer to do it this way because:

1. This is the only way that localization of the UI is possible. Translating "Mute" and "Sounds" independently and concatenating the result may not yield the same result as translating "Mute Sounds" as a unit.
2. When looking for the code for a button it's useful to be able to search for the text of the button in the source code insofar as it's possible. Searching for "Mute Sounds" would previously return no results, but now it will.

## Demo Video or Screenshot
n/a

## Testing Plan 
Automated.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
