### PR TITLE
feat(vx-scan): Remove option to export CVR to custom location

### DIFF
--- a/apps/vx-scan/frontend/src/components/export_results_modal.test.tsx
+++ b/apps/vx-scan/frontend/src/components/export_results_modal.test.tsx
@@ -63,43 +63,6 @@ test('render no usb found screen when there is not a mounted usb drive', () => {
   }
 });
 
-test('render export modal when a usb drive is mounted as expected and allows custom export', async () => {
-  const mockKiosk = fakeKiosk();
-  window.kiosk = mockKiosk;
-  mockKiosk.saveAs = jest.fn().mockResolvedValue(fakeFileWriter());
-  mockKiosk.getUsbDriveInfo.mockResolvedValue([fakeUsbDrive()]);
-
-  fetchMock.postOnce('/precinct-scanner/export', {
-    body: '',
-  });
-
-  const closeFn = jest.fn();
-  const { getByText, getByAltText } = renderInAppContext(
-    <ExportResultsModal
-      onClose={closeFn}
-      usbDrive={{ status: 'mounted', eject: jest.fn() }}
-      scannedBallotCount={5}
-      isTestMode
-    />,
-    { auth }
-  );
-  getByText('Save CVRs');
-  getByText(
-    /A CVR file will automatically be saved to the default location on the mounted USB drive. /
-  );
-  getByAltText('Insert USB Image');
-
-  fireEvent.click(getByText('Custom'));
-  await waitFor(() => getByText('CVRs Saved to USB Drive'));
-  await waitFor(() => {
-    expect(mockKiosk.saveAs).toHaveBeenCalledTimes(1);
-  });
-  expect(fetchMock.called('/precinct-scanner/export')).toBe(true);
-
-  fireEvent.click(getByText('Cancel'));
-  expect(closeFn).toHaveBeenCalled();
-});
-
 test('render export modal when a usb drive is mounted as expected and allows automatic export', async () => {
   const mockKiosk = fakeKiosk();
   window.kiosk = mockKiosk;

--- a/apps/vx-scan/frontend/src/components/export_results_modal.tsx
+++ b/apps/vx-scan/frontend/src/components/export_results_modal.tsx
@@ -48,26 +48,22 @@ export function ExportResultsModal({
   assert(isElectionManagerAuth(auth) || isPollWorkerAuth(auth));
   const userRole = auth.user.role;
 
-  const exportResults = useCallback(
-    async (openDialog: boolean) => {
-      setCurrentState(ModalState.SAVING);
-      try {
-        await saveCvrExportToUsb({
-          electionDefinition,
-          machineConfig,
-          scannedBallotCount,
-          isTestMode,
-          openFilePickerDialog: openDialog,
-        });
-        setCurrentState(ModalState.DONE);
-      } catch (error) {
-        assert(error instanceof Error);
-        setErrorMessage(`Failed to save CVRs. ${error.message}`);
-        setCurrentState(ModalState.ERROR);
-      }
-    },
-    [electionDefinition, isTestMode, machineConfig, scannedBallotCount]
-  );
+  const exportResults = useCallback(async () => {
+    setCurrentState(ModalState.SAVING);
+    try {
+      await saveCvrExportToUsb({
+        electionDefinition,
+        machineConfig,
+        scannedBallotCount,
+        isTestMode,
+      });
+      setCurrentState(ModalState.DONE);
+    } catch (error) {
+      assert(error instanceof Error);
+      setErrorMessage(`Failed to save CVRs. ${error.message}`);
+      setCurrentState(ModalState.ERROR);
+    }
+  }, [electionDefinition, isTestMode, machineConfig, scannedBallotCount]);
 
   if (currentState === ModalState.ERROR) {
     return (
@@ -151,31 +147,12 @@ export function ExportResultsModal({
               <h1>No USB Drive Detected</h1>
               <p>
                 Please insert a USB drive in order to save CVRs.
-                <UsbImage
-                  src="/assets/usb-drive.svg"
-                  alt="Insert USB Image"
-                  // hidden feature to save with file dialog by double-clicking
-                  onDoubleClick={() => exportResults(true)}
-                />
+                <UsbImage src="/assets/usb-drive.svg" alt="Insert USB Image" />
               </p>
             </Prose>
           }
           onOverlayClick={onClose}
-          actions={
-            <React.Fragment>
-              {!window.kiosk && (
-                <Button
-                  data-testid="manual-export"
-                  onPress={() => exportResults(true)}
-                  disabled // Not currently supported
-                  primary
-                >
-                  Save
-                </Button>
-              )}
-              <Button onPress={onClose}>Cancel</Button>
-            </React.Fragment>
-          }
+          actions={<Button onPress={onClose}>Cancel</Button>}
         />
       );
     case 'ejecting':
@@ -196,19 +173,17 @@ export function ExportResultsModal({
               <UsbImage src="/assets/usb-drive.svg" alt="Insert USB Image" />
               <p>
                 A CVR file will automatically be saved to the default location
-                on the mounted USB drive. Optionally, you may pick a custom save
-                location.
+                on the mounted USB drive.
               </p>
             </Prose>
           }
           onOverlayClick={onClose}
           actions={
             <React.Fragment>
-              <Button primary onPress={() => exportResults(false)}>
+              <Button primary onPress={exportResults}>
                 Save
               </Button>
               <Button onPress={onClose}>Cancel</Button>
-              <Button onPress={() => exportResults(true)}>Custom</Button>
             </React.Fragment>
           }
         />

--- a/apps/vx-scan/frontend/src/screens/poll_worker_screen.tsx
+++ b/apps/vx-scan/frontend/src/screens/poll_worker_screen.tsx
@@ -384,7 +384,6 @@ export function PollWorkerScreen({
       machineConfig,
       scannedBallotCount,
       isTestMode: !isLiveMode,
-      openFilePickerDialog: false,
     });
   }
 

--- a/apps/vx-scan/frontend/src/utils/save_cvr_export_to_usb.test.ts
+++ b/apps/vx-scan/frontend/src/utils/save_cvr_export_to_usb.test.ts
@@ -42,7 +42,6 @@ test('throws error when scan service errors', async () => {
       machineConfig,
       scannedBallotCount: 0,
       isTestMode: false,
-      openFilePickerDialog: false,
     })
   ).rejects.toThrowErrorMatchingInlineSnapshot(
     `"Unable to get CVR file: FetchFailed (status=Internal Server Error)"`
@@ -62,14 +61,13 @@ test('throws error when there is no usb mounted in kiosk mode', async () => {
       machineConfig,
       scannedBallotCount: 0,
       isTestMode: false,
-      openFilePickerDialog: false,
     })
   ).rejects.toThrowErrorMatchingInlineSnapshot(
     `"could not save file; path to usb drive missing"`
   );
 });
 
-test('calls kiosk saveAs when opening file picker dialog', async () => {
+test('saves file to default location in kiosk mode', async () => {
   fetchMock.postOnce(
     '/precinct-scanner/export',
     electionMinimalExhaustiveSampleFixtures.cvrData
@@ -80,45 +78,6 @@ test('calls kiosk saveAs when opening file picker dialog', async () => {
     machineConfig,
     scannedBallotCount: 0,
     isTestMode: false,
-    openFilePickerDialog: true,
-  });
-  expect(kiosk.saveAs).toHaveBeenCalledWith({
-    defaultPath: 'machine_0003__0_ballots__2020-10-31_00-00-00.jsonl',
-  });
-});
-
-test('throws error when no file is chosen in file picker', async () => {
-  fetchMock.postOnce(
-    '/precinct-scanner/export',
-    electionMinimalExhaustiveSampleFixtures.cvrData
-  );
-  kiosk.saveAs.mockResolvedValue(undefined);
-  await expect(
-    saveCvrExportToUsb({
-      electionDefinition:
-        electionMinimalExhaustiveSampleFixtures.electionDefinition,
-      machineConfig,
-      scannedBallotCount: 0,
-      isTestMode: false,
-      openFilePickerDialog: true,
-    })
-  ).rejects.toThrowErrorMatchingInlineSnapshot(
-    `"Could not save; no file was chosen"`
-  );
-});
-
-test('saves file to default location when openFilePicker is false in kiosk mode', async () => {
-  fetchMock.postOnce(
-    '/precinct-scanner/export',
-    electionMinimalExhaustiveSampleFixtures.cvrData
-  );
-  await saveCvrExportToUsb({
-    electionDefinition:
-      electionMinimalExhaustiveSampleFixtures.electionDefinition,
-    machineConfig,
-    scannedBallotCount: 0,
-    isTestMode: false,
-    openFilePickerDialog: false,
   });
   expect(kiosk.makeDirectory).toHaveBeenCalledWith(
     'fake mount point/cast-vote-records/sample-county_example-primary-election_0dabcacc5d',

--- a/apps/vx-scan/frontend/src/utils/save_cvr_export_to_usb.ts
+++ b/apps/vx-scan/frontend/src/utils/save_cvr_export_to_usb.ts
@@ -14,7 +14,6 @@ interface SaveCvrExportToUsbArgs {
   machineConfig: MachineConfig;
   scannedBallotCount: number;
   isTestMode: boolean;
-  openFilePickerDialog: boolean;
 }
 
 /**
@@ -26,7 +25,6 @@ export async function saveCvrExportToUsb({
   machineConfig,
   scannedBallotCount,
   isTestMode,
-  openFilePickerDialog,
 }: SaveCvrExportToUsbArgs): Promise<void> {
   // TODO: filename should be determined server-side
   const cvrFilename = generateFilenameForScanningResults(
@@ -37,35 +35,26 @@ export async function saveCvrExportToUsb({
   );
   let result: Result<void, DownloadError>;
   if (window.kiosk) {
-    if (!openFilePickerDialog) {
-      const usbPath = await usbstick.getPath();
-      if (!usbPath) {
-        throw new Error('could not save file; path to usb drive missing');
-      }
-      const electionFolderName = generateElectionBasedSubfolderName(
-        electionDefinition.election,
-        electionDefinition.electionHash
-      );
-      const pathToFolder = join(
-        usbPath,
-        SCANNER_RESULTS_FOLDER,
-        electionFolderName
-      );
-      result = await download('/precinct-scanner/export', {
-        directory: pathToFolder,
-        filename: cvrFilename,
-        fetchOptions: {
-          method: 'POST',
-        },
-      });
-    } else {
-      result = await download('/precinct-scanner/export', {
-        filename: cvrFilename,
-        fetchOptions: {
-          method: 'POST',
-        },
-      });
+    const usbPath = await usbstick.getPath();
+    if (!usbPath) {
+      throw new Error('could not save file; path to usb drive missing');
     }
+    const electionFolderName = generateElectionBasedSubfolderName(
+      electionDefinition.election,
+      electionDefinition.electionHash
+    );
+    const pathToFolder = join(
+      usbPath,
+      SCANNER_RESULTS_FOLDER,
+      electionFolderName
+    );
+    result = await download('/precinct-scanner/export', {
+      directory: pathToFolder,
+      filename: cvrFilename,
+      fetchOptions: {
+        method: 'POST',
+      },
+    });
     await usbstick.doSync();
   } else {
     // Downloading CVR files outside of kiosk-browser is not supported after


### PR DESCRIPTION
## Overview
Task: #2814 

Before moving the CVR export logic to the backend, simplifying it by removing the ability to save it anywhere other than a USB.

## Demo Video or Screenshot
<img width="904" alt="Screen Shot 2023-01-05 at 10 58 29 AM" src="https://user-images.githubusercontent.com/530106/210859699-2182df95-a3ca-45b5-aeda-8b00235efec5.png">



## Testing Plan 
- Manual test
- Removed relevant automated tests

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
