### PR TITLE
Add Batch Info to CVR

### DIFF
--- a/apps/central-scan/backend/src/store.test.ts
+++ b/apps/central-scan/backend/src/store.test.ts
@@ -351,6 +351,7 @@ test('batch cleanup works correctly', async () => {
   const batches = store.batchStatus();
   expect(batches).toHaveLength(1);
   expect(batches[0].id).toEqual(firstBatchId);
+  expect(batches[0].batchNumber).toEqual(1);
   expect(batches[0].label).toEqual('Batch 1');
 
   const thirdBatchId = store.addBatch();
@@ -363,10 +364,12 @@ test('batch cleanup works correctly', async () => {
   ).toEqual([
     expect.objectContaining({
       id: firstBatchId,
+      batchNumber: 1,
       label: 'Batch 1',
     }),
     expect.objectContaining({
       id: thirdBatchId,
+      batchNumber: 3,
       label: 'Batch 3',
     }),
   ]);

--- a/apps/central-scan/backend/src/store.ts
+++ b/apps/central-scan/backend/src/store.ts
@@ -885,6 +885,7 @@ export class Store {
   batchStatus(): BatchInfo[] {
     interface SqliteBatchInfo {
       id: string;
+      batchNumber: number;
       label: string;
       startedAt: string;
       endedAt: string | null;
@@ -894,6 +895,7 @@ export class Store {
     const batchInfo = this.client.all(`
       select
         batches.id as id,
+        batches.batch_number as batchNumber,
         batches.label as label,
         strftime('%s', started_at) as startedAt,
         (case when ended_at is null then ended_at else strftime('%s', ended_at) end) as endedAt,
@@ -917,6 +919,7 @@ export class Store {
     `) as SqliteBatchInfo[];
     return batchInfo.map((info) => ({
       id: info.id,
+      batchNumber: info.batchNumber,
       label: info.label,
       // eslint-disable-next-line vx/gts-safe-number-parse
       startedAt: DateTime.fromSeconds(Number(info.startedAt)).toISO(),

--- a/apps/central-scan/frontend/src/app.test.tsx
+++ b/apps/central-scan/frontend/src/app.test.tsx
@@ -255,6 +255,7 @@ test('clicking "Save CVRs" shows modal and makes a request to export', async () 
     batches: [
       {
         id: 'test-batch',
+        batchNumber: 1,
         label: 'Batch 1',
         count: 2,
         startedAt: '2021-05-13T13:19:42.353Z',

--- a/apps/central-scan/frontend/src/screens/dashboard_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/dashboard_screen.test.tsx
@@ -41,6 +41,7 @@ test('shows scanned ballot count', () => {
     batches: [
       {
         id: 'a',
+        batchNumber: 1,
         count: 1,
         label: 'Batch 1',
         startedAt: new Date(0).toISOString(),
@@ -48,6 +49,7 @@ test('shows scanned ballot count', () => {
       },
       {
         id: 'b',
+        batchNumber: 2,
         count: 3,
         label: 'Batch 2',
         startedAt: new Date(0).toISOString(),
@@ -78,6 +80,7 @@ test('shows whether a batch is scanning', () => {
     batches: [
       {
         id: 'a',
+        batchNumber: 1,
         label: 'Batch 1',
         count: 3,
         startedAt: new Date(0).toISOString(),
@@ -101,6 +104,7 @@ test('allows deleting a batch', async () => {
     batches: [
       {
         id: 'a',
+        batchNumber: 1,
         label: 'Batch 1',
         count: 1,
         startedAt: new Date(0).toISOString(),
@@ -108,6 +112,7 @@ test('allows deleting a batch', async () => {
       },
       {
         id: 'b',
+        batchNumber: 2,
         label: 'Batch 2',
         count: 3,
         startedAt: new Date(0).toISOString(),

--- a/apps/scan/backend/src/store.test.ts
+++ b/apps/scan/backend/src/store.test.ts
@@ -366,6 +366,7 @@ test('batch cleanup works correctly', async () => {
   const batches = store.batchStatus();
   expect(batches).toHaveLength(1);
   expect(batches[0].id).toEqual(firstBatchId);
+  expect(batches[0].batchNumber).toEqual(1);
   expect(batches[0].label).toEqual('Batch 1');
 
   const thirdBatchId = store.addBatch();
@@ -378,10 +379,12 @@ test('batch cleanup works correctly', async () => {
   ).toEqual([
     expect.objectContaining({
       id: firstBatchId,
+      batchNumber: 1,
       label: 'Batch 1',
     }),
     expect.objectContaining({
       id: thirdBatchId,
+      batchNumber: 3,
       label: 'Batch 3',
     }),
   ]);

--- a/apps/scan/backend/src/store.ts
+++ b/apps/scan/backend/src/store.ts
@@ -902,6 +902,7 @@ export class Store {
   batchStatus(): BatchInfo[] {
     interface SqliteBatchInfo {
       id: string;
+      batchNumber: number;
       label: string;
       startedAt: string;
       endedAt: string | null;
@@ -911,6 +912,7 @@ export class Store {
     const batchInfo = this.client.all(`
       select
         batches.id as id,
+        batches.batch_number as batchNumber,
         batches.label as label,
         strftime('%s', started_at) as startedAt,
         (case when ended_at is null then ended_at else strftime('%s', ended_at) end) as endedAt,
@@ -934,6 +936,7 @@ export class Store {
     `) as SqliteBatchInfo[];
     return batchInfo.map((info) => ({
       id: info.id,
+      batchNumber: info.batchNumber,
       label: info.label,
       // eslint-disable-next-line vx/gts-safe-number-parse
       startedAt: DateTime.fromSeconds(Number(info.startedAt)).toISO(),

--- a/libs/backend/src/scan/cast_vote_records/build_report_metadata.test.ts
+++ b/libs/backend/src/scan/cast_vote_records/build_report_metadata.test.ts
@@ -25,7 +25,11 @@ test('builds well-formed cast vote record report', () => {
     batchInfo: [
       {
         id: 'batch-1',
+        batchNumber: 1,
         label: 'Batch 1',
+        startedAt: new Date(1989, 11, 13).toISOString(),
+        endedAt: new Date(1989, 11, 14).toISOString(),
+        count: 2,
       },
     ],
   });
@@ -46,6 +50,11 @@ test('builds well-formed cast vote record report', () => {
     {
       '@id': 'batch-1',
       BatchLabel: 'Batch 1',
+      SequenceId: 1,
+      StartTime: new Date(1989, 11, 13).toISOString(),
+      EndTime: new Date(1989, 11, 14).toISOString(),
+      Size: 2,
+      CreatingDeviceId: scannerId,
     },
   ]);
 

--- a/libs/backend/src/scan/cast_vote_records/build_report_metadata.test.ts
+++ b/libs/backend/src/scan/cast_vote_records/build_report_metadata.test.ts
@@ -53,7 +53,7 @@ test('builds well-formed cast vote record report', () => {
       SequenceId: 1,
       StartTime: new Date(1989, 11, 13).toISOString(),
       EndTime: new Date(1989, 11, 14).toISOString(),
-      Size: 2,
+      NumberSheets: 2,
       CreatingDeviceId: scannerId,
     },
   ]);

--- a/libs/backend/src/scan/cast_vote_records/build_report_metadata.ts
+++ b/libs/backend/src/scan/cast_vote_records/build_report_metadata.ts
@@ -217,7 +217,7 @@ export function buildCastVoteRecordReportMetadata({
       SequenceId: batch.batchNumber,
       StartTime: batch.startedAt,
       EndTime: batch.endedAt,
-      Size: batch.count,
+      NumberSheets: batch.count,
       CreatingDeviceId: generatingDeviceId,
     })),
   };

--- a/libs/backend/src/scan/cast_vote_records/build_report_metadata.ts
+++ b/libs/backend/src/scan/cast_vote_records/build_report_metadata.ts
@@ -1,5 +1,6 @@
 import {
   AnyContest,
+  BatchInfo,
   CandidateContest,
   CVR,
   Election,
@@ -138,7 +139,7 @@ interface BuildCastVoteRecordReportMetadataParams {
   scannerIds: string[];
   reportTypes: CVR.ReportType[];
   isTestMode: boolean;
-  batchInfo: Array<{ id: string; label: string }>;
+  batchInfo: BatchInfo[];
 }
 
 /**
@@ -213,6 +214,11 @@ export function buildCastVoteRecordReportMetadata({
       '@type': 'CVR.vxBatch',
       '@id': batch.id,
       BatchLabel: batch.label,
+      SequenceId: batch.batchNumber,
+      StartTime: batch.startedAt,
+      EndTime: batch.endedAt,
+      Size: batch.count,
+      CreatingDeviceId: generatingDeviceId,
     })),
   };
 }

--- a/libs/types/src/cdf/cast-vote-records/index.test.ts
+++ b/libs/types/src/cdf/cast-vote-records/index.test.ts
@@ -19,7 +19,7 @@ const castVoteRecordReport: CastVoteRecordReport = {
   ReportingDevice: [
     {
       '@type': 'CVR.ReportingDevice',
-      '@id': '12345',
+      '@id': 'SC-01-000',
       Manufacturer: 'VotingWorks',
       Model: 'Test',
     },
@@ -51,6 +51,18 @@ const castVoteRecordReport: CastVoteRecordReport = {
       Type: ReportingUnitType.Precinct,
     },
   ],
+  vxBatch: [
+    {
+      '@type': 'CVR.vxBatch',
+      '@id': 'uuid',
+      BatchLabel: 'Batch 1',
+      SequenceId: 1,
+      StartTime: '2022-01-10T13:00:00.000Z',
+      EndTime: '2022-01-10T13:00:00.000Z',
+      Size: 1,
+      CreatingDeviceId: 'SC-01-000',
+    },
+  ],
   CVR: [
     {
       '@type': 'CVR.CVR',
@@ -58,7 +70,7 @@ const castVoteRecordReport: CastVoteRecordReport = {
       BallotStyleId: '1', // ballotStyleId
       BallotStyleUnitId: '6538', // precinctId
       BatchId: '1', // batchId
-      CreatingDeviceId: '000', // scannerId
+      CreatingDeviceId: 'SC-01-000', // scannerId
       CurrentSnapshotId: '1',
       // CVR snapshots come in three Types:
       // - original (what the scanner sees on the ballot)

--- a/libs/types/src/cdf/cast-vote-records/index.test.ts
+++ b/libs/types/src/cdf/cast-vote-records/index.test.ts
@@ -59,7 +59,7 @@ const castVoteRecordReport: CastVoteRecordReport = {
       SequenceId: 1,
       StartTime: '2022-01-10T13:00:00.000Z',
       EndTime: '2022-01-10T13:00:00.000Z',
-      Size: 1,
+      NumberSheets: 1,
       CreatingDeviceId: 'SC-01-000',
     },
   ],

--- a/libs/types/src/cdf/cast-vote-records/index.ts
+++ b/libs/types/src/cdf/cast-vote-records/index.ts
@@ -1855,7 +1855,7 @@ export interface vxBatch {
   /**
    * The number of sheets included in a batch.
    */
-  readonly Size: integer;
+  readonly NumberSheets: integer;
 
   /**
    * The tabulator that created the batch.
@@ -1873,7 +1873,7 @@ export const vxBatchSchema: z.ZodSchema<vxBatch> = z.object({
   SequenceId: integerSchema,
   StartTime: DateTimeSchema,
   EndTime: z.optional(DateTimeSchema),
-  Size: integerSchema,
+  NumberSheets: integerSchema,
   CreatingDeviceId: z.string(),
 });
 

--- a/libs/types/src/cdf/cast-vote-records/index.ts
+++ b/libs/types/src/cdf/cast-vote-records/index.ts
@@ -1832,7 +1832,35 @@ export interface vxBatch {
 
   readonly '@type': 'CVR.vxBatch';
 
+  /**
+   * A human readable label for the batch.
+   */
   readonly BatchLabel: string;
+
+  /**
+   * The ordinal number of the batch in the tabulator's sequence of batches in a given election.
+   */
+  readonly SequenceId: integer;
+
+  /**
+   * The start time of the batch. On a precinct scanner, the start time is when the polls are opened or voting is resumed. On a central scanner, the start time is when the user initiates scanning a batch.
+   */
+  readonly StartTime: DateTime;
+
+  /**
+   * The end time of the batch. On a precinct scanner, the end time is when the polls are closed or voting is paused. On a central scanner, the end time is when a batch scan is complete
+   */
+  readonly EndTime?: DateTime;
+
+  /**
+   * The number of sheets included in a batch.
+   */
+  readonly Size: integer;
+
+  /**
+   * The tabulator that created the batch.
+   */
+  readonly CreatingDeviceId: string;
 }
 
 /**
@@ -1842,5 +1870,10 @@ export const vxBatchSchema: z.ZodSchema<vxBatch> = z.object({
   '@id': z.string(),
   '@type': z.literal('CVR.vxBatch'),
   BatchLabel: z.string(),
+  SequenceId: integerSchema,
+  StartTime: DateTimeSchema,
+  EndTime: z.optional(DateTimeSchema),
+  Size: integerSchema,
+  CreatingDeviceId: z.string(),
 });
 

--- a/libs/types/src/cdf/cast-vote-records/vx-schema.json
+++ b/libs/types/src/cdf/cast-vote-records/vx-schema.json
@@ -1203,7 +1203,15 @@
     },
     "CVR.vxBatch": {
       "description": "Entity containing metadata about a scanned batch. Cast vote records link to batches via CVR::BatchId.",
-      "required": ["@id", "@type", "BatchLabel"],
+      "required": [
+        "@id",
+        "@type",
+        "BatchLabel",
+        "SequenceId",
+        "StartTime",
+        "Size",
+        "CreatingDeviceId"
+      ],
       "additionalProperties": false,
       "properties": {
         "@id": {
@@ -1214,7 +1222,31 @@
           "type": "string"
         },
         "BatchLabel": {
+          "description": "A human readable label for the batch.",
           "type": "string"
+        },
+        "SequenceId": {
+          "description": "The ordinal number of the batch in the tabulator's sequence of batches in a given election.",
+          "type": "integer"
+        },
+        "StartTime": {
+          "description": "The start time of the batch. On a precinct scanner, the start time is when the polls are opened or voting is resumed. On a central scanner, the start time is when the user initiates scanning a batch.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "EndTime": {
+          "description": "The end time of the batch. On a precinct scanner, the end time is when the polls are closed or voting is paused. On a central scanner, the end time is when a batch scan is complete",
+          "type": "string",
+          "format": "date-time"
+        },
+        "Size": {
+          "description": "The number of sheets included in a batch.",
+          "type": "integer"
+        },
+        "CreatingDeviceId": {
+          "description": "The tabulator that created the batch.",
+          "type": "string",
+          "refTypes": ["CVR.ReportingDevice"]
         }
       },
       "type": "object"

--- a/libs/types/src/cdf/cast-vote-records/vx-schema.json
+++ b/libs/types/src/cdf/cast-vote-records/vx-schema.json
@@ -1209,7 +1209,7 @@
         "BatchLabel",
         "SequenceId",
         "StartTime",
-        "Size",
+        "NumberSheets",
         "CreatingDeviceId"
       ],
       "additionalProperties": false,
@@ -1239,7 +1239,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "Size": {
+        "NumberSheets": {
           "description": "The number of sheets included in a batch.",
           "type": "integer"
         },

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -966,6 +966,7 @@ export const SideSchema = z.union([z.literal('front'), z.literal('back')]);
 
 export interface BatchInfo {
   id: string;
+  batchNumber: number;
   label: string;
   startedAt: Iso8601Timestamp;
   endedAt?: Iso8601Timestamp;
@@ -975,6 +976,7 @@ export interface BatchInfo {
 
 export const BatchInfoSchema: z.ZodSchema<BatchInfo> = z.object({
   id: IdSchema,
+  batchNumber: z.number().int().positive(),
   label: z.string(),
   startedAt: Iso8601TimestampSchema,
   endedAt: z.optional(Iso8601TimestampSchema),


### PR DESCRIPTION
Per [internal discussion](https://votingworks.slack.com/archives/CEL6D3GAD/p1678208279298859) about making our cast vote records more audit friendly, this change adds the following batch information to the CDF CVR (still feature-flagged):

- SequenceId (or batchNumber)
- Batch Start Time
- Batch End Time (if exists)
- Batch Size

One wrinkle on precinct scanner may be that we may export cast vote records before the polls are officially closed, so the last (and likely only) batch will not have an end time. I don't think solving that problem is within the scope of this PR if it is important.
