### PR TITLE
feat(all): allow file picker for various exports

### DIFF
--- a/frontends/bsd/src/components/export_logs_modal.tsx
+++ b/frontends/bsd/src/components/export_logs_modal.tsx
@@ -84,7 +84,7 @@ export function ExportLogsModal({ onClose, logFileType }: Props): JSX.Element {
   }, [userRole, logger]);
   const defaultFilename = generateLogFilename('vx-logs', logFileType);
 
-  async function exportResults(openFileDialog: boolean) {
+  async function exportLogs(openFileDialog: boolean) {
     assert(window.kiosk);
     setCurrentState(ModalState.Saving);
 
@@ -236,7 +236,12 @@ export function ExportLogsModal({ onClose, logFileType }: Props): JSX.Element {
             <Prose>
               <h1>No USB Drive Detected</h1>
               <p>
-                <UsbImage src="/assets/usb-drive.svg" alt="Insert USB Image" />
+                <UsbImage
+                  src="/assets/usb-drive.svg"
+                  alt="Insert USB Image"
+                  // hidden feature to save with file dialog by double-clicking
+                  onDoubleClick={() => exportLogs(true)}
+                />
                 Please insert a USB drive where you would like the save the log
                 file.
               </p>
@@ -248,7 +253,7 @@ export function ExportLogsModal({ onClose, logFileType }: Props): JSX.Element {
               {process.env.NODE_ENV === 'development' && (
                 <Button
                   data-testid="manual-export"
-                  onPress={() => exportResults(true)}
+                  onPress={() => exportLogs(true)}
                 >
                   Save
                 </Button>
@@ -282,10 +287,10 @@ export function ExportLogsModal({ onClose, logFileType }: Props): JSX.Element {
           onOverlayClick={onClose}
           actions={
             <React.Fragment>
-              <Button primary onPress={() => exportResults(false)}>
+              <Button primary onPress={() => exportLogs(false)}>
                 Save
               </Button>
-              <Button onPress={() => exportResults(true)}>Save As…</Button>
+              <Button onPress={() => exportLogs(true)}>Save As…</Button>
               <LinkButton onPress={onClose}>Cancel</LinkButton>
             </React.Fragment>
           }

--- a/frontends/bsd/src/components/export_results_modal.tsx
+++ b/frontends/bsd/src/components/export_results_modal.tsx
@@ -233,6 +233,7 @@ export function ExportResultsModal({
                 <UsbImage
                   src="/assets/usb-drive.svg"
                   alt="Insert USB Image"
+                  // hidden feature to save with file dialog by double-clicking
                   onDoubleClick={() => exportResults(true)}
                 />
                 Please insert a USB drive in order to save CVRs.

--- a/frontends/election-manager/src/components/export_logs_modal.tsx
+++ b/frontends/election-manager/src/components/export_logs_modal.tsx
@@ -236,7 +236,12 @@ export function ExportLogsModal({ onClose, logFileType }: Props): JSX.Element {
             <Prose>
               <h1>No USB Drive Detected</h1>
               <p>
-                <UsbImage src="/assets/usb-drive.svg" alt="Insert USB Image" />
+                <UsbImage
+                  src="/assets/usb-drive.svg"
+                  alt="Insert USB Image"
+                  // hidden feature to save with file dialog by double-clicking
+                  onDoubleClick={() => exportResults(true)}
+                />
                 Please insert a USB drive where you would like the save the log
                 file.
               </p>

--- a/frontends/election-manager/src/components/save_file_to_usb.tsx
+++ b/frontends/election-manager/src/components/save_file_to_usb.tsx
@@ -233,7 +233,12 @@ export function SaveFileToUsb({
             <Prose>
               <h1>No USB Drive Detected</h1>
               <p>
-                <UsbImage src="/assets/usb-drive.svg" alt="Insert USB Image" />
+                <UsbImage
+                  src="/assets/usb-drive.svg"
+                  alt="Insert USB Image"
+                  // hidden feature to save with file dialog by double-clicking
+                  onDoubleClick={() => exportResults(true)}
+                />
                 Please insert a USB drive where you would like the save the{' '}
                 {fileName}.
               </p>

--- a/frontends/precinct-scanner/src/components/export_backup_modal.tsx
+++ b/frontends/precinct-scanner/src/components/export_backup_modal.tsx
@@ -192,8 +192,9 @@ export function ExportBackupModal({ onClose, usbDrive }: Props): JSX.Element {
                 Please insert a USB drive to save the backup.
                 <UsbImage
                   src="/assets/usb-drive.svg"
-                  onDoubleClick={() => exportBackup(true)}
                   alt="Insert USB Image"
+                  // hidden feature to save with file dialog by double-clicking
+                  onDoubleClick={() => exportBackup(true)}
                 />
               </p>
             </Prose>

--- a/frontends/precinct-scanner/src/components/export_results_modal.tsx
+++ b/frontends/precinct-scanner/src/components/export_results_modal.tsx
@@ -150,7 +150,12 @@ export function ExportResultsModal({
               <h1>No USB Drive Detected</h1>
               <p>
                 Please insert a USB drive in order to save CVRs.
-                <UsbImage src="/assets/usb-drive.svg" alt="Insert USB Image" />
+                <UsbImage
+                  src="/assets/usb-drive.svg"
+                  alt="Insert USB Image"
+                  // hidden feature to save with file dialog by double-clicking
+                  onDoubleClick={() => exportResults(true)}
+                />
               </p>
             </Prose>
           }


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Same thing as elsewhere: double-click the USB icon.

## Demo Video or Screenshot
n/a

## Testing Plan 
n/a

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
