### PR TITLE
bump max size limit in admin server

### DIFF
--- a/services/admin/src/server.ts
+++ b/services/admin/src/server.ts
@@ -23,7 +23,7 @@ import { createWorkspace, Workspace } from './util/workspace';
 type NoParams = never;
 
 const CVR_FILE_ATTACHMENT_NAME = 'cvrFile';
-const MAX_UPLOAD_FILE_SIZE = 500 * 1024 * 1024; // 500MB
+const MAX_UPLOAD_FILE_SIZE = 2 * 1000 * 1024 * 1024; // 2GB
 
 /**
  * Builds an express application.


### PR DESCRIPTION
## Overview
I think there are problems beyond this with loading a very large cvr (testing with a 1.4GB cvr for 967 write ins) into VxAdmin but this definitely needs to be bumped for it to work. 

## Demo Video or Screenshot

## Testing Plan 

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
