### PR TITLE
[VxAdmin] Use CVRs from the server when computing tallies

### DIFF
--- a/frontends/election-manager/src/hooks/use_cvrs_query.ts
+++ b/frontends/election-manager/src/hooks/use_cvrs_query.ts
@@ -1,24 +1,23 @@
 import { QueryKey, useQuery, UseQueryResult } from '@tanstack/react-query';
 import { useContext } from 'react';
 
-import { Admin } from '@votingworks/api';
+import { CastVoteRecord } from '@votingworks/types';
 
 import { ServicesContext } from '../contexts/services_context';
 
 /**
- * Gets the query key for {@link useCvrFilesQuery}.
+ * Gets the query key for {@link useCvrsQuery}.
  */
 export function getCvrsQueryKey(): QueryKey {
   return ['cvrs'];
 }
 
 /**
- * Returns a metadata query for all imported CVR files, if any, for the current
- * election.
+ * Returns a query for all CVRs imported for the current election.
  */
-export function useCvrFilesQuery(): UseQueryResult<
-  Admin.CastVoteRecordFileRecord[]
-> {
+export function useCvrsQuery(): UseQueryResult<CastVoteRecord[]> {
   const { backend } = useContext(ServicesContext);
-  return useQuery(getCvrsQueryKey(), () => backend.getCvrs());
+  return useQuery(getCvrsQueryKey(), () => backend.getCvrs(), {
+    staleTime: Infinity,
+  });
 }

--- a/frontends/election-manager/src/lib/backends/admin_backend.ts
+++ b/frontends/election-manager/src/lib/backends/admin_backend.ts
@@ -326,7 +326,10 @@ export class ElectionManagerStoreAdminBackend
   }
 
   async getCvrs(): Promise<CastVoteRecord[]> {
-    const currentElectionId = await this.loadCurrentElectionIdOrThrow();
+    const currentElectionId = await this.loadCurrentElectionId();
+    if (!currentElectionId) {
+      return [];
+    }
 
     return (await fetchJson(
       `/admin/elections/${currentElectionId}/cvrs`

--- a/frontends/election-manager/src/lib/backends/memory_backend.ts
+++ b/frontends/election-manager/src/lib/backends/memory_backend.ts
@@ -151,11 +151,7 @@ export class ElectionManagerStoreMemoryBackend
   }
 
   getCvrs(): Promise<CastVoteRecord[]> {
-    if (!this.electionDefinition) {
-      throw new Error('Election definition must be configured first');
-    }
-
-    if (!this.castVoteRecordFiles) {
+    if (!this.electionDefinition || !this.castVoteRecordFiles) {
       return Promise.resolve([]);
     }
 


### PR DESCRIPTION
## Overview
Related to: https://github.com/votingworks/vxsuite/issues/2716

Updates client-side tally computation logic to use CVRs from the server to enable removing all CVR data from client-side local storage.

## Demo Video or Screenshot
https://user-images.githubusercontent.com/264902/204389687-10a35364-af40-403d-8c6e-d8d3938b958f.mov

## Testing Plan 
- Existing tests for regression detection
- Local run to verify tallies are computed and cleared appropriately

## Checklist
- [n/a] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [n/a] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
