### PR TITLE
fix(admin): format both `X of Y` as counts

### DIFF
--- a/frontends/election-manager/src/screens/write_ins_transcription_screen.tsx
+++ b/frontends/election-manager/src/screens/write_ins_transcription_screen.tsx
@@ -257,7 +257,7 @@ export function WriteInsTranscriptionScreen({
               Previous
             </Button>
             <Text center>
-              {offset + 1} of {format.count(adjudications.length)}
+              {format.count(offset + 1)} of {format.count(adjudications.length)}
             </Text>
             <Button
               ref={nextButton}


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
It's unlikely we'll encounter a situation anytime soon where this will make a difference, but it's better to have it be correct to serve as an example.

## Demo Video or Screenshot
n/a

## Testing Plan 
n/a

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
