### PR TITLE
fix(scan): improve `retry-scan` error handling

### DIFF
--- a/services/scan/bin/retry-scan
+++ b/services/scan/bin/retry-scan
@@ -8,7 +8,7 @@ require('../src/cli/retry-scan/main')
     stderr: process.stderr,
   })
   .catch((error) => {
-    process.stderr.write(`CRASH: ${error}\n`);
+    process.stderr.write(`CRASH: ${error.stack}\n`);
     return 1;
   })
   .then((code) => {

--- a/services/scan/src/workers/child_process_worker.js
+++ b/services/scan/src/workers/child_process_worker.js
@@ -6,6 +6,7 @@ if (process.env.NODE_ENV !== 'production') {
   require('esbuild-runner/register');
 }
 
+const { ok, err } = require('@votingworks/types');
 const { assert } = require('@votingworks/utils');
 const { resolve } = require('path');
 const json = require('./json_serialization');
@@ -26,13 +27,15 @@ process.on(
 
     try {
       output = await call(json.deserialize(input));
+
+      if (process.send) {
+        process.send(json.serialize(ok(output)));
+      }
     } catch (error) {
       assert(error instanceof Error);
-      output = { type: 'error', error: `${error.stack}` };
-    }
-
-    if (process.send) {
-      process.send({ output: json.serialize(output) });
+      if (process.send) {
+        process.send(json.serialize(err(error)));
+      }
     }
   }
 );

--- a/services/scan/src/workers/worker_thread_worker.js
+++ b/services/scan/src/workers/worker_thread_worker.js
@@ -6,6 +6,7 @@ if (process.env.NODE_ENV !== 'production') {
   require('esbuild-runner/register');
 }
 
+const { err, ok } = require('@votingworks/types');
 const { assert } = require('@votingworks/utils');
 const { resolve } = require('path');
 const { parentPort, workerData } = require('worker_threads');
@@ -23,12 +24,12 @@ if (pp) {
     let output;
 
     try {
-      output = await call(json.deserialize(input));
+      output = ok(await call(json.deserialize(input)));
     } catch (error) {
       assert(error instanceof Error);
-      output = { type: 'error', error: `${error.stack}` };
+      output = err(error);
     }
 
-    pp.postMessage({ output: json.serialize(output) });
+    pp.postMessage(json.serialize(output));
   });
 }


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Makes a couple minor improvements to error handling with `retry-scan` and anything that uses the worker pool. When an error was thrown while a worker was running a job it would return an object from `pool.call` like `{ type: 'error', error: 'message' }` rather than throwing. We now throw (i.e. return a rejected promise) when the worker throws.

## Demo Video or Screenshot
n/a

## Testing Plan 
Tested locally with `retry-scan` manually, lots of automated testing.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
