### PR TITLE
test(plustek-sdk): fix flaky coverage

### DIFF
--- a/libs/plustek-sdk/src/mocks.ts
+++ b/libs/plustek-sdk/src/mocks.ts
@@ -252,6 +252,10 @@ function initMachine(toggleHoldDuration: number, passthroughDuration: number) {
   );
 }
 
+function oneOf<T>(...array: T[]): T {
+  return array[Math.floor(Math.random() * array.length)];
+}
+
 /**
  * Provides a mock `ScannerClient` that acts like the plustek VTM 300.
  */
@@ -468,9 +472,7 @@ export class MockScannerClient implements ScannerClient {
       case 'no_paper_before_hold':
         debug('no paper');
         return ok(
-          Math.random() > 0.5
-            ? PaperStatus.VtmDevReadyNoPaper
-            : PaperStatus.NoPaperStatus
+          oneOf(PaperStatus.VtmDevReadyNoPaper, PaperStatus.NoPaperStatus)
         );
       case 'ready_to_scan':
         debug('ready to scan');
@@ -481,9 +483,10 @@ export class MockScannerClient implements ScannerClient {
       case 'jam':
         debug('jam');
         return ok(
-          Math.random() > 0.5
-            ? PaperStatus.VtmFrontAndBackSensorHavePaperReady
-            : PaperStatus.Jam
+          oneOf(
+            PaperStatus.VtmFrontAndBackSensorHavePaperReady,
+            PaperStatus.Jam
+          )
         );
       case 'both_sides_have_paper':
         debug('both sides have paper');


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Rather than using a ternary expression, which Istanbul checks both branches for execution, just pick one from an array so the code will always be considered covered.

Fixes #2589 

## Demo Video or Screenshot
n/a

## Testing Plan 
Automated.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
