### PR TITLE
build(all): wait for service build before running

### DIFF
--- a/script/src/run-dev/index.ts
+++ b/script/src/run-dev/index.ts
@@ -168,7 +168,7 @@ export async function main(
             npmBinCommand({
               name: `${name}:run`,
               command:
-                'nodemon --watch build --delay 1 --exitcrash --exec node build/index.js',
+                'while [ ! -f build/index.js ]; do echo "Waiting for build…"; sleep 1; done; nodemon --watch build --delay 1 --exitcrash --exec node build/index.js',
               prefixColor: 'cyan',
               cwd: serviceRoot,
               env: extraEnv,


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
We have a bootstrapping problem. After setting up development and running `pnpm install`, nothing is actually built yet. When running a frontend we run the associated services and their build in watch mode. But because the service has never been built the service fails to run and the build does not complete because `concurrently` kills it when the service run process exits.

This commit fixes the bootstrapping problem by waiting to run the service until the build completes.

## Demo Video or Screenshot
Note the "Waiting for build…" in the output below.

```
❯ pnpm start            

> @votingworks/election-manager@0.1.0 start /home/brian/code/vxsuite/frontends/election-manager
> pnpm -w run-dev -- election-manager


> vxsuite@ run-dev /home/brian/code/vxsuite
> script/run-dev "election-manager"

[converter-ms-sems:run] FLASK_APP=converter.core python3.9 -m pipenv run python -m flask run --port 3003
[admin:run] Waiting for build...
[election-manager:build] 
[election-manager:build] 9:29:47 AM - Starting compilation in watch mode...
[election-manager:build] 
[admin:build] 
[admin:build] 9:29:47 AM - Starting compilation in watch mode...
[admin:build] 
[converter-ms-sems:run]  * Serving Flask app 'converter.core' (lazy loading)
[converter-ms-sems:run]  * Environment: production
[converter-ms-sems:run]    WARNING: This is a development server. Do not use it in a production deployment.
[converter-ms-sems:run]    Use a production WSGI server instead.
[converter-ms-sems:run]  * Debug mode: off
[converter-ms-sems:run]  * Running on http://127.0.0.1:3003 (Press CTRL+C to quit)
[election-manager:server] [HPM] Proxy created: /card  -> http://localhost:3001/
[election-manager:server] [HPM] Proxy created: /convert  -> http://localhost:3003/
[election-manager:server] [HPM] Proxy created: /admin  -> http://localhost:3004/
[election-manager:server] 
[election-manager:server]   vite v2.9.13 dev server running at:
[election-manager:server] 
[election-manager:server]   > Local: http://localhost:3000/
[election-manager:server]   > Network: use `--host` to expose
[election-manager:server] 
[election-manager:server]   ready in 692ms.
[election-manager:server] 
[admin:run] Waiting for build...
[admin:run] Waiting for build...
[admin:build] 
[admin:build] 9:29:49 AM - Found 0 errors. Watching for file changes.
[admin:run] [nodemon] 2.0.20
[admin:run] [nodemon] to restart at any time, enter `rs`
[admin:run] [nodemon] watching path(s): build/**/*
[admin:run] [nodemon] watching extensions: js,mjs,json
[admin:run] [nodemon] starting `node build/index.js`
[admin:run] {"source":"vx-admin-service","eventId":"application-startup","eventType":"application-status","user":"system","message":"Admin Service running at http://localhost:3004/","disposition":"success"}
[election-manager:build] 
[election-manager:build] 9:29:56 AM - Found 0 errors. Watching for file changes.
```

## Testing Plan 
Tested by running this in `frontends/election-manager`:

```
pnpm -w clean-all
pnpm install
pnpm start
```

You can see the output above.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
