### PR TITLE
handle single sided blank ballots properly

### DIFF
--- a/services/scan/src/precinct_scanner_interpreter.ts
+++ b/services/scan/src/precinct_scanner_interpreter.ts
@@ -89,12 +89,14 @@ function combinePageInterpretationsForSheet(
     let reasons: AdjudicationReasonInfo[];
     // If both sides are blank, the ballot is blank
     if (
-      frontReasons.some(
+      (frontReasons.some(
         (reason) => reason.type === AdjudicationReason.BlankBallot
-      ) &&
-      backReasons.some(
+      ) ||
+        front.interpretation.markInfo.marks.length === 0) &&
+      (backReasons.some(
         (reason) => reason.type === AdjudicationReason.BlankBallot
-      )
+      ) ||
+        back.interpretation.markInfo.marks.length === 0)
     ) {
       reasons = [{ type: AdjudicationReason.BlankBallot }];
     }


### PR DESCRIPTION
In a different part of the code this is the logic for figuring out if a sheet requires adjudication, both pages must be "blank" but any pages with 0 possible marks are automatically considered blank, so I'm updating this part of the code that tells the state machine what to tell the frontend about the adjudication reason to do the same thing 