### PR TITLE
fix(message-coder): validate uint values

### DIFF
--- a/libs/message-coder/src/constants.ts
+++ b/libs/message-coder/src/constants.ts
@@ -1,0 +1,61 @@
+import { Uint16, Uint2, Uint24, Uint32, Uint4, Uint8 } from './types';
+
+/**
+ * Minimum uint2 value.
+ */
+export const MIN_UINT2: Uint2 = 0b00;
+
+/**
+ * Maximum uint2 value.
+ */
+export const MAX_UINT2: Uint2 = 0b11;
+
+/**
+ * Minimum uint4 value.
+ */
+export const MIN_UINT4: Uint4 = 0b0000;
+
+/**
+ * Maximum uint4 value.
+ */
+export const MAX_UINT4: Uint4 = 0b1111;
+
+/**
+ * Minimum uint8 value.
+ */
+export const MIN_UINT8: Uint8 = 0b00000000;
+
+/**
+ * Maximum uint8 value.
+ */
+export const MAX_UINT8: Uint8 = 0b11111111;
+
+/**
+ * Minimum uint16 value.
+ */
+export const MIN_UINT16: Uint16 = 0b0000000000000000;
+
+/**
+ * Maximum uint16 value.
+ */
+export const MAX_UINT16: Uint16 = 0b1111111111111111;
+
+/**
+ * Minimum uint24 value.
+ */
+export const MIN_UINT24: Uint24 = 0b000000000000000000000000;
+
+/**
+ * Maximum uint24 value.
+ */
+export const MAX_UINT24: Uint24 = 0b111111111111111111111111;
+
+/**
+ * Minimum uint32 value.
+ */
+export const MIN_UINT32: Uint32 = 0b00000000000000000000000000000000;
+
+/**
+ * Maximum uint32 value.
+ */
+export const MAX_UINT32: Uint32 = 0b11111111111111111111111111111111;

--- a/libs/message-coder/src/uint16_coder.test.ts
+++ b/libs/message-coder/src/uint16_coder.test.ts
@@ -1,6 +1,7 @@
-import { ok, typedAs } from '@votingworks/basics';
+import { err, ok, typedAs } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import * as fc from 'fast-check';
+import { MAX_UINT16 } from './constants';
 import { CoderType } from './message_coder';
 import { DecodeResult } from './types';
 import { uint16 } from './uint16_coder';
@@ -26,4 +27,25 @@ test('uint16', () => {
       }
     )
   );
+});
+
+test('uint16 with enumeration', () => {
+  enum Enum {
+    A = 1,
+    B = 2,
+    C = 3,
+  }
+
+  const field = uint16<Enum>(Enum);
+  expect(field.bitLength(Enum.A)).toEqual(16);
+  expect(field.encode(Enum.A)).toEqual(ok(Buffer.from([1, 0])));
+  expect(field.decode(Buffer.from([1, 0]))).toEqual(ok(Enum.A));
+  expect(field.encode(99)).toEqual(err('InvalidValue'));
+  expect(field.decode(Buffer.from([99, 0]))).toEqual(err('InvalidValue'));
+});
+
+test('uint16 with invalid value', () => {
+  const coder = uint16();
+  expect(coder.encode(-1)).toEqual(err('InvalidValue'));
+  expect(coder.encode(MAX_UINT16 + 1)).toEqual(err('InvalidValue'));
 });

--- a/libs/message-coder/src/uint16_coder.ts
+++ b/libs/message-coder/src/uint16_coder.ts
@@ -1,4 +1,5 @@
 import { Buffer } from 'buffer';
+import { MAX_UINT16, MIN_UINT16 } from './constants';
 import {
   BitLength,
   BitOffset,
@@ -18,6 +19,9 @@ export class Uint16Coder extends UintCoder {
   bitLength(): BitLength {
     return 16;
   }
+
+  protected minValue = MIN_UINT16;
+  protected maxValue = MAX_UINT16;
 
   encodeInto(
     value: Uint16,

--- a/libs/message-coder/src/uint24_coder.test.ts
+++ b/libs/message-coder/src/uint24_coder.test.ts
@@ -1,6 +1,7 @@
-import { ok, typedAs } from '@votingworks/basics';
+import { err, ok, typedAs } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import * as fc from 'fast-check';
+import { MAX_UINT24 } from './constants';
 import { CoderType } from './message_coder';
 import { DecodeResult } from './types';
 import { uint24 } from './uint24_coder';
@@ -26,4 +27,25 @@ test('uint24', () => {
       }
     )
   );
+});
+
+test('uint24 with enumeration', () => {
+  enum Enum {
+    A = 1,
+    B = 2,
+    C = 3,
+  }
+
+  const field = uint24<Enum>(Enum);
+  expect(field.bitLength(Enum.A)).toEqual(24);
+  expect(field.encode(Enum.A)).toEqual(ok(Buffer.from([1, 0, 0])));
+  expect(field.decode(Buffer.from([1, 0, 0]))).toEqual(ok(Enum.A));
+  expect(field.encode(99)).toEqual(err('InvalidValue'));
+  expect(field.decode(Buffer.from([99, 0, 0]))).toEqual(err('InvalidValue'));
+});
+
+test('uint24 with invalid value', () => {
+  const coder = uint24();
+  expect(coder.encode(-1)).toEqual(err('InvalidValue'));
+  expect(coder.encode(MAX_UINT24 + 1)).toEqual(err('InvalidValue'));
 });

--- a/libs/message-coder/src/uint24_coder.ts
+++ b/libs/message-coder/src/uint24_coder.ts
@@ -1,4 +1,5 @@
 import { Buffer } from 'buffer';
+import { MAX_UINT24, MIN_UINT24 } from './constants';
 import {
   BitOffset,
   Coder,
@@ -17,6 +18,9 @@ export class Uint24Coder extends UintCoder {
   bitLength(): Uint24 {
     return 24;
   }
+
+  protected minValue = MIN_UINT24;
+  protected maxValue = MAX_UINT24;
 
   encodeInto(
     value: Uint24,

--- a/libs/message-coder/src/uint2_coder.test.ts
+++ b/libs/message-coder/src/uint2_coder.test.ts
@@ -2,6 +2,7 @@ import { err, ok } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import fc from 'fast-check';
 import { toBitOffset } from './bits';
+import { MAX_UINT2 } from './constants';
 import { uint2 } from './uint2_coder';
 
 test('uint2 simple', () => {
@@ -79,4 +80,10 @@ test('uint2 with unsupported offset', () => {
   expect(coder.decodeFrom(Buffer.alloc(1), 7)).toEqual(
     err('UnsupportedOffset')
   );
+});
+
+test('uint2 with invalid values', () => {
+  const coder = uint2();
+  expect(coder.encode(-1)).toEqual(err('InvalidValue'));
+  expect(coder.encode(MAX_UINT2 + 1)).toEqual(err('InvalidValue'));
 });

--- a/libs/message-coder/src/uint2_coder.ts
+++ b/libs/message-coder/src/uint2_coder.ts
@@ -25,6 +25,9 @@ class Uint2Coder extends BaseCoder<Uint2> {
     return 2;
   }
 
+  protected minValue = 0b00;
+  protected maxValue = 0b11;
+
   encodeInto(value: Uint2, buffer: Buffer, bitOffset: BitOffset): EncodeResult {
     const validationResult = validateEnumValue(this.enumeration, value);
 
@@ -33,6 +36,11 @@ class Uint2Coder extends BaseCoder<Uint2> {
     }
 
     const validatedValue = validationResult.ok();
+
+    if (validatedValue < this.minValue || validatedValue > this.maxValue) {
+      return err('InvalidValue');
+    }
+
     const remainder = bitOffset % BITS_PER_BYTE;
 
     if (remainder + 1 >= BITS_PER_BYTE) {

--- a/libs/message-coder/src/uint32_coder.test.ts
+++ b/libs/message-coder/src/uint32_coder.test.ts
@@ -1,6 +1,7 @@
-import { ok, typedAs } from '@votingworks/basics';
+import { err, ok, typedAs } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import * as fc from 'fast-check';
+import { MAX_UINT32 } from './constants';
 import { CoderType } from './message_coder';
 import { DecodeResult } from './types';
 import { uint32 } from './uint32_coder';
@@ -26,4 +27,25 @@ test('uint32', () => {
       }
     )
   );
+});
+
+test('uint32 with enumeration', () => {
+  enum Enum {
+    A = 1,
+    B = 2,
+    C = 3,
+  }
+
+  const field = uint32<Enum>(Enum);
+  expect(field.bitLength(Enum.A)).toEqual(32);
+  expect(field.encode(Enum.A)).toEqual(ok(Buffer.from([1, 0, 0, 0])));
+  expect(field.decode(Buffer.from([1, 0, 0, 0]))).toEqual(ok(Enum.A));
+  expect(field.encode(99)).toEqual(err('InvalidValue'));
+  expect(field.decode(Buffer.from([99, 0, 0, 0]))).toEqual(err('InvalidValue'));
+});
+
+test('uint32 with invalid value', () => {
+  const coder = uint32();
+  expect(coder.encode(-1)).toEqual(err('InvalidValue'));
+  expect(coder.encode(MAX_UINT32 + 1)).toEqual(err('InvalidValue'));
 });

--- a/libs/message-coder/src/uint32_coder.ts
+++ b/libs/message-coder/src/uint32_coder.ts
@@ -1,4 +1,5 @@
 import { Buffer } from 'buffer';
+import { MAX_UINT32, MIN_UINT32 } from './constants';
 import {
   BitLength,
   BitOffset,
@@ -18,6 +19,9 @@ export class Uint32Coder extends UintCoder {
   bitLength(): BitLength {
     return 32;
   }
+
+  protected minValue = MIN_UINT32;
+  protected maxValue = MAX_UINT32;
 
   encodeInto(
     value: Uint32,

--- a/libs/message-coder/src/uint8_coder.test.ts
+++ b/libs/message-coder/src/uint8_coder.test.ts
@@ -1,6 +1,7 @@
 import { err, ok, typedAs } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import * as fc from 'fast-check';
+import { MAX_UINT8 } from './constants';
 import { CoderType } from './message_coder';
 import { DecodeResult } from './types';
 import { uint8 } from './uint8_coder';
@@ -67,4 +68,10 @@ test('uint8 with enumeration', () => {
   expect(field.decode(Buffer.from([1]))).toEqual(ok(Enum.A));
   expect(field.encode(99)).toEqual(err('InvalidValue'));
   expect(field.decode(Buffer.from([99]))).toEqual(err('InvalidValue'));
+});
+
+test('uint8 with invalid value', () => {
+  const coder = uint8();
+  expect(coder.encode(-1)).toEqual(err('InvalidValue'));
+  expect(coder.encode(MAX_UINT8 + 1)).toEqual(err('InvalidValue'));
 });

--- a/libs/message-coder/src/uint8_coder.ts
+++ b/libs/message-coder/src/uint8_coder.ts
@@ -1,4 +1,5 @@
 import { Buffer } from 'buffer';
+import { MAX_UINT8, MIN_UINT8 } from './constants';
 import {
   BitLength,
   BitOffset,
@@ -17,6 +18,9 @@ export class Uint8Coder extends UintCoder {
   bitLength(): BitLength {
     return 8;
   }
+
+  protected minValue = MIN_UINT8;
+  protected maxValue = MAX_UINT8;
 
   encodeInto(value: Uint8, buffer: Buffer, bitOffset: BitOffset): EncodeResult {
     return mapResult(this.validateValue(value), () =>


### PR DESCRIPTION

## Overview
<!-- add a link to a GitHub Issue here -->
Without this we'd just call e.g. `Buffer#writeUInt8` and throw an exception. Now we properly return an `Err` result.

## Demo Video or Screenshot
n/a

## Testing Plan
New automated tests.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
