### PR TITLE
fix(nh-next): ensure proper pageNumber on back page

### DIFF
--- a/apps/scan/backend/src/interpret_nh_next_adapter.ts
+++ b/apps/scan/backend/src/interpret_nh_next_adapter.ts
@@ -232,17 +232,21 @@ function convertNextInterpretedBallotPage(
   electionDefinition: ElectionDefinition,
   options: CurrentInterpretOptions,
   nextInterpretedBallotCard: next.InterpretedBallotCard,
-  nextInterpretation: next.InterpretedBallotPage
+  nextInterpretation: next.InterpretedBallotPage,
+  pageNumber: number
 ): current.InterpretFileResult {
   return {
     interpretation: {
       type: 'InterpretedHmpbPage',
-      metadata: buildInterpretedHmpbPageMetadata(
-        electionDefinition,
-        options,
-        nextInterpretedBallotCard.front.grid
-          .metadata as next.BallotPageMetadataFront
-      ),
+      metadata: {
+        ...buildInterpretedHmpbPageMetadata(
+          electionDefinition,
+          options,
+          nextInterpretedBallotCard.front.grid
+            .metadata as next.BallotPageMetadataFront
+        ),
+        pageNumber,
+      },
       markInfo: convertMarksToMarkInfo(
         nextInterpretation.grid.geometry,
         nextInterpretation.marks
@@ -277,13 +281,15 @@ function convertNextInterpretResult(
       electionDefinition,
       options,
       ballotCard,
-      front
+      front,
+      1
     ),
     convertNextInterpretedBallotPage(
       electionDefinition,
       options,
       ballotCard,
-      back
+      back,
+      2
     ),
   ];
   return ok(currentResult);


### PR DESCRIPTION
The interpreter already takes care of putting page 1 as front and page 2 as back. This is of course not compatible with multi-sheet ballots but in general I'm not sure we are yet, and a fix for that would be a lot more involved.