### PR TITLE
Test Deck Print Refactor

### DIFF
--- a/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
+++ b/frontends/election-manager/src/__snapshots__/app.test.tsx.snap
@@ -1,293 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`L&A (logic and accuracy) flow 1`] = `
-<div
-  aria-hidden="true"
->
-  <div
-    class="sc-cNKpQo ecBuSt"
-  >
-    <nav
-      class="sc-bdfBwQ gqAMTS"
-    >
-      <div
-        class="sc-gsTCUz iTmZjl"
-      >
-        <div
-          class="sc-dlfnbm VzbFO"
-        >
-          Voting
-          <span>
-            Works
-          </span>
-        </div>
-        <div
-          class="sc-hKgILt"
-        >
-          VxAdmin
-        </div>
-      </div>
-      <div
-        class="sc-eCssSg kiVrGp"
-      >
-        <button
-          class="sc-egiSv dHUDgX"
-          role="option"
-          type="button"
-        >
-          Ballots
-        </button>
-        <button
-          class="sc-egiSv dHUDgX active-section"
-          role="option"
-          type="button"
-        >
-          L&A
-        </button>
-        <button
-          class="sc-egiSv dHUDgX"
-          role="option"
-          type="button"
-        >
-          Tally
-        </button>
-        <button
-          class="sc-egiSv dHUDgX"
-          role="option"
-          type="button"
-        >
-          Write-Ins
-        </button>
-        <button
-          class="sc-egiSv dHUDgX"
-          role="option"
-          type="button"
-        >
-          Reports
-        </button>
-      </div>
-      <div
-        class="sc-jSgupP eMSuCK"
-      >
-        <button
-          class="sc-egiSv feoAXt"
-          type="button"
-        >
-          Lock Machine
-        </button>
-        <button
-          class="sc-egiSv feoAXt"
-          type="button"
-        >
-          Eject USB
-        </button>
-      </div>
-    </nav>
-    <main
-      class="sc-ezbkgU eLPlep"
-    >
-      <div
-        class="sc-hKwCoD kuXZyB"
-      >
-        <h1>
-          Precinct L&A Packages
-        </h1>
-        <p>
-          Print the L&A Packages for all precincts, or for a specific precinct, by selecting a button below.
-        </p>
-        <p
-          class="sc-iwjezw jqTYVd"
-        />
-        <p>
-          Each Precinct L&A Package prints:
-        </p>
-        <ol>
-          <li>
-            A Precinct Tally Report — the expected results of the precinct.
-          </li>
-          <li>
-            Pre-voted VxMark test ballots.
-          </li>
-          <li>
-            Pre-voted hand-marked test ballots.
-          </li>
-          <li>
-            Two blank hand-marked test ballots — one remains blank, one is hand-marked by an election official to replace a pre-voted hand-marked test ballot.
-          </li>
-          <li>
-            One overvoted hand-marked test ballot.
-          </li>
-        </ol>
-        <p
-          class="sc-iwjezw jqTYVd"
-        />
-      </div>
-      <p>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          <strong>
-            Print Packages for All Precincts
-          </strong>
-        </button>
-      </p>
-      <div
-        class="sc-fFubgz exWqux"
-      >
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          Bywy
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          Chester
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          District 5
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          East Weir
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          Fentress
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          French Camp
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          Hebron
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          Kenego
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          Panhandle
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          Reform
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          Sherwood
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          Southwest Ackerman
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          West Weir
-        </button>
-      </div>
-    </main>
-    <div
-      class="sc-fKVsgm fFwtSv"
-      data-testid="electionInfoBar"
-    >
-      <div
-        class="sc-hKwCoD gvrBrR"
-        style="flex: 1;"
-      >
-        <strong>
-          Mock General Election Choctaw 2020
-        </strong>
-         —
-         
-        <span
-          class="sc-gsDJrp fUIxJs"
-        >
-          Aug 26, 2020
-        </span>
-        <div
-          class="sc-bdvvaa iybVtA"
-        >
-          <span
-            class="sc-gsDJrp fUIxJs"
-          >
-            Choctaw County
-            ,
-          </span>
-           
-          <span
-            class="sc-gsDJrp fUIxJs"
-          >
-            State of Mississippi
-          </span>
-        </div>
-      </div>
-      <div
-        class="sc-hKwCoD fZQsN"
-      >
-        <div
-          class="sc-bdvvaa bmZoEB"
-        >
-          Software Version
-        </div>
-        <strong>
-          TEST
-        </strong>
-      </div>
-      <div
-        class="sc-hKwCoD fZQsN"
-      >
-        <div
-          class="sc-bdvvaa bmZoEB"
-        >
-          Machine ID
-        </div>
-        <strong>
-          0000
-        </strong>
-      </div>
-      <div
-        class="sc-hKwCoD fZQsN"
-      >
-        <div
-          class="sc-bdvvaa iybVtA"
-        >
-          Election ID
-        </div>
-        <strong>
-          b1e83122e8
-        </strong>
-      </div>
-    </div>
-  </div>
+<div>
   <div
     class="sc-iAKVOt KcewZ print-only"
   >
@@ -1471,1945 +1185,1364 @@ House Bill 1796 - Flag Referendum
       </div>
     </section>
   </div>
-  <div />
 </div>
 `;
 
 exports[`L&A (logic and accuracy) flow 2`] = `
-<div
-  aria-hidden="true"
->
+<div>
   <div
-    class="sc-cNKpQo ecBuSt"
+    aria-hidden="true"
+    class="sc-jRQAMF kQCdaK"
   >
-    <nav
-      class="sc-bdfBwQ gqAMTS"
-    >
-      <div
-        class="sc-gsTCUz iTmZjl"
-      >
-        <div
-          class="sc-dlfnbm VzbFO"
-        >
-          Voting
-          <span>
-            Works
-          </span>
-        </div>
-        <div
-          class="sc-hKgILt"
-        >
-          VxAdmin
-        </div>
-      </div>
-      <div
-        class="sc-eCssSg kiVrGp"
-      >
-        <button
-          class="sc-egiSv dHUDgX"
-          role="option"
-          type="button"
-        >
-          Ballots
-        </button>
-        <button
-          class="sc-egiSv dHUDgX active-section"
-          role="option"
-          type="button"
-        >
-          L&A
-        </button>
-        <button
-          class="sc-egiSv dHUDgX"
-          role="option"
-          type="button"
-        >
-          Tally
-        </button>
-        <button
-          class="sc-egiSv dHUDgX"
-          role="option"
-          type="button"
-        >
-          Write-Ins
-        </button>
-        <button
-          class="sc-egiSv dHUDgX"
-          role="option"
-          type="button"
-        >
-          Reports
-        </button>
-      </div>
-      <div
-        class="sc-jSgupP eMSuCK"
-      >
-        <button
-          class="sc-egiSv feoAXt"
-          type="button"
-        >
-          Lock Machine
-        </button>
-        <button
-          class="sc-egiSv feoAXt"
-          type="button"
-        >
-          Eject USB
-        </button>
-      </div>
-    </nav>
-    <main
-      class="sc-ezbkgU eLPlep"
-    >
-      <div
-        class="sc-hKwCoD kuXZyB"
-      >
-        <h1>
-          Precinct L&A Packages
-        </h1>
-        <p>
-          Print the L&A Packages for all precincts, or for a specific precinct, by selecting a button below.
-        </p>
-        <p
-          class="sc-iwjezw jqTYVd"
-        />
-        <p>
-          Each Precinct L&A Package prints:
-        </p>
-        <ol>
-          <li>
-            A Precinct Tally Report — the expected results of the precinct.
-          </li>
-          <li>
-            Pre-voted VxMark test ballots.
-          </li>
-          <li>
-            Pre-voted hand-marked test ballots.
-          </li>
-          <li>
-            Two blank hand-marked test ballots — one remains blank, one is hand-marked by an election official to replace a pre-voted hand-marked test ballot.
-          </li>
-          <li>
-            One overvoted hand-marked test ballot.
-          </li>
-        </ol>
-        <p
-          class="sc-iwjezw jqTYVd"
-        />
-      </div>
-      <p>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          <strong>
-            Print Packages for All Precincts
-          </strong>
-        </button>
-      </p>
-      <div
-        class="sc-fFubgz exWqux"
-      >
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          Bywy
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          Chester
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          District 5
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          East Weir
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          Fentress
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          French Camp
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          Hebron
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          Kenego
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          Panhandle
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          Reform
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          Sherwood
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          Southwest Ackerman
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          West Weir
-        </button>
-      </div>
-    </main>
     <div
-      class="sc-fKVsgm fFwtSv"
-      data-testid="electionInfoBar"
+      class="sc-iCfLBT cSkaik"
     >
       <div
-        class="sc-hKwCoD gvrBrR"
-        style="flex: 1;"
+        class="seal"
+        data-testid="printed-ballot-seal"
+        id="printedBallotSealContainer"
       >
-        <strong>
-          Mock General Election Choctaw 2020
-        </strong>
-         —
-         
-        <span
-          class="sc-gsDJrp fUIxJs"
-        >
-          Aug 26, 2020
-        </span>
-        <div
-          class="sc-bdvvaa iybVtA"
-        >
-          <span
-            class="sc-gsDJrp fUIxJs"
-          >
-            Choctaw County
-            ,
-          </span>
+        <img
+          alt=""
+          class="sc-gKckTs hLVAuh"
+          data-testid="printed-ballot-seal-image"
+          src="/seals/Seal_of_Mississippi_BW.svg"
+        />
+      </div>
+      <div
+        class="sc-hKwCoD gmiWky ballot-header-content"
+      >
+        <h2>
+          Unofficial TEST Ballot
+        </h2>
+        <h3>
+          
            
-          <span
-            class="sc-gsDJrp fUIxJs"
+          Mock General Election Choctaw 2020
+        </h3>
+        <p>
+          August 26, 2020
+          <br />
+          Choctaw County
+          , 
+          State of Mississippi
+        </p>
+      </div>
+      <div
+        class="sc-furvIG cfpKDm"
+      >
+        <div
+          class="sc-eCImvq gScWpb"
+        >
+          <svg
+            height="128"
+            shape-rendering="crispEdges"
+            viewBox="0 0 33 33"
+            width="128"
           >
-            State of Mississippi
-          </span>
+            <path
+              d="M0,0 h33v33H0z"
+              fill="#FFFFFF"
+            />
+            <path
+              d="M0 0h7v1H0zM8 0h2v1H8zM12 0h1v1H12zM15 0h1v1H15zM17 0h2v1H17zM20 0h1v1H20zM22 0h2v1H22zM26,0 h7v1H26zM0 1h1v1H0zM6 1h1v1H6zM8 1h1v1H8zM10 1h4v1H10zM15 1h1v1H15zM19 1h1v1H19zM21 1h4v1H21zM26 1h1v1H26zM32,1 h1v1H32zM0 2h1v1H0zM2 2h3v1H2zM6 2h1v1H6zM9 2h3v1H9zM17 2h4v1H17zM23 2h1v1H23zM26 2h1v1H26zM28 2h3v1H28zM32,2 h1v1H32zM0 3h1v1H0zM2 3h3v1H2zM6 3h1v1H6zM8 3h1v1H8zM11 3h1v1H11zM13 3h1v1H13zM16 3h2v1H16zM19 3h1v1H19zM23 3h2v1H23zM26 3h1v1H26zM28 3h3v1H28zM32,3 h1v1H32zM0 4h1v1H0zM2 4h3v1H2zM6 4h1v1H6zM8 4h1v1H8zM12 4h1v1H12zM14 4h1v1H14zM19 4h4v1H19zM24 4h1v1H24zM26 4h1v1H26zM28 4h3v1H28zM32,4 h1v1H32zM0 5h1v1H0zM6 5h1v1H6zM8 5h1v1H8zM11 5h1v1H11zM13 5h1v1H13zM16 5h1v1H16zM19 5h1v1H19zM21 5h1v1H21zM24 5h1v1H24zM26 5h1v1H26zM32,5 h1v1H32zM0 6h7v1H0zM8 6h1v1H8zM10 6h1v1H10zM12 6h1v1H12zM14 6h1v1H14zM16 6h1v1H16zM18 6h1v1H18zM20 6h1v1H20zM22 6h1v1H22zM24 6h1v1H24zM26,6 h7v1H26zM9 7h1v1H9zM12 7h1v1H12zM14 7h2v1H14zM17 7h3v1H17zM21 7h3v1H21zM3 8h1v1H3zM6 8h1v1H6zM10 8h1v1H10zM12 8h1v1H12zM14 8h1v1H14zM18 8h1v1H18zM21 8h4v1H21zM27 8h3v1H27zM31,8 h2v1H31zM0 9h1v1H0zM3 9h3v1H3zM8 9h3v1H8zM12 9h2v1H12zM16 9h1v1H16zM23 9h3v1H23zM29 9h1v1H29zM32,9 h1v1H32zM1 10h3v1H1zM6 10h1v1H6zM8 10h1v1H8zM11 10h4v1H11zM16 10h1v1H16zM21 10h2v1H21zM25 10h1v1H25zM27 10h4v1H27zM32,10 h1v1H32zM1 11h2v1H1zM4 11h1v1H4zM9 11h2v1H9zM13 11h1v1H13zM17 11h1v1H17zM24 11h1v1H24zM26 11h1v1H26zM32,11 h1v1H32zM2 12h2v1H2zM5 12h3v1H5zM11 12h1v1H11zM15 12h1v1H15zM17 12h1v1H17zM20 12h1v1H20zM23 12h4v1H23zM28 12h2v1H28zM0 13h1v1H0zM4 13h2v1H4zM9 13h2v1H9zM14 13h1v1H14zM17 13h2v1H17zM20 13h3v1H20zM24 13h1v1H24zM31 13h1v1H31zM2 14h3v1H2zM6 14h1v1H6zM8 14h1v1H8zM11 14h2v1H11zM15 14h2v1H15zM19 14h1v1H19zM21 14h1v1H21zM23 14h1v1H23zM25 14h1v1H25zM29 14h1v1H29zM31 14h1v1H31zM0 15h1v1H0zM2 15h1v1H2zM4 15h1v1H4zM7 15h1v1H7zM10 15h3v1H10zM14 15h5v1H14zM20 15h3v1H20zM24 15h2v1H24zM28 15h1v1H28zM31 15h1v1H31zM1 16h2v1H1zM6 16h1v1H6zM9 16h1v1H9zM12 16h2v1H12zM15 16h1v1H15zM19 16h6v1H19zM26 16h1v1H26zM4 17h2v1H4zM7 17h3v1H7zM12 17h2v1H12zM18 17h7v1H18zM26 17h1v1H26zM29 17h1v1H29zM32,17 h1v1H32zM0 18h3v1H0zM6 18h2v1H6zM9 18h1v1H9zM11 18h1v1H11zM13 18h2v1H13zM17 18h1v1H17zM19 18h2v1H19zM22 18h1v1H22zM26 18h1v1H26zM31,18 h2v1H31zM2 19h1v1H2zM5 19h1v1H5zM7 19h1v1H7zM10 19h3v1H10zM14 19h1v1H14zM18 19h2v1H18zM21 19h2v1H21zM25 19h1v1H25zM28 19h1v1H28zM31 19h1v1H31zM0 20h9v1H0zM10 20h2v1H10zM13 20h2v1H13zM16 20h3v1H16zM23 20h2v1H23zM27 20h3v1H27zM32,20 h1v1H32zM2 21h4v1H2zM7 21h1v1H7zM12 21h1v1H12zM16 21h3v1H16zM20 21h1v1H20zM22 21h3v1H22zM31 21h1v1H31zM0 22h3v1H0zM4 22h4v1H4zM10 22h1v1H10zM13 22h2v1H13zM16 22h2v1H16zM19 22h1v1H19zM21 22h7v1H21zM29 22h2v1H29zM32,22 h1v1H32zM1 23h1v1H1zM4 23h2v1H4zM8 23h2v1H8zM11 23h2v1H11zM14 23h2v1H14zM17 23h1v1H17zM19 23h6v1H19zM27 23h3v1H27zM31,23 h2v1H31zM0 24h1v1H0zM2 24h3v1H2zM6 24h1v1H6zM10 24h1v1H10zM17 24h1v1H17zM21 24h1v1H21zM23 24h6v1H23zM8 25h2v1H8zM17 25h1v1H17zM21 25h1v1H21zM23 25h2v1H23zM28 25h2v1H28zM0 26h7v1H0zM11 26h1v1H11zM14 26h1v1H14zM16 26h2v1H16zM19 26h2v1H19zM22 26h3v1H22zM26 26h1v1H26zM28 26h4v1H28zM0 27h1v1H0zM6 27h1v1H6zM9 27h2v1H9zM13 27h1v1H13zM17 27h1v1H17zM21 27h2v1H21zM24 27h1v1H24zM28 27h1v1H28zM31 27h1v1H31zM0 28h1v1H0zM2 28h3v1H2zM6 28h1v1H6zM11 28h1v1H11zM13 28h1v1H13zM15 28h1v1H15zM17 28h3v1H17zM24 28h5v1H24zM30 28h2v1H30zM0 29h1v1H0zM2 29h3v1H2zM6 29h1v1H6zM8 29h1v1H8zM10 29h1v1H10zM13 29h1v1H13zM18 29h1v1H18zM20 29h4v1H20zM26 29h4v1H26zM32,29 h1v1H32zM0 30h1v1H0zM2 30h3v1H2zM6 30h1v1H6zM10 30h2v1H10zM17 30h1v1H17zM19 30h2v1H19zM24 30h2v1H24zM27 30h2v1H27zM32,30 h1v1H32zM0 31h1v1H0zM6 31h1v1H6zM10 31h1v1H10zM12 31h3v1H12zM17 31h1v1H17zM23 31h2v1H23zM27 31h3v1H27zM0 32h7v1H0zM9 32h3v1H9zM15 32h5v1H15zM21 32h1v1H21zM24 32h4v1H24zM29 32h3v1H29z"
+              fill="#000000"
+            />
+          </svg>
+        </div>
+        <div>
+          <div>
+            <div>
+              <div>
+                Precinct
+              </div>
+              <strong>
+                District 5
+              </strong>
+            </div>
+            <div>
+              <div>
+                Ballot Style
+              </div>
+              <strong>
+                5
+              </strong>
+            </div>
+            <div>
+              <div>
+                Ballot ID
+              </div>
+              <strong
+                class="sc-gsDJrp fUIxJs"
+              >
+                Asdf1234Asdf12
+              </strong>
+            </div>
+          </div>
         </div>
       </div>
+    </div>
+    <div
+      class="sc-pVTma NVkwn"
+    >
       <div
-        class="sc-hKwCoD fZQsN"
+        class="sc-jrQzUz jgYCbw"
       >
         <div
-          class="sc-bdvvaa bmZoEB"
+          class="sc-kDThTU gkFLxJ"
         >
-          Software Version
+          <div
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+          >
+            <h3>
+              President
+            </h3>
+            <p
+              class="sc-bdvvaa eSpfPW"
+            >
+              <span
+                class="sc-bdvvaa hsgYyE"
+              >
+                Presidential Electors for Joe Biden for President and Kamala Harris for Vice President
+              </span>
+               
+              / Democrat
+            </p>
+          </div>
         </div>
-        <strong>
-          TEST
-        </strong>
+        <div
+          class="sc-kDThTU gkFLxJ"
+        >
+          <div
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+          >
+            <h3>
+              Senate 
+            </h3>
+            <p
+              class="sc-bdvvaa eSpfPW"
+            >
+              <span
+                class="sc-bdvvaa hsgYyE"
+              >
+                Mike Espy
+              </span>
+               
+              / Democrat
+            </p>
+          </div>
+        </div>
+        <div
+          class="sc-kDThTU gkFLxJ"
+        >
+          <div
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+          >
+            <h3>
+              1st Congressional District
+            </h3>
+            <p
+              class="sc-bdvvaa eSpfPW"
+            >
+              <span
+                class="sc-bdvvaa hsgYyE"
+              >
+                Antonia Eliason
+              </span>
+               
+              / Democrat
+            </p>
+          </div>
+        </div>
+        <div
+          class="sc-kDThTU gkFLxJ"
+        >
+          <div
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+          >
+            <h3>
+              Supreme Court District 3(Northern) Position 3
+            </h3>
+            <p
+              class="sc-bdvvaa eSpfPW"
+            >
+              <span
+                class="sc-bdvvaa hsgYyE"
+              >
+                Josiah Dennis Coleman
+              </span>
+               
+              / Nonpartisan
+            </p>
+          </div>
+        </div>
+        <div
+          class="sc-kDThTU gkFLxJ"
+        >
+          <div
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+          >
+            <h3>
+              Election Commissioner 05
+            </h3>
+            <p
+              class="sc-bdvvaa eSpfPW"
+            >
+              <span
+                class="sc-bdvvaa hsgYyE"
+              >
+                Ouida A Loper
+              </span>
+               
+              / Independent
+            </p>
+          </div>
+        </div>
+        <div
+          class="sc-kDThTU gkFLxJ"
+        >
+          <div
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+          >
+            <h3>
+              School Board 05
+            </h3>
+            <p
+              class="sc-bdvvaa eSpfPW"
+            >
+              <span
+                class="sc-bdvvaa hsgYyE"
+              >
+                Michael D Thomas
+              </span>
+               
+            </p>
+          </div>
+        </div>
+        <div
+          class="sc-kDThTU gkFLxJ"
+        >
+          <div
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+          >
+            <h3>
+              Ballot Measure 2
+House Concurrent Resolution No. 47
+            </h3>
+            <p
+              class="sc-bdvvaa kdHchw"
+            >
+              Yes
+               
+            </p>
+          </div>
+        </div>
+        <div
+          class="sc-kDThTU gkFLxJ"
+        >
+          <div
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+          >
+            <h3>
+              Ballot Measure 3
+House Bill 1796 - Flag Referendum
+            </h3>
+            <p
+              class="sc-bdvvaa kdHchw"
+            >
+              Yes
+               
+            </p>
+          </div>
+        </div>
+        <div
+          class="sc-kDThTU gkFLxJ"
+        >
+          <div
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+          >
+            <h3>
+              Ballot Measure 1
+            </h3>
+            <p
+              class="sc-bdvvaa kdHchw"
+            >
+              •
+               
+              FOR APPROVAL OF EITHER Initiative No. 65 OR Alternative Measure No. 65 A
+            </p>
+            <p
+              class="sc-bdvvaa kdHchw"
+            >
+              •
+               
+              FOR Initiative Measure No. 65
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    aria-hidden="true"
+    class="sc-jRQAMF kQCdaK"
+  >
+    <div
+      class="sc-iCfLBT cSkaik"
+    >
+      <div
+        class="seal"
+        data-testid="printed-ballot-seal"
+        id="printedBallotSealContainer"
+      >
+        <img
+          alt=""
+          class="sc-gKckTs hLVAuh"
+          data-testid="printed-ballot-seal-image"
+          src="/seals/Seal_of_Mississippi_BW.svg"
+        />
       </div>
       <div
-        class="sc-hKwCoD fZQsN"
+        class="sc-hKwCoD gmiWky ballot-header-content"
       >
-        <div
-          class="sc-bdvvaa bmZoEB"
-        >
-          Machine ID
-        </div>
-        <strong>
-          0000
-        </strong>
+        <h2>
+          Unofficial TEST Ballot
+        </h2>
+        <h3>
+          
+           
+          Mock General Election Choctaw 2020
+        </h3>
+        <p>
+          August 26, 2020
+          <br />
+          Choctaw County
+          , 
+          State of Mississippi
+        </p>
       </div>
       <div
-        class="sc-hKwCoD fZQsN"
+        class="sc-furvIG cfpKDm"
       >
         <div
-          class="sc-bdvvaa iybVtA"
+          class="sc-eCImvq gScWpb"
         >
-          Election ID
+          <svg
+            height="128"
+            shape-rendering="crispEdges"
+            viewBox="0 0 37 37"
+            width="128"
+          >
+            <path
+              d="M0,0 h37v37H0z"
+              fill="#FFFFFF"
+            />
+            <path
+              d="M0 0h7v1H0zM8 0h1v1H8zM10 0h1v1H10zM13 0h6v1H13zM20 0h1v1H20zM22 0h3v1H22zM27 0h2v1H27zM30,0 h7v1H30zM0 1h1v1H0zM6 1h1v1H6zM9 1h2v1H9zM16 1h1v1H16zM18 1h1v1H18zM21 1h1v1H21zM23 1h2v1H23zM26 1h3v1H26zM30 1h1v1H30zM36,1 h1v1H36zM0 2h1v1H0zM2 2h3v1H2zM6 2h1v1H6zM9 2h3v1H9zM13 2h1v1H13zM15 2h1v1H15zM18 2h2v1H18zM21 2h2v1H21zM26 2h1v1H26zM28 2h1v1H28zM30 2h1v1H30zM32 2h3v1H32zM36,2 h1v1H36zM0 3h1v1H0zM2 3h3v1H2zM6 3h1v1H6zM8 3h1v1H8zM16 3h2v1H16zM20 3h1v1H20zM26 3h3v1H26zM30 3h1v1H30zM32 3h3v1H32zM36,3 h1v1H36zM0 4h1v1H0zM2 4h3v1H2zM6 4h1v1H6zM9 4h13v1H9zM23 4h1v1H23zM25 4h3v1H25zM30 4h1v1H30zM32 4h3v1H32zM36,4 h1v1H36zM0 5h1v1H0zM6 5h1v1H6zM9 5h2v1H9zM12 5h2v1H12zM16 5h4v1H16zM21 5h1v1H21zM23 5h2v1H23zM26 5h3v1H26zM30 5h1v1H30zM36,5 h1v1H36zM0 6h7v1H0zM8 6h1v1H8zM10 6h1v1H10zM12 6h1v1H12zM14 6h1v1H14zM16 6h1v1H16zM18 6h1v1H18zM20 6h1v1H20zM22 6h1v1H22zM24 6h1v1H24zM26 6h1v1H26zM28 6h1v1H28zM30,6 h7v1H30zM14 7h6v1H14zM22 7h3v1H22zM28 7h1v1H28zM2 8h1v1H2zM4 8h3v1H4zM8 8h2v1H8zM12 8h1v1H12zM14 8h4v1H14zM20 8h3v1H20zM29 8h1v1H29zM33 8h1v1H33zM36,8 h1v1H36zM0 9h1v1H0zM2 9h2v1H2zM8 9h1v1H8zM11 9h1v1H11zM13 9h1v1H13zM15 9h5v1H15zM23 9h1v1H23zM27 9h1v1H27zM29 9h1v1H29zM32 9h2v1H32zM35 9h1v1H35zM0 10h1v1H0zM3 10h2v1H3zM6 10h1v1H6zM8 10h2v1H8zM12 10h7v1H12zM21 10h4v1H21zM26 10h1v1H26zM30 10h1v1H30zM33,10 h4v1H33zM2 11h4v1H2zM8 11h3v1H8zM13 11h2v1H13zM17 11h3v1H17zM23 11h3v1H23zM27 11h1v1H27zM30 11h1v1H30zM32 11h1v1H32zM0 12h1v1H0zM2 12h5v1H2zM8 12h1v1H8zM10 12h2v1H10zM16 12h3v1H16zM20 12h1v1H20zM23 12h1v1H23zM28 12h4v1H28zM34 12h1v1H34zM36,12 h1v1H36zM0 13h1v1H0zM3 13h3v1H3zM7 13h3v1H7zM11 13h1v1H11zM14 13h1v1H14zM16 13h1v1H16zM18 13h1v1H18zM20 13h1v1H20zM23 13h1v1H23zM25 13h1v1H25zM27 13h2v1H27zM30 13h1v1H30zM0 14h3v1H0zM4 14h1v1H4zM6 14h1v1H6zM8 14h1v1H8zM10 14h2v1H10zM17 14h3v1H17zM24 14h1v1H24zM26 14h1v1H26zM28 14h1v1H28zM30 14h2v1H30zM35,14 h2v1H35zM0 15h1v1H0zM2 15h1v1H2zM7 15h5v1H7zM13 15h3v1H13zM17 15h1v1H17zM20 15h1v1H20zM22 15h1v1H22zM25 15h1v1H25zM27 15h1v1H27zM32 15h1v1H32zM1 16h2v1H1zM4 16h1v1H4zM6 16h2v1H6zM9 16h4v1H9zM14 16h1v1H14zM18 16h1v1H18zM21 16h1v1H21zM24 16h1v1H24zM28 16h1v1H28zM30 16h1v1H30zM0 17h6v1H0zM7 17h4v1H7zM12 17h1v1H12zM14 17h8v1H14zM27 17h2v1H27zM30 17h1v1H30zM33 17h2v1H33zM0 18h1v1H0zM6 18h2v1H6zM9 18h1v1H9zM12 18h2v1H12zM16 18h4v1H16zM22 18h1v1H22zM25 18h1v1H25zM28 18h1v1H28zM30 18h2v1H30zM33,18 h4v1H33zM0 19h1v1H0zM2 19h3v1H2zM7 19h2v1H7zM10 19h3v1H10zM15 19h1v1H15zM19 19h2v1H19zM23 19h1v1H23zM25 19h3v1H25zM29 19h1v1H29zM32 19h1v1H32zM35 19h1v1H35zM2 20h1v1H2zM4 20h4v1H4zM9 20h1v1H9zM12 20h1v1H12zM14 20h1v1H14zM20 20h3v1H20zM24 20h2v1H24zM27 20h4v1H27zM32 20h1v1H32zM34,20 h3v1H34zM0 21h2v1H0zM3 21h2v1H3zM12 21h2v1H12zM17 21h3v1H17zM22 21h1v1H22zM25 21h1v1H25zM28 21h2v1H28zM34 21h1v1H34zM36,21 h1v1H36zM0 22h2v1H0zM3 22h1v1H3zM5 22h2v1H5zM8 22h1v1H8zM11 22h3v1H11zM15 22h1v1H15zM17 22h6v1H17zM24 22h1v1H24zM26 22h1v1H26zM30 22h2v1H30zM33,22 h4v1H33zM0 23h1v1H0zM2 23h1v1H2zM9 23h1v1H9zM11 23h1v1H11zM13 23h1v1H13zM16 23h5v1H16zM23 23h1v1H23zM25 23h4v1H25zM35 23h1v1H35zM4 24h3v1H4zM8 24h1v1H8zM10 24h1v1H10zM12 24h1v1H12zM14 24h1v1H14zM16 24h4v1H16zM21 24h3v1H21zM26 24h1v1H26zM28 24h1v1H28zM30 24h1v1H30zM32 24h1v1H32zM34,24 h3v1H34zM2 25h2v1H2zM5 25h1v1H5zM7 25h2v1H7zM10 25h5v1H10zM17 25h2v1H17zM20 25h4v1H20zM26 25h3v1H26zM31 25h1v1H31zM0 26h1v1H0zM3 26h4v1H3zM9 26h1v1H9zM13 26h1v1H13zM16 26h2v1H16zM26 26h3v1H26zM30 26h2v1H30zM33 26h1v1H33zM35,26 h2v1H35zM1 27h1v1H1zM5 27h1v1H5zM7 27h1v1H7zM9 27h2v1H9zM12 27h1v1H12zM16 27h2v1H16zM19 27h1v1H19zM21 27h3v1H21zM25 27h2v1H25zM28 27h1v1H28zM30 27h1v1H30zM35 27h1v1H35zM0 28h1v1H0zM4 28h1v1H4zM6 28h3v1H6zM13 28h2v1H13zM16 28h6v1H16zM25 28h1v1H25zM27 28h6v1H27zM35,28 h2v1H35zM8 29h2v1H8zM11 29h1v1H11zM14 29h7v1H14zM22 29h5v1H22zM28 29h1v1H28zM32 29h1v1H32zM34,29 h3v1H34zM0 30h7v1H0zM9 30h4v1H9zM14 30h2v1H14zM17 30h2v1H17zM25 30h1v1H25zM27 30h2v1H27zM30 30h1v1H30zM32 30h1v1H32zM34,30 h3v1H34zM0 31h1v1H0zM6 31h1v1H6zM8 31h2v1H8zM11 31h1v1H11zM13 31h1v1H13zM18 31h1v1H18zM21 31h5v1H21zM28 31h1v1H28zM32 31h1v1H32zM0 32h1v1H0zM2 32h3v1H2zM6 32h1v1H6zM8 32h1v1H8zM10 32h3v1H10zM15 32h1v1H15zM17 32h1v1H17zM21 32h4v1H21zM28 32h5v1H28zM35,32 h2v1H35zM0 33h1v1H0zM2 33h3v1H2zM6 33h1v1H6zM9 33h2v1H9zM12 33h2v1H12zM19 33h1v1H19zM21 33h1v1H21zM23 33h2v1H23zM28 33h1v1H28zM31 33h3v1H31zM35,33 h2v1H35zM0 34h1v1H0zM2 34h3v1H2zM6 34h1v1H6zM8 34h2v1H8zM12 34h1v1H12zM14 34h2v1H14zM17 34h1v1H17zM19 34h1v1H19zM22 34h4v1H22zM32 34h2v1H32zM36,34 h1v1H36zM0 35h1v1H0zM6 35h1v1H6zM9 35h1v1H9zM11 35h1v1H11zM14 35h4v1H14zM19 35h2v1H19zM24 35h3v1H24zM29 35h1v1H29zM31 35h1v1H31zM35 35h1v1H35zM0 36h7v1H0zM10 36h1v1H10zM13 36h1v1H13zM16 36h4v1H16zM23 36h3v1H23zM27 36h2v1H27zM30 36h1v1H30zM35,36 h2v1H35z"
+              fill="#000000"
+            />
+          </svg>
         </div>
-        <strong>
-          b1e83122e8
-        </strong>
+        <div>
+          <div>
+            <div>
+              <div>
+                Precinct
+              </div>
+              <strong>
+                District 5
+              </strong>
+            </div>
+            <div>
+              <div>
+                Ballot Style
+              </div>
+              <strong>
+                5
+              </strong>
+            </div>
+            <div>
+              <div>
+                Ballot ID
+              </div>
+              <strong
+                class="sc-gsDJrp fUIxJs"
+              >
+                Asdf1234Asdf12
+              </strong>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="sc-pVTma NVkwn"
+    >
+      <div
+        class="sc-jrQzUz jgYCbw"
+      >
+        <div
+          class="sc-kDThTU gkFLxJ"
+        >
+          <div
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+          >
+            <h3>
+              President
+            </h3>
+            <p
+              class="sc-bdvvaa eSpfPW"
+            >
+              <span
+                class="sc-bdvvaa hsgYyE"
+              >
+                Presidential Electors for Donald J. Trump for President and Michael R. Pence for Vice President
+              </span>
+               
+              / Republican
+            </p>
+          </div>
+        </div>
+        <div
+          class="sc-kDThTU gkFLxJ"
+        >
+          <div
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+          >
+            <h3>
+              Senate 
+            </h3>
+            <p
+              class="sc-bdvvaa eSpfPW"
+            >
+              <span
+                class="sc-bdvvaa hsgYyE"
+              >
+                Cindy Hyde-Smith
+              </span>
+               
+              / Republican
+            </p>
+          </div>
+        </div>
+        <div
+          class="sc-kDThTU gkFLxJ"
+        >
+          <div
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+          >
+            <h3>
+              1st Congressional District
+            </h3>
+            <p
+              class="sc-bdvvaa eSpfPW"
+            >
+              <span
+                class="sc-bdvvaa hsgYyE"
+              >
+                Trent Kelly
+              </span>
+               
+              / Republican
+            </p>
+          </div>
+        </div>
+        <div
+          class="sc-kDThTU gkFLxJ"
+        >
+          <div
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+          >
+            <h3>
+              Supreme Court District 3(Northern) Position 3
+            </h3>
+            <p
+              class="sc-bdvvaa eSpfPW"
+            >
+              <span
+                class="sc-bdvvaa hsgYyE"
+              >
+                Percy L. Lynchard
+              </span>
+               
+              / Nonpartisan
+            </p>
+          </div>
+        </div>
+        <div
+          class="sc-kDThTU gkFLxJ"
+        >
+          <div
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+          >
+            <h3>
+              Election Commissioner 05
+            </h3>
+            <p
+              class="sc-bdvvaa eSpfPW"
+            >
+              <span
+                class="sc-bdvvaa hsgYyE"
+              >
+                Wayne McLeod
+              </span>
+               
+            </p>
+          </div>
+        </div>
+        <div
+          class="sc-kDThTU gkFLxJ"
+        >
+          <div
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+          >
+            <h3>
+              School Board 05
+            </h3>
+            <p
+              class="sc-bdvvaa eSpfPW"
+            >
+              <span
+                class="sc-bdvvaa hsgYyE"
+              >
+                WRITE-IN
+              </span>
+               
+              (write-in)
+            </p>
+          </div>
+        </div>
+        <div
+          class="sc-kDThTU gkFLxJ"
+        >
+          <div
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+          >
+            <h3>
+              Ballot Measure 2
+House Concurrent Resolution No. 47
+            </h3>
+            <p
+              class="sc-bdvvaa kdHchw"
+            >
+              No
+               
+            </p>
+          </div>
+        </div>
+        <div
+          class="sc-kDThTU gkFLxJ"
+        >
+          <div
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+          >
+            <h3>
+              Ballot Measure 3
+House Bill 1796 - Flag Referendum
+            </h3>
+            <p
+              class="sc-bdvvaa kdHchw"
+            >
+              No
+               
+            </p>
+          </div>
+        </div>
+        <div
+          class="sc-kDThTU gkFLxJ"
+        >
+          <div
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+          >
+            <h3>
+              Ballot Measure 1
+            </h3>
+            <p
+              class="sc-bdvvaa kdHchw"
+            >
+              •
+               
+              AGAINST BOTH Initiative Measure No. 65 AND Alternative Measure No. 65 A
+            </p>
+            <p
+              class="sc-bdvvaa kdHchw"
+            >
+              •
+               
+              FOR Alternative Measure 65 A
+            </p>
+          </div>
+        </div>
       </div>
     </div>
   </div>
   <div
-    class="print-only"
+    aria-hidden="true"
+    class="sc-jRQAMF kQCdaK"
   >
     <div
-      aria-hidden="true"
-      class="sc-jRQAMF kQCdaK"
+      class="sc-iCfLBT cSkaik"
     >
       <div
-        class="sc-iCfLBT cSkaik"
+        class="seal"
+        data-testid="printed-ballot-seal"
+        id="printedBallotSealContainer"
+      >
+        <img
+          alt=""
+          class="sc-gKckTs hLVAuh"
+          data-testid="printed-ballot-seal-image"
+          src="/seals/Seal_of_Mississippi_BW.svg"
+        />
+      </div>
+      <div
+        class="sc-hKwCoD gmiWky ballot-header-content"
+      >
+        <h2>
+          Unofficial TEST Ballot
+        </h2>
+        <h3>
+          
+           
+          Mock General Election Choctaw 2020
+        </h3>
+        <p>
+          August 26, 2020
+          <br />
+          Choctaw County
+          , 
+          State of Mississippi
+        </p>
+      </div>
+      <div
+        class="sc-furvIG cfpKDm"
       >
         <div
-          class="seal"
-          data-testid="printed-ballot-seal"
-          id="printedBallotSealContainer"
+          class="sc-eCImvq gScWpb"
         >
-          <img
-            alt=""
-            class="sc-gKckTs hLVAuh"
-            data-testid="printed-ballot-seal-image"
-            src="/seals/Seal_of_Mississippi_BW.svg"
-          />
-        </div>
-        <div
-          class="sc-hKwCoD gmiWky ballot-header-content"
-        >
-          <h2>
-            Unofficial TEST Ballot
-          </h2>
-          <h3>
-            
-             
-            Mock General Election Choctaw 2020
-          </h3>
-          <p>
-            August 26, 2020
-            <br />
-            Choctaw County
-            , 
-            State of Mississippi
-          </p>
-        </div>
-        <div
-          class="sc-furvIG cfpKDm"
-        >
-          <div
-            class="sc-eCImvq gScWpb"
+          <svg
+            height="128"
+            shape-rendering="crispEdges"
+            viewBox="0 0 41 41"
+            width="128"
           >
-            <svg
-              height="128"
-              shape-rendering="crispEdges"
-              viewBox="0 0 33 33"
-              width="128"
-            >
-              <path
-                d="M0,0 h33v33H0z"
-                fill="#FFFFFF"
-              />
-              <path
-                d="M0 0h7v1H0zM8 0h2v1H8zM12 0h1v1H12zM15 0h1v1H15zM17 0h2v1H17zM20 0h1v1H20zM22 0h2v1H22zM26,0 h7v1H26zM0 1h1v1H0zM6 1h1v1H6zM8 1h1v1H8zM10 1h4v1H10zM15 1h1v1H15zM19 1h1v1H19zM21 1h4v1H21zM26 1h1v1H26zM32,1 h1v1H32zM0 2h1v1H0zM2 2h3v1H2zM6 2h1v1H6zM9 2h3v1H9zM17 2h4v1H17zM23 2h1v1H23zM26 2h1v1H26zM28 2h3v1H28zM32,2 h1v1H32zM0 3h1v1H0zM2 3h3v1H2zM6 3h1v1H6zM8 3h1v1H8zM11 3h1v1H11zM13 3h1v1H13zM16 3h2v1H16zM19 3h1v1H19zM23 3h2v1H23zM26 3h1v1H26zM28 3h3v1H28zM32,3 h1v1H32zM0 4h1v1H0zM2 4h3v1H2zM6 4h1v1H6zM8 4h1v1H8zM12 4h1v1H12zM14 4h1v1H14zM19 4h4v1H19zM24 4h1v1H24zM26 4h1v1H26zM28 4h3v1H28zM32,4 h1v1H32zM0 5h1v1H0zM6 5h1v1H6zM8 5h1v1H8zM11 5h1v1H11zM13 5h1v1H13zM16 5h1v1H16zM19 5h1v1H19zM21 5h1v1H21zM24 5h1v1H24zM26 5h1v1H26zM32,5 h1v1H32zM0 6h7v1H0zM8 6h1v1H8zM10 6h1v1H10zM12 6h1v1H12zM14 6h1v1H14zM16 6h1v1H16zM18 6h1v1H18zM20 6h1v1H20zM22 6h1v1H22zM24 6h1v1H24zM26,6 h7v1H26zM9 7h1v1H9zM12 7h1v1H12zM14 7h2v1H14zM17 7h3v1H17zM21 7h3v1H21zM3 8h1v1H3zM6 8h1v1H6zM10 8h1v1H10zM12 8h1v1H12zM14 8h1v1H14zM18 8h1v1H18zM21 8h4v1H21zM27 8h3v1H27zM31,8 h2v1H31zM0 9h1v1H0zM3 9h3v1H3zM8 9h3v1H8zM12 9h2v1H12zM16 9h1v1H16zM23 9h3v1H23zM29 9h1v1H29zM32,9 h1v1H32zM1 10h3v1H1zM6 10h1v1H6zM8 10h1v1H8zM11 10h4v1H11zM16 10h1v1H16zM21 10h2v1H21zM25 10h1v1H25zM27 10h4v1H27zM32,10 h1v1H32zM1 11h2v1H1zM4 11h1v1H4zM9 11h2v1H9zM13 11h1v1H13zM17 11h1v1H17zM24 11h1v1H24zM26 11h1v1H26zM32,11 h1v1H32zM2 12h2v1H2zM5 12h3v1H5zM11 12h1v1H11zM15 12h1v1H15zM17 12h1v1H17zM20 12h1v1H20zM23 12h4v1H23zM28 12h2v1H28zM0 13h1v1H0zM4 13h2v1H4zM9 13h2v1H9zM14 13h1v1H14zM17 13h2v1H17zM20 13h3v1H20zM24 13h1v1H24zM31 13h1v1H31zM2 14h3v1H2zM6 14h1v1H6zM8 14h1v1H8zM11 14h2v1H11zM15 14h2v1H15zM19 14h1v1H19zM21 14h1v1H21zM23 14h1v1H23zM25 14h1v1H25zM29 14h1v1H29zM31 14h1v1H31zM0 15h1v1H0zM2 15h1v1H2zM4 15h1v1H4zM7 15h1v1H7zM10 15h3v1H10zM14 15h5v1H14zM20 15h3v1H20zM24 15h2v1H24zM28 15h1v1H28zM31 15h1v1H31zM1 16h2v1H1zM6 16h1v1H6zM9 16h1v1H9zM12 16h2v1H12zM15 16h1v1H15zM19 16h6v1H19zM26 16h1v1H26zM4 17h2v1H4zM7 17h3v1H7zM12 17h2v1H12zM18 17h7v1H18zM26 17h1v1H26zM29 17h1v1H29zM32,17 h1v1H32zM0 18h3v1H0zM6 18h2v1H6zM9 18h1v1H9zM11 18h1v1H11zM13 18h2v1H13zM17 18h1v1H17zM19 18h2v1H19zM22 18h1v1H22zM26 18h1v1H26zM31,18 h2v1H31zM2 19h1v1H2zM5 19h1v1H5zM7 19h1v1H7zM10 19h3v1H10zM14 19h1v1H14zM18 19h2v1H18zM21 19h2v1H21zM25 19h1v1H25zM28 19h1v1H28zM31 19h1v1H31zM0 20h9v1H0zM10 20h2v1H10zM13 20h2v1H13zM16 20h3v1H16zM23 20h2v1H23zM27 20h3v1H27zM32,20 h1v1H32zM2 21h4v1H2zM7 21h1v1H7zM12 21h1v1H12zM16 21h3v1H16zM20 21h1v1H20zM22 21h3v1H22zM31 21h1v1H31zM0 22h3v1H0zM4 22h4v1H4zM10 22h1v1H10zM13 22h2v1H13zM16 22h2v1H16zM19 22h1v1H19zM21 22h7v1H21zM29 22h2v1H29zM32,22 h1v1H32zM1 23h1v1H1zM4 23h2v1H4zM8 23h2v1H8zM11 23h2v1H11zM14 23h2v1H14zM17 23h1v1H17zM19 23h6v1H19zM27 23h3v1H27zM31,23 h2v1H31zM0 24h1v1H0zM2 24h3v1H2zM6 24h1v1H6zM10 24h1v1H10zM17 24h1v1H17zM21 24h1v1H21zM23 24h6v1H23zM8 25h2v1H8zM17 25h1v1H17zM21 25h1v1H21zM23 25h2v1H23zM28 25h2v1H28zM0 26h7v1H0zM11 26h1v1H11zM14 26h1v1H14zM16 26h2v1H16zM19 26h2v1H19zM22 26h3v1H22zM26 26h1v1H26zM28 26h4v1H28zM0 27h1v1H0zM6 27h1v1H6zM9 27h2v1H9zM13 27h1v1H13zM17 27h1v1H17zM21 27h2v1H21zM24 27h1v1H24zM28 27h1v1H28zM31 27h1v1H31zM0 28h1v1H0zM2 28h3v1H2zM6 28h1v1H6zM11 28h1v1H11zM13 28h1v1H13zM15 28h1v1H15zM17 28h3v1H17zM24 28h5v1H24zM30 28h2v1H30zM0 29h1v1H0zM2 29h3v1H2zM6 29h1v1H6zM8 29h1v1H8zM10 29h1v1H10zM13 29h1v1H13zM18 29h1v1H18zM20 29h4v1H20zM26 29h4v1H26zM32,29 h1v1H32zM0 30h1v1H0zM2 30h3v1H2zM6 30h1v1H6zM10 30h2v1H10zM17 30h1v1H17zM19 30h2v1H19zM24 30h2v1H24zM27 30h2v1H27zM32,30 h1v1H32zM0 31h1v1H0zM6 31h1v1H6zM10 31h1v1H10zM12 31h3v1H12zM17 31h1v1H17zM23 31h2v1H23zM27 31h3v1H27zM0 32h7v1H0zM9 32h3v1H9zM15 32h5v1H15zM21 32h1v1H21zM24 32h4v1H24zM29 32h3v1H29z"
-                fill="#000000"
-              />
-            </svg>
-          </div>
+            <path
+              d="M0,0 h41v41H0z"
+              fill="#FFFFFF"
+            />
+            <path
+              d="M0 0h7v1H0zM9 0h1v1H9zM13 0h2v1H13zM19 0h1v1H19zM21 0h1v1H21zM24 0h3v1H24zM28 0h4v1H28zM34,0 h7v1H34zM0 1h1v1H0zM6 1h1v1H6zM8 1h8v1H8zM17 1h1v1H17zM19 1h2v1H19zM22 1h5v1H22zM29 1h1v1H29zM31 1h1v1H31zM34 1h1v1H34zM40,1 h1v1H40zM0 2h1v1H0zM2 2h3v1H2zM6 2h1v1H6zM9 2h1v1H9zM12 2h1v1H12zM17 2h2v1H17zM20 2h3v1H20zM24 2h1v1H24zM26 2h3v1H26zM31 2h1v1H31zM34 2h1v1H34zM36 2h3v1H36zM40,2 h1v1H40zM0 3h1v1H0zM2 3h3v1H2zM6 3h1v1H6zM9 3h1v1H9zM12 3h1v1H12zM14 3h1v1H14zM17 3h1v1H17zM20 3h4v1H20zM27 3h1v1H27zM29 3h3v1H29zM34 3h1v1H34zM36 3h3v1H36zM40,3 h1v1H40zM0 4h1v1H0zM2 4h3v1H2zM6 4h1v1H6zM9 4h1v1H9zM12 4h3v1H12zM17 4h1v1H17zM19 4h1v1H19zM21 4h3v1H21zM25 4h1v1H25zM27 4h1v1H27zM29 4h3v1H29zM34 4h1v1H34zM36 4h3v1H36zM40,4 h1v1H40zM0 5h1v1H0zM6 5h1v1H6zM8 5h3v1H8zM12 5h2v1H12zM16 5h2v1H16zM19 5h3v1H19zM23 5h4v1H23zM28 5h1v1H28zM30 5h2v1H30zM34 5h1v1H34zM40,5 h1v1H40zM0 6h7v1H0zM8 6h1v1H8zM10 6h1v1H10zM12 6h1v1H12zM14 6h1v1H14zM16 6h1v1H16zM18 6h1v1H18zM20 6h1v1H20zM22 6h1v1H22zM24 6h1v1H24zM26 6h1v1H26zM28 6h1v1H28zM30 6h1v1H30zM32 6h1v1H32zM34,6 h7v1H34zM8 7h1v1H8zM11 7h4v1H11zM16 7h1v1H16zM18 7h2v1H18zM21 7h3v1H21zM27 7h4v1H27zM32 7h1v1H32zM4 8h4v1H4zM10 8h1v1H10zM19 8h2v1H19zM24 8h1v1H24zM26 8h2v1H26zM29 8h1v1H29zM32 8h1v1H32zM34 8h2v1H34zM39 8h1v1H39zM0 9h5v1H0zM7 9h1v1H7zM14 9h1v1H14zM16 9h2v1H16zM23 9h1v1H23zM25 9h1v1H25zM27 9h3v1H27zM31 9h1v1H31zM33 9h1v1H33zM35 9h2v1H35zM38 9h1v1H38zM1 10h3v1H1zM5 10h9v1H5zM15 10h1v1H15zM17 10h1v1H17zM19 10h2v1H19zM22 10h4v1H22zM27 10h1v1H27zM29 10h1v1H29zM34 10h2v1H34zM38 10h1v1H38zM40,10 h1v1H40zM1 11h3v1H1zM5 11h1v1H5zM8 11h1v1H8zM13 11h2v1H13zM16 11h2v1H16zM19 11h3v1H19zM23 11h1v1H23zM25 11h2v1H25zM28 11h2v1H28zM33 11h2v1H33zM37 11h1v1H37zM39,11 h2v1H39zM0 12h1v1H0zM2 12h2v1H2zM5 12h2v1H5zM8 12h1v1H8zM12 12h3v1H12zM19 12h2v1H19zM24 12h3v1H24zM29 12h2v1H29zM32 12h2v1H32zM36 12h2v1H36zM39 12h1v1H39zM2 13h3v1H2zM7 13h1v1H7zM15 13h1v1H15zM17 13h2v1H17zM21 13h1v1H21zM23 13h1v1H23zM28 13h6v1H28zM35 13h5v1H35zM2 14h1v1H2zM4 14h3v1H4zM8 14h3v1H8zM12 14h2v1H12zM16 14h1v1H16zM19 14h2v1H19zM22 14h1v1H22zM26 14h1v1H26zM28 14h1v1H28zM33 14h3v1H33zM40,14 h1v1H40zM0 15h2v1H0zM4 15h2v1H4zM10 15h2v1H10zM14 15h6v1H14zM21 15h1v1H21zM23 15h3v1H23zM29 15h1v1H29zM32 15h1v1H32zM35 15h1v1H35zM37 15h1v1H37zM40,15 h1v1H40zM1 16h1v1H1zM3 16h1v1H3zM5 16h2v1H5zM8 16h1v1H8zM10 16h1v1H10zM12 16h1v1H12zM16 16h1v1H16zM18 16h2v1H18zM22 16h1v1H22zM25 16h5v1H25zM31 16h3v1H31zM35 16h1v1H35zM38 16h2v1H38zM2 17h1v1H2zM7 17h1v1H7zM10 17h1v1H10zM12 17h2v1H12zM18 17h2v1H18zM27 17h2v1H27zM30 17h2v1H30zM34 17h3v1H34zM38,17 h3v1H38zM1 18h1v1H1zM5 18h5v1H5zM12 18h3v1H12zM16 18h3v1H16zM20 18h1v1H20zM22 18h2v1H22zM27 18h3v1H27zM32 18h1v1H32zM34 18h1v1H34zM36 18h1v1H36zM39,18 h2v1H39zM4 19h1v1H4zM8 19h1v1H8zM13 19h2v1H13zM17 19h2v1H17zM24 19h1v1H24zM26 19h5v1H26zM33 19h1v1H33zM35 19h1v1H35zM37 19h1v1H37zM40,19 h1v1H40zM1 20h1v1H1zM3 20h1v1H3zM5 20h2v1H5zM8 20h3v1H8zM12 20h3v1H12zM18 20h3v1H18zM27 20h1v1H27zM30 20h4v1H30zM37 20h2v1H37zM1 21h1v1H1zM3 21h2v1H3zM7 21h1v1H7zM9 21h1v1H9zM13 21h1v1H13zM15 21h1v1H15zM19 21h1v1H19zM22 21h1v1H22zM24 21h1v1H24zM26 21h3v1H26zM31 21h1v1H31zM35 21h2v1H35zM38 21h2v1H38zM2 22h9v1H2zM13 22h2v1H13zM18 22h5v1H18zM25 22h1v1H25zM27 22h1v1H27zM29 22h2v1H29zM32 22h3v1H32zM38 22h1v1H38zM40,22 h1v1H40zM1 23h4v1H1zM9 23h1v1H9zM12 23h1v1H12zM14 23h4v1H14zM19 23h3v1H19zM23 23h1v1H23zM26 23h1v1H26zM28 23h3v1H28zM35 23h3v1H35zM39,23 h2v1H39zM0 24h2v1H0zM3 24h2v1H3zM6 24h1v1H6zM8 24h4v1H8zM13 24h3v1H13zM18 24h2v1H18zM22 24h4v1H22zM27 24h1v1H27zM29 24h1v1H29zM31 24h1v1H31zM33 24h1v1H33zM36 24h4v1H36zM1 25h2v1H1zM9 25h3v1H9zM13 25h2v1H13zM18 25h1v1H18zM20 25h1v1H20zM22 25h1v1H22zM24 25h1v1H24zM28 25h3v1H28zM33 25h1v1H33zM35 25h2v1H35zM39,25 h2v1H39zM1 26h3v1H1zM6 26h2v1H6zM12 26h1v1H12zM16 26h2v1H16zM19 26h3v1H19zM24 26h4v1H24zM30 26h1v1H30zM32 26h3v1H32zM40,26 h1v1H40zM2 27h1v1H2zM4 27h2v1H4zM8 27h3v1H8zM12 27h1v1H12zM14 27h2v1H14zM18 27h2v1H18zM24 27h1v1H24zM27 27h6v1H27zM34 27h2v1H34zM37 27h1v1H37zM40,27 h1v1H40zM0 28h1v1H0zM2 28h1v1H2zM4 28h3v1H4zM9 28h1v1H9zM12 28h1v1H12zM14 28h1v1H14zM16 28h1v1H16zM20 28h1v1H20zM22 28h4v1H22zM27 28h3v1H27zM31 28h1v1H31zM35 28h1v1H35zM37 28h1v1H37zM40,28 h1v1H40zM0 29h2v1H0zM4 29h1v1H4zM7 29h2v1H7zM10 29h2v1H10zM13 29h1v1H13zM15 29h5v1H15zM21 29h3v1H21zM25 29h1v1H25zM29 29h2v1H29zM32 29h3v1H32zM36 29h2v1H36zM39 29h1v1H39zM2 30h1v1H2zM4 30h3v1H4zM9 30h5v1H9zM15 30h3v1H15zM22 30h2v1H22zM27 30h1v1H27zM32 30h1v1H32zM34 30h1v1H34zM40,30 h1v1H40zM3 31h1v1H3zM8 31h2v1H8zM11 31h2v1H11zM16 31h1v1H16zM18 31h1v1H18zM20 31h1v1H20zM23 31h2v1H23zM27 31h5v1H27zM34 31h2v1H34zM37 31h1v1H37zM39,31 h2v1H39zM0 32h2v1H0zM3 32h2v1H3zM6 32h1v1H6zM9 32h1v1H9zM12 32h1v1H12zM16 32h2v1H16zM19 32h1v1H19zM21 32h1v1H21zM24 32h1v1H24zM29 32h10v1H29zM8 33h1v1H8zM10 33h4v1H10zM15 33h4v1H15zM21 33h9v1H21zM31 33h2v1H31zM36 33h2v1H36zM40,33 h1v1H40zM0 34h7v1H0zM8 34h5v1H8zM14 34h1v1H14zM16 34h7v1H16zM24 34h1v1H24zM26 34h3v1H26zM30 34h3v1H30zM34 34h1v1H34zM36 34h1v1H36zM38 34h1v1H38zM40,34 h1v1H40zM0 35h1v1H0zM6 35h1v1H6zM8 35h3v1H8zM12 35h2v1H12zM15 35h4v1H15zM21 35h2v1H21zM24 35h1v1H24zM26 35h1v1H26zM31 35h2v1H31zM36 35h1v1H36zM0 36h1v1H0zM2 36h3v1H2zM6 36h1v1H6zM8 36h1v1H8zM11 36h1v1H11zM13 36h4v1H13zM21 36h2v1H21zM24 36h3v1H24zM31 36h6v1H31zM39,36 h2v1H39zM0 37h1v1H0zM2 37h3v1H2zM6 37h1v1H6zM9 37h3v1H9zM13 37h9v1H13zM24 37h2v1H24zM27 37h5v1H27zM33 37h1v1H33zM36 37h1v1H36zM38,37 h3v1H38zM0 38h1v1H0zM2 38h3v1H2zM6 38h1v1H6zM17 38h2v1H17zM20 38h2v1H20zM23 38h3v1H23zM27 38h1v1H27zM29 38h1v1H29zM33 38h1v1H33zM37 38h1v1H37zM39,38 h2v1H39zM0 39h1v1H0zM6 39h1v1H6zM9 39h1v1H9zM11 39h1v1H11zM17 39h1v1H17zM20 39h4v1H20zM25 39h2v1H25zM28 39h4v1H28zM34 39h1v1H34zM36 39h2v1H36zM39,39 h2v1H39zM0 40h7v1H0zM13 40h3v1H13zM17 40h1v1H17zM19 40h1v1H19zM21 40h1v1H21zM23 40h2v1H23zM26 40h3v1H26zM32 40h1v1H32zM35 40h2v1H35zM39 40h1v1H39z"
+              fill="#000000"
+            />
+          </svg>
+        </div>
+        <div>
           <div>
             <div>
               <div>
-                <div>
-                  Precinct
-                </div>
-                <strong>
-                  District 5
-                </strong>
+                Precinct
               </div>
+              <strong>
+                District 5
+              </strong>
+            </div>
+            <div>
               <div>
-                <div>
-                  Ballot Style
-                </div>
-                <strong>
-                  5
-                </strong>
+                Ballot Style
               </div>
+              <strong>
+                5
+              </strong>
+            </div>
+            <div>
               <div>
-                <div>
-                  Ballot ID
-                </div>
-                <strong
-                  class="sc-gsDJrp fUIxJs"
-                >
-                  Asdf1234Asdf12
-                </strong>
+                Ballot ID
               </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="sc-pVTma NVkwn"
-      >
-        <div
-          class="sc-jrQzUz jgYCbw"
-        >
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
-            >
-              <h3>
-                President
-              </h3>
-              <p
-                class="sc-bdvvaa eSpfPW"
+              <strong
+                class="sc-gsDJrp fUIxJs"
               >
-                <span
-                  class="sc-bdvvaa hsgYyE"
-                >
-                  Presidential Electors for Joe Biden for President and Kamala Harris for Vice President
-                </span>
-                 
-                / Democrat
-              </p>
-            </div>
-          </div>
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
-            >
-              <h3>
-                Senate 
-              </h3>
-              <p
-                class="sc-bdvvaa eSpfPW"
-              >
-                <span
-                  class="sc-bdvvaa hsgYyE"
-                >
-                  Mike Espy
-                </span>
-                 
-                / Democrat
-              </p>
-            </div>
-          </div>
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
-            >
-              <h3>
-                1st Congressional District
-              </h3>
-              <p
-                class="sc-bdvvaa eSpfPW"
-              >
-                <span
-                  class="sc-bdvvaa hsgYyE"
-                >
-                  Antonia Eliason
-                </span>
-                 
-                / Democrat
-              </p>
-            </div>
-          </div>
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
-            >
-              <h3>
-                Supreme Court District 3(Northern) Position 3
-              </h3>
-              <p
-                class="sc-bdvvaa eSpfPW"
-              >
-                <span
-                  class="sc-bdvvaa hsgYyE"
-                >
-                  Josiah Dennis Coleman
-                </span>
-                 
-                / Nonpartisan
-              </p>
-            </div>
-          </div>
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
-            >
-              <h3>
-                Election Commissioner 05
-              </h3>
-              <p
-                class="sc-bdvvaa eSpfPW"
-              >
-                <span
-                  class="sc-bdvvaa hsgYyE"
-                >
-                  Ouida A Loper
-                </span>
-                 
-                / Independent
-              </p>
-            </div>
-          </div>
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
-            >
-              <h3>
-                School Board 05
-              </h3>
-              <p
-                class="sc-bdvvaa eSpfPW"
-              >
-                <span
-                  class="sc-bdvvaa hsgYyE"
-                >
-                  Michael D Thomas
-                </span>
-                 
-              </p>
-            </div>
-          </div>
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
-            >
-              <h3>
-                Ballot Measure 2
-House Concurrent Resolution No. 47
-              </h3>
-              <p
-                class="sc-bdvvaa kdHchw"
-              >
-                Yes
-                 
-              </p>
-            </div>
-          </div>
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
-            >
-              <h3>
-                Ballot Measure 3
-House Bill 1796 - Flag Referendum
-              </h3>
-              <p
-                class="sc-bdvvaa kdHchw"
-              >
-                Yes
-                 
-              </p>
-            </div>
-          </div>
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
-            >
-              <h3>
-                Ballot Measure 1
-              </h3>
-              <p
-                class="sc-bdvvaa kdHchw"
-              >
-                •
-                 
-                FOR APPROVAL OF EITHER Initiative No. 65 OR Alternative Measure No. 65 A
-              </p>
-              <p
-                class="sc-bdvvaa kdHchw"
-              >
-                •
-                 
-                FOR Initiative Measure No. 65
-              </p>
+                Asdf1234Asdf12
+              </strong>
             </div>
           </div>
         </div>
       </div>
     </div>
     <div
-      aria-hidden="true"
-      class="sc-jRQAMF kQCdaK"
+      class="sc-pVTma NVkwn"
     >
       <div
-        class="sc-iCfLBT cSkaik"
+        class="sc-jrQzUz jgYCbw"
       >
         <div
-          class="seal"
-          data-testid="printed-ballot-seal"
-          id="printedBallotSealContainer"
+          class="sc-kDThTU gkFLxJ"
         >
-          <img
-            alt=""
-            class="sc-gKckTs hLVAuh"
-            data-testid="printed-ballot-seal-image"
-            src="/seals/Seal_of_Mississippi_BW.svg"
-          />
+          <div
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+          >
+            <h3>
+              President
+            </h3>
+            <p
+              class="sc-bdvvaa eSpfPW"
+            >
+              <span
+                class="sc-bdvvaa hsgYyE"
+              >
+                Presidential Electors for Phil Collins for President and Bill Parker for Vice President
+              </span>
+               
+              / Independent
+            </p>
+          </div>
         </div>
         <div
-          class="sc-hKwCoD gmiWky ballot-header-content"
+          class="sc-kDThTU gkFLxJ"
         >
-          <h2>
-            Unofficial TEST Ballot
-          </h2>
-          <h3>
-            
-             
-            Mock General Election Choctaw 2020
-          </h3>
-          <p>
-            August 26, 2020
-            <br />
-            Choctaw County
-            , 
-            State of Mississippi
-          </p>
+          <div
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+          >
+            <h3>
+              Senate 
+            </h3>
+            <p
+              class="sc-bdvvaa eSpfPW"
+            >
+              <span
+                class="sc-bdvvaa hsgYyE"
+              >
+                Jimmy Edwards
+              </span>
+               
+              / Libertarian
+            </p>
+          </div>
         </div>
         <div
-          class="sc-furvIG cfpKDm"
+          class="sc-kDThTU gkFLxJ"
         >
           <div
-            class="sc-eCImvq gScWpb"
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
           >
-            <svg
-              height="128"
-              shape-rendering="crispEdges"
-              viewBox="0 0 37 37"
-              width="128"
+            <h3>
+              1st Congressional District
+            </h3>
+            <p
+              class="sc-bdvvaa eSpfPW"
             >
-              <path
-                d="M0,0 h37v37H0z"
-                fill="#FFFFFF"
-              />
-              <path
-                d="M0 0h7v1H0zM8 0h1v1H8zM10 0h1v1H10zM13 0h6v1H13zM20 0h1v1H20zM22 0h3v1H22zM27 0h2v1H27zM30,0 h7v1H30zM0 1h1v1H0zM6 1h1v1H6zM9 1h2v1H9zM16 1h1v1H16zM18 1h1v1H18zM21 1h1v1H21zM23 1h2v1H23zM26 1h3v1H26zM30 1h1v1H30zM36,1 h1v1H36zM0 2h1v1H0zM2 2h3v1H2zM6 2h1v1H6zM9 2h3v1H9zM13 2h1v1H13zM15 2h1v1H15zM18 2h2v1H18zM21 2h2v1H21zM26 2h1v1H26zM28 2h1v1H28zM30 2h1v1H30zM32 2h3v1H32zM36,2 h1v1H36zM0 3h1v1H0zM2 3h3v1H2zM6 3h1v1H6zM8 3h1v1H8zM16 3h2v1H16zM20 3h1v1H20zM26 3h3v1H26zM30 3h1v1H30zM32 3h3v1H32zM36,3 h1v1H36zM0 4h1v1H0zM2 4h3v1H2zM6 4h1v1H6zM9 4h13v1H9zM23 4h1v1H23zM25 4h3v1H25zM30 4h1v1H30zM32 4h3v1H32zM36,4 h1v1H36zM0 5h1v1H0zM6 5h1v1H6zM9 5h2v1H9zM12 5h2v1H12zM16 5h4v1H16zM21 5h1v1H21zM23 5h2v1H23zM26 5h3v1H26zM30 5h1v1H30zM36,5 h1v1H36zM0 6h7v1H0zM8 6h1v1H8zM10 6h1v1H10zM12 6h1v1H12zM14 6h1v1H14zM16 6h1v1H16zM18 6h1v1H18zM20 6h1v1H20zM22 6h1v1H22zM24 6h1v1H24zM26 6h1v1H26zM28 6h1v1H28zM30,6 h7v1H30zM14 7h6v1H14zM22 7h3v1H22zM28 7h1v1H28zM2 8h1v1H2zM4 8h3v1H4zM8 8h2v1H8zM12 8h1v1H12zM14 8h4v1H14zM20 8h3v1H20zM29 8h1v1H29zM33 8h1v1H33zM36,8 h1v1H36zM0 9h1v1H0zM2 9h2v1H2zM8 9h1v1H8zM11 9h1v1H11zM13 9h1v1H13zM15 9h5v1H15zM23 9h1v1H23zM27 9h1v1H27zM29 9h1v1H29zM32 9h2v1H32zM35 9h1v1H35zM0 10h1v1H0zM3 10h2v1H3zM6 10h1v1H6zM8 10h2v1H8zM12 10h7v1H12zM21 10h4v1H21zM26 10h1v1H26zM30 10h1v1H30zM33,10 h4v1H33zM2 11h4v1H2zM8 11h3v1H8zM13 11h2v1H13zM17 11h3v1H17zM23 11h3v1H23zM27 11h1v1H27zM30 11h1v1H30zM32 11h1v1H32zM0 12h1v1H0zM2 12h5v1H2zM8 12h1v1H8zM10 12h2v1H10zM16 12h3v1H16zM20 12h1v1H20zM23 12h1v1H23zM28 12h4v1H28zM34 12h1v1H34zM36,12 h1v1H36zM0 13h1v1H0zM3 13h3v1H3zM7 13h3v1H7zM11 13h1v1H11zM14 13h1v1H14zM16 13h1v1H16zM18 13h1v1H18zM20 13h1v1H20zM23 13h1v1H23zM25 13h1v1H25zM27 13h2v1H27zM30 13h1v1H30zM0 14h3v1H0zM4 14h1v1H4zM6 14h1v1H6zM8 14h1v1H8zM10 14h2v1H10zM17 14h3v1H17zM24 14h1v1H24zM26 14h1v1H26zM28 14h1v1H28zM30 14h2v1H30zM35,14 h2v1H35zM0 15h1v1H0zM2 15h1v1H2zM7 15h5v1H7zM13 15h3v1H13zM17 15h1v1H17zM20 15h1v1H20zM22 15h1v1H22zM25 15h1v1H25zM27 15h1v1H27zM32 15h1v1H32zM1 16h2v1H1zM4 16h1v1H4zM6 16h2v1H6zM9 16h4v1H9zM14 16h1v1H14zM18 16h1v1H18zM21 16h1v1H21zM24 16h1v1H24zM28 16h1v1H28zM30 16h1v1H30zM0 17h6v1H0zM7 17h4v1H7zM12 17h1v1H12zM14 17h8v1H14zM27 17h2v1H27zM30 17h1v1H30zM33 17h2v1H33zM0 18h1v1H0zM6 18h2v1H6zM9 18h1v1H9zM12 18h2v1H12zM16 18h4v1H16zM22 18h1v1H22zM25 18h1v1H25zM28 18h1v1H28zM30 18h2v1H30zM33,18 h4v1H33zM0 19h1v1H0zM2 19h3v1H2zM7 19h2v1H7zM10 19h3v1H10zM15 19h1v1H15zM19 19h2v1H19zM23 19h1v1H23zM25 19h3v1H25zM29 19h1v1H29zM32 19h1v1H32zM35 19h1v1H35zM2 20h1v1H2zM4 20h4v1H4zM9 20h1v1H9zM12 20h1v1H12zM14 20h1v1H14zM20 20h3v1H20zM24 20h2v1H24zM27 20h4v1H27zM32 20h1v1H32zM34,20 h3v1H34zM0 21h2v1H0zM3 21h2v1H3zM12 21h2v1H12zM17 21h3v1H17zM22 21h1v1H22zM25 21h1v1H25zM28 21h2v1H28zM34 21h1v1H34zM36,21 h1v1H36zM0 22h2v1H0zM3 22h1v1H3zM5 22h2v1H5zM8 22h1v1H8zM11 22h3v1H11zM15 22h1v1H15zM17 22h6v1H17zM24 22h1v1H24zM26 22h1v1H26zM30 22h2v1H30zM33,22 h4v1H33zM0 23h1v1H0zM2 23h1v1H2zM9 23h1v1H9zM11 23h1v1H11zM13 23h1v1H13zM16 23h5v1H16zM23 23h1v1H23zM25 23h4v1H25zM35 23h1v1H35zM4 24h3v1H4zM8 24h1v1H8zM10 24h1v1H10zM12 24h1v1H12zM14 24h1v1H14zM16 24h4v1H16zM21 24h3v1H21zM26 24h1v1H26zM28 24h1v1H28zM30 24h1v1H30zM32 24h1v1H32zM34,24 h3v1H34zM2 25h2v1H2zM5 25h1v1H5zM7 25h2v1H7zM10 25h5v1H10zM17 25h2v1H17zM20 25h4v1H20zM26 25h3v1H26zM31 25h1v1H31zM0 26h1v1H0zM3 26h4v1H3zM9 26h1v1H9zM13 26h1v1H13zM16 26h2v1H16zM26 26h3v1H26zM30 26h2v1H30zM33 26h1v1H33zM35,26 h2v1H35zM1 27h1v1H1zM5 27h1v1H5zM7 27h1v1H7zM9 27h2v1H9zM12 27h1v1H12zM16 27h2v1H16zM19 27h1v1H19zM21 27h3v1H21zM25 27h2v1H25zM28 27h1v1H28zM30 27h1v1H30zM35 27h1v1H35zM0 28h1v1H0zM4 28h1v1H4zM6 28h3v1H6zM13 28h2v1H13zM16 28h6v1H16zM25 28h1v1H25zM27 28h6v1H27zM35,28 h2v1H35zM8 29h2v1H8zM11 29h1v1H11zM14 29h7v1H14zM22 29h5v1H22zM28 29h1v1H28zM32 29h1v1H32zM34,29 h3v1H34zM0 30h7v1H0zM9 30h4v1H9zM14 30h2v1H14zM17 30h2v1H17zM25 30h1v1H25zM27 30h2v1H27zM30 30h1v1H30zM32 30h1v1H32zM34,30 h3v1H34zM0 31h1v1H0zM6 31h1v1H6zM8 31h2v1H8zM11 31h1v1H11zM13 31h1v1H13zM18 31h1v1H18zM21 31h5v1H21zM28 31h1v1H28zM32 31h1v1H32zM0 32h1v1H0zM2 32h3v1H2zM6 32h1v1H6zM8 32h1v1H8zM10 32h3v1H10zM15 32h1v1H15zM17 32h1v1H17zM21 32h4v1H21zM28 32h5v1H28zM35,32 h2v1H35zM0 33h1v1H0zM2 33h3v1H2zM6 33h1v1H6zM9 33h2v1H9zM12 33h2v1H12zM19 33h1v1H19zM21 33h1v1H21zM23 33h2v1H23zM28 33h1v1H28zM31 33h3v1H31zM35,33 h2v1H35zM0 34h1v1H0zM2 34h3v1H2zM6 34h1v1H6zM8 34h2v1H8zM12 34h1v1H12zM14 34h2v1H14zM17 34h1v1H17zM19 34h1v1H19zM22 34h4v1H22zM32 34h2v1H32zM36,34 h1v1H36zM0 35h1v1H0zM6 35h1v1H6zM9 35h1v1H9zM11 35h1v1H11zM14 35h4v1H14zM19 35h2v1H19zM24 35h3v1H24zM29 35h1v1H29zM31 35h1v1H31zM35 35h1v1H35zM0 36h7v1H0zM10 36h1v1H10zM13 36h1v1H13zM16 36h4v1H16zM23 36h3v1H23zM27 36h2v1H27zM30 36h1v1H30zM35,36 h2v1H35z"
-                fill="#000000"
-              />
-            </svg>
-          </div>
-          <div>
-            <div>
-              <div>
-                <div>
-                  Precinct
-                </div>
-                <strong>
-                  District 5
-                </strong>
-              </div>
-              <div>
-                <div>
-                  Ballot Style
-                </div>
-                <strong>
-                  5
-                </strong>
-              </div>
-              <div>
-                <div>
-                  Ballot ID
-                </div>
-                <strong
-                  class="sc-gsDJrp fUIxJs"
-                >
-                  Asdf1234Asdf12
-                </strong>
-              </div>
-            </div>
+              <span
+                class="sc-bdvvaa hsgYyE"
+              >
+                WRITE-IN
+              </span>
+               
+              (write-in)
+            </p>
           </div>
         </div>
-      </div>
-      <div
-        class="sc-pVTma NVkwn"
-      >
         <div
-          class="sc-jrQzUz jgYCbw"
+          class="sc-kDThTU gkFLxJ"
         >
           <div
-            class="sc-kDThTU gkFLxJ"
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
           >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+            <h3>
+              Supreme Court District 3(Northern) Position 3
+            </h3>
+            <p
+              class="sc-bdvvaa eSpfPW"
             >
-              <h3>
-                President
-              </h3>
-              <p
-                class="sc-bdvvaa eSpfPW"
+              <span
+                class="sc-bdvvaa hsgYyE"
               >
-                <span
-                  class="sc-bdvvaa hsgYyE"
-                >
-                  Presidential Electors for Donald J. Trump for President and Michael R. Pence for Vice President
-                </span>
-                 
-                / Republican
-              </p>
-            </div>
+                WRITE-IN
+              </span>
+               
+              (write-in)
+            </p>
           </div>
+        </div>
+        <div
+          class="sc-kDThTU gkFLxJ"
+        >
           <div
-            class="sc-kDThTU gkFLxJ"
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
           >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+            <h3>
+              Election Commissioner 05
+            </h3>
+            <p
+              class="sc-bdvvaa eSpfPW"
             >
-              <h3>
-                Senate 
-              </h3>
-              <p
-                class="sc-bdvvaa eSpfPW"
+              <span
+                class="sc-bdvvaa hsgYyE"
               >
-                <span
-                  class="sc-bdvvaa hsgYyE"
-                >
-                  Cindy Hyde-Smith
-                </span>
-                 
-                / Republican
-              </p>
-            </div>
+                WRITE-IN
+              </span>
+               
+              (write-in)
+            </p>
           </div>
+        </div>
+        <div
+          class="sc-kDThTU gkFLxJ"
+        >
           <div
-            class="sc-kDThTU gkFLxJ"
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
           >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+            <h3>
+              School Board 05
+            </h3>
+            <p
+              class="sc-bdvvaa eSpfPW"
             >
-              <h3>
-                1st Congressional District
-              </h3>
-              <p
-                class="sc-bdvvaa eSpfPW"
+              <span
+                class="sc-bdvvaa hsgYyE"
               >
-                <span
-                  class="sc-bdvvaa hsgYyE"
-                >
-                  Trent Kelly
-                </span>
-                 
-                / Republican
-              </p>
-            </div>
+                Michael D Thomas
+              </span>
+               
+            </p>
           </div>
+        </div>
+        <div
+          class="sc-kDThTU gkFLxJ"
+        >
           <div
-            class="sc-kDThTU gkFLxJ"
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
           >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
-            >
-              <h3>
-                Supreme Court District 3(Northern) Position 3
-              </h3>
-              <p
-                class="sc-bdvvaa eSpfPW"
-              >
-                <span
-                  class="sc-bdvvaa hsgYyE"
-                >
-                  Percy L. Lynchard
-                </span>
-                 
-                / Nonpartisan
-              </p>
-            </div>
-          </div>
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
-            >
-              <h3>
-                Election Commissioner 05
-              </h3>
-              <p
-                class="sc-bdvvaa eSpfPW"
-              >
-                <span
-                  class="sc-bdvvaa hsgYyE"
-                >
-                  Wayne McLeod
-                </span>
-                 
-              </p>
-            </div>
-          </div>
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
-            >
-              <h3>
-                School Board 05
-              </h3>
-              <p
-                class="sc-bdvvaa eSpfPW"
-              >
-                <span
-                  class="sc-bdvvaa hsgYyE"
-                >
-                  WRITE-IN
-                </span>
-                 
-                (write-in)
-              </p>
-            </div>
-          </div>
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
-            >
-              <h3>
-                Ballot Measure 2
+            <h3>
+              Ballot Measure 2
 House Concurrent Resolution No. 47
-              </h3>
-              <p
-                class="sc-bdvvaa kdHchw"
-              >
-                No
-                 
-              </p>
-            </div>
-          </div>
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+            </h3>
+            <p
+              class="sc-bdvvaa kdHchw"
             >
-              <h3>
-                Ballot Measure 3
+              Yes
+               
+            </p>
+          </div>
+        </div>
+        <div
+          class="sc-kDThTU gkFLxJ"
+        >
+          <div
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+          >
+            <h3>
+              Ballot Measure 3
 House Bill 1796 - Flag Referendum
-              </h3>
-              <p
-                class="sc-bdvvaa kdHchw"
-              >
-                No
-                 
-              </p>
-            </div>
-          </div>
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+            </h3>
+            <p
+              class="sc-bdvvaa kdHchw"
             >
-              <h3>
-                Ballot Measure 1
-              </h3>
-              <p
-                class="sc-bdvvaa kdHchw"
-              >
-                •
-                 
-                AGAINST BOTH Initiative Measure No. 65 AND Alternative Measure No. 65 A
-              </p>
-              <p
-                class="sc-bdvvaa kdHchw"
-              >
-                •
-                 
-                FOR Alternative Measure 65 A
-              </p>
-            </div>
+              Yes
+               
+            </p>
           </div>
         </div>
-      </div>
-    </div>
-    <div
-      aria-hidden="true"
-      class="sc-jRQAMF kQCdaK"
-    >
-      <div
-        class="sc-iCfLBT cSkaik"
-      >
         <div
-          class="seal"
-          data-testid="printed-ballot-seal"
-          id="printedBallotSealContainer"
-        >
-          <img
-            alt=""
-            class="sc-gKckTs hLVAuh"
-            data-testid="printed-ballot-seal-image"
-            src="/seals/Seal_of_Mississippi_BW.svg"
-          />
-        </div>
-        <div
-          class="sc-hKwCoD gmiWky ballot-header-content"
-        >
-          <h2>
-            Unofficial TEST Ballot
-          </h2>
-          <h3>
-            
-             
-            Mock General Election Choctaw 2020
-          </h3>
-          <p>
-            August 26, 2020
-            <br />
-            Choctaw County
-            , 
-            State of Mississippi
-          </p>
-        </div>
-        <div
-          class="sc-furvIG cfpKDm"
+          class="sc-kDThTU gkFLxJ"
         >
           <div
-            class="sc-eCImvq gScWpb"
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
           >
-            <svg
-              height="128"
-              shape-rendering="crispEdges"
-              viewBox="0 0 41 41"
-              width="128"
+            <h3>
+              Ballot Measure 1
+            </h3>
+            <p
+              class="sc-bdvvaa kdHchw"
             >
-              <path
-                d="M0,0 h41v41H0z"
-                fill="#FFFFFF"
-              />
-              <path
-                d="M0 0h7v1H0zM9 0h1v1H9zM13 0h2v1H13zM19 0h1v1H19zM21 0h1v1H21zM24 0h3v1H24zM28 0h4v1H28zM34,0 h7v1H34zM0 1h1v1H0zM6 1h1v1H6zM8 1h8v1H8zM17 1h1v1H17zM19 1h2v1H19zM22 1h5v1H22zM29 1h1v1H29zM31 1h1v1H31zM34 1h1v1H34zM40,1 h1v1H40zM0 2h1v1H0zM2 2h3v1H2zM6 2h1v1H6zM9 2h1v1H9zM12 2h1v1H12zM17 2h2v1H17zM20 2h3v1H20zM24 2h1v1H24zM26 2h3v1H26zM31 2h1v1H31zM34 2h1v1H34zM36 2h3v1H36zM40,2 h1v1H40zM0 3h1v1H0zM2 3h3v1H2zM6 3h1v1H6zM9 3h1v1H9zM12 3h1v1H12zM14 3h1v1H14zM17 3h1v1H17zM20 3h4v1H20zM27 3h1v1H27zM29 3h3v1H29zM34 3h1v1H34zM36 3h3v1H36zM40,3 h1v1H40zM0 4h1v1H0zM2 4h3v1H2zM6 4h1v1H6zM9 4h1v1H9zM12 4h3v1H12zM17 4h1v1H17zM19 4h1v1H19zM21 4h3v1H21zM25 4h1v1H25zM27 4h1v1H27zM29 4h3v1H29zM34 4h1v1H34zM36 4h3v1H36zM40,4 h1v1H40zM0 5h1v1H0zM6 5h1v1H6zM8 5h3v1H8zM12 5h2v1H12zM16 5h2v1H16zM19 5h3v1H19zM23 5h4v1H23zM28 5h1v1H28zM30 5h2v1H30zM34 5h1v1H34zM40,5 h1v1H40zM0 6h7v1H0zM8 6h1v1H8zM10 6h1v1H10zM12 6h1v1H12zM14 6h1v1H14zM16 6h1v1H16zM18 6h1v1H18zM20 6h1v1H20zM22 6h1v1H22zM24 6h1v1H24zM26 6h1v1H26zM28 6h1v1H28zM30 6h1v1H30zM32 6h1v1H32zM34,6 h7v1H34zM8 7h1v1H8zM11 7h4v1H11zM16 7h1v1H16zM18 7h2v1H18zM21 7h3v1H21zM27 7h4v1H27zM32 7h1v1H32zM4 8h4v1H4zM10 8h1v1H10zM19 8h2v1H19zM24 8h1v1H24zM26 8h2v1H26zM29 8h1v1H29zM32 8h1v1H32zM34 8h2v1H34zM39 8h1v1H39zM0 9h5v1H0zM7 9h1v1H7zM14 9h1v1H14zM16 9h2v1H16zM23 9h1v1H23zM25 9h1v1H25zM27 9h3v1H27zM31 9h1v1H31zM33 9h1v1H33zM35 9h2v1H35zM38 9h1v1H38zM1 10h3v1H1zM5 10h9v1H5zM15 10h1v1H15zM17 10h1v1H17zM19 10h2v1H19zM22 10h4v1H22zM27 10h1v1H27zM29 10h1v1H29zM34 10h2v1H34zM38 10h1v1H38zM40,10 h1v1H40zM1 11h3v1H1zM5 11h1v1H5zM8 11h1v1H8zM13 11h2v1H13zM16 11h2v1H16zM19 11h3v1H19zM23 11h1v1H23zM25 11h2v1H25zM28 11h2v1H28zM33 11h2v1H33zM37 11h1v1H37zM39,11 h2v1H39zM0 12h1v1H0zM2 12h2v1H2zM5 12h2v1H5zM8 12h1v1H8zM12 12h3v1H12zM19 12h2v1H19zM24 12h3v1H24zM29 12h2v1H29zM32 12h2v1H32zM36 12h2v1H36zM39 12h1v1H39zM2 13h3v1H2zM7 13h1v1H7zM15 13h1v1H15zM17 13h2v1H17zM21 13h1v1H21zM23 13h1v1H23zM28 13h6v1H28zM35 13h5v1H35zM2 14h1v1H2zM4 14h3v1H4zM8 14h3v1H8zM12 14h2v1H12zM16 14h1v1H16zM19 14h2v1H19zM22 14h1v1H22zM26 14h1v1H26zM28 14h1v1H28zM33 14h3v1H33zM40,14 h1v1H40zM0 15h2v1H0zM4 15h2v1H4zM10 15h2v1H10zM14 15h6v1H14zM21 15h1v1H21zM23 15h3v1H23zM29 15h1v1H29zM32 15h1v1H32zM35 15h1v1H35zM37 15h1v1H37zM40,15 h1v1H40zM1 16h1v1H1zM3 16h1v1H3zM5 16h2v1H5zM8 16h1v1H8zM10 16h1v1H10zM12 16h1v1H12zM16 16h1v1H16zM18 16h2v1H18zM22 16h1v1H22zM25 16h5v1H25zM31 16h3v1H31zM35 16h1v1H35zM38 16h2v1H38zM2 17h1v1H2zM7 17h1v1H7zM10 17h1v1H10zM12 17h2v1H12zM18 17h2v1H18zM27 17h2v1H27zM30 17h2v1H30zM34 17h3v1H34zM38,17 h3v1H38zM1 18h1v1H1zM5 18h5v1H5zM12 18h3v1H12zM16 18h3v1H16zM20 18h1v1H20zM22 18h2v1H22zM27 18h3v1H27zM32 18h1v1H32zM34 18h1v1H34zM36 18h1v1H36zM39,18 h2v1H39zM4 19h1v1H4zM8 19h1v1H8zM13 19h2v1H13zM17 19h2v1H17zM24 19h1v1H24zM26 19h5v1H26zM33 19h1v1H33zM35 19h1v1H35zM37 19h1v1H37zM40,19 h1v1H40zM1 20h1v1H1zM3 20h1v1H3zM5 20h2v1H5zM8 20h3v1H8zM12 20h3v1H12zM18 20h3v1H18zM27 20h1v1H27zM30 20h4v1H30zM37 20h2v1H37zM1 21h1v1H1zM3 21h2v1H3zM7 21h1v1H7zM9 21h1v1H9zM13 21h1v1H13zM15 21h1v1H15zM19 21h1v1H19zM22 21h1v1H22zM24 21h1v1H24zM26 21h3v1H26zM31 21h1v1H31zM35 21h2v1H35zM38 21h2v1H38zM2 22h9v1H2zM13 22h2v1H13zM18 22h5v1H18zM25 22h1v1H25zM27 22h1v1H27zM29 22h2v1H29zM32 22h3v1H32zM38 22h1v1H38zM40,22 h1v1H40zM1 23h4v1H1zM9 23h1v1H9zM12 23h1v1H12zM14 23h4v1H14zM19 23h3v1H19zM23 23h1v1H23zM26 23h1v1H26zM28 23h3v1H28zM35 23h3v1H35zM39,23 h2v1H39zM0 24h2v1H0zM3 24h2v1H3zM6 24h1v1H6zM8 24h4v1H8zM13 24h3v1H13zM18 24h2v1H18zM22 24h4v1H22zM27 24h1v1H27zM29 24h1v1H29zM31 24h1v1H31zM33 24h1v1H33zM36 24h4v1H36zM1 25h2v1H1zM9 25h3v1H9zM13 25h2v1H13zM18 25h1v1H18zM20 25h1v1H20zM22 25h1v1H22zM24 25h1v1H24zM28 25h3v1H28zM33 25h1v1H33zM35 25h2v1H35zM39,25 h2v1H39zM1 26h3v1H1zM6 26h2v1H6zM12 26h1v1H12zM16 26h2v1H16zM19 26h3v1H19zM24 26h4v1H24zM30 26h1v1H30zM32 26h3v1H32zM40,26 h1v1H40zM2 27h1v1H2zM4 27h2v1H4zM8 27h3v1H8zM12 27h1v1H12zM14 27h2v1H14zM18 27h2v1H18zM24 27h1v1H24zM27 27h6v1H27zM34 27h2v1H34zM37 27h1v1H37zM40,27 h1v1H40zM0 28h1v1H0zM2 28h1v1H2zM4 28h3v1H4zM9 28h1v1H9zM12 28h1v1H12zM14 28h1v1H14zM16 28h1v1H16zM20 28h1v1H20zM22 28h4v1H22zM27 28h3v1H27zM31 28h1v1H31zM35 28h1v1H35zM37 28h1v1H37zM40,28 h1v1H40zM0 29h2v1H0zM4 29h1v1H4zM7 29h2v1H7zM10 29h2v1H10zM13 29h1v1H13zM15 29h5v1H15zM21 29h3v1H21zM25 29h1v1H25zM29 29h2v1H29zM32 29h3v1H32zM36 29h2v1H36zM39 29h1v1H39zM2 30h1v1H2zM4 30h3v1H4zM9 30h5v1H9zM15 30h3v1H15zM22 30h2v1H22zM27 30h1v1H27zM32 30h1v1H32zM34 30h1v1H34zM40,30 h1v1H40zM3 31h1v1H3zM8 31h2v1H8zM11 31h2v1H11zM16 31h1v1H16zM18 31h1v1H18zM20 31h1v1H20zM23 31h2v1H23zM27 31h5v1H27zM34 31h2v1H34zM37 31h1v1H37zM39,31 h2v1H39zM0 32h2v1H0zM3 32h2v1H3zM6 32h1v1H6zM9 32h1v1H9zM12 32h1v1H12zM16 32h2v1H16zM19 32h1v1H19zM21 32h1v1H21zM24 32h1v1H24zM29 32h10v1H29zM8 33h1v1H8zM10 33h4v1H10zM15 33h4v1H15zM21 33h9v1H21zM31 33h2v1H31zM36 33h2v1H36zM40,33 h1v1H40zM0 34h7v1H0zM8 34h5v1H8zM14 34h1v1H14zM16 34h7v1H16zM24 34h1v1H24zM26 34h3v1H26zM30 34h3v1H30zM34 34h1v1H34zM36 34h1v1H36zM38 34h1v1H38zM40,34 h1v1H40zM0 35h1v1H0zM6 35h1v1H6zM8 35h3v1H8zM12 35h2v1H12zM15 35h4v1H15zM21 35h2v1H21zM24 35h1v1H24zM26 35h1v1H26zM31 35h2v1H31zM36 35h1v1H36zM0 36h1v1H0zM2 36h3v1H2zM6 36h1v1H6zM8 36h1v1H8zM11 36h1v1H11zM13 36h4v1H13zM21 36h2v1H21zM24 36h3v1H24zM31 36h6v1H31zM39,36 h2v1H39zM0 37h1v1H0zM2 37h3v1H2zM6 37h1v1H6zM9 37h3v1H9zM13 37h9v1H13zM24 37h2v1H24zM27 37h5v1H27zM33 37h1v1H33zM36 37h1v1H36zM38,37 h3v1H38zM0 38h1v1H0zM2 38h3v1H2zM6 38h1v1H6zM17 38h2v1H17zM20 38h2v1H20zM23 38h3v1H23zM27 38h1v1H27zM29 38h1v1H29zM33 38h1v1H33zM37 38h1v1H37zM39,38 h2v1H39zM0 39h1v1H0zM6 39h1v1H6zM9 39h1v1H9zM11 39h1v1H11zM17 39h1v1H17zM20 39h4v1H20zM25 39h2v1H25zM28 39h4v1H28zM34 39h1v1H34zM36 39h2v1H36zM39,39 h2v1H39zM0 40h7v1H0zM13 40h3v1H13zM17 40h1v1H17zM19 40h1v1H19zM21 40h1v1H21zM23 40h2v1H23zM26 40h3v1H26zM32 40h1v1H32zM35 40h2v1H35zM39 40h1v1H39z"
-                fill="#000000"
-              />
-            </svg>
-          </div>
-          <div>
-            <div>
-              <div>
-                <div>
-                  Precinct
-                </div>
-                <strong>
-                  District 5
-                </strong>
-              </div>
-              <div>
-                <div>
-                  Ballot Style
-                </div>
-                <strong>
-                  5
-                </strong>
-              </div>
-              <div>
-                <div>
-                  Ballot ID
-                </div>
-                <strong
-                  class="sc-gsDJrp fUIxJs"
-                >
-                  Asdf1234Asdf12
-                </strong>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="sc-pVTma NVkwn"
-      >
-        <div
-          class="sc-jrQzUz jgYCbw"
-        >
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+              •
+               
+              FOR APPROVAL OF EITHER Initiative No. 65 OR Alternative Measure No. 65 A
+            </p>
+            <p
+              class="sc-bdvvaa kdHchw"
             >
-              <h3>
-                President
-              </h3>
-              <p
-                class="sc-bdvvaa eSpfPW"
-              >
-                <span
-                  class="sc-bdvvaa hsgYyE"
-                >
-                  Presidential Electors for Phil Collins for President and Bill Parker for Vice President
-                </span>
-                 
-                / Independent
-              </p>
-            </div>
-          </div>
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
-            >
-              <h3>
-                Senate 
-              </h3>
-              <p
-                class="sc-bdvvaa eSpfPW"
-              >
-                <span
-                  class="sc-bdvvaa hsgYyE"
-                >
-                  Jimmy Edwards
-                </span>
-                 
-                / Libertarian
-              </p>
-            </div>
-          </div>
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
-            >
-              <h3>
-                1st Congressional District
-              </h3>
-              <p
-                class="sc-bdvvaa eSpfPW"
-              >
-                <span
-                  class="sc-bdvvaa hsgYyE"
-                >
-                  WRITE-IN
-                </span>
-                 
-                (write-in)
-              </p>
-            </div>
-          </div>
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
-            >
-              <h3>
-                Supreme Court District 3(Northern) Position 3
-              </h3>
-              <p
-                class="sc-bdvvaa eSpfPW"
-              >
-                <span
-                  class="sc-bdvvaa hsgYyE"
-                >
-                  WRITE-IN
-                </span>
-                 
-                (write-in)
-              </p>
-            </div>
-          </div>
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
-            >
-              <h3>
-                Election Commissioner 05
-              </h3>
-              <p
-                class="sc-bdvvaa eSpfPW"
-              >
-                <span
-                  class="sc-bdvvaa hsgYyE"
-                >
-                  WRITE-IN
-                </span>
-                 
-                (write-in)
-              </p>
-            </div>
-          </div>
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
-            >
-              <h3>
-                School Board 05
-              </h3>
-              <p
-                class="sc-bdvvaa eSpfPW"
-              >
-                <span
-                  class="sc-bdvvaa hsgYyE"
-                >
-                  Michael D Thomas
-                </span>
-                 
-              </p>
-            </div>
-          </div>
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
-            >
-              <h3>
-                Ballot Measure 2
-House Concurrent Resolution No. 47
-              </h3>
-              <p
-                class="sc-bdvvaa kdHchw"
-              >
-                Yes
-                 
-              </p>
-            </div>
-          </div>
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
-            >
-              <h3>
-                Ballot Measure 3
-House Bill 1796 - Flag Referendum
-              </h3>
-              <p
-                class="sc-bdvvaa kdHchw"
-              >
-                Yes
-                 
-              </p>
-            </div>
-          </div>
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
-            >
-              <h3>
-                Ballot Measure 1
-              </h3>
-              <p
-                class="sc-bdvvaa kdHchw"
-              >
-                •
-                 
-                FOR APPROVAL OF EITHER Initiative No. 65 OR Alternative Measure No. 65 A
-              </p>
-              <p
-                class="sc-bdvvaa kdHchw"
-              >
-                •
-                 
-                FOR Initiative Measure No. 65
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      aria-hidden="true"
-      class="sc-jRQAMF kQCdaK"
-    >
-      <div
-        class="sc-iCfLBT cSkaik"
-      >
-        <div
-          class="seal"
-          data-testid="printed-ballot-seal"
-          id="printedBallotSealContainer"
-        >
-          <img
-            alt=""
-            class="sc-gKckTs hLVAuh"
-            data-testid="printed-ballot-seal-image"
-            src="/seals/Seal_of_Mississippi_BW.svg"
-          />
-        </div>
-        <div
-          class="sc-hKwCoD gmiWky ballot-header-content"
-        >
-          <h2>
-            Unofficial TEST Ballot
-          </h2>
-          <h3>
-            
-             
-            Mock General Election Choctaw 2020
-          </h3>
-          <p>
-            August 26, 2020
-            <br />
-            Choctaw County
-            , 
-            State of Mississippi
-          </p>
-        </div>
-        <div
-          class="sc-furvIG cfpKDm"
-        >
-          <div
-            class="sc-eCImvq gScWpb"
-          >
-            <svg
-              height="128"
-              shape-rendering="crispEdges"
-              viewBox="0 0 41 41"
-              width="128"
-            >
-              <path
-                d="M0,0 h41v41H0z"
-                fill="#FFFFFF"
-              />
-              <path
-                d="M0 0h7v1H0zM11 0h2v1H11zM15 0h3v1H15zM22 0h5v1H22zM31 0h1v1H31zM34,0 h7v1H34zM0 1h1v1H0zM6 1h1v1H6zM8 1h2v1H8zM13 1h1v1H13zM17 1h1v1H17zM19 1h1v1H19zM21 1h4v1H21zM28 1h3v1H28zM32 1h1v1H32zM34 1h1v1H34zM40,1 h1v1H40zM0 2h1v1H0zM2 2h3v1H2zM6 2h1v1H6zM8 2h1v1H8zM10 2h1v1H10zM13 2h2v1H13zM19 2h1v1H19zM21 2h2v1H21zM24 2h2v1H24zM27 2h1v1H27zM30 2h3v1H30zM34 2h1v1H34zM36 2h3v1H36zM40,2 h1v1H40zM0 3h1v1H0zM2 3h3v1H2zM6 3h1v1H6zM8 3h4v1H8zM13 3h3v1H13zM18 3h2v1H18zM22 3h2v1H22zM30 3h2v1H30zM34 3h1v1H34zM36 3h3v1H36zM40,3 h1v1H40zM0 4h1v1H0zM2 4h3v1H2zM6 4h1v1H6zM8 4h1v1H8zM10 4h2v1H10zM13 4h2v1H13zM16 4h1v1H16zM20 4h1v1H20zM22 4h1v1H22zM24 4h2v1H24zM27 4h1v1H27zM30 4h2v1H30zM34 4h1v1H34zM36 4h3v1H36zM40,4 h1v1H40zM0 5h1v1H0zM6 5h1v1H6zM8 5h4v1H8zM14 5h1v1H14zM16 5h3v1H16zM20 5h2v1H20zM24 5h1v1H24zM28 5h1v1H28zM32 5h1v1H32zM34 5h1v1H34zM40,5 h1v1H40zM0 6h7v1H0zM8 6h1v1H8zM10 6h1v1H10zM12 6h1v1H12zM14 6h1v1H14zM16 6h1v1H16zM18 6h1v1H18zM20 6h1v1H20zM22 6h1v1H22zM24 6h1v1H24zM26 6h1v1H26zM28 6h1v1H28zM30 6h1v1H30zM32 6h1v1H32zM34,6 h7v1H34zM9 7h2v1H9zM12 7h3v1H12zM17 7h4v1H17zM30 7h1v1H30zM32 7h1v1H32zM2 8h1v1H2zM5 8h5v1H5zM15 8h3v1H15zM20 8h3v1H20zM24 8h1v1H24zM26 8h3v1H26zM32 8h2v1H32zM35 8h5v1H35zM0 9h6v1H0zM7 9h3v1H7zM12 9h2v1H12zM16 9h6v1H16zM23 9h2v1H23zM26 9h5v1H26zM32 9h1v1H32zM34 9h2v1H34zM37 9h1v1H37zM40,9 h1v1H40zM1 10h1v1H1zM3 10h1v1H3zM5 10h2v1H5zM10 10h2v1H10zM14 10h2v1H14zM18 10h1v1H18zM21 10h3v1H21zM25 10h3v1H25zM29 10h4v1H29zM37 10h1v1H37zM40,10 h1v1H40zM1 11h1v1H1zM4 11h1v1H4zM7 11h3v1H7zM11 11h1v1H11zM14 11h2v1H14zM17 11h5v1H17zM26 11h2v1H26zM33 11h5v1H33zM39,11 h2v1H39zM0 12h1v1H0zM2 12h1v1H2zM4 12h3v1H4zM10 12h4v1H10zM15 12h2v1H15zM19 12h2v1H19zM22 12h3v1H22zM26 12h3v1H26zM30 12h1v1H30zM32 12h1v1H32zM34 12h4v1H34zM40,12 h1v1H40zM0 13h1v1H0zM2 13h1v1H2zM4 13h2v1H4zM7 13h6v1H7zM20 13h2v1H20zM26 13h1v1H26zM28 13h2v1H28zM34 13h2v1H34zM40,13 h1v1H40zM0 14h2v1H0zM4 14h5v1H4zM10 14h1v1H10zM13 14h1v1H13zM18 14h1v1H18zM20 14h1v1H20zM22 14h2v1H22zM26 14h1v1H26zM28 14h1v1H28zM30 14h2v1H30zM33 14h6v1H33zM40,14 h1v1H40zM0 15h2v1H0zM3 15h1v1H3zM11 15h3v1H11zM16 15h3v1H16zM20 15h3v1H20zM24 15h1v1H24zM27 15h2v1H27zM33 15h2v1H33zM37 15h1v1H37zM40,15 h1v1H40zM1 16h1v1H1zM4 16h1v1H4zM6 16h1v1H6zM8 16h1v1H8zM11 16h5v1H11zM18 16h3v1H18zM22 16h2v1H22zM25 16h1v1H25zM29 16h1v1H29zM31 16h2v1H31zM34 16h1v1H34zM38 16h2v1H38zM1 17h1v1H1zM8 17h1v1H8zM10 17h2v1H10zM14 17h3v1H14zM23 17h3v1H23zM28 17h1v1H28zM31 17h2v1H31zM34 17h2v1H34zM38,17 h3v1H38zM2 18h1v1H2zM4 18h1v1H4zM6 18h1v1H6zM9 18h2v1H9zM12 18h4v1H12zM19 18h1v1H19zM21 18h1v1H21zM23 18h1v1H23zM25 18h7v1H25zM34 18h1v1H34zM39,18 h2v1H39zM0 19h1v1H0zM3 19h2v1H3zM8 19h1v1H8zM11 19h2v1H11zM15 19h1v1H15zM18 19h1v1H18zM21 19h2v1H21zM24 19h1v1H24zM27 19h1v1H27zM30 19h1v1H30zM34 19h1v1H34zM39 19h1v1H39zM0 20h2v1H0zM5 20h2v1H5zM8 20h1v1H8zM10 20h2v1H10zM14 20h2v1H14zM17 20h1v1H17zM19 20h1v1H19zM21 20h1v1H21zM23 20h1v1H23zM26 20h5v1H26zM32 20h1v1H32zM34 20h3v1H34zM39,20 h2v1H39zM0 21h4v1H0zM5 21h1v1H5zM8 21h2v1H8zM12 21h1v1H12zM16 21h1v1H16zM18 21h3v1H18zM22 21h1v1H22zM25 21h1v1H25zM27 21h2v1H27zM30 21h1v1H30zM32 21h1v1H32zM35 21h1v1H35zM38 21h2v1H38zM0 22h2v1H0zM6 22h2v1H6zM9 22h2v1H9zM16 22h1v1H16zM19 22h1v1H19zM21 22h4v1H21zM26 22h4v1H26zM31 22h1v1H31zM33 22h1v1H33zM35 22h1v1H35zM38 22h1v1H38zM40,22 h1v1H40zM0 23h1v1H0zM2 23h3v1H2zM7 23h2v1H7zM10 23h2v1H10zM14 23h1v1H14zM19 23h1v1H19zM22 23h2v1H22zM26 23h2v1H26zM30 23h1v1H30zM33 23h2v1H33zM36 23h2v1H36zM0 24h2v1H0zM3 24h1v1H3zM6 24h1v1H6zM8 24h1v1H8zM11 24h1v1H11zM13 24h6v1H13zM21 24h1v1H21zM24 24h2v1H24zM27 24h2v1H27zM31 24h1v1H31zM34 24h2v1H34zM37 24h1v1H37zM40,24 h1v1H40zM0 25h1v1H0zM2 25h1v1H2zM4 25h2v1H4zM7 25h1v1H7zM10 25h3v1H10zM17 25h1v1H17zM19 25h1v1H19zM22 25h1v1H22zM26 25h1v1H26zM28 25h2v1H28zM31 25h3v1H31zM35 25h1v1H35zM37 25h3v1H37zM0 26h2v1H0zM4 26h4v1H4zM9 26h1v1H9zM16 26h1v1H16zM18 26h1v1H18zM22 26h1v1H22zM25 26h3v1H25zM31 26h1v1H31zM35 26h4v1H35zM40,26 h1v1H40zM0 27h1v1H0zM2 27h1v1H2zM5 27h1v1H5zM7 27h7v1H7zM16 27h2v1H16zM19 27h1v1H19zM23 27h4v1H23zM30 27h5v1H30zM36 27h2v1H36zM39,27 h2v1H39zM0 28h2v1H0zM4 28h1v1H4zM6 28h1v1H6zM11 28h1v1H11zM13 28h3v1H13zM20 28h1v1H20zM26 28h1v1H26zM31 28h2v1H31zM34 28h1v1H34zM37 28h1v1H37zM39 28h1v1H39zM1 29h4v1H1zM9 29h1v1H9zM11 29h2v1H11zM14 29h1v1H14zM16 29h6v1H16zM23 29h1v1H23zM26 29h1v1H26zM29 29h1v1H29zM32 29h1v1H32zM34 29h1v1H34zM38 29h1v1H38zM0 30h2v1H0zM3 30h5v1H3zM11 30h2v1H11zM15 30h2v1H15zM19 30h1v1H19zM22 30h2v1H22zM26 30h2v1H26zM31 30h1v1H31zM34 30h1v1H34zM36 30h3v1H36zM40,30 h1v1H40zM3 31h3v1H3zM10 31h1v1H10zM15 31h1v1H15zM20 31h2v1H20zM23 31h1v1H23zM25 31h1v1H25zM30 31h1v1H30zM33 31h1v1H33zM37 31h1v1H37zM39,31 h2v1H39zM0 32h2v1H0zM5 32h3v1H5zM12 32h1v1H12zM14 32h1v1H14zM16 32h4v1H16zM22 32h1v1H22zM26 32h3v1H26zM31 32h9v1H31zM8 33h2v1H8zM11 33h2v1H11zM14 33h6v1H14zM21 33h9v1H21zM32 33h1v1H32zM36 33h2v1H36zM40,33 h1v1H40zM0 34h7v1H0zM8 34h1v1H8zM10 34h2v1H10zM14 34h3v1H14zM19 34h3v1H19zM26 34h2v1H26zM32 34h1v1H32zM34 34h1v1H34zM36 34h2v1H36zM40,34 h1v1H40zM0 35h1v1H0zM6 35h1v1H6zM8 35h1v1H8zM11 35h2v1H11zM15 35h1v1H15zM17 35h1v1H17zM19 35h2v1H19zM25 35h5v1H25zM31 35h2v1H31zM36 35h2v1H36zM39,35 h2v1H39zM0 36h1v1H0zM2 36h3v1H2zM6 36h1v1H6zM9 36h1v1H9zM11 36h2v1H11zM14 36h1v1H14zM16 36h3v1H16zM20 36h1v1H20zM22 36h4v1H22zM29 36h1v1H29zM31 36h7v1H31zM0 37h1v1H0zM2 37h3v1H2zM6 37h1v1H6zM9 37h1v1H9zM11 37h1v1H11zM14 37h4v1H14zM20 37h2v1H20zM24 37h1v1H24zM26 37h1v1H26zM28 37h2v1H28zM31 37h3v1H31zM38,37 h3v1H38zM0 38h1v1H0zM2 38h3v1H2zM6 38h1v1H6zM8 38h1v1H8zM12 38h3v1H12zM16 38h2v1H16zM21 38h1v1H21zM26 38h2v1H26zM29 38h2v1H29zM32 38h2v1H32zM36 38h1v1H36zM38,38 h3v1H38zM0 39h1v1H0zM6 39h1v1H6zM10 39h2v1H10zM15 39h2v1H15zM19 39h1v1H19zM25 39h2v1H25zM30 39h2v1H30zM33 39h1v1H33zM35 39h3v1H35zM0 40h7v1H0zM9 40h2v1H9zM13 40h4v1H13zM22 40h1v1H22zM24 40h1v1H24zM26 40h1v1H26zM29 40h1v1H29zM32 40h3v1H32zM36 40h1v1H36zM38 40h1v1H38zM40,40 h1v1H40z"
-                fill="#000000"
-              />
-            </svg>
-          </div>
-          <div>
-            <div>
-              <div>
-                <div>
-                  Precinct
-                </div>
-                <strong>
-                  District 5
-                </strong>
-              </div>
-              <div>
-                <div>
-                  Ballot Style
-                </div>
-                <strong>
-                  5
-                </strong>
-              </div>
-              <div>
-                <div>
-                  Ballot ID
-                </div>
-                <strong
-                  class="sc-gsDJrp fUIxJs"
-                >
-                  Asdf1234Asdf12
-                </strong>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="sc-pVTma NVkwn"
-      >
-        <div
-          class="sc-jrQzUz jgYCbw"
-        >
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
-            >
-              <h3>
-                President
-              </h3>
-              <p
-                class="sc-bdvvaa eSpfPW"
-              >
-                <span
-                  class="sc-bdvvaa hsgYyE"
-                >
-                  WRITE-IN
-                </span>
-                 
-                (write-in)
-              </p>
-            </div>
-          </div>
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
-            >
-              <h3>
-                Senate 
-              </h3>
-              <p
-                class="sc-bdvvaa eSpfPW"
-              >
-                <span
-                  class="sc-bdvvaa hsgYyE"
-                >
-                  WRITE-IN
-                </span>
-                 
-                (write-in)
-              </p>
-            </div>
-          </div>
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
-            >
-              <h3>
-                1st Congressional District
-              </h3>
-              <p
-                class="sc-bdvvaa eSpfPW"
-              >
-                <span
-                  class="sc-bdvvaa hsgYyE"
-                >
-                  Antonia Eliason
-                </span>
-                 
-                / Democrat
-              </p>
-            </div>
-          </div>
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
-            >
-              <h3>
-                Supreme Court District 3(Northern) Position 3
-              </h3>
-              <p
-                class="sc-bdvvaa eSpfPW"
-              >
-                <span
-                  class="sc-bdvvaa hsgYyE"
-                >
-                  Josiah Dennis Coleman
-                </span>
-                 
-                / Nonpartisan
-              </p>
-            </div>
-          </div>
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
-            >
-              <h3>
-                Election Commissioner 05
-              </h3>
-              <p
-                class="sc-bdvvaa eSpfPW"
-              >
-                <span
-                  class="sc-bdvvaa hsgYyE"
-                >
-                  Ouida A Loper
-                </span>
-                 
-                / Independent
-              </p>
-            </div>
-          </div>
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
-            >
-              <h3>
-                School Board 05
-              </h3>
-              <p
-                class="sc-bdvvaa eSpfPW"
-              >
-                <span
-                  class="sc-bdvvaa hsgYyE"
-                >
-                  WRITE-IN
-                </span>
-                 
-                (write-in)
-              </p>
-            </div>
-          </div>
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
-            >
-              <h3>
-                Ballot Measure 2
-House Concurrent Resolution No. 47
-              </h3>
-              <p
-                class="sc-bdvvaa kdHchw"
-              >
-                No
-                 
-              </p>
-            </div>
-          </div>
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
-            >
-              <h3>
-                Ballot Measure 3
-House Bill 1796 - Flag Referendum
-              </h3>
-              <p
-                class="sc-bdvvaa kdHchw"
-              >
-                No
-                 
-              </p>
-            </div>
-          </div>
-          <div
-            class="sc-kDThTU gkFLxJ"
-          >
-            <div
-              class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
-            >
-              <h3>
-                Ballot Measure 1
-              </h3>
-              <p
-                class="sc-bdvvaa kdHchw"
-              >
-                •
-                 
-                AGAINST BOTH Initiative Measure No. 65 AND Alternative Measure No. 65 A
-              </p>
-              <p
-                class="sc-bdvvaa kdHchw"
-              >
-                •
-                 
-                FOR Alternative Measure 65 A
-              </p>
-            </div>
+              •
+               
+              FOR Initiative Measure No. 65
+            </p>
           </div>
         </div>
       </div>
     </div>
   </div>
-  <div />
+  <div
+    aria-hidden="true"
+    class="sc-jRQAMF kQCdaK"
+  >
+    <div
+      class="sc-iCfLBT cSkaik"
+    >
+      <div
+        class="seal"
+        data-testid="printed-ballot-seal"
+        id="printedBallotSealContainer"
+      >
+        <img
+          alt=""
+          class="sc-gKckTs hLVAuh"
+          data-testid="printed-ballot-seal-image"
+          src="/seals/Seal_of_Mississippi_BW.svg"
+        />
+      </div>
+      <div
+        class="sc-hKwCoD gmiWky ballot-header-content"
+      >
+        <h2>
+          Unofficial TEST Ballot
+        </h2>
+        <h3>
+          
+           
+          Mock General Election Choctaw 2020
+        </h3>
+        <p>
+          August 26, 2020
+          <br />
+          Choctaw County
+          , 
+          State of Mississippi
+        </p>
+      </div>
+      <div
+        class="sc-furvIG cfpKDm"
+      >
+        <div
+          class="sc-eCImvq gScWpb"
+        >
+          <svg
+            height="128"
+            shape-rendering="crispEdges"
+            viewBox="0 0 41 41"
+            width="128"
+          >
+            <path
+              d="M0,0 h41v41H0z"
+              fill="#FFFFFF"
+            />
+            <path
+              d="M0 0h7v1H0zM11 0h2v1H11zM15 0h3v1H15zM22 0h5v1H22zM31 0h1v1H31zM34,0 h7v1H34zM0 1h1v1H0zM6 1h1v1H6zM8 1h2v1H8zM13 1h1v1H13zM17 1h1v1H17zM19 1h1v1H19zM21 1h4v1H21zM28 1h3v1H28zM32 1h1v1H32zM34 1h1v1H34zM40,1 h1v1H40zM0 2h1v1H0zM2 2h3v1H2zM6 2h1v1H6zM8 2h1v1H8zM10 2h1v1H10zM13 2h2v1H13zM19 2h1v1H19zM21 2h2v1H21zM24 2h2v1H24zM27 2h1v1H27zM30 2h3v1H30zM34 2h1v1H34zM36 2h3v1H36zM40,2 h1v1H40zM0 3h1v1H0zM2 3h3v1H2zM6 3h1v1H6zM8 3h4v1H8zM13 3h3v1H13zM18 3h2v1H18zM22 3h2v1H22zM30 3h2v1H30zM34 3h1v1H34zM36 3h3v1H36zM40,3 h1v1H40zM0 4h1v1H0zM2 4h3v1H2zM6 4h1v1H6zM8 4h1v1H8zM10 4h2v1H10zM13 4h2v1H13zM16 4h1v1H16zM20 4h1v1H20zM22 4h1v1H22zM24 4h2v1H24zM27 4h1v1H27zM30 4h2v1H30zM34 4h1v1H34zM36 4h3v1H36zM40,4 h1v1H40zM0 5h1v1H0zM6 5h1v1H6zM8 5h4v1H8zM14 5h1v1H14zM16 5h3v1H16zM20 5h2v1H20zM24 5h1v1H24zM28 5h1v1H28zM32 5h1v1H32zM34 5h1v1H34zM40,5 h1v1H40zM0 6h7v1H0zM8 6h1v1H8zM10 6h1v1H10zM12 6h1v1H12zM14 6h1v1H14zM16 6h1v1H16zM18 6h1v1H18zM20 6h1v1H20zM22 6h1v1H22zM24 6h1v1H24zM26 6h1v1H26zM28 6h1v1H28zM30 6h1v1H30zM32 6h1v1H32zM34,6 h7v1H34zM9 7h2v1H9zM12 7h3v1H12zM17 7h4v1H17zM30 7h1v1H30zM32 7h1v1H32zM2 8h1v1H2zM5 8h5v1H5zM15 8h3v1H15zM20 8h3v1H20zM24 8h1v1H24zM26 8h3v1H26zM32 8h2v1H32zM35 8h5v1H35zM0 9h6v1H0zM7 9h3v1H7zM12 9h2v1H12zM16 9h6v1H16zM23 9h2v1H23zM26 9h5v1H26zM32 9h1v1H32zM34 9h2v1H34zM37 9h1v1H37zM40,9 h1v1H40zM1 10h1v1H1zM3 10h1v1H3zM5 10h2v1H5zM10 10h2v1H10zM14 10h2v1H14zM18 10h1v1H18zM21 10h3v1H21zM25 10h3v1H25zM29 10h4v1H29zM37 10h1v1H37zM40,10 h1v1H40zM1 11h1v1H1zM4 11h1v1H4zM7 11h3v1H7zM11 11h1v1H11zM14 11h2v1H14zM17 11h5v1H17zM26 11h2v1H26zM33 11h5v1H33zM39,11 h2v1H39zM0 12h1v1H0zM2 12h1v1H2zM4 12h3v1H4zM10 12h4v1H10zM15 12h2v1H15zM19 12h2v1H19zM22 12h3v1H22zM26 12h3v1H26zM30 12h1v1H30zM32 12h1v1H32zM34 12h4v1H34zM40,12 h1v1H40zM0 13h1v1H0zM2 13h1v1H2zM4 13h2v1H4zM7 13h6v1H7zM20 13h2v1H20zM26 13h1v1H26zM28 13h2v1H28zM34 13h2v1H34zM40,13 h1v1H40zM0 14h2v1H0zM4 14h5v1H4zM10 14h1v1H10zM13 14h1v1H13zM18 14h1v1H18zM20 14h1v1H20zM22 14h2v1H22zM26 14h1v1H26zM28 14h1v1H28zM30 14h2v1H30zM33 14h6v1H33zM40,14 h1v1H40zM0 15h2v1H0zM3 15h1v1H3zM11 15h3v1H11zM16 15h3v1H16zM20 15h3v1H20zM24 15h1v1H24zM27 15h2v1H27zM33 15h2v1H33zM37 15h1v1H37zM40,15 h1v1H40zM1 16h1v1H1zM4 16h1v1H4zM6 16h1v1H6zM8 16h1v1H8zM11 16h5v1H11zM18 16h3v1H18zM22 16h2v1H22zM25 16h1v1H25zM29 16h1v1H29zM31 16h2v1H31zM34 16h1v1H34zM38 16h2v1H38zM1 17h1v1H1zM8 17h1v1H8zM10 17h2v1H10zM14 17h3v1H14zM23 17h3v1H23zM28 17h1v1H28zM31 17h2v1H31zM34 17h2v1H34zM38,17 h3v1H38zM2 18h1v1H2zM4 18h1v1H4zM6 18h1v1H6zM9 18h2v1H9zM12 18h4v1H12zM19 18h1v1H19zM21 18h1v1H21zM23 18h1v1H23zM25 18h7v1H25zM34 18h1v1H34zM39,18 h2v1H39zM0 19h1v1H0zM3 19h2v1H3zM8 19h1v1H8zM11 19h2v1H11zM15 19h1v1H15zM18 19h1v1H18zM21 19h2v1H21zM24 19h1v1H24zM27 19h1v1H27zM30 19h1v1H30zM34 19h1v1H34zM39 19h1v1H39zM0 20h2v1H0zM5 20h2v1H5zM8 20h1v1H8zM10 20h2v1H10zM14 20h2v1H14zM17 20h1v1H17zM19 20h1v1H19zM21 20h1v1H21zM23 20h1v1H23zM26 20h5v1H26zM32 20h1v1H32zM34 20h3v1H34zM39,20 h2v1H39zM0 21h4v1H0zM5 21h1v1H5zM8 21h2v1H8zM12 21h1v1H12zM16 21h1v1H16zM18 21h3v1H18zM22 21h1v1H22zM25 21h1v1H25zM27 21h2v1H27zM30 21h1v1H30zM32 21h1v1H32zM35 21h1v1H35zM38 21h2v1H38zM0 22h2v1H0zM6 22h2v1H6zM9 22h2v1H9zM16 22h1v1H16zM19 22h1v1H19zM21 22h4v1H21zM26 22h4v1H26zM31 22h1v1H31zM33 22h1v1H33zM35 22h1v1H35zM38 22h1v1H38zM40,22 h1v1H40zM0 23h1v1H0zM2 23h3v1H2zM7 23h2v1H7zM10 23h2v1H10zM14 23h1v1H14zM19 23h1v1H19zM22 23h2v1H22zM26 23h2v1H26zM30 23h1v1H30zM33 23h2v1H33zM36 23h2v1H36zM0 24h2v1H0zM3 24h1v1H3zM6 24h1v1H6zM8 24h1v1H8zM11 24h1v1H11zM13 24h6v1H13zM21 24h1v1H21zM24 24h2v1H24zM27 24h2v1H27zM31 24h1v1H31zM34 24h2v1H34zM37 24h1v1H37zM40,24 h1v1H40zM0 25h1v1H0zM2 25h1v1H2zM4 25h2v1H4zM7 25h1v1H7zM10 25h3v1H10zM17 25h1v1H17zM19 25h1v1H19zM22 25h1v1H22zM26 25h1v1H26zM28 25h2v1H28zM31 25h3v1H31zM35 25h1v1H35zM37 25h3v1H37zM0 26h2v1H0zM4 26h4v1H4zM9 26h1v1H9zM16 26h1v1H16zM18 26h1v1H18zM22 26h1v1H22zM25 26h3v1H25zM31 26h1v1H31zM35 26h4v1H35zM40,26 h1v1H40zM0 27h1v1H0zM2 27h1v1H2zM5 27h1v1H5zM7 27h7v1H7zM16 27h2v1H16zM19 27h1v1H19zM23 27h4v1H23zM30 27h5v1H30zM36 27h2v1H36zM39,27 h2v1H39zM0 28h2v1H0zM4 28h1v1H4zM6 28h1v1H6zM11 28h1v1H11zM13 28h3v1H13zM20 28h1v1H20zM26 28h1v1H26zM31 28h2v1H31zM34 28h1v1H34zM37 28h1v1H37zM39 28h1v1H39zM1 29h4v1H1zM9 29h1v1H9zM11 29h2v1H11zM14 29h1v1H14zM16 29h6v1H16zM23 29h1v1H23zM26 29h1v1H26zM29 29h1v1H29zM32 29h1v1H32zM34 29h1v1H34zM38 29h1v1H38zM0 30h2v1H0zM3 30h5v1H3zM11 30h2v1H11zM15 30h2v1H15zM19 30h1v1H19zM22 30h2v1H22zM26 30h2v1H26zM31 30h1v1H31zM34 30h1v1H34zM36 30h3v1H36zM40,30 h1v1H40zM3 31h3v1H3zM10 31h1v1H10zM15 31h1v1H15zM20 31h2v1H20zM23 31h1v1H23zM25 31h1v1H25zM30 31h1v1H30zM33 31h1v1H33zM37 31h1v1H37zM39,31 h2v1H39zM0 32h2v1H0zM5 32h3v1H5zM12 32h1v1H12zM14 32h1v1H14zM16 32h4v1H16zM22 32h1v1H22zM26 32h3v1H26zM31 32h9v1H31zM8 33h2v1H8zM11 33h2v1H11zM14 33h6v1H14zM21 33h9v1H21zM32 33h1v1H32zM36 33h2v1H36zM40,33 h1v1H40zM0 34h7v1H0zM8 34h1v1H8zM10 34h2v1H10zM14 34h3v1H14zM19 34h3v1H19zM26 34h2v1H26zM32 34h1v1H32zM34 34h1v1H34zM36 34h2v1H36zM40,34 h1v1H40zM0 35h1v1H0zM6 35h1v1H6zM8 35h1v1H8zM11 35h2v1H11zM15 35h1v1H15zM17 35h1v1H17zM19 35h2v1H19zM25 35h5v1H25zM31 35h2v1H31zM36 35h2v1H36zM39,35 h2v1H39zM0 36h1v1H0zM2 36h3v1H2zM6 36h1v1H6zM9 36h1v1H9zM11 36h2v1H11zM14 36h1v1H14zM16 36h3v1H16zM20 36h1v1H20zM22 36h4v1H22zM29 36h1v1H29zM31 36h7v1H31zM0 37h1v1H0zM2 37h3v1H2zM6 37h1v1H6zM9 37h1v1H9zM11 37h1v1H11zM14 37h4v1H14zM20 37h2v1H20zM24 37h1v1H24zM26 37h1v1H26zM28 37h2v1H28zM31 37h3v1H31zM38,37 h3v1H38zM0 38h1v1H0zM2 38h3v1H2zM6 38h1v1H6zM8 38h1v1H8zM12 38h3v1H12zM16 38h2v1H16zM21 38h1v1H21zM26 38h2v1H26zM29 38h2v1H29zM32 38h2v1H32zM36 38h1v1H36zM38,38 h3v1H38zM0 39h1v1H0zM6 39h1v1H6zM10 39h2v1H10zM15 39h2v1H15zM19 39h1v1H19zM25 39h2v1H25zM30 39h2v1H30zM33 39h1v1H33zM35 39h3v1H35zM0 40h7v1H0zM9 40h2v1H9zM13 40h4v1H13zM22 40h1v1H22zM24 40h1v1H24zM26 40h1v1H26zM29 40h1v1H29zM32 40h3v1H32zM36 40h1v1H36zM38 40h1v1H38zM40,40 h1v1H40z"
+              fill="#000000"
+            />
+          </svg>
+        </div>
+        <div>
+          <div>
+            <div>
+              <div>
+                Precinct
+              </div>
+              <strong>
+                District 5
+              </strong>
+            </div>
+            <div>
+              <div>
+                Ballot Style
+              </div>
+              <strong>
+                5
+              </strong>
+            </div>
+            <div>
+              <div>
+                Ballot ID
+              </div>
+              <strong
+                class="sc-gsDJrp fUIxJs"
+              >
+                Asdf1234Asdf12
+              </strong>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="sc-pVTma NVkwn"
+    >
+      <div
+        class="sc-jrQzUz jgYCbw"
+      >
+        <div
+          class="sc-kDThTU gkFLxJ"
+        >
+          <div
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+          >
+            <h3>
+              President
+            </h3>
+            <p
+              class="sc-bdvvaa eSpfPW"
+            >
+              <span
+                class="sc-bdvvaa hsgYyE"
+              >
+                WRITE-IN
+              </span>
+               
+              (write-in)
+            </p>
+          </div>
+        </div>
+        <div
+          class="sc-kDThTU gkFLxJ"
+        >
+          <div
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+          >
+            <h3>
+              Senate 
+            </h3>
+            <p
+              class="sc-bdvvaa eSpfPW"
+            >
+              <span
+                class="sc-bdvvaa hsgYyE"
+              >
+                WRITE-IN
+              </span>
+               
+              (write-in)
+            </p>
+          </div>
+        </div>
+        <div
+          class="sc-kDThTU gkFLxJ"
+        >
+          <div
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+          >
+            <h3>
+              1st Congressional District
+            </h3>
+            <p
+              class="sc-bdvvaa eSpfPW"
+            >
+              <span
+                class="sc-bdvvaa hsgYyE"
+              >
+                Antonia Eliason
+              </span>
+               
+              / Democrat
+            </p>
+          </div>
+        </div>
+        <div
+          class="sc-kDThTU gkFLxJ"
+        >
+          <div
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+          >
+            <h3>
+              Supreme Court District 3(Northern) Position 3
+            </h3>
+            <p
+              class="sc-bdvvaa eSpfPW"
+            >
+              <span
+                class="sc-bdvvaa hsgYyE"
+              >
+                Josiah Dennis Coleman
+              </span>
+               
+              / Nonpartisan
+            </p>
+          </div>
+        </div>
+        <div
+          class="sc-kDThTU gkFLxJ"
+        >
+          <div
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+          >
+            <h3>
+              Election Commissioner 05
+            </h3>
+            <p
+              class="sc-bdvvaa eSpfPW"
+            >
+              <span
+                class="sc-bdvvaa hsgYyE"
+              >
+                Ouida A Loper
+              </span>
+               
+              / Independent
+            </p>
+          </div>
+        </div>
+        <div
+          class="sc-kDThTU gkFLxJ"
+        >
+          <div
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+          >
+            <h3>
+              School Board 05
+            </h3>
+            <p
+              class="sc-bdvvaa eSpfPW"
+            >
+              <span
+                class="sc-bdvvaa hsgYyE"
+              >
+                WRITE-IN
+              </span>
+               
+              (write-in)
+            </p>
+          </div>
+        </div>
+        <div
+          class="sc-kDThTU gkFLxJ"
+        >
+          <div
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+          >
+            <h3>
+              Ballot Measure 2
+House Concurrent Resolution No. 47
+            </h3>
+            <p
+              class="sc-bdvvaa kdHchw"
+            >
+              No
+               
+            </p>
+          </div>
+        </div>
+        <div
+          class="sc-kDThTU gkFLxJ"
+        >
+          <div
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+          >
+            <h3>
+              Ballot Measure 3
+House Bill 1796 - Flag Referendum
+            </h3>
+            <p
+              class="sc-bdvvaa kdHchw"
+            >
+              No
+               
+            </p>
+          </div>
+        </div>
+        <div
+          class="sc-kDThTU gkFLxJ"
+        >
+          <div
+            class="sc-hKwCoD sc-iqsfdx eDCLhO vjIZd"
+          >
+            <h3>
+              Ballot Measure 1
+            </h3>
+            <p
+              class="sc-bdvvaa kdHchw"
+            >
+              •
+               
+              AGAINST BOTH Initiative Measure No. 65 AND Alternative Measure No. 65 A
+            </p>
+            <p
+              class="sc-bdvvaa kdHchw"
+            >
+              •
+               
+              FOR Alternative Measure 65 A
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 `;
 
 exports[`L&A (logic and accuracy) flow 3`] = `
-<div
-  aria-hidden="true"
->
-  <div
-    class="sc-cNKpQo ecBuSt"
-  >
-    <nav
-      class="sc-bdfBwQ gqAMTS"
-    >
-      <div
-        class="sc-gsTCUz iTmZjl"
-      >
-        <div
-          class="sc-dlfnbm VzbFO"
-        >
-          Voting
-          <span>
-            Works
-          </span>
-        </div>
-        <div
-          class="sc-hKgILt"
-        >
-          VxAdmin
-        </div>
-      </div>
-      <div
-        class="sc-eCssSg kiVrGp"
-      >
-        <button
-          class="sc-egiSv dHUDgX"
-          role="option"
-          type="button"
-        >
-          Ballots
-        </button>
-        <button
-          class="sc-egiSv dHUDgX active-section"
-          role="option"
-          type="button"
-        >
-          L&A
-        </button>
-        <button
-          class="sc-egiSv dHUDgX"
-          role="option"
-          type="button"
-        >
-          Tally
-        </button>
-        <button
-          class="sc-egiSv dHUDgX"
-          role="option"
-          type="button"
-        >
-          Write-Ins
-        </button>
-        <button
-          class="sc-egiSv dHUDgX"
-          role="option"
-          type="button"
-        >
-          Reports
-        </button>
-      </div>
-      <div
-        class="sc-jSgupP eMSuCK"
-      >
-        <button
-          class="sc-egiSv feoAXt"
-          type="button"
-        >
-          Lock Machine
-        </button>
-        <button
-          class="sc-egiSv feoAXt"
-          type="button"
-        >
-          Eject USB
-        </button>
-      </div>
-    </nav>
-    <main
-      class="sc-ezbkgU eLPlep"
-    >
-      <div
-        class="sc-hKwCoD kuXZyB"
-      >
-        <h1>
-          Precinct L&A Packages
-        </h1>
-        <p>
-          Print the L&A Packages for all precincts, or for a specific precinct, by selecting a button below.
-        </p>
-        <p
-          class="sc-iwjezw jqTYVd"
-        />
-        <p>
-          Each Precinct L&A Package prints:
-        </p>
-        <ol>
-          <li>
-            A Precinct Tally Report — the expected results of the precinct.
-          </li>
-          <li>
-            Pre-voted VxMark test ballots.
-          </li>
-          <li>
-            Pre-voted hand-marked test ballots.
-          </li>
-          <li>
-            Two blank hand-marked test ballots — one remains blank, one is hand-marked by an election official to replace a pre-voted hand-marked test ballot.
-          </li>
-          <li>
-            One overvoted hand-marked test ballot.
-          </li>
-        </ol>
-        <p
-          class="sc-iwjezw jqTYVd"
-        />
-      </div>
-      <p>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          <strong>
-            Print Packages for All Precincts
-          </strong>
-        </button>
-      </p>
-      <div
-        class="sc-fFubgz exWqux"
-      >
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          Bywy
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          Chester
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          District 5
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          East Weir
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          Fentress
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          French Camp
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          Hebron
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          Kenego
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          Panhandle
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          Reform
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          Sherwood
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          Southwest Ackerman
-        </button>
-        <button
-          class="sc-egiSv jleLtH"
-          type="button"
-        >
-          West Weir
-        </button>
-      </div>
-    </main>
-    <div
-      class="sc-fKVsgm fFwtSv"
-      data-testid="electionInfoBar"
-    >
-      <div
-        class="sc-hKwCoD gvrBrR"
-        style="flex: 1;"
-      >
-        <strong>
-          Mock General Election Choctaw 2020
-        </strong>
-         —
-         
-        <span
-          class="sc-gsDJrp fUIxJs"
-        >
-          Aug 26, 2020
-        </span>
-        <div
-          class="sc-bdvvaa iybVtA"
-        >
-          <span
-            class="sc-gsDJrp fUIxJs"
-          >
-            Choctaw County
-            ,
-          </span>
-           
-          <span
-            class="sc-gsDJrp fUIxJs"
-          >
-            State of Mississippi
-          </span>
-        </div>
-      </div>
-      <div
-        class="sc-hKwCoD fZQsN"
-      >
-        <div
-          class="sc-bdvvaa bmZoEB"
-        >
-          Software Version
-        </div>
-        <strong>
-          TEST
-        </strong>
-      </div>
-      <div
-        class="sc-hKwCoD fZQsN"
-      >
-        <div
-          class="sc-bdvvaa bmZoEB"
-        >
-          Machine ID
-        </div>
-        <strong>
-          0000
-        </strong>
-      </div>
-      <div
-        class="sc-hKwCoD fZQsN"
-      >
-        <div
-          class="sc-bdvvaa iybVtA"
-        >
-          Election ID
-        </div>
-        <strong>
-          b1e83122e8
-        </strong>
-      </div>
-    </div>
+<div>
+  <div>
+    <h1>
+      Mocked HMPB
+    </h1>
+    <p>
+      Election: 
+      Mock General Election Choctaw 2020
+    </p>
+    <p>
+      Ballot Style: 
+      5
+    </p>
+    <p>
+      Precinct: 
+      District 5
+    </p>
+    <p>
+      Absentee: 
+      false
+    </p>
+    <p>
+      Ballot Mode: 
+      test
+    </p>
   </div>
   <div>
-    <div>
-      <h1>
-        Mocked HMPB
-      </h1>
-      <p>
-        Election: 
-        Mock General Election Choctaw 2020
-      </p>
-      <p>
-        Ballot Style: 
-        5
-      </p>
-      <p>
-        Precinct: 
-        6522
-      </p>
-      <p>
-        Absentee: 
-        false
-      </p>
-      <p>
-        Ballot Mode: 
-        test
-      </p>
-    </div>
-    <div>
-      <h1>
-        Mocked HMPB
-      </h1>
-      <p>
-        Election: 
-        Mock General Election Choctaw 2020
-      </p>
-      <p>
-        Ballot Style: 
-        5
-      </p>
-      <p>
-        Precinct: 
-        6522
-      </p>
-      <p>
-        Absentee: 
-        false
-      </p>
-      <p>
-        Ballot Mode: 
-        test
-      </p>
-    </div>
-    <div>
-      <h1>
-        Mocked HMPB
-      </h1>
-      <p>
-        Election: 
-        Mock General Election Choctaw 2020
-      </p>
-      <p>
-        Ballot Style: 
-        5
-      </p>
-      <p>
-        Precinct: 
-        6522
-      </p>
-      <p>
-        Absentee: 
-        false
-      </p>
-      <p>
-        Ballot Mode: 
-        test
-      </p>
-    </div>
-    <div>
-      <h1>
-        Mocked HMPB
-      </h1>
-      <p>
-        Election: 
-        Mock General Election Choctaw 2020
-      </p>
-      <p>
-        Ballot Style: 
-        5
-      </p>
-      <p>
-        Precinct: 
-        6522
-      </p>
-      <p>
-        Absentee: 
-        false
-      </p>
-      <p>
-        Ballot Mode: 
-        test
-      </p>
-    </div>
-    <div>
-      <h1>
-        Mocked HMPB
-      </h1>
-      <p>
-        Election: 
-        Mock General Election Choctaw 2020
-      </p>
-      <p>
-        Ballot Style: 
-        5
-      </p>
-      <p>
-        Precinct: 
-        6522
-      </p>
-      <p>
-        Absentee: 
-        false
-      </p>
-      <p>
-        Ballot Mode: 
-        test
-      </p>
-    </div>
-    <div>
-      <h1>
-        Mocked HMPB
-      </h1>
-      <p>
-        Election: 
-        Mock General Election Choctaw 2020
-      </p>
-      <p>
-        Ballot Style: 
-        5
-      </p>
-      <p>
-        Precinct: 
-        6522
-      </p>
-      <p>
-        Absentee: 
-        false
-      </p>
-      <p>
-        Ballot Mode: 
-        test
-      </p>
-    </div>
-    <div>
-      <h1>
-        Mocked HMPB
-      </h1>
-      <p>
-        Election: 
-        Mock General Election Choctaw 2020
-      </p>
-      <p>
-        Ballot Style: 
-        5
-      </p>
-      <p>
-        Precinct: 
-        6522
-      </p>
-      <p>
-        Absentee: 
-        false
-      </p>
-      <p>
-        Ballot Mode: 
-        test
-      </p>
-    </div>
+    <h1>
+      Mocked HMPB
+    </h1>
+    <p>
+      Election: 
+      Mock General Election Choctaw 2020
+    </p>
+    <p>
+      Ballot Style: 
+      5
+    </p>
+    <p>
+      Precinct: 
+      District 5
+    </p>
+    <p>
+      Absentee: 
+      false
+    </p>
+    <p>
+      Ballot Mode: 
+      test
+    </p>
   </div>
-  <div />
+  <div>
+    <h1>
+      Mocked HMPB
+    </h1>
+    <p>
+      Election: 
+      Mock General Election Choctaw 2020
+    </p>
+    <p>
+      Ballot Style: 
+      5
+    </p>
+    <p>
+      Precinct: 
+      District 5
+    </p>
+    <p>
+      Absentee: 
+      false
+    </p>
+    <p>
+      Ballot Mode: 
+      test
+    </p>
+  </div>
+  <div>
+    <h1>
+      Mocked HMPB
+    </h1>
+    <p>
+      Election: 
+      Mock General Election Choctaw 2020
+    </p>
+    <p>
+      Ballot Style: 
+      5
+    </p>
+    <p>
+      Precinct: 
+      District 5
+    </p>
+    <p>
+      Absentee: 
+      false
+    </p>
+    <p>
+      Ballot Mode: 
+      test
+    </p>
+  </div>
+  <div>
+    <h1>
+      Mocked HMPB
+    </h1>
+    <p>
+      Election: 
+      Mock General Election Choctaw 2020
+    </p>
+    <p>
+      Ballot Style: 
+      5
+    </p>
+    <p>
+      Precinct: 
+      District 5
+    </p>
+    <p>
+      Absentee: 
+      false
+    </p>
+    <p>
+      Ballot Mode: 
+      test
+    </p>
+  </div>
+  <div>
+    <h1>
+      Mocked HMPB
+    </h1>
+    <p>
+      Election: 
+      Mock General Election Choctaw 2020
+    </p>
+    <p>
+      Ballot Style: 
+      5
+    </p>
+    <p>
+      Precinct: 
+      District 5
+    </p>
+    <p>
+      Absentee: 
+      false
+    </p>
+    <p>
+      Ballot Mode: 
+      test
+    </p>
+  </div>
+  <div>
+    <h1>
+      Mocked HMPB
+    </h1>
+    <p>
+      Election: 
+      Mock General Election Choctaw 2020
+    </p>
+    <p>
+      Ballot Style: 
+      5
+    </p>
+    <p>
+      Precinct: 
+      District 5
+    </p>
+    <p>
+      Absentee: 
+      false
+    </p>
+    <p>
+      Ballot Mode: 
+      test
+    </p>
+  </div>
 </div>
 `;
 

--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -7,7 +7,6 @@ import {
   getByTestId as domGetByTestId,
   getByText as domGetByText,
   getAllByRole as domGetAllByRole,
-  getAllByText as domGetAllByText,
   act,
   within,
 } from '@testing-library/react';
@@ -392,6 +391,10 @@ test('L&A (logic and accuracy) flow', async () => {
   );
 
   // Test printing full test deck tally
+  userEvent.click(screen.getByText('L&A'));
+  userEvent.click(screen.getByText('Print Full Test Deck Tally Report'));
+
+  await screen.findByText('Printing');
   const expectedTallies: { [tally: string]: number } = {
     '104': 10,
     '52': 12,
@@ -400,20 +403,15 @@ test('L&A (logic and accuracy) flow', async () => {
     '8': 3,
     '4': 2,
   };
-  userEvent.click(screen.getByText('L&A'));
-  userEvent.click(screen.getByText('Print Full Test Deck Tally Report'));
-  await waitFor(() => {
-    const fullTestDeckTallyReport = screen.getByTestId(
-      'full-test-deck-tally-report'
+  await expectPrint((printedElement, printOptions) => {
+    printedElement.getByText(
+      'Test Deck Mock General Election Choctaw 2020 Tally Report'
     );
     for (const [tally, times] of Object.entries(expectedTallies)) {
-      expect(domGetAllByText(fullTestDeckTallyReport, tally).length).toEqual(
-        times
-      );
+      expect(printedElement.getAllByText(tally).length).toEqual(times);
     }
+    expect(printOptions).toMatchObject({ sides: 'one-sided' });
   });
-  await screen.findByText('Printing');
-  expect(printer.print).toHaveBeenCalledTimes(1);
   expect(logger.log).toHaveBeenCalledWith(
     LogEventId.TestDeckTallyReportPrinted,
     expect.any(String),

--- a/frontends/election-manager/src/components/__mocks__/hand_marked_paper_ballot.tsx
+++ b/frontends/election-manager/src/components/__mocks__/hand_marked_paper_ballot.tsx
@@ -1,3 +1,4 @@
+import { getPrecinctById } from '@votingworks/types';
 import React, { useEffect } from 'react';
 import { HandMarkedPaperBallotProps } from '../hand_marked_paper_ballot';
 
@@ -15,12 +16,14 @@ export function HandMarkedPaperBallot({
     onRendered?.(0);
   }, [ballotStyleId, election, electionHash, locales, onRendered, precinctId]);
 
+  const precinct = getPrecinctById({ election, precinctId });
+
   return (
     <div>
       <h1>Mocked HMPB</h1>
       <p>Election: {election.title}</p>
       <p>Ballot Style: {ballotStyleId}</p>
-      <p>Precinct: {precinctId}</p>
+      <p>Precinct: {precinct?.name}</p>
       <p>Absentee: {Boolean(isAbsentee).toString()}</p>
       <p>Ballot Mode: {ballotMode}</p>
     </div>

--- a/frontends/election-manager/src/components/full_test_deck_tally_report_button.tsx
+++ b/frontends/election-manager/src/components/full_test_deck_tally_report_button.tsx
@@ -2,11 +2,11 @@ import React, { useContext, useCallback } from 'react';
 import { assert } from '@votingworks/utils';
 import { LogEventId } from '@votingworks/logging';
 
-import { isElectionManagerAuth } from '@votingworks/ui';
+import { isElectionManagerAuth, printElement } from '@votingworks/ui';
 import { AppContext } from '../contexts/app_context';
-import { DeprecatedPrintButton } from './deprecated_print_button';
 import { TestDeckTallyReport } from './test_deck_tally_report';
 import { generateTestDeckBallots } from '../utils/election';
+import { PrintButton } from './print_button';
 
 export function FullTestDeckTallyReportButton(): JSX.Element {
   const { auth, electionDefinition, logger } = useContext(AppContext);
@@ -16,46 +16,37 @@ export function FullTestDeckTallyReportButton(): JSX.Element {
   assert(electionDefinition);
   const { election } = electionDefinition;
 
-  const ballots = generateTestDeckBallots({ election });
-  const votes = ballots.map((b) => b.votes);
+  const printFullTestDeckTallyReport = useCallback(async () => {
+    try {
+      const ballots = generateTestDeckBallots({ election });
+      const votes = ballots.map((b) => b.votes);
+      // Full test deck tallies should be 4 times that of a single test deck because
+      // it counts scanning 2 test decks (BMD + HMPB) twice (VxScan + VxCentralScan)
+      const fullTestDeckTallyReport = (
+        <TestDeckTallyReport
+          election={election}
+          votes={[...votes, ...votes, ...votes, ...votes]}
+        />
+      );
 
-  const afterPrint = useCallback(() => {
-    void logger.log(LogEventId.TestDeckTallyReportPrinted, userRole, {
-      disposition: 'success',
-      message: `User printed the full test deck tally report`,
-    });
-  }, [logger, userRole]);
-
-  const afterPrintError = useCallback(
-    (errorMessage: string) => {
-      void logger.log(LogEventId.TestDeckTallyReportPrinted, userRole, {
+      await printElement(fullTestDeckTallyReport, { sides: 'one-sided' });
+      await logger.log(LogEventId.TestDeckTallyReportPrinted, userRole, {
+        disposition: 'success',
+        message: `User printed the full test deck tally report`,
+      });
+    } catch (error) {
+      assert(error instanceof Error);
+      await logger.log(LogEventId.TestDeckTallyReportPrinted, userRole, {
         disposition: 'failure',
-        errorMessage,
-        message: `Error printing the full test deck tally report: ${errorMessage}`,
+        message: `Error printing the full test deck tally report: ${error.message}`,
         result: 'User shown error.',
       });
-    },
-    [logger, userRole]
-  );
-
-  // Full test deck tallies should be 4 times that of a single test deck because
-  // it counts scanning 2 test decks (BMD + HMPB) twice (VxScan + VxCentralScan)
-  const fullTestDeckTallyReport = (
-    <TestDeckTallyReport
-      election={election}
-      votes={[...votes, ...votes, ...votes, ...votes]}
-    />
-  );
+    }
+  }, [election, logger, userRole]);
 
   return (
-    <DeprecatedPrintButton
-      afterPrint={afterPrint}
-      afterPrintError={afterPrintError}
-      sides="one-sided"
-      printTarget={fullTestDeckTallyReport}
-      printTargetTestId="full-test-deck-tally-report"
-    >
+    <PrintButton print={printFullTestDeckTallyReport}>
       Print Full Test Deck Tally Report
-    </DeprecatedPrintButton>
+    </PrintButton>
   );
 }

--- a/frontends/election-manager/src/components/print_all_ballots_button.test.tsx
+++ b/frontends/election-manager/src/components/print_all_ballots_button.test.tsx
@@ -13,7 +13,7 @@ import {
   hasTextAcrossElements,
   simulateErrorOnNextPrint,
 } from '@votingworks/test-utils';
-import { BallotStyleId, PrecinctId } from '@votingworks/types';
+import { BallotStyleId } from '@votingworks/types';
 import {
   renderInAppContext,
   renderRootElement,
@@ -111,24 +111,24 @@ test('print sequence proceeds as expected', async () => {
     )
   );
 
-  const expectedBallotStyles: Array<[string, PrecinctId, BallotStyleId]> = [
-    ['Precinct 1', 'precinct-1', '1M'],
-    ['Precinct 1', 'precinct-1', '2F'],
-    ['Precinct 2', 'precinct-2', '1M'],
-    ['Precinct 2', 'precinct-2', '2F'],
+  const expectedBallotStyles: Array<[string, BallotStyleId]> = [
+    ['Precinct 1', '1M'],
+    ['Precinct 1', '2F'],
+    ['Precinct 2', '1M'],
+    ['Precinct 2', '2F'],
   ];
 
   for (const [i, expectedBallotStyle] of expectedBallotStyles.entries()) {
     await within(modal).findByText(`Printing Official Ballot (${i + 1} of 4)`);
     within(modal).getByText(
       hasTextAcrossElements(
-        `Precinct: ${expectedBallotStyle[0]}, Ballot Style: ${expectedBallotStyle[2]}`
+        `Precinct: ${expectedBallotStyle[0]}, Ballot Style: ${expectedBallotStyle[1]}`
       )
     );
     await expectPrint((printedElement, printOptions) => {
       printedElement.getByText('Mocked HMPB');
-      printedElement.getByText(`Ballot Style: ${expectedBallotStyle[2]}`);
-      printedElement.getByText(`Precinct: ${expectedBallotStyle[1]}`);
+      printedElement.getByText(`Ballot Style: ${expectedBallotStyle[1]}`);
+      printedElement.getByText(`Precinct: ${expectedBallotStyle[0]}`);
       expect(printOptions).toMatchObject({
         sides: 'two-sided-long-edge',
         copies: 1,

--- a/frontends/election-manager/src/screens/print_test_deck_screen.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.tsx
@@ -1,11 +1,11 @@
-import React, { useState, useContext, useCallback, useEffect } from 'react';
+import React, { useState, useContext, useCallback } from 'react';
 import { Admin } from '@votingworks/api';
 import {
   BallotPaperSize,
   Election,
   ElectionDefinition,
+  ElementWithCallback,
   getPrecinctById,
-  Precinct,
   PrecinctId,
 } from '@votingworks/types';
 import { assert, sleep } from '@votingworks/utils';
@@ -19,6 +19,8 @@ import {
   isElectionManagerAuth,
   isSystemAdministratorAuth,
   HorizontalRule,
+  printElement,
+  printElementWhenReady,
 } from '@votingworks/ui';
 
 import { AppContext } from '../contexts/app_context';
@@ -36,7 +38,6 @@ import {
   getBallotLayoutPageSize,
   getBallotLayoutPageSizeReadableString,
 } from '../utils/get_ballot_layout_page_size';
-import { PrinterNotConnectedModal } from '../components/printer_not_connected_modal';
 
 export const ONE_SIDED_PAGE_PRINT_TIME_MS = 3000;
 export const TWO_SIDED_PAGE_PRINT_TIME_MS = 5000;
@@ -45,21 +46,14 @@ export const LAST_PRINT_JOB_SLEEP_MS = 5000;
 interface PrecinctTallyReportProps {
   election: Election;
   precinctId: PrecinctId;
-  onRendered: (numPages: number) => void;
 }
 
 function PrecinctTallyReport({
   election,
   precinctId,
-  onRendered,
 }: PrecinctTallyReportProps): JSX.Element {
   const ballots = generateTestDeckBallots({ election, precinctId });
   const votes = ballots.map((b) => b.votes);
-
-  useEffect(() => {
-    const parties = new Set(election.ballotStyles.map((bs) => bs.partyId));
-    onRendered(Math.max(parties.size, 1));
-  }, [election, precinctId, onRendered]);
 
   // Precinct test deck tallies should be twice that of a single test
   // deck because it counts scanning 2 test decks (BMD + HMPB)
@@ -74,41 +68,26 @@ function PrecinctTallyReport({
 
 interface BmdPaperBallotsProps {
   electionDefinition: ElectionDefinition;
-  onAllRendered: (numBallots: number) => void;
   precinctId: PrecinctId;
 }
 
-function BmdPaperBallots({
+function getBmdPaperBallots({
   electionDefinition,
-  onAllRendered,
   precinctId,
-}: BmdPaperBallotsProps): JSX.Element {
+}: BmdPaperBallotsProps): JSX.Element[] {
   const { election } = electionDefinition;
   const ballots = generateTestDeckBallots({ election, precinctId });
 
-  let numRendered = 0;
-  function onRendered() {
-    numRendered += 1;
-    if (numRendered === ballots.length) {
-      onAllRendered(ballots.length);
-    }
-  }
-
-  return (
-    <div className="print-only">
-      {ballots.map((ballot, i) => (
-        <BmdPaperBallot
-          ballotStyleId={ballot.ballotStyleId}
-          electionDefinition={electionDefinition}
-          isLiveMode={false}
-          key={`ballot-${i}`} // eslint-disable-line react/no-array-index-key
-          precinctId={ballot.precinctId}
-          votes={ballot.votes}
-          onRendered={onRendered}
-        />
-      ))}
-    </div>
-  );
+  return ballots.map((ballot, i) => (
+    <BmdPaperBallot
+      ballotStyleId={ballot.ballotStyleId}
+      electionDefinition={electionDefinition}
+      isLiveMode={false}
+      key={`ballot-${i}`} // eslint-disable-line react/no-array-index-key
+      precinctId={ballot.precinctId}
+      votes={ballot.votes}
+    />
+  ));
 }
 
 function generateHandMarkedPaperBallots({
@@ -133,30 +112,22 @@ interface HandMarkedPaperBallotsProps {
   election: Election;
   electionHash: string;
   precinctId: PrecinctId;
-  onAllRendered: (numBallots: number) => void;
 }
 
-function HandMarkedPaperBallots({
+function getHandMarkedPaperBallotsWithOnReadyCallback({
   election,
   electionHash,
   precinctId,
-  onAllRendered,
-}: HandMarkedPaperBallotsProps): JSX.Element {
-  const ballots = generateHandMarkedPaperBallots({ election, precinctId });
+}: HandMarkedPaperBallotsProps): ElementWithCallback[] {
+  const ballots = generateHandMarkedPaperBallots({
+    election,
+    precinctId,
+  });
 
-  let numRendered = 0;
-  function onRendered() {
-    numRendered += 1;
-    if (numRendered === ballots.length) {
-      onAllRendered(ballots.length);
-    }
-  }
-
-  return (
-    <div>
-      {ballots.map((ballot, i) => (
+  return ballots.map((ballot, i) => {
+    function HandMarkedPaperBallotWithCallback(onReady: VoidFunction) {
+      return (
         <HandMarkedPaperBallot
-          key={`ballot-${i}`} // eslint-disable-line react/no-array-index-key
           ballotStyleId={ballot.ballotStyleId}
           election={election}
           electionHash={electionHash}
@@ -165,43 +136,40 @@ function HandMarkedPaperBallots({
           precinctId={ballot.precinctId}
           locales={{ primary: 'en-US' }}
           votes={ballot.votes}
-          onRendered={() => onRendered()}
+          onRendered={onReady}
+          key={`ballot-${i}`} // eslint-disable-line react/no-array-index-key
         />
-      ))}
-    </div>
-  );
+      );
+    }
+
+    return HandMarkedPaperBallotWithCallback;
+  });
 }
 
-// FIXME: We're using `React.memo` to prevent re-rendering `TestDeckBallots`,
-// but this is explicitly against the React docs: https://reactjs.org/docs/react-api.html#reactmemo
-//
-// > This method only exists as a performance optimization. Do not rely on it to
-// > “prevent” a render, as this can lead to bugs.
-//
-// What happens if we remove `React.memo`? See https://github.com/votingworks/vxsuite/issues/1416.
-// We need to figure out a better way to handle renders that happen at times we
-// don't expect, not by preventing them but by being resilient to them.
-//
-// https://github.com/votingworks/vxsuite/issues/1531
-const BmdPaperBallotsMemoized = React.memo(BmdPaperBallots);
-const HandMarkedPaperBallotsMemoized = React.memo(HandMarkedPaperBallots);
+interface PrintIndex {
+  precinctIds: PrecinctId[];
+  precinctIndex: number;
+  phase: 'PrintingLetter' | 'PaperChangeModal' | 'PrintingNonLetter';
+}
 
 interface PrintingModalProps {
-  advancePrinting: () => void;
-  currentPrecinct: Precinct;
-  election: Election;
-  precinctIds: string[];
   printIndex: PrintIndex;
+  advancePrinting: (initialPrintIndex: PrintIndex) => void;
+  election: Election;
 }
 
 function PrintingModal({
-  advancePrinting,
-  currentPrecinct,
-  election,
-  precinctIds,
   printIndex,
+  advancePrinting,
+  election,
 }: PrintingModalProps): JSX.Element {
-  if (printIndex.component === 'PaperChangeModal') {
+  const currentPrecinct = getPrecinctById({
+    election,
+    precinctId: printIndex.precinctIds[printIndex.precinctIndex],
+  });
+  assert(currentPrecinct);
+
+  if (printIndex.phase === 'PaperChangeModal') {
     return (
       <Modal
         centerContent
@@ -218,7 +186,7 @@ function PrintingModal({
           </Prose>
         }
         actions={
-          <Button onPress={advancePrinting} primary>
+          <Button onPress={() => advancePrinting(printIndex)} primary>
             {getBallotLayoutPageSizeReadableString(election, {
               capitalize: true,
             })}{' '}
@@ -238,15 +206,15 @@ function PrintingModal({
               {`Printing L&A Package for ${currentPrecinct.name}`}
             </Loading>
           </p>
-          {precinctIds.length > 1 && (
+          {printIndex.precinctIds.length > 1 && (
             <p>
               This is package {printIndex.precinctIndex + 1} of{' '}
-              {precinctIds.length}.
+              {printIndex.precinctIds.length}.
             </p>
           )}
           {getBallotLayoutPageSize(election) !== BallotPaperSize.Letter && (
             <p>
-              {printIndex.component === 'HandMarkedPaperBallots'
+              {printIndex.phase === 'PrintingNonLetter'
                 ? `Currently printing ${getBallotLayoutPageSizeReadableString(
                     election
                   )}-size pages.`
@@ -259,237 +227,199 @@ function PrintingModal({
   );
 }
 
-interface PrintIndex {
-  precinctIndex: number;
-  component:
-    | 'TallyReport'
-    | 'BmdPaperBallots'
-    | 'PaperChangeModal'
-    | 'HandMarkedPaperBallots';
-}
-
 export function PrintTestDeckScreen(): JSX.Element {
   const makeCancelable = useCancelablePromise();
-  const { electionDefinition, printer, auth, logger } = useContext(AppContext);
+  const { electionDefinition, auth, logger } = useContext(AppContext);
   assert(electionDefinition);
   assert(isElectionManagerAuth(auth) || isSystemAdministratorAuth(auth)); // TODO(auth) should this check for a specific user type
   const userRole = auth.user.role;
   const { election, electionHash } = electionDefinition;
-  const [precinctIds, setPrecinctIds] = useState<PrecinctId[]>([]);
   const [printIndex, setPrintIndex] = useState<PrintIndex>();
-  const [showPrintingError, setShowPrintingError] = useState(false);
 
   const pageTitle = 'Precinct L&A Packages';
 
-  function generatePrecinctIds(precinctId: PrecinctId): PrecinctId[] {
-    if (precinctId === 'all') {
-      const sortedPrecincts = [...election.precincts].sort((a, b) =>
-        a.name.localeCompare(b.name, undefined, {
-          ignorePunctuation: true,
-        })
-      );
-      return sortedPrecincts.map((p) => p.id);
-    }
-
-    return [precinctId];
-  }
-
-  const advancePrinting = useCallback(() => {
-    if (!printIndex) {
-      return;
-    }
-    const { component, precinctIndex } = printIndex;
-
-    const areHandMarkedPaperBallotsLetterSize =
-      getBallotLayoutPageSize(election) === BallotPaperSize.Letter;
-    const isLastPrecinct = precinctIndex === precinctIds.length - 1;
-
-    let nextPrecinctIndex = precinctIndex;
-    let nextComponent = component;
-    let endPrinting = false;
-
-    // Full collation: If all content is letter-size, print tally reports, BMD paper ballots, and
-    // hand-marked paper ballots grouped by precinct
-    if (areHandMarkedPaperBallotsLetterSize) {
-      if (component === 'TallyReport') {
-        nextComponent = 'BmdPaperBallots';
-      } else if (component === 'BmdPaperBallots') {
-        nextComponent = 'HandMarkedPaperBallots';
-      } else if (component === 'HandMarkedPaperBallots') {
-        if (!isLastPrecinct) {
-          nextPrecinctIndex = precinctIndex + 1;
-          nextComponent = 'TallyReport';
-        } else {
-          endPrinting = true;
-        }
+  const generatePrecinctIds = useCallback(
+    (precinctId: PrecinctId) => {
+      if (precinctId === 'all') {
+        const sortedPrecincts = [...election.precincts].sort((a, b) =>
+          a.name.localeCompare(b.name, undefined, {
+            ignorePunctuation: true,
+          })
+        );
+        return sortedPrecincts.map((p) => p.id);
       }
-    }
 
-    // Best-effort collation: If hand-marked paper ballots are not letter-size, print tally reports
-    // and BMD paper ballots grouped by precinct. Then prompt the election official to change paper,
-    // and print hand-marked paper ballots grouped by precinct
-    if (!areHandMarkedPaperBallotsLetterSize) {
-      if (component === 'TallyReport') {
-        nextComponent = 'BmdPaperBallots';
-      } else if (component === 'BmdPaperBallots') {
-        if (!isLastPrecinct) {
-          nextPrecinctIndex = precinctIndex + 1;
-          nextComponent = 'TallyReport';
-        } else {
-          nextComponent = 'PaperChangeModal';
-        }
-      } else if (component === 'PaperChangeModal') {
-        nextPrecinctIndex = 0;
-        nextComponent = 'HandMarkedPaperBallots';
-      } else if (component === 'HandMarkedPaperBallots') {
-        if (!isLastPrecinct) {
-          nextPrecinctIndex = precinctIndex + 1;
-        } else {
-          endPrinting = true;
-        }
-      }
-    }
+      return [precinctId];
+    },
+    [election.precincts]
+  );
 
-    if (endPrinting) {
-      setPrintIndex(undefined);
-      setPrecinctIds([]);
-    } else {
-      setPrintIndex({
-        precinctIndex: nextPrecinctIndex,
-        component: nextComponent,
+  const printPrecinctTallyReport = useCallback(
+    async (precinctId: PrecinctId) => {
+      const parties = new Set(election.ballotStyles.map((bs) => bs.partyId));
+      const numParties = Math.max(parties.size, 1);
+
+      await printElement(PrecinctTallyReport({ election, precinctId }), {
+        sides: 'one-sided',
       });
-    }
-  }, [election, precinctIds.length, printIndex]);
-
-  async function startPrint(precinctId: PrecinctId) {
-    if (window.kiosk) {
-      const printers = await window.kiosk.getPrinterInfo();
-      if (printers.some((p) => p.connected)) {
-        setPrecinctIds(generatePrecinctIds(precinctId));
-        setPrintIndex({ precinctIndex: 0, component: 'TallyReport' });
-      } else {
-        setShowPrintingError(true);
-        await logger.log(LogEventId.TestDeckPrinted, userRole, {
-          disposition: 'failure',
-          message: `Failed to print L&A Package: no printer connected.`,
-          result: 'User shown error message, asked to try again.',
-          error: 'No printer connected.',
-        });
-      }
-    } else {
-      setPrecinctIds(generatePrecinctIds(precinctId));
-      setPrintIndex({ precinctIndex: 0, component: 'TallyReport' });
-    }
-  }
-
-  const onPrecinctTallyReportRendered = useCallback(
-    async (numPages) => {
-      if (!printIndex) {
-        return;
-      }
-
-      const precinctId = precinctIds[printIndex.precinctIndex];
-      await printer.print({ sides: 'one-sided' });
       await logger.log(LogEventId.TestDeckTallyReportPrinted, userRole, {
         disposition: 'success',
         message: `Test deck tally report printed as part of L&A package for precinct ID: ${precinctId}`,
         precinctId,
       });
-
-      await makeCancelable(sleep(numPages * ONE_SIDED_PAGE_PRINT_TIME_MS));
-      advancePrinting();
+      await makeCancelable(sleep(numParties * ONE_SIDED_PAGE_PRINT_TIME_MS));
     },
-    [
-      advancePrinting,
-      printIndex,
-      printer,
-      logger,
-      userRole,
-      precinctIds,
-      makeCancelable,
-    ]
+    [election, logger, makeCancelable, userRole]
   );
 
-  const onAllBmdPaperBallotsRendered = useCallback(
-    async (numBallots) => {
-      if (!printIndex) {
-        return;
-      }
-
-      const precinctId = precinctIds[printIndex.precinctIndex];
-      await printer.print({ sides: 'one-sided' });
+  const printBmdPaperBallots = useCallback(
+    async (precinctId: PrecinctId) => {
+      const bmdPaperBallots = getBmdPaperBallots({
+        electionDefinition,
+        precinctId,
+      });
+      await printElement(<React.Fragment>{bmdPaperBallots}</React.Fragment>, {
+        sides: 'one-sided',
+      });
       await logger.log(LogEventId.TestDeckPrinted, userRole, {
         disposition: 'success',
         message: `BMD paper ballot test deck printed as part of L&A package for precinct ID: ${precinctId}`,
         precinctId,
       });
-
-      await makeCancelable(sleep(numBallots * ONE_SIDED_PAGE_PRINT_TIME_MS));
-      advancePrinting();
+      await makeCancelable(
+        sleep(bmdPaperBallots.length * ONE_SIDED_PAGE_PRINT_TIME_MS)
+      );
     },
-    [
-      advancePrinting,
-      userRole,
-      logger,
-      makeCancelable,
-      precinctIds,
-      printer,
-      printIndex,
-    ]
+    [electionDefinition, logger, makeCancelable, userRole]
   );
 
-  const onAllHandMarkedPaperBallotsRendered = useCallback(
-    async (numBallots) => {
-      if (!printIndex) {
-        return;
-      }
+  const printHandMarkedPaperBallots = useCallback(
+    async (precinctId: PrecinctId, isLastPrecinct: boolean) => {
+      const handMarkedPaperBallotsWithCallback =
+        getHandMarkedPaperBallotsWithOnReadyCallback({
+          election,
+          electionHash,
+          precinctId,
+        });
+      const numBallots = handMarkedPaperBallotsWithCallback.length;
 
-      const precinctId = precinctIds[printIndex.precinctIndex];
-      await printer.print({ sides: 'two-sided-long-edge' });
+      await printElementWhenReady(
+        (onAllRendered) => {
+          let numRendered = 0;
+          function onRendered() {
+            numRendered += 1;
+            if (numRendered === numBallots) {
+              onAllRendered();
+            }
+          }
+
+          return (
+            <React.Fragment>
+              {handMarkedPaperBallotsWithCallback.map(
+                (handMarkedPaperBallotWithCallback) =>
+                  handMarkedPaperBallotWithCallback(onRendered)
+              )}
+            </React.Fragment>
+          );
+        },
+        {
+          sides: 'two-sided-long-edge',
+        }
+      );
       await logger.log(LogEventId.TestDeckPrinted, userRole, {
         disposition: 'success',
         message: `Hand-marked paper ballot test deck printed as part of L&A package for precinct ID: ${precinctId}`,
         precinctId,
       });
 
-      if (printIndex.precinctIndex < precinctIds.length - 1) {
+      if (!isLastPrecinct) {
         await makeCancelable(sleep(numBallots * TWO_SIDED_PAGE_PRINT_TIME_MS));
       } else {
-        // For the last print job, rather than waiting for all pages to finish printing, free up
+        // For the last precinct, rather than waiting for all pages to finish printing, free up
         // the UI from the print modal earlier
         await makeCancelable(sleep(LAST_PRINT_JOB_SLEEP_MS));
       }
-      advancePrinting();
+    },
+    [election, electionHash, logger, makeCancelable, userRole]
+  );
+
+  const printLetterComponentsOfLogicAndAccuracyPackage = useCallback(
+    async (precinctId: PrecinctId) => {
+      const precinctIds = generatePrecinctIds(precinctId);
+      const areHandMarkedPaperBallotsLetterSize =
+        getBallotLayoutPageSize(election) === BallotPaperSize.Letter;
+
+      for (const [
+        currentPrecinctIndex,
+        currentPrecinctId,
+      ] of precinctIds.entries()) {
+        setPrintIndex({
+          precinctIds,
+          precinctIndex: currentPrecinctIndex,
+          phase: 'PrintingLetter',
+        });
+        await printPrecinctTallyReport(currentPrecinctId);
+        await printBmdPaperBallots(currentPrecinctId);
+
+        // Print HMPB ballots if they are letter-sized
+        if (areHandMarkedPaperBallotsLetterSize) {
+          await printHandMarkedPaperBallots(
+            currentPrecinctId,
+            currentPrecinctIndex === precinctIds.length - 1
+          );
+        }
+      }
+
+      if (areHandMarkedPaperBallotsLetterSize) {
+        // We're done printing because everything was letter-sized
+        setPrintIndex(undefined);
+      } else {
+        // We have to prompt user to replace paper and print the non-letter-sized ballots
+        setPrintIndex({
+          precinctIds,
+          precinctIndex: 0,
+          phase: 'PaperChangeModal',
+        });
+      }
     },
     [
-      advancePrinting,
-      printIndex,
-      printer,
-      logger,
-      userRole,
-      precinctIds,
-      makeCancelable,
+      election,
+      generatePrecinctIds,
+      printBmdPaperBallots,
+      printHandMarkedPaperBallots,
+      printPrecinctTallyReport,
     ]
   );
 
-  const currentPrecinctId = printIndex
-    ? precinctIds[printIndex.precinctIndex]
-    : '';
-  const currentPrecinct: Precinct | undefined = printIndex
-    ? getPrecinctById({
-        election,
-        precinctId: currentPrecinctId,
-      })
-    : undefined;
+  const printNonLetterComponentsOfLogicAndAccuracyPackage = useCallback(
+    async (initialPrintIndex: PrintIndex) => {
+      const { precinctIds } = initialPrintIndex;
+
+      for (const [
+        currentPrecinctIndex,
+        currentPrecinctId,
+      ] of precinctIds.entries()) {
+        setPrintIndex({
+          precinctIds,
+          precinctIndex: currentPrecinctIndex,
+          phase: 'PrintingNonLetter',
+        });
+        await printHandMarkedPaperBallots(
+          currentPrecinctId,
+          currentPrecinctIndex === precinctIds.length - 1
+        );
+      }
+      setPrintIndex(undefined);
+    },
+    [printHandMarkedPaperBallots]
+  );
 
   return (
     <React.Fragment>
-      {printIndex && currentPrecinct && (
+      {printIndex && (
         <PrintingModal
-          advancePrinting={advancePrinting}
-          currentPrecinct={currentPrecinct}
           election={election}
-          precinctIds={precinctIds}
+          advancePrinting={printNonLetterComponentsOfLogicAndAccuracyPackage}
           printIndex={printIndex}
         />
       )}
@@ -519,7 +449,12 @@ export function PrintTestDeckScreen(): JSX.Element {
           <HorizontalRule />
         </Prose>
         <p>
-          <Button onPress={() => startPrint('all')} fullWidth>
+          <Button
+            onPress={() =>
+              printLetterComponentsOfLogicAndAccuracyPackage('all')
+            }
+            fullWidth
+          >
             <strong>Print Packages for All Precincts</strong>
           </Button>
         </p>
@@ -531,37 +466,18 @@ export function PrintTestDeckScreen(): JSX.Element {
               })
             )
             .map((p) => (
-              <Button key={p.id} onPress={() => startPrint(p.id)} fullWidth>
+              <Button
+                key={p.id}
+                onPress={() =>
+                  printLetterComponentsOfLogicAndAccuracyPackage(p.id)
+                }
+                fullWidth
+              >
                 {p.name}
               </Button>
             ))}
         </ButtonList>
       </NavigationScreen>
-      {printIndex?.component === 'TallyReport' && (
-        <PrecinctTallyReport
-          election={election}
-          precinctId={currentPrecinctId}
-          onRendered={onPrecinctTallyReportRendered}
-        />
-      )}
-      {printIndex?.component === 'BmdPaperBallots' && (
-        <BmdPaperBallotsMemoized
-          electionDefinition={electionDefinition}
-          onAllRendered={onAllBmdPaperBallotsRendered}
-          precinctId={precinctIds[printIndex.precinctIndex]}
-        />
-      )}
-      {printIndex?.component === 'HandMarkedPaperBallots' && (
-        <HandMarkedPaperBallotsMemoized
-          election={election}
-          electionHash={electionHash}
-          precinctId={currentPrecinctId}
-          onAllRendered={onAllHandMarkedPaperBallotsRendered}
-        />
-      )}
-      {showPrintingError && (
-        <PrinterNotConnectedModal onClose={() => setShowPrintingError(false)} />
-      )}
     </React.Fragment>
   );
 }

--- a/frontends/election-manager/src/screens/print_test_deck_screen.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.tsx
@@ -38,6 +38,7 @@ import {
   getBallotLayoutPageSize,
   getBallotLayoutPageSizeReadableString,
 } from '../utils/get_ballot_layout_page_size';
+import { PrintButton } from '../components/print_button';
 
 export const ONE_SIDED_PAGE_PRINT_TIME_MS = 3000;
 export const TWO_SIDED_PAGE_PRINT_TIME_MS = 5000;
@@ -449,14 +450,13 @@ export function PrintTestDeckScreen(): JSX.Element {
           <HorizontalRule />
         </Prose>
         <p>
-          <Button
-            onPress={() =>
-              printLetterComponentsOfLogicAndAccuracyPackage('all')
-            }
+          <PrintButton
+            print={() => printLetterComponentsOfLogicAndAccuracyPackage('all')}
+            useDefaultProgressModal={false}
             fullWidth
           >
             <strong>Print Packages for All Precincts</strong>
-          </Button>
+          </PrintButton>
         </p>
         <ButtonList>
           {[...election.precincts]
@@ -466,15 +466,16 @@ export function PrintTestDeckScreen(): JSX.Element {
               })
             )
             .map((p) => (
-              <Button
+              <PrintButton
                 key={p.id}
-                onPress={() =>
+                print={() =>
                   printLetterComponentsOfLogicAndAccuracyPackage(p.id)
                 }
+                useDefaultProgressModal={false}
                 fullWidth
               >
                 {p.name}
-              </Button>
+              </PrintButton>
             ))}
         </ButtonList>
       </NavigationScreen>

--- a/frontends/election-manager/test/util/load_ballot_seal_images.ts
+++ b/frontends/election-manager/test/util/load_ballot_seal_images.ts
@@ -1,8 +1,0 @@
-import { fireEvent, screen } from '@testing-library/react';
-
-export function loadBallotSealImages(): void {
-  const ballotSealImages = screen.getAllByTestId('printed-ballot-seal-image');
-  for (const ballotSealImage of ballotSealImages) {
-    fireEvent.load(ballotSealImage);
-  }
-}


### PR DESCRIPTION
## Overview
Part of #2759. Closes #2289. Uses the new print approach - in which we semantically print an element rather than render an element and print the whole screen (although under the hood, that is what is happening) - for the test deck printing.

## Demo Video or Screenshot
N/A

## Testing Plan 
Updated (expanded!) automated testing and manually tested the letter and non-letter ballot flow.
