### PR TITLE
refactor(vx-scan): Move types from libs/api into apps/vx-scan/backend

### DIFF
--- a/apps/vx-scan/backend/package.json
+++ b/apps/vx-scan/backend/package.json
@@ -37,7 +37,6 @@
     ]
   },
   "dependencies": {
-    "@votingworks/api": "workspace:*",
     "@votingworks/ballot-encoder": "workspace:*",
     "@votingworks/ballot-interpreter-nh": "workspace:*",
     "@votingworks/ballot-interpreter-vx": "workspace:*",

--- a/apps/vx-scan/backend/src/app.ts
+++ b/apps/vx-scan/backend/src/app.ts
@@ -1,4 +1,3 @@
-import { Scan } from '@votingworks/api';
 import * as grout from '@votingworks/grout';
 import { LogEventId, Logger } from '@votingworks/logging';
 import {
@@ -30,11 +29,11 @@ import { PrecinctScannerInterpreter } from './interpret';
 import { PrecinctScannerStateMachine } from './state_machine';
 import { Workspace } from './util/workspace';
 import { Usb } from './util/usb';
-
-/**
- * Possible errors that can occur during configuration (currently there's only one).
- */
-export type ConfigurationError = 'no_ballot_package_on_usb_drive';
+import {
+  ConfigurationError,
+  PrecinctScannerConfig,
+  PrecinctScannerStatus,
+} from './types';
 
 function buildApi(
   machine: PrecinctScannerStateMachine,
@@ -109,7 +108,7 @@ function buildApi(
     },
 
     // eslint-disable-next-line @typescript-eslint/require-await
-    async getConfig(): Promise<Scan.PrecinctScannerConfig> {
+    async getConfig(): Promise<PrecinctScannerConfig> {
       return {
         electionDefinition: store.getElectionDefinition(),
         precinctSelection: store.getPrecinctSelection(),
@@ -222,9 +221,8 @@ function buildApi(
       store.setBallotCountWhenBallotBagLastReplaced(store.getBallotsCounted());
     },
 
-    async backupToUsbDrive(): Promise<Result<void, Scan.BackupError>> {
-      const result = await backupToUsbDrive(store, usb);
-      return result.isErr() ? result : ok();
+    async backupToUsbDrive(): Promise<Result<void, ExportDataError>> {
+      return await backupToUsbDrive(store, usb);
     },
 
     async exportCastVoteRecordsToUsbDrive(input: {
@@ -249,7 +247,7 @@ function buildApi(
     },
 
     // eslint-disable-next-line @typescript-eslint/require-await
-    async getScannerStatus(): Promise<Scan.PrecinctScannerStatus> {
+    async getScannerStatus(): Promise<PrecinctScannerStatus> {
       const machineStatus = machine.status();
       const ballotsCounted = store.getBallotsCounted();
       const canUnconfigure = store.getCanUnconfigure();

--- a/apps/vx-scan/backend/src/app_config.test.ts
+++ b/apps/vx-scan/backend/src/app_config.test.ts
@@ -4,7 +4,6 @@ import {
   electionMinimalExhaustiveSampleSinglePrecinctDefinition,
   electionSampleDefinition,
 } from '@votingworks/fixtures';
-import { Scan } from '@votingworks/api';
 import waitForExpect from 'wait-for-expect';
 import { LogEventId } from '@votingworks/logging';
 import * as grout from '@votingworks/grout';
@@ -25,6 +24,7 @@ import {
   waitForStatus,
 } from '../test/helpers/app_helpers';
 import { Api } from './app';
+import { SheetInterpretation } from './types';
 
 jest.setTimeout(20_000);
 
@@ -41,7 +41,7 @@ async function scanBallot(
     ballotsCounted: initialBallotsCounted,
   });
 
-  const interpretation: Scan.SheetInterpretation = {
+  const interpretation: SheetInterpretation = {
     type: 'ValidSheet',
   };
 

--- a/apps/vx-scan/backend/src/app_scan.test.ts
+++ b/apps/vx-scan/backend/src/app_scan.test.ts
@@ -1,6 +1,5 @@
 import { AdjudicationReason, err, ok } from '@votingworks/types';
 import waitForExpect from 'wait-for-expect';
-import { Scan } from '@votingworks/api';
 import { Logger } from '@votingworks/logging';
 import { MAX_FAILED_SCAN_ATTEMPTS } from './state_machine';
 import { PrecinctScannerInterpreter } from './interpret';
@@ -11,6 +10,7 @@ import {
   expectStatus,
   waitForStatus,
 } from '../test/helpers/app_helpers';
+import { SheetInterpretation } from './types';
 
 jest.setTimeout(20_000);
 
@@ -62,7 +62,7 @@ export function checkLogs(logger: Logger): void {
  */
 function mockInterpretation(
   interpreter: PrecinctScannerInterpreter,
-  interpretation: Scan.SheetInterpretation
+  interpretation: SheetInterpretation
 ) {
   jest.spyOn(interpreter, 'interpret').mockResolvedValue(
     ok({
@@ -92,7 +92,7 @@ test('configure and scan hmpb', async () => {
   ).unsafeUnwrap();
   await waitForStatus(apiClient, { state: 'ready_to_scan' });
 
-  const interpretation: Scan.SheetInterpretation = {
+  const interpretation: SheetInterpretation = {
     type: 'ValidSheet',
   };
 
@@ -131,7 +131,7 @@ test('configure and scan bmd ballot', async () => {
   ).unsafeUnwrap();
   await waitForStatus(apiClient, { state: 'ready_to_scan' });
 
-  const interpretation: Scan.SheetInterpretation = {
+  const interpretation: SheetInterpretation = {
     type: 'ValidSheet',
   };
 
@@ -163,7 +163,7 @@ test('configure and scan bmd ballot', async () => {
   checkLogs(logger);
 });
 
-const needsReviewInterpretation: Scan.SheetInterpretation = {
+const needsReviewInterpretation: SheetInterpretation = {
   type: 'NeedsReviewSheet',
   reasons: [{ type: AdjudicationReason.BlankBallot }],
 };
@@ -258,7 +258,7 @@ test('invalid ballot rejected', async () => {
   ).unsafeUnwrap();
   await waitForStatus(apiClient, { state: 'ready_to_scan' });
 
-  const interpretation: Scan.SheetInterpretation = {
+  const interpretation: SheetInterpretation = {
     type: 'InvalidSheet',
     reason: 'invalid_election_hash',
   };
@@ -297,7 +297,7 @@ test('bmd ballot is rejected when scanned for wrong precinct', async () => {
   ).unsafeUnwrap();
   await waitForStatus(apiClient, { state: 'ready_to_scan' });
 
-  const interpretation: Scan.SheetInterpretation = {
+  const interpretation: SheetInterpretation = {
     type: 'InvalidSheet',
     reason: 'invalid_precinct',
   };
@@ -322,7 +322,7 @@ test('bmd ballot is accepted if precinct is set for the right precinct', async (
   await configureApp(apiClient, mockUsb, { precinctId: '23' });
   // Configure for the proper precinct and verify the ballot scans
 
-  const validInterpretation: Scan.SheetInterpretation = {
+  const validInterpretation: SheetInterpretation = {
     type: 'ValidSheet',
   };
 
@@ -352,7 +352,7 @@ test('hmpb ballot is rejected when scanned for wrong precinct', async () => {
   ).unsafeUnwrap();
   await waitForStatus(apiClient, { state: 'ready_to_scan' });
 
-  const interpretation: Scan.SheetInterpretation = {
+  const interpretation: SheetInterpretation = {
     type: 'InvalidSheet',
     reason: 'invalid_precinct',
   };
@@ -380,7 +380,7 @@ test('hmpb ballot is accepted if precinct is set for the right precinct', async 
   });
   // Configure for the proper precinct and verify the ballot scans
 
-  const validInterpretation: Scan.SheetInterpretation = {
+  const validInterpretation: SheetInterpretation = {
     type: 'ValidSheet',
   };
 
@@ -404,7 +404,7 @@ test('blank sheet ballot rejected', async () => {
   (await mockPlustek.simulateLoadSheet(ballotImages.blankSheet)).unsafeUnwrap();
   await waitForStatus(apiClient, { state: 'ready_to_scan' });
 
-  const interpretation: Scan.SheetInterpretation = {
+  const interpretation: SheetInterpretation = {
     type: 'InvalidSheet',
     reason: 'unknown',
   };
@@ -462,7 +462,7 @@ test('scanner powered off while accepting', async () => {
   ).unsafeUnwrap();
   await waitForStatus(apiClient, { state: 'ready_to_scan' });
 
-  const interpretation: Scan.SheetInterpretation = {
+  const interpretation: SheetInterpretation = {
     type: 'ValidSheet',
   };
   mockInterpretation(interpreter, interpretation);
@@ -494,7 +494,7 @@ test('scanner powered off after accepting', async () => {
   ).unsafeUnwrap();
   await waitForStatus(apiClient, { state: 'ready_to_scan' });
 
-  const interpretation: Scan.SheetInterpretation = {
+  const interpretation: SheetInterpretation = {
     type: 'ValidSheet',
   };
   mockInterpretation(interpreter, interpretation);
@@ -532,7 +532,7 @@ test('scanner powered off while rejecting', async () => {
   ).unsafeUnwrap();
   await waitForStatus(apiClient, { state: 'ready_to_scan' });
 
-  const interpretation: Scan.SheetInterpretation = {
+  const interpretation: SheetInterpretation = {
     type: 'InvalidSheet',
     reason: 'invalid_election_hash',
   };
@@ -660,7 +660,7 @@ test('insert second ballot before first ballot accept', async () => {
   ).unsafeUnwrap();
   await waitForStatus(apiClient, { state: 'ready_to_scan' });
 
-  const interpretation: Scan.SheetInterpretation = {
+  const interpretation: SheetInterpretation = {
     type: 'ValidSheet',
   };
   mockInterpretation(interpreter, interpretation);
@@ -701,7 +701,7 @@ test('insert second ballot while first ballot is accepting', async () => {
   ).unsafeUnwrap();
   await waitForStatus(apiClient, { state: 'ready_to_scan' });
 
-  const interpretation: Scan.SheetInterpretation = {
+  const interpretation: SheetInterpretation = {
     type: 'ValidSheet',
   };
   mockInterpretation(interpreter, interpretation);
@@ -772,7 +772,7 @@ test('insert second ballot while first ballot is rejecting', async () => {
   ).unsafeUnwrap();
   await waitForStatus(apiClient, { state: 'ready_to_scan' });
 
-  const interpretation: Scan.SheetInterpretation = {
+  const interpretation: SheetInterpretation = {
     type: 'InvalidSheet',
     reason: 'invalid_election_hash',
   };
@@ -881,7 +881,7 @@ test('jam on accept', async () => {
   ).unsafeUnwrap();
   await waitForStatus(apiClient, { state: 'ready_to_scan' });
 
-  const interpretation: Scan.SheetInterpretation = {
+  const interpretation: SheetInterpretation = {
     type: 'ValidSheet',
   };
   mockInterpretation(interpreter, interpretation);
@@ -946,7 +946,7 @@ test('jam on reject', async () => {
   ).unsafeUnwrap();
   await waitForStatus(apiClient, { state: 'ready_to_scan' });
 
-  const interpretation: Scan.SheetInterpretation = {
+  const interpretation: SheetInterpretation = {
     type: 'InvalidSheet',
     reason: 'invalid_election_hash',
   };
@@ -999,7 +999,7 @@ test('scan fails and retries', async () => {
   ).unsafeUnwrap();
   await waitForStatus(apiClient, { state: 'ready_to_scan' });
 
-  const interpretation: Scan.SheetInterpretation = {
+  const interpretation: SheetInterpretation = {
     type: 'ValidSheet',
   };
   mockInterpretation(interpreter, interpretation);

--- a/apps/vx-scan/backend/src/index.ts
+++ b/apps/vx-scan/backend/src/index.ts
@@ -8,7 +8,8 @@ import { MOCK_SCANNER_HTTP, MOCK_SCANNER_PORT, NODE_ENV } from './globals';
 import * as server from './server';
 import { plustekMockServer } from './plustek_mock_server';
 
-export type { Api, ConfigurationError } from './app';
+export type { Api } from './app';
+export * from './types';
 
 // https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
 const dotEnvPath = '.env';

--- a/apps/vx-scan/backend/src/interpret.ts
+++ b/apps/vx-scan/backend/src/interpret.ts
@@ -15,7 +15,6 @@ import {
   mapSheet,
   SheetOf,
 } from '@votingworks/types';
-import { Scan } from '@votingworks/api';
 import {
   detectQrcodeInFilePath,
   normalizeSheetOutput,
@@ -24,6 +23,7 @@ import { time } from '@votingworks/utils';
 import { Interpreter as VxInterpreter } from './vx_interpreter';
 import { saveSheetImages } from './util/save_images';
 import { rootDebug } from './util/debug';
+import { SheetInterpretation } from './types';
 
 export interface InterpreterConfig {
   readonly electionDefinition: ElectionDefinition;
@@ -44,7 +44,7 @@ export interface PrecinctScannerInterpreter {
   interpret(
     sheetId: Id,
     sheet: SheetOf<string>
-  ): Promise<Result<SheetInterpretation, Error>>;
+  ): Promise<Result<SheetInterpretationWithPages, Error>>;
 }
 
 /**
@@ -52,13 +52,13 @@ export interface PrecinctScannerInterpreter {
  * result for the sheet as a whole and the individual page (i.e. front and back)
  * interpretations.
  */
-export type SheetInterpretation = Scan.SheetInterpretation & {
+export type SheetInterpretationWithPages = SheetInterpretation & {
   pages: SheetOf<PageInterpretationWithFiles>;
 };
 
 function combinePageInterpretationsForSheet(
   pages: SheetOf<PageInterpretationWithFiles>
-): Scan.SheetInterpretation {
+): SheetInterpretation {
   const [front, back] = pages;
   const frontType = front.interpretation.type;
   const backType = back.interpretation.type;

--- a/apps/vx-scan/backend/src/store.ts
+++ b/apps/vx-scan/backend/src/store.ts
@@ -2,12 +2,12 @@
 // The durable datastore for CVRs and configuration info.
 //
 
-import { Scan } from '@votingworks/api';
 import { generateBallotPageLayouts } from '@votingworks/ballot-interpreter-nh';
 import { interpretTemplate } from '@votingworks/ballot-interpreter-vx';
 import { Bindable, Client as DbClient } from '@votingworks/db';
 import { pdfToImages } from '@votingworks/image-utils';
 import {
+  AdjudicationStatus,
   AnyContest,
   BallotMetadata,
   BallotMetadataSchema,
@@ -17,6 +17,7 @@ import {
   BallotPageMetadata,
   BallotPaperSize,
   BallotSheetInfo,
+  BatchInfo,
   ElectionDefinition,
   getBallotStyle,
   getContests,
@@ -36,6 +37,7 @@ import {
   safeParseElectionDefinition,
   safeParseJson,
   SheetOf,
+  Side,
 } from '@votingworks/types';
 import { assert, BallotPackageEntry, find } from '@votingworks/utils';
 import { Buffer } from 'buffer';
@@ -793,7 +795,7 @@ export class Store {
 
   getBallotFilenames(
     sheetId: string,
-    side: Scan.Side
+    side: Side
   ): { original: string; normalized: string } | undefined {
     const row = this.client.one<[string]>(
       `
@@ -958,7 +960,7 @@ export class Store {
   /**
    * Gets all batches, including their sheet count.
    */
-  batchStatus(): Scan.BatchInfo[] {
+  batchStatus(): BatchInfo[] {
     interface SqliteBatchInfo {
       id: string;
       label: string;
@@ -1008,7 +1010,7 @@ export class Store {
   /**
    * Gets adjudication status.
    */
-  adjudicationStatus(): Scan.AdjudicationStatus {
+  adjudicationStatus(): AdjudicationStatus {
     const { remaining } = this.client.one(`
         select count(*) as remaining
         from sheets

--- a/apps/vx-scan/backend/src/types.ts
+++ b/apps/vx-scan/backend/src/types.ts
@@ -1,9 +1,18 @@
 import {
+  AdjudicationReasonInfo,
   BallotTargetMark,
+  ElectionDefinition,
   MarkStatus,
   MarkThresholds,
   PageInterpretation,
+  PollsState,
+  PrecinctSelection,
 } from '@votingworks/types';
+
+/**
+ * Possible errors that can occur during configuration (currently there's only one).
+ */
+export type ConfigurationError = 'no_ballot_package_on_usb_drive';
 
 export interface PageInterpretationWithAdjudication<
   T extends PageInterpretation = PageInterpretation
@@ -30,4 +39,78 @@ export function getMarkStatus(
   }
 
   return MarkStatus.Unmarked;
+}
+
+export type PrecinctScannerState =
+  | 'connecting'
+  | 'disconnected'
+  | 'no_paper'
+  | 'ready_to_scan'
+  | 'scanning'
+  | 'ready_to_accept'
+  | 'accepting'
+  | 'accepted'
+  | 'needs_review'
+  | 'accepting_after_review'
+  | 'returning'
+  | 'returned'
+  | 'rejecting'
+  | 'rejected'
+  | 'calibrating'
+  | 'jammed'
+  | 'both_sides_have_paper'
+  | 'recovering_from_error'
+  | 'unrecoverable_error';
+
+export type InvalidInterpretationReason =
+  | 'invalid_test_mode'
+  | 'invalid_election_hash'
+  | 'invalid_precinct'
+  | 'unreadable'
+  | 'unknown';
+
+export type SheetInterpretation =
+  | {
+      type: 'ValidSheet';
+    }
+  | {
+      type: 'InvalidSheet';
+      reason: InvalidInterpretationReason;
+    }
+  | {
+      type: 'NeedsReviewSheet';
+      reasons: AdjudicationReasonInfo[];
+    };
+export type PrecinctScannerErrorType =
+  | 'paper_status_timed_out'
+  | 'scanning_timed_out'
+  | 'scanning_failed'
+  | 'both_sides_have_paper'
+  | 'paper_in_back_after_accept'
+  | 'paper_in_front_after_reconnect'
+  | 'paper_in_back_after_reconnect'
+  | 'unexpected_paper_status'
+  | 'unexpected_event'
+  | 'plustek_error';
+export interface PrecinctScannerMachineStatus {
+  state: PrecinctScannerState;
+  interpretation?: SheetInterpretation;
+  error?: PrecinctScannerErrorType;
+}
+
+export interface PrecinctScannerStatus extends PrecinctScannerMachineStatus {
+  ballotsCounted: number;
+  canUnconfigure: boolean;
+}
+
+export interface PrecinctScannerConfig {
+  // Config that persists across switching modes
+  electionDefinition?: ElectionDefinition;
+  precinctSelection?: PrecinctSelection;
+  markThresholdOverrides?: MarkThresholds;
+  isSoundMuted: boolean;
+  // "Config" that is specific to each election session
+  isTestMode: boolean;
+  pollsState: PollsState;
+  ballotCountWhenBallotBagLastReplaced: number;
 }

--- a/apps/vx-scan/backend/test/helpers/app_helpers.ts
+++ b/apps/vx-scan/backend/test/helpers/app_helpers.ts
@@ -8,7 +8,6 @@ import * as grout from '@votingworks/grout';
 import { Application } from 'express';
 import { Buffer } from 'buffer';
 import { ElectionDefinition, ok, PrecinctId, Result } from '@votingworks/types';
-import { Scan } from '@votingworks/api';
 import waitForExpect from 'wait-for-expect';
 import { fakeLogger, Logger } from '@votingworks/logging';
 import {
@@ -34,6 +33,7 @@ import {
 } from '../../src/interpret';
 import { createWorkspace, Workspace } from '../../src/util/workspace';
 import { Usb } from '../../src/util/usb';
+import { PrecinctScannerState, PrecinctScannerStatus } from '../../src/types';
 
 // TODO(jonah) - Is there a way to ensure Grout always has access to node-fetch
 // in a node environment?
@@ -108,8 +108,8 @@ export function createMockUsb(): MockUsb {
 export async function expectStatus(
   apiClient: grout.Client<Api>,
   expectedStatus: {
-    state: Scan.PrecinctScannerState;
-  } & Partial<Scan.PrecinctScannerStatus>
+    state: PrecinctScannerState;
+  } & Partial<PrecinctScannerStatus>
 ): Promise<void> {
   const status = await apiClient.getScannerStatus();
   expect(status).toEqual({
@@ -126,8 +126,8 @@ export async function expectStatus(
 export async function waitForStatus(
   apiClient: grout.Client<Api>,
   status: {
-    state: Scan.PrecinctScannerState;
-  } & Partial<Scan.PrecinctScannerStatus>
+    state: PrecinctScannerState;
+  } & Partial<PrecinctScannerStatus>
 ): Promise<void> {
   await waitForExpect(async () => {
     await expectStatus(apiClient, status);

--- a/apps/vx-scan/frontend/package.json
+++ b/apps/vx-scan/frontend/package.json
@@ -65,7 +65,6 @@
     "@types/react-dom": "^17.0.0",
     "@types/react-router-dom": "^5.1.5",
     "@types/styled-components": "^5.1.9",
-    "@votingworks/api": "workspace:*",
     "@votingworks/ballot-interpreter-vx": "workspace:*",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/grout": "workspace:*",

--- a/apps/vx-scan/frontend/src/app.test.tsx
+++ b/apps/vx-scan/frontend/src/app.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import fetchMock from 'fetch-mock';
-import { Scan } from '@votingworks/api';
 import {
   ALL_PRECINCTS_SELECTION,
   ReportSourceMachineType,
@@ -29,6 +28,11 @@ import {
 } from '@votingworks/fixtures';
 import { AdjudicationReason, err, ok } from '@votingworks/types';
 
+// eslint-disable-next-line vx/gts-no-import-export-type
+import type {
+  PrecinctScannerConfig,
+  SheetInterpretation,
+} from '@votingworks/vx-scan-backend';
 import {
   BALLOT_BAG_CAPACITY,
   POLLING_INTERVAL_FOR_SCANNER_STATUS_MS,
@@ -188,7 +192,7 @@ test('election manager must set precinct', async () => {
 
 test('election manager and poll worker configuration', async () => {
   const electionDefinition = electionSampleDefinition;
-  let config: Partial<Scan.PrecinctScannerConfig> = { electionDefinition };
+  let config: Partial<PrecinctScannerConfig> = { electionDefinition };
   apiMock.expectGetConfig(config);
   const { card, logger } = renderApp();
   apiMock.expectGetScannerStatus(statusNoPaper);
@@ -493,7 +497,7 @@ test('voter can cast a ballot that needs review and adjudicate as desired', asyn
   renderApp();
   await screen.findByText('Insert Your Ballot Below');
 
-  const interpretation: Scan.SheetInterpretation = {
+  const interpretation: SheetInterpretation = {
     type: 'NeedsReviewSheet',
     reasons: [{ type: AdjudicationReason.BlankBallot }],
   };

--- a/apps/vx-scan/frontend/src/app_root.tsx
+++ b/apps/vx-scan/frontend/src/app_root.tsx
@@ -28,7 +28,8 @@ import {
 } from '@votingworks/utils';
 import { LogEventId, Logger } from '@votingworks/logging';
 
-import { Scan } from '@votingworks/api';
+// eslint-disable-next-line vx/gts-no-import-export-type
+import type { PrecinctScannerConfig } from '@votingworks/vx-scan-backend';
 import { UnconfiguredElectionScreen } from './screens/unconfigured_election_screen';
 import { LoadingConfigurationScreen } from './screens/loading_configuration_screen';
 import { MachineConfig } from './config/types';
@@ -71,7 +72,7 @@ interface HardwareState {
   machineConfig: Readonly<MachineConfig>;
 }
 
-export interface State extends HardwareState, Scan.PrecinctScannerConfig {
+export interface State extends HardwareState, PrecinctScannerConfig {
   isBackendStateLoaded: boolean;
 }
 
@@ -82,9 +83,16 @@ const initialHardwareState: Readonly<HardwareState> = {
   },
 };
 
+const initialPrecinctScannerConfig: PrecinctScannerConfig = {
+  isSoundMuted: false,
+  isTestMode: true,
+  pollsState: 'polls_closed_initial',
+  ballotCountWhenBallotBagLastReplaced: 0,
+};
+
 const initialState: Readonly<State> = {
   ...initialHardwareState,
-  ...Scan.InitialPrecinctScannerConfig,
+  ...initialPrecinctScannerConfig,
   isBackendStateLoaded: false,
 };
 
@@ -94,7 +102,7 @@ type AppAction =
   | { type: 'resetElectionSession' }
   | {
       type: 'refreshStateFromBackend';
-      scannerConfig: Scan.PrecinctScannerConfig;
+      scannerConfig: PrecinctScannerConfig;
     }
   | { type: 'updatePrecinctSelection'; precinctSelection: PrecinctSelection }
   | {

--- a/apps/vx-scan/frontend/src/components/calibrate_scanner_modal.test.tsx
+++ b/apps/vx-scan/frontend/src/components/calibrate_scanner_modal.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
-import { Scan } from '@votingworks/api';
 import { deferred } from '@votingworks/utils';
 import userEvent from '@testing-library/user-event';
+// eslint-disable-next-line vx/gts-no-import-export-type
+import type { PrecinctScannerStatus } from '@votingworks/vx-scan-backend';
 import {
   CalibrateScannerModal,
   CalibrateScannerModalProps,
@@ -10,7 +11,7 @@ import {
 import { ApiClientContext } from '../api/api';
 import { createApiMock } from '../../test/helpers/mock_api_client';
 
-const fakeScannerStatus: Scan.PrecinctScannerStatus = {
+const fakeScannerStatus: PrecinctScannerStatus = {
   state: 'no_paper',
   ballotsCounted: 0,
   canUnconfigure: true,

--- a/apps/vx-scan/frontend/src/components/calibrate_scanner_modal.tsx
+++ b/apps/vx-scan/frontend/src/components/calibrate_scanner_modal.tsx
@@ -1,11 +1,12 @@
 import React, { useState } from 'react';
-import { Scan } from '@votingworks/api';
 import { Button, Modal, Prose, useCancelablePromise } from '@votingworks/ui';
 import { assert } from '@votingworks/utils';
+// eslint-disable-next-line vx/gts-no-import-export-type
+import type { PrecinctScannerStatus } from '@votingworks/vx-scan-backend';
 import { useApiClient } from '../api/api';
 
 export interface CalibrateScannerModalProps {
-  scannerStatus: Scan.PrecinctScannerStatus;
+  scannerStatus: PrecinctScannerStatus;
   onCancel: VoidFunction;
 }
 

--- a/apps/vx-scan/frontend/src/hooks/use_precinct_scanner_status.test.tsx
+++ b/apps/vx-scan/frontend/src/hooks/use_precinct_scanner_status.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
-import { Scan } from '@votingworks/api';
 import { deferred } from '@votingworks/utils';
 import { advanceTimersAndPromises } from '@votingworks/test-utils';
+// eslint-disable-next-line vx/gts-no-import-export-type
+import type { PrecinctScannerStatus } from '@votingworks/vx-scan-backend';
 import { usePrecinctScannerStatus } from './use_precinct_scanner_status';
 import { ApiClientContext } from '../api/api';
 import {
@@ -61,7 +62,7 @@ test('issues one status check at a time', async () => {
   apiMock.mockApiClient.getScannerStatus
     .expectCallWith()
     .resolves(statusNoPaper);
-  const { promise, resolve } = deferred<Scan.PrecinctScannerStatus>();
+  const { promise, resolve } = deferred<PrecinctScannerStatus>();
   apiMock.mockApiClient.getScannerStatus.expectCallWith().returns(promise);
   const { result } = render(1000);
   expect(result.current).toBeUndefined();

--- a/apps/vx-scan/frontend/src/hooks/use_precinct_scanner_status.ts
+++ b/apps/vx-scan/frontend/src/hooks/use_precinct_scanner_status.ts
@@ -1,6 +1,7 @@
-import { Scan } from '@votingworks/api';
 import { Optional } from '@votingworks/types';
 import { useCancelablePromise } from '@votingworks/ui';
+// eslint-disable-next-line vx/gts-no-import-export-type
+import type { PrecinctScannerStatus } from '@votingworks/vx-scan-backend';
 import { useRef, useState } from 'react';
 import useInterval from 'use-interval';
 import { useApiClient } from '../api/api';
@@ -8,9 +9,9 @@ import { POLLING_INTERVAL_FOR_SCANNER_STATUS_MS } from '../config/globals';
 
 export function usePrecinctScannerStatus(
   interval: number | false = POLLING_INTERVAL_FOR_SCANNER_STATUS_MS
-): Optional<Scan.PrecinctScannerStatus> {
+): Optional<PrecinctScannerStatus> {
   const apiClient = useApiClient();
-  const [status, setStatus] = useState<Scan.PrecinctScannerStatus>();
+  const [status, setStatus] = useState<PrecinctScannerStatus>();
   const isFetchingStatus = useRef(false);
   const makeCancelable = useCancelablePromise();
 

--- a/apps/vx-scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/vx-scan/frontend/src/screens/election_manager_screen.tsx
@@ -18,8 +18,9 @@ import {
 } from '@votingworks/ui';
 import { assert } from '@votingworks/utils';
 import React, { useCallback, useContext, useState } from 'react';
-import { Scan } from '@votingworks/api';
 import { Logger, LogSource } from '@votingworks/logging';
+// eslint-disable-next-line vx/gts-no-import-export-type
+import type { PrecinctScannerStatus } from '@votingworks/vx-scan-backend';
 import { CalibrateScannerModal } from '../components/calibrate_scanner_modal';
 import { ExportBackupModal } from '../components/export_backup_modal';
 import { ExportResultsModal } from '../components/export_results_modal';
@@ -31,7 +32,7 @@ import { SetMarkThresholdsModal } from '../components/set_mark_thresholds_modal'
 export const SELECT_PRECINCT_TEXT = 'Select a precinct for this device…';
 
 export interface ElectionManagerScreenProps {
-  scannerStatus: Scan.PrecinctScannerStatus;
+  scannerStatus: PrecinctScannerStatus;
   isTestMode: boolean;
   pollsState: PollsState;
   updatePrecinctSelection(precinctSelection: PrecinctSelection): Promise<void>;

--- a/apps/vx-scan/frontend/src/screens/scan_error_screen.tsx
+++ b/apps/vx-scan/frontend/src/screens/scan_error_screen.tsx
@@ -1,7 +1,11 @@
 import React, { useEffect } from 'react';
 import { Text } from '@votingworks/ui';
 import { throwIllegalValue } from '@votingworks/utils';
-import { Scan } from '@votingworks/api';
+// eslint-disable-next-line vx/gts-no-import-export-type
+import type {
+  InvalidInterpretationReason,
+  PrecinctScannerErrorType,
+} from '@votingworks/vx-scan-backend';
 import { TimesCircle } from '../components/graphics';
 import {
   CenteredLargeProse,
@@ -11,7 +15,7 @@ import { ScannedBallotCount } from '../components/scanned_ballot_count';
 import { useSound } from '../hooks/use_sound';
 
 interface Props {
-  error?: Scan.InvalidInterpretationReason | Scan.PrecinctScannerErrorType;
+  error?: InvalidInterpretationReason | PrecinctScannerErrorType;
   isTestMode: boolean;
   scannedBallotCount: number;
   restartRequired?: boolean;

--- a/apps/vx-scan/frontend/test/helpers/helpers.ts
+++ b/apps/vx-scan/frontend/test/helpers/helpers.ts
@@ -1,6 +1,7 @@
 import userEvent from '@testing-library/user-event';
 import { screen } from '@testing-library/react';
-import { Scan } from '@votingworks/api';
+// eslint-disable-next-line vx/gts-no-import-export-type
+import type { PrecinctScannerStatus } from '@votingworks/vx-scan-backend';
 import { CARD_POLLING_INTERVAL } from '../../src/config/globals';
 
 export async function authenticateElectionManagerCard(): Promise<void> {
@@ -16,8 +17,8 @@ export async function authenticateElectionManagerCard(): Promise<void> {
 }
 
 export function scannerStatus(
-  props: Partial<Scan.GetPrecinctScannerStatusResponse> = {}
-): Scan.GetPrecinctScannerStatusResponse {
+  props: Partial<PrecinctScannerStatus> = {}
+): PrecinctScannerStatus {
   return {
     state: 'no_paper',
     ballotsCounted: 0,

--- a/apps/vx-scan/frontend/test/helpers/mock_api_client.ts
+++ b/apps/vx-scan/frontend/test/helpers/mock_api_client.ts
@@ -1,4 +1,3 @@
-import { Scan } from '@votingworks/api';
 import { electionSampleDefinition } from '@votingworks/fixtures';
 import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 import {
@@ -9,15 +8,22 @@ import {
 } from '@votingworks/types';
 import { createMockClient } from '@votingworks/grout-test-utils';
 // eslint-disable-next-line vx/gts-no-import-export-type
-import type { Api } from '@votingworks/vx-scan-backend';
+import type {
+  Api,
+  PrecinctScannerConfig,
+  PrecinctScannerStatus,
+} from '@votingworks/vx-scan-backend';
 
-const defaultConfig: Scan.PrecinctScannerConfig = {
-  ...Scan.InitialPrecinctScannerConfig,
+const defaultConfig: PrecinctScannerConfig = {
+  isSoundMuted: false,
+  isTestMode: true,
+  pollsState: 'polls_closed_initial',
+  ballotCountWhenBallotBagLastReplaced: 0,
   electionDefinition: electionSampleDefinition,
   precinctSelection: ALL_PRECINCTS_SELECTION,
 };
 
-export const statusNoPaper: Scan.PrecinctScannerStatus = {
+export const statusNoPaper: PrecinctScannerStatus = {
   state: 'no_paper',
   canUnconfigure: false,
   ballotsCounted: 0,
@@ -33,7 +39,7 @@ export function createApiMock() {
   return {
     mockApiClient,
 
-    expectGetConfig(config: Partial<Scan.PrecinctScannerConfig> = {}): void {
+    expectGetConfig(config: Partial<PrecinctScannerConfig> = {}): void {
       mockApiClient.getConfig.expectCallWith().resolves({
         ...defaultConfig,
         ...config,
@@ -50,10 +56,7 @@ export function createApiMock() {
       mockApiClient.setTestMode.expectCallWith({ isTestMode }).resolves();
     },
 
-    expectGetScannerStatus(
-      status: Scan.PrecinctScannerStatus,
-      times = 1
-    ): void {
+    expectGetScannerStatus(status: PrecinctScannerStatus, times = 1): void {
       for (let i = 0; i < times; i += 1) {
         mockApiClient.getScannerStatus.expectCallWith().resolves(status);
       }

--- a/frontends/bsd/src/screens/ballot_eject_screen.tsx
+++ b/frontends/bsd/src/screens/ballot_eject_screen.tsx
@@ -3,6 +3,7 @@ import {
   AdjudicationReason,
   Contest,
   PageInterpretation,
+  Side,
 } from '@votingworks/types';
 import { Scan } from '@votingworks/api';
 import { assert } from '@votingworks/utils';
@@ -236,7 +237,7 @@ export function BallotEjectScreen({
 
   for (const reviewPageInfo of [
     {
-      side: 'front' as Scan.Side,
+      side: 'front' as Side,
       imageUrl: reviewInfo.interpreted.front.image.url,
       interpretation: reviewInfo.interpreted.front.interpretation,
       layout: reviewInfo.layouts.front,
@@ -245,7 +246,7 @@ export function BallotEjectScreen({
         reviewInfo.interpreted.front.adjudicationFinishedAt,
     },
     {
-      side: 'back' as Scan.Side,
+      side: 'back' as Side,
       imageUrl: reviewInfo.interpreted.back.image.url,
       interpretation: reviewInfo.interpreted.back.interpretation,
       layout: reviewInfo.layouts.back,

--- a/frontends/bsd/src/screens/dashboard_screen.test.tsx
+++ b/frontends/bsd/src/screens/dashboard_screen.test.tsx
@@ -1,12 +1,13 @@
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Scan } from '@votingworks/api';
+import { AdjudicationStatus } from '@votingworks/types';
 import { createMemoryHistory } from 'history';
 import React from 'react';
 import { Router } from 'react-router-dom';
 import { DashboardScreen } from './dashboard_screen';
 
-const noneLeftAdjudicationStatus: Scan.AdjudicationStatus = {
+const noneLeftAdjudicationStatus: AdjudicationStatus = {
   adjudicated: 0,
   remaining: 0,
 };

--- a/frontends/bsd/src/screens/dashboard_screen.tsx
+++ b/frontends/bsd/src/screens/dashboard_screen.tsx
@@ -6,6 +6,7 @@ import { Scan } from '@votingworks/api';
 
 import { Modal, Text } from '@votingworks/ui';
 import { assert } from '@votingworks/utils';
+import { BatchInfo } from '@votingworks/types';
 import { Prose } from '../components/prose';
 import { Table, TD } from '../components/table';
 import { Button } from '../components/button';
@@ -43,8 +44,7 @@ export function DashboardScreen({
   const batchCount = batches.length;
   const ballotCount = batches.reduce((result, b) => result + b.count, 0);
 
-  const [pendingDeleteBatch, setPendingDeleteBatchId] =
-    useState<Scan.BatchInfo>();
+  const [pendingDeleteBatch, setPendingDeleteBatchId] = useState<BatchInfo>();
   const [isDeletingBatch, setIsDeletingBatch] = useState(false);
   const [deleteBatchError, setDeleteBatchError] = useState<string>();
 

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -8,6 +8,8 @@ import {
   Id,
   IdSchema,
   Iso8601Date,
+  Iso8601Timestamp,
+  Iso8601TimestampSchema,
   NewType,
   Optional,
   safeParse,
@@ -1054,6 +1056,38 @@ export const AdjudicationInfoSchema: z.ZodSchema<AdjudicationInfo> = z.object({
   enabledReasons: z.array(AdjudicationReasonSchema),
   enabledReasonInfos: z.array(AdjudicationReasonInfoSchema),
   ignoredReasonInfos: z.array(AdjudicationReasonInfoSchema),
+});
+
+export interface AdjudicationStatus {
+  adjudicated: number;
+  remaining: number;
+}
+
+export const AdjudicationStatusSchema: z.ZodSchema<AdjudicationStatus> =
+  z.object({
+    adjudicated: z.number(),
+    remaining: z.number(),
+  });
+
+export type Side = 'front' | 'back';
+export const SideSchema = z.union([z.literal('front'), z.literal('back')]);
+
+export interface BatchInfo {
+  id: string;
+  label: string;
+  startedAt: Iso8601Timestamp;
+  endedAt?: Iso8601Timestamp;
+  error?: string;
+  count: number;
+}
+
+export const BatchInfoSchema: z.ZodSchema<BatchInfo> = z.object({
+  id: IdSchema,
+  label: z.string(),
+  startedAt: Iso8601TimestampSchema,
+  endedAt: z.optional(Iso8601TimestampSchema),
+  error: z.optional(z.string()),
+  count: z.number().nonnegative(),
 });
 
 export interface InlineBallotImage {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,6 @@ importers:
       sort-package-json: ^1.50.0
   apps/vx-scan/backend:
     dependencies:
-      '@votingworks/api': link:../../../libs/api
       '@votingworks/ballot-encoder': link:../../../libs/ballot-encoder
       '@votingworks/ballot-interpreter-nh': link:../../../libs/ballot-interpreter-nh
       '@votingworks/ballot-interpreter-vx': link:../../../libs/ballot-interpreter-vx
@@ -107,7 +106,6 @@ importers:
       '@types/zip-stream': workspace:*
       '@typescript-eslint/eslint-plugin': ^5.37.0
       '@typescript-eslint/parser': ^5.37.0
-      '@votingworks/api': workspace:*
       '@votingworks/ballot-encoder': workspace:*
       '@votingworks/ballot-interpreter-nh': workspace:*
       '@votingworks/ballot-interpreter-vx': workspace:*
@@ -174,7 +172,6 @@ importers:
       '@types/react-dom': 17.0.13
       '@types/react-router-dom': 5.1.7
       '@types/styled-components': 5.1.9
-      '@votingworks/api': link:../../../libs/api
       '@votingworks/ballot-interpreter-vx': link:../../../libs/ballot-interpreter-vx
       '@votingworks/fixtures': link:../../../libs/fixtures
       '@votingworks/grout': link:../../../libs/grout
@@ -282,7 +279,6 @@ importers:
       '@typescript-eslint/eslint-plugin': ^5.37.0
       '@typescript-eslint/parser': ^5.37.0
       '@vitejs/plugin-react': ^1.3.2
-      '@votingworks/api': workspace:*
       '@votingworks/ballot-interpreter-vx': workspace:*
       '@votingworks/fixtures': workspace:*
       '@votingworks/grout': workspace:*

--- a/services/scan/src/store.ts
+++ b/services/scan/src/store.ts
@@ -2,12 +2,12 @@
 // The durable datastore for CVRs and configuration info.
 //
 
-import { Scan } from '@votingworks/api';
 import { generateBallotPageLayouts } from '@votingworks/ballot-interpreter-nh';
 import { interpretTemplate } from '@votingworks/ballot-interpreter-vx';
 import { Bindable, Client as DbClient } from '@votingworks/db';
 import { pdfToImages } from '@votingworks/image-utils';
 import {
+  AdjudicationStatus,
   AnyContest,
   BallotMetadata,
   BallotMetadataSchema,
@@ -17,6 +17,7 @@ import {
   BallotPageMetadata,
   BallotPaperSize,
   BallotSheetInfo,
+  BatchInfo,
   ElectionDefinition,
   getBallotStyle,
   getContests,
@@ -36,6 +37,7 @@ import {
   safeParseElectionDefinition,
   safeParseJson,
   SheetOf,
+  Side,
 } from '@votingworks/types';
 import { assert } from '@votingworks/utils';
 import { Buffer } from 'buffer';
@@ -780,7 +782,7 @@ export class Store {
 
   getBallotFilenames(
     sheetId: string,
-    side: Scan.Side
+    side: Side
   ): { original: string; normalized: string } | undefined {
     const row = this.client.one<[string]>(
       `
@@ -945,7 +947,7 @@ export class Store {
   /**
    * Gets all batches, including their sheet count.
    */
-  batchStatus(): Scan.BatchInfo[] {
+  batchStatus(): BatchInfo[] {
     interface SqliteBatchInfo {
       id: string;
       label: string;
@@ -995,7 +997,7 @@ export class Store {
   /**
    * Gets adjudication status.
    */
-  adjudicationStatus(): Scan.AdjudicationStatus {
+  adjudicationStatus(): AdjudicationStatus {
     const { remaining } = this.client.one(`
         select count(*) as remaining
         from sheets


### PR DESCRIPTION

## Overview
Task: #2814 
There were a bunch of types that were used by the scan service but only applied to the precinct scanner. Now that VxScan is its own contained app, those types can live within the backend and be imported by the frontend.

There were also a few shared scanning types that I moved into libs/types. Now libs/api/scan only contains types used by VxCentralScan, so when we convert it to the new app-based architecture, we can similarly move those types into the app.

## Demo Video or Screenshot
N/A

## Testing Plan 
- Existing tests

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
