### PR TITLE
chore(scan): remove write-in area scoring

### DIFF
--- a/frontends/bsd/src/screens/ballot_eject_screen.tsx
+++ b/frontends/bsd/src/screens/ballot_eject_screen.tsx
@@ -165,9 +165,7 @@ export function BallotEjectScreen({
     const frontAdjudication = frontInterpretation.adjudicationInfo;
     const backAdjudication = backInterpretation.adjudicationInfo;
 
-    // A ballot is blank if both sides are marked blank
-    // and neither side contains an unmarked write in,
-    // because an unmarked write-in is a sign the page isn't blank.
+    // A ballot is blank if both sides are marked blank.
     //
     // One could argue that making this call is the server's job.
     // We leave that consideration to:
@@ -176,10 +174,9 @@ export function BallotEjectScreen({
       frontAdjudication.enabledReasonInfos.some(
         (info) => info.type === AdjudicationReason.BlankBallot
       ) &&
-      (backAdjudication.enabledReasonInfos.some(
+      backAdjudication.enabledReasonInfos.some(
         (info) => info.type === AdjudicationReason.BlankBallot
-      ) ||
-        backInterpretation.markInfo.marks.length === 0);
+      );
 
     if (!isBlank) {
       if (

--- a/libs/ballot-interpreter-vx/src/interpreter/index.ts
+++ b/libs/ballot-interpreter-vx/src/interpreter/index.ts
@@ -64,7 +64,6 @@ export interface Options {
 }
 
 export const DEFAULT_MARK_SCORE_VOTE_THRESHOLD = 0.12;
-export const WRITE_IN_REGION_UPWARD_SHIFT_HEIGHT_RATIO = 0.15;
 
 type TemplateKey = Pick<
   BallotPageMetadata,
@@ -495,18 +494,6 @@ export class Interpreter {
       layout: BallotPageContestOptionLayout,
       option: Candidate
     ): void => {
-      let writeInTextScore: BallotCandidateTargetMark['writeInTextScore'];
-
-      if (option.isWriteIn) {
-        writeInTextScore = this.writeInTextScore(
-          template.imageData,
-          mappedBallot,
-          layout,
-          contest,
-          option
-        );
-      }
-
       const { score, offset } = this.targetMarkScore(
         template.imageData,
         mappedBallot,
@@ -526,7 +513,6 @@ export class Interpreter {
         score,
         scoredOffset: offset,
         target: layout.target,
-        writeInTextScore,
       };
       marks.push(mark);
     };
@@ -774,59 +760,6 @@ export class Interpreter {
     );
 
     return { score: bestMatchScore, offset: bestMatchOffset };
-  }
-
-  private writeInTextScore(
-    template: ImageData,
-    ballot: ImageData,
-    layout: BallotPageContestOptionLayout,
-    contest: CandidateContest,
-    candidate: Candidate
-  ): number {
-    const writeInRegion: Rect = {
-      x: layout.target.bounds.x + layout.target.bounds.width,
-      y:
-        layout.bounds.y -
-        Math.round(
-          layout.bounds.height * WRITE_IN_REGION_UPWARD_SHIFT_HEIGHT_RATIO
-        ),
-      width: layout.bounds.width - layout.target.bounds.width,
-      height: layout.bounds.height,
-    };
-
-    debug(
-      'contest=%s/candidate=%s checking region for write-in text: %o',
-      contest.id,
-      candidate.id,
-      writeInRegion
-    );
-
-    const templateWriteInRegionImage = outline(
-      outline(crop(template, writeInRegion))
-    );
-    const scannedWriteInRegionImage = crop(ballot, writeInRegion);
-
-    binarize(templateWriteInRegionImage);
-    binarize(scannedWriteInRegionImage);
-
-    const newScannedPixels = diff(
-      templateWriteInRegionImage,
-      scannedWriteInRegionImage
-    );
-    const newScannedPixelsCount = countPixels(newScannedPixels);
-    const totalRegionPixelCount = writeInRegion.width * writeInRegion.height;
-    const score = newScannedPixelsCount / totalRegionPixelCount;
-
-    debug(
-      'contest=%s/candidate=%s computed write-in text score: %d (%d / %d pixels)',
-      contest.id,
-      candidate.id,
-      score,
-      newScannedPixelsCount,
-      totalRegionPixelCount
-    );
-
-    return score;
   }
 
   private mapImageWithPoints(

--- a/libs/ballot-interpreter-vx/src/interpreter/invalid_marks.test.ts
+++ b/libs/ballot-interpreter-vx/src/interpreter/invalid_marks.test.ts
@@ -97,7 +97,6 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
-        "writeInTextScore": undefined,
       },
       Object {
         "bounds": Object {
@@ -128,7 +127,6 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
-        "writeInTextScore": undefined,
       },
       Object {
         "bounds": Object {
@@ -159,7 +157,6 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
-        "writeInTextScore": undefined,
       },
       Object {
         "bounds": Object {
@@ -190,7 +187,6 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
-        "writeInTextScore": 0.002881844380403458,
       },
       Object {
         "bounds": Object {
@@ -221,7 +217,6 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
-        "writeInTextScore": 0.002881844380403458,
       },
       Object {
         "bounds": Object {
@@ -372,7 +367,6 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
-        "writeInTextScore": undefined,
       },
       Object {
         "bounds": Object {
@@ -403,7 +397,6 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
-        "writeInTextScore": undefined,
       },
       Object {
         "bounds": Object {
@@ -434,7 +427,6 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
-        "writeInTextScore": undefined,
       },
       Object {
         "bounds": Object {
@@ -465,7 +457,6 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
-        "writeInTextScore": undefined,
       },
       Object {
         "bounds": Object {
@@ -496,7 +487,6 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
-        "writeInTextScore": undefined,
       },
       Object {
         "bounds": Object {
@@ -527,7 +517,6 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
-        "writeInTextScore": undefined,
       },
       Object {
         "bounds": Object {
@@ -558,7 +547,6 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
-        "writeInTextScore": 0.00005747126436781609,
       },
       Object {
         "bounds": Object {
@@ -589,7 +577,6 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
-        "writeInTextScore": 0.03637931034482759,
       },
       Object {
         "bounds": Object {
@@ -620,7 +607,6 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
-        "writeInTextScore": 0.00017241379310344826,
       },
       Object {
         "bounds": Object {
@@ -651,7 +637,6 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
-        "writeInTextScore": undefined,
       },
       Object {
         "bounds": Object {
@@ -682,7 +667,6 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
-        "writeInTextScore": undefined,
       },
       Object {
         "bounds": Object {
@@ -713,7 +697,6 @@ test('invalid marks', async () => {
           },
         },
         "type": "candidate",
-        "writeInTextScore": 0,
       },
     ]
   `);

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -945,7 +945,6 @@ export interface BallotCandidateTargetMark {
   optionId: CandidateId | WriteInId;
   score: number;
   scoredOffset: Offset;
-  writeInTextScore?: number;
 }
 export const BallotCandidateTargetMarkSchema: z.ZodSchema<BallotCandidateTargetMark> =
   z.object({
@@ -956,7 +955,6 @@ export const BallotCandidateTargetMarkSchema: z.ZodSchema<BallotCandidateTargetM
     optionId: z.union([CandidateIdSchema, WriteInIdSchema]),
     score: z.number().min(0).max(1),
     scoredOffset: OffsetSchema,
-    writeInTextScore: z.number().min(0).max(1).optional(),
   });
 
 export interface BallotYesNoTargetMark {

--- a/libs/types/src/hmpb.ts
+++ b/libs/types/src/hmpb.ts
@@ -84,7 +84,6 @@ export enum MarkStatus {
   Marked = 'marked',
   Unmarked = 'unmarked',
   Marginal = 'marginal',
-  UnmarkedWriteIn = 'unmarkedWriteIn',
 }
 export const MarkStatusSchema: z.ZodSchema<MarkStatus> =
   z.nativeEnum(MarkStatus);

--- a/libs/utils/src/hmpb/ballot_adjudication_reasons.test.ts
+++ b/libs/utils/src/hmpb/ballot_adjudication_reasons.test.ts
@@ -311,33 +311,6 @@ test('a ballot with just a write-in', () => {
   `);
 });
 
-test('a ballot with just an unmarked write-in', () => {
-  const reasons = [
-    ...ballotAdjudicationReasons([zooCouncilMammal], {
-      optionMarkStatus: (option) =>
-        option.contestId === zooCouncilMammal.id && option.id === 'write-in-0'
-          ? MarkStatus.UnmarkedWriteIn
-          : MarkStatus.Unmarked,
-    }),
-  ];
-
-  // in particular, no unmarked write-in adjudication reason anymore.
-  expect(reasons).toMatchInlineSnapshot(`
-    Array [
-      Object {
-        "contestId": "zoo-council-mammal",
-        "expected": 3,
-        "optionIds": Array [],
-        "optionIndexes": Array [],
-        "type": "Undervote",
-      },
-      Object {
-        "type": "BlankBallot",
-      },
-    ]
-  `);
-});
-
 test('a ballot with an ms-either-neither happy path', () => {
   const reasons = [
     ...ballotAdjudicationReasons([eitherNeitherQuestion], {

--- a/libs/utils/src/hmpb/ballot_adjudication_reasons.ts
+++ b/libs/utils/src/hmpb/ballot_adjudication_reasons.ts
@@ -60,7 +60,6 @@ export function* ballotAdjudicationReasons(
 
             break;
 
-          case MarkStatus.UnmarkedWriteIn:
           case MarkStatus.Unmarked:
             break;
 

--- a/services/scan/src/interpreter.test.ts
+++ b/services/scan/src/interpreter.test.ts
@@ -531,7 +531,6 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
               },
             },
             "type": "candidate",
-            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -562,7 +561,6 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
               },
             },
             "type": "candidate",
-            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -593,7 +591,6 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
               },
             },
             "type": "candidate",
-            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -624,7 +621,6 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
               },
             },
             "type": "candidate",
-            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -655,7 +651,6 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
               },
             },
             "type": "candidate",
-            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -686,7 +681,6 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
               },
             },
             "type": "candidate",
-            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -717,7 +711,6 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
               },
             },
             "type": "candidate",
-            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -748,7 +741,6 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
               },
             },
             "type": "candidate",
-            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -779,7 +771,6 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
               },
             },
             "type": "candidate",
-            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -810,7 +801,6 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
               },
             },
             "type": "candidate",
-            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -841,7 +831,6 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
               },
             },
             "type": "candidate",
-            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -872,7 +861,6 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
               },
             },
             "type": "candidate",
-            "writeInTextScore": 0,
           },
           Object {
             "bounds": Object {
@@ -903,7 +891,6 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
               },
             },
             "type": "candidate",
-            "writeInTextScore": 0,
           },
           Object {
             "bounds": Object {
@@ -934,7 +921,6 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
               },
             },
             "type": "candidate",
-            "writeInTextScore": 0.026644826644826643,
           },
           Object {
             "bounds": Object {
@@ -965,7 +951,6 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
               },
             },
             "type": "candidate",
-            "writeInTextScore": 0,
           },
           Object {
             "bounds": Object {
@@ -996,7 +981,6 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
               },
             },
             "type": "candidate",
-            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -1027,7 +1011,6 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
               },
             },
             "type": "candidate",
-            "writeInTextScore": 0,
           },
           Object {
             "bounds": Object {
@@ -1058,7 +1041,6 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
               },
             },
             "type": "candidate",
-            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -1089,7 +1071,6 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
               },
             },
             "type": "candidate",
-            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -1120,7 +1101,6 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
               },
             },
             "type": "candidate",
-            "writeInTextScore": 0,
           },
           Object {
             "bounds": Object {
@@ -1151,7 +1131,6 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
               },
             },
             "type": "candidate",
-            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -1182,7 +1161,6 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
               },
             },
             "type": "candidate",
-            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -1213,7 +1191,6 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
               },
             },
             "type": "candidate",
-            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -1244,7 +1221,6 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
               },
             },
             "type": "candidate",
-            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -1275,7 +1251,6 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
               },
             },
             "type": "candidate",
-            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -1306,7 +1281,6 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
               },
             },
             "type": "candidate",
-            "writeInTextScore": undefined,
           },
           Object {
             "bounds": Object {
@@ -1337,7 +1311,6 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
               },
             },
             "type": "candidate",
-            "writeInTextScore": 0,
           },
           Object {
             "bounds": Object {
@@ -1368,7 +1341,6 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
               },
             },
             "type": "candidate",
-            "writeInTextScore": 0,
           },
           Object {
             "bounds": Object {
@@ -1399,7 +1371,6 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
               },
             },
             "type": "candidate",
-            "writeInTextScore": 0.000044820940343328406,
           },
         ],
       },

--- a/services/scan/src/types.ts
+++ b/services/scan/src/types.ts
@@ -74,15 +74,6 @@ export function getMarkStatus(
     return MarkStatus.Marginal;
   }
 
-  if (
-    mark.type === 'candidate' &&
-    typeof mark.writeInTextScore === 'number' &&
-    typeof markThresholds.writeInText === 'number' &&
-    mark.writeInTextScore >= markThresholds.writeInText
-  ) {
-    return MarkStatus.UnmarkedWriteIn;
-  }
-
   return MarkStatus.Unmarked;
 }
 

--- a/services/scan/src/util/option_mark_status.test.ts
+++ b/services/scan/src/util/option_mark_status.test.ts
@@ -92,33 +92,6 @@ test('a candidate mark', () => {
   expect(emptyResult).toBe(MarkStatus.Unmarked);
 });
 
-test('a candidate write-in mark', () => {
-  const contest = election.contests.find(
-    (c) => c.type === 'candidate' && c.allowWriteIns
-  ) as CandidateContest;
-  const optionId = 'write-in-0';
-  const result = optionMarkStatus({
-    contests: election.contests,
-    markThresholds,
-    marks: [
-      {
-        type: 'candidate',
-        bounds: defaultShape.bounds,
-        contestId: contest.id,
-        target: defaultShape,
-        optionId,
-        score: 0,
-        scoredOffset: { x: 0, y: 0 },
-        writeInTextScore: 0.05,
-      },
-    ],
-    contestId: contest.id,
-    optionId,
-  });
-
-  expect(result).toBe(MarkStatus.UnmarkedWriteIn);
-});
-
 test('a ms-either-neither mark', () => {
   const contest = eitherNeitherElection.contests.find(
     (c) => c.type === 'ms-either-neither'


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
We don't have a customer that needs this right now and it makes #2459 more complicated because it requires us to have the ballot template images when interpreting. If we want to bring this back I suggest we encode the area to look for a write-in mark within the layout of the ballots and assume the entire area is white and/or make the threshold configurable to account for the inclusion of some black lines or text. Issue to re-evaluate this later: #2458.

Support for this as an adjudication reason was removed in #2076.
[Slack discussion for further context](https://votingworks.slack.com/archives/CEL6D3GAD/p1661200605817059)

## Demo Video or Screenshot
n/a

## Testing Plan 
Automated.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
