### PR TITLE
Remove 'error' language on scan progress screen

### DIFF
--- a/frontends/precinct-scanner/src/screens/scan_processing_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/scan_processing_screen.tsx
@@ -11,7 +11,7 @@ export function ScanProcessingScreen(): JSX.Element {
       <IndeterminateProgressBar />
       <CenteredLargeProse>
         <h1>Please wait…</h1>
-        <p>Checking your ballot for errors.</p>
+        <p>Scanning your ballot marks.</p>
       </CenteredLargeProse>
     </ScreenMainCenterChild>
   );


### PR DESCRIPTION
## Overview
Close #2619: Replacing "checking for errors" language on the scan progress screen with friendlier messaging.

## Demo Video or Screenshot
**Before:**
<img width="240" alt="Screenshot 2022-10-04 at 1 06 08 PM" src="https://user-images.githubusercontent.com/264902/193908961-60a4849c-144d-4d23-a622-1736e74d7f8d.png">

**After:**
<img width="240" alt="Screenshot 2022-10-04 at 1 05 57 PM" src="https://user-images.githubusercontent.com/264902/193909029-6d05b279-54ce-4fe9-abeb-91fe5503b8f7.png">

## Testing Plan 
Ran locally to verify.

## Checklist
- [n/a] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [n/a] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
