### PR TITLE
test(scan): remove duplicate `adjudicateSheet` call

### DIFF
--- a/services/scan/src/store.test.ts
+++ b/services/scan/src/store.test.ts
@@ -1091,7 +1091,6 @@ test('exportCvrs called with orderBySheetId actually orders by sheet ID', async 
       },
     ]);
     store.adjudicateSheet(sheetId);
-    store.adjudicateSheet(sheetId);
   }
 
   const stream = new streams.WritableStream();


### PR DESCRIPTION

## Overview
<!-- add a link to a Github Issue here -->
Missed this in #2765.

## Demo Video or Screenshot
n/a

## Testing Plan 
Automated tests.
## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
