### PR TITLE
chore: Remove dead link to script/react-scripts

### DIFF
--- a/frontends/bas/script/react-scripts
+++ b/frontends/bas/script/react-scripts
@@ -1,1 +1,0 @@
-../../../script/react-scripts

--- a/frontends/bmd/script/react-scripts
+++ b/frontends/bmd/script/react-scripts
@@ -1,1 +1,0 @@
-../../../script/react-scripts

--- a/frontends/bsd/script/react-scripts
+++ b/frontends/bsd/script/react-scripts
@@ -1,1 +1,0 @@
-../../../script/react-scripts

--- a/frontends/election-manager/script/react-scripts
+++ b/frontends/election-manager/script/react-scripts
@@ -1,1 +1,0 @@
-../../../script/react-scripts

--- a/frontends/precinct-scanner/script/react-scripts
+++ b/frontends/precinct-scanner/script/react-scripts
@@ -1,1 +1,0 @@
-../../../script/react-scripts


### PR DESCRIPTION

## Overview
I couldn't find the script that these links were pointing to, so I assume it was removed when we migrated to vite.

## Demo Video or Screenshot
N/A
## Testing Plan 
N/A
## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
