### PR TITLE
feat(res-to-ts): count `application/xml` as text

### DIFF
--- a/libs/res-to-ts/src/mime.test.ts
+++ b/libs/res-to-ts/src/mime.test.ts
@@ -27,6 +27,7 @@ test('image types', () => {
 test('text types', () => {
   expect(isTextMimeType('text/plain')).toBe(true);
   expect(isTextMimeType('text/csv')).toBe(true);
+  expect(isTextMimeType('application/xml')).toBe(true);
   expect(isTextMimeType('application/json')).toBe(true);
   expect(isTextMimeType('application/jsonlines')).toBe(true);
   expect(isTextMimeType('image/png')).toBe(false);

--- a/libs/res-to-ts/src/mime.ts
+++ b/libs/res-to-ts/src/mime.ts
@@ -24,7 +24,9 @@ export function getMimeType(path: string): string {
  */
 export function isTextMimeType(mimeType: string): boolean {
   return (
-    mimeType.startsWith('text/') || mimeType.startsWith('application/json')
+    mimeType.startsWith('text/') ||
+    mimeType.startsWith('application/json') ||
+    mimeType === 'application/xml'
   );
 }
 

--- a/services/scan/bin/retry-scan
+++ b/services/scan/bin/retry-scan
@@ -8,7 +8,7 @@ require('../src/cli/retry-scan/main')
     stderr: process.stderr,
   })
   .catch((error) => {
-    process.stderr.write(`CRASH: ${error}\n`);
+    process.stderr.write(`CRASH: ${error.stack}\n`);
     return 1;
   })
   .then((code) => {

--- a/services/scan/src/workers/child_process_worker.js
+++ b/services/scan/src/workers/child_process_worker.js
@@ -6,6 +6,7 @@ if (process.env.NODE_ENV !== 'production') {
   require('esbuild-runner/register');
 }
 
+const { ok, err } = require('@votingworks/types');
 const { assert } = require('@votingworks/utils');
 const { resolve } = require('path');
 const json = require('./json_serialization');
@@ -26,13 +27,15 @@ process.on(
 
     try {
       output = await call(json.deserialize(input));
+
+      if (process.send) {
+        process.send(json.serialize(ok(output)));
+      }
     } catch (error) {
       assert(error instanceof Error);
-      output = { type: 'error', error: `${error.stack}` };
-    }
-
-    if (process.send) {
-      process.send({ output: json.serialize(output) });
+      if (process.send) {
+        process.send(json.serialize(err(error)));
+      }
     }
   }
 );

--- a/services/scan/src/workers/worker_thread_worker.js
+++ b/services/scan/src/workers/worker_thread_worker.js
@@ -6,6 +6,7 @@ if (process.env.NODE_ENV !== 'production') {
   require('esbuild-runner/register');
 }
 
+const { err, ok } = require('@votingworks/types');
 const { assert } = require('@votingworks/utils');
 const { resolve } = require('path');
 const { parentPort, workerData } = require('worker_threads');
@@ -23,12 +24,12 @@ if (pp) {
     let output;
 
     try {
-      output = await call(json.deserialize(input));
+      output = ok(await call(json.deserialize(input)));
     } catch (error) {
       assert(error instanceof Error);
-      output = { type: 'error', error: `${error.stack}` };
+      output = err(error);
     }
 
-    pp.postMessage({ output: json.serialize(output) });
+    pp.postMessage(json.serialize(output));
   });
 }


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
I'll be adding an `.xml` fixture soon and I need to be able to use `.asText()` with it.

## Demo Video or Screenshot
n/a

## Testing Plan 
Tested manually in a later commit built on top of this.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
