### PR TITLE
Load env file from root of vxsuite and in scan service

### DIFF
--- a/frontends/bas/config/env.js
+++ b/frontends/bas/config/env.js
@@ -23,6 +23,8 @@ const dotenvFiles = [
   NODE_ENV !== 'test' && `${paths.dotenv}.local`,
   `${paths.dotenv}.${NODE_ENV}`,
   paths.dotenv,
+  NODE_ENV !== 'test' && `../../${paths.dotenv}.local`,
+  `../../${paths.dotenv}`,
 ].filter(Boolean);
 
 // Load environment variables from .env* files. Suppress warnings using silent

--- a/frontends/bmd/config/env.js
+++ b/frontends/bmd/config/env.js
@@ -23,6 +23,8 @@ const dotenvFiles = [
   NODE_ENV !== 'test' && `${paths.dotenv}.local`,
   `${paths.dotenv}.${NODE_ENV}`,
   paths.dotenv,
+  NODE_ENV !== 'test' && `../../${paths.dotenv}.local`,
+  `../../${paths.dotenv}`,
 ].filter(Boolean);
 
 // Load environment variables from .env* files. Suppress warnings using silent

--- a/frontends/bmd/vite.config.ts
+++ b/frontends/bmd/vite.config.ts
@@ -10,8 +10,9 @@ export default defineConfig(async (env) => {
   );
 
   const envPrefix = 'REACT_APP_';
-  const dotenvValues = loadEnv(env.mode, __dirname, envPrefix);
-  const processEnvDefines = Object.entries(dotenvValues).reduce<
+  const rootDotenvValues = loadEnv(env.mode, join(__dirname, '../..'), envPrefix);
+  const coreDotenvValues = loadEnv(env.mode, __dirname, envPrefix)
+  const processEnvDefines = [...Object.entries(rootDotenvValues), ...Object.entries(coreDotenvValues)].reduce<
     Record<string, string>
   >(
     (acc, [key, value]) => ({

--- a/frontends/bsd/config/env.js
+++ b/frontends/bsd/config/env.js
@@ -23,6 +23,8 @@ const dotenvFiles = [
   NODE_ENV !== 'test' && `${paths.dotenv}.local`,
   `${paths.dotenv}.${NODE_ENV}`,
   paths.dotenv,
+  NODE_ENV !== 'test' && `../../${paths.dotenv}.local`,
+  `../../${paths.dotenv}`,
 ].filter(Boolean);
 
 // Load environment variables from .env* files. Suppress warnings using silent

--- a/frontends/bsd/vite.config.ts
+++ b/frontends/bsd/vite.config.ts
@@ -10,8 +10,9 @@ export default defineConfig(async (env) => {
   );
 
   const envPrefix = 'REACT_APP_';
-  const dotenvValues = loadEnv(env.mode, __dirname, envPrefix);
-  const processEnvDefines = Object.entries(dotenvValues).reduce<
+  const rootDotenvValues = loadEnv(env.mode, join(__dirname, '../..'), envPrefix);
+  const coreDotenvValues = loadEnv(env.mode, __dirname, envPrefix)
+  const processEnvDefines = [...Object.entries(rootDotenvValues), ...Object.entries(coreDotenvValues)].reduce<
     Record<string, string>
   >(
     (acc, [key, value]) => ({

--- a/frontends/election-manager/config/env.js
+++ b/frontends/election-manager/config/env.js
@@ -23,6 +23,8 @@ const dotenvFiles = [
   NODE_ENV !== 'test' && `${paths.dotenv}.local`,
   `${paths.dotenv}.${NODE_ENV}`,
   paths.dotenv,
+  NODE_ENV !== 'test' && `../../${paths.dotenv}.local`,
+  `../../${paths.dotenv}`,
 ].filter(Boolean);
 
 // Load environment variables from .env* files. Suppress warnings using silent

--- a/frontends/election-manager/vite.config.ts
+++ b/frontends/election-manager/vite.config.ts
@@ -10,8 +10,9 @@ export default defineConfig(async (env) => {
   );
 
   const envPrefix = 'REACT_APP_';
-  const dotenvValues = loadEnv(env.mode, __dirname, envPrefix);
-  const processEnvDefines = Object.entries(dotenvValues).reduce<
+  const rootDotenvValues = loadEnv(env.mode, join(__dirname, '../..'), envPrefix);
+  const coreDotenvValues = loadEnv(env.mode, __dirname, envPrefix)
+  const processEnvDefines = [...Object.entries(rootDotenvValues), ...Object.entries(coreDotenvValues)].reduce<
     Record<string, string>
   >(
     (acc, [key, value]) => ({

--- a/frontends/precinct-scanner/config/env.js
+++ b/frontends/precinct-scanner/config/env.js
@@ -23,6 +23,8 @@ const dotenvFiles = [
   NODE_ENV !== 'test' && `${paths.dotenv}.local`,
   `${paths.dotenv}.${NODE_ENV}`,
   paths.dotenv,
+  NODE_ENV !== 'test' && `../../${paths.dotenv}.local`,
+  `../../${paths.dotenv}`,
 ].filter(Boolean);
 
 // Load environment variables from .env* files. Suppress warnings using silent

--- a/frontends/precinct-scanner/vite.config.ts
+++ b/frontends/precinct-scanner/vite.config.ts
@@ -10,8 +10,9 @@ export default defineConfig(async (env) => {
   );
 
   const envPrefix = 'REACT_APP_';
-  const dotenvValues = loadEnv(env.mode, __dirname, envPrefix);
-  const processEnvDefines = Object.entries(dotenvValues).reduce<
+  const rootDotenvValues = loadEnv(env.mode, join(__dirname, '../..'), envPrefix);
+  const coreDotenvValues = loadEnv(env.mode, __dirname, envPrefix)
+  const processEnvDefines = [...Object.entries(rootDotenvValues), ...Object.entries(coreDotenvValues)].reduce<
     Record<string, string>
   >(
     (acc, [key, value]) => ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2729,6 +2729,8 @@ importers:
       chalk: 4.1.0
       debug: 4.3.1
       deep-eql: 4.0.0
+      dotenv: 16.0.2
+      dotenv-expand: 9.0.0
       express: 4.18.0
       fs-extra: 9.0.1
       got: 11.8.2
@@ -2778,7 +2780,7 @@ importers:
       eslint-plugin-vx: link:../../libs/eslint-plugin-vx
       fast-check: 2.23.2
       is-ci-cli: 2.1.2
-      jest: 26.6.3
+      jest: 26.6.3_canvas@2.9.1
       jest-watch-typeahead: 0.6.4_jest@26.6.3
       lint-staged: 10.5.3
       nock: 13.1.0
@@ -2827,6 +2829,8 @@ importers:
       chalk: ^4.1.0
       debug: ^4.3.1
       deep-eql: ^4.0.0
+      dotenv: ^16.0.2
+      dotenv-expand: ^9.0.0
       esbuild: ^0.14.29
       esbuild-runner: ^2.2.1
       eslint: ^7.17.0
@@ -7766,6 +7770,43 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==
+  /@jest/core/26.6.3_canvas@2.9.1:
+    dependencies:
+      '@jest/console': 26.6.2
+      '@jest/reporters': 26.6.2
+      '@jest/test-result': 26.6.2
+      '@jest/transform': 26.6.2
+      '@jest/types': 26.6.2
+      '@types/node': 17.0.36
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.10
+      jest-changed-files: 26.6.2
+      jest-config: 26.6.3_canvas@2.9.1
+      jest-haste-map: 26.6.2
+      jest-message-util: 26.6.2
+      jest-regex-util: 26.0.0
+      jest-resolve: 26.6.2
+      jest-resolve-dependencies: 26.6.3
+      jest-runner: 26.6.3_canvas@2.9.1
+      jest-runtime: 26.6.3_canvas@2.9.1
+      jest-snapshot: 26.6.2
+      jest-util: 26.6.2
+      jest-validate: 26.6.2
+      jest-watcher: 26.6.2
+      micromatch: 4.0.5
+      p-each-series: 2.2.0
+      rimraf: 3.0.2
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      canvas: '*'
+    resolution:
+      integrity: sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==
   /@jest/core/27.3.1:
     dependencies:
       '@jest/console': 27.3.1
@@ -8544,6 +8585,20 @@ packages:
     dev: true
     engines:
       node: '>= 10.14.2'
+    resolution:
+      integrity: sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==
+  /@jest/test-sequencer/26.6.3_canvas@2.9.1:
+    dependencies:
+      '@jest/test-result': 26.6.2
+      graceful-fs: 4.2.10
+      jest-haste-map: 26.6.2
+      jest-runner: 26.6.3_canvas@2.9.1
+      jest-runtime: 26.6.3_canvas@2.9.1
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      canvas: '*'
     resolution:
       integrity: sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==
   /@jest/test-sequencer/27.3.1:
@@ -15884,6 +15939,18 @@ packages:
   /dotenv-expand/5.1.0:
     resolution:
       integrity: sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==
+  /dotenv-expand/9.0.0:
+    dev: false
+    engines:
+      node: '>=12'
+    resolution:
+      integrity: sha512-uW8Hrhp5ammm9x7kBLR6jDfujgaDarNA02tprvZdyrJ7MpdzD1KyrIHG4l+YoC2fJ2UcdFdNWNWIjt+sexBHJw==
+  /dotenv/16.0.2:
+    dev: false
+    engines:
+      node: '>=12'
+    resolution:
+      integrity: sha512-JvpYKUmzQhYoIFgK2MOnF3bciIZoItIIoryihy0rIA+H4Jy0FmgyKYAHCTN98P5ybGSJcIFbh6QKeJdtZd1qhA==
   /dotenv/8.2.0:
     engines:
       node: '>=8'
@@ -19107,7 +19174,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 5.21.0_4059d5ee7aba256d5e330151ee3418c0
       '@typescript-eslint/utils': 5.22.0_eslint@7.17.0+typescript@4.6.3
       eslint: 7.17.0
-      jest: 26.6.3
+      jest: 26.6.3_canvas@2.9.1
     dev: true
     engines:
       node: ^12.22.0 || ^14.17.0 || >=16.0.0
@@ -23603,6 +23670,29 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
+  /jest-cli/26.6.3_canvas@2.9.1:
+    dependencies:
+      '@jest/core': 26.6.3_canvas@2.9.1
+      '@jest/test-result': 26.6.2
+      '@jest/types': 26.6.2
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.10
+      import-local: 3.1.0
+      is-ci: 2.0.0
+      jest-config: 26.6.3_canvas@2.9.1
+      jest-util: 26.6.2
+      jest-validate: 26.6.2
+      prompts: 2.4.2
+      yargs: 15.4.1
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    hasBin: true
+    peerDependencies:
+      canvas: '*'
+    resolution:
+      integrity: sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
   /jest-cli/27.3.1:
     dependencies:
       '@jest/core': 27.3.1
@@ -23780,6 +23870,37 @@ packages:
     engines:
       node: '>= 10.14.2'
     peerDependencies:
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      ts-node:
+        optional: true
+    resolution:
+      integrity: sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==
+  /jest-config/26.6.3_canvas@2.9.1:
+    dependencies:
+      '@babel/core': 7.18.2
+      '@jest/test-sequencer': 26.6.3_canvas@2.9.1
+      '@jest/types': 26.6.2
+      babel-jest: 26.6.3_@babel+core@7.18.2
+      chalk: 4.1.2
+      deepmerge: 4.2.2
+      glob: 7.2.3
+      graceful-fs: 4.2.10
+      jest-environment-jsdom: 26.6.2_canvas@2.9.1
+      jest-environment-node: 26.6.2
+      jest-get-type: 26.3.0
+      jest-jasmine2: 26.6.3_canvas@2.9.1
+      jest-regex-util: 26.0.0
+      jest-resolve: 26.6.2
+      jest-util: 26.6.2
+      jest-validate: 26.6.2
+      micromatch: 4.0.5
+      pretty-format: 26.6.2
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      canvas: '*'
       ts-node: '>=9.0.0'
     peerDependenciesMeta:
       ts-node:
@@ -24226,6 +24347,22 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-jgPqCruTlt3Kwqg5/WVFyHIOJHsiAvhcp2qiR2QQstuG9yWox5+iHpU3ZrcBxW14T4fe5Z68jAfLRh7joCSP2Q==
+  /jest-environment-jsdom/26.6.2_canvas@2.9.1:
+    dependencies:
+      '@jest/environment': 26.6.2
+      '@jest/fake-timers': 26.6.2
+      '@jest/types': 26.6.2
+      '@types/node': 17.0.36
+      jest-mock: 26.6.2
+      jest-util: 26.6.2
+      jsdom: 16.7.0_canvas@2.9.1
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      canvas: '*'
+    resolution:
+      integrity: sha512-jgPqCruTlt3Kwqg5/WVFyHIOJHsiAvhcp2qiR2QQstuG9yWox5+iHpU3ZrcBxW14T4fe5Z68jAfLRh7joCSP2Q==
   /jest-environment-jsdom/27.3.1:
     dependencies:
       '@jest/environment': 27.3.1
@@ -24557,6 +24694,33 @@ packages:
     dev: true
     engines:
       node: '>= 10.14.2'
+    resolution:
+      integrity: sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==
+  /jest-jasmine2/26.6.3_canvas@2.9.1:
+    dependencies:
+      '@babel/traverse': 7.18.2
+      '@jest/environment': 26.6.2
+      '@jest/source-map': 26.6.2
+      '@jest/test-result': 26.6.2
+      '@jest/types': 26.6.2
+      '@types/node': 17.0.36
+      chalk: 4.1.2
+      co: 4.6.0
+      expect: 26.6.2
+      is-generator-fn: 2.1.0
+      jest-each: 26.6.2
+      jest-matcher-utils: 26.6.2
+      jest-message-util: 26.6.2
+      jest-runtime: 26.6.3_canvas@2.9.1
+      jest-snapshot: 26.6.2
+      jest-util: 26.6.2
+      pretty-format: 26.6.2
+      throat: 5.0.0
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      canvas: '*'
     resolution:
       integrity: sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==
   /jest-jasmine2/27.3.1:
@@ -25186,6 +25350,35 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==
+  /jest-runner/26.6.3_canvas@2.9.1:
+    dependencies:
+      '@jest/console': 26.6.2
+      '@jest/environment': 26.6.2
+      '@jest/test-result': 26.6.2
+      '@jest/types': 26.6.2
+      '@types/node': 17.0.36
+      chalk: 4.1.2
+      emittery: 0.7.2
+      exit: 0.1.2
+      graceful-fs: 4.2.10
+      jest-config: 26.6.3_canvas@2.9.1
+      jest-docblock: 26.0.0
+      jest-haste-map: 26.6.2
+      jest-leak-detector: 26.6.2
+      jest-message-util: 26.6.2
+      jest-resolve: 26.6.2
+      jest-runtime: 26.6.3_canvas@2.9.1
+      jest-util: 26.6.2
+      jest-worker: 26.6.2
+      source-map-support: 0.5.21
+      throat: 5.0.0
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      canvas: '*'
+    resolution:
+      integrity: sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==
   /jest-runner/27.3.1:
     dependencies:
       '@jest/console': 27.3.1
@@ -25333,6 +25526,43 @@ packages:
     engines:
       node: '>= 10.14.2'
     hasBin: true
+    resolution:
+      integrity: sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==
+  /jest-runtime/26.6.3_canvas@2.9.1:
+    dependencies:
+      '@jest/console': 26.6.2
+      '@jest/environment': 26.6.2
+      '@jest/fake-timers': 26.6.2
+      '@jest/globals': 26.6.2
+      '@jest/source-map': 26.6.2
+      '@jest/test-result': 26.6.2
+      '@jest/transform': 26.6.2
+      '@jest/types': 26.6.2
+      '@types/yargs': 15.0.14
+      chalk: 4.1.2
+      cjs-module-lexer: 0.6.0
+      collect-v8-coverage: 1.0.1
+      exit: 0.1.2
+      glob: 7.2.3
+      graceful-fs: 4.2.10
+      jest-config: 26.6.3_canvas@2.9.1
+      jest-haste-map: 26.6.2
+      jest-message-util: 26.6.2
+      jest-mock: 26.6.2
+      jest-regex-util: 26.0.0
+      jest-resolve: 26.6.2
+      jest-snapshot: 26.6.2
+      jest-util: 26.6.2
+      jest-validate: 26.6.2
+      slash: 3.0.0
+      strip-bom: 4.0.0
+      yargs: 15.4.1
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    hasBin: true
+    peerDependencies:
+      canvas: '*'
     resolution:
       integrity: sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==
   /jest-runtime/27.3.1:
@@ -25867,7 +26097,7 @@ packages:
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
-      jest: 26.6.3
+      jest: 26.6.3_canvas@2.9.1
       jest-regex-util: 27.5.1
       jest-watcher: 27.5.1
       slash: 3.0.0
@@ -26131,6 +26361,19 @@ packages:
     engines:
       node: '>= 10.14.2'
     hasBin: true
+    resolution:
+      integrity: sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
+  /jest/26.6.3_canvas@2.9.1:
+    dependencies:
+      '@jest/core': 26.6.3_canvas@2.9.1
+      import-local: 3.1.0
+      jest-cli: 26.6.3_canvas@2.9.1
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    hasBin: true
+    peerDependencies:
+      canvas: '*'
     resolution:
       integrity: sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
   /jest/27.3.1:
@@ -32994,7 +33237,7 @@ packages:
       bs-logger: 0.2.6
       buffer-from: 1.1.1
       fast-json-stable-stringify: 2.1.0
-      jest: 26.6.3
+      jest: 26.6.3_canvas@2.9.1
       jest-util: 26.6.2
       json5: 2.1.3
       lodash.memoize: 4.1.2

--- a/services/scan/package.json
+++ b/services/scan/package.json
@@ -56,6 +56,8 @@
     "chalk": "^4.1.0",
     "debug": "^4.3.1",
     "deep-eql": "^4.0.0",
+    "dotenv": "^16.0.2",
+    "dotenv-expand": "^9.0.0",
     "express": "^4.18.0",
     "fs-extra": "^9.0.1",
     "got": "^11.8.2",

--- a/services/scan/src/index.ts
+++ b/services/scan/src/index.ts
@@ -2,16 +2,45 @@
 import { MockScannerClient, ScannerClient } from '@votingworks/plustek-sdk';
 import { Logger, LogSource, LogEventId } from '@votingworks/logging';
 import { ok, Result } from '@votingworks/types';
+import fs from 'fs';
+import * as dotenv from 'dotenv';
+import * as dotenvExpand from 'dotenv-expand';
 import {
   MOCK_SCANNER_FILES,
   MOCK_SCANNER_HTTP,
   MOCK_SCANNER_PORT,
   VX_MACHINE_TYPE,
+  NODE_ENV,
 } from './globals';
 import { LoopScanner, parseBatchesFromEnv } from './loop_scanner';
 import { BatchScanner } from './fujitsu_scanner';
 import * as server from './server';
 import { plustekMockServer } from './plustek_mock_server';
+
+// https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
+const dotEnvPath = '.env';
+const dotenvFiles: string[] = [
+  `${dotEnvPath}.${NODE_ENV}.local`,
+  // Don't include `.env.local` for `test` environment
+  // since normally you expect tests to produce the same
+  // results for everyone
+  NODE_ENV !== 'test' ? `${dotEnvPath}.local` : '',
+  `${dotEnvPath}.${NODE_ENV}`,
+  dotEnvPath,
+  NODE_ENV !== 'test' ? `../../${dotEnvPath}.local` : '',
+  `../../${dotEnvPath}`,
+].filter(Boolean);
+
+// Load environment variables from .env* files. Suppress warnings using silent
+// if this file is missing. dotenv will never modify any environment variables
+// that have already been set.  Variable expansion is supported in .env files.
+// https://github.com/motdotla/dotenv
+// https://github.com/motdotla/dotenv-expand
+for (const dotenvFile of dotenvFiles) {
+  if (fs.existsSync(dotenvFile)) {
+    dotenvExpand.expand(dotenv.config({ path: dotenvFile }));
+  }
+}
 
 const logger = new Logger(LogSource.VxScanService);
 


### PR DESCRIPTION
## Overview
Addresses https://github.com/votingworks/vxsuite/issues/2518 and takes a first step towards https://github.com/votingworks/vxsuite/issues/2442

This will cause all of the frontend react apps, and the scan-service to load environment variables from .env files both at the repo level AND at the root of vxsuite. A file in the subrepo for a particular app will supersede one at the root level. I think this will make environment variable management easier by being able to have a file just at the root level of vxsuite, that will be particularly convenient for VxDev. Next I want to colocate all of the feature flagging configuration in a shared library with a script that can autogenerate a .env file and place it at the root so that people know where to look for what environment variables can be set and configure as they want to. VxDev will then also be able to run this script. 

## Demo Video or Screenshot

## Testing Plan 
Placed env files at both the local subrepo level and the root of vxsuite, running frontends with both pnpm start and running production builds saw the variables loaded with the subrepo overriding anything at the root level. 

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
