### PR TITLE
fix(admin): don't print the React Query devtools

### DIFF
--- a/frontends/election-manager/src/index.tsx
+++ b/frontends/election-manager/src/index.tsx
@@ -35,7 +35,11 @@ ReactDom.render(
       </ServicesContext.Provider>
       {isFeatureFlagEnabled(
         EnvironmentFlagName.ENABLE_REACT_QUERY_DEVTOOLS
-      ) && <ReactQueryDevtools initialIsOpen={false} position="top-left" />}
+      ) && (
+        <div className="no-print">
+          <ReactQueryDevtools initialIsOpen={false} position="top-left" />
+        </div>
+      )}
     </QueryClientProvider>
   </React.StrictMode>,
   document.getElementById('root')


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
The React Query devtools flower toggle button was showing up in printed ballots and reports when it is present (which is not the default).

## Demo Video or Screenshot
| Before | After |
|-|-|
| <img width="312" alt="Screen Shot 2022-10-24 at 9 55 53 AM" src="https://user-images.githubusercontent.com/1938/197582823-dcd88a2b-908a-4239-9505-8e75a3318554.png"> | <img width="311" alt="Screen Shot 2022-10-24 at 9 56 33 AM" src="https://user-images.githubusercontent.com/1938/197582833-325098c4-3873-49f1-824f-2f7f5ac527ed.png"> |

## Testing Plan 
Tested manually with Chrome's print preview.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
