### PR TITLE
fix(utils): use secure RNG for PINs

### DIFF
--- a/libs/utils/src/pins.ts
+++ b/libs/utils/src/pins.ts
@@ -1,3 +1,4 @@
+import randomBytes from 'randombytes';
 import { EnvironmentFlagName } from './environment_flag';
 import { isFeatureFlagEnabled } from './features';
 
@@ -12,13 +13,14 @@ export function generatePin(length = 6): string {
     throw new Error('PIN length must be greater than 0');
   }
 
+  const bytes = randomBytes(length);
   let pin = '';
   for (let i = 0; i < length; i += 1) {
     const nextDigit = isFeatureFlagEnabled(
       EnvironmentFlagName.ALL_ZERO_SMARTCARD_PIN
     )
       ? 0
-      : Math.floor(Math.random() * 10);
+      : (bytes[i] as number) % 10;
     pin += `${nextDigit}`;
   }
   return pin;


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Fixes #2723

Uses [`randombytes`](https://www.npmjs.com/package/randombytes):

> randombytes from node that works in the browser. In node you just get `crypto.randomBytes`, but in the browser it uses `.crypto/msCrypto.getRandomValues`

## Demo Video or Screenshot
<img width="645" alt="image" src="https://user-images.githubusercontent.com/1938/197047116-bc91c4b8-9e1b-43f5-99ca-5ec3f68b2b8e.png">

## Testing Plan
Tested with `REACT_APP_VX_ENABLE_ALL_ZERO_SMARTCARD_PIN_GENERATION=false`.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
