### PR TITLE
fix(scan): orderBySheetId in VxScan for voter privacy

### DIFF
--- a/services/scan/src/precinct_scanner_app.ts
+++ b/services/scan/src/precinct_scanner_app.ts
@@ -477,7 +477,7 @@ export async function buildPrecinctScannerApp(
       response
         .header('Content-Type', 'text/plain; charset=utf-8')
         .header('Content-Disposition', `attachment; filename="${cvrFilename}"`);
-      void store.exportCvrs(response, { skipImages });
+      void store.exportCvrs(response, { skipImages, orderBySheetId: true });
       response.on('end', () => {
         store.setCvrsAsBackedUp();
       });


### PR DESCRIPTION
Analogous to #3090 applied to `main`, but looks a lot different because at this time the `scan` backends were not split and VxScan was not using `grout`.