### PR TITLE
Back up either original or normalized scan images depending on scanned ballot count

### DIFF
--- a/frontends/bsd/src/app_root.tsx
+++ b/frontends/bsd/src/app_root.tsx
@@ -65,6 +65,13 @@ const Buttons = styled.div`
   }
 `;
 
+/**
+ * At greater than 6000 scanned ballots, if we store original scan images, we run the risk of the
+ * central scanner backup zip being larger than 4GB, the max file size on FAT32 formatted USB
+ * drives
+ */
+export const MAX_BALLOT_COUNT_FOR_INCLUDING_ORIGINAL_SCAN_IMAGES = 6000;
+
 export interface AppRootProps {
   card: Card;
   hardware: Hardware;
@@ -392,13 +399,20 @@ export function AppRoot({ card, hardware, logger }: AppRootProps): JSX.Element {
   }, [history, logger, userRole, currentNumberOfBallots, refreshConfig]);
 
   const backup = useCallback(async () => {
-    await download('/central-scanner/scan/backup');
+    const scanImagesToInclude =
+      currentNumberOfBallots <=
+      MAX_BALLOT_COUNT_FOR_INCLUDING_ORIGINAL_SCAN_IMAGES
+        ? 'originalOnly'
+        : 'normalizedOnly';
+    await download(
+      `/central-scanner/scan/backup?scanImagesToInclude=${scanImagesToInclude}`
+    );
     if (window.kiosk) {
       // Backups can take several minutes. Ensure the data is flushed to the
       // usb before prompting the user to eject it.
       await usbstick.doSync();
     }
-  }, []);
+  }, [currentNumberOfBallots]);
 
   const toggleTestMode = useCallback(async () => {
     try {

--- a/frontends/precinct-scanner/src/components/export_backup_modal.test.tsx
+++ b/frontends/precinct-scanner/src/components/export_backup_modal.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { electionSampleDefinition } from '@votingworks/fixtures';
 import { fakeKiosk, fakeUsbDrive, Inserted } from '@votingworks/test-utils';
 
@@ -9,7 +10,10 @@ import { mocked } from 'ts-jest/utils';
 import { MachineConfig } from '../config/types';
 import { AppContext } from '../contexts/app_context';
 import { download, DownloadErrorKind } from '../utils/download';
-import { ExportBackupModal } from './export_backup_modal';
+import {
+  ExportBackupModal,
+  MAX_BALLOT_COUNT_FOR_INCLUDING_ORIGINAL_SCAN_IMAGES,
+} from './export_backup_modal';
 
 jest.mock('../utils/download');
 
@@ -20,6 +24,8 @@ const machineConfig: MachineConfig = {
   codeVersion: 'TEST',
 };
 const auth = Inserted.fakeElectionManagerAuth();
+const scannedBallotCount =
+  MAX_BALLOT_COUNT_FOR_INCLUDING_ORIGINAL_SCAN_IMAGES - 1;
 
 test('renders loading screen when USB drive is mounting or ejecting in export modal', () => {
   const usbStatuses = [UsbDriveStatus.present, UsbDriveStatus.ejecting];
@@ -37,6 +43,7 @@ test('renders loading screen when USB drive is mounting or ejecting in export mo
       >
         <ExportBackupModal
           onClose={closeFn}
+          scannedBallotCount={scannedBallotCount}
           usbDrive={{ status, eject: jest.fn() }}
         />
       </AppContext.Provider>
@@ -66,6 +73,7 @@ test('render no USB found screen when there is not a mounted USB drive', () => {
       >
         <ExportBackupModal
           onClose={closeFn}
+          scannedBallotCount={scannedBallotCount}
           usbDrive={{ status, eject: jest.fn() }}
         />
       </AppContext.Provider>
@@ -99,6 +107,7 @@ test('render export modal when a USB drive is mounted as expected and allows cus
     >
       <ExportBackupModal
         onClose={closeFn}
+        scannedBallotCount={scannedBallotCount}
         usbDrive={{ status: UsbDriveStatus.mounted, eject: jest.fn() }}
       />
     </AppContext.Provider>
@@ -111,7 +120,9 @@ test('render export modal when a USB drive is mounted as expected and allows cus
 
   fireEvent.click(screen.getByText('Custom'));
   await screen.findByText('Backup Saved');
-  expect(download).toHaveBeenCalledWith('/precinct-scanner/backup');
+  expect(download).toHaveBeenCalledWith(
+    '/precinct-scanner/backup?scanImagesToInclude=originalOnly'
+  );
 
   fireEvent.click(screen.getByText('Cancel'));
   expect(closeFn).toHaveBeenCalled();
@@ -126,6 +137,7 @@ test('render export modal when a USB drive is mounted as expected and allows cus
     >
       <ExportBackupModal
         onClose={closeFn}
+        scannedBallotCount={scannedBallotCount}
         usbDrive={{ status: UsbDriveStatus.recentlyEjected, eject: jest.fn() }}
       />
     </AppContext.Provider>
@@ -152,6 +164,7 @@ test('render export modal when a USB drive is mounted as expected and allows aut
     >
       <ExportBackupModal
         onClose={closeFn}
+        scannedBallotCount={scannedBallotCount}
         usbDrive={{ status: UsbDriveStatus.mounted, eject: ejectFn }}
       />
     </AppContext.Provider>
@@ -160,9 +173,12 @@ test('render export modal when a USB drive is mounted as expected and allows aut
 
   fireEvent.click(screen.getByText('Save'));
   await screen.findByText('Backup Saved');
-  expect(download).toHaveBeenCalledWith('/precinct-scanner/backup', {
-    into: 'fake mount point/scanner-backups/franklin-county_general-election_748dc61ad3',
-  });
+  expect(download).toHaveBeenCalledWith(
+    '/precinct-scanner/backup?scanImagesToInclude=originalOnly',
+    {
+      into: 'fake mount point/scanner-backups/franklin-county_general-election_748dc61ad3',
+    }
+  );
   expect(mockKiosk.syncUsbDrive).toHaveBeenCalledWith('fake mount point');
 
   fireEvent.click(screen.getByText('Eject USB'));
@@ -187,6 +203,7 @@ test('handles no USB drives', async () => {
     >
       <ExportBackupModal
         onClose={closeFn}
+        scannedBallotCount={scannedBallotCount}
         usbDrive={{ status: UsbDriveStatus.mounted, eject: jest.fn() }}
       />
     </AppContext.Provider>
@@ -218,6 +235,7 @@ test('shows a specific error for file writer failure', async () => {
     >
       <ExportBackupModal
         onClose={closeFn}
+        scannedBallotCount={scannedBallotCount}
         usbDrive={{ status: UsbDriveStatus.mounted, eject: jest.fn() }}
       />
     </AppContext.Provider>
@@ -256,6 +274,7 @@ test('shows a specific error for fetch failure', async () => {
     >
       <ExportBackupModal
         onClose={closeFn}
+        scannedBallotCount={scannedBallotCount}
         usbDrive={{ status: UsbDriveStatus.mounted, eject: jest.fn() }}
       />
     </AppContext.Provider>
@@ -275,4 +294,40 @@ test('shows a specific error for fetch failure', async () => {
 
   fireEvent.click(screen.getByText('Close'));
   expect(closeFn).toHaveBeenCalled();
+});
+
+test('backs up only normalized scan images once scanned ballot count gets high enough', async () => {
+  const mockKiosk = fakeKiosk();
+  window.kiosk = mockKiosk;
+  mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
+  mocked(download).mockResolvedValueOnce(ok());
+
+  render(
+    <AppContext.Provider
+      value={{
+        auth,
+        electionDefinition: electionSampleDefinition,
+        isSoundMuted: false,
+        machineConfig,
+      }}
+    >
+      <ExportBackupModal
+        onClose={jest.fn()}
+        scannedBallotCount={
+          MAX_BALLOT_COUNT_FOR_INCLUDING_ORIGINAL_SCAN_IMAGES + 1
+        }
+        usbDrive={{ status: UsbDriveStatus.mounted, eject: jest.fn() }}
+      />
+    </AppContext.Provider>
+  );
+
+  await screen.findByRole('heading', { name: 'Save Backup' });
+  userEvent.click(screen.getByRole('button', { name: 'Save' }));
+  await screen.findByRole('heading', { name: 'Backup Saved' });
+  expect(download).toHaveBeenCalledWith(
+    '/precinct-scanner/backup?scanImagesToInclude=normalizedOnly',
+    {
+      into: 'fake mount point/scanner-backups/franklin-county_general-election_748dc61ad3',
+    }
+  );
 });

--- a/frontends/precinct-scanner/src/screens/election_manager_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/election_manager_screen.tsx
@@ -295,6 +295,7 @@ export function ElectionManagerScreen({
       {isExportingBackup && (
         <ExportBackupModal
           onClose={() => setIsExportingBackup(false)}
+          scannedBallotCount={scannerStatus.ballotsCounted}
           usbDrive={usbDrive}
         />
       )}

--- a/services/scan/src/central_scanner_app.ts
+++ b/services/scan/src/central_scanner_app.ts
@@ -15,7 +15,7 @@ import { readFile } from 'fs-extra';
 import { z } from 'zod';
 import { Store } from './store';
 import { Importer } from './importer';
-import { backup } from './backup';
+import { backup, parseScanImagesToIncludeQueryParam } from './backup';
 
 const debug = makeDebug('scan:central-scanner');
 
@@ -621,7 +621,10 @@ export async function buildCentralScannerApp({
     }
   );
 
-  app.get('/central-scanner/scan/backup', (_request, response) => {
+  app.get('/central-scanner/scan/backup', (request, response) => {
+    const scanImagesToInclude = parseScanImagesToIncludeQueryParam(
+      request.query['scanImagesToInclude']
+    );
     const electionDefinition = store.getElectionDefinition();
 
     if (!electionDefinition) {
@@ -649,7 +652,7 @@ export async function buildCentralScannerApp({
       )
       .flushHeaders();
 
-    backup(store)
+    backup(store, { scanImagesToInclude })
       .on('error', (error: Error) => {
         debug('backup error: %s', error.stack);
         response.status(500).json({

--- a/services/scan/src/precinct_scanner_app.ts
+++ b/services/scan/src/precinct_scanner_app.ts
@@ -18,7 +18,7 @@ import { interpretTemplate } from '@votingworks/ballot-interpreter-vx';
 import { PrecinctScannerStateMachine } from './precinct_scanner_state_machine';
 import { pdfToImages } from './util/pdf_to_images';
 import { Workspace } from './util/workspace';
-import { backup } from './backup';
+import { backup, parseScanImagesToIncludeQueryParam } from './backup';
 import { PrecinctScannerInterpreter } from './precinct_scanner_interpreter';
 import { Store } from './store';
 
@@ -459,7 +459,10 @@ export async function buildPrecinctScannerApp(
     }
   );
 
-  app.get('/precinct-scanner/backup', (_request, response) => {
+  app.get('/precinct-scanner/backup', (request, response) => {
+    const scanImagesToInclude = parseScanImagesToIncludeQueryParam(
+      request.query['scanImagesToInclude']
+    );
     const electionDefinition = store.getElectionDefinition();
 
     if (!electionDefinition) {
@@ -487,7 +490,7 @@ export async function buildPrecinctScannerApp(
       )
       .flushHeaders();
 
-    backup(store)
+    backup(store, { scanImagesToInclude })
       .on('error', (error: Error) => {
         // debug('backup error: %s', error.stack);
         response.status(500).json({


### PR DESCRIPTION
_Commit by commit reviewing recommended_

## Overview

We've been hitting file size limits exporting backups to FAT32 formatted USB drives, which have a 4GB file size limit. As a short-term mitigation for m14, after a certain number of ballots have been scanned, we'll only export normalized scan images (much smaller than original scan images). Before that number of ballots have been scanned, we'll only export original scan images (most useful to us for debugging). Today, we export both normalized and original images.

Through testing, we've landed on different thresholds for VxScan and VxCentralScan.

## Testing Plan 

- [x] Updated services/scan tests
- [x] Updated frontends/precinct-scanner tests
- [x] Tested VxScan manually
- [x] Tested VxCentralScan manually

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A
- [x] I have added JSDoc comments to any newly introduced exports