### PR TITLE
chore: fix PR template formatting

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,12 +8,8 @@
 
 ## Checklist
 
-- [ ] I have added
-      [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging)
-      where appropriate to any new user actions, system updates such as file
-      reads or storage writes, or errors introduced.
+- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
 - [ ] I have added JSDoc comments to any newly introduced exports
 <!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
 - [ ] I have added a screenshot and/or video to this PR to demo the change
-- [ ] I have added the "user_facing_change" label to this PR to automate an
-      announcement in #machine-product-updates
+- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates


### PR DESCRIPTION
## Overview
GitHub seemingly has different Markdown renderers. The README renderer is fine with the formatting as it was and renders it as expected. The PR description one renders the whitespace differently, so we have to put it all on one line if we want it rendered properly.

## Demo Video or Screenshot
n/a

## Testing Plan
n/a

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
