### PR TITLE
Complete Java Card implementation of card programming methods

### DIFF
--- a/libs/auth/src/card_reader.ts
+++ b/libs/auth/src/card_reader.ts
@@ -86,10 +86,6 @@ export class CardReader {
     });
   }
 
-  getReaderStatus(): Reader['status'] {
-    return this.reader.status;
-  }
-
   /**
    * Transmits command APDUs to a smart card. On success, returns response data. On error, throws.
    * Specifically throws a ResponseApduError when a response APDU with a non-success status word is

--- a/libs/auth/src/certs.ts
+++ b/libs/auth/src/certs.ts
@@ -1,0 +1,111 @@
+import { Buffer } from 'buffer';
+import { z } from 'zod';
+import { assert, throwIllegalValue } from '@votingworks/basics';
+import { User } from '@votingworks/types';
+
+import { openssl } from './openssl';
+
+/**
+ * VotingWorks's IANA-assigned enterprise OID
+ */
+const VX_IANA_ENTERPRISE_OID = '1.3.6.1.4.1.59817';
+
+/**
+ * Instead of overloading existing X.509 cert fields, we're using our own custom cert fields.
+ */
+const VX_CUSTOM_CERT_FIELD = {
+  /** One of: card, admin, central-scan, mark, scan (the latter four referring to machines) */
+  COMPONENT: `${VX_IANA_ENTERPRISE_OID}.1`,
+  /** Format: {state-2-letter-abbreviation}.{county-or-town} (e.g. MS.Warren) */
+  JURISDICTION: `${VX_IANA_ENTERPRISE_OID}.2`,
+  /** One of: sa, em, pw (system administrator, election manager, or poll worker) */
+  CARD_TYPE: `${VX_IANA_ENTERPRISE_OID}.3`,
+  /** The SHA-256 hash of the election definition  */
+  ELECTION_HASH: `${VX_IANA_ENTERPRISE_OID}.4`,
+} as const;
+
+/**
+ * Parsed custom cert fields
+ */
+interface CustomCertFields {
+  component: 'card' | 'admin' | 'central-scan' | 'mark' | 'scan';
+  jurisdiction: string;
+  cardType?: 'sa' | 'em' | 'pw';
+  electionHash?: string;
+}
+
+/**
+ * A schema to facilitate parsing custom cert fields
+ */
+const CustomCertFieldsSchema: z.ZodSchema<CustomCertFields> = z.object({
+  component: z.enum(['card', 'admin', 'central-scan', 'mark', 'scan']),
+  jurisdiction: z.string(),
+  cardType: z.optional(z.enum(['sa', 'em', 'pw'])),
+  electionHash: z.optional(z.string()),
+});
+
+/**
+ * Parses the provided cert and returns the custom cert fields. Throws an error if the cert doesn't
+ * follow VotingWorks's cert format.
+ */
+export async function parseCert(cert: Buffer): Promise<CustomCertFields> {
+  const response = await openssl(['x509', '-noout', '-subject', '-in', cert]);
+
+  const responseString = response.toString();
+  assert(responseString.startsWith('subject='));
+  const certSubject = responseString.replace('subject=', '').trimEnd();
+
+  const certFieldsList = certSubject
+    .split(',')
+    .map((field) => field.trimStart());
+  const certFields: { [fieldName: string]: string } = {};
+  for (const certField of certFieldsList) {
+    const [fieldName, fieldValue] = certField.split(' = ');
+    if (fieldName && fieldValue) {
+      certFields[fieldName] = fieldValue;
+    }
+  }
+
+  const customCertFields = CustomCertFieldsSchema.parse({
+    component: certFields[VX_CUSTOM_CERT_FIELD.COMPONENT],
+    jurisdiction: certFields[VX_CUSTOM_CERT_FIELD.JURISDICTION],
+    cardType: certFields[VX_CUSTOM_CERT_FIELD.CARD_TYPE],
+    electionHash: certFields[VX_CUSTOM_CERT_FIELD.ELECTION_HASH],
+  });
+
+  return customCertFields;
+}
+
+/**
+ * Parses the provided cert and returns a user object. Throws an error if the cert doesn't follow
+ * VotingWorks's card cert format or isn't for the specified jurisdiction.
+ */
+export async function parseUserDataFromCert(
+  cert: Buffer,
+  expectedJurisdiction: string
+): Promise<User> {
+  const { component, jurisdiction, cardType, electionHash } = await parseCert(
+    cert
+  );
+  assert(component === 'card');
+  assert(jurisdiction === expectedJurisdiction);
+  assert(cardType !== undefined);
+
+  switch (cardType) {
+    case 'sa': {
+      return { role: 'system_administrator' };
+    }
+    case 'em': {
+      assert(electionHash !== undefined);
+      return { role: 'election_manager', electionHash };
+    }
+    case 'pw': {
+      assert(electionHash !== undefined);
+      return { role: 'poll_worker', electionHash };
+    }
+    /* istanbul ignore next: Compile-time check for completeness */
+    default: {
+      throwIllegalValue(cardType);
+    }
+  }
+}

--- a/libs/auth/src/certs.ts
+++ b/libs/auth/src/certs.ts
@@ -118,7 +118,7 @@ export async function parseUserDataFromCert(
 /**
  * Constructs a VotingWorks card cert subject that can be passed to an openssl command
  */
-export function constructCertSubject(
+export function constructCardCertSubject(
   user: SystemAdministratorUser | ElectionManagerUser | PollWorkerUser,
   jurisdiction: string
 ): string {

--- a/libs/auth/src/index.ts
+++ b/libs/auth/src/index.ts
@@ -1,4 +1,3 @@
-export * from './card';
 export * from './dipped_smart_card_auth_api';
 export * from './dipped_smart_card_auth';
 export * from './inserted_smart_card_auth_api';

--- a/libs/auth/src/java_card.ts
+++ b/libs/auth/src/java_card.ts
@@ -23,7 +23,7 @@ import {
 import { Card, CardStatus, CheckPinResponse } from './card';
 import { CardReader } from './card_reader';
 import {
-  constructCertSubject,
+  constructCardCertSubject,
   parseCert,
   parseUserDataFromCert,
 } from './certs';
@@ -246,7 +246,7 @@ export class JavaCard implements Card {
       pin
     );
     const cardVxAdminCert = await createCertBySigningPublicKey({
-      certSubject: constructCertSubject(input.user, this.jurisdiction),
+      certSubject: constructCardCertSubject(input.user, this.jurisdiction),
       opensslConfig: vxAdminOpensslConfigPath,
       publicKeyToSign: publicKey,
       signingCertAuthorityCert: vxAdminCertAuthorityCertPath,

--- a/libs/auth/src/java_card.ts
+++ b/libs/auth/src/java_card.ts
@@ -30,7 +30,7 @@ import {
 import {
   certDerToPem,
   certPemToDer,
-  createCertBySigningPublicKey,
+  createCert,
   extractPublicKeyFromCert,
   PUBLIC_KEY_IN_DER_FORMAT_HEADER,
   publicKeyDerToPem,
@@ -66,7 +66,7 @@ const DEFAULT_PIN = '000000';
 
 /**
  * The PIN unblocking key or PUK. Typically a sensitive value but not for us given our modification
- * to OpenFIPS201 to invalidate the card on PIN reset.
+ * to OpenFIPS201 to clear all PIN-gated keys on PIN reset, which invalidates the card.
  */
 const PUK = Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
 
@@ -245,7 +245,7 @@ export class JavaCard implements Card {
       CARD_VX_ADMIN_CERT.PRIVATE_KEY_SLOT,
       pin
     );
-    const cardVxAdminCert = await createCertBySigningPublicKey({
+    const cardVxAdminCert = await createCert({
       certSubject: constructCardCertSubject(input.user, this.jurisdiction),
       opensslConfig: vxAdminOpensslConfigPath,
       publicKeyToSign: publicKey,

--- a/libs/auth/src/java_card.ts
+++ b/libs/auth/src/java_card.ts
@@ -128,9 +128,9 @@ const GENERIC_STORAGE_SPACE = {
 } as const;
 
 /**
- * Additional constructor inputs that only VxAdmin needs to provide, for card programming
+ * Additional constructor inputs that only VxAdmin needs to provide for card programming
  */
-interface VxAdminParams {
+interface CardProgrammingParams {
   vxAdminCertAuthorityCertPath: string;
   vxAdminOpensslConfigPath: string;
   vxAdminPrivateKeyPassword: string;
@@ -143,20 +143,20 @@ interface VxAdminParams {
  * inspiration from the NIST PIV standard but diverges where PIV doesn't suit our needs.
  */
 export class JavaCard implements Card {
+  private readonly cardProgrammingParams?: CardProgrammingParams;
   private readonly cardReader: CardReader;
   private cardStatus: CardStatus;
   private readonly jurisdiction: string;
-  private readonly vxAdminParams?: VxAdminParams;
   private readonly vxCertAuthorityCertPath: string;
 
   constructor(input: {
+    cardProgrammingParams?: CardProgrammingParams;
     jurisdiction: string;
-    vxAdminParams?: VxAdminParams;
     vxCertAuthorityCertPath: string;
   }) {
+    this.cardProgrammingParams = input.cardProgrammingParams;
     this.cardStatus = { status: 'no_card' };
     this.jurisdiction = input.jurisdiction;
-    this.vxAdminParams = input.vxAdminParams;
     this.vxCertAuthorityCertPath = input.vxCertAuthorityCertPath;
 
     this.cardReader = new CardReader({
@@ -229,13 +229,13 @@ export class JavaCard implements Card {
       | { user: ElectionManagerUser; pin: string; electionData: string }
       | { user: PollWorkerUser }
   ): Promise<void> {
-    assert(this.vxAdminParams !== undefined);
+    assert(this.cardProgrammingParams !== undefined);
     const {
       vxAdminCertAuthorityCertPath,
       vxAdminOpensslConfigPath,
       vxAdminPrivateKeyPassword,
       vxAdminPrivateKeyPath,
-    } = this.vxAdminParams;
+    } = this.cardProgrammingParams;
     const pin = 'pin' in input ? input.pin : DEFAULT_PIN;
     await this.selectApplet();
 

--- a/libs/auth/src/openssl.ts
+++ b/libs/auth/src/openssl.ts
@@ -184,7 +184,7 @@ export async function verifySignature({
  * Creates a cert by signing a public key with a signing cert authority cert and private key. All
  * key and cert inputs should be in PEM format. The outputted cert will also be in PEM format.
  */
-export async function createCertBySigningPublicKey({
+export async function createCert({
   certSubject,
   opensslConfig,
   publicKeyToSign,

--- a/libs/auth/src/openssl.ts
+++ b/libs/auth/src/openssl.ts
@@ -4,6 +4,14 @@ import { existsSync } from 'fs';
 import * as fs from 'fs/promises';
 import { v4 as uuid } from 'uuid';
 
+/**
+ * The static header for a public key in DER format
+ */
+export const PUBLIC_KEY_IN_DER_FORMAT_HEADER = Buffer.from([
+  0x30, 0x59, 0x30, 0x13, 0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01,
+  0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07, 0x03, 0x42, 0x00,
+]);
+
 type OpensslParam = string | Buffer;
 
 /**
@@ -170,4 +178,53 @@ export async function verifySignature({
     challengeSignature,
     challenge,
   ]);
+}
+
+/**
+ * Creates a cert by signing a public key with a signing cert authority cert and private key. All
+ * key and cert inputs should be in PEM format. The outputted cert will also be in PEM format.
+ */
+export async function createCertBySigningPublicKey({
+  certSubject,
+  opensslConfig,
+  publicKeyToSign,
+  signingCertAuthorityCert,
+  signingPrivateKey,
+  signingPrivateKeyPassword,
+}: {
+  certSubject: string;
+  opensslConfig: FilePathOrBuffer;
+  publicKeyToSign: FilePathOrBuffer;
+  signingCertAuthorityCert: FilePathOrBuffer;
+  signingPrivateKey: FilePathOrBuffer;
+  signingPrivateKeyPassword: string;
+}): Promise<Buffer> {
+  const certSigningRequest = await openssl([
+    'req',
+    '-new',
+    '-config',
+    opensslConfig,
+    '-key',
+    signingPrivateKey,
+    '-passin',
+    `pass:${signingPrivateKeyPassword}`,
+    '-subj',
+    certSubject,
+  ]);
+  const cert = await openssl([
+    'x509',
+    '-req',
+    '-CA',
+    signingCertAuthorityCert,
+    '-CAkey',
+    signingPrivateKey,
+    '-passin',
+    `pass:${signingPrivateKeyPassword}`,
+    '-CAcreateserial',
+    '-in',
+    certSigningRequest,
+    '-force_pubkey',
+    publicKeyToSign,
+  ]);
+  return cert;
 }

--- a/libs/auth/src/piv.ts
+++ b/libs/auth/src/piv.ts
@@ -1,0 +1,94 @@
+import { Buffer } from 'buffer';
+import { assert } from '@votingworks/basics';
+import { Byte } from '@votingworks/types';
+
+import { STATUS_WORD } from './apdu';
+
+/**
+ * PIV-specific IDs for different cryptographic algorithms, e.g. ECC, RSA, etc.
+ */
+export const CRYPTOGRAPHIC_ALGORITHM_IDENTIFIER = {
+  /** Elliptic curve cryptography, curve P-256 */
+  ECC256: 0x11,
+} as const;
+
+/**
+ * The GENERAL AUTHENTICATE command is a PIV command that initiates an authentication protocol.
+ */
+export const GENERAL_AUTHENTICATE = {
+  INS: 0x87,
+  DYNAMIC_AUTHENTICATION_TEMPLATE_TAG: 0x7c,
+  CHALLENGE_TAG: 0x81,
+  RESPONSE_TAG: 0x82,
+} as const;
+
+/**
+ * The GET DATA command is a PIV command that retrieves a data object.
+ */
+export const GET_DATA = {
+  INS: 0xcb,
+  P1: 0x3f,
+  P2: 0xff,
+  TAG_LIST_TAG: 0x5c,
+} as const;
+
+/**
+ * The PUT DATA command is a PIV command that stores a data object.
+ */
+export const PUT_DATA = {
+  INS: 0xdb,
+  P1: 0x3f,
+  P2: 0xff,
+  TAG_LIST_TAG: 0x5c,
+  DATA_TAG: 0x53,
+} as const;
+
+/**
+ * The VERIFY command is a PIV command that performs various forms of user verification, including
+ * PIN checks.
+ */
+export const VERIFY = {
+  INS: 0x20,
+  P1_VERIFY: 0x00,
+  P2_PIN: 0x80,
+} as const;
+
+/**
+ * Data object IDs of the format 0x5f 0xc1 0xXX are a PIV convention.
+ */
+export function pivDataObjectId(uniqueByte: Byte): Buffer {
+  return Buffer.from([0x5f, 0xc1, uniqueByte]);
+}
+
+/**
+ * Converts a PIN to the padded 8-byte buffer that the VERIFY command expects
+ */
+export function construct8BytePinBuffer(pin: string): Buffer {
+  return Buffer.concat([
+    Buffer.from(pin, 'utf-8'),
+    Buffer.from([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]), // Padding
+  ]).subarray(0, 8);
+}
+
+/**
+ * The incorrect-PIN status word has the format 0x63 0xcX, where X is the number of remaining PIN
+ * entry attempts before complete lockout (X being a hex digit).
+ */
+export function isIncorrectPinStatusWord(statusWord: [Byte, Byte]): boolean {
+  const [sw1, sw2] = statusWord;
+  // eslint-disable-next-line no-bitwise
+  return sw1 === STATUS_WORD.VERIFY_FAIL.SW1 && sw2 >> 4 === 0x0c;
+}
+
+/**
+ * See isIncorrectPinStatusWord().
+ */
+export function numRemainingAttemptsFromIncorrectPinStatusWord(
+  statusWord: [Byte, Byte]
+): number {
+  assert(isIncorrectPinStatusWord(statusWord));
+  const [, sw2] = statusWord;
+  // Extract the last 4 bits of SW2
+  // eslint-disable-next-line no-bitwise
+  return sw2 & 0x0f;
+}

--- a/libs/auth/src/piv.ts
+++ b/libs/auth/src/piv.ts
@@ -23,6 +23,17 @@ export const GENERAL_AUTHENTICATE = {
 } as const;
 
 /**
+ * The GENERATE ASYMMETRIC KEY PAIR command is a PIV command that generates an asymmetric key pair.
+ * The public key is exported, and the private key never leaves the card.
+ */
+export const GENERATE_ASYMMETRIC_KEY_PAIR = {
+  INS: 0x47,
+  P1: 0x00,
+  CRYPTOGRAPHIC_ALGORITHM_IDENTIFIER_TEMPLATE_TAG: 0xac,
+  CRYPTOGRAPHIC_ALGORITHM_IDENTIFIER_TAG: 0x80,
+} as const;
+
+/**
  * The GET DATA command is a PIV command that retrieves a data object.
  */
 export const GET_DATA = {
@@ -41,6 +52,20 @@ export const PUT_DATA = {
   P2: 0xff,
   TAG_LIST_TAG: 0x5c,
   DATA_TAG: 0x53,
+  CERT_TAG: 0x70,
+  CERT_INFO_TAG: 0x71,
+  CERT_INFO_UNCOMPRESSED: 0x00,
+  ERROR_DETECTION_CODE_TAG: 0xfe,
+} as const;
+
+/**
+ * The RESET RETRY COUNTER command is a PIV command that changes the card PIN given the PUK (PIN
+ * unblocking key) and resets the remaining PIN entry attempts count to its initial value.
+ */
+export const RESET_RETRY_COUNTER = {
+  INS: 0x2c,
+  P1: 0x00,
+  P2: 0x80,
 } as const;
 
 /**

--- a/libs/auth/test/utils.ts
+++ b/libs/auth/test/utils.ts
@@ -1,4 +1,4 @@
-import { Card } from '../src';
+import { Card } from '../src/card';
 
 /**
  * Builds a mock card instance


### PR DESCRIPTION
_Reviewing by commit recommended_

## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/2909

This PR completes the Java Card implementation of the card API's card programming methods (`program` and `unprogram`). By extension, this completes the Java Card implementation of the card API!

It also cleans up existing Java Card code, better organizing across files:

- `openssl.ts` - Generic openssl commands (not VotingWorks-specific)
- `piv.ts` - PIV standards (not VotingWorks-specific)
- `certs.ts` - VotingWorks-specific cert logic
- `java_card.ts` - Top-level logic

## Testing

- [x] Manually tested programming and unprogramming

Automated tests will be coming in follow-up PRs!

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ Coming in follow-up PRs
- [x] I have added JSDoc comments to any newly introduced exports