### PR TITLE
Add Manual Write-In Results

### DIFF
--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -865,24 +865,21 @@ test('tabulating CVRs with SEMS file and manual data', async () => {
   fireEvent.click(getByText('Add Manually Entered Results'));
   getByText('Manually Entered Precinct Results');
   fireEvent.click(getByText('Edit Precinct Results for District 5'));
-  getByText('Save Precinct Results for District 5');
-  fireEvent.change(getByTestId('775020876-undervotes'), {
+  await screen.findByText('Save Precinct Results for District 5');
+  fireEvent.change(getByTestId('775020876-undervotes-input'), {
     target: { value: '12' },
   });
-  fireEvent.change(getByTestId('775020876-overvotes'), {
+  fireEvent.change(getByTestId('775020876-overvotes-input'), {
     target: { value: '8' },
   });
-  fireEvent.change(getByTestId('775020876-775031988'), {
+  fireEvent.change(getByTestId('775020876-775031988-input'), {
     target: { value: '32' },
   });
-  fireEvent.change(getByTestId('775020876-775031987'), {
+  fireEvent.change(getByTestId('775020876-775031987-input'), {
     target: { value: '28' },
   });
-  fireEvent.change(getByTestId('775020876-775031989'), {
-    target: { value: '10' },
-  });
-  fireEvent.change(getByTestId('775020876-write-in'), {
-    target: { value: '10' },
+  fireEvent.change(getByTestId('775020876-775031989-input'), {
+    target: { value: '20' },
   });
 
   fireEvent.click(getByText('Save Precinct Results for District 5'));
@@ -942,16 +939,16 @@ test('tabulating CVRs with SEMS file and manual data', async () => {
   // Change to another precinct
   fireEvent.click(getByText('Edit Absentee Results for Panhandle'));
   await screen.findByText('Save Absentee Results for Panhandle');
-  fireEvent.change(getByTestId('750000017-undervotes'), {
+  fireEvent.change(getByTestId('750000017-undervotes-input'), {
     target: { value: '17' },
   });
-  fireEvent.change(getByTestId('750000017-overvotes'), {
+  fireEvent.change(getByTestId('750000017-overvotes-input'), {
     target: { value: '3' },
   });
-  fireEvent.change(getByTestId('750000017-yes'), {
+  fireEvent.change(getByTestId('750000017-yes-input'), {
     target: { value: '54' },
   });
-  fireEvent.change(getByTestId('750000017-no'), {
+  fireEvent.change(getByTestId('750000017-no-input'), {
     target: { value: '26' },
   });
 

--- a/frontends/election-manager/src/app_root.tsx
+++ b/frontends/election-manager/src/app_root.tsx
@@ -14,6 +14,7 @@ import {
   ExternalTallySourceType,
   Provider,
   Printer,
+  VotingMethod,
 } from '@votingworks/types';
 import {
   assert,
@@ -68,6 +69,9 @@ export function AppRoot({
   const { cardReader, printer: printerInfo } = useDevices({ hardware, logger });
 
   const [isTabulationRunning, setIsTabulationRunning] = useState(false);
+  const [manualTallyVotingMethod, setManualTallyVotingMethod] = useState(
+    VotingMethod.Precinct
+  );
   const [machineConfig, setMachineConfig] = useState<MachineConfig>({
     machineId: '0000',
     codeVersion: '',
@@ -279,6 +283,8 @@ export function AppRoot({
         fullElectionTally,
         fullElectionExternalTallies: store.fullElectionExternalTallies,
         updateExternalTally,
+        manualTallyVotingMethod,
+        setManualTallyVotingMethod,
         saveTranscribedValue,
         isTabulationRunning,
         setIsTabulationRunning,

--- a/frontends/election-manager/src/app_write_in_flows.test.tsx
+++ b/frontends/election-manager/src/app_write_in_flows.test.tsx
@@ -43,7 +43,6 @@ afterEach(() => {
 });
 
 test('manual write-in data end-to-end test', async () => {
-  // Set up an an existing adjudicated value
   const backend = new ElectionManagerStoreMemoryBackend({
     electionDefinition: electionMinimalExhaustiveSampleDefinition,
   });
@@ -53,6 +52,22 @@ test('manual write-in data end-to-end test', async () => {
       'partial1.jsonl'
     )
   );
+  const card = new MemoryCard();
+  const hardware = MemoryHardware.buildStandard();
+  renderRootElement(<App card={card} hardware={hardware} />, { backend });
+
+  // Navigate to manual data entry
+  await authenticateWithElectionManagerCard(
+    card,
+    electionMinimalExhaustiveSampleDefinition
+  );
+  userEvent.click(screen.getByText('Tally'));
+  userEvent.click(screen.getByText('Add Manually Entered Results'));
+  userEvent.click(screen.getByText('Edit Precinct Results for Precinct 1'));
+
+  // Navigate away, adjudicated a write-in, and return - to ensure the
+  // page does not use stale data
+  userEvent.click(await screen.findByText('Cancel'));
   const writeIn = (
     await backend.loadWriteIns({
       contestId: 'zoo-council-mammal',
@@ -64,17 +79,6 @@ test('manual write-in data end-to-end test', async () => {
     'Chimera',
     'Chimera'
   );
-  const card = new MemoryCard();
-  const hardware = MemoryHardware.buildStandard();
-
-  renderRootElement(<App card={card} hardware={hardware} />, { backend });
-
-  await authenticateWithElectionManagerCard(
-    card,
-    electionMinimalExhaustiveSampleDefinition
-  );
-  userEvent.click(screen.getByText('Tally'));
-  userEvent.click(screen.getByText('Add Manually Entered Results'));
   userEvent.click(screen.getByText('Edit Precinct Results for Precinct 1'));
 
   // Enter some official results for Precinct 1

--- a/frontends/election-manager/src/app_write_in_flows.test.tsx
+++ b/frontends/election-manager/src/app_write_in_flows.test.tsx
@@ -1,0 +1,249 @@
+import React from 'react';
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  electionMinimalExhaustiveSampleDefinition,
+  electionMinimalExhaustiveSampleFixtures,
+} from '@votingworks/fixtures';
+import { MemoryCard, MemoryHardware, typedAs } from '@votingworks/utils';
+import { fakeKiosk, hasTextAcrossElements } from '@votingworks/test-utils';
+import fetchMock from 'fetch-mock';
+import { renderRootElement } from '../test/render_in_app_context';
+import { authenticateWithElectionManagerCard } from '../test/util/authenticate';
+import { App } from './app';
+import { ElectionManagerStoreMemoryBackend } from './lib/backends';
+import { VxFiles } from './lib/converters';
+import { MachineConfig } from './config/types';
+
+let mockKiosk!: jest.Mocked<KioskBrowser.Kiosk>;
+
+beforeEach(() => {
+  mockKiosk = fakeKiosk();
+  window.kiosk = mockKiosk;
+  fetchMock.reset();
+  fetchMock.get(
+    '/convert/tallies/files',
+    typedAs<VxFiles>({
+      inputFiles: [{ name: 'name' }, { name: 'name' }],
+      outputFiles: [{ name: 'name' }],
+    })
+  );
+  fetchMock.get(
+    '/machine-config',
+    typedAs<MachineConfig>({
+      machineId: '0000',
+      codeVersion: 'TEST',
+    })
+  );
+  fetchMock.delete('/admin/write-ins/cvrs', { body: { status: 'ok ' } });
+});
+
+afterEach(() => {
+  delete window.kiosk;
+});
+
+test('manual write-in data end-to-end test', async () => {
+  // Set up an an existing adjudicated value
+  const backend = new ElectionManagerStoreMemoryBackend({
+    electionDefinition: electionMinimalExhaustiveSampleDefinition,
+  });
+  await backend.addCastVoteRecordFile(
+    new File(
+      [electionMinimalExhaustiveSampleFixtures.partial1CvrFile.asBuffer()],
+      'partial1.jsonl'
+    )
+  );
+  const writeIn = (
+    await backend.loadWriteIns({
+      contestId: 'zoo-council-mammal',
+    })
+  )[0];
+  await backend.transcribeWriteIn(writeIn.id, 'Chimera');
+  await backend.adjudicateWriteInTranscription(
+    'zoo-council-mammal',
+    'Chimera',
+    'Chimera'
+  );
+  const card = new MemoryCard();
+  const hardware = MemoryHardware.buildStandard();
+
+  renderRootElement(<App card={card} hardware={hardware} />, { backend });
+
+  await authenticateWithElectionManagerCard(
+    card,
+    electionMinimalExhaustiveSampleDefinition
+  );
+  userEvent.click(screen.getByText('Tally'));
+  userEvent.click(screen.getByText('Add Manually Entered Results'));
+  userEvent.click(screen.getByText('Edit Precinct Results for Precinct 1'));
+
+  // Enter some official results for Precinct 1
+  await screen.findByText('Manually Entered Precinct Results:');
+  userEvent.type(
+    screen.getByTestId('zoo-council-mammal-zebra-input').closest('input')!,
+    '7'
+  );
+  userEvent.type(
+    screen.getByTestId('zoo-council-mammal-kangaroo-input').closest('input')!,
+    '3'
+  );
+
+  // Add votes to the the pre-adjudicated value
+  const zooMammalCouncil = screen
+    .getByText('Zoo Council - Mammal Party')
+    .closest('div')!;
+  userEvent.type(
+    within(zooMammalCouncil).getByTestId(
+      'zoo-council-mammal-write-in-(Chimera)-input'
+    ),
+    '9'
+  );
+
+  // Add a write-in to appear in the results
+  userEvent.click(within(zooMammalCouncil).getByText('Add Write-In Candidate'));
+  userEvent.type(
+    within(zooMammalCouncil).getByTestId('zoo-council-mammal-write-in-input'),
+    'Rapidash'
+  );
+  userEvent.click(within(zooMammalCouncil).getByText('Add'));
+  userEvent.type(
+    within(zooMammalCouncil).getByTestId(
+      'zoo-council-mammal-write-in-(Rapidash)-manual-input'
+    ),
+    '5'
+  );
+
+  // Add a write-in we'll remove later
+  userEvent.click(within(zooMammalCouncil).getByText('Add Write-In Candidate'));
+  userEvent.type(
+    within(zooMammalCouncil).getByTestId('zoo-council-mammal-write-in-input'),
+    'Slakoth'
+  );
+  userEvent.click(within(zooMammalCouncil).getByText('Add'));
+  userEvent.type(
+    within(zooMammalCouncil).getByTestId(
+      'zoo-council-mammal-write-in-(Slakoth)-manual-input'
+    ),
+    '9'
+  );
+  expect(
+    within(zooMammalCouncil).getByTestId('zoo-council-mammal-numBallots')
+      .textContent
+  ).toEqual('11');
+
+  // Add a write-in to another race
+  const zooFishCouncil = screen
+    .getByText('Zoo Council - Fish Party')
+    .closest('div')!;
+  userEvent.click(within(zooFishCouncil).getByText('Add Write-In Candidate'));
+  userEvent.type(
+    within(zooFishCouncil).getByTestId('aquarium-council-fish-write-in-input'),
+    'Relicanth'
+  );
+  userEvent.click(within(zooFishCouncil).getByText('Add'));
+  userEvent.type(
+    within(zooFishCouncil).getByTestId(
+      'aquarium-council-fish-write-in-(Relicanth)-manual-input'
+    ),
+    '14'
+  );
+
+  // Save results and check index screen
+  userEvent.click(screen.getByText('Save Precinct Results for Precinct 1'));
+  let summaryTable = await screen.findByTestId('summary-data');
+  let precinct1SummaryRow = within(summaryTable)
+    .getByText('Precinct 1')
+    .closest('tr')!;
+  expect(
+    within(precinct1SummaryRow).getByTestId('numBallots').textContent
+  ).toEqual('18');
+
+  // Check our write-ins appear for precinct 2
+  userEvent.click(screen.getByText('Edit Precinct Results for Precinct 2'));
+  screen.getByText('Chimera (write-in)');
+  screen.getByText('Rapidash (write-in)');
+  screen.getByText('Slakoth (write-in)');
+  screen.getByText('Relicanth (write-in)');
+
+  // Add results for one write-in for precinct 2
+  userEvent.type(
+    screen.getByTestId('zoo-council-mammal-write-in-(Rapidash)-manual-input'),
+    '15'
+  );
+
+  // Remove one of the write-in candidates in precinct 2 screen
+  userEvent.click(
+    within(
+      screen.getByTestId('zoo-council-mammal-write-in-(Slakoth)-manual')
+    ).getByText('Remove')
+  );
+  userEvent.click(screen.getByText('Remove Candidate'));
+
+  // Save results and confirm index screen has updated appropriately
+  userEvent.click(screen.getByText('Save Precinct Results for Precinct 2'));
+  summaryTable = await screen.findByTestId('summary-data');
+  precinct1SummaryRow = within(summaryTable)
+    .getByText('Precinct 1')
+    .closest('tr')!;
+  const precinct2SummaryRow = within(summaryTable)
+    .getByText('Precinct 2')
+    .closest('tr')!;
+  // Here we're confirming that removing a candidate from one precinct screen
+  // alters the candidates and results from another precinct
+  expect(
+    within(precinct1SummaryRow).getByTestId('numBallots').textContent
+  ).toEqual('15');
+  expect(
+    within(precinct2SummaryRow).getByTestId('numBallots').textContent
+  ).toEqual('5');
+
+  // Check that results are appropriately incorporated into the main report
+  userEvent.click(screen.getByText('Reports'));
+  userEvent.click(screen.getByText('Unofficial Full Election Tally Report'));
+  const printableArea = await screen.findByTestId('printable-area');
+  within(printableArea).getByText(
+    'Unofficial Mammal Party Example Primary Election Tally Report'
+  );
+  const zooCouncilMammal = within(printableArea).getByTestId(
+    'results-table-zoo-council-mammal'
+  );
+  const zooCouncilFish = within(printableArea).getByTestId(
+    'results-table-aquarium-council-fish'
+  );
+  // Added write-in candidates should not appear in the report
+  expect(
+    within(zooCouncilMammal).queryByText(/Chimera/)
+  ).not.toBeInTheDocument();
+  expect(
+    within(zooCouncilMammal).queryByText(/Rapidash/)
+  ).not.toBeInTheDocument();
+  expect(
+    within(zooCouncilFish).queryByText(/Relicanth/)
+  ).not.toBeInTheDocument();
+  // Check totals are correct
+  within(zooCouncilMammal).getByText(
+    hasTextAcrossElements('Ballots Cast10113114')
+  );
+  within(zooCouncilMammal).getByText(hasTextAcrossElements('Zebra58765'));
+  within(zooCouncilMammal).getByText(hasTextAcrossElements('Kangaroo42345'));
+  within(zooCouncilMammal).getByText(hasTextAcrossElements('Write-In422971'));
+  within(zooCouncilFish).getByText(hasTextAcrossElements('Ballots Cast077'));
+  within(zooCouncilFish).getByText(hasTextAcrossElements('Write-In01414'));
+
+  // Check that results are appropriately incorporated into scatter report
+  userEvent.click(screen.getByText('Reports'));
+  userEvent.click(screen.getByText('Unofficial Write-In Tally Report'));
+  const printableArea2 = await screen.findByTestId('printable-area');
+  within(printableArea2).getByText(
+    'Unofficial Mammal Party Example Primary Election Write-In Tally Report'
+  );
+  const zooCouncilMammal2 = within(printableArea2).getByTestId(
+    'results-table-zoo-council-mammal'
+  );
+  const zooCouncilFish2 = within(printableArea2).getByTestId(
+    'results-table-aquarium-council-fish'
+  );
+  within(zooCouncilMammal2).getByText(hasTextAcrossElements('Chimera10'));
+  within(zooCouncilMammal2).getByText(hasTextAcrossElements('Rapidash20'));
+  within(zooCouncilFish2).getByText(hasTextAcrossElements('Relicanth14'));
+});

--- a/frontends/election-manager/src/components/election_manager_tally_report.tsx
+++ b/frontends/election-manager/src/components/election_manager_tally_report.tsx
@@ -27,6 +27,7 @@ import React, { forwardRef } from 'react';
 
 import { filterExternalTalliesByParams } from '../utils/external_tallies';
 import { modifyTallyWithWriteInInfo } from '../lib/votecounting';
+import { mergeWriteIns } from '../utils/write_ins';
 
 export type TallyReportType = 'Official' | 'Unofficial' | 'Test Deck';
 
@@ -117,7 +118,7 @@ export const ElectionManagerTallyReport = forwardRef<HTMLDivElement, Props>(
                 filteredExternalTally.numberOfBallotsCounted > 0
               ) {
                 if (t.source === ExternalTallySourceType.Manual) {
-                  manualTallyForReport = filteredExternalTally;
+                  manualTallyForReport = mergeWriteIns(filteredExternalTally);
                 } else {
                   otherExternalTalliesForReport.push(filteredExternalTally);
                 }

--- a/frontends/election-manager/src/contexts/app_context.ts
+++ b/frontends/election-manager/src/contexts/app_context.ts
@@ -6,6 +6,7 @@ import {
   DippedSmartcardAuth,
   FullElectionExternalTallies,
   Printer,
+  VotingMethod,
 } from '@votingworks/types';
 import { usbstick, NullPrinter } from '@votingworks/utils';
 import { Logger, LogSource, LoggingUserRole } from '@votingworks/logging';
@@ -48,6 +49,8 @@ export interface AppContextInterface {
   updateExternalTally: (
     newExternalTally: FullElectionExternalTally
   ) => Promise<void>;
+  manualTallyVotingMethod: VotingMethod;
+  setManualTallyVotingMethod: (votingMethod: VotingMethod) => void;
   saveTranscribedValue: (
     adjudicationId: string,
     transcribedValue: string
@@ -86,6 +89,8 @@ const appContext: AppContextInterface = {
   fullElectionTally: getEmptyFullElectionTally(),
   fullElectionExternalTallies: new Map(),
   updateExternalTally: async () => undefined,
+  manualTallyVotingMethod: VotingMethod.Precinct,
+  setManualTallyVotingMethod: () => undefined,
   saveTranscribedValue: async () => undefined,
   isTabulationRunning: false,
   setIsTabulationRunning: () => undefined,

--- a/frontends/election-manager/src/screens/tally_report_screen.tsx
+++ b/frontends/election-manager/src/screens/tally_report_screen.tsx
@@ -38,7 +38,7 @@ import { useWriteInSummaryQuery } from '../hooks/use_write_in_summary_query';
 import { SaveFileToUsb, FileType } from '../components/save_file_to_usb';
 import { ElectionManagerTallyReport } from '../components/election_manager_tally_report';
 import { PrintableArea } from '../components/printable_area';
-import { getWriteInCountsByContestAndCandidate } from '../utils/write_ins';
+import { getScreenAdjudicatedWriteInCounts } from '../utils/write_ins';
 
 const TallyReportPreview = styled(TallyReport)`
   section {
@@ -77,8 +77,8 @@ export function TallyReportScreen(): JSX.Element {
   assert(isElectionManagerAuth(auth)); // TODO(auth) check permissions for viewing tally reports.
   const userRole = auth.user.role;
   const writeInSummaryQuery = useWriteInSummaryQuery({ status: 'adjudicated' });
-  const writeInCountsByContestAndCandidate =
-    getWriteInCountsByContestAndCandidate(writeInSummaryQuery.data ?? [], true);
+  const screenAdjudicatedOfficialCandidateWriteInCounts =
+    getScreenAdjudicatedWriteInCounts(writeInSummaryQuery.data ?? [], true);
 
   const location = useLocation();
 
@@ -233,7 +233,7 @@ export function TallyReportScreen(): JSX.Element {
     previewReportRef,
     printReportRef,
     isOfficialResults,
-    writeInCountsByContestAndCandidate,
+    screenAdjudicatedOfficialCandidateWriteInCounts,
   ]);
 
   return (
@@ -325,7 +325,9 @@ export function TallyReportScreen(): JSX.Element {
           election={election}
           fullElectionExternalTallies={fullElectionExternalTallies}
           fullElectionTally={fullElectionTally}
-          officialCandidateWriteIns={writeInCountsByContestAndCandidate}
+          officialCandidateWriteIns={
+            screenAdjudicatedOfficialCandidateWriteInCounts
+          }
           generatedAtTime={generatedAtTime}
           tallyReportType={isOfficialResults ? 'Official' : 'Unofficial'}
           partyId={partyId}

--- a/frontends/election-manager/src/utils/write_ins.test.ts
+++ b/frontends/election-manager/src/utils/write_ins.test.ts
@@ -1,0 +1,153 @@
+import { electionSample } from '@votingworks/fixtures';
+import {
+  CandidateId,
+  Dictionary,
+  ExternalTally,
+  writeInCandidate,
+} from '@votingworks/types';
+import { buildExternalTally } from '../../test/helpers/build_external_tally';
+import {
+  combineWriteInCounts,
+  CountsByContestAndCandidateName,
+  getAdjudicatedWriteInCandidate,
+  getManualWriteInCounts,
+  mergeWriteIns,
+} from './write_ins';
+
+// Converts the nested maps of write-in counts to an object for easier assertions
+function writeInCountsAsObject(
+  counts: CountsByContestAndCandidateName
+): Dictionary<Dictionary<number>> {
+  const countsObject: Dictionary<Dictionary<number>> = {};
+  for (const [key, value] of counts) {
+    countsObject[key] = Object.fromEntries(value);
+  }
+  return countsObject;
+}
+
+// Modifies a contest of external tally to include an additional write-in
+// returns new write-in candidate id
+function addWriteInToExternalTally(
+  externalTally: ExternalTally,
+  contestId: string,
+  name: string,
+  tally: number
+): CandidateId {
+  const contestTally = externalTally.contestTallies[contestId];
+  const candidate = getAdjudicatedWriteInCandidate(name, false);
+  contestTally!.tallies[candidate.id] = {
+    option: candidate,
+    tally,
+  };
+  return candidate.id;
+}
+
+test('getManualWriteInCounts', () => {
+  const externalTally = buildExternalTally(electionSample, 1, [
+    'county-commissioners',
+    'city-mayor',
+    'president',
+  ]);
+  addWriteInToExternalTally(externalTally, 'county-commissioners', 'John', 4);
+  addWriteInToExternalTally(externalTally, 'county-commissioners', 'Jane', 7);
+  addWriteInToExternalTally(externalTally, 'city-mayor', 'Jill', 8);
+
+  expect(
+    writeInCountsAsObject(getManualWriteInCounts(externalTally))
+  ).toMatchObject({
+    'county-commissioners': {
+      John: 4,
+      Jane: 7,
+    },
+    'city-mayor': {
+      Jill: 8,
+    },
+  });
+});
+
+test('combineWriteInCounts', () => {
+  const writeInCount1 = new Map([
+    [
+      'president',
+      new Map([
+        ['John', 5],
+        ['Jane', 3],
+        ['Jill', 4],
+      ]),
+    ],
+    [
+      'governor',
+      new Map([
+        ['Hal', 3],
+        ['Hoda', 4],
+      ]),
+    ],
+  ]);
+  const writeInCount2 = new Map([
+    [
+      'president',
+      new Map([
+        ['John', 7],
+        ['Jane', 1],
+        ['Jack', 2],
+      ]),
+    ],
+    ['mayor', new Map([['Manny', 7]])],
+  ]);
+
+  const combinedCount = combineWriteInCounts([writeInCount1, writeInCount2]);
+  expect(writeInCountsAsObject(combinedCount)).toMatchObject({
+    president: {
+      John: 12,
+      Jane: 4,
+      Jill: 4,
+      Jack: 2,
+    },
+    governor: {
+      Hal: 3,
+      Hoda: 4,
+    },
+    mayor: {
+      Manny: 7,
+    },
+  });
+});
+
+test('mergeWriteIns', () => {
+  const externalTally = buildExternalTally(electionSample, 0, [
+    'county-commissioners',
+  ]);
+  const originalWriteInIds = [];
+  originalWriteInIds.push(
+    addWriteInToExternalTally(externalTally, 'county-commissioners', 'Bri', 10)
+  );
+  originalWriteInIds.push(
+    addWriteInToExternalTally(externalTally, 'county-commissioners', 'Brad', 9)
+  );
+  originalWriteInIds.push(
+    addWriteInToExternalTally(externalTally, 'county-commissioners', 'Bran', 8)
+  );
+
+  const externalTallyWithWriteInsMerged = mergeWriteIns(externalTally);
+
+  // Should have the merged results
+  expect(
+    externalTallyWithWriteInsMerged.contestTallies['county-commissioners']
+  ).toMatchObject({
+    tallies: {
+      'write-in': {
+        option: writeInCandidate,
+        tally: 27,
+      },
+    },
+  });
+
+  // Should not have the original write-ins
+  const countyCommissionerCandidateIds = Object.keys(
+    externalTallyWithWriteInsMerged.contestTallies['county-commissioners']!
+      .tallies
+  );
+  for (const originalWriteInId of originalWriteInIds) {
+    expect(countyCommissionerCandidateIds).not.toContain(originalWriteInId);
+  }
+});

--- a/frontends/election-manager/src/utils/write_ins.ts
+++ b/frontends/election-manager/src/utils/write_ins.ts
@@ -1,11 +1,27 @@
 import { Admin } from '@votingworks/api';
-import { ContestId, ContestOptionId } from '@votingworks/types';
-import { collections, groupBy } from '@votingworks/utils';
+import {
+  Candidate,
+  ContestId,
+  ContestOptionId,
+  ContestOptionTally,
+  ContestTally,
+  Dictionary,
+  Election,
+  ExternalTally,
+  PartyId,
+  writeInCandidate,
+} from '@votingworks/types';
+import { assert, collections, groupBy } from '@votingworks/utils';
 
-export function getWriteInCountsByContestAndCandidate(
+export type CountsByContestAndCandidateName = Map<
+  ContestId,
+  Map<string, number>
+>;
+
+export function getScreenAdjudicatedWriteInCounts(
   writeInSummaryData: Admin.WriteInSummaryEntryAdjudicated[],
   onlyOfficialCandidates = false
-): Map<ContestId, Map<string, number>> {
+): CountsByContestAndCandidateName {
   const writeInsByContestAndCandidate = collections.map(
     groupBy(writeInSummaryData, ({ contestId }) => contestId),
     (writeInSummary) => {
@@ -33,4 +49,143 @@ export function getWriteInCountsByContestAndCandidate(
       )
     )
   );
+}
+
+export function filterWriteInCountsByParty(
+  counts: CountsByContestAndCandidateName,
+  election: Election,
+  partyId?: PartyId
+): CountsByContestAndCandidateName {
+  if (!partyId) return counts;
+
+  const filteredCounts = new Map<ContestId, Map<string, number>>();
+  for (const [contestId, contestCounts] of counts) {
+    const contest = election.contests.find((c) => c.id === contestId);
+    if (contest && contest.partyId === partyId) {
+      filteredCounts.set(contestId, contestCounts);
+    }
+  }
+  return filteredCounts;
+}
+
+// ExternalTally write-in candidate id creation
+export function getAdjudicatedWriteInCandidateId(
+  name: string,
+  manual: boolean
+): string {
+  return `write-in-(${name})${manual ? '-manual' : ''}`;
+}
+
+export function getAdjudicatedWriteInCandidate(
+  name: string,
+  manual: boolean
+): Candidate {
+  return {
+    id: getAdjudicatedWriteInCandidateId(name, manual),
+    name,
+    isWriteIn: true,
+  };
+}
+
+export function isManuallyAdjudicatedWriteInCandidate(
+  candidate: Candidate
+): boolean {
+  return (
+    candidate.id.startsWith('write-in-(') && candidate.id.endsWith(')-manual')
+  );
+}
+
+// Extracts all write-in data from an ExternalTally and formats it
+// as CountsByContestAndCandidateName for the write-in report
+export function getManualWriteInCounts(
+  manualTally: ExternalTally
+): CountsByContestAndCandidateName {
+  const allContestCounts = new Map<ContestId, Map<string, number>>();
+  for (const [contestId, contestTally] of Object.entries(
+    manualTally.contestTallies
+  )) {
+    if (contestTally?.contest.type === 'candidate') {
+      const candidateCountsForContest = new Map<string, number>();
+      for (const contestOptionTally of Object.values(contestTally.tallies)) {
+        const candidate = contestOptionTally?.option as Candidate;
+        const voteCount = contestOptionTally?.tally;
+        if (candidate.isWriteIn && voteCount && voteCount > 0) {
+          candidateCountsForContest.set(candidate.name, voteCount);
+        }
+      }
+      if (candidateCountsForContest.size > 0) {
+        allContestCounts.set(contestId, candidateCountsForContest);
+      }
+    }
+  }
+  return allContestCounts;
+}
+
+export function combineWriteInCounts(
+  writeInCounts: CountsByContestAndCandidateName[]
+): CountsByContestAndCandidateName {
+  const combinedCounts = new Map<ContestId, Map<string, number>>();
+
+  const combinedContestIds = new Set<ContestId>();
+  for (const writeInCount of writeInCounts) {
+    for (const contestId of writeInCount.keys()) {
+      combinedContestIds.add(contestId);
+    }
+  }
+
+  for (const contestId of combinedContestIds) {
+    const combinedCandidateCountsForContest = new Map<string, number>();
+    for (const writeInCount of writeInCounts) {
+      const candidateCountForContest = writeInCount.get(contestId);
+      if (candidateCountForContest) {
+        for (const [name, count] of candidateCountForContest) {
+          combinedCandidateCountsForContest.set(
+            name,
+            (combinedCandidateCountsForContest.get(name) ?? 0) + count
+          );
+        }
+      }
+    }
+
+    combinedCounts.set(contestId, combinedCandidateCountsForContest);
+  }
+
+  return combinedCounts;
+}
+
+// Merges all the distinct write-in candidate tallies in an ExternalTally
+// into a single "Write-In" umbrella tally for the main tally reports
+export function mergeWriteIns(externalTally: ExternalTally): ExternalTally {
+  const newContestTallies: Dictionary<ContestTally> = {};
+  for (const contestTally of Object.values(externalTally.contestTallies)) {
+    assert(contestTally);
+    let newContestOptionTallies: Dictionary<ContestOptionTally> = {};
+    if (contestTally.contest.type === 'candidate') {
+      let writeInTally = 0;
+      for (const contestOptionTally of Object.values(contestTally.tallies)) {
+        assert(contestOptionTally);
+        const candidate = contestOptionTally.option as Candidate;
+        if (candidate.isWriteIn) {
+          writeInTally += contestOptionTally.tally;
+        } else {
+          newContestOptionTallies[candidate.id] = contestOptionTally;
+        }
+      }
+      newContestOptionTallies[writeInCandidate.id] = {
+        option: writeInCandidate,
+        tally: writeInTally,
+      };
+    } else {
+      newContestOptionTallies = contestTally.tallies;
+    }
+    newContestTallies[contestTally.contest.id] = {
+      ...contestTally,
+      tallies: newContestOptionTallies,
+    };
+  }
+
+  return {
+    ...externalTally,
+    contestTallies: newContestTallies,
+  };
 }

--- a/frontends/election-manager/test/helpers/build_external_tally.ts
+++ b/frontends/election-manager/test/helpers/build_external_tally.ts
@@ -1,0 +1,59 @@
+import {
+  CandidateContest,
+  ContestOptionTally,
+  Dictionary,
+  Election,
+  ExternalTally,
+} from '@votingworks/types';
+import { assert } from '@votingworks/utils';
+import {
+  getEmptyContestTallies,
+  getTotalNumberOfBallots,
+} from '../../src/utils/external_tallies';
+
+// Note this helper uses 'getEmptyContestTallies' and 'getTotalNumberOfBallots' util functions so should not be used to test those implementations.
+export function buildExternalTally(
+  election: Election,
+  multiplier: number,
+  contestIdsToPopulate: string[]
+): ExternalTally {
+  // Initialize an empty set of contest tallies
+  const contestTallies = getEmptyContestTallies(election);
+  for (const contestId of contestIdsToPopulate) {
+    if (!(contestId in contestTallies)) {
+      throw new Error(
+        `Contest ID ${contestId} is not in the provided election`
+      );
+    }
+    const emptyTally = contestTallies[contestId];
+    assert(emptyTally);
+    const populatedTallies: Dictionary<ContestOptionTally> = {};
+    const numSeats =
+      emptyTally.contest.type === 'candidate'
+        ? (emptyTally.contest as CandidateContest).seats
+        : 1;
+    let numberOfBallotsInContest = 2 * multiplier; // Undervotes and Overvotes
+    for (const optionId of Object.keys(emptyTally.tallies)) {
+      const option = emptyTally.tallies[optionId];
+      assert(option);
+      populatedTallies[optionId] = {
+        ...option,
+        tally: 1 * multiplier * numSeats,
+      };
+      numberOfBallotsInContest += 1 * multiplier;
+    }
+    contestTallies[contestId] = {
+      ...emptyTally,
+      tallies: populatedTallies,
+      metadata: {
+        undervotes: 1 * multiplier * numSeats,
+        overvotes: 1 * multiplier * numSeats,
+        ballots: numberOfBallotsInContest,
+      },
+    };
+  }
+  return {
+    contestTallies,
+    numberOfBallotsCounted: getTotalNumberOfBallots(contestTallies, election),
+  };
+}

--- a/frontends/election-manager/test/render_in_app_context.tsx
+++ b/frontends/election-manager/test/render_in_app_context.tsx
@@ -12,6 +12,7 @@ import {
   AdjudicationId,
   DippedSmartcardAuth,
   Printer,
+  VotingMethod,
 } from '@votingworks/types';
 import { usbstick, NullPrinter } from '@votingworks/utils';
 import { fakeLogger, Logger, LogSource } from '@votingworks/logging';
@@ -68,6 +69,8 @@ interface RenderInAppContextParams {
   updateExternalTally?: (
     newExternalTally: FullElectionExternalTally
   ) => Promise<void>;
+  manualTallyVotingMethod?: VotingMethod;
+  setManualTallyVotingMethod?: (votingMethod: VotingMethod) => void;
   fullElectionExternalTallies?: FullElectionExternalTallies;
   generateExportableTallies?: () => ExportableTallies;
   auth?: DippedSmartcardAuth.Auth;
@@ -125,6 +128,8 @@ export function renderInAppContext(
     isTabulationRunning = false,
     setIsTabulationRunning = jest.fn(),
     updateExternalTally = jest.fn(),
+    manualTallyVotingMethod = VotingMethod.Precinct,
+    setManualTallyVotingMethod = jest.fn(),
     fullElectionExternalTallies = new Map(),
     saveTranscribedValue = jest.fn(),
     generateExportableTallies = jest.fn(),
@@ -164,6 +169,8 @@ export function renderInAppContext(
         isTabulationRunning,
         setIsTabulationRunning,
         updateExternalTally,
+        manualTallyVotingMethod,
+        setManualTallyVotingMethod,
         fullElectionExternalTallies,
         generateExportableTallies,
         saveTranscribedValue,


### PR DESCRIPTION
## Overview
Closes #2585. Adds the ability to manually add write-in candidates and their vote counts via our manually entered data flow.

## Demo Video or Screenshot
[manual-write-ins.webm](https://user-images.githubusercontent.com/37960853/195188836-dde635da-f480-4ab1-b51c-79f9fadafc40.webm)

## Testing Plan
- Manual and Automated Testing

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
