### PR TITLE
[VxAdmin|VxScan] Hide tally by voting method if unable to distinguish

### DIFF
--- a/frontends/election-manager/src/components/election_manager_tally_report.tsx
+++ b/frontends/election-manager/src/components/election_manager_tally_report.tsx
@@ -152,6 +152,7 @@ export const ElectionManagerTallyReport = forwardRef<HTMLDivElement, Props>(
                     <TallyReportSummary
                       totalBallotCount={reportBallotCount}
                       ballotCountsByVotingMethod={ballotCountsByVotingMethod}
+                      election={election}
                     />
                     <ContestTally
                       election={election}
@@ -184,6 +185,7 @@ export const ElectionManagerTallyReport = forwardRef<HTMLDivElement, Props>(
                     <TallyReportSummary
                       totalBallotCount={reportBallotCount}
                       ballotCountsByVotingMethod={ballotCountsByVotingMethod}
+                      election={election}
                     />
                     <ContestTally
                       election={election}
@@ -212,6 +214,7 @@ export const ElectionManagerTallyReport = forwardRef<HTMLDivElement, Props>(
                     <TallyReportSummary
                       totalBallotCount={reportBallotCount}
                       ballotCountsByVotingMethod={ballotCountsByVotingMethod}
+                      election={election}
                     />
                     <ContestTally
                       election={election}
@@ -268,6 +271,7 @@ export const ElectionManagerTallyReport = forwardRef<HTMLDivElement, Props>(
                   <TallyReportSummary
                     totalBallotCount={reportBallotCount}
                     ballotCountsByVotingMethod={ballotCountsByVotingMethod}
+                    election={election}
                   />
                   <ContestTally
                     election={election}

--- a/frontends/election-manager/src/screens/reports_screen.tsx
+++ b/frontends/election-manager/src/screens/reports_screen.tsx
@@ -3,6 +3,7 @@ import pluralize from 'pluralize';
 
 import {
   assert,
+  canDistinguishPrecinctAndAbsenteeBallots,
   generateSemsFinalExportDefaultFilename,
   format,
 } from '@votingworks/utils';
@@ -132,8 +133,12 @@ export function ReportsScreen(): JSX.Element {
       <React.Fragment>
         <h2>Tally Report by Precinct</h2>
         <BallotCountsTable breakdownCategory={TallyCategory.Precinct} />
-        <h2>Tally Report by Voting Method</h2>
-        <BallotCountsTable breakdownCategory={TallyCategory.VotingMethod} />
+        {canDistinguishPrecinctAndAbsenteeBallots(election) && (
+          <React.Fragment>
+            <h2>Tally Report by Voting Method</h2>
+            <BallotCountsTable breakdownCategory={TallyCategory.VotingMethod} />
+          </React.Fragment>
+        )}
         {partiesForPrimaries.length > 0 && (
           <React.Fragment>
             <h2>Tally Report by Party</h2>

--- a/frontends/election-manager/src/screens/reports_screen.tsx
+++ b/frontends/election-manager/src/screens/reports_screen.tsx
@@ -3,7 +3,7 @@ import pluralize from 'pluralize';
 
 import {
   assert,
-  canDistinguishPrecinctAndAbsenteeBallots,
+  canDistinguishVotingMethods,
   generateSemsFinalExportDefaultFilename,
   format,
 } from '@votingworks/utils';
@@ -133,7 +133,7 @@ export function ReportsScreen(): JSX.Element {
       <React.Fragment>
         <h2>Tally Report by Precinct</h2>
         <BallotCountsTable breakdownCategory={TallyCategory.Precinct} />
-        {canDistinguishPrecinctAndAbsenteeBallots(election) && (
+        {canDistinguishVotingMethods(election) && (
           <React.Fragment>
             <h2>Tally Report by Voting Method</h2>
             <BallotCountsTable breakdownCategory={TallyCategory.VotingMethod} />

--- a/frontends/election-manager/src/utils/generate_results_csv.ts
+++ b/frontends/election-manager/src/utils/generate_results_csv.ts
@@ -168,6 +168,9 @@ export function generateResultsCsv(
   fullElectionTally: FullElectionTally,
   election: Election
 ): string {
+  // TODO(https://github.com/votingworks/vxsuite/issues/2631): Omit the voting method column for
+  // elections where we can't distinguish between absentee/precinct ballots (e.g. NH). Punted as
+  // out-of-scope for the NH pilot.
   let finalDataString = `Contest, Contest ID, Selection, Selection ID, Precinct, Precinct ID, Voting Method, Votes`;
   for (const rowCsvString of generateRows(fullElectionTally, election)) {
     finalDataString += `\n${rowCsvString}`;

--- a/libs/ui/src/precinct_scanner_tally_report.tsx
+++ b/libs/ui/src/precinct_scanner_tally_report.tsx
@@ -162,6 +162,7 @@ export function PrecinctScannerTallyReport({
             <TallyReportSummary
               totalBallotCount={tally.numberOfBallotsCounted}
               ballotCountsByVotingMethod={tally.ballotCountsByVotingMethod}
+              election={election}
             />
             <ContestTally
               election={election}

--- a/libs/ui/src/tally_report_summary.test.tsx
+++ b/libs/ui/src/tally_report_summary.test.tsx
@@ -2,20 +2,12 @@ import React from 'react';
 import { render, getByText as domGetByText } from '@testing-library/react';
 
 import { Tally, VotingMethod } from '@votingworks/types';
-import { electionSampleDefinition } from '@votingworks/fixtures';
-import { mockOf } from '@votingworks/test-utils';
-import { canDistinguishVotingMethods } from '@votingworks/utils';
+import {
+  electionSampleDefinition,
+  electionGridLayoutNewHampshireAmherstFixtures,
+} from '@votingworks/fixtures';
 
 import { TallyReportSummary } from './tally_report_summary';
-
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
-  ...jest.requireActual('@votingworks/utils'),
-  canDistinguishVotingMethods: jest.fn(),
-}));
-
-beforeEach(() => {
-  mockOf(canDistinguishVotingMethods).mockReturnValue(true);
-});
 
 test('Renders with data source table and voting method table when all data provided', () => {
   const ballotCounts: Tally['ballotCountsByVotingMethod'] = {
@@ -77,8 +69,6 @@ test('Hides the other row in the voting method table when empty', () => {
 });
 
 test('Is empty element if voting methods cannot be distinguished for election', () => {
-  mockOf(canDistinguishVotingMethods).mockReturnValue(false);
-
   const ballotCounts: Tally['ballotCountsByVotingMethod'] = {
     [VotingMethod.Absentee]: 1200,
     [VotingMethod.Precinct]: 1045,
@@ -88,7 +78,7 @@ test('Is empty element if voting methods cannot be distinguished for election', 
     <TallyReportSummary
       totalBallotCount={3579}
       ballotCountsByVotingMethod={ballotCounts}
-      election={electionSampleDefinition.election}
+      election={electionGridLayoutNewHampshireAmherstFixtures.election}
     />
   );
 

--- a/libs/ui/src/tally_report_summary.test.tsx
+++ b/libs/ui/src/tally_report_summary.test.tsx
@@ -4,17 +4,17 @@ import { render, getByText as domGetByText } from '@testing-library/react';
 import { Tally, VotingMethod } from '@votingworks/types';
 import { electionSampleDefinition } from '@votingworks/fixtures';
 import { mockOf } from '@votingworks/test-utils';
-import { canDistinguishPrecinctAndAbsenteeBallots } from '@votingworks/utils';
+import { canDistinguishVotingMethods } from '@votingworks/utils';
 
 import { TallyReportSummary } from './tally_report_summary';
 
 jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
   ...jest.requireActual('@votingworks/utils'),
-  canDistinguishPrecinctAndAbsenteeBallots: jest.fn(),
+  canDistinguishVotingMethods: jest.fn(),
 }));
 
 beforeEach(() => {
-  mockOf(canDistinguishPrecinctAndAbsenteeBallots).mockReturnValue(true);
+  mockOf(canDistinguishVotingMethods).mockReturnValue(true);
 });
 
 test('Renders with data source table and voting method table when all data provided', () => {
@@ -77,7 +77,7 @@ test('Hides the other row in the voting method table when empty', () => {
 });
 
 test('Is empty element if voting methods cannot be distinguished for election', () => {
-  mockOf(canDistinguishPrecinctAndAbsenteeBallots).mockReturnValue(false);
+  mockOf(canDistinguishVotingMethods).mockReturnValue(false);
 
   const ballotCounts: Tally['ballotCountsByVotingMethod'] = {
     [VotingMethod.Absentee]: 1200,

--- a/libs/ui/src/tally_report_summary.tsx
+++ b/libs/ui/src/tally_report_summary.tsx
@@ -8,10 +8,7 @@ import {
   Election,
 } from '@votingworks/types';
 
-import {
-  canDistinguishPrecinctAndAbsenteeBallots,
-  format,
-} from '@votingworks/utils';
+import { canDistinguishVotingMethods, format } from '@votingworks/utils';
 import { Table, TD } from './table';
 
 const BallotSummary = styled.div`
@@ -37,7 +34,7 @@ export function TallyReportSummary({
   ballotCountsByVotingMethod,
   election,
 }: Props): JSX.Element | null {
-  if (!canDistinguishPrecinctAndAbsenteeBallots(election)) {
+  if (!canDistinguishVotingMethods(election)) {
     return null;
   }
 

--- a/libs/ui/src/tally_report_summary.tsx
+++ b/libs/ui/src/tally_report_summary.tsx
@@ -5,9 +5,13 @@ import {
   Dictionary,
   VotingMethod,
   getLabelForVotingMethod,
+  Election,
 } from '@votingworks/types';
 
-import { format } from '@votingworks/utils';
+import {
+  canDistinguishPrecinctAndAbsenteeBallots,
+  format,
+} from '@votingworks/utils';
 import { Table, TD } from './table';
 
 const BallotSummary = styled.div`
@@ -25,12 +29,18 @@ const BallotSummary = styled.div`
 interface Props {
   totalBallotCount: number;
   ballotCountsByVotingMethod: Dictionary<number>;
+  election: Election;
 }
 
 export function TallyReportSummary({
   totalBallotCount,
   ballotCountsByVotingMethod,
-}: Props): JSX.Element {
+  election,
+}: Props): JSX.Element | null {
+  if (!canDistinguishPrecinctAndAbsenteeBallots(election)) {
+    return null;
+  }
+
   return (
     <BallotSummary>
       <h3>Ballots by Voting Method</h3>

--- a/libs/utils/src/elections.test.ts
+++ b/libs/utils/src/elections.test.ts
@@ -1,0 +1,20 @@
+import {
+  electionSampleDefinition,
+  electionGridLayoutNewHampshireAmherstFixtures,
+} from '@votingworks/fixtures';
+
+import { canDistinguishPrecinctAndAbsenteeBallots } from './elections';
+
+test('returns true if gridLayouts is absent', () => {
+  expect(
+    canDistinguishPrecinctAndAbsenteeBallots(electionSampleDefinition.election)
+  ).toBeTruthy();
+});
+
+test('returns false if gridLayouts is present', () => {
+  expect(
+    canDistinguishPrecinctAndAbsenteeBallots(
+      electionGridLayoutNewHampshireAmherstFixtures.election
+    )
+  ).toBeFalsy();
+});

--- a/libs/utils/src/elections.test.ts
+++ b/libs/utils/src/elections.test.ts
@@ -3,17 +3,17 @@ import {
   electionGridLayoutNewHampshireAmherstFixtures,
 } from '@votingworks/fixtures';
 
-import { canDistinguishPrecinctAndAbsenteeBallots } from './elections';
+import { canDistinguishVotingMethods } from './elections';
 
 test('returns true if gridLayouts is absent', () => {
   expect(
-    canDistinguishPrecinctAndAbsenteeBallots(electionSampleDefinition.election)
+    canDistinguishVotingMethods(electionSampleDefinition.election)
   ).toBeTruthy();
 });
 
 test('returns false if gridLayouts is present', () => {
   expect(
-    canDistinguishPrecinctAndAbsenteeBallots(
+    canDistinguishVotingMethods(
       electionGridLayoutNewHampshireAmherstFixtures.election
     )
   ).toBeFalsy();

--- a/libs/utils/src/elections.ts
+++ b/libs/utils/src/elections.ts
@@ -4,8 +4,6 @@ import { Election } from '@votingworks/types';
  * Determines if we can distinguish between voting methods for a given election.
  * See https://github.com/votingworks/vxsuite/issues/2631 for added context.
  */
-export function canDistinguishPrecinctAndAbsenteeBallots(
-  election: Election
-): boolean {
+export function canDistinguishVotingMethods(election: Election): boolean {
   return !election.gridLayouts;
 }

--- a/libs/utils/src/elections.ts
+++ b/libs/utils/src/elections.ts
@@ -1,0 +1,11 @@
+import { Election } from '@votingworks/types';
+
+/**
+ * Determines if we can distinguish between voting methods for a given election.
+ * See https://github.com/votingworks/vxsuite/issues/2631 for added context.
+ */
+export function canDistinguishPrecinctAndAbsenteeBallots(
+  election: Election
+): boolean {
+  return !election.gridLayouts;
+}

--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -7,6 +7,7 @@ export * as collections from './collections';
 export * from './compressed_tallies';
 export * from './date';
 export * from './deferred';
+export * from './elections';
 export * from './environment_flag';
 export * from './find';
 export * as format from './format';


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/2631:
- Hiding tallies broken down by voting method whenever we're unable to distinguish voting methods for an election.
- Adding `canDistinguishPrecinctAndAbsenteeBallots` util (currently just a proxy for absence of `gridLayouts` in the election definition).

## Demo Video or Screenshot
### [VxAmdin] Reports Screen:
<img width="400" alt="Screenshot 2022-10-12 at 10 16 33 AM" src="https://user-images.githubusercontent.com/264902/195382315-c40242ab-9264-4c53-9806-402dbebafcf2.png"> <img width="400" alt="Screenshot 2022-10-12 at 10 16 01 AM" src="https://user-images.githubusercontent.com/264902/195382337-4038901b-ff97-4275-8e74-1cc0d6c66422.png">

### [VxAdmin] Tally Report Table:
<img width="400" alt="Screenshot 2022-10-12 at 9 43 40 AM" src="https://user-images.githubusercontent.com/264902/195382798-968cd3a3-63a5-4b69-a8dc-2c30552fd603.png"> <img width="400" alt="Screenshot 2022-10-12 at 9 45 11 AM" src="https://user-images.githubusercontent.com/264902/195382818-b490e04a-88be-4a3e-a44c-b4e36560303a.png">

### [VxScan] Polls Open/Closed Report:
<img width="385" alt="Screenshot 2022-10-12 at 12 17 15 PM" src="https://user-images.githubusercontent.com/264902/195407476-440a09ba-1baf-4c74-bbe3-ac7cf30332ac.png"> <img width="391" alt="Screenshot 2022-10-12 at 12 16 04 PM" src="https://user-images.githubusercontent.com/264902/195407618-25d77e89-2cba-4aca-827d-39a3683afc94.png">


## Testing Plan 
- Unit test coverage and local verification

## Checklist
- [n/a] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
