### PR TITLE
Re-add auth logging

### DIFF
--- a/apps/admin/backend/src/server.ts
+++ b/apps/admin/backend/src/server.ts
@@ -926,6 +926,7 @@ export async function start({
         config: {
           allowElectionManagersToAccessUnconfiguredMachines: false,
         },
+        logger,
       }),
       workspace: resolvedWorkspace,
     });

--- a/apps/central-scan/backend/src/server.ts
+++ b/apps/central-scan/backend/src/server.ts
@@ -88,6 +88,7 @@ export async function start({
         config: {
           allowElectionManagersToAccessUnconfiguredMachines: true,
         },
+        logger,
       }),
       exporter: resolvedExporter,
       importer: resolvedImporter,

--- a/apps/mark/backend/src/server.ts
+++ b/apps/mark/backend/src/server.ts
@@ -28,6 +28,7 @@ export function start({
       ],
       allowElectionManagersToAccessMachinesConfiguredForOtherElections: true,
     },
+    logger,
   });
   const app = buildApp(auth);
 

--- a/apps/scan/backend/src/server.ts
+++ b/apps/scan/backend/src/server.ts
@@ -37,6 +37,7 @@ export function start({
         'poll_worker',
       ],
     },
+    logger,
   });
   const usb: Usb = { getUsbDrives };
   const app = buildApp(

--- a/libs/auth/src/dipped_smart_card_auth.test.ts
+++ b/libs/auth/src/dipped_smart_card_auth.test.ts
@@ -1,3 +1,5 @@
+import { fakeLogger } from '@votingworks/logging';
+
 import { buildMockCard } from '../test/utils';
 import { DippedSmartCardAuth } from './dipped_smart_card_auth';
 
@@ -7,7 +9,11 @@ beforeEach(() => {
 
 test('DippedSmartCardAuth returns auth status', async () => {
   const card = buildMockCard();
-  const auth = new DippedSmartCardAuth({ card, config: {} });
+  const auth = new DippedSmartCardAuth({
+    card,
+    config: {},
+    logger: fakeLogger(),
+  });
   expect(await auth.getAuthStatus({ electionHash: undefined })).toEqual({
     status: 'logged_out',
     reason: 'machine_locked',

--- a/libs/auth/src/inserted_smart_card_auth.test.ts
+++ b/libs/auth/src/inserted_smart_card_auth.test.ts
@@ -1,3 +1,5 @@
+import { fakeLogger } from '@votingworks/logging';
+
 import { buildMockCard } from '../test/utils';
 import { InsertedSmartCardAuth } from './inserted_smart_card_auth';
 
@@ -9,6 +11,7 @@ test('InsertedSmartCardAuth returns auth status', async () => {
   const auth = new InsertedSmartCardAuth({
     card: buildMockCard(),
     config: { allowedUserRoles: [] },
+    logger: fakeLogger(),
   });
   expect(await auth.getAuthStatus({ electionHash: undefined })).toEqual({
     status: 'logged_out',

--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -46,13 +46,13 @@ IDs are logged with each log to identify the log being written.
 **Type:** [user-action](#user-action)  
 **Description:** A user attempted to enter a PIN to log in.  
 **Machines:** All
-### auth-logout
-**Type:** [user-action](#user-action)  
-**Description:** A user logged out.  
-**Machines:** All
 ### auth-login
 **Type:** [user-action](#user-action)  
 **Description:** A user attempted to log in. Disposition is success if they logged in, failure if not. An optional reason may be provided.  
+**Machines:** All
+### auth-logout
+**Type:** [user-action](#user-action)  
+**Description:** A user logged out.  
 **Machines:** All
 ### usb-drive-detected
 **Type:** [application-status](#application-status)  
@@ -138,26 +138,22 @@ IDs are logged with each log to identify the log being written.
 **Type:** [user-action](#user-action)  
 **Description:** Report of all printed ballots was printed. Success or failure indicated by the disposition.  
 **Machines:** vx-admin-frontend
-### smartcard-program-init
+### smart-card-program-init
 **Type:** [user-action](#user-action)  
-**Description:** A smartcard is being programmed for a specific user role. The user role is indicated by the programmedUserRole key.  
-**Machines:** vx-admin-frontend
-### smartcard-program-complete
+**Description:** A smart card is being programmed. The new smart card user role is indicated by the programmedUserRole key.  
+**Machines:** vx-admin-service
+### smart-card-program-complete
 **Type:** [user-action](#user-action)  
-**Description:** A smartcard has been programmed for a specific user role. The user role is indicated by the programmedUserRole key. Success or failure is indicated by the disposition.  
-**Machines:** vx-admin-frontend
-### smartcard-unprogram-init
+**Description:** A smart card has been programmed. The new smart card user role is indicated by the programmedUserRole key. Success or failure is indicated by the disposition.  
+**Machines:** vx-admin-service
+### smart-card-unprogram-init
 **Type:** [user-action](#user-action)  
-**Description:** A smartcard is being unprogrammed. The current smartcard user role is indicated by the programmedUserRole key.  
-**Machines:** vx-admin-frontend
-### smartcard-unprogram-complete
+**Description:** A smart card is being unprogrammed. The current smart card user role is indicated by the programmedUserRole key.  
+**Machines:** vx-admin-service
+### smart-card-unprogram-complete
 **Type:** [user-action](#user-action)  
-**Description:** A smartcard has been unprogrammed. The previous (or current in the case of failure) smartcard user role is indicated by the previousProgrammedUserRole (or programmedUserRole in the case of failure) key. Success or failure is indicated by the disposition.  
-**Machines:** vx-admin-frontend
-### smartcard-programmed-override-write-protection
-**Type:** [user-action](#user-action)  
-**Description:** Smartcard is programmed to override a flag protecting writes on the card. By default admin cards can not be written unless write protection is first overridden.  
-**Machines:** vx-admin-frontend
+**Description:** A smart card has been unprogrammed. The previous (or current in the case of failure) smart card user role is indicated by the previousProgrammedUserRole (or programmedUserRole in the case of failure) key. Success or failure is indicated by the disposition.  
+**Machines:** vx-admin-service
 ### cvr-loaded
 **Type:** [user-action](#user-action)  
 **Description:** User loaded CVR to the machine. Success or failure indicated by disposition.  

--- a/libs/logging/src/log_documentation.test.ts
+++ b/libs/logging/src/log_documentation.test.ts
@@ -27,7 +27,7 @@ describe('test cdf documentation generation', () => {
     expect(structuredData.DeviceModel).toEqual('VxAdmin 1.0');
     expect(structuredData.GeneratedDate).toEqual('2020-07-24T00:00:00.000Z');
     expect(structuredData.EventTypeDescription).toHaveLength(5);
-    expect(structuredData.EventIdDescription).toHaveLength(58);
+    expect(structuredData.EventIdDescription).toHaveLength(53);
     // Make sure VxAdminFrontend specific logs are included.
     expect(structuredData.EventIdDescription).toContainEqual(
       expect.objectContaining({

--- a/libs/logging/src/log_event_ids.ts
+++ b/libs/logging/src/log_event_ids.ts
@@ -20,10 +20,10 @@ export enum LogEventId {
   MachineShutdownInit = 'machine-shutdown-init',
   MachineShutdownComplete = 'machine-shutdown-complete',
   UsbDeviceChangeDetected = 'usb-device-change-detected',
-  // Authentication related logs
+  // Auth logs
   AuthPinEntry = 'auth-pin-entry',
-  AuthLogout = 'auth-logout',
   AuthLogin = 'auth-login',
+  AuthLogout = 'auth-logout',
   // USB related logs
   UsbDriveDetected = 'usb-drive-detected',
   UsbDriveRemoved = 'usb-drive-removed',
@@ -50,13 +50,10 @@ export enum LogEventId {
   SaveBallotPackageComplete = 'save-ballot-package-complete',
   BallotPrinted = 'ballot-printed',
   PrintedBallotReportPrinted = 'printed-ballot-report-printed',
-  SmartcardProgramInit = 'smartcard-program-init',
-  SmartcardProgramComplete = 'smartcard-program-complete',
-  SmartcardUnprogramInit = 'smartcard-unprogram-init',
-  SmartcardUnprogramComplete = 'smartcard-unprogram-complete',
-  // TODO(https://github.com/votingworks/vxsuite/issues/2085):
-  // Remove SmartcardProgrammedOverrideWriteProtection when removing legacy smartcards screen
-  SmartcardProgrammedOverrideWriteProtection = 'smartcard-programmed-override-write-protection',
+  SmartCardProgramInit = 'smart-card-program-init',
+  SmartCardProgramComplete = 'smart-card-program-complete',
+  SmartCardUnprogramInit = 'smart-card-unprogram-init',
+  SmartCardUnprogramComplete = 'smart-card-unprogram-complete',
   CvrLoaded = 'cvr-loaded',
   CvrFilesReadFromUsb = 'cvr-files-read-from-usb',
   RecomputingTally = 'recompute-tally-init',
@@ -349,40 +346,33 @@ const FileSaved: LogDetails = {
     'File is saved to a USB drive. Success or failure indicated by disposition. Type of file specified with "fileType" key. For success logs the saved filename specified with "filename" key.',
 };
 
-const SmartcardProgramInit: LogDetails = {
-  eventId: LogEventId.SmartcardProgramInit,
+const SmartCardProgramInit: LogDetails = {
+  eventId: LogEventId.SmartCardProgramInit,
   eventType: LogEventType.UserAction,
   documentationMessage:
-    'A smartcard is being programmed for a specific user role. The user role is indicated by the programmedUserRole key.',
-  restrictInDocumentationToApps: [LogSource.VxAdminFrontend],
+    'A smart card is being programmed. The new smart card user role is indicated by the programmedUserRole key.',
+  restrictInDocumentationToApps: [LogSource.VxAdminService],
 };
-const SmartcardProgramComplete: LogDetails = {
-  eventId: LogEventId.SmartcardProgramComplete,
+const SmartCardProgramComplete: LogDetails = {
+  eventId: LogEventId.SmartCardProgramComplete,
   eventType: LogEventType.UserAction,
   documentationMessage:
-    'A smartcard has been programmed for a specific user role. The user role is indicated by the programmedUserRole key. Success or failure is indicated by the disposition.',
-  restrictInDocumentationToApps: [LogSource.VxAdminFrontend],
+    'A smart card has been programmed. The new smart card user role is indicated by the programmedUserRole key. Success or failure is indicated by the disposition.',
+  restrictInDocumentationToApps: [LogSource.VxAdminService],
 };
-const SmartcardUnprogramInit: LogDetails = {
-  eventId: LogEventId.SmartcardUnprogramInit,
+const SmartCardUnprogramInit: LogDetails = {
+  eventId: LogEventId.SmartCardUnprogramInit,
   eventType: LogEventType.UserAction,
   documentationMessage:
-    'A smartcard is being unprogrammed. The current smartcard user role is indicated by the programmedUserRole key.',
-  restrictInDocumentationToApps: [LogSource.VxAdminFrontend],
+    'A smart card is being unprogrammed. The current smart card user role is indicated by the programmedUserRole key.',
+  restrictInDocumentationToApps: [LogSource.VxAdminService],
 };
-const SmartcardUnprogramComplete: LogDetails = {
-  eventId: LogEventId.SmartcardUnprogramComplete,
+const SmartCardUnprogramComplete: LogDetails = {
+  eventId: LogEventId.SmartCardUnprogramComplete,
   eventType: LogEventType.UserAction,
   documentationMessage:
-    'A smartcard has been unprogrammed. The previous (or current in the case of failure) smartcard user role is indicated by the previousProgrammedUserRole (or programmedUserRole in the case of failure) key. Success or failure is indicated by the disposition.',
-  restrictInDocumentationToApps: [LogSource.VxAdminFrontend],
-};
-const SmartcardProgrammedOverrideWriteProtection: LogDetails = {
-  eventId: LogEventId.SmartcardProgrammedOverrideWriteProtection,
-  eventType: LogEventType.UserAction,
-  documentationMessage:
-    'Smartcard is programmed to override a flag protecting writes on the card. By default admin cards can not be written unless write protection is first overridden.',
-  restrictInDocumentationToApps: [LogSource.VxAdminFrontend],
+    'A smart card has been unprogrammed. The previous (or current in the case of failure) smart card user role is indicated by the previousProgrammedUserRole (or programmedUserRole in the case of failure) key. Success or failure is indicated by the disposition.',
+  restrictInDocumentationToApps: [LogSource.VxAdminService],
 };
 const CvrLoaded: LogDetails = {
   eventId: LogEventId.CvrLoaded,
@@ -931,16 +921,14 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return PrintedBallotReportPrinted;
     case LogEventId.FileSaved:
       return FileSaved;
-    case LogEventId.SmartcardProgramInit:
-      return SmartcardProgramInit;
-    case LogEventId.SmartcardProgramComplete:
-      return SmartcardProgramComplete;
-    case LogEventId.SmartcardUnprogramInit:
-      return SmartcardUnprogramInit;
-    case LogEventId.SmartcardUnprogramComplete:
-      return SmartcardUnprogramComplete;
-    case LogEventId.SmartcardProgrammedOverrideWriteProtection:
-      return SmartcardProgrammedOverrideWriteProtection;
+    case LogEventId.SmartCardProgramInit:
+      return SmartCardProgramInit;
+    case LogEventId.SmartCardProgramComplete:
+      return SmartCardProgramComplete;
+    case LogEventId.SmartCardUnprogramInit:
+      return SmartCardUnprogramInit;
+    case LogEventId.SmartCardUnprogramComplete:
+      return SmartCardUnprogramComplete;
     case LogEventId.CvrFilesReadFromUsb:
       return CvrFilesReadFromUsb;
     case LogEventId.CvrLoaded:


### PR DESCRIPTION
## Overview

Issue links: https://github.com/votingworks/vxsuite/issues/3056, https://github.com/votingworks/vxsuite/issues/2528

This PR re-adds auth logging that I consciously dropped while moving auth to the backend.

## Testing

- [x] Tested `DippedSmartCardAuth` logging manually, including card programming
- [x] Tested `InsertedSmartCardAuth` logging manually, including cardless voter sessions

Will cover logging in upcoming automated tests as well!

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced :tada:
- [x] I have added JSDoc comments to any newly introduced exports