### PR TITLE
fix(ps): backup cvr stream blockage

### DIFF
--- a/services/scan/src/backup.ts
+++ b/services/scan/src/backup.ts
@@ -90,7 +90,7 @@ export class Backup {
     debug('added election.json to backup');
 
     debug('adding CVRs to backup...');
-    const cvrStream = new PassThrough({ highWaterMark: 100000000 }); // 100MB
+    const cvrStream = new PassThrough();
     void this.store.exportCvrs(cvrStream);
     await this.addEntry('cvrs.jsonl', cvrStream);
     debug('added CVRs to backup');

--- a/services/scan/src/precinct_scanner_app.ts
+++ b/services/scan/src/precinct_scanner_app.ts
@@ -512,7 +512,7 @@ export async function buildPrecinctScannerApp(
       saveOnlyOriginalImagesThenOnlyNormalizedImagesAfterNumSheets: 1000,
     })
       .on('error', (error: Error) => {
-        // debug('backup error: %s', error.stack);
+        debug('backup error: %s', error.stack);
         response.status(500).json({
           errors: [
             {


### PR DESCRIPTION
In #2696, we made it so we only write to the CVR stream when it is ready to write (it drains). This improves performance when we're writing to a `response`.

However, in many cases, we are writing to stream which is not being piped anywhere. In other words, it is not being drained, so there is no `drain` event. Thus, it hangs. When we use streams like this (e.g. `new WritableStream()`) we need to set the `highWaterMark` to something that is larger than the expected data size so that it never blocks.

In this PR, I both set the `highWaterMark` and `pipe` the export stream directly into the zip file stream (via a `Passthrough`) which improves efficiency.

Also left some useful debugging in there.