### PR TITLE
feat(scan): add `scale` option to `render-pages`

### DIFF
--- a/services/scan/src/util/images.ts
+++ b/services/scan/src/util/images.ts
@@ -1,6 +1,7 @@
 import { Buffer } from 'buffer';
 import { createCanvas, createImageData, loadImage } from 'canvas';
 import { createWriteStream } from 'fs';
+import { pipeline } from 'stream/promises';
 
 function ensureImageData(imageData: ImageData): ImageData {
   return createImageData(imageData.data, imageData.width, imageData.height);
@@ -26,12 +27,9 @@ export async function writeImageData(
   const context = canvas.getContext('2d');
   context.putImageData(ensureImageData(imageData), 0, 0);
 
-  await new Promise((resolve, reject) => {
-    const fileWriter = createWriteStream(path);
-    const imageStream = /\.png$/i.test(path)
-      ? canvas.createPNGStream()
-      : canvas.createJPEGStream();
-
-    imageStream.once('error', reject).once('end', resolve).pipe(fileWriter);
-  });
+  const fileWriter = createWriteStream(path);
+  const imageStream = /\.png$/i.test(path)
+    ? canvas.createPNGStream()
+    : canvas.createJPEGStream();
+  await pipeline(imageStream, fileWriter);
 }


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
This is useful for generating the images needed for the `ballot-interpreter-nh/bin/convert` binary since it expects 72ppi rather than the default 144ppi that `render-pages` uses.

I changed `writeImageData` to use `pipeline` from `stream/promises` both because [it's more idiomatic](https://stackoverflow.com/a/68750761) and because it fixes an issue where the `imageStream` would be done but the `fileWriter` was not yet for PNG images. This wasn't a problem when using the binary for real, but was a problem with tests.

## Demo Video or Screenshot
```
❯ ./bin/render-pages ../../libs/fixtures/data/electionFamousNames2021/ballot.pdf
📝 ../../libs/fixtures/data/electionFamousNames2021/ballot-p1.jpg
📝 ../../libs/fixtures/data/electionFamousNames2021/ballot-p2.jpg

❯ file ../../libs/fixtures/data/electionFamousNames2021/ballot-p1.jpg
../../libs/fixtures/data/electionFamousNames2021/ballot-p1.jpg: … 1224x1584, components 3

❯ ./bin/render-pages ../../libs/fixtures/data/electionFamousNames2021/ballot.pdf --scale 1
📝 ../../libs/fixtures/data/electionFamousNames2021/ballot-p1.jpg
📝 ../../libs/fixtures/data/electionFamousNames2021/ballot-p2.jpg

❯ file ../../libs/fixtures/data/electionFamousNames2021/ballot-p1.jpg                
../../libs/fixtures/data/electionFamousNames2021/ballot-p1.jpg: … 612x792, components 3
```

## Testing Plan 
Manually tested as shown above.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
