### PR TITLE
chore(scan): remove `PLUSTEKCTL_PATH`

### DIFF
--- a/apps/scan/backend/src/env.d.ts
+++ b/apps/scan/backend/src/env.d.ts
@@ -2,7 +2,6 @@ declare namespace NodeJS {
   export interface ProcessEnv {
     readonly CI?: string;
     readonly NODE_ENV: 'development' | 'production' | 'test';
-    readonly PLUSTEKCTL_PATH?: string;
     readonly PORT?: string;
     readonly SCAN_ALLOWED_EXPORT_PATTERNS?: string;
     readonly SCAN_WORKSPACE?: string;

--- a/apps/scan/backend/src/globals.ts
+++ b/apps/scan/backend/src/globals.ts
@@ -43,8 +43,3 @@ export const SCAN_ALLOWED_EXPORT_PATTERNS =
   defaultAllowedExportPatterns;
 
 export const CVR_EXPORT_FORMAT = process.env.CVR_EXPORT_FORMAT ?? 'vxf';
-
-/**
- * Path to the `plustekctl` binary.
- */
-export const { PLUSTEKCTL_PATH } = process.env;

--- a/apps/scan/backend/src/state_machine.ts
+++ b/apps/scan/backend/src/state_machine.ts
@@ -31,7 +31,6 @@ import {
 } from 'xstate';
 import { waitFor } from 'xstate/lib/waitFor';
 import { LogEventId, Logger, LogLine } from '@votingworks/logging';
-import { PLUSTEKCTL_PATH } from './globals';
 import {
   SheetInterpretationWithPages,
   PrecinctScannerInterpreter,
@@ -114,13 +113,10 @@ function connectToPlustek(
 ) {
   return async (): Promise<ScannerClient> => {
     debug('Connecting to plustek');
-    const plustekClient = await createPlustekClient(
-      {
-        ...DEFAULT_CONFIG,
-        savepath: scannedImagesPath,
-      },
-      { plustekctlPath: PLUSTEKCTL_PATH }
-    );
+    const plustekClient = await createPlustekClient({
+      ...DEFAULT_CONFIG,
+      savepath: scannedImagesPath,
+    });
     debug('Plustek client connected: %s', plustekClient.isOk());
     return plustekClient.unsafeUnwrap();
   };


### PR DESCRIPTION

## Overview
We don't use the "fake plustekctl" approach for using the Custom scanner anymore.

<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot
n/a

## Testing Plan
Automated.

## Checklist

- [ ] I have added
      [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging)
      where appropriate to any new user actions, system updates such as file
      reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an
      announcement in #machine-product-updates
