### PR TITLE
feat(grout): Log unexpected errors to console to show stack trace

### DIFF
--- a/libs/grout/src/grout.test.ts
+++ b/libs/grout/src/grout.test.ts
@@ -90,6 +90,7 @@ test('registers Express routes for an API', async () => {
 });
 
 test('sends a 500 for unexpected errors', async () => {
+  const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
   const api = createApi({
     async getStuff(): Promise<number> {
       throw new Error('Unexpected error');
@@ -105,6 +106,11 @@ test('sends a 500 for unexpected errors', async () => {
 
   await expect(client.getStuff()).rejects.toThrow('Unexpected error');
   await expect(client.doStuff()).rejects.toThrow('Not even an Error');
+
+  expect(consoleErrorSpy).toHaveBeenCalledTimes(2);
+  expect(consoleErrorSpy).toHaveBeenCalledWith(new Error('Unexpected error'));
+  expect(consoleErrorSpy).toHaveBeenCalledWith('Not even an Error');
+
   server.close();
 });
 

--- a/libs/grout/src/server.ts
+++ b/libs/grout/src/server.ts
@@ -166,6 +166,8 @@ export function buildRouter(
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         debug(`Error: ${message}`);
+        // eslint-disable-next-line no-console
+        console.error(error); // To aid debugging, log the full error with stack trace
         response.status(500).json({ message });
       }
     });


### PR DESCRIPTION
## Overview
Task: #2858 

To aid debugging unexpected errors, make sure we log the actual error so we can see a stack trace.

## Demo Video or Screenshot
N/A

## Testing Plan 
- Added unit test

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
