### PR TITLE
feat(admin): remember ballot settings

### DIFF
--- a/frontends/election-manager/src/contexts/services_context.ts
+++ b/frontends/election-manager/src/contexts/services_context.ts
@@ -1,4 +1,5 @@
 import { Logger, LogSource } from '@votingworks/logging';
+import { MemoryStorage, Storage } from '@votingworks/utils';
 import { createContext } from 'react';
 import {
   ElectionManagerStoreBackend,
@@ -11,6 +12,7 @@ import {
 export interface ServicesContextInterface {
   readonly backend: ElectionManagerStoreBackend;
   readonly logger: Logger;
+  readonly storage: Storage;
 }
 
 /**
@@ -19,4 +21,5 @@ export interface ServicesContextInterface {
 export const ServicesContext = createContext<ServicesContextInterface>({
   backend: new ElectionManagerStoreMemoryBackend(),
   logger: new Logger(LogSource.VxAdminFrontend),
+  storage: new MemoryStorage(),
 });

--- a/frontends/election-manager/src/hooks/use_adjudicate_transcription_mutation.test.tsx
+++ b/frontends/election-manager/src/hooks/use_adjudicate_transcription_mutation.test.tsx
@@ -3,7 +3,7 @@ import { renderHook } from '@testing-library/react-hooks/dom';
 import { fakeLogger } from '@votingworks/logging';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { electionMinimalExhaustiveSampleFixtures } from '@votingworks/fixtures';
-import { typedAs } from '@votingworks/utils';
+import { MemoryStorage, typedAs } from '@votingworks/utils';
 import { Admin } from '@votingworks/api';
 import { ServicesContext } from '../contexts/services_context';
 import { ElectionManagerStoreMemoryBackend } from '../lib/backends';
@@ -39,7 +39,9 @@ test('useAdjudicateTranscriptionMutation', async () => {
   // set up & trigger mutation
   function wrapper({ children }: { children: React.ReactNode }) {
     return (
-      <ServicesContext.Provider value={{ backend, logger }}>
+      <ServicesContext.Provider
+        value={{ backend, logger, storage: new MemoryStorage() }}
+      >
         <QueryClientProvider client={new QueryClient()}>
           {children}
         </QueryClientProvider>

--- a/frontends/election-manager/src/hooks/write_in_adjudication_end_to_end.test.tsx
+++ b/frontends/election-manager/src/hooks/write_in_adjudication_end_to_end.test.tsx
@@ -4,7 +4,7 @@ import { renderHook } from '@testing-library/react-hooks/dom';
 import { Admin } from '@votingworks/api';
 import { electionMinimalExhaustiveSampleFixtures } from '@votingworks/fixtures';
 import { fakeLogger } from '@votingworks/logging';
-import { typedAs } from '@votingworks/utils';
+import { MemoryStorage, typedAs } from '@votingworks/utils';
 import React from 'react';
 import { ServicesContext } from '../contexts/services_context';
 import { ElectionManagerStoreMemoryBackend } from '../lib/backends';
@@ -24,7 +24,9 @@ test('write-in adjudication end-to-end', async () => {
 
   function wrapper({ children }: { children: React.ReactNode }) {
     return (
-      <ServicesContext.Provider value={{ backend, logger }}>
+      <ServicesContext.Provider
+        value={{ backend, logger, storage: new MemoryStorage() }}
+      >
         <QueryClientProvider client={queryClient}>
           {children}
         </QueryClientProvider>

--- a/frontends/election-manager/src/index.tsx
+++ b/frontends/election-manager/src/index.tsx
@@ -30,7 +30,7 @@ const backend = new ElectionManagerStoreAdminBackend({ storage, logger });
 ReactDom.render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
-      <ServicesContext.Provider value={{ backend, logger }}>
+      <ServicesContext.Provider value={{ backend, logger, storage }}>
         <App />
       </ServicesContext.Provider>
       {isFeatureFlagEnabled(

--- a/frontends/election-manager/test/render_in_app_context.tsx
+++ b/frontends/election-manager/test/render_in_app_context.tsx
@@ -14,7 +14,12 @@ import {
   Printer,
   VotingMethod,
 } from '@votingworks/types';
-import { usbstick, NullPrinter } from '@votingworks/utils';
+import {
+  usbstick,
+  NullPrinter,
+  MemoryStorage,
+  Storage,
+} from '@votingworks/utils';
 import { fakeLogger, Logger, LogSource } from '@votingworks/logging';
 
 import { Dipped } from '@votingworks/test-utils';
@@ -80,15 +85,17 @@ export function renderRootElement(
   {
     backend = new ElectionManagerStoreMemoryBackend(),
     logger = fakeLogger(),
+    storage = new MemoryStorage(),
     queryClient = new QueryClient(),
   }: {
     backend?: ElectionManagerStoreBackend;
     logger?: Logger;
+    storage?: Storage;
     queryClient?: QueryClient;
   } = {}
 ): RenderResult {
   return testRender(
-    <ServicesContext.Provider value={{ backend, logger }}>
+    <ServicesContext.Provider value={{ backend, logger, storage }}>
       <QueryClientProvider client={queryClient}>
         {component}
       </QueryClientProvider>


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Previously ballot type and mode would reset every time you go back to the ballot screen. Now they will be remembered and restored on a per user role basis. That is, the sysadmin role and election manager role will have separate settings.

See [Slack discussion](https://votingworks.slack.com/archives/CJU9MSC6S/p1666649531051729)

## Demo Video or Screenshot
https://user-images.githubusercontent.com/1938/198076197-5c4cd394-cfde-4137-80d6-b8321a6e342c.mov


## Testing Plan 
Tested manually in Chrome as shown in the video.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
