### PR TITLE
fix(admin): ignore missing converter output

### DIFF
--- a/frontends/election-manager/src/screens/unconfigured_screen.tsx
+++ b/frontends/election-manager/src/screens/unconfigured_screen.tsx
@@ -163,6 +163,10 @@ export function UnconfiguredScreen(): JSX.Element {
       }
 
       const electionFile = files.outputFiles[0];
+      if (!electionFile) {
+        return;
+      }
+
       if (electionFile.path) {
         await getOutputFile(electionFile.name);
         return;


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
I don't think this is actually an issue at runtime, but the `smartcard_modal.test.tsx` tests were [printing `failed updateStatus() 'path' is not a property of undefined`](https://app.circleci.com/pipelines/github/votingworks/vxsuite/5950/workflows/5d15738a-c5db-4aae-8600-a070d3fe8fe2/jobs/139163?invite=true#step-108-141).

## Demo Video or Screenshot
n/a

## Testing Plan 
n/a

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
