### PR TITLE
Custom scanner tweaks

### DIFF
--- a/apps/scan/backend/src/index.ts
+++ b/apps/scan/backend/src/index.ts
@@ -11,6 +11,7 @@ import * as plustekStateMachine from './scanners/plustek/state_machine';
 import * as customStateMachine from './scanners/custom/state_machine';
 import * as server from './server';
 import { createWorkspace, Workspace } from './util/workspace';
+import { PrecinctScannerStateMachine } from './types';
 
 export type { Api } from './app';
 export * from './types';

--- a/apps/scan/backend/src/scanners/custom/state_machine.ts
+++ b/apps/scan/backend/src/scanners/custom/state_machine.ts
@@ -280,9 +280,7 @@ async function reset({ client }: Context): Promise<void> {
   assert(client);
   debug('Resetting hardware');
   const result = await client.resetHardware();
-  if (result.isErr()) {
-    throw result.err();
-  }
+  result.unsafeUnwrap();
 }
 
 async function scan({ client, workspace }: Context): Promise<SheetOf<string>> {

--- a/libs/custom-scanner/package.json
+++ b/libs/custom-scanner/package.json
@@ -25,6 +25,7 @@
     "@votingworks/types": "workspace:*",
     "@votingworks/utils": "workspace:*",
     "buffer": "^6.0.3",
+    "chalk": "^4.0.0",
     "debug": "^4.3.4",
     "usb": "^2.6.0",
     "xstate": "^4.32.1",

--- a/libs/custom-scanner/src/cli/demo/index.ts
+++ b/libs/custom-scanner/src/cli/demo/index.ts
@@ -1,117 +1,160 @@
+import { sleep } from '@votingworks/basics';
 import { Optional } from '@votingworks/types';
 import { Buffer } from 'buffer';
+import { assert } from 'console';
 import { writeFile } from 'fs/promises';
+import * as readline from 'readline';
 import { openScanner } from '../../open_scanner';
 import {
   DoubleSheetDetectOpt,
+  FormMovement,
   FormStanding,
   ImageColorDepthType,
   ImageResolution,
   ReleaseType,
   ScanParameters,
   ScanSide,
-  SensorStatus,
 } from '../../types';
 import { CustomScanner } from '../../types/custom_scanner';
-import { watchStatus } from '../../utils/status_watcher';
+// import { watchStatus } from '../../utils/status_watcher';
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
 
 /**
  * Simple demo program for using the Custom A4 scanner.
  */
 export async function main(): Promise<number> {
-  let scanner: Optional<CustomScanner>;
+  let initialScanner: Optional<CustomScanner>;
 
   process.on('SIGINT', async () => {
-    await scanner?.disconnect();
+    await initialScanner?.disconnect();
     process.exit(0);
   });
 
-  scanner = (await openScanner()).assertOk('failed to open scanner');
-
-  const model = (await scanner.getReleaseVersion(ReleaseType.Model)).assertOk(
-    'failed to get model'
-  );
-  const firmware = (
-    await scanner.getReleaseVersion(ReleaseType.Firmware)
-  ).assertOk('failed to get firmware');
-  const hardware = (
-    await scanner.getReleaseVersion(ReleaseType.Hardware)
-  ).assertOk('failed to get hardware');
-
-  console.log({ model, firmware, hardware });
-
-  const watcher = watchStatus(scanner);
-
-  process.stdout.write('> Waiting for paper to scan…\n');
-
-  for await (const result of watcher) {
-    if (result.isErr()) {
-      console.error(result.err());
-    } else {
-      const status = result.ok();
-
-      console.log(
-        `${status.isScanInProgress ? 'SCAN' : 'NO SCAN'}, ` +
-          `${status.isMotorOn ? 'MOVE' : 'NO MOVE'}, ` +
-          `LL ${SensorStatus[status.sensorInputLeftLeft]}, ` +
-          `CL ${SensorStatus[status.sensorInputCenterLeft]}, ` +
-          `CR ${SensorStatus[status.sensorInputCenterRight]}, ` +
-          `RR ${SensorStatus[status.sensorInputRightRight]}`
-      );
-
-      if (status.isTicketOnEnterA4 && !status.isMotorOn) {
-        watcher.stop();
-        console.log('Scanning…');
-        const scanParameters: ScanParameters = {
-          wantedScanSide: ScanSide.A_AND_B,
-          formStandingAfterScan: FormStanding.HOLD_TICKET,
-          resolution: ImageResolution.RESOLUTION_200_DPI,
-          imageColorDepth: ImageColorDepthType.Grey8bpp,
-          doubleSheetDetection: DoubleSheetDetectOpt.DetectOff,
-        };
-        const scanResult = await scanner.scan(scanParameters);
-
-        if (scanResult.isErr()) {
-          console.error('Scan failed:', scanResult.err());
-        } else {
-          const [sideA, sideB] = scanResult.ok();
-
-          console.log('Writing side A to sideA.pgm...');
-          await writeFile(
-            'sideA.pgm',
-            Buffer.concat([
-              Buffer.from('P5\n'),
-              Buffer.from(`${sideA.imageWidth} ${sideA.imageHeight}\n`),
-              Buffer.from('255\n'),
-              sideA.imageBuffer,
-            ])
-          );
-
-          console.log('Writing side B to sideB.pgm...');
-          await writeFile(
-            'sideB.pgm',
-            Buffer.concat([
-              Buffer.from('P5\n'),
-              Buffer.from(`${sideB.imageWidth} ${sideB.imageHeight}\n`),
-              Buffer.from('255\n'),
-              sideA.imageBuffer,
-            ])
-          );
+  function takeUserInput(scanner: CustomScanner) {
+    const helpInfo = `Command List  
+    exit - Disconnect the scanner
+    model - Print the model information
+    firmware - Print the firmware version
+    hardware - Print the hardware version 
+    status - Print the current scanner status
+    scan - Scan a sheet
+    reset - Reset the hardware, you will need to call reconnect after issuing this command.
+    connect - Calls connect on the scanner
+    disconnect - Calls disconnect on the scanner
+    reconnect - Establishes a fresh scanner connection
+    eject - Ejects the paper forward
+    retract - Retracts the paper
+    load - Loads paper 
+    `;
+    rl.question(`${helpInfo}\n Command: `, async (answer) => {
+      switch (answer) {
+        case 'exit': {
+          await scanner?.disconnect();
+          return rl.close();
         }
+        case 'model': {
+          const model = (
+            await scanner.getReleaseVersion(ReleaseType.Model)
+          ).assertOk('failed to get model');
+          console.log('Model is ', model);
+          return takeUserInput(scanner);
+        }
+        case 'firmware': {
+          const firmware = (
+            await scanner.getReleaseVersion(ReleaseType.Firmware)
+          ).assertOk('failed to get firmware');
+          console.log('Firmware is: ', firmware);
+          return takeUserInput(scanner);
+        }
+        case 'hardware': {
+          const hardware = (
+            await scanner.getReleaseVersion(ReleaseType.Hardware)
+          ).assertOk('failed to get hardware');
+          console.log('Hardware is: ', hardware);
+          return takeUserInput(scanner);
+        }
+        case 'status': {
+          const status = await scanner.getStatus();
+          console.log('Status is: ', status);
+          return takeUserInput(scanner);
+        }
+        case 'scan': {
+          const scanParameters: ScanParameters = {
+            wantedScanSide: ScanSide.A_AND_B,
+            formStandingAfterScan: FormStanding.HOLD_TICKET,
+            resolution: ImageResolution.RESOLUTION_200_DPI,
+            imageColorDepth: ImageColorDepthType.Grey8bpp,
+            doubleSheetDetection: DoubleSheetDetectOpt.DetectOff,
+          };
+          const scanResult = await scanner.scan(scanParameters);
 
-        // console.log(
-        //   'Move result:',
-        //   await scanner.move(FormMovement.EJECT_PAPER_FORWARD)
-        // );
-        // console.log('Start scan:', await scanner.startScan());
-        // setTimeout(async () => {
-        //   console.log('Stop scan:', await scanner?.stopScan());
-        // }, 1500);
+          if (scanResult.isErr()) {
+            console.error('Scan failed:', scanResult.err());
+          } else {
+            const [sideA, sideB] = scanResult.ok();
+
+            console.log('Writing side A to sideA.pgm...');
+            await writeFile(
+              'sideA.pgm',
+              Buffer.concat([
+                Buffer.from('P5\n'),
+                Buffer.from(`${sideA.imageWidth} ${sideA.imageHeight}\n`),
+                Buffer.from('255\n'),
+                sideA.imageBuffer,
+              ])
+            );
+
+            console.log('Writing side B to sideB.pgm...');
+            await writeFile(
+              'sideB.pgm',
+              Buffer.concat([
+                Buffer.from('P5\n'),
+                Buffer.from(`${sideB.imageWidth} ${sideB.imageHeight}\n`),
+                Buffer.from('255\n'),
+                sideA.imageBuffer,
+              ])
+            );
+          }
+          return takeUserInput(scanner);
+        }
+        case 'reset':
+          console.log(await scanner.resetHardware());
+          await sleep(500);
+          return takeUserInput(scanner);
+        case 'eject':
+          console.log(await scanner.move(FormMovement.EJECT_PAPER_FORWARD));
+          return takeUserInput(scanner);
+        case 'retract':
+          console.log(await scanner.move(FormMovement.RETRACT_PAPER_BACKWARD));
+          return takeUserInput(scanner);
+        case 'load':
+          console.log(await scanner.move(FormMovement.LOAD_PAPER));
+          return takeUserInput(scanner);
+        case 'connect':
+          console.log(await scanner.connect());
+          return takeUserInput(scanner);
+        case 'disconnect':
+          console.log(await scanner.disconnect());
+          return takeUserInput(scanner);
+        case 'reconnect': {
+          const newScanner = (await openScanner()).ok();
+          console.log(newScanner);
+          assert(newScanner);
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          return takeUserInput(newScanner!);
+        }
+        default:
+          console.log('invalid input');
+          return takeUserInput(scanner);
       }
-    }
+    });
   }
+  initialScanner = (await openScanner()).assertOk('failed to open scanner');
 
-  await scanner.disconnect();
-
+  takeUserInput(initialScanner);
   return 0;
 }

--- a/libs/custom-scanner/src/cli/demo/index.ts
+++ b/libs/custom-scanner/src/cli/demo/index.ts
@@ -1,12 +1,14 @@
+import chalk from 'chalk';
 import { sleep } from '@votingworks/basics';
 import { Optional } from '@votingworks/types';
 import { Buffer } from 'buffer';
-import { assert } from 'console';
 import { writeFile } from 'fs/promises';
 import * as readline from 'readline';
+import { inspect } from 'util';
 import { openScanner } from '../../open_scanner';
 import {
   DoubleSheetDetectOpt,
+  ErrorCode,
   FormMovement,
   FormStanding,
   ImageColorDepthType,
@@ -16,145 +18,204 @@ import {
   ScanSide,
 } from '../../types';
 import { CustomScanner } from '../../types/custom_scanner';
-// import { watchStatus } from '../../utils/status_watcher';
 
-const rl = readline.createInterface({
-  input: process.stdin,
-  output: process.stdout,
-});
+function readlines(prompt = '> '): AsyncIterableIterator<string> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  const iterator: AsyncIterableIterator<string> = {
+    [Symbol.asyncIterator]: () => iterator,
+    async next() {
+      return new Promise((resolve) => {
+        rl.question(prompt, (answer) => {
+          resolve({ done: false, value: answer });
+        });
+      });
+    },
+
+    return() {
+      rl.close();
+      return Promise.resolve({ done: true, value: undefined });
+    },
+  };
+
+  return iterator;
+}
 
 /**
  * Simple demo program for using the Custom A4 scanner.
  */
 export async function main(): Promise<number> {
-  let initialScanner: Optional<CustomScanner>;
+  const { stdout, stderr } = process;
+  let scanner: Optional<CustomScanner>;
 
   process.on('SIGINT', async () => {
-    await initialScanner?.disconnect();
+    await scanner?.disconnect();
     process.exit(0);
   });
 
-  function takeUserInput(scanner: CustomScanner) {
-    const helpInfo = `Command List  
-    exit - Disconnect the scanner
-    model - Print the model information
-    firmware - Print the firmware version
-    hardware - Print the hardware version 
-    status - Print the current scanner status
-    scan - Scan a sheet
-    reset - Reset the hardware, you will need to call reconnect after issuing this command.
-    connect - Calls connect on the scanner
-    disconnect - Calls disconnect on the scanner
-    reconnect - Establishes a fresh scanner connection
-    eject - Ejects the paper forward
-    retract - Retracts the paper
-    load - Loads paper 
-    `;
-    rl.question(`${helpInfo}\n Command: `, async (answer) => {
-      switch (answer) {
-        case 'exit': {
-          await scanner?.disconnect();
-          return rl.close();
-        }
-        case 'model': {
-          const model = (
-            await scanner.getReleaseVersion(ReleaseType.Model)
-          ).assertOk('failed to get model');
-          console.log('Model is ', model);
-          return takeUserInput(scanner);
-        }
-        case 'firmware': {
-          const firmware = (
-            await scanner.getReleaseVersion(ReleaseType.Firmware)
-          ).assertOk('failed to get firmware');
-          console.log('Firmware is: ', firmware);
-          return takeUserInput(scanner);
-        }
-        case 'hardware': {
-          const hardware = (
-            await scanner.getReleaseVersion(ReleaseType.Hardware)
-          ).assertOk('failed to get hardware');
-          console.log('Hardware is: ', hardware);
-          return takeUserInput(scanner);
-        }
-        case 'status': {
-          const status = await scanner.getStatus();
-          console.log('Status is: ', status);
-          return takeUserInput(scanner);
-        }
-        case 'scan': {
-          const scanParameters: ScanParameters = {
-            wantedScanSide: ScanSide.A_AND_B,
-            formStandingAfterScan: FormStanding.HOLD_TICKET,
-            resolution: ImageResolution.RESOLUTION_200_DPI,
-            imageColorDepth: ImageColorDepthType.Grey8bpp,
-            doubleSheetDetection: DoubleSheetDetectOpt.DetectOff,
-          };
-          const scanResult = await scanner.scan(scanParameters);
-
-          if (scanResult.isErr()) {
-            console.error('Scan failed:', scanResult.err());
-          } else {
-            const [sideA, sideB] = scanResult.ok();
-
-            console.log('Writing side A to sideA.pgm...');
-            await writeFile(
-              'sideA.pgm',
-              Buffer.concat([
-                Buffer.from('P5\n'),
-                Buffer.from(`${sideA.imageWidth} ${sideA.imageHeight}\n`),
-                Buffer.from('255\n'),
-                sideA.imageBuffer,
-              ])
-            );
-
-            console.log('Writing side B to sideB.pgm...');
-            await writeFile(
-              'sideB.pgm',
-              Buffer.concat([
-                Buffer.from('P5\n'),
-                Buffer.from(`${sideB.imageWidth} ${sideB.imageHeight}\n`),
-                Buffer.from('255\n'),
-                sideA.imageBuffer,
-              ])
-            );
-          }
-          return takeUserInput(scanner);
-        }
-        case 'reset':
-          console.log(await scanner.resetHardware());
-          await sleep(500);
-          return takeUserInput(scanner);
-        case 'eject':
-          console.log(await scanner.move(FormMovement.EJECT_PAPER_FORWARD));
-          return takeUserInput(scanner);
-        case 'retract':
-          console.log(await scanner.move(FormMovement.RETRACT_PAPER_BACKWARD));
-          return takeUserInput(scanner);
-        case 'load':
-          console.log(await scanner.move(FormMovement.LOAD_PAPER));
-          return takeUserInput(scanner);
-        case 'connect':
-          console.log(await scanner.connect());
-          return takeUserInput(scanner);
-        case 'disconnect':
-          console.log(await scanner.disconnect());
-          return takeUserInput(scanner);
-        case 'reconnect': {
-          const newScanner = (await openScanner()).ok();
-          console.log(newScanner);
-          assert(newScanner);
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          return takeUserInput(newScanner!);
-        }
-        default:
-          console.log('invalid input');
-          return takeUserInput(scanner);
-      }
-    });
+  async function reconnect(): Promise<void> {
+    scanner = (await openScanner()).assertOk('failed to open scanner');
   }
-  initialScanner = (await openScanner()).assertOk('failed to open scanner');
 
-  takeUserInput(initialScanner);
+  await reconnect();
+
+  function writeOutput(
+    message: unknown,
+    stream: NodeJS.WritableStream = stdout
+  ): void {
+    stream.write(
+      typeof message === 'string'
+        ? message
+        : inspect(message, { colors: stream === stdout || stream === stderr })
+    );
+    stream.write('\n');
+  }
+
+  const prompt = [
+    chalk.bold('Command List'),
+    'exit - Disconnect the scanner',
+    'model - Print the model information',
+    'firmware - Print the firmware version',
+    'hardware - Print the hardware version ',
+    'status - Print the current scanner status',
+    'scan - Scan a sheet',
+    'reset - Reset the hardware, you will need to call reconnect after issuing this command.',
+    'connect - Calls connect on the scanner',
+    'disconnect - Calls disconnect on the scanner',
+    'reconnect - Establishes a fresh scanner connection',
+    'eject - Ejects the paper forward',
+    'retract - Retracts the paper',
+    'load - Loads paper',
+    '',
+    chalk.bold('Enter a command: '),
+  ].join('\n');
+
+  for await (const line of readlines(prompt)) {
+    if (!scanner) {
+      break;
+    }
+
+    switch (line) {
+      case 'exit': {
+        await scanner.disconnect();
+        scanner = undefined;
+        break;
+      }
+
+      case 'model': {
+        const model = await scanner.getReleaseVersion(ReleaseType.Model);
+        writeOutput(model);
+        break;
+      }
+
+      case 'firmware': {
+        writeOutput(await scanner.getReleaseVersion(ReleaseType.Firmware));
+        break;
+      }
+
+      case 'hardware': {
+        writeOutput(await scanner.getReleaseVersion(ReleaseType.Hardware));
+        break;
+      }
+
+      case 'status': {
+        writeOutput(await scanner.getStatus());
+        break;
+      }
+
+      case 'scan': {
+        const scanParameters: ScanParameters = {
+          wantedScanSide: ScanSide.A_AND_B,
+          formStandingAfterScan: FormStanding.HOLD_TICKET,
+          resolution: ImageResolution.RESOLUTION_200_DPI,
+          imageColorDepth: ImageColorDepthType.Grey8bpp,
+          doubleSheetDetection: DoubleSheetDetectOpt.DetectOff,
+        };
+        const scanResult = await scanner.scan(scanParameters);
+
+        if (scanResult.isErr()) {
+          writeOutput(`Scan failed: ${inspect(scanResult.err())}`, stderr);
+        } else {
+          const [sideA, sideB] = scanResult.ok();
+
+          writeOutput('Writing side A to sideA.pgm...');
+          await writeFile(
+            'sideA.pgm',
+            Buffer.concat([
+              Buffer.from('P5\n'),
+              Buffer.from(`${sideA.imageWidth} ${sideA.imageHeight}\n`),
+              Buffer.from('255\n'),
+              sideA.imageBuffer,
+            ])
+          );
+
+          writeOutput('Writing side B to sideB.pgm...');
+          await writeFile(
+            'sideB.pgm',
+            Buffer.concat([
+              Buffer.from('P5\n'),
+              Buffer.from(`${sideB.imageWidth} ${sideB.imageHeight}\n`),
+              Buffer.from('255\n'),
+              sideA.imageBuffer,
+            ])
+          );
+        }
+        break;
+      }
+
+      case 'reset':
+        writeOutput(await scanner.resetHardware());
+        await sleep(500);
+        break;
+
+      case 'eject': {
+        const moveResult = await scanner.move(FormMovement.EJECT_PAPER_FORWARD);
+        writeOutput(
+          moveResult.isOk()
+            ? 'ejected'
+            : `failed to eject: ${ErrorCode[moveResult.err()]}`
+        );
+        break;
+      }
+
+      case 'retract':
+        writeOutput(await scanner.move(FormMovement.RETRACT_PAPER_BACKWARD));
+        break;
+
+      case 'load':
+        writeOutput(await scanner.move(FormMovement.LOAD_PAPER));
+        break;
+
+      case 'connect':
+        writeOutput(await scanner.connect());
+        break;
+
+      case 'disconnect':
+        writeOutput(await scanner.disconnect());
+        break;
+
+      case 'reconnect': {
+        await reconnect();
+        const newScanner = await openScanner();
+        writeOutput(newScanner);
+        scanner = newScanner.assertOk('failed to open scanner');
+        break;
+      }
+
+      default:
+        writeOutput('invalid input', stderr);
+        break;
+    }
+
+    if (!scanner) {
+      break;
+    }
+
+    writeOutput('');
+  }
+
   return 0;
 }

--- a/libs/custom-scanner/src/types/custom_scanner.ts
+++ b/libs/custom-scanner/src/types/custom_scanner.ts
@@ -60,7 +60,8 @@ export interface CustomScanner {
   ): Promise<Result<SheetOf<ImageFromScanner>, ErrorCode>>;
 
   /**
-   * Resets the hardware.
+   * Resets the hardware. Note that you MUST establish a connection
+   * with a new instance of CustomScanner after calling this command.
    */
   resetHardware(): Promise<Result<void, ErrorCode>>;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2401,6 +2401,7 @@ importers:
       '@votingworks/types': workspace:*
       '@votingworks/utils': workspace:*
       buffer: ^6.0.3
+      chalk: ^4.0.0
       debug: ^4.3.4
       esbuild: ^0.16.16
       esbuild-runner: ^2.2.2
@@ -2430,6 +2431,7 @@ importers:
       '@votingworks/types': link:../types
       '@votingworks/utils': link:../utils
       buffer: 6.0.3
+      chalk: 4.1.2
       debug: 4.3.4
       usb: 2.8.0
       xstate: 4.32.1


### PR DESCRIPTION
## Overview
Improves jam error handling to pause before retrying scanning which seems to prevent a variety of strange race conditions in the custom scanner. It also introduces a "jam_cleared" state where when all the paper sensors are 0 after a jam has been encountered we will try to reset the hardware, which involves issuing a reset command and then reestablishing a new connection to the scanner. If the jam is cleared the internal isPaperJam status of the custom scanner will reset to false by doing this.

In a second commit I made some changes to the demo program in libs/custom-scanner to make it easier to work with for manual testing. It's not that well thought out right now just calls anything you can call in Scanner, we should improve this in the future but I think its ok for now. 

## Demo Video or Screenshot

## Testing Plan
Manually tested the happy path of scanning, a forced jam mid scan, a forced jam on accepting a ballot, and janking the paper out once a scan has begun, saw acceptable responses in all cases. 

Manually tested the demo program with node bin/demo 

## Checklist

- [ ] I have added
      [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging)
      where appropriate to any new user actions, system updates such as file
      reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an
      announcement in #machine-product-updates
