### PR TITLE
fix(scan): prevent running out of space in `/tmp`

### DIFF
--- a/services/scan/src/central_scanner_app.test.ts
+++ b/services/scan/src/central_scanner_app.test.ts
@@ -32,7 +32,7 @@ let importer: jest.Mocked<Importer>;
 
 beforeEach(async () => {
   importer = makeMock(Importer);
-  workspace = await createWorkspace(dirSync().name);
+  workspace = createWorkspace(dirSync().name);
   workspace.store.setElection(stateOfHamilton.electionDefinition);
   workspace.store.setTestMode(false);
   workspace.store.addHmpbTemplate(

--- a/services/scan/src/cli/retry-scan/index.test.ts
+++ b/services/scan/src/cli/retry-scan/index.test.ts
@@ -140,7 +140,7 @@ test('query with sheet ids', () => {
 });
 
 (process.env.CI ? test.skip : test)('full rescan', async () => {
-  const inputWorkspace = await createWorkspace(dirSync().name);
+  const inputWorkspace = createWorkspace(dirSync().name);
   const { store } = inputWorkspace;
 
   store.setElection(fixtures.electionDefinition);
@@ -225,8 +225,8 @@ test('query with sheet ids', () => {
 (process.env.CI ? test.skip : test)(
   'writing output to another database',
   async () => {
-    const inputWorkspace = await createWorkspace(dirSync().name);
-    const outputWorkspace = await createWorkspace(dirSync().name);
+    const inputWorkspace = createWorkspace(dirSync().name);
+    const outputWorkspace = createWorkspace(dirSync().name);
     const inputDb = inputWorkspace.store;
 
     inputDb.setElection(fixtures.electionDefinition);

--- a/services/scan/src/cli/retry-scan/index.ts
+++ b/services/scan/src/cli/retry-scan/index.ts
@@ -88,12 +88,10 @@ export async function retryScan(
   options: Options,
   listeners?: RetryScanListeners
 ): Promise<void> {
-  const input = await createWorkspace(
+  const input = createWorkspace(
     options.inputWorkspace ?? join(__dirname, '../../../dev-workspace')
   );
-  const output = await createWorkspace(
-    options.outputWorkspace ?? dirSync().name
-  );
+  const output = createWorkspace(options.outputWorkspace ?? dirSync().name);
   const outputBatchId = output.store.addBatch();
 
   listeners?.configured?.({

--- a/services/scan/src/end_to_end.test.ts
+++ b/services/scan/src/end_to_end.test.ts
@@ -29,7 +29,7 @@ let scanner: MockScanner;
 
 beforeEach(async () => {
   scanner = makeMockScanner();
-  workspace = await createWorkspace(dirSync().name);
+  workspace = createWorkspace(dirSync().name);
   importer = new Importer({
     workspace,
     scanner,

--- a/services/scan/src/end_to_end_hmpb.test.ts
+++ b/services/scan/src/end_to_end_hmpb.test.ts
@@ -49,7 +49,7 @@ let importer: Importer;
 let app: Application;
 
 beforeEach(async () => {
-  workspace = await createWorkspace(dirSync().name);
+  workspace = createWorkspace(dirSync().name);
   scanner = makeMockScanner();
   importer = new Importer({ workspace, scanner });
   app = await buildCentralScannerApp({ importer, store: workspace.store });

--- a/services/scan/src/importer.test.ts
+++ b/services/scan/src/importer.test.ts
@@ -24,8 +24,8 @@ const sampleBallotImagesPath = join(__dirname, '..', 'sample-ballot-images/');
 
 let workspace: Workspace;
 
-beforeEach(async () => {
-  workspace = await createWorkspace(dirSync().name);
+beforeEach(() => {
+  workspace = createWorkspace(dirSync().name);
 });
 
 afterEach(async () => {

--- a/services/scan/src/importer.ts
+++ b/services/scan/src/importer.ts
@@ -599,9 +599,8 @@ export class Importer {
    * Reset all the data, both in the store and the ballot images.
    */
   async doZero(): Promise<void> {
-    this.workspace.store.zero();
+    this.workspace.zero();
     await this.setMarkThresholdOverrides(undefined);
-    fsExtra.emptyDirSync(this.workspace.ballotImagesPath);
   }
 
   /**

--- a/services/scan/src/precinct_scanner_app.test.ts
+++ b/services/scan/src/precinct_scanner_app.test.ts
@@ -203,7 +203,7 @@ async function createApp(
   }
 ) {
   const logger = fakeLogger();
-  const workspace = await createWorkspace(dirSync().name);
+  const workspace = createWorkspace(dirSync().name);
   const mockPlustek = new MockScannerClient({
     toggleHoldDuration: 100,
     passthroughDuration: 100,
@@ -215,13 +215,13 @@ async function createApp(
     return ok(mockPlustek);
   }
   const interpreter = createInterpreter();
-  const precinctScannerMachine = createPrecinctScannerStateMachine(
+  const precinctScannerMachine = createPrecinctScannerStateMachine({
     createPlustekClient,
-    workspace.store,
+    workspace,
     interpreter,
     logger,
-    delays
-  );
+    delays,
+  });
   const app = await buildPrecinctScannerApp(
     precinctScannerMachine,
     interpreter,

--- a/services/scan/src/precinct_scanner_app.ts
+++ b/services/scan/src/precinct_scanner_app.ts
@@ -1,7 +1,6 @@
 import { OkResponse, Scan } from '@votingworks/api';
 import * as streams from 'memory-streams';
 import { Buffer } from 'buffer';
-import * as fsExtra from 'fs-extra';
 import {
   BallotPageLayoutSchema,
   BallotPageLayoutWithImage,
@@ -185,9 +184,7 @@ export async function buildPrecinctScannerApp(
       }
 
       interpreter.unconfigure();
-      store.zero();
-      fsExtra.emptyDirSync(workspace.ballotImagesPath);
-      store.reset();
+      workspace.reset();
       response.json({ status: 'ok' });
     }
   );
@@ -219,8 +216,7 @@ export async function buildPrecinctScannerApp(
       return;
     }
 
-    store.zero();
-    fsExtra.emptyDirSync(workspace.ballotImagesPath);
+    workspace.zero();
     store.setTestMode(bodyParseResult.ok().testMode);
     await configureInterpreter(interpreter, workspace);
     response.json({ status: 'ok' });

--- a/services/scan/src/server.ts
+++ b/services/scan/src/server.ts
@@ -67,19 +67,19 @@ export async function start({
         'workspace path could not be determined; pass a workspace or run with SCAN_WORKSPACE'
       );
     }
-    resolvedWorkspace = await createWorkspace(workspacePath);
+    resolvedWorkspace = createWorkspace(workspacePath);
   }
 
   let resolvedApp: express.Application;
 
   if (machineType === 'precinct-scanner') {
     const precinctScannerInterpreter = createInterpreter();
-    const precinctScannerMachine = createPrecinctScannerStateMachine(
+    const precinctScannerMachine = createPrecinctScannerStateMachine({
       createPlustekClient,
-      resolvedWorkspace.store,
-      precinctScannerInterpreter,
-      logger
-    );
+      workspace: resolvedWorkspace,
+      interpreter: precinctScannerInterpreter,
+      logger,
+    });
     resolvedApp = await buildPrecinctScannerApp(
       precinctScannerMachine,
       precinctScannerInterpreter,

--- a/services/scan/src/util/workspace.ts
+++ b/services/scan/src/util/workspace.ts
@@ -1,22 +1,68 @@
-import { ensureDir } from 'fs-extra';
+import { emptyDirSync, ensureDirSync } from 'fs-extra';
 import { join, resolve } from 'path';
 import { Store } from '../store';
 
 export interface Workspace {
+  /**
+   * The path to the workspace root.
+   */
   readonly path: string;
+
+  /**
+   * The directory where interpreted images are stored.
+   */
   readonly ballotImagesPath: string;
+
+  /**
+   * The directory where the scanner will save images.
+   */
+  readonly scannedImagesPath: string;
+
+  /**
+   * The store associated with the workspace.
+   */
   readonly store: Store;
+
+  /**
+   * Zero out the data in the workspace, but leave the election configuration.
+   */
+  zero(): void;
+
+  /**
+   * Reset the workspace, including the election configuration. This is the same
+   * as deleting the workspace and recreating it.
+   */
+  reset(): void;
 }
 
-export async function createWorkspace(root: string): Promise<Workspace> {
+export function createWorkspace(root: string): Workspace {
   const resolvedRoot = resolve(root);
   const ballotImagesPath = join(resolvedRoot, 'ballot-images');
+  const scannedImagesPath = join(ballotImagesPath, 'scanned-images');
+  ensureDirSync(ballotImagesPath);
+  ensureDirSync(scannedImagesPath);
+
   const dbPath = join(resolvedRoot, 'ballots.db');
-  await ensureDir(ballotImagesPath);
+  const store = Store.fileStore(dbPath);
 
   return {
     path: resolvedRoot,
     ballotImagesPath,
-    store: Store.fileStore(dbPath),
+    scannedImagesPath,
+    store,
+    zero() {
+      store.zero();
+      emptyDirSync(ballotImagesPath);
+      emptyDirSync(scannedImagesPath);
+      ensureDirSync(ballotImagesPath);
+      ensureDirSync(scannedImagesPath);
+    },
+    reset() {
+      store.reset();
+      emptyDirSync(ballotImagesPath);
+      emptyDirSync(scannedImagesPath);
+      ensureDirSync(ballotImagesPath);
+      ensureDirSync(scannedImagesPath);
+    },
   };
 }


### PR DESCRIPTION
## Overview
This commit has more or less the same effect as #2486, but for `main`. I did things a little bit differently:
- used a more general `scanned-images` directory compared to `plustek-images`
- refactored zero/reset to be methods on `Workspace` to ensure consistency

## Demo Video or Screenshot
```
❯ tree --inodes dev-workspace
dev-workspace
├── [1961759]  ballot-images
│   ├── [1865139]  PIC-1661798828-001-40243cf5-f2f7-4114-a24f-89725366d058-normalized.jpg
│   ├── [1865137]  PIC-1661798828-001-40243cf5-f2f7-4114-a24f-89725366d058-original.jpg
│   ├── [1865140]  PIC-1661798828-002-40243cf5-f2f7-4114-a24f-89725366d058-normalized.jpg
│   ├── [1865138]  PIC-1661798828-002-40243cf5-f2f7-4114-a24f-89725366d058-original.jpg
│   └── [1961801]  scanned-images
│       ├── [1865137]  PIC-1661798828-001.jpg
│       └── [1865138]  PIC-1661798828-002.jpg
├── [1864096]  ballots.db
└── [1864097]  ballots.db.digest

2 directories, 8 files
```

## Testing Plan 
Tested manually with the precinct scanner configuration and a real ballot sheet.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
