### PR TITLE
fix(scan): Require restart when only one scan image file returned

### DIFF
--- a/libs/plustek-sdk/src/mocks.test.ts
+++ b/libs/plustek-sdk/src/mocks.test.ts
@@ -413,7 +413,7 @@ test('scanning errors', async () => {
   expectNoPaper((await mock.getPaperStatus()).ok());
   (await mock.simulateLoadSheet(files)).unsafeUnwrap();
   scanResult = mock.scan();
-  mock.simulateScanError('bad_scan_result');
+  mock.simulateScanError('only_one_file_returned');
   expect((await scanResult).err()).toEqual(
     new InvalidClientResponseError('expected two files, got [ file1.jpg ]')
   );

--- a/libs/plustek-sdk/src/mocks.ts
+++ b/libs/plustek-sdk/src/mocks.ts
@@ -33,7 +33,7 @@ interface Context {
   sheetFiles?: readonly [string, string];
   holdAfterReject?: boolean;
   jamOnNextOperation: boolean;
-  scanError?: 'error_feeding' | 'bad_scan_result';
+  scanError?: 'error_feeding' | 'only_one_file_returned';
 }
 
 type Event =
@@ -53,7 +53,7 @@ type Event =
   | { type: 'CALIBRATE' }
   | {
       type: 'SCAN_ERROR';
-      error: 'error_feeding' | 'bad_scan_result';
+      error: 'error_feeding' | 'only_one_file_returned';
     }
   | { type: 'JAM_ON_NEXT_OPERATION' }
   | { type: 'CHECK_JAM_FLAG' };
@@ -130,7 +130,7 @@ const mockPlustekMachine = createMachine<Context, Event>({
           {
             target: 'ready_to_eject',
             actions: assign({ scanError: (_context, event) => event.error }),
-            cond: (_context, event) => event.error === 'bad_scan_result',
+            cond: (_context, event) => event.error === 'only_one_file_returned',
           },
         ],
         LOAD_SHEET: 'both_sides_have_paper',
@@ -372,7 +372,7 @@ export class MockScannerClient implements ScannerClient {
   /**
    * Run during a scan operation to simulate an error pulling the paper into the scanner.
    */
-  simulateScanError(error: 'error_feeding' | 'bad_scan_result'): void {
+  simulateScanError(error: 'error_feeding' | 'only_one_file_returned'): void {
     debug('simulating scan error: %o', error);
     this.machine.send({ type: 'SCAN_ERROR', error });
   }
@@ -536,7 +536,7 @@ export class MockScannerClient implements ScannerClient {
                   ? ScannerError.PaperStatusErrorFeeding
                   : ScannerError.PaperStatusNoPaper
               );
-            case 'bad_scan_result':
+            case 'only_one_file_returned':
               return err(
                 new InvalidClientResponseError(
                   'expected two files, got [ file1.jpg ]'


### PR DESCRIPTION

## Overview
Fixes https://github.com/votingworks/vxsuite/issues/2471

When Plustek only returns one scanned image file, it seems to be
unrecoverable even if we disconnect/reconnect to Plustek. Subsequent scans exhibit the same buggy behavior.

Restarting the tablet seems to fix it, so we make the state machine go to the unrecoverable_error state, which shows the user instructions to restart. The ballot will be rejected automatically after restart.

## Demo Video or Screenshot
None

## Testing Plan 
- Update automated test
- Manually tested with a faked error


