### PR TITLE
Fix Precinct Change Lag on VxScan Backend

### DIFF
--- a/frontends/precinct-scanner/src/screens/election_manager_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/election_manager_screen.tsx
@@ -111,7 +111,11 @@ export function ElectionManagerScreen({
       openToggleLiveModeWarningModal();
     } else {
       setIsLoading(true);
+      const minimumDelay = new Promise((resolve) => {
+        setTimeout(resolve, 2000);
+      });
       await toggleLiveMode();
+      await minimumDelay;
       setIsLoading(false);
     }
   }

--- a/services/scan/src/central_scanner_app.test.ts
+++ b/services/scan/src/central_scanner_app.test.ts
@@ -25,7 +25,7 @@ import { makeMock } from '../test/util/mocks';
 import { Importer } from './importer';
 import { createWorkspace, Workspace } from './util/workspace';
 import { buildCentralScannerApp } from './central_scanner_app';
-import { getMockBallotPageLayoutWithImage } from '../test/helpers/mock_layouts';
+import { getMockBallotPageLayoutsWithImages } from '../test/helpers/mock_layouts';
 
 jest.mock('./importer');
 jest.mock('@votingworks/plustek-sdk');
@@ -47,16 +47,11 @@ beforeEach(async () => {
     precinctId: '23',
     isTestMode: false,
   };
-  workspace.store.addHmpbTemplate(Buffer.of(), ballotMetadata, [
-    getMockBallotPageLayoutWithImage({
-      ...ballotMetadata,
-      pageNumber: 1,
-    }),
-    getMockBallotPageLayoutWithImage({
-      ...ballotMetadata,
-      pageNumber: 2,
-    }),
-  ]);
+  workspace.store.addHmpbTemplate(
+    Buffer.of(),
+    ballotMetadata,
+    getMockBallotPageLayoutsWithImages(ballotMetadata, 2)
+  );
   app = await buildCentralScannerApp({ importer, workspace });
 });
 

--- a/services/scan/src/central_scanner_app.test.ts
+++ b/services/scan/src/central_scanner_app.test.ts
@@ -4,6 +4,7 @@ import {
 } from '@votingworks/fixtures';
 import {
   AdjudicationReason,
+  BallotMetadata,
   BallotPageLayout,
   BallotPageLayoutWithImage,
   BallotType,
@@ -24,6 +25,7 @@ import { makeMock } from '../test/util/mocks';
 import { Importer } from './importer';
 import { createWorkspace, Workspace } from './util/workspace';
 import { buildCentralScannerApp } from './central_scanner_app';
+import { getMockBallotPageLayoutWithImage } from '../test/helpers/mock_layouts';
 
 jest.mock('./importer');
 jest.mock('@votingworks/plustek-sdk');
@@ -37,45 +39,24 @@ beforeEach(async () => {
   workspace = createWorkspace(dirSync().name);
   workspace.store.setElection(stateOfHamilton.electionDefinition.electionData);
   workspace.store.setTestMode(false);
-  workspace.store.addHmpbTemplate(
-    Buffer.of(),
-    {
-      locales: { primary: 'en-US' },
-      electionHash: stateOfHamilton.electionDefinition.electionHash,
-      ballotType: BallotType.Standard,
-      ballotStyleId: '12',
-      precinctId: '23',
-      isTestMode: false,
-    },
-    [
-      {
-        pageSize: { width: 1, height: 1 },
-        metadata: {
-          locales: { primary: 'en-US' },
-          electionHash: stateOfHamilton.electionDefinition.electionHash,
-          ballotType: BallotType.Standard,
-          ballotStyleId: '12',
-          precinctId: '23',
-          isTestMode: false,
-          pageNumber: 1,
-        },
-        contests: [],
-      },
-      {
-        pageSize: { width: 1, height: 1 },
-        metadata: {
-          locales: { primary: 'en-US' },
-          electionHash: stateOfHamilton.electionDefinition.electionHash,
-          ballotType: BallotType.Standard,
-          ballotStyleId: '12',
-          precinctId: '23',
-          isTestMode: false,
-          pageNumber: 2,
-        },
-        contests: [],
-      },
-    ]
-  );
+  const ballotMetadata: BallotMetadata = {
+    locales: { primary: 'en-US' },
+    electionHash: stateOfHamilton.electionDefinition.electionHash,
+    ballotType: BallotType.Standard,
+    ballotStyleId: '12',
+    precinctId: '23',
+    isTestMode: false,
+  };
+  workspace.store.addHmpbTemplate(Buffer.of(), ballotMetadata, [
+    getMockBallotPageLayoutWithImage({
+      ...ballotMetadata,
+      pageNumber: 1,
+    }),
+    getMockBallotPageLayoutWithImage({
+      ...ballotMetadata,
+      pageNumber: 2,
+    }),
+  ]);
   app = await buildCentralScannerApp({ importer, workspace });
 });
 

--- a/services/scan/src/central_scanner_app.test.ts
+++ b/services/scan/src/central_scanner_app.test.ts
@@ -36,7 +36,7 @@ let importer: jest.Mocked<Importer>;
 
 beforeEach(async () => {
   importer = makeMock(Importer);
-  workspace = createWorkspace(dirSync().name);
+  workspace = await createWorkspace(dirSync().name);
   workspace.store.setElection(stateOfHamilton.electionDefinition.electionData);
   workspace.store.setTestMode(false);
   const ballotMetadata: BallotMetadata = {

--- a/services/scan/src/cli/render_pages.test.ts
+++ b/services/scan/src/cli/render_pages.test.ts
@@ -163,7 +163,7 @@ test('render from db', async () => {
   const tmpDir = tmpNameSync();
   await fs.mkdir(tmpDir);
   const tmpDbPath = join(tmpDir, 'ballots.db');
-  const store = Store.fileStore(tmpDbPath);
+  const store = await Store.fileStore(tmpDbPath);
   const electionDefinition = asElectionDefinition(election);
   store.setElection(electionDefinition.electionData);
   const metadata: BallotMetadata = {
@@ -226,7 +226,7 @@ test('db without an election', async () => {
   const stderr = fakeOutput();
   const tmpDir = tmpNameSync();
   await fs.mkdir(tmpDir);
-  const store = Store.fileStore(join(tmpDir, 'ballots.db'));
+  const store = await Store.fileStore(join(tmpDir, 'ballots.db'));
 
   expect(await main([store.getDbPath()], { stdout, stderr })).toEqual(1);
   expect(stderr.toString()).toEqual(

--- a/services/scan/src/cli/render_pages.test.ts
+++ b/services/scan/src/cli/render_pages.test.ts
@@ -12,7 +12,7 @@ import {
   ballotPdf,
 } from '../../test/fixtures/choctaw-2020-09-22-f30480cc99';
 import { main } from './render_pages';
-import { getMockBallotPageLayoutWithImage } from '../../test/helpers/mock_layouts';
+import { getMockBallotPageLayoutsWithImages } from '../../test/helpers/mock_layouts';
 
 function fakeOutput(): WritableStream & NodeJS.WriteStream {
   return new WritableStream() as WritableStream & NodeJS.WriteStream;
@@ -174,16 +174,11 @@ test('render from db', async () => {
     locales: { primary: 'en-US' },
     precinctId: '6538',
   };
-  store.addHmpbTemplate(await fs.readFile(ballotPdf), metadata, [
-    getMockBallotPageLayoutWithImage({
-      ...metadata,
-      pageNumber: 1,
-    }),
-    getMockBallotPageLayoutWithImage({
-      ...metadata,
-      pageNumber: 2,
-    }),
-  ]);
+  store.addHmpbTemplate(
+    await fs.readFile(ballotPdf),
+    metadata,
+    getMockBallotPageLayoutsWithImages(metadata, 2)
+  );
 
   const stdout = fakeOutput();
   const stderr = fakeOutput();

--- a/services/scan/src/cli/render_pages.test.ts
+++ b/services/scan/src/cli/render_pages.test.ts
@@ -12,6 +12,7 @@ import {
   ballotPdf,
 } from '../../test/fixtures/choctaw-2020-09-22-f30480cc99';
 import { main } from './render_pages';
+import { getMockBallotPageLayoutWithImage } from '../../test/helpers/mock_layouts';
 
 function fakeOutput(): WritableStream & NodeJS.WriteStream {
   return new WritableStream() as WritableStream & NodeJS.WriteStream;
@@ -174,16 +175,14 @@ test('render from db', async () => {
     precinctId: '6538',
   };
   store.addHmpbTemplate(await fs.readFile(ballotPdf), metadata, [
-    {
-      pageSize: { width: 1, height: 1 },
-      metadata: { ...metadata, pageNumber: 1 },
-      contests: [],
-    },
-    {
-      pageSize: { width: 1, height: 1 },
-      metadata: { ...metadata, pageNumber: 2 },
-      contests: [],
-    },
+    getMockBallotPageLayoutWithImage({
+      ...metadata,
+      pageNumber: 1,
+    }),
+    getMockBallotPageLayoutWithImage({
+      ...metadata,
+      pageNumber: 2,
+    }),
   ]);
 
   const stdout = fakeOutput();

--- a/services/scan/src/cli/render_pages.ts
+++ b/services/scan/src/cli/render_pages.ts
@@ -137,7 +137,7 @@ export async function main(
     if (ext === '.pdf') {
       queue.push({ pdf: await fs.readFile(path), base });
     } else if (ext === '.db') {
-      const store = Store.fileStore(path);
+      const store = await Store.fileStore(path);
       const electionDefinition = store.getElectionDefinition();
 
       if (!electionDefinition) {

--- a/services/scan/src/cli/retry-scan/index.test.ts
+++ b/services/scan/src/cli/retry-scan/index.test.ts
@@ -141,7 +141,7 @@ test('query with sheet ids', () => {
 });
 
 (process.env.CI ? test.skip : test)('full rescan', async () => {
-  const inputWorkspace = createWorkspace(dirSync().name);
+  const inputWorkspace = await createWorkspace(dirSync().name);
   const { store } = inputWorkspace;
 
   store.setElection(fixtures.electionDefinition.electionData);
@@ -227,8 +227,8 @@ test('query with sheet ids', () => {
 (process.env.CI ? test.skip : test)(
   'writing output to another database',
   async () => {
-    const inputWorkspace = createWorkspace(dirSync().name);
-    const outputWorkspace = createWorkspace(dirSync().name);
+    const inputWorkspace = await createWorkspace(dirSync().name);
+    const outputWorkspace = await createWorkspace(dirSync().name);
     const inputDb = inputWorkspace.store;
 
     inputDb.setElection(fixtures.electionDefinition.electionData);

--- a/services/scan/src/cli/retry-scan/index.ts
+++ b/services/scan/src/cli/retry-scan/index.ts
@@ -92,10 +92,12 @@ export async function retryScan(
   options: Options,
   listeners?: RetryScanListeners
 ): Promise<void> {
-  const input = createWorkspace(
+  const input = await createWorkspace(
     options.inputWorkspace ?? join(__dirname, '../../../dev-workspace')
   );
-  const output = createWorkspace(options.outputWorkspace ?? dirSync().name);
+  const output = await createWorkspace(
+    options.outputWorkspace ?? dirSync().name
+  );
   const outputBatchId = output.store.addBatch();
 
   listeners?.configured?.({

--- a/services/scan/src/cvrs/export.test.ts
+++ b/services/scan/src/cvrs/export.test.ts
@@ -13,6 +13,7 @@ import { pipeline } from 'stream/promises';
 import * as tmp from 'tmp';
 import { v4 as uuid } from 'uuid';
 import * as stateOfHamilton from '../../test/fixtures/state-of-hamilton';
+import { getMockBallotPageLayoutWithImage } from '../../test/helpers/mock_layouts';
 import { Store } from '../store';
 import * as buildCastVoteRecord from './build';
 import { exportCastVoteRecordsAsNdJson } from './export';
@@ -82,22 +83,14 @@ test('exportCvrs', async () => {
   };
 
   store.addHmpbTemplate(Buffer.of(1, 2, 3), metadata, [
-    {
-      pageSize: { width: 1, height: 1 },
-      metadata: {
-        ...metadata,
-        pageNumber: 1,
-      },
-      contests: [],
-    },
-    {
-      pageSize: { width: 1, height: 1 },
-      metadata: {
-        ...metadata,
-        pageNumber: 2,
-      },
-      contests: [],
-    },
+    getMockBallotPageLayoutWithImage({
+      ...metadata,
+      pageNumber: 1,
+    }),
+    getMockBallotPageLayoutWithImage({
+      ...metadata,
+      pageNumber: 2,
+    }),
   ]);
 
   // Create CVRs, confirm that they are exported should work
@@ -210,22 +203,14 @@ test('exportCvrs without write-ins does not load ballot images', async () => {
   };
 
   store.addHmpbTemplate(Buffer.of(1, 2, 3), metadata, [
-    {
-      pageSize: { width: 1, height: 1 },
-      metadata: {
-        ...metadata,
-        pageNumber: 1,
-      },
-      contests: [],
-    },
-    {
-      pageSize: { width: 1, height: 1 },
-      metadata: {
-        ...metadata,
-        pageNumber: 2,
-      },
-      contests: [],
-    },
+    getMockBallotPageLayoutWithImage({
+      ...metadata,
+      pageNumber: 1,
+    }),
+    getMockBallotPageLayoutWithImage({
+      ...metadata,
+      pageNumber: 2,
+    }),
   ]);
 
   // Create CVRs, confirm that they are exported should work
@@ -332,22 +317,14 @@ test('exportCvrs does not export ballot images when feature flag turned off', as
   };
 
   store.addHmpbTemplate(Buffer.of(1, 2, 3), metadata, [
-    {
-      pageSize: { width: 1, height: 1 },
-      metadata: {
-        ...metadata,
-        pageNumber: 1,
-      },
-      contests: [],
-    },
-    {
-      pageSize: { width: 1, height: 1 },
-      metadata: {
-        ...metadata,
-        pageNumber: 2,
-      },
-      contests: [],
-    },
+    getMockBallotPageLayoutWithImage({
+      ...metadata,
+      pageNumber: 1,
+    }),
+    getMockBallotPageLayoutWithImage({
+      ...metadata,
+      pageNumber: 2,
+    }),
   ]);
 
   // Create CVRs, confirm that they are exported should work
@@ -428,22 +405,14 @@ test('exportCvrs does not export ballot images when skipImages is true', async (
   };
 
   store.addHmpbTemplate(Buffer.of(1, 2, 3), metadata, [
-    {
-      pageSize: { width: 1, height: 1 },
-      metadata: {
-        ...metadata,
-        pageNumber: 1,
-      },
-      contests: [],
-    },
-    {
-      pageSize: { width: 1, height: 1 },
-      metadata: {
-        ...metadata,
-        pageNumber: 2,
-      },
-      contests: [],
-    },
+    getMockBallotPageLayoutWithImage({
+      ...metadata,
+      pageNumber: 1,
+    }),
+    getMockBallotPageLayoutWithImage({
+      ...metadata,
+      pageNumber: 2,
+    }),
   ]);
 
   const frontNormalizedFile = tmp.fileSync();
@@ -518,22 +487,14 @@ test('exportCvrs called with orderBySheetId actually orders by sheet ID', async 
   };
 
   store.addHmpbTemplate(Buffer.of(1, 2, 3), metadata, [
-    {
-      pageSize: { width: 1, height: 1 },
-      metadata: {
-        ...metadata,
-        pageNumber: 1,
-      },
-      contests: [],
-    },
-    {
-      pageSize: { width: 1, height: 1 },
-      metadata: {
-        ...metadata,
-        pageNumber: 2,
-      },
-      contests: [],
-    },
+    getMockBallotPageLayoutWithImage({
+      ...metadata,
+      pageNumber: 1,
+    }),
+    getMockBallotPageLayoutWithImage({
+      ...metadata,
+      pageNumber: 2,
+    }),
   ]);
 
   // Create CVRs, confirm that they are exported should work

--- a/services/scan/src/cvrs/export.test.ts
+++ b/services/scan/src/cvrs/export.test.ts
@@ -13,7 +13,7 @@ import { pipeline } from 'stream/promises';
 import * as tmp from 'tmp';
 import { v4 as uuid } from 'uuid';
 import * as stateOfHamilton from '../../test/fixtures/state-of-hamilton';
-import { getMockBallotPageLayoutWithImage } from '../../test/helpers/mock_layouts';
+import { getMockBallotPageLayoutsWithImages } from '../../test/helpers/mock_layouts';
 import { Store } from '../store';
 import * as buildCastVoteRecord from './build';
 import { exportCastVoteRecordsAsNdJson } from './export';
@@ -82,16 +82,11 @@ test('exportCvrs', async () => {
     pageNumber: 1,
   };
 
-  store.addHmpbTemplate(Buffer.of(1, 2, 3), metadata, [
-    getMockBallotPageLayoutWithImage({
-      ...metadata,
-      pageNumber: 1,
-    }),
-    getMockBallotPageLayoutWithImage({
-      ...metadata,
-      pageNumber: 2,
-    }),
-  ]);
+  store.addHmpbTemplate(
+    Buffer.of(1, 2, 3),
+    metadata,
+    getMockBallotPageLayoutsWithImages(metadata, 2)
+  );
 
   // Create CVRs, confirm that they are exported should work
   const batchId = store.addBatch();
@@ -202,16 +197,11 @@ test('exportCvrs without write-ins does not load ballot images', async () => {
     pageNumber: 1,
   };
 
-  store.addHmpbTemplate(Buffer.of(1, 2, 3), metadata, [
-    getMockBallotPageLayoutWithImage({
-      ...metadata,
-      pageNumber: 1,
-    }),
-    getMockBallotPageLayoutWithImage({
-      ...metadata,
-      pageNumber: 2,
-    }),
-  ]);
+  store.addHmpbTemplate(
+    Buffer.of(1, 2, 3),
+    metadata,
+    getMockBallotPageLayoutsWithImages(metadata, 2)
+  );
 
   // Create CVRs, confirm that they are exported should work
   const batchId = store.addBatch();
@@ -316,16 +306,11 @@ test('exportCvrs does not export ballot images when feature flag turned off', as
     pageNumber: 1,
   };
 
-  store.addHmpbTemplate(Buffer.of(1, 2, 3), metadata, [
-    getMockBallotPageLayoutWithImage({
-      ...metadata,
-      pageNumber: 1,
-    }),
-    getMockBallotPageLayoutWithImage({
-      ...metadata,
-      pageNumber: 2,
-    }),
-  ]);
+  store.addHmpbTemplate(
+    Buffer.of(1, 2, 3),
+    metadata,
+    getMockBallotPageLayoutsWithImages(metadata, 2)
+  );
 
   // Create CVRs, confirm that they are exported should work
   const batchId = store.addBatch();
@@ -404,16 +389,11 @@ test('exportCvrs does not export ballot images when skipImages is true', async (
     pageNumber: 1,
   };
 
-  store.addHmpbTemplate(Buffer.of(1, 2, 3), metadata, [
-    getMockBallotPageLayoutWithImage({
-      ...metadata,
-      pageNumber: 1,
-    }),
-    getMockBallotPageLayoutWithImage({
-      ...metadata,
-      pageNumber: 2,
-    }),
-  ]);
+  store.addHmpbTemplate(
+    Buffer.of(1, 2, 3),
+    metadata,
+    getMockBallotPageLayoutsWithImages(metadata, 2)
+  );
 
   const frontNormalizedFile = tmp.fileSync();
   await writeFile(frontNormalizedFile.fd, 'front normalized');
@@ -486,16 +466,11 @@ test('exportCvrs called with orderBySheetId actually orders by sheet ID', async 
     pageNumber: 1,
   };
 
-  store.addHmpbTemplate(Buffer.of(1, 2, 3), metadata, [
-    getMockBallotPageLayoutWithImage({
-      ...metadata,
-      pageNumber: 1,
-    }),
-    getMockBallotPageLayoutWithImage({
-      ...metadata,
-      pageNumber: 2,
-    }),
-  ]);
+  store.addHmpbTemplate(
+    Buffer.of(1, 2, 3),
+    metadata,
+    getMockBallotPageLayoutsWithImages(metadata, 2)
+  );
 
   // Create CVRs, confirm that they are exported should work
   const sheetIds = ['fake-uuid-zzz', 'fake-uuid-lll', 'fake-uuid-aaa'];

--- a/services/scan/src/end_to_end.test.ts
+++ b/services/scan/src/end_to_end.test.ts
@@ -29,7 +29,7 @@ let scanner: MockScanner;
 
 beforeEach(async () => {
   scanner = makeMockScanner();
-  workspace = createWorkspace(dirSync().name);
+  workspace = await createWorkspace(dirSync().name);
   importer = new Importer({
     workspace,
     scanner,

--- a/services/scan/src/end_to_end_hmpb.test.ts
+++ b/services/scan/src/end_to_end_hmpb.test.ts
@@ -48,7 +48,7 @@ let importer: Importer;
 let app: Application;
 
 beforeEach(async () => {
-  workspace = createWorkspace(dirSync().name);
+  workspace = await createWorkspace(dirSync().name);
   scanner = makeMockScanner();
   importer = new Importer({ workspace, scanner });
   app = await buildCentralScannerApp({ importer, workspace });

--- a/services/scan/src/importer.test.ts
+++ b/services/scan/src/importer.test.ts
@@ -24,8 +24,8 @@ const sampleBallotImagesPath = join(__dirname, '..', 'sample-ballot-images/');
 
 let workspace: Workspace;
 
-beforeEach(() => {
-  workspace = createWorkspace(dirSync().name);
+beforeEach(async () => {
+  workspace = await createWorkspace(dirSync().name);
 });
 
 afterEach(async () => {

--- a/services/scan/src/importer.ts
+++ b/services/scan/src/importer.ts
@@ -116,8 +116,7 @@ export class Importer {
     this.workspace.store.addHmpbTemplate(
       pdf,
       result[0].ballotPageLayout.metadata,
-      // remove ballot image for storage
-      result.map(({ ballotPageLayout }) => ballotPageLayout)
+      result
     );
 
     this.invalidateInterpreterConfig();

--- a/services/scan/src/precinct_scanner_app.ts
+++ b/services/scan/src/precinct_scanner_app.ts
@@ -31,16 +31,13 @@ const debug = makeDebug('scan:precinct-scanner:app');
 
 type NoParams = never;
 
-export async function buildPrecinctScannerApp(
+export function buildPrecinctScannerApp(
   machine: PrecinctScannerStateMachine,
   interpreter: PrecinctScannerInterpreter,
   workspace: Workspace,
   logger: Logger
-): Promise<Application> {
+): Application {
   const { store } = workspace;
-
-  // Trigger the layouts to be cached in the store
-  await store.loadLayouts();
 
   const app: Application = express();
   const upload = multer({

--- a/services/scan/src/server.ts
+++ b/services/scan/src/server.ts
@@ -83,7 +83,7 @@ export async function start({
       interpreter: precinctScannerInterpreter,
       logger,
     });
-    resolvedApp = await buildPrecinctScannerApp(
+    resolvedApp = buildPrecinctScannerApp(
       precinctScannerMachine,
       precinctScannerInterpreter,
       resolvedWorkspace,

--- a/services/scan/src/server.ts
+++ b/services/scan/src/server.ts
@@ -67,7 +67,7 @@ export async function start({
         'workspace path could not be determined; pass a workspace or run with SCAN_WORKSPACE'
       );
     }
-    resolvedWorkspace = createWorkspace(workspacePath);
+    resolvedWorkspace = await createWorkspace(workspacePath);
   }
 
   // clear any cached data

--- a/services/scan/src/store.test.ts
+++ b/services/scan/src/store.test.ts
@@ -23,7 +23,7 @@ import { v4 as uuid } from 'uuid';
 import * as stateOfHamilton from '../test/fixtures/state-of-hamilton';
 import { zeroRect } from '../test/fixtures/zero_rect';
 import {
-  getMockBallotPageLayoutWithImage,
+  getMockBallotPageLayoutsWithImages,
   getMockImageData,
 } from '../test/helpers/mock_layouts';
 import { ResultSheet, Store } from './store';
@@ -232,16 +232,11 @@ test('HMPB template handling', () => {
 
   expect(store.getHmpbTemplates()).toEqual([]);
 
-  store.addHmpbTemplate(Buffer.of(1, 2, 3), metadata, [
-    getMockBallotPageLayoutWithImage({
-      ...metadata,
-      pageNumber: 1,
-    }),
-    getMockBallotPageLayoutWithImage({
-      ...metadata,
-      pageNumber: 2,
-    }),
-  ]);
+  store.addHmpbTemplate(
+    Buffer.of(1, 2, 3),
+    metadata,
+    getMockBallotPageLayoutsWithImages(metadata, 2)
+  );
 
   expect(store.getHmpbTemplates()).toEqual(
     typedAs<Array<[Buffer, BallotPageLayout[]]>>([

--- a/services/scan/src/store.test.ts
+++ b/services/scan/src/store.test.ts
@@ -22,6 +22,10 @@ import * as tmp from 'tmp';
 import { v4 as uuid } from 'uuid';
 import * as stateOfHamilton from '../test/fixtures/state-of-hamilton';
 import { zeroRect } from '../test/fixtures/zero_rect';
+import {
+  getMockBallotPageLayoutWithImage,
+  getMockImageData,
+} from '../test/helpers/mock_layouts';
 import { ResultSheet, Store } from './store';
 
 // We pause in some of these tests so we need to increase the timeout
@@ -229,22 +233,14 @@ test('HMPB template handling', () => {
   expect(store.getHmpbTemplates()).toEqual([]);
 
   store.addHmpbTemplate(Buffer.of(1, 2, 3), metadata, [
-    {
-      pageSize: { width: 1, height: 1 },
-      metadata: {
-        ...metadata,
-        pageNumber: 1,
-      },
-      contests: [],
-    },
-    {
-      pageSize: { width: 1, height: 1 },
-      metadata: {
-        ...metadata,
-        pageNumber: 2,
-      },
-      contests: [],
-    },
+    getMockBallotPageLayoutWithImage({
+      ...metadata,
+      pageNumber: 1,
+    }),
+    getMockBallotPageLayoutWithImage({
+      ...metadata,
+      pageNumber: 2,
+    }),
   ]);
 
   expect(store.getHmpbTemplates()).toEqual(
@@ -557,49 +553,52 @@ test('adjudication', () => {
     Buffer.of(),
     metadata,
     [1, 2].map((pageNumber) => ({
-      pageSize: { width: 1, height: 1 },
-      metadata: {
-        ...metadata,
-        pageNumber,
+      imageData: getMockImageData(),
+      ballotPageLayout: {
+        pageSize: { width: 1, height: 1 },
+        metadata: {
+          ...metadata,
+          pageNumber,
+        },
+        contests: [
+          {
+            bounds: zeroRect,
+            corners: [
+              { x: 0, y: 0 },
+              { x: 0, y: 0 },
+              { x: 0, y: 0 },
+              { x: 0, y: 0 },
+            ],
+            options: [
+              {
+                bounds: zeroRect,
+                target: {
+                  bounds: zeroRect,
+                  inner: zeroRect,
+                },
+              },
+            ],
+          },
+          {
+            bounds: zeroRect,
+            corners: [
+              { x: 0, y: 0 },
+              { x: 0, y: 0 },
+              { x: 0, y: 0 },
+              { x: 0, y: 0 },
+            ],
+            options: [
+              {
+                bounds: zeroRect,
+                target: {
+                  bounds: zeroRect,
+                  inner: zeroRect,
+                },
+              },
+            ],
+          },
+        ],
       },
-      contests: [
-        {
-          bounds: zeroRect,
-          corners: [
-            { x: 0, y: 0 },
-            { x: 0, y: 0 },
-            { x: 0, y: 0 },
-            { x: 0, y: 0 },
-          ],
-          options: [
-            {
-              bounds: zeroRect,
-              target: {
-                bounds: zeroRect,
-                inner: zeroRect,
-              },
-            },
-          ],
-        },
-        {
-          bounds: zeroRect,
-          corners: [
-            { x: 0, y: 0 },
-            { x: 0, y: 0 },
-            { x: 0, y: 0 },
-            { x: 0, y: 0 },
-          ],
-          options: [
-            {
-              bounds: zeroRect,
-              target: {
-                bounds: zeroRect,
-                inner: zeroRect,
-              },
-            },
-          ],
-        },
-      ],
     }))
   );
   function fakePage(i: 0 | 1): PageInterpretationWithFiles {

--- a/services/scan/src/store.ts
+++ b/services/scan/src/store.ts
@@ -4,13 +4,16 @@
 
 import { Scan } from '@votingworks/api';
 import { generateBallotPageLayouts } from '@votingworks/ballot-interpreter-nh';
+import { interpretTemplate } from '@votingworks/ballot-interpreter-vx';
 import { Bindable, Client as DbClient } from '@votingworks/db';
+import { pdfToImages } from '@votingworks/image-utils';
 import {
   AnyContest,
   BallotMetadata,
   BallotMetadataSchema,
   BallotPageLayout,
   BallotPageLayoutSchema,
+  BallotPageLayoutWithImage,
   BallotPageMetadata,
   BallotPaperSize,
   BallotSheetInfo,
@@ -75,6 +78,7 @@ function dateTimeFromNoOffsetSqliteDate(noOffsetSqliteDate: string): DateTime {
  */
 export class Store {
   private constructor(private readonly client: DbClient) {}
+  private cachedLayouts: BallotPageLayoutWithImage[] = [];
 
   getDbPath(): string {
     return this.client.getDatabasePath();
@@ -167,10 +171,11 @@ export class Store {
   }
 
   /**
-   * Resets the database.
+   * Resets the database and any cached data in the store.
    */
   reset(): void {
     this.client.reset();
+    this.cachedLayouts = [];
   }
 
   /**
@@ -1047,9 +1052,13 @@ export class Store {
   addHmpbTemplate(
     pdf: Buffer,
     metadata: BallotMetadata,
-    layouts: readonly BallotPageLayout[]
+    layoutsWithImages: readonly BallotPageLayoutWithImage[]
   ): string {
     debug('storing HMPB template: %O', metadata);
+    // remove page image for storage, but we need the image here to cache
+    const layouts = layoutsWithImages.map(
+      ({ ballotPageLayout }) => ballotPageLayout
+    );
 
     this.client.run(
       `
@@ -1084,6 +1093,8 @@ export class Store {
       JSON.stringify(metadata),
       JSON.stringify(layouts)
     );
+    // cache our layouts so they can be immediately used by the interpreter
+    this.cachedLayouts.push(...layoutsWithImages);
     return id;
   }
 
@@ -1129,6 +1140,33 @@ export class Store {
     }
 
     return results;
+  }
+
+  async loadLayouts(): Promise<BallotPageLayoutWithImage[] | undefined> {
+    const electionDefinition = this.getElectionDefinition();
+    if (!electionDefinition) return;
+
+    if (this.cachedLayouts.length > 0) return this.cachedLayouts;
+
+    const templates = this.getHmpbTemplates();
+    const loadedLayouts: BallotPageLayoutWithImage[] = [];
+
+    for (const [pdf, layouts] of templates) {
+      for await (const { page, pageNumber } of pdfToImages(pdf, { scale: 2 })) {
+        const ballotPageLayout = layouts[pageNumber - 1];
+        loadedLayouts.push(
+          await interpretTemplate({
+            electionDefinition,
+            imageData: page,
+            metadata: ballotPageLayout.metadata,
+          })
+        );
+      }
+    }
+
+    // These computations are expensive so we cache the loaded layouts
+    this.cachedLayouts = loadedLayouts;
+    return loadedLayouts;
   }
 
   getBallotPageLayoutForMetadata(

--- a/services/scan/src/store.ts
+++ b/services/scan/src/store.ts
@@ -102,8 +102,13 @@ export class Store {
   /**
    * Builds and returns a new store at `dbPath`.
    */
-  static fileStore(dbPath: string): Store {
-    return new Store(DbClient.fileClient(dbPath, SchemaPath));
+  static async fileStore(dbPath: string): Promise<Store> {
+    const newStore = new Store(DbClient.fileClient(dbPath, SchemaPath));
+
+    // If there are already templates, force caching of the layouts with image
+    await newStore.loadLayouts();
+
+    return newStore;
   }
 
   /**

--- a/services/scan/src/util/workspace.ts
+++ b/services/scan/src/util/workspace.ts
@@ -45,7 +45,7 @@ export interface Workspace {
   clearUploads(): void;
 }
 
-export function createWorkspace(root: string): Workspace {
+export async function createWorkspace(root: string): Promise<Workspace> {
   const resolvedRoot = resolve(root);
   const ballotImagesPath = join(resolvedRoot, 'ballot-images');
   const scannedImagesPath = join(ballotImagesPath, 'scanned-images');
@@ -54,7 +54,7 @@ export function createWorkspace(root: string): Workspace {
   ensureDirSync(scannedImagesPath);
 
   const dbPath = join(resolvedRoot, 'ballots.db');
-  const store = Store.fileStore(dbPath);
+  const store = await Store.fileStore(dbPath);
 
   return {
     path: resolvedRoot,

--- a/services/scan/src/workers/interpret_nh.test.ts
+++ b/services/scan/src/workers/interpret_nh.test.ts
@@ -17,7 +17,7 @@ test('configure', async () => {
 test('interpret', async () => {
   const dbPath = fileSync().name;
   const ballotImagesPath = dirSync().name;
-  const store = Store.fileStore(dbPath);
+  const store = await Store.fileStore(dbPath);
 
   const { electionDefinition } = electionGridLayoutNewHampshireAmherstFixtures;
   store.setElection(electionDefinition.electionData);

--- a/services/scan/src/workers/interpret_nh.ts
+++ b/services/scan/src/workers/interpret_nh.ts
@@ -36,7 +36,7 @@ let isTestMode: boolean | undefined;
 export async function call(input: Input): Promise<Output> {
   switch (input.action) {
     case 'configure': {
-      const store = Store.fileStore(input.dbPath);
+      const store = await Store.fileStore(input.dbPath);
       electionDefinition = store.getElectionDefinition();
       isTestMode = store.getTestMode();
       return;

--- a/services/scan/src/workers/interpret_vx.ts
+++ b/services/scan/src/workers/interpret_vx.ts
@@ -121,7 +121,7 @@ export async function interpret(
 export async function call(input: Input): Promise<Output> {
   switch (input.action) {
     case 'configure': {
-      const store = Store.fileStore(input.dbPath);
+      const store = await Store.fileStore(input.dbPath);
       return await configure(store);
     }
 

--- a/services/scan/test/helpers/mock_layouts.ts
+++ b/services/scan/test/helpers/mock_layouts.ts
@@ -1,4 +1,5 @@
 import {
+  BallotMetadata,
   BallotPageLayout,
   BallotPageLayoutWithImage,
   BallotPageMetadata,
@@ -30,4 +31,17 @@ export function getMockBallotPageLayoutWithImage(
     imageData: getMockImageData(),
     ballotPageLayout: getMockBallotPageLayout(metadata),
   };
+}
+
+export function getMockBallotPageLayoutsWithImages(
+  metadata: BallotMetadata,
+  numPages: number
+): BallotPageLayoutWithImage[] {
+  const mockBallotPageLayoutsWithImages: BallotPageLayoutWithImage[] = [];
+  for (let i = 1; i <= numPages; i += 1) {
+    mockBallotPageLayoutsWithImages.push(
+      getMockBallotPageLayoutWithImage({ ...metadata, pageNumber: i })
+    );
+  }
+  return mockBallotPageLayoutsWithImages;
 }

--- a/services/scan/test/helpers/mock_layouts.ts
+++ b/services/scan/test/helpers/mock_layouts.ts
@@ -1,0 +1,33 @@
+import {
+  BallotPageLayout,
+  BallotPageLayoutWithImage,
+  BallotPageMetadata,
+  ImageData,
+} from '@votingworks/types';
+
+export function getMockBallotPageLayout(
+  metadata: BallotPageMetadata
+): BallotPageLayout {
+  return {
+    pageSize: { width: 1, height: 1 },
+    metadata,
+    contests: [],
+  };
+}
+
+export function getMockImageData(width = 1, height = 1): ImageData {
+  return {
+    data: Uint8ClampedArray.of(0, 0, 0, 0),
+    width,
+    height,
+  };
+}
+
+export function getMockBallotPageLayoutWithImage(
+  metadata: BallotPageMetadata
+): BallotPageLayoutWithImage {
+  return {
+    imageData: getMockImageData(),
+    ballotPageLayout: getMockBallotPageLayout(metadata),
+  };
+}

--- a/services/scan/test/helpers/precinct_scanner_app.ts
+++ b/services/scan/test/helpers/precinct_scanner_app.ts
@@ -212,7 +212,7 @@ export async function createApp(
       ...delays,
     },
   });
-  const app = await buildPrecinctScannerApp(
+  const app = buildPrecinctScannerApp(
     precinctScannerMachine,
     interpreter,
     workspace,

--- a/services/scan/test/helpers/precinct_scanner_app.ts
+++ b/services/scan/test/helpers/precinct_scanner_app.ts
@@ -186,7 +186,7 @@ export async function createApp(
   interpreter: PrecinctScannerInterpreter;
 }> {
   const logger = fakeLogger();
-  const workspace = createWorkspace(dirSync().name);
+  const workspace = await createWorkspace(dirSync().name);
   const mockPlustek = new MockScannerClient({
     toggleHoldDuration: 100,
     passthroughDuration: 100,


### PR DESCRIPTION
## Overview
Instead of #2797, in which I introduced loading screens to handle the slow precinct change, here we optimize on the backend to make the operation faster. This also makes switching modes faster (see video), although switch modes could take longer than in the video if there were more ballots scanned.

## Demo Video or Screenshot

https://user-images.githubusercontent.com/37960853/204388692-dac9580c-6d5d-44c8-b8dd-24581fb959a1.mov


