### PR TITLE
chore(vscode): ignore `.jestcache`

### DIFF
--- a/vxsuite.code-workspace
+++ b/vxsuite.code-workspace
@@ -166,11 +166,13 @@
       "yesno"
     ],
     "search.exclude": {
+      "**/.jestcache": true,
       "**/build": true,
       "**/coverage": true
     },
     "files.exclude": {
       "**/*.tsbuildinfo": true,
+      "**/.jestcache": true,
       "**/build": true,
       "**/coverage": true
     },


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
Excludes it from both the file explorer and project search.

## Demo Video or Screenshot
| Before | After |
|-|-|
| <img width="456" alt="image" src="https://user-images.githubusercontent.com/1938/197649329-57250fe4-07c7-4d81-a025-c5f6aea62a29.png"> | <img width="460" alt="image" src="https://user-images.githubusercontent.com/1938/197649308-796e8a79-0ced-44dd-a367-d5f356c6f50e.png"> |

## Testing Plan 
Tested locally in VS Code.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
