### PR TITLE
fix(scan-nh): enforce configuring test mode

### DIFF
--- a/libs/ballot-interpreter-nh/src/cli/interpret/index.test.ts
+++ b/libs/ballot-interpreter-nh/src/cli/interpret/index.test.ts
@@ -170,6 +170,7 @@ test('--mark-thresholds DEFINITE', async () => {
 
   // ensure the 10% threshold is applied
   expect(interpret).toHaveBeenCalledWith(expect.anything(), expect.anything(), {
+    isTestMode: true,
     markThresholds: {
       definite: 0.1,
       marginal: 0.1,
@@ -221,6 +222,7 @@ test('--mark-thresholds MARGINAL,DEFINITE', async () => {
 
   // ensure the thresholds are applied
   expect(interpret).toHaveBeenCalledWith(expect.anything(), expect.anything(), {
+    isTestMode: true,
     markThresholds: {
       definite: 0.1,
       marginal: 0.05,

--- a/libs/ballot-interpreter-nh/src/cli/interpret/index.ts
+++ b/libs/ballot-interpreter-nh/src/cli/interpret/index.ts
@@ -240,7 +240,7 @@ export async function main(
   const interpretResult = await interpret(
     electionDefinition,
     [frontBallotPath, backBallotPath],
-    { markThresholds: options.markThresholds }
+    { isTestMode: true, markThresholds: options.markThresholds }
   );
 
   if (interpretResult.isErr()) {

--- a/libs/ballot-interpreter-nh/src/interpret/index.test.ts
+++ b/libs/ballot-interpreter-nh/src/interpret/index.test.ts
@@ -7,10 +7,11 @@ test('interpret marked', async () => {
     electionGridLayoutNewHampshireHudsonFixtures.scanMarkedFront.asFilePath();
   const backImagePath =
     electionGridLayoutNewHampshireHudsonFixtures.scanMarkedBack.asFilePath();
-  const interpretResult = await interpret(electionDefinition, [
-    frontImagePath,
-    backImagePath,
-  ]);
+  const interpretResult = await interpret(
+    electionDefinition,
+    [frontImagePath, backImagePath],
+    { isTestMode: false }
+  );
   expect(
     interpretResult.unsafeUnwrap().map(({ interpretation }) => interpretation)
   ).toMatchInlineSnapshot(`
@@ -5973,10 +5974,11 @@ test('interpret unmarked', async () => {
     electionGridLayoutNewHampshireHudsonFixtures.scanUnmarkedFront.asFilePath();
   const backImagePath =
     electionGridLayoutNewHampshireHudsonFixtures.scanUnmarkedBack.asFilePath();
-  const interpretResult = await interpret(electionDefinition, [
-    frontImagePath,
-    backImagePath,
-  ]);
+  const interpretResult = await interpret(
+    electionDefinition,
+    [frontImagePath, backImagePath],
+    { isTestMode: false }
+  );
   expect(
     interpretResult.unsafeUnwrap().map(({ interpretation }) => interpretation)
   ).toMatchInlineSnapshot(`
@@ -11363,10 +11365,11 @@ test('interpret marked 300dpi', async () => {
     electionGridLayoutNewHampshireHudsonFixtures.scanMarkedFront300dpi.asFilePath();
   const backImagePath =
     electionGridLayoutNewHampshireHudsonFixtures.scanMarkedBack300dpi.asFilePath();
-  const interpretResult = await interpret(electionDefinition, [
-    frontImagePath,
-    backImagePath,
-  ]);
+  const interpretResult = await interpret(
+    electionDefinition,
+    [frontImagePath, backImagePath],
+    { isTestMode: false }
+  );
 
   const interpretation = interpretResult.unsafeUnwrap();
   expect(

--- a/libs/ballot-interpreter-nh/src/interpret/index.ts
+++ b/libs/ballot-interpreter-nh/src/interpret/index.ts
@@ -51,15 +51,15 @@ export async function interpret(
   electionDefinition: ElectionDefinition,
   sheet: readonly [string, string],
   {
+    isTestMode,
     markThresholds = electionDefinition.election.markThresholds ??
       DefaultMarkThresholds,
     adjudicationReasons = [],
-    isTestMode = false,
   }: {
+    isTestMode: boolean;
     markThresholds?: MarkThresholds;
     adjudicationReasons?: readonly AdjudicationReason[];
-    isTestMode?: boolean;
-  } = {}
+  }
 ): Promise<Result<[InterpretFileResult, InterpretFileResult], Error>> {
   const paperSize = electionDefinition.election.ballotLayout?.paperSize;
 

--- a/services/scan/src/precinct_scanner_interpreter.test.ts
+++ b/services/scan/src/precinct_scanner_interpreter.test.ts
@@ -1,9 +1,15 @@
 import { electionGridLayoutNewHampshireAmherstFixtures } from '@votingworks/fixtures';
-import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
+import {
+  HmpbBallotPageMetadata,
+  HmpbPageInterpretation,
+} from '@votingworks/types';
+import { ALL_PRECINCTS_SELECTION, typedAs } from '@votingworks/utils';
+import * as fs from 'fs/promises';
+import { dirSync } from 'tmp';
 import { createInterpreter } from './precinct_scanner_interpreter';
 
 if (process.env.CI) {
-  jest.setTimeout(20000);
+  jest.setTimeout(20_000);
 }
 
 const ballotImages = {
@@ -11,7 +17,21 @@ const ballotImages = {
     electionGridLayoutNewHampshireAmherstFixtures.scanMarkedOvervoteFront.asFilePath(),
     electionGridLayoutNewHampshireAmherstFixtures.scanMarkedOvervoteBack.asFilePath(),
   ],
+  normalBallot: [
+    electionGridLayoutNewHampshireAmherstFixtures.scanMarkedFront.asFilePath(),
+    electionGridLayoutNewHampshireAmherstFixtures.scanMarkedBack.asFilePath(),
+  ],
 } as const;
+
+let ballotImagesPath!: string;
+
+beforeEach(() => {
+  ballotImagesPath = dirSync().name;
+});
+
+afterEach(async () => {
+  await fs.rm(ballotImagesPath, { recursive: true });
+});
 
 test('NH interpreter of overvote yields a sheet that needs to be reviewed', async () => {
   const interpreter = createInterpreter();
@@ -21,7 +41,7 @@ test('NH interpreter of overvote yields a sheet that needs to be reviewed', asyn
       electionGridLayoutNewHampshireAmherstFixtures.electionDefinition,
     precinctSelection: ALL_PRECINCTS_SELECTION,
     layouts: [],
-    ballotImagesPath: '',
+    ballotImagesPath,
     testMode: true,
   });
 
@@ -31,3 +51,39 @@ test('NH interpreter of overvote yields a sheet that needs to be reviewed', asyn
   );
   expect(result.ok()?.type).toBe('NeedsReviewSheet');
 });
+
+test.each([true, false])(
+  'NH interpreter with testMode=%s',
+  async (testMode) => {
+    const interpreter = createInterpreter();
+
+    interpreter.configure({
+      electionDefinition:
+        electionGridLayoutNewHampshireAmherstFixtures.electionDefinition,
+      precinctSelection: ALL_PRECINCTS_SELECTION,
+      layouts: [],
+      ballotImagesPath,
+      testMode,
+    });
+
+    const sheet = (
+      await interpreter.interpret('foo-sheet-id', ballotImages.normalBallot)
+    ).unsafeUnwrap();
+    expect(sheet.type).toBe('ValidSheet');
+
+    for (const page of sheet.pages) {
+      expect(page.interpretation).toEqual(
+        expect.objectContaining(
+          typedAs<Partial<HmpbPageInterpretation>>({
+            type: 'InterpretedHmpbPage',
+            metadata: expect.objectContaining(
+              typedAs<Partial<HmpbBallotPageMetadata>>({
+                isTestMode: testMode,
+              })
+            ),
+          })
+        )
+      );
+    }
+  }
+);

--- a/services/scan/src/precinct_scanner_interpreter.ts
+++ b/services/scan/src/precinct_scanner_interpreter.ts
@@ -176,6 +176,7 @@ async function nhInterpret(
   const { electionDefinition, ballotImagesPath, markThresholdOverrides } =
     config;
   const result = await interpretNh(electionDefinition, sheet, {
+    isTestMode: config.testMode,
     markThresholds: markThresholdOverrides,
     adjudicationReasons:
       electionDefinition.election.precinctScanAdjudicationReasons ?? [],


### PR DESCRIPTION
## Overview
Fixes #2703 (for real this time)

In #2706 I only passed the test mode config through in the VxCentralScan code path. I had added `isTestMode` as a config parameter to the NH `interpret` function, but I'd made it optional so the type checking didn't complain when we didn't pass it in the VxScan code path. This time I made `isTestMode` required and added it in the VxScan code path.

## Demo Video or Screenshot
Exported CVR from a ballot scanned using VxScan in test mode:
```json
{"_ballotId":"22032f7b-a225-4825-a286-1af205849265",
"_ballotStyleId":"card-number-59",
"_ballotType":"standard",
"_batchId":"c685ede0-41a6-4a7e-af92-03742f76a3d0",
"_batchLabel":"Batch 4",
"_precinctId":"town-id-25901-precinct-id-",
"_scannerId":"000",
"_testBallot":true
```

## Testing Plan 
Tested manually with VxScan, added some unit tests.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
