### PR TITLE
Require Precinct Selection on VxScan

### DIFF
--- a/frontends/bmd/src/app_root.tsx
+++ b/frontends/bmd/src/app_root.tsx
@@ -942,5 +942,9 @@ export function AppRoot({
       </IdleTimer>
     );
   }
-  return <UnconfiguredScreen />;
+  return (
+    <UnconfiguredScreen
+      hasElectionDefinition={Boolean(optionalElectionDefinition)}
+    />
+  );
 }

--- a/frontends/bmd/src/pages/unconfigured_screen.tsx
+++ b/frontends/bmd/src/pages/unconfigured_screen.tsx
@@ -2,13 +2,23 @@ import React from 'react';
 
 import { Main, Screen, Prose } from '@votingworks/ui';
 
-export function UnconfiguredScreen(): JSX.Element {
+interface Props {
+  hasElectionDefinition: boolean;
+}
+
+export function UnconfiguredScreen({
+  hasElectionDefinition,
+}: Props): JSX.Element {
   return (
     <Screen>
       <Main centerChild>
         <Prose textCenter>
           <h1>VxMark is Not Configured</h1>
-          <p>Insert Election Manager card to configure.</p>
+          {hasElectionDefinition ? (
+            <p>Insert Election Manager card to select a precinct.</p>
+          ) : (
+            <p>Insert Election Manager card to load an election.</p>
+          )}
         </Prose>
       </Main>
     </Screen>

--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -59,6 +59,7 @@ import { ScanJamScreen } from './screens/scan_jam_screen';
 import { ScanBusyScreen } from './screens/scan_busy_screen';
 import { ReplaceBallotBagScreen } from './components/replace_ballot_bag_screen';
 import { BALLOT_BAG_CAPACITY } from './config/globals';
+import { UnconfiguredPrecinctScreen } from './screens/unconfigured_precinct_screen';
 
 const debug = makeDebug('precinct-scanner:app-root');
 
@@ -517,6 +518,8 @@ export function AppRoot({
       </AppContext.Provider>
     );
   }
+
+  if (!currentPrecinctId) return <UnconfiguredPrecinctScreen />;
 
   if (window.kiosk && usbDrive.status !== usbstick.UsbDriveStatus.mounted) {
     return <InsertUsbScreen />;

--- a/frontends/precinct-scanner/src/app_tally_report_paths.test.tsx
+++ b/frontends/precinct-scanner/src/app_tally_report_paths.test.tsx
@@ -35,6 +35,7 @@ import {
 import { App } from './app';
 import { stateStorageKey } from './app_root';
 import { MachineConfigResponse } from './config/types';
+import { ALL_PRECINCTS_OPTION_VALUE } from './screens/election_manager_screen';
 
 beforeEach(() => {
   jest.useFakeTimers();
@@ -51,9 +52,10 @@ const getTestModeConfigTrueResponseBody: Scan.GetTestModeConfigResponse = {
   testMode: true,
 };
 
-const getPrecinctConfigNoPrecinctResponseBody: Scan.GetCurrentPrecinctConfigResponse =
+const getPrecinctConfigAllPrecinctsResponseBody: Scan.GetCurrentPrecinctConfigResponse =
   {
     status: 'ok',
+    precinctId: ALL_PRECINCTS_OPTION_VALUE,
   };
 
 const getPrecinctConfigPrecinct1ResponseBody: Scan.GetCurrentPrecinctConfigResponse =
@@ -142,7 +144,7 @@ test('expected tally reports are printed for a primary election with all precinc
       body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
     })
     .get('/precinct-scanner/config/precinct', {
-      body: getPrecinctConfigNoPrecinctResponseBody,
+      body: getPrecinctConfigAllPrecinctsResponseBody,
     })
     .get('/precinct-scanner/scanner/status', { body: statusNoPaper })
     .patchOnce('/precinct-scanner/config/testMode', {
@@ -209,7 +211,7 @@ test('expected tally reports for a primary election with all precincts with CVRs
       body: getTestModeConfigTrueResponseBody,
     })
     .get('/precinct-scanner/config/precinct', {
-      body: getPrecinctConfigNoPrecinctResponseBody,
+      body: getPrecinctConfigAllPrecinctsResponseBody,
     })
     .get('/precinct-scanner/config/markThresholdOverrides', {
       body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
@@ -877,7 +879,7 @@ test('expected tally reports for a general election with all precincts with CVRs
       body: getTestModeConfigTrueResponseBody,
     })
     .get('/precinct-scanner/config/precinct', {
-      body: getPrecinctConfigNoPrecinctResponseBody,
+      body: getPrecinctConfigAllPrecinctsResponseBody,
     })
     .get('/precinct-scanner/config/markThresholdOverrides', {
       body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,

--- a/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
+++ b/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
@@ -36,6 +36,7 @@ import {
   scannerStatus,
 } from '../test/helpers/helpers';
 import { stateStorageKey } from './app_root';
+import { ALL_PRECINCTS_OPTION_VALUE } from './screens/election_manager_screen';
 
 const getMachineConfigBody: MachineConfigResponse = {
   machineId: '0002',
@@ -53,9 +54,10 @@ const statusNoPaper: Scan.GetPrecinctScannerStatusResponse = {
   ballotsCounted: 0,
 };
 
-const getPrecinctConfigNoPrecinctResponseBody: Scan.GetCurrentPrecinctConfigResponse =
+const getPrecinctConfigAllPrecinctsResponseBody: Scan.GetCurrentPrecinctConfigResponse =
   {
     status: 'ok',
+    precinctId: ALL_PRECINCTS_OPTION_VALUE,
   };
 
 const getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody: Scan.GetMarkThresholdOverridesConfigResponse =
@@ -90,7 +92,7 @@ test('services/scan fails to unconfigure', async () => {
       body: getTestModeConfigTrueResponseBody,
     })
     .get('/precinct-scanner/config/precinct', {
-      body: getPrecinctConfigNoPrecinctResponseBody,
+      body: getPrecinctConfigAllPrecinctsResponseBody,
     })
     .get('/precinct-scanner/config/markThresholdOverrides', {
       body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
@@ -134,7 +136,7 @@ test('Show invalid card screen when unsupported cards are given', async () => {
       body: getTestModeConfigTrueResponseBody,
     })
     .get('/precinct-scanner/config/precinct', {
-      body: getPrecinctConfigNoPrecinctResponseBody,
+      body: getPrecinctConfigAllPrecinctsResponseBody,
     })
     .get('/precinct-scanner/config/markThresholdOverrides', {
       body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
@@ -194,7 +196,7 @@ test('show card backwards screen when card connection error occurs', async () =>
       body: getTestModeConfigTrueResponseBody,
     })
     .get('/precinct-scanner/config/precinct', {
-      body: getPrecinctConfigNoPrecinctResponseBody,
+      body: getPrecinctConfigAllPrecinctsResponseBody,
     })
     .get('/precinct-scanner/config/markThresholdOverrides', {
       body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
@@ -231,7 +233,7 @@ test('shows internal wiring message when there is no plustek scanner, but tablet
       body: getTestModeConfigTrueResponseBody,
     })
     .get('/precinct-scanner/config/precinct', {
-      body: getPrecinctConfigNoPrecinctResponseBody,
+      body: getPrecinctConfigAllPrecinctsResponseBody,
     })
     .get('/precinct-scanner/config/markThresholdOverrides', {
       body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
@@ -260,7 +262,7 @@ test('shows power cable message when there is no plustek scanner and tablet is n
       body: getTestModeConfigTrueResponseBody,
     })
     .get('/precinct-scanner/config/precinct', {
-      body: getPrecinctConfigNoPrecinctResponseBody,
+      body: getPrecinctConfigAllPrecinctsResponseBody,
     })
     .get('/precinct-scanner/config/markThresholdOverrides', {
       body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
@@ -302,7 +304,7 @@ test('shows instructions to restart when the plustek crashed', async () => {
       body: getTestModeConfigTrueResponseBody,
     })
     .get('/precinct-scanner/config/precinct', {
-      body: getPrecinctConfigNoPrecinctResponseBody,
+      body: getPrecinctConfigAllPrecinctsResponseBody,
     })
     .get('/precinct-scanner/config/markThresholdOverrides', {
       body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
@@ -337,7 +339,7 @@ test('App shows warning message to connect to power when disconnected', async ()
       body: getTestModeConfigTrueResponseBody,
     })
     .get('/precinct-scanner/config/precinct', {
-      body: getPrecinctConfigNoPrecinctResponseBody,
+      body: getPrecinctConfigAllPrecinctsResponseBody,
     })
     .get('/precinct-scanner/config/markThresholdOverrides', {
       body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
@@ -399,7 +401,7 @@ test('removing card during calibration', async () => {
       body: getTestModeConfigTrueResponseBody,
     })
     .get('/precinct-scanner/config/precinct', {
-      body: getPrecinctConfigNoPrecinctResponseBody,
+      body: getPrecinctConfigAllPrecinctsResponseBody,
     })
     .get('/precinct-scanner/config/markThresholdOverrides', {
       body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,

--- a/frontends/precinct-scanner/src/components/layout.tsx
+++ b/frontends/precinct-scanner/src/components/layout.tsx
@@ -34,7 +34,7 @@ export function ScreenMainCenterChild({
       {infoBar && (
         <ElectionInfoBar
           mode={infoBarMode}
-          showPrecinctInfo
+          showPrecinctInfo={Boolean(currentPrecinctId)}
           precinctId={currentPrecinctId}
           electionDefinition={electionDefinition}
           codeVersion={machineConfig.codeVersion}

--- a/frontends/precinct-scanner/src/preview_app.tsx
+++ b/frontends/precinct-scanner/src/preview_app.tsx
@@ -25,6 +25,7 @@ import * as ScanJamScreen from './screens/scan_jam_screen';
 import * as ScanBusyScreen from './screens/scan_busy_screen';
 import * as SetupScannerScreen from './screens/setup_scanner_screen';
 import * as UnconfiguredElectionScreen from './screens/unconfigured_election_screen';
+import * as UnconfiguredPrecinctScreen from './screens/unconfigured_precinct_screen';
 import * as ReplaceBallotBagScreen from './components/replace_ballot_bag_screen';
 
 export function PreviewApp(): JSX.Element {
@@ -52,6 +53,7 @@ export function PreviewApp(): JSX.Element {
         ScanBusyScreen,
         SetupScannerScreen,
         UnconfiguredElectionScreen,
+        UnconfiguredPrecinctScreen,
         ReplaceBallotBagScreen,
       ]}
     />

--- a/frontends/precinct-scanner/src/screens/election_manager_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/election_manager_screen.tsx
@@ -28,6 +28,8 @@ import { ScreenMainCenterChild } from '../components/layout';
 import { AppContext } from '../contexts/app_context';
 import { SetMarkThresholdsModal } from '../components/set_mark_thresholds_modal';
 
+export const ALL_PRECINCTS_OPTION_VALUE = 'ALL_PRECINCTS_OPTION_VALUE';
+
 interface Props {
   scannerStatus: Scan.PrecinctScannerStatus;
   isTestMode: boolean;
@@ -132,12 +134,15 @@ export function ElectionManagerScreen({
           <Select
             id="selectPrecinct"
             data-testid="selectPrecinct"
-            value={currentPrecinctId}
+            value={currentPrecinctId ?? ''}
             onBlur={changeAppPrecinctId}
             onChange={changeAppPrecinctId}
             large
           >
-            <option value="">All Precincts</option>
+            <option value="" disabled>
+              Select a precinct for this device…
+            </option>
+            <option value={ALL_PRECINCTS_OPTION_VALUE}>All Precincts</option>
             {[...election.precincts]
               .sort((a, b) =>
                 a.name.localeCompare(b.name, undefined, {

--- a/frontends/precinct-scanner/src/screens/poll_worker_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/poll_worker_screen.test.tsx
@@ -11,6 +11,7 @@ import { AppContext } from '../contexts/app_context';
 import { PollWorkerScreen } from './poll_worker_screen';
 
 import { isLiveCheckEnabled } from '../config/features';
+import { ALL_PRECINCTS_OPTION_VALUE } from './election_manager_screen';
 
 jest.mock('../config/features');
 
@@ -40,6 +41,7 @@ function renderScreen({
     <AppContext.Provider
       value={{
         electionDefinition: electionSampleDefinition,
+        currentPrecinctId: ALL_PRECINCTS_OPTION_VALUE,
         machineConfig: { machineId: '0000', codeVersion: 'TEST' },
         isSoundMuted: false,
         auth,

--- a/frontends/precinct-scanner/src/screens/poll_worker_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/poll_worker_screen.tsx
@@ -19,6 +19,7 @@ import {
   compressTally,
   computeTallyWithPrecomputedCategories,
   filterTalliesByParams,
+  find,
   getTallyIdentifier,
   PrecinctScannerCardTally,
   PrecinctScannerCardTallySchema,
@@ -109,8 +110,7 @@ export function PollWorkerScreen({
   const { electionDefinition, currentPrecinctId, machineConfig, auth } =
     useContext(AppContext);
   assert(electionDefinition);
-  // Assert that a precinct was selected by the Election Manager
-  assert(typeof currentPrecinctId === 'string');
+  assert(typeof currentPrecinctId !== 'undefined');
   assert(isPollWorkerAuth(auth));
   const [currentTally, setCurrentTally] = useState<FullElectionTally>();
   const [currentSubTallies, setCurrentSubTallies] = useState<
@@ -124,10 +124,7 @@ export function PollWorkerScreen({
   const precinct =
     currentPrecinctId === ALL_PRECINCTS_OPTION_VALUE
       ? ALL_PRECINCTS_OPTION_VALUE
-      : election.precincts.find((p) => p.id === currentPrecinctId);
-
-  // Assert that the precinct id was found in the election
-  assert(typeof precinct !== 'undefined');
+      : find(election.precincts, (p) => p.id === currentPrecinctId);
 
   const precinctSelection: PrecinctSelection = useMemo(
     () =>

--- a/frontends/precinct-scanner/src/screens/unconfigured_precinct_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/unconfigured_precinct_screen.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import {
+  CenteredLargeProse,
+  ScreenMainCenterChild,
+} from '../components/layout';
+import { QuestionCircle } from '../components/graphics';
+
+export function UnconfiguredPrecinctScreen(): JSX.Element {
+  return (
+    <ScreenMainCenterChild infoBar={false}>
+      <QuestionCircle />
+      <CenteredLargeProse>
+        <h1>No Precinct Selected</h1>
+        <p>
+          Insert an Election Manager card to select a precinct for this VxScan.
+        </p>
+      </CenteredLargeProse>
+    </ScreenMainCenterChild>
+  );
+}
+
+/* istanbul ignore next */
+export function DefaultPreview(): JSX.Element {
+  return <UnconfiguredPrecinctScreen />;
+}

--- a/frontends/precinct-scanner/src/screens/unconfigured_precinct_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/unconfigured_precinct_screen.tsx
@@ -11,9 +11,7 @@ export function UnconfiguredPrecinctScreen(): JSX.Element {
       <QuestionCircle />
       <CenteredLargeProse>
         <h1>No Precinct Selected</h1>
-        <p>
-          Insert an Election Manager card to select a precinct for this VxScan.
-        </p>
+        <p>Insert an Election Manager card to select a precinct.</p>
       </CenteredLargeProse>
     </ScreenMainCenterChild>
   );


### PR DESCRIPTION
## Overview
Closes #1972. Requires that a precinct (or specifically "All Precincts") is selected in the Election Manager menu before the machine is operable or the poll worker screen is accessible.

## Demo Video or Screenshot

### VxScan Configure Flow
[must-select-precinct.webm](https://user-images.githubusercontent.com/37960853/187556618-5f27f1a9-c94b-43c7-b017-203bf107cab2.webm)

### VxMark Tweak
Alongside this change, I tweaked the copy in the BMD unconfigure screen so it's apparent when it's unconfigured because there's no election or when there's no precinct. This is as much a tool for me in development and testing as anything.

#### No Election
<img width="1155" alt="Screen Shot 2022-08-30 at 3 49 03 PM" src="https://user-images.githubusercontent.com/37960853/187557121-3960dd85-4ba9-442a-a928-52ca6268b6cd.png">

#### No Precinct
<img width="1156" alt="Screen Shot 2022-08-30 at 3 48 45 PM" src="https://user-images.githubusercontent.com/37960853/187557122-301a91d7-4747-47ef-a3cb-b0edaf8cafe5.png">


## Testing Plan
- Manual testing
- Added test in `app.test.tsx` and cleaned up a related test

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
