### PR TITLE
Contain space-optimized backup logic to the scan service

### DIFF
--- a/frontends/bsd/src/app_root.tsx
+++ b/frontends/bsd/src/app_root.tsx
@@ -65,13 +65,6 @@ const Buttons = styled.div`
   }
 `;
 
-/**
- * At greater than 6000 scanned ballots, if we store original scan images, we run the risk of the
- * central scanner backup zip being larger than 4GB, the max file size on FAT32 formatted USB
- * drives
- */
-export const MAX_BALLOT_COUNT_FOR_INCLUDING_ORIGINAL_SCAN_IMAGES = 6000;
-
 export interface AppRootProps {
   card: Card;
   hardware: Hardware;
@@ -399,20 +392,13 @@ export function AppRoot({ card, hardware, logger }: AppRootProps): JSX.Element {
   }, [history, logger, userRole, currentNumberOfBallots, refreshConfig]);
 
   const backup = useCallback(async () => {
-    const scanImagesToInclude =
-      currentNumberOfBallots <=
-      MAX_BALLOT_COUNT_FOR_INCLUDING_ORIGINAL_SCAN_IMAGES
-        ? 'originalOnly'
-        : 'normalizedOnly';
-    await download(
-      `/central-scanner/scan/backup?scanImagesToInclude=${scanImagesToInclude}`
-    );
+    await download('/central-scanner/scan/backup');
     if (window.kiosk) {
       // Backups can take several minutes. Ensure the data is flushed to the
       // usb before prompting the user to eject it.
       await usbstick.doSync();
     }
-  }, [currentNumberOfBallots]);
+  }, []);
 
   const toggleTestMode = useCallback(async () => {
     try {

--- a/frontends/precinct-scanner/src/components/export_backup_modal.test.tsx
+++ b/frontends/precinct-scanner/src/components/export_backup_modal.test.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { electionSampleDefinition } from '@votingworks/fixtures';
 import { fakeKiosk, fakeUsbDrive, Inserted } from '@votingworks/test-utils';
 
@@ -10,10 +9,7 @@ import { mocked } from 'ts-jest/utils';
 import { MachineConfig } from '../config/types';
 import { AppContext } from '../contexts/app_context';
 import { download, DownloadErrorKind } from '../utils/download';
-import {
-  ExportBackupModal,
-  MAX_BALLOT_COUNT_FOR_INCLUDING_ORIGINAL_SCAN_IMAGES,
-} from './export_backup_modal';
+import { ExportBackupModal } from './export_backup_modal';
 
 jest.mock('../utils/download');
 
@@ -24,8 +20,6 @@ const machineConfig: MachineConfig = {
   codeVersion: 'TEST',
 };
 const auth = Inserted.fakeElectionManagerAuth();
-const scannedBallotCount =
-  MAX_BALLOT_COUNT_FOR_INCLUDING_ORIGINAL_SCAN_IMAGES - 1;
 
 test('renders loading screen when USB drive is mounting or ejecting in export modal', () => {
   const usbStatuses = [UsbDriveStatus.present, UsbDriveStatus.ejecting];
@@ -43,7 +37,6 @@ test('renders loading screen when USB drive is mounting or ejecting in export mo
       >
         <ExportBackupModal
           onClose={closeFn}
-          scannedBallotCount={scannedBallotCount}
           usbDrive={{ status, eject: jest.fn() }}
         />
       </AppContext.Provider>
@@ -73,7 +66,6 @@ test('render no USB found screen when there is not a mounted USB drive', () => {
       >
         <ExportBackupModal
           onClose={closeFn}
-          scannedBallotCount={scannedBallotCount}
           usbDrive={{ status, eject: jest.fn() }}
         />
       </AppContext.Provider>
@@ -107,7 +99,6 @@ test('render export modal when a USB drive is mounted as expected and allows cus
     >
       <ExportBackupModal
         onClose={closeFn}
-        scannedBallotCount={scannedBallotCount}
         usbDrive={{ status: UsbDriveStatus.mounted, eject: jest.fn() }}
       />
     </AppContext.Provider>
@@ -120,9 +111,7 @@ test('render export modal when a USB drive is mounted as expected and allows cus
 
   fireEvent.click(screen.getByText('Custom'));
   await screen.findByText('Backup Saved');
-  expect(download).toHaveBeenCalledWith(
-    '/precinct-scanner/backup?scanImagesToInclude=originalOnly'
-  );
+  expect(download).toHaveBeenCalledWith('/precinct-scanner/backup');
 
   fireEvent.click(screen.getByText('Cancel'));
   expect(closeFn).toHaveBeenCalled();
@@ -137,7 +126,6 @@ test('render export modal when a USB drive is mounted as expected and allows cus
     >
       <ExportBackupModal
         onClose={closeFn}
-        scannedBallotCount={scannedBallotCount}
         usbDrive={{ status: UsbDriveStatus.recentlyEjected, eject: jest.fn() }}
       />
     </AppContext.Provider>
@@ -164,7 +152,6 @@ test('render export modal when a USB drive is mounted as expected and allows aut
     >
       <ExportBackupModal
         onClose={closeFn}
-        scannedBallotCount={scannedBallotCount}
         usbDrive={{ status: UsbDriveStatus.mounted, eject: ejectFn }}
       />
     </AppContext.Provider>
@@ -173,12 +160,9 @@ test('render export modal when a USB drive is mounted as expected and allows aut
 
   fireEvent.click(screen.getByText('Save'));
   await screen.findByText('Backup Saved');
-  expect(download).toHaveBeenCalledWith(
-    '/precinct-scanner/backup?scanImagesToInclude=originalOnly',
-    {
-      into: 'fake mount point/scanner-backups/franklin-county_general-election_748dc61ad3',
-    }
-  );
+  expect(download).toHaveBeenCalledWith('/precinct-scanner/backup', {
+    into: 'fake mount point/scanner-backups/franklin-county_general-election_748dc61ad3',
+  });
   expect(mockKiosk.syncUsbDrive).toHaveBeenCalledWith('fake mount point');
 
   fireEvent.click(screen.getByText('Eject USB'));
@@ -203,7 +187,6 @@ test('handles no USB drives', async () => {
     >
       <ExportBackupModal
         onClose={closeFn}
-        scannedBallotCount={scannedBallotCount}
         usbDrive={{ status: UsbDriveStatus.mounted, eject: jest.fn() }}
       />
     </AppContext.Provider>
@@ -235,7 +218,6 @@ test('shows a specific error for file writer failure', async () => {
     >
       <ExportBackupModal
         onClose={closeFn}
-        scannedBallotCount={scannedBallotCount}
         usbDrive={{ status: UsbDriveStatus.mounted, eject: jest.fn() }}
       />
     </AppContext.Provider>
@@ -274,7 +256,6 @@ test('shows a specific error for fetch failure', async () => {
     >
       <ExportBackupModal
         onClose={closeFn}
-        scannedBallotCount={scannedBallotCount}
         usbDrive={{ status: UsbDriveStatus.mounted, eject: jest.fn() }}
       />
     </AppContext.Provider>
@@ -294,40 +275,4 @@ test('shows a specific error for fetch failure', async () => {
 
   fireEvent.click(screen.getByText('Close'));
   expect(closeFn).toHaveBeenCalled();
-});
-
-test('backs up only normalized scan images once scanned ballot count gets high enough', async () => {
-  const mockKiosk = fakeKiosk();
-  window.kiosk = mockKiosk;
-  mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
-  mocked(download).mockResolvedValueOnce(ok());
-
-  render(
-    <AppContext.Provider
-      value={{
-        auth,
-        electionDefinition: electionSampleDefinition,
-        isSoundMuted: false,
-        machineConfig,
-      }}
-    >
-      <ExportBackupModal
-        onClose={jest.fn()}
-        scannedBallotCount={
-          MAX_BALLOT_COUNT_FOR_INCLUDING_ORIGINAL_SCAN_IMAGES + 1
-        }
-        usbDrive={{ status: UsbDriveStatus.mounted, eject: jest.fn() }}
-      />
-    </AppContext.Provider>
-  );
-
-  await screen.findByRole('heading', { name: 'Save Backup' });
-  userEvent.click(screen.getByRole('button', { name: 'Save' }));
-  await screen.findByRole('heading', { name: 'Backup Saved' });
-  expect(download).toHaveBeenCalledWith(
-    '/precinct-scanner/backup?scanImagesToInclude=normalizedOnly',
-    {
-      into: 'fake mount point/scanner-backups/franklin-county_general-election_748dc61ad3',
-    }
-  );
 });

--- a/frontends/precinct-scanner/src/screens/election_manager_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/election_manager_screen.tsx
@@ -295,7 +295,6 @@ export function ElectionManagerScreen({
       {isExportingBackup && (
         <ExportBackupModal
           onClose={() => setIsExportingBackup(false)}
-          scannedBallotCount={scannerStatus.ballotsCounted}
           usbDrive={usbDrive}
         />
       )}


### PR DESCRIPTION
## Overview

We quickly prepared a patch in https://github.com/votingworks/vxsuite/pull/2481 to avoid file size limits when exporting backups to FAT32 formatted USB drives. @jonahkagan pointed out that the logic in that PR, which spans both the backend scan service and VxScan/VxCentralScan frontends, could be contained to just the backend scan service.

This PR tweaks the implementation of the optimization accordingly. In addition to cleanliness/simplicity, this tweak also has the nice benefit of counting failed scans toward the "switch to normalized images only" threshold. That said, I don't see an urgent need to incorporate this tweak into our m14 images.

## Testing

- [x] Updated scan service tests
- [x] Tested VxScan with a modified threshold manually
- [x] Tested VxCentralScan with a modified threshold manually

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A
- [x] I have added JSDoc comments to any newly introduced exports