### PR TITLE
refactor(backend): use `jsonStream` to simplify CVR streams

### DIFF
--- a/libs/backend/src/scan/cast_vote_records/build_report_metadata.ts
+++ b/libs/backend/src/scan/cast_vote_records/build_report_metadata.ts
@@ -154,7 +154,10 @@ export function buildCastVoteRecordReportMetadata({
   reportTypes,
   isTestMode,
   batchInfo,
-}: BuildCastVoteRecordReportMetadataParams): CVR.CastVoteRecordReport {
+}: BuildCastVoteRecordReportMetadataParams): Omit<
+  CVR.CastVoteRecordReport,
+  'CVR'
+> {
   // TODO: pull from ballot definition once it exists. For now, the scope
   // is just the current state
   const electionScopeId = 'election-state';

--- a/libs/backend/src/scan/cast_vote_records/export.ts
+++ b/libs/backend/src/scan/cast_vote_records/export.ts
@@ -11,7 +11,7 @@ import {
   SheetOf,
   unsafeParse,
 } from '@votingworks/types';
-import { err, ok, Result } from '@votingworks/basics';
+import { err, ok, Result, typedAs } from '@votingworks/basics';
 import { Readable } from 'stream';
 import {
   generateCastVoteRecordReportDirectoryName,
@@ -31,6 +31,14 @@ import { getUsbDrives } from '../../get_usb_drives';
 import { SCAN_ALLOWED_EXPORT_PATTERNS, VX_MACHINE_ID } from '../globals';
 import { BallotPageLayoutsLookup, getBallotPageLayout } from './page_layouts';
 import { buildCastVoteRecordReportMetadata } from './build_report_metadata';
+
+type WithArraysAsIterables<T> = {
+  [P in keyof T]: T[P] extends ReadonlyArray<infer U>
+    ? Iterable<U>
+    : T[P] extends ReadonlyArray<infer U> | undefined
+    ? Optional<Iterable<U>>
+    : T[P];
+};
 
 /**
  * Properties of each sheet that are needed to generate a cast vote record
@@ -235,10 +243,12 @@ export function getCastVoteRecordReportStream({
   });
 
   return Readable.from(
-    jsonStream({
-      ...castVoteRecordReportMetadata,
-      CVR: castVoteRecordGenerator,
-    })
+    jsonStream(
+      typedAs<WithArraysAsIterables<CVR.CastVoteRecordReport>>({
+        ...castVoteRecordReportMetadata,
+        CVR: castVoteRecordGenerator,
+      })
+    )
   );
 }
 

--- a/libs/backend/src/scan/cast_vote_records/export.ts
+++ b/libs/backend/src/scan/cast_vote_records/export.ts
@@ -192,27 +192,6 @@ function* getCastVoteRecordGenerator({
   }
 }
 
-/**
- * Combines the report metadata and a cast vote record generator string
- * generator which yields the entire contents of the report.
- */
-function* getCastVoteRecordReportGenerator({
-  castVoteRecordReportMetadata,
-  castVoteRecordGenerator,
-}: {
-  castVoteRecordReportMetadata: CVR.CastVoteRecordReport;
-  castVoteRecordGenerator: Generator<CVR.CVR>;
-}): Generator<string> {
-  if (castVoteRecordReportMetadata.CVR) {
-    throw new Error('report metadata should contain no cast vote records');
-  }
-
-  yield* jsonStream({
-    ...castVoteRecordReportMetadata,
-    CVR: castVoteRecordGenerator,
-  });
-}
-
 interface BuildCastVoteRecordReportMetadataParams
   extends GetCastVoteRecordGeneratorParams {
   isTestMode: boolean;
@@ -255,10 +234,14 @@ export function getCastVoteRecordReportStream({
     batchInfo,
   });
 
+  if (castVoteRecordReportMetadata.CVR) {
+    throw new Error('report metadata should contain no cast vote records');
+  }
+
   return Readable.from(
-    getCastVoteRecordReportGenerator({
-      castVoteRecordReportMetadata,
-      castVoteRecordGenerator,
+    jsonStream({
+      ...castVoteRecordReportMetadata,
+      CVR: castVoteRecordGenerator,
     })
   );
 }

--- a/libs/backend/src/scan/cast_vote_records/export.ts
+++ b/libs/backend/src/scan/cast_vote_records/export.ts
@@ -11,7 +11,7 @@ import {
   SheetOf,
   unsafeParse,
 } from '@votingworks/types';
-import { err, ok, Result, typedAs } from '@votingworks/basics';
+import { err, ok, Result } from '@votingworks/basics';
 import { Readable } from 'stream';
 import {
   generateCastVoteRecordReportDirectoryName,
@@ -31,14 +31,6 @@ import { getUsbDrives } from '../../get_usb_drives';
 import { SCAN_ALLOWED_EXPORT_PATTERNS, VX_MACHINE_ID } from '../globals';
 import { BallotPageLayoutsLookup, getBallotPageLayout } from './page_layouts';
 import { buildCastVoteRecordReportMetadata } from './build_report_metadata';
-
-type WithArraysAsIterables<T> = {
-  [P in keyof T]: T[P] extends ReadonlyArray<infer U>
-    ? Iterable<U>
-    : T[P] extends ReadonlyArray<infer U> | undefined
-    ? Optional<Iterable<U>>
-    : T[P];
-};
 
 /**
  * Properties of each sheet that are needed to generate a cast vote record
@@ -243,12 +235,10 @@ export function getCastVoteRecordReportStream({
   });
 
   return Readable.from(
-    jsonStream(
-      typedAs<WithArraysAsIterables<CVR.CastVoteRecordReport>>({
-        ...castVoteRecordReportMetadata,
-        CVR: castVoteRecordGenerator,
-      })
-    )
+    jsonStream<CVR.CastVoteRecordReport>({
+      ...castVoteRecordReportMetadata,
+      CVR: castVoteRecordGenerator,
+    })
   );
 }
 

--- a/libs/backend/src/scan/cast_vote_records/export.ts
+++ b/libs/backend/src/scan/cast_vote_records/export.ts
@@ -234,10 +234,6 @@ export function getCastVoteRecordReportStream({
     batchInfo,
   });
 
-  if (castVoteRecordReportMetadata.CVR) {
-    throw new Error('report metadata should contain no cast vote records');
-  }
-
   return Readable.from(
     jsonStream({
       ...castVoteRecordReportMetadata,

--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -13,6 +13,7 @@ export * from './fetch_json';
 export * from './filenames';
 export * from './Hardware';
 export * from './hmpb';
+export * from './json_stream';
 export * from './make_async';
 export * from './perf';
 export * from './polls';

--- a/libs/utils/src/json_stream.test.ts
+++ b/libs/utils/src/json_stream.test.ts
@@ -1,11 +1,8 @@
 import { integers } from '@votingworks/basics';
 import * as fc from 'fast-check';
-import { jsonStream, JsonStreamInput } from './json_stream';
+import { jsonStream, JsonStreamInput, JsonStreamOptions } from './json_stream';
 
-function asString<T>(
-  input: JsonStreamInput<T>,
-  options?: Parameters<typeof jsonStream>[1]
-) {
+function asString<T>(input: JsonStreamInput<T>, options?: JsonStreamOptions) {
   const output = [];
   for (const chunk of jsonStream<T>(input, options)) {
     output.push(chunk);

--- a/libs/utils/src/json_stream.test.ts
+++ b/libs/utils/src/json_stream.test.ts
@@ -76,6 +76,25 @@ test('iterable', () => {
   ).toEqual('[\n  1,\n  2,\n  3\n]');
 });
 
+test('fails with circular references', () => {
+  const obj: any = { a: 1 };
+  obj.b = obj;
+  expect(() => asString(obj)).toThrowError();
+
+  const arr: any[] = [];
+  arr.push(arr);
+  expect(() => asString(arr)).toThrowError();
+});
+
+test('fails with non-serializable objects', () => {
+  expect(() => asString({ a: 1, b: () => 2 })).toThrowError(
+    `cannot serialize type 'function'`
+  );
+  expect(() => asString([undefined])).toThrowError(
+    `cannot serialize type 'undefined'`
+  );
+});
+
 test('generates correct JSON', () => {
   fc.assert(
     fc.property(fc.jsonObject(), fc.boolean(), (input, compact) => {

--- a/libs/utils/src/json_stream.test.ts
+++ b/libs/utils/src/json_stream.test.ts
@@ -1,10 +1,13 @@
 import { integers } from '@votingworks/basics';
 import * as fc from 'fast-check';
-import { jsonStream } from './json_stream';
+import { jsonStream, JsonStreamInput } from './json_stream';
 
-function asString(input: unknown) {
+function asString<T>(
+  input: JsonStreamInput<T>,
+  options?: Parameters<typeof jsonStream>[1]
+) {
   const output = [];
-  for (const chunk of jsonStream(input)) {
+  for (const chunk of jsonStream<T>(input, options)) {
     output.push(chunk);
   }
   return output.join('');
@@ -28,56 +31,57 @@ test('boolean', () => {
 
 test('array', () => {
   expect(asString([])).toEqual('[]');
-  expect(asString([1, 2, 3])).toEqual('[\n  1,\n  2,\n  3\n]');
+  expect(asString([1, 2, 3])).toEqual('[1,2,3]');
+  expect(asString([1, 2, 3], { compact: false })).toEqual(
+    '[\n  1,\n  2,\n  3\n]'
+  );
 });
 
 test('object', () => {
   expect(asString({})).toEqual('{}');
-  expect(asString({ a: 1, b: 2 })).toEqual('{\n  "a": 1,\n  "b": 2\n}');
+  expect(asString({ a: 1, b: 2 })).toEqual('{"a":1,"b":2}');
+  expect(asString({ a: 1, b: 2 }, { compact: false })).toEqual(
+    '{\n  "a": 1,\n  "b": 2\n}'
+  );
 });
 
 test('undefined object properties', () => {
-  expect(asString({ a: 1, b: undefined })).toEqual('{\n  "a": 1\n}');
-  expect(asString({ a: undefined, b: 1 })).toEqual('{\n  "b": 1\n}');
+  expect(asString({ a: 1, b: undefined })).toEqual('{"a":1}');
+  expect(asString({ a: undefined, b: 1 })).toEqual('{"b":1}');
+  expect(asString({ a: undefined, b: undefined })).toEqual('{}');
+  expect(asString({ a: 1, b: undefined }, { compact: false })).toEqual(
+    '{\n  "a": 1\n}'
+  );
 });
 
 test('nested', () => {
-  expect(asString({ a: 1, b: [2, 3] })).toEqual(
+  expect(asString({ a: 1, b: [2, 3] })).toEqual('{"a":1,"b":[2,3]}');
+  expect(asString({ a: 1, b: [2, 3] }, { compact: false })).toEqual(
     '{\n  "a": 1,\n  "b": [\n    2,\n    3\n  ]\n}'
   );
 });
 
 test('nested object', () => {
-  expect(asString({ a: 1, b: { c: 2 } })).toEqual(
+  expect(asString({ a: 1, b: { c: 2 } })).toEqual('{"a":1,"b":{"c":2}}');
+  expect(asString({ a: 1, b: { c: 2 } }, { compact: false })).toEqual(
     '{\n  "a": 1,\n  "b": {\n    "c": 2\n  }\n}'
   );
 });
 
 test('iterable', () => {
-  expect(asString(new Set([1, 2, 3]))).toEqual('[\n  1,\n  2,\n  3\n]');
-  expect(asString(integers({ from: 1, through: 3 }))).toEqual(
-    '[\n  1,\n  2,\n  3\n]'
-  );
+  expect(asString(new Set([1, 2, 3]))).toEqual('[1,2,3]');
+  expect(asString(integers({ from: 1, through: 3 }))).toEqual('[1,2,3]');
+  expect(
+    asString(integers({ from: 1, through: 3 }), { compact: false })
+  ).toEqual('[\n  1,\n  2,\n  3\n]');
 });
 
 test('generates correct JSON', () => {
-  const { serializable } = fc.letrec((tie) => ({
-    serializable: fc.oneof(
-      fc.integer(),
-      fc.string(),
-      fc.boolean(),
-      fc.constant(null),
-      fc.array(tie('serializable')),
-      fc.record({
-        key: fc.string(),
-        value: fc.oneof(tie('serializable'), fc.constant(undefined)),
-      })
-    ),
-  }));
-
   fc.assert(
-    fc.property(serializable, (input) => {
-      expect(JSON.parse(asString(input))).toEqual(input);
+    fc.property(fc.jsonObject(), fc.boolean(), (input, compact) => {
+      expect(
+        JSON.parse(asString(input as JsonStreamInput<unknown>, { compact }))
+      ).toEqual(input);
     })
   );
 });

--- a/libs/utils/src/json_stream.test.ts
+++ b/libs/utils/src/json_stream.test.ts
@@ -38,6 +38,7 @@ test('object', () => {
 
 test('undefined object properties', () => {
   expect(asString({ a: 1, b: undefined })).toEqual('{\n  "a": 1\n}');
+  expect(asString({ a: undefined, b: 1 })).toEqual('{\n  "b": 1\n}');
 });
 
 test('nested', () => {

--- a/libs/utils/src/json_stream.test.ts
+++ b/libs/utils/src/json_stream.test.ts
@@ -61,16 +61,19 @@ test('iterable', () => {
 });
 
 test('generates correct JSON', () => {
-  const serializable = fc.letrec((tie) => ({
-    any: fc.oneof(
+  const { serializable } = fc.letrec((tie) => ({
+    serializable: fc.oneof(
       fc.integer(),
       fc.string(),
       fc.boolean(),
       fc.constant(null),
-      fc.array(tie('any')),
-      fc.record({ key: fc.string(), value: tie('any') })
+      fc.array(tie('serializable')),
+      fc.record({
+        key: fc.string(),
+        value: fc.oneof(tie('serializable'), fc.constant(undefined)),
+      })
     ),
-  })).any;
+  }));
 
   fc.assert(
     fc.property(serializable, (input) => {

--- a/libs/utils/src/json_stream.test.ts
+++ b/libs/utils/src/json_stream.test.ts
@@ -1,0 +1,79 @@
+import { integers } from '@votingworks/basics';
+import * as fc from 'fast-check';
+import { jsonStream } from './json_stream';
+
+function asString(input: unknown) {
+  const output = [];
+  for (const chunk of jsonStream(input)) {
+    output.push(chunk);
+  }
+  return output.join('');
+}
+
+test('number', () => {
+  expect(asString(1)).toEqual('1');
+});
+
+test('string', () => {
+  expect(asString('hello')).toEqual('"hello"');
+});
+
+test('null', () => {
+  expect(asString(null)).toEqual('null');
+});
+
+test('boolean', () => {
+  expect(asString(true)).toEqual('true');
+});
+
+test('array', () => {
+  expect(asString([])).toEqual('[]');
+  expect(asString([1, 2, 3])).toEqual('[\n  1,\n  2,\n  3\n]');
+});
+
+test('object', () => {
+  expect(asString({})).toEqual('{}');
+  expect(asString({ a: 1, b: 2 })).toEqual('{\n  "a": 1,\n  "b": 2\n}');
+});
+
+test('undefined object properties', () => {
+  expect(asString({ a: 1, b: undefined })).toEqual('{\n  "a": 1\n}');
+});
+
+test('nested', () => {
+  expect(asString({ a: 1, b: [2, 3] })).toEqual(
+    '{\n  "a": 1,\n  "b": [\n    2,\n    3\n  ]\n}'
+  );
+});
+
+test('nested object', () => {
+  expect(asString({ a: 1, b: { c: 2 } })).toEqual(
+    '{\n  "a": 1,\n  "b": {\n    "c": 2\n  }\n}'
+  );
+});
+
+test('iterable', () => {
+  expect(asString(new Set([1, 2, 3]))).toEqual('[\n  1,\n  2,\n  3\n]');
+  expect(asString(integers({ from: 1, through: 3 }))).toEqual(
+    '[\n  1,\n  2,\n  3\n]'
+  );
+});
+
+test('generates correct JSON', () => {
+  const serializable = fc.letrec((tie) => ({
+    any: fc.oneof(
+      fc.integer(),
+      fc.string(),
+      fc.boolean(),
+      fc.constant(null),
+      fc.array(tie('any')),
+      fc.record({ key: fc.string(), value: tie('any') })
+    ),
+  })).any;
+
+  fc.assert(
+    fc.property(serializable, (input) => {
+      expect(JSON.parse(asString(input))).toEqual(input);
+    })
+  );
+});

--- a/libs/utils/src/json_stream.ts
+++ b/libs/utils/src/json_stream.ts
@@ -1,0 +1,80 @@
+import { integers, zipMin } from '@votingworks/basics';
+
+function isIterable(value: unknown): value is Iterable<unknown> {
+  return (
+    typeof value === 'object' && value !== null && Symbol.iterator in value
+  );
+}
+
+/**
+ * Stream a JSON-serializable value as a series of strings. In addition to the
+ * standard JSON types, this also supports `Iterable` values such as
+ * `Generator`.
+ *
+ * @example
+ *
+ * ```ts
+ * function* generateLargeArray() {
+ *   for (let i = 0; i < 1_000_000_000; i++) {
+ *   yield i;
+ * }
+ *
+ * const stream = jsonStream({ foo: [1, 2, 3], bar: generateLargeArray() });
+ * const writer = createWriteStream('output.json');
+ * for (const chunk of stream) {
+ *  writer.write(chunk);
+ * }
+ * ```
+ */
+export function* jsonStream(input: unknown, indent = 0): Generator<string> {
+  if (input === null) {
+    yield 'null';
+  } else if (
+    typeof input === 'boolean' ||
+    typeof input === 'number' ||
+    typeof input === 'string'
+  ) {
+    yield JSON.stringify(input);
+  } else if (isIterable(input)) {
+    const indentString = ' '.repeat(indent * 2);
+    const nextIndent = indent + 1;
+    const nextIndentString = ' '.repeat(nextIndent * 2);
+    yield '[';
+    let isEmpty = true;
+    for (const [value, index] of zipMin(input, integers())) {
+      isEmpty = false;
+      if (index !== 0) {
+        yield ',';
+      }
+      yield `\n${nextIndentString}`;
+      yield* jsonStream(value, nextIndent);
+    }
+    yield isEmpty ? ']' : `\n${indentString}]`;
+  } else if (typeof input === 'object') {
+    const indentString = ' '.repeat(indent * 2);
+    const nextIndent = indent + 1;
+    const nextIndentString = ' '.repeat(nextIndent * 2);
+    yield '{';
+    let isEmpty = true;
+    for (const [[key, value], index] of zipMin(
+      Object.entries(input),
+      integers()
+    )) {
+      if (value === undefined) {
+        continue;
+      }
+
+      isEmpty = false;
+      if (index !== 0) {
+        yield ',';
+      }
+      yield `\n${nextIndentString}`;
+      yield* jsonStream(key, nextIndent);
+      yield ': ';
+      yield* jsonStream(value, nextIndent);
+    }
+    yield isEmpty ? '}' : `\n${indentString}}`;
+  } else {
+    throw new Error(`unknown type ${typeof input}`);
+  }
+}

--- a/libs/utils/src/json_stream.ts
+++ b/libs/utils/src/json_stream.ts
@@ -88,7 +88,7 @@ export function* jsonStream<T>(
           hasEntries = true;
         }
         yield nextIndentString;
-        yield* jsonStreamInternal(entry as JsonStreamInput<unknown>, nextLevel);
+        yield* jsonStreamInternal(entry, nextLevel);
       }
       if (hasEntries) {
         yield indentString;

--- a/libs/utils/src/json_stream.ts
+++ b/libs/utils/src/json_stream.ts
@@ -1,5 +1,3 @@
-import { integers, zipMin } from '@votingworks/basics';
-
 function isIterable(value: unknown): value is Iterable<unknown> {
   return (
     typeof value === 'object' && value !== null && Symbol.iterator in value
@@ -40,40 +38,39 @@ export function* jsonStream(input: unknown, indent = 0): Generator<string> {
     const nextIndent = indent + 1;
     const nextIndentString = ' '.repeat(nextIndent * 2);
     yield '[';
-    let isEmpty = true;
-    for (const [value, index] of zipMin(input, integers())) {
-      isEmpty = false;
-      if (index !== 0) {
+    let hasEntries = false;
+    for (const value of input) {
+      if (hasEntries) {
         yield ',';
+      } else {
+        hasEntries = true;
       }
       yield `\n${nextIndentString}`;
       yield* jsonStream(value, nextIndent);
     }
-    yield isEmpty ? ']' : `\n${indentString}]`;
+    yield !hasEntries ? ']' : `\n${indentString}]`;
   } else if (typeof input === 'object') {
     const indentString = ' '.repeat(indent * 2);
     const nextIndent = indent + 1;
     const nextIndentString = ' '.repeat(nextIndent * 2);
     yield '{';
-    let isEmpty = true;
-    for (const [[key, value], index] of zipMin(
-      Object.entries(input),
-      integers()
-    )) {
+    let hasEntries = false;
+    for (const [key, value] of Object.entries(input)) {
       if (value === undefined) {
         continue;
       }
 
-      isEmpty = false;
-      if (index !== 0) {
+      if (hasEntries) {
         yield ',';
+      } else {
+        hasEntries = true;
       }
       yield `\n${nextIndentString}`;
       yield* jsonStream(key, nextIndent);
       yield ': ';
       yield* jsonStream(value, nextIndent);
     }
-    yield isEmpty ? '}' : `\n${indentString}}`;
+    yield !hasEntries ? '}' : `\n${indentString}}`;
   } else {
     throw new Error(`unknown type ${typeof input}`);
   }

--- a/libs/utils/src/json_stream.ts
+++ b/libs/utils/src/json_stream.ts
@@ -14,7 +14,8 @@ function isIterable(value: unknown): value is Iterable<unknown> {
  * ```ts
  * function* generateLargeArray() {
  *   for (let i = 0; i < 1_000_000_000; i++) {
- *   yield i;
+ *     yield i;
+ *   }
  * }
  *
  * const stream = jsonStream({ foo: [1, 2, 3], bar: generateLargeArray() });

--- a/libs/utils/src/votes.test.ts
+++ b/libs/utils/src/votes.test.ts
@@ -25,19 +25,17 @@ import {
 } from '@votingworks/types';
 import { assert, find } from '@votingworks/basics';
 import {
-  calculateTallyForCastVoteRecords,
-  filterTallyContestsByParty,
-  getEmptyTally,
-} from '.';
-import {
   ALL_PARTY_FILTER,
   buildVoteFromCvr,
+  calculateTallyForCastVoteRecords,
   castVoteRecordHasWriteIns,
   castVoteRecordVotes,
   computeTallyWithPrecomputedCategories,
   filterTalliesByParams,
+  filterTallyContestsByParty,
   getContestVoteOptionsForCandidateContest,
   getContestVoteOptionsForYesNoContest,
+  getEmptyTally,
   getPartyIdForCvr,
   getSingleYesNoVote,
   NONPARTISAN_FILTER,


### PR DESCRIPTION
## Overview
This is some follow-up to #3032, which I was doing a light review of while it got merged. I found the `JSON.stringify(…).replace(…)` we had there to be pretty janky and thought we should do better. This is my attempt to do that.

<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added
      [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging)
      where appropriate to any new user actions, system updates such as file
      reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an
      announcement in #machine-product-updates
