### PR TITLE
fix(admin): clear uploads after request

### DIFF
--- a/services/admin/src/server.test.ts
+++ b/services/admin/src/server.test.ts
@@ -20,7 +20,7 @@ let workspace: Workspace;
 beforeEach(() => {
   jest.restoreAllMocks();
   workspace = createWorkspace(dirSync().name);
-  app = buildApp({ store: workspace.store });
+  app = buildApp({ workspace });
 });
 
 test('starts with default logger and port', async () => {

--- a/services/admin/src/server.writeins.test.ts
+++ b/services/admin/src/server.writeins.test.ts
@@ -14,7 +14,7 @@ let workspace: Workspace;
 beforeEach(() => {
   jest.restoreAllMocks();
   workspace = createWorkspace(dirSync().name);
-  app = buildApp({ store: workspace.store });
+  app = buildApp({ workspace });
 });
 
 test('write-in adjudication lifecycle', async () => {

--- a/services/admin/src/util/workspace.ts
+++ b/services/admin/src/util/workspace.ts
@@ -8,6 +8,7 @@ import { Store } from '../store';
 export interface Workspace {
   readonly path: string;
   readonly store: Store;
+  readonly uploadsPath: string;
 }
 
 /**
@@ -22,5 +23,6 @@ export function createWorkspace(root: string): Workspace {
   return {
     path: resolvedRoot,
     store: Store.fileStore(dbPath),
+    uploadsPath: join(resolvedRoot, 'uploads'),
   };
 }


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Previously we were storing uploads in a temporary file in `/tmp`, but they were never getting cleaned up. Eventually the `/tmp` partition would run out of disk space and we'd be unable to upload anything new, and other operations that used `/tmp` would start to fail as well.

Now, we upload to the `uploads` folder within the current workspace. After the request finishes we delete the uploaded file.

## Demo Video or Screenshot
Watching the `uploads` directory during the upload of a 1.3GB CVR file:
```
while true; do du -a ~/code/vxsuite/services/admin/dev-workspace/uploads/ | sort -rn | head -n 5; sleep 1; done
4	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
4	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
4	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
4	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
4	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
4	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
4	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
4	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
4	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
4	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
4	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
4	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
4	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
4	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
90388	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
90384	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/8ceb0164eb7b57a59a414772a3ebdb83
302964	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
302960	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/8ceb0164eb7b57a59a414772a3ebdb83
508548	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
508544	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/8ceb0164eb7b57a59a414772a3ebdb83
716404	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
716400	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/8ceb0164eb7b57a59a414772a3ebdb83
927364	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
927360	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/8ceb0164eb7b57a59a414772a3ebdb83
1130452	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
1130448	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/8ceb0164eb7b57a59a414772a3ebdb83
1310464	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
1310460	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/8ceb0164eb7b57a59a414772a3ebdb83
1310464	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
1310460	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/8ceb0164eb7b57a59a414772a3ebdb83
1310464	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
1310460	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/8ceb0164eb7b57a59a414772a3ebdb83
1310464	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
1310460	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/8ceb0164eb7b57a59a414772a3ebdb83
1310464	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
1310460	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/8ceb0164eb7b57a59a414772a3ebdb83
1310468	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
1310464	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/8ceb0164eb7b57a59a414772a3ebdb83
1310468	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
1310464	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/8ceb0164eb7b57a59a414772a3ebdb83
1310476	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
1310472	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/8ceb0164eb7b57a59a414772a3ebdb83
1310476	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
1310472	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/8ceb0164eb7b57a59a414772a3ebdb83
4	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
4	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
4	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
4	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
4	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
4	/home/brian/code/vxsuite/services/admin/dev-workspace/uploads/
```

## Testing Plan 
Tested manually with a large CVR file.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
