### PR TITLE
fix(lint): make `gts-spread-like-types` work with `new`

### DIFF
--- a/libs/eslint-plugin-vx/src/rules/gts_spread_like_types.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_spread_like_types.ts
@@ -86,6 +86,7 @@ const rule: TSESLint.RuleModule<
 
         switch (node.parent.type) {
           case AST_NODE_TYPES.CallExpression:
+          case AST_NODE_TYPES.NewExpression:
           case AST_NODE_TYPES.ArrayExpression: {
             const isIterable = isIterableType(spreadArgumentType);
             if (!isIterable) {

--- a/libs/eslint-plugin-vx/tests/rules/gts_spread_like_types.test.ts
+++ b/libs/eslint-plugin-vx/tests/rules/gts_spread_like_types.test.ts
@@ -30,6 +30,9 @@ ruleTester.run('gts-spread-like-types', rule, {
 
     // `any`
     `declare const a: any; [...a]`,
+
+    // classes
+    `new A(...[1])`,
   ],
   invalid: [
     // arrays


### PR DESCRIPTION
## Overview
<!-- add a link to a GitHub Issue here -->
I guess we don't use classes much. Before, this error would occur with e.g. `new A(...b)`:

```
Error: unexpected spread element parent: NewExpression
Occurred while linting /home/brian/code/vxsuite/libs/message-coder/src/literal_coder.ts:66
Rule: "vx/gts-spread-like-types"
```

## Demo Video or Screenshot
See above.

## Testing Plan
Fixed the issue and tested on the code that originally caused the above error.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
