### PR TITLE
test(cypress): improve flakiness

### DIFF
--- a/integration-testing/election-manager/cypress/e2e/candidate_contest_tallies.cy.ts
+++ b/integration-testing/election-manager/cypress/e2e/candidate_contest_tallies.cy.ts
@@ -114,6 +114,10 @@ describe('Election Manager can create SEMS tallies', () => {
       { force: true }
     );
     cy.contains(electionDefinition.electionHash.slice(0, 10));
+
+    // wait until the loading screen goes away
+    cy.contains('h1', 'Election Definition');
+
     cy.contains('Lock Machine').click();
     mockElectionManagerCardInsertion(electionDefinition);
     enterPin();

--- a/integration-testing/election-manager/cypress/e2e/configuration.cy.ts
+++ b/integration-testing/election-manager/cypress/e2e/configuration.cy.ts
@@ -22,8 +22,7 @@ describe('Election Manager and Module Converter MS SEMS configuration', () => {
     cy.contains('Special Election for Senate 15');
     cy.contains('0d610ab44c');
     // The page renders twice when first loaded, make sure that is done before we navigate.
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(500);
+    cy.contains('h1', 'Election Definition');
     cy.contains('Definition').click();
     cy.contains('State Senate 15');
     cy.contains('District 15');

--- a/integration-testing/election-manager/cypress/e2e/tallies.cy.ts
+++ b/integration-testing/election-manager/cypress/e2e/tallies.cy.ts
@@ -19,6 +19,10 @@ describe('Election Manager can create SEMS tallies', () => {
       { force: true }
     );
     cy.contains(electionDefinition.electionHash.slice(0, 10));
+
+    // wait until the loading screen goes away
+    cy.contains('h1', 'Election Definition');
+
     cy.contains('Lock Machine').click();
     mockElectionManagerCardInsertion(
       electionMultiPartyPrimaryFixtures.electionDefinition

--- a/integration-testing/election-manager/cypress/e2e/yes_no_contest_tallies.cy.ts
+++ b/integration-testing/election-manager/cypress/e2e/yes_no_contest_tallies.cy.ts
@@ -174,6 +174,10 @@ describe('Election Manager can create SEMS tallies', () => {
     cy.contains(
       electionWithMsEitherNeitherDefinition.electionHash.slice(0, 10)
     );
+
+    // wait until the loading screen goes away
+    cy.contains('h1', 'Election Definition');
+
     cy.contains('Lock Machine').click();
     mockElectionManagerCardInsertion(electionWithMsEitherNeitherDefinition);
     enterPin();

--- a/integration-testing/election-manager/cypress/support/auth.ts
+++ b/integration-testing/election-manager/cypress/support/auth.ts
@@ -38,6 +38,7 @@ export function mockElectionManagerCardInsertion({
  * Enters a card PIN
  */
 export function enterPin(): void {
+  cy.contains('Enter the card security code to unlock.');
   for (const digit of PIN) {
     cy.get(`button:contains(${digit})`).click();
   }


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->

Unlike with pastries, with tests we do _not_ want flakiness. 🥐 

The most common inconsistent test failure in the EM tests was trying to click "Lock Machine". The error said that the DOM element being clicked was detached from the document, and helpfully pointed to [some documentation][1]. That documentation, in turn, pointed to an [even more helpful blog post on this particular race condition][2]. The problem is similar to race conditions we've encountered with Jest DOM tests where the test runner gets ahead of the application under test. The solution is also the same in both cases: wait for the conditions to be right before performing more actions.

In the case of the "Lock Machine" flake, the problem is that we render that button as part of the `NavigationScreen`, but that screen is passed the children it should render (i.e. the main screen content) rather than rendering that content itself. This means that we have many invocations of `NavigationScreen` depending on the current state. Switching between them, e.g. when transitioning from a "Loading" screen to the "Election Definition" screen, completely unmounts and re-mounts the `NavigationScreen` and its buttons. So when we tell Cypress to do this:

```ts
cy.contains('Lock Machine').click();
```

This is actually two separate actions:
1. finds the appropriate DOM element containing "Lock Machine"
2. (after some amount of time) clicks it

However, the application may update the screen between 1 & 2, such as when a `fetch` with the election definition data returns. That means [this happens (see `candidate_contest_tallies.cy.ts` at 29s)](https://app.circleci.com/pipelines/github/votingworks/vxsuite/5937/workflows/5ab3df41-e6ca-493c-84e1-6b405b10d3c7/jobs/138717/artifacts):

1. `fetch` for election definition data begins
2. renders "Loading" screen
3. finds the appropriate DOM element containing "Lock Machine"
4. `fetch` from (1) returns and the "Election Definition" screen loads, replacing the "Lock Machine" element from (3) with a new one
5. attempt to click "Lock Machine" from (3), which fails because it is no longer in the DOM

This typically passes locally because our development machines are fast and the above steps happen in the expected order rather than this incorrect order. You can force it to happen locally when running interactively by changing the code above to this:

```ts
cy.contains('Lock Machine').pause().click();
```

This forces the ordering that triggers the race condition since there will be a lot of time between the `contains` and `click` actions. This commit fixes the issue by ensuring that we're on the "Election Definition" screen before the `contains` action happens, which ensures that the DOM element is not detached before the `click` is run.

This commit also updates the PIN pad with a similar fix–we tell the test runner to wait until we're prompted to enter the PIN instead of racing ahead if it happens to see a button with the right number in its text.

[1]: https://docs.cypress.io/guides/references/error-messages#cy-failed-because-the-element-you-are-chaining-off-of-has-become-detached-or-removed-from-the-dom
[2]: https://www.cypress.io/blog/2020/07/22/do-not-get-too-detached/

## Demo Video or Screenshot

## Testing Plan 
Ran all the EM Cypress tests locally a fair amount, verified that adding `.pause()` triggered the race condition and that the fixes made it work even with the `.pause()` present. Also, I'll note that the tests passed in CI with no flakes!

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
