### PR TITLE
Take election def as input in auth lib methods

### DIFF
--- a/apps/admin/backend/src/server.test.ts
+++ b/apps/admin/backend/src/server.test.ts
@@ -986,9 +986,14 @@ test('PATCH /admin/elections/:electionId bad election ID', async () => {
 });
 
 test('Auth', async () => {
-  const { electionDefinition } = electionMinimalExhaustiveSampleFixtures;
   const logger = fakeLogger();
-  workspace.store.addElection(electionDefinition.electionData);
+  workspace.store.addElection(
+    electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData
+  );
+  workspace.store.addElection(
+    electionFamousNames2021Fixtures.electionDefinition.electionData
+  );
+  const { electionDefinition } = electionFamousNames2021Fixtures;
   server = await start({ app, logger, workspace });
   const apiClient = grout.createClient<Api>({
     baseUrl: `http://localhost:${PORT}/api`,

--- a/apps/admin/backend/src/server.test.ts
+++ b/apps/admin/backend/src/server.test.ts
@@ -994,6 +994,7 @@ test('Auth', async () => {
     electionFamousNames2021Fixtures.electionDefinition.electionData
   );
   const { electionDefinition } = electionFamousNames2021Fixtures;
+  const { electionData, electionHash } = electionDefinition;
   server = await start({ app, logger, workspace });
   const apiClient = grout.createClient<Api>({
     baseUrl: `http://localhost:${PORT}/api`,
@@ -1003,26 +1004,32 @@ test('Auth', async () => {
   await apiClient.checkPin({ pin: '123456' });
   await apiClient.logOut();
   void (await apiClient.programCard({ userRole: 'system_administrator' }));
+  void (await apiClient.programCard({ userRole: 'election_manager' }));
   void (await apiClient.unprogramCard());
 
   expect(auth.getAuthStatus).toHaveBeenCalledTimes(1);
-  expect(auth.getAuthStatus).toHaveBeenNthCalledWith(1, { electionDefinition });
+  expect(auth.getAuthStatus).toHaveBeenNthCalledWith(1, { electionHash });
   expect(auth.checkPin).toHaveBeenCalledTimes(1);
   expect(auth.checkPin).toHaveBeenNthCalledWith(
     1,
-    { electionDefinition },
+    { electionHash },
     { pin: '123456' }
   );
   expect(auth.logOut).toHaveBeenCalledTimes(1);
-  expect(auth.logOut).toHaveBeenNthCalledWith(1, { electionDefinition });
-  expect(auth.programCard).toHaveBeenCalledTimes(1);
+  expect(auth.logOut).toHaveBeenNthCalledWith(1, { electionHash });
+  expect(auth.programCard).toHaveBeenCalledTimes(2);
   expect(auth.programCard).toHaveBeenNthCalledWith(
     1,
-    { electionDefinition },
+    { electionHash },
     { userRole: 'system_administrator' }
   );
+  expect(auth.programCard).toHaveBeenNthCalledWith(
+    2,
+    { electionHash },
+    { userRole: 'election_manager', electionData }
+  );
   expect(auth.unprogramCard).toHaveBeenCalledTimes(1);
-  expect(auth.unprogramCard).toHaveBeenNthCalledWith(1, { electionDefinition });
+  expect(auth.unprogramCard).toHaveBeenNthCalledWith(1, { electionHash });
 });
 
 test('Auth before election definition has been configured', async () => {
@@ -1035,31 +1042,19 @@ test('Auth before election definition has been configured', async () => {
   await apiClient.getAuthStatus();
   await apiClient.checkPin({ pin: '123456' });
   await apiClient.logOut();
-  void (await apiClient.programCard({ userRole: 'system_administrator' }));
-  void (await apiClient.unprogramCard());
 
   expect(auth.getAuthStatus).toHaveBeenCalledTimes(1);
   expect(auth.getAuthStatus).toHaveBeenNthCalledWith(1, {
-    electionDefinition: undefined,
+    electionHash: undefined,
   });
   expect(auth.checkPin).toHaveBeenCalledTimes(1);
   expect(auth.checkPin).toHaveBeenNthCalledWith(
     1,
-    { electionDefinition: undefined },
+    { electionHash: undefined },
     { pin: '123456' }
   );
   expect(auth.logOut).toHaveBeenCalledTimes(1);
   expect(auth.logOut).toHaveBeenNthCalledWith(1, {
-    electionDefinition: undefined,
-  });
-  expect(auth.programCard).toHaveBeenCalledTimes(1);
-  expect(auth.programCard).toHaveBeenNthCalledWith(
-    1,
-    { electionDefinition: undefined },
-    { userRole: 'system_administrator' }
-  );
-  expect(auth.unprogramCard).toHaveBeenCalledTimes(1);
-  expect(auth.unprogramCard).toHaveBeenNthCalledWith(1, {
-    electionDefinition: undefined,
+    electionHash: undefined,
   });
 });

--- a/apps/admin/backend/src/server.ts
+++ b/apps/admin/backend/src/server.ts
@@ -38,11 +38,22 @@ function constructDippedSmartCardAuthMachineState(
   workspace: Workspace
 ): DippedSmartCardAuthMachineState {
   // TODO: Once we actually support multiple elections, configure the auth instance with the
-  // currently selected election rather than the first. In fact, do so as soon as the currently
-  // selected election is persisted on the backend instead of the frontend since, even today, in
-  // dev, we can end up with multiple election definitions under the hood via incognito windows
+  // currently selected election rather than the most recently created. In fact, do so as soon as
+  // the currently selected election is persisted on the backend instead of the frontend since,
+  // even today, in dev, we can end up with multiple election definitions under the hood via
+  // incognito windows
   const elections = workspace.store.getElections();
-  return { electionDefinition: elections[0]?.electionDefinition };
+  const mostRecentlyCreatedElection =
+    elections.length > 0
+      ? elections.reduce((e1, e2) =>
+          new Date(e1.createdAt) > new Date(e2.createdAt)
+            ? /* istanbul ignore next */ e1
+            : e2
+        )
+      : undefined;
+  return {
+    electionDefinition: mostRecentlyCreatedElection?.electionDefinition,
+  };
 }
 
 function buildApi(auth: DippedSmartCardAuthApi, workspace: Workspace) {

--- a/apps/central-scan/backend/src/central_scanner_app.test.ts
+++ b/apps/central-scan/backend/src/central_scanner_app.test.ts
@@ -810,7 +810,7 @@ test('get next sheet layouts', async () => {
 });
 
 test('Auth', async () => {
-  const { electionDefinition } = stateOfHamilton;
+  const { electionHash } = stateOfHamilton.electionDefinition;
   const logger = fakeLogger();
   server = await start({ app, logger, workspace });
   const apiClient = grout.createClient<Api>({
@@ -822,13 +822,13 @@ test('Auth', async () => {
   await apiClient.logOut();
 
   expect(auth.getAuthStatus).toHaveBeenCalledTimes(1);
-  expect(auth.getAuthStatus).toHaveBeenNthCalledWith(1, { electionDefinition });
+  expect(auth.getAuthStatus).toHaveBeenNthCalledWith(1, { electionHash });
   expect(auth.checkPin).toHaveBeenCalledTimes(1);
   expect(auth.checkPin).toHaveBeenNthCalledWith(
     1,
-    { electionDefinition },
+    { electionHash },
     { pin: '123456' }
   );
   expect(auth.logOut).toHaveBeenCalledTimes(1);
-  expect(auth.logOut).toHaveBeenNthCalledWith(1, { electionDefinition });
+  expect(auth.logOut).toHaveBeenNthCalledWith(1, { electionHash });
 });

--- a/apps/central-scan/backend/src/central_scanner_app.test.ts
+++ b/apps/central-scan/backend/src/central_scanner_app.test.ts
@@ -35,7 +35,6 @@ import {
 import { Server } from 'http';
 import * as grout from '@votingworks/grout';
 import { fakeLogger } from '@votingworks/logging';
-import { mockOf } from '@votingworks/test-utils';
 import * as stateOfHamilton from '../test/fixtures/state-of-hamilton';
 import { makeMock } from '../test/util/mocks';
 import { Importer } from './importer';
@@ -233,8 +232,6 @@ test('GET /config/markThresholdOverrides', async () => {
 });
 
 test('PATCH /config/election', async () => {
-  mockOf(auth.setElectionDefinition).mockClear();
-
   await request(app)
     .patch('/central-scanner/config/election')
     .send(testElectionDefinition.electionData)
@@ -247,11 +244,6 @@ test('PATCH /config/election', async () => {
         title: testElectionDefinition.election.title,
       }),
     })
-  );
-  expect(auth.setElectionDefinition).toHaveBeenCalledTimes(1);
-  expect(auth.setElectionDefinition).toHaveBeenNthCalledWith(
-    1,
-    testElectionDefinition
   );
 
   // bad content type
@@ -320,7 +312,6 @@ test('DELETE /config/election', async () => {
     .set('Accept', 'application/json')
     .expect(200, { status: 'ok' });
   expect(importer.unconfigure).toBeCalled();
-  expect(auth.clearElectionDefinition).toHaveBeenCalledTimes(1);
 });
 
 test('DELETE /config/election ignores lack of backup when ?ignoreBackupRequirement=true is specified', async () => {
@@ -819,6 +810,7 @@ test('get next sheet layouts', async () => {
 });
 
 test('Auth', async () => {
+  const { electionDefinition } = stateOfHamilton;
   const logger = fakeLogger();
   server = await start({ app, logger, workspace });
   const apiClient = grout.createClient<Api>({
@@ -830,22 +822,13 @@ test('Auth', async () => {
   await apiClient.logOut();
 
   expect(auth.getAuthStatus).toHaveBeenCalledTimes(1);
+  expect(auth.getAuthStatus).toHaveBeenNthCalledWith(1, { electionDefinition });
   expect(auth.checkPin).toHaveBeenCalledTimes(1);
-  expect(auth.checkPin).toHaveBeenNthCalledWith(1, { pin: '123456' });
-  expect(auth.logOut).toHaveBeenCalledTimes(1);
-});
-
-test('Auth initial election definition configuration', async () => {
-  mockOf(auth.setElectionDefinition).mockClear();
-
-  workspace.store.setElection(
-    electionFamousNames2021Fixtures.electionDefinition.electionData
-  );
-  await buildCentralScannerApp({ auth, exporter, importer, workspace });
-
-  expect(auth.setElectionDefinition).toHaveBeenCalledTimes(1);
-  expect(auth.setElectionDefinition).toHaveBeenNthCalledWith(
+  expect(auth.checkPin).toHaveBeenNthCalledWith(
     1,
-    electionFamousNames2021Fixtures.electionDefinition
+    { electionDefinition },
+    { pin: '123456' }
   );
+  expect(auth.logOut).toHaveBeenCalledTimes(1);
+  expect(auth.logOut).toHaveBeenNthCalledWith(1, { electionDefinition });
 });

--- a/apps/central-scan/backend/src/central_scanner_app.ts
+++ b/apps/central-scan/backend/src/central_scanner_app.ts
@@ -1,5 +1,8 @@
 import { Scan } from '@votingworks/api';
-import { DippedSmartCardAuthApi } from '@votingworks/auth';
+import {
+  DippedSmartCardAuthApi,
+  DippedSmartCardAuthMachineState,
+} from '@votingworks/auth';
 import { assert } from '@votingworks/basics';
 import { Exporter } from '@votingworks/data';
 import {
@@ -38,11 +41,23 @@ export interface AppOptions {
   workspace: Workspace;
 }
 
-function buildApi(auth: DippedSmartCardAuthApi) {
+function constructDippedSmartCardAuthMachineState(
+  workspace: Workspace
+): DippedSmartCardAuthMachineState {
+  const electionDefinition = workspace.store.getElectionDefinition();
+  return { electionDefinition };
+}
+
+function buildApi(auth: DippedSmartCardAuthApi, workspace: Workspace) {
   return grout.createApi({
-    getAuthStatus: () => auth.getAuthStatus(),
-    checkPin: (input: { pin: string }) => auth.checkPin(input),
-    logOut: () => auth.logOut(),
+    getAuthStatus: () =>
+      auth.getAuthStatus(constructDippedSmartCardAuthMachineState(workspace)),
+
+    checkPin: (input: { pin: string }) =>
+      auth.checkPin(constructDippedSmartCardAuthMachineState(workspace), input),
+
+    logOut: () =>
+      auth.logOut(constructDippedSmartCardAuthMachineState(workspace)),
   });
 }
 
@@ -63,14 +78,8 @@ export async function buildCentralScannerApp({
 }: AppOptions): Promise<Application> {
   const { store } = workspace;
 
-  const initialElectionDefinition = store.getElectionDefinition();
-  if (initialElectionDefinition) {
-    auth.setElectionDefinition(initialElectionDefinition);
-  }
-
   const app: Application = express();
-
-  const api = buildApi(auth);
+  const api = buildApi(auth, workspace);
   app.use('/api', grout.buildRouter(api, express));
 
   const upload = multer({
@@ -147,7 +156,6 @@ export async function buildCentralScannerApp({
 
     const electionDefinition = bodyParseResult.ok();
     importer.configure(electionDefinition);
-    auth.setElectionDefinition(electionDefinition);
     response.json({ status: 'ok' });
   });
 
@@ -172,7 +180,6 @@ export async function buildCentralScannerApp({
       }
 
       importer.unconfigure();
-      auth.clearElectionDefinition();
       response.json({ status: 'ok' });
     }
   );

--- a/apps/central-scan/backend/src/central_scanner_app.ts
+++ b/apps/central-scan/backend/src/central_scanner_app.ts
@@ -45,7 +45,7 @@ function constructDippedSmartCardAuthMachineState(
   workspace: Workspace
 ): DippedSmartCardAuthMachineState {
   const electionDefinition = workspace.store.getElectionDefinition();
-  return { electionDefinition };
+  return { electionHash: electionDefinition?.electionHash };
 }
 
 function buildApi(auth: DippedSmartCardAuthApi, workspace: Workspace) {

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -44,7 +44,7 @@ function constructInsertedSmartCardAuthMachineState(
   workspace: Workspace
 ): InsertedSmartCardAuthMachineState {
   const electionDefinition = workspace.store.getElectionDefinition();
-  return { electionDefinition };
+  return { electionHash: electionDefinition?.electionHash };
 }
 
 function buildApi(

--- a/apps/scan/backend/src/app_config.test.ts
+++ b/apps/scan/backend/src/app_config.test.ts
@@ -337,7 +337,7 @@ test('unconfiguring machine', async () => {
 });
 
 test('auth', async () => {
-  const { electionDefinition } = electionFamousNames2021Fixtures;
+  const { electionHash } = electionFamousNames2021Fixtures.electionDefinition;
   const { apiClient, mockAuth, mockUsb } = await createApp();
   await configureApp(apiClient, mockUsb);
 
@@ -346,12 +346,12 @@ test('auth', async () => {
 
   expect(mockAuth.getAuthStatus).toHaveBeenCalledTimes(1);
   expect(mockAuth.getAuthStatus).toHaveBeenNthCalledWith(1, {
-    electionDefinition,
+    electionHash,
   });
   expect(mockAuth.checkPin).toHaveBeenCalledTimes(1);
   expect(mockAuth.checkPin).toHaveBeenNthCalledWith(
     1,
-    { electionDefinition },
+    { electionHash },
     { pin: '123456' }
   );
 });
@@ -365,6 +365,7 @@ test('write scanner report data to card', async () => {
   );
 
   const { electionDefinition } = electionFamousNames2021Fixtures;
+  const { electionHash } = electionDefinition;
   const scannerReportData: ScannerReportData = {
     ballotCounts: {},
     isLiveMode: false,
@@ -405,7 +406,7 @@ test('write scanner report data to card', async () => {
   expect(mockAuth.writeCardData).toHaveBeenCalledTimes(1);
   expect(mockAuth.writeCardData).toHaveBeenNthCalledWith(
     1,
-    { electionDefinition },
+    { electionHash },
     { data: scannerReportData, schema: ScannerReportDataSchema }
   );
 });

--- a/apps/scan/backend/src/app_config.test.ts
+++ b/apps/scan/backend/src/app_config.test.ts
@@ -120,7 +120,7 @@ test("fails to configure if there's no ballot package on the usb drive", async (
 });
 
 test("if there's only one precinct in the election, it's selected automatically on configure", async () => {
-  const { apiClient, mockAuth, mockUsb } = await createApp();
+  const { apiClient, mockUsb } = await createApp();
   mockUsb.insertUsbDrive({
     'ballot-packages': {
       'test-ballot-package.zip': createBallotPackageWithoutTemplates(
@@ -134,21 +134,10 @@ test("if there's only one precinct in the election, it's selected automatically 
     kind: 'SinglePrecinct',
     precinctId: 'precinct-1',
   });
-
-  expect(mockAuth.setElectionDefinition).toHaveBeenCalledTimes(1);
-  expect(mockAuth.setElectionDefinition).toHaveBeenNthCalledWith(
-    1,
-    electionMinimalExhaustiveSampleSinglePrecinctDefinition
-  );
-  expect(mockAuth.setPrecinctSelection).toHaveBeenCalledTimes(1);
-  expect(mockAuth.setPrecinctSelection).toHaveBeenNthCalledWith(1, {
-    kind: 'SinglePrecinct',
-    precinctId: 'precinct-1',
-  });
 });
 
 test('configures using the most recently created ballot package on the usb drive', async () => {
-  const { apiClient, mockAuth, mockUsb } = await createApp();
+  const { apiClient, mockUsb } = await createApp();
 
   mockUsb.insertUsbDrive({
     'ballot-packages': {
@@ -180,13 +169,6 @@ test('configures using the most recently created ballot package on the usb drive
   expect(config.electionDefinition?.election.title).toEqual(
     electionSampleDefinition.election.title
   );
-
-  expect(mockAuth.setElectionDefinition).toHaveBeenCalledTimes(1);
-  expect(mockAuth.setElectionDefinition).toHaveBeenNthCalledWith(
-    1,
-    electionSampleDefinition
-  );
-  expect(mockAuth.setPrecinctSelection).not.toHaveBeenCalled();
 });
 
 test('export the CVRs to USB', async () => {
@@ -243,22 +225,14 @@ test('export the CVRs to USB', async () => {
 });
 
 test('setPrecinctSelection will reset polls to closed and update auth instance', async () => {
-  const { apiClient, mockAuth, mockUsb, workspace } = await createApp();
+  const { apiClient, mockUsb, workspace } = await createApp();
   await configureApp(apiClient, mockUsb);
-
-  mockOf(mockAuth.setPrecinctSelection).mockClear();
 
   workspace.store.setPollsState('polls_open');
   await apiClient.setPrecinctSelection({
     precinctSelection: singlePrecinctSelectionFor('21'),
   });
   expect(workspace.store.getPollsState()).toEqual('polls_closed_initial');
-
-  expect(mockAuth.setPrecinctSelection).toHaveBeenCalledTimes(1);
-  expect(mockAuth.setPrecinctSelection).toHaveBeenNthCalledWith(
-    1,
-    singlePrecinctSelectionFor('21')
-  );
 });
 
 test('ballot batching', async () => {
@@ -350,8 +324,7 @@ test('ballot batching', async () => {
 });
 
 test('unconfiguring machine', async () => {
-  const { apiClient, mockAuth, mockUsb, interpreter, workspace } =
-    await createApp();
+  const { apiClient, mockUsb, interpreter, workspace } = await createApp();
   await configureApp(apiClient, mockUsb);
 
   jest.spyOn(interpreter, 'unconfigure');
@@ -361,11 +334,10 @@ test('unconfiguring machine', async () => {
 
   expect(interpreter.unconfigure).toHaveBeenCalledTimes(1);
   expect(workspace.reset).toHaveBeenCalledTimes(1);
-  expect(mockAuth.clearElectionDefinition).toHaveBeenCalledTimes(1);
-  expect(mockAuth.clearPrecinctSelection).toHaveBeenCalledTimes(1);
 });
 
 test('auth', async () => {
+  const { electionDefinition } = electionFamousNames2021Fixtures;
   const { apiClient, mockAuth, mockUsb } = await createApp();
   await configureApp(apiClient, mockUsb);
 
@@ -373,28 +345,14 @@ test('auth', async () => {
   await apiClient.checkPin({ pin: '123456' });
 
   expect(mockAuth.getAuthStatus).toHaveBeenCalledTimes(1);
-  expect(mockAuth.checkPin).toHaveBeenCalledTimes(1);
-  expect(mockAuth.checkPin).toHaveBeenNthCalledWith(1, { pin: '123456' });
-});
-
-test('auth initial election definition and precinct selection configuration', async () => {
-  const createAppResult = await createApp();
-  await configureApp(createAppResult.apiClient, createAppResult.mockUsb);
-  const preconfiguredWorkspace = createAppResult.workspace;
-
-  const { mockAuth } = await createApp({
-    preconfiguredWorkspace,
+  expect(mockAuth.getAuthStatus).toHaveBeenNthCalledWith(1, {
+    electionDefinition,
   });
-
-  expect(mockAuth.setElectionDefinition).toHaveBeenCalledTimes(1);
-  expect(mockAuth.setElectionDefinition).toHaveBeenNthCalledWith(
+  expect(mockAuth.checkPin).toHaveBeenCalledTimes(1);
+  expect(mockAuth.checkPin).toHaveBeenNthCalledWith(
     1,
-    electionFamousNames2021Fixtures.electionDefinition
-  );
-  expect(mockAuth.setPrecinctSelection).toHaveBeenCalledTimes(1);
-  expect(mockAuth.setPrecinctSelection).toHaveBeenNthCalledWith(
-    1,
-    ALL_PRECINCTS_SELECTION
+    { electionDefinition },
+    { pin: '123456' }
   );
 });
 
@@ -421,29 +379,33 @@ test('write scanner report data to card', async () => {
   };
   let result: Result<void, Error>;
 
-  mockOf(mockAuth.getAuthStatus).mockImplementation(() => ({
-    status: 'logged_out',
-    reason: 'no_card',
-  }));
+  mockOf(mockAuth.getAuthStatus).mockImplementation(() =>
+    Promise.resolve({ status: 'logged_out', reason: 'no_card' })
+  );
   result = await apiClient.saveScannerReportDataToCard({ scannerReportData });
   expect(result).toEqual(err(new Error('User is not logged in')));
 
-  mockOf(mockAuth.getAuthStatus).mockImplementation(() => ({
-    status: 'logged_in',
-    user: fakeElectionManagerUser(electionDefinition),
-  }));
+  mockOf(mockAuth.getAuthStatus).mockImplementation(() =>
+    Promise.resolve({
+      status: 'logged_in',
+      user: fakeElectionManagerUser(electionDefinition),
+    })
+  );
   result = await apiClient.saveScannerReportDataToCard({ scannerReportData });
   expect(result).toEqual(err(new Error('User is not a poll worker')));
 
-  mockOf(mockAuth.getAuthStatus).mockImplementation(() => ({
-    status: 'logged_in',
-    user: fakePollWorkerUser(electionDefinition),
-  }));
+  mockOf(mockAuth.getAuthStatus).mockImplementation(() =>
+    Promise.resolve({
+      status: 'logged_in',
+      user: fakePollWorkerUser(electionDefinition),
+    })
+  );
   result = await apiClient.saveScannerReportDataToCard({ scannerReportData });
   expect(result).toEqual(ok());
   expect(mockAuth.writeCardData).toHaveBeenCalledTimes(1);
-  expect(mockAuth.writeCardData).toHaveBeenNthCalledWith(1, {
-    data: scannerReportData,
-    schema: ScannerReportDataSchema,
-  });
+  expect(mockAuth.writeCardData).toHaveBeenNthCalledWith(
+    1,
+    { electionDefinition },
+    { data: scannerReportData, schema: ScannerReportDataSchema }
+  );
 });

--- a/libs/auth/src/dipped_smart_card_auth.ts
+++ b/libs/auth/src/dipped_smart_card_auth.ts
@@ -1,7 +1,6 @@
 import { Result } from '@votingworks/basics';
 import {
   DippedSmartCardAuth,
-  ElectionDefinition,
   ElectionManagerUser,
   PollWorkerUser,
   SystemAdministratorUser,
@@ -24,12 +23,10 @@ export interface DippedSmartCardAuthApi {
 
   programCard: (
     machineState: DippedSmartCardAuthMachineState,
-    input: {
-      userRole:
-        | SystemAdministratorUser['role']
-        | ElectionManagerUser['role']
-        | PollWorkerUser['role'];
-    }
+    input:
+      | { userRole: SystemAdministratorUser['role'] }
+      | { userRole: ElectionManagerUser['role']; electionData: string }
+      | { userRole: PollWorkerUser['role'] }
   ) => Promise<Result<{ pin?: string }, Error>>;
   unprogramCard: (
     machineState: DippedSmartCardAuthMachineState
@@ -47,5 +44,5 @@ export interface DippedSmartCardAuthConfig {
  * Machine state that the consumer is responsible for providing
  */
 export interface DippedSmartCardAuthMachineState {
-  electionDefinition?: ElectionDefinition;
+  electionHash?: string;
 }

--- a/libs/auth/src/dipped_smart_card_auth.ts
+++ b/libs/auth/src/dipped_smart_card_auth.ts
@@ -12,21 +12,28 @@ import {
  * inserted and removed from the card reader for the user to be authenticated
  */
 export interface DippedSmartCardAuthApi {
-  getAuthStatus: () => DippedSmartCardAuth.AuthStatus;
+  getAuthStatus: (
+    machineState: DippedSmartCardAuthMachineState
+  ) => Promise<DippedSmartCardAuth.AuthStatus>;
 
-  checkPin: (input: { pin: string }) => void;
-  logOut: () => void;
+  checkPin: (
+    machineState: DippedSmartCardAuthMachineState,
+    input: { pin: string }
+  ) => Promise<void>;
+  logOut: (machineState: DippedSmartCardAuthMachineState) => Promise<void>;
 
-  programCard: (input: {
-    userRole:
-      | SystemAdministratorUser['role']
-      | ElectionManagerUser['role']
-      | PollWorkerUser['role'];
-  }) => Promise<Result<{ pin?: string }, Error>>;
-  unprogramCard: () => Promise<Result<void, Error>>;
-
-  setElectionDefinition: (electionDefinition: ElectionDefinition) => void;
-  clearElectionDefinition: () => void;
+  programCard: (
+    machineState: DippedSmartCardAuthMachineState,
+    input: {
+      userRole:
+        | SystemAdministratorUser['role']
+        | ElectionManagerUser['role']
+        | PollWorkerUser['role'];
+    }
+  ) => Promise<Result<{ pin?: string }, Error>>;
+  unprogramCard: (
+    machineState: DippedSmartCardAuthMachineState
+  ) => Promise<Result<void, Error>>;
 }
 
 /**
@@ -34,5 +41,11 @@ export interface DippedSmartCardAuthApi {
  */
 export interface DippedSmartCardAuthConfig {
   allowElectionManagersToAccessUnconfiguredMachines?: boolean;
+}
+
+/**
+ * Machine state that the consumer is responsible for providing
+ */
+export interface DippedSmartCardAuthMachineState {
   electionDefinition?: ElectionDefinition;
 }

--- a/libs/auth/src/dipped_smart_card_auth_with_memory_card.test.ts
+++ b/libs/auth/src/dipped_smart_card_auth_with_memory_card.test.ts
@@ -9,7 +9,7 @@ beforeEach(() => {
 test('DippedSmartCardAuthWithMemoryCard returns auth status', async () => {
   const card = new MockMemoryCard();
   const auth = new DippedSmartCardAuthWithMemoryCard({ card, config: {} });
-  expect(await auth.getAuthStatus({ electionDefinition: undefined })).toEqual({
+  expect(await auth.getAuthStatus({ electionHash: undefined })).toEqual({
     status: 'logged_out',
     reason: 'machine_locked',
   });

--- a/libs/auth/src/dipped_smart_card_auth_with_memory_card.test.ts
+++ b/libs/auth/src/dipped_smart_card_auth_with_memory_card.test.ts
@@ -6,10 +6,10 @@ beforeEach(() => {
   jest.useFakeTimers();
 });
 
-test('DippedSmartCardAuthWithMemoryCard returns auth status', () => {
+test('DippedSmartCardAuthWithMemoryCard returns auth status', async () => {
   const card = new MockMemoryCard();
   const auth = new DippedSmartCardAuthWithMemoryCard({ card, config: {} });
-  expect(auth.getAuthStatus()).toEqual({
+  expect(await auth.getAuthStatus({ electionDefinition: undefined })).toEqual({
     status: 'logged_out',
     reason: 'machine_locked',
   });

--- a/libs/auth/src/dipped_smart_card_auth_with_memory_card.ts
+++ b/libs/auth/src/dipped_smart_card_auth_with_memory_card.ts
@@ -11,7 +11,6 @@ import {
   Card,
   CardSummary,
   DippedSmartCardAuth,
-  ElectionDefinition,
   ElectionManagerCardData,
   PollWorkerCardData,
   SystemAdministratorCardData,
@@ -22,18 +21,16 @@ import { generatePin } from '@votingworks/utils';
 import {
   DippedSmartCardAuthApi,
   DippedSmartCardAuthConfig,
+  DippedSmartCardAuthMachineState,
 } from './dipped_smart_card_auth';
-import {
-  CARD_POLLING_INTERVAL_MS,
-  parseUserFromCardSummary,
-} from './memory_card';
+import { parseUserFromCardSummary } from './memory_card';
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 global.fetch = fetch;
 
 type AuthAction =
-  | { type: 'read_card'; cardSummary: CardSummary }
+  | { type: 'check_card_reader'; cardSummary: CardSummary }
   | { type: 'check_pin'; pin: string }
   | { type: 'log_out' };
 
@@ -51,59 +48,52 @@ export class DippedSmartCardAuthWithMemoryCard
 {
   private authStatus: DippedSmartCardAuth.AuthStatus;
   private readonly card: Card;
-  private config: DippedSmartCardAuthConfig;
+  private readonly config: DippedSmartCardAuthConfig;
 
   constructor({
     card,
     config,
   }: {
     card: Card;
-    config: Omit<DippedSmartCardAuthConfig, 'electionDefinition'>;
+    config: DippedSmartCardAuthConfig;
   }) {
     this.authStatus = DippedSmartCardAuth.DEFAULT_AUTH_STATUS;
     this.card = card;
     this.config = config;
-
-    setInterval(
-      async () => {
-        try {
-          const newCardSummary = await this.card.readSummary();
-          this.updateAuthStatus({
-            type: 'read_card',
-            cardSummary: newCardSummary,
-          });
-        } catch {
-          // Swallow errors so that they don't crash the auth instance and containing backend
-        }
-      },
-      CARD_POLLING_INTERVAL_MS,
-      true
-    );
   }
 
-  getAuthStatus(): DippedSmartCardAuth.AuthStatus {
+  async getAuthStatus(
+    machineState: DippedSmartCardAuthMachineState
+  ): Promise<DippedSmartCardAuth.AuthStatus> {
+    await this.checkCardReaderAndUpdateAuthStatus(machineState);
     return this.authStatus;
   }
 
-  checkPin({ pin }: { pin: string }): void {
-    this.updateAuthStatus({ type: 'check_pin', pin });
+  async checkPin(
+    machineState: DippedSmartCardAuthMachineState,
+    input: { pin: string }
+  ): Promise<void> {
+    await this.checkCardReaderAndUpdateAuthStatus(machineState);
+    this.updateAuthStatus(machineState, { type: 'check_pin', pin: input.pin });
   }
 
-  logOut(): void {
-    this.updateAuthStatus({ type: 'log_out' });
+  async logOut(machineState: DippedSmartCardAuthMachineState): Promise<void> {
+    this.updateAuthStatus(machineState, { type: 'log_out' });
+    return Promise.resolve();
   }
 
-  async programCard({
-    userRole,
-  }: {
-    userRole: 'system_administrator' | 'election_manager' | 'poll_worker';
-  }): Promise<Result<{ pin?: string }, Error>> {
-    const { electionDefinition } = this.config;
+  async programCard(
+    machineState: DippedSmartCardAuthMachineState,
+    input: {
+      userRole: 'system_administrator' | 'election_manager' | 'poll_worker';
+    }
+  ): Promise<Result<{ pin?: string }, Error>> {
+    const { electionDefinition } = machineState;
     const electionHash = electionDefinition?.electionHash;
     const electionData = electionDefinition?.electionData;
     const pin = generatePin();
     try {
-      switch (userRole) {
+      switch (input.userRole) {
         case 'system_administrator': {
           const cardData: SystemAdministratorCardData = {
             t: 'system_administrator',
@@ -140,7 +130,7 @@ export class DippedSmartCardAuthWithMemoryCard
         }
         /* istanbul ignore next: Compile-time check for completeness */
         default:
-          throwIllegalValue(userRole);
+          throwIllegalValue(input.userRole);
       }
     } catch (error) {
       return wrapException(error);
@@ -161,24 +151,31 @@ export class DippedSmartCardAuthWithMemoryCard
     return ok();
   }
 
-  setElectionDefinition(electionDefinition: ElectionDefinition): void {
-    this.config.electionDefinition = electionDefinition;
+  private async checkCardReaderAndUpdateAuthStatus(
+    machineState: DippedSmartCardAuthMachineState
+  ) {
+    const cardSummary = await this.card.readSummary();
+    this.updateAuthStatus(machineState, {
+      type: 'check_card_reader',
+      cardSummary,
+    });
   }
 
-  clearElectionDefinition(): void {
-    delete this.config.electionDefinition;
-  }
-
-  private updateAuthStatus(action: AuthAction): void {
-    this.authStatus = this.determineNewAuthStatus(action);
+  private updateAuthStatus(
+    machineState: DippedSmartCardAuthMachineState,
+    action: AuthAction
+  ) {
+    this.authStatus = this.determineNewAuthStatus(machineState, action);
   }
 
   private determineNewAuthStatus(
+    machineState: DippedSmartCardAuthMachineState,
     action: AuthAction
   ): DippedSmartCardAuth.AuthStatus {
     const currentAuthStatus = this.authStatus;
+
     switch (action.type) {
-      case 'read_card': {
+      case 'check_card_reader': {
         const newAuthStatus = ((): DippedSmartCardAuth.AuthStatus => {
           switch (currentAuthStatus.status) {
             case 'logged_out': {
@@ -191,7 +188,10 @@ export class DippedSmartCardAuthWithMemoryCard
 
                 case 'ready': {
                   const user = parseUserFromCardSummary(action.cardSummary);
-                  const validationResult = this.validateCardUser(user);
+                  const validationResult = this.validateCardUser(
+                    machineState,
+                    user
+                  );
                   if (validationResult.isOk()) {
                     assert(
                       user &&
@@ -280,6 +280,7 @@ export class DippedSmartCardAuthWithMemoryCard
   }
 
   private validateCardUser(
+    machineState: DippedSmartCardAuthMachineState,
     user?: User
   ): Result<void, DippedSmartCardAuth.LoggedOut['reason']> {
     if (!user) {
@@ -291,12 +292,12 @@ export class DippedSmartCardAuthWithMemoryCard
     }
 
     if (user.role === 'election_manager') {
-      if (!this.config.electionDefinition) {
+      if (!machineState.electionDefinition) {
         return this.config.allowElectionManagersToAccessUnconfiguredMachines
           ? ok()
           : err('machine_not_configured');
       }
-      if (user.electionHash !== this.config.electionDefinition.electionHash) {
+      if (user.electionHash !== machineState.electionDefinition.electionHash) {
         return err('election_manager_wrong_election');
       }
     }

--- a/libs/auth/src/inserted_smart_card_auth.ts
+++ b/libs/auth/src/inserted_smart_card_auth.ts
@@ -1,11 +1,6 @@
 import { z } from 'zod';
 import { Result } from '@votingworks/basics';
-import {
-  ElectionDefinition,
-  InsertedSmartCardAuth,
-  Optional,
-  UserRole,
-} from '@votingworks/types';
+import { InsertedSmartCardAuth, Optional, UserRole } from '@votingworks/types';
 
 /**
  * The API for an inserted smart card auth instance, "inserted" meaning that the card needs to be
@@ -51,5 +46,5 @@ export interface InsertedSmartCardAuthConfig {
  * Machine state that the consumer is responsible for providing
  */
 export interface InsertedSmartCardAuthMachineState {
-  electionDefinition?: ElectionDefinition;
+  electionHash?: string;
 }

--- a/libs/auth/src/inserted_smart_card_auth.ts
+++ b/libs/auth/src/inserted_smart_card_auth.ts
@@ -4,7 +4,6 @@ import {
   ElectionDefinition,
   InsertedSmartCardAuth,
   Optional,
-  PrecinctSelection,
   UserRole,
 } from '@votingworks/types';
 
@@ -13,23 +12,31 @@ import {
  * kept in the card reader for the user to remain authenticated
  */
 export interface InsertedSmartCardAuthApi {
-  getAuthStatus: () => InsertedSmartCardAuth.AuthStatus;
+  getAuthStatus: (
+    machineState: InsertedSmartCardAuthMachineState
+  ) => Promise<InsertedSmartCardAuth.AuthStatus>;
 
-  checkPin: (input: { pin: string }) => void;
+  checkPin: (
+    machineState: InsertedSmartCardAuthMachineState,
+    input: { pin: string }
+  ) => Promise<void>;
 
-  readCardData: <T>(input: {
-    schema: z.ZodSchema<T>;
-  }) => Promise<Result<Optional<T>, SyntaxError | z.ZodError | Error>>;
-  writeCardData: <T>(input: {
-    data: T;
-    schema: z.ZodSchema<T>;
-  }) => Promise<Result<void, Error>>;
-  clearCardData: () => Promise<Result<void, Error>>;
-
-  setElectionDefinition: (electionDefinition: ElectionDefinition) => void;
-  clearElectionDefinition: () => void;
-  setPrecinctSelection: (precinctSelection: PrecinctSelection) => void;
-  clearPrecinctSelection: () => void;
+  readCardData: <T>(
+    machineState: InsertedSmartCardAuthMachineState,
+    input: {
+      schema: z.ZodSchema<T>;
+    }
+  ) => Promise<Result<Optional<T>, SyntaxError | z.ZodError | Error>>;
+  writeCardData: <T>(
+    machineState: InsertedSmartCardAuthMachineState,
+    input: {
+      data: T;
+      schema: z.ZodSchema<T>;
+    }
+  ) => Promise<Result<void, Error>>;
+  clearCardData: (
+    machineState: InsertedSmartCardAuthMachineState
+  ) => Promise<Result<void, Error>>;
 }
 
 /**
@@ -38,6 +45,11 @@ export interface InsertedSmartCardAuthApi {
 export interface InsertedSmartCardAuthConfig {
   allowedUserRoles: UserRole[];
   allowElectionManagersToAccessMachinesConfiguredForOtherElections?: boolean;
+}
+
+/**
+ * Machine state that the consumer is responsible for providing
+ */
+export interface InsertedSmartCardAuthMachineState {
   electionDefinition?: ElectionDefinition;
-  precinctSelection?: PrecinctSelection;
 }

--- a/libs/auth/src/inserted_smart_card_auth_with_memory_card.test.ts
+++ b/libs/auth/src/inserted_smart_card_auth_with_memory_card.test.ts
@@ -12,7 +12,7 @@ test('InsertedSmartCardAuthWithMemoryCard returns auth status', async () => {
     card,
     config: { allowedUserRoles: [] },
   });
-  expect(await auth.getAuthStatus({ electionDefinition: undefined })).toEqual({
+  expect(await auth.getAuthStatus({ electionHash: undefined })).toEqual({
     status: 'logged_out',
     reason: 'no_card',
   });

--- a/libs/auth/src/inserted_smart_card_auth_with_memory_card.test.ts
+++ b/libs/auth/src/inserted_smart_card_auth_with_memory_card.test.ts
@@ -6,13 +6,13 @@ beforeEach(() => {
   jest.useFakeTimers();
 });
 
-test('InsertedSmartCardAuthWithMemoryCard returns auth status', () => {
+test('InsertedSmartCardAuthWithMemoryCard returns auth status', async () => {
   const card = new MockMemoryCard();
   const auth = new InsertedSmartCardAuthWithMemoryCard({
     card,
     config: { allowedUserRoles: [] },
   });
-  expect(auth.getAuthStatus()).toEqual({
+  expect(await auth.getAuthStatus({ electionDefinition: undefined })).toEqual({
     status: 'logged_out',
     reason: 'no_card',
   });

--- a/libs/auth/src/inserted_smart_card_auth_with_memory_card.ts
+++ b/libs/auth/src/inserted_smart_card_auth_with_memory_card.ts
@@ -11,28 +11,24 @@ import {
 import {
   Card,
   CardSummary,
-  ElectionDefinition,
   InsertedSmartCardAuth,
   Optional,
-  PrecinctSelection,
   User,
 } from '@votingworks/types';
 
 import {
   InsertedSmartCardAuthApi,
   InsertedSmartCardAuthConfig,
+  InsertedSmartCardAuthMachineState,
 } from './inserted_smart_card_auth';
-import {
-  CARD_POLLING_INTERVAL_MS,
-  parseUserFromCardSummary,
-} from './memory_card';
+import { parseUserFromCardSummary } from './memory_card';
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 global.fetch = fetch;
 
 type AuthAction =
-  | { type: 'read_card'; cardSummary: CardSummary }
+  | { type: 'check_card_reader'; cardSummary: CardSummary }
   | { type: 'check_pin'; pin: string };
 
 /**
@@ -49,70 +45,56 @@ export class InsertedSmartCardAuthWithMemoryCard
 {
   private authStatus: InsertedSmartCardAuth.AuthStatus;
   private readonly card: Card;
-  private config: InsertedSmartCardAuthConfig;
+  private readonly config: InsertedSmartCardAuthConfig;
 
   constructor({
     card,
     config,
   }: {
     card: Card;
-    config: Omit<
-      InsertedSmartCardAuthConfig,
-      'electionDefinition' | 'precinctSelection'
-    >;
+    config: InsertedSmartCardAuthConfig;
   }) {
     this.authStatus = InsertedSmartCardAuth.DEFAULT_AUTH_STATUS;
     this.card = card;
     this.config = config;
-
-    setInterval(
-      async () => {
-        try {
-          const newCardSummary = await this.card.readSummary();
-          this.updateAuthStatus({
-            type: 'read_card',
-            cardSummary: newCardSummary,
-          });
-        } catch {
-          // Swallow errors so that they don't crash the auth instance and containing backend
-        }
-      },
-      CARD_POLLING_INTERVAL_MS,
-      true
-    );
   }
 
-  getAuthStatus(): InsertedSmartCardAuth.AuthStatus {
+  async getAuthStatus(
+    machineState: InsertedSmartCardAuthMachineState
+  ): Promise<InsertedSmartCardAuth.AuthStatus> {
+    await this.checkCardReaderAndUpdateAuthStatus(machineState);
     return this.authStatus;
   }
 
-  checkPin({ pin }: { pin: string }): void {
-    this.updateAuthStatus({ type: 'check_pin', pin });
+  async checkPin(
+    machineState: InsertedSmartCardAuthMachineState,
+    input: { pin: string }
+  ): Promise<void> {
+    await this.checkCardReaderAndUpdateAuthStatus(machineState);
+    this.updateAuthStatus(machineState, { type: 'check_pin', pin: input.pin });
   }
 
-  readCardData<T>({
-    schema,
-  }: {
-    schema: z.ZodSchema<T>;
-  }): Promise<Result<Optional<T>, SyntaxError | z.ZodError | Error>> {
-    return this.card.readLongObject(schema);
+  readCardData<T>(
+    machineState: InsertedSmartCardAuthMachineState,
+    input: { schema: z.ZodSchema<T> }
+  ): Promise<Result<Optional<T>, SyntaxError | z.ZodError | Error>> {
+    return this.card.readLongObject(input.schema);
   }
 
-  async writeCardData<T>({
-    data,
-    schema,
-  }: {
-    data: T;
-    schema: z.ZodSchema<T>;
-  }): Promise<Result<void, Error>> {
+  async writeCardData<T>(
+    machineState: InsertedSmartCardAuthMachineState,
+    input: { data: T; schema: z.ZodSchema<T> }
+  ): Promise<Result<void, Error>> {
     try {
-      await this.card.writeLongObject(data);
+      await this.card.writeLongObject(input.data);
     } catch (error) {
       return wrapException(error);
     }
 
     // Verify that the write was in fact successful by reading the data
-    const readResult = await this.readCardData({ schema });
+    const readResult = await this.readCardData(machineState, {
+      schema: input.schema,
+    });
     if (readResult.isErr()) {
       return err(new Error('Verification of write by reading data failed'));
     }
@@ -129,33 +111,31 @@ export class InsertedSmartCardAuthWithMemoryCard
     return ok();
   }
 
-  setElectionDefinition(electionDefinition: ElectionDefinition): void {
-    this.config.electionDefinition = electionDefinition;
+  private async checkCardReaderAndUpdateAuthStatus(
+    machineState: InsertedSmartCardAuthMachineState
+  ) {
+    const cardSummary = await this.card.readSummary();
+    this.updateAuthStatus(machineState, {
+      type: 'check_card_reader',
+      cardSummary,
+    });
   }
 
-  clearElectionDefinition(): void {
-    delete this.config.electionDefinition;
-  }
-
-  setPrecinctSelection(precinctSelection: PrecinctSelection): void {
-    this.config.precinctSelection = precinctSelection;
-  }
-
-  clearPrecinctSelection(): void {
-    delete this.config.precinctSelection;
-  }
-
-  private updateAuthStatus(action: AuthAction): void {
-    this.authStatus = this.determineNewAuthStatus(action);
+  private updateAuthStatus(
+    machineState: InsertedSmartCardAuthMachineState,
+    action: AuthAction
+  ): void {
+    this.authStatus = this.determineNewAuthStatus(machineState, action);
   }
 
   private determineNewAuthStatus(
+    machineState: InsertedSmartCardAuthMachineState,
     action: AuthAction
   ): InsertedSmartCardAuth.AuthStatus {
     const currentAuthStatus = this.authStatus;
 
     switch (action.type) {
-      case 'read_card': {
+      case 'check_card_reader': {
         const newAuthStatus = ((): InsertedSmartCardAuth.AuthStatus => {
           switch (action.cardSummary.status) {
             case 'no_card':
@@ -166,7 +146,10 @@ export class InsertedSmartCardAuthWithMemoryCard
 
             case 'ready': {
               const user = parseUserFromCardSummary(action.cardSummary);
-              const validationResult = this.validateCardUser(user);
+              const validationResult = this.validateCardUser(
+                machineState,
+                user
+              );
               if (validationResult.isOk()) {
                 assert(user);
                 if (currentAuthStatus.status === 'logged_out') {
@@ -217,6 +200,7 @@ export class InsertedSmartCardAuthWithMemoryCard
   }
 
   private validateCardUser(
+    machineState: InsertedSmartCardAuthMachineState,
     user?: User
   ): Result<void, InsertedSmartCardAuth.LoggedOut['reason']> {
     if (!user) {
@@ -228,11 +212,11 @@ export class InsertedSmartCardAuthWithMemoryCard
     }
 
     if (user.role === 'election_manager') {
-      if (!this.config.electionDefinition) {
+      if (!machineState.electionDefinition) {
         return ok();
       }
       if (
-        user.electionHash !== this.config.electionDefinition.electionHash &&
+        user.electionHash !== machineState.electionDefinition.electionHash &&
         !this.config
           .allowElectionManagersToAccessMachinesConfiguredForOtherElections
       ) {
@@ -241,10 +225,10 @@ export class InsertedSmartCardAuthWithMemoryCard
     }
 
     if (user.role === 'poll_worker') {
-      if (!this.config.electionDefinition) {
+      if (!machineState.electionDefinition) {
         return err('machine_not_configured');
       }
-      if (user.electionHash !== this.config.electionDefinition.electionHash) {
+      if (user.electionHash !== machineState.electionDefinition.electionHash) {
         return err('poll_worker_wrong_election');
       }
     }

--- a/libs/auth/src/inserted_smart_card_auth_with_memory_card.ts
+++ b/libs/auth/src/inserted_smart_card_auth_with_memory_card.ts
@@ -212,11 +212,11 @@ export class InsertedSmartCardAuthWithMemoryCard
     }
 
     if (user.role === 'election_manager') {
-      if (!machineState.electionDefinition) {
+      if (!machineState.electionHash) {
         return ok();
       }
       if (
-        user.electionHash !== machineState.electionDefinition.electionHash &&
+        user.electionHash !== machineState.electionHash &&
         !this.config
           .allowElectionManagersToAccessMachinesConfiguredForOtherElections
       ) {
@@ -225,10 +225,10 @@ export class InsertedSmartCardAuthWithMemoryCard
     }
 
     if (user.role === 'poll_worker') {
-      if (!machineState.electionDefinition) {
+      if (!machineState.electionHash) {
         return err('machine_not_configured');
       }
-      if (user.electionHash !== machineState.electionDefinition.electionHash) {
+      if (user.electionHash !== machineState.electionHash) {
         return err('poll_worker_wrong_election');
       }
     }

--- a/libs/auth/src/test_utils.ts
+++ b/libs/auth/src/test_utils.ts
@@ -11,8 +11,6 @@ export function buildMockDippedSmartCardAuth(): DippedSmartCardAuthApi {
     logOut: jest.fn(),
     programCard: jest.fn(),
     unprogramCard: jest.fn(),
-    setElectionDefinition: jest.fn(),
-    clearElectionDefinition: jest.fn(),
   };
 }
 
@@ -26,9 +24,5 @@ export function buildMockInsertedSmartCardAuth(): InsertedSmartCardAuthApi {
     readCardData: jest.fn(),
     writeCardData: jest.fn(),
     clearCardData: jest.fn(),
-    setElectionDefinition: jest.fn(),
-    clearElectionDefinition: jest.fn(),
-    setPrecinctSelection: jest.fn(),
-    clearPrecinctSelection: jest.fn(),
   };
 }

--- a/vxsuite.code-workspace
+++ b/vxsuite.code-workspace
@@ -1,26 +1,6 @@
 {
   "folders": [
     {
-      "name": "apps/mark/backend",
-      "path": "apps/mark/backend"
-    },
-    {
-      "name": "apps/mark/frontend",
-      "path": "apps/mark/frontend"
-    },
-    {
-      "name": "apps/mark/integration-testing",
-      "path": "apps/mark/integration-testing"
-    },
-    {
-      "name": "apps/scan/backend",
-      "path": "apps/scan/backend"
-    },
-    {
-      "name": "apps/scan/frontend",
-      "path": "apps/scan/frontend"
-    },
-    {
       "name": "apps/admin/backend",
       "path": "apps/admin/backend"
     },
@@ -43,6 +23,26 @@
     {
       "name": "apps/central-scan/integration-testing",
       "path": "apps/central-scan/integration-testing"
+    },
+    {
+      "name": "apps/mark/backend",
+      "path": "apps/mark/backend"
+    },
+    {
+      "name": "apps/mark/frontend",
+      "path": "apps/mark/frontend"
+    },
+    {
+      "name": "apps/mark/integration-testing",
+      "path": "apps/mark/integration-testing"
+    },
+    {
+      "name": "apps/scan/backend",
+      "path": "apps/scan/backend"
+    },
+    {
+      "name": "apps/scan/frontend",
+      "path": "apps/scan/frontend"
     },
     {
       "name": "libs/api",


### PR DESCRIPTION
_Reviewing by commit recommended_

## Overview

This PR adjusts how the auth lib accesses the election definition. I've thus far been having backends configure the auth lib with the election definition on startup and subsequent election definition changes, meaning that the auth lib is essentially caching the election definition. This is error prone since we have to remember to update the auth lib's copy of the election definition any time it changes in the containing backend.

This PR looks at an alternative: having the backend provide the election definition on every auth lib call. Even though the frontend polls auth status, we're not worried about this from a performance perspective since 1) SQLite can comfortably handle this read pattern and 2) we're in a fully local context.

## Testing

- [x] Updated/added automated tests
- [x] Tested VxAdmin auth manually
- [x] Tested VxCentralScan auth manually
- [x] Tested VxScan auth manually

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A
- [x] I have added JSDoc comments to any newly introduced exports