### PR TITLE
[VxAdmin] Add API and client for fetching CVRs for the current election

### DIFF
--- a/frontends/election-manager/src/hooks/use_add_cast_vote_record_file_mutation.ts
+++ b/frontends/election-manager/src/hooks/use_add_cast_vote_record_file_mutation.ts
@@ -6,6 +6,7 @@ import {
 import { useContext } from 'react';
 import { ServicesContext } from '../contexts/services_context';
 import { AddCastVoteRecordFileResult } from '../lib/backends';
+import { getCvrsQueryKey } from './use_cvrs_query';
 import { getCvrFilesQueryKey } from './use_cvr_files_query';
 import { getCvrFileModeQueryKey } from './use_cvr_file_mode_query';
 import { cvrsStorageKey } from './use_election_manager_store';
@@ -34,6 +35,7 @@ export function useAddCastVoteRecordFileMutation(): UseAddCastVoteRecordFileMuta
       onSuccess() {
         void queryClient.invalidateQueries([cvrsStorageKey]);
         void queryClient.invalidateQueries(getCvrFilesQueryKey());
+        void queryClient.invalidateQueries(getCvrsQueryKey());
         void queryClient.invalidateQueries(getCvrFileModeQueryKey());
       },
     }

--- a/frontends/election-manager/src/hooks/use_clear_cast_vote_record_files_mutation.ts
+++ b/frontends/election-manager/src/hooks/use_clear_cast_vote_record_files_mutation.ts
@@ -13,6 +13,7 @@ import { getCvrFileModeQueryKey } from './use_cvr_file_mode_query';
 import { getWriteInImageQueryKey } from './use_write_in_images_query';
 import { getWriteInSummaryQueryKey } from './use_write_in_summary_query';
 import { getCvrFilesQueryKey } from './use_cvr_files_query';
+import { getCvrsQueryKey } from './use_cvrs_query';
 
 /**
  * The result of calling {@link useClearCastVoteRecordFilesMutation}.
@@ -48,6 +49,7 @@ export function useClearCastVoteRecordFilesMutation(): UseClearCastVoteRecordFil
           getCurrentElectionMetadataResultsQueryKey()
         );
         void queryClient.invalidateQueries(getCvrFilesQueryKey());
+        void queryClient.invalidateQueries(getCvrsQueryKey());
         void queryClient.invalidateQueries(getCvrFileModeQueryKey());
       },
     }

--- a/frontends/election-manager/src/hooks/use_cvrs_query.ts
+++ b/frontends/election-manager/src/hooks/use_cvrs_query.ts
@@ -1,0 +1,24 @@
+import { QueryKey, useQuery, UseQueryResult } from '@tanstack/react-query';
+import { useContext } from 'react';
+
+import { Admin } from '@votingworks/api';
+
+import { ServicesContext } from '../contexts/services_context';
+
+/**
+ * Gets the query key for {@link useCvrFilesQuery}.
+ */
+export function getCvrsQueryKey(): QueryKey {
+  return ['cvrs'];
+}
+
+/**
+ * Returns a metadata query for all imported CVR files, if any, for the current
+ * election.
+ */
+export function useCvrFilesQuery(): UseQueryResult<
+  Admin.CastVoteRecordFileRecord[]
+> {
+  const { backend } = useContext(ServicesContext);
+  return useQuery(getCvrsQueryKey(), () => backend.getCvrs());
+}

--- a/frontends/election-manager/src/hooks/use_election_manager_store.ts
+++ b/frontends/election-manager/src/hooks/use_election_manager_store.ts
@@ -15,6 +15,7 @@ import { useCallback, useContext, useMemo, useRef } from 'react';
 import { ServicesContext } from '../contexts/services_context';
 import { CastVoteRecordFiles } from '../utils/cast_vote_record_files';
 import { getCurrentElectionMetadataResultsQueryKey } from './use_current_election_metadata';
+import { getCvrsQueryKey } from './use_cvrs_query';
 import { getCvrFilesQueryKey } from './use_cvr_files_query';
 import { getCvrFileModeQueryKey } from './use_cvr_file_mode_query';
 import { getPrintedBallotsQueryKey } from './use_printed_ballots_query';
@@ -127,6 +128,7 @@ export function useElectionManagerStore(): ElectionManagerStore {
       getCurrentElectionMetadataResultsQueryKey()
     );
     await queryClient.invalidateQueries(getCvrFilesQueryKey());
+    await queryClient.invalidateQueries(getCvrsQueryKey());
     await queryClient.invalidateQueries(getCvrFileModeQueryKey());
   }, [backend, logger, queryClient]);
 

--- a/frontends/election-manager/src/lib/backends/admin_backend.ts
+++ b/frontends/election-manager/src/lib/backends/admin_backend.ts
@@ -1,6 +1,7 @@
 import { Admin, fetchWithSchema } from '@votingworks/api';
 import { LogEventId, Logger, LoggingUserRole } from '@votingworks/logging';
 import {
+  CastVoteRecord,
   ContestId,
   ContestOptionId,
   ElectionDefinition,
@@ -322,6 +323,14 @@ export class ElectionManagerStoreAdminBackend
     return (await fetchJson(
       `/admin/elections/${currentElectionId}/cvr-files`
     )) as Admin.CastVoteRecordFileRecord[];
+  }
+
+  async getCvrs(): Promise<CastVoteRecord[]> {
+    const currentElectionId = await this.loadCurrentElectionIdOrThrow();
+
+    return (await fetchJson(
+      `/admin/elections/${currentElectionId}/cvrs`
+    )) as CastVoteRecord[];
   }
 
   async addCastVoteRecordFile(

--- a/frontends/election-manager/src/lib/backends/memory_backend.ts
+++ b/frontends/election-manager/src/lib/backends/memory_backend.ts
@@ -150,6 +150,18 @@ export class ElectionManagerStoreMemoryBackend
     );
   }
 
+  getCvrs(): Promise<CastVoteRecord[]> {
+    if (!this.electionDefinition) {
+      throw new Error('Election definition must be configured first');
+    }
+
+    if (!this.castVoteRecordFiles) {
+      return Promise.resolve([]);
+    }
+
+    return Promise.resolve([...this.castVoteRecordFiles.castVoteRecords]);
+  }
+
   loadCastVoteRecordFiles(): Promise<CastVoteRecordFiles | undefined> {
     return Promise.resolve(this.castVoteRecordFiles);
   }

--- a/frontends/election-manager/src/lib/backends/types.ts
+++ b/frontends/election-manager/src/lib/backends/types.ts
@@ -1,5 +1,6 @@
 import { Admin } from '@votingworks/api';
 import {
+  CastVoteRecord,
   ContestId,
   ContestOptionId,
   ElectionDefinition,
@@ -43,6 +44,11 @@ export interface ElectionManagerStoreBackend {
    * Returns all imported CVR files for the current election.
    */
   getCvrFiles(): Promise<Admin.CastVoteRecordFileRecord[]>;
+
+  /**
+   * Returns all CVRs for the current election.
+   */
+  getCvrs(): Promise<CastVoteRecord[]>;
 
   /**
    * Loads the existing cast vote record files.

--- a/libs/api/src/services/admin/endpoints.ts
+++ b/libs/api/src/services/admin/endpoints.ts
@@ -1,4 +1,5 @@
 import {
+  CastVoteRecord,
   ContestId,
   ContestIdSchema,
   ContestOptionId,
@@ -273,6 +274,12 @@ export type GetCvrFilesResponse = CastVoteRecordFileRecord[];
  */
 export const GetCvrFilesResponseSchema: z.ZodSchema<GetCvrFilesResponse> =
   z.array(CastVoteRecordFileRecordSchema);
+
+/**
+ * @url /admin/elections/:electionId/cvrs
+ * @method GET
+ */
+export type GetCvrsResponse = CastVoteRecord[];
 
 /**
  * @url /admin/elections/:electionId/cvr-file-mode

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2850,6 +2850,7 @@ importers:
       '@votingworks/types': link:../../libs/types
       '@votingworks/utils': link:../../libs/utils
       better-sqlite3: 7.5.3
+      compression: 1.7.4
       debug: 4.3.4
       express: 4.18.0
       fs-extra: 10.1.0
@@ -2860,6 +2861,7 @@ importers:
     devDependencies:
       '@jest/types': 28.1.1
       '@types/better-sqlite3': 7.5.0
+      '@types/compression': 1.7.2
       '@types/debug': 4.1.7
       '@types/express': 4.17.13
       '@types/fs-extra': 9.0.13
@@ -2898,6 +2900,7 @@ importers:
     specifiers:
       '@jest/types': ^28.1.1
       '@types/better-sqlite3': ^7.5.0
+      '@types/compression': ^1.7.2
       '@types/debug': ^4.1.7
       '@types/express': ^4.17.13
       '@types/fs-extra': ^9.0.13
@@ -2917,6 +2920,7 @@ importers:
       '@votingworks/types': workspace:*
       '@votingworks/utils': workspace:*
       better-sqlite3: ^7.5.3
+      compression: ^1.7.4
       debug: ^4.3.4
       esbuild: ^0.14.29
       esbuild-runner: ^2.2.1
@@ -11282,6 +11286,12 @@ packages:
       '@types/responselike': 1.0.0
     resolution:
       integrity: sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==
+  /@types/compression/1.7.2:
+    dependencies:
+      '@types/express': 4.17.14
+    dev: true
+    resolution:
+      integrity: sha512-lwEL4M/uAGWngWFLSG87ZDr2kLrbuR8p7X+QZB1OQlT+qkHsCPDVFnHPyXf4Vyl4yDDorNY+mAhosxkCvppatg==
   /@types/connect/3.4.35:
     dependencies:
       '@types/node': 17.0.36
@@ -11351,6 +11361,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==
+  /@types/express-serve-static-core/4.17.31:
+    dependencies:
+      '@types/node': 18.8.0
+      '@types/qs': 6.9.7
+      '@types/range-parser': 1.2.4
+    dev: true
+    resolution:
+      integrity: sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==
   /@types/express/4.17.13:
     dependencies:
       '@types/body-parser': 1.19.2
@@ -11360,6 +11378,15 @@ packages:
     dev: true
     resolution:
       integrity: sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==
+  /@types/express/4.17.14:
+    dependencies:
+      '@types/body-parser': 1.19.2
+      '@types/express-serve-static-core': 4.17.31
+      '@types/qs': 6.9.7
+      '@types/serve-static': 1.15.0
+    dev: true
+    resolution:
+      integrity: sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==
   /@types/fast-text-encoding/1.0.1:
     dev: true
     resolution:
@@ -11599,6 +11626,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==
+  /@types/mime/3.0.1:
+    dev: true
+    resolution:
+      integrity: sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==
   /@types/minimatch/3.0.5:
     resolution:
       integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
@@ -11878,6 +11909,13 @@ packages:
     dev: true
     resolution:
       integrity: sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==
+  /@types/serve-static/1.15.0:
+    dependencies:
+      '@types/mime': 3.0.1
+      '@types/node': 18.8.0
+    dev: true
+    resolution:
+      integrity: sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==
   /@types/setimmediate/1.0.2:
     dev: true
     resolution:
@@ -14719,7 +14757,7 @@ packages:
     engines:
       node: '>= 0.8'
     resolution:
-      integrity: sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=
+      integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==
   /bytes/3.1.0:
     dev: false
     engines:

--- a/services/admin/package.json
+++ b/services/admin/package.json
@@ -40,6 +40,7 @@
     "@votingworks/types": "workspace:*",
     "@votingworks/utils": "workspace:*",
     "better-sqlite3": "^7.5.3",
+    "compression": "^1.7.4",
     "debug": "^4.3.4",
     "express": "^4.18.0",
     "fs-extra": "^10.1.0",
@@ -51,6 +52,7 @@
   "devDependencies": {
     "@jest/types": "^28.1.1",
     "@types/better-sqlite3": "^7.5.0",
+    "@types/compression": "^1.7.2",
     "@types/debug": "^4.1.7",
     "@types/express": "^4.17.13",
     "@types/fs-extra": "^9.0.13",

--- a/services/admin/src/server.ts
+++ b/services/admin/src/server.ts
@@ -125,6 +125,10 @@ export function buildApp({ workspace }: { workspace: Workspace }): Application {
     }
   );
 
+  // TODO(https://github.com/votingworks/vxsuite/issues/2613): This endpoint
+  // can be removed once we've moved tally computation to the server - it's
+  // currently only used as a stopgap while we migrate all app state to the
+  // server.
   app.get<{ electionId: Id }, Admin.GetCvrsResponse>(
     '/admin/elections/:electionId/cvrs',
     (request, response) => {
@@ -135,6 +139,12 @@ export function buildApp({ workspace }: { workspace: Workspace }): Application {
             (entry) =>
               safeParseJson(entry.data).unsafeUnwrap() as CastVoteRecord
           )
+          .map((cvr) => ({
+            ...cvr,
+            // Strip out ballot images to keep the response size low, since
+            // they're not needed client-side.
+            _ballotImages: undefined,
+          }))
       );
     }
   );

--- a/services/admin/src/server.ts
+++ b/services/admin/src/server.ts
@@ -3,12 +3,14 @@ import { LogEventId, Logger, LogSource } from '@votingworks/logging';
 import {
   BallotPageLayout,
   CandidateContest,
+  CastVoteRecord,
   getBallotStyle,
   getContests,
   Id,
   InlineBallotImage,
   Rect,
   safeParse,
+  safeParseJson,
   safeParseNumber,
 } from '@votingworks/types';
 import { zip } from '@votingworks/utils';
@@ -118,6 +120,20 @@ export function buildApp({ workspace }: { workspace: Workspace }): Application {
     '/admin/elections/:electionId/cvr-files',
     (request, response) => {
       response.json(store.getCvrFiles(request.params.electionId));
+    }
+  );
+
+  app.get<{ electionId: Id }, Admin.GetCvrsResponse>(
+    '/admin/elections/:electionId/cvrs',
+    (request, response) => {
+      response.json(
+        store
+          .getCastVoteRecordEntries(request.params.electionId)
+          .map(
+            (entry) =>
+              safeParseJson(entry.data).unsafeUnwrap() as CastVoteRecord
+          )
+      );
     }
   );
 

--- a/services/admin/src/server.ts
+++ b/services/admin/src/server.ts
@@ -15,6 +15,7 @@ import {
 } from '@votingworks/types';
 import { zip } from '@votingworks/utils';
 import express, { Application } from 'express';
+import compression from 'compression';
 import * as fs from 'fs/promises';
 import multer from 'multer';
 import { ADMIN_WORKSPACE, PORT } from './globals';
@@ -41,6 +42,7 @@ export function buildApp({ workspace }: { workspace: Workspace }): Application {
   app.use(express.raw());
   app.use(express.json({ limit: '50mb', type: 'application/json' }));
   app.use(express.urlencoded({ extended: false }));
+  app.use(compression());
 
   app.get<NoParams>('/admin/elections', (_request, response) => {
     response.json(store.getElections());

--- a/services/admin/src/store.ts
+++ b/services/admin/src/store.ts
@@ -709,6 +709,7 @@ export class Store {
           datetime(created_at, 'localtime') as createdAt
         from cvrs
         where election_id = ?
+        order by created_at asc
       `,
       electionId
     ) as Array<{


### PR DESCRIPTION
## Overview
Related to: https://github.com/votingworks/vxsuite/issues/2716

- Adding a `GET .../cvrs` endpoint to the admin service for fetching all CVRs for a given election.
- Also adding the relevant client code and react-query hook for interacting with the server endpoint.
- Will be used for generating tallies in the client, in lieu of the CVRs from local storage

## Demo Video or Screenshot
<img width="759" alt="Screenshot 2022-11-23 at 8 30 24 AM" src="https://user-images.githubusercontent.com/264902/203599080-ce9d5661-1e20-4d80-b407-573140cb0d6c.png">

## Testing Plan 
- New test cases for the new API handler and client code
- Manual verification that API call returns expected data

## Checklist
- [n/a] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [n/a] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
