### PR TITLE
fix(admin): do not duplicate write-ins from multiple CVR files

### DIFF
--- a/services/admin/src/store.test.ts
+++ b/services/admin/src/store.test.ts
@@ -153,6 +153,43 @@ test('add a duplicate CVR file', async () => {
   });
 });
 
+test('partially duplicate CVR files', async () => {
+  const store = Store.memoryStore();
+  const electionId = store.addElection(
+    electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData
+  );
+  const partial1CvrFile =
+    electionMinimalExhaustiveSampleFixtures.partial1CvrFile.asFilePath();
+  const partial2CvrFile =
+    electionMinimalExhaustiveSampleFixtures.partial2CvrFile.asFilePath();
+  const addPartial1Result = (
+    await store.addCastVoteRecordFile({ electionId, filePath: partial1CvrFile })
+  ).unsafeUnwrap();
+  expect(addPartial1Result).toEqual({
+    id: expect.stringMatching(/^[-0-9a-f]+$/),
+    wasExistingFile: false,
+    newlyAdded: 101,
+    alreadyPresent: 0,
+  });
+  const addPartial2Result = (
+    await store.addCastVoteRecordFile({ electionId, filePath: partial2CvrFile })
+  ).unsafeUnwrap();
+  expect(addPartial2Result).toEqual({
+    id: expect.stringMatching(/^[-0-9a-f]+$/),
+    wasExistingFile: false,
+    newlyAdded: 20,
+    alreadyPresent: 21,
+  });
+
+  const partial1WriteInCount = 42;
+  const partial2WriteInCount = 17;
+  const duplicatedWriteInCount = 6;
+
+  expect(store.getWriteInRecords({ electionId })).toHaveLength(
+    partial1WriteInCount + partial2WriteInCount - duplicatedWriteInCount
+  );
+});
+
 test('analyze a CVR file', async () => {
   const store = Store.memoryStore();
   const electionId = store.addElection(

--- a/services/admin/src/store.ts
+++ b/services/admin/src/store.ts
@@ -743,7 +743,7 @@ export class Store {
 
     const writeInRows = this.client.all(
       `
-        select
+        select distinct
           write_ins.id as id,
           write_ins.cvr_id as castVoteRecordId,
           write_ins.contest_id as contestId,


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
When importing multiple files that have any duplicate CVRs we store each CVR only once but link them to all the CVR files they are present in via the `cvr_file_entries` table. When getting the write-in records for an election we need to join `write_ins` with `cvr_file_entries` and `cvr_files`, which means that a write-in record will show up however many times its CVR appears in `cvr_file_entries`. To fix this, we `select distinct` to ensure that only one of each write-in is returned.

Closes #2710 

## Demo Video or Screenshot
When importing [two CVR files that duplicate 200 write-ins per contest (600 for State Representative)](https://votingworks.slack.com/archives/C02Q3M874SV/p1666202204325849?thread_ts=1666192691.204109&cid=C02Q3M874SV):
| Before | After |
|-|-|
|<img width="662" alt="image" src="https://user-images.githubusercontent.com/1938/196776789-6b27d84a-abde-4690-b1f2-64d61e4b6ca2.png">|<img width="644" alt="image" src="https://user-images.githubusercontent.com/1938/196776811-05ebc94b-9622-470d-b38a-ed8b60068899.png">|

Report from importing `partial1.jsonl` and `partial2.json` of the [minimally-exhaustive election fixtures](https://github.com/votingworks/vxsuite/tree/8f25131a1e1e1b18a69581a9f44aaad820afd7f6/libs/fixtures/data/electionMinimalExhaustiveSample/cvrFiles):

<img width="16" src="https://user-images.githubusercontent.com/1938/196777794-c9bfa0b8-6994-49ab-8d52-9c257c81868c.png"> [tabulation-writein-report-sample-county-example-primary-election-all-precincts.pdf](https://github.com/votingworks/vxsuite/files/9823335/tabulation-writein-report-sample-county-example-primary-election-all-precincts.pdf)

We were seeing 59 (42 in `partial1.jsonl`, 17 in `partial2.jsonl`) write-ins with that, but 53 (removing the 6 duplicates) after the fix.

## Testing Plan
Tested manually with @carolinemodic's 200 write-in CVR files (shown above) and the [overlapping CVRs from the minimally-exhaustive election fixtures](https://github.com/votingworks/vxsuite/tree/8f25131a1e1e1b18a69581a9f44aaad820afd7f6/libs/fixtures/data/electionMinimalExhaustiveSample/cvrFiles). Verified that the counts carry through to "Adjudication Queue" & "Completed" on the Write-Ins screen as well as the final reports. Added some basic automated testing.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
