### PR TITLE
Add libs/auth tests, part 3

### DIFF
--- a/apps/admin/frontend/src/components/smartcard_modal/smartcard_modal.test.tsx
+++ b/apps/admin/frontend/src/components/smartcard_modal/smartcard_modal.test.tsx
@@ -4,7 +4,7 @@ import {
   ElectionManagerUser,
   PollWorkerUser,
   SystemAdministratorUser,
-  User,
+  UserWithCard,
 } from '@votingworks/types';
 import {
   electionSampleDefinition,
@@ -60,7 +60,7 @@ test('Smartcard modal displays card details', async () => {
   await apiMock.authenticateAsSystemAdministrator();
 
   const testCases: Array<{
-    programmedUser: User;
+    programmedUser: UserWithCard;
     expectedHeading: string;
     expectedElectionString?: string;
     shouldResetCardPinButtonBeDisplayed: boolean;
@@ -171,7 +171,7 @@ test('Smartcard modal displays card details when no election definition on machi
   await apiMock.authenticateAsSystemAdministrator();
 
   const testCases: Array<{
-    programmedUser: User;
+    programmedUser: UserWithCard;
     expectedHeading: string;
     expectedElectionString?: string;
     shouldResetCardPinButtonBeDisplayed: boolean;
@@ -569,7 +569,7 @@ test('Unprogramming smartcards', async () => {
   await screen.findByRole('heading', { name: 'Election Definition' });
 
   const testCases: Array<{
-    programmedUser: User;
+    programmedUser: UserWithCard;
     expectedHeadingBeforeUnprogramming: string;
     expectedSuccessText: string;
   }> = [
@@ -640,7 +640,7 @@ test('Error handling', async () => {
 
   const testCases: Array<{
     beginFromSuperAdminCardsScreen?: boolean;
-    programmedUser?: User;
+    programmedUser?: UserWithCard;
     buttonToPress: string;
     expectedProgressText: string;
     expectedErrorText: string;

--- a/apps/admin/frontend/src/components/smartcard_modal/smartcard_modal.test.tsx
+++ b/apps/admin/frontend/src/components/smartcard_modal/smartcard_modal.test.tsx
@@ -750,7 +750,7 @@ test('Error handling', async () => {
   }
 });
 
-test('Card inserted backwards is handled with message', async () => {
+test('Backwards card handling', async () => {
   const { renderApp } = buildApp(apiMock);
   apiMock.expectGetCurrentElectionMetadata({ electionDefinition });
   apiMock.expectGetCastVoteRecords([]);
@@ -760,7 +760,7 @@ test('Card inserted backwards is handled with message', async () => {
   apiMock.setAuthStatus({
     status: 'logged_in',
     user: fakeSystemAdministratorUser(),
-    programmableCard: { status: 'error' },
+    programmableCard: { status: 'card_error' },
   });
   await screen.findByText('Card is Backwards');
 

--- a/apps/admin/frontend/src/components/smartcard_modal/smartcard_modal.tsx
+++ b/apps/admin/frontend/src/components/smartcard_modal/smartcard_modal.tsx
@@ -30,10 +30,11 @@ export function SmartcardModal(): JSX.Element | null {
   }, [cardStatus]);
 
   switch (cardStatus) {
-    case 'no_card': {
+    case 'no_card':
+    case 'unknown_error': {
       return null;
     }
-    case 'error': {
+    case 'card_error': {
       return (
         <Modal fullscreen content={<InvalidCardScreen reason="card_error" />} />
       );

--- a/apps/mark/backend/src/server.ts
+++ b/apps/mark/backend/src/server.ts
@@ -41,12 +41,7 @@ export function start({
           )
         : new MemoryCard({ baseUrl: 'http://localhost:3001' }),
     config: {
-      allowedUserRoles: [
-        'system_administrator',
-        'election_manager',
-        'poll_worker',
-        'cardless_voter',
-      ],
+      allowCardlessVoterSessions: true,
       allowElectionManagersToAccessMachinesConfiguredForOtherElections: true,
     },
     logger,

--- a/apps/scan/backend/src/server.ts
+++ b/apps/scan/backend/src/server.ts
@@ -48,13 +48,7 @@ export function start({
             })
           )
         : new MemoryCard({ baseUrl: 'http://localhost:3001' }),
-    config: {
-      allowedUserRoles: [
-        'system_administrator',
-        'election_manager',
-        'poll_worker',
-      ],
-    },
+    config: {},
     logger,
   });
 

--- a/libs/auth/jest.config.js
+++ b/libs/auth/jest.config.js
@@ -14,10 +14,10 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      statements: 51,
-      branches: 39,
-      functions: 60,
-      lines: 51,
+      statements: 79,
+      branches: 91,
+      functions: 74,
+      lines: 79,
     },
   },
 };

--- a/libs/auth/src/card.ts
+++ b/libs/auth/src/card.ts
@@ -3,12 +3,12 @@ import {
   ElectionManagerUser,
   PollWorkerUser,
   SystemAdministratorUser,
-  User,
+  UserWithCard,
 } from '@votingworks/types';
 
 interface CardStatusReady {
   status: 'ready';
-  user?: User;
+  user?: UserWithCard;
 }
 
 interface CardStatusNotReady {

--- a/libs/auth/src/card_reader.ts
+++ b/libs/auth/src/card_reader.ts
@@ -79,7 +79,7 @@ export class CardReader {
           );
         } else {
           this.updateReader({ status: 'no_card' });
-          reader.disconnect(() => undefined);
+          reader.disconnect(/* istanbul ignore next */ () => undefined);
         }
       });
 

--- a/libs/auth/src/certs.ts
+++ b/libs/auth/src/certs.ts
@@ -1,12 +1,7 @@
 import { Buffer } from 'buffer';
 import { z } from 'zod';
 import { assert, throwIllegalValue } from '@votingworks/basics';
-import {
-  ElectionManagerUser,
-  PollWorkerUser,
-  SystemAdministratorUser,
-  User,
-} from '@votingworks/types';
+import { UserWithCard } from '@votingworks/types';
 
 import { openssl } from './openssl';
 
@@ -104,7 +99,7 @@ export async function parseCert(cert: Buffer): Promise<CustomCertFields> {
 export async function parseUserDataFromCert(
   cert: Buffer,
   expectedJurisdiction: string
-): Promise<User> {
+): Promise<UserWithCard> {
   const { component, jurisdiction, cardType, electionHash } = await parseCert(
     cert
   );
@@ -135,7 +130,7 @@ export async function parseUserDataFromCert(
  * Constructs a VotingWorks card cert subject that can be passed to an openssl command
  */
 export function constructCardCertSubject(
-  user: SystemAdministratorUser | ElectionManagerUser | PollWorkerUser,
+  user: UserWithCard,
   jurisdiction: string
 ): string {
   const component: CustomCertFields['component'] = 'card';

--- a/libs/auth/src/dipped_smart_card_auth.test.ts
+++ b/libs/auth/src/dipped_smart_card_auth.test.ts
@@ -1,21 +1,888 @@
-import { fakeLogger } from '@votingworks/logging';
+import { err, ok } from '@votingworks/basics';
+import {
+  electionSample2Definition,
+  electionSampleDefinition,
+} from '@votingworks/fixtures';
+import {
+  fakeLogger,
+  LogDispositionStandardTypes,
+  LogEventId,
+  Logger,
+} from '@votingworks/logging';
+import {
+  fakeElectionManagerUser,
+  fakePollWorkerUser,
+  fakeSystemAdministratorUser,
+  mockOf,
+} from '@votingworks/test-utils';
+import {
+  DippedSmartCardAuth as DippedSmartCardAuthTypes,
+  UserWithCard,
+} from '@votingworks/types';
+import {
+  BooleanEnvironmentVariableName,
+  generatePin,
+  isFeatureFlagEnabled,
+} from '@votingworks/utils';
 
-import { buildMockCard } from '../test/utils';
+import { buildMockCard, MockCard, mockCardAssertComplete } from '../test/utils';
+import { Card, CardStatus } from './card';
 import { DippedSmartCardAuth } from './dipped_smart_card_auth';
+import {
+  DippedSmartCardAuthConfig,
+  DippedSmartCardAuthMachineState,
+} from './dipped_smart_card_auth_api';
+
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  generatePin: jest.fn(),
+  isFeatureFlagEnabled: jest.fn(),
+}));
+
+const pin = '123456';
+const wrongPin = '654321';
+
+let mockCard: MockCard;
+let mockLogger: Logger;
 
 beforeEach(() => {
-  jest.useFakeTimers();
+  mockOf(generatePin).mockImplementation(() => pin);
+  mockOf(isFeatureFlagEnabled).mockImplementation(() => false);
+
+  mockCard = buildMockCard();
+  mockLogger = fakeLogger();
 });
 
-test('DippedSmartCardAuth returns auth status', async () => {
-  const card = buildMockCard();
-  const auth = new DippedSmartCardAuth({
-    card,
-    config: {},
-    logger: fakeLogger(),
+afterEach(() => {
+  mockCardAssertComplete(mockCard);
+
+  // Remove all mock implementations
+  jest.resetAllMocks();
+});
+
+const { electionData, electionHash } = electionSampleDefinition;
+const otherElectionHash = electionSample2Definition.electionHash;
+const defaultConfig: DippedSmartCardAuthConfig = {};
+const machineState: DippedSmartCardAuthMachineState = { electionHash };
+const systemAdministratorUser = fakeSystemAdministratorUser();
+const electionManagerUser = fakeElectionManagerUser({ electionHash });
+const pollWorkerUser = fakePollWorkerUser({ electionHash });
+
+function mockCardStatus(cardStatus: CardStatus) {
+  mockCard.getCardStatus.expectRepeatedCallsWith().resolves(cardStatus);
+}
+
+async function logInAsSystemAdministrator(auth: DippedSmartCardAuth) {
+  mockCardStatus({ status: 'ready', user: systemAdministratorUser });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'checking_pin',
+    user: systemAdministratorUser,
   });
-  expect(await auth.getAuthStatus({ electionHash: undefined })).toEqual({
+  mockCard.checkPin.expectCallWith(pin).resolves({ response: 'correct' });
+  await auth.checkPin(machineState, { pin });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'remove_card',
+    user: systemAdministratorUser,
+  });
+  mockCardStatus({ status: 'no_card' });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'logged_in',
+    user: systemAdministratorUser,
+    programmableCard: { status: 'no_card' },
+  });
+  mockOf(mockLogger.log).mockClear();
+}
+
+async function logInAsElectionManager(auth: DippedSmartCardAuth) {
+  mockCardStatus({ status: 'ready', user: electionManagerUser });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'checking_pin',
+    user: electionManagerUser,
+  });
+  mockCard.checkPin.expectCallWith(pin).resolves({ response: 'correct' });
+  await auth.checkPin(machineState, { pin });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'remove_card',
+    user: electionManagerUser,
+  });
+  mockCardStatus({ status: 'no_card' });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'logged_in',
+    user: electionManagerUser,
+  });
+  mockOf(mockLogger.log).mockClear();
+}
+
+test('Card insertions and removals', async () => {
+  const auth = new DippedSmartCardAuth({
+    card: mockCard,
+    config: defaultConfig,
+    logger: mockLogger,
+  });
+
+  const testSequence: Array<{
+    cardStatus: CardStatus;
+    expectedAuthStatus: DippedSmartCardAuthTypes.AuthStatus;
+    expectedLog?: Parameters<Logger['log']>;
+  }> = [
+    {
+      cardStatus: { status: 'no_card' },
+      expectedAuthStatus: { status: 'logged_out', reason: 'machine_locked' },
+    },
+    {
+      cardStatus: { status: 'unknown_error' },
+      expectedAuthStatus: { status: 'logged_out', reason: 'machine_locked' },
+    },
+    {
+      cardStatus: { status: 'no_card' },
+      expectedAuthStatus: { status: 'logged_out', reason: 'machine_locked' },
+    },
+    {
+      cardStatus: { status: 'card_error' },
+      expectedAuthStatus: { status: 'logged_out', reason: 'card_error' },
+      expectedLog: [
+        LogEventId.AuthLogin,
+        'unknown',
+        {
+          disposition: LogDispositionStandardTypes.Failure,
+          message: 'User failed login.',
+          reason: 'card_error',
+        },
+      ],
+    },
+    {
+      cardStatus: { status: 'no_card' },
+      expectedAuthStatus: { status: 'logged_out', reason: 'machine_locked' },
+    },
+    {
+      cardStatus: { status: 'ready', user: undefined },
+      expectedAuthStatus: {
+        status: 'logged_out',
+        reason: 'invalid_user_on_card',
+      },
+      expectedLog: [
+        LogEventId.AuthLogin,
+        'unknown',
+        {
+          disposition: LogDispositionStandardTypes.Failure,
+          message: 'User failed login.',
+          reason: 'invalid_user_on_card',
+        },
+      ],
+    },
+    {
+      cardStatus: { status: 'no_card' },
+      expectedAuthStatus: { status: 'logged_out', reason: 'machine_locked' },
+    },
+    {
+      cardStatus: { status: 'ready', user: pollWorkerUser },
+      expectedAuthStatus: {
+        status: 'logged_out',
+        reason: 'user_role_not_allowed',
+        cardUserRole: 'poll_worker',
+      },
+      expectedLog: [
+        LogEventId.AuthLogin,
+        'poll_worker',
+        {
+          disposition: LogDispositionStandardTypes.Failure,
+          message: 'User failed login.',
+          reason: 'user_role_not_allowed',
+        },
+      ],
+    },
+    {
+      cardStatus: { status: 'no_card' },
+      expectedAuthStatus: { status: 'logged_out', reason: 'machine_locked' },
+    },
+    {
+      cardStatus: { status: 'ready', user: systemAdministratorUser },
+      expectedAuthStatus: {
+        status: 'checking_pin',
+        user: systemAdministratorUser,
+      },
+    },
+    {
+      cardStatus: { status: 'no_card' },
+      expectedAuthStatus: { status: 'logged_out', reason: 'machine_locked' },
+      expectedLog: [
+        LogEventId.AuthPinEntry,
+        'system_administrator',
+        {
+          disposition: LogDispositionStandardTypes.Failure,
+          message: 'User canceled PIN entry.',
+        },
+      ],
+    },
+  ];
+
+  let logIndex = 1;
+  for (const { cardStatus, expectedAuthStatus, expectedLog } of testSequence) {
+    mockCardStatus(cardStatus);
+    expect(await auth.getAuthStatus(machineState)).toEqual(expectedAuthStatus);
+    if (expectedLog) {
+      expect(mockLogger.log).toHaveBeenNthCalledWith(logIndex, ...expectedLog);
+      logIndex += 1;
+    }
+  }
+  expect(mockLogger.log).toHaveBeenCalledTimes(4);
+});
+
+test.each<{
+  description: string;
+  user: UserWithCard;
+  expectedLoggedInAuthStatus: DippedSmartCardAuthTypes.LoggedIn;
+}>([
+  {
+    description: 'system administrator',
+    user: systemAdministratorUser,
+    expectedLoggedInAuthStatus: {
+      status: 'logged_in',
+      user: systemAdministratorUser,
+      programmableCard: { status: 'no_card' },
+    },
+  },
+  {
+    description: 'election manager',
+    user: electionManagerUser,
+    expectedLoggedInAuthStatus: {
+      status: 'logged_in',
+      user: electionManagerUser,
+    },
+  },
+])(
+  'Login and logout - $description',
+  async ({ user, expectedLoggedInAuthStatus }) => {
+    const auth = new DippedSmartCardAuth({
+      card: mockCard,
+      config: defaultConfig,
+      logger: mockLogger,
+    });
+
+    mockCardStatus({ status: 'ready', user });
+    expect(await auth.getAuthStatus(machineState)).toEqual({
+      status: 'checking_pin',
+      user,
+    });
+
+    mockCard.checkPin
+      .expectCallWith(wrongPin)
+      .resolves({ response: 'incorrect', numRemainingAttempts: Infinity });
+    await auth.checkPin(machineState, { pin: wrongPin });
+    expect(await auth.getAuthStatus(machineState)).toEqual({
+      status: 'checking_pin',
+      user,
+      wrongPinEnteredAt: expect.any(Date),
+    });
+    expect(mockLogger.log).toHaveBeenCalledTimes(1);
+    expect(mockLogger.log).toHaveBeenNthCalledWith(
+      1,
+      LogEventId.AuthPinEntry,
+      user.role,
+      {
+        disposition: LogDispositionStandardTypes.Failure,
+        message: 'User entered incorrect PIN.',
+      }
+    );
+
+    mockCard.checkPin.expectCallWith(pin).resolves({ response: 'correct' });
+    await auth.checkPin(machineState, { pin });
+    expect(await auth.getAuthStatus(machineState)).toEqual({
+      status: 'remove_card',
+      user,
+    });
+    expect(mockLogger.log).toHaveBeenCalledTimes(2);
+    expect(mockLogger.log).toHaveBeenNthCalledWith(
+      2,
+      LogEventId.AuthPinEntry,
+      user.role,
+      {
+        disposition: LogDispositionStandardTypes.Success,
+        message: 'User entered correct PIN.',
+      }
+    );
+
+    mockCardStatus({ status: 'no_card' });
+    expect(await auth.getAuthStatus(machineState)).toEqual(
+      expectedLoggedInAuthStatus
+    );
+    expect(mockLogger.log).toHaveBeenCalledTimes(3);
+    expect(mockLogger.log).toHaveBeenNthCalledWith(
+      3,
+      LogEventId.AuthLogin,
+      user.role,
+      {
+        disposition: LogDispositionStandardTypes.Success,
+        message: 'User logged in.',
+      }
+    );
+
+    await auth.logOut(machineState);
+    expect(await auth.getAuthStatus(machineState)).toEqual({
+      status: 'logged_out',
+      reason: 'machine_locked',
+    });
+    expect(mockLogger.log).toHaveBeenCalledTimes(4);
+    expect(mockLogger.log).toHaveBeenNthCalledWith(
+      4,
+      LogEventId.AuthLogout,
+      user.role,
+      {
+        disposition: LogDispositionStandardTypes.Success,
+        message: 'User logged out.',
+      }
+    );
+  }
+);
+
+test.each<{
+  description: string;
+  config: DippedSmartCardAuthConfig;
+  machineElectionHash?: string;
+  expectedAuthStatus: DippedSmartCardAuthTypes.AuthStatus;
+  expectedLog?: Parameters<Logger['log']>;
+}>([
+  {
+    description: 'unconfigured machine',
+    config: defaultConfig,
+    machineElectionHash: undefined,
+    expectedAuthStatus: {
+      status: 'logged_out',
+      reason: 'machine_not_configured',
+      cardUserRole: 'election_manager',
+    },
+    expectedLog: [
+      LogEventId.AuthLogin,
+      'election_manager',
+      {
+        disposition: LogDispositionStandardTypes.Failure,
+        message: 'User failed login.',
+        reason: 'machine_not_configured',
+      },
+    ],
+  },
+  {
+    description: 'mismatched election hash',
+    config: defaultConfig,
+    machineElectionHash: otherElectionHash,
+    expectedAuthStatus: {
+      status: 'logged_out',
+      reason: 'election_manager_wrong_election',
+      cardUserRole: 'election_manager',
+    },
+    expectedLog: [
+      LogEventId.AuthLogin,
+      'election_manager',
+      {
+        disposition: LogDispositionStandardTypes.Failure,
+        message: 'User failed login.',
+        reason: 'election_manager_wrong_election',
+      },
+    ],
+  },
+  {
+    description:
+      'unconfigured machine, allowElectionManagersToAccessUnconfiguredMachines = true',
+    config: {
+      ...defaultConfig,
+      allowElectionManagersToAccessUnconfiguredMachines: true,
+    },
+    machineElectionHash: undefined,
+    expectedAuthStatus: {
+      status: 'checking_pin',
+      user: electionManagerUser,
+    },
+  },
+])(
+  'Election checks - $description',
+  async ({ config, machineElectionHash, expectedAuthStatus, expectedLog }) => {
+    const auth = new DippedSmartCardAuth({
+      card: mockCard,
+      config,
+      logger: mockLogger,
+    });
+
+    mockCardStatus({ status: 'ready', user: electionManagerUser });
+    expect(
+      await auth.getAuthStatus({ electionHash: machineElectionHash })
+    ).toEqual(expectedAuthStatus);
+    if (expectedLog) {
+      expect(mockLogger.log).toHaveBeenCalledTimes(1);
+      expect(mockLogger.log).toHaveBeenNthCalledWith(1, ...expectedLog);
+    }
+  }
+);
+
+test.each<{
+  description: string;
+  input: Parameters<DippedSmartCardAuth['programCard']>[1];
+  expectedCardProgramInput: Parameters<Card['program']>[0];
+  expectedProgramResult: Awaited<
+    ReturnType<DippedSmartCardAuth['programCard']>
+  >;
+}>([
+  {
+    description: 'system administrator cards',
+    input: { userRole: 'system_administrator' },
+    expectedCardProgramInput: {
+      user: { role: 'system_administrator' },
+      pin,
+    },
+    expectedProgramResult: ok({ pin }),
+  },
+  {
+    description: 'election manager cards',
+    input: { userRole: 'election_manager', electionData },
+    expectedCardProgramInput: {
+      user: { role: 'election_manager', electionHash },
+      pin,
+      electionData,
+    },
+    expectedProgramResult: ok({ pin }),
+  },
+  {
+    description: 'poll worker cards',
+    input: { userRole: 'poll_worker' },
+    expectedCardProgramInput: {
+      user: { role: 'poll_worker', electionHash },
+    },
+    expectedProgramResult: ok({}),
+  },
+])(
+  'Card programming and unprogramming - $description',
+  async ({ input, expectedCardProgramInput, expectedProgramResult }) => {
+    const auth = new DippedSmartCardAuth({
+      card: mockCard,
+      config: defaultConfig,
+      logger: mockLogger,
+    });
+
+    await logInAsSystemAdministrator(auth);
+
+    mockCardStatus({ status: 'ready', user: undefined });
+    expect(await auth.getAuthStatus(machineState)).toEqual({
+      status: 'logged_in',
+      user: systemAdministratorUser,
+      programmableCard: { status: 'ready', programmedUser: undefined },
+    });
+
+    mockCard.program.expectCallWith(expectedCardProgramInput).resolves();
+    expect(await auth.programCard(machineState, input)).toEqual(
+      expectedProgramResult
+    );
+    expect(mockLogger.log).toHaveBeenCalledTimes(2);
+    expect(mockLogger.log).toHaveBeenNthCalledWith(
+      1,
+      LogEventId.SmartCardProgramInit,
+      'system_administrator',
+      {
+        message: 'Programming smart card...',
+        programmedUserRole: input.userRole,
+      }
+    );
+    expect(mockLogger.log).toHaveBeenNthCalledWith(
+      2,
+      LogEventId.SmartCardProgramComplete,
+      'system_administrator',
+      {
+        disposition: LogDispositionStandardTypes.Success,
+        message: 'Successfully programmed smart card.',
+        programmedUserRole: input.userRole,
+      }
+    );
+
+    const programmedUser = expectedCardProgramInput.user;
+    mockCardStatus({ status: 'ready', user: programmedUser });
+    expect(await auth.getAuthStatus(machineState)).toEqual({
+      status: 'logged_in',
+      user: systemAdministratorUser,
+      programmableCard: { status: 'ready', programmedUser },
+    });
+
+    mockCard.unprogram.expectCallWith().resolves();
+    expect(await auth.unprogramCard(machineState)).toEqual(ok());
+    expect(mockLogger.log).toHaveBeenCalledTimes(4);
+    expect(mockLogger.log).toHaveBeenNthCalledWith(
+      3,
+      LogEventId.SmartCardUnprogramInit,
+      'system_administrator',
+      {
+        message: 'Unprogramming smart card...',
+        programmedUserRole: input.userRole,
+      }
+    );
+    expect(mockLogger.log).toHaveBeenNthCalledWith(
+      4,
+      LogEventId.SmartCardUnprogramComplete,
+      'system_administrator',
+      {
+        disposition: LogDispositionStandardTypes.Success,
+        message: 'Successfully unprogrammed smart card.',
+        previousProgrammedUserRole: input.userRole,
+      }
+    );
+
+    mockCardStatus({ status: 'ready', user: undefined });
+    expect(await auth.getAuthStatus(machineState)).toEqual({
+      status: 'logged_in',
+      user: systemAdministratorUser,
+      programmableCard: { status: 'ready', programmedUser: undefined },
+    });
+  }
+);
+
+test('Checking PIN error handling', async () => {
+  const auth = new DippedSmartCardAuth({
+    card: mockCard,
+    config: defaultConfig,
+    logger: mockLogger,
+  });
+
+  mockCardStatus({ status: 'ready', user: electionManagerUser });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'checking_pin',
+    user: electionManagerUser,
+  });
+
+  mockCard.checkPin.expectCallWith(pin).throws(new Error('Whoa!'));
+  await auth.checkPin(machineState, { pin });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'checking_pin',
+    user: electionManagerUser,
+    error: true,
+  });
+  expect(mockLogger.log).toHaveBeenCalledTimes(1);
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    1,
+    LogEventId.AuthPinEntry,
+    'election_manager',
+    {
+      disposition: LogDispositionStandardTypes.Failure,
+      message: 'Error checking PIN: Whoa!',
+    }
+  );
+
+  // Check that "successfully" entering an incorrect PIN clears the error state
+  mockCard.checkPin
+    .expectCallWith(wrongPin)
+    .resolves({ response: 'incorrect', numRemainingAttempts: Infinity });
+  await auth.checkPin(machineState, { pin: wrongPin });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'checking_pin',
+    user: electionManagerUser,
+    wrongPinEnteredAt: expect.any(Date),
+  });
+  expect(mockLogger.log).toHaveBeenCalledTimes(2);
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    2,
+    LogEventId.AuthPinEntry,
+    'election_manager',
+    {
+      disposition: LogDispositionStandardTypes.Failure,
+      message: 'User entered incorrect PIN.',
+    }
+  );
+
+  // Check that wrong PIN entry state is maintained after an error
+  mockCard.checkPin.expectCallWith(pin).throws(new Error('Whoa!'));
+  await auth.checkPin(machineState, { pin });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'checking_pin',
+    user: electionManagerUser,
+    error: true,
+    wrongPinEnteredAt: expect.any(Date),
+  });
+  expect(mockLogger.log).toHaveBeenCalledTimes(3);
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    3,
+    LogEventId.AuthPinEntry,
+    'election_manager',
+    {
+      disposition: LogDispositionStandardTypes.Failure,
+      message: 'Error checking PIN: Whoa!',
+    }
+  );
+
+  mockCard.checkPin.expectCallWith(pin).resolves({ response: 'correct' });
+  await auth.checkPin(machineState, { pin });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'remove_card',
+    user: electionManagerUser,
+  });
+});
+
+test(
+  'Checking PIN when not in PIN checking state, ' +
+    'e.g. because someone removed their card right after entering their PIN',
+  async () => {
+    const auth = new DippedSmartCardAuth({
+      card: mockCard,
+      config: defaultConfig,
+      logger: mockLogger,
+    });
+
+    mockCardStatus({ status: 'no_card' });
+    mockCard.checkPin
+      .expectCallWith(pin)
+      .throws(new Error('Whoa! Card no longer in reader'));
+    await auth.checkPin(machineState, { pin });
+    expect(await auth.getAuthStatus(machineState)).toEqual({
+      status: 'logged_out',
+      reason: 'machine_locked',
+    });
+    expect(mockLogger.log).toHaveBeenCalledTimes(1);
+    expect(mockLogger.log).toHaveBeenNthCalledWith(
+      1,
+      LogEventId.AuthPinEntry,
+      'unknown',
+      {
+        disposition: LogDispositionStandardTypes.Failure,
+        message: 'Error checking PIN: Whoa! Card no longer in reader',
+      }
+    );
+  }
+);
+
+test('Card programming error handling', async () => {
+  const auth = new DippedSmartCardAuth({
+    card: mockCard,
+    config: defaultConfig,
+    logger: mockLogger,
+  });
+
+  await logInAsSystemAdministrator(auth);
+
+  mockCardStatus({ status: 'card_error' });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'logged_in',
+    user: systemAdministratorUser,
+    programmableCard: { status: 'card_error' },
+  });
+
+  mockCardStatus({ status: 'unknown_error' });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'logged_in',
+    user: systemAdministratorUser,
+    programmableCard: { status: 'unknown_error' },
+  });
+
+  mockCardStatus({ status: 'ready', user: undefined });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'logged_in',
+    user: systemAdministratorUser,
+    programmableCard: { status: 'ready', programmedUser: undefined },
+  });
+
+  mockCard.program
+    .expectCallWith({ user: { role: 'poll_worker', electionHash } })
+    .throws(new Error('Whoa!'));
+  expect(
+    await auth.programCard(machineState, { userRole: 'poll_worker' })
+  ).toEqual(err(new Error('Error programming card')));
+  expect(mockLogger.log).toHaveBeenCalledTimes(2);
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    1,
+    LogEventId.SmartCardProgramInit,
+    'system_administrator',
+    {
+      message: 'Programming smart card...',
+      programmedUserRole: 'poll_worker',
+    }
+  );
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    2,
+    LogEventId.SmartCardProgramComplete,
+    'system_administrator',
+    {
+      disposition: LogDispositionStandardTypes.Failure,
+      message: 'Error programming smart card: Whoa!',
+      programmedUserRole: 'poll_worker',
+    }
+  );
+});
+
+test('Card unprogramming error handling', async () => {
+  const auth = new DippedSmartCardAuth({
+    card: mockCard,
+    config: defaultConfig,
+    logger: mockLogger,
+  });
+
+  await logInAsSystemAdministrator(auth);
+
+  mockCardStatus({ status: 'ready', user: pollWorkerUser });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'logged_in',
+    user: systemAdministratorUser,
+    programmableCard: { status: 'ready', programmedUser: pollWorkerUser },
+  });
+
+  mockCard.unprogram.expectCallWith().throws(new Error('Whoa!'));
+  expect(await auth.unprogramCard(machineState)).toEqual(
+    err(new Error('Error unprogramming card'))
+  );
+  expect(mockLogger.log).toHaveBeenCalledTimes(2);
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    1,
+    LogEventId.SmartCardUnprogramInit,
+    'system_administrator',
+    {
+      message: 'Unprogramming smart card...',
+      programmedUserRole: 'poll_worker',
+    }
+  );
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    2,
+    LogEventId.SmartCardUnprogramComplete,
+    'system_administrator',
+    {
+      disposition: LogDispositionStandardTypes.Failure,
+      message: 'Error unprogramming smart card: Whoa!',
+      programmedUserRole: 'poll_worker',
+    }
+  );
+});
+
+test('Attempting card programming and unprogramming when logged out', async () => {
+  const auth = new DippedSmartCardAuth({
+    card: mockCard,
+    config: defaultConfig,
+    logger: mockLogger,
+  });
+
+  mockCardStatus({ status: 'no_card' });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
     status: 'logged_out',
     reason: 'machine_locked',
+  });
+
+  expect(
+    await auth.programCard(machineState, { userRole: 'poll_worker' })
+  ).toEqual(err(new Error('Error programming card')));
+  expect(mockLogger.log).toHaveBeenCalledTimes(2);
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    1,
+    LogEventId.SmartCardProgramInit,
+    'system_administrator',
+    {
+      message: 'Programming smart card...',
+      programmedUserRole: 'poll_worker',
+    }
+  );
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    2,
+    LogEventId.SmartCardProgramComplete,
+    'system_administrator',
+    {
+      disposition: LogDispositionStandardTypes.Failure,
+      message: 'Error programming smart card: User is not logged in',
+      programmedUserRole: 'poll_worker',
+    }
+  );
+
+  expect(await auth.unprogramCard(machineState)).toEqual(
+    err(new Error('Error unprogramming card'))
+  );
+  expect(mockLogger.log).toHaveBeenCalledTimes(4);
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    3,
+    LogEventId.SmartCardUnprogramInit,
+    'system_administrator',
+    {
+      message: 'Unprogramming smart card...',
+      programmedUserRole: 'unprogrammed',
+    }
+  );
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    4,
+    LogEventId.SmartCardUnprogramComplete,
+    'system_administrator',
+    {
+      disposition: LogDispositionStandardTypes.Failure,
+      message: 'Error unprogramming smart card: User is not logged in',
+      programmedUserRole: 'unprogrammed',
+    }
+  );
+});
+
+test('Attempting card programming and unprogramming when not a system administrator', async () => {
+  const auth = new DippedSmartCardAuth({
+    card: mockCard,
+    config: defaultConfig,
+    logger: mockLogger,
+  });
+
+  await logInAsElectionManager(auth);
+
+  expect(
+    await auth.programCard(machineState, { userRole: 'poll_worker' })
+  ).toEqual(err(new Error('Error programming card')));
+  expect(mockLogger.log).toHaveBeenCalledTimes(2);
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    1,
+    LogEventId.SmartCardProgramInit,
+    'system_administrator',
+    {
+      message: 'Programming smart card...',
+      programmedUserRole: 'poll_worker',
+    }
+  );
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    2,
+    LogEventId.SmartCardProgramComplete,
+    'system_administrator',
+    {
+      disposition: LogDispositionStandardTypes.Failure,
+      message:
+        'Error programming smart card: User is not a system administrator',
+      programmedUserRole: 'poll_worker',
+    }
+  );
+
+  expect(await auth.unprogramCard(machineState)).toEqual(
+    err(new Error('Error unprogramming card'))
+  );
+  expect(mockLogger.log).toHaveBeenCalledTimes(4);
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    3,
+    LogEventId.SmartCardUnprogramInit,
+    'system_administrator',
+    {
+      message: 'Unprogramming smart card...',
+      programmedUserRole: 'unprogrammed',
+    }
+  );
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    4,
+    LogEventId.SmartCardUnprogramComplete,
+    'system_administrator',
+    {
+      disposition: LogDispositionStandardTypes.Failure,
+      message:
+        'Error unprogramming smart card: User is not a system administrator',
+      programmedUserRole: 'unprogrammed',
+    }
+  );
+});
+
+test('SKIP_PIN_ENTRY feature flag', async () => {
+  mockOf(isFeatureFlagEnabled).mockImplementation(
+    (flag) => flag === BooleanEnvironmentVariableName.SKIP_PIN_ENTRY
+  );
+  const auth = new DippedSmartCardAuth({
+    card: mockCard,
+    config: defaultConfig,
+    logger: mockLogger,
+  });
+
+  mockCardStatus({ status: 'ready', user: electionManagerUser });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'remove_card',
+    user: electionManagerUser,
+  });
+  mockCardStatus({ status: 'no_card' });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'logged_in',
+    user: electionManagerUser,
   });
 });

--- a/libs/auth/src/dipped_smart_card_auth.ts
+++ b/libs/auth/src/dipped_smart_card_auth.ts
@@ -227,7 +227,7 @@ export class DippedSmartCardAuth implements DippedSmartCardAuthApi {
         LogEventId.SmartCardProgramComplete,
         'system_administrator',
         {
-          disposition: 'failure',
+          disposition: LogDispositionStandardTypes.Failure,
           message: `Error programming smart card: ${extractErrorMessage(
             error
           )}.`,
@@ -240,7 +240,7 @@ export class DippedSmartCardAuth implements DippedSmartCardAuthApi {
       LogEventId.SmartCardProgramComplete,
       'system_administrator',
       {
-        disposition: 'success',
+        disposition: LogDispositionStandardTypes.Success,
         message: 'Successfully programmed smart card.',
         programmedUserRole: input.userRole,
       }
@@ -271,7 +271,7 @@ export class DippedSmartCardAuth implements DippedSmartCardAuthApi {
         LogEventId.SmartCardUnprogramComplete,
         'system_administrator',
         {
-          disposition: 'failure',
+          disposition: LogDispositionStandardTypes.Failure,
           message: `Error unprogramming smart card: ${extractErrorMessage(
             error
           )}.`,
@@ -284,7 +284,7 @@ export class DippedSmartCardAuth implements DippedSmartCardAuthApi {
       LogEventId.SmartCardUnprogramComplete,
       'system_administrator',
       {
-        disposition: 'success',
+        disposition: LogDispositionStandardTypes.Success,
         message: 'Successfully unprogrammed smart card.',
         previousProgrammedUserRole: programmedUserRole,
       }

--- a/libs/auth/src/dipped_smart_card_auth.ts
+++ b/libs/auth/src/dipped_smart_card_auth.ts
@@ -39,16 +39,15 @@ function cardStatusToProgrammableCard(
   cardStatus: CardStatus
 ): DippedSmartCardAuthTypes.ProgrammableCard {
   switch (cardStatus.status) {
-    case 'no_card': {
-      return { status: 'no_card' };
-    }
     case 'card_error':
+    case 'no_card':
     case 'unknown_error': {
-      return { status: 'error' };
+      return { status: cardStatus.status };
     }
     case 'ready': {
       return { status: 'ready', programmedUser: cardStatus.user };
     }
+    /* istanbul ignore next: Compile-time check for completeness */
     default: {
       throwIllegalValue(cardStatus, 'status');
     }

--- a/libs/auth/src/dipped_smart_card_auth.ts
+++ b/libs/auth/src/dipped_smart_card_auth.ts
@@ -1,6 +1,7 @@
 import {
   assert,
   err,
+  extractErrorMessage,
   ok,
   Result,
   throwIllegalValue,
@@ -188,10 +189,9 @@ export class DippedSmartCardAuth implements DippedSmartCardAuthApi {
     } catch (error) {
       const userRole =
         'user' in this.authStatus ? this.authStatus.user.role : 'unknown';
-      const errorMessage = error instanceof Error ? error.message : error;
       await this.logger.log(LogEventId.AuthPinEntry, userRole, {
         disposition: LogDispositionStandardTypes.Failure,
-        message: `Error checking PIN: ${errorMessage}.`,
+        message: `Error checking PIN: ${extractErrorMessage(error)}.`,
       });
       checkPinResponse = { response: 'error' };
     }
@@ -216,7 +216,7 @@ export class DippedSmartCardAuth implements DippedSmartCardAuthApi {
       LogEventId.SmartCardProgramInit,
       'system_administrator',
       {
-        message: `Programming ${input.userRole} smart card...`,
+        message: 'Programming smart card...',
         programmedUserRole: input.userRole,
       }
     );
@@ -224,13 +224,14 @@ export class DippedSmartCardAuth implements DippedSmartCardAuthApi {
     try {
       pin = await this.programCardBase(machineState, input);
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : error;
       await this.logger.log(
         LogEventId.SmartCardProgramComplete,
         'system_administrator',
         {
           disposition: 'failure',
-          message: `Error programming ${input.userRole} smart card: ${errorMessage}.`,
+          message: `Error programming smart card: ${extractErrorMessage(
+            error
+          )}.`,
           programmedUserRole: input.userRole,
         }
       );
@@ -241,7 +242,7 @@ export class DippedSmartCardAuth implements DippedSmartCardAuthApi {
       'system_administrator',
       {
         disposition: 'success',
-        message: `Successfully programmed ${input.userRole} smart card.`,
+        message: 'Successfully programmed smart card.',
         programmedUserRole: input.userRole,
       }
     );
@@ -260,20 +261,21 @@ export class DippedSmartCardAuth implements DippedSmartCardAuthApi {
       LogEventId.SmartCardUnprogramInit,
       'system_administrator',
       {
-        message: `Unprogramming ${programmedUserRole} smart card...`,
+        message: 'Unprogramming smart card...',
         programmedUserRole,
       }
     );
     try {
       await this.unprogramCardBase(machineState);
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : error;
       await this.logger.log(
         LogEventId.SmartCardUnprogramComplete,
         'system_administrator',
         {
           disposition: 'failure',
-          message: `Error unprogramming ${programmedUserRole} smart card: ${errorMessage}.`,
+          message: `Error unprogramming smart card: ${extractErrorMessage(
+            error
+          )}.`,
           programmedUserRole,
         }
       );
@@ -284,7 +286,7 @@ export class DippedSmartCardAuth implements DippedSmartCardAuthApi {
       'system_administrator',
       {
         disposition: 'success',
-        message: `Successfully unprogrammed ${programmedUserRole} smart card.`,
+        message: 'Successfully unprogrammed smart card.',
         previousProgrammedUserRole: programmedUserRole,
       }
     );

--- a/libs/auth/src/dipped_smart_card_auth.ts
+++ b/libs/auth/src/dipped_smart_card_auth.ts
@@ -13,7 +13,7 @@ import {
 } from '@votingworks/logging';
 import {
   DippedSmartCardAuth as DippedSmartCardAuthTypes,
-  User,
+  UserWithCard,
 } from '@votingworks/types';
 import {
   BooleanEnvironmentVariableName,
@@ -512,7 +512,7 @@ export class DippedSmartCardAuth implements DippedSmartCardAuthApi {
 
   private validateCardUser(
     machineState: DippedSmartCardAuthMachineState,
-    user?: User
+    user?: UserWithCard
   ): Result<void, DippedSmartCardAuthTypes.LoggedOut['reason']> {
     if (!user) {
       return err('invalid_user_on_card');

--- a/libs/auth/src/inserted_smart_card_auth.test.ts
+++ b/libs/auth/src/inserted_smart_card_auth.test.ts
@@ -1,20 +1,928 @@
-import { fakeLogger } from '@votingworks/logging';
+import { Buffer } from 'buffer';
+import { z } from 'zod';
+import { err, ok } from '@votingworks/basics';
+import {
+  electionSample2Definition,
+  electionSampleDefinition,
+} from '@votingworks/fixtures';
+import {
+  fakeLogger,
+  LogDispositionStandardTypes,
+  LogEventId,
+  Logger,
+} from '@votingworks/logging';
+import {
+  fakeCardlessVoterUser,
+  fakeElectionManagerUser,
+  fakePollWorkerUser,
+  fakeSystemAdministratorUser,
+  mockOf,
+} from '@votingworks/test-utils';
+import {
+  ElectionSchema,
+  InsertedSmartCardAuth as InsertedSmartCardAuthTypes,
+  UserWithCard,
+} from '@votingworks/types';
+import {
+  BooleanEnvironmentVariableName,
+  generatePin,
+  isFeatureFlagEnabled,
+} from '@votingworks/utils';
 
-import { buildMockCard } from '../test/utils';
+import { buildMockCard, MockCard, mockCardAssertComplete } from '../test/utils';
+import { CardStatus } from './card';
 import { InsertedSmartCardAuth } from './inserted_smart_card_auth';
+import {
+  InsertedSmartCardAuthConfig,
+  InsertedSmartCardAuthMachineState,
+} from './inserted_smart_card_auth_api';
+
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  generatePin: jest.fn(),
+  isFeatureFlagEnabled: jest.fn(),
+}));
+
+const pin = '123456';
+const wrongPin = '654321';
+
+let mockCard: MockCard;
+let mockLogger: Logger;
 
 beforeEach(() => {
-  jest.useFakeTimers();
+  mockOf(generatePin).mockImplementation(() => pin);
+  mockOf(isFeatureFlagEnabled).mockImplementation(() => false);
+
+  mockCard = buildMockCard();
+  mockLogger = fakeLogger();
 });
 
-test('InsertedSmartCardAuth returns auth status', async () => {
-  const auth = new InsertedSmartCardAuth({
-    card: buildMockCard(),
-    config: { allowedUserRoles: [] },
-    logger: fakeLogger(),
+afterEach(() => {
+  mockCardAssertComplete(mockCard);
+
+  // Remove all mock implementations
+  jest.resetAllMocks();
+});
+
+const { election, electionData, electionHash } = electionSampleDefinition;
+const otherElectionHash = electionSample2Definition.electionHash;
+const defaultConfig: InsertedSmartCardAuthConfig = {};
+const machineState: InsertedSmartCardAuthMachineState = { electionHash };
+const systemAdministratorUser = fakeSystemAdministratorUser();
+const electionManagerUser = fakeElectionManagerUser({ electionHash });
+const pollWorkerUser = fakePollWorkerUser({ electionHash });
+const cardlessVoterUser = fakeCardlessVoterUser();
+
+function mockCardStatus(cardStatus: CardStatus) {
+  mockCard.getCardStatus.expectRepeatedCallsWith().resolves(cardStatus);
+}
+
+async function logInAsElectionManager(auth: InsertedSmartCardAuth) {
+  mockCardStatus({ status: 'ready', user: electionManagerUser });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'checking_pin',
+    user: electionManagerUser,
   });
-  expect(await auth.getAuthStatus({ electionHash: undefined })).toEqual({
+  mockCard.checkPin.expectCallWith(pin).resolves({ response: 'correct' });
+  await auth.checkPin(machineState, { pin });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'logged_in',
+    user: electionManagerUser,
+  });
+  mockOf(mockLogger.log).mockClear();
+}
+
+async function logInAsPollWorker(auth: InsertedSmartCardAuth) {
+  mockCardStatus({ status: 'ready', user: pollWorkerUser });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'logged_in',
+    user: pollWorkerUser,
+  });
+  mockOf(mockLogger.log).mockClear();
+}
+
+test('Card insertions and removals', async () => {
+  const auth = new InsertedSmartCardAuth({
+    card: mockCard,
+    config: defaultConfig,
+    logger: mockLogger,
+  });
+
+  const testSequence: Array<{
+    cardStatus: CardStatus;
+    expectedAuthStatus: InsertedSmartCardAuthTypes.AuthStatus;
+    expectedLog?: Parameters<Logger['log']>;
+  }> = [
+    {
+      cardStatus: { status: 'no_card' },
+      expectedAuthStatus: { status: 'logged_out', reason: 'no_card' },
+    },
+    {
+      cardStatus: { status: 'unknown_error' },
+      expectedAuthStatus: { status: 'logged_out', reason: 'no_card' },
+    },
+    {
+      cardStatus: { status: 'no_card' },
+      expectedAuthStatus: { status: 'logged_out', reason: 'no_card' },
+    },
+    {
+      cardStatus: { status: 'card_error' },
+      expectedAuthStatus: { status: 'logged_out', reason: 'card_error' },
+      expectedLog: [
+        LogEventId.AuthLogin,
+        'unknown',
+        {
+          disposition: LogDispositionStandardTypes.Failure,
+          message: 'User failed login.',
+          reason: 'card_error',
+        },
+      ],
+    },
+    {
+      cardStatus: { status: 'no_card' },
+      expectedAuthStatus: { status: 'logged_out', reason: 'no_card' },
+    },
+    {
+      cardStatus: { status: 'ready', user: undefined },
+      expectedAuthStatus: {
+        status: 'logged_out',
+        reason: 'invalid_user_on_card',
+      },
+      expectedLog: [
+        LogEventId.AuthLogin,
+        'unknown',
+        {
+          disposition: LogDispositionStandardTypes.Failure,
+          message: 'User failed login.',
+          reason: 'invalid_user_on_card',
+        },
+      ],
+    },
+    {
+      cardStatus: { status: 'no_card' },
+      expectedAuthStatus: { status: 'logged_out', reason: 'no_card' },
+    },
+    {
+      cardStatus: { status: 'ready', user: systemAdministratorUser },
+      expectedAuthStatus: {
+        status: 'checking_pin',
+        user: systemAdministratorUser,
+      },
+    },
+    {
+      cardStatus: { status: 'no_card' },
+      expectedAuthStatus: { status: 'logged_out', reason: 'no_card' },
+      expectedLog: [
+        LogEventId.AuthPinEntry,
+        'system_administrator',
+        {
+          disposition: LogDispositionStandardTypes.Failure,
+          message: 'User canceled PIN entry.',
+        },
+      ],
+    },
+  ];
+
+  let logIndex = 1;
+  for (const { cardStatus, expectedAuthStatus, expectedLog } of testSequence) {
+    mockCardStatus(cardStatus);
+    expect(await auth.getAuthStatus(machineState)).toEqual(expectedAuthStatus);
+    if (expectedLog) {
+      expect(mockLogger.log).toHaveBeenNthCalledWith(logIndex, ...expectedLog);
+      logIndex += 1;
+    }
+  }
+  expect(mockLogger.log).toHaveBeenCalledTimes(3);
+});
+
+test.each<{
+  description: string;
+  user: UserWithCard;
+}>([
+  {
+    description: 'system administrator',
+    user: systemAdministratorUser,
+  },
+  {
+    description: 'election manager',
+    user: electionManagerUser,
+  },
+])('Login and logout for users with PINs - $description', async ({ user }) => {
+  const auth = new InsertedSmartCardAuth({
+    card: mockCard,
+    config: defaultConfig,
+    logger: mockLogger,
+  });
+
+  mockCardStatus({ status: 'ready', user });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'checking_pin',
+    user,
+  });
+
+  mockCard.checkPin
+    .expectCallWith(wrongPin)
+    .resolves({ response: 'incorrect', numRemainingAttempts: Infinity });
+  await auth.checkPin(machineState, { pin: wrongPin });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'checking_pin',
+    user,
+    wrongPinEnteredAt: expect.any(Date),
+  });
+  expect(mockLogger.log).toHaveBeenCalledTimes(1);
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    1,
+    LogEventId.AuthPinEntry,
+    user.role,
+    {
+      disposition: LogDispositionStandardTypes.Failure,
+      message: 'User entered incorrect PIN.',
+    }
+  );
+
+  mockCard.checkPin.expectCallWith(pin).resolves({ response: 'correct' });
+  await auth.checkPin(machineState, { pin });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'logged_in',
+    user,
+  });
+  expect(mockLogger.log).toHaveBeenCalledTimes(3);
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    2,
+    LogEventId.AuthPinEntry,
+    user.role,
+    {
+      disposition: LogDispositionStandardTypes.Success,
+      message: 'User entered correct PIN.',
+    }
+  );
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    3,
+    LogEventId.AuthLogin,
+    user.role,
+    {
+      disposition: LogDispositionStandardTypes.Success,
+      message: 'User logged in.',
+    }
+  );
+
+  mockCardStatus({ status: 'no_card' });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
     status: 'logged_out',
     reason: 'no_card',
+  });
+  expect(mockLogger.log).toHaveBeenCalledTimes(4);
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    4,
+    LogEventId.AuthLogout,
+    user.role,
+    {
+      disposition: LogDispositionStandardTypes.Success,
+      message: 'User logged out.',
+    }
+  );
+});
+
+test('Login and logout for users without PINs', async () => {
+  const auth = new InsertedSmartCardAuth({
+    card: mockCard,
+    config: defaultConfig,
+    logger: mockLogger,
+  });
+
+  mockCardStatus({ status: 'ready', user: pollWorkerUser });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'logged_in',
+    user: pollWorkerUser,
+  });
+  expect(mockLogger.log).toHaveBeenCalledTimes(1);
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    1,
+    LogEventId.AuthLogin,
+    'poll_worker',
+    {
+      disposition: LogDispositionStandardTypes.Success,
+      message: 'User logged in.',
+    }
+  );
+
+  mockCardStatus({ status: 'no_card' });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'logged_out',
+    reason: 'no_card',
+  });
+  expect(mockLogger.log).toHaveBeenCalledTimes(2);
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    2,
+    LogEventId.AuthLogout,
+    'poll_worker',
+    {
+      disposition: LogDispositionStandardTypes.Success,
+      message: 'User logged out.',
+    }
+  );
+});
+
+test.each<{
+  description: string;
+  config: InsertedSmartCardAuthConfig;
+  machineElectionHash?: string;
+  user: UserWithCard;
+  expectedAuthStatus: InsertedSmartCardAuthTypes.AuthStatus;
+  expectedLog?: Parameters<Logger['log']>;
+}>([
+  {
+    description: 'election manager can access unconfigured machine',
+    config: defaultConfig,
+    machineElectionHash: undefined,
+    user: electionManagerUser,
+    expectedAuthStatus: {
+      status: 'checking_pin',
+      user: electionManagerUser,
+    },
+  },
+  {
+    description: 'poll worker cannot access unconfigured machine',
+    config: defaultConfig,
+    machineElectionHash: undefined,
+    user: pollWorkerUser,
+    expectedAuthStatus: {
+      status: 'logged_out',
+      reason: 'machine_not_configured',
+      cardUserRole: 'poll_worker',
+    },
+    expectedLog: [
+      LogEventId.AuthLogin,
+      'poll_worker',
+      {
+        disposition: LogDispositionStandardTypes.Failure,
+        message: 'User failed login.',
+        reason: 'machine_not_configured',
+      },
+    ],
+  },
+  {
+    description: 'election manager mismatched election hash',
+    config: defaultConfig,
+    machineElectionHash: otherElectionHash,
+    user: electionManagerUser,
+    expectedAuthStatus: {
+      status: 'logged_out',
+      reason: 'election_manager_wrong_election',
+      cardUserRole: 'election_manager',
+    },
+    expectedLog: [
+      LogEventId.AuthLogin,
+      'election_manager',
+      {
+        disposition: LogDispositionStandardTypes.Failure,
+        message: 'User failed login.',
+        reason: 'election_manager_wrong_election',
+      },
+    ],
+  },
+  {
+    description: 'poll worker mismatched election hash',
+    config: defaultConfig,
+    machineElectionHash: otherElectionHash,
+    user: pollWorkerUser,
+    expectedAuthStatus: {
+      status: 'logged_out',
+      reason: 'poll_worker_wrong_election',
+      cardUserRole: 'poll_worker',
+    },
+    expectedLog: [
+      LogEventId.AuthLogin,
+      'poll_worker',
+      {
+        disposition: LogDispositionStandardTypes.Failure,
+        message: 'User failed login.',
+        reason: 'poll_worker_wrong_election',
+      },
+    ],
+  },
+  {
+    description:
+      'election manager mismatched election hash, ' +
+      'allowElectionManagersToAccessMachinesConfiguredForOtherElections=true',
+    config: {
+      ...defaultConfig,
+      allowElectionManagersToAccessMachinesConfiguredForOtherElections: true,
+    },
+    machineElectionHash: otherElectionHash,
+    user: electionManagerUser,
+    expectedAuthStatus: {
+      status: 'checking_pin',
+      user: electionManagerUser,
+    },
+  },
+])(
+  'Election checks - $description',
+  async ({
+    config,
+    machineElectionHash,
+    user,
+    expectedAuthStatus,
+    expectedLog,
+  }) => {
+    const auth = new InsertedSmartCardAuth({
+      card: mockCard,
+      config,
+      logger: mockLogger,
+    });
+
+    mockCardStatus({ status: 'ready', user });
+    expect(
+      await auth.getAuthStatus({ electionHash: machineElectionHash })
+    ).toEqual(expectedAuthStatus);
+    if (expectedLog) {
+      expect(mockLogger.log).toHaveBeenCalledTimes(1);
+      expect(mockLogger.log).toHaveBeenNthCalledWith(1, ...expectedLog);
+    }
+  }
+);
+
+test('Cardless voter sessions - ending preemptively', async () => {
+  const auth = new InsertedSmartCardAuth({
+    card: mockCard,
+    config: { ...defaultConfig, allowCardlessVoterSessions: true },
+    logger: mockLogger,
+  });
+
+  await logInAsPollWorker(auth);
+
+  // Start cardless voter session
+  await auth.startCardlessVoterSession(machineState, {
+    ballotStyleId: cardlessVoterUser.ballotStyleId,
+    precinctId: cardlessVoterUser.precinctId,
+  });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'logged_in',
+    user: pollWorkerUser,
+    cardlessVoterUser,
+  });
+  expect(mockLogger.log).toHaveBeenCalledTimes(1);
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    1,
+    LogEventId.AuthLogin,
+    'cardless_voter',
+    {
+      disposition: LogDispositionStandardTypes.Success,
+      message: 'Cardless voter session started.',
+    }
+  );
+
+  // End cardless voter session before removing poll worker card
+  await auth.endCardlessVoterSession();
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'logged_in',
+    user: pollWorkerUser,
+  });
+  expect(mockLogger.log).toHaveBeenCalledTimes(2);
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    2,
+    LogEventId.AuthLogout,
+    'cardless_voter',
+    {
+      disposition: LogDispositionStandardTypes.Success,
+      message: 'Cardless voter session ended.',
+    }
+  );
+});
+
+test('Cardless voter sessions - end-to-end', async () => {
+  const auth = new InsertedSmartCardAuth({
+    card: mockCard,
+    config: { ...defaultConfig, allowCardlessVoterSessions: true },
+    logger: mockLogger,
+  });
+
+  await logInAsPollWorker(auth);
+
+  // Start cardless voter session
+  await auth.startCardlessVoterSession(machineState, {
+    ballotStyleId: cardlessVoterUser.ballotStyleId,
+    precinctId: cardlessVoterUser.precinctId,
+  });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'logged_in',
+    user: pollWorkerUser,
+    cardlessVoterUser,
+  });
+  expect(mockLogger.log).toHaveBeenCalledTimes(1);
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    1,
+    LogEventId.AuthLogin,
+    'cardless_voter',
+    {
+      disposition: LogDispositionStandardTypes.Success,
+      message: 'Cardless voter session started.',
+    }
+  );
+
+  // Remove poll worker card, granting control to cardless voter
+  mockCardStatus({ status: 'no_card' });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'logged_in',
+    user: cardlessVoterUser,
+  });
+  expect(mockLogger.log).toHaveBeenCalledTimes(2);
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    2,
+    LogEventId.AuthLogout,
+    'poll_worker',
+    {
+      disposition: LogDispositionStandardTypes.Success,
+      message: 'User logged out.',
+    }
+  );
+
+  // Insert poll worker card in the middle of cardless voter session
+  mockCardStatus({ status: 'ready', user: pollWorkerUser });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'logged_in',
+    user: pollWorkerUser,
+    cardlessVoterUser,
+  });
+  expect(mockLogger.log).toHaveBeenCalledTimes(3);
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    3,
+    LogEventId.AuthLogin,
+    'poll_worker',
+    {
+      disposition: LogDispositionStandardTypes.Success,
+      message: 'User logged in.',
+    }
+  );
+
+  // Re-remove poll worker card, granting control back to cardless voter
+  mockCardStatus({ status: 'no_card' });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'logged_in',
+    user: cardlessVoterUser,
+  });
+  expect(mockLogger.log).toHaveBeenCalledTimes(4);
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    4,
+    LogEventId.AuthLogout,
+    'poll_worker',
+    {
+      disposition: LogDispositionStandardTypes.Success,
+      message: 'User logged out.',
+    }
+  );
+
+  // End cardless voter session
+  await auth.endCardlessVoterSession();
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'logged_out',
+    reason: 'no_card',
+  });
+  expect(mockLogger.log).toHaveBeenCalledTimes(5);
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    5,
+    LogEventId.AuthLogout,
+    'cardless_voter',
+    {
+      disposition: LogDispositionStandardTypes.Success,
+      message: 'Cardless voter session ended.',
+    }
+  );
+});
+
+test('Reading card data', async () => {
+  const auth = new InsertedSmartCardAuth({
+    card: mockCard,
+    config: defaultConfig,
+    logger: mockLogger,
+  });
+
+  mockCard.readData
+    .expectCallWith()
+    .resolves(Buffer.from(electionData, 'utf-8'));
+  expect(
+    await auth.readCardData(machineState, { schema: ElectionSchema })
+  ).toEqual(ok(election));
+
+  mockCard.readData
+    .expectCallWith()
+    .resolves(Buffer.from(electionData, 'utf-8'));
+  expect(await auth.readCardDataAsString()).toEqual(ok(electionData));
+});
+
+test('Reading card data as string', async () => {
+  const auth = new InsertedSmartCardAuth({
+    card: mockCard,
+    config: defaultConfig,
+    logger: mockLogger,
+  });
+
+  mockCard.readData.expectCallWith().resolves(Buffer.from([]));
+  expect(
+    await auth.readCardData(machineState, { schema: ElectionSchema })
+  ).toEqual(ok(undefined));
+
+  mockCard.readData.expectCallWith().resolves(Buffer.from([]));
+  expect(await auth.readCardDataAsString()).toEqual(ok(undefined));
+});
+
+test('Writing card data', async () => {
+  const auth = new InsertedSmartCardAuth({
+    card: mockCard,
+    config: defaultConfig,
+    logger: mockLogger,
+  });
+
+  mockCard.writeData
+    .expectCallWith(Buffer.from(JSON.stringify(election), 'utf-8'))
+    .resolves();
+  mockCard.readData
+    .expectCallWith()
+    .resolves(Buffer.from(JSON.stringify(election), 'utf-8'));
+  expect(
+    await auth.writeCardData(machineState, {
+      data: election,
+      schema: ElectionSchema,
+    })
+  ).toEqual(ok());
+});
+
+test('Clearing card data', async () => {
+  const auth = new InsertedSmartCardAuth({
+    card: mockCard,
+    config: defaultConfig,
+    logger: mockLogger,
+  });
+
+  mockCard.clearData.expectCallWith().resolves();
+  expect(await auth.clearCardData()).toEqual(ok());
+});
+
+test('Checking PIN error handling', async () => {
+  const auth = new InsertedSmartCardAuth({
+    card: mockCard,
+    config: defaultConfig,
+    logger: mockLogger,
+  });
+
+  mockCardStatus({ status: 'ready', user: electionManagerUser });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'checking_pin',
+    user: electionManagerUser,
+  });
+
+  mockCard.checkPin.expectCallWith(pin).throws(new Error('Whoa!'));
+  await auth.checkPin(machineState, { pin });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'checking_pin',
+    user: electionManagerUser,
+    error: true,
+  });
+  expect(mockLogger.log).toHaveBeenCalledTimes(1);
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    1,
+    LogEventId.AuthPinEntry,
+    'election_manager',
+    {
+      disposition: LogDispositionStandardTypes.Failure,
+      message: 'Error checking PIN: Whoa!',
+    }
+  );
+
+  // Check that "successfully" entering an incorrect PIN clears the error state
+  mockCard.checkPin
+    .expectCallWith(wrongPin)
+    .resolves({ response: 'incorrect', numRemainingAttempts: Infinity });
+  await auth.checkPin(machineState, { pin: wrongPin });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'checking_pin',
+    user: electionManagerUser,
+    wrongPinEnteredAt: expect.any(Date),
+  });
+  expect(mockLogger.log).toHaveBeenCalledTimes(2);
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    2,
+    LogEventId.AuthPinEntry,
+    'election_manager',
+    {
+      disposition: LogDispositionStandardTypes.Failure,
+      message: 'User entered incorrect PIN.',
+    }
+  );
+
+  // Check that wrong PIN entry state is maintained after an error
+  mockCard.checkPin.expectCallWith(pin).throws(new Error('Whoa!'));
+  await auth.checkPin(machineState, { pin });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'checking_pin',
+    user: electionManagerUser,
+    error: true,
+    wrongPinEnteredAt: expect.any(Date),
+  });
+  expect(mockLogger.log).toHaveBeenCalledTimes(3);
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    3,
+    LogEventId.AuthPinEntry,
+    'election_manager',
+    {
+      disposition: LogDispositionStandardTypes.Failure,
+      message: 'Error checking PIN: Whoa!',
+    }
+  );
+
+  mockCard.checkPin.expectCallWith(pin).resolves({ response: 'correct' });
+  await auth.checkPin(machineState, { pin });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'logged_in',
+    user: electionManagerUser,
+  });
+});
+
+test(
+  'Checking PIN when not in PIN checking state, ' +
+    'e.g. because someone removed their card right after entering their PIN',
+  async () => {
+    const auth = new InsertedSmartCardAuth({
+      card: mockCard,
+      config: defaultConfig,
+      logger: mockLogger,
+    });
+
+    mockCardStatus({ status: 'no_card' });
+    mockCard.checkPin
+      .expectCallWith(pin)
+      .throws(new Error('Whoa! Card no longer in reader'));
+    await auth.checkPin(machineState, { pin });
+    expect(await auth.getAuthStatus(machineState)).toEqual({
+      status: 'logged_out',
+      reason: 'no_card',
+    });
+    expect(mockLogger.log).toHaveBeenCalledTimes(1);
+    expect(mockLogger.log).toHaveBeenNthCalledWith(
+      1,
+      LogEventId.AuthPinEntry,
+      'unknown',
+      {
+        disposition: LogDispositionStandardTypes.Failure,
+        message: 'Error checking PIN: Whoa! Card no longer in reader',
+      }
+    );
+  }
+);
+
+test('Attempting to start a cardless voter session when logged out', async () => {
+  const auth = new InsertedSmartCardAuth({
+    card: mockCard,
+    config: { ...defaultConfig, allowCardlessVoterSessions: true },
+    logger: mockLogger,
+  });
+
+  mockCardStatus({ status: 'no_card' });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'logged_out',
+    reason: 'no_card',
+  });
+
+  await auth.startCardlessVoterSession(machineState, {
+    ballotStyleId: cardlessVoterUser.ballotStyleId,
+    precinctId: cardlessVoterUser.precinctId,
+  });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'logged_out',
+    reason: 'no_card',
+  });
+});
+
+test('Attempting to start a cardless voter session when not a poll worker', async () => {
+  const auth = new InsertedSmartCardAuth({
+    card: mockCard,
+    config: { ...defaultConfig, allowCardlessVoterSessions: true },
+    logger: mockLogger,
+  });
+
+  await logInAsElectionManager(auth);
+
+  await auth.startCardlessVoterSession(machineState, {
+    ballotStyleId: cardlessVoterUser.ballotStyleId,
+    precinctId: cardlessVoterUser.precinctId,
+  });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'logged_in',
+    user: electionManagerUser,
+  });
+});
+
+test('Attempting to start a cardless voter session when not allowed by config', async () => {
+  const auth = new InsertedSmartCardAuth({
+    card: mockCard,
+    config: defaultConfig,
+    logger: mockLogger,
+  });
+
+  await logInAsPollWorker(auth);
+
+  await expect(
+    auth.startCardlessVoterSession(machineState, {
+      ballotStyleId: cardlessVoterUser.ballotStyleId,
+      precinctId: cardlessVoterUser.precinctId,
+    })
+  ).rejects.toThrow();
+  await expect(auth.endCardlessVoterSession()).rejects.toThrow();
+});
+
+test('Reading card data error handling', async () => {
+  const auth = new InsertedSmartCardAuth({
+    card: mockCard,
+    config: defaultConfig,
+    logger: mockLogger,
+  });
+
+  mockCard.readData.expectCallWith().throws(new Error('Whoa!'));
+  expect(
+    await auth.readCardData(machineState, { schema: ElectionSchema })
+  ).toEqual(err(new Error('Whoa!')));
+});
+
+test('Reading card data as string error handling', async () => {
+  const auth = new InsertedSmartCardAuth({
+    card: mockCard,
+    config: defaultConfig,
+    logger: mockLogger,
+  });
+
+  mockCard.readData
+    .expectCallWith()
+    .resolves(Buffer.from(JSON.stringify({}), 'utf-8'));
+  expect(
+    await auth.readCardData(machineState, { schema: ElectionSchema })
+  ).toEqual(err(expect.any(z.ZodError)));
+
+  mockCard.readData.expectCallWith().throws(new Error('Whoa!'));
+  expect(await auth.readCardDataAsString()).toEqual(err(new Error('Whoa!')));
+});
+
+test('Writing card data error handling', async () => {
+  const auth = new InsertedSmartCardAuth({
+    card: mockCard,
+    config: defaultConfig,
+    logger: mockLogger,
+  });
+
+  mockCard.writeData
+    .expectCallWith(Buffer.from(JSON.stringify(election), 'utf-8'))
+    .throws(new Error('Whoa!'));
+  expect(
+    await auth.writeCardData(machineState, {
+      data: election,
+      schema: ElectionSchema,
+    })
+  ).toEqual(err(new Error('Whoa!')));
+
+  mockCard.writeData
+    .expectCallWith(Buffer.from(JSON.stringify(election), 'utf-8'))
+    .resolves();
+  mockCard.readData.expectCallWith().throws(new Error('Whoa!'));
+  expect(
+    await auth.writeCardData(machineState, {
+      data: election,
+      schema: ElectionSchema,
+    })
+  ).toEqual(err(new Error('Verification of write by reading data failed')));
+});
+
+test('Clearing card data error handling', async () => {
+  const auth = new InsertedSmartCardAuth({
+    card: mockCard,
+    config: defaultConfig,
+    logger: mockLogger,
+  });
+
+  mockCard.clearData.expectCallWith().throws(new Error('Whoa!'));
+  expect(await auth.clearCardData()).toEqual(err(new Error('Whoa!')));
+});
+
+test.each<{ description: string; user: UserWithCard }>([
+  {
+    description: 'system administrator',
+    user: systemAdministratorUser,
+  },
+  {
+    description: 'election manager',
+    user: electionManagerUser,
+  },
+])('SKIP_PIN_ENTRY feature flag - $description', async ({ user }) => {
+  mockOf(isFeatureFlagEnabled).mockImplementation(
+    (flag) => flag === BooleanEnvironmentVariableName.SKIP_PIN_ENTRY
+  );
+  const auth = new InsertedSmartCardAuth({
+    card: mockCard,
+    config: defaultConfig,
+    logger: mockLogger,
+  });
+
+  mockCardStatus({ status: 'ready', user });
+  expect(await auth.getAuthStatus(machineState)).toEqual({
+    status: 'logged_in',
+    user,
   });
 });

--- a/libs/auth/src/inserted_smart_card_auth.ts
+++ b/libs/auth/src/inserted_smart_card_auth.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import {
   assert,
   err,
+  extractErrorMessage,
   ok,
   Result,
   throwIllegalValue,
@@ -200,10 +201,9 @@ export class InsertedSmartCardAuth implements InsertedSmartCardAuthApi {
     } catch (error) {
       const userRole =
         'user' in this.authStatus ? this.authStatus.user.role : 'unknown';
-      const errorMessage = error instanceof Error ? error.message : error;
       await this.logger.log(LogEventId.AuthPinEntry, userRole, {
         disposition: LogDispositionStandardTypes.Failure,
-        message: `Error checking PIN: ${errorMessage}.`,
+        message: `Error checking PIN: ${extractErrorMessage(error)}.`,
       });
       checkPinResponse = { response: 'error' };
     }

--- a/libs/auth/src/inserted_smart_card_auth.ts
+++ b/libs/auth/src/inserted_smart_card_auth.ts
@@ -21,7 +21,7 @@ import {
   Optional,
   PrecinctId,
   safeParseJson,
-  User,
+  UserWithCard,
 } from '@votingworks/types';
 import {
   BooleanEnvironmentVariableName,
@@ -359,9 +359,6 @@ export class InsertedSmartCardAuth implements InsertedSmartCardAuthApi {
                     ? { status: 'logged_in', user }
                     : { status: 'checking_pin', user };
                 }
-                if (user.role === 'poll_worker') {
-                  return { status: 'logged_in', user };
-                }
                 return { status: 'logged_in', user };
               }
               return currentAuthStatus;
@@ -416,7 +413,7 @@ export class InsertedSmartCardAuth implements InsertedSmartCardAuthApi {
 
   private validateCardUser(
     machineState: InsertedSmartCardAuthMachineState,
-    user?: User
+    user?: UserWithCard
   ): Result<void, InsertedSmartCardAuthTypes.LoggedOut['reason']> {
     if (!user) {
       return err('invalid_user_on_card');

--- a/libs/auth/src/inserted_smart_card_auth.ts
+++ b/libs/auth/src/inserted_smart_card_auth.ts
@@ -217,7 +217,7 @@ export class InsertedSmartCardAuth implements InsertedSmartCardAuthApi {
     machineState: InsertedSmartCardAuthMachineState,
     input: { ballotStyleId: BallotStyleId; precinctId: PrecinctId }
   ): Promise<void> {
-    assert(this.config.allowedUserRoles.includes('cardless_voter'));
+    assert(this.config.allowCardlessVoterSessions);
     await this.checkCardReaderAndUpdateAuthStatus(machineState);
     if (
       this.authStatus.status !== 'logged_in' ||
@@ -235,7 +235,7 @@ export class InsertedSmartCardAuth implements InsertedSmartCardAuthApi {
   }
 
   async endCardlessVoterSession(): Promise<void> {
-    assert(this.config.allowedUserRoles.includes('cardless_voter'));
+    assert(this.config.allowCardlessVoterSessions);
 
     this.cardlessVoterUser = undefined;
 
@@ -420,10 +420,6 @@ export class InsertedSmartCardAuth implements InsertedSmartCardAuthApi {
   ): Result<void, InsertedSmartCardAuthTypes.LoggedOut['reason']> {
     if (!user) {
       return err('invalid_user_on_card');
-    }
-
-    if (!this.config.allowedUserRoles.includes(user.role)) {
-      return err('user_role_not_allowed');
     }
 
     if (user.role === 'election_manager') {

--- a/libs/auth/src/inserted_smart_card_auth_api.ts
+++ b/libs/auth/src/inserted_smart_card_auth_api.ts
@@ -5,7 +5,6 @@ import {
   InsertedSmartCardAuth,
   Optional,
   PrecinctId,
-  UserRole,
 } from '@votingworks/types';
 
 /**
@@ -50,7 +49,7 @@ export interface InsertedSmartCardAuthApi {
  * Configuration parameters for an inserted smart card auth instance
  */
 export interface InsertedSmartCardAuthConfig {
-  allowedUserRoles: UserRole[];
+  allowCardlessVoterSessions?: boolean;
   allowElectionManagersToAccessMachinesConfiguredForOtherElections?: boolean;
 }
 

--- a/libs/auth/src/java_card.ts
+++ b/libs/auth/src/java_card.ts
@@ -9,7 +9,7 @@ import {
   Optional,
   PollWorkerUser,
   SystemAdministratorUser,
-  User,
+  UserWithCard,
 } from '@votingworks/types';
 
 import {
@@ -328,7 +328,7 @@ export class JavaCard implements Card {
    * 2. Can throw errors due to external actions like preemptively removing the card from the card
    *    reader
    */
-  private async safeReadUser(): Promise<Optional<User>> {
+  private async safeReadUser(): Promise<Optional<UserWithCard>> {
     try {
       return await this.readUser();
     } catch {
@@ -340,7 +340,7 @@ export class JavaCard implements Card {
    * Reads the user on the card, performing various forms of verification along the way. Throws an
    * error if any verification fails.
    */
-  private async readUser(): Promise<Optional<User>> {
+  private async readUser(): Promise<Optional<UserWithCard>> {
     await this.selectApplet();
 
     // Verify that the card VotingWorks cert was signed by VotingWorks

--- a/libs/auth/src/memory_card.ts
+++ b/libs/auth/src/memory_card.ts
@@ -7,9 +7,9 @@ import {
   PollWorkerUser,
   safeParseJson,
   SystemAdministratorUser,
-  User,
   UserRole,
   UserRoleSchema,
+  UserWithCard,
 } from '@votingworks/types';
 
 import { Card, CardStatus, CheckPinResponse } from './card';
@@ -86,7 +86,7 @@ const AnyCardDataSchema: z.ZodSchema<AnyCardData> = z.union([
 ]);
 
 function parseUserDataFromCardSummary(cardSummary: Legacy.CardSummaryReady): {
-  user?: User;
+  user?: UserWithCard;
   pin?: string;
 } {
   if (!cardSummary.shortValue) {

--- a/libs/auth/test/utils.ts
+++ b/libs/auth/test/utils.ts
@@ -40,23 +40,13 @@ export function buildMockCard(): MockCard {
   };
 }
 
-type MockCardField = keyof MockCard;
-
 /**
  * Asserts that all the expected calls to all the methods of a mock card were made
  */
 export function mockCardAssertComplete(mockCard: MockCard): void {
-  // Use a Record type to ensure that we're being exhaustive
-  const methods: Record<MockCardField, undefined> = {
-    getCardStatus: undefined,
-    checkPin: undefined,
-    program: undefined,
-    readData: undefined,
-    writeData: undefined,
-    clearData: undefined,
-    unprogram: undefined,
-  };
-  for (const method of Object.keys(methods) as MockCardField[]) {
-    mockCard[method].assertComplete();
+  for (const mockMethod of Object.values(mockCard) as Array<
+    MockCard[keyof MockCard]
+  >) {
+    mockMethod.assertComplete();
   }
 }

--- a/libs/auth/test/utils.ts
+++ b/libs/auth/test/utils.ts
@@ -40,19 +40,23 @@ export function buildMockCard(): MockCard {
   };
 }
 
+type MockCardField = keyof MockCard;
+
 /**
  * Asserts that all the expected calls to all the methods of a mock card were made
  */
 export function mockCardAssertComplete(mockCard: MockCard): void {
-  for (const method of [
-    'getCardStatus',
-    'checkPin',
-    'program',
-    'readData',
-    'writeData',
-    'clearData',
-    'unprogram',
-  ] as const) {
+  // Use a Record type to ensure that we're being exhaustive
+  const methods: Record<MockCardField, undefined> = {
+    getCardStatus: undefined,
+    checkPin: undefined,
+    program: undefined,
+    readData: undefined,
+    writeData: undefined,
+    clearData: undefined,
+    unprogram: undefined,
+  };
+  for (const method of Object.keys(methods) as MockCardField[]) {
     mockCard[method].assertComplete();
   }
 }

--- a/libs/auth/test/utils.ts
+++ b/libs/auth/test/utils.ts
@@ -1,3 +1,5 @@
+import { MockFunction, mockFunction } from '@votingworks/test-utils';
+
 import { Card } from '../src/card';
 
 /**
@@ -11,16 +13,46 @@ export function numericArray(input: {
 }
 
 /**
+ * The card API with all methods mocked using our custom libs/test-utils mocks
+ */
+export interface MockCard {
+  getCardStatus: MockFunction<Card['getCardStatus']>;
+  checkPin: MockFunction<Card['checkPin']>;
+  program: MockFunction<Card['program']>;
+  readData: MockFunction<Card['readData']>;
+  writeData: MockFunction<Card['writeData']>;
+  clearData: MockFunction<Card['clearData']>;
+  unprogram: MockFunction<Card['unprogram']>;
+}
+
+/**
  * Builds a mock card instance
  */
-export function buildMockCard(): Card {
+export function buildMockCard(): MockCard {
   return {
-    getCardStatus: jest.fn(() => Promise.resolve({ status: 'no_card' })),
-    checkPin: jest.fn(),
-    program: jest.fn(),
-    readData: jest.fn(),
-    writeData: jest.fn(),
-    clearData: jest.fn(),
-    unprogram: jest.fn(),
+    getCardStatus: mockFunction<Card['getCardStatus']>('getCardStatus'),
+    checkPin: mockFunction<Card['checkPin']>('checkPin'),
+    program: mockFunction<Card['program']>('program'),
+    readData: mockFunction<Card['readData']>('readData'),
+    writeData: mockFunction<Card['writeData']>('writeData'),
+    clearData: mockFunction<Card['clearData']>('clearData'),
+    unprogram: mockFunction<Card['unprogram']>('unprogram'),
   };
+}
+
+/**
+ * Asserts that all the expected calls to all the methods of a mock card were made
+ */
+export function mockCardAssertComplete(mockCard: MockCard): void {
+  for (const method of [
+    'getCardStatus',
+    'checkPin',
+    'program',
+    'readData',
+    'writeData',
+    'clearData',
+    'unprogram',
+  ] as const) {
+    mockCard[method].assertComplete();
+  }
 }

--- a/libs/basics/src/errors.test.ts
+++ b/libs/basics/src/errors.test.ts
@@ -1,0 +1,13 @@
+import { Buffer } from 'buffer';
+
+import { extractErrorMessage } from './errors';
+
+test.each<{ error: unknown; expectedErrorMessage: string }>([
+  { error: new Error('Whoa!'), expectedErrorMessage: 'Whoa!' },
+  { error: 'Whoa!', expectedErrorMessage: 'Whoa!' },
+  { error: Buffer.from('Whoa!', 'utf-8'), expectedErrorMessage: 'Whoa!' },
+  { error: 1234, expectedErrorMessage: '1234' },
+  { error: { error: 'Whoa!' }, expectedErrorMessage: '[object Object]' },
+])('extractErrorMessage', ({ error, expectedErrorMessage }) => {
+  expect(extractErrorMessage(error)).toEqual(expectedErrorMessage);
+});

--- a/libs/basics/src/errors.ts
+++ b/libs/basics/src/errors.ts
@@ -1,0 +1,6 @@
+/**
+ * Extracts the error message from an error in a type-safe way
+ */
+export function extractErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/libs/basics/src/index.ts
+++ b/libs/basics/src/index.ts
@@ -3,6 +3,7 @@ export * from './assert';
 export * as collections from './collections';
 export * from './deferred';
 export * from './duplicates';
+export * from './errors';
 export * from './find';
 export * from './group_by';
 export * from './in_groups_of';

--- a/libs/types/src/auth/auth.ts
+++ b/libs/types/src/auth/auth.ts
@@ -28,6 +28,8 @@ export type User =
   | PollWorkerUser
   | CardlessVoterUser;
 
+export type UserWithCard = Exclude<User, CardlessVoterUser>;
+
 export type UserRole = User['role'];
 
 export const UserRoleSchema: z.ZodSchema<UserRole> = z.union([

--- a/libs/types/src/auth/dipped_smart_card_auth.ts
+++ b/libs/types/src/auth/dipped_smart_card_auth.ts
@@ -1,8 +1,8 @@
 import {
   ElectionManagerUser,
   SystemAdministratorUser,
-  User,
   UserRole,
+  UserWithCard,
 } from './auth';
 
 export interface LoggedOut {
@@ -29,9 +29,16 @@ export interface RemoveCard {
   readonly user: SystemAdministratorUser | ElectionManagerUser;
 }
 
-export type ProgrammableCard =
-  | { status: 'no_card' | 'error' }
-  | { status: 'ready'; programmedUser?: User };
+interface ProgrammableCardReady {
+  status: 'ready';
+  programmedUser?: UserWithCard;
+}
+
+interface ProgrammableCardNotReady {
+  status: 'card_error' | 'no_card' | 'unknown_error';
+}
+
+export type ProgrammableCard = ProgrammableCardReady | ProgrammableCardNotReady;
 
 export interface SystemAdministratorLoggedIn {
   readonly status: 'logged_in';

--- a/libs/types/src/auth/inserted_smart_card_auth.ts
+++ b/libs/types/src/auth/inserted_smart_card_auth.ts
@@ -14,8 +14,7 @@ export interface LoggedOut {
     | 'invalid_user_on_card'
     | 'machine_not_configured'
     | 'no_card'
-    | 'poll_worker_wrong_election'
-    | 'user_role_not_allowed';
+    | 'poll_worker_wrong_election';
   readonly cardUserRole?: UserRole;
 }
 


### PR DESCRIPTION
_Easiest reviewed by commit_

## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/3057

More `libs/auth` tests, this time for the top-level auth API implementations

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A
- [x] I have added JSDoc comments to any newly introduced exports