### PR TITLE
test(utils): fix minor issues

### DIFF
--- a/libs/utils/src/json_stream.test.ts
+++ b/libs/utils/src/json_stream.test.ts
@@ -74,11 +74,11 @@ test('iterable', () => {
 });
 
 test('fails with circular references', () => {
-  const obj: any = { a: 1 };
+  const obj: { a: number; b?: unknown } = { a: 1 };
   obj.b = obj;
   expect(() => asString(obj)).toThrowError();
 
-  const arr: any[] = [];
+  const arr: unknown[] = [];
   arr.push(arr);
   expect(() => asString(arr)).toThrowError();
 });
@@ -94,10 +94,15 @@ test('fails with non-serializable objects', () => {
 
 test('generates correct JSON', () => {
   fc.assert(
-    fc.property(fc.jsonObject(), fc.boolean(), (input, compact) => {
-      expect(
-        JSON.parse(asString(input as JsonStreamInput<unknown>, { compact }))
-      ).toEqual(input);
-    })
+    fc.property(
+      // filter out -0 because JSON.stringify() converts it to 0
+      fc.jsonObject().filter((v) => !Object.is(v, -0)),
+      fc.boolean(),
+      (input, compact) => {
+        expect(
+          JSON.parse(asString(input as JsonStreamInput<unknown>, { compact }))
+        ).toEqual(input);
+      }
+    )
   );
 });


### PR DESCRIPTION

## Overview
- `fc.jsonObject()` might produce `-0` which serializes to `"0"` which then parses as `0` which Jest `toEqual` considers different from `-0` (see [failing build](https://app.circleci.com/pipelines/github/votingworks/vxsuite/8427/workflows/9f690331-aacc-4e5a-a8b7-696c01bf3c6a/jobs/230657))
- stop using `any` to get rid of warnings

<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot
n/a

## Testing Plan
Automated.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
