### PR TITLE
Remove stylelint --fix option from BAS commit script

### DIFF
--- a/frontends/bas/package.json
+++ b/frontends/bas/package.json
@@ -24,7 +24,7 @@
   },
   "lint-staged": {
     "*.+(js|jsx|ts|tsx)": [
-      "stylelint --fix",
+      "stylelint",
       "eslint --quiet --fix"
     ],
     "*.css": [


### PR DESCRIPTION
Linting style in `styled-component`s only works with a specific processor, `stylelint-processor-styled-components`. That processor is deprecated and archived, even though `styled-component`'s docs still recommend it as a solution. We're not on the latest version of `stylelint`, but it is still a problem on the latest version and there's some discourse [here](https://github.com/styled-components/styled-components/issues/3607).

The proximate issue is that `stylelint --fix` doesn't work when we are using a processor.

In this PR, I'm just removing the `--fix` flag in bas so it matches the other repos and can actually stage changes.