### PR TITLE
Add libs/auth tests, part 2

### DIFF
--- a/libs/auth/jest.config.js
+++ b/libs/auth/jest.config.js
@@ -14,10 +14,10 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      statements: 44,
-      branches: 31,
-      functions: 48,
-      lines: 44,
+      statements: 50,
+      branches: 35,
+      functions: 55,
+      lines: 50,
     },
   },
 };

--- a/libs/auth/src/apdu.test.ts
+++ b/libs/auth/src/apdu.test.ts
@@ -19,7 +19,7 @@ test.each<{
   { cla: { chained: true }, expectedFirstByte: 0x10 },
   { cla: { secure: true }, expectedFirstByte: 0x0c },
   { cla: { chained: true, secure: true }, expectedFirstByte: 0x1c },
-])('CommandApdu CLA handling, $cla', ({ cla, expectedFirstByte }) => {
+])('CommandApdu CLA handling - $cla', ({ cla, expectedFirstByte }) => {
   const apdu = new CommandApdu({
     cla,
     ins: 0x01,
@@ -158,7 +158,7 @@ test.each<{ valueLength: number; expectedTlvLength: Byte[] }>([
   { valueLength: 3017, expectedTlvLength: [0x82, 0x0b, 0xc9] },
   { valueLength: 65535, expectedTlvLength: [0x82, 0xff, 0xff] },
 ])(
-  'constructTlv value length handling ($valueLength)',
+  'constructTlv value length handling - $valueLength',
   ({ valueLength, expectedTlvLength }) => {
     const value = numericArray({ length: valueLength });
     const tlv = constructTlv(0x01, Buffer.from(value));

--- a/libs/auth/src/card_reader.test.ts
+++ b/libs/auth/src/card_reader.test.ts
@@ -132,6 +132,7 @@ test('CardReader status changes', () => {
   newCardReader();
 
   mockPcscLite.emit('error');
+  expect(onReaderStatusChange).toHaveBeenCalledTimes(1);
   expect(onReaderStatusChange).toHaveBeenNthCalledWith(1, 'unknown_error');
 
   mockPcscLite.emit('reader', mockPcscLiteReader);
@@ -145,6 +146,7 @@ test('CardReader status changes', () => {
     { share_mode: mockPcscLiteReader.SCARD_SHARE_EXCLUSIVE },
     expect.anything()
   );
+  expect(onReaderStatusChange).toHaveBeenCalledTimes(2);
   expect(onReaderStatusChange).toHaveBeenNthCalledWith(2, 'card_error');
 
   mockOf(mockPcscLiteReader.connect).mockImplementationOnce(mockConnectSuccess);
@@ -153,20 +155,21 @@ test('CardReader status changes', () => {
     { share_mode: mockPcscLiteReader.SCARD_SHARE_EXCLUSIVE },
     expect.anything()
   );
+  expect(onReaderStatusChange).toHaveBeenCalledTimes(3);
   expect(onReaderStatusChange).toHaveBeenNthCalledWith(3, 'ready');
 
   mockPcscLiteReader.emit('status', { state: 0 });
+  expect(onReaderStatusChange).toHaveBeenCalledTimes(4);
   expect(onReaderStatusChange).toHaveBeenNthCalledWith(4, 'no_card');
   expect(mockPcscLiteReader.disconnect).toHaveBeenCalledTimes(1);
 
   mockPcscLiteReader.emit('error');
+  expect(onReaderStatusChange).toHaveBeenCalledTimes(5);
   expect(onReaderStatusChange).toHaveBeenNthCalledWith(5, 'unknown_error');
 
   mockPcscLiteReader.emit('end');
-  expect(onReaderStatusChange).toHaveBeenNthCalledWith(6, 'no_card_reader');
-
-  // Verify that onReaderStatusChange hasn't been called any additional times
   expect(onReaderStatusChange).toHaveBeenCalledTimes(6);
+  expect(onReaderStatusChange).toHaveBeenNthCalledWith(6, 'no_card_reader');
 });
 
 test('CardReader command transmission - reader not ready', async () => {
@@ -189,6 +192,7 @@ test('CardReader command transmission - success', async () => {
     Buffer.from([])
   );
 
+  expect(mockPcscLiteReader.transmit).toHaveBeenCalledTimes(1);
   expect(mockPcscLiteReader.transmit).toHaveBeenNthCalledWith(
     1,
     simpleCommand.buffer,
@@ -216,6 +220,7 @@ test('CardReader command transmission - response APDU with non-success status wo
     ])
   );
 
+  expect(mockPcscLiteReader.transmit).toHaveBeenCalledTimes(1);
   expect(mockPcscLiteReader.transmit).toHaveBeenNthCalledWith(
     1,
     simpleCommand.buffer,
@@ -233,6 +238,7 @@ test('CardReader command transmission - response APDU with no status word', asyn
 
   await expect(cardReader.transmit(simpleCommand.command)).rejects.toThrow();
 
+  expect(mockPcscLiteReader.transmit).toHaveBeenCalledTimes(1);
   expect(mockPcscLiteReader.transmit).toHaveBeenNthCalledWith(
     1,
     simpleCommand.buffer,
@@ -264,6 +270,7 @@ test('CardReader command transmission - chained command', async () => {
     Buffer.from([0x00])
   );
 
+  expect(mockPcscLiteReader.transmit).toHaveBeenCalledTimes(3);
   expect(mockPcscLiteReader.transmit).toHaveBeenNthCalledWith(
     1,
     commandWithLotsOfData.buffers[0],
@@ -315,6 +322,7 @@ test('CardReader command transmission - chained response', async () => {
     ])
   );
 
+  expect(mockPcscLiteReader.transmit).toHaveBeenCalledTimes(2);
   expect(mockPcscLiteReader.transmit).toHaveBeenNthCalledWith(
     1,
     simpleCommand.buffer,
@@ -345,6 +353,7 @@ test('CardReader command transmission - transmit failure', async () => {
     'Failed to transmit data to card'
   );
 
+  expect(mockPcscLiteReader.transmit).toHaveBeenCalledTimes(1);
   expect(mockPcscLiteReader.transmit).toHaveBeenNthCalledWith(
     1,
     simpleCommand.buffer,

--- a/libs/auth/src/card_reader.test.ts
+++ b/libs/auth/src/card_reader.test.ts
@@ -169,7 +169,7 @@ test('CardReader status changes', () => {
   expect(onReaderStatusChange).toHaveBeenCalledTimes(6);
 });
 
-test('CardReader command transmission, reader not ready', async () => {
+test('CardReader command transmission - reader not ready', async () => {
   const cardReader = newCardReader();
 
   await expect(cardReader.transmit(simpleCommand.command)).rejects.toThrow(
@@ -177,7 +177,7 @@ test('CardReader command transmission, reader not ready', async () => {
   );
 });
 
-test('CardReader command transmission, success', async () => {
+test('CardReader command transmission - success', async () => {
   const cardReader = newCardReader('ready');
   mockOf(mockPcscLiteReader.transmit).mockImplementationOnce(
     newMockTransmitSuccess(
@@ -198,7 +198,7 @@ test('CardReader command transmission, success', async () => {
   );
 });
 
-test('CardReader command transmission, response APDU with non-success status word', async () => {
+test('CardReader command transmission - response APDU with non-success status word', async () => {
   const cardReader = newCardReader('ready');
   mockOf(mockPcscLiteReader.transmit).mockImplementationOnce(
     newMockTransmitSuccess(
@@ -225,7 +225,7 @@ test('CardReader command transmission, response APDU with non-success status wor
   );
 });
 
-test('CardReader command transmission, response APDU with no status', async () => {
+test('CardReader command transmission - response APDU with no status word', async () => {
   const cardReader = newCardReader('ready');
   mockOf(mockPcscLiteReader.transmit).mockImplementationOnce(
     newMockTransmitSuccess(Buffer.from([]))
@@ -242,7 +242,7 @@ test('CardReader command transmission, response APDU with no status', async () =
   );
 });
 
-test('CardReader command transmission, chained command', async () => {
+test('CardReader command transmission - chained command', async () => {
   const cardReader = newCardReader('ready');
   mockOf(mockPcscLiteReader.transmit).mockImplementationOnce(
     newMockTransmitSuccess(
@@ -287,7 +287,7 @@ test('CardReader command transmission, chained command', async () => {
   );
 });
 
-test('CardReader command transmission, chained response', async () => {
+test('CardReader command transmission - chained response', async () => {
   const cardReader = newCardReader('ready');
   mockOf(mockPcscLiteReader.transmit).mockImplementationOnce(
     newMockTransmitSuccess(
@@ -337,7 +337,7 @@ test('CardReader command transmission, chained response', async () => {
   );
 });
 
-test('CardReader command transmission, transmit failure', async () => {
+test('CardReader command transmission - transmit failure', async () => {
   const cardReader = newCardReader('ready');
   mockOf(mockPcscLiteReader.transmit).mockImplementationOnce(mockTransmitError);
 

--- a/libs/auth/src/certs.test.ts
+++ b/libs/auth/src/certs.test.ts
@@ -96,7 +96,7 @@ test.each<{ description: string; subject: string }>([
       'subject=C = US, ST = CA, O = VotingWorks, ' +
       '1.3.6.1.4.1.59817.1 = admin',
   },
-])('parseCert validation, $description', async ({ subject }) => {
+])('parseCert validation - $description', async ({ subject }) => {
   mockOf(openssl).mockImplementationOnce(() =>
     Promise.resolve(Buffer.from(subject, 'utf-8'))
   );
@@ -178,7 +178,7 @@ test.each<{ description: string; subject: string }>([
       `1.3.6.1.4.1.59817.2 = ${jurisdiction}, ` +
       '1.3.6.1.4.1.59817.3 = em',
   },
-])('parseUserDataFromCert validation, $description', async ({ subject }) => {
+])('parseUserDataFromCert validation - $description', async ({ subject }) => {
   mockOf(openssl).mockImplementationOnce(() =>
     Promise.resolve(Buffer.from(subject, 'utf-8'))
   );

--- a/libs/auth/src/openssl.test.ts
+++ b/libs/auth/src/openssl.test.ts
@@ -1,0 +1,267 @@
+import { Buffer } from 'buffer';
+import { spawn } from 'child_process';
+import { existsSync } from 'fs';
+import * as fs from 'fs/promises';
+import { v4 as uuid } from 'uuid';
+import {
+  fakeChildProcess as newMockChildProcess,
+  FakeChildProcess as MockChildProcess,
+  mockOf,
+} from '@votingworks/test-utils';
+
+import { createCert, openssl } from './openssl';
+
+jest.mock('child_process');
+jest.mock('fs');
+jest.mock('fs/promises');
+jest.mock('uuid');
+
+let mockChildProcess: MockChildProcess;
+let mockUuid = 0;
+
+beforeEach(() => {
+  mockChildProcess = newMockChildProcess();
+  mockOf(spawn).mockImplementation(() => mockChildProcess);
+
+  mockOf(existsSync).mockImplementation(() => true);
+  mockOf(fs.mkdir).mockImplementation(() => Promise.resolve(undefined));
+  mockOf(fs.unlink).mockImplementation(() => Promise.resolve());
+  mockOf(fs.writeFile).mockImplementation(() => Promise.resolve());
+
+  mockUuid = 0;
+  mockOf(uuid).mockImplementation(() => {
+    mockUuid += 1;
+    return `random-file-name-${mockUuid}`;
+  });
+});
+
+afterEach(() => {
+  // Remove all mock implementations
+  jest.resetAllMocks();
+});
+
+const fileBuffers = [
+  Buffer.from('file1Contents', 'utf-8'),
+  Buffer.from('file2contents', 'utf-8'),
+] as const;
+const tempFilePaths = [
+  '/tmp/openssl/random-file-name-1',
+  '/tmp/openssl/random-file-name-2',
+] as const;
+const responseChunks = [
+  Buffer.from('Hey!', 'utf-8'),
+  Buffer.from(' ', 'utf-8'),
+  Buffer.from('How is it going?', 'utf-8'),
+] as const;
+const errorChunks = [
+  Buffer.from('Uh ', 'utf-8'),
+  Buffer.from('oh!', 'utf-8'),
+] as const;
+
+test('openssl', async () => {
+  mockOf(existsSync).mockImplementationOnce(() => false);
+  setTimeout(() => {
+    responseChunks.forEach((responseChunk) => {
+      mockChildProcess.stdout.emit('data', responseChunk);
+    });
+    mockChildProcess.stderr.emit('data', Buffer.from('Some warning', 'utf-8'));
+    mockChildProcess.emit('close', 0);
+  });
+
+  const response = await openssl([
+    'some',
+    fileBuffers[0],
+    'command',
+    fileBuffers[1],
+  ]);
+  expect(response.toString()).toEqual('Hey! How is it going?');
+
+  expect(existsSync).toHaveBeenCalledTimes(2);
+  expect(existsSync).toHaveBeenNthCalledWith(1, '/tmp/openssl');
+  expect(existsSync).toHaveBeenNthCalledWith(2, '/tmp/openssl');
+  expect(fs.mkdir).toHaveBeenCalledTimes(1);
+  expect(fs.mkdir).toHaveBeenNthCalledWith(1, '/tmp/openssl');
+  expect(uuid).toHaveBeenCalledTimes(2);
+  expect(fs.writeFile).toHaveBeenCalledTimes(2);
+  expect(fs.writeFile).toHaveBeenNthCalledWith(
+    1,
+    tempFilePaths[0],
+    fileBuffers[0]
+  );
+  expect(fs.writeFile).toHaveBeenNthCalledWith(
+    2,
+    tempFilePaths[1],
+    fileBuffers[1]
+  );
+  expect(spawn).toHaveBeenCalledTimes(1);
+  expect(spawn).toHaveBeenNthCalledWith(1, 'openssl', [
+    'some',
+    tempFilePaths[0],
+    'command',
+    tempFilePaths[1],
+  ]);
+  expect(fs.unlink).toHaveBeenCalledTimes(2);
+  expect(fs.unlink).toHaveBeenNthCalledWith(1, tempFilePaths[0]);
+  expect(fs.unlink).toHaveBeenNthCalledWith(2, tempFilePaths[1]);
+});
+
+test('openssl - no Buffer params', async () => {
+  setTimeout(() => {
+    responseChunks.forEach((responseChunk) => {
+      mockChildProcess.stdout.emit('data', responseChunk);
+    });
+    mockChildProcess.emit('close', 0);
+  });
+
+  const response = await openssl(['some', 'command']);
+  expect(response.toString()).toEqual('Hey! How is it going?');
+
+  expect(existsSync).toHaveBeenCalledTimes(0);
+  expect(fs.mkdir).toHaveBeenCalledTimes(0);
+  expect(uuid).toHaveBeenCalledTimes(0);
+  expect(fs.writeFile).toHaveBeenCalledTimes(0);
+  expect(spawn).toHaveBeenCalledTimes(1);
+  expect(spawn).toHaveBeenNthCalledWith(1, 'openssl', ['some', 'command']);
+  expect(fs.unlink).toHaveBeenCalledTimes(0);
+});
+
+test('openssl - no standard output', async () => {
+  setTimeout(() => {
+    mockChildProcess.emit('close', 0);
+  });
+
+  const response = await openssl(['some', 'command']);
+  expect(response).toEqual(Buffer.from([]));
+});
+
+test('openssl - error creating working directory', async () => {
+  mockOf(existsSync).mockImplementationOnce(() => false);
+  mockOf(fs.mkdir).mockImplementationOnce(() =>
+    Promise.reject(new Error('Whoa!'))
+  );
+
+  await expect(openssl([fileBuffers[0]])).rejects.toThrow();
+});
+
+test('openssl - error writing temp file', async () => {
+  mockOf(fs.writeFile).mockImplementationOnce(() =>
+    Promise.reject(new Error('Whoa!'))
+  );
+
+  await expect(openssl([fileBuffers[0]])).rejects.toThrow();
+});
+
+test('openssl - error cleaning up temp files', async () => {
+  mockOf(fs.unlink).mockImplementationOnce(() =>
+    Promise.reject(new Error('Whoa!'))
+  );
+  setTimeout(() => {
+    mockChildProcess.emit('close', 0);
+  });
+
+  await expect(openssl([fileBuffers[0]])).rejects.toThrow();
+});
+
+test('openssl - process exits with a non-success status code', async () => {
+  setTimeout(() => {
+    errorChunks.forEach((errorChunk) => {
+      mockChildProcess.stderr.emit('data', errorChunk);
+    });
+    mockChildProcess.emit('close', 1);
+  });
+
+  await expect(openssl([fileBuffers[0]])).rejects.toThrow('Uh oh!');
+});
+
+test.each<{
+  certType?: 'standard' | 'certAuthorityCert';
+  expiryInDays?: number;
+  expectedSecondOpensslCallParams: string[];
+}>([
+  {
+    certType: undefined,
+    expiryInDays: undefined,
+    expectedSecondOpensslCallParams: [
+      'x509',
+      '-req',
+      '-CA',
+      '/path/to/cert-authority-cert.pem',
+      '-CAkey',
+      '/path/to/private-key.pem',
+      '-passin',
+      `pass:1234`,
+      '-CAcreateserial',
+      '-in',
+      '/tmp/openssl/random-file-name-1',
+      '-force_pubkey',
+      '/path/to/public-key.pem',
+      '-days',
+      '365',
+    ],
+  },
+  {
+    certType: 'certAuthorityCert',
+    expiryInDays: 1000,
+    expectedSecondOpensslCallParams: [
+      'x509',
+      '-req',
+      '-CA',
+      '/path/to/cert-authority-cert.pem',
+      '-CAkey',
+      '/path/to/private-key.pem',
+      '-passin',
+      `pass:1234`,
+      '-CAcreateserial',
+      '-in',
+      '/tmp/openssl/random-file-name-1',
+      '-force_pubkey',
+      '/path/to/public-key.pem',
+      '-days',
+      '1000',
+      '-extensions',
+      'v3_ca',
+      '-extfile',
+      '/path/to/openssl.cnf',
+    ],
+  },
+])(
+  'createCert - certType = $certType, expiryInDays = $expiryInDays',
+  async ({ certType, expiryInDays, expectedSecondOpensslCallParams }) => {
+    setTimeout(() => {
+      mockChildProcess.emit('close', 0);
+    });
+    setTimeout(() => {
+      mockChildProcess.emit('close', 0);
+    });
+
+    await createCert({
+      certSubject: '//',
+      certType,
+      expiryInDays,
+      opensslConfig: '/path/to/openssl.cnf',
+      publicKeyToSign: '/path/to/public-key.pem',
+      signingCertAuthorityCert: '/path/to/cert-authority-cert.pem',
+      signingPrivateKey: '/path/to/private-key.pem',
+      signingPrivateKeyPassword: '1234',
+    });
+
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(spawn).toHaveBeenNthCalledWith(1, 'openssl', [
+      'req',
+      '-new',
+      '-config',
+      '/path/to/openssl.cnf',
+      '-key',
+      '/path/to/private-key.pem',
+      '-passin',
+      'pass:1234',
+      '-subj',
+      '//',
+    ]);
+    expect(spawn).toHaveBeenNthCalledWith(
+      2,
+      'openssl',
+      expectedSecondOpensslCallParams
+    );
+  }
+);


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/3057

Another day 🌅, another `libs/auth` tests PR. This PR specifically adds tests for openssl helpers.

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A
- [ ] ~I have added JSDoc comments to any newly introduced exports~ N/A