### PR TITLE
fix(em): make test deck tally report look same as (un)official

### DIFF
--- a/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
+++ b/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
@@ -281,7 +281,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
     </div>
   </div>
   <div
-    class="sc-hiCivh bWrhyG"
+    class="sc-hiCivh bWrhyG print-only"
   >
     <section
       class="sc-kLwgWK fnXcLU"
@@ -291,27 +291,18 @@ exports[`L&A (logic and accuracy) flow 1`] = `
         class="sc-cxpRKc kqUdsO"
         src="/votingworks-wordmark-black.svg"
       />
-      <div>
-        <strong>
-          Test Deck Tally Reports
-        </strong>
-         for 
-         Mock General Election Choctaw 2020
-      </div>
       <div
         class="sc-jRQAMF foBEwC"
       >
-        <h1
-          class="sc-ikJzcn hrFjNm"
-          style="margin-bottom: 0.75em; margin-top: 0.25em;"
-        >
-          Precinct
-           Tally Report for
+        <h1>
+          Test Deck
+           Precinct Tally Report for:
            
-          <strong>
-            District 5
-          </strong>
+          District 5
         </h1>
+        <h2>
+          Mock General Election Choctaw 2020
+        </h2>
         <p>
           Wednesday, August 26, 2020
           , 
@@ -330,6 +321,66 @@ exports[`L&A (logic and accuracy) flow 1`] = `
       <div
         class="sc-jJoQpE Icimc"
       >
+        <div
+          class="sc-iAKVOt kfoWZP"
+        >
+          <h3>
+            Ballots by Voting Method
+          </h3>
+          <table
+            class="sc-ieebsP kIjWQX"
+            data-testid="voting-method-table"
+          >
+            <tbody>
+              <tr
+                data-testid="absentee"
+              >
+                <td
+                  class="sc-dJjZJu bbhgyU"
+                >
+                  Absentee
+                </td>
+                <td
+                  class="sc-dJjZJu BqrMg"
+                >
+                  0
+                </td>
+              </tr>
+              <tr
+                data-testid="standard"
+              >
+                <td
+                  class="sc-dJjZJu bbhgyU"
+                >
+                  Precinct
+                </td>
+                <td
+                  class="sc-dJjZJu BqrMg"
+                >
+                  8
+                </td>
+              </tr>
+              <tr
+                data-testid="total"
+              >
+                <td
+                  class="sc-dJjZJu bbhgyU"
+                >
+                  <strong>
+                    Total Ballots Cast
+                  </strong>
+                </td>
+                <td
+                  class="sc-dJjZJu BqrMg"
+                >
+                  <strong>
+                    8
+                  </strong>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
         <div
           class="sc-hGPAah dymfDz"
         >
@@ -683,7 +734,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
           </div>
         </div>
         <div
-          class="sc-hGPAah dymfDz"
+          class="sc-hGPAah fGDelY"
         >
           <div
             class="sc-jRQAMF foBEwC"
@@ -732,9 +783,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
                   </td>
                   <td
                     class="sc-dJjZJu fKfTwY"
-                  >
-                    0
-                  </td>
+                  />
                 </tr>
                 <tr
                   data-testid="775020899-write-in"
@@ -744,16 +793,14 @@ exports[`L&A (logic and accuracy) flow 1`] = `
                   </td>
                   <td
                     class="sc-dJjZJu fKfTwY"
-                  >
-                    0
-                  </td>
+                  />
                 </tr>
               </tbody>
             </table>
           </div>
         </div>
         <div
-          class="sc-hGPAah dymfDz"
+          class="sc-hGPAah fGDelY"
         >
           <div
             class="sc-jRQAMF foBEwC"
@@ -802,9 +849,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
                   </td>
                   <td
                     class="sc-dJjZJu fKfTwY"
-                  >
-                    0
-                  </td>
+                  />
                 </tr>
                 <tr
                   data-testid="775020900-775032017"
@@ -814,9 +859,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
                   </td>
                   <td
                     class="sc-dJjZJu fKfTwY"
-                  >
-                    0
-                  </td>
+                  />
                 </tr>
                 <tr
                   data-testid="775020900-write-in"
@@ -826,16 +869,14 @@ exports[`L&A (logic and accuracy) flow 1`] = `
                   </td>
                   <td
                     class="sc-dJjZJu fKfTwY"
-                  >
-                    0
-                  </td>
+                  />
                 </tr>
               </tbody>
             </table>
           </div>
         </div>
         <div
-          class="sc-hGPAah dymfDz"
+          class="sc-hGPAah fGDelY"
         >
           <div
             class="sc-jRQAMF foBEwC"
@@ -884,9 +925,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
                   </td>
                   <td
                     class="sc-dJjZJu fKfTwY"
-                  >
-                    0
-                  </td>
+                  />
                 </tr>
                 <tr
                   data-testid="775020901-write-in"
@@ -896,16 +935,14 @@ exports[`L&A (logic and accuracy) flow 1`] = `
                   </td>
                   <td
                     class="sc-dJjZJu fKfTwY"
-                  >
-                    0
-                  </td>
+                  />
                 </tr>
               </tbody>
             </table>
           </div>
         </div>
         <div
-          class="sc-hGPAah dymfDz"
+          class="sc-hGPAah fGDelY"
         >
           <div
             class="sc-jRQAMF foBEwC"
@@ -954,9 +991,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
                   </td>
                   <td
                     class="sc-dJjZJu fKfTwY"
-                  >
-                    0
-                  </td>
+                  />
                 </tr>
                 <tr
                   data-testid="775020902-775032020"
@@ -966,9 +1001,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
                   </td>
                   <td
                     class="sc-dJjZJu fKfTwY"
-                  >
-                    0
-                  </td>
+                  />
                 </tr>
                 <tr
                   data-testid="775020902-write-in"
@@ -978,9 +1011,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
                   </td>
                   <td
                     class="sc-dJjZJu fKfTwY"
-                  >
-                    0
-                  </td>
+                  />
                 </tr>
               </tbody>
             </table>

--- a/frontends/election-manager/src/components/election_manager_tally_report.tsx
+++ b/frontends/election-manager/src/components/election_manager_tally_report.tsx
@@ -24,6 +24,8 @@ import React, { forwardRef } from 'react';
 
 import { filterExternalTalliesByParams } from '../utils/external_tallies';
 
+export type TallyReportType = 'Official' | 'Unofficial' | 'Test Deck';
+
 export interface Props {
   batchId?: string;
   batchLabel?: string;
@@ -31,7 +33,7 @@ export interface Props {
   fullElectionExternalTallies: readonly FullElectionExternalTally[];
   fullElectionTally: FullElectionTally;
   generatedAtTime?: Date;
-  isOfficialResults: boolean;
+  tallyReportType: TallyReportType;
   partyId?: string;
   precinctId?: string;
   scannerId?: string;
@@ -47,7 +49,7 @@ export const ElectionManagerTallyReport = forwardRef<HTMLDivElement, Props>(
       fullElectionExternalTallies,
       fullElectionTally,
       generatedAtTime = new Date(),
-      isOfficialResults,
+      tallyReportType,
       partyId: partyIdFromProps,
       precinctId: precinctIdFromProps,
       scannerId,
@@ -55,8 +57,6 @@ export const ElectionManagerTallyReport = forwardRef<HTMLDivElement, Props>(
     },
     ref
   ) => {
-    const statusPrefix = isOfficialResults ? 'Official' : 'Unofficial';
-
     const ballotStylePartyIds =
       partyIdFromProps !== undefined
         ? [unsafeParse(PartyIdSchema, partyIdFromProps)]
@@ -114,7 +114,7 @@ export const ElectionManagerTallyReport = forwardRef<HTMLDivElement, Props>(
                   <LogoMark />
                   <Prose maxWidth={false}>
                     <h1>
-                      {statusPrefix} Precinct Tally Report for:{' '}
+                      {tallyReportType} Precinct Tally Report for:{' '}
                       {currentPrecinctName}
                     </h1>
                     <h2>{electionTitle}</h2>
@@ -145,7 +145,7 @@ export const ElectionManagerTallyReport = forwardRef<HTMLDivElement, Props>(
                   <LogoMark />
                   <Prose maxWidth={false}>
                     <h1>
-                      {statusPrefix} Scanner Tally Report for Scanner:{' '}
+                      {tallyReportType} Scanner Tally Report for Scanner:{' '}
                       {scannerId}
                     </h1>
                     <h2>{electionTitle}</h2>
@@ -175,7 +175,7 @@ export const ElectionManagerTallyReport = forwardRef<HTMLDivElement, Props>(
                   <LogoMark />
                   <Prose maxWidth={false}>
                     <h1>
-                      {statusPrefix} Batch Tally Report for {batchLabel}:
+                      {tallyReportType} Batch Tally Report for {batchLabel}:
                     </h1>
                     <h2>{electionTitle}</h2>
                     <TallyReportMetadata
@@ -205,7 +205,7 @@ export const ElectionManagerTallyReport = forwardRef<HTMLDivElement, Props>(
                   <LogoMark />
                   <Prose maxWidth={false}>
                     <h1>
-                      {statusPrefix} “{label}” Ballot Tally Report
+                      {tallyReportType} “{label}” Ballot Tally Report
                     </h1>
                     <h2>{electionTitle}</h2>
                     <TallyReportMetadata
@@ -232,7 +232,7 @@ export const ElectionManagerTallyReport = forwardRef<HTMLDivElement, Props>(
                 <LogoMark />
                 <Prose maxWidth={false}>
                   <h1>
-                    {statusPrefix} {electionTitle} Tally Report
+                    {tallyReportType} {electionTitle} Tally Report
                   </h1>
                   <TallyReportMetadata
                     generatedAtTime={generatedAtTime}

--- a/frontends/election-manager/src/components/full_test_deck_tally_report_button.tsx
+++ b/frontends/election-manager/src/components/full_test_deck_tally_report_button.tsx
@@ -1,7 +1,6 @@
 import React, { useContext, useCallback } from 'react';
-import { assert, tallyVotesByContest } from '@votingworks/utils';
+import { assert } from '@votingworks/utils';
 import { LogEventId } from '@votingworks/logging';
-import { Tally, VotingMethod } from '@votingworks/types';
 
 import { isElectionManagerAuth } from '@votingworks/ui';
 import { AppContext } from '../contexts/app_context';
@@ -19,21 +18,6 @@ export function FullTestDeckTallyReportButton(): JSX.Element {
 
   const ballots = generateTestDeckBallots({ election });
   const votes = ballots.map((b) => b.votes);
-
-  // Full test deck tallies should be 4 times that of a single test deck because
-  // it counts scanning 2 test decks (BMD + HMPB) twice (VxScan + VxCentralScan)
-  const quadrupledVotes = [...votes, ...votes, ...votes, ...votes];
-  const testDeckTally: Tally = {
-    numberOfBallotsCounted: quadrupledVotes.length,
-    castVoteRecords: new Set(),
-    contestTallies: tallyVotesByContest({
-      election,
-      votes: quadrupledVotes,
-    }),
-    ballotCountsByVotingMethod: {
-      [VotingMethod.Unknown]: quadrupledVotes.length,
-    },
-  };
 
   const afterPrint = useCallback(() => {
     void logger.log(LogEventId.TestDeckTallyReportPrinted, userRole, {
@@ -54,8 +38,13 @@ export function FullTestDeckTallyReportButton(): JSX.Element {
     [logger, userRole]
   );
 
+  // Full test deck tallies should be 4 times that of a single test deck because
+  // it counts scanning 2 test decks (BMD + HMPB) twice (VxScan + VxCentralScan)
   const fullTestDeckTallyReport = (
-    <TestDeckTallyReport election={election} electionTally={testDeckTally} />
+    <TestDeckTallyReport
+      election={election}
+      votes={[...votes, ...votes, ...votes, ...votes]}
+    />
   );
 
   return (

--- a/frontends/election-manager/src/screens/print_test_deck_screen.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.tsx
@@ -6,10 +6,8 @@ import {
   getPrecinctById,
   Precinct,
   PrecinctId,
-  Tally,
-  VotingMethod,
 } from '@votingworks/types';
-import { assert, sleep, tallyVotesByContest } from '@votingworks/utils';
+import { assert, sleep } from '@votingworks/utils';
 import { LogEventId } from '@votingworks/logging';
 import {
   BmdPaperBallot,
@@ -57,28 +55,17 @@ function PrecinctTallyReport({
   const ballots = generateTestDeckBallots({ election, precinctId });
   const votes = ballots.map((b) => b.votes);
 
-  // Precinct test deck tallies should be twice that of a single test
-  // deck because it counts scanning 2 test decks (BMD + HMPB)
-  const doubledVotes = [...votes, ...votes];
-  const testDeckTally: Tally = {
-    numberOfBallotsCounted: doubledVotes.length,
-    castVoteRecords: new Set(),
-    contestTallies: tallyVotesByContest({
-      election,
-      votes: doubledVotes,
-    }),
-    ballotCountsByVotingMethod: { [VotingMethod.Unknown]: doubledVotes.length },
-  };
-
   useEffect(() => {
     const parties = new Set(election.ballotStyles.map((bs) => bs.partyId));
     onRendered(Math.max(parties.size, 1));
   }, [election, precinctId, onRendered]);
 
+  // Precinct test deck tallies should be twice that of a single test
+  // deck because it counts scanning 2 test decks (BMD + HMPB)
   return (
     <TestDeckTallyReport
       election={election}
-      electionTally={testDeckTally}
+      votes={[...votes, ...votes]}
       precinctId={precinctId}
     />
   );

--- a/frontends/election-manager/src/screens/tally_report_screen.tsx
+++ b/frontends/election-manager/src/screens/tally_report_screen.tsx
@@ -316,7 +316,7 @@ export function TallyReportScreen(): JSX.Element {
           fullElectionExternalTallies={fullElectionExternalTallies}
           fullElectionTally={fullElectionTally}
           generatedAtTime={generatedAtTime}
-          isOfficialResults={isOfficialResults}
+          tallyReportType={isOfficialResults ? 'Official' : 'Unofficial'}
           partyId={partyId}
           precinctId={precinctId}
           ref={printReportRef}


### PR DESCRIPTION
## Overview
Closes #1552. The test deck tally report was using a different component than our actual reports. This standardizes them, so the test deck tally report is using the same underlying component and will change as our main report changes. Specifically, it makes the title look the same and adds the voting method table. Took the chance to abstract a little logic into the `TestDeckTallyReport` component.

## Demo Video or Screenshot

### New Test Deck Report Look
[full-election-test-new.pdf](https://github.com/votingworks/vxsuite/files/9455722/full-election-test-new.pdf)

### New (and Old) Regular Report Look
[full-election-unofficial-same.pdf](https://github.com/votingworks/vxsuite/files/9455723/full-election-unofficial-same.pdf)

## Testing Plan 
- Manual Testing
- Need to update a snapshot

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
