### PR TITLE
refactor(hooks): more idiomatic `useEffect`

### DIFF
--- a/frontends/election-manager/src/screens/unconfigured_screen.tsx
+++ b/frontends/election-manager/src/screens/unconfigured_screen.tsx
@@ -1,4 +1,10 @@
-import React, { useContext, useState, useEffect, useCallback } from 'react';
+import React, {
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+} from 'react';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -8,7 +14,6 @@ import { Button, Prose, useMountedState } from '@votingworks/ui';
 import { assert } from '@votingworks/utils';
 
 import {
-  ConverterClient,
   getElectionDefinitionConverterClient,
   VxFile,
 } from '../lib/converters';
@@ -67,12 +72,12 @@ export function UnconfiguredScreen(): JSX.Element {
   );
   const [isLoading, setIsLoading] = useState(false);
   const [vxElectionFileIsInvalid, setVxElectionFileIsInvalid] = useState(false);
-  const [client, setClient] = useState<ConverterClient>();
   const [isUsingConverter, setIsUsingConverter] = useState(false);
 
-  useEffect(() => {
-    setClient(getElectionDefinitionConverterClient(converter));
-  }, [converter]);
+  const client = useMemo(
+    () => getElectionDefinitionConverterClient(converter),
+    [converter]
+  );
 
   async function loadDemoElection() {
     await saveElection(demoElection);


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Per https://beta.reactjs.org/learn/you-might-not-need-an-effect, we shouldn't use `useEffect` to set state as it just causes additional renders. Instead, just compute the values at the component top level. In the case of the converter client, use `useMemo` since the client is potentially stateful.

I found these by searching for `( *)useEffect\(\(\) => \{\n\1 *set[A-Z]`. There were a couple other matches, but they were both `setTimeout` and not a `useState` setter.

## Demo Video or Screenshot
n/a

## Testing Plan 
Tested the MS converter flow for VxAdmin manually.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
