### PR TITLE
VxAdmin: List Available CVR Files on Backend

### DIFF
--- a/apps/admin/backend/package.json
+++ b/apps/admin/backend/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@votingworks/api": "workspace:*",
     "@votingworks/auth": "workspace:*",
+    "@votingworks/backend": "workspace:*",
     "@votingworks/basics": "workspace:*",
     "@votingworks/db": "workspace:*",
     "@votingworks/fixtures": "workspace:*",

--- a/apps/admin/backend/src/app.test.ts
+++ b/apps/admin/backend/src/app.test.ts
@@ -378,13 +378,9 @@ test('addCastVoteRecordFile - handle parsing error', async () => {
 test('auth', async () => {
   const { electionDefinition } = electionFamousNames2021Fixtures;
   const { electionData, electionHash } = electionDefinition;
-  const { apiClient, auth, workspace } = buildTestEnvironment();
-  workspace.store.addElection(
-    electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData
-  );
-  workspace.store.addElection(
-    electionFamousNames2021Fixtures.electionDefinition.electionData
-  );
+  const { apiClient, auth } = buildTestEnvironment();
+  await configureMachine(apiClient, auth, electionDefinition);
+  expect(auth.getAuthStatus).toHaveBeenCalledTimes(1);
 
   await apiClient.getAuthStatus();
   await apiClient.checkPin({ pin: '123456' });
@@ -393,8 +389,8 @@ test('auth', async () => {
   void (await apiClient.programCard({ userRole: 'election_manager' }));
   void (await apiClient.unprogramCard());
 
-  expect(auth.getAuthStatus).toHaveBeenCalledTimes(1);
-  expect(auth.getAuthStatus).toHaveBeenNthCalledWith(1, { electionHash });
+  expect(auth.getAuthStatus).toHaveBeenCalledTimes(2);
+  expect(auth.getAuthStatus).toHaveBeenNthCalledWith(2, { electionHash });
   expect(auth.checkPin).toHaveBeenCalledTimes(1);
   expect(auth.checkPin).toHaveBeenNthCalledWith(
     1,

--- a/apps/admin/backend/src/app.test.ts
+++ b/apps/admin/backend/src/app.test.ts
@@ -6,6 +6,7 @@ import {
   electionSampleCdfDefinition,
 } from '@votingworks/fixtures';
 import { LogEventId } from '@votingworks/logging';
+import { mockOf } from '@votingworks/test-utils';
 import { promises as fs } from 'fs';
 import { sha256 } from 'js-sha256';
 import { tmpdir } from 'os';
@@ -16,10 +17,13 @@ import {
   mockElectionManagerAuth,
   mockSystemAdministratorAuth,
 } from '../test/app';
+import { listCastVoteRecordFilesOnUsb } from './cvr_files';
 
 beforeEach(() => {
   jest.restoreAllMocks();
 });
+
+jest.mock('./cvr_files');
 
 test('managing the current election', async () => {
   const { apiClient, auth, logger } = buildTestEnvironment();
@@ -145,6 +149,10 @@ test('cast vote records - happy path election flow', async () => {
   expect(await apiClient.getCastVoteRecordFileMode()).toEqual(
     Admin.CvrFileMode.Unlocked
   );
+
+  // frontend can poll for available cast vote record files
+  mockOf(listCastVoteRecordFilesOnUsb).mockResolvedValueOnce([]);
+  expect(await apiClient.listCastVoteRecordFilesOnUsb()).toEqual([]);
 
   // add a file, with a filename that is not parse-able
   const cvrTestFilePath = standardCvrFile.asFilePath();

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -28,6 +28,7 @@ import { basename } from 'path';
 import { parseCvrFileInfoFromFilename } from '@votingworks/utils';
 import { AddCastVoteRecordFileResult, ConfigureResult } from './types';
 import { Workspace } from './util/workspace';
+import { listCastVoteRecordFilesOnUsb } from './cvr_files';
 
 function getMostRecentlyCreateElectionDefinition(
   workspace: Workspace
@@ -186,6 +187,14 @@ function buildApi({
           disposition: 'success',
         }
       );
+    },
+
+    listCastVoteRecordFilesOnUsb() {
+      const electionDefinition =
+        getMostRecentlyCreateElectionDefinition(workspace);
+      assert(electionDefinition);
+
+      return listCastVoteRecordFilesOnUsb(electionDefinition, logger);
     },
 
     getCastVoteRecordFiles(): Admin.CastVoteRecordFileRecord[] {

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -29,6 +29,7 @@ import { parseCvrFileInfoFromFilename } from '@votingworks/utils';
 import { AddCastVoteRecordFileResult, ConfigureResult } from './types';
 import { Workspace } from './util/workspace';
 import { listCastVoteRecordFilesOnUsb } from './cvr_files';
+import { Usb } from './util/usb';
 
 function getCurrentElectionDefinition(
   workspace: Workspace
@@ -58,10 +59,12 @@ function buildApi({
   auth,
   workspace,
   logger,
+  usb,
 }: {
   auth: DippedSmartCardAuthApi;
   workspace: Workspace;
   logger: Logger;
+  usb: Usb;
 }) {
   const { store } = workspace;
 
@@ -182,7 +185,7 @@ function buildApi({
       const electionDefinition = getCurrentElectionDefinition(workspace);
       assert(electionDefinition);
 
-      return listCastVoteRecordFilesOnUsb(electionDefinition, logger);
+      return listCastVoteRecordFilesOnUsb(electionDefinition, usb, logger);
     },
 
     getCastVoteRecordFiles(): Admin.CastVoteRecordFileRecord[] {
@@ -523,13 +526,15 @@ export function buildApp({
   auth,
   workspace,
   logger,
+  usb,
 }: {
   auth: DippedSmartCardAuthApi;
   workspace: Workspace;
   logger: Logger;
+  usb: Usb;
 }): Application {
   const app: Application = express();
-  const api = buildApi({ auth, workspace, logger });
+  const api = buildApi({ auth, workspace, logger, usb });
   app.use('/api', grout.buildRouter(api, express));
   return app;
 }

--- a/apps/admin/backend/src/cvr_files.test.ts
+++ b/apps/admin/backend/src/cvr_files.test.ts
@@ -1,0 +1,179 @@
+import {
+  listDirectoryOnUsbDrive,
+  FileSystemEntry,
+  FileSystemEntryType,
+} from '@votingworks/backend';
+import { err, ok } from '@votingworks/basics';
+import { electionMinimalExhaustiveSampleDefinition } from '@votingworks/fixtures';
+import { fakeLogger, LogEventId } from '@votingworks/logging';
+import { mockOf } from '@votingworks/test-utils';
+import { getDisplayElectionHash } from '@votingworks/types';
+import { listCastVoteRecordFilesOnUsb } from './cvr_files';
+
+jest.mock('@votingworks/backend');
+
+const mockListDirectoryOnUsbDrive = mockOf(listDirectoryOnUsbDrive);
+const mockFileSystemEntry: FileSystemEntry = {
+  name: 'TEST__machine_0000__4_ballots__2022-07-01_11-21-41.jsonl',
+  path: '/tmp/TEST__machine_0000__4_ballots__2022-07-01_11-21-41.jsonl',
+  type: FileSystemEntryType.File,
+  size: 1024,
+  mtime: new Date(),
+  atime: new Date(),
+  ctime: new Date(),
+};
+
+const electionDefinition = electionMinimalExhaustiveSampleDefinition;
+
+beforeEach(() => {
+  mockListDirectoryOnUsbDrive.mockReset();
+});
+
+describe('list cast vote record files on USB drive', () => {
+  test('files present', async () => {
+    const logger = fakeLogger();
+    mockListDirectoryOnUsbDrive.mockResolvedValueOnce(
+      ok([
+        mockFileSystemEntry, // valid
+        {
+          ...mockFileSystemEntry, // valid
+          name: 'TEST__machine_0000__8_ballots__2022-07-01_11-31-41.jsonl',
+          path: '/tmp/TEST__machine_0000__8_ballots__2022-07-01_11-31-41.jsonl',
+        },
+        {
+          ...mockFileSystemEntry, // invalid because file name
+          name: 'cvr.jsonl',
+          path: '/tmp/cvr.jsonl',
+        },
+        { ...mockFileSystemEntry, type: FileSystemEntryType.Directory }, // invalid because directory
+        {
+          ...mockFileSystemEntry,
+          name: 'TEST__machine_0000__4_ballots__2022-07-01_11-21-41.json', // invalid because extension
+          path: '/tmp/TEST__machine_0000__4_ballots__2022-07-01_11-21-41.json',
+        },
+      ])
+    );
+
+    const cvrFileMetadata = await listCastVoteRecordFilesOnUsb(
+      electionDefinition,
+      logger
+    );
+
+    expect(mockListDirectoryOnUsbDrive).toHaveBeenCalledWith(
+      `cast-vote-records/sample-county_example-primary-election_${getDisplayElectionHash(
+        electionDefinition
+      )}`
+    );
+    expect(cvrFileMetadata).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "cvrCount": 8,
+          "exportTimestamp": 2022-07-01T11:31:41.000Z,
+          "isTestModeResults": true,
+          "name": "TEST__machine_0000__8_ballots__2022-07-01_11-31-41.jsonl",
+          "path": "/tmp/TEST__machine_0000__8_ballots__2022-07-01_11-31-41.jsonl",
+          "scannerIds": Array [
+            "0000",
+          ],
+        },
+        Object {
+          "cvrCount": 4,
+          "exportTimestamp": 2022-07-01T11:21:41.000Z,
+          "isTestModeResults": true,
+          "name": "TEST__machine_0000__4_ballots__2022-07-01_11-21-41.jsonl",
+          "path": "/tmp/TEST__machine_0000__4_ballots__2022-07-01_11-21-41.jsonl",
+          "scannerIds": Array [
+            "0000",
+          ],
+        },
+      ]
+    `);
+
+    expect(logger.log).toHaveBeenCalledWith(
+      LogEventId.CvrFilesReadFromUsb,
+      'system',
+      {
+        disposition: 'success',
+        message: 'Found 2 CVR files on USB drive, user shown option to load.',
+      }
+    );
+  });
+
+  test('usb not present or mounted', async () => {
+    const logger = fakeLogger();
+
+    mockListDirectoryOnUsbDrive.mockResolvedValueOnce(
+      err({ type: 'usb-drive-not-mounted' })
+    );
+    expect(
+      await listCastVoteRecordFilesOnUsb(electionDefinition, logger)
+    ).toEqual([]);
+
+    mockListDirectoryOnUsbDrive.mockResolvedValueOnce(
+      err({ type: 'no-usb-drive' })
+    );
+    expect(
+      await listCastVoteRecordFilesOnUsb(electionDefinition, logger)
+    ).toEqual([]);
+
+    expect(logger.log).not.toHaveBeenCalled();
+  });
+
+  test('default directory not found on USB', async () => {
+    const logger = fakeLogger();
+
+    mockListDirectoryOnUsbDrive.mockResolvedValueOnce(
+      err({ type: 'no-entity', message: 'any' })
+    );
+    expect(
+      await listCastVoteRecordFilesOnUsb(electionDefinition, logger)
+    ).toEqual([]);
+    expect(logger.log).toHaveBeenCalledWith(
+      LogEventId.CvrFilesReadFromUsb,
+      'system',
+      {
+        disposition: 'success',
+        message:
+          'No cast vote record files automatically found on USB drive. User is allowed to manually select files.',
+      }
+    );
+  });
+
+  test('unexpected issue accessing directory', async () => {
+    const logger = fakeLogger();
+
+    mockListDirectoryOnUsbDrive.mockResolvedValueOnce(
+      err({ type: 'not-directory', message: 'any' })
+    );
+    expect(
+      await listCastVoteRecordFilesOnUsb(electionDefinition, logger)
+    ).toEqual([]);
+    expect(logger.log).toHaveBeenNthCalledWith(
+      1,
+      LogEventId.CvrFilesReadFromUsb,
+      'system',
+      {
+        disposition: 'failure',
+        message:
+          'Error accessing cast vote record files on USB drive, which may be corrupted.',
+      }
+    );
+
+    mockListDirectoryOnUsbDrive.mockResolvedValueOnce(
+      err({ type: 'permission-denied', message: 'any' })
+    );
+    expect(
+      await listCastVoteRecordFilesOnUsb(electionDefinition, logger)
+    ).toEqual([]);
+    expect(logger.log).toHaveBeenNthCalledWith(
+      2,
+      LogEventId.CvrFilesReadFromUsb,
+      'system',
+      {
+        disposition: 'failure',
+        message:
+          'Error accessing cast vote record files on USB drive, which may be corrupted.',
+      }
+    );
+  });
+});

--- a/apps/admin/backend/src/cvr_files.ts
+++ b/apps/admin/backend/src/cvr_files.ts
@@ -12,6 +12,7 @@ import {
 } from '@votingworks/utils';
 import { join } from 'path';
 import { CastVoteRecordFileMetadata } from './types';
+import { Usb } from './util/usb';
 
 /**
  * Gets the metadata, including the path, of cast vote record files found in
@@ -20,6 +21,7 @@ import { CastVoteRecordFileMetadata } from './types';
  */
 export async function listCastVoteRecordFilesOnUsb(
   electionDefinition: ElectionDefinition,
+  usb: Usb,
   logger: Logger
 ): Promise<CastVoteRecordFileMetadata[]> {
   const { election, electionHash } = electionDefinition;
@@ -27,7 +29,8 @@ export async function listCastVoteRecordFilesOnUsb(
     join(
       SCANNER_RESULTS_FOLDER,
       generateElectionBasedSubfolderName(election, electionHash)
-    )
+    ),
+    usb.getUsbDrives
   );
 
   if (fileSearchResult.isErr()) {

--- a/apps/admin/backend/src/cvr_files.ts
+++ b/apps/admin/backend/src/cvr_files.ts
@@ -1,0 +1,108 @@
+import {
+  FileSystemEntryType,
+  listDirectoryOnUsbDrive,
+} from '@votingworks/backend';
+import { throwIllegalValue } from '@votingworks/basics';
+import { LogEventId, Logger } from '@votingworks/logging';
+import { ElectionDefinition } from '@votingworks/types';
+import {
+  generateElectionBasedSubfolderName,
+  parseCvrFileInfoFromFilename,
+  SCANNER_RESULTS_FOLDER,
+} from '@votingworks/utils';
+import { join } from 'path';
+
+/**
+ * Metadata about a found cast vote record file.
+ */
+export interface CastVoteRecordFileMetadata {
+  readonly name: string;
+  readonly path: string;
+  readonly cvrCount: number;
+  readonly scannerIds: readonly string[];
+  readonly exportTimestamp: Date;
+  readonly isTestModeResults: boolean;
+}
+
+/**
+ * Gets the metadata, including the path, of cast vote record files found in
+ * the default location on a mounted USB drive. If there is no mounted USB
+ * drive or the USB drive appears corrupted then it will return an empty array.
+ */
+export async function listCastVoteRecordFilesOnUsb(
+  electionDefinition: ElectionDefinition,
+  logger: Logger
+): Promise<CastVoteRecordFileMetadata[]> {
+  const { election, electionHash } = electionDefinition;
+  const fileSearchResult = await listDirectoryOnUsbDrive(
+    join(
+      SCANNER_RESULTS_FOLDER,
+      generateElectionBasedSubfolderName(election, electionHash)
+    )
+  );
+
+  if (fileSearchResult.isErr()) {
+    const errorType = fileSearchResult.err().type;
+    switch (errorType) {
+      case 'no-entity':
+        await logger.log(LogEventId.CvrFilesReadFromUsb, 'system', {
+          message:
+            'No cast vote record files automatically found on USB drive. User is allowed to manually select files.',
+          disposition: 'success',
+        });
+        break;
+      case 'not-directory':
+      case 'permission-denied':
+        await logger.log(LogEventId.CvrFilesReadFromUsb, 'system', {
+          message:
+            'Error accessing cast vote record files on USB drive, which may be corrupted.',
+          disposition: 'failure',
+        });
+        break;
+      case 'no-usb-drive':
+      case 'usb-drive-not-mounted':
+        // we're just polling without a USB drive in these cases, no issue
+        break;
+      default:
+        throwIllegalValue(errorType);
+    }
+
+    return [];
+  }
+
+  const castVoteRecordFileMetadataList: CastVoteRecordFileMetadata[] = [];
+
+  for (const entry of fileSearchResult.ok()) {
+    if (
+      entry.type === FileSystemEntryType.File &&
+      entry.name.endsWith('.jsonl')
+    ) {
+      try {
+        const parsedFileInfo = parseCvrFileInfoFromFilename(entry.name);
+        if (parsedFileInfo) {
+          castVoteRecordFileMetadataList.push({
+            exportTimestamp: parsedFileInfo.timestamp,
+            cvrCount: parsedFileInfo.numberOfBallots,
+            isTestModeResults: parsedFileInfo.isTestModeResults,
+            name: entry.name,
+            path: entry.path,
+            scannerIds: [parsedFileInfo.machineId],
+          });
+        }
+      } catch (error) {
+        // The filename isn't able to be parsed as a valid CVR filename. We are
+        // only interested in valid CVR files so ignore it.
+        continue;
+      }
+    }
+  }
+
+  await logger.log(LogEventId.CvrFilesReadFromUsb, 'system', {
+    message: `Found ${castVoteRecordFileMetadataList.length} CVR files on USB drive, user shown option to load.`,
+    disposition: 'success',
+  });
+
+  return [...castVoteRecordFileMetadataList].sort(
+    (a, b) => b.exportTimestamp.getTime() - a.exportTimestamp.getTime()
+  );
+}

--- a/apps/admin/backend/src/cvr_files.ts
+++ b/apps/admin/backend/src/cvr_files.ts
@@ -11,18 +11,7 @@ import {
   SCANNER_RESULTS_FOLDER,
 } from '@votingworks/utils';
 import { join } from 'path';
-
-/**
- * Metadata about a found cast vote record file.
- */
-export interface CastVoteRecordFileMetadata {
-  readonly name: string;
-  readonly path: string;
-  readonly cvrCount: number;
-  readonly scannerIds: readonly string[];
-  readonly exportTimestamp: Date;
-  readonly isTestModeResults: boolean;
-}
+import { CastVoteRecordFileMetadata } from './types';
 
 /**
  * Gets the metadata, including the path, of cast vote record files found in

--- a/apps/admin/backend/src/server.test.ts
+++ b/apps/admin/backend/src/server.test.ts
@@ -8,6 +8,7 @@ import { start } from './server';
 import { createWorkspace } from './util/workspace';
 import { PORT } from './globals';
 import { buildApp } from './app';
+import { createMockUsb } from '../test/app';
 
 beforeEach(() => {
   jest.restoreAllMocks();
@@ -17,7 +18,8 @@ test('starts with default logger and port', async () => {
   const auth = buildMockDippedSmartCardAuth();
   const workspace = createWorkspace(dirSync().name);
   const logger = fakeLogger();
-  const app = buildApp({ auth, workspace, logger });
+  const { usb } = createMockUsb();
+  const app = buildApp({ auth, workspace, logger, usb });
 
   // don't actually listen
   jest.spyOn(app, 'listen').mockImplementationOnce((_port, onListening) => {
@@ -39,7 +41,8 @@ test('start with config options', async () => {
   const auth = buildMockDippedSmartCardAuth();
   const workspace = createWorkspace(dirSync().name);
   const logger = fakeLogger();
-  const app = buildApp({ auth, workspace, logger });
+  const { usb } = createMockUsb();
+  const app = buildApp({ auth, workspace, logger, usb });
 
   // don't actually listen
   jest.spyOn(app, 'listen').mockImplementationOnce((_port, onListening) => {
@@ -59,7 +62,8 @@ test('errors on start with no workspace', async () => {
   const auth = buildMockDippedSmartCardAuth();
   const workspace = createWorkspace(dirSync().name);
   const logger = fakeLogger();
-  const app = buildApp({ auth, workspace, logger });
+  const { usb } = createMockUsb();
+  const app = buildApp({ auth, workspace, logger, usb });
 
   // start up the server
   try {

--- a/apps/admin/backend/src/server.ts
+++ b/apps/admin/backend/src/server.ts
@@ -6,6 +6,7 @@ import {
   JavaCard,
   constructDevJavaCardConfig,
 } from '@votingworks/auth';
+import { getUsbDrives } from '@votingworks/backend';
 import { Server } from 'http';
 import {
   BooleanEnvironmentVariableName,
@@ -14,6 +15,7 @@ import {
 import { ADMIN_WORKSPACE, PORT } from './globals';
 import { createWorkspace, Workspace } from './util/workspace';
 import { buildApp } from './app';
+import { Usb } from './util/usb';
 
 /**
  * Options for starting the admin service.
@@ -73,6 +75,8 @@ export async function start({
   // clear any cached data
   resolvedWorkspace.clearUploads();
 
+  const usb: Usb = { getUsbDrives };
+
   /* istanbul ignore next */
   const resolvedApp =
     app ??
@@ -80,6 +84,7 @@ export async function start({
       auth,
       workspace: resolvedWorkspace,
       logger,
+      usb,
     });
 
   const server = resolvedApp.listen(port, async () => {

--- a/apps/admin/backend/src/types.ts
+++ b/apps/admin/backend/src/types.ts
@@ -25,3 +25,15 @@ export type AddCastVoteRecordFileResult = Result<
   Admin.CvrFileImportInfo,
   AddCastVoteRecordFileError
 >;
+
+/**
+ * Metadata about a cast vote record file found on a USB drive.
+ */
+export interface CastVoteRecordFileMetadata {
+  readonly name: string;
+  readonly path: string;
+  readonly cvrCount: number;
+  readonly scannerIds: readonly string[];
+  readonly exportTimestamp: Date;
+  readonly isTestModeResults: boolean;
+}

--- a/apps/admin/backend/src/util/usb.ts
+++ b/apps/admin/backend/src/util/usb.ts
@@ -1,0 +1,9 @@
+import { UsbDrive } from '@votingworks/backend';
+
+/**
+ * An interface for interacting with USB drives. We inject this into the apps so
+ * that we can easily mock it in tests.
+ */
+export interface Usb {
+  getUsbDrives: () => Promise<UsbDrive[]>;
+}

--- a/apps/admin/backend/tsconfig.build.json
+++ b/apps/admin/backend/tsconfig.build.json
@@ -12,6 +12,7 @@
   "references": [
     { "path": "../../../libs/api/tsconfig.build.json" },
     { "path": "../../../libs/auth/tsconfig.build.json" },
+    { "path": "../../../libs/backend/tsconfig.build.json" },
     { "path": "../../../libs/basics/tsconfig.build.json" },
     { "path": "../../../libs/db/tsconfig.build.json" },
     { "path": "../../../libs/eslint-plugin-vx/tsconfig.build.json" },

--- a/apps/admin/backend/tsconfig.json
+++ b/apps/admin/backend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../../tsconfig.shared.json",
-  "include": ["src"],
+  "include": ["src", "test"],
   "exclude": [],
   "compilerOptions": {
     "allowJs": true,

--- a/apps/admin/backend/tsconfig.json
+++ b/apps/admin/backend/tsconfig.json
@@ -18,6 +18,7 @@
   "references": [
     { "path": "../../../libs/api/tsconfig.build.json" },
     { "path": "../../../libs/auth/tsconfig.build.json" },
+    { "path": "../../../libs/backend/tsconfig.build.json" },
     { "path": "../../../libs/basics/tsconfig.build.json" },
     { "path": "../../../libs/db/tsconfig.build.json" },
     { "path": "../../../libs/eslint-plugin-vx/tsconfig.build.json" },

--- a/apps/admin/backend/tsconfig.json
+++ b/apps/admin/backend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../../tsconfig.shared.json",
-  "include": ["src", "test"],
+  "include": ["src"],
   "exclude": [],
   "compilerOptions": {
     "allowJs": true,

--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -123,6 +123,18 @@ export const getCurrentElectionMetadata = {
   },
 } as const;
 
+export const listCastVoteRecordFilesOnUsb = {
+  queryKey(): QueryKey {
+    return ['listCastVoteRecordFilesOnUsb'];
+  },
+  useQuery() {
+    const apiClient = useApiClient();
+    return useQuery(this.queryKey(), () =>
+      apiClient.listCastVoteRecordFilesOnUsb()
+    );
+  },
+} as const;
+
 export const getCastVoteRecordFiles = {
   queryKey(): QueryKey {
     return ['getCastVoteRecordFiles'];

--- a/apps/admin/frontend/test/helpers/api_mock.ts
+++ b/apps/admin/frontend/test/helpers/api_mock.ts
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react';
-import type { Api } from '@votingworks/admin-backend'; // eslint-disable-line vx/gts-no-import-export-type
+import { Api, CastVoteRecordFileMetadata } from '@votingworks/admin-backend';
 import { Admin } from '@votingworks/api';
 import { ok } from '@votingworks/basics';
 import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
@@ -186,6 +186,10 @@ export function createApiMock(
 
     expectClearCastVoteRecordFiles() {
       apiClient.clearCastVoteRecordFiles.expectCallWith().resolves();
+    },
+
+    expectListCastVoteRecordFilesOnUsb(files: CastVoteRecordFileMetadata[]) {
+      apiClient.listCastVoteRecordFilesOnUsb.expectCallWith().resolves(files);
     },
   };
 }

--- a/libs/backend/jest.config.js
+++ b/libs/backend/jest.config.js
@@ -7,10 +7,10 @@ module.exports = {
   ...shared,
   coverageThreshold: {
     global: {
-      statements: 95,
-      branches: 85,
+      statements: 93,
+      branches: 83,
       functions: 95,
-      lines: 95,
+      lines: 94,
     },
   },
 };

--- a/libs/backend/src/index.ts
+++ b/libs/backend/src/index.ts
@@ -3,3 +3,4 @@ export * from './exporter';
 export * from './get_usb_drives';
 export * from './scan';
 export * from './split';
+export * from './list_directory';

--- a/libs/backend/src/list_directory.test.ts
+++ b/libs/backend/src/list_directory.test.ts
@@ -112,4 +112,29 @@ describe('listDirectoryOnUsbDrive', () => {
       type: 'usb-drive-not-mounted',
     });
   });
+
+  test('can inject a different getUsbDrive for testing', async () => {
+    const mockMountPoint = tmp.dirSync();
+    const directory = tmp.dirSync({
+      name: 'directory',
+      dir: mockMountPoint.name,
+    });
+    tmp.fileSync({ name: 'mock-file-1', dir: directory.name });
+
+    const injectedGetUsbDrive = jest
+      .fn()
+      .mockResolvedValueOnce([
+        { deviceName: 'mock', mountPoint: mockMountPoint.name },
+      ]);
+
+    const result = await listDirectoryOnUsbDrive(
+      './directory',
+      injectedGetUsbDrive
+    );
+    expect(result.ok()).toMatchObject([
+      expect.objectContaining({
+        name: 'mock-file-1',
+      }),
+    ]);
+  });
 });

--- a/libs/backend/src/list_directory.test.ts
+++ b/libs/backend/src/list_directory.test.ts
@@ -1,0 +1,123 @@
+import { mockOf } from '@votingworks/test-utils';
+import tmp from 'tmp';
+import { getUsbDrives } from './get_usb_drives';
+import {
+  FileSystemEntryType,
+  listDirectory,
+  listDirectoryOnUsbDrive,
+} from './list_directory';
+
+jest.mock('./get_usb_drives');
+
+const getUsbDrivesMock = mockOf(getUsbDrives);
+
+describe('listDirectory', () => {
+  test('happy path', async () => {
+    const directory = tmp.dirSync({
+      dir: '/tmp',
+    });
+    tmp.fileSync({ name: 'file-1', dir: directory.name });
+    tmp.fileSync({ name: 'file-2', dir: directory.name });
+    tmp.dirSync({
+      name: 'subdirectory',
+      dir: directory.name,
+    });
+
+    const listDirectoryResult = await listDirectory(directory.name);
+    expect(listDirectoryResult.isOk()).toBeTruthy();
+
+    expect(listDirectoryResult.ok()).toMatchObject([
+      expect.objectContaining({
+        name: 'file-1',
+        type: FileSystemEntryType.File,
+      }),
+      expect.objectContaining({
+        name: 'file-2',
+        type: FileSystemEntryType.File,
+      }),
+      expect.objectContaining({
+        name: 'subdirectory',
+        type: FileSystemEntryType.Directory,
+      }),
+    ]);
+  });
+
+  test('throws error on relative path', async () => {
+    await expect(listDirectory('./relative')).rejects.toThrow();
+  });
+
+  test('returns error on non-existent file', async () => {
+    const listDirectoryResult = await listDirectory('/tmp/no-entity');
+    expect(listDirectoryResult.isErr()).toBeTruthy();
+    expect(listDirectoryResult.err()).toMatchObject({ type: 'no-entity' });
+  });
+
+  test('returns error on non-directory', async () => {
+    const file = tmp.fileSync();
+    const listDirectoryResult = await listDirectory(file.name);
+    expect(listDirectoryResult.isErr()).toBeTruthy();
+    expect(listDirectoryResult.err()).toMatchObject({ type: 'not-directory' });
+  });
+
+  test('returns error on permission denied', async () => {
+    const listDirectoryResult = await listDirectory('/root');
+    expect(listDirectoryResult.isErr()).toBeTruthy();
+    expect(listDirectoryResult.err()).toMatchObject({
+      type: 'permission-denied',
+    });
+  });
+});
+
+describe('listDirectoryOnUsbDrive', () => {
+  test('happy path', async () => {
+    const mockMountPoint = tmp.dirSync();
+    getUsbDrivesMock.mockResolvedValueOnce([
+      { deviceName: 'mock', mountPoint: mockMountPoint.name },
+    ]);
+
+    const directory = tmp.dirSync({
+      name: 'directory',
+      dir: mockMountPoint.name,
+    });
+    tmp.fileSync({ name: 'file-1', dir: directory.name });
+    tmp.fileSync({ name: 'file-2', dir: directory.name });
+    tmp.dirSync({
+      name: 'subdirectory',
+      dir: directory.name,
+    });
+
+    const listDirectoryResult = await listDirectoryOnUsbDrive('./directory');
+    expect(listDirectoryResult.isOk()).toBeTruthy();
+
+    expect(listDirectoryResult.ok()).toMatchObject([
+      expect.objectContaining({
+        name: 'file-1',
+        type: FileSystemEntryType.File,
+      }),
+      expect.objectContaining({
+        name: 'file-2',
+        type: FileSystemEntryType.File,
+      }),
+      expect.objectContaining({
+        name: 'subdirectory',
+        type: FileSystemEntryType.Directory,
+      }),
+    ]);
+  });
+
+  test('error on no usb drive', async () => {
+    getUsbDrivesMock.mockResolvedValueOnce([]);
+    const listDirectoryResult = await listDirectoryOnUsbDrive('./directory');
+    expect(listDirectoryResult.isErr()).toBeTruthy();
+    expect(listDirectoryResult.err()).toMatchObject({ type: 'no-usb-drive' });
+  });
+
+  test('error on unmounted usb drive', async () => {
+    getUsbDrivesMock.mockResolvedValueOnce([{ deviceName: 'mock' }]);
+    const listDirectoryResult = await listDirectoryOnUsbDrive('./directory');
+    expect(listDirectoryResult.isErr()).toBeTruthy();
+    expect(listDirectoryResult.err()).toMatchObject({
+      type: 'usb-drive-not-mounted',
+    });
+  });
+});

--- a/libs/backend/src/list_directory.test.ts
+++ b/libs/backend/src/list_directory.test.ts
@@ -58,14 +58,6 @@ describe('listDirectory', () => {
     expect(listDirectoryResult.isErr()).toBeTruthy();
     expect(listDirectoryResult.err()).toMatchObject({ type: 'not-directory' });
   });
-
-  test('returns error on permission denied', async () => {
-    const listDirectoryResult = await listDirectory('/root');
-    expect(listDirectoryResult.isErr()).toBeTruthy();
-    expect(listDirectoryResult.err()).toMatchObject({
-      type: 'permission-denied',
-    });
-  });
 });
 
 describe('listDirectoryOnUsbDrive', () => {

--- a/libs/backend/src/list_directory.ts
+++ b/libs/backend/src/list_directory.ts
@@ -1,7 +1,10 @@
 import { err, ok, Result, assert } from '@votingworks/basics';
 import { Dirent, promises as fs } from 'fs';
 import { isAbsolute, join } from 'path';
-import { getUsbDrives } from './get_usb_drives';
+import {
+  getUsbDrives as defaultGetUsbDrives,
+  UsbDrive,
+} from './get_usb_drives';
 
 /**
  * Types of file system entities defined in `libuv`. We omit only `Unknown`,
@@ -119,7 +122,8 @@ export type ListDirectoryOnUsbDriveError =
  * drive's filesystem. Looks at only the first found USB drive.
  */
 export async function listDirectoryOnUsbDrive(
-  relativePath: string
+  relativePath: string,
+  getUsbDrives: () => Promise<UsbDrive[]> = defaultGetUsbDrives
 ): Promise<Result<FileSystemEntry[], ListDirectoryOnUsbDriveError>> {
   // We currently do not support multiple USB drives
   const [usbDrive] = await getUsbDrives();

--- a/libs/backend/src/list_directory.ts
+++ b/libs/backend/src/list_directory.ts
@@ -1,0 +1,137 @@
+import { err, ok, Result, assert } from '@votingworks/basics';
+import { Dirent, promises as fs } from 'fs';
+import { isAbsolute, join } from 'path';
+import { getUsbDrives } from './get_usb_drives';
+
+/**
+ * Types of file system entities defined in `libuv`. We omit only `Unknown`,
+ * which we handle as an error.
+ */
+export enum FileSystemEntryType {
+  File = 1, // UV_DIRENT_FILE
+  Directory = 2, // UV_DIRENT_DIR
+  SymbolicLink = 3, // UV_DIRENT_LINK
+  FIFO = 4, // UV_DIRENT_FIFO
+  Socket = 5, // UV_DIRENT_SOCKET
+  CharacterDevice = 6, // UV_DIRENT_CHAR
+  BlockDevice = 7, // UV_DIRENT_BLOCK
+}
+
+/**
+ * Information about a file system entry found in a directory.
+ */
+export interface FileSystemEntry {
+  readonly name: string;
+  readonly path: string;
+  readonly type: FileSystemEntryType;
+  readonly size: number;
+  readonly mtime: Date;
+  readonly atime: Date;
+  readonly ctime: Date;
+}
+
+/**
+ * Finds the {@link FileSystemEntryType} of a directory entity.
+ */
+function getDirentType(dirent: Dirent): FileSystemEntryType {
+  if (dirent.isFile()) return FileSystemEntryType.File;
+  if (dirent.isDirectory()) return FileSystemEntryType.Directory;
+  if (dirent.isSymbolicLink()) return FileSystemEntryType.SymbolicLink;
+  if (dirent.isFIFO()) return FileSystemEntryType.FIFO;
+  if (dirent.isSocket()) return FileSystemEntryType.Socket;
+  if (dirent.isCharacterDevice()) return FileSystemEntryType.CharacterDevice;
+  if (dirent.isBlockDevice()) return FileSystemEntryType.BlockDevice;
+  throw new TypeError('dirent is not of a known type');
+}
+
+/**
+ * Expected errors that can occur when trying to list directories at an absolute path.
+ */
+export type ListDirectoryError =
+  | { type: 'permission-denied'; message: string }
+  | { type: 'no-entity'; message: string }
+  | { type: 'not-directory'; message: string };
+
+/**
+ * Get entries for a directory, includes stat information for each entry.
+ * Requires that the path be absolute.
+ */
+export async function listDirectory(
+  path: string
+): Promise<Result<FileSystemEntry[], ListDirectoryError>> {
+  assert(isAbsolute(path));
+
+  try {
+    const entries = await fs.readdir(path, { withFileTypes: true });
+    return ok(
+      await Promise.all(
+        entries
+          .filter((entry) => entry.isFile() || entry.isDirectory())
+          .map(async (entry) => {
+            const entryPath = join(path, entry.name);
+            const stat = await fs.lstat(entryPath);
+
+            return {
+              name: entry.name,
+              path: entryPath,
+              size: stat.size,
+              type: getDirentType(entry),
+              mtime: stat.mtime,
+              atime: stat.atime,
+              ctime: stat.ctime,
+            };
+          })
+      )
+    );
+  } catch (e) {
+    const error = e as { code: string };
+    switch (error.code) {
+      case 'ENOENT':
+        return err({
+          type: 'no-entity',
+          message: `${path} does not exist`,
+        });
+      case 'ENOTDIR':
+        return err({
+          type: 'not-directory',
+          message: `${path} is not a directory`,
+        });
+      case 'EACCES':
+        return err({
+          type: 'permission-denied',
+          message: `insufficient permissions to read from ${path}`,
+        });
+      default:
+        throw error;
+    }
+  }
+}
+
+/**
+ * Expected errors that can occur when trying to list directories on a USB drive.
+ */
+export type ListDirectoryOnUsbDriveError =
+  | ListDirectoryError
+  | { type: 'no-usb-drive' }
+  | { type: 'usb-drive-not-mounted' };
+/**
+ * Lists entities in a directory specified by a relative path within a USB
+ * drive's filesystem. Looks at only the first found USB drive.
+ */
+export async function listDirectoryOnUsbDrive(
+  relativePath: string
+): Promise<Result<FileSystemEntry[], ListDirectoryOnUsbDriveError>> {
+  // We currently do not support multiple USB drives
+  const [usbDrive] = await getUsbDrives();
+
+  if (!usbDrive) {
+    return err({ type: 'no-usb-drive' });
+  }
+
+  if (!usbDrive.mountPoint) {
+    return err({ type: 'usb-drive-not-mounted' });
+  }
+
+  const absolutePath = join(usbDrive.mountPoint, relativePath);
+  return await listDirectory(absolutePath);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,7 @@ importers:
       '@typescript-eslint/parser': ^5.37.0
       '@votingworks/api': workspace:*
       '@votingworks/auth': workspace:*
+      '@votingworks/backend': workspace:*
       '@votingworks/basics': workspace:*
       '@votingworks/db': workspace:*
       '@votingworks/fixtures': workspace:*
@@ -135,6 +136,7 @@ importers:
     dependencies:
       '@votingworks/api': link:../../../libs/api
       '@votingworks/auth': link:../../../libs/auth
+      '@votingworks/backend': link:../../../libs/backend
       '@votingworks/basics': link:../../../libs/basics
       '@votingworks/db': link:../../../libs/db
       '@votingworks/fixtures': link:../../../libs/fixtures
@@ -19393,18 +19395,6 @@ packages:
       debug: 4.3.2
     dev: false
 
-  /follow-redirects/1.14.1_debug@4.3.4:
-    resolution: {integrity: sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dependencies:
-      debug: 4.3.4
-    dev: false
-
   /for-each/0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
     dependencies:
@@ -20377,7 +20367,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.14.1_debug@4.3.4
+      follow-redirects: 1.14.1_debug@4.3.2
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug


### PR DESCRIPTION
## Overview

We list available CVR files on a USB drive for the user when they are importing CVR files. This PR moves the listing (reading of the directory on the USB drive) from the frontend to the backend. We'll have to update this listing and loading code when we switch to CVR CDF so it seemed appropriate to first move it to the backend.

Closes #3076, but does not achieve one of its main goals - re-enabling the integration testing disabled in #3052. See below for discussion.

## Testing Plan
- Testing in `libs/backend`, `admin/backend` and `admin/frontend`
- Manual Testing

## Checklist

- [ ] I have added
      [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging)
      where appropriate to any new user actions, system updates such as file
      reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an
      announcement in #machine-product-updates
