### PR TITLE
Ensure VxScan CVRs are randomly sorted

### DIFF
--- a/apps/scan/backend/src/cvrs/export.test.ts
+++ b/apps/scan/backend/src/cvrs/export.test.ts
@@ -432,7 +432,7 @@ test('exportCvrs does not export ballot images when skipImages is true', async (
   expect(addBallotImagesToCvrMock).not.toHaveBeenCalled();
 });
 
-test('exportCvrs called with orderBySheetId actually orders by sheet ID', async () => {
+test('exportCvrs orders by sheet ID', async () => {
   const store = Store.memoryStore();
   store.setElection(stateOfHamilton.electionDefinition.electionData);
 
@@ -476,10 +476,7 @@ test('exportCvrs called with orderBySheetId actually orders by sheet ID', async 
   }
 
   const stream = new streams.WritableStream();
-  await pipeline(
-    exportCastVoteRecordsAsNdJson({ store, orderBySheetId: true }),
-    stream
-  );
+  await pipeline(exportCastVoteRecordsAsNdJson({ store }), stream);
   const exportedCvrs: CastVoteRecord[] = stream
     .toString()
     .split('\n')

--- a/apps/scan/backend/src/cvrs/export.ts
+++ b/apps/scan/backend/src/cvrs/export.ts
@@ -64,11 +64,9 @@ async function loadImagePathShrinkBase64(
 export async function* exportCastVoteRecords({
   store,
   skipImages,
-  orderBySheetId,
 }: {
   store: Store;
   skipImages?: boolean;
-  orderBySheetId?: boolean;
 }): AsyncGenerator<CastVoteRecord> {
   const electionDefinition = store.getElectionDefinition();
 
@@ -81,7 +79,7 @@ export async function* exportCastVoteRecords({
     batchId,
     batchLabel,
     interpretation,
-  } of store.forEachResultSheet({ orderBySheetId })) {
+  } of store.forEachResultSheet()) {
     const frontImage: InlineBallotImage = { normalized: '' };
     const backImage: InlineBallotImage = { normalized: '' };
     const includeImages =
@@ -177,15 +175,13 @@ export async function* exportCastVoteRecords({
 export function exportCastVoteRecordsAsNdJson({
   store,
   skipImages,
-  orderBySheetId,
 }: {
   store: Store;
   skipImages?: boolean;
-  orderBySheetId?: boolean;
 }): NodeJS.ReadableStream {
   return Readable.from(
     mapAsync(
-      exportCastVoteRecords({ store, skipImages, orderBySheetId }),
+      exportCastVoteRecords({ store, skipImages }),
       (cvr) => `${JSON.stringify(cvr)}\n`
     )
   );

--- a/apps/scan/backend/src/store.ts
+++ b/apps/scan/backend/src/store.ts
@@ -971,9 +971,7 @@ export class Store {
   /**
    * Yields all sheets in the database that would be included in a CVR export.
    */
-  *forEachResultSheet(options?: {
-    orderBySheetId?: boolean;
-  }): Generator<ResultSheet> {
+  *forEachResultSheet(): Generator<ResultSheet> {
     const sql = `
       select
         sheets.id as id,
@@ -989,7 +987,7 @@ export class Store {
         (requires_adjudication = 0 or finished_adjudication_at is not null)
         and sheets.deleted_at is null
         and batches.deleted_at is null
-      ${options?.orderBySheetId ? 'order by sheets.id' : ''}
+      order by sheets.id
     `;
     for (const row of this.client.each(sql) as Iterable<{
       id: string;


### PR DESCRIPTION
## Overview

Reapplies the change made in #2692 which was somehow lost along the way, which is a privacy concern. VxScan no longer has option to export them in a non-randomized order, so the testing should keep it random.