### PR TITLE
add bootstrap directive to Makefile

### DIFF
--- a/apps/vx-mark/backend/Makefile
+++ b/apps/vx-mark/backend/Makefile
@@ -4,5 +4,7 @@ FORCE:
 build: FORCE
 	pnpm install && pnpm build
 
+bootstrap: build
+
 run:
 	pnpm start


### PR DESCRIPTION
Our toplevel bootstrap script (`script/bootstrap`) expects each `Makefile` to include a `bootstrap` directive. This adds that to the vx-mark app backend. 