### PR TITLE
refactor(types): move `Optional` to `basics`

### DIFF
--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -10,7 +10,6 @@ import {
   getBallotStyle,
   getContests,
   InlineBallotImage,
-  Optional,
   Rect,
   safeParseElectionDefinition,
   safeParseJson,
@@ -18,7 +17,14 @@ import {
   SystemSettings,
   SystemSettingsSchema,
 } from '@votingworks/types';
-import { assert, assertDefined, err, ok, iter } from '@votingworks/basics';
+import {
+  assert,
+  assertDefined,
+  err,
+  ok,
+  iter,
+  Optional,
+} from '@votingworks/basics';
 import express, { Application } from 'express';
 import {
   DippedSmartCardAuthApi,

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -5,6 +5,7 @@
 import { Admin } from '@votingworks/api';
 import {
   assert,
+  Optional,
   Result,
   err,
   ok,
@@ -20,7 +21,6 @@ import {
   ContestOptionId,
   Id,
   Iso8601Timestamp,
-  Optional,
   PrecinctId,
   safeParse,
   safeParseElectionDefinition,

--- a/apps/admin/frontend/src/components/election_manager_tally_report.tsx
+++ b/apps/admin/frontend/src/components/election_manager_tally_report.tsx
@@ -20,7 +20,6 @@ import {
   Tally,
   unsafeParse,
   VotingMethod,
-  Optional,
   PartyId,
   getPartyIdsWithContests,
   getPartySpecificElectionTitle,
@@ -32,7 +31,7 @@ import {
 } from '@votingworks/utils';
 import React from 'react';
 
-import { find } from '@votingworks/basics';
+import { find, Optional } from '@votingworks/basics';
 import { filterExternalTalliesByParams } from '../utils/external_tallies';
 import { mergeWriteIns } from '../utils/write_ins';
 

--- a/apps/admin/frontend/src/config/types.ts
+++ b/apps/admin/frontend/src/config/types.ts
@@ -4,13 +4,12 @@ import {
   CastVoteRecord,
   ContestTallyMeta,
   Dictionary,
-  Optional,
   PartyId,
   PrecinctId,
   PromiseOr,
   VotingMethod,
 } from '@votingworks/types';
-import { throwIllegalValue } from '@votingworks/basics';
+import { Optional, throwIllegalValue } from '@votingworks/basics';
 import { z } from 'zod';
 
 // Events

--- a/apps/central-scan/backend/src/store.ts
+++ b/apps/central-scan/backend/src/store.ts
@@ -24,7 +24,6 @@ import {
   Iso8601Timestamp,
   mapSheet,
   MarkThresholds,
-  Optional,
   PageInterpretationSchema,
   PageInterpretationWithFiles,
   PollsState as PollsStateType,
@@ -37,7 +36,7 @@ import {
   SheetOf,
   Side,
 } from '@votingworks/types';
-import { assert } from '@votingworks/basics';
+import { assert, Optional } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import makeDebug from 'debug';
 import * as fs from 'fs-extra';

--- a/apps/central-scan/backend/src/workers/json_serialization.ts
+++ b/apps/central-scan/backend/src/workers/json_serialization.ts
@@ -1,5 +1,4 @@
-import { err, isResult, ok } from '@votingworks/basics';
-import { throwIllegalValue } from '@votingworks/basics';
+import { err, isResult, ok, throwIllegalValue } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 
 /* eslint-disable no-underscore-dangle */

--- a/apps/central-scan/frontend/src/app_root.tsx
+++ b/apps/central-scan/frontend/src/app_root.tsx
@@ -3,7 +3,6 @@ import { Route, Switch, useHistory } from 'react-router-dom';
 import {
   ElectionDefinition,
   MarkThresholds,
-  Optional,
   safeParseJson,
 } from '@votingworks/types';
 import styled from 'styled-components';
@@ -33,7 +32,7 @@ import {
   Button,
 } from '@votingworks/ui';
 import { LogEventId, Logger } from '@votingworks/logging';
-import { assert, Result, ok, err } from '@votingworks/basics';
+import { assert, Optional, Result, ok, err } from '@votingworks/basics';
 import { MachineConfig } from './config/types';
 import { AppContext, AppContextInterface } from './contexts/app_context';
 

--- a/apps/mark/backend/src/app.test.ts
+++ b/apps/mark/backend/src/app.test.ts
@@ -1,11 +1,11 @@
-import { err, ok, Result } from '@votingworks/basics';
+import { err, ok, Optional, Result } from '@votingworks/basics';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 import {
   fakeElectionManagerUser,
   fakePollWorkerUser,
   mockOf,
 } from '@votingworks/test-utils';
-import { ElectionDefinition, Optional } from '@votingworks/types';
+import { ElectionDefinition } from '@votingworks/types';
 import {
   ALL_PRECINCTS_SELECTION,
   ReportSourceMachineType,

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -5,12 +5,11 @@ import {
   InsertedSmartCardAuthApi,
   InsertedSmartCardAuthMachineState,
 } from '@votingworks/auth';
-import { err, ok, Result } from '@votingworks/basics';
+import { err, ok, Optional, Result } from '@votingworks/basics';
 import * as grout from '@votingworks/grout';
 import {
   BallotStyleId,
   ElectionDefinition,
-  Optional,
   PrecinctId,
   safeParseElectionDefinition,
 } from '@votingworks/types';

--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -6,7 +6,6 @@ import {
   VotesDict,
   getBallotStyle,
   getContests,
-  Optional,
   ContestId,
   PrecinctId,
   BallotStyleId,
@@ -40,7 +39,7 @@ import {
   UnlockMachineScreen,
 } from '@votingworks/ui';
 
-import { assert, throwIllegalValue } from '@votingworks/basics';
+import { assert, Optional, throwIllegalValue } from '@votingworks/basics';
 import {
   checkPin,
   endCardlessVoterSession,

--- a/apps/mark/frontend/src/components/yes_no_contest.tsx
+++ b/apps/mark/frontend/src/components/yes_no_contest.tsx
@@ -9,7 +9,6 @@ import {
   YesNoVote,
   OptionalYesNoVote,
   YesNoContest as YesNoContestInterface,
-  Optional,
   YesOrNo,
   getContestDistrictName,
 } from '@votingworks/types';
@@ -24,7 +23,7 @@ import {
 } from '@votingworks/ui';
 
 import { getSingleYesNoVote } from '@votingworks/utils';
-import { assert } from '@votingworks/basics';
+import { assert, Optional } from '@votingworks/basics';
 import { ScrollDirections, UpdateVoteFunction } from '../config/types';
 
 import { BallotContext } from '../contexts/ballot_context';

--- a/apps/mark/frontend/src/pages/diagnostics_screen.tsx
+++ b/apps/mark/frontend/src/pages/diagnostics_screen.tsx
@@ -10,12 +10,11 @@ import {
   Text,
   useCancelablePromise,
 } from '@votingworks/ui';
-import { Optional } from '@votingworks/types';
 import { formatTime, Hardware } from '@votingworks/utils';
 import { DateTime } from 'luxon';
 import { useHistory, Switch, Route } from 'react-router-dom';
 import styled from 'styled-components';
-import { assert } from '@votingworks/basics';
+import { assert, Optional } from '@votingworks/basics';
 import {
   AccessibleControllerDiagnosticScreen,
   AccessibleControllerDiagnosticResults,

--- a/apps/mark/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/mark/frontend/test/helpers/mock_api_client.tsx
@@ -8,7 +8,6 @@ import {
   BallotStyleId,
   ElectionDefinition,
   InsertedSmartCardAuth,
-  Optional,
   PrecinctId,
 } from '@votingworks/types';
 import {
@@ -17,7 +16,7 @@ import {
   fakePollWorkerUser,
   fakeSystemAdministratorUser,
 } from '@votingworks/test-utils';
-import { ok, Result } from '@votingworks/basics';
+import { ok, Optional, Result } from '@votingworks/basics';
 import { ScannerReportData } from '@votingworks/utils';
 import { ApiClientContext, createQueryClient } from '../../src/api';
 import { fakeMachineConfig } from './fake_machine_config';

--- a/apps/scan/backend/src/interpret.ts
+++ b/apps/scan/backend/src/interpret.ts
@@ -6,7 +6,6 @@ import {
   ElectionDefinition,
   Id,
   MarkThresholds,
-  Optional,
   PageInterpretationWithFiles,
   PrecinctSelection,
   mapSheet,
@@ -17,7 +16,7 @@ import {
   normalizeSheetOutput,
 } from '@votingworks/ballot-interpreter-vx';
 import { time } from '@votingworks/utils';
-import { err, ok, Result } from '@votingworks/basics';
+import { err, ok, Optional, Result } from '@votingworks/basics';
 import { interpret as interpretNhNext } from './interpret_nh_next_adapter';
 import { Interpreter as VxInterpreter } from './vx_interpreter';
 import { saveSheetImages } from './util/save_images';

--- a/apps/scan/backend/src/store.ts
+++ b/apps/scan/backend/src/store.ts
@@ -24,7 +24,6 @@ import {
   Iso8601Timestamp,
   mapSheet,
   MarkThresholds,
-  Optional,
   PageInterpretationSchema,
   PageInterpretationWithFiles,
   PollsState as PollsStateType,
@@ -38,7 +37,7 @@ import {
   Side,
 } from '@votingworks/types';
 import { BallotPackageEntry } from '@votingworks/utils';
-import { assert, find } from '@votingworks/basics';
+import { assert, find, Optional } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import * as fs from 'fs-extra';
 import { sha256 } from 'js-sha256';

--- a/apps/scan/frontend/src/screens/poll_worker_screen.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.tsx
@@ -40,7 +40,6 @@ import {
   getPartyIdsInBallotStyles,
   PollsState,
   PollsTransition,
-  Optional,
   ElectionDefinition,
   PrecinctSelection,
 } from '@votingworks/types';
@@ -49,7 +48,13 @@ import {
   LogEventId,
   Logger,
 } from '@votingworks/logging';
-import { assert, Result, sleep, throwIllegalValue } from '@votingworks/basics';
+import {
+  assert,
+  Optional,
+  Result,
+  sleep,
+  throwIllegalValue,
+} from '@votingworks/basics';
 import { ScreenMainCenterChild } from '../components/layout';
 
 import { LiveCheckModal } from '../components/live_check_modal';

--- a/codemods/bin/codemod-move-symbols
+++ b/codemods/bin/codemod-move-symbols
@@ -4,6 +4,4 @@ set -euo pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-TARGET="$PWD"
-
-exec "${DIR}/../node_modules/.bin/tsx" "${DIR}/../src/codemod-move-symbols/main.ts" --dir "${TARGET}" "$@"
+exec "${DIR}/../node_modules/.bin/tsx" "${DIR}/../src/codemod-move-symbols/main.ts" "$@"

--- a/codemods/bin/codemod-move-symbols
+++ b/codemods/bin/codemod-move-symbols
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+TARGET="$PWD"
+
+exec "${DIR}/../node_modules/.bin/tsx" "${DIR}/../src/codemod-move-symbols/main.ts" --dir "${TARGET}" "$@"

--- a/codemods/package.json
+++ b/codemods/package.json
@@ -33,6 +33,6 @@
     "is-ci-cli": "^2.2.0",
     "prettier": "^2.8.3",
     "tsx": "^3.12.6",
-    "typescript": "^4.3.5"
+    "typescript": "4.6.3"
   }
 }

--- a/codemods/package.json
+++ b/codemods/package.json
@@ -15,6 +15,7 @@
     "esbuild": "^0.17.6",
     "esbuild-esm-loader": "^0.2.3",
     "ts-morph": "^12.2.0",
+    "@votingworks/basics": "workspace:*",
     "@votingworks/utils": "workspace:*"
   },
   "devDependencies": {

--- a/codemods/package.json
+++ b/codemods/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "esbuild": "^0.17.6",
     "esbuild-esm-loader": "^0.2.3",
-    "ts-morph": "^12.2.0"
+    "ts-morph": "^12.2.0",
+    "@votingworks/utils": "workspace:*"
   },
   "devDependencies": {
     "@types/babel__core": "^7.20.0",
@@ -30,6 +31,7 @@
     "eslint-plugin-vx": "workspace:*",
     "is-ci-cli": "^2.2.0",
     "prettier": "^2.8.3",
+    "tsx": "^3.12.6",
     "typescript": "^4.3.5"
   }
 }

--- a/codemods/src/codemod-move-symbols/index.ts
+++ b/codemods/src/codemod-move-symbols/index.ts
@@ -26,8 +26,9 @@
 import { constants, promises as fs } from 'fs';
 import { join, relative } from 'path';
 import { Project } from 'ts-morph';
+import { iter, Optional } from '@votingworks/basics';
 import { formatDurationNs } from '@votingworks/utils';
-import { getWorkspacePackageInfo } from '../pnpm';
+import { getWorkspacePackageInfo, PackageInfo } from '../pnpm';
 
 const VOTINGWORKS_PACKAGE_NAMESPACE = '@votingworks';
 
@@ -47,22 +48,31 @@ async function getTsConfigFilePath(cwd: string): Promise<string | undefined> {
   }
 }
 
-function fullyQualifiedPackageName(name: string): string {
-  return name.startsWith(VOTINGWORKS_PACKAGE_NAMESPACE)
-    ? name
-    : `${VOTINGWORKS_PACKAGE_NAMESPACE}/${name}`;
+function findPackageByName(
+  packages: Iterable<PackageInfo>,
+  name: string
+): Optional<PackageInfo> {
+  for (const pkg of packages) {
+    if (
+      pkg.name === name ||
+      pkg.name === `${VOTINGWORKS_PACKAGE_NAMESPACE}/${name}`
+    ) {
+      return pkg;
+    }
+  }
 }
 
 interface Movement {
   symbol: string;
-  source: string;
-  target: string;
+  source: PackageInfo;
+  target: PackageInfo;
 }
 
 export async function main(args: readonly string[]): Promise<number> {
   const monorepoRoot = join(__dirname, '../../..');
   const movements: Movement[] = [];
-  const packages: string[] = [];
+  const packages: PackageInfo[] = [];
+  const workspacePackageInfo = await getWorkspacePackageInfo(monorepoRoot);
 
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i] as string;
@@ -70,16 +80,25 @@ export async function main(args: readonly string[]): Promise<number> {
       const value = args[i + 1];
       i += 1;
       if (value && !value.startsWith('-')) {
-        packages.push(value);
+        const absolutePath = join(process.cwd(), value);
+        const pkg = iter(workspacePackageInfo.values()).find(
+          ({ path }) => path === absolutePath
+        );
+        if (!pkg) {
+          process.stderr.write(
+            `error: ${value} is not a valid package directory\n`
+          );
+          return 1;
+        }
+        packages.push(pkg);
       } else {
         process.stderr.write(`error: missing value for --dir\n`);
         return 1;
       }
     } else if (arg === '--all') {
-      const workspacePackageInfo = await getWorkspacePackageInfo(monorepoRoot);
       for (const pkg of workspacePackageInfo.values()) {
         if (pkg.name.startsWith(`${VOTINGWORKS_PACKAGE_NAMESPACE}/`)) {
-          packages.push(pkg.path);
+          packages.push(pkg);
         }
       }
     } else if (arg.startsWith('-')) {
@@ -88,10 +107,33 @@ export async function main(args: readonly string[]): Promise<number> {
     } else {
       const [symbol, source, target] = arg.split(':');
       if (symbol && source && target) {
+        const sourcePackage = findPackageByName(
+          workspacePackageInfo.values(),
+          source
+        );
+        const targetPackage = findPackageByName(
+          workspacePackageInfo.values(),
+          target
+        );
+
+        if (!sourcePackage) {
+          process.stderr.write(
+            `error: ${source} is not a valid package name\n`
+          );
+          return 1;
+        }
+
+        if (!targetPackage) {
+          process.stderr.write(
+            `error: ${target} is not a valid package name\n`
+          );
+          return 1;
+        }
+
         movements.push({
           symbol,
-          source: fullyQualifiedPackageName(source),
-          target: fullyQualifiedPackageName(target),
+          source: sourcePackage,
+          target: targetPackage,
         });
       } else {
         process.stderr.write(
@@ -102,14 +144,14 @@ export async function main(args: readonly string[]): Promise<number> {
     }
   }
 
-  for (const packageRoot of packages) {
-    const relativePackagePath = relative(monorepoRoot, packageRoot);
+  for (const pkg of packages) {
     const start = process.hrtime.bigint();
-    const tsConfigFilePath = await getTsConfigFilePath(packageRoot);
+    let updates = 0;
+    const tsConfigFilePath = await getTsConfigFilePath(pkg.path);
 
     if (!tsConfigFilePath) {
       process.stderr.write(
-        `${relativePackagePath}: could not locate a tsconfig.json file to use\n`
+        `${pkg.name}: could not locate a tsconfig.json file to use\n`
       );
       return 1;
     }
@@ -118,18 +160,28 @@ export async function main(args: readonly string[]): Promise<number> {
 
     for (const sourceFile of project.getSourceFiles()) {
       const filePath = sourceFile.getFilePath();
-      const relativeFilePath = relative(packageRoot, filePath);
+      const relativeFilePath = relative(pkg.path, filePath);
 
       if (relativeFilePath.startsWith('../')) {
         continue;
       }
 
       for (const { symbol, source, target } of movements) {
+        // skip if the source and target are the same
+        if (source.name === target.name) {
+          continue;
+        }
+
+        // skip the package we're moving the symbol from or to
+        if (pkg.name === source.name || pkg.name === target.name) {
+          continue;
+        }
+
         const importDeclarationForSource = sourceFile.getImportDeclaration(
           (importDeclaration) => {
             const moduleSpecifier = importDeclaration.getModuleSpecifierValue();
             return (
-              moduleSpecifier === source &&
+              moduleSpecifier === source.name &&
               importDeclaration
                 .getNamedImports()
                 .some((namedImport) => namedImport.getName() === symbol)
@@ -144,7 +196,7 @@ export async function main(args: readonly string[]): Promise<number> {
         const importDeclarationFromTarget = sourceFile.getImportDeclaration(
           (importDeclaration) => {
             const moduleSpecifier = importDeclaration.getModuleSpecifierValue();
-            return moduleSpecifier === target;
+            return moduleSpecifier === target.name;
           }
         );
 
@@ -168,7 +220,7 @@ export async function main(args: readonly string[]): Promise<number> {
         } else {
           sourceFile.addImportDeclaration({
             namedImports: [symbol],
-            moduleSpecifier: target,
+            moduleSpecifier: target.name,
           });
         }
 
@@ -183,16 +235,17 @@ export async function main(args: readonly string[]): Promise<number> {
         }
 
         process.stdout.write(
-          `${relativePackagePath}: ${relativeFilePath}: ${symbol}: ${source} → ${target}\n`
+          `${pkg.name}: ${relativeFilePath}: ${symbol}: ${source.name} → ${target.name}\n`
         );
+        updates += 1;
       }
     }
 
     await project.save();
     process.stdout.write(
-      `${relativePackagePath}: ✅ ${formatDurationNs(
+      `${pkg.name}: ✅ ${formatDurationNs(
         process.hrtime.bigint() - start
-      )}\n`
+      )} (${updates} updated)\n`
     );
   }
 

--- a/codemods/src/codemod-move-symbols/index.ts
+++ b/codemods/src/codemod-move-symbols/index.ts
@@ -1,0 +1,171 @@
+/**
+ * Moves symbols from one TypeScript package to another.
+ *
+ * Run it like this:
+ *
+ *   bin/codemod-move-symbols --dir path/to/project MOVEMENT [MOVEMENT ...]
+ *
+ * A `MOVEMENT` is a string of the form `SYMBOL:SOURCE:TARGET` where `SYMBOL` is
+ * the name of the symbol to move, `SOURCE` is the name of the package to move
+ * it from, and `TARGET` is the name of the package to move it to.
+ *
+ * For example, to move the `Optional` symbol from `@votingworks/types` to
+ * `@votingworks/basics`:
+ *
+ *   bin/codemod-move-symbols --dir path/to/project Optional:@votingworks/types:@votingworks/basics
+ *
+ * Or, using shorthand for the packages:
+ *
+ *   bin/codemod-move-symbols --dir path/to/project Optional:types:basics
+ */
+
+import { constants, promises as fs } from 'fs';
+import { join, relative } from 'path';
+import { Project } from 'ts-morph';
+
+async function canReadWrite(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath, constants.O_RDWR);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function getTsConfigFilePath(cwd: string): Promise<string | undefined> {
+  const tsConfigFilePath = join(cwd, 'tsconfig.json');
+  if (await canReadWrite(tsConfigFilePath)) {
+    return tsConfigFilePath;
+  }
+}
+
+function fullyQualifiedPackageName(name: string): string {
+  return name.startsWith('@votingworks') ? name : `@votingworks/${name}`;
+}
+
+interface Movement {
+  symbol: string;
+  source: string;
+  target: string;
+}
+
+export async function main(args: readonly string[]): Promise<number> {
+  const movements: Movement[] = [];
+  let root = process.cwd();
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i] as string;
+    if (arg === '--dir') {
+      const value = args[i + 1];
+      i += 1;
+      if (value && !value.startsWith('-')) {
+        root = value;
+      } else {
+        process.stderr.write(`error: missing value for --dir\n`);
+        return 1;
+      }
+    } else if (arg.startsWith('-')) {
+      process.stderr.write(`error: unknown option ${arg}\n`);
+      return 1;
+    } else {
+      const [symbol, source, target] = arg.split(':');
+      if (symbol && source && target) {
+        movements.push({
+          symbol,
+          source: fullyQualifiedPackageName(source),
+          target: fullyQualifiedPackageName(target),
+        });
+      } else {
+        process.stderr.write(
+          `error: invalid movement ${arg}, expected format is SYMBOL:SOURCE:TARGET\n`
+        );
+        return 1;
+      }
+    }
+  }
+
+  const tsConfigFilePath = await getTsConfigFilePath(root);
+
+  if (!tsConfigFilePath) {
+    process.stderr.write(
+      'error: could not locate a tsconfig.json file to use\n'
+    );
+    return 1;
+  }
+
+  const project = new Project({ tsConfigFilePath });
+
+  for (const sourceFile of project.getSourceFiles()) {
+    const filePath = sourceFile.getFilePath();
+    const relativeFilePath = relative(root, filePath);
+
+    if (relativeFilePath.startsWith('../')) {
+      continue;
+    }
+
+    for (const { symbol, source, target } of movements) {
+      const importDeclarationForSource = sourceFile.getImportDeclaration(
+        (importDeclaration) => {
+          const moduleSpecifier = importDeclaration.getModuleSpecifierValue();
+          return (
+            moduleSpecifier === source &&
+            importDeclaration
+              .getNamedImports()
+              .some((namedImport) => namedImport.getName() === symbol)
+          );
+        }
+      );
+
+      if (!importDeclarationForSource) {
+        continue;
+      }
+
+      const importDeclarationFromTarget = sourceFile.getImportDeclaration(
+        (importDeclaration) => {
+          const moduleSpecifier = importDeclaration.getModuleSpecifierValue();
+          return moduleSpecifier === target;
+        }
+      );
+
+      if (importDeclarationFromTarget) {
+        const existingNamedImports =
+          importDeclarationFromTarget.getNamedImports();
+        const insertionIndex = existingNamedImports.findIndex(
+          (namedImport) =>
+            namedImport
+              .getName()
+              .toLocaleLowerCase()
+              .localeCompare(symbol.toLocaleLowerCase()) > 0
+        );
+
+        importDeclarationFromTarget.insertNamedImport(
+          insertionIndex === -1 ? existingNamedImports.length : insertionIndex,
+          symbol
+        );
+      } else {
+        sourceFile.addImportDeclaration({
+          namedImports: [symbol],
+          moduleSpecifier: target,
+        });
+      }
+
+      for (const namedImport of importDeclarationForSource.getNamedImports()) {
+        if (namedImport.getName() === symbol) {
+          namedImport.remove();
+        }
+      }
+
+      if (importDeclarationForSource.getNamedImports().length === 0) {
+        importDeclarationForSource.remove();
+      }
+
+      process.stdout.write(
+        `${relativeFilePath}: ${symbol}: ${source} → ${target}\n`
+      );
+    }
+  }
+
+  await project.save();
+
+  return 0;
+}

--- a/codemods/src/codemod-move-symbols/main.ts
+++ b/codemods/src/codemod-move-symbols/main.ts
@@ -1,0 +1,11 @@
+import { main } from './index';
+
+main(process.argv.slice(2)).then(
+  (exitCode) => {
+    process.exitCode = exitCode;
+  },
+  (error) => {
+    process.stderr.write(`${error.stack}\n`);
+    process.exit(1);
+  }
+);

--- a/codemods/src/pnpm.ts
+++ b/codemods/src/pnpm.ts
@@ -1,0 +1,1 @@
+../../script/src/validate-monorepo/pnpm.ts

--- a/codemods/tsconfig.build.json
+++ b/codemods/tsconfig.build.json
@@ -8,6 +8,8 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts"],
   "references": [
-    { "path": "../libs/eslint-plugin-vx/tsconfig.build.json" }
+    { "path": "../libs/basics/tsconfig.build.json" },
+    { "path": "../libs/eslint-plugin-vx/tsconfig.build.json" },
+    { "path": "../libs/utils/tsconfig.build.json" }
   ]
 }

--- a/codemods/tsconfig.json
+++ b/codemods/tsconfig.json
@@ -61,6 +61,8 @@
   },
   "include": ["src"],
   "references": [
-    { "path": "../libs/eslint-plugin-vx/tsconfig.build.json" }
+    { "path": "../libs/basics/tsconfig.build.json" },
+    { "path": "../libs/eslint-plugin-vx/tsconfig.build.json" },
+    { "path": "../libs/utils/tsconfig.build.json" }
   ]
 }

--- a/libs/api/src/services/scan/index.ts
+++ b/libs/api/src/services/scan/index.ts
@@ -1,4 +1,4 @@
-import { Result } from '@votingworks/basics';
+import { Optional, Result } from '@votingworks/basics';
 import {
   AdjudicationStatus,
   AdjudicationStatusSchema,
@@ -15,7 +15,6 @@ import {
   IdSchema,
   MarkThresholds,
   MarkThresholdsSchema,
-  Optional,
   PollsState,
   PollsStateSchema,
   PrecinctSelection,

--- a/libs/auth/scripts/mock_card.ts
+++ b/libs/auth/scripts/mock_card.ts
@@ -3,8 +3,8 @@ import { Buffer } from 'buffer';
 import * as fs from 'fs';
 import { sha256 } from 'js-sha256';
 import yargs from 'yargs/yargs';
-import { assert, throwIllegalValue } from '@votingworks/basics';
-import { Optional, safeParseElection } from '@votingworks/types';
+import { assert, Optional, throwIllegalValue } from '@votingworks/basics';
+import { safeParseElection } from '@votingworks/types';
 
 import { DEV_JURISDICTION } from '../src/certs';
 import { mockCard } from '../src/mock_file_card';

--- a/libs/auth/src/inserted_smart_card_auth.ts
+++ b/libs/auth/src/inserted_smart_card_auth.ts
@@ -5,6 +5,7 @@ import {
   err,
   extractErrorMessage,
   ok,
+  Optional,
   Result,
   throwIllegalValue,
   wrapException,
@@ -18,7 +19,6 @@ import {
   BallotStyleId,
   CardlessVoterUser,
   InsertedSmartCardAuth as InsertedSmartCardAuthTypes,
-  Optional,
   PrecinctId,
   safeParseJson,
 } from '@votingworks/types';

--- a/libs/auth/src/inserted_smart_card_auth_api.ts
+++ b/libs/auth/src/inserted_smart_card_auth_api.ts
@@ -1,9 +1,8 @@
 import { z } from 'zod';
-import { Result } from '@votingworks/basics';
+import { Optional, Result } from '@votingworks/basics';
 import {
   BallotStyleId,
   InsertedSmartCardAuth,
-  Optional,
   PrecinctId,
 } from '@votingworks/types';
 

--- a/libs/auth/src/java_card.ts
+++ b/libs/auth/src/java_card.ts
@@ -2,11 +2,10 @@ import { Buffer } from 'buffer';
 import { promises as fs } from 'fs';
 import { sha256 } from 'js-sha256';
 import { v4 as uuid } from 'uuid';
-import { assert, throwIllegalValue } from '@votingworks/basics';
+import { assert, Optional, throwIllegalValue } from '@votingworks/basics';
 import {
   Byte,
   ElectionManagerUser,
-  Optional,
   PollWorkerUser,
   SystemAdministratorUser,
 } from '@votingworks/types';

--- a/libs/auth/src/legacy/card.ts
+++ b/libs/auth/src/legacy/card.ts
@@ -1,7 +1,6 @@
 /* eslint-disable vx/gts-jsdoc */
 import { z } from 'zod';
-import { Result } from '@votingworks/basics';
-import { Optional } from '@votingworks/types';
+import { Optional, Result } from '@votingworks/basics';
 
 export interface CardSummaryNotReady {
   status: 'no_card' | 'error';

--- a/libs/auth/src/legacy/web_service_card.ts
+++ b/libs/auth/src/legacy/web_service_card.ts
@@ -1,8 +1,8 @@
 import { fromByteArray, toByteArray } from 'base64-js';
 import fetch from 'node-fetch';
 import { z } from 'zod';
-import { ok, Result } from '@votingworks/basics';
-import { Optional, safeParseJson, unsafeParse } from '@votingworks/types';
+import { ok, Optional, Result } from '@votingworks/basics';
+import { safeParseJson, unsafeParse } from '@votingworks/types';
 import { fetchJson } from '@votingworks/utils';
 
 import {

--- a/libs/backend/src/scan/cast_vote_records/export.ts
+++ b/libs/backend/src/scan/cast_vote_records/export.ts
@@ -6,12 +6,11 @@ import {
   Election,
   ElectionDefinition,
   Id,
-  Optional,
   PageInterpretation,
   SheetOf,
   unsafeParse,
 } from '@votingworks/types';
-import { err, ok, Result } from '@votingworks/basics';
+import { err, ok, Optional, Result } from '@votingworks/basics';
 import { Readable } from 'stream';
 import {
   CAST_VOTE_RECORD_REPORT_FILENAME,

--- a/libs/ballot-interpreter-nh-next/ts/src/cli.ts
+++ b/libs/ballot-interpreter-nh-next/ts/src/cli.ts
@@ -1,8 +1,15 @@
-import { assert, err, find, iter, ok, Result } from '@votingworks/basics';
+import {
+  assert,
+  err,
+  find,
+  iter,
+  ok,
+  Optional,
+  Result,
+} from '@votingworks/basics';
 import {
   ElectionDefinition,
   mapSheet,
-  Optional,
   safeParseElectionDefinition,
   safeParseJson,
   SheetOf,

--- a/libs/ballot-interpreter-nh-next/ts/src/types.ts
+++ b/libs/ballot-interpreter-nh-next/ts/src/types.ts
@@ -1,5 +1,5 @@
-import { BallotPaperSize, GridPosition, Optional } from '@votingworks/types';
-import { Result } from '@votingworks/basics';
+import { BallotPaperSize, GridPosition } from '@votingworks/types';
+import { Optional, Result } from '@votingworks/basics';
 
 /*
  * Many of these types are from the Rust code.

--- a/libs/basics/src/types.ts
+++ b/libs/basics/src/types.ts
@@ -2,3 +2,8 @@
  * A type or a promise of a type.
  */
 export type MaybePromise<T> = T | Promise<T>;
+
+/**
+ * Represents an optional value where `undefined` is used when missing.
+ */
+export type Optional<T> = T | undefined;

--- a/libs/custom-scanner/src/cli/demo/index.ts
+++ b/libs/custom-scanner/src/cli/demo/index.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
-import { sleep } from '@votingworks/basics';
-import { Optional } from '@votingworks/types';
+import { Optional, sleep } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import { writeFile } from 'fs/promises';
 import * as readline from 'readline';

--- a/libs/custom-scanner/src/mocks/protocol.ts
+++ b/libs/custom-scanner/src/mocks/protocol.ts
@@ -1,6 +1,5 @@
-import { err, ok, Result } from '@votingworks/basics';
+import { err, ok, Optional, Result } from '@votingworks/basics';
 import { Coder } from '@votingworks/message-coder';
-import { Optional } from '@votingworks/types';
 import { Buffer } from 'buffer';
 import { inspect } from 'util';
 import { debug } from '../debug';

--- a/libs/custom-scanner/src/mutex.ts
+++ b/libs/custom-scanner/src/mutex.ts
@@ -1,5 +1,4 @@
-import { Optional } from '@votingworks/types';
-import { deferred } from '@votingworks/basics';
+import { deferred, Optional } from '@votingworks/basics';
 
 interface LockResult<T> {
   value: T;

--- a/libs/custom-scanner/src/protocol.ts
+++ b/libs/custom-scanner/src/protocol.ts
@@ -22,11 +22,11 @@ import {
   err,
   isResult,
   ok,
+  Optional,
   Result,
   throwIllegalValue,
 } from '@votingworks/basics';
 import { Buffer } from 'buffer';
-import { Optional } from '@votingworks/types';
 import { debug as baseDebug } from './debug';
 import {
   AckResponse,

--- a/libs/image-utils/src/image_data.ts
+++ b/libs/image-utils/src/image_data.ts
@@ -1,5 +1,5 @@
-import { err, ok, Result } from '@votingworks/basics';
-import { Optional, safeParseInt } from '@votingworks/types';
+import { err, ok, Optional, Result } from '@votingworks/basics';
+import { safeParseInt } from '@votingworks/types';
 import { Buffer } from 'buffer';
 import {
   createCanvas,

--- a/libs/test-utils/src/expect_print.ts
+++ b/libs/test-utils/src/expect_print.ts
@@ -1,10 +1,6 @@
 import { render, RenderResult, waitFor } from '@testing-library/react';
-import {
-  ElementWithCallback,
-  Optional,
-  PrintOptions,
-} from '@votingworks/types';
-import { assert } from '@votingworks/basics';
+import { ElementWithCallback, PrintOptions } from '@votingworks/types';
+import { assert, Optional } from '@votingworks/basics';
 
 export class ExpectPrintError extends Error {}
 

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -1,3 +1,4 @@
+import { Optional } from '@votingworks/basics';
 import { sha256 } from 'js-sha256';
 import * as z from 'zod';
 import {
@@ -9,7 +10,6 @@ import {
   Iso8601Timestamp,
   Iso8601TimestampSchema,
   NewType,
-  Optional,
 } from './generic';
 import {
   Offset,

--- a/libs/types/src/generic.ts
+++ b/libs/types/src/generic.ts
@@ -1,6 +1,6 @@
 import check8601 from '@antongolub/iso8601';
 import { z } from 'zod';
-import { err, ok, Result, wrapException } from '@votingworks/basics';
+import { err, ok, Optional, Result, wrapException } from '@votingworks/basics';
 
 export interface DefinedDictionary<T> {
   [key: string]: T;
@@ -8,7 +8,6 @@ export interface DefinedDictionary<T> {
 export interface Dictionary<T> {
   [key: string]: Optional<T>;
 }
-export type Optional<T> = T | undefined;
 export interface Provider<T> {
   get(): Promise<T>;
 }

--- a/libs/types/src/tallies.ts
+++ b/libs/types/src/tallies.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod';
+import { Optional } from '@votingworks/basics';
 import { CastVoteRecord } from './cast_vote_record';
 import { Candidate, AnyContest } from './election';
-import { Dictionary, Optional } from './generic';
+import { Dictionary } from './generic';
 
 export type YesNoVoteId = 'yes' | 'no';
 export type YesNoVoteOption = ['yes'] | ['no'] | [];

--- a/libs/ui/src/hooks/use_stored_state.ts
+++ b/libs/ui/src/hooks/use_stored_state.ts
@@ -1,4 +1,4 @@
-import { Optional, unsafeParse } from '@votingworks/types';
+import { unsafeParse } from '@votingworks/types';
 import { Storage } from '@votingworks/utils';
 import {
   Dispatch,
@@ -8,6 +8,7 @@ import {
   useState,
 } from 'react';
 import { z } from 'zod';
+import { Optional } from '@votingworks/basics';
 import { useCancelablePromise } from './use_cancelable_promise';
 
 /**

--- a/libs/utils/src/filenames.ts
+++ b/libs/utils/src/filenames.ts
@@ -4,10 +4,9 @@ import {
   ElectionDefinition,
   MachineId,
   maybeParse,
-  Optional,
   safeParseNumber,
 } from '@votingworks/types';
-import { assert, throwIllegalValue } from '@votingworks/basics';
+import { assert, Optional, throwIllegalValue } from '@votingworks/basics';
 import { basename } from 'path';
 
 const SECTION_SEPARATOR = '__';

--- a/libs/utils/src/json_stream.ts
+++ b/libs/utils/src/json_stream.ts
@@ -1,4 +1,4 @@
-import { Optional } from '@votingworks/types';
+import { Optional } from '@votingworks/basics';
 
 function isIterable(
   value: unknown

--- a/libs/utils/src/votecounting.ts
+++ b/libs/utils/src/votecounting.ts
@@ -8,7 +8,6 @@ import {
   getBallotStyle,
   getContests,
   Dictionary,
-  Optional,
   FullElectionTally,
   TallyCategory,
   BatchTally,
@@ -19,7 +18,13 @@ import {
   ContestId,
 } from '@votingworks/types';
 
-import { assert, throwIllegalValue, find, typedAs } from '@votingworks/basics';
+import {
+  assert,
+  Optional,
+  throwIllegalValue,
+  find,
+  typedAs,
+} from '@votingworks/basics';
 import {
   CastVoteRecordFilters,
   computeTallyWithPrecomputedCategories,

--- a/libs/utils/src/votes.ts
+++ b/libs/utils/src/votes.ts
@@ -1,4 +1,10 @@
-import { assert, find, throwIllegalValue, typedAs } from '@votingworks/basics';
+import {
+  assert,
+  find,
+  Optional,
+  throwIllegalValue,
+  typedAs,
+} from '@votingworks/basics';
 import {
   BallotTargetMark,
   BatchTally,
@@ -19,7 +25,6 @@ import {
   getBallotStyle,
   MarkStatus,
   MarkThresholds,
-  Optional,
   PartyId,
   PrecinctId,
   safeParse,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1749,6 +1749,7 @@ importers:
       '@types/node': 16.11.29
       '@typescript-eslint/eslint-plugin': ^5.21.0
       '@typescript-eslint/parser': ^5.21.0
+      '@votingworks/utils': workspace:*
       esbuild: ^0.17.6
       esbuild-esm-loader: ^0.2.3
       eslint-config-prettier: ^8.3.0
@@ -1759,8 +1760,10 @@ importers:
       is-ci-cli: ^2.2.0
       prettier: ^2.8.3
       ts-morph: ^12.2.0
+      tsx: ^3.12.6
       typescript: ^4.3.5
     dependencies:
+      '@votingworks/utils': link:../libs/utils
       esbuild: 0.17.6
       esbuild-esm-loader: 0.2.3_esbuild@0.17.6
       ts-morph: 12.2.0
@@ -1778,6 +1781,7 @@ importers:
       eslint-plugin-vx: link:../libs/eslint-plugin-vx
       is-ci-cli: 2.2.0
       prettier: 2.8.3
+      tsx: 3.12.6
       typescript: 4.3.5
 
   libs/@types/compress-commons:
@@ -6286,6 +6290,27 @@ packages:
       react: '>=16.8.0'
     dependencies:
       react: 17.0.2
+    dev: true
+
+  /@esbuild-kit/cjs-loader/2.4.2:
+    resolution: {integrity: sha512-BDXFbYOJzT/NBEtp71cvsrGPwGAMGRB/349rwKuoxNSiKjPraNNnlK6MIIabViCjqZugu6j+xeMDlEkWdHHJSg==}
+    dependencies:
+      '@esbuild-kit/core-utils': 3.1.0
+      get-tsconfig: 4.4.0
+    dev: true
+
+  /@esbuild-kit/core-utils/3.1.0:
+    resolution: {integrity: sha512-Uuk8RpCg/7fdHSceR1M6XbSZFSuMrxcePFuGgyvsBn+u339dk5OeL4jv2EojwTN2st/unJGsVm4qHWjWNmJ/tw==}
+    dependencies:
+      esbuild: 0.17.11
+      source-map-support: 0.5.21
+    dev: true
+
+  /@esbuild-kit/esm-loader/2.5.5:
+    resolution: {integrity: sha512-Qwfvj/qoPbClxCRNuac1Du01r9gvNOT+pMYtJDapfB1eoGN1YlJ1BixLyL9WVENRx5RXgNLdfYdx/CuswlGhMw==}
+    dependencies:
+      '@esbuild-kit/core-utils': 3.1.0
+      get-tsconfig: 4.4.0
     dev: true
 
   /@esbuild/android-arm/0.15.10:
@@ -19901,6 +19926,10 @@ packages:
       call-bind: 1.0.2
       get-intrinsic: 1.2.0
 
+  /get-tsconfig/4.4.0:
+    resolution: {integrity: sha512-0Gdjo/9+FzsYhXCEFueo2aY1z1tpXrxWZzP7k8ul9qt1U5o8rYJwTJYmaeHdrVosYIVYkOy2iwCJ9FdpocJhPQ==}
+    dev: true
+
   /get-value/2.0.6:
     resolution: {integrity: sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==}
     engines: {node: '>=0.10.0'}
@@ -32418,6 +32447,17 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 4.6.3
+
+  /tsx/3.12.6:
+    resolution: {integrity: sha512-q93WgS3lBdHlPgS0h1i+87Pt6n9K/qULIMNYZo07nSeu2z5QE2CellcAZfofVXBo2tQg9av2ZcRMQ2S2i5oadQ==}
+    hasBin: true
+    dependencies:
+      '@esbuild-kit/cjs-loader': 2.4.2
+      '@esbuild-kit/core-utils': 3.1.0
+      '@esbuild-kit/esm-loader': 2.5.5
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
 
   /tty-browserify/0.0.0:
     resolution: {integrity: sha512-JVa5ijo+j/sOoHGjw0sxw734b1LhBkQ3bvUGNdxnVXDCX81Yx7TFgnZygxrIIWn23hbfTaMYLwRmAxFyDuFmIw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1762,7 +1762,7 @@ importers:
       prettier: ^2.8.3
       ts-morph: ^12.2.0
       tsx: ^3.12.6
-      typescript: ^4.3.5
+      typescript: 4.6.3
     dependencies:
       '@votingworks/basics': link:../libs/basics
       '@votingworks/utils': link:../libs/utils
@@ -1774,8 +1774,8 @@ importers:
       '@types/babel__generator': 7.6.4
       '@types/babel__traverse': 7.18.3
       '@types/node': 16.11.29
-      '@typescript-eslint/eslint-plugin': 5.21.0_ajtuzpokmrpgpyirkbadzhgtki
-      '@typescript-eslint/parser': 5.21.0_elepmqlprrtpqqnqqn67do3niu
+      '@typescript-eslint/eslint-plugin': 5.21.0_suuom2mrslqmyia4b7dehhcqhq
+      '@typescript-eslint/parser': 5.21.0_meject34o2v4gmz2y6b4koze4q
       eslint-config-prettier: 8.3.0_eslint@8.33.0
       eslint-import-resolver-node: 0.3.6
       eslint-plugin-import: 2.27.5_2udi2uo2o2xkt52mpd4frcyzwe
@@ -1784,7 +1784,7 @@ importers:
       is-ci-cli: 2.2.0
       prettier: 2.8.3
       tsx: 3.12.6
-      typescript: 4.3.5
+      typescript: 4.6.3
 
   libs/@types/compress-commons:
     specifiers:
@@ -11110,7 +11110,7 @@ packages:
     dev: false
     optional: true
 
-  /@typescript-eslint/eslint-plugin/5.21.0_ajtuzpokmrpgpyirkbadzhgtki:
+  /@typescript-eslint/eslint-plugin/5.21.0_suuom2mrslqmyia4b7dehhcqhq:
     resolution: {integrity: sha512-fTU85q8v5ZLpoZEyn/u1S2qrFOhi33Edo2CZ0+q1gDaWWm0JuPh3bgOyU8lM0edIEYgKLDkPFiZX2MOupgjlyg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -11121,18 +11121,18 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.21.0_elepmqlprrtpqqnqqn67do3niu
+      '@typescript-eslint/parser': 5.21.0_meject34o2v4gmz2y6b4koze4q
       '@typescript-eslint/scope-manager': 5.21.0
-      '@typescript-eslint/type-utils': 5.21.0_elepmqlprrtpqqnqqn67do3niu
-      '@typescript-eslint/utils': 5.21.0_elepmqlprrtpqqnqqn67do3niu
+      '@typescript-eslint/type-utils': 5.21.0_meject34o2v4gmz2y6b4koze4q
+      '@typescript-eslint/utils': 5.21.0_meject34o2v4gmz2y6b4koze4q
       debug: 4.3.4
       eslint: 8.33.0
       functional-red-black-tree: 1.0.1
       ignore: 5.2.0
       regexpp: 3.2.0
       semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.3.5
-      typescript: 4.3.5
+      tsutils: 3.21.0_typescript@4.6.3
+      typescript: 4.6.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11304,7 +11304,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/parser/5.21.0_elepmqlprrtpqqnqqn67do3niu:
+  /@typescript-eslint/parser/5.21.0_meject34o2v4gmz2y6b4koze4q:
     resolution: {integrity: sha512-8RUwTO77hstXUr3pZoWZbRQUxXcSXafZ8/5gpnQCfXvgmP9gpNlRGlWzvfbEQ14TLjmtU8eGnONkff8U2ui2Eg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -11316,10 +11316,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.21.0
       '@typescript-eslint/types': 5.21.0
-      '@typescript-eslint/typescript-estree': 5.21.0_typescript@4.3.5
+      '@typescript-eslint/typescript-estree': 5.21.0_typescript@4.6.3
       debug: 4.3.4
       eslint: 8.33.0
-      typescript: 4.3.5
+      typescript: 4.6.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11383,26 +11383,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/parser/5.49.0_elepmqlprrtpqqnqqn67do3niu:
-    resolution: {integrity: sha512-veDlZN9mUhGqU31Qiv2qEp+XrJj5fgZpJ8PW30sHU+j/8/e5ruAhLaVDAeznS7A7i4ucb/s8IozpDtt9NqCkZg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 5.49.0
-      '@typescript-eslint/types': 5.49.0
-      '@typescript-eslint/typescript-estree': 5.49.0_typescript@4.3.5
-      debug: 4.3.4
-      eslint: 8.33.0
-      typescript: 4.3.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/parser/5.49.0_meject34o2v4gmz2y6b4koze4q:
     resolution: {integrity: sha512-veDlZN9mUhGqU31Qiv2qEp+XrJj5fgZpJ8PW30sHU+j/8/e5ruAhLaVDAeznS7A7i4ucb/s8IozpDtt9NqCkZg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -11460,7 +11440,7 @@ packages:
       '@typescript-eslint/types': 5.49.0
       '@typescript-eslint/visitor-keys': 5.49.0
 
-  /@typescript-eslint/type-utils/5.21.0_elepmqlprrtpqqnqqn67do3niu:
+  /@typescript-eslint/type-utils/5.21.0_meject34o2v4gmz2y6b4koze4q:
     resolution: {integrity: sha512-MxmLZj0tkGlkcZCSE17ORaHl8Th3JQwBzyXL/uvC6sNmu128LsgjTX0NIzy+wdH2J7Pd02GN8FaoudJntFvSOw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -11470,11 +11450,11 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 5.21.0_elepmqlprrtpqqnqqn67do3niu
+      '@typescript-eslint/utils': 5.21.0_meject34o2v4gmz2y6b4koze4q
       debug: 4.3.4
       eslint: 8.33.0
-      tsutils: 3.21.0_typescript@4.3.5
-      typescript: 4.3.5
+      tsutils: 3.21.0_typescript@4.6.3
+      typescript: 4.6.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11580,27 +11560,6 @@ packages:
     resolution: {integrity: sha512-7If46kusG+sSnEpu0yOz2xFv5nRz158nzEXnJFCGVEHWnuzolXKwrH5Bsf9zsNlOQkyZuk0BZKKoJQI+1JPBBg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  /@typescript-eslint/typescript-estree/5.21.0_typescript@4.3.5:
-    resolution: {integrity: sha512-Y8Y2T2FNvm08qlcoSMoNchh9y2Uj3QmjtwNMdRQkcFG7Muz//wfJBGBxh8R7HAGQFpgYpdHqUpEoPQk+q9Kjfg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.21.0
-      '@typescript-eslint/visitor-keys': 5.21.0
-      debug: 4.3.4
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.3.5
-      typescript: 4.3.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/typescript-estree/5.21.0_typescript@4.6.3:
     resolution: {integrity: sha512-Y8Y2T2FNvm08qlcoSMoNchh9y2Uj3QmjtwNMdRQkcFG7Muz//wfJBGBxh8R7HAGQFpgYpdHqUpEoPQk+q9Kjfg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -11683,27 +11642,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/typescript-estree/5.49.0_typescript@4.3.5:
-    resolution: {integrity: sha512-PBdx+V7deZT/3GjNYPVQv1Nc0U46dAHbIuOG8AZ3on3vuEKiPDwFE/lG1snN2eUB9IhF7EyF7K1hmTcLztNIsA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.49.0
-      '@typescript-eslint/visitor-keys': 5.49.0
-      debug: 4.3.4
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.3.5
-      typescript: 4.3.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/typescript-estree/5.49.0_typescript@4.6.3:
     resolution: {integrity: sha512-PBdx+V7deZT/3GjNYPVQv1Nc0U46dAHbIuOG8AZ3on3vuEKiPDwFE/lG1snN2eUB9IhF7EyF7K1hmTcLztNIsA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -11724,17 +11662,17 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/utils/5.21.0_elepmqlprrtpqqnqqn67do3niu:
+  /@typescript-eslint/utils/5.21.0_meject34o2v4gmz2y6b4koze4q:
     resolution: {integrity: sha512-q/emogbND9wry7zxy7VYri+7ydawo2HDZhRZ5k6yggIvXa7PvBbAAZ4PFH/oZLem72ezC4Pr63rJvDK/sTlL8Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@types/json-schema': 7.0.11
-      '@typescript-eslint/parser': 5.49.0_elepmqlprrtpqqnqqn67do3niu
+      '@typescript-eslint/parser': 5.49.0_meject34o2v4gmz2y6b4koze4q
       '@typescript-eslint/scope-manager': 5.21.0
       '@typescript-eslint/types': 5.21.0
-      '@typescript-eslint/typescript-estree': 5.21.0_typescript@4.3.5
+      '@typescript-eslint/typescript-estree': 5.21.0_typescript@4.6.3
       eslint: 8.33.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.33.0
@@ -17589,7 +17527,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.21.0_elepmqlprrtpqqnqqn67do3niu
+      '@typescript-eslint/parser': 5.21.0_meject34o2v4gmz2y6b4koze4q
       debug: 3.2.7
       eslint: 8.33.0
       eslint-import-resolver-node: 0.3.7
@@ -17848,7 +17786,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.21.0_elepmqlprrtpqqnqqn67do3niu
+      '@typescript-eslint/parser': 5.21.0_meject34o2v4gmz2y6b4koze4q
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
@@ -32349,7 +32287,7 @@ packages:
       '@babel/core': 7.20.12
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.4.1
+      jest: 29.4.1_@types+node@16.11.29
       jest-util: 29.4.3
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -32430,16 +32368,6 @@ packages:
 
   /tslib/2.4.0:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
-
-  /tsutils/3.21.0_typescript@4.3.5:
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    dependencies:
-      tslib: 1.14.1
-      typescript: 4.3.5
-    dev: true
 
   /tsutils/3.21.0_typescript@4.6.3:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
@@ -32568,12 +32496,6 @@ packages:
 
   /typescript/4.3.4:
     resolution: {integrity: sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
-    dev: true
-
-  /typescript/4.3.5:
-    resolution: {integrity: sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1749,6 +1749,7 @@ importers:
       '@types/node': 16.11.29
       '@typescript-eslint/eslint-plugin': ^5.21.0
       '@typescript-eslint/parser': ^5.21.0
+      '@votingworks/basics': workspace:*
       '@votingworks/utils': workspace:*
       esbuild: ^0.17.6
       esbuild-esm-loader: ^0.2.3
@@ -1763,6 +1764,7 @@ importers:
       tsx: ^3.12.6
       typescript: ^4.3.5
     dependencies:
+      '@votingworks/basics': link:../libs/basics
       '@votingworks/utils': link:../libs/utils
       esbuild: 0.17.6
       esbuild-esm-loader: 0.2.3_esbuild@0.17.6


### PR DESCRIPTION
## Overview

_(review by commit)_

Moves `Optional` to `@votingworks/basics`. Uses a codemod that can be used to move symbols generally.
<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot
```sh
# update `Dictionary` references from `@votingworks/types` to `@votingworks/basics`
❯ ./bin/codemod-move-symbols --all Dictionary:types:basics
@votingworks/admin-backend: ✅ 1.27s (0 updated)
@votingworks/admin-frontend: src/components/ballot_counts_table.test.tsx: Dictionary: @votingworks/types → @votingworks/basics
@votingworks/admin-frontend: src/components/hand_marked_paper_ballot.tsx: Dictionary: @votingworks/types → @votingworks/basics
@votingworks/admin-frontend: src/config/globals.ts: Dictionary: @votingworks/types → @votingworks/basics
@votingworks/admin-frontend: src/config/types.ts: Dictionary: @votingworks/types → @votingworks/basics
@votingworks/admin-frontend: src/screens/manual_data_import_precinct_screen.tsx: Dictionary: @votingworks/types → @votingworks/basics
@votingworks/admin-frontend: src/screens/printed_ballots_report_screen.tsx: Dictionary: @votingworks/types → @votingworks/basics
@votingworks/admin-frontend: src/utils/election.test.ts: Dictionary: @votingworks/types → @votingworks/basics
@votingworks/admin-frontend: src/utils/exportable_tallies.ts: Dictionary: @votingworks/types → @votingworks/basics
@votingworks/admin-frontend: src/utils/external_tallies.test.ts: Dictionary: @votingworks/types → @votingworks/basics
@votingworks/admin-frontend: src/utils/external_tallies.ts: Dictionary: @votingworks/types → @votingworks/basics
@votingworks/admin-frontend: src/utils/write_ins.test.ts: Dictionary: @votingworks/types → @votingworks/basics
@votingworks/admin-frontend: src/utils/write_ins.ts: Dictionary: @votingworks/types → @votingworks/basics
@votingworks/admin-frontend: test/helpers/build_external_tally.ts: Dictionary: @votingworks/types → @votingworks/basics
@votingworks/admin-frontend: test/util/build_candidate_tallies.tsx: Dictionary: @votingworks/types → @votingworks/basics
@votingworks/admin-frontend: ✅ 1.68s (14 updated)
@votingworks/integration-testing-election-manager: cypress/support/assertions.ts: Dictionary: @votingworks/types → @votingworks/basics
@votingworks/integration-testing-election-manager: ✅ 1.06s (1 updated)
@votingworks/central-scan-backend: src/cvrs/build.ts: Dictionary: @votingworks/types → @votingworks/basics
@votingworks/central-scan-backend: ✅ 958.64ms (1 updated)
@votingworks/central-scan-frontend: ✅ 979.29ms (0 updated)
@votingworks/central-scan-integration-testing: ✅ 700.99ms (0 updated)
@votingworks/mark-backend: ✅ 654.48ms (0 updated)
@votingworks/mark-frontend: src/app_polls_flows.test.tsx: Dictionary: @votingworks/types → @votingworks/basics
@votingworks/mark-frontend: ✅ 1.16s (1 updated)
@votingworks/mark-integration-testing: ✅ 303.26ms (0 updated)
@votingworks/scan-backend: src/cvrs/build.ts: Dictionary: @votingworks/types → @votingworks/basics
@votingworks/scan-backend: ✅ 922.73ms (1 updated)
@votingworks/scan-frontend: src/app_tally_report_paths.test.tsx: Dictionary: @votingworks/types → @votingworks/basics
@votingworks/scan-frontend: src/screens/poll_worker_screen.tsx: Dictionary: @votingworks/types → @votingworks/basics
@votingworks/scan-frontend: ✅ 926.29ms (2 updated)
@votingworks/codemods: ✅ 594.68ms (0 updated)
@votingworks/api: ✅ 508.01ms (0 updated)
@votingworks/auth: ✅ 893.3ms (0 updated)
@votingworks/backend: ✅ 727.17ms (0 updated)
@votingworks/ballot-encoder: ✅ 541.24ms (0 updated)
@votingworks/ballot-interpreter-nh: ✅ 731.28ms (0 updated)
@votingworks/ballot-interpreter-nh-next: ✅ 497.75ms (0 updated)
@votingworks/ballot-interpreter-vx: ✅ 647.38ms (0 updated)
@votingworks/basics: ✅ 322.31ms (0 updated)
@votingworks/cdf-schema-builder: ✅ 346.11ms (0 updated)
@votingworks/custom-scanner: ✅ 755.62ms (0 updated)
@votingworks/cvr-fixture-generator: ✅ 743.79ms (0 updated)
@votingworks/db: ✅ 248.91ms (0 updated)
@votingworks/fixtures: ✅ 935.76ms (0 updated)
@votingworks/grout: ✅ 330.51ms (0 updated)
@votingworks/grout-test-utils: ✅ 580.45ms (0 updated)
@votingworks/image-utils: ✅ 488.8ms (0 updated)
@votingworks/logging: src/logger.ts: Dictionary: @votingworks/types → @votingworks/basics
@votingworks/logging: src/types.ts: Dictionary: @votingworks/types → @votingworks/basics
@votingworks/logging: ✅ 604.51ms (2 updated)
@votingworks/message-coder: ✅ 402.45ms (0 updated)
@votingworks/plustek-scanner: ✅ 635.34ms (0 updated)
@votingworks/res-to-ts: ✅ 510.1ms (0 updated)
@votingworks/test-utils: src/cast_vote_record.ts: Dictionary: @votingworks/types → @votingworks/basics
@votingworks/test-utils: ✅ 537.25ms (1 updated)
@votingworks/types: ✅ 476.36ms (0 updated)
@votingworks/ui: src/tally_report_summary.tsx: Dictionary: @votingworks/types → @votingworks/basics
@votingworks/ui: ✅ 1.14s (1 updated)
@votingworks/utils: src/compressed_tallies.test.ts: Dictionary: @votingworks/types → @votingworks/basics
@votingworks/utils: src/compressed_tallies.ts: Dictionary: @votingworks/types → @votingworks/basics
@votingworks/utils: src/tallies.ts: Dictionary: @votingworks/types → @votingworks/basics
@votingworks/utils: src/types.ts: Dictionary: @votingworks/types → @votingworks/basics
@votingworks/utils: src/votecounting.ts: Dictionary: @votingworks/types → @votingworks/basics
@votingworks/utils: src/votes.ts: Dictionary: @votingworks/types → @votingworks/basics
@votingworks/utils: ✅ 713.5ms (6 updated)
```

## Testing Plan
Automated.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
