### PR TITLE
fix formatting and BMD path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The VotingWorks in-person voting system.
 
 ## About
 
-Includes software for a [ballot-marking device (BMD)](./frontends/bmd), a
+Includes software for a [ballot-marking device (BMD)](./apps/mark/frontend), a
 [ballot activation system (BAS)](./frontends/bas), a
 [ballot scanning device (BSD)](./frontends/bsd), a
 [precinct scanner](./frontends/precinct-scanner), and an
@@ -79,8 +79,6 @@ If you are not using our automated build process, you can clone manually.
 mkdir code
 cd code
 git clone git@github.com:votingworks/vxsuite.git
-```
-
 # If you are doing a lot of development in vxsuite you will likely eventually need the following repos.
 # kiosk-browser is an electron-based browser where our apps run in production.
 git clone git@github.com:votingworks/kiosk-browser.git
@@ -110,7 +108,7 @@ Test that you can run the code
 
 ```sh
 # try out BMD:
-cd frontends/bmd
+cd apps/mark/frontend
 pnpm start
 # if it worked, go to http://localhost:3000/ in your VM
 ```

--- a/README.md
+++ b/README.md
@@ -5,10 +5,9 @@ The VotingWorks in-person voting system.
 ## About
 
 Includes software for a [ballot-marking device (BMD)](./apps/mark/frontend), a
-[ballot activation system (BAS)](./frontends/bas), a
-[ballot scanning device (BSD)](./frontends/bsd), a
-[precinct scanner](./frontends/precinct-scanner), and an
-[election manager](./frontends/election-manager). See https://voting.works for
+[ballot scanning device (BSD)](./apps/central-scan/frontend), a
+[precinct scanner](./apps/scan/frontend), and an
+[election manager](./apps/admin/frontend). See https://voting.works for
 more information about VotingWorks.
 
 ## Development


### PR DESCRIPTION
## Overview

Fixes formatting and path for BMD app in the README. Other paths at the top of the README are also outdated but I don't know the new paths; feel free to comment and I'll update

## Demo Video or Screenshot
Before
![Screenshot 2023-02-21 at 4 02 53 PM](https://user-images.githubusercontent.com/1060688/220486421-1355779c-75aa-4acd-ae39-faa9e792fe8c.png)



After
![Screenshot 2023-02-21 at 4 02 36 PM](https://user-images.githubusercontent.com/1060688/220486441-44c528e6-f2cf-4620-8da5-d1919e44105e.png)


## Testing Plan
N/A README change only

## Checklist
Not applicable:
- [x] I have added
      [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging)
      where appropriate to any new user actions, system updates such as file
      reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
