### PR TITLE
[VxAdmin] Block CVR file imports on failed validation

### DIFF
--- a/services/admin/src/server.ts
+++ b/services/admin/src/server.ts
@@ -206,9 +206,9 @@ export function buildApp({ workspace }: { workspace: Workspace }): Application {
     { electionId: Id },
     Admin.DeleteCvrFileResponse,
     Admin.DeleteCvrFileRequest
-  >('/admin/elections/:electionId/cvr-files', async (request, response) => {
+  >('/admin/elections/:electionId/cvr-files', (request, response) => {
     const { electionId } = request.params;
-    await store.deleteCastVoteRecordFiles(electionId);
+    store.deleteCastVoteRecordFiles(electionId);
     store.setElectionResultsOfficial(electionId, false);
     response.json({ status: 'ok' });
   });

--- a/services/admin/src/server.ts
+++ b/services/admin/src/server.ts
@@ -206,9 +206,9 @@ export function buildApp({ workspace }: { workspace: Workspace }): Application {
     { electionId: Id },
     Admin.DeleteCvrFileResponse,
     Admin.DeleteCvrFileRequest
-  >('/admin/elections/:electionId/cvr-files', (request, response) => {
+  >('/admin/elections/:electionId/cvr-files', async (request, response) => {
     const { electionId } = request.params;
-    store.deleteCastVoteRecordFiles(electionId);
+    await store.deleteCastVoteRecordFiles(electionId);
     store.setElectionResultsOfficial(electionId, false);
     response.json({ status: 'ok' });
   });

--- a/services/admin/src/store.test.ts
+++ b/services/admin/src/store.test.ts
@@ -269,7 +269,6 @@ test('add a CVR file entry without a ballot ID', async () => {
     filePath: tmpfile.name,
   });
 
-  expect(result.isErr()).toBe(true);
   expect(result.unsafeUnwrapErr()).toEqual(
     typedAs<AddCastVoteRecordError>({ kind: 'BallotIdRequired' })
   );
@@ -299,7 +298,6 @@ test('add a CVR file entry matching an existing ballot ID with different data', 
     filePath: tmpFile.name,
   });
 
-  expect(result.isErr()).toBe(true);
   expect(result.err()).toMatchObject({
     kind: 'BallotIdAlreadyExistsWithDifferentData',
     existingData: /zebra/,
@@ -338,7 +336,6 @@ test('add a live CVR file after adding a test CVR file', async () => {
     originalFilename: 'live-cvrs.jsonl',
   });
 
-  expect(result.isErr()).toBe(true);
   expect(result.err()).toEqual({
     kind: 'InvalidCvrFileMode',
     userFriendlyMessage:
@@ -377,7 +374,6 @@ test('add a test CVR file after adding a live CVR file', async () => {
     originalFilename: 'test-cvrs.jsonl',
   });
 
-  expect(result.isErr()).toBe(true);
   expect(result.err()).toEqual({
     kind: 'InvalidCvrFileMode',
     userFriendlyMessage:
@@ -406,7 +402,6 @@ test('add a CVR file with mixed live and test CVRs', async () => {
     originalFilename: 'mixed-cvrs.jsonl',
   });
 
-  expect(result.isErr()).toBe(true);
   expect(result.err()).toEqual({
     kind: 'MixedLiveAndTestBallots',
     userFriendlyMessage:
@@ -428,7 +423,6 @@ test('add a CVR file with an invalid election id', async () => {
     filePath: cvrFile.asFilePath(),
   });
 
-  expect(result.isErr()).toBe(true);
   expect(result.err()).toEqual({ kind: 'InvalidElectionId' });
 });
 
@@ -445,7 +439,6 @@ test('add a CVR file with mismatched election details', async () => {
     filePath: cvrFile.asFilePath(),
   });
 
-  expect(result.isErr()).toBe(true);
   expect(result.err()).toMatchObject({
     kind: 'MismatchedElectionDetails',
     lineNumber: 1,
@@ -471,7 +464,6 @@ test('add a CVR file with an invalid vote', async () => {
     filePath: tmpFile.name,
   });
 
-  expect(result.isErr()).toBe(true);
   expect(result.err()).toMatchObject({
     kind: 'InvalidVote',
     lineNumber: 1,
@@ -982,7 +974,7 @@ test('write-in adjudication lifecycle', async () => {
     }
   `);
 
-  await store.deleteCastVoteRecordFiles(electionId);
+  store.deleteCastVoteRecordFiles(electionId);
 
   expect(store.getDebugSummary()).toMatchInlineSnapshot(`
     Map {

--- a/services/admin/src/store.ts
+++ b/services/admin/src/store.ts
@@ -413,7 +413,7 @@ export class Store {
       });
     };
 
-    function shouldCommit(result: AddCastVoteResult) {
+    function shouldCommit(result: AddCastVoteResult): boolean {
       if (analyzeOnly) {
         return false;
       }
@@ -680,8 +680,8 @@ export class Store {
   /**
    * Deletes all CVR files for an election.
    */
-  async deleteCastVoteRecordFiles(electionId: Id): Promise<void> {
-    await this.client.transaction(() => {
+  deleteCastVoteRecordFiles(electionId: Id): void {
+    this.client.transaction(() => {
       this.client.run(
         `
           delete from cvr_file_entries


### PR DESCRIPTION
## Overview
Related to: https://github.com/votingworks/vxsuite/issues/2716

- Now using the `parseCvr()` util (used in the client) in the server
- Failing CVR file imports whenever any validation errors are found
- Showing generic messaging to the user on most errors, but adding special handling for the following, given the issue mentioned in https://github.com/votingworks/vxsuite/issues/2680:
  - Mismatched election - CVR contains contests not found in the election definition
  - Invalid vote - a yes/no or candidate choice has an invalid value
- Also updated `addCastVoteRecordFile()` to use a modified `DbClient.transaction` to avoid the chance of forgetting to roll back transactions when returning errors

## Demo Video or Screenshot

https://user-images.githubusercontent.com/264902/201155601-359d0b8d-f3bc-4035-bd1f-fa98bacef448.mov

<img width="550" alt="Screenshot 2022-11-09 at 5 38 01 PM" src="https://user-images.githubusercontent.com/264902/201157849-68ef308b-8408-497d-8abc-fc69fc8ff8bd.png">

<img width="550" alt="Screenshot 2022-11-09 at 5 33 01 PM" src="https://user-images.githubusercontent.com/264902/201157941-b4d0bdf6-f2ea-4fe8-9f1d-79c64cb29b76.png">

<img width="550" alt="Screenshot 2022-11-09 at 5 32 33 PM" src="https://user-images.githubusercontent.com/264902/201157958-719eec79-33bb-451e-a4d7-69ed06f97114.png">

## Testing Plan 
- Added test cases for the new error paths
- Verified locally

## Checklist
- [n/a] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
