### PR TITLE
Improve Custom State Machine Handling

### DIFF
--- a/apps/scan/backend/src/types.ts
+++ b/apps/scan/backend/src/types.ts
@@ -94,6 +94,7 @@ export type PrecinctScannerErrorType =
   | 'both_sides_have_paper'
   | 'paper_in_back_after_accept'
   | 'paper_in_front_after_reconnect'
+  | 'paper_in_both_sides_after_reconnect'
   | 'paper_in_back_after_reconnect'
   | 'unexpected_paper_status'
   | 'unexpected_event'

--- a/apps/scan/frontend/src/screens/scan_error_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_error_screen.tsx
@@ -47,6 +47,7 @@ export function ScanErrorScreen({
       case 'scanning_failed':
       case 'both_sides_have_paper':
       case 'paper_in_front_after_reconnect':
+      case 'paper_in_both_sides_after_reconnect':
       case 'paper_in_back_after_reconnect':
       case 'paper_in_back_after_accept':
         return 'Remove ballot to continue.';

--- a/libs/custom-scanner/.gitignore
+++ b/libs/custom-scanner/.gitignore
@@ -1,0 +1,2 @@
+sideA.pgm
+sideB.pgm


### PR DESCRIPTION
Makes a few changes to the state machine:

- If paper is seen when an accept is processing, it will be interrupted with a load paper command and the first sheet will be accepted. If the second sheet is in the scanner after this it will be rejected forward and scanned through as well.
- If the scanner cover opens we will go to internal connection problem screen until closed
- If the scanner disconnects it now properly goes to the disconnected state so that it recovers when reconnected

I also noticed we were handling jams strangely in debugging issues here and I think we need to handle jams that are unexpected situations we treat like a jam differently from when the scanner is actually telling us there is a jam. We do not need to do the resetHardware thing when the scanner isn't telling us there is a jam. So this separates those ideas. 

I also improved handling of both_sides_have_paper throughout, most notably when the app first loads, to reject the paper and not go into the state for handling both sides having paper while a scan is processing, which is a different action. 

Something about these changes I believe also fixed the issue with restarting the scanner while in a jam state as I can not repro's Roe's behavior there but I will confirm with him. 

