### PR TITLE
Move VxCentralScan auth to the backend

### DIFF
--- a/frontends/bsd/package.json
+++ b/frontends/bsd/package.json
@@ -51,6 +51,7 @@
     "extends": "react-app"
   },
   "dependencies": {
+    "@tanstack/react-query": "^4.22.0",
     "@types/jest": "24.0.11",
     "@types/node": "16.11.29",
     "@types/pluralize": "^0.0.29",
@@ -60,6 +61,7 @@
     "@votingworks/api": "workspace:*",
     "@votingworks/ballot-interpreter-vx": "workspace:*",
     "@votingworks/basics": "workspace:*",
+    "@votingworks/grout": "workspace:*",
     "@votingworks/logging": "workspace:*",
     "@votingworks/types": "workspace:*",
     "@votingworks/ui": "workspace:*",
@@ -106,6 +108,8 @@
     "@vitejs/plugin-react": "^1.3.2",
     "@votingworks/ballot-encoder": "workspace:*",
     "@votingworks/fixtures": "workspace:*",
+    "@votingworks/grout-test-utils": "workspace:*",
+    "@votingworks/scan": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
     "esbuild": "^0.15.10",
     "esbuild-runner": "^2.2.1",

--- a/frontends/bsd/prodserver/setupProxy.js
+++ b/frontends/bsd/prodserver/setupProxy.js
@@ -12,8 +12,8 @@ const { createProxyMiddleware: proxy } = require('http-proxy-middleware');
  * @param {import('connect').Server} app
  */
 module.exports = function (app) {
-  app.use(proxy('/card', { target: 'http://localhost:3001/' }));
   app.use(proxy('/central-scanner', { target: 'http://localhost:3002/' }));
+  app.use(proxy('/api', { target: 'http://localhost:3002/' }));
 
   app.use('/machine-config', (req, res, next) => {
     if (req.method === 'GET') {

--- a/frontends/bsd/src/api.ts
+++ b/frontends/bsd/src/api.ts
@@ -1,0 +1,76 @@
+import React from 'react';
+import type { Api } from '@votingworks/scan'; // eslint-disable-line vx/gts-no-import-export-type
+import {
+  AUTH_STATUS_POLLING_INTERVAL_MS,
+  QUERY_CLIENT_DEFAULT_OPTIONS,
+} from '@votingworks/ui';
+import {
+  QueryClient,
+  QueryKey,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
+import * as grout from '@votingworks/grout';
+
+export type ApiClient = grout.Client<Api>;
+
+export function createApiClient(): ApiClient {
+  return grout.createClient<Api>({ baseUrl: '/api' });
+}
+
+export const ApiClientContext = React.createContext<ApiClient | undefined>(
+  undefined
+);
+
+export function useApiClient(): ApiClient {
+  const apiClient = React.useContext(ApiClientContext);
+  if (!apiClient) {
+    throw new Error('ApiClientContext.Provider not found');
+  }
+  return apiClient;
+}
+
+export function createQueryClient(): QueryClient {
+  return new QueryClient({ defaultOptions: QUERY_CLIENT_DEFAULT_OPTIONS });
+}
+
+export const getAuthStatus = {
+  queryKey(): QueryKey {
+    return ['getAuthStatus'];
+  },
+  useQuery() {
+    const apiClient = useApiClient();
+    return useQuery(this.queryKey(), () => apiClient.getAuthStatus(), {
+      refetchInterval: AUTH_STATUS_POLLING_INTERVAL_MS,
+    });
+  },
+} as const;
+
+export const checkPin = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.checkPin, {
+      async onSuccess() {
+        // Because we poll auth status with high frequency, this invalidation isn't strictly
+        // necessary
+        await queryClient.invalidateQueries(getAuthStatus.queryKey());
+      },
+    });
+  },
+} as const;
+
+export const logOut = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.logOut, {
+      async onSuccess() {
+        // Because we poll auth status with high frequency, this invalidation isn't strictly
+        // necessary
+        await queryClient.invalidateQueries(getAuthStatus.queryKey());
+      },
+    });
+  },
+} as const;

--- a/frontends/bsd/src/app.test.tsx
+++ b/frontends/bsd/src/app.test.tsx
@@ -11,31 +11,33 @@ import { act } from 'react-dom/test-utils';
 import {
   electionSample,
   electionSampleDefinition,
-  electionSample2Definition,
 } from '@votingworks/fixtures';
 import {
+  fakeElectionManagerUser,
   fakeKiosk,
+  fakeSystemAdministratorUser,
   hasTextAcrossElements,
-  makeElectionManagerCard,
-  makeSystemAdministratorCard,
 } from '@votingworks/test-utils';
-import { MemoryCard, MemoryHardware } from '@votingworks/utils';
+import { MemoryHardware } from '@votingworks/utils';
 import { typedAs, sleep } from '@votingworks/basics';
 import { Scan } from '@votingworks/api';
-import {
-  ElectionManagerCardData,
-  PollWorkerCardData,
-} from '@votingworks/types';
+import { ElectionDefinition } from '@votingworks/types';
 import userEvent from '@testing-library/user-event';
-import { fakeLogger, LogEventId } from '@votingworks/logging';
+import { fakeLogger } from '@votingworks/logging';
 import { download } from './util/download';
 import { App } from './app';
 import { MachineConfigResponse } from './config/types';
+import { createMockApiClient, MockApiClient, setAuthStatus } from '../test/api';
 
 jest.mock('./util/download');
 
+let mockApiClient: MockApiClient;
+
 beforeEach(() => {
   window.kiosk = undefined;
+
+  mockApiClient = createMockApiClient();
+
   fetchMock.config.fallbackToNetwork = true;
   fetchMock.get(
     '/central-scanner/scan/status',
@@ -64,53 +66,38 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  mockApiClient.assertComplete();
   expect(fetchMock.done()).toEqual(true);
   expect(fetchMock.calls('unmatched')).toEqual([]);
 });
 
-async function authenticateWithSystemAdministratorCard(card: MemoryCard) {
-  await screen.findByText('VxCentralScan is Locked');
-  card.insertCard(makeSystemAdministratorCard());
-  await screen.findByText('Enter the card security code to unlock.');
-  userEvent.click(screen.getByText('1'));
-  userEvent.click(screen.getByText('2'));
-  userEvent.click(screen.getByText('3'));
-  userEvent.click(screen.getByText('4'));
-  userEvent.click(screen.getByText('5'));
-  userEvent.click(screen.getByText('6'));
-  await screen.findByText('Remove card to continue.');
-  card.removeCard();
+export async function authenticateAsSystemAdministrator(
+  lockScreenText = 'VxCentralScan is Locked'
+): Promise<void> {
+  // First verify that we're logged out
+  await screen.findByText(lockScreenText);
+
+  setAuthStatus(mockApiClient, {
+    status: 'logged_in',
+    user: fakeSystemAdministratorUser(),
+    programmableCard: { status: 'no_card' },
+  });
   await screen.findByText('Lock Machine');
 }
 
-async function authenticateWithElectionManagerCard(
-  card: MemoryCard,
-  options: { isMachineConfigured?: boolean } = {}
-) {
-  const isMachineConfigured = options.isMachineConfigured ?? true;
+export async function authenticateAsElectionManager(
+  electionDefinition: ElectionDefinition,
+  lockScreenText = 'VxCentralScan is Locked'
+): Promise<void> {
+  // First verify that we're logged out
+  await screen.findByText(lockScreenText);
 
-  await screen.findByText(
-    isMachineConfigured
-      ? 'VxCentralScan is Locked'
-      : 'VxCentralScan is Not Configured'
-  );
-  await screen.findByText(
-    isMachineConfigured
-      ? 'Insert Election Manager card to unlock.'
-      : 'Insert Election Manager card to configure.'
-  );
-  card.insertCard(
-    makeElectionManagerCard(electionSampleDefinition.electionHash)
-  );
-  await screen.findByText('Enter the card security code to unlock.');
-  userEvent.click(screen.getByText('1'));
-  userEvent.click(screen.getByText('2'));
-  userEvent.click(screen.getByText('3'));
-  userEvent.click(screen.getByText('4'));
-  userEvent.click(screen.getByText('5'));
-  userEvent.click(screen.getByText('6'));
-  await screen.findByText('Remove card to continue.');
-  card.removeCard();
+  setAuthStatus(mockApiClient, {
+    status: 'logged_in',
+    user: fakeElectionManagerUser({
+      electionHash: electionDefinition.electionHash,
+    }),
+  });
   await screen.findByText('Lock Machine');
 }
 
@@ -136,9 +123,8 @@ test('renders without crashing', async () => {
       body: getMarkThresholdOverridesResponseBody,
     });
 
-  const card = new MemoryCard();
   const hardware = MemoryHardware.buildStandard();
-  render(<App card={card} hardware={hardware} />);
+  render(<App apiClient={mockApiClient} hardware={hardware} />);
   await waitFor(() => fetchMock.called());
 });
 
@@ -160,10 +146,9 @@ test('shows a "Test mode" button if the app is in Live Mode', async () => {
       body: getMarkThresholdOverridesResponseBody,
     });
 
-  const card = new MemoryCard();
   const hardware = MemoryHardware.buildStandard();
-  const result = render(<App card={card} hardware={hardware} />);
-  await authenticateWithElectionManagerCard(card);
+  const result = render(<App apiClient={mockApiClient} hardware={hardware} />);
+  await authenticateAsElectionManager(electionSampleDefinition);
 
   fireEvent.click(result.getByText('Admin'));
 
@@ -188,24 +173,17 @@ test('shows a "Live mode" button if the app is in Test Mode', async () => {
       body: getMarkThresholdOverridesResponseBody,
     });
 
-  const card = new MemoryCard();
   const hardware = MemoryHardware.buildStandard();
   const logger = fakeLogger();
 
   const result = render(
-    <App card={card} hardware={hardware} logger={logger} />
+    <App apiClient={mockApiClient} hardware={hardware} logger={logger} />
   );
-  await authenticateWithElectionManagerCard(card);
+  await authenticateAsElectionManager(electionSampleDefinition);
 
   fireEvent.click(result.getByText('Admin'));
 
   result.getByText('Toggle to Live Mode');
-
-  expect(logger.log).toHaveBeenCalledWith(
-    LogEventId.AuthLogin,
-    'election_manager',
-    expect.objectContaining({ disposition: 'success' })
-  );
 });
 
 test('clicking Scan Batch will scan a batch', async () => {
@@ -235,12 +213,13 @@ test('clicking Scan Batch will scan a batch', async () => {
 
   const mockAlert = jest.fn();
   window.alert = mockAlert;
-  const card = new MemoryCard();
   const hardware = MemoryHardware.buildStandard();
 
   await act(async () => {
-    const { getByText } = render(<App card={card} hardware={hardware} />);
-    await authenticateWithElectionManagerCard(card);
+    const { getByText } = render(
+      <App apiClient={mockApiClient} hardware={hardware} />
+    );
+    await authenticateAsElectionManager(electionSampleDefinition);
     fireEvent.click(getByText('Scan New Batch'));
   });
 
@@ -291,13 +270,12 @@ test('clicking "Save CVRs" shows modal and makes a request to export', async () 
       { overwriteRoutes: true }
     );
 
-  const card = new MemoryCard();
   const hardware = MemoryHardware.buildStandard();
 
   const { getByText, queryByText, getByTestId } = render(
-    <App card={card} hardware={hardware} />
+    <App apiClient={mockApiClient} hardware={hardware} />
   );
-  await authenticateWithElectionManagerCard(card);
+  await authenticateAsElectionManager(electionSampleDefinition);
   const exportingModalText = 'No USB Drive Detected';
 
   await act(async () => {
@@ -346,14 +324,14 @@ test('configuring election from usb ballot package works end to end', async () =
       status: 200,
     });
 
-  const card = new MemoryCard();
   const hardware = MemoryHardware.buildStandard();
   const { getByText, getByTestId } = render(
-    <App card={card} hardware={hardware} />
+    <App apiClient={mockApiClient} hardware={hardware} />
   );
-  await authenticateWithElectionManagerCard(card, {
-    isMachineConfigured: false,
-  });
+  await authenticateAsElectionManager(
+    electionSampleDefinition,
+    'VxCentralScan is Not Configured'
+  );
 
   const mockKiosk = fakeKiosk();
   window.kiosk = mockKiosk;
@@ -417,7 +395,6 @@ test('configuring election from usb ballot package works end to end', async () =
 });
 
 test('authentication works', async () => {
-  const card = new MemoryCard();
   const hardware = MemoryHardware.buildStandard();
   hardware.setBatchScannerConnected(false);
   const getElectionResponseBody: Scan.GetElectionConfigResponse =
@@ -438,18 +415,9 @@ test('authentication works', async () => {
       body: getMarkThresholdOverridesResponseBody,
     });
 
-  render(<App card={card} hardware={hardware} />);
+  render(<App apiClient={mockApiClient} hardware={hardware} />);
 
   await screen.findByText('VxCentralScan is Locked');
-  const electionManagerCard: ElectionManagerCardData = {
-    t: 'election_manager',
-    h: electionSampleDefinition.electionHash,
-    p: '123456',
-  };
-  const pollWorkerCard: PollWorkerCardData = {
-    t: 'poll_worker',
-    h: electionSampleDefinition.electionHash,
-  };
 
   // Disconnect card reader
   act(() => {
@@ -462,10 +430,11 @@ test('authentication works', async () => {
   await screen.findByText('VxCentralScan is Locked');
 
   // Insert an election manager card and enter the wrong code.
-  card.insertCard(electionManagerCard);
-  await act(async () => {
-    await sleep(100);
+  setAuthStatus(mockApiClient, {
+    status: 'checking_passcode',
+    user: fakeElectionManagerUser(electionSampleDefinition),
   });
+  mockApiClient.checkPin.expectCallWith({ pin: '111111' }).resolves();
   await screen.findByText('Enter the card security code to unlock.');
   fireEvent.click(screen.getByText('1'));
   fireEvent.click(screen.getByText('1'));
@@ -473,29 +442,35 @@ test('authentication works', async () => {
   fireEvent.click(screen.getByText('1'));
   fireEvent.click(screen.getByText('1'));
   fireEvent.click(screen.getByText('1'));
+  setAuthStatus(mockApiClient, {
+    status: 'checking_passcode',
+    user: fakeElectionManagerUser(electionSampleDefinition),
+    wrongPasscodeEnteredAt: new Date(),
+  });
   await screen.findByText('Invalid code. Please try again.');
 
-  // Remove card and insert a pollworker card.
-  card.removeCard();
-  await act(async () => {
-    await sleep(100);
+  // Remove card and insert an invalid card, e.g. a pollworker card.
+  setAuthStatus(mockApiClient, {
+    status: 'logged_out',
+    reason: 'machine_locked',
   });
   await screen.findByText('VxCentralScan is Locked');
-  card.insertCard(pollWorkerCard);
-  await act(async () => {
-    await sleep(100);
+  setAuthStatus(mockApiClient, {
+    status: 'logged_out',
+    reason: 'user_role_not_allowed',
   });
   await screen.findByText('Invalid Card');
-  card.removeCard();
-  await act(async () => {
-    await sleep(100);
+  setAuthStatus(mockApiClient, {
+    status: 'logged_out',
+    reason: 'machine_locked',
   });
 
   // Insert election manager card and enter correct code.
-  card.insertCard(electionManagerCard);
-  await act(async () => {
-    await sleep(100);
+  setAuthStatus(mockApiClient, {
+    status: 'checking_passcode',
+    user: fakeElectionManagerUser(electionSampleDefinition),
   });
+  mockApiClient.checkPin.expectCallWith({ pin: '123456' }).resolves();
   await screen.findByText('Enter the card security code to unlock.');
   fireEvent.click(screen.getByText('1'));
   fireEvent.click(screen.getByText('2'));
@@ -505,39 +480,27 @@ test('authentication works', async () => {
   fireEvent.click(screen.getByText('6'));
 
   // 'Remove Card' screen is shown after successful authentication.
+  setAuthStatus(mockApiClient, {
+    status: 'remove_card',
+    user: fakeElectionManagerUser(electionSampleDefinition),
+  });
   await screen.findByText('Remove card to continue.');
   screen.getByText('VxCentralScan Unlocked');
 
   // Machine is unlocked when card removed
-  card.removeCard();
-  await act(async () => {
-    await sleep(100);
+  setAuthStatus(mockApiClient, {
+    status: 'logged_in',
+    user: fakeElectionManagerUser(electionSampleDefinition),
   });
   await screen.findByText('No Scanner');
-
-  // The card and other cards can be inserted with no impact.
-  card.insertCard(electionManagerCard);
-  await act(async () => {
-    await sleep(100);
-  });
-  await screen.findByText('No Scanner');
-  card.removeCard();
-  await act(async () => {
-    await sleep(100);
-  });
-  await screen.findByText('No Scanner');
-  card.insertCard(pollWorkerCard);
-  await act(async () => {
-    await sleep(100);
-  });
-  await screen.findByText('No Scanner');
-  card.removeCard();
-  await act(async () => {
-    await sleep(100);
-  });
 
   // Lock the machine
+  mockApiClient.logOut.expectCallWith().resolves();
   fireEvent.click(screen.getByText('Lock Machine'));
+  setAuthStatus(mockApiClient, {
+    status: 'logged_out',
+    reason: 'machine_locked',
+  });
   await screen.findByText('VxCentralScan is Locked');
 });
 
@@ -566,11 +529,10 @@ test('system administrator can log in and unconfigure machine', async () => {
       body: deleteElectionConfigResponseBody,
     });
 
-  const card = new MemoryCard();
   const hardware = MemoryHardware.buildStandard();
-  render(<App card={card} hardware={hardware} />);
+  render(<App apiClient={mockApiClient} hardware={hardware} />);
 
-  await authenticateWithSystemAdministratorCard(card);
+  await authenticateAsSystemAdministrator();
 
   screen.getByRole('button', { name: 'Reboot from USB' });
   screen.getByRole('button', { name: 'Reboot to BIOS' });
@@ -585,10 +547,12 @@ test('system administrator can log in and unconfigure machine', async () => {
       name: 'Yes, Delete Election Data',
     })
   );
+  fetchMock.get(
+    '/central-scanner/config/election',
+    { body: 'null' },
+    { overwriteRoutes: false }
+  );
   await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
-
-  userEvent.click(screen.getByText('Lock Machine'));
-  await screen.findByText('VxCentralScan is Locked');
 });
 
 test('election manager cannot auth onto machine with different election hash', async () => {
@@ -608,14 +572,14 @@ test('election manager cannot auth onto machine with different election hash', a
       body: getMarkThresholdOverridesResponseBody,
     });
 
-  const card = new MemoryCard();
   const hardware = MemoryHardware.buildStandard();
-  render(<App card={card} hardware={hardware} />);
+  render(<App apiClient={mockApiClient} hardware={hardware} />);
 
   await screen.findByText('VxCentralScan is Locked');
-  card.insertCard(
-    makeElectionManagerCard(electionSample2Definition.electionHash)
-  );
+  setAuthStatus(mockApiClient, {
+    status: 'logged_out',
+    reason: 'election_manager_wrong_election',
+  });
   await screen.findByText(
     'The inserted Election Manager card is programmed for another election and cannot be used to unlock this machine. ' +
       'Please insert a valid Election Manager or System Administrator card.'

--- a/frontends/bsd/src/app.tsx
+++ b/frontends/bsd/src/app.tsx
@@ -1,22 +1,30 @@
 import React from 'react';
-import { WebServiceCard, getHardware } from '@votingworks/utils';
+import { getHardware } from '@votingworks/utils';
 import { BrowserRouter } from 'react-router-dom';
-
 import { Logger, LogSource } from '@votingworks/logging';
 import { ColorMode } from '@votingworks/types';
-import { AppBase } from '@votingworks/ui';
+import { AppBase, ErrorBoundary, Prose, Text } from '@votingworks/ui';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AppRoot, AppRootProps } from './app_root';
+import {
+  ApiClient,
+  ApiClientContext,
+  createApiClient,
+  createQueryClient,
+} from './api';
 
 export interface Props {
-  card?: AppRootProps['card'];
   hardware?: AppRootProps['hardware'];
   logger?: AppRootProps['logger'];
+  apiClient?: ApiClient;
+  queryClient?: QueryClient;
 }
 
 export function App({
   hardware = getHardware(),
-  card = new WebServiceCard(),
   logger = new Logger(LogSource.VxCentralScanFrontend, window.kiosk),
+  apiClient = createApiClient(),
+  queryClient = createQueryClient(),
 }: Props): JSX.Element {
   // Copied from old App.css
   const baseFontSizePx = 24;
@@ -26,9 +34,25 @@ export function App({
 
   return (
     <BrowserRouter>
-      <AppBase colorMode={colorMode} legacyBaseFontSizePx={baseFontSizePx}>
-        <AppRoot hardware={hardware} card={card} logger={logger} />
-      </AppBase>
+      <ErrorBoundary
+        errorMessage={
+          <Prose textCenter>
+            <h1>Something went wrong</h1>
+            <Text>Please restart the machine.</Text>
+          </Prose>
+        }
+      >
+        <ApiClientContext.Provider value={apiClient}>
+          <QueryClientProvider client={queryClient}>
+            <AppBase
+              colorMode={colorMode}
+              legacyBaseFontSizePx={baseFontSizePx}
+            >
+              <AppRoot hardware={hardware} logger={logger} />
+            </AppBase>
+          </QueryClientProvider>
+        </ApiClientContext.Provider>
+      </ErrorBoundary>
     </BrowserRouter>
   );
 }

--- a/frontends/bsd/src/components/election_configuration.tsx
+++ b/frontends/bsd/src/components/election_configuration.tsx
@@ -22,9 +22,9 @@ import { MainNav } from './main_nav';
 import { Loading } from './loading';
 import { FileInputButton } from './file_input_button';
 import { AppContext } from '../contexts/app_context';
-
 import { Button } from './button';
 import { Table, TD } from './table';
+import { logOut } from '../api';
 
 const Image = styled.img`
   float: right;
@@ -61,6 +61,7 @@ export function ElectionConfiguration({
     useContext(AppContext);
   assert(isElectionManagerAuth(auth));
   const userRole = auth.user.role;
+  const logOutMutation = logOut.useMutation();
 
   async function acceptAutomaticallyChosenFile(
     file: KioskBrowser.FileSystemEntry
@@ -142,7 +143,7 @@ export function ElectionConfiguration({
 
   const mainNav = (
     <MainNav isTestMode={false}>
-      <Button small onPress={() => auth.logOut()}>
+      <Button small onPress={() => logOutMutation.mutate()}>
         Lock Machine
       </Button>
       <UsbControllerButton

--- a/frontends/bsd/src/components/export_results_modal.test.tsx
+++ b/frontends/bsd/src/components/export_results_modal.test.tsx
@@ -6,16 +6,16 @@ import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 import fetchMock from 'fetch-mock';
 
-import { Dipped, fakeKiosk, fakeUsbDrive } from '@votingworks/test-utils';
-import { MemoryStorage } from '@votingworks/utils';
-import { Logger, LogSource } from '@votingworks/logging';
+import { fakeKiosk, fakeUsbDrive } from '@votingworks/test-utils';
 import { safeParseJson } from '@votingworks/types';
 import { UsbDriveStatus } from '@votingworks/ui';
 import { assert } from '@votingworks/basics';
 import { ExportResultsModal } from './export_results_modal';
 import { fakeFileWriter } from '../../test/helpers/fake_file_writer';
-import { renderInAppContext } from '../../test/render_in_app_context';
-import { AppContext } from '../contexts/app_context';
+import {
+  renderInAppContext,
+  wrapInAppContext,
+} from '../../test/render_in_app_context';
 
 test('renders loading screen when usb drive is mounting or ejecting in export modal', () => {
   const usbStatuses: UsbDriveStatus[] = ['mounting', 'ejecting'];
@@ -152,29 +152,18 @@ test('render export modal when a usb drive is mounted as expected and allows aut
   expect(closeFn).toHaveBeenCalled();
 
   rerender(
-    <AppContext.Provider
-      value={{
-        electionDefinition,
-        machineConfig: {
-          machineId: '0001',
-          codeVersion: 'TEST',
-        },
+    wrapInAppContext(
+      <ExportResultsModal
+        onClose={closeFn}
+        electionDefinition={electionDefinition}
+        numberOfBallots={5}
+        isTestMode
+      />,
+      {
+        history,
         usbDriveStatus: 'ejected',
-        usbDriveEject: jest.fn(),
-        storage: new MemoryStorage(),
-        auth: Dipped.fakeElectionManagerAuth(),
-        logger: new Logger(LogSource.VxCentralScanFrontend),
-      }}
-    >
-      <Router history={history}>
-        <ExportResultsModal
-          onClose={closeFn}
-          electionDefinition={electionDefinition}
-          numberOfBallots={5}
-          isTestMode
-        />
-      </Router>
-    </AppContext.Provider>
+      }
+    )
   );
   getByText(
     'USB drive successfully ejected, you may now take it to VxAdmin for tabulation.'

--- a/frontends/bsd/src/contexts/app_context.ts
+++ b/frontends/bsd/src/contexts/app_context.ts
@@ -1,5 +1,5 @@
 import { LoggingUserRole, LogSource, Logger } from '@votingworks/logging';
-import { DippedSmartcardAuth, ElectionDefinition } from '@votingworks/types';
+import { DippedSmartCardAuth, ElectionDefinition } from '@votingworks/types';
 import { UsbDriveStatus } from '@votingworks/ui';
 import { MemoryStorage, Storage } from '@votingworks/utils';
 import { createContext } from 'react';
@@ -12,7 +12,7 @@ export interface AppContextInterface {
   electionDefinition?: ElectionDefinition;
   electionHash?: string;
   storage: Storage;
-  auth: DippedSmartcardAuth.Auth;
+  auth: DippedSmartCardAuth.AuthStatus;
   logger: Logger;
 }
 

--- a/frontends/bsd/src/screens/admin_actions_screen.tsx
+++ b/frontends/bsd/src/screens/admin_actions_screen.tsx
@@ -20,6 +20,7 @@ import { Prose } from '../components/prose';
 import { ToggleTestModeButton } from '../components/toggle_test_mode_button';
 import { SetMarkThresholdsModal } from '../components/set_mark_thresholds_modal';
 import { AppContext } from '../contexts/app_context';
+import { logOut } from '../api';
 
 export interface AdminActionScreenProps {
   unconfigureServer: () => Promise<void>;
@@ -52,6 +53,7 @@ export function AdminActionsScreen({
     useContext(AppContext);
   assert(isElectionManagerAuth(auth));
   const userRole = auth.user.role;
+  const logOutMutation = logOut.useMutation();
   const [isConfirmingUnconfigure, setIsConfirmingUnconfigure] = useState(false);
   const [isDoubleConfirmingUnconfigure, setIsDoubleConfirmingUnconfigure] =
     useState(false);
@@ -185,7 +187,7 @@ export function AdminActionsScreen({
           </Prose>
         </Main>
         <MainNav isTestMode={isTestMode}>
-          <Button small onPress={() => auth.logOut()}>
+          <Button small onPress={() => logOutMutation.mutate()}>
             Lock Machine
           </Button>
           <LinkButton small to="/">

--- a/frontends/bsd/test/api.ts
+++ b/frontends/bsd/test/api.ts
@@ -1,0 +1,28 @@
+import type { Api } from '@votingworks/scan'; // eslint-disable-line vx/gts-no-import-export-type
+import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
+import { DippedSmartCardAuth } from '@votingworks/types';
+
+export type MockApiClient = Omit<MockClient<Api>, 'getAuthStatus'> & {
+  // Because this is polled so frequently, we opt for a standard jest mock instead of a
+  // libs/test-utils mock since the latter requires every call to be explicitly mocked
+  getAuthStatus: jest.Mock;
+};
+
+export function createMockApiClient(): MockApiClient {
+  const mockApiClient = createMockClient<Api>();
+  // For some reason, using an object spread to override the getAuthStatus method breaks the rest
+  // of the mockApiClient, so we override like this instead
+  (mockApiClient.getAuthStatus as unknown as jest.Mock) = jest.fn(() =>
+    Promise.resolve({ status: 'logged_out', reason: 'machine_locked' })
+  );
+  return mockApiClient as unknown as MockApiClient;
+}
+
+export function setAuthStatus(
+  mockApiClient: MockApiClient,
+  authStatus: DippedSmartCardAuth.AuthStatus
+): void {
+  mockApiClient.getAuthStatus.mockImplementation(() =>
+    Promise.resolve(authStatus)
+  );
+}

--- a/frontends/bsd/tsconfig.json
+++ b/frontends/bsd/tsconfig.json
@@ -23,10 +23,13 @@
     { "path": "../../libs/basics/tsconfig.build.json" },
     { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../../libs/fixtures/tsconfig.build.json" },
+    { "path": "../../libs/grout/tsconfig.build.json" },
+    { "path": "../../libs/grout/test-utils/tsconfig.build.json" },
     { "path": "../../libs/logging/tsconfig.build.json" },
     { "path": "../../libs/test-utils/tsconfig.build.json" },
     { "path": "../../libs/types/tsconfig.build.json" },
     { "path": "../../libs/ui/tsconfig.build.json" },
-    { "path": "../../libs/utils/tsconfig.build.json" }
+    { "path": "../../libs/utils/tsconfig.build.json" },
+    { "path": "../../services/scan/tsconfig.build.json" }
   ]
 }

--- a/frontends/election-manager/prodserver/setupProxy.js
+++ b/frontends/election-manager/prodserver/setupProxy.js
@@ -15,7 +15,6 @@ const { dirname, join } = require('path');
  * @param {import('connect').Server} app
  */
 module.exports = function (app) {
-  app.use(proxy('/card', { target: 'http://localhost:3001/' }));
   app.use(proxy('/convert', { target: 'http://localhost:3003/' }));
   app.use(proxy('/admin', { target: 'http://localhost:3004/' }));
   app.use(proxy('/api', { target: 'http://localhost:3004/' }));

--- a/frontends/election-manager/src/api.ts
+++ b/frontends/election-manager/src/api.ts
@@ -1,6 +1,11 @@
 import React from 'react';
 import type { Api } from '@votingworks/admin'; // eslint-disable-line vx/gts-no-import-export-type
 import {
+  AUTH_STATUS_POLLING_INTERVAL_MS,
+  QUERY_CLIENT_DEFAULT_OPTIONS,
+} from '@votingworks/ui';
+import {
+  QueryClient,
   QueryKey,
   useMutation,
   useQuery,
@@ -26,7 +31,9 @@ export function useApiClient(): ApiClient {
   return apiClient;
 }
 
-const AUTH_STATUS_POLLING_INTERVAL_MS = 100;
+export function createQueryClient(): QueryClient {
+  return new QueryClient({ defaultOptions: QUERY_CLIENT_DEFAULT_OPTIONS });
+}
 
 export const getAuthStatus = {
   queryKey(): QueryKey {

--- a/frontends/election-manager/src/app.test.tsx
+++ b/frontends/election-manager/src/app.test.tsx
@@ -226,10 +226,8 @@ test('authentication works', async () => {
 
   // Disconnect card reader
   act(() => hardware.setCardReaderConnected(false));
-  await advanceTimersAndPromises(1);
   await screen.findByText('Card Reader Not Detected');
   act(() => hardware.setCardReaderConnected(true));
-  await advanceTimersAndPromises(1);
   await screen.findByText('VxAdmin is Locked');
 
   // Insert an election manager card and enter the wrong code.
@@ -261,19 +259,16 @@ test('authentication works', async () => {
     status: 'logged_out',
     reason: 'machine_locked',
   });
-  await advanceTimersAndPromises(1);
   await screen.findByText('VxAdmin is Locked');
   setAuthStatus(mockApiClient, {
     status: 'logged_out',
-    reason: 'invalid_user_on_card',
+    reason: 'user_role_not_allowed',
   });
-  await advanceTimersAndPromises(1);
   await screen.findByText('Invalid Card');
   setAuthStatus(mockApiClient, {
     status: 'logged_out',
     reason: 'machine_locked',
   });
-  await advanceTimersAndPromises(1);
 
   // Insert election manager card and enter correct code.
   setAuthStatus(mockApiClient, {
@@ -282,7 +277,6 @@ test('authentication works', async () => {
       electionHash: eitherNeitherElectionDefinition.electionHash,
     }),
   });
-  await advanceTimersAndPromises(1);
   mockApiClient.checkPin.expectCallWith({ pin: '123456' }).resolves();
   await screen.findByText('Enter the card security code to unlock.');
   fireEvent.click(screen.getByText('1'));

--- a/frontends/election-manager/src/app_root.tsx
+++ b/frontends/election-manager/src/app_root.tsx
@@ -65,10 +65,10 @@ export function AppRoot({
     codeVersion: '',
   });
 
-  const authStatus = getAuthStatus.useQuery();
+  const authStatusQuery = getAuthStatus.useQuery();
   const currentUserRole =
-    authStatus.data?.status === 'logged_in'
-      ? authStatus.data.user.role
+    authStatusQuery.data?.status === 'logged_in'
+      ? authStatusQuery.data.user.role
       : 'unknown';
 
   const store = useElectionManagerStore();
@@ -210,7 +210,7 @@ export function AppRoot({
     [logger, currentUserRole, clearCastVoteRecordFilesMutation, store]
   );
 
-  if (!authStatus.isSuccess || !currentElection.isSuccess) {
+  if (!authStatusQuery.isSuccess || !currentElection.isSuccess) {
     return null;
   }
 
@@ -234,7 +234,7 @@ export function AppRoot({
         isTabulationRunning,
         setIsTabulationRunning,
         generateExportableTallies,
-        auth: authStatus.data,
+        auth: authStatusQuery.data,
         machineConfig,
         hasCardReaderAttached: !!cardReader,
         hasPrinterAttached: !!printerInfo,

--- a/frontends/election-manager/src/index.tsx
+++ b/frontends/election-manager/src/index.tsx
@@ -2,7 +2,7 @@ import './polyfills';
 import React from 'react';
 import ReactDom from 'react-dom';
 import './i18n';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import {
   BooleanEnvironmentVariableName,
@@ -11,16 +11,11 @@ import {
   LocalStorage,
 } from '@votingworks/utils';
 import { Logger, LogSource } from '@votingworks/logging';
-import {
-  ErrorBoundary,
-  Prose,
-  QUERY_CLIENT_DEFAULT_OPTIONS,
-  Text,
-} from '@votingworks/ui';
+import { ErrorBoundary, Prose, Text } from '@votingworks/ui';
 import { App } from './app';
 import { ElectionManagerStoreAdminBackend } from './lib/backends';
 import { ServicesContext } from './contexts/services_context';
-import { ApiClientContext, createApiClient } from './api';
+import { ApiClientContext, createApiClient, createQueryClient } from './api';
 
 const storage = window.kiosk
   ? new KioskStorage(window.kiosk)
@@ -28,9 +23,7 @@ const storage = window.kiosk
 const logger = new Logger(LogSource.VxAdminFrontend, window.kiosk);
 const backend = new ElectionManagerStoreAdminBackend({ storage, logger });
 const apiClient = createApiClient();
-const queryClient = new QueryClient({
-  defaultOptions: QUERY_CLIENT_DEFAULT_OPTIONS,
-});
+const queryClient = createQueryClient();
 
 ReactDom.render(
   <React.StrictMode>

--- a/frontends/election-manager/test/render_in_app_context.tsx
+++ b/frontends/election-manager/test/render_in_app_context.tsx
@@ -71,8 +71,8 @@ interface RenderInAppContextParams {
   hasPrinterAttached?: boolean;
   logger?: Logger;
   backend?: ElectionManagerStoreBackend;
-  queryClient?: QueryClient;
   apiClient?: ApiClient;
+  queryClient?: QueryClient;
 }
 
 export function renderRootElement(
@@ -81,14 +81,16 @@ export function renderRootElement(
     backend = new ElectionManagerStoreMemoryBackend(),
     logger = fakeLogger(),
     storage = new MemoryStorage(),
-    queryClient = new QueryClient(),
     apiClient = createMockApiClient(),
+    // TODO: Determine why tests fail when using createQueryClient and, by extension,
+    // QUERY_CLIENT_DEFAULT_OPTIONS
+    queryClient = new QueryClient(),
   }: {
     backend?: ElectionManagerStoreBackend;
     logger?: Logger;
     storage?: Storage;
-    queryClient?: QueryClient;
     apiClient?: ApiClient;
+    queryClient?: QueryClient;
   } = {}
 ): RenderResult {
   return testRender(
@@ -132,8 +134,8 @@ export function renderInAppContext(
     hasPrinterAttached = true,
     logger = new Logger(LogSource.VxAdminFrontend),
     backend,
-    queryClient,
     apiClient,
+    queryClient,
   }: RenderInAppContextParams = {}
 ): RenderResult {
   return renderRootElement(

--- a/integration-testing/bsd/cypress/e2e/configuration.cy.ts
+++ b/integration-testing/bsd/cypress/e2e/configuration.cy.ts
@@ -1,4 +1,5 @@
 import { Buffer } from 'buffer';
+import { methodUrl } from '@votingworks/grout';
 import { sha256 } from 'js-sha256';
 
 const PIN = '000000';
@@ -33,8 +34,13 @@ function removeCard() {
   });
 }
 
+function logOut() {
+  cy.request('POST', methodUrl('logOut', 'http://localhost:3000/api'), {});
+}
+
 describe('BSD and services/Scan', () => {
   beforeEach(() => {
+    logOut();
     // Unconfigure services/scan
     cy.request('DELETE', '/central-scanner/config/election');
     mockElectionManagerCard();

--- a/integration-testing/bsd/package.json
+++ b/integration-testing/bsd/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@testing-library/cypress": "^8.0.3",
     "@votingworks/fixtures": "workspace:*",
+    "@votingworks/grout": "workspace:*",
     "buffer": "^6.0.3",
     "cypress": "^10.3.1",
     "js-sha256": "^0.9.0",

--- a/integration-testing/bsd/tsconfig.json
+++ b/integration-testing/bsd/tsconfig.json
@@ -17,7 +17,8 @@
   },
   "include": ["**/*.ts"],
   "references": [
+    { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../../libs/fixtures/tsconfig.build.json" },
-    { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" }
+    { "path": "../../libs/grout/tsconfig.build.json" }
   ]
 }

--- a/libs/ui/src/auth.ts
+++ b/libs/ui/src/auth.ts
@@ -1,0 +1,2 @@
+/* istanbul ignore next */
+export const AUTH_STATUS_POLLING_INTERVAL_MS = 100;

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -1,5 +1,6 @@
 /* istanbul ignore file */
 export * from './app_base';
+export * from './auth';
 export * from './bmd_paper_ballot';
 export * from './button';
 export * from './button_bar';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -781,6 +781,7 @@ importers:
 
   frontends/bsd:
     specifiers:
+      '@tanstack/react-query': ^4.22.0
       '@testing-library/jest-dom': ^5.16.4
       '@testing-library/react': ^12.1.5
       '@testing-library/user-event': ^13.2.1
@@ -808,7 +809,10 @@ importers:
       '@votingworks/ballot-interpreter-vx': workspace:*
       '@votingworks/basics': workspace:*
       '@votingworks/fixtures': workspace:*
+      '@votingworks/grout': workspace:*
+      '@votingworks/grout-test-utils': workspace:*
       '@votingworks/logging': workspace:*
+      '@votingworks/scan': workspace:*
       '@votingworks/test-utils': workspace:*
       '@votingworks/types': workspace:*
       '@votingworks/ui': workspace:*
@@ -873,6 +877,7 @@ importers:
       zip-stream: ^3.0.1
       zod: 3.14.4
     dependencies:
+      '@tanstack/react-query': 4.22.0_w7o5yyljkiidx2s2nzb26ottzu
       '@types/jest': 24.0.11
       '@types/node': 16.11.29
       '@types/pluralize': 0.0.29
@@ -882,6 +887,7 @@ importers:
       '@votingworks/api': link:../../libs/api
       '@votingworks/ballot-interpreter-vx': link:../../libs/ballot-interpreter-vx
       '@votingworks/basics': link:../../libs/basics
+      '@votingworks/grout': link:../../libs/grout
       '@votingworks/logging': link:../../libs/logging
       '@votingworks/types': link:../../libs/types
       '@votingworks/ui': link:../../libs/ui
@@ -927,6 +933,8 @@ importers:
       '@vitejs/plugin-react': 1.3.2
       '@votingworks/ballot-encoder': link:../../libs/ballot-encoder
       '@votingworks/fixtures': link:../../libs/fixtures
+      '@votingworks/grout-test-utils': link:../../libs/grout/test-utils
+      '@votingworks/scan': link:../../services/scan
       '@votingworks/test-utils': link:../../libs/test-utils
       esbuild: 0.15.10
       esbuild-runner: 2.2.1_esbuild@0.15.10
@@ -1331,6 +1339,7 @@ importers:
       '@typescript-eslint/eslint-plugin': ^5.37.0
       '@typescript-eslint/parser': ^5.37.0
       '@votingworks/fixtures': workspace:*
+      '@votingworks/grout': workspace:*
       buffer: ^6.0.3
       cypress: ^10.3.1
       eslint: ^8.23.1
@@ -1355,6 +1364,7 @@ importers:
     dependencies:
       '@testing-library/cypress': 8.0.3_cypress@10.3.1
       '@votingworks/fixtures': link:../../libs/fixtures
+      '@votingworks/grout': link:../../libs/grout
       buffer: 6.0.3
       cypress: 10.3.1
       js-sha256: 0.9.0
@@ -3399,7 +3409,7 @@ importers:
       '@types/better-sqlite3': ^7.4.3
       '@types/debug': ^4.1.7
       '@types/deep-eql': workspace:*
-      '@types/express': ^4.17.13
+      '@types/express': ^4.17.14
       '@types/fs-extra': ^9.0.6
       '@types/jest': ^26.0.6
       '@types/luxon': ^1.26.5
@@ -3412,6 +3422,7 @@ importers:
       '@typescript-eslint/eslint-plugin': ^5.37.0
       '@typescript-eslint/parser': ^5.37.0
       '@votingworks/api': workspace:*
+      '@votingworks/auth': workspace:*
       '@votingworks/ballot-encoder': workspace:*
       '@votingworks/ballot-interpreter-nh': workspace:*
       '@votingworks/ballot-interpreter-vx': workspace:*
@@ -3419,6 +3430,7 @@ importers:
       '@votingworks/data': workspace:*
       '@votingworks/db': workspace:*
       '@votingworks/fixtures': workspace:*
+      '@votingworks/grout': workspace:*
       '@votingworks/image-utils': workspace:*
       '@votingworks/logging': workspace:*
       '@votingworks/test-utils': workspace:*
@@ -3469,6 +3481,7 @@ importers:
       zod: 3.14.4
     dependencies:
       '@votingworks/api': link:../../libs/api
+      '@votingworks/auth': link:../../libs/auth
       '@votingworks/ballot-encoder': link:../../libs/ballot-encoder
       '@votingworks/ballot-interpreter-nh': link:../../libs/ballot-interpreter-nh
       '@votingworks/ballot-interpreter-vx': link:../../libs/ballot-interpreter-vx
@@ -3476,6 +3489,7 @@ importers:
       '@votingworks/data': link:../../libs/data
       '@votingworks/db': link:../../libs/db
       '@votingworks/fixtures': link:../../libs/fixtures
+      '@votingworks/grout': link:../../libs/grout
       '@votingworks/image-utils': link:../../libs/image-utils
       '@votingworks/logging': link:../../libs/logging
       '@votingworks/test-utils': link:../../libs/test-utils
@@ -3507,7 +3521,7 @@ importers:
       '@types/better-sqlite3': 7.4.3
       '@types/debug': 4.1.7
       '@types/deep-eql': link:../../libs/@types/deep-eql
-      '@types/express': 4.17.13
+      '@types/express': 4.17.14
       '@types/fs-extra': 9.0.6
       '@types/jest': 26.0.20
       '@types/luxon': 1.26.5
@@ -10742,12 +10756,6 @@ packages:
       '@babel/parser': 7.20.13
       '@babel/types': 7.20.7
 
-  /@types/babel__traverse/7.17.1:
-    resolution: {integrity: sha512-kVzjari1s2YVi77D3w1yuvohV2idweYXMCDzqBiVNN63TcDWrIlTVOYpqVrvbbyOE/IyzBoTKF0fdnLPEORFxA==}
-    dependencies:
-      '@babel/types': 7.20.7
-    dev: true
-
   /@types/babel__traverse/7.18.1:
     resolution: {integrity: sha512-FSdLaZh2UxaMuLp9lixWaHq/golWTRWOnRsAXzDTDSDOQLuZb1nsdCt6pJSPWSEQt2eFZ2YVk3oYhn+1kLMeMA==}
     dependencies:
@@ -10885,29 +10893,12 @@ packages:
   /@types/estree/0.0.51:
     resolution: {integrity: sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==}
 
-  /@types/express-serve-static-core/4.17.28:
-    resolution: {integrity: sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==}
-    dependencies:
-      '@types/node': 18.11.18
-      '@types/qs': 6.9.7
-      '@types/range-parser': 1.2.4
-    dev: true
-
   /@types/express-serve-static-core/4.17.31:
     resolution: {integrity: sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==}
     dependencies:
       '@types/node': 18.11.18
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
-
-  /@types/express/4.17.13:
-    resolution: {integrity: sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==}
-    dependencies:
-      '@types/body-parser': 1.19.2
-      '@types/express-serve-static-core': 4.17.28
-      '@types/qs': 6.9.7
-      '@types/serve-static': 1.13.10
-    dev: true
 
   /@types/express/4.17.14:
     resolution: {integrity: sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==}
@@ -11171,10 +11162,6 @@ packages:
     resolution: {integrity: sha512-vXOTGVSLR2jMw440moWTC7H19iUyLtP3Z1YTj7cSsubOICinjMxFeb/V57v9QdyyPGbbWolUFSSmSiRSn94tFw==}
     dev: true
 
-  /@types/mime/1.3.2:
-    resolution: {integrity: sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==}
-    dev: true
-
   /@types/mime/2.0.3:
     resolution: {integrity: sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==}
     dev: true
@@ -11382,13 +11369,6 @@ packages:
 
   /@types/semver/7.3.13:
     resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
-    dev: true
-
-  /@types/serve-static/1.13.10:
-    resolution: {integrity: sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==}
-    dependencies:
-      '@types/mime': 1.3.2
-      '@types/node': 18.11.18
     dev: true
 
   /@types/serve-static/1.15.0:
@@ -22977,11 +22957,11 @@ packages:
     resolution: {integrity: sha512-L2/Y9szN6FJPWFK8kzWXwfp+FOR7xq0cUL4lIsdbIdwz3Vh6P1nrpcqOleSzr28zOtSHQNV9Z7Tl+KkuK7t5Ng==}
     engines: {node: '>= 10.14.2'}
     dependencies:
-      '@babel/traverse': 7.18.2
+      '@babel/traverse': 7.19.1
       '@jest/environment': 26.6.2
       '@jest/test-result': 26.6.2
       '@jest/types': 26.6.2
-      '@types/babel__traverse': 7.17.1
+      '@types/babel__traverse': 7.18.1
       '@types/node': 18.11.18
       chalk: 4.1.2
       co: 4.6.0

--- a/services/admin/src/server.cvr_file_mode.test.ts
+++ b/services/admin/src/server.cvr_file_mode.test.ts
@@ -6,7 +6,7 @@ import { Application } from 'express';
 import request from 'supertest';
 import { dirSync } from 'tmp';
 import { buildApp } from './server';
-import { buildTestAuth } from '../test/utils';
+import { buildMockAuth } from '../test/utils';
 import { createWorkspace, Workspace } from './util/workspace';
 
 let app: Application;
@@ -17,7 +17,7 @@ let electionId: string;
 beforeEach(() => {
   jest.restoreAllMocks();
 
-  ({ auth } = buildTestAuth());
+  auth = buildMockAuth();
 
   workspace = createWorkspace(dirSync().name);
   workspace.store.getCurrentCvrFileModeForElection = jest.fn();

--- a/services/admin/src/server.printed_ballots.test.ts
+++ b/services/admin/src/server.printed_ballots.test.ts
@@ -7,7 +7,7 @@ import { Application } from 'express';
 import request from 'supertest';
 import { dirSync } from 'tmp';
 import { buildApp } from './server';
-import { buildTestAuth } from '../test/utils';
+import { buildMockAuth } from '../test/utils';
 import { createWorkspace, Workspace } from './util/workspace';
 
 let app: Application;
@@ -16,7 +16,7 @@ let workspace: Workspace;
 
 beforeEach(() => {
   jest.restoreAllMocks();
-  ({ auth } = buildTestAuth());
+  auth = buildMockAuth();
   workspace = createWorkspace(dirSync().name);
   app = buildApp({ auth, workspace });
 });

--- a/services/admin/src/server.ts
+++ b/services/admin/src/server.ts
@@ -839,13 +839,6 @@ export async function start({
   port = PORT,
   workspace,
 }: Partial<StartOptions>): Promise<Server> {
-  const auth = new DippedSmartCardAuthWithMemoryCard({
-    card: new WebServiceCard({ baseUrl: 'http://localhost:3001' }),
-    config: {
-      allowElectionManagersToAccessUnconfiguredMachines: false,
-    },
-  });
-
   let resolvedWorkspace = workspace;
 
   if (workspace) {
@@ -870,7 +863,17 @@ export async function start({
   resolvedWorkspace.clearUploads();
 
   /* istanbul ignore next */
-  const resolvedApp = app ?? buildApp({ auth, workspace: resolvedWorkspace });
+  const resolvedApp =
+    app ??
+    buildApp({
+      auth: new DippedSmartCardAuthWithMemoryCard({
+        card: new WebServiceCard({ baseUrl: 'http://localhost:3001' }),
+        config: {
+          allowElectionManagersToAccessUnconfiguredMachines: false,
+        },
+      }),
+      workspace: resolvedWorkspace,
+    });
 
   const server = resolvedApp.listen(port, async () => {
     await logger.log(LogEventId.ApplicationStartup, 'system', {

--- a/services/admin/src/server.writeins.test.ts
+++ b/services/admin/src/server.writeins.test.ts
@@ -7,7 +7,7 @@ import { Application } from 'express';
 import request from 'supertest';
 import { dirSync } from 'tmp';
 import { buildApp } from './server';
-import { buildTestAuth } from '../test/utils';
+import { buildMockAuth } from '../test/utils';
 import { createWorkspace, Workspace } from './util/workspace';
 
 let app: Application;
@@ -16,7 +16,7 @@ let workspace: Workspace;
 
 beforeEach(() => {
   jest.restoreAllMocks();
-  ({ auth } = buildTestAuth());
+  auth = buildMockAuth();
   workspace = createWorkspace(dirSync().name);
   app = buildApp({ auth, workspace });
 });

--- a/services/admin/test/utils.ts
+++ b/services/admin/test/utils.ts
@@ -1,10 +1,6 @@
 import { Admin } from '@votingworks/api';
 import { CandidateContest } from '@votingworks/types';
-import {
-  DippedSmartCardAuthApi,
-  DippedSmartCardAuthWithMemoryCard,
-} from '@votingworks/auth';
-import { MemoryCard as MockCard } from '@votingworks/utils';
+import { DippedSmartCardAuthApi } from '@votingworks/auth';
 
 /**
  * Builds the group of options for adjudicating write-ins to official candidates
@@ -26,18 +22,16 @@ export function buildOfficialCandidatesWriteInAdjudicationOptionGroup(
 }
 
 /**
- * Builds an auth instance for tests
+ * Builds a mock auth instance
  */
-export function buildTestAuth(): {
-  auth: DippedSmartCardAuthApi;
-  card: MockCard;
-} {
-  const card = new MockCard();
-  const auth = new DippedSmartCardAuthWithMemoryCard({
-    card,
-    config: {
-      allowElectionManagersToAccessUnconfiguredMachines: false,
-    },
-  });
-  return { auth, card };
+export function buildMockAuth(): DippedSmartCardAuthApi {
+  return {
+    getAuthStatus: jest.fn(),
+    checkPin: jest.fn(),
+    logOut: jest.fn(),
+    programCard: jest.fn(),
+    unprogramCard: jest.fn(),
+    setElectionDefinition: jest.fn(),
+    clearElectionDefinition: jest.fn(),
+  };
 }

--- a/services/scan/package.json
+++ b/services/scan/package.json
@@ -2,6 +2,8 @@
   "name": "@votingworks/scan",
   "version": "0.1.0",
   "private": true,
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "files": [
     "build",
     "bin",
@@ -36,6 +38,7 @@
   },
   "dependencies": {
     "@votingworks/api": "workspace:*",
+    "@votingworks/auth": "workspace:*",
     "@votingworks/ballot-encoder": "workspace:*",
     "@votingworks/ballot-interpreter-nh": "workspace:*",
     "@votingworks/ballot-interpreter-vx": "workspace:*",
@@ -43,6 +46,7 @@
     "@votingworks/data": "workspace:*",
     "@votingworks/db": "workspace:*",
     "@votingworks/fixtures": "workspace:*",
+    "@votingworks/grout": "workspace:*",
     "@votingworks/image-utils": "workspace:*",
     "@votingworks/logging": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
@@ -75,7 +79,7 @@
     "@types/better-sqlite3": "^7.4.3",
     "@types/debug": "^4.1.7",
     "@types/deep-eql": "workspace:*",
-    "@types/express": "^4.17.13",
+    "@types/express": "^4.17.14",
     "@types/fs-extra": "^9.0.6",
     "@types/jest": "^26.0.6",
     "@types/luxon": "^1.26.5",

--- a/services/scan/src/end_to_end.test.ts
+++ b/services/scan/src/end_to_end.test.ts
@@ -1,4 +1,5 @@
 import { Scan } from '@votingworks/api';
+import { DippedSmartCardAuthApi } from '@votingworks/auth';
 import { Exporter } from '@votingworks/data';
 import {
   asElectionDefinition,
@@ -14,7 +15,11 @@ import * as fsExtra from 'fs-extra';
 import * as path from 'path';
 import request from 'supertest';
 import { dirSync } from 'tmp';
-import { makeMockScanner, MockScanner } from '../test/util/mocks';
+import {
+  buildMockAuth,
+  makeMockScanner,
+  MockScanner,
+} from '../test/util/mocks';
 import { buildCentralScannerApp } from './central_scanner_app';
 import { Importer } from './importer';
 import { createWorkspace, Workspace } from './util/workspace';
@@ -35,18 +40,20 @@ const exporter = new Exporter({
 });
 
 let app: Application;
+let auth: DippedSmartCardAuthApi;
 let importer: Importer;
 let workspace: Workspace;
 let scanner: MockScanner;
 
 beforeEach(async () => {
+  auth = buildMockAuth();
   scanner = makeMockScanner();
   workspace = await createWorkspace(dirSync().name);
   importer = new Importer({
     workspace,
     scanner,
   });
-  app = await buildCentralScannerApp({ exporter, importer, workspace });
+  app = await buildCentralScannerApp({ auth, exporter, importer, workspace });
 });
 
 afterEach(async () => {

--- a/services/scan/src/end_to_end_hmpb.test.ts
+++ b/services/scan/src/end_to_end_hmpb.test.ts
@@ -15,9 +15,14 @@ import { join } from 'path';
 import request from 'supertest';
 import { dirSync } from 'tmp';
 import { Scan } from '@votingworks/api';
+import { DippedSmartCardAuthApi } from '@votingworks/auth';
 import * as choctawMockGeneral2020Fixtures from '../test/fixtures/choctaw-mock-general-election-2020';
 import * as stateOfHamilton from '../test/fixtures/state-of-hamilton';
-import { makeMockScanner, MockScanner } from '../test/util/mocks';
+import {
+  buildMockAuth,
+  makeMockScanner,
+  MockScanner,
+} from '../test/util/mocks';
 import { Importer } from './importer';
 import { createWorkspace, Workspace } from './util/workspace';
 import { buildCentralScannerApp } from './central_scanner_app';
@@ -55,16 +60,18 @@ const exporter = new Exporter({
   getUsbDrives: mockGetUsbDrives,
 });
 
+let auth: DippedSmartCardAuthApi;
 let workspace: Workspace;
 let scanner: MockScanner;
 let importer: Importer;
 let app: Application;
 
 beforeEach(async () => {
+  auth = buildMockAuth();
   workspace = await createWorkspace(dirSync().name);
   scanner = makeMockScanner();
   importer = new Importer({ workspace, scanner });
-  app = await buildCentralScannerApp({ exporter, importer, workspace });
+  app = await buildCentralScannerApp({ auth, exporter, importer, workspace });
 });
 
 afterEach(async () => {

--- a/services/scan/src/index.ts
+++ b/services/scan/src/index.ts
@@ -7,6 +7,8 @@ import { LoopScanner, parseBatchesFromEnv } from './loop_scanner';
 import { BatchScanner } from './fujitsu_scanner';
 import * as server from './server';
 
+export type { Api } from './central_scanner_app';
+
 // https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
 const dotenvPath = '.env';
 const dotenvFiles: string[] = [

--- a/services/scan/test/util/mocks.ts
+++ b/services/scan/test/util/mocks.ts
@@ -11,6 +11,7 @@ import { ChildProcess } from 'child_process';
 import { EventEmitter } from 'events';
 import { fileSync } from 'tmp';
 import { MaybeMocked, mocked } from 'ts-jest/dist/utils/testing';
+import { DippedSmartCardAuthApi } from '@votingworks/auth';
 import { BatchControl, BatchScanner } from '../../src/fujitsu_scanner';
 import { inlinePool, WorkerOps, WorkerPool } from '../../src/workers/pool';
 
@@ -191,4 +192,16 @@ export async function makeImageFile(): Promise<string> {
     height: 1,
   });
   return imageFile.name;
+}
+
+export function buildMockAuth(): DippedSmartCardAuthApi {
+  return {
+    getAuthStatus: jest.fn(),
+    checkPin: jest.fn(),
+    logOut: jest.fn(),
+    programCard: jest.fn(),
+    unprogramCard: jest.fn(),
+    setElectionDefinition: jest.fn(),
+    clearElectionDefinition: jest.fn(),
+  };
 }

--- a/services/scan/tsconfig.build.json
+++ b/services/scan/tsconfig.build.json
@@ -6,7 +6,8 @@
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",
-    "declaration": true
+    "declaration": true,
+    "declarationMap": true
   },
   "references": [
     { "path": "../../libs/api/tsconfig.build.json" },

--- a/services/scan/tsconfig.build.json
+++ b/services/scan/tsconfig.build.json
@@ -10,6 +10,7 @@
   },
   "references": [
     { "path": "../../libs/api/tsconfig.build.json" },
+    { "path": "../../libs/auth/tsconfig.build.json" },
     { "path": "../../libs/ballot-encoder/tsconfig.build.json" },
     { "path": "../../libs/ballot-interpreter-nh/tsconfig.build.json" },
     { "path": "../../libs/ballot-interpreter-vx/tsconfig.build.json" },
@@ -18,6 +19,7 @@
     { "path": "../../libs/db/tsconfig.build.json" },
     { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../../libs/fixtures/tsconfig.build.json" },
+    { "path": "../../libs/grout/tsconfig.build.json" },
     { "path": "../../libs/image-utils/tsconfig.build.json" },
     { "path": "../../libs/logging/tsconfig.build.json" },
     { "path": "../../libs/test-utils/tsconfig.build.json" },

--- a/services/scan/tsconfig.json
+++ b/services/scan/tsconfig.json
@@ -5,6 +5,7 @@
   "compilerOptions": {
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
+    "composite": true,
     "esModuleInterop": true,
     "lib": ["dom", "dom.iterable", "esnext"],
     "module": "commonjs",
@@ -17,6 +18,7 @@
   },
   "references": [
     { "path": "../../libs/api/tsconfig.build.json" },
+    { "path": "../../libs/auth/tsconfig.build.json" },
     { "path": "../../libs/ballot-encoder/tsconfig.build.json" },
     { "path": "../../libs/ballot-interpreter-nh/tsconfig.build.json" },
     { "path": "../../libs/ballot-interpreter-vx/tsconfig.build.json" },
@@ -25,6 +27,7 @@
     { "path": "../../libs/db/tsconfig.build.json" },
     { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../../libs/fixtures/tsconfig.build.json" },
+    { "path": "../../libs/grout/tsconfig.build.json" },
     { "path": "../../libs/image-utils/tsconfig.build.json" },
     { "path": "../../libs/logging/tsconfig.build.json" },
     { "path": "../../libs/test-utils/tsconfig.build.json" },


### PR DESCRIPTION
_Recommend reviewing by commit_

## Overview

Issue links: https://github.com/votingworks/vxsuite/issues/2901

This PR moves VxCentralScan auth to the backend, using the backend dipped smart card auth logic set up in https://github.com/votingworks/vxsuite/pull/2960.

## Testing

- [x] Updated test suites
- [x] Manually tested VxCentralScan auth

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ Intentionally skipping and revisiting in later PRs
- [x] I have added JSDoc comments to any newly introduced exports