### PR TITLE
Fix Precinct Change Lag on VxScan

### DIFF
--- a/frontends/precinct-scanner/src/app.test.tsx
+++ b/frontends/precinct-scanner/src/app.test.tsx
@@ -282,7 +282,7 @@ test('election manager and poll worker configuration', async () => {
   // Change mode as Election Manager
   mockTestModeChange(false);
   userEvent.click(await screen.findByText('Live Election Mode'));
-  await screen.findByText('Loading');
+  await screen.findByText('Switching to Live Election Mode');
   await advanceTimersAndPromises(1);
   expect(logger.log).toHaveBeenCalledWith(
     LogEventId.AuthLogin,
@@ -400,7 +400,7 @@ test('election manager and poll worker configuration', async () => {
     await screen.findByText('Delete All Election Data from VxScan')
   );
   userEvent.click(await screen.findByText('Yes, Delete All'));
-  await screen.findByText('Loading');
+  await screen.findByText('Deleting Election Data');
   await waitFor(() =>
     expect(
       fetchMock.calls('./precinct-scanner/config/election', {

--- a/frontends/precinct-scanner/src/app.test.tsx
+++ b/frontends/precinct-scanner/src/app.test.tsx
@@ -233,6 +233,10 @@ test('election manager must set precinct', async () => {
   screen.getByText(SELECT_PRECINCT_TEXT);
   mockPrecinctChange(singlePrecinctSelectionFor('23'));
   userEvent.selectOptions(await screen.findByTestId('selectPrecinct'), '23');
+  await screen.findByText('Changing Precinct');
+  await waitFor(() =>
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+  );
   card.removeCard();
   // Confirm precinct is set and correct
   await screen.findByText('Polls Closed');
@@ -293,6 +297,10 @@ test('election manager and poll worker configuration', async () => {
   // Change precinct as Election Manager
   mockPrecinctChange(singlePrecinctSelectionFor('23'));
   userEvent.selectOptions(await screen.findByTestId('selectPrecinct'), '23');
+  await screen.findByText('Changing Precinct');
+  await waitFor(() =>
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+  );
   await waitFor(() => {
     expect(logger.log).toHaveBeenCalledWith(
       LogEventId.PrecinctConfigurationChanged,
@@ -335,6 +343,7 @@ test('election manager and poll worker configuration', async () => {
   mockPollsChange('polls_closed_initial');
   userEvent.selectOptions(await screen.findByTestId('selectPrecinct'), '20');
   userEvent.click(screen.getByText('Confirm'));
+  await screen.findByText('Changing Precinct');
   await waitFor(() => {
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
   });

--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -294,11 +294,11 @@ export function AppRoot({
   async function updatePrecinctSelection(
     newPrecinctSelection: PrecinctSelection
   ) {
-    await config.setPrecinctSelection(newPrecinctSelection);
     dispatchAppState({
       type: 'updatePrecinctSelection',
       precinctSelection: newPrecinctSelection,
     });
+    await config.setPrecinctSelection(newPrecinctSelection);
     await refreshConfig();
   }
 

--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -165,6 +165,7 @@ function appReducer(state: State, action: AppAction): State {
         machineConfig:
           action.machineConfig ?? initialHardwareState.machineConfig,
       };
+    /* istanbul ignore next */
     default:
       throwIllegalValue(action);
   }

--- a/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
+++ b/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
@@ -78,7 +78,7 @@ test('services/scan fails to unconfigure', async () => {
   );
   userEvent.click(await screen.findByText('Yes, Delete All'));
 
-  await screen.findByText('Loading');
+  await screen.findByText('Deleting Election Data');
 });
 
 test('Show invalid card screen when unsupported cards are given', async () => {

--- a/frontends/precinct-scanner/src/components/export_backup_modal.tsx
+++ b/frontends/precinct-scanner/src/components/export_backup_modal.tsx
@@ -201,6 +201,7 @@ export function ExportBackupModal({ onClose, usbDrive }: Props): JSX.Element {
           }
         />
       );
+    /* istanbul ignore next */
     default:
       throwIllegalValue(usbDrive.status);
   }

--- a/frontends/precinct-scanner/src/components/export_results_modal.tsx
+++ b/frontends/precinct-scanner/src/components/export_results_modal.tsx
@@ -217,6 +217,7 @@ export function ExportResultsModal({
           }
         />
       );
+    /* istanbul ignore next */
     default:
       throwIllegalValue(usbDrive.status);
   }

--- a/frontends/precinct-scanner/src/components/set_mark_thresholds_modal.tsx
+++ b/frontends/precinct-scanner/src/components/set_mark_thresholds_modal.tsx
@@ -233,6 +233,7 @@ export function SetMarkThresholdsModal({
           }
         />
       );
+    /* istanbul ignore next */
     default:
       throwIllegalValue(currentState);
   }

--- a/frontends/precinct-scanner/src/screens/election_manager_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/election_manager_screen.test.tsx
@@ -12,7 +12,7 @@ import {
   electionMinimalExhaustiveSampleSinglePrecinctDefinition,
   electionSampleDefinition,
 } from '@votingworks/fixtures';
-import { fakeKiosk, Inserted } from '@votingworks/test-utils';
+import { advancePromises, fakeKiosk, Inserted } from '@votingworks/test-utils';
 import { singlePrecinctSelectionFor, usbstick } from '@votingworks/utils';
 import MockDate from 'mockdate';
 import React from 'react';
@@ -113,6 +113,8 @@ test('option to set precinct if more than one', async () => {
     1,
     expect.objectContaining(singlePrecinctSelectionFor(precinct.id))
   );
+
+  await advancePromises(); // avoid memory leak warning
 });
 
 test('no option to change precinct if there is only one precinct', async () => {

--- a/frontends/precinct-scanner/src/screens/election_manager_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/election_manager_screen.tsx
@@ -66,7 +66,7 @@ export function ElectionManagerScreen({
   assert(isElectionManagerAuth(auth));
   const userRole = auth.user.role;
 
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingText, setIsLoadingText] = useState<string>();
 
   const [
     isShowingToggleLiveModeWarningModal,
@@ -110,14 +110,18 @@ export function ElectionManagerScreen({
     if (!isTestMode && !scannerStatus.canUnconfigure) {
       openToggleLiveModeWarningModal();
     } else {
-      setIsLoading(true);
+      setIsLoadingText(
+        isTestMode
+          ? 'Switching to Live Election Mode'
+          : 'Switching to Testing Mode'
+      );
       await toggleLiveMode();
-      setIsLoading(false);
+      setIsLoadingText(undefined);
     }
   }
 
   async function handleUnconfigure() {
-    setIsLoading(true);
+    setIsLoadingText('Deleting Election Data');
     // If there is a mounted usb eject it so that it doesn't auto reconfigure the machine.
     if (usbDrive.status === usbstick.UsbDriveStatus.mounted) {
       await usbDrive.eject(userRole);
@@ -277,7 +281,7 @@ export function ElectionManagerScreen({
           onCancel={closeCalibrateScannerModal}
         />
       )}
-      {isLoading && <Modal content={<Loading />} />}
+      {isLoadingText && <Modal content={<Loading>{isLoadingText}</Loading>} />}
       {isExportingResults && (
         <ExportResultsModal
           onClose={() => setIsExportingResults(false)}

--- a/frontends/precinct-scanner/src/screens/scan_error_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/scan_error_screen.tsx
@@ -56,6 +56,7 @@ export function ScanErrorScreen({
         // These cases require restart, so we don't need to show an error
         // message, since that's handled below.
         return undefined;
+      /* istanbul ignore next */
       default:
         throwIllegalValue(error);
     }

--- a/libs/ui/src/change_precinct_button.test.tsx
+++ b/libs/ui/src/change_precinct_button.test.tsx
@@ -149,7 +149,7 @@ test('confirmation required mode', async () => {
   );
   screen.getByRole('option', { name: 'All Precincts', selected: true });
   userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
-  await screen.findByText('Loading');
+  await screen.findByText('Changing Precinct');
   expect(updatePrecinctSelection).toHaveBeenCalledTimes(1);
   expect(updatePrecinctSelection).toHaveBeenLastCalledWith(
     expect.objectContaining({

--- a/libs/ui/src/change_precinct_button.test.tsx
+++ b/libs/ui/src/change_precinct_button.test.tsx
@@ -41,6 +41,7 @@ test('default mode: set precinct from unset', async () => {
 
   // Updates app state
   userEvent.selectOptions(dropdown, 'precinct-1');
+  await screen.findByRole('alertdialog');
   expect(updatePrecinctSelection).toHaveBeenCalledTimes(1);
   expect(updatePrecinctSelection).toHaveBeenCalledWith(
     expect.objectContaining(singlePrecinctSelectionFor('precinct-1'))
@@ -55,6 +56,7 @@ test('default mode: set precinct from unset', async () => {
       })
     );
   });
+  expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
 
   // Prompt is still disabled
   expect(
@@ -82,11 +84,11 @@ test('default mode: switch precinct', async () => {
   expect(screen.getByRole('option', { name: 'All Precincts' })).toBeDisabled();
 
   userEvent.selectOptions(dropdown, 'precinct-2');
+  await screen.findByRole('alertdialog');
   expect(updatePrecinctSelection).toHaveBeenCalledTimes(1);
   expect(updatePrecinctSelection).toHaveBeenCalledWith(
     expect.objectContaining(singlePrecinctSelectionFor('precinct-2'))
   );
-
   await waitFor(() => {
     expect(logger.log).toHaveBeenCalledWith(
       LogEventId.PrecinctConfigurationChanged,
@@ -97,6 +99,7 @@ test('default mode: switch precinct', async () => {
       })
     );
   });
+  expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
 });
 
 test('confirmation required mode', async () => {
@@ -146,16 +149,13 @@ test('confirmation required mode', async () => {
   );
   screen.getByRole('option', { name: 'All Precincts', selected: true });
   userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
-  await waitFor(() => {
-    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
-  });
+  await screen.findByText('Loading');
   expect(updatePrecinctSelection).toHaveBeenCalledTimes(1);
   expect(updatePrecinctSelection).toHaveBeenLastCalledWith(
     expect.objectContaining({
       kind: 'AllPrecincts',
     })
   );
-
   await waitFor(() => {
     expect(logger.log).toHaveBeenCalledWith(
       LogEventId.PrecinctConfigurationChanged,
@@ -166,6 +166,7 @@ test('confirmation required mode', async () => {
       })
     );
   });
+  expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
   expect(logger.log).toHaveBeenCalledTimes(1);
 });
 

--- a/libs/ui/src/change_precinct_button.tsx
+++ b/libs/ui/src/change_precinct_button.tsx
@@ -162,7 +162,9 @@ export function ChangePrecinctButton({
           Change Precinct
         </Button>
       )}
-      {modalShown === 'changing_precinct' && <Modal content={<Loading />} />}
+      {modalShown === 'changing_precinct' && (
+        <Modal content={<Loading>Changing Precinct</Loading>} />
+      )}
       {modalShown === 'confirmation' && (
         <Modal
           content={

--- a/services/scan/src/central_scanner_app.test.ts
+++ b/services/scan/src/central_scanner_app.test.ts
@@ -25,7 +25,7 @@ import { makeMock } from '../test/util/mocks';
 import { Importer } from './importer';
 import { createWorkspace, Workspace } from './util/workspace';
 import { buildCentralScannerApp } from './central_scanner_app';
-import { getMockBallotPageLayoutWithImage } from '../test/helpers/mock_layouts';
+import { getMockBallotPageLayoutsWithImages } from '../test/helpers/mock_layouts';
 
 jest.mock('./importer');
 jest.mock('@votingworks/plustek-sdk');
@@ -47,16 +47,11 @@ beforeEach(async () => {
     precinctId: '23',
     isTestMode: false,
   };
-  workspace.store.addHmpbTemplate(Buffer.of(), ballotMetadata, [
-    getMockBallotPageLayoutWithImage({
-      ...ballotMetadata,
-      pageNumber: 1,
-    }),
-    getMockBallotPageLayoutWithImage({
-      ...ballotMetadata,
-      pageNumber: 2,
-    }),
-  ]);
+  workspace.store.addHmpbTemplate(
+    Buffer.of(),
+    ballotMetadata,
+    getMockBallotPageLayoutsWithImages(ballotMetadata, 2)
+  );
   app = await buildCentralScannerApp({ importer, workspace });
 });
 

--- a/services/scan/src/central_scanner_app.test.ts
+++ b/services/scan/src/central_scanner_app.test.ts
@@ -4,6 +4,7 @@ import {
 } from '@votingworks/fixtures';
 import {
   AdjudicationReason,
+  BallotMetadata,
   BallotPageLayout,
   BallotPageLayoutWithImage,
   BallotType,
@@ -24,6 +25,7 @@ import { makeMock } from '../test/util/mocks';
 import { Importer } from './importer';
 import { createWorkspace, Workspace } from './util/workspace';
 import { buildCentralScannerApp } from './central_scanner_app';
+import { getMockBallotPageLayoutWithImage } from '../test/helpers/mock_layouts';
 
 jest.mock('./importer');
 jest.mock('@votingworks/plustek-sdk');
@@ -37,45 +39,24 @@ beforeEach(async () => {
   workspace = createWorkspace(dirSync().name);
   workspace.store.setElection(stateOfHamilton.electionDefinition.electionData);
   workspace.store.setTestMode(false);
-  workspace.store.addHmpbTemplate(
-    Buffer.of(),
-    {
-      locales: { primary: 'en-US' },
-      electionHash: stateOfHamilton.electionDefinition.electionHash,
-      ballotType: BallotType.Standard,
-      ballotStyleId: '12',
-      precinctId: '23',
-      isTestMode: false,
-    },
-    [
-      {
-        pageSize: { width: 1, height: 1 },
-        metadata: {
-          locales: { primary: 'en-US' },
-          electionHash: stateOfHamilton.electionDefinition.electionHash,
-          ballotType: BallotType.Standard,
-          ballotStyleId: '12',
-          precinctId: '23',
-          isTestMode: false,
-          pageNumber: 1,
-        },
-        contests: [],
-      },
-      {
-        pageSize: { width: 1, height: 1 },
-        metadata: {
-          locales: { primary: 'en-US' },
-          electionHash: stateOfHamilton.electionDefinition.electionHash,
-          ballotType: BallotType.Standard,
-          ballotStyleId: '12',
-          precinctId: '23',
-          isTestMode: false,
-          pageNumber: 2,
-        },
-        contests: [],
-      },
-    ]
-  );
+  const ballotMetadata: BallotMetadata = {
+    locales: { primary: 'en-US' },
+    electionHash: stateOfHamilton.electionDefinition.electionHash,
+    ballotType: BallotType.Standard,
+    ballotStyleId: '12',
+    precinctId: '23',
+    isTestMode: false,
+  };
+  workspace.store.addHmpbTemplate(Buffer.of(), ballotMetadata, [
+    getMockBallotPageLayoutWithImage({
+      ...ballotMetadata,
+      pageNumber: 1,
+    }),
+    getMockBallotPageLayoutWithImage({
+      ...ballotMetadata,
+      pageNumber: 2,
+    }),
+  ]);
   app = await buildCentralScannerApp({ importer, workspace });
 });
 

--- a/services/scan/src/cli/render_pages.test.ts
+++ b/services/scan/src/cli/render_pages.test.ts
@@ -12,7 +12,7 @@ import {
   ballotPdf,
 } from '../../test/fixtures/choctaw-2020-09-22-f30480cc99';
 import { main } from './render_pages';
-import { getMockBallotPageLayoutWithImage } from '../../test/helpers/mock_layouts';
+import { getMockBallotPageLayoutsWithImages } from '../../test/helpers/mock_layouts';
 
 function fakeOutput(): WritableStream & NodeJS.WriteStream {
   return new WritableStream() as WritableStream & NodeJS.WriteStream;
@@ -174,16 +174,11 @@ test('render from db', async () => {
     locales: { primary: 'en-US' },
     precinctId: '6538',
   };
-  store.addHmpbTemplate(await fs.readFile(ballotPdf), metadata, [
-    getMockBallotPageLayoutWithImage({
-      ...metadata,
-      pageNumber: 1,
-    }),
-    getMockBallotPageLayoutWithImage({
-      ...metadata,
-      pageNumber: 2,
-    }),
-  ]);
+  store.addHmpbTemplate(
+    await fs.readFile(ballotPdf),
+    metadata,
+    getMockBallotPageLayoutsWithImages(metadata, 2)
+  );
 
   const stdout = fakeOutput();
   const stderr = fakeOutput();

--- a/services/scan/src/cli/render_pages.test.ts
+++ b/services/scan/src/cli/render_pages.test.ts
@@ -12,6 +12,7 @@ import {
   ballotPdf,
 } from '../../test/fixtures/choctaw-2020-09-22-f30480cc99';
 import { main } from './render_pages';
+import { getMockBallotPageLayoutWithImage } from '../../test/helpers/mock_layouts';
 
 function fakeOutput(): WritableStream & NodeJS.WriteStream {
   return new WritableStream() as WritableStream & NodeJS.WriteStream;
@@ -174,16 +175,14 @@ test('render from db', async () => {
     precinctId: '6538',
   };
   store.addHmpbTemplate(await fs.readFile(ballotPdf), metadata, [
-    {
-      pageSize: { width: 1, height: 1 },
-      metadata: { ...metadata, pageNumber: 1 },
-      contests: [],
-    },
-    {
-      pageSize: { width: 1, height: 1 },
-      metadata: { ...metadata, pageNumber: 2 },
-      contests: [],
-    },
+    getMockBallotPageLayoutWithImage({
+      ...metadata,
+      pageNumber: 1,
+    }),
+    getMockBallotPageLayoutWithImage({
+      ...metadata,
+      pageNumber: 2,
+    }),
   ]);
 
   const stdout = fakeOutput();

--- a/services/scan/src/cvrs/export.test.ts
+++ b/services/scan/src/cvrs/export.test.ts
@@ -13,6 +13,7 @@ import { pipeline } from 'stream/promises';
 import * as tmp from 'tmp';
 import { v4 as uuid } from 'uuid';
 import * as stateOfHamilton from '../../test/fixtures/state-of-hamilton';
+import { getMockBallotPageLayoutWithImage } from '../../test/helpers/mock_layouts';
 import { Store } from '../store';
 import * as buildCastVoteRecord from './build';
 import { exportCastVoteRecordsAsNdJson } from './export';
@@ -82,22 +83,14 @@ test('exportCvrs', async () => {
   };
 
   store.addHmpbTemplate(Buffer.of(1, 2, 3), metadata, [
-    {
-      pageSize: { width: 1, height: 1 },
-      metadata: {
-        ...metadata,
-        pageNumber: 1,
-      },
-      contests: [],
-    },
-    {
-      pageSize: { width: 1, height: 1 },
-      metadata: {
-        ...metadata,
-        pageNumber: 2,
-      },
-      contests: [],
-    },
+    getMockBallotPageLayoutWithImage({
+      ...metadata,
+      pageNumber: 1,
+    }),
+    getMockBallotPageLayoutWithImage({
+      ...metadata,
+      pageNumber: 2,
+    }),
   ]);
 
   // Create CVRs, confirm that they are exported should work
@@ -210,22 +203,14 @@ test('exportCvrs without write-ins does not load ballot images', async () => {
   };
 
   store.addHmpbTemplate(Buffer.of(1, 2, 3), metadata, [
-    {
-      pageSize: { width: 1, height: 1 },
-      metadata: {
-        ...metadata,
-        pageNumber: 1,
-      },
-      contests: [],
-    },
-    {
-      pageSize: { width: 1, height: 1 },
-      metadata: {
-        ...metadata,
-        pageNumber: 2,
-      },
-      contests: [],
-    },
+    getMockBallotPageLayoutWithImage({
+      ...metadata,
+      pageNumber: 1,
+    }),
+    getMockBallotPageLayoutWithImage({
+      ...metadata,
+      pageNumber: 2,
+    }),
   ]);
 
   // Create CVRs, confirm that they are exported should work
@@ -332,22 +317,14 @@ test('exportCvrs does not export ballot images when feature flag turned off', as
   };
 
   store.addHmpbTemplate(Buffer.of(1, 2, 3), metadata, [
-    {
-      pageSize: { width: 1, height: 1 },
-      metadata: {
-        ...metadata,
-        pageNumber: 1,
-      },
-      contests: [],
-    },
-    {
-      pageSize: { width: 1, height: 1 },
-      metadata: {
-        ...metadata,
-        pageNumber: 2,
-      },
-      contests: [],
-    },
+    getMockBallotPageLayoutWithImage({
+      ...metadata,
+      pageNumber: 1,
+    }),
+    getMockBallotPageLayoutWithImage({
+      ...metadata,
+      pageNumber: 2,
+    }),
   ]);
 
   // Create CVRs, confirm that they are exported should work
@@ -428,22 +405,14 @@ test('exportCvrs does not export ballot images when skipImages is true', async (
   };
 
   store.addHmpbTemplate(Buffer.of(1, 2, 3), metadata, [
-    {
-      pageSize: { width: 1, height: 1 },
-      metadata: {
-        ...metadata,
-        pageNumber: 1,
-      },
-      contests: [],
-    },
-    {
-      pageSize: { width: 1, height: 1 },
-      metadata: {
-        ...metadata,
-        pageNumber: 2,
-      },
-      contests: [],
-    },
+    getMockBallotPageLayoutWithImage({
+      ...metadata,
+      pageNumber: 1,
+    }),
+    getMockBallotPageLayoutWithImage({
+      ...metadata,
+      pageNumber: 2,
+    }),
   ]);
 
   const frontNormalizedFile = tmp.fileSync();
@@ -518,22 +487,14 @@ test('exportCvrs called with orderBySheetId actually orders by sheet ID', async 
   };
 
   store.addHmpbTemplate(Buffer.of(1, 2, 3), metadata, [
-    {
-      pageSize: { width: 1, height: 1 },
-      metadata: {
-        ...metadata,
-        pageNumber: 1,
-      },
-      contests: [],
-    },
-    {
-      pageSize: { width: 1, height: 1 },
-      metadata: {
-        ...metadata,
-        pageNumber: 2,
-      },
-      contests: [],
-    },
+    getMockBallotPageLayoutWithImage({
+      ...metadata,
+      pageNumber: 1,
+    }),
+    getMockBallotPageLayoutWithImage({
+      ...metadata,
+      pageNumber: 2,
+    }),
   ]);
 
   // Create CVRs, confirm that they are exported should work

--- a/services/scan/src/cvrs/export.test.ts
+++ b/services/scan/src/cvrs/export.test.ts
@@ -13,7 +13,7 @@ import { pipeline } from 'stream/promises';
 import * as tmp from 'tmp';
 import { v4 as uuid } from 'uuid';
 import * as stateOfHamilton from '../../test/fixtures/state-of-hamilton';
-import { getMockBallotPageLayoutWithImage } from '../../test/helpers/mock_layouts';
+import { getMockBallotPageLayoutsWithImages } from '../../test/helpers/mock_layouts';
 import { Store } from '../store';
 import * as buildCastVoteRecord from './build';
 import { exportCastVoteRecordsAsNdJson } from './export';
@@ -82,16 +82,11 @@ test('exportCvrs', async () => {
     pageNumber: 1,
   };
 
-  store.addHmpbTemplate(Buffer.of(1, 2, 3), metadata, [
-    getMockBallotPageLayoutWithImage({
-      ...metadata,
-      pageNumber: 1,
-    }),
-    getMockBallotPageLayoutWithImage({
-      ...metadata,
-      pageNumber: 2,
-    }),
-  ]);
+  store.addHmpbTemplate(
+    Buffer.of(1, 2, 3),
+    metadata,
+    getMockBallotPageLayoutsWithImages(metadata, 2)
+  );
 
   // Create CVRs, confirm that they are exported should work
   const batchId = store.addBatch();
@@ -202,16 +197,11 @@ test('exportCvrs without write-ins does not load ballot images', async () => {
     pageNumber: 1,
   };
 
-  store.addHmpbTemplate(Buffer.of(1, 2, 3), metadata, [
-    getMockBallotPageLayoutWithImage({
-      ...metadata,
-      pageNumber: 1,
-    }),
-    getMockBallotPageLayoutWithImage({
-      ...metadata,
-      pageNumber: 2,
-    }),
-  ]);
+  store.addHmpbTemplate(
+    Buffer.of(1, 2, 3),
+    metadata,
+    getMockBallotPageLayoutsWithImages(metadata, 2)
+  );
 
   // Create CVRs, confirm that they are exported should work
   const batchId = store.addBatch();
@@ -316,16 +306,11 @@ test('exportCvrs does not export ballot images when feature flag turned off', as
     pageNumber: 1,
   };
 
-  store.addHmpbTemplate(Buffer.of(1, 2, 3), metadata, [
-    getMockBallotPageLayoutWithImage({
-      ...metadata,
-      pageNumber: 1,
-    }),
-    getMockBallotPageLayoutWithImage({
-      ...metadata,
-      pageNumber: 2,
-    }),
-  ]);
+  store.addHmpbTemplate(
+    Buffer.of(1, 2, 3),
+    metadata,
+    getMockBallotPageLayoutsWithImages(metadata, 2)
+  );
 
   // Create CVRs, confirm that they are exported should work
   const batchId = store.addBatch();
@@ -404,16 +389,11 @@ test('exportCvrs does not export ballot images when skipImages is true', async (
     pageNumber: 1,
   };
 
-  store.addHmpbTemplate(Buffer.of(1, 2, 3), metadata, [
-    getMockBallotPageLayoutWithImage({
-      ...metadata,
-      pageNumber: 1,
-    }),
-    getMockBallotPageLayoutWithImage({
-      ...metadata,
-      pageNumber: 2,
-    }),
-  ]);
+  store.addHmpbTemplate(
+    Buffer.of(1, 2, 3),
+    metadata,
+    getMockBallotPageLayoutsWithImages(metadata, 2)
+  );
 
   const frontNormalizedFile = tmp.fileSync();
   await writeFile(frontNormalizedFile.fd, 'front normalized');
@@ -486,16 +466,11 @@ test('exportCvrs called with orderBySheetId actually orders by sheet ID', async 
     pageNumber: 1,
   };
 
-  store.addHmpbTemplate(Buffer.of(1, 2, 3), metadata, [
-    getMockBallotPageLayoutWithImage({
-      ...metadata,
-      pageNumber: 1,
-    }),
-    getMockBallotPageLayoutWithImage({
-      ...metadata,
-      pageNumber: 2,
-    }),
-  ]);
+  store.addHmpbTemplate(
+    Buffer.of(1, 2, 3),
+    metadata,
+    getMockBallotPageLayoutsWithImages(metadata, 2)
+  );
 
   // Create CVRs, confirm that they are exported should work
   const sheetIds = ['fake-uuid-zzz', 'fake-uuid-lll', 'fake-uuid-aaa'];

--- a/services/scan/src/importer.ts
+++ b/services/scan/src/importer.ts
@@ -116,8 +116,7 @@ export class Importer {
     this.workspace.store.addHmpbTemplate(
       pdf,
       result[0].ballotPageLayout.metadata,
-      // remove ballot image for storage
-      result.map(({ ballotPageLayout }) => ballotPageLayout)
+      result
     );
 
     this.invalidateInterpreterConfig();

--- a/services/scan/src/store.test.ts
+++ b/services/scan/src/store.test.ts
@@ -23,7 +23,7 @@ import { v4 as uuid } from 'uuid';
 import * as stateOfHamilton from '../test/fixtures/state-of-hamilton';
 import { zeroRect } from '../test/fixtures/zero_rect';
 import {
-  getMockBallotPageLayoutWithImage,
+  getMockBallotPageLayoutsWithImages,
   getMockImageData,
 } from '../test/helpers/mock_layouts';
 import { ResultSheet, Store } from './store';
@@ -232,16 +232,11 @@ test('HMPB template handling', () => {
 
   expect(store.getHmpbTemplates()).toEqual([]);
 
-  store.addHmpbTemplate(Buffer.of(1, 2, 3), metadata, [
-    getMockBallotPageLayoutWithImage({
-      ...metadata,
-      pageNumber: 1,
-    }),
-    getMockBallotPageLayoutWithImage({
-      ...metadata,
-      pageNumber: 2,
-    }),
-  ]);
+  store.addHmpbTemplate(
+    Buffer.of(1, 2, 3),
+    metadata,
+    getMockBallotPageLayoutsWithImages(metadata, 2)
+  );
 
   expect(store.getHmpbTemplates()).toEqual(
     typedAs<Array<[Buffer, BallotPageLayout[]]>>([

--- a/services/scan/src/store.test.ts
+++ b/services/scan/src/store.test.ts
@@ -22,6 +22,10 @@ import * as tmp from 'tmp';
 import { v4 as uuid } from 'uuid';
 import * as stateOfHamilton from '../test/fixtures/state-of-hamilton';
 import { zeroRect } from '../test/fixtures/zero_rect';
+import {
+  getMockBallotPageLayoutWithImage,
+  getMockImageData,
+} from '../test/helpers/mock_layouts';
 import { ResultSheet, Store } from './store';
 
 // We pause in some of these tests so we need to increase the timeout
@@ -229,22 +233,14 @@ test('HMPB template handling', () => {
   expect(store.getHmpbTemplates()).toEqual([]);
 
   store.addHmpbTemplate(Buffer.of(1, 2, 3), metadata, [
-    {
-      pageSize: { width: 1, height: 1 },
-      metadata: {
-        ...metadata,
-        pageNumber: 1,
-      },
-      contests: [],
-    },
-    {
-      pageSize: { width: 1, height: 1 },
-      metadata: {
-        ...metadata,
-        pageNumber: 2,
-      },
-      contests: [],
-    },
+    getMockBallotPageLayoutWithImage({
+      ...metadata,
+      pageNumber: 1,
+    }),
+    getMockBallotPageLayoutWithImage({
+      ...metadata,
+      pageNumber: 2,
+    }),
   ]);
 
   expect(store.getHmpbTemplates()).toEqual(
@@ -557,49 +553,52 @@ test('adjudication', () => {
     Buffer.of(),
     metadata,
     [1, 2].map((pageNumber) => ({
-      pageSize: { width: 1, height: 1 },
-      metadata: {
-        ...metadata,
-        pageNumber,
+      imageData: getMockImageData(),
+      ballotPageLayout: {
+        pageSize: { width: 1, height: 1 },
+        metadata: {
+          ...metadata,
+          pageNumber,
+        },
+        contests: [
+          {
+            bounds: zeroRect,
+            corners: [
+              { x: 0, y: 0 },
+              { x: 0, y: 0 },
+              { x: 0, y: 0 },
+              { x: 0, y: 0 },
+            ],
+            options: [
+              {
+                bounds: zeroRect,
+                target: {
+                  bounds: zeroRect,
+                  inner: zeroRect,
+                },
+              },
+            ],
+          },
+          {
+            bounds: zeroRect,
+            corners: [
+              { x: 0, y: 0 },
+              { x: 0, y: 0 },
+              { x: 0, y: 0 },
+              { x: 0, y: 0 },
+            ],
+            options: [
+              {
+                bounds: zeroRect,
+                target: {
+                  bounds: zeroRect,
+                  inner: zeroRect,
+                },
+              },
+            ],
+          },
+        ],
       },
-      contests: [
-        {
-          bounds: zeroRect,
-          corners: [
-            { x: 0, y: 0 },
-            { x: 0, y: 0 },
-            { x: 0, y: 0 },
-            { x: 0, y: 0 },
-          ],
-          options: [
-            {
-              bounds: zeroRect,
-              target: {
-                bounds: zeroRect,
-                inner: zeroRect,
-              },
-            },
-          ],
-        },
-        {
-          bounds: zeroRect,
-          corners: [
-            { x: 0, y: 0 },
-            { x: 0, y: 0 },
-            { x: 0, y: 0 },
-            { x: 0, y: 0 },
-          ],
-          options: [
-            {
-              bounds: zeroRect,
-              target: {
-                bounds: zeroRect,
-                inner: zeroRect,
-              },
-            },
-          ],
-        },
-      ],
     }))
   );
   function fakePage(i: 0 | 1): PageInterpretationWithFiles {

--- a/services/scan/src/store.ts
+++ b/services/scan/src/store.ts
@@ -4,13 +4,16 @@
 
 import { Scan } from '@votingworks/api';
 import { generateBallotPageLayouts } from '@votingworks/ballot-interpreter-nh';
+import { interpretTemplate } from '@votingworks/ballot-interpreter-vx';
 import { Bindable, Client as DbClient } from '@votingworks/db';
+import { pdfToImages } from '@votingworks/image-utils';
 import {
   AnyContest,
   BallotMetadata,
   BallotMetadataSchema,
   BallotPageLayout,
   BallotPageLayoutSchema,
+  BallotPageLayoutWithImage,
   BallotPageMetadata,
   BallotPaperSize,
   BallotSheetInfo,
@@ -75,6 +78,7 @@ function dateTimeFromNoOffsetSqliteDate(noOffsetSqliteDate: string): DateTime {
  */
 export class Store {
   private constructor(private readonly client: DbClient) {}
+  private cachedLayouts: BallotPageLayoutWithImage[] = [];
 
   getDbPath(): string {
     return this.client.getDatabasePath();
@@ -167,10 +171,11 @@ export class Store {
   }
 
   /**
-   * Resets the database.
+   * Resets the database and any cached data in the store.
    */
   reset(): void {
     this.client.reset();
+    this.cachedLayouts = [];
   }
 
   /**
@@ -1047,9 +1052,13 @@ export class Store {
   addHmpbTemplate(
     pdf: Buffer,
     metadata: BallotMetadata,
-    layouts: readonly BallotPageLayout[]
+    layoutsWithImages: readonly BallotPageLayoutWithImage[]
   ): string {
     debug('storing HMPB template: %O', metadata);
+    // remove page image for storage, but we need the image here to cache
+    const layouts = layoutsWithImages.map(
+      ({ ballotPageLayout }) => ballotPageLayout
+    );
 
     this.client.run(
       `
@@ -1084,6 +1093,8 @@ export class Store {
       JSON.stringify(metadata),
       JSON.stringify(layouts)
     );
+    // cache our layouts so they can be immediately used by the interpreter
+    this.cachedLayouts.push(...layoutsWithImages);
     return id;
   }
 
@@ -1129,6 +1140,33 @@ export class Store {
     }
 
     return results;
+  }
+
+  async loadLayouts(): Promise<BallotPageLayoutWithImage[] | undefined> {
+    const electionDefinition = this.getElectionDefinition();
+    if (!electionDefinition) return;
+
+    if (this.cachedLayouts.length > 0) return this.cachedLayouts;
+
+    const templates = this.getHmpbTemplates();
+    const loadedLayouts: BallotPageLayoutWithImage[] = [];
+
+    for (const [pdf, layouts] of templates) {
+      for await (const { page, pageNumber } of pdfToImages(pdf, { scale: 2 })) {
+        const ballotPageLayout = layouts[pageNumber - 1];
+        loadedLayouts.push(
+          await interpretTemplate({
+            electionDefinition,
+            imageData: page,
+            metadata: ballotPageLayout.metadata,
+          })
+        );
+      }
+    }
+
+    // These computations are expensive so we cache the loaded layouts
+    this.cachedLayouts = loadedLayouts;
+    return loadedLayouts;
   }
 
   getBallotPageLayoutForMetadata(

--- a/services/scan/test/helpers/mock_layouts.ts
+++ b/services/scan/test/helpers/mock_layouts.ts
@@ -1,4 +1,5 @@
 import {
+  BallotMetadata,
   BallotPageLayout,
   BallotPageLayoutWithImage,
   BallotPageMetadata,
@@ -30,4 +31,17 @@ export function getMockBallotPageLayoutWithImage(
     imageData: getMockImageData(),
     ballotPageLayout: getMockBallotPageLayout(metadata),
   };
+}
+
+export function getMockBallotPageLayoutsWithImages(
+  metadata: BallotMetadata,
+  numPages: number
+): BallotPageLayoutWithImage[] {
+  const mockBallotPageLayoutsWithImages: BallotPageLayoutWithImage[] = [];
+  for (let i = 1; i <= numPages; i += 1) {
+    mockBallotPageLayoutsWithImages.push(
+      getMockBallotPageLayoutWithImage({ ...metadata, pageNumber: i })
+    );
+  }
+  return mockBallotPageLayoutsWithImages;
 }

--- a/services/scan/test/helpers/mock_layouts.ts
+++ b/services/scan/test/helpers/mock_layouts.ts
@@ -1,0 +1,33 @@
+import {
+  BallotPageLayout,
+  BallotPageLayoutWithImage,
+  BallotPageMetadata,
+  ImageData,
+} from '@votingworks/types';
+
+export function getMockBallotPageLayout(
+  metadata: BallotPageMetadata
+): BallotPageLayout {
+  return {
+    pageSize: { width: 1, height: 1 },
+    metadata,
+    contests: [],
+  };
+}
+
+export function getMockImageData(width = 1, height = 1): ImageData {
+  return {
+    data: Uint8ClampedArray.of(0, 0, 0, 0),
+    width,
+    height,
+  };
+}
+
+export function getMockBallotPageLayoutWithImage(
+  metadata: BallotPageMetadata
+): BallotPageLayoutWithImage {
+  return {
+    imageData: getMockImageData(),
+    ballotPageLayout: getMockBallotPageLayout(metadata),
+  };
+}


### PR DESCRIPTION
## Overview
Fix issues identified in [slack thread](https://votingworks.slack.com/archives/CEL6D3GAD/p1668803903643469). On changing the precinct, the UI lags and easily creates confusion for the election manager. And with pressing the button multiple times, possibly weird states.

The problem was introduced when we decided to limit when the precinct can be changed to only when there are 0 ballots. As a result of that, the backend has to do a non-trivial amount of work, and it takes longer. It is essentially the same change as switching modes.

So, I added a progress modal when you change the precinct.

## Demo Video or Screenshot

Since I made this video I changed the modal language from "Changing Precinct" to "Loading" to match the mode switch.
[precinct-change-progress.webm](https://user-images.githubusercontent.com/37960853/202814421-33ea20dd-3e0d-4d39-aa14-65a26e640160.webm)
