### PR TITLE
clear jest cache on clean-all

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ build
 coverage
 .eslintcache
 junit.xml
+.jestcache
 
 # python
 *.pyc

--- a/jest.config.shared.js
+++ b/jest.config.shared.js
@@ -24,4 +24,5 @@ module.exports = {
     'jest-watch-typeahead/filename',
     'jest-watch-typeahead/testname',
   ],
+  cacheDirectory: '.jestcache'
 }


### PR DESCRIPTION
It's possible to end up with very confusing jest errors if jest is relying on its cached directory structure. By default, it's `/tmp/jest_rs`. Setting it within the repository means it will be cleared with `clean-all`.

https://jestjs.io/docs/configuration#cachedirectory-string