### PR TITLE
[VxAdmin] Update client to use CVR file metadata from the server

### DIFF
--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -1107,6 +1107,10 @@ test('changing election resets sems, cvr, and manual data files', async () => {
     fireEvent.click(getByText('Load Demo Election Definition'));
   });
 
+  await backend.configure(
+    electionFamousNames2021Fixtures.electionDefinition.electionData
+  );
+
   userEvent.click(screen.getByText('Lock Machine'));
   await authenticateWithElectionManagerCard(
     card,

--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -583,7 +583,9 @@ test('tabulating CVRs', async () => {
     expect.anything()
   );
 
-  fireEvent.click(getByText('Mark Tally Results as Official'));
+  const markOfficialButton = getByText('Mark Tally Results as Official');
+  await waitFor(expect(markOfficialButton).toBeEnabled);
+  fireEvent.click(markOfficialButton);
   getByText('Mark Unofficial Tally Results as Official Tally Results?');
   const modal = await screen.findByRole('alertdialog');
   fireEvent.click(within(modal).getByText('Mark Tally Results as Official'));
@@ -711,7 +713,12 @@ test('tabulating CVRs', async () => {
 
   // Clear results
   fireEvent.click(getByText('Tally'));
-  fireEvent.click(getByText('Clear All Tallies and Results'));
+
+  const clearTalliesButton = await screen.findByText(
+    'Clear All Tallies and Results'
+  );
+  expect(clearTalliesButton).toBeEnabled();
+  fireEvent.click(clearTalliesButton);
   fireEvent.click(getByText('Remove All Data'));
   await waitFor(() => expect(getByText('No CVR files loaded.')));
   expect(logger.log).toHaveBeenCalledWith(
@@ -767,7 +774,7 @@ test('tabulating CVRs with SEMS file', async () => {
   );
 
   fireEvent.click(getByText('Tally'));
-  getByText('External Results (sems-results.csv)');
+  await screen.findByText('External Results (sems-results.csv)');
 
   fireEvent.click(getByText('Reports'));
   getByText('External Results (sems-results.csv)');
@@ -847,7 +854,7 @@ test('tabulating CVRs with SEMS file', async () => {
 
   // Test removing the SEMS file
   fireEvent.click(getByText('Tally'));
-  fireEvent.click(getByText('Remove External Results File'));
+  fireEvent.click(await screen.findByText('Remove External Results File'));
   fireEvent.click(getByText('Remove External Files'));
   await waitFor(() =>
     expect(getByTestId('total-cvr-count').textContent).toEqual('100')
@@ -886,7 +893,8 @@ test('tabulating CVRs with SEMS file and manual data', async () => {
   );
 
   fireEvent.click(getByText('Tally'));
-  expect(getByTestId('total-cvr-count').textContent).toEqual('200');
+  await advanceTimersAndPromises(5); // Allow async queries to resolve first.
+  expect(await screen.findByTestId('total-cvr-count')).toHaveTextContent('200');
 
   fireEvent.click(getByText('Add Manually Entered Results'));
   getByText('Manually Entered Precinct Results');
@@ -914,7 +922,7 @@ test('tabulating CVRs with SEMS file and manual data', async () => {
     expect(getByTestId('total-ballots-entered').textContent).toEqual('100');
   });
   fireEvent.click(getByText('Back to Tally'));
-  expect(getByTestId('total-cvr-count').textContent).toEqual('300');
+  expect(await screen.findByTestId('total-cvr-count')).toHaveTextContent('300');
 
   const fileTable = getByTestId('loaded-file-table');
   const manualRow = domGetByText(
@@ -953,7 +961,7 @@ test('tabulating CVRs with SEMS file and manual data', async () => {
 
   // Now edit the manual data
   fireEvent.click(getByText('Tally'));
-  fireEvent.click(getByText('Edit Manually Entered Results'));
+  fireEvent.click(await screen.findByText('Edit Manually Entered Results'));
 
   // Existing data is still there
   const district5Row = getByText('District 5').closest('tr')!;
@@ -987,7 +995,7 @@ test('tabulating CVRs with SEMS file and manual data', async () => {
   });
 
   fireEvent.click(getByText('Back to Tally'));
-  expect(getByTestId('total-cvr-count').textContent).toEqual('400');
+  expect(await screen.findByTestId('total-cvr-count')).toHaveTextContent('400');
   const fileTable2 = getByTestId('loaded-file-table');
   const manualRow2 = domGetByText(
     fileTable2,
@@ -1024,7 +1032,7 @@ test('tabulating CVRs with SEMS file and manual data', async () => {
 
   // Remove the manual data
   fireEvent.click(getByText('Tally'));
-  fireEvent.click(getByText('Remove Manual Data'));
+  fireEvent.click(await screen.findByText('Remove Manual Data'));
 
   getByText('Do you want to remove the manually entered data?');
   const modal = await screen.findByRole('alertdialog');
@@ -1106,7 +1114,7 @@ test('changing election resets sems, cvr, and manual data files', async () => {
   );
 
   fireEvent.click(await screen.findByText('Tally'));
-  getByText('No CVR files loaded.');
+  await screen.findByText('No CVR files loaded.');
   await screen.findByText('Currently tallying live ballots.');
   // We're waiting on a query for isOfficialResults. It has a default value,
   // so there is no change on the page to wait for before test ends.
@@ -1165,7 +1173,9 @@ test('clearing all files after marking as official clears SEMS, CVR, and manual 
   );
 
   fireEvent.click(getByText('Unofficial Full Election Tally Report'));
-  fireEvent.click(getByText('Mark Tally Results as Official'));
+  const markOfficialButton = getByText('Mark Tally Results as Official');
+  await waitFor(expect(markOfficialButton).toBeEnabled);
+  fireEvent.click(markOfficialButton);
   const modal = await screen.findByRole('alertdialog');
   fireEvent.click(within(modal).getByText('Mark Tally Results as Official'));
 
@@ -1175,7 +1185,9 @@ test('clearing all files after marking as official clears SEMS, CVR, and manual 
   });
 
   fireEvent.click(getByText('Tally'));
-  expect(getByText('Load CVR Files').closest('button')).toBeDisabled();
+  expect(
+    (await screen.findByText('Load CVR Files')).closest('button')
+  ).toBeDisabled();
   expect(getByText('Remove CVR Files').closest('button')).toBeDisabled();
   expect(
     getByText('Edit Manually Entered Results').closest('button')

--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -1174,7 +1174,7 @@ test('clearing all files after marking as official clears SEMS, CVR, and manual 
 
   fireEvent.click(getByText('Unofficial Full Election Tally Report'));
   const markOfficialButton = getByText('Mark Tally Results as Official');
-  await waitFor(expect(markOfficialButton).toBeEnabled);
+  await waitFor(() => expect(markOfficialButton).toBeEnabled());
   fireEvent.click(markOfficialButton);
   const modal = await screen.findByRole('alertdialog');
   fireEvent.click(within(modal).getByText('Mark Tally Results as Official'));

--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -584,7 +584,7 @@ test('tabulating CVRs', async () => {
   );
 
   const markOfficialButton = getByText('Mark Tally Results as Official');
-  await waitFor(expect(markOfficialButton).toBeEnabled);
+  await waitFor(() => expect(markOfficialButton).toBeEnabled());
   fireEvent.click(markOfficialButton);
   getByText('Mark Unofficial Tally Results as Official Tally Results?');
   const modal = await screen.findByRole('alertdialog');

--- a/frontends/election-manager/src/app_root.tsx
+++ b/frontends/election-manager/src/app_root.tsx
@@ -225,7 +225,6 @@ export function AppRoot({
   return (
     <AppContext.Provider
       value={{
-        castVoteRecordFiles: store.castVoteRecordFiles,
         electionDefinition,
         configuredAt: currentElection.data?.createdAt,
         converter,

--- a/frontends/election-manager/src/app_write_in_flows.test.tsx
+++ b/frontends/election-manager/src/app_write_in_flows.test.tsx
@@ -67,7 +67,7 @@ test('manual write-in data end-to-end test', async () => {
     electionMinimalExhaustiveSampleDefinition
   );
   userEvent.click(screen.getByText('Tally'));
-  userEvent.click(screen.getByText('Add Manually Entered Results'));
+  userEvent.click(await screen.findByText('Add Manually Entered Results'));
   userEvent.click(screen.getByText('Edit Precinct Results for Precinct 1'));
 
   // Navigate away, adjudicated a write-in, and return - to ensure the

--- a/frontends/election-manager/src/components/confirm_removing_file_modal.tsx
+++ b/frontends/election-manager/src/components/confirm_removing_file_modal.tsx
@@ -45,7 +45,10 @@ export function ConfirmRemovingFileModal({
         return <Loading />;
       }
 
-      const fileList = cvrFilesQuery.data || [];
+      const fileList =
+        cvrFilesQuery.isLoading || cvrFilesQuery.isError
+          ? []
+          : cvrFilesQuery.data;
       singleFileRemoval = fileList.length <= 1;
       fileTypeName = 'CVR Files';
       mainContent = (
@@ -83,7 +86,10 @@ export function ConfirmRemovingFileModal({
 
       fileTypeName = 'Data';
       singleFileRemoval = false;
-      const fileList = cvrFilesQuery.data || [];
+      const fileList =
+        cvrFilesQuery.isLoading || cvrFilesQuery.isError
+          ? []
+          : cvrFilesQuery.data;
       let externalDetails = '';
       if (semsFile !== undefined && manualData !== undefined) {
         externalDetails = `, the external results file ${semsFile.inputSourceName}, and the manually entered data`;

--- a/frontends/election-manager/src/components/confirm_removing_file_modal.tsx
+++ b/frontends/election-manager/src/components/confirm_removing_file_modal.tsx
@@ -6,6 +6,8 @@ import { Modal, Prose, Button } from '@votingworks/ui';
 import { ExternalTallySourceType } from '@votingworks/types';
 import { AppContext } from '../contexts/app_context';
 import { ResultsFileType } from '../config/types';
+import { useCvrFilesQuery } from '../hooks/use_cvr_files_query';
+import { Loading } from './loading';
 
 export interface Props {
   onConfirm: (fileType: ResultsFileType) => void;
@@ -18,8 +20,7 @@ export function ConfirmRemovingFileModal({
   onCancel,
   fileType,
 }: Props): JSX.Element {
-  const { castVoteRecordFiles, fullElectionExternalTallies } =
-    useContext(AppContext);
+  const { fullElectionExternalTallies } = useContext(AppContext);
 
   const semsFile = fullElectionExternalTallies.get(
     ExternalTallySourceType.SEMS
@@ -28,27 +29,31 @@ export function ConfirmRemovingFileModal({
     ExternalTallySourceType.Manual
   );
 
+  const cvrFilesQuery = useCvrFilesQuery();
+
+  const isLoading =
+    (fileType === ResultsFileType.CastVoteRecord ||
+      fileType === ResultsFileType.All) &&
+    cvrFilesQuery.isLoading;
+
   let mainContent: React.ReactNode = null;
   let fileTypeName = '';
   let singleFileRemoval = true;
   switch (fileType) {
     case ResultsFileType.CastVoteRecord: {
-      const { fileList } = castVoteRecordFiles;
+      if (isLoading) {
+        return <Loading />;
+      }
+
+      const fileList = cvrFilesQuery.data || [];
       singleFileRemoval = fileList.length <= 1;
       fileTypeName = 'CVR Files';
       mainContent = (
         <React.Fragment>
-          {fileList.length ? (
-            <p>
-              Do you want to remove the {fileList.length} loaded CVR{' '}
-              {pluralize('files', fileList.length)}?
-            </p>
-          ) : (
-            <p>
-              Do you want to remove the files causing errors:{' '}
-              {castVoteRecordFiles.lastError?.filename}?
-            </p>
-          )}
+          <p>
+            Do you want to remove the {fileList.length} loaded CVR{' '}
+            {pluralize('files', fileList.length)}?
+          </p>
           <p>All reports will be unavailable without CVR data.</p>
         </React.Fragment>
       );
@@ -72,9 +77,13 @@ export function ConfirmRemovingFileModal({
       break;
     }
     case ResultsFileType.All: {
+      if (isLoading) {
+        return <Loading />;
+      }
+
       fileTypeName = 'Data';
       singleFileRemoval = false;
-      const { fileList } = castVoteRecordFiles;
+      const fileList = cvrFilesQuery.data || [];
       let externalDetails = '';
       if (semsFile !== undefined && manualData !== undefined) {
         externalDetails = `, the external results file ${semsFile.inputSourceName}, and the manually entered data`;
@@ -105,7 +114,11 @@ export function ConfirmRemovingFileModal({
       content={<Prose textCenter>{mainContent}</Prose>}
       actions={
         <React.Fragment>
-          <Button danger onPress={() => onConfirm(fileType)}>
+          <Button
+            danger
+            disabled={isLoading}
+            onPress={() => onConfirm(fileType)}
+          >
             Remove {!singleFileRemoval && 'All'} {fileTypeName}
           </Button>
           <Button onPress={onCancel}>Cancel</Button>

--- a/frontends/election-manager/src/components/import_cvrfiles_modal.test.tsx
+++ b/frontends/election-manager/src/components/import_cvrfiles_modal.test.tsx
@@ -30,7 +30,11 @@ const LIVE_FILE1 = 'machine_0002__10_ballots__2020-12-09_15-59-32.jsonl';
 
 const { UsbDriveStatus } = usbstick;
 
-test('No USB screen shows when there is no USB drive', () => {
+test('No USB screen shows when there is no USB drive', async () => {
+  const backend = new ElectionManagerStoreMemoryBackend({
+    electionDefinition: eitherNeitherElectionDefinition,
+  });
+
   const usbStatuses = [
     UsbDriveStatus.absent,
     UsbDriveStatus.recentlyEjected,
@@ -41,9 +45,9 @@ test('No USB screen shows when there is no USB drive', () => {
     const closeFn = jest.fn();
     const { unmount, getByText } = renderInAppContext(
       <ImportCvrFilesModal onClose={closeFn} />,
-      { usbDriveStatus: usbStatus }
+      { backend, usbDriveStatus: usbStatus }
     );
-    getByText('No USB Drive Detected');
+    await screen.findByText('No USB Drive Detected');
 
     fireEvent.click(getByText('Cancel'));
     expect(closeFn).toHaveBeenCalledTimes(1);

--- a/frontends/election-manager/src/components/import_cvrfiles_modal.test.tsx
+++ b/frontends/election-manager/src/components/import_cvrfiles_modal.test.tsx
@@ -268,7 +268,6 @@ describe('Screens display properly when USB is mounted', () => {
       <ImportCvrFilesModal onClose={closeFn} />,
       {
         usbDriveStatus: UsbDriveStatus.mounted,
-        castVoteRecordFiles: added,
         logger,
         backend,
       }
@@ -380,7 +379,6 @@ describe('Screens display properly when USB is mounted', () => {
       <ImportCvrFilesModal onClose={closeFn} />,
       {
         usbDriveStatus: UsbDriveStatus.mounted,
-        castVoteRecordFiles: added,
         backend,
       }
     );
@@ -450,7 +448,6 @@ describe('Screens display properly when USB is mounted', () => {
       <ImportCvrFilesModal onClose={closeFn} />,
       {
         usbDriveStatus: UsbDriveStatus.mounted,
-        castVoteRecordFiles: added,
         backend,
       }
     );

--- a/frontends/election-manager/src/components/import_cvrfiles_modal.tsx
+++ b/frontends/election-manager/src/components/import_cvrfiles_modal.tsx
@@ -349,7 +349,7 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
     // Parse the file options on the USB drive and build table rows for each valid file.
     const fileTableRows: JSX.Element[] = [];
     let numberOfNewFiles = 0;
-    const cvrFiles = cvrFilesQuery.data || [];
+    const cvrFiles = cvrFilesQuery.isError ? [] : cvrFilesQuery.data;
     const importedFileNames = new Set(cvrFiles.map((f) => f.filename));
     for (const file of foundFiles) {
       const { isTestModeResults, scannerIds, exportTimestamp, cvrCount, name } =

--- a/frontends/election-manager/src/components/import_cvrfiles_modal.tsx
+++ b/frontends/election-manager/src/components/import_cvrfiles_modal.tsx
@@ -78,7 +78,7 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
   const { usbDriveStatus, electionDefinition, auth, logger } =
     useContext(AppContext);
   const addCastVoteRecordFileMutation = useAddCastVoteRecordFileMutation();
-  const cvrFiles = useCvrFilesQuery().data || [];
+  const cvrFilesQuery = useCvrFilesQuery();
   const fileMode = useCvrFileModeQuery().data;
 
   assert(electionDefinition);
@@ -289,6 +289,7 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
   }
 
   if (
+    cvrFilesQuery.isFetching ||
     currentState.state === 'loading' ||
     usbDriveStatus === usbstick.UsbDriveStatus.ejecting ||
     usbDriveStatus === usbstick.UsbDriveStatus.present
@@ -348,6 +349,7 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
     // Parse the file options on the USB drive and build table rows for each valid file.
     const fileTableRows: JSX.Element[] = [];
     let numberOfNewFiles = 0;
+    const cvrFiles = cvrFilesQuery.data || [];
     const importedFileNames = new Set(cvrFiles.map((f) => f.filename));
     for (const file of foundFiles) {
       const { isTestModeResults, scannerIds, exportTimestamp, cvrCount, name } =

--- a/frontends/election-manager/src/components/import_cvrfiles_modal.tsx
+++ b/frontends/election-manager/src/components/import_cvrfiles_modal.tsx
@@ -33,6 +33,8 @@ import { TIME_FORMAT } from '../config/globals';
 import { useAddCastVoteRecordFileMutation } from '../hooks/use_add_cast_vote_record_file_mutation';
 import { useCvrFileModeQuery } from '../hooks/use_cvr_file_mode_query';
 import { AddCastVoteRecordFileResult } from '../lib/backends';
+import { useCvrFilesQuery } from '../hooks/use_cvr_files_query';
+import { CastVoteRecordFiles } from '../utils/cast_vote_record_files';
 
 const { UsbDriveStatus } = usbstick;
 
@@ -73,14 +75,10 @@ function throwBadStatus(s: never): never {
 }
 
 export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
-  const {
-    usbDriveStatus,
-    castVoteRecordFiles,
-    electionDefinition,
-    auth,
-    logger,
-  } = useContext(AppContext);
+  const { usbDriveStatus, electionDefinition, auth, logger } =
+    useContext(AppContext);
   const addCastVoteRecordFileMutation = useAddCastVoteRecordFileMutation();
+  const cvrFiles = useCvrFilesQuery().data || [];
   const fileMode = useCvrFileModeQuery().data;
 
   assert(electionDefinition);
@@ -189,9 +187,8 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
         (f) => f.type === 1 && f.name.endsWith('.jsonl')
       );
       assert(electionDefinition !== undefined);
-      const parsedFileInformation = castVoteRecordFiles
-        .parseAllFromFileSystemEntries(newFoundFiles)
-        .sort(
+      const parsedFileInformation =
+        CastVoteRecordFiles.parseAllFromFileSystemEntries(newFoundFiles).sort(
           (a, b) => b.exportTimestamp.getTime() - a.exportTimestamp.getTime()
         );
       setFoundFiles(parsedFileInformation);
@@ -351,15 +348,11 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
     // Parse the file options on the USB drive and build table rows for each valid file.
     const fileTableRows: JSX.Element[] = [];
     let numberOfNewFiles = 0;
+    const importedFileNames = new Set(cvrFiles.map((f) => f.filename));
     for (const file of foundFiles) {
-      const {
-        isTestModeResults,
-        scannerIds,
-        exportTimestamp,
-        cvrCount,
-        name,
-        fileImported,
-      } = file;
+      const { isTestModeResults, scannerIds, exportTimestamp, cvrCount, name } =
+        file;
+      const fileImported = importedFileNames.has(name);
       const inProperFileMode =
         !fileModeLocked ||
         (isTestModeResults && fileMode === Admin.CvrFileMode.Test) ||

--- a/frontends/election-manager/src/components/import_cvrfiles_modal.tsx
+++ b/frontends/election-manager/src/components/import_cvrfiles_modal.tsx
@@ -289,7 +289,7 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
   }
 
   if (
-    cvrFilesQuery.isFetching ||
+    cvrFilesQuery.isLoading ||
     currentState.state === 'loading' ||
     usbDriveStatus === usbstick.UsbDriveStatus.ejecting ||
     usbDriveStatus === usbstick.UsbDriveStatus.present

--- a/frontends/election-manager/src/config/types.ts
+++ b/frontends/election-manager/src/config/types.ts
@@ -140,7 +140,6 @@ export interface CastVoteRecordFilePreprocessedData {
   readonly scannerIds: readonly string[];
   readonly exportTimestamp: Date;
   readonly isTestModeResults: boolean;
-  readonly fileImported: boolean;
 }
 
 export type VoteCounts = Dictionary<Dictionary<number>>;

--- a/frontends/election-manager/src/contexts/app_context.ts
+++ b/frontends/election-manager/src/contexts/app_context.ts
@@ -23,11 +23,9 @@ import {
   ConverterClientType,
   ResetElection,
 } from '../config/types';
-import { CastVoteRecordFiles } from '../utils/cast_vote_record_files';
 import { getEmptyExportableTallies } from '../utils/exportable_tallies';
 
 export interface AppContextInterface {
-  castVoteRecordFiles: CastVoteRecordFiles;
   electionDefinition?: ElectionDefinition;
   configuredAt?: Iso8601Timestamp;
   converter?: ConverterClientType;
@@ -57,7 +55,6 @@ export interface AppContextInterface {
 
 /* eslint-disable @typescript-eslint/require-await */
 const appContext: AppContextInterface = {
-  castVoteRecordFiles: CastVoteRecordFiles.empty,
   electionDefinition: undefined,
   configuredAt: undefined,
   isOfficialResults: false,

--- a/frontends/election-manager/src/hooks/use_add_cast_vote_record_file_mutation.ts
+++ b/frontends/election-manager/src/hooks/use_add_cast_vote_record_file_mutation.ts
@@ -9,7 +9,6 @@ import { AddCastVoteRecordFileResult } from '../lib/backends';
 import { getCvrsQueryKey } from './use_cvrs_query';
 import { getCvrFilesQueryKey } from './use_cvr_files_query';
 import { getCvrFileModeQueryKey } from './use_cvr_file_mode_query';
-import { cvrsStorageKey } from './use_election_manager_store';
 
 /**
  * The result of calling {@link useAddCastVoteRecordFileMutation}.
@@ -33,7 +32,6 @@ export function useAddCastVoteRecordFileMutation(): UseAddCastVoteRecordFileMuta
       await backend.addCastVoteRecordFile(newCastVoteRecordFile),
     {
       onSuccess() {
-        void queryClient.invalidateQueries([cvrsStorageKey]);
         void queryClient.invalidateQueries(getCvrFilesQueryKey());
         void queryClient.invalidateQueries(getCvrsQueryKey());
         void queryClient.invalidateQueries(getCvrFileModeQueryKey());

--- a/frontends/election-manager/src/hooks/use_clear_cast_vote_record_files_mutation.ts
+++ b/frontends/election-manager/src/hooks/use_clear_cast_vote_record_files_mutation.ts
@@ -6,7 +6,6 @@ import {
 import { useContext } from 'react';
 import { ServicesContext } from '../contexts/services_context';
 import { getCurrentElectionMetadataResultsQueryKey } from './use_current_election_metadata';
-import { cvrsStorageKey } from './use_election_manager_store';
 import { getWriteInsQueryKey } from './use_write_ins_query';
 import { getWriteInAdjudicationTableQueryKey } from './use_write_in_adjudication_table_query';
 import { getCvrFileModeQueryKey } from './use_cvr_file_mode_query';
@@ -38,7 +37,6 @@ export function useClearCastVoteRecordFilesMutation(): UseClearCastVoteRecordFil
     },
     {
       onSuccess() {
-        void queryClient.invalidateQueries([cvrsStorageKey]);
         void queryClient.invalidateQueries(getWriteInImageQueryKey());
         void queryClient.invalidateQueries(getWriteInsQueryKey());
         void queryClient.invalidateQueries(getWriteInSummaryQueryKey());

--- a/frontends/election-manager/src/hooks/use_cvrs_query.ts
+++ b/frontends/election-manager/src/hooks/use_cvrs_query.ts
@@ -17,7 +17,5 @@ export function getCvrsQueryKey(): QueryKey {
  */
 export function useCvrsQuery(): UseQueryResult<CastVoteRecord[]> {
   const { backend } = useContext(ServicesContext);
-  return useQuery(getCvrsQueryKey(), () => backend.getCvrs(), {
-    staleTime: Infinity,
-  });
+  return useQuery(getCvrsQueryKey(), () => backend.getCvrs());
 }

--- a/frontends/election-manager/src/hooks/use_election_manager_store.ts
+++ b/frontends/election-manager/src/hooks/use_election_manager_store.ts
@@ -13,7 +13,6 @@ import {
 import { assert, typedAs } from '@votingworks/utils';
 import { useCallback, useContext, useMemo, useRef } from 'react';
 import { ServicesContext } from '../contexts/services_context';
-import { CastVoteRecordFiles } from '../utils/cast_vote_record_files';
 import { getCurrentElectionMetadataResultsQueryKey } from './use_current_election_metadata';
 import { getCvrsQueryKey } from './use_cvrs_query';
 import { getCvrFilesQueryKey } from './use_cvr_files_query';
@@ -29,11 +28,6 @@ export interface ElectionManagerStore {
    * The currently configured election definition.
    */
   readonly electionDefinition?: ElectionDefinition;
-
-  /**
-   * The current set of loaded cast vote record files.
-   */
-  readonly castVoteRecordFiles: CastVoteRecordFiles;
 
   /**
    * Tallies from external sources, e.g. SEMS or manually entered tallies.
@@ -78,7 +72,6 @@ export interface ElectionManagerStore {
   setCurrentUserRole(newCurrentUserRole: LoggingUserRole): void;
 }
 
-export const cvrsStorageKey = 'cvrFiles';
 export const configuredAtStorageKey = 'configuredAt';
 export const externalVoteTalliesFileStorageKey = 'externalVoteTallies';
 
@@ -89,16 +82,6 @@ export function useElectionManagerStore(): ElectionManagerStore {
   const { backend, logger } = useContext(ServicesContext);
   const queryClient = useQueryClient();
   const currentUserRoleRef = useRef<LoggingUserRole>('unknown');
-
-  const getCastVoteRecordFilesQuery = useQuery<CastVoteRecordFiles>(
-    [cvrsStorageKey],
-    async () => {
-      return (
-        (await backend.loadCastVoteRecordFiles()) ?? CastVoteRecordFiles.empty
-      );
-    }
-  );
-  const castVoteRecordFiles = getCastVoteRecordFilesQuery.data;
 
   const getExternalElectionTalliesQuery = useQuery<FullElectionExternalTallies>(
     [externalVoteTalliesFileStorageKey],
@@ -117,7 +100,6 @@ export function useElectionManagerStore(): ElectionManagerStore {
         disposition: LogDispositionStandardTypes.Success,
       }
     );
-    await queryClient.invalidateQueries([cvrsStorageKey]);
     await queryClient.invalidateQueries([externalVoteTalliesFileStorageKey]);
     await queryClient.invalidateQueries(getPrintedBallotsQueryKey());
     await queryClient.invalidateQueries(getWriteInImageQueryKey());
@@ -220,7 +202,6 @@ export function useElectionManagerStore(): ElectionManagerStore {
   return useMemo(
     () =>
       typedAs<ElectionManagerStore>({
-        castVoteRecordFiles: castVoteRecordFiles ?? CastVoteRecordFiles.empty,
         fullElectionExternalTallies: fullElectionExternalTallies ?? new Map(),
 
         clearFullElectionExternalTallies,
@@ -231,7 +212,6 @@ export function useElectionManagerStore(): ElectionManagerStore {
         removeFullElectionExternalTally,
       }),
     [
-      castVoteRecordFiles,
       clearFullElectionExternalTallies,
       configure,
       fullElectionExternalTallies,

--- a/frontends/election-manager/src/hooks/use_election_manager_store.ts
+++ b/frontends/election-manager/src/hooks/use_election_manager_store.ts
@@ -109,7 +109,12 @@ export function useElectionManagerStore(): ElectionManagerStore {
     await queryClient.invalidateQueries(
       getCurrentElectionMetadataResultsQueryKey()
     );
-    await queryClient.invalidateQueries(getCvrFilesQueryKey());
+    await queryClient.invalidateQueries(getCvrFilesQueryKey(), {
+      // TODO(kofi): This is a pattern we're potentially adopting across the
+      // repo and will be make sweeping updates for soon. This specific case is
+      // needed to enable a test to pass after a recent change.
+      refetchType: 'all',
+    });
     await queryClient.invalidateQueries(getCvrsQueryKey());
     await queryClient.invalidateQueries(getCvrFileModeQueryKey());
   }, [backend, logger, queryClient]);

--- a/frontends/election-manager/src/index.tsx
+++ b/frontends/election-manager/src/index.tsx
@@ -20,6 +20,9 @@ const queryClient = new QueryClient({
     mutations: { networkMode: 'always' },
     queries: {
       networkMode: 'always',
+
+      // Avoid re-fetching data unnecessarily on page navigation and rely on
+      // explicit cache invalidation calls when we mutate data:
       staleTime: Infinity,
     },
   },

--- a/frontends/election-manager/src/index.tsx
+++ b/frontends/election-manager/src/index.tsx
@@ -18,7 +18,10 @@ import { ServicesContext } from './contexts/services_context';
 const queryClient = new QueryClient({
   defaultOptions: {
     mutations: { networkMode: 'always' },
-    queries: { networkMode: 'always' },
+    queries: {
+      networkMode: 'always',
+      staleTime: Infinity,
+    },
   },
 });
 const storage = window.kiosk

--- a/frontends/election-manager/src/lib/backends/admin_backend.test.ts
+++ b/frontends/election-manager/src/lib/backends/admin_backend.test.ts
@@ -278,8 +278,6 @@ test('addCastVoteRecordFile happy path', async () => {
     }
   );
 
-  await expect(backend.loadCastVoteRecordFiles()).resolves.toBeUndefined();
-
   await expect(
     backend.addCastVoteRecordFile(
       new File([partial1CvrFile.asBuffer()], 'cvrs.jsonl', {
@@ -296,10 +294,6 @@ test('addCastVoteRecordFile happy path', async () => {
     scannerIds: ['scanner-4', 'scanner-6'],
     wasExistingFile: false,
   });
-
-  const cvrFilesFromStorage = await backend.loadCastVoteRecordFiles();
-  expect(cvrFilesFromStorage).not.toBeUndefined();
-  expect(cvrFilesFromStorage?.fileList.length).toBeGreaterThan(0);
 });
 
 test('addCastVoteRecordFile prioritizes export timestamp in filename', async () => {
@@ -362,10 +356,6 @@ test('addCastVoteRecordFile prioritizes export timestamp in filename', async () 
     scannerIds: ['scanner-4', 'scanner-6'],
     wasExistingFile: false,
   });
-
-  const cvrFilesFromStorage = await backend.loadCastVoteRecordFiles();
-  expect(cvrFilesFromStorage).not.toBeUndefined();
-  expect(cvrFilesFromStorage?.fileList.length).toBeGreaterThan(0);
 });
 
 test('addCastVoteRecordFile analyze only', async () => {
@@ -393,8 +383,6 @@ test('addCastVoteRecordFile analyze only', async () => {
     apiResponse
   );
 
-  await expect(backend.loadCastVoteRecordFiles()).resolves.toBeUndefined();
-
   await expect(
     backend.addCastVoteRecordFile(
       new File([partial1CvrFile.asBuffer()], 'cvrs.jsonl'),
@@ -410,8 +398,6 @@ test('addCastVoteRecordFile analyze only', async () => {
     scannerIds: ['scanner-2', 'scanner-3'],
     wasExistingFile: false,
   });
-
-  await expect(backend.loadCastVoteRecordFiles()).resolves.toBeUndefined();
 });
 
 test('addCastVoteRecordFile handles api errors', async () => {

--- a/frontends/election-manager/src/lib/backends/memory_backend.ts
+++ b/frontends/election-manager/src/lib/backends/memory_backend.ts
@@ -158,10 +158,6 @@ export class ElectionManagerStoreMemoryBackend
     return Promise.resolve([...this.castVoteRecordFiles.castVoteRecords]);
   }
 
-  loadCastVoteRecordFiles(): Promise<CastVoteRecordFiles | undefined> {
-    return Promise.resolve(this.castVoteRecordFiles);
-  }
-
   getWriteInsFromCastVoteRecords(
     castVoteRecordFile: CastVoteRecordFile
   ): Admin.WriteInRecord[] {

--- a/frontends/election-manager/src/lib/backends/types.ts
+++ b/frontends/election-manager/src/lib/backends/types.ts
@@ -9,7 +9,6 @@ import {
   FullElectionExternalTally,
   Id,
 } from '@votingworks/types';
-import { CastVoteRecordFiles } from '../../utils/cast_vote_record_files';
 
 export interface AddCastVoteRecordFileResult {
   readonly wasExistingFile: boolean;
@@ -49,11 +48,6 @@ export interface ElectionManagerStoreBackend {
    * Returns all CVRs for the current election.
    */
   getCvrs(): Promise<CastVoteRecord[]>;
-
-  /**
-   * Loads the existing cast vote record files.
-   */
-  loadCastVoteRecordFiles(): Promise<CastVoteRecordFiles | undefined>;
 
   /**
    * Adds a new cast vote record file.

--- a/frontends/election-manager/src/screens/reports_screen.tsx
+++ b/frontends/election-manager/src/screens/reports_screen.tsx
@@ -31,12 +31,12 @@ import { getTallyConverterClient } from '../lib/converters';
 import { SaveResultsButton } from '../components/save_results_button';
 import { usePrintedBallotsQuery } from '../hooks/use_printed_ballots_query';
 import { useCvrFileModeQuery } from '../hooks/use_cvr_file_mode_query';
+import { useCvrFilesQuery } from '../hooks/use_cvr_files_query';
 
 export function ReportsScreen(): JSX.Element {
   const makeCancelable = useCancelablePromise();
 
   const {
-    castVoteRecordFiles,
     electionDefinition,
     converter,
     isOfficialResults,
@@ -48,6 +48,8 @@ export function ReportsScreen(): JSX.Element {
     logger,
     auth,
   } = useContext(AppContext);
+  const cvrFilesQuery = useCvrFilesQuery();
+  const cvrFiles = cvrFilesQuery.data || [];
   const printedBallotsQuery = usePrintedBallotsQuery({
     ballotMode: Admin.BallotMode.Official,
   });
@@ -193,7 +195,7 @@ export function ReportsScreen(): JSX.Element {
             <LinkButton primary to={routerPaths.tallyFullReport}>
               {statusPrefix} Full Election Tally Report
             </LinkButton>{' '}
-            {castVoteRecordFiles.wereAdded && (
+            {cvrFiles.length > 0 && (
               <React.Fragment>
                 {converterName !== '' && (
                   <React.Fragment>

--- a/frontends/election-manager/src/screens/reports_screen.tsx
+++ b/frontends/election-manager/src/screens/reports_screen.tsx
@@ -185,7 +185,7 @@ export function ReportsScreen(): JSX.Element {
   );
 
   const canSaveResults =
-    !cvrFilesQuery.isFetching &&
+    !cvrFilesQuery.isLoading &&
     !!cvrFilesQuery.data &&
     cvrFilesQuery.data.length > 0;
 

--- a/frontends/election-manager/src/screens/reports_screen.tsx
+++ b/frontends/election-manager/src/screens/reports_screen.tsx
@@ -186,7 +186,7 @@ export function ReportsScreen(): JSX.Element {
 
   const canSaveResults =
     !cvrFilesQuery.isLoading &&
-    !!cvrFilesQuery.data &&
+    !cvrFilesQuery.isError &&
     cvrFilesQuery.data.length > 0;
 
   return (

--- a/frontends/election-manager/src/screens/reports_screen.tsx
+++ b/frontends/election-manager/src/screens/reports_screen.tsx
@@ -49,7 +49,6 @@ export function ReportsScreen(): JSX.Element {
     auth,
   } = useContext(AppContext);
   const cvrFilesQuery = useCvrFilesQuery();
-  const cvrFiles = cvrFilesQuery.data || [];
   const printedBallotsQuery = usePrintedBallotsQuery({
     ballotMode: Admin.BallotMode.Official,
   });
@@ -185,6 +184,11 @@ export function ReportsScreen(): JSX.Element {
     </p>
   );
 
+  const canSaveResults =
+    !cvrFilesQuery.isFetching &&
+    !!cvrFilesQuery.data &&
+    cvrFilesQuery.data.length > 0;
+
   return (
     <React.Fragment>
       <NavigationScreen>
@@ -195,7 +199,7 @@ export function ReportsScreen(): JSX.Element {
             <LinkButton primary to={routerPaths.tallyFullReport}>
               {statusPrefix} Full Election Tally Report
             </LinkButton>{' '}
-            {cvrFiles.length > 0 && (
+            {canSaveResults && (
               <React.Fragment>
                 {converterName !== '' && (
                   <React.Fragment>

--- a/frontends/election-manager/src/screens/tally_report_screen.tsx
+++ b/frontends/election-manager/src/screens/tally_report_screen.tsx
@@ -258,7 +258,7 @@ export function TallyReportScreen(): JSX.Element {
             <p>
               <Button
                 disabled={
-                  cvrFilesQuery.isFetching ||
+                  cvrFilesQuery.isLoading ||
                   !cvrFilesQuery.data ||
                   cvrFilesQuery.data.length === 0 ||
                   isOfficialResults

--- a/frontends/election-manager/src/screens/tally_report_screen.tsx
+++ b/frontends/election-manager/src/screens/tally_report_screen.tsx
@@ -39,6 +39,7 @@ import { useWriteInSummaryQuery } from '../hooks/use_write_in_summary_query';
 import { SaveFileToUsb, FileType } from '../components/save_file_to_usb';
 import { ElectionManagerTallyReport } from '../components/election_manager_tally_report';
 import { getScreenAdjudicatedWriteInCounts } from '../utils/write_ins';
+import { useCvrFilesQuery } from '../hooks/use_cvr_files_query';
 import { PrintButton } from '../components/print_button';
 
 export function TallyReportScreen(): JSX.Element {
@@ -52,7 +53,6 @@ export function TallyReportScreen(): JSX.Element {
     useParams<VotingMethodReportScreenProps>();
   const votingMethod = votingMethodFromProps as VotingMethod;
   const {
-    castVoteRecordFiles,
     electionDefinition,
     isOfficialResults,
     fullElectionTally,
@@ -68,6 +68,9 @@ export function TallyReportScreen(): JSX.Element {
   const writeInSummaryQuery = useWriteInSummaryQuery({ status: 'adjudicated' });
   const screenAdjudicatedOfficialCandidateWriteInCounts =
     getScreenAdjudicatedWriteInCounts(writeInSummaryQuery.data ?? [], true);
+
+  const cvrFilesQuery = useCvrFilesQuery();
+  const cvrFiles = cvrFilesQuery.data || [];
 
   const location = useLocation();
 
@@ -255,7 +258,7 @@ export function TallyReportScreen(): JSX.Element {
           {location.pathname === routerPaths.tallyFullReport && (
             <p>
               <Button
-                disabled={!castVoteRecordFiles.wereAdded || isOfficialResults}
+                disabled={cvrFiles.length === 0 || isOfficialResults}
                 onPress={openMarkOfficialModal}
               >
                 Mark Tally Results as Official

--- a/frontends/election-manager/src/screens/tally_report_screen.tsx
+++ b/frontends/election-manager/src/screens/tally_report_screen.tsx
@@ -70,7 +70,6 @@ export function TallyReportScreen(): JSX.Element {
     getScreenAdjudicatedWriteInCounts(writeInSummaryQuery.data ?? [], true);
 
   const cvrFilesQuery = useCvrFilesQuery();
-  const cvrFiles = cvrFilesQuery.data || [];
 
   const location = useLocation();
 
@@ -258,7 +257,12 @@ export function TallyReportScreen(): JSX.Element {
           {location.pathname === routerPaths.tallyFullReport && (
             <p>
               <Button
-                disabled={cvrFiles.length === 0 || isOfficialResults}
+                disabled={
+                  cvrFilesQuery.isFetching ||
+                  !cvrFilesQuery.data ||
+                  cvrFilesQuery.data.length === 0 ||
+                  isOfficialResults
+                }
                 onPress={openMarkOfficialModal}
               >
                 Mark Tally Results as Official

--- a/frontends/election-manager/src/screens/tally_report_screen.tsx
+++ b/frontends/election-manager/src/screens/tally_report_screen.tsx
@@ -259,7 +259,7 @@ export function TallyReportScreen(): JSX.Element {
               <Button
                 disabled={
                   cvrFilesQuery.isLoading ||
-                  !cvrFilesQuery.data ||
+                  cvrFilesQuery.isError ||
                   cvrFilesQuery.data.length === 0 ||
                   isOfficialResults
                 }

--- a/frontends/election-manager/src/screens/tally_screen.tsx
+++ b/frontends/election-manager/src/screens/tally_screen.tsx
@@ -155,7 +155,7 @@ export function TallyScreen(): JSX.Element {
             </Button>{' '}
             <Button
               disabled={
-                cvrFilesQuery.isFetching ||
+                cvrFilesQuery.isLoading ||
                 castVoteRecordFileList.length === 0 ||
                 isOfficialResults
               }
@@ -184,7 +184,7 @@ export function TallyScreen(): JSX.Element {
                       Precinct
                     </TD>
                   </tr>
-                  {cvrFilesQuery.isFetching ? (
+                  {cvrFilesQuery.isLoading ? (
                     <tr>
                       <TD>
                         <Loading />

--- a/frontends/election-manager/src/screens/tally_screen.tsx
+++ b/frontends/election-manager/src/screens/tally_screen.tsx
@@ -65,7 +65,8 @@ export function TallyScreen(): JSX.Element {
   }
 
   const cvrFilesQuery = useCvrFilesQuery();
-  const castVoteRecordFileList = cvrFilesQuery.data ?? [];
+  const castVoteRecordFileList =
+    cvrFilesQuery.isLoading || cvrFilesQuery.isError ? [] : cvrFilesQuery.data;
   const hasAnyFiles =
     castVoteRecordFileList.length > 0 || fullElectionExternalTallies.size > 0;
   const hasExternalSemsFile = fullElectionExternalTallies.has(

--- a/frontends/election-manager/src/screens/tally_screen.tsx
+++ b/frontends/election-manager/src/screens/tally_screen.tsx
@@ -26,10 +26,11 @@ import { ConfirmRemovingFileModal } from '../components/confirm_removing_file_mo
 import { TIME_FORMAT } from '../config/globals';
 import { ImportExternalResultsModal } from '../components/import_external_results_modal';
 import { useCvrFileModeQuery } from '../hooks/use_cvr_file_mode_query';
+import { useCvrFilesQuery } from '../hooks/use_cvr_files_query';
+import { Loading } from '../components/loading';
 
 export function TallyScreen(): JSX.Element {
   const {
-    castVoteRecordFiles,
     electionDefinition,
     converter,
     isOfficialResults,
@@ -63,9 +64,10 @@ export function TallyScreen(): JSX.Element {
       .join(', ');
   }
 
-  const castVoteRecordFileList = castVoteRecordFiles.fileList;
+  const cvrFilesQuery = useCvrFilesQuery();
+  const castVoteRecordFileList = cvrFilesQuery.data ?? [];
   const hasAnyFiles =
-    castVoteRecordFiles.wereAdded || fullElectionExternalTallies.size > 0;
+    castVoteRecordFileList.length > 0 || fullElectionExternalTallies.size > 0;
   const hasExternalSemsFile = fullElectionExternalTallies.has(
     ExternalTallySourceType.SEMS
   );
@@ -152,7 +154,11 @@ export function TallyScreen(): JSX.Element {
               Load CVR Files
             </Button>{' '}
             <Button
-              disabled={!castVoteRecordFiles.wereAdded || isOfficialResults}
+              disabled={
+                cvrFilesQuery.isFetching ||
+                castVoteRecordFileList.length === 0 ||
+                isOfficialResults
+              }
               onPress={() =>
                 beginConfirmRemoveFiles(ResultsFileType.CastVoteRecord)
               }
@@ -178,26 +184,34 @@ export function TallyScreen(): JSX.Element {
                       Precinct
                     </TD>
                   </tr>
-                  {castVoteRecordFileList.map(
-                    ({
-                      name,
-                      exportTimestamp,
-                      importedCvrCount,
-                      scannerIds,
-                      precinctIds,
-                    }) => (
-                      <tr key={name}>
-                        <TD narrow nowrap>
-                          {moment(exportTimestamp).format(
-                            'MM/DD/YYYY hh:mm:ss A'
-                          )}
-                        </TD>
-                        <TD nowrap>{format.count(importedCvrCount)} </TD>
-                        <TD narrow nowrap>
-                          {scannerIds.join(', ')}
-                        </TD>
-                        <TD>{getPrecinctNames(precinctIds)}</TD>
-                      </tr>
+                  {cvrFilesQuery.isFetching ? (
+                    <tr>
+                      <TD>
+                        <Loading />
+                      </TD>
+                    </tr>
+                  ) : (
+                    castVoteRecordFileList.map(
+                      ({
+                        filename,
+                        exportTimestamp,
+                        numCvrsImported,
+                        scannerIds,
+                        precinctIds,
+                      }) => (
+                        <tr key={filename}>
+                          <TD narrow nowrap>
+                            {moment(exportTimestamp).format(
+                              'MM/DD/YYYY hh:mm:ss A'
+                            )}
+                          </TD>
+                          <TD nowrap>{format.count(numCvrsImported)} </TD>
+                          <TD narrow nowrap>
+                            {scannerIds.join(', ')}
+                          </TD>
+                          <TD>{getPrecinctNames(precinctIds)}</TD>
+                        </tr>
+                      )
                     )
                   )}
                   {externalTallyRows}
@@ -208,7 +222,7 @@ export function TallyScreen(): JSX.Element {
                     <TD as="th" narrow data-testid="total-cvr-count">
                       {format.count(
                         castVoteRecordFileList.reduce(
-                          (prev, curr) => prev + curr.importedCvrCount,
+                          (prev, curr) => prev + curr.numCvrsImported,
                           0
                         ) + externalFileBallotCount
                       )}

--- a/frontends/election-manager/src/screens/write_ins_screen.test.tsx
+++ b/frontends/election-manager/src/screens/write_ins_screen.test.tsx
@@ -20,7 +20,11 @@ afterEach(async () => {
 });
 
 test('No CVRs loaded', async () => {
-  renderInAppContext(<WriteInsScreen />, { electionDefinition });
+  const backend = new ElectionManagerStoreMemoryBackend({
+    electionDefinition,
+  });
+
+  renderInAppContext(<WriteInsScreen />, { backend, electionDefinition });
   await screen.findByText(
     'Load CVRs to begin transcribing and adjudicating write-in votes.'
   );

--- a/frontends/election-manager/src/screens/write_ins_screen.tsx
+++ b/frontends/election-manager/src/screens/write_ins_screen.tsx
@@ -19,6 +19,7 @@ import { useWriteInsQuery } from '../hooks/use_write_ins_query';
 import { useTranscribeWriteInMutation } from '../hooks/use_transcribe_write_in_mutation';
 import { useAdjudicateTranscriptionMutation } from '../hooks/use_adjudicate_transcription_mutation';
 import { useUpdateWriteInAdjudicationMutation } from '../hooks/use_update_write_in_adjudication_mutation';
+import { useCvrFilesQuery } from '../hooks/use_cvr_files_query';
 
 const ContentWrapper = styled.div`
   display: inline-block;
@@ -32,8 +33,7 @@ const ResultsFinalizedNotice = styled.p`
 `;
 
 export function WriteInsScreen(): JSX.Element {
-  const { castVoteRecordFiles, electionDefinition, isOfficialResults } =
-    useContext(AppContext);
+  const { electionDefinition, isOfficialResults } = useContext(AppContext);
   const [contestBeingTranscribed, setContestBeingTranscribed] =
     useState<CandidateContest>();
   const [contestBeingAdjudicated, setContestBeingAdjudicated] =
@@ -44,6 +44,7 @@ export function WriteInsScreen(): JSX.Element {
   const updateWriteInAdjudicationMutation =
     useUpdateWriteInAdjudicationMutation();
   const writeInsQuery = useWriteInsQuery();
+  const cvrFilesQuery = useCvrFilesQuery();
 
   // Get write-in counts grouped by contest
   const writeInCountsByContest = useMemo(() => {
@@ -137,7 +138,8 @@ export function WriteInsScreen(): JSX.Element {
       );
     }
 
-    if (!castVoteRecordFiles.wereAdded) {
+    const cvrFiles = cvrFilesQuery.data || [];
+    if (cvrFiles.length === 0) {
       return (
         <p>
           <em>

--- a/frontends/election-manager/src/screens/write_ins_screen.tsx
+++ b/frontends/election-manager/src/screens/write_ins_screen.tsx
@@ -138,7 +138,7 @@ export function WriteInsScreen(): JSX.Element {
       );
     }
 
-    if (cvrFilesQuery.data?.length === 0) {
+    if (cvrFilesQuery.isSuccess && cvrFilesQuery.data.length === 0) {
       return (
         <p>
           <em>

--- a/frontends/election-manager/src/screens/write_ins_screen.tsx
+++ b/frontends/election-manager/src/screens/write_ins_screen.tsx
@@ -138,8 +138,7 @@ export function WriteInsScreen(): JSX.Element {
       );
     }
 
-    const cvrFiles = cvrFilesQuery.data || [];
-    if (cvrFiles.length === 0) {
+    if (cvrFilesQuery.data?.length === 0) {
       return (
         <p>
           <em>

--- a/frontends/election-manager/src/utils/cast_vote_record_files.test.ts
+++ b/frontends/election-manager/src/utils/cast_vote_record_files.test.ts
@@ -188,7 +188,7 @@ test('can preprocess files to give information about expected duplicates', async
   const newFileName = `machine_abc__3_ballots__${moment(newFileDate).format(
     'YYYY-MM-DD_HH-mm-ss'
   )}`;
-  const parsedData = added.parseAllFromFileSystemEntries([
+  const parsedData = CastVoteRecordFiles.parseAllFromFileSystemEntries([
     {
       name: newFileName,
       path: 'this/is/a/path',
@@ -207,31 +207,6 @@ test('can preprocess files to give information about expected duplicates', async
       scannerIds: ['abc'],
       exportTimestamp: newFileDate,
       isTestModeResults: false,
-      fileImported: false,
-    },
-  ]);
-
-  // Can handle a previously loaded file properly
-  const parsedData2 = added.parseAllFromFileSystemEntries([
-    {
-      name: existingFileName,
-      path: 'this/is/a/path',
-      type: 1,
-      size: 0,
-      mtime: TEST_DATE,
-      atime: new Date(),
-      ctime: new Date(),
-    },
-  ]);
-  expect(parsedData2).toEqual<CastVoteRecordFilePreprocessedData[]>([
-    {
-      name: existingFileName,
-      path: 'this/is/a/path',
-      cvrCount: 1,
-      scannerIds: ['abc'],
-      exportTimestamp: TEST_DATE,
-      isTestModeResults: false,
-      fileImported: true,
     },
   ]);
 });
@@ -263,7 +238,7 @@ test('parseAllFromFileSystemEntries handles empty files', async () => {
   expect(added.lastError).toBeUndefined();
 
   expect(
-    added.parseAllFromFileSystemEntries([
+    CastVoteRecordFiles.parseAllFromFileSystemEntries([
       {
         name: existingFileName,
         path: 'this/is/a/path',
@@ -282,7 +257,6 @@ test('parseAllFromFileSystemEntries handles empty files', async () => {
       scannerIds: ['abc'],
       exportTimestamp: TEST_DATE,
       isTestModeResults: false,
-      fileImported: true,
     },
   ]);
 });

--- a/frontends/election-manager/src/utils/cast_vote_record_files.ts
+++ b/frontends/election-manager/src/utils/cast_vote_record_files.ts
@@ -185,19 +185,20 @@ export class CastVoteRecordFiles {
   /**
    * Parses the filenames for the given CVR {@link files} for information about
    * the CVRs they contain.
+   *
+   * TODO: After a few rounds of refactoring, this is now mostly just a proxy to
+   * {@link parseCvrFileInfoFromFilename} - should consolidate at some point.
    */
-  parseAllFromFileSystemEntries(
+  static parseAllFromFileSystemEntries(
     files: KioskBrowser.FileSystemEntry[]
   ): CastVoteRecordFilePreprocessedData[] {
     const results: CastVoteRecordFilePreprocessedData[] = [];
     for (const file of files) {
       try {
-        const fileImported = [...this.files].some((f) => f.name === file.name);
         const parsedFileInfo = parseCvrFileInfoFromFilename(file.name);
         if (parsedFileInfo) {
           results.push({
             exportTimestamp: parsedFileInfo.timestamp,
-            fileImported,
             cvrCount: parsedFileInfo.numberOfBallots,
             isTestModeResults: parsedFileInfo.isTestModeResults,
             name: file.name,

--- a/frontends/election-manager/test/render_in_app_context.tsx
+++ b/frontends/election-manager/test/render_in_app_context.tsx
@@ -32,7 +32,6 @@ import {
   MachineConfig,
   ResetElection,
 } from '../src/config/types';
-import { CastVoteRecordFiles } from '../src/utils/cast_vote_record_files';
 import { ServicesContext } from '../src/contexts/services_context';
 import {
   ElectionManagerStoreBackend,
@@ -45,7 +44,6 @@ export const eitherNeitherElectionDefinition =
 interface RenderInAppContextParams {
   route?: string;
   history?: MemoryHistory;
-  castVoteRecordFiles?: CastVoteRecordFiles;
   electionDefinition?: ElectionDefinition | 'NONE';
   configuredAt?: Iso8601Timestamp;
   isOfficialResults?: boolean;
@@ -102,7 +100,6 @@ export function renderInAppContext(
   {
     route = '/',
     history = createMemoryHistory({ initialEntries: [route] }),
-    castVoteRecordFiles = CastVoteRecordFiles.empty,
     electionDefinition = eitherNeitherElectionDefinition,
     configuredAt = new Date().toISOString(),
     isOfficialResults = false,
@@ -135,7 +132,6 @@ export function renderInAppContext(
   return renderRootElement(
     <AppContext.Provider
       value={{
-        castVoteRecordFiles,
         electionDefinition:
           electionDefinition === 'NONE' ? undefined : electionDefinition,
         configuredAt,


### PR DESCRIPTION
## Overview
Closes https://github.com/votingworks/vxsuite/issues/2716:

- Replacing all references to CVR data in client-side local storage with queries for server-side data.
- Removing all logic around writing to and reading CVR data from local storage.
- Leaving the `CastVoteRecords` class mostly intact, since it's used with our `memory_backend` test utility.

## Demo Video or Screenshot
https://user-images.githubusercontent.com/264902/204634905-846ff00f-13c9-4243-9e34-934cade05b7b.mov

## Testing Plan 
- Updated existing tests to account for the changes
- Manual functional verification, clicking through the various user flows that read/write CVR data and also checking for console errors/warnings:
  - Tally screen + import/delete modals
  - Write-ins screen
  - Reports screen and tally report

## Checklist
- [n/a] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [n/a] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [n/a] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
