### PR TITLE
`expectPrint` Polish

### DIFF
--- a/frontends/bmd/src/setupTests.tsx
+++ b/frontends/bmd/src/setupTests.tsx
@@ -6,7 +6,7 @@ import fetchMock from 'fetch-mock';
 import { TextDecoder, TextEncoder } from 'util';
 import { configure } from '@testing-library/react';
 import {
-  expectAllPrintsAsserted,
+  expectTestToEndWithAllPrintsAsserted,
   fakePrintElement,
   fakePrintElementWhenReady,
 } from '@votingworks/test-utils';
@@ -64,7 +64,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  expectAllPrintsAsserted();
+  expectTestToEndWithAllPrintsAsserted();
   fetchMock.restore();
 });
 

--- a/frontends/precinct-scanner/src/setupTests.ts
+++ b/frontends/precinct-scanner/src/setupTests.ts
@@ -5,7 +5,7 @@ import { TextDecoder, TextEncoder } from 'util';
 
 import { configure } from '@testing-library/react';
 import {
-  expectAllPrintsAsserted,
+  expectTestToEndWithAllPrintsAsserted,
   fakePrintElement,
   fakePrintElementWhenReady,
 } from '@votingworks/test-utils';
@@ -28,7 +28,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  expectAllPrintsAsserted();
+  expectTestToEndWithAllPrintsAsserted();
 });
 
 globalThis.TextDecoder = TextDecoder as typeof globalThis.TextDecoder;


### PR DESCRIPTION
Closes #2758.

- When test assertions fail within `expectPrint`, the DOM printed now only includes the printed container
- Cleans up `expectPrint` module state between tests and failures