### PR TITLE
Better converter fix

### DIFF
--- a/frontends/election-manager/src/screens/unconfigured_screen.tsx
+++ b/frontends/election-manager/src/screens/unconfigured_screen.tsx
@@ -66,6 +66,7 @@ export function UnconfiguredScreen(): JSX.Element {
   const [inputConversionFiles, setInputConversionFiles] = useState<VxFile[]>(
     []
   );
+  const [isLoading, setIsLoading] = useState(true);
   const [vxElectionFileIsInvalid, setVxElectionFileIsInvalid] = useState(false);
   const [client, setClient] = useState<ConverterClient>();
   const [isUsingConverter, setIsUsingConverter] = useState(false);
@@ -129,6 +130,8 @@ export function UnconfiguredScreen(): JSX.Element {
         saveElectionAndShowSuccess(electionJson);
       } catch (error) {
         console.log('failed getOutputFile()', error); // eslint-disable-line no-console
+      } finally {
+        setIsLoading(false);
       }
     },
     [client, resetServerFiles, saveElectionAndShowSuccess]
@@ -143,9 +146,10 @@ export function UnconfiguredScreen(): JSX.Element {
       } catch (error) {
         console.log('failed processInputFiles()', error); // eslint-disable-line no-console
         await client.reset();
+        setIsLoading(false);
       }
     },
-    [client, getOutputFile]
+    [client, getOutputFile, setIsLoading]
   );
 
   const updateStatus = useCallback(async () => {
@@ -156,6 +160,8 @@ export function UnconfiguredScreen(): JSX.Element {
       if (!isMounted()) {
         return;
       }
+
+      setIsLoading(true);
 
       const electionFile = files.outputFiles[0];
       if (electionFile.path) {
@@ -169,8 +175,9 @@ export function UnconfiguredScreen(): JSX.Element {
       }
 
       setInputConversionFiles(files.inputFiles);
-    } catch {
-      // ignore error
+      setIsLoading(false);
+    } catch (error) {
+      setIsLoading(false);
     }
   }, [client, getOutputFile, isMounted, processInputFiles]);
 
@@ -209,7 +216,7 @@ export function UnconfiguredScreen(): JSX.Element {
     void updateStatus();
   }, [updateStatus]);
 
-  if (isUploading) {
+  if (isUploading || isLoading) {
     return (
       <NavigationScreen>
         <Loading isFullscreen />

--- a/integration-testing/election-manager/cypress/e2e/candidate_contest_tallies.cy.ts
+++ b/integration-testing/election-manager/cypress/e2e/candidate_contest_tallies.cy.ts
@@ -113,7 +113,6 @@ describe('Election Manager can create SEMS tallies', () => {
       { contents: Cypress.Buffer.from(electionDefinition.electionData) },
       { force: true }
     );
-    cy.contains('Election loading');
     cy.contains(electionDefinition.electionHash.slice(0, 10));
     cy.pause();
     cy.contains('Lock Machine').click();

--- a/integration-testing/election-manager/cypress/e2e/configuration.cy.ts
+++ b/integration-testing/election-manager/cypress/e2e/configuration.cy.ts
@@ -19,7 +19,6 @@ describe('Election Manager and Module Converter MS SEMS configuration', () => {
       'cypress/fixtures/semsCandidateMappingFile.txt',
       { force: true }
     );
-    cy.contains('Election loading');
     cy.contains('Special Election for Senate 15');
     cy.contains('0d610ab44c');
     // The page renders twice when first loaded, make sure that is done before we navigate.

--- a/integration-testing/election-manager/cypress/e2e/tallies.cy.ts
+++ b/integration-testing/election-manager/cypress/e2e/tallies.cy.ts
@@ -18,7 +18,6 @@ describe('Election Manager can create SEMS tallies', () => {
       { contents: Cypress.Buffer.from(electionDefinition.electionData) },
       { force: true }
     );
-    cy.contains('Election loading');
     cy.contains(electionDefinition.electionHash.slice(0, 10));
     cy.contains('Lock Machine').click();
     mockElectionManagerCardInsertion(

--- a/integration-testing/election-manager/cypress/e2e/yes_no_contest_tallies.cy.ts
+++ b/integration-testing/election-manager/cypress/e2e/yes_no_contest_tallies.cy.ts
@@ -171,7 +171,6 @@ describe('Election Manager can create SEMS tallies', () => {
       },
       { force: true }
     );
-    cy.contains('Election loading');
     cy.contains(
       electionWithMsEitherNeitherDefinition.electionHash.slice(0, 10)
     );


### PR DESCRIPTION
The previous fix caused a UX lag when converting that could be confusing. The `isLoading` state is still useful. So brought it back, and moved the state transitions to strictly when they're needed, so it doesn't happen on every load.

There's likely still some further refactoring we could do here, just to simplify the `updateStatus` approach. Leaving that to later work.