### PR TITLE
refactor(scan): make `server.ts` scanner-agnostic

### DIFF
--- a/apps/scan/backend/jest.config.js
+++ b/apps/scan/backend/jest.config.js
@@ -10,19 +10,13 @@ module.exports = {
   // which we should probably make not be there by using smarter
   // tsconfig.json values.
   roots: ['<rootDir>/src'],
-  collectCoverageFrom: [
-    '**/*.{ts,tsx}',
-    '!**/node_modules/**',
-    '!src/index.ts',
-    '!src/types.ts',
-    '!test/**/*',
-  ],
+  collectCoverageFrom: ['**/*.{ts,tsx}', '!**/node_modules/**', '!test/**/*'],
   coverageThreshold: {
     global: {
       statements: 89,
       branches: 75,
       functions: 90,
-      lines: 90,
+      lines: 89,
     },
   },
 };

--- a/apps/scan/backend/src/server.test.ts
+++ b/apps/scan/backend/src/server.test.ts
@@ -1,0 +1,100 @@
+import { LogEventId, Logger, LogSource } from '@votingworks/logging';
+import { Application } from 'express';
+import { dirSync } from 'tmp';
+import { buildApp } from './app';
+import { PORT } from './globals';
+import { createInterpreter } from './interpret';
+import { start } from './server';
+import { PrecinctScannerStateMachine } from './state_machine';
+import { createWorkspace, Workspace } from './util/workspace';
+
+jest.mock('./app');
+jest.mock('@votingworks/logging');
+
+const buildAppMock = buildApp as jest.MockedFunction<typeof buildApp>;
+const LoggerMock = Logger as jest.MockedClass<typeof Logger>;
+
+let workspace!: Workspace;
+
+beforeEach(async () => {
+  workspace = await createWorkspace(dirSync().name);
+});
+
+afterEach(() => {
+  workspace.reset();
+});
+
+function createPrecinctScannerStateMachineMock(): jest.Mocked<PrecinctScannerStateMachine> {
+  return {
+    status: jest.fn(),
+    scan: jest.fn(),
+    accept: jest.fn(),
+    return: jest.fn(),
+    calibrate: jest.fn(),
+  };
+}
+
+test('start passes the state machine and workspace to `buildApp`', async () => {
+  const precinctScannerStateMachine = createPrecinctScannerStateMachineMock();
+  const precinctScannerInterpreter = createInterpreter();
+  const listen = jest.fn();
+  const logger = new LoggerMock(LogSource.VxScanBackend);
+  buildAppMock.mockReturnValueOnce({ listen } as unknown as Application);
+
+  start({
+    precinctScannerStateMachine,
+    precinctScannerInterpreter,
+    workspace,
+    logger,
+  });
+
+  expect(buildAppMock).toHaveBeenCalledWith(
+    expect.anything(), // auth
+    precinctScannerStateMachine,
+    expect.anything(), // precinctScannerInterpreter
+    workspace,
+    expect.anything(), // usb
+    logger
+  );
+  expect(listen).toHaveBeenNthCalledWith(1, PORT, expect.any(Function));
+
+  const callback = listen.mock.calls[0][1];
+  await callback();
+
+  expect(logger.log).toHaveBeenNthCalledWith(
+    1,
+    LogEventId.ApplicationStartup,
+    expect.anything(),
+    expect.anything()
+  );
+  expect(logger.log).toHaveBeenNthCalledWith(
+    2,
+    LogEventId.ScanServiceConfigurationMessage,
+    expect.anything(),
+    expect.anything()
+  );
+});
+
+test('start uses its own logger if none is provided', async () => {
+  const precinctScannerStateMachine = createPrecinctScannerStateMachineMock();
+  const precinctScannerInterpreter = createInterpreter();
+  const listen = jest.fn();
+  buildAppMock.mockReturnValueOnce({ listen } as unknown as Application);
+
+  start({ precinctScannerStateMachine, precinctScannerInterpreter, workspace });
+
+  expect(buildAppMock).toHaveBeenCalledWith(
+    expect.anything(), // auth
+    precinctScannerStateMachine,
+    expect.anything(), // precinctScannerInterpreter
+    workspace,
+    expect.anything(), // usb
+    expect.any(Logger)
+  );
+  expect(listen).toHaveBeenNthCalledWith(1, PORT, expect.any(Function));
+
+  const callback = listen.mock.calls[0][1];
+  await callback();
+
+  expect(LoggerMock).toHaveBeenCalledWith(LogSource.VxScanBackend);
+});


### PR DESCRIPTION

## Overview
Rather than taking a function to create the "scanner client", we now just accept a `PrecinctScannerStateMachine`. The work of creating the client, workspace, and state machine has moved to `index.ts`. Since these files were ignored for coverage purposes this felt like cheating, so I added basic tests for `server.ts` and made them both count toward coverage stats.

<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot
n/a

## Testing Plan
Did some manual testing, plus new automated tests.

## Checklist

- [ ] I have added
      [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging)
      where appropriate to any new user actions, system updates such as file
      reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an
      announcement in #machine-product-updates
