### PR TITLE
[VxAdmin] Remove client-side CVR pre-loading logic

### DIFF
--- a/frontends/election-manager/src/config/types.ts
+++ b/frontends/election-manager/src/config/types.ts
@@ -135,13 +135,12 @@ export interface CastVoteRecordFile {
 }
 export interface CastVoteRecordFilePreprocessedData {
   readonly name: string;
-  readonly newCvrCount: number;
-  readonly importedCvrCount: number;
+  readonly path: string;
+  readonly cvrCount: number;
   readonly scannerIds: readonly string[];
   readonly exportTimestamp: Date;
   readonly isTestModeResults: boolean;
   readonly fileImported: boolean;
-  readonly fileContent: string;
 }
 
 export type VoteCounts = Dictionary<Dictionary<number>>;

--- a/frontends/election-manager/src/utils/cast_vote_record_files.ts
+++ b/frontends/election-manager/src/utils/cast_vote_record_files.ts
@@ -183,8 +183,8 @@ export class CastVoteRecordFiles {
   }
 
   /**
-   * Parses the CVR files from `files` to determine the number of CVR entries
-   * in the file and the number of those entries that are duplicates.
+   * Parses the filenames for the given CVR {@link files} for information about
+   * the CVRs they contain.
    */
   parseAllFromFileSystemEntries(
     files: KioskBrowser.FileSystemEntry[]
@@ -192,12 +192,12 @@ export class CastVoteRecordFiles {
     const results: CastVoteRecordFilePreprocessedData[] = [];
     for (const file of files) {
       try {
-        const importedFile = [...this.files].find((f) => f.name === file.name);
+        const fileImported = [...this.files].some((f) => f.name === file.name);
         const parsedFileInfo = parseCvrFileInfoFromFilename(file.name);
         if (parsedFileInfo) {
           results.push({
             exportTimestamp: parsedFileInfo.timestamp,
-            fileImported: !!importedFile,
+            fileImported,
             cvrCount: parsedFileInfo.numberOfBallots,
             isTestModeResults: parsedFileInfo.isTestModeResults,
             name: file.name,

--- a/frontends/election-manager/src/utils/cast_vote_record_files.ts
+++ b/frontends/election-manager/src/utils/cast_vote_record_files.ts
@@ -186,38 +186,24 @@ export class CastVoteRecordFiles {
    * Parses the CVR files from `files` to determine the number of CVR entries
    * in the file and the number of those entries that are duplicates.
    */
-  async parseAllFromFileSystemEntries(
-    files: KioskBrowser.FileSystemEntry[],
-    election: Election
-  ): Promise<CastVoteRecordFilePreprocessedData[]> {
+  parseAllFromFileSystemEntries(
+    files: KioskBrowser.FileSystemEntry[]
+  ): CastVoteRecordFilePreprocessedData[] {
     const results: CastVoteRecordFilePreprocessedData[] = [];
     for (const file of files) {
       try {
         const importedFile = [...this.files].find((f) => f.name === file.name);
-        if (importedFile) {
+        const parsedFileInfo = parseCvrFileInfoFromFilename(file.name);
+        if (parsedFileInfo) {
           results.push({
-            fileImported: true,
-            newCvrCount: 0,
-            importedCvrCount: importedFile.importedCvrCount,
-            scannerIds: importedFile.scannerIds,
-            exportTimestamp: importedFile.exportTimestamp,
-            isTestModeResults:
-              !!importedFile.allCastVoteRecords[0]?._testBallot,
-            fileContent: '',
+            exportTimestamp: parsedFileInfo.timestamp,
+            fileImported: !!importedFile,
+            cvrCount: parsedFileInfo.numberOfBallots,
+            isTestModeResults: parsedFileInfo.isTestModeResults,
             name: file.name,
+            path: file.path,
+            scannerIds: [parsedFileInfo.machineId],
           });
-        } else {
-          assert(window.kiosk);
-          const fileContent = await window.kiosk.readFile(file.path, 'utf-8');
-          const parsedFileInfo = parseCvrFileInfoFromFilename(file.name);
-          const parsedFile = this.parseFromFileContent(
-            fileContent,
-            file.name,
-            parsedFileInfo?.timestamp || new Date(file.mtime),
-            parsedFileInfo?.machineId || '',
-            election
-          );
-          results.push(parsedFile);
         }
       } catch (error) {
         // The file isn't able to be read or isn't a valid CVR file for loading and could not be processed.
@@ -254,53 +240,6 @@ export class CastVoteRecordFiles {
         this.deduplicatedCastVoteRecords
       );
     }
-  }
-
-  private parseFromFileContent(
-    fileContent: string,
-    fileName: string,
-    exportTimestamp: Date,
-    scannerId: string,
-    election: Election
-  ): CastVoteRecordFilePreprocessedData {
-    const fileCastVoteRecords: CastVoteRecord[] = [];
-    let testBallotSeen = false;
-    let liveBallotSeen = false;
-
-    for (const { cvr } of parseCvrs(fileContent, election)) {
-      fileCastVoteRecords.push(cvr);
-      if (cvr._testBallot) {
-        testBallotSeen = true;
-      } else {
-        liveBallotSeen = true;
-      }
-      if (testBallotSeen && liveBallotSeen) {
-        throw new Error(
-          'These CVRs cannot be tabulated together because they mix live and test ballots'
-        );
-      }
-    }
-
-    const scannerIds = arrayUnique(
-      fileCastVoteRecords.map((cvr) => cvr._scannerId)
-    );
-
-    const [
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      deduplicatedCastVoteRecords,
-      duplicateCount,
-    ] = this.addUniqueCastVoteRecordsToCurrentCollection(fileCastVoteRecords);
-
-    return {
-      name: fileName,
-      newCvrCount: fileCastVoteRecords.length - duplicateCount,
-      importedCvrCount: duplicateCount,
-      scannerIds: scannerIds.length > 0 ? scannerIds : [scannerId],
-      exportTimestamp,
-      isTestModeResults: testBallotSeen,
-      fileContent,
-      fileImported: false,
-    };
   }
 
   private addFromFileContent(


### PR DESCRIPTION
## Overview
Related to: https://github.com/votingworks/vxsuite/issues/2716

- Removing client-side logic around pre-loading/parsing CVR files found on the USB drive to detect duplicate CVRs prior to importing.
- This simplifies the code a bit as we move CVR data management to the backend and should improve performance in cases where there are multiple large CVR files on the USB drive.
- Side-effects:
  - We no longer show duplicate CVR counts in the import modal (these are still surfaced in the confirmation modal after import)
  - All information displayed in the CVR table are now based solely on information from the filename (as was the case before the pre-loading logic was added)

More context around the decision in [this slack thread](https://votingworks.slack.com/archives/CEL6D3GAD/p1668541124423049)

## Demo Video or Screenshot

### Before:
<img width="1121" alt="Screenshot 2022-11-16 at 9 55 05 AM" src="https://user-images.githubusercontent.com/264902/202230850-9e134707-71df-4fbb-86b3-cc2035317a24.png">

### After:
<img width="1127" alt="Screenshot 2022-11-15 at 4 53 02 PM" src="https://user-images.githubusercontent.com/264902/202230982-e4a01071-a2f9-4000-8dbf-e368a36d3a9b.png">

<img width="1133" alt="Screenshot 2022-11-15 at 4 53 14 PM" src="https://user-images.githubusercontent.com/264902/202232150-b7c5bf97-3d9d-47ef-960a-d3fc5ad783ec.png">

## Testing Plan 
- Updated existing tests
- Verified locally

## Checklist
- [n/a] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [n/a] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
