### PR TITLE
Non-Zero Total Warning on VxScan

### DIFF
--- a/frontends/precinct-scanner/src/app.test.tsx
+++ b/frontends/precinct-scanner/src/app.test.tsx
@@ -718,9 +718,8 @@ test('scanning is not triggered when polls closed or cards present', async () =>
   const { mockPollsChange } = mockConfig();
 
   fetchMock
-    // Set up the status endpoint with 15 ballots scanned
     .get('/precinct-scanner/scanner/status', {
-      body: scannerStatus({ state: 'ready_to_scan', ballotsCounted: 15 }),
+      body: scannerStatus({ state: 'ready_to_scan' }),
     })
     // Mock the scan endpoint just so we can check that we don't hit it
     .post('/precinct-scanner/scanner/scan', { status: 500 });
@@ -730,12 +729,9 @@ test('scanning is not triggered when polls closed or cards present', async () =>
   fetchMock.post('/precinct-scanner/export', {});
   card.insertCard(pollWorkerCard);
   await screen.findByText('Do you want to open the polls?');
-  // We should see 15 ballots were scanned
-  userEvent.click(screen.getAllByText('No')[0]);
-  expect((await screen.findByTestId('ballot-count')).textContent).toBe('15');
   // Open Polls
   mockPollsChange('polls_open');
-  userEvent.click(await screen.findByText('Open Polls'));
+  userEvent.click(screen.getByText('Yes, Open the Polls'));
   await screen.findByText('Polls are open.');
 
   // Once we remove the poll worker card, scanning should start

--- a/frontends/precinct-scanner/src/screens/poll_worker_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/poll_worker_screen.test.tsx
@@ -108,8 +108,10 @@ describe('shows Livecheck button only when enabled', () => {
 
 describe('transitions from polls closed', () => {
   let updatePollsState = jest.fn();
+  let logger = fakeLogger();
   beforeEach(async () => {
     updatePollsState = jest.fn();
+    logger = fakeLogger();
     renderScreen({
       pollWorkerScreenProps: {
         scannedBallotCount: 0,
@@ -118,6 +120,7 @@ describe('transitions from polls closed', () => {
       },
       appContextProps: {
         auth: readableFakePollWorkerAuth(),
+        logger,
       },
     });
     await screen.findByText('Do you want to open the polls?');
@@ -128,6 +131,11 @@ describe('transitions from polls closed', () => {
     await screen.findByText('Opening Polls…');
     await screen.findByText('Polls are open.');
     expect(updatePollsState).toHaveBeenLastCalledWith('polls_open');
+    expect(logger.log).toHaveBeenCalledWith(
+      LogEventId.PollsOpened,
+      'poll_worker',
+      expect.objectContaining({ disposition: 'success' })
+    );
   });
 
   test('open polls from landing screen', async () => {
@@ -136,12 +144,19 @@ describe('transitions from polls closed', () => {
     await screen.findByText('Opening Polls…');
     await screen.findByText('Polls are open.');
     expect(updatePollsState).toHaveBeenLastCalledWith('polls_open');
+    expect(logger.log).toHaveBeenCalledWith(
+      LogEventId.PollsOpened,
+      'poll_worker',
+      expect.objectContaining({ disposition: 'success' })
+    );
   });
 });
 
 describe('transitions from polls open', () => {
   let updatePollsState = jest.fn();
+  let logger = fakeLogger();
   beforeEach(async () => {
+    logger = fakeLogger();
     updatePollsState = jest.fn();
     renderScreen({
       pollWorkerScreenProps: {
@@ -151,6 +166,7 @@ describe('transitions from polls open', () => {
       },
       appContextProps: {
         auth: readableFakePollWorkerAuth(),
+        logger,
       },
     });
     await screen.findByText('Do you want to close the polls?');
@@ -161,6 +177,11 @@ describe('transitions from polls open', () => {
     await screen.findByText('Closing Polls…');
     await screen.findByText('Polls are closed.');
     expect(updatePollsState).toHaveBeenLastCalledWith('polls_closed_final');
+    expect(logger.log).toHaveBeenCalledWith(
+      LogEventId.PollsClosed,
+      'poll_worker',
+      expect.objectContaining({ disposition: 'success' })
+    );
   });
 
   test('close polls from landing screen', async () => {
@@ -169,21 +190,33 @@ describe('transitions from polls open', () => {
     await screen.findByText('Closing Polls…');
     await screen.findByText('Polls are closed.');
     expect(updatePollsState).toHaveBeenLastCalledWith('polls_closed_final');
+    expect(logger.log).toHaveBeenCalledWith(
+      LogEventId.PollsClosed,
+      'poll_worker',
+      expect.objectContaining({ disposition: 'success' })
+    );
   });
 
-  test('pause polls', async () => {
+  test('pause voting', async () => {
     userEvent.click(screen.getByText('No'));
     userEvent.click(await screen.findByText('Pause Voting'));
     await screen.findByText('Pausing Voting…');
     await screen.findByText('Voting paused.');
     expect(updatePollsState).toHaveBeenLastCalledWith('polls_paused');
+    expect(logger.log).toHaveBeenCalledWith(
+      LogEventId.VotingPaused,
+      'poll_worker',
+      expect.objectContaining({ disposition: 'success' })
+    );
   });
 });
 
 describe('transitions from polls paused', () => {
   let updatePollsState = jest.fn();
+  let logger = fakeLogger();
   beforeEach(async () => {
     updatePollsState = jest.fn();
+    logger = fakeLogger();
     renderScreen({
       pollWorkerScreenProps: {
         scannedBallotCount: 0,
@@ -192,24 +225,35 @@ describe('transitions from polls paused', () => {
       },
       appContextProps: {
         auth: readableFakePollWorkerAuth(),
+        logger,
       },
     });
     await screen.findByText('Do you want to resume voting?');
   });
 
-  test('open polls happy path', async () => {
+  test('resume voting happy path', async () => {
     userEvent.click(screen.getByText('Yes, Resume Voting'));
     await screen.findByText('Resuming Voting…');
     await screen.findByText('Voting resumed.');
     expect(updatePollsState).toHaveBeenLastCalledWith('polls_open');
+    expect(logger.log).toHaveBeenCalledWith(
+      LogEventId.VotingResumed,
+      'poll_worker',
+      expect.objectContaining({ disposition: 'success' })
+    );
   });
 
-  test('open polls from landing screen', async () => {
+  test('resume voting from landing screen', async () => {
     userEvent.click(screen.getByText('No'));
     userEvent.click(await screen.findByText('Resume Voting'));
     await screen.findByText('Resuming Voting…');
     await screen.findByText('Voting resumed.');
     expect(updatePollsState).toHaveBeenLastCalledWith('polls_open');
+    expect(logger.log).toHaveBeenCalledWith(
+      LogEventId.VotingResumed,
+      'poll_worker',
+      expect.objectContaining({ disposition: 'success' })
+    );
   });
 
   test('close polls from landing screen', async () => {
@@ -218,6 +262,11 @@ describe('transitions from polls paused', () => {
     await screen.findByText('Closing Polls…');
     await screen.findByText('Polls are closed.');
     expect(updatePollsState).toHaveBeenLastCalledWith('polls_closed_final');
+    expect(logger.log).toHaveBeenCalledWith(
+      LogEventId.PollsClosed,
+      'poll_worker',
+      expect.objectContaining({ disposition: 'success' })
+    );
   });
 });
 

--- a/frontends/precinct-scanner/src/screens/poll_worker_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/poll_worker_screen.test.tsx
@@ -22,6 +22,8 @@ jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
   };
 });
 
+jest.mock('../utils/save_cvr_export_to_usb');
+
 MockDate.set('2020-10-31T00:00:00.000Z');
 
 beforeEach(() => {
@@ -134,7 +136,10 @@ describe('transitions from polls closed', () => {
     expect(logger.log).toHaveBeenCalledWith(
       LogEventId.PollsOpened,
       'poll_worker',
-      expect.objectContaining({ disposition: 'success' })
+      expect.objectContaining({
+        disposition: 'success',
+        scannedBallotCount: 0,
+      })
     );
   });
 
@@ -147,7 +152,10 @@ describe('transitions from polls closed', () => {
     expect(logger.log).toHaveBeenCalledWith(
       LogEventId.PollsOpened,
       'poll_worker',
-      expect.objectContaining({ disposition: 'success' })
+      expect.objectContaining({
+        disposition: 'success',
+        scannedBallotCount: 0,
+      })
     );
   });
 });
@@ -160,7 +168,7 @@ describe('transitions from polls open', () => {
     updatePollsState = jest.fn();
     renderScreen({
       pollWorkerScreenProps: {
-        scannedBallotCount: 0,
+        scannedBallotCount: 7,
         pollsState: 'polls_open',
         updatePollsState,
       },
@@ -180,7 +188,10 @@ describe('transitions from polls open', () => {
     expect(logger.log).toHaveBeenCalledWith(
       LogEventId.PollsClosed,
       'poll_worker',
-      expect.objectContaining({ disposition: 'success' })
+      expect.objectContaining({
+        disposition: 'success',
+        scannedBallotCount: 7,
+      })
     );
   });
 
@@ -193,7 +204,10 @@ describe('transitions from polls open', () => {
     expect(logger.log).toHaveBeenCalledWith(
       LogEventId.PollsClosed,
       'poll_worker',
-      expect.objectContaining({ disposition: 'success' })
+      expect.objectContaining({
+        disposition: 'success',
+        scannedBallotCount: 7,
+      })
     );
   });
 
@@ -206,7 +220,10 @@ describe('transitions from polls open', () => {
     expect(logger.log).toHaveBeenCalledWith(
       LogEventId.VotingPaused,
       'poll_worker',
-      expect.objectContaining({ disposition: 'success' })
+      expect.objectContaining({
+        disposition: 'success',
+        scannedBallotCount: 7,
+      })
     );
   });
 });
@@ -219,7 +236,7 @@ describe('transitions from polls paused', () => {
     logger = fakeLogger();
     renderScreen({
       pollWorkerScreenProps: {
-        scannedBallotCount: 0,
+        scannedBallotCount: 7,
         pollsState: 'polls_paused',
         updatePollsState,
       },
@@ -239,7 +256,10 @@ describe('transitions from polls paused', () => {
     expect(logger.log).toHaveBeenCalledWith(
       LogEventId.VotingResumed,
       'poll_worker',
-      expect.objectContaining({ disposition: 'success' })
+      expect.objectContaining({
+        disposition: 'success',
+        scannedBallotCount: 7,
+      })
     );
   });
 
@@ -252,7 +272,10 @@ describe('transitions from polls paused', () => {
     expect(logger.log).toHaveBeenCalledWith(
       LogEventId.VotingResumed,
       'poll_worker',
-      expect.objectContaining({ disposition: 'success' })
+      expect.objectContaining({
+        disposition: 'success',
+        scannedBallotCount: 7,
+      })
     );
   });
 
@@ -265,7 +288,10 @@ describe('transitions from polls paused', () => {
     expect(logger.log).toHaveBeenCalledWith(
       LogEventId.PollsClosed,
       'poll_worker',
-      expect.objectContaining({ disposition: 'success' })
+      expect.objectContaining({
+        disposition: 'success',
+        scannedBallotCount: 7,
+      })
     );
   });
 });
@@ -303,6 +329,7 @@ test('there is a warning if we attempt to polls with ballots scanned', async () 
     'poll_worker',
     expect.objectContaining({
       disposition: 'failure',
+      scannedBallotCount: 1,
     })
   );
 });

--- a/frontends/precinct-scanner/src/screens/poll_worker_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/poll_worker_screen.tsx
@@ -43,6 +43,7 @@ import {
   PollsTransition,
   Optional,
 } from '@votingworks/types';
+import { LogEventId } from '@votingworks/logging';
 import {
   CenteredLargeProse,
   ScreenMainCenterChild,
@@ -51,7 +52,7 @@ import {
 import { LiveCheckModal } from '../components/live_check_modal';
 
 import { AppContext } from '../contexts/app_context';
-import { IndeterminateProgressBar } from '../components/graphics';
+import { IndeterminateProgressBar, TimesCircle } from '../components/graphics';
 import { ScannedBallotCount } from '../components/scanned_ballot_count';
 import { saveCvrExportToUsb } from '../utils/save_cvr_export_to_usb';
 import * as scan from '../api/scan';
@@ -88,6 +89,21 @@ async function getCvrsFromExport(): Promise<CastVoteRecord[]> {
 
 const debug = makeDebug('precinct-scanner:pollworker-screen');
 
+const BallotsAlreadyScannedScreen = (
+  <ScreenMainCenterChild infoBarMode="pollworker">
+    <TimesCircle />
+    <CenteredLargeProse>
+      <h1>Ballots Already Scanned</h1>
+      <p>
+        Ballots were scanned on this machine before polls were opened. This may
+        indicate an internal error or tampering. The polls can no longer be
+        opened on this machine. Please report this issue to an election
+        administrator.
+      </p>
+    </CenteredLargeProse>
+  </ScreenMainCenterChild>
+);
+
 export interface PollWorkerScreenProps {
   scannedBallotCount: number;
   pollsState: PollsState;
@@ -103,7 +119,7 @@ export function PollWorkerScreen({
   isLiveMode,
   hasPrinterAttached: printerFromProps,
 }: PollWorkerScreenProps): JSX.Element {
-  const { electionDefinition, precinctSelection, machineConfig, auth } =
+  const { electionDefinition, precinctSelection, machineConfig, auth, logger } =
     useContext(AppContext);
   assert(electionDefinition);
   assert(precinctSelection);
@@ -113,6 +129,10 @@ export function PollWorkerScreen({
     ReadonlyMap<string, Tally>
   >(new Map());
   const [isShowingLiveCheck, setIsShowingLiveCheck] = useState(false);
+  const [
+    isShowingBallotsAlreadyScannedScreen,
+    setIsShowingBallotsAlreadyScannedScreen,
+  ] = useState(false);
   const hasPrinterAttached = printerFromProps || !window.kiosk;
   const { election } = electionDefinition;
 
@@ -340,6 +360,19 @@ export function PollWorkerScreen({
   }
 
   async function transitionPolls(pollsTransition: PollsTransition) {
+    // In compliance with VVSG 2.0 1.1.3-B, confirm there are no scanned
+    // ballots before opening polls, even though this should be an impossible
+    // state in production.
+    if (pollsTransition === 'open_polls' && scannedBallotCount > 0) {
+      setIsShowingBallotsAlreadyScannedScreen(true);
+      await logger.log(LogEventId.PollsOpened, 'poll_worker', {
+        disposition: 'failure',
+        message:
+          'Non-zero ballots scanned count detected upon attempt to open polls.',
+      });
+      return;
+    }
+
     const timePollsTransitioned = Date.now();
     setCurrentPollsTransition(pollsTransition);
     setPollWorkerFlowState('polls_transition_processing');
@@ -389,6 +422,10 @@ export function PollWorkerScreen({
         </CenteredLargeProse>
       </ScreenMainCenterChild>
     );
+  }
+
+  if (isShowingBallotsAlreadyScannedScreen) {
+    return BallotsAlreadyScannedScreen;
   }
 
   if (pollWorkerFlowState === 'open_polls_prompt') {
@@ -582,4 +619,9 @@ export function PollWorkerScreen({
       )}
     </ScreenMainCenterChild>
   );
+}
+
+/* istanbul ignore next */
+export function BallotsAlreadyScannedScreenPreview(): JSX.Element {
+  return BallotsAlreadyScannedScreen;
 }

--- a/frontends/precinct-scanner/src/screens/poll_worker_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/poll_worker_screen.tsx
@@ -43,7 +43,10 @@ import {
   PollsTransition,
   Optional,
 } from '@votingworks/types';
-import { LogEventId } from '@votingworks/logging';
+import {
+  getLogEventIdForPollsTransition,
+  LogEventId,
+} from '@votingworks/logging';
 import {
   CenteredLargeProse,
   ScreenMainCenterChild,
@@ -382,6 +385,13 @@ export function PollWorkerScreen({
     }
     setCurrentPollsTransitionTime(timePollsTransitioned);
     updatePollsState(getPollsTransitionDestinationState(pollsTransition));
+    await logger.log(
+      getLogEventIdForPollsTransition(pollsTransition),
+      'poll_worker',
+      {
+        disposition: 'success',
+      }
+    );
     setPollWorkerFlowState('polls_transition_complete');
   }
 

--- a/frontends/precinct-scanner/src/screens/poll_worker_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/poll_worker_screen.tsx
@@ -372,6 +372,7 @@ export function PollWorkerScreen({
         disposition: 'failure',
         message:
           'Non-zero ballots scanned count detected upon attempt to open polls.',
+        scannedBallotCount,
       });
       return;
     }
@@ -390,6 +391,7 @@ export function PollWorkerScreen({
       'poll_worker',
       {
         disposition: 'success',
+        scannedBallotCount,
       }
     );
     setPollWorkerFlowState('polls_transition_complete');

--- a/libs/logging/src/helpers.test.ts
+++ b/libs/logging/src/helpers.test.ts
@@ -1,0 +1,17 @@
+import { getLogEventIdForPollsTransition } from './helpers';
+import { LogEventId } from './log_event_ids';
+
+test('getLogEventIdForPollsTransition', () => {
+  expect(getLogEventIdForPollsTransition('open_polls')).toEqual(
+    LogEventId.PollsOpened
+  );
+  expect(getLogEventIdForPollsTransition('resume_voting')).toEqual(
+    LogEventId.VotingResumed
+  );
+  expect(getLogEventIdForPollsTransition('pause_voting')).toEqual(
+    LogEventId.VotingPaused
+  );
+  expect(getLogEventIdForPollsTransition('close_polls')).toEqual(
+    LogEventId.PollsClosed
+  );
+});

--- a/libs/logging/src/helpers.ts
+++ b/libs/logging/src/helpers.ts
@@ -1,0 +1,21 @@
+import { PollsTransition } from '@votingworks/types';
+import { throwIllegalValue } from '@votingworks/utils';
+import { LogEventId } from './log_event_ids';
+
+export function getLogEventIdForPollsTransition(
+  transition: PollsTransition
+): LogEventId {
+  switch (transition) {
+    case 'open_polls':
+      return LogEventId.PollsOpened;
+    case 'pause_voting':
+      return LogEventId.VotingPaused;
+    case 'resume_voting':
+      return LogEventId.VotingResumed;
+    case 'close_polls':
+      return LogEventId.PollsClosed;
+    /* istanbul ignore next */
+    default:
+      throwIllegalValue(transition);
+  }
+}

--- a/libs/logging/src/index.ts
+++ b/libs/logging/src/index.ts
@@ -5,3 +5,4 @@ export * from './log_event_ids';
 export * from './log_event_types';
 export * from './log_source';
 export * from './test_utils';
+export * from './helpers';


### PR DESCRIPTION
## Overview
To meet VVSG 2.0 1.1.3-B as part of #2800. If we're only doing the warning on VxScan, it closes that issue. If we have to do it on VxMark as well, will make a separate PR. Please review copy below, knowing that this copy will almost certainly never be seen in production. 

I also added logging to the regular polls closed/open/paused actions in a second commit, as this was something missed in the first pass.

## Demo Video or Screenshot

<img width="1093" alt="Screen Shot 2022-11-29 at 9 49 29 AM" src="https://user-images.githubusercontent.com/37960853/204643006-c53d838c-3f8f-4564-8433-9583e3597118.png">

## Testing Plan

Automated testing and added this screen to the Preview App for easy viewing.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates

