### PR TITLE
Revert "fix(admin): use non-array index key (#2583)"

### DIFF
--- a/frontends/election-manager/src/screens/print_test_deck_screen.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.tsx
@@ -96,12 +96,12 @@ function BmdPaperBallots({
 
   return (
     <div className="print-only">
-      {ballots.map((ballot) => (
+      {ballots.map((ballot, i) => (
         <BmdPaperBallot
           ballotStyleId={ballot.ballotStyleId}
           electionDefinition={electionDefinition}
           isLiveMode={false}
-          key={`ballot-${ballot.precinctId}-${ballot.ballotStyleId}`}
+          key={`ballot-${i}`} // eslint-disable-line react/no-array-index-key
           precinctId={ballot.precinctId}
           votes={ballot.votes}
           onRendered={onRendered}


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
This reverts commit 8fc721f4ba6cb4c9a8347683b33be4e9c05877a1. [Slack context](https://votingworks.slack.com/archives/CEL6D3GAD/p1664055582530589). Refs #1864.

## Demo Video or Screenshot
n/a

## Testing Plan 
@arsalansufi found that the change this reverts created duplicate keys in some circumstances. This fixes it by reverting.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
