### PR TITLE
Removes Tallies from Card for Suspension Reports

### DIFF
--- a/frontends/bmd/src/app_end_to_end.test.tsx
+++ b/frontends/bmd/src/app_end_to_end.test.tsx
@@ -20,7 +20,7 @@ import {
   MemoryStorage,
   MemoryCard,
   MemoryHardware,
-  TallySourceMachineType,
+  ReportSourceMachineType,
 } from '@votingworks/utils';
 import { fakeLogger, LogEventId } from '@votingworks/logging';
 import userEvent from '@testing-library/user-event';
@@ -379,7 +379,7 @@ it('MarkAndPrint end-to-end flow', async () => {
     pollWorkerCard,
     JSON.stringify({
       tally: getZeroCompressedTally(electionDefinition.election),
-      tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
+      tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       machineId: '0002',
       timeSaved: new Date('2020-10-31').getTime(),
       timePollsTransitioned: new Date('2020-10-31').getTime(),

--- a/frontends/bmd/src/app_polls_flows.test.tsx
+++ b/frontends/bmd/src/app_polls_flows.test.tsx
@@ -15,10 +15,11 @@ import {
 } from '@votingworks/test-utils';
 import {
   ALL_PRECINCTS_SELECTION,
-  PrecinctScannerCardTally,
   singlePrecinctSelectionFor,
-  TallySourceMachineType,
+  ReportSourceMachineType,
   typedAs,
+  PrecinctScannerCardBallotCountReport,
+  PrecinctScannerCardTallyReport,
 } from '@votingworks/utils';
 import userEvent from '@testing-library/user-event';
 import {
@@ -141,8 +142,8 @@ test('full polls flow with tally reports - general, single precinct', async () =
   const precinctSelection = singlePrecinctSelectionFor('23');
 
   // Opening Polls
-  const pollsOpenCardTallyReport: PrecinctScannerCardTally = {
-    tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
+  const pollsOpenCardTallyReport: PrecinctScannerCardTallyReport = {
+    tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
     tally: getZeroCompressedTally(electionSample),
     totalBallotsScanned: 0,
     machineId: '001',
@@ -211,9 +212,8 @@ test('full polls flow with tally reports - general, single precinct', async () =
 
   // Pausing Voting
   const votingPausedTime = new Date('2022-10-31T16:23:00.000Z').getTime();
-  const votingPausedCardTallyReport: PrecinctScannerCardTally = {
-    tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
-    tally: getZeroCompressedTally(electionSample),
+  const votingPausedCardTallyReport: PrecinctScannerCardBallotCountReport = {
+    tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
     totalBallotsScanned: 3,
     machineId: '001',
     timeSaved: votingPausedTime,
@@ -221,10 +221,6 @@ test('full polls flow with tally reports - general, single precinct', async () =
     precinctSelection,
     isLiveMode: true,
     pollsTransition: 'pause_voting',
-    ballotCounts: {
-      'undefined,__ALL_PRECINCTS': [3, 0],
-      'undefined,23': [3, 0],
-    },
   };
 
   card.insertCard(pollWorkerCard, JSON.stringify(votingPausedCardTallyReport));
@@ -283,9 +279,8 @@ test('full polls flow with tally reports - general, single precinct', async () =
 
   // Resuming Voting
   const votingResumedTime = new Date('2022-10-31T16:23:00.000Z').getTime();
-  const votingResumedCardTallyReport: PrecinctScannerCardTally = {
-    tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
-    tally: getZeroCompressedTally(electionSample),
+  const votingResumedCardTallyReport: PrecinctScannerCardBallotCountReport = {
+    tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
     totalBallotsScanned: 3,
     machineId: '001',
     timeSaved: votingResumedTime,
@@ -293,10 +288,6 @@ test('full polls flow with tally reports - general, single precinct', async () =
     precinctSelection,
     isLiveMode: true,
     pollsTransition: 'resume_voting',
-    ballotCounts: {
-      'undefined,__ALL_PRECINCTS': [3, 0],
-      'undefined,23': [3, 0],
-    },
   };
 
   card.insertCard(pollWorkerCard, JSON.stringify(votingResumedCardTallyReport));
@@ -363,8 +354,8 @@ test('full polls flow with tally reports - general, single precinct', async () =
     6 /* for 'court-blumhardt' */, 5 /* for 'boone-lian' */,
     3 /* for 'hildebrand-garritty' */, 0 /* for 'patterson-lariviere' */,
   ]);
-  const pollsClosedCardTallyReport: PrecinctScannerCardTally = {
-    tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
+  const pollsClosedCardTallyReport: PrecinctScannerCardTallyReport = {
+    tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
     tally: existingTally,
     talliesByPrecinct: { '23': existingTally },
     totalBallotsScanned: 25,
@@ -460,8 +451,8 @@ test('tally report: as expected with all precinct combined data for general elec
     6 /* for 'court-blumhardt' */, 5 /* for 'boone-lian' */,
     3 /* for 'hildebrand-garritty' */, 0 /* for 'patterson-lariviere' */,
   ]);
-  const tallyOnCard: PrecinctScannerCardTally = {
-    tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
+  const tallyOnCard: PrecinctScannerCardTallyReport = {
+    tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
     tally: existingTally,
     totalBallotsScanned: 25,
     machineId: '001',
@@ -539,8 +530,8 @@ test('tally report: as expected with all precinct specific data for general elec
     2 /* for 'court-blumhardt' */, 2 /* for 'boone-lian' */,
     1 /* for 'hildebrand-garritty' */, 1 /* for 'patterson-lariviere' */,
   ]);
-  const tallyOnCard: PrecinctScannerCardTally = {
-    tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
+  const tallyOnCard: PrecinctScannerCardTallyReport = {
+    tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
     tally: combinedTally,
     talliesByPrecinct: {
       23: centerSpringfield,
@@ -778,8 +769,8 @@ function checkPrimaryElectionOverallTallyReports(printedElement: RenderResult) {
 test('tally report: as expected with a single precinct for primary election', async () => {
   const electionDefinition = electionMinimalExhaustiveSampleDefinition;
 
-  const tallyOnCard: PrecinctScannerCardTally = {
-    tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
+  const tallyOnCard: PrecinctScannerCardTallyReport = {
+    tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
     tally: primaryElectionOverallTally,
     totalBallotsScanned: 3,
     machineId: '001',
@@ -817,8 +808,8 @@ test('tally report: as expected with a single precinct for primary election', as
 test('tally report: as expected with all precinct combined data for primary election', async () => {
   const electionDefinition = electionMinimalExhaustiveSampleDefinition;
 
-  const tallyOnCard: PrecinctScannerCardTally = {
-    tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
+  const tallyOnCard: PrecinctScannerCardTallyReport = {
+    tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
     tally: primaryElectionOverallTally,
     totalBallotsScanned: 3,
     machineId: '001',
@@ -935,8 +926,8 @@ test('tally report: as expected with all precinct specific data for primary elec
     ],
   };
 
-  const tallyOnCard: PrecinctScannerCardTally = {
-    tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
+  const tallyOnCard: PrecinctScannerCardTallyReport = {
+    tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
     tally: primaryElectionOverallTally,
     talliesByPrecinct,
     totalBallotsScanned: 3,
@@ -1176,8 +1167,8 @@ test('tally report: will print but not update polls state appropriate', async ()
   const precinctSelection = singlePrecinctSelectionFor('23');
 
   // Opening Polls
-  const pollsOpenCardTallyReport: PrecinctScannerCardTally = {
-    tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
+  const pollsOpenCardTallyReport: PrecinctScannerCardTallyReport = {
+    tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
     tally: getZeroCompressedTally(electionSample),
     totalBallotsScanned: 0,
     machineId: '001',
@@ -1378,8 +1369,8 @@ test('will not try to print report or change polls if report on card is in wrong
   const precinctSelection = singlePrecinctSelectionFor('23');
 
   // Closed polls report from L&A left on card
-  const pollsOpenCardTallyReport: PrecinctScannerCardTally = {
-    tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
+  const pollsOpenCardTallyReport: PrecinctScannerCardTallyReport = {
+    tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
     tally: getZeroCompressedTally(electionSample),
     totalBallotsScanned: 0,
     machineId: '001',
@@ -1414,8 +1405,8 @@ test('cannot close polls from closed report on card if polls have not been opene
   const precinctSelection = singlePrecinctSelectionFor('23');
 
   // Polls closed report on card
-  const pollsClosedCardTallyReport: PrecinctScannerCardTally = {
-    tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
+  const pollsClosedCardTallyReport: PrecinctScannerCardTallyReport = {
+    tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
     tally: getZeroCompressedTally(electionSample),
     totalBallotsScanned: 0,
     machineId: '001',

--- a/frontends/bmd/src/app_polls_flows.test.tsx
+++ b/frontends/bmd/src/app_polls_flows.test.tsx
@@ -212,18 +212,22 @@ test('full polls flow with tally reports - general, single precinct', async () =
 
   // Pausing Voting
   const votingPausedTime = new Date('2022-10-31T16:23:00.000Z').getTime();
-  const votingPausedCardTallyReport: PrecinctScannerCardBallotCountReport = {
-    tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
-    totalBallotsScanned: 3,
-    machineId: '001',
-    timeSaved: votingPausedTime,
-    timePollsTransitioned: votingPausedTime,
-    precinctSelection,
-    isLiveMode: true,
-    pollsTransition: 'pause_voting',
-  };
+  const votingPausedCardBallotCountReport: PrecinctScannerCardBallotCountReport =
+    {
+      tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
+      totalBallotsScanned: 3,
+      machineId: '001',
+      timeSaved: votingPausedTime,
+      timePollsTransitioned: votingPausedTime,
+      precinctSelection,
+      isLiveMode: true,
+      pollsTransition: 'pause_voting',
+    };
 
-  card.insertCard(pollWorkerCard, JSON.stringify(votingPausedCardTallyReport));
+  card.insertCard(
+    pollWorkerCard,
+    JSON.stringify(votingPausedCardBallotCountReport)
+  );
   await screen.findByText('Voting Paused Report on Card');
   screen.getByText(/contains a voting paused report/);
   screen.getByText(/the polls will be paused on VxMark/);
@@ -279,18 +283,22 @@ test('full polls flow with tally reports - general, single precinct', async () =
 
   // Resuming Voting
   const votingResumedTime = new Date('2022-10-31T16:23:00.000Z').getTime();
-  const votingResumedCardTallyReport: PrecinctScannerCardBallotCountReport = {
-    tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
-    totalBallotsScanned: 3,
-    machineId: '001',
-    timeSaved: votingResumedTime,
-    timePollsTransitioned: votingResumedTime,
-    precinctSelection,
-    isLiveMode: true,
-    pollsTransition: 'resume_voting',
-  };
+  const votingResumedCardBallotCountReport: PrecinctScannerCardBallotCountReport =
+    {
+      tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
+      totalBallotsScanned: 3,
+      machineId: '001',
+      timeSaved: votingResumedTime,
+      timePollsTransitioned: votingResumedTime,
+      precinctSelection,
+      isLiveMode: true,
+      pollsTransition: 'resume_voting',
+    };
 
-  card.insertCard(pollWorkerCard, JSON.stringify(votingResumedCardTallyReport));
+  card.insertCard(
+    pollWorkerCard,
+    JSON.stringify(votingResumedCardBallotCountReport)
+  );
   await screen.findByText('Voting Resumed Report on Card');
   screen.getByText(/contains a voting resumed report/);
   screen.getByText(/the polls will be open on VxMark/);

--- a/frontends/bmd/src/app_polls_flows.test.tsx
+++ b/frontends/bmd/src/app_polls_flows.test.tsx
@@ -18,8 +18,8 @@ import {
   singlePrecinctSelectionFor,
   ReportSourceMachineType,
   typedAs,
-  PrecinctScannerCardBallotCountReport,
-  PrecinctScannerCardTallyReport,
+  ScannerBallotCountReportData,
+  ScannerTallyReportData,
 } from '@votingworks/utils';
 import userEvent from '@testing-library/user-event';
 import {
@@ -142,7 +142,7 @@ test('full polls flow with tally reports - general, single precinct', async () =
   const precinctSelection = singlePrecinctSelectionFor('23');
 
   // Opening Polls
-  const pollsOpenCardTallyReport: PrecinctScannerCardTallyReport = {
+  const pollsOpenCardTallyReport: ScannerTallyReportData = {
     tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
     tally: getZeroCompressedTally(electionSample),
     totalBallotsScanned: 0,
@@ -212,17 +212,16 @@ test('full polls flow with tally reports - general, single precinct', async () =
 
   // Pausing Voting
   const votingPausedTime = new Date('2022-10-31T16:23:00.000Z').getTime();
-  const votingPausedCardBallotCountReport: PrecinctScannerCardBallotCountReport =
-    {
-      tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
-      totalBallotsScanned: 3,
-      machineId: '001',
-      timeSaved: votingPausedTime,
-      timePollsTransitioned: votingPausedTime,
-      precinctSelection,
-      isLiveMode: true,
-      pollsTransition: 'pause_voting',
-    };
+  const votingPausedCardBallotCountReport: ScannerBallotCountReportData = {
+    tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
+    totalBallotsScanned: 3,
+    machineId: '001',
+    timeSaved: votingPausedTime,
+    timePollsTransitioned: votingPausedTime,
+    precinctSelection,
+    isLiveMode: true,
+    pollsTransition: 'pause_voting',
+  };
 
   card.insertCard(
     pollWorkerCard,
@@ -283,17 +282,16 @@ test('full polls flow with tally reports - general, single precinct', async () =
 
   // Resuming Voting
   const votingResumedTime = new Date('2022-10-31T16:23:00.000Z').getTime();
-  const votingResumedCardBallotCountReport: PrecinctScannerCardBallotCountReport =
-    {
-      tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
-      totalBallotsScanned: 3,
-      machineId: '001',
-      timeSaved: votingResumedTime,
-      timePollsTransitioned: votingResumedTime,
-      precinctSelection,
-      isLiveMode: true,
-      pollsTransition: 'resume_voting',
-    };
+  const votingResumedCardBallotCountReport: ScannerBallotCountReportData = {
+    tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
+    totalBallotsScanned: 3,
+    machineId: '001',
+    timeSaved: votingResumedTime,
+    timePollsTransitioned: votingResumedTime,
+    precinctSelection,
+    isLiveMode: true,
+    pollsTransition: 'resume_voting',
+  };
 
   card.insertCard(
     pollWorkerCard,
@@ -362,7 +360,7 @@ test('full polls flow with tally reports - general, single precinct', async () =
     6 /* for 'court-blumhardt' */, 5 /* for 'boone-lian' */,
     3 /* for 'hildebrand-garritty' */, 0 /* for 'patterson-lariviere' */,
   ]);
-  const pollsClosedCardTallyReport: PrecinctScannerCardTallyReport = {
+  const pollsClosedCardTallyReport: ScannerTallyReportData = {
     tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
     tally: existingTally,
     talliesByPrecinct: { '23': existingTally },
@@ -459,7 +457,7 @@ test('tally report: as expected with all precinct combined data for general elec
     6 /* for 'court-blumhardt' */, 5 /* for 'boone-lian' */,
     3 /* for 'hildebrand-garritty' */, 0 /* for 'patterson-lariviere' */,
   ]);
-  const tallyOnCard: PrecinctScannerCardTallyReport = {
+  const tallyOnCard: ScannerTallyReportData = {
     tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
     tally: existingTally,
     totalBallotsScanned: 25,
@@ -538,7 +536,7 @@ test('tally report: as expected with all precinct specific data for general elec
     2 /* for 'court-blumhardt' */, 2 /* for 'boone-lian' */,
     1 /* for 'hildebrand-garritty' */, 1 /* for 'patterson-lariviere' */,
   ]);
-  const tallyOnCard: PrecinctScannerCardTallyReport = {
+  const tallyOnCard: ScannerTallyReportData = {
     tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
     tally: combinedTally,
     talliesByPrecinct: {
@@ -777,7 +775,7 @@ function checkPrimaryElectionOverallTallyReports(printedElement: RenderResult) {
 test('tally report: as expected with a single precinct for primary election', async () => {
   const electionDefinition = electionMinimalExhaustiveSampleDefinition;
 
-  const tallyOnCard: PrecinctScannerCardTallyReport = {
+  const tallyOnCard: ScannerTallyReportData = {
     tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
     tally: primaryElectionOverallTally,
     totalBallotsScanned: 3,
@@ -816,7 +814,7 @@ test('tally report: as expected with a single precinct for primary election', as
 test('tally report: as expected with all precinct combined data for primary election', async () => {
   const electionDefinition = electionMinimalExhaustiveSampleDefinition;
 
-  const tallyOnCard: PrecinctScannerCardTallyReport = {
+  const tallyOnCard: ScannerTallyReportData = {
     tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
     tally: primaryElectionOverallTally,
     totalBallotsScanned: 3,
@@ -934,7 +932,7 @@ test('tally report: as expected with all precinct specific data for primary elec
     ],
   };
 
-  const tallyOnCard: PrecinctScannerCardTallyReport = {
+  const tallyOnCard: ScannerTallyReportData = {
     tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
     tally: primaryElectionOverallTally,
     talliesByPrecinct,
@@ -1175,7 +1173,7 @@ test('tally report: will print but not update polls state appropriate', async ()
   const precinctSelection = singlePrecinctSelectionFor('23');
 
   // Opening Polls
-  const pollsOpenCardTallyReport: PrecinctScannerCardTallyReport = {
+  const pollsOpenCardTallyReport: ScannerTallyReportData = {
     tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
     tally: getZeroCompressedTally(electionSample),
     totalBallotsScanned: 0,
@@ -1377,7 +1375,7 @@ test('will not try to print report or change polls if report on card is in wrong
   const precinctSelection = singlePrecinctSelectionFor('23');
 
   // Closed polls report from L&A left on card
-  const pollsOpenCardTallyReport: PrecinctScannerCardTallyReport = {
+  const pollsOpenCardTallyReport: ScannerTallyReportData = {
     tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
     tally: getZeroCompressedTally(electionSample),
     totalBallotsScanned: 0,
@@ -1413,7 +1411,7 @@ test('cannot close polls from closed report on card if polls have not been opene
   const precinctSelection = singlePrecinctSelectionFor('23');
 
   // Polls closed report on card
-  const pollsClosedCardTallyReport: PrecinctScannerCardTallyReport = {
+  const pollsClosedCardTallyReport: ScannerTallyReportData = {
     tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
     tally: getZeroCompressedTally(electionSample),
     totalBallotsScanned: 0,

--- a/frontends/bmd/src/pages/poll_worker_screen.test.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.test.tsx
@@ -9,7 +9,7 @@ import {
 
 import { fireEvent, screen } from '@testing-library/react';
 import {
-  PrecinctScannerCardReport,
+  ScannerReportData,
   singlePrecinctSelectionFor,
   MemoryHardware,
 } from '@votingworks/utils';
@@ -43,7 +43,7 @@ beforeEach(() => {
 
 function fakePollworkerAuth(
   electionDefinition: ElectionDefinition,
-  tally?: PrecinctScannerCardReport
+  tally?: ScannerReportData
 ): InsertedSmartcardAuth.PollWorkerLoggedIn {
   return Inserted.fakePollWorkerAuth(
     fakePollWorkerUser({ electionHash: electionDefinition.electionHash }),

--- a/frontends/bmd/src/pages/poll_worker_screen.test.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.test.tsx
@@ -9,7 +9,7 @@ import {
 
 import { fireEvent, screen } from '@testing-library/react';
 import {
-  PrecinctScannerCardTally,
+  PrecinctScannerCardReport,
   singlePrecinctSelectionFor,
   MemoryHardware,
 } from '@votingworks/utils';
@@ -43,7 +43,7 @@ beforeEach(() => {
 
 function fakePollworkerAuth(
   electionDefinition: ElectionDefinition,
-  tally?: PrecinctScannerCardTally
+  tally?: PrecinctScannerCardReport
 ): InsertedSmartcardAuth.PollWorkerLoggedIn {
   return Inserted.fakePollWorkerAuth(
     fakePollWorkerUser({ electionHash: electionDefinition.electionHash }),

--- a/frontends/bmd/src/pages/poll_worker_screen.tsx
+++ b/frontends/bmd/src/pages/poll_worker_screen.tsx
@@ -51,7 +51,8 @@ import {
   PrecinctScannerCardReport,
   PrecinctScannerCardTallyReport,
   PrecinctScannerCardReportSchema,
-  isPrecinctScannerCardBallotCountReport,
+  isPollsSuspensionTransition,
+  PrecinctScannerCardBallotCountReport,
 } from '@votingworks/utils';
 
 import { LogEventId, Logger } from '@votingworks/logging';
@@ -116,6 +117,12 @@ function parsePrecinctScannerCardReportTally(
   };
 }
 
+function isPrecinctScannerBallotCountReport(
+  precinctScannerCardReport: PrecinctScannerCardReport
+): precinctScannerCardReport is PrecinctScannerCardBallotCountReport {
+  return isPollsSuspensionTransition(precinctScannerCardReport.pollsTransition);
+}
+
 type PrecinctScannerReportModalState = 'initial' | 'printing' | 'reprint';
 
 function PrecinctScannerReportModal({
@@ -149,7 +156,7 @@ function PrecinctScannerReportModal({
 
   async function printReport(copies: number) {
     const report = await (async () => {
-      if (isPrecinctScannerCardBallotCountReport(precinctScannerReport)) {
+      if (isPrecinctScannerBallotCountReport(precinctScannerReport)) {
         return (
           <PrecinctScannerBallotCountReport
             electionDefinition={electionDefinition}

--- a/frontends/precinct-scanner/src/app.test.tsx
+++ b/frontends/precinct-scanner/src/app.test.tsx
@@ -3,7 +3,7 @@ import { promises as fs } from 'fs';
 import { Scan } from '@votingworks/api';
 import {
   ALL_PRECINCTS_SELECTION,
-  TallySourceMachineType,
+  ReportSourceMachineType,
   readBallotPackageFromFilePointer,
   singlePrecinctSelectionFor,
 } from '@votingworks/utils';
@@ -483,7 +483,7 @@ test('voter can cast a ballot that scans successfully ', async () => {
   expect(writeLongObjectMock).toHaveBeenCalledWith(
     expect.objectContaining({
       isLiveMode: false,
-      tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
+      tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 1,
       machineId: '0002',
       timeSaved: expect.anything(),
@@ -911,7 +911,7 @@ test('no printer: open polls, scan ballot, close polls, save results', async () 
   expect(writeLongObjectMock).toHaveBeenCalledWith(
     expect.objectContaining({
       isLiveMode: false,
-      tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
+      tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 1,
       machineId: '0002',
       timeSaved: expect.anything(),

--- a/frontends/precinct-scanner/src/app_tally_report_paths.test.tsx
+++ b/frontends/precinct-scanner/src/app_tally_report_paths.test.tsx
@@ -24,7 +24,7 @@ import {
   ALL_PRECINCTS_SELECTION,
   BallotCountDetails,
   singlePrecinctSelectionFor,
-  TallySourceMachineType,
+  ReportSourceMachineType,
 } from '@votingworks/utils';
 import {
   CompressedTally,
@@ -236,7 +236,7 @@ test('saving to card: polls open, All Precincts, primary election + test failed 
     1,
     expect.objectContaining({
       isLiveMode: false,
-      tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
+      tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 0,
       machineId: '0002',
       timePollsTransitioned: expect.anything(),
@@ -253,7 +253,7 @@ test('saving to card: polls open, All Precincts, primary election + test failed 
     2,
     expect.objectContaining({
       isLiveMode: false,
-      tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
+      tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 0,
       machineId: '0002',
       timePollsTransitioned: expect.anything(),
@@ -583,7 +583,7 @@ test('saving to card: polls closed, primary election, all precincts', async () =
   expect(writeLongObjectMock).toHaveBeenCalledWith(
     expect.objectContaining({
       isLiveMode: false,
-      tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
+      tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 3,
       machineId: '0002',
       timePollsTransitioned: expect.anything(),
@@ -822,7 +822,7 @@ test('saving to card: polls closed, primary election, single precinct', async ()
   expect(writeLongObjectMock).toHaveBeenCalledWith(
     expect.objectContaining({
       isLiveMode: false,
-      tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
+      tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 3,
       machineId: '0002',
       timePollsTransitioned: expect.anything(),
@@ -1011,7 +1011,7 @@ test('saving to card: polls closed, general election, all precincts', async () =
   expect(writeLongObjectMock).toHaveBeenCalledWith(
     expect.objectContaining({
       isLiveMode: false,
-      tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
+      tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 2,
       machineId: '0002',
       timePollsTransitioned: expect.anything(),
@@ -1164,7 +1164,7 @@ test('saving to card: polls closed, general election, single precinct', async ()
   expect(writeLongObjectMock).toHaveBeenCalledWith(
     expect.objectContaining({
       isLiveMode: false,
-      tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
+      tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 2,
       machineId: '0002',
       timePollsTransitioned: expect.anything(),
@@ -1247,23 +1247,16 @@ test('saving to card: polls paused', async () => {
   card.removeCard();
   await advanceTimersAndPromises(1);
 
-  const expectedBallotCounts: Dictionary<BallotCountDetails> = {
-    'undefined,__ALL_PRECINCTS': [1, 1],
-    'undefined,23': [1, 1],
-  };
   expect(writeLongObjectMock).toHaveBeenCalledTimes(1);
   expect(writeLongObjectMock).toHaveBeenCalledWith(
     expect.objectContaining({
       isLiveMode: false,
-      tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
+      tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 2,
       machineId: '0002',
       timePollsTransitioned: expect.anything(),
       timeSaved: expect.anything(),
       precinctSelection: singlePrecinctSelectionFor('23'),
-      tally: expect.anything(),
-      talliesByPrecinct: expect.anything(),
-      ballotCounts: expectedBallotCounts,
       pollsTransition: 'pause_voting',
     })
   );
@@ -1335,23 +1328,16 @@ test('saving to card: polls unpaused', async () => {
   card.removeCard();
   await advanceTimersAndPromises(1);
 
-  const expectedBallotCounts: Dictionary<BallotCountDetails> = {
-    'undefined,__ALL_PRECINCTS': [1, 1],
-    'undefined,23': [1, 1],
-  };
   expect(writeLongObjectMock).toHaveBeenCalledTimes(1);
   expect(writeLongObjectMock).toHaveBeenCalledWith(
     expect.objectContaining({
       isLiveMode: false,
-      tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
+      tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 2,
       machineId: '0002',
       timePollsTransitioned: expect.anything(),
       timeSaved: expect.anything(),
       precinctSelection: singlePrecinctSelectionFor('23'),
-      tally: expect.anything(),
-      talliesByPrecinct: expect.anything(),
-      ballotCounts: expectedBallotCounts,
       pollsTransition: 'resume_voting',
     })
   );
@@ -1471,7 +1457,7 @@ test('saving to card: polls closed from paused, general election, single precinc
   expect(writeLongObjectMock).toHaveBeenCalledWith(
     expect.objectContaining({
       isLiveMode: false,
-      tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
+      tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 2,
       machineId: '0002',
       timePollsTransitioned: expect.anything(),

--- a/frontends/precinct-scanner/src/screens/poll_worker_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/poll_worker_screen.tsx
@@ -8,9 +8,10 @@ import {
   isPollWorkerAuth,
   DEFAULT_NUMBER_POLL_REPORT_COPIES,
   fontSizeTheme,
-  PrecinctScannerFullReport,
+  PrecinctScannerTallyReports,
   printElement,
   getSignedQuickResultsReportingUrl,
+  PrecinctScannerBallotCountReport,
 } from '@votingworks/ui';
 import {
   assert,
@@ -21,13 +22,17 @@ import {
   getSubTalliesByPartyAndPrecinct,
   getTallyIdentifier,
   isFeatureFlagEnabled,
-  PrecinctScannerCardTally,
-  PrecinctScannerCardTallySchema,
+  PrecinctScannerCardReport,
+  PrecinctScannerCardReportSchema,
   sleep,
-  TallySourceMachineType,
+  ReportSourceMachineType,
   throwIllegalValue,
   getPollsTransitionDestinationState,
   getPollsReportTitle,
+  PrecinctScannerCardBallotCountReport,
+  isPollsSuspensionTransition,
+  PrecinctScannerCardTallyReport,
+  PrecinctScannerCardReportBase,
 } from '@votingworks/utils';
 import {
   CastVoteRecord,
@@ -65,15 +70,15 @@ type PollWorkerFlowState =
   | 'polls_transition_complete'
   | 'reprinting_report';
 
-async function saveTallyToCard(
+async function saveReportToCard(
   auth: InsertedSmartcardAuth.PollWorkerLoggedIn,
-  cardTally: PrecinctScannerCardTally
+  cardReport: PrecinctScannerCardReport
 ): Promise<boolean> {
-  await auth.card.writeStoredData(cardTally);
+  await auth.card.writeStoredData(cardReport);
   const possibleTally = await auth.card.readStoredObject(
-    PrecinctScannerCardTallySchema
+    PrecinctScannerCardReportSchema
   );
-  return possibleTally.ok()?.timeSaved === cardTally.timeSaved;
+  return possibleTally.ok()?.timeSaved === cardReport.timeSaved;
 }
 
 async function getCvrsFromExport(): Promise<CastVoteRecord[]> {
@@ -181,14 +186,35 @@ export function PollWorkerScreen({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  async function saveTally(
+  async function saveReport(
     pollsTransition: PollsTransition,
     timePollsTransitioned: number
   ) {
+    assert(precinctSelection);
+    assert(isPollWorkerAuth(auth));
+    const reportBasicInformation: PrecinctScannerCardReportBase = {
+      tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
+      machineId: machineConfig.machineId,
+      isLiveMode,
+      precinctSelection,
+      totalBallotsScanned: scannedBallotCount,
+      timeSaved: Date.now(),
+      timePollsTransitioned,
+    };
+
+    if (isPollsSuspensionTransition(pollsTransition)) {
+      const cardBallotCountReport: PrecinctScannerCardBallotCountReport = {
+        ...reportBasicInformation,
+        pollsTransition,
+      };
+      await saveReportToCard(auth, cardBallotCountReport);
+      return;
+    }
+
     assert(currentTally);
+    assert(currentCompressedTally);
     let compressedTalliesByPrecinct: Dictionary<CompressedTally> = {};
     // We only need to save tallies by precinct if the precinct scanner is configured for all precincts
-    assert(precinctSelection);
     if (precinctSelection.kind === 'AllPrecincts') {
       const talliesByPrecinct = currentTally.resultsByCategory.get(
         TallyCategory.Precinct
@@ -239,31 +265,23 @@ export function PollWorkerScreen({
         subTally.ballotCountsByVotingMethod[VotingMethod.Absentee] ?? 0,
       ];
     }
-    assert(currentCompressedTally);
 
-    const fullTallyInformation: PrecinctScannerCardTally = {
-      tallyMachineType: TallySourceMachineType.PRECINCT_SCANNER,
-      totalBallotsScanned: scannedBallotCount,
-      isLiveMode,
+    const cardTallyReport: PrecinctScannerCardTallyReport = {
+      ...reportBasicInformation,
       pollsTransition,
-      machineId: machineConfig.machineId,
-      timeSaved: Date.now(),
-      timePollsTransitioned,
-      precinctSelection,
-      ballotCounts: ballotCountBreakdowns,
-      talliesByPrecinct: compressedTalliesByPrecinct,
       tally: currentCompressedTally,
+      talliesByPrecinct: compressedTalliesByPrecinct,
+      ballotCounts: ballotCountBreakdowns,
     };
 
-    assert(isPollWorkerAuth(auth));
-    const success = await saveTallyToCard(auth, fullTallyInformation);
+    const success = await saveReportToCard(auth, cardTallyReport);
     if (!success) {
       debug(
         'Error saving tally information to card, trying again without precinct-specific data'
       );
       // TODO show an error message if this attempt also fails.
-      await saveTallyToCard(auth, {
-        ...fullTallyInformation,
+      await saveReportToCard(auth, {
+        ...cardTallyReport,
         talliesByPrecinct: undefined,
         timeSaved: Date.now(),
       });
@@ -274,7 +292,7 @@ export function PollWorkerScreen({
     return setPollWorkerFlowState(undefined);
   }
 
-  async function printTallyReport(
+  async function printReport(
     pollsTransition: PollsTransition,
     timePollsTransitioned: number,
     copies: number
@@ -284,33 +302,49 @@ export function PollWorkerScreen({
     assert(currentCompressedTally);
     assert(currentSubTallies);
 
-    const signedQuickResultsReportingUrl =
-      await getSignedQuickResultsReportingUrl({
-        electionDefinition,
-        isLiveMode,
-        compressedTally: currentCompressedTally,
-        signingMachineId: machineConfig.machineId,
-      });
-
-    await printElement(
-      <PrecinctScannerFullReport
-        electionDefinition={electionDefinition}
-        precinctSelection={precinctSelection}
-        subTallies={currentSubTallies}
-        hasPrecinctSubTallies
-        pollsTransition={pollsTransition}
-        isLiveMode={isLiveMode}
-        pollsTransitionedTime={timePollsTransitioned}
-        currentTime={Date.now()}
-        precinctScannerMachineId={machineConfig.machineId}
-        totalBallotsScanned={scannedBallotCount}
-        signedQuickResultsReportingUrl={signedQuickResultsReportingUrl}
-      />,
-      {
-        sides: 'one-sided',
-        copies,
+    const report = await (async () => {
+      if (isPollsSuspensionTransition(pollsTransition)) {
+        return (
+          <PrecinctScannerBallotCountReport
+            electionDefinition={electionDefinition}
+            precinctSelection={precinctSelection}
+            totalBallotsScanned={scannedBallotCount}
+            pollsTransition={pollsTransition}
+            pollsTransitionedTime={timePollsTransitioned}
+            isLiveMode={isLiveMode}
+            precinctScannerMachineId={machineConfig.machineId}
+          />
+        );
       }
-    );
+
+      const signedQuickResultsReportingUrl =
+        await getSignedQuickResultsReportingUrl({
+          electionDefinition,
+          isLiveMode,
+          compressedTally: currentCompressedTally,
+          signingMachineId: machineConfig.machineId,
+        });
+
+      return (
+        <PrecinctScannerTallyReports
+          electionDefinition={electionDefinition}
+          precinctSelection={precinctSelection}
+          subTallies={currentSubTallies}
+          hasPrecinctSubTallies
+          pollsTransition={pollsTransition}
+          isLiveMode={isLiveMode}
+          pollsTransitionedTime={timePollsTransitioned}
+          precinctScannerMachineId={machineConfig.machineId}
+          totalBallotsScanned={scannedBallotCount}
+          signedQuickResultsReportingUrl={signedQuickResultsReportingUrl}
+        />
+      );
+    })();
+
+    await printElement(report, {
+      sides: 'one-sided',
+      copies,
+    });
   }
 
   async function dispatchReport(
@@ -318,13 +352,13 @@ export function PollWorkerScreen({
     timePollsTransitioned: number
   ) {
     if (hasPrinterAttached) {
-      await printTallyReport(
+      await printReport(
         pollsTransition,
         timePollsTransitioned,
         DEFAULT_NUMBER_POLL_REPORT_COPIES
       );
     } else {
-      await saveTally(pollsTransition, timePollsTransitioned);
+      await saveReport(pollsTransition, timePollsTransitioned);
     }
   }
 
@@ -372,11 +406,7 @@ export function PollWorkerScreen({
     assert(typeof currentPollsTransition === 'string');
     assert(typeof currentPollsTransitionTime === 'number');
     setPollWorkerFlowState('reprinting_report');
-    await printTallyReport(
-      currentPollsTransition,
-      currentPollsTransitionTime,
-      1
-    );
+    await printReport(currentPollsTransition, currentPollsTransitionTime, 1);
     await sleep(REPRINT_REPORT_TIMEOUT_SECONDS * 1000);
     setPollWorkerFlowState('polls_transition_complete');
   }

--- a/libs/fixtures/data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingPausedAllPrecincts.json
+++ b/libs/fixtures/data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingPausedAllPrecincts.json
@@ -1,6 +1,6 @@
 {
   "tallyMachineType": "precinct_scanner",
-  "totalBallotsScanned": 0,
+  "totalBallotsScanned": 97,
   "isLiveMode": false,
   "pollsTransition": "pause_voting",
   "machineId": "0000",
@@ -8,39 +8,5 @@
   "timePollsTransitioned": 1665616069769,
   "precinctSelection": {
     "kind": "AllPrecincts"
-  },
-  "ballotCounts": {
-    "0,precinct-1": [0, 0],
-    "0,precinct-2": [0, 0],
-    "1,precinct-1": [0, 0],
-    "1,precinct-2": [0, 0],
-    "0,__ALL_PRECINCTS": [0, 0],
-    "1,__ALL_PRECINCTS": [0, 0]
-  },
-  "talliesByPrecinct": {
-    "precinct-1": [
-      [0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0]
-    ],
-    "precinct-2": [
-      [0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0]
-    ]
-  },
-  "tally": [
-    [0, 0, 0, 0, 0, 0, 0],
-    [0, 0, 0, 0, 0, 0],
-    [0, 0, 0, 0, 0, 0, 0, 0],
-    [0, 0, 0, 0, 0, 0, 0, 0],
-    [0, 0, 0, 0, 0, 0, 0, 0, 0],
-    [0, 0, 0, 0, 0]
-  ]
+  }
 }

--- a/libs/fixtures/data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingPausedSinglePrecinct.json
+++ b/libs/fixtures/data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingPausedSinglePrecinct.json
@@ -1,37 +1,13 @@
 {
   "tallyMachineType": "precinct_scanner",
-  "totalBallotsScanned": 0,
+  "totalBallotsScanned": 97,
   "isLiveMode": false,
   "pollsTransition": "pause_voting",
   "machineId": "0000",
-  "timeSaved": 1665617553851,
-  "timePollsTransitioned": 1665617553851,
+  "timeSaved": 1665616069769,
+  "timePollsTransitioned": 1665616069769,
   "precinctSelection": {
     "kind": "SinglePrecinct",
     "precinctId": "precinct-1"
-  },
-  "ballotCounts": {
-    "0,precinct-1": [0, 0],
-    "1,precinct-1": [0, 0],
-    "0,__ALL_PRECINCTS": [0, 0],
-    "1,__ALL_PRECINCTS": [0, 0]
-  },
-  "talliesByPrecinct": {
-    "precinct-1": [
-      [0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0]
-    ]
-  },
-  "tally": [
-    [0, 0, 0, 0, 0, 0, 0],
-    [0, 0, 0, 0, 0, 0],
-    [0, 0, 0, 0, 0, 0, 0, 0],
-    [0, 0, 0, 0, 0, 0, 0, 0],
-    [0, 0, 0, 0, 0, 0, 0, 0, 0],
-    [0, 0, 0, 0, 0]
-  ]
+  }
 }

--- a/libs/fixtures/data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingResumedAllPrecincts.json
+++ b/libs/fixtures/data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingResumedAllPrecincts.json
@@ -1,46 +1,12 @@
 {
   "tallyMachineType": "precinct_scanner",
-  "totalBallotsScanned": 0,
+  "totalBallotsScanned": 97,
   "isLiveMode": false,
   "pollsTransition": "resume_voting",
   "machineId": "0000",
-  "timeSaved": 1665616069769,
-  "timePollsTransitioned": 1665616069769,
+  "timeSaved": 1665617553851,
+  "timePollsTransitioned": 1665617553851,
   "precinctSelection": {
     "kind": "AllPrecincts"
-  },
-  "ballotCounts": {
-    "0,precinct-1": [0, 0],
-    "0,precinct-2": [0, 0],
-    "1,precinct-1": [0, 0],
-    "1,precinct-2": [0, 0],
-    "0,__ALL_PRECINCTS": [0, 0],
-    "1,__ALL_PRECINCTS": [0, 0]
-  },
-  "talliesByPrecinct": {
-    "precinct-1": [
-      [0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0]
-    ],
-    "precinct-2": [
-      [0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0]
-    ]
-  },
-  "tally": [
-    [0, 0, 0, 0, 0, 0, 0],
-    [0, 0, 0, 0, 0, 0],
-    [0, 0, 0, 0, 0, 0, 0, 0],
-    [0, 0, 0, 0, 0, 0, 0, 0],
-    [0, 0, 0, 0, 0, 0, 0, 0, 0],
-    [0, 0, 0, 0, 0]
-  ]
+  }
 }

--- a/libs/fixtures/data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingResumedSinglePrecinct.json
+++ b/libs/fixtures/data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingResumedSinglePrecinct.json
@@ -1,6 +1,6 @@
 {
   "tallyMachineType": "precinct_scanner",
-  "totalBallotsScanned": 0,
+  "totalBallotsScanned": 97,
   "isLiveMode": false,
   "pollsTransition": "resume_voting",
   "machineId": "0000",
@@ -9,29 +9,5 @@
   "precinctSelection": {
     "kind": "SinglePrecinct",
     "precinctId": "precinct-1"
-  },
-  "ballotCounts": {
-    "0,precinct-1": [0, 0],
-    "1,precinct-1": [0, 0],
-    "0,__ALL_PRECINCTS": [0, 0],
-    "1,__ALL_PRECINCTS": [0, 0]
-  },
-  "talliesByPrecinct": {
-    "precinct-1": [
-      [0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0]
-    ]
-  },
-  "tally": [
-    [0, 0, 0, 0, 0, 0, 0],
-    [0, 0, 0, 0, 0, 0],
-    [0, 0, 0, 0, 0, 0, 0, 0],
-    [0, 0, 0, 0, 0, 0, 0, 0],
-    [0, 0, 0, 0, 0, 0, 0, 0, 0],
-    [0, 0, 0, 0, 0]
-  ]
+  }
 }

--- a/libs/fixtures/src/data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingPausedAllPrecincts.json.ts
+++ b/libs/fixtures/src/data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingPausedAllPrecincts.json.ts
@@ -10,9 +10,9 @@ import { join, sep } from 'path';
 /**
  * Data of data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingPausedAllPrecincts.json encoded as base64.
  *
- * SHA-256 hash of file data: e245ed66493dd7c2be75cd2a5676258d0a3cd60b6c4bb37532fbc3102c27e4f6
+ * SHA-256 hash of file data: 388bbdd36b122a6325525d50dd36f3810bb0b8a7523b1b7b1079934b5423121d
  */
-const resourceDataBase64 = 'ewogICJ0YWxseU1hY2hpbmVUeXBlIjogInByZWNpbmN0X3NjYW5uZXIiLAogICJ0b3RhbEJhbGxvdHNTY2FubmVkIjogMCwKICAiaXNMaXZlTW9kZSI6IGZhbHNlLAogICJwb2xsc1RyYW5zaXRpb24iOiAicGF1c2Vfdm90aW5nIiwKICAibWFjaGluZUlkIjogIjAwMDAiLAogICJ0aW1lU2F2ZWQiOiAxNjY1NjE2MDY5NzY5LAogICJ0aW1lUG9sbHNUcmFuc2l0aW9uZWQiOiAxNjY1NjE2MDY5NzY5LAogICJwcmVjaW5jdFNlbGVjdGlvbiI6IHsKICAgICJraW5kIjogIkFsbFByZWNpbmN0cyIKICB9LAogICJiYWxsb3RDb3VudHMiOiB7CiAgICAiMCxwcmVjaW5jdC0xIjogWzAsIDBdLAogICAgIjAscHJlY2luY3QtMiI6IFswLCAwXSwKICAgICIxLHByZWNpbmN0LTEiOiBbMCwgMF0sCiAgICAiMSxwcmVjaW5jdC0yIjogWzAsIDBdLAogICAgIjAsX19BTExfUFJFQ0lOQ1RTIjogWzAsIDBdLAogICAgIjEsX19BTExfUFJFQ0lOQ1RTIjogWzAsIDBdCiAgfSwKICAidGFsbGllc0J5UHJlY2luY3QiOiB7CiAgICAicHJlY2luY3QtMSI6IFsKICAgICAgWzAsIDAsIDAsIDAsIDAsIDAsIDBdLAogICAgICBbMCwgMCwgMCwgMCwgMCwgMF0sCiAgICAgIFswLCAwLCAwLCAwLCAwLCAwLCAwLCAwXSwKICAgICAgWzAsIDAsIDAsIDAsIDAsIDAsIDAsIDBdLAogICAgICBbMCwgMCwgMCwgMCwgMCwgMCwgMCwgMCwgMF0sCiAgICAgIFswLCAwLCAwLCAwLCAwXQogICAgXSwKICAgICJwcmVjaW5jdC0yIjogWwogICAgICBbMCwgMCwgMCwgMCwgMCwgMCwgMF0sCiAgICAgIFswLCAwLCAwLCAwLCAwLCAwXSwKICAgICAgWzAsIDAsIDAsIDAsIDAsIDAsIDAsIDBdLAogICAgICBbMCwgMCwgMCwgMCwgMCwgMCwgMCwgMF0sCiAgICAgIFswLCAwLCAwLCAwLCAwLCAwLCAwLCAwLCAwXSwKICAgICAgWzAsIDAsIDAsIDAsIDBdCiAgICBdCiAgfSwKICAidGFsbHkiOiBbCiAgICBbMCwgMCwgMCwgMCwgMCwgMCwgMF0sCiAgICBbMCwgMCwgMCwgMCwgMCwgMF0sCiAgICBbMCwgMCwgMCwgMCwgMCwgMCwgMCwgMF0sCiAgICBbMCwgMCwgMCwgMCwgMCwgMCwgMCwgMF0sCiAgICBbMCwgMCwgMCwgMCwgMCwgMCwgMCwgMCwgMF0sCiAgICBbMCwgMCwgMCwgMCwgMF0KICBdCn0K';
+const resourceDataBase64 = 'ewogICJ0YWxseU1hY2hpbmVUeXBlIjogInByZWNpbmN0X3NjYW5uZXIiLAogICJ0b3RhbEJhbGxvdHNTY2FubmVkIjogOTcsCiAgImlzTGl2ZU1vZGUiOiBmYWxzZSwKICAicG9sbHNUcmFuc2l0aW9uIjogInBhdXNlX3ZvdGluZyIsCiAgIm1hY2hpbmVJZCI6ICIwMDAwIiwKICAidGltZVNhdmVkIjogMTY2NTYxNjA2OTc2OSwKICAidGltZVBvbGxzVHJhbnNpdGlvbmVkIjogMTY2NTYxNjA2OTc2OSwKICAicHJlY2luY3RTZWxlY3Rpb24iOiB7CiAgICAia2luZCI6ICJBbGxQcmVjaW5jdHMiCiAgfQp9Cg==';
 
 /**
  * MIME type of data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingPausedAllPrecincts.json.
@@ -22,7 +22,7 @@ export const mimeType = 'application/json';
 /**
  * Path to a file containing this file's contents.
  *
- * SHA-256 hash of file data: e245ed66493dd7c2be75cd2a5676258d0a3cd60b6c4bb37532fbc3102c27e4f6
+ * SHA-256 hash of file data: 388bbdd36b122a6325525d50dd36f3810bb0b8a7523b1b7b1079934b5423121d
  */
 export function asFilePath(): string {
   const directoryPath = mkdtempSync(tmpdir() + sep);
@@ -34,7 +34,7 @@ export function asFilePath(): string {
 /**
  * Convert to a `data:` URL of data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingPausedAllPrecincts.json, suitable for embedding in HTML.
  *
- * SHA-256 hash of file data: e245ed66493dd7c2be75cd2a5676258d0a3cd60b6c4bb37532fbc3102c27e4f6
+ * SHA-256 hash of file data: 388bbdd36b122a6325525d50dd36f3810bb0b8a7523b1b7b1079934b5423121d
  */
 export function asDataUrl(): string {
   return `data:${mimeType};base64,${resourceDataBase64}`;
@@ -43,7 +43,7 @@ export function asDataUrl(): string {
 /**
  * Raw data of data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingPausedAllPrecincts.json.
  *
- * SHA-256 hash of file data: e245ed66493dd7c2be75cd2a5676258d0a3cd60b6c4bb37532fbc3102c27e4f6
+ * SHA-256 hash of file data: 388bbdd36b122a6325525d50dd36f3810bb0b8a7523b1b7b1079934b5423121d
  */
 export function asBuffer(): Buffer {
   return Buffer.from(resourceDataBase64, 'base64');
@@ -52,7 +52,7 @@ export function asBuffer(): Buffer {
 /**
  * Text content of data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingPausedAllPrecincts.json.
  *
- * SHA-256 hash of file data: e245ed66493dd7c2be75cd2a5676258d0a3cd60b6c4bb37532fbc3102c27e4f6
+ * SHA-256 hash of file data: 388bbdd36b122a6325525d50dd36f3810bb0b8a7523b1b7b1079934b5423121d
  */
 export function asText(): string {
   return asBuffer().toString('utf-8');

--- a/libs/fixtures/src/data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingPausedSinglePrecinct.json.ts
+++ b/libs/fixtures/src/data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingPausedSinglePrecinct.json.ts
@@ -10,9 +10,9 @@ import { join, sep } from 'path';
 /**
  * Data of data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingPausedSinglePrecinct.json encoded as base64.
  *
- * SHA-256 hash of file data: a623099417c896f7a2bbf9b646fc5b86926ef88692911c08400b049a89f1080b
+ * SHA-256 hash of file data: 8697f48d895fa7e49199b9f571493033bbde08d5b45258026aa68f21c8448301
  */
-const resourceDataBase64 = 'ewogICJ0YWxseU1hY2hpbmVUeXBlIjogInByZWNpbmN0X3NjYW5uZXIiLAogICJ0b3RhbEJhbGxvdHNTY2FubmVkIjogMCwKICAiaXNMaXZlTW9kZSI6IGZhbHNlLAogICJwb2xsc1RyYW5zaXRpb24iOiAicGF1c2Vfdm90aW5nIiwKICAibWFjaGluZUlkIjogIjAwMDAiLAogICJ0aW1lU2F2ZWQiOiAxNjY1NjE3NTUzODUxLAogICJ0aW1lUG9sbHNUcmFuc2l0aW9uZWQiOiAxNjY1NjE3NTUzODUxLAogICJwcmVjaW5jdFNlbGVjdGlvbiI6IHsKICAgICJraW5kIjogIlNpbmdsZVByZWNpbmN0IiwKICAgICJwcmVjaW5jdElkIjogInByZWNpbmN0LTEiCiAgfSwKICAiYmFsbG90Q291bnRzIjogewogICAgIjAscHJlY2luY3QtMSI6IFswLCAwXSwKICAgICIxLHByZWNpbmN0LTEiOiBbMCwgMF0sCiAgICAiMCxfX0FMTF9QUkVDSU5DVFMiOiBbMCwgMF0sCiAgICAiMSxfX0FMTF9QUkVDSU5DVFMiOiBbMCwgMF0KICB9LAogICJ0YWxsaWVzQnlQcmVjaW5jdCI6IHsKICAgICJwcmVjaW5jdC0xIjogWwogICAgICBbMCwgMCwgMCwgMCwgMCwgMCwgMF0sCiAgICAgIFswLCAwLCAwLCAwLCAwLCAwXSwKICAgICAgWzAsIDAsIDAsIDAsIDAsIDAsIDAsIDBdLAogICAgICBbMCwgMCwgMCwgMCwgMCwgMCwgMCwgMF0sCiAgICAgIFswLCAwLCAwLCAwLCAwLCAwLCAwLCAwLCAwXSwKICAgICAgWzAsIDAsIDAsIDAsIDBdCiAgICBdCiAgfSwKICAidGFsbHkiOiBbCiAgICBbMCwgMCwgMCwgMCwgMCwgMCwgMF0sCiAgICBbMCwgMCwgMCwgMCwgMCwgMF0sCiAgICBbMCwgMCwgMCwgMCwgMCwgMCwgMCwgMF0sCiAgICBbMCwgMCwgMCwgMCwgMCwgMCwgMCwgMF0sCiAgICBbMCwgMCwgMCwgMCwgMCwgMCwgMCwgMCwgMF0sCiAgICBbMCwgMCwgMCwgMCwgMF0KICBdCn0K';
+const resourceDataBase64 = 'ewogICJ0YWxseU1hY2hpbmVUeXBlIjogInByZWNpbmN0X3NjYW5uZXIiLAogICJ0b3RhbEJhbGxvdHNTY2FubmVkIjogOTcsCiAgImlzTGl2ZU1vZGUiOiBmYWxzZSwKICAicG9sbHNUcmFuc2l0aW9uIjogInBhdXNlX3ZvdGluZyIsCiAgIm1hY2hpbmVJZCI6ICIwMDAwIiwKICAidGltZVNhdmVkIjogMTY2NTYxNjA2OTc2OSwKICAidGltZVBvbGxzVHJhbnNpdGlvbmVkIjogMTY2NTYxNjA2OTc2OSwKICAicHJlY2luY3RTZWxlY3Rpb24iOiB7CiAgICAia2luZCI6ICJTaW5nbGVQcmVjaW5jdCIsCiAgICAicHJlY2luY3RJZCI6ICJwcmVjaW5jdC0xIgogIH0KfQo=';
 
 /**
  * MIME type of data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingPausedSinglePrecinct.json.
@@ -22,7 +22,7 @@ export const mimeType = 'application/json';
 /**
  * Path to a file containing this file's contents.
  *
- * SHA-256 hash of file data: a623099417c896f7a2bbf9b646fc5b86926ef88692911c08400b049a89f1080b
+ * SHA-256 hash of file data: 8697f48d895fa7e49199b9f571493033bbde08d5b45258026aa68f21c8448301
  */
 export function asFilePath(): string {
   const directoryPath = mkdtempSync(tmpdir() + sep);
@@ -34,7 +34,7 @@ export function asFilePath(): string {
 /**
  * Convert to a `data:` URL of data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingPausedSinglePrecinct.json, suitable for embedding in HTML.
  *
- * SHA-256 hash of file data: a623099417c896f7a2bbf9b646fc5b86926ef88692911c08400b049a89f1080b
+ * SHA-256 hash of file data: 8697f48d895fa7e49199b9f571493033bbde08d5b45258026aa68f21c8448301
  */
 export function asDataUrl(): string {
   return `data:${mimeType};base64,${resourceDataBase64}`;
@@ -43,7 +43,7 @@ export function asDataUrl(): string {
 /**
  * Raw data of data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingPausedSinglePrecinct.json.
  *
- * SHA-256 hash of file data: a623099417c896f7a2bbf9b646fc5b86926ef88692911c08400b049a89f1080b
+ * SHA-256 hash of file data: 8697f48d895fa7e49199b9f571493033bbde08d5b45258026aa68f21c8448301
  */
 export function asBuffer(): Buffer {
   return Buffer.from(resourceDataBase64, 'base64');
@@ -52,7 +52,7 @@ export function asBuffer(): Buffer {
 /**
  * Text content of data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingPausedSinglePrecinct.json.
  *
- * SHA-256 hash of file data: a623099417c896f7a2bbf9b646fc5b86926ef88692911c08400b049a89f1080b
+ * SHA-256 hash of file data: 8697f48d895fa7e49199b9f571493033bbde08d5b45258026aa68f21c8448301
  */
 export function asText(): string {
   return asBuffer().toString('utf-8');

--- a/libs/fixtures/src/data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingResumedAllPrecincts.json.ts
+++ b/libs/fixtures/src/data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingResumedAllPrecincts.json.ts
@@ -10,9 +10,9 @@ import { join, sep } from 'path';
 /**
  * Data of data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingResumedAllPrecincts.json encoded as base64.
  *
- * SHA-256 hash of file data: f5ab337c38f93658c1827f82bd5eda53c9daa8e2b5cbf55f421c839b7ccf7a87
+ * SHA-256 hash of file data: c76d279277fb33af41c7f2f72f0eef1391d77b3dec3cff56c531507ebe76994a
  */
-const resourceDataBase64 = 'ewogICJ0YWxseU1hY2hpbmVUeXBlIjogInByZWNpbmN0X3NjYW5uZXIiLAogICJ0b3RhbEJhbGxvdHNTY2FubmVkIjogMCwKICAiaXNMaXZlTW9kZSI6IGZhbHNlLAogICJwb2xsc1RyYW5zaXRpb24iOiAicmVzdW1lX3ZvdGluZyIsCiAgIm1hY2hpbmVJZCI6ICIwMDAwIiwKICAidGltZVNhdmVkIjogMTY2NTYxNjA2OTc2OSwKICAidGltZVBvbGxzVHJhbnNpdGlvbmVkIjogMTY2NTYxNjA2OTc2OSwKICAicHJlY2luY3RTZWxlY3Rpb24iOiB7CiAgICAia2luZCI6ICJBbGxQcmVjaW5jdHMiCiAgfSwKICAiYmFsbG90Q291bnRzIjogewogICAgIjAscHJlY2luY3QtMSI6IFswLCAwXSwKICAgICIwLHByZWNpbmN0LTIiOiBbMCwgMF0sCiAgICAiMSxwcmVjaW5jdC0xIjogWzAsIDBdLAogICAgIjEscHJlY2luY3QtMiI6IFswLCAwXSwKICAgICIwLF9fQUxMX1BSRUNJTkNUUyI6IFswLCAwXSwKICAgICIxLF9fQUxMX1BSRUNJTkNUUyI6IFswLCAwXQogIH0sCiAgInRhbGxpZXNCeVByZWNpbmN0IjogewogICAgInByZWNpbmN0LTEiOiBbCiAgICAgIFswLCAwLCAwLCAwLCAwLCAwLCAwXSwKICAgICAgWzAsIDAsIDAsIDAsIDAsIDBdLAogICAgICBbMCwgMCwgMCwgMCwgMCwgMCwgMCwgMF0sCiAgICAgIFswLCAwLCAwLCAwLCAwLCAwLCAwLCAwXSwKICAgICAgWzAsIDAsIDAsIDAsIDAsIDAsIDAsIDAsIDBdLAogICAgICBbMCwgMCwgMCwgMCwgMF0KICAgIF0sCiAgICAicHJlY2luY3QtMiI6IFsKICAgICAgWzAsIDAsIDAsIDAsIDAsIDAsIDBdLAogICAgICBbMCwgMCwgMCwgMCwgMCwgMF0sCiAgICAgIFswLCAwLCAwLCAwLCAwLCAwLCAwLCAwXSwKICAgICAgWzAsIDAsIDAsIDAsIDAsIDAsIDAsIDBdLAogICAgICBbMCwgMCwgMCwgMCwgMCwgMCwgMCwgMCwgMF0sCiAgICAgIFswLCAwLCAwLCAwLCAwXQogICAgXQogIH0sCiAgInRhbGx5IjogWwogICAgWzAsIDAsIDAsIDAsIDAsIDAsIDBdLAogICAgWzAsIDAsIDAsIDAsIDAsIDBdLAogICAgWzAsIDAsIDAsIDAsIDAsIDAsIDAsIDBdLAogICAgWzAsIDAsIDAsIDAsIDAsIDAsIDAsIDBdLAogICAgWzAsIDAsIDAsIDAsIDAsIDAsIDAsIDAsIDBdLAogICAgWzAsIDAsIDAsIDAsIDBdCiAgXQp9Cg==';
+const resourceDataBase64 = 'ewogICJ0YWxseU1hY2hpbmVUeXBlIjogInByZWNpbmN0X3NjYW5uZXIiLAogICJ0b3RhbEJhbGxvdHNTY2FubmVkIjogOTcsCiAgImlzTGl2ZU1vZGUiOiBmYWxzZSwKICAicG9sbHNUcmFuc2l0aW9uIjogInJlc3VtZV92b3RpbmciLAogICJtYWNoaW5lSWQiOiAiMDAwMCIsCiAgInRpbWVTYXZlZCI6IDE2NjU2MTc1NTM4NTEsCiAgInRpbWVQb2xsc1RyYW5zaXRpb25lZCI6IDE2NjU2MTc1NTM4NTEsCiAgInByZWNpbmN0U2VsZWN0aW9uIjogewogICAgImtpbmQiOiAiQWxsUHJlY2luY3RzIgogIH0KfQo=';
 
 /**
  * MIME type of data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingResumedAllPrecincts.json.
@@ -22,7 +22,7 @@ export const mimeType = 'application/json';
 /**
  * Path to a file containing this file's contents.
  *
- * SHA-256 hash of file data: f5ab337c38f93658c1827f82bd5eda53c9daa8e2b5cbf55f421c839b7ccf7a87
+ * SHA-256 hash of file data: c76d279277fb33af41c7f2f72f0eef1391d77b3dec3cff56c531507ebe76994a
  */
 export function asFilePath(): string {
   const directoryPath = mkdtempSync(tmpdir() + sep);
@@ -34,7 +34,7 @@ export function asFilePath(): string {
 /**
  * Convert to a `data:` URL of data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingResumedAllPrecincts.json, suitable for embedding in HTML.
  *
- * SHA-256 hash of file data: f5ab337c38f93658c1827f82bd5eda53c9daa8e2b5cbf55f421c839b7ccf7a87
+ * SHA-256 hash of file data: c76d279277fb33af41c7f2f72f0eef1391d77b3dec3cff56c531507ebe76994a
  */
 export function asDataUrl(): string {
   return `data:${mimeType};base64,${resourceDataBase64}`;
@@ -43,7 +43,7 @@ export function asDataUrl(): string {
 /**
  * Raw data of data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingResumedAllPrecincts.json.
  *
- * SHA-256 hash of file data: f5ab337c38f93658c1827f82bd5eda53c9daa8e2b5cbf55f421c839b7ccf7a87
+ * SHA-256 hash of file data: c76d279277fb33af41c7f2f72f0eef1391d77b3dec3cff56c531507ebe76994a
  */
 export function asBuffer(): Buffer {
   return Buffer.from(resourceDataBase64, 'base64');
@@ -52,7 +52,7 @@ export function asBuffer(): Buffer {
 /**
  * Text content of data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingResumedAllPrecincts.json.
  *
- * SHA-256 hash of file data: f5ab337c38f93658c1827f82bd5eda53c9daa8e2b5cbf55f421c839b7ccf7a87
+ * SHA-256 hash of file data: c76d279277fb33af41c7f2f72f0eef1391d77b3dec3cff56c531507ebe76994a
  */
 export function asText(): string {
   return asBuffer().toString('utf-8');

--- a/libs/fixtures/src/data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingResumedSinglePrecinct.json.ts
+++ b/libs/fixtures/src/data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingResumedSinglePrecinct.json.ts
@@ -10,9 +10,9 @@ import { join, sep } from 'path';
 /**
  * Data of data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingResumedSinglePrecinct.json encoded as base64.
  *
- * SHA-256 hash of file data: d4f0a08faa6d65f185a7747388da43aa679f49a7e70b2e6c46ae21da3c0bf76d
+ * SHA-256 hash of file data: 9aa8657f814548dbca6b7a251f2703ddea59b3bb7c8eb1ec5e40dd0f7d1580f1
  */
-const resourceDataBase64 = 'ewogICJ0YWxseU1hY2hpbmVUeXBlIjogInByZWNpbmN0X3NjYW5uZXIiLAogICJ0b3RhbEJhbGxvdHNTY2FubmVkIjogMCwKICAiaXNMaXZlTW9kZSI6IGZhbHNlLAogICJwb2xsc1RyYW5zaXRpb24iOiAicmVzdW1lX3ZvdGluZyIsCiAgIm1hY2hpbmVJZCI6ICIwMDAwIiwKICAidGltZVNhdmVkIjogMTY2NTYxNzU1Mzg1MSwKICAidGltZVBvbGxzVHJhbnNpdGlvbmVkIjogMTY2NTYxNzU1Mzg1MSwKICAicHJlY2luY3RTZWxlY3Rpb24iOiB7CiAgICAia2luZCI6ICJTaW5nbGVQcmVjaW5jdCIsCiAgICAicHJlY2luY3RJZCI6ICJwcmVjaW5jdC0xIgogIH0sCiAgImJhbGxvdENvdW50cyI6IHsKICAgICIwLHByZWNpbmN0LTEiOiBbMCwgMF0sCiAgICAiMSxwcmVjaW5jdC0xIjogWzAsIDBdLAogICAgIjAsX19BTExfUFJFQ0lOQ1RTIjogWzAsIDBdLAogICAgIjEsX19BTExfUFJFQ0lOQ1RTIjogWzAsIDBdCiAgfSwKICAidGFsbGllc0J5UHJlY2luY3QiOiB7CiAgICAicHJlY2luY3QtMSI6IFsKICAgICAgWzAsIDAsIDAsIDAsIDAsIDAsIDBdLAogICAgICBbMCwgMCwgMCwgMCwgMCwgMF0sCiAgICAgIFswLCAwLCAwLCAwLCAwLCAwLCAwLCAwXSwKICAgICAgWzAsIDAsIDAsIDAsIDAsIDAsIDAsIDBdLAogICAgICBbMCwgMCwgMCwgMCwgMCwgMCwgMCwgMCwgMF0sCiAgICAgIFswLCAwLCAwLCAwLCAwXQogICAgXQogIH0sCiAgInRhbGx5IjogWwogICAgWzAsIDAsIDAsIDAsIDAsIDAsIDBdLAogICAgWzAsIDAsIDAsIDAsIDAsIDBdLAogICAgWzAsIDAsIDAsIDAsIDAsIDAsIDAsIDBdLAogICAgWzAsIDAsIDAsIDAsIDAsIDAsIDAsIDBdLAogICAgWzAsIDAsIDAsIDAsIDAsIDAsIDAsIDAsIDBdLAogICAgWzAsIDAsIDAsIDAsIDBdCiAgXQp9Cg==';
+const resourceDataBase64 = 'ewogICJ0YWxseU1hY2hpbmVUeXBlIjogInByZWNpbmN0X3NjYW5uZXIiLAogICJ0b3RhbEJhbGxvdHNTY2FubmVkIjogOTcsCiAgImlzTGl2ZU1vZGUiOiBmYWxzZSwKICAicG9sbHNUcmFuc2l0aW9uIjogInJlc3VtZV92b3RpbmciLAogICJtYWNoaW5lSWQiOiAiMDAwMCIsCiAgInRpbWVTYXZlZCI6IDE2NjU2MTc1NTM4NTEsCiAgInRpbWVQb2xsc1RyYW5zaXRpb25lZCI6IDE2NjU2MTc1NTM4NTEsCiAgInByZWNpbmN0U2VsZWN0aW9uIjogewogICAgImtpbmQiOiAiU2luZ2xlUHJlY2luY3QiLAogICAgInByZWNpbmN0SWQiOiAicHJlY2luY3QtMSIKICB9Cn0K';
 
 /**
  * MIME type of data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingResumedSinglePrecinct.json.
@@ -22,7 +22,7 @@ export const mimeType = 'application/json';
 /**
  * Path to a file containing this file's contents.
  *
- * SHA-256 hash of file data: d4f0a08faa6d65f185a7747388da43aa679f49a7e70b2e6c46ae21da3c0bf76d
+ * SHA-256 hash of file data: 9aa8657f814548dbca6b7a251f2703ddea59b3bb7c8eb1ec5e40dd0f7d1580f1
  */
 export function asFilePath(): string {
   const directoryPath = mkdtempSync(tmpdir() + sep);
@@ -34,7 +34,7 @@ export function asFilePath(): string {
 /**
  * Convert to a `data:` URL of data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingResumedSinglePrecinct.json, suitable for embedding in HTML.
  *
- * SHA-256 hash of file data: d4f0a08faa6d65f185a7747388da43aa679f49a7e70b2e6c46ae21da3c0bf76d
+ * SHA-256 hash of file data: 9aa8657f814548dbca6b7a251f2703ddea59b3bb7c8eb1ec5e40dd0f7d1580f1
  */
 export function asDataUrl(): string {
   return `data:${mimeType};base64,${resourceDataBase64}`;
@@ -43,7 +43,7 @@ export function asDataUrl(): string {
 /**
  * Raw data of data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingResumedSinglePrecinct.json.
  *
- * SHA-256 hash of file data: d4f0a08faa6d65f185a7747388da43aa679f49a7e70b2e6c46ae21da3c0bf76d
+ * SHA-256 hash of file data: 9aa8657f814548dbca6b7a251f2703ddea59b3bb7c8eb1ec5e40dd0f7d1580f1
  */
 export function asBuffer(): Buffer {
   return Buffer.from(resourceDataBase64, 'base64');
@@ -52,7 +52,7 @@ export function asBuffer(): Buffer {
 /**
  * Text content of data/electionMinimalExhaustiveSample/precinctScannerCardTallies/votingResumedSinglePrecinct.json.
  *
- * SHA-256 hash of file data: d4f0a08faa6d65f185a7747388da43aa679f49a7e70b2e6c46ae21da3c0bf76d
+ * SHA-256 hash of file data: 9aa8657f814548dbca6b7a251f2703ddea59b3bb7c8eb1ec5e40dd0f7d1580f1
  */
 export function asText(): string {
   return asBuffer().toString('utf-8');

--- a/libs/types/src/polls.ts
+++ b/libs/types/src/polls.ts
@@ -13,15 +13,17 @@ export const PollsStateSchema: z.ZodSchema<PollsState> = z.union([
   z.literal('polls_closed_final'),
 ]);
 
+export type StandardPollsTransition = 'open_polls' | 'close_polls';
+export type PollsSuspensionTransition = 'pause_voting' | 'resume_voting';
 export type PollsTransition =
-  | 'open_polls'
-  | 'pause_voting'
-  | 'resume_voting'
-  | 'close_polls';
+  | StandardPollsTransition
+  | PollsSuspensionTransition;
 
+export const StandardPollsTransitionSchema: z.ZodSchema<StandardPollsTransition> =
+  z.union([z.literal('open_polls'), z.literal('close_polls')]);
+export const PollsSuspensionTransitionSchema: z.ZodSchema<PollsSuspensionTransition> =
+  z.union([z.literal('pause_voting'), z.literal('resume_voting')]);
 export const PollsTransitionSchema: z.ZodSchema<PollsTransition> = z.union([
-  z.literal('open_polls'),
-  z.literal('pause_voting'),
-  z.literal('resume_voting'),
-  z.literal('close_polls'),
+  StandardPollsTransitionSchema,
+  PollsSuspensionTransitionSchema,
 ]);

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -53,5 +53,6 @@ export * from './unlock_machine_screen';
 export * from './system_administrator_screen_contents';
 export * from './unconfigure_machine_button';
 export * from './print_element';
-export * from './precinct_scanner_full_report';
+export * from './precinct_scanner_tally_reports';
 export * from './change_precinct_button';
+export * from './precinct_scanner_ballot_count_report';

--- a/libs/ui/src/precinct_scanner_ballot_count_report.test.tsx
+++ b/libs/ui/src/precinct_scanner_ballot_count_report.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import MockDate from 'mockdate';
 import { render, screen } from '@testing-library/react';
 import { electionSampleDefinition } from '@votingworks/fixtures';
 import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
@@ -9,6 +10,7 @@ const pollsTransitionedTime = new Date(2021, 8, 19, 11, 5).getTime();
 const currentTime = new Date(2021, 8, 19, 11, 6).getTime();
 
 test('renders info properly', () => {
+  MockDate.set(currentTime);
   render(
     <PrecinctScannerBallotCountReport
       electionDefinition={electionSampleDefinition}
@@ -16,7 +18,6 @@ test('renders info properly', () => {
       totalBallotsScanned={23}
       pollsTransition="pause_voting"
       pollsTransitionedTime={pollsTransitionedTime}
-      currentTime={currentTime}
       isLiveMode={false}
       precinctScannerMachineId="SC-01-000"
     />

--- a/libs/ui/src/precinct_scanner_ballot_count_report.tsx
+++ b/libs/ui/src/precinct_scanner_ballot_count_report.tsx
@@ -1,4 +1,8 @@
-import { ElectionDefinition, PrecinctSelection } from '@votingworks/types';
+import {
+  ElectionDefinition,
+  PollsSuspensionTransition,
+  PrecinctSelection,
+} from '@votingworks/types';
 import {
   formatFullDateTimeZone,
   getPollsStateName,
@@ -39,9 +43,8 @@ interface Props {
   electionDefinition: ElectionDefinition;
   precinctSelection: PrecinctSelection;
   totalBallotsScanned: number;
-  pollsTransition: 'pause_voting' | 'resume_voting';
+  pollsTransition: PollsSuspensionTransition;
   pollsTransitionedTime: number;
-  currentTime: number;
   isLiveMode: boolean;
   precinctScannerMachineId: string;
 }
@@ -52,10 +55,11 @@ export function PrecinctScannerBallotCountReport({
   totalBallotsScanned,
   pollsTransition,
   pollsTransitionedTime,
-  currentTime,
   isLiveMode,
   precinctScannerMachineId,
 }: Props): JSX.Element {
+  const currentTime = Date.now();
+
   return (
     <PrintableContainer data-testid="ballot-count-report">
       <TallyReport>

--- a/libs/ui/src/precinct_scanner_tally_report.tsx
+++ b/libs/ui/src/precinct_scanner_tally_report.tsx
@@ -2,6 +2,7 @@ import {
   ElectionDefinition,
   PartyId,
   PrecinctSelection,
+  StandardPollsTransition,
   Tally,
 } from '@votingworks/types';
 import React from 'react';
@@ -20,13 +21,17 @@ interface Props {
   partyId?: PartyId;
   precinctSelection: PrecinctSelection;
   tally: Tally;
-  pollsTransition: 'open_polls' | 'close_polls';
+  pollsTransition: StandardPollsTransition;
   isLiveMode: boolean;
   pollsTransitionedTime: number;
   currentTime: number;
   precinctScannerMachineId: string;
 }
 
+/**
+ * A single tally report representing a single precinct selection and party
+ * selection, which could be "All Precincts" and "No Party" respectively.
+ */
 export function PrecinctScannerTallyReport({
   electionDefinition,
   partyId,

--- a/libs/ui/src/precinct_scanner_tally_reports.test.tsx
+++ b/libs/ui/src/precinct_scanner_tally_reports.test.tsx
@@ -12,7 +12,7 @@ import {
   getSubTalliesByPartyAndPrecinct,
   singlePrecinctSelectionFor,
 } from '@votingworks/utils';
-import { PrecinctScannerFullReport } from './precinct_scanner_full_report';
+import { PrecinctScannerTallyReports } from './precinct_scanner_tally_reports';
 
 test('polls closed: tally reports for each party in primary, single precinct', () => {
   const { election } = electionMinimalExhaustiveSampleDefinition;
@@ -27,14 +27,13 @@ test('polls closed: tally reports for each party in primary, single precinct', (
     precinctSelection,
   });
   render(
-    <PrecinctScannerFullReport
+    <PrecinctScannerTallyReports
       electionDefinition={electionMinimalExhaustiveSampleDefinition}
       precinctSelection={precinctSelection}
       subTallies={subTallies}
       pollsTransition="close_polls"
       isLiveMode
       pollsTransitionedTime={new Date().getTime()}
-      currentTime={new Date().getTime()}
       precinctScannerMachineId="SC-01-000"
       totalBallotsScanned={1} // to trigger qr code page
       signedQuickResultsReportingUrl="https://voting.works"
@@ -64,7 +63,7 @@ test('polls closed: tally reports for each precinct when there is data for all p
     precinctSelection: ALL_PRECINCTS_SELECTION,
   });
   render(
-    <PrecinctScannerFullReport
+    <PrecinctScannerTallyReports
       electionDefinition={electionDefinition}
       precinctSelection={ALL_PRECINCTS_SELECTION}
       hasPrecinctSubTallies
@@ -72,7 +71,6 @@ test('polls closed: tally reports for each precinct when there is data for all p
       pollsTransition="close_polls"
       isLiveMode
       pollsTransitionedTime={new Date().getTime()}
-      currentTime={new Date().getTime()}
       precinctScannerMachineId="SC-01-000"
       totalBallotsScanned={0}
       signedQuickResultsReportingUrl="https://voting.works"
@@ -100,7 +98,7 @@ test('polls closed: tally report for "All Precincts" when there is only data for
     tally,
   });
   render(
-    <PrecinctScannerFullReport
+    <PrecinctScannerTallyReports
       electionDefinition={electionDefinition}
       precinctSelection={ALL_PRECINCTS_SELECTION}
       hasPrecinctSubTallies={false}
@@ -108,7 +106,6 @@ test('polls closed: tally report for "All Precincts" when there is only data for
       pollsTransition="close_polls"
       isLiveMode
       pollsTransitionedTime={new Date().getTime()}
-      currentTime={new Date().getTime()}
       precinctScannerMachineId="SC-01-000"
       totalBallotsScanned={0}
       signedQuickResultsReportingUrl="https://voting.works"
@@ -116,40 +113,6 @@ test('polls closed: tally report for "All Precincts" when there is only data for
   );
 
   screen.getByText('Official Polls Closed Report for All Precincts');
-  expect(
-    screen.queryByText('Automatic Election Results Reporting')
-  ).not.toBeInTheDocument();
-});
-
-test('polls paused: includes ballot count page only', () => {
-  const { electionDefinition } = electionFamousNames2021Fixtures;
-  const { election } = electionDefinition;
-  const tally: FullElectionTally = {
-    overallTally: getEmptyTally(),
-    resultsByCategory: new Map(),
-  };
-  const subTallies = getSubTalliesByPartyAndPrecinct({
-    election,
-    tally,
-  });
-  render(
-    <PrecinctScannerFullReport
-      electionDefinition={electionDefinition}
-      precinctSelection={ALL_PRECINCTS_SELECTION}
-      hasPrecinctSubTallies={false}
-      subTallies={subTallies}
-      pollsTransition="pause_voting"
-      isLiveMode
-      pollsTransitionedTime={new Date().getTime()}
-      currentTime={new Date().getTime()}
-      precinctScannerMachineId="SC-01-000"
-      totalBallotsScanned={0}
-      signedQuickResultsReportingUrl="https://voting.works"
-    />
-  );
-
-  screen.getByText('Official Voting Paused Report for All Precincts');
-  screen.getByText('Ballots Scanned Count');
   expect(
     screen.queryByText('Automatic Election Results Reporting')
   ).not.toBeInTheDocument();
@@ -167,7 +130,7 @@ test('includes quick results page under right conditions', () => {
     tally,
   });
   render(
-    <PrecinctScannerFullReport
+    <PrecinctScannerTallyReports
       electionDefinition={
         electionMinimalExhaustiveSampleWithReportingUrlDefinition
       }
@@ -176,7 +139,6 @@ test('includes quick results page under right conditions', () => {
       pollsTransition="close_polls" // to trigger qrcode
       isLiveMode
       pollsTransitionedTime={new Date().getTime()}
-      currentTime={new Date().getTime()}
       precinctScannerMachineId="SC-01-000"
       totalBallotsScanned={1} // to trigger qrcode
       signedQuickResultsReportingUrl="https://voting.works"
@@ -195,7 +157,7 @@ test('does not include quick results page if ballot count is 0', () => {
   };
   const subTallies = getSubTalliesByPartyAndPrecinct({ election, tally });
   render(
-    <PrecinctScannerFullReport
+    <PrecinctScannerTallyReports
       electionDefinition={
         electionMinimalExhaustiveSampleWithReportingUrlDefinition
       }
@@ -204,7 +166,6 @@ test('does not include quick results page if ballot count is 0', () => {
       pollsTransition="close_polls" // to trigger qrcode
       isLiveMode
       pollsTransitionedTime={new Date().getTime()}
-      currentTime={new Date().getTime()}
       precinctScannerMachineId="SC-01-000"
       totalBallotsScanned={0} // to disable qrcode
       signedQuickResultsReportingUrl="https://voting.works"
@@ -228,7 +189,7 @@ test('does not include quick results page if polls are being opened', () => {
     tally,
   });
   render(
-    <PrecinctScannerFullReport
+    <PrecinctScannerTallyReports
       electionDefinition={
         electionMinimalExhaustiveSampleWithReportingUrlDefinition
       }
@@ -237,7 +198,6 @@ test('does not include quick results page if polls are being opened', () => {
       pollsTransition="open_polls" // to disable qrcode
       isLiveMode
       pollsTransitionedTime={new Date().getTime()}
-      currentTime={new Date().getTime()}
       precinctScannerMachineId="SC-01-000"
       totalBallotsScanned={1} // to trigger qrcode
       signedQuickResultsReportingUrl="https://voting.works"

--- a/libs/ui/src/precinct_scanner_tally_reports.tsx
+++ b/libs/ui/src/precinct_scanner_tally_reports.tsx
@@ -1,8 +1,8 @@
 import {
   ElectionDefinition,
   getPartyIdsInBallotStyles,
-  PollsTransition,
   PrecinctSelection,
+  StandardPollsTransition,
   Tally,
 } from '@votingworks/types';
 import {
@@ -11,25 +11,27 @@ import {
   singlePrecinctSelectionFor,
 } from '@votingworks/utils';
 import React from 'react';
-import { PrecinctScannerBallotCountReport } from './precinct_scanner_ballot_count_report';
 import { PrecinctScannerTallyQrCode } from './precinct_scanner_tally_qrcode';
 import { PrecinctScannerTallyReport } from './precinct_scanner_tally_report';
 
-export interface PrecinctScannerFullReportProps {
+export interface PrecinctScannerTallyReportsProps {
   electionDefinition: ElectionDefinition;
   precinctSelection: PrecinctSelection;
   hasPrecinctSubTallies?: boolean;
   subTallies: ReadonlyMap<string, Tally>;
-  pollsTransition: PollsTransition;
+  pollsTransition: StandardPollsTransition;
   isLiveMode: boolean;
   pollsTransitionedTime: number;
-  currentTime: number;
   precinctScannerMachineId: string;
   signedQuickResultsReportingUrl: string;
   totalBallotsScanned: number;
 }
 
-export function PrecinctScannerFullReport({
+/**
+ * A tally report for each precinct and party represented in the scanner's
+ * results. Additionally, the VxQR code page if applicable.
+ */
+export function PrecinctScannerTallyReports({
   electionDefinition,
   precinctSelection,
   hasPrecinctSubTallies,
@@ -37,29 +39,11 @@ export function PrecinctScannerFullReport({
   pollsTransition,
   isLiveMode,
   pollsTransitionedTime,
-  currentTime,
   precinctScannerMachineId,
   signedQuickResultsReportingUrl,
   totalBallotsScanned,
-}: PrecinctScannerFullReportProps): JSX.Element {
-  const showTallies =
-    pollsTransition === 'open_polls' || pollsTransition === 'close_polls';
-
-  if (!showTallies) {
-    return (
-      <PrecinctScannerBallotCountReport
-        electionDefinition={electionDefinition}
-        precinctSelection={precinctSelection}
-        pollsTransition={pollsTransition}
-        totalBallotsScanned={totalBallotsScanned}
-        isLiveMode={isLiveMode}
-        pollsTransitionedTime={pollsTransitionedTime}
-        currentTime={currentTime}
-        precinctScannerMachineId={precinctScannerMachineId}
-      />
-    );
-  }
-
+}: PrecinctScannerTallyReportsProps): JSX.Element {
+  const currentTime = Date.now();
   const parties = getPartyIdsInBallotStyles(electionDefinition.election);
   const showQuickResults =
     electionDefinition.election.quickResultsReportingUrl &&

--- a/libs/utils/src/polls.test.ts
+++ b/libs/utils/src/polls.test.ts
@@ -5,6 +5,7 @@ import {
   getPollsTransitionActionPastTense,
   getPollsTransitionDestinationState,
   getPollTransitionsFromState,
+  isPollsSuspensionTransition,
   isValidPollsStateChange,
 } from './polls';
 
@@ -124,4 +125,11 @@ test('getPollsTransitionActionPastTense', () => {
   expect(getPollsTransitionActionPastTense('pause_voting')).toEqual(
     'Voting Paused'
   );
+});
+
+test('isPollsSuspensionTransition', () => {
+  expect(isPollsSuspensionTransition('close_polls')).toEqual(false);
+  expect(isPollsSuspensionTransition('open_polls')).toEqual(false);
+  expect(isPollsSuspensionTransition('resume_voting')).toEqual(true);
+  expect(isPollsSuspensionTransition('pause_voting')).toEqual(true);
 });

--- a/libs/utils/src/polls.ts
+++ b/libs/utils/src/polls.ts
@@ -4,10 +4,6 @@ import {
   PollsTransition,
 } from '@votingworks/types';
 import { throwIllegalValue } from './assert';
-import {
-  PrecinctScannerCardBallotCountReport,
-  PrecinctScannerCardReport,
-} from './types';
 
 export function getPollsTransitionDestinationState(
   transition: PollsTransition
@@ -143,10 +139,4 @@ export function isPollsSuspensionTransition(
     default:
       throwIllegalValue(transition);
   }
-}
-
-export function isPrecinctScannerCardBallotCountReport(
-  precinctScannerCardReport: PrecinctScannerCardReport
-): precinctScannerCardReport is PrecinctScannerCardBallotCountReport {
-  return isPollsSuspensionTransition(precinctScannerCardReport.pollsTransition);
 }

--- a/libs/utils/src/polls.ts
+++ b/libs/utils/src/polls.ts
@@ -1,5 +1,13 @@
-import { PollsState, PollsTransition } from '@votingworks/types';
+import {
+  PollsState,
+  PollsSuspensionTransition,
+  PollsTransition,
+} from '@votingworks/types';
 import { throwIllegalValue } from './assert';
+import {
+  PrecinctScannerCardBallotCountReport,
+  PrecinctScannerCardReport,
+} from './types';
 
 export function getPollsTransitionDestinationState(
   transition: PollsTransition
@@ -119,4 +127,26 @@ export function getPollsTransitionActionPastTense(
     default:
       throwIllegalValue(transition);
   }
+}
+
+export function isPollsSuspensionTransition(
+  transition: PollsTransition
+): transition is PollsSuspensionTransition {
+  switch (transition) {
+    case 'close_polls':
+    case 'open_polls':
+      return false;
+    case 'resume_voting':
+    case 'pause_voting':
+      return true;
+    /* istanbul ignore next - compile-time check for completeness */
+    default:
+      throwIllegalValue(transition);
+  }
+}
+
+export function isPrecinctScannerCardBallotCountReport(
+  precinctScannerCardReport: PrecinctScannerCardReport
+): precinctScannerCardReport is PrecinctScannerCardBallotCountReport {
+  return isPollsSuspensionTransition(precinctScannerCardReport.pollsTransition);
 }

--- a/libs/utils/src/types.test.ts
+++ b/libs/utils/src/types.test.ts
@@ -1,6 +1,6 @@
-import { TallySourceMachineType } from './types';
+import { ReportSourceMachineType } from './types';
 
 // Enums act weirdly with jest coverage, this is needed to get to 100% coverage
-test('TallySourceMachineType', () => {
-  expect(Object.values(TallySourceMachineType)).toHaveLength(1);
+test('ReportSourceMachineType', () => {
+  expect(Object.values(ReportSourceMachineType)).toHaveLength(1);
 });

--- a/libs/utils/src/types.ts
+++ b/libs/utils/src/types.ts
@@ -45,6 +45,10 @@ export const ScannerReportDataBaseSchema = z.object({
   timePollsTransitioned: z.number(),
 });
 
+/**
+ * Data representing a precinct scanner tally report for when polls are opened
+ * or closed.
+ */
 export interface ScannerTallyReportData extends ScannerReportDataBase {
   readonly pollsTransition: StandardPollsTransition;
   readonly ballotCounts: Dictionary<BallotCountDetails>;
@@ -60,6 +64,13 @@ export const ScannerTallyReportDataSchema: z.ZodSchema<ScannerTallyReportData> =
     ballotCounts: z.object({}).catchall(BallotCountDetailsSchema),
   });
 
+/**
+ * Data representing a precinct scanner ballot count report for when voting is
+ * paused or resumed. Unlike the tally reports used for polls opening and
+ * closing, ballot count reports omit any tally data in accordance with
+ * VVSG 2.0 1.1.9-K which disallows extracting vote tally data while the polls
+ * are open.
+ */
 export interface ScannerBallotCountReportData extends ScannerReportDataBase {
   pollsTransition: PollsSuspensionTransition;
 }
@@ -69,6 +80,13 @@ export const ScannerBallotCountReportDataSchema: z.ZodSchema<ScannerBallotCountR
     pollsTransition: PollsSuspensionTransitionSchema,
   });
 
+/**
+ * Data representing a precinct scanner report for polls opening, polls
+ * closing, voting paused, or voting resumed. In order to be allow printing
+ * a precinct scanner's report on a ballot-marking device, we export the
+ * formatted data onto a smartcard which will then be loaded on the
+ * ballot-marking device.
+ */
 export type ScannerReportData =
   | ScannerBallotCountReportData
   | ScannerTallyReportData;

--- a/libs/utils/src/types.ts
+++ b/libs/utils/src/types.ts
@@ -25,7 +25,7 @@ export type BallotCountDetails = [precinct: number, absentee: number];
 export const BallotCountDetailsSchema: z.ZodSchema<BallotCountDetails> =
   z.tuple([z.number(), z.number()]);
 
-export interface PrecinctScannerCardReportBase {
+export interface ScannerReportDataBase {
   readonly tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER;
   readonly machineId: string;
   readonly isLiveMode: boolean;
@@ -35,7 +35,7 @@ export interface PrecinctScannerCardReportBase {
   readonly timePollsTransitioned: number;
 }
 
-export const PrecinctScannerCardReportBaseSchema = z.object({
+export const ScannerReportDataBaseSchema = z.object({
   tallyMachineType: z.literal(ReportSourceMachineType.PRECINCT_SCANNER),
   machineId: MachineId,
   isLiveMode: z.boolean(),
@@ -45,41 +45,38 @@ export const PrecinctScannerCardReportBaseSchema = z.object({
   timePollsTransitioned: z.number(),
 });
 
-export interface PrecinctScannerCardTallyReport
-  extends PrecinctScannerCardReportBase {
+export interface ScannerTallyReportData extends ScannerReportDataBase {
   readonly pollsTransition: StandardPollsTransition;
   readonly ballotCounts: Dictionary<BallotCountDetails>;
   readonly talliesByPrecinct?: Dictionary<CompressedTally>;
   readonly tally: CompressedTally;
 }
 
-export const PrecinctScannerCardTallyReportSchema: z.ZodSchema<PrecinctScannerCardTallyReport> =
-  PrecinctScannerCardReportBaseSchema.extend({
+export const ScannerTallyReportDataSchema: z.ZodSchema<ScannerTallyReportData> =
+  ScannerReportDataBaseSchema.extend({
     pollsTransition: StandardPollsTransitionSchema,
     tally: CompressedTallySchema,
     talliesByPrecinct: z.object({}).catchall(CompressedTallySchema).optional(),
     ballotCounts: z.object({}).catchall(BallotCountDetailsSchema),
   });
 
-export interface PrecinctScannerCardBallotCountReport
-  extends PrecinctScannerCardReportBase {
+export interface ScannerBallotCountReportData extends ScannerReportDataBase {
   pollsTransition: PollsSuspensionTransition;
 }
 
-export const PrecinctScannerCardBallotCountReportSchema: z.ZodSchema<PrecinctScannerCardBallotCountReport> =
-  PrecinctScannerCardReportBaseSchema.extend({
+export const ScannerBallotCountReportDataSchema: z.ZodSchema<ScannerBallotCountReportData> =
+  ScannerReportDataBaseSchema.extend({
     pollsTransition: PollsSuspensionTransitionSchema,
   });
 
-export type PrecinctScannerCardReport =
-  | PrecinctScannerCardBallotCountReport
-  | PrecinctScannerCardTallyReport;
+export type ScannerReportData =
+  | ScannerBallotCountReportData
+  | ScannerTallyReportData;
 
-export const PrecinctScannerCardReportSchema: z.ZodSchema<PrecinctScannerCardReport> =
-  z.union([
-    PrecinctScannerCardTallyReportSchema,
-    PrecinctScannerCardBallotCountReportSchema,
-  ]);
+export const ScannerReportDataSchema: z.ZodSchema<ScannerReportData> = z.union([
+  ScannerTallyReportDataSchema,
+  ScannerBallotCountReportDataSchema,
+]);
 
 /**
  * Identity function useful for asserting the type of the argument/return value.


### PR DESCRIPTION
## Overview
Closes #2799. Aims to meet an exhaustive interpretation of VVSG 1.1.9-K:

> The voting system must prevent the printing of vote data reports and extracting vote tally data while the polls are open. Discussion: Providing ballot counts does not violate this requirement. The prohibition is against providing vote totals for ballot contests.

Arguably, having the vote tally data on the card is a way of extracting vote tally data - even if, with java cards, it will become impossible to do so. This PR introduces more specific typing for the reports saved to the card and, in the process, refactors code around the saving, loading, and usage of the card data.

## Testing Plan
Manually tested the flow with the various types of reports.
