### PR TITLE
Fix Broken Either Neither

### DIFF
--- a/apps/admin/frontend/src/components/hand_marked_paper_ballot.tsx
+++ b/apps/admin/frontend/src/components/hand_marked_paper_ballot.tsx
@@ -1114,7 +1114,7 @@ export function HandMarkedPaperBallot({
                           }}
                         />
                       )}
-                      <Text bold noWrap>
+                      <Text bold>
                         <BubbleMark
                           position={election.ballotLayout?.targetMarkPosition}
                           checked={hasVote(votes?.[contest.id], 'yes')}
@@ -1126,7 +1126,7 @@ export function HandMarkedPaperBallot({
                           </span>
                         </BubbleMark>
                       </Text>
-                      <Text bold noWrap>
+                      <Text bold>
                         <BubbleMark
                           position={election.ballotLayout?.targetMarkPosition}
                           checked={hasVote(votes?.[contest.id], 'no')}


### PR DESCRIPTION
## Overview

Currently, the text of "Yes" and "No" options in our ballot measures are not allowed to wrap in the ballot. With the recent change removing the special casing of either-neither in the hand-marked paper ballot (#2972), that means that our either-neither ballots are currently broken. This means they won't scan, their layouts won't be generated correctly, and we can't infer a lot of information about them.

I know we're going to change our ballot generation and layout soon but even if it's only in the interim I'd like to merge this and not have some of or main fixtures broken.
