### PR TITLE
fix(grout): Fix latent bug in serializing undefined

### DIFF
--- a/libs/grout/src/serialization.ts
+++ b/libs/grout/src/serialization.ts
@@ -20,7 +20,6 @@ type JsonBuiltInValue =
 function isJsonBuiltInValueShallow(value: unknown): value is JsonBuiltInValue {
   return (
     value === null ||
-    value === undefined ||
     isBoolean(value) ||
     isNumber(value) ||
     isString(value) ||


### PR DESCRIPTION


## Overview
The helper function to determine if a value is a JSON built-in value was mistakenly identifying `undefined` as a built-in, which it's not (it only exists in JS value space, not JSON). This didn't actually impact the end logic that used this function, but that was just by chance. Fixing this to prevent any future bugs that might occur from this being wrong.

## Demo Video or Screenshot
N/A

## Testing Plan
Existing tests still pass

## Checklist

- [ ] I have added
      [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging)
      where appropriate to any new user actions, system updates such as file
      reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an
      announcement in #machine-product-updates
