### PR TITLE
Kevin/standardize official ballot terminology

### DIFF
--- a/apps/admin/frontend/src/app.test.tsx
+++ b/apps/admin/frontend/src/app.test.tsx
@@ -1037,7 +1037,7 @@ test('changing election resets cvr and manual data files', async () => {
 
   fireEvent.click(await screen.findByText('Tally'));
   await screen.findByText('No CVR files loaded.');
-  await screen.findByText('Currently tallying live ballots.');
+  await screen.findByText('Currently tallying official ballots.');
   // We're waiting on a query for isOfficialResults. It has a default value,
   // so there is no change on the page to wait for before test ends.
   // TODO: Remove after upgrade to React 18, which does not warn in this case.

--- a/apps/admin/frontend/src/components/import_cvrfiles_modal.test.tsx
+++ b/apps/admin/frontend/src/components/import_cvrfiles_modal.test.tsx
@@ -273,7 +273,7 @@ describe('Screens display properly when USB is mounted', () => {
     );
     await waitFor(() =>
       expect(getByTestId('modal-title')).toHaveTextContent(
-        'Load Test Mode CVR Files'
+        'Load Test Ballot Mode CVR Files'
       )
     );
 
@@ -381,7 +381,7 @@ describe('Screens display properly when USB is mounted', () => {
         backend,
       }
     );
-    await screen.findByText('Load Live Mode CVR Files');
+    await screen.findByText('Load Official Ballot Mode CVR Files');
 
     const tableRows = getAllByTestId('table-row');
     expect(tableRows).toHaveLength(1);
@@ -450,9 +450,9 @@ describe('Screens display properly when USB is mounted', () => {
         backend,
       }
     );
-    await screen.findByText('Load Live Mode CVR Files');
+    await screen.findByText('Load Official Ballot Mode CVR Files');
     getByText(
-      /There were no new Live Mode CVR files automatically found on this USB drive./
+      /There were no new Official Ballot Mode CVR files automatically found on this USB drive./
     );
 
     const tableRows = getAllByTestId('table-row');

--- a/apps/admin/frontend/src/components/import_cvrfiles_modal.tsx
+++ b/apps/admin/frontend/src/components/import_cvrfiles_modal.tsx
@@ -355,7 +355,7 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
           {!fileModeLocked && (
             <td>
               <LabelText>
-                {isTestModeResults ? <TestMode>Test</TestMode> : 'Live'}
+                {isTestModeResults ? <TestMode>Test</TestMode> : 'Official'}
               </LabelText>
             </td>
           )}
@@ -381,9 +381,9 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element {
     // Set the header and instructional text for the modal
     const headerModeText =
       fileMode === 'test' ? (
-        <TestMode>Test Mode</TestMode>
+        <TestMode>Test Ballot Mode</TestMode>
       ) : fileMode === 'live' ? (
-        'Live Mode'
+        'Official Ballot Mode'
       ) : (
         ''
       );

--- a/apps/admin/frontend/src/screens/tally_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally_screen.tsx
@@ -66,9 +66,9 @@ export function TallyScreen(): JSX.Element {
   const fileMode = useCvrFileModeQuery().data;
   const fileModeText =
     fileMode === Admin.CvrFileMode.Test
-      ? 'Currently tallying test ballots. Once you have completed L&A testing and are ready to start tallying live ballots remove all of the loaded CVR files before loading live ballot results.'
+      ? 'Currently tallying test ballots. Once you have completed L&A testing and are ready to start tallying official ballots remove all of the loaded CVR files before loading official ballot results.'
       : fileMode === Admin.CvrFileMode.Official
-      ? 'Currently tallying live ballots.'
+      ? 'Currently tallying official ballots.'
       : '';
 
   const externalTallyRows = Array.from(

--- a/apps/central-scan/frontend/src/app.test.tsx
+++ b/apps/central-scan/frontend/src/app.test.tsx
@@ -128,7 +128,7 @@ test('renders without crashing', async () => {
   await waitFor(() => fetchMock.called());
 });
 
-test('shows a "Test mode" button if the app is in Live Mode', async () => {
+test('shows a "test ballot mode" button if the app is in Official Ballot Mode', async () => {
   const getElectionResponseBody: Scan.GetElectionConfigResponse =
     electionSampleDefinition;
   const getTestModeResponseBody: Scan.GetTestModeConfigResponse = {
@@ -152,10 +152,10 @@ test('shows a "Test mode" button if the app is in Live Mode', async () => {
 
   fireEvent.click(result.getByText('Admin'));
 
-  result.getByText('Toggle to Test Mode');
+  result.getByText('Toggle to Test Ballot Mode');
 });
 
-test('shows a "Live mode" button if the app is in Test Mode', async () => {
+test('shows an "official ballot mode" button if the app is in Test Mode', async () => {
   const getElectionResponseBody: Scan.GetElectionConfigResponse =
     electionSampleDefinition;
   const getTestModeResponseBody: Scan.GetTestModeConfigResponse = {
@@ -183,7 +183,7 @@ test('shows a "Live mode" button if the app is in Test Mode', async () => {
 
   fireEvent.click(result.getByText('Admin'));
 
-  result.getByText('Toggle to Live Mode');
+  result.getByText('Toggle to Official Ballot Mode');
 });
 
 test('clicking Scan Batch will scan a batch', async () => {

--- a/apps/central-scan/frontend/src/app_root.tsx
+++ b/apps/central-scan/frontend/src/app_root.tsx
@@ -411,22 +411,26 @@ export function AppRoot({
     try {
       setTogglingTestMode(true);
       await logger.log(LogEventId.TogglingTestMode, userRole, {
-        message: `Toggling to ${isTestMode ? 'Live' : 'Test'} Mode...`,
+        message: `Toggling to ${
+          isTestMode ? 'Official' : 'Test'
+        } Ballot Mode...`,
       });
       await config.setTestMode(!isTestMode);
       await refreshConfig();
       await logger.log(LogEventId.ToggledTestMode, userRole, {
         disposition: 'success',
-        message: `Successfully toggled to ${isTestMode ? 'Live' : 'Test'} Mode`,
+        message: `Successfully toggled to ${
+          isTestMode ? 'Official' : 'Test'
+        } Ballot Mode`,
       });
       history.replace('/');
     } catch (error) {
       assert(error instanceof Error);
       await logger.log(LogEventId.ToggledTestMode, userRole, {
         disposition: 'failure',
-        message: `Error toggling to ${isTestMode ? 'Live' : 'Test'} Mode: ${
-          error.message
-        }`,
+        message: `Error toggling to ${
+          isTestMode ? 'Official' : 'Test'
+        } Ballot Mode: ${error.message}`,
         result: 'Mode not changed, user shown error.',
       });
     } finally {

--- a/apps/central-scan/frontend/src/components/main_nav.tsx
+++ b/apps/central-scan/frontend/src/components/main_nav.tsx
@@ -71,7 +71,7 @@ export function MainNav({ children, isTestMode = false }: Props): JSX.Element {
           </MakeName>
           <ModelName>VxCentralScan</ModelName>
         </Brand>
-        {isTestMode && <TestMode>Machine is in Testing Mode</TestMode>}
+        {isTestMode && <TestMode>Machine is in Test Ballot Mode</TestMode>}
         <NavButtons>{children}</NavButtons>
       </Nav>
     </NavWrapper>

--- a/apps/central-scan/frontend/src/components/toggle_test_mode_button.test.tsx
+++ b/apps/central-scan/frontend/src/components/toggle_test_mode_button.test.tsx
@@ -1,9 +1,10 @@
-import { fireEvent, render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { ToggleTestModeButton } from './toggle_test_mode_button';
 
 test('shows a button to toggle to live mode when in test mode', () => {
-  const { getByText } = render(
+  render(
     <ToggleTestModeButton
       canUnconfigure={false}
       isTestMode
@@ -12,11 +13,11 @@ test('shows a button to toggle to live mode when in test mode', () => {
     />
   );
 
-  getByText('Toggle to Official Ballot Mode');
+  screen.getByText('Toggle to Official Ballot Mode');
 });
 
 test('shows a button to toggle to test mode when in live mode', () => {
-  const { getByText } = render(
+  render(
     <ToggleTestModeButton
       canUnconfigure
       isTestMode={false}
@@ -25,11 +26,11 @@ test('shows a button to toggle to test mode when in live mode', () => {
     />
   );
 
-  getByText('Toggle to Test Ballot Mode');
+  screen.getByText('Toggle to Test Ballot Mode');
 });
 
 test('shows a disabled button when in live mode but the machine cannot be unconfigured', () => {
-  const { getByText } = render(
+  render(
     <ToggleTestModeButton
       canUnconfigure={false}
       isTestMode={false}
@@ -39,12 +40,12 @@ test('shows a disabled button when in live mode but the machine cannot be unconf
   );
 
   expect(
-    (getByText('Toggle to Test Ballot Mode') as HTMLButtonElement).disabled
+    screen.getByText('Toggle to Test Ballot Mode').hasAttribute('disabled')
   ).toEqual(true);
 });
 
 test('shows a disabled button with "Toggling" when toggling', () => {
-  const { getByText } = render(
+  render(
     <ToggleTestModeButton
       canUnconfigure
       isTestMode
@@ -53,12 +54,12 @@ test('shows a disabled button with "Toggling" when toggling', () => {
     />
   );
 
-  expect((getByText('Toggling…') as HTMLButtonElement).disabled).toEqual(true);
+  expect(screen.getByText('Toggling…').hasAttribute('disabled')).toEqual(true);
 });
 
 test('calls the callback on confirmation', () => {
   const toggleTestMode = jest.fn();
-  const { getByText, getAllByText } = render(
+  render(
     <ToggleTestModeButton
       canUnconfigure
       isTestMode
@@ -68,20 +69,22 @@ test('calls the callback on confirmation', () => {
   );
 
   // Click the button.
-  fireEvent.click(getByText('Toggle to Official Ballot Mode'));
+  userEvent.click(screen.getByText('Toggle to Official Ballot Mode'));
 
   // Then click the confirmation button inside the modal.
-  const [confirmButton] = getAllByText('Toggle to Official Ballot Mode').filter(
-    (element) => element instanceof HTMLButtonElement && !element.disabled
-  );
+  const [confirmButton] = screen
+    .getAllByText('Toggle to Official Ballot Mode')
+    .filter(
+      (element) => element instanceof HTMLButtonElement && !element.disabled
+    );
   expect(toggleTestMode).not.toHaveBeenCalled();
-  fireEvent.click(confirmButton);
+  userEvent.click(confirmButton);
   expect(toggleTestMode).toHaveBeenCalled();
 });
 
 test('toggle modal shows "official ballot mode" when toggling away from test ballot mode', () => {
   const toggleTestMode = jest.fn();
-  const { getByText } = render(
+  render(
     <ToggleTestModeButton
       canUnconfigure
       isTestMode
@@ -91,16 +94,16 @@ test('toggle modal shows "official ballot mode" when toggling away from test bal
   );
 
   // Click the button.
-  fireEvent.click(getByText('Toggle to Official Ballot Mode'));
+  userEvent.click(screen.getByText('Toggle to Official Ballot Mode'));
 
-  getByText(
+  screen.getByText(
     'Toggling to Official Ballot Mode will zero out your scanned ballots. Are you sure?'
   );
 });
 
 test('toggle modal shows "test ballot mode" when toggling away from official ballot mode', () => {
   const toggleTestMode = jest.fn();
-  const { getByText } = render(
+  render(
     <ToggleTestModeButton
       canUnconfigure
       isTestMode={false}
@@ -110,16 +113,16 @@ test('toggle modal shows "test ballot mode" when toggling away from official bal
   );
 
   // Click the button.
-  fireEvent.click(getByText('Toggle to Test Ballot Mode'));
+  userEvent.click(screen.getByText('Toggle to Test Ballot Mode'));
 
-  getByText(
+  screen.getByText(
     'Toggling to Test Ballot Mode will zero out your scanned ballots. Are you sure?'
   );
 });
 
 test('shows a modal when toggling to official ballot mode is in progress', () => {
   const toggleTestMode = jest.fn();
-  const { getByText } = render(
+  render(
     <ToggleTestModeButton
       canUnconfigure
       isTestMode
@@ -128,13 +131,13 @@ test('shows a modal when toggling to official ballot mode is in progress', () =>
     />
   );
 
-  getByText('Toggling to Official Ballot Mode');
-  getByText('Zeroing out scanned ballots and reloading…');
+  screen.getByText('Toggling to Official Ballot Mode');
+  screen.getByText('Zeroing out scanned ballots and reloading…');
 });
 
 test('shows a modal when toggling to test ballot mode is in progress', () => {
   const toggleTestMode = jest.fn();
-  const { getByText } = render(
+  render(
     <ToggleTestModeButton
       canUnconfigure
       isTestMode={false}
@@ -143,6 +146,6 @@ test('shows a modal when toggling to test ballot mode is in progress', () => {
     />
   );
 
-  getByText('Toggling to Test Ballot Mode');
-  getByText('Zeroing out scanned ballots and reloading…');
+  screen.getByText('Toggling to Test Ballot Mode');
+  screen.getByText('Zeroing out scanned ballots and reloading…');
 });

--- a/apps/central-scan/frontend/src/components/toggle_test_mode_button.test.tsx
+++ b/apps/central-scan/frontend/src/components/toggle_test_mode_button.test.tsx
@@ -12,7 +12,7 @@ test('shows a button to toggle to live mode when in test mode', () => {
     />
   );
 
-  getByText('Toggle to Live Mode');
+  getByText('Toggle to Official Ballot Mode');
 });
 
 test('shows a button to toggle to test mode when in live mode', () => {
@@ -25,7 +25,7 @@ test('shows a button to toggle to test mode when in live mode', () => {
     />
   );
 
-  getByText('Toggle to Test Mode');
+  getByText('Toggle to Test Ballot Mode');
 });
 
 test('shows a disabled button when in live mode but the machine cannot be unconfigured', () => {
@@ -39,7 +39,7 @@ test('shows a disabled button when in live mode but the machine cannot be unconf
   );
 
   expect(
-    (getByText('Toggle to Test Mode') as HTMLButtonElement).disabled
+    (getByText('Toggle to Test Ballot Mode') as HTMLButtonElement).disabled
   ).toEqual(true);
 });
 
@@ -68,10 +68,10 @@ test('calls the callback on confirmation', () => {
   );
 
   // Click the button.
-  fireEvent.click(getByText('Toggle to Live Mode'));
+  fireEvent.click(getByText('Toggle to Official Ballot Mode'));
 
   // Then click the confirmation button inside the modal.
-  const [confirmButton] = getAllByText('Toggle to Live Mode').filter(
+  const [confirmButton] = getAllByText('Toggle to Official Ballot Mode').filter(
     (element) => element instanceof HTMLButtonElement && !element.disabled
   );
   expect(toggleTestMode).not.toHaveBeenCalled();
@@ -90,7 +90,7 @@ test('shows a modal when toggling to live mode', () => {
     />
   );
 
-  getByText('Toggling to Live Mode');
+  getByText('Toggling to Official Ballot Mode');
   getByText('Zeroing out scanned ballots and reloading…');
 });
 
@@ -105,6 +105,6 @@ test('shows a modal when toggling to test mode', () => {
     />
   );
 
-  getByText('Toggling to Test Mode');
+  getByText('Toggling to Test Ballot Mode');
   getByText('Zeroing out scanned ballots and reloading…');
 });

--- a/apps/central-scan/frontend/src/components/toggle_test_mode_button.test.tsx
+++ b/apps/central-scan/frontend/src/components/toggle_test_mode_button.test.tsx
@@ -79,7 +79,45 @@ test('calls the callback on confirmation', () => {
   expect(toggleTestMode).toHaveBeenCalled();
 });
 
-test('shows a modal when toggling to live mode', () => {
+test('toggle modal shows "official ballot mode" when toggling away from test ballot mode', () => {
+  const toggleTestMode = jest.fn();
+  const { getByText } = render(
+    <ToggleTestModeButton
+      canUnconfigure
+      isTestMode
+      isTogglingTestMode={false}
+      toggleTestMode={toggleTestMode}
+    />
+  );
+
+  // Click the button.
+  fireEvent.click(getByText('Toggle to Official Ballot Mode'));
+
+  getByText(
+    'Toggling to Official Ballot Mode will zero out your scanned ballots. Are you sure?'
+  );
+});
+
+test('toggle modal shows "test ballot mode" when toggling away from official ballot mode', () => {
+  const toggleTestMode = jest.fn();
+  const { getByText } = render(
+    <ToggleTestModeButton
+      canUnconfigure
+      isTestMode={false}
+      isTogglingTestMode={false}
+      toggleTestMode={toggleTestMode}
+    />
+  );
+
+  // Click the button.
+  fireEvent.click(getByText('Toggle to Test Ballot Mode'));
+
+  getByText(
+    'Toggling to Test Ballot Mode will zero out your scanned ballots. Are you sure?'
+  );
+});
+
+test('shows a modal when toggling to official ballot mode is in progress', () => {
   const toggleTestMode = jest.fn();
   const { getByText } = render(
     <ToggleTestModeButton
@@ -94,7 +132,7 @@ test('shows a modal when toggling to live mode', () => {
   getByText('Zeroing out scanned ballots and reloading…');
 });
 
-test('shows a modal when toggling to test mode', () => {
+test('shows a modal when toggling to test ballot mode is in progress', () => {
   const toggleTestMode = jest.fn();
   const { getByText } = render(
     <ToggleTestModeButton

--- a/apps/central-scan/frontend/src/components/toggle_test_mode_button.tsx
+++ b/apps/central-scan/frontend/src/components/toggle_test_mode_button.tsx
@@ -64,7 +64,9 @@ export function ToggleTestModeButton({
               <p>
                 {isTogglingTestMode
                   ? 'Zeroing out scanned ballots and reloading…'
-                  : 'Toggling to Test Ballot Mode will zero out your scanned ballots. Are you sure?'}
+                  : `Toggling to ${
+                      isTestMode ? 'Official' : 'Test'
+                    } Ballot Mode will zero out your scanned ballots. Are you sure?`}
               </p>
             </Prose>
           }

--- a/apps/central-scan/frontend/src/components/toggle_test_mode_button.tsx
+++ b/apps/central-scan/frontend/src/components/toggle_test_mode_button.tsx
@@ -44,8 +44,8 @@ export function ToggleTestModeButton({
         {isTogglingTestMode
           ? 'Toggling…'
           : isTestMode
-          ? 'Toggle to Live Mode'
-          : 'Toggle to Test Mode'}
+          ? 'Toggle to Official Ballot Mode'
+          : 'Toggle to Test Ballot Mode'}
       </Button>
       {isConfirming && (
         <Modal
@@ -55,16 +55,16 @@ export function ToggleTestModeButton({
               <h1>
                 {isTogglingTestMode
                   ? isTestMode
-                    ? 'Toggling to Live Mode'
-                    : 'Toggling to Test Mode'
+                    ? 'Toggling to Official Ballot Mode'
+                    : 'Toggling to Test Ballot Mode'
                   : isTestMode
-                  ? 'Toggle to Live Mode'
-                  : 'Toggle to Test Mode'}
+                  ? 'Toggle to Official Ballot Mode'
+                  : 'Toggle to Test Ballot Mode'}
               </h1>
               <p>
                 {isTogglingTestMode
                   ? 'Zeroing out scanned ballots and reloading…'
-                  : 'Toggling test mode will zero out your scanned ballots. Are you sure?'}
+                  : 'Toggling to Test Ballot Mode will zero out your scanned ballots. Are you sure?'}
               </p>
             </Prose>
           }
@@ -77,7 +77,9 @@ export function ToggleTestModeButton({
                   primary
                   onPress={toggleTestMode}
                 >
-                  {isTestMode ? 'Toggle to Live Mode' : 'Toggle to Test Mode'}
+                  {isTestMode
+                    ? 'Toggle to Official Ballot Mode'
+                    : 'Toggle to Test Ballot Mode'}
                 </Button>
                 <Button onPress={toggleIsConfirming}>Cancel</Button>
               </React.Fragment>

--- a/apps/central-scan/frontend/src/screens/ballot_eject_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/ballot_eject_screen.test.tsx
@@ -403,7 +403,7 @@ test('says the ballot sheet is blank if it is', async () => {
   });
 });
 
-test('calls out live ballot sheets in test mode', async () => {
+test('calls out official ballot sheets in test mode', async () => {
   fetchMock.getOnce(
     '/central-scanner/scan/hmpb/review/next-sheet',
     typedAs<Scan.GetNextReviewSheetResponse>({
@@ -457,9 +457,9 @@ test('calls out live ballot sheets in test mode', async () => {
     await waitFor(() => fetchMock.called);
   });
 
-  screen.getByText('Live Ballot');
+  screen.getByText('Official Ballot');
   screen.getByText('The last scanned ballot was not tabulated.');
-  screen.getByText('Remove the LIVE ballot before continuing.');
+  screen.getByText('Remove the OFFICIAL ballot before continuing.');
   expect(screen.getByRole('button').textContent).toEqual(
     'The ballot has been removed'
   );

--- a/apps/central-scan/frontend/src/screens/ballot_eject_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/ballot_eject_screen.tsx
@@ -313,7 +313,7 @@ export function BallotEjectScreen({
                 <span style={{ fontSize: '2em' }}>
                   {isInvalidTestModeSheet
                     ? isTestMode
-                      ? 'Live Ballot'
+                      ? 'Official Ballot'
                       : 'Test Ballot'
                     : isInvalidElectionHashSheet
                     ? 'Wrong Election'
@@ -369,7 +369,7 @@ export function BallotEjectScreen({
                 </React.Fragment>
               ) : isInvalidTestModeSheet ? (
                 isTestMode ? (
-                  <p>Remove the LIVE ballot before continuing.</p>
+                  <p>Remove the OFFICIAL ballot before continuing.</p>
                 ) : (
                   <p>Remove the TEST ballot before continuing.</p>
                 )

--- a/apps/central-scan/integration-testing/cypress/e2e/configuration.cy.ts
+++ b/apps/central-scan/integration-testing/cypress/e2e/configuration.cy.ts
@@ -77,9 +77,9 @@ describe('BSD and services/Scan', () => {
     cy.contains('Successfully Configured', { timeout: 20000 });
     cy.contains('Close').click();
     cy.contains('Admin').click();
-    cy.contains('Toggle to Live Mode').click();
+    cy.contains('Toggle to Official Ballot Mode').click();
     cy.get('button[data-testid="confirm-toggle"]')
-      .contains('Toggle to Live Mode')
+      .contains('Toggle to Official Ballot Mode')
       .click();
     cy.contains('No ballots have been scanned', { timeout: 30000 });
     cy.contains('Scan New Batch').click();
@@ -106,18 +106,18 @@ describe('BSD and services/Scan', () => {
     // cy.contains('Scan New Batch').click();
     // cy.contains('A total of 1 ballot has been scanned in 1 batch.');
     // cy.contains('Admin').click();
-    // cy.contains('Toggle to Test Mode').click();
+    // cy.contains('Toggle to Test Ballot Mode').click();
     // cy.get('button[data-testid="confirm-toggle"]')
-    //   .contains('Toggle to Test Mode')
+    //   .contains('Toggle to Test Ballot Mode')
     //   .click();
     // cy.contains('VxCentralScan TEST MODE', { timeout: 30000 });
     // cy.contains('No ballots have been scanned');
     // cy.contains('Scan New Batch').click();
-    // // We are now in test mode so the live ballot will not scan
-    // cy.contains('Remove the LIVE ballot before continuing');
+    // // We are now in test mode so the official ballot will not scan
+    // cy.contains('Remove the OFFICIAL ballot before continuing');
     // cy.contains('Confirm Ballot Removed and Continue Scanning').click();
     // cy.contains('Admin').click();
-    // cy.contains('Toggle to Live Mode');
+    // cy.contains('Toggle to Official Ballot Mode');
     // cy.contains('Save Backup').click();
     // cy.contains('Delete Election Data from VxCentralScan').click();
     // cy.contains('Yes, Delete Election Data').click();

--- a/apps/mark/frontend/src/app_cardless_voting.test.tsx
+++ b/apps/mark/frontend/src/app_cardless_voting.test.tsx
@@ -84,9 +84,9 @@ test('Cardless Voting Flow', async () => {
   fireEvent.change(precinctSelect, { target: { value: precinctId } });
   within(screen.getByTestId('electionInfoBar')).getByText(/Center Springfield/);
 
-  fireEvent.click(screen.getByText('Live Election Mode'));
+  fireEvent.click(screen.getByText('Official Ballot Mode'));
   expect(
-    screen.getByText<HTMLButtonElement>('Live Election Mode').disabled
+    screen.getByText<HTMLButtonElement>('Official Ballot Mode').disabled
   ).toBeTruthy();
 
   // Remove card
@@ -392,9 +392,9 @@ test('poll worker must select a precinct first', async () => {
   fireEvent.change(precinctSelect, { target: { value: precinctId } });
   within(screen.getByTestId('electionInfoBar')).getByText(/All Precincts/);
 
-  fireEvent.click(screen.getByText('Live Election Mode'));
+  fireEvent.click(screen.getByText('Official Ballot Mode'));
   expect(
-    screen.getByText<HTMLButtonElement>('Live Election Mode').disabled
+    screen.getByText<HTMLButtonElement>('Official Ballot Mode').disabled
   ).toBeTruthy();
 
   // Remove card

--- a/apps/mark/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark/frontend/src/app_end_to_end.test.tsx
@@ -141,9 +141,9 @@ test('MarkAndPrint end-to-end flow', async () => {
   );
   within(screen.getByTestId('electionInfoBar')).getByText(/Center Springfield/);
 
-  userEvent.click(screen.getByText('Live Election Mode'));
+  userEvent.click(screen.getByText('Official Ballot Mode'));
   expect(
-    screen.getByText<HTMLButtonElement>('Live Election Mode').disabled
+    screen.getByText<HTMLButtonElement>('Official Ballot Mode').disabled
   ).toBeTruthy();
 
   // Remove card

--- a/apps/mark/frontend/src/app_test_mode.test.tsx
+++ b/apps/mark/frontend/src/app_test_mode.test.tsx
@@ -46,7 +46,7 @@ it('Prompts to change from test mode to live mode on election day', async () => 
     />
   );
 
-  await screen.findByText('Machine is in Testing Mode');
+  await screen.findByText('Machine is in Test Ballot Mode');
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);
   await screen.findByText(
     'Switch to Official Ballot Mode and reset the Ballots Printed count?'
@@ -55,6 +55,6 @@ it('Prompts to change from test mode to live mode on election day', async () => 
     screen.getByRole('button', { name: 'Switch to Official Ballot Mode' })
   );
   await waitFor(() =>
-    expect(screen.queryByText('Machine is in Testing Mode')).toBeNull()
+    expect(screen.queryByText('Machine is in Test Ballot Mode')).toBeNull()
   );
 });

--- a/apps/mark/frontend/src/app_test_mode.test.tsx
+++ b/apps/mark/frontend/src/app_test_mode.test.tsx
@@ -49,10 +49,10 @@ it('Prompts to change from test mode to live mode on election day', async () => 
   await screen.findByText('Machine is in Testing Mode');
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);
   await screen.findByText(
-    'Switch to Live Election Mode and reset the Ballots Printed count?'
+    'Switch to Official Ballot Mode and reset the Ballots Printed count?'
   );
   userEvent.click(
-    screen.getByRole('button', { name: 'Switch to Live Election Mode' })
+    screen.getByRole('button', { name: 'Switch to Official Ballot Mode' })
   );
   await waitFor(() =>
     expect(screen.queryByText('Machine is in Testing Mode')).toBeNull()

--- a/apps/mark/frontend/src/app_voter_settings_landscape.test.tsx
+++ b/apps/mark/frontend/src/app_voter_settings_landscape.test.tsx
@@ -69,7 +69,7 @@ test('MarkAndPrint: voter settings in landscape orientation', async () => {
     screen.getByLabelText('Precinct'),
     screen.getByText('Center Springfield')
   );
-  userEvent.click(screen.getByText('Live Election Mode'));
+  userEvent.click(screen.getByText('Official Ballot Mode'));
   apiMock.setAuthStatusLoggedOut();
   await advanceTimersAndPromises();
   await screen.findByText('Polls Closed');

--- a/apps/mark/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.tsx
@@ -130,7 +130,7 @@ export function AdminScreen({
                   </React.Fragment>
                 )}
               </p>
-              <h2>Testing Mode</h2>
+              <h2>Test Ballot Mode</h2>
               <p>
                 <SegmentedButton>
                   <Button
@@ -138,14 +138,14 @@ export function AdminScreen({
                     primary={!isLiveMode}
                     disabled={!isLiveMode}
                   >
-                    Testing Mode
+                    Test Ballot Mode
                   </Button>
                   <Button
                     onPress={toggleLiveMode}
                     primary={isLiveMode}
                     disabled={isLiveMode}
                   >
-                    Live Election Mode
+                    Official Ballot Mode
                   </Button>
                 </SegmentedButton>
                 <br />

--- a/apps/mark/frontend/src/pages/poll_worker_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.test.tsx
@@ -122,9 +122,9 @@ test('switching out of test mode on election day', () => {
   });
 
   screen.getByText(
-    'Switch to Live Election Mode and reset the Ballots Printed count?'
+    'Switch to Official Ballot Mode and reset the Ballots Printed count?'
   );
-  fireEvent.click(screen.getByText('Switch to Live Election Mode'));
+  fireEvent.click(screen.getByText('Switch to Official Ballot Mode'));
   expect(enableLiveMode).toHaveBeenCalled();
 });
 
@@ -140,7 +140,7 @@ test('keeping test mode on election day', () => {
   renderScreen({ electionDefinition, enableLiveMode });
 
   screen.getByText(
-    'Switch to Live Election Mode and reset the Ballots Printed count?'
+    'Switch to Official Ballot Mode and reset the Ballots Printed count?'
   );
   fireEvent.click(screen.getByText('Cancel'));
   expect(enableLiveMode).not.toHaveBeenCalled();
@@ -153,7 +153,7 @@ test('live mode on election day', () => {
   renderScreen({ isLiveMode: true });
   expect(
     screen.queryByText(
-      'Switch to Live Election Mode and reset the Ballots Printed count?'
+      'Switch to Official Ballot Mode and reset the Ballots Printed count?'
     )
   ).toBeNull();
 });

--- a/apps/mark/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.tsx
@@ -770,7 +770,7 @@ export function PollWorkerScreen({
                   </strong>
                 </p>
                 <Text small italic>
-                  Note: Switching back to Testing Mode requires an{' '}
+                  Note: Switching back to Test Ballot Mode requires an{' '}
                   <NoWrap>Election Manager Card.</NoWrap>
                 </Text>
               </Prose>

--- a/apps/mark/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.tsx
@@ -760,13 +760,13 @@ export function PollWorkerScreen({
             content={
               <Prose textCenter id="modalaudiofocus">
                 <h1>
-                  Switch to Live Election Mode and reset the Ballots Printed
+                  Switch to Official Ballot Mode and reset the Ballots Printed
                   count?
                 </h1>
                 <p>
                   Today is election day and this machine is in{' '}
                   <strong>
-                    <NoWrap>Election Testing Mode.</NoWrap>
+                    <NoWrap>Test Ballot Mode.</NoWrap>
                   </strong>
                 </p>
                 <Text small italic>
@@ -778,7 +778,7 @@ export function PollWorkerScreen({
             actions={
               <React.Fragment>
                 <Button primary danger onPress={confirmEnableLiveMode}>
-                  Switch to Live Election Mode
+                  Switch to Official Ballot Mode
                 </Button>
                 <Button onPress={cancelEnableLiveMode}>Cancel</Button>
               </React.Fragment>

--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -200,9 +200,9 @@ test('election manager and poll worker configuration', async () => {
   apiMock.expectSetTestMode(false);
   config = { ...config, isTestMode: true };
   apiMock.expectGetConfig(config);
-  userEvent.click(await screen.findByText('Live Election Mode'));
+  userEvent.click(await screen.findByText('Official Ballot Mode'));
   await waitFor(() =>
-    expect(screen.getByText('Live Election Mode')).toBeDisabled()
+    expect(screen.getByText('Official Ballot Mode')).toBeDisabled()
   );
 
   // Change precinct as Election Manager

--- a/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
@@ -180,14 +180,14 @@ test('unconfigure button is disabled when the machine cannot be unconfigured', a
   expect(screen.queryByText('Unconfigure Machine?')).toBeNull();
 });
 
-test('cannot toggle to testing mode when the machine cannot be unconfigured', async () => {
+test('cannot toggle to Test Ballot Mode when the machine cannot be unconfigured', async () => {
   apiMock.expectCheckCalibrationSupported(true);
   apiMock.expectGetConfig({ isTestMode: false });
   renderScreen();
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
 
-  userEvent.click(screen.getByText('Testing Mode'));
-  screen.getByText('Save Backup to switch to Test Mode');
+  userEvent.click(screen.getByText('Test Ballot Mode'));
+  screen.getByText('Save Backup to switch to Test Ballot Mode');
   userEvent.click(screen.getByText('Cancel'));
 });
 

--- a/apps/scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.tsx
@@ -131,14 +131,14 @@ export function ElectionManagerScreen({
               onPress={handleTogglingTestMode}
               disabled={isTestMode || setTestModeMutation.isLoading}
             >
-              Testing Mode
+              Test Ballot Mode
             </Button>
             <Button
               large
               onPress={handleTogglingTestMode}
               disabled={!isTestMode || setTestModeMutation.isLoading}
             >
-              Live Election Mode
+              Official Ballot Mode
             </Button>
           </SegmentedButton>
         </p>
@@ -219,10 +219,10 @@ export function ElectionManagerScreen({
         <Modal
           content={
             <Prose>
-              <h1>Save Backup to switch to Test Mode</h1>
+              <h1>Save Backup to switch to Test Ballot Mode</h1>
               <p>
-                You must &quot;Save Backup&quot; before you may switch to
-                Testing Mode.
+                You must &quot;Save Backup&quot; before you may switch to Test
+                Ballot Mode.
               </p>
             </Prose>
           }

--- a/libs/ui/src/__snapshots__/test_mode.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/test_mode.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`renders TestMode 1`] = `
     class="c0"
   >
     <div>
-      Machine is in Testing Mode
+      Machine is in Test Ballot Mode
     </div>
   </div>
 </div>

--- a/libs/ui/src/test_mode.test.tsx
+++ b/libs/ui/src/test_mode.test.tsx
@@ -5,6 +5,6 @@ import { TestMode } from './test_mode';
 
 test('renders TestMode', () => {
   const { container } = render(<TestMode />);
-  screen.getByText('Machine is in Testing Mode');
+  screen.getByText('Machine is in Test Ballot Mode');
   expect(container).toMatchSnapshot();
 });

--- a/libs/ui/src/test_mode.tsx
+++ b/libs/ui/src/test_mode.tsx
@@ -31,7 +31,7 @@ const TestingModeContainer = styled.div`
 export function TestMode(): JSX.Element {
   return (
     <TestingModeContainer>
-      <div>Machine is in Testing Mode</div>
+      <div>Machine is in Test Ballot Mode</div>
     </TestingModeContainer>
   );
 }

--- a/libs/utils/src/filenames.ts
+++ b/libs/utils/src/filenames.ts
@@ -134,6 +134,9 @@ export function generateCastVoteRecordReportDirectoryName(
 }
 
 /* Extract information about a CVR file from the filename */
+// Expected filename format with human-readable separators is:
+// [TEST__]machine_{machineId}__{numberOfBallots}_ballots__YYYY-MM-DD_HH-mm-ss.jsonl
+// This format is current as of 2023-02-22 and may be out of date if separator constants have changed
 export function parseCvrFileInfoFromFilename(
   filename: string
 ): CvrFileData | undefined {


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/2783

Standardizes references for test/live mode from "Testing Mode", "Election Testing Mode", "Test Election Mode" etc to "Test Ballot Mode" and "Official Ballot Mode". Discussion in [Slack](https://votingworks.slack.com/archives/CEL6D3GAD/p1677281469337549).

## Demo Video or Screenshot

### VxCentralScan
![Screenshot 2023-02-28 at 6 44 21 PM](https://user-images.githubusercontent.com/1060688/222031883-ee8ebd8d-7a53-4734-82eb-a7dbf9cb53c3.png)
---
![Screenshot 2023-02-28 at 6 44 32 PM](https://user-images.githubusercontent.com/1060688/222031886-7e50c359-80f0-4d35-a7bd-19df60d9a5e6.png)
---
![Screenshot 2023-02-28 at 6 44 39 PM](https://user-images.githubusercontent.com/1060688/222031888-66461f17-4783-40c0-955f-99afec7c60aa.png)
---
![Screenshot 2023-02-28 at 6 46 06 PM](https://user-images.githubusercontent.com/1060688/222032015-779cc407-0273-4d00-8423-0c9fe6ff09f5.png)

---

### VxScan
![Screenshot 2023-02-24 at 4 49 13 PM](https://user-images.githubusercontent.com/1060688/221703773-1e4f1bc7-f5c3-42bc-a5e1-398ddaf79c2a.png)

---

### VxAdmin
![Screenshot 2023-02-27 at 2 59 06 PM](https://user-images.githubusercontent.com/1060688/221708546-ce9588f7-00d1-4f64-a13b-86bd6a656703.png)
---
![Screenshot 2023-02-27 at 3 01 10 PM](https://user-images.githubusercontent.com/1060688/221708887-5d943ab5-04b6-42c8-ab8f-0431c5a6018f.png)
---
![Screenshot 2023-02-28 at 6 43 50 PM](https://user-images.githubusercontent.com/1060688/222031939-769a1560-6d33-4b69-9fd2-8db1b206b507.png)


### VxMark
![Screenshot 2023-02-27 at 11 51 24 AM](https://user-images.githubusercontent.com/1060688/221708990-6d891f7f-caa3-46d8-bfca-981d9fd48a21.png)
---
![Screenshot 2023-02-27 at 4 10 45 PM](https://user-images.githubusercontent.com/1060688/221718365-0cdc0da6-0479-4c3c-b4da-7654c7eb02ba.png)


## Testing Plan
* Updated test expectations
* Manually rendered pages to confirm changes


## Checklist


- [x] I have added
      [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging)
      where appropriate to any new user actions, system updates such as file
      reads or storage writes, or errors introduced. **No new user actions or errors**
- [x] I have added JSDoc comments to any newly introduced exports **No new exports**
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an
      announcement in #machine-product-updates
