### PR TITLE
docs: update git version to 2.39.1

### DIFF
--- a/docs/commit_signing.md
+++ b/docs/commit_signing.md
@@ -28,15 +28,15 @@ Linux VM.
    details.
 5. [VM] Install Git v2.34+:
    1. Create and `cd` to a temp directory.
-   2. Download Git v2.39.0 source code:
-      `wget https://www.kernel.org/pub/software/scm/git/git-2.39.0.tar.gz`.
-   3. Unpack the source code: `tar -xzf git-2.39.0.tar.gz`.
-   4. `cd` into the unpacked directory: `cd git-2.39.0`.
+   2. Download Git v2.39.1 source code:
+      `wget https://www.kernel.org/pub/software/scm/git/git-2.39.1.tar.gz`.
+   3. Unpack the source code: `tar -xzf git-2.39.1.tar.gz`.
+   4. `cd` into the unpacked directory: `cd git-2.39.1`.
    5. Install dependencies:
       `sudo apt-get install libcurl4-openssl-dev gettext -y`.
    6. Make and install to your home directory: `make && make install` (see
       `INSTALL` for more options, or ensure `~/bin` is in your `PATH`).
-   7. Verify the installation: `git --version` (should be `2.39.0`).
+   7. Verify the installation: `git --version` (should be `2.39.1`).
 6. [Host] If you want to be able to sign commits in macOS, configure Git commit
    signing from the info screen of the SSH key you just created (the header will
    prompt you).

--- a/docs/commit_signing.md
+++ b/docs/commit_signing.md
@@ -26,14 +26,14 @@ Linux VM.
    **TWICE**, once as a signing key and once as an authentication key. If you
    have the 1Password extension for your browser it should offer to fill in the
    details.
-5. [VM] Install Git v2.34+:
+5. [VM] Install Git v2.39.1+:
    1. Create and `cd` to a temp directory.
    2. Download Git v2.39.1 source code:
       `wget https://www.kernel.org/pub/software/scm/git/git-2.39.1.tar.gz`.
    3. Unpack the source code: `tar -xzf git-2.39.1.tar.gz`.
    4. `cd` into the unpacked directory: `cd git-2.39.1`.
    5. Install dependencies:
-      `sudo apt-get install libcurl4-openssl-dev gettext -y`.
+      `sudo apt-get install libssl-dev libcurl4-openssl-dev gettext -y`.
    6. Make and install to your home directory: `make && make install` (see
       `INSTALL` for more options, or ensure `~/bin` is in your `PATH`).
    7. Verify the installation: `git --version` (should be `2.39.1`).


### PR DESCRIPTION

## Overview
<!-- add a link to a GitHub Issue here -->
https://github.blog/2023-01-17-git-security-vulnerabilities-announced-2/

## Demo Video or Screenshot
n/a

## Testing Plan 
Ran the commands myself, verified `git --version` outputs `2.39.1`.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
