### PR TITLE
Try upgrading circleci orb version to fix integration test builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  browser-tools: circleci/browser-tools@1.1.0
+  browser-tools: circleci/browser-tools@1.4.1
 
 executors:
   nodejs-browsers:


### PR DESCRIPTION
## Overview
Upgrading the circleci `browser-tools` to v1.4.1 to fix the integration test failures that started yesterday.

Relevant issue here: https://github.com/CircleCI-Public/browser-tools-orb/issues/62