### PR TITLE
Pause Polls on VxScan

### DIFF
--- a/frontends/precinct-scanner/src/api/config.ts
+++ b/frontends/precinct-scanner/src/api/config.ts
@@ -4,6 +4,7 @@ import {
   MarkThresholds,
   safeParseJson,
   PrecinctSelection,
+  PollsState,
 } from '@votingworks/types';
 import { ErrorsResponse, OkResponse, Scan } from '@votingworks/api';
 import { BallotPackage, BallotPackageEntry, assert } from '@votingworks/utils';
@@ -163,6 +164,23 @@ export async function setPrecinctSelection(
       precinctSelection,
     }
   );
+}
+
+export async function getPollsState(): Promise<PollsState> {
+  return safeParseJson(
+    await (
+      await fetch('/precinct-scanner/config/polls', {
+        headers: { Accept: 'application/json' },
+      })
+    ).text(),
+    Scan.GetPollsStateConfigResponseSchema
+  ).unsafeUnwrap().pollsState;
+}
+
+export async function setPollsState(pollsState: PollsState): Promise<void> {
+  await put<Scan.PutPollsStateConfigRequest>('/precinct-scanner/config/polls', {
+    pollsState,
+  });
 }
 
 export interface AddTemplatesEvents extends EventEmitter {

--- a/frontends/precinct-scanner/src/app.test.tsx
+++ b/frontends/precinct-scanner/src/app.test.tsx
@@ -386,6 +386,9 @@ test('election manager and poll worker configuration', async () => {
   mockPollsState('polls_closed_initial');
   userEvent.selectOptions(await screen.findByTestId('selectPrecinct'), '20');
   userEvent.click(screen.getByText('Confirm'));
+  await waitFor(() => {
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
   card.removeCard();
   await screen.findByText('Polls Closed');
   await screen.findByText('South Springfield,');

--- a/frontends/precinct-scanner/src/app.test.tsx
+++ b/frontends/precinct-scanner/src/app.test.tsx
@@ -1,24 +1,15 @@
-import React from 'react';
 import fetchMock from 'fetch-mock';
 import { promises as fs } from 'fs';
 import { Scan } from '@votingworks/api';
 import {
   ALL_PRECINCTS_SELECTION,
   TallySourceMachineType,
-  MemoryCard,
-  MemoryHardware,
-  MemoryStorage,
   typedAs,
   readBallotPackageFromFilePointer,
+  singlePrecinctSelectionFor,
 } from '@votingworks/utils';
-import { fakeLogger, LogEventId } from '@votingworks/logging';
-import {
-  render,
-  waitFor,
-  fireEvent,
-  screen,
-  within,
-} from '@testing-library/react';
+import { LogEventId } from '@votingworks/logging';
+import { waitFor, screen, within } from '@testing-library/react';
 import {
   fakeKiosk,
   fakeUsbDrive,
@@ -26,7 +17,6 @@ import {
   makePollWorkerCard,
   makeElectionManagerCard,
   makeSystemAdministratorCard,
-  getZeroCompressedTally,
   expectPrint,
 } from '@votingworks/test-utils';
 import { join } from 'path';
@@ -39,7 +29,6 @@ import { AdjudicationReason } from '@votingworks/types';
 
 import { mocked } from 'ts-jest/utils';
 import userEvent from '@testing-library/user-event';
-import { App } from './app';
 
 import { stateStorageKey } from './app_root';
 import {
@@ -54,6 +43,15 @@ import {
 import { REPRINT_REPORT_TIMEOUT_SECONDS } from './screens/poll_worker_screen';
 import { SELECT_PRECINCT_TEXT } from './screens/election_manager_screen';
 import { fakeFileWriter } from '../test/helpers/fake_file_writer';
+import {
+  mockPrecinctState,
+  mockPrecinctStateChange,
+} from '../test/helpers/mock_precinct_state';
+import { buildApp } from '../test/helpers/build_app';
+import {
+  mockPollsState,
+  mockPollsStateChange,
+} from '../test/helpers/mock_polls_state';
 
 jest.setTimeout(20000);
 
@@ -94,19 +92,11 @@ const getPrecinctConfigAllPrecinctsResponseBody: Scan.GetPrecinctSelectionConfig
     precinctSelection: ALL_PRECINCTS_SELECTION,
   };
 
-const getPrecinctConfigNoPrecinctResponseBody: Scan.GetPrecinctSelectionConfigResponse =
-  {
-    status: 'ok',
-  };
-
 const getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody: Scan.GetMarkThresholdOverridesConfigResponse =
   {
     status: 'ok',
   };
 
-let card: MemoryCard;
-let storage: MemoryStorage;
-let hardware: MemoryHardware;
 let kiosk = fakeKiosk();
 
 const pollWorkerCard = makePollWorkerCard(
@@ -120,13 +110,6 @@ const electionManagerCard = makeElectionManagerCard(
 
 beforeEach(() => {
   jest.useFakeTimers();
-
-  card = new MemoryCard();
-  storage = new MemoryStorage();
-  hardware = MemoryHardware.build({
-    connectCardReader: true,
-    connectPrecinctScanner: true,
-  });
 
   kiosk = fakeKiosk();
   kiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
@@ -149,39 +132,36 @@ beforeEach(() => {
     })
     .get('/precinct-scanner/config/markThresholdOverrides', {
       body: getMarkThresholdOverridesConfigNoMarkThresholdOverridesResponseBody,
+    })
+    .get('/precinct-scanner/config/polls', {
+      body: { status: 'ok', pollsState: 'polls_closed_initial' },
     });
 });
 
 test('shows setup card reader screen when there is no card reader', async () => {
+  const { hardware, renderApp } = buildApp();
   hardware.setCardReaderConnected(false);
   fetchMock.get('/precinct-scanner/scanner/status', { body: statusNoPaper });
-  render(<App storage={storage} hardware={hardware} card={card} />);
+  renderApp();
   await screen.findByText('Card Reader Not Detected');
 });
 
-test('initializes app with stored state', async () => {
-  const logger = fakeLogger();
-  await storage.set(stateStorageKey, { isPollsOpen: true });
+test('shows insert USB Drive screen when there is no card reader', async () => {
   kiosk.getUsbDrives.mockResolvedValue([]);
-  fetchMock
-    .get('/precinct-scanner/scanner/status', { body: statusNoPaper })
-    .patchOnce('/precinct-scanner/config/testMode', {
-      body: typedAs<Scan.PatchTestModeConfigResponse>({ status: 'ok' }),
-      status: 200,
-    });
-  render(
-    <App card={card} hardware={hardware} storage={storage} logger={logger} />
-  );
-  await advanceTimersAndPromises(1);
+  fetchMock.get('/precinct-scanner/scanner/status', { body: statusNoPaper });
+  buildApp().renderApp();
   await screen.findByText('No USB Drive Detected');
-  kiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
-  await advanceTimersAndPromises(1);
+});
 
-  // Insert a pollworker card
-  fetchMock.post('/precinct-scanner/export', {});
-  card.insertCard(pollWorkerCard);
-  await advanceTimersAndPromises(1);
-  await screen.findByText('Do you want to close the polls?');
+test('initializes app with stored state', async () => {
+  const { storage, card, renderApp } = buildApp();
+  await storage.set(stateStorageKey, { isSoundMuted: true });
+  fetchMock.get('/precinct-scanner/scanner/status', { body: statusNoPaper });
+  renderApp();
+
+  card.insertCard(electionManagerCard);
+  await authenticateElectionManagerCard();
+  await screen.findByText('Unmute Sounds');
 });
 
 test('app can load and configure from a usb stick', async () => {
@@ -191,7 +171,7 @@ test('app can load and configure from a usb stick', async () => {
       overwriteRoutes: true,
     })
     .get('/precinct-scanner/scanner/status', { body: statusNoPaper });
-  render(<App storage={storage} card={card} hardware={hardware} />);
+  buildApp().renderApp();
   await screen.findByText('Loading Configuration…');
   await advanceTimersAndPromises(1);
   await screen.findByText('VxScan is Not Configured');
@@ -258,10 +238,6 @@ test('app can load and configure from a usb stick', async () => {
   readBallotPackageFromFilePointerMock.mockResolvedValue(ballotPackage);
 
   fetchMock
-    .patchOnce('/precinct-scanner/config/testMode', {
-      body: typedAs<Scan.PatchTestModeConfigResponse>({ status: 'ok' }),
-      status: 200,
-    })
     .patchOnce('/precinct-scanner/config/election', {
       body: typedAs<Scan.PatchElectionConfigResponse>({ status: 'ok' }),
       status: 200,
@@ -297,25 +273,14 @@ test('app can load and configure from a usb stick', async () => {
 });
 
 test('election manager must set precinct', async () => {
-  fetchMock
-    .get('/precinct-scanner/scanner/status', { body: statusNoPaper })
-    .get(
-      '/precinct-scanner/config/precinct',
-      {
-        body: getPrecinctConfigNoPrecinctResponseBody,
-      },
-      { overwriteRoutes: true }
-    )
-    .putOnce('/precinct-scanner/config/precinct', {
-      body: { status: 'ok' },
-    });
-  render(<App card={card} hardware={hardware} storage={storage} />);
-  await advanceTimersAndPromises(1);
+  mockPrecinctState(undefined);
+  fetchMock.get('/precinct-scanner/scanner/status', { body: statusNoPaper });
+  const { card, renderApp } = buildApp();
+  renderApp();
   await screen.findByText('No Precinct Selected');
 
   // Poll Worker card does nothing
   card.insertCard(pollWorkerCard);
-  await advanceTimersAndPromises(1);
   await screen.findByText('No Precinct Selected');
   card.removeCard();
   await advanceTimersAndPromises(1);
@@ -324,13 +289,9 @@ test('election manager must set precinct', async () => {
   card.insertCard(electionManagerCard, electionSampleDefinition.electionData);
   await authenticateElectionManagerCard();
   screen.getByText(SELECT_PRECINCT_TEXT);
+  mockPrecinctStateChange(singlePrecinctSelectionFor('23'));
   userEvent.selectOptions(await screen.findByTestId('selectPrecinct'), '23');
-  expect(
-    fetchMock.calls('/precinct-scanner/config/precinct', { method: 'PUT' })
-  ).toHaveLength(1);
   card.removeCard();
-  await advanceTimersAndPromises(1);
-
   // Confirm precinct is set and correct
   await screen.findByText('Polls Closed');
   screen.getByText('Center Springfield,');
@@ -338,169 +299,145 @@ test('election manager must set precinct', async () => {
   // Poll Worker card can be used to open polls now
   fetchMock.post('/precinct-scanner/export', {});
   card.insertCard(pollWorkerCard);
-  await advanceTimersAndPromises(1);
   await screen.findByText('Do you want to open the polls?');
 });
 
 test('election manager and poll worker configuration', async () => {
-  const logger = fakeLogger();
-  const writeLongObjectMock = jest.spyOn(card, 'writeLongObject');
-  kiosk.getUsbDrives.mockResolvedValue([]);
+  const { card, renderApp, logger } = buildApp();
   fetchMock
     .get('/precinct-scanner/scanner/status', { body: statusNoPaper })
     .patchOnce('/precinct-scanner/config/testMode', {
       body: typedAs<Scan.PatchTestModeConfigResponse>({ status: 'ok' }),
       status: 200,
     });
-  render(
-    <App card={card} hardware={hardware} storage={storage} logger={logger} />
-  );
-  await advanceTimersAndPromises(1);
-  await screen.findByText('No USB Drive Detected');
-  kiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
-  await advanceTimersAndPromises(1);
+  renderApp();
   await screen.findByText('Polls Closed');
 
-  // Insert a pollworker card
-  fetchMock.post('/precinct-scanner/export', {});
-  card.insertCard(pollWorkerCard);
-  await advanceTimersAndPromises(1);
-  await screen.findByText('Do you want to open the polls?');
-
-  // Basic auth logging check
-  expect(logger.log).toHaveBeenCalledWith(
-    LogEventId.AuthLogin,
-    'poll_worker',
-    expect.objectContaining({ disposition: 'success' })
-  );
-
-  // Open Polls
-  fireEvent.click(await screen.findByText('Yes, Open the Polls'));
-  await screen.findByText(
-    'Insert poll worker card into VxMark to print the report.'
-  );
-  expect(writeLongObjectMock).toHaveBeenCalledTimes(1);
-  expect(writeLongObjectMock).toHaveBeenCalledWith(
-    expect.objectContaining({
-      isLiveMode: false,
-      tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
-      totalBallotsScanned: 0,
-      machineId: '0002',
-      timeSaved: expect.anything(),
-      precinctSelection: ALL_PRECINCTS_SELECTION,
-      tally: getZeroCompressedTally(electionSampleDefinition.election),
-    })
-  );
-  expect(fetchMock.calls('/precinct-scanner/export')).toHaveLength(1);
-
-  // Remove poll worker card to see Insert Ballot Screen
-  card.removeCard();
-  await screen.findByText('Insert Your Ballot Below');
-  await screen.findByText('Scan one ballot sheet at a time.');
-  await screen.findByText('General Election');
-  await screen.findByText('All Precincts,');
-  await screen.findByText('Franklin County,');
-  await screen.findByText('State of Hamilton');
-  await screen.findByText('Election ID');
-  await screen.findByText('748dc61ad3');
-
-  // Change mode with Election Manager card
-  card.insertCard(electionManagerCard, electionSampleDefinition.electionData);
-  await authenticateElectionManagerCard();
-  fireEvent.click(await screen.findByText('Live Election Mode'));
-  await screen.findByText('Loading');
-  await advanceTimersAndPromises(1);
-  expect(
-    fetchMock.calls('/precinct-scanner/config/testMode', { method: 'PATCH' })
-  ).toHaveLength(1);
-
-  // Remove Card and check polls were reset to closed.
-  card.removeCard();
-  await advanceTimersAndPromises(1);
-  await screen.findByText('Polls Closed');
-
-  // Open Polls again
-  card.insertCard(pollWorkerCard);
-  await advanceTimersAndPromises(1);
-  fireEvent.click(await screen.findByText('Yes, Open the Polls'));
-  await screen.findByText(
-    'Insert poll worker card into VxMark to print the report.'
-  );
-  card.removeCard();
-  await advanceTimersAndPromises(1);
-
-  // Change precinct with Election Manager card
-  fetchMock.putOnce('/precinct-scanner/config/precinct', {
-    body: { status: 'ok' },
-  });
-  card.insertCard(electionManagerCard, electionSampleDefinition.electionData);
-  await authenticateElectionManagerCard();
-  fireEvent.change(await screen.findByTestId('selectPrecinct'), {
-    target: { value: '23' },
-  });
-  card.removeCard();
-  await advanceTimersAndPromises(1);
-
-  // Verify polls were closed and the right precinct was set
-  await screen.findByText('Polls Closed');
-  await screen.findByText('Center Springfield,');
-
-  // Calibrate scanner with Election Manager card
+  // Calibrate scanner as Election Manager
   fetchMock.post('/precinct-scanner/scanner/calibrate', {
     body: { status: 'ok' },
   });
   card.insertCard(electionManagerCard, electionSampleDefinition.electionData);
   await authenticateElectionManagerCard();
-  fireEvent.click(await screen.findByText('Calibrate Scanner'));
+  userEvent.click(await screen.findByText('Calibrate Scanner'));
   await screen.findByText('Waiting for Paper');
-  fireEvent.click(await screen.findByText('Cancel'));
+  userEvent.click(await screen.findByText('Cancel'));
   expect(screen.queryByText('Waiting for Paper')).toBeNull();
-  fireEvent.click(await screen.findByText('Calibrate Scanner'));
-  fetchMock.getOnce(
-    '/precinct-scanner/scanner/status',
-    { body: statusReadyToScan },
-    { overwriteRoutes: true }
-  );
+  userEvent.click(await screen.findByText('Calibrate Scanner'));
+  fetchMock
+    .getOnce(
+      '/precinct-scanner/scanner/status',
+      { body: statusReadyToScan },
+      { overwriteRoutes: true }
+    )
+    .get('/precinct-scanner/scanner/status', { body: statusNoPaper });
   await advanceTimersAndPromises();
-  fireEvent.click(await screen.findByText('Calibrate'));
+  userEvent.click(await screen.findByText('Calibrate'));
   expect(fetchMock.calls('/precinct-scanner/scanner/calibrate')).toHaveLength(
     1
   );
   await advanceTimersAndPromises();
   await screen.findByText('Calibration succeeded!');
-  fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+  userEvent.click(screen.getByRole('button', { name: 'Close' }));
+
+  // Change mode as Election Manager
+  userEvent.click(await screen.findByText('Live Election Mode'));
+  await screen.findByText('Loading');
+  await advanceTimersAndPromises(1);
+  expect(logger.log).toHaveBeenCalledWith(
+    LogEventId.AuthLogin,
+    'election_manager',
+    expect.objectContaining({ disposition: 'success' })
+  );
+  expect(
+    fetchMock.calls('/precinct-scanner/config/testMode', { method: 'PATCH' })
+  ).toHaveLength(1);
+
+  // Change precinct as Election Manager
+  mockPrecinctStateChange(singlePrecinctSelectionFor('23'));
+  userEvent.selectOptions(await screen.findByTestId('selectPrecinct'), '23');
+  card.removeCard();
+  await advanceTimersAndPromises(1);
+
+  // Open the polls
+  fetchMock.post('/precinct-scanner/export', {});
+  card.insertCard(pollWorkerCard);
+  await screen.findByText('Do you want to open the polls?');
+  expect(fetchMock.calls('/precinct-scanner/export')).toHaveLength(1);
+  expect(logger.log).toHaveBeenCalledWith(
+    LogEventId.AuthLogin,
+    'poll_worker',
+    expect.objectContaining({ disposition: 'success' })
+  );
+  mockPollsStateChange('polls_open');
+  userEvent.click(await screen.findByText('Yes, Open the Polls'));
+  await screen.findByText(
+    'Insert poll worker card into VxMark to print the report.'
+  );
+  card.removeCard();
+  await advanceTimersAndPromises(1);
+
+  // Change precinct as Election Manager with polls open
+  card.insertCard(electionManagerCard, electionSampleDefinition.electionData);
+  await authenticateElectionManagerCard();
+  userEvent.click(screen.getByText('Change Precinct'));
+  screen.getByText(/WARNING/);
+  mockPrecinctStateChange(singlePrecinctSelectionFor('20'));
+  mockPollsState('polls_closed_initial');
+  userEvent.selectOptions(await screen.findByTestId('selectPrecinct'), '20');
+  userEvent.click(screen.getByText('Confirm'));
+  card.removeCard();
+  await screen.findByText('Polls Closed');
+  await screen.findByText('South Springfield,');
+
+  // Open the polls again
+  card.insertCard(pollWorkerCard);
+  await screen.findByText('Do you want to open the polls?');
+  expect(fetchMock.calls('/precinct-scanner/export')).toHaveLength(2);
+  expect(logger.log).toHaveBeenCalledWith(
+    LogEventId.AuthLogin,
+    'poll_worker',
+    expect.objectContaining({ disposition: 'success' })
+  );
+  mockPollsStateChange('polls_open');
+  userEvent.click(await screen.findByText('Yes, Open the Polls'));
+  await screen.findByText(
+    'Insert poll worker card into VxMark to print the report.'
+  );
+  card.removeCard();
+  await advanceTimersAndPromises(1);
 
   // Remove card and insert election manager card to unconfigure
   fetchMock
     .get(
       '/precinct-scanner/scanner/status',
-      { body: { ...statusNoPaper, canUnconfigure: true } },
+      { body: { ...statusNoPaper, canUnconfigure: true, ballotsCounted: 1 } },
       { overwriteRoutes: true }
     )
     .delete('./precinct-scanner/config/election', {
       body: '{"status": "ok"}',
       status: 200,
     });
-  card.removeCard();
-  await advanceTimersAndPromises(1);
   card.insertCard(electionManagerCard, electionSampleDefinition.electionData);
   await authenticateElectionManagerCard();
-  fireEvent.click(
+  // Confirm we can't unconfigure just by changing precinct
+  expect(screen.queryByTestId('selectPrecinct')).not.toBeInTheDocument();
+  userEvent.click(
     await screen.findByText('Delete All Election Data from VxScan')
   );
   await screen.findByText(
     'Do you want to remove all election information and data from this machine?'
   );
-  fireEvent.click(await screen.findByText('Cancel'));
+  userEvent.click(await screen.findByText('Cancel'));
   expect(
     screen.queryByText(
       'Do you want to remove all election information and data from this machine?'
     )
   ).toBeNull();
-  fireEvent.click(
+  userEvent.click(
     await screen.findByText('Delete All Election Data from VxScan')
   );
-  fireEvent.click(await screen.findByText('Yes, Delete All'));
+  userEvent.click(await screen.findByText('Yes, Delete All'));
   await screen.findByText('Loading');
   await waitFor(() =>
     expect(
@@ -513,25 +450,28 @@ test('election manager and poll worker configuration', async () => {
 });
 
 test('voter can cast a ballot that scans successfully ', async () => {
-  await storage.set(stateStorageKey, { isPollsOpen: true });
+  const { card, renderApp } = buildApp();
   const writeLongObjectMock = jest.spyOn(card, 'writeLongObject');
-  fetchMock.getOnce('/precinct-scanner/scanner/status', {
+  mockPollsState('polls_open');
+  fetchMock.get('/precinct-scanner/scanner/status', {
     body: statusNoPaper,
   });
-  render(<App card={card} hardware={hardware} storage={storage} />);
-  await advanceTimersAndPromises(1);
+  renderApp();
   await screen.findByText('Insert Your Ballot Below');
-  await screen.findByText('Scan one ballot sheet at a time.');
-  await screen.findByText('General Election');
-  await screen.findByText(/Franklin County/);
-  await screen.findByText(/State of Hamilton/);
-  await screen.findByText('Election ID');
-  await screen.findByText('748dc61ad3');
-
+  screen.getByText('Scan one ballot sheet at a time.');
+  screen.getByText('General Election');
+  screen.getByText(/Franklin County/);
+  screen.getByText(/State of Hamilton/);
+  screen.getByText('Election ID');
+  screen.getByText('748dc61ad3');
   fetchMock
-    .getOnce('/precinct-scanner/scanner/status', {
-      body: scannerStatus({ state: 'ready_to_scan' }),
-    })
+    .getOnce(
+      '/precinct-scanner/scanner/status',
+      {
+        body: scannerStatus({ state: 'ready_to_scan' }),
+      },
+      { overwriteRoutes: true }
+    )
     .post('/precinct-scanner/scanner/scan', { body: { status: 'ok' } })
     .getOnce('/precinct-scanner/scanner/status', {
       body: scannerStatus({ state: 'scanning' }),
@@ -558,7 +498,6 @@ test('voter can cast a ballot that scans successfully ', async () => {
   await screen.findByText('Scan one ballot sheet at a time.');
   expect((await screen.findByTestId('ballot-count')).textContent).toBe('1');
   expect(fetchMock.done()).toBe(true);
-
   // Insert a pollworker card
   fetchMock.post('/precinct-scanner/export', {
     _precinctId: '23',
@@ -569,12 +508,13 @@ test('voter can cast a ballot that scans successfully ', async () => {
     'county-registrar-of-wills': ['write-in'],
     'judicial-robert-demergue': ['yes'],
   });
+
   card.insertCard(pollWorkerCard);
-  await advanceTimersAndPromises(1);
   await screen.findByText('Do you want to close the polls?');
 
   // Close Polls
-  fireEvent.click(await screen.findByText('Yes, Close the Polls'));
+  mockPollsStateChange('polls_closed_final');
+  userEvent.click(await screen.findByText('Yes, Close the Polls'));
   await screen.findByText('Closing Polls…');
   await screen.findByText('Polls are closed.');
   expect(writeLongObjectMock).toHaveBeenCalledTimes(1);
@@ -624,21 +564,21 @@ test('voter can cast a ballot that scans successfully ', async () => {
   card.insertCard(electionManagerCard, electionSampleDefinition.electionData);
   await authenticateElectionManagerCard();
   await screen.findByText('Election Manager Settings');
-  fireEvent.click(await screen.findByText('Save CVRs'));
+  userEvent.click(await screen.findByText('Save CVRs'));
   await screen.findByText('No USB Drive Detected');
-  fireEvent.click(await screen.findByText('Cancel'));
+  userEvent.click(await screen.findByText('Cancel'));
   expect(screen.queryByText('No USB Drive Detected')).toBeNull();
-  fireEvent.click(await screen.findByText('Save CVRs'));
+  userEvent.click(await screen.findByText('Save CVRs'));
   await screen.findByText('No USB Drive Detected');
-  fireEvent.click(await screen.findByText('Cancel'));
+  userEvent.click(await screen.findByText('Cancel'));
   expect(screen.queryByText('No USB Drive Detected')).toBeNull();
   // Insert usb drive
   kiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
   await advanceTimersAndPromises(2);
-  fireEvent.click(await screen.findByText('Save CVRs'));
+  userEvent.click(await screen.findByText('Save CVRs'));
 
   expect(screen.getAllByText('Save CVRs')).toHaveLength(2);
-  fireEvent.click(await screen.findByText('Save'));
+  userEvent.click(await screen.findByText('Save'));
   await screen.findByText('CVRs Saved to USB Drive');
   expect(kiosk.writeFile).toHaveBeenCalledTimes(2);
   expect(kiosk.writeFile).toHaveBeenNthCalledWith(
@@ -651,17 +591,17 @@ test('voter can cast a ballot that scans successfully ', async () => {
     )
   );
   expect(fetchMock.calls('/precinct-scanner/export')).toHaveLength(3);
-  fireEvent.click(await screen.findByText('Eject USB'));
+  userEvent.click(await screen.findByText('Eject USB'));
   expect(screen.queryByText('Eject USB')).toBeNull();
   await advanceTimersAndPromises(1);
 });
 
 test('voter can cast a ballot that needs review and adjudicate as desired', async () => {
-  await storage.set(stateStorageKey, { isPollsOpen: true });
+  mockPollsState('polls_open');
   fetchMock.getOnce('/precinct-scanner/scanner/status', {
     body: statusNoPaper,
   });
-  render(<App storage={storage} card={card} hardware={hardware} />);
+  buildApp().renderApp();
   await screen.findByText('Insert Your Ballot Below');
   await screen.findByText('Scan one ballot sheet at a time.');
   await screen.findByText('General Election');
@@ -704,9 +644,9 @@ test('voter can cast a ballot that needs review and adjudicate as desired', asyn
       body: scannerStatus({ state: 'no_paper', ballotsCounted: 1 }),
     });
 
-  fireEvent.click(screen.getByRole('button', { name: 'Cast Ballot As Is' }));
+  userEvent.click(screen.getByRole('button', { name: 'Cast Ballot As Is' }));
   await screen.findByText('Are you sure?');
-  fireEvent.click(
+  userEvent.click(
     screen.getByRole('button', { name: 'Yes, Cast Ballot As Is' })
   );
 
@@ -719,11 +659,11 @@ test('voter can cast a ballot that needs review and adjudicate as desired', asyn
 });
 
 test('voter can cast a rejected ballot', async () => {
-  await storage.set(stateStorageKey, { isPollsOpen: true });
+  mockPollsState('polls_open');
   fetchMock.getOnce('/precinct-scanner/scanner/status', {
     body: statusNoPaper,
   });
-  render(<App storage={storage} card={card} hardware={hardware} />);
+  buildApp().renderApp();
   await screen.findByText('Insert Your Ballot Below');
   await screen.findByText('Scan one ballot sheet at a time.');
   await screen.findByText('General Election');
@@ -768,11 +708,11 @@ test('voter can cast a rejected ballot', async () => {
 });
 
 test('voter can cast another ballot while the success screen is showing', async () => {
-  await storage.set(stateStorageKey, { isPollsOpen: true });
+  mockPollsState('polls_open');
   fetchMock.getOnce('/precinct-scanner/scanner/status', {
     body: scannerStatus({ state: 'accepted', ballotsCounted: 1 }),
   });
-  render(<App storage={storage} card={card} hardware={hardware} />);
+  buildApp().renderApp();
   await screen.findByText('Your ballot was counted!');
   await screen.findByText('General Election');
   await screen.findByText(/Franklin County/);
@@ -820,18 +760,18 @@ test('scanning is not triggered when polls closed or cards present', async () =>
     })
     // Mock the scan endpoint just so we can check that we don't hit it
     .post('/precinct-scanner/scanner/scan', { status: 500 });
-
-  render(<App storage={storage} card={card} hardware={hardware} />);
+  const { card, renderApp } = buildApp();
+  renderApp();
   await screen.findByText('Polls Closed');
   fetchMock.post('/precinct-scanner/export', {});
   card.insertCard(pollWorkerCard);
-  await advanceTimersAndPromises(1);
   await screen.findByText('Do you want to open the polls?');
   // We should see 15 ballots were scanned
-  fireEvent.click(screen.getAllByText('No')[0]);
+  userEvent.click(screen.getAllByText('No')[0]);
   expect((await screen.findByTestId('ballot-count')).textContent).toBe('15');
   // Open Polls
-  fireEvent.click(await screen.findByText('Open Polls for All Precincts'));
+  mockPollsStateChange('polls_open');
+  userEvent.click(await screen.findByText('Open Polls for All Precincts'));
   await screen.findByText('Polls are open.');
 
   // Once we remove the poll worker card, scanning should start
@@ -847,22 +787,17 @@ test('scanning is not triggered when polls closed or cards present', async () =>
 });
 
 test('no printer: poll worker can open and close polls without scanning any ballots', async () => {
-  fetchMock
-    .get('/precinct-scanner/scanner/status', { body: statusNoPaper })
-    .patchOnce('/precinct-scanner/config/testMode', {
-      body: typedAs<Scan.PatchTestModeConfigResponse>({ status: 'ok' }),
-      status: 200,
-    });
-  render(<App card={card} hardware={hardware} storage={storage} />);
-  await advanceTimersAndPromises(1);
+  fetchMock.get('/precinct-scanner/scanner/status', { body: statusNoPaper });
+  const { card, renderApp } = buildApp();
+  renderApp();
   await screen.findByText('Polls Closed');
   fetchMock.post('/precinct-scanner/export', {});
 
   // Open Polls Flow
   card.insertCard(pollWorkerCard);
-  await advanceTimersAndPromises(1);
   await screen.findByText('Do you want to open the polls?');
-  fireEvent.click(await screen.findByText('Yes, Open the Polls'));
+  mockPollsStateChange('polls_open');
+  userEvent.click(await screen.findByText('Yes, Open the Polls'));
   await screen.findByText(
     'Insert poll worker card into VxMark to print the report.'
   );
@@ -871,9 +806,9 @@ test('no printer: poll worker can open and close polls without scanning any ball
 
   // Close Polls Flow
   card.insertCard(pollWorkerCard);
-  await advanceTimersAndPromises(1);
   await screen.findByText('Do you want to close the polls?');
-  fireEvent.click(await screen.findByText('Yes, Close the Polls'));
+  mockPollsStateChange('polls_closed_final');
+  userEvent.click(await screen.findByText('Yes, Close the Polls'));
   await screen.findByText('Closing Polls…');
   await screen.findByText(
     'Insert poll worker card into VxMark to print the report.'
@@ -883,22 +818,16 @@ test('no printer: poll worker can open and close polls without scanning any ball
 });
 
 test('with printer: poll worker can open and close polls without scanning any ballots', async () => {
-  hardware.setPrinterConnected(true);
-  fetchMock
-    .get('/precinct-scanner/scanner/status', { body: statusNoPaper })
-    .patchOnce('/precinct-scanner/config/testMode', {
-      body: typedAs<Scan.PatchTestModeConfigResponse>({ status: 'ok' }),
-      status: 200,
-    });
-  render(<App card={card} hardware={hardware} storage={storage} />);
-  await advanceTimersAndPromises(1);
+  fetchMock.get('/precinct-scanner/scanner/status', { body: statusNoPaper });
+  const { card, renderApp } = buildApp(true);
+  renderApp();
   await screen.findByText('Polls Closed');
   fetchMock.post('/precinct-scanner/export', {});
 
   // Open Polls Flow
   card.insertCard(pollWorkerCard);
-  await advanceTimersAndPromises(1);
   await screen.findByText('Do you want to open the polls?');
+  mockPollsStateChange('polls_open');
   userEvent.click(screen.getByRole('button', { name: 'Yes, Open the Polls' }));
   await screen.findByText('Polls are open.');
   await expectPrint();
@@ -916,8 +845,8 @@ test('with printer: poll worker can open and close polls without scanning any ba
 
   // Close Polls Flow
   card.insertCard(pollWorkerCard);
-  await advanceTimersAndPromises(1);
   await screen.findByText('Do you want to close the polls?');
+  mockPollsStateChange('polls_closed_final');
   userEvent.click(screen.getByRole('button', { name: 'Yes, Close the Polls' }));
   await screen.findByText('Polls are closed.');
   await expectPrint();
@@ -935,23 +864,18 @@ test('with printer: poll worker can open and close polls without scanning any ba
 });
 
 test('no printer: open polls, scan ballot, close polls, save results', async () => {
+  fetchMock.get('/precinct-scanner/scanner/status', { body: statusNoPaper });
+  const { card, renderApp } = buildApp();
   const writeLongObjectMock = jest.spyOn(card, 'writeLongObject');
-  fetchMock
-    .get('/precinct-scanner/scanner/status', { body: statusNoPaper })
-    .patchOnce('/precinct-scanner/config/testMode', {
-      body: typedAs<Scan.PatchTestModeConfigResponse>({ status: 'ok' }),
-      status: 200,
-    });
-  render(<App card={card} hardware={hardware} storage={storage} />);
-  await advanceTimersAndPromises(1);
+  renderApp();
   await screen.findByText('Polls Closed');
   fetchMock.post('/precinct-scanner/export', {});
 
   // Open Polls Flow
   card.insertCard(pollWorkerCard);
-  await advanceTimersAndPromises(1);
   await screen.findByText('Do you want to open the polls?');
-  fireEvent.click(await screen.findByText('Yes, Open the Polls'));
+  mockPollsStateChange('polls_open');
+  userEvent.click(await screen.findByText('Yes, Open the Polls'));
   expect(writeLongObjectMock).toHaveBeenCalledTimes(1);
   await screen.findByText(
     'Insert poll worker card into VxMark to print the report.'
@@ -1008,10 +932,9 @@ test('no printer: open polls, scan ballot, close polls, save results', async () 
     { overwriteRoutes: true }
   );
   card.insertCard(pollWorkerCard);
-  await advanceTimersAndPromises(1);
   await screen.findByText('Do you want to close the polls?');
-
-  fireEvent.click(await screen.findByText('Yes, Close the Polls'));
+  mockPollsStateChange('polls_closed_final');
+  userEvent.click(await screen.findByText('Yes, Close the Polls'));
   await screen.findByText('Closing Polls…');
   await screen.findByText('Polls are closed.');
   await screen.findByText(
@@ -1053,13 +976,69 @@ test('no printer: open polls, scan ballot, close polls, save results', async () 
   await screen.findByText('Polls Closed');
 });
 
+test('poll worker can open, pause, unpause, and close poll without scanning any ballots', async () => {
+  fetchMock.get('/precinct-scanner/scanner/status', { body: statusNoPaper });
+  const { card, renderApp } = buildApp();
+  renderApp();
+  await screen.findByText('Polls Closed');
+  fetchMock.post('/precinct-scanner/export', {});
+
+  // Open Polls
+  card.insertCard(pollWorkerCard);
+  await screen.findByText('Do you want to open the polls?');
+  mockPollsStateChange('polls_open');
+  userEvent.click(await screen.findByText('Yes, Open the Polls'));
+  await screen.findByText(
+    'Insert poll worker card into VxMark to print the report.'
+  );
+  card.removeCard();
+  await screen.findByText('Insert Your Ballot Below');
+
+  // Pause Polls Flow
+  card.insertCard(pollWorkerCard);
+  await screen.findByText('Do you want to close the polls?');
+  userEvent.click(await screen.findByText('No'));
+  mockPollsStateChange('polls_paused');
+  userEvent.click(await screen.findByText('Pause Polls for All Precincts'));
+  await screen.findByText('Pausing Polls…');
+  await screen.findByText(
+    'Insert poll worker card into VxMark to print the report.'
+  );
+  card.removeCard();
+  await screen.findByText('Polls Paused');
+
+  // Unpause Polls Flow
+  card.insertCard(pollWorkerCard);
+  await screen.findByText('Do you want to open the polls?');
+  mockPollsStateChange('polls_open');
+  userEvent.click(await screen.findByText('Yes, Open the Polls'));
+  await screen.findByText(
+    'Insert poll worker card into VxMark to print the report.'
+  );
+  card.removeCard();
+  await screen.findByText('Insert Your Ballot Below');
+
+  // Close Polls Flow
+  card.insertCard(pollWorkerCard);
+  await screen.findByText('Do you want to close the polls?');
+  mockPollsStateChange('polls_closed_final');
+  userEvent.click(await screen.findByText('Yes, Close the Polls'));
+  await screen.findByText('Closing Polls…');
+  await screen.findByText(
+    'Insert poll worker card into VxMark to print the report.'
+  );
+  card.removeCard();
+  await screen.findByText('Polls Closed');
+});
+
 test('system administrator can log in and unconfigure machine', async () => {
   fetchMock
     .get('/precinct-scanner/scanner/status', { body: statusNoPaper })
     .delete('/precinct-scanner/config/election?ignoreBackupRequirement=true', {
       body: deleteElectionConfigResponseBody,
     });
-  render(<App card={card} storage={storage} hardware={hardware} />);
+  const { card, renderApp } = buildApp();
+  renderApp();
 
   card.insertCard(makeSystemAdministratorCard());
   await screen.findByText('Enter the card security code to unlock.');
@@ -1097,16 +1076,53 @@ test('system administrator allowed to log in on unconfigured machine', async () 
     )
     .get('/precinct-scanner/scanner/status', { body: statusNoPaper });
 
-  render(<App card={card} storage={storage} hardware={hardware} />);
+  const { card, renderApp } = buildApp();
+  renderApp();
 
   card.insertCard(makeSystemAdministratorCard());
   await screen.findByText('Enter the card security code to unlock.');
 });
 
+test('system administrator can reset polls to paused', async () => {
+  mockPollsState('polls_closed_final');
+  fetchMock
+    .get('/precinct-scanner/scanner/status', { body: statusNoPaper })
+    .delete('/precinct-scanner/config/election?ignoreBackupRequirement=true', {
+      body: deleteElectionConfigResponseBody,
+    });
+  const { card, renderApp } = buildApp();
+  renderApp();
+  await screen.findByText('Polls Closed');
+
+  card.insertCard(makeSystemAdministratorCard());
+  await screen.findByText('Enter the card security code to unlock.');
+  userEvent.click(screen.getByText('1'));
+  userEvent.click(screen.getByText('2'));
+  userEvent.click(screen.getByText('3'));
+  userEvent.click(screen.getByText('4'));
+  userEvent.click(screen.getByText('5'));
+  userEvent.click(screen.getByText('6'));
+
+  userEvent.click(
+    await screen.findByRole('button', { name: 'Reset Polls to Paused' })
+  );
+  const modal = await screen.findByRole('alertdialog');
+  mockPollsStateChange('polls_paused');
+  userEvent.click(
+    await within(modal).findByRole('button', { name: 'Reset Polls to Paused' })
+  );
+  await waitFor(() =>
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+  );
+  card.removeCard();
+  await screen.findByText('Polls Paused');
+});
+
 test('election manager cannot auth onto machine with different election hash', async () => {
   fetchMock.get('/precinct-scanner/scanner/status', { body: statusNoPaper });
 
-  render(<App card={card} storage={storage} hardware={hardware} />);
+  const { card, renderApp } = buildApp();
+  renderApp();
 
   card.insertCard(
     makeElectionManagerCard(electionSample2Definition.electionHash)
@@ -1115,11 +1131,12 @@ test('election manager cannot auth onto machine with different election hash', a
 });
 
 test('replace ballot bag flow', async () => {
-  await storage.set(stateStorageKey, { isPollsOpen: true });
+  mockPollsState('polls_open');
   fetchMock.getOnce('/precinct-scanner/scanner/status', {
     body: statusNoPaper,
   });
-  render(<App card={card} hardware={hardware} storage={storage} />);
+  const { card, renderApp } = buildApp();
+  renderApp();
   await advanceTimersAndPromises(1);
   await screen.findByText('Insert Your Ballot Below');
 
@@ -1208,8 +1225,9 @@ test('replace ballot bag flow', async () => {
 });
 
 test('uses storage for frontend state', async () => {
+  mockPollsState('polls_open');
+  const { card, storage, renderApp } = buildApp();
   await storage.set(stateStorageKey, {
-    isPollsOpen: true,
     isSoundMuted: true,
     ballotCountWhenBallotBagLastReplaced: BALLOT_BAG_CAPACITY,
   });
@@ -1219,10 +1237,7 @@ test('uses storage for frontend state', async () => {
       ballotsCounted: BALLOT_BAG_CAPACITY,
     }),
   });
-  render(<App card={card} hardware={hardware} storage={storage} />);
-  await advanceTimersAndPromises(1);
-
-  // Confirm polls status and ballot bag status loaded from storage
+  renderApp();
   await screen.findByText('Insert Your Ballot Below');
 
   // Confirm muted status loaded from storage
@@ -1256,16 +1271,5 @@ test('uses storage for frontend state', async () => {
   await advanceTimersAndPromises(1);
   expect(await storage.get(stateStorageKey)).toMatchObject({
     ballotCountWhenBallotBagLastReplaced: BALLOT_BAG_CAPACITY * 2,
-  });
-
-  // Confirm polls status is saved to storage
-  fetchMock.post('/precinct-scanner/export', {});
-  card.insertCard(pollWorkerCard);
-  userEvent.click(await screen.findByText('Yes, Close the Polls'));
-  await screen.findByText('Polls are closed.');
-  card.removeCard();
-  await advanceTimersAndPromises(1);
-  expect(await storage.get(stateStorageKey)).toMatchObject({
-    isPollsOpen: false,
   });
 });

--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -356,7 +356,7 @@ export function AppRoot({
     await config.setPollsState(newPollsState);
   }, []);
 
-  const resetPollsToClosed = useCallback(async () => {
+  const resetPollsToPaused = useCallback(async () => {
     await updatePollsState('polls_paused');
   }, [updatePollsState]);
 
@@ -460,7 +460,7 @@ export function AppRoot({
           }
           showResetPollsToPausedButton
           resetPollsToPaused={
-            pollsState === 'polls_closed_final' ? resetPollsToClosed : undefined
+            pollsState === 'polls_closed_final' ? resetPollsToPaused : undefined
           }
           isMachineConfigured={Boolean(electionDefinition)}
           usbDriveStatus={usbDriveDisplayStatus}

--- a/frontends/precinct-scanner/src/app_tally_report_paths.test.tsx
+++ b/frontends/precinct-scanner/src/app_tally_report_paths.test.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
 import fetchMock from 'fetch-mock';
-import { render, fireEvent, screen, within } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import {
   electionMinimalExhaustiveSample,
   electionMinimalExhaustiveSampleDefinition,
@@ -23,9 +22,6 @@ import { Scan } from '@votingworks/api';
 import {
   ALL_PRECINCTS_SELECTION,
   BallotCountDetails,
-  MemoryCard,
-  MemoryHardware,
-  MemoryStorage,
   singlePrecinctSelectionFor,
   TallySourceMachineType,
 } from '@votingworks/utils';
@@ -38,10 +34,13 @@ import {
 } from '@votingworks/types';
 
 import userEvent from '@testing-library/user-event';
-import { App } from './app';
-import { stateStorageKey } from './app_root';
 import { MachineConfigResponse } from './config/types';
 import { fakeFileWriter } from '../test/helpers/fake_file_writer';
+import {
+  mockPollsState,
+  mockPollsStateChange,
+} from '../test/helpers/mock_polls_state';
+import { buildApp } from '../test/helpers/build_app';
 
 const getMachineConfigBody: MachineConfigResponse = {
   machineId: '0002',
@@ -138,10 +137,7 @@ beforeEach(() => {
 });
 
 test('printing: polls open, All Precincts, primary election + check additional report', async () => {
-  const card = new MemoryCard();
-  const hardware = MemoryHardware.buildStandard();
-  const storage = new MemoryStorage();
-  await storage.set(stateStorageKey, { isPollsOpen: false });
+  mockPollsState('polls_closed_initial');
   const { election } =
     electionMinimalExhaustiveSampleWithReportingUrlDefinition;
   fetchMock
@@ -152,8 +148,8 @@ test('printing: polls open, All Precincts, primary election + check additional r
       body: getPrecinctConfigAllPrecinctsResponseBody,
     })
     .get('/precinct-scanner/scanner/status', { body: statusNoPaper });
-  render(<App card={card} hardware={hardware} storage={storage} />);
-  await advanceTimersAndPromises(1);
+  const { card, renderApp } = buildApp(true);
+  renderApp();
   await screen.findByText('Polls Closed');
 
   // Open the polls
@@ -162,8 +158,8 @@ test('printing: polls open, All Precincts, primary election + check additional r
     electionMinimalExhaustiveSampleDefinition.electionHash
   );
   card.insertCard(pollWorkerCard);
-  await advanceTimersAndPromises(1);
   await screen.findByText('Do you want to open the polls?');
+  mockPollsStateChange('polls_open');
   userEvent.click(screen.getByText('Yes, Open the Polls'));
   await screen.findByText('Polls are open.');
 
@@ -199,12 +195,7 @@ test('printing: polls open, All Precincts, primary election + check additional r
 });
 
 test('saving to card: polls open, All Precincts, primary election + test failed card write', async () => {
-  const card = new MemoryCard();
-  const writeLongObjectMock = jest.spyOn(card, 'writeLongObject');
-  const hardware = MemoryHardware.buildStandard();
-  hardware.setPrinterConnected(false);
-  const storage = new MemoryStorage();
-  await storage.set(stateStorageKey, { isPollsOpen: false });
+  mockPollsState('polls_closed_initial');
   fetchMock
     .get('/precinct-scanner/config/election', {
       body: electionMinimalExhaustiveSampleDefinition,
@@ -213,8 +204,9 @@ test('saving to card: polls open, All Precincts, primary election + test failed 
       body: getPrecinctConfigAllPrecinctsResponseBody,
     })
     .get('/precinct-scanner/scanner/status', { body: statusNoPaper });
-  render(<App card={card} hardware={hardware} storage={storage} />);
-  await advanceTimersAndPromises(1);
+  const { card, renderApp } = buildApp();
+  const writeLongObjectMock = jest.spyOn(card, 'writeLongObject');
+  renderApp();
   await screen.findByText('Polls Closed');
 
   // Open the polls
@@ -223,13 +215,13 @@ test('saving to card: polls open, All Precincts, primary election + test failed 
     electionMinimalExhaustiveSampleDefinition.electionHash
   );
   card.insertCard(pollWorkerCard);
-  await advanceTimersAndPromises(1);
   await screen.findByText('Do you want to open the polls?');
   // Mimic what would happen if the tallies by precinct didn't fit on the card but the overall tally does.
   // Mock the card reader not to return back whatever we save
   jest
     .spyOn(card, 'readLongObject')
     .mockResolvedValue(err(new Error('bad read')));
+  mockPollsStateChange('polls_open');
   userEvent.click(screen.getByText('Yes, Open the Polls'));
   await screen.findByText('Polls are open.');
   card.removeCard();
@@ -277,6 +269,7 @@ test('saving to card: polls open, All Precincts, primary election + test failed 
       tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 0,
       machineId: '0002',
+      timePollsToggled: expect.anything(),
       timeSaved: expect.anything(),
       precinctSelection: ALL_PRECINCTS_SELECTION,
       tally: expectedCombinedTally,
@@ -293,6 +286,7 @@ test('saving to card: polls open, All Precincts, primary election + test failed 
       tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 0,
       machineId: '0002',
+      timePollsToggled: expect.anything(),
       timeSaved: expect.anything(),
       precinctSelection: ALL_PRECINCTS_SELECTION,
       tally: expectedCombinedTally,
@@ -348,10 +342,7 @@ const PRIMARY_ALL_PRECINCTS_CVRS = generateFileContentFromCvrs([
 ]);
 
 test('printing: polls closed, primary election, all precincts + quickresults on', async () => {
-  const card = new MemoryCard();
-  const hardware = MemoryHardware.buildStandard();
-  const storage = new MemoryStorage();
-  await storage.set(stateStorageKey, { isPollsOpen: true });
+  mockPollsState('polls_open');
   const { election } =
     electionMinimalExhaustiveSampleWithReportingUrlDefinition;
 
@@ -365,8 +356,8 @@ test('printing: polls closed, primary election, all precincts + quickresults on'
     .get('/precinct-scanner/scanner/status', {
       body: { ...statusNoPaper, ballotsCounted: 3 },
     });
-  render(<App card={card} hardware={hardware} storage={storage} />);
-  await advanceTimersAndPromises(1);
+  const { card, renderApp } = buildApp(true);
+  renderApp();
   await screen.findByText('Insert Your Ballot Below');
 
   // Close the polls
@@ -375,12 +366,10 @@ test('printing: polls closed, primary election, all precincts + quickresults on'
     electionMinimalExhaustiveSampleWithReportingUrlDefinition.electionHash
   );
   card.insertCard(pollWorkerCard);
-  await advanceTimersAndPromises(1);
   await screen.findByText('Do you want to close the polls?');
-
+  mockPollsStateChange('polls_closed_final');
   userEvent.click(await screen.findByText('Yes, Close the Polls'));
   await screen.findByText('Polls are closed.');
-  await advanceTimersAndPromises(1);
   await expectPrint((printedElement) => {
     expect(
       printedElement.queryAllByText('TEST Polls Closed Report for Precinct 1')
@@ -565,12 +554,7 @@ test('printing: polls closed, primary election, all precincts + quickresults on'
 });
 
 test('saving to card: polls closed, primary election, all precincts', async () => {
-  const card = new MemoryCard();
-  const writeLongObjectMock = jest.spyOn(card, 'writeLongObject');
-  const hardware = MemoryHardware.buildStandard();
-  hardware.setPrinterConnected(false);
-  const storage = new MemoryStorage();
-  await storage.set(stateStorageKey, { isPollsOpen: true });
+  mockPollsState('polls_open');
 
   fetchMock
     .get('/precinct-scanner/config/election', {
@@ -582,8 +566,9 @@ test('saving to card: polls closed, primary election, all precincts', async () =
     .get('/precinct-scanner/scanner/status', {
       body: { ...statusNoPaper, ballotsCounted: 3 },
     });
-  render(<App card={card} hardware={hardware} storage={storage} />);
-  await advanceTimersAndPromises(1);
+  const { card, renderApp } = buildApp();
+  const writeLongObjectMock = jest.spyOn(card, 'writeLongObject');
+  renderApp();
   await screen.findByText('Insert Your Ballot Below');
 
   // Close the polls
@@ -592,8 +577,8 @@ test('saving to card: polls closed, primary election, all precincts', async () =
     electionMinimalExhaustiveSampleWithReportingUrlDefinition.electionHash
   );
   card.insertCard(pollWorkerCard);
-  await advanceTimersAndPromises(1);
   await screen.findByText('Do you want to close the polls?');
+  mockPollsStateChange('polls_closed_final');
   userEvent.click(await screen.findByText('Yes, Close the Polls'));
   await screen.findByText('Polls are closed.');
   card.removeCard();
@@ -639,6 +624,7 @@ test('saving to card: polls closed, primary election, all precincts', async () =
       tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 3,
       machineId: '0002',
+      timePollsToggled: expect.anything(),
       timeSaved: expect.anything(),
       precinctSelection: ALL_PRECINCTS_SELECTION,
       tally: expectedCombinedTally,
@@ -694,10 +680,7 @@ const PRIMARY_SINGLE_PRECINCT_CVRS = generateFileContentFromCvrs([
 ]);
 
 test('printing: polls closed, primary election, single precinct + check additional report', async () => {
-  const card = new MemoryCard();
-  const hardware = MemoryHardware.buildStandard();
-  const storage = new MemoryStorage();
-  await storage.set(stateStorageKey, { isPollsOpen: true });
+  mockPollsState('polls_open');
   const { election } = electionMinimalExhaustiveSampleDefinition;
 
   fetchMock
@@ -710,8 +693,8 @@ test('printing: polls closed, primary election, single precinct + check addition
     .get('/precinct-scanner/scanner/status', {
       body: { ...statusNoPaper, ballotsCounted: 3 },
     });
-  render(<App card={card} hardware={hardware} storage={storage} />);
-  await advanceTimersAndPromises(1);
+  const { card, renderApp } = buildApp(true);
+  renderApp();
   await screen.findByText('Insert Your Ballot Below');
 
   // Close the polls
@@ -720,8 +703,8 @@ test('printing: polls closed, primary election, single precinct + check addition
     electionMinimalExhaustiveSampleDefinition.electionHash
   );
   card.insertCard(pollWorkerCard);
-  await advanceTimersAndPromises(1);
   await screen.findByText('Do you want to close the polls?');
+  mockPollsStateChange('polls_closed_final');
   userEvent.click(await screen.findByText('Yes, Close the Polls'));
   await screen.findByText('Polls are closed.');
   async function checkReport() {
@@ -834,13 +817,7 @@ test('printing: polls closed, primary election, single precinct + check addition
 });
 
 test('saving to card: polls closed, primary election, single precinct', async () => {
-  const card = new MemoryCard();
-  const writeLongObjectMock = jest.spyOn(card, 'writeLongObject');
-  const hardware = MemoryHardware.buildStandard();
-  hardware.setPrinterConnected(false);
-  const storage = new MemoryStorage();
-  await storage.set(stateStorageKey, { isPollsOpen: true });
-
+  mockPollsState('polls_open');
   fetchMock
     .get('/precinct-scanner/config/election', {
       body: electionMinimalExhaustiveSampleDefinition,
@@ -851,8 +828,9 @@ test('saving to card: polls closed, primary election, single precinct', async ()
     .get('/precinct-scanner/scanner/status', {
       body: { ...statusNoPaper, ballotsCounted: 3 },
     });
-  render(<App card={card} hardware={hardware} storage={storage} />);
-  await advanceTimersAndPromises(1);
+  const { card, renderApp } = buildApp();
+  const writeLongObjectMock = jest.spyOn(card, 'writeLongObject');
+  renderApp();
   await screen.findByText('Insert Your Ballot Below');
 
   // Close the polls
@@ -861,9 +839,9 @@ test('saving to card: polls closed, primary election, single precinct', async ()
     electionMinimalExhaustiveSampleDefinition.electionHash
   );
   card.insertCard(pollWorkerCard);
-  await advanceTimersAndPromises(1);
   await screen.findByText('Do you want to close the polls?');
   // Save the tally to card and get the expected tallies
+  mockPollsStateChange('polls_closed_final');
   userEvent.click(await screen.findByText('Yes, Close the Polls'));
   await screen.findByText('Polls are closed.');
   card.removeCard();
@@ -892,6 +870,7 @@ test('saving to card: polls closed, primary election, single precinct', async ()
       tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 3,
       machineId: '0002',
+      timePollsToggled: expect.anything(),
       timeSaved: expect.anything(),
       precinctSelection: singlePrecinctSelectionFor('precinct-1'),
       tally: expectedCombinedTally,
@@ -930,10 +909,7 @@ const GENERAL_ALL_PRECINCTS_CVRS = generateFileContentFromCvrs([
 ]);
 
 test('printing: polls closed, general election, all precincts', async () => {
-  const card = new MemoryCard();
-  const hardware = MemoryHardware.buildStandard();
-  const storage = new MemoryStorage();
-  await storage.set(stateStorageKey, { isPollsOpen: true });
+  mockPollsState('polls_open');
 
   fetchMock
     .get('/precinct-scanner/config/election', {
@@ -945,8 +921,8 @@ test('printing: polls closed, general election, all precincts', async () => {
     .get('/precinct-scanner/scanner/status', {
       body: { ...statusNoPaper, ballotsCounted: 2 },
     });
-  render(<App card={card} hardware={hardware} storage={storage} />);
-  await advanceTimersAndPromises(1);
+  const { card, renderApp } = buildApp(true);
+  renderApp();
   await screen.findByText('Insert Your Ballot Below');
 
   // Close the polls
@@ -955,8 +931,8 @@ test('printing: polls closed, general election, all precincts', async () => {
     electionSample2Definition.electionHash
   );
   card.insertCard(pollWorkerCard);
-  await advanceTimersAndPromises(1);
   await screen.findByText('Do you want to close the polls?');
+  mockPollsStateChange('polls_closed_final');
   userEvent.click(screen.getByText('Yes, Close the Polls'));
   await screen.findByText('Polls are closed.');
 
@@ -1034,14 +1010,8 @@ test('printing: polls closed, general election, all precincts', async () => {
 });
 
 test('saving to card: polls closed, general election, all precincts', async () => {
-  const card = new MemoryCard();
-  const writeLongObjectMock = jest.spyOn(card, 'writeLongObject');
-  const hardware = MemoryHardware.buildStandard();
-  hardware.setPrinterConnected(false);
-  const storage = new MemoryStorage();
-  await storage.set(stateStorageKey, { isPollsOpen: true });
   const { election } = electionSample2Definition;
-
+  mockPollsState('polls_open');
   fetchMock
     .get('/precinct-scanner/config/election', {
       body: electionSample2Definition,
@@ -1052,8 +1022,9 @@ test('saving to card: polls closed, general election, all precincts', async () =
     .get('/precinct-scanner/scanner/status', {
       body: { ...statusNoPaper, ballotsCounted: 2 },
     });
-  render(<App card={card} hardware={hardware} storage={storage} />);
-  await advanceTimersAndPromises(1);
+  const { card, renderApp } = buildApp();
+  const writeLongObjectMock = jest.spyOn(card, 'writeLongObject');
+  renderApp();
   await screen.findByText('Insert Your Ballot Below');
 
   // Close the polls
@@ -1062,9 +1033,9 @@ test('saving to card: polls closed, general election, all precincts', async () =
     electionSample2Definition.electionHash
   );
   card.insertCard(pollWorkerCard);
-  await advanceTimersAndPromises(1);
   await screen.findByText('Do you want to close the polls?');
-  fireEvent.click(await screen.findByText('Yes, Close the Polls'));
+  mockPollsStateChange('polls_closed_final');
+  userEvent.click(await screen.findByText('Yes, Close the Polls'));
   await screen.findByText('Polls are closed.');
   card.removeCard();
   await advanceTimersAndPromises(1);
@@ -1097,6 +1068,7 @@ test('saving to card: polls closed, general election, all precincts', async () =
       tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 2,
       machineId: '0002',
+      timePollsToggled: expect.anything(),
       timeSaved: expect.anything(),
       precinctSelection: ALL_PRECINCTS_SELECTION,
       tally: expectedCombinedTally,
@@ -1135,11 +1107,7 @@ const GENERAL_SINGLE_PRECINCT_CVRS = generateFileContentFromCvrs([
 ]);
 
 test('printing: polls closed, general election, single precinct', async () => {
-  const card = new MemoryCard();
-  const hardware = MemoryHardware.buildStandard();
-  const storage = new MemoryStorage();
-  await storage.set(stateStorageKey, { isPollsOpen: true });
-
+  mockPollsState('polls_open');
   fetchMock
     .get('/precinct-scanner/config/election', {
       body: electionSample2Definition,
@@ -1150,8 +1118,8 @@ test('printing: polls closed, general election, single precinct', async () => {
     .get('/precinct-scanner/scanner/status', {
       body: { ...statusNoPaper, ballotsCounted: 2 },
     });
-  render(<App card={card} hardware={hardware} storage={storage} />);
-  await advanceTimersAndPromises(1);
+  const { card, renderApp } = buildApp(true);
+  renderApp();
   await screen.findByText('Insert Your Ballot Below');
 
   // Close the polls
@@ -1160,8 +1128,8 @@ test('printing: polls closed, general election, single precinct', async () => {
     electionSample2Definition.electionHash
   );
   card.insertCard(pollWorkerCard);
-  await advanceTimersAndPromises(1);
   await screen.findByText('Do you want to close the polls?');
+  mockPollsStateChange('polls_closed_final');
   userEvent.click(await screen.findByText('Yes, Close the Polls'));
   await screen.findByText('Polls are closed.');
 
@@ -1211,12 +1179,7 @@ test('printing: polls closed, general election, single precinct', async () => {
 });
 
 test('saving to card: polls closed, general election, single precinct', async () => {
-  const card = new MemoryCard();
-  const writeLongObjectMock = jest.spyOn(card, 'writeLongObject');
-  const hardware = MemoryHardware.buildStandard();
-  hardware.setPrinterConnected(false);
-  const storage = new MemoryStorage();
-  await storage.set(stateStorageKey, { isPollsOpen: true });
+  mockPollsState('polls_open');
   const { election } = electionSample2Definition;
 
   fetchMock
@@ -1229,8 +1192,9 @@ test('saving to card: polls closed, general election, single precinct', async ()
     .get('/precinct-scanner/scanner/status', {
       body: { ...statusNoPaper, ballotsCounted: 2 },
     });
-  render(<App card={card} hardware={hardware} storage={storage} />);
-  await advanceTimersAndPromises(1);
+  const { card, renderApp } = buildApp();
+  const writeLongObjectMock = jest.spyOn(card, 'writeLongObject');
+  renderApp();
   await screen.findByText('Insert Your Ballot Below');
 
   // Close the polls
@@ -1239,8 +1203,8 @@ test('saving to card: polls closed, general election, single precinct', async ()
     electionSample2Definition.electionHash
   );
   card.insertCard(pollWorkerCard);
-  await advanceTimersAndPromises(1);
   await screen.findByText('Do you want to close the polls?');
+  mockPollsStateChange('polls_closed_final');
   userEvent.click(await screen.findByText('Yes, Close the Polls'));
   await screen.findByText('Polls are closed.');
   card.removeCard();
@@ -1264,12 +1228,188 @@ test('saving to card: polls closed, general election, single precinct', async ()
       tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 2,
       machineId: '0002',
+      timePollsToggled: expect.anything(),
       timeSaved: expect.anything(),
       precinctSelection: singlePrecinctSelectionFor('23'),
       tally: expectedCombinedTally,
       talliesByPrecinct: expectedTalliesByPrecinct,
       ballotCounts: expectedBallotCounts,
       isPollsOpen: false,
+    })
+  );
+});
+
+test('TODO printing: polls paused', async () => {
+  mockPollsState('polls_open');
+  fetchMock
+    .get('/precinct-scanner/config/election', {
+      body: electionSample2Definition,
+    })
+    .get('/precinct-scanner/config/precinct', {
+      body: getPrecinctConfigPrecinct23ResponseBody,
+    })
+    .get('/precinct-scanner/scanner/status', {
+      body: { ...statusNoPaper, ballotsCounted: 2 },
+    });
+  const { card, renderApp } = buildApp(true);
+  renderApp();
+  await screen.findByText('Insert Your Ballot Below');
+
+  // Close the polls
+  fetchMock.post('/precinct-scanner/export', GENERAL_SINGLE_PRECINCT_CVRS);
+  const pollWorkerCard = makePollWorkerCard(
+    electionSample2Definition.electionHash
+  );
+  card.insertCard(pollWorkerCard);
+  await screen.findByText('Do you want to close the polls?');
+  userEvent.click(await screen.findByText('No'));
+  mockPollsStateChange('polls_paused');
+  userEvent.click(
+    await screen.findByText('Pause Polls for Center Springfield')
+  );
+  await screen.findByText('Polls are paused.');
+
+  await expectPrint((printedElement) => {
+    printedElement.getByText('TEST Polls Closed Report for Center Springfield');
+    // TODO: Write testing once polls paused reports are designed vxsuite#2686
+  });
+});
+
+test('saving to card: polls paused', async () => {
+  mockPollsState('polls_open');
+  fetchMock
+    .get('/precinct-scanner/config/election', {
+      body: electionSample2Definition,
+    })
+    .get('/precinct-scanner/config/precinct', {
+      body: getPrecinctConfigPrecinct23ResponseBody,
+    })
+    .get('/precinct-scanner/scanner/status', {
+      body: { ...statusNoPaper, ballotsCounted: 2 },
+    });
+  const { card, renderApp } = buildApp();
+  const writeLongObjectMock = jest.spyOn(card, 'writeLongObject');
+  renderApp();
+  await screen.findByText('Insert Your Ballot Below');
+
+  // Pause the polls
+  fetchMock.post('/precinct-scanner/export', GENERAL_SINGLE_PRECINCT_CVRS);
+  const pollWorkerCard = makePollWorkerCard(
+    electionSample2Definition.electionHash
+  );
+  card.insertCard(pollWorkerCard);
+  await screen.findByText('Do you want to close the polls?');
+  userEvent.click(screen.getByText('No'));
+  mockPollsStateChange('polls_paused');
+  userEvent.click(
+    await screen.findByText('Pause Polls for Center Springfield')
+  );
+  await screen.findByText('Polls are paused.');
+  card.removeCard();
+  await advanceTimersAndPromises(1);
+
+  const expectedBallotCounts: Dictionary<BallotCountDetails> = {
+    'undefined,__ALL_PRECINCTS': [1, 1],
+    'undefined,23': [1, 1],
+  };
+  expect(writeLongObjectMock).toHaveBeenCalledTimes(1);
+  expect(writeLongObjectMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      isLiveMode: false,
+      tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
+      totalBallotsScanned: 2,
+      machineId: '0002',
+      timePollsToggled: expect.anything(),
+      timeSaved: expect.anything(),
+      precinctSelection: singlePrecinctSelectionFor('23'),
+      tally: expect.anything(),
+      talliesByPrecinct: expect.anything(),
+      ballotCounts: expectedBallotCounts,
+      isPollsOpen: false,
+    })
+  );
+});
+
+test('TODO printing: polls unpaused', async () => {
+  mockPollsState('polls_paused');
+  fetchMock
+    .get('/precinct-scanner/config/election', {
+      body: electionSample2Definition,
+    })
+    .get('/precinct-scanner/config/precinct', {
+      body: getPrecinctConfigPrecinct23ResponseBody,
+    })
+    .get('/precinct-scanner/scanner/status', {
+      body: { ...statusNoPaper, ballotsCounted: 2 },
+    });
+  const { card, renderApp } = buildApp(true);
+  renderApp();
+  await screen.findByText('Polls Paused');
+
+  // Unpause the polls
+  fetchMock.post('/precinct-scanner/export', GENERAL_SINGLE_PRECINCT_CVRS);
+  const pollWorkerCard = makePollWorkerCard(
+    electionSample2Definition.electionHash
+  );
+  card.insertCard(pollWorkerCard);
+  await screen.findByText('Do you want to open the polls?');
+  userEvent.click(await screen.findByText('Yes, Open the Polls'));
+  mockPollsStateChange('polls_open');
+  await screen.findByText('Polls are open.');
+
+  await expectPrint((printedElement) => {
+    printedElement.getByText('TEST Polls Opened Report for Center Springfield');
+    // TODO: Write testing once polls paused reports are designed vxsuite#2686
+  });
+});
+
+test('saving to card: polls unpaused', async () => {
+  mockPollsState('polls_paused');
+  fetchMock
+    .get('/precinct-scanner/config/election', {
+      body: electionSample2Definition,
+    })
+    .get('/precinct-scanner/config/precinct', {
+      body: getPrecinctConfigPrecinct23ResponseBody,
+    })
+    .get('/precinct-scanner/scanner/status', {
+      body: { ...statusNoPaper, ballotsCounted: 2 },
+    });
+  const { card, renderApp } = buildApp();
+  const writeLongObjectMock = jest.spyOn(card, 'writeLongObject');
+  renderApp();
+
+  // Unpause the polls
+  fetchMock.post('/precinct-scanner/export', GENERAL_SINGLE_PRECINCT_CVRS);
+  const pollWorkerCard = makePollWorkerCard(
+    electionSample2Definition.electionHash
+  );
+  card.insertCard(pollWorkerCard);
+  await screen.findByText('Do you want to open the polls?');
+  userEvent.click(screen.getByText('Yes, Open the Polls'));
+  mockPollsStateChange('polls_open');
+  await screen.findByText('Polls are open.');
+  card.removeCard();
+  await advanceTimersAndPromises(1);
+
+  const expectedBallotCounts: Dictionary<BallotCountDetails> = {
+    'undefined,__ALL_PRECINCTS': [1, 1],
+    'undefined,23': [1, 1],
+  };
+  expect(writeLongObjectMock).toHaveBeenCalledTimes(1);
+  expect(writeLongObjectMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      isLiveMode: false,
+      tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
+      totalBallotsScanned: 2,
+      machineId: '0002',
+      timePollsToggled: expect.anything(),
+      timeSaved: expect.anything(),
+      precinctSelection: singlePrecinctSelectionFor('23'),
+      tally: expect.anything(),
+      talliesByPrecinct: expect.anything(),
+      ballotCounts: expectedBallotCounts,
+      isPollsOpen: true,
     })
   );
 });

--- a/frontends/precinct-scanner/src/components/change_precinct_button.test.tsx
+++ b/frontends/precinct-scanner/src/components/change_precinct_button.test.tsx
@@ -1,21 +1,85 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { electionMinimalExhaustiveSample } from '@votingworks/fixtures';
-import { singlePrecinctSelectionFor } from '@votingworks/utils';
+import {
+  ALL_PRECINCTS_SELECTION,
+  singlePrecinctSelectionFor,
+} from '@votingworks/utils';
 import userEvent from '@testing-library/user-event';
 import {
   ALL_PRECINCTS_OPTION_VALUE,
   ChangePrecinctButton,
+  SELECT_PRECINCT_TEXT,
 } from './change_precinct_button';
 
-test('change precinct button flow', async () => {
+test('polls closed initial: set precinct initially', async () => {
   const updatePrecinctSelection = jest.fn();
 
   render(
     <ChangePrecinctButton
+      appPrecinctSelection={undefined}
       updatePrecinctSelection={updatePrecinctSelection}
-      initialPrecinctSelection={singlePrecinctSelectionFor('precinct-1')}
       election={electionMinimalExhaustiveSample}
+      ballotsCast={false}
+      pollsState="polls_closed_initial"
+    />
+  );
+
+  // Dropdown defaults to disabled selection prompt
+  const dropdown = await screen.findByTestId('selectPrecinct');
+  screen.getByRole('option', { name: SELECT_PRECINCT_TEXT, selected: true });
+  expect(
+    screen.getByRole('option', { name: SELECT_PRECINCT_TEXT })
+  ).toBeDisabled();
+
+  // Updates app state
+  userEvent.selectOptions(dropdown, 'precinct-1');
+  expect(updatePrecinctSelection).toHaveBeenCalledTimes(1);
+  expect(updatePrecinctSelection).toHaveBeenCalledWith(
+    expect.objectContaining(singlePrecinctSelectionFor('precinct-1'))
+  );
+
+  // Prompt is still disabled
+  expect(
+    screen.getByRole('option', { name: SELECT_PRECINCT_TEXT })
+  ).toBeDisabled();
+});
+
+test('polls closed initial: switch precinct', async () => {
+  const updatePrecinctSelection = jest.fn();
+
+  render(
+    <ChangePrecinctButton
+      appPrecinctSelection={ALL_PRECINCTS_SELECTION}
+      updatePrecinctSelection={updatePrecinctSelection}
+      election={electionMinimalExhaustiveSample}
+      ballotsCast={false}
+      pollsState="polls_closed_initial"
+    />
+  );
+
+  // Dropdown starts on All Precincts, which is disabled since it is selected
+  const dropdown = await screen.findByTestId('selectPrecinct');
+  screen.getByRole('option', { name: 'All Precincts', selected: true });
+  expect(screen.getByRole('option', { name: 'All Precincts' })).toBeDisabled();
+
+  userEvent.selectOptions(dropdown, 'precinct-2');
+  expect(updatePrecinctSelection).toHaveBeenCalledTimes(1);
+  expect(updatePrecinctSelection).toHaveBeenCalledWith(
+    expect.objectContaining(singlePrecinctSelectionFor('precinct-2'))
+  );
+});
+
+test('polls open, no ballots: selection behind confirmation', async () => {
+  const updatePrecinctSelection = jest.fn();
+
+  render(
+    <ChangePrecinctButton
+      appPrecinctSelection={singlePrecinctSelectionFor('precinct-1')}
+      updatePrecinctSelection={updatePrecinctSelection}
+      election={electionMinimalExhaustiveSample}
+      ballotsCast={false}
+      pollsState="polls_open"
     />
   );
 
@@ -27,31 +91,30 @@ test('change precinct button flow', async () => {
   userEvent.click(mainButton);
   screen.getByRole('alertdialog');
 
-  // Loads with the initial precinct and confirm disabled
-  screen.getByText('Precinct 1');
+  // Loads with the initial precinct and confirm, which is disabled as an option
+  screen.getByRole('option', { name: 'Precinct 1', selected: true });
+  expect(screen.getByRole('option', { name: 'Precinct 1' })).toBeDisabled();
   expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
 
-  // Can select other precincts;
+  // Can select another single precinct, which enables confirmation
   userEvent.selectOptions(screen.getByTestId('selectPrecinct'), 'precinct-2');
-  screen.getByText('Precinct 2');
+  screen.getByRole('option', { name: 'Precinct 2', selected: true });
   expect(screen.getByRole('button', { name: 'Confirm' })).not.toBeDisabled();
-  userEvent.selectOptions(
-    screen.getByTestId('selectPrecinct'),
-    ALL_PRECINCTS_OPTION_VALUE
-  );
-  screen.getByText('All Precincts');
-  expect(screen.getByRole('button', { name: 'Confirm' })).not.toBeDisabled();
+  expect(screen.getByRole('option', { name: 'Precinct 1' })).toBeDisabled();
 
   // Can close modal, re-open, and we will be back to default
   userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
   expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
   userEvent.click(mainButton);
-  screen.getByText('Precinct 1');
+  screen.getByRole('option', { name: 'Precinct 1', selected: true });
   expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
 
   // Can select and confirm a precinct
-  userEvent.selectOptions(screen.getByTestId('selectPrecinct'), 'precinct-2');
-  screen.getByText('Precinct 2');
+  userEvent.selectOptions(
+    screen.getByTestId('selectPrecinct'),
+    ALL_PRECINCTS_OPTION_VALUE
+  );
+  screen.getByRole('option', { name: 'All Precincts', selected: true });
   userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
   await waitFor(() => {
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
@@ -59,19 +122,33 @@ test('change precinct button flow', async () => {
   expect(updatePrecinctSelection).toHaveBeenCalledTimes(1);
   expect(updatePrecinctSelection).toHaveBeenLastCalledWith(
     expect.objectContaining({
-      kind: 'SinglePrecinct',
-      precinctId: 'precinct-2',
+      kind: 'AllPrecincts',
     })
   );
 });
 
-test('disabled if set as disabled', () => {
+test('disabled if ballots cast', () => {
   render(
     <ChangePrecinctButton
+      appPrecinctSelection={undefined}
       updatePrecinctSelection={jest.fn()}
-      initialPrecinctSelection={singlePrecinctSelectionFor('precinct-1')}
       election={electionMinimalExhaustiveSample}
-      disabled
+      ballotsCast
+      pollsState="polls_open"
+    />
+  );
+
+  expect(screen.getByText('Change Precinct')).toBeDisabled();
+});
+
+test('disabled if polls closed final', () => {
+  render(
+    <ChangePrecinctButton
+      appPrecinctSelection={undefined}
+      updatePrecinctSelection={jest.fn()}
+      election={electionMinimalExhaustiveSample}
+      ballotsCast={false}
+      pollsState="polls_closed_final"
     />
   );
 

--- a/frontends/precinct-scanner/src/components/change_precinct_button.test.tsx
+++ b/frontends/precinct-scanner/src/components/change_precinct_button.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { electionMinimalExhaustiveSample } from '@votingworks/fixtures';
+import { singlePrecinctSelectionFor } from '@votingworks/utils';
+import userEvent from '@testing-library/user-event';
+import {
+  ALL_PRECINCTS_OPTION_VALUE,
+  ChangePrecinctButton,
+} from './change_precinct_button';
+
+test('change precinct button flow', async () => {
+  const updatePrecinctSelection = jest.fn();
+
+  render(
+    <ChangePrecinctButton
+      updatePrecinctSelection={updatePrecinctSelection}
+      initialPrecinctSelection={singlePrecinctSelectionFor('precinct-1')}
+      election={electionMinimalExhaustiveSample}
+    />
+  );
+
+  // Initially it's the button only
+  const mainButton = screen.getByRole('button', { name: 'Change Precinct' });
+  expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+
+  // Press the button and modal opens
+  userEvent.click(mainButton);
+  screen.getByRole('alertdialog');
+
+  // Loads with the initial precinct and confirm disabled
+  screen.getByText('Precinct 1');
+  expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
+
+  // Can select other precincts;
+  userEvent.selectOptions(screen.getByTestId('selectPrecinct'), 'precinct-2');
+  screen.getByText('Precinct 2');
+  expect(screen.getByRole('button', { name: 'Confirm' })).not.toBeDisabled();
+  userEvent.selectOptions(
+    screen.getByTestId('selectPrecinct'),
+    ALL_PRECINCTS_OPTION_VALUE
+  );
+  screen.getByText('All Precincts');
+  expect(screen.getByRole('button', { name: 'Confirm' })).not.toBeDisabled();
+
+  // Can close modal, re-open, and we will be back to default
+  userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+  expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  userEvent.click(mainButton);
+  screen.getByText('Precinct 1');
+  expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
+
+  // Can select and confirm a precinct
+  userEvent.selectOptions(screen.getByTestId('selectPrecinct'), 'precinct-2');
+  screen.getByText('Precinct 2');
+  userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+  await waitFor(() => {
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
+  expect(updatePrecinctSelection).toHaveBeenCalledTimes(1);
+  expect(updatePrecinctSelection).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      kind: 'SinglePrecinct',
+      precinctId: 'precinct-2',
+    })
+  );
+});
+
+test('disabled if set as disabled', () => {
+  render(
+    <ChangePrecinctButton
+      updatePrecinctSelection={jest.fn()}
+      initialPrecinctSelection={singlePrecinctSelectionFor('precinct-1')}
+      election={electionMinimalExhaustiveSample}
+      disabled
+    />
+  );
+
+  expect(screen.getByText('Change Precinct')).toBeDisabled();
+});

--- a/frontends/precinct-scanner/src/components/change_precinct_button.tsx
+++ b/frontends/precinct-scanner/src/components/change_precinct_button.tsx
@@ -1,0 +1,132 @@
+import React, { useState } from 'react';
+import { Button, Modal, Prose, Select } from '@votingworks/ui';
+import {
+  Election,
+  PrecinctSelection,
+  SelectChangeEventFunction,
+} from '@votingworks/types';
+import {
+  ALL_PRECINCTS_NAME,
+  ALL_PRECINCTS_SELECTION,
+  areEqualPrecinctSelections,
+  singlePrecinctSelectionFor,
+} from '@votingworks/utils';
+
+export const ALL_PRECINCTS_OPTION_VALUE = 'ALL_PRECINCTS_OPTION_VALUE';
+
+export interface ChangePrecinctButtonProps {
+  initialPrecinctSelection: PrecinctSelection;
+  updatePrecinctSelection: (
+    precinctSelection: PrecinctSelection
+  ) => Promise<void>;
+  election: Election;
+  disabled?: boolean;
+}
+
+export function ChangePrecinctButton({
+  initialPrecinctSelection,
+  updatePrecinctSelection,
+  election,
+  disabled,
+}: ChangePrecinctButtonProps): JSX.Element {
+  const [isModalShowing, setIsModalShowing] = useState(false);
+  const [pendingPrecinctSelection, setPendingPrecinctSelection] = useState(
+    initialPrecinctSelection
+  );
+
+  function openModal() {
+    setIsModalShowing(true);
+  }
+
+  function closeModal() {
+    setIsModalShowing(false);
+    setPendingPrecinctSelection(initialPrecinctSelection);
+  }
+
+  const handlePendingPrecinctSelectionChange: SelectChangeEventFunction = (
+    event
+  ) => {
+    const { value } = event.currentTarget;
+    const newPrecinctSelection =
+      value === ALL_PRECINCTS_OPTION_VALUE
+        ? ALL_PRECINCTS_SELECTION
+        : singlePrecinctSelectionFor(value);
+
+    setPendingPrecinctSelection(newPrecinctSelection);
+  };
+
+  async function confirmPrecinctChange() {
+    await updatePrecinctSelection(pendingPrecinctSelection);
+    closeModal();
+  }
+
+  const pendingPrecinctSelectionValue =
+    pendingPrecinctSelection.kind === 'AllPrecincts'
+      ? ALL_PRECINCTS_OPTION_VALUE
+      : pendingPrecinctSelection.precinctId;
+
+  return (
+    <React.Fragment>
+      <Button onPress={openModal} large disabled={disabled}>
+        Change Precinct
+      </Button>
+      {isModalShowing && (
+        <Modal
+          content={
+            <Prose>
+              <h1>Change Precinct</h1>
+              <p>
+                WARNING: The polls are open on this machine. Changing the
+                precinct will reset the polls to closed. To resume voting, the
+                polls must be reopened. Please select a precinct and confirm
+                below.
+              </p>
+              <Prose textCenter>
+                <Select
+                  id="selectPrecinct"
+                  data-testid="selectPrecinct"
+                  value={pendingPrecinctSelectionValue}
+                  onBlur={handlePendingPrecinctSelectionChange}
+                  onChange={handlePendingPrecinctSelectionChange}
+                >
+                  {election.precincts.length > 1 && (
+                    <option value={ALL_PRECINCTS_OPTION_VALUE}>
+                      {ALL_PRECINCTS_NAME}
+                    </option>
+                  )}
+                  {[...election.precincts]
+                    .sort((a, b) =>
+                      a.name.localeCompare(b.name, undefined, {
+                        ignorePunctuation: true,
+                      })
+                    )
+                    .map((precinct) => (
+                      <option key={precinct.id} value={precinct.id}>
+                        {precinct.name}
+                      </option>
+                    ))}
+                </Select>
+              </Prose>
+            </Prose>
+          }
+          actions={
+            <React.Fragment>
+              <Button
+                danger
+                onPress={confirmPrecinctChange}
+                disabled={areEqualPrecinctSelections(
+                  initialPrecinctSelection,
+                  pendingPrecinctSelection
+                )}
+              >
+                Confirm
+              </Button>
+              <Button onPress={closeModal}>Cancel</Button>
+            </React.Fragment>
+          }
+          onOverlayClick={closeModal}
+        />
+      )}
+    </React.Fragment>
+  );
+}

--- a/frontends/precinct-scanner/src/components/change_precinct_button.tsx
+++ b/frontends/precinct-scanner/src/components/change_precinct_button.tsx
@@ -9,9 +9,7 @@ import {
 import {
   ALL_PRECINCTS_NAME,
   ALL_PRECINCTS_SELECTION,
-  areEqualPrecinctSelections,
   assert,
-  assertDefined,
   singlePrecinctSelectionFor,
 } from '@votingworks/utils';
 
@@ -149,13 +147,7 @@ export function ChangePrecinctButton({
               <Button
                 danger
                 onPress={confirmPrecinctChange}
-                disabled={
-                  !unconfirmedPrecinctSelection ||
-                  areEqualPrecinctSelections(
-                    assertDefined(appPrecinctSelection),
-                    unconfirmedPrecinctSelection
-                  )
-                }
+                disabled={!unconfirmedPrecinctSelection}
               >
                 Confirm
               </Button>

--- a/frontends/precinct-scanner/src/preview_app.tsx
+++ b/frontends/precinct-scanner/src/preview_app.tsx
@@ -14,7 +14,7 @@ import * as ElectionManagerScreen from './screens/election_manager_screen';
 import * as InsertBallotScreen from './screens/insert_ballot_screen';
 import * as InvalidCardScreen from './screens/invalid_card_screen';
 import * as LoadingConfigurationScreen from './screens/loading_configuration_screen';
-import * as PollsClosedScreen from './screens/polls_closed_screen';
+import * as PollsNotOpenScreen from './screens/polls_not_open_screen';
 import * as PollWorkerScreen from './screens/poll_worker_screen';
 import * as ScanErrorScreen from './screens/scan_error_screen';
 import * as ScanProcessingScreen from './screens/scan_processing_screen';
@@ -42,7 +42,7 @@ export function PreviewApp(): JSX.Element {
         InsertBallotScreen,
         InvalidCardScreen,
         LoadingConfigurationScreen,
-        PollsClosedScreen,
+        PollsNotOpenScreen,
         PollWorkerScreen,
         ScanErrorScreen,
         ScanProcessingScreen,

--- a/frontends/precinct-scanner/src/screens/election_manager_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/election_manager_screen.test.tsx
@@ -13,11 +13,7 @@ import {
   electionSampleDefinition,
 } from '@votingworks/fixtures';
 import { fakeKiosk, Inserted } from '@votingworks/test-utils';
-import {
-  ALL_PRECINCTS_NAME,
-  singlePrecinctSelectionFor,
-  usbstick,
-} from '@votingworks/utils';
+import { singlePrecinctSelectionFor, usbstick } from '@votingworks/utils';
 import MockDate from 'mockdate';
 import React from 'react';
 import { AppContext, AppContextInterface } from '../contexts/app_context';
@@ -110,77 +106,32 @@ test('renders date and time settings modal', async () => {
   screen.getByText(startDate);
 });
 
-describe('setting the precinct', () => {
-  test('can set with dropdown if polls have not been opened', async () => {
-    const updatePrecinctSelection = jest.fn();
-    renderScreen({ electionManagerScreenProps: { updatePrecinctSelection } });
+test('option to set precinct if more than one', async () => {
+  const updatePrecinctSelection = jest.fn();
+  renderScreen({ electionManagerScreenProps: { updatePrecinctSelection } });
 
-    const precinct = electionSampleDefinition.election.precincts[0];
-    const selectPrecinct = await screen.findByTestId('selectPrecinct');
+  const precinct = electionSampleDefinition.election.precincts[0];
+  const selectPrecinct = await screen.findByTestId('selectPrecinct');
 
-    // set precinct
-    userEvent.selectOptions(selectPrecinct, precinct.id);
-    expect(updatePrecinctSelection).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining(singlePrecinctSelectionFor(precinct.id))
-    );
+  // set precinct
+  userEvent.selectOptions(selectPrecinct, precinct.id);
+  expect(updatePrecinctSelection).toHaveBeenNthCalledWith(
+    1,
+    expect.objectContaining(singlePrecinctSelectionFor(precinct.id))
+  );
+});
+
+test('no option to change precinct if there is only one precinct', async () => {
+  renderScreen({
+    appContextProps: {
+      electionDefinition:
+        electionMinimalExhaustiveSampleSinglePrecinctDefinition,
+      precinctSelection: singlePrecinctSelectionFor('precinct-1'),
+    },
   });
 
-  test('All Precincts not an option in dropdown if only one precinct', async () => {
-    renderScreen({
-      appContextProps: {
-        electionDefinition:
-          electionMinimalExhaustiveSampleSinglePrecinctDefinition,
-        precinctSelection: singlePrecinctSelectionFor('precinct-1'),
-      },
-    });
-
-    await screen.findByText('Precinct 1');
-    expect(screen.queryByText(ALL_PRECINCTS_NAME)).not.toBeInTheDocument();
-  });
-
-  test('shows Change Precinct button instead of polls open and no ballots cast', () => {
-    renderScreen({
-      appContextProps: {
-        precinctSelection: singlePrecinctSelectionFor('23'),
-      },
-      electionManagerScreenProps: {
-        pollsState: 'polls_open',
-      },
-    });
-    screen.getByRole('button', { name: 'Change Precinct' });
-    expect(screen.queryByTestId('selectPrecinct')).not.toBeInTheDocument();
-  });
-
-  test('shows disabled Change Precinct button if ballots have been cast', () => {
-    renderScreen({
-      appContextProps: {
-        precinctSelection: singlePrecinctSelectionFor('23'),
-      },
-      electionManagerScreenProps: {
-        pollsState: 'polls_open',
-        scannerStatus: {
-          ...scannerStatus,
-          ballotsCounted: 1,
-        },
-      },
-    });
-    expect(screen.queryByText('Change Precinct')).toBeDisabled();
-    expect(screen.queryByTestId('selectPrecinct')).not.toBeInTheDocument();
-  });
-
-  test('no options to change if polls are closed and final', () => {
-    renderScreen({
-      appContextProps: {
-        precinctSelection: singlePrecinctSelectionFor('23'),
-      },
-      electionManagerScreenProps: {
-        pollsState: 'polls_closed_final',
-      },
-    });
-    expect(screen.queryByText('Change Precinct')).toBeDisabled();
-    expect(screen.queryByTestId('selectPrecinct')).not.toBeInTheDocument();
-  });
+  await screen.findByText('Election Manager Settings');
+  expect(screen.queryByTestId('selectPrecinct')).not.toBeInTheDocument();
 });
 
 test('export from admin screen', () => {

--- a/frontends/precinct-scanner/src/screens/poll_worker_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/poll_worker_screen.tsx
@@ -5,7 +5,6 @@ import {
   Button,
   Prose,
   Loading,
-  UsbDrive,
   isPollWorkerAuth,
   DEFAULT_NUMBER_POLL_REPORT_COPIES,
   fontSizeTheme,
@@ -28,6 +27,9 @@ import {
   singlePrecinctSelectionFor,
   sleep,
   TallySourceMachineType,
+  throwIllegalValue,
+  getPollsTransitionDestinationState,
+  getPollsReportTitle,
 } from '@votingworks/utils';
 import {
   CastVoteRecord,
@@ -39,13 +41,15 @@ import {
   CompressedTally,
   getPartyIdsInBallotStyles,
   InsertedSmartcardAuth,
+  PollsState,
+  PollsTransition,
+  Optional,
 } from '@votingworks/types';
 import {
   CenteredLargeProse,
   ScreenMainCenterChild,
 } from '../components/layout';
 
-import { ExportResultsModal } from '../components/export_results_modal';
 import { LiveCheckModal } from '../components/live_check_modal';
 
 import { AppContext } from '../contexts/app_context';
@@ -56,14 +60,24 @@ import * as scan from '../api/scan';
 
 export const REPRINT_REPORT_TIMEOUT_SECONDS = 4;
 
-enum PollWorkerFlowState {
-  OPEN_POLLS_FLOW__CONFIRM = 'open polls flow: confirm',
-  OPEN_POLLS_FLOW__PROCESSING = 'open polls flow: processing',
-  OPEN_POLLS_FLOW__COMPLETE = 'open polls flow: complete',
-  CLOSE_POLLS_FLOW__CONFIRM = 'close polls flow: confirm',
-  CLOSE_POLLS_FLOW__PROCESSING = 'close polls flow: processing',
-  CLOSE_POLLS_FLOW__COMPLETE = 'close polls flow: complete',
-  EITHER_FLOW__REPRINTING = 'either polls flow: reprinting',
+type PollWorkerFlowState =
+  | 'open_polls_prompt'
+  | 'close_polls_prompt'
+  | 'polls_transition_processing'
+  | 'polls_transition_complete'
+  | 'reprinting_report';
+
+// TODO: Remove this. This is a temporary conversion of the new type for
+// polls reports (open, close, pause, unpause) to the old way (boolean).
+// Using while the reports themselves have not been updated yet.
+function pollsTransitionToPollsOpen(pollsTransition: PollsTransition): boolean {
+  switch (pollsTransition) {
+    case 'open_polls':
+    case 'unpause_polls':
+      return true;
+    default:
+      return false;
+  }
 }
 
 async function saveTallyToCard(
@@ -89,23 +103,21 @@ async function getCvrsFromExport(): Promise<CastVoteRecord[]> {
 
 const debug = makeDebug('precinct-scanner:pollworker-screen');
 
-interface Props {
+export interface PollWorkerScreenProps {
   scannedBallotCount: number;
-  isPollsOpen: boolean;
+  pollsState: PollsState;
+  updatePollsState: (newPollsState: PollsState) => void;
   isLiveMode: boolean;
-  togglePollsOpen: () => void;
   hasPrinterAttached: boolean;
-  usbDrive: UsbDrive;
 }
 
 export function PollWorkerScreen({
   scannedBallotCount,
-  isPollsOpen,
-  togglePollsOpen,
+  pollsState,
+  updatePollsState,
   isLiveMode,
   hasPrinterAttached: printerFromProps,
-  usbDrive,
-}: Props): JSX.Element {
+}: PollWorkerScreenProps): JSX.Element {
   const { electionDefinition, precinctSelection, machineConfig, auth } =
     useContext(AppContext);
   assert(electionDefinition);
@@ -115,13 +127,29 @@ export function PollWorkerScreen({
   const [currentSubTallies, setCurrentSubTallies] = useState<
     ReadonlyMap<string, Tally>
   >(new Map());
-  const [isExportingResults, setIsExportingResults] = useState(false);
   const [isShowingLiveCheck, setIsShowingLiveCheck] = useState(false);
-  const [pollsToggledTime, setPollsToggledTime] = useState<number>();
   const hasPrinterAttached = printerFromProps || !window.kiosk;
   const { election } = electionDefinition;
 
-  const currentTime = Date.now();
+  function initialPollWorkerFlowState(): Optional<PollWorkerFlowState> {
+    switch (pollsState) {
+      case 'polls_closed_initial':
+      case 'polls_paused':
+        return 'open_polls_prompt';
+      case 'polls_open':
+        return 'close_polls_prompt';
+      default:
+        return undefined;
+    }
+  }
+
+  const [pollWorkerFlowState, setPollWorkerFlowState] = useState<
+    Optional<PollWorkerFlowState>
+  >(initialPollWorkerFlowState());
+  const [currentPollsTransition, setCurrentPollsTransition] =
+    useState<PollsTransition>();
+  const [currentPollsTransitionTime, setCurrentPollsTransitionTime] =
+    useState<number>();
 
   const currentCompressedTally = useMemo(
     () => currentTally && compressTally(election, currentTally.overallTally),
@@ -167,7 +195,10 @@ export function PollWorkerScreen({
     void calculateTally();
   }, [election, scannedBallotCount, precinctSelection]);
 
-  async function saveTally() {
+  async function saveTally(
+    pollsTransition: PollsTransition,
+    timePollsTransitioned: number
+  ) {
     assert(currentTally);
     let compressedTalliesByPrecinct: Dictionary<CompressedTally> = {};
     // We only need to save tallies by precinct if the precinct scanner is configured for all precincts
@@ -228,10 +259,10 @@ export function PollWorkerScreen({
       tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: scannedBallotCount,
       isLiveMode,
-      isPollsOpen: !isPollsOpen, // When we are saving we are about to either open or close polls and want the state to reflect what it will be after that is complete.
+      isPollsOpen: pollsTransitionToPollsOpen(pollsTransition),
       machineId: machineConfig.machineId,
-      timeSaved: currentTime,
-      timePollsToggled: currentTime,
+      timeSaved: Date.now(),
+      timePollsToggled: timePollsTransitioned,
       precinctSelection,
       ballotCounts: ballotCountBreakdowns,
       talliesByPrecinct: compressedTalliesByPrecinct,
@@ -253,29 +284,19 @@ export function PollWorkerScreen({
     }
   }
 
-  const [pollWorkerFlowState, setPollWorkerFlowState] = useState<
-    PollWorkerFlowState | undefined
-  >(
-    isPollsOpen
-      ? PollWorkerFlowState.CLOSE_POLLS_FLOW__CONFIRM
-      : PollWorkerFlowState.OPEN_POLLS_FLOW__CONFIRM
-  );
   function showAllPollWorkerActions() {
     return setPollWorkerFlowState(undefined);
   }
 
-  async function printTallyReport(copies: number) {
+  async function printTallyReport(
+    pollsTransition: PollsTransition,
+    timePollsTransitioned: number,
+    copies: number
+  ) {
     assert(electionDefinition);
     assert(precinctSelection);
     assert(currentCompressedTally);
     assert(currentSubTallies);
-
-    const isPollsOpenForReport =
-      pollWorkerFlowState === PollWorkerFlowState.EITHER_FLOW__REPRINTING ||
-      pollWorkerFlowState === PollWorkerFlowState.CLOSE_POLLS_FLOW__COMPLETE ||
-      pollWorkerFlowState === PollWorkerFlowState.OPEN_POLLS_FLOW__COMPLETE
-        ? isPollsOpen
-        : !isPollsOpen;
 
     const precinctSelectionList =
       precinctSelection.kind === 'SinglePrecinct'
@@ -295,10 +316,10 @@ export function PollWorkerScreen({
         electionDefinition={electionDefinition}
         precinctSelectionList={precinctSelectionList}
         subTallies={currentSubTallies}
-        isPollsOpen={isPollsOpenForReport}
+        isPollsOpen={pollsTransitionToPollsOpen(pollsTransition)}
         isLiveMode={isLiveMode}
-        pollsToggledTime={pollsToggledTime || currentTime}
-        currentTime={currentTime}
+        pollsToggledTime={timePollsTransitioned}
+        currentTime={Date.now()}
         precinctScannerMachineId={machineConfig.machineId}
         totalBallotsScanned={scannedBallotCount}
         signedQuickResultsReportingUrl={signedQuickResultsReportingUrl}
@@ -310,45 +331,72 @@ export function PollWorkerScreen({
     );
   }
 
-  async function dispatchReport() {
-    setPollsToggledTime(currentTime);
+  async function dispatchReport(
+    pollsTransition: PollsTransition,
+    timePollsTransitioned: number
+  ) {
     if (hasPrinterAttached) {
-      await printTallyReport(DEFAULT_NUMBER_POLL_REPORT_COPIES);
+      await printTallyReport(
+        pollsTransition,
+        timePollsTransitioned,
+        DEFAULT_NUMBER_POLL_REPORT_COPIES
+      );
     } else {
-      await saveTally();
+      await saveTally(pollsTransition, timePollsTransitioned);
     }
   }
 
-  async function openPolls() {
-    setPollWorkerFlowState(PollWorkerFlowState.OPEN_POLLS_FLOW__PROCESSING);
-    await dispatchReport();
-    togglePollsOpen();
-    setPollWorkerFlowState(PollWorkerFlowState.OPEN_POLLS_FLOW__COMPLETE);
-  }
-
-  async function closePolls() {
+  async function exportCvrs(): Promise<void> {
     assert(electionDefinition);
-    setPollWorkerFlowState(PollWorkerFlowState.CLOSE_POLLS_FLOW__PROCESSING);
-    await dispatchReport();
-    if (scannedBallotCount > 0) {
-      await saveCvrExportToUsb({
-        electionDefinition,
-        machineConfig,
-        scannedBallotCount,
-        isTestMode: !isLiveMode,
-        openFilePickerDialog: false,
-      });
+    await saveCvrExportToUsb({
+      electionDefinition,
+      machineConfig,
+      scannedBallotCount,
+      isTestMode: !isLiveMode,
+      openFilePickerDialog: false,
+    });
+  }
+
+  async function transitionPolls(pollsTransition: PollsTransition) {
+    const timePollsTransitioned = Date.now();
+    setCurrentPollsTransition(pollsTransition);
+    setPollWorkerFlowState('polls_transition_processing');
+    await dispatchReport(pollsTransition, timePollsTransitioned);
+    if (pollsTransition === 'close_polls' && scannedBallotCount > 0) {
+      await exportCvrs();
     }
-    togglePollsOpen();
-    setPollWorkerFlowState(PollWorkerFlowState.CLOSE_POLLS_FLOW__COMPLETE);
+    setCurrentPollsTransitionTime(timePollsTransitioned);
+    updatePollsState(getPollsTransitionDestinationState(pollsTransition));
+    setPollWorkerFlowState('polls_transition_complete');
+  }
+
+  function openPolls() {
+    return transitionPolls('open_polls');
+  }
+
+  function closePolls() {
+    return transitionPolls('close_polls');
+  }
+
+  function pausePolls() {
+    return transitionPolls('pause_polls');
+  }
+
+  function unpausePolls() {
+    return transitionPolls('unpause_polls');
   }
 
   async function reprintReport() {
-    const initialFlowState = pollWorkerFlowState;
-    setPollWorkerFlowState(PollWorkerFlowState.EITHER_FLOW__REPRINTING);
-    await printTallyReport(1);
+    assert(typeof currentPollsTransition === 'string');
+    assert(typeof currentPollsTransitionTime === 'number');
+    setPollWorkerFlowState('reprinting_report');
+    await printTallyReport(
+      currentPollsTransition,
+      currentPollsTransitionTime,
+      1
+    );
     await sleep(REPRINT_REPORT_TIMEOUT_SECONDS * 1000);
-    setPollWorkerFlowState(initialFlowState);
+    setPollWorkerFlowState('polls_transition_complete');
   }
 
   const precinctName = getPrecinctSelectionName(
@@ -366,13 +414,18 @@ export function PollWorkerScreen({
     );
   }
 
-  if (pollWorkerFlowState === PollWorkerFlowState.OPEN_POLLS_FLOW__CONFIRM) {
+  if (pollWorkerFlowState === 'open_polls_prompt') {
     return (
       <ScreenMainCenterChild infoBarMode="pollworker">
         <CenteredLargeProse>
           <p>Do you want to open the polls?</p>
           <p>
-            <Button primary onPress={openPolls}>
+            <Button
+              primary
+              onPress={
+                pollsState === 'polls_closed_initial' ? openPolls : unpausePolls
+              }
+            >
               Yes, Open the Polls
             </Button>{' '}
             <Button onPress={showAllPollWorkerActions}>No</Button>
@@ -382,41 +435,7 @@ export function PollWorkerScreen({
     );
   }
 
-  if (pollWorkerFlowState === PollWorkerFlowState.OPEN_POLLS_FLOW__PROCESSING) {
-    return (
-      <ScreenMainCenterChild infoBarMode="pollworker">
-        <IndeterminateProgressBar />
-        <CenteredLargeProse>
-          <h1>Opening Polls…</h1>
-        </CenteredLargeProse>
-      </ScreenMainCenterChild>
-    );
-  }
-
-  if (pollWorkerFlowState === PollWorkerFlowState.OPEN_POLLS_FLOW__COMPLETE) {
-    return (
-      <ScreenMainCenterChild infoBarMode="pollworker">
-        <CenteredLargeProse>
-          <h1>Polls are open.</h1>
-          {hasPrinterAttached ? (
-            <Prose theme={fontSizeTheme.medium}>
-              <Button onPress={reprintReport}>
-                Print Additional Polls Opened Report
-              </Button>
-              <p>
-                Remove the poll worker card if you have printed all necessary
-                reports.
-              </p>
-            </Prose>
-          ) : (
-            <p>Insert poll worker card into VxMark to print the report.</p>
-          )}
-        </CenteredLargeProse>
-      </ScreenMainCenterChild>
-    );
-  }
-
-  if (pollWorkerFlowState === PollWorkerFlowState.CLOSE_POLLS_FLOW__CONFIRM) {
+  if (pollWorkerFlowState === 'close_polls_prompt') {
     return (
       <ScreenMainCenterChild infoBarMode="pollworker">
         <CenteredLargeProse>
@@ -432,28 +451,60 @@ export function PollWorkerScreen({
     );
   }
 
-  if (
-    pollWorkerFlowState === PollWorkerFlowState.CLOSE_POLLS_FLOW__PROCESSING
-  ) {
+  if (pollWorkerFlowState === 'polls_transition_processing') {
+    assert(typeof currentPollsTransition === 'string');
+    const pollsTransitionProcessingText = (() => {
+      switch (currentPollsTransition) {
+        case 'close_polls':
+          return 'Closing Polls…';
+        case 'open_polls':
+          return 'Opening Polls…';
+        case 'pause_polls':
+          return 'Pausing Polls…';
+        case 'unpause_polls':
+          return 'Opening Polls…';
+        /* istanbul ignore next - compile-time check for completeness */
+        default:
+          throwIllegalValue(currentPollsTransition);
+      }
+    })();
+
     return (
       <ScreenMainCenterChild infoBarMode="pollworker">
         <IndeterminateProgressBar />
         <CenteredLargeProse>
-          <h1>Closing Polls…</h1>
+          <h1>{pollsTransitionProcessingText}</h1>
         </CenteredLargeProse>
       </ScreenMainCenterChild>
     );
   }
 
-  if (pollWorkerFlowState === PollWorkerFlowState.CLOSE_POLLS_FLOW__COMPLETE) {
+  if (pollWorkerFlowState === 'polls_transition_complete') {
+    assert(typeof currentPollsTransition === 'string');
+    const pollsTransitionCompleteText = (() => {
+      switch (currentPollsTransition) {
+        case 'close_polls':
+          return 'Polls are closed.';
+        case 'open_polls':
+          return 'Polls are open.';
+        case 'unpause_polls':
+          return 'Polls are open.';
+        case 'pause_polls':
+          return 'Polls are paused.';
+        /* istanbul ignore next - compile-time check for completeness */
+        default:
+          throwIllegalValue(currentPollsTransition);
+      }
+    })();
+
     return (
       <ScreenMainCenterChild infoBarMode="pollworker">
         <CenteredLargeProse>
-          <h1>Polls are closed.</h1>
+          <h1>{pollsTransitionCompleteText}</h1>
           {hasPrinterAttached ? (
             <Prose theme={fontSizeTheme.medium}>
               <Button onPress={reprintReport}>
-                Print Additional Polls Closed Report
+                Print Additional {getPollsReportTitle(currentPollsTransition)}
               </Button>
               <p>
                 Remove the poll worker card if you have printed all necessary
@@ -468,7 +519,7 @@ export function PollWorkerScreen({
     );
   }
 
-  if (pollWorkerFlowState === PollWorkerFlowState.EITHER_FLOW__REPRINTING) {
+  if (pollWorkerFlowState === 'reprinting_report') {
     return (
       <ScreenMainCenterChild infoBarMode="pollworker">
         <IndeterminateProgressBar />
@@ -478,28 +529,65 @@ export function PollWorkerScreen({
       </ScreenMainCenterChild>
     );
   }
+
+  const pollsTransitionActions = (() => {
+    switch (pollsState) {
+      case 'polls_closed_initial':
+        return (
+          <React.Fragment>
+            <p>The polls have not been opened.</p>
+            <p>
+              <Button primary large onPress={openPolls}>
+                Open Polls for {precinctName}
+              </Button>
+            </p>
+          </React.Fragment>
+        );
+      case 'polls_open':
+        return (
+          <React.Fragment>
+            <p>The polls are currently open.</p>
+            <p>
+              <Button primary large onPress={closePolls}>
+                Close Polls for {precinctName}
+              </Button>
+            </p>
+            <p>
+              <Button large onPress={pausePolls}>
+                Pause Polls for {precinctName}
+              </Button>
+            </p>
+          </React.Fragment>
+        );
+      case 'polls_paused':
+        return (
+          <React.Fragment>
+            <p>The polls are currently paused.</p>
+            <p>
+              <Button primary large onPress={unpausePolls}>
+                Open Polls for {precinctName}
+              </Button>
+            </p>
+            <p>
+              <Button large onPress={closePolls}>
+                Close Polls for {precinctName}
+              </Button>
+            </p>
+          </React.Fragment>
+        );
+      case 'polls_closed_final':
+        return <p>Voting is complete and the polls cannot be re-opened.</p>;
+      /* istanbul ignore next - compile-time check for completeness */
+      default:
+        throwIllegalValue(pollsState);
+    }
+  })();
+
   return (
     <ScreenMainCenterChild infoBarMode="pollworker">
       <Prose textCenter>
         <h1>Poll Worker Actions</h1>
-        <p>
-          {isPollsOpen ? (
-            <Button primary large onPress={closePolls}>
-              Close Polls for {precinctName}
-            </Button>
-          ) : (
-            <Button primary large onPress={openPolls}>
-              Open Polls for {precinctName}
-            </Button>
-          )}
-        </p>
-        {!isPollsOpen && scannedBallotCount > 0 && (
-          <p>
-            <Button onPress={() => setIsExportingResults(true)}>
-              Save Results to USB Drive
-            </Button>
-          </p>
-        )}
+        {pollsTransitionActions}
         {isFeatureFlagEnabled(EnvironmentFlagName.LIVECHECK) && (
           <p>
             <Button onPress={() => setIsShowingLiveCheck(true)}>
@@ -509,14 +597,6 @@ export function PollWorkerScreen({
         )}
       </Prose>
       <ScannedBallotCount count={scannedBallotCount} />
-      {isExportingResults && (
-        <ExportResultsModal
-          onClose={() => setIsExportingResults(false)}
-          usbDrive={usbDrive}
-          isTestMode={!isLiveMode}
-          scannedBallotCount={scannedBallotCount}
-        />
-      )}
       {isShowingLiveCheck && (
         <LiveCheckModal onClose={() => setIsShowingLiveCheck(false)} />
       )}

--- a/frontends/precinct-scanner/src/screens/polls_not_open_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/polls_not_open_screen.test.tsx
@@ -5,14 +5,14 @@ import { electionSampleDefinition } from '@votingworks/fixtures';
 import { singlePrecinctSelectionFor } from '@votingworks/utils';
 import { AppContext } from '../contexts/app_context';
 import {
-  PollsClosedScreen,
-  PollsClosedScreenProps,
-} from './polls_closed_screen';
+  PollsNotOpenScreen,
+  PollsNotOpenScreenProps,
+} from './polls_not_open_screen';
 
 const TEST_BALLOT_COUNT = 50;
 const MACHINE_ID = '0003';
 
-function renderScreen(props: Partial<PollsClosedScreenProps> = {}) {
+function renderScreen(props: Partial<PollsNotOpenScreenProps> = {}) {
   render(
     <AppContext.Provider
       value={{
@@ -27,9 +27,10 @@ function renderScreen(props: Partial<PollsClosedScreenProps> = {}) {
         isSoundMuted: false,
       }}
     >
-      <PollsClosedScreen
+      <PollsNotOpenScreen
         showNoChargerWarning={false}
         isLiveMode
+        pollsState="polls_closed_initial"
         scannedBallotCount={TEST_BALLOT_COUNT}
         {...props}
       />
@@ -37,10 +38,26 @@ function renderScreen(props: Partial<PollsClosedScreenProps> = {}) {
   );
 }
 
-describe('PollsClosedScreen', () => {
-  test('shows "Polls Closed"', async () => {
+describe('PollsNotOpenScreen', () => {
+  test('shows correct state on initial polls closed', async () => {
     renderScreen();
     await screen.findByText('Polls Closed');
+    screen.getByText('Insert a poll worker card to open polls.');
+  });
+
+  test('shows correct state on polls paused', async () => {
+    renderScreen({ pollsState: 'polls_paused' });
+    await screen.findByText('Polls Paused');
+    screen.getByText('Insert a poll worker card to open polls.');
+  });
+
+  test('shows correct state on final polls closed', async () => {
+    renderScreen({ pollsState: 'polls_closed_final' });
+    await screen.findByText('Polls Closed');
+    screen.getByText('Voting is complete.');
+    expect(
+      screen.queryByText('Insert a poll worker card to open polls.')
+    ).not.toBeInTheDocument();
   });
 
   test('shows "No Power Detected" when called for', async () => {

--- a/frontends/precinct-scanner/src/screens/polls_not_open_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/polls_not_open_screen.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Text } from '@votingworks/ui';
+import { PollsState } from '@votingworks/types';
 import { DoNotEnter } from '../components/graphics';
 import {
   CenteredLargeProse,
@@ -7,23 +8,31 @@ import {
 } from '../components/layout';
 import { ScannedBallotCount } from '../components/scanned_ballot_count';
 
-export interface PollsClosedScreenProps {
+export interface PollsNotOpenScreenProps {
   isLiveMode: boolean;
+  pollsState: Omit<PollsState, 'polls_open'>;
   showNoChargerWarning: boolean;
   scannedBallotCount: number;
 }
 
-export function PollsClosedScreen({
+export function PollsNotOpenScreen({
   isLiveMode,
+  pollsState,
   showNoChargerWarning,
   scannedBallotCount,
-}: PollsClosedScreenProps): JSX.Element {
+}: PollsNotOpenScreenProps): JSX.Element {
   return (
     <ScreenMainCenterChild isLiveMode={isLiveMode} infoBarMode="pollworker">
       <DoNotEnter />
       <CenteredLargeProse>
-        <h1>Polls Closed</h1>
-        <p>Insert a poll worker card to open polls.</p>
+        <h1>
+          {pollsState === 'polls_paused' ? 'Polls Paused' : 'Polls Closed'}
+        </h1>
+        {pollsState === 'polls_closed_final' ? (
+          <p>Voting is complete.</p>
+        ) : (
+          <p>Insert a poll worker card to open polls.</p>
+        )}
         {showNoChargerWarning && (
           <Text warning small center>
             <strong>No Power Detected.</strong> Please ask a poll worker to plug
@@ -39,8 +48,9 @@ export function PollsClosedScreen({
 /* istanbul ignore next */
 export function DefaultPreview(): JSX.Element {
   return (
-    <PollsClosedScreen
+    <PollsNotOpenScreen
       isLiveMode
+      pollsState="polls_closed_initial"
       showNoChargerWarning={false}
       scannedBallotCount={42}
     />
@@ -50,8 +60,9 @@ export function DefaultPreview(): JSX.Element {
 /* istanbul ignore next */
 export function DefaultTestModePreview(): JSX.Element {
   return (
-    <PollsClosedScreen
+    <PollsNotOpenScreen
       isLiveMode={false}
+      pollsState="polls_closed_initial"
       showNoChargerWarning={false}
       scannedBallotCount={42}
     />
@@ -61,8 +72,9 @@ export function DefaultTestModePreview(): JSX.Element {
 /* istanbul ignore next */
 export function NoPowerConnectedPreview(): JSX.Element {
   return (
-    <PollsClosedScreen
+    <PollsNotOpenScreen
       isLiveMode
+      pollsState="polls_closed_initial"
       showNoChargerWarning
       scannedBallotCount={42}
     />
@@ -70,11 +82,24 @@ export function NoPowerConnectedPreview(): JSX.Element {
 }
 
 /* istanbul ignore next */
-export function NoPowerConnectedTestModePreview(): JSX.Element {
+export function PollsPausedPreview(): JSX.Element {
   return (
-    <PollsClosedScreen
-      isLiveMode={false}
-      showNoChargerWarning
+    <PollsNotOpenScreen
+      isLiveMode
+      pollsState="polls_paused"
+      showNoChargerWarning={false}
+      scannedBallotCount={42}
+    />
+  );
+}
+
+/* istanbul ignore next */
+export function PollsClosedFinalPreview(): JSX.Element {
+  return (
+    <PollsNotOpenScreen
+      isLiveMode
+      pollsState="polls_closed_final"
+      showNoChargerWarning={false}
       scannedBallotCount={42}
     />
   );

--- a/frontends/precinct-scanner/test/helpers/build_app.ts
+++ b/frontends/precinct-scanner/test/helpers/build_app.ts
@@ -1,0 +1,25 @@
+import { render, RenderResult } from '@testing-library/react';
+import { fakeLogger, Logger } from '@votingworks/logging';
+import { MemoryCard, MemoryHardware, MemoryStorage } from '@votingworks/utils';
+import { App } from '../../src/app';
+
+export function buildApp(connectPrinter = false): {
+  card: MemoryCard;
+  hardware: MemoryHardware;
+  storage: MemoryStorage;
+  logger: Logger;
+  renderApp: () => RenderResult;
+} {
+  const card = new MemoryCard();
+  const hardware = MemoryHardware.build({
+    connectPrinter,
+    connectCardReader: true,
+    connectPrecinctScanner: true,
+  });
+  const logger = fakeLogger();
+  const storage = new MemoryStorage();
+  function renderApp() {
+    return render(App({ card, hardware, storage, logger }));
+  }
+  return { renderApp, card, hardware, logger, storage };
+}

--- a/frontends/precinct-scanner/test/helpers/mock_polls_state.ts
+++ b/frontends/precinct-scanner/test/helpers/mock_polls_state.ts
@@ -1,0 +1,25 @@
+import { PollsState } from '@votingworks/types';
+import fetchMock from 'fetch-mock';
+
+export function mockPollsState(pollsState: PollsState): void {
+  fetchMock.get(
+    '/precinct-scanner/config/polls',
+    {
+      body: {
+        status: 'ok',
+        pollsState,
+      },
+    },
+    { overwriteRoutes: true }
+  );
+}
+
+export function mockPollsStateChange(pollsState: PollsState): void {
+  fetchMock.putOnce(
+    { url: '/precinct-scanner/config/polls', body: { pollsState } },
+    {
+      body: { status: 'ok' },
+    }
+  );
+  mockPollsState(pollsState);
+}

--- a/frontends/precinct-scanner/test/helpers/mock_precinct_state.ts
+++ b/frontends/precinct-scanner/test/helpers/mock_precinct_state.ts
@@ -1,0 +1,29 @@
+import { PrecinctSelection } from '@votingworks/types';
+import fetchMock from 'fetch-mock';
+
+export function mockPrecinctState(precinctSelection?: PrecinctSelection): void {
+  fetchMock.get(
+    '/precinct-scanner/config/precinct',
+    precinctSelection
+      ? {
+          body: {
+            status: 'ok',
+            precinctSelection,
+          },
+        }
+      : { body: { status: 'ok' } },
+    { overwriteRoutes: true }
+  );
+}
+
+export function mockPrecinctStateChange(
+  precinctSelection: PrecinctSelection
+): void {
+  fetchMock.putOnce(
+    { url: '/precinct-scanner/config/precinct', body: { precinctSelection } },
+    {
+      body: { status: 'ok' },
+    }
+  );
+  mockPrecinctState(precinctSelection);
+}

--- a/libs/api/src/services/scan/index.ts
+++ b/libs/api/src/services/scan/index.ts
@@ -17,6 +17,8 @@ import {
   MarkThresholds,
   MarkThresholdsSchema,
   Optional,
+  PollsState,
+  PollsStateSchema,
   PrecinctSelection,
   PrecinctSelectionSchema,
 } from '@votingworks/types';
@@ -273,6 +275,54 @@ export type DeletePrecinctSelectionConfigResponse = OkResponse;
  * @method DELETE
  */
 export const DeletePrecinctSelectionConfigResponseSchema = OkResponseSchema;
+
+/**
+ * @url /config/polls
+ * @method GET
+ */
+export type GetPollsStateConfigResponse = OkResponse<{
+  pollsState: PollsState;
+}>;
+
+/**
+ * @url /config/polls
+ * @method GET
+ */
+export const GetPollsStateConfigResponseSchema: z.ZodSchema<GetPollsStateConfigResponse> =
+  z.object({
+    status: z.literal('ok'),
+    pollsState: PollsStateSchema,
+  });
+
+/**
+ * @url /config/polls
+ * @method PUT
+ */
+export interface PutPollsStateConfigRequest {
+  pollsState: PollsState;
+}
+
+/**
+ * @url /config/polls
+ * @method PUT
+ */
+export const PutPollsStateConfigRequestSchema: z.ZodSchema<PutPollsStateConfigRequest> =
+  z.object({
+    pollsState: PollsStateSchema,
+  });
+
+/**
+ * @url /config/polls
+ * @method PUT
+ */
+export type PutPollsStateConfigResponse = OkResponse | ErrorsResponse;
+
+/**
+ * @url /config/polls
+ * @method PUT
+ */
+export const PutPollsStateConfigResponseSchema: z.ZodSchema<PutPollsStateConfigResponse> =
+  z.union([OkResponseSchema, ErrorsResponseSchema]);
 
 /**
  * @url /config/markThresholdOverrides

--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -334,6 +334,10 @@ IDs are logged with each log to identify the log being written.
 **Type:** [user-action](#user-action)  
 **Description:** User has triggered a reboot of the machine.  
 **Machines:** All
+### reset-polls-to-paused
+**Type:** [user-action](#user-action)  
+**Description:** User has reset the polls from closed to paused.  
+**Machines:** vx-ballot-marking-device-frontend, vx-precinct-scan-frontend
 ### scanner-state-machine-event
 **Type:** [application-action](#application-action)  
 **Description:** Precinct scanner state machine received an event.  

--- a/libs/logging/src/log_event_ids.ts
+++ b/libs/logging/src/log_event_ids.ts
@@ -102,6 +102,7 @@ export enum LogEventId {
   PrepareBootFromUsbInit = 'prepare-boot-from-usb-init',
   PrepareBootFromUsbComplete = 'prepare-boot-from-usb-complete',
   RebootMachine = 'reboot-machine',
+  ResetPollsToPaused = 'reset-polls-to-paused',
   // VxScan service state machine logs
   ScannerEvent = 'scanner-state-machine-event',
   ScannerStateChanged = 'scanner-state-machine-transition',
@@ -729,6 +730,16 @@ const RebootMachine: LogDetails = {
   documentationMessage: 'User has triggered a reboot of the machine.',
 };
 
+const ResetPollsToPaused: LogDetails = {
+  eventId: LogEventId.ResetPollsToPaused,
+  eventType: LogEventType.UserAction,
+  documentationMessage: 'User has reset the polls from closed to paused.',
+  restrictInDocumentationToApps: [
+    LogSource.VxBallotMarkingDeviceFrontend,
+    LogSource.VxPrecinctScanFrontend,
+  ],
+};
+
 const ScannerEvent: LogDetails = {
   eventId: LogEventId.ScannerEvent,
   eventType: LogEventType.ApplicationAction,
@@ -905,6 +916,8 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return PrepareBootFromUsbComplete;
     case LogEventId.RebootMachine:
       return RebootMachine;
+    case LogEventId.ResetPollsToPaused:
+      return ResetPollsToPaused;
     case LogEventId.ScannerEvent:
       return ScannerEvent;
     case LogEventId.ScannerStateChanged:

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -9,6 +9,7 @@ export * from './geometry';
 export * from './image';
 export * from './interpretation';
 export * from './numeric';
+export * from './polls';
 export * from './precinct_selection';
 export * from './printing';
 export * from './result';

--- a/libs/types/src/polls.ts
+++ b/libs/types/src/polls.ts
@@ -1,0 +1,27 @@
+import * as z from 'zod';
+
+export type PollsState =
+  | 'polls_closed_initial'
+  | 'polls_open'
+  | 'polls_paused'
+  | 'polls_closed_final';
+
+export const PollsStateSchema: z.ZodSchema<PollsState> = z.union([
+  z.literal('polls_closed_initial'),
+  z.literal('polls_open'),
+  z.literal('polls_paused'),
+  z.literal('polls_closed_final'),
+]);
+
+export type PollsTransition =
+  | 'open_polls'
+  | 'pause_polls'
+  | 'unpause_polls'
+  | 'close_polls';
+
+export const PollsTransitionSchema: z.ZodSchema<PollsTransition> = z.union([
+  z.literal('open_polls'),
+  z.literal('pause_polls'),
+  z.literal('unpause_polls'),
+  z.literal('close_polls'),
+]);

--- a/libs/ui/src/reset_polls_to_paused_button.test.tsx
+++ b/libs/ui/src/reset_polls_to_paused_button.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { fakeLogger, LogEventId } from '@votingworks/logging';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import { ResetPollsToPausedButton } from './reset_polls_to_paused_button';
+
+test('component flow', async () => {
+  const resetPollsToPaused = jest.fn();
+  const logger = fakeLogger();
+  render(
+    <ResetPollsToPausedButton
+      logger={logger}
+      resetPollsToPaused={resetPollsToPaused}
+    />
+  );
+
+  // Initially should just contain the button
+  const mainButton = screen.getByRole('button', {
+    name: 'Reset Polls to Paused',
+  });
+  expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+
+  // Clicking should show modal
+  userEvent.click(mainButton);
+  screen.getByRole('alertdialog');
+
+  // Clicking cancel should close modal
+  userEvent.click(
+    screen.getByRole('button', {
+      name: 'Close',
+    })
+  );
+  expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+
+  // Can reset polls
+  userEvent.click(mainButton);
+  const modal = screen.getByRole('alertdialog');
+  userEvent.click(
+    within(modal).getByRole('button', { name: 'Reset Polls to Paused' })
+  );
+  await waitFor(() => {
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
+  expect(resetPollsToPaused).toHaveBeenCalledTimes(1);
+  expect(logger.log).toHaveBeenCalledTimes(1);
+  expect(logger.log).toHaveBeenLastCalledWith(
+    LogEventId.ResetPollsToPaused,
+    'system_administrator',
+    expect.objectContaining({
+      message: 'Polls were reset from closed to paused.',
+      disposition: 'success',
+    })
+  );
+});
+
+test('is disabled without callback', () => {
+  const logger = fakeLogger();
+  render(<ResetPollsToPausedButton logger={logger} />);
+
+  // Initially should just contain the button
+  expect(
+    screen.getByRole('button', {
+      name: 'Reset Polls to Paused',
+    })
+  ).toBeDisabled();
+});

--- a/libs/ui/src/reset_polls_to_paused_button.tsx
+++ b/libs/ui/src/reset_polls_to_paused_button.tsx
@@ -1,0 +1,67 @@
+import { LogEventId, Logger } from '@votingworks/logging';
+import { assert } from '@votingworks/utils';
+import React, { useState } from 'react';
+import { Button } from './button';
+import { Modal } from './modal';
+import { Prose } from './prose';
+
+interface Props {
+  resetPollsToPaused?: () => Promise<void>;
+  logger: Logger;
+}
+
+export function ResetPollsToPausedButton({
+  resetPollsToPaused,
+  logger,
+}: Props): JSX.Element {
+  const [isShowingConfirmModal, setIsShowingConfirmModal] = useState(false);
+
+  function showModal() {
+    setIsShowingConfirmModal(true);
+  }
+
+  function hideModal() {
+    setIsShowingConfirmModal(false);
+  }
+
+  async function doReset() {
+    assert(resetPollsToPaused);
+    await resetPollsToPaused();
+    await logger.log(LogEventId.ResetPollsToPaused, 'system_administrator', {
+      message: 'Polls were reset from closed to paused.',
+      disposition: 'success',
+    });
+    hideModal();
+  }
+
+  return (
+    <React.Fragment>
+      <Button onPress={showModal} disabled={!resetPollsToPaused}>
+        Reset Polls to Paused
+      </Button>
+      {isShowingConfirmModal && (
+        <Modal
+          content={
+            <Prose>
+              <h1>Reset Polls to Paused</h1>
+              <p>
+                The polls are closed and voting is complete. After resetting the
+                polls to paused, it will be possible to re-open the polls and
+                resume voting. All current cast vote records will be preserved.
+              </p>
+            </Prose>
+          }
+          onOverlayClick={hideModal}
+          actions={
+            <React.Fragment>
+              <Button danger onPress={doReset}>
+                Reset Polls to Paused
+              </Button>
+              <Button onPress={hideModal}>Close</Button>
+            </React.Fragment>
+          }
+        />
+      )}
+    </React.Fragment>
+  );
+}

--- a/libs/ui/src/system_administrator_screen_contents.test.tsx
+++ b/libs/ui/src/system_administrator_screen_contents.test.tsx
@@ -143,3 +143,36 @@ test('Quit button does nothing when kiosk is undefined', () => {
 
   userEvent.click(screen.getByRole('button', { name: 'Quit' }));
 });
+
+test('Reset Polls to Paused button not rendered if not specified', () => {
+  render(
+    <SystemAdministratorScreenContents
+      logger={fakeLogger()}
+      primaryText="Primary Text"
+      unconfigureMachine={jest.fn()}
+      resetPollsToPaused={jest.fn()}
+      isMachineConfigured
+      usbDriveStatus={usbstick.UsbDriveStatus.mounted}
+    />
+  );
+
+  expect(
+    screen.queryByRole('button', { name: 'Reset Polls to Paused' })
+  ).not.toBeInTheDocument();
+});
+
+test('Reset Polls to Paused rendered if callback and flag specified', () => {
+  render(
+    <SystemAdministratorScreenContents
+      logger={fakeLogger()}
+      primaryText="Primary Text"
+      unconfigureMachine={jest.fn()}
+      isMachineConfigured
+      showResetPollsToPausedButton
+      resetPollsToPaused={jest.fn()}
+      usbDriveStatus={usbstick.UsbDriveStatus.mounted}
+    />
+  );
+
+  screen.getByRole('button', { name: 'Reset Polls to Paused' });
+});

--- a/libs/ui/src/system_administrator_screen_contents.tsx
+++ b/libs/ui/src/system_administrator_screen_contents.tsx
@@ -8,12 +8,15 @@ import { Prose } from './prose';
 import { RebootFromUsbButton } from './reboot_from_usb_button';
 import { RebootToBiosButton } from './reboot_to_bios_button';
 import { UnconfigureMachineButton } from './unconfigure_machine_button';
+import { ResetPollsToPausedButton } from './reset_polls_to_paused_button';
 
 interface Props {
   displayRemoveCardToLeavePrompt?: boolean;
   logger: Logger;
   primaryText: React.ReactNode;
   unconfigureMachine: () => Promise<void>;
+  showResetPollsToPausedButton?: boolean;
+  resetPollsToPaused?: () => Promise<void>;
   isMachineConfigured: boolean;
   usbDriveStatus: usbstick.UsbDriveStatus;
 }
@@ -27,6 +30,8 @@ export function SystemAdministratorScreenContents({
   logger,
   primaryText,
   unconfigureMachine,
+  showResetPollsToPausedButton,
+  resetPollsToPaused,
   isMachineConfigured,
   usbDriveStatus,
 }: Props): JSX.Element {
@@ -36,6 +41,14 @@ export function SystemAdministratorScreenContents({
         <p>{primaryText}</p>
         {displayRemoveCardToLeavePrompt && (
           <p>Remove the System Administrator card to leave this screen.</p>
+        )}
+        {showResetPollsToPausedButton && (
+          <p>
+            <ResetPollsToPausedButton
+              resetPollsToPaused={resetPollsToPaused}
+              logger={logger}
+            />
+          </p>
         )}
         <p>
           <RebootFromUsbButton

--- a/libs/utils/src/assert.test.ts
+++ b/libs/utils/src/assert.test.ts
@@ -1,4 +1,5 @@
-import { assert, fail, throwIllegalValue } from './assert';
+import { Optional } from '@votingworks/types';
+import { assert, assertDefined, fail, throwIllegalValue } from './assert';
 
 test('assert', () => {
   assert(true);
@@ -8,6 +9,15 @@ test('assert', () => {
   const value: unknown = 'value';
   assert(typeof value === 'string');
   expect(value.startsWith('v')).toBe(true);
+});
+
+test('assertDefined', () => {
+  expect(() => assertDefined(undefined, 'message')).toThrow('message');
+  expect(() => assertDefined(null, 'message')).toThrow('message');
+
+  // compile-time test checking that `value`'s type is narrowed by TS
+  const value = 'value' as Optional<string>;
+  assertDefined(value).startsWith('hey');
 });
 
 test('fail', () => {

--- a/libs/utils/src/assert.ts
+++ b/libs/utils/src/assert.ts
@@ -12,6 +12,17 @@ export function assert(
 }
 
 /**
+ * Asserts that `condition` is true. This function exists to avoid a polyfill
+ * for `assert` in the browser.
+ */
+export function assertDefined<T>(entity?: T, message?: string): T {
+  if (entity === undefined || entity === null) {
+    throw new Error(message);
+  }
+  return entity;
+}
+
+/**
  * Fail with an optional error message.
  */
 export function fail(message?: string): never {

--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -20,6 +20,7 @@ export * from './in_groups_of';
 export * from './iterators';
 export * from './Hardware';
 export * from './hmpb';
+export * from './polls';
 export * from './precinct_selection';
 export * from './Printer';
 export * from './random';

--- a/libs/utils/src/polls.test.ts
+++ b/libs/utils/src/polls.test.ts
@@ -1,0 +1,26 @@
+import {
+  getPollsReportTitle,
+  getPollsTransitionDestinationState,
+} from './polls';
+
+test('getPollsTransitionDestinationState', () => {
+  expect(getPollsTransitionDestinationState('close_polls')).toEqual(
+    'polls_closed_final'
+  );
+  expect(getPollsTransitionDestinationState('open_polls')).toEqual(
+    'polls_open'
+  );
+  expect(getPollsTransitionDestinationState('unpause_polls')).toEqual(
+    'polls_open'
+  );
+  expect(getPollsTransitionDestinationState('pause_polls')).toEqual(
+    'polls_paused'
+  );
+});
+
+test('getPollsReportTitle', () => {
+  expect(getPollsReportTitle('close_polls')).toEqual('Polls Closed Report');
+  expect(getPollsReportTitle('open_polls')).toEqual('Polls Opened Report');
+  expect(getPollsReportTitle('unpause_polls')).toEqual('Polls Opened Report');
+  expect(getPollsReportTitle('pause_polls')).toEqual('Polls Paused Report');
+});

--- a/libs/utils/src/polls.ts
+++ b/libs/utils/src/polls.ts
@@ -1,0 +1,36 @@
+import { PollsState, PollsTransition } from '@votingworks/types';
+import { throwIllegalValue } from './assert';
+
+export function getPollsTransitionDestinationState(
+  transition: PollsTransition
+): PollsState {
+  switch (transition) {
+    case 'open_polls':
+      return 'polls_open';
+    case 'pause_polls':
+      return 'polls_paused';
+    case 'unpause_polls':
+      return 'polls_open';
+    case 'close_polls':
+      return 'polls_closed_final';
+    /* istanbul ignore next - compile time check for completeness */
+    default:
+      throwIllegalValue(transition);
+  }
+}
+
+export function getPollsReportTitle(transition: PollsTransition): string {
+  switch (transition) {
+    case 'close_polls':
+      return 'Polls Closed Report';
+    case 'open_polls':
+      return 'Polls Opened Report';
+    case 'unpause_polls':
+      return 'Polls Opened Report';
+    case 'pause_polls':
+      return 'Polls Paused Report';
+    /* istanbul ignore next - compile-time check for completeness */
+    default:
+      throwIllegalValue(transition);
+  }
+}

--- a/libs/utils/src/precinct_selection.test.ts
+++ b/libs/utils/src/precinct_selection.test.ts
@@ -2,6 +2,7 @@ import { electionSample } from '@votingworks/fixtures';
 import {
   ALL_PRECINCTS_NAME,
   ALL_PRECINCTS_SELECTION,
+  areEqualPrecinctSelections,
   getPrecinctSelectionName,
   singlePrecinctSelectionFor,
 } from './precinct_selection';
@@ -39,5 +40,52 @@ describe('getPrecinctSelectionName', () => {
         precinctId: 'none',
       });
     }).toThrowError();
+  });
+});
+
+describe('areEqualPrecinctSelections', () => {
+  test('both are All Precincts', () => {
+    expect(
+      areEqualPrecinctSelections(
+        ALL_PRECINCTS_SELECTION,
+        ALL_PRECINCTS_SELECTION
+      )
+    ).toEqual(true);
+  });
+
+  test('first is All Precincts, second is not', () => {
+    expect(
+      areEqualPrecinctSelections(
+        ALL_PRECINCTS_SELECTION,
+        singlePrecinctSelectionFor('precinct-1')
+      )
+    ).toEqual(false);
+  });
+
+  test('second is All Precincts, first is not', () => {
+    expect(
+      areEqualPrecinctSelections(
+        singlePrecinctSelectionFor('precinct-1'),
+        ALL_PRECINCTS_SELECTION
+      )
+    ).toEqual(false);
+  });
+
+  test('two different single precincts', () => {
+    expect(
+      areEqualPrecinctSelections(
+        singlePrecinctSelectionFor('precinct-1'),
+        singlePrecinctSelectionFor('precinct-2')
+      )
+    ).toEqual(false);
+  });
+
+  test('same single precinct', () => {
+    expect(
+      areEqualPrecinctSelections(
+        singlePrecinctSelectionFor('precinct-1'),
+        singlePrecinctSelectionFor('precinct-1')
+      )
+    ).toEqual(true);
   });
 });

--- a/libs/utils/src/precinct_selection.ts
+++ b/libs/utils/src/precinct_selection.ts
@@ -32,3 +32,18 @@ export function getPrecinctSelectionName(
 
   return find(precincts, (p) => p.id === precinctSelection.precinctId).name;
 }
+
+export function areEqualPrecinctSelections(
+  precinctSelectionOne: PrecinctSelection,
+  precinctSelectionTwo: PrecinctSelection
+): boolean {
+  if (precinctSelectionOne.kind === 'AllPrecincts') {
+    return precinctSelectionTwo.kind === 'AllPrecincts';
+  }
+
+  if (precinctSelectionTwo.kind === 'AllPrecincts') {
+    return false;
+  }
+
+  return precinctSelectionOne.precinctId === precinctSelectionTwo.precinctId;
+}

--- a/services/scan/src/store.test.ts
+++ b/services/scan/src/store.test.ts
@@ -101,6 +101,15 @@ test('get current mark thresholds falls back to election definition defaults', (
   });
 });
 
+test('get/set polls state', () => {
+  const store = Store.memoryStore();
+
+  expect(store.getPollsState()).toEqual('polls_closed_initial');
+
+  store.setPollsState('polls_open');
+  expect(store.getPollsState()).toEqual('polls_open');
+});
+
 test('HMPB template handling', () => {
   const store = Store.memoryStore();
   const metadata: BallotMetadata = {

--- a/services/scan/src/store.ts
+++ b/services/scan/src/store.ts
@@ -27,6 +27,8 @@ import {
   Optional,
   PageInterpretation,
   PageInterpretationWithFiles,
+  PollsState as PollsStateType,
+  PollsStateSchema,
   PrecinctSelection as PrecinctSelectionType,
   PrecinctSelectionSchema,
   safeParseJson,
@@ -70,6 +72,7 @@ export enum ConfigKey {
   // @deprecated
   SkipElectionHashCheck = 'skipElectionHashCheck',
   PrecinctSelection = 'precinctSelection',
+  PollsState = 'pollsState',
 }
 
 export enum BackupKey {
@@ -329,6 +332,24 @@ export class Store {
    */
   setPrecinctSelection(precinctSelection?: PrecinctSelectionType): void {
     this.setConfig(ConfigKey.PrecinctSelection, precinctSelection);
+  }
+
+  /**
+   * Gets the current polls state (open, paused, closed initial, or closed final)
+   */
+  getPollsState(): PollsStateType {
+    return this.getConfig(
+      ConfigKey.PollsState,
+      'polls_closed_initial',
+      PollsStateSchema
+    );
+  }
+
+  /**
+   * Sets the current polls state
+   */
+  setPollsState(pollsState: PollsStateType): void {
+    this.setConfig(ConfigKey.PollsState, pollsState);
   }
 
   /**
@@ -604,6 +625,7 @@ export class Store {
     this.client.run('delete from batches');
     // reset autoincrementing key on "batches" table
     this.client.run("delete from sqlite_sequence where name = 'batches'");
+    this.setConfig(ConfigKey.PollsState, 'polls_closed_initial');
   }
 
   getBallotFilenames(


### PR DESCRIPTION
## Overview
Closes #2683. Changes two main things about the election flow:
1. After polls are closed, polls cannot be re-opened. Poll Workers will not be able to re-open the polls and Election Managers will not be able to re-open the polls without reconfiguring first. System Administrators have an option to reset polls from closed to paused.
2. Adds polls paused (or "suspended" according to VVSG language) state. In this state, voting cannot take place but polls _can_ be re-opened.

We also place more limits on when election managers can change the precinct on a device. Formerly, they could change the precinct at any time. Now, they can change it freely while polls are not open. While polls are open but no ballots are not cast, they can still change the precinct but it will require a modal confirmation, reset the polls to unopened, and reprint the polls report.

Some things that are _not_ in this change:
- The new polls transition types (paused, unpaused) will _not_ be represented on the printed reports or in VxMark in any way. That will come in the next two PRs (VxMark and reports respectively).
- Testing for the previous bullet, since it doesn't exist yet

## Demo Video or Screenshot
Poll Worker Flow:
[all_states_in_flow.webm](https://user-images.githubusercontent.com/37960853/198367053-1c91aea3-db32-4786-8108-5abad0e252e2.webm)


Sys Admin Reset Flow:
[reset_polls_paused.webm](https://user-images.githubusercontent.com/37960853/198367073-9438d51c-2b4f-45a1-89ea-a00fc89b6f30.webm)


Election Manager Precinct Change Flow:
[change_precinct.webm](https://user-images.githubusercontent.com/37960853/198367157-b270dec1-37c4-473e-a49b-ce5ecc58cdb8.webm)



## Testing Plan
I refactored a lot of our testing in the frontend and wrote a good bit of new testing. Some backend and utility testing too. Manual testing.

## Checklist
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
