### PR TITLE
Do not allow polls closed to closed on VxMark

### DIFF
--- a/libs/utils/src/polls.test.ts
+++ b/libs/utils/src/polls.test.ts
@@ -54,10 +54,10 @@ test('isValidPollsStateChange', () => {
   );
   expect(
     isValidPollsStateChange('polls_closed_initial', 'polls_paused')
-  ).toEqual(true);
+  ).toEqual(false);
   expect(
     isValidPollsStateChange('polls_closed_initial', 'polls_closed_final')
-  ).toEqual(true);
+  ).toEqual(false);
 
   // from polls open
   expect(isValidPollsStateChange('polls_open', 'polls_closed_initial')).toEqual(

--- a/libs/utils/src/polls.ts
+++ b/libs/utils/src/polls.ts
@@ -89,10 +89,19 @@ export function isValidPollsStateChange(
   prevState: PollsState,
   newState: PollsState
 ): boolean {
-  if (prevState === newState) return false; // no change an invalid change
-  if (prevState === 'polls_closed_final') return false; // cannot change if voting complete
-  if (newState === 'polls_closed_initial') return false; // cannot revert to initial closed
-  return true;
+  switch (prevState) {
+    case 'polls_closed_initial':
+      return newState === 'polls_open';
+    case 'polls_open':
+      return newState === 'polls_paused' || newState === 'polls_closed_final';
+    case 'polls_paused':
+      return newState === 'polls_open' || newState === 'polls_closed_final';
+    case 'polls_closed_final':
+      return false;
+    /* istanbul ignore next */
+    default:
+      throwIllegalValue(prevState);
+  }
 }
 export function getPollsTransitionActionPastTense(
   transition: PollsTransition


### PR DESCRIPTION
## Overview
[Slack thread](https://votingworks.slack.com/archives/CEL6D3GAD/p1668628984553129). Currently there is a poll worker footgun where, if you have a polls closed report on a card from VxScan, and you print that at VxMark, you will move VxMark from "initial closed" to "final closed." I'm not quite sure how you would end up in that position, but it seems like the safer logic is to print the report but _not_ change polls state. If the user really needed to change the state to polls closed on VxMark, they could use the direct option on the poll worker menu.

**Old Logic**: VxMark would transition to any state that it could feasibly be in in the future
**New Logic**: VxMark will only do transitions that would be possible on VxScan

