### PR TITLE
fix(scan-nh): pass test/live mode through to interpreter

### DIFF
--- a/libs/ballot-interpreter-nh/src/interpret/index.ts
+++ b/libs/ballot-interpreter-nh/src/interpret/index.ts
@@ -54,9 +54,11 @@ export async function interpret(
     markThresholds = electionDefinition.election.markThresholds ??
       DefaultMarkThresholds,
     adjudicationReasons = [],
+    isTestMode = false,
   }: {
     markThresholds?: MarkThresholds;
     adjudicationReasons?: readonly AdjudicationReason[];
+    isTestMode?: boolean;
   } = {}
 ): Promise<Result<[InterpretFileResult, InterpretFileResult], Error>> {
   const paperSize = electionDefinition.election.ballotLayout?.paperSize;
@@ -172,7 +174,7 @@ export async function interpret(
     ballotStyleId,
     ballotType: BallotType.Standard,
     electionHash: electionDefinition.electionHash,
-    isTestMode: false,
+    isTestMode,
     locales: { primary: 'unknown' },
     pageNumber: 1,
     precinctId,

--- a/services/scan/src/workers/interpret_nh.ts
+++ b/services/scan/src/workers/interpret_nh.ts
@@ -31,17 +31,19 @@ export type InterpretOutput = Result<
 export type Output = InterpretOutput | void;
 
 let electionDefinition: ElectionDefinition | undefined;
+let isTestMode: boolean | undefined;
 
 export async function call(input: Input): Promise<Output> {
   switch (input.action) {
     case 'configure': {
       const store = Store.fileStore(input.dbPath);
       electionDefinition = store.getElectionDefinition();
+      isTestMode = store.getTestMode();
       return;
     }
 
     case 'interpret': {
-      if (!electionDefinition) {
+      if (!electionDefinition || isTestMode === undefined) {
         return err(
           new Error('cannot interpret ballot with no configured election')
         );
@@ -60,7 +62,7 @@ export async function call(input: Input): Promise<Output> {
       const result = await interpret(
         electionDefinition,
         [input.frontImagePath, input.backImagePath],
-        { adjudicationReasons }
+        { adjudicationReasons, isTestMode }
       );
 
       if (result.isErr()) {


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Fixes #2703 

## Demo Video or Screenshot
From a CVR export after the fix:
```json
{"_ballotId":"e93735c6-e16e-493a-8771-dca935de1a7b",
"_ballotStyleId":"card-number-3",
"_ballotType":"standard",
"_batchId":"dd6f4ffb-fa28-4232-a156-365970a7b3e3",
"_batchLabel":"Batch 3",
"_precinctId":"town-id-00701-precinct-id-",
"_scannerId":"000",
"_testBallot":true,
"_locales":{"primary":"unknown"},
"_pageNumbers":[1,2],
```

## Testing Plan 
Scanned some NH ballots and found the CVR exports respected the current test mode setting.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
