### PR TITLE
scale images up that are at 50%

### DIFF
--- a/frontends/election-manager/src/screens/write_ins_transcription_screen.tsx
+++ b/frontends/election-manager/src/screens/write_ins_transcription_screen.tsx
@@ -23,6 +23,8 @@ import { Navigation } from '../components/navigation';
 import { InlineForm, TextInput } from '../components/text_input';
 import { useWriteInImageQuery } from '../hooks/use_write_in_images_query';
 
+const IMAGE_SCALE = 0.5; // The images are downscaled by 50% in the export, this is to adjust for that.
+
 const BallotViews = styled.div`
   flex: 3;
   background: #455a64;
@@ -101,10 +103,10 @@ function WriteInImage({
       src={imageUrl}
       alt="write-in area"
       crop={{
-        x: bounds.x,
-        y: bounds.y - bounds.height * margin,
-        width: bounds.width,
-        height: bounds.height * (1 + 2 * margin),
+        x: bounds.x * IMAGE_SCALE,
+        y: IMAGE_SCALE * (bounds.y - bounds.height * margin),
+        width: bounds.width * IMAGE_SCALE,
+        height: bounds.height * IMAGE_SCALE * (1 + 2 * margin),
       }}
       style={{ width: width || '100%' }}
     />


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->

## Demo Video or Screenshot

## Testing Plan 

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
