### PR TITLE
[VxAdmin] Add a cvr-files GET API to admin service

### DIFF
--- a/libs/api/src/services/admin/endpoints.ts
+++ b/libs/api/src/services/admin/endpoints.ts
@@ -265,13 +265,13 @@ export const GetCvrFilesRequestSchema: z.ZodSchema<GetCvrFilesRequest> =
  * @url /admin/elections/:electionId/cvr-files
  * @method GET
  */
-export type GetCvrFileResponse = CastVoteRecordFileRecord[];
+export type GetCvrFilesResponse = CastVoteRecordFileRecord[];
 
 /**
  * @url /admin/elections/:electionId/cvr-files
  * @method GET
  */
-export const GetCvrFileResponseSchema: z.ZodSchema<GetCvrFileResponse> =
+export const GetCvrFilesResponseSchema: z.ZodSchema<GetCvrFilesResponse> =
   z.array(CastVoteRecordFileRecordSchema);
 
 /**

--- a/services/admin/src/server.ts
+++ b/services/admin/src/server.ts
@@ -114,6 +114,13 @@ export function buildApp({ workspace }: { workspace: Workspace }): Application {
     }
   );
 
+  app.get<{ electionId: Id }, Admin.GetCvrFilesResponse>(
+    '/admin/elections/:electionId/cvr-files',
+    (request, response) => {
+      response.json(store.getCvrFiles(request.params.electionId));
+    }
+  );
+
   app.post<
     { electionId: Id },
     Admin.PostCvrFileResponse,

--- a/services/admin/src/store.ts
+++ b/services/admin/src/store.ts
@@ -131,7 +131,7 @@ export class Store {
       select
         id,
         data as electionData,
-        created_at as createdAt,
+        datetime(created_at, 'localtime') as createdAt,
         is_official_results as isOfficialResults
       from elections
       where deleted_at is null
@@ -160,7 +160,7 @@ export class Store {
       select
         id,
         data as electionData,
-        created_at as createdAt,
+        datetime(created_at, 'localtime') as createdAt,
         is_official_results as isOfficialResults
       from elections
       where deleted_at is null AND id = ?
@@ -643,7 +643,7 @@ export class Store {
         precinct_ids as precinctIds,
         scanner_ids as scannerIds,
         sha256_hash as sha256Hash,
-        created_at as createdAt
+        datetime(created_at, 'localtime') as createdAt
       from cvr_files
       where election_id = ?
       order by export_timestamp desc
@@ -693,7 +693,7 @@ export class Store {
           id,
           ballot_id as ballotId,
           data,
-          created_at as createdAt
+          datetime(created_at, 'localtime') as createdAt
         from cvrs
         where election_id = ?
       `,
@@ -893,7 +893,7 @@ export class Store {
           write_ins.contest_id as contestId,
           write_ins.option_id as optionId,
           write_ins.transcribed_value as transcribedValue,
-          write_ins.transcribed_at as transcribedAt
+          datetime(write_ins.transcribed_at, 'localtime') as transcribedAt
         from write_ins
         inner join
           cvr_file_entries on write_ins.cvr_id = cvr_file_entries.cvr_id
@@ -1256,7 +1256,7 @@ export class Store {
           ballot_type as ballotType,
           ballot_mode as ballotMode,
           num_copies as numCopies,
-          created_at as createdAt
+          datetime(created_at, 'localtime') as createdAt
         from printed_ballots
         where ${whereParts.join(' and ')}
       `,


### PR DESCRIPTION
## Overview
Related to: https://github.com/votingworks/vxsuite/issues/2716

- Adding a `GET .../cvr-files` endpoint for retrieving metadata about CVR files imported for the given election.
- Updated the store method to return CVR files matching an election ID, instead of a single CVR file matching a CVR file ID, since we didn't have any consumers yet for the latter. Still leaves the door open for adding a filtering option if we need it down the line.
- Future PRs will hook this up to the client to replace the calls to local storage.

## Testing Plan 
- Added test cases for the store method and API handler

## Checklist
- [n/a] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [n/a] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [n/a] I have added a screenshot and/or video to this PR to demo the change
- [n/a] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
