### PR TITLE
fix(scan): de-dupe contests by ID, not title

### DIFF
--- a/frontends/precinct-scanner/src/screens/scan_warning_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/scan_warning_screen.tsx
@@ -94,7 +94,7 @@ function OvervoteWarningScreen({
       )
     )
     .reduce<AnyContest[]>(
-      (a, c) => (a.findIndex((o) => o.title === c.title) >= 0 ? a : [...a, c]),
+      (acc, c) => (acc.find((o) => o.id === c.id) ? acc : [...acc, c]),
       []
     )
     .map((c) => c.title);


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
In the rare case where there are two contests with the same title, ensure the contest names and count are correct.

## Demo Video or Screenshot
n/a

## Testing Plan 
Discovered this while testing with an election that had multiple contests with the same title (due to #2643).

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
