### PR TITLE
Add Total Write-In Count

### DIFF
--- a/libs/backend/src/scan/cast_vote_records/__snapshots__/export.test.ts.snap
+++ b/libs/backend/src/scan/cast_vote_records/__snapshots__/export.test.ts.snap
@@ -19,11 +19,13 @@ Object {
               "@type": "CVR.CVRContest",
               "CVRContestSelection": Array [],
               "ContestId": "best-animal-fish",
+              "Overvotes": 0,
               "Status": Array [
                 "not-indicated",
                 "undervoted",
               ],
               "Undervotes": 1,
+              "WriteIns": 0,
             },
             Object {
               "@type": "CVR.CVRContest",
@@ -43,10 +45,12 @@ Object {
                 },
               ],
               "ContestId": "aquarium-council-fish",
+              "Overvotes": 0,
               "Status": Array [
                 "undervoted",
               ],
               "Undervotes": 1,
+              "WriteIns": 0,
             },
             Object {
               "@type": "CVR.CVRContest",
@@ -66,9 +70,12 @@ Object {
                 },
               ],
               "ContestId": "fishing",
+              "Overvotes": 0,
+              "Undervotes": 0,
             },
           ],
           "Type": "modified",
+          "vxWriteIns": 0,
         },
         Object {
           "@id": "ballot-1-original",
@@ -158,11 +165,13 @@ Object {
               "@type": "CVR.CVRContest",
               "CVRContestSelection": Array [],
               "ContestId": "best-animal-fish",
+              "Overvotes": 0,
               "Status": Array [
                 "not-indicated",
                 "undervoted",
               ],
               "Undervotes": 1,
+              "WriteIns": 0,
             },
             Object {
               "@type": "CVR.CVRContest",
@@ -182,15 +191,18 @@ Object {
                 },
               ],
               "ContestId": "aquarium-council-fish",
+              "Overvotes": 0,
               "Status": Array [
                 "undervoted",
               ],
               "Undervotes": 1,
+              "WriteIns": 0,
             },
             Object {
               "@type": "CVR.CVRContest",
               "CVRContestSelection": Array [],
               "ContestId": "new-zoo-either",
+              "Overvotes": 0,
               "Status": Array [
                 "undervoted",
                 "not-indicated",
@@ -201,6 +213,7 @@ Object {
               "@type": "CVR.CVRContest",
               "CVRContestSelection": Array [],
               "ContestId": "new-zoo-pick",
+              "Overvotes": 0,
               "Status": Array [
                 "undervoted",
                 "not-indicated",
@@ -225,9 +238,12 @@ Object {
                 },
               ],
               "ContestId": "fishing",
+              "Overvotes": 0,
+              "Undervotes": 0,
             },
           ],
           "Type": "original",
+          "vxWriteIns": 0,
         },
       ],
       "CreatingDeviceId": "000",

--- a/libs/backend/src/scan/cast_vote_records/build_cast_vote_record.test.ts
+++ b/libs/backend/src/scan/cast_vote_records/build_cast_vote_record.test.ts
@@ -118,9 +118,9 @@ describe('buildCVRContestsFromVotes', () => {
           },
         ],
         "ContestId": "fishing",
-        "Overvotes": undefined,
+        "Overvotes": 0,
         "Status": undefined,
-        "Undervotes": undefined,
+        "Undervotes": 0,
       }
     `);
   });
@@ -135,6 +135,8 @@ describe('buildCVRContestsFromVotes', () => {
     expect(result).toHaveLength(1);
     const cvrContest = result[0];
     expect(cvrContest).toMatchObject({
+      Overvotes: 0,
+      Undervotes: 0,
       CVRContestSelection: [
         expect.objectContaining({
           ContestSelectionId: 'no',
@@ -160,6 +162,7 @@ describe('buildCVRContestsFromVotes', () => {
         CVR.ContestStatus.Overvoted,
       ]),
       Overvotes: 1,
+      Undervotes: 0,
       CVRContestSelection: expect.anything(),
     });
     for (const contestSelection of cvrContest!.CVRContestSelection!) {
@@ -184,6 +187,7 @@ describe('buildCVRContestsFromVotes', () => {
     expect(result).toHaveLength(1);
     const cvrContest = result[0];
     expect(cvrContest).toMatchObject({
+      Overvotes: 0,
       Undervotes: 1,
       Status: expect.arrayContaining([
         CVR.ContestStatus.NotIndicated,
@@ -257,10 +261,10 @@ describe('buildCVRContestsFromVotes', () => {
           },
         ],
         "ContestId": "zoo-council-mammal",
-        "Overvotes": undefined,
+        "Overvotes": 0,
         "Status": undefined,
-        "Undervotes": undefined,
-        "WriteIns": undefined,
+        "Undervotes": 0,
+        "WriteIns": 0,
       }
     `);
   });
@@ -275,6 +279,7 @@ describe('buildCVRContestsFromVotes', () => {
     expect(result).toHaveLength(1);
     const cvrContest = result[0];
     expect(cvrContest).toMatchObject({
+      Overvotes: 0,
       Undervotes: 3,
       Status: expect.arrayContaining([
         CVR.ContestStatus.NotIndicated,
@@ -295,6 +300,7 @@ describe('buildCVRContestsFromVotes', () => {
     expect(result).toHaveLength(1);
     const cvrContest = result[0];
     expect(cvrContest).toMatchObject({
+      Overvotes: 0,
       Undervotes: 2,
       Status: expect.arrayContaining([CVR.ContestStatus.Undervoted]),
     });
@@ -313,6 +319,7 @@ describe('buildCVRContestsFromVotes', () => {
     const cvrContest = result[0];
     expect(cvrContest).toMatchObject({
       Overvotes: 1,
+      Undervotes: 0,
       Status: expect.arrayContaining([
         CVR.ContestStatus.Overvoted,
         CVR.ContestStatus.InvalidatedRules,

--- a/libs/backend/src/scan/cast_vote_records/build_cast_vote_record.ts
+++ b/libs/backend/src/scan/cast_vote_records/build_cast_vote_record.ts
@@ -59,8 +59,8 @@ function buildCVRBallotMeasureContest({
   return {
     '@type': 'CVR.CVRContest',
     ContestId: contest.id,
-    Overvotes: overvoted ? 1 : undefined,
-    Undervotes: undervoted ? 1 : undefined,
+    Overvotes: Math.max(vote.length - 1, 0),
+    Undervotes: Math.max(1 - vote.length, 0),
     Status: overvoted
       ? [CVR.ContestStatus.Overvoted, CVR.ContestStatus.InvalidatedRules]
       : undervoted
@@ -214,9 +214,9 @@ function buildCVRCandidateContest({
   return {
     '@type': 'CVR.CVRContest',
     ContestId: contest.id,
-    Overvotes: overvoted ? vote.length - contest.seats : undefined, // VVSG 2.0 1.1.5-E.2
-    Undervotes: undervoted ? contest.seats - vote.length : undefined, // VVSG 2.0 1.1.5-E.2
-    WriteIns: numWriteIns > 0 ? numWriteIns : undefined, // VVSG 2.0 1.1.5-E.3
+    Overvotes: Math.max(vote.length - contest.seats, 0), // VVSG 2.0 1.1.5-E.2
+    Undervotes: Math.max(contest.seats - vote.length, 0), // VVSG 2.0 1.1.5-E.2
+    WriteIns: numWriteIns, // VVSG 2.0 1.1.5-E.3
     Status: statuses.length > 0 ? statuses : undefined,
     CVRContestSelection: voteWriteInIndexed.map((candidate) => {
       const { isWriteIn } = candidate;
@@ -512,7 +512,7 @@ export function buildCastVoteRecord({
               ballotMarkingMode: 'machine',
             },
           }),
-          vxWriteIns: writeInCount > 0 ? writeInCount : undefined,
+          vxWriteIns: writeInCount,
         },
       ],
     };
@@ -571,7 +571,7 @@ export function buildCastVoteRecord({
             },
           }),
         ],
-        vxWriteIns: writeInCount > 0 ? writeInCount : undefined,
+        vxWriteIns: writeInCount,
       },
       buildOriginalSnapshot({
         castVoteRecordId,

--- a/libs/backend/src/scan/cast_vote_records/build_cast_vote_record.ts
+++ b/libs/backend/src/scan/cast_vote_records/build_cast_vote_record.ts
@@ -384,6 +384,28 @@ function buildOriginalSnapshot({
 }
 
 /**
+ * Determines the number of write-in candidates in a {@link VotesDict}
+ */
+export function getWriteInCount(votes: VotesDict): number {
+  let count = 0;
+  for (const vote of Object.values(votes)) {
+    if (vote) {
+      for (const voteOption of vote) {
+        if (
+          voteOption !== 'yes' &&
+          voteOption !== 'no' &&
+          voteOption.isWriteIn
+        ) {
+          count += 1;
+        }
+      }
+    }
+  }
+
+  return count;
+}
+
+/**
  * Determines whether a {@link VotesDict} contains any write-in candidates
  */
 export function hasWriteIns(votes: VotesDict): boolean {
@@ -473,6 +495,7 @@ export function buildCastVoteRecord({
     });
     assert(ballotStyle);
     const contests = getContests({ election, ballotStyle });
+    const writeInCount = getWriteInCount(interpretation.votes);
 
     return {
       ...cvrMetadata,
@@ -489,6 +512,7 @@ export function buildCastVoteRecord({
               ballotMarkingMode: 'machine',
             },
           }),
+          vxWriteIns: writeInCount > 0 ? writeInCount : undefined,
         },
       ],
     };
@@ -506,6 +530,9 @@ export function buildCastVoteRecord({
   ).toString();
 
   const hasImageFileUris = pages[0].imageFileUri || pages[1].imageFileUri;
+  const writeInCount =
+    getWriteInCount(pages[0].interpretation.votes) +
+    getWriteInCount(pages[1].interpretation.votes);
 
   // CVR for hand-marked paper ballots, has both "original" snapshot with
   // scores for all marks and "modified" snapshot with contest rules applied.
@@ -544,6 +571,7 @@ export function buildCastVoteRecord({
             },
           }),
         ],
+        vxWriteIns: writeInCount > 0 ? writeInCount : undefined,
       },
       buildOriginalSnapshot({
         castVoteRecordId,

--- a/libs/types/src/cdf/cast-vote-records/index.test.ts
+++ b/libs/types/src/cdf/cast-vote-records/index.test.ts
@@ -108,6 +108,7 @@ const castVoteRecordReport: CastVoteRecordReport = {
               WriteIns: 0,
             },
           ],
+          vxWriteIns: 0,
         },
       ],
       BallotSheetId: '1',

--- a/libs/types/src/cdf/cast-vote-records/index.ts
+++ b/libs/types/src/cdf/cast-vote-records/index.ts
@@ -875,6 +875,11 @@ export interface CVRSnapshot {
    * The type of the snapshot, e.g., original.
    */
   readonly Type: CVRType;
+
+  /**
+   * Records the total number of write-ins in the CVR as currently modified or adjudicated, per VVSG 2.0 1.1.5-D.4. The number of write-ins per contest is indicated separately by `CVRContest.WriteIns`.
+   */
+  readonly vxWriteIns?: integer;
 }
 
 /**
@@ -888,6 +893,7 @@ export const CVRSnapshotSchema: z.ZodSchema<CVRSnapshot> = z.object({
   OtherStatus: z.optional(z.string()),
   Status: z.optional(z.array(z.lazy(/* istanbul ignore next */ () => CVRStatusSchema))),
   Type: z.lazy(/* istanbul ignore next */ () => CVRTypeSchema),
+  vxWriteIns: z.optional(integerSchema),
 });
 
 /**

--- a/libs/types/src/cdf/cast-vote-records/vx-schema.json
+++ b/libs/types/src/cdf/cast-vote-records/vx-schema.json
@@ -323,6 +323,10 @@
         },
         "Type": {
           "$ref": "#/definitions/CVR.CVRType"
+        },
+        "vxWriteIns": {
+          "description": "Records the total number of write-ins in the CVR as currently modified or adjudicated, per VVSG 2.0 1.1.5-D.4. The number of write-ins per contest is indicated separately by `CVRContest.WriteIns`.",
+          "type": "integer"
         }
       },
       "type": "object"


### PR DESCRIPTION
We've discussed whether this is necessary, but might as well just do it as long as it's easy per discussions with Jessica. See discussion in #1240. We already have a count of write-ins per contest if any exist. This adds a cumulative count of write-ins at the at the CVr snapshot level, if it exists.
