### PR TITLE
feat(all): Hide scroll bars on screen and print

### DIFF
--- a/frontends/bas/src/App.css
+++ b/frontends/bas/src/App.css
@@ -44,6 +44,11 @@ select option {
   color: rgb(0, 0, 238);
 }
 
+/* Hide scrollbars as Chrome on Linux displays them by default. This style also hides scrollbars when printing. */
+::-webkit-scrollbar {
+  display: none;
+}
+
 /* Foundational */
 html,
 body,

--- a/frontends/bmd/src/App.css
+++ b/frontends/bmd/src/App.css
@@ -77,6 +77,11 @@ body,
   }
 }
 
+/* Hide scrollbars as Chrome on Linux displays them by default. This style also hides scrollbars when printing. */
+::-webkit-scrollbar {
+  display: none;
+}
+
 /* Typography */
 html {
   background: #edeff0;
@@ -114,13 +119,6 @@ html {
     display: block;
   }
   .no-print {
-    display: none;
-  }
-}
-
-@media print {
-  /* Chrome on Linux prints scrollbars */
-  ::-webkit-scrollbar {
     display: none;
   }
 }

--- a/frontends/bsd/src/App.css
+++ b/frontends/bsd/src/App.css
@@ -64,6 +64,11 @@ body,
   }
 }
 
+/* Hide scrollbars as Chrome on Linux displays them by default. This style also hides scrollbars when printing. */
+::-webkit-scrollbar {
+  display: none;
+}
+
 /* Typography */
 html {
   background: #edeff0;

--- a/frontends/election-manager/src/App.css
+++ b/frontends/election-manager/src/App.css
@@ -70,6 +70,11 @@ body,
   }
 }
 
+/* Hide scrollbars as Chrome on Linux displays them by default. This style also hides scrollbars when printing. */
+::-webkit-scrollbar {
+  display: none;
+}
+
 /* Typography */
 html {
   background: #edeff0;
@@ -108,13 +113,6 @@ html {
     display: block;
   }
   .no-print {
-    display: none;
-  }
-}
-
-@media print {
-  /* Chrome on Linux prints scrollbars */
-  ::-webkit-scrollbar {
     display: none;
   }
 }

--- a/frontends/precinct-scanner/src/App.css
+++ b/frontends/precinct-scanner/src/App.css
@@ -70,6 +70,11 @@ body,
   }
 }
 
+/* Hide scrollbars as Chrome on Linux displays them by default. This style also hides scrollbars when printing. */
+::-webkit-scrollbar {
+  display: none;
+}
+
 /* Typography */
 html {
   background: #edeff0;
@@ -107,13 +112,6 @@ html {
     display: block;
   }
   .no-print {
-    display: none;
-  }
-}
-
-@media print {
-  /* Chrome on Linux prints scrollbars */
-  ::-webkit-scrollbar {
     display: none;
   }
 }


### PR DESCRIPTION
## Overview
When we moved to Debian scroll bars appeared on screen. 

We disabled them when printing in the past, this change hides them for both screen and print media.
