### PR TITLE
feat(image-utils): use the standard PGM raw image format

### DIFF
--- a/libs/image-utils/src/image_data.test.ts
+++ b/libs/image-utils/src/image_data.test.ts
@@ -85,6 +85,16 @@ test('loadImage/writeImageData', async () => {
   );
 });
 
+test('loadImageData with invalid PGM format', async () => {
+  const filePath = fileSync({
+    template: `tmp-XXXXXX.pgm`,
+  }).name;
+  await writeFile(filePath, `P5\n0\n255\n`);
+  await expect(loadImageData(filePath)).rejects.toThrow(
+    new Error(`Invalid PGM image: ${filePath}`)
+  );
+});
+
 test('loadImage/loadImageData with PGM format', async () => {
   await fc.assert(
     fc.asyncProperty(arbitraryImageData(), async (imageData) => {

--- a/libs/image-utils/src/image_data.test.ts
+++ b/libs/image-utils/src/image_data.test.ts
@@ -85,20 +85,16 @@ test('loadImage/writeImageData', async () => {
   );
 });
 
-test('loadImage with invalid RAW filename', async () => {
-  await expect(loadImage('invalid.raw')).rejects.toThrowError(
-    'Invalid raw image filename'
-  );
-});
-
-test('loadImage/loadImageData with RAW format', async () => {
+test('loadImage/loadImageData with PGM format', async () => {
   await fc.assert(
     fc.asyncProperty(arbitraryImageData(), async (imageData) => {
-      const bitsPerPixel = getImageChannelCount(imageData) * 8;
       const filePath = fileSync({
-        template: `tmp-XXXXXX-${imageData.width}x${imageData.height}-${bitsPerPixel}bpp.raw`,
+        template: `tmp-XXXXXX.pgm`,
       }).name;
-      await writeFile(filePath, imageData.data);
+      await writeFile(
+        filePath,
+        `P5\n${imageData.width} ${imageData.height}\n255\n${imageData.data}`
+      );
       const loadedImage = await loadImage(filePath);
       const loadedImageData = await loadImageData(filePath);
       expect({


### PR DESCRIPTION
## Overview
<!-- add a link to a GitHub Issue here -->
The `.raw` format we previously supported was just my workaround for not having `libjpeg` integrated with `customctl`. For now we still need a workaround, but I found the old standard [PGM file format](https://en.wikipedia.org/wiki/Netpbm) that we can use instead.

## Demo Video or Screenshot
n/a

## Testing Plan 
- [x] Add automated tests
- [ ] Test with `customctl` updates

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
