### PR TITLE
refactor(admin): make store updates more granular

### DIFF
--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -673,12 +673,7 @@ test('tabulating CVRs with SEMS file', async () => {
     electionDefinition: eitherNeitherElectionDefinition,
   });
 
-  await backend.setCastVoteRecordFiles(
-    await CastVoteRecordFiles.empty.add(
-      EITHER_NEITHER_CVR_FILE,
-      eitherNeitherElectionDefinition.election
-    )
-  );
+  await backend.addCastVoteRecordFile(EITHER_NEITHER_CVR_FILE);
 
   const semsFileTally = convertSemsFileToExternalTally(
     EITHER_NEITHER_SEMS_DATA,
@@ -687,7 +682,10 @@ test('tabulating CVRs with SEMS file', async () => {
     'sems-results.csv',
     new Date()
   );
-  await backend.addFullElectionExternalTally(semsFileTally);
+  await backend.updateFullElectionExternalTally(
+    semsFileTally.source,
+    semsFileTally
+  );
 
   const card = new MemoryCard();
   const hardware = MemoryHardware.buildStandard();
@@ -786,12 +784,7 @@ test('tabulating CVRs with SEMS file and manual data', async () => {
   const backend = new ElectionManagerStoreMemoryBackend({
     electionDefinition: eitherNeitherElectionDefinition,
   });
-  await backend.setCastVoteRecordFiles(
-    await CastVoteRecordFiles.empty.add(
-      EITHER_NEITHER_CVR_FILE,
-      eitherNeitherElectionDefinition.election
-    )
-  );
+  await backend.addCastVoteRecordFile(EITHER_NEITHER_CVR_FILE);
 
   const semsFileTally = convertSemsFileToExternalTally(
     EITHER_NEITHER_SEMS_DATA,
@@ -800,7 +793,10 @@ test('tabulating CVRs with SEMS file and manual data', async () => {
     'sems-results.csv',
     new Date()
   );
-  await backend.addFullElectionExternalTally(semsFileTally);
+  await backend.updateFullElectionExternalTally(
+    semsFileTally.source,
+    semsFileTally
+  );
 
   const card = new MemoryCard();
   const hardware = MemoryHardware.buildStandard();
@@ -966,12 +962,7 @@ test('changing election resets sems, cvr, and manual data files', async () => {
   const backend = new ElectionManagerStoreMemoryBackend({
     electionDefinition: eitherNeitherElectionDefinition,
   });
-  await backend.setCastVoteRecordFiles(
-    await CastVoteRecordFiles.empty.add(
-      EITHER_NEITHER_CVR_FILE,
-      eitherNeitherElectionDefinition.election
-    )
-  );
+  await backend.addCastVoteRecordFile(EITHER_NEITHER_CVR_FILE);
 
   const semsFileTally = convertSemsFileToExternalTally(
     EITHER_NEITHER_SEMS_DATA,
@@ -988,8 +979,14 @@ test('changing election resets sems, cvr, and manual data files', async () => {
     'Manually Added Data',
     new Date()
   );
-  await backend.addFullElectionExternalTally(semsFileTally);
-  await backend.addFullElectionExternalTally(manualTally);
+  await backend.updateFullElectionExternalTally(
+    semsFileTally.source,
+    semsFileTally
+  );
+  await backend.updateFullElectionExternalTally(
+    manualTally.source,
+    manualTally
+  );
 
   const card = new MemoryCard();
   const hardware = MemoryHardware.buildStandard();
@@ -1033,12 +1030,7 @@ test('clearing all files after marking as official clears SEMS, CVR, and manual 
   const backend = new ElectionManagerStoreMemoryBackend({
     electionDefinition: eitherNeitherElectionDefinition,
   });
-  await backend.setCastVoteRecordFiles(
-    await CastVoteRecordFiles.empty.add(
-      EITHER_NEITHER_CVR_FILE,
-      eitherNeitherElectionDefinition.election
-    )
-  );
+  await backend.addCastVoteRecordFile(EITHER_NEITHER_CVR_FILE);
 
   const semsFileTally = convertSemsFileToExternalTally(
     EITHER_NEITHER_SEMS_DATA,
@@ -1055,8 +1047,14 @@ test('clearing all files after marking as official clears SEMS, CVR, and manual 
     'Manually Added Data',
     new Date()
   );
-  await backend.addFullElectionExternalTally(semsFileTally);
-  await backend.addFullElectionExternalTally(manualTally);
+  await backend.updateFullElectionExternalTally(
+    semsFileTally.source,
+    semsFileTally
+  );
+  await backend.updateFullElectionExternalTally(
+    manualTally.source,
+    manualTally
+  );
 
   const card = new MemoryCard();
   const hardware = MemoryHardware.buildStandard();

--- a/frontends/election-manager/src/components/ballot_counts_table.test.tsx
+++ b/frontends/election-manager/src/components/ballot_counts_table.test.tsx
@@ -147,7 +147,9 @@ describe('Ballot Counts by Precinct', () => {
       <BallotCountsTable breakdownCategory={TallyCategory.Precinct} />,
       {
         fullElectionTally,
-        fullElectionExternalTallies: [fullElectionExternalTally],
+        fullElectionExternalTallies: new Map([
+          [fullElectionExternalTally.source, fullElectionExternalTally],
+        ]),
       }
     );
     for (const precinct of electionWithMsEitherNeither.precincts) {
@@ -268,7 +270,9 @@ describe('Ballot Counts by Scanner', () => {
       <BallotCountsTable breakdownCategory={TallyCategory.Scanner} />,
       {
         fullElectionTally,
-        fullElectionExternalTallies: [fullElectionExternalTally],
+        fullElectionExternalTallies: new Map([
+          [fullElectionExternalTally.source, fullElectionExternalTally],
+        ]),
       }
     );
 
@@ -451,7 +455,9 @@ describe('Ballots Counts by Party', () => {
           electionData: '',
         },
         fullElectionTally,
-        fullElectionExternalTallies: [fullElectionExternalTally],
+        fullElectionExternalTallies: new Map([
+          [fullElectionExternalTally.source, fullElectionExternalTally],
+        ]),
       }
     );
 
@@ -588,7 +594,9 @@ describe('Ballots Counts by VotingMethod', () => {
       <BallotCountsTable breakdownCategory={TallyCategory.VotingMethod} />,
       {
         fullElectionTally,
-        fullElectionExternalTallies: [fullElectionExternalTally],
+        fullElectionExternalTallies: new Map([
+          [fullElectionExternalTally.source, fullElectionExternalTally],
+        ]),
       }
     );
 
@@ -767,7 +775,9 @@ describe('Ballots Counts by Batch', () => {
       <BallotCountsTable breakdownCategory={TallyCategory.Batch} />,
       {
         fullElectionTally,
-        fullElectionExternalTallies: [fullElectionExternalTally],
+        fullElectionExternalTallies: new Map([
+          [fullElectionExternalTally.source, fullElectionExternalTally],
+        ]),
       }
     );
 

--- a/frontends/election-manager/src/components/ballot_counts_table.tsx
+++ b/frontends/election-manager/src/components/ballot_counts_table.tsx
@@ -39,7 +39,9 @@ export function BallotCountsTable({ breakdownCategory }: Props): JSX.Element {
 
   const totalBallotCountInternal =
     fullElectionTally?.overallTally.numberOfBallotsCounted ?? 0;
-  const totalBallotCountExternal = fullElectionExternalTallies.reduce(
+  const totalBallotCountExternal = Array.from(
+    fullElectionExternalTallies.values()
+  ).reduce(
     (prev, tally) => prev + tally.overallTally.numberOfBallotsCounted,
     0
   );
@@ -48,9 +50,9 @@ export function BallotCountsTable({ breakdownCategory }: Props): JSX.Element {
     case TallyCategory.Precinct: {
       const resultsByPrecinct =
         fullElectionTally?.resultsByCategory.get(TallyCategory.Precinct) || {};
-      const externalResultsByPrecinct = fullElectionExternalTallies.map(
-        (t) => t.resultsByCategory.get(TallyCategory.Precinct) || {}
-      );
+      const externalResultsByPrecinct = Array.from(
+        fullElectionExternalTallies.values()
+      ).map((t) => t.resultsByCategory.get(TallyCategory.Precinct) || {});
       return (
         <Table>
           <tbody>
@@ -177,7 +179,7 @@ export function BallotCountsTable({ breakdownCategory }: Props): JSX.Element {
                     </tr>
                   );
                 })}
-              {fullElectionExternalTallies.map((t) => (
+              {Array.from(fullElectionExternalTallies.values()).map((t) => (
                 <tr data-testid="table-row" key={t.inputSourceName}>
                   <TD narrow nowrap>
                     External Results ({t.inputSourceName})
@@ -207,9 +209,9 @@ export function BallotCountsTable({ breakdownCategory }: Props): JSX.Element {
     case TallyCategory.Party: {
       const resultsByParty =
         fullElectionTally?.resultsByCategory.get(TallyCategory.Party) || {};
-      const externalResultsByParty = fullElectionExternalTallies.map(
-        (t) => t.resultsByCategory.get(TallyCategory.Party) || {}
-      );
+      const externalResultsByParty = Array.from(
+        fullElectionExternalTallies.values()
+      ).map((t) => t.resultsByCategory.get(TallyCategory.Party) || {});
       const partiesForPrimaries = getPartiesWithPrimaryElections(election);
       if (partiesForPrimaries.length === 0) {
         return <React.Fragment />;
@@ -300,7 +302,7 @@ export function BallotCountsTable({ breakdownCategory }: Props): JSX.Element {
                 0;
               const votingMethodBallotsCount =
                 // Include external results as appropriate
-                fullElectionExternalTallies
+                Array.from(fullElectionExternalTallies.values())
                   .filter((t) => t.votingMethod === votingMethod)
                   .reduce(
                     (prev, t) => prev + t.overallTally.numberOfBallotsCounted,
@@ -391,7 +393,7 @@ export function BallotCountsTable({ breakdownCategory }: Props): JSX.Element {
                 </tr>
               );
             })}
-            {fullElectionExternalTallies.map((t) => (
+            {Array.from(fullElectionExternalTallies.values()).map((t) => (
               <tr data-testid="table-row" key={t.inputSourceName}>
                 <TD narrow nowrap data-testid="batch-external">
                   External Results ({t.inputSourceName})

--- a/frontends/election-manager/src/components/confirm_removing_file_modal.tsx
+++ b/frontends/election-manager/src/components/confirm_removing_file_modal.tsx
@@ -21,11 +21,11 @@ export function ConfirmRemovingFileModal({
   const { castVoteRecordFiles, fullElectionExternalTallies } =
     useContext(AppContext);
 
-  const semsFile = fullElectionExternalTallies.find(
-    (t) => t.source === ExternalTallySourceType.SEMS
+  const semsFile = fullElectionExternalTallies.get(
+    ExternalTallySourceType.SEMS
   );
-  const manualData = fullElectionExternalTallies.find(
-    (t) => t.source === ExternalTallySourceType.Manual
+  const manualData = fullElectionExternalTallies.get(
+    ExternalTallySourceType.Manual
   );
 
   let mainContent = null;
@@ -60,7 +60,7 @@ export function ConfirmRemovingFileModal({
       mainContent = (
         <p>
           Do you want to remove the external results{' '}
-          {pluralize('files', fullElectionExternalTallies.length)}{' '}
+          {pluralize('files', fullElectionExternalTallies.size)}{' '}
           {semsFile.inputSourceName}?
         </p>
       );

--- a/frontends/election-manager/src/components/election_manager_tally_report.tsx
+++ b/frontends/election-manager/src/components/election_manager_tally_report.tsx
@@ -11,7 +11,7 @@ import {
 import {
   Election,
   ExternalTally,
-  FullElectionExternalTally,
+  FullElectionExternalTallies,
   FullElectionTally,
   getLabelForVotingMethod,
   PartyIdSchema,
@@ -30,7 +30,7 @@ export interface Props {
   batchId?: string;
   batchLabel?: string;
   election: Election;
-  fullElectionExternalTallies: readonly FullElectionExternalTally[];
+  fullElectionExternalTallies: FullElectionExternalTallies;
   fullElectionTally: FullElectionTally;
   generatedAtTime?: Date;
   tallyReportType: TallyReportType;
@@ -87,7 +87,7 @@ export const ElectionManagerTallyReport = forwardRef<HTMLDivElement, Props>(
               };
             let reportBallotCount = tallyForReport.numberOfBallotsCounted;
             const externalTalliesForReport: ExternalTally[] = [];
-            for (const t of fullElectionExternalTallies) {
+            for (const t of fullElectionExternalTallies.values()) {
               const filteredTally = filterExternalTalliesByParams(t, election, {
                 precinctId,
                 partyId,

--- a/frontends/election-manager/src/components/import_cvrfiles_modal.test.tsx
+++ b/frontends/election-manager/src/components/import_cvrfiles_modal.test.tsx
@@ -75,13 +75,13 @@ describe('Screens display properly when USB is mounted', () => {
 
   test('No files found screen shows when mounted usb has no valid files', async () => {
     const closeFn = jest.fn();
-    const saveCvr = jest.fn();
+    const addCvr = jest.fn();
     const logger = fakeLogger();
     const { getByText, getByTestId } = renderInAppContext(
       <ImportCvrFilesModal onClose={closeFn} />,
       {
         usbDriveStatus: UsbDriveStatus.mounted,
-        saveCastVoteRecordFiles: saveCvr,
+        addCastVoteRecordFile: addCvr,
         logger,
       }
     );
@@ -99,7 +99,7 @@ describe('Screens display properly when USB is mounted', () => {
       target: { files: [new File([''], 'file.jsonl')] },
     });
     await waitFor(() => getByText('0 new CVRs Loaded'));
-    expect(saveCvr).toHaveBeenCalledTimes(1);
+    expect(addCvr).toHaveBeenCalledTimes(1);
     expect(logger.log).toHaveBeenCalledWith(
       LogEventId.CvrFilesReadFromUsb,
       'election_manager',
@@ -109,7 +109,7 @@ describe('Screens display properly when USB is mounted', () => {
 
   test('Load CVR files screen shows table with test and live CVRs', async () => {
     const closeFn = jest.fn();
-    const saveCvr = jest.fn();
+    const addCvr = jest.fn();
     const fileEntries = [
       {
         name: LIVE_FILE1,
@@ -135,7 +135,7 @@ describe('Screens display properly when USB is mounted', () => {
       <ImportCvrFilesModal onClose={closeFn} />,
       {
         usbDriveStatus: UsbDriveStatus.mounted,
-        saveCastVoteRecordFiles: saveCvr,
+        addCastVoteRecordFile: addCvr,
         logger,
       }
     );
@@ -174,7 +174,7 @@ describe('Screens display properly when USB is mounted', () => {
     fireEvent.click(domGetByText(tableRows[0], 'Load'));
     getByText('Loading');
     await waitFor(() => {
-      expect(saveCvr).toHaveBeenCalledTimes(1);
+      expect(addCvr).toHaveBeenCalledTimes(1);
       // We should not need to read the file another time since it was already read.
       expect(window.kiosk!.readFile).toHaveBeenCalledTimes(3);
       getByText('0 new CVRs Loaded');
@@ -188,7 +188,7 @@ describe('Screens display properly when USB is mounted', () => {
 
   test('Can handle errors appropriately', async () => {
     const closeFn = jest.fn();
-    const saveCvr = jest.fn();
+    const addCvr = jest.fn();
     const logger = fakeLogger();
     const fileEntries = [
       {
@@ -217,7 +217,7 @@ describe('Screens display properly when USB is mounted', () => {
       <ImportCvrFilesModal onClose={closeFn} />,
       {
         usbDriveStatus: UsbDriveStatus.mounted,
-        saveCastVoteRecordFiles: saveCvr,
+        addCastVoteRecordFile: addCvr,
         logger,
       }
     );
@@ -238,7 +238,7 @@ describe('Screens display properly when USB is mounted', () => {
     });
     getByText('Loading');
     await waitFor(() => {
-      expect(saveCvr).toHaveBeenCalledTimes(1);
+      expect(addCvr).toHaveBeenCalledTimes(1);
       // There should be an error loading the file.
       getByText('Error');
       getByText(/There was an error reading the content of the file/);
@@ -252,7 +252,7 @@ describe('Screens display properly when USB is mounted', () => {
 
   test('Load CVR files screen locks to test mode when test files have been loaded', async () => {
     const closeFn = jest.fn();
-    const saveCvr = jest.fn();
+    const addCvr = jest.fn();
     const logger = fakeLogger();
     const fileEntries = [
       {
@@ -304,7 +304,7 @@ describe('Screens display properly when USB is mounted', () => {
       {
         usbDriveStatus: UsbDriveStatus.mounted,
         castVoteRecordFiles: added,
-        saveCastVoteRecordFiles: saveCvr,
+        addCastVoteRecordFile: addCvr,
         logger,
       }
     );
@@ -346,7 +346,7 @@ describe('Screens display properly when USB is mounted', () => {
     fireEvent.click(domGetByText(tableRows[1], 'Load'));
     getByText('Loading');
     await waitFor(() => {
-      expect(saveCvr).toHaveBeenCalledTimes(1);
+      expect(addCvr).toHaveBeenCalledTimes(1);
       // There should be a message about loading a duplicate file displayed.
       getByText('Duplicate File');
       getByText(
@@ -362,7 +362,7 @@ describe('Screens display properly when USB is mounted', () => {
 
   test('Load CVR files screen locks to live mode when live files have been loaded', async () => {
     const closeFn = jest.fn();
-    const saveCvr = jest.fn();
+    const addCvr = jest.fn();
     const fileEntries = [
       {
         name: LIVE_FILE1,
@@ -403,7 +403,7 @@ describe('Screens display properly when USB is mounted', () => {
       {
         usbDriveStatus: UsbDriveStatus.mounted,
         castVoteRecordFiles: added,
-        saveCastVoteRecordFiles: saveCvr,
+        addCastVoteRecordFile: addCvr,
       }
     );
     await waitFor(() => getByText('Load Live Mode CVR Files'));
@@ -423,14 +423,14 @@ describe('Screens display properly when USB is mounted', () => {
     fireEvent.click(domGetByText(tableRows[0], 'Load'));
     getByText('Loading');
     await waitFor(() => {
-      expect(saveCvr).toHaveBeenCalledTimes(1);
+      expect(addCvr).toHaveBeenCalledTimes(1);
       getByText('0 new CVRs Loaded');
     });
   });
 
   test('Shows previously loaded files when all files have already been loaded', async () => {
     const closeFn = jest.fn();
-    const saveCvr = jest.fn();
+    const addCvr = jest.fn();
     const fileEntries = [
       {
         name: LIVE_FILE1,
@@ -461,7 +461,7 @@ describe('Screens display properly when USB is mounted', () => {
       {
         usbDriveStatus: UsbDriveStatus.mounted,
         castVoteRecordFiles: added,
-        saveCastVoteRecordFiles: saveCvr,
+        addCastVoteRecordFile: addCvr,
       }
     );
     await waitFor(() => getByText('Load Live Mode CVR Files'));

--- a/frontends/election-manager/src/components/import_cvrfiles_modal.tsx
+++ b/frontends/election-manager/src/components/import_cvrfiles_modal.tsx
@@ -73,7 +73,7 @@ function throwBadStatus(s: never): never {
 export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
   const {
     usbDriveStatus,
-    saveCastVoteRecordFiles,
+    addCastVoteRecordFile,
     castVoteRecordFiles,
     electionDefinition,
     auth,
@@ -97,7 +97,9 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
       fileData,
       election
     );
-    await saveCastVoteRecordFiles(newCastVoteRecordFiles);
+    await addCastVoteRecordFile(
+      new File([fileData.fileContent], fileData.name)
+    );
 
     if (newCastVoteRecordFiles.duplicateFiles.includes(fileData.name)) {
       setCurrentState(ModalState.DUPLICATE);
@@ -146,7 +148,7 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
         files,
         election
       );
-      await saveCastVoteRecordFiles(newCastVoteRecordFiles);
+      await addCastVoteRecordFile(files[0]);
 
       input.value = '';
       const filename = files[0].name;

--- a/frontends/election-manager/src/components/import_external_results_modal.tsx
+++ b/frontends/election-manager/src/components/import_external_results_modal.tsx
@@ -30,7 +30,7 @@ export function ImportExternalResultsModal({
   selectedFile,
 }: Props): JSX.Element {
   const {
-    addExternalTally,
+    updateExternalTally,
     setIsTabulationRunning,
     electionDefinition,
     auth,
@@ -120,7 +120,7 @@ export function ImportExternalResultsModal({
         fileType: ExternalTallySourceType.SEMS,
         numberOfBallotsImported: tally.overallTally.numberOfBallotsCounted,
       });
-      await addExternalTally(tally);
+      await updateExternalTally(tally);
       setIsTabulationRunning(false);
       onClose();
     }

--- a/frontends/election-manager/src/components/test_deck_tally_report.tsx
+++ b/frontends/election-manager/src/components/test_deck_tally_report.tsx
@@ -57,7 +57,7 @@ export function TestDeckTallyReport({
       election={election}
       tallyReportType="Test Deck"
       fullElectionTally={fullElectionTally}
-      fullElectionExternalTallies={[]}
+      fullElectionExternalTallies={new Map()}
     />
   );
 }

--- a/frontends/election-manager/src/contexts/app_context.ts
+++ b/frontends/election-manager/src/contexts/app_context.ts
@@ -4,6 +4,7 @@ import {
   FullElectionTally,
   FullElectionExternalTally,
   DippedSmartcardAuth,
+  FullElectionExternalTallies,
 } from '@votingworks/types';
 import { usbstick, NullPrinter, Printer } from '@votingworks/utils';
 import { Logger, LogSource, LoggingUserRole } from '@votingworks/logging';
@@ -17,10 +18,7 @@ import {
   ConverterClientType,
   ResetElection,
 } from '../config/types';
-import {
-  CastVoteRecordFiles,
-  SaveCastVoteRecordFiles,
-} from '../utils/cast_vote_record_files';
+import { CastVoteRecordFiles } from '../utils/cast_vote_record_files';
 import { getEmptyFullElectionTally } from '../lib/votecounting';
 import { getEmptyExportableTallies } from '../utils/exportable_tallies';
 
@@ -32,7 +30,8 @@ export interface AppContextInterface {
   isOfficialResults: boolean;
   printer: Printer;
   printBallotRef?: RefObject<HTMLElement>;
-  saveCastVoteRecordFiles: SaveCastVoteRecordFiles;
+  addCastVoteRecordFile: (newCastVoteRecordFile: File) => Promise<void>;
+  clearCastVoteRecordFiles: () => Promise<void>;
   saveElection: SaveElection;
   resetElection: ResetElection;
   markResultsOfficial: () => Promise<void>;
@@ -42,11 +41,10 @@ export interface AppContextInterface {
   addPrintedBallot: (printedBallot: PrintedBallot) => void;
   printedBallots: readonly PrintedBallot[];
   fullElectionTally: FullElectionTally;
-  fullElectionExternalTallies: readonly FullElectionExternalTally[];
+  fullElectionExternalTallies: FullElectionExternalTallies;
   isTabulationRunning: boolean;
-  addExternalTally: (externalTally: FullElectionExternalTally) => Promise<void>;
-  saveExternalTallies: (
-    externalTallies: FullElectionExternalTally[]
+  updateExternalTally: (
+    newExternalTally: FullElectionExternalTally
   ) => Promise<void>;
   saveTranscribedValue: (
     adjudicationId: string,
@@ -69,7 +67,8 @@ const appContext: AppContextInterface = {
   isOfficialResults: false,
   printer: new NullPrinter(),
   printBallotRef: undefined,
-  saveCastVoteRecordFiles: async () => undefined,
+  addCastVoteRecordFile: async () => undefined,
+  clearCastVoteRecordFiles: async () => undefined,
   saveElection: async () => undefined,
   resetElection: async () => undefined,
   markResultsOfficial: async () => undefined,
@@ -79,9 +78,8 @@ const appContext: AppContextInterface = {
   addPrintedBallot: () => undefined,
   printedBallots: [],
   fullElectionTally: getEmptyFullElectionTally(),
-  fullElectionExternalTallies: [],
-  addExternalTally: async () => undefined,
-  saveExternalTallies: async () => undefined,
+  fullElectionExternalTallies: new Map(),
+  updateExternalTally: async () => undefined,
   saveTranscribedValue: async () => undefined,
   isTabulationRunning: false,
   setIsTabulationRunning: () => undefined,

--- a/frontends/election-manager/src/lib/backends/types.ts
+++ b/frontends/election-manager/src/lib/backends/types.ts
@@ -1,5 +1,7 @@
 import {
   ElectionDefinition,
+  ExternalTallySourceType,
+  FullElectionExternalTallies,
   FullElectionExternalTally,
   Iso8601Timestamp,
 } from '@votingworks/types';
@@ -33,11 +35,9 @@ export interface ElectionManagerStoreBackend {
   loadCastVoteRecordFiles(): Promise<CastVoteRecordFiles | undefined>;
 
   /**
-   * Overwrites the existing cast vote record files with the given ones.
+   * Adds a new cast vote record file.
    */
-  setCastVoteRecordFiles(
-    newCastVoteRecordFiles: CastVoteRecordFiles
-  ): Promise<void>;
+  addCastVoteRecordFile(newCastVoteRecordFile: File): Promise<void>;
 
   /**
    * Resets all cast vote record files.
@@ -48,22 +48,28 @@ export interface ElectionManagerStoreBackend {
    * Loads the existing external tallies.
    */
   loadFullElectionExternalTallies(): Promise<
-    FullElectionExternalTally[] | undefined
+    FullElectionExternalTallies | undefined
   >;
 
   /**
-   * Adds an external tally to the list.
+   * Updates the external tally for a given source.
    */
-  addFullElectionExternalTally(
+  updateFullElectionExternalTally(
+    sourceType: ExternalTallySourceType,
     newFullElectionExternalTally: FullElectionExternalTally
   ): Promise<void>;
 
   /**
-   * Replaces all external tallies with the given ones.
+   * Removes the external tally for a given source.
    */
-  setFullElectionExternalTallies(
-    newFullElectionExternalTallies: readonly FullElectionExternalTally[]
+  removeFullElectionExternalTally(
+    sourceType: ExternalTallySourceType
   ): Promise<void>;
+
+  /**
+   * Clears all external tallies.
+   */
+  clearFullElectionExternalTallies(): Promise<void>;
 
   /**
    * Loads the existing setting for whether the results are official.

--- a/frontends/election-manager/src/screens/manual_data_import_index_screen.test.tsx
+++ b/frontends/election-manager/src/screens/manual_data_import_index_screen.test.tsx
@@ -30,7 +30,7 @@ beforeEach(() => {
 });
 
 test('can toggle ballot types for data', async () => {
-  const saveExternalTallies = jest.fn();
+  const updateExternalTally = jest.fn();
   const { getByText, getByTestId } = renderInAppContext(
     <Route path="/tally/manual-data-import">
       <ManualDataImportIndexScreen />
@@ -38,7 +38,7 @@ test('can toggle ballot types for data', async () => {
     {
       route: '/tally/manual-data-import',
       electionDefinition: multiPartyPrimaryElectionDefinition,
-      saveExternalTallies,
+      updateExternalTally,
     }
   );
   getByText('Manually Entered Precinct Results');
@@ -57,27 +57,27 @@ test('can toggle ballot types for data', async () => {
   expect(getByTestId('ballottype-absentee').closest('button')).toBeDisabled();
   getByText('Edit Absentee Results for Precinct 5');
 
-  await waitFor(() => expect(saveExternalTallies).toHaveBeenCalled());
-  expect(saveExternalTallies).toHaveBeenCalledWith([
+  await waitFor(() => expect(updateExternalTally).toHaveBeenCalled());
+  expect(updateExternalTally).toHaveBeenCalledWith(
     expect.objectContaining({
       source: ExternalTallySourceType.Manual,
       votingMethod: VotingMethod.Absentee,
-    }),
-  ]);
+    })
+  );
 
   fireEvent.click(getByTestId('ballottype-precinct'));
-  await waitFor(() => expect(saveExternalTallies).toHaveBeenCalledTimes(2));
-  expect(saveExternalTallies).toHaveBeenCalledWith([
+  await waitFor(() => expect(updateExternalTally).toHaveBeenCalledTimes(2));
+  expect(updateExternalTally).toHaveBeenCalledWith(
     expect.objectContaining({
       source: ExternalTallySourceType.Manual,
       votingMethod: VotingMethod.Precinct,
-    }),
-  ]);
+    })
+  );
   getByText('Edit Precinct Results for Precinct 5');
 });
 
 test('precinct table renders properly when there is no data', () => {
-  const saveExternalTallies = jest.fn();
+  const updateExternalTally = jest.fn();
   const history = createMemoryHistory();
   const { getByText, getByTestId } = renderInAppContext(
     <Router history={history}>
@@ -86,7 +86,7 @@ test('precinct table renders properly when there is no data', () => {
     {
       route: '/tally/manual-data-import',
       electionDefinition: electionSampleDefinition,
-      saveExternalTallies,
+      updateExternalTally,
     }
   );
   getByText('Manually Entered Precinct Results');
@@ -206,7 +206,9 @@ test('loads prexisting manual data to edit', async () => {
       route: '/tally/manual-data-import',
       electionDefinition: electionSampleDefinition,
       resetFiles,
-      fullElectionExternalTallies: [externalTally],
+      fullElectionExternalTallies: new Map([
+        [externalTally.source, externalTally],
+      ]),
     }
   );
   getByText('Manually Entered Absentee Results');

--- a/frontends/election-manager/src/screens/manual_data_import_index_screen.tsx
+++ b/frontends/election-manager/src/screens/manual_data_import_index_screen.tsx
@@ -50,7 +50,7 @@ export function ManualDataImportIndexScreen(): JSX.Element {
   const {
     electionDefinition,
     fullElectionExternalTallies,
-    saveExternalTallies,
+    updateExternalTally,
     resetFiles,
     auth,
     logger,
@@ -61,13 +61,9 @@ export function ManualDataImportIndexScreen(): JSX.Element {
   const { election } = electionDefinition;
   const history = useHistory();
 
-  const existingManualDataTallies = fullElectionExternalTallies.filter(
-    (t) => t.source === ExternalTallySourceType.Manual
+  const existingManualData = fullElectionExternalTallies.get(
+    ExternalTallySourceType.Manual
   );
-  const existingManualData =
-    existingManualDataTallies.length === 1
-      ? existingManualDataTallies[0]
-      : undefined;
   const existingTalliesByPrecinct = existingManualData?.resultsByCategory.get(
     TallyCategory.Precinct
   );
@@ -102,13 +98,7 @@ export function ManualDataImportIndexScreen(): JSX.Element {
       newBallotType,
       message: `Ballot type for manually entered tally data changed to ${newBallotType}`,
     });
-    // Don't modify any external tallies for non-manual data
-    const newTallies = fullElectionExternalTallies.filter(
-      (t) => t.source !== ExternalTallySourceType.Manual
-    );
-    // Add the new tally
-    newTallies.push(externalTally);
-    await saveExternalTallies(newTallies);
+    await updateExternalTally(externalTally);
   }
 
   useEffect(() => {

--- a/frontends/election-manager/src/screens/manual_data_import_precinct_screen.test.tsx
+++ b/frontends/election-manager/src/screens/manual_data_import_precinct_screen.test.tsx
@@ -37,7 +37,7 @@ test('displays error screen for invalid precinct', () => {
 });
 
 test('displays correct contests for each precinct', () => {
-  const saveExternalTallies = jest.fn();
+  const updateExternalTally = jest.fn();
   const commissionerRaces = [
     'Election Commissioner 01',
     'Election Commissioner 02',
@@ -85,7 +85,7 @@ test('displays correct contests for each precinct', () => {
       {
         route: `/tally/manual-data-import/precinct/${precinctId}`,
         electionDefinition: electionWithMsEitherNeitherDefinition,
-        saveExternalTallies,
+        updateExternalTally,
       }
     );
     getByText('Manually Entered Precinct Results:');
@@ -105,7 +105,7 @@ test('displays correct contests for each precinct', () => {
 });
 
 test('can enter data for candidate contests as expected', async () => {
-  const saveExternalTallies = jest.fn();
+  const updateExternalTally = jest.fn();
   const logger = fakeLogger();
   const { getByText, queryAllByTestId, getByTestId } = renderInAppContext(
     <Route path="/tally/manual-data-import/precinct/:precinctId">
@@ -113,7 +113,7 @@ test('can enter data for candidate contests as expected', async () => {
     </Route>,
     {
       route: '/tally/manual-data-import/precinct/23',
-      saveExternalTallies,
+      updateExternalTally,
       electionDefinition: electionSampleDefinition,
       logger,
     }
@@ -165,8 +165,8 @@ test('can enter data for candidate contests as expected', async () => {
       expect.objectContaining({ disposition: 'success' })
     )
   );
-  expect(saveExternalTallies).toHaveBeenCalledTimes(1);
-  expect(saveExternalTallies).toHaveBeenCalledWith([
+  expect(updateExternalTally).toHaveBeenCalledTimes(1);
+  expect(updateExternalTally).toHaveBeenCalledWith(
     expect.objectContaining({
       overallTally: {
         numberOfBallotsCounted: 100,
@@ -184,12 +184,12 @@ test('can enter data for candidate contests as expected', async () => {
           }),
         }),
       },
-    }),
-  ]);
+    })
+  );
 });
 
 test('can enter data for candidate contest with a write in row as expected', async () => {
-  const saveExternalTallies = jest.fn();
+  const updateExternalTally = jest.fn();
   const logger = fakeLogger();
   const { getByText, getByTestId } = renderInAppContext(
     <Route path="/tally/manual-data-import/precinct/:precinctId">
@@ -197,7 +197,7 @@ test('can enter data for candidate contest with a write in row as expected', asy
     </Route>,
     {
       route: '/tally/manual-data-import/precinct/23',
-      saveExternalTallies,
+      updateExternalTally,
       electionDefinition: electionSampleDefinition,
       logger,
     }
@@ -227,8 +227,8 @@ test('can enter data for candidate contest with a write in row as expected', asy
       expect.objectContaining({ disposition: 'success' })
     )
   );
-  expect(saveExternalTallies).toHaveBeenCalledTimes(1);
-  expect(saveExternalTallies).toHaveBeenCalledWith([
+  expect(updateExternalTally).toHaveBeenCalledTimes(1);
+  expect(updateExternalTally).toHaveBeenCalledWith(
     expect.objectContaining({
       overallTally: {
         numberOfBallotsCounted: 10,
@@ -241,12 +241,12 @@ test('can enter data for candidate contest with a write in row as expected', asy
           }),
         }),
       },
-    }),
-  ]);
+    })
+  );
 });
 
 test('can enter data for yes no contests as expected', async () => {
-  const saveExternalTallies = jest.fn();
+  const updateExternalTally = jest.fn();
   const logger = fakeLogger();
   const { getByText, queryAllByTestId, getByTestId } = renderInAppContext(
     <Route path="/tally/manual-data-import/precinct/:precinctId">
@@ -254,7 +254,7 @@ test('can enter data for yes no contests as expected', async () => {
     </Route>,
     {
       route: '/tally/manual-data-import/precinct/23',
-      saveExternalTallies,
+      updateExternalTally,
       electionDefinition: electionSampleDefinition,
       logger,
     }
@@ -316,8 +316,8 @@ test('can enter data for yes no contests as expected', async () => {
       expect.objectContaining({ disposition: 'success' })
     )
   );
-  expect(saveExternalTallies).toHaveBeenCalledTimes(1);
-  expect(saveExternalTallies).toHaveBeenCalledWith([
+  expect(updateExternalTally).toHaveBeenCalledTimes(1);
+  expect(updateExternalTally).toHaveBeenCalledWith(
     expect.objectContaining({
       overallTally: {
         numberOfBallotsCounted: 100,
@@ -331,8 +331,8 @@ test('can enter data for yes no contests as expected', async () => {
           }),
         }),
       },
-    }),
-  ]);
+    })
+  );
 });
 
 test('loads prexisting manual data to edit', () => {
@@ -408,16 +408,18 @@ test('loads prexisting manual data to edit', () => {
     timestampCreated: new Date(),
   };
 
-  const saveExternalTallies = jest.fn();
+  const updateExternalTally = jest.fn();
   const centerSpringfield = renderInAppContext(
     <Route path="/tally/manual-data-import/precinct/:precinctId">
       <ManualDataImportPrecinctScreen />
     </Route>,
     {
       route: '/tally/manual-data-import/precinct/23',
-      saveExternalTallies,
+      updateExternalTally,
       electionDefinition: electionSampleDefinition,
-      fullElectionExternalTallies: [externalTally],
+      fullElectionExternalTallies: new Map([
+        [externalTally.source, externalTally],
+      ]),
     }
   );
   centerSpringfield.getByText('Manually Entered Absentee Results:');
@@ -489,9 +491,11 @@ test('loads prexisting manual data to edit', () => {
     </Route>,
     {
       route: '/tally/manual-data-import/precinct/20',
-      saveExternalTallies,
+      updateExternalTally,
       electionDefinition: electionSampleDefinition,
-      fullElectionExternalTallies: [externalTally],
+      fullElectionExternalTallies: new Map([
+        [externalTally.source, externalTally],
+      ]),
     }
   );
   southSpringfieldComponent.getByText('Manually Entered Absentee Results:');
@@ -530,9 +534,11 @@ test('loads prexisting manual data to edit', () => {
     </Route>,
     {
       route: '/tally/manual-data-import/precinct/21',
-      saveExternalTallies,
+      updateExternalTally,
       electionDefinition: electionSampleDefinition,
-      fullElectionExternalTallies: [externalTally],
+      fullElectionExternalTallies: new Map([
+        [externalTally.source, externalTally],
+      ]),
     }
   );
   northSpringfieldComponent.getByText('Manually Entered Absentee Results:');

--- a/frontends/election-manager/src/screens/manual_data_import_precinct_screen.tsx
+++ b/frontends/election-manager/src/screens/manual_data_import_precinct_screen.tsx
@@ -142,7 +142,7 @@ export function ManualDataImportPrecinctScreen(): JSX.Element {
   const {
     electionDefinition,
     fullElectionExternalTallies,
-    saveExternalTallies,
+    updateExternalTally,
     auth,
     logger,
   } = useContext(AppContext);
@@ -166,13 +166,9 @@ export function ManualDataImportPrecinctScreen(): JSX.Element {
       </Prose>
     );
   }
-  const existingManualDataTallies = fullElectionExternalTallies.filter(
-    (t) => t.source === ExternalTallySourceType.Manual
+  const existingManualData = fullElectionExternalTallies.get(
+    ExternalTallySourceType.Manual
   );
-  const existingManualData =
-    existingManualDataTallies.length === 1
-      ? existingManualDataTallies[0]
-      : undefined;
   const existingTalliesByPrecinct = existingManualData?.resultsByCategory.get(
     TallyCategory.Precinct
   );
@@ -260,14 +256,7 @@ export function ManualDataImportPrecinctScreen(): JSX.Element {
       numberOfBallotsInPrecinct: currentPrecinctTally.numberOfBallotsCounted,
       precinctId: currentPrecinctId,
     });
-    // Don't modify any external tallies for non-manual data
-    const newTallies = fullElectionExternalTallies.filter(
-      (t) => t.source !== ExternalTallySourceType.Manual
-    );
-    // Add the new tally
-    newTallies.push(externalTally);
-    // TODO: switch to `addExternalTally` if we can avoid the `filter` above
-    await saveExternalTallies(newTallies);
+    await updateExternalTally(externalTally);
     history.push(routerPaths.manualDataImport);
   }
 

--- a/frontends/election-manager/src/screens/reports_screen.tsx
+++ b/frontends/election-manager/src/screens/reports_screen.tsx
@@ -64,7 +64,9 @@ export function ReportsScreen(): JSX.Element {
 
   const totalBallotCountInternal =
     fullElectionTally?.overallTally.numberOfBallotsCounted ?? 0;
-  const totalBallotCountExternal = fullElectionExternalTallies.reduce(
+  const totalBallotCountExternal = Array.from(
+    fullElectionExternalTallies.values()
+  ).reduce(
     (prev, tally) => prev + tally.overallTally.numberOfBallotsCounted,
     0
   );

--- a/frontends/election-manager/src/screens/tally_screen.tsx
+++ b/frontends/election-manager/src/screens/tally_screen.tsx
@@ -63,12 +63,12 @@ export function TallyScreen(): JSX.Element {
 
   const castVoteRecordFileList = castVoteRecordFiles.fileList;
   const hasAnyFiles =
-    castVoteRecordFiles.wereAdded || fullElectionExternalTallies.length > 0;
-  const hasExternalSemsFile = fullElectionExternalTallies.some(
-    (t) => t.source === ExternalTallySourceType.SEMS
+    castVoteRecordFiles.wereAdded || fullElectionExternalTallies.size > 0;
+  const hasExternalSemsFile = fullElectionExternalTallies.has(
+    ExternalTallySourceType.SEMS
   );
-  const hasExternalManualData = fullElectionExternalTallies.some(
-    (t) => t.source === ExternalTallySourceType.Manual
+  const hasExternalManualData = fullElectionExternalTallies.has(
+    ExternalTallySourceType.Manual
   );
 
   const [isImportExternalModalOpen, setIsImportExternalModalOpen] =
@@ -101,7 +101,9 @@ export function TallyScreen(): JSX.Element {
       ? 'Currently tallying live ballots.'
       : '';
 
-  const externalTallyRows = fullElectionExternalTallies.map((t) => {
+  const externalTallyRows = Array.from(
+    fullElectionExternalTallies.values()
+  ).map((t) => {
     const precinctsInExternalFile = getPrecinctIdsInExternalTally(t);
     return (
       <tr key={t.inputSourceName}>
@@ -116,7 +118,9 @@ export function TallyScreen(): JSX.Element {
       </tr>
     );
   });
-  const externalFileBallotCount = fullElectionExternalTallies.reduce(
+  const externalFileBallotCount = Array.from(
+    fullElectionExternalTallies.values()
+  ).reduce(
     (prev, tally) => prev + tally.overallTally.numberOfBallotsCounted,
     0
   );

--- a/frontends/election-manager/src/utils/cast_vote_record_files.ts
+++ b/frontends/election-manager/src/utils/cast_vote_record_files.ts
@@ -464,6 +464,4 @@ export class CastVoteRecordFiles {
   }
 }
 
-export type SaveCastVoteRecordFiles = (
-  value: CastVoteRecordFiles
-) => Promise<void>;
+export type AddCastVoteRecordFile = (value: File) => Promise<void>;

--- a/frontends/election-manager/src/utils/exportable_tallies.test.ts
+++ b/frontends/election-manager/src/utils/exportable_tallies.test.ts
@@ -62,7 +62,7 @@ function assertTalliesAreIdenticalMultiples(
       expect(contestId in multipleForPrecinct!).toBeTruthy();
       const baseContestTally = baseForPrecinct![contestId]!;
       const multipleContestTally = multipleForPrecinct![contestId]!;
-      // Metadata should be mulitiplied
+      // Metadata should be multiplied
       expect(multipleContestTally.metadata).toEqual({
         ballots: baseContestTally.metadata.ballots * multiplier,
         overvotes: baseContestTally.metadata.overvotes * multiplier,
@@ -75,7 +75,7 @@ function assertTalliesAreIdenticalMultiples(
       );
 
       for (const optionId of Object.keys(baseContestTally.tallies)) {
-        // Candidate/yes/no tallies should be multipled
+        // Candidate/yes/no tallies should be multiplied
         expect(multipleContestTally.tallies[optionId]!).toEqual(
           multiplier * baseContestTally.tallies[optionId]!
         );
@@ -257,7 +257,7 @@ describe('getExportableTallies', () => {
     );
     const tally = getExportableTallies(
       fullInternalTally,
-      [],
+      new Map(),
       electionWithMsEitherNeither
     );
     expect(tally).toMatchSnapshot();
@@ -282,26 +282,18 @@ describe('getExportableTallies', () => {
     // Get tally with just CVR data
     const baseTally = getExportableTallies(
       fullInternalTally,
-      [],
+      new Map(),
       electionWithMsEitherNeither
     );
     // Get tally with CVR and SEMS data
     const doubleTally = getExportableTallies(
       fullInternalTally,
-      [fullExternalTally],
+      new Map([[fullExternalTally.source, fullExternalTally]]),
       electionWithMsEitherNeither
     );
 
     // doubleTally should be exactly 2 times everything in baseTally
     assertTalliesAreIdenticalMultiples(baseTally, doubleTally, 2);
-    // Get tally with SEMS data duplicated 3x
-    const quadrupleTally = getExportableTallies(
-      fullInternalTally,
-      [fullExternalTally, fullExternalTally, fullExternalTally],
-      electionWithMsEitherNeither
-    );
-    // quadrupleTally should be exactly 4 times everyhting in baseTally
-    assertTalliesAreIdenticalMultiples(baseTally, quadrupleTally, 4);
   });
 
   it('builds expected tally object for primary election with just internal data', () => {
@@ -315,7 +307,7 @@ describe('getExportableTallies', () => {
     );
     const tally = getExportableTallies(
       fullInternalTally,
-      [],
+      new Map(),
       multiPartyPrimaryElection
     );
     expect(tally).toMatchSnapshot();
@@ -340,25 +332,17 @@ describe('getExportableTallies', () => {
     // Get tally with just CVR data
     const baseTally = getExportableTallies(
       fullInternalTally,
-      [],
+      new Map(),
       multiPartyPrimaryElection
     );
     // Get tally with CVR and SEMS data
     const doubleTally = getExportableTallies(
       fullInternalTally,
-      [fullExternalTally],
+      new Map([[fullExternalTally.source, fullExternalTally]]),
       multiPartyPrimaryElection
     );
 
     // doubleTally should be exactly 2 times everything in baseTally
     assertTalliesAreIdenticalMultiples(baseTally, doubleTally, 2);
-    // Get tally with SEMS data duplicated 3x
-    const quadrupleTally = getExportableTallies(
-      fullInternalTally,
-      [fullExternalTally, fullExternalTally, fullExternalTally],
-      multiPartyPrimaryElection
-    );
-    // quadrupleTally should be exactly 4 times everyhting in baseTally
-    assertTalliesAreIdenticalMultiples(baseTally, quadrupleTally, 4);
   });
 });

--- a/frontends/election-manager/src/utils/exportable_tallies.ts
+++ b/frontends/election-manager/src/utils/exportable_tallies.ts
@@ -5,9 +5,9 @@ import {
   expandEitherNeitherContests,
   ContestTally,
   ExternalTally,
-  FullElectionExternalTally,
   FullElectionTally,
   TallyCategory,
+  FullElectionExternalTallies,
 } from '@votingworks/types';
 import {
   ExportableContestTally,
@@ -56,13 +56,13 @@ export function getCombinedExportableContestTally(
 
 export function getExportableTallies(
   internalElectionTally: FullElectionTally,
-  externalElectionTallies: readonly FullElectionExternalTally[],
+  externalElectionTallies: FullElectionExternalTallies,
   election: Election
 ): ExportableTallies {
   const talliesByPrecinct = internalElectionTally.resultsByCategory.get(
     TallyCategory.Precinct
   );
-  const externalTalliesByPrecinct = externalElectionTallies
+  const externalTalliesByPrecinct = Array.from(externalElectionTallies.values())
     .map((t) => t.resultsByCategory.get(TallyCategory.Precinct))
     .filter((t): t is Dictionary<ExternalTally> => !!t);
 

--- a/frontends/election-manager/src/utils/external_tallies.test.ts
+++ b/frontends/election-manager/src/utils/external_tallies.test.ts
@@ -322,9 +322,9 @@ describe('convertExternalTalliesToStorageString, convertStorageStringToExternalT
       timestampCreated: new Date(1989, 11, 13),
     }; // Have information both in the main tally and results by category
 
-    const storageString = convertExternalTalliesToStorageString([
-      fullTallySems,
-    ]);
+    const storageString = convertExternalTalliesToStorageString(
+      new Map([[fullTallySems.source, fullTallySems]])
+    );
     const recreatedTallies =
       convertStorageStringToExternalTallies(storageString);
     expect(recreatedTallies).toStrictEqual([fullTallySems]);
@@ -339,10 +339,12 @@ describe('convertExternalTalliesToStorageString, convertStorageStringToExternalT
       timestampCreated: new Date(2013, 1, 3),
     };
 
-    const storageString2 = convertExternalTalliesToStorageString([
-      fullTallySems,
-      fullTallyManual,
-    ]);
+    const storageString2 = convertExternalTalliesToStorageString(
+      new Map([
+        [fullTallySems.source, fullTallySems],
+        [fullTallyManual.source, fullTallyManual],
+      ])
+    );
     const recreatedTallies2 =
       convertStorageStringToExternalTallies(storageString2);
     expect(recreatedTallies2).toStrictEqual([fullTallySems, fullTallyManual]);

--- a/frontends/election-manager/src/utils/external_tallies.ts
+++ b/frontends/election-manager/src/utils/external_tallies.ts
@@ -15,6 +15,7 @@ import {
   writeInCandidate,
   PartyId,
   PrecinctId,
+  FullElectionExternalTallies,
 } from '@votingworks/types';
 import {
   assert,
@@ -28,10 +29,10 @@ import {
 } from './election';
 
 export function convertExternalTalliesToStorageString(
-  tallies: readonly FullElectionExternalTally[]
+  tallies: FullElectionExternalTallies
 ): string {
   return JSON.stringify(
-    tallies.map((tally) => {
+    Array.from(tallies.values()).map((tally) => {
       return {
         ...tally,
         resultsByCategory: Array.from(tally.resultsByCategory.entries()),

--- a/frontends/election-manager/test/render_in_app_context.tsx
+++ b/frontends/election-manager/test/render_in_app_context.tsx
@@ -8,6 +8,7 @@ import {
   ElectionDefinition,
   FullElectionTally,
   FullElectionExternalTally,
+  FullElectionExternalTallies,
   AdjudicationId,
   DippedSmartcardAuth,
 } from '@votingworks/types';
@@ -26,8 +27,8 @@ import {
   ResetElection,
 } from '../src/config/types';
 import {
+  AddCastVoteRecordFile,
   CastVoteRecordFiles,
-  SaveCastVoteRecordFiles,
 } from '../src/utils/cast_vote_record_files';
 import { getEmptyFullElectionTally } from '../src/lib/votecounting';
 
@@ -43,16 +44,14 @@ interface RenderInAppContextParams {
   isOfficialResults?: boolean;
   printer?: Printer;
   printBallotRef?: RefObject<HTMLElement>;
-  saveCastVoteRecordFiles?: SaveCastVoteRecordFiles;
   saveElection?: SaveElection;
   resetElection?: ResetElection;
   saveTranscribedValue?: (
     adjudicationId: AdjudicationId,
     transcribedValue: string
   ) => Promise<void>;
-  setCastVoteRecordFiles?: React.Dispatch<
-    React.SetStateAction<CastVoteRecordFiles>
-  >;
+  addCastVoteRecordFile?: AddCastVoteRecordFile;
+  clearCastVoteRecordFiles?: () => Promise<void>;
   saveIsOfficialResults?: () => Promise<void>;
   resetFiles?: () => Promise<void>;
   usbDriveStatus?: usbstick.UsbDriveStatus;
@@ -62,13 +61,10 @@ interface RenderInAppContextParams {
   fullElectionTally?: FullElectionTally;
   isTabulationRunning?: boolean;
   setIsTabulationRunning?: React.Dispatch<React.SetStateAction<boolean>>;
-  addExternalTally?: (
-    externalTally: FullElectionExternalTally
+  updateExternalTally?: (
+    newExternalTally: FullElectionExternalTally
   ) => Promise<void>;
-  saveExternalTallies?: (
-    externalTallies: FullElectionExternalTally[]
-  ) => Promise<void>;
-  fullElectionExternalTallies?: FullElectionExternalTally[];
+  fullElectionExternalTallies?: FullElectionExternalTallies;
   generateExportableTallies?: () => ExportableTallies;
   auth?: DippedSmartcardAuth.Auth;
   machineConfig?: MachineConfig;
@@ -98,7 +94,8 @@ export function renderInAppContext(
     isOfficialResults = false,
     printer = new NullPrinter(),
     printBallotRef = undefined,
-    saveCastVoteRecordFiles = jest.fn(),
+    addCastVoteRecordFile = jest.fn(),
+    clearCastVoteRecordFiles = jest.fn(),
     saveElection = jest.fn(),
     resetElection = jest.fn(),
     saveIsOfficialResults: markResultsOfficial = jest.fn(),
@@ -110,9 +107,8 @@ export function renderInAppContext(
     fullElectionTally = getEmptyFullElectionTally(),
     isTabulationRunning = false,
     setIsTabulationRunning = jest.fn(),
-    addExternalTally = jest.fn(),
-    saveExternalTallies = jest.fn(),
-    fullElectionExternalTallies = [],
+    updateExternalTally = jest.fn(),
+    fullElectionExternalTallies = new Map(),
     saveTranscribedValue = jest.fn(),
     generateExportableTallies = jest.fn(),
     auth = Dipped.fakeElectionManagerAuth(),
@@ -136,7 +132,8 @@ export function renderInAppContext(
         isOfficialResults,
         printer,
         printBallotRef,
-        saveCastVoteRecordFiles,
+        addCastVoteRecordFile,
+        clearCastVoteRecordFiles,
         saveElection,
         resetElection,
         markResultsOfficial,
@@ -148,8 +145,7 @@ export function renderInAppContext(
         fullElectionTally,
         isTabulationRunning,
         setIsTabulationRunning,
-        addExternalTally,
-        saveExternalTallies,
+        updateExternalTally,
         fullElectionExternalTallies,
         generateExportableTallies,
         saveTranscribedValue,

--- a/libs/types/src/tallies.ts
+++ b/libs/types/src/tallies.ts
@@ -82,6 +82,11 @@ export interface FullElectionExternalTally {
   readonly timestampCreated: Date;
 }
 
+export type FullElectionExternalTallies = ReadonlyMap<
+  ExternalTallySourceType,
+  FullElectionExternalTally
+>;
+
 export type OptionalExternalTally = Optional<ExternalTally>;
 export type OptionalFullElectionTally = Optional<FullElectionTally>;
 export type OptionalFullElectionExternalTally =


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
When making changes to CVRs, i.e. loading a new one or clearing the list, we previously would get the list of all the CVRs and build a new one from it, then set the whole thing again. Instead, we now have distinct operations for the actions we want to perform: `add` and `clear`.

This same thing applies to the external tallies, with the addition that we now enforce that there is only ever at most one of each external tally source type.

The next step here is to add API endpoints for the CVRs in the admin service corresponding to the `add` and `clear` actions.

## Demo Video or Screenshot
n/a

## Testing Plan 
Tested manually in VxAdmin with the exhaustive minimal sample election:
- [ ] loading CVRs, unique and duplicative
- [ ] clearing CVRs
- [ ] adding manually entered data
- [ ] adding external (SEMS) data

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
