### PR TITLE
fix(ps): show infobar on polls closed

### DIFF
--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -570,11 +570,22 @@ export function AppRoot({
 
   if (!isPollsOpen) {
     return (
-      <PollsClosedScreen
-        isLiveMode={!isTestMode}
-        showNoChargerWarning={!computer.batteryIsCharging}
-        scannedBallotCount={scannerStatus.ballotsCounted}
-      />
+      <AppContext.Provider
+        value={{
+          electionDefinition,
+          currentPrecinctId,
+          currentMarkThresholds,
+          machineConfig,
+          auth,
+          isSoundMuted,
+        }}
+      >
+        <PollsClosedScreen
+          isLiveMode={!isTestMode}
+          showNoChargerWarning={!computer.batteryIsCharging}
+          scannedBallotCount={scannerStatus.ballotsCounted}
+        />
+      </AppContext.Provider>
     );
   }
 

--- a/frontends/precinct-scanner/src/screens/polls_closed_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/polls_closed_screen.test.tsx
@@ -43,6 +43,12 @@ describe('PollsClosedScreen', () => {
     await screen.findByText('No Power Detected.');
   });
 
+  test('does not show "No Power Detected" when not called for', async () => {
+    renderScreen(false);
+    await screen.findByText('Polls Closed');
+    expect(screen.queryAllByText('No Power Detected.').length).toBe(0);
+  });
+
   test('shows ballot count', async () => {
     renderScreen(false);
     await screen.findByText(TEST_BALLOT_COUNT);

--- a/frontends/precinct-scanner/src/screens/polls_closed_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/polls_closed_screen.test.tsx
@@ -3,12 +3,15 @@ import { render, screen } from '@testing-library/react';
 import { Inserted } from '@votingworks/test-utils';
 import { electionSampleDefinition } from '@votingworks/fixtures';
 import { AppContext } from '../contexts/app_context';
-import { PollsClosedScreen } from './polls_closed_screen';
+import {
+  PollsClosedScreen,
+  PollsClosedScreenProps,
+} from './polls_closed_screen';
 
 const TEST_BALLOT_COUNT = 50;
 const MACHINE_ID = '0003';
 
-function renderScreen(showNoChargerWarning: boolean) {
+function renderScreen(props: Partial<PollsClosedScreenProps> = {}) {
   render(
     <AppContext.Provider
       value={{
@@ -24,9 +27,10 @@ function renderScreen(showNoChargerWarning: boolean) {
       }}
     >
       <PollsClosedScreen
-        showNoChargerWarning={showNoChargerWarning}
+        showNoChargerWarning={false}
         isLiveMode
         scannedBallotCount={TEST_BALLOT_COUNT}
+        {...props}
       />
     </AppContext.Provider>
   );
@@ -34,28 +38,28 @@ function renderScreen(showNoChargerWarning: boolean) {
 
 describe('PollsClosedScreen', () => {
   test('shows "Polls Closed"', async () => {
-    renderScreen(false);
+    renderScreen();
     await screen.findByText('Polls Closed');
   });
 
   test('shows "No Power Detected" when called for', async () => {
-    renderScreen(true);
+    renderScreen({ showNoChargerWarning: true });
     await screen.findByText('No Power Detected.');
   });
 
   test('does not show "No Power Detected" when not called for', async () => {
-    renderScreen(false);
+    renderScreen();
     await screen.findByText('Polls Closed');
     expect(screen.queryAllByText('No Power Detected.').length).toBe(0);
   });
 
   test('shows ballot count', async () => {
-    renderScreen(false);
+    renderScreen();
     await screen.findByText(TEST_BALLOT_COUNT);
   });
 
   test('shows jurisdiction, precinct, and machine id in election info bar', async () => {
-    renderScreen(false);
+    renderScreen();
     await screen.findByText('Franklin County, State of Hamilton');
     screen.getByText('Center Springfield');
     screen.getByText(MACHINE_ID);

--- a/frontends/precinct-scanner/src/screens/polls_closed_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/polls_closed_screen.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Inserted } from '@votingworks/test-utils';
+import { electionSampleDefinition } from '@votingworks/fixtures';
+import { AppContext } from '../contexts/app_context';
+import { PollsClosedScreen } from './polls_closed_screen';
+
+const TEST_BALLOT_COUNT = 50;
+const MACHINE_ID = '0003';
+
+function renderScreen(showNoChargerWarning: boolean) {
+  render(
+    <AppContext.Provider
+      value={{
+        electionDefinition: electionSampleDefinition,
+        currentPrecinctId: '23',
+        currentMarkThresholds: { definite: 0.12, marginal: 0.12 },
+        machineConfig: {
+          machineId: MACHINE_ID,
+          codeVersion: 'TEST',
+        },
+        auth: Inserted.fakeLoggedOutAuth(),
+        isSoundMuted: false,
+      }}
+    >
+      <PollsClosedScreen
+        showNoChargerWarning={showNoChargerWarning}
+        isLiveMode
+        scannedBallotCount={TEST_BALLOT_COUNT}
+      />
+    </AppContext.Provider>
+  );
+}
+
+describe('PollsClosedScreen', () => {
+  test('shows "Polls Closed"', async () => {
+    renderScreen(false);
+    await screen.findByText('Polls Closed');
+  });
+
+  test('shows "No Power Detected" when called for', async () => {
+    renderScreen(true);
+    await screen.findByText('No Power Detected.');
+  });
+
+  test('shows ballot count', async () => {
+    renderScreen(false);
+    await screen.findByText(TEST_BALLOT_COUNT);
+  });
+
+  test('shows jurisdiction, precinct, and machine id in election info bar', async () => {
+    renderScreen(false);
+    await screen.findByText('Franklin County, State of Hamilton');
+    screen.getByText('Center Springfield');
+    screen.getByText(MACHINE_ID);
+  });
+});

--- a/frontends/precinct-scanner/src/screens/polls_closed_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/polls_closed_screen.tsx
@@ -7,7 +7,7 @@ import {
 } from '../components/layout';
 import { ScannedBallotCount } from '../components/scanned_ballot_count';
 
-interface Props {
+export interface PollsClosedScreenProps {
   isLiveMode: boolean;
   showNoChargerWarning: boolean;
   scannedBallotCount: number;
@@ -17,7 +17,7 @@ export function PollsClosedScreen({
   isLiveMode,
   showNoChargerWarning,
   scannedBallotCount,
-}: Props): JSX.Element {
+}: PollsClosedScreenProps): JSX.Element {
   return (
     <ScreenMainCenterChild isLiveMode={isLiveMode} infoBarMode="pollworker">
       <DoNotEnter />

--- a/frontends/precinct-scanner/src/screens/polls_closed_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/polls_closed_screen.tsx
@@ -19,7 +19,7 @@ export function PollsClosedScreen({
   scannedBallotCount,
 }: Props): JSX.Element {
   return (
-    <ScreenMainCenterChild isLiveMode={isLiveMode}>
+    <ScreenMainCenterChild isLiveMode={isLiveMode} infoBarMode="pollworker">
       <DoNotEnter />
       <CenteredLargeProse>
         <h1>Polls Closed</h1>


### PR DESCRIPTION
Closes #2425. The Election Info Bar should have been on this page - and technically was - but wasn't able to display because the screen wasn't being passed appropriate app context.