### PR TITLE
fix(ballot-interpreter-nh): ensure the contest layout bounds are generated in right order

### DIFF
--- a/libs/ballot-interpreter-nh/src/layout.ts
+++ b/libs/ballot-interpreter-nh/src/layout.ts
@@ -309,10 +309,20 @@ export function generateBallotPageLayouts(
       });
     }
 
+    // ensure the layouts are returned in the contest-order defined by the election definition
+    const contestsInOrder: BallotPageContestLayout[] = election.contests
+      .map((electionContest) =>
+        contests.find((c) => c.contestId === electionContest.id)
+      )
+      .filter(
+        (contestLayout): contestLayout is BallotPageContestLayout =>
+          contestLayout !== undefined
+      );
+
     layouts.push({
       metadata: { ...metadata, pageNumber: i + 1 },
       pageSize: geometry.canvasSize,
-      contests,
+      contests: contestsInOrder,
     });
   }
 


### PR DESCRIPTION

Sometimes, `generateBallotPageLayouts` outputs contest layouts in an order different from the election definition. That messes up write-in adjudication downstream.

I considered alternate fixes:
- fixing the election definition converter so that it would always yield grid layouts in an order that would yield the right contest layout downstream, but that seemed a bit flimsy.
- changing the data structure to a map keyed on `contestId`, but that seems like a large, risky, and unnecessary change when we already often rely on contest ordering identical to the election definition.