### PR TITLE
fix(scan): Log error fields correctly

### DIFF
--- a/services/scan/src/precinct_scanner_app.test.ts
+++ b/services/scan/src/precinct_scanner_app.test.ts
@@ -1255,7 +1255,7 @@ test('scan fails due to plustek error', async () => {
     {
       message: 'Context updated',
       changedFields: expect.stringMatching(
-        /{"error":{"message":"expected two files, got \[ file1.jpg \]","stack":".*"},"failedScanAttempts":1}/
+        /{"error":{"message":"expected two files, got \[ file1.jpg \]","stack":".*"}}/
       ),
     },
     expect.any(Function)

--- a/services/scan/src/precinct_scanner_app.test.ts
+++ b/services/scan/src/precinct_scanner_app.test.ts
@@ -1287,7 +1287,7 @@ test('scanning time out', async () => {
     {
       message: 'Context updated',
       changedFields: expect.stringMatching(
-        /{"error":{"message":"scanning_timed_out","stack":".*"}}/
+        /{"error":{"type":"scanning_timed_out","message":"scanning_timed_out","stack":".*"}}/
       ),
     },
     expect.any(Function)

--- a/services/scan/src/precinct_scanner_state_machine.ts
+++ b/services/scan/src/precinct_scanner_state_machine.ts
@@ -878,7 +878,7 @@ function setupLogging(
         // Make sure we log the important fields of an error
         .map(([key, value]) =>
           key === 'error' && value instanceof Error
-            ? [key, { message: value.message, stack: value.stack }]
+            ? [key, { ...value, message: value.message, stack: value.stack }]
             : [key, value]
         )
         .map(([key, value]) => [

--- a/services/scan/src/precinct_scanner_state_machine.ts
+++ b/services/scan/src/precinct_scanner_state_machine.ts
@@ -875,6 +875,12 @@ function setupLogging(
         .map(([key, value]) =>
           key === 'interpretation' ? [key, value?.type] : [key, value]
         )
+        // Make sure we log the important fields of an error
+        .map(([key, value]) =>
+          key === 'error' && value instanceof Error
+            ? [key, { message: value.message, stack: value.stack }]
+            : [key, value]
+        )
         .map(([key, value]) => [
           key,
           value === undefined ? 'undefined' : value,


### PR DESCRIPTION


## Overview
By default, `JSON.stringify` will log an instance of `Error` as `{}` since the `message` and `stack` fields are not enumerable. Here, we explicitly pick out those two fields for logging to ensure we get the info we need about the error.

## Demo Video or Screenshot
N/A

## Testing Plan 
- Manually tested
- Updated automated tests


