### PR TITLE
feat(basics): add `windows` method for `iter`

### DIFF
--- a/libs/basics/src/iterators/async_iterator_plus.test.ts
+++ b/libs/basics/src/iterators/async_iterator_plus.test.ts
@@ -456,3 +456,23 @@ test('partition', async () => {
       .partition((a) => a % 2 === 0)
   ).toEqual([new Set([2]), new Set([1, 3])]);
 });
+
+test('windows', async () => {
+  expect(() => iter([]).async().windows(0)).toThrowError();
+  expect(await iter([]).async().windows(2).toArray()).toEqual([]);
+  expect(await iter([1]).async().windows(2).toArray()).toEqual([]);
+  expect(await iter([1, 2]).async().windows(2).toArray()).toEqual([[1, 2]]);
+  expect(await iter([1, 2, 3]).async().windows(2).toArray()).toEqual([
+    [1, 2],
+    [2, 3],
+  ]);
+  expect(await iter([1, 2, 3]).async().windows(3).toArray()).toEqual([
+    [1, 2, 3],
+  ]);
+  expect(await iter([1, 2, 3]).async().windows(4).toArray()).toEqual([]);
+  expect(await iter('rust').async().windows(2).toArray()).toEqual([
+    ['r', 'u'],
+    ['u', 's'],
+    ['s', 't'],
+  ]);
+});

--- a/libs/basics/src/iterators/async_iterator_plus.ts
+++ b/libs/basics/src/iterators/async_iterator_plus.ts
@@ -307,6 +307,33 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
     return set;
   }
 
+  windows(groupSize: 0): never;
+  windows(groupSize: 1): AsyncIteratorPlus<[T]>;
+  windows(groupSize: 2): AsyncIteratorPlus<[T, T]>;
+  windows(groupSize: 3): AsyncIteratorPlus<[T, T, T]>;
+  windows(groupSize: 4): AsyncIteratorPlus<[T, T, T, T]>;
+  windows(groupSize: 5): AsyncIteratorPlus<[T, T, T, T, T]>;
+  windows(groupSize: number): AsyncIteratorPlus<T[]>;
+  windows(groupSize: number): AsyncIteratorPlus<T[]> {
+    if (groupSize <= 0) {
+      throw new Error('groupSize must be greater than 0');
+    }
+
+    const { iterable } = this;
+    return new AsyncIteratorPlusImpl(
+      (async function* gen() {
+        const window: T[] = [];
+        for await (const value of iterable) {
+          window.push(value);
+          if (window.length === groupSize) {
+            yield window.slice();
+            window.shift();
+          }
+        }
+      })()
+    );
+  }
+
   zip(): AsyncIteratorPlus<[T]>;
   zip<U>(other: AsyncIterable<U>): AsyncIteratorPlus<[T, U]>;
   zip<U, V>(

--- a/libs/basics/src/iterators/iterator_plus.test.ts
+++ b/libs/basics/src/iterators/iterator_plus.test.ts
@@ -312,3 +312,21 @@ test('partition', () => {
     new Set([1, 3]),
   ]);
 });
+
+test('windows', () => {
+  expect(() => iter([]).windows(0)).toThrowError();
+  expect(iter([]).windows(2).toArray()).toEqual([]);
+  expect(iter([1]).windows(2).toArray()).toEqual([]);
+  expect(iter([1, 2]).windows(2).toArray()).toEqual([[1, 2]]);
+  expect(iter([1, 2, 3]).windows(2).toArray()).toEqual([
+    [1, 2],
+    [2, 3],
+  ]);
+  expect(iter([1, 2, 3]).windows(3).toArray()).toEqual([[1, 2, 3]]);
+  expect(iter([1, 2, 3]).windows(4).toArray()).toEqual([]);
+  expect(iter('rust').windows(2).toArray()).toEqual([
+    ['r', 'u'],
+    ['u', 's'],
+    ['s', 't'],
+  ]);
+});

--- a/libs/basics/src/iterators/iterator_plus.ts
+++ b/libs/basics/src/iterators/iterator_plus.ts
@@ -302,6 +302,33 @@ export class IteratorPlusImpl<T> implements IteratorPlus<T>, AsyncIterable<T> {
     return new Set(this.iterable);
   }
 
+  windows(groupSize: 0): never;
+  windows(groupSize: 1): IteratorPlus<[T]>;
+  windows(groupSize: 2): IteratorPlus<[T, T]>;
+  windows(groupSize: 3): IteratorPlus<[T, T, T]>;
+  windows(groupSize: 4): IteratorPlus<[T, T, T, T]>;
+  windows(groupSize: 5): IteratorPlus<[T, T, T, T, T]>;
+  windows(groupSize: number): IteratorPlus<T[]>;
+  windows(groupSize: number): IteratorPlus<T[]> {
+    if (groupSize <= 0) {
+      throw new Error('groupSize must be greater than 0');
+    }
+
+    const { iterable } = this;
+    return new IteratorPlusImpl(
+      (function* gen() {
+        const window: T[] = [];
+        for (const value of iterable) {
+          window.push(value);
+          if (window.length === groupSize) {
+            yield window.slice();
+            window.shift();
+          }
+        }
+      })()
+    );
+  }
+
   zip(): IteratorPlus<[T]>;
   zip<U>(other: Iterable<U>): IteratorPlus<[T, U]>;
   zip<U, V>(other1: Iterable<U>, other2: Iterable<V>): IteratorPlus<[T, U, V]>;

--- a/libs/basics/src/iterators/types.ts
+++ b/libs/basics/src/iterators/types.ts
@@ -174,6 +174,41 @@ export interface IteratorPlus<T> extends Iterable<T> {
   toSet(): Set<T>;
 
   /**
+   * Throws an error because `groupSize` must be greater than 0.
+   */
+  windows(groupSize: 0): never;
+
+  /**
+   * Yields elements from `this` as 1-element tuples.
+   */
+  windows(groupSize: 1): IteratorPlus<[T]>;
+
+  /**
+   * Yields tuples of two elements at a time.
+   */
+  windows(groupSize: 2): IteratorPlus<[T, T]>;
+
+  /**
+   * Yields tuples of three elements at a time.
+   */
+  windows(groupSize: 3): IteratorPlus<[T, T, T]>;
+
+  /**
+   * Yields tuples of four elements at a time.
+   */
+  windows(groupSize: 4): IteratorPlus<[T, T, T, T]>;
+
+  /**
+   * Yields tuples of five elements at a time.
+   */
+  windows(groupSize: 5): IteratorPlus<[T, T, T, T, T]>;
+
+  /**
+   * Yields tuples of elements at a time.
+   */
+  windows(groupSize: number): IteratorPlus<T[]>;
+
+  /**
    * Yields elements of `this` as 1-element tuples.
    */
   zip(): IteratorPlus<[T]>;
@@ -443,6 +478,41 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
    * iterable.
    */
   toSet(): Promise<Set<T>>;
+
+  /**
+   * Throws an error because `groupSize` must be greater than 0.
+   */
+  windows(groupSize: 0): never;
+
+  /**
+   * Yields elements from `this` as 1-element tuples.
+   */
+  windows(groupSize: 1): AsyncIteratorPlus<[T]>;
+
+  /**
+   * Yields tuples of two elements at a time.
+   */
+  windows(groupSize: 2): AsyncIteratorPlus<[T, T]>;
+
+  /**
+   * Yields tuples of three elements at a time.
+   */
+  windows(groupSize: 3): AsyncIteratorPlus<[T, T, T]>;
+
+  /**
+   * Yields tuples of four elements at a time.
+   */
+  windows(groupSize: 4): AsyncIteratorPlus<[T, T, T, T]>;
+
+  /**
+   * Yields tuples of five elements at a time.
+   */
+  windows(groupSize: 5): AsyncIteratorPlus<[T, T, T, T, T]>;
+
+  /**
+   * Yields tuples of elements at a time.
+   */
+  windows(groupSize: number): AsyncIteratorPlus<T[]>;
 
   /**
    * Yields elements of `this` as 1-element tuples.


### PR DESCRIPTION
## Overview
As long as we're aping Rust's `Iterator`, let's do it properly! https://doc.rust-lang.org/1.68.0/std/iter/trait.Iterator.html

I took [this comment](https://github.com/votingworks/vxsuite/pull/3129#discussion_r1142593332) as tacit support for this.

<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot
n/a

## Testing Plan
Automated.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
