### PR TITLE
fix feature flagging in production builds

### DIFF
--- a/libs/utils/src/env.d.ts
+++ b/libs/utils/src/env.d.ts
@@ -3,5 +3,9 @@ declare namespace NodeJS {
     NODE_ENV: 'development' | 'production' | 'test';
     REACT_APP_VX_DEV?: string;
     REACT_APP_VX_DISABLE_CARD_READER_CHECK?: string;
+    REACT_APP_VX_ENABLE_WRITE_IN_ADJUDICATION?: string;
+    REACT_APP_VX_ENABLE_ALL_ZERO_SMARTCARD_PIN_GENERATION?: string;
+    REACT_APP_VX_ENABLE_LIVECHECK?: string;
+    REACT_APP_VX_DISALLOW_CASTING_OVERVOTES?: string;
   }
 }

--- a/libs/utils/src/environment_flag.test.ts
+++ b/libs/utils/src/environment_flag.test.ts
@@ -1,10 +1,38 @@
-import { EnvironmentFlagName, getFlagDetails } from './environment_flag';
+import {
+  EnvironmentFlagName,
+  getFlag,
+  getFlagDetails,
+} from './environment_flag';
 
 describe('environment flags', () => {
+  const { env } = process;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...env };
+  });
+
   it('gets flag details as expected', () => {
     for (const flag of Object.values(EnvironmentFlagName)) {
       const details = getFlagDetails(flag);
       expect(details.name).toBe(flag);
     }
+  });
+
+  it('flags are undefined by default', () => {
+    for (const flag of Object.values(EnvironmentFlagName)) {
+      expect(getFlag(flag)).toBe(undefined);
+    }
+  });
+
+  it('flags are true as appropriate', () => {
+    for (const flag of Object.values(EnvironmentFlagName)) {
+      process.env[flag] = 'TRUE';
+      expect(getFlag(flag)).toBe('TRUE');
+    }
+  });
+
+  afterEach(() => {
+    process.env = env;
   });
 });

--- a/libs/utils/src/environment_flag.ts
+++ b/libs/utils/src/environment_flag.ts
@@ -21,6 +21,24 @@ export interface EnvironmentFlag {
   autoEnableInDevelopment: boolean;
 }
 
+export function getFlag(name: EnvironmentFlagName): string | undefined {
+  switch (name) {
+    case EnvironmentFlagName.WRITE_IN_ADJUDICATION:
+      return process.env.REACT_APP_VX_ENABLE_WRITE_IN_ADJUDICATION;
+    case EnvironmentFlagName.ALL_ZERO_SMARTCARD_PIN:
+      return process.env.REACT_APP_VX_ENABLE_ALL_ZERO_SMARTCARD_PIN_GENERATION;
+    case EnvironmentFlagName.DISABLE_CARD_READER_CHECK:
+      return process.env.REACT_APP_VX_DISABLE_CARD_READER_CHECK;
+    case EnvironmentFlagName.LIVECHECK:
+      return process.env.REACT_APP_VX_ENABLE_LIVECHECK;
+    case EnvironmentFlagName.DISALLOW_CASTING_OVERVOTES:
+      return process.env.REACT_APP_VX_DISALLOW_CASTING_OVERVOTES;
+    /* istanbul ignore next compile time check */
+    default:
+      throwIllegalValue(name);
+  }
+}
+
 export function getFlagDetails(name: EnvironmentFlagName): EnvironmentFlag {
   switch (name) {
     case EnvironmentFlagName.WRITE_IN_ADJUDICATION:

--- a/libs/utils/src/features.ts
+++ b/libs/utils/src/features.ts
@@ -1,5 +1,9 @@
 import { asBoolean } from './as_boolean';
-import { EnvironmentFlagName, getFlagDetails } from './environment_flag';
+import {
+  EnvironmentFlagName,
+  getFlag,
+  getFlagDetails,
+} from './environment_flag';
 
 export function isVxDev(): boolean {
   return asBoolean(process.env.REACT_APP_VX_DEV);
@@ -11,6 +15,6 @@ export function isFeatureFlagEnabled(flag: EnvironmentFlagName): boolean {
     (flagInfo.allowInProduction ||
       process.env.NODE_ENV === 'development' ||
       isVxDev()) &&
-    asBoolean(process.env[flag])
+    asBoolean(getFlag(flag))
   );
 }


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
See https://votingworks.slack.com/archives/CEL6D3GAD/p1663178111465069
For some reason in production builds, and specifically on real hardware not in VMs, trying to access indexed values on process.env was throwing type errors. On my surface go it was saying process was undefined and on my thinkpads it was saying env was undefined, but if I defined a variable on the env.d.ts file I could access it fine so this was the only way I could figure out how to fix it (I tried adding an arbitrary `[key: string]: string | undefined` but that didn't work). I'm annoyed that this adds 2 more locations where you have to add a bit of boilerplate when adding a feature flag so if people have suggestions on other things to try let me know.  

## Demo Video or Screenshot

## Testing Plan 
Ran on VxDev things worked as expected 

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
