### PR TITLE
fix broken reconfigure for single-precinct

### DIFF
--- a/services/scan/src/precinct_scanner_app.ts
+++ b/services/scan/src/precinct_scanner_app.ts
@@ -125,7 +125,7 @@ export async function buildPrecinctScannerApp(
     NoParams,
     Scan.PatchElectionConfigResponse,
     Scan.PatchElectionConfigRequest
-  >('/precinct-scanner/config/election', (request, response) => {
+  >('/precinct-scanner/config/election', async (request, response) => {
     const { body } = request;
 
     if (!Buffer.isBuffer(body)) {
@@ -168,6 +168,7 @@ export async function buildPrecinctScannerApp(
       store.setPrecinctSelection(
         singlePrecinctSelectionFor(electionDefinition.election.precincts[0].id)
       );
+      await updateInterpreterConfig(interpreter, workspace);
     }
     response.json({ status: 'ok' });
   });
@@ -420,6 +421,7 @@ export async function buildPrecinctScannerApp(
           );
         }
 
+        await updateInterpreterConfig(interpreter, workspace);
         response.json({ status: 'ok' });
       } catch (error) {
         assert(error instanceof Error);


### PR DESCRIPTION
## Overview
Closes #2663. The bug only affects single precinct elections and was introduced in #2641. The interpreter was not being updated after we auto-set the precinct. Further, now that the precinct can be set before templates are done being uploaded, we have to update the interpreter after we add each template. 

It seems like we could manage interpreter state a little more cleanly, because right now anytime we add something that changes interpreter inputs we have to remember to update the interpreter. If we forget, as I did in the linked PR, bugs! Why can't the interpreter just use the state from the store? I haven't dug into this yet, just musing.

## Testing Plan 
Manual only.
