### PR TITLE
Avoid relying on env variables for election manager tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,6 @@ jobs:
       - run:
           name: Build
           command: |
-            cp .env frontends/election-manager/.env
             pnpm --dir frontends/election-manager build
       - run:
           name: Lint

--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -564,7 +564,12 @@ test('tabulating CVRs', async () => {
   const logger = fakeLogger();
   const { getByText, getAllByText, getByTestId, queryByText } =
     renderRootElement(
-      <App card={card} hardware={hardware} printer={printer} />,
+      <App
+        card={card}
+        hardware={hardware}
+        printer={printer}
+        converter="ms-sems"
+      />,
       { backend, logger }
     );
   jest.advanceTimersByTime(2000); // Cause the usb drive to be detected
@@ -764,7 +769,7 @@ test('tabulating CVRs with SEMS file', async () => {
   const card = new MemoryCard();
   const hardware = MemoryHardware.buildStandard();
   const { getByText, getByTestId, getAllByText } = renderRootElement(
-    <App card={card} hardware={hardware} />,
+    <App card={card} hardware={hardware} converter="ms-sems" />,
     { backend }
   );
   jest.advanceTimersByTime(2000);


### PR DESCRIPTION
A couple of our `election-manager` tests are passing in CI but not locally. In CI, we copy the `.env` file from the root of `vxsuite` to the root of the library. 

To avoid this confusion (speaking for myself, a confused lad), I'd prefer to remove the special treatment in CI and update the tests so that they are passed the necessary information within the test. Alternatively, we could update the `package.json` script to use the env variable, but I am not sure we will always want `REACT_APP_VX_CONVERTER=ms-sems` and don't want to be locked into that.