### PR TITLE
feat(types): add side parameter to `mapSheet`

### DIFF
--- a/libs/types/src/hmpb.test.ts
+++ b/libs/types/src/hmpb.test.ts
@@ -2,6 +2,11 @@ import { mapSheet } from './hmpb';
 
 test('mapSheet sync', () => {
   expect(mapSheet([1, 2], (x) => x + 1)).toEqual([2, 3]);
+
+  const fn = jest.fn();
+  mapSheet([1, 2], fn);
+  expect(fn).toHaveBeenNthCalledWith(1, 1, 'front');
+  expect(fn).toHaveBeenNthCalledWith(2, 2, 'back');
 });
 
 test('mapSheet async', async () => {

--- a/libs/types/src/hmpb.ts
+++ b/libs/types/src/hmpb.ts
@@ -5,6 +5,7 @@ import {
   ContestOptionSchema,
   HmpbBallotPageMetadata,
   HmpbBallotPageMetadataSchema,
+  Side,
   TargetShape,
   TargetShapeSchema,
 } from './election';
@@ -93,18 +94,18 @@ export type SheetOf<T> = readonly [T, T];
  */
 export function mapSheet<T, U>(
   sheet: SheetOf<T>,
-  fn: (page: T) => Promise<U>
+  fn: (page: T, side: Side) => Promise<U>
 ): Promise<SheetOf<U>>;
 export function mapSheet<T, U>(
   sheet: SheetOf<T>,
-  fn: (page: T) => U
+  fn: (page: T, side: Side) => U
 ): SheetOf<U>;
 export function mapSheet<T, U>(
   sheet: SheetOf<T>,
-  fn: (page: T) => U
+  fn: (page: T, side: Side) => U
 ): SheetOf<U> | Promise<SheetOf<U>> {
-  const front = fn(sheet[0]);
-  const back = fn(sheet[1]);
+  const front = fn(sheet[0], 'front');
+  const back = fn(sheet[1], 'back');
 
   if (
     front &&


### PR DESCRIPTION
## Overview
<!-- add a link to a GitHub Issue here -->
It's similar to the index parameter on the `map` callback and is similarly useful in some cases.

## Demo Video or Screenshot
n/a

## Testing Plan
n/a

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
