### PR TITLE
repro zip await bug

### DIFF
--- a/apps/admin/frontend/src/screens/unconfigured_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/unconfigured_screen.test.tsx
@@ -29,7 +29,8 @@ test('renders a button to load setup package', async () => {
   await screen.findByText('Select Existing Setup Package Zip File');
 });
 
-test('handles an uploaded file', async () => {
+/* eslint-disable jest/no-focused-tests */
+test.only('handles an uploaded file', async () => {
   const { electionDefinition } = electionMinimalExhaustiveSampleFixtures;
 
   apiMock.expectConfigure(electionDefinition.electionData);

--- a/apps/admin/frontend/src/screens/unconfigured_screen.tsx
+++ b/apps/admin/frontend/src/screens/unconfigured_screen.tsx
@@ -9,8 +9,8 @@ import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 
 import {
-  electionMinimalExhaustiveSampleFixtures,
-  systemSettings,
+  // electionMinimalExhaustiveSampleFixtures,
+  // systemSettings,
   electionFamousNames2021Fixtures,
 } from '@votingworks/fixtures';
 import { Button, Prose, useMountedState } from '@votingworks/ui';
@@ -19,7 +19,7 @@ import { assert } from '@votingworks/basics';
 // eslint-disable-next-line vx/gts-no-import-export-type
 import type { ConfigureResult } from '@votingworks/admin-backend';
 import { readFileAsyncAsString } from '@votingworks/utils';
-// import { readInitialAdminSetupPackageFromFile } from '../utils/initial_setup_package';
+import { readInitialAdminSetupPackageFromFile } from '../utils/initial_setup_package';
 import {
   getElectionDefinitionConverterClient,
   VxFile,
@@ -163,16 +163,16 @@ export function UnconfiguredScreen(): JSX.Element {
     const file = input.files && input.files[0];
 
     if (file) {
-      // This configuration passes because the test does not end prematurely
-      // const initialSetupPackage = await readInitialAdminSetupPackageFromFile(
-      //   file
-      // );
-      const initialSetupPackage = await Promise.resolve({
-        electionString:
-          electionMinimalExhaustiveSampleFixtures.electionDefinition
-            .electionData,
-        systemSettingsString: systemSettings.asText(),
-      });
+      // This configuration fails because the test ends before all code is done running
+      const initialSetupPackage = await readInitialAdminSetupPackageFromFile(
+        file
+      );
+      // const initialSetupPackage = await Promise.resolve({
+      //   electionString:
+      //     electionMinimalExhaustiveSampleFixtures.electionDefinition
+      //       .electionData,
+      //   systemSettingsString: systemSettings.asText(),
+      // });
 
       setVxElectionFileIsInvalid(false);
       setSystemSettingsFileIsInvalid(false);

--- a/apps/admin/frontend/src/screens/unconfigured_screen.tsx
+++ b/apps/admin/frontend/src/screens/unconfigured_screen.tsx
@@ -8,14 +8,18 @@ import React, {
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+import {
+  electionMinimalExhaustiveSampleFixtures,
+  systemSettings,
+  electionFamousNames2021Fixtures,
+} from '@votingworks/fixtures';
 import { Button, Prose, useMountedState } from '@votingworks/ui';
 import { assert } from '@votingworks/basics';
 
 // eslint-disable-next-line vx/gts-no-import-export-type
 import type { ConfigureResult } from '@votingworks/admin-backend';
 import { readFileAsyncAsString } from '@votingworks/utils';
-import { readInitialAdminSetupPackageFromFile } from '../utils/initial_setup_package';
+// import { readInitialAdminSetupPackageFromFile } from '../utils/initial_setup_package';
 import {
   getElectionDefinitionConverterClient,
   VxFile,
@@ -159,9 +163,17 @@ export function UnconfiguredScreen(): JSX.Element {
     const file = input.files && input.files[0];
 
     if (file) {
-      const initialSetupPackage = await readInitialAdminSetupPackageFromFile(
-        file
-      );
+      // This configuration passes because the test does not end prematurely
+      // const initialSetupPackage = await readInitialAdminSetupPackageFromFile(
+      //   file
+      // );
+      const initialSetupPackage = await Promise.resolve({
+        electionString:
+          electionMinimalExhaustiveSampleFixtures.electionDefinition
+            .electionData,
+        systemSettingsString: systemSettings.asText(),
+      });
+
       setVxElectionFileIsInvalid(false);
       setSystemSettingsFileIsInvalid(false);
       await saveElectionToBackend(initialSetupPackage.electionString);

--- a/apps/admin/frontend/src/utils/initial_setup_package.ts
+++ b/apps/admin/frontend/src/utils/initial_setup_package.ts
@@ -21,15 +21,28 @@ export interface InitialAdminSetupPackage {
 async function readInitialAdminSetupPackageFromBuffer(
   source: Buffer
 ): Promise<InitialAdminSetupPackage> {
+  console.log('readInitialAdminSetupPackageFromBuffer opening zip');
   const zipfile = await openZip(source);
   const entries = getEntries(zipfile);
+
+  console.log('Opened zip, reading election');
 
   const electionEntry = getFileByName(entries, 'election.json');
   const electionString = await readTextEntry(electionEntry);
 
+  /**
+   * Observe when running the test:
+   * ```
+   *  Cannot log after tests are done. Did you forget to wait for something async in your test?
+    Attempted to log "Done reading election, reading system settings".
+    ```
+   */
+
+  console.log('Done reading election, reading system settings');
   const systemSettingsEntry = getFileByName(entries, 'systemSettings.json');
   const systemSettingsString = await readTextEntry(systemSettingsEntry);
 
+  console.log('Returning setup package');
   return {
     electionString,
     systemSettingsString,


### PR DESCRIPTION
## Overview

Don't merge; repros potential bug with zip testing util

Run `pnpm test src/app.test.tsx` from `apps/admin/frontend` to repro

Test fails with
```
TestingLibraryElementError: Unable to find an element with the text: Select Existing Setup Package Zip File.
```
because the test is ending before the component can finish loading the election and rerender. Debug output of the DOM shows the page has still rendered the `Loading` message.

In line with this, the API mock expectation assertions also fail:

```
   ● loading an initial setup package

    Mismatch between expected mock function calls and actual mock function calls:

    Call #0
    Expected: getCurrentElectionMetadata()
    Actual: getCurrentElectionMetadata()

    Call #1
    Expected: getCurrentElectionMetadata()
    Actual: <none>
```

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
