### PR TITLE
Fix blank ballot adjudication on precinct scanner

### DIFF
--- a/apps/scan/backend/src/interpret.ts
+++ b/apps/scan/backend/src/interpret.ts
@@ -90,12 +90,14 @@ function combinePageInterpretationsForSheet(
     let reasons: AdjudicationReasonInfo[];
     // If both sides are blank, the ballot is blank
     if (
-      frontReasons.some(
+      (frontReasons.some(
         (reason) => reason.type === AdjudicationReason.BlankBallot
-      ) &&
-      backReasons.some(
+      ) ||
+        front.interpretation.markInfo.marks.length === 0) &&
+      (backReasons.some(
         (reason) => reason.type === AdjudicationReason.BlankBallot
-      )
+      ) ||
+        back.interpretation.markInfo.marks.length === 0)
     ) {
       reasons = [{ type: AdjudicationReason.BlankBallot }];
     }


### PR DESCRIPTION
## Overview
Fixes a bug where if a ballot is blank, the BlankBallot adjudication reason will not work properly if there are only contests on one side of the ballot in precinct-scanner. It will be marked as requiring adjudication as the code in vx_interpret does the right thing, but this part of the code does not (why is this logic duplicated?). Testing this would be complicated as I don't think we have an election definition that has this case so I'm just fixing the bug right now. 
<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added
      [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging)
      where appropriate to any new user actions, system updates such as file
      reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an
      announcement in #machine-product-updates
