### PR TITLE
test(scan): fix `act` warning

### DIFF
--- a/frontends/precinct-scanner/src/screens/election_manager_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/election_manager_screen.test.tsx
@@ -274,7 +274,7 @@ test('cannot toggle to testing mode when the machine cannot be unconfigured', ()
   fireEvent.click(screen.getByText('Cancel'));
 });
 
-test('Allows overriding mark thresholds', () => {
+test('Allows overriding mark thresholds', async () => {
   const setMarkThresholdOverridesFn = jest.fn();
 
   render(
@@ -312,4 +312,6 @@ test('Allows overriding mark thresholds', () => {
     definite: 0.5,
     marginal: 0.25,
   });
+
+  await screen.findByText('Override Mark Thresholds');
 });


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
This test has async operations that happen after the test has been torn down, leading to a warning about using `act`. This commit adds an `await` to find something on the screen after the action has been performed to ensure the async stuff all happens by the time the test is done.

## Demo Video or Screenshot
n/a

## Testing Plan 
Ran tests, warning disappeared.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
