### PR TITLE
CDF CVR Schema Restrictions & Testing

### DIFF
--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -54,6 +54,7 @@
     "@typescript-eslint/parser": "^5.37.0",
     "@votingworks/cdf-schema-builder": "workspace:*",
     "ajv": "^8.12.0",
+    "ajv-draft-04": "^1.0.0",
     "esbuild-runner": "^2.2.1",
     "eslint": "^8.23.1",
     "eslint-config-prettier": "^8.5.0",

--- a/libs/types/src/cdf/cast-vote-records/index.test.ts
+++ b/libs/types/src/cdf/cast-vote-records/index.test.ts
@@ -16,7 +16,7 @@ import {
 import {
   findUnusedDefinitions,
   isSubsetCdfSchema,
-  validateSchema,
+  validateSchemaDraft04,
 } from '../../../test/cdf_schema_utils';
 
 const castVoteRecordReport: CastVoteRecordReport = {
@@ -153,11 +153,11 @@ test('generated types are in sync with schema', () => {
 });
 
 test('NIST schemas is valid JSON schema', () => {
-  validateSchema(nistSchema);
+  validateSchemaDraft04(nistSchema);
 });
 
 test('VX schema is valid JSON schema', () => {
-  validateSchema(vxSchema);
+  validateSchemaDraft04(vxSchema);
 });
 
 test('VX schema has no unused definitions', () => {

--- a/libs/types/src/cdf/cast-vote-records/index.test.ts
+++ b/libs/types/src/cdf/cast-vote-records/index.test.ts
@@ -1,6 +1,7 @@
 import { buildSchema } from '@votingworks/cdf-schema-builder';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { ok } from '@votingworks/basics';
 import { mockWritable } from '../../../test/helpers/mock_writable';
 import {
   AllocationStatus,
@@ -10,7 +11,13 @@ import {
   CVRType,
   IndicationStatus,
   ReportingUnitType,
+  vxBallotType,
 } from '.';
+import {
+  findUnusedDefinitions,
+  isSubsetCdfSchema,
+  validateSchema,
+} from '../../../test/cdf_schema_utils';
 
 const castVoteRecordReport: CastVoteRecordReport = {
   '@type': 'CVR.CastVoteRecordReport',
@@ -113,25 +120,50 @@ const castVoteRecordReport: CastVoteRecordReport = {
       ],
       BallotSheetId: '1',
       BatchSequenceId: 1,
+      UniqueId: 'a8932',
+      vxBallotType: vxBallotType.Precinct,
       ElectionId: '1',
     },
     // More ballots go here...
   ],
 };
 
+const nistXsd = readFileSync(
+  join(__dirname, '../../../data/cdf/cast-vote-records/nist-schema.xsd'),
+  'utf-8'
+);
+const nistJson = readFileSync(
+  join(__dirname, '../../../data/cdf/cast-vote-records/nist-schema.json'),
+  'utf-8'
+);
+const nistSchema = JSON.parse(nistJson);
+const vxJson = readFileSync(join(__dirname, './vx-schema.json'), 'utf-8');
+const vxSchema = JSON.parse(vxJson);
+
 test('CastVoteRecordReport', () => {
   CastVoteRecordReportSchema.parse(castVoteRecordReport);
 });
 
-test('schema in sync', () => {
-  const xsd = readFileSync(
-    join(__dirname, '../../../data/cdf/cast-vote-records/nist-schema.xsd'),
-    'utf-8'
-  );
-  const json = readFileSync(join(__dirname, './vx-schema.json'), 'utf-8');
-  const currentOutput = readFileSync(join(__dirname, './index.ts'), 'utf-8');
+test('generated types are in sync with schema', () => {
+  const generatedTypes = readFileSync(join(__dirname, './index.ts'), 'utf-8');
   const out = mockWritable();
-  buildSchema(xsd, json, out).unsafeUnwrap();
-  const expectedOutput = out.toString();
-  expect(currentOutput).toEqual(expectedOutput);
+  buildSchema(nistXsd, vxJson, out).unsafeUnwrap();
+  const expectedTypes = out.toString();
+  expect(generatedTypes).toEqual(expectedTypes);
+});
+
+test('NIST schemas is valid JSON schema', () => {
+  validateSchema(nistSchema);
+});
+
+test('VX schema is valid JSON schema', () => {
+  validateSchema(vxSchema);
+});
+
+test('VX schema has no unused definitions', () => {
+  expect(findUnusedDefinitions(vxSchema)).toEqual([]);
+});
+
+test('VX schema accepts a subset of NIST schema', () => {
+  expect(isSubsetCdfSchema(vxSchema, nistSchema)).toEqual(ok());
 });

--- a/libs/types/src/cdf/cast-vote-records/index.ts
+++ b/libs/types/src/cdf/cast-vote-records/index.ts
@@ -644,17 +644,17 @@ export interface CVR {
   /**
    * An identifier of the ballot style associated with the corresponding ballot.
    */
-  readonly BallotStyleId?: string;
+  readonly BallotStyleId: string;
 
   /**
    * Identifies the smallest unit of geography associated with the corresponding ballot, typically a precinct or split-precinct.
    */
-  readonly BallotStyleUnitId?: string;
+  readonly BallotStyleUnitId: string;
 
   /**
    * The identifier for the batch that includes this CVR.
    */
-  readonly BatchId?: string;
+  readonly BatchId: string;
 
   /**
    * The sequence number of the corresponding paper ballot within a batch.
@@ -669,7 +669,7 @@ export interface CVR {
   /**
    * Identifies the device that created the CVR.
    */
-  readonly CreatingDeviceId?: string;
+  readonly CreatingDeviceId: string;
 
   /**
    * Identifies the snapshot that is currently tabulatable.
@@ -689,12 +689,12 @@ export interface CVR {
   /**
    * The sequence number for this CVR. This represents the ordinal number that this CVR was processed by the tabulating device.
    */
-  readonly UniqueId?: string;
+  readonly UniqueId: string;
 
   /**
    * Indicates whether the ballot is an absentee or precinct ballot.
    */
-  readonly vxBallotType?: vxBallotType;
+  readonly vxBallotType: vxBallotType;
 }
 
 /**
@@ -706,17 +706,17 @@ export const CVRSchema: z.ZodSchema<CVR> = z.object({
   BallotImage: z.optional(z.array(z.lazy(/* istanbul ignore next */ () => ImageDataSchema))),
   BallotPrePrintedId: z.optional(z.string()),
   BallotSheetId: z.optional(z.string()),
-  BallotStyleId: z.optional(z.string()),
-  BallotStyleUnitId: z.optional(z.string()),
-  BatchId: z.optional(z.string()),
+  BallotStyleId: z.string(),
+  BallotStyleUnitId: z.string(),
+  BatchId: z.string(),
   BatchSequenceId: z.optional(integerSchema),
   CVRSnapshot: z.array(z.lazy(/* istanbul ignore next */ () => CVRSnapshotSchema)).min(1),
-  CreatingDeviceId: z.optional(z.string()),
+  CreatingDeviceId: z.string(),
   CurrentSnapshotId: z.string(),
   ElectionId: z.string(),
   PartyIds: z.optional(z.array(z.string())),
-  UniqueId: z.optional(z.string()),
-  vxBallotType: z.optional(z.lazy(/* istanbul ignore next */ () => vxBallotTypeSchema)),
+  UniqueId: z.string(),
+  vxBallotType: z.lazy(/* istanbul ignore next */ () => vxBallotTypeSchema),
 });
 
 /**

--- a/libs/types/src/cdf/cast-vote-records/index.ts
+++ b/libs/types/src/cdf/cast-vote-records/index.ts
@@ -554,7 +554,7 @@ export interface BallotMeasureContest {
   /**
    * Identifies the contest selections in the contest.
    */
-  readonly ContestSelection: ReadonlyArray<ContestSelection | PartySelection | BallotMeasureSelection | CandidateSelection>;
+  readonly ContestSelection: ReadonlyArray<ContestSelection | BallotMeasureSelection | CandidateSelection>;
 
   /**
    * Title or name of the contest, e.g., "Governor" or "Question on Legalization of Gambling".
@@ -580,7 +580,7 @@ export const BallotMeasureContestSchema: z.ZodSchema<BallotMeasureContest> = z.o
   '@type': z.literal('CVR.BallotMeasureContest'),
   Abbreviation: z.optional(z.string()),
   Code: z.optional(z.array(z.lazy(/* istanbul ignore next */ () => CodeSchema))),
-  ContestSelection: z.array(z.union([z.lazy(/* istanbul ignore next */ () => ContestSelectionSchema), z.lazy(/* istanbul ignore next */ () => PartySelectionSchema), z.lazy(/* istanbul ignore next */ () => BallotMeasureSelectionSchema), z.lazy(/* istanbul ignore next */ () => CandidateSelectionSchema)])).min(1),
+  ContestSelection: z.array(z.union([z.lazy(/* istanbul ignore next */ () => ContestSelectionSchema), z.lazy(/* istanbul ignore next */ () => BallotMeasureSelectionSchema), z.lazy(/* istanbul ignore next */ () => CandidateSelectionSchema)])).min(1),
   Name: z.optional(z.string()),
   OtherVoteVariation: z.optional(z.string()),
   VoteVariation: z.optional(z.lazy(/* istanbul ignore next */ () => VoteVariationSchema)),
@@ -978,7 +978,7 @@ export interface CandidateContest {
   /**
    * Identifies the contest selections in the contest.
    */
-  readonly ContestSelection: ReadonlyArray<ContestSelection | PartySelection | BallotMeasureSelection | CandidateSelection>;
+  readonly ContestSelection: ReadonlyArray<ContestSelection | BallotMeasureSelection | CandidateSelection>;
 
   /**
    * Title or name of the contest, e.g., "Governor" or "Question on Legalization of Gambling".
@@ -1019,7 +1019,7 @@ export const CandidateContestSchema: z.ZodSchema<CandidateContest> = z.object({
   '@type': z.literal('CVR.CandidateContest'),
   Abbreviation: z.optional(z.string()),
   Code: z.optional(z.array(z.lazy(/* istanbul ignore next */ () => CodeSchema))),
-  ContestSelection: z.array(z.union([z.lazy(/* istanbul ignore next */ () => ContestSelectionSchema), z.lazy(/* istanbul ignore next */ () => PartySelectionSchema), z.lazy(/* istanbul ignore next */ () => BallotMeasureSelectionSchema), z.lazy(/* istanbul ignore next */ () => CandidateSelectionSchema)])).min(1),
+  ContestSelection: z.array(z.union([z.lazy(/* istanbul ignore next */ () => ContestSelectionSchema), z.lazy(/* istanbul ignore next */ () => BallotMeasureSelectionSchema), z.lazy(/* istanbul ignore next */ () => CandidateSelectionSchema)])).min(1),
   Name: z.optional(z.string()),
   NumberElected: z.optional(integerSchema),
   OtherVoteVariation: z.optional(z.string()),
@@ -1216,7 +1216,7 @@ export interface Contest {
   /**
    * Identifies the contest selections in the contest.
    */
-  readonly ContestSelection: ReadonlyArray<ContestSelection | PartySelection | BallotMeasureSelection | CandidateSelection>;
+  readonly ContestSelection: ReadonlyArray<ContestSelection | BallotMeasureSelection | CandidateSelection>;
 
   /**
    * Title or name of the contest, e.g., "Governor" or "Question on Legalization of Gambling".
@@ -1242,7 +1242,7 @@ export const ContestSchema: z.ZodSchema<Contest> = z.object({
   '@type': z.literal('CVR.Contest'),
   Abbreviation: z.optional(z.string()),
   Code: z.optional(z.array(z.lazy(/* istanbul ignore next */ () => CodeSchema))),
-  ContestSelection: z.array(z.union([z.lazy(/* istanbul ignore next */ () => ContestSelectionSchema), z.lazy(/* istanbul ignore next */ () => PartySelectionSchema), z.lazy(/* istanbul ignore next */ () => BallotMeasureSelectionSchema), z.lazy(/* istanbul ignore next */ () => CandidateSelectionSchema)])).min(1),
+  ContestSelection: z.array(z.union([z.lazy(/* istanbul ignore next */ () => ContestSelectionSchema), z.lazy(/* istanbul ignore next */ () => BallotMeasureSelectionSchema), z.lazy(/* istanbul ignore next */ () => CandidateSelectionSchema)])).min(1),
   Name: z.optional(z.string()),
   OtherVoteVariation: z.optional(z.string()),
   VoteVariation: z.optional(z.lazy(/* istanbul ignore next */ () => VoteVariationSchema)),
@@ -1304,7 +1304,7 @@ export interface Election {
   /**
    * Used for establishing a collection of contest definitions that will be referenced by the CVRs.
    */
-  readonly Contest: ReadonlyArray<Contest | PartyContest | BallotMeasureContest | CandidateContest | RetentionContest>;
+  readonly Contest: ReadonlyArray<Contest | BallotMeasureContest | CandidateContest | RetentionContest>;
 
   /**
    * Used to identify the election scope, i.e., the political geography corresponding to the election.
@@ -1325,7 +1325,7 @@ export const ElectionSchema: z.ZodSchema<Election> = z.object({
   '@type': z.literal('CVR.Election'),
   Candidate: z.optional(z.array(z.lazy(/* istanbul ignore next */ () => CandidateSchema))),
   Code: z.optional(z.array(z.lazy(/* istanbul ignore next */ () => CodeSchema))),
-  Contest: z.array(z.union([z.lazy(/* istanbul ignore next */ () => ContestSchema), z.lazy(/* istanbul ignore next */ () => PartyContestSchema), z.lazy(/* istanbul ignore next */ () => BallotMeasureContestSchema), z.lazy(/* istanbul ignore next */ () => CandidateContestSchema), z.lazy(/* istanbul ignore next */ () => RetentionContestSchema)])).min(1),
+  Contest: z.array(z.union([z.lazy(/* istanbul ignore next */ () => ContestSchema), z.lazy(/* istanbul ignore next */ () => BallotMeasureContestSchema), z.lazy(/* istanbul ignore next */ () => CandidateContestSchema), z.lazy(/* istanbul ignore next */ () => RetentionContestSchema)])).min(1),
   ElectionScopeId: z.string(),
   Name: z.optional(z.string()),
 });
@@ -1545,88 +1545,6 @@ export const PartySchema: z.ZodSchema<Party> = z.object({
 });
 
 /**
- * PartyContest is a subclass of Contest and is used to identify the type of contest as involving a straight party selection.  It inherits attributes from Contest.
- */
-export interface PartyContest {
-  readonly '@id': string;
-
-  readonly '@type': 'CVR.PartyContest';
-
-  /**
-   * An abbreviation associated with the contest.
-   */
-  readonly Abbreviation?: string;
-
-  /**
-   * A code or identifier used for this contest.
-   */
-  readonly Code?: readonly Code[];
-
-  /**
-   * Identifies the contest selections in the contest.
-   */
-  readonly ContestSelection: ReadonlyArray<ContestSelection | PartySelection | BallotMeasureSelection | CandidateSelection>;
-
-  /**
-   * Title or name of the contest, e.g., "Governor" or "Question on Legalization of Gambling".
-   */
-  readonly Name?: string;
-
-  /**
-   * If VoteVariation is 'other', the vote variation for this contest.
-   */
-  readonly OtherVoteVariation?: string;
-
-  /**
-   * The vote variation for this contest, from the VoteVariation enumeration.
-   */
-  readonly VoteVariation?: VoteVariation;
-}
-
-/**
- * Schema for {@link PartyContest}.
- */
-export const PartyContestSchema: z.ZodSchema<PartyContest> = z.object({
-  '@id': z.string(),
-  '@type': z.literal('CVR.PartyContest'),
-  Abbreviation: z.optional(z.string()),
-  Code: z.optional(z.array(z.lazy(/* istanbul ignore next */ () => CodeSchema))),
-  ContestSelection: z.array(z.union([z.lazy(/* istanbul ignore next */ () => ContestSelectionSchema), z.lazy(/* istanbul ignore next */ () => PartySelectionSchema), z.lazy(/* istanbul ignore next */ () => BallotMeasureSelectionSchema), z.lazy(/* istanbul ignore next */ () => CandidateSelectionSchema)])).min(1),
-  Name: z.optional(z.string()),
-  OtherVoteVariation: z.optional(z.string()),
-  VoteVariation: z.optional(z.lazy(/* istanbul ignore next */ () => VoteVariationSchema)),
-});
-
-/**
- * PartySelection is a subclass of ContestSelection and is used typically for a contest selection in a straight-party contest.
- */
-export interface PartySelection {
-  readonly '@id': string;
-
-  readonly '@type': 'CVR.PartySelection';
-
-  /**
-   * Code used to identify the contest selection.
-   */
-  readonly Code?: readonly Code[];
-
-  /**
-   * The party associated with the contest selection.
-   */
-  readonly PartyIds: readonly string[];
-}
-
-/**
- * Schema for {@link PartySelection}.
- */
-export const PartySelectionSchema: z.ZodSchema<PartySelection> = z.object({
-  '@id': z.string(),
-  '@type': z.literal('CVR.PartySelection'),
-  Code: z.optional(z.array(z.lazy(/* istanbul ignore next */ () => CodeSchema))),
-  PartyIds: z.array(z.string()).min(1),
-});
-
-/**
  * ReportingDevice is used to specify a voting device as the "political geography" at hand.  CastVoteRecordReport refers to it as ReportGeneratingDevice and uses it to specify the device that created the CVR report. CVR refers to it as CreatingDevice to specify the device that created the CVRs.
  */
 export interface ReportingDevice {
@@ -1711,7 +1629,7 @@ export interface RetentionContest {
   /**
    * Identifies the contest selections in the contest.
    */
-  readonly ContestSelection: ReadonlyArray<ContestSelection | PartySelection | BallotMeasureSelection | CandidateSelection>;
+  readonly ContestSelection: ReadonlyArray<ContestSelection | BallotMeasureSelection | CandidateSelection>;
 
   /**
    * Title or name of the contest, e.g., "Governor" or "Question on Legalization of Gambling".
@@ -1738,7 +1656,7 @@ export const RetentionContestSchema: z.ZodSchema<RetentionContest> = z.object({
   Abbreviation: z.optional(z.string()),
   CandidateId: z.optional(z.string()),
   Code: z.optional(z.array(z.lazy(/* istanbul ignore next */ () => CodeSchema))),
-  ContestSelection: z.array(z.union([z.lazy(/* istanbul ignore next */ () => ContestSelectionSchema), z.lazy(/* istanbul ignore next */ () => PartySelectionSchema), z.lazy(/* istanbul ignore next */ () => BallotMeasureSelectionSchema), z.lazy(/* istanbul ignore next */ () => CandidateSelectionSchema)])).min(1),
+  ContestSelection: z.array(z.union([z.lazy(/* istanbul ignore next */ () => ContestSelectionSchema), z.lazy(/* istanbul ignore next */ () => BallotMeasureSelectionSchema), z.lazy(/* istanbul ignore next */ () => CandidateSelectionSchema)])).min(1),
   Name: z.optional(z.string()),
   OtherVoteVariation: z.optional(z.string()),
   VoteVariation: z.optional(z.lazy(/* istanbul ignore next */ () => VoteVariationSchema)),

--- a/libs/types/src/cdf/cast-vote-records/index.ts
+++ b/libs/types/src/cdf/cast-vote-records/index.ts
@@ -1331,35 +1331,6 @@ export const ElectionSchema: z.ZodSchema<Election> = z.object({
 });
 
 /**
- * Used to hold the contents of a file or identify a file created by the scanning device.  The file generally would contain an image of the scanned ballot or an image of a write-in entered by a voter onto the scanned ballot.  SubClass Image is used if the file contains an image.
- */
-export interface File {
-  readonly '@type': 'CVR.File';
-
-  readonly Data: Byte;
-
-  /**
-   * Contains the name of the file or an identifier of the file.
-   */
-  readonly FileName?: string;
-
-  /**
-   * The mime type of the file, e.g., image/jpeg.
-   */
-  readonly MimeType?: string;
-}
-
-/**
- * Schema for {@link File}.
- */
-export const FileSchema: z.ZodSchema<File> = z.object({
-  '@type': z.literal('CVR.File'),
-  Data: ByteSchema,
-  FileName: z.optional(z.string()),
-  MimeType: z.optional(z.string()),
-});
-
-/**
  * Used for identifying a geographical unit for various purposes, including:
  * 
  * The reporting unit of the report generation device, e.g., a precinct location of a scanner that generates the collection of CVRs,

--- a/libs/types/src/cdf/cast-vote-records/index.ts
+++ b/libs/types/src/cdf/cast-vote-records/index.ts
@@ -1127,7 +1127,7 @@ export interface CastVoteRecordReport {
   /**
    * List of scanner batches with metadata.
    */
-  readonly vxBatch?: readonly vxBatch[];
+  readonly vxBatch: readonly vxBatch[];
 }
 
 /**
@@ -1146,7 +1146,7 @@ export const CastVoteRecordReportSchema: z.ZodSchema<CastVoteRecordReport> = z.o
   ReportType: z.optional(z.array(z.lazy(/* istanbul ignore next */ () => ReportTypeSchema))),
   ReportingDevice: z.array(z.lazy(/* istanbul ignore next */ () => ReportingDeviceSchema)).min(1),
   Version: z.lazy(/* istanbul ignore next */ () => CastVoteRecordVersionSchema),
-  vxBatch: z.optional(z.array(z.lazy(/* istanbul ignore next */ () => vxBatchSchema))),
+  vxBatch: z.array(z.lazy(/* istanbul ignore next */ () => vxBatchSchema)),
 });
 
 /**

--- a/libs/types/src/cdf/cast-vote-records/index.ts
+++ b/libs/types/src/cdf/cast-vote-records/index.ts
@@ -1304,7 +1304,7 @@ export interface Election {
   /**
    * Used for establishing a collection of contest definitions that will be referenced by the CVRs.
    */
-  readonly Contest: ReadonlyArray<Contest | BallotMeasureContest | CandidateContest | RetentionContest>;
+  readonly Contest: ReadonlyArray<Contest | BallotMeasureContest | CandidateContest>;
 
   /**
    * Used to identify the election scope, i.e., the political geography corresponding to the election.
@@ -1325,7 +1325,7 @@ export const ElectionSchema: z.ZodSchema<Election> = z.object({
   '@type': z.literal('CVR.Election'),
   Candidate: z.optional(z.array(z.lazy(/* istanbul ignore next */ () => CandidateSchema))),
   Code: z.optional(z.array(z.lazy(/* istanbul ignore next */ () => CodeSchema))),
-  Contest: z.array(z.union([z.lazy(/* istanbul ignore next */ () => ContestSchema), z.lazy(/* istanbul ignore next */ () => BallotMeasureContestSchema), z.lazy(/* istanbul ignore next */ () => CandidateContestSchema), z.lazy(/* istanbul ignore next */ () => RetentionContestSchema)])).min(1),
+  Contest: z.array(z.union([z.lazy(/* istanbul ignore next */ () => ContestSchema), z.lazy(/* istanbul ignore next */ () => BallotMeasureContestSchema), z.lazy(/* istanbul ignore next */ () => CandidateContestSchema)])).min(1),
   ElectionScopeId: z.string(),
   Name: z.optional(z.string()),
 });
@@ -1601,65 +1601,6 @@ export const ReportingDeviceSchema: z.ZodSchema<ReportingDevice> = z.object({
   Model: z.optional(z.string()),
   Notes: z.optional(z.array(z.string())),
   SerialNumber: z.optional(z.string()),
-});
-
-/**
- * RetentionContest is a subclass of BallotMeasureContest and is used to identify the type of contest as involving a retention, such as for a judicial retention.  While it is similar to BallotMeasureContest, it contains a link to Candidate that BallotMeasureContest does not.  RetentionContest inherits attributes from Contest.
- */
-export interface RetentionContest {
-  readonly '@id': string;
-
-  readonly '@type': 'CVR.RetentionContest';
-
-  /**
-   * An abbreviation associated with the contest.
-   */
-  readonly Abbreviation?: string;
-
-  /**
-   * Identifies the candidate in the retention contest.
-   */
-  readonly CandidateId?: string;
-
-  /**
-   * A code or identifier used for this contest.
-   */
-  readonly Code?: readonly Code[];
-
-  /**
-   * Identifies the contest selections in the contest.
-   */
-  readonly ContestSelection: ReadonlyArray<ContestSelection | BallotMeasureSelection | CandidateSelection>;
-
-  /**
-   * Title or name of the contest, e.g., "Governor" or "Question on Legalization of Gambling".
-   */
-  readonly Name?: string;
-
-  /**
-   * If VoteVariation is 'other', the vote variation for this contest.
-   */
-  readonly OtherVoteVariation?: string;
-
-  /**
-   * The vote variation for this contest, from the VoteVariation enumeration.
-   */
-  readonly VoteVariation?: VoteVariation;
-}
-
-/**
- * Schema for {@link RetentionContest}.
- */
-export const RetentionContestSchema: z.ZodSchema<RetentionContest> = z.object({
-  '@id': z.string(),
-  '@type': z.literal('CVR.RetentionContest'),
-  Abbreviation: z.optional(z.string()),
-  CandidateId: z.optional(z.string()),
-  Code: z.optional(z.array(z.lazy(/* istanbul ignore next */ () => CodeSchema))),
-  ContestSelection: z.array(z.union([z.lazy(/* istanbul ignore next */ () => ContestSelectionSchema), z.lazy(/* istanbul ignore next */ () => BallotMeasureSelectionSchema), z.lazy(/* istanbul ignore next */ () => CandidateSelectionSchema)])).min(1),
-  Name: z.optional(z.string()),
-  OtherVoteVariation: z.optional(z.string()),
-  VoteVariation: z.optional(z.lazy(/* istanbul ignore next */ () => VoteVariationSchema)),
 });
 
 /**

--- a/libs/types/src/cdf/cast-vote-records/vx-schema.json
+++ b/libs/types/src/cdf/cast-vote-records/vx-schema.json
@@ -113,7 +113,18 @@
       "type": "object"
     },
     "CVR.CVR": {
-      "required": ["@type", "CVRSnapshot", "CurrentSnapshotId", "ElectionId"],
+      "required": [
+        "@type",
+        "CVRSnapshot",
+        "CurrentSnapshotId",
+        "ElectionId",
+        "BallotStyleId",
+        "BallotStyleUnitId",
+        "BatchId",
+        "CreatingDeviceId",
+        "UniqueId",
+        "vxBallotType"
+      ],
       "additionalProperties": false,
       "properties": {
         "@type": {

--- a/libs/types/src/cdf/cast-vote-records/vx-schema.json
+++ b/libs/types/src/cdf/cast-vote-records/vx-schema.json
@@ -742,27 +742,6 @@
       },
       "type": "object"
     },
-    "CVR.File": {
-      "required": ["@type", "Data"],
-      "additionalProperties": false,
-      "properties": {
-        "@type": {
-          "enum": ["CVR.File"],
-          "type": "string"
-        },
-        "Data": {
-          "type": "string",
-          "format": "byte"
-        },
-        "FileName": {
-          "type": "string"
-        },
-        "MimeType": {
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
     "CVR.FractionalNumber": {
       "pattern": "([0-9]+/[1-9]+[0-9]*)|(\\.[0-9]+)",
       "type": "string"

--- a/libs/types/src/cdf/cast-vote-records/vx-schema.json
+++ b/libs/types/src/cdf/cast-vote-records/vx-schema.json
@@ -279,6 +279,7 @@
             "$ref": "#/definitions/CVR.SelectionPosition"
           },
           "minItems": 1,
+          "maxItems": 1,
           "type": "array"
         },
         "Status": {

--- a/libs/types/src/cdf/cast-vote-records/vx-schema.json
+++ b/libs/types/src/cdf/cast-vote-records/vx-schema.json
@@ -63,9 +63,6 @@
                 "$ref": "#/definitions/CVR.ContestSelection"
               },
               {
-                "$ref": "#/definitions/CVR.PartySelection"
-              },
-              {
                 "$ref": "#/definitions/CVR.BallotMeasureSelection"
               },
               {
@@ -217,7 +214,6 @@
           "type": "string",
           "refTypes": [
             "CVR.Contest",
-            "CVR.PartyContest",
             "CVR.BallotMeasureContest",
             "CVR.CandidateContest",
             "CVR.RetentionContest"
@@ -260,7 +256,6 @@
           "type": "string",
           "refTypes": [
             "CVR.ContestSelection",
-            "CVR.PartySelection",
             "CVR.BallotMeasureSelection",
             "CVR.CandidateSelection"
           ]
@@ -422,9 +417,6 @@
             "oneOf": [
               {
                 "$ref": "#/definitions/CVR.ContestSelection"
-              },
-              {
-                "$ref": "#/definitions/CVR.PartySelection"
               },
               {
                 "$ref": "#/definitions/CVR.BallotMeasureSelection"
@@ -637,9 +629,6 @@
                 "$ref": "#/definitions/CVR.ContestSelection"
               },
               {
-                "$ref": "#/definitions/CVR.PartySelection"
-              },
-              {
                 "$ref": "#/definitions/CVR.BallotMeasureSelection"
               },
               {
@@ -732,9 +721,6 @@
             "oneOf": [
               {
                 "$ref": "#/definitions/CVR.Contest"
-              },
-              {
-                "$ref": "#/definitions/CVR.PartyContest"
               },
               {
                 "$ref": "#/definitions/CVR.BallotMeasureContest"
@@ -931,88 +917,6 @@
       },
       "type": "object"
     },
-    "CVR.PartyContest": {
-      "required": ["@id", "@type", "ContestSelection"],
-      "additionalProperties": false,
-      "properties": {
-        "@id": {
-          "type": "string"
-        },
-        "@type": {
-          "enum": ["CVR.PartyContest"],
-          "type": "string"
-        },
-        "Abbreviation": {
-          "type": "string"
-        },
-        "Code": {
-          "items": {
-            "$ref": "#/definitions/CVR.Code"
-          },
-          "minItems": 0,
-          "type": "array"
-        },
-        "ContestSelection": {
-          "items": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/CVR.ContestSelection"
-              },
-              {
-                "$ref": "#/definitions/CVR.PartySelection"
-              },
-              {
-                "$ref": "#/definitions/CVR.BallotMeasureSelection"
-              },
-              {
-                "$ref": "#/definitions/CVR.CandidateSelection"
-              }
-            ]
-          },
-          "minItems": 1,
-          "type": "array"
-        },
-        "Name": {
-          "type": "string"
-        },
-        "OtherVoteVariation": {
-          "type": "string"
-        },
-        "VoteVariation": {
-          "$ref": "#/definitions/CVR.VoteVariation"
-        }
-      },
-      "type": "object"
-    },
-    "CVR.PartySelection": {
-      "required": ["@id", "@type", "PartyIds"],
-      "additionalProperties": false,
-      "properties": {
-        "@id": {
-          "type": "string"
-        },
-        "@type": {
-          "enum": ["CVR.PartySelection"],
-          "type": "string"
-        },
-        "Code": {
-          "items": {
-            "$ref": "#/definitions/CVR.Code"
-          },
-          "minItems": 0,
-          "type": "array"
-        },
-        "PartyIds": {
-          "items": {
-            "type": "string",
-            "refTypes": ["CVR.Party"]
-          },
-          "minItems": 1,
-          "type": "array"
-        }
-      },
-      "type": "object"
-    },
     "CVR.PositionStatus": {
       "enum": ["adjudicated", "generated-rules", "invalidated-rules", "other"],
       "type": "string"
@@ -1111,9 +1015,6 @@
             "oneOf": [
               {
                 "$ref": "#/definitions/CVR.ContestSelection"
-              },
-              {
-                "$ref": "#/definitions/CVR.PartySelection"
               },
               {
                 "$ref": "#/definitions/CVR.BallotMeasureSelection"

--- a/libs/types/src/cdf/cast-vote-records/vx-schema.json
+++ b/libs/types/src/cdf/cast-vote-records/vx-schema.json
@@ -215,8 +215,7 @@
           "refTypes": [
             "CVR.Contest",
             "CVR.BallotMeasureContest",
-            "CVR.CandidateContest",
-            "CVR.RetentionContest"
+            "CVR.CandidateContest"
           ]
         },
         "OtherStatus": {
@@ -727,9 +726,6 @@
               },
               {
                 "$ref": "#/definitions/CVR.CandidateContest"
-              },
-              {
-                "$ref": "#/definitions/CVR.RetentionContest"
               }
             ]
           },
@@ -984,60 +980,6 @@
         "vote-center"
       ],
       "type": "string"
-    },
-    "CVR.RetentionContest": {
-      "required": ["@id", "@type", "ContestSelection"],
-      "additionalProperties": false,
-      "properties": {
-        "@id": {
-          "type": "string"
-        },
-        "@type": {
-          "enum": ["CVR.RetentionContest"],
-          "type": "string"
-        },
-        "Abbreviation": {
-          "type": "string"
-        },
-        "CandidateId": {
-          "type": "string",
-          "refTypes": ["CVR.Candidate"]
-        },
-        "Code": {
-          "items": {
-            "$ref": "#/definitions/CVR.Code"
-          },
-          "minItems": 0,
-          "type": "array"
-        },
-        "ContestSelection": {
-          "items": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/CVR.ContestSelection"
-              },
-              {
-                "$ref": "#/definitions/CVR.BallotMeasureSelection"
-              },
-              {
-                "$ref": "#/definitions/CVR.CandidateSelection"
-              }
-            ]
-          },
-          "minItems": 1,
-          "type": "array"
-        },
-        "Name": {
-          "type": "string"
-        },
-        "OtherVoteVariation": {
-          "type": "string"
-        },
-        "VoteVariation": {
-          "$ref": "#/definitions/CVR.VoteVariation"
-        }
-      },
-      "type": "object"
     },
     "CVR.SelectionPosition": {
       "required": ["@type", "HasIndication", "NumberVotes"],

--- a/libs/types/src/cdf/cast-vote-records/vx-schema.json
+++ b/libs/types/src/cdf/cast-vote-records/vx-schema.json
@@ -498,7 +498,8 @@
         "GpUnit",
         "ReportGeneratingDeviceIds",
         "ReportingDevice",
-        "Version"
+        "Version",
+        "vxBatch"
       ],
       "additionalProperties": false,
       "properties": {

--- a/libs/types/test/cdf_schema_utils.test.ts
+++ b/libs/types/test/cdf_schema_utils.test.ts
@@ -101,6 +101,13 @@ test('isSubsetCdfSchema', () => {
       { definitions: { A: { type: 'string' } } }
     )
   ).toEqual(err('extra definition in subschema: B'));
+  // Extra definitions prefixed with 'vx' are allowed
+  expect(
+    isSubsetCdfSchema(
+      { definitions: { 'Namespace.vxDefinition': { type: 'string' } } },
+      { definitions: { A: { type: 'string' } } }
+    )
+  ).toEqual(ok());
 
   // Basic type matching
   expect(

--- a/libs/types/test/cdf_schema_utils.test.ts
+++ b/libs/types/test/cdf_schema_utils.test.ts
@@ -3,12 +3,26 @@ import {
   findUnusedDefinitions,
   isSubsetCdfSchema,
   validateSchema,
+  validateSchemaDraft04,
 } from './cdf_schema_utils';
 
 test('validateSchema', () => {
   validateSchema({ definitions: { A: { type: 'string' } } });
   expect(() =>
     validateSchema({
+      definitions: {
+        A: {
+          type: 'not-a-real-type',
+        },
+      },
+    })
+  ).toThrow();
+});
+
+test('validateSchemaDraft04', () => {
+  validateSchemaDraft04({ definitions: { A: { type: 'string' } } });
+  expect(() =>
+    validateSchemaDraft04({
       definitions: {
         A: {
           type: 'not-a-real-type',

--- a/libs/types/test/cdf_schema_utils.ts
+++ b/libs/types/test/cdf_schema_utils.ts
@@ -218,6 +218,10 @@ export function isSubsetCdfSchema(
   for (const [key, subDefinition] of Object.entries(
     rootSubSchema.definitions
   )) {
+    // carve out for additional custom definitions
+    const [, keyName] = key.split('.');
+    if (keyName && keyName.startsWith('vx')) continue;
+
     const superDefinition = rootSuperSchema.definitions[key];
     if (!superDefinition) {
       return err(`extra definition in subschema: ${key}`);

--- a/libs/types/test/cdf_schema_utils.ts
+++ b/libs/types/test/cdf_schema_utils.ts
@@ -6,6 +6,7 @@ import {
   assert,
 } from '@votingworks/basics';
 import Ajv, { AnySchema } from 'ajv';
+import AjvDraft04, { AnySchema as AnySchemaDraft04 } from 'ajv-draft-04';
 
 // Limited types for the kinds of JSON schemas that we see in CDF
 
@@ -42,6 +43,25 @@ export function validateSchema(schema: AnySchema): void {
       date: true,
       time: true,
       'date-time': true,
+    },
+  });
+  ajv.compile(schema);
+}
+
+/**
+ * Validates that a schema is a valid JSON schema.
+ * @throws if the schema is invalid
+ */
+export function validateSchemaDraft04(schema: AnySchemaDraft04): void {
+  // Allow some custom keywords/formats that the NIST schema uses
+  const ajv = new AjvDraft04({
+    keywords: ['refTypes'],
+    formats: {
+      uri: true,
+      date: true,
+      time: true,
+      'date-time': true,
+      byte: true,
     },
   });
   ajv.compile(schema);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3158,6 +3158,7 @@ importers:
       '@votingworks/basics': workspace:*
       '@votingworks/cdf-schema-builder': workspace:*
       ajv: ^8.12.0
+      ajv-draft-04: ^1.0.0
       esbuild-runner: ^2.2.1
       eslint: ^8.23.1
       eslint-config-prettier: ^8.5.0
@@ -3198,6 +3199,7 @@ importers:
       '@typescript-eslint/parser': 5.37.0_2owex2qphpdtje5ztrbqluisqa
       '@votingworks/cdf-schema-builder': link:../cdf-schema-builder
       ajv: 8.12.0
+      ajv-draft-04: 1.0.0_ajv@8.12.0
       esbuild-runner: 2.2.1_esbuild@0.17.6
       eslint: 8.23.1
       eslint-config-prettier: 8.5.0_eslint@8.23.1
@@ -11862,6 +11864,17 @@ packages:
     dependencies:
       clean-stack: 2.2.0
       indent-string: 4.0.0
+
+  /ajv-draft-04/1.0.0_ajv@8.12.0:
+    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+    dependencies:
+      ajv: 8.12.0
+    dev: true
 
   /ajv-errors/1.0.1_ajv@6.12.6:
     resolution: {integrity: sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==}


### PR DESCRIPTION
_Review commit-by-commit_

## Overview

Add a few restrictions on the CDF CVR. Primarily:
- Requiring some VVSG 2.0 necessary metadata on the CVR
- Requiring batch information in the report
- Removing party & retention contests

## Testing Plan

Also added testing for the CDF CVR schema in this PR similar to the ballot definition schema. A few adjustments had to be made:

- The NIST schema has unused definitions, so only testing that on the VX schema
- The NIST schema (and forked VX schema) are a different version of the JSON schema spec and thus require a variant library of `ajv`
- In the VX schema for cast vote records we've added a definition, so I needed to add a carveout to the subset validation that allowed custom definitions prefixed with `vx`. 

