### PR TITLE
[VxAdmin] Augment cvr_files db schema with fields needed in the client

### DIFF
--- a/libs/api/src/services/admin/types.ts
+++ b/libs/api/src/services/admin/types.ts
@@ -63,6 +63,9 @@ export interface CastVoteRecordFileRecord {
   readonly id: Id;
   readonly electionId: Id;
   readonly filename: string;
+  readonly exportTimestamp: Iso8601Timestamp;
+  readonly precinctIds: string[];
+  readonly scannerIds: string[];
   readonly sha256Hash: string;
   readonly createdAt: Iso8601Timestamp;
 }
@@ -75,6 +78,9 @@ export const CastVoteRecordFileRecordSchema: z.ZodSchema<CastVoteRecordFileRecor
     id: IdSchema,
     electionId: IdSchema,
     filename: z.string().nonempty(),
+    exportTimestamp: Iso8601TimestampSchema,
+    precinctIds: z.array(z.string()),
+    scannerIds: z.array(z.string()),
     sha256Hash: z.string().nonempty(),
     createdAt: Iso8601TimestampSchema,
   });

--- a/services/admin/schema.sql
+++ b/services/admin/schema.sql
@@ -46,6 +46,9 @@ create table cvr_files (
   id varchar(36) primary key,
   election_id varchar(36) not null,
   filename text not null,
+  export_timestamp timestamp not null,
+  precinct_ids text not null,
+  scanner_ids text not null,
   sha256_hash text not null,
   created_at timestamp not null default current_timestamp,
   foreign key (election_id) references elections(id)

--- a/services/admin/src/store.test.ts
+++ b/services/admin/src/store.test.ts
@@ -598,6 +598,9 @@ test('get CVR file metadata', async () => {
       id,
       electionId,
       filename: 'cvrs.jsonl',
+      exportTimestamp: '2021-09-02T22:27:58.327Z',
+      precinctIds: ['precinct-1', 'precinct-2'],
+      scannerIds: ['scanner-1', 'scanner-2'],
       sha256Hash: expect.any(String),
       createdAt: expect.any(String),
     })


### PR DESCRIPTION
## Overview
Related to https://github.com/votingworks/vxsuite/issues/2716

Expanding the `cvr_files` DB table in the admin service to include additional metadata needed in the "Tally" tab in the VxAdmin UI:
- `export_timestamp` - passed in from the client in the `POST` API call
- `precinct_ids` - parsed from CVR file contents
- `scanner_ids` - parsed from CVR file contents

Making sure we have all the data we need for any summary views in the UI without having to read through all CVR data each time.

## Testing Plan 
- Updated existing test cases

## Checklist
- [n/a] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [n/a] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [n/a] I have added a screenshot and/or video to this PR to demo the change
- [n/a] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
