### PR TITLE
feat(em): card backwards screen on card programming

### DIFF
--- a/frontends/bas/src/app_root.tsx
+++ b/frontends/bas/src/app_root.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState, useMemo } from 'react';
 import {
   BallotStyle,
+  Card,
   ElectionSchema,
   PartyId,
   PartyIdSchema,
@@ -14,7 +15,7 @@ import {
   useDevices,
   useStoredState,
 } from '@votingworks/ui';
-import { assert, Card, Hardware, sleep, Storage } from '@votingworks/utils';
+import { assert, Hardware, sleep, Storage } from '@votingworks/utils';
 
 import { z } from 'zod';
 import { EventTargetFunction } from './config/types';

--- a/frontends/bas/src/utils/use_smartcard.ts
+++ b/frontends/bas/src/utils/use_smartcard.ts
@@ -1,6 +1,9 @@
 import {
   AnyCardData,
   AnyCardDataSchema,
+  Card,
+  CardSummary,
+  CardSummaryNotReady,
   err,
   ok,
   Optional,
@@ -12,12 +15,7 @@ import {
   Devices,
   useCancelablePromise,
 } from '@votingworks/ui';
-import {
-  assert,
-  Card,
-  CardSummary,
-  CardSummaryNotReady,
-} from '@votingworks/utils';
+import { assert } from '@votingworks/utils';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import useInterval from 'use-interval';
 

--- a/frontends/bmd/src/app_root.tsx
+++ b/frontends/bmd/src/app_root.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useReducer, useRef } from 'react';
 import {
   BallotType,
+  Card,
   CompletedBallot,
   ElectionDefinition,
   OptionalElectionDefinition,
@@ -25,7 +26,6 @@ import IdleTimer from 'react-idle-timer';
 import useInterval from '@rooks/use-interval';
 import {
   assert,
-  Card,
   Storage,
   Hardware,
   throwIllegalValue,

--- a/frontends/bsd/src/app_root.tsx
+++ b/frontends/bsd/src/app_root.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { Route, Switch, useHistory } from 'react-router-dom';
 import {
+  Card,
   ElectionDefinition,
   MarkThresholds,
   Optional,
@@ -13,7 +14,6 @@ import {
   usbstick,
   KioskStorage,
   LocalStorage,
-  Card,
   Hardware,
   assert,
 } from '@votingworks/utils';

--- a/frontends/election-manager/src/app_root.tsx
+++ b/frontends/election-manager/src/app_root.tsx
@@ -8,6 +8,7 @@ import React, {
 import 'normalize.css';
 import { Logger, LogEventId } from '@votingworks/logging';
 import {
+  Card,
   FullElectionExternalTally,
   ExternalTallySourceType,
   Provider,
@@ -17,7 +18,6 @@ import {
   throwIllegalValue,
   usbstick,
   Printer,
-  Card,
   Hardware,
 } from '@votingworks/utils';
 import {

--- a/frontends/election-manager/src/components/smartcard_modal/smartcard_modal.test.tsx
+++ b/frontends/election-manager/src/components/smartcard_modal/smartcard_modal.test.tsx
@@ -715,3 +715,21 @@ test('Error handling', async () => {
     );
   }
 });
+
+test('Card inserted backwards is handled with message', async () => {
+  const card = new MemoryCard();
+  const hardware = MemoryHardware.buildStandard();
+  const backend = new ElectionManagerStoreMemoryBackend({ electionDefinition });
+  renderInQueryClientContext(
+    <App card={card} hardware={hardware} backend={backend} />
+  );
+  await authenticateWithSystemAdministratorCard(card);
+
+  card.insertCard(undefined, undefined, 'error');
+  await screen.findByText('Card is Backwards');
+
+  card.removeCard();
+  await waitFor(() =>
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+  );
+});

--- a/frontends/election-manager/src/components/smartcard_modal/smartcard_modal.tsx
+++ b/frontends/election-manager/src/components/smartcard_modal/smartcard_modal.tsx
@@ -1,6 +1,10 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { assert } from '@votingworks/utils';
-import { isSystemAdministratorAuth, Modal } from '@votingworks/ui';
+import {
+  InvalidCardScreen,
+  isSystemAdministratorAuth,
+  Modal,
+} from '@votingworks/ui';
 import { useLocation } from 'react-router-dom';
 
 import { AppContext } from '../../contexts/app_context';
@@ -22,14 +26,20 @@ export function SmartcardModal(): JSX.Element | null {
 
   useEffect(() => {
     // Clear the current status message when the card is removed
-    if (!auth.card) {
+    if (auth.card === 'no_card') {
       setActionStatus(undefined);
     }
   }, [auth.card]);
 
   // Auto-open the modal when a card is inserted, and auto-close the modal when a card is removed
-  if (!auth.card) {
+  if (auth.card === 'no_card') {
     return null;
+  }
+
+  if (auth.card === 'error') {
+    return (
+      <Modal fullscreen content={<InvalidCardScreen reason="card_error" />} />
+    );
   }
 
   const onSystemAdministratorSmartcardsScreen =

--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -3,6 +3,7 @@ import 'normalize.css';
 import makeDebug from 'debug';
 
 import {
+  Card,
   OptionalElectionDefinition,
   Provider,
   PrecinctId,
@@ -23,7 +24,6 @@ import {
 } from '@votingworks/ui';
 import {
   throwIllegalValue,
-  Card,
   Hardware,
   Storage,
   usbstick,

--- a/libs/test-utils/src/smartcard_auth/dipped.ts
+++ b/libs/test-utils/src/smartcard_auth/dipped.ts
@@ -6,9 +6,9 @@ import {
 } from '@votingworks/types';
 import {
   fakeSystemAdministratorUser,
-  fakeCardStorage,
   fakeElectionManagerUser,
   fakeCardProgramming,
+  fakeCardStorage,
 } from './auth';
 
 export function fakeCheckingPasscodeAuth(
@@ -23,27 +23,26 @@ export function fakeCheckingPasscodeAuth(
 }
 
 export function fakeSystemAdministratorAuth(
-  card: Partial<CardStorage & CardProgramming> = {}
+  programmableCard: Partial<CardStorage & CardProgramming> = {}
 ): DippedSmartcardAuth.SystemAdministratorLoggedIn {
   return {
     status: 'logged_in',
     user: fakeSystemAdministratorUser(),
-    card: {
-      ...fakeCardStorage(card),
-      ...fakeCardProgramming(card),
+    programmableCard: {
+      status: 'ready',
+      ...fakeCardProgramming(programmableCard),
+      ...fakeCardStorage(programmableCard),
     },
     logOut: jest.fn(),
   };
 }
 
 export function fakeElectionManagerAuth(
-  user: Partial<ElectionManagerUser> = {},
-  card: Partial<CardStorage> = {}
+  user: Partial<ElectionManagerUser> = {}
 ): DippedSmartcardAuth.ElectionManagerLoggedIn {
   return {
     status: 'logged_in',
     user: fakeElectionManagerUser(user),
-    card: fakeCardStorage(card),
     logOut: jest.fn(),
   };
 }

--- a/libs/types/src/card.ts
+++ b/libs/types/src/card.ts
@@ -1,0 +1,88 @@
+import { z } from 'zod';
+import { Optional } from './generic';
+import { Result } from './result';
+
+export interface CardSummaryNotReady {
+  status: 'no_card' | 'error';
+}
+export interface CardSummaryReady {
+  status: 'ready';
+  shortValue?: string;
+  longValueExists?: boolean;
+}
+export type CardSummary = CardSummaryNotReady | CardSummaryReady;
+
+export const CardSummaryNotReadySchema: z.ZodSchema<CardSummaryNotReady> =
+  z.object({
+    status: z.enum(['no_card', 'error']),
+  });
+export const CardSummaryReadySchema: z.ZodSchema<CardSummaryReady> = z.object({
+  status: z.literal('ready'),
+  shortValue: z.string().optional(),
+  longValueExists: z.boolean().optional(),
+});
+export const CardSummarySchema: z.ZodSchema<CardSummary> = z.union([
+  CardSummaryNotReadySchema,
+  CardSummaryReadySchema,
+]);
+
+export interface ShortAndLongValues {
+  shortValue: string;
+  longValue: string;
+}
+
+/**
+ * Defines the API for accessing a smart card reader.
+ */
+export interface Card {
+  /**
+   * Reads basic information about the card, including whether one is present,
+   * what its short value is and whether it has a long value.
+   */
+  readSummary(): Promise<CardSummary>;
+
+  /**
+   * Reads the long value as an object, or `undefined` if there is no long
+   * value and validates it using `schema`.
+   */
+  readLongObject<T>(
+    schema: z.ZodSchema<T>
+  ): Promise<Result<Optional<T>, SyntaxError | z.ZodError>>;
+
+  /**
+   * Reads the long value as a string, or `undefined` if there is no long
+   * value.
+   */
+  readLongString(): Promise<Optional<string>>;
+
+  /**
+   * Reads the long value as binary data, or `undefined` if there is no long
+   * value.
+   */
+  readLongUint8Array(): Promise<Optional<Uint8Array>>;
+
+  /**
+   * Writes a new short value to the card.
+   */
+  writeShortValue(value: string): Promise<void>;
+
+  /**
+   * Writes a new long value as a serialized object.
+   */
+  writeLongObject(value: unknown): Promise<void>;
+
+  /**
+   * Writes binary data to the long value.
+   */
+  writeLongUint8Array(value: Uint8Array): Promise<void>;
+
+  /**
+   * Writes new short and long values to the card.
+   */
+  writeShortAndLongValues(values: ShortAndLongValues): Promise<void>;
+
+  /**
+   * Overrides card write protection.
+   */
+  overrideWriteProtection(): Promise<void>;
+}

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -1,6 +1,7 @@
 /* istanbul ignore file */
 export * from './ballot_locales';
 export * from './hmpb';
+export * from './card';
 export * from './cast_vote_record';
 export * from './dom';
 export * from './election';

--- a/libs/types/src/smartcard_auth/dipped_smartcard_auth.ts
+++ b/libs/types/src/smartcard_auth/dipped_smartcard_auth.ts
@@ -31,19 +31,20 @@ export interface RemoveCard {
   readonly user: SystemAdministratorUser | ElectionManagerUser;
 }
 
+export type ProgrammableCard =
+  | CardSummaryNotReady
+  | ({ status: 'ready' } & CardProgramming & CardStorage);
+
 export interface SystemAdministratorLoggedIn {
   readonly status: 'logged_in';
   readonly user: SystemAdministratorUser;
-  readonly card:
-    | CardSummaryNotReady['status']
-    | (CardStorage & CardProgramming);
+  readonly programmableCard: ProgrammableCard;
   readonly logOut: () => void;
 }
 
 export interface ElectionManagerLoggedIn {
   readonly status: 'logged_in';
   readonly user: ElectionManagerUser;
-  readonly card: CardSummaryNotReady['status'] | CardStorage;
   readonly logOut: () => void;
 }
 

--- a/libs/types/src/smartcard_auth/dipped_smartcard_auth.ts
+++ b/libs/types/src/smartcard_auth/dipped_smartcard_auth.ts
@@ -1,3 +1,4 @@
+import { CardSummaryNotReady } from '../card';
 import {
   ElectionManagerUser,
   CardProgramming,
@@ -30,19 +31,19 @@ export interface RemoveCard {
   readonly user: SystemAdministratorUser | ElectionManagerUser;
 }
 
-export type CardSummaryNotReadyStatus = 'no_card' | 'error';
-
 export interface SystemAdministratorLoggedIn {
   readonly status: 'logged_in';
   readonly user: SystemAdministratorUser;
-  readonly card: CardSummaryNotReadyStatus | (CardStorage & CardProgramming);
+  readonly card:
+    | CardSummaryNotReady['status']
+    | (CardStorage & CardProgramming);
   readonly logOut: () => void;
 }
 
 export interface ElectionManagerLoggedIn {
   readonly status: 'logged_in';
   readonly user: ElectionManagerUser;
-  readonly card: CardSummaryNotReadyStatus | CardStorage;
+  readonly card: CardSummaryNotReady['status'] | CardStorage;
   readonly logOut: () => void;
 }
 

--- a/libs/types/src/smartcard_auth/dipped_smartcard_auth.ts
+++ b/libs/types/src/smartcard_auth/dipped_smartcard_auth.ts
@@ -30,17 +30,19 @@ export interface RemoveCard {
   readonly user: SystemAdministratorUser | ElectionManagerUser;
 }
 
+export type CardSummaryNotReadyStatus = 'no_card' | 'error';
+
 export interface SystemAdministratorLoggedIn {
   readonly status: 'logged_in';
   readonly user: SystemAdministratorUser;
-  readonly card?: CardStorage & CardProgramming;
+  readonly card: CardSummaryNotReadyStatus | (CardStorage & CardProgramming);
   readonly logOut: () => void;
 }
 
 export interface ElectionManagerLoggedIn {
   readonly status: 'logged_in';
   readonly user: ElectionManagerUser;
-  readonly card?: CardStorage;
+  readonly card: CardSummaryNotReadyStatus | CardStorage;
   readonly logOut: () => void;
 }
 

--- a/libs/ui/src/hooks/smartcard_auth/auth_helpers.ts
+++ b/libs/ui/src/hooks/smartcard_auth/auth_helpers.ts
@@ -1,6 +1,8 @@
 import {
   ElectionManagerCardData,
   AnyCardDataSchema,
+  Card,
+  CardSummaryReady,
   CardProgramming,
   CardStorage,
   DippedSmartcardAuth,
@@ -14,7 +16,7 @@ import {
   User,
   wrapException,
 } from '@votingworks/types';
-import { Card, CardSummaryReady, throwIllegalValue } from '@votingworks/utils';
+import { throwIllegalValue } from '@votingworks/utils';
 import { LogEventId, Logger } from '@votingworks/logging';
 
 import { Lock } from '../use_lock';
@@ -66,7 +68,7 @@ export function buildCardStorage(
   return {
     hasStoredData: !!cardSummary.longValueExists,
 
-    readStoredObject: async (schema) => cardApi.readLongObject(schema),
+    readStoredObject: (schema) => cardApi.readLongObject(schema),
 
     readStoredString: async () => {
       try {

--- a/libs/ui/src/hooks/smartcard_auth/use_dipped_smartcard_auth.test.ts
+++ b/libs/ui/src/hooks/smartcard_auth/use_dipped_smartcard_auth.test.ts
@@ -130,7 +130,7 @@ describe('useDippedSmartcardAuth', () => {
     await waitForNextUpdate();
     expect(result.current).toEqual({
       status: 'logged_in',
-      card: undefined,
+      card: 'no_card',
       user,
       logOut: expect.any(Function),
     });
@@ -256,7 +256,7 @@ describe('useDippedSmartcardAuth', () => {
     await waitForNextUpdate();
     expect(result.current).toEqual({
       status: 'logged_in',
-      card: undefined,
+      card: 'no_card',
       user,
       logOut: expect.any(Function),
     });
@@ -492,5 +492,41 @@ describe('useDippedSmartcardAuth', () => {
         reason: 'election_manager_wrong_election',
       })
     );
+  });
+
+  it('recognizes card is inserted backwards while logged in', async () => {
+    const cardApi = new MemoryCard();
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useDippedSmartcardAuth({
+        cardApi,
+        scope: { electionDefinition },
+      })
+    );
+    expect(result.current).toMatchObject({
+      status: 'logged_out',
+      reason: 'machine_locked',
+    });
+
+    // Log in with a system administrator card
+    const passcode = '123456';
+    const user = fakeSystemAdministratorUser({ passcode });
+    cardApi.insertCard(makeSystemAdministratorCard(passcode));
+    await waitForNextUpdate();
+    act(() => {
+      assert(result.current.status === 'checking_passcode');
+      result.current.checkPasscode(passcode);
+    });
+    await waitForNextUpdate();
+    cardApi.removeCard();
+    await waitForNextUpdate();
+
+    // Inserting a card backwards can be detected
+    cardApi.insertCard(undefined, undefined, 'error');
+    await waitForNextUpdate();
+    expect(result.current).toMatchObject({
+      status: 'logged_in',
+      card: 'error',
+      user,
+    });
   });
 });

--- a/libs/ui/src/hooks/smartcard_auth/use_dipped_smartcard_auth.test.ts
+++ b/libs/ui/src/hooks/smartcard_auth/use_dipped_smartcard_auth.test.ts
@@ -130,7 +130,7 @@ describe('useDippedSmartcardAuth', () => {
     await waitForNextUpdate();
     expect(result.current).toEqual({
       status: 'logged_in',
-      card: 'no_card',
+      programmableCard: { status: 'no_card' },
       user,
       logOut: expect.any(Function),
     });
@@ -140,7 +140,6 @@ describe('useDippedSmartcardAuth', () => {
     await waitForNextUpdate();
     expect(result.current).toMatchObject({
       status: 'logged_in',
-      card: expect.any(Object),
       user,
     });
     cardApi.removeCard();
@@ -256,7 +255,6 @@ describe('useDippedSmartcardAuth', () => {
     await waitForNextUpdate();
     expect(result.current).toEqual({
       status: 'logged_in',
-      card: 'no_card',
       user,
       logOut: expect.any(Function),
     });
@@ -266,7 +264,6 @@ describe('useDippedSmartcardAuth', () => {
     await waitForNextUpdate();
     expect(result.current).toMatchObject({
       status: 'logged_in',
-      card: expect.any(Object),
       user,
     });
     cardApi.removeCard();
@@ -525,7 +522,7 @@ describe('useDippedSmartcardAuth', () => {
     await waitForNextUpdate();
     expect(result.current).toMatchObject({
       status: 'logged_in',
-      card: 'error',
+      programmableCard: { status: 'error' },
       user,
     });
   });

--- a/libs/ui/src/hooks/smartcard_auth/use_dipped_smartcard_auth.ts
+++ b/libs/ui/src/hooks/smartcard_auth/use_dipped_smartcard_auth.ts
@@ -4,6 +4,8 @@ import {
   Logger,
 } from '@votingworks/logging';
 import {
+  Card,
+  CardSummary,
   DippedSmartcardAuth,
   ElectionDefinition,
   err,
@@ -13,12 +15,7 @@ import {
   User,
 } from '@votingworks/types';
 import { LoggedOut } from '@votingworks/types/src/smartcard_auth/dipped_smartcard_auth';
-import {
-  assert,
-  Card,
-  CardSummary,
-  throwIllegalValue,
-} from '@votingworks/utils';
+import { assert, throwIllegalValue } from '@votingworks/utils';
 import deepEqual from 'deep-eql';
 import { useEffect, useReducer } from 'react';
 import useInterval from 'use-interval';

--- a/libs/ui/src/hooks/smartcard_auth/use_dipped_smartcard_auth.ts
+++ b/libs/ui/src/hooks/smartcard_auth/use_dipped_smartcard_auth.ts
@@ -233,9 +233,10 @@ function useDippedSmartcardAuthBase({
           return {
             status,
             user,
-            card:
+            programmableCard:
               cardSummary.status === 'ready'
                 ? {
+                    status: 'ready',
                     ...buildCardStorage(cardSummary, cardApi, cardWriteLock),
                     ...buildCardProgramming(
                       cardSummary,
@@ -244,7 +245,7 @@ function useDippedSmartcardAuthBase({
                       logger
                     ),
                   }
-                : cardSummary.status,
+                : cardSummary,
             logOut: () => dispatch({ type: 'log_out' }),
           };
         }
@@ -253,10 +254,6 @@ function useDippedSmartcardAuthBase({
           return {
             status,
             user,
-            card:
-              cardSummary.status === 'ready'
-                ? buildCardStorage(cardSummary, cardApi, cardWriteLock)
-                : cardSummary.status,
             logOut: () => dispatch({ type: 'log_out' }),
           };
         }

--- a/libs/ui/src/hooks/smartcard_auth/use_dipped_smartcard_auth.ts
+++ b/libs/ui/src/hooks/smartcard_auth/use_dipped_smartcard_auth.ts
@@ -247,7 +247,7 @@ function useDippedSmartcardAuthBase({
                       logger
                     ),
                   }
-                : undefined,
+                : cardSummary.status,
             logOut: () => dispatch({ type: 'log_out' }),
           };
         }
@@ -259,7 +259,7 @@ function useDippedSmartcardAuthBase({
             card:
               cardSummary.status === 'ready'
                 ? buildCardStorage(cardSummary, cardApi, cardWriteLock)
-                : undefined,
+                : cardSummary.status,
             logOut: () => dispatch({ type: 'log_out' }),
           };
         }

--- a/libs/ui/src/hooks/smartcard_auth/use_inserted_smartcard_auth.ts
+++ b/libs/ui/src/hooks/smartcard_auth/use_inserted_smartcard_auth.ts
@@ -4,6 +4,9 @@ import {
   safeParseJson,
   ok,
   err,
+  Card,
+  CardSummary,
+  CardSummaryReady,
   ElectionDefinition,
   Result,
   wrapException,
@@ -19,14 +22,7 @@ import {
   InsertedSmartcardAuth,
   Optional,
 } from '@votingworks/types';
-import {
-  assert,
-  Card,
-  CardSummary,
-  CardSummaryReady,
-  throwIllegalValue,
-  utcTimestamp,
-} from '@votingworks/utils';
+import { assert, throwIllegalValue, utcTimestamp } from '@votingworks/utils';
 import { useEffect, useReducer, useState } from 'react';
 import useInterval from 'use-interval';
 import deepEqual from 'deep-eql';

--- a/libs/utils/src/Card/memory_card.ts
+++ b/libs/utils/src/Card/memory_card.ts
@@ -1,6 +1,13 @@
-import { ok, Optional, Result, safeParseJson } from '@votingworks/types';
+import {
+  Card,
+  CardSummary,
+  ok,
+  Optional,
+  Result,
+  safeParseJson,
+  ShortAndLongValues,
+} from '@votingworks/types';
 import { z } from 'zod';
-import { Card, CardSummary, ShortAndLongValues } from '../types';
 
 /* eslint-disable @typescript-eslint/require-await */
 

--- a/libs/utils/src/Card/web_service_card.test.ts
+++ b/libs/utils/src/Card/web_service_card.test.ts
@@ -1,8 +1,9 @@
+import { CardSummaryReady } from '@votingworks/types';
 import { fromByteArray, toByteArray } from 'base64-js';
 import fetchMock, { MockRequest } from 'fetch-mock';
 import { z } from 'zod';
 import { WebServiceCard } from '.';
-import { CardSummaryReady, typedAs } from '../types';
+import { typedAs } from '../types';
 
 const AbSchema = z.object({ a: z.number(), b: z.number() });
 

--- a/libs/utils/src/Card/web_service_card.ts
+++ b/libs/utils/src/Card/web_service_card.ts
@@ -1,19 +1,17 @@
 import {
+  Card,
+  CardSummary,
+  CardSummarySchema,
   ok,
   Optional,
   Result,
   safeParseJson,
+  ShortAndLongValues,
   unsafeParse,
 } from '@votingworks/types';
 import { fromByteArray, toByteArray } from 'base64-js';
 import { z } from 'zod';
 import { fetchJson } from '../fetch_json';
-import {
-  Card,
-  CardSummary,
-  CardSummarySchema,
-  ShortAndLongValues,
-} from '../types';
 
 interface LongValueResponse {
   longValue?: string;

--- a/libs/utils/src/types.ts
+++ b/libs/utils/src/types.ts
@@ -3,10 +3,8 @@ import {
   CompressedTallySchema,
   Dictionary,
   MachineId,
-  Optional,
   PrecinctSelection,
   PrecinctSelectionSchema,
-  Result,
 } from '@votingworks/types';
 import { z } from 'zod';
 
@@ -94,91 +92,6 @@ export interface Storage {
    * Clears all objects out of storage.
    */
   clear(): Promise<void>;
-}
-
-export interface CardSummaryNotReady {
-  status: 'no_card' | 'error';
-}
-export interface CardSummaryReady {
-  status: 'ready';
-  shortValue?: string;
-  longValueExists?: boolean;
-}
-export type CardSummary = CardSummaryNotReady | CardSummaryReady;
-
-export const CardSummaryNotReadySchema: z.ZodSchema<CardSummaryNotReady> =
-  z.object({
-    status: z.enum(['no_card', 'error']),
-  });
-export const CardSummaryReadySchema: z.ZodSchema<CardSummaryReady> = z.object({
-  status: z.literal('ready'),
-  shortValue: z.string().optional(),
-  longValueExists: z.boolean().optional(),
-});
-export const CardSummarySchema: z.ZodSchema<CardSummary> = z.union([
-  CardSummaryNotReadySchema,
-  CardSummaryReadySchema,
-]);
-
-export interface ShortAndLongValues {
-  shortValue: string;
-  longValue: string;
-}
-
-/**
- * Defines the API for accessing a smart card reader.
- */
-export interface Card {
-  /**
-   * Reads basic information about the card, including whether one is present,
-   * what its short value is and whether it has a long value.
-   */
-  readSummary(): Promise<CardSummary>;
-
-  /**
-   * Reads the long value as an object, or `undefined` if there is no long
-   * value and validates it using `schema`.
-   */
-  readLongObject<T>(
-    schema: z.ZodSchema<T>
-  ): Promise<Result<Optional<T>, SyntaxError | z.ZodError>>;
-
-  /**
-   * Reads the long value as a string, or `undefined` if there is no long
-   * value.
-   */
-  readLongString(): Promise<Optional<string>>;
-
-  /**
-   * Reads the long value as binary data, or `undefined` if there is no long
-   * value.
-   */
-  readLongUint8Array(): Promise<Optional<Uint8Array>>;
-
-  /**
-   * Writes a new short value to the card.
-   */
-  writeShortValue(value: string): Promise<void>;
-
-  /**
-   * Writes a new long value as a serialized object.
-   */
-  writeLongObject(value: unknown): Promise<void>;
-
-  /**
-   * Writes binary data to the long value.
-   */
-  writeLongUint8Array(value: Uint8Array): Promise<void>;
-
-  /**
-   * Writes new short and long values to the card.
-   */
-  writeShortAndLongValues(values: ShortAndLongValues): Promise<void>;
-
-  /**
-   * Overrides card write protection.
-   */
-  overrideWriteProtection(): Promise<void>;
 }
 
 /**


### PR DESCRIPTION
## Overview
Closes #2417. Shows a "Card is Backwards" screen if card is inserted backwards during card programming.

## Demo Video or Screenshot

[card-backwards.webm](https://user-images.githubusercontent.com/37960853/187802451-75e2c2da-1be7-4ce0-bcd0-5d68c529fd7e.webm)

## Testing Plan 
- Added test in `libs/ui` where the hook changed slightly
- Added test in `frontends/election-manager` to test the screen comes up.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
