### PR TITLE
fix(ui): correct modal UI button ordering

### DIFF
--- a/frontends/precinct-scanner/src/components/export_backup_modal.tsx
+++ b/frontends/precinct-scanner/src/components/export_backup_modal.tsx
@@ -154,13 +154,13 @@ export function ExportBackupModal({ onClose, usbDrive }: Props): JSX.Element {
         onOverlayClick={onClose}
         actions={
           <React.Fragment>
-            <Button onPress={onClose}>Cancel</Button>
             <UsbControllerButton
               small={false}
               primary
               usbDriveStatus={usbDrive.status ?? usbstick.UsbDriveStatus.absent}
               usbDriveEject={() => usbDrive.eject(userRole)}
             />
+            <Button onPress={onClose}>Cancel</Button>
           </React.Fragment>
         }
       />
@@ -202,7 +202,6 @@ export function ExportBackupModal({ onClose, usbDrive }: Props): JSX.Element {
           onOverlayClick={onClose}
           actions={
             <React.Fragment>
-              <Button onPress={onClose}>Cancel</Button>
               {!window.kiosk && (
                 <Button
                   data-testid="manual-export"
@@ -211,6 +210,7 @@ export function ExportBackupModal({ onClose, usbDrive }: Props): JSX.Element {
                   Save
                 </Button>
               )}{' '}
+              <Button onPress={onClose}>Cancel</Button>
             </React.Fragment>
           }
         />

--- a/frontends/precinct-scanner/src/components/export_results_modal.tsx
+++ b/frontends/precinct-scanner/src/components/export_results_modal.tsx
@@ -113,7 +113,6 @@ export function ExportResultsModal({
         onOverlayClick={onClose}
         actions={
           <React.Fragment>
-            <Button onPress={onClose}>Cancel</Button>
             <UsbControllerButton
               small={false}
               primary
@@ -122,6 +121,7 @@ export function ExportResultsModal({
               }
               usbDriveEject={() => usbDrive.eject(userRole)}
             />
+            <Button onPress={onClose}>Cancel</Button>
           </React.Fragment>
         }
       />
@@ -162,7 +162,6 @@ export function ExportResultsModal({
           onOverlayClick={onClose}
           actions={
             <React.Fragment>
-              <Button onPress={onClose}>Cancel</Button>
               {!window.kiosk && (
                 <Button
                   data-testid="manual-export"
@@ -171,6 +170,7 @@ export function ExportResultsModal({
                   Save
                 </Button>
               )}{' '}
+              <Button onPress={onClose}>Cancel</Button>
             </React.Fragment>
           }
         />


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
The primary button should go first, then any secondary buttons, then a Cancel button.

Closes #2684

## Demo Video or Screenshot
| Before | After |
|-|-|
|<img width="765" alt="image" src="https://user-images.githubusercontent.com/1938/196242250-c056536a-8fb9-4f2c-a8ad-5d96f15ea37c.png">|<img width="767" alt="image" src="https://user-images.githubusercontent.com/1938/196292356-77f842ab-f2aa-4fb1-8a5f-ddfeea05cd33.png">|

## Testing Plan 
Tested manually.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
