### PR TITLE
fix(lint): make VS Code+ESLint integration work

### DIFF
--- a/apps/admin/backend/package.json
+++ b/apps/admin/backend/package.json
@@ -74,7 +74,7 @@
     "@votingworks/test-utils": "workspace:*",
     "esbuild": "^0.14.29",
     "esbuild-runner": "^2.2.1",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-node": "^0.3.4",
     "eslint-plugin-cypress": "^2.12.1",

--- a/apps/admin/frontend/package.json
+++ b/apps/admin/frontend/package.json
@@ -185,7 +185,7 @@
     "@votingworks/grout-test-utils": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
     "babel-plugin-transform-import-meta": "^2.1.1",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.5.0",
     "eslint-config-react-app": "^7.0.1",

--- a/apps/admin/integration-testing/package.json
+++ b/apps/admin/integration-testing/package.json
@@ -53,7 +53,7 @@
     "@typescript-eslint/eslint-plugin": "^5.37.0",
     "@typescript-eslint/parser": "^5.37.0",
     "concurrently": "^7.6.0",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-node": "^0.3.4",

--- a/apps/central-scan/backend/package.json
+++ b/apps/central-scan/backend/package.json
@@ -93,7 +93,7 @@
     "@typescript-eslint/parser": "^5.37.0",
     "esbuild": "^0.14.29",
     "esbuild-runner": "^2.2.1",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-node": "^0.3.4",
     "eslint-plugin-cypress": "^2.12.1",

--- a/apps/central-scan/frontend/package.json
+++ b/apps/central-scan/frontend/package.json
@@ -113,7 +113,7 @@
     "@votingworks/test-utils": "workspace:*",
     "esbuild": "^0.15.10",
     "esbuild-runner": "^2.2.1",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-node": "^0.3.4",

--- a/apps/central-scan/integration-testing/package.json
+++ b/apps/central-scan/integration-testing/package.json
@@ -52,7 +52,7 @@
     "@typescript-eslint/eslint-plugin": "^5.37.0",
     "@typescript-eslint/parser": "^5.37.0",
     "concurrently": "^7.6.0",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-node": "^0.3.4",

--- a/apps/mark/backend/package.json
+++ b/apps/mark/backend/package.json
@@ -56,7 +56,7 @@
     "@votingworks/test-utils": "workspace:*",
     "esbuild": "^0.14.29",
     "esbuild-runner": "^2.2.1",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-node": "^0.3.4",
     "eslint-plugin-import": "^2.26.0",

--- a/apps/mark/frontend/package.json
+++ b/apps/mark/frontend/package.json
@@ -144,7 +144,7 @@
     "@votingworks/test-utils": "workspace:*",
     "chalk": "^4.1.2",
     "concurrently": "^7.3.0",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.5.0",
     "eslint-config-react-app": "^7.0.1",

--- a/apps/mark/integration-testing/package.json
+++ b/apps/mark/integration-testing/package.json
@@ -53,7 +53,7 @@
     "@typescript-eslint/eslint-plugin": "^5.37.0",
     "@typescript-eslint/parser": "^5.37.0",
     "concurrently": "^7.6.0",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-node": "^0.3.4",

--- a/apps/scan/backend/package.json
+++ b/apps/scan/backend/package.json
@@ -90,7 +90,7 @@
     "@typescript-eslint/parser": "^5.37.0",
     "esbuild": "^0.14.29",
     "esbuild-runner": "^2.2.1",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-node": "^0.3.4",
     "eslint-plugin-import": "^2.26.0",

--- a/apps/scan/frontend/package.json
+++ b/apps/scan/frontend/package.json
@@ -102,7 +102,7 @@
     "@votingworks/grout-test-utils": "workspace:*",
     "@votingworks/scan-backend": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.5.0",
     "eslint-config-react-app": "^7.0.1",

--- a/libs/api/package.json
+++ b/libs/api/package.json
@@ -44,7 +44,7 @@
     "@types/jest": "^27.0.3",
     "@typescript-eslint/eslint-plugin": "^5.37.0",
     "@typescript-eslint/parser": "^5.37.0",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-plugin-import": "^2.26.0",

--- a/libs/auth/package.json
+++ b/libs/auth/package.json
@@ -50,7 +50,7 @@
     "@typescript-eslint/parser": "^5.37.0",
     "@votingworks/test-utils": "workspace:*",
     "esbuild-runner": "^2.2.1",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-plugin-import": "^2.26.0",

--- a/libs/backend/package.json
+++ b/libs/backend/package.json
@@ -57,7 +57,7 @@
     "@typescript-eslint/eslint-plugin": "^5.37.0",
     "@typescript-eslint/parser": "^5.37.0",
     "@votingworks/test-utils": "workspace:*",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-plugin-import": "^2.26.0",

--- a/libs/ballot-encoder/package.json
+++ b/libs/ballot-encoder/package.json
@@ -45,7 +45,7 @@
     "@typescript-eslint/eslint-plugin": "^5.37.0",
     "@typescript-eslint/parser": "^5.37.0",
     "@votingworks/fixtures": "workspace:*",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-node": "^0.3.4",
     "eslint-plugin-import": "^2.26.0",

--- a/libs/ballot-interpreter-nh/package.json
+++ b/libs/ballot-interpreter-nh/package.json
@@ -52,7 +52,7 @@
     "@votingworks/test-utils": "workspace:*",
     "esbuild": "^0.14.23",
     "esbuild-runner": "^2.2.1",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-plugin-import": "^2.26.0",

--- a/libs/ballot-interpreter-vx/package.json
+++ b/libs/ballot-interpreter-vx/package.json
@@ -72,7 +72,7 @@
     "benchmark": "^2.1.4",
     "esbuild": "^0.14.25",
     "esbuild-runner": "^2.2.1",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-node": "^0.3.6",

--- a/libs/basics/package.json
+++ b/libs/basics/package.json
@@ -38,7 +38,7 @@
     "@types/node": "^18.11.18",
     "@typescript-eslint/eslint-plugin": "^5.37.0",
     "@typescript-eslint/parser": "^5.37.0",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-plugin-import": "^2.26.0",

--- a/libs/cdf-schema-builder/package.json
+++ b/libs/cdf-schema-builder/package.json
@@ -47,7 +47,7 @@
     "@types/node": "16.11.29",
     "@typescript-eslint/eslint-plugin": "^5.37.0",
     "@typescript-eslint/parser": "^5.37.0",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-node": "^0.3.4",
     "eslint-plugin-import": "^2.26.0",

--- a/libs/cvr-fixture-generator/package.json
+++ b/libs/cvr-fixture-generator/package.json
@@ -39,7 +39,7 @@
     "@typescript-eslint/eslint-plugin": "^5.37.0",
     "@typescript-eslint/parser": "^5.37.0",
     "@votingworks/test-utils": "*",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-plugin-import": "^2.26.0",

--- a/libs/db/package.json
+++ b/libs/db/package.json
@@ -33,7 +33,7 @@
     "@types/tmp": "^0.2.3",
     "@typescript-eslint/eslint-plugin": "^5.37.0",
     "@typescript-eslint/parser": "^5.37.0",
-    "eslint": "^8.26.0",
+    "eslint": "8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-plugin-import": "^2.26.0",

--- a/libs/eslint-plugin-vx/package.json
+++ b/libs/eslint-plugin-vx/package.json
@@ -43,7 +43,7 @@
     "@types/node": "^16.11.29",
     "@types/react": "^17.0.20",
     "@typescript-eslint/parser": "^5.21.0",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-jest": "^26.1.5",
     "eslint-plugin-prettier": "^4.2.1",

--- a/libs/fixtures/package.json
+++ b/libs/fixtures/package.json
@@ -48,7 +48,7 @@
     "@typescript-eslint/eslint-plugin": "^5.37.0",
     "@typescript-eslint/parser": "^5.37.0",
     "@votingworks/res-to-ts": "workspace:*",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-plugin-import": "^2.26.0",

--- a/libs/grout/package.json
+++ b/libs/grout/package.json
@@ -42,7 +42,7 @@
     "@types/node-fetch": "^2.6.0",
     "@typescript-eslint/eslint-plugin": "^5.37.0",
     "@typescript-eslint/parser": "^5.37.0",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-plugin-import": "^2.26.0",

--- a/libs/grout/test-utils/package.json
+++ b/libs/grout/test-utils/package.json
@@ -38,7 +38,7 @@
     "@typescript-eslint/eslint-plugin": "^5.37.0",
     "@typescript-eslint/parser": "^5.37.0",
     "@votingworks/grout": "workspace:*",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-plugin-import": "^2.26.0",

--- a/libs/logging/package.json
+++ b/libs/logging/package.json
@@ -54,7 +54,7 @@
     "@votingworks/test-utils": "workspace:*",
     "esbuild": "^0.14.30",
     "esbuild-runner": "^2.2.1",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-plugin-import": "^2.26.0",

--- a/libs/message-coder/package.json
+++ b/libs/message-coder/package.json
@@ -26,7 +26,7 @@
     "@types/jest": "^29.2.6",
     "@typescript-eslint/eslint-plugin": "^5.49.0",
     "@typescript-eslint/parser": "^5.49.0",
-    "eslint": "^8.32.0",
+    "eslint": "8.23.1",
     "eslint-config-prettier": "^8.6.0",
     "eslint-import-resolver-node": "^0.3.7",
     "eslint-plugin-import": "^2.27.5",

--- a/libs/plustek-scanner/package.json
+++ b/libs/plustek-scanner/package.json
@@ -47,7 +47,7 @@
     "@votingworks/test-utils": "workspace:*",
     "esbuild": "^0.14.30",
     "esbuild-runner": "^2.2.1",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-plugin-import": "^2.26.0",

--- a/libs/res-to-ts/package.json
+++ b/libs/res-to-ts/package.json
@@ -37,7 +37,7 @@
     "@votingworks/test-utils": "workspace:*",
     "esbuild": "^0.14.27",
     "esbuild-runner": "^2.2.1",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-plugin-import": "^2.26.0",

--- a/libs/test-utils/package.json
+++ b/libs/test-utils/package.json
@@ -54,7 +54,7 @@
     "@types/zip-stream": "workspace:*",
     "@typescript-eslint/eslint-plugin": "^5.37.0",
     "@typescript-eslint/parser": "^5.37.0",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-plugin-import": "^2.26.0",

--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -56,7 +56,7 @@
     "ajv": "^8.12.0",
     "ajv-draft-04": "^1.0.0",
     "esbuild-runner": "^2.2.1",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-plugin-import": "^2.26.0",

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -92,7 +92,7 @@
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
     "buffer": "^6.0.3",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.5.0",
     "eslint-config-react-app": "^7.0.1",

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -63,7 +63,7 @@
     "@typescript-eslint/parser": "^5.37.0",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
-    "eslint": "^8.23.1",
+    "eslint": "8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-plugin-import": "^2.26.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,7 +105,7 @@ importers:
       dotenv-expand: ^9.0.0
       esbuild: ^0.14.29
       esbuild-runner: ^2.2.1
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-prettier: ^8.5.0
       eslint-import-resolver-node: ^0.3.4
       eslint-plugin-cypress: ^2.12.1
@@ -166,18 +166,18 @@ importers:
       '@types/supertest': 2.0.10
       '@types/tmp': 0.2.3
       '@types/uuid': 8.3.4
-      '@typescript-eslint/eslint-plugin': 5.49.0_e5nl3pgtbq7irh2db7scmsnz3q
-      '@typescript-eslint/parser': 5.49.0_meject34o2v4gmz2y6b4koze4q
+      '@typescript-eslint/eslint-plugin': 5.49.0_rl4vfvvb32d4rquxp7auin2by4
+      '@typescript-eslint/parser': 5.49.0_2owex2qphpdtje5ztrbqluisqa
       '@votingworks/test-utils': link:../../../libs/test-utils
       esbuild: 0.14.42
       esbuild-runner: 2.2.1_esbuild@0.14.42
-      eslint: 8.33.0
-      eslint-config-prettier: 8.6.0_eslint@8.33.0
+      eslint: 8.23.1
+      eslint-config-prettier: 8.6.0_eslint@8.23.1
       eslint-import-resolver-node: 0.3.7
-      eslint-plugin-cypress: 2.12.1_eslint@8.33.0
-      eslint-plugin-import: 2.27.5_kf2q37rsxgsj6p2nz45hjttose
-      eslint-plugin-jest: 26.6.0_ihbafhzv62iz2rfufl4kz4vdjm
-      eslint-plugin-prettier: 4.2.1_jqplj6qf3uqpxpu4gdyhwwasnq
+      eslint-plugin-cypress: 2.12.1_eslint@8.23.1
+      eslint-plugin-import: 2.27.5_bzcdwbny5jz32axx4jcmp44t5i
+      eslint-plugin-jest: 26.6.0_vjevoksicmlnkjn4ab6ptajvou
+      eslint-plugin-prettier: 4.2.1_uq5ey77uvtr34xlijuws27iaxy
       eslint-plugin-vx: link:../../../libs/eslint-plugin-vx
       fast-check: 2.18.0
       is-ci-cli: 2.2.0
@@ -268,7 +268,7 @@ importers:
       dompurify: ^2.0.12
       dotenv: 8.2.0
       dotenv-expand: 5.1.0
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-airbnb: ^19.0.4
       eslint-config-prettier: ^8.5.0
       eslint-config-react-app: ^7.0.1
@@ -397,7 +397,7 @@ importers:
       '@zip.js/zip.js': 2.4.12
       array-unique: 0.3.2
       assert: 2.0.0
-      babel-eslint: 10.1.0_eslint@8.33.0
+      babel-eslint: 10.1.0_eslint@8.23.1
       babel-jest: 26.6.3_@babel+core@7.12.3
       babel-loader: 8.1.0_ijzbfparldiylzlxam7rtsqhk4
       babel-plugin-named-asset-import: 0.3.7_@babel+core@7.12.3
@@ -445,7 +445,7 @@ importers:
       prompts: 2.4.0
       react: 17.0.1
       react-app-polyfill: 2.0.0
-      react-dev-utils: 11.0.3_aujbwneux7xsh6nzyv4q5odp7y
+      react-dev-utils: 11.0.3_ncroedkm2fa5vjohk6lc3nx6c4
       react-dom: 17.0.1_react@17.0.1
       react-i18next: 11.8.5_76jgnd33bit7oqtjqbiyu4rufi
       react-refresh: 0.8.3
@@ -489,29 +489,29 @@ importers:
       '@types/testing-library__jest-dom': 5.14.3
       '@types/uuid': 8.3.4
       '@types/zip-stream': link:../../../libs/@types/zip-stream
-      '@typescript-eslint/eslint-plugin': 5.49.0_e5nl3pgtbq7irh2db7scmsnz3q
-      '@typescript-eslint/parser': 5.49.0_meject34o2v4gmz2y6b4koze4q
+      '@typescript-eslint/eslint-plugin': 5.49.0_rl4vfvvb32d4rquxp7auin2by4
+      '@typescript-eslint/parser': 5.49.0_2owex2qphpdtje5ztrbqluisqa
       '@vitejs/plugin-react': 1.3.2
       '@votingworks/admin-backend': link:../backend
       '@votingworks/grout-test-utils': link:../../../libs/grout/test-utils
       '@votingworks/test-utils': link:../../../libs/test-utils
       babel-plugin-transform-import-meta: 2.1.1_@babel+core@7.12.3
-      eslint: 8.33.0
-      eslint-config-airbnb: 19.0.4_4unmkwsbwnq2azq6y4ttc4sdem
-      eslint-config-prettier: 8.6.0_eslint@8.33.0
-      eslint-config-react-app: 7.0.1_do25er56need6uvlt6654hqyu4
+      eslint: 8.23.1
+      eslint-config-airbnb: 19.0.4_3irxnmmytvcwyuqwe57qqjt3wq
+      eslint-config-prettier: 8.6.0_eslint@8.23.1
+      eslint-config-react-app: 7.0.1_ud4nhlemy5rgevyptkhk2fu4vy
       eslint-import-resolver-node: 0.3.7
-      eslint-plugin-cypress: 2.12.1_eslint@8.33.0
-      eslint-plugin-flowtype: 5.2.0_eslint@8.33.0
-      eslint-plugin-import: 2.27.5_kf2q37rsxgsj6p2nz45hjttose
-      eslint-plugin-jest: 26.6.0_elixyayyhmyxbik6oxof7xq3i4
-      eslint-plugin-jsx-a11y: 6.6.1_eslint@8.33.0
-      eslint-plugin-prettier: 4.2.1_jqplj6qf3uqpxpu4gdyhwwasnq
-      eslint-plugin-react: 7.31.8_eslint@8.33.0
-      eslint-plugin-react-hooks: 4.6.0_eslint@8.33.0
-      eslint-plugin-testing-library: 5.6.4_meject34o2v4gmz2y6b4koze4q
+      eslint-plugin-cypress: 2.12.1_eslint@8.23.1
+      eslint-plugin-flowtype: 5.2.0_eslint@8.23.1
+      eslint-plugin-import: 2.27.5_bzcdwbny5jz32axx4jcmp44t5i
+      eslint-plugin-jest: 26.6.0_nweqlnqyww56czqrc3qvkpw2p4
+      eslint-plugin-jsx-a11y: 6.6.1_eslint@8.23.1
+      eslint-plugin-prettier: 4.2.1_uq5ey77uvtr34xlijuws27iaxy
+      eslint-plugin-react: 7.31.8_eslint@8.23.1
+      eslint-plugin-react-hooks: 4.6.0_eslint@8.23.1
+      eslint-plugin-testing-library: 5.6.4_2owex2qphpdtje5ztrbqluisqa
       eslint-plugin-vx: link:../../../libs/eslint-plugin-vx
-      eslint-webpack-plugin: 2.4.1_p4rw3jph5dagt54h5drwbkzsce
+      eslint-webpack-plugin: 2.4.1_sycz7lcl6yepnet57jvpov6ms4
       express: 4.18.2
       glob: 8.0.3
       is-ci-cli: 2.2.0
@@ -556,7 +556,7 @@ importers:
       '@votingworks/types': workspace:*
       concurrently: ^7.6.0
       cypress: ^10.3.1
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-airbnb-base: ^14.2.1
       eslint-config-prettier: ^8.5.0
       eslint-import-resolver-node: ^0.3.4
@@ -583,19 +583,19 @@ importers:
       start-server-and-test: 1.14.0
     devDependencies:
       '@types/node': 18.11.18
-      '@typescript-eslint/eslint-plugin': 5.49.0_e5nl3pgtbq7irh2db7scmsnz3q
-      '@typescript-eslint/parser': 5.49.0_meject34o2v4gmz2y6b4koze4q
+      '@typescript-eslint/eslint-plugin': 5.49.0_rl4vfvvb32d4rquxp7auin2by4
+      '@typescript-eslint/parser': 5.49.0_2owex2qphpdtje5ztrbqluisqa
       concurrently: 7.6.0
-      eslint: 8.33.0
-      eslint-config-airbnb-base: 14.2.1_ohdts44xlqyeyrlje4qnefqeay
-      eslint-config-prettier: 8.6.0_eslint@8.33.0
+      eslint: 8.23.1
+      eslint-config-airbnb-base: 14.2.1_gm3nckdpyjle62atxfx4boqatm
+      eslint-config-prettier: 8.6.0_eslint@8.23.1
       eslint-import-resolver-node: 0.3.7
-      eslint-plugin-cypress: 2.12.1_eslint@8.33.0
-      eslint-plugin-flowtype: 5.2.0_eslint@8.33.0
-      eslint-plugin-import: 2.27.5_kf2q37rsxgsj6p2nz45hjttose
-      eslint-plugin-jest: 26.6.0_v4vzmluohzmzetuufbkrldtdcy
-      eslint-plugin-jsx-a11y: 6.6.1_eslint@8.33.0
-      eslint-plugin-prettier: 4.2.1_jqplj6qf3uqpxpu4gdyhwwasnq
+      eslint-plugin-cypress: 2.12.1_eslint@8.23.1
+      eslint-plugin-flowtype: 5.2.0_eslint@8.23.1
+      eslint-plugin-import: 2.27.5_bzcdwbny5jz32axx4jcmp44t5i
+      eslint-plugin-jest: 26.6.0_6jh3f5xpvchtxrdgqf7zhexlqm
+      eslint-plugin-jsx-a11y: 6.6.1_eslint@8.23.1
+      eslint-plugin-prettier: 4.2.1_uq5ey77uvtr34xlijuws27iaxy
       eslint-plugin-vx: link:../../../libs/eslint-plugin-vx
       is-ci-cli: 2.2.0
       lint-staged: 11.0.0
@@ -646,7 +646,7 @@ importers:
       dotenv-expand: ^9.0.0
       esbuild: ^0.14.29
       esbuild-runner: ^2.2.1
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-prettier: ^8.5.0
       eslint-import-resolver-node: ^0.3.4
       eslint-plugin-cypress: ^2.12.1
@@ -732,17 +732,17 @@ importers:
       '@types/tmp': 0.2.3
       '@types/uuid': 8.3.4
       '@types/zip-stream': link:../../../libs/@types/zip-stream
-      '@typescript-eslint/eslint-plugin': 5.49.0_e5nl3pgtbq7irh2db7scmsnz3q
-      '@typescript-eslint/parser': 5.49.0_meject34o2v4gmz2y6b4koze4q
+      '@typescript-eslint/eslint-plugin': 5.49.0_rl4vfvvb32d4rquxp7auin2by4
+      '@typescript-eslint/parser': 5.49.0_2owex2qphpdtje5ztrbqluisqa
       esbuild: 0.14.42
       esbuild-runner: 2.2.1_esbuild@0.14.42
-      eslint: 8.33.0
-      eslint-config-prettier: 8.6.0_eslint@8.33.0
+      eslint: 8.23.1
+      eslint-config-prettier: 8.6.0_eslint@8.23.1
       eslint-import-resolver-node: 0.3.7
-      eslint-plugin-cypress: 2.12.1_eslint@8.33.0
-      eslint-plugin-import: 2.27.5_kf2q37rsxgsj6p2nz45hjttose
-      eslint-plugin-jest: 26.6.0_ihbafhzv62iz2rfufl4kz4vdjm
-      eslint-plugin-prettier: 4.2.1_jqplj6qf3uqpxpu4gdyhwwasnq
+      eslint-plugin-cypress: 2.12.1_eslint@8.23.1
+      eslint-plugin-import: 2.27.5_bzcdwbny5jz32axx4jcmp44t5i
+      eslint-plugin-jest: 26.6.0_vjevoksicmlnkjn4ab6ptajvou
+      eslint-plugin-prettier: 4.2.1_uq5ey77uvtr34xlijuws27iaxy
       eslint-plugin-vx: link:../../../libs/eslint-plugin-vx
       fast-check: 2.23.2
       is-ci-cli: 2.2.0
@@ -801,7 +801,7 @@ importers:
       dotenv-expand: 5.1.0
       esbuild: ^0.15.10
       esbuild-runner: ^2.2.1
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-airbnb: ^19.0.4
       eslint-config-prettier: ^8.5.0
       eslint-import-resolver-node: ^0.3.4
@@ -907,8 +907,8 @@ importers:
       '@types/setimmediate': 1.0.2
       '@types/testing-library__jest-dom': 5.14.3
       '@types/zip-stream': link:../../../libs/@types/zip-stream
-      '@typescript-eslint/eslint-plugin': 5.49.0_e5nl3pgtbq7irh2db7scmsnz3q
-      '@typescript-eslint/parser': 5.49.0_meject34o2v4gmz2y6b4koze4q
+      '@typescript-eslint/eslint-plugin': 5.49.0_rl4vfvvb32d4rquxp7auin2by4
+      '@typescript-eslint/parser': 5.49.0_2owex2qphpdtje5ztrbqluisqa
       '@vitejs/plugin-react': 1.3.2
       '@votingworks/ballot-encoder': link:../../../libs/ballot-encoder
       '@votingworks/central-scan-backend': link:../backend
@@ -917,16 +917,16 @@ importers:
       '@votingworks/test-utils': link:../../../libs/test-utils
       esbuild: 0.15.10
       esbuild-runner: 2.2.1_esbuild@0.15.10
-      eslint: 8.33.0
-      eslint-config-airbnb: 19.0.4_4unmkwsbwnq2azq6y4ttc4sdem
-      eslint-config-prettier: 8.6.0_eslint@8.33.0
+      eslint: 8.23.1
+      eslint-config-airbnb: 19.0.4_3irxnmmytvcwyuqwe57qqjt3wq
+      eslint-config-prettier: 8.6.0_eslint@8.23.1
       eslint-import-resolver-node: 0.3.7
-      eslint-plugin-import: 2.27.5_kf2q37rsxgsj6p2nz45hjttose
-      eslint-plugin-jest: 26.6.0_ihbafhzv62iz2rfufl4kz4vdjm
-      eslint-plugin-jsx-a11y: 6.6.1_eslint@8.33.0
-      eslint-plugin-prettier: 4.2.1_jqplj6qf3uqpxpu4gdyhwwasnq
-      eslint-plugin-react: 7.31.8_eslint@8.33.0
-      eslint-plugin-react-hooks: 4.6.0_eslint@8.33.0
+      eslint-plugin-import: 2.27.5_bzcdwbny5jz32axx4jcmp44t5i
+      eslint-plugin-jest: 26.6.0_vjevoksicmlnkjn4ab6ptajvou
+      eslint-plugin-jsx-a11y: 6.6.1_eslint@8.23.1
+      eslint-plugin-prettier: 4.2.1_uq5ey77uvtr34xlijuws27iaxy
+      eslint-plugin-react: 7.31.8_eslint@8.23.1
+      eslint-plugin-react-hooks: 4.6.0_eslint@8.23.1
       eslint-plugin-vx: link:../../../libs/eslint-plugin-vx
       fetch-mock: 9.11.0_node-fetch@2.6.7
       history: 4.10.1
@@ -941,7 +941,7 @@ importers:
       node-fetch: 2.6.7
       prettier: 2.8.3
       react-app-polyfill: 3.0.0
-      react-dev-utils: 12.0.1_aujbwneux7xsh6nzyv4q5odp7y
+      react-dev-utils: 12.0.1_ncroedkm2fa5vjohk6lc3nx6c4
       react-refresh: 0.9.0
       sort-package-json: 1.53.1
       stylelint: 13.8.0
@@ -971,7 +971,7 @@ importers:
       buffer: ^6.0.3
       concurrently: ^7.6.0
       cypress: ^10.3.1
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-airbnb-base: ^14.2.1
       eslint-config-prettier: ^8.5.0
       eslint-import-resolver-node: ^0.3.4
@@ -999,19 +999,19 @@ importers:
       js-sha256: 0.9.0
       start-server-and-test: 1.14.0
     devDependencies:
-      '@typescript-eslint/eslint-plugin': 5.49.0_e5nl3pgtbq7irh2db7scmsnz3q
-      '@typescript-eslint/parser': 5.49.0_meject34o2v4gmz2y6b4koze4q
+      '@typescript-eslint/eslint-plugin': 5.49.0_rl4vfvvb32d4rquxp7auin2by4
+      '@typescript-eslint/parser': 5.49.0_2owex2qphpdtje5ztrbqluisqa
       concurrently: 7.6.0
-      eslint: 8.33.0
-      eslint-config-airbnb-base: 14.2.1_ohdts44xlqyeyrlje4qnefqeay
-      eslint-config-prettier: 8.6.0_eslint@8.33.0
+      eslint: 8.23.1
+      eslint-config-airbnb-base: 14.2.1_gm3nckdpyjle62atxfx4boqatm
+      eslint-config-prettier: 8.6.0_eslint@8.23.1
       eslint-import-resolver-node: 0.3.7
-      eslint-plugin-cypress: 2.12.1_eslint@8.33.0
-      eslint-plugin-flowtype: 5.2.0_eslint@8.33.0
-      eslint-plugin-import: 2.27.5_kf2q37rsxgsj6p2nz45hjttose
-      eslint-plugin-jest: 26.6.0_v4vzmluohzmzetuufbkrldtdcy
-      eslint-plugin-jsx-a11y: 6.6.1_eslint@8.33.0
-      eslint-plugin-prettier: 4.2.1_jqplj6qf3uqpxpu4gdyhwwasnq
+      eslint-plugin-cypress: 2.12.1_eslint@8.23.1
+      eslint-plugin-flowtype: 5.2.0_eslint@8.23.1
+      eslint-plugin-import: 2.27.5_bzcdwbny5jz32axx4jcmp44t5i
+      eslint-plugin-jest: 26.6.0_6jh3f5xpvchtxrdgqf7zhexlqm
+      eslint-plugin-jsx-a11y: 6.6.1_eslint@8.23.1
+      eslint-plugin-prettier: 4.2.1_uq5ey77uvtr34xlijuws27iaxy
       eslint-plugin-vx: link:../../../libs/eslint-plugin-vx
       is-ci-cli: 2.2.0
       jest-environment-jsdom-sixteen: 1.0.3
@@ -1040,7 +1040,7 @@ importers:
       dotenv-expand: ^9.0.0
       esbuild: ^0.14.29
       esbuild-runner: ^2.2.1
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-prettier: ^8.5.0
       eslint-import-resolver-node: ^0.3.4
       eslint-plugin-import: ^2.26.0
@@ -1076,17 +1076,17 @@ importers:
       '@types/express': 4.17.14
       '@types/jest': 26.0.23
       '@types/node': 16.11.29
-      '@typescript-eslint/eslint-plugin': 5.49.0_e5nl3pgtbq7irh2db7scmsnz3q
-      '@typescript-eslint/parser': 5.49.0_meject34o2v4gmz2y6b4koze4q
+      '@typescript-eslint/eslint-plugin': 5.49.0_rl4vfvvb32d4rquxp7auin2by4
+      '@typescript-eslint/parser': 5.49.0_2owex2qphpdtje5ztrbqluisqa
       '@votingworks/test-utils': link:../../../libs/test-utils
       esbuild: 0.14.42
       esbuild-runner: 2.2.1_esbuild@0.14.42
-      eslint: 8.33.0
-      eslint-config-prettier: 8.6.0_eslint@8.33.0
+      eslint: 8.23.1
+      eslint-config-prettier: 8.6.0_eslint@8.23.1
       eslint-import-resolver-node: 0.3.7
-      eslint-plugin-import: 2.27.5_kf2q37rsxgsj6p2nz45hjttose
-      eslint-plugin-jest: 26.6.0_ihbafhzv62iz2rfufl4kz4vdjm
-      eslint-plugin-prettier: 4.2.1_jqplj6qf3uqpxpu4gdyhwwasnq
+      eslint-plugin-import: 2.27.5_bzcdwbny5jz32axx4jcmp44t5i
+      eslint-plugin-jest: 26.6.0_vjevoksicmlnkjn4ab6ptajvou
+      eslint-plugin-prettier: 4.2.1_uq5ey77uvtr34xlijuws27iaxy
       eslint-plugin-vx: link:../../../libs/eslint-plugin-vx
       is-ci-cli: 2.2.0
       jest: 26.6.3
@@ -1152,7 +1152,7 @@ importers:
       debug: ^4.3.2
       dotenv: 8.2.0
       dotenv-expand: 5.1.0
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-airbnb: ^19.0.4
       eslint-config-prettier: ^8.5.0
       eslint-config-react-app: ^7.0.1
@@ -1242,7 +1242,7 @@ importers:
       '@votingworks/ui': link:../../../libs/ui
       '@votingworks/utils': link:../../../libs/utils
       abortcontroller-polyfill: 1.7.1
-      babel-eslint: 10.1.0_eslint@8.33.0
+      babel-eslint: 10.1.0_eslint@8.23.1
       babel-loader: 8.1.0_ijzbfparldiylzlxam7rtsqhk4
       babel-plugin-named-asset-import: 0.3.7_@babel+core@7.12.3
       babel-preset-react-app: 10.0.1
@@ -1268,7 +1268,7 @@ importers:
       postcss-safe-parser: 5.0.2
       react: 17.0.1
       react-app-polyfill: 2.0.0
-      react-dev-utils: 11.0.3_aujbwneux7xsh6nzyv4q5odp7y
+      react-dev-utils: 11.0.3_ncroedkm2fa5vjohk6lc3nx6c4
       react-dom: 17.0.1_react@17.0.1
       react-gamepad: 1.0.3_react@17.0.1
       react-idle-timer: 4.2.12_4e3lqv4kxjeymudkthvbfyn3ra
@@ -1297,27 +1297,27 @@ importers:
       '@types/react-gamepad': 1.0.0
       '@types/setimmediate': 1.0.2
       '@types/testing-library__jest-dom': 5.14.3
-      '@typescript-eslint/eslint-plugin': 5.49.0_e5nl3pgtbq7irh2db7scmsnz3q
-      '@typescript-eslint/parser': 5.49.0_meject34o2v4gmz2y6b4koze4q
+      '@typescript-eslint/eslint-plugin': 5.49.0_rl4vfvvb32d4rquxp7auin2by4
+      '@typescript-eslint/parser': 5.49.0_2owex2qphpdtje5ztrbqluisqa
       '@vitejs/plugin-react': 1.3.2
       '@votingworks/grout-test-utils': link:../../../libs/grout/test-utils
       '@votingworks/mark-backend': link:../backend
       '@votingworks/test-utils': link:../../../libs/test-utils
       chalk: 4.1.2
       concurrently: 7.4.0
-      eslint: 8.33.0
-      eslint-config-airbnb: 19.0.4_4unmkwsbwnq2azq6y4ttc4sdem
-      eslint-config-prettier: 8.6.0_eslint@8.33.0
-      eslint-config-react-app: 7.0.1_do25er56need6uvlt6654hqyu4
+      eslint: 8.23.1
+      eslint-config-airbnb: 19.0.4_3irxnmmytvcwyuqwe57qqjt3wq
+      eslint-config-prettier: 8.6.0_eslint@8.23.1
+      eslint-config-react-app: 7.0.1_ud4nhlemy5rgevyptkhk2fu4vy
       eslint-import-resolver-node: 0.3.7
-      eslint-plugin-flowtype: 5.2.0_eslint@8.33.0
-      eslint-plugin-import: 2.27.5_kf2q37rsxgsj6p2nz45hjttose
-      eslint-plugin-jest: 26.6.0_elixyayyhmyxbik6oxof7xq3i4
-      eslint-plugin-jsx-a11y: 6.6.1_eslint@8.33.0
-      eslint-plugin-prettier: 4.2.1_jqplj6qf3uqpxpu4gdyhwwasnq
-      eslint-plugin-react: 7.31.8_eslint@8.33.0
-      eslint-plugin-react-hooks: 4.6.0_eslint@8.33.0
-      eslint-plugin-testing-library: 5.6.4_meject34o2v4gmz2y6b4koze4q
+      eslint-plugin-flowtype: 5.2.0_eslint@8.23.1
+      eslint-plugin-import: 2.27.5_bzcdwbny5jz32axx4jcmp44t5i
+      eslint-plugin-jest: 26.6.0_nweqlnqyww56czqrc3qvkpw2p4
+      eslint-plugin-jsx-a11y: 6.6.1_eslint@8.23.1
+      eslint-plugin-prettier: 4.2.1_uq5ey77uvtr34xlijuws27iaxy
+      eslint-plugin-react: 7.31.8_eslint@8.23.1
+      eslint-plugin-react-hooks: 4.6.0_eslint@8.23.1
+      eslint-plugin-testing-library: 5.6.4_2owex2qphpdtje5ztrbqluisqa
       eslint-plugin-vx: link:../../../libs/eslint-plugin-vx
       fetch-mock: 9.11.0_node-fetch@2.6.7
       is-ci-cli: 2.2.0
@@ -1362,7 +1362,7 @@ importers:
       '@votingworks/types': workspace:*
       concurrently: ^7.6.0
       cypress: ^10.3.1
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-airbnb-base: ^14.2.1
       eslint-config-prettier: ^8.5.0
       eslint-import-resolver-node: ^0.3.4
@@ -1389,19 +1389,19 @@ importers:
       start-server-and-test: 1.14.0
     devDependencies:
       '@types/node': 18.11.18
-      '@typescript-eslint/eslint-plugin': 5.49.0_e5nl3pgtbq7irh2db7scmsnz3q
-      '@typescript-eslint/parser': 5.49.0_meject34o2v4gmz2y6b4koze4q
+      '@typescript-eslint/eslint-plugin': 5.49.0_rl4vfvvb32d4rquxp7auin2by4
+      '@typescript-eslint/parser': 5.49.0_2owex2qphpdtje5ztrbqluisqa
       concurrently: 7.6.0
-      eslint: 8.33.0
-      eslint-config-airbnb-base: 14.2.1_ohdts44xlqyeyrlje4qnefqeay
-      eslint-config-prettier: 8.6.0_eslint@8.33.0
+      eslint: 8.23.1
+      eslint-config-airbnb-base: 14.2.1_gm3nckdpyjle62atxfx4boqatm
+      eslint-config-prettier: 8.6.0_eslint@8.23.1
       eslint-import-resolver-node: 0.3.7
-      eslint-plugin-cypress: 2.12.1_eslint@8.33.0
-      eslint-plugin-flowtype: 5.2.0_eslint@8.33.0
-      eslint-plugin-import: 2.27.5_kf2q37rsxgsj6p2nz45hjttose
-      eslint-plugin-jest: 26.6.0_v4vzmluohzmzetuufbkrldtdcy
-      eslint-plugin-jsx-a11y: 6.6.1_eslint@8.33.0
-      eslint-plugin-prettier: 4.2.1_jqplj6qf3uqpxpu4gdyhwwasnq
+      eslint-plugin-cypress: 2.12.1_eslint@8.23.1
+      eslint-plugin-flowtype: 5.2.0_eslint@8.23.1
+      eslint-plugin-import: 2.27.5_bzcdwbny5jz32axx4jcmp44t5i
+      eslint-plugin-jest: 26.6.0_6jh3f5xpvchtxrdgqf7zhexlqm
+      eslint-plugin-jsx-a11y: 6.6.1_eslint@8.23.1
+      eslint-plugin-prettier: 4.2.1_uq5ey77uvtr34xlijuws27iaxy
       eslint-plugin-vx: link:../../../libs/eslint-plugin-vx
       is-ci-cli: 2.2.0
       lint-staged: 11.0.0
@@ -1449,7 +1449,7 @@ importers:
       dotenv-expand: ^9.0.0
       esbuild: ^0.14.29
       esbuild-runner: ^2.2.1
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-prettier: ^8.5.0
       eslint-import-resolver-node: ^0.3.4
       eslint-plugin-import: ^2.26.0
@@ -1531,16 +1531,16 @@ importers:
       '@types/tmp': 0.2.3
       '@types/uuid': 8.3.4
       '@types/zip-stream': link:../../../libs/@types/zip-stream
-      '@typescript-eslint/eslint-plugin': 5.49.0_e5nl3pgtbq7irh2db7scmsnz3q
-      '@typescript-eslint/parser': 5.49.0_meject34o2v4gmz2y6b4koze4q
+      '@typescript-eslint/eslint-plugin': 5.49.0_rl4vfvvb32d4rquxp7auin2by4
+      '@typescript-eslint/parser': 5.49.0_2owex2qphpdtje5ztrbqluisqa
       esbuild: 0.14.42
       esbuild-runner: 2.2.1_esbuild@0.14.42
-      eslint: 8.33.0
-      eslint-config-prettier: 8.6.0_eslint@8.33.0
+      eslint: 8.23.1
+      eslint-config-prettier: 8.6.0_eslint@8.23.1
       eslint-import-resolver-node: 0.3.7
-      eslint-plugin-import: 2.27.5_kf2q37rsxgsj6p2nz45hjttose
-      eslint-plugin-jest: 26.6.0_ihbafhzv62iz2rfufl4kz4vdjm
-      eslint-plugin-prettier: 4.2.1_jqplj6qf3uqpxpu4gdyhwwasnq
+      eslint-plugin-import: 2.27.5_bzcdwbny5jz32axx4jcmp44t5i
+      eslint-plugin-jest: 26.6.0_vjevoksicmlnkjn4ab6ptajvou
+      eslint-plugin-prettier: 4.2.1_uq5ey77uvtr34xlijuws27iaxy
       eslint-plugin-vx: link:../../../libs/eslint-plugin-vx
       is-ci-cli: 2.2.0
       jest: 26.6.3_canvas@2.9.1
@@ -1593,7 +1593,7 @@ importers:
       debug: ^4.3.1
       dotenv: 8.2.0
       dotenv-expand: 5.1.0
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-airbnb: ^19.0.4
       eslint-config-prettier: ^8.5.0
       eslint-config-react-app: ^7.0.1
@@ -1683,25 +1683,25 @@ importers:
       '@types/pluralize': 0.0.29
       '@types/setimmediate': 1.0.2
       '@types/testing-library__jest-dom': 5.14.3
-      '@typescript-eslint/eslint-plugin': 5.49.0_e5nl3pgtbq7irh2db7scmsnz3q
-      '@typescript-eslint/parser': 5.49.0_meject34o2v4gmz2y6b4koze4q
+      '@typescript-eslint/eslint-plugin': 5.49.0_rl4vfvvb32d4rquxp7auin2by4
+      '@typescript-eslint/parser': 5.49.0_2owex2qphpdtje5ztrbqluisqa
       '@vitejs/plugin-react': 1.3.2
       '@votingworks/grout-test-utils': link:../../../libs/grout/test-utils
       '@votingworks/scan-backend': link:../backend
       '@votingworks/test-utils': link:../../../libs/test-utils
-      eslint: 8.33.0
-      eslint-config-airbnb: 19.0.4_4unmkwsbwnq2azq6y4ttc4sdem
-      eslint-config-prettier: 8.6.0_eslint@8.33.0
-      eslint-config-react-app: 7.0.1_jj6fu62ti5nunysbsr7l3emdqq
+      eslint: 8.23.1
+      eslint-config-airbnb: 19.0.4_3irxnmmytvcwyuqwe57qqjt3wq
+      eslint-config-prettier: 8.6.0_eslint@8.23.1
+      eslint-config-react-app: 7.0.1_wc5uzycbse5qs2tk6i7njlzowm
       eslint-import-resolver-node: 0.3.7
-      eslint-plugin-cypress: 2.12.1_eslint@8.33.0
-      eslint-plugin-flowtype: 5.2.0_eslint@8.33.0
-      eslint-plugin-import: 2.27.5_kf2q37rsxgsj6p2nz45hjttose
-      eslint-plugin-jest: 26.6.0_ihbafhzv62iz2rfufl4kz4vdjm
-      eslint-plugin-jsx-a11y: 6.6.1_eslint@8.33.0
-      eslint-plugin-prettier: 4.2.1_jqplj6qf3uqpxpu4gdyhwwasnq
-      eslint-plugin-react: 7.31.8_eslint@8.33.0
-      eslint-plugin-react-hooks: 4.6.0_eslint@8.33.0
+      eslint-plugin-cypress: 2.12.1_eslint@8.23.1
+      eslint-plugin-flowtype: 5.2.0_eslint@8.23.1
+      eslint-plugin-import: 2.27.5_bzcdwbny5jz32axx4jcmp44t5i
+      eslint-plugin-jest: 26.6.0_vjevoksicmlnkjn4ab6ptajvou
+      eslint-plugin-jsx-a11y: 6.6.1_eslint@8.23.1
+      eslint-plugin-prettier: 4.2.1_uq5ey77uvtr34xlijuws27iaxy
+      eslint-plugin-react: 7.31.8_eslint@8.23.1
+      eslint-plugin-react-hooks: 4.6.0_eslint@8.23.1
       eslint-plugin-vx: link:../../../libs/eslint-plugin-vx
       is-ci-cli: 2.2.0
       jest: 26.6.3
@@ -1712,7 +1712,7 @@ importers:
       lint-staged: 10.5.4
       prettier: 2.8.3
       react-app-polyfill: 3.0.0
-      react-dev-utils: 12.0.1_aujbwneux7xsh6nzyv4q5odp7y
+      react-dev-utils: 12.0.1_ncroedkm2fa5vjohk6lc3nx6c4
       react-refresh: 0.9.0
       sort-package-json: 1.53.1
       stylelint: 13.8.0
@@ -1812,7 +1812,7 @@ importers:
       '@votingworks/fixtures': workspace:*
       '@votingworks/types': workspace:*
       '@votingworks/utils': '*'
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-prettier: ^8.5.0
       eslint-import-resolver-node: ^0.3.6
       eslint-plugin-import: ^2.26.0
@@ -1874,7 +1874,7 @@ importers:
       '@votingworks/utils': workspace:*
       base64-js: ^1.3.1
       esbuild-runner: ^2.2.1
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-prettier: ^8.5.0
       eslint-import-resolver-node: ^0.3.6
       eslint-plugin-import: ^2.26.0
@@ -1911,16 +1911,16 @@ importers:
       '@types/jest': 27.4.1
       '@types/node-fetch': 2.6.2
       '@types/uuid': 9.0.1
-      '@typescript-eslint/eslint-plugin': 5.37.0_srb6gpj27cpytxa4hvxonfqyzi
-      '@typescript-eslint/parser': 5.37.0_fnqnj4wr4adlkzkgntzwybsmii
+      '@typescript-eslint/eslint-plugin': 5.37.0_clqnhij63k7sxivgn64qsibvv4
+      '@typescript-eslint/parser': 5.37.0_2owex2qphpdtje5ztrbqluisqa
       '@votingworks/test-utils': link:../test-utils
       esbuild-runner: 2.2.1_esbuild@0.17.6
-      eslint: 8.26.0
-      eslint-config-prettier: 8.5.0_eslint@8.26.0
+      eslint: 8.23.1
+      eslint-config-prettier: 8.5.0_eslint@8.23.1
       eslint-import-resolver-node: 0.3.6
-      eslint-plugin-import: 2.26.0_f7h3xcst4xms75btu7jvjeks3e
-      eslint-plugin-jest: 26.6.0_35phkc7pfykerjsst4kd367zhm
-      eslint-plugin-prettier: 4.2.1_aniwkeyvlpmwkidetuytnokvcm
+      eslint-plugin-import: 2.26.0_uzffwd2kxyy6gwinwkcp25zmz4
+      eslint-plugin-jest: 26.6.0_bnhaycgaqq2lyfixynbuzalk2m
+      eslint-plugin-prettier: 4.2.1_cabrci5exjdaojcvd6xoxgeowu
       eslint-plugin-vx: link:../eslint-plugin-vx
       fetch-mock: 9.11.0_node-fetch@2.6.7
       is-ci-cli: 2.2.0
@@ -1952,7 +1952,7 @@ importers:
       '@votingworks/utils': workspace:*
       buffer: ^6.0.3
       debug: ^4.3.2
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-prettier: ^8.5.0
       eslint-import-resolver-node: ^0.3.6
       eslint-plugin-import: ^2.26.0
@@ -1996,15 +1996,15 @@ importers:
       '@types/node': 16.11.29
       '@types/stream-chopper': link:../@types/stream-chopper
       '@types/tmp': 0.2.3
-      '@typescript-eslint/eslint-plugin': 5.49.0_e5nl3pgtbq7irh2db7scmsnz3q
-      '@typescript-eslint/parser': 5.49.0_meject34o2v4gmz2y6b4koze4q
+      '@typescript-eslint/eslint-plugin': 5.49.0_rl4vfvvb32d4rquxp7auin2by4
+      '@typescript-eslint/parser': 5.49.0_2owex2qphpdtje5ztrbqluisqa
       '@votingworks/test-utils': link:../test-utils
-      eslint: 8.33.0
-      eslint-config-prettier: 8.6.0_eslint@8.33.0
+      eslint: 8.23.1
+      eslint-config-prettier: 8.6.0_eslint@8.23.1
       eslint-import-resolver-node: 0.3.7
-      eslint-plugin-import: 2.27.5_kf2q37rsxgsj6p2nz45hjttose
-      eslint-plugin-jest: 26.6.0_cxz2engwmihnktt6iwgkwntofu
-      eslint-plugin-prettier: 4.2.1_jqplj6qf3uqpxpu4gdyhwwasnq
+      eslint-plugin-import: 2.27.5_bzcdwbny5jz32axx4jcmp44t5i
+      eslint-plugin-jest: 26.6.0_g3e7nfonsjxnpiwfriv5wjdzyi
+      eslint-plugin-prettier: 4.2.1_uq5ey77uvtr34xlijuws27iaxy
       eslint-plugin-vx: link:../eslint-plugin-vx
       fast-check: 2.23.2
       is-ci-cli: 2.2.0
@@ -2032,7 +2032,7 @@ importers:
       '@votingworks/fixtures': workspace:*
       '@votingworks/types': workspace:*
       '@votingworks/utils': workspace:*
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-prettier: ^8.5.0
       eslint-import-resolver-node: ^0.3.4
       eslint-plugin-import: ^2.26.0
@@ -2110,7 +2110,7 @@ importers:
       debug: ^4.3.3
       esbuild: ^0.14.23
       esbuild-runner: ^2.2.1
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-prettier: ^8.5.0
       eslint-import-resolver-node: ^0.3.6
       eslint-plugin-import: ^2.26.0
@@ -2204,7 +2204,7 @@ importers:
       debug: ^4.2.0
       esbuild: ^0.14.25
       esbuild-runner: ^2.2.1
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-airbnb-base: ^14.2.1
       eslint-config-prettier: ^8.5.0
       eslint-import-resolver-node: ^0.3.6
@@ -2295,7 +2295,7 @@ importers:
       '@types/node': ^18.11.18
       '@typescript-eslint/eslint-plugin': ^5.37.0
       '@typescript-eslint/parser': ^5.37.0
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-prettier: ^8.5.0
       eslint-import-resolver-node: ^0.3.6
       eslint-plugin-import: ^2.26.0
@@ -2318,14 +2318,14 @@ importers:
     devDependencies:
       '@types/jest': 27.4.1
       '@types/node': 18.11.18
-      '@typescript-eslint/eslint-plugin': 5.37.0_srb6gpj27cpytxa4hvxonfqyzi
-      '@typescript-eslint/parser': 5.37.0_fnqnj4wr4adlkzkgntzwybsmii
-      eslint: 8.26.0
-      eslint-config-prettier: 8.5.0_eslint@8.26.0
+      '@typescript-eslint/eslint-plugin': 5.37.0_clqnhij63k7sxivgn64qsibvv4
+      '@typescript-eslint/parser': 5.37.0_2owex2qphpdtje5ztrbqluisqa
+      eslint: 8.23.1
+      eslint-config-prettier: 8.5.0_eslint@8.23.1
       eslint-import-resolver-node: 0.3.6
-      eslint-plugin-import: 2.26.0_f7h3xcst4xms75btu7jvjeks3e
-      eslint-plugin-jest: 26.6.0_35phkc7pfykerjsst4kd367zhm
-      eslint-plugin-prettier: 4.2.1_aniwkeyvlpmwkidetuytnokvcm
+      eslint-plugin-import: 2.26.0_uzffwd2kxyy6gwinwkcp25zmz4
+      eslint-plugin-jest: 26.6.0_bnhaycgaqq2lyfixynbuzalk2m
+      eslint-plugin-prettier: 4.2.1_cabrci5exjdaojcvd6xoxgeowu
       eslint-plugin-vx: link:../eslint-plugin-vx
       fast-check: 2.23.2
       is-ci-cli: 2.2.0
@@ -2347,7 +2347,7 @@ importers:
       '@typescript-eslint/eslint-plugin': ^5.37.0
       '@typescript-eslint/parser': ^5.37.0
       '@votingworks/basics': workspace:*
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-prettier: ^8.5.0
       eslint-import-resolver-node: ^0.3.4
       eslint-plugin-import: ^2.26.0
@@ -2415,7 +2415,7 @@ importers:
       '@votingworks/utils': '*'
       esbuild: ^0.15.7
       esbuild-runner: ^2.2.1
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-prettier: ^8.5.0
       eslint-import-resolver-node: ^0.3.6
       eslint-plugin-import: ^2.26.0
@@ -2483,7 +2483,7 @@ importers:
       '@votingworks/basics': workspace:*
       better-sqlite3: ^7.5.3
       debug: ^4.3.4
-      eslint: ^8.26.0
+      eslint: 8.23.1
       eslint-config-prettier: ^8.5.0
       eslint-import-resolver-node: ^0.3.6
       eslint-plugin-import: ^2.26.0
@@ -2509,14 +2509,14 @@ importers:
       '@types/jest': 28.1.6
       '@types/node': 18.8.0
       '@types/tmp': 0.2.3
-      '@typescript-eslint/eslint-plugin': 5.37.0_srb6gpj27cpytxa4hvxonfqyzi
-      '@typescript-eslint/parser': 5.37.0_fnqnj4wr4adlkzkgntzwybsmii
-      eslint: 8.26.0
-      eslint-config-prettier: 8.5.0_eslint@8.26.0
+      '@typescript-eslint/eslint-plugin': 5.37.0_clqnhij63k7sxivgn64qsibvv4
+      '@typescript-eslint/parser': 5.37.0_2owex2qphpdtje5ztrbqluisqa
+      eslint: 8.23.1
+      eslint-config-prettier: 8.5.0_eslint@8.23.1
       eslint-import-resolver-node: 0.3.6
-      eslint-plugin-import: 2.26.0_f7h3xcst4xms75btu7jvjeks3e
-      eslint-plugin-jest: 26.6.0_4rhbl2u5cwr5asblcuddcnjhaa
-      eslint-plugin-prettier: 4.2.1_aniwkeyvlpmwkidetuytnokvcm
+      eslint-plugin-import: 2.26.0_uzffwd2kxyy6gwinwkcp25zmz4
+      eslint-plugin-jest: 26.6.0_wphx3phx2gg26dl5pvw5rz6jqm
+      eslint-plugin-prettier: 4.2.1_cabrci5exjdaojcvd6xoxgeowu
       eslint-plugin-vx: link:../eslint-plugin-vx
       is-ci-cli: 2.2.0
       jest: 28.1.3_@types+node@18.8.0
@@ -2537,7 +2537,7 @@ importers:
       '@typescript-eslint/parser': ^5.21.0
       '@typescript-eslint/utils': ^5.37.0
       comment-parser: ^1.2.4
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-airbnb: ^19.0.4
       eslint-config-airbnb-base: ^15.0.0
       eslint-config-prettier: ^8.5.0
@@ -2601,7 +2601,7 @@ importers:
       buffer: ^6.0.3
       canvas: 2.9.1
       csv-writer: ^1.6.0
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-prettier: ^8.5.0
       eslint-import-resolver-node: ^0.3.6
       eslint-plugin-import: ^2.26.0
@@ -2658,7 +2658,7 @@ importers:
       '@votingworks/basics': workspace:*
       cross-fetch: ^3.1.5
       debug: ^4.3.4
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-prettier: ^8.5.0
       eslint-import-resolver-node: ^0.3.6
       eslint-plugin-import: ^2.26.0
@@ -2685,14 +2685,14 @@ importers:
     devDependencies:
       '@types/jest': 27.4.1
       '@types/node-fetch': 2.6.2
-      '@typescript-eslint/eslint-plugin': 5.37.0_srb6gpj27cpytxa4hvxonfqyzi
-      '@typescript-eslint/parser': 5.37.0_fnqnj4wr4adlkzkgntzwybsmii
-      eslint: 8.26.0
-      eslint-config-prettier: 8.5.0_eslint@8.26.0
+      '@typescript-eslint/eslint-plugin': 5.37.0_clqnhij63k7sxivgn64qsibvv4
+      '@typescript-eslint/parser': 5.37.0_2owex2qphpdtje5ztrbqluisqa
+      eslint: 8.23.1
+      eslint-config-prettier: 8.5.0_eslint@8.23.1
       eslint-import-resolver-node: 0.3.6
-      eslint-plugin-import: 2.26.0_f7h3xcst4xms75btu7jvjeks3e
-      eslint-plugin-jest: 26.6.0_35phkc7pfykerjsst4kd367zhm
-      eslint-plugin-prettier: 4.2.1_aniwkeyvlpmwkidetuytnokvcm
+      eslint-plugin-import: 2.26.0_uzffwd2kxyy6gwinwkcp25zmz4
+      eslint-plugin-jest: 26.6.0_bnhaycgaqq2lyfixynbuzalk2m
+      eslint-plugin-prettier: 4.2.1_cabrci5exjdaojcvd6xoxgeowu
       eslint-plugin-vx: link:../eslint-plugin-vx
       expect-type: 0.15.0
       express: 4.18.2
@@ -2713,7 +2713,7 @@ importers:
       '@typescript-eslint/parser': ^5.37.0
       '@votingworks/grout': workspace:*
       '@votingworks/test-utils': workspace:*
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-prettier: ^8.5.0
       eslint-import-resolver-node: ^0.3.6
       eslint-plugin-import: ^2.26.0
@@ -2734,15 +2734,15 @@ importers:
       '@votingworks/test-utils': link:../../test-utils
     devDependencies:
       '@types/jest': 27.4.1
-      '@typescript-eslint/eslint-plugin': 5.37.0_srb6gpj27cpytxa4hvxonfqyzi
-      '@typescript-eslint/parser': 5.37.0_fnqnj4wr4adlkzkgntzwybsmii
+      '@typescript-eslint/eslint-plugin': 5.37.0_clqnhij63k7sxivgn64qsibvv4
+      '@typescript-eslint/parser': 5.37.0_2owex2qphpdtje5ztrbqluisqa
       '@votingworks/grout': link:..
-      eslint: 8.26.0
-      eslint-config-prettier: 8.5.0_eslint@8.26.0
+      eslint: 8.23.1
+      eslint-config-prettier: 8.5.0_eslint@8.23.1
       eslint-import-resolver-node: 0.3.6
-      eslint-plugin-import: 2.26.0_f7h3xcst4xms75btu7jvjeks3e
-      eslint-plugin-jest: 26.6.0_35phkc7pfykerjsst4kd367zhm
-      eslint-plugin-prettier: 4.2.1_aniwkeyvlpmwkidetuytnokvcm
+      eslint-plugin-import: 2.26.0_uzffwd2kxyy6gwinwkcp25zmz4
+      eslint-plugin-jest: 26.6.0_bnhaycgaqq2lyfixynbuzalk2m
+      eslint-plugin-prettier: 4.2.1_cabrci5exjdaojcvd6xoxgeowu
       eslint-plugin-vx: link:../../eslint-plugin-vx
       expect-type: 0.15.0
       is-ci-cli: 2.2.0
@@ -2836,7 +2836,7 @@ importers:
       debug: ^4.3.2
       esbuild: ^0.14.30
       esbuild-runner: ^2.2.1
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-prettier: ^8.5.0
       eslint-import-resolver-node: ^0.3.6
       eslint-plugin-import: ^2.26.0
@@ -2906,7 +2906,7 @@ importers:
       '@typescript-eslint/parser': ^5.49.0
       '@votingworks/basics': workspace:*
       buffer: ^6.0.3
-      eslint: ^8.32.0
+      eslint: 8.23.1
       eslint-config-prettier: ^8.6.0
       eslint-import-resolver-node: ^0.3.7
       eslint-plugin-import: ^2.27.5
@@ -2926,14 +2926,14 @@ importers:
       buffer: 6.0.3
     devDependencies:
       '@types/jest': 29.4.0
-      '@typescript-eslint/eslint-plugin': 5.49.0_e5nl3pgtbq7irh2db7scmsnz3q
-      '@typescript-eslint/parser': 5.49.0_meject34o2v4gmz2y6b4koze4q
-      eslint: 8.33.0
-      eslint-config-prettier: 8.6.0_eslint@8.33.0
+      '@typescript-eslint/eslint-plugin': 5.49.0_rl4vfvvb32d4rquxp7auin2by4
+      '@typescript-eslint/parser': 5.49.0_2owex2qphpdtje5ztrbqluisqa
+      eslint: 8.23.1
+      eslint-config-prettier: 8.6.0_eslint@8.23.1
       eslint-import-resolver-node: 0.3.7
-      eslint-plugin-import: 2.27.5_kf2q37rsxgsj6p2nz45hjttose
-      eslint-plugin-jest: 27.2.1_f5ej4mifwuut23syazosqocogm
-      eslint-plugin-prettier: 4.2.1_jqplj6qf3uqpxpu4gdyhwwasnq
+      eslint-plugin-import: 2.27.5_bzcdwbny5jz32axx4jcmp44t5i
+      eslint-plugin-jest: 27.2.1_pnka6ppo7hjoqypnps7avyeizy
+      eslint-plugin-prettier: 4.2.1_uq5ey77uvtr34xlijuws27iaxy
       eslint-plugin-vx: link:../eslint-plugin-vx
       fast-check: 2.18.0
       is-ci-cli: 2.2.0
@@ -2959,7 +2959,7 @@ importers:
       debug: ^4.3.2
       esbuild: ^0.14.30
       esbuild-runner: ^2.2.1
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-prettier: ^8.5.0
       eslint-import-resolver-node: ^0.3.6
       eslint-plugin-import: ^2.26.0
@@ -2992,17 +2992,17 @@ importers:
       '@types/jest': 27.4.1
       '@types/node': 16.11.29
       '@types/temp': 0.9.0
-      '@typescript-eslint/eslint-plugin': 5.49.0_e5nl3pgtbq7irh2db7scmsnz3q
-      '@typescript-eslint/parser': 5.49.0_meject34o2v4gmz2y6b4koze4q
+      '@typescript-eslint/eslint-plugin': 5.49.0_rl4vfvvb32d4rquxp7auin2by4
+      '@typescript-eslint/parser': 5.49.0_2owex2qphpdtje5ztrbqluisqa
       '@votingworks/test-utils': link:../test-utils
       esbuild: 0.14.42
       esbuild-runner: 2.2.1_esbuild@0.14.42
-      eslint: 8.33.0
-      eslint-config-prettier: 8.6.0_eslint@8.33.0
+      eslint: 8.23.1
+      eslint-config-prettier: 8.6.0_eslint@8.23.1
       eslint-import-resolver-node: 0.3.7
-      eslint-plugin-import: 2.27.5_kf2q37rsxgsj6p2nz45hjttose
-      eslint-plugin-jest: 26.6.0_cxz2engwmihnktt6iwgkwntofu
-      eslint-plugin-prettier: 4.2.1_jqplj6qf3uqpxpu4gdyhwwasnq
+      eslint-plugin-import: 2.27.5_bzcdwbny5jz32axx4jcmp44t5i
+      eslint-plugin-jest: 26.6.0_g3e7nfonsjxnpiwfriv5wjdzyi
+      eslint-plugin-prettier: 4.2.1_uq5ey77uvtr34xlijuws27iaxy
       eslint-plugin-vx: link:../eslint-plugin-vx
       is-ci-cli: 2.2.0
       jest: 27.5.1
@@ -3026,7 +3026,7 @@ importers:
       '@votingworks/test-utils': workspace:*
       esbuild: ^0.14.27
       esbuild-runner: ^2.2.1
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-prettier: ^8.5.0
       eslint-import-resolver-node: ^0.3.6
       eslint-plugin-import: ^2.26.0
@@ -3088,7 +3088,7 @@ importers:
       '@votingworks/types': workspace:*
       buffer: ^6.0.3
       deep-eql: ^4.1.3
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-prettier: ^8.5.0
       eslint-import-resolver-node: ^0.3.6
       eslint-plugin-import: ^2.26.0
@@ -3166,7 +3166,7 @@ importers:
       ajv: ^8.12.0
       ajv-draft-04: ^1.0.0
       esbuild-runner: ^2.2.1
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-prettier: ^8.5.0
       eslint-import-resolver-node: ^0.3.6
       eslint-plugin-import: ^2.26.0
@@ -3270,7 +3270,7 @@ importers:
       debug: ^4.3.2
       deep-eql: ^4.0.0
       dompurify: ^2.0.12
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-airbnb: ^19.0.4
       eslint-config-prettier: ^8.5.0
       eslint-config-react-app: ^7.0.1
@@ -3434,7 +3434,7 @@ importers:
       base64-js: ^1.3.1
       buffer: ^6.0.3
       debug: ^4.3.2
-      eslint: ^8.23.1
+      eslint: 8.23.1
       eslint-config-prettier: ^8.5.0
       eslint-import-resolver-node: ^0.3.6
       eslint-plugin-import: ^2.26.0
@@ -3629,20 +3629,6 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/eslint-parser/7.19.1_b3mcivpi6zqbotlvqqcfprcnry:
-    resolution: {integrity: sha512-AqNf2QWt1rtu2/1rLswy6CDP7H9Oh3mMhk177Y67Rg8d7RD9WfOLLv8CGn6tisFvS2htm86yIe1yLF6I1UDaGQ==}
-    engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
-    peerDependencies:
-      '@babel/core': '>=7.11.0'
-      eslint: ^7.5.0 || ^8.0.0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 8.33.0
-      eslint-visitor-keys: 2.1.0
-      semver: 6.3.0
-    dev: true
 
   /@babel/eslint-parser/7.19.1_uxfp2mlmakr6bcwr23fktsqgeq:
     resolution: {integrity: sha512-AqNf2QWt1rtu2/1rLswy6CDP7H9Oh3mMhk177Y67Rg8d7RD9WfOLLv8CGn6tisFvS2htm86yIe1yLF6I1UDaGQ==}
@@ -6557,39 +6543,6 @@ packages:
       - supports-color
     dev: true
 
-  /@eslint/eslintrc/1.3.2:
-    resolution: {integrity: sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      ajv: 6.12.6
-      debug: 4.3.4
-      espree: 9.4.0
-      globals: 13.20.0
-      ignore: 5.2.0
-      import-fresh: 3.3.0
-      js-yaml: 4.1.0
-      minimatch: 3.1.2
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-
-  /@eslint/eslintrc/1.3.3:
-    resolution: {integrity: sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      ajv: 6.12.6
-      debug: 4.3.4
-      espree: 9.4.0
-      globals: 13.20.0
-      ignore: 5.2.0
-      import-fresh: 3.3.0
-      js-yaml: 4.1.0
-      minimatch: 3.1.2
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@eslint/eslintrc/1.4.1:
     resolution: {integrity: sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -6695,17 +6648,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@humanwhocodes/config-array/0.11.7:
-    resolution: {integrity: sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==}
-    engines: {node: '>=10.10.0'}
-    dependencies:
-      '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4
-      minimatch: 3.1.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@humanwhocodes/config-array/0.11.8:
     resolution: {integrity: sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==}
     engines: {node: '>=10.10.0'}
@@ -6715,6 +6657,7 @@ packages:
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@humanwhocodes/gitignore-to-minimatch/1.0.2:
     resolution: {integrity: sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==}
@@ -10744,33 +10687,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.37.0_srb6gpj27cpytxa4hvxonfqyzi:
-    resolution: {integrity: sha512-Fde6W0IafXktz1UlnhGkrrmnnGpAo1kyX7dnyHHVrmwJOn72Oqm3eYtddrpOwwel2W8PAK9F3pIL5S+lfoM0og==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.37.0_fnqnj4wr4adlkzkgntzwybsmii
-      '@typescript-eslint/scope-manager': 5.37.0
-      '@typescript-eslint/type-utils': 5.37.0_fnqnj4wr4adlkzkgntzwybsmii
-      '@typescript-eslint/utils': 5.37.0_fnqnj4wr4adlkzkgntzwybsmii
-      debug: 4.3.4
-      eslint: 8.26.0
-      functional-red-black-tree: 1.0.1
-      ignore: 5.2.0
-      regexpp: 3.2.0
-      semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.6.3
-      typescript: 4.6.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/eslint-plugin/5.37.0_uvlayu23ckyn2obt7h3vgg4xui:
     resolution: {integrity: sha512-Fde6W0IafXktz1UlnhGkrrmnnGpAo1kyX7dnyHHVrmwJOn72Oqm3eYtddrpOwwel2W8PAK9F3pIL5S+lfoM0og==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -10790,33 +10706,6 @@ packages:
       eslint: 8.33.0
       functional-red-black-tree: 1.0.1
       ignore: 5.2.0
-      regexpp: 3.2.0
-      semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.6.3
-      typescript: 4.6.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/eslint-plugin/5.49.0_e5nl3pgtbq7irh2db7scmsnz3q:
-    resolution: {integrity: sha512-IhxabIpcf++TBaBa1h7jtOWyon80SXPRLDq0dVz5SLFC/eW6tofkw/O7Ar3lkx5z5U6wzbKDrl2larprp5kk5Q==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.49.0_meject34o2v4gmz2y6b4koze4q
-      '@typescript-eslint/scope-manager': 5.49.0
-      '@typescript-eslint/type-utils': 5.49.0_meject34o2v4gmz2y6b4koze4q
-      '@typescript-eslint/utils': 5.49.0_meject34o2v4gmz2y6b4koze4q
-      debug: 4.3.4
-      eslint: 8.33.0
-      ignore: 5.2.0
-      natural-compare-lite: 1.4.0
       regexpp: 3.2.0
       semver: 7.3.7
       tsutils: 3.21.0_typescript@4.6.3
@@ -10860,19 +10749,6 @@ packages:
     dependencies:
       '@typescript-eslint/utils': 5.37.0_2owex2qphpdtje5ztrbqluisqa
       eslint: 8.23.1
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /@typescript-eslint/experimental-utils/5.37.0_meject34o2v4gmz2y6b4koze4q:
-    resolution: {integrity: sha512-mmzzOOK2YpwSgzhXpeSAtAlxBZVLGuq8OdvrfzibR4jfTTrTd3AjCy17M2dUKVFNsrNfLM0nWsxMsJz0kiYHqw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@typescript-eslint/utils': 5.37.0_meject34o2v4gmz2y6b4koze4q
-      eslint: 8.33.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -10937,26 +10813,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.37.0_fnqnj4wr4adlkzkgntzwybsmii:
-    resolution: {integrity: sha512-01VzI/ipYKuaG5PkE5+qyJ6m02fVALmMPY3Qq5BHflDx3y4VobbLdHQkSMg9VPRS4KdNt4oYTMaomFoHonBGAw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 5.37.0
-      '@typescript-eslint/types': 5.37.0
-      '@typescript-eslint/typescript-estree': 5.37.0_typescript@4.6.3
-      debug: 4.3.4
-      eslint: 8.26.0
-      typescript: 4.6.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/parser/5.37.0_meject34o2v4gmz2y6b4koze4q:
     resolution: {integrity: sha512-01VzI/ipYKuaG5PkE5+qyJ6m02fVALmMPY3Qq5BHflDx3y4VobbLdHQkSMg9VPRS4KdNt4oYTMaomFoHonBGAw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -11012,26 +10868,6 @@ packages:
       debug: 4.3.4
       eslint: 8.33.0
       typescript: 4.3.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/parser/5.49.0_fnqnj4wr4adlkzkgntzwybsmii:
-    resolution: {integrity: sha512-veDlZN9mUhGqU31Qiv2qEp+XrJj5fgZpJ8PW30sHU+j/8/e5ruAhLaVDAeznS7A7i4ucb/s8IozpDtt9NqCkZg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 5.49.0
-      '@typescript-eslint/types': 5.49.0
-      '@typescript-eslint/typescript-estree': 5.49.0_typescript@4.6.3
-      debug: 4.3.4
-      eslint: 8.26.0
-      typescript: 4.6.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11131,26 +10967,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/type-utils/5.37.0_fnqnj4wr4adlkzkgntzwybsmii:
-    resolution: {integrity: sha512-BSx/O0Z0SXOF5tY0bNTBcDEKz2Ec20GVYvq/H/XNKiUorUFilH7NPbFUuiiyzWaSdN3PA8JV0OvYx0gH/5aFAQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/typescript-estree': 5.37.0_typescript@4.6.3
-      '@typescript-eslint/utils': 5.37.0_fnqnj4wr4adlkzkgntzwybsmii
-      debug: 4.3.4
-      eslint: 8.26.0
-      tsutils: 3.21.0_typescript@4.6.3
-      typescript: 4.6.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/type-utils/5.37.0_meject34o2v4gmz2y6b4koze4q:
     resolution: {integrity: sha512-BSx/O0Z0SXOF5tY0bNTBcDEKz2Ec20GVYvq/H/XNKiUorUFilH7NPbFUuiiyzWaSdN3PA8JV0OvYx0gH/5aFAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -11185,26 +11001,6 @@ packages:
       '@typescript-eslint/utils': 5.49.0_2owex2qphpdtje5ztrbqluisqa
       debug: 4.3.4
       eslint: 8.23.1
-      tsutils: 3.21.0_typescript@4.6.3
-      typescript: 4.6.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/type-utils/5.49.0_meject34o2v4gmz2y6b4koze4q:
-    resolution: {integrity: sha512-eUgLTYq0tR0FGU5g1YHm4rt5H/+V2IPVkP0cBmbhRyEmyGe4XvJ2YJ6sYTmONfjmdMqyMLad7SB8GvblbeESZA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/typescript-estree': 5.49.0_typescript@4.6.3
-      '@typescript-eslint/utils': 5.49.0_meject34o2v4gmz2y6b4koze4q
-      debug: 4.3.4
-      eslint: 8.33.0
       tsutils: 3.21.0_typescript@4.6.3
       typescript: 4.6.3
     transitivePeerDependencies:
@@ -11452,25 +11248,6 @@ packages:
       - supports-color
       - typescript
 
-  /@typescript-eslint/utils/5.37.0_fnqnj4wr4adlkzkgntzwybsmii:
-    resolution: {integrity: sha512-jUEJoQrWbZhmikbcWSMDuUSxEE7ID2W/QCV/uz10WtQqfOuKZUqFGjqLJ+qhDd17rjgp+QJPqTdPIBWwoob2NQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@types/json-schema': 7.0.11
-      '@typescript-eslint/parser': 5.49.0_fnqnj4wr4adlkzkgntzwybsmii
-      '@typescript-eslint/scope-manager': 5.37.0
-      '@typescript-eslint/types': 5.37.0
-      '@typescript-eslint/typescript-estree': 5.37.0_typescript@4.6.3
-      eslint: 8.26.0
-      eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@8.26.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
   /@typescript-eslint/utils/5.37.0_meject34o2v4gmz2y6b4koze4q:
     resolution: {integrity: sha512-jUEJoQrWbZhmikbcWSMDuUSxEE7ID2W/QCV/uz10WtQqfOuKZUqFGjqLJ+qhDd17rjgp+QJPqTdPIBWwoob2NQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -11505,27 +11282,6 @@ packages:
       eslint: 8.23.1
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.23.1
-      semver: 7.3.7
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /@typescript-eslint/utils/5.49.0_fnqnj4wr4adlkzkgntzwybsmii:
-    resolution: {integrity: sha512-cPJue/4Si25FViIb74sHCLtM4nTSBXtLx1d3/QT6mirQ/c65bV8arBEebBJJizfq8W2YyMoPI/WWPFWitmNqnQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@types/json-schema': 7.0.11
-      '@types/semver': 7.3.13
-      '@typescript-eslint/parser': 5.49.0_fnqnj4wr4adlkzkgntzwybsmii
-      '@typescript-eslint/scope-manager': 5.49.0
-      '@typescript-eslint/types': 5.49.0
-      '@typescript-eslint/typescript-estree': 5.49.0_typescript@4.6.3
-      eslint: 8.26.0
-      eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@8.26.0
       semver: 7.3.7
     transitivePeerDependencies:
       - supports-color
@@ -12329,7 +12085,7 @@ packages:
       '@babel/core': 7.20.12
     dev: true
 
-  /babel-eslint/10.1.0_eslint@8.33.0:
+  /babel-eslint/10.1.0_eslint@8.23.1:
     resolution: {integrity: sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==}
     engines: {node: '>=6'}
     deprecated: babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.
@@ -12340,7 +12096,7 @@ packages:
       '@babel/parser': 7.18.4
       '@babel/traverse': 7.18.2
       '@babel/types': 7.18.4
-      eslint: 8.33.0
+      eslint: 8.23.1
       eslint-visitor-keys: 1.3.0
       resolve: 1.22.1
     transitivePeerDependencies:
@@ -16911,6 +16667,20 @@ packages:
     optionalDependencies:
       source-map: 0.6.1
 
+  /eslint-config-airbnb-base/14.2.1_gm3nckdpyjle62atxfx4boqatm:
+    resolution: {integrity: sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==}
+    engines: {node: '>= 6'}
+    peerDependencies:
+      eslint: ^5.16.0 || ^6.8.0 || ^7.2.0
+      eslint-plugin-import: ^2.22.1
+    dependencies:
+      confusing-browser-globals: 1.0.11
+      eslint: 8.23.1
+      eslint-plugin-import: 2.27.5_bzcdwbny5jz32axx4jcmp44t5i
+      object.assign: 4.1.4
+      object.entries: 1.1.5
+    dev: true
+
   /eslint-config-airbnb-base/14.2.1_hdzsmr7kawaomymueo2tso6fjq:
     resolution: {integrity: sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==}
     engines: {node: '>= 6'}
@@ -16925,18 +16695,19 @@ packages:
       object.entries: 1.1.5
     dev: true
 
-  /eslint-config-airbnb-base/14.2.1_ohdts44xlqyeyrlje4qnefqeay:
-    resolution: {integrity: sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==}
-    engines: {node: '>= 6'}
+  /eslint-config-airbnb-base/15.0.0_gm3nckdpyjle62atxfx4boqatm:
+    resolution: {integrity: sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==}
+    engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
-      eslint: ^5.16.0 || ^6.8.0 || ^7.2.0
-      eslint-plugin-import: ^2.22.1
+      eslint: ^7.32.0 || ^8.2.0
+      eslint-plugin-import: ^2.25.2
     dependencies:
       confusing-browser-globals: 1.0.11
-      eslint: 8.33.0
-      eslint-plugin-import: 2.27.5_kf2q37rsxgsj6p2nz45hjttose
+      eslint: 8.23.1
+      eslint-plugin-import: 2.27.5_bzcdwbny5jz32axx4jcmp44t5i
       object.assign: 4.1.4
       object.entries: 1.1.5
+      semver: 6.3.0
     dev: true
 
   /eslint-config-airbnb-base/15.0.0_hdzsmr7kawaomymueo2tso6fjq:
@@ -16953,22 +16724,7 @@ packages:
       object.entries: 1.1.5
       semver: 6.3.0
 
-  /eslint-config-airbnb-base/15.0.0_ohdts44xlqyeyrlje4qnefqeay:
-    resolution: {integrity: sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      eslint: ^7.32.0 || ^8.2.0
-      eslint-plugin-import: ^2.25.2
-    dependencies:
-      confusing-browser-globals: 1.0.11
-      eslint: 8.33.0
-      eslint-plugin-import: 2.27.5_kf2q37rsxgsj6p2nz45hjttose
-      object.assign: 4.1.4
-      object.entries: 1.1.5
-      semver: 6.3.0
-    dev: true
-
-  /eslint-config-airbnb/19.0.4_4unmkwsbwnq2azq6y4ttc4sdem:
+  /eslint-config-airbnb/19.0.4_3irxnmmytvcwyuqwe57qqjt3wq:
     resolution: {integrity: sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==}
     engines: {node: ^10.12.0 || ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -16978,12 +16734,12 @@ packages:
       eslint-plugin-react: ^7.28.0
       eslint-plugin-react-hooks: ^4.3.0
     dependencies:
-      eslint: 8.33.0
-      eslint-config-airbnb-base: 15.0.0_ohdts44xlqyeyrlje4qnefqeay
-      eslint-plugin-import: 2.27.5_kf2q37rsxgsj6p2nz45hjttose
-      eslint-plugin-jsx-a11y: 6.6.1_eslint@8.33.0
-      eslint-plugin-react: 7.31.8_eslint@8.33.0
-      eslint-plugin-react-hooks: 4.6.0_eslint@8.33.0
+      eslint: 8.23.1
+      eslint-config-airbnb-base: 15.0.0_gm3nckdpyjle62atxfx4boqatm
+      eslint-plugin-import: 2.27.5_bzcdwbny5jz32axx4jcmp44t5i
+      eslint-plugin-jsx-a11y: 6.6.1_eslint@8.23.1
+      eslint-plugin-react: 7.31.8_eslint@8.23.1
+      eslint-plugin-react-hooks: 4.6.0_eslint@8.23.1
       object.assign: 4.1.4
       object.entries: 1.1.5
     dev: true
@@ -17025,15 +16781,6 @@ packages:
       eslint: 8.23.1
     dev: true
 
-  /eslint-config-prettier/8.5.0_eslint@8.26.0:
-    resolution: {integrity: sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==}
-    hasBin: true
-    peerDependencies:
-      eslint: '>=7.0.0'
-    dependencies:
-      eslint: 8.26.0
-    dev: true
-
   /eslint-config-prettier/8.5.0_eslint@8.33.0:
     resolution: {integrity: sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==}
     hasBin: true
@@ -17043,48 +16790,13 @@ packages:
       eslint: 8.33.0
     dev: true
 
-  /eslint-config-prettier/8.6.0_eslint@8.33.0:
+  /eslint-config-prettier/8.6.0_eslint@8.23.1:
     resolution: {integrity: sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
-      eslint: 8.33.0
-    dev: true
-
-  /eslint-config-react-app/7.0.1_do25er56need6uvlt6654hqyu4:
-    resolution: {integrity: sha512-K6rNzvkIeHaTd8m/QEh1Zko0KI7BACWkkneSs6s9cKZC/J27X3eZR6Upt1jkmZ/4FK+XUOPPxMEN7+lbUXfSlA==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      eslint: ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/eslint-parser': 7.19.1_b3mcivpi6zqbotlvqqcfprcnry
-      '@rushstack/eslint-patch': 1.2.0
-      '@typescript-eslint/eslint-plugin': 5.49.0_e5nl3pgtbq7irh2db7scmsnz3q
-      '@typescript-eslint/parser': 5.49.0_meject34o2v4gmz2y6b4koze4q
-      babel-preset-react-app: 10.0.1
-      confusing-browser-globals: 1.0.11
-      eslint: 8.33.0
-      eslint-plugin-flowtype: 8.0.3_dbm4zd4qfhols3fjlijwxohvlm
-      eslint-plugin-import: 2.27.5_kf2q37rsxgsj6p2nz45hjttose
-      eslint-plugin-jest: 25.7.0_elixyayyhmyxbik6oxof7xq3i4
-      eslint-plugin-jsx-a11y: 6.6.1_eslint@8.33.0
-      eslint-plugin-react: 7.31.8_eslint@8.33.0
-      eslint-plugin-react-hooks: 4.6.0_eslint@8.33.0
-      eslint-plugin-testing-library: 5.6.4_meject34o2v4gmz2y6b4koze4q
-      typescript: 4.6.3
-    transitivePeerDependencies:
-      - '@babel/plugin-syntax-flow'
-      - '@babel/plugin-transform-react-jsx'
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - jest
-      - supports-color
+      eslint: 8.23.1
     dev: true
 
   /eslint-config-react-app/7.0.1_eegtpa2h3btkfjhfab5ysjf3my:
@@ -17122,7 +16834,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-config-react-app/7.0.1_jj6fu62ti5nunysbsr7l3emdqq:
+  /eslint-config-react-app/7.0.1_ud4nhlemy5rgevyptkhk2fu4vy:
     resolution: {integrity: sha512-K6rNzvkIeHaTd8m/QEh1Zko0KI7BACWkkneSs6s9cKZC/J27X3eZR6Upt1jkmZ/4FK+XUOPPxMEN7+lbUXfSlA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -17133,20 +16845,55 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/eslint-parser': 7.19.1_b3mcivpi6zqbotlvqqcfprcnry
+      '@babel/eslint-parser': 7.19.1_uxfp2mlmakr6bcwr23fktsqgeq
       '@rushstack/eslint-patch': 1.2.0
-      '@typescript-eslint/eslint-plugin': 5.49.0_e5nl3pgtbq7irh2db7scmsnz3q
-      '@typescript-eslint/parser': 5.49.0_meject34o2v4gmz2y6b4koze4q
+      '@typescript-eslint/eslint-plugin': 5.49.0_rl4vfvvb32d4rquxp7auin2by4
+      '@typescript-eslint/parser': 5.49.0_2owex2qphpdtje5ztrbqluisqa
       babel-preset-react-app: 10.0.1
       confusing-browser-globals: 1.0.11
-      eslint: 8.33.0
-      eslint-plugin-flowtype: 8.0.3_dbm4zd4qfhols3fjlijwxohvlm
-      eslint-plugin-import: 2.27.5_kf2q37rsxgsj6p2nz45hjttose
-      eslint-plugin-jest: 25.7.0_ihbafhzv62iz2rfufl4kz4vdjm
-      eslint-plugin-jsx-a11y: 6.6.1_eslint@8.33.0
-      eslint-plugin-react: 7.31.8_eslint@8.33.0
-      eslint-plugin-react-hooks: 4.6.0_eslint@8.33.0
-      eslint-plugin-testing-library: 5.6.4_meject34o2v4gmz2y6b4koze4q
+      eslint: 8.23.1
+      eslint-plugin-flowtype: 8.0.3_kpcs5p4zm4a4w6zxhbzwfayc7m
+      eslint-plugin-import: 2.27.5_bzcdwbny5jz32axx4jcmp44t5i
+      eslint-plugin-jest: 25.7.0_nweqlnqyww56czqrc3qvkpw2p4
+      eslint-plugin-jsx-a11y: 6.6.1_eslint@8.23.1
+      eslint-plugin-react: 7.31.8_eslint@8.23.1
+      eslint-plugin-react-hooks: 4.6.0_eslint@8.23.1
+      eslint-plugin-testing-library: 5.6.4_2owex2qphpdtje5ztrbqluisqa
+      typescript: 4.6.3
+    transitivePeerDependencies:
+      - '@babel/plugin-syntax-flow'
+      - '@babel/plugin-transform-react-jsx'
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - jest
+      - supports-color
+    dev: true
+
+  /eslint-config-react-app/7.0.1_wc5uzycbse5qs2tk6i7njlzowm:
+    resolution: {integrity: sha512-K6rNzvkIeHaTd8m/QEh1Zko0KI7BACWkkneSs6s9cKZC/J27X3eZR6Upt1jkmZ/4FK+XUOPPxMEN7+lbUXfSlA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      eslint: ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@babel/core': 7.20.12
+      '@babel/eslint-parser': 7.19.1_uxfp2mlmakr6bcwr23fktsqgeq
+      '@rushstack/eslint-patch': 1.2.0
+      '@typescript-eslint/eslint-plugin': 5.49.0_rl4vfvvb32d4rquxp7auin2by4
+      '@typescript-eslint/parser': 5.49.0_2owex2qphpdtje5ztrbqluisqa
+      babel-preset-react-app: 10.0.1
+      confusing-browser-globals: 1.0.11
+      eslint: 8.23.1
+      eslint-plugin-flowtype: 8.0.3_kpcs5p4zm4a4w6zxhbzwfayc7m
+      eslint-plugin-import: 2.27.5_bzcdwbny5jz32axx4jcmp44t5i
+      eslint-plugin-jest: 25.7.0_vjevoksicmlnkjn4ab6ptajvou
+      eslint-plugin-jsx-a11y: 6.6.1_eslint@8.23.1
+      eslint-plugin-react: 7.31.8_eslint@8.23.1
+      eslint-plugin-react-hooks: 4.6.0_eslint@8.23.1
+      eslint-plugin-testing-library: 5.6.4_2owex2qphpdtje5ztrbqluisqa
       typescript: 4.6.3
     transitivePeerDependencies:
       - '@babel/plugin-syntax-flow'
@@ -17182,35 +16929,6 @@ packages:
       resolve: 1.22.1
     transitivePeerDependencies:
       - supports-color
-
-  /eslint-module-utils/2.7.4_a5jfphyyegozc5blomb7uu4w7e:
-    resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint:
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.49.0_meject34o2v4gmz2y6b4koze4q
-      debug: 3.2.7
-      eslint: 8.33.0
-      eslint-import-resolver-node: 0.3.7
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /eslint-module-utils/2.7.4_ccqcs2zgfrcz4vsmvuxwlnfvem:
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
@@ -17356,35 +17074,6 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils/2.7.4_zb3r25qnhtodt62ijugzsp74om:
-    resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint:
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.37.0_fnqnj4wr4adlkzkgntzwybsmii
-      debug: 3.2.7
-      eslint: 8.26.0
-      eslint-import-resolver-node: 0.3.7
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /eslint-plugin-cypress/2.12.1_eslint@8.23.1:
     resolution: {integrity: sha512-c2W/uPADl5kospNDihgiLc7n87t5XhUbFDoTl6CfVkmG+kDAb5Ux10V9PoLPu9N+r7znpc+iQlcmAqT1A/89HA==}
     peerDependencies:
@@ -17392,15 +17081,6 @@ packages:
     dependencies:
       eslint: 8.23.1
       globals: 11.12.0
-
-  /eslint-plugin-cypress/2.12.1_eslint@8.33.0:
-    resolution: {integrity: sha512-c2W/uPADl5kospNDihgiLc7n87t5XhUbFDoTl6CfVkmG+kDAb5Ux10V9PoLPu9N+r7znpc+iQlcmAqT1A/89HA==}
-    peerDependencies:
-      eslint: '>= 3.2.1'
-    dependencies:
-      eslint: 8.33.0
-      globals: 11.12.0
-    dev: true
 
   /eslint-plugin-flowtype/5.2.0_eslint@8.23.1:
     resolution: {integrity: sha512-z7ULdTxuhlRJcEe1MVljePXricuPOrsWfScRXFhNzVD5dmTHWjIF57AxD0e7AbEoLSbjSsaA5S+hCg43WvpXJQ==}
@@ -17413,18 +17093,7 @@ packages:
       string-natural-compare: 3.0.1
     dev: true
 
-  /eslint-plugin-flowtype/5.2.0_eslint@8.33.0:
-    resolution: {integrity: sha512-z7ULdTxuhlRJcEe1MVljePXricuPOrsWfScRXFhNzVD5dmTHWjIF57AxD0e7AbEoLSbjSsaA5S+hCg43WvpXJQ==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      eslint: ^7.1.0
-    dependencies:
-      eslint: 8.33.0
-      lodash: 4.17.21
-      string-natural-compare: 3.0.1
-    dev: true
-
-  /eslint-plugin-flowtype/8.0.3_dbm4zd4qfhols3fjlijwxohvlm:
+  /eslint-plugin-flowtype/8.0.3_kpcs5p4zm4a4w6zxhbzwfayc7m:
     resolution: {integrity: sha512-dX8l6qUL6O+fYPtpNRideCFSpmWOUVx5QcaGLVqe/vlDiBSe4vYljDWDETwnyFzpl7By/WVIu6rcrniCgH9BqQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -17434,21 +17103,6 @@ packages:
     dependencies:
       '@babel/plugin-syntax-flow': 7.18.6_@babel+core@7.12.3
       '@babel/plugin-transform-react-jsx': 7.20.13_@babel+core@7.12.3
-      eslint: 8.33.0
-      lodash: 4.17.21
-      string-natural-compare: 3.0.1
-    dev: true
-
-  /eslint-plugin-flowtype/8.0.3_kpcs5p4zm4a4w6zxhbzwfayc7m:
-    resolution: {integrity: sha512-dX8l6qUL6O+fYPtpNRideCFSpmWOUVx5QcaGLVqe/vlDiBSe4vYljDWDETwnyFzpl7By/WVIu6rcrniCgH9BqQ==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      '@babel/plugin-syntax-flow': ^7.14.5
-      '@babel/plugin-transform-react-jsx': ^7.14.9
-      eslint: ^8.1.0
-    dependencies:
-      '@babel/plugin-syntax-flow': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-react-jsx': 7.20.13_@babel+core@7.20.12
       eslint: 8.23.1
       lodash: 4.17.21
       string-natural-compare: 3.0.1
@@ -17483,37 +17137,6 @@ packages:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
-
-  /eslint-plugin-import/2.26.0_f7h3xcst4xms75btu7jvjeks3e:
-    resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.37.0_fnqnj4wr4adlkzkgntzwybsmii
-      array-includes: 3.1.5
-      array.prototype.flat: 1.3.0
-      debug: 2.6.9
-      doctrine: 2.1.0
-      eslint: 8.26.0
-      eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.7.4_zb3r25qnhtodt62ijugzsp74om
-      has: 1.0.3
-      is-core-module: 2.10.0
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.values: 1.1.5
-      resolve: 1.22.1
-      tsconfig-paths: 3.14.1
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-    dev: true
 
   /eslint-plugin-import/2.26.0_niytuuf2nrnenji7hgsgfjd3ny:
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
@@ -17643,40 +17266,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-import/2.27.5_kf2q37rsxgsj6p2nz45hjttose:
-    resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.49.0_meject34o2v4gmz2y6b4koze4q
-      array-includes: 3.1.6
-      array.prototype.flat: 1.3.1
-      array.prototype.flatmap: 1.3.1
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 8.33.0
-      eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.7.4_a5jfphyyegozc5blomb7uu4w7e
-      has: 1.0.3
-      is-core-module: 2.11.0
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.values: 1.1.6
-      resolve: 1.22.1
-      semver: 6.3.0
-      tsconfig-paths: 3.14.1
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-    dev: true
-
-  /eslint-plugin-jest/25.7.0_elixyayyhmyxbik6oxof7xq3i4:
+  /eslint-plugin-jest/25.7.0_nweqlnqyww56czqrc3qvkpw2p4:
     resolution: {integrity: sha512-PWLUEXeeF7C9QGKqvdSbzLOiLTx+bno7/HC9eefePfEb257QFHg7ye3dh80AZVkaa/RQsBB1Q/ORQvg2X7F0NQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     peerDependencies:
@@ -17689,16 +17279,16 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.49.0_e5nl3pgtbq7irh2db7scmsnz3q
-      '@typescript-eslint/experimental-utils': 5.37.0_meject34o2v4gmz2y6b4koze4q
-      eslint: 8.33.0
+      '@typescript-eslint/eslint-plugin': 5.49.0_rl4vfvvb32d4rquxp7auin2by4
+      '@typescript-eslint/experimental-utils': 5.37.0_2owex2qphpdtje5ztrbqluisqa
+      eslint: 8.23.1
       jest: 26.6.0_canvas@2.9.1
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /eslint-plugin-jest/25.7.0_ihbafhzv62iz2rfufl4kz4vdjm:
+  /eslint-plugin-jest/25.7.0_vjevoksicmlnkjn4ab6ptajvou:
     resolution: {integrity: sha512-PWLUEXeeF7C9QGKqvdSbzLOiLTx+bno7/HC9eefePfEb257QFHg7ye3dh80AZVkaa/RQsBB1Q/ORQvg2X7F0NQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     peerDependencies:
@@ -17711,9 +17301,9 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.49.0_e5nl3pgtbq7irh2db7scmsnz3q
-      '@typescript-eslint/experimental-utils': 5.37.0_meject34o2v4gmz2y6b4koze4q
-      eslint: 8.33.0
+      '@typescript-eslint/eslint-plugin': 5.49.0_rl4vfvvb32d4rquxp7auin2by4
+      '@typescript-eslint/experimental-utils': 5.37.0_2owex2qphpdtje5ztrbqluisqa
+      eslint: 8.23.1
       jest: 26.6.3
     transitivePeerDependencies:
       - supports-color
@@ -17874,7 +17464,7 @@ packages:
       - typescript
     dev: true
 
-  /eslint-plugin-jest/26.6.0_35phkc7pfykerjsst4kd367zhm:
+  /eslint-plugin-jest/26.6.0_6jh3f5xpvchtxrdgqf7zhexlqm:
     resolution: {integrity: sha512-f8n46/97ZFdU4KqeQYqO8AEVGIhHWvkpgNBWHH3jrM28/y8llnbf3IjfIKv6p2pZIMinK1PCqbbROxs9Eud02Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -17887,16 +17477,37 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.37.0_srb6gpj27cpytxa4hvxonfqyzi
-      '@typescript-eslint/utils': 5.49.0_fnqnj4wr4adlkzkgntzwybsmii
-      eslint: 8.26.0
+      '@typescript-eslint/eslint-plugin': 5.49.0_rl4vfvvb32d4rquxp7auin2by4
+      '@typescript-eslint/utils': 5.49.0_2owex2qphpdtje5ztrbqluisqa
+      eslint: 8.23.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /eslint-plugin-jest/26.6.0_bnhaycgaqq2lyfixynbuzalk2m:
+    resolution: {integrity: sha512-f8n46/97ZFdU4KqeQYqO8AEVGIhHWvkpgNBWHH3jrM28/y8llnbf3IjfIKv6p2pZIMinK1PCqbbROxs9Eud02Q==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      jest: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
+      jest:
+        optional: true
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 5.37.0_clqnhij63k7sxivgn64qsibvv4
+      '@typescript-eslint/utils': 5.49.0_2owex2qphpdtje5ztrbqluisqa
+      eslint: 8.23.1
       jest: 27.5.1
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /eslint-plugin-jest/26.6.0_4rhbl2u5cwr5asblcuddcnjhaa:
+  /eslint-plugin-jest/26.6.0_g3e7nfonsjxnpiwfriv5wjdzyi:
     resolution: {integrity: sha512-f8n46/97ZFdU4KqeQYqO8AEVGIhHWvkpgNBWHH3jrM28/y8llnbf3IjfIKv6p2pZIMinK1PCqbbROxs9Eud02Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -17909,38 +17520,16 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.37.0_srb6gpj27cpytxa4hvxonfqyzi
-      '@typescript-eslint/utils': 5.49.0_fnqnj4wr4adlkzkgntzwybsmii
-      eslint: 8.26.0
-      jest: 28.1.3_@types+node@18.8.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /eslint-plugin-jest/26.6.0_cxz2engwmihnktt6iwgkwntofu:
-    resolution: {integrity: sha512-f8n46/97ZFdU4KqeQYqO8AEVGIhHWvkpgNBWHH3jrM28/y8llnbf3IjfIKv6p2pZIMinK1PCqbbROxs9Eud02Q==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      '@typescript-eslint/eslint-plugin': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      jest: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/eslint-plugin':
-        optional: true
-      jest:
-        optional: true
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 5.49.0_e5nl3pgtbq7irh2db7scmsnz3q
-      '@typescript-eslint/utils': 5.49.0_meject34o2v4gmz2y6b4koze4q
-      eslint: 8.33.0
+      '@typescript-eslint/eslint-plugin': 5.49.0_rl4vfvvb32d4rquxp7auin2by4
+      '@typescript-eslint/utils': 5.49.0_2owex2qphpdtje5ztrbqluisqa
+      eslint: 8.23.1
       jest: 27.5.1
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /eslint-plugin-jest/26.6.0_elixyayyhmyxbik6oxof7xq3i4:
+  /eslint-plugin-jest/26.6.0_nweqlnqyww56czqrc3qvkpw2p4:
     resolution: {integrity: sha512-f8n46/97ZFdU4KqeQYqO8AEVGIhHWvkpgNBWHH3jrM28/y8llnbf3IjfIKv6p2pZIMinK1PCqbbROxs9Eud02Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -17953,16 +17542,16 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.49.0_e5nl3pgtbq7irh2db7scmsnz3q
-      '@typescript-eslint/utils': 5.49.0_meject34o2v4gmz2y6b4koze4q
-      eslint: 8.33.0
+      '@typescript-eslint/eslint-plugin': 5.49.0_rl4vfvvb32d4rquxp7auin2by4
+      '@typescript-eslint/utils': 5.49.0_2owex2qphpdtje5ztrbqluisqa
+      eslint: 8.23.1
       jest: 26.6.0_canvas@2.9.1
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /eslint-plugin-jest/26.6.0_ihbafhzv62iz2rfufl4kz4vdjm:
+  /eslint-plugin-jest/26.6.0_vjevoksicmlnkjn4ab6ptajvou:
     resolution: {integrity: sha512-f8n46/97ZFdU4KqeQYqO8AEVGIhHWvkpgNBWHH3jrM28/y8llnbf3IjfIKv6p2pZIMinK1PCqbbROxs9Eud02Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -17975,16 +17564,16 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.49.0_e5nl3pgtbq7irh2db7scmsnz3q
-      '@typescript-eslint/utils': 5.49.0_meject34o2v4gmz2y6b4koze4q
-      eslint: 8.33.0
+      '@typescript-eslint/eslint-plugin': 5.49.0_rl4vfvvb32d4rquxp7auin2by4
+      '@typescript-eslint/utils': 5.49.0_2owex2qphpdtje5ztrbqluisqa
+      eslint: 8.23.1
       jest: 26.6.3
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /eslint-plugin-jest/26.6.0_v4vzmluohzmzetuufbkrldtdcy:
+  /eslint-plugin-jest/26.6.0_wphx3phx2gg26dl5pvw5rz6jqm:
     resolution: {integrity: sha512-f8n46/97ZFdU4KqeQYqO8AEVGIhHWvkpgNBWHH3jrM28/y8llnbf3IjfIKv6p2pZIMinK1PCqbbROxs9Eud02Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -17997,9 +17586,10 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.49.0_e5nl3pgtbq7irh2db7scmsnz3q
-      '@typescript-eslint/utils': 5.49.0_meject34o2v4gmz2y6b4koze4q
-      eslint: 8.33.0
+      '@typescript-eslint/eslint-plugin': 5.37.0_clqnhij63k7sxivgn64qsibvv4
+      '@typescript-eslint/utils': 5.49.0_2owex2qphpdtje5ztrbqluisqa
+      eslint: 8.23.1
+      jest: 28.1.3_@types+node@18.8.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -18049,7 +17639,7 @@ packages:
       - typescript
     dev: true
 
-  /eslint-plugin-jest/27.2.1_f5ej4mifwuut23syazosqocogm:
+  /eslint-plugin-jest/27.2.1_pnka6ppo7hjoqypnps7avyeizy:
     resolution: {integrity: sha512-l067Uxx7ZT8cO9NJuf+eJHvt6bqJyz2Z29wykyEdz/OtmcELQl2MQGQLX8J94O1cSJWAwUSEvCjwjA7KEK3Hmg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -18062,9 +17652,9 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.49.0_e5nl3pgtbq7irh2db7scmsnz3q
-      '@typescript-eslint/utils': 5.49.0_meject34o2v4gmz2y6b4koze4q
-      eslint: 8.33.0
+      '@typescript-eslint/eslint-plugin': 5.49.0_rl4vfvvb32d4rquxp7auin2by4
+      '@typescript-eslint/utils': 5.49.0_2owex2qphpdtje5ztrbqluisqa
+      eslint: 8.23.1
       jest: 29.4.1
     transitivePeerDependencies:
       - supports-color
@@ -18092,28 +17682,6 @@ packages:
       minimatch: 3.1.2
       semver: 6.3.0
 
-  /eslint-plugin-jsx-a11y/6.6.1_eslint@8.33.0:
-    resolution: {integrity: sha512-sXgFVNHiWffBq23uiS/JaP6eVR622DqwB4yTzKvGZGcPq6/yZ3WmOZfuBks/vHWo9GaFOqC2ZK4i6+C35knx7Q==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
-    dependencies:
-      '@babel/runtime': 7.20.6
-      aria-query: 4.2.2
-      array-includes: 3.1.5
-      ast-types-flow: 0.0.7
-      axe-core: 4.4.3
-      axobject-query: 2.2.0
-      damerau-levenshtein: 1.0.8
-      emoji-regex: 9.2.2
-      eslint: 8.33.0
-      has: 1.0.3
-      jsx-ast-utils: 3.3.3
-      language-tags: 1.0.5
-      minimatch: 3.1.2
-      semver: 6.3.0
-    dev: true
-
   /eslint-plugin-no-null/1.0.2_eslint@8.23.1:
     resolution: {integrity: sha1-EjaoEjkTkKGHetQAfCbnRTQclR8=}
     engines: {node: '>=5.0.0'}
@@ -18140,23 +17708,6 @@ packages:
       prettier-linter-helpers: 1.0.0
     dev: true
 
-  /eslint-plugin-prettier/4.2.1_aniwkeyvlpmwkidetuytnokvcm:
-    resolution: {integrity: sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      eslint: '>=7.28.0'
-      eslint-config-prettier: '*'
-      prettier: '>=2.0.0'
-    peerDependenciesMeta:
-      eslint-config-prettier:
-        optional: true
-    dependencies:
-      eslint: 8.26.0
-      eslint-config-prettier: 8.5.0_eslint@8.26.0
-      prettier: 2.7.1
-      prettier-linter-helpers: 1.0.0
-    dev: true
-
   /eslint-plugin-prettier/4.2.1_cabrci5exjdaojcvd6xoxgeowu:
     resolution: {integrity: sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==}
     engines: {node: '>=12.0.0'}
@@ -18171,23 +17722,6 @@ packages:
       eslint: 8.23.1
       eslint-config-prettier: 8.5.0_eslint@8.23.1
       prettier: 2.7.1
-      prettier-linter-helpers: 1.0.0
-    dev: true
-
-  /eslint-plugin-prettier/4.2.1_jqplj6qf3uqpxpu4gdyhwwasnq:
-    resolution: {integrity: sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      eslint: '>=7.28.0'
-      eslint-config-prettier: '*'
-      prettier: '>=2.0.0'
-    peerDependenciesMeta:
-      eslint-config-prettier:
-        optional: true
-    dependencies:
-      eslint: 8.33.0
-      eslint-config-prettier: 8.6.0_eslint@8.33.0
-      prettier: 2.8.3
       prettier-linter-helpers: 1.0.0
     dev: true
 
@@ -18225,6 +17759,23 @@ packages:
       prettier-linter-helpers: 1.0.0
     dev: true
 
+  /eslint-plugin-prettier/4.2.1_uq5ey77uvtr34xlijuws27iaxy:
+    resolution: {integrity: sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      eslint: '>=7.28.0'
+      eslint-config-prettier: '*'
+      prettier: '>=2.0.0'
+    peerDependenciesMeta:
+      eslint-config-prettier:
+        optional: true
+    dependencies:
+      eslint: 8.23.1
+      eslint-config-prettier: 8.6.0_eslint@8.23.1
+      prettier: 2.8.3
+      prettier-linter-helpers: 1.0.0
+    dev: true
+
   /eslint-plugin-prettier/4.2.1_vfj7rq6mxr4czeazljj3yeubse:
     resolution: {integrity: sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==}
     engines: {node: '>=12.0.0'}
@@ -18250,15 +17801,6 @@ packages:
     dependencies:
       eslint: 8.23.1
 
-  /eslint-plugin-react-hooks/4.6.0_eslint@8.33.0:
-    resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
-    dependencies:
-      eslint: 8.33.0
-    dev: true
-
   /eslint-plugin-react/7.31.8_eslint@8.23.1:
     resolution: {integrity: sha512-5lBTZmgQmARLLSYiwI71tiGVTLUuqXantZM6vlSY39OaDSV0M7+32K5DnLkmFrwTe+Ksz0ffuLUC91RUviVZfw==}
     engines: {node: '>=4'}
@@ -18280,29 +17822,6 @@ packages:
       resolve: 2.0.0-next.3
       semver: 6.3.0
       string.prototype.matchall: 4.0.7
-
-  /eslint-plugin-react/7.31.8_eslint@8.33.0:
-    resolution: {integrity: sha512-5lBTZmgQmARLLSYiwI71tiGVTLUuqXantZM6vlSY39OaDSV0M7+32K5DnLkmFrwTe+Ksz0ffuLUC91RUviVZfw==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
-    dependencies:
-      array-includes: 3.1.6
-      array.prototype.flatmap: 1.3.1
-      doctrine: 2.1.0
-      eslint: 8.33.0
-      estraverse: 5.3.0
-      jsx-ast-utils: 3.3.3
-      minimatch: 3.1.2
-      object.entries: 1.1.5
-      object.fromentries: 2.0.5
-      object.hasown: 1.1.1
-      object.values: 1.1.6
-      prop-types: 15.8.1
-      resolve: 2.0.0-next.3
-      semver: 6.3.0
-      string.prototype.matchall: 4.0.7
-    dev: true
 
   /eslint-plugin-storybook/0.6.10_2owex2qphpdtje5ztrbqluisqa:
     resolution: {integrity: sha512-3DKXRey06EhwnTKaG6fgMqGTy4C3z6Ikyv6VVixO5BvaExWQe3yGWIAufrC2Et0OaAMIaMwx9KWjqb/Wq+JxPg==}
@@ -18328,19 +17847,6 @@ packages:
     dependencies:
       '@typescript-eslint/utils': 5.49.0_2owex2qphpdtje5ztrbqluisqa
       eslint: 8.23.1
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /eslint-plugin-testing-library/5.6.4_meject34o2v4gmz2y6b4koze4q:
-    resolution: {integrity: sha512-0oW3tC5NNT2WexmJ3848a/utawOymw4ibl3/NkwywndVAz2hT9+ab70imA7ccg3RaScQgMvJT60OL00hpmJvrg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0, npm: '>=6'}
-    peerDependencies:
-      eslint: ^7.5.0 || ^8.0.0
-    dependencies:
-      '@typescript-eslint/utils': 5.49.0_meject34o2v4gmz2y6b4koze4q
-      eslint: 8.33.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -18383,16 +17889,6 @@ packages:
       eslint: 8.23.1
       eslint-visitor-keys: 2.1.0
 
-  /eslint-utils/3.0.0_eslint@8.26.0:
-    resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
-    engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
-    peerDependencies:
-      eslint: '>=5'
-    dependencies:
-      eslint: 8.26.0
-      eslint-visitor-keys: 2.1.0
-    dev: true
-
   /eslint-utils/3.0.0_eslint@8.33.0:
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
@@ -18401,6 +17897,7 @@ packages:
     dependencies:
       eslint: 8.33.0
       eslint-visitor-keys: 2.1.0
+    dev: true
 
   /eslint-visitor-keys/1.3.0:
     resolution: {integrity: sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==}
@@ -18414,7 +17911,7 @@ packages:
     resolution: {integrity: sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  /eslint-webpack-plugin/2.4.1_p4rw3jph5dagt54h5drwbkzsce:
+  /eslint-webpack-plugin/2.4.1_sycz7lcl6yepnet57jvpov6ms4:
     resolution: {integrity: sha512-cj8iPWZKuAiVD8MMgTSunyMCAvxQxp5mxoPHZl1UMGkApFXaXJHdCFcCR+oZEJbBNhReNa5SjESIn34uqUbBtg==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -18423,7 +17920,7 @@ packages:
     dependencies:
       '@types/eslint': 7.2.6
       arrify: 2.0.1
-      eslint: 8.33.0
+      eslint: 8.23.1
       jest-worker: 26.6.2
       micromatch: 4.0.5
       schema-utils: 3.0.0
@@ -18483,7 +17980,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
-      '@eslint/eslintrc': 1.3.2
+      '@eslint/eslintrc': 1.4.1
       '@humanwhocodes/config-array': 0.10.4
       '@humanwhocodes/gitignore-to-minimatch': 1.0.2
       '@humanwhocodes/module-importer': 1.0.1
@@ -18503,60 +18000,13 @@ packages:
       file-entry-cache: 6.0.1
       find-up: 5.0.0
       glob-parent: 6.0.2
-      globals: 13.17.0
+      globals: 13.20.0
       globby: 11.1.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.0
       import-fresh: 3.3.0
       imurmurhash: 0.1.4
       is-glob: 4.0.3
-      js-sdsl: 4.1.4
-      js-yaml: 4.1.0
-      json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.4.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.2
-      natural-compare: 1.4.0
-      optionator: 0.9.1
-      regexpp: 3.2.0
-      strip-ansi: 6.0.1
-      strip-json-comments: 3.1.1
-      text-table: 0.2.0
-    transitivePeerDependencies:
-      - supports-color
-
-  /eslint/8.26.0:
-    resolution: {integrity: sha512-kzJkpaw1Bfwheq4VXUezFriD1GxszX6dUekM7Z3aC2o4hju+tsR/XyTC3RcoSD7jmy9VkPU3+N6YjVU2e96Oyg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    hasBin: true
-    dependencies:
-      '@eslint/eslintrc': 1.3.3
-      '@humanwhocodes/config-array': 0.11.7
-      '@humanwhocodes/module-importer': 1.0.1
-      '@nodelib/fs.walk': 1.2.8
-      ajv: 6.12.6
-      chalk: 4.1.2
-      cross-spawn: 7.0.3
-      debug: 4.3.4
-      doctrine: 3.0.0
-      escape-string-regexp: 4.0.0
-      eslint-scope: 7.1.1
-      eslint-utils: 3.0.0_eslint@8.26.0
-      eslint-visitor-keys: 3.3.0
-      espree: 9.4.0
-      esquery: 1.4.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 6.0.1
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      globals: 13.17.0
-      grapheme-splitter: 1.0.4
-      ignore: 5.2.0
-      import-fresh: 3.3.0
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      is-path-inside: 3.0.3
       js-sdsl: 4.1.5
       js-yaml: 4.1.0
       json-stable-stringify-without-jsonify: 1.0.1
@@ -18571,7 +18021,6 @@ packages:
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /eslint/8.33.0:
     resolution: {integrity: sha512-WjOpFQgKK8VrCnAtl8We0SUOy/oVZ5NHykyMiagV1M9r8IFpIJX7DduK6n1mpfhlG7T1NLWm2SuD8QB7KFySaA==}
@@ -18619,6 +18068,7 @@ packages:
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /espree/7.3.1:
     resolution: {integrity: sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==}
@@ -19398,18 +18848,6 @@ packages:
       debug: 4.3.2
     dev: false
 
-  /follow-redirects/1.14.1_debug@4.3.4:
-    resolution: {integrity: sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dependencies:
-      debug: 4.3.4
-    dev: false
-
   /for-each/0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
     dependencies:
@@ -19431,7 +18869,7 @@ packages:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
     dev: false
 
-  /fork-ts-checker-webpack-plugin/4.1.6_aujbwneux7xsh6nzyv4q5odp7y:
+  /fork-ts-checker-webpack-plugin/4.1.6_ncroedkm2fa5vjohk6lc3nx6c4:
     resolution: {integrity: sha512-DUxuQaKoqfNne8iikd14SAkh5uw4+8vNifp6gmA73yYNS6ywLIWSLD/n/mBzHQRpW3J7rbATEakmiA8JvkTyZw==}
     engines: {node: '>=6.11.5', yarn: '>=1.0.0'}
     peerDependencies:
@@ -19447,7 +18885,7 @@ packages:
     dependencies:
       '@babel/code-frame': 7.18.6
       chalk: 2.4.2
-      eslint: 8.33.0
+      eslint: 8.23.1
       micromatch: 3.1.10
       minimatch: 3.1.2
       semver: 5.7.1
@@ -19459,7 +18897,7 @@ packages:
       - supports-color
     dev: false
 
-  /fork-ts-checker-webpack-plugin/6.5.2_aujbwneux7xsh6nzyv4q5odp7y:
+  /fork-ts-checker-webpack-plugin/6.5.2_ncroedkm2fa5vjohk6lc3nx6c4:
     resolution: {integrity: sha512-m5cUmF30xkZ7h4tWUgTAcEaKmUW7tfyUyTqNNOz7OxWJ0v1VWKTcOvH8FWHUwSjlW/356Ijc9vi3XfcPstpQKA==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -19479,7 +18917,7 @@ packages:
       chokidar: 3.5.3
       cosmiconfig: 6.0.0
       deepmerge: 4.2.2
-      eslint: 8.33.0
+      eslint: 8.23.1
       fs-extra: 9.1.0
       glob: 7.2.3
       memfs: 3.4.7
@@ -19860,12 +19298,6 @@ packages:
   /globals/11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
-
-  /globals/13.17.0:
-    resolution: {integrity: sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==}
-    engines: {node: '>=8'}
-    dependencies:
-      type-fest: 0.20.2
 
   /globals/13.20.0:
     resolution: {integrity: sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==}
@@ -20382,7 +19814,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.14.1_debug@4.3.4
+      follow-redirects: 1.14.1_debug@4.3.2
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -25013,9 +24445,6 @@ packages:
     resolution: {integrity: sha512-rML+NkoD08p5Dllpjo0ffy4jRHeY6Zsapvr/W86N7E0yuzAO6qa5X9+xog6zQNlH102J7IXljNY2FtS6Lj3ucg==}
     dev: false
 
-  /js-sdsl/4.1.4:
-    resolution: {integrity: sha512-Y2/yD55y5jteOAmY50JbUZYwk3CP3wnLPEZnlR1w9oKhITrBEtAxwuWKebFf8hMrPMgbYwFoWK/lH2sBkErELw==}
-
   /js-sdsl/4.1.5:
     resolution: {integrity: sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==}
 
@@ -28541,7 +27970,7 @@ packages:
       react-dom: 17.0.1_react@17.0.2
     dev: true
 
-  /react-dev-utils/11.0.3_aujbwneux7xsh6nzyv4q5odp7y:
+  /react-dev-utils/11.0.3_ncroedkm2fa5vjohk6lc3nx6c4:
     resolution: {integrity: sha512-4lEA5gF4OHrcJLMUV1t+4XbNDiJbsAWCH5Z2uqlTqW6dD7Cf5nEASkeXrCI/Mz83sI2o527oBIFKVMXtRf1Vtg==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -28560,7 +27989,7 @@ packages:
       escape-string-regexp: 2.0.0
       filesize: 6.1.0
       find-up: 4.1.0
-      fork-ts-checker-webpack-plugin: 4.1.6_aujbwneux7xsh6nzyv4q5odp7y
+      fork-ts-checker-webpack-plugin: 4.1.6_ncroedkm2fa5vjohk6lc3nx6c4
       global-modules: 2.0.0
       globby: 11.0.1
       gzip-size: 5.1.1
@@ -28583,7 +28012,7 @@ packages:
       - vue-template-compiler
     dev: false
 
-  /react-dev-utils/12.0.1_aujbwneux7xsh6nzyv4q5odp7y:
+  /react-dev-utils/12.0.1_ncroedkm2fa5vjohk6lc3nx6c4:
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -28602,7 +28031,7 @@ packages:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.2_aujbwneux7xsh6nzyv4q5odp7y
+      fork-ts-checker-webpack-plugin: 6.5.2_ncroedkm2fa5vjohk6lc3nx6c4
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -31685,7 +31114,7 @@ packages:
       esbuild: 0.14.25
       fast-json-stable-stringify: 2.1.0
       jest: 29.4.3
-      jest-util: 29.4.2
+      jest-util: 29.4.1
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6


### PR DESCRIPTION

## Overview
I keep getting errors in VS Code with the `no-underscore-dangle` rule. It says the configuration has unknown properties. Newer versions of ESLint introduced new config properties that seem to be showing up in the resolved config, but the version of ESLint the VS Code integration ends up picking is sometimes a version that does not know about those config properties, making ESLint in VS Code stop working. This commit fixes that by pinning to a specific ESLint version.

<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot
n/a

## Testing Plan
Tried it locally for a while, the issue I mentioned hasn't reoccured.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
