### PR TITLE
fix bug with tally report not loading adjudications on first load

### DIFF
--- a/frontends/election-manager/src/screens/tally_report_screen.tsx
+++ b/frontends/election-manager/src/screens/tally_report_screen.tsx
@@ -229,7 +229,12 @@ export function TallyReportScreen(): JSX.Element {
     if (previewReportRef?.current && printReportRef?.current) {
       previewReportRef.current.innerHTML = printReportRef.current.innerHTML;
     }
-  }, [previewReportRef, printReportRef, isOfficialResults]);
+  }, [
+    previewReportRef,
+    printReportRef,
+    isOfficialResults,
+    writeInCountsByContestAndCandidate,
+  ]);
 
   return (
     <React.Fragment>


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
When the tally report screen loads it calls react query for the write in summary information. It immediately calls it twice, the first set of results is stale and writeInSummaryQuery.isStale is true, long term the better fix here is probably to be using that variable and show a loading state or something while isState is true, but its immediately re-called and then given new data. However since the counts are not in this useEffect that shows the preview on the screen it is not redrawn with the new data when it gets loaded, like the write in tally report does, so the new data never appears. This was the most minimal change to fix that but I defer to @eventualbuddha on if we should be using isStale or doing something else long term as the better solution here. 

## Demo Video or Screenshot

## Testing Plan 
Adjudicated write-ins immediately loaded tally report and saw the proper tallies. 

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
