### PR TITLE
VxScan: Stream CVR Exports

### DIFF
--- a/frontends/precinct-scanner/src/api/scan.test.ts
+++ b/frontends/precinct-scanner/src/api/scan.test.ts
@@ -11,10 +11,10 @@ test('calibrate success', async () => {
   expect(fetchMock.done()).toBe(true);
 });
 
-test('getExport returns CVRs on success', async () => {
+test('getExportWithoutImages returns CVRs on success', async () => {
   const fileContent = electionWithMsEitherNeitherFixtures.cvrData;
   fetchMock.postOnce('/precinct-scanner/export', fileContent);
-  const cvrsFileString = await scan.getExport();
+  const cvrsFileString = await scan.getExportWithoutImages();
   const lines = cvrsFileString.split('\n');
   const cvrs = lines.flatMap((line) =>
     line.length > 0 ? (JSON.parse(line) as CastVoteRecord) : []
@@ -22,12 +22,20 @@ test('getExport returns CVRs on success', async () => {
   expect(cvrs).toHaveLength(100);
 });
 
+test('getExportWithoutImages specifies to skip images in request', async () => {
+  fetchMock.postOnce(
+    { url: '/precinct-scanner/export', body: { skipImages: true } },
+    'anything'
+  );
+  await scan.getExportWithoutImages();
+});
+
 test('getExport throws on failure', async () => {
   fetchMock.postOnce('/precinct-scanner/export', {
     status: 500,
     body: { status: 'error' },
   });
-  await expect(scan.getExport()).rejects.toThrowError(
+  await expect(scan.getExportWithoutImages()).rejects.toThrowError(
     'failed to generate scan export'
   );
 });

--- a/frontends/precinct-scanner/src/api/scan.ts
+++ b/frontends/precinct-scanner/src/api/scan.ts
@@ -3,7 +3,7 @@ import { Scan } from '@votingworks/api';
 import { fetchJson } from '@votingworks/utils';
 import makeDebug from 'debug';
 
-const debug = makeDebug('/precinct-scanner:api:scan');
+const debug = makeDebug('precinct-scanner:api:scan');
 
 export async function getStatus(): Promise<Scan.PrecinctScannerStatus> {
   return unsafeParse(
@@ -32,9 +32,14 @@ export async function calibrate(): Promise<boolean> {
   return result.status === 'ok';
 }
 
-export async function getExport(): Promise<string> {
+// Returns CVR file which does not include any write-in images
+export async function getExportWithoutImages(): Promise<string> {
   const response = await fetch('/precinct-scanner/export', {
     method: 'post',
+    body: JSON.stringify({ skipImages: true }),
+    headers: {
+      'Content-Type': 'application/json',
+    },
   });
   if (response.status !== 200) {
     debug('failed to get scan export: %o', response);

--- a/frontends/precinct-scanner/src/app.test.tsx
+++ b/frontends/precinct-scanner/src/app.test.tsx
@@ -53,6 +53,7 @@ import {
 } from '../test/helpers/helpers';
 import { REPRINT_REPORT_TIMEOUT_SECONDS } from './screens/poll_worker_screen';
 import { SELECT_PRECINCT_TEXT } from './screens/election_manager_screen';
+import { fakeFileWriter } from '../test/helpers/fake_file_writer';
 
 jest.setTimeout(20000);
 
@@ -129,6 +130,9 @@ beforeEach(() => {
 
   kiosk = fakeKiosk();
   kiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
+  kiosk.writeFile.mockResolvedValue(
+    fakeFileWriter() as unknown as ReturnType<KioskBrowser.Kiosk['writeFile']>
+  );
   window.kiosk = kiosk;
 
   fetchMock.reset();
@@ -599,8 +603,7 @@ test('voter can cast a ballot that scans successfully ', async () => {
         0,
         10
       )}/TEST__machine_0002__1_ballots`
-    ),
-    expect.anything()
+    )
   );
   expect(fetchMock.calls('/precinct-scanner/export')).toHaveLength(2);
 
@@ -645,8 +648,7 @@ test('voter can cast a ballot that scans successfully ', async () => {
         0,
         10
       )}/TEST__machine_0002__1_ballots`
-    ),
-    expect.anything()
+    )
   );
   expect(fetchMock.calls('/precinct-scanner/export')).toHaveLength(3);
   fireEvent.click(await screen.findByText('Eject USB'));
@@ -1051,8 +1053,7 @@ test('no printer: open polls, scan ballot, close polls, save results', async () 
         0,
         10
       )}/TEST__machine_0002__1_ballots`
-    ),
-    expect.anything()
+    )
   );
   await advanceTimersAndPromises(1);
 

--- a/frontends/precinct-scanner/src/app_tally_report_paths.test.tsx
+++ b/frontends/precinct-scanner/src/app_tally_report_paths.test.tsx
@@ -36,10 +36,18 @@ import {
 import { App } from './app';
 import { stateStorageKey } from './app_root';
 import { MachineConfigResponse } from './config/types';
+import { fakeFileWriter } from '../test/helpers/fake_file_writer';
 
 beforeEach(() => {
   jest.useFakeTimers();
   fetchMock.reset();
+
+  const kiosk = fakeKiosk();
+  kiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
+  kiosk.writeFile.mockResolvedValue(
+    fakeFileWriter() as unknown as ReturnType<KioskBrowser.Kiosk['writeFile']>
+  );
+  window.kiosk = kiosk;
 });
 
 const getMachineConfigBody: MachineConfigResponse = {
@@ -127,9 +135,6 @@ test('expected tally reports are printed for a primary election with all precinc
   const hardware = MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
   await storage.set(stateStorageKey, { isPollsOpen: false });
-  const kiosk = fakeKiosk();
-  kiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
-  window.kiosk = kiosk;
   const { election } =
     electionMinimalExhaustiveSampleWithReportingUrlDefinition;
   fetchMock
@@ -191,9 +196,6 @@ test('expected tally reports for a primary election with all precincts with CVRs
   const hardware = MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
   await storage.set(stateStorageKey, { isPollsOpen: true });
-  const kiosk = fakeKiosk();
-  kiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
-  window.kiosk = kiosk;
   const { election } =
     electionMinimalExhaustiveSampleWithReportingUrlDefinition;
 
@@ -542,9 +544,6 @@ test('expected tally reports for a primary election with a single precincts with
   const hardware = MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
   await storage.set(stateStorageKey, { isPollsOpen: true });
-  const kiosk = fakeKiosk();
-  kiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
-  window.kiosk = kiosk;
   const { election } = electionMinimalExhaustiveSampleDefinition;
 
   fetchMock
@@ -805,9 +804,6 @@ test('expected tally reports for a general election with all precincts with CVRs
   const hardware = MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
   await storage.set(stateStorageKey, { isPollsOpen: true });
-  const kiosk = fakeKiosk();
-  kiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
-  window.kiosk = kiosk;
   const { election } = electionSample2Definition;
 
   fetchMock
@@ -1029,9 +1025,6 @@ test('expected tally reports for a general election with a single precincts with
   const hardware = MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
   await storage.set(stateStorageKey, { isPollsOpen: true });
-  const kiosk = fakeKiosk();
-  kiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
-  window.kiosk = kiosk;
   const { election } = electionSample2Definition;
 
   fetchMock

--- a/frontends/precinct-scanner/src/components/export_backup_modal.test.tsx
+++ b/frontends/precinct-scanner/src/components/export_backup_modal.test.tsx
@@ -161,7 +161,8 @@ test('render export modal when a USB drive is mounted as expected and allows aut
   fireEvent.click(screen.getByText('Save'));
   await screen.findByText('Backup Saved');
   expect(download).toHaveBeenCalledWith('/precinct-scanner/backup', {
-    into: 'fake mount point/scanner-backups/franklin-county_general-election_748dc61ad3',
+    directory:
+      'fake mount point/scanner-backups/franklin-county_general-election_748dc61ad3',
   });
   expect(mockKiosk.syncUsbDrive).toHaveBeenCalledWith('fake mount point');
 

--- a/frontends/precinct-scanner/src/components/export_backup_modal.tsx
+++ b/frontends/precinct-scanner/src/components/export_backup_modal.tsx
@@ -70,7 +70,7 @@ export function ExportBackupModal({ onClose, usbDrive }: Props): JSX.Element {
           electionFolderName
         );
         result = await download('/precinct-scanner/backup', {
-          into: pathToFolder,
+          directory: pathToFolder,
         });
       } else {
         result = await download('/precinct-scanner/backup');

--- a/frontends/precinct-scanner/src/components/export_results_modal.test.tsx
+++ b/frontends/precinct-scanner/src/components/export_results_modal.test.tsx
@@ -85,10 +85,8 @@ test('render no usb found screen when there is not a mounted usb drive', () => {
 
 test('render export modal when a usb drive is mounted as expected and allows custom export', async () => {
   const mockKiosk = fakeKiosk();
-  const fileWriter = fakeFileWriter();
   window.kiosk = mockKiosk;
-  const saveAsFunction = jest.fn().mockResolvedValue(fileWriter);
-  mockKiosk.saveAs = saveAsFunction;
+  mockKiosk.saveAs = jest.fn().mockResolvedValue(fakeFileWriter());
   mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
 
   fetchMock.postOnce('/precinct-scanner/export', {
@@ -122,7 +120,7 @@ test('render export modal when a usb drive is mounted as expected and allows cus
   fireEvent.click(getByText('Custom'));
   await waitFor(() => getByText('CVRs Saved to USB Drive'));
   await waitFor(() => {
-    expect(saveAsFunction).toHaveBeenCalledTimes(1);
+    expect(mockKiosk.saveAs).toHaveBeenCalledTimes(1);
   });
   expect(fetchMock.called('/precinct-scanner/export')).toBe(true);
 
@@ -133,6 +131,9 @@ test('render export modal when a usb drive is mounted as expected and allows cus
 test('render export modal when a usb drive is mounted as expected and allows automatic export', async () => {
   const mockKiosk = fakeKiosk();
   window.kiosk = mockKiosk;
+  mockKiosk.writeFile.mockResolvedValue(
+    fakeFileWriter() as unknown as ReturnType<KioskBrowser.Kiosk['writeFile']>
+  );
   mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
 
   fetchMock.postOnce('/precinct-scanner/export', {
@@ -179,8 +180,7 @@ test('render export modal when a usb drive is mounted as expected and allows aut
         0,
         10
       )}/TEST__machine_0003__5_ballots`
-    ),
-    expect.anything()
+    )
   );
   expect(fetchMock.called('/precinct-scanner/export')).toBe(true);
 

--- a/frontends/precinct-scanner/src/components/export_results_modal.tsx
+++ b/frontends/precinct-scanner/src/components/export_results_modal.tsx
@@ -167,6 +167,7 @@ export function ExportResultsModal({
                 <Button
                   data-testid="manual-export"
                   onPress={() => exportResults(true)}
+                  disabled // Not currently supported
                 >
                   Save
                 </Button>

--- a/frontends/precinct-scanner/src/components/export_results_modal.tsx
+++ b/frontends/precinct-scanner/src/components/export_results_modal.tsx
@@ -129,7 +129,12 @@ export function ExportResultsModal({
   }
 
   if (currentState === ModalState.SAVING) {
-    return <Modal content={<Loading />} onOverlayClick={onClose} />;
+    return (
+      <Modal
+        content={<Loading>Saving CVRs</Loading>}
+        onOverlayClick={onClose}
+      />
+    );
   }
 
   if (currentState !== ModalState.INIT) {

--- a/frontends/precinct-scanner/src/screens/poll_worker_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/poll_worker_screen.tsx
@@ -80,7 +80,7 @@ async function saveTallyToCard(
 }
 
 async function getCvrsFromExport(): Promise<CastVoteRecord[]> {
-  const castVoteRecordsString = await scan.getExport();
+  const castVoteRecordsString = await scan.getExportWithoutImages();
   const lines = castVoteRecordsString.split('\n');
   const cvrs = lines.flatMap((line) =>
     line.length > 0 ? (JSON.parse(line) as CastVoteRecord) : []

--- a/frontends/precinct-scanner/src/utils/download.test.ts
+++ b/frontends/precinct-scanner/src/utils/download.test.ts
@@ -78,6 +78,14 @@ test('download with kiosk-browser and no body', async () => {
   });
 });
 
+test('download with fetch options', async () => {
+  const kiosk = fakeKiosk();
+  window.kiosk = kiosk;
+
+  fetchMock.postOnce('/file.txt', {});
+  await download('/file.txt', { fetchOptions: { method: 'POST' } });
+});
+
 test('download with kiosk-browser and no content-disposition filename', async () => {
   const kiosk = fakeKiosk();
   window.kiosk = kiosk;
@@ -165,7 +173,7 @@ test('download with kiosk-browser with a target directory', async () => {
   kiosk.writeFile.mockResolvedValueOnce(
     fileWriter as unknown as ReturnType<KioskBrowser.Kiosk['writeFile']>
   );
-  const result = await download('/file.txt', { into: '/some/directory' });
+  const result = await download('/file.txt', { directory: '/some/directory' });
   result.unsafeUnwrap();
   expect(kiosk.makeDirectory).toHaveBeenCalledWith('/some/directory', {
     recursive: true,
@@ -184,7 +192,7 @@ test('download with kiosk-browser with a target directory and un-writable path',
   });
 
   kiosk.writeFile.mockRejectedValueOnce(new Error('EPERM'));
-  const result = await download('/file.txt', { into: '/some/directory' });
+  const result = await download('/file.txt', { directory: '/some/directory' });
   expect(result.err()).toEqual({
     kind: DownloadErrorKind.OpenFailed,
     path: '/some/directory/abc.txt',

--- a/libs/api/src/services/scan/index.ts
+++ b/libs/api/src/services/scan/index.ts
@@ -16,6 +16,7 @@ import {
   MarkAdjudicationsSchema,
   MarkThresholds,
   MarkThresholdsSchema,
+  Optional,
   PrecinctSelection,
   PrecinctSelectionSchema,
 } from '@votingworks/types';
@@ -502,20 +503,22 @@ export const DoneTemplatesResponseSchema: z.ZodSchema<DoneTemplatesResponse> =
   OkResponseSchema;
 
 /**
- * This is `never` because there is no request data.
- *
  * @url /scan/export
  * @method POST
  */
-export type ExportRequest = never;
+export type ExportRequest = Optional<{
+  skipImages: boolean;
+}>;
 
 /**
- * This is `never` because there is no request data.
- *
  * @url /scan/export
  * @method POST
  */
-export const ExportRequestSchema: z.ZodSchema<ExportRequest> = z.never();
+export const ExportRequestSchema: z.ZodSchema<ExportRequest> = z
+  .object({
+    skipImages: z.boolean(),
+  })
+  .optional();
 
 /**
  * @url /scan/export

--- a/services/scan/src/precinct_scanner_app.test.ts
+++ b/services/scan/src/precinct_scanner_app.test.ts
@@ -1390,3 +1390,23 @@ test('stops completely if plustekctl freezes and cant be killed', async () => {
     error: 'paper_status_timed_out',
   });
 });
+
+describe('POST /precinct-scanner/export', () => {
+  test('passes skipImages parameter to exportCvrs', async () => {
+    const { app, workspace } = await createApp();
+    const spyExportCvrs = jest.spyOn(workspace.store, 'exportCvrs');
+
+    await configureApp(app);
+    await request(app)
+      .post('/precinct-scanner/export')
+      .set('Accept', 'application/json')
+      .set('Content-Type', 'application/json')
+      .send({ skipImages: true })
+      .expect(200);
+
+    expect(spyExportCvrs).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ skipImages: true })
+    );
+  });
+});

--- a/services/scan/src/store.ts
+++ b/services/scan/src/store.ts
@@ -820,7 +820,10 @@ export class Store {
   /**
    * Exports all CVR JSON data to a stream.
    */
-  exportCvrs(writeStream: Writable): void {
+  exportCvrs(
+    writeStream: Writable,
+    options: { skipImages?: boolean } = {}
+  ): void {
     const electionDefinition = this.getElectionDefinition();
 
     if (!electionDefinition) {
@@ -876,7 +879,10 @@ export class Store {
 
       const frontImage: InlineBallotImage = { normalized: '' };
       const backImage: InlineBallotImage = { normalized: '' };
-      if (isFeatureFlagEnabled(EnvironmentFlagName.WRITE_IN_ADJUDICATION)) {
+      const includeImages =
+        isFeatureFlagEnabled(EnvironmentFlagName.WRITE_IN_ADJUDICATION) &&
+        !options.skipImages;
+      if (includeImages) {
         if (
           frontInterpretation.type === 'InterpretedHmpbPage' ||
           frontInterpretation.type === 'UninterpretedHmpbPage'
@@ -929,7 +935,7 @@ export class Store {
           },
         ],
         [frontImage, backImage],
-        isFeatureFlagEnabled(EnvironmentFlagName.WRITE_IN_ADJUDICATION) &&
+        includeImages &&
           (frontInterpretation.type === 'InterpretedHmpbPage' ||
             frontInterpretation.type === 'UninterpretedHmpbPage') &&
           (backInterpretation.type === 'InterpretedHmpbPage' ||
@@ -946,6 +952,8 @@ export class Store {
         writeStream.write('\n');
       }
     }
+
+    writeStream.end();
   }
 
   addHmpbTemplate(

--- a/services/scan/src/store.ts
+++ b/services/scan/src/store.ts
@@ -947,9 +947,10 @@ export class Store {
           : undefined
       );
 
+      // TODO: We should be waiting for the writeStream to drain before
+      // writing more data to it
       if (cvr) {
-        writeStream.write(JSON.stringify(cvr));
-        writeStream.write('\n');
+        writeStream.write(`${JSON.stringify(cvr)}\n`);
       }
     }
 


### PR DESCRIPTION
## Overview
Does two things:
1. Makes CVR exports streaming (from the backend to the frontend to the download) to accommodate larger CVRs
2. Sets up option to get CVRs without inline images for tally purposes, to speed up polls closing

Now that we are downloading the file from the backend, we should set it's file name via the content disposition. However, currently we don't have access to the machine ID (which needs to be in the filename) in the backend. That's easy to do, but to do it right, we should abstract out the machine config provider to `utils` which I didn't want to bother with on the fly.

## Testing Plan 
- Edited a bunch of tests, added a few
- Manual testing _in kiosk-brower_
- Note: I have not tested this in the browser. We have some logic for downloads in the browser for dev purposes, and I have not validated those, although they should be intact

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
