### PR TITLE
Connect Write in Tally Report to real data

### DIFF
--- a/frontends/election-manager/src/components/election_manager_tally_report.tsx
+++ b/frontends/election-manager/src/components/election_manager_tally_report.tsx
@@ -9,6 +9,7 @@ import {
   TallyReportSummary,
 } from '@votingworks/ui';
 import {
+  ContestId,
   Election,
   ExternalTally,
   FullElectionExternalTallies,
@@ -39,7 +40,7 @@ export interface Props {
   precinctId?: string;
   scannerId?: string;
   votingMethod?: VotingMethod;
-  officialCandidateWriteIns?: Map<string, Map<string, number>>; // Contest -> Candidate ID -> Count
+  officialCandidateWriteIns?: Map<ContestId, Map<string, number>>; // Contest -> Candidate ID -> Count
 }
 
 export const ElectionManagerTallyReport = forwardRef<HTMLDivElement, Props>(

--- a/frontends/election-manager/src/lib/votecounting.ts
+++ b/frontends/election-manager/src/lib/votecounting.ts
@@ -22,6 +22,7 @@ import {
   Tally,
   ContestTally,
   ContestOptionTally,
+  ContestId,
 } from '@votingworks/types';
 import {
   assert,
@@ -411,7 +412,7 @@ function processCastVoteRecord({
 
 export function modifyTallyWithWriteInInfo(
   tally: Tally,
-  writeIns: Map<string, Map<string, number>>
+  writeIns: Map<ContestId, Map<string, number>>
 ): Tally {
   const oldContestTallies = tally.contestTallies;
   const newContestTallies: Dictionary<ContestTally> = {};

--- a/frontends/election-manager/src/utils/write_ins.tsx
+++ b/frontends/election-manager/src/utils/write_ins.tsx
@@ -1,0 +1,46 @@
+import { Admin } from '@votingworks/api';
+import { ContestId } from '@votingworks/types';
+import { assert, collections, groupBy } from '@votingworks/utils';
+
+export function getWriteInCountsByContestAndCandidate(
+  writeInSummaryData: Admin.WriteInSummaryEntry[],
+  onlyOfficialCandidates = false
+): Map<ContestId, Map<string, number>> {
+  const writeInsByContestAndCandidate = collections.map(
+    groupBy(writeInSummaryData, ({ contestId }) => contestId),
+    (writeInSummary) => {
+      return onlyOfficialCandidates
+        ? groupBy(
+            [...writeInSummary].filter(
+              (s) => s.writeInAdjudication?.adjudicatedOptionId !== undefined
+            ),
+            (s) => {
+              // we have already filtered for this
+              assert(s.writeInAdjudication?.adjudicatedOptionId !== undefined);
+              return s.writeInAdjudication.adjudicatedOptionId;
+            }
+          )
+        : groupBy(
+            [...writeInSummary].filter(
+              (s) =>
+                s.writeInAdjudication?.adjudicatedValue !== undefined &&
+                s.writeInAdjudication?.adjudicatedOptionId === undefined
+            ),
+            (s) => {
+              // we have already filtered for this
+              assert(s.writeInAdjudication?.adjudicatedValue !== undefined);
+              return s.writeInAdjudication.adjudicatedValue;
+            }
+          );
+    }
+  );
+  return collections.map(writeInsByContestAndCandidate, (byCandidate) =>
+    collections.map(byCandidate, (entries) =>
+      collections.reduce(
+        entries,
+        (sum, entry) => sum + entry.writeInCount ?? 0,
+        0
+      )
+    )
+  );
+}


### PR DESCRIPTION
## Overview
Based on https://github.com/votingworks/vxsuite/pull/2562/files wires up the write in tally report to actual data. 

## Demo Video or Screenshot


## Testing Plan 
Manually adjudicated write-ins and saw results. 

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
