### PR TITLE
fix(types): remove duplicate `writeFile` overloads

### DIFF
--- a/libs/@types/kiosk-browser/kiosk-browser.d.ts
+++ b/libs/@types/kiosk-browser/kiosk-browser.d.ts
@@ -60,10 +60,10 @@ declare namespace KioskBrowser {
   export type PrinterIppAttributes =
     | { state: 'unknown' } // We didn't get a response from the printer
     | {
-      state: 'idle' | 'processing' | 'stopped';
-      stateReasons: IppPrinterStateReason[];
-      markerInfos: IppMarkerInfo[];
-    };
+        state: 'idle' | 'processing' | 'stopped';
+        stateReasons: IppPrinterStateReason[];
+        markerInfos: IppMarkerInfo[];
+      };
 
   interface PrinterInfoBase {
     // Docs: http://electronjs.org/docs/api/structures/printer-info
@@ -209,12 +209,6 @@ declare namespace KioskBrowser {
     mountUsbDrive(device: string): Promise<void>;
     unmountUsbDrive(device: string): Promise<void>;
     syncUsbDrive(mountPoint: string): Promise<void>;
-
-    /**
-     * Writes a file to a specified file path
-     */
-    writeFile(path: string): Promise<FileWriter>;
-    writeFile(path: string, content: Uint8Array | string): Promise<void>;
 
     /**
      * Creates a directory at the specified path.


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
This must have been the result of a bad merge or something. It never affected type checking because TS doesn't have a problem with overloads with identical signatures.

## Demo Video or Screenshot
n/a

## Testing Plan 
n/a

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
