### PR TITLE
fix(admin): handle larger CVR file import

### DIFF
--- a/libs/api/src/services/admin/endpoints.ts
+++ b/libs/api/src/services/admin/endpoints.ts
@@ -17,7 +17,7 @@ import {
   OkResponseSchema,
 } from '../../base';
 import {
-  CastVoteRecordFileMetadata,
+  CastVoteRecordFileRecord,
   CastVoteRecordFileRecordSchema,
   ElectionRecord,
   ElectionRecordSchema,
@@ -221,7 +221,7 @@ export const GetCvrFilesRequestSchema: z.ZodSchema<GetCvrFilesRequest> =
  * @url /admin/:electionId/cvr-files
  * @method GET
  */
-export type GetCvrFileResponse = CastVoteRecordFileMetadata[];
+export type GetCvrFileResponse = CastVoteRecordFileRecord[];
 
 /**
  * @url /admin/:electionId/cvr-files

--- a/libs/api/src/services/admin/types.ts
+++ b/libs/api/src/services/admin/types.ts
@@ -36,31 +36,12 @@ export const ElectionRecordSchema: z.ZodSchema<ElectionRecord> = z.object({
 /**
  * A cast vote record file's metadata.
  */
-export interface CastVoteRecordFileMetadata {
+export interface CastVoteRecordFileRecord {
   readonly id: Id;
   readonly electionId: Id;
   readonly filename: string;
   readonly sha256Hash: string;
   readonly createdAt: Iso8601Timestamp;
-}
-
-/**
- * Schema for {@link CastVoteRecordFileMetadata}.
- */
-export const CastVoteRecordFileMetadataSchema: z.ZodSchema<CastVoteRecordFileMetadata> =
-  z.object({
-    id: IdSchema,
-    electionId: IdSchema,
-    filename: z.string().nonempty(),
-    sha256Hash: z.string().nonempty(),
-    createdAt: Iso8601TimestampSchema,
-  });
-
-/**
- * A cast vote record file and associated DB metadata.
- */
-export interface CastVoteRecordFileRecord extends CastVoteRecordFileMetadata {
-  readonly data: string;
 }
 
 /**
@@ -71,7 +52,6 @@ export const CastVoteRecordFileRecordSchema: z.ZodSchema<CastVoteRecordFileRecor
     id: IdSchema,
     electionId: IdSchema,
     filename: z.string().nonempty(),
-    data: z.string(),
     sha256Hash: z.string().nonempty(),
     createdAt: Iso8601TimestampSchema,
   });

--- a/services/admin/schema.sql
+++ b/services/admin/schema.sql
@@ -45,7 +45,6 @@ create table cvr_files (
   id varchar(36) primary key,
   election_id varchar(36) not null,
   filename text not null,
-  data text not null,
   sha256_hash text not null,
   created_at timestamp not null default current_timestamp,
   foreign key (election_id) references elections(id)

--- a/services/admin/src/server.test.ts
+++ b/services/admin/src/server.test.ts
@@ -167,7 +167,7 @@ test('POST /admin/elections/:electionId/cvr-files', async () => {
   expect(
     workspace.store.getCastVoteRecordFileMetadata(response.id)
   ).toMatchObject(
-    typedAs<Partial<Admin.CastVoteRecordFileMetadata>>({
+    typedAs<Partial<Admin.CastVoteRecordFileRecord>>({
       id: response.id,
       electionId,
       filename: 'cvrFile.json',

--- a/services/admin/src/server.ts
+++ b/services/admin/src/server.ts
@@ -13,9 +13,7 @@ import {
 } from '@votingworks/types';
 import { zip } from '@votingworks/utils';
 import express, { Application } from 'express';
-import { readFileSync } from 'fs';
 import multer from 'multer';
-import { basename } from 'path';
 import { ADMIN_WORKSPACE, PORT } from './globals';
 import { Store } from './store';
 import { createWorkspace, Workspace } from './util/workspace';
@@ -82,7 +80,7 @@ export function buildApp({ store }: { store: Store }): Application {
   >(
     '/admin/elections/:electionId/cvr-files',
     upload.fields([{ name: CVR_FILE_ATTACHMENT_NAME, maxCount: 1 }]),
-    (request, response) => {
+    async (request, response) => {
       const { electionId } = request.params;
       /* istanbul ignore next */
       const file = !Array.isArray(request.files)
@@ -121,12 +119,11 @@ export function buildApp({ store }: { store: Store }): Application {
       }
 
       const { analyzeOnly } = parseQueryResult.ok();
-      const filename = basename(file.originalname);
-      const cvrFile = readFileSync(file.path, 'utf8');
-      const result = store.addCastVoteRecordFile({
+
+      const result = await store.addCastVoteRecordFile({
         electionId,
-        filename,
-        cvrFile,
+        filePath: file.path,
+        originalFilename: file.originalname,
         analyzeOnly,
       });
 

--- a/services/admin/src/util/sha256_file.test.ts
+++ b/services/admin/src/util/sha256_file.test.ts
@@ -1,0 +1,19 @@
+import * as fc from 'fast-check';
+import { fileSync } from 'tmp';
+import * as fs from 'fs/promises';
+import { sha256 } from 'js-sha256';
+import { sha256File } from './sha256_file';
+
+test('random data', async () => {
+  await fc.assert(
+    fc.asyncProperty(fc.string(), async (data) => {
+      const file = fileSync();
+      await fs.writeFile(file.name, data);
+      expect(await sha256File(file.name)).toEqual(sha256(data));
+    })
+  );
+});
+
+test('no file', async () => {
+  await expect(sha256File('no-file')).rejects.toThrow();
+});

--- a/services/admin/src/util/sha256_file.ts
+++ b/services/admin/src/util/sha256_file.ts
@@ -1,0 +1,17 @@
+import { createHash } from 'crypto';
+import * as fs from 'fs';
+
+/**
+ * Compute the SHA256 hash of a file. Use this to compute the hash of a
+ * file rather than reading its contents into memory and computing the hash.
+ * This version is more efficient and avoids memory issues.
+ */
+export function sha256File(path: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = createHash('sha256');
+    const stream = fs.createReadStream(path);
+    stream.on('error', reject);
+    stream.on('data', (data) => hash.update(data));
+    stream.on('end', () => resolve(hash.digest('hex')));
+  });
+}


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
CVR files that have a lot of write-in images can be pretty large, i.e. 1GB+. Attempting to read this in as a string is a really bad idea and NodeJS will simply not allow it as it exceeds the maximum length of a string in V8.

This commit fixes the issue by:
a) passing in the file path when importing rather than the contents
b) computing the sha256 hash via a file read stream
c) reading the CVR file one line at a time

We end up reading the file twice (once for the hash, once for the CVR entry import), but overall this is both more efficient and faster even for strings that do fit in memory.

**NOTE:** This does _not_ change the client-side CVR handling which still doesn't seem happy with CVR files this large.

## Demo Video or Screenshot
https://user-images.githubusercontent.com/1938/196287850-24a74875-9a08-48ca-87a5-f5d46345f184.mov

## Testing Plan 
Tested with @carolinemodic's 1.3GB 967-entry CVR file with a bunch of write in images.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
