### PR TITLE
Improve Performance + Safety of Large CVR Export

### DIFF
--- a/services/scan/src/central_scanner_app.test.ts
+++ b/services/scan/src/central_scanner_app.test.ts
@@ -365,8 +365,7 @@ test('POST /scan/scanBatch errors', async () => {
 });
 
 test('POST /scan/export', async () => {
-  importer.doExport.mockResolvedValue('');
-
+  importer.doExport.mockResolvedValue();
   await request(app)
     .post('/central-scanner/scan/export')
     .set('Accept', 'application/json')

--- a/services/scan/src/central_scanner_app.ts
+++ b/services/scan/src/central_scanner_app.ts
@@ -442,10 +442,10 @@ export async function buildCentralScannerApp({
   app.post<NoParams, Scan.ExportResponse, Scan.ExportRequest>(
     '/central-scanner/scan/export',
     async (_request, response) => {
-      const cvrs = await importer.doExport();
+      response.type('text/plain; charset=utf-8');
+      await importer.doExport(response);
       store.setCvrsAsBackedUp();
-      response.set('Content-Type', 'text/plain; charset=utf-8');
-      response.send(cvrs);
+      response.end();
     }
   );
 

--- a/services/scan/src/importer.ts
+++ b/services/scan/src/importer.ts
@@ -16,8 +16,8 @@ import { ALL_PRECINCTS_SELECTION, find, sleep } from '@votingworks/utils';
 import { Buffer } from 'buffer';
 import makeDebug from 'debug';
 import * as fsExtra from 'fs-extra';
-import * as streams from 'memory-streams';
 import { join } from 'path';
+import { Writable } from 'stream';
 import { v4 as uuid } from 'uuid';
 import { BatchControl, BatchScanner } from './fujitsu_scanner';
 import { SheetOf } from './types';
@@ -550,16 +550,14 @@ export class Importer {
   /**
    * Export the current CVRs to a string.
    */
-  async doExport(): Promise<string> {
+  async doExport(writeStream: Writable): Promise<void> {
     const election = this.workspace.store.getElectionDefinition();
 
     if (!election) {
-      return '';
+      return;
     }
 
-    const outputStream = new streams.WritableStream();
-    await this.workspace.store.exportCvrs(outputStream);
-    return outputStream.toString();
+    await this.workspace.store.exportCvrs(writeStream);
   }
 
   /**

--- a/services/scan/src/precinct_scanner_app.ts
+++ b/services/scan/src/precinct_scanner_app.ts
@@ -471,8 +471,10 @@ export async function buildPrecinctScannerApp(
         .header('Content-Disposition', `attachment; filename="${cvrFilename}"`);
       const cvrStream = new PassThrough();
       cvrStream.pipe(response);
-      await store.exportCvrs(cvrStream, { skipImages, orderBySheetId: true });
-      store.setCvrsAsBackedUp();
+      void store.exportCvrs(cvrStream, { skipImages, orderBySheetId: true });
+      cvrStream.on('end', () => {
+        store.setCvrsAsBackedUp();
+      });
     }
   );
 

--- a/services/scan/src/precinct_scanner_app.ts
+++ b/services/scan/src/precinct_scanner_app.ts
@@ -452,7 +452,7 @@ export async function buildPrecinctScannerApp(
 
   app.post<NoParams, Scan.ExportResponse, Scan.ExportRequest>(
     '/precinct-scanner/export',
-    async (request, response) => {
+    (request, response) => {
       const skipImages = request.body?.skipImages;
       debug(`exporting CVRs ${skipImages ? 'without' : 'with'} inline images`);
 

--- a/services/scan/src/precinct_scanner_app.ts
+++ b/services/scan/src/precinct_scanner_app.ts
@@ -20,7 +20,6 @@ import { readFile } from 'fs-extra';
 import makeDebug from 'debug';
 import multer from 'multer';
 import { z } from 'zod';
-import { PassThrough } from 'stream';
 import { backup } from './backup';
 import { PrecinctScannerInterpreter } from './precinct_scanner_interpreter';
 import { PrecinctScannerStateMachine } from './precinct_scanner_state_machine';
@@ -469,10 +468,8 @@ export async function buildPrecinctScannerApp(
       response
         .header('Content-Type', 'text/plain; charset=utf-8')
         .header('Content-Disposition', `attachment; filename="${cvrFilename}"`);
-      const cvrStream = new PassThrough();
-      cvrStream.pipe(response);
-      void store.exportCvrs(cvrStream, { skipImages, orderBySheetId: true });
-      cvrStream.on('end', () => {
+      void store.exportCvrs(response, { skipImages });
+      response.on('end', () => {
         store.setCvrsAsBackedUp();
       });
     }

--- a/services/scan/src/store.ts
+++ b/services/scan/src/store.ts
@@ -940,14 +940,20 @@ export class Store {
           {
             interpretation: frontInterpretation,
             contestIds: isHmpbPage(frontInterpretation)
-              ? this.getContestIdsForMetadata(frontInterpretation.metadata)
+              ? this.getContestIdsForMetadata(
+                  frontInterpretation.metadata,
+                  electionDefinition
+                )
               : undefined,
             markAdjudications: frontAdjudications,
           },
           {
             interpretation: backInterpretation,
             contestIds: isHmpbPage(backInterpretation)
-              ? this.getContestIdsForMetadata(backInterpretation.metadata)
+              ? this.getContestIdsForMetadata(
+                  backInterpretation.metadata,
+                  electionDefinition
+                )
               : undefined,
             markAdjudications: backAdjudications,
           },
@@ -957,7 +963,8 @@ export class Store {
               interpretations,
               (interpretation) =>
                 this.getBallotPageLayoutForMetadata(
-                  interpretation.metadata
+                  interpretation.metadata,
+                  electionDefinition
                 ) as BallotPageLayout
             )
           : undefined
@@ -1103,18 +1110,19 @@ export class Store {
   }
 
   getBallotPageLayoutForMetadata(
-    metadata: BallotPageMetadata
+    metadata: BallotPageMetadata,
+    electionDefinition?: ElectionDefinition
   ): BallotPageLayout | undefined {
-    return this.getBallotPageLayoutsForMetadata(metadata).find(
-      (layout) => layout.metadata.pageNumber === metadata.pageNumber
-    );
+    return this.getBallotPageLayoutsForMetadata(
+      metadata,
+      electionDefinition
+    ).find((layout) => layout.metadata.pageNumber === metadata.pageNumber);
   }
 
   getBallotPageLayoutsForMetadata(
-    metadata: BallotMetadata
+    metadata: BallotMetadata,
+    electionDefinition = this.getElectionDefinition()
   ): BallotPageLayout[] {
-    const electionDefinition = this.getElectionDefinition();
-
     // Handle timing mark ballots differently. We should have the layout from
     // the scan/interpret process, but since we don't right now we generate it
     // from what we expect the layout to be instead. This means there could be
@@ -1164,15 +1172,17 @@ export class Store {
   }
 
   getContestIdsForMetadata(
-    metadata: BallotPageMetadata
+    metadata: BallotPageMetadata,
+    electionDefinition = this.getElectionDefinition()
   ): Array<AnyContest['id']> {
-    const electionDefinition = this.getElectionDefinition();
-
     if (!electionDefinition) {
       throw new Error('no election configured');
     }
 
-    const layouts = this.getBallotPageLayoutsForMetadata(metadata);
+    const layouts = this.getBallotPageLayoutsForMetadata(
+      metadata,
+      electionDefinition
+    );
     let contestOffset = 0;
 
     for (const layout of layouts) {

--- a/services/scan/src/store.ts
+++ b/services/scan/src/store.ts
@@ -1001,10 +1001,14 @@ export class Store {
           }
         }
 
-        // TODO: We should be waiting for the writeStream to drain before
-        // writing more data to it
-        writeStream.write(JSON.stringify(cvrMaybeWithBallotImages));
-        writeStream.write('\n');
+        const canWriteNext = writeStream.write(
+          `${JSON.stringify(cvrMaybeWithBallotImages)}\n`
+        );
+        if (!canWriteNext) {
+          await new Promise((resolve) => {
+            writeStream.once('drain', resolve);
+          });
+        }
       }
     }
 


### PR DESCRIPTION
Small tweaks to follow #2681. Three commits:
1. Safely waits for writeStream to be ready to consume data before writing to it
2. Passes electionDefinition as an argument to stop hitting the DB (this the time of the `exportCvrs` method from about 8 to 2 seconds when not exporting write-ins)
3. Gets rid of intermediary Passthrough stream.

This fixes the problem where the file-picker doesn't come up write away AND it means the `exportCvrs` method is no longer blocking.