### PR TITLE
Drew - Require Scan Precinct

### DIFF
--- a/frontends/bmd/src/pages/admin_screen.tsx
+++ b/frontends/bmd/src/pages/admin_screen.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-import { ElectionDefinition } from '@votingworks/types';
+import { ALL_PRECINCTS_ID, ElectionDefinition } from '@votingworks/types';
 import {
   Button,
   CurrentDateAndTime,
@@ -38,8 +38,6 @@ interface Props {
   screenReader: ScreenReader;
 }
 
-const ALL_PRECINCTS_OPTION_VALUE = '_ALL';
-
 export function AdminScreen({
   appPrecinct,
   ballotsPrintedCount,
@@ -56,7 +54,7 @@ export function AdminScreen({
   const changeAppPrecinctId: SelectChangeEventFunction = (event) => {
     const precinctId = event.currentTarget.value;
 
-    if (precinctId === ALL_PRECINCTS_OPTION_VALUE) {
+    if (precinctId === ALL_PRECINCTS_ID) {
       updateAppPrecinct({ kind: PrecinctSelectionKind.AllPrecincts });
     } else if (precinctId) {
       updateAppPrecinct({
@@ -93,7 +91,7 @@ export function AdminScreen({
                   id="selectPrecinct"
                   value={
                     appPrecinct?.kind === PrecinctSelectionKind.AllPrecincts
-                      ? ALL_PRECINCTS_OPTION_VALUE
+                      ? ALL_PRECINCTS_ID
                       : appPrecinct?.precinctId ?? ''
                   }
                   onBlur={changeAppPrecinctId}
@@ -102,7 +100,7 @@ export function AdminScreen({
                   <option value="" disabled>
                     Select a precinct for this device…
                   </option>
-                  <option value={ALL_PRECINCTS_OPTION_VALUE}>
+                  <option value={ALL_PRECINCTS_ID}>
                     {AllPrecinctsDisplayName}
                   </option>
                   {[...election.precincts]

--- a/frontends/precinct-scanner/src/api/config.ts
+++ b/frontends/precinct-scanner/src/api/config.ts
@@ -4,6 +4,7 @@ import {
   Precinct,
   MarkThresholds,
   safeParseJson,
+  PrecinctId,
 } from '@votingworks/types';
 import { ErrorsResponse, OkResponse, Scan } from '@votingworks/api';
 import { BallotPackage, BallotPackageEntry, assert } from '@votingworks/utils';
@@ -155,7 +156,7 @@ export async function getCurrentPrecinctId(): Promise<
 }
 
 export async function setCurrentPrecinctId(
-  precinctId?: Precinct['id']
+  precinctId?: PrecinctId
 ): Promise<void> {
   if (!precinctId) {
     await del('/precinct-scanner/config/precinct');

--- a/frontends/precinct-scanner/src/app.test.tsx
+++ b/frontends/precinct-scanner/src/app.test.tsx
@@ -33,7 +33,11 @@ import {
   electionSample2Definition,
 } from '@votingworks/fixtures';
 
-import { AdjudicationReason, PrecinctSelectionKind } from '@votingworks/types';
+import {
+  AdjudicationReason,
+  ALL_PRECINCTS_ID,
+  PrecinctSelectionKind,
+} from '@votingworks/types';
 
 import { mocked } from 'ts-jest/utils';
 import userEvent from '@testing-library/user-event';
@@ -49,7 +53,6 @@ import {
   authenticateElectionManagerCard,
   scannerStatus,
 } from '../test/helpers/helpers';
-import { ALL_PRECINCTS_OPTION_VALUE } from './screens/election_manager_screen';
 
 jest.setTimeout(20000);
 
@@ -87,7 +90,7 @@ const statusReadyToScan = scannerStatus({ state: 'ready_to_scan' });
 const getPrecinctConfigAllPrecinctsResponseBody: Scan.GetCurrentPrecinctConfigResponse =
   {
     status: 'ok',
-    precinctId: ALL_PRECINCTS_OPTION_VALUE,
+    precinctId: ALL_PRECINCTS_ID,
   };
 
 const getPrecinctConfigNoPrecinctResponseBody: Scan.GetCurrentPrecinctConfigResponse =

--- a/frontends/precinct-scanner/src/app_tally_report_paths.test.tsx
+++ b/frontends/precinct-scanner/src/app_tally_report_paths.test.tsx
@@ -25,6 +25,7 @@ import {
   typedAs,
 } from '@votingworks/utils';
 import {
+  ALL_PRECINCTS_ID,
   CompressedTally,
   ContestId,
   Dictionary,
@@ -35,7 +36,6 @@ import {
 import { App } from './app';
 import { stateStorageKey } from './app_root';
 import { MachineConfigResponse } from './config/types';
-import { ALL_PRECINCTS_OPTION_VALUE } from './screens/election_manager_screen';
 
 beforeEach(() => {
   jest.useFakeTimers();
@@ -55,7 +55,7 @@ const getTestModeConfigTrueResponseBody: Scan.GetTestModeConfigResponse = {
 const getPrecinctConfigAllPrecinctsResponseBody: Scan.GetCurrentPrecinctConfigResponse =
   {
     status: 'ok',
-    precinctId: ALL_PRECINCTS_OPTION_VALUE,
+    precinctId: ALL_PRECINCTS_ID,
   };
 
 const getPrecinctConfigPrecinct1ResponseBody: Scan.GetCurrentPrecinctConfigResponse =

--- a/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
+++ b/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
@@ -29,6 +29,7 @@ import {
 } from '@votingworks/utils';
 
 import userEvent from '@testing-library/user-event';
+import { ALL_PRECINCTS_ID } from '@votingworks/types';
 import { App } from './app';
 import { MachineConfigResponse } from './config/types';
 import {
@@ -36,7 +37,6 @@ import {
   scannerStatus,
 } from '../test/helpers/helpers';
 import { stateStorageKey } from './app_root';
-import { ALL_PRECINCTS_OPTION_VALUE } from './screens/election_manager_screen';
 
 const getMachineConfigBody: MachineConfigResponse = {
   machineId: '0002',
@@ -57,7 +57,7 @@ const statusNoPaper: Scan.GetPrecinctScannerStatusResponse = {
 const getPrecinctConfigAllPrecinctsResponseBody: Scan.GetCurrentPrecinctConfigResponse =
   {
     status: 'ok',
-    precinctId: ALL_PRECINCTS_OPTION_VALUE,
+    precinctId: ALL_PRECINCTS_ID,
   };
 
 const getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody: Scan.GetMarkThresholdOverridesConfigResponse =

--- a/frontends/precinct-scanner/src/screens/election_manager_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/election_manager_screen.tsx
@@ -4,6 +4,7 @@ import {
   PrecinctId,
   SelectChangeEventFunction,
   ok,
+  ALL_PRECINCTS,
 } from '@votingworks/types';
 import {
   Button,
@@ -27,8 +28,6 @@ import { ScannedBallotCount } from '../components/scanned_ballot_count';
 import { ScreenMainCenterChild } from '../components/layout';
 import { AppContext } from '../contexts/app_context';
 import { SetMarkThresholdsModal } from '../components/set_mark_thresholds_modal';
-
-export const ALL_PRECINCTS_OPTION_VALUE = 'ALL_PRECINCTS_OPTION_VALUE';
 
 interface Props {
   scannerStatus: Scan.PrecinctScannerStatus;
@@ -142,7 +141,7 @@ export function ElectionManagerScreen({
             <option value="" disabled>
               Select a precinct for this device…
             </option>
-            <option value={ALL_PRECINCTS_OPTION_VALUE}>All Precincts</option>
+            <option value={ALL_PRECINCTS.id}>{ALL_PRECINCTS.name}</option>
             {[...election.precincts]
               .sort((a, b) =>
                 a.name.localeCompare(b.name, undefined, {

--- a/frontends/precinct-scanner/src/screens/poll_worker_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/poll_worker_screen.test.tsx
@@ -4,14 +4,13 @@ import { advanceTimersAndPromises, Inserted } from '@votingworks/test-utils';
 import { NullPrinter, usbstick } from '@votingworks/utils';
 import MockDate from 'mockdate';
 import React from 'react';
-import { InsertedSmartcardAuth } from '@votingworks/types';
+import { ALL_PRECINCTS_ID, InsertedSmartcardAuth } from '@votingworks/types';
 import { mocked } from 'ts-jest/utils';
 import fetchMock from 'fetch-mock';
 import { AppContext } from '../contexts/app_context';
 import { PollWorkerScreen } from './poll_worker_screen';
 
 import { isLiveCheckEnabled } from '../config/features';
-import { ALL_PRECINCTS_OPTION_VALUE } from './election_manager_screen';
 
 jest.mock('../config/features');
 
@@ -41,7 +40,7 @@ function renderScreen({
     <AppContext.Provider
       value={{
         electionDefinition: electionSampleDefinition,
-        currentPrecinctId: ALL_PRECINCTS_OPTION_VALUE,
+        currentPrecinctId: ALL_PRECINCTS_ID,
         machineConfig: { machineId: '0000', codeVersion: 'TEST' },
         isSoundMuted: false,
         auth,

--- a/frontends/precinct-scanner/src/screens/poll_worker_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/poll_worker_screen.tsx
@@ -38,6 +38,8 @@ import {
   CompressedTally,
   getPartyIdsInBallotStyles,
   InsertedSmartcardAuth,
+  ALL_PRECINCTS_ID,
+  ALL_PRECINCTS,
 } from '@votingworks/types';
 import { isLiveCheckEnabled } from '../config/features';
 import {
@@ -53,7 +55,6 @@ import { IndeterminateProgressBar } from '../components/graphics';
 import { ScannedBallotCount } from '../components/scanned_ballot_count';
 import { saveCvrExportToUsb } from '../utils/save_cvr_export_to_usb';
 import * as scan from '../api/scan';
-import { ALL_PRECINCTS_OPTION_VALUE } from './election_manager_screen';
 
 enum PollWorkerFlowState {
   OPEN_POLLS_FLOW__CONFIRM = 'open polls flow: confirm',
@@ -122,13 +123,13 @@ export function PollWorkerScreen({
   const { election } = electionDefinition;
 
   const precinct =
-    currentPrecinctId === ALL_PRECINCTS_OPTION_VALUE
-      ? ALL_PRECINCTS_OPTION_VALUE
+    currentPrecinctId === ALL_PRECINCTS_ID
+      ? ALL_PRECINCTS
       : find(election.precincts, (p) => p.id === currentPrecinctId);
 
   const precinctSelection: PrecinctSelection = useMemo(
     () =>
-      currentPrecinctId === ALL_PRECINCTS_OPTION_VALUE
+      currentPrecinctId === ALL_PRECINCTS_ID
         ? { kind: PrecinctSelectionKind.AllPrecincts }
         : {
             kind: PrecinctSelectionKind.SinglePrecinct,
@@ -326,8 +327,6 @@ export function PollWorkerScreen({
     setPollWorkerFlowState(PollWorkerFlowState.CLOSE_POLLS_FLOW__COMPLETE);
   }
 
-  const precinctName =
-    precinct === ALL_PRECINCTS_OPTION_VALUE ? 'All Precincts' : precinct.name;
   const currentTime = Date.now();
 
   if (!currentTally) {
@@ -506,11 +505,11 @@ export function PollWorkerScreen({
           <p>
             {isPollsOpen ? (
               <Button primary large onPress={closePolls}>
-                Close Polls for {precinctName}
+                Close Polls for {precinct.name}
               </Button>
             ) : (
               <Button primary large onPress={openPolls}>
-                Open Polls for {precinctName}
+                Open Polls for {precinct.name}
               </Button>
             )}
           </p>

--- a/libs/api/src/services/scan/index.ts
+++ b/libs/api/src/services/scan/index.ts
@@ -236,7 +236,7 @@ export const GetCurrentPrecinctResponseSchema: z.ZodSchema<GetCurrentPrecinctCon
  * @method PUT
  */
 export interface PutCurrentPrecinctConfigRequest {
-  precinctId?: PrecinctId;
+  precinctId: PrecinctId;
 }
 
 /**
@@ -245,7 +245,7 @@ export interface PutCurrentPrecinctConfigRequest {
  */
 export const PutCurrentPrecinctConfigRequestSchema: z.ZodSchema<PutCurrentPrecinctConfigRequest> =
   z.object({
-    precinctId: z.optional(PrecinctIdSchema),
+    precinctId: PrecinctIdSchema,
   });
 
 /**

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -353,6 +353,10 @@ export const AllPrecinctsSchema: z.ZodSchema<AllPrecincts> = z.object({
   id: AllPrecinctsIdSchema,
   name: z.literal(ALL_PRECINCTS_NAME),
 });
+export const ALL_PRECINCTS: AllPrecincts = {
+  id: ALL_PRECINCTS_ID,
+  name: ALL_PRECINCTS_NAME,
+};
 export interface IndividualPrecinct {
   readonly id: IndividualPrecinctId;
   readonly name: string;

--- a/services/scan/src/central_scanner_app.ts
+++ b/services/scan/src/central_scanner_app.ts
@@ -8,6 +8,7 @@ import {
   safeParseJson,
   BallotPageLayoutSchema,
   BallotPageLayout,
+  ALL_PRECINCTS_ID,
 } from '@votingworks/types';
 import { assert, readBallotPackageFromBuffer } from '@votingworks/utils';
 import makeDebug from 'debug';
@@ -34,6 +35,8 @@ export async function buildCentralScannerApp({
   store,
   importer,
 }: AppOptions): Promise<Application> {
+  store.setCurrentPrecinctId(ALL_PRECINCTS_ID);
+
   const app: Application = express();
   const upload = multer({ storage: multer.diskStorage({}) });
 

--- a/services/scan/src/central_scanner_app.ts
+++ b/services/scan/src/central_scanner_app.ts
@@ -8,7 +8,6 @@ import {
   safeParseJson,
   BallotPageLayoutSchema,
   BallotPageLayout,
-  ALL_PRECINCTS_ID,
 } from '@votingworks/types';
 import { assert, readBallotPackageFromBuffer } from '@votingworks/utils';
 import makeDebug from 'debug';
@@ -35,8 +34,6 @@ export async function buildCentralScannerApp({
   store,
   importer,
 }: AppOptions): Promise<Application> {
-  store.setCurrentPrecinctId(ALL_PRECINCTS_ID);
-
   const app: Application = express();
   const upload = multer({ storage: multer.diskStorage({}) });
 

--- a/services/scan/src/cli/retry-scan/index.test.ts
+++ b/services/scan/src/cli/retry-scan/index.test.ts
@@ -1,4 +1,5 @@
 import { dirSync } from 'tmp';
+import { ALL_PRECINCTS_ID } from '@votingworks/types';
 import * as fixtures from '../../../test/fixtures/choctaw-2020-09-22-f30480cc99';
 import { createWorkspace } from '../../util/workspace';
 import { queryFromOptions, retryScan } from '.';
@@ -144,6 +145,7 @@ test('query with sheet ids', () => {
   const { store } = inputWorkspace;
 
   store.setElection(fixtures.electionDefinition);
+  store.setCurrentPrecinctId(ALL_PRECINCTS_ID);
   store.setTestMode(false);
   store.setSkipElectionHashCheck(true);
 
@@ -230,6 +232,7 @@ test('query with sheet ids', () => {
     const inputDb = inputWorkspace.store;
 
     inputDb.setElection(fixtures.electionDefinition);
+    inputDb.setCurrentPrecinctId(ALL_PRECINCTS_ID);
     inputDb.setTestMode(false);
     inputDb.setSkipElectionHashCheck(true);
 

--- a/services/scan/src/importer.test.ts
+++ b/services/scan/src/importer.test.ts
@@ -4,7 +4,6 @@ import {
   electionSampleDefinition as electionDefinition,
 } from '@votingworks/fixtures';
 import {
-  ALL_PRECINCTS_ID,
   BallotPageMetadata,
   BallotSheetInfo,
   BallotType,
@@ -27,7 +26,6 @@ let workspace: Workspace;
 
 beforeEach(() => {
   workspace = createWorkspace(dirSync().name);
-  workspace.store.setCurrentPrecinctId(ALL_PRECINCTS_ID);
 });
 
 afterEach(async () => {
@@ -220,7 +218,7 @@ test('manually importing files', async () => {
     ...frontMetadata,
     pageNumber: 2,
   };
-  workspace.store.setElection(electionDefinition);
+  importer.configure(electionDefinition);
 
   const frontImagePath = await makeImageFile();
   const backImagePath = await makeImageFile();
@@ -693,7 +691,6 @@ test('rejects sheets that would not produce a valid CVR', async () => {
 
   const currentPrecinctId = election.precincts[0].id;
   importer.configure(electionDefinition);
-  workspace.store.setCurrentPrecinctId(currentPrecinctId);
   jest.spyOn(workspace.store, 'addSheet').mockReturnValueOnce('sheet-id');
 
   // eslint-disable-next-line @typescript-eslint/require-await

--- a/services/scan/src/importer.test.ts
+++ b/services/scan/src/importer.test.ts
@@ -4,6 +4,7 @@ import {
   electionSampleDefinition as electionDefinition,
 } from '@votingworks/fixtures';
 import {
+  ALL_PRECINCTS_ID,
   BallotPageMetadata,
   BallotSheetInfo,
   BallotType,
@@ -26,6 +27,7 @@ let workspace: Workspace;
 
 beforeEach(() => {
   workspace = createWorkspace(dirSync().name);
+  workspace.store.setCurrentPrecinctId(ALL_PRECINCTS_ID);
 });
 
 afterEach(async () => {

--- a/services/scan/src/importer.ts
+++ b/services/scan/src/importer.ts
@@ -1,5 +1,6 @@
 import { Scan } from '@votingworks/api';
 import {
+  ALL_PRECINCTS_ID,
   BallotPageLayout,
   BallotPageLayoutWithImage,
   ElectionDefinition,
@@ -199,6 +200,9 @@ export class Importer {
       throw new Error('missing election definition');
     }
     const currentPrecinctId = this.workspace.store.getCurrentPrecinctId();
+    if (!currentPrecinctId) {
+      throw new Error('missing precinct selection');
+    }
     const interpretResult = await this.interpretSheet(sheetId, [
       frontImagePath,
       backImagePath,
@@ -237,7 +241,7 @@ export class Importer {
     );
 
     debug('currentPrecinctId=%s', currentPrecinctId);
-    if (currentPrecinctId) {
+    if (currentPrecinctId !== ALL_PRECINCTS_ID) {
       if (
         (frontInterpretation.type === 'InterpretedHmpbPage' ||
           frontInterpretation.type === 'InterpretedBmdPage') &&

--- a/services/scan/src/importer.ts
+++ b/services/scan/src/importer.ts
@@ -137,6 +137,7 @@ export class Importer {
    */
   configure(electionDefinition: ElectionDefinition): void {
     this.workspace.store.setElection(electionDefinition);
+    this.workspace.store.setCurrentPrecinctId(ALL_PRECINCTS_ID);
   }
 
   async setTestMode(testMode: boolean): Promise<void> {

--- a/services/scan/src/interpreter.test.ts
+++ b/services/scan/src/interpreter.test.ts
@@ -1,6 +1,7 @@
 import { electionSampleDefinition } from '@votingworks/fixtures';
 import {
   AdjudicationReason,
+  ALL_PRECINCTS_ID,
   BallotIdSchema,
   BlankPage,
   ElectionDefinition,
@@ -41,6 +42,7 @@ test('extracts votes encoded in a QR code', async () => {
             markThresholds: { definite: 0.2, marginal: 0.17 },
           },
         },
+        currentPrecinctId: ALL_PRECINCTS_ID,
         testMode: true,
         // TODO: remove this once the QR code is fixed (https://github.com/votingworks/vxsuite/issues/1524)
         skipElectionHashCheck: true,
@@ -87,6 +89,7 @@ test('properly scans a BMD ballot with a phantom QR code on back', async () => {
   const interpreter = createInterpreter();
   interpreter.configure({
     electionDefinition,
+    currentPrecinctId: ALL_PRECINCTS_ID,
     testMode: true,
     layouts: [],
     ballotImagesPath: interpreterOutputPath,
@@ -115,6 +118,7 @@ test('properly detects test ballot in live mode', async () => {
         markThresholds: { definite: 0.2, marginal: 0.17 },
       },
     },
+    currentPrecinctId: ALL_PRECINCTS_ID,
     testMode: false, // this is the test mode
     // TODO: remove this once the QR code is fixed (https://github.com/votingworks/vxsuite/issues/1524)
     skipElectionHashCheck: true,
@@ -195,6 +199,7 @@ test('detects a blank page', async () => {
   const ballotImagePath = join(sampleBallotImagesPath, 'blank-page.png');
   const interpretationResult = await new Interpreter({
     electionDefinition: stateOfHamiltonFixtures.electionDefinition,
+    currentPrecinctId: ALL_PRECINCTS_ID,
     testMode: true,
     adjudicationReasons: [],
   }).interpretFile({
@@ -209,6 +214,7 @@ test('detects a blank page', async () => {
 test('interprets marks on a HMPB', async () => {
   const interpreter = new Interpreter({
     electionDefinition: stateOfHamiltonFixtures.electionDefinition,
+    currentPrecinctId: ALL_PRECINCTS_ID,
     testMode: false,
     adjudicationReasons:
       electionSampleDefinition.election.centralScanAdjudicationReasons ?? [],
@@ -272,6 +278,7 @@ test('interprets marks on a HMPB', async () => {
 test('interprets marks on an upside-down HMPB', async () => {
   const interpreter = new Interpreter({
     electionDefinition: stateOfHamiltonFixtures.electionDefinition,
+    currentPrecinctId: ALL_PRECINCTS_ID,
     testMode: false,
     adjudicationReasons:
       electionSampleDefinition.election.centralScanAdjudicationReasons ?? [],
@@ -318,6 +325,7 @@ test('interprets marks in ballots', async () => {
   };
   const interpreter = new Interpreter({
     electionDefinition,
+    currentPrecinctId: ALL_PRECINCTS_ID,
     testMode: false,
     adjudicationReasons:
       electionSampleDefinition.election.centralScanAdjudicationReasons ?? [],
@@ -419,6 +427,7 @@ test('interprets marks in ballots', async () => {
 test('returns metadata if the QR code is readable but the HMPB ballot is not', async () => {
   const interpreter = new Interpreter({
     electionDefinition: stateOfHamiltonFixtures.electionDefinition,
+    currentPrecinctId: ALL_PRECINCTS_ID,
     testMode: false,
     adjudicationReasons:
       electionSampleDefinition.election.centralScanAdjudicationReasons ?? [],

--- a/services/scan/src/interpreter.ts
+++ b/services/scan/src/interpreter.ts
@@ -17,6 +17,7 @@ import { imageDebugger } from '@votingworks/image-utils';
 import {
   AdjudicationReason,
   AdjudicationReasonInfo,
+  ALL_PRECINCTS_ID,
   BallotPageLayoutWithImage,
   BallotPageMetadata,
   BallotType,
@@ -27,6 +28,7 @@ import {
   MarkThresholds,
   ok,
   PageInterpretation,
+  PrecinctId,
   Result,
 } from '@votingworks/types';
 import {
@@ -149,20 +151,20 @@ export function sheetRequiresAdjudication([
 
 export interface InterpreterOptions {
   electionDefinition: ElectionDefinition;
+  currentPrecinctId: PrecinctId;
   testMode: boolean;
   markThresholdOverrides?: MarkThresholds;
   skipElectionHashCheck?: boolean;
   adjudicationReasons: readonly AdjudicationReason[];
-  currentPrecinctId?: string;
 }
 
 export class Interpreter {
   private hmpbInterpreter?: HmpbInterpreter;
   private readonly electionDefinition: ElectionDefinition;
+  private readonly currentPrecinctId: PrecinctId;
   private readonly testMode: boolean;
   private readonly markThresholds: MarkThresholds;
   private readonly skipElectionHashCheck?: boolean;
-  private readonly currentPrecinctId?: string;
   private readonly adjudicationReasons: readonly AdjudicationReason[];
 
   constructor({
@@ -292,7 +294,7 @@ export class Interpreter {
       }
 
       if (
-        this.currentPrecinctId &&
+        this.currentPrecinctId !== ALL_PRECINCTS_ID &&
         bmdMetadata.precinctId !== this.currentPrecinctId
       ) {
         timer.end();
@@ -319,7 +321,7 @@ export class Interpreter {
         assert(interpretation && interpretation.type === 'InterpretedHmpbPage');
 
         if (
-          this.currentPrecinctId &&
+          this.currentPrecinctId !== ALL_PRECINCTS_ID &&
           interpretation.metadata.precinctId !== this.currentPrecinctId
         ) {
           timer.end();

--- a/services/scan/src/precinct_scanner_interpreter.ts
+++ b/services/scan/src/precinct_scanner_interpreter.ts
@@ -26,7 +26,7 @@ export interface InterpreterConfig {
   readonly ballotImagesPath: string;
   readonly markThresholdOverrides?: MarkThresholds;
   readonly testMode: boolean;
-  readonly currentPrecinctId?: string;
+  readonly currentPrecinctId: string;
 }
 
 /**

--- a/services/scan/src/store.ts
+++ b/services/scan/src/store.ts
@@ -27,6 +27,7 @@ import {
   PageInterpretation,
   PageInterpretationWithFiles,
   Precinct,
+  PrecinctId,
   safeParseJson,
   unsafeParse,
 } from '@votingworks/types';
@@ -273,8 +274,8 @@ export class Store {
 
   /**
    * Gets the current precinct `scan` is accepting ballots for. If set to
-   * `undefined`, ballots from all precincts will be accepted (this is the
-   * default).
+   * ALL_PRECINCTS_ID, ballots from all precincts will be accepted. If not set,
+   * no ballots will be accepted (the default).
    */
   getCurrentPrecinctId(): Optional<Precinct['id']> {
     return this.getConfig(ConfigKey.CurrentPrecinctId, z.string());
@@ -282,9 +283,9 @@ export class Store {
 
   /**
    * Sets the current precinct `scan` is accepting ballots for. Set to
-   * `undefined` to accept from all precincts (this is the default).
+   * ALL_PRECINCTS_ID to accept from all precincts. Defaults to unset.
    */
-  setCurrentPrecinctId(currentPrecinctId?: Precinct['id']): void {
+  setCurrentPrecinctId(currentPrecinctId?: PrecinctId): void {
     this.setConfig(ConfigKey.CurrentPrecinctId, currentPrecinctId);
   }
 

--- a/services/scan/src/workers/interpret_vx.ts
+++ b/services/scan/src/workers/interpret_vx.ts
@@ -40,21 +40,27 @@ export let interpreter: Interpreter | undefined;
  */
 export async function configure(store: Store): Promise<void> {
   interpreter = undefined;
-
   debug('configuring from %s', store.getDbPath());
-  const electionDefinition = store.getElectionDefinition();
 
+  const electionDefinition = store.getElectionDefinition();
   if (!electionDefinition) {
     debug('no election configured');
     return;
   }
-
   debug('election: %o', electionDefinition.election.title);
+
+  const currentPrecinctId = store.getCurrentPrecinctId();
+  if (!currentPrecinctId) {
+    debug('no precinct configured');
+    return;
+  }
+
   const templates = store.getHmpbTemplates();
 
   debug('creating a new interpreter');
   interpreter = new Interpreter({
     electionDefinition,
+    currentPrecinctId,
     skipElectionHashCheck: store.getSkipElectionHashCheck(),
     testMode: store.getTestMode(),
     markThresholdOverrides: store.getMarkThresholdOverrides(),


### PR DESCRIPTION
Fixes bug on main where no ballots will scan in precinct scanner on all precincts mode: https://votingworks.slack.com/archives/CEL6D3GAD/p1661984695650299. 

@eventualbuddha @jonahkagan I realize I may have navigated the types wrong, and need to redo a lot of this. I extended our `PrecinctId` type to have an explicit `AllPrecinctsId` subtype. But now I'm seeing there's duplicated typing between `Precinct` and `PrecinctSelection`. I think I should go back and, reverting the `PrecinctId` type, type everything in the scan service and frontends as `PrecinctSelection`. Want to get your confirmation that's the right way to go before digging in again.
