### PR TITLE
docs(github): reformat templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,21 +4,25 @@ about: Create a report to help us improve
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 ## Description
+
 A clear and concise description of what the bug is.
 
 ## Repro
+
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
 ## Expected behavior
+
 A clear and concise description of what you expected to happen.
 
 ## Screenshots
+
 If applicable, add screenshots to help explain your problem.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -4,7 +4,6 @@ about: for new functionality
 title: ''
 labels:
 assignees: ''
-
 ---
 
 ## Summary

--- a/.github/ISSUE_TEMPLATE/hardware.md
+++ b/.github/ISSUE_TEMPLATE/hardware.md
@@ -4,5 +4,4 @@ about: for hardware tickets
 title: ''
 labels: hardware
 assignees: ''
-
 ---

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,19 @@
 ## Overview
+
 <!-- add a link to a GitHub Issue here -->
 
 ## Demo Video or Screenshot
 
-## Testing Plan 
+## Testing Plan
 
 ## Checklist
-- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
+
+- [ ] I have added
+      [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging)
+      where appropriate to any new user actions, system updates such as file
+      reads or storage writes, or errors introduced.
 - [ ] I have added JSDoc comments to any newly introduced exports
 <!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
 - [ ] I have added a screenshot and/or video to this PR to demo the change
-- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
+- [ ] I have added the "user_facing_change" label to this PR to automate an
+      announcement in #machine-product-updates


### PR DESCRIPTION

## Overview
<!-- add a link to a GitHub Issue here -->
`npx prettier --write .`

## Demo Video or Screenshot
n/a

## Testing Plan
n/a

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
