### PR TITLE
fix(em): no linux alert for no printer

### DIFF
--- a/frontends/election-manager/src/components/print_button.tsx
+++ b/frontends/election-manager/src/components/print_button.tsx
@@ -6,12 +6,12 @@ import {
   Modal,
   useCancelablePromise,
   useMountedState,
-  Prose,
 } from '@votingworks/ui';
 import { Loading } from './loading';
 import { PrintOptions } from '../config/types';
 import { AppContext } from '../contexts/app_context';
 import { PrintableArea } from './printable_area';
+import { PrinterNotConnectedModal } from './printer_not_connected_modal';
 
 interface ConfirmModal {
   content: React.ReactNode;
@@ -140,15 +140,7 @@ export function PrintButton({
         />
       )}
       {showPrintingError && (
-        <Modal
-          content={
-            <Prose>
-              <h2>The printer is not connected.</h2>
-              <p>Please connect the printer and try again.</p>
-            </Prose>
-          }
-          actions={<Button onPress={donePrintingError}>Okay</Button>}
-        />
+        <PrinterNotConnectedModal onClose={donePrintingError} />
       )}
       {printTarget && shouldRenderPrintTarget && (
         <PrintableArea data-testid={printTargetTestId}>

--- a/frontends/election-manager/src/components/printer_not_connected_modal.tsx
+++ b/frontends/election-manager/src/components/printer_not_connected_modal.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Button, Modal, Prose } from '@votingworks/ui';
+
+interface Props {
+  onClose: VoidFunction;
+}
+
+export function PrinterNotConnectedModal({ onClose }: Props): JSX.Element {
+  return (
+    <Modal
+      content={
+        <Prose>
+          <h2>The printer is not connected.</h2>
+          <p>Please connect the printer and try again.</p>
+        </Prose>
+      }
+      actions={<Button onPress={onClose}>Okay</Button>}
+    />
+  );
+}

--- a/frontends/election-manager/src/screens/print_test_deck_screen.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.tsx
@@ -36,6 +36,7 @@ import {
   getBallotLayoutPageSizeReadableString,
 } from '../utils/get_ballot_layout_page_size';
 import { BallotMode } from '../config/types';
+import { PrinterNotConnectedModal } from '../components/printer_not_connected_modal';
 
 export const ONE_SIDED_PAGE_PRINT_TIME_MS = 3000;
 export const TWO_SIDED_PAGE_PRINT_TIME_MS = 5000;
@@ -336,6 +337,7 @@ export function PrintTestDeckScreen(): JSX.Element {
   const { election, electionHash } = electionDefinition;
   const [precinctIds, setPrecinctIds] = useState<string[]>([]);
   const [printIndex, setPrintIndex] = useState<PrintIndex>();
+  const [showPrintingError, setShowPrintingError] = useState(false);
 
   const pageTitle = 'Precinct L&A Packages';
 
@@ -426,8 +428,7 @@ export function PrintTestDeckScreen(): JSX.Element {
         setPrecinctIds(generatePrecinctIds(precinctId));
         setPrintIndex({ precinctIndex: 0, component: 'TallyReport' });
       } else {
-        // eslint-disable-next-line no-alert
-        window.alert('Please connect the printer.');
+        setShowPrintingError(true);
         await logger.log(LogEventId.TestDeckPrinted, userRole, {
           disposition: 'failure',
           message: `Failed to print L&A Package: no printer connected.`,
@@ -628,6 +629,9 @@ export function PrintTestDeckScreen(): JSX.Element {
             onAllRendered={onAllHandMarkedPaperBallotsRendered}
           />
         )}
+      {showPrintingError && (
+        <PrinterNotConnectedModal onClose={() => setShowPrintingError(false)} />
+      )}
     </React.Fragment>
   );
 }


### PR DESCRIPTION
## Overview
Closes #2383. Makes the no printer detected dialog for the test deck print buttons the same as for the other print buttons in the app.

## Demo Video or Screenshot
### Before
<img width="1727" alt="image (1)" src="https://user-images.githubusercontent.com/37960853/187852327-f9565c5a-1968-4b27-990c-12e4405af527.png">

### After
<img width="1473" alt="Screen Shot 2022-08-31 at 11 47 17 PM" src="https://user-images.githubusercontent.com/37960853/187852220-daabd860-8f87-4599-82d9-3554194d3407.png">



## Testing Plan
Manual testing only. Seems unnecessary to write a regression test here.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
