### PR TITLE
fix(scan): Timeout for accept

### DIFF
--- a/services/scan/src/precinct_scanner_app.test.ts
+++ b/services/scan/src/precinct_scanner_app.test.ts
@@ -1060,7 +1060,9 @@ test('jam on scan', async () => {
 });
 
 test('jam on accept', async () => {
-  const { app, mockPlustek } = await createApp();
+  const { app, mockPlustek } = await createApp({
+    DELAY_ACCEPTING_TIMEOUT: 500,
+  });
   await configureApp(app);
 
   await mockPlustek.simulateLoadSheet(ballotImages.completeBmd);
@@ -1076,9 +1078,10 @@ test('jam on accept', async () => {
 
   mockPlustek.simulateJamOnNextOperation();
   await post(app, '/precinct-scanner/scanner/accept');
+  await waitForStatus(app, { state: 'accepting', interpretation });
   // The paper can't get permanently jammed on accept - it just stays held in
   // the back and we can reject at that point
-  await expectStatus(app, {
+  await waitForStatus(app, {
     state: 'rejecting',
     interpretation,
     error: 'paper_in_back_after_accept',


### PR DESCRIPTION


## Overview
If the accept command returns successfully, it may or may not actually be done accepting the ballot (e.g. if there is an obstruction holding the ballot back). In order to make sure the ballot was actually dropped, we check the paper status. Since the rollers may still be trying to drop the ballot, we need to wait a few seconds to see if the ballot gets dropped or not. If it doesn't then we're safe to reject. Previously, we tried rejecting too early which led to a series of confusing paper statuses.

## Demo Video or Screenshot
N/A
## Testing Plan 
- Updated automated test
- Manual testing by holding the paper in the back during accept

