### PR TITLE
feat(admin): make write-in transcription work

### DIFF
--- a/frontends/election-manager/src/hooks/use_transcribe_write_in_mutation.ts
+++ b/frontends/election-manager/src/hooks/use_transcribe_write_in_mutation.ts
@@ -1,0 +1,62 @@
+import {
+  useMutation,
+  UseMutationResult,
+  useQueryClient,
+} from '@tanstack/react-query';
+import { Admin } from '@votingworks/api';
+import { Id } from '@votingworks/types';
+import { fetchJson, typedAs } from '@votingworks/utils';
+import { getWriteInsQueryKey } from './use_write_ins_query';
+
+/**
+ * Values to pass to the transcription mutation.
+ */
+export interface Props {
+  readonly writeInId: Id;
+  readonly transcribedValue: string;
+}
+
+/**
+ * `useMutation` result for transcribing a write-in value.
+ */
+export type UseTranscribeWriteInMutationResult = UseMutationResult<
+  void,
+  unknown,
+  Props,
+  unknown
+>;
+
+/**
+ * Provides a mutation function to transcribe a write-in value.
+ */
+export function useTranscribeWriteInMutation(): UseTranscribeWriteInMutationResult {
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    async ({ writeInId, transcribedValue }) => {
+      const response = (await fetchJson(
+        `/admin/write-ins/${writeInId}/transcription`,
+        {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(
+            typedAs<Admin.PutWriteInTranscriptionRequest>({
+              value: transcribedValue,
+            })
+          ),
+        }
+      )) as Admin.PutWriteInTranscriptionResponse;
+
+      if (response.status !== 'ok') {
+        throw new Error(response.errors.map((e) => e.message).join(', '));
+      }
+    },
+    {
+      onSuccess: () => {
+        void queryClient.invalidateQueries(getWriteInsQueryKey());
+      },
+    }
+  );
+}

--- a/frontends/election-manager/src/screens/write_ins_transcription_screen.test.tsx
+++ b/frontends/election-manager/src/screens/write_ins_transcription_screen.test.tsx
@@ -1,76 +1,64 @@
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import React from 'react';
 import fetchMock from 'fetch-mock';
 import { electionMinimalExhaustiveSampleDefinition as electionDefinition } from '@votingworks/fixtures';
 import { CandidateContest } from '@votingworks/types';
+import userEvent from '@testing-library/user-event';
 import { renderInAppContext } from '../../test/render_in_app_context';
 import { WriteInsTranscriptionScreen } from './write_ins_transcription_screen';
+import { ElectionManagerStoreMemoryBackend } from '../lib/backends';
 
-describe('write-ins screen', () => {
-  const contest = electionDefinition.election.contests[0] as CandidateContest;
-  const onClickNext = jest.fn();
-  const onClickPrevious = jest.fn();
-  const onClose = jest.fn();
-  const onListAll = jest.fn();
-  const saveTranscribedValue = jest.fn();
+const contest = electionDefinition.election.contests[0] as CandidateContest;
+const onClose = jest.fn();
+const onListAll = jest.fn();
+const saveTranscribedValue = jest.fn();
 
-  beforeEach(() => {
-    fetchMock.mock();
-    fetchMock.get('/admin/write-ins/adjudications/contestId/count', [
-      { contestId: 'zoo-council-mammal', adjudicationCount: 3 },
-    ]);
-    fetchMock.get('/admin/write-ins/transcribed-values', [
-      'Daffy',
-      'Mickey Mouse',
-    ]);
-    fetchMock.get('/admin/write-ins/adjudication/id-174', [
-      {
-        contestId: 'best-animal-mammal',
-        transcribedValue: '',
-        id: 'id-174',
-      },
-    ]);
+beforeEach(() => {
+  fetchMock.mock();
+});
+
+test('clicking a previously-saved value', async () => {
+  const backend = new ElectionManagerStoreMemoryBackend({
+    electionDefinition,
   });
 
-  test('clicking a previously-saved value', async () => {
-    renderInAppContext(
-      <WriteInsTranscriptionScreen
-        election={electionDefinition.election}
-        contest={contest}
-        paginationIdx={0}
-        adjudications={[
-          {
-            contestId: 'best-animal-mammal',
-            transcribedValue: '',
-            id: 'id-174',
-          },
-        ]}
-        onClickNext={onClickNext}
-        onClickPrevious={onClickPrevious}
-        onClose={onClose}
-        onListAll={onListAll}
-        saveTranscribedValue={saveTranscribedValue}
-      />,
-      { electionDefinition }
-    );
-    screen.getByText('BALLOT IMAGES GO HERE');
+  renderInAppContext(
+    <WriteInsTranscriptionScreen
+      election={electionDefinition.election}
+      contest={contest}
+      adjudications={[
+        {
+          contestId: 'best-animal-mammal',
+          transcribedValue: '',
+          id: 'id-174',
+        },
+        {
+          contestId: 'best-animal-mammal',
+          transcribedValue: 'Mickey Mouse',
+          id: 'id-175',
+        },
+      ]}
+      onClose={onClose}
+      onListAll={onListAll}
+      saveTranscribedValue={saveTranscribedValue}
+    />,
+    { backend, electionDefinition }
+  );
+  await screen.findByText('BALLOT IMAGES GO HERE');
 
-    // Click a previously-saved transcription
-    await waitFor(() => {
-      screen.getByText('Mickey Mouse').click();
-    });
-    expect(saveTranscribedValue).toHaveBeenCalledWith('id-174', 'Mickey Mouse');
+  // Click a previously-saved transcription
+  userEvent.click(await screen.findByText('Mickey Mouse'));
+  expect(saveTranscribedValue).toHaveBeenCalledWith('id-174', 'Mickey Mouse');
 
-    screen.getByText('List All').click();
-    expect(onListAll).toHaveBeenCalledTimes(1);
+  userEvent.click(await screen.findByText('List All'));
+  expect(onListAll).toHaveBeenCalledTimes(1);
 
-    screen.getByText('Previous').click();
-    expect(onClickPrevious).toHaveBeenCalledTimes(1);
+  await screen.findByTestId('transcribe:id-174');
+  userEvent.click(await screen.findByText('Next'));
+  await screen.findByTestId('transcribe:id-175');
+  userEvent.click(await screen.findByText('Previous'));
+  await screen.findByTestId('transcribe:id-174');
 
-    screen.getByText('Next').click();
-    expect(onClickNext).toHaveBeenCalledTimes(1);
-
-    screen.getByText('Exit').click();
-    expect(onClose).toHaveBeenCalledTimes(1);
-  });
+  userEvent.click(await screen.findByText('Exit'));
+  expect(onClose).toHaveBeenCalledTimes(1);
 });

--- a/frontends/election-manager/test/render_in_app_context.tsx
+++ b/frontends/election-manager/test/render_in_app_context.tsx
@@ -30,7 +30,10 @@ import { CastVoteRecordFiles } from '../src/utils/cast_vote_record_files';
 import { AddCastVoteRecordFileResult } from '../src/lib/backends/types';
 import { getEmptyFullElectionTally } from '../src/lib/votecounting';
 import { ServicesContext } from '../src/contexts/services_context';
-import { ElectionManagerStoreMemoryBackend } from '../src/lib/backends';
+import {
+  ElectionManagerStoreBackend,
+  ElectionManagerStoreMemoryBackend,
+} from '../src/lib/backends';
 
 export const eitherNeitherElectionDefinition =
   electionWithMsEitherNeitherDefinition;
@@ -71,6 +74,7 @@ interface RenderInAppContextParams {
   hasCardReaderAttached?: boolean;
   hasPrinterAttached?: boolean;
   logger?: Logger;
+  backend?: ElectionManagerStoreBackend;
   queryClient?: QueryClient;
 }
 
@@ -80,6 +84,10 @@ export function renderRootElement(
     backend = new ElectionManagerStoreMemoryBackend(),
     logger = fakeLogger(),
     queryClient = new QueryClient(),
+  }: {
+    backend?: ElectionManagerStoreBackend;
+    logger?: Logger;
+    queryClient?: QueryClient;
   } = {}
 ): RenderResult {
   return testRender(
@@ -127,6 +135,7 @@ export function renderInAppContext(
     hasCardReaderAttached = true,
     hasPrinterAttached = true,
     logger = new Logger(LogSource.VxAdminFrontend),
+    backend,
     queryClient,
   }: RenderInAppContextParams = {}
 ): RenderResult {
@@ -166,6 +175,6 @@ export function renderInAppContext(
     >
       <Router history={history}>{component}</Router>
     </AppContext.Provider>,
-    { queryClient }
+    { backend, logger, queryClient }
   );
 }

--- a/libs/utils/src/collections.test.ts
+++ b/libs/utils/src/collections.test.ts
@@ -1,0 +1,68 @@
+import { map, reduce } from './collections';
+
+test('map with an array', () => {
+  const result = map(['a', 'b', 'c'], (value) => value.toUpperCase());
+  expect(result).toEqual(['A', 'B', 'C']);
+});
+
+test('map with a Map', () => {
+  const result = map(
+    new Map([
+      ['a', 'A'],
+      ['b', 'B'],
+      ['c', 'C'],
+    ]),
+    (value) => value.toLowerCase()
+  );
+  expect(result).toEqual(
+    new Map([
+      ['a', 'a'],
+      ['b', 'b'],
+      ['c', 'c'],
+    ])
+  );
+});
+
+test('map with a Set', () => {
+  const result = map(new Set(['a', 'b', 'c']), (value) => value.toUpperCase());
+  expect(result).toEqual(new Set(['A', 'B', 'C']));
+});
+
+test('map with an unsupported collection type', () => {
+  expect(() => map(0 as unknown as unknown[], () => 0)).toThrowError(
+    'Unsupported collection type'
+  );
+});
+
+test('reduce with an array', () => {
+  const result = reduce(['a', 'b', 'c'], (acc, item) => acc + item, '');
+  expect(result).toEqual('abc');
+});
+
+test('reduce with a Map', () => {
+  const result = reduce(
+    new Map([
+      ['a', 'A'],
+      ['b', 'B'],
+      ['c', 'C'],
+    ]),
+    (acc, item, key) => `${acc}${key}: ${item}\n`,
+    ''
+  );
+  expect(result).toEqual('a: A\nb: B\nc: C\n');
+});
+
+test('reduce with a Set', () => {
+  const result = reduce(
+    new Set(['a', 'b', 'c']),
+    (acc, item) => acc + item,
+    ''
+  );
+  expect(result).toEqual('abc');
+});
+
+test('reduce with an unsupported collection type', () => {
+  expect(() => reduce(0 as unknown as unknown[], () => 0, 0)).toThrowError(
+    'Unsupported collection type'
+  );
+});

--- a/libs/utils/src/collections.ts
+++ b/libs/utils/src/collections.ts
@@ -1,0 +1,99 @@
+/**
+ * Maps values from a `Map` to another `Map`, preserving the original keys.
+ */
+export function map<K, V, U>(
+  collection: ReadonlyMap<K, V>,
+  fn: (value: V, key: K) => U
+): Map<K, U>;
+
+/**
+ * Maps values from a `Set` to another `Set`.
+ */
+export function map<T, U>(
+  collection: ReadonlySet<T>,
+  fn: (value: T) => U
+): Set<U>;
+
+/**
+ * Maps values from an array to another array.
+ */
+export function map<T, U>(
+  collection: readonly T[],
+  fn: (value: T, index: number) => U
+): U[];
+
+export function map<T, U>(
+  collection: ReadonlyMap<unknown, T> | ReadonlySet<T> | readonly T[],
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fn: (value: T, key: any) => U
+): Map<unknown, U> | Set<U> | U[] {
+  if (collection instanceof Map) {
+    return new Map(
+      Array.from(collection, ([key, value]) => [key, fn(value, key)])
+    );
+  }
+
+  if (collection instanceof Set) {
+    return new Set(Array.from(collection, (value) => fn(value, value)));
+  }
+
+  if (Array.isArray(collection)) {
+    return collection.map((value, index) => fn(value, index));
+  }
+
+  throw new Error('Unsupported collection type');
+}
+
+/**
+ * Reduces values from a `Map` to a single value.
+ */
+export function reduce<K, V, U>(
+  collection: ReadonlyMap<K, V>,
+  fn: (acc: U, value: V, key: K) => U,
+  initial: U
+): U;
+
+/**
+ * Reduces values from a `Set` to a single value.
+ */
+export function reduce<T, U>(
+  collection: ReadonlySet<T>,
+  fn: (acc: U, value: T) => U,
+  initial: U
+): U;
+
+/**
+ * Reduces values from an array to a single value.
+ */
+export function reduce<T, U>(
+  collection: readonly T[],
+  fn: (acc: U, value: T, index: number) => U,
+  initial: U
+): U;
+
+export function reduce<T, U>(
+  collection: ReadonlyMap<unknown, T> | ReadonlySet<T> | readonly T[],
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fn: (acc: U, value: T, key: any) => U,
+  initial: U
+): U {
+  if (collection instanceof Map) {
+    return Array.from(collection).reduce(
+      (acc, [key, value]) => fn(acc, value, key),
+      initial
+    );
+  }
+
+  if (collection instanceof Set) {
+    return Array.from(collection).reduce(
+      (acc, value) => fn(acc, value, value),
+      initial
+    );
+  }
+
+  if (Array.isArray(collection)) {
+    return collection.reduce(fn, initial);
+  }
+
+  throw new Error('Unsupported collection type');
+}

--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -3,6 +3,7 @@ export * from './as_boolean';
 export * from './assert';
 export * from './ballot_package';
 export * from './Card';
+export * as collections from './collections';
 export * from './compressed_tallies';
 export * from './date';
 export * from './deferred';


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
This simplifies a few things in `WriteInScreen` and `WriteInTranscriptionScreen` around data management by removing the `useEffect` + `setSomeState` pattern. We can just compute things on the fly from the query data and we'll do something to make it faster if it's slow.

Responsibility for the current transcription "page" now belongs to `WriteInTranscriptionScreen`. In changing to react-query and `useWriteInsQuery` we reload the write-in data every time it changes. This isn't really ideal, but will probably work for now. As a result of that the `useEffect` that was trying to reset `paginationIdx` to 0 was being triggered on every transcription. Instead, we now let the transcription screen handle it and use `key=${contestId}` to ensure the new `offset` is reset in the event we somehow switch contests without unmounting the component first.

Transcription is now handled by a react-query mutation, wrapped in `useTranscribeWriteInMutation`. This ensures that the necessary data is reloaded when transcription happens.

## Demo Video or Screenshot

https://user-images.githubusercontent.com/1938/190278778-99afbf6c-d82e-499a-a405-67dafa046cd7.mov

## Testing Plan 
Tested manually:
- [x] adding new transcription value
- [x] selecting an existing transcription value

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
