### PR TITLE
feat(scan): save backups directly from the backend

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -413,6 +413,28 @@ jobs:
       - store_test_results:
           path: libs/cvr-fixture-generator/reports/
 
+  test-libs-data:
+    executor: nodejs
+    resource_class: xlarge
+    steps:
+      - checkout-and-install
+      - run:
+          name: Build
+          command: |
+            pnpm --dir libs/data build
+      - run:
+          name: Lint
+          command: |
+            pnpm --dir libs/data lint
+      - run:
+          name: Test
+          command: |
+            pnpm --dir libs/data test
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./reports/
+      - store_test_results:
+          path: libs/data/reports/
+
   test-libs-db:
     executor: nodejs
     resource_class: xlarge
@@ -773,6 +795,7 @@ workflows:
       - test-libs-cdf-types-cast-vote-records
       - test-libs-cdf-types-election-event-logging
       - test-libs-cvr-fixture-generator
+      - test-libs-data
       - test-libs-db
       - test-libs-eslint-plugin-vx
       - test-libs-fixtures

--- a/frontends/precinct-scanner/src/components/export_backup_modal.test.tsx
+++ b/frontends/precinct-scanner/src/components/export_backup_modal.test.tsx
@@ -1,27 +1,22 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
-import { electionSampleDefinition } from '@votingworks/fixtures';
-import { Logger, LogSource } from '@votingworks/logging';
+import { Scan } from '@votingworks/api';
 import { fakeKiosk, fakeUsbDrive, Inserted } from '@votingworks/test-utils';
-
-import { err, ok } from '@votingworks/types';
-import { usbstick } from '@votingworks/utils';
+import { typedAs, usbstick } from '@votingworks/utils';
+import fetchMock from 'fetch-mock';
+import jestFetchMock from 'jest-fetch-mock';
 import React from 'react';
-import { mocked } from 'ts-jest/utils';
 import { renderInAppContext } from '../../test/helpers/render_in_app_context';
-import { MachineConfig } from '../config/types';
-import { AppContext } from '../contexts/app_context';
-import { download, DownloadErrorKind } from '../utils/download';
 import { ExportBackupModal } from './export_backup_modal';
-
-jest.mock('../utils/download');
 
 const { UsbDriveStatus } = usbstick;
 
-const machineConfig: MachineConfig = {
-  machineId: '0003',
-  codeVersion: 'TEST',
-};
 const auth = Inserted.fakeElectionManagerAuth();
+
+beforeEach(() => {
+  jestFetchMock.enableMocks();
+  fetchMock.reset();
+  fetchMock.mock();
+});
 
 test('renders loading screen when USB drive is mounting or ejecting in export modal', () => {
   const usbStatuses = [UsbDriveStatus.present, UsbDriveStatus.ejecting];
@@ -67,56 +62,10 @@ test('render no USB found screen when there is not a mounted USB drive', () => {
   }
 });
 
-test('render export modal when a USB drive is mounted as expected and allows custom export', async () => {
-  const mockKiosk = fakeKiosk();
-  window.kiosk = mockKiosk;
-  mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
-  mocked(download).mockResolvedValueOnce(ok());
-
-  const closeFn = jest.fn();
-  const { rerender } = renderInAppContext(
-    <ExportBackupModal
-      onClose={closeFn}
-      usbDrive={{ status: UsbDriveStatus.mounted, eject: jest.fn() }}
-    />,
-    { auth }
-  );
-  screen.getByText('Save Backup');
-  screen.getByText(
-    /A ZIP file will automatically be saved to the default location on the mounted USB drive./
-  );
-  screen.getByAltText('Insert USB Image');
-
-  fireEvent.click(screen.getByText('Custom'));
-  await screen.findByText('Backup Saved');
-  expect(download).toHaveBeenCalledWith('/precinct-scanner/backup');
-
-  fireEvent.click(screen.getByText('Cancel'));
-  expect(closeFn).toHaveBeenCalled();
-  rerender(
-    <AppContext.Provider
-      value={{
-        electionDefinition: electionSampleDefinition,
-        machineConfig,
-        isSoundMuted: false,
-        auth,
-        logger: new Logger(LogSource.VxPrecinctScanFrontend),
-      }}
-    >
-      <ExportBackupModal
-        onClose={closeFn}
-        usbDrive={{ status: UsbDriveStatus.recentlyEjected, eject: jest.fn() }}
-      />
-    </AppContext.Provider>
-  );
-  screen.getByText('USB drive successfully ejected.');
-});
-
 test('render export modal when a USB drive is mounted as expected and allows automatic export', async () => {
   const mockKiosk = fakeKiosk();
   window.kiosk = mockKiosk;
   mockKiosk.getUsbDrives.mockResolvedValue([fakeUsbDrive()]);
-  mocked(download).mockResolvedValueOnce(ok());
 
   const closeFn = jest.fn();
   const ejectFn = jest.fn();
@@ -129,13 +78,15 @@ test('render export modal when a USB drive is mounted as expected and allows aut
   );
   screen.getByText('Save Backup');
 
+  fetchMock.postOnce('/precinct-scanner/backup-to-usb-drive', {
+    status: 200,
+    body: typedAs<Scan.BackupToUsbResponse>({
+      status: 'ok',
+      paths: ['/media/usb-drive-sdb1/backup.zip'],
+    }),
+  });
   fireEvent.click(screen.getByText('Save'));
   await screen.findByText('Backup Saved');
-  expect(download).toHaveBeenCalledWith('/precinct-scanner/backup', {
-    directory:
-      'fake mount point/scanner-backups/franklin-county_general-election_748dc61ad3',
-  });
-  expect(mockKiosk.syncUsbDrive).toHaveBeenCalledWith('fake mount point');
 
   fireEvent.click(screen.getByText('Eject USB'));
   expect(ejectFn).toHaveBeenCalled();
@@ -166,37 +117,7 @@ test('handles no USB drives', async () => {
   expect(closeFn).toHaveBeenCalled();
 });
 
-test('shows a specific error for file writer failure', async () => {
-  const mockKiosk = fakeKiosk();
-  window.kiosk = mockKiosk;
-
-  const closeFn = jest.fn();
-  const { getByText } = renderInAppContext(
-    <ExportBackupModal
-      onClose={closeFn}
-      usbDrive={{ status: UsbDriveStatus.mounted, eject: jest.fn() }}
-    />,
-    { auth }
-  );
-  getByText('Save Backup');
-
-  mockKiosk.getUsbDrives.mockResolvedValueOnce([fakeUsbDrive()]);
-  mocked(download).mockResolvedValueOnce(
-    err({
-      kind: DownloadErrorKind.OpenFailed,
-      path: 'backup.zip',
-      error: new Error('NOPE'),
-    })
-  );
-  fireEvent.click(getByText('Save'));
-  await waitFor(() => getByText('Failed to Save Backup'));
-  getByText(/Unable to write file to save location: backup.zip/);
-
-  fireEvent.click(getByText('Close'));
-  expect(closeFn).toHaveBeenCalled();
-});
-
-test('shows a specific error for fetch failure', async () => {
+test('shows errors from the backend', async () => {
   const mockKiosk = fakeKiosk();
   window.kiosk = mockKiosk;
 
@@ -211,15 +132,16 @@ test('shows a specific error for fetch failure', async () => {
   screen.getByText('Save Backup');
 
   mockKiosk.getUsbDrives.mockResolvedValueOnce([fakeUsbDrive()]);
-  mocked(download).mockResolvedValueOnce(
-    err({
-      kind: DownloadErrorKind.FetchFailed,
-      response: new Response('', { status: 504, statusText: 'Bad Gateway' }),
-    })
-  );
+  fetchMock.postOnce('/precinct-scanner/backup-to-usb-drive', {
+    status: 200,
+    body: typedAs<Scan.BackupToUsbResponse>({
+      status: 'error',
+      errors: [{ type: 'permission-denied', message: 'Permission denied' }],
+    }),
+  });
   fireEvent.click(screen.getByText('Save'));
   await screen.findByText('Failed to Save Backup');
-  screen.getByText('Unable to get backup: FetchFailed (status=Bad Gateway)');
+  screen.getByText('Permission denied');
 
   fireEvent.click(screen.getByText('Close'));
   expect(closeFn).toHaveBeenCalled();

--- a/libs/@types/stream-chopper/package.json
+++ b/libs/@types/stream-chopper/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@types/stream-chopper",
+  "version": "0.0.1-development",
+  "types": "stream-chopper",
+  "dependencies": {
+    "@types/node": "*"
+  }
+}

--- a/libs/@types/stream-chopper/stream-chopper.d.ts
+++ b/libs/@types/stream-chopper/stream-chopper.d.ts
@@ -1,0 +1,113 @@
+import { Readable, Transform, Writable } from 'stream';
+
+declare const split: unique symbol;
+declare const overflow: unique symbol;
+declare const underflow: unique symbol;
+
+type StreamChopperType = typeof split | typeof overflow | typeof underflow;
+
+interface StreamChopperOptions {
+  /**
+   * The maximum number of bytes that can be written to the chopper stream
+   * before a new output stream is emitted (default: `Infinity`).
+   */
+  size?: number;
+
+  /**
+   * The maximum number of milliseconds that an output stream can be in use
+   * before a new output stream is emitted (default: `-1` which means no limit).
+   */
+  time?: number;
+
+  /**
+   * Change the algorithm used to determine how a written chunk that cannot fit into the current output stream should be handled. The following values are possible:
+   * - `StreamChopper.split` - Fit as much data from the chunk as possible into the current stream and write the remainder to the next stream (default).
+   * - `StreamChopper.overflow` - Allow the entire chunk to be written to the current stream. After writing, the stream is ended.
+   * - `StreamChopper.underflow` - End the current output stream and write the entire chunk to the next stream.
+   */
+  type?: StreamChopperType;
+
+  /**
+   * An optional function that returns a transform stream used for transforming
+   * the data in some way (e.g. a zlib Gzip stream). If used, the size option
+   * will count towards the size of the output chunks. This config option cannot
+   * be used together with the `StreamChopper.split` type.
+   */
+  transform?: () => Transform;
+}
+
+/**
+ * Instantiate a `StreamChopper` instance. `StreamChopper` is a writable stream.
+ */
+declare class StreamChopper extends Writable {
+  static split: typeof split;
+  static overflow: typeof overflow;
+  static underflow: typeof underflow;
+
+  constructor(options?: StreamChopperOptions);
+
+  /**
+   * The maximum number of bytes that can be written to the chopper stream
+   * before a new output stream is emitted.
+   *
+   * Use this property to override it with a new value. The new value will take
+   * effect immediately on the current stream.
+   */
+  size: number;
+
+  /**
+   * The maximum number of milliseconds that an output stream can be in use
+   * before a new output stream is emitted.
+   *
+   * Use this property to override it with a new value. The new value will take
+   * effect when the next stream is initialized. To change the current timer,
+   * see `chopper.resetTimer()`.
+   *
+   * Set to -1 for no time limit.
+   */
+  time: number;
+
+  /**
+   * Change the algorithm used to determine how a written chunk that cannot fit into the current output stream should be handled. The following values are possible:
+   * - `StreamChopper.split` - Fit as much data from the chunk as possible into the current stream and write the remainder to the next stream (default).
+   * - `StreamChopper.overflow` - Allow the entire chunk to be written to the current stream. After writing, the stream is ended.
+   * - `StreamChopper.underflow` - End the current output stream and write the entire chunk to the next stream.
+   *
+   * Use this property to override it with a new value. The new value will take effect immediately on the current stream.
+   */
+  type: StreamChopperType;
+
+  /**
+   * Emitted every time a new output stream is ready. You must listen for this
+   * event.
+   */
+  on(
+    event: 'stream',
+    listener: (stream: Readable, next: (error?: unknown) => void) => void
+  ): this;
+  on(event: string, listener: (...args: any[]) => void): this;
+
+  /**
+   * Manually chop the stream. Forces the current output stream to end even if its size limit or time timeout hasn't been reached yet.
+   *
+   * @param callback An optional callback which will be called once the output stream have ended
+   */
+  chop(callback?: (error?: unknown) => void): void;
+
+  /**
+   * Use this function to reset the current timer (configured via the time
+   * config option). Calling this function will force the current timer to start
+   * over.
+   *
+   * If the optional time argument is provided, this value is used as the new
+   * time. This is equivalent to calling:
+   * 
+   * ```ts
+   * chopper.time = time
+   * chopper.resetTimer()
+   * ```
+   */
+  resetTimer(time?: number): void;
+}
+
+export = StreamChopper;

--- a/libs/data/.eslintignore
+++ b/libs/data/.eslintignore
@@ -1,0 +1,3 @@
+build
+coverage
+jest.config.js

--- a/libs/data/.eslintrc.json
+++ b/libs/data/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["plugin:vx/recommended"]
+}

--- a/libs/data/README.md
+++ b/libs/data/README.md
@@ -1,0 +1,9 @@
+# @votingworks/data
+
+Data manipulation utilities for NodeJS in the vxsuite monorepo. This package is
+intended to be used _only_ in NodeJS, not in the browser. Do not use this
+package in any frontends.
+
+## License
+
+GPLv3

--- a/libs/data/jest.config.js
+++ b/libs/data/jest.config.js
@@ -1,0 +1,8 @@
+const shared = require('../../jest.config.shared');
+
+/**
+ * @type {import('@jest/types').Config.InitialOptions}
+ */
+module.exports = {
+  ...shared,
+};

--- a/libs/data/package.json
+++ b/libs/data/package.json
@@ -1,0 +1,77 @@
+{
+  "name": "@votingworks/data",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Data manipulation utilities for NodeJS",
+  "license": "GPL-3.0",
+  "author": "VotingWorks Eng <eng@voting.works>",
+  "main": "build/index.js",
+  "types": "build/index.d.js",
+  "files": [
+    "build"
+  ],
+  "scripts": {
+    "build": "tsc --build tsconfig.build.json",
+    "clean": "rm -rf build tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
+    "lint": "pnpm type-check && eslint .",
+    "lint:fix": "pnpm type-check && eslint . --fix",
+    "pre-commit": "lint-staged",
+    "test": "is-ci test:ci test:watch",
+    "test:ci": "TZ=UTC pnpm build && pnpm test:coverage -- --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:coverage": "TZ=UTC jest --coverage",
+    "test:watch": "TZ=UTC jest --watch",
+    "type-check": "tsc --build"
+  },
+  "lint-staged": {
+    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
+      "prettier --write"
+    ],
+    "*.+(js|jsx|ts|tsx)": [
+      "eslint --quiet --fix"
+    ],
+    "package.json": [
+      "sort-package-json"
+    ]
+  },
+  "dependencies": {
+    "@votingworks/types": "workspace:*",
+    "@votingworks/utils": "workspace:*",
+    "buffer": "^6.0.3",
+    "debug": "^4.3.2",
+    "micromatch": "^4.0.5",
+    "readline": "^1.3.0",
+    "stream-chopper": "^3.0.1",
+    "zod": "3.14.4"
+  },
+  "devDependencies": {
+    "@types/debug": "^4.1.7",
+    "@types/jest": "^27.0.3",
+    "@types/micromatch": "^4.0.2",
+    "@types/node": "16.11.29",
+    "@types/stream-chopper": "workspace:*",
+    "@types/tmp": "^0.2.3",
+    "@typescript-eslint/eslint-plugin": "^5.37.0",
+    "@typescript-eslint/parser": "^5.37.0",
+    "@votingworks/test-utils": "workspace:*",
+    "eslint": "^8.23.1",
+    "eslint-config-prettier": "^8.5.0",
+    "eslint-import-resolver-node": "^0.3.6",
+    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-jest": "^26.1.5",
+    "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-vx": "workspace:*",
+    "fast-check": "^2.18.0",
+    "is-ci-cli": "^2.2.0",
+    "jest": "^27.3.1",
+    "jest-junit": "^14.0.1",
+    "jest-watch-typeahead": "^0.6.4",
+    "lint-staged": "^11.0.0",
+    "memory-streams": "^0.1.3",
+    "prettier": "^2.6.2",
+    "sort-package-json": "^1.50.0",
+    "tmp": "^0.2.1",
+    "ts-jest": "^27.0.7",
+    "typescript": "4.6.3"
+  },
+  "packageManager": "pnpm@5.18.10"
+}

--- a/libs/data/src/exporter.test.ts
+++ b/libs/data/src/exporter.test.ts
@@ -1,0 +1,158 @@
+import { mockOf } from '@votingworks/test-utils';
+import { err, ok } from '@votingworks/types';
+import { Buffer } from 'buffer';
+import { readFile, symlink, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { Readable } from 'stream';
+import { DirResult, dirSync } from 'tmp';
+import { Exporter, ExportFileResult } from './exporter';
+import { getUsbDrives, UsbDrive } from './get_usb_drives';
+import { execFile } from './utils/exec';
+
+jest.mock('./get_usb_drives', (): typeof import('./get_usb_drives') => ({
+  ...jest.requireActual('./get_usb_drives'),
+  getUsbDrives: jest.fn(),
+}));
+
+jest.mock('./utils/exec', (): typeof import('./utils/exec') => ({
+  ...jest.requireActual('./utils/exec'),
+  execFile: jest.fn(),
+}));
+
+const getUsbDrivesMock = mockOf(getUsbDrives);
+const execFileMock = mockOf(execFile);
+const tmpDirs: DirResult[] = [];
+
+function createTmpDir() {
+  const tmpDir = dirSync({ unsafeCleanup: true });
+  tmpDirs.push(tmpDir);
+  return tmpDir.name;
+}
+
+afterEach(() => {
+  for (const tmpDir of tmpDirs) {
+    tmpDir.removeCallback();
+  }
+  tmpDirs.length = 0;
+});
+
+test('exportData with string', async () => {
+  const tmpDir = createTmpDir();
+  const exporter = new Exporter({ allowedExportPatterns: ['/tmp/**'] });
+  const path = join(tmpDir, 'test.txt');
+  const result = await exporter.exportData(path, 'bar');
+  expect(result).toEqual(ok([path]));
+  expect(await readFile(path, 'utf-8')).toEqual('bar');
+});
+
+test('exportData relative path', async () => {
+  const exporter = new Exporter({ allowedExportPatterns: ['/tmp/**'] });
+  expect((await exporter.exportData('test.txt', 'bar')).err()?.message).toMatch(
+    /Path must be absolute/
+  );
+});
+
+test('exportData disallowed path', async () => {
+  const exporter = new Exporter({ allowedExportPatterns: ['/tmp/**'] });
+  expect(
+    (await exporter.exportData('/etc/passwd', 'bar')).err()?.message
+  ).toMatch(/Path is not allowed/);
+});
+
+test('exportData with stream', async () => {
+  const exporter = new Exporter({ allowedExportPatterns: ['/tmp/**'] });
+  const tmpDir = createTmpDir();
+  const path = join(tmpDir, 'test.txt');
+  const result = await exporter.exportData(
+    path,
+    Readable.from(Buffer.of(1, 2, 3))
+  );
+  expect(result).toEqual(ok([path]));
+  expect(await readFile(path)).toEqual(Buffer.of(1, 2, 3));
+});
+
+test('exportData with stream and maximumFileSize', async () => {
+  const exporter = new Exporter({ allowedExportPatterns: ['/tmp/**'] });
+  const tmpDir = createTmpDir();
+  const path = join(tmpDir, 'test.txt');
+  const result = await exporter.exportData(
+    path,
+    Readable.from(Buffer.of(1, 2, 3)),
+    {
+      maximumFileSize: 2,
+    }
+  );
+  expect(result).toEqual(ok([`${path}-part-1`, `${path}-part-2`]));
+  expect(await readFile(`${path}-part-1`)).toEqual(Buffer.of(1, 2));
+  expect(await readFile(`${path}-part-2`)).toEqual(Buffer.of(3));
+});
+
+test('exportData with a symbolic link', async () => {
+  const exporter = new Exporter({ allowedExportPatterns: ['/tmp/**'] });
+  const tmpDir = createTmpDir();
+  const existingPath = join(tmpDir, 'test.txt');
+  const linkPath = join(tmpDir, 'test-link.txt');
+  await writeFile(existingPath, 'bar');
+  await symlink(existingPath, linkPath);
+  const result = await exporter.exportData(linkPath, 'bar');
+  expect(result).toEqual<ExportFileResult>(
+    err({
+      type: 'permission-denied',
+      message: expect.stringContaining('Path must not contain symbolic links'),
+    })
+  );
+});
+
+test('exportDataToUsbDrive with no drives', async () => {
+  getUsbDrivesMock.mockResolvedValueOnce([]);
+  const exporter = new Exporter({ allowedExportPatterns: ['/tmp/**'] });
+  const result = await exporter.exportDataToUsbDrive(
+    'bucket',
+    'test.txt',
+    'bar'
+  );
+  expect(result.err()?.message).toMatch(/No USB drive found/);
+  expect(execFileMock).not.toHaveBeenCalled();
+});
+
+test('exportDataToUsbDrive happy path', async () => {
+  const exporter = new Exporter({ allowedExportPatterns: ['/tmp/**'] });
+  const tmpDir = createTmpDir();
+  const path = join(tmpDir, 'bucket/test.txt');
+  const drive: UsbDrive = {
+    deviceName: '/dev/sdb',
+    mountPoint: tmpDir,
+  };
+  getUsbDrivesMock.mockResolvedValueOnce([drive]);
+  const result = await exporter.exportDataToUsbDrive(
+    'bucket',
+    'test.txt',
+    'bar'
+  );
+  expect(result).toEqual(ok([path]));
+  expect(await readFile(path, 'utf-8')).toEqual('bar');
+  expect(execFileMock).toHaveBeenCalledWith('sync', ['-f', drive.mountPoint]);
+});
+
+test('exportDataToUsbDrive with maximumFileSize', async () => {
+  const exporter = new Exporter({ allowedExportPatterns: ['/tmp/**'] });
+  const tmpDir = createTmpDir();
+  const path = join(tmpDir, 'bucket/test.txt');
+  const drive: UsbDrive = {
+    deviceName: '/dev/sdb',
+    mountPoint: tmpDir,
+  };
+  getUsbDrivesMock.mockResolvedValueOnce([drive]);
+  const result = await exporter.exportDataToUsbDrive(
+    'bucket',
+    'test.txt',
+    'bar',
+    {
+      maximumFileSize: 2,
+    }
+  );
+  expect(result).toEqual(ok([`${path}-part-1`, `${path}-part-2`]));
+  expect(await readFile(`${path}-part-1`, 'utf-8')).toEqual('ba');
+  expect(await readFile(`${path}-part-2`, 'utf-8')).toEqual('r');
+  expect(execFileMock).toHaveBeenCalledWith('sync', ['-f', drive.mountPoint]);
+});

--- a/libs/data/src/exporter.ts
+++ b/libs/data/src/exporter.ts
@@ -1,0 +1,216 @@
+import { z } from 'zod';
+import { err, ok, Result } from '@votingworks/types';
+import { mkdir } from 'fs/promises';
+import { any } from 'micromatch';
+import { isAbsolute, join, normalize, parse } from 'path';
+import { Readable } from 'stream';
+import { lstatSync } from 'fs';
+import { splitToFiles } from './split';
+import { execFile } from './utils/exec';
+import { getUsbDrives } from './get_usb_drives';
+
+/**
+ * The largest file size that can be exported to a USB drive formatted as FAT32.
+ * Since each file size is recorded as a 32-bit unsigned integer, the largest
+ * file size is 4,294,967,295 bytes.
+ */
+const MAXIMUM_FAT32_FILE_SIZE = 2 ** 32 - 1;
+
+/**
+ * Possible export errors.
+ */
+export type ExportDataError =
+  | { type: 'relative-file-path'; message: string }
+  | { type: 'permission-denied'; message: string }
+  | { type: 'file-system-error'; message: string }
+  | { type: 'missing-usb-drive'; message: string };
+
+/**
+ * Schema for {@link ExportDataError}.
+ */
+export const ExportFileErrorSchema: z.ZodSchema<ExportDataError> =
+  z.discriminatedUnion('type', [
+    z.object({
+      type: z.literal('relative-file-path'),
+      message: z.string(),
+    }),
+    z.object({
+      type: z.literal('permission-denied'),
+      message: z.string(),
+    }),
+    z.object({
+      type: z.literal('file-system-error'),
+      message: z.string(),
+    }),
+    z.object({
+      type: z.literal('missing-usb-drive'),
+      message: z.string(),
+    }),
+  ]);
+
+/**
+ * Result of exporting a file to the file system.
+ */
+export type ExportFileResult = Result<string[], ExportDataError>;
+
+/**
+ * Provides data export functionality for writing to the file system.
+ */
+export class Exporter {
+  private readonly allowedExportPatterns: readonly string[];
+
+  /**
+   * Builds an exporter with the given allowed export patterns. To allow all
+   * paths, use `['**']`. Ideally you should be as specific as possible to avoid
+   * writing to unexpected locations.
+   */
+  constructor({
+    allowedExportPatterns,
+  }: {
+    allowedExportPatterns: Iterable<string>;
+  }) {
+    this.allowedExportPatterns = Array.from(allowedExportPatterns);
+  }
+
+  /**
+   * Exports data to a file on the file system. The file and its parent directories
+   * will be created if they do not exist. To split the data into multiple files,
+   * specify a `maximumFileSize` greater than 0.
+   */
+  async exportData(
+    path: string,
+    data: string | NodeJS.ReadableStream,
+    {
+      maximumFileSize,
+    }: {
+      maximumFileSize?: number;
+    } = {}
+  ): Promise<ExportFileResult> {
+    const getSafePathResult = this.getSafePathForWriting(path);
+
+    if (getSafePathResult.isErr()) {
+      return getSafePathResult;
+    }
+
+    const safePath = getSafePathResult.ok();
+    const pathParts = parse(safePath);
+
+    await mkdir(pathParts.dir, { recursive: true });
+
+    return ok(
+      await splitToFiles(
+        typeof data === 'string' ? Readable.from(data) : data,
+        {
+          size: maximumFileSize ?? Infinity,
+          nextPath: (index) =>
+            join(pathParts.dir, `${pathParts.base}-part-${index + 1}`),
+          singleFileName: pathParts.base,
+        }
+      )
+    );
+  }
+
+  /**
+   * Exports data to a USB drive. The file and its parent directories will be
+   * created if they do not exist. By default the data will be split into multiple
+   * files if it is larger than the maximum FAT32 file size. To disable this, set
+   * `maximumFileSize` to `Infinity`.
+   *
+   * Once the promise returned by this function resolves, the data has been
+   * successfully written to the USB drive and it may be safely unmounted.
+   *
+   * @returns a list of the paths of the files that were created, or an error
+   */
+  async exportDataToUsbDrive(
+    bucket: string,
+    name: string,
+    data: string | NodeJS.ReadableStream,
+    {
+      maximumFileSize = MAXIMUM_FAT32_FILE_SIZE,
+    }: {
+      maximumFileSize?: number;
+    } = {}
+  ): Promise<ExportFileResult> {
+    const [usbDrive] = await getUsbDrives();
+
+    if (!usbDrive?.mountPoint) {
+      return err({
+        type: 'missing-usb-drive',
+        message: 'No USB drive found',
+      });
+    }
+
+    const result = await this.exportData(
+      join(usbDrive.mountPoint, bucket, name),
+      data,
+      { maximumFileSize }
+    );
+
+    // Exporting a file might take a while. Ensure the data is flushed to the USB
+    // drive before we consider it safe to remove.
+    await execFile('sync', ['-f', usbDrive.mountPoint]);
+
+    return result;
+  }
+
+  /**
+   * Validates that the path is allowed for export. Checks that the path will not
+   * allow writing outside of the allowed export patterns either via symlinks or
+   * by using `..` to escape the allowed export patterns.
+   */
+  private getSafePathForWriting(path: string): Result<string, ExportDataError> {
+    if (!isAbsolute(path)) {
+      return err({
+        type: 'relative-file-path',
+        message: `Path must be absolute: ${path}`,
+      });
+    }
+
+    const normalizedPath = normalize(path);
+
+    if (!any(normalizedPath, this.allowedExportPatterns)) {
+      return err({
+        type: 'permission-denied',
+        message: `Path is not allowed: ${path}`,
+      });
+    }
+
+    // gets e.g. ['/', '/foo', '/foo/bar'] from '/foo/bar'
+    const allPathPrefixes = normalizedPath
+      .split('/')
+      .map((_, index, parts) =>
+        index === 0 ? '/' : parts.slice(0, index + 1).join('/')
+      );
+
+    for (const pathPrefix of allPathPrefixes) {
+      if (this.isSymbolicLink(pathPrefix)) {
+        return err({
+          type: 'permission-denied',
+          message: `Path must not contain symbolic links: ${path}`,
+        });
+      }
+    }
+
+    return ok(normalizedPath);
+  }
+
+  /**
+   * Determines whether the given path exists and is a symbolic link.
+   */
+  private isSymbolicLink(path: string): boolean {
+    try {
+      return lstatSync(path).isSymbolicLink();
+    } catch (error) {
+      if (
+        error &&
+        'code' in (error as { code?: string }) &&
+        (error as { code: string }).code === 'ENOENT'
+      ) {
+        return false;
+      }
+
+      /* istanbul ignore next */
+      throw error;
+    }
+  }
+}

--- a/libs/data/src/get_usb_drives.test.ts
+++ b/libs/data/src/get_usb_drives.test.ts
@@ -1,0 +1,98 @@
+import { mockOf } from '@votingworks/test-utils';
+import * as fs from 'fs/promises';
+import { getUsbDrives } from './get_usb_drives';
+import { execFile } from './utils/exec';
+
+const execMock = mockOf(execFile);
+const accessMock = fs.access as unknown as jest.MockedFunction<
+  () => Promise<void>
+>;
+const readdirMock = fs.readdir as unknown as jest.MockedFunction<
+  () => Promise<string[]>
+>;
+const readlinkMock = fs.readlink as unknown as jest.MockedFunction<
+  () => Promise<string>
+>;
+
+jest.mock('fs/promises', () => ({
+  access: jest.fn(),
+  readdir: jest.fn(),
+  readlink: jest.fn(),
+}));
+
+jest.mock('./utils/exec', (): typeof import('./utils/exec') => ({
+  ...jest.requireActual('./utils/exec'),
+  execFile: jest.fn(),
+}));
+
+test('getUsbDrives', async () => {
+  readdirMock.mockResolvedValueOnce([
+    'usb-foobar-part23',
+    'notausb-bazbar-part21',
+    'usb-babar-part3',
+  ]);
+  readlinkMock.mockResolvedValueOnce('../../sdb1');
+  readlinkMock.mockResolvedValueOnce('../../sdc1');
+  execMock.mockResolvedValueOnce({
+    stdout: JSON.stringify({
+      blockdevices: [
+        {
+          name: 'sdb1',
+          'maj:min': '8:3',
+          rm: '0',
+          size: '93.9M',
+          ro: '1',
+          type: 'part',
+          mountpoint: '/media/usb-drive-sdb1',
+        },
+      ],
+    }),
+    stderr: '',
+  });
+  execMock.mockResolvedValueOnce({
+    stdout: JSON.stringify({
+      blockdevices: [
+        {
+          name: 'sdc1',
+          'maj:min': '8:3',
+          rm: '0',
+          size: '73.2M',
+          ro: '1',
+          type: 'part',
+          mountpoint: null,
+        },
+      ],
+    }),
+    stderr: '',
+  });
+
+  execMock.mockResolvedValueOnce({
+    stdout: JSON.stringify({
+      filesystems: [
+        {
+          target: '/media/usb-drive-sdb1',
+          source: '/dev/sdb1',
+        },
+        {
+          target: '/media/usb-drive-sdz1',
+          source: '/dev/sdz1',
+        },
+        {
+          target: 'something',
+          source: 'random',
+        },
+      ],
+    }),
+    stderr: '',
+  });
+
+  accessMock.mockResolvedValueOnce().mockRejectedValueOnce(new Error('ENOENT'));
+
+  const devices = await getUsbDrives();
+
+  expect(execMock).toHaveBeenCalledTimes(2);
+  expect(devices).toEqual([
+    { deviceName: 'sdb1', mountPoint: '/media/usb-drive-sdb1' },
+    { deviceName: 'sdc1' },
+  ]);
+});

--- a/libs/data/src/get_usb_drives.ts
+++ b/libs/data/src/get_usb_drives.ts
@@ -1,0 +1,59 @@
+import * as fs from 'fs/promises';
+import { join } from 'path';
+import { execFile } from './utils/exec';
+
+/**
+ * A USB drive.
+ */
+export interface UsbDrive {
+  deviceName: string;
+  mountPoint?: string;
+}
+
+interface BlockDevice {
+  name: string;
+  mountpoint: string | null;
+  partuuid?: string | null;
+}
+
+interface RawDataReturn {
+  blockdevices: [BlockDevice, ...BlockDevice[]];
+}
+
+const DEVICE_PATH_PREFIX = '/dev/disk/by-id/';
+const USB_REGEXP = /^usb(.+)part(.*)$/;
+
+/**
+ * Gets the USB drives connected to the system, whether they are mounted or not.
+ */
+export async function getUsbDrives(): Promise<UsbDrive[]> {
+  // only the USB partitions
+  const devicesById = (await fs.readdir(DEVICE_PATH_PREFIX)).filter((name) =>
+    USB_REGEXP.test(name)
+  );
+
+  // follow the symlinks
+  const devices = await Promise.all(
+    devicesById.map(async (deviceId) =>
+      join(
+        DEVICE_PATH_PREFIX,
+        await fs.readlink(join(DEVICE_PATH_PREFIX, deviceId))
+      )
+    )
+  );
+
+  // get the block device info, including mount point
+  const usbDrives = await Promise.all(
+    devices.map(async (device) => {
+      const { stdout } = await execFile('lsblk', ['-J', '-n', '-l', device]);
+
+      const rawData = JSON.parse(stdout) as RawDataReturn;
+      return {
+        deviceName: rawData.blockdevices[0].name,
+        mountPoint: rawData.blockdevices[0].mountpoint ?? undefined,
+      };
+    })
+  );
+
+  return usbDrives;
+}

--- a/libs/data/src/index.ts
+++ b/libs/data/src/index.ts
@@ -1,0 +1,4 @@
+/* istanbul ignore file */
+export * from './exporter';
+export * from './get_usb_drives';
+export * from './split';

--- a/libs/data/src/split.test.ts
+++ b/libs/data/src/split.test.ts
@@ -1,0 +1,329 @@
+import { zip } from '@votingworks/utils';
+import { Buffer } from 'buffer';
+import { execFileSync } from 'child_process';
+import * as fc from 'fast-check';
+import { readdirSync, readFileSync } from 'fs';
+import { WritableStream } from 'memory-streams';
+import { join } from 'path';
+import { Readable } from 'stream';
+import { DirResult, dirSync } from 'tmp';
+import { split, splitToFiles } from './split';
+
+const tmpDirs: DirResult[] = [];
+
+function createTmpDir() {
+  const tmpDir = dirSync({ unsafeCleanup: true });
+  tmpDirs.push(tmpDir);
+  return tmpDir;
+}
+
+afterEach(() => {
+  for (const tmpDir of tmpDirs) {
+    tmpDir.removeCallback();
+  }
+});
+
+test('empty stream', async () => {
+  const output = new WritableStream();
+  const nextOutput = jest.fn().mockReturnValueOnce(output);
+
+  await split(Readable.from([]), {
+    size: 1,
+    nextOutput,
+  });
+
+  expect(output.toString()).toEqual('');
+  expect(nextOutput).not.toHaveBeenCalled();
+});
+
+test('empty stream to files', async () => {
+  const tmpDir = createTmpDir();
+
+  const result = await splitToFiles(Readable.from([]), {
+    size: 1,
+    nextPath: (index) => join(tmpDir.name, `file-${index}.txt`),
+  });
+
+  expect(result).toEqual([]);
+  expect(readdirSync(tmpDir.name)).toEqual([]);
+});
+
+test('single stream', async () => {
+  const output = new WritableStream();
+  const nextOutput = jest.fn().mockReturnValue(output);
+
+  await split(Readable.from(['a']), {
+    size: 1,
+    nextOutput,
+  });
+
+  expect(output.toString()).toEqual('a');
+  expect(nextOutput).toHaveBeenCalledTimes(1);
+});
+
+test('single file', async () => {
+  const tmpDir = createTmpDir();
+
+  const paths = await splitToFiles(Readable.from(['a']), {
+    size: 1,
+    nextPath: (index) => join(tmpDir.name, `file-${index}.txt`),
+  });
+
+  expect(paths).toEqual([join(tmpDir.name, 'file-0.txt')]);
+  expect(readdirSync(tmpDir.name)).toEqual(['file-0.txt']);
+  expect(readFileSync(join(tmpDir.name, 'file-0.txt'), 'utf-8')).toEqual('a');
+});
+
+test('error in stream', async () => {
+  await expect(
+    split(Readable.from(['a']), {
+      size: 1,
+      nextOutput: () => {
+        throw new Error('error');
+      },
+    })
+  ).rejects.toThrowError('error');
+});
+
+test('error in file stream', async () => {
+  await expect(
+    splitToFiles(Readable.from(['a']), {
+      size: 1,
+      nextPath: () => {
+        throw new Error('error');
+      },
+    })
+  ).rejects.toThrowError('error');
+});
+
+test('single file with singleFileName', async () => {
+  const tmpDir = createTmpDir();
+
+  const paths = await splitToFiles(Readable.from(['a']), {
+    size: 1,
+    nextPath: (index) => join(tmpDir.name, `file-${index}.txt`),
+    singleFileName: 'file.txt',
+  });
+
+  expect(paths).toEqual([join(tmpDir.name, 'file.txt')]);
+  expect(readdirSync(tmpDir.name)).toEqual(['file.txt']);
+  expect(readFileSync(join(tmpDir.name, 'file.txt'), 'utf-8')).toEqual('a');
+});
+
+test('multiple streams', async () => {
+  const output1 = new WritableStream();
+  const output2 = new WritableStream();
+  const nextOutput = jest
+    .fn()
+    .mockReturnValueOnce(output1)
+    .mockReturnValueOnce(output2);
+
+  await split(Readable.from(['abc', 'd']), {
+    size: 2,
+    nextOutput,
+  });
+
+  expect(output1.toString()).toEqual('ab');
+  expect(output2.toString()).toEqual('cd');
+});
+
+test('multiple files', async () => {
+  const tmpDir = createTmpDir();
+  const nextPath = jest
+    .fn()
+    .mockReturnValueOnce(join(tmpDir.name, 'file-0.txt'))
+    .mockReturnValueOnce(join(tmpDir.name, 'file-1.txt'));
+
+  const paths = await splitToFiles(Readable.from(['abc', 'd']), {
+    size: 2,
+    nextPath,
+  });
+
+  expect(paths).toEqual([
+    join(tmpDir.name, 'file-0.txt'),
+    join(tmpDir.name, 'file-1.txt'),
+  ]);
+  expect(readdirSync(tmpDir.name)).toEqual(['file-0.txt', 'file-1.txt']);
+  expect(readFileSync(join(tmpDir.name, 'file-0.txt'), 'utf-8')).toEqual('ab');
+  expect(readFileSync(join(tmpDir.name, 'file-1.txt'), 'utf-8')).toEqual('cd');
+});
+
+test('split streams contain all string data in order', async () => {
+  await fc.assert(
+    fc.asyncProperty(
+      fc.record({
+        size: fc.integer({ min: 1, max: 1000 }),
+        data: fc.array(fc.string(), { minLength: 1 }),
+      }),
+      async ({ size, data }) => {
+        const outputs: WritableStream[] = [];
+        await split(Readable.from(data), {
+          size,
+          nextOutput() {
+            const output = new WritableStream();
+            outputs.push(output);
+            return output;
+          },
+        });
+        const output = outputs.map((o) => o.toString()).join('');
+        expect(output).toEqual(data.join(''));
+      }
+    )
+  );
+});
+
+test('split files contain all string data in order', async () => {
+  await fc.assert(
+    fc.asyncProperty(
+      fc.record({
+        size: fc.integer({ min: 1, max: 1000 }),
+        data: fc.array(fc.string(), { minLength: 1 }),
+      }),
+      async ({ size, data }) => {
+        const tmpDir = createTmpDir();
+        const paths = await splitToFiles(Readable.from(data), {
+          size,
+          nextPath: (index) => join(tmpDir.name, `file-${index}.txt`),
+        });
+        const output = paths
+          .map((path) => readFileSync(path, 'utf-8'))
+          .join('');
+        expect(output).toEqual(data.join(''));
+      }
+    )
+  );
+});
+
+test('split streams contain all Buffer data in order', async () => {
+  await fc.assert(
+    fc.asyncProperty(
+      fc.record({
+        size: fc.integer({ min: 1, max: 1000 }),
+        data: fc.array(fc.uint8Array(), { minLength: 1 }),
+      }),
+      async ({ size, data }) => {
+        const outputs: WritableStream[] = [];
+        await split(Readable.from(data), {
+          size,
+          nextOutput() {
+            const output = new WritableStream();
+            outputs.push(output);
+            return output;
+          },
+        });
+        const output = Buffer.concat(outputs.map((o) => o.toBuffer()));
+        expect(output).toEqual(Buffer.concat(data));
+      }
+    )
+  );
+});
+
+test('split files contain all Buffer data in order', async () => {
+  await fc.assert(
+    fc.asyncProperty(
+      fc.record({
+        size: fc.integer({ min: 1, max: 1000 }),
+        data: fc.array(fc.uint8Array(), { minLength: 1 }),
+      }),
+      async ({ size, data }) => {
+        const tmpDir = createTmpDir();
+        const paths = await splitToFiles(Readable.from(data), {
+          size,
+          nextPath: (index) => join(tmpDir.name, `file-${index}.bin`),
+        });
+        const output = Buffer.concat(paths.map((path) => readFileSync(path)));
+        expect(output).toEqual(Buffer.concat(data));
+      }
+    )
+  );
+});
+
+test('split works like POSIX split', async () => {
+  await fc.assert(
+    fc.asyncProperty(
+      fc.record({
+        size: fc.integer({ min: 1, max: 1000 }),
+        data: fc.array(fc.string({ minLength: 1 }), {
+          minLength: 1,
+        }),
+      }),
+      async ({ size, data }) => {
+        // run split and collect outputs
+        const streamOutputs: WritableStream[] = [];
+        const fileOutputs: string[] = [];
+
+        await split(Readable.from(data), {
+          size,
+          nextOutput() {
+            const output = new WritableStream();
+            streamOutputs.push(output);
+            return output;
+          },
+        });
+
+        // run POSIX split and collect outputs
+        const tmpDir = createTmpDir();
+        execFileSync(
+          'split',
+          ['-b', size.toString(), '-', join(tmpDir.name, 'out-')],
+          { input: data.join('') }
+        );
+
+        for (const file of readdirSync(tmpDir.name).sort()) {
+          fileOutputs.push(readFileSync(join(tmpDir.name, file), 'utf-8'));
+        }
+
+        // compare outputs
+        for (const [fileOutput, output] of zip(fileOutputs, streamOutputs)) {
+          expect(fileOutput).toEqual(output.toString());
+        }
+      }
+    )
+  );
+});
+
+test('splitToFiles works like POSIX split', async () => {
+  await fc.assert(
+    fc.asyncProperty(
+      fc.record({
+        size: fc.integer({ min: 1, max: 1000 }),
+        data: fc.array(fc.string({ minLength: 1 }), {
+          minLength: 1,
+        }),
+      }),
+      async ({ size, data }) => {
+        const tmpDir = createTmpDir();
+        const posixSplitPaths: string[] = [];
+
+        // run split and collect outputs
+        const splitToFilesPaths = await splitToFiles(Readable.from(data), {
+          size,
+          nextPath: (index) => join(tmpDir.name, `splitToFiles-${index}`),
+        });
+
+        // run POSIX split and collect outputs
+        execFileSync(
+          'split',
+          ['-b', size.toString(), '-', join(tmpDir.name, 'posix-split-')],
+          { input: data.join('') }
+        );
+
+        for (const file of readdirSync(tmpDir.name).sort()) {
+          if (file.startsWith('posix-split-')) {
+            posixSplitPaths.push(join(tmpDir.name, file));
+          }
+        }
+
+        // compare outputs
+        for (const [posixSplitPath, splitToFilesPath] of zip(
+          posixSplitPaths,
+          splitToFilesPaths
+        )) {
+          expect(readFileSync(splitToFilesPath, 'utf-8')).toEqual(
+            readFileSync(posixSplitPath, 'utf-8')
+          );
+        }
+      }
+    )
+  );
+});

--- a/libs/data/src/split.ts
+++ b/libs/data/src/split.ts
@@ -1,0 +1,158 @@
+import { assert } from '@votingworks/utils';
+import { createWriteStream, renameSync } from 'fs';
+import { join, parse } from 'path';
+import StreamChopper from 'stream-chopper';
+import { pipeline } from 'stream/promises';
+
+/**
+ * Options for {@link split}.
+ */
+export interface SplitOptions {
+  /**
+   * Number of bytes (for Buffer) or characters (for string) to write to each stream.
+   */
+  size: number;
+
+  /**
+   * Gets the next stream to write to.
+   *
+   * @param index - the number of the stream, i.e. how many have come before
+   */
+  nextOutput(index: number): NodeJS.WritableStream;
+}
+
+/**
+ * Reads a stream and splits it into multiple streams, changing from one to the next
+ * once the current stream reaches the specified size. Resolves once all data has
+ * been written and the last stream is finished.
+ *
+ * @example
+ *
+ * ```ts
+ * await split(process.stdin, {
+ *   size: 100 * 1024 * 1024, // 100MB
+ *   nextOutput: (index) => {
+ *     console.log(`starting stream ${index}`);
+ *     return process.stdout;
+ *   },
+ * });
+ * ```
+ */
+export async function split(
+  input: NodeJS.ReadableStream,
+  options: SplitOptions
+): Promise<void> {
+  // `split` is a thin wrapper around `stream-chopper`. That library creates a
+  // new writable stream and yields readable streams split by size or time. In
+  // contrast, `split` takes a readable stream and asks for a series of writable
+  // streams to write the original stream data to.
+
+  let streamIndex = 0;
+  const chopper = new StreamChopper({
+    size: options.size,
+    type: StreamChopper.split,
+  });
+
+  const finishPromises: Array<Promise<void>> = [];
+  chopper.on('stream', async (stream, next) => {
+    try {
+      const nextOutput = options.nextOutput(streamIndex);
+      streamIndex += 1;
+      const finishPromise = new Promise<void>((resolve) => {
+        nextOutput.on('finish', resolve);
+      });
+      finishPromises.push(finishPromise);
+      await pipeline(stream, nextOutput);
+      next();
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  await pipeline(input, chopper);
+
+  // ensure all streams are finished before returning
+  await Promise.all(finishPromises);
+}
+
+/**
+ * Options for {@link splitToFiles}.
+ */
+export interface SplitToFilesOptions {
+  /**
+   * Number of bytes (for Buffer) or characters (for string) to write to each file.
+   */
+  size: number;
+
+  /**
+   * Gets the path for the next file to write data to.
+   */
+  nextPath(index: number): string;
+
+  /**
+   * Optional filename for when there is a single file to write to. Note that
+   * the data will still be written to a temporary file and then renamed to this
+   * path.
+   */
+  singleFileName?: string;
+}
+
+/**
+ * Splits a stream into multiple files, changing from one to the next once the
+ * current file reaches the specified size. If `singleFileName` is specified and
+ * only a single file is written, the file will be renamed to that value.
+ *
+ * Note that if the stream is empty then no files will be written.
+ *
+ * @returns the paths of the files written to
+ *
+ * @example
+ *
+ * ```ts
+ * // splits a file from a stream into multiple files, each with a maximum size of 1MB
+ * // i.e. large-file.zip-part-00, large-file.zip-part-01, large-file.zip-part-02, etc.
+ * await splitToFiles(fs.createReadStream('large-file.zip'), {
+ *  size: 1024 * 1024, // 1MB per file
+ *  nextPath: (index) => `large-file.zip-part-${index.toString().padStart(2, '0')}`),
+ * });
+ *
+ * // writes data from a stream to a single file if it fits, or splits it into multiple
+ * await splitToFiles(stream, {
+ *   size: 1024 * 1024, // 1MB per file
+ *   nextPath: (index) => `large-file.zip-part-${index.toString().padStart(2, '0')}`,
+ *   singleFileName: 'large-file.zip',
+ * });
+ * ```
+ */
+export async function splitToFiles(
+  input: NodeJS.ReadableStream,
+  options: SplitToFilesOptions
+): Promise<string[]> {
+  assert(options.size > 0, 'size must be greater than 0');
+
+  if (options.singleFileName) {
+    const { dir } = parse(options.singleFileName);
+    assert(!dir, 'singleFileName must not include a directory');
+  }
+
+  const paths: string[] = [];
+
+  await split(input, {
+    ...options,
+    nextOutput(index) {
+      const path = options.nextPath(index);
+      paths.push(path);
+      return createWriteStream(path);
+    },
+  });
+
+  if (options.singleFileName && paths.length === 1) {
+    const path = paths[0] as string;
+    const { dir } = parse(path);
+    const singleFilePath = join(dir, options.singleFileName);
+    renameSync(path, singleFilePath);
+    paths[0] = singleFilePath;
+  }
+
+  return paths;
+}

--- a/libs/data/src/utils/exec.ts
+++ b/libs/data/src/utils/exec.ts
@@ -1,0 +1,13 @@
+// Isolate the system exec from the rest of the code to make it easier to test.
+//
+// If we don't do this, and we mock exec(), other parts of the code,
+// notably related to sqlite3, can't be imported at all, because
+// they use exec under the covers.
+
+import * as cp from 'child_process';
+import { promisify } from 'util';
+
+/**
+ * See `child_process.execFile` for details.
+ */
+export const execFile = promisify(cp.execFile);

--- a/libs/data/tsconfig.build.json
+++ b/libs/data/tsconfig.build.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src", "src/data/*.json"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"],
+  "compilerOptions": {
+    "noEmit": false,
+    "rootDir": "src",
+    "outDir": "build",
+    "declaration": true
+  },
+  "references": [
+    { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
+    { "path": "../../libs/test-utils/tsconfig.build.json" },
+    { "path": "../../libs/fixtures/tsconfig.build.json" },
+    { "path": "../../libs/types/tsconfig.build.json" },
+    { "path": "../../libs/utils/tsconfig.build.json" }
+  ]
+}

--- a/libs/data/tsconfig.json
+++ b/libs/data/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "../../tsconfig.shared.json",
+  "include": ["src", "src/data/*.json"],
+  "exclude": [],
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "composite": true,
+    "noEmit": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "references": [
+    { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
+    { "path": "../../libs/test-utils/tsconfig.build.json" },
+    { "path": "../../libs/fixtures/tsconfig.build.json" },
+    { "path": "../../libs/types/tsconfig.build.json" },
+    { "path": "../../libs/utils/tsconfig.build.json" }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,7 +297,7 @@ importers:
       file-loader: 6.1.1
       fs-extra: 9.1.0
       history: 4.10.1
-      http-proxy-middleware: 1.0.6_debug@4.3.2
+      http-proxy-middleware: 1.0.6
       identity-obj-proxy: 3.0.0
       lodash.camelcase: 4.3.0
       luxon: 1.26.0
@@ -769,7 +769,7 @@ importers:
       fs-extra: 9.1.0
       history: 4.10.1
       html-webpack-plugin: 4.5.0_webpack@4.44.2
-      http-proxy-middleware: 1.0.6_debug@4.3.2
+      http-proxy-middleware: 1.0.6
       i18next: 19.8.4
       identity-obj-proxy: 3.0.0
       js-file-download: 0.4.12
@@ -862,8 +862,8 @@ importers:
       express: 4.18.1
       glob: 8.0.3
       is-ci-cli: 2.1.2
-      jest: 26.6.0_canvas@2.9.1
-      jest-circus: 26.6.0_canvas@2.9.1
+      jest: 26.6.0
+      jest-circus: 26.6.0
       jest-environment-jsdom-sixteen: 1.0.3_canvas@2.9.1
       jest-junit: 14.0.1
       jest-resolve: 26.6.0
@@ -1078,7 +1078,7 @@ importers:
       dotenv-expand: 5.1.0
       events: 3.3.0
       fetch-mock: 9.11.0
-      http-proxy-middleware: 1.0.6_debug@4.3.1
+      http-proxy-middleware: 1.0.6
       i18next: 19.8.4
       jest-fetch-mock: 3.0.3
       js-file-download: 0.4.12
@@ -1367,6 +1367,11 @@ importers:
       rxjs: ^6.6.6
   libs/@types/node-quirc:
     specifiers: {}
+  libs/@types/stream-chopper:
+    dependencies:
+      '@types/node': 18.8.0
+    specifiers:
+      '@types/node': '*'
   libs/@types/zip-stream:
     dependencies:
       '@types/compress-commons': link:../compress-commons
@@ -1923,6 +1928,82 @@ importers:
       ts-jest: ^28.0.8
       typescript: 4.6.3
       yargs: ^17.5.1
+      zod: 3.14.4
+  libs/data:
+    dependencies:
+      '@votingworks/types': link:../types
+      '@votingworks/utils': link:../utils
+      buffer: 6.0.3
+      debug: 4.3.4
+      micromatch: 4.0.5
+      readline: 1.3.0
+      stream-chopper: 3.0.1
+      zod: 3.14.4
+    devDependencies:
+      '@types/debug': 4.1.7
+      '@types/jest': 27.4.1
+      '@types/micromatch': 4.0.2
+      '@types/node': 16.11.29
+      '@types/stream-chopper': link:../@types/stream-chopper
+      '@types/tmp': 0.2.3
+      '@typescript-eslint/eslint-plugin': 5.37.0_9443e33d3af89f89dc1c3d6ee69618ca
+      '@typescript-eslint/parser': 5.37.0_eslint@8.26.0+typescript@4.6.3
+      '@votingworks/test-utils': link:../test-utils
+      eslint: 8.26.0
+      eslint-config-prettier: 8.5.0_eslint@8.26.0
+      eslint-import-resolver-node: 0.3.6
+      eslint-plugin-import: 2.26.0_eslint@8.26.0+typescript@4.6.3
+      eslint-plugin-jest: 26.6.0_df5e750bef2e1448a6529f143dfbf93b
+      eslint-plugin-prettier: 4.2.1_03516513155bd96520649d3136b95513
+      eslint-plugin-vx: link:../eslint-plugin-vx
+      fast-check: 2.23.2
+      is-ci-cli: 2.2.0
+      jest: 27.5.1
+      jest-junit: 14.0.1
+      jest-watch-typeahead: 0.6.5_jest@27.5.1
+      lint-staged: 11.0.0
+      memory-streams: 0.1.3
+      prettier: 2.7.1
+      sort-package-json: 1.53.1
+      tmp: 0.2.1
+      ts-jest: 27.1.5_9985e1834e803358b7be1e6ce5ca0eea
+      typescript: 4.6.3
+    specifiers:
+      '@types/debug': ^4.1.7
+      '@types/jest': ^27.0.3
+      '@types/micromatch': ^4.0.2
+      '@types/node': 16.11.29
+      '@types/stream-chopper': workspace:*
+      '@types/tmp': ^0.2.3
+      '@typescript-eslint/eslint-plugin': ^5.37.0
+      '@typescript-eslint/parser': ^5.37.0
+      '@votingworks/test-utils': workspace:*
+      '@votingworks/types': workspace:*
+      '@votingworks/utils': workspace:*
+      buffer: ^6.0.3
+      debug: ^4.3.2
+      eslint: ^8.23.1
+      eslint-config-prettier: ^8.5.0
+      eslint-import-resolver-node: ^0.3.6
+      eslint-plugin-import: ^2.26.0
+      eslint-plugin-jest: ^26.1.5
+      eslint-plugin-prettier: ^4.2.1
+      eslint-plugin-vx: workspace:*
+      fast-check: ^2.18.0
+      is-ci-cli: ^2.2.0
+      jest: ^27.3.1
+      jest-junit: ^14.0.1
+      jest-watch-typeahead: ^0.6.4
+      lint-staged: ^11.0.0
+      memory-streams: ^0.1.3
+      micromatch: ^4.0.5
+      prettier: ^2.6.2
+      readline: ^1.3.0
+      sort-package-json: ^1.50.0
+      stream-chopper: ^3.0.1
+      tmp: ^0.2.1
+      ts-jest: ^27.0.7
+      typescript: 4.6.3
       zod: 3.14.4
   libs/db:
     dependencies:
@@ -2872,6 +2953,7 @@ importers:
       '@votingworks/ballot-encoder': link:../../libs/ballot-encoder
       '@votingworks/ballot-interpreter-nh': link:../../libs/ballot-interpreter-nh
       '@votingworks/ballot-interpreter-vx': link:../../libs/ballot-interpreter-vx
+      '@votingworks/data': link:../../libs/data
       '@votingworks/db': link:../../libs/db
       '@votingworks/fixtures': link:../../libs/fixtures
       '@votingworks/image-utils': link:../../libs/image-utils
@@ -2937,7 +3019,7 @@ importers:
       eslint-plugin-vx: link:../../libs/eslint-plugin-vx
       fast-check: 2.23.2
       is-ci-cli: 2.1.2
-      jest: 26.6.3_canvas@2.9.1
+      jest: 26.6.3
       jest-junit: 14.0.1
       jest-watch-typeahead: 0.6.4_jest@26.6.3
       lint-staged: 10.5.3
@@ -2972,6 +3054,7 @@ importers:
       '@votingworks/ballot-encoder': workspace:*
       '@votingworks/ballot-interpreter-nh': workspace:*
       '@votingworks/ballot-interpreter-vx': workspace:*
+      '@votingworks/data': workspace:*
       '@votingworks/db': workspace:*
       '@votingworks/fixtures': workspace:*
       '@votingworks/image-utils': workspace:*
@@ -9202,43 +9285,6 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==
-  /@jest/core/26.6.3_canvas@2.9.1:
-    dependencies:
-      '@jest/console': 26.6.2
-      '@jest/reporters': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/transform': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/node': 17.0.36
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.10
-      jest-changed-files: 26.6.2
-      jest-config: 26.6.3_canvas@2.9.1
-      jest-haste-map: 26.6.2
-      jest-message-util: 26.6.2
-      jest-regex-util: 26.0.0
-      jest-resolve: 26.6.2
-      jest-resolve-dependencies: 26.6.3
-      jest-runner: 26.6.3_canvas@2.9.1
-      jest-runtime: 26.6.3_canvas@2.9.1
-      jest-snapshot: 26.6.2
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      jest-watcher: 26.6.2
-      micromatch: 4.0.5
-      p-each-series: 2.2.0
-      rimraf: 3.0.2
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      canvas: '*'
-    resolution:
-      integrity: sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==
   /@jest/core/27.3.1:
     dependencies:
       '@jest/console': 27.3.1
@@ -9299,7 +9345,7 @@ packages:
       jest-regex-util: 27.0.6
       jest-resolve: 27.3.1
       jest-resolve-dependencies: 27.3.1
-      jest-runner: 27.3.1_canvas@2.9.1
+      jest-runner: 27.3.1
       jest-runtime: 27.3.1
       jest-snapshot: 27.3.1
       jest-util: 27.3.1
@@ -9420,7 +9466,7 @@ packages:
       jest-regex-util: 27.5.1
       jest-resolve: 27.5.1
       jest-resolve-dependencies: 27.5.1
-      jest-runner: 27.5.1_canvas@2.9.1
+      jest-runner: 27.5.1
       jest-runtime: 27.5.1
       jest-snapshot: 27.5.1
       jest-util: 27.5.1
@@ -10033,20 +10079,6 @@ packages:
     dev: true
     engines:
       node: '>= 10.14.2'
-    resolution:
-      integrity: sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==
-  /@jest/test-sequencer/26.6.3_canvas@2.9.1:
-    dependencies:
-      '@jest/test-result': 26.6.2
-      graceful-fs: 4.2.10
-      jest-haste-map: 26.6.2
-      jest-runner: 26.6.3_canvas@2.9.1
-      jest-runtime: 26.6.3_canvas@2.9.1
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      canvas: '*'
     resolution:
       integrity: sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==
   /@jest/test-sequencer/27.3.1:
@@ -11232,6 +11264,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==
+  /@types/braces/3.0.1:
+    dev: true
+    resolution:
+      integrity: sha512-+euflG6ygo4bn0JHtn4pYqcXwRtLvElQ7/nnjDu7iYG56H0+OhCd7d6Ug0IE3WcFpZozBKW2+80FUbv5QGk5AQ==
   /@types/busboy/0.2.3:
     dependencies:
       '@types/node': 14.14.20
@@ -11549,6 +11585,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-gzh6mqZcLryYHn4g2MuMWjo9J1+Py/XYwITyZmUxV7ZoBIi7bTbBgSiuC5tcm3UL3gmaiYssQFDlXr/3fK94cw==
+  /@types/micromatch/4.0.2:
+    dependencies:
+      '@types/braces': 3.0.1
+    dev: true
+    resolution:
+      integrity: sha512-oqXqVb0ci19GtH0vOA/U2TmHTcRY9kuZl4mqUxe0QmJAlIW13kzhuK5pi1i9+ngav8FjpSb9FVS/GE00GLX1VA==
   /@types/mime/1.3.2:
     dev: true
     resolution:
@@ -11635,7 +11677,6 @@ packages:
     resolution:
       integrity: sha512-XnjpaI8Bgc3eBag2Aw4t2Uj/49lLBSStHWfqKvIuXD7FIrZyMLWp8KuAFHAqxMZYTF9l08N1ctUn9YNybZJVmQ==
   /@types/node/18.8.0:
-    dev: true
     resolution:
       integrity: sha512-u+h43R6U8xXDt2vzUaVP3VwjjLyOJk6uEciZS8OSyziUQGOwmk+l+4drxcsDboHXwyTaqS1INebghmWMRxq3LA==
   /@types/normalize-package-data/2.4.1:
@@ -13569,7 +13610,7 @@ packages:
       integrity: sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==
   /axios/0.21.1_debug@4.3.1:
     dependencies:
-      follow-redirects: 1.14.1_debug@4.3.1
+      follow-redirects: 1.14.1_debug@4.3.4
     dev: false
     peerDependencies:
       debug: '*'
@@ -19692,6 +19733,27 @@ packages:
         optional: true
     resolution:
       integrity: sha512-f8n46/97ZFdU4KqeQYqO8AEVGIhHWvkpgNBWHH3jrM28/y8llnbf3IjfIKv6p2pZIMinK1PCqbbROxs9Eud02Q==
+  /eslint-plugin-jest/26.6.0_df5e750bef2e1448a6529f143dfbf93b:
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 5.37.0_9443e33d3af89f89dc1c3d6ee69618ca
+      '@typescript-eslint/utils': 5.22.0_eslint@8.26.0+typescript@4.6.3
+      eslint: 8.26.0
+      jest: 27.5.1
+    dev: true
+    engines:
+      node: ^12.22.0 || ^14.17.0 || >=16.0.0
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      jest: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
+      jest:
+        optional: true
+    resolution:
+      integrity: sha512-f8n46/97ZFdU4KqeQYqO8AEVGIhHWvkpgNBWHH3jrM28/y8llnbf3IjfIKv6p2pZIMinK1PCqbbROxs9Eud02Q==
   /eslint-plugin-jest/26.6.0_e44e15ea9d15a3d0482b150631352700:
     dependencies:
       '@typescript-eslint/eslint-plugin': 5.37.0_9443e33d3af89f89dc1c3d6ee69618ca
@@ -20983,6 +21045,7 @@ packages:
   /follow-redirects/1.14.1_debug@4.3.2:
     dependencies:
       debug: 4.3.2
+    dev: true
     engines:
       node: '>=4.0'
     peerDependencies:
@@ -22046,34 +22109,6 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
-  /http-proxy-middleware/1.0.6_debug@4.3.1:
-    dependencies:
-      '@types/http-proxy': 1.17.6
-      http-proxy: 1.18.1_debug@4.3.1
-      is-glob: 4.0.1
-      lodash: 4.17.21
-      micromatch: 4.0.4
-    dev: false
-    engines:
-      node: '>=8.0.0'
-    peerDependencies:
-      debug: '*'
-    resolution:
-      integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
-  /http-proxy-middleware/1.0.6_debug@4.3.2:
-    dependencies:
-      '@types/http-proxy': 1.17.6
-      http-proxy: 1.18.1_debug@4.3.2
-      is-glob: 4.0.1
-      lodash: 4.17.21
-      micromatch: 4.0.4
-    dev: false
-    engines:
-      node: '>=8.0.0'
-    peerDependencies:
-      debug: '*'
-    resolution:
-      integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==
   /http-proxy/1.18.1:
     dependencies:
       eventemitter3: 4.0.7
@@ -22082,30 +22117,6 @@ packages:
     dev: false
     engines:
       node: '>=8.0.0'
-    resolution:
-      integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
-  /http-proxy/1.18.1_debug@4.3.1:
-    dependencies:
-      eventemitter3: 4.0.7
-      follow-redirects: 1.14.1_debug@4.3.1
-      requires-port: 1.0.0
-    dev: false
-    engines:
-      node: '>=8.0.0'
-    peerDependencies:
-      debug: '*'
-    resolution:
-      integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
-  /http-proxy/1.18.1_debug@4.3.2:
-    dependencies:
-      eventemitter3: 4.0.7
-      follow-redirects: 1.14.1_debug@4.3.2
-      requires-port: 1.0.0
-    dev: false
-    engines:
-      node: '>=8.0.0'
-    peerDependencies:
-      debug: '*'
     resolution:
       integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
   /http-proxy/1.18.1_debug@4.3.4:
@@ -22949,7 +22960,6 @@ packages:
     resolution:
       integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
   /isarray/0.0.1:
-    dev: false
     resolution:
       integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==
   /isarray/1.0.0:
@@ -23134,37 +23144,6 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-L2/Y9szN6FJPWFK8kzWXwfp+FOR7xq0cUL4lIsdbIdwz3Vh6P1nrpcqOleSzr28zOtSHQNV9Z7Tl+KkuK7t5Ng==
-  /jest-circus/26.6.0_canvas@2.9.1:
-    dependencies:
-      '@babel/traverse': 7.18.2
-      '@jest/environment': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/babel__traverse': 7.17.1
-      '@types/node': 17.0.36
-      chalk: 4.1.2
-      co: 4.6.0
-      dedent: 0.7.0
-      expect: 26.6.2
-      is-generator-fn: 2.1.0
-      jest-each: 26.6.2
-      jest-matcher-utils: 26.6.2
-      jest-message-util: 26.6.2
-      jest-runner: 26.6.3_canvas@2.9.1
-      jest-runtime: 26.6.3_canvas@2.9.1
-      jest-snapshot: 26.6.2
-      jest-util: 26.6.2
-      prettier: 2.6.2
-      pretty-format: 26.6.2
-      stack-utils: 2.0.5
-      throat: 5.0.0
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      canvas: '*'
-    resolution:
-      integrity: sha512-L2/Y9szN6FJPWFK8kzWXwfp+FOR7xq0cUL4lIsdbIdwz3Vh6P1nrpcqOleSzr28zOtSHQNV9Z7Tl+KkuK7t5Ng==
   /jest-circus/27.3.1:
     dependencies:
       '@jest/environment': 27.3.1
@@ -23292,29 +23271,6 @@ packages:
     engines:
       node: '>= 10.14.2'
     hasBin: true
-    resolution:
-      integrity: sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
-  /jest-cli/26.6.3_canvas@2.9.1:
-    dependencies:
-      '@jest/core': 26.6.3_canvas@2.9.1
-      '@jest/test-result': 26.6.2
-      '@jest/types': 26.6.2
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.10
-      import-local: 3.1.0
-      is-ci: 2.0.0
-      jest-config: 26.6.3_canvas@2.9.1
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      prompts: 2.4.2
-      yargs: 15.4.1
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    hasBin: true
-    peerDependencies:
-      canvas: '*'
     resolution:
       integrity: sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
   /jest-cli/27.3.1:
@@ -23552,37 +23508,6 @@ packages:
         optional: true
     resolution:
       integrity: sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==
-  /jest-config/26.6.3_canvas@2.9.1:
-    dependencies:
-      '@babel/core': 7.18.2
-      '@jest/test-sequencer': 26.6.3_canvas@2.9.1
-      '@jest/types': 26.6.2
-      babel-jest: 26.6.3_@babel+core@7.18.2
-      chalk: 4.1.2
-      deepmerge: 4.2.2
-      glob: 7.2.3
-      graceful-fs: 4.2.10
-      jest-environment-jsdom: 26.6.2_canvas@2.9.1
-      jest-environment-node: 26.6.2
-      jest-get-type: 26.3.0
-      jest-jasmine2: 26.6.3_canvas@2.9.1
-      jest-regex-util: 26.0.0
-      jest-resolve: 26.6.2
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      micromatch: 4.0.5
-      pretty-format: 26.6.2
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      canvas: '*'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      ts-node:
-        optional: true
-    resolution:
-      integrity: sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==
   /jest-config/27.3.1:
     dependencies:
       '@babel/core': 7.16.0
@@ -23634,7 +23559,7 @@ packages:
       jest-jasmine2: 27.3.1
       jest-regex-util: 27.0.6
       jest-resolve: 27.3.1
-      jest-runner: 27.3.1_canvas@2.9.1
+      jest-runner: 27.3.1
       jest-util: 27.3.1
       jest-validate: 27.3.1
       micromatch: 4.0.4
@@ -23738,7 +23663,7 @@ packages:
       jest-jasmine2: 27.5.1
       jest-regex-util: 27.5.1
       jest-resolve: 27.5.1
-      jest-runner: 27.5.1_canvas@2.9.1
+      jest-runner: 27.5.1
       jest-util: 27.5.1
       jest-validate: 27.5.1
       micromatch: 4.0.5
@@ -24110,22 +24035,6 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-jgPqCruTlt3Kwqg5/WVFyHIOJHsiAvhcp2qiR2QQstuG9yWox5+iHpU3ZrcBxW14T4fe5Z68jAfLRh7joCSP2Q==
-  /jest-environment-jsdom/26.6.2_canvas@2.9.1:
-    dependencies:
-      '@jest/environment': 26.6.2
-      '@jest/fake-timers': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/node': 17.0.36
-      jest-mock: 26.6.2
-      jest-util: 26.6.2
-      jsdom: 16.7.0_canvas@2.9.1
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      canvas: '*'
-    resolution:
-      integrity: sha512-jgPqCruTlt3Kwqg5/WVFyHIOJHsiAvhcp2qiR2QQstuG9yWox5+iHpU3ZrcBxW14T4fe5Z68jAfLRh7joCSP2Q==
   /jest-environment-jsdom/27.3.1:
     dependencies:
       '@jest/environment': 27.3.1
@@ -24463,33 +24372,6 @@ packages:
     dev: true
     engines:
       node: '>= 10.14.2'
-    resolution:
-      integrity: sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==
-  /jest-jasmine2/26.6.3_canvas@2.9.1:
-    dependencies:
-      '@babel/traverse': 7.18.2
-      '@jest/environment': 26.6.2
-      '@jest/source-map': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/node': 17.0.36
-      chalk: 4.1.2
-      co: 4.6.0
-      expect: 26.6.2
-      is-generator-fn: 2.1.0
-      jest-each: 26.6.2
-      jest-matcher-utils: 26.6.2
-      jest-message-util: 26.6.2
-      jest-runtime: 26.6.3_canvas@2.9.1
-      jest-snapshot: 26.6.2
-      jest-util: 26.6.2
-      pretty-format: 26.6.2
-      throat: 5.0.0
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      canvas: '*'
     resolution:
       integrity: sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==
   /jest-jasmine2/27.3.1:
@@ -25157,35 +25039,6 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==
-  /jest-runner/26.6.3_canvas@2.9.1:
-    dependencies:
-      '@jest/console': 26.6.2
-      '@jest/environment': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/node': 17.0.36
-      chalk: 4.1.2
-      emittery: 0.7.2
-      exit: 0.1.2
-      graceful-fs: 4.2.10
-      jest-config: 26.6.3_canvas@2.9.1
-      jest-docblock: 26.0.0
-      jest-haste-map: 26.6.2
-      jest-leak-detector: 26.6.2
-      jest-message-util: 26.6.2
-      jest-resolve: 26.6.2
-      jest-runtime: 26.6.3_canvas@2.9.1
-      jest-util: 26.6.2
-      jest-worker: 26.6.2
-      source-map-support: 0.5.21
-      throat: 5.0.0
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      canvas: '*'
-    resolution:
-      integrity: sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==
   /jest-runner/27.3.1:
     dependencies:
       '@jest/console': 27.3.1
@@ -25213,37 +25066,6 @@ packages:
     dev: true
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
-    resolution:
-      integrity: sha512-r4W6kBn6sPr3TBwQNmqE94mPlYVn7fLBseeJfo4E2uCTmAyDFm2O5DYAQAFP7Q3YfiA/bMwg8TVsciP7k0xOww==
-  /jest-runner/27.3.1_canvas@2.9.1:
-    dependencies:
-      '@jest/console': 27.3.1
-      '@jest/environment': 27.3.1
-      '@jest/test-result': 27.3.1
-      '@jest/transform': 27.3.1
-      '@jest/types': 27.2.5
-      '@types/node': 15.3.0
-      chalk: 4.1.2
-      emittery: 0.8.1
-      exit: 0.1.2
-      graceful-fs: 4.2.10
-      jest-docblock: 27.0.6
-      jest-environment-jsdom: 27.3.1_canvas@2.9.1
-      jest-environment-node: 27.3.1
-      jest-haste-map: 27.3.1
-      jest-leak-detector: 27.3.1
-      jest-message-util: 27.3.1
-      jest-resolve: 27.3.1
-      jest-runtime: 27.3.1
-      jest-util: 27.3.1
-      jest-worker: 27.3.1
-      source-map-support: 0.5.20
-      throat: 6.0.1
-    dev: true
-    engines:
-      node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
-    peerDependencies:
-      canvas: '*'
     resolution:
       integrity: sha512-r4W6kBn6sPr3TBwQNmqE94mPlYVn7fLBseeJfo4E2uCTmAyDFm2O5DYAQAFP7Q3YfiA/bMwg8TVsciP7k0xOww==
   /jest-runner/27.4.5:
@@ -25301,36 +25123,6 @@ packages:
     dev: true
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
-    resolution:
-      integrity: sha512-g4NPsM4mFCOwFKXO4p/H/kWGdJp9V8kURY2lX8Me2drgXqG7rrZAx5kv+5H7wtt/cdFIjhqYx1HrlqWHaOvDaQ==
-  /jest-runner/27.5.1_canvas@2.9.1:
-    dependencies:
-      '@jest/console': 27.5.1
-      '@jest/environment': 27.5.1
-      '@jest/test-result': 27.5.1
-      '@jest/transform': 27.5.1
-      '@jest/types': 27.5.1
-      '@types/node': 17.0.36
-      chalk: 4.1.2
-      emittery: 0.8.1
-      graceful-fs: 4.2.10
-      jest-docblock: 27.5.1
-      jest-environment-jsdom: 27.5.1_canvas@2.9.1
-      jest-environment-node: 27.5.1
-      jest-haste-map: 27.5.1
-      jest-leak-detector: 27.5.1
-      jest-message-util: 27.5.1
-      jest-resolve: 27.5.1
-      jest-runtime: 27.5.1
-      jest-util: 27.5.1
-      jest-worker: 27.5.1
-      source-map-support: 0.5.21
-      throat: 6.0.1
-    dev: true
-    engines:
-      node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
-    peerDependencies:
-      canvas: '*'
     resolution:
       integrity: sha512-g4NPsM4mFCOwFKXO4p/H/kWGdJp9V8kURY2lX8Me2drgXqG7rrZAx5kv+5H7wtt/cdFIjhqYx1HrlqWHaOvDaQ==
   /jest-runner/28.1.3:
@@ -25394,43 +25186,6 @@ packages:
     engines:
       node: '>= 10.14.2'
     hasBin: true
-    resolution:
-      integrity: sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==
-  /jest-runtime/26.6.3_canvas@2.9.1:
-    dependencies:
-      '@jest/console': 26.6.2
-      '@jest/environment': 26.6.2
-      '@jest/fake-timers': 26.6.2
-      '@jest/globals': 26.6.2
-      '@jest/source-map': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/transform': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/yargs': 15.0.14
-      chalk: 4.1.2
-      cjs-module-lexer: 0.6.0
-      collect-v8-coverage: 1.0.1
-      exit: 0.1.2
-      glob: 7.2.3
-      graceful-fs: 4.2.10
-      jest-config: 26.6.3_canvas@2.9.1
-      jest-haste-map: 26.6.2
-      jest-message-util: 26.6.2
-      jest-mock: 26.6.2
-      jest-regex-util: 26.0.0
-      jest-resolve: 26.6.2
-      jest-snapshot: 26.6.2
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      slash: 3.0.0
-      strip-bom: 4.0.0
-      yargs: 15.4.1
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    hasBin: true
-    peerDependencies:
-      canvas: '*'
     resolution:
       integrity: sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==
   /jest-runtime/27.3.1:
@@ -25978,7 +25733,7 @@ packages:
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
-      jest: 26.6.3_canvas@2.9.1
+      jest: 26.6.3
       jest-regex-util: 27.5.1
       jest-watcher: 27.5.1
       slash: 3.0.0
@@ -26233,19 +25988,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-jxTmrvuecVISvKFFhOkjsWRZV7sFqdSUAd1ajOKY+/QE/aLBVstsJ/dX8GczLzwiT6ZEwwmZqtCUHLHHQVzcfA==
-  /jest/26.6.0_canvas@2.9.1:
-    dependencies:
-      '@jest/core': 26.6.3_canvas@2.9.1
-      import-local: 3.1.0
-      jest-cli: 26.6.3_canvas@2.9.1
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    hasBin: true
-    peerDependencies:
-      canvas: '*'
-    resolution:
-      integrity: sha512-jxTmrvuecVISvKFFhOkjsWRZV7sFqdSUAd1ajOKY+/QE/aLBVstsJ/dX8GczLzwiT6ZEwwmZqtCUHLHHQVzcfA==
   /jest/26.6.3:
     dependencies:
       '@jest/core': 26.6.3
@@ -26255,19 +25997,6 @@ packages:
     engines:
       node: '>= 10.14.2'
     hasBin: true
-    resolution:
-      integrity: sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
-  /jest/26.6.3_canvas@2.9.1:
-    dependencies:
-      '@jest/core': 26.6.3_canvas@2.9.1
-      import-local: 3.1.0
-      jest-cli: 26.6.3_canvas@2.9.1
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    hasBin: true
-    peerDependencies:
-      canvas: '*'
     resolution:
       integrity: sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
   /jest/27.3.1:
@@ -27452,7 +27181,6 @@ packages:
   /memory-streams/0.1.3:
     dependencies:
       readable-stream: 1.0.34
-    dev: false
     resolution:
       integrity: sha512-qVQ/CjkMyMInPaaRMrwWNDvf6boRZXaT/DbQeMYcCWuXPEBf1v8qChOc9OlEVQp2uOvRXa1Qu30fLmKhY6NipA==
   /memorystream/0.3.1:
@@ -30618,13 +30346,12 @@ packages:
       integrity: sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==
   /readable-stream/1.0.34:
     dependencies:
-      core-util-is: 1.0.2
+      core-util-is: 1.0.3
       inherits: 2.0.4
       isarray: 0.0.1
       string_decoder: 0.10.31
-    dev: false
     resolution:
-      integrity: sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=
+      integrity: sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==
   /readable-stream/1.1.14:
     dependencies:
       core-util-is: 1.0.3
@@ -31992,6 +31719,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==
+  /stream-chopper/3.0.1:
+    dependencies:
+      readable-stream: 3.6.0
+    dev: false
+    resolution:
+      integrity: sha512-f7h+ly8baAE26iIjcp3VbnBkbIRGtrvV0X0xxFM/d7fwLTYnLzDPTXRKNxa2HZzohOrc96NTrR+FaV3mzOelNA==
   /stream-combiner/0.0.4:
     dependencies:
       duplexer: 0.1.2
@@ -32157,7 +31890,6 @@ packages:
     resolution:
       integrity: sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==
   /string_decoder/0.10.31:
-    dev: false
     resolution:
       integrity: sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==
   /string_decoder/1.1.1:
@@ -33089,7 +32821,7 @@ packages:
       bs-logger: 0.2.6
       buffer-from: 1.1.1
       fast-json-stable-stringify: 2.1.0
-      jest: 26.6.3_canvas@2.9.1
+      jest: 26.6.3
       jest-util: 26.6.2
       json5: 2.1.3
       lodash.memoize: 4.1.2
@@ -33383,6 +33115,41 @@ packages:
         optional: true
     resolution:
       integrity: sha512-6Nlura7s6uM9BVUAoqLH7JHyMXjz8gluryjpPXxr3IxZdAXnU6FhjvVLHFtfd1vsE1p8zD1OJfskkc0jhTSnkA==
+  /ts-jest/27.1.5_9985e1834e803358b7be1e6ce5ca0eea:
+    dependencies:
+      '@types/jest': 27.4.1
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      jest: 27.5.1
+      jest-util: 27.5.1
+      json5: 2.2.1
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.3.7
+      typescript: 4.6.3
+      yargs-parser: 20.2.9
+    dev: true
+    engines:
+      node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@types/jest': ^27.0.0
+      babel-jest: '>=27.0.0 <28'
+      esbuild: '*'
+      jest: ^27.0.0
+      typescript: '>=3.8 <5.0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@types/jest':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+    resolution:
+      integrity: sha512-Xv6jBQPoBEvBq/5i2TeSG9tt/nqkbpcurrEG1b+2yfBrcJelOZF9Ml6dmyMh7bcW9JyFbRYpR5rxROSlBLTZHA==
   /ts-jest/27.1.5_b5363b1100a4404f3a1c52c9b8143c8a:
     dependencies:
       '@babel/core': 7.12.3
@@ -33531,7 +33298,7 @@ packages:
       babel-jest: 26.6.3_@babel+core@7.12.3
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 26.6.0_canvas@2.9.1
+      jest: 26.6.0
       jest-util: 28.1.3
       json5: 2.2.1
       lodash.memoize: 4.1.2

--- a/services/scan/package.json
+++ b/services/scan/package.json
@@ -41,6 +41,7 @@
     "@votingworks/ballot-encoder": "workspace:*",
     "@votingworks/ballot-interpreter-nh": "workspace:*",
     "@votingworks/ballot-interpreter-vx": "workspace:*",
+    "@votingworks/data": "workspace:*",
     "@votingworks/db": "workspace:*",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/image-utils": "workspace:*",

--- a/services/scan/src/env.d.ts
+++ b/services/scan/src/env.d.ts
@@ -5,6 +5,7 @@ declare namespace NodeJS {
     readonly NODE_ENV: 'development' | 'production' | 'test';
     readonly PORT?: string;
     readonly SCAN_ALWAYS_HOLD_ON_REJECT?: string;
+    readonly SCAN_ALLOWED_EXPORT_PATTERNS?: string;
     readonly SCAN_WORKSPACE?: string;
     readonly VX_MACHINE_ID?: string;
     readonly VX_MACHINE_TYPE?: string;

--- a/services/scan/src/globals.ts
+++ b/services/scan/src/globals.ts
@@ -79,3 +79,9 @@ export const SCAN_WORKSPACE =
  */
 export const SCAN_ALWAYS_HOLD_ON_REJECT =
   process.env.SCAN_ALWAYS_HOLD_ON_REJECT !== '0';
+
+/**
+ * Where are exported files allowed to be written to?
+ */
+export const SCAN_ALLOWED_EXPORT_PATTERNS =
+  process.env.SCAN_ALLOWED_EXPORT_PATTERNS?.split(',') ?? ['/media/**/*'];

--- a/services/scan/src/util/exporter.ts
+++ b/services/scan/src/util/exporter.ts
@@ -1,0 +1,12 @@
+import { Exporter } from '@votingworks/data';
+import { SCAN_ALLOWED_EXPORT_PATTERNS } from '../globals';
+
+/**
+ * Builds an exporter suitable for saving data to a file or USB drive.
+ */
+export function buildExporter(): Exporter {
+  const exporter = new Exporter({
+    allowedExportPatterns: SCAN_ALLOWED_EXPORT_PATTERNS,
+  });
+  return exporter;
+}

--- a/services/scan/tsconfig.build.json
+++ b/services/scan/tsconfig.build.json
@@ -13,6 +13,7 @@
     { "path": "../../libs/ballot-encoder/tsconfig.build.json" },
     { "path": "../../libs/ballot-interpreter-nh/tsconfig.build.json" },
     { "path": "../../libs/ballot-interpreter-vx/tsconfig.build.json" },
+    { "path": "../../libs/data/tsconfig.build.json" },
     { "path": "../../libs/db/tsconfig.build.json" },
     { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../../libs/fixtures/tsconfig.build.json" },

--- a/services/scan/tsconfig.json
+++ b/services/scan/tsconfig.json
@@ -20,6 +20,7 @@
     { "path": "../../libs/ballot-encoder/tsconfig.build.json" },
     { "path": "../../libs/ballot-interpreter-nh/tsconfig.build.json" },
     { "path": "../../libs/ballot-interpreter-vx/tsconfig.build.json" },
+    { "path": "../../libs/data/tsconfig.build.json" },
     { "path": "../../libs/db/tsconfig.build.json" },
     { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../../libs/fixtures/tsconfig.build.json" },

--- a/vxsuite.code-workspace
+++ b/vxsuite.code-workspace
@@ -69,6 +69,10 @@
       "path": "libs/cvr-fixture-generator"
     },
     {
+      "name": "libs/data",
+      "path": "libs/data"
+    },
+    {
       "name": "libs/db",
       "path": "libs/db"
     },


### PR DESCRIPTION
## Overview
<!-- add a link to a GitHub Issue here -->
Previously we would stream the data through the client and either download it (Chrome) or write it directly to a file (`kiosk-browser`). Now we directly write to the USB drive, ensuring that we can only write to paths matching `/media/**`.

This also adds the ability to split large files into 4GB chunks when writing to USB drives given the assumption that we're working with FAT32-formatted drives.

The file export functionality, including splitting, lives in a new library in part because `utils` is a large grab bag and adding file system-specific code makes loading `utils` in clients difficult (we have to stub `fs` and related modules).

Refs #2360 

## Demo Video or Screenshot
No changes to the UI other than removing the "Custom" option for where to save the backup.

## Testing Plan
Tested with artificially small maximum file sizes (10 MB) and verified that joining the files together with `cat` did yield a usable `.zip` file.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
