### PR TITLE
refactor(admin): store CVRs in `admin` backend

### DIFF
--- a/frontends/election-manager/src/app_root.tsx
+++ b/frontends/election-manager/src/app_root.tsx
@@ -31,7 +31,6 @@ import {
 } from './lib/votecounting';
 
 import { AppContext } from './contexts/app_context';
-import { AddCastVoteRecordFile } from './utils/cast_vote_record_files';
 import { ElectionManager } from './components/election_manager';
 import {
   SaveElection,
@@ -44,7 +43,10 @@ import {
 } from './config/types';
 import { useElectionManagerStore } from './hooks/use_election_manager_store';
 import { getExportableTallies } from './utils/exportable_tallies';
-import { ElectionManagerStoreBackend } from './lib/backends/types';
+import {
+  AddCastVoteRecordFileResult,
+  ElectionManagerStoreBackend,
+} from './lib/backends/types';
 
 export interface Props {
   logger: Logger;
@@ -181,9 +183,9 @@ export function AppRoot({
     [store]
   );
 
-  const addCastVoteRecordFile: AddCastVoteRecordFile = useCallback(
-    async (newCvrFile) => {
-      await store.addCastVoteRecordFile(newCvrFile);
+  const addCastVoteRecordFile = useCallback(
+    async (newCvrFile: File): Promise<AddCastVoteRecordFileResult> => {
+      return await store.addCastVoteRecordFile(newCvrFile);
     },
     [store]
   );

--- a/frontends/election-manager/src/components/import_cvrfiles_modal.test.tsx
+++ b/frontends/election-manager/src/components/import_cvrfiles_modal.test.tsx
@@ -20,6 +20,7 @@ import {
   eitherNeitherElectionDefinition,
 } from '../../test/render_in_app_context';
 import { CastVoteRecordFiles } from '../utils/cast_vote_record_files';
+import { AddCastVoteRecordFileResult } from '../lib/backends';
 
 const TEST_FILE1 = 'TEST__machine_0001__10_ballots__2020-12-09_15-49-32.jsonl';
 const TEST_FILE2 = 'TEST__machine_0003__5_ballots__2020-12-07_15-49-32.jsonl';
@@ -75,7 +76,7 @@ describe('Screens display properly when USB is mounted', () => {
 
   test('No files found screen shows when mounted usb has no valid files', async () => {
     const closeFn = jest.fn();
-    const addCvr = jest.fn();
+    const addCvr = jest.fn<Promise<AddCastVoteRecordFileResult>, [File]>();
     const logger = fakeLogger();
     const { getByText, getByTestId } = renderInAppContext(
       <ImportCvrFilesModal onClose={closeFn} />,
@@ -94,6 +95,12 @@ describe('Screens display properly when USB is mounted', () => {
     fireEvent.click(getByText('Cancel'));
     expect(closeFn).toHaveBeenCalledTimes(1);
 
+    addCvr.mockResolvedValueOnce({
+      wasExistingFile: false,
+      newlyAdded: 0,
+      alreadyPresent: 0,
+    });
+
     // You can still manually load files
     fireEvent.change(getByTestId('manual-input'), {
       target: { files: [new File([''], 'file.jsonl')] },
@@ -109,7 +116,7 @@ describe('Screens display properly when USB is mounted', () => {
 
   test('Load CVR files screen shows table with test and live CVRs', async () => {
     const closeFn = jest.fn();
-    const addCvr = jest.fn();
+    const addCvr = jest.fn<Promise<AddCastVoteRecordFileResult>, [File]>();
     const fileEntries = [
       {
         name: LIVE_FILE1,
@@ -171,6 +178,11 @@ describe('Screens display properly when USB is mounted', () => {
     fireEvent.click(getByText('Cancel'));
     expect(closeFn).toHaveBeenCalledTimes(1);
 
+    addCvr.mockResolvedValueOnce({
+      wasExistingFile: false,
+      newlyAdded: 0,
+      alreadyPresent: 0,
+    });
     fireEvent.click(domGetByText(tableRows[0], 'Load'));
     getByText('Loading');
     await waitFor(() => {
@@ -188,7 +200,7 @@ describe('Screens display properly when USB is mounted', () => {
 
   test('Can handle errors appropriately', async () => {
     const closeFn = jest.fn();
-    const addCvr = jest.fn();
+    const addCvr = jest.fn<Promise<AddCastVoteRecordFileResult>, [File]>();
     const logger = fakeLogger();
     const fileEntries = [
       {
@@ -233,6 +245,7 @@ describe('Screens display properly when USB is mounted', () => {
     );
     expect(window.kiosk!.readFile).toHaveBeenCalledTimes(3); // The files should have been read.
 
+    addCvr.mockRejectedValueOnce(new Error('test error'));
     fireEvent.change(getByTestId('manual-input'), {
       target: { files: [new File(['invalid-file-contents'], 'file.jsonl')] },
     });
@@ -252,7 +265,7 @@ describe('Screens display properly when USB is mounted', () => {
 
   test('Load CVR files screen locks to test mode when test files have been loaded', async () => {
     const closeFn = jest.fn();
-    const addCvr = jest.fn();
+    const addCvr = jest.fn<Promise<AddCastVoteRecordFileResult>, [File]>();
     const logger = fakeLogger();
     const fileEntries = [
       {
@@ -343,6 +356,11 @@ describe('Screens display properly when USB is mounted', () => {
     fireEvent.click(getByText('Cancel'));
     expect(closeFn).toHaveBeenCalledTimes(1);
 
+    addCvr.mockResolvedValueOnce({
+      wasExistingFile: true,
+      newlyAdded: 0,
+      alreadyPresent: 0,
+    });
     fireEvent.click(domGetByText(tableRows[1], 'Load'));
     getByText('Loading');
     await waitFor(() => {
@@ -362,7 +380,7 @@ describe('Screens display properly when USB is mounted', () => {
 
   test('Load CVR files screen locks to live mode when live files have been loaded', async () => {
     const closeFn = jest.fn();
-    const addCvr = jest.fn();
+    const addCvr = jest.fn<Promise<AddCastVoteRecordFileResult>, [File]>();
     const fileEntries = [
       {
         name: LIVE_FILE1,
@@ -412,6 +430,11 @@ describe('Screens display properly when USB is mounted', () => {
     expect(tableRows).toHaveLength(1);
     domGetByText(tableRows[0], '12/09/2020 03:59:32 PM');
     domGetByText(tableRows[0], '0002');
+    addCvr.mockResolvedValueOnce({
+      wasExistingFile: false,
+      newlyAdded: 0,
+      alreadyPresent: 0,
+    });
     expect(domGetByText(tableRows[0], 'Load').closest('button')!.disabled).toBe(
       false
     );
@@ -430,7 +453,7 @@ describe('Screens display properly when USB is mounted', () => {
 
   test('Shows previously loaded files when all files have already been loaded', async () => {
     const closeFn = jest.fn();
-    const addCvr = jest.fn();
+    const addCvr = jest.fn<Promise<AddCastVoteRecordFileResult>, [File]>();
     const fileEntries = [
       {
         name: LIVE_FILE1,

--- a/frontends/election-manager/src/contexts/app_context.ts
+++ b/frontends/election-manager/src/contexts/app_context.ts
@@ -21,6 +21,7 @@ import {
 import { CastVoteRecordFiles } from '../utils/cast_vote_record_files';
 import { getEmptyFullElectionTally } from '../lib/votecounting';
 import { getEmptyExportableTallies } from '../utils/exportable_tallies';
+import { AddCastVoteRecordFileResult } from '../lib/backends/types';
 
 export interface AppContextInterface {
   castVoteRecordFiles: CastVoteRecordFiles;
@@ -30,7 +31,7 @@ export interface AppContextInterface {
   isOfficialResults: boolean;
   printer: Printer;
   printBallotRef?: RefObject<HTMLElement>;
-  addCastVoteRecordFile: (newCastVoteRecordFile: File) => Promise<void>;
+  addCastVoteRecordFile: (file: File) => Promise<AddCastVoteRecordFileResult>;
   clearCastVoteRecordFiles: () => Promise<void>;
   saveElection: SaveElection;
   resetElection: ResetElection;
@@ -67,7 +68,11 @@ const appContext: AppContextInterface = {
   isOfficialResults: false,
   printer: new NullPrinter(),
   printBallotRef: undefined,
-  addCastVoteRecordFile: async () => undefined,
+  addCastVoteRecordFile: async () => ({
+    wasExistingFile: false,
+    newlyAdded: 0,
+    alreadyPresent: 0,
+  }),
   clearCastVoteRecordFiles: async () => undefined,
   saveElection: async () => undefined,
   resetElection: async () => undefined,

--- a/frontends/election-manager/src/hooks/use_election_manager_store.ts
+++ b/frontends/election-manager/src/hooks/use_election_manager_store.ts
@@ -15,7 +15,10 @@ import {
 import { assert, typedAs } from '@votingworks/utils';
 import { useCallback, useMemo, useRef } from 'react';
 import { PrintedBallot } from '../config/types';
-import { ElectionManagerStoreBackend } from '../lib/backends/types';
+import {
+  AddCastVoteRecordFileResult,
+  ElectionManagerStoreBackend,
+} from '../lib/backends/types';
 import { CastVoteRecordFiles } from '../utils/cast_vote_record_files';
 
 export interface ElectionManagerStore {
@@ -64,7 +67,9 @@ export interface ElectionManagerStore {
   /**
    * Adds a new cast vote record file.
    */
-  addCastVoteRecordFile(newCastVoteRecordFile: File): Promise<void>;
+  addCastVoteRecordFile(
+    newCastVoteRecordFile: File
+  ): Promise<AddCastVoteRecordFileResult>;
 
   /**
    * Resets all cast vote record files.
@@ -239,7 +244,7 @@ export function useElectionManagerStore({
 
   const addCastVoteRecordFileMutation = useMutation(
     async (newCastVoteRecordFile: File) => {
-      await backend.addCastVoteRecordFile(newCastVoteRecordFile);
+      return await backend.addCastVoteRecordFile(newCastVoteRecordFile);
     },
     {
       onSuccess() {
@@ -250,7 +255,9 @@ export function useElectionManagerStore({
 
   const addCastVoteRecordFile = useCallback(
     async (newCastVoteRecordFile: File) => {
-      await addCastVoteRecordFileMutation.mutateAsync(newCastVoteRecordFile);
+      return await addCastVoteRecordFileMutation.mutateAsync(
+        newCastVoteRecordFile
+      );
     },
     [addCastVoteRecordFileMutation]
   );

--- a/frontends/election-manager/src/lib/backends/admin_backend.test.ts
+++ b/frontends/election-manager/src/lib/backends/admin_backend.test.ts
@@ -16,13 +16,11 @@ const getElectionsResponse: Admin.GetElectionsResponse = [
     id: 'test-election-1',
     electionDefinition: electionWithMsEitherNeitherDefinition,
     createdAt: '2021-01-01T00:00:00.000Z',
-    updatedAt: '2021-01-01T00:00:00.000Z',
   },
   {
     id: 'test-election-2',
     electionDefinition: electionMinimalExhaustiveSampleDefinition,
     createdAt: '2022-01-01T00:00:00.000Z',
-    updatedAt: '2022-01-01T00:00:00.000Z',
   },
 ];
 

--- a/frontends/election-manager/src/lib/backends/backends.test.ts
+++ b/frontends/election-manager/src/lib/backends/backends.test.ts
@@ -75,7 +75,6 @@ function makeAdminBackend(): ElectionManagerStoreAdminBackend {
             Admin.PostElectionRequestSchema
           ).unsafeUnwrap(),
           createdAt: new Date().toISOString(),
-          updatedAt: new Date().toISOString(),
         },
         castVoteRecordFiles: CastVoteRecordFiles.empty,
       });

--- a/frontends/election-manager/src/lib/backends/backends.test.ts
+++ b/frontends/election-manager/src/lib/backends/backends.test.ts
@@ -6,6 +6,7 @@ import {
 import { fakeLogger } from '@votingworks/logging';
 import {
   ExternalTallySourceType,
+  Id,
   safeParseJson,
   VotingMethod,
 } from '@votingworks/types';
@@ -13,6 +14,7 @@ import { MemoryStorage, typedAs } from '@votingworks/utils';
 import fetchMock from 'fetch-mock';
 import { eitherNeitherElectionDefinition } from '../../../test/render_in_app_context';
 import { PrintedBallot } from '../../config/types';
+import { CastVoteRecordFiles } from '../../utils/cast_vote_record_files';
 import { convertTalliesByPrecinctToFullExternalTally } from '../../utils/external_tallies';
 import { ElectionManagerStoreAdminBackend } from './admin_backend';
 import { ElectionManagerStoreMemoryBackend } from './memory_backend';
@@ -47,32 +49,76 @@ function makeAdminBackend(): ElectionManagerStoreAdminBackend {
   const logger = fakeLogger();
 
   let nextElectionIndex = 1;
-  let elections: Admin.ElectionRecord[] = [];
+  const db = new Map<
+    Id,
+    {
+      electionRecord: Admin.ElectionRecord;
+      castVoteRecordFiles: CastVoteRecordFiles;
+    }
+  >();
+
   fetchMock
     .reset()
     .get('/admin/elections', () => ({
-      body: typedAs<Admin.GetElectionsResponse>(elections),
+      body: typedAs<Admin.GetElectionsResponse>(
+        Array.from(db.values()).map(({ electionRecord }) => electionRecord)
+      ),
     }))
     .post('/admin/elections', (url, request) => {
       const id = `test-election-${nextElectionIndex}`;
       nextElectionIndex += 1;
-      elections.push({
-        id,
-        electionDefinition: safeParseJson(
-          request.body as string,
-          Admin.PostElectionRequestSchema
-        ).unsafeUnwrap(),
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
+      db.set(id, {
+        electionRecord: {
+          id,
+          electionDefinition: safeParseJson(
+            request.body as string,
+            Admin.PostElectionRequestSchema
+          ).unsafeUnwrap(),
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+        castVoteRecordFiles: CastVoteRecordFiles.empty,
       });
       return {
         body: typedAs<Admin.PostElectionResponse>({ status: 'ok', id }),
       };
     })
     .delete('glob:/admin/elections/*', (url) => {
-      const match = url.match(/\/admin\/elections\/(.+)/);
-      elections = elections.filter((e) => e.id !== match?.[1]);
+      const match = url.match(/^\/admin\/elections\/(.+)$/);
+      db.delete(match?.[1] ?? '');
       return { body: typedAs<Admin.DeleteElectionResponse>({ status: 'ok' }) };
+    })
+    .post('glob:/admin/elections/*/cvr-files', async (url, request) => {
+      const match = url.match(/^\/admin\/elections\/(.+)\/cvr-files$/);
+      const body = request.body as FormData;
+      const cvrFile = body.get('cvrFile') as File | undefined;
+
+      const electionId = match?.[1] as Id;
+      const dbEntry = electionId && db.get(electionId);
+
+      if (!dbEntry || !cvrFile) {
+        return { status: 404 };
+      }
+
+      const newCastVoteRecordFiles = await dbEntry.castVoteRecordFiles.add(
+        cvrFile,
+        dbEntry.electionRecord.electionDefinition.election
+      );
+      const addedFile = newCastVoteRecordFiles.fileList.find(
+        (f) => f.name === cvrFile.name
+      )!;
+
+      return {
+        body: typedAs<Admin.PostCvrFileResponse>({
+          status: 'ok',
+          id: `${electionId};${cvrFile.name}`,
+          wasExistingFile: newCastVoteRecordFiles.duplicateFiles.includes(
+            addedFile.name
+          ),
+          newlyAdded: addedFile.importedCvrCount,
+          alreadyPresent: addedFile.duplicatedCvrCount,
+        }),
+      };
     });
 
   return new ElectionManagerStoreAdminBackend({

--- a/frontends/election-manager/src/lib/backends/storage_backend.ts
+++ b/frontends/election-manager/src/lib/backends/storage_backend.ts
@@ -16,7 +16,10 @@ import {
   convertExternalTalliesToStorageString,
   convertStorageStringToExternalTallies,
 } from '../../utils/external_tallies';
-import { ElectionManagerStoreBackend } from './types';
+import {
+  AddCastVoteRecordFileResult,
+  ElectionManagerStoreBackend,
+} from './types';
 
 const electionDefinitionStorageKey = 'electionDefinition';
 const cvrsStorageKey = 'cvrFiles';
@@ -159,7 +162,9 @@ export class ElectionManagerStoreStorageBackend
     }
   }
 
-  async addCastVoteRecordFile(newCastVoteRecordFile: File): Promise<void> {
+  async addCastVoteRecordFile(
+    newCastVoteRecordFile: File
+  ): Promise<AddCastVoteRecordFileResult> {
     const loadElectionResult =
       await this.loadElectionDefinitionAndConfiguredAt();
 
@@ -180,6 +185,21 @@ export class ElectionManagerStoreStorageBackend
       newCastVoteRecordFiles.export(),
       'Cast vote records'
     );
+
+    const wasExistingFile = newCastVoteRecordFiles.duplicateFiles.includes(
+      newCastVoteRecordFile.name
+    );
+    const file = newCastVoteRecordFiles.fileList.find(
+      (f) => f.name === newCastVoteRecordFile.name
+    );
+    const newlyAdded = file?.importedCvrCount ?? 0;
+    const alreadyPresent = file?.duplicatedCvrCount ?? 0;
+
+    return {
+      wasExistingFile,
+      newlyAdded,
+      alreadyPresent,
+    };
   }
 
   async clearCastVoteRecordFiles(): Promise<void> {

--- a/frontends/election-manager/src/lib/backends/types.ts
+++ b/frontends/election-manager/src/lib/backends/types.ts
@@ -8,6 +8,12 @@ import {
 import { PrintedBallot } from '../../config/types';
 import { CastVoteRecordFiles } from '../../utils/cast_vote_record_files';
 
+export interface AddCastVoteRecordFileResult {
+  readonly wasExistingFile: boolean;
+  readonly newlyAdded: number;
+  readonly alreadyPresent: number;
+}
+
 export interface ElectionManagerStoreBackend {
   /**
    * Resets all stored data, including the election definition and CVRs.
@@ -37,7 +43,9 @@ export interface ElectionManagerStoreBackend {
   /**
    * Adds a new cast vote record file.
    */
-  addCastVoteRecordFile(newCastVoteRecordFile: File): Promise<void>;
+  addCastVoteRecordFile(
+    newCastVoteRecordFile: File
+  ): Promise<AddCastVoteRecordFileResult>;
 
   /**
    * Resets all cast vote record files.

--- a/frontends/election-manager/src/utils/cast_vote_record_files.ts
+++ b/frontends/election-manager/src/utils/cast_vote_record_files.ts
@@ -1,11 +1,11 @@
-import arrayUnique from 'array-unique';
-import { sha256 } from 'js-sha256';
 import { CastVoteRecord, Election } from '@votingworks/types';
 import { assert, parseCvrFileInfoFromFilename } from '@votingworks/utils';
+import arrayUnique from 'array-unique';
+import { sha256 } from 'js-sha256';
 import {
   CastVoteRecordFile,
-  CastVoteRecordFilePreprocessedData,
   CastVoteRecordFileMode,
+  CastVoteRecordFilePreprocessedData,
 } from '../config/types';
 import { readFileAsync } from '../lib/read_file_async';
 import { parseCvrs } from '../lib/votecounting';
@@ -463,5 +463,3 @@ export class CastVoteRecordFiles {
     return this.fileList.length > 0 || Boolean(this.lastError);
   }
 }
-
-export type AddCastVoteRecordFile = (value: File) => Promise<void>;

--- a/frontends/election-manager/test/render_in_app_context.tsx
+++ b/frontends/election-manager/test/render_in_app_context.tsx
@@ -26,10 +26,8 @@ import {
   MachineConfig,
   ResetElection,
 } from '../src/config/types';
-import {
-  AddCastVoteRecordFile,
-  CastVoteRecordFiles,
-} from '../src/utils/cast_vote_record_files';
+import { CastVoteRecordFiles } from '../src/utils/cast_vote_record_files';
+import { AddCastVoteRecordFileResult } from '../src/lib/backends/types';
 import { getEmptyFullElectionTally } from '../src/lib/votecounting';
 
 export const eitherNeitherElectionDefinition =
@@ -50,7 +48,7 @@ interface RenderInAppContextParams {
     adjudicationId: AdjudicationId,
     transcribedValue: string
   ) => Promise<void>;
-  addCastVoteRecordFile?: AddCastVoteRecordFile;
+  addCastVoteRecordFile?: (file: File) => Promise<AddCastVoteRecordFileResult>;
   clearCastVoteRecordFiles?: () => Promise<void>;
   saveIsOfficialResults?: () => Promise<void>;
   resetFiles?: () => Promise<void>;

--- a/libs/api/src/services/admin/index.test.ts
+++ b/libs/api/src/services/admin/index.test.ts
@@ -1,0 +1,22 @@
+import { unsafeParse } from '@votingworks/types';
+import {
+  GetWriteInAdjudicationsQueryParamsSchema,
+  PostCvrFileQueryParamsSchema,
+} from '.';
+
+test('PostCvrFileQueryParamsSchema', () => {
+  expect(unsafeParse(PostCvrFileQueryParamsSchema, {})).toEqual({});
+  expect(
+    unsafeParse(PostCvrFileQueryParamsSchema, { analyzeOnly: 'true' })
+  ).toEqual({ analyzeOnly: true });
+  expect(
+    unsafeParse(PostCvrFileQueryParamsSchema, { analyzeOnly: 'false' })
+  ).toEqual({ analyzeOnly: false });
+});
+
+test('GetWriteInAdjudicationsQueryParamsSchema', () => {
+  expect(unsafeParse(GetWriteInAdjudicationsQueryParamsSchema, {})).toEqual({});
+  expect(
+    unsafeParse(GetWriteInAdjudicationsQueryParamsSchema, { limit: '1' })
+  ).toEqual({ limit: 1 });
+});

--- a/libs/api/src/services/admin/index.ts
+++ b/libs/api/src/services/admin/index.ts
@@ -26,7 +26,6 @@ export interface ElectionRecord {
   readonly id: Id;
   readonly electionDefinition: ElectionDefinition;
   readonly createdAt: Iso8601Timestamp;
-  readonly updatedAt: Iso8601Timestamp;
 }
 
 /**
@@ -36,11 +35,10 @@ export const ElectionRecordSchema: z.ZodSchema<ElectionRecord> = z.object({
   id: IdSchema,
   electionDefinition: ElectionDefinitionSchema,
   createdAt: Iso8601TimestampSchema,
-  updatedAt: Iso8601TimestampSchema,
 });
 
 /**
- * A cast vote record's metadata.
+ * A cast vote record file's metadata.
  */
 export interface CastVoteRecordFileMetadata {
   readonly id: Id;
@@ -48,7 +46,6 @@ export interface CastVoteRecordFileMetadata {
   readonly filename: string;
   readonly sha256Hash: string;
   readonly createdAt: Iso8601Timestamp;
-  readonly updatedAt: Iso8601Timestamp;
 }
 
 /**
@@ -61,7 +58,6 @@ export const CastVoteRecordFileMetadataSchema: z.ZodSchema<CastVoteRecordFileMet
     filename: z.string().nonempty(),
     sha256Hash: z.string().nonempty(),
     createdAt: Iso8601TimestampSchema,
-    updatedAt: Iso8601TimestampSchema,
   });
 
 /**
@@ -82,7 +78,6 @@ export const CastVoteRecordFileRecordSchema: z.ZodSchema<CastVoteRecordFileRecor
     data: z.string(),
     sha256Hash: z.string().nonempty(),
     createdAt: Iso8601TimestampSchema,
-    updatedAt: Iso8601TimestampSchema,
   });
 
 /**
@@ -93,7 +88,6 @@ export interface CastVoteRecordFileEntryRecord {
   readonly electionId: Id;
   readonly data: string;
   readonly createdAt: Iso8601Timestamp;
-  readonly updatedAt: Iso8601Timestamp;
 }
 
 /**
@@ -105,7 +99,6 @@ export const CastVoteRecordFileEntryRecordSchema: z.ZodSchema<CastVoteRecordFile
     electionId: IdSchema,
     data: z.string(),
     createdAt: Iso8601TimestampSchema,
-    updatedAt: Iso8601TimestampSchema,
   });
 
 /**

--- a/libs/api/src/services/admin/index.ts
+++ b/libs/api/src/services/admin/index.ts
@@ -1,10 +1,15 @@
 import {
+  ContestId,
+  ContestIdSchema,
+  ContestOptionId,
+  ContestOptionIdSchema,
   ElectionDefinition,
   ElectionDefinitionSchema,
   Id,
   IdSchema,
   Iso8601Timestamp,
   Iso8601TimestampSchema,
+  safeParseNumber,
 } from '@votingworks/types';
 import * as z from 'zod';
 import {
@@ -101,6 +106,96 @@ export const CastVoteRecordFileEntryRecordSchema: z.ZodSchema<CastVoteRecordFile
     data: z.string(),
     createdAt: Iso8601TimestampSchema,
     updatedAt: Iso8601TimestampSchema,
+  });
+
+/**
+ * Status values for a write-in adjudication.
+ */
+export type WriteInAdjudicationStatus =
+  | 'pending'
+  | 'transcribed'
+  | 'adjudicated';
+
+/**
+ * Schema for {@link WriteInAdjudicationStatus}.
+ */
+export const WriteInAdjudicationStatusSchema: z.ZodSchema<WriteInAdjudicationStatus> =
+  z.union([
+    z.literal('pending'),
+    z.literal('transcribed'),
+    z.literal('adjudicated'),
+  ]);
+
+/**
+ * Information about a write-in adjudication.
+ */
+export interface WriteInRecord {
+  readonly id: Id;
+  readonly contestId: ContestId;
+  readonly optionId: ContestOptionId;
+  readonly castVoteRecordId: Id;
+  readonly status: WriteInAdjudicationStatus;
+  readonly transcribedValue?: string;
+  readonly adjudicatedOptionId?: ContestOptionId;
+  readonly adjudicatedValue?: string;
+}
+
+/**
+ * Schema for {@link WriteInRecord}.
+ */
+export const WriteInsRecordSchema: z.ZodSchema<WriteInRecord> = z.object({
+  id: IdSchema,
+  contestId: ContestIdSchema,
+  optionId: ContestOptionIdSchema,
+  castVoteRecordId: IdSchema,
+  status: WriteInAdjudicationStatusSchema,
+  transcribedValue: z.string().nonempty().optional(),
+  adjudicatedOptionId: ContestOptionIdSchema.optional(),
+  adjudicatedValue: z.string().nonempty().optional(),
+});
+
+/**
+ * Write-in adjudication information.
+ */
+export interface WriteInAdjudicationRecord {
+  readonly id: Id;
+  readonly contestId: ContestId;
+  readonly transcribedValue: string;
+  readonly adjudicatedValue?: string;
+  readonly adjudicatedOptionId?: ContestOptionId;
+}
+
+/**
+ * Schema for {@link WriteInAdjudicationRecord}.
+ */
+export const WriteInAdjudicationRecordSchema: z.ZodSchema<WriteInAdjudicationRecord> =
+  z.object({
+    id: IdSchema,
+    contestId: ContestIdSchema,
+    transcribedValue: z.string().nonempty(),
+    adjudicatedValue: z.string().nonempty().optional(),
+    adjudicatedOptionId: ContestOptionIdSchema.optional(),
+  });
+
+/**
+ * Write-in summary information.
+ */
+export interface WriteInSummaryEntry {
+  readonly contestId: ContestId;
+  readonly transcribedValue?: string;
+  readonly writeInCount: number;
+  readonly writeInAdjudication?: WriteInAdjudicationRecord;
+}
+
+/**
+ * Schema for {@link WriteInSummaryEntry}.
+ */
+export const WriteInSummaryEntrySchema: z.ZodSchema<WriteInSummaryEntry> =
+  z.object({
+    contestId: ContestIdSchema,
+    transcribedValue: z.string().nonempty().optional(),
+    writeInCount: z.number().int().min(1),
+    writeInAdjudication: WriteInAdjudicationRecordSchema.optional(),
   });
 
 /**
@@ -211,7 +306,7 @@ export type PostCvrFileResponse =
   | ErrorsResponse;
 
 /**
- * @url /admin/elections/:electionId/cvrs
+ * @url /admin/elections/:electionId/cvr-files
  * @method POST
  */
 export const PostCvrFileResponseSchema: z.ZodSchema<PostCvrFileResponse> =
@@ -225,6 +320,26 @@ export const PostCvrFileResponseSchema: z.ZodSchema<PostCvrFileResponse> =
     }),
     ErrorsResponseSchema,
   ]);
+
+/**
+ * @url /admin/elections/:electionId/cvr-files
+ * @method POST
+ */
+export interface PostCvrFileQueryParams {
+  readonly analyzeOnly?: boolean;
+}
+
+/**
+ * Schema for {@link PostCvrFileQueryParams}.
+ */
+export const PostCvrFileQueryParamsSchema: z.ZodSchema<PostCvrFileQueryParams> =
+  z
+    .object({
+      analyzeOnly: z
+        .preprocess((value: unknown) => value === 'true', z.boolean())
+        .optional(),
+    })
+    .strict();
 
 /**
  * @url /admin/elections/:electionId/cvr-files
@@ -277,3 +392,168 @@ export type GetCvrFileResponse = CastVoteRecordFileMetadata[];
  */
 export const GetCvrFileResponseSchema: z.ZodSchema<GetCvrFileResponse> =
   z.array(CastVoteRecordFileRecordSchema);
+
+/**
+ * @url /admin/elections/:electionId/write-ins
+ * @method GET
+ */
+export type GetWriteInsRequest = never;
+
+/**
+ * @url /admin/elections/:electionId/write-ins
+ * @method GET
+ */
+export const GetWriteInsRequestSchema: z.ZodSchema<GetWriteInsRequest> =
+  z.never();
+
+/**
+ * @url /admin/elections/:electionId/write-ins
+ * @method GET
+ */
+export type GetWriteInsResponse = WriteInRecord[] | ErrorsResponse;
+
+/**
+ * @url /admin/elections/:electionId/write-ins
+ * @method GET
+ */
+export const GetWriteInsResponseSchema: z.ZodSchema<GetWriteInsResponse> =
+  z.union([z.array(WriteInsRecordSchema), ErrorsResponseSchema]);
+
+/**
+ * @url /admin/elections/:electionId/write-ins
+ * @method GET
+ */
+export interface GetWriteInAdjudicationsQueryParams {
+  readonly contestId?: ContestId;
+  readonly status?: WriteInAdjudicationStatus;
+  readonly limit?: number;
+}
+
+/**
+ * Schema for {@link GetWriteInAdjudicationsQueryParams}.
+ */
+export const GetWriteInAdjudicationsQueryParamsSchema: z.ZodSchema<GetWriteInAdjudicationsQueryParams> =
+  z
+    .object({
+      contestId: ContestIdSchema.optional(),
+      status: WriteInAdjudicationStatusSchema.optional(),
+      limit: z
+        .preprocess(
+          (value) => safeParseNumber(value).unsafeUnwrap(),
+          z.number().nonnegative().int()
+        )
+        .optional(),
+    })
+    .strict();
+
+/**
+ * @url /admin/write-ins/:writeInId/transcription
+ * @method PUT
+ */
+export interface PutWriteInTranscriptionRequest {
+  readonly value: string;
+}
+
+/**
+ * Schema for {@link PutWriteInTranscriptionRequest}.
+ */
+export const PutWriteInTranscriptionRequestSchema: z.ZodSchema<PutWriteInTranscriptionRequest> =
+  z.object({
+    value: z.string(),
+  });
+
+/**
+ * @url /admin/write-ins/:writeInId/transcription
+ * @method PUT
+ */
+export type PutWriteInTranscriptionResponse = OkResponse | ErrorsResponse;
+
+/**
+ * Schema for {@link PutWriteInTranscriptionResponse}.
+ */
+export const PutWriteInTranscriptionResponseSchema: z.ZodSchema<PutWriteInTranscriptionResponse> =
+  z.union([OkResponseSchema, ErrorsResponseSchema]);
+
+/**
+ * @url /admin/elections/:electionId/write-in-adjudications
+ * @method POST
+ */
+export interface PostWriteInAdjudicationRequest {
+  readonly contestId: ContestId;
+  readonly transcribedValue: string;
+  readonly adjudicatedValue?: string;
+  readonly adjudicatedOptionId?: ContestOptionId;
+}
+
+/**
+ * Schema for {@link PostWriteInAdjudicationRequest}.
+ */
+export const PostWriteInAdjudicationRequestSchema: z.ZodSchema<PostWriteInAdjudicationRequest> =
+  z.object({
+    contestId: ContestIdSchema,
+    transcribedValue: z.string(),
+    adjudicatedValue: z.string().optional(),
+    adjudicatedOptionId: ContestOptionIdSchema.optional(),
+  });
+
+/**
+ * @url /admin/elections/:electionId/write-in-adjudications
+ * @method POST
+ */
+export type PostWriteInAdjudicationResponse =
+  | OkResponse<{ id: Id }>
+  | ErrorsResponse;
+
+/**
+ * Schema for {@link PostWriteInAdjudicationResponse}.
+ */
+export const PostWriteInAdjudicationResponseSchema: z.ZodSchema<PostWriteInAdjudicationResponse> =
+  z.union([
+    z.object({
+      status: z.literal('ok'),
+      id: IdSchema,
+    }),
+    ErrorsResponseSchema,
+  ]);
+
+/**
+ * @url /admin/elections/:electionId/write-in-summary
+ * @method GET
+ */
+export type GetWriteInSummaryRequest = never;
+
+/**
+ * Schema for {@link GetWriteInSummaryRequest}.
+ */
+export const GetWriteInSummaryRequestSchema: z.ZodSchema<GetWriteInSummaryRequest> =
+  z.never();
+
+/**
+ * @url /admin/elections/:electionId/write-in-summary
+ * @method GET
+ */
+export type GetWriteInSummaryResponse = WriteInSummaryEntry[] | ErrorsResponse;
+
+/**
+ * Schema for {@link GetWriteInSummaryResponse}.
+ */
+export const GetWriteInSummaryResponseSchema: z.ZodSchema<GetWriteInSummaryResponse> =
+  z.array(WriteInSummaryEntrySchema);
+
+/**
+ * @url /admin/elections/:electionId/write-in-summary
+ * @method GET
+ */
+export interface GetWriteInSummaryQueryParams {
+  readonly contestId?: ContestId;
+}
+
+/**
+ * Schema for {@link GetWriteInSummaryQueryParams}.
+ */
+export const GetWriteInSummaryQueryParamsSchema: z.ZodSchema<GetWriteInSummaryQueryParams> =
+  z
+    .object({
+      contestId: ContestIdSchema.optional(),
+    })
+    .strict();

--- a/libs/fixtures/src/data/electionMinimalExhaustiveSample/index.ts
+++ b/libs/fixtures/src/data/electionMinimalExhaustiveSample/index.ts
@@ -5,6 +5,10 @@ import { asText as semsDataAsText } from './semsFiles/standard.csv';
 import { asText as batchResultsCsvAsText } from './csvFiles/batchResults.csv';
 import { asText as finalResultsCsvAsText } from './csvFiles/finalResults.csv';
 
+export * as standardCvrFile from './cvrFiles/standard.jsonl';
+export * as partial1CvrFile from './cvrFiles/partial1.jsonl';
+export * as partial2CvrFile from './cvrFiles/partial2.jsonl';
+
 export const cvrData = standardCvrsAsText();
 export const semsData = semsDataAsText();
 export const semsDataPartial1 = partial1CvrsAsText();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2688,6 +2688,7 @@ importers:
       express: 4.18.0
       fs-extra: 10.1.0
       js-sha256: 0.9.0
+      multer: 1.4.5-lts.1
       uuid: 8.3.2
       zod: 3.14.4
     devDependencies:
@@ -2697,6 +2698,7 @@ importers:
       '@types/express': 4.17.13
       '@types/fs-extra': 9.0.13
       '@types/jest': 26.0.23
+      '@types/multer': 1.4.7
       '@types/node': 16.11.29
       '@types/supertest': 2.0.10
       '@types/tmp': 0.2.3
@@ -2731,6 +2733,7 @@ importers:
       '@types/express': ^4.17.13
       '@types/fs-extra': ^9.0.13
       '@types/jest': ^26.0.6
+      '@types/multer': ^1.4.7
       '@types/node': 16.11.29
       '@types/supertest': ^2.0.10
       '@types/tmp': ^0.2.3
@@ -2762,6 +2765,7 @@ importers:
       jest-watch-typeahead: ^0.6.4
       js-sha256: ^0.9.0
       lint-staged: ^10.5.3
+      multer: ^1.4.5-lts.1
       prettier: ^2.6.2
       sort-package-json: ^1.50.0
       supertest: ^6.0.1
@@ -13095,7 +13099,7 @@ packages:
   /append-field/1.0.0:
     dev: false
     resolution:
-      integrity: sha1-HjRA6RXwsSA9I3SOeO3XubW0PlY=
+      integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==
   /aproba/1.2.0:
     dev: false
     resolution:
@@ -14436,6 +14440,14 @@ packages:
       node: '>=4.5.0'
     resolution:
       integrity: sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==
+  /busboy/1.6.0:
+    dependencies:
+      streamsearch: 1.1.0
+    dev: false
+    engines:
+      node: '>=10.16.0'
+    resolution:
+      integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==
   /bytes/3.0.0:
     dev: false
     engines:
@@ -29113,6 +29125,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
+  /mkdirp/0.5.6:
+    dependencies:
+      minimist: 1.2.6
+    dev: false
+    hasBin: true
+    resolution:
+      integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
   /mkdirp/1.0.4:
     engines:
       node: '>=10'
@@ -29169,6 +29188,20 @@ packages:
       node: '>= 0.10.0'
     resolution:
       integrity: sha512-xY8pX7V+ybyUpbYMxtjM9KAiD9ixtg5/JkeKUTD6xilfDv0vzzOFcCp4Ljb1UU3tSOM3VTZtKo63OmzOrGi3Cg==
+  /multer/1.4.5-lts.1:
+    dependencies:
+      append-field: 1.0.0
+      busboy: 1.6.0
+      concat-stream: 1.6.2
+      mkdirp: 0.5.6
+      object-assign: 4.1.1
+      type-is: 1.6.18
+      xtend: 4.0.2
+    dev: false
+    engines:
+      node: '>= 6.0.0'
+    resolution:
+      integrity: sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==
   /multicast-dns-service-types/1.1.0:
     dev: false
     resolution:
@@ -33397,6 +33430,12 @@ packages:
       node: '>=0.8.0'
     resolution:
       integrity: sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=
+  /streamsearch/1.1.0:
+    dev: false
+    engines:
+      node: '>=10.0.0'
+    resolution:
+      integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
   /strict-uri-encode/1.1.0:
     dev: false
     engines:

--- a/services/admin/package.json
+++ b/services/admin/package.json
@@ -45,6 +45,7 @@
     "express": "^4.18.0",
     "fs-extra": "^10.1.0",
     "js-sha256": "^0.9.0",
+    "multer": "^1.4.5-lts.1",
     "uuid": "^8.3.2",
     "zod": "3.14.4"
   },
@@ -55,6 +56,7 @@
     "@types/express": "^4.17.13",
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^26.0.6",
+    "@types/multer": "^1.4.7",
     "@types/node": "16.11.29",
     "@types/supertest": "^2.0.10",
     "@types/tmp": "^0.2.3",

--- a/services/admin/schema.sql
+++ b/services/admin/schema.sql
@@ -7,37 +7,43 @@ create table elections (
 );
 
 create table adjudications (
-	id varchar(36) primary key,
-	contest_id text,
-	transcribed_value text,
-	cvr_id varchar(36),
-	foreign key (cvr_id) references cvrs(id)
-		on update cascade
-		on delete cascade
+  id varchar(36) primary key,
+  contest_id text not null,
+  transcribed_value text,
+  cvr_id varchar(36) not null,
+  foreign key (cvr_id) references cvrs(id)
+    on update cascade
+    on delete cascade
 );
 
 create table cvrs (
-	id varchar(36) primary key,
-	ballot_id varchar(36) unique,
-	imported_by_file varchar(36),
-	data text,
-	foreign key (imported_by_file) references cvr_files(id)
-	  on update cascade
-	  on delete cascade
+  id varchar(36) primary key,
+  election_id varchar(36) not null,
+  ballot_id varchar(36) not null,
+  data text not null,
+  created_at timestamp not null default current_timestamp,
+  updated_at timestamp not null default current_timestamp
 );
 
 create table cvr_files (
-	id varchar(36) primary key,
-	election_id varchar(36) not null,
-	signature text,
-	filename text,
-	timestamp text,
-	imported_cvr_count integer,
-	duplicated_cvr_count integer,
-	scanner_ids text,
-	precinct_ids text,
-	contains_test_mode_cvrs boolean,
-	foreign key (election_id) references elections(id)
-	  on update cascade
-	  on delete cascade
+  id varchar(36) primary key,
+  election_id varchar(36) not null,
+  filename text not null,
+  data text not null,
+  sha256_hash text not null,
+  created_at timestamp not null default current_timestamp,
+  updated_at timestamp not null default current_timestamp,
+  foreign key (election_id) references elections(id)
+    on update cascade
+    on delete cascade
+);
+
+create table cvr_file_entries (
+  cvr_file_id varchar(36) not null,
+  cvr_id varchar(36) not null,
+  primary key (cvr_file_id, cvr_id),
+  foreign key (cvr_file_id) references cvr_files(id)
+    on update cascade,
+  foreign key (cvr_id) references cvrs(id)
+    on update cascade
 );

--- a/services/admin/schema.sql
+++ b/services/admin/schema.sql
@@ -6,14 +6,32 @@ create table elections (
   deleted_at timestamp
 );
 
-create table adjudications (
+create table write_in_adjudications (
   id varchar(36) primary key,
+  election_id varchar(36) not null,
   contest_id text not null,
-  transcribed_value text,
+  transcribed_value text not null,
+  adjudicated_value text,
+  adjudicated_option_id text,
+  created_at timestamp not null default current_timestamp,
+  foreign key (election_id) references elections(id)
+    on update cascade
+    on delete cascade,
+  unique (election_id, contest_id, transcribed_value)
+);
+
+create table write_ins (
+  id varchar(36) primary key,
   cvr_id varchar(36) not null,
+  contest_id text not null,
+  option_id text not null,
+  transcribed_value text,
+  transcribed_at timestamp,
+  created_at timestamp not null default current_timestamp,
   foreign key (cvr_id) references cvrs(id)
     on update cascade
-    on delete cascade
+    on delete cascade,
+  unique (cvr_id, contest_id, option_id)
 );
 
 create table cvrs (

--- a/services/admin/schema.sql
+++ b/services/admin/schema.sql
@@ -2,7 +2,6 @@ create table elections (
   id serial primary key,
   data text not null,
   created_at timestamp not null default current_timestamp,
-  updated_at timestamp not null default current_timestamp,
   deleted_at timestamp
 );
 
@@ -15,7 +14,6 @@ create table write_in_adjudications (
   adjudicated_option_id text,
   created_at timestamp not null default current_timestamp,
   foreign key (election_id) references elections(id)
-    on update cascade
     on delete cascade,
   unique (election_id, contest_id, transcribed_value)
 );
@@ -29,7 +27,6 @@ create table write_ins (
   transcribed_at timestamp,
   created_at timestamp not null default current_timestamp,
   foreign key (cvr_id) references cvrs(id)
-    on update cascade
     on delete cascade,
   unique (cvr_id, contest_id, option_id)
 );
@@ -40,7 +37,8 @@ create table cvrs (
   ballot_id varchar(36) not null,
   data text not null,
   created_at timestamp not null default current_timestamp,
-  updated_at timestamp not null default current_timestamp
+  foreign key (election_id) references elections(id)
+    on delete cascade
 );
 
 create table cvr_files (
@@ -50,9 +48,7 @@ create table cvr_files (
   data text not null,
   sha256_hash text not null,
   created_at timestamp not null default current_timestamp,
-  updated_at timestamp not null default current_timestamp,
   foreign key (election_id) references elections(id)
-    on update cascade
     on delete cascade
 );
 
@@ -61,7 +57,7 @@ create table cvr_file_entries (
   cvr_id varchar(36) not null,
   primary key (cvr_file_id, cvr_id),
   foreign key (cvr_file_id) references cvr_files(id)
-    on update cascade,
+    on delete cascade,
   foreign key (cvr_id) references cvrs(id)
-    on update cascade
+    on delete cascade
 );

--- a/services/admin/src/db_client.ts
+++ b/services/admin/src/db_client.ts
@@ -11,7 +11,10 @@ const debug = makeDebug('admin:db-client');
 
 const MEMORY_DB_PATH = ':memory:';
 
-type Bindable = string | number | bigint | Buffer | null;
+/**
+ * Values that may be passed to the client as bindable parameters.
+ */
+export type Bindable = string | number | bigint | Buffer | null;
 
 /**
  * Manages a connection for a SQLite database.

--- a/services/admin/src/server.test.ts
+++ b/services/admin/src/server.test.ts
@@ -93,7 +93,6 @@ test('GET /admin/elections', async () => {
         id: electionId,
         electionDefinition: electionFamousNames2021Fixtures.electionDefinition,
         createdAt: expect.any(String),
-        updatedAt: expect.any(String),
       })
     ),
   ]);

--- a/services/admin/src/server.test.ts
+++ b/services/admin/src/server.test.ts
@@ -1,7 +1,12 @@
 import { Admin } from '@votingworks/api';
-import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+import {
+  electionFamousNames2021Fixtures,
+  electionMinimalExhaustiveSampleFixtures,
+} from '@votingworks/fixtures';
 import { fakeLogger, LogEventId } from '@votingworks/logging';
+import { unsafeParse } from '@votingworks/types';
 import { assert, typedAs } from '@votingworks/utils';
+import { Buffer } from 'buffer';
 import { Application } from 'express';
 import { Server } from 'http';
 import request from 'supertest';
@@ -13,6 +18,7 @@ let app: Application;
 let workspace: Workspace;
 
 beforeEach(() => {
+  jest.restoreAllMocks();
   workspace = createWorkspace(dirSync().name);
   app = buildApp({ store: workspace.store });
 });
@@ -137,4 +143,294 @@ test('DELETE /admin/elections/:electionId', async () => {
 
   await request(app).delete(`/admin/elections/${electionId}`).expect(200);
   await request(app).get('/admin/elections').expect(200, []);
+});
+
+test('POST /admin/elections/:electionId/cvr-files', async () => {
+  const electionId = workspace.store.addElection(
+    electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData
+  );
+
+  const httpResponse = await request(app)
+    .post(`/admin/elections/${electionId}/cvr-files`)
+    .attach(
+      'cvrFile',
+      electionMinimalExhaustiveSampleFixtures.standardCvrFile.asBuffer(),
+      'cvrFile.json'
+    )
+    .expect(200);
+  const response = unsafeParse(
+    Admin.PostCvrFileResponseSchema,
+    httpResponse.body
+  );
+
+  assert(response.status === 'ok');
+
+  expect(
+    workspace.store.getCastVoteRecordFileMetadata(response.id)
+  ).toMatchObject(
+    typedAs<Partial<Admin.CastVoteRecordFileMetadata>>({
+      id: response.id,
+      electionId,
+      filename: 'cvrFile.json',
+    })
+  );
+
+  expect(workspace.store.getCastVoteRecordEntries(electionId)).toHaveLength(
+    3000
+  );
+});
+
+test('POST /admin/elections/:electionId/cvr-files duplicate file', async () => {
+  const electionId = workspace.store.addElection(
+    electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData
+  );
+
+  const httpResponse = await request(app)
+    .post(`/admin/elections/${electionId}/cvr-files`)
+    .attach(
+      'cvrFile',
+      electionMinimalExhaustiveSampleFixtures.standardCvrFile.asBuffer(),
+      'cvrFile.json'
+    )
+    .expect(200);
+  const response = unsafeParse(
+    Admin.PostCvrFileResponseSchema,
+    httpResponse.body
+  );
+
+  expect(response).toEqual(
+    typedAs<Admin.PostCvrFileResponse>({
+      status: 'ok',
+      id: expect.any(String),
+      wasExistingFile: false,
+      newlyAdded: 3000,
+      alreadyPresent: 0,
+    })
+  );
+
+  const httpResponse2 = await request(app)
+    .post(`/admin/elections/${electionId}/cvr-files`)
+    .attach(
+      'cvrFile',
+      electionMinimalExhaustiveSampleFixtures.standardCvrFile.asBuffer(),
+      'cvrFile.json'
+    )
+    .expect(200);
+  const response2 = unsafeParse(
+    Admin.PostCvrFileResponseSchema,
+    httpResponse2.body
+  );
+
+  expect(response2).toEqual(
+    typedAs<Admin.PostCvrFileResponse>({
+      status: 'ok',
+      id: expect.any(String),
+      wasExistingFile: true,
+      newlyAdded: 0,
+      alreadyPresent: 3000,
+    })
+  );
+});
+
+test('POST /admin/elections/:electionId/cvr-files?analyzeOnly=true', async () => {
+  const electionId = workspace.store.addElection(
+    electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData
+  );
+
+  const httpResponse = await request(app)
+    .post(`/admin/elections/${electionId}/cvr-files?analyzeOnly=true`)
+    .attach(
+      'cvrFile',
+      electionMinimalExhaustiveSampleFixtures.standardCvrFile.asBuffer(),
+      'cvrFile.json'
+    )
+    .expect(200);
+  const response = unsafeParse(
+    Admin.PostCvrFileResponseSchema,
+    httpResponse.body
+  );
+
+  expect(response).toEqual(
+    typedAs<Admin.PostCvrFileResponse>({
+      status: 'ok',
+      id: expect.any(String),
+      wasExistingFile: false,
+      newlyAdded: 3000,
+      alreadyPresent: 0,
+    })
+  );
+
+  expect(workspace.store.getCastVoteRecordEntries(electionId)).toHaveLength(0);
+});
+
+test('POST /admin/elections/:electionId/cvr-files without a file', async () => {
+  const electionId = workspace.store.addElection(
+    electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData
+  );
+
+  await request(app)
+    .post(`/admin/elections/${electionId}/cvr-files`)
+    .expect(400);
+});
+
+test('POST /admin/elections/:electionId/cvr-files with duplicate CVR entries', async () => {
+  const electionId = workspace.store.addElection(
+    electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData
+  );
+
+  expect(workspace.store.getCastVoteRecordEntries(electionId)).toHaveLength(0);
+
+  const partial1HttpResponse = await request(app)
+    .post(`/admin/elections/${electionId}/cvr-files`)
+    .attach(
+      'cvrFile',
+      electionMinimalExhaustiveSampleFixtures.partial1CvrFile.asBuffer(),
+      'cvrFile.json'
+    )
+    .expect(200);
+  const partial1Response = unsafeParse(
+    Admin.PostCvrFileResponseSchema,
+    partial1HttpResponse.body
+  );
+
+  expect(partial1Response).toEqual(
+    typedAs<Admin.PostCvrFileResponse>({
+      status: 'ok',
+      id: expect.any(String),
+      wasExistingFile: false,
+      newlyAdded: 101,
+      alreadyPresent: 0,
+    })
+  );
+
+  expect(workspace.store.getCastVoteRecordEntries(electionId)).toHaveLength(
+    101
+  );
+
+  const partial2HttpResponse = await request(app)
+    .post(`/admin/elections/${electionId}/cvr-files`)
+    .attach(
+      'cvrFile',
+      electionMinimalExhaustiveSampleFixtures.partial2CvrFile.asBuffer(),
+      'cvrFile.json'
+    )
+    .expect(200);
+
+  const partial2Response = unsafeParse(
+    Admin.PostCvrFileResponseSchema,
+    partial2HttpResponse.body
+  );
+
+  expect(partial2Response).toEqual(
+    typedAs<Admin.PostCvrFileResponse>({
+      status: 'ok',
+      id: expect.any(String),
+      wasExistingFile: false,
+      newlyAdded: 20,
+      alreadyPresent: 21,
+    })
+  );
+
+  expect(workspace.store.getCastVoteRecordEntries(electionId)).toHaveLength(
+    121 /* 101 from partial1 + 20 new */
+  );
+
+  const standardHttpResponse = await request(app)
+    .post(`/admin/elections/${electionId}/cvr-files`)
+    .attach(
+      'cvrFile',
+      electionMinimalExhaustiveSampleFixtures.standardCvrFile.asBuffer(),
+      'cvrFile.json'
+    )
+    .expect(200);
+
+  const standardResponse = unsafeParse(
+    Admin.PostCvrFileResponseSchema,
+    standardHttpResponse.body
+  );
+
+  expect(standardResponse).toEqual(
+    typedAs<Admin.PostCvrFileResponse>({
+      status: 'ok',
+      id: expect.any(String),
+      wasExistingFile: false,
+      newlyAdded: 2879,
+      alreadyPresent: 121,
+    })
+  );
+
+  expect(partial2Response).toEqual(
+    typedAs<Admin.PostCvrFileResponse>({
+      status: 'ok',
+      id: expect.any(String),
+      wasExistingFile: false,
+      newlyAdded: 20,
+      alreadyPresent: 21,
+    })
+  );
+  expect(workspace.store.getCastVoteRecordEntries(electionId)).toHaveLength(
+    3000 /* 101 from partial1 + 20 from partial2 + 2879 new */
+  );
+});
+
+test('POST /admin/elections/:electionId/cvr-files with duplicate ballot IDs', async () => {
+  const electionId = workspace.store.addElection(
+    electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData
+  );
+
+  expect(workspace.store.getCastVoteRecordEntries(electionId)).toHaveLength(0);
+
+  const cvrs = electionMinimalExhaustiveSampleFixtures.partial1CvrFile
+    .asText()
+    .split('\n');
+  const cvr1 = JSON.parse(cvrs[0] as string);
+
+  const httpResponse = await request(app)
+    .post(`/admin/elections/${electionId}/cvr-files`)
+    .attach(
+      'cvrFile',
+      Buffer.concat([
+        Buffer.from(JSON.stringify(cvr1)),
+        Buffer.from('\n'),
+        Buffer.from(JSON.stringify({ ...cvr1, _something: 'different' })),
+      ]),
+      'cvrFile.json'
+    )
+    .expect(400);
+  const response = unsafeParse(
+    Admin.PostCvrFileResponseSchema,
+    httpResponse.body
+  );
+
+  expect(response).toEqual(
+    typedAs<Admin.PostCvrFileResponse>({
+      status: 'error',
+      errors: [
+        expect.objectContaining({
+          type: 'BallotIdAlreadyExistsWithDifferentData',
+        }),
+      ],
+    })
+  );
+});
+
+test('DELETE /admin/elections/:electionId/cvr-files', async () => {
+  const electionId = workspace.store.addElection(
+    electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData
+  );
+
+  await request(app)
+    .post(`/admin/elections/${electionId}/cvr-files`)
+    .attach(
+      'cvrFile',
+      electionMinimalExhaustiveSampleFixtures.partial1CvrFile.asBuffer(),
+      'cvrFile.json'
+    )
+    .expect(200);
+
+  await request(app)
+    .delete(`/admin/elections/${electionId}/cvr-files`)
+    .expect(200);
+
+  expect(workspace.store.getCastVoteRecordEntries(electionId)).toHaveLength(0);
 });

--- a/services/admin/src/server.ts
+++ b/services/admin/src/server.ts
@@ -288,7 +288,6 @@ export function buildApp({ store }: { store: Store }): Application {
     }
 
     const { contestId } = parseQueryResult.ok();
-    store.getWriteInRecords({ electionId });
     response.json(
       store.getWriteInAdjudicationSummary({ electionId, contestId })
     );

--- a/services/admin/src/server.ts
+++ b/services/admin/src/server.ts
@@ -1,18 +1,29 @@
 import { Admin } from '@votingworks/api';
 import { LogEventId, Logger, LogSource } from '@votingworks/logging';
 import { Id, safeParse } from '@votingworks/types';
+import multer from 'multer';
 import express, { Application } from 'express';
+import { readFileSync } from 'fs';
+import { basename } from 'path';
+import { asBoolean } from '@votingworks/utils';
 import { ADMIN_WORKSPACE, PORT } from './globals';
 import { Store } from './store';
 import { createWorkspace, Workspace } from './util/workspace';
 
 type NoParams = never;
 
+const CVR_FILE_ATTACHMENT_NAME = 'cvrFile';
+const MAX_UPLOAD_FILE_SIZE = 500 * 1024 * 1024; // 500MB
+
 /**
  * Builds an express application.
  */
 export function buildApp({ store }: { store: Store }): Application {
   const app: Application = express();
+  const upload = multer({
+    storage: multer.diskStorage({}),
+    limits: { fileSize: MAX_UPLOAD_FILE_SIZE },
+  });
 
   app.use(express.raw());
   app.use(express.json({ limit: '50mb', type: 'application/json' }));
@@ -53,6 +64,81 @@ export function buildApp({ store }: { store: Store }): Application {
       response.json({ status: 'ok' });
     }
   );
+
+  app.post<
+    { electionId: Id },
+    Admin.PostCvrFileResponse,
+    Admin.PostCvrFileRequest
+  >(
+    '/admin/elections/:electionId/cvr-files',
+    upload.fields([{ name: CVR_FILE_ATTACHMENT_NAME, maxCount: 1 }]),
+    (request, response) => {
+      const { electionId } = request.params;
+      /* istanbul ignore next */
+      const file = !Array.isArray(request.files)
+        ? request.files?.[CVR_FILE_ATTACHMENT_NAME]?.[0]
+        : undefined;
+
+      if (!file) {
+        response.status(400).json({
+          status: 'error',
+          errors: [
+            {
+              type: 'invalid-value',
+              message: `expected file field to be named "${CVR_FILE_ATTACHMENT_NAME}"`,
+            },
+          ],
+        });
+        return;
+      }
+
+      const analyzeOnlyQuery = request.query['analyzeOnly'];
+      const analyzeOnly =
+        typeof analyzeOnlyQuery === 'string' && asBoolean(analyzeOnlyQuery);
+      const filename = basename(file.originalname);
+      const cvrFile = readFileSync(file.path, 'utf8');
+      const result = store.addCastVoteRecordFile({
+        electionId,
+        filename,
+        cvrFile,
+        analyzeOnly,
+      });
+
+      if (result.isErr()) {
+        response.status(400).json({
+          status: 'error',
+          errors: [
+            {
+              type: result.err().kind,
+              message: JSON.stringify(result.err()),
+            },
+          ],
+        });
+        return;
+      }
+
+      const { id, wasExistingFile, newlyAdded, alreadyPresent } = result.ok();
+      const body: Admin.PostCvrFileResponse = {
+        status: 'ok',
+        id,
+        wasExistingFile,
+        newlyAdded,
+        alreadyPresent,
+      };
+
+      response.json(body);
+    }
+  );
+
+  app.delete<
+    { electionId: Id },
+    Admin.DeleteCvrFileResponse,
+    Admin.DeleteCvrFileRequest
+  >('/admin/elections/:electionId/cvr-files', (request, response) => {
+    const { electionId } = request.params;
+    store.deleteCastVoteRecordFiles(electionId);
+    response.json({ status: 'ok' });
+  });
 
   return app;
 }

--- a/services/admin/src/server.writeins.test.ts
+++ b/services/admin/src/server.writeins.test.ts
@@ -1,0 +1,175 @@
+import { Admin } from '@votingworks/api';
+import { electionMinimalExhaustiveSampleFixtures } from '@votingworks/fixtures';
+import { unsafeParse } from '@votingworks/types';
+import { assert, typedAs } from '@votingworks/utils';
+import { Application } from 'express';
+import request from 'supertest';
+import { dirSync } from 'tmp';
+import { buildApp } from './server';
+import { createWorkspace, Workspace } from './util/workspace';
+
+let app: Application;
+let workspace: Workspace;
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+  workspace = createWorkspace(dirSync().name);
+  app = buildApp({ store: workspace.store });
+});
+
+test('write-in adjudication lifecycle', async () => {
+  const electionId = workspace.store.addElection(
+    electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData
+  );
+
+  // upload the CVR file
+  const postCvrHttpResponse = await request(app)
+    .post(`/admin/elections/${electionId}/cvr-files`)
+    .attach(
+      'cvrFile',
+      electionMinimalExhaustiveSampleFixtures.standardCvrFile.asBuffer(),
+      'cvrFile.json'
+    )
+    .expect(200);
+  const postCvrResponse = unsafeParse(
+    Admin.PostCvrFileResponseSchema,
+    postCvrHttpResponse.body
+  );
+
+  assert(postCvrResponse.status === 'ok');
+
+  // focus on this contest
+  const contestId = 'zoo-council-mammal';
+
+  // view the adjudication table
+  const getWriteInSummaryHttpResponse = await request(app)
+    .get(
+      `/admin/elections/${electionId}/write-in-summary?contestId=${contestId}`
+    )
+    .expect(200);
+  const getWriteInSummaryResponse = unsafeParse(
+    Admin.GetWriteInSummaryResponseSchema,
+    getWriteInSummaryHttpResponse.body
+  );
+  expect(getWriteInSummaryResponse).toEqual(
+    typedAs<Admin.WriteInSummaryEntry[]>([
+      {
+        contestId,
+        writeInCount: expect.any(Number),
+      },
+    ])
+  );
+
+  // process all the write-ins for the contest we're going to adjudicate
+  let writeInCount = 0;
+  for (;;) {
+    const getWriteInsHttpResponse = await request(app)
+      .get(
+        `/admin/elections/${electionId}/write-ins?status=pending&contestId=${contestId}&limit=1`
+      )
+      .expect(200);
+    const getWriteInsResponse = unsafeParse(
+      Admin.GetWriteInsResponseSchema,
+      getWriteInsHttpResponse.body
+    );
+    assert(Array.isArray(getWriteInsResponse));
+
+    if (getWriteInsResponse.length === 0) {
+      break;
+    }
+
+    const writeInRecord = getWriteInsResponse[0]!;
+
+    // transcribe it
+    await request(app)
+      .put(`/admin/write-ins/${writeInRecord.id}/transcription`)
+      .send(
+        typedAs<Admin.PutWriteInTranscriptionRequest>({
+          value: 'Mickey Mouse',
+        })
+      )
+      .expect(200);
+
+    writeInCount += 1;
+  }
+
+  // view the adjudication table
+  const getWriteInSummaryAfterTranscriptionHttpResponse = await request(app)
+    .get(
+      `/admin/elections/${electionId}/write-in-summary?contestId=${contestId}`
+    )
+    .expect(200);
+  const getWriteInSummaryAfterTranscriptionResponse = unsafeParse(
+    Admin.GetWriteInSummaryResponseSchema,
+    getWriteInSummaryAfterTranscriptionHttpResponse.body
+  );
+
+  expect(getWriteInSummaryAfterTranscriptionResponse).toEqual(
+    typedAs<Admin.GetWriteInSummaryResponse>([
+      {
+        contestId,
+        transcribedValue: 'Mickey Mouse',
+        writeInCount,
+      },
+    ])
+  );
+
+  // adjudicate all "Mickey Mouse" transcribed write-ins as "Mickey Mouse"
+  await request(app)
+    .post(`/admin/elections/${electionId}/write-in-adjudications`)
+    .send(
+      typedAs<Admin.PostWriteInAdjudicationRequest>({
+        contestId,
+        transcribedValue: 'Mickey Mouse',
+        adjudicatedValue: 'Mickey Mouse',
+      })
+    )
+    .expect(200);
+
+  // view the adjudication table
+  const getWriteInSummaryAfterAdjudicationHttpResponse = await request(app)
+    .get(
+      `/admin/elections/${electionId}/write-in-summary?contestId=${contestId}`
+    )
+    .expect(200);
+  const getWriteInSummaryAfterAdjudicationResponse = unsafeParse(
+    Admin.GetWriteInSummaryResponseSchema,
+    getWriteInSummaryAfterAdjudicationHttpResponse.body
+  );
+  expect(getWriteInSummaryAfterAdjudicationResponse).toEqual(
+    typedAs<Admin.GetWriteInSummaryResponse>([
+      {
+        contestId,
+        transcribedValue: 'Mickey Mouse',
+        writeInCount,
+        writeInAdjudication: {
+          id: expect.any(String),
+          contestId,
+          transcribedValue: 'Mickey Mouse',
+          adjudicatedValue: 'Mickey Mouse',
+        },
+      },
+    ])
+  );
+});
+
+test('create write-in adjudication with invalid request', async () => {
+  const electionId = workspace.store.addElection(
+    electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData
+  );
+
+  await request(app)
+    .post(`/admin/elections/${electionId}/write-in-adjudications`)
+    .send({})
+    .expect(400);
+});
+
+test('GET /admin/elections/:electionId/write-in-summary with bad query', async () => {
+  const electionId = workspace.store.addElection(
+    electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData
+  );
+
+  await request(app)
+    .get(`/admin/elections/${electionId}/write-in-summary?bad=query`)
+    .expect(400);
+});

--- a/services/admin/src/store.test.ts
+++ b/services/admin/src/store.test.ts
@@ -194,7 +194,6 @@ test('get CVR file metadata', () => {
       filename: 'cvrs.jsonl',
       sha256Hash: expect.any(String),
       createdAt: expect.any(String),
-      updatedAt: expect.any(String),
     })
   );
 });
@@ -225,7 +224,6 @@ test('get CVR file', () => {
       data: cvrFile,
       sha256Hash: expect.any(String),
       createdAt: expect.any(String),
-      updatedAt: expect.any(String),
     })
   );
 });

--- a/services/admin/src/store.test.ts
+++ b/services/admin/src/store.test.ts
@@ -1,7 +1,10 @@
+import { Admin } from '@votingworks/api';
+import { electionMinimalExhaustiveSampleFixtures } from '@votingworks/fixtures';
+import { typedAs } from '@votingworks/utils';
 import { promises as fs } from 'fs';
 import { join } from 'path';
 import { tmpNameSync } from 'tmp';
-import { Store } from './store';
+import { AddCastVoteRecordError, Store } from './store';
 
 test('create a file store', async () => {
   const tmpDir = tmpNameSync();
@@ -17,4 +20,199 @@ test('create a memory store', () => {
   const store = Store.memoryStore();
   expect(store).toBeInstanceOf(Store);
   expect(store.getDbPath()).toBe(':memory:');
+});
+
+test('add an election', () => {
+  const store = Store.memoryStore();
+  const electionId = store.addElection(
+    electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData
+  );
+  store.assertElectionExists(electionId);
+  expect(store.getElections().map((r) => r.id)).toContain(electionId);
+});
+
+test('assert election exists', () => {
+  const store = Store.memoryStore();
+  expect(() => store.assertElectionExists('foo')).toThrowError(
+    'Election not found: foo'
+  );
+});
+
+test('add a CVR file', () => {
+  const store = Store.memoryStore();
+  const electionId = store.addElection(
+    electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData
+  );
+  const cvrFile = electionMinimalExhaustiveSampleFixtures.cvrData;
+  expect(
+    store
+      .addCastVoteRecordFile({ electionId, filename: 'cvrs.jsonl', cvrFile })
+      .unsafeUnwrap()
+  ).toEqual({
+    id: expect.stringMatching(/^[-0-9a-f]+$/),
+    wasExistingFile: false,
+    newlyAdded: 3000,
+    alreadyPresent: 0,
+  });
+});
+
+test('add a duplicate CVR file', () => {
+  const store = Store.memoryStore();
+  const electionId = store.addElection(
+    electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData
+  );
+  const cvrFile = electionMinimalExhaustiveSampleFixtures.cvrData;
+  const originalResult = store
+    .addCastVoteRecordFile({ electionId, filename: 'cvrs.jsonl', cvrFile })
+    .unsafeUnwrap();
+  expect(originalResult).toEqual({
+    id: expect.stringMatching(/^[-0-9a-f]+$/),
+    wasExistingFile: false,
+    newlyAdded: 3000,
+    alreadyPresent: 0,
+  });
+  const duplicateResult = store
+    .addCastVoteRecordFile({ electionId, filename: 'cvrs.jsonl', cvrFile })
+    .unsafeUnwrap();
+  expect(duplicateResult).toEqual({
+    id: originalResult.id,
+    wasExistingFile: true,
+    newlyAdded: 0,
+    alreadyPresent: 3000,
+  });
+});
+
+test('analyze a CVR file', () => {
+  const store = Store.memoryStore();
+  const electionId = store.addElection(
+    electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData
+  );
+  const cvrFile = electionMinimalExhaustiveSampleFixtures.cvrData;
+  expect(
+    store
+      .addCastVoteRecordFile({
+        electionId,
+        filename: 'cvrs.jsonl',
+        cvrFile,
+        analyzeOnly: true,
+      })
+      .unsafeUnwrap()
+  ).toEqual({
+    id: expect.any(String),
+    wasExistingFile: false,
+    newlyAdded: 3000,
+    alreadyPresent: 0,
+  });
+
+  // analyzing does not add to the store
+  expect(store.getCastVoteRecordEntries(electionId)).toHaveLength(0);
+});
+
+test('adding a CVR file if adding an entry fails', () => {
+  const store = Store.memoryStore();
+  const electionId = store.addElection(
+    electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData
+  );
+  const cvrFile = electionMinimalExhaustiveSampleFixtures.cvrData;
+
+  jest.spyOn(store, 'addCastVoteRecordFileEntry').mockImplementation(() => {
+    throw new Error('oops');
+  });
+
+  expect(() =>
+    store
+      .addCastVoteRecordFile({
+        electionId,
+        filename: 'cvrs.jsonl',
+        cvrFile,
+      })
+      .unsafeUnwrap()
+  ).toThrowError('oops');
+
+  expect(store.getCastVoteRecordEntries(electionId)).toHaveLength(0);
+});
+
+test('add a CVR file entry without a ballot ID', () => {
+  const store = Store.memoryStore();
+  const electionId = store.addElection(
+    electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData
+  );
+  const cvrFile = electionMinimalExhaustiveSampleFixtures.cvrData.replaceAll(
+    '_ballotId',
+    '_notBallotId'
+  );
+
+  const result = store.addCastVoteRecordFile({
+    electionId,
+    filename: 'cvrs.jsonl',
+    cvrFile,
+  });
+
+  expect(result.isErr()).toBe(true);
+  expect(result.unsafeUnwrapErr()).toEqual(
+    typedAs<AddCastVoteRecordError>({ kind: 'BallotIdRequired' })
+  );
+});
+
+test('get CVR file metadata', () => {
+  const store = Store.memoryStore();
+  const electionId = store.addElection(
+    electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData
+  );
+  const cvrFile = electionMinimalExhaustiveSampleFixtures.cvrData;
+
+  expect(
+    store.getCastVoteRecordFileMetadata('not a CVR file ID')
+  ).toBeUndefined();
+
+  const { id } = store
+    .addCastVoteRecordFile({
+      electionId,
+      filename: 'cvrs.jsonl',
+      cvrFile,
+    })
+    .unsafeUnwrap();
+
+  const cvrFileMetadata = store.getCastVoteRecordFileMetadata(id);
+  expect(cvrFileMetadata).toEqual(
+    typedAs<Admin.CastVoteRecordFileMetadata>({
+      id,
+      electionId,
+      filename: 'cvrs.jsonl',
+      sha256Hash: expect.any(String),
+      createdAt: expect.any(String),
+      updatedAt: expect.any(String),
+    })
+  );
+});
+
+test('get CVR file', () => {
+  const store = Store.memoryStore();
+  const electionId = store.addElection(
+    electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData
+  );
+  const cvrFile = electionMinimalExhaustiveSampleFixtures.cvrData;
+
+  expect(store.getCastVoteRecordFile('not a CVR file ID')).toBeUndefined();
+
+  const { id } = store
+    .addCastVoteRecordFile({
+      electionId,
+      filename: 'cvrs.jsonl',
+      cvrFile,
+    })
+    .unsafeUnwrap();
+
+  const cvrFileMetadata = store.getCastVoteRecordFile(id);
+  expect(cvrFileMetadata).toEqual(
+    typedAs<Admin.CastVoteRecordFileRecord>({
+      id,
+      electionId,
+      filename: 'cvrs.jsonl',
+      data: cvrFile,
+      sha256Hash: expect.any(String),
+      createdAt: expect.any(String),
+      updatedAt: expect.any(String),
+    })
+  );
 });

--- a/services/admin/src/store.ts
+++ b/services/admin/src/store.ts
@@ -4,10 +4,16 @@
 
 import { Admin } from '@votingworks/api';
 import {
+  CastVoteRecord,
+  err,
   Id,
   Iso8601Timestamp,
+  ok,
+  Result,
   safeParseElectionDefinition,
+  safeParseJson,
 } from '@votingworks/types';
+import { sha256 } from 'js-sha256';
 import { join } from 'path';
 import { v4 as uuid } from 'uuid';
 import { DbClient } from './db_client';
@@ -19,6 +25,36 @@ function convertSqliteTimestampToIso8601(
 ): Iso8601Timestamp {
   return new Date(sqliteTimestamp).toISOString();
 }
+
+/**
+ * Kinds of errors that can occur when adding a CVR file.
+ */
+export type AddCastVoteRecordErrorKind =
+  | 'BallotIdRequired'
+  | 'BallotIdAlreadyExistsWithDifferentData';
+
+/**
+ * An error caused by a missing ballot ID in a CVR file.
+ */
+export interface AddCastVoteRecordBallotIdRequiredError {
+  readonly kind: 'BallotIdRequired';
+}
+
+/**
+ * An error caused by a duplicate ballot ID.
+ */
+export interface AddCastVoteRecordBallotIdExistsWithDifferentDataError {
+  readonly kind: 'BallotIdAlreadyExistsWithDifferentData';
+  readonly newData: string;
+  readonly existingData: string;
+}
+
+/**
+ * Errors that can occur when adding a CVR file.
+ */
+export type AddCastVoteRecordError =
+  | AddCastVoteRecordBallotIdRequiredError
+  | AddCastVoteRecordBallotIdExistsWithDifferentDataError;
 
 /**
  * Manages a data store for imported election data, cast vote records, and
@@ -95,5 +131,362 @@ export class Store {
       'update elections set deleted_at = current_timestamp where id = ?',
       id
     );
+  }
+
+  /**
+   * Asserts that an election with the given ID exists and is not deleted.
+   */
+  assertElectionExists(electionId: Id): void {
+    const election = this.client.one(
+      `
+        select id from elections
+        where id = ? and deleted_at is null
+      `,
+      electionId
+    ) as { id: Id } | undefined;
+
+    if (!election) {
+      throw new Error(`Election not found: ${electionId}`);
+    }
+  }
+
+  /**
+   * Adds a CVR file record and returns its ID. If a CVR file with the same
+   * contents has already been added, returns the ID of that record instead.
+   *
+   * Call with `analyzeOnly` set to `true` to only analyze the file and not add
+   * it to the database.
+   */
+  addCastVoteRecordFile({
+    electionId,
+    filename,
+    cvrFile,
+    analyzeOnly,
+  }: {
+    electionId: Id;
+    filename: string;
+    cvrFile: string;
+    analyzeOnly?: boolean;
+  }): Result<
+    {
+      id: Id;
+      wasExistingFile: boolean;
+      newlyAdded: number;
+      alreadyPresent: number;
+    },
+    AddCastVoteRecordError
+  > {
+    this.assertElectionExists(electionId);
+    this.client.run('begin transaction');
+    let inTransaction = true;
+
+    try {
+      let id = uuid();
+      let newlyAdded = 0;
+      let alreadyPresent = 0;
+      const sha256Hash = sha256(cvrFile);
+
+      const existing = this.client.one(
+        `
+          select id
+          from cvr_files
+          where election_id = ?
+            and sha256_hash = ?
+        `,
+        electionId,
+        sha256Hash
+      ) as { id: Id } | undefined;
+
+      if (existing) {
+        alreadyPresent = (
+          this.client.one(
+            `
+              select count(cvr_id) as alreadyPresent
+              from cvr_file_entries
+              where cvr_file_id = ?
+            `,
+            existing.id
+          ) as { alreadyPresent: number }
+        ).alreadyPresent;
+        id = existing.id;
+      } else {
+        this.client.run(
+          `
+      insert into cvr_files (
+        id,
+        election_id,
+        filename,
+        data,
+        sha256_hash
+      ) values (
+        ?, ?, ?, ?, ?
+      )
+    `,
+          id,
+          electionId,
+          filename,
+          cvrFile,
+          sha256Hash
+        );
+
+        for (const line of cvrFile.split('\n')) {
+          if (line.trim() === '') {
+            continue;
+          }
+
+          const result = this.addCastVoteRecordFileEntry(electionId, id, line);
+
+          if (result.isErr()) {
+            return result;
+          }
+
+          if (result.ok().isNew) {
+            newlyAdded += 1;
+          } else {
+            alreadyPresent += 1;
+          }
+        }
+      }
+
+      this.client.run(
+        analyzeOnly ? 'rollback transaction' : 'commit transaction'
+      );
+      inTransaction = false;
+
+      return ok({
+        id,
+        wasExistingFile: !!existing,
+        newlyAdded,
+        alreadyPresent,
+      });
+    } catch (error) {
+      if (inTransaction) {
+        this.client.run('rollback transaction');
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Adds a CVR file entry record and returns its ID. If a CVR file entry with
+   * the same contents has already been added, returns the ID of that record and
+   * associates `cvrFileId` with it.
+   */
+  addCastVoteRecordFileEntry(
+    electionId: Id,
+    cvrFileId: Id,
+    data: string
+  ): Result<{ id: Id; isNew: boolean }, AddCastVoteRecordError> {
+    const cvr = safeParseJson(data).unsafeUnwrap() as CastVoteRecord;
+    const ballotId = cvr._ballotId;
+
+    if (!ballotId) {
+      return err({ kind: 'BallotIdRequired' });
+    }
+
+    const existing = this.client.one(
+      `
+        select
+          id,
+          data
+        from cvrs
+        where
+          election_id = ? and
+          ballot_id = ?
+      `,
+      electionId,
+      ballotId
+    ) as { id: Id; data: string } | undefined;
+
+    const id = existing?.id ?? uuid();
+
+    if (existing) {
+      if (existing.data !== data) {
+        return err({
+          kind: 'BallotIdAlreadyExistsWithDifferentData',
+          newData: data,
+          existingData: existing.data,
+        });
+      }
+    } else {
+      this.client.run(
+        `
+        insert into cvrs (
+          id,
+          election_id,
+          ballot_id,
+          data
+        ) values (
+          ?, ?, ?, ?
+        )
+      `,
+        id,
+        electionId,
+        ballotId,
+        data
+      );
+    }
+
+    this.client.run(
+      `
+        insert or ignore into cvr_file_entries (
+          cvr_file_id,
+          cvr_id
+        ) values (
+          ?, ?
+        )
+      `,
+      cvrFileId,
+      id
+    );
+
+    return ok({ id, isNew: !existing });
+  }
+
+  getCastVoteRecordFileMetadata(
+    cvrFileId: Id
+  ): Admin.CastVoteRecordFileMetadata | undefined {
+    const result = this.client.one(
+      `
+      select
+        election_id as electionId,
+        filename,
+        sha256_hash as sha256Hash,
+        created_at as createdAt,
+        updated_at as updatedAt
+      from cvr_files
+      where id = ?
+    `,
+      cvrFileId
+    ) as
+      | {
+          electionId: Id;
+          filename: string;
+          sha256Hash: string;
+          createdAt: string;
+          updatedAt: string;
+        }
+      | undefined;
+
+    if (!result) {
+      return undefined;
+    }
+
+    return {
+      id: cvrFileId,
+      electionId: result.electionId,
+      sha256Hash: result.sha256Hash,
+      filename: result.filename,
+      createdAt: convertSqliteTimestampToIso8601(result.createdAt),
+      updatedAt: convertSqliteTimestampToIso8601(result.updatedAt),
+    };
+  }
+
+  getCastVoteRecordFile(id: Id): Admin.CastVoteRecordFileRecord | undefined {
+    const result = this.client.one(
+      `
+      select
+        election_id as electionId,
+        filename,
+        sha256_hash as sha256Hash,
+        data,
+        created_at as createdAt,
+        updated_at as updatedAt
+      from cvr_files
+      where id = ?
+    `,
+      id
+    ) as
+      | {
+          electionId: Id;
+          filename: string;
+          sha256Hash: string;
+          data: string;
+          createdAt: string;
+          updatedAt: string;
+        }
+      | undefined;
+
+    if (!result) {
+      return undefined;
+    }
+
+    return {
+      id,
+      electionId: result.electionId,
+      sha256Hash: result.sha256Hash,
+      filename: result.filename,
+      data: result.data,
+      createdAt: convertSqliteTimestampToIso8601(result.createdAt),
+      updatedAt: convertSqliteTimestampToIso8601(result.updatedAt),
+    };
+  }
+
+  /**
+   * Gets all CVR entries for an election.
+   */
+  getCastVoteRecordEntries(
+    electionId: Id
+  ): Admin.CastVoteRecordFileEntryRecord[] {
+    const entries = this.client.all(
+      `
+        select
+          id,
+          ballot_id as ballotId,
+          data,
+          created_at as createdAt,
+          updated_at as updatedAt
+        from cvrs
+        where election_id = ?
+      `,
+      electionId
+    ) as Array<{
+      id: Id;
+      ballotId: string;
+      data: string;
+      createdAt: Iso8601Timestamp;
+      updatedAt: Iso8601Timestamp;
+    }>;
+
+    return entries.map((entry) => ({
+      id: entry.id,
+      ballotId: entry.ballotId,
+      electionId,
+      data: entry.data,
+      createdAt: convertSqliteTimestampToIso8601(entry.createdAt),
+      updatedAt: convertSqliteTimestampToIso8601(entry.updatedAt),
+    }));
+  }
+
+  /**
+   * Deletes all CVR files for an election.
+   */
+  deleteCastVoteRecordFiles(electionId: Id): void {
+    this.client.transaction(() => {
+      this.client.run(
+        `
+          delete from cvr_file_entries
+          where cvr_file_id in (
+            select id from cvr_files where election_id = ?
+          )
+        `,
+        electionId
+      );
+      this.client.run(
+        `
+          delete from cvr_files
+          where election_id = ?
+        `,
+        electionId
+      );
+      this.client.run(
+        `
+          delete from cvrs
+          where not exists (
+            select 1 from cvr_file_entries where cvr_id = cvrs.id
+          )
+        `
+      );
+    });
   }
 }

--- a/services/admin/src/store.ts
+++ b/services/admin/src/store.ts
@@ -106,15 +106,13 @@ export class Store {
       select
         id,
         data as electionData,
-        created_at as createdAt,
-        updated_at as updatedAt
+        created_at as createdAt
       from elections
       where deleted_at is null
     `) as Array<{
         id: Id;
         electionData: string;
         createdAt: string;
-        updatedAt: string;
       }>
     ).map((r) => ({
       id: r.id,
@@ -122,7 +120,6 @@ export class Store {
         r.electionData
       ).unsafeUnwrap(),
       createdAt: convertSqliteTimestampToIso8601(r.createdAt),
-      updatedAt: convertSqliteTimestampToIso8601(r.updatedAt),
     }));
   }
 
@@ -179,7 +176,6 @@ export class Store {
     },
     AddCastVoteRecordError
   > {
-    this.assertElectionExists(electionId);
     this.client.run('begin transaction');
     let inTransaction = true;
 
@@ -399,8 +395,7 @@ export class Store {
         election_id as electionId,
         filename,
         sha256_hash as sha256Hash,
-        created_at as createdAt,
-        updated_at as updatedAt
+        created_at as createdAt
       from cvr_files
       where id = ?
     `,
@@ -411,7 +406,6 @@ export class Store {
           filename: string;
           sha256Hash: string;
           createdAt: string;
-          updatedAt: string;
         }
       | undefined;
 
@@ -425,7 +419,6 @@ export class Store {
       sha256Hash: result.sha256Hash,
       filename: result.filename,
       createdAt: convertSqliteTimestampToIso8601(result.createdAt),
-      updatedAt: convertSqliteTimestampToIso8601(result.updatedAt),
     };
   }
 
@@ -437,8 +430,7 @@ export class Store {
         filename,
         sha256_hash as sha256Hash,
         data,
-        created_at as createdAt,
-        updated_at as updatedAt
+        created_at as createdAt
       from cvr_files
       where id = ?
     `,
@@ -450,7 +442,6 @@ export class Store {
           sha256Hash: string;
           data: string;
           createdAt: string;
-          updatedAt: string;
         }
       | undefined;
 
@@ -465,7 +456,6 @@ export class Store {
       filename: result.filename,
       data: result.data,
       createdAt: convertSqliteTimestampToIso8601(result.createdAt),
-      updatedAt: convertSqliteTimestampToIso8601(result.updatedAt),
     };
   }
 
@@ -481,8 +471,7 @@ export class Store {
           id,
           ballot_id as ballotId,
           data,
-          created_at as createdAt,
-          updated_at as updatedAt
+          created_at as createdAt
         from cvrs
         where election_id = ?
       `,
@@ -492,7 +481,6 @@ export class Store {
       ballotId: string;
       data: string;
       createdAt: Iso8601Timestamp;
-      updatedAt: Iso8601Timestamp;
     }>;
 
     return entries.map((entry) => ({
@@ -501,7 +489,6 @@ export class Store {
       electionId,
       data: entry.data,
       createdAt: convertSqliteTimestampToIso8601(entry.createdAt),
-      updatedAt: convertSqliteTimestampToIso8601(entry.updatedAt),
     }));
   }
 

--- a/services/admin/src/util/cvrs.ts
+++ b/services/admin/src/util/cvrs.ts
@@ -1,0 +1,31 @@
+import { CastVoteRecord, ContestId, ContestOptionId } from '@votingworks/types';
+
+/**
+ * Gets all the write-in options from a list.
+ */
+export function getWriteInVotes(
+  optionIds: ContestOptionId[]
+): ContestOptionId[] {
+  return optionIds.filter((id) => id.startsWith('write-in'));
+}
+
+/**
+ * Gets all the write-in options from a CVR.
+ */
+export function getWriteInsFromCastVoteRecord(
+  cvr: CastVoteRecord
+): Map<ContestId, ContestOptionId[]> {
+  const result = new Map<ContestId, ContestOptionId[]>();
+
+  for (const [contestId, votes] of Object.entries(cvr)) {
+    if (contestId.startsWith('_')) {
+      continue;
+    }
+
+    if (Array.isArray(votes)) {
+      result.set(contestId, getWriteInVotes(votes));
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
Adds endpoints to import CVR files and process them. Adds a join table for `cvr_files` and `cvrs` so that duplicate CVRs are linked to both files. Changes the frontend to use the new endpoints for adding and clearing files, but also preserves the existing storage for now to keep the tally code the same.

## Demo Video or Screenshot
n/a

## Testing Plan 
Tested with VxAdmin in Chrome adding and removing CVR files, including duplicates etc. Haven't really tested thoroughly with kiosk browser and the import table.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
