### PR TITLE
feat(grout): Allow sync methods to not return a Promise

### DIFF
--- a/apps/vx-scan/backend/src/app.ts
+++ b/apps/vx-scan/backend/src/app.ts
@@ -107,8 +107,7 @@ function buildApi(
       return ok();
     },
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    async getConfig(): Promise<PrecinctScannerConfig> {
+    getConfig(): PrecinctScannerConfig {
       return {
         electionDefinition: store.getElectionDefinition(),
         precinctSelection: store.getPrecinctSelection(),
@@ -121,10 +120,7 @@ function buildApi(
       };
     },
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    async unconfigureElection(input: {
-      ignoreBackupRequirement?: boolean;
-    }): Promise<void> {
+    unconfigureElection(input: { ignoreBackupRequirement?: boolean }): void {
       assert(
         input.ignoreBackupRequirement || store.getCanUnconfigure(),
         'Attempt to unconfigure without backup'
@@ -133,10 +129,9 @@ function buildApi(
       workspace.reset();
     },
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    async setPrecinctSelection(input: {
+    setPrecinctSelection(input: {
       precinctSelection: PrecinctSelection;
-    }): Promise<void> {
+    }): void {
       assert(
         store.getBallotsCounted() === 0,
         'Attempt to change precinct selection after ballots have been cast'
@@ -145,20 +140,17 @@ function buildApi(
       workspace.resetElectionSession();
     },
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    async setMarkThresholdOverrides(input: {
+    setMarkThresholdOverrides(input: {
       markThresholdOverrides?: MarkThresholds;
-    }): Promise<void> {
+    }): void {
       store.setMarkThresholdOverrides(input.markThresholdOverrides);
     },
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    async setIsSoundMuted(input: { isSoundMuted: boolean }): Promise<void> {
+    setIsSoundMuted(input: { isSoundMuted: boolean }): void {
       store.setIsSoundMuted(input.isSoundMuted);
     },
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    async setTestMode(input: { isTestMode: boolean }): Promise<void> {
+    setTestMode(input: { isTestMode: boolean }): void {
       workspace.resetElectionSession();
       store.setTestMode(input.isTestMode);
     },
@@ -246,8 +238,7 @@ function buildApi(
       return castVoteRecords;
     },
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    async getScannerStatus(): Promise<PrecinctScannerStatus> {
+    getScannerStatus(): PrecinctScannerStatus {
       const machineStatus = machine.status();
       const ballotsCounted = store.getBallotsCounted();
       const canUnconfigure = store.getCanUnconfigure();
@@ -277,13 +268,11 @@ function buildApi(
       machine.scan();
     },
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    async acceptBallot(): Promise<void> {
+    acceptBallot(): void {
       machine.accept();
     },
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    async returnBallot(): Promise<void> {
+    returnBallot(): void {
       machine.return();
     },
 

--- a/libs/grout/README.md
+++ b/libs/grout/README.md
@@ -25,20 +25,20 @@ interface Person {
 
 // Create an API definition by building an object with async methods.
 const api = grout.createApi({
-  // Each method should return a Promise. The data returned should be simple TS
-  // values - not fancy class instances. Values that can be easily serialized to
-  // JSON. More details on this below.
-  async getAllPeople(): Promise<Person[]> {
+  // Each method should return simple TS values - not fancy class instances.
+  // Values that can be easily serialized to JSON. More details on this below.
+  getAllPeople(): Person[] {
     return store.getAllPeople(); // Assume this accesses the database, etc.
   },
 
   // Methods can take input, but it must be packaged into a single object.
   // Think of it like using named parameters, or React component props.
-  async getPersonByName(input: { name: string }): Promise<Person | undefined> {
+  getPersonByName(input: { name: string }): Person | undefined {
     return store.getPersonByName(input.name);
   },
 
-  // For known errors (e.g. invalid input), use a Result type so that the client
+  // Async methods are supported, just wrap the return type with a Promise. For
+  // known errors (e.g. invalid input), use a Result type so that the client is
   // forced to handle them explicitly.
   async updatePersonAge(input: {
     name: string;
@@ -81,7 +81,8 @@ const baseUrl = '/api';
 // Create the client using MyApi as a type parameter.
 const apiClient = grout.createClient<MyApi>({ baseUrl });
 
-// Now we can call the API methods we defined as normal functions.
+// Now we can call the API methods we defined as normal functions. Note that all
+// the methods are async now, since there's a network request involved.
 await apiClient.getAllPeople(); // => [{ name: 'Alice', age: 99 }, ...]
 await apiClient.getPersonByName({ name: 'Bob' }); // => { name: 'Bob', age: 42 }
 await apiClient.updatePersonAge({ name: 'Bob', age: 43 }); // => ok()

--- a/libs/grout/src/grout.test.ts
+++ b/libs/grout/src/grout.test.ts
@@ -37,9 +37,7 @@ test('registers Express routes for an API', async () => {
     async getAllPeople(): Promise<Person[]> {
       return store.people;
     },
-    async getPersonByName(input: {
-      name: string;
-    }): Promise<Person | undefined> {
+    getPersonByName(input: { name: string }): Person | undefined {
       return store.people.find((person) => person.name === input.name);
     },
     async createPerson(input: { person: Person }) {

--- a/libs/grout/src/server.ts
+++ b/libs/grout/src/server.ts
@@ -10,8 +10,8 @@ const debug = rootDebug.extend('server');
  * A Grout RPC method.
  *
  * A method must take either no arguments or a single object argument (which
- * is intended to be used as a dictionary of named parameters). The return value
- * must be a Promise.
+ * is intended to be used as a dictionary of named parameters). It may be either
+ * sync or async (i.e. return a plain value or a Promise).
  *
  * Method input and output values must be serializable to JSON and
  * deserializable from JSON. Grout supports built-in JSON types as well as some
@@ -19,15 +19,14 @@ const debug = rootDebug.extend('server');
  * specifics.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AnyRpcMethod = (input: any) => Promise<any>;
+export type AnyRpcMethod = (input: any) => any;
 // Notes(jonah):
 // - We can't enforce the constraints on method input at compile time, because
 //  function argument subtyping is contravariant, meaning that for an RPC method to
 //  be a subtype of AnyRpcMethod, its input must be a supertype of
-//  Parameters<AnyRPCMethod>. Function return value subtyping is covariant, which
-//  is why we can enforce the Promise constraint there. Maybe there's another
-//  approach that would work, but I couldn't figure it out. Instead I opted to
-//  just put in runtime checks during serialization/deserialization.
+//  Parameters<AnyRPCMethod>. Maybe there's another approach that would work,
+//  but I couldn't figure it out. Instead I opted to just put in runtime checks
+//  during serialization/deserialization.
 //
 // - There are a few reasons behind having one single input argument object:
 //   - Input parameters will be named in the serialized JSON, which will
@@ -55,7 +54,7 @@ export type Api<Methods extends AnyMethods> = Methods;
 export type AnyApi = Api<AnyMethods>;
 
 /**
- * Helper to extract the method type from an API definition type
+ * Helper to extract the method types from an API definition type
  */
 export type inferApiMethods<SomeApi extends AnyApi> = SomeApi extends Api<
   infer Methods

--- a/libs/grout/test-utils/src/mock_client.test.ts
+++ b/libs/grout/test-utils/src/mock_client.test.ts
@@ -4,8 +4,7 @@ import { createApi, createClient } from '@votingworks/grout';
 import { createMockClient } from './mock_client';
 
 const api = createApi({
-  // eslint-disable-next-line @typescript-eslint/require-await
-  async add(input: { num1: number; num2: number }): Promise<number> {
+  add(input: { num1: number; num2: number }): number {
     return input.num1 + input.num2;
   },
   // eslint-disable-next-line @typescript-eslint/require-await
@@ -19,6 +18,9 @@ test('creates a mock client', () => {
   // A mock client has a mock function for each method
   expectTypeOf(mockClient.add).toEqualTypeOf<
     MockFunction<(input: { num1: number; num2: number }) => Promise<number>>
+  >();
+  expectTypeOf(mockClient.sqrt).toEqualTypeOf<
+    MockFunction<(input: { num: number }) => Promise<number>>
   >();
   // A mock client can pass as a real client
   expectTypeOf(mockClient).toMatchTypeOf(

--- a/libs/grout/test-utils/src/mock_client.ts
+++ b/libs/grout/test-utils/src/mock_client.ts
@@ -3,10 +3,15 @@ import {
   MockFunction,
   MockFunctionError,
 } from '@votingworks/test-utils';
-import { AnyApi, AnyMethods, inferApiMethods } from '@votingworks/grout';
+import {
+  AnyApi,
+  AnyMethods,
+  AsyncFunction,
+  inferApiMethods,
+} from '@votingworks/grout';
 
 type MockMethods<Methods extends AnyMethods> = {
-  [Method in keyof Methods]: MockFunction<Methods[Method]>;
+  [Method in keyof Methods]: MockFunction<AsyncFunction<Methods[Method]>>;
 };
 
 interface MockHelpers {


### PR DESCRIPTION
## Overview
Task: #2858 

Many of our RPC methods won't actually be async functions on the backend
since we use a sync db interface. This small change allows those
methods to be defined sync in the server and still be typed as async
functions in the client.

## Demo Video or Screenshot
N/A

## Testing Plan 
- Updated tests

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
