### PR TITLE
fix(ps) save plustek images as workspace ballot image path

### DIFF
--- a/services/scan/src/precinct_scanner_app.test.ts
+++ b/services/scan/src/precinct_scanner_app.test.ts
@@ -208,6 +208,7 @@ async function createApp(
   }
   const precinctScannerMachine = createPrecinctScannerStateMachine(
     createPlustekClient,
+    workspace,
     logger,
     delays
   );

--- a/services/scan/src/server.ts
+++ b/services/scan/src/server.ts
@@ -67,6 +67,7 @@ export async function start({
   if (machineType === 'precinct-scanner') {
     const precinctScannerMachine = createPrecinctScannerStateMachine(
       createPlustekClient,
+      resolvedWorkspace,
       logger
     );
     resolvedApp = buildPrecinctScannerApp(

--- a/services/scan/src/util/workspace.ts
+++ b/services/scan/src/util/workspace.ts
@@ -5,14 +5,28 @@ import { Store } from '../store';
 export interface Workspace {
   readonly path: string;
   readonly ballotImagesPath: string;
+  readonly plustekImagesPath?: string;
   readonly store: Store;
 }
 
-export async function createWorkspace(root: string): Promise<Workspace> {
+export async function createWorkspace(
+  root: string,
+  isPrecinctScanner = false
+): Promise<Workspace> {
   const resolvedRoot = resolve(root);
   const ballotImagesPath = join(resolvedRoot, 'ballot-images');
   const dbPath = join(resolvedRoot, 'ballots.db');
   await ensureDir(ballotImagesPath);
+  if (isPrecinctScanner) {
+    const plustekImagesPath = join(ballotImagesPath, 'plustek-images');
+    await ensureDir(plustekImagesPath);
+    return {
+      path: resolvedRoot,
+      ballotImagesPath,
+      plustekImagesPath,
+      store: Store.fileStore(dbPath),
+    };
+  }
 
   return {
     path: resolvedRoot,


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
We are automatically saving plustek images to /tmp, in prod /tmp only has 1GB of space so every ~300 ballots we run out of space and require a reboot, this fixes this by moving to a directory in the ballot-images workspace. Conveniently we already just link files when we put them in ballot-images so it doesn't actually increase the space we are using at all. 

## Demo Video or Screenshot

## Testing Plan 
Tested with and without the proper directory already existing, tested exporting a backup and made sure images got exported properly. 

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
