### PR TITLE
Add support for `customctl`

### DIFF
--- a/apps/vx-scan/backend/src/env.d.ts
+++ b/apps/vx-scan/backend/src/env.d.ts
@@ -3,6 +3,7 @@ declare namespace NodeJS {
     readonly CI?: string;
     readonly MOCK_SCANNER_HTTP?: string;
     readonly NODE_ENV: 'development' | 'production' | 'test';
+    readonly PLUSTEKCTL_PATH?: string;
     readonly PORT?: string;
     readonly SCAN_ALWAYS_HOLD_ON_REJECT?: string;
     readonly SCAN_ALLOWED_EXPORT_PATTERNS?: string;

--- a/apps/vx-scan/backend/src/globals.ts
+++ b/apps/vx-scan/backend/src/globals.ts
@@ -51,3 +51,8 @@ export const SCAN_WORKSPACE =
  */
 export const SCAN_ALLOWED_EXPORT_PATTERNS =
   process.env.SCAN_ALLOWED_EXPORT_PATTERNS?.split(',') ?? ['/media/**/*'];
+
+/**
+ * Path to the `plustekctl` binary.
+ */
+export const { PLUSTEKCTL_PATH } = process.env;

--- a/apps/vx-scan/backend/src/interpreter.ts
+++ b/apps/vx-scan/backend/src/interpreter.ts
@@ -13,7 +13,7 @@ import {
   Interpreter as HmpbInterpreter,
   metadataFromBytes,
 } from '@votingworks/ballot-interpreter-vx';
-import { imageDebugger } from '@votingworks/image-utils';
+import { imageDebugger, loadImageData } from '@votingworks/image-utils';
 import {
   AdjudicationReason,
   AdjudicationReasonInfo,
@@ -37,7 +37,6 @@ import { Buffer } from 'buffer';
 import { ImageData } from 'canvas';
 import makeDebug from 'debug';
 import { BallotPageQrcode } from './types';
-import { loadImageData } from './util/images';
 import { optionMarkStatus } from './util/option_mark_status';
 import { time } from './util/perf';
 import * as qrcodeWorker from './workers/qrcode';

--- a/apps/vx-scan/backend/src/precinct_scanner_state_machine.ts
+++ b/apps/vx-scan/backend/src/precinct_scanner_state_machine.ts
@@ -27,6 +27,7 @@ import { Scan } from '@votingworks/api';
 import makeDebug from 'debug';
 import { waitFor } from 'xstate/lib/waitFor';
 import { LogEventId, Logger, LogLine } from '@votingworks/logging';
+import { PLUSTEKCTL_PATH } from './globals';
 import {
   SheetInterpretation,
   PrecinctScannerInterpreter,
@@ -103,10 +104,13 @@ function connectToPlustek(
 ) {
   return async (): Promise<ScannerClient> => {
     debug('Connecting to plustek');
-    const plustekClient = await createPlustekClient({
-      ...DEFAULT_CONFIG,
-      savepath: scannedImagesPath,
-    });
+    const plustekClient = await createPlustekClient(
+      {
+        ...DEFAULT_CONFIG,
+        savepath: scannedImagesPath,
+      },
+      { plustekctlPath: PLUSTEKCTL_PATH }
+    );
     debug('Plustek client connected: %s', plustekClient.isOk());
     return plustekClient.unsafeUnwrap();
   };

--- a/apps/vx-scan/backend/src/util/images.ts
+++ b/apps/vx-scan/backend/src/util/images.ts
@@ -1,14 +1,6 @@
-import { safeParseInt } from '@votingworks/types';
-import { assert } from '@votingworks/utils';
-import { Buffer } from 'buffer';
-import { createCanvas, createImageData, ImageData, loadImage } from 'canvas';
-import { createWriteStream, promises as fs } from 'fs';
-import { parse } from 'path';
+import { createCanvas, createImageData, ImageData } from 'canvas';
+import { createWriteStream } from 'fs';
 import { pipeline } from 'stream/promises';
-
-const GRAY_CHANNEL_COUNT = 1;
-const RGB_CHANNEL_COUNT = 3;
-const RGBA_CHANNEL_COUNT = 4;
 
 /**
  * Ensures that `imageData` is acceptable to `canvas`.
@@ -18,91 +10,6 @@ export function ensureImageData(imageData: globalThis.ImageData): ImageData {
     return imageData;
   }
   return createImageData(imageData.data, imageData.width, imageData.height);
-}
-
-/**
- * Loads a RAW image from a file.
- */
-async function loadRawImage(
-  path: string,
-  width: number,
-  height: number,
-  channelCount: number
-): Promise<ImageData> {
-  assert(
-    channelCount === GRAY_CHANNEL_COUNT ||
-      channelCount === RGB_CHANNEL_COUNT ||
-      channelCount === RGBA_CHANNEL_COUNT
-  );
-
-  const imageData = createImageData(width, height);
-  const buffer = await fs.readFile(path);
-
-  for (
-    let srcOffset = 0, dstOffset = 0;
-    srcOffset < buffer.length;
-    srcOffset += channelCount, dstOffset += RGBA_CHANNEL_COUNT
-  ) {
-    imageData.data[dstOffset] = buffer[srcOffset];
-    imageData.data[dstOffset + 1] =
-      buffer[channelCount > GRAY_CHANNEL_COUNT ? srcOffset + 1 : srcOffset];
-    imageData.data[dstOffset + 2] =
-      buffer[channelCount > GRAY_CHANNEL_COUNT ? srcOffset + 2 : srcOffset];
-    imageData.data[dstOffset + 3] =
-      buffer[channelCount > RGB_CHANNEL_COUNT ? srcOffset + 3 : srcOffset];
-  }
-
-  return imageData;
-}
-
-/**
- * Loads a RAW image from a file. The file name must be in the format
- * `{label}-{width}x{height}-{bitsPerPixel}bpp.raw`. For example:
- * `ballot-1700x2200-24bpp.raw` or `scan-1700x2200-8bpp.raw`.
- */
-async function loadRawImageWithMetadataInFileName(
-  path: string
-): Promise<ImageData> {
-  const parts = parse(path);
-  const match = parts.name.match(/(\d+)x(\d+)-(\d)bpp/);
-  if (!match) {
-    throw new Error(`Invalid raw image filename: ${parts.name}`);
-  }
-  const [, widthResult, heightResult, bitsPerPixelResult] = match.map((n) =>
-    safeParseInt(n, { min: 1 })
-  );
-  if (
-    widthResult.isErr() ||
-    heightResult.isErr() ||
-    bitsPerPixelResult.isErr()
-  ) {
-    throw new Error(`Invalid raw image filename: ${parts.name}`);
-  }
-
-  const width = widthResult.ok();
-  const height = heightResult.ok();
-  const bitsPerPixel = bitsPerPixelResult.ok();
-  const srcBytesPerPixel = Math.round(bitsPerPixel / 8);
-  return await loadRawImage(path, width, height, srcBytesPerPixel);
-}
-
-export async function loadImageData(path: string): Promise<ImageData>;
-export async function loadImageData(data: Buffer): Promise<ImageData>;
-export async function loadImageData(
-  pathOrData: string | Buffer
-): Promise<ImageData> {
-  if (typeof pathOrData === 'string') {
-    const parts = parse(pathOrData);
-    if (parts.ext === '.raw') {
-      return loadRawImageWithMetadataInFileName(pathOrData);
-    }
-  }
-
-  const img = await loadImage(pathOrData);
-  const canvas = createCanvas(img.width, img.height);
-  const context = canvas.getContext('2d');
-  context.drawImage(img, 0, 0);
-  return context.getImageData(0, 0, img.width, img.height);
 }
 
 export async function writeImageData(

--- a/apps/vx-scan/backend/src/workers/qrcode.ts
+++ b/apps/vx-scan/backend/src/workers/qrcode.ts
@@ -5,8 +5,8 @@ import {
   detectQrCode,
   getQrCodeSearchAreas,
 } from '@votingworks/ballot-interpreter-vx';
+import { loadImageData } from '@votingworks/image-utils';
 import { BallotPageQrcode } from '../types';
-import { loadImageData } from '../util/images';
 import { Stats, stats } from '../util/luminosity';
 import { normalizeSheetMetadata } from '../util/metadata';
 

--- a/libs/image-utils/src/image_data.ts
+++ b/libs/image-utils/src/image_data.ts
@@ -8,8 +8,7 @@ import {
   ImageData,
   loadImage as canvasLoadImage,
 } from 'canvas';
-import * as fs from 'fs/promises';
-import { createWriteStream } from 'fs';
+import { createWriteStream, promises as fs } from 'fs';
 import { extname, parse } from 'path';
 import { assertInteger } from './numeric';
 import { int, usize } from './types';

--- a/libs/plustek-sdk/src/scanner.ts
+++ b/libs/plustek-sdk/src/scanner.ts
@@ -32,11 +32,13 @@ export class ClientDisconnectedError extends ClientError {}
 export class InvalidClientResponseError extends ClientError {}
 
 /**
- * A collection of callbacks that will be called by {@link ScannerClient} at
- * various points in its lifecycle. This is similar to using an
- * {@link EventEmitter}, but more type-safe and intentionally less flexible.
+ * Options for creating a scanner client, especially callbacks that will be
+ * called by {@link ScannerClient} at various points in its lifecycle. This is
+ * similar to using an {@link EventEmitter}, but more type-safe and
+ * intentionally less flexible.
  */
-export interface ScannerClientCallbacks {
+export interface ScannerClientOptions {
+  plustekctlPath?: string;
   onConfigResolved?(config: Config): void;
   onError?(error: Error): void;
   onConnecting?(): void;
@@ -163,13 +165,14 @@ export async function createClient(
   config = DEFAULT_CONFIG,
   /* istanbul ignore next */
   {
+    plustekctlPath = 'plustekctl',
     onConfigResolved = noop,
     onConnecting = noop,
     onConnected = noop,
     onDisconnected = noop,
     onError = noop,
     onWaitingForHandshake = noop,
-  }: ScannerClientCallbacks = {}
+  }: ScannerClientOptions = {}
 ): Promise<Result<ScannerClient, Error>> {
   const resolvedConfig: Config = {
     ...config,
@@ -181,7 +184,6 @@ export async function createClient(
     JSON.stringify(resolvedConfig, undefined, 2)
   );
   const args = ['--config', configFilePath, '--delimiter', CLI_DELIMITER];
-  const plustekctlPath = 'plustekctl';
   debug('spawning: %s %o', plustekctlPath, args);
   const plustekctl = spawn(plustekctlPath, args, { stdio: 'pipe' });
   const clientDebug = makeDebug(

--- a/libs/types/src/result.test.ts
+++ b/libs/types/src/result.test.ts
@@ -30,6 +30,16 @@ test('ok unsafeUnwrapErr', () => {
   expect(() => ok('value').unsafeUnwrapErr()).toThrowError();
 });
 
+test('ok unsafeExpect', () => {
+  expect(ok(0).unsafeExpect('a value')).toBe(0);
+});
+
+test('ok unsafeExpectErr', () => {
+  expect(() => ok('value').unsafeExpectErr('an error')).toThrowError(
+    'an error'
+  );
+});
+
 test('ok is Result', () => {
   expect(isResult(ok())).toBe(true);
 });
@@ -69,6 +79,16 @@ test('err unsafeUnwrap', () => {
 
 test('err unsafeUnwrapErr', () => {
   expect(err('error').unsafeUnwrapErr()).toBe('error');
+});
+
+test('err unsafeExpect', () => {
+  expect(() => err('error').unsafeExpect('an error!')).toThrowError(
+    'an error!'
+  );
+});
+
+test('err unsafeExpectErr', () => {
+  expect(err('error').unsafeExpectErr('what?')).toBe('error');
 });
 
 test('err is Result', () => {

--- a/libs/types/src/result.ts
+++ b/libs/types/src/result.ts
@@ -50,6 +50,21 @@ class Ok<T> {
   }
 
   /**
+   * Returns the contained value.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  unsafeExpect(message: string): T {
+    return this.value;
+  }
+
+  /**
+   * Throws the given error message.
+   */
+  unsafeExpectErr(message: string): never {
+    throw new Error(message);
+  }
+
+  /**
    * Provides a custom inspect function for `Ok` values so that `console.log`
    * and the node REPL will pretty-print the wrapper and value.
    */
@@ -112,6 +127,21 @@ class Err<E> {
    * Returns the contained error.
    */
   unsafeUnwrapErr(): E {
+    return this.error;
+  }
+
+  /**
+   * Throws the given error message.
+   */
+  unsafeExpect(message: string): never {
+    throw new Error(message);
+  }
+
+  /**
+   * Returns the contained error.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  unsafeExpectErr(message: string): E {
     return this.error;
   }
 


### PR DESCRIPTION
## Overview
<!-- add a link to a GitHub Issue here -->
Allows running VxScan with `PLUSTEKCTL_PATH=/path/to/customctl` to work with the Custom America A4 scanner.

## Demo Video or Screenshot
```sh
# Runs like so:
PLUSTEKCTL_PATH=$HOME/code/plustekctl/customctl pnpm start
```

## Testing Plan 
Tested manually with the `customctl` branch of the `plustekctl` repo with an IdeaPad Flex running vxsuite and the UI running in Chrome on macOS. Used the Ashland 11/8/22 election.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
