### PR TITLE
feat(message-coder): create default values from coders

### DIFF
--- a/libs/message-coder/src/base_coder.test.ts
+++ b/libs/message-coder/src/base_coder.test.ts
@@ -6,6 +6,10 @@ import { bufferContainsBitOffset, toByteOffset } from './bits';
 import { DecodeResult, EncodeResult, Uint8 } from './types';
 
 class TestCoder extends BaseCoder<number> {
+  default(): number {
+    return 0;
+  }
+
   bitLength(): number {
     return 8;
   }

--- a/libs/message-coder/src/base_coder.ts
+++ b/libs/message-coder/src/base_coder.ts
@@ -14,6 +14,7 @@ import {
  * Base class for coders with default implementations for encoding and decoding.
  */
 export abstract class BaseCoder<T> implements Coder<T> {
+  abstract default(): T;
   abstract bitLength(value: T): number;
   abstract encodeInto(
     value: T,

--- a/libs/message-coder/src/fixed_string.test.ts
+++ b/libs/message-coder/src/fixed_string.test.ts
@@ -10,6 +10,7 @@ test('fixed string', () => {
   const coder = fixedString(5);
   type coder = CoderType<typeof coder>;
 
+  expect(coder.default()).toEqual('');
   expect(coder.bitLength('hello')).toEqual(40);
   expect(coder.encode('hello')).toEqual(ok(Buffer.from('hello')));
   expect(coder.decode(Buffer.from('hello'))).toEqual(ok('hello'));
@@ -27,6 +28,8 @@ test('fixed string with trailing nulls', () => {
   const coder = fixedString(5, true);
   type coder = CoderType<typeof coder>;
   const buffer = Buffer.alloc(5);
+
+  expect(coder.default()).toEqual('\0\0\0\0\0');
   expect(coder.encodeInto('abc', buffer, 0)).toEqual(ok(40));
   expect(coder.decodeFrom(buffer, 0)).toEqual(
     typedAs<DecodeResult<coder>>(ok({ value: 'abc\0\0', bitOffset: 40 }))

--- a/libs/message-coder/src/fixed_string.ts
+++ b/libs/message-coder/src/fixed_string.ts
@@ -26,6 +26,14 @@ export class FixedStringCoder implements Coder<string> {
     private readonly includeTrailingNulls = false
   ) {}
 
+  default(): string {
+    if (!this.includeTrailingNulls) {
+      return '';
+    }
+
+    return Buffer.alloc(this.byteLength).toString('utf8');
+  }
+
   bitLength(): BitLength {
     return toBitLength(this.byteLength);
   }

--- a/libs/message-coder/src/literal_coder.test.ts
+++ b/libs/message-coder/src/literal_coder.test.ts
@@ -27,6 +27,7 @@ test('literal', () => {
         const lit = literal(...parts);
         type lit = CoderType<typeof lit>;
 
+        expect(lit.default()).toEqual(undefined);
         expect(lit.encodeInto(undefined, buffer, bitOffset)).toEqual(
           ok(bitOffset + bytes.length * 8)
         );

--- a/libs/message-coder/src/literal_coder.ts
+++ b/libs/message-coder/src/literal_coder.ts
@@ -23,6 +23,10 @@ export class LiteralCoder extends BaseCoder<void> {
     );
   }
 
+  default(): void {
+    return undefined;
+  }
+
   bitLength(): number {
     return toBitLength(this.value.byteLength);
   }

--- a/libs/message-coder/src/message_coder.test.ts
+++ b/libs/message-coder/src/message_coder.test.ts
@@ -10,6 +10,7 @@ test('empty message', () => {
   const m = message({});
   type m = CoderType<typeof m>;
 
+  expect(m.default()).toEqual({});
   expect(m.bitLength({})).toEqual(0);
   expect(m.encode({})).toEqual(ok(Buffer.alloc(0)));
   expect(m.decode(Buffer.alloc(0))).toEqual(typedAs<m>(ok({})));
@@ -25,6 +26,7 @@ test('message with single literal', () => {
   const m = message({ header: literal('PDF') });
   type m = CoderType<typeof m>;
 
+  expect(m.default()).toEqual({});
   expect(m.bitLength({})).toEqual(24);
   expect(m.encode({ header: 'PDF' })).toEqual(ok(Buffer.from('PDF')));
   expect(m.decode(Buffer.from('PDF'))).toEqual(ok(typedAs<m>({})));
@@ -33,6 +35,7 @@ test('message with single literal', () => {
 
 test('message with single uint8', () => {
   const m = message({ version: uint8() });
+  expect(m.default()).toEqual({ version: 0 });
   expect(m.bitLength({ version: 1 })).toEqual(8);
   expect(m.encode({ version: 1 })).toEqual(ok(Buffer.from([1])));
   expect(m.decode(Buffer.from([1]))).toEqual(ok({ version: 1 }));
@@ -44,6 +47,7 @@ test('message with multiple fields', () => {
     version: uint8(),
     flags: uint8(),
   });
+  expect(m.default()).toEqual({ version: 0, flags: 0 });
   expect(m.bitLength({ version: 1, flags: 2 })).toEqual(40);
   expect(m.encode({ version: 1, flags: 2 })).toEqual(
     // 0x01 = version, 0x02 = flags
@@ -97,4 +101,13 @@ test('id3v1 tag', () => {
   const encodeResult = id3v1.encode(tag);
   const decodeResult = id3v1.decode(encodeResult.assertOk('encode failed'));
   expect(decodeResult).toEqual(ok(tag));
+  expect(id3v1.default()).toEqual({
+    title: '',
+    artist: '',
+    album: '',
+    year: '',
+    comment: '',
+    track: 0,
+    genre: 0,
+  });
 });

--- a/libs/message-coder/src/message_coder.ts
+++ b/libs/message-coder/src/message_coder.ts
@@ -73,6 +73,20 @@ class MessageCoder<P extends MessageCoderParts<object>>
     super();
   }
 
+  default(): ObjectFromParts<P> {
+    const result: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(this.parts)) {
+      const coder = v as Coder<ObjectFromParts<P>[keyof ObjectFromParts<P>]>;
+      if (
+        !(coder instanceof LiteralCoder) &&
+        !(coder instanceof PaddingCoder)
+      ) {
+        result[k] = coder.default();
+      }
+    }
+    return result as ObjectFromParts<P>;
+  }
+
   bitLength(value: ObjectFromParts<P>): number {
     let length = 0;
     for (const [k, v] of Object.entries(this.parts)) {

--- a/libs/message-coder/src/padding_coder.test.ts
+++ b/libs/message-coder/src/padding_coder.test.ts
@@ -12,6 +12,7 @@ test('padding', () => {
     b: uint8(),
   });
 
+  expect(m.default()).toEqual({ a: 0, b: 0 });
   expect(m.bitLength({ a: 1, b: 2 })).toEqual(16);
   expect(m.encode({ a: 1, b: 2 })).toEqual(ok(Buffer.from([0b00010000, 0x02])));
   expect(m.decode(Buffer.from([0b00010000, 0x02]))).toEqual(ok({ a: 1, b: 2 }));
@@ -25,6 +26,11 @@ test('padding with too small buffer', () => {
     padding: padding(16),
   });
 
+  expect(m.default()).toEqual({});
   expect(m.encodeInto({}, Buffer.alloc(1), 0)).toEqual(err('SmallBuffer'));
   expect(m.decodeFrom(Buffer.alloc(1), 0)).toEqual(err('SmallBuffer'));
+});
+
+test('padding has no default', () => {
+  expect(padding(1).default()).toBeUndefined();
 });

--- a/libs/message-coder/src/padding_coder.ts
+++ b/libs/message-coder/src/padding_coder.ts
@@ -12,6 +12,10 @@ export class PaddingCoder extends BaseCoder<void> {
     super();
   }
 
+  default(): void {
+    return undefined;
+  }
+
   bitLength(): number {
     return this.paddingBitsLength;
   }

--- a/libs/message-coder/src/types.ts
+++ b/libs/message-coder/src/types.ts
@@ -65,6 +65,13 @@ export type Uint32 = number;
  */
 export interface Coder<T> {
   /**
+   * The default value for this coder, typically the value that is encoded as a
+   * sequence of zero bits. Useful for building "blank" versions of a type for
+   * test values or similar.
+   */
+  default(): T;
+
+  /**
    * Encode a value as a buffer.
    */
   encode(value: T): Result<Buffer, CoderError>;

--- a/libs/message-coder/src/uint16_coder.ts
+++ b/libs/message-coder/src/uint16_coder.ts
@@ -49,5 +49,5 @@ export class Uint16Coder extends UintCoder {
 export function uint16<T extends number = Uint16>(
   enumeration?: unknown
 ): Coder<T> {
-  return new Uint16Coder(enumeration) as Coder<T>;
+  return new Uint16Coder(enumeration) as unknown as Coder<T>;
 }

--- a/libs/message-coder/src/uint1_coder.test.ts
+++ b/libs/message-coder/src/uint1_coder.test.ts
@@ -10,6 +10,7 @@ test('uint1 offset=0', () => {
   type coder = CoderType<typeof coder>;
   const buffer = Buffer.alloc(1);
   const bitOffset = 0;
+  expect(coder.default()).toEqual(false);
   expect(coder.encodeInto(true, buffer, bitOffset)).toEqual(ok(bitOffset + 1));
   expect(buffer.readUInt8(0)).toEqual(0b10000000);
   expect(coder.decodeFrom(buffer, bitOffset)).toEqual(
@@ -27,6 +28,7 @@ test('uint1 true offset=3', () => {
   type coder = CoderType<typeof coder>;
   const buffer = Buffer.alloc(1);
   const bitOffset = 3;
+  expect(coder.default()).toEqual(false);
   expect(coder.encodeInto(true, buffer, bitOffset)).toEqual(ok(bitOffset + 1));
   expect(buffer.readUInt8(0)).toEqual(0b00010000);
   expect(coder.decodeFrom(buffer, bitOffset)).toEqual(
@@ -45,16 +47,16 @@ test('uint1', () => {
           'bitOffset should be aligned after subtracting remainder'
         );
         const buffer = Buffer.alloc(1 + byteOffset);
-        const field = uint1();
-        type field = CoderType<typeof field>;
+        const coder = uint1();
 
-        expect(field.encodeInto(value, buffer, bitOffset)).toEqual(
+        expect(coder.default()).toEqual(false);
+        expect(coder.encodeInto(value, buffer, bitOffset)).toEqual(
           ok(bitOffset + 1)
         );
         expect(
           (buffer.readUInt8(byteOffset) & (0b10000000 >> remainder)) !== 0
         ).toEqual(value);
-        expect(field.decodeFrom(buffer, bitOffset)).toEqual(
+        expect(coder.decodeFrom(buffer, bitOffset)).toEqual(
           ok({ value, bitOffset: bitOffset + 1 })
         );
       }

--- a/libs/message-coder/src/uint1_coder.ts
+++ b/libs/message-coder/src/uint1_coder.ts
@@ -14,6 +14,10 @@ import {
  * Coder for a uint1, aka a boolean.
  */
 export class Uint1Coder extends BaseCoder<boolean> {
+  default(): boolean {
+    return false;
+  }
+
   bitLength(): BitLength {
     return 1;
   }

--- a/libs/message-coder/src/uint24_coder.ts
+++ b/libs/message-coder/src/uint24_coder.ts
@@ -51,5 +51,5 @@ export class Uint24Coder extends UintCoder {
 export function uint24<T extends number = Uint24>(
   enumeration?: unknown
 ): Coder<T> {
-  return new Uint24Coder(enumeration) as Coder<T>;
+  return new Uint24Coder(enumeration) as unknown as Coder<T>;
 }

--- a/libs/message-coder/src/uint2_coder.ts
+++ b/libs/message-coder/src/uint2_coder.ts
@@ -11,7 +11,7 @@ import {
   mapResult,
   Uint2,
 } from './types';
-import { validateEnumValue } from './uint_coder';
+import { defaultEnumValue, validateEnumValue } from './uint_coder';
 
 /**
  * Coder for a uint2, aka a 2-bit unsigned integer.
@@ -19,6 +19,10 @@ import { validateEnumValue } from './uint_coder';
 class Uint2Coder extends BaseCoder<Uint2> {
   constructor(private readonly enumeration?: unknown) {
     super();
+  }
+
+  default(): Uint2 {
+    return defaultEnumValue(this.enumeration);
   }
 
   bitLength(): BitLength {
@@ -87,5 +91,5 @@ class Uint2Coder extends BaseCoder<Uint2> {
  */
 // eslint-disable-next-line vx/gts-no-return-type-only-generics -- TS does not have a way of saying "I want an enum of numbers"
 export function uint2<T extends Uint2>(enumeration?: unknown): Coder<T> {
-  return new Uint2Coder(enumeration) as Coder<T>;
+  return new Uint2Coder(enumeration) as unknown as Coder<T>;
 }

--- a/libs/message-coder/src/uint32_coder.ts
+++ b/libs/message-coder/src/uint32_coder.ts
@@ -49,5 +49,5 @@ export class Uint32Coder extends UintCoder {
 export function uint32<T extends number = Uint32>(
   enumeration?: unknown
 ): Coder<T> {
-  return new Uint32Coder(enumeration) as Coder<T>;
+  return new Uint32Coder(enumeration) as unknown as Coder<T>;
 }

--- a/libs/message-coder/src/uint4_coder.ts
+++ b/libs/message-coder/src/uint4_coder.ts
@@ -11,7 +11,7 @@ import {
   mapResult,
   Uint4,
 } from './types';
-import { validateEnumValue } from './uint_coder';
+import { defaultEnumValue, validateEnumValue } from './uint_coder';
 
 /**
  * Coder for a uint4, aka a 4-bit unsigned integer.
@@ -19,6 +19,10 @@ import { validateEnumValue } from './uint_coder';
 export class Uint4Coder extends BaseCoder<Uint4> {
   constructor(private readonly enumeration?: unknown) {
     super();
+  }
+
+  default(): Uint4 {
+    return defaultEnumValue(this.enumeration);
   }
 
   bitLength(): BitLength {
@@ -90,5 +94,5 @@ export class Uint4Coder extends BaseCoder<Uint4> {
 export function uint4<T extends number = Uint4>(
   enumeration?: unknown
 ): Coder<T> {
-  return new Uint4Coder(enumeration) as Coder<T>;
+  return new Uint4Coder(enumeration) as unknown as Coder<T>;
 }

--- a/libs/message-coder/src/uint8_coder.ts
+++ b/libs/message-coder/src/uint8_coder.ts
@@ -44,5 +44,5 @@ export class Uint8Coder extends UintCoder {
 export function uint8<T extends number = Uint8>(
   enumeration?: unknown
 ): Coder<T> {
-  return new Uint8Coder(enumeration) as Coder<T>;
+  return new Uint8Coder(enumeration) as unknown as Coder<T>;
 }

--- a/libs/message-coder/src/uint_coder.ts
+++ b/libs/message-coder/src/uint_coder.ts
@@ -31,11 +31,35 @@ export function validateEnumValue(
 }
 
 /**
+ * Gets the default–i.e. first–enum value.
+ */
+export function defaultEnumValue(enumeration: unknown): number {
+  if (typeof enumeration === 'object') {
+    const e = enumeration as Record<string, number | string>;
+
+    for (const value of Object.values(e)) {
+      if (typeof value === 'number') {
+        return value;
+      }
+    }
+
+    /* istanbul ignore next */
+    throw new Error('no enum values');
+  }
+
+  return 0;
+}
+
+/**
  * Base coder for byte-aligned uints.
  */
 export abstract class UintCoder extends BaseCoder<number> {
   constructor(private readonly enumeration?: unknown) {
     super();
+  }
+
+  default(): number {
+    return defaultEnumValue(this.enumeration);
   }
 
   abstract bitLength(): BitLength;

--- a/libs/message-coder/src/unbounded_string_coder.test.ts
+++ b/libs/message-coder/src/unbounded_string_coder.test.ts
@@ -6,6 +6,7 @@ import { unboundedString } from './unbounded_string_coder';
 
 test('unbounded string', () => {
   const coder = unboundedString();
+  expect(coder.default()).toEqual('');
   expect(coder.bitLength('hello')).toEqual(5 * 8);
   expect(coder.encode('hello')).toEqual(ok(Buffer.from('hello')));
   expect(coder.decode(Buffer.from('hello'))).toEqual(ok('hello'));
@@ -13,6 +14,7 @@ test('unbounded string', () => {
 
 test('unbounded string inside a message', () => {
   const m = message({ header: literal('CDAT'), data: unboundedString() });
+  expect(m.default()).toEqual({ data: '' });
   expect(m.bitLength({ data: 'hello' })).toEqual(32 + 5 * 8);
   expect(m.encode({ data: 'hello' })).toEqual(ok(Buffer.from('CDAThello')));
   expect(m.decode(Buffer.from('CDAThello'))).toEqual(ok({ data: 'hello' }));

--- a/libs/message-coder/src/unbounded_string_coder.ts
+++ b/libs/message-coder/src/unbounded_string_coder.ts
@@ -21,6 +21,10 @@ import {
  * required to be the last field in a message.
  */
 export class UnboundedStringCoder implements Coder<string> {
+  default(): string {
+    return '';
+  }
+
   bitLength(string: string): BitLength {
     return toBitLength(Buffer.from(string).byteLength);
   }


### PR DESCRIPTION
## Overview
<!-- add a link to a GitHub Issue here -->
Useful for building values for coders in tests.

## Demo Video or Screenshot
n/a

## Testing Plan 
Automated.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
