### PR TITLE
Print Element Utility + First Use Case

### DIFF
--- a/frontends/bmd/__mocks__/@votingworks/ui.ts
+++ b/frontends/bmd/__mocks__/@votingworks/ui.ts
@@ -1,0 +1,14 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import {
+  fakePrintElementWhenReady,
+  fakePrintElement,
+} from '@votingworks/test-utils';
+
+const ui = jest.requireActual('@votingworks/ui');
+
+// eslint-disable-next-line vx/gts-no-default-exports
+export default {
+  ...ui,
+  printElement: fakePrintElement,
+  printElementWhenReady: fakePrintElementWhenReady,
+};

--- a/frontends/bmd/src/app_end_to_end.test.tsx
+++ b/frontends/bmd/src/app_end_to_end.test.tsx
@@ -14,6 +14,8 @@ import {
   makePollWorkerCard,
   getZeroCompressedTally,
   makeSystemAdministratorCard,
+  expectPrint,
+  fakePrinter,
 } from '@votingworks/test-utils';
 import {
   MemoryStorage,
@@ -23,7 +25,6 @@ import {
 } from '@votingworks/utils';
 import { fakeLogger, LogEventId } from '@votingworks/logging';
 import userEvent from '@testing-library/user-event';
-import { fakePrinter } from '@votingworks/test-utils';
 import * as GLOBALS from './config/globals';
 
 import { electionSampleDefinition } from './data';
@@ -410,8 +411,8 @@ it('MarkAndPrint end-to-end flow', async () => {
   fireEvent.click(screen.getByText('Close Polls and Print Report'));
   await advanceTimersAndPromises();
   screen.getByText('Printing polls closed report');
+  await expectPrint();
   await advanceTimersAndPromises(REPORT_PRINTING_TIMEOUT_SECONDS);
-  expect(printer.print).toHaveBeenCalledTimes(2);
   fireEvent.click(await screen.findByText('Continue'));
 
   expect(writeLongUint8ArrayMock).toHaveBeenCalledTimes(4);

--- a/frontends/bmd/src/pages/poll_worker_screen.test.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.test.tsx
@@ -39,6 +39,7 @@ import {
   fakeCardStorage,
   fakePrinter,
   hasTextAcrossElements,
+  expectPrint,
 } from '@votingworks/test-utils';
 import userEvent from '@testing-library/user-event';
 
@@ -240,33 +241,37 @@ test('precinct scanner report populated as expected with all precinct data for g
 
   await printPollsClosedReport();
 
-  // vxqr is turned off by default
-  expect(
-    screen.queryAllByText('Automatic Election Results Reporting')
-  ).toHaveLength(0);
+  await expectPrint((printedElement) => {
+    // vxqr is turned off by default
+    expect(
+      printedElement.queryAllByText('Automatic Election Results Reporting')
+    ).toHaveLength(0);
 
-  const allPrecinctsReport = screen.getByTestId(
-    'tally-report-undefined-undefined'
-  );
-  expectBallotCountsInReport(allPrecinctsReport, 20, 5, 25);
-  expectContestResultsInReport(
-    allPrecinctsReport,
-    'president',
-    { ballotsCast: 34, undervotes: 6, overvotes: 0 },
-    {
-      'barchi-hallaren': 6,
-      'cramer-vuocolo': 5,
-      'court-blumhardt': 6,
-      'boone-lian': 5,
-      'hildebrand-garritty': 3,
-      'patterson-lariviere': 0,
-    }
-  );
-  const senatorContest = screen.getAllByTestId('results-table-senator')[0];
-  within(senatorContest).getByText(/0 ballots/);
-  within(senatorContest).getByText(/0 undervotes/);
-  within(senatorContest).getByText(/0 overvotes/);
-  expect(within(senatorContest).getAllByText('0')).toHaveLength(7); // All 7 candidates should have 0 totals
+    const allPrecinctsReport = printedElement.getByTestId(
+      'tally-report-undefined-undefined'
+    );
+    expectBallotCountsInReport(allPrecinctsReport, 20, 5, 25);
+    expectContestResultsInReport(
+      allPrecinctsReport,
+      'president',
+      { ballotsCast: 34, undervotes: 6, overvotes: 0 },
+      {
+        'barchi-hallaren': 6,
+        'cramer-vuocolo': 5,
+        'court-blumhardt': 6,
+        'boone-lian': 5,
+        'hildebrand-garritty': 3,
+        'patterson-lariviere': 0,
+      }
+    );
+    const senatorContest = printedElement.getAllByTestId(
+      'results-table-senator'
+    )[0];
+    within(senatorContest).getByText(/0 ballots/);
+    within(senatorContest).getByText(/0 undervotes/);
+    within(senatorContest).getByText(/0 overvotes/);
+    expect(within(senatorContest).getAllByText('0')).toHaveLength(7); // All 7 candidates should have 0 totals
+  });
 });
 
 test('precinct scanner report with quickresults reporting turned on', async () => {
@@ -314,7 +319,9 @@ test('precinct scanner report with quickresults reporting turned on', async () =
   await printPollsClosedReport();
 
   // vxqr is turned on for this election
-  screen.getByText('Automatic Election Results Reporting');
+  await expectPrint((printedElement) => {
+    printedElement.getByText('Automatic Election Results Reporting');
+  });
 });
 
 test('precinct scanner report populated as expected with single precinct data for general election', async () => {
@@ -360,32 +367,36 @@ test('precinct scanner report populated as expected with single precinct data fo
 
   await printPollsClosedReport();
 
-  const centerSpringfieldReport = screen.getByTestId(
-    'tally-report-undefined-23'
-  );
-  expectBallotCountsInReport(centerSpringfieldReport, 20, 5, 25);
-  expectContestResultsInReport(
-    centerSpringfieldReport,
-    'president',
-    {
-      ballotsCast: 34,
-      undervotes: 6,
-      overvotes: 0,
-    },
-    {
-      'barchi-hallaren': 6,
-      'cramer-vuocolo': 5,
-      'court-blumhardt': 6,
-      'boone-lian': 5,
-      'hildebrand-garritty': 3,
-      'patterson-lariviere': 0,
-    }
-  );
-  const senatorContest = screen.getAllByTestId('results-table-senator')[0];
-  within(senatorContest).getByText(/0 ballots/);
-  within(senatorContest).getByText(/0 undervotes/);
-  within(senatorContest).getByText(/0 overvotes/);
-  expect(within(senatorContest).getAllByText('0')).toHaveLength(7); // All 7 candidates should have 0 totals
+  await expectPrint((printedElement) => {
+    const centerSpringfieldReport = printedElement.getByTestId(
+      'tally-report-undefined-23'
+    );
+    expectBallotCountsInReport(centerSpringfieldReport, 20, 5, 25);
+    expectContestResultsInReport(
+      centerSpringfieldReport,
+      'president',
+      {
+        ballotsCast: 34,
+        undervotes: 6,
+        overvotes: 0,
+      },
+      {
+        'barchi-hallaren': 6,
+        'cramer-vuocolo': 5,
+        'court-blumhardt': 6,
+        'boone-lian': 5,
+        'hildebrand-garritty': 3,
+        'patterson-lariviere': 0,
+      }
+    );
+    const senatorContest = printedElement.getAllByTestId(
+      'results-table-senator'
+    )[0];
+    within(senatorContest).getByText(/0 ballots/);
+    within(senatorContest).getByText(/0 undervotes/);
+    within(senatorContest).getByText(/0 overvotes/);
+    expect(within(senatorContest).getAllByText('0')).toHaveLength(7); // All 7 candidates should have 0 totals
+  });
 });
 
 test('precinct scanner report populated as expected with all precinct specific data for general election', async () => {
@@ -457,71 +468,73 @@ test('precinct scanner report populated as expected with all precinct specific d
 
   await printPollsClosedReport();
 
-  const centerSpringfieldReport = screen.getByTestId(
-    'tally-report-undefined-23'
-  );
-  expectBallotCountsInReport(centerSpringfieldReport, 10, 0, 10);
-  expectContestResultsInReport(
-    centerSpringfieldReport,
-    'president',
-    {
-      ballotsCast: 10,
-      undervotes: 1,
-      overvotes: 1,
-    },
-    {
-      'barchi-hallaren': 4,
-      'cramer-vuocolo': 2,
-      'court-blumhardt': 1,
-      'boone-lian': 1,
-      'hildebrand-garritty': 0,
-      'patterson-lariviere': 0,
-    }
-  );
+  await expectPrint((printedElement) => {
+    const centerSpringfieldReport = printedElement.getByTestId(
+      'tally-report-undefined-23'
+    );
+    expectBallotCountsInReport(centerSpringfieldReport, 10, 0, 10);
+    expectContestResultsInReport(
+      centerSpringfieldReport,
+      'president',
+      {
+        ballotsCast: 10,
+        undervotes: 1,
+        overvotes: 1,
+      },
+      {
+        'barchi-hallaren': 4,
+        'cramer-vuocolo': 2,
+        'court-blumhardt': 1,
+        'boone-lian': 1,
+        'hildebrand-garritty': 0,
+        'patterson-lariviere': 0,
+      }
+    );
 
-  const northSpringfieldReport = screen.getByTestId(
-    'tally-report-undefined-21'
-  );
-  expectBallotCountsInReport(northSpringfieldReport, 10, 5, 15);
-  expectContestResultsInReport(
-    northSpringfieldReport,
-    'president',
-    {
-      ballotsCast: 15,
-      undervotes: 2,
-      overvotes: 3,
-    },
-    {
-      'barchi-hallaren': 4,
-      'cramer-vuocolo': 2,
-      'court-blumhardt': 1,
-      'boone-lian': 1,
-      'hildebrand-garritty': 1,
-      'patterson-lariviere': 1,
-    }
-  );
+    const northSpringfieldReport = printedElement.getByTestId(
+      'tally-report-undefined-21'
+    );
+    expectBallotCountsInReport(northSpringfieldReport, 10, 5, 15);
+    expectContestResultsInReport(
+      northSpringfieldReport,
+      'president',
+      {
+        ballotsCast: 15,
+        undervotes: 2,
+        overvotes: 3,
+      },
+      {
+        'barchi-hallaren': 4,
+        'cramer-vuocolo': 2,
+        'court-blumhardt': 1,
+        'boone-lian': 1,
+        'hildebrand-garritty': 1,
+        'patterson-lariviere': 1,
+      }
+    );
 
-  const southSpringfieldReport = screen.getByTestId(
-    'tally-report-undefined-20'
-  );
-  expectBallotCountsInReport(southSpringfieldReport, 0, 0, 0);
-  expectContestResultsInReport(
-    southSpringfieldReport,
-    'president',
-    {
-      ballotsCast: 0,
-      undervotes: 0,
-      overvotes: 0,
-    },
-    {
-      'barchi-hallaren': 0,
-      'cramer-vuocolo': 0,
-      'court-blumhardt': 0,
-      'boone-lian': 0,
-      'hildebrand-garritty': 0,
-      'patterson-lariviere': 0,
-    }
-  );
+    const southSpringfieldReport = printedElement.getByTestId(
+      'tally-report-undefined-20'
+    );
+    expectBallotCountsInReport(southSpringfieldReport, 0, 0, 0);
+    expectContestResultsInReport(
+      southSpringfieldReport,
+      'president',
+      {
+        ballotsCast: 0,
+        undervotes: 0,
+        overvotes: 0,
+      },
+      {
+        'barchi-hallaren': 0,
+        'cramer-vuocolo': 0,
+        'court-blumhardt': 0,
+        'boone-lian': 0,
+        'hildebrand-garritty': 0,
+        'patterson-lariviere': 0,
+      }
+    );
+  });
 });
 
 test('precinct scanner report populated as expected with all precinct specific data for primary election', async () => {
@@ -676,182 +689,192 @@ test('precinct scanner report populated as expected with all precinct specific d
 
   await printPollsClosedReport();
 
-  // Check that the expected results are on the tally report for Precinct 1 Mammal Party
-  const precinct1MammalReport = screen.getByTestId('tally-report-0-precinct-1');
-  expectBallotCountsInReport(precinct1MammalReport, 1, 0, 1);
-  expect(
-    within(precinct1MammalReport).queryAllByTestId(
-      'results-table-best-animal-fish'
-    )
-  ).toHaveLength(0);
-  expectContestResultsInReport(
-    precinct1MammalReport,
-    'best-animal-mammal',
-    {
-      ballotsCast: 1,
-      undervotes: 0,
-      overvotes: 0,
-    },
-    { horse: 0, otter: 1, fox: 0 }
-  );
-  expectContestResultsInReport(
-    precinct1MammalReport,
-    'zoo-council-mammal',
-    {
-      ballotsCast: 1,
-      undervotes: 1,
-      overvotes: 0,
-    },
-    { zebra: 1, lion: 0, kangaroo: 0, elephant: 0, 'write-in': 1 }
-  );
-  expectContestResultsInReport(
-    precinct1MammalReport,
-    'new-zoo-either',
-    {
-      ballotsCast: 1,
-      undervotes: 0,
-      overvotes: 0,
-    },
-    { yes: 1, no: 0 }
-  );
-  expectContestResultsInReport(
-    precinct1MammalReport,
-    'new-zoo-pick',
-    {
-      ballotsCast: 1,
-      undervotes: 1,
-      overvotes: 0,
-    },
-    { yes: 0, no: 0 }
-  );
-  // Check that the expected results are on the tally report for Precinct 1 Fish Party
-  const precinct1FishReport = screen.getByTestId('tally-report-1-precinct-1');
-  expectBallotCountsInReport(precinct1FishReport, 0, 0, 0);
-  expect(
-    within(precinct1FishReport).queryAllByTestId(
-      'results-table-best-animal-mammal'
-    )
-  ).toHaveLength(0);
-  expectContestResultsInReport(
-    precinct1FishReport,
-    'best-animal-fish',
-    {
-      ballotsCast: 0,
-      undervotes: 0,
-      overvotes: 0,
-    },
-    { seahorse: 0, salmon: 0 }
-  );
-  expectContestResultsInReport(
-    precinct1FishReport,
-    'aquarium-council-fish',
-    {
-      ballotsCast: 0,
-      undervotes: 0,
-      overvotes: 0,
-    },
-    {
-      'manta-ray': 0,
-      pufferfish: 0,
-      rockfish: 0,
-      triggerfish: 0,
-      'write-in': 0,
-    }
-  );
-  expectContestResultsInReport(
-    precinct1FishReport,
-    'fishing',
-    { ballotsCast: 0, undervotes: 0, overvotes: 0 },
-    { yes: 0, no: 0 }
-  );
-  // Check that the expected results are on the tally report for Precinct 2 Mammal Party
-  const precinct2MammalReport = screen.getByTestId('tally-report-0-precinct-2');
-  expectBallotCountsInReport(precinct2MammalReport, 0, 1, 1);
-  expect(
-    within(precinct2MammalReport).queryAllByTestId(
-      'results-table-best-animal-fish'
-    )
-  ).toHaveLength(0);
-  expectContestResultsInReport(
-    precinct2MammalReport,
-    'best-animal-mammal',
-    {
-      ballotsCast: 1,
-      undervotes: 0,
-      overvotes: 1,
-    },
-    { horse: 0, otter: 0, fox: 0 }
-  );
-  expectContestResultsInReport(
-    precinct2MammalReport,
-    'zoo-council-mammal',
-    {
-      ballotsCast: 1,
-      undervotes: 2,
-      overvotes: 0,
-    },
-    { zebra: 0, lion: 0, kangaroo: 0, elephant: 1, 'write-in': 0 }
-  );
-  expectContestResultsInReport(
-    precinct2MammalReport,
-    'new-zoo-either',
-    {
-      ballotsCast: 1,
-      undervotes: 0,
-      overvotes: 0,
-    },
-    { yes: 1, no: 0 }
-  );
-  expectContestResultsInReport(
-    precinct2MammalReport,
-    'new-zoo-pick',
-    {
-      ballotsCast: 1,
-      undervotes: 0,
-      overvotes: 0,
-    },
-    { yes: 0, no: 1 }
-  );
-  // Check that the expected results are on the tally report for Precinct 2 Fish Party
-  const precinct2FishReport = screen.getByTestId('tally-report-1-precinct-2');
-  expectBallotCountsInReport(precinct2FishReport, 1, 0, 1);
-  expect(
-    within(precinct2FishReport).queryAllByTestId(
-      'results-table-best-animal-mammal'
-    )
-  ).toHaveLength(0);
-  expectContestResultsInReport(
-    precinct2FishReport,
-    'best-animal-fish',
-    {
-      ballotsCast: 1,
-      undervotes: 0,
-      overvotes: 0,
-    },
-    { seahorse: 1, salmon: 0 }
-  );
-  expectContestResultsInReport(
-    precinct2FishReport,
-    'aquarium-council-fish',
-    {
-      ballotsCast: 1,
-      undervotes: 0,
-      overvotes: 0,
-    },
-    {
-      'manta-ray': 1,
-      pufferfish: 0,
-      rockfish: 0,
-      triggerfish: 1,
-      'write-in': 0,
-    }
-  );
-  expectContestResultsInReport(
-    precinct2FishReport,
-    'fishing',
-    { ballotsCast: 1, undervotes: 0, overvotes: 0 },
-    { yes: 0, no: 1 }
-  );
+  await expectPrint((printedElement) => {
+    // Check that the expected results are on the tally report for Precinct 1 Mammal Party
+    const precinct1MammalReport = printedElement.getByTestId(
+      'tally-report-0-precinct-1'
+    );
+    expectBallotCountsInReport(precinct1MammalReport, 1, 0, 1);
+    expect(
+      within(precinct1MammalReport).queryAllByTestId(
+        'results-table-best-animal-fish'
+      )
+    ).toHaveLength(0);
+    expectContestResultsInReport(
+      precinct1MammalReport,
+      'best-animal-mammal',
+      {
+        ballotsCast: 1,
+        undervotes: 0,
+        overvotes: 0,
+      },
+      { horse: 0, otter: 1, fox: 0 }
+    );
+    expectContestResultsInReport(
+      precinct1MammalReport,
+      'zoo-council-mammal',
+      {
+        ballotsCast: 1,
+        undervotes: 1,
+        overvotes: 0,
+      },
+      { zebra: 1, lion: 0, kangaroo: 0, elephant: 0, 'write-in': 1 }
+    );
+    expectContestResultsInReport(
+      precinct1MammalReport,
+      'new-zoo-either',
+      {
+        ballotsCast: 1,
+        undervotes: 0,
+        overvotes: 0,
+      },
+      { yes: 1, no: 0 }
+    );
+    expectContestResultsInReport(
+      precinct1MammalReport,
+      'new-zoo-pick',
+      {
+        ballotsCast: 1,
+        undervotes: 1,
+        overvotes: 0,
+      },
+      { yes: 0, no: 0 }
+    );
+    // Check that the expected results are on the tally report for Precinct 1 Fish Party
+    const precinct1FishReport = printedElement.getByTestId(
+      'tally-report-1-precinct-1'
+    );
+    expectBallotCountsInReport(precinct1FishReport, 0, 0, 0);
+    expect(
+      within(precinct1FishReport).queryAllByTestId(
+        'results-table-best-animal-mammal'
+      )
+    ).toHaveLength(0);
+    expectContestResultsInReport(
+      precinct1FishReport,
+      'best-animal-fish',
+      {
+        ballotsCast: 0,
+        undervotes: 0,
+        overvotes: 0,
+      },
+      { seahorse: 0, salmon: 0 }
+    );
+    expectContestResultsInReport(
+      precinct1FishReport,
+      'aquarium-council-fish',
+      {
+        ballotsCast: 0,
+        undervotes: 0,
+        overvotes: 0,
+      },
+      {
+        'manta-ray': 0,
+        pufferfish: 0,
+        rockfish: 0,
+        triggerfish: 0,
+        'write-in': 0,
+      }
+    );
+    expectContestResultsInReport(
+      precinct1FishReport,
+      'fishing',
+      { ballotsCast: 0, undervotes: 0, overvotes: 0 },
+      { yes: 0, no: 0 }
+    );
+    // Check that the expected results are on the tally report for Precinct 2 Mammal Party
+    const precinct2MammalReport = printedElement.getByTestId(
+      'tally-report-0-precinct-2'
+    );
+    expectBallotCountsInReport(precinct2MammalReport, 0, 1, 1);
+    expect(
+      within(precinct2MammalReport).queryAllByTestId(
+        'results-table-best-animal-fish'
+      )
+    ).toHaveLength(0);
+    expectContestResultsInReport(
+      precinct2MammalReport,
+      'best-animal-mammal',
+      {
+        ballotsCast: 1,
+        undervotes: 0,
+        overvotes: 1,
+      },
+      { horse: 0, otter: 0, fox: 0 }
+    );
+    expectContestResultsInReport(
+      precinct2MammalReport,
+      'zoo-council-mammal',
+      {
+        ballotsCast: 1,
+        undervotes: 2,
+        overvotes: 0,
+      },
+      { zebra: 0, lion: 0, kangaroo: 0, elephant: 1, 'write-in': 0 }
+    );
+    expectContestResultsInReport(
+      precinct2MammalReport,
+      'new-zoo-either',
+      {
+        ballotsCast: 1,
+        undervotes: 0,
+        overvotes: 0,
+      },
+      { yes: 1, no: 0 }
+    );
+    expectContestResultsInReport(
+      precinct2MammalReport,
+      'new-zoo-pick',
+      {
+        ballotsCast: 1,
+        undervotes: 0,
+        overvotes: 0,
+      },
+      { yes: 0, no: 1 }
+    );
+    // Check that the expected results are on the tally report for Precinct 2 Fish Party
+    const precinct2FishReport = printedElement.getByTestId(
+      'tally-report-1-precinct-2'
+    );
+    expectBallotCountsInReport(precinct2FishReport, 1, 0, 1);
+    expect(
+      within(precinct2FishReport).queryAllByTestId(
+        'results-table-best-animal-mammal'
+      )
+    ).toHaveLength(0);
+    expectContestResultsInReport(
+      precinct2FishReport,
+      'best-animal-fish',
+      {
+        ballotsCast: 1,
+        undervotes: 0,
+        overvotes: 0,
+      },
+      { seahorse: 1, salmon: 0 }
+    );
+    expectContestResultsInReport(
+      precinct2FishReport,
+      'aquarium-council-fish',
+      {
+        ballotsCast: 1,
+        undervotes: 0,
+        overvotes: 0,
+      },
+      {
+        'manta-ray': 1,
+        pufferfish: 0,
+        rockfish: 0,
+        triggerfish: 1,
+        'write-in': 0,
+      }
+    );
+    expectContestResultsInReport(
+      precinct2FishReport,
+      'fishing',
+      { ballotsCast: 1, undervotes: 0, overvotes: 0 },
+      { yes: 0, no: 1 }
+    );
+  });
 });
 
 test('precinct scanner report populated as expected with all precinct combined data for primary election', async () => {
@@ -928,101 +951,104 @@ test('precinct scanner report populated as expected with all precinct combined d
   });
 
   await printPollsClosedReport();
-
-  // Check that the expected results are on the tally report for Precinct 1 Mammal Party
-  const allPrecinctMammalReport = screen.getByTestId(
-    'tally-report-0-undefined'
-  );
-  expectBallotCountsInReport(allPrecinctMammalReport, 1, 1, 2);
-  expect(
-    within(allPrecinctMammalReport).queryAllByTestId(
-      'results-table-best-animal-fish'
-    )
-  ).toHaveLength(0);
-  expectContestResultsInReport(
-    allPrecinctMammalReport,
-    'best-animal-mammal',
-    {
-      ballotsCast: 2,
-      undervotes: 0,
-      overvotes: 1,
-    },
-    { horse: 0, otter: 1, fox: 0 }
-  );
-  expectContestResultsInReport(
-    allPrecinctMammalReport,
-    'zoo-council-mammal',
-    {
-      ballotsCast: 2,
-      undervotes: 3,
-      overvotes: 0,
-    },
-    { zebra: 1, lion: 0, kangaroo: 0, elephant: 1, 'write-in': 1 }
-  );
-  expectContestResultsInReport(
-    allPrecinctMammalReport,
-    'new-zoo-either',
-    {
-      ballotsCast: 2,
-      undervotes: 0,
-      overvotes: 0,
-    },
-    { yes: 2, no: 0 }
-  );
-  expectContestResultsInReport(
-    allPrecinctMammalReport,
-    'new-zoo-pick',
-    {
-      ballotsCast: 2,
-      undervotes: 1,
-      overvotes: 0,
-    },
-    { yes: 0, no: 1 }
-  );
-  // Check that the expected results are on the tally report for Precinct 1 Fish Party
-  const allPrecinctFishReport = screen.getByTestId('tally-report-1-undefined');
-  expectBallotCountsInReport(allPrecinctFishReport, 1, 0, 1);
-  expect(
-    within(allPrecinctFishReport).queryAllByTestId(
-      'results-table-best-animal-mammal'
-    )
-  ).toHaveLength(0);
-  expectContestResultsInReport(
-    allPrecinctFishReport,
-    'best-animal-fish',
-    {
-      ballotsCast: 1,
-      undervotes: 0,
-      overvotes: 0,
-    },
-    { seahorse: 1, salmon: 0 }
-  );
-  expectContestResultsInReport(
-    allPrecinctFishReport,
-    'aquarium-council-fish',
-    {
-      ballotsCast: 1,
-      undervotes: 0,
-      overvotes: 0,
-    },
-    {
-      'manta-ray': 1,
-      pufferfish: 0,
-      rockfish: 0,
-      triggerfish: 1,
-      'write-in': 0,
-    }
-  );
-  expectContestResultsInReport(
-    allPrecinctFishReport,
-    'fishing',
-    {
-      ballotsCast: 1,
-      undervotes: 0,
-      overvotes: 0,
-    },
-    { yes: 0, no: 1 }
-  );
+  await expectPrint((printedElement) => {
+    // Check that the expected results are on the tally report for Precinct 1 Mammal Party
+    const allPrecinctMammalReport = printedElement.getByTestId(
+      'tally-report-0-undefined'
+    );
+    expectBallotCountsInReport(allPrecinctMammalReport, 1, 1, 2);
+    expect(
+      within(allPrecinctMammalReport).queryAllByTestId(
+        'results-table-best-animal-fish'
+      )
+    ).toHaveLength(0);
+    expectContestResultsInReport(
+      allPrecinctMammalReport,
+      'best-animal-mammal',
+      {
+        ballotsCast: 2,
+        undervotes: 0,
+        overvotes: 1,
+      },
+      { horse: 0, otter: 1, fox: 0 }
+    );
+    expectContestResultsInReport(
+      allPrecinctMammalReport,
+      'zoo-council-mammal',
+      {
+        ballotsCast: 2,
+        undervotes: 3,
+        overvotes: 0,
+      },
+      { zebra: 1, lion: 0, kangaroo: 0, elephant: 1, 'write-in': 1 }
+    );
+    expectContestResultsInReport(
+      allPrecinctMammalReport,
+      'new-zoo-either',
+      {
+        ballotsCast: 2,
+        undervotes: 0,
+        overvotes: 0,
+      },
+      { yes: 2, no: 0 }
+    );
+    expectContestResultsInReport(
+      allPrecinctMammalReport,
+      'new-zoo-pick',
+      {
+        ballotsCast: 2,
+        undervotes: 1,
+        overvotes: 0,
+      },
+      { yes: 0, no: 1 }
+    );
+    // Check that the expected results are on the tally report for Precinct 1 Fish Party
+    const allPrecinctFishReport = printedElement.getByTestId(
+      'tally-report-1-undefined'
+    );
+    expectBallotCountsInReport(allPrecinctFishReport, 1, 0, 1);
+    expect(
+      within(allPrecinctFishReport).queryAllByTestId(
+        'results-table-best-animal-mammal'
+      )
+    ).toHaveLength(0);
+    expectContestResultsInReport(
+      allPrecinctFishReport,
+      'best-animal-fish',
+      {
+        ballotsCast: 1,
+        undervotes: 0,
+        overvotes: 0,
+      },
+      { seahorse: 1, salmon: 0 }
+    );
+    expectContestResultsInReport(
+      allPrecinctFishReport,
+      'aquarium-council-fish',
+      {
+        ballotsCast: 1,
+        undervotes: 0,
+        overvotes: 0,
+      },
+      {
+        'manta-ray': 1,
+        pufferfish: 0,
+        rockfish: 0,
+        triggerfish: 1,
+        'write-in': 0,
+      }
+    );
+    expectContestResultsInReport(
+      allPrecinctFishReport,
+      'fishing',
+      {
+        ballotsCast: 1,
+        undervotes: 0,
+        overvotes: 0,
+      },
+      { yes: 0, no: 1 }
+    );
+  });
 });
 
 test('precinct scanner report populated as expected with a single precinct for primary election', async () => {
@@ -1098,100 +1124,104 @@ test('precinct scanner report populated as expected with a single precinct for p
 
   await printPollsClosedReport();
 
-  // Check that the expected results are on the tally report for Precinct 1 Mammal Party
-  const allPrecinctMammalReport = screen.getByTestId(
-    'tally-report-0-precinct-1'
-  );
-  expectBallotCountsInReport(allPrecinctMammalReport, 1, 1, 2);
-  expect(
-    within(allPrecinctMammalReport).queryAllByTestId(
-      'results-table-best-animal-fish'
-    )
-  ).toHaveLength(0);
-  expectContestResultsInReport(
-    allPrecinctMammalReport,
-    'best-animal-mammal',
-    {
-      ballotsCast: 2,
-      undervotes: 0,
-      overvotes: 1,
-    },
-    { horse: 0, otter: 1, fox: 0 }
-  );
-  expectContestResultsInReport(
-    allPrecinctMammalReport,
-    'zoo-council-mammal',
-    {
-      ballotsCast: 2,
-      undervotes: 3,
-      overvotes: 0,
-    },
-    { zebra: 1, lion: 0, kangaroo: 0, elephant: 1, 'write-in': 1 }
-  );
-  expectContestResultsInReport(
-    allPrecinctMammalReport,
-    'new-zoo-either',
-    {
-      ballotsCast: 2,
-      undervotes: 0,
-      overvotes: 0,
-    },
-    { yes: 2, no: 0 }
-  );
-  expectContestResultsInReport(
-    allPrecinctMammalReport,
-    'new-zoo-pick',
-    {
-      ballotsCast: 2,
-      undervotes: 1,
-      overvotes: 0,
-    },
-    { yes: 0, no: 1 }
-  );
-  // Check that the expected results are on the tally report for Precinct 1 Fish Party
-  const allPrecinctFishReport = screen.getByTestId('tally-report-1-precinct-1');
-  expectBallotCountsInReport(allPrecinctFishReport, 1, 0, 1);
-  expect(
-    within(allPrecinctFishReport).queryAllByTestId(
-      'results-table-best-animal-mammal'
-    )
-  ).toHaveLength(0);
-  expectContestResultsInReport(
-    allPrecinctFishReport,
-    'best-animal-fish',
-    {
-      ballotsCast: 1,
-      undervotes: 0,
-      overvotes: 0,
-    },
-    { seahorse: 1, salmon: 0 }
-  );
-  expectContestResultsInReport(
-    allPrecinctFishReport,
-    'aquarium-council-fish',
-    {
-      ballotsCast: 1,
-      undervotes: 0,
-      overvotes: 0,
-    },
-    {
-      'manta-ray': 1,
-      pufferfish: 0,
-      rockfish: 0,
-      triggerfish: 1,
-      'write-in': 0,
-    }
-  );
-  expectContestResultsInReport(
-    allPrecinctFishReport,
-    'fishing',
-    {
-      ballotsCast: 1,
-      undervotes: 0,
-      overvotes: 0,
-    },
-    { yes: 0, no: 1 }
-  );
+  await expectPrint((printedElement) => {
+    // Check that the expected results are on the tally report for Precinct 1 Mammal Party
+    const allPrecinctMammalReport = printedElement.getByTestId(
+      'tally-report-0-precinct-1'
+    );
+    expectBallotCountsInReport(allPrecinctMammalReport, 1, 1, 2);
+    expect(
+      within(allPrecinctMammalReport).queryAllByTestId(
+        'results-table-best-animal-fish'
+      )
+    ).toHaveLength(0);
+    expectContestResultsInReport(
+      allPrecinctMammalReport,
+      'best-animal-mammal',
+      {
+        ballotsCast: 2,
+        undervotes: 0,
+        overvotes: 1,
+      },
+      { horse: 0, otter: 1, fox: 0 }
+    );
+    expectContestResultsInReport(
+      allPrecinctMammalReport,
+      'zoo-council-mammal',
+      {
+        ballotsCast: 2,
+        undervotes: 3,
+        overvotes: 0,
+      },
+      { zebra: 1, lion: 0, kangaroo: 0, elephant: 1, 'write-in': 1 }
+    );
+    expectContestResultsInReport(
+      allPrecinctMammalReport,
+      'new-zoo-either',
+      {
+        ballotsCast: 2,
+        undervotes: 0,
+        overvotes: 0,
+      },
+      { yes: 2, no: 0 }
+    );
+    expectContestResultsInReport(
+      allPrecinctMammalReport,
+      'new-zoo-pick',
+      {
+        ballotsCast: 2,
+        undervotes: 1,
+        overvotes: 0,
+      },
+      { yes: 0, no: 1 }
+    );
+    // Check that the expected results are on the tally report for Precinct 1 Fish Party
+    const allPrecinctFishReport = printedElement.getByTestId(
+      'tally-report-1-precinct-1'
+    );
+    expectBallotCountsInReport(allPrecinctFishReport, 1, 0, 1);
+    expect(
+      within(allPrecinctFishReport).queryAllByTestId(
+        'results-table-best-animal-mammal'
+      )
+    ).toHaveLength(0);
+    expectContestResultsInReport(
+      allPrecinctFishReport,
+      'best-animal-fish',
+      {
+        ballotsCast: 1,
+        undervotes: 0,
+        overvotes: 0,
+      },
+      { seahorse: 1, salmon: 0 }
+    );
+    expectContestResultsInReport(
+      allPrecinctFishReport,
+      'aquarium-council-fish',
+      {
+        ballotsCast: 1,
+        undervotes: 0,
+        overvotes: 0,
+      },
+      {
+        'manta-ray': 1,
+        pufferfish: 0,
+        rockfish: 0,
+        triggerfish: 1,
+        'write-in': 0,
+      }
+    );
+    expectContestResultsInReport(
+      allPrecinctFishReport,
+      'fishing',
+      {
+        ballotsCast: 1,
+        undervotes: 0,
+        overvotes: 0,
+      },
+      { yes: 0, no: 1 }
+    );
+  });
 });
 
 test('navigates to System Diagnostics screen', () => {
@@ -1269,8 +1299,8 @@ test('printing polls opened report clears card and opens the polls', async () =>
   );
 
   // check that the report was printed
-  await waitFor(() => {
-    expect(printFn).toHaveBeenCalledTimes(1);
+  await expectPrint((printedElement) => {
+    printedElement.getAllByText('TEST Polls Opened Report for All Precincts');
   });
   screen.getByText('Printing polls opened report');
   jest.advanceTimersByTime(REPORT_PRINTING_TIMEOUT_SECONDS * 1000);
@@ -1286,8 +1316,8 @@ test('printing polls opened report clears card and opens the polls', async () =>
   userEvent.click(
     screen.getByRole('button', { name: 'Print Additional Report' })
   );
-  await waitFor(() => {
-    expect(printFn).toHaveBeenCalledTimes(2);
+  await expectPrint((printedElement) => {
+    printedElement.getAllByText('TEST Polls Opened Report for All Precincts');
   });
   screen.getByText('Printing polls opened report');
   await screen.findByText('Polls Opened Report Printed');
@@ -1344,11 +1374,11 @@ test('printing polls closed report clears card and closes the polls', async () =
     screen.getByRole('button', { name: 'Close Polls and Print Report' })
   );
 
-  // check that the report was printed
-  await waitFor(() => {
-    expect(printFn).toHaveBeenCalledTimes(1);
+  // Check that the report was printed
+  await screen.findByText('Printing polls closed report');
+  await expectPrint((printedElement) => {
+    printedElement.getAllByText('TEST Polls Closed Report for All Precincts');
   });
-  screen.getByText('Printing polls closed report');
   jest.advanceTimersByTime(REPORT_PRINTING_TIMEOUT_SECONDS * 1000);
   await screen.findByText('Polls Closed Report Printed');
 
@@ -1364,8 +1394,8 @@ test('printing polls closed report clears card and closes the polls', async () =
   userEvent.click(
     screen.getByRole('button', { name: 'Print Additional Report' })
   );
-  await waitFor(() => {
-    expect(printFn).toHaveBeenCalledTimes(2);
+  await expectPrint((printedElement) => {
+    printedElement.getAllByText('TEST Polls Closed Report for All Precincts');
   });
   screen.getByText('Printing polls closed report');
   await screen.findByText('Polls Closed Report Printed');

--- a/frontends/bmd/src/setupTests.tsx
+++ b/frontends/bmd/src/setupTests.tsx
@@ -5,6 +5,7 @@ import '@testing-library/jest-dom/extend-expect';
 import fetchMock from 'fetch-mock';
 import { TextDecoder, TextEncoder } from 'util';
 import { configure } from '@testing-library/react';
+import { expectAllPrintsTested } from '@votingworks/test-utils';
 
 configure({ asyncUtilTimeout: 5_000 });
 
@@ -51,6 +52,7 @@ beforeEach(() => {
 
 afterEach(() => {
   fetchMock.restore();
+  expectAllPrintsTested();
 });
 
 globalThis.TextDecoder = TextDecoder as typeof globalThis.TextDecoder;

--- a/frontends/bmd/tsconfig.json
+++ b/frontends/bmd/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.shared.json",
-  "include": ["src", "test"],
+  "include": ["src", "test", "__mocks__"],
   "exclude": ["src/setupProxy.js"],
   "compilerOptions": {
     "allowJs": true,

--- a/frontends/precinct-scanner/__mocks__/@votingworks/ui.ts
+++ b/frontends/precinct-scanner/__mocks__/@votingworks/ui.ts
@@ -1,4 +1,4 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
+// eslint-disable-next-line import/no-extraneous-dependencies, import/no-import-module-exports
 import {
   fakePrintElementWhenReady,
   fakePrintElement,
@@ -6,8 +6,7 @@ import {
 
 const ui = jest.requireActual('@votingworks/ui');
 
-// eslint-disable-next-line vx/gts-no-default-exports
-export default {
+module.exports = {
   ...ui,
   printElement: fakePrintElement,
   printElementWhenReady: fakePrintElementWhenReady,

--- a/frontends/precinct-scanner/__mocks__/@votingworks/ui.ts
+++ b/frontends/precinct-scanner/__mocks__/@votingworks/ui.ts
@@ -1,0 +1,14 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import {
+  fakePrintElementWhenReady,
+  fakePrintElement,
+} from '@votingworks/test-utils';
+
+const ui = jest.requireActual('@votingworks/ui');
+
+// eslint-disable-next-line vx/gts-no-default-exports
+export default {
+  ...ui,
+  printElement: fakePrintElement,
+  printElementWhenReady: fakePrintElementWhenReady,
+};

--- a/frontends/precinct-scanner/jest.config.js
+++ b/frontends/precinct-scanner/jest.config.js
@@ -14,7 +14,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       statements: 95,
-      branches: 87,
+      branches: 86,
       functions: 89,
       lines: 95,
     },

--- a/frontends/precinct-scanner/src/app.test.tsx
+++ b/frontends/precinct-scanner/src/app.test.tsx
@@ -28,6 +28,7 @@ import {
   makeSystemAdministratorCard,
   getZeroCompressedTally,
   fakePrinter,
+  expectPrint,
 } from '@votingworks/test-utils';
 import { join } from 'path';
 import {
@@ -890,13 +891,12 @@ test('with printer: poll worker can open and close polls without scanning any ba
       body: typedAs<Scan.PatchTestModeConfigResponse>({ status: 'ok' }),
       status: 200,
     });
-  const printFn = jest.fn();
   render(
     <App
       card={card}
       hardware={hardware}
       storage={storage}
-      printer={fakePrinter({ print: printFn })}
+      printer={fakePrinter()}
     />
   );
   await advanceTimersAndPromises(1);
@@ -909,12 +909,12 @@ test('with printer: poll worker can open and close polls without scanning any ba
   await screen.findByText('Do you want to open the polls?');
   userEvent.click(screen.getByRole('button', { name: 'Yes, Open the Polls' }));
   await screen.findByText('Polls are open.');
-  expect(printFn).toHaveBeenCalledTimes(1);
+  await expectPrint();
   userEvent.click(
     screen.getByRole('button', { name: 'Print Additional Polls Opened Report' })
   );
   await screen.findByText('Printing Report…');
-  expect(printFn).toHaveBeenCalledTimes(2);
+  await expectPrint();
   await advanceTimersAndPromises(REPRINT_REPORT_TIMEOUT_SECONDS);
   await screen.findByText('Polls are open.');
   screen.getByRole('button', { name: 'Print Additional Polls Opened Report' });
@@ -928,12 +928,12 @@ test('with printer: poll worker can open and close polls without scanning any ba
   await screen.findByText('Do you want to close the polls?');
   userEvent.click(screen.getByRole('button', { name: 'Yes, Close the Polls' }));
   await screen.findByText('Polls are closed.');
-  expect(printFn).toHaveBeenCalledTimes(3);
+  await expectPrint();
   userEvent.click(
     screen.getByRole('button', { name: 'Print Additional Polls Closed Report' })
   );
   await screen.findByText('Printing Report…');
-  expect(printFn).toHaveBeenCalledTimes(4);
+  await expectPrint();
   await advanceTimersAndPromises(REPRINT_REPORT_TIMEOUT_SECONDS);
   await screen.findByText('Polls are closed.');
   screen.getByRole('button', { name: 'Print Additional Polls Closed Report' });

--- a/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
+++ b/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
@@ -13,6 +13,7 @@ import {
 import { fakeLogger } from '@votingworks/logging';
 import {
   advanceTimersAndPromises,
+  expectPrint,
   fakeKiosk,
   fakeUsbDrive,
   makeElectionManagerCard,
@@ -423,6 +424,7 @@ test('removing card during calibration', async () => {
     await screen.findByRole('button', { name: 'Yes, Open the Polls' })
   );
   await screen.findByText('Polls are open.');
+  await expectPrint();
   card.removeCard();
   await screen.findByText('Insert Your Ballot Below');
 

--- a/frontends/precinct-scanner/src/screens/poll_worker_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/poll_worker_screen.tsx
@@ -5,14 +5,13 @@ import {
   Button,
   Prose,
   Loading,
-  PrecinctScannerTallyReport,
-  PrecinctScannerTallyQrCode,
-  PrintableContainer,
-  TallyReport,
   UsbDrive,
   isPollWorkerAuth,
   DEFAULT_NUMBER_POLL_REPORT_COPIES,
   fontSizeTheme,
+  PrecinctScannerFullReport,
+  printElement,
+  getSignedQuickResultsReportingUrl,
 } from '@votingworks/ui';
 import {
   assert,
@@ -20,8 +19,8 @@ import {
   compressTally,
   computeTallyWithPrecomputedCategories,
   EnvironmentFlagName,
-  filterTalliesByParams,
   getPrecinctSelectionName,
+  getSubTalliesByPartyAndPrecinct,
   getTallyIdentifier,
   isFeatureFlagEnabled,
   PrecinctScannerCardTally,
@@ -132,14 +131,6 @@ export function PollWorkerScreen({
     [election, currentTally]
   );
 
-  const precinctList = useMemo(
-    () =>
-      precinctSelection.kind === 'AllPrecincts'
-        ? election.precincts.map(({ id }) => id)
-        : [precinctSelection.precinctId],
-    [precinctSelection, election.precincts]
-  );
-
   const parties = useMemo(
     () => getPartyIdsInBallotStyles(election),
     [election]
@@ -154,20 +145,14 @@ export function PollWorkerScreen({
         [TallyCategory.Party, TallyCategory.Precinct]
       );
       // Get all tallies by precinct and party
-      const newSubTallies = new Map();
-      for (const partyId of parties) {
-        for (const precinctId of precinctList) {
-          const filteredTally = filterTalliesByParams(tally, election, {
-            precinctId,
-            partyId,
-          });
-          newSubTallies.set(
-            getTallyIdentifier(partyId, precinctId),
-            filteredTally
-          );
-        }
-      }
-      setCurrentSubTallies(newSubTallies);
+      assert(precinctSelection);
+      setCurrentSubTallies(
+        getSubTalliesByPartyAndPrecinct({
+          election,
+          tally,
+          precinctSelection,
+        })
+      );
       if (castVoteRecords.length !== scannedBallotCount) {
         debug(
           `Warning, ballots scanned count from status endpoint (${scannedBallotCount}) does not match number of CVRs (${castVoteRecords.length}) `
@@ -183,7 +168,7 @@ export function PollWorkerScreen({
       setCurrentTally(tally);
     }
     void calculateTally();
-  }, [election, scannedBallotCount, parties, precinctList]);
+  }, [election, scannedBallotCount, precinctSelection]);
 
   async function saveTally() {
     assert(currentTally);
@@ -271,22 +256,6 @@ export function PollWorkerScreen({
     }
   }
 
-  async function printTallyReport(copies: number) {
-    await printer.print({
-      sides: 'one-sided',
-      copies,
-    });
-  }
-
-  async function dispatchReport() {
-    setPollsToggledTime(currentTime);
-    if (hasPrinterAttached) {
-      await printTallyReport(DEFAULT_NUMBER_POLL_REPORT_COPIES);
-    } else {
-      await saveTally();
-    }
-  }
-
   const [pollWorkerFlowState, setPollWorkerFlowState] = useState<
     PollWorkerFlowState | undefined
   >(
@@ -296,6 +265,62 @@ export function PollWorkerScreen({
   );
   function showAllPollWorkerActions() {
     return setPollWorkerFlowState(undefined);
+  }
+
+  async function printTallyReport(copies: number) {
+    if (!electionDefinition) return;
+    if (!precinctSelection) return;
+    if (!currentCompressedTally) return;
+    if (!currentSubTallies) return;
+
+    const isPollsOpenForReport =
+      pollWorkerFlowState === PollWorkerFlowState.EITHER_FLOW__REPRINTING ||
+      pollWorkerFlowState === PollWorkerFlowState.CLOSE_POLLS_FLOW__COMPLETE ||
+      pollWorkerFlowState === PollWorkerFlowState.OPEN_POLLS_FLOW__COMPLETE
+        ? isPollsOpen
+        : !isPollsOpen;
+
+    const precinctSelectionList =
+      precinctSelection.kind === 'SinglePrecinct'
+        ? [precinctSelection]
+        : election.precincts.map(({ id }) => singlePrecinctSelectionFor(id));
+
+    const signedQuickResultsReportingUrl =
+      await getSignedQuickResultsReportingUrl({
+        electionDefinition,
+        isLiveMode,
+        compressedTally: currentCompressedTally,
+        signingMachineId: machineConfig.machineId,
+      });
+
+    await printElement(
+      <PrecinctScannerFullReport
+        electionDefinition={electionDefinition}
+        precinctSelectionList={precinctSelectionList}
+        subTallies={currentSubTallies}
+        isPollsOpen={isPollsOpenForReport}
+        isLiveMode={isLiveMode}
+        pollsToggledTime={pollsToggledTime || currentTime}
+        currentTime={currentTime}
+        precinctScannerMachineId={machineConfig.machineId}
+        totalBallotsScanned={scannedBallotCount}
+        signedQuickResultsReportingUrl={signedQuickResultsReportingUrl}
+      />,
+      printer,
+      {
+        sides: 'one-sided',
+        copies,
+      }
+    );
+  }
+
+  async function dispatchReport() {
+    setPollsToggledTime(currentTime);
+    if (hasPrinterAttached) {
+      await printTallyReport(DEFAULT_NUMBER_POLL_REPORT_COPIES);
+    } else {
+      await saveTally();
+    }
   }
 
   async function openPolls() {
@@ -345,85 +370,30 @@ export function PollWorkerScreen({
     );
   }
 
-  const isPollsOpenForReport =
-    pollWorkerFlowState === PollWorkerFlowState.EITHER_FLOW__REPRINTING ||
-    pollWorkerFlowState === PollWorkerFlowState.CLOSE_POLLS_FLOW__COMPLETE ||
-    pollWorkerFlowState === PollWorkerFlowState.OPEN_POLLS_FLOW__COMPLETE
-      ? isPollsOpen
-      : !isPollsOpen;
-
-  const printableReport = currentTally && (
-    <PrintableContainer>
-      <TallyReport>
-        {precinctList.map((precinctId) =>
-          parties.map((partyId) => {
-            const tallyForReport = currentSubTallies.get(
-              getTallyIdentifier(partyId, precinctId)
-            );
-            assert(tallyForReport);
-            return (
-              <PrecinctScannerTallyReport
-                key={getTallyIdentifier(partyId, precinctId)}
-                data-testid={getTallyIdentifier(partyId, precinctId)}
-                electionDefinition={electionDefinition}
-                tally={tallyForReport}
-                precinctSelection={singlePrecinctSelectionFor(precinctId)}
-                partyId={partyId}
-                isPollsOpen={isPollsOpenForReport}
-                isLiveMode={isLiveMode}
-                currentTime={currentTime}
-                pollsToggledTime={pollsToggledTime || currentTime}
-                precinctScannerMachineId={machineConfig.machineId}
-              />
-            );
-          })
-        )}
-        {electionDefinition.election.quickResultsReportingUrl &&
-          currentCompressedTally &&
-          scannedBallotCount > 0 && (
-            <PrecinctScannerTallyQrCode
-              electionDefinition={electionDefinition}
-              signingMachineId={machineConfig.machineId}
-              compressedTally={currentCompressedTally}
-              isPollsOpen={isPollsOpenForReport}
-              isLiveMode={isLiveMode}
-              pollsToggledTime={pollsToggledTime || currentTime}
-            />
-          )}
-      </TallyReport>
-    </PrintableContainer>
-  );
-
   if (pollWorkerFlowState === PollWorkerFlowState.OPEN_POLLS_FLOW__CONFIRM) {
     return (
-      <React.Fragment>
-        <ScreenMainCenterChild infoBarMode="pollworker">
-          <CenteredLargeProse>
-            <p>Do you want to open the polls?</p>
-            <p>
-              <Button primary onPress={openPolls}>
-                Yes, Open the Polls
-              </Button>{' '}
-              <Button onPress={showAllPollWorkerActions}>No</Button>
-            </p>
-          </CenteredLargeProse>
-        </ScreenMainCenterChild>
-        {printableReport}
-      </React.Fragment>
+      <ScreenMainCenterChild infoBarMode="pollworker">
+        <CenteredLargeProse>
+          <p>Do you want to open the polls?</p>
+          <p>
+            <Button primary onPress={openPolls}>
+              Yes, Open the Polls
+            </Button>{' '}
+            <Button onPress={showAllPollWorkerActions}>No</Button>
+          </p>
+        </CenteredLargeProse>
+      </ScreenMainCenterChild>
     );
   }
 
   if (pollWorkerFlowState === PollWorkerFlowState.OPEN_POLLS_FLOW__PROCESSING) {
     return (
-      <React.Fragment>
-        <ScreenMainCenterChild infoBarMode="pollworker">
-          <IndeterminateProgressBar />
-          <CenteredLargeProse>
-            <h1>Opening Polls…</h1>
-          </CenteredLargeProse>
-        </ScreenMainCenterChild>
-        {printableReport}
-      </React.Fragment>
+      <ScreenMainCenterChild infoBarMode="pollworker">
+        <IndeterminateProgressBar />
+        <CenteredLargeProse>
+          <h1>Opening Polls…</h1>
+        </CenteredLargeProse>
+      </ScreenMainCenterChild>
     );
   }
 
@@ -446,27 +416,23 @@ export function PollWorkerScreen({
             <p>Insert poll worker card into VxMark to print the report.</p>
           )}
         </CenteredLargeProse>
-        {printableReport}
       </ScreenMainCenterChild>
     );
   }
 
   if (pollWorkerFlowState === PollWorkerFlowState.CLOSE_POLLS_FLOW__CONFIRM) {
     return (
-      <React.Fragment>
-        <ScreenMainCenterChild infoBarMode="pollworker">
-          <CenteredLargeProse>
-            <p>Do you want to close the polls?</p>
-            <p>
-              <Button primary onPress={closePolls}>
-                Yes, Close the Polls
-              </Button>{' '}
-              <Button onPress={showAllPollWorkerActions}>No</Button>
-            </p>
-          </CenteredLargeProse>
-        </ScreenMainCenterChild>
-        {printableReport}
-      </React.Fragment>
+      <ScreenMainCenterChild infoBarMode="pollworker">
+        <CenteredLargeProse>
+          <p>Do you want to close the polls?</p>
+          <p>
+            <Button primary onPress={closePolls}>
+              Yes, Close the Polls
+            </Button>{' '}
+            <Button onPress={showAllPollWorkerActions}>No</Button>
+          </p>
+        </CenteredLargeProse>
+      </ScreenMainCenterChild>
     );
   }
 
@@ -474,15 +440,12 @@ export function PollWorkerScreen({
     pollWorkerFlowState === PollWorkerFlowState.CLOSE_POLLS_FLOW__PROCESSING
   ) {
     return (
-      <React.Fragment>
-        <ScreenMainCenterChild infoBarMode="pollworker">
-          <IndeterminateProgressBar />
-          <CenteredLargeProse>
-            <h1>Closing Polls…</h1>
-          </CenteredLargeProse>
-        </ScreenMainCenterChild>
-        {printableReport}
-      </React.Fragment>
+      <ScreenMainCenterChild infoBarMode="pollworker">
+        <IndeterminateProgressBar />
+        <CenteredLargeProse>
+          <h1>Closing Polls…</h1>
+        </CenteredLargeProse>
+      </ScreenMainCenterChild>
     );
   }
 
@@ -505,69 +468,62 @@ export function PollWorkerScreen({
             <p>Insert poll worker card into VxMark to print the report.</p>
           )}
         </CenteredLargeProse>
-        {printableReport}
       </ScreenMainCenterChild>
     );
   }
 
   if (pollWorkerFlowState === PollWorkerFlowState.EITHER_FLOW__REPRINTING) {
     return (
-      <React.Fragment>
-        <ScreenMainCenterChild infoBarMode="pollworker">
-          <IndeterminateProgressBar />
-          <CenteredLargeProse>
-            <h1>Printing Report…</h1>
-          </CenteredLargeProse>
-        </ScreenMainCenterChild>
-        {printableReport}
-      </React.Fragment>
+      <ScreenMainCenterChild infoBarMode="pollworker">
+        <IndeterminateProgressBar />
+        <CenteredLargeProse>
+          <h1>Printing Report…</h1>
+        </CenteredLargeProse>
+      </ScreenMainCenterChild>
     );
   }
   return (
-    <React.Fragment>
-      <ScreenMainCenterChild infoBarMode="pollworker">
-        <Prose textCenter>
-          <h1>Poll Worker Actions</h1>
+    <ScreenMainCenterChild infoBarMode="pollworker">
+      <Prose textCenter>
+        <h1>Poll Worker Actions</h1>
+        <p>
+          {isPollsOpen ? (
+            <Button primary large onPress={closePolls}>
+              Close Polls for {precinctName}
+            </Button>
+          ) : (
+            <Button primary large onPress={openPolls}>
+              Open Polls for {precinctName}
+            </Button>
+          )}
+        </p>
+        {!isPollsOpen && scannedBallotCount > 0 && (
           <p>
-            {isPollsOpen ? (
-              <Button primary large onPress={closePolls}>
-                Close Polls for {precinctName}
-              </Button>
-            ) : (
-              <Button primary large onPress={openPolls}>
-                Open Polls for {precinctName}
-              </Button>
-            )}
+            <Button onPress={() => setIsExportingResults(true)}>
+              Save Results to USB Drive
+            </Button>
           </p>
-          {!isPollsOpen && scannedBallotCount > 0 && (
-            <p>
-              <Button onPress={() => setIsExportingResults(true)}>
-                Save Results to USB Drive
-              </Button>
-            </p>
-          )}
-          {isFeatureFlagEnabled(EnvironmentFlagName.LIVECHECK) && (
-            <p>
-              <Button onPress={() => setIsShowingLiveCheck(true)}>
-                Live Check
-              </Button>
-            </p>
-          )}
-        </Prose>
-        <ScannedBallotCount count={scannedBallotCount} />
-        {isExportingResults && (
-          <ExportResultsModal
-            onClose={() => setIsExportingResults(false)}
-            usbDrive={usbDrive}
-            isTestMode={!isLiveMode}
-            scannedBallotCount={scannedBallotCount}
-          />
         )}
-        {isShowingLiveCheck && (
-          <LiveCheckModal onClose={() => setIsShowingLiveCheck(false)} />
+        {isFeatureFlagEnabled(EnvironmentFlagName.LIVECHECK) && (
+          <p>
+            <Button onPress={() => setIsShowingLiveCheck(true)}>
+              Live Check
+            </Button>
+          </p>
         )}
-      </ScreenMainCenterChild>
-      {printableReport}
-    </React.Fragment>
+      </Prose>
+      <ScannedBallotCount count={scannedBallotCount} />
+      {isExportingResults && (
+        <ExportResultsModal
+          onClose={() => setIsExportingResults(false)}
+          usbDrive={usbDrive}
+          isTestMode={!isLiveMode}
+          scannedBallotCount={scannedBallotCount}
+        />
+      )}
+      {isShowingLiveCheck && (
+        <LiveCheckModal onClose={() => setIsShowingLiveCheck(false)} />
+      )}
+    </ScreenMainCenterChild>
   );
 }

--- a/frontends/precinct-scanner/src/setupTests.ts
+++ b/frontends/precinct-scanner/src/setupTests.ts
@@ -4,6 +4,7 @@ import '@testing-library/jest-dom/extend-expect';
 import { TextDecoder, TextEncoder } from 'util';
 
 import { configure } from '@testing-library/react';
+import { expectAllPrintsTested } from '@votingworks/test-utils';
 
 configure({ asyncUtilTimeout: 5_000 });
 
@@ -11,6 +12,10 @@ beforeEach(() => {
   jestFetchMock.enableMocks();
   fetchMock.reset();
   fetchMock.mock();
+});
+
+afterEach(() => {
+  expectAllPrintsTested();
 });
 
 globalThis.TextDecoder = TextDecoder as typeof globalThis.TextDecoder;

--- a/frontends/precinct-scanner/tsconfig.json
+++ b/frontends/precinct-scanner/tsconfig.json
@@ -14,7 +14,7 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": false
   },
-  "include": ["src", "test", "types"],
+  "include": ["src", "test", "types", "__mocks__"],
   "exclude": ["src/setupProxy.js"],
   "references": [
     { "path": "../../libs/api/tsconfig.build.json" },

--- a/libs/test-utils/src/expect_print.ts
+++ b/libs/test-utils/src/expect_print.ts
@@ -1,0 +1,100 @@
+import { render, RenderResult } from '@testing-library/react';
+import { Optional, Printer, PrintOptions } from '@votingworks/types';
+import { advanceTimersAndPromises } from './advance_timers';
+import { assert } from './assert';
+
+export const fakePrintElement = jest.fn(
+  (_element: JSX.Element, printer: Printer, printOptions: PrintOptions) => {
+    return printer.print(printOptions);
+  }
+);
+
+export const fakePrintElementWhenReady = jest.fn(
+  async (
+    renderElement: (onReadyToPrint: () => void) => JSX.Element,
+    printer: Printer,
+    printOptions: PrintOptions
+  ) => {
+    return printer.print(printOptions);
+  }
+);
+
+async function inspectPrintedElement(
+  inspect: (renderResult: RenderResult) => void
+): Promise<void> {
+  await advanceTimersAndPromises();
+  const lastCall =
+    fakePrintElement.mock.calls[fakePrintElement.mock.calls.length - 1];
+  assert(lastCall, 'no printed element to inspect');
+
+  const renderResult = render(lastCall[0]);
+  inspect(renderResult);
+
+  renderResult.unmount();
+  await advanceTimersAndPromises(0);
+}
+
+async function inspectPrintedElementWhenReady(
+  inspect: (renderResult: RenderResult) => void
+): Promise<void> {
+  const lastCall =
+    fakePrintElementWhenReady.mock.calls[
+      fakePrintElementWhenReady.mock.calls.length - 1
+    ];
+  assert(lastCall, 'no printed element to inspect');
+  const renderElement = lastCall[0];
+
+  let renderResult: Optional<RenderResult>;
+  const renderedPromise = new Promise<void>((resolve) => {
+    renderResult = render(renderElement(resolve));
+  });
+  /**
+   * We have to advance promises here to allow effects to run before
+   * running assertion the rendered element.
+   */
+  await advanceTimersAndPromises();
+  await renderedPromise;
+  assert(renderResult);
+  inspect(renderResult);
+
+  renderResult.unmount();
+}
+
+export async function expectPrint(
+  inspect?: (renderResult: RenderResult) => void
+): Promise<void> {
+  await advanceTimersAndPromises();
+
+  const numPrints =
+    fakePrintElementWhenReady.mock.calls.length +
+    fakePrintElement.mock.calls.length;
+
+  if (numPrints === 0) {
+    throw new Error('nothing has been printed');
+  }
+
+  if (numPrints > 1) {
+    throw new Error('there have been multiple prints');
+  }
+
+  if (inspect) {
+    if (fakePrintElement.mock.calls.length) {
+      await inspectPrintedElement(inspect);
+    } else {
+      await inspectPrintedElementWhenReady(inspect);
+    }
+  }
+
+  fakePrintElement.mockClear();
+  fakePrintElementWhenReady.mockClear();
+}
+
+export function expectAllPrintsTested(): void {
+  const numPrints =
+    fakePrintElementWhenReady.mock.calls.length +
+    fakePrintElement.mock.calls.length;
+
+  if (numPrints !== 0) {
+    throw new Error(`${numPrints} untested print(s) in this test`);
+  }
+}

--- a/libs/test-utils/src/index.ts
+++ b/libs/test-utils/src/index.ts
@@ -11,3 +11,4 @@ export * from './smartcards';
 export * from './smartcard_auth';
 export * from './zip';
 export * from './mock_of';
+export * from './expect_print';

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -72,6 +72,7 @@
     "@types/node": "16.11.29",
     "@types/pluralize": "^0.0.29",
     "@types/react": "17.0.39",
+    "@types/react-dom": "^18.0.6",
     "@types/styled-components": "^5.1.9",
     "@types/testing-library__jest-dom": "^5.14.3",
     "@typescript-eslint/eslint-plugin": "^5.37.0",

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -55,3 +55,4 @@ export * from './unlock_machine_screen';
 export * from './system_administrator_screen_contents';
 export * from './unconfigure_machine_button';
 export * from './print_element';
+export * from './precinct_scanner_full_report';

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -54,3 +54,4 @@ export { InvalidCardScreen } from './invalid_card_screen';
 export * from './unlock_machine_screen';
 export * from './system_administrator_screen_contents';
 export * from './unconfigure_machine_button';
+export * from './print_element';

--- a/libs/ui/src/precinct_scanner_full_report.test.tsx
+++ b/libs/ui/src/precinct_scanner_full_report.test.tsx
@@ -1,0 +1,216 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import {
+  electionFamousNames2021Fixtures,
+  electionMinimalExhaustiveSampleDefinition,
+  electionMinimalExhaustiveSampleWithReportingUrlDefinition,
+} from '@votingworks/fixtures';
+import { FullElectionTally } from '@votingworks/types';
+import {
+  ALL_PRECINCTS_SELECTION,
+  getEmptyTally,
+  getSubTalliesByPartyAndPrecinct,
+  singlePrecinctSelectionFor,
+} from '@votingworks/utils';
+import { PrecinctScannerFullReport } from './precinct_scanner_full_report';
+
+test('renders report for each party in primary, single precinct', () => {
+  const { election } = electionMinimalExhaustiveSampleDefinition;
+  const precinctSelection = singlePrecinctSelectionFor('precinct-1');
+  const tally: FullElectionTally = {
+    overallTally: getEmptyTally(),
+    resultsByCategory: new Map(),
+  };
+  const subTallies = getSubTalliesByPartyAndPrecinct({
+    election,
+    tally,
+    precinctSelection,
+  });
+  render(
+    <PrecinctScannerFullReport
+      electionDefinition={electionMinimalExhaustiveSampleDefinition}
+      precinctSelectionList={[precinctSelection]}
+      subTallies={subTallies}
+      isPollsOpen={false}
+      isLiveMode
+      pollsToggledTime={new Date().getTime()}
+      currentTime={new Date().getTime()}
+      precinctScannerMachineId="SC-01-000"
+      totalBallotsScanned={1} // to trigger qr code page
+      signedQuickResultsReportingUrl="https://voting.works"
+    />
+  );
+
+  expect(
+    screen.getAllByText('Official Polls Closed Report for Precinct 1')
+  ).toHaveLength(2);
+  screen.getByText('Mammal Party Example Primary Election:');
+  screen.getByText('Fish Party Example Primary Election:');
+  expect(
+    screen.queryByText('Automatic Election Results Reporting')
+  ).not.toBeInTheDocument();
+});
+
+test('renders report for each precinct when there is data for all precincts', () => {
+  const { electionDefinition } = electionFamousNames2021Fixtures;
+  const { election } = electionDefinition;
+  const tally: FullElectionTally = {
+    overallTally: getEmptyTally(),
+    resultsByCategory: new Map(),
+  };
+  const subTallies = getSubTalliesByPartyAndPrecinct({
+    election,
+    tally,
+    precinctSelection: ALL_PRECINCTS_SELECTION,
+  });
+  render(
+    <PrecinctScannerFullReport
+      electionDefinition={electionDefinition}
+      precinctSelectionList={election.precincts.map((precinct) =>
+        singlePrecinctSelectionFor(precinct.id)
+      )}
+      subTallies={subTallies}
+      isPollsOpen={false}
+      isLiveMode
+      pollsToggledTime={new Date().getTime()}
+      currentTime={new Date().getTime()}
+      precinctScannerMachineId="SC-01-000"
+      totalBallotsScanned={0}
+      signedQuickResultsReportingUrl="https://voting.works"
+    />
+  );
+
+  screen.getByText('Official Polls Closed Report for North Lincoln');
+  screen.getByText('Official Polls Closed Report for West Lincoln');
+  screen.getByText('Official Polls Closed Report for East Lincoln');
+  screen.getByText('Official Polls Closed Report for South Lincoln');
+  expect(
+    screen.queryByText('Automatic Election Results Reporting')
+  ).not.toBeInTheDocument();
+});
+
+test('renders report for "All Precincts" when there is only data for all precincts', () => {
+  const { electionDefinition } = electionFamousNames2021Fixtures;
+  const { election } = electionDefinition;
+  const tally: FullElectionTally = {
+    overallTally: getEmptyTally(),
+    resultsByCategory: new Map(),
+  };
+  const subTallies = getSubTalliesByPartyAndPrecinct({
+    election,
+    tally,
+  });
+  render(
+    <PrecinctScannerFullReport
+      electionDefinition={electionDefinition}
+      precinctSelectionList={[ALL_PRECINCTS_SELECTION]}
+      subTallies={subTallies}
+      isPollsOpen={false}
+      isLiveMode
+      pollsToggledTime={new Date().getTime()}
+      currentTime={new Date().getTime()}
+      precinctScannerMachineId="SC-01-000"
+      totalBallotsScanned={0}
+      signedQuickResultsReportingUrl="https://voting.works"
+    />
+  );
+
+  screen.getByText('Official Polls Closed Report for All Precincts');
+  expect(
+    screen.queryByText('Automatic Election Results Reporting')
+  ).not.toBeInTheDocument();
+});
+
+test('renders quick results page under right conditions', () => {
+  const { election } =
+    electionMinimalExhaustiveSampleWithReportingUrlDefinition;
+  const tally: FullElectionTally = {
+    overallTally: getEmptyTally(),
+    resultsByCategory: new Map(),
+  };
+  const subTallies = getSubTalliesByPartyAndPrecinct({
+    election,
+    tally,
+  });
+  render(
+    <PrecinctScannerFullReport
+      electionDefinition={
+        electionMinimalExhaustiveSampleWithReportingUrlDefinition
+      }
+      precinctSelectionList={[ALL_PRECINCTS_SELECTION]}
+      subTallies={subTallies}
+      isPollsOpen={false} // to trigger qrcode
+      isLiveMode
+      pollsToggledTime={new Date().getTime()}
+      currentTime={new Date().getTime()}
+      precinctScannerMachineId="SC-01-000"
+      totalBallotsScanned={1} // to trigger qrcode
+      signedQuickResultsReportingUrl="https://voting.works"
+    />
+  );
+
+  screen.getByText('Automatic Election Results Reporting');
+});
+
+test('does not render quick results if ballot count is 0', () => {
+  const { election } =
+    electionMinimalExhaustiveSampleWithReportingUrlDefinition;
+  const tally: FullElectionTally = {
+    overallTally: getEmptyTally(),
+    resultsByCategory: new Map(),
+  };
+  const subTallies = getSubTalliesByPartyAndPrecinct({ election, tally });
+  render(
+    <PrecinctScannerFullReport
+      electionDefinition={
+        electionMinimalExhaustiveSampleWithReportingUrlDefinition
+      }
+      precinctSelectionList={[ALL_PRECINCTS_SELECTION]}
+      subTallies={subTallies}
+      isPollsOpen={false} // to trigger qrcode
+      isLiveMode
+      pollsToggledTime={new Date().getTime()}
+      currentTime={new Date().getTime()}
+      precinctScannerMachineId="SC-01-000"
+      totalBallotsScanned={0} // to disable qrcode
+      signedQuickResultsReportingUrl="https://voting.works"
+    />
+  );
+
+  expect(
+    screen.queryByText('Automatic Election Results Reporting')
+  ).not.toBeInTheDocument();
+});
+
+test('does not render quick results if polls are open', () => {
+  const { election } =
+    electionMinimalExhaustiveSampleWithReportingUrlDefinition;
+  const tally: FullElectionTally = {
+    overallTally: getEmptyTally(),
+    resultsByCategory: new Map(),
+  };
+  const subTallies = getSubTalliesByPartyAndPrecinct({
+    election,
+    tally,
+  });
+  render(
+    <PrecinctScannerFullReport
+      electionDefinition={
+        electionMinimalExhaustiveSampleWithReportingUrlDefinition
+      }
+      precinctSelectionList={[ALL_PRECINCTS_SELECTION]}
+      subTallies={subTallies}
+      isPollsOpen // to disable qrcode
+      isLiveMode
+      pollsToggledTime={new Date().getTime()}
+      currentTime={new Date().getTime()}
+      precinctScannerMachineId="SC-01-000"
+      totalBallotsScanned={1} // to trigger qrcode
+      signedQuickResultsReportingUrl="https://voting.works"
+    />
+  );
+
+  expect(
+    screen.queryByText('Automatic Election Results Reporting')
+  ).not.toBeInTheDocument();
+});

--- a/libs/ui/src/precinct_scanner_full_report.tsx
+++ b/libs/ui/src/precinct_scanner_full_report.tsx
@@ -1,0 +1,81 @@
+import {
+  ElectionDefinition,
+  getPartyIdsInBallotStyles,
+  PrecinctSelection,
+  Tally,
+} from '@votingworks/types';
+import { assert, getTallyIdentifier } from '@votingworks/utils';
+import React from 'react';
+import { PrecinctScannerTallyQrCode } from './precinct_scanner_tally_qrcode';
+import { PrecinctScannerTallyReport } from './precinct_scanner_tally_report';
+
+export interface PrecinctScannerFullReportProps {
+  electionDefinition: ElectionDefinition;
+  precinctSelectionList: PrecinctSelection[];
+  subTallies: ReadonlyMap<string, Tally>;
+  isPollsOpen: boolean;
+  isLiveMode: boolean;
+  pollsToggledTime: number;
+  currentTime: number;
+  precinctScannerMachineId: string;
+  signedQuickResultsReportingUrl: string;
+  totalBallotsScanned: number;
+}
+
+export function PrecinctScannerFullReport({
+  electionDefinition,
+  precinctSelectionList,
+  subTallies,
+  isPollsOpen,
+  isLiveMode,
+  pollsToggledTime,
+  currentTime,
+  precinctScannerMachineId,
+  signedQuickResultsReportingUrl,
+  totalBallotsScanned,
+}: PrecinctScannerFullReportProps): JSX.Element {
+  const parties = getPartyIdsInBallotStyles(electionDefinition.election);
+  const showQuickResults =
+    electionDefinition.election.quickResultsReportingUrl &&
+    totalBallotsScanned > 0 &&
+    !isPollsOpen;
+
+  return (
+    <React.Fragment>
+      {precinctSelectionList.map((precinctSelection) =>
+        parties.map((partyId) => {
+          const tallyIdentifier = getTallyIdentifier(
+            partyId,
+            precinctSelection.kind === 'SinglePrecinct'
+              ? precinctSelection.precinctId
+              : undefined
+          );
+          const tallyForReport = subTallies.get(tallyIdentifier);
+          assert(tallyForReport);
+          return (
+            <PrecinctScannerTallyReport
+              key={tallyIdentifier}
+              electionDefinition={electionDefinition}
+              tally={tallyForReport}
+              precinctSelection={precinctSelection}
+              partyId={partyId}
+              isPollsOpen={isPollsOpen}
+              isLiveMode={isLiveMode}
+              pollsToggledTime={pollsToggledTime}
+              currentTime={currentTime}
+              precinctScannerMachineId={precinctScannerMachineId}
+            />
+          );
+        })
+      )}
+      {showQuickResults && (
+        <PrecinctScannerTallyQrCode
+          pollsToggledTime={pollsToggledTime}
+          election={electionDefinition.election}
+          isPollsOpen={isPollsOpen}
+          signedQuickResultsReportingUrl={signedQuickResultsReportingUrl}
+        />
+      )}
+    </React.Fragment>
+  );
+}

--- a/libs/ui/src/print_element.test.tsx
+++ b/libs/ui/src/print_element.test.tsx
@@ -1,0 +1,93 @@
+import React, { useEffect } from 'react';
+import { advanceTimersAndPromises, fakePrinter } from '@votingworks/test-utils';
+import { screen, waitFor, within } from '@testing-library/react';
+import { sleep } from '@votingworks/utils';
+import { printElement, printElementWhenReady } from './print_element';
+
+const simpleElement: JSX.Element = <p>Print me!</p>;
+
+describe('printElement', () => {
+  test('calls print with expected args', async () => {
+    const printer = fakePrinter();
+    await printElement(simpleElement, printer, { sides: 'one-sided' });
+    expect(printer.print).toHaveBeenCalledTimes(1);
+    expect(printer.print).toHaveBeenLastCalledWith(
+      expect.objectContaining({ sides: 'one-sided' })
+    );
+  });
+
+  test('renders element within print container', async () => {
+    const printer = fakePrinter();
+    const printPromise = printElement(simpleElement, printer, {
+      sides: 'one-sided',
+    });
+
+    await waitFor(async () => {
+      const printContainer = await screen.findByTestId('print-container');
+      within(printContainer).getByText('Print me!');
+    });
+
+    await printPromise;
+  });
+
+  test('removes element after print', async () => {
+    const printer = fakePrinter();
+    const printPromise = printElement(simpleElement, printer, {
+      sides: 'one-sided',
+    });
+
+    await screen.findByText('Print me!');
+    await printPromise;
+    expect(screen.queryByText('Print me!')).not.toBeInTheDocument();
+  });
+
+  test('calls print AFTER element is rendered', async () => {
+    const printer = fakePrinter();
+    const printPromise = printElement(simpleElement, printer, {
+      sides: 'one-sided',
+    });
+
+    await waitFor(() => {
+      expect(printer.print).not.toHaveBeenCalled();
+      screen.getByText('Print me!');
+    });
+
+    await printPromise;
+    expect(screen.queryByText('Print me!')).not.toBeInTheDocument();
+    expect(printer.print).toHaveBeenCalledTimes(1);
+  });
+});
+
+function SleeperElement({ afterSleep }: { afterSleep: () => void }) {
+  useEffect(() => {
+    async function sleepThenResolve() {
+      await sleep(10000);
+      afterSleep();
+    }
+    void sleepThenResolve();
+  }, [afterSleep]);
+  return simpleElement;
+}
+
+test('printElementWhenReady prints only after element uses callback', async () => {
+  jest.useFakeTimers();
+  const printer = fakePrinter();
+
+  let readyToPrintSpy = jest.fn();
+
+  function renderSleeperElement(readyToPrint: () => void) {
+    readyToPrintSpy = jest.fn(readyToPrint);
+    return <SleeperElement afterSleep={readyToPrintSpy} />;
+  }
+
+  const printPromise = printElementWhenReady(renderSleeperElement, printer, {
+    sides: 'one-sided',
+  });
+
+  while (readyToPrintSpy.mock.calls.length === 0) {
+    expect(printer.print).not.toHaveBeenCalled();
+    await advanceTimersAndPromises(1);
+  }
+  await printPromise;
+  expect(printer.print).toHaveBeenCalledTimes(1);
+});

--- a/libs/ui/src/print_element.tsx
+++ b/libs/ui/src/print_element.tsx
@@ -1,0 +1,73 @@
+import React, { useEffect } from 'react';
+import ReactDom from 'react-dom';
+import styled from 'styled-components';
+
+import { Printer, PrintOptions } from '@votingworks/types';
+
+const PrintStyles = styled.div`
+  display: none;
+  @media print {
+    display: block;
+  }
+`;
+
+// Render an element and print it. The function to render the element takes an
+// onReadyToPrint callback to indicate when the component has finished rendering
+// and is ready to be printed. This accommodates components that may want to do
+// multiple renders or post-processing before being ready to print.
+export async function printElementWhenReady(
+  renderElement: (onReadyToPrint: () => void) => JSX.Element,
+  printer: Printer,
+  printOptions: PrintOptions
+): Promise<void> {
+  const printContainer = document.createElement('div');
+  printContainer.dataset['testid'] = 'print-container';
+  document.body.appendChild(printContainer);
+
+  return new Promise<void>((resolve) => {
+    async function onReadyToPrint() {
+      await printer.print(printOptions);
+      ReactDom.unmountComponentAtNode(printContainer);
+      printContainer.remove();
+      resolve();
+    }
+    ReactDom.render(
+      <PrintStyles>{renderElement(onReadyToPrint)}</PrintStyles>,
+      printContainer
+    );
+  });
+}
+
+// Wrapper component to give a regular component an "onRendered"
+// callback prop that will get called after the first render of
+// the component finishes.
+export function WrapperWithCallbackAfterFirstRender({
+  children,
+  onRendered,
+}: {
+  children: JSX.Element;
+  onRendered: () => void;
+}): JSX.Element {
+  useEffect(() => {
+    onRendered();
+  }, [onRendered]);
+  return children;
+}
+
+// Function for printing regular React components that are ready to print
+// after their initial render.
+export function printElement(
+  element: JSX.Element,
+  printer: Printer,
+  printOptions: PrintOptions
+): Promise<void> {
+  return printElementWhenReady(
+    (readyToPrint) => (
+      <WrapperWithCallbackAfterFirstRender onRendered={readyToPrint}>
+        {element}
+      </WrapperWithCallbackAfterFirstRender>
+    ),
+    printer,
+    printOptions
+  );
+}

--- a/libs/utils/src/tallies.test.ts
+++ b/libs/utils/src/tallies.test.ts
@@ -1,8 +1,19 @@
-import { electionSample } from '@votingworks/fixtures';
-import { ContestTally } from '@votingworks/types';
+import {
+  electionFamousNames2021Fixtures,
+  electionMinimalExhaustiveSample,
+  electionSample,
+} from '@votingworks/fixtures';
+import { ContestTally, FullElectionTally } from '@votingworks/types';
 import { assert } from './assert';
-import { tallyVotesByContest } from './votes';
-import { combineContestTallies } from './tallies';
+import { getEmptyTally, tallyVotesByContest } from './votes';
+import {
+  combineContestTallies,
+  getSubTalliesByPartyAndPrecinct,
+} from './tallies';
+import {
+  ALL_PRECINCTS_SELECTION,
+  singlePrecinctSelectionFor,
+} from './precinct_selection';
 
 test('combineContestTallies adds tallies together', () => {
   const contestZeroTallies = tallyVotesByContest({
@@ -26,4 +37,43 @@ test('combineContestTallies adds tallies together', () => {
       combineContestTallies(contestZeroTally, contestUndefinedTally)
     ).toEqual(contestZeroTally);
   }
+});
+
+const emptyTally: FullElectionTally = {
+  overallTally: getEmptyTally(),
+  resultsByCategory: new Map(),
+};
+describe('getSubTalliesByPartyAndPrecinct', () => {
+  test('primary election and no precinct specific data', () => {
+    const subTallies = getSubTalliesByPartyAndPrecinct({
+      election: electionMinimalExhaustiveSample,
+      tally: emptyTally,
+    });
+
+    expect(Array.from(subTallies.keys()).sort()).toMatchObject(
+      ['0,__ALL_PRECINCTS', '1,__ALL_PRECINCTS'].sort()
+    );
+  });
+
+  test('general election and all precincts specific data', () => {
+    const subTallies = getSubTalliesByPartyAndPrecinct({
+      election: electionFamousNames2021Fixtures.election,
+      tally: emptyTally,
+      precinctSelection: ALL_PRECINCTS_SELECTION,
+    });
+
+    expect(Array.from(subTallies.keys()).sort()).toMatchObject(
+      ['undefined,20', 'undefined,21', 'undefined,22', 'undefined,23'].sort()
+    );
+  });
+
+  test('general election and single precinct data', () => {
+    const subTallies = getSubTalliesByPartyAndPrecinct({
+      election: electionFamousNames2021Fixtures.election,
+      tally: emptyTally,
+      precinctSelection: singlePrecinctSelectionFor('20'),
+    });
+
+    expect(Array.from(subTallies.keys())).toMatchObject(['undefined,20']);
+  });
 });

--- a/libs/utils/src/tallies.ts
+++ b/libs/utils/src/tallies.ts
@@ -2,8 +2,15 @@ import {
   ContestOptionTally,
   ContestTally,
   Dictionary,
+  Election,
+  FullElectionTally,
+  getPartyIdsInBallotStyles,
+  PrecinctSelection,
+  Tally,
 } from '@votingworks/types';
 import { assert } from './assert';
+import { getTallyIdentifier } from './compressed_tallies';
+import { filterTalliesByParams } from './votes';
 
 export function combineContestTallies(
   firstTally: ContestTally,
@@ -32,4 +39,32 @@ export function combineContestTallies(
       ballots: firstTally.metadata.ballots + secondTally.metadata.ballots,
     },
   };
+}
+
+export function getSubTalliesByPartyAndPrecinct({
+  election,
+  tally,
+  precinctSelection,
+}: {
+  election: Election;
+  tally: FullElectionTally;
+  precinctSelection?: PrecinctSelection;
+}): Map<string, Tally> {
+  const newSubTallies = new Map();
+  const precinctIdList = precinctSelection
+    ? precinctSelection.kind === 'AllPrecincts'
+      ? election.precincts.map(({ id }) => id)
+      : [precinctSelection.precinctId]
+    : [undefined];
+
+  for (const partyId of getPartyIdsInBallotStyles(election)) {
+    for (const precinctId of precinctIdList) {
+      const filteredTally = filterTalliesByParams(tally, election, {
+        precinctId,
+        partyId,
+      });
+      newSubTallies.set(getTallyIdentifier(partyId, precinctId), filteredTally);
+    }
+  }
+  return newSubTallies;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,7 +297,7 @@ importers:
       file-loader: 6.1.1
       fs-extra: 9.1.0
       history: 4.10.1
-      http-proxy-middleware: 1.0.6_debug@4.3.2
+      http-proxy-middleware: 1.0.6
       identity-obj-proxy: 3.0.0
       lodash.camelcase: 4.3.0
       luxon: 1.26.0
@@ -769,7 +769,7 @@ importers:
       fs-extra: 9.1.0
       history: 4.10.1
       html-webpack-plugin: 4.5.0_webpack@4.44.2
-      http-proxy-middleware: 1.0.6_debug@4.3.2
+      http-proxy-middleware: 1.0.6
       i18next: 19.8.4
       identity-obj-proxy: 3.0.0
       js-file-download: 0.4.12
@@ -862,8 +862,8 @@ importers:
       express: 4.18.1
       glob: 8.0.3
       is-ci-cli: 2.1.2
-      jest: 26.6.0_canvas@2.9.1
-      jest-circus: 26.6.0_canvas@2.9.1
+      jest: 26.6.0
+      jest-circus: 26.6.0
       jest-environment-jsdom-sixteen: 1.0.3_canvas@2.9.1
       jest-junit: 14.0.1
       jest-resolve: 26.6.0
@@ -1078,7 +1078,7 @@ importers:
       dotenv-expand: 5.1.0
       events: 3.3.0
       fetch-mock: 9.11.0
-      http-proxy-middleware: 1.0.6_debug@4.3.1
+      http-proxy-middleware: 1.0.6
       i18next: 19.8.4
       jest-fetch-mock: 3.0.3
       js-file-download: 0.4.12
@@ -2362,7 +2362,7 @@ importers:
       typescript: 4.6.3
   libs/test-utils:
     dependencies:
-      '@testing-library/react': 12.1.5_react-dom@17.0.1+react@17.0.1
+      '@testing-library/react': 12.1.5_react-dom@17.0.1+react@17.0.2
       '@types/node': 16.11.29
       '@votingworks/types': link:../types
       buffer: 6.0.3
@@ -2391,8 +2391,8 @@ importers:
       jest-watch-typeahead: 0.6.5_jest@27.3.1
       lint-staged: 11.0.0
       prettier: 2.6.2
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      react: 17.0.2
+      react-dom: 17.0.1_react@17.0.2
       sort-package-json: 1.50.0
       ts-jest: 27.0.7_1dcf3a5c8307703c73427a631f3faf30
       typescript: 4.6.3
@@ -2531,6 +2531,7 @@ importers:
       '@types/node': 16.11.29
       '@types/pluralize': 0.0.29
       '@types/react': 17.0.39
+      '@types/react-dom': 18.0.6
       '@types/styled-components': 5.1.9
       '@types/testing-library__jest-dom': 5.14.3
       '@typescript-eslint/eslint-plugin': 5.37.0_12e0d3a13edabf2ba2a66fb9092035af
@@ -2585,6 +2586,7 @@ importers:
       '@types/node': 16.11.29
       '@types/pluralize': ^0.0.29
       '@types/react': 17.0.39
+      '@types/react-dom': ^18.0.6
       '@types/react-modal': ^3.13.1
       '@types/react-router-dom': ^5.1.7
       '@types/styled-components': ^5.1.9
@@ -2926,7 +2928,7 @@ importers:
       eslint-plugin-vx: link:../../libs/eslint-plugin-vx
       fast-check: 2.23.2
       is-ci-cli: 2.1.2
-      jest: 26.6.3_canvas@2.9.1
+      jest: 26.6.3
       jest-junit: 14.0.1
       jest-watch-typeahead: 0.6.4_jest@26.6.3
       lint-staged: 10.5.3
@@ -9121,43 +9123,6 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==
-  /@jest/core/26.6.3_canvas@2.9.1:
-    dependencies:
-      '@jest/console': 26.6.2
-      '@jest/reporters': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/transform': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/node': 17.0.36
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.10
-      jest-changed-files: 26.6.2
-      jest-config: 26.6.3_canvas@2.9.1
-      jest-haste-map: 26.6.2
-      jest-message-util: 26.6.2
-      jest-regex-util: 26.0.0
-      jest-resolve: 26.6.2
-      jest-resolve-dependencies: 26.6.3
-      jest-runner: 26.6.3_canvas@2.9.1
-      jest-runtime: 26.6.3_canvas@2.9.1
-      jest-snapshot: 26.6.2
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      jest-watcher: 26.6.2
-      micromatch: 4.0.5
-      p-each-series: 2.2.0
-      rimraf: 3.0.2
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      canvas: '*'
-    resolution:
-      integrity: sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==
   /@jest/core/27.3.1:
     dependencies:
       '@jest/console': 27.3.1
@@ -9218,7 +9183,7 @@ packages:
       jest-regex-util: 27.0.6
       jest-resolve: 27.3.1
       jest-resolve-dependencies: 27.3.1
-      jest-runner: 27.3.1_canvas@2.9.1
+      jest-runner: 27.3.1
       jest-runtime: 27.3.1
       jest-snapshot: 27.3.1
       jest-util: 27.3.1
@@ -9339,7 +9304,7 @@ packages:
       jest-regex-util: 27.5.1
       jest-resolve: 27.5.1
       jest-resolve-dependencies: 27.5.1
-      jest-runner: 27.5.1_canvas@2.9.1
+      jest-runner: 27.5.1
       jest-runtime: 27.5.1
       jest-snapshot: 27.5.1
       jest-util: 27.5.1
@@ -9952,20 +9917,6 @@ packages:
     dev: true
     engines:
       node: '>= 10.14.2'
-    resolution:
-      integrity: sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==
-  /@jest/test-sequencer/26.6.3_canvas@2.9.1:
-    dependencies:
-      '@jest/test-result': 26.6.2
-      graceful-fs: 4.2.10
-      jest-haste-map: 26.6.2
-      jest-runner: 26.6.3_canvas@2.9.1
-      jest-runtime: 26.6.3_canvas@2.9.1
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      canvas: '*'
     resolution:
       integrity: sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==
   /@jest/test-sequencer/27.3.1:
@@ -10974,6 +10925,21 @@ packages:
       react-dom: <18.0.0
     resolution:
       integrity: sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==
+  /@testing-library/react/12.1.5_react-dom@17.0.1+react@17.0.2:
+    dependencies:
+      '@babel/runtime': 7.17.9
+      '@testing-library/dom': 8.11.3
+      '@types/react-dom': 17.0.13
+      react: 17.0.2
+      react-dom: 17.0.1_react@17.0.2
+    dev: false
+    engines:
+      node: '>=12'
+    peerDependencies:
+      react: <18.0.0
+      react-dom: <18.0.0
+    resolution:
+      integrity: sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==
   /@testing-library/user-event/12.6.0:
     dependencies:
       '@babel/runtime': 7.12.5
@@ -11626,6 +11592,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-wIvGxLfgpVDSAMH5utdL9Ngm5Owu0VsGmldro3ORLXV8CShrL8awVj06NuEXFQ5xyaYfdca7Sgbk/50Ri1GdPg==
+  /@types/react-dom/18.0.6:
+    dependencies:
+      '@types/react': 17.0.39
+    dev: true
+    resolution:
+      integrity: sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==
   /@types/react-gamepad/1.0.0:
     dependencies:
       '@types/react': 17.0.0
@@ -13349,7 +13321,7 @@ packages:
       integrity: sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==
   /axios/0.21.1_debug@4.3.1:
     dependencies:
-      follow-redirects: 1.14.1_debug@4.3.1
+      follow-redirects: 1.14.1_debug@4.3.4
     dev: false
     peerDependencies:
       debug: '*'
@@ -20646,6 +20618,7 @@ packages:
   /follow-redirects/1.14.1_debug@4.3.2:
     dependencies:
       debug: 4.3.2
+    dev: true
     engines:
       node: '>=4.0'
     peerDependencies:
@@ -21709,34 +21682,6 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
-  /http-proxy-middleware/1.0.6_debug@4.3.1:
-    dependencies:
-      '@types/http-proxy': 1.17.6
-      http-proxy: 1.18.1_debug@4.3.1
-      is-glob: 4.0.1
-      lodash: 4.17.21
-      micromatch: 4.0.4
-    dev: false
-    engines:
-      node: '>=8.0.0'
-    peerDependencies:
-      debug: '*'
-    resolution:
-      integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
-  /http-proxy-middleware/1.0.6_debug@4.3.2:
-    dependencies:
-      '@types/http-proxy': 1.17.6
-      http-proxy: 1.18.1_debug@4.3.2
-      is-glob: 4.0.1
-      lodash: 4.17.21
-      micromatch: 4.0.4
-    dev: false
-    engines:
-      node: '>=8.0.0'
-    peerDependencies:
-      debug: '*'
-    resolution:
-      integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
   /http-proxy/1.18.1:
     dependencies:
       eventemitter3: 4.0.7
@@ -21745,30 +21690,6 @@ packages:
     dev: false
     engines:
       node: '>=8.0.0'
-    resolution:
-      integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
-  /http-proxy/1.18.1_debug@4.3.1:
-    dependencies:
-      eventemitter3: 4.0.7
-      follow-redirects: 1.14.1_debug@4.3.1
-      requires-port: 1.0.0
-    dev: false
-    engines:
-      node: '>=8.0.0'
-    peerDependencies:
-      debug: '*'
-    resolution:
-      integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
-  /http-proxy/1.18.1_debug@4.3.2:
-    dependencies:
-      eventemitter3: 4.0.7
-      follow-redirects: 1.14.1_debug@4.3.2
-      requires-port: 1.0.0
-    dev: false
-    engines:
-      node: '>=8.0.0'
-    peerDependencies:
-      debug: '*'
     resolution:
       integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
   /http-proxy/1.18.1_debug@4.3.4:
@@ -22796,37 +22717,6 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-L2/Y9szN6FJPWFK8kzWXwfp+FOR7xq0cUL4lIsdbIdwz3Vh6P1nrpcqOleSzr28zOtSHQNV9Z7Tl+KkuK7t5Ng==
-  /jest-circus/26.6.0_canvas@2.9.1:
-    dependencies:
-      '@babel/traverse': 7.18.2
-      '@jest/environment': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/babel__traverse': 7.17.1
-      '@types/node': 17.0.36
-      chalk: 4.1.2
-      co: 4.6.0
-      dedent: 0.7.0
-      expect: 26.6.2
-      is-generator-fn: 2.1.0
-      jest-each: 26.6.2
-      jest-matcher-utils: 26.6.2
-      jest-message-util: 26.6.2
-      jest-runner: 26.6.3_canvas@2.9.1
-      jest-runtime: 26.6.3_canvas@2.9.1
-      jest-snapshot: 26.6.2
-      jest-util: 26.6.2
-      prettier: 2.6.2
-      pretty-format: 26.6.2
-      stack-utils: 2.0.5
-      throat: 5.0.0
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      canvas: '*'
-    resolution:
-      integrity: sha512-L2/Y9szN6FJPWFK8kzWXwfp+FOR7xq0cUL4lIsdbIdwz3Vh6P1nrpcqOleSzr28zOtSHQNV9Z7Tl+KkuK7t5Ng==
   /jest-circus/27.3.1:
     dependencies:
       '@jest/environment': 27.3.1
@@ -22954,29 +22844,6 @@ packages:
     engines:
       node: '>= 10.14.2'
     hasBin: true
-    resolution:
-      integrity: sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
-  /jest-cli/26.6.3_canvas@2.9.1:
-    dependencies:
-      '@jest/core': 26.6.3_canvas@2.9.1
-      '@jest/test-result': 26.6.2
-      '@jest/types': 26.6.2
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.10
-      import-local: 3.1.0
-      is-ci: 2.0.0
-      jest-config: 26.6.3_canvas@2.9.1
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      prompts: 2.4.2
-      yargs: 15.4.1
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    hasBin: true
-    peerDependencies:
-      canvas: '*'
     resolution:
       integrity: sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
   /jest-cli/27.3.1:
@@ -23188,37 +23055,6 @@ packages:
         optional: true
     resolution:
       integrity: sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==
-  /jest-config/26.6.3_canvas@2.9.1:
-    dependencies:
-      '@babel/core': 7.18.2
-      '@jest/test-sequencer': 26.6.3_canvas@2.9.1
-      '@jest/types': 26.6.2
-      babel-jest: 26.6.3_@babel+core@7.18.2
-      chalk: 4.1.2
-      deepmerge: 4.2.2
-      glob: 7.2.3
-      graceful-fs: 4.2.10
-      jest-environment-jsdom: 26.6.2_canvas@2.9.1
-      jest-environment-node: 26.6.2
-      jest-get-type: 26.3.0
-      jest-jasmine2: 26.6.3_canvas@2.9.1
-      jest-regex-util: 26.0.0
-      jest-resolve: 26.6.2
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      micromatch: 4.0.5
-      pretty-format: 26.6.2
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      canvas: '*'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      ts-node:
-        optional: true
-    resolution:
-      integrity: sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==
   /jest-config/27.3.1:
     dependencies:
       '@babel/core': 7.16.0
@@ -23270,7 +23106,7 @@ packages:
       jest-jasmine2: 27.3.1
       jest-regex-util: 27.0.6
       jest-resolve: 27.3.1
-      jest-runner: 27.3.1_canvas@2.9.1
+      jest-runner: 27.3.1
       jest-util: 27.3.1
       jest-validate: 27.3.1
       micromatch: 4.0.4
@@ -23374,7 +23210,7 @@ packages:
       jest-jasmine2: 27.5.1
       jest-regex-util: 27.5.1
       jest-resolve: 27.5.1
-      jest-runner: 27.5.1_canvas@2.9.1
+      jest-runner: 27.5.1
       jest-util: 27.5.1
       jest-validate: 27.5.1
       micromatch: 4.0.5
@@ -23706,22 +23542,6 @@ packages:
     dev: true
     engines:
       node: '>= 10.14.2'
-    resolution:
-      integrity: sha512-jgPqCruTlt3Kwqg5/WVFyHIOJHsiAvhcp2qiR2QQstuG9yWox5+iHpU3ZrcBxW14T4fe5Z68jAfLRh7joCSP2Q==
-  /jest-environment-jsdom/26.6.2_canvas@2.9.1:
-    dependencies:
-      '@jest/environment': 26.6.2
-      '@jest/fake-timers': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/node': 17.0.36
-      jest-mock: 26.6.2
-      jest-util: 26.6.2
-      jsdom: 16.7.0_canvas@2.9.1
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      canvas: '*'
     resolution:
       integrity: sha512-jgPqCruTlt3Kwqg5/WVFyHIOJHsiAvhcp2qiR2QQstuG9yWox5+iHpU3ZrcBxW14T4fe5Z68jAfLRh7joCSP2Q==
   /jest-environment-jsdom/27.3.1:
@@ -24061,33 +23881,6 @@ packages:
     dev: true
     engines:
       node: '>= 10.14.2'
-    resolution:
-      integrity: sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==
-  /jest-jasmine2/26.6.3_canvas@2.9.1:
-    dependencies:
-      '@babel/traverse': 7.18.2
-      '@jest/environment': 26.6.2
-      '@jest/source-map': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/node': 17.0.36
-      chalk: 4.1.2
-      co: 4.6.0
-      expect: 26.6.2
-      is-generator-fn: 2.1.0
-      jest-each: 26.6.2
-      jest-matcher-utils: 26.6.2
-      jest-message-util: 26.6.2
-      jest-runtime: 26.6.3_canvas@2.9.1
-      jest-snapshot: 26.6.2
-      jest-util: 26.6.2
-      pretty-format: 26.6.2
-      throat: 5.0.0
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      canvas: '*'
     resolution:
       integrity: sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==
   /jest-jasmine2/27.3.1:
@@ -24755,35 +24548,6 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==
-  /jest-runner/26.6.3_canvas@2.9.1:
-    dependencies:
-      '@jest/console': 26.6.2
-      '@jest/environment': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/node': 17.0.36
-      chalk: 4.1.2
-      emittery: 0.7.2
-      exit: 0.1.2
-      graceful-fs: 4.2.10
-      jest-config: 26.6.3_canvas@2.9.1
-      jest-docblock: 26.0.0
-      jest-haste-map: 26.6.2
-      jest-leak-detector: 26.6.2
-      jest-message-util: 26.6.2
-      jest-resolve: 26.6.2
-      jest-runtime: 26.6.3_canvas@2.9.1
-      jest-util: 26.6.2
-      jest-worker: 26.6.2
-      source-map-support: 0.5.21
-      throat: 5.0.0
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      canvas: '*'
-    resolution:
-      integrity: sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==
   /jest-runner/27.3.1:
     dependencies:
       '@jest/console': 27.3.1
@@ -24811,37 +24575,6 @@ packages:
     dev: true
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
-    resolution:
-      integrity: sha512-r4W6kBn6sPr3TBwQNmqE94mPlYVn7fLBseeJfo4E2uCTmAyDFm2O5DYAQAFP7Q3YfiA/bMwg8TVsciP7k0xOww==
-  /jest-runner/27.3.1_canvas@2.9.1:
-    dependencies:
-      '@jest/console': 27.3.1
-      '@jest/environment': 27.3.1
-      '@jest/test-result': 27.3.1
-      '@jest/transform': 27.3.1
-      '@jest/types': 27.2.5
-      '@types/node': 15.3.0
-      chalk: 4.1.2
-      emittery: 0.8.1
-      exit: 0.1.2
-      graceful-fs: 4.2.10
-      jest-docblock: 27.0.6
-      jest-environment-jsdom: 27.3.1_canvas@2.9.1
-      jest-environment-node: 27.3.1
-      jest-haste-map: 27.3.1
-      jest-leak-detector: 27.3.1
-      jest-message-util: 27.3.1
-      jest-resolve: 27.3.1
-      jest-runtime: 27.3.1
-      jest-util: 27.3.1
-      jest-worker: 27.3.1
-      source-map-support: 0.5.20
-      throat: 6.0.1
-    dev: true
-    engines:
-      node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
-    peerDependencies:
-      canvas: '*'
     resolution:
       integrity: sha512-r4W6kBn6sPr3TBwQNmqE94mPlYVn7fLBseeJfo4E2uCTmAyDFm2O5DYAQAFP7Q3YfiA/bMwg8TVsciP7k0xOww==
   /jest-runner/27.4.5:
@@ -24899,36 +24632,6 @@ packages:
     dev: true
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
-    resolution:
-      integrity: sha512-g4NPsM4mFCOwFKXO4p/H/kWGdJp9V8kURY2lX8Me2drgXqG7rrZAx5kv+5H7wtt/cdFIjhqYx1HrlqWHaOvDaQ==
-  /jest-runner/27.5.1_canvas@2.9.1:
-    dependencies:
-      '@jest/console': 27.5.1
-      '@jest/environment': 27.5.1
-      '@jest/test-result': 27.5.1
-      '@jest/transform': 27.5.1
-      '@jest/types': 27.5.1
-      '@types/node': 17.0.36
-      chalk: 4.1.2
-      emittery: 0.8.1
-      graceful-fs: 4.2.10
-      jest-docblock: 27.5.1
-      jest-environment-jsdom: 27.5.1_canvas@2.9.1
-      jest-environment-node: 27.5.1
-      jest-haste-map: 27.5.1
-      jest-leak-detector: 27.5.1
-      jest-message-util: 27.5.1
-      jest-resolve: 27.5.1
-      jest-runtime: 27.5.1
-      jest-util: 27.5.1
-      jest-worker: 27.5.1
-      source-map-support: 0.5.21
-      throat: 6.0.1
-    dev: true
-    engines:
-      node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
-    peerDependencies:
-      canvas: '*'
     resolution:
       integrity: sha512-g4NPsM4mFCOwFKXO4p/H/kWGdJp9V8kURY2lX8Me2drgXqG7rrZAx5kv+5H7wtt/cdFIjhqYx1HrlqWHaOvDaQ==
   /jest-runner/28.1.3:
@@ -24992,43 +24695,6 @@ packages:
     engines:
       node: '>= 10.14.2'
     hasBin: true
-    resolution:
-      integrity: sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==
-  /jest-runtime/26.6.3_canvas@2.9.1:
-    dependencies:
-      '@jest/console': 26.6.2
-      '@jest/environment': 26.6.2
-      '@jest/fake-timers': 26.6.2
-      '@jest/globals': 26.6.2
-      '@jest/source-map': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/transform': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/yargs': 15.0.14
-      chalk: 4.1.2
-      cjs-module-lexer: 0.6.0
-      collect-v8-coverage: 1.0.1
-      exit: 0.1.2
-      glob: 7.2.3
-      graceful-fs: 4.2.10
-      jest-config: 26.6.3_canvas@2.9.1
-      jest-haste-map: 26.6.2
-      jest-message-util: 26.6.2
-      jest-mock: 26.6.2
-      jest-regex-util: 26.0.0
-      jest-resolve: 26.6.2
-      jest-snapshot: 26.6.2
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      slash: 3.0.0
-      strip-bom: 4.0.0
-      yargs: 15.4.1
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    hasBin: true
-    peerDependencies:
-      canvas: '*'
     resolution:
       integrity: sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==
   /jest-runtime/27.3.1:
@@ -25576,7 +25242,7 @@ packages:
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
-      jest: 26.6.3_canvas@2.9.1
+      jest: 26.6.3
       jest-regex-util: 27.5.1
       jest-watcher: 27.5.1
       slash: 3.0.0
@@ -25831,19 +25497,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-jxTmrvuecVISvKFFhOkjsWRZV7sFqdSUAd1ajOKY+/QE/aLBVstsJ/dX8GczLzwiT6ZEwwmZqtCUHLHHQVzcfA==
-  /jest/26.6.0_canvas@2.9.1:
-    dependencies:
-      '@jest/core': 26.6.3_canvas@2.9.1
-      import-local: 3.1.0
-      jest-cli: 26.6.3_canvas@2.9.1
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    hasBin: true
-    peerDependencies:
-      canvas: '*'
-    resolution:
-      integrity: sha512-jxTmrvuecVISvKFFhOkjsWRZV7sFqdSUAd1ajOKY+/QE/aLBVstsJ/dX8GczLzwiT6ZEwwmZqtCUHLHHQVzcfA==
   /jest/26.6.3:
     dependencies:
       '@jest/core': 26.6.3
@@ -25853,19 +25506,6 @@ packages:
     engines:
       node: '>= 10.14.2'
     hasBin: true
-    resolution:
-      integrity: sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
-  /jest/26.6.3_canvas@2.9.1:
-    dependencies:
-      '@jest/core': 26.6.3_canvas@2.9.1
-      import-local: 3.1.0
-      jest-cli: 26.6.3_canvas@2.9.1
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    hasBin: true
-    peerDependencies:
-      canvas: '*'
     resolution:
       integrity: sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
   /jest/27.3.1:
@@ -29969,6 +29609,18 @@ packages:
       object-assign: 4.1.1
       react: 17.0.1
       scheduler: 0.20.1
+    dev: false
+    peerDependencies:
+      react: 17.0.1
+    resolution:
+      integrity: sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==
+  /react-dom/17.0.1_react@17.0.2:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react: 17.0.2
+      scheduler: 0.20.1
+    dev: true
     peerDependencies:
       react: 17.0.1
     resolution:
@@ -32681,7 +32333,7 @@ packages:
       bs-logger: 0.2.6
       buffer-from: 1.1.1
       fast-json-stable-stringify: 2.1.0
-      jest: 26.6.3_canvas@2.9.1
+      jest: 26.6.3
       jest-util: 26.6.2
       json5: 2.1.3
       lodash.memoize: 4.1.2
@@ -33088,7 +32740,7 @@ packages:
       babel-jest: 26.6.3_@babel+core@7.12.3
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 26.6.0_canvas@2.9.1
+      jest: 26.6.0
       jest-util: 28.1.3
       json5: 2.2.1
       lodash.memoize: 4.1.2


### PR DESCRIPTION
Begins #1531 by creating a tool to print a `JSX` element directly. Currently, we employ two approaches:

- have document persistently rendered to page, out of view, and print on button push
- render document and print as a side effect

With this tool, you pass it a `JSX` element or a function which returns a `JSX` element with a callback. It will handle placing the element on the page, printing it at the appropriate time, and removing it from the page.

In preparation for votingworks/vxsuite-roadmap#37, I used the new tool for printing polls open and closed reports on VxMark and VxScan. 

