### PR TITLE
Fix Test Warnings in VxAdmin

### DIFF
--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -730,7 +730,8 @@ test('tabulating CVRs', async () => {
 
   const reportPreview2 = getByTestId('report-preview');
   expect(within(reportPreview2).getAllByText('0').length).toBe(40);
-  // useQuery's in AppRoot are refetching data, and there's no change to wait on
+  // useQuery's in AppRoot are refetching data, and there's no change to wait on.
+  // TODO: Remove after upgrade to React 18, which does not warn in this case.
   await advanceTimersAndPromises();
 });
 
@@ -1109,7 +1110,7 @@ test('changing election resets sems, cvr, and manual data files', async () => {
   await screen.findByText('Currently tallying live ballots.');
   // We're waiting on a query for isOfficialResults. It has a default value,
   // so there is no change on the page to wait for before test ends.
-  // Await promises to avoid test warning.
+  // TODO: Remove after upgrade to React 18, which does not warn in this case.
   await advanceTimersAndPromises();
 });
 
@@ -1259,7 +1260,7 @@ test('election manager UI has expected nav', async () => {
   await screen.findByRole('heading', { name: 'L&A Testing Documents' });
   // We're waiting on a query for the file mode (live vs. test).
   // It has a default value, so there is no change on the page when loaded.
-  // Await promises to avoid test warning.
+  // TODO: Remove after upgrade to React 18, which does not warn in this case
   await advanceTimersAndPromises();
   userEvent.click(screen.getByText('Tally'));
   await screen.findByRole('heading', {

--- a/frontends/election-manager/src/screens/manual_data_import_precinct_screen.test.tsx
+++ b/frontends/election-manager/src/screens/manual_data_import_precinct_screen.test.tsx
@@ -46,6 +46,7 @@ test('displays error screen for invalid precinct', async () => {
   screen.getByText('Back to Index');
   // There's no change in the invalid precinct case after the writeInQuery
   // fires, so we just have to wait to avoid a test warning.
+  // TODO: Remove after upgrade to React 18, which does not warn in this case.
   await act(async () => {
     await sleep(1);
   });

--- a/frontends/election-manager/src/screens/manual_data_import_precinct_screen.test.tsx
+++ b/frontends/election-manager/src/screens/manual_data_import_precinct_screen.test.tsx
@@ -6,7 +6,13 @@ import {
   electionMinimalExhaustiveSampleFixtures,
 } from '@votingworks/fixtures';
 import { Route } from 'react-router-dom';
-import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
 
 import {
   ExternalTallySourceType,
@@ -16,7 +22,7 @@ import {
 } from '@votingworks/types';
 import { fakeLogger, LogEventId } from '@votingworks/logging';
 import userEvent from '@testing-library/user-event';
-import { assert } from '@votingworks/utils';
+import { assert, sleep } from '@votingworks/utils';
 import { renderInAppContext } from '../../test/render_in_app_context';
 import {
   getEmptyExternalTalliesByPrecinct,
@@ -26,8 +32,8 @@ import { ManualDataImportPrecinctScreen } from './manual_data_import_precinct_sc
 import { buildExternalTally } from '../../test/helpers/build_external_tally';
 import { ElectionManagerStoreMemoryBackend } from '../lib/backends';
 
-test('displays error screen for invalid precinct', () => {
-  const { getByText } = renderInAppContext(
+test('displays error screen for invalid precinct', async () => {
+  renderInAppContext(
     <Route path="/tally/manual-data-import/precinct/:precinctId">
       <ManualDataImportPrecinctScreen />
     </Route>,
@@ -36,8 +42,13 @@ test('displays error screen for invalid precinct', () => {
       electionDefinition: electionWithMsEitherNeitherDefinition,
     }
   );
-  getByText('Error: Could not find precinct 12345.');
-  getByText('Back to Index');
+  await screen.findByText('Error: Could not find precinct 12345.');
+  screen.getByText('Back to Index');
+  // There's no change in the invalid precinct case after the writeInQuery
+  // fires, so we just have to wait to avoid a test warning.
+  await act(async () => {
+    await sleep(1);
+  });
 });
 
 test('displays correct contests for each precinct', async () => {

--- a/frontends/election-manager/src/screens/write_ins_screen.test.tsx
+++ b/frontends/election-manager/src/screens/write_ins_screen.test.tsx
@@ -1,6 +1,7 @@
-import { screen, waitFor } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { electionMinimalExhaustiveSampleFixtures } from '@votingworks/fixtures';
+import { sleep } from '@votingworks/utils';
 import React from 'react';
 import { renderInAppContext } from '../../test/render_in_app_context';
 import { ElectionManagerStoreMemoryBackend } from '../lib/backends';
@@ -8,6 +9,14 @@ import { WriteInsScreen } from './write_ins_screen';
 
 const { electionDefinition, cvrData } = electionMinimalExhaustiveSampleFixtures;
 const abbreviatedCvrData = cvrData.split('\n').slice(0, 20).join('\n');
+
+afterEach(async () => {
+  // Several tests on this page create test warnings because hooks run after
+  // the end of the test, and there is no specific change on the page to check
+  await act(async () => {
+    await sleep(1);
+  });
+});
 
 test('No CVRs loaded', async () => {
   renderInAppContext(<WriteInsScreen />, { electionDefinition });

--- a/frontends/election-manager/src/screens/write_ins_screen.test.tsx
+++ b/frontends/election-manager/src/screens/write_ins_screen.test.tsx
@@ -12,7 +12,8 @@ const abbreviatedCvrData = cvrData.split('\n').slice(0, 20).join('\n');
 
 afterEach(async () => {
   // Several tests on this page create test warnings because hooks run after
-  // the end of the test, and there is no specific change on the page to check
+  // the end of the test, and there is no specific change on the page to check.
+  // TODO: Remove after upgrade to React 18, which does not warn in this case.
   await act(async () => {
     await sleep(1);
   });


### PR DESCRIPTION
With the introduction of React Query, we are getting a lot test warnings about updates to unmounted components. This can make it hard to read the test output and can obscure more concerning warnings.

The cause seems to be that React Query is fetching and making state updates after tests have ended. RTL good practice would be to wait for changes on the screen before ending or continuing the test. But in some cases, there are no changes on the screen, because the data is simply refetching or it is fetching data for which we have a default value (so there is no change on screen). I'll comment to point out some of the different cases.

I don't necessarily intend to merge this PR, but I was curious to see what it took to sort out the warnings and to start a discussion around it.