### PR TITLE
ci(jest): limit `maxWorkers`

### DIFF
--- a/codemods/package.json
+++ b/codemods/package.json
@@ -11,7 +11,7 @@
     "test": "is-ci test:ci test:watch",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit"
+    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=7"
   },
   "dependencies": {
     "@babel/core": "^7.18.2",

--- a/frontends/bas/package.json
+++ b/frontends/bas/package.json
@@ -20,7 +20,7 @@
     "test": "is-ci test:ci test:watch",
     "test:watch": "node scripts/test.js",
     "test:coverage": "node scripts/test.js --coverage --watchAll=false",
-    "test:ci": "node scripts/test.js --coverage --watchAll=false --reporters=default --reporters=jest-junit",
+    "test:ci": "node scripts/test.js --coverage --watchAll=false --reporters=default --reporters=jest-junit --maxWorkers=7",
     "pre-commit": "lint-staged"
   },
   "lint-staged": {

--- a/frontends/bmd/package.json
+++ b/frontends/bmd/package.json
@@ -20,7 +20,7 @@
     "start": "vite",
     "stylelint:run": "stylelint 'src/**/*.{js,jsx,ts,tsx}' && stylelint 'src/**/*.css' --config .stylelintrc-css.js",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "TZ=UTC CI=true node scripts/test.js --maxWorkers 2 --env=jest-environment-jsdom-sixteen --coverage --reporters=default --reporters=jest-junit && pnpm build:resources -- --check",
+    "test:ci": "TZ=UTC CI=true node scripts/test.js --maxWorkers=7 --env=jest-environment-jsdom-sixteen --coverage --reporters=default --reporters=jest-junit && pnpm build:resources -- --check",
     "test:coverage": "TZ=UTC node scripts/test.js --coverage --watchAll=false --env=jest-environment-jsdom-sixteen",
     "test:e2e": "is-ci \"test:e2e:ci\" \"test:e2e:watch\"",
     "test:e2e:ci": "start-server-and-test test:e2e:setup http-get://localhost:3000 cypress:run",

--- a/frontends/bsd/package.json
+++ b/frontends/bsd/package.json
@@ -20,7 +20,7 @@
     "test": "is-ci test:ci test:watch",
     "test:watch": "TZ=UTC node scripts/test.js --env=jest-environment-jsdom-sixteen",
     "test:coverage": "TZ=UTC node scripts/test.js --coverage --watchAll=false",
-    "test:ci": "TZ=UTC node scripts/test.js --coverage --watchAll=false --reporters=default --reporters=jest-junit",
+    "test:ci": "TZ=UTC node scripts/test.js --coverage --watchAll=false --reporters=default --reporters=jest-junit --maxWorkers=7",
     "pre-commit": "lint-staged"
   },
   "lint-staged": {

--- a/frontends/election-manager/package.json
+++ b/frontends/election-manager/package.json
@@ -21,7 +21,7 @@
     "test": "is-ci test:ci test:watch",
     "test:watch": "TZ=UTC node scripts/test.js --env=jest-environment-jsdom-sixteen",
     "test:coverage": "TZ=UTC node scripts/test.js --coverage --watchAll=false",
-    "test:ci": "TZ=UTC node scripts/test.js --coverage --watchAll=false --reporters=default --reporters=jest-junit",
+    "test:ci": "TZ=UTC node scripts/test.js --coverage --watchAll=false --reporters=default --reporters=jest-junit --maxWorkers=7",
     "pre-commit": "lint-staged"
   },
   "lint-staged": {

--- a/frontends/precinct-scanner/package.json
+++ b/frontends/precinct-scanner/package.json
@@ -21,7 +21,7 @@
     "test": "is-ci test:ci test:watch",
     "test:watch": "TZ=UTC node scripts/test.js --env=jest-environment-jsdom-sixteen",
     "test:coverage": "TZ=UTC node scripts/test.js --coverage --watchAll=false",
-    "test:ci": "TZ=UTC node scripts/test.js --coverage --watchAll=false --reporters=default --reporters=jest-junit",
+    "test:ci": "TZ=UTC node scripts/test.js --coverage --watchAll=false --reporters=default --reporters=jest-junit --maxWorkers=7",
     "pre-commit": "lint-staged"
   },
   "lint-staged": {

--- a/libs/api/package.json
+++ b/libs/api/package.json
@@ -18,7 +18,7 @@
     "lint:fix": "pnpm type-check && eslint . --fix",
     "pre-commit": "lint-staged",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit",
+    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "type-check": "tsc --build",

--- a/libs/ballot-encoder/package.json
+++ b/libs/ballot-encoder/package.json
@@ -15,7 +15,7 @@
     "lint": "pnpm type-check && eslint .",
     "lint:fix": "pnpm type-check && eslint . --fix",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "jest --ci --coverage --reporters=default --reporters=jest-junit",
+    "test:ci": "jest --ci --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
     "test:coverage": "jest --coverage",
     "test:debug": "node --inspect-brk $(which jest) --runInBand --no-cache",
     "test:watch": "jest --watch",

--- a/libs/ballot-interpreter-nh/package.json
+++ b/libs/ballot-interpreter-nh/package.json
@@ -16,7 +16,7 @@
     "lint": "pnpm type-check && eslint .",
     "lint:fix": "pnpm type-check && eslint . --fix",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "jest --coverage --ci --reporters=default --reporters=jest-junit && pnpm build:resources -- --check",
+    "test:ci": "jest --coverage --ci --reporters=default --reporters=jest-junit --maxWorkers=7 && pnpm build:resources -- --check",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch"
   },

--- a/libs/ballot-interpreter-vx/package.json
+++ b/libs/ballot-interpreter-vx/package.json
@@ -23,7 +23,7 @@
     "lint:fix": "pnpm type-check && eslint . --fix",
     "prepack": "tsc --build",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "pnpm test:coverage -- --reporters=default --reporters=jest-junit",
+    "test:ci": "pnpm test:coverage -- --reporters=default --reporters=jest-junit --maxWorkers=7",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "pre-commit": "lint-staged"

--- a/libs/cdf-schema-builder/package.json
+++ b/libs/cdf-schema-builder/package.json
@@ -18,7 +18,7 @@
     "lint:fix": "pnpm type-check && eslint . --fix",
     "pre-commit": "lint-staged",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "jest --ci --coverage --reporters=default --reporters=jest-junit",
+    "test:ci": "jest --ci --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
     "test:coverage": "jest --coverage",
     "test:debug": "node --inspect-brk $(which jest) --runInBand --no-cache",
     "test:watch": "jest --watch",

--- a/libs/cdf-types-cast-vote-records/package.json
+++ b/libs/cdf-types-cast-vote-records/package.json
@@ -16,7 +16,7 @@
     "schema:build": "mkdir -p src && cdf-schema-builder data/schema.xml data/schema.json > src/index.ts",
     "schema:update": "curl -sLo- https://raw.githubusercontent.com/usnistgov/ElectionEventLogging/master/NIST_V1_election_event_logging.xsd > data/schema.xml && pnpm schema:build",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "jest --ci --coverage --reporters=default --reporters=jest-junit",
+    "test:ci": "jest --ci --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
     "test:coverage": "jest --coverage",
     "test:debug": "node --inspect-brk $(which jest) --runInBand --no-cache",
     "test:watch": "jest --watch",

--- a/libs/cdf-types-election-event-logging/package.json
+++ b/libs/cdf-types-election-event-logging/package.json
@@ -16,7 +16,7 @@
     "schema:build": "mkdir -p src && cdf-schema-builder data/schema.json data/schema.xml > src/index.ts",
     "schema:update": "curl -sLo- https://raw.githubusercontent.com/usnistgov/ElectionEventLogging/master/NIST_V1_election_event_logging.xsd > data/schema.xml && pnpm schema:build",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "jest --ci --coverage --reporters=default --reporters=jest-junit",
+    "test:ci": "jest --ci --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
     "test:coverage": "jest --coverage",
     "test:debug": "node --inspect-brk $(which jest) --runInBand --no-cache",
     "test:watch": "jest --watch",

--- a/libs/cvr-fixture-generator/package.json
+++ b/libs/cvr-fixture-generator/package.json
@@ -17,7 +17,7 @@
     "test": "is-ci test:ci test:watch",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
-    "test:ci": "jest --coverage --ci --reporters=default --reporters=jest-junit",
+    "test:ci": "jest --coverage --ci --reporters=default --reporters=jest-junit --maxWorkers=7",
     "pre-commit": "lint-staged"
   },
   "dependencies": {

--- a/libs/eslint-plugin-vx/package.json
+++ b/libs/eslint-plugin-vx/package.json
@@ -21,7 +21,7 @@
     "test": "is-ci test:ci test:watch",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit"
+    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=7"
   },
   "packageManager": "pnpm@5.18.10",
   "dependencies": {

--- a/libs/fixtures/package.json
+++ b/libs/fixtures/package.json
@@ -23,7 +23,7 @@
     "test": "is-ci test:ci test:watch",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
-    "test:ci": "jest --coverage --ci --reporters=default --reporters=jest-junit && pnpm build:resources -- --check",
+    "test:ci": "jest --coverage --ci --reporters=default --reporters=jest-junit --maxWorkers=7 && pnpm build:resources -- --check",
     "pre-commit": "lint-staged"
   },
   "lint-staged": {

--- a/libs/image-utils/package.json
+++ b/libs/image-utils/package.json
@@ -12,7 +12,7 @@
     "lint": "pnpm type-check && eslint .",
     "lint:fix": "pnpm type-check && eslint . --fix",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "jest --coverage --ci --reporters=default --reporters=jest-junit",
+    "test:ci": "jest --coverage --ci --reporters=default --reporters=jest-junit --maxWorkers=7",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch"
   },

--- a/libs/logging/package.json
+++ b/libs/logging/package.json
@@ -21,7 +21,7 @@
     "test": "is-ci test:ci test:watch",
     "test:watch": "TZ=UTC jest --watch",
     "test:coverage": "TZ=UTC jest --coverage",
-    "test:ci": "TZ=UTC pnpm build && pnpm test:coverage -- --reporters=default --reporters=jest-junit",
+    "test:ci": "TZ=UTC pnpm build && pnpm test:coverage -- --reporters=default --reporters=jest-junit --maxWorkers=7",
     "pre-commit": "lint-staged"
   },
   "lint-staged": {

--- a/libs/lsd/package.json
+++ b/libs/lsd/package.json
@@ -23,7 +23,7 @@
     "lint:fix": "pnpm type-check && eslint . --fix",
     "test": "is-ci test:ci test:watch",
     "test:coverage": "jest --coverage",
-    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit",
+    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
     "test:watch": "jest --watch",
     "pre-commit": "lint-staged"
   },

--- a/libs/plustek-sdk/package.json
+++ b/libs/plustek-sdk/package.json
@@ -20,7 +20,7 @@
     "test": "is-ci test:ci test:watch",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit",
+    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
     "lint": "pnpm type-check && eslint .",
     "lint:fix": "pnpm type-check && eslint . --fix",
     "pre-commit": "lint-staged"

--- a/libs/res-to-ts/package.json
+++ b/libs/res-to-ts/package.json
@@ -16,7 +16,7 @@
     "lint": "pnpm type-check && eslint .",
     "lint:fix": "pnpm type-check && eslint . --fix",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "jest --coverage --ci --reporters=default --reporters=jest-junit",
+    "test:ci": "jest --coverage --ci --reporters=default --reporters=jest-junit --maxWorkers=7",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch"
   },

--- a/libs/test-utils/package.json
+++ b/libs/test-utils/package.json
@@ -19,7 +19,7 @@
     "lint:fix": "pnpm type-check && eslint . --fix",
     "test": "is-ci test:ci test:watch",
     "test:coverage": "jest --coverage",
-    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit",
+    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
     "test:watch": "jest --watch",
     "pre-commit": "lint-staged"
   },

--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -20,7 +20,7 @@
     "lint:fix": "pnpm type-check && eslint . --fix",
     "test": "is-ci test:ci test:watch",
     "test:coverage": "jest --coverage",
-    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit",
+    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
     "test:watch": "jest --watch",
     "pre-commit": "lint-staged"
   },

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -21,7 +21,7 @@
     "stylelint:run": "stylelint 'src/**/*.{js,jsx,ts,tsx}'",
     "test": "is-ci test:ci test:watch",
     "test:coverage": "TZ=UTC jest --coverage",
-    "test:ci": "TZ=UTC jest --coverage --reporters=default --reporters=jest-junit",
+    "test:ci": "TZ=UTC jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
     "test:watch": "TZ=UTC jest --watch",
     "pre-commit": "lint-staged"
   },

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -21,7 +21,7 @@
     "test": "is-ci test:ci test:watch",
     "test:watch": "TZ=UTC jest --watch",
     "test:coverage": "TZ=UTC jest --coverage",
-    "test:ci": "TZ=UTC pnpm build && pnpm test:coverage -- --reporters=default --reporters=jest-junit",
+    "test:ci": "TZ=UTC pnpm build && pnpm test:coverage -- --reporters=default --reporters=jest-junit --maxWorkers=7",
     "pre-commit": "lint-staged"
   },
   "lint-staged": {

--- a/services/admin/package.json
+++ b/services/admin/package.json
@@ -17,7 +17,7 @@
     "pre-commit": "lint-staged",
     "start": "node ./build/index.js",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit",
+    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
     "test:coverage": "jest --coverage",
     "test:debug": "node --inspect-brk $(which jest) --runInBand --no-cache",
     "test:watch": "jest --watch",

--- a/services/scan/package.json
+++ b/services/scan/package.json
@@ -23,7 +23,7 @@
     "start:central": "VX_MACHINE_TYPE=bsd node ./build/index.js",
     "test": "is-ci test:ci test:watch",
     "test:coverage": "jest --coverage",
-    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit",
+    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
     "test:debug": "node --inspect-brk $(which jest) --runInBand --no-cache",
     "test:watch": "jest --watch",
     "pre-commit": "lint-staged"


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Death to flakes! ⚔️ 🥐 

Per https://support.circleci.com/hc/en-us/articles/360005442714-Your-test-tools-are-smart-and-that-s-a-problem-Learn-about-when-optimization-goes-wrong-, Jest may be trying to run too much at once. This may be causing tests to take much too long and time out. I picked `--maxWorkers=7` because `xlarge` instances have 8 CPUs.

## Demo Video or Screenshot
Using `services/scan` as an example:

### [Before](https://app.circleci.com/pipelines/github/votingworks/vxsuite/5985/workflows/19da5dfb-1487-456c-b9f3-6be2ca301fff/jobs/140296/steps)
```
 PASS  src/backup.test.ts (29.173 s)
 PASS  src/build_cast_vote_record.test.ts (28.031 s)
 PASS  src/central_scanner_app.test.ts (30.405 s)
 PASS  src/cli/mock-scanner/index.test.ts (24.223 s)
 PASS  src/cli/read-qrcode/index.test.ts (26.079 s)
 PASS  src/cli/render_pages.test.ts (30.101 s)
 PASS  src/cli/retry-scan/index.test.ts (28.301 s)
 PASS  src/cli/retry-scan/main.test.ts (29.009 s)
 PASS  src/cli/retry-scan/options.test.ts (22.566 s)
 PASS  src/cli/util/spinner.test.ts (23.016 s)
 PASS  src/db_client.test.ts (24.291 s)
 PASS  src/end_to_end.test.ts (23.349 s)
 FAIL  src/end_to_end_hmpb.test.ts (68.16 s)
 PASS  src/exec.test.ts
 PASS  src/fujitsu_scanner.test.ts (26.157 s)
 PASS  src/importer.test.ts (36.79 s)
 PASS  src/interpreter.test.ts (12.07 s)
 PASS  src/loop_scanner.test.ts (23.196 s)
 PASS  src/plustek_mock_server.test.ts (26.141 s)
 FAIL  src/precinct_scanner_app.test.ts (117.332 s)
 PASS  src/precinct_scanner_interpreter.test.ts (36.766 s)
 PASS  src/store.test.ts (57.898 s)
 PASS  src/util/castability.test.ts (23.192 s)
 PASS  src/util/get_ballot_page_contests.test.ts (22.78 s)
 PASS  src/util/lines.test.ts (23.962 s)
 PASS  src/util/marks.test.ts (22.103 s)
 PASS  src/util/metadata.test.ts (26.098 s)
 PASS  src/util/multi_map.test.ts (22.908 s)
 PASS  src/util/option_mark_status.test.ts (22.905 s)
 PASS  src/util/path.test.ts (22.776 s)
 PASS  src/util/perf.test.ts (22.325 s)
 PASS  src/util/stream_lines.test.ts (22.613 s)
 PASS  src/workers/interpret_nh.test.ts (36.865 s)
 PASS  src/workers/json_serialization.test.ts (24.916 s)
 PASS  src/workers/pool.test.ts (28.89 s)
 PASS  src/workers/qrcode.test.ts (27.543 s)
```

### [After](https://app.circleci.com/pipelines/github/votingworks/vxsuite/5991/workflows/878b736e-6b67-491a-8fd8-b73ce9b157d2/jobs/140501/steps)
```
 PASS  src/build_cast_vote_record.test.ts (7.037 s)
 PASS  src/backup.test.ts
 PASS  src/central_scanner_app.test.ts (9.649 s)
 PASS  src/importer.test.ts (10.406 s)
 PASS  src/cli/retry-scan/index.test.ts
 PASS  src/fujitsu_scanner.test.ts
 PASS  src/workers/pool.test.ts
 PASS  src/cli/retry-scan/main.test.ts
 PASS  src/db_client.test.ts
 PASS  src/util/option_mark_status.test.ts
 PASS  src/store.test.ts (13.557 s)
 PASS  src/util/metadata.test.ts
 PASS  src/util/castability.test.ts
 PASS  src/cli/retry-scan/options.test.ts
 PASS  src/cli/render_pages.test.ts
 PASS  src/end_to_end.test.ts
 PASS  src/util/marks.test.ts
 PASS  src/cli/util/spinner.test.ts
 PASS  src/loop_scanner.test.ts
 PASS  src/cli/read-qrcode/index.test.ts
 PASS  src/workers/qrcode.test.ts
 PASS  src/workers/json_serialization.test.ts
 PASS  src/util/lines.test.ts
 PASS  src/util/multi_map.test.ts
 PASS  src/util/get_ballot_page_contests.test.ts
 PASS  src/util/perf.test.ts
 PASS  src/cli/mock-scanner/index.test.ts
 PASS  src/util/stream_lines.test.ts
 PASS  src/util/path.test.ts
 PASS  src/plustek_mock_server.test.ts
 PASS  src/exec.test.ts
 PASS  src/interpreter.test.ts (17.782 s)
 PASS  src/workers/interpret_nh.test.ts
 PASS  src/precinct_scanner_interpreter.test.ts
 PASS  src/end_to_end_hmpb.test.ts (24.315 s)
 PASS  src/precinct_scanner_app.test.ts (73.336 s)
```

## Testing Plan 
CircleCI tests ran and passed on the first try.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
