### PR TITLE
fix(admin): improve display of transcriptions remaining

### DIFF
--- a/frontends/election-manager/src/screens/write_ins_transcription_screen.tsx
+++ b/frontends/election-manager/src/screens/write_ins_transcription_screen.tsx
@@ -18,6 +18,7 @@ import {
   HorizontalRule,
 } from '@votingworks/ui';
 import { assert, format } from '@votingworks/utils';
+import pluralize from 'pluralize';
 import { Navigation } from '../components/navigation';
 import { InlineForm, TextInput } from '../components/text_input';
 import { useWriteInImageQuery } from '../hooks/use_write_in_images_query';
@@ -215,7 +216,10 @@ export function WriteInsTranscriptionScreen({
             <Text as="span">
               {isEmptyTranscriptionQueue
                 ? 'No further write-ins to transcribe for this contest.'
-                : `${transcriptionQueue} write-ins to transcribe.`}
+                : `${format.count(transcriptionQueue)} ${pluralize(
+                    'write-in',
+                    transcriptionQueue
+                  )} to transcribe.`}
             </Text>
             <Button small primary={isEmptyTranscriptionQueue} onPress={onClose}>
               Back to All Write-Ins


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
- Uses `format.count` to properly display an integer count (i.e. grouping separators for 1,000+).
- Shows "1 write-in to transcribe" when there's only one left (instead of "1 write-ins to transcribe").

## Demo Video or Screenshot
| Before | After |
|-|-|
| <img width="429" alt="Screen Shot 2022-10-13 at 1 55 25 PM" src="https://user-images.githubusercontent.com/1938/195709904-4b3ee226-3d2d-4e1e-9d2c-082e00cd61dc.png"> | <img width="431" alt="Screen Shot 2022-10-13 at 1 55 05 PM" src="https://user-images.githubusercontent.com/1938/195709926-9d26b30f-f4b4-46ef-bb0c-7fb2f26d018d.png"> |
| <img width="438" alt="Screen Shot 2022-10-13 at 2 03 51 PM" src="https://user-images.githubusercontent.com/1938/195710183-0d11b2bd-c154-46b8-a957-dfa92b2228d8.png"> | <img width="445" alt="Screen Shot 2022-10-13 at 1 58 41 PM" src="https://user-images.githubusercontent.com/1938/195710208-c2869b89-87eb-49e5-8cd1-099f96bcda43.png"> |

## Testing Plan 
Tested manually.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
