### PR TITLE
fix(wia): adjust contest index based on the previous page's number of contests

### DIFF
--- a/libs/ballot-interpreter-nh/src/layout.ts
+++ b/libs/ballot-interpreter-nh/src/layout.ts
@@ -309,10 +309,20 @@ export function generateBallotPageLayouts(
       });
     }
 
+    // ensure the layouts are returned in the contest-order defined by the election definition
+    const contestsInOrder: BallotPageContestLayout[] = election.contests
+      .map((electionContest) =>
+        contests.find((c) => c.contestId === electionContest.id)
+      )
+      .filter(
+        (contestLayout): contestLayout is BallotPageContestLayout =>
+          contestLayout !== undefined
+      );
+
     layouts.push({
       metadata: { ...metadata, pageNumber: i + 1 },
       pageSize: geometry.canvasSize,
-      contests,
+      contests: contestsInOrder,
     });
   }
 

--- a/services/admin/src/server.ts
+++ b/services/admin/src/server.ts
@@ -505,12 +505,14 @@ export function buildApp({ workspace }: { workspace: Workspace }): Application {
       let currentLayoutOptionIdx = 0;
       let currentLayout = layouts[currentLayoutOptionIdx];
       while (currentLayout && contestIdx >= currentLayout.contests.length) {
+        // move to the next page, past the contests of the current page
+        contestIdx -= currentLayout.contests.length;
+
         currentLayoutOptionIdx += 1;
         currentLayout = layouts[currentLayoutOptionIdx];
         if (!currentLayout) {
           throw new Error('unexpected types');
         }
-        contestIdx -= currentLayout.contests.length;
       }
       currentLayout = layouts[currentLayoutOptionIdx];
       if (!currentLayout) {


### PR DESCRIPTION

In locating the proper portions of the ballot for write-in adjudication, we go through each page's layout and find the current contest's index on its current page. To do that, we subtract from the index the contests that appear on prior pages.

There was a bug where we were subtracting the number of contests on the *current* page, rather than the previous page. This wasn't noticed before because we happened to be testing on an election that had the same number of contests on the front and back pages.