### PR TITLE
VxAdmin: use consistent locked/unlocked language

### DIFF
--- a/libs/ui/src/remove_card_screen.tsx
+++ b/libs/ui/src/remove_card_screen.tsx
@@ -16,7 +16,7 @@ export function RemoveCardScreen(): JSX.Element {
       <Main centerChild>
         <Prose textCenter theme={fontSizeTheme.medium}>
           <RemoveCardImage aria-hidden src="/assets/remove-card.svg" alt="" />
-          <h1>Successful Authentication</h1>
+          <h1>VxAdmin Unlocked</h1>
           <p>Remove card to continue.</p>
         </Prose>
       </Main>


### PR DESCRIPTION
## Overview
Close #2420: After successful authentication, replace screen header text with "VxAdmin Unlocked" to match the "VxAdmin is locked" messaging in the previous screen.

## Demo Video or Screenshot
<img width="300" alt="Screenshot 2022-10-04 at 5 02 12 PM" src="https://user-images.githubusercontent.com/264902/193938617-3242a771-75bd-4476-804d-becf54d81d62.png"> 
<img width="300" alt="Screenshot 2022-10-04 at 5 03 20 PM" src="https://user-images.githubusercontent.com/264902/193938680-67ba1a39-4ce9-4342-a4b3-1a70244996a0.png">


## Testing Plan 

## Checklist
- [n/a] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [n/a] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
