### PR TITLE
[lbis/ui] Add color/size theme pickers to storybook

### DIFF
--- a/libs/ui/.storybook/preview.tsx
+++ b/libs/ui/.storybook/preview.tsx
@@ -1,7 +1,63 @@
 import React from 'react';
-import { DecoratorFunction, Parameters } from '@storybook/types';
+import { DecoratorFunction, GlobalTypes, InputType, Parameters } from '@storybook/types';
 
 import { AppBase } from '../src';
+import { ColorMode, SizeMode } from '@votingworks/types';
+
+// TODO: Find the storybook.js type declaration for this. Doesn't seem to be in
+// the @storybook/types repo.
+interface ToolbarItem<T> {
+  value: T, title: string, left?: string
+}
+
+type ColorModeToolBarItem = ToolbarItem<ColorMode>;
+
+type SizeModeToolBarItem = ToolbarItem<SizeMode>;
+
+const DEFAULT_SIZE_MODE: SizeMode = "l";
+const sizeThemeToolBarItems: Record<SizeMode, SizeModeToolBarItem> = {
+  s: { title: 'Size Theme - S', value: 's'},
+  m: { title: 'Size Theme - M', value: 'm'},
+  l: { title: 'Size Theme - L', value: 'l'},
+  xl: { title: 'Size Theme - XL', value: 'xl'},
+  legacy: { title: 'Size Theme - Legacy', value: 'legacy'},
+}
+
+const DEFAULT_COLOR_MODE: ColorMode = 'contrastHighLight';
+const colorThemeToolBarItems: Record<ColorMode, ColorModeToolBarItem> = {
+  contrastHighLight: { title: 'Color Theme - Light', value: 'contrastHighLight'},
+  contrastHighDark: { title: 'Color Theme - Dark', value: 'contrastHighDark'},
+  contrastMedium: { title: 'Color Theme - Medium', value: 'contrastMedium'},
+  legacy: { title: 'Color Theme - Legacy', value: 'legacy'},
+}
+
+/**
+ * Defines global types that are passed through the story context to all stories
+ * rendered in the storybook UI.
+ *
+ * The theme types are consumed below in {@link decorators} to set the VX theme
+ * for all components that support theming.
+ */
+export const globalTypes: GlobalTypes = {
+  colorMode: {
+    name: 'Color Theme',
+    toolbar: {
+      icon: 'sun',
+      items: Object.values(colorThemeToolBarItems),
+      dynamicTitle: true,
+    },
+    defaultValue: DEFAULT_COLOR_MODE,
+  },
+  sizeMode: {
+    name: 'Size Theme',
+    toolbar: {
+      icon: 'ruler',
+      items: Object.values(sizeThemeToolBarItems),
+      dynamicTitle: true,
+    },
+    defaultValue: DEFAULT_SIZE_MODE,
+  },
+};
 
 export const parameters: Parameters = {
   // This defines which prop name patterns are recognized as event handler
@@ -28,11 +84,16 @@ export const parameters: Parameters = {
 export const decorators: DecoratorFunction[] = [
   (
     Story: any, // Original type here isn't inferred as a React render function
+    context
   ) => {
     return (
-      <AppBase>
+      <AppBase
+        colorMode={context.globals.colorMode}
+        sizeMode={context.globals.sizeMode}
+      >
         <Story />
       </AppBase>
     );
   },
 ];
+

--- a/libs/ui/src/prose.stories.tsx
+++ b/libs/ui/src/prose.stories.tsx
@@ -1,13 +1,47 @@
+import React from 'react';
 import { LoremIpsum } from 'lorem-ipsum';
 import { Meta } from '@storybook/react';
 
 import { Prose, ProseProps } from './prose';
 
+const loremIpsum = new LoremIpsum({
+  sentencesPerParagraph: { max: 8, min: 5 },
+  wordsPerSentence: { max: 8, min: 5 },
+});
+
 const initialProps: ProseProps = {
-  children: new LoremIpsum({
-    sentencesPerParagraph: { max: 5, min: 3 },
-    wordsPerSentence: { max: 15, min: 10 },
-  }).generateParagraphs(1),
+  children: (
+    <React.Fragment>
+      <h1>{'<h1>'} Heading</h1>
+      <h2>{'<h2>'} Heading</h2>
+      <h3>{'<h3>'} Heading</h3>
+      <h4>{'<h4>'} Heading</h4>
+      <h5>{'<h5>'} Heading</h5>
+      <h6>{'<h6>'} Heading</h6>
+      <p>
+        {'<p>'}
+        {loremIpsum.generateParagraphs(1)}
+      </p>
+      <p>
+        {'<p>'}
+        {loremIpsum.generateParagraphs(1)}
+      </p>
+      <ul>
+        {'<ul>'} Unordered List
+        <li>{loremIpsum.generateWords(2)}</li>
+        <li>{loremIpsum.generateWords(2)}</li>
+        <li>{loremIpsum.generateWords(2)}</li>
+        <li>{loremIpsum.generateWords(2)}</li>
+      </ul>
+      <ol>
+        {'<ol>'} Ordered List
+        <li>{loremIpsum.generateWords(2)}</li>
+        <li>{loremIpsum.generateWords(2)}</li>
+        <li>{loremIpsum.generateWords(2)}</li>
+        <li>{loremIpsum.generateWords(2)}</li>
+      </ol>
+    </React.Fragment>
+  ),
 };
 
 const meta: Meta<typeof Prose> = {


### PR DESCRIPTION
## Overview
Related to: https://github.com/votingworks/vxsuite/issues/2743

- Updated storybook.js configuration to include global color and size theme pickers.
- Added a bit more content to the `<Prose>` demo to see how sub-elements change with different base font sizes.

## Demo Video or Screenshot

https://user-images.githubusercontent.com/264902/214975537-c27f24c0-0366-454d-a000-d66d1bbc9781.mov

## Testing Plan 
- Just manual testing for this one

## Checklist
- [n/a] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [n/a] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [n/a] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
