### PR TITLE
feat(scan): support loading raw image files

### DIFF
--- a/services/scan/src/interpreter.test.ts
+++ b/services/scan/src/interpreter.test.ts
@@ -54,7 +54,6 @@ test('extracts votes encoded in a QR code', async () => {
           [],
       }).interpretFile({
         ballotImagePath,
-        ballotImageFile: await readFile(ballotImagePath),
         detectQrcodeResult: await detectQrcodeInFilePath(ballotImagePath),
       })
     ).interpretation
@@ -129,7 +128,6 @@ test('properly detects test ballot in live mode', async () => {
       electionSampleDefinition.election.centralScanAdjudicationReasons ?? [],
   }).interpretFile({
     ballotImagePath,
-    ballotImageFile: await readFile(ballotImagePath),
     detectQrcodeResult: await detectQrcodeInFilePath(ballotImagePath),
   });
 
@@ -159,7 +157,6 @@ test('properly detects bmd ballot with wrong precinct', async () => {
       electionSampleDefinition.election.centralScanAdjudicationReasons ?? [],
   }).interpretFile({
     ballotImagePath,
-    ballotImageFile: await readFile(ballotImagePath),
     detectQrcodeResult: await detectQrcodeInFilePath(ballotImagePath),
   });
 
@@ -189,7 +186,6 @@ test('properly detects bmd ballot with correct precinct', async () => {
       electionSampleDefinition.election.centralScanAdjudicationReasons ?? [],
   }).interpretFile({
     ballotImagePath,
-    ballotImageFile: await readFile(ballotImagePath),
     detectQrcodeResult: await detectQrcodeInFilePath(ballotImagePath),
   });
 
@@ -207,7 +203,6 @@ test('detects a blank page', async () => {
     adjudicationReasons: [],
   }).interpretFile({
     ballotImagePath,
-    ballotImageFile: await readFile(ballotImagePath),
     detectQrcodeResult: await detectQrcodeInFilePath(ballotImagePath),
   });
 
@@ -240,7 +235,6 @@ test('interprets marks on a HMPB', async () => {
   const { votes } = (
     await interpreter.interpretFile({
       ballotImagePath,
-      ballotImageFile: await readFile(ballotImagePath),
       detectQrcodeResult: await detectQrcodeInFilePath(ballotImagePath),
     })
   ).interpretation as InterpretedHmpbPage;
@@ -303,7 +297,6 @@ test('interprets marks on an upside-down HMPB', async () => {
     (
       await interpreter.interpretFile({
         ballotImagePath,
-        ballotImageFile: await readFile(ballotImagePath),
         detectQrcodeResult: await detectQrcodeInFilePath(ballotImagePath),
       })
     ).interpretation as InterpretedHmpbPage
@@ -350,7 +343,6 @@ test('interprets marks in ballots', async () => {
         (
           await interpreter.interpretFile({
             ballotImagePath,
-            ballotImageFile: await readFile(ballotImagePath),
             detectQrcodeResult: await detectQrcodeInFilePath(ballotImagePath),
           })
         ).interpretation as InterpretedHmpbPage
@@ -402,7 +394,6 @@ test('interprets marks in ballots', async () => {
         (
           await interpreter.interpretFile({
             ballotImagePath,
-            ballotImageFile: await readFile(ballotImagePath),
             detectQrcodeResult: await detectQrcodeInFilePath(ballotImagePath),
           })
         ).interpretation as InterpretedHmpbPage
@@ -454,7 +445,6 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
     (
       await interpreter.interpretFile({
         ballotImagePath,
-        ballotImageFile: await readFile(ballotImagePath),
         detectQrcodeResult: await detectQrcodeInFilePath(ballotImagePath),
       })
     ).interpretation as UninterpretedHmpbPage

--- a/services/scan/src/interpreter.ts
+++ b/services/scan/src/interpreter.ts
@@ -21,14 +21,11 @@ import {
   BallotPageMetadata,
   BallotType,
   ElectionDefinition,
-  err,
   getContestsFromIds,
   InterpretedBmdPage,
   MarkThresholds,
-  ok,
   PageInterpretation,
   PrecinctSelection,
-  Result,
 } from '@votingworks/types';
 import {
   adjudicationReasonDescription,
@@ -54,28 +51,6 @@ export interface InterpretFileParams {
 export interface InterpretFileResult {
   interpretation: PageInterpretation;
   normalizedImage?: ImageData;
-}
-
-interface BallotImageData {
-  image: ImageData;
-  qrcode: BallotPageQrcode;
-}
-
-export async function getBallotImageData(
-  filename: string,
-  detectQrcodeResult: qrcodeWorker.NonBlankPageOutput
-): Promise<Result<BallotImageData, PageInterpretation>> {
-  const image = await loadImageData(filename);
-
-  if (detectQrcodeResult.qrcode) {
-    return ok({ image, qrcode: detectQrcodeResult.qrcode });
-  }
-
-  debug('no QR code found in %s', filename);
-  return err({
-    type: 'UnreadablePage',
-    reason: 'No QR code found',
-  });
 }
 
 /**

--- a/services/scan/src/precinct_scanner_interpreter.ts
+++ b/services/scan/src/precinct_scanner_interpreter.ts
@@ -14,7 +14,6 @@ import {
   PrecinctSelection,
   Result,
 } from '@votingworks/types';
-import { readFile } from 'fs/promises';
 import { Scan } from '@votingworks/api';
 import * as qrcodeWorker from './workers/qrcode';
 import { Interpreter as VxInterpreter } from './interpreter';
@@ -256,10 +255,8 @@ async function vxInterpret(
       ballotImagePath,
       detectQrcodeResult,
     ]): Promise<PageInterpretationWithFiles> => {
-      const ballotImageFile = await readFile(ballotImagePath);
       const result = await vxInterpreter.interpretFile({
         ballotImagePath,
-        ballotImageFile,
         detectQrcodeResult,
       });
 

--- a/services/scan/src/util/images.ts
+++ b/services/scan/src/util/images.ts
@@ -1,10 +1,89 @@
+import { safeParseInt } from '@votingworks/types';
+import { assert } from '@votingworks/utils';
 import { Buffer } from 'buffer';
-import { createCanvas, createImageData, loadImage } from 'canvas';
-import { createWriteStream } from 'fs';
+import { createCanvas, createImageData, ImageData, loadImage } from 'canvas';
+import { createWriteStream, promises as fs } from 'fs';
+import { parse } from 'path';
 import { pipeline } from 'stream/promises';
 
-function ensureImageData(imageData: ImageData): ImageData {
+const GRAY_CHANNEL_COUNT = 1;
+const RGB_CHANNEL_COUNT = 3;
+const RGBA_CHANNEL_COUNT = 4;
+
+/**
+ * Ensures that `imageData` is acceptable to `canvas`.
+ */
+export function ensureImageData(imageData: globalThis.ImageData): ImageData {
+  if (imageData instanceof ImageData) {
+    return imageData;
+  }
   return createImageData(imageData.data, imageData.width, imageData.height);
+}
+
+/**
+ * Loads a RAW image from a file.
+ */
+async function loadRawImage(
+  path: string,
+  width: number,
+  height: number,
+  channelCount: number
+): Promise<ImageData> {
+  assert(
+    channelCount === GRAY_CHANNEL_COUNT ||
+      channelCount === RGB_CHANNEL_COUNT ||
+      channelCount === RGBA_CHANNEL_COUNT
+  );
+
+  const imageData = createImageData(width, height);
+  const buffer = await fs.readFile(path);
+
+  for (
+    let srcOffset = 0, dstOffset = 0;
+    srcOffset < buffer.length;
+    srcOffset += channelCount, dstOffset += RGBA_CHANNEL_COUNT
+  ) {
+    imageData.data[dstOffset] = buffer[srcOffset];
+    imageData.data[dstOffset + 1] =
+      buffer[channelCount > GRAY_CHANNEL_COUNT ? srcOffset + 1 : srcOffset];
+    imageData.data[dstOffset + 2] =
+      buffer[channelCount > GRAY_CHANNEL_COUNT ? srcOffset + 2 : srcOffset];
+    imageData.data[dstOffset + 3] =
+      buffer[channelCount > RGB_CHANNEL_COUNT ? srcOffset + 3 : srcOffset];
+  }
+
+  return imageData;
+}
+
+/**
+ * Loads a RAW image from a file. The file name must be in the format
+ * `{label}-{width}x{height}-{bitsPerPixel}bpp.raw`. For example:
+ * `ballot-1700x2200-24bpp.raw` or `scan-1700x2200-8bpp.raw`.
+ */
+async function loadRawImageWithMetadataInFileName(
+  path: string
+): Promise<ImageData> {
+  const parts = parse(path);
+  const match = parts.name.match(/(\d+)x(\d+)-(\d)bpp/);
+  if (!match) {
+    throw new Error(`Invalid raw image filename: ${parts.name}`);
+  }
+  const [, widthResult, heightResult, bitsPerPixelResult] = match.map((n) =>
+    safeParseInt(n, { min: 1 })
+  );
+  if (
+    widthResult.isErr() ||
+    heightResult.isErr() ||
+    bitsPerPixelResult.isErr()
+  ) {
+    throw new Error(`Invalid raw image filename: ${parts.name}`);
+  }
+
+  const width = widthResult.ok();
+  const height = heightResult.ok();
+  const bitsPerPixel = bitsPerPixelResult.ok();
+  const srcBytesPerPixel = Math.round(bitsPerPixel / 8);
+  return await loadRawImage(path, width, height, srcBytesPerPixel);
 }
 
 export async function loadImageData(path: string): Promise<ImageData>;
@@ -12,6 +91,13 @@ export async function loadImageData(data: Buffer): Promise<ImageData>;
 export async function loadImageData(
   pathOrData: string | Buffer
 ): Promise<ImageData> {
+  if (typeof pathOrData === 'string') {
+    const parts = parse(pathOrData);
+    if (parts.ext === '.raw') {
+      return loadRawImageWithMetadataInFileName(pathOrData);
+    }
+  }
+
   const img = await loadImage(pathOrData);
   const canvas = createCanvas(img.width, img.height);
   const context = canvas.getContext('2d');

--- a/services/scan/src/util/save_images.ts
+++ b/services/scan/src/util/save_images.ts
@@ -1,6 +1,6 @@
 import makeDebug from 'debug';
 import * as fsExtra from 'fs-extra';
-import { basename, extname, join } from 'path';
+import { basename, join, parse } from 'path';
 import { writeImageData } from './images';
 
 const debug = makeDebug('scan:importer');
@@ -58,7 +58,8 @@ export async function saveSheetImages(
   ballotImagePath: string,
   normalizedImage?: ImageData
 ): Promise<SaveImagesResult> {
-  const ext = extname(ballotImagePath);
+  const parts = parse(ballotImagePath);
+  const ext = parts.ext === '.png' ? '.png' : '.jpg';
   const originalImagePath = join(
     ballotImagesPath,
     `${basename(ballotImagePath, ext)}-${sheetId}-original${ext}`

--- a/services/scan/src/workers/interpret_vx.ts
+++ b/services/scan/src/workers/interpret_vx.ts
@@ -2,7 +2,6 @@ import { pdfToImages } from '@votingworks/image-utils';
 import { AdjudicationReason, PageInterpretation } from '@votingworks/types';
 import { throwIllegalValue } from '@votingworks/utils';
 import makeDebug from 'debug';
-import { readFile } from 'fs-extra';
 import { ScannerLocation, SCANNER_LOCATION } from '../globals';
 import { Interpreter } from '../interpreter';
 import { Store } from '../store';
@@ -99,7 +98,6 @@ export async function interpret(
 
   const result = await interpreter.interpretFile({
     ballotImagePath,
-    ballotImageFile: await readFile(ballotImagePath),
     detectQrcodeResult,
   });
   debug(

--- a/services/scan/src/workers/qrcode.test.ts
+++ b/services/scan/src/workers/qrcode.test.ts
@@ -1,38 +1,40 @@
 import { metadataFromBytes } from '@votingworks/ballot-interpreter-vx';
-import { assert } from '@votingworks/utils';
+import { typedAs } from '@votingworks/utils';
 import { Buffer } from 'buffer';
-import { readFile } from 'fs-extra';
 import { join } from 'path';
 import * as general2020Fixtures from '../../test/fixtures/2020-general';
 import * as choctaw2020SpecialFixtures from '../../test/fixtures/choctaw-2020-09-22-f30480cc99';
-import { getBallotImageData } from '../interpreter';
-import { detectQrcodeInFilePath } from './qrcode';
+import { BallotPageQrcode } from '../types';
+import { detectQrcodeInFilePath, NonBlankPageOutput, Output } from './qrcode';
 
 const sampleBallotImagesPath = join(__dirname, '../../sample-ballot-images');
 
 test('does not find QR codes when there are none to find', async () => {
   const filepath = join(sampleBallotImagesPath, 'not-a-ballot.jpg');
   const detectResult = await detectQrcodeInFilePath(filepath);
-  assert(!detectResult.blank);
-  expect(
-    (
-      await getBallotImageData(await readFile(filepath), filepath, detectResult)
-    ).unsafeUnwrapErr()
-  ).toEqual({ type: 'UnreadablePage', reason: 'No QR code found' });
+  expect(detectResult).toEqual(
+    typedAs<Output>({
+      blank: false,
+      qrcode: undefined,
+    })
+  );
 });
 
 test('can read metadata encoded in a QR code with base64', async () => {
   const fixtures = choctaw2020SpecialFixtures;
   const { electionDefinition } = fixtures;
   const detectResult = await detectQrcodeInFilePath(fixtures.blankPage1);
-  assert(!detectResult.blank);
-  const { qrcode } = (
-    await getBallotImageData(
-      await readFile(fixtures.blankPage1),
-      fixtures.blankPage1,
-      detectResult
-    )
-  ).unsafeUnwrap();
+  expect(detectResult).toEqual(
+    typedAs<Output>({
+      blank: false,
+      qrcode: {
+        data: expect.any(Buffer),
+        position: 'bottom',
+      },
+    })
+  );
+  const qrcode = (detectResult as NonBlankPageOutput)
+    .qrcode as BallotPageQrcode;
 
   expect(metadataFromBytes(electionDefinition, Buffer.from(qrcode.data)))
     .toMatchInlineSnapshot(`
@@ -57,41 +59,35 @@ test('can read metadata in QR code with skewed / dirty ballot', async () => {
   const detectResult = await detectQrcodeInFilePath(
     fixtures.skewedQrCodeBallotPage
   );
-  assert(!detectResult.blank);
-  const { qrcode } = (
-    await getBallotImageData(
-      await readFile(fixtures.skewedQrCodeBallotPage),
-      fixtures.skewedQrCodeBallotPage,
-      detectResult
-    )
-  ).unsafeUnwrap();
-
-  expect(qrcode.data).toMatchInlineSnapshot(`
-    Object {
-      "data": Array [
-        86,
-        80,
-        1,
-        20,
-        111,
-        111,
-        156,
-        219,
-        48,
-        24,
-        169,
-        41,
-        115,
-        168,
-        20,
-        5,
-        17,
-        0,
-        0,
-        6,
-        0,
-      ],
-      "type": "Buffer",
-    }
-  `);
+  expect(detectResult).toEqual(
+    typedAs<Output>({
+      blank: false,
+      qrcode: {
+        data: Buffer.of(
+          86,
+          80,
+          1,
+          20,
+          111,
+          111,
+          156,
+          219,
+          48,
+          24,
+          169,
+          41,
+          115,
+          168,
+          20,
+          5,
+          17,
+          0,
+          0,
+          6,
+          0
+        ),
+        position: 'top',
+      },
+    })
+  );
 });


### PR DESCRIPTION
## Overview
<!-- add a link to a Github Issue here -->
Such files are a temporary workaround for the Custom scanner not working with JPEG. This is only a problem because we're using the same approach as `plustekctl` which writes the files to disk, but long term we should consider loading the scanned images directly in memory.

## Demo Video or Screenshot
n/a

## Testing Plan 
Tested manually with the files generated by the [`plustekctl` for Custom](https://github.com/votingworks/plustekctl/compare/customctl).

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
