### PR TITLE
test(scan): Fix flaky precinct scanner test

### DIFF
--- a/services/scan/src/precinct_scanner_app.test.ts
+++ b/services/scan/src/precinct_scanner_app.test.ts
@@ -1063,12 +1063,6 @@ test('insert second ballot while first ballot is returning', async () => {
   await waitForStatus(app, { state: 'needs_review', interpretation });
 
   await post(app, '/precinct-scanner/scanner/return');
-  await waitForStatus(app, {
-    state: 'returning',
-    interpretation,
-    canUnconfigure: false,
-  });
-
   await mockPlustek.simulateLoadSheet(ballotImages.unmarkedHmpb);
   await waitForStatus(app, {
     state: 'both_sides_have_paper',


### PR DESCRIPTION


## Overview
This test was flaky because sometimes the precinct scanner state machine would get to the `returned` state before the second ballot was inserted. To prevent the chance of that happening, I removed a check for `returning` state that delayed insertion of the second ballot. It's not an important check since it's covered by other tests.

