### PR TITLE
fix(scan): Reconnect to plustek after any unexpected scanning error

### DIFF
--- a/services/scan/src/precinct_scanner_app.test.ts
+++ b/services/scan/src/precinct_scanner_app.test.ts
@@ -1042,7 +1042,9 @@ test('insert second ballot while first ballot is returning', async () => {
 });
 
 test('jam on scan', async () => {
-  const { app, mockPlustek } = await createApp();
+  const { app, mockPlustek } = await createApp({
+    DELAY_RECONNECT_ON_UNEXPECTED_ERROR: 500,
+  });
   await configureApp(app);
 
   await mockPlustek.simulateLoadSheet(ballotImages.completeBmd);
@@ -1050,9 +1052,10 @@ test('jam on scan', async () => {
 
   mockPlustek.simulateJamOnNextOperation();
   await post(app, '/precinct-scanner/scanner/scan');
-  await waitForStatus(app, { state: 'jammed' });
-
-  await mockPlustek.simulateRemoveSheet();
+  await waitForStatus(app, {
+    state: 'recovering_from_error',
+    error: 'plustek_error',
+  });
   await waitForStatus(app, { state: 'no_paper' });
 });
 
@@ -1214,8 +1217,10 @@ test('scan fails repeatedly and eventually gives up', async () => {
   await waitForStatus(app, { state: 'rejected', error: 'scanning_failed' });
 });
 
-test('scan fails with the paper in the back afterwards', async () => {
-  const { app, mockPlustek } = await createApp();
+test('scan fails due to plustek error', async () => {
+  const { app, mockPlustek } = await createApp({
+    DELAY_RECONNECT_ON_UNEXPECTED_ERROR: 500,
+  });
   await configureApp(app);
 
   await mockPlustek.simulateLoadSheet(ballotImages.completeBmd);
@@ -1224,8 +1229,11 @@ test('scan fails with the paper in the back afterwards', async () => {
   await post(app, '/precinct-scanner/scanner/scan');
   await expectStatus(app, { state: 'scanning' });
   mockPlustek.simulateScanError('bad_scan_result');
-  await waitForStatus(app, { state: 'rejecting', error: 'plustek_error' });
-  await waitForStatus(app, { state: 'rejected', error: 'plustek_error' });
+  await waitForStatus(app, {
+    state: 'recovering_from_error',
+    error: 'plustek_error',
+  });
+  await waitForStatus(app, { state: 'no_paper' });
 });
 
 test('scanning time out', async () => {

--- a/services/scan/src/precinct_scanner_state_machine.ts
+++ b/services/scan/src/precinct_scanner_state_machine.ts
@@ -545,10 +545,26 @@ function buildMachine(
                     scannedSheet: event.data,
                   })),
                 },
-                onError: {
-                  target: 'error_scanning',
-                  actions: assign((_context, event) => ({ error: event.data })),
-                },
+                onError: [
+                  // If we got an error that indicates the paper wasn't grabbed
+                  // or fed through the scanner, retry.
+                  {
+                    cond: (_context, event) =>
+                      event.data === ScannerError.PaperStatusErrorFeeding ||
+                      event.data === ScannerError.PaperStatusNoPaper,
+                    target: 'retry_scanning',
+                    actions: assign((_context, event) => ({
+                      error: event.data,
+                    })),
+                  },
+                  // Otherwise, treat it as an unexpected error
+                  {
+                    target: '#error',
+                    actions: assign((_context, event) => ({
+                      error: event.data,
+                    })),
+                  },
+                ],
               },
               after: {
                 DELAY_SCANNING_TIMEOUT: {
@@ -566,11 +582,11 @@ function buildMachine(
               invoke: pollPaperStatus,
               on: {
                 SCANNER_READY_TO_EJECT: '#interpreting',
-                SCANNER_NO_PAPER: 'error_scanning',
-                SCANNER_READY_TO_SCAN: 'error_scanning',
+                SCANNER_NO_PAPER: 'retry_scanning',
+                SCANNER_READY_TO_SCAN: 'retry_scanning',
               },
             },
-            error_scanning: {
+            retry_scanning: {
               entry: assign({
                 failedScanAttempts: (context) => {
                   assert(context.failedScanAttempts !== undefined);
@@ -580,19 +596,13 @@ function buildMachine(
               invoke: pollPaperStatus,
               on: {
                 SCANNER_READY_TO_SCAN: [
-                  // If the paper is still in the front due to an error that
-                  // indicates the paper wasn't grabbed or fed through the
-                  // scanner, retry (up to a certain number of attempts).
+                  // If the paper is still in the front, retry (up to a certain
+                  // number of attempts).
                   {
                     target: 'starting_scan',
                     cond: (context) => {
                       assert(context.failedScanAttempts !== undefined);
-                      const gotExpectedScanningError =
-                        context.error ===
-                          ScannerError.PaperStatusErrorFeeding ||
-                        context.error === ScannerError.PaperStatusNoPaper;
                       const shouldRetry =
-                        (!context.error || gotExpectedScanningError) &&
                         context.failedScanAttempts < MAX_FAILED_SCAN_ATTEMPTS;
                       return shouldRetry;
                     },


### PR DESCRIPTION
#2451 adapted for main

## Overview
Previously, if we got an unexpected scanning error and the Plustek was still responsive, we would either automatically retry scanning or reject and let the voter retry, depending on the paper status. Now, if we get an unexpected scanning error, we handle it like any other unexpected error, reconnecting to Plustek. This will hopefully make us more resilient to scanning errors where we don't know the root cause.

## Demo Video or Screenshot
N/A

## Testing Plan 
- Various manual scan error tests
- Updated automated tests

