### PR TITLE
fix(scan): clear uploads after request

### DIFF
--- a/services/admin/src/server.ts
+++ b/services/admin/src/server.ts
@@ -610,6 +610,9 @@ export async function start({
     resolvedWorkspace = createWorkspace(workspacePath);
   }
 
+  // clear any cached data
+  resolvedWorkspace.clearUploads();
+
   /* istanbul ignore next */
   const resolvedApp = app ?? buildApp({ workspace: resolvedWorkspace });
 

--- a/services/admin/src/util/workspace.ts
+++ b/services/admin/src/util/workspace.ts
@@ -1,4 +1,4 @@
-import { ensureDirSync } from 'fs-extra';
+import { emptyDirSync, ensureDirSync } from 'fs-extra';
 import { join, resolve } from 'path';
 import { Store } from '../store';
 
@@ -9,6 +9,11 @@ export interface Workspace {
   readonly path: string;
   readonly store: Store;
   readonly uploadsPath: string;
+
+  /**
+   * Clears the uploads directory.
+   */
+  clearUploads(): void;
 }
 
 /**
@@ -17,12 +22,16 @@ export interface Workspace {
 export function createWorkspace(root: string): Workspace {
   const resolvedRoot = resolve(root);
   const dbPath = join(resolvedRoot, 'data.db');
+  const uploadsPath = join(resolvedRoot, 'uploads');
 
   ensureDirSync(resolvedRoot);
 
   return {
     path: resolvedRoot,
     store: Store.fileStore(dbPath),
-    uploadsPath: join(resolvedRoot, 'uploads'),
+    uploadsPath,
+    clearUploads() {
+      emptyDirSync(uploadsPath);
+    },
   };
 }

--- a/services/scan/src/central_scanner_app.test.ts
+++ b/services/scan/src/central_scanner_app.test.ts
@@ -74,7 +74,7 @@ beforeEach(async () => {
       },
     ]
   );
-  app = await buildCentralScannerApp({ importer, store: workspace.store });
+  app = await buildCentralScannerApp({ importer, workspace });
 });
 
 test('reloads configuration from the store', () => {

--- a/services/scan/src/end_to_end.test.ts
+++ b/services/scan/src/end_to_end.test.ts
@@ -34,7 +34,7 @@ beforeEach(async () => {
     workspace,
     scanner,
   });
-  app = await buildCentralScannerApp({ importer, store: workspace.store });
+  app = await buildCentralScannerApp({ importer, workspace });
 });
 
 afterEach(async () => {

--- a/services/scan/src/end_to_end_hmpb.test.ts
+++ b/services/scan/src/end_to_end_hmpb.test.ts
@@ -52,7 +52,7 @@ beforeEach(async () => {
   workspace = createWorkspace(dirSync().name);
   scanner = makeMockScanner();
   importer = new Importer({ workspace, scanner });
-  app = await buildCentralScannerApp({ importer, store: workspace.store });
+  app = await buildCentralScannerApp({ importer, workspace });
 });
 
 afterEach(async () => {

--- a/services/scan/src/server.ts
+++ b/services/scan/src/server.ts
@@ -70,6 +70,9 @@ export async function start({
     resolvedWorkspace = createWorkspace(workspacePath);
   }
 
+  // clear any cached data
+  resolvedWorkspace.clearUploads();
+
   let resolvedApp: express.Application;
 
   if (machineType === 'precinct-scanner') {
@@ -109,7 +112,7 @@ export async function start({
       app ??
       (await buildCentralScannerApp({
         importer: resolvedImporter,
-        store: resolvedWorkspace.store,
+        workspace: resolvedWorkspace,
       }));
   }
 

--- a/services/scan/src/util/workspace.ts
+++ b/services/scan/src/util/workspace.ts
@@ -19,6 +19,11 @@ export interface Workspace {
   readonly scannedImagesPath: string;
 
   /**
+   * The directory where files are uploaded.
+   */
+  readonly uploadsPath: string;
+
+  /**
    * The store associated with the workspace.
    */
   readonly store: Store;
@@ -33,12 +38,18 @@ export interface Workspace {
    * as deleting the workspace and recreating it.
    */
   reset(): void;
+
+  /**
+   * Clears the uploads directory.
+   */
+  clearUploads(): void;
 }
 
 export function createWorkspace(root: string): Workspace {
   const resolvedRoot = resolve(root);
   const ballotImagesPath = join(resolvedRoot, 'ballot-images');
   const scannedImagesPath = join(ballotImagesPath, 'scanned-images');
+  const uploadsPath = join(resolvedRoot, 'uploads');
   ensureDirSync(ballotImagesPath);
   ensureDirSync(scannedImagesPath);
 
@@ -49,6 +60,7 @@ export function createWorkspace(root: string): Workspace {
     path: resolvedRoot,
     ballotImagesPath,
     scannedImagesPath,
+    uploadsPath,
     store,
     zero() {
       store.zero();
@@ -63,6 +75,9 @@ export function createWorkspace(root: string): Workspace {
       emptyDirSync(scannedImagesPath);
       ensureDirSync(ballotImagesPath);
       ensureDirSync(scannedImagesPath);
+    },
+    clearUploads() {
+      emptyDirSync(uploadsPath);
     },
   };
 }


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Similar as #2701, but for `services/scan`. Also clears uploads on startup, and adds the same for `services/admin`.

## Demo Video or Screenshot
n/a

## Testing Plan 
Tested manually similarly to how I did it in #2701.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
