### PR TITLE
define a no-op for make install so complete-system build doesnt fail

### DIFF
--- a/apps/vx-mark/backend/Makefile
+++ b/apps/vx-mark/backend/Makefile
@@ -6,7 +6,7 @@ build: FORCE
 
 bootstrap: build
 
-install: build
+install: ;
 
 run:
 	pnpm start


### PR DESCRIPTION
vx-mark's backend has no real `make install` requirement. Rather than calling the `build` directive, which introduces dependencies that can fail on a clean system, make it a no-op. This will eventually go away as system level configuration is moved out of Makefiles, but this is a fix for now. 