### PR TITLE
[VxAdmin] Expand CVR import API response for parity w/client-side code

### DIFF
--- a/frontends/election-manager/src/components/import_cvrfiles_modal.test.tsx
+++ b/frontends/election-manager/src/components/import_cvrfiles_modal.test.tsx
@@ -8,6 +8,7 @@ import {
 } from '@testing-library/react';
 import { fakeKiosk, fakeUsbDrive } from '@votingworks/test-utils';
 
+import { Admin } from '@votingworks/api';
 import { usbstick } from '@votingworks/utils';
 import {
   BallotIdSchema,
@@ -102,6 +103,11 @@ describe('Screens display properly when USB is mounted', () => {
       wasExistingFile: false,
       newlyAdded: 0,
       alreadyPresent: 0,
+      exportedTimestamp: new Date().toISOString(),
+      fileMode: Admin.CvrFileMode.Test,
+      fileName: 'cvrs.jsonl',
+      id: 'cvr-file-1',
+      scannerIds: ['scanner-2', 'scanner-3'],
     });
 
     // You can still manually load files
@@ -186,6 +192,11 @@ describe('Screens display properly when USB is mounted', () => {
       wasExistingFile: false,
       newlyAdded: 0,
       alreadyPresent: 0,
+      exportedTimestamp: new Date().toISOString(),
+      fileMode: Admin.CvrFileMode.Test,
+      fileName: 'cvrs.jsonl',
+      id: 'cvr-file-1',
+      scannerIds: ['scanner-2', 'scanner-3'],
     });
     fireEvent.click(domGetByText(tableRows[0], 'Load'));
     await screen.findByText('Loading');
@@ -290,6 +301,11 @@ describe('Screens display properly when USB is mounted', () => {
       wasExistingFile: true,
       newlyAdded: 0,
       alreadyPresent: 0,
+      exportedTimestamp: new Date().toISOString(),
+      fileMode: Admin.CvrFileMode.Test,
+      fileName: 'cvrs.jsonl',
+      id: 'cvr-file-1',
+      scannerIds: ['scanner-2', 'scanner-3'],
     });
     fireEvent.click(domGetByText(tableRows[1], 'Load'));
     await screen.findByText('Loading');
@@ -378,6 +394,11 @@ describe('Screens display properly when USB is mounted', () => {
       wasExistingFile: false,
       newlyAdded: 0,
       alreadyPresent: 0,
+      exportedTimestamp: new Date().toISOString(),
+      fileMode: Admin.CvrFileMode.Test,
+      fileName: 'cvrs.jsonl',
+      id: 'cvr-file-1',
+      scannerIds: ['scanner-2', 'scanner-3'],
     });
     expect(domGetByText(tableRows[0], 'Load').closest('button')!.disabled).toBe(
       false

--- a/frontends/election-manager/src/components/import_cvrfiles_modal.tsx
+++ b/frontends/election-manager/src/components/import_cvrfiles_modal.tsx
@@ -150,7 +150,11 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
     // instead of file attachments.
     const fileContent = await window.kiosk.readFile(fileData.path, 'utf-8');
 
-    await importCvrFile(new File([fileContent], fileData.name));
+    await importCvrFile(
+      new File([fileContent], fileData.name, {
+        lastModified: moment(fileData.exportTimestamp).valueOf(),
+      })
+    );
   }
 
   const processCastVoteRecordFileFromFilePicker: InputEventFunction = async (

--- a/frontends/election-manager/src/hooks/use_cvr_file_analysis_query.ts
+++ b/frontends/election-manager/src/hooks/use_cvr_file_analysis_query.ts
@@ -1,8 +1,8 @@
 import { QueryKey, useQuery, UseQueryResult } from '@tanstack/react-query';
+import { Admin } from '@votingworks/api';
 import { useContext } from 'react';
 
 import { ServicesContext } from '../contexts/services_context';
-import { AddCastVoteRecordFileResult } from '../lib/backends';
 
 /** Gets the query key for the CVR file analysis query. */
 export function getCvrFileAnalysisQueryKey(cvrFile: File): QueryKey {
@@ -12,7 +12,7 @@ export function getCvrFileAnalysisQueryKey(cvrFile: File): QueryKey {
 /** Returns a query for an analysis of the given CVR file. */
 export function useCvrFileAnalysisQuery(
   cvrFile: File
-): UseQueryResult<AddCastVoteRecordFileResult> {
+): UseQueryResult<Admin.CvrFileImportInfo> {
   const { backend } = useContext(ServicesContext);
 
   return useQuery(getCvrFileAnalysisQueryKey(cvrFile), () =>

--- a/frontends/election-manager/src/lib/backends/backends.test.ts
+++ b/frontends/election-manager/src/lib/backends/backends.test.ts
@@ -122,6 +122,10 @@ function makeAdminBackend(): ElectionManagerStoreAdminBackend {
           wasExistingFile: result.wasExistingFile,
           newlyAdded: result.newlyAdded,
           alreadyPresent: result.alreadyPresent,
+          exportedTimestamp: result.exportedTimestamp,
+          fileMode: result.fileMode,
+          fileName: result.fileName,
+          scannerIds: result.scannerIds,
         }),
       };
     })

--- a/frontends/election-manager/src/lib/backends/memory_backend.ts
+++ b/frontends/election-manager/src/lib/backends/memory_backend.ts
@@ -24,10 +24,7 @@ import {
 import { v4 as uuid } from 'uuid';
 import { CastVoteRecordFile } from '../../config/types';
 import { CastVoteRecordFiles } from '../../utils/cast_vote_record_files';
-import {
-  AddCastVoteRecordFileResult,
-  ElectionManagerStoreBackend,
-} from './types';
+import { ElectionManagerStoreBackend } from './types';
 
 interface MemoryWriteInRecord {
   readonly id: Id;
@@ -184,7 +181,7 @@ export class ElectionManagerStoreMemoryBackend
   async addCastVoteRecordFile(
     newCastVoteRecordFile: File,
     options?: { analyzeOnly?: boolean }
-  ): Promise<AddCastVoteRecordFileResult> {
+  ): Promise<Admin.CvrFileImportInfo> {
     if (!this.electionDefinition) {
       throw new Error('Election definition must be configured first');
     }
@@ -213,10 +210,17 @@ export class ElectionManagerStoreMemoryBackend
       this.castVoteRecordFiles = oldCastVoteRecordFiles;
     }
 
+    assert(file);
+
     return {
       wasExistingFile,
       newlyAdded,
       alreadyPresent,
+      exportedTimestamp: file.exportTimestamp.toISOString(),
+      fileMode: await this.getCurrentCvrFileMode(),
+      fileName: file.name,
+      id: uuid(),
+      scannerIds: [...file.scannerIds],
     };
   }
 

--- a/frontends/election-manager/src/lib/backends/types.ts
+++ b/frontends/election-manager/src/lib/backends/types.ts
@@ -50,7 +50,7 @@ export interface ElectionManagerStoreBackend {
   addCastVoteRecordFile(
     newCastVoteRecordFile: File,
     options?: { analyzeOnly?: boolean }
-  ): Promise<AddCastVoteRecordFileResult>;
+  ): Promise<Admin.CvrFileImportInfo>;
 
   /**
    * Resets all cast vote record files.

--- a/libs/api/src/services/admin/endpoints.ts
+++ b/libs/api/src/services/admin/endpoints.ts
@@ -7,6 +7,8 @@ import {
   ElectionDefinitionSchema,
   Id,
   IdSchema,
+  Iso8601Timestamp,
+  Iso8601TimestampSchema,
   safeParseNumber,
 } from '@votingworks/types';
 import * as z from 'zod';
@@ -17,6 +19,7 @@ import {
   OkResponseSchema,
 } from '../../base';
 import {
+  CvrFileImportInfo,
   BallotMode,
   BallotModeSchema,
   CastVoteRecordFileRecord,
@@ -160,26 +163,23 @@ export const DeleteElectionResponseSchema = z.union([
  * @url /admin/elections/:electionId/cvr-files
  * @method POST
  */
-export type PostCvrFileRequest = never;
+export interface PostCvrFileRequest {
+  exportedTimestamp: Iso8601Timestamp;
+}
 
 /**
  * @url /admin/elections/:electionId/cvr-files
  * @method POST
  */
 export const PostCvrFileRequestSchema: z.ZodSchema<PostCvrFileRequest> =
-  z.never();
+  z.object({ exportedTimestamp: Iso8601TimestampSchema });
 
 /**
  * @url /admin/elections/:electionId/cvr-files
  * @method POST
  */
 export type PostCvrFileResponse =
-  | OkResponse<{
-      id: Id;
-      wasExistingFile: boolean;
-      newlyAdded: number;
-      alreadyPresent: number;
-    }>
+  | OkResponse<CvrFileImportInfo>
   | ErrorsResponse;
 
 /**
@@ -194,6 +194,10 @@ export const PostCvrFileResponseSchema: z.ZodSchema<PostCvrFileResponse> =
       wasExistingFile: z.boolean(),
       newlyAdded: z.number().int().nonnegative(),
       alreadyPresent: z.number().int().nonnegative(),
+      exportedTimestamp: Iso8601TimestampSchema,
+      fileMode: z.nativeEnum(CvrFileMode),
+      fileName: z.string(),
+      scannerIds: z.array(z.string()),
     }),
     ErrorsResponseSchema,
   ]);

--- a/libs/api/src/services/admin/types.ts
+++ b/libs/api/src/services/admin/types.ts
@@ -42,6 +42,21 @@ export const ElectionRecordSchema: z.ZodSchema<ElectionRecord> = z.object({
 });
 
 /**
+ * Info related to a CVR file import attempt.
+ */
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type CvrFileImportInfo = {
+  id: Id;
+  alreadyPresent: number;
+  exportedTimestamp: Iso8601Timestamp;
+  fileMode: CvrFileMode;
+  fileName: string;
+  newlyAdded: number;
+  scannerIds: string[];
+  wasExistingFile: boolean;
+};
+
+/**
  * A cast vote record file's metadata.
  */
 export interface CastVoteRecordFileRecord {

--- a/services/admin/src/server.test.ts
+++ b/services/admin/src/server.test.ts
@@ -156,6 +156,7 @@ test('POST /admin/elections/:electionId/cvr-files', async () => {
       electionMinimalExhaustiveSampleFixtures.standardCvrFile.asBuffer(),
       'cvrFile.json'
     )
+    .field('exportedTimestamp', '2021-09-02T22:27:58.327Z')
     .expect(200);
   const response = unsafeParse(
     Admin.PostCvrFileResponseSchema,
@@ -191,6 +192,7 @@ test('POST /admin/elections/:electionId/cvr-files duplicate file', async () => {
       electionMinimalExhaustiveSampleFixtures.standardCvrFile.asBuffer(),
       'cvrFile.json'
     )
+    .field('exportedTimestamp', '2021-09-02T22:27:58.327Z')
     .expect(200);
   const response = unsafeParse(
     Admin.PostCvrFileResponseSchema,
@@ -204,6 +206,10 @@ test('POST /admin/elections/:electionId/cvr-files duplicate file', async () => {
       wasExistingFile: false,
       newlyAdded: 3000,
       alreadyPresent: 0,
+      exportedTimestamp: '2021-09-02T22:27:58.327Z',
+      fileMode: Admin.CvrFileMode.Test,
+      fileName: 'cvrFile.json',
+      scannerIds: expect.arrayContaining(['scanner-1', 'scanner-2']),
     })
   );
 
@@ -214,6 +220,7 @@ test('POST /admin/elections/:electionId/cvr-files duplicate file', async () => {
       electionMinimalExhaustiveSampleFixtures.standardCvrFile.asBuffer(),
       'cvrFile.json'
     )
+    .field('exportedTimestamp', '2021-09-02T22:27:58.327Z')
     .expect(200);
   const response2 = unsafeParse(
     Admin.PostCvrFileResponseSchema,
@@ -227,6 +234,10 @@ test('POST /admin/elections/:electionId/cvr-files duplicate file', async () => {
       wasExistingFile: true,
       newlyAdded: 0,
       alreadyPresent: 3000,
+      exportedTimestamp: '2021-09-02T22:27:58.327Z',
+      fileMode: Admin.CvrFileMode.Test,
+      fileName: 'cvrFile.json',
+      scannerIds: [],
     })
   );
 });
@@ -243,6 +254,7 @@ test('POST /admin/elections/:electionId/cvr-files?analyzeOnly=true', async () =>
       electionMinimalExhaustiveSampleFixtures.standardCvrFile.asBuffer(),
       'cvrFile.json'
     )
+    .field('exportedTimestamp', '2021-09-02T22:27:58.327Z')
     .expect(200);
   const response = unsafeParse(
     Admin.PostCvrFileResponseSchema,
@@ -256,6 +268,10 @@ test('POST /admin/elections/:electionId/cvr-files?analyzeOnly=true', async () =>
       wasExistingFile: false,
       newlyAdded: 3000,
       alreadyPresent: 0,
+      exportedTimestamp: '2021-09-02T22:27:58.327Z',
+      fileMode: Admin.CvrFileMode.Test,
+      fileName: 'cvrFile.json',
+      scannerIds: expect.arrayContaining(['scanner-1', 'scanner-2']),
     })
   );
 
@@ -274,6 +290,7 @@ test('POST /admin/elections/:electionId/cvr-files bad query param', async () => 
       electionMinimalExhaustiveSampleFixtures.standardCvrFile.asBuffer(),
       'cvrFile.json'
     )
+    .field('exportedTimestamp', '2021-09-02T22:27:58.327Z')
     .expect(400);
 });
 
@@ -284,6 +301,22 @@ test('POST /admin/elections/:electionId/cvr-files without a file', async () => {
 
   await request(app)
     .post(`/admin/elections/${electionId}/cvr-files`)
+    .field('exportedTimestamp', '2021-09-02T22:27:58.327Z')
+    .expect(400);
+});
+
+test('POST /admin/elections/:electionId/cvr-files without exportedTimestamp', async () => {
+  const electionId = workspace.store.addElection(
+    electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData
+  );
+
+  await request(app)
+    .post(`/admin/elections/${electionId}/cvr-files`)
+    .attach(
+      'cvrFile',
+      electionMinimalExhaustiveSampleFixtures.standardCvrFile.asBuffer(),
+      'cvrFile.json'
+    )
     .expect(400);
 });
 
@@ -301,6 +334,7 @@ test('POST /admin/elections/:electionId/cvr-files with duplicate CVR entries', a
       electionMinimalExhaustiveSampleFixtures.partial1CvrFile.asBuffer(),
       'cvrFile.json'
     )
+    .field('exportedTimestamp', '2021-09-02T22:27:58.327Z')
     .expect(200);
   const partial1Response = unsafeParse(
     Admin.PostCvrFileResponseSchema,
@@ -314,6 +348,10 @@ test('POST /admin/elections/:electionId/cvr-files with duplicate CVR entries', a
       wasExistingFile: false,
       newlyAdded: 101,
       alreadyPresent: 0,
+      exportedTimestamp: '2021-09-02T22:27:58.327Z',
+      fileMode: Admin.CvrFileMode.Test,
+      fileName: 'cvrFile.json',
+      scannerIds: expect.arrayContaining(['scanner-1', 'scanner-2']),
     })
   );
 
@@ -328,6 +366,7 @@ test('POST /admin/elections/:electionId/cvr-files with duplicate CVR entries', a
       electionMinimalExhaustiveSampleFixtures.partial2CvrFile.asBuffer(),
       'cvrFile.json'
     )
+    .field('exportedTimestamp', '2021-09-02T22:27:58.327Z')
     .expect(200);
 
   const partial2Response = unsafeParse(
@@ -342,6 +381,10 @@ test('POST /admin/elections/:electionId/cvr-files with duplicate CVR entries', a
       wasExistingFile: false,
       newlyAdded: 20,
       alreadyPresent: 21,
+      exportedTimestamp: '2021-09-02T22:27:58.327Z',
+      fileMode: Admin.CvrFileMode.Test,
+      fileName: 'cvrFile.json',
+      scannerIds: expect.arrayContaining(['scanner-1', 'scanner-2']),
     })
   );
 
@@ -356,6 +399,7 @@ test('POST /admin/elections/:electionId/cvr-files with duplicate CVR entries', a
       electionMinimalExhaustiveSampleFixtures.standardCvrFile.asBuffer(),
       'cvrFile.json'
     )
+    .field('exportedTimestamp', '2021-09-02T22:27:58.327Z')
     .expect(200);
 
   const standardResponse = unsafeParse(
@@ -370,6 +414,10 @@ test('POST /admin/elections/:electionId/cvr-files with duplicate CVR entries', a
       wasExistingFile: false,
       newlyAdded: 2879,
       alreadyPresent: 121,
+      exportedTimestamp: '2021-09-02T22:27:58.327Z',
+      fileMode: Admin.CvrFileMode.Test,
+      fileName: 'cvrFile.json',
+      scannerIds: expect.arrayContaining(['scanner-1', 'scanner-2']),
     })
   );
 
@@ -380,6 +428,10 @@ test('POST /admin/elections/:electionId/cvr-files with duplicate CVR entries', a
       wasExistingFile: false,
       newlyAdded: 20,
       alreadyPresent: 21,
+      exportedTimestamp: '2021-09-02T22:27:58.327Z',
+      fileMode: Admin.CvrFileMode.Test,
+      fileName: 'cvrFile.json',
+      scannerIds: expect.arrayContaining(['scanner-1', 'scanner-2']),
     })
   );
   expect(workspace.store.getCastVoteRecordEntries(electionId)).toHaveLength(
@@ -410,6 +462,7 @@ test('POST /admin/elections/:electionId/cvr-files with duplicate ballot IDs', as
       ]),
       'cvrFile.json'
     )
+    .field('exportedTimestamp', '2021-09-02T22:27:58.327Z')
     .expect(400);
   const response = unsafeParse(
     Admin.PostCvrFileResponseSchema,
@@ -440,6 +493,7 @@ test('DELETE /admin/elections/:electionId/cvr-files', async () => {
       electionMinimalExhaustiveSampleFixtures.partial1CvrFile.asBuffer(),
       'cvrFile.json'
     )
+    .field('exportedTimestamp', '2021-09-02T22:27:58.327Z')
     .expect(200);
 
   await request(app)
@@ -461,6 +515,7 @@ test('GET /admin/elections/:electionId/write-ins', async () => {
       electionMinimalExhaustiveSampleFixtures.standardCvrFile.asBuffer(),
       'cvrFile.json'
     )
+    .field('exportedTimestamp', '2021-09-02T22:27:58.327Z')
     .expect(200);
   const postCvrResponse = unsafeParse(
     Admin.PostCvrFileResponseSchema,
@@ -531,6 +586,7 @@ test('PUT /admin/write-ins/:writeInId/transcription', async () => {
       electionMinimalExhaustiveSampleFixtures.standardCvrFile.asBuffer(),
       'cvrFile.json'
     )
+    .field('exportedTimestamp', '2021-09-02T22:27:58.327Z')
     .expect(200);
   const postCvrResponse = unsafeParse(
     Admin.PostCvrFileResponseSchema,
@@ -591,6 +647,7 @@ test('PUT /admin/write-ins/:writeInId/transcription missing value', async () => 
       electionMinimalExhaustiveSampleFixtures.standardCvrFile.asBuffer(),
       'cvrFile.json'
     )
+    .field('exportedTimestamp', '2021-09-02T22:27:58.327Z')
     .expect(200);
   const postCvrResponse = unsafeParse(
     Admin.PostCvrFileResponseSchema,

--- a/services/admin/src/server.writeins.test.ts
+++ b/services/admin/src/server.writeins.test.ts
@@ -30,6 +30,7 @@ test('write-in adjudication lifecycle', async () => {
       electionMinimalExhaustiveSampleFixtures.standardCvrFile.asBuffer(),
       'cvrFile.json'
     )
+    .field('exportedTimestamp', '2021-09-02T22:27:58.327Z')
     .expect(200);
   const postCvrResponse = unsafeParse(
     Admin.PostCvrFileResponseSchema,
@@ -404,6 +405,7 @@ test('write-in summary filtered by contestId & status', async () => {
       electionMinimalExhaustiveSampleFixtures.standardCvrFile.asBuffer(),
       'cvrFile.json'
     )
+    .field('exportedTimestamp', '2021-09-02T22:27:58.327Z')
     .expect(200);
   const postCvrResponse = unsafeParse(
     Admin.PostCvrFileResponseSchema,

--- a/services/admin/src/store.test.ts
+++ b/services/admin/src/store.test.ts
@@ -69,13 +69,18 @@ test('add a CVR file', async () => {
         electionId,
         filePath: cvrFile,
         originalFilename: 'cvrs.jsonl',
+        exportedTimestamp: '2021-09-02T22:27:58.327Z',
       })
     ).unsafeUnwrap()
-  ).toEqual({
+  ).toEqual<Admin.CvrFileImportInfo>({
     id: expect.stringMatching(/^[-0-9a-f]+$/),
     wasExistingFile: false,
     newlyAdded: 3000,
     alreadyPresent: 0,
+    exportedTimestamp: '2021-09-02T22:27:58.327Z',
+    fileMode: Admin.CvrFileMode.Test,
+    fileName: 'cvrs.jsonl',
+    scannerIds: expect.arrayContaining(['scanner-1', 'scanner-2']),
   });
 
   const writeInCount = (await fs.readFile(cvrFile, 'utf-8'))
@@ -111,13 +116,18 @@ test('add a CVR file with empty lines', async () => {
         electionId,
         filePath: cvrFile,
         originalFilename: 'cvrs.jsonl',
+        exportedTimestamp: '2021-09-02T22:27:58.327Z',
       })
     ).unsafeUnwrap()
-  ).toEqual({
+  ).toEqual<Admin.CvrFileImportInfo>({
     id: expect.stringMatching(/^[-0-9a-f]+$/),
     wasExistingFile: false,
     newlyAdded: 3000,
     alreadyPresent: 0,
+    exportedTimestamp: '2021-09-02T22:27:58.327Z',
+    fileMode: Admin.CvrFileMode.Test,
+    fileName: 'cvrs.jsonl',
+    scannerIds: expect.arrayContaining(['scanner-1', 'scanner-2']),
   });
 
   const writeInCount = (await fs.readFile(cvrFile, 'utf-8'))
@@ -144,22 +154,40 @@ test('add a duplicate CVR file', async () => {
   const cvrFile =
     electionMinimalExhaustiveSampleFixtures.standardCvrFile.asFilePath();
   const originalResult = (
-    await store.addCastVoteRecordFile({ electionId, filePath: cvrFile })
+    await store.addCastVoteRecordFile({
+      electionId,
+      filePath: cvrFile,
+      originalFilename: 'cvrs.jsonl',
+      exportedTimestamp: '2021-09-02T22:27:58.327Z',
+    })
   ).unsafeUnwrap();
-  expect(originalResult).toEqual({
+  expect(originalResult).toEqual<Admin.CvrFileImportInfo>({
     id: expect.stringMatching(/^[-0-9a-f]+$/),
     wasExistingFile: false,
     newlyAdded: 3000,
     alreadyPresent: 0,
+    exportedTimestamp: '2021-09-02T22:27:58.327Z',
+    fileMode: Admin.CvrFileMode.Test,
+    fileName: 'cvrs.jsonl',
+    scannerIds: expect.arrayContaining(['scanner-1', 'scanner-2']),
   });
   const duplicateResult = (
-    await store.addCastVoteRecordFile({ electionId, filePath: cvrFile })
+    await store.addCastVoteRecordFile({
+      electionId,
+      filePath: cvrFile,
+      originalFilename: 'cvrs.jsonl',
+      exportedTimestamp: '2021-09-02T22:27:58.327Z',
+    })
   ).unsafeUnwrap();
-  expect(duplicateResult).toEqual({
+  expect(duplicateResult).toEqual<Admin.CvrFileImportInfo>({
     id: originalResult.id,
     wasExistingFile: true,
     newlyAdded: 0,
     alreadyPresent: 3000,
+    exportedTimestamp: '2021-09-02T22:27:58.327Z',
+    fileMode: Admin.CvrFileMode.Test,
+    fileName: 'cvrs.jsonl',
+    scannerIds: [],
   });
 });
 
@@ -173,22 +201,40 @@ test('partially duplicate CVR files', async () => {
   const partial2CvrFile =
     electionMinimalExhaustiveSampleFixtures.partial2CvrFile.asFilePath();
   const addPartial1Result = (
-    await store.addCastVoteRecordFile({ electionId, filePath: partial1CvrFile })
+    await store.addCastVoteRecordFile({
+      electionId,
+      filePath: partial1CvrFile,
+      originalFilename: 'cvrs.jsonl',
+      exportedTimestamp: '2021-09-02T22:27:58.327Z',
+    })
   ).unsafeUnwrap();
-  expect(addPartial1Result).toEqual({
+  expect(addPartial1Result).toEqual<Admin.CvrFileImportInfo>({
     id: expect.stringMatching(/^[-0-9a-f]+$/),
     wasExistingFile: false,
     newlyAdded: 101,
     alreadyPresent: 0,
+    exportedTimestamp: '2021-09-02T22:27:58.327Z',
+    fileMode: Admin.CvrFileMode.Test,
+    fileName: 'cvrs.jsonl',
+    scannerIds: expect.arrayContaining(['scanner-1', 'scanner-2']),
   });
   const addPartial2Result = (
-    await store.addCastVoteRecordFile({ electionId, filePath: partial2CvrFile })
+    await store.addCastVoteRecordFile({
+      electionId,
+      filePath: partial2CvrFile,
+      originalFilename: 'cvrs-2.jsonl',
+      exportedTimestamp: '2021-09-02T22:27:58.327Z',
+    })
   ).unsafeUnwrap();
-  expect(addPartial2Result).toEqual({
+  expect(addPartial2Result).toEqual<Admin.CvrFileImportInfo>({
     id: expect.stringMatching(/^[-0-9a-f]+$/),
     wasExistingFile: false,
     newlyAdded: 20,
     alreadyPresent: 21,
+    exportedTimestamp: '2021-09-02T22:27:58.327Z',
+    fileMode: Admin.CvrFileMode.Test,
+    fileName: 'cvrs-2.jsonl',
+    scannerIds: expect.arrayContaining(['scanner-1', 'scanner-2']),
   });
 
   const partial1WriteInCount = 42;
@@ -213,13 +259,19 @@ test('analyze a CVR file', async () => {
         electionId,
         filePath: cvrFile,
         analyzeOnly: true,
+        originalFilename: 'cvrs.jsonl',
+        exportedTimestamp: '2021-09-02T22:27:58.327Z',
       })
     ).unsafeUnwrap()
-  ).toEqual({
+  ).toEqual<Admin.CvrFileImportInfo>({
     id: expect.any(String),
     wasExistingFile: false,
     newlyAdded: 3000,
     alreadyPresent: 0,
+    exportedTimestamp: '2021-09-02T22:27:58.327Z',
+    fileMode: Admin.CvrFileMode.Test,
+    fileName: 'cvrs.jsonl',
+    scannerIds: expect.arrayContaining(['scanner-1', 'scanner-2']),
   });
 
   // analyzing does not add to the store
@@ -244,6 +296,7 @@ test('adding a CVR file if adding an entry fails', async () => {
         electionId,
         filePath: cvrFile,
         originalFilename: 'cvrs.jsonl',
+        exportedTimestamp: '2021-09-02T22:27:58.327Z',
       })
     ).unsafeUnwrap()
   ).rejects.toThrowError('oops');
@@ -267,6 +320,7 @@ test('add a CVR file entry without a ballot ID', async () => {
     electionId,
     originalFilename: 'cvrs.jsonl',
     filePath: tmpfile.name,
+    exportedTimestamp: '2021-09-02T22:27:58.327Z',
   });
 
   expect(result.unsafeUnwrapErr()).toEqual(
@@ -284,6 +338,8 @@ test('add a CVR file entry matching an existing ballot ID with different data', 
   await store.addCastVoteRecordFile({
     electionId,
     filePath: standardCvrFile.asFilePath(),
+    originalFilename: 'cvrs.jsonl',
+    exportedTimestamp: '2021-09-02T22:27:58.327Z',
   });
 
   // Create modified CVR file with ballot data changed slightly:
@@ -296,6 +352,8 @@ test('add a CVR file entry matching an existing ballot ID with different data', 
   const result = await store.addCastVoteRecordFile({
     electionId,
     filePath: tmpFile.name,
+    originalFilename: 'cvrs.jsonl',
+    exportedTimestamp: '2021-09-02T22:27:58.327Z',
   });
 
   expect(result.err()).toMatchObject({
@@ -316,6 +374,7 @@ test('add a live CVR file after adding a test CVR file', async () => {
     electionId,
     filePath: standardCvrFile.asFilePath(),
     originalFilename: 'test-cvrs.jsonl',
+    exportedTimestamp: '2021-09-02T22:27:58.327Z',
   });
 
   const liveCvr: CastVoteRecord = {
@@ -334,6 +393,7 @@ test('add a live CVR file after adding a test CVR file', async () => {
     electionId,
     filePath: tmpFile.name,
     originalFilename: 'live-cvrs.jsonl',
+    exportedTimestamp: '2021-09-02T22:27:58.327Z',
   });
 
   expect(result.err()).toEqual({
@@ -354,6 +414,7 @@ test('add a test CVR file after adding a live CVR file', async () => {
     electionId,
     filePath: standardLiveCvrFile.asFilePath(),
     originalFilename: 'live-cvrs.jsonl',
+    exportedTimestamp: '2021-09-02T22:27:58.327Z',
   });
 
   const testCvr: CastVoteRecord = {
@@ -372,6 +433,7 @@ test('add a test CVR file after adding a live CVR file', async () => {
     electionId,
     filePath: tmpFile.name,
     originalFilename: 'test-cvrs.jsonl',
+    exportedTimestamp: '2021-09-02T22:27:58.327Z',
   });
 
   expect(result.err()).toEqual({
@@ -400,6 +462,7 @@ test('add a CVR file with mixed live and test CVRs', async () => {
     electionId,
     filePath: tmpFile.name,
     originalFilename: 'mixed-cvrs.jsonl',
+    exportedTimestamp: '2021-09-02T22:27:58.327Z',
   });
 
   expect(result.err()).toEqual({
@@ -421,6 +484,8 @@ test('add a CVR file with an invalid election id', async () => {
   const result = await store.addCastVoteRecordFile({
     electionId: 'not-a-real-election-id',
     filePath: cvrFile.asFilePath(),
+    originalFilename: 'cvrs.jsonl',
+    exportedTimestamp: '2021-09-02T22:27:58.327Z',
   });
 
   expect(result.err()).toEqual({ kind: 'InvalidElectionId' });
@@ -437,6 +502,8 @@ test('add a CVR file with mismatched election details', async () => {
   const result = await store.addCastVoteRecordFile({
     electionId,
     filePath: cvrFile.asFilePath(),
+    originalFilename: 'cvrs.jsonl',
+    exportedTimestamp: '2021-09-02T22:27:58.327Z',
   });
 
   expect(result.err()).toMatchObject({
@@ -462,6 +529,8 @@ test('add a CVR file with an invalid vote', async () => {
   const result = await store.addCastVoteRecordFile({
     electionId,
     filePath: tmpFile.name,
+    originalFilename: 'cvrs.jsonl',
+    exportedTimestamp: '2021-09-02T22:27:58.327Z',
   });
 
   expect(result.err()).toMatchObject({
@@ -489,6 +558,8 @@ test('add a CVR file with unhandled validation errors', async () => {
   const result = await store.addCastVoteRecordFile({
     electionId,
     filePath: tmpFile.name,
+    originalFilename: 'cvrs.jsonl',
+    exportedTimestamp: '2021-09-02T22:27:58.327Z',
   });
 
   expect(result.isErr()).toBe(true);
@@ -517,6 +588,7 @@ test('get CVR file metadata', async () => {
       electionId,
       originalFilename: 'cvrs.jsonl',
       filePath: cvrFile,
+      exportedTimestamp: '2021-09-02T22:27:58.327Z',
     })
   ).unsafeUnwrap();
 
@@ -557,6 +629,7 @@ test('getCvrFileMode returns "test" if test CVRs previously imported', async () 
     filePath:
       electionMinimalExhaustiveSampleFixtures.standardCvrFile.asFilePath(),
     originalFilename: 'cvrs.jsonl',
+    exportedTimestamp: '2021-09-02T22:27:58.327Z',
   });
 
   expect(store.getCurrentCvrFileModeForElection(electionId)).toBe(
@@ -575,6 +648,7 @@ test('getCvrFileMode returns "live" if official CVRs previously imported', async
     filePath:
       electionMinimalExhaustiveSampleFixtures.standardLiveCvrFile.asFilePath(),
     originalFilename: 'cvrs.jsonl',
+    exportedTimestamp: '2021-09-02T22:27:58.327Z',
   });
 
   expect(store.getCurrentCvrFileModeForElection(electionId)).toBe(
@@ -600,6 +674,7 @@ test('get write-in adjudication records', async () => {
       originalFilename: 'cvrs.jsonl',
       // add the first two CVRs, which do not have write-ins
       filePath: tmpfile.name,
+      exportedTimestamp: '2021-09-02T22:27:58.327Z',
     })
   ).unsafeUnwrap();
 
@@ -710,6 +785,7 @@ test('write-in adjudication lifecycle', async () => {
       electionId,
       originalFilename: 'cvrs.jsonl',
       filePath: tmpfile.name,
+      exportedTimestamp: '2021-09-02T22:27:58.327Z',
     })
   ).unsafeUnwrap();
 


### PR DESCRIPTION
## Overview
Related to: https://github.com/votingworks/vxsuite/issues/2716

Adding additional data to the `PostCvrFileResponse` from the admin backend to match what's used client-side for listing CVR files on the USB drive.

## Testing Plan 
- Added new test cases and updated any relevant existing tests
- Not hooked up to any user flows yet, but will be also be testing locally once that's done

## Checklist
- [n/a] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [n/a] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [n/a] I have added a screenshot and/or video to this PR to demo the change
- [n/a] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
