### PR TITLE
[VxScan] Make sure prod app and preview app share global styles/themes

### DIFF
--- a/apps/scan/frontend/src/app.tsx
+++ b/apps/scan/frontend/src/app.tsx
@@ -4,8 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { getHardware } from '@votingworks/utils';
 import { Logger, LogSource } from '@votingworks/logging';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { AppBase, ErrorBoundary, Text } from '@votingworks/ui';
-import { ColorMode } from '@votingworks/types';
+import { ErrorBoundary, Text } from '@votingworks/ui';
 import { AppRoot, Props as AppRootProps } from './app_root';
 import {
   ApiClient,
@@ -15,6 +14,7 @@ import {
 } from './api';
 import { TimesCircle } from './components/graphics';
 import { CenteredLargeProse } from './components/layout';
+import { ScanAppBase } from './scan_app_base';
 
 export interface AppProps {
   hardware?: AppRootProps['hardware'];
@@ -29,37 +29,27 @@ export function App({
   apiClient = createApiClient(),
   queryClient = createQueryClient(),
 }: AppProps): JSX.Element {
-  // Copied from old App.css
-  const baseFontSizePx = 28;
-
-  // TODO: Default to high contrast and vary based on user selection.
-  const colorMode: ColorMode = 'legacy';
-
   return (
-    <BrowserRouter>
-      <ErrorBoundary
-        errorMessage={
-          <React.Fragment>
-            <TimesCircle />
-            <CenteredLargeProse>
-              <h1>Something went wrong</h1>
-              <Text>Ask a poll worker to restart the scanner.</Text>
-            </CenteredLargeProse>
-          </React.Fragment>
-        }
-      >
-        <ApiClientContext.Provider value={apiClient}>
-          <QueryClientProvider client={queryClient}>
-            <AppBase
-              colorMode={colorMode}
-              isTouchscreen
-              legacyBaseFontSizePx={baseFontSizePx}
-            >
+    <ScanAppBase>
+      <BrowserRouter>
+        <ErrorBoundary
+          errorMessage={
+            <React.Fragment>
+              <TimesCircle />
+              <CenteredLargeProse>
+                <h1>Something went wrong</h1>
+                <Text>Ask a poll worker to restart the scanner.</Text>
+              </CenteredLargeProse>
+            </React.Fragment>
+          }
+        >
+          <ApiClientContext.Provider value={apiClient}>
+            <QueryClientProvider client={queryClient}>
               <AppRoot hardware={hardware} logger={logger} />
-            </AppBase>
-          </QueryClientProvider>
-        </ApiClientContext.Provider>
-      </ErrorBoundary>
-    </BrowserRouter>
+            </QueryClientProvider>
+          </ApiClientContext.Provider>
+        </ErrorBoundary>
+      </BrowserRouter>
+    </ScanAppBase>
   );
 }

--- a/apps/scan/frontend/src/preview_app.tsx
+++ b/apps/scan/frontend/src/preview_app.tsx
@@ -27,35 +27,38 @@ import * as SetupScannerScreen from './screens/setup_scanner_screen';
 import * as UnconfiguredElectionScreen from './screens/unconfigured_election_screen';
 import * as UnconfiguredPrecinctScreen from './screens/unconfigured_precinct_screen';
 import * as ReplaceBallotBagScreen from './components/replace_ballot_bag_screen';
+import { ScanAppBase } from './scan_app_base';
 
 export function PreviewApp(): JSX.Element {
   return (
-    <PreviewDashboard
-      electionDefinitions={[
-        electionSampleDefinition,
-        primaryElectionSampleDefinition,
-        electionWithMsEitherNeitherDefinition,
-      ]}
-      modules={[
-        CardErrorScreen,
-        ElectionManagerScreen,
-        InsertBallotScreen,
-        InvalidCardScreen,
-        LoadingConfigurationScreen,
-        PollsNotOpenScreen,
-        PollWorkerScreen,
-        ScanErrorScreen,
-        ScanProcessingScreen,
-        ScanSuccessScreen,
-        ScanWarningScreen,
-        ScanReturnedBallotScreen,
-        ScanJamScreen,
-        ScanBusyScreen,
-        SetupScannerScreen,
-        UnconfiguredElectionScreen,
-        UnconfiguredPrecinctScreen,
-        ReplaceBallotBagScreen,
-      ]}
-    />
+    <ScanAppBase>
+      <PreviewDashboard
+        electionDefinitions={[
+          electionSampleDefinition,
+          primaryElectionSampleDefinition,
+          electionWithMsEitherNeitherDefinition,
+        ]}
+        modules={[
+          CardErrorScreen,
+          ElectionManagerScreen,
+          InsertBallotScreen,
+          InvalidCardScreen,
+          LoadingConfigurationScreen,
+          PollsNotOpenScreen,
+          PollWorkerScreen,
+          ScanErrorScreen,
+          ScanProcessingScreen,
+          ScanSuccessScreen,
+          ScanWarningScreen,
+          ScanReturnedBallotScreen,
+          ScanJamScreen,
+          ScanBusyScreen,
+          SetupScannerScreen,
+          UnconfiguredElectionScreen,
+          UnconfiguredPrecinctScreen,
+          ReplaceBallotBagScreen,
+        ]}
+      />
+    </ScanAppBase>
   );
 }

--- a/apps/scan/frontend/src/scan_app_base.tsx
+++ b/apps/scan/frontend/src/scan_app_base.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import { AppBase } from '@votingworks/ui';
+
+export interface AppBaseProps {
+  children: React.ReactNode;
+}
+
+// Copied from old App.css
+const BASE_FONT_SIZE_PX = 28;
+
+// TODO: Default to high contrast and vary based on user selection.
+const DEFAULT_COLOR_MODE = 'legacy';
+
+/**
+ * Installs global styles and UI themes - should be rendered at the root of the
+ * app before anything else.
+ */
+export function ScanAppBase({ children }: AppBaseProps): JSX.Element {
+  return (
+    <AppBase
+      colorMode={DEFAULT_COLOR_MODE}
+      isTouchscreen
+      legacyBaseFontSizePx={BASE_FONT_SIZE_PX}
+    >
+      {children}
+    </AppBase>
+  );
+}


### PR DESCRIPTION
## Overview
Related to: https://github.com/votingworks/vxsuite/issues/2744

- Creating a `ScanAppBase` that renders `libs/ui/AppBase` with the VxScan defaults, so they can be shared between the production app and preview app.
- Also moving the app base to the top level of the render tree to make sure all components use the global styles/themes (including the newly added top-level `ErrorBoundary`)

## Demo Video or Screenshot

### Before/After:
<img width="350" alt="Screenshot 2023-03-02 at 14 48 00" src="https://user-images.githubusercontent.com/264902/222548541-0da485ba-4d62-43a0-b40c-5bde1549c097.png"> <img width="350" alt="Screenshot 2023-03-02 at 14 48 19" src="https://user-images.githubusercontent.com/264902/222548590-04c5ec2b-af96-4ecf-9464-290cd72be295.png">

## Testing Plan
N/A - No functional changes

## Checklist

- [N/A] I have added
      [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging)
      where appropriate to any new user actions, system updates such as file
      reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [n/a] I have added the "user_facing_change" label to this PR to automate an
      announcement in #machine-product-updates
