### PR TITLE
fix(types): no implicit `any`

### DIFF
--- a/frontends/election-manager/src/components/confirm_removing_file_modal.tsx
+++ b/frontends/election-manager/src/components/confirm_removing_file_modal.tsx
@@ -28,7 +28,7 @@ export function ConfirmRemovingFileModal({
     ExternalTallySourceType.Manual
   );
 
-  let mainContent = null;
+  let mainContent: React.ReactNode = null;
   let fileTypeName = '';
   let singleFileRemoval = true;
   switch (fileType) {

--- a/frontends/election-manager/src/components/export_ballot_pdfs_button.tsx
+++ b/frontends/election-manager/src/components/export_ballot_pdfs_button.tsx
@@ -184,8 +184,8 @@ export function ExportBallotPdfsButton(): JSX.Element {
     }
   }
 
-  let mainContent = null;
-  let actions = null;
+  let mainContent: React.ReactNode = null;
+  let actions: React.ReactNode = null;
 
   switch (modalState) {
     case 'BeforeExport':

--- a/frontends/election-manager/src/components/export_election_ballot_package_modal_button.tsx
+++ b/frontends/election-manager/src/components/export_election_ballot_package_modal_button.tsx
@@ -188,8 +188,8 @@ export function ExportElectionBallotPackageModalButton(): JSX.Element {
     }
   }
 
-  let mainContent = null;
-  let actions = null;
+  let mainContent: React.ReactNode = null;
+  let actions: React.ReactNode = null;
 
   switch (state.type) {
     case 'Init': {

--- a/frontends/election-manager/src/components/print_all_ballots_button.tsx
+++ b/frontends/election-manager/src/components/print_all_ballots_button.tsx
@@ -225,8 +225,8 @@ export function PrintAllBallotsButton(): JSX.Element {
     onPrintError,
   ]);
 
-  let mainContent = null;
-  let actions = null;
+  let mainContent: React.ReactNode = null;
+  let actions: React.ReactNode = null;
   let onOverlayClick: VoidFunction | undefined = closeModal;
 
   switch (modalState) {


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
These variables were treated as `any` by TypeScript, but annoyingly don't trigger the `noImplicitAny` configuration in `tsconfig.json`. This commit adds a type annotation so the type can be properly enforced.

## Demo Video or Screenshot
n/a

## Testing Plan 
n/a

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
