### PR TITLE
feat(scan-nh): remove `BlankBallot` adjudication reason

### DIFF
--- a/libs/ballot-interpreter-nh/src/convert.test.ts
+++ b/libs/ballot-interpreter-nh/src/convert.test.ts
@@ -404,14 +404,12 @@ test('default adjudication reasons', async () => {
     typedAs<AdjudicationReason[]>([
       AdjudicationReason.UninterpretableBallot,
       AdjudicationReason.Overvote,
-      AdjudicationReason.BlankBallot,
     ])
   );
   expect(convertResult.election?.precinctScanAdjudicationReasons).toEqual(
     typedAs<AdjudicationReason[]>([
       AdjudicationReason.UninterpretableBallot,
       AdjudicationReason.Overvote,
-      AdjudicationReason.BlankBallot,
     ])
   );
 });

--- a/libs/ballot-interpreter-nh/src/convert.ts
+++ b/libs/ballot-interpreter-nh/src/convert.ts
@@ -883,12 +883,10 @@ export function convertElectionDefinitionHeader(
     centralScanAdjudicationReasons: [
       AdjudicationReason.UninterpretableBallot,
       AdjudicationReason.Overvote,
-      AdjudicationReason.BlankBallot,
     ],
     precinctScanAdjudicationReasons: [
       AdjudicationReason.UninterpretableBallot,
       AdjudicationReason.Overvote,
-      AdjudicationReason.BlankBallot,
     ],
     sealUrl: '/seals/Seal_of_New_Hampshire.svg',
   };

--- a/libs/ballot-interpreter-nh/src/interpret/index.test.ts
+++ b/libs/ballot-interpreter-nh/src/interpret/index.test.ts
@@ -1609,7 +1609,7 @@ test('interpret marked', async () => {
           "metadata": Object {
             "ballotStyleId": "card-number-54",
             "ballotType": 0,
-            "electionHash": "e68e493e38c5bad141ed00373499a4ad4ffd8a00865de38cc1263669c9c6d9a6",
+            "electionHash": "f3b3502d0faafae126dee57d83320e4515dad78824eebf99db22ee642f18f044",
             "isTestMode": false,
             "locales": Object {
               "primary": "unknown",
@@ -3943,7 +3943,7 @@ test('interpret marked', async () => {
         "metadata": Object {
           "ballotStyleId": "card-number-54",
           "ballotType": 0,
-          "electionHash": "e68e493e38c5bad141ed00373499a4ad4ffd8a00865de38cc1263669c9c6d9a6",
+          "electionHash": "f3b3502d0faafae126dee57d83320e4515dad78824eebf99db22ee642f18f044",
           "isTestMode": false,
           "locales": Object {
             "primary": "unknown",
@@ -4937,7 +4937,7 @@ test('interpret marked', async () => {
           "metadata": Object {
             "ballotStyleId": "card-number-54",
             "ballotType": 0,
-            "electionHash": "e68e493e38c5bad141ed00373499a4ad4ffd8a00865de38cc1263669c9c6d9a6",
+            "electionHash": "f3b3502d0faafae126dee57d83320e4515dad78824eebf99db22ee642f18f044",
             "isTestMode": false,
             "locales": Object {
               "primary": "unknown",
@@ -5801,7 +5801,7 @@ test('interpret marked', async () => {
         "metadata": Object {
           "ballotStyleId": "card-number-54",
           "ballotType": 0,
-          "electionHash": "e68e493e38c5bad141ed00373499a4ad4ffd8a00865de38cc1263669c9c6d9a6",
+          "electionHash": "f3b3502d0faafae126dee57d83320e4515dad78824eebf99db22ee642f18f044",
           "isTestMode": false,
           "locales": Object {
             "primary": "unknown",
@@ -7456,7 +7456,7 @@ test('interpret unmarked', async () => {
           "metadata": Object {
             "ballotStyleId": "card-number-54",
             "ballotType": 0,
-            "electionHash": "e68e493e38c5bad141ed00373499a4ad4ffd8a00865de38cc1263669c9c6d9a6",
+            "electionHash": "f3b3502d0faafae126dee57d83320e4515dad78824eebf99db22ee642f18f044",
             "isTestMode": false,
             "locales": Object {
               "primary": "unknown",
@@ -9790,7 +9790,7 @@ test('interpret unmarked', async () => {
         "metadata": Object {
           "ballotStyleId": "card-number-54",
           "ballotType": 0,
-          "electionHash": "e68e493e38c5bad141ed00373499a4ad4ffd8a00865de38cc1263669c9c6d9a6",
+          "electionHash": "f3b3502d0faafae126dee57d83320e4515dad78824eebf99db22ee642f18f044",
           "isTestMode": false,
           "locales": Object {
             "primary": "unknown",
@@ -10474,7 +10474,7 @@ test('interpret unmarked', async () => {
           "metadata": Object {
             "ballotStyleId": "card-number-54",
             "ballotType": 0,
-            "electionHash": "e68e493e38c5bad141ed00373499a4ad4ffd8a00865de38cc1263669c9c6d9a6",
+            "electionHash": "f3b3502d0faafae126dee57d83320e4515dad78824eebf99db22ee642f18f044",
             "isTestMode": false,
             "locales": Object {
               "primary": "unknown",
@@ -11338,7 +11338,7 @@ test('interpret unmarked', async () => {
         "metadata": Object {
           "ballotStyleId": "card-number-54",
           "ballotType": 0,
-          "electionHash": "e68e493e38c5bad141ed00373499a4ad4ffd8a00865de38cc1263669c9c6d9a6",
+          "electionHash": "f3b3502d0faafae126dee57d83320e4515dad78824eebf99db22ee642f18f044",
           "isTestMode": false,
           "locales": Object {
             "primary": "unknown",

--- a/libs/ballot-interpreter-nh/test/fixtures/amherst-2022-07-12/election.json
+++ b/libs/ballot-interpreter-nh/test/fixtures/amherst-2022-07-12/election.json
@@ -16,8 +16,7 @@
   ],
   "centralScanAdjudicationReasons": [
     "UninterpretableBallot",
-    "Overvote",
-    "BlankBallot"
+    "Overvote"
   ],
   "contests": [
     {
@@ -874,8 +873,7 @@
   ],
   "precinctScanAdjudicationReasons": [
     "UninterpretableBallot",
-    "Overvote",
-    "BlankBallot"
+    "Overvote"
   ],
   "precincts": [
     {

--- a/libs/ballot-interpreter-nh/test/fixtures/hudson-2020-11-03/election.json
+++ b/libs/ballot-interpreter-nh/test/fixtures/hudson-2020-11-03/election.json
@@ -16,8 +16,7 @@
   ],
   "centralScanAdjudicationReasons": [
     "UninterpretableBallot",
-    "Overvote",
-    "BlankBallot"
+    "Overvote"
   ],
   "contests": [
     {
@@ -1175,8 +1174,7 @@
   ],
   "precinctScanAdjudicationReasons": [
     "UninterpretableBallot",
-    "Overvote",
-    "BlankBallot"
+    "Overvote"
   ],
   "precincts": [
     {


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
New election definitions converted from NH format will no longer have the `BlankBallot` adjudication reason, per NH SoS.

Closes #2578 

## Demo Video or Screenshot
n/a

## Testing Plan 
n/a

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
