### PR TITLE
Don't Show Contests in Write-In Report if they have no data

### DIFF
--- a/frontends/election-manager/src/components/election_manager_writein_tally_report.tsx
+++ b/frontends/election-manager/src/components/election_manager_writein_tally_report.tsx
@@ -21,6 +21,7 @@ import {
   combineWriteInCounts,
   CountsByContestAndCandidateName,
   filterWriteInCountsByParty,
+  writeInCountsAreEmpty,
 } from '../utils/write_ins';
 
 export interface Props {
@@ -95,6 +96,9 @@ export const ElectionManagerWriteInTallyReport = forwardRef<
             election,
             partyId
           );
+          if (writeInCountsAreEmpty(writeInCountsFilteredByParty)) {
+            return null;
+          }
           return precinctIds.map((precinctId) => {
             const party = election.parties.find((p) => p.id === partyId);
             const electionTitle = party

--- a/frontends/election-manager/src/screens/tally_writein_report_screen.tsx
+++ b/frontends/election-manager/src/screens/tally_writein_report_screen.tsx
@@ -46,6 +46,7 @@ import { useWriteInSummaryQuery } from '../hooks/use_write_in_summary_query';
 import {
   getManualWriteInCounts,
   getScreenAdjudicatedWriteInCounts,
+  writeInCountsAreEmpty,
 } from '../utils/write_ins';
 
 const TallyReportPreview = styled(TallyReport)`
@@ -220,42 +221,59 @@ export function TallyWriteInReportScreen(): JSX.Element {
     );
   }
 
+  const isReportEmpty =
+    writeInCountsAreEmpty(screenAdjudicatedWriteInCounts) &&
+    (!manualWriteInCounts || writeInCountsAreEmpty(manualWriteInCounts));
+
   return (
     <React.Fragment>
       <NavigationScreen>
         <Prose>
           <h1>{reportDisplayTitle}</h1>
-          <TallyReportMetadata
-            generatedAtTime={generatedAtTime}
-            election={election}
-          />
-          <p>
-            <PrintButton
-              afterPrint={afterPrint}
-              afterPrintError={afterPrintError}
-              primary
-              sides="one-sided"
-            >
-              Print Report
-            </PrintButton>{' '}
-            {window.kiosk && (
-              <Button onPress={() => setIsSaveModalOpen(true)}>
-                Save Report as PDF
-              </Button>
-            )}
-          </p>
+          {!isReportEmpty ? (
+            <React.Fragment>
+              <TallyReportMetadata
+                generatedAtTime={generatedAtTime}
+                election={election}
+              />
+              <p>
+                <PrintButton
+                  afterPrint={afterPrint}
+                  afterPrintError={afterPrintError}
+                  primary
+                  sides="one-sided"
+                >
+                  Print Report
+                </PrintButton>{' '}
+                {window.kiosk && (
+                  <Button onPress={() => setIsSaveModalOpen(true)}>
+                    Save Report as PDF
+                  </Button>
+                )}
+              </p>
+            </React.Fragment>
+          ) : (
+            <p>
+              The Write-In Tally Report is currently empty because there are no
+              write-in votes adjudicated to non-official candidates. Write-in
+              votes adjudicated to official candidates are included in the Full
+              Election Tally Report and not this report.
+            </p>
+          )}
           <p>
             <LinkButton small to={routerPaths.tally}>
               Back to Tally Index
             </LinkButton>
           </p>
-          <React.Fragment>
-            <h2>Report Preview</h2>
-            <Text italic small>
-              <strong>Note:</strong> Printed reports may be paginated to more
-              than one piece of paper.
-            </Text>
-          </React.Fragment>
+          {!isReportEmpty && (
+            <React.Fragment>
+              <h2>Report Preview</h2>
+              <Text italic small>
+                <strong>Note:</strong> Printed reports may be paginated to more
+                than one piece of paper.
+              </Text>
+            </React.Fragment>
+          )}
         </Prose>
         <TallyReportPreview ref={previewReportRef} />
       </NavigationScreen>

--- a/frontends/election-manager/src/utils/write_ins.ts
+++ b/frontends/election-manager/src/utils/write_ins.ts
@@ -153,6 +153,18 @@ export function combineWriteInCounts(
   return combinedCounts;
 }
 
+export function writeInCountsAreEmpty(
+  counts: CountsByContestAndCandidateName
+): boolean {
+  if (counts.size === 0) return true;
+
+  for (const candidateCounts of counts.values()) {
+    if (candidateCounts.size > 0) return false;
+  }
+
+  return true;
+}
+
 // Merges all the distinct write-in candidate tallies in an ExternalTally
 // into a single "Write-In" umbrella tally for the main tally reports
 export function mergeWriteIns(externalTally: ExternalTally): ExternalTally {

--- a/libs/ui/src/contest_writein_tally.test.tsx
+++ b/libs/ui/src/contest_writein_tally.test.tsx
@@ -28,7 +28,6 @@ beforeEach(() => {
       ]),
     ],
     ['representative-district-18', new Map([])],
-    ['prop-1', new Map([])],
   ]);
 });
 
@@ -47,9 +46,7 @@ it('renders correctly', () => {
   within(screen.getByText('Bob').closest('tr')!).getByText('8');
   within(screen.getByText('Charlie').closest('tr')!).getByText('4');
 
-  within(
-    screen.getByText('Representative, District 18').closest('div')!
-  ).getByText(
-    'Adjudication of write-in votes has not been completed for this contest.'
-  );
+  expect(
+    screen.queryByText('Representative, District 18')
+  ).not.toBeInTheDocument();
 });

--- a/libs/ui/src/contest_writein_tally.tsx
+++ b/libs/ui/src/contest_writein_tally.tsx
@@ -41,55 +41,44 @@ export function ContestWriteInTally({
 }: Props): JSX.Element {
   return (
     <React.Fragment>
-      {election.contests.map((contest) => {
-        const contestWriteInCounts = writeInCounts.get(contest.id);
-        if (!contestWriteInCounts || contestWriteInCounts.size === 0) {
-          return null;
-        }
-
-        const contestOptionTableRows: JSX.Element[] = [];
-        switch (contest.type) {
-          case 'candidate': {
-            for (const [transcribedValue, count] of contestWriteInCounts) {
-              const key = `${contest.id}-${transcribedValue}`;
-              contestOptionTableRows.push(
-                <tr key={key} data-testid={key}>
-                  <td>{transcribedValue}</td>
-                  <TD narrow textAlign="right">
-                    {count}
-                  </TD>
-                </tr>
-              );
-            }
-            break;
+      {election.contests
+        .filter((contest) => contest.type === 'candidate')
+        .map((contest) => {
+          const contestWriteInCounts = writeInCounts.get(contest.id);
+          if (!contestWriteInCounts || contestWriteInCounts.size === 0) {
+            return null;
           }
-          default:
-            break;
-        }
 
-        return (
-          <Contest key={`div-${contest.id}`}>
-            <Prose maxWidth={false} data-testid={`results-table-${contest.id}`}>
-              {contest.section !== contest.title && (
-                <Text small>{contest.section}</Text>
-              )}
-              <h3>{contest.title}</h3>
-              {contestOptionTableRows.length ? (
+          const contestOptionTableRows: JSX.Element[] = [];
+          for (const [transcribedValue, count] of contestWriteInCounts) {
+            const key = `${contest.id}-${transcribedValue}`;
+            contestOptionTableRows.push(
+              <tr key={key} data-testid={key}>
+                <td>{transcribedValue}</td>
+                <TD narrow textAlign="right">
+                  {count}
+                </TD>
+              </tr>
+            );
+          }
+
+          return (
+            <Contest key={`div-${contest.id}`}>
+              <Prose
+                maxWidth={false}
+                data-testid={`results-table-${contest.id}`}
+              >
+                {contest.section !== contest.title && (
+                  <Text small>{contest.section}</Text>
+                )}
+                <h3>{contest.title}</h3>
                 <Table borderTop condensed>
                   <tbody>{contestOptionTableRows}</tbody>
                 </Table>
-              ) : (
-                <p>
-                  <em>
-                    Adjudication of write-in votes has not been completed for
-                    this contest.
-                  </em>
-                </p>
-              )}
-            </Prose>
-          </Contest>
-        );
-      })}
+              </Prose>
+            </Contest>
+          );
+        })}
     </React.Fragment>
   );
 }

--- a/libs/ui/src/contest_writein_tally.tsx
+++ b/libs/ui/src/contest_writein_tally.tsx
@@ -43,7 +43,7 @@ export function ContestWriteInTally({
     <React.Fragment>
       {election.contests.map((contest) => {
         const contestWriteInCounts = writeInCounts.get(contest.id);
-        if (!contestWriteInCounts) {
+        if (!contestWriteInCounts || contestWriteInCounts.size === 0) {
           return null;
         }
 


### PR DESCRIPTION
## Overview
Clsoes #2595. Rather than say that adjudication hasn't been completed for contests with no non-official write-in candidates in the scatter report, just don't show those contests. If there are no contests on a primary report, don't show that party's part of the report. If there are no reports at all, don't show any report at all.

## Demo Video or Screenshot

<img width="757" alt="Screen Shot 2022-10-12 at 9 34 38 AM" src="https://user-images.githubusercontent.com/37960853/195411142-db3e6fa7-dd4c-499c-b85b-a35a57a40dba.png">

## Testing Plan 
- Wrote new write-in report flow test
- Manual Testing

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
