### PR TITLE
WIA: disable adjudication after finalizing results

### DIFF
--- a/frontends/election-manager/src/screens/write_ins_screen.test.tsx
+++ b/frontends/election-manager/src/screens/write_ins_screen.test.tsx
@@ -34,12 +34,12 @@ test('Tally results already marked as official', async () => {
 
   await screen.findByText(/No further changes may be made/);
 
-  const transcribeButtons = await screen.findAllByText(/Transcribe \d/);
+  const transcribeButtons = screen.queryAllByText(/Transcribe \d/);
   for (const transcribeButton of transcribeButtons) {
     expect(transcribeButton).toBeDisabled();
   }
 
-  const adjudicateButtons = await screen.findAllByText('Adjudicate');
+  const adjudicateButtons = screen.queryAllByText('Adjudicate');
   for (const adjudicateButton of adjudicateButtons) {
     expect(adjudicateButton).toBeDisabled();
   }

--- a/frontends/election-manager/src/screens/write_ins_screen.test.tsx
+++ b/frontends/election-manager/src/screens/write_ins_screen.test.tsx
@@ -17,6 +17,34 @@ test('No CVRs loaded', async () => {
   expect(screen.queryByText('Transcribe')).not.toBeInTheDocument();
 });
 
+test('Tally results already marked as official', async () => {
+  const backend = new ElectionManagerStoreMemoryBackend({
+    electionDefinition,
+  });
+
+  await backend.addCastVoteRecordFile(
+    new File([abbreviatedCvrData], 'cvrs.jsonl')
+  );
+
+  renderInAppContext(<WriteInsScreen />, {
+    backend,
+    electionDefinition,
+    isOfficialResults: true,
+  });
+
+  await screen.findByText(/No further changes may be made/);
+
+  const transcribeButtons = await screen.findAllByText(/Transcribe \d/);
+  for (const transcribeButton of transcribeButtons) {
+    expect(transcribeButton).toBeDisabled();
+  }
+
+  const adjudicateButtons = await screen.findAllByText('Adjudicate');
+  for (const adjudicateButton of adjudicateButtons) {
+    expect(adjudicateButton).toBeDisabled();
+  }
+});
+
 test('CVRs with write-ins loaded', async () => {
   const backend = new ElectionManagerStoreMemoryBackend({
     electionDefinition,

--- a/frontends/election-manager/src/screens/write_ins_screen.tsx
+++ b/frontends/election-manager/src/screens/write_ins_screen.tsx
@@ -27,8 +27,13 @@ const ContentWrapper = styled.div`
   }
 `;
 
+const ResultsFinalizedNotice = styled.p`
+  color: rgb(71, 167, 75);
+`;
+
 export function WriteInsScreen(): JSX.Element {
-  const { castVoteRecordFiles, electionDefinition } = useContext(AppContext);
+  const { castVoteRecordFiles, electionDefinition, isOfficialResults } =
+    useContext(AppContext);
   const [contestBeingTranscribed, setContestBeingTranscribed] =
     useState<CandidateContest>();
   const [contestBeingAdjudicated, setContestBeingAdjudicated] =
@@ -123,20 +128,35 @@ export function WriteInsScreen(): JSX.Element {
     });
   }
 
+  function renderHeaderText() {
+    if (isOfficialResults) {
+      return (
+        <ResultsFinalizedNotice>
+          Tally results have been finalized. No further changes may be made.
+        </ResultsFinalizedNotice>
+      );
+    }
+
+    if (!castVoteRecordFiles.wereAdded) {
+      return (
+        <p>Load CVRs to begin transcribing and adjudicating write-in votes.</p>
+      );
+    }
+
+    return (
+      <p>
+        Transcribe all write-in values, then map the transcriptions to
+        adjudicated candidates.
+      </p>
+    );
+  }
+
   return (
     <NavigationScreen>
       <ContentWrapper>
         <Prose maxWidth={false}>
           <h1>Write-Ins Transcription and Adjudication</h1>
-          {!castVoteRecordFiles.wereAdded && (
-            <p>
-              Load CVRs to begin transcribing and adjudicating write-in votes.
-            </p>
-          )}
-          <p>
-            Transcribe all write-in values, then map the transcriptions to
-            adjudicated candidates.
-          </p>
+          {renderHeaderText()}
           <Table>
             <thead>
               <tr>
@@ -188,6 +208,7 @@ export function WriteInsScreen(): JSX.Element {
                         </Text>
                       ) : (
                         <Button
+                          disabled={isOfficialResults}
                           primary={!!transcriptionQueue}
                           onPress={() => setContestBeingTranscribed(contest)}
                         >
@@ -204,6 +225,7 @@ export function WriteInsScreen(): JSX.Element {
                         </Text>
                       ) : (
                         <Button
+                          disabled={isOfficialResults}
                           primary={!!adjudicationQueue}
                           onPress={() => setContestBeingAdjudicated(contest)}
                         >


### PR DESCRIPTION
## Overview
Closes https://github.com/votingworks/vxsuite/issues/2593
- Disable action buttons on the WIA screen after results have been marked as official.
- Additionally, adding messaging in the header for the screen to explain why editing has been disabled.

## Demo Video or Screenshot
<img width="986" alt="wia_disabled_state" src="https://user-images.githubusercontent.com/264902/194390950-44e4f8e5-dab3-489f-852a-6c8cdd881a23.png">

https://user-images.githubusercontent.com/264902/194391008-326b6aae-18bf-45af-88d9-533cf44dcf43.mov

## Testing Plan 
- Added unit test for the new case to verify disabled buttons and presence of explanation message
- Sanity check with local runthrough

## Checklist
- [n/a] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [n/a] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
