### PR TITLE
Reduce Unmount Delay & Sync On Unmount

### DIFF
--- a/libs/ui/src/hooks/use_usb_drive.test.tsx
+++ b/libs/ui/src/hooks/use_usb_drive.test.tsx
@@ -21,8 +21,8 @@ async function waitForStatusUpdate(): Promise<void> {
   await advanceTimersAndPromises(POLLING_INTERVAL_FOR_USB / 1000);
 }
 
-async function waitForIoFlush(): Promise<void> {
-  await advanceTimersAndPromises(usbstick.FLUSH_IO_DELAY_MS / 1000);
+async function waitForUnmount(): Promise<void> {
+  await advanceTimersAndPromises(usbstick.MIN_TIME_TO_UNMOUNT_USB / 1000);
 }
 
 let logger: Logger;
@@ -170,7 +170,7 @@ test('full lifecycle with USBControllerButton', async () => {
   expect(kiosk.unmountUsbDrive).toHaveBeenCalled();
   await waitForStatusUpdate();
   await advanceTimersAndPromises();
-  await waitForIoFlush();
+  await waitForUnmount();
 
   await waitForStatusUpdate();
   screen.getByText('Ejected');
@@ -255,7 +255,7 @@ test('usb drive that is removed while being ejected is updated to absent', async
   await waitForStatusUpdate();
   await advanceTimersAndPromises();
   // Updates to No USB state as expected
-  await waitForIoFlush();
+  await waitForUnmount();
   await waitForStatusUpdate();
   screen.getByText('No USB');
 

--- a/libs/ui/src/hooks/use_usb_drive.ts
+++ b/libs/ui/src/hooks/use_usb_drive.ts
@@ -45,7 +45,7 @@ export function useUsbDrive({ logger }: UsbDriveProps): UsbDrive {
       setStatus(UsbDriveStatus.ejecting);
       await logger.log(LogEventId.UsbDriveEjectInit, currentUser);
       try {
-        await makeCancelable(usbstick.doUnmount());
+        await makeCancelable(usbstick.doEject());
         setRecentlyEjected(true);
         await logger.log(LogEventId.UsbDriveEjected, currentUser, {
           disposition: 'success',

--- a/libs/utils/src/usbstick.test.ts
+++ b/libs/utils/src/usbstick.test.ts
@@ -3,7 +3,7 @@ import {
   UsbDriveStatus,
   getStatus,
   doMount,
-  doUnmount,
+  doEject,
   getDevicePath,
   doSync,
 } from './usbstick';
@@ -50,7 +50,7 @@ test('can mount and unmount USB drive', async () => {
   fKiosk.getUsbDrives.mockResolvedValue(unmountedDevices);
 
   // unmount should do nothing
-  await doUnmount();
+  await doEject();
   expect(window.kiosk.unmountUsbDrive).not.toBeCalled();
 
   await doMount();
@@ -64,7 +64,7 @@ test('can mount and unmount USB drive', async () => {
   await doMount();
   expect(window.kiosk.mountUsbDrive).not.toBeCalled();
 
-  await doUnmount();
+  await doEject();
   expect(window.kiosk.syncUsbDrive).toBeCalledWith('/media/usb-drive-sdb');
   expect(window.kiosk.unmountUsbDrive).toBeCalledWith('sdb');
 });
@@ -74,7 +74,7 @@ test('without a kiosk, calls do not crash', async () => {
   expect(await getStatus()).toBe(UsbDriveStatus.notavailable);
 
   await doMount();
-  await doUnmount();
+  await doEject();
   await doSync();
 });
 

--- a/libs/utils/src/usbstick.test.ts
+++ b/libs/utils/src/usbstick.test.ts
@@ -65,6 +65,7 @@ test('can mount and unmount USB drive', async () => {
   expect(window.kiosk.mountUsbDrive).not.toBeCalled();
 
   await doUnmount();
+  expect(window.kiosk.syncUsbDrive).toBeCalledWith('/media/usb-drive-sdb');
   expect(window.kiosk.unmountUsbDrive).toBeCalledWith('sdb');
 });
 

--- a/libs/utils/src/usbstick.ts
+++ b/libs/utils/src/usbstick.ts
@@ -52,7 +52,7 @@ export async function doMount(): Promise<void> {
   await window.kiosk.mountUsbDrive(device.deviceName);
 }
 
-export async function doUnmount(): Promise<void> {
+export async function doEject(): Promise<void> {
   const device = await getDevice();
   if (!device?.mountPoint) {
     return;

--- a/libs/utils/src/usbstick.ts
+++ b/libs/utils/src/usbstick.ts
@@ -1,7 +1,7 @@
 import { assert } from './assert';
 import { sleep } from './sleep';
 
-export const FLUSH_IO_DELAY_MS = 10_000;
+export const MIN_TIME_TO_UNMOUNT_USB = 1000;
 
 function isAvailable() {
   return !!window.kiosk;
@@ -57,9 +57,16 @@ export async function doUnmount(): Promise<void> {
   if (!device?.mountPoint) {
     return;
   }
+
+  const start = new Date().getTime();
   assert(window.kiosk);
+  await window.kiosk.syncUsbDrive(device.mountPoint);
   await window.kiosk.unmountUsbDrive(device.deviceName);
-  return await sleep(FLUSH_IO_DELAY_MS);
+  const timeToUnmount = new Date().getTime() - start;
+
+  if (timeToUnmount < MIN_TIME_TO_UNMOUNT_USB) {
+    await sleep(MIN_TIME_TO_UNMOUNT_USB - timeToUnmount);
+  }
 }
 
 // Triggers linux 'sync' command which forces any cached file data to be


### PR DESCRIPTION
## Overview
Closes #2248. Instead of waiting a static 10 seconds to unmount USBs (hoping that that 10s will ensure the data is flushed to disk), trigger a `sync` before each unmount and wait a minimum of one seconds so the user has some feedback.

## Testing Plan 
- Updated automated testing where necessary
- Manual testing of ejecting the USB in different apps. It's a little challenging to test a longer delay because all of our files are small enough to eject within the 1 second delay, and our largest file exports, the backups, are set up so that they will already be synced by the time the user is prompted to eject.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
