### PR TITLE
Build Script to Build All Dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ more information about VotingWorks.
 ## Development
 
 Building VxSuite for development requires git, [NodeJS](https://nodejs.org/)
-v16.14.2 and [pnpm](https://pnpm.js.org) v5 (or use `corepack` to automatically use the right package manager).
+v16.14.2 and [pnpm](https://pnpm.js.org) v5 (or use `corepack` to automatically
+use the right package manager).
 
 Most of the code is written in TypeScript. We follow the
 [Google TypeScript Style Guide](https://google.github.io/styleguide/tsguide.html)
@@ -98,10 +99,7 @@ Test that you can run the code
 
 ```sh
 # try out BMD:
-make -C services/smartcards build run &
-# ^ wait for this to settle, then…
 cd frontends/bmd
-pnpm install
 pnpm build
 pnpm start
 # if it worked, go to http://localhost:3000/ in your VM
@@ -273,8 +271,16 @@ help you contribute.
 ## Development Best Practices
 
 ### Feature Flags
-Feature flags are defined in the libs/utils subrepo [here](https://github.com/votingworks/vxsuite/blob/main/libs/utils/src/environment_flag.ts). 
-To configure which flags you are using you can set them in an `.env.local` file. This file can live either at the root of vxsuite or in the subrepo you want that flag to apply to. Flag values set in subrepo files will override those set at the root. `.env.local` file will also override a default `.env` file at either a subrepo or root level. To generate a `.env.local` file properly run the `pnpm configure-dev` command. If you are using VxDev you can run the `pnpm configure-vxdev-env` command BEFORE running the update code program. 
+
+Feature flags are defined in the libs/utils subrepo
+[here](https://github.com/votingworks/vxsuite/blob/main/libs/utils/src/environment_flag.ts).
+To configure which flags you are using you can set them in an `.env.local` file.
+This file can live either at the root of vxsuite or in the subrepo you want that
+flag to apply to. Flag values set in subrepo files will override those set at
+the root. `.env.local` file will also override a default `.env` file at either a
+subrepo or root level. To generate a `.env.local` file properly run the
+`pnpm configure-dev` command. If you are using VxDev you can run the
+`pnpm configure-vxdev-env` command BEFORE running the update code program.
 
 ### Use `zod` for validating/parsing JSON data
 
@@ -454,7 +460,6 @@ log in a single test file, add this above all the other code in the file:
 import { enable } from 'debug';
 enable('math:*'); // or whatever globs you want
 ```
-
 
 ## License
 

--- a/frontends/bas/README.md
+++ b/frontends/bas/README.md
@@ -5,15 +5,30 @@ Activates voter cards for use with the VxSuite
 
 ## Setup
 
-Follow the instructions in the [VxSuite README](../../README.md) to get set up,
-then run the app like so:
+Follow the instructions in the [VxSuite README](../../README.md) to get set up.
+You can build and run the app as follows:
 
 ```sh
 # in frontends/bas
+pnpm build # on initial setup only
 pnpm start
 ```
 
 The server will be available at http://localhost:3000/.
+
+### Running Services Separately
+
+`pnpm build` and `pnpm start` will build and run, respectively, the smartcard
+service that the app depends on. In the rare cases where you only want to run
+the app itself and spin up the smartcard service separately:
+
+```sh
+# in frontends/bas
+pnpm build:core # on initial setup only
+pnpm start:core
+```
+
+Then, build and run [`services/smartcards`](../../services/smartcards).
 
 ## Testing
 

--- a/frontends/bas/package.json
+++ b/frontends/bas/package.json
@@ -9,7 +9,8 @@
   ],
   "scripts": {
     "type-check": "tsc --build",
-    "build": "pnpm type-check && vite build",
+    "build": "pnpm -w build-dev -- bas",
+    "build:core": "pnpm -w build-dev -- bas --core-only",
     "format": "prettier '**/*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
     "lint": "pnpm type-check && eslint . --fix && pnpm stylelint:run",
     "lint:fix": "pnpm type-check && eslint . --fix && pnpm stylelint:run:fix",

--- a/frontends/bmd/README.md
+++ b/frontends/bmd/README.md
@@ -4,11 +4,18 @@ Marks and/or prints ballots for a voter.
 
 ## Setup
 
-Follow the instructions in the [VxSuite README](../../README.md) to get set up,
-then run BMD like so:
+Follow the instructions in the [VxSuite README](../../README.md) to get set up.
+If it's your first time running the app, you'll have to build it:
 
 ```sh
 # In frontends/bmd
+pnpm build
+```
+
+Then to run the app:
+
+```sh
+# in frontends/bmd
 # To run in mark-only mode (when there's a separate standalone printer)
 VX_APP_MODE=MarkOnly pnpm start
 
@@ -24,6 +31,20 @@ pnpm start
 ```
 
 The server will be available at http://localhost:3000/.
+
+### Running Services Separately
+
+`pnpm build` and `pnpm start` will build and run, respectively, the smartcard
+service that the app depends on. In the rare cases where you only want to run
+the app itself and spin up the smartcard service separately:
+
+```sh
+# in frontends/bmd
+pnpm build:core # on initial setup only
+pnpm start:core
+```
+
+Then, build and run [`services/smartcards`](../../services/smartcards).
 
 ## Testing
 

--- a/frontends/bmd/package.json
+++ b/frontends/bmd/package.json
@@ -9,7 +9,8 @@
   ],
   "scripts": {
     "type-check": "tsc --build",
-    "build": "pnpm type-check && vite build",
+    "build": "pnpm -w build-dev -- bmd",
+    "build:core": "pnpm -w build-dev -- bmd --core-only",
     "build:resources": "res-to-ts --rootDir data --outDir src/data 'data/**/*.json'",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run --browser chrome --reporter junit",

--- a/frontends/bsd/README.md
+++ b/frontends/bsd/README.md
@@ -10,6 +10,7 @@ then run the app like so:
 
 ```sh
 # in frontends/bsd
+pnpm build # on initial setup only
 pnpm start
 ```
 
@@ -24,6 +25,23 @@ intend to test hand-marked paper ballots (HMPBs).
 
 To display a batch of scanned ballots use the `MOCK_SCANNER_FILES` environment
 variable set as described in [`services/scan`](../../services/scan).
+
+### Running Services Separately
+
+`pnpm build` and `pnpm start` will build and run, respectively, the app's
+dependent services. In the rare cases where you only want to run the app itself
+and spin up services separately:
+
+```sh
+# in frontends/bsd
+pnpm build:core # on initial setup only
+pnpm start:core
+```
+
+Then run the following:
+
+- [`services/scan`](../../services/admin), using `pnpm start:bsd`
+- [`services/smartcards`](../../services/smartcards)
 
 ## Testing
 

--- a/frontends/bsd/package.json
+++ b/frontends/bsd/package.json
@@ -9,7 +9,8 @@
   ],
   "scripts": {
     "type-check": "tsc --build",
-    "build": "pnpm type-check && vite build",
+    "build": "pnpm -w build-dev -- bsd",
+    "build:core": "pnpm -w build-dev -- bsd --core-only",
     "format": "prettier '**/*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
     "lint": "pnpm type-check && eslint . && pnpm stylelint:run",
     "lint:fix": "pnpm type-check && eslint . --fix && pnpm stylelint:run:fix",

--- a/frontends/election-manager/README.md
+++ b/frontends/election-manager/README.md
@@ -3,16 +3,17 @@
 This app is intended to be used on an offline computer by system administrators
 and election managers.
 
-Note: Election manager can refer to VxAdmin or a user role, depending on the
+Note: "Election Manager" can refer to VxAdmin or a user role, depending on the
 context.
 
 ## Setup
 
-Follow the instructions in the [VxSuite README](../../README.md) to get set up,
-then run the app like so:
+Follow the instructions in the [VxSuite README](../../README.md) to get set up.
+You can build and run the app as follows:
 
 ```sh
 # in frontends/election-manager
+pnpm build # on initial setup only
 pnpm start
 ```
 
@@ -33,12 +34,24 @@ with `REACT_APP_VX_CONVERTER` set to the appropriate value:
 You may set this value in `.env.local` to make the value persistent on your
 machine.
 
-### Optional prerequisites
+### Running Services Separately
 
-- If you want to program smartcards, start
-  [`services/smartcards`](../../services/smartcards)
-- If you will need to convert SEMS files, start
-  [`services/converter-ms-sems`](../../services/converter-ms-sems)
+`pnpm build` and `pnpm start` will build and run, respectively, the app's
+dependent services. In the rare cases where you only want to run the app itself
+and spin up services separately:
+
+```sh
+# in frontends/election-manager
+pnpm build:core # on initial setup only
+pnpm start:core
+```
+
+Then run the following:
+
+- [`services/admin`](../../services/admin)
+- [`services/smartcards`](../../services/smartcards)
+- [`services/converter-ms-sems`](../../services/converter-ms-sems), if you need
+  to convert SEMS files
 
 ## Testing
 

--- a/frontends/election-manager/package.json
+++ b/frontends/election-manager/package.json
@@ -9,7 +9,8 @@
   ],
   "scripts": {
     "type-check": "tsc --build",
-    "build": "pnpm type-check && vite build",
+    "build": "pnpm -w build-dev -- election-manager",
+    "build:core": "pnpm -w build-dev -- election-manager --core-only",
     "build:stubs": "script/build-stubs fs:src/stubs/fs.ts glob:src/stubs/glob.ts os:src/stubs/os.ts jsdom:src/stubs/jsdom.ts",
     "format": "prettier '**/*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
     "lint": "pnpm type-check && eslint . && pnpm stylelint:run",

--- a/frontends/precinct-scanner/README.md
+++ b/frontends/precinct-scanner/README.md
@@ -7,11 +7,12 @@ the VxSuite [Election Manager](../election-manager).
 
 ## Setup
 
-Follow the instructions in the [VxSuite README](../../README.md) to get set up,
-then run the app like so:
+Follow the instructions in the [VxSuite README](../../README.md) to get set up.
+You can build and run the app as follows:
 
 ```sh
 # in frontends/precinct-scanner
+pnpm build # on initial setup only
 pnpm start
 ```
 
@@ -26,6 +27,23 @@ that folder. You'll need to run the application inside
 
 To use a mock scanner, follow the directions from in
 [`services/scan`](../../services/scan#Single-sheet-scanner).
+
+### Running Services Separately
+
+`pnpm build` and `pnpm start` will build and run, respectively, the app's
+dependent services. In the rare cases where you only want to run the app itself
+and spin up services separately:
+
+```sh
+# in frontends/precinct-scanner
+pnpm build:core # on initial setup only
+pnpm start:core
+```
+
+Then run the following:
+
+- [`services/scan`](../../services/admin), using `pnpm start:precinct-scanner`
+- [`services/smartcards`](../../services/smartcards)
 
 ## Testing
 

--- a/frontends/precinct-scanner/package.json
+++ b/frontends/precinct-scanner/package.json
@@ -9,7 +9,8 @@
   ],
   "scripts": {
     "type-check": "tsc --build",
-    "build": "pnpm type-check && vite build",
+    "build": "pnpm -w build-dev -- precinct-scanner",
+    "build:core": "pnpm -w build-dev -- precinct-scanner --core-only",
     "build:stubs": "script/build-stubs fs:src/stubs/fs.ts os:src/stubs/os.ts",
     "format": "prettier '**/*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
     "lint": "pnpm type-check && eslint . && pnpm stylelint:run",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "prepare": "husky install",
     "configure-env": "pnpx ts-node --esm libs/utils/src/scripts/generate_env_file.ts",
     "configure-vxdev-env": "pnpx ts-node --esm libs/utils/src/scripts/generate_env_file.ts --isVxDev -o /vx/config/.env.local",
-    "run-dev": "script/run-dev"
+    "run-dev": "script/run-dev",
+    "build-dev": "script/build-dev"
   },
   "lint-staged": {
     "package.json": "sort-package-json",

--- a/script/build-dev
+++ b/script/build-dev
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+// @ts-check
+
+require('esbuild-runner/register');
+
+require('./src/build-dev')
+  .main(process.argv, {
+    stdout: process.stdout,
+    stderr: process.stderr,
+  })

--- a/script/src/build-dev/index.ts
+++ b/script/src/build-dev/index.ts
@@ -1,0 +1,153 @@
+import { spawnSync, StdioOptions } from 'child_process';
+import * as fs from 'fs';
+import { basename, join } from 'path';
+import { Writable } from 'stream';
+
+interface IO {
+  readonly stdout: Writable;
+  readonly stderr: Writable;
+}
+
+/**
+ * Determines whether a package builds with `tsc --build`.
+ */
+function isTscBuildPackage(cwd: string): boolean {
+  return fs.existsSync(join(cwd, 'tsconfig.build.json'));
+}
+
+/**
+ * Returns the tsc build path, which have a base of 
+ * tsconfig.build.json or tsconfig.json
+ */
+ function tscBuildPath(cwd: string): string {
+  return join(cwd, isTscBuildPackage(cwd) ? 'tsconfig.build.json' : 'tsconfig.json');
+}
+
+/**
+ * Determines whether a package runs with Python.
+ */
+function isPythonPackage(cwd: string): boolean {
+  return fs.existsSync(join(cwd, 'Pipfile'));
+}
+
+/**
+ * Creates a command for running a binary from a package's
+ * `node_modules/.bin` directory.
+ */
+function npmBinCommandFile(cwd: string, command: string): string {
+ return join(cwd, 'node_modules', '.bin', command)
+}
+
+/**
+ * Spawns process to build a package's typescript dependencies
+ */
+function buildTscDependencies(cwd: string, stdio: StdioOptions) {
+  spawnSync(
+    npmBinCommandFile(cwd, 'tsc'), 
+    ['--build', tscBuildPath(cwd), '--pretty'], 
+    { stdio }
+  );
+}
+
+/**
+ * Builds the frontend, related services, and dependencies
+ */
+export function main(
+  argv: readonly string[],
+  { stdout, stderr }: IO
+): number {
+  const [, programName, ...args] = argv;
+  const stdio: StdioOptions = [null, stdout, stderr];
+
+  let coreOnly = false;
+  let frontend: string | undefined;
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i] as string;
+    switch (arg) {
+      case '-h':
+      case '--help':
+        stdout.write(`Usage: ${programName} FRONTEND [--core-only]\n`);
+        return 0;
+
+      case '--core-only':
+        coreOnly = true;
+        break;
+
+      default:
+        if (arg.startsWith('-')) {
+          stderr.write(`Unknown option: ${arg}\n`);
+          return 1;
+        }
+
+        if (frontend) {
+          stderr.write(`Only one frontend can be specified, got: ${arg}\n`);
+          return 1;
+        }
+
+        frontend = arg;
+        break;
+    }
+  }
+
+  if (!frontend) {
+    stderr.write('No frontend specified\n');
+    return 1;
+  }
+
+  const monorepoRoot = join(__dirname, '../../..');
+  const frontendRoot = join(monorepoRoot, 'frontends', frontend);
+
+  if (!fs.existsSync(frontendRoot)) {
+    stderr.write(`Frontend not found: ${frontend}\n`);
+    return 1;
+  }
+
+  // Always build the frontend
+  stdout.write('> building frontend dependencies...\n');
+  buildTscDependencies(frontendRoot, stdio);
+  stdout.write('> building frontend: ');
+  spawnSync(
+    npmBinCommandFile(frontendRoot, 'vite'), 
+    ['build', frontendRoot], 
+    { stdio }
+  );
+
+  // Optionally run all the dependent services
+  if (!coreOnly) {
+    const frontendPackageJson = JSON.parse(
+      fs.readFileSync(join(frontendRoot, 'package.json'), 'utf8')
+    );
+    const frontendVxConfig = frontendPackageJson['vx'] ?? {};
+
+    if (frontendVxConfig.services) {
+      for (const service of frontendVxConfig.services) {
+        const serviceRoot = join(frontendRoot, service);
+        const name = basename(service);
+        stdout.write('\n');
+        if (isTscBuildPackage(serviceRoot)) {
+          stdout.write(`> building ${name} service dependencies...\n`);
+          buildTscDependencies(serviceRoot, stdio);
+          stdout.write(`> building ${name} service...\n`);
+          spawnSync(
+            npmBinCommandFile(frontendRoot, 'pnpm'), 
+            ['build'], 
+            { stdio }
+          );
+        } else if (isPythonPackage(serviceRoot)) {
+          stdout.write(`> building ${name} service...\n`);
+          spawnSync(
+            'make', 
+            ['build', '-C', serviceRoot], 
+            { stdio }
+          );
+        } else {
+          stderr.write(`Cannot find build command for service: ${name}\n`);
+          return 1;
+        }
+      }
+    }
+    stdout.write('> all dependent services built\n');
+  }  
+
+  return 0;
+}

--- a/services/converter-ms-sems/Makefile
+++ b/services/converter-ms-sems/Makefile
@@ -8,7 +8,7 @@ install-python: add-ppa
 install: install-python
 
 install-dependencies:
-	python3.9 -m pip install pipenv
+	python3.9 -m pip install pipenv --quiet
 	python3.9 -m pipenv install
 
 install-dev-dependencies:

--- a/services/smartcards/Makefile
+++ b/services/smartcards/Makefile
@@ -11,7 +11,7 @@ install-smartcard:
 install: install-python install-smartcard
 
 build:
-	python3.9 -m pip install pipenv
+	python3.9 -m pip install pipenv --quiet
 	python3.9 -m pipenv install
 
 build-dev:


### PR DESCRIPTION
Modeled after @eventualbuddha's #2640, this PR creates a general `build-dev` script and uses it to build all the frontends and their services. Like `run-dev` it uses the existing vx config package.json key to determine which services need to be built along with a frontend.

`pnpm build` by default builds all the services (which normally is quite fast) and `pnpm build:core` builds only the frontend and its dependencies, to parallel `pnpm run`.
