### PR TITLE
test(scan): Fix flaky scanner test (second attempt)

### DIFF
--- a/libs/plustek-sdk/src/mocks.ts
+++ b/libs/plustek-sdk/src/mocks.ts
@@ -220,7 +220,7 @@ export enum Errors {
 /**
  * Configuration options for {@link MockScannerClient}.
  */
-export interface Options {
+export interface MockScannerClientOptions {
   /**
    * How long does it take to take or release a paper hold forward or backward?
    */
@@ -264,7 +264,7 @@ export class MockScannerClient implements ScannerClient {
     toggleHoldDuration = 100,
     passthroughDuration = 1000,
     frozenTimeout = 60_000,
-  }: Options = {}) {
+  }: MockScannerClientOptions = {}) {
     this.toggleHoldDuration = toggleHoldDuration;
     this.passthroughDuration = passthroughDuration;
     this.frozenTimeout = frozenTimeout;


### PR DESCRIPTION


## Overview
Follow up to https://github.com/votingworks/vxsuite/pull/2515. This time, we increase the `passthroughDuration` option for the mock scanner for this test only, which should hopefully prevent the ballot from being returned before the second ballot is inserted.
