### PR TITLE
feat(scan): disallow casting overvotes based on a feature flag.

### DIFF
--- a/frontends/precinct-scanner/src/screens/scan_warning_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/scan_warning_screen.tsx
@@ -16,7 +16,14 @@ import {
   Prose,
   Text,
 } from '@votingworks/ui';
-import { assert, find, integers, take } from '@votingworks/utils';
+import {
+  assert,
+  find,
+  integers,
+  take,
+  isFeatureFlagEnabled,
+  EnvironmentFlagName,
+} from '@votingworks/utils';
 import pluralize from 'pluralize';
 import * as scanner from '../api/scan';
 
@@ -75,6 +82,9 @@ function OvervoteWarningScreen({
   electionDefinition,
   overvotes,
 }: OvervoteWarningScreenProps): JSX.Element {
+  const allowCastingOvervotes = !isFeatureFlagEnabled(
+    EnvironmentFlagName.DISALLOW_CASTING_OVERVOTES
+  );
   const [confirmTabulate, setConfirmTabulate] = useState(false);
   const contestNames = overvotes
     .map((overvote) =>
@@ -102,11 +112,16 @@ function OvervoteWarningScreen({
         <p>
           <Button primary onPress={scanner.returnBallot}>
             Return Ballot
-          </Button>{' '}
-          or{' '}
-          <Button onPress={() => setConfirmTabulate(true)}>
-            Cast Ballot As Is
           </Button>
+          {allowCastingOvervotes && (
+            <React.Fragment>
+              {' '}
+              or{' '}
+              <Button onPress={() => setConfirmTabulate(true)}>
+                Cast Ballot As Is
+              </Button>
+            </React.Fragment>
+          )}
         </p>
         <Text italic small>
           Ask a poll worker if you need help.

--- a/libs/utils/src/environment_flag.ts
+++ b/libs/utils/src/environment_flag.ts
@@ -9,6 +9,8 @@ export enum EnvironmentFlagName {
   DISABLE_CARD_READER_CHECK = 'REACT_APP_VX_DISABLE_CARD_READER_CHECK',
   // Enables livecheck in VxScan.
   LIVECHECK = 'REACT_APP_VX_ENABLE_LIVECHECK',
+  // Whether overvotes can be cast (this exists entirely for NH special case right now).
+  DISALLOW_CASTING_OVERVOTES = 'REACT_APP_VX_DISALLOW_CASTING_OVERVOTES',
 }
 
 export interface EnvironmentFlag {
@@ -42,6 +44,12 @@ export function getFlagDetails(name: EnvironmentFlagName): EnvironmentFlag {
         name,
         allowInProduction: false,
         autoEnableInDevelopment: true,
+      };
+    case EnvironmentFlagName.DISALLOW_CASTING_OVERVOTES:
+      return {
+        name,
+        allowInProduction: true,
+        autoEnableInDevelopment: false,
       };
     /* istanbul ignore next compile time check */
     default:


### PR DESCRIPTION
## Overview

When the `DISALLOW_CASTING_OVERVOTES` feature flag is set, the overvote warning screen should not allow casting the ballot.

Fixes #2187 

## Demo Video or Screenshot
<img width="2810" alt="Screen Shot 2022-09-12 at 7 21 07 PM" src="https://user-images.githubusercontent.com/18057/189774966-4d3ab6e7-5f85-40f4-9fee-933cc0b7cd3d.png">

## Testing Plan 

## Checklist
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
- [ ] ~I have added JSDoc comments to any newly introduced exports~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [X] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
