### PR TITLE
Modify react-query query client default options

### DIFF
--- a/libs/ui/src/react_query.test.ts
+++ b/libs/ui/src/react_query.test.ts
@@ -1,6 +1,6 @@
 import { assert } from '@votingworks/basics';
 
-import { QUERY_CLIENT_DEFAULT_OPTIONS } from './react_query';
+import { QUERY_CLIENT_DEFAULT_OPTIONS, shouldRetry } from './react_query';
 
 test('Relevant settings are consistent for queries and mutations', () => {
   const querySettings = QUERY_CLIENT_DEFAULT_OPTIONS.queries;
@@ -15,5 +15,23 @@ test('Relevant settings are consistent for queries and mutations', () => {
   expect(querySettings.retry).toEqual(mutationSettings.retry);
   expect(querySettings.useErrorBoundary).toEqual(
     mutationSettings.useErrorBoundary
+  );
+});
+
+test('Custom retry function', () => {
+  expect(
+    shouldRetry(0, new Error('Something something 504 something something'))
+  ).toEqual(true);
+  expect(
+    shouldRetry(3, new Error('Something something 504 something something'))
+  ).toEqual(true);
+  expect(
+    shouldRetry(4, new Error('Something something 504 something something'))
+  ).toEqual(false);
+  expect(
+    shouldRetry(0, new Error('Something something 500 something something'))
+  ).toEqual(false);
+  expect(shouldRetry(0, 'Something something 504 something something')).toEqual(
+    false
   );
 });

--- a/libs/ui/src/react_query.ts
+++ b/libs/ui/src/react_query.ts
@@ -13,6 +13,9 @@ import type { DefaultOptions } from '@tanstack/react-query';
  * = 15 seconds of total wait time
  *
  * Otherwise, don't retry. Because everything is local, we don't expect intermittent errors.
+ *
+ * TODO: Remove this custom retry logic if/when we update our infrastructure to only start the
+ * frontend once the backend is running.
  */
 export function shouldRetry(failedRetryCount: number, error: unknown): boolean {
   const isBackendLikelyStartingUp =


### PR DESCRIPTION
## Overview

With the shift to react-query and our specific default options (notably `retry: false` and `useErrorBoundary: true`), we often see the frontend error boundary get triggered when the backend is spinning up or restarting due to changes. We've seen this in dev, but I suspect it could affect prod, too.

<table><tr><td>
<img src="https://user-images.githubusercontent.com/12616928/220428072-5306d5c2-e51a-4b6f-a621-b461fb99916d.png" />
</table></tr></td>

This PR modifies our react-query query client default options with a custom retry function in place of `retry: false` to prevent this.

## Testing

- [x] Added unit tests for custom retry function
- [x] Tested initial backend startup, backend restart, and true backend failure manually

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A
- [x] I have added JSDoc comments to any newly introduced exports