### PR TITLE
BMD - Automatically set precinct if only one

### DIFF
--- a/frontends/bmd/src/app_root.tsx
+++ b/frontends/bmd/src/app_root.tsx
@@ -31,6 +31,7 @@ import {
   Hardware,
   throwIllegalValue,
   usbstick,
+  singlePrecinctSelectionFor,
 } from '@votingworks/utils';
 
 import { Logger } from '@votingworks/logging';
@@ -277,12 +278,19 @@ function appReducer(state: State, action: AppAction): State {
         ballotsPrintedCount: state.ballotsPrintedCount + 1,
       };
     }
-    case 'updateElectionDefinition':
+    case 'updateElectionDefinition': {
+      const { precincts } = action.electionDefinition.election;
+      let defaultPrecinct: Optional<PrecinctSelection>;
+      if (precincts.length === 1) {
+        defaultPrecinct = singlePrecinctSelectionFor(precincts[0].id);
+      }
       return {
         ...state,
         ...initialUserState,
         electionDefinition: action.electionDefinition,
+        appPrecinct: defaultPrecinct,
       };
+    }
     case 'startWritingLongValue':
       return {
         ...state,

--- a/frontends/bmd/src/app_single_precinct_election.test.tsx
+++ b/frontends/bmd/src/app_single_precinct_election.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import {
+  ALL_PRECINCTS_NAME,
+  MemoryCard,
+  MemoryHardware,
+  MemoryStorage,
+} from '@votingworks/utils';
+import { makeElectionManagerCard } from '@votingworks/test-utils';
+import { screen } from '@testing-library/react';
+import { electionMinimalExhaustiveSampleSinglePrecinctDefinition } from '@votingworks/fixtures';
+import userEvent from '@testing-library/user-event';
+import { fakeMachineConfigProvider } from '../test/helpers/fake_machine_config';
+import { enterPin, render } from '../test/test_utils';
+import { App } from './app';
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  window.location.href = '/';
+});
+
+jest.setTimeout(15000);
+
+test('loading election with a single precinct automatically sets precinct', async () => {
+  const card = new MemoryCard();
+  const hardware = MemoryHardware.buildStandard();
+  const storage = new MemoryStorage();
+  const machineConfig = fakeMachineConfigProvider();
+
+  render(
+    <App
+      card={card}
+      hardware={hardware}
+      storage={storage}
+      machineConfig={machineConfig}
+      reload={jest.fn()}
+    />
+  );
+
+  await screen.findByText('VxMark is Not Configured');
+
+  // insert election manager card with different election
+  card.insertCard(
+    makeElectionManagerCard(
+      electionMinimalExhaustiveSampleSinglePrecinctDefinition.electionHash
+    ),
+    electionMinimalExhaustiveSampleSinglePrecinctDefinition.electionData
+  );
+  await enterPin();
+  userEvent.click(await screen.findByText('Load Election Definition'));
+  await screen.findByText('10edbc8d2c');
+  // Should not have All Precincts option available
+  expect(screen.queryByText(ALL_PRECINCTS_NAME)).not.toBeInTheDocument();
+  card.removeCard();
+  await screen.findByText('Precinct 1');
+});

--- a/frontends/bmd/src/pages/admin_screen.tsx
+++ b/frontends/bmd/src/pages/admin_screen.tsx
@@ -101,9 +101,11 @@ export function AdminScreen({
                   <option value="" disabled>
                     Select a precinct for this device…
                   </option>
-                  <option value={ALL_PRECINCTS_OPTION_VALUE}>
-                    {ALL_PRECINCTS_NAME}
-                  </option>
+                  {election.precincts.length > 1 && (
+                    <option value={ALL_PRECINCTS_OPTION_VALUE}>
+                      {ALL_PRECINCTS_NAME}
+                    </option>
+                  )}
                   {[...election.precincts]
                     .sort((a, b) =>
                       a.name.localeCompare(b.name, undefined, {

--- a/frontends/precinct-scanner/src/app.test.tsx
+++ b/frontends/precinct-scanner/src/app.test.tsx
@@ -324,7 +324,6 @@ test('election manager must set precinct', async () => {
   expect(
     fetchMock.calls('/precinct-scanner/config/precinct', { method: 'PUT' })
   ).toHaveLength(1);
-  expect(screen.queryByText(SELECT_PRECINCT_TEXT)).not.toBeInTheDocument();
   card.removeCard();
   await advanceTimersAndPromises(1);
 

--- a/frontends/precinct-scanner/src/screens/election_manager_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/election_manager_screen.test.tsx
@@ -23,7 +23,6 @@ import { AppContext, AppContextInterface } from '../contexts/app_context';
 import {
   ElectionManagerScreen,
   ElectionManagerScreenProps,
-  SELECT_PRECINCT_TEXT,
 } from './election_manager_screen';
 
 beforeEach(() => {
@@ -138,7 +137,6 @@ test('no All Precincts option if only one precinct', async () => {
   // Should have precinct name in both the dropdown and the footer
   expect(await screen.findAllByText('Precinct 1')).toHaveLength(2);
   expect(screen.queryByText(ALL_PRECINCTS_NAME)).not.toBeInTheDocument();
-  expect(screen.queryByText(SELECT_PRECINCT_TEXT)).not.toBeInTheDocument();
 });
 
 test('export from admin screen', () => {

--- a/frontends/precinct-scanner/src/screens/election_manager_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/election_manager_screen.tsx
@@ -158,11 +158,9 @@ export function ElectionManagerScreen({
             onChange={changeAppPrecinctSelection}
             large
           >
-            {!precinctSelectionValue && (
-              <option value="" disabled>
-                {SELECT_PRECINCT_TEXT}
-              </option>
-            )}
+            <option value="" disabled>
+              {SELECT_PRECINCT_TEXT}
+            </option>
             {election.precincts.length > 1 && (
               <option value={ALL_PRECINCTS_OPTION_VALUE}>
                 {ALL_PRECINCTS_NAME}


### PR DESCRIPTION
Not an explicit requirement, but I wanted the behavior in VxMark to match the behavior in VxScan after #2641. With this change (first commit), if you load an election into VxMark that has only one precinct, it will automatically set the precinct. 

There's a second very small commit in which I revert a UI tweak in VxScan. I had hidden the "Select a precinct for this device..." menu option after a precinct was selected, but I noticed in VxMark that it actually changed the width of the dropdown in an unflattering way and it's weird to have a dropdown with only one option. Ideally, if there's only one precinct, there's no dropdown at all. But in this PR I just wanted things to align across apps.

