### PR TITLE
[services/admin] Remove dupulicate CVR store function

### DIFF
--- a/services/admin/src/store.test.ts
+++ b/services/admin/src/store.test.ts
@@ -303,36 +303,6 @@ test('get CVR file metadata', async () => {
   );
 });
 
-test('get CVR file', async () => {
-  const store = Store.memoryStore();
-  const electionId = store.addElection(
-    electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData
-  );
-  const cvrFile =
-    electionMinimalExhaustiveSampleFixtures.standardCvrFile.asFilePath();
-
-  expect(store.getCastVoteRecordFile('not a CVR file ID')).toBeUndefined();
-
-  const { id } = (
-    await store.addCastVoteRecordFile({
-      electionId,
-      originalFilename: 'cvrs.jsonl',
-      filePath: cvrFile,
-    })
-  ).unsafeUnwrap();
-
-  const cvrFileMetadata = store.getCastVoteRecordFile(id);
-  expect(cvrFileMetadata).toEqual(
-    typedAs<Admin.CastVoteRecordFileRecord>({
-      id,
-      electionId,
-      filename: 'cvrs.jsonl',
-      sha256Hash: expect.any(String),
-      createdAt: expect.any(String),
-    })
-  );
-});
-
 test('get write-in adjudication records', async () => {
   const store = Store.memoryStore();
   const electionId = store.addElection(

--- a/services/admin/src/store.ts
+++ b/services/admin/src/store.ts
@@ -511,40 +511,6 @@ export class Store {
     };
   }
 
-  getCastVoteRecordFile(id: Id): Admin.CastVoteRecordFileRecord | undefined {
-    const result = this.client.one(
-      `
-      select
-        election_id as electionId,
-        filename,
-        sha256_hash as sha256Hash,
-        created_at as createdAt
-      from cvr_files
-      where id = ?
-    `,
-      id
-    ) as
-      | {
-          electionId: Id;
-          filename: string;
-          sha256Hash: string;
-          createdAt: string;
-        }
-      | undefined;
-
-    if (!result) {
-      return undefined;
-    }
-
-    return {
-      id,
-      electionId: result.electionId,
-      sha256Hash: result.sha256Hash,
-      filename: result.filename,
-      createdAt: convertSqliteTimestampToIso8601(result.createdAt),
-    };
-  }
-
   /**
    * Gets all CVR entries for an election.
    */


### PR DESCRIPTION
## Overview
Related: https://github.com/votingworks/vxsuite/issues/2716

Remove `getCastVoteRecordFile()`, which looks like a duplicate of `getCastVoteRecordFileMetadata()`

## Testing Plan 
Verified no other references exist, besides in the deleted test

## Checklist
- [n/a] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [n/a] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [n/a] I have added a screenshot and/or video to this PR to demo the change
- [n/a] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
