### PR TITLE
Support save PDF option in all places we print from vxadmin

### DIFF
--- a/apps/admin/frontend/jest.config.js
+++ b/apps/admin/frontend/jest.config.js
@@ -27,7 +27,7 @@ module.exports = {
     global: {
       statements: 83,
       branches: 70,
-      functions: 81,
+      functions: 80.5,
       lines: 83,
     },
   },

--- a/apps/admin/frontend/src/app.test.tsx
+++ b/apps/admin/frontend/src/app.test.tsx
@@ -396,7 +396,7 @@ test('L&A (logic and accuracy) flow', async () => {
 
   // Test printing L&A package
   userEvent.click(screen.getByText('List Precinct L&A Packages'));
-  userEvent.click(screen.getByText('District 5'));
+  userEvent.click(screen.getByText('Print District 5'));
 
   // L&A package: Tally report
   await screen.findByText('Printing L&A Package for District 5', {
@@ -869,7 +869,7 @@ test('tabulating CVRs with manual data', async () => {
     'External Results (Manually Added Data)'
   ).closest('tr')!;
   domGetByText(manualRow, '100');
-  domGetByText(manualRow, 'District 5');
+  domGetByText(manualRow, 'Print District 5');
 
   fireEvent.click(getByText('Reports'));
   getByText('External Results (Manually Added Data)');
@@ -903,7 +903,7 @@ test('tabulating CVRs with manual data', async () => {
   fireEvent.click(await screen.findByText('Edit Manually Entered Results'));
 
   // Existing data is still there
-  const district5Row = getByText('District 5').closest('tr')!;
+  const district5Row = getByText('Print District 5').closest('tr')!;
   expect(domGetByTestId(district5Row, 'numBallots')!.textContent).toEqual(
     '100'
   );

--- a/apps/admin/frontend/src/app.test.tsx
+++ b/apps/admin/frontend/src/app.test.tsx
@@ -869,7 +869,7 @@ test('tabulating CVRs with manual data', async () => {
     'External Results (Manually Added Data)'
   ).closest('tr')!;
   domGetByText(manualRow, '100');
-  domGetByText(manualRow, 'Print District 5');
+  domGetByText(manualRow, 'District 5');
 
   fireEvent.click(getByText('Reports'));
   getByText('External Results (Manually Added Data)');
@@ -903,7 +903,7 @@ test('tabulating CVRs with manual data', async () => {
   fireEvent.click(await screen.findByText('Edit Manually Entered Results'));
 
   // Existing data is still there
-  const district5Row = getByText('Print District 5').closest('tr')!;
+  const district5Row = getByText('District 5').closest('tr')!;
   expect(domGetByTestId(district5Row, 'numBallots')!.textContent).toEqual(
     '100'
   );

--- a/apps/admin/frontend/src/components/full_test_deck_tally_report_button.test.tsx
+++ b/apps/admin/frontend/src/components/full_test_deck_tally_report_button.test.tsx
@@ -72,13 +72,11 @@ test('prints appropriate report for general election', async () => {
 
 test('renders SaveFileToUsb component for saving PDF', async () => {
   const usbDrive = mockUsbDrive('mounted');
-  const { unmount } = renderInAppContext(<FullTestDeckTallyReportButton />, {
+  renderInAppContext(<FullTestDeckTallyReportButton />, {
     electionDefinition: electionFamousNames2021Fixtures.electionDefinition,
     usbDrive,
   });
   userEvent.click(screen.getByText('Save Full Test Deck Tally Report as PDF'));
   const modal = await screen.findByRole('alertdialog');
   within(modal).getByText('Save Test Deck Tally Report');
-
-  unmount();
 });

--- a/apps/admin/frontend/src/components/full_test_deck_tally_report_button.test.tsx
+++ b/apps/admin/frontend/src/components/full_test_deck_tally_report_button.test.tsx
@@ -3,11 +3,22 @@ import {
   electionFamousNames2021Fixtures,
   electionMinimalExhaustiveSampleDefinition,
 } from '@votingworks/fixtures';
-import { expectPrint } from '@votingworks/test-utils';
+import { expectPrint, fakeKiosk, fakeUsbDrive } from '@votingworks/test-utils';
 import React from 'react';
 import { screen, within } from '../../test/react_testing_library';
 import { renderInAppContext } from '../../test/render_in_app_context';
 import { FullTestDeckTallyReportButton } from './full_test_deck_tally_report_button';
+import { mockUsbDrive } from '../../test/helpers/mock_usb_drive';
+import { fakeFileWriter } from '../../test/helpers/fake_file_writer';
+
+beforeEach(() => {
+  const mockKiosk = fakeKiosk();
+  mockKiosk.getUsbDriveInfo.mockResolvedValue([fakeUsbDrive()]);
+  const fileWriter = fakeFileWriter();
+  mockKiosk.saveAs = jest.fn().mockResolvedValue(fileWriter);
+  mockKiosk.writeFile = jest.fn().mockResolvedValue(fileWriter);
+  window.kiosk = mockKiosk;
+});
 
 test('prints appropriate reports for primary election', async () => {
   renderInAppContext(<FullTestDeckTallyReportButton />, {
@@ -57,4 +68,17 @@ test('prints appropriate report for general election', async () => {
 
     expect(printOptions).toMatchObject({ sides: 'one-sided' });
   });
+});
+
+test('renders SaveFileToUsb component for saving PDF', async () => {
+  const usbDrive = mockUsbDrive('mounted');
+  const { unmount } = renderInAppContext(<FullTestDeckTallyReportButton />, {
+    electionDefinition: electionFamousNames2021Fixtures.electionDefinition,
+    usbDrive,
+  });
+  userEvent.click(screen.getByText('Save Full Test Deck Tally Report as PDF'));
+  const modal = await screen.findByRole('alertdialog');
+  within(modal).getByText('Save Test Deck Tally Report');
+
+  unmount();
 });

--- a/apps/admin/frontend/src/components/full_test_deck_tally_report_button.test.tsx
+++ b/apps/admin/frontend/src/components/full_test_deck_tally_report_button.test.tsx
@@ -80,3 +80,16 @@ test('renders SaveFileToUsb component for saving PDF', async () => {
   const modal = await screen.findByRole('alertdialog');
   within(modal).getByText('Save Test Deck Tally Report');
 });
+
+test('closes SaveFileToUsb modal', async () => {
+  const usbDrive = mockUsbDrive('mounted');
+  renderInAppContext(<FullTestDeckTallyReportButton />, {
+    electionDefinition: electionFamousNames2021Fixtures.electionDefinition,
+    usbDrive,
+  });
+  userEvent.click(screen.getByText('Save Full Test Deck Tally Report as PDF'));
+  const modal = await screen.findByRole('alertdialog');
+  within(modal).getByText('Save Test Deck Tally Report');
+  userEvent.click(screen.getByText('Cancel'));
+  expect(screen.queryByRole('alertdialog')).toEqual(null);
+});

--- a/apps/admin/frontend/src/components/full_test_deck_tally_report_button.tsx
+++ b/apps/admin/frontend/src/components/full_test_deck_tally_report_button.tsx
@@ -51,10 +51,9 @@ export function FullTestDeckTallyReportButton(): JSX.Element {
   }, [logger, userRole, fullTestDeckTallyReport]);
 
   const onClickSaveFullTestDeckTallyReportToPdf = useCallback(async () => {
-    // TODO add new logging event
-    await logger.log(LogEventId.TestDeckTallyReportPrinted, userRole, {
+    await logger.log(LogEventId.TestDeckTallyReportSavedToPdf, userRole, {
       disposition: 'na',
-      message: 'User clicked "Save PDF"',
+      message: 'User attempted to save full test deck tally report to PDF',
     });
     setIsSaveModalOpen(true);
   }, [logger, userRole]);

--- a/apps/admin/frontend/src/components/full_test_deck_tally_report_button.tsx
+++ b/apps/admin/frontend/src/components/full_test_deck_tally_report_button.tsx
@@ -1,38 +1,44 @@
-import React, { useContext, useCallback } from 'react';
+import React, { useContext, useCallback, useState, useMemo } from 'react';
 import { assert } from '@votingworks/basics';
 import { LogEventId } from '@votingworks/logging';
 
-import { printElement } from '@votingworks/ui';
+import { Button, printElement, printElementToPdf } from '@votingworks/ui';
 import { isElectionManagerAuth } from '@votingworks/utils';
 import { AppContext } from '../contexts/app_context';
 import { TestDeckTallyReport } from './test_deck_tally_report';
 import { generateTestDeckBallots } from '../utils/election';
+import { generateDefaultReportFilename } from '../utils/save_as_pdf';
+import { SaveFileToUsb, FileType } from './save_file_to_usb';
 import { PrintButton } from './print_button';
 
 export function FullTestDeckTallyReportButton(): JSX.Element {
   const { auth, electionDefinition, logger } = useContext(AppContext);
+  const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
   assert(isElectionManagerAuth(auth));
   const userRole = auth.user.role;
 
   assert(electionDefinition);
   const { election } = electionDefinition;
 
+  const ballots = generateTestDeckBallots({ election });
+  // Full test deck tallies should be 4 times that of a single test deck because
+  // it counts scanning 2 test decks (BMD + HMPB) twice (VxScan + VxCentralScan)
+  const fullTestDeckTallyReport = useMemo(
+    () => (
+      <TestDeckTallyReport
+        election={election}
+        testDeckBallots={[...ballots, ...ballots, ...ballots, ...ballots]}
+      />
+    ),
+    [election, ballots]
+  );
+
   const printFullTestDeckTallyReport = useCallback(async () => {
     try {
-      const ballots = generateTestDeckBallots({ election });
-      // Full test deck tallies should be 4 times that of a single test deck because
-      // it counts scanning 2 test decks (BMD + HMPB) twice (VxScan + VxCentralScan)
-      const fullTestDeckTallyReport = (
-        <TestDeckTallyReport
-          election={election}
-          testDeckBallots={[...ballots, ...ballots, ...ballots, ...ballots]}
-        />
-      );
-
       await printElement(fullTestDeckTallyReport, { sides: 'one-sided' });
       await logger.log(LogEventId.TestDeckTallyReportPrinted, userRole, {
         disposition: 'success',
-        message: `User printed the full test deck tally report`,
+        message: 'User printed the full test deck tally report',
       });
     } catch (error) {
       assert(error instanceof Error);
@@ -42,11 +48,40 @@ export function FullTestDeckTallyReportButton(): JSX.Element {
         result: 'User shown error.',
       });
     }
-  }, [election, logger, userRole]);
+  }, [logger, userRole, fullTestDeckTallyReport]);
+
+  const onClickSaveFullTestDeckTallyReportToPdf = useCallback(async () => {
+    // TODO add new logging event
+    await logger.log(LogEventId.TestDeckTallyReportPrinted, userRole, {
+      disposition: 'na',
+      message: 'User clicked "Save PDF"',
+    });
+    setIsSaveModalOpen(true);
+  }, [logger, userRole]);
+
+  const defaultReportFilename = generateDefaultReportFilename(
+    'full-test-deck-tally-report',
+    election
+  );
 
   return (
-    <PrintButton print={printFullTestDeckTallyReport}>
-      Print Full Test Deck Tally Report
-    </PrintButton>
+    <React.Fragment>
+      <PrintButton print={printFullTestDeckTallyReport}>
+        Print Full Test Deck Tally Report
+      </PrintButton>{' '}
+      {window.kiosk && (
+        <Button onPress={onClickSaveFullTestDeckTallyReportToPdf}>
+          Save Full Test Deck Tally Report as PDF
+        </Button>
+      )}
+      {isSaveModalOpen && (
+        <SaveFileToUsb
+          onClose={() => setIsSaveModalOpen(false)}
+          generateFileContent={() => printElementToPdf(fullTestDeckTallyReport)}
+          defaultFilename={defaultReportFilename}
+          fileType={FileType.TestDeckTallyReport}
+        />
+      )}
+    </React.Fragment>
   );
 }

--- a/apps/admin/frontend/src/components/save_file_to_usb.tsx
+++ b/apps/admin/frontend/src/components/save_file_to_usb.tsx
@@ -25,6 +25,8 @@ export const UsbImage = styled.img`
 
 export enum FileType {
   TallyReport = 'TallyReport',
+  PrintedBallotsReport = 'PrintedBallotReport',
+  LogicAndAccuracyPackage = 'LogicAndAccuracyPackage',
   TestDeckTallyReport = 'TestDeckTallyReport',
   Ballot = 'Ballot',
   Results = 'Results',
@@ -70,6 +72,14 @@ export function SaveFileToUsb({
     case FileType.TallyReport:
       title = `${isOfficialResults ? 'Official' : 'Unofficial'} Tally Report`;
       fileName = 'tally report';
+      break;
+    case FileType.PrintedBallotsReport:
+      title = 'Printed Ballots Report';
+      fileName = 'printed ballots report';
+      break;
+    case FileType.LogicAndAccuracyPackage:
+      title = 'Logic & Accuracy Package';
+      fileName = 'logic and accuracy package';
       break;
     case FileType.TestDeckTallyReport:
       title = 'Test Deck Tally Report';

--- a/apps/admin/frontend/src/screens/print_test_deck_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/print_test_deck_screen.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { electionMinimalExhaustiveSampleDefinition } from '@votingworks/fixtures';
 import userEvent from '@testing-library/user-event';
 import { BallotPaperSize, Printer } from '@votingworks/types';
 import {
@@ -53,12 +54,27 @@ afterAll(() => {
 test('Saving L&A package for one precinct', () => {
   const usbDrive = mockUsbDrive('mounted');
   renderInAppContext(<PrintTestDeckScreen />, {
+    electionDefinition: electionMinimalExhaustiveSampleDefinition,
     logger: mockLogger,
     usbDrive,
   });
 
-  userEvent.click(screen.getByText('Save District 5 to PDF'));
+  userEvent.click(screen.getByText('Save Precinct 1 to PDF'));
   screen.getByText('Save Logic & Accuracy Package');
+  screen.getByText('Save');
+});
+
+test('Saving L&A package for all precincts', () => {
+  const usbDrive = mockUsbDrive('mounted');
+  renderInAppContext(<PrintTestDeckScreen />, {
+    electionDefinition: electionMinimalExhaustiveSampleDefinition,
+    logger: mockLogger,
+    usbDrive,
+  });
+
+  userEvent.click(screen.getByText('Save Packages for All Precincts as PDF'));
+  screen.getByText('Save Logic & Accuracy Package');
+  screen.getByText('Save');
 });
 
 test('Printing L&A package for one precinct', async () => {

--- a/apps/admin/frontend/src/screens/print_test_deck_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/print_test_deck_screen.test.tsx
@@ -10,9 +10,12 @@ import {
   fakeKiosk,
   fakePrinter,
   fakePrinterInfo,
+  fakeUsbDrive,
 } from '@votingworks/test-utils';
 import { LogEventId, Logger, LogSource } from '@votingworks/logging';
 import { screen, waitFor } from '../../test/react_testing_library';
+import { mockUsbDrive } from '../../test/helpers/mock_usb_drive';
+import { fakeFileWriter } from '../../test/helpers/fake_file_writer';
 
 import {
   LAST_PRINT_JOB_SLEEP_MS,
@@ -37,10 +40,25 @@ beforeEach(() => {
   window.kiosk = mockKiosk;
   mockLogger = new Logger(LogSource.VxAdminFrontend, mockKiosk);
   mockPrinter = fakePrinter();
+  mockKiosk.getUsbDriveInfo.mockResolvedValue([fakeUsbDrive()]);
+  const fileWriter = fakeFileWriter();
+  mockKiosk.saveAs = jest.fn().mockResolvedValue(fileWriter);
+  mockKiosk.writeFile = jest.fn().mockResolvedValue(fileWriter);
 });
 
 afterAll(() => {
   delete window.kiosk;
+});
+
+test('Saving L&A package for one precinct', () => {
+  const usbDrive = mockUsbDrive('mounted');
+  renderInAppContext(<PrintTestDeckScreen />, {
+    logger: mockLogger,
+    usbDrive,
+  });
+
+  userEvent.click(screen.getByText('Save District 5 to PDF'));
+  screen.getByText('Save Logic & Accuracy Package');
 });
 
 test('Printing L&A package for one precinct', async () => {
@@ -48,7 +66,7 @@ test('Printing L&A package for one precinct', async () => {
     logger: mockLogger,
   });
 
-  userEvent.click(screen.getByText('District 5'));
+  userEvent.click(screen.getByText('Print District 5'));
 
   await screen.findByText('Printing L&A Package for District 5');
   await expectPrint((printedElement, printOptions) => {
@@ -96,7 +114,7 @@ test('Printing L&A package for one precinct', async () => {
   );
   jest.advanceTimersByTime(LAST_PRINT_JOB_SLEEP_MS);
 
-  await screen.findByText('District 5');
+  await screen.findByText('Print District 5');
   expect(screen.queryByText('Printing')).not.toBeInTheDocument();
 });
 
@@ -202,7 +220,7 @@ test('Printing L&A package for one precinct, when HMPBs are not letter-size', as
     printer: mockPrinter,
   });
 
-  userEvent.click(screen.getByText('District 5'));
+  userEvent.click(screen.getByText('Print District 5'));
 
   await screen.findByText('Printing L&A Package for District 5');
   await screen.findByText('Currently printing letter-size pages.');
@@ -257,7 +275,7 @@ test('Printing L&A package for one precinct, when HMPBs are not letter-size', as
   );
   jest.advanceTimersByTime(LAST_PRINT_JOB_SLEEP_MS);
 
-  await screen.findByText('District 5');
+  await screen.findByText('Print District 5');
   expect(screen.queryByText('Printing')).not.toBeInTheDocument();
 });
 

--- a/apps/admin/frontend/src/screens/print_test_deck_screen.tsx
+++ b/apps/admin/frontend/src/screens/print_test_deck_screen.tsx
@@ -424,7 +424,11 @@ export function PrintTestDeckScreen(): JSX.Element {
       return (
         <React.Fragment key={precinctId}>
           {PrecinctTallyReport({ election, precinctId })}
-          {getBmdPaperBallots({ electionDefinition, precinctId })}
+          {getBmdPaperBallots({
+            electionDefinition,
+            precinctId,
+            generateBallotId,
+          })}
           <React.Fragment>
             {handMarkedPaperBallotCallbacks.map(
               (handMarkedPaperBallotWithCallback) =>
@@ -434,7 +438,7 @@ export function PrintTestDeckScreen(): JSX.Element {
         </React.Fragment>
       );
     },
-    [election, electionDefinition]
+    [election, electionDefinition, generateBallotId]
   );
 
   // printLogicAndAccuracyPackageToPdf prints the L&A package for all precincts to PDF format.

--- a/apps/admin/frontend/src/screens/print_test_deck_screen.tsx
+++ b/apps/admin/frontend/src/screens/print_test_deck_screen.tsx
@@ -17,7 +17,6 @@ import {
   Modal,
   Prose,
   HorizontalRule,
-  precinctNameFromId,
   printElement,
   printElementWhenReady,
   printElementToPdfWhenReady,
@@ -250,6 +249,10 @@ export function PrintTestDeckScreen(): JSX.Element {
   const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
   const [precinctToSaveToPdf, setPrecinctToSaveToPdf] =
     useState<PrecinctId>('all');
+  const currentPrecinct = getPrecinctById({
+    election,
+    precinctId: precinctToSaveToPdf,
+  });
 
   const pageTitle = 'Precinct L&A Packages';
 
@@ -429,12 +432,10 @@ export function PrintTestDeckScreen(): JSX.Element {
             precinctId,
             generateBallotId,
           })}
-          <React.Fragment>
-            {handMarkedPaperBallotCallbacks.map(
-              (handMarkedPaperBallotWithCallback) =>
-                handMarkedPaperBallotWithCallback(onRendered)
-            )}
-          </React.Fragment>
+          {handMarkedPaperBallotCallbacks.map(
+            (handMarkedPaperBallotWithCallback) =>
+              handMarkedPaperBallotWithCallback(onRendered)
+          )}
         </React.Fragment>
       );
     },
@@ -612,7 +613,7 @@ export function PrintTestDeckScreen(): JSX.Element {
             election,
             precinctToSaveToPdf === 'all'
               ? 'all-precincts'
-              : precinctNameFromId(election, precinctToSaveToPdf)
+              : currentPrecinct?.name
           )}
           fileType={FileType.LogicAndAccuracyPackage}
         />

--- a/apps/admin/frontend/src/screens/print_test_deck_screen.tsx
+++ b/apps/admin/frontend/src/screens/print_test_deck_screen.tsx
@@ -599,6 +599,7 @@ export function PrintTestDeckScreen(): JSX.Element {
                       Save {p.name} to PDF
                     </Button>
                   )}
+                  <p />
                 </React.Fragment>
               ))}
           </ButtonList>

--- a/apps/admin/frontend/src/screens/print_test_deck_screen.tsx
+++ b/apps/admin/frontend/src/screens/print_test_deck_screen.tsx
@@ -610,7 +610,7 @@ export function PrintTestDeckScreen(): JSX.Element {
               ? 'all-precincts'
               : precinctNameFromId(election, precinctToSaveToPdf)
           )}
-          fileType={FileType.TestDeckTallyReport}
+          fileType={FileType.LogicAndAccuracyPackage}
         />
       )}
     </React.Fragment>

--- a/apps/admin/frontend/src/screens/printed_ballots_report_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/printed_ballots_report_screen.test.tsx
@@ -1,0 +1,31 @@
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { electionMinimalExhaustiveSampleDefinition } from '@votingworks/fixtures';
+import React from 'react';
+import { fakeKiosk, fakeUsbDrive } from '@votingworks/test-utils';
+import { renderInAppContext } from '../../test/render_in_app_context';
+import { PrintedBallotsReportScreen } from './printed_ballots_report_screen';
+import { mockUsbDrive } from '../../test/helpers/mock_usb_drive';
+import { fakeFileWriter } from '../../test/helpers/fake_file_writer';
+
+beforeEach(() => {
+  const mockKiosk = fakeKiosk();
+  mockKiosk.getUsbDriveInfo.mockResolvedValue([fakeUsbDrive()]);
+  const fileWriter = fakeFileWriter();
+  mockKiosk.saveAs = jest.fn().mockResolvedValue(fileWriter);
+  mockKiosk.writeFile = jest.fn().mockResolvedValue(fileWriter);
+  window.kiosk = mockKiosk;
+});
+
+test('renders SaveFileToUsb component for saving PDF', async () => {
+  const usbDrive = mockUsbDrive('mounted');
+  const { unmount } = renderInAppContext(<PrintedBallotsReportScreen />, {
+    electionDefinition: electionMinimalExhaustiveSampleDefinition,
+    usbDrive,
+  });
+  userEvent.click(screen.getByText('Save Report to PDF'));
+  const modal = await screen.findByRole('alertdialog');
+  within(modal).getByText('Save Printed Ballots Report');
+
+  unmount();
+});

--- a/apps/admin/frontend/src/screens/printed_ballots_report_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/printed_ballots_report_screen.test.tsx
@@ -19,13 +19,11 @@ beforeEach(() => {
 
 test('renders SaveFileToUsb component for saving PDF', async () => {
   const usbDrive = mockUsbDrive('mounted');
-  const { unmount } = renderInAppContext(<PrintedBallotsReportScreen />, {
+  renderInAppContext(<PrintedBallotsReportScreen />, {
     electionDefinition: electionMinimalExhaustiveSampleDefinition,
     usbDrive,
   });
   userEvent.click(screen.getByText('Save Report to PDF'));
   const modal = await screen.findByRole('alertdialog');
   within(modal).getByText('Save Printed Ballots Report');
-
-  unmount();
 });

--- a/apps/admin/frontend/src/screens/printed_ballots_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/printed_ballots_report_screen.tsx
@@ -265,7 +265,7 @@ export function PrintedBallotsReportScreen(): JSX.Element {
             'printed-ballots-report',
             election
           )}
-          fileType={FileType.TestDeckTallyReport}
+          fileType={FileType.PrintedBallotsReport}
         />
       )}
     </React.Fragment>

--- a/apps/admin/frontend/src/screens/tally_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally_report_screen.tsx
@@ -6,11 +6,14 @@ import {
 } from '@votingworks/utils';
 import { assert, find } from '@votingworks/basics';
 import { LogEventId } from '@votingworks/logging';
-import { VotingMethod, getLabelForVotingMethod } from '@votingworks/types';
+import {
+  VotingMethod,
+  getLabelForVotingMethod,
+  getPrecinctById,
+} from '@votingworks/types';
 import {
   Button,
   Modal,
-  precinctNameFromId,
   printElement,
   printElementToPdf,
   Prose,
@@ -76,7 +79,7 @@ export function TallyReportScreen(): JSX.Element {
   const { election } = electionDefinition;
   const statusPrefix = isOfficialResults ? 'Official' : 'Unofficial';
 
-  const precinctName = precinctNameFromId(election, precinctId);
+  const precinctName = getPrecinctById({ election, precinctId })?.name;
 
   const fileSuffix = useMemo(() => {
     if (scannerId) {

--- a/apps/admin/frontend/src/screens/tally_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally_report_screen.tsx
@@ -10,6 +10,7 @@ import { VotingMethod, getLabelForVotingMethod } from '@votingworks/types';
 import {
   Button,
   Modal,
+  precinctNameFromId,
   printElement,
   printElementToPdf,
   Prose,
@@ -75,11 +76,7 @@ export function TallyReportScreen(): JSX.Element {
   const { election } = electionDefinition;
   const statusPrefix = isOfficialResults ? 'Official' : 'Unofficial';
 
-  const precinctName =
-    (precinctId &&
-      precinctId !== 'all' &&
-      find(election.precincts, (p) => p.id === precinctId).name) ||
-    undefined;
+  const precinctName = precinctNameFromId(election, precinctId);
 
   const fileSuffix = useMemo(() => {
     if (scannerId) {

--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -206,6 +206,10 @@ IDs are logged with each log to identify the log being written.
 **Type:** [user-action](#user-action)  
 **Description:** User printed the test deck tally report. Success or failure indicated by disposition.  
 **Machines:** vx-admin-frontend
+### test-deck-tally-report-saved-to-pdf
+**Type:** [user-action](#user-action)  
+**Description:** User attempted to save the test deck tally report as PDF. Success or failure indicated by subsequent FileSaved log disposition.  
+**Machines:** vx-admin-frontend
 ### toggle-test-mode-init
 **Type:** [user-action](#user-action)  
 **Description:** User has initiated toggling between test mode and live mode in the current application.  

--- a/libs/logging/src/log_documentation.test.ts
+++ b/libs/logging/src/log_documentation.test.ts
@@ -27,7 +27,7 @@ describe('test cdf documentation generation', () => {
     expect(structuredData.DeviceModel).toEqual('VxAdmin 1.0');
     expect(structuredData.GeneratedDate).toEqual('2020-07-24T00:00:00.000Z');
     expect(structuredData.EventTypeDescription).toHaveLength(5);
-    expect(structuredData.EventIdDescription).toHaveLength(53);
+    expect(structuredData.EventIdDescription).toHaveLength(54);
     // Make sure VxAdminFrontend specific logs are included.
     expect(structuredData.EventIdDescription).toContainEqual(
       expect.objectContaining({

--- a/libs/logging/src/log_event_ids.ts
+++ b/libs/logging/src/log_event_ids.ts
@@ -3,10 +3,11 @@ import { LogEventType } from './log_event_types';
 import { LogSource } from './log_source';
 
 /**
- * In order to add a new log event you must do three things:
+ * In order to add a new log event you must do four things:
  * 1. Add the new event to the enum LogEventId
  * 2. Define a LogDetails object representing the information about that log event.
  * 3. Add a case statement to the switch in getDetailsForEventId returning your new LogDetails object when you see your new LogEventId.
+ * 4. Update the test expectation for number of EventIdDescriptions in libs/logging/src/log_documentation.test.ts
  * You will then be ready to use the log event from your code!
  */
 

--- a/libs/logging/src/log_event_ids.ts
+++ b/libs/logging/src/log_event_ids.ts
@@ -67,6 +67,7 @@ export enum LogEventId {
   ConvertingResultsToSemsFormat = 'converting-to-sems',
   TestDeckPrinted = 'test-deck-printed',
   TestDeckTallyReportPrinted = 'test-deck-tally-report-printed',
+  TestDeckTallyReportSavedToPdf = 'test-deck-tally-report-saved-to-pdf',
   // VxCentralScan specific user action logs
   TogglingTestMode = 'toggle-test-mode-init',
   ToggledTestMode = 'toggled-test-mode',
@@ -463,6 +464,14 @@ const TestDeckTallyReportPrinted: LogDetails = {
   eventType: LogEventType.UserAction,
   documentationMessage:
     'User printed the test deck tally report. Success or failure indicated by disposition.',
+  restrictInDocumentationToApps: [LogSource.VxAdminFrontend],
+};
+
+const TestDeckTallyReportSavedToPdf: LogDetails = {
+  eventId: LogEventId.TestDeckTallyReportSavedToPdf,
+  eventType: LogEventType.UserAction,
+  documentationMessage:
+    'User attempted to save the test deck tally report as PDF. Success or failure indicated by subsequent FileSaved log disposition.',
   restrictInDocumentationToApps: [LogSource.VxAdminFrontend],
 };
 
@@ -955,6 +964,8 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return TestDeckPrinted;
     case LogEventId.TestDeckTallyReportPrinted:
       return TestDeckTallyReportPrinted;
+    case LogEventId.TestDeckTallyReportSavedToPdf:
+      return TestDeckTallyReportSavedToPdf;
     case LogEventId.TogglingTestMode:
       return TogglingTestMode;
     case LogEventId.ToggledTestMode:

--- a/libs/ui/src/print_element.tsx
+++ b/libs/ui/src/print_element.tsx
@@ -2,9 +2,14 @@ import React, { useEffect } from 'react';
 import ReactDom from 'react-dom';
 import styled from 'styled-components';
 
-import { ElementWithCallback, PrintOptions } from '@votingworks/types';
+import {
+  Election,
+  ElementWithCallback,
+  PrecinctId,
+  PrintOptions,
+} from '@votingworks/types';
 import { getPrinter } from '@votingworks/utils';
-import { assert } from '@votingworks/basics';
+import { assert, find } from '@votingworks/basics';
 
 const PrintOnly = styled.div`
   @media screen {
@@ -157,4 +162,16 @@ export async function printElementToPdf(
   element: JSX.Element
 ): Promise<Uint8Array> {
   return printElementSuper(element, printToPdf);
+}
+
+export function precinctNameFromId(
+  election: Election,
+  precinctId: PrecinctId
+): string | undefined {
+  return (
+    (precinctId &&
+      precinctId !== 'all' &&
+      find(election.precincts, (p) => p.id === precinctId).name) ||
+    undefined
+  );
 }

--- a/libs/ui/src/print_element.tsx
+++ b/libs/ui/src/print_element.tsx
@@ -2,14 +2,9 @@ import React, { useEffect } from 'react';
 import ReactDom from 'react-dom';
 import styled from 'styled-components';
 
-import {
-  Election,
-  ElementWithCallback,
-  PrecinctId,
-  PrintOptions,
-} from '@votingworks/types';
+import { ElementWithCallback, PrintOptions } from '@votingworks/types';
 import { getPrinter } from '@votingworks/utils';
-import { assert, find } from '@votingworks/basics';
+import { assert } from '@votingworks/basics';
 
 const PrintOnly = styled.div`
   @media screen {
@@ -162,16 +157,4 @@ export async function printElementToPdf(
   element: JSX.Element
 ): Promise<Uint8Array> {
   return printElementSuper(element, printToPdf);
-}
-
-export function precinctNameFromId(
-  election: Election,
-  precinctId: PrecinctId
-): string | undefined {
-  return (
-    (precinctId &&
-      precinctId !== 'all' &&
-      find(election.precincts, (p) => p.id === precinctId).name) ||
-    undefined
-  );
 }


### PR DESCRIPTION
## Overview
Adds a "Save PDF" option in all places we were missing it in VxAdmin.

## Demo Video or Screenshot
![Screenshot 2023-03-03 at 3 21 17 PM](https://user-images.githubusercontent.com/1060688/222853560-e5f2cf8b-7275-4c59-a54d-135ec271072b.png)
![Screenshot 2023-03-03 at 3 21 20 PM](https://user-images.githubusercontent.com/1060688/222853564-9d38e9a5-1815-4c9d-98a9-e245ad498452.png)
![Screenshot 2023-03-03 at 3 21 26 PM](https://user-images.githubusercontent.com/1060688/222853567-f28b45ef-1599-4dde-8360-0a19523fad83.png)

## Testing Plan
Added simple tests for render of `SaveFileToUsb` modal. There are 2 options for more robust tests
1. Trust that SaveFileToUsb is covered by its own tests; validate that `SaveFileToUsb` is wired up with the correct props in each case
2. Write a functional test with mock USB to assert files are saved with the correct data

## Checklist

- [x] I have added
      [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging)
      where appropriate to any new user actions, system updates such as file
      reads or storage writes, or errors introduced.
  - The existing SaveFileToUsb component logs when file writing succeeds or fails
- [x] I have added JSDoc comments to any newly introduced exports
  - no new exports
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an
      announcement in #machine-product-updates
