### PR TITLE
Adam/clean runthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ sudo whoami
 ```
 
 Automatically install and build all dependencies in the vxsuite repo with the 
-following command
+following command:
 
 ```sh
 ./script/bootstrap

--- a/README.md
+++ b/README.md
@@ -86,8 +86,16 @@ node -v # this should return 16.x.x
 pnpm -v # this should return 5.x.x
 ```
 
-Automatically install all dependencies in the vxsuite repo with the following
-command
+NOTE: The initial bootstrap will take some time. You may be prompted for your
+`sudo` password during the run. To minimize the chance of it happening, you can
+reset the timer by running a quick sudo command before the bootstrap:
+
+```sh
+sudo whoami
+```
+
+Automatically install and build all dependencies in the vxsuite repo with the 
+following command
 
 ```sh
 ./script/bootstrap

--- a/README.md
+++ b/README.md
@@ -42,13 +42,12 @@ the following commands.
 
 ```sh
 su - # this will prompt for the root password
-usermod -aG sudo <USERNAME> # use your user account username
+echo "USERNAME ALL=(ALL:ALL) ALL" > /etc/sudoers.d/USERNAME # use your user account username
 exit
 ```
 
-Restart your machine or open a new terminal for the changes to take effect. You
-can verify it worked after restart by entering `sudo whoami` in the terminal and
-you should see `root`.
+Verify your account has sudo privileges by running `sudo whoami` in the terminal.
+You should see `root`.
 
 Next install git, and create an SSH key following the
 [github guide](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent).

--- a/README.md
+++ b/README.md
@@ -97,11 +97,7 @@ Test that you can run the code
 
 ```sh
 # try out BMD:
-make -C services/smartcards build
-# ^ wait for this to settle, then…
 cd frontends/bmd
-pnpm install
-pnpm build
 pnpm start
 # if it worked, go to http://localhost:3000/ in your VM
 ```

--- a/frontends/bas/Makefile
+++ b/frontends/bas/Makefile
@@ -8,5 +8,7 @@ install:
 build: FORCE
 	pnpm install && pnpm build
 
+bootstrap: install build
+
 run:
 	cd prodserver && node index.js

--- a/frontends/bmd/Makefile
+++ b/frontends/bmd/Makefile
@@ -8,5 +8,7 @@ install:
 build: FORCE
 	pnpm install && pnpm build
 
+bootstrap: install build
+
 run:
 	cd prodserver && node index.js

--- a/frontends/bsd/Makefile
+++ b/frontends/bsd/Makefile
@@ -8,5 +8,7 @@ install:
 build: FORCE
 	pnpm install && pnpm build
 
+bootstrap: install build
+
 run:
 	cd prodserver && node index.js

--- a/frontends/election-manager/Makefile
+++ b/frontends/election-manager/Makefile
@@ -8,5 +8,7 @@ install:
 build: FORCE
 	pnpm install && pnpm build
 
+bootstrap: install build
+
 run:
 	cd prodserver && node index.js

--- a/frontends/precinct-scanner/Makefile
+++ b/frontends/precinct-scanner/Makefile
@@ -8,5 +8,7 @@ install:
 build: FORCE
 	pnpm install && pnpm build
 
+bootstrap: install build
+
 run:
 	cd prodserver && node index.js

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# pixman-1 is effectively a dependency in all pnpm calls, go ahead and install it 
+sudo apt install -y libsane libpng-dev libjpeg-dev libx11-dev libpixman-1-dev libcairo2-dev libpango1.0-dev libgif-dev
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 for app in ${DIR}/../frontends/* ${DIR}/../services/*; do

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -6,7 +6,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 for app in ${DIR}/../frontends/* ${DIR}/../services/*; do
   if [ -d "${app}" ]; then
-    make -C "${app}" install
+    make -C "${app}" bootstrap
   fi
 done
 

--- a/services/admin/Makefile
+++ b/services/admin/Makefile
@@ -8,6 +8,8 @@ install:
 build: FORCE
 	pnpm install && pnpm build
 
+bootstrap: install build
+
 run:
 	pnpm start
 

--- a/services/converter-ms-sems/Makefile
+++ b/services/converter-ms-sems/Makefile
@@ -16,6 +16,8 @@ install-dev-dependencies:
 
 build: install-dependencies
 
+bootstrap: install build install-dev-dependencies
+
 test:
 	python3.9 -m pipenv run python -m pytest
 

--- a/services/scan/Makefile
+++ b/services/scan/Makefile
@@ -20,6 +20,8 @@ endif
 build: FORCE
 	pnpm install && pnpm build
 
+bootstrap: install build
+
 run:
 	pnpm start
 

--- a/services/smartcards/Makefile
+++ b/services/smartcards/Makefile
@@ -14,6 +14,8 @@ build:
 	python3.9 -m pip install pipenv
 	python3.9 -m pipenv install
 
+bootstrap: install build
+
 build-dev:
 	python3.9 -m pipenv install --dev
 


### PR DESCRIPTION
## Overview
This improves the initial (and ongoing) dev experience related to getting vxsuite components up and running. After `script/bootstrap` has completed, every service and frontend component is ready for use, barring any weird edge-cases I haven't yet encountered.

This PR also changes how sudo is granted to a developer account. Adding to the `sudo` group may be convenient, but it's a bad practice we should avoid. Explicitly creating `/etc/sudoers.d/username` configs is cleaner and makes auditing/troubleshooting much more clear.

The bulk of this PR is related to the bootstrap process. Previously, all it did was run `make install` within the various `services/frontends` directories. It left developers in an in-between state that was confusing and not very well documented. With this change to the bootstrap process, developers can now run `pnpm start` in any configured frontend without worrying about related services or build steps. For consistency, I've updated every Makefile to include a `bootstrap` directive appropriate for it. That said, there are more opportunities for improvement here. To simplify things (for now), I added multiple package installs to the bootstrap script rather than updating the Makefile `install` directive everywhere since it would result in excessive duplication. Longer term, I think we should identify system-level packages and make them a separate configuration requirement. 

## Testing Plan 

Build a fresh VM from scratch. Confirm you can start up any frontend you wish. 

## Checklist
- [ n/a] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [n/a ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [n/a ] I have added a screenshot and/or video to this PR to demo the change
- [n/a] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
