### PR TITLE
fix(admin): delete CVRs with `DELETE` method, not `GET`

### DIFF
--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -122,7 +122,7 @@ beforeEach(() => {
       codeVersion: 'TEST',
     })
   );
-  fetchMock.get('/admin/write-ins/cvrs/reset', { body: { status: 'ok ' } });
+  fetchMock.delete('/admin/write-ins/cvrs', { body: { status: 'ok ' } });
 });
 
 afterEach(() => {

--- a/frontends/election-manager/src/app_root.tsx
+++ b/frontends/election-manager/src/app_root.tsx
@@ -438,7 +438,7 @@ export function AppRoot({
       }
 
       if (newCvrFiles === CastVoteRecordFiles.empty) {
-        await fetch('/admin/write-ins/cvrs/reset', { method: 'GET' });
+        await fetch('/admin/write-ins/cvrs', { method: 'DELETE' });
         await removeStorageKeyAndLog(cvrsStorageKey, 'Cast vote records');
         await removeStorageKeyAndLog(
           isOfficialResultsKey,
@@ -451,7 +451,7 @@ export function AppRoot({
           newCvrFiles.export(),
           'Cast vote records'
         );
-        await fetch('/admin/write-ins/cvrs/', {
+        await fetch('/admin/write-ins/cvrs', {
           method: 'POST',
           body: newCvrFiles.export(),
           headers: {

--- a/services/admin/src/server.test.ts
+++ b/services/admin/src/server.test.ts
@@ -174,10 +174,10 @@ test('GET /admin/write-ins/adjudications/contestId/count', async () => {
     ]);
 });
 
-test('GET /admin/write-ins/reset', async () => {
+test('DELETE /admin/write-ins/cvrs', async () => {
   workspace.store.deleteCvrsAndCvrFiles = jest.fn();
 
-  await request(app).get('/admin/write-ins/cvrs/reset').expect(200);
+  await request(app).delete('/admin/write-ins/cvrs').expect(200);
   expect(workspace.store.deleteCvrsAndCvrFiles).toHaveBeenCalled();
 });
 

--- a/services/admin/src/server.ts
+++ b/services/admin/src/server.ts
@@ -20,7 +20,7 @@ export function buildApp({ store }: { store: Store }): Application {
   app.use(express.json({ limit: '50mb', type: 'application/json' }));
   app.use(express.urlencoded({ extended: false }));
 
-  app.get<NoParams>('/admin/write-ins/cvrs/reset', (_, response) => {
+  app.delete<NoParams>('/admin/write-ins/cvrs', (_, response) => {
     store.deleteCvrsAndCvrFiles();
     response.status(200).json({ status: 'ok' });
   });


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
`GET` should not be used for destructive actions.

## Demo Video or Screenshot
n/a

## Testing Plan 
Automated.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
