### PR TITLE
feat(ui): Change listener hooks

### DIFF
--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -60,6 +60,7 @@
   },
   "devDependencies": {
     "@codemod/parser": "^1.0.6",
+    "@tanstack/react-query": "^4.22.0",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^12.1.5",
     "@testing-library/react-hooks": "^8.0.0-alpha.1",

--- a/libs/ui/src/hooks/use_change_listener.test.ts
+++ b/libs/ui/src/hooks/use_change_listener.test.ts
@@ -1,0 +1,183 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { mockFunction } from '@votingworks/test-utils';
+import { UseQueryResult } from '@tanstack/react-query';
+import {
+  useExternalStateChangeListener,
+  useQueryChangeListener,
+} from './use_change_listener';
+
+describe('useExternalStateChangeListener', () => {
+  test('calls the changeHandler function when the state changes', () => {
+    const changeHandler =
+      mockFunction<(newState: string, previousState?: string) => void>(
+        'changeHandler'
+      );
+
+    changeHandler.expectCallWith('state 1', undefined).returns();
+    const { rerender } = renderHook(
+      (state) => useExternalStateChangeListener(state, changeHandler),
+      { initialProps: 'state 1' }
+    );
+
+    changeHandler.expectCallWith('state 2', 'state 1').returns();
+    rerender('state 2');
+
+    // When state doesn't change, the changeHandler is not called
+    rerender('state 2');
+
+    changeHandler.expectCallWith('state 3', 'state 2').returns();
+    rerender('state 3');
+
+    changeHandler.assertComplete();
+  });
+
+  test('works with objects using value equality', () => {
+    const changeHandler =
+      mockFunction<
+        (newState: { a: number }, previousState?: { a: number }) => void
+      >('changeHandler');
+
+    changeHandler.expectCallWith({ a: 1 }, undefined).returns();
+    const { rerender } = renderHook(
+      (state) => useExternalStateChangeListener(state, changeHandler),
+      { initialProps: { a: 1 } }
+    );
+
+    changeHandler.expectCallWith({ a: 2 }, { a: 1 }).returns();
+    rerender({ a: 2 });
+
+    // When object values don't change, even if object identity changes, the changeHandler is not called
+    rerender({ a: 2 });
+
+    changeHandler.expectCallWith({ a: 3 }, { a: 2 }).returns();
+    rerender({ a: 3 });
+
+    changeHandler.assertComplete();
+  });
+
+  test('works with async changeHandler', () => {
+    const changeHandler =
+      mockFunction<(newState: string, previousState?: string) => Promise<void>>(
+        'changeHandler'
+      );
+
+    changeHandler.expectCallWith('state 1', undefined).resolves();
+    const { rerender } = renderHook(
+      (state) => useExternalStateChangeListener(state, changeHandler),
+      { initialProps: 'state 1' }
+    );
+
+    changeHandler.expectCallWith('state 2', 'state 1').resolves();
+    rerender('state 2');
+
+    changeHandler.assertComplete();
+  });
+});
+
+describe('useQueryChangeListener', () => {
+  test('calls the changeHandler function when the query data changes', () => {
+    const changeHandler =
+      mockFunction<(newData: string, previousData?: string) => void>(
+        'changeHandler'
+      );
+
+    changeHandler.expectCallWith('data 1', undefined).returns();
+    const { rerender } = renderHook(
+      (data) => {
+        const mockQuery = {
+          isSuccess: true,
+          data,
+        } as unknown as UseQueryResult<string>;
+        return useQueryChangeListener(mockQuery, changeHandler);
+      },
+      { initialProps: 'data 1' }
+    );
+
+    changeHandler.expectCallWith('data 2', 'data 1').returns();
+    rerender('data 2');
+
+    // When data doesn't change, the changeHandler is not called
+    rerender('data 2');
+
+    changeHandler.expectCallWith('data 3', 'data 2').returns();
+    rerender('data 3');
+
+    changeHandler.assertComplete();
+  });
+
+  test('works with objects using value equality', () => {
+    const changeHandler =
+      mockFunction<
+        (newData: { a: number }, previousData?: { a: number }) => void
+      >('changeHandler');
+
+    changeHandler.expectCallWith({ a: 1 }, undefined).returns();
+    const { rerender } = renderHook(
+      (data) => {
+        const mockQuery = {
+          isSuccess: true,
+          data,
+        } as unknown as UseQueryResult<{ a: number }>;
+        return useQueryChangeListener(mockQuery, changeHandler);
+      },
+      { initialProps: { a: 1 } }
+    );
+
+    changeHandler.expectCallWith({ a: 2 }, { a: 1 }).returns();
+    rerender({ a: 2 });
+
+    // When object values don't change, even if object identity changes, the changeHandler is not called
+    rerender({ a: 2 });
+
+    changeHandler.expectCallWith({ a: 3 }, { a: 2 }).returns();
+    rerender({ a: 3 });
+
+    changeHandler.assertComplete();
+  });
+
+  test('works with async changeHandler', () => {
+    const changeHandler =
+      mockFunction<(newData: string, previousData?: string) => Promise<void>>(
+        'changeHandler'
+      );
+
+    changeHandler.expectCallWith('data 1', undefined).resolves();
+    const { rerender } = renderHook(
+      (data) => {
+        const mockQuery = {
+          isSuccess: true,
+          data,
+        } as unknown as UseQueryResult<string>;
+        return useQueryChangeListener(mockQuery, changeHandler);
+      },
+      { initialProps: 'data 1' }
+    );
+
+    changeHandler.expectCallWith('data 2', 'data 1').resolves();
+    rerender('data 2');
+
+    changeHandler.assertComplete();
+  });
+
+  test("doesn't call the changeHandler function when the query is not successful", () => {
+    const changeHandler =
+      mockFunction<(newData: string, previousData?: string) => void>(
+        'changeHandler'
+      );
+
+    const { rerender } = renderHook(
+      (data) => {
+        const mockQuery = {
+          isSuccess: false,
+          data,
+        } as unknown as UseQueryResult<string>;
+        return useQueryChangeListener(mockQuery, changeHandler);
+      },
+      { initialProps: undefined }
+    );
+
+    rerender();
+
+    changeHandler.assertComplete();
+  });
+});

--- a/libs/ui/src/hooks/use_change_listener.ts
+++ b/libs/ui/src/hooks/use_change_listener.ts
@@ -48,13 +48,13 @@ export function useExternalStateChangeListener<State>(
  */
 export function useQueryChangeListener<Data>(
   query: UseQueryResult<Data>,
-  changeHandler: (newData: Data, previousData?: Data) => void
+  changeHandler: (newData: Data, previousData?: Data) => void | Promise<void>
 ): void {
   const previousData = useRef<Data>();
 
   useEffect(() => {
     if (query.isSuccess && !deepEqual(previousData.current, query.data)) {
-      changeHandler(query.data, previousData.current);
+      void changeHandler(query.data, previousData.current);
       previousData.current = query.data;
     }
   }, [query.isSuccess, query.data, changeHandler]);

--- a/libs/ui/src/hooks/use_change_listener.ts
+++ b/libs/ui/src/hooks/use_change_listener.ts
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from 'react';
+import deepEqual from 'deep-eql';
+// eslint-disable-next-line vx/gts-no-import-export-type
+import type { UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * Registers a handler that will be called whenever some external state changes
+ * (based on a deep equality check).
+ *
+ * Think of this like an event listener for events that are triggered outside of
+ * the on-screen UI (e.g. similar to how we can put an onChange handler on, say,
+ * a button, for a user event that is triggered in the UI).
+ *
+ * @deprecated Move the external state to the backend and use the
+ * useQueryChangeListener hook instead.
+ */
+export function useExternalStateChangeListener<State>(
+  currentState: State,
+  changeHandler: (
+    newState: State,
+    previousState?: State
+  ) => void | Promise<void>
+): void {
+  const previousState = useRef<State>();
+
+  useEffect(() => {
+    if (!deepEqual(previousState.current, currentState)) {
+      void changeHandler(currentState, previousState.current);
+      previousState.current = currentState;
+    }
+  }, [currentState, changeHandler]);
+}
+
+/**
+ * Registers a handler that will be called whenever the result of a useQuery
+ * hook changes (based on a deep equality check).
+ *
+ * Think of this like an event listener for events that are triggered outside of
+ * the on-screen UI (e.g. similar to how we can put an onChange handler on, say,
+ * a button, for a user event that is triggered in the UI).
+ *
+ * It can be combined with the refetchInterval option of useQuery to make the
+ * query poll for new data regularly.
+ *
+ * Example use cases:
+ * - Playing a sound when the scanner accepts a ballot
+ * - Redirecting to a new URL when a background task is complete
+ */
+export function useQueryChangeListener<Data>(
+  query: UseQueryResult<Data>,
+  changeHandler: (newData: Data, previousData?: Data) => void
+): void {
+  const previousData = useRef<Data>();
+
+  useEffect(() => {
+    if (query.isSuccess && !deepEqual(previousData.current, query.data)) {
+      changeHandler(query.data, previousData.current);
+      previousData.current = query.data;
+    }
+  }, [query.isSuccess, query.data, changeHandler]);
+}

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -11,6 +11,7 @@ export * from './globals';
 export * from './hand_marked_paper_ballot_prose';
 export * from './hooks/use_autocomplete';
 export * from './hooks/use_cancelable_promise';
+export * from './hooks/use_change_listener';
 export * from './hooks/use_devices';
 export * from './hooks/use_lock';
 export * from './hooks/use_mounted_state';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1205,8 +1205,8 @@ importers:
       express: 4.18.1
       glob: 8.0.3
       is-ci-cli: 2.1.2
-      jest: 26.6.0
-      jest-circus: 26.6.0
+      jest: 26.6.0_canvas@2.9.1
+      jest-circus: 26.6.0_canvas@2.9.1
       jest-environment-jsdom-sixteen: 1.0.3_canvas@2.9.1
       jest-junit: 14.0.1
       jest-resolve: 26.6.0
@@ -2874,6 +2874,7 @@ importers:
       zod: 3.14.4
     devDependencies:
       '@codemod/parser': 1.1.0
+      '@tanstack/react-query': 4.22.0_react-dom@17.0.1+react@17.0.1
       '@testing-library/jest-dom': 5.16.4
       '@testing-library/react': 12.1.5_react-dom@17.0.1+react@17.0.1
       '@testing-library/react-hooks': 8.0.0-alpha.1_react-dom@17.0.1+react@17.0.1
@@ -2931,6 +2932,7 @@ importers:
       typescript: 4.6.3
     specifiers:
       '@codemod/parser': ^1.0.6
+      '@tanstack/react-query': ^4.22.0
       '@testing-library/jest-dom': ^5.16.4
       '@testing-library/react': ^12.1.5
       '@testing-library/react-hooks': ^8.0.0-alpha.1
@@ -9665,7 +9667,7 @@ packages:
       jest-regex-util: 27.0.6
       jest-resolve: 27.3.1
       jest-resolve-dependencies: 27.3.1
-      jest-runner: 27.3.1
+      jest-runner: 27.3.1_canvas@2.9.1
       jest-runtime: 27.3.1
       jest-snapshot: 27.3.1
       jest-util: 27.3.1
@@ -9786,7 +9788,7 @@ packages:
       jest-regex-util: 27.5.1
       jest-resolve: 27.5.1
       jest-resolve-dependencies: 27.5.1
-      jest-runner: 27.5.1
+      jest-runner: 27.5.1_canvas@2.9.1
       jest-runtime: 27.5.1
       jest-snapshot: 27.5.1
       jest-util: 27.5.1
@@ -11199,6 +11201,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-zdt5lYWs1dZaA3IxJbCgtAfHZJScRZONpiLL7YkeOkrme5MfjQqTpjq7LYbzpyuwPOh2Jx68le0PLl57JFv5hQ==
+  /@tanstack/query-core/4.22.0:
+    dev: true
+    resolution:
+      integrity: sha512-OeLyBKBQoT265f5G9biReijeP8mBxNFwY7ZUu1dKL+YzqpG5q5z7J/N1eT8aWyKuhyDTiUHuKm5l+oIVzbtrjw==
   /@tanstack/react-query-devtools/4.3.9_c35f85980f456f36adab49b5c175683e:
     dependencies:
       '@tanstack/match-sorter-utils': 8.1.1
@@ -11232,6 +11238,24 @@ packages:
         optional: true
     resolution:
       integrity: sha512-JLaMOxoJTkiAu7QpevRCt2uI/0vd3E8K/rSlCuRgWlcW5DeJDFpDS5kfzmLO5MOcD97fgsJRrDbxDORxR1FdJA==
+  /@tanstack/react-query/4.22.0_react-dom@17.0.1+react@17.0.1:
+    dependencies:
+      '@tanstack/query-core': 4.22.0
+      react: 17.0.1
+      react-dom: 17.0.1_react@17.0.1
+      use-sync-external-store: 1.2.0_react@17.0.1
+    dev: true
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-native: '*'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+    resolution:
+      integrity: sha512-P9o+HjG42uB/xHR6dMsJaPhtZydSe4v0xdG5G/cEj1oHZAXelMlm67/rYJNQGKgBamKElKogj+HYGF+NY2yHYg==
   /@testing-library/cypress/8.0.3_cypress@10.3.1:
     dependencies:
       '@babel/runtime': 7.18.3
@@ -13943,7 +13967,7 @@ packages:
       integrity: sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==
   /axios/0.21.1_debug@4.3.1:
     dependencies:
-      follow-redirects: 1.14.1_debug@4.3.4
+      follow-redirects: 1.14.1_debug@4.3.1
     dev: false
     peerDependencies:
       debug: '*'
@@ -21574,7 +21598,9 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=
-  /follow-redirects/1.14.1:
+  /follow-redirects/1.14.1_debug@4.3.1:
+    dependencies:
+      debug: 4.3.1
     dev: false
     engines:
       node: '>=4.0'
@@ -22706,7 +22732,7 @@ packages:
   /http-proxy/1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.14.1
+      follow-redirects: 1.14.1_debug@4.3.1
       requires-port: 1.0.0
     dev: false
     engines:
@@ -23751,6 +23777,37 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-L2/Y9szN6FJPWFK8kzWXwfp+FOR7xq0cUL4lIsdbIdwz3Vh6P1nrpcqOleSzr28zOtSHQNV9Z7Tl+KkuK7t5Ng==
+  /jest-circus/26.6.0_canvas@2.9.1:
+    dependencies:
+      '@babel/traverse': 7.18.2
+      '@jest/environment': 26.6.2
+      '@jest/test-result': 26.6.2
+      '@jest/types': 26.6.2
+      '@types/babel__traverse': 7.17.1
+      '@types/node': 17.0.36
+      chalk: 4.1.2
+      co: 4.6.0
+      dedent: 0.7.0
+      expect: 26.6.2
+      is-generator-fn: 2.1.0
+      jest-each: 26.6.2
+      jest-matcher-utils: 26.6.2
+      jest-message-util: 26.6.2
+      jest-runner: 26.6.3_canvas@2.9.1
+      jest-runtime: 26.6.3_canvas@2.9.1
+      jest-snapshot: 26.6.2
+      jest-util: 26.6.2
+      prettier: 2.6.2
+      pretty-format: 26.6.2
+      stack-utils: 2.0.5
+      throat: 5.0.0
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      canvas: '*'
+    resolution:
+      integrity: sha512-L2/Y9szN6FJPWFK8kzWXwfp+FOR7xq0cUL4lIsdbIdwz3Vh6P1nrpcqOleSzr28zOtSHQNV9Z7Tl+KkuK7t5Ng==
   /jest-circus/27.3.1:
     dependencies:
       '@jest/environment': 27.3.1
@@ -24220,7 +24277,7 @@ packages:
       jest-jasmine2: 27.3.1
       jest-regex-util: 27.0.6
       jest-resolve: 27.3.1
-      jest-runner: 27.3.1
+      jest-runner: 27.3.1_canvas@2.9.1
       jest-util: 27.3.1
       jest-validate: 27.3.1
       micromatch: 4.0.4
@@ -24324,7 +24381,7 @@ packages:
       jest-jasmine2: 27.5.1
       jest-regex-util: 27.5.1
       jest-resolve: 27.5.1
-      jest-runner: 27.5.1
+      jest-runner: 27.5.1_canvas@2.9.1
       jest-util: 27.5.1
       jest-validate: 27.5.1
       micromatch: 4.0.5
@@ -25798,6 +25855,37 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-r4W6kBn6sPr3TBwQNmqE94mPlYVn7fLBseeJfo4E2uCTmAyDFm2O5DYAQAFP7Q3YfiA/bMwg8TVsciP7k0xOww==
+  /jest-runner/27.3.1_canvas@2.9.1:
+    dependencies:
+      '@jest/console': 27.3.1
+      '@jest/environment': 27.3.1
+      '@jest/test-result': 27.3.1
+      '@jest/transform': 27.3.1
+      '@jest/types': 27.2.5
+      '@types/node': 15.3.0
+      chalk: 4.1.2
+      emittery: 0.8.1
+      exit: 0.1.2
+      graceful-fs: 4.2.10
+      jest-docblock: 27.0.6
+      jest-environment-jsdom: 27.3.1_canvas@2.9.1
+      jest-environment-node: 27.3.1
+      jest-haste-map: 27.3.1
+      jest-leak-detector: 27.3.1
+      jest-message-util: 27.3.1
+      jest-resolve: 27.3.1
+      jest-runtime: 27.3.1
+      jest-util: 27.3.1
+      jest-worker: 27.3.1
+      source-map-support: 0.5.20
+      throat: 6.0.1
+    dev: true
+    engines:
+      node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
+    peerDependencies:
+      canvas: '*'
+    resolution:
+      integrity: sha512-r4W6kBn6sPr3TBwQNmqE94mPlYVn7fLBseeJfo4E2uCTmAyDFm2O5DYAQAFP7Q3YfiA/bMwg8TVsciP7k0xOww==
   /jest-runner/27.4.5:
     dependencies:
       '@jest/console': 27.4.2
@@ -25853,6 +25941,36 @@ packages:
     dev: true
     engines:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
+    resolution:
+      integrity: sha512-g4NPsM4mFCOwFKXO4p/H/kWGdJp9V8kURY2lX8Me2drgXqG7rrZAx5kv+5H7wtt/cdFIjhqYx1HrlqWHaOvDaQ==
+  /jest-runner/27.5.1_canvas@2.9.1:
+    dependencies:
+      '@jest/console': 27.5.1
+      '@jest/environment': 27.5.1
+      '@jest/test-result': 27.5.1
+      '@jest/transform': 27.5.1
+      '@jest/types': 27.5.1
+      '@types/node': 17.0.36
+      chalk: 4.1.2
+      emittery: 0.8.1
+      graceful-fs: 4.2.10
+      jest-docblock: 27.5.1
+      jest-environment-jsdom: 27.5.1_canvas@2.9.1
+      jest-environment-node: 27.5.1
+      jest-haste-map: 27.5.1
+      jest-leak-detector: 27.5.1
+      jest-message-util: 27.5.1
+      jest-resolve: 27.5.1
+      jest-runtime: 27.5.1
+      jest-util: 27.5.1
+      jest-worker: 27.5.1
+      source-map-support: 0.5.21
+      throat: 6.0.1
+    dev: true
+    engines:
+      node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
+    peerDependencies:
+      canvas: '*'
     resolution:
       integrity: sha512-g4NPsM4mFCOwFKXO4p/H/kWGdJp9V8kURY2lX8Me2drgXqG7rrZAx5kv+5H7wtt/cdFIjhqYx1HrlqWHaOvDaQ==
   /jest-runner/28.1.3:
@@ -26775,6 +26893,19 @@ packages:
     engines:
       node: '>= 10.14.2'
     hasBin: true
+    resolution:
+      integrity: sha512-jxTmrvuecVISvKFFhOkjsWRZV7sFqdSUAd1ajOKY+/QE/aLBVstsJ/dX8GczLzwiT6ZEwwmZqtCUHLHHQVzcfA==
+  /jest/26.6.0_canvas@2.9.1:
+    dependencies:
+      '@jest/core': 26.6.3_canvas@2.9.1
+      import-local: 3.1.0
+      jest-cli: 26.6.3_canvas@2.9.1
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    hasBin: true
+    peerDependencies:
+      canvas: '*'
     resolution:
       integrity: sha512-jxTmrvuecVISvKFFhOkjsWRZV7sFqdSUAd1ajOKY+/QE/aLBVstsJ/dX8GczLzwiT6ZEwwmZqtCUHLHHQVzcfA==
   /jest/26.6.3:
@@ -34144,7 +34275,7 @@ packages:
       babel-jest: 26.6.3_@babel+core@7.12.3
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 26.6.0
+      jest: 26.6.0_canvas@2.9.1
       jest-util: 28.1.3
       json5: 2.2.1
       lodash.memoize: 4.1.2
@@ -34671,7 +34802,6 @@ packages:
   /use-sync-external-store/1.2.0_react@17.0.1:
     dependencies:
       react: 17.0.1
-    dev: false
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
     resolution:


### PR DESCRIPTION
## Overview

Adds two new hooks to `libs/ui` for registering a change listener to run on external state changes. See hook documentation in the code for full explanation. The goal is to make a safer alternative to using a `useEffect` hook to try to listen to an external state change.

Uses one of these hooks in VxScan as an example.

## Demo Video or Screenshot
N/A

## Testing Plan
- Automated tests

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
