### PR TITLE
feat(scan-nh): add `--write-normalized-images` CLI flag

### DIFF
--- a/libs/ballot-interpreter-nh/src/cli/interpret/index.test.ts
+++ b/libs/ballot-interpreter-nh/src/cli/interpret/index.test.ts
@@ -34,10 +34,9 @@ test('--help', async () => {
 
   const exitCode = await main(['--help'], io);
 
-  expect(io.stdout.toString()).toMatchInlineSnapshot(`
-    "usage: interpret [-t [MARGINAL,]DEFINITE] <election.json> <front-ballot.jpg> <back-ballot.jpg> [--debug] [--json]
-    "
-  `);
+  expect(io.stdout.toString()).toContain(
+    'interpret [options] <election.json> <front-ballot.jpg> <back-ballot.jpg>'
+  );
   expect(exitCode).toBe(0);
 });
 
@@ -50,10 +49,9 @@ test('-h', async () => {
 
   const exitCode = await main(['-h'], io);
 
-  expect(io.stdout.toString()).toMatchInlineSnapshot(`
-    "usage: interpret [-t [MARGINAL,]DEFINITE] <election.json> <front-ballot.jpg> <back-ballot.jpg> [--debug] [--json]
-    "
-  `);
+  expect(io.stdout.toString()).toContain(
+    'interpret [options] <election.json> <front-ballot.jpg> <back-ballot.jpg>'
+  );
   expect(exitCode).toBe(0);
 });
 


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
I needed to get access to the normalized images generated by the interpretation process. This new flag causes the normalized images to be written to disk alongside the originals.

## Demo Video or Screenshot
n/a

## Testing Plan 
Tested manually with the new flag.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
