### PR TITLE
Move generatePin to utils lib for later use in admin service

### DIFF
--- a/frontends/election-manager/src/components/smartcard_modal/card_details_view.tsx
+++ b/frontends/election-manager/src/components/smartcard_modal/card_details_view.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import styled from 'styled-components';
-import { assert, throwIllegalValue } from '@votingworks/utils';
+import { assert, generatePin, throwIllegalValue } from '@votingworks/utils';
 import {
   Button,
   fontSizeTheme,
@@ -12,7 +12,6 @@ import { CardProgramming, ElectionDefinition, User } from '@votingworks/types';
 
 import { AppContext } from '../../contexts/app_context';
 import { electionToDisplayString } from './elections';
-import { generatePin } from './pins';
 import {
   SmartcardAction,
   SmartcardActionStatus,

--- a/frontends/election-manager/src/components/smartcard_modal/program_election_card_view.tsx
+++ b/frontends/election-manager/src/components/smartcard_modal/program_election_card_view.tsx
@@ -1,12 +1,11 @@
 import React, { useContext } from 'react';
 import styled from 'styled-components';
-import { assert } from '@votingworks/utils';
+import { assert, generatePin } from '@votingworks/utils';
 import { Button, fontSizeTheme, HorizontalRule, Prose } from '@votingworks/ui';
 import { CardProgramming } from '@votingworks/types';
 
 import { AppContext } from '../../contexts/app_context';
 import { electionToDisplayString } from './elections';
-import { generatePin } from './pins';
 import {
   isSmartcardActionComplete,
   SmartcardActionStatus,

--- a/frontends/election-manager/src/components/smartcard_modal/program_system_administrator_card_view.tsx
+++ b/frontends/election-manager/src/components/smartcard_modal/program_system_administrator_card_view.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import styled from 'styled-components';
 import { Button, fontSizeTheme, HorizontalRule, Prose } from '@votingworks/ui';
 import { CardProgramming } from '@votingworks/types';
+import { generatePin } from '@votingworks/utils';
 
-import { generatePin } from './pins';
 import {
   isSmartcardActionComplete,
   SmartcardActionStatus,

--- a/frontends/election-manager/src/components/smartcard_modal/smartcard_modal.test.tsx
+++ b/frontends/election-manager/src/components/smartcard_modal/smartcard_modal.test.tsx
@@ -8,6 +8,7 @@ import {
 } from '@votingworks/types';
 import {
   assert,
+  generatePin,
   MemoryCard,
   MemoryHardware,
   throwIllegalValue,
@@ -28,15 +29,14 @@ import { screen, waitFor, within } from '@testing-library/react';
 
 import { App } from '../../app';
 import { authenticateWithSystemAdministratorCard } from '../../../test/util/authenticate';
-import { generatePin } from './pins';
 import { MachineConfig } from '../../config/types';
 import { VxFiles } from '../../lib/converters';
 import { renderRootElement } from '../../../test/render_in_app_context';
 import { ElectionManagerStoreMemoryBackend } from '../../lib/backends';
 
-jest.mock('./pins', (): typeof import('./pins') => {
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
   return {
-    ...jest.requireActual('./pins'),
+    ...jest.requireActual('@votingworks/utils'),
     generatePin: jest.fn(),
   };
 });

--- a/frontends/election-manager/src/components/smartcard_modal/status_message.tsx
+++ b/frontends/election-manager/src/components/smartcard_modal/status_message.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Loading, Modal, Text } from '@votingworks/ui';
-import { throwIllegalValue } from '@votingworks/utils';
+import { hyphenatePin, throwIllegalValue } from '@votingworks/utils';
 import { User, UserRole } from '@votingworks/types';
 
-import { hyphenatePin } from './pins';
 import { userRoleToReadableString } from './user_roles';
 
 const TextLarge = styled(Text)`

--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -3,6 +3,7 @@ export * from './as_boolean';
 export * from './assert';
 export * from './ballot_package';
 export * from './Card';
+export * from './pins';
 export * as collections from './collections';
 export * from './compressed_tallies';
 export * from './date';

--- a/libs/utils/src/pins.test.ts
+++ b/libs/utils/src/pins.test.ts
@@ -1,11 +1,11 @@
 import { mockOf } from '@votingworks/test-utils';
 
-import { isFeatureFlagEnabled } from '@votingworks/utils';
+import { isFeatureFlagEnabled } from './features';
 import { generatePin, hyphenatePin } from './pins';
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
+jest.mock('./features', (): typeof import('./features') => {
   return {
-    ...jest.requireActual('@votingworks/utils'),
+    ...jest.requireActual('./features'),
     isFeatureFlagEnabled: jest.fn(),
   };
 });

--- a/libs/utils/src/pins.ts
+++ b/libs/utils/src/pins.ts
@@ -1,4 +1,5 @@
-import { EnvironmentFlagName, isFeatureFlagEnabled } from '@votingworks/utils';
+import { EnvironmentFlagName } from './environment_flag';
+import { isFeatureFlagEnabled } from './features';
 
 /**
  * generatePin generates random numeric PINs of the specified length (default = 6).


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/1926:
Moving `generatePin` utility to `lib/utils` to prepare for moving PIN generation logic to the admin service

## Testing Plan 
- Using existing tests as regression tests
- Verified locally

## Checklist
- [n/a] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [n/a] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [n/a] I have added a screenshot and/or video to this PR to demo the change
- [n/a] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
