### PR TITLE
[VxAdmin|VxCentralScan] use product-specific copy on unlock screen

### DIFF
--- a/frontends/bsd/src/app.test.tsx
+++ b/frontends/bsd/src/app.test.tsx
@@ -502,6 +502,7 @@ test('authentication works', async () => {
 
   // 'Remove Card' screen is shown after successful authentication.
   await screen.findByText('Remove card to continue.');
+  screen.getByText('VxCentralScan Unlocked');
 
   // Machine is unlocked when card removed
   card.removeCard();

--- a/frontends/bsd/src/app_root.tsx
+++ b/frontends/bsd/src/app_root.tsx
@@ -534,7 +534,7 @@ export function AppRoot({ card, hardware, logger }: AppRootProps): JSX.Element {
   }
 
   if (auth.status === 'remove_card') {
-    return <RemoveCardScreen />;
+    return <RemoveCardScreen productName="VxCentralScan" />;
   }
 
   if (isSystemAdministratorAuth(auth)) {

--- a/frontends/election-manager/src/components/election_manager.tsx
+++ b/frontends/election-manager/src/components/election_manager.tsx
@@ -49,7 +49,7 @@ export function ElectionManager(): JSX.Element {
   }
 
   if (auth.status === 'remove_card') {
-    return <RemoveCardScreen />;
+    return <RemoveCardScreen productName="VxAdmin" />;
   }
 
   if (auth.status === 'logged_out') {

--- a/libs/ui/src/remove_card_screen.test.tsx
+++ b/libs/ui/src/remove_card_screen.test.tsx
@@ -5,7 +5,8 @@ import { RemoveCardScreen } from './remove_card_screen';
 
 describe('RemoveCardPage', () => {
   test('says "Remove card"', () => {
-    const { getByText } = render(<RemoveCardScreen />);
+    const { getByText } = render(<RemoveCardScreen productName="VxTest" />);
+    getByText('VxTest Unlocked');
     getByText('Remove card to continue.');
   });
 });

--- a/libs/ui/src/remove_card_screen.tsx
+++ b/libs/ui/src/remove_card_screen.tsx
@@ -10,13 +10,17 @@ const RemoveCardImage = styled.img`
   height: 30vw;
 `;
 
-export function RemoveCardScreen(): JSX.Element {
+interface Props {
+  productName: string;
+}
+
+export function RemoveCardScreen({ productName }: Props): JSX.Element {
   return (
     <Screen white>
       <Main centerChild>
         <Prose textCenter theme={fontSizeTheme.medium}>
           <RemoveCardImage aria-hidden src="/assets/remove-card.svg" alt="" />
-          <h1>VxAdmin Unlocked</h1>
+          <h1>{productName} Unlocked</h1>
           <p>Remove card to continue.</p>
         </Prose>
       </Main>


### PR DESCRIPTION
## Overview
Closes https://github.com/votingworks/vxsuite/issues/2642:
Updating the `RemoveCardScreen` component with product-specific copy, instead of hardcoding "VxAdmin" (introduced in PR https://github.com/votingworks/vxsuite/pull/2630), since it's also used in VxCentralScan.

## Demo Video or Screenshot
### Via VxAdmin:
<img width="300" alt="Screenshot 2022-10-10 at 12 59 17 PM" src="https://user-images.githubusercontent.com/264902/194928406-3a6d973f-f910-4941-9262-768431888e9d.png">

### Via VxCentralScan:
<img width="300" alt="Screenshot 2022-10-10 at 1 07 29 PM" src="https://user-images.githubusercontent.com/264902/194928437-a25a3f39-a622-4005-aa0b-0e8fa9b1d35c.png">

## Testing Plan 
- Updated unit tests to check for product name
- Verified locally

## Checklist
- [n/a] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [n/a] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
