### PR TITLE
fix(admin): correct some printed ballot wording

### DIFF
--- a/frontends/election-manager/src/screens/printed_ballots_report_screen.tsx
+++ b/frontends/election-manager/src/screens/printed_ballots_report_screen.tsx
@@ -136,8 +136,8 @@ export function PrintedBallotsReportScreen(): JSX.Element {
       </p>
       <p>
         {pluralize('absentee ballot', totalAbsenteeBallotsPrinted, true)} and{' '}
-        {pluralize('precinct ballot', totalPrecinctBallotsPrinted, true)}{' '}
-        {pluralize('have', totalBallotsPrinted)} been printed.
+        {pluralize('precinct ballot', totalPrecinctBallotsPrinted, true)} have
+        been printed.
       </p>
       <p>
         <strong>

--- a/frontends/election-manager/src/screens/reports_screen.tsx
+++ b/frontends/election-manager/src/screens/reports_screen.tsx
@@ -173,9 +173,12 @@ export function ReportsScreen(): JSX.Element {
   const ballotPrintingSummaryText = (
     <p>
       <strong>
-        {pluralize('official ballot', totalBallotsPrinted, true)}{' '}
+        {pluralize(
+          `${format.count(totalBallotsPrinted)} official ballots`,
+          totalBallotsPrinted
+        )}{' '}
       </strong>{' '}
-      have been printed.
+      {`${pluralize('have', totalBallotsPrinted)} been printed`}.
     </p>
   );
 


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
Before:
- "1 official ballot have been printed"
- "1 absentee ballot and 0 precinct ballots has been printed"

After:
- "1 official ballot has been printed"
- "1 absentee ballot and 0 precinct ballots have been printed"

## Demo Video or Screenshot
n/a

## Testing Plan 
Manually tested with a few different printed ballot counts.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
