### PR TITLE
feat(EM): Disable ballot view/print with nh-accuvote converter

### DIFF
--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -1126,6 +1126,42 @@ test('clearing all files after marking as official clears SEMS, CVR, and manual 
   getByText('No CVR files loaded.');
 });
 
+test('Can not view or print ballots when using nh-accuvote converter', async () => {
+  const backend = new ElectionManagerStoreMemoryBackend({
+    // Not an election definition for NH, but doesn't matter for test.
+    electionDefinition: eitherNeitherElectionDefinition,
+  });
+
+  const card = new MemoryCard();
+  const hardware = MemoryHardware.buildStandard();
+  const { getByText, queryByText } = renderInQueryClientContext(
+    <App
+      backend={backend}
+      card={card}
+      hardware={hardware}
+      converter="nh-accuvote"
+    />
+  );
+
+  await authenticateWithSystemAdministratorCard(card);
+  fireEvent.click(getByText('Ballots'));
+  await screen.findByText(
+    'This election uses custom ballots not produced by VxAdmin.'
+  );
+  expect(queryByText('Save Ballot Package')).toBeNull();
+  fireEvent.click(getByText('Lock Machine'));
+
+  await authenticateWithElectionManagerCard(
+    card,
+    eitherNeitherElectionDefinition
+  );
+  fireEvent.click(getByText('Ballots'));
+  await screen.findByText(
+    'This election uses custom ballots not produced by VxAdmin.'
+  );
+  getByText('Save Ballot Package');
+});
+
 test('election manager UI has expected nav', async () => {
   const card = new MemoryCard();
   const hardware = MemoryHardware.buildStandard();

--- a/frontends/election-manager/src/screens/ballot_list_screen.tsx
+++ b/frontends/election-manager/src/screens/ballot_list_screen.tsx
@@ -28,6 +28,7 @@ import { NavigationScreen } from '../components/navigation_screen';
 import { ExportElectionBallotPackageModalButton } from '../components/export_election_ballot_package_modal_button';
 import { ExportBallotPdfsButton } from '../components/export_ballot_pdfs_button';
 import { PrintAllBallotsButton } from '../components/print_all_ballots_button';
+import { canViewAndPrintBallotsWithConverter } from '../utils/can_view_and_print_ballots_with_converter';
 
 const Header = styled.div`
   display: flex;
@@ -36,9 +37,11 @@ const Header = styled.div`
 `;
 
 export function BallotListScreen(): JSX.Element {
-  const { auth, electionDefinition, configuredAt } = useContext(AppContext);
+  const { auth, converter, configuredAt, electionDefinition } =
+    useContext(AppContext);
   assert(electionDefinition && typeof configuredAt === 'string');
   const { election } = electionDefinition;
+  const canViewAndPrintBallots = canViewAndPrintBallotsWithConverter(converter);
 
   const allBallotStyles = getBallotStylesData(election);
   const ballotLists = [
@@ -59,6 +62,33 @@ export function BallotListScreen(): JSX.Element {
   }
 
   const ballots = ballotLists[ballotView];
+
+  if (!canViewAndPrintBallots) {
+    return (
+      <NavigationScreen>
+        <Header>
+          <Prose>
+            <p>This election uses custom ballots not produced by VxAdmin.</p>
+            <p>
+              The Ballot Package is still used to configure VxScan, the ballot
+              scanner.
+            </p>
+            {isElectionManagerAuth(auth) ? (
+              <p>
+                <ExportElectionBallotPackageModalButton />
+              </p>
+            ) : (
+              <p>
+                <em>
+                  Insert Election Manager card to save the Ballot Package.
+                </em>
+              </p>
+            )}
+          </Prose>
+        </Header>
+      </NavigationScreen>
+    );
+  }
 
   return (
     <NavigationScreen>

--- a/frontends/election-manager/src/utils/can_view_and_print_ballots_with_converter.ts
+++ b/frontends/election-manager/src/utils/can_view_and_print_ballots_with_converter.ts
@@ -1,0 +1,5 @@
+export function canViewAndPrintBallotsWithConverter(
+  converter?: string
+): boolean {
+  return converter !== 'nh-accuvote';
+}


### PR DESCRIPTION
Resolves #2492 

## Overview
When using `nh-accuvote` converter, there is not need to view/print ballots because VxAdmin produced ballots are not being used. 

System Administrator and Election Manager see message informing them of this on the Ballots tab. 

Election Manager still has access to "Save Ballot Package" button as this is necessary for configuring VxScan.

## Demo Video or Screenshot
https://user-images.githubusercontent.com/28444/190234541-3e7aa019-02af-4424-8a84-2510f06b1349.mov

## Testing Plan 
Added tests!

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
