### PR TITLE
test: suppress non-useful React 17 error in tests

### DIFF
--- a/apps/vx-mark/frontend/src/setupTests.tsx
+++ b/apps/vx-mark/frontend/src/setupTests.tsx
@@ -9,9 +9,11 @@ import {
   expectTestToEndWithAllPrintsAsserted,
   fakePrintElement,
   fakePrintElementWhenReady,
+  suppressReact17UnmountedWarning,
 } from '@votingworks/test-utils';
 
 configure({ asyncUtilTimeout: 5_000 });
+suppressReact17UnmountedWarning();
 
 jest.mock('@votingworks/ui', (): typeof import('@votingworks/ui') => {
   const original = jest.requireActual('@votingworks/ui');

--- a/apps/vx-scan/frontend/src/setupTests.ts
+++ b/apps/vx-scan/frontend/src/setupTests.ts
@@ -7,9 +7,11 @@ import {
   expectTestToEndWithAllPrintsAsserted,
   fakePrintElement,
   fakePrintElementWhenReady,
+  suppressReact17UnmountedWarning,
 } from '@votingworks/test-utils';
 
 configure({ asyncUtilTimeout: 5_000 });
+suppressReact17UnmountedWarning();
 
 jest.mock('@votingworks/ui', (): typeof import('@votingworks/ui') => {
   const original = jest.requireActual('@votingworks/ui');

--- a/frontends/bsd/src/setupTests.ts
+++ b/frontends/bsd/src/setupTests.ts
@@ -1,10 +1,12 @@
 import { configure } from '@testing-library/react';
+import { suppressReact17UnmountedWarning } from '@votingworks/test-utils';
 import fetchMock from 'fetch-mock';
 import jestFetchMock from 'jest-fetch-mock';
 import 'jest-styled-components';
 import { TextDecoder, TextEncoder } from 'util';
 
 configure({ asyncUtilTimeout: 5_000 });
+suppressReact17UnmountedWarning();
 
 beforeEach(() => {
   jestFetchMock.enableMocks();

--- a/frontends/election-manager/src/setupTests.ts
+++ b/frontends/election-manager/src/setupTests.ts
@@ -9,9 +9,11 @@ import {
   expectTestToEndWithAllPrintsAsserted,
   fakePrintElement as mockPrintElement,
   fakePrintElementWhenReady as mockPrintElementWhenReady,
+  suppressReact17UnmountedWarning,
 } from '@votingworks/test-utils';
 
 configure({ asyncUtilTimeout: 5_000 });
+suppressReact17UnmountedWarning();
 
 jest.mock('@votingworks/ui', (): typeof import('@votingworks/ui') => {
   const original = jest.requireActual('@votingworks/ui');

--- a/libs/test-utils/src/index.ts
+++ b/libs/test-utils/src/index.ts
@@ -11,6 +11,7 @@ export * from './has_text_across_elements';
 export * from './mock_function';
 export * from './mock_of';
 export * from './observable';
+export * from './react';
 export * from './smartcards';
 export * from './smartcard_auth';
 export * from './strip_election_hash';

--- a/libs/test-utils/src/react.ts
+++ b/libs/test-utils/src/react.ts
@@ -1,0 +1,23 @@
+/* eslint-disable no-console -- this file monkey-patches `console` */
+
+/**
+ * Suppresses the "Can't perform a React state update on an unmounted component" warning by
+ * modifying the `console.error` method to ignore the warning.
+ *
+ * This is a temporary workaround until we upgrade to React 18.
+ */
+export function suppressReact17UnmountedWarning(): void {
+  const originalConsoleError = console.error;
+  console.error = (...args: unknown[]) => {
+    if (
+      typeof args[0] === 'string' &&
+      args[0].startsWith(
+        `Warning: Can't perform a React state update on an unmounted component`
+      )
+    ) {
+      return;
+    }
+
+    originalConsoleError(...args);
+  };
+}

--- a/libs/ui/src/setupTests.ts
+++ b/libs/ui/src/setupTests.ts
@@ -1,5 +1,7 @@
 import '@testing-library/jest-dom/extend-expect';
 import 'jest-styled-components';
 import { configure } from '@testing-library/react';
+import { suppressReact17UnmountedWarning } from '@votingworks/test-utils';
 
 configure({ asyncUtilTimeout: 5_000 });
+suppressReact17UnmountedWarning();


### PR DESCRIPTION
## Overview
<!-- add a link to a GitHub Issue here -->
Suppresses this warning which is not a warning in React 18:
> Can't perform a React state update on an unmounted component.

## Demo Video or Screenshot
| Before | After |
|-|-|
|<img width="969" alt="image" src="https://user-images.githubusercontent.com/1938/217073493-911b2279-9708-405e-8b85-84172d1644df.png">|<img width="672" alt="image" src="https://user-images.githubusercontent.com/1938/217073605-fcea741c-a7c3-4e65-a714-6ac7e2f98c43.png">|

## Testing Plan
Tested locally, also can examine CircleCI output.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
