### PR TITLE
[VxAdmin] Remove unused ElectionManagerStore function

### DIFF
--- a/frontends/election-manager/src/hooks/use_election_manager_store.ts
+++ b/frontends/election-manager/src/hooks/use_election_manager_store.ts
@@ -13,7 +13,6 @@ import {
 import { assert, typedAs } from '@votingworks/utils';
 import { useCallback, useContext, useMemo, useRef } from 'react';
 import { ServicesContext } from '../contexts/services_context';
-import { AddCastVoteRecordFileResult } from '../lib/backends/types';
 import { CastVoteRecordFiles } from '../utils/cast_vote_record_files';
 import { getCurrentElectionMetadataResultsQueryKey } from './use_current_election_metadata';
 import { getPrintedBallotsQueryKey } from './use_printed_ballots_query';
@@ -49,13 +48,6 @@ export interface ElectionManagerStore {
    * @param newElectionData election definition as JSON string
    */
   configure(newElectionData: string): Promise<ElectionDefinition>;
-
-  /**
-   * Adds a new cast vote record file.
-   */
-  addCastVoteRecordFile(
-    newCastVoteRecordFile: File
-  ): Promise<AddCastVoteRecordFileResult>;
 
   /**
    * Updates the external tally for a given source.
@@ -155,26 +147,6 @@ export function useElectionManagerStore(): ElectionManagerStore {
     [backend, logger, queryClient, reset]
   );
 
-  const addCastVoteRecordFileMutation = useMutation(
-    async (newCastVoteRecordFile: File) => {
-      return await backend.addCastVoteRecordFile(newCastVoteRecordFile);
-    },
-    {
-      onSuccess() {
-        void queryClient.invalidateQueries([cvrsStorageKey]);
-      },
-    }
-  );
-
-  const addCastVoteRecordFile = useCallback(
-    async (newCastVoteRecordFile: File) => {
-      return await addCastVoteRecordFileMutation.mutateAsync(
-        newCastVoteRecordFile
-      );
-    },
-    [addCastVoteRecordFileMutation]
-  );
-
   const updateFullElectionExternalTallyMutation = useMutation(
     async (newFullElectionExternalTally: FullElectionExternalTally) => {
       await backend.updateFullElectionExternalTally(
@@ -245,7 +217,6 @@ export function useElectionManagerStore(): ElectionManagerStore {
         castVoteRecordFiles: castVoteRecordFiles ?? CastVoteRecordFiles.empty,
         fullElectionExternalTallies: fullElectionExternalTallies ?? new Map(),
 
-        addCastVoteRecordFile,
         clearFullElectionExternalTallies,
         configure,
         reset,
@@ -254,7 +225,6 @@ export function useElectionManagerStore(): ElectionManagerStore {
         removeFullElectionExternalTally,
       }),
     [
-      addCastVoteRecordFile,
       castVoteRecordFiles,
       clearFullElectionExternalTallies,
       configure,


### PR DESCRIPTION
## Overview
Related to: https://github.com/votingworks/vxsuite/issues/2716

Removing unused `addCastVoteRecordFile` mutation function from the `ElectionManagerStore` - there's already an implementation in use in a separate [use_add_cast_vote_record_file_mutation.ts](https://github.com/votingworks/vxsuite/blob/main/frontends/election-manager/src/hooks/use_add_cast_vote_record_file_mutation.ts) file.

## Testing Plan 
- Relying on existing tests as regression guard
- Verified that CVR import functionality doesn't break locally

## Checklist
- [n/a] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [n/a] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [n/a] I have added a screenshot and/or video to this PR to demo the change
- [n/a] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
