### PR TITLE
refactor(types): use `assertOk` instead of `unsafeExpect`

### DIFF
--- a/libs/image-utils/src/image_data.ts
+++ b/libs/image-utils/src/image_data.ts
@@ -163,9 +163,9 @@ async function loadRawImageWithMetadataInFileName(
   ];
 
   // these should be valid because of the regex above
-  const width = widthResult.unsafeExpect('width is valid');
-  const height = heightResult.unsafeExpect('height is valid');
-  const bitsPerPixel = bitsPerPixelResult.unsafeExpect('bitsPerPixel is valid');
+  const width = widthResult.assertOk('width is valid');
+  const height = heightResult.assertOk('height is valid');
+  const bitsPerPixel = bitsPerPixelResult.assertOk('bitsPerPixel is valid');
   const srcBytesPerPixel = Math.round(bitsPerPixel / 8);
   return await loadRawImage(path, width, height, srcBytesPerPixel);
 }

--- a/libs/types/src/result.test.ts
+++ b/libs/types/src/result.test.ts
@@ -34,7 +34,7 @@ test('ok assertOk', () => {
   expect(ok(0).assertOk('a value')).toBe(0);
 });
 
-test('ok assertOkErr', () => {
+test('ok assertErr', () => {
   expect(() => ok('value').assertErr('an error')).toThrowError('an error');
 });
 

--- a/libs/types/src/result.test.ts
+++ b/libs/types/src/result.test.ts
@@ -83,7 +83,7 @@ test('err assertOk', () => {
   expect(() => err('error').assertOk('an error!')).toThrowError('an error!');
 });
 
-test('err assertOkErr', () => {
+test('err assertErr', () => {
   expect(err('error').assertErr('what?')).toBe('error');
 });
 

--- a/libs/types/src/result.test.ts
+++ b/libs/types/src/result.test.ts
@@ -30,14 +30,12 @@ test('ok unsafeUnwrapErr', () => {
   expect(() => ok('value').unsafeUnwrapErr()).toThrowError();
 });
 
-test('ok unsafeExpect', () => {
-  expect(ok(0).unsafeExpect('a value')).toBe(0);
+test('ok assertOk', () => {
+  expect(ok(0).assertOk('a value')).toBe(0);
 });
 
-test('ok unsafeExpectErr', () => {
-  expect(() => ok('value').unsafeExpectErr('an error')).toThrowError(
-    'an error'
-  );
+test('ok assertOkErr', () => {
+  expect(() => ok('value').assertErr('an error')).toThrowError('an error');
 });
 
 test('ok is Result', () => {
@@ -81,14 +79,12 @@ test('err unsafeUnwrapErr', () => {
   expect(err('error').unsafeUnwrapErr()).toBe('error');
 });
 
-test('err unsafeExpect', () => {
-  expect(() => err('error').unsafeExpect('an error!')).toThrowError(
-    'an error!'
-  );
+test('err assertOk', () => {
+  expect(() => err('error').assertOk('an error!')).toThrowError('an error!');
 });
 
-test('err unsafeExpectErr', () => {
-  expect(err('error').unsafeExpectErr('what?')).toBe('error');
+test('err assertOkErr', () => {
+  expect(err('error').assertErr('what?')).toBe('error');
 });
 
 test('err is Result', () => {

--- a/libs/types/src/result.ts
+++ b/libs/types/src/result.ts
@@ -53,14 +53,14 @@ class Ok<T> {
    * Returns the contained value.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  unsafeExpect(message: string): T {
+  assertOk(message: string): T {
     return this.value;
   }
 
   /**
    * Throws the given error message.
    */
-  unsafeExpectErr(message: string): never {
+  assertErr(message: string): never {
     throw new Error(message);
   }
 
@@ -133,7 +133,7 @@ class Err<E> {
   /**
    * Throws the given error message.
    */
-  unsafeExpect(message: string): never {
+  assertOk(message: string): never {
     throw new Error(message);
   }
 
@@ -141,7 +141,7 @@ class Err<E> {
    * Returns the contained error.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  unsafeExpectErr(message: string): E {
+  assertErr(message: string): E {
     return this.error;
   }
 


### PR DESCRIPTION
## Overview
<!-- add a link to a GitHub Issue here -->
@jonahkagan pointed out this would be closer to idiomatic TypeScript here: https://github.com/votingworks/vxsuite/pull/2828#discussion_r1041315602

## Demo Video or Screenshot
n/a

## Testing Plan 
n/a

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
