### PR TITLE
Move VxScan auth to the backend

### DIFF
--- a/apps/vx-mark/frontend/src/apimachine_config.test.tsx
+++ b/apps/vx-mark/frontend/src/apimachine_config.test.tsx
@@ -7,19 +7,19 @@ import {
   makePollWorkerCard,
 } from '@votingworks/test-utils';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
-import { createApiMock } from '../test/helpers/mock_api_client';
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 import { App } from './app';
 import {
   setElectionInStorage,
   setStateInStorage,
 } from '../test/helpers/election';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
 });
 
 afterEach(() => {

--- a/apps/vx-mark/frontend/src/app.test.tsx
+++ b/apps/vx-mark/frontend/src/app.test.tsx
@@ -20,13 +20,13 @@ import { advanceTimersAndPromises } from '../test/helpers/smartcards';
 import { render } from '../test/test_utils';
 import { App } from './app';
 import { AriaScreenReader } from './utils/ScreenReader';
-import { createApiMock } from '../test/helpers/mock_api_client';
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
 });
 
 afterEach(() => {

--- a/apps/vx-mark/frontend/src/app_card_unhappy_paths.test.tsx
+++ b/apps/vx-mark/frontend/src/app_card_unhappy_paths.test.tsx
@@ -32,14 +32,14 @@ import {
   setElectionInStorage,
   setStateInStorage,
 } from '../test/helpers/election';
-import { createApiMock } from '../test/helpers/mock_api_client';
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
 });
 
 afterEach(() => {

--- a/apps/vx-mark/frontend/src/app_cardless_voting.test.tsx
+++ b/apps/vx-mark/frontend/src/app_cardless_voting.test.tsx
@@ -24,14 +24,14 @@ import { withMarkup } from '../test/helpers/with_markup';
 import { advanceTimersAndPromises } from '../test/helpers/smartcards';
 
 import { enterPin } from '../test/test_utils';
-import { createApiMock } from '../test/helpers/mock_api_client';
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
 });
 
 afterEach(() => {

--- a/apps/vx-mark/frontend/src/app_contest_candidate_no_party.test.tsx
+++ b/apps/vx-mark/frontend/src/app_contest_candidate_no_party.test.tsx
@@ -14,9 +14,9 @@ import { advanceTimersAndPromises } from '../test/helpers/smartcards';
 
 import { setStateInStorage } from '../test/helpers/election';
 import { electionStorageKey } from './app_root';
-import { createApiMock } from '../test/helpers/mock_api_client';
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 const { election } = electionSampleDefinition;
 const electionWithNoPartyCandidateContests: Election = {
@@ -40,7 +40,7 @@ const electionWithNoPartyCandidateContests: Election = {
 beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
 });
 
 afterEach(() => {

--- a/apps/vx-mark/frontend/src/app_contest_ms_either_neither.test.tsx
+++ b/apps/vx-mark/frontend/src/app_contest_ms_either_neither.test.tsx
@@ -33,14 +33,14 @@ import {
   setElectionInStorage,
   setStateInStorage,
 } from '../test/helpers/election';
-import { createApiMock } from '../test/helpers/mock_api_client';
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
 });
 
 afterEach(() => {

--- a/apps/vx-mark/frontend/src/app_contest_multi_seat.test.tsx
+++ b/apps/vx-mark/frontend/src/app_contest_multi_seat.test.tsx
@@ -13,14 +13,14 @@ import {
   setElectionInStorage,
   setStateInStorage,
 } from '../test/helpers/election';
-import { createApiMock } from '../test/helpers/mock_api_client';
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
 });
 
 afterEach(() => {

--- a/apps/vx-mark/frontend/src/app_contest_single_seat.test.tsx
+++ b/apps/vx-mark/frontend/src/app_contest_single_seat.test.tsx
@@ -13,14 +13,14 @@ import {
   setElectionInStorage,
   setStateInStorage,
 } from '../test/helpers/election';
-import { createApiMock } from '../test/helpers/mock_api_client';
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
 });
 
 afterEach(() => {

--- a/apps/vx-mark/frontend/src/app_contest_write_in.test.tsx
+++ b/apps/vx-mark/frontend/src/app_contest_write_in.test.tsx
@@ -19,14 +19,14 @@ import {
   setElectionInStorage,
   setStateInStorage,
 } from '../test/helpers/election';
-import { createApiMock } from '../test/helpers/mock_api_client';
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
 });
 
 afterEach(() => {

--- a/apps/vx-mark/frontend/src/app_contest_yes_no.test.tsx
+++ b/apps/vx-mark/frontend/src/app_contest_yes_no.test.tsx
@@ -16,14 +16,14 @@ import {
   setElectionInStorage,
   setStateInStorage,
 } from '../test/helpers/election';
-import { createApiMock } from '../test/helpers/mock_api_client';
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
 });
 
 afterEach(() => {

--- a/apps/vx-mark/frontend/src/app_data.test.tsx
+++ b/apps/vx-mark/frontend/src/app_data.test.tsx
@@ -9,14 +9,14 @@ import {
 } from '../test/helpers/election';
 import { advanceTimersAndPromises } from '../test/helpers/smartcards';
 import { buildApp } from '../test/helpers/build_app';
-import { createApiMock } from '../test/helpers/mock_api_client';
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
   apiMock.expectGetMachineConfig();
 });
 

--- a/apps/vx-mark/frontend/src/app_end_to_end.test.tsx
+++ b/apps/vx-mark/frontend/src/app_end_to_end.test.tsx
@@ -40,14 +40,14 @@ import {
 } from '../test/helpers/election';
 import { REPORT_PRINTING_TIMEOUT_SECONDS } from './config/globals';
 import { enterPin } from '../test/test_utils';
-import { createApiMock } from '../test/helpers/mock_api_client';
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
 });
 
 afterEach(() => {

--- a/apps/vx-mark/frontend/src/app_mark_only.test.tsx
+++ b/apps/vx-mark/frontend/src/app_mark_only.test.tsx
@@ -23,14 +23,14 @@ import {
   voterContests,
 } from '../test/helpers/election';
 import { enterPin } from '../test/test_utils';
-import { createApiMock } from '../test/helpers/mock_api_client';
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
 });
 
 afterEach(() => {

--- a/apps/vx-mark/frontend/src/app_mark_voter_card_invalid.test.tsx
+++ b/apps/vx-mark/frontend/src/app_mark_voter_card_invalid.test.tsx
@@ -23,14 +23,14 @@ import {
   IDLE_TIMEOUT_SECONDS,
   IDLE_RESET_TIMEOUT_SECONDS,
 } from './config/globals';
-import { createApiMock } from '../test/helpers/mock_api_client';
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
 });
 
 afterEach(() => {

--- a/apps/vx-mark/frontend/src/app_polls_flows.test.tsx
+++ b/apps/vx-mark/frontend/src/app_polls_flows.test.tsx
@@ -46,9 +46,9 @@ import {
 import { buildApp } from '../test/helpers/build_app';
 import { REPORT_PRINTING_TIMEOUT_SECONDS } from './config/globals';
 import { enterPin } from '../test/test_utils';
-import { createApiMock } from '../test/helpers/mock_api_client';
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 function expectBallotCountsInReport(
   container: HTMLElement,
@@ -118,7 +118,7 @@ async function printPollsClosedReport() {
 beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
   apiMock.expectGetMachineConfig();
 });
 
@@ -1476,9 +1476,9 @@ test('tally report: will print but not update polls state appropriate', async ()
 });
 
 test('full polls flow without tally reports', async () => {
-  const { renderApp, card, storage, logger } = buildApp(apiMock);
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
   apiMock.expectGetMachineConfig({ appMode: MarkAndPrint });
+  const { renderApp, card, storage, logger } = buildApp(apiMock);
   await setElectionInStorage(storage, electionSampleDefinition);
   await setStateInStorage(storage, { pollsState: 'polls_closed_initial' });
   renderApp();

--- a/apps/vx-mark/frontend/src/app_print_only.test.tsx
+++ b/apps/vx-mark/frontend/src/app_print_only.test.tsx
@@ -36,14 +36,14 @@ import { withMarkup } from '../test/helpers/with_markup';
 
 import * as GLOBALS from './config/globals';
 import { enterPin } from '../test/test_utils';
-import { createApiMock } from '../test/helpers/mock_api_client';
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 beforeEach(() => {
   window.location.href = '/';
   jest.useFakeTimers();
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
 });
 
 afterEach(() => {

--- a/apps/vx-mark/frontend/src/app_quit_on_idle.test.tsx
+++ b/apps/vx-mark/frontend/src/app_quit_on_idle.test.tsx
@@ -13,15 +13,15 @@ import {
 } from '../test/helpers/election';
 
 import { QUIT_KIOSK_IDLE_SECONDS } from './config/globals';
-import { createApiMock } from '../test/helpers/mock_api_client';
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
   window.kiosk = fakeKiosk();
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
 });
 
 afterEach(() => {

--- a/apps/vx-mark/frontend/src/app_refresh.test.tsx
+++ b/apps/vx-mark/frontend/src/app_refresh.test.tsx
@@ -17,14 +17,14 @@ import {
   setElectionInStorage,
   setStateInStorage,
 } from '../test/helpers/election';
-import { createApiMock } from '../test/helpers/mock_api_client';
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
 });
 
 afterEach(() => {

--- a/apps/vx-mark/frontend/src/app_replace_election.test.tsx
+++ b/apps/vx-mark/frontend/src/app_replace_election.test.tsx
@@ -10,14 +10,14 @@ import {
 import { enterPin, render } from '../test/test_utils';
 import { App } from './app';
 import { advanceTimersAndPromises } from '../test/helpers/smartcards';
-import { createApiMock } from '../test/helpers/mock_api_client';
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
 });
 
 afterEach(() => {

--- a/apps/vx-mark/frontend/src/app_setup_errors.test.tsx
+++ b/apps/vx-mark/frontend/src/app_setup_errors.test.tsx
@@ -21,14 +21,14 @@ import {
 } from '../test/helpers/election';
 import { withMarkup } from '../test/helpers/with_markup';
 import { enterPin } from '../test/test_utils';
-import { createApiMock } from '../test/helpers/mock_api_client';
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
 });
 
 afterEach(() => {

--- a/apps/vx-mark/frontend/src/app_single_precinct_election.test.tsx
+++ b/apps/vx-mark/frontend/src/app_single_precinct_election.test.tsx
@@ -7,14 +7,14 @@ import userEvent from '@testing-library/user-event';
 import { getDisplayElectionHash } from '@votingworks/types';
 import { enterPin, render } from '../test/test_utils';
 import { App } from './app';
-import { createApiMock } from '../test/helpers/mock_api_client';
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
 });
 
 afterEach(() => {

--- a/apps/vx-mark/frontend/src/app_test_mode.test.tsx
+++ b/apps/vx-mark/frontend/src/app_test_mode.test.tsx
@@ -9,14 +9,14 @@ import {
   setStateInStorage,
 } from '../test/helpers/election';
 import { advanceTimersAndPromises } from '../test/helpers/smartcards';
-import { createApiMock } from '../test/helpers/mock_api_client';
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
 });
 
 afterEach(() => {

--- a/apps/vx-mark/frontend/src/app_voter_settings_landscape.test.tsx
+++ b/apps/vx-mark/frontend/src/app_voter_settings_landscape.test.tsx
@@ -20,14 +20,14 @@ import { advanceTimersAndPromises } from '../test/helpers/smartcards';
 
 import { voterContests } from '../test/helpers/election';
 import { enterPin } from '../test/test_utils';
-import { createApiMock } from '../test/helpers/mock_api_client';
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
 });
 
 afterEach(() => {

--- a/apps/vx-mark/frontend/src/lib/gamepad.test.tsx
+++ b/apps/vx-mark/frontend/src/lib/gamepad.test.tsx
@@ -18,14 +18,14 @@ import {
 } from '../../test/helpers/election';
 
 import { getActiveElement, handleGamepadButtonDown } from './gamepad';
-import { createApiMock } from '../../test/helpers/mock_api_client';
+import { ApiMock, createApiMock } from '../../test/helpers/mock_api_client';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
 });
 
 afterEach(() => {

--- a/apps/vx-mark/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/vx-mark/frontend/test/helpers/mock_api_client.tsx
@@ -30,6 +30,8 @@ export function createApiMock() {
   };
 }
 
+export type ApiMock = ReturnType<typeof createApiMock>;
+
 export function provideApi(
   apiMock: ReturnType<typeof createApiMock>,
   children: React.ReactNode

--- a/apps/vx-scan/backend/package.json
+++ b/apps/vx-scan/backend/package.json
@@ -37,6 +37,7 @@
     ]
   },
   "dependencies": {
+    "@votingworks/auth": "workspace:*",
     "@votingworks/ballot-encoder": "workspace:*",
     "@votingworks/ballot-interpreter-nh": "workspace:*",
     "@votingworks/ballot-interpreter-vx": "workspace:*",

--- a/apps/vx-scan/backend/src/app.ts
+++ b/apps/vx-scan/backend/src/app.ts
@@ -311,7 +311,7 @@ function buildApi(
       const authStatus = auth.getAuthStatus();
 
       // Though we only initiate this action when a poll worker is logged in, a poll worker could
-      // remove their card right after, so we treat these as handled errors rather than unexpected
+      // remove their card right after, so we treat these as user errors rather than unexpected
       // errors
       if (authStatus.status !== 'logged_in') {
         return err(new Error('User is not logged in'));

--- a/apps/vx-scan/backend/src/app.ts
+++ b/apps/vx-scan/backend/src/app.ts
@@ -338,6 +338,15 @@ export function buildApp(
   usb: Usb,
   logger: Logger
 ): Application {
+  const electionDefinition = workspace.store.getElectionDefinition();
+  if (electionDefinition) {
+    auth.setElectionDefinition(electionDefinition);
+  }
+  const precinctSelection = workspace.store.getPrecinctSelection();
+  if (precinctSelection) {
+    auth.setPrecinctSelection(precinctSelection);
+  }
+
   const app: Application = express();
   const api = buildApi(auth, machine, interpreter, workspace, usb, logger);
   app.use('/api', grout.buildRouter(api, express));

--- a/apps/vx-scan/backend/src/app.ts
+++ b/apps/vx-scan/backend/src/app.ts
@@ -310,6 +310,9 @@ function buildApi(
     }): Promise<Result<void, Error>> {
       const authStatus = auth.getAuthStatus();
 
+      // Though we only initiate this action when a poll worker is logged in, a poll worker could
+      // remove their card right after, so we treat these as handled errors rather than unexpected
+      // errors
       if (authStatus.status !== 'logged_in') {
         return err(new Error('User is not logged in'));
       }

--- a/apps/vx-scan/backend/src/app_config.test.ts
+++ b/apps/vx-scan/backend/src/app_config.test.ts
@@ -8,13 +8,14 @@ import waitForExpect from 'wait-for-expect';
 import { LogEventId } from '@votingworks/logging';
 import * as grout from '@votingworks/grout';
 import {
+  ScannerReportDataSchema,
   SCANNER_RESULTS_FOLDER,
   singlePrecinctSelectionFor,
 } from '@votingworks/utils';
 import { assert, err, ok } from '@votingworks/basics';
 import fs from 'fs';
 import { join } from 'path';
-import { generateCvr } from '@votingworks/test-utils';
+import { generateCvr, mockOf } from '@votingworks/test-utils';
 import {
   ballotImages,
   configureApp,
@@ -111,7 +112,7 @@ test("fails to configure if there's no ballot package on the usb drive", async (
 });
 
 test("if there's only one precinct in the election, it's selected automatically on configure", async () => {
-  const { apiClient, mockUsb } = await createApp();
+  const { apiClient, mockAuth, mockUsb } = await createApp();
   mockUsb.insertUsbDrive({
     'ballot-packages': {
       'test-ballot-package.zip': createBallotPackageWithoutTemplates(
@@ -125,10 +126,21 @@ test("if there's only one precinct in the election, it's selected automatically 
     kind: 'SinglePrecinct',
     precinctId: 'precinct-1',
   });
+
+  expect(mockAuth.setElectionDefinition).toHaveBeenCalledTimes(1);
+  expect(mockAuth.setElectionDefinition).toHaveBeenNthCalledWith(
+    1,
+    electionMinimalExhaustiveSampleSinglePrecinctDefinition
+  );
+  expect(mockAuth.setPrecinctSelection).toHaveBeenCalledTimes(1);
+  expect(mockAuth.setPrecinctSelection).toHaveBeenNthCalledWith(1, {
+    kind: 'SinglePrecinct',
+    precinctId: 'precinct-1',
+  });
 });
 
 test('configures using the most recently created ballot package on the usb drive', async () => {
-  const { apiClient, mockUsb } = await createApp();
+  const { apiClient, mockAuth, mockUsb } = await createApp();
 
   mockUsb.insertUsbDrive({
     'ballot-packages': {
@@ -160,6 +172,13 @@ test('configures using the most recently created ballot package on the usb drive
   expect(config.electionDefinition?.election.title).toEqual(
     electionSampleDefinition.election.title
   );
+
+  expect(mockAuth.setElectionDefinition).toHaveBeenCalledTimes(1);
+  expect(mockAuth.setElectionDefinition).toHaveBeenNthCalledWith(
+    1,
+    electionSampleDefinition
+  );
+  expect(mockAuth.setPrecinctSelection).not.toHaveBeenCalled();
 });
 
 test('export the CVRs to USB', async () => {
@@ -215,15 +234,23 @@ test('export the CVRs to USB', async () => {
   expect(workspace.store.getCvrsBackupTimestamp()).toBeDefined();
 });
 
-test('setPrecinctSelection will reset polls to closed', async () => {
-  const { apiClient, workspace, mockUsb } = await createApp();
+test('setPrecinctSelection will reset polls to closed and update auth instance', async () => {
+  const { apiClient, mockAuth, mockUsb, workspace } = await createApp();
   await configureApp(apiClient, mockUsb);
+
+  mockOf(mockAuth.setPrecinctSelection).mockClear();
 
   workspace.store.setPollsState('polls_open');
   await apiClient.setPrecinctSelection({
     precinctSelection: singlePrecinctSelectionFor('21'),
   });
   expect(workspace.store.getPollsState()).toEqual('polls_closed_initial');
+
+  expect(mockAuth.setPrecinctSelection).toHaveBeenCalledTimes(1);
+  expect(mockAuth.setPrecinctSelection).toHaveBeenNthCalledWith(
+    1,
+    singlePrecinctSelectionFor('21')
+  );
 });
 
 test('ballot batching', async () => {
@@ -312,4 +339,47 @@ test('ballot batching', async () => {
   const batch3Id = cvrs[4]._batchId;
   expect(cvrs[3]._batchId).not.toEqual(batch3Id);
   expect(cvrs[5]._batchId).toEqual(batch3Id);
+});
+
+test('unconfiguring machine', async () => {
+  const { apiClient, mockAuth, mockUsb, interpreter, workspace } =
+    await createApp();
+  await configureApp(apiClient, mockUsb);
+
+  jest.spyOn(interpreter, 'unconfigure');
+  jest.spyOn(workspace, 'reset');
+
+  await apiClient.unconfigureElection({});
+
+  expect(interpreter.unconfigure).toHaveBeenCalledTimes(1);
+  expect(workspace.reset).toHaveBeenCalledTimes(1);
+  expect(mockAuth.clearElectionDefinition).toHaveBeenCalledTimes(1);
+  expect(mockAuth.clearPrecinctSelection).toHaveBeenCalledTimes(1);
+});
+
+test('auth', async () => {
+  const { apiClient, mockAuth, mockUsb } = await createApp();
+  await configureApp(apiClient, mockUsb);
+
+  await apiClient.getAuthStatus();
+  await apiClient.checkPin({ pin: '123456' });
+
+  void (await apiClient.readCardData({ schema: 'ScannerReportDataSchema' }));
+  void (await apiClient.writeCardData({
+    data: {},
+    schema: 'ScannerReportDataSchema',
+  }));
+
+  expect(mockAuth.getAuthStatus).toHaveBeenCalledTimes(1);
+  expect(mockAuth.checkPin).toHaveBeenCalledTimes(1);
+  expect(mockAuth.checkPin).toHaveBeenNthCalledWith(1, { pin: '123456' });
+  expect(mockAuth.readCardData).toHaveBeenCalledTimes(1);
+  expect(mockAuth.readCardData).toHaveBeenNthCalledWith(1, {
+    schema: ScannerReportDataSchema,
+  });
+  expect(mockAuth.writeCardData).toHaveBeenCalledTimes(1);
+  expect(mockAuth.writeCardData).toHaveBeenNthCalledWith(1, {
+    data: {},
+    schema: ScannerReportDataSchema,
+  });
 });

--- a/apps/vx-scan/backend/src/app_config.test.ts
+++ b/apps/vx-scan/backend/src/app_config.test.ts
@@ -377,6 +377,27 @@ test('auth', async () => {
   expect(mockAuth.checkPin).toHaveBeenNthCalledWith(1, { pin: '123456' });
 });
 
+test('auth initial election definition and precinct selection configuration', async () => {
+  const createAppResult = await createApp();
+  await configureApp(createAppResult.apiClient, createAppResult.mockUsb);
+  const preconfiguredWorkspace = createAppResult.workspace;
+
+  const { mockAuth } = await createApp({
+    preconfiguredWorkspace,
+  });
+
+  expect(mockAuth.setElectionDefinition).toHaveBeenCalledTimes(1);
+  expect(mockAuth.setElectionDefinition).toHaveBeenNthCalledWith(
+    1,
+    electionFamousNames2021Fixtures.electionDefinition
+  );
+  expect(mockAuth.setPrecinctSelection).toHaveBeenCalledTimes(1);
+  expect(mockAuth.setPrecinctSelection).toHaveBeenNthCalledWith(
+    1,
+    ALL_PRECINCTS_SELECTION
+  );
+});
+
 test('write scanner report data to card', async () => {
   const { apiClient, mockAuth, mockUsb } = await createApp();
   await configureApp(apiClient, mockUsb);

--- a/apps/vx-scan/backend/src/app_scan.test.ts
+++ b/apps/vx-scan/backend/src/app_scan.test.ts
@@ -628,10 +628,10 @@ test('scanner powered off after returning', async () => {
 });
 
 test('insert second ballot while first ballot is scanning', async () => {
-  const { apiClient, mockPlustek, mockUsb } = await createApp(
-    {},
-    { passthroughDuration: 500 }
-  );
+  const { apiClient, mockPlustek, mockUsb } = await createApp({
+    delays: {},
+    mockPlustekOptions: { passthroughDuration: 500 },
+  });
   await configureApp(apiClient, mockUsb);
 
   (
@@ -701,8 +701,10 @@ test('insert second ballot before first ballot accept', async () => {
 
 test('insert second ballot while first ballot is accepting', async () => {
   const { apiClient, mockPlustek, interpreter, mockUsb } = await createApp({
-    DELAY_ACCEPTED_READY_FOR_NEXT_BALLOT: 1000,
-    DELAY_ACCEPTED_RESET_TO_NO_PAPER: 2000,
+    delays: {
+      DELAY_ACCEPTED_READY_FOR_NEXT_BALLOT: 1000,
+      DELAY_ACCEPTED_RESET_TO_NO_PAPER: 2000,
+    },
   });
   await configureApp(apiClient, mockUsb);
 
@@ -771,10 +773,10 @@ test('insert second ballot while first ballot needs review', async () => {
 });
 
 test('insert second ballot while first ballot is rejecting', async () => {
-  const { apiClient, mockPlustek, interpreter, mockUsb } = await createApp(
-    {},
-    { passthroughDuration: 500 }
-  );
+  const { apiClient, mockPlustek, interpreter, mockUsb } = await createApp({
+    delays: {},
+    mockPlustekOptions: { passthroughDuration: 500 },
+  });
   await configureApp(apiClient, mockUsb);
 
   (
@@ -818,10 +820,10 @@ test('insert second ballot while first ballot is rejecting', async () => {
 });
 
 test('insert second ballot while first ballot is returning', async () => {
-  const { apiClient, mockPlustek, interpreter, mockUsb } = await createApp(
-    {},
-    { passthroughDuration: 500 }
-  );
+  const { apiClient, mockPlustek, interpreter, mockUsb } = await createApp({
+    delays: {},
+    mockPlustekOptions: { passthroughDuration: 500 },
+  });
   await configureApp(apiClient, mockUsb);
 
   (
@@ -862,7 +864,9 @@ test('insert second ballot while first ballot is returning', async () => {
 
 test('jam on scan', async () => {
   const { apiClient, mockPlustek, mockUsb } = await createApp({
-    DELAY_RECONNECT_ON_UNEXPECTED_ERROR: 500,
+    delays: {
+      DELAY_RECONNECT_ON_UNEXPECTED_ERROR: 500,
+    },
   });
   await configureApp(apiClient, mockUsb);
 
@@ -882,7 +886,9 @@ test('jam on scan', async () => {
 
 test('jam on accept', async () => {
   const { apiClient, mockPlustek, interpreter, mockUsb } = await createApp({
-    DELAY_ACCEPTING_TIMEOUT: 500,
+    delays: {
+      DELAY_ACCEPTING_TIMEOUT: 500,
+    },
   });
   await configureApp(apiClient, mockUsb);
 
@@ -1091,8 +1097,10 @@ test('scan fails due to plustek returning only one file instead of two', async (
 
 test('scanning time out', async () => {
   const { apiClient, mockPlustek, logger, mockUsb } = await createApp({
-    DELAY_SCANNING_TIMEOUT: 50,
-    DELAY_RECONNECT_ON_UNEXPECTED_ERROR: 500,
+    delays: {
+      DELAY_SCANNING_TIMEOUT: 50,
+      DELAY_RECONNECT_ON_UNEXPECTED_ERROR: 500,
+    },
   });
   await configureApp(apiClient, mockUsb);
 
@@ -1125,10 +1133,12 @@ test('scanning time out', async () => {
 
 test('kills plustekctl if it freezes', async () => {
   const { apiClient, mockPlustek, mockUsb } = await createApp({
-    DELAY_SCANNING_TIMEOUT: 50,
-    DELAY_RECONNECT_ON_UNEXPECTED_ERROR: 500,
-    DELAY_KILL_AFTER_DISCONNECT_TIMEOUT: 500,
-    DELAY_PAPER_STATUS_POLLING_TIMEOUT: 1000,
+    delays: {
+      DELAY_SCANNING_TIMEOUT: 50,
+      DELAY_RECONNECT_ON_UNEXPECTED_ERROR: 500,
+      DELAY_KILL_AFTER_DISCONNECT_TIMEOUT: 500,
+      DELAY_PAPER_STATUS_POLLING_TIMEOUT: 1000,
+    },
   });
   await configureApp(apiClient, mockUsb);
 
@@ -1150,10 +1160,12 @@ test('kills plustekctl if it freezes', async () => {
 
 test('stops completely if plustekctl freezes and cant be killed', async () => {
   const { apiClient, mockPlustek, mockUsb } = await createApp({
-    DELAY_SCANNING_TIMEOUT: 50,
-    DELAY_RECONNECT_ON_UNEXPECTED_ERROR: 500,
-    DELAY_KILL_AFTER_DISCONNECT_TIMEOUT: 500,
-    DELAY_PAPER_STATUS_POLLING_TIMEOUT: 1000,
+    delays: {
+      DELAY_SCANNING_TIMEOUT: 50,
+      DELAY_RECONNECT_ON_UNEXPECTED_ERROR: 500,
+      DELAY_KILL_AFTER_DISCONNECT_TIMEOUT: 500,
+      DELAY_PAPER_STATUS_POLLING_TIMEOUT: 1000,
+    },
   });
   await configureApp(apiClient, mockUsb);
 

--- a/apps/vx-scan/backend/src/index.ts
+++ b/apps/vx-scan/backend/src/index.ts
@@ -5,7 +5,7 @@ import fs from 'fs';
 import { NODE_ENV } from './globals';
 import * as server from './server';
 
-export type { Api } from './app';
+export type { Api, CardDataSchemaName } from './app';
 export * from './types';
 
 // https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use

--- a/apps/vx-scan/backend/src/index.ts
+++ b/apps/vx-scan/backend/src/index.ts
@@ -5,7 +5,7 @@ import fs from 'fs';
 import { NODE_ENV } from './globals';
 import * as server from './server';
 
-export type { Api, CardDataSchemaName } from './app';
+export type { Api } from './app';
 export * from './types';
 
 // https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use

--- a/apps/vx-scan/backend/test/helpers/app_helpers.ts
+++ b/apps/vx-scan/backend/test/helpers/app_helpers.ts
@@ -20,7 +20,10 @@ import { AddressInfo } from 'net';
 import fs from 'fs';
 import { execSync } from 'child_process';
 import { assert, deferred, ok, Result } from '@votingworks/basics';
-import { InsertedSmartCardAuthApi } from '@votingworks/auth';
+import {
+  buildMockInsertedSmartCardAuth,
+  InsertedSmartCardAuthApi,
+} from '@votingworks/auth';
 import { buildApp, Api } from '../../src/app';
 import {
   createPrecinctScannerStateMachine,
@@ -98,20 +101,6 @@ export function createMockUsb(): MockUsb {
   };
 }
 
-export function buildMockAuth(): InsertedSmartCardAuthApi {
-  return {
-    getAuthStatus: jest.fn(),
-    checkPin: jest.fn(),
-    readCardData: jest.fn(),
-    writeCardData: jest.fn(),
-    clearCardData: jest.fn(),
-    setElectionDefinition: jest.fn(),
-    clearElectionDefinition: jest.fn(),
-    setPrecinctSelection: jest.fn(),
-    clearPrecinctSelection: jest.fn(),
-  };
-}
-
 export async function expectStatus(
   apiClient: grout.Client<Api>,
   expectedStatus: {
@@ -154,7 +143,7 @@ export async function createApp(
   logger: Logger;
   interpreter: PrecinctScannerInterpreter;
 }> {
-  const mockAuth = buildMockAuth();
+  const mockAuth = buildMockInsertedSmartCardAuth();
   const logger = fakeLogger();
   const workspace = await createWorkspace(tmp.dirSync().name);
   const mockPlustek = new MockScannerClient({

--- a/apps/vx-scan/backend/test/helpers/app_helpers.ts
+++ b/apps/vx-scan/backend/test/helpers/app_helpers.ts
@@ -130,10 +130,15 @@ export async function waitForStatus(
   }, 1_000);
 }
 
-export async function createApp(
-  delays: Partial<Delays> = {},
-  mockPlustekOptions: Partial<MockScannerClientOptions> = {}
-): Promise<{
+export async function createApp({
+  delays = {},
+  mockPlustekOptions = {},
+  preconfiguredWorkspace,
+}: {
+  delays?: Partial<Delays>;
+  mockPlustekOptions?: Partial<MockScannerClientOptions>;
+  preconfiguredWorkspace?: Workspace;
+} = {}): Promise<{
   apiClient: grout.Client<Api>;
   app: Application;
   mockAuth: InsertedSmartCardAuthApi;
@@ -145,7 +150,8 @@ export async function createApp(
 }> {
   const mockAuth = buildMockInsertedSmartCardAuth();
   const logger = fakeLogger();
-  const workspace = await createWorkspace(tmp.dirSync().name);
+  const workspace =
+    preconfiguredWorkspace ?? (await createWorkspace(tmp.dirSync().name));
   const mockPlustek = new MockScannerClient({
     toggleHoldDuration: 100,
     passthroughDuration: 100,

--- a/apps/vx-scan/backend/test/helpers/app_helpers.ts
+++ b/apps/vx-scan/backend/test/helpers/app_helpers.ts
@@ -271,7 +271,10 @@ export async function configureApp(
   {
     addTemplates = false,
     precinctId,
-  }: { addTemplates?: boolean; precinctId?: PrecinctId } = {
+  }: {
+    addTemplates?: boolean;
+    precinctId?: PrecinctId;
+  } = {
     addTemplates: false,
   }
 ): Promise<void> {

--- a/apps/vx-scan/backend/tsconfig.build.json
+++ b/apps/vx-scan/backend/tsconfig.build.json
@@ -11,6 +11,7 @@
   },
   "references": [
     { "path": "../../../libs/api/tsconfig.build.json" },
+    { "path": "../../../libs/auth/tsconfig.build.json" },
     { "path": "../../../libs/ballot-encoder/tsconfig.build.json" },
     { "path": "../../../libs/ballot-interpreter-nh/tsconfig.build.json" },
     { "path": "../../../libs/ballot-interpreter-vx/tsconfig.build.json" },

--- a/apps/vx-scan/backend/tsconfig.json
+++ b/apps/vx-scan/backend/tsconfig.json
@@ -18,6 +18,7 @@
   },
   "references": [
     { "path": "../../../libs/api/tsconfig.build.json" },
+    { "path": "../../../libs/auth/tsconfig.build.json" },
     { "path": "../../../libs/ballot-encoder/tsconfig.build.json" },
     { "path": "../../../libs/ballot-interpreter-nh/tsconfig.build.json" },
     { "path": "../../../libs/ballot-interpreter-vx/tsconfig.build.json" },

--- a/apps/vx-scan/frontend/src/api.ts
+++ b/apps/vx-scan/frontend/src/api.ts
@@ -1,9 +1,5 @@
 /* eslint-disable-next-line vx/gts-no-import-export-type */
-import type {
-  Api,
-  CardDataSchemaName,
-  PrecinctScannerStatus,
-} from '@votingworks/vx-scan-backend';
+import type { Api, PrecinctScannerStatus } from '@votingworks/vx-scan-backend';
 import React from 'react';
 import * as grout from '@votingworks/grout';
 import {
@@ -73,41 +69,6 @@ export const checkPin = {
         // Because we poll auth status with high frequency, this invalidation isn't strictly
         // necessary
         await queryClient.invalidateQueries(getAuthStatus.queryKey());
-      },
-    });
-  },
-} as const;
-
-export const readCardData = {
-  queryKey(): QueryKey {
-    return ['readCardData'];
-  },
-  useQuery<T>(schema: CardDataSchemaName) {
-    const apiClient = useApiClient();
-    return useQuery(
-      this.queryKey(),
-      () =>
-        // In the conversion from the Api type to the ApiClient type, generics are lost, so we cast
-        // back to the original type here
-        (apiClient.readCardData as Api['readCardData'])<T>({ schema }),
-      {
-        // Don't cache this data because so many actions can invalidate it, e.g. not just writing
-        // card data but also card removal
-        staleTime: 0,
-      }
-    );
-  },
-} as const;
-
-export const writeCardData = {
-  useMutation() {
-    const apiClient = useApiClient();
-    const queryClient = useQueryClient();
-    return useMutation(apiClient.writeCardData, {
-      async onSuccess() {
-        // Because we immediately consider retrieved card data stale, this invalidation isn't
-        // strictly necessary
-        await queryClient.invalidateQueries(readCardData.queryKey());
       },
     });
   },
@@ -288,5 +249,12 @@ export const calibrate = {
   useMutation() {
     const apiClient = useApiClient();
     return useMutation(apiClient.calibrate);
+  },
+} as const;
+
+export const saveScannerReportDataToCard = {
+  useMutation() {
+    const apiClient = useApiClient();
+    return useMutation(apiClient.saveScannerReportDataToCard);
   },
 } as const;

--- a/apps/vx-scan/frontend/src/app.test.tsx
+++ b/apps/vx-scan/frontend/src/app.test.tsx
@@ -409,9 +409,13 @@ test('voter can cast a ballot that scans successfully ', async () => {
   userEvent.click(await screen.findByText('Yes, Close the Polls'));
   await screen.findByText('Closing Polls…');
   await screen.findByText('Polls are closed.');
-  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledTimes(1);
-  expect(apiMock.mockApiClient.writeCardData).toHaveBeenNthCalledWith(1, {
-    data: expect.objectContaining({
+  expect(
+    apiMock.mockApiClient.saveScannerReportDataToCard
+  ).toHaveBeenCalledTimes(1);
+  expect(
+    apiMock.mockApiClient.saveScannerReportDataToCard
+  ).toHaveBeenNthCalledWith(1, {
+    scannerReportData: expect.objectContaining({
       isLiveMode: false,
       tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 1,
@@ -426,7 +430,6 @@ test('voter can cast a ballot that scans successfully ', async () => {
         [0, 0, 1, 1, 0], // Judicial Robert Demergue expected tally
       ]),
     }),
-    schema: 'ScannerReportDataSchema',
   });
 
   // Simulate unmounted usb drive
@@ -599,7 +602,7 @@ test('scanning is not triggered when polls closed or cards present', async () =>
 
 test('no printer: poll worker can open and close polls without scanning any ballots', async () => {
   apiMock.expectGetConfig();
-  apiMock.expectGetScannerStatus(statusNoPaper, 5);
+  apiMock.expectGetScannerStatus(statusNoPaper, 4);
   renderApp();
   await screen.findByText('Polls Closed');
 
@@ -700,7 +703,9 @@ test('no printer: open polls, scan ballot, close polls, save results', async () 
   await screen.findByText(
     'Insert poll worker card into VxMark to print the report.'
   );
-  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledTimes(1);
+  expect(
+    apiMock.mockApiClient.saveScannerReportDataToCard
+  ).toHaveBeenCalledTimes(1);
   apiMock.removeCard();
   await screen.findByText('Insert Your Ballot Below');
 
@@ -735,9 +740,13 @@ test('no printer: open polls, scan ballot, close polls, save results', async () 
   await screen.findByText(
     'Insert poll worker card into VxMark to print the report.'
   );
-  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledTimes(2);
-  expect(apiMock.mockApiClient.writeCardData).toHaveBeenNthCalledWith(2, {
-    data: expect.objectContaining({
+  expect(
+    apiMock.mockApiClient.saveScannerReportDataToCard
+  ).toHaveBeenCalledTimes(2);
+  expect(
+    apiMock.mockApiClient.saveScannerReportDataToCard
+  ).toHaveBeenNthCalledWith(2, {
+    scannerReportData: expect.objectContaining({
       isLiveMode: false,
       tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 1,
@@ -752,7 +761,6 @@ test('no printer: open polls, scan ballot, close polls, save results', async () 
         [0, 0, 1, 1, 0], // Judicial Robert Demergue expected tally
       ]),
     }),
-    schema: 'ScannerReportDataSchema',
   });
 
   apiMock.expectGetScannerStatus(statusNoPaper);

--- a/apps/vx-scan/frontend/src/app.tsx
+++ b/apps/vx-scan/frontend/src/app.tsx
@@ -1,40 +1,33 @@
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 
-import { WebServiceCard, getHardware } from '@votingworks/utils';
+import { getHardware } from '@votingworks/utils';
 import { Logger, LogSource } from '@votingworks/logging';
-import * as grout from '@votingworks/grout';
-// eslint-disable-next-line vx/gts-no-import-export-type
-import type { Api } from '@votingworks/vx-scan-backend';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import {
-  AppBase,
-  ErrorBoundary,
-  QUERY_CLIENT_DEFAULT_OPTIONS,
-  Text,
-} from '@votingworks/ui';
+import { AppBase, ErrorBoundary, Text } from '@votingworks/ui';
 import { ColorMode } from '@votingworks/types';
 import { AppRoot, Props as AppRootProps } from './app_root';
-import { ApiClientContext } from './api';
+import {
+  ApiClient,
+  ApiClientContext,
+  createApiClient,
+  createQueryClient,
+} from './api';
 import { TimesCircle } from './components/graphics';
 import { CenteredLargeProse } from './components/layout';
 
 export interface AppProps {
   hardware?: AppRootProps['hardware'];
-  card?: AppRootProps['card'];
   logger?: AppRootProps['logger'];
-  apiClient?: grout.Client<Api>;
+  apiClient?: ApiClient;
   queryClient?: QueryClient;
 }
 
 export function App({
   hardware = getHardware(),
-  card = new WebServiceCard(),
   logger = new Logger(LogSource.VxScanFrontend, window.kiosk),
-  apiClient = grout.createClient<Api>({ baseUrl: '/api' }),
-  queryClient = new QueryClient({
-    defaultOptions: QUERY_CLIENT_DEFAULT_OPTIONS,
-  }),
+  apiClient = createApiClient(),
+  queryClient = createQueryClient(),
 }: AppProps): JSX.Element {
   // Copied from old App.css
   const baseFontSizePx = 28;
@@ -62,7 +55,7 @@ export function App({
               isTouchscreen
               legacyBaseFontSizePx={baseFontSizePx}
             >
-              <AppRoot card={card} hardware={hardware} logger={logger} />
+              <AppRoot hardware={hardware} logger={logger} />
             </AppBase>
           </QueryClientProvider>
         </ApiClientContext.Provider>

--- a/apps/vx-scan/frontend/src/app_tally_report_paths.test.tsx
+++ b/apps/vx-scan/frontend/src/app_tally_report_paths.test.tsx
@@ -200,7 +200,7 @@ test('printing: polls open, All Precincts, primary election + check additional r
 test('saving to card: polls open, All Precincts, primary election + test failed card write', async () => {
   const electionDefinition = electionMinimalExhaustiveSampleDefinition;
   apiMock.expectGetConfig({ electionDefinition });
-  apiMock.expectGetScannerStatus(statusNoPaper, 5);
+  apiMock.expectGetScannerStatus(statusNoPaper, 4);
   renderApp({ connectPrinter: false });
   await screen.findByText('Polls Closed');
 
@@ -209,7 +209,7 @@ test('saving to card: polls open, All Precincts, primary election + test failed 
   apiMock.authenticateAsPollWorker(electionDefinition);
   await screen.findByText('Do you want to open the polls?');
   // Mimic what would happen if the tallies by precinct didn't fit on the card but the overall tally does
-  apiMock.mockApiClient.writeCardData.mockImplementationOnce(() =>
+  apiMock.mockApiClient.saveScannerReportDataToCard.mockImplementationOnce(() =>
     err(new Error('Whoa!'))
   );
   apiMock.expectSetPollsState('polls_open');
@@ -256,9 +256,13 @@ test('saving to card: polls open, All Precincts, primary election + test failed 
     '1,precinct-1': [0, 0],
     '1,precinct-2': [0, 0],
   };
-  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledTimes(2);
-  expect(apiMock.mockApiClient.writeCardData).toHaveBeenNthCalledWith(1, {
-    data: expect.objectContaining({
+  expect(
+    apiMock.mockApiClient.saveScannerReportDataToCard
+  ).toHaveBeenCalledTimes(2);
+  expect(
+    apiMock.mockApiClient.saveScannerReportDataToCard
+  ).toHaveBeenNthCalledWith(1, {
+    scannerReportData: expect.objectContaining({
       isLiveMode: false,
       tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 0,
@@ -271,11 +275,12 @@ test('saving to card: polls open, All Precincts, primary election + test failed 
       ballotCounts: expectedBallotCounts,
       pollsTransition: 'open_polls',
     }),
-    schema: 'ScannerReportDataSchema',
   });
   // Expect the final call to have an empty tallies by precinct dictionary
-  expect(apiMock.mockApiClient.writeCardData).toHaveBeenNthCalledWith(2, {
-    data: expect.objectContaining({
+  expect(
+    apiMock.mockApiClient.saveScannerReportDataToCard
+  ).toHaveBeenNthCalledWith(2, {
+    scannerReportData: expect.objectContaining({
       isLiveMode: false,
       tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 0,
@@ -288,7 +293,6 @@ test('saving to card: polls open, All Precincts, primary election + test failed 
       ballotCounts: expectedBallotCounts,
       pollsTransition: 'open_polls',
     }),
-    schema: 'ScannerReportDataSchema',
   });
 });
 
@@ -587,9 +591,13 @@ test('saving to card: polls closed, primary election, all precincts', async () =
     '1,precinct-1': [0, 0],
     '1,precinct-2': [1, 0],
   };
-  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledTimes(1);
-  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledWith({
-    data: expect.objectContaining({
+  expect(
+    apiMock.mockApiClient.saveScannerReportDataToCard
+  ).toHaveBeenCalledTimes(1);
+  expect(
+    apiMock.mockApiClient.saveScannerReportDataToCard
+  ).toHaveBeenCalledWith({
+    scannerReportData: expect.objectContaining({
       isLiveMode: false,
       tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 3,
@@ -602,7 +610,6 @@ test('saving to card: polls closed, primary election, all precincts', async () =
       ballotCounts: expectedBallotCounts,
       pollsTransition: 'close_polls',
     }),
-    schema: 'ScannerReportDataSchema',
   });
 });
 
@@ -821,9 +828,13 @@ test('saving to card: polls closed, primary election, single precinct', async ()
     '1,__ALL_PRECINCTS': [1, 0],
     '1,precinct-1': [1, 0],
   };
-  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledTimes(1);
-  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledWith({
-    data: expect.objectContaining({
+  expect(
+    apiMock.mockApiClient.saveScannerReportDataToCard
+  ).toHaveBeenCalledTimes(1);
+  expect(
+    apiMock.mockApiClient.saveScannerReportDataToCard
+  ).toHaveBeenCalledWith({
+    scannerReportData: expect.objectContaining({
       isLiveMode: false,
       tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 3,
@@ -836,7 +847,6 @@ test('saving to card: polls closed, primary election, single precinct', async ()
       ballotCounts: expectedBallotCounts,
       pollsTransition: 'close_polls',
     }),
-    schema: 'ScannerReportDataSchema',
   });
 });
 
@@ -990,9 +1000,13 @@ test('saving to card: polls closed, general election, all precincts', async () =
     'undefined,21': [0, 1],
     'undefined,20': [0, 0],
   };
-  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledTimes(1);
-  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledWith({
-    data: expect.objectContaining({
+  expect(
+    apiMock.mockApiClient.saveScannerReportDataToCard
+  ).toHaveBeenCalledTimes(1);
+  expect(
+    apiMock.mockApiClient.saveScannerReportDataToCard
+  ).toHaveBeenCalledWith({
+    scannerReportData: expect.objectContaining({
       isLiveMode: false,
       tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 2,
@@ -1005,7 +1019,6 @@ test('saving to card: polls closed, general election, all precincts', async () =
       ballotCounts: expectedBallotCounts,
       pollsTransition: 'close_polls',
     }),
-    schema: 'ScannerReportDataSchema',
   });
 });
 
@@ -1131,9 +1144,13 @@ test('saving to card: polls closed, general election, single precinct', async ()
     'undefined,__ALL_PRECINCTS': [1, 1],
     'undefined,23': [1, 1],
   };
-  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledTimes(1);
-  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledWith({
-    data: expect.objectContaining({
+  expect(
+    apiMock.mockApiClient.saveScannerReportDataToCard
+  ).toHaveBeenCalledTimes(1);
+  expect(
+    apiMock.mockApiClient.saveScannerReportDataToCard
+  ).toHaveBeenCalledWith({
+    scannerReportData: expect.objectContaining({
       isLiveMode: false,
       tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 2,
@@ -1146,7 +1163,6 @@ test('saving to card: polls closed, general election, single precinct', async ()
       ballotCounts: expectedBallotCounts,
       pollsTransition: 'close_polls',
     }),
-    schema: 'ScannerReportDataSchema',
   });
 });
 
@@ -1346,9 +1362,13 @@ test('saving to card: polls closed, general election with non-partisan contests,
     '0,__ALL_PRECINCTS': [2, 0],
     '1,__ALL_PRECINCTS': [2, 0],
   };
-  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledTimes(1);
-  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledWith({
-    data: expect.objectContaining({
+  expect(
+    apiMock.mockApiClient.saveScannerReportDataToCard
+  ).toHaveBeenCalledTimes(1);
+  expect(
+    apiMock.mockApiClient.saveScannerReportDataToCard
+  ).toHaveBeenCalledWith({
+    scannerReportData: expect.objectContaining({
       isLiveMode: false,
       tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 4,
@@ -1361,7 +1381,6 @@ test('saving to card: polls closed, general election with non-partisan contests,
       ballotCounts: expectedBallotCounts,
       pollsTransition: 'close_polls',
     }),
-    schema: 'ScannerReportDataSchema',
   });
 });
 
@@ -1433,9 +1452,13 @@ test('saving to card: polls paused', async () => {
   apiMock.removeCard();
   await advanceTimersAndPromises(1);
 
-  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledTimes(1);
-  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledWith({
-    data: expect.objectContaining({
+  expect(
+    apiMock.mockApiClient.saveScannerReportDataToCard
+  ).toHaveBeenCalledTimes(1);
+  expect(
+    apiMock.mockApiClient.saveScannerReportDataToCard
+  ).toHaveBeenCalledWith({
+    scannerReportData: expect.objectContaining({
       isLiveMode: false,
       tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 2,
@@ -1445,7 +1468,6 @@ test('saving to card: polls paused', async () => {
       precinctSelection: singlePrecinctSelectionFor('23'),
       pollsTransition: 'pause_voting',
     }),
-    schema: 'ScannerReportDataSchema',
   });
 });
 
@@ -1514,9 +1536,13 @@ test('saving to card: polls unpaused', async () => {
   apiMock.removeCard();
   await advanceTimersAndPromises(1);
 
-  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledTimes(1);
-  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledWith({
-    data: expect.objectContaining({
+  expect(
+    apiMock.mockApiClient.saveScannerReportDataToCard
+  ).toHaveBeenCalledTimes(1);
+  expect(
+    apiMock.mockApiClient.saveScannerReportDataToCard
+  ).toHaveBeenCalledWith({
+    scannerReportData: expect.objectContaining({
       isLiveMode: false,
       tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 2,
@@ -1526,7 +1552,6 @@ test('saving to card: polls unpaused', async () => {
       precinctSelection: singlePrecinctSelectionFor('23'),
       pollsTransition: 'resume_voting',
     }),
-    schema: 'ScannerReportDataSchema',
   });
 });
 
@@ -1609,7 +1634,7 @@ test('saving to card: polls closed from paused, general election, single precinc
     precinctSelection: singlePrecinctSelectionFor('23'),
     pollsState: 'polls_paused',
   });
-  apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 }, 5);
+  apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 }, 4);
   renderApp({ connectPrinter: false });
   await screen.findByText('Polls Paused');
 
@@ -1641,9 +1666,13 @@ test('saving to card: polls closed from paused, general election, single precinc
     'undefined,__ALL_PRECINCTS': [1, 1],
     'undefined,23': [1, 1],
   };
-  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledTimes(1);
-  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledWith({
-    data: expect.objectContaining({
+  expect(
+    apiMock.mockApiClient.saveScannerReportDataToCard
+  ).toHaveBeenCalledTimes(1);
+  expect(
+    apiMock.mockApiClient.saveScannerReportDataToCard
+  ).toHaveBeenCalledWith({
+    scannerReportData: expect.objectContaining({
       isLiveMode: false,
       tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 2,
@@ -1656,6 +1685,5 @@ test('saving to card: polls closed from paused, general election, single precinc
       ballotCounts: expectedBallotCounts,
       pollsTransition: 'close_polls',
     }),
-    schema: 'ScannerReportDataSchema',
   });
 });

--- a/apps/vx-scan/frontend/src/app_tally_report_paths.test.tsx
+++ b/apps/vx-scan/frontend/src/app_tally_report_paths.test.tsx
@@ -12,7 +12,6 @@ import {
 import {
   fakeKiosk,
   advanceTimersAndPromises,
-  makePollWorkerCard,
   generateCvr,
   getZeroCompressedTally,
   fakeUsbDrive,
@@ -24,7 +23,6 @@ import {
   BallotCountDetails,
   singlePrecinctSelectionFor,
   ReportSourceMachineType,
-  MemoryCard,
   MemoryHardware,
   MemoryStorage,
 } from '@votingworks/utils';
@@ -44,9 +42,13 @@ import { fakeLogger } from '@votingworks/logging';
 import { err } from '@votingworks/basics';
 import { fakeFileWriter } from '../test/helpers/fake_file_writer';
 import { App } from './app';
-import { createApiMock, statusNoPaper } from '../test/helpers/mock_api_client';
+import {
+  ApiMock,
+  createApiMock,
+  statusNoPaper,
+} from '../test/helpers/mock_api_client';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 function expectBallotCountsInReport(
   container: HTMLElement,
@@ -84,7 +86,6 @@ function expectContestResultsInReport(
 }
 
 function renderApp({ connectPrinter }: { connectPrinter: boolean }) {
-  const card = new MemoryCard();
   const hardware = MemoryHardware.build({
     connectPrinter,
     connectCardReader: true,
@@ -94,18 +95,17 @@ function renderApp({ connectPrinter }: { connectPrinter: boolean }) {
   const storage = new MemoryStorage();
   render(
     <App
-      card={card}
       hardware={hardware}
       logger={logger}
       apiClient={apiMock.mockApiClient}
     />
   );
-  return { card, hardware, logger, storage };
+  return { hardware, logger, storage };
 }
 
 beforeEach(() => {
   jest.useFakeTimers();
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
   apiMock.expectGetMachineConfig();
 
   const kiosk = fakeKiosk();
@@ -124,19 +124,16 @@ async function closePolls({
   electionDefinition,
   castVoteRecords,
   precinctSelection,
-  card,
   removeCardAfter = true,
 }: {
   electionDefinition: ElectionDefinition;
   castVoteRecords: CastVoteRecord[];
   precinctSelection: PrecinctSelection;
-  card: MemoryCard;
   removeCardAfter?: boolean;
 }): Promise<void> {
   apiMock.expectGetCastVoteRecordsForTally(castVoteRecords);
   apiMock.expectExportCastVoteRecordsToUsbDrive();
-  const pollWorkerCard = makePollWorkerCard(electionDefinition.electionHash);
-  card.insertCard(pollWorkerCard);
+  apiMock.authenticateAsPollWorker(electionDefinition);
   await screen.findByText('Do you want to close the polls?');
   apiMock.expectSetPollsState('polls_closed_final');
   apiMock.expectGetConfig({
@@ -147,7 +144,7 @@ async function closePolls({
   userEvent.click(await screen.findByText('Yes, Close the Polls'));
   await screen.findByText('Polls are closed.');
   if (removeCardAfter) {
-    card.removeCard();
+    apiMock.removeCard();
     await screen.findByText('Voting is complete.');
   }
 }
@@ -157,13 +154,12 @@ test('printing: polls open, All Precincts, primary election + check additional r
   const { election } = electionDefinition;
   apiMock.expectGetConfig({ electionDefinition });
   apiMock.expectGetScannerStatus(statusNoPaper, 4);
-  const { card } = renderApp({ connectPrinter: true });
+  renderApp({ connectPrinter: true });
   await screen.findByText('Polls Closed');
 
   // Open the polls
   apiMock.expectGetCastVoteRecordsForTally([]);
-  const pollWorkerCard = makePollWorkerCard(electionDefinition.electionHash);
-  card.insertCard(pollWorkerCard);
+  apiMock.authenticateAsPollWorker(electionDefinition);
   await screen.findByText('Do you want to open the polls?');
   apiMock.expectSetPollsState('polls_open');
   apiMock.expectGetConfig({ electionDefinition, pollsState: 'polls_open' });
@@ -204,26 +200,23 @@ test('printing: polls open, All Precincts, primary election + check additional r
 test('saving to card: polls open, All Precincts, primary election + test failed card write', async () => {
   const electionDefinition = electionMinimalExhaustiveSampleDefinition;
   apiMock.expectGetConfig({ electionDefinition });
-  apiMock.expectGetScannerStatus(statusNoPaper, 4);
-  const { card } = renderApp({ connectPrinter: false });
-  const writeLongObjectMock = jest.spyOn(card, 'writeLongObject');
+  apiMock.expectGetScannerStatus(statusNoPaper, 5);
+  renderApp({ connectPrinter: false });
   await screen.findByText('Polls Closed');
 
   // Open the polls
   apiMock.expectGetCastVoteRecordsForTally([]);
-  const pollWorkerCard = makePollWorkerCard(electionDefinition.electionHash);
-  card.insertCard(pollWorkerCard);
+  apiMock.authenticateAsPollWorker(electionDefinition);
   await screen.findByText('Do you want to open the polls?');
-  // Mimic what would happen if the tallies by precinct didn't fit on the card but the overall tally does.
-  // Mock the card reader not to return back whatever we save
-  jest
-    .spyOn(card, 'readLongObject')
-    .mockResolvedValue(err(new Error('bad read')));
+  // Mimic what would happen if the tallies by precinct didn't fit on the card but the overall tally does
+  apiMock.mockApiClient.writeCardData.mockImplementationOnce(() =>
+    err(new Error('Whoa!'))
+  );
   apiMock.expectSetPollsState('polls_open');
   apiMock.expectGetConfig({ electionDefinition, pollsState: 'polls_open' });
   userEvent.click(screen.getByText('Yes, Open the Polls'));
   await screen.findByText('Polls are open.');
-  card.removeCard();
+  apiMock.removeCard();
   await advanceTimersAndPromises(1);
 
   const expectedCombinedTally: CompressedTally = [
@@ -263,10 +256,9 @@ test('saving to card: polls open, All Precincts, primary election + test failed 
     '1,precinct-1': [0, 0],
     '1,precinct-2': [0, 0],
   };
-  expect(writeLongObjectMock).toHaveBeenCalledTimes(2);
-  expect(writeLongObjectMock).toHaveBeenNthCalledWith(
-    1,
-    expect.objectContaining({
+  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledTimes(2);
+  expect(apiMock.mockApiClient.writeCardData).toHaveBeenNthCalledWith(1, {
+    data: expect.objectContaining({
       isLiveMode: false,
       tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 0,
@@ -278,12 +270,12 @@ test('saving to card: polls open, All Precincts, primary election + test failed 
       talliesByPrecinct: expectedTalliesByPrecinct,
       ballotCounts: expectedBallotCounts,
       pollsTransition: 'open_polls',
-    })
-  );
+    }),
+    schema: 'ScannerReportDataSchema',
+  });
   // Expect the final call to have an empty tallies by precinct dictionary
-  expect(writeLongObjectMock).toHaveBeenNthCalledWith(
-    2,
-    expect.objectContaining({
+  expect(apiMock.mockApiClient.writeCardData).toHaveBeenNthCalledWith(2, {
+    data: expect.objectContaining({
       isLiveMode: false,
       tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 0,
@@ -295,8 +287,9 @@ test('saving to card: polls open, All Precincts, primary election + test failed 
       talliesByPrecinct: undefined,
       ballotCounts: expectedBallotCounts,
       pollsTransition: 'open_polls',
-    })
-  );
+    }),
+    schema: 'ScannerReportDataSchema',
+  });
 });
 
 const PRIMARY_ALL_PRECINCTS_CVRS = [
@@ -348,8 +341,8 @@ test('printing: polls closed, primary election, all precincts + quickresults on'
     electionMinimalExhaustiveSampleWithReportingUrlDefinition;
   const { election } = electionDefinition;
   apiMock.expectGetConfig({ electionDefinition, pollsState: 'polls_open' });
-  apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 3 }, 3);
-  const { card } = renderApp({ connectPrinter: true });
+  apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 3 }, 4);
+  renderApp({ connectPrinter: true });
   await screen.findByText('Insert Your Ballot Below');
 
   // Close the polls
@@ -357,7 +350,6 @@ test('printing: polls closed, primary election, all precincts + quickresults on'
     electionDefinition,
     castVoteRecords: PRIMARY_ALL_PRECINCTS_CVRS,
     precinctSelection: ALL_PRECINCTS_SELECTION,
-    card,
   });
 
   await expectPrint((printedElement) => {
@@ -547,9 +539,8 @@ test('saving to card: polls closed, primary election, all precincts', async () =
   const electionDefinition =
     electionMinimalExhaustiveSampleWithReportingUrlDefinition;
   apiMock.expectGetConfig({ electionDefinition, pollsState: 'polls_open' });
-  apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 3 }, 3);
-  const { card } = renderApp({ connectPrinter: false });
-  const writeLongObjectMock = jest.spyOn(card, 'writeLongObject');
+  apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 3 }, 4);
+  renderApp({ connectPrinter: false });
   await screen.findByText('Insert Your Ballot Below');
 
   // Close the polls
@@ -557,7 +548,6 @@ test('saving to card: polls closed, primary election, all precincts', async () =
     electionDefinition,
     castVoteRecords: PRIMARY_ALL_PRECINCTS_CVRS,
     precinctSelection: ALL_PRECINCTS_SELECTION,
-    card,
   });
 
   const expectedCombinedTally: CompressedTally = [
@@ -597,9 +587,9 @@ test('saving to card: polls closed, primary election, all precincts', async () =
     '1,precinct-1': [0, 0],
     '1,precinct-2': [1, 0],
   };
-  expect(writeLongObjectMock).toHaveBeenCalledTimes(1);
-  expect(writeLongObjectMock).toHaveBeenCalledWith(
-    expect.objectContaining({
+  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledTimes(1);
+  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledWith({
+    data: expect.objectContaining({
       isLiveMode: false,
       tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 3,
@@ -611,8 +601,9 @@ test('saving to card: polls closed, primary election, all precincts', async () =
       talliesByPrecinct: expectedTalliesByPrecinct,
       ballotCounts: expectedBallotCounts,
       pollsTransition: 'close_polls',
-    })
-  );
+    }),
+    schema: 'ScannerReportDataSchema',
+  });
 });
 
 const PRIMARY_SINGLE_PRECINCT_CVRS = [
@@ -669,7 +660,7 @@ test('printing: polls closed, primary election, single precinct + check addition
     pollsState: 'polls_open',
   });
   apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 3 }, 3);
-  const { card } = renderApp({ connectPrinter: true });
+  renderApp({ connectPrinter: true });
   await screen.findByText('Insert Your Ballot Below');
 
   // Close the polls
@@ -677,7 +668,6 @@ test('printing: polls closed, primary election, single precinct + check addition
     electionDefinition,
     castVoteRecords: PRIMARY_SINGLE_PRECINCT_CVRS,
     precinctSelection,
-    card,
     removeCardAfter: false,
   });
 
@@ -802,9 +792,8 @@ test('saving to card: polls closed, primary election, single precinct', async ()
     precinctSelection,
     pollsState: 'polls_open',
   });
-  apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 3 }, 3);
-  const { card } = renderApp({ connectPrinter: false });
-  const writeLongObjectMock = jest.spyOn(card, 'writeLongObject');
+  apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 3 }, 4);
+  renderApp({ connectPrinter: false });
   await screen.findByText('Insert Your Ballot Below');
 
   // Close the polls
@@ -812,7 +801,6 @@ test('saving to card: polls closed, primary election, single precinct', async ()
     electionDefinition,
     castVoteRecords: PRIMARY_SINGLE_PRECINCT_CVRS,
     precinctSelection,
-    card,
   });
 
   const expectedCombinedTally: CompressedTally = [
@@ -833,9 +821,9 @@ test('saving to card: polls closed, primary election, single precinct', async ()
     '1,__ALL_PRECINCTS': [1, 0],
     '1,precinct-1': [1, 0],
   };
-  expect(writeLongObjectMock).toHaveBeenCalledTimes(1);
-  expect(writeLongObjectMock).toHaveBeenCalledWith(
-    expect.objectContaining({
+  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledTimes(1);
+  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledWith({
+    data: expect.objectContaining({
       isLiveMode: false,
       tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 3,
@@ -847,8 +835,9 @@ test('saving to card: polls closed, primary election, single precinct', async ()
       talliesByPrecinct: expectedTalliesByPrecinct,
       ballotCounts: expectedBallotCounts,
       pollsTransition: 'close_polls',
-    })
-  );
+    }),
+    schema: 'ScannerReportDataSchema',
+  });
 });
 
 const GENERAL_ALL_PRECINCTS_CVRS = [
@@ -881,8 +870,8 @@ const GENERAL_ALL_PRECINCTS_CVRS = [
 test('printing: polls closed, general election, all precincts', async () => {
   const electionDefinition = electionSample2Definition;
   apiMock.expectGetConfig({ electionDefinition, pollsState: 'polls_open' });
-  apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 }, 3);
-  const { card } = renderApp({ connectPrinter: true });
+  apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 }, 4);
+  renderApp({ connectPrinter: true });
   await screen.findByText('Insert Your Ballot Below');
 
   // Close the polls
@@ -890,7 +879,6 @@ test('printing: polls closed, general election, all precincts', async () => {
     electionDefinition,
     castVoteRecords: GENERAL_ALL_PRECINCTS_CVRS,
     precinctSelection: ALL_PRECINCTS_SELECTION,
-    card,
   });
 
   await expectPrint((printedElement) => {
@@ -970,9 +958,8 @@ test('saving to card: polls closed, general election, all precincts', async () =
   const electionDefinition = electionSample2Definition;
   const { election } = electionDefinition;
   apiMock.expectGetConfig({ electionDefinition, pollsState: 'polls_open' });
-  apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 }, 3);
-  const { card } = renderApp({ connectPrinter: false });
-  const writeLongObjectMock = jest.spyOn(card, 'writeLongObject');
+  apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 }, 4);
+  renderApp({ connectPrinter: false });
   await screen.findByText('Insert Your Ballot Below');
 
   // Close the polls
@@ -980,7 +967,6 @@ test('saving to card: polls closed, general election, all precincts', async () =
     electionDefinition,
     castVoteRecords: GENERAL_ALL_PRECINCTS_CVRS,
     precinctSelection: ALL_PRECINCTS_SELECTION,
-    card,
   });
 
   const expectedCombinedTally = election.contests.map(() => expect.anything());
@@ -1004,9 +990,9 @@ test('saving to card: polls closed, general election, all precincts', async () =
     'undefined,21': [0, 1],
     'undefined,20': [0, 0],
   };
-  expect(writeLongObjectMock).toHaveBeenCalledTimes(1);
-  expect(writeLongObjectMock).toHaveBeenCalledWith(
-    expect.objectContaining({
+  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledTimes(1);
+  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledWith({
+    data: expect.objectContaining({
       isLiveMode: false,
       tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 2,
@@ -1018,8 +1004,9 @@ test('saving to card: polls closed, general election, all precincts', async () =
       talliesByPrecinct: expectedTalliesByPrecinct,
       ballotCounts: expectedBallotCounts,
       pollsTransition: 'close_polls',
-    })
-  );
+    }),
+    schema: 'ScannerReportDataSchema',
+  });
 });
 
 const GENERAL_SINGLE_PRECINCT_CVRS = [
@@ -1057,8 +1044,8 @@ test('printing: polls closed, general election, single precinct', async () => {
     precinctSelection,
     pollsState: 'polls_open',
   });
-  apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 }, 3);
-  const { card } = renderApp({ connectPrinter: true });
+  apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 }, 4);
+  renderApp({ connectPrinter: true });
   await screen.findByText('Insert Your Ballot Below');
 
   // Close the polls
@@ -1066,7 +1053,6 @@ test('printing: polls closed, general election, single precinct', async () => {
     electionDefinition,
     castVoteRecords: GENERAL_SINGLE_PRECINCT_CVRS,
     precinctSelection,
-    card,
   });
 
   await expectPrint((printedElement) => {
@@ -1123,9 +1109,8 @@ test('saving to card: polls closed, general election, single precinct', async ()
     precinctSelection,
     pollsState: 'polls_open',
   });
-  apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 }, 3);
-  const { card } = renderApp({ connectPrinter: false });
-  const writeLongObjectMock = jest.spyOn(card, 'writeLongObject');
+  apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 }, 4);
+  renderApp({ connectPrinter: false });
   await screen.findByText('Insert Your Ballot Below');
 
   // Close the polls
@@ -1133,7 +1118,6 @@ test('saving to card: polls closed, general election, single precinct', async ()
     electionDefinition,
     castVoteRecords: GENERAL_SINGLE_PRECINCT_CVRS,
     precinctSelection,
-    card,
   });
 
   const expectedCombinedTally = election.contests.map(() => expect.anything());
@@ -1147,9 +1131,9 @@ test('saving to card: polls closed, general election, single precinct', async ()
     'undefined,__ALL_PRECINCTS': [1, 1],
     'undefined,23': [1, 1],
   };
-  expect(writeLongObjectMock).toHaveBeenCalledTimes(1);
-  expect(writeLongObjectMock).toHaveBeenCalledWith(
-    expect.objectContaining({
+  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledTimes(1);
+  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledWith({
+    data: expect.objectContaining({
       isLiveMode: false,
       tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 2,
@@ -1161,8 +1145,9 @@ test('saving to card: polls closed, general election, single precinct', async ()
       talliesByPrecinct: expectedTalliesByPrecinct,
       ballotCounts: expectedBallotCounts,
       pollsTransition: 'close_polls',
-    })
-  );
+    }),
+    schema: 'ScannerReportDataSchema',
+  });
 });
 
 const PRIMARY_NONPARTISAN_CONTESTS_CVR = [
@@ -1225,15 +1210,14 @@ test('printing: polls closed, general election with non-partisan contests, all p
     precinctSelection,
     pollsState: 'polls_open',
   });
-  apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 4 }, 3);
-  const { card } = renderApp({ connectPrinter: true });
+  apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 4 }, 4);
+  renderApp({ connectPrinter: true });
   await screen.findByText('Insert Your Ballot Below');
 
   await closePolls({
     electionDefinition,
     castVoteRecords: PRIMARY_NONPARTISAN_CONTESTS_CVR,
     precinctSelection,
-    card,
   });
 
   await expectPrint((printedElement) => {
@@ -1308,9 +1292,8 @@ test('saving to card: polls closed, general election with non-partisan contests,
     precinctSelection,
     pollsState: 'polls_open',
   });
-  apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 4 }, 3);
-  const { card } = renderApp({ connectPrinter: false });
-  const writeLongObjectMock = jest.spyOn(card, 'writeLongObject');
+  apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 4 }, 4);
+  renderApp({ connectPrinter: false });
   await screen.findByText('Insert Your Ballot Below');
 
   // Close the polls
@@ -1318,7 +1301,6 @@ test('saving to card: polls closed, general election with non-partisan contests,
     electionDefinition,
     castVoteRecords: PRIMARY_NONPARTISAN_CONTESTS_CVR,
     precinctSelection,
-    card,
   });
 
   const expectedCombinedTally = [
@@ -1364,9 +1346,9 @@ test('saving to card: polls closed, general election with non-partisan contests,
     '0,__ALL_PRECINCTS': [2, 0],
     '1,__ALL_PRECINCTS': [2, 0],
   };
-  expect(writeLongObjectMock).toHaveBeenCalledTimes(1);
-  expect(writeLongObjectMock).toHaveBeenCalledWith(
-    expect.objectContaining({
+  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledTimes(1);
+  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledWith({
+    data: expect.objectContaining({
       isLiveMode: false,
       tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 4,
@@ -1378,8 +1360,9 @@ test('saving to card: polls closed, general election with non-partisan contests,
       talliesByPrecinct: expectedTalliesByPrecinct,
       ballotCounts: expectedBallotCounts,
       pollsTransition: 'close_polls',
-    })
-  );
+    }),
+    schema: 'ScannerReportDataSchema',
+  });
 });
 
 test('printing: polls paused', async () => {
@@ -1390,14 +1373,13 @@ test('printing: polls paused', async () => {
     precinctSelection: singlePrecinctSelectionFor('23'),
     pollsState: 'polls_open',
   });
-  apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 }, 2);
-  const { card } = renderApp({ connectPrinter: true });
+  apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 }, 3);
+  renderApp({ connectPrinter: true });
   await screen.findByText('Insert Your Ballot Below');
 
   // Pause the polls
   apiMock.expectGetCastVoteRecordsForTally(GENERAL_SINGLE_PRECINCT_CVRS);
-  const pollWorkerCard = makePollWorkerCard(electionDefinition.electionHash);
-  card.insertCard(pollWorkerCard);
+  apiMock.authenticateAsPollWorker(electionDefinition);
   await screen.findByText('Do you want to close the polls?');
   userEvent.click(await screen.findByText('No'));
   apiMock.expectSetPollsState('polls_paused');
@@ -1432,14 +1414,12 @@ test('saving to card: polls paused', async () => {
     pollsState: 'polls_open',
   });
   apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 }, 4);
-  const { card } = renderApp({ connectPrinter: false });
-  const writeLongObjectMock = jest.spyOn(card, 'writeLongObject');
+  renderApp({ connectPrinter: false });
   await screen.findByText('Insert Your Ballot Below');
 
   // Pause the polls
   apiMock.expectGetCastVoteRecordsForTally(GENERAL_SINGLE_PRECINCT_CVRS);
-  const pollWorkerCard = makePollWorkerCard(electionDefinition.electionHash);
-  card.insertCard(pollWorkerCard);
+  apiMock.authenticateAsPollWorker(electionDefinition);
   await screen.findByText('Do you want to close the polls?');
   userEvent.click(screen.getByText('No'));
   apiMock.expectSetPollsState('polls_paused');
@@ -1450,12 +1430,12 @@ test('saving to card: polls paused', async () => {
   });
   userEvent.click(await screen.findByText('Pause Voting'));
   await screen.findByText('Voting paused.');
-  card.removeCard();
+  apiMock.removeCard();
   await advanceTimersAndPromises(1);
 
-  expect(writeLongObjectMock).toHaveBeenCalledTimes(1);
-  expect(writeLongObjectMock).toHaveBeenCalledWith(
-    expect.objectContaining({
+  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledTimes(1);
+  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledWith({
+    data: expect.objectContaining({
       isLiveMode: false,
       tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 2,
@@ -1464,8 +1444,9 @@ test('saving to card: polls paused', async () => {
       timeSaved: expect.anything(),
       precinctSelection: singlePrecinctSelectionFor('23'),
       pollsTransition: 'pause_voting',
-    })
-  );
+    }),
+    schema: 'ScannerReportDataSchema',
+  });
 });
 
 test('printing: polls unpaused', async () => {
@@ -1476,14 +1457,13 @@ test('printing: polls unpaused', async () => {
     precinctSelection: singlePrecinctSelectionFor('23'),
     pollsState: 'polls_paused',
   });
-  apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 }, 2);
-  const { card } = renderApp({ connectPrinter: true });
+  apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 }, 3);
+  renderApp({ connectPrinter: true });
   await screen.findByText('Polls Paused');
 
   // Unpause the polls
   apiMock.expectGetCastVoteRecordsForTally(GENERAL_SINGLE_PRECINCT_CVRS);
-  const pollWorkerCard = makePollWorkerCard(electionDefinition.electionHash);
-  card.insertCard(pollWorkerCard);
+  apiMock.authenticateAsPollWorker(electionDefinition);
   await screen.findByText('Do you want to resume voting?');
   userEvent.click(await screen.findByText('Yes, Resume Voting'));
   apiMock.expectSetPollsState('polls_open');
@@ -1516,14 +1496,12 @@ test('saving to card: polls unpaused', async () => {
     precinctSelection: singlePrecinctSelectionFor('23'),
     pollsState: 'polls_paused',
   });
-  apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 }, 3);
-  const { card } = renderApp({ connectPrinter: false });
-  const writeLongObjectMock = jest.spyOn(card, 'writeLongObject');
+  apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 }, 4);
+  renderApp({ connectPrinter: false });
 
   // Unpause the polls
   apiMock.expectGetCastVoteRecordsForTally(GENERAL_SINGLE_PRECINCT_CVRS);
-  const pollWorkerCard = makePollWorkerCard(electionDefinition.electionHash);
-  card.insertCard(pollWorkerCard);
+  apiMock.authenticateAsPollWorker(electionDefinition);
   await screen.findByText('Do you want to resume voting?');
   userEvent.click(screen.getByText('Yes, Resume Voting'));
   apiMock.expectSetPollsState('polls_open');
@@ -1533,12 +1511,12 @@ test('saving to card: polls unpaused', async () => {
     pollsState: 'polls_open',
   });
   await screen.findByText('Voting resumed.');
-  card.removeCard();
+  apiMock.removeCard();
   await advanceTimersAndPromises(1);
 
-  expect(writeLongObjectMock).toHaveBeenCalledTimes(1);
-  expect(writeLongObjectMock).toHaveBeenCalledWith(
-    expect.objectContaining({
+  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledTimes(1);
+  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledWith({
+    data: expect.objectContaining({
       isLiveMode: false,
       tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 2,
@@ -1547,8 +1525,9 @@ test('saving to card: polls unpaused', async () => {
       timeSaved: expect.anything(),
       precinctSelection: singlePrecinctSelectionFor('23'),
       pollsTransition: 'resume_voting',
-    })
-  );
+    }),
+    schema: 'ScannerReportDataSchema',
+  });
 });
 
 test('printing: polls closed from paused, general election, single precinct', async () => {
@@ -1559,14 +1538,13 @@ test('printing: polls closed from paused, general election, single precinct', as
     pollsState: 'polls_paused',
   });
   apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 }, 3);
-  const { card } = renderApp({ connectPrinter: true });
+  renderApp({ connectPrinter: true });
   await screen.findByText('Polls Paused');
 
   // Close the polls
   apiMock.expectGetCastVoteRecordsForTally(GENERAL_SINGLE_PRECINCT_CVRS);
   apiMock.expectExportCastVoteRecordsToUsbDrive();
-  const pollWorkerCard = makePollWorkerCard(electionDefinition.electionHash);
-  card.insertCard(pollWorkerCard);
+  apiMock.authenticateAsPollWorker(electionDefinition);
   await screen.findByText('Do you want to resume voting?');
   userEvent.click(screen.getByText('No'));
   apiMock.expectSetPollsState('polls_closed_final');
@@ -1631,16 +1609,14 @@ test('saving to card: polls closed from paused, general election, single precinc
     precinctSelection: singlePrecinctSelectionFor('23'),
     pollsState: 'polls_paused',
   });
-  apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 }, 4);
-  const { card } = renderApp({ connectPrinter: false });
-  const writeLongObjectMock = jest.spyOn(card, 'writeLongObject');
+  apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 }, 5);
+  renderApp({ connectPrinter: false });
   await screen.findByText('Polls Paused');
 
   // Close the polls
   apiMock.expectGetCastVoteRecordsForTally(GENERAL_SINGLE_PRECINCT_CVRS);
   apiMock.expectExportCastVoteRecordsToUsbDrive();
-  const pollWorkerCard = makePollWorkerCard(electionDefinition.electionHash);
-  card.insertCard(pollWorkerCard);
+  apiMock.authenticateAsPollWorker(electionDefinition);
   await screen.findByText('Do you want to resume voting?');
   userEvent.click(screen.getByText('No'));
   apiMock.expectSetPollsState('polls_closed_final');
@@ -1651,7 +1627,7 @@ test('saving to card: polls closed from paused, general election, single precinc
   });
   userEvent.click(await screen.findByText('Close Polls'));
   await screen.findByText('Polls are closed.');
-  card.removeCard();
+  apiMock.removeCard();
   await advanceTimersAndPromises(1);
 
   const expectedCombinedTally = election.contests.map(() => expect.anything());
@@ -1665,9 +1641,9 @@ test('saving to card: polls closed from paused, general election, single precinc
     'undefined,__ALL_PRECINCTS': [1, 1],
     'undefined,23': [1, 1],
   };
-  expect(writeLongObjectMock).toHaveBeenCalledTimes(1);
-  expect(writeLongObjectMock).toHaveBeenCalledWith(
-    expect.objectContaining({
+  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledTimes(1);
+  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledWith({
+    data: expect.objectContaining({
       isLiveMode: false,
       tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
       totalBallotsScanned: 2,
@@ -1679,6 +1655,7 @@ test('saving to card: polls closed from paused, general election, single precinc
       talliesByPrecinct: expectedTalliesByPrecinct,
       ballotCounts: expectedBallotCounts,
       pollsTransition: 'close_polls',
-    })
-  );
+    }),
+    schema: 'ScannerReportDataSchema',
+  });
 });

--- a/apps/vx-scan/frontend/src/app_unhappy_paths.test.tsx
+++ b/apps/vx-scan/frontend/src/app_unhappy_paths.test.tsx
@@ -228,10 +228,13 @@ test('App shows warning message to connect to power when disconnected', async ()
   apiMock.expectGetConfig({ pollsState: 'polls_open' });
   userEvent.click(await screen.findByText('Yes, Open the Polls'));
   await screen.findByText('Polls are open.');
-  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledTimes(1);
-  expect(apiMock.mockApiClient.writeCardData).toHaveBeenNthCalledWith(1, {
-    data: expect.anything(),
-    schema: 'ScannerReportDataSchema',
+  expect(
+    apiMock.mockApiClient.saveScannerReportDataToCard
+  ).toHaveBeenCalledTimes(1);
+  expect(
+    apiMock.mockApiClient.saveScannerReportDataToCard
+  ).toHaveBeenNthCalledWith(1, {
+    scannerReportData: expect.anything(),
   });
 
   // Remove pollworker card

--- a/apps/vx-scan/frontend/src/app_unhappy_paths.test.tsx
+++ b/apps/vx-scan/frontend/src/app_unhappy_paths.test.tsx
@@ -1,36 +1,30 @@
 /* eslint-disable no-console */
 import React from 'react';
 import { act, render, screen, waitFor } from '@testing-library/react';
-import {
-  electionSampleDefinition,
-  electionWithMsEitherNeitherDefinition,
-} from '@votingworks/fixtures';
+import { electionSampleDefinition } from '@votingworks/fixtures';
 import {
   advanceTimersAndPromises,
   fakeKiosk,
   fakeUsbDrive,
-  makeElectionManagerCard,
-  makePollWorkerCard,
-  makeVoterCard,
 } from '@votingworks/test-utils';
-import { MemoryCard, MemoryHardware, MemoryStorage } from '@votingworks/utils';
+import { MemoryHardware, MemoryStorage } from '@votingworks/utils';
 
 import userEvent from '@testing-library/user-event';
 
 import { ServerError } from '@votingworks/grout';
 import { fakeLogger } from '@votingworks/logging';
 import { deferred } from '@votingworks/basics';
+import { scannerStatus } from '../test/helpers/helpers';
 import {
-  authenticateElectionManagerCard,
-  scannerStatus,
-} from '../test/helpers/helpers';
-import { createApiMock, statusNoPaper } from '../test/helpers/mock_api_client';
+  ApiMock,
+  createApiMock,
+  statusNoPaper,
+} from '../test/helpers/mock_api_client';
 import { App, AppProps } from './app';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 function renderApp(props: Partial<AppProps> = {}) {
-  const card = new MemoryCard();
   const hardware = MemoryHardware.build({
     connectPrinter: false,
     connectCardReader: true,
@@ -40,19 +34,18 @@ function renderApp(props: Partial<AppProps> = {}) {
   const storage = new MemoryStorage();
   render(
     <App
-      card={card}
       hardware={hardware}
       logger={logger}
       apiClient={apiMock.mockApiClient}
       {...props}
     />
   );
-  return { card, hardware, logger, storage };
+  return { hardware, logger, storage };
 }
 
 beforeEach(() => {
   jest.useFakeTimers();
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
   apiMock.expectGetMachineConfig();
 });
 
@@ -86,13 +79,8 @@ test('backend fails to unconfigure', async () => {
     .expectCallWith({})
     .throws(new ServerError('failed'));
 
-  const { card } = renderApp();
-  const electionManagerCard = makeElectionManagerCard(
-    electionSampleDefinition.electionHash,
-    '123456'
-  );
-  card.insertCard(electionManagerCard, electionSampleDefinition.electionData);
-  await authenticateElectionManagerCard();
+  renderApp();
+  apiMock.authenticateAsElectionManager(electionSampleDefinition);
 
   userEvent.click(
     await screen.findByText('Delete All Election Data from VxScan')
@@ -107,57 +95,59 @@ test('backend fails to unconfigure', async () => {
 
 test('Show invalid card screen when unsupported cards are given', async () => {
   apiMock.expectGetConfig();
-  apiMock.expectGetScannerStatus(statusNoPaper, 2);
+  apiMock.expectGetScannerStatus(statusNoPaper, 3);
 
-  const { card } = renderApp();
-  await screen.findByText('Polls Closed');
-  const voterCard = makeVoterCard(electionSampleDefinition.election);
-  card.insertCard(voterCard);
-  await screen.findByText('Invalid Card');
-
-  // Remove card
-  card.removeCard();
+  renderApp();
   await screen.findByText('Polls Closed');
 
   // Insert an invalid card
-  card.insertCard(JSON.stringify({ t: 'something' }));
+  apiMock.setAuthStatus({
+    status: 'logged_out',
+    reason: 'invalid_user_on_card',
+  });
   await screen.findByText('Invalid Card');
 
   // Remove card
-  card.removeCard();
+  apiMock.removeCard();
   await screen.findByText('Polls Closed');
 
   // Insert a voter card which is invalid
-  card.insertCard(JSON.stringify({ t: 'voter' }));
+  apiMock.setAuthStatus({
+    status: 'logged_out',
+    reason: 'voter_wrong_election',
+  });
   await screen.findByText('Invalid Card');
 
   // Remove card
-  card.removeCard();
+  apiMock.removeCard();
   await screen.findByText('Polls Closed');
 
   // Insert a poll worker card which is invalid
-  const pollWorkerCardWrongElection = makePollWorkerCard(
-    electionWithMsEitherNeitherDefinition.electionHash
-  );
-  card.insertCard(pollWorkerCardWrongElection);
+  apiMock.setAuthStatus({
+    status: 'logged_out',
+    reason: 'poll_worker_wrong_election',
+  });
   await screen.findByText('Invalid Card');
 
   // Remove card
-  card.removeCard();
+  apiMock.removeCard();
   await screen.findByText('Polls Closed');
 });
 
 test('show card backwards screen when card connection error occurs', async () => {
   apiMock.expectGetConfig();
   apiMock.expectGetScannerStatus(statusNoPaper);
-  const { card } = renderApp();
+  renderApp();
 
   await screen.findByText('Polls Closed');
-  card.insertCard(undefined, undefined, 'error');
+  apiMock.setAuthStatus({
+    status: 'logged_out',
+    reason: 'card_error',
+  });
   await screen.findByText('Card is Backwards');
   screen.getByText('Remove the card, turn it around, and insert it again.');
 
-  card.removeCard();
+  apiMock.removeCard();
   await screen.findByText('Polls Closed');
 });
 
@@ -216,7 +206,7 @@ test('App shows warning message to connect to power when disconnected', async ()
   kiosk.getUsbDriveInfo = jest.fn().mockResolvedValue([fakeUsbDrive()]);
   window.kiosk = kiosk;
   apiMock.expectGetScannerStatus(statusNoPaper, 7);
-  const { card } = renderApp({ hardware });
+  renderApp({ hardware });
   apiMock.expectGetCastVoteRecordsForTally([]);
   await screen.findByText('Polls Closed');
   await screen.findByText('No Power Detected.');
@@ -233,17 +223,19 @@ test('App shows warning message to connect to power when disconnected', async ()
   expect(screen.queryByText('No Power Detected.')).toBeNull();
 
   // Open Polls
-  const pollWorkerCard = makePollWorkerCard(
-    electionSampleDefinition.electionHash
-  );
-  card.insertCard(pollWorkerCard);
+  apiMock.authenticateAsPollWorker(electionSampleDefinition);
   apiMock.expectSetPollsState('polls_open');
   apiMock.expectGetConfig({ pollsState: 'polls_open' });
   userEvent.click(await screen.findByText('Yes, Open the Polls'));
   await screen.findByText('Polls are open.');
+  expect(apiMock.mockApiClient.writeCardData).toHaveBeenCalledTimes(1);
+  expect(apiMock.mockApiClient.writeCardData).toHaveBeenNthCalledWith(1, {
+    data: expect.anything(),
+    schema: 'ScannerReportDataSchema',
+  });
 
   // Remove pollworker card
-  card.removeCard();
+  apiMock.removeCard();
   await screen.findByText('Insert Your Ballot Below');
   // There should be no warning about power
   expect(screen.queryByText('No Power Detected.')).toBeNull();
@@ -261,28 +253,21 @@ test('removing card during calibration', async () => {
   window.kiosk = kiosk;
   apiMock.expectGetScannerStatus(statusNoPaper, 4);
   apiMock.expectGetCastVoteRecordsForTally([]);
-  const { card } = renderApp();
+  renderApp();
 
   // Open Polls
-  const pollWorkerCard = makePollWorkerCard(
-    electionSampleDefinition.electionHash
-  );
-  card.insertCard(pollWorkerCard);
+  apiMock.authenticateAsPollWorker(electionSampleDefinition);
   userEvent.click(
     await screen.findByRole('button', { name: 'Yes, Open the Polls' })
   );
   apiMock.expectSetPollsState('polls_open');
   apiMock.expectGetConfig({ pollsState: 'polls_open' });
   await screen.findByText('Polls are open.');
-  card.removeCard();
+  apiMock.removeCard();
   await screen.findByText('Insert Your Ballot Below');
 
   // Start calibrating
-  const electionManagerCard = makeElectionManagerCard(
-    electionSampleDefinition.electionHash
-  );
-  card.insertCard(electionManagerCard, electionSampleDefinition.electionData);
-  await authenticateElectionManagerCard();
+  apiMock.authenticateAsElectionManager(electionSampleDefinition);
 
   const { promise, resolve } = deferred<boolean>();
   apiMock.mockApiClient.calibrate.expectCallWith().returns(promise);
@@ -303,7 +288,7 @@ test('removing card during calibration', async () => {
   );
 
   // Removing card shouldn't crash the app - for now we just show a blank screen
-  card.removeCard();
+  apiMock.removeCard();
   await waitFor(() => {
     expect(screen.queryByText(/Calibrating/)).not.toBeInTheDocument();
   });

--- a/apps/vx-scan/frontend/src/components/calibrate_scanner_modal.test.tsx
+++ b/apps/vx-scan/frontend/src/components/calibrate_scanner_modal.test.tsx
@@ -8,7 +8,11 @@ import {
   CalibrateScannerModal,
   CalibrateScannerModalProps,
 } from './calibrate_scanner_modal';
-import { createApiMock, provideApi } from '../../test/helpers/mock_api_client';
+import {
+  ApiMock,
+  createApiMock,
+  provideApi,
+} from '../../test/helpers/mock_api_client';
 
 const fakeScannerStatus: PrecinctScannerStatus = {
   state: 'no_paper',
@@ -16,7 +20,7 @@ const fakeScannerStatus: PrecinctScannerStatus = {
   canUnconfigure: true,
 };
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 function renderModal(props: Partial<CalibrateScannerModalProps> = {}) {
   return render(
@@ -32,7 +36,7 @@ function renderModal(props: Partial<CalibrateScannerModalProps> = {}) {
 }
 
 beforeEach(() => {
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
 });
 
 afterEach(() => {

--- a/apps/vx-scan/frontend/src/components/export_backup_modal.test.tsx
+++ b/apps/vx-scan/frontend/src/components/export_backup_modal.test.tsx
@@ -4,17 +4,21 @@ import userEvent from '@testing-library/user-event';
 import { fakeKiosk, fakeUsbDrive } from '@votingworks/test-utils';
 import { err, ok } from '@votingworks/basics';
 import { UsbDriveStatus } from '@votingworks/ui';
-import { createApiMock, provideApi } from '../../test/helpers/mock_api_client';
+import {
+  ApiMock,
+  createApiMock,
+  provideApi,
+} from '../../test/helpers/mock_api_client';
 import { mockUsbDrive } from '../../test/helpers/mock_usb_drive';
 import {
   ExportBackupModal,
   ExportBackupModalProps,
 } from './export_backup_modal';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 beforeEach(() => {
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
 });
 
 afterEach(() => {

--- a/apps/vx-scan/frontend/src/components/export_results_modal.test.tsx
+++ b/apps/vx-scan/frontend/src/components/export_results_modal.test.tsx
@@ -10,10 +10,14 @@ import {
   ExportResultsModalProps,
 } from './export_results_modal';
 import { fakeFileWriter } from '../../test/helpers/fake_file_writer';
-import { createApiMock, provideApi } from '../../test/helpers/mock_api_client';
+import {
+  ApiMock,
+  createApiMock,
+  provideApi,
+} from '../../test/helpers/mock_api_client';
 import { mockUsbDrive } from '../../test/helpers/mock_usb_drive';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 function renderModal(props: Partial<ExportResultsModalProps> = {}) {
   return render(
@@ -29,7 +33,7 @@ function renderModal(props: Partial<ExportResultsModalProps> = {}) {
 }
 
 beforeEach(() => {
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
 });
 
 afterEach(() => {

--- a/apps/vx-scan/frontend/src/components/set_mark_thresholds_modal.test.tsx
+++ b/apps/vx-scan/frontend/src/components/set_mark_thresholds_modal.test.tsx
@@ -6,12 +6,16 @@ import {
   SetMarkThresholdsModal,
   SetMarkThresholdsModalProps,
 } from './set_mark_thresholds_modal';
-import { createApiMock, provideApi } from '../../test/helpers/mock_api_client';
+import {
+  ApiMock,
+  createApiMock,
+  provideApi,
+} from '../../test/helpers/mock_api_client';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 beforeEach(() => {
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
 });
 
 afterEach(() => {

--- a/apps/vx-scan/frontend/src/preview_dashboard.tsx
+++ b/apps/vx-scan/frontend/src/preview_dashboard.tsx
@@ -4,16 +4,13 @@ import {
   ElectionDefinition,
   safeParseElectionDefinition,
 } from '@votingworks/types';
-import { Prose, QUERY_CLIENT_DEFAULT_OPTIONS, Select } from '@votingworks/ui';
+import { Prose, Select } from '@votingworks/ui';
 import { assert } from '@votingworks/basics';
 import React, { useRef, useState } from 'react';
 import { BrowserRouter, Link, Route } from 'react-router-dom';
 import styled from 'styled-components';
-import * as grout from '@votingworks/grout';
-// eslint-disable-next-line vx/gts-no-import-export-type
-import type { Api } from '@votingworks/vx-scan-backend';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ApiClientContext } from './api';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { ApiClientContext, createApiClient, createQueryClient } from './api';
 
 interface PreviewContextValues {
   electionDefinition: ElectionDefinition;
@@ -162,14 +159,8 @@ export function PreviewDashboard({
 
   return (
     <PreviewContext.Provider value={{ electionDefinition }}>
-      <ApiClientContext.Provider
-        value={grout.createClient<Api>({ baseUrl: '/api' })}
-      >
-        <QueryClientProvider
-          client={
-            new QueryClient({ defaultOptions: QUERY_CLIENT_DEFAULT_OPTIONS })
-          }
-        >
+      <ApiClientContext.Provider value={createApiClient()}>
+        <QueryClientProvider client={createQueryClient()}>
           <BrowserRouter>
             <Route path="/preview" exact>
               <h1>Previews</h1>

--- a/apps/vx-scan/frontend/src/screens/election_manager_screen.test.tsx
+++ b/apps/vx-scan/frontend/src/screens/election_manager_screen.test.tsx
@@ -17,6 +17,7 @@ import { singlePrecinctSelectionFor } from '@votingworks/utils';
 import MockDate from 'mockdate';
 import React from 'react';
 import {
+  ApiMock,
   createApiMock,
   provideApi,
   statusNoPaper,
@@ -27,14 +28,14 @@ import {
   ElectionManagerScreenProps,
 } from './election_manager_screen';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 beforeEach(() => {
   MockDate.set('2020-10-31T00:00:00.000Z');
   jest.useFakeTimers();
   window.location.href = '/';
   window.kiosk = fakeKiosk();
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
   apiMock.expectGetMachineConfig();
 });
 

--- a/apps/vx-scan/frontend/src/screens/poll_worker_screen.tsx
+++ b/apps/vx-scan/frontend/src/screens/poll_worker_screen.tsx
@@ -231,6 +231,7 @@ export function PollWorkerScreen({
         ...reportBasicData,
         pollsTransition,
       };
+      // TODO: Handle when this returns false
       await saveScannerReportDataToCard(ballotCountReportData);
       return;
     }
@@ -303,7 +304,7 @@ export function PollWorkerScreen({
       debug(
         'Error saving tally information to card, trying again without precinct-specific data'
       );
-      // TODO show an error message if this attempt also fails.
+      // TODO: Handle when this second attempt returns false
       await saveScannerReportDataToCard({
         ...tallyReportData,
         talliesByPrecinct: undefined,

--- a/apps/vx-scan/frontend/src/screens/poll_worker_screen.tsx
+++ b/apps/vx-scan/frontend/src/screens/poll_worker_screen.tsx
@@ -20,7 +20,6 @@ import {
   getTallyIdentifier,
   isFeatureFlagEnabled,
   ScannerReportData,
-  ScannerReportDataSchema,
   ReportSourceMachineType,
   getPollsTransitionDestinationState,
   getPollsReportTitle,
@@ -37,7 +36,6 @@ import {
   Dictionary,
   CompressedTally,
   getPartyIdsInBallotStyles,
-  InsertedSmartcardAuth,
   PollsState,
   PollsTransition,
   Optional,
@@ -49,7 +47,7 @@ import {
   LogEventId,
   Logger,
 } from '@votingworks/logging';
-import { assert, sleep, throwIllegalValue } from '@votingworks/basics';
+import { assert, Result, sleep, throwIllegalValue } from '@votingworks/basics';
 import {
   CenteredLargeProse,
   ScreenMainCenterChild,
@@ -64,6 +62,7 @@ import {
   exportCastVoteRecordsToUsbDrive,
   getCastVoteRecordsForTally,
   setPollsState,
+  writeCardData,
 } from '../api';
 import { MachineConfig } from '../config/types';
 
@@ -75,19 +74,6 @@ type PollWorkerFlowState =
   | 'polls_transition_processing'
   | 'polls_transition_complete'
   | 'reprinting_report';
-
-async function saveReportDataToCard(
-  auth: InsertedSmartcardAuth.PollWorkerLoggedIn,
-  reportData: ScannerReportData
-): Promise<boolean> {
-  if ((await auth.card.writeStoredData(reportData)).isErr()) {
-    return false;
-  }
-  const possibleTally = await auth.card.readStoredObject(
-    ScannerReportDataSchema
-  );
-  return possibleTally.ok()?.timeSaved === reportData.timeSaved;
-}
 
 const debug = rootDebug.extend('pollworker-screen');
 
@@ -114,7 +100,6 @@ export interface PollWorkerScreenProps {
   pollsState: PollsState;
   isLiveMode: boolean;
   hasPrinterAttached: boolean;
-  auth: InsertedSmartcardAuth.PollWorkerLoggedIn;
   logger: Logger;
 }
 
@@ -126,7 +111,6 @@ export function PollWorkerScreen({
   pollsState,
   isLiveMode,
   hasPrinterAttached: printerFromProps,
-  auth,
   logger,
 }: PollWorkerScreenProps): JSX.Element {
   const setPollsStateMutation = setPollsState.useMutation();
@@ -149,6 +133,23 @@ export function PollWorkerScreen({
   ] = useState(false);
   const hasPrinterAttached = printerFromProps || !window.kiosk;
   const { election } = electionDefinition;
+  const writeCardDataMutation = writeCardData.useMutation();
+
+  async function saveReportDataToCard(
+    reportData: ScannerReportData
+  ): Promise<boolean> {
+    let result: Result<void, Error>;
+    try {
+      result = await writeCardDataMutation.mutateAsync({
+        data: reportData,
+        schema: 'ScannerReportDataSchema',
+      });
+    } catch {
+      // Handled by query client's default error handling
+      return false;
+    }
+    return result.isOk();
+  }
 
   function initialPollWorkerFlowState(): Optional<PollWorkerFlowState> {
     switch (pollsState) {
@@ -230,7 +231,7 @@ export function PollWorkerScreen({
         ...reportBasicData,
         pollsTransition,
       };
-      await saveReportDataToCard(auth, ballotCountReportData);
+      await saveReportDataToCard(ballotCountReportData);
       return;
     }
 
@@ -297,13 +298,13 @@ export function PollWorkerScreen({
       ballotCounts: ballotCountBreakdowns,
     };
 
-    const success = await saveReportDataToCard(auth, tallyReportData);
+    const success = await saveReportDataToCard(tallyReportData);
     if (!success) {
       debug(
         'Error saving tally information to card, trying again without precinct-specific data'
       );
       // TODO show an error message if this attempt also fails.
-      await saveReportDataToCard(auth, {
+      await saveReportDataToCard({
         ...tallyReportData,
         talliesByPrecinct: undefined,
         timeSaved: Date.now(),

--- a/apps/vx-scan/frontend/src/screens/polls_not_open_screen.test.tsx
+++ b/apps/vx-scan/frontend/src/screens/polls_not_open_screen.test.tsx
@@ -6,6 +6,7 @@ import {
   PollsNotOpenScreenProps,
 } from './polls_not_open_screen';
 import {
+  ApiMock,
   createApiMock,
   machineConfig,
   provideApi,
@@ -13,10 +14,10 @@ import {
 
 const TEST_BALLOT_COUNT = 50;
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 beforeEach(() => {
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetConfig({
     precinctSelection: singlePrecinctSelectionFor('23'),

--- a/apps/vx-scan/frontend/src/screens/scan_error_screen.test.tsx
+++ b/apps/vx-scan/frontend/src/screens/scan_error_screen.test.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { ScanErrorScreen } from './scan_error_screen';
-import { createApiMock, provideApi } from '../../test/helpers/mock_api_client';
+import {
+  ApiMock,
+  createApiMock,
+  provideApi,
+} from '../../test/helpers/mock_api_client';
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 beforeEach(() => {
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetConfig();
 });

--- a/apps/vx-scan/frontend/src/screens/scan_warning_screen.test.tsx
+++ b/apps/vx-scan/frontend/src/screens/scan_warning_screen.test.tsx
@@ -10,7 +10,11 @@ import {
 import { mockOf } from '@votingworks/test-utils';
 import { integers, take } from '@votingworks/basics';
 import { ScanWarningScreen, Props } from './scan_warning_screen';
-import { createApiMock, provideApi } from '../../test/helpers/mock_api_client';
+import {
+  ApiMock,
+  createApiMock,
+  provideApi,
+} from '../../test/helpers/mock_api_client';
 
 jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
   return {
@@ -19,10 +23,10 @@ jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
   };
 });
 
-const apiMock = createApiMock();
+let apiMock: ApiMock;
 
 beforeEach(() => {
-  apiMock.mockApiClient.reset();
+  apiMock = createApiMock();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetConfig();
 });

--- a/apps/vx-scan/frontend/test/helpers/build_app.ts
+++ b/apps/vx-scan/frontend/test/helpers/build_app.ts
@@ -1,15 +1,13 @@
 import { render, RenderResult } from '@testing-library/react';
 import { fakeLogger, Logger } from '@votingworks/logging';
-import { MemoryCard, MemoryHardware } from '@votingworks/utils';
+import { MemoryHardware } from '@votingworks/utils';
 import { App } from '../../src/app';
 
 export function buildApp(connectPrinter = false): {
-  card: MemoryCard;
   hardware: MemoryHardware;
   logger: Logger;
   renderApp: () => RenderResult;
 } {
-  const card = new MemoryCard();
   const hardware = MemoryHardware.build({
     connectPrinter,
     connectCardReader: true,
@@ -17,7 +15,7 @@ export function buildApp(connectPrinter = false): {
   });
   const logger = fakeLogger();
   function renderApp() {
-    return render(App({ card, hardware, logger }));
+    return render(App({ hardware, logger }));
   }
-  return { renderApp, card, hardware, logger };
+  return { renderApp, hardware, logger };
 }

--- a/apps/vx-scan/frontend/test/helpers/helpers.ts
+++ b/apps/vx-scan/frontend/test/helpers/helpers.ts
@@ -1,20 +1,5 @@
-import userEvent from '@testing-library/user-event';
-import { screen } from '@testing-library/react';
 // eslint-disable-next-line vx/gts-no-import-export-type
 import type { PrecinctScannerStatus } from '@votingworks/vx-scan-backend';
-import { CARD_POLLING_INTERVAL } from '../../src/config/globals';
-
-export async function authenticateElectionManagerCard(): Promise<void> {
-  jest.advanceTimersByTime(CARD_POLLING_INTERVAL);
-  await screen.findByText('Enter the card security code to unlock.');
-  userEvent.click(screen.getByText('1'));
-  userEvent.click(screen.getByText('2'));
-  userEvent.click(screen.getByText('3'));
-  userEvent.click(screen.getByText('4'));
-  userEvent.click(screen.getByText('5'));
-  userEvent.click(screen.getByText('6'));
-  await screen.findByText('Election Manager Settings');
-}
 
 export function scannerStatus(
   props: Partial<PrecinctScannerStatus> = {}

--- a/apps/vx-scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/vx-scan/frontend/test/helpers/mock_api_client.tsx
@@ -56,7 +56,7 @@ type MockApiClient = Omit<
   // Because the values passed to this are so complex, we opt for a standard jest mock instead of a
   // libs/test-utils mock since the latter requires exact input matching and doesn't support
   // matchers like expect.objectContaining
-  writeCardData: jest.Mock;
+  saveScannerReportDataToCard: jest.Mock;
 };
 
 function createMockApiClient(): MockApiClient {
@@ -66,8 +66,8 @@ function createMockApiClient(): MockApiClient {
   (mockApiClient.getAuthStatus as unknown as jest.Mock) = jest.fn(() =>
     Promise.resolve({ status: 'logged_out', reason: 'no_card' })
   );
-  (mockApiClient.writeCardData as unknown as jest.Mock) = jest.fn(() =>
-    Promise.resolve(ok())
+  (mockApiClient.saveScannerReportDataToCard as unknown as jest.Mock) = jest.fn(
+    () => Promise.resolve(ok())
   );
   return mockApiClient as unknown as MockApiClient;
 }

--- a/apps/vx-scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/vx-scan/frontend/test/helpers/mock_api_client.tsx
@@ -3,11 +3,13 @@ import { electionSampleDefinition } from '@votingworks/fixtures';
 import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 import {
   CastVoteRecord,
+  ElectionDefinition,
+  InsertedSmartCardAuth,
   MarkThresholds,
   PollsState,
   PrecinctSelection,
 } from '@votingworks/types';
-import { createMockClient } from '@votingworks/grout-test-utils';
+import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
 // eslint-disable-next-line vx/gts-no-import-export-type
 import type {
   Api,
@@ -15,10 +17,14 @@ import type {
   PrecinctScannerConfig,
   PrecinctScannerStatus,
 } from '@votingworks/vx-scan-backend';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { ok } from '@votingworks/basics';
-import { QUERY_CLIENT_DEFAULT_OPTIONS } from '@votingworks/ui';
-import { ApiClientContext } from '../../src/api';
+import {
+  fakeElectionManagerUser,
+  fakePollWorkerUser,
+  fakeSystemAdministratorUser,
+} from '@votingworks/test-utils';
+import { ApiClientContext, createQueryClient } from '../../src/api';
 
 export const machineConfig: MachineConfig = {
   machineId: '0002',
@@ -40,15 +46,82 @@ export const statusNoPaper: PrecinctScannerStatus = {
   ballotsCounted: 0,
 };
 
+type MockApiClient = Omit<
+  MockClient<Api>,
+  'getAuthStatus' | 'writeCardData'
+> & {
+  // Because this is polled so frequently, we opt for a standard jest mock instead of a
+  // libs/test-utils mock since the latter requires every call to be explicitly mocked
+  getAuthStatus: jest.Mock;
+  // Because the values passed to this are so complex, we opt for a standard jest mock instead of a
+  // libs/test-utils mock since the latter requires exact input matching and doesn't support
+  // matchers like expect.objectContaining
+  writeCardData: jest.Mock;
+};
+
+function createMockApiClient(): MockApiClient {
+  const mockApiClient = createMockClient<Api>();
+  // For some reason, using an object spread to override the getAuthStatus method breaks the rest
+  // of the mockApiClient, so we override like this instead
+  (mockApiClient.getAuthStatus as unknown as jest.Mock) = jest.fn(() =>
+    Promise.resolve({ status: 'logged_out', reason: 'no_card' })
+  );
+  (mockApiClient.writeCardData as unknown as jest.Mock) = jest.fn(() =>
+    Promise.resolve(ok())
+  );
+  return mockApiClient as unknown as MockApiClient;
+}
+
 /**
  * Creates a VxScan specific wrapper around commonly used methods from the Grout
  * mock API client to make it easier to use for our specific test needs
  */
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function createApiMock() {
-  const mockApiClient = createMockClient<Api>();
+  const mockApiClient = createMockApiClient();
+
+  function setAuthStatus(authStatus: InsertedSmartCardAuth.AuthStatus): void {
+    mockApiClient.getAuthStatus.mockImplementation(() =>
+      Promise.resolve(authStatus)
+    );
+  }
+
   return {
     mockApiClient,
+
+    setAuthStatus,
+
+    authenticateAsSystemAdministrator() {
+      setAuthStatus({
+        status: 'logged_in',
+        user: fakeSystemAdministratorUser(),
+      });
+    },
+
+    authenticateAsElectionManager(electionDefinition: ElectionDefinition) {
+      setAuthStatus({
+        status: 'logged_in',
+        user: fakeElectionManagerUser({
+          electionHash: electionDefinition.electionHash,
+        }),
+      });
+    },
+
+    authenticateAsPollWorker(electionDefinition: ElectionDefinition) {
+      setAuthStatus({
+        status: 'logged_in',
+        user: fakePollWorkerUser({
+          electionHash: electionDefinition.electionHash,
+        }),
+      });
+    },
+
+    removeCard() {
+      setAuthStatus({
+        status: 'logged_out',
+        reason: 'no_card',
+      });
+    },
 
     expectGetMachineConfig(): void {
       mockApiClient.getMachineConfig.expectCallWith().resolves(machineConfig);
@@ -103,17 +176,15 @@ export function createApiMock() {
   };
 }
 
+export type ApiMock = ReturnType<typeof createApiMock>;
+
 export function provideApi(
   apiMock: ReturnType<typeof createApiMock>,
   children: React.ReactNode
 ): JSX.Element {
   return (
     <ApiClientContext.Provider value={apiMock.mockApiClient}>
-      <QueryClientProvider
-        client={
-          new QueryClient({ defaultOptions: QUERY_CLIENT_DEFAULT_OPTIONS })
-        }
-      >
+      <QueryClientProvider client={createQueryClient()}>
         {children}
       </QueryClientProvider>
     </ApiClientContext.Provider>

--- a/libs/auth/src/dipped_smart_card_auth.ts
+++ b/libs/auth/src/dipped_smart_card_auth.ts
@@ -1,3 +1,4 @@
+import { Result } from '@votingworks/basics';
 import {
   DippedSmartCardAuth,
   ElectionDefinition,
@@ -5,11 +6,10 @@ import {
   PollWorkerUser,
   SystemAdministratorUser,
 } from '@votingworks/types';
-import { Result } from '@votingworks/basics';
 
 /**
  * The API for a dipped smart card auth instance, "dipped" meaning that the card needs to be
- * inserted and removed from the card reader to complete authentication
+ * inserted and removed from the card reader for the user to be authenticated
  */
 export interface DippedSmartCardAuthApi {
   getAuthStatus: () => DippedSmartCardAuth.AuthStatus;

--- a/libs/auth/src/index.ts
+++ b/libs/auth/src/index.ts
@@ -1,2 +1,4 @@
 export * from './dipped_smart_card_auth_with_memory_card';
 export * from './dipped_smart_card_auth';
+export * from './inserted_smart_card_auth_with_memory_card';
+export * from './inserted_smart_card_auth';

--- a/libs/auth/src/index.ts
+++ b/libs/auth/src/index.ts
@@ -2,3 +2,4 @@ export * from './dipped_smart_card_auth_with_memory_card';
 export * from './dipped_smart_card_auth';
 export * from './inserted_smart_card_auth_with_memory_card';
 export * from './inserted_smart_card_auth';
+export * from './test_utils';

--- a/libs/auth/src/inserted_smart_card_auth.ts
+++ b/libs/auth/src/inserted_smart_card_auth.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+import { Result } from '@votingworks/basics';
+import {
+  ElectionDefinition,
+  InsertedSmartCardAuth,
+  Optional,
+  PrecinctSelection,
+  UserRole,
+} from '@votingworks/types';
+
+/**
+ * The API for an inserted smart card auth instance, "inserted" meaning that the card needs to be
+ * kept in the card reader for the user to remain authenticated
+ */
+export interface InsertedSmartCardAuthApi {
+  getAuthStatus: () => InsertedSmartCardAuth.AuthStatus;
+
+  checkPin: (input: { pin: string }) => void;
+
+  readCardData: <T>(input: {
+    schema: z.ZodSchema<T>;
+  }) => Promise<Result<Optional<T>, SyntaxError | z.ZodError | Error>>;
+  writeCardData: <T>(input: {
+    data: T;
+    schema: z.ZodSchema<T>;
+  }) => Promise<Result<void, Error>>;
+  clearCardData: () => Promise<Result<void, Error>>;
+
+  setElectionDefinition: (electionDefinition: ElectionDefinition) => void;
+  clearElectionDefinition: () => void;
+  setPrecinctSelection: (precinctSelection: PrecinctSelection) => void;
+  clearPrecinctSelection: () => void;
+}
+
+/**
+ * Configuration parameters for an inserted smart card auth instance
+ */
+export interface InsertedSmartCardAuthConfig {
+  allowedUserRoles: UserRole[];
+  allowElectionManagersToAccessMachinesConfiguredForOtherElections?: boolean;
+  electionDefinition?: ElectionDefinition;
+  precinctSelection?: PrecinctSelection;
+}

--- a/libs/auth/src/inserted_smart_card_auth_with_memory_card.test.ts
+++ b/libs/auth/src/inserted_smart_card_auth_with_memory_card.test.ts
@@ -1,0 +1,19 @@
+import { MemoryCard as MockMemoryCard } from '@votingworks/utils';
+
+import { InsertedSmartCardAuthWithMemoryCard } from './inserted_smart_card_auth_with_memory_card';
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+test('InsertedSmartCardAuthWithMemoryCard returns auth status', () => {
+  const card = new MockMemoryCard();
+  const auth = new InsertedSmartCardAuthWithMemoryCard({
+    card,
+    config: { allowedUserRoles: [] },
+  });
+  expect(auth.getAuthStatus()).toEqual({
+    status: 'logged_out',
+    reason: 'no_card',
+  });
+});

--- a/libs/auth/src/inserted_smart_card_auth_with_memory_card.ts
+++ b/libs/auth/src/inserted_smart_card_auth_with_memory_card.ts
@@ -1,0 +1,294 @@
+import fetch from 'node-fetch';
+import { z } from 'zod';
+import {
+  assert,
+  err,
+  ok,
+  Result,
+  throwIllegalValue,
+  wrapException,
+} from '@votingworks/basics';
+import {
+  Card,
+  CardSummary,
+  ElectionDefinition,
+  getBallotStyle,
+  getPrecinctById,
+  InsertedSmartCardAuth,
+  Optional,
+  PrecinctSelection,
+  User,
+} from '@votingworks/types';
+import { utcTimestamp } from '@votingworks/utils';
+
+import {
+  InsertedSmartCardAuthApi,
+  InsertedSmartCardAuthConfig,
+} from './inserted_smart_card_auth';
+import {
+  CARD_POLLING_INTERVAL_MS,
+  parseUserFromCardSummary,
+} from './memory_card';
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+global.fetch = fetch;
+
+const VOTER_CARD_EXPIRATION_SECONDS = 60 * 60; // 1 hour
+
+type AuthAction =
+  | { type: 'read_card'; cardSummary: CardSummary }
+  | { type: 'check_pin'; pin: string };
+
+/**
+ * An implementation of the dipped smart card auth API, backed by a memory card
+ *
+ * Since this is just a stopgap until we implement InsertedSmartCardAuthWithJavaCard, I haven't
+ * implemented the following:
+ * - Locking to avoid concurrent card writes
+ * - Logging
+ * - Tests
+ */
+export class InsertedSmartCardAuthWithMemoryCard
+  implements InsertedSmartCardAuthApi
+{
+  private authStatus: InsertedSmartCardAuth.AuthStatus;
+  private readonly card: Card;
+  private config: InsertedSmartCardAuthConfig;
+
+  constructor({
+    card,
+    config,
+  }: {
+    card: Card;
+    config: Omit<
+      InsertedSmartCardAuthConfig,
+      'electionDefinition' | 'precinctSelection'
+    >;
+  }) {
+    this.authStatus = InsertedSmartCardAuth.DEFAULT_AUTH_STATUS;
+    this.card = card;
+    this.config = config;
+
+    setInterval(
+      async () => {
+        try {
+          const newCardSummary = await this.card.readSummary();
+          this.updateAuthStatus({
+            type: 'read_card',
+            cardSummary: newCardSummary,
+          });
+        } catch {
+          // Swallow errors so that they don't crash the auth instance and containing backend
+        }
+      },
+      CARD_POLLING_INTERVAL_MS,
+      true
+    );
+  }
+
+  getAuthStatus(): InsertedSmartCardAuth.AuthStatus {
+    return this.authStatus;
+  }
+
+  checkPin({ pin }: { pin: string }): void {
+    this.updateAuthStatus({ type: 'check_pin', pin });
+  }
+
+  readCardData<T>({
+    schema,
+  }: {
+    schema: z.ZodSchema<T>;
+  }): Promise<Result<Optional<T>, SyntaxError | z.ZodError | Error>> {
+    return this.card.readLongObject(schema);
+  }
+
+  async writeCardData<T>({
+    data,
+    schema,
+  }: {
+    data: T;
+    schema: z.ZodSchema<T>;
+  }): Promise<Result<void, Error>> {
+    try {
+      await this.card.writeLongObject(data);
+    } catch (error) {
+      return wrapException(error);
+    }
+
+    // Verify that the write was in fact successful by reading the data
+    const readResult = await this.readCardData({ schema });
+    if (readResult.isErr()) {
+      return err(new Error('Verification of write by reading data failed'));
+    }
+
+    return ok();
+  }
+
+  async clearCardData(): Promise<Result<void, Error>> {
+    try {
+      await this.card.writeLongUint8Array(Uint8Array.of());
+    } catch (error) {
+      return wrapException(error);
+    }
+    return ok();
+  }
+
+  setElectionDefinition(electionDefinition: ElectionDefinition): void {
+    this.config.electionDefinition = electionDefinition;
+  }
+
+  clearElectionDefinition(): void {
+    delete this.config.electionDefinition;
+  }
+
+  setPrecinctSelection(precinctSelection: PrecinctSelection): void {
+    this.config.precinctSelection = precinctSelection;
+  }
+
+  clearPrecinctSelection(): void {
+    delete this.config.precinctSelection;
+  }
+
+  private updateAuthStatus(action: AuthAction): void {
+    this.authStatus = this.determineNewAuthStatus(action);
+  }
+
+  private determineNewAuthStatus(
+    action: AuthAction
+  ): InsertedSmartCardAuth.AuthStatus {
+    const currentAuthStatus = this.authStatus;
+
+    switch (action.type) {
+      case 'read_card': {
+        const newAuthStatus = ((): InsertedSmartCardAuth.AuthStatus => {
+          switch (action.cardSummary.status) {
+            case 'no_card':
+              return { status: 'logged_out', reason: 'no_card' };
+
+            case 'error':
+              return { status: 'logged_out', reason: 'card_error' };
+
+            case 'ready': {
+              const user = parseUserFromCardSummary(action.cardSummary);
+              const validationResult = this.validateCardUser(user);
+              if (validationResult.isOk()) {
+                assert(user);
+                if (currentAuthStatus.status === 'logged_out') {
+                  if (
+                    user.role === 'system_administrator' ||
+                    user.role === 'election_manager'
+                  ) {
+                    return { status: 'checking_passcode', user };
+                  }
+                  if (user.role === 'poll_worker') {
+                    return { status: 'logged_in', user };
+                  }
+                  if (user.role === 'voter') {
+                    return { status: 'logged_in', user };
+                  }
+                  return { status: 'logged_in', user };
+                }
+                return currentAuthStatus;
+              }
+              return {
+                status: 'logged_out',
+                reason: validationResult.err(),
+                cardUserRole: user?.role,
+              };
+            }
+
+            /* istanbul ignore next: Compile-time check for completeness */
+            default:
+              throwIllegalValue(action.cardSummary, 'status');
+          }
+        })();
+
+        return newAuthStatus;
+      }
+
+      case 'check_pin': {
+        assert(currentAuthStatus.status === 'checking_passcode');
+        if (action.pin === currentAuthStatus.user.passcode) {
+          if (currentAuthStatus.user.role === 'system_administrator') {
+            return { status: 'logged_in', user: currentAuthStatus.user };
+          }
+          return { status: 'logged_in', user: currentAuthStatus.user };
+        }
+        return { ...currentAuthStatus, wrongPasscodeEnteredAt: new Date() };
+      }
+
+      /* istanbul ignore next: Compile-time check for completeness */
+      default:
+        throwIllegalValue(action, 'type');
+    }
+  }
+
+  private validateCardUser(
+    user?: User
+  ): Result<void, InsertedSmartCardAuth.LoggedOut['reason']> {
+    if (!user) {
+      return err('invalid_user_on_card');
+    }
+
+    if (!this.config.allowedUserRoles.includes(user.role)) {
+      return err('user_role_not_allowed');
+    }
+
+    if (user.role === 'election_manager') {
+      if (!this.config.electionDefinition) {
+        return ok();
+      }
+      if (
+        user.electionHash !== this.config.electionDefinition.electionHash &&
+        !this.config
+          .allowElectionManagersToAccessMachinesConfiguredForOtherElections
+      ) {
+        return err('election_manager_wrong_election');
+      }
+    }
+
+    if (user.role === 'poll_worker') {
+      if (!this.config.electionDefinition) {
+        return err('machine_not_configured');
+      }
+      if (user.electionHash !== this.config.electionDefinition.electionHash) {
+        return err('poll_worker_wrong_election');
+      }
+    }
+
+    if (user.role === 'voter') {
+      if (!this.config.electionDefinition || !this.config.precinctSelection) {
+        return err('machine_not_configured');
+      }
+      if (utcTimestamp() >= user.createdAt + VOTER_CARD_EXPIRATION_SECONDS) {
+        return err('voter_card_expired');
+      }
+      if (user.voidedAt) {
+        return err('voter_card_voided');
+      }
+      if (user.ballotPrintedAt && this.authStatus.status !== 'logged_in') {
+        return err('voter_card_printed');
+      }
+      const ballotStyle = getBallotStyle({
+        election: this.config.electionDefinition.election,
+        ballotStyleId: user.ballotStyleId,
+      });
+      const precinct = getPrecinctById({
+        election: this.config.electionDefinition.election,
+        precinctId: user.precinctId,
+      });
+      if (!ballotStyle || !precinct) {
+        return err('voter_wrong_election');
+      }
+      if (
+        this.config.precinctSelection.kind === 'SinglePrecinct' &&
+        precinct.id !== this.config.precinctSelection.precinctId
+      ) {
+        return err('voter_wrong_precinct');
+      }
+    }
+
+    return ok();
+  }
+}

--- a/libs/auth/src/memory_card.ts
+++ b/libs/auth/src/memory_card.ts
@@ -1,0 +1,65 @@
+import { throwIllegalValue } from '@votingworks/basics';
+import {
+  AnyCardDataSchema,
+  CardSummaryReady,
+  Optional,
+  safeParseJson,
+  User,
+} from '@votingworks/types';
+
+/**
+ * The frequency with which we poll the memory card summary
+ */
+export const CARD_POLLING_INTERVAL_MS = 100;
+
+/**
+ * Parses a user from a memory card summary
+ */
+export function parseUserFromCardSummary(
+  cardSummary: CardSummaryReady
+): Optional<User> {
+  if (!cardSummary.shortValue) {
+    return undefined;
+  }
+
+  const cardData = safeParseJson(
+    cardSummary.shortValue,
+    AnyCardDataSchema
+  ).ok();
+  if (!cardData) {
+    return undefined;
+  }
+
+  switch (cardData.t) {
+    case 'system_administrator':
+      return {
+        role: 'system_administrator',
+        passcode: cardData.p,
+      };
+    case 'election_manager':
+      return {
+        role: 'election_manager',
+        electionHash: cardData.h,
+        passcode: cardData.p,
+      };
+    case 'poll_worker':
+      return {
+        role: 'poll_worker',
+        electionHash: cardData.h,
+      };
+    case 'voter':
+      return {
+        role: 'voter',
+        ballotPrintedAt: cardData.bp,
+        ballotStyleId: cardData.bs,
+        createdAt: cardData.c,
+        markMachineId: cardData.m,
+        precinctId: cardData.pr,
+        updatedAt: cardData.u,
+        voidedAt: cardData.uz,
+      };
+    /* istanbul ignore next: Compile-time check for completeness */
+    default:
+      throwIllegalValue(cardData, 't');
+  }
+}

--- a/libs/auth/src/test_utils.ts
+++ b/libs/auth/src/test_utils.ts
@@ -1,0 +1,34 @@
+import { DippedSmartCardAuthApi } from './dipped_smart_card_auth';
+import { InsertedSmartCardAuthApi } from './inserted_smart_card_auth';
+
+/**
+ * Builds a mock dipped smart card auth instance for application-level tests
+ */
+export function buildMockDippedSmartCardAuth(): DippedSmartCardAuthApi {
+  return {
+    getAuthStatus: jest.fn(),
+    checkPin: jest.fn(),
+    logOut: jest.fn(),
+    programCard: jest.fn(),
+    unprogramCard: jest.fn(),
+    setElectionDefinition: jest.fn(),
+    clearElectionDefinition: jest.fn(),
+  };
+}
+
+/**
+ * Builds a mock inserted smart card auth instance for application-level tests
+ */
+export function buildMockInsertedSmartCardAuth(): InsertedSmartCardAuthApi {
+  return {
+    getAuthStatus: jest.fn(),
+    checkPin: jest.fn(),
+    readCardData: jest.fn(),
+    writeCardData: jest.fn(),
+    clearCardData: jest.fn(),
+    setElectionDefinition: jest.fn(),
+    clearElectionDefinition: jest.fn(),
+    setPrecinctSelection: jest.fn(),
+    clearPrecinctSelection: jest.fn(),
+  };
+}

--- a/libs/grout/README.md
+++ b/libs/grout/README.md
@@ -122,11 +122,12 @@ from `@votingworks/grout-test-utils`:
 
 ```ts
 import { createMockClient } from '@votingworks/grout-test-utils';
-const mockApiClient = createMockClient<MyApi>();
 
-// Ensure the mock is in a clean state before each test
+let mockApiClient: MockClient<Api>;
+
+// Ensure the mock is in a clean state before each test by creating a new one
 beforeEach(() => {
-  mockApiClient.reset();
+  mockApiClient = createMockClient<MyApi>();
 });
 
 // Ensure all expected calls were made after each test

--- a/libs/grout/test-utils/src/mock_client.test.ts
+++ b/libs/grout/test-utils/src/mock_client.test.ts
@@ -73,12 +73,3 @@ test('asserts complete for all methods', async () => {
     Actual: <none>"
   `);
 });
-
-test('resets all methods', () => {
-  const mockClient = createMockClient<typeof api>();
-  mockClient.add.expectCallWith({ num1: 1, num2: 2 }).resolves(42);
-  mockClient.sqrt.expectCallWith({ num: 4 }).resolves(100);
-
-  mockClient.reset();
-  mockClient.assertComplete();
-});

--- a/libs/grout/test-utils/src/mock_client.ts
+++ b/libs/grout/test-utils/src/mock_client.ts
@@ -16,7 +16,6 @@ type MockMethods<Methods extends AnyMethods> = {
 
 interface MockHelpers {
   assertComplete(): void;
-  reset(): void;
 }
 
 /**
@@ -71,12 +70,6 @@ export function createMockClient<Api extends AnyApi>(options?: {
     assertComplete(): void {
       for (const mockMethod of Object.values(mockMethods)) {
         mockMethod.assertComplete();
-      }
-    },
-
-    reset(): void {
-      for (const mockMethod of Object.values(mockMethods)) {
-        mockMethod.reset();
       }
     },
   };

--- a/libs/types/src/auth/index.ts
+++ b/libs/types/src/auth/index.ts
@@ -1,5 +1,6 @@
 export * from './auth';
 export * as DippedSmartCardAuth from './dipped_smart_card_auth';
+export * as InsertedSmartCardAuth from './inserted_smart_card_auth';
 
 /** Being phased out */
 export * as DippedSmartcardAuth from './dipped_smartcard_auth';

--- a/libs/types/src/auth/inserted_smart_card_auth.ts
+++ b/libs/types/src/auth/inserted_smart_card_auth.ts
@@ -1,0 +1,71 @@
+import {
+  CardlessVoterUser,
+  ElectionManagerUser,
+  PollWorkerUser,
+  SystemAdministratorUser,
+  UserRole,
+  VoterUser,
+} from './auth';
+
+export interface LoggedOut {
+  readonly status: 'logged_out';
+  readonly reason:
+    | 'card_error'
+    | 'election_manager_wrong_election'
+    | 'invalid_user_on_card'
+    | 'machine_not_configured'
+    | 'no_card'
+    | 'poll_worker_wrong_election'
+    | 'user_role_not_allowed'
+    | 'voter_card_expired'
+    | 'voter_card_printed'
+    | 'voter_card_voided'
+    | 'voter_wrong_election'
+    | 'voter_wrong_precinct';
+  readonly cardUserRole?: UserRole;
+}
+
+export interface CheckingPin {
+  readonly status: 'checking_passcode';
+  readonly user: SystemAdministratorUser | ElectionManagerUser;
+  readonly wrongPasscodeEnteredAt?: Date;
+}
+
+export interface SystemAdministratorLoggedIn {
+  readonly status: 'logged_in';
+  readonly user: SystemAdministratorUser;
+}
+
+export interface ElectionManagerLoggedIn {
+  readonly status: 'logged_in';
+  readonly user: ElectionManagerUser;
+}
+
+export interface PollWorkerLoggedIn {
+  readonly status: 'logged_in';
+  readonly user: PollWorkerUser;
+}
+
+export interface VoterLoggedIn {
+  readonly status: 'logged_in';
+  readonly user: VoterUser;
+}
+
+export interface CardlessVoterLoggedIn {
+  readonly status: 'logged_in';
+  readonly user: CardlessVoterUser;
+}
+
+export type LoggedIn =
+  | SystemAdministratorLoggedIn
+  | ElectionManagerLoggedIn
+  | PollWorkerLoggedIn
+  | VoterLoggedIn
+  | CardlessVoterLoggedIn;
+
+export type AuthStatus = LoggedOut | CheckingPin | LoggedIn;
+
+export const DEFAULT_AUTH_STATUS: Readonly<AuthStatus> = {
+  status: 'logged_out',
+  reason: 'no_card',
+};

--- a/libs/ui/src/hooks/auth/auth_helpers.ts
+++ b/libs/ui/src/hooks/auth/auth_helpers.ts
@@ -13,6 +13,7 @@ import {
   SystemAdministratorCardData,
   User,
   DippedSmartCardAuth,
+  InsertedSmartCardAuth,
 } from '@votingworks/types';
 import { err, ok, throwIllegalValue, wrapException } from '@votingworks/basics';
 import { LogEventId, Logger } from '@votingworks/logging';
@@ -287,6 +288,12 @@ export function isSystemAdministratorAuth(
   auth: InsertedSmartcardAuth.Auth
 ): auth is InsertedSmartcardAuth.SystemAdministratorLoggedIn;
 export function isSystemAdministratorAuth(
+  auth: InsertedSmartCardAuth.AuthStatus
+): auth is InsertedSmartCardAuth.SystemAdministratorLoggedIn;
+export function isSystemAdministratorAuth(
+  auth: InsertedSmartcardAuth.Auth | InsertedSmartCardAuth.AuthStatus
+): auth is InsertedSmartCardAuth.SystemAdministratorLoggedIn;
+export function isSystemAdministratorAuth(
   auth: DippedSmartcardAuth.Auth
 ): auth is DippedSmartcardAuth.SystemAdministratorLoggedIn;
 export function isSystemAdministratorAuth(
@@ -298,6 +305,7 @@ export function isSystemAdministratorAuth(
 export function isSystemAdministratorAuth(
   auth:
     | InsertedSmartcardAuth.Auth
+    | InsertedSmartCardAuth.AuthStatus
     | DippedSmartcardAuth.Auth
     | DippedSmartCardAuth.AuthStatus
 ): boolean {
@@ -310,6 +318,12 @@ export function isElectionManagerAuth(
   auth: InsertedSmartcardAuth.Auth
 ): auth is InsertedSmartcardAuth.ElectionManagerLoggedIn;
 export function isElectionManagerAuth(
+  auth: InsertedSmartCardAuth.AuthStatus
+): auth is InsertedSmartCardAuth.ElectionManagerLoggedIn;
+export function isElectionManagerAuth(
+  auth: InsertedSmartcardAuth.Auth | InsertedSmartCardAuth.AuthStatus
+): auth is InsertedSmartCardAuth.ElectionManagerLoggedIn;
+export function isElectionManagerAuth(
   auth: DippedSmartcardAuth.Auth
 ): auth is DippedSmartcardAuth.ElectionManagerLoggedIn;
 export function isElectionManagerAuth(
@@ -321,6 +335,7 @@ export function isElectionManagerAuth(
 export function isElectionManagerAuth(
   auth:
     | InsertedSmartcardAuth.Auth
+    | InsertedSmartCardAuth.AuthStatus
     | DippedSmartcardAuth.Auth
     | DippedSmartCardAuth.AuthStatus
 ): boolean {
@@ -329,7 +344,16 @@ export function isElectionManagerAuth(
 
 export function isPollWorkerAuth(
   auth: InsertedSmartcardAuth.Auth
-): auth is InsertedSmartcardAuth.PollWorkerLoggedIn {
+): auth is InsertedSmartcardAuth.PollWorkerLoggedIn;
+export function isPollWorkerAuth(
+  auth: InsertedSmartCardAuth.AuthStatus
+): auth is InsertedSmartCardAuth.PollWorkerLoggedIn;
+export function isPollWorkerAuth(
+  auth: InsertedSmartcardAuth.Auth | InsertedSmartCardAuth.AuthStatus
+): auth is InsertedSmartCardAuth.PollWorkerLoggedIn;
+export function isPollWorkerAuth(
+  auth: InsertedSmartcardAuth.Auth | InsertedSmartCardAuth.AuthStatus
+): boolean {
   return auth.status === 'logged_in' && auth.user.role === 'poll_worker';
 }
 

--- a/libs/ui/src/unlock_machine_screen.tsx
+++ b/libs/ui/src/unlock_machine_screen.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import {
   DippedSmartCardAuth,
   DippedSmartcardAuth,
+  InsertedSmartCardAuth,
   InsertedSmartcardAuth,
 } from '@votingworks/types';
 import {
@@ -44,7 +45,8 @@ const EnteredCode = styled.div`
 type CheckingPassCodeAuth =
   | DippedSmartcardAuth.CheckingPasscode
   | DippedSmartCardAuth.CheckingPin
-  | InsertedSmartcardAuth.CheckingPasscode;
+  | InsertedSmartcardAuth.CheckingPasscode
+  | InsertedSmartCardAuth.CheckingPin;
 
 interface Props {
   auth: CheckingPassCodeAuth;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -421,6 +421,7 @@ importers:
       '@types/zip-stream': workspace:*
       '@typescript-eslint/eslint-plugin': ^5.37.0
       '@typescript-eslint/parser': ^5.37.0
+      '@votingworks/auth': workspace:*
       '@votingworks/ballot-encoder': workspace:*
       '@votingworks/ballot-interpreter-nh': workspace:*
       '@votingworks/ballot-interpreter-vx': workspace:*
@@ -477,6 +478,7 @@ importers:
       zip-stream: ^4.1.0
       zod: 3.14.4
     dependencies:
+      '@votingworks/auth': link:../../../libs/auth
       '@votingworks/ballot-encoder': link:../../../libs/ballot-encoder
       '@votingworks/ballot-interpreter-nh': link:../../../libs/ballot-interpreter-nh
       '@votingworks/ballot-interpreter-vx': link:../../../libs/ballot-interpreter-vx

--- a/services/admin/src/server.cvr_file_mode.test.ts
+++ b/services/admin/src/server.cvr_file_mode.test.ts
@@ -1,12 +1,14 @@
 import { Admin } from '@votingworks/api';
-import { DippedSmartCardAuthApi } from '@votingworks/auth';
+import {
+  buildMockDippedSmartCardAuth,
+  DippedSmartCardAuthApi,
+} from '@votingworks/auth';
 import { electionMinimalExhaustiveSampleFixtures } from '@votingworks/fixtures';
 import { mockOf } from '@votingworks/test-utils';
 import { Application } from 'express';
 import request from 'supertest';
 import { dirSync } from 'tmp';
 import { buildApp } from './server';
-import { buildMockAuth } from '../test/utils';
 import { createWorkspace, Workspace } from './util/workspace';
 
 let app: Application;
@@ -17,7 +19,7 @@ let electionId: string;
 beforeEach(() => {
   jest.restoreAllMocks();
 
-  auth = buildMockAuth();
+  auth = buildMockDippedSmartCardAuth();
 
   workspace = createWorkspace(dirSync().name);
   workspace.store.getCurrentCvrFileModeForElection = jest.fn();

--- a/services/admin/src/server.printed_ballots.test.ts
+++ b/services/admin/src/server.printed_ballots.test.ts
@@ -1,5 +1,8 @@
 import { Admin } from '@votingworks/api';
-import { DippedSmartCardAuthApi } from '@votingworks/auth';
+import {
+  buildMockDippedSmartCardAuth,
+  DippedSmartCardAuthApi,
+} from '@votingworks/auth';
 import { electionMinimalExhaustiveSampleFixtures } from '@votingworks/fixtures';
 import { unsafeParse } from '@votingworks/types';
 import { assert, typedAs } from '@votingworks/basics';
@@ -7,7 +10,6 @@ import { Application } from 'express';
 import request from 'supertest';
 import { dirSync } from 'tmp';
 import { buildApp } from './server';
-import { buildMockAuth } from '../test/utils';
 import { createWorkspace, Workspace } from './util/workspace';
 
 let app: Application;
@@ -16,7 +18,7 @@ let workspace: Workspace;
 
 beforeEach(() => {
   jest.restoreAllMocks();
-  auth = buildMockAuth();
+  auth = buildMockDippedSmartCardAuth();
   workspace = createWorkspace(dirSync().name);
   app = buildApp({ auth, workspace });
 });

--- a/services/admin/src/server.test.ts
+++ b/services/admin/src/server.test.ts
@@ -12,11 +12,13 @@ import { promises as fs } from 'fs';
 import { Server } from 'http';
 import request from 'supertest';
 import { dirSync, fileSync } from 'tmp';
-import { DippedSmartCardAuthApi } from '@votingworks/auth';
+import {
+  buildMockDippedSmartCardAuth,
+  DippedSmartCardAuthApi,
+} from '@votingworks/auth';
 import * as grout from '@votingworks/grout';
 import { Api, buildApp, start } from './server';
 import { createWorkspace, Workspace } from './util/workspace';
-import { buildMockAuth } from '../test/utils';
 import { PORT } from './globals';
 
 let app: Application;
@@ -26,7 +28,7 @@ let workspace: Workspace;
 
 beforeEach(() => {
   jest.restoreAllMocks();
-  auth = buildMockAuth();
+  auth = buildMockDippedSmartCardAuth();
   workspace = createWorkspace(dirSync().name);
   app = buildApp({ auth, workspace });
 });

--- a/services/admin/src/server.writeins.test.ts
+++ b/services/admin/src/server.writeins.test.ts
@@ -1,5 +1,8 @@
 import { Admin } from '@votingworks/api';
-import { DippedSmartCardAuthApi } from '@votingworks/auth';
+import {
+  buildMockDippedSmartCardAuth,
+  DippedSmartCardAuthApi,
+} from '@votingworks/auth';
 import { electionMinimalExhaustiveSampleFixtures } from '@votingworks/fixtures';
 import { unsafeParse } from '@votingworks/types';
 import { assert, typedAs } from '@votingworks/basics';
@@ -7,7 +10,6 @@ import { Application } from 'express';
 import request from 'supertest';
 import { dirSync } from 'tmp';
 import { buildApp } from './server';
-import { buildMockAuth } from '../test/utils';
 import { createWorkspace, Workspace } from './util/workspace';
 
 let app: Application;
@@ -16,7 +18,7 @@ let workspace: Workspace;
 
 beforeEach(() => {
   jest.restoreAllMocks();
-  auth = buildMockAuth();
+  auth = buildMockDippedSmartCardAuth();
   workspace = createWorkspace(dirSync().name);
   app = buildApp({ auth, workspace });
 });

--- a/services/admin/test/utils.ts
+++ b/services/admin/test/utils.ts
@@ -1,6 +1,5 @@
 import { Admin } from '@votingworks/api';
 import { CandidateContest } from '@votingworks/types';
-import { DippedSmartCardAuthApi } from '@votingworks/auth';
 
 /**
  * Builds the group of options for adjudicating write-ins to official candidates
@@ -18,20 +17,5 @@ export function buildOfficialCandidatesWriteInAdjudicationOptionGroup(
         enabled: true,
       }))
       .sort((a, b) => a.adjudicatedValue.localeCompare(b.adjudicatedValue)),
-  };
-}
-
-/**
- * Builds a mock auth instance
- */
-export function buildMockAuth(): DippedSmartCardAuthApi {
-  return {
-    getAuthStatus: jest.fn(),
-    checkPin: jest.fn(),
-    logOut: jest.fn(),
-    programCard: jest.fn(),
-    unprogramCard: jest.fn(),
-    setElectionDefinition: jest.fn(),
-    clearElectionDefinition: jest.fn(),
   };
 }

--- a/services/scan/src/central_scanner_app.test.ts
+++ b/services/scan/src/central_scanner_app.test.ts
@@ -28,13 +28,16 @@ import { dirSync } from 'tmp';
 import { v4 as uuid } from 'uuid';
 import path from 'path';
 import { typedAs } from '@votingworks/basics';
-import { DippedSmartCardAuthApi } from '@votingworks/auth';
+import {
+  buildMockDippedSmartCardAuth,
+  DippedSmartCardAuthApi,
+} from '@votingworks/auth';
 import { Server } from 'http';
 import * as grout from '@votingworks/grout';
 import { fakeLogger } from '@votingworks/logging';
 import { mockOf } from '@votingworks/test-utils';
 import * as stateOfHamilton from '../test/fixtures/state-of-hamilton';
-import { buildMockAuth, makeMock } from '../test/util/mocks';
+import { makeMock } from '../test/util/mocks';
 import { Importer } from './importer';
 import { createWorkspace, Workspace } from './util/workspace';
 import { Api, buildCentralScannerApp } from './central_scanner_app';
@@ -58,7 +61,7 @@ let workspace: Workspace;
 
 beforeEach(async () => {
   mockGetUsbDrives.mockReset();
-  auth = buildMockAuth();
+  auth = buildMockDippedSmartCardAuth();
   importer = makeMock(Importer);
   workspace = await createWorkspace(dirSync().name);
   workspace.store.setElection(stateOfHamilton.electionDefinition.electionData);

--- a/services/scan/src/end_to_end.test.ts
+++ b/services/scan/src/end_to_end.test.ts
@@ -1,5 +1,8 @@
 import { Scan } from '@votingworks/api';
-import { DippedSmartCardAuthApi } from '@votingworks/auth';
+import {
+  buildMockDippedSmartCardAuth,
+  DippedSmartCardAuthApi,
+} from '@votingworks/auth';
 import { Exporter } from '@votingworks/data';
 import {
   asElectionDefinition,
@@ -15,11 +18,7 @@ import * as fsExtra from 'fs-extra';
 import * as path from 'path';
 import request from 'supertest';
 import { dirSync } from 'tmp';
-import {
-  buildMockAuth,
-  makeMockScanner,
-  MockScanner,
-} from '../test/util/mocks';
+import { makeMockScanner, MockScanner } from '../test/util/mocks';
 import { buildCentralScannerApp } from './central_scanner_app';
 import { Importer } from './importer';
 import { createWorkspace, Workspace } from './util/workspace';
@@ -46,7 +45,7 @@ let workspace: Workspace;
 let scanner: MockScanner;
 
 beforeEach(async () => {
-  auth = buildMockAuth();
+  auth = buildMockDippedSmartCardAuth();
   scanner = makeMockScanner();
   workspace = await createWorkspace(dirSync().name);
   importer = new Importer({

--- a/services/scan/src/end_to_end_hmpb.test.ts
+++ b/services/scan/src/end_to_end_hmpb.test.ts
@@ -15,13 +15,12 @@ import { join } from 'path';
 import request from 'supertest';
 import { dirSync } from 'tmp';
 import { Scan } from '@votingworks/api';
-import { DippedSmartCardAuthApi } from '@votingworks/auth';
-import * as stateOfHamilton from '../test/fixtures/state-of-hamilton';
 import {
-  buildMockAuth,
-  makeMockScanner,
-  MockScanner,
-} from '../test/util/mocks';
+  buildMockDippedSmartCardAuth,
+  DippedSmartCardAuthApi,
+} from '@votingworks/auth';
+import * as stateOfHamilton from '../test/fixtures/state-of-hamilton';
+import { makeMockScanner, MockScanner } from '../test/util/mocks';
 import { Importer } from './importer';
 import { createWorkspace, Workspace } from './util/workspace';
 import { buildCentralScannerApp } from './central_scanner_app';
@@ -66,7 +65,7 @@ let importer: Importer;
 let app: Application;
 
 beforeEach(async () => {
-  auth = buildMockAuth();
+  auth = buildMockDippedSmartCardAuth();
   workspace = await createWorkspace(dirSync().name);
   scanner = makeMockScanner();
   importer = new Importer({ workspace, scanner });

--- a/services/scan/test/util/mocks.ts
+++ b/services/scan/test/util/mocks.ts
@@ -11,7 +11,6 @@ import { ChildProcess } from 'child_process';
 import { EventEmitter } from 'events';
 import { fileSync } from 'tmp';
 import { MaybeMocked, mocked } from 'ts-jest/dist/utils/testing';
-import { DippedSmartCardAuthApi } from '@votingworks/auth';
 import { BatchControl, BatchScanner } from '../../src/fujitsu_scanner';
 import { inlinePool, WorkerOps, WorkerPool } from '../../src/workers/pool';
 
@@ -192,16 +191,4 @@ export async function makeImageFile(): Promise<string> {
     height: 1,
   });
   return imageFile.name;
-}
-
-export function buildMockAuth(): DippedSmartCardAuthApi {
-  return {
-    getAuthStatus: jest.fn(),
-    checkPin: jest.fn(),
-    logOut: jest.fn(),
-    programCard: jest.fn(),
-    unprogramCard: jest.fn(),
-    setElectionDefinition: jest.fn(),
-    clearElectionDefinition: jest.fn(),
-  };
 }

--- a/vxsuite.code-workspace
+++ b/vxsuite.code-workspace
@@ -17,10 +17,6 @@
       "path": "apps/vx-scan/frontend"
     },
     {
-      "name": "frontends/bmd",
-      "path": "frontends/bmd"
-    },
-    {
       "name": "frontends/bsd",
       "path": "frontends/bsd"
     },


### PR DESCRIPTION
_Reviewing by commit recommended_

## Overview

Issue links: https://github.com/votingworks/vxsuite/issues/2906, https://github.com/votingworks/vxsuite/issues/2903

And another machine's auth moved to the backend. This PR sets up inserted smart card auth on the backend and updates VxScan to use it instead of frontend auth.

## Testing

- [x] Updated test suites
- [x] Manually tested VxScan auth and writing reports to cards

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ Intentionally skipping and revisiting in later PRs
- [x] I have added JSDoc comments to any newly introduced exports