### PR TITLE
refactor(admin): remove unnecessary `useEffect`

### DIFF
--- a/frontends/bas/src/app.tsx
+++ b/frontends/bas/src/app.tsx
@@ -4,29 +4,16 @@ import {
   LocalStorage,
   WebServiceCard,
 } from '@votingworks/utils';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import './App.css';
 import { AppRoot, Props as AppRootProps } from './app_root';
 
 export type Props = Partial<AppRootProps>;
 
 export function App({
-  hardware,
+  hardware = getHardware(),
   card = new WebServiceCard(),
   storage = window.kiosk ? new KioskStorage(window.kiosk) : new LocalStorage(),
 }: Props): JSX.Element {
-  const [internalHardware, setInternalHardware] = useState(hardware);
-  useEffect(() => {
-    function updateHardware() {
-      const newInternalHardware = getHardware();
-      setInternalHardware((prev) => prev ?? newInternalHardware);
-    }
-    void updateHardware();
-  });
-
-  if (!internalHardware) {
-    return <React.Fragment />;
-  }
-
-  return <AppRoot card={card} hardware={internalHardware} storage={storage} />;
+  return <AppRoot card={card} hardware={hardware} storage={storage} />;
 }

--- a/frontends/bsd/src/app.tsx
+++ b/frontends/bsd/src/app.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { WebServiceCard, getHardware } from '@votingworks/utils';
 import { BrowserRouter } from 'react-router-dom';
 
@@ -14,23 +14,13 @@ export interface Props {
 }
 
 export function App({
-  hardware,
+  hardware = getHardware(),
   card = new WebServiceCard(),
   logger = new Logger(LogSource.VxCentralScanFrontend, window.kiosk),
 }: Props): JSX.Element {
-  const [internalHardware, setInternalHardware] = useState(hardware);
-  useEffect(() => {
-    const newInternalHardware = getHardware();
-    setInternalHardware((prev) => prev ?? newInternalHardware);
-  }, []);
-
-  if (!internalHardware) {
-    return <React.Fragment />;
-  }
-
   return (
     <BrowserRouter>
-      <AppRoot hardware={internalHardware} card={card} logger={logger} />
+      <AppRoot hardware={hardware} card={card} logger={logger} />
     </BrowserRouter>
   );
 }

--- a/frontends/election-manager/src/app.tsx
+++ b/frontends/election-manager/src/app.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 
 import './App.css';
@@ -32,34 +32,20 @@ const defaultStorage = window.kiosk
 const queryClient = new QueryClient();
 
 export function App({
-  hardware,
+  hardware = getHardware(),
   card = new WebServiceCard(),
   storage = defaultStorage,
   printer = getPrinter(),
   machineConfig = machineConfigProvider,
   converter = getConverterClientType(),
 }: Props): JSX.Element {
-  const [internalHardware, setInternalHardware] = useState(hardware);
-
-  useEffect(() => {
-    function updateHardware() {
-      const newHardware = getHardware();
-      setInternalHardware((prev) => prev ?? newHardware);
-    }
-    void updateHardware();
-  });
-
-  if (!internalHardware) {
-    return <React.Fragment />;
-  }
-
   return (
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
         <AppRoot
           storage={storage}
           printer={printer}
-          hardware={internalHardware}
+          hardware={hardware}
           card={card}
           machineConfigProvider={machineConfig}
           converter={converter}

--- a/frontends/precinct-scanner/src/app.tsx
+++ b/frontends/precinct-scanner/src/app.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 
 import './App.css';
@@ -25,27 +25,18 @@ export interface Props {
 }
 
 export function App({
-  hardware,
+  hardware = getHardware(),
   card = new WebServiceCard(),
   storage = window.kiosk ? new KioskStorage(window.kiosk) : new LocalStorage(),
   printer = getPrinter(),
   machineConfig = machineConfigProvider,
   logger = new Logger(LogSource.VxPrecinctScanFrontend, window.kiosk),
 }: Props): JSX.Element {
-  const [internalHardware, setInternalHardware] = useState(hardware);
-  useEffect(() => {
-    const newInternalHardware = getHardware();
-    setInternalHardware((prev) => prev ?? newInternalHardware);
-  }, []);
-
-  if (!internalHardware) {
-    return <BrowserRouter />;
-  }
   return (
     <BrowserRouter>
       <AppRoot
         card={card}
-        hardware={internalHardware}
+        hardware={hardware}
         printer={printer}
         machineConfig={machineConfig}
         storage={storage}


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
I think `getHardware` used to be `async` so we needed the `useEffect`. Now we can just use it as a default parameter value.

## Demo Video or Screenshot
n/a

## Testing Plan 
Automated.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
