### PR TITLE
[VxAdmin] Add react query for analyzing CVR file contents before import

### DIFF
--- a/frontends/election-manager/src/hooks/use_cvr_file_analysis_query.ts
+++ b/frontends/election-manager/src/hooks/use_cvr_file_analysis_query.ts
@@ -9,7 +9,7 @@ export function getCvrFileAnalysisQueryKey(cvrFile: File): QueryKey {
   return ['cvr-file-analysis', cvrFile.name, cvrFile.lastModified];
 }
 
-/** Returns a query for an analysis of the the given CVR file. */
+/** Returns a query for an analysis of the given CVR file. */
 export function useCvrFileAnalysisQuery(
   cvrFile: File
 ): UseQueryResult<AddCastVoteRecordFileResult> {

--- a/frontends/election-manager/src/hooks/use_cvr_file_analysis_query.ts
+++ b/frontends/election-manager/src/hooks/use_cvr_file_analysis_query.ts
@@ -1,0 +1,21 @@
+import { QueryKey, useQuery, UseQueryResult } from '@tanstack/react-query';
+import { useContext } from 'react';
+
+import { ServicesContext } from '../contexts/services_context';
+import { AddCastVoteRecordFileResult } from '../lib/backends';
+
+/** Gets the query key for the CVR file analysis query. */
+export function getCvrFileAnalysisQueryKey(cvrFile: File): QueryKey {
+  return ['cvr-file-analysis', cvrFile.name, cvrFile.lastModified];
+}
+
+/** Returns a query for an analysis of the the given CVR file. */
+export function useCvrFileAnalysisQuery(
+  cvrFile: File
+): UseQueryResult<AddCastVoteRecordFileResult> {
+  const { backend } = useContext(ServicesContext);
+
+  return useQuery(getCvrFileAnalysisQueryKey(cvrFile), () =>
+    backend.addCastVoteRecordFile(cvrFile, { analyzeOnly: true })
+  );
+}

--- a/frontends/election-manager/src/lib/backends/admin_backend.test.ts
+++ b/frontends/election-manager/src/lib/backends/admin_backend.test.ts
@@ -1,6 +1,7 @@
 import { Admin } from '@votingworks/api';
 import {
   electionMinimalExhaustiveSampleDefinition,
+  electionMinimalExhaustiveSampleFixtures,
   electionWithMsEitherNeitherDefinition,
 } from '@votingworks/fixtures';
 import { fakeLogger } from '@votingworks/logging';
@@ -25,6 +26,10 @@ const getElectionsResponse: Admin.GetElectionsResponse = [
     isOfficialResults: false,
   },
 ];
+
+beforeEach(() => {
+  fetchMock.reset();
+});
 
 test('load election without a current election ID', async () => {
   const storage = new MemoryStorage();
@@ -129,4 +134,99 @@ test('configure errors response', async () => {
   await expect(
     backend.configure(electionWithMsEitherNeitherDefinition.electionData)
   ).rejects.toThrowError('invalid election, I do not like you');
+});
+
+test('addCastVoteRecordFile happy path', async () => {
+  const { partial1CvrFile } = electionMinimalExhaustiveSampleFixtures;
+  const storage = new MemoryStorage();
+  const logger = fakeLogger();
+  const backend = new ElectionManagerStoreAdminBackend({ storage, logger });
+
+  await storage.set(currentElectionIdStorageKey, 'test-election-2');
+  fetchMock.get('/admin/elections', { body: getElectionsResponse });
+
+  const apiResponse: Admin.PostCvrFileResponse = {
+    status: 'ok',
+    id: 'cvr-file-1',
+    alreadyPresent: 10,
+    newlyAdded: 450,
+    wasExistingFile: false,
+  };
+  fetchMock.post(`/admin/elections/test-election-2/cvr-files?`, apiResponse);
+
+  await expect(backend.loadCastVoteRecordFiles()).resolves.toBeUndefined();
+
+  await expect(
+    backend.addCastVoteRecordFile(
+      new File([partial1CvrFile.asBuffer()], 'cvrs.jsonl')
+    )
+  ).resolves.toEqual({
+    alreadyPresent: 10,
+    newlyAdded: 450,
+    wasExistingFile: false,
+  });
+
+  const cvrFilesFromStorage = await backend.loadCastVoteRecordFiles();
+  expect(cvrFilesFromStorage).not.toBeUndefined();
+  expect(cvrFilesFromStorage?.fileList.length).toBeGreaterThan(0);
+});
+
+test('addCastVoteRecordFile analyze only', async () => {
+  const { partial1CvrFile } = electionMinimalExhaustiveSampleFixtures;
+  const storage = new MemoryStorage();
+  const logger = fakeLogger();
+  const backend = new ElectionManagerStoreAdminBackend({ storage, logger });
+
+  await storage.set(currentElectionIdStorageKey, 'test-election-2');
+
+  const apiResponse: Admin.PostCvrFileResponse = {
+    status: 'ok',
+    id: 'cvr-file-1',
+    alreadyPresent: 10,
+    newlyAdded: 450,
+    wasExistingFile: false,
+  };
+  fetchMock.post(
+    `/admin/elections/test-election-2/cvr-files?analyzeOnly=true`,
+    apiResponse
+  );
+
+  await expect(backend.loadCastVoteRecordFiles()).resolves.toBeUndefined();
+
+  await expect(
+    backend.addCastVoteRecordFile(
+      new File([partial1CvrFile.asBuffer()], 'cvrs.jsonl'),
+      { analyzeOnly: true }
+    )
+  ).resolves.toEqual({
+    alreadyPresent: 10,
+    newlyAdded: 450,
+    wasExistingFile: false,
+  });
+
+  await expect(backend.loadCastVoteRecordFiles()).resolves.toBeUndefined();
+});
+
+test('addCastVoteRecordFile handles api errors', async () => {
+  const { partial1CvrFile } = electionMinimalExhaustiveSampleFixtures;
+  const storage = new MemoryStorage();
+  const logger = fakeLogger();
+  const backend = new ElectionManagerStoreAdminBackend({ storage, logger });
+
+  await storage.set(currentElectionIdStorageKey, 'test-election-2');
+  fetchMock.get('/admin/elections', { body: getElectionsResponse });
+
+  await storage.set(currentElectionIdStorageKey, 'test-election-id');
+
+  const apiError: Admin.PostCvrFileResponse = {
+    status: 'error',
+    errors: [{ type: 'oops', message: 'that was unexpected' }],
+  };
+  fetchMock.post(`/admin/elections/test-election-id/cvr-files?`, apiError);
+
+  await expect(
+    backend.addCastVoteRecordFile(
+      new File([partial1CvrFile.asBuffer()], 'cvrs.jsonl')
+    )
+  ).rejects.toThrow(/that was unexpected/);
 });

--- a/frontends/election-manager/src/lib/backends/memory_backend.ts
+++ b/frontends/election-manager/src/lib/backends/memory_backend.ts
@@ -182,11 +182,14 @@ export class ElectionManagerStoreMemoryBackend
   }
 
   async addCastVoteRecordFile(
-    newCastVoteRecordFile: File
+    newCastVoteRecordFile: File,
+    options?: { analyzeOnly?: boolean }
   ): Promise<AddCastVoteRecordFileResult> {
     if (!this.electionDefinition) {
       throw new Error('Election definition must be configured first');
     }
+
+    const oldCastVoteRecordFiles = this.castVoteRecordFiles;
 
     this.castVoteRecordFiles = await (
       this.castVoteRecordFiles ?? CastVoteRecordFiles.empty
@@ -201,9 +204,13 @@ export class ElectionManagerStoreMemoryBackend
     const newlyAdded = file?.importedCvrCount ?? 0;
     const alreadyPresent = file?.duplicatedCvrCount ?? 0;
 
-    if (!wasExistingFile && file) {
+    if (!wasExistingFile && file && !options?.analyzeOnly) {
       const newWriteIns = this.getWriteInsFromCastVoteRecords(file);
       this.writeIns = [...(this.writeIns ?? []), ...newWriteIns];
+    }
+
+    if (options?.analyzeOnly) {
+      this.castVoteRecordFiles = oldCastVoteRecordFiles;
     }
 
     return {

--- a/frontends/election-manager/src/lib/backends/types.ts
+++ b/frontends/election-manager/src/lib/backends/types.ts
@@ -48,7 +48,8 @@ export interface ElectionManagerStoreBackend {
    * Adds a new cast vote record file.
    */
   addCastVoteRecordFile(
-    newCastVoteRecordFile: File
+    newCastVoteRecordFile: File,
+    options?: { analyzeOnly?: boolean }
   ): Promise<AddCastVoteRecordFileResult>;
 
   /**


### PR DESCRIPTION
## Overview
Related to: https://github.com/votingworks/vxsuite/issues/2716

Adding a `use_cvr_file_analysis_query` hook  which leverages the existing `analyzeOnly` option flag in the `POST /admin/elections/:id/cvr-files` server endpoint.

This is in preparation for replacing the client-side file analysis in the `ImportCvrFilesModal` with server calls to get information about files discovered on the USB drive, although there's still a bit of work to do in follow-up PRs to return additional data we can use for that.

## Testing Plan 
- Backfilled a couple test cases for the `admin_backend.addCastVoteRecordFile()` function and added a case for the `analyzeOnly` path.
- Not hooked up to any user flows yet, so will test locally later as this gets fleshed out

## Checklist
- [n/a] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [n/a] I have added a screenshot and/or video to this PR to demo the change
- [n/a] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates