### PR TITLE
[VxAdmin] Add a react-query hook for fetching CVR files from the backend

### DIFF
--- a/frontends/election-manager/src/hooks/use_add_cast_vote_record_file_mutation.ts
+++ b/frontends/election-manager/src/hooks/use_add_cast_vote_record_file_mutation.ts
@@ -6,6 +6,7 @@ import {
 import { useContext } from 'react';
 import { ServicesContext } from '../contexts/services_context';
 import { AddCastVoteRecordFileResult } from '../lib/backends';
+import { getCvrFilesQueryKey } from './use_cvr_files_query';
 import { getCvrFileModeQueryKey } from './use_cvr_file_mode_query';
 import { cvrsStorageKey } from './use_election_manager_store';
 
@@ -32,6 +33,7 @@ export function useAddCastVoteRecordFileMutation(): UseAddCastVoteRecordFileMuta
     {
       onSuccess() {
         void queryClient.invalidateQueries([cvrsStorageKey]);
+        void queryClient.invalidateQueries(getCvrFilesQueryKey());
         void queryClient.invalidateQueries(getCvrFileModeQueryKey());
       },
     }

--- a/frontends/election-manager/src/hooks/use_clear_cast_vote_record_files_mutation.ts
+++ b/frontends/election-manager/src/hooks/use_clear_cast_vote_record_files_mutation.ts
@@ -12,6 +12,7 @@ import { getWriteInAdjudicationTableQueryKey } from './use_write_in_adjudication
 import { getCvrFileModeQueryKey } from './use_cvr_file_mode_query';
 import { getWriteInImageQueryKey } from './use_write_in_images_query';
 import { getWriteInSummaryQueryKey } from './use_write_in_summary_query';
+import { getCvrFilesQueryKey } from './use_cvr_files_query';
 
 /**
  * The result of calling {@link useClearCastVoteRecordFilesMutation}.
@@ -46,6 +47,7 @@ export function useClearCastVoteRecordFilesMutation(): UseClearCastVoteRecordFil
         void queryClient.invalidateQueries(
           getCurrentElectionMetadataResultsQueryKey()
         );
+        void queryClient.invalidateQueries(getCvrFilesQueryKey());
         void queryClient.invalidateQueries(getCvrFileModeQueryKey());
       },
     }

--- a/frontends/election-manager/src/hooks/use_cvr_files_query.ts
+++ b/frontends/election-manager/src/hooks/use_cvr_files_query.ts
@@ -1,0 +1,24 @@
+import { QueryKey, useQuery, UseQueryResult } from '@tanstack/react-query';
+import { useContext } from 'react';
+
+import { Admin } from '@votingworks/api';
+
+import { ServicesContext } from '../contexts/services_context';
+
+/**
+ * Gets the query key for the CVR file list query.
+ */
+export function getCvrFilesQueryKey(): QueryKey {
+  return ['cvr-files'];
+}
+
+/**
+ * Returns a metadata query for all imported CVR files, if any, for the current
+ * election.
+ */
+export function useCvrFilesQuery(): UseQueryResult<
+  Admin.CastVoteRecordFileRecord[]
+> {
+  const { backend } = useContext(ServicesContext);
+  return useQuery(getCvrFilesQueryKey(), () => backend.getCvrFiles());
+}

--- a/frontends/election-manager/src/hooks/use_election_manager_store.ts
+++ b/frontends/election-manager/src/hooks/use_election_manager_store.ts
@@ -15,6 +15,7 @@ import { useCallback, useContext, useMemo, useRef } from 'react';
 import { ServicesContext } from '../contexts/services_context';
 import { CastVoteRecordFiles } from '../utils/cast_vote_record_files';
 import { getCurrentElectionMetadataResultsQueryKey } from './use_current_election_metadata';
+import { getCvrFilesQueryKey } from './use_cvr_files_query';
 import { getCvrFileModeQueryKey } from './use_cvr_file_mode_query';
 import { getPrintedBallotsQueryKey } from './use_printed_ballots_query';
 import { getWriteInsQueryKey } from './use_write_ins_query';
@@ -125,6 +126,7 @@ export function useElectionManagerStore(): ElectionManagerStore {
     await queryClient.invalidateQueries(
       getCurrentElectionMetadataResultsQueryKey()
     );
+    await queryClient.invalidateQueries(getCvrFilesQueryKey());
     await queryClient.invalidateQueries(getCvrFileModeQueryKey());
   }, [backend, logger, queryClient]);
 

--- a/frontends/election-manager/src/lib/backends/admin_backend.ts
+++ b/frontends/election-manager/src/lib/backends/admin_backend.ts
@@ -316,6 +316,14 @@ export class ElectionManagerStoreAdminBackend
     return response.cvrFileMode;
   }
 
+  async getCvrFiles(): Promise<Admin.CastVoteRecordFileRecord[]> {
+    const currentElectionId = await this.loadCurrentElectionIdOrThrow();
+
+    return (await fetchJson(
+      `/admin/elections/${currentElectionId}/cvr-files`
+    )) as Admin.CastVoteRecordFileRecord[];
+  }
+
   async addCastVoteRecordFile(
     newCastVoteRecordFile: File,
     options?: { analyzeOnly?: boolean }

--- a/frontends/election-manager/src/lib/backends/memory_backend.ts
+++ b/frontends/election-manager/src/lib/backends/memory_backend.ts
@@ -178,6 +178,32 @@ export class ElectionManagerStoreMemoryBackend
     return newWriteIns;
   }
 
+  getCvrFiles(): Promise<Admin.CastVoteRecordFileRecord[]> {
+    if (!this.electionDefinition) {
+      throw new Error('Election definition must be configured first');
+    }
+
+    if (!this.castVoteRecordFiles) {
+      return Promise.resolve([]);
+    }
+
+    return Promise.resolve(
+      this.castVoteRecordFiles.fileList.map<Admin.CastVoteRecordFileRecord>(
+        (f) => ({
+          createdAt: f.exportTimestamp.toISOString(),
+          electionId: this.electionId,
+          exportTimestamp: f.exportTimestamp.toISOString(),
+          filename: f.name,
+          numCvrsImported: f.importedCvrCount,
+          id: uuid(),
+          precinctIds: [...f.precinctIds],
+          scannerIds: [...f.scannerIds],
+          sha256Hash: '',
+        })
+      )
+    );
+  }
+
   async addCastVoteRecordFile(
     newCastVoteRecordFile: File,
     options?: { analyzeOnly?: boolean }

--- a/frontends/election-manager/src/lib/backends/types.ts
+++ b/frontends/election-manager/src/lib/backends/types.ts
@@ -40,6 +40,11 @@ export interface ElectionManagerStoreBackend {
   getCurrentCvrFileMode(): Promise<Admin.CvrFileMode>;
 
   /**
+   * Returns all imported CVR files for the current election.
+   */
+  getCvrFiles(): Promise<Admin.CastVoteRecordFileRecord[]>;
+
+  /**
    * Loads the existing cast vote record files.
    */
   loadCastVoteRecordFiles(): Promise<CastVoteRecordFiles | undefined>;


### PR DESCRIPTION
## Overview
Related to: https://github.com/votingworks/vxsuite/issues/2716

Adding a react-query hook (and relevant backend client code) for fetching CVR files for the current election from the admin service.

## Testing Plan 
- Added test cases for the new backend client code

## Checklist
- [n/a] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [n/a] I have added a screenshot and/or video to this PR to demo the change
- [n/a] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
