### PR TITLE
fix(admin): make write-in report "Back" go to reports

### DIFF
--- a/frontends/election-manager/src/screens/tally_writein_report_screen.tsx
+++ b/frontends/election-manager/src/screens/tally_writein_report_screen.tsx
@@ -261,8 +261,8 @@ export function TallyWriteInReportScreen(): JSX.Element {
             </p>
           )}
           <p>
-            <LinkButton small to={routerPaths.tally}>
-              Back to Tally Index
+            <LinkButton small to={routerPaths.reports}>
+              Back to Reports
             </LinkButton>
           </p>
           {!isReportEmpty && (


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
I think this report used to live under the Tally tab and when we moved it we didn't change the "Back to Tally Index" button.

[Slack context](https://votingworks.slack.com/archives/CEL6D3GAD/p1666201476079439)

## Demo Video or Screenshot
<img width="582" alt="image" src="https://user-images.githubusercontent.com/1938/196769678-5463a29f-de84-4c8a-b65f-dab07257174c.png">

## Testing Plan 
Tested manually in VxAdmin w/kiosk-browser.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
