### PR TITLE
feat(vx-scan): add `supportsCalibration` API

### DIFF
--- a/apps/vx-scan/backend/src/app.ts
+++ b/apps/vx-scan/backend/src/app.ts
@@ -280,9 +280,13 @@ function buildApi(
       machine.return();
     },
 
+    supportsCalibration(): boolean {
+      return true;
+    },
+
     async calibrate(): Promise<boolean> {
-      const result = await machine.calibrate();
-      return result.isOk();
+      const result = await machine.calibrate?.();
+      return result?.isOk() ?? false;
     },
   });
 }

--- a/apps/vx-scan/backend/src/app_scan.test.ts
+++ b/apps/vx-scan/backend/src/app_scan.test.ts
@@ -983,8 +983,20 @@ test('calibrate', async () => {
 
   const calibratePromise = apiClient.calibrate();
   await waitForStatus(apiClient, { state: 'calibrating' });
-  await calibratePromise;
+  expect(await calibratePromise).toEqual(true);
   await expectStatus(apiClient, { state: 'no_paper' });
+});
+
+test('calibrate not supported', async () => {
+  const { apiClient, mockPlustek, mockUsb } = await createApp();
+  await configureApp(apiClient, mockUsb);
+
+  (await mockPlustek.simulateLoadSheet(ballotImages.blankSheet)).unsafeUnwrap();
+  await waitForStatus(apiClient, { state: 'ready_to_scan' });
+
+  mockPlustek.simulateCalibrateNotSupported();
+  const calibrateResult = await apiClient.calibrate();
+  expect(calibrateResult).toEqual(false);
 });
 
 test('jam on calibrate', async () => {

--- a/apps/vx-scan/backend/src/types.ts
+++ b/apps/vx-scan/backend/src/types.ts
@@ -96,6 +96,7 @@ export type PrecinctScannerErrorType =
   | 'paper_in_back_after_reconnect'
   | 'unexpected_paper_status'
   | 'unexpected_event'
+  | 'calibration_failed'
   | 'plustek_error';
 export interface PrecinctScannerMachineStatus {
   state: PrecinctScannerState;

--- a/apps/vx-scan/frontend/src/api.ts
+++ b/apps/vx-scan/frontend/src/api.ts
@@ -204,6 +204,16 @@ export const returnBallot = {
   },
 } as const;
 
+export const supportsCalibration = {
+  queryKey(): QueryKey {
+    return ['supportsCalibration'];
+  },
+  useQuery() {
+    const apiClient = useApiClient();
+    return useQuery(this.queryKey(), () => apiClient.supportsCalibration());
+  },
+} as const;
+
 export const calibrate = {
   useMutation() {
     const apiClient = useApiClient();

--- a/apps/vx-scan/frontend/src/app.test.tsx
+++ b/apps/vx-scan/frontend/src/app.test.tsx
@@ -152,6 +152,7 @@ test('app can load and configure from a usb stick', async () => {
 });
 
 test('election manager must set precinct', async () => {
+  apiMock.expectCheckCalibrationSupported(true);
   apiMock.expectGetConfig({
     precinctSelection: undefined,
   });
@@ -188,6 +189,7 @@ test('election manager must set precinct', async () => {
 test('election manager and poll worker configuration', async () => {
   const electionDefinition = electionSampleDefinition;
   let config: Partial<PrecinctScannerConfig> = { electionDefinition };
+  apiMock.expectCheckCalibrationSupported(true);
   apiMock.expectGetConfig(config);
   apiMock.expectGetScannerStatus(statusNoPaper, 2);
   const { card, logger } = renderApp();
@@ -390,6 +392,7 @@ async function scanBallot() {
 }
 
 test('voter can cast a ballot that scans successfully ', async () => {
+  apiMock.expectCheckCalibrationSupported(true);
   apiMock.expectGetConfig({
     pollsState: 'polls_open',
   });

--- a/apps/vx-scan/frontend/src/app_unhappy_paths.test.tsx
+++ b/apps/vx-scan/frontend/src/app_unhappy_paths.test.tsx
@@ -80,6 +80,7 @@ test('backend fails to unconfigure', async () => {
   const originalConsoleError = console.error;
   console.error = jest.fn();
 
+  apiMock.expectCheckCalibrationSupported(true);
   apiMock.expectGetConfig();
   apiMock.expectGetScannerStatus({ ...statusNoPaper, canUnconfigure: true });
   apiMock.mockApiClient.unconfigureElection
@@ -259,6 +260,7 @@ test('removing card during calibration', async () => {
   const kiosk = fakeKiosk();
   kiosk.getUsbDriveInfo = jest.fn().mockResolvedValue([fakeUsbDrive()]);
   window.kiosk = kiosk;
+  apiMock.expectCheckCalibrationSupported(true);
   apiMock.expectGetScannerStatus(statusNoPaper, 4);
   apiMock.expectGetCastVoteRecordsForTally([]);
   const { card } = renderApp();

--- a/apps/vx-scan/frontend/src/components/calibrate_scanner_modal.test.tsx
+++ b/apps/vx-scan/frontend/src/components/calibrate_scanner_modal.test.tsx
@@ -40,6 +40,7 @@ afterEach(() => {
 });
 
 test('shows instructions', () => {
+  apiMock.expectCheckCalibrationSupported(true);
   renderModal();
 
   screen.getByRole('heading', { name: 'Calibrate Scanner' });
@@ -48,6 +49,7 @@ test('shows instructions', () => {
 
 test('waiting for paper', async () => {
   const onCancel = jest.fn();
+  apiMock.expectCheckCalibrationSupported(true);
   renderModal({ onCancel });
 
   expect(
@@ -60,6 +62,7 @@ test('waiting for paper', async () => {
 
 test('scanner not available', async () => {
   const onCancel = jest.fn();
+  apiMock.expectCheckCalibrationSupported(true);
   renderModal({
     scannerStatus: { ...fakeScannerStatus, state: 'jammed' },
     onCancel,
@@ -75,6 +78,7 @@ test('scanner not available', async () => {
 
 test('calibrate success', async () => {
   const { promise, resolve } = deferred<boolean>();
+  apiMock.expectCheckCalibrationSupported(true);
   apiMock.mockApiClient.calibrate.expectCallWith().returns(promise);
   renderModal({
     // Note that in reality, scanner status would update as the scanner
@@ -92,8 +96,19 @@ test('calibrate success', async () => {
   await screen.findByText('Calibration succeeded!');
 });
 
+test('calibrate unsupported', async () => {
+  apiMock.expectCheckCalibrationSupported(false);
+  renderModal({
+    scannerStatus: { ...fakeScannerStatus, state: 'ready_to_scan' },
+  });
+
+  await screen.findByText('Calibration not supported');
+  userEvent.click(await screen.findByText('Cancel'));
+});
+
 test('calibrate error and cancel', async () => {
   const { promise, resolve } = deferred<boolean>();
+  apiMock.expectCheckCalibrationSupported(true);
   apiMock.mockApiClient.calibrate.expectCallWith().returns(promise);
   const onCancel = jest.fn();
   renderModal({
@@ -118,6 +133,7 @@ test('calibrate error and cancel', async () => {
 
 test('calibrate error and try again', async () => {
   const { promise, resolve } = deferred<boolean>();
+  apiMock.expectCheckCalibrationSupported(true);
   apiMock.mockApiClient.calibrate.expectCallWith().returns(promise);
   renderModal({
     // Note that in reality, scanner status would update as the scanner
@@ -142,6 +158,7 @@ test('calibrate error and try again', async () => {
 // "An update to CalibrateScannerModal inside a test was not wrapped in act(...)."
 test('unmount during calibration (e.g. if election manager card removed)', async () => {
   const { promise, resolve } = deferred<boolean>();
+  apiMock.expectCheckCalibrationSupported(true);
   apiMock.mockApiClient.calibrate.expectCallWith().returns(promise);
   const { unmount } = renderModal({
     scannerStatus: { ...fakeScannerStatus, state: 'ready_to_scan' },

--- a/apps/vx-scan/frontend/src/components/calibrate_scanner_modal.tsx
+++ b/apps/vx-scan/frontend/src/components/calibrate_scanner_modal.tsx
@@ -3,7 +3,7 @@ import { Button, Modal, Prose } from '@votingworks/ui';
 import { assert } from '@votingworks/basics';
 // eslint-disable-next-line vx/gts-no-import-export-type
 import type { PrecinctScannerStatus } from '@votingworks/vx-scan-backend';
-import { calibrate } from '../api';
+import { calibrate, supportsCalibration } from '../api';
 
 export interface CalibrateScannerModalProps {
   scannerStatus: PrecinctScannerStatus;
@@ -20,6 +20,7 @@ export function CalibrateScannerModal({
   scannerStatus,
   onCancel,
 }: CalibrateScannerModalProps): JSX.Element {
+  const supportsCalibrationQuery = supportsCalibration.useQuery();
   const calibrateMutation = calibrate.useMutation();
   const [calibrationState, setCalibrationState] =
     useState<CalibrationState>('ready');
@@ -30,6 +31,21 @@ export function CalibrateScannerModal({
       onSuccess: (calibrationResult: boolean) =>
         setCalibrationState(calibrationResult ? 'calibrated' : 'failed'),
     });
+  }
+
+  if (supportsCalibrationQuery.data === false) {
+    return (
+      <Modal
+        centerContent
+        content={
+          <Prose textCenter>
+            <h1>Calibration not supported</h1>
+            <p>This scanner does not support calibration.</p>
+          </Prose>
+        }
+        actions={<Button onPress={onCancel}>Cancel</Button>}
+      />
+    );
   }
 
   if (calibrationState === 'ready') {

--- a/apps/vx-scan/frontend/src/screens/election_manager_screen.test.tsx
+++ b/apps/vx-scan/frontend/src/screens/election_manager_screen.test.tsx
@@ -61,6 +61,7 @@ function renderScreen(
 }
 
 test('renders date and time settings modal', async () => {
+  apiMock.expectCheckCalibrationSupported(true);
   apiMock.expectGetConfig();
   renderScreen();
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
@@ -95,6 +96,7 @@ test('renders date and time settings modal', async () => {
 });
 
 test('option to set precinct if more than one', async () => {
+  apiMock.expectCheckCalibrationSupported(true);
   apiMock.expectGetConfig();
   const precinct = electionSampleDefinition.election.precincts[0];
   const precinctSelection = singlePrecinctSelectionFor(precinct.id);
@@ -108,6 +110,7 @@ test('option to set precinct if more than one', async () => {
 });
 
 test('no option to change precinct if there is only one precinct', async () => {
+  apiMock.expectCheckCalibrationSupported(true);
   const electionDefinition =
     electionMinimalExhaustiveSampleSinglePrecinctDefinition;
   apiMock.expectGetConfig({
@@ -121,6 +124,7 @@ test('no option to change precinct if there is only one precinct', async () => {
 });
 
 test('export from admin screen', async () => {
+  apiMock.expectCheckCalibrationSupported(true);
   apiMock.expectGetConfig();
   renderScreen();
 
@@ -130,6 +134,7 @@ test('export from admin screen', async () => {
 });
 
 test('unconfigure does not eject a usb drive that is not mounted', async () => {
+  apiMock.expectCheckCalibrationSupported(true);
   apiMock.expectGetConfig();
   const usbDrive = mockUsbDrive('absent');
   renderScreen({
@@ -146,6 +151,7 @@ test('unconfigure does not eject a usb drive that is not mounted', async () => {
 });
 
 test('unconfigure ejects a usb drive when it is mounted', async () => {
+  apiMock.expectCheckCalibrationSupported(true);
   apiMock.expectGetConfig();
   const usbDrive = mockUsbDrive('mounted');
   renderScreen({
@@ -164,6 +170,7 @@ test('unconfigure ejects a usb drive when it is mounted', async () => {
 });
 
 test('unconfigure button is disabled when the machine cannot be unconfigured', async () => {
+  apiMock.expectCheckCalibrationSupported(true);
   apiMock.expectGetConfig();
   renderScreen();
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
@@ -173,6 +180,7 @@ test('unconfigure button is disabled when the machine cannot be unconfigured', a
 });
 
 test('cannot toggle to testing mode when the machine cannot be unconfigured', async () => {
+  apiMock.expectCheckCalibrationSupported(true);
   apiMock.expectGetConfig({ isTestMode: false });
   renderScreen();
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
@@ -183,6 +191,7 @@ test('cannot toggle to testing mode when the machine cannot be unconfigured', as
 });
 
 test('allows overriding mark thresholds', async () => {
+  apiMock.expectCheckCalibrationSupported(true);
   apiMock.expectGetConfig();
   renderScreen();
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
@@ -206,6 +215,7 @@ test('allows overriding mark thresholds', async () => {
 });
 
 test('when sounds are not muted, shows a button to mute sounds', async () => {
+  apiMock.expectCheckCalibrationSupported(true);
   apiMock.expectGetConfig({ isSoundMuted: false });
   renderScreen();
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
@@ -219,6 +229,7 @@ test('when sounds are not muted, shows a button to mute sounds', async () => {
 });
 
 test('when sounds are muted, shows a button to unmute sounds', async () => {
+  apiMock.expectCheckCalibrationSupported(true);
   apiMock.expectGetConfig({ isSoundMuted: true });
   renderScreen();
   await screen.findByRole('heading', { name: 'Election Manager Settings' });

--- a/apps/vx-scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/vx-scan/frontend/src/screens/election_manager_screen.tsx
@@ -25,6 +25,7 @@ import {
   setIsSoundMuted,
   setPrecinctSelection,
   setTestMode,
+  supportsCalibration,
   unconfigureElection,
 } from '../api';
 import { usePreviewContext } from '../preview_dashboard';
@@ -46,6 +47,7 @@ export function ElectionManagerScreen({
   usbDrive,
   logger,
 }: ElectionManagerScreenProps): JSX.Element | null {
+  const supportsCalibrationQuery = supportsCalibration.useQuery();
   const configQuery = getConfig.useQuery();
   const setPrecinctSelectionMutation = setPrecinctSelection.useMutation();
   const setTestModeMutation = setTestMode.useMutation();
@@ -162,7 +164,15 @@ export function ElectionManagerScreen({
           </Button>
         </p>
         <p>
-          <Button onPress={() => setIsCalibratingScanner(true)}>
+          <Button
+            disabled={supportsCalibrationQuery.data === false}
+            onPress={() => setIsCalibratingScanner(true)}
+            title={
+              !supportsCalibrationQuery.data
+                ? 'This scanner does not support calibration.'
+                : undefined
+            }
+          >
             Calibrate Scanner
           </Button>
         </p>

--- a/apps/vx-scan/frontend/src/screens/scan_error_screen.tsx
+++ b/apps/vx-scan/frontend/src/screens/scan_error_screen.tsx
@@ -38,6 +38,8 @@ export function ScanErrorScreen({
         return 'The ballot does not match the election this scanner is configured for.';
       case 'invalid_precinct':
         return 'The ballot does not match the precinct this scanner is configured for.';
+      case 'calibration_failed':
+        return 'Calibration failed.';
       case 'unreadable':
       case 'unknown':
         return 'There was a problem scanning your ballot. Please scan it again.';

--- a/apps/vx-scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/vx-scan/frontend/test/helpers/mock_api_client.tsx
@@ -100,6 +100,12 @@ export function createApiMock() {
         .expectCallWith()
         .resolves(ok());
     },
+
+    expectCheckCalibrationSupported(supportsCalibration: boolean): void {
+      mockApiClient.supportsCalibration
+        .expectCallWith()
+        .resolves(supportsCalibration);
+    },
   };
 }
 

--- a/libs/plustek-scanner/src/scanner.ts
+++ b/libs/plustek-scanner/src/scanner.ts
@@ -79,7 +79,7 @@ export type AcceptResult = Result<void, ScannerError | Error>;
 export type RejectResult = Result<void, ScannerError | Error>;
 
 /**
- * The return type of {@link ScannerClient.calibrate}.
+ * The return type of {@link ScannerClient['calibrate']}.
  */
 export type CalibrateResult = Result<void, ScannerError | Error>;
 


### PR DESCRIPTION
## Overview
<!-- add a link to a GitHub Issue here -->
The Custom scanner does not seem to support calibration. This adds the `supportsCalibration` API to determine whether the current scanner supports calibration. Currently it is hardcoded to return `true`, but that will change with the introduction of the Custom scanner.

## Demo Video or Screenshot
<img width="552" alt="image" src="https://user-images.githubusercontent.com/1938/217107226-7c831196-8325-4714-ac03-d10e3c721d38.png">

## Testing Plan 
Tested manually, added automated tests.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
