### PR TITLE
proof-of-concept for removing `Interpreter#interpretTemplate`

### DIFF
--- a/libs/ballot-interpreter-vx/src/interpreter/enforcing_test_vs_live_mode.test.ts
+++ b/libs/ballot-interpreter-vx/src/interpreter/enforcing_test_vs_live_mode.test.ts
@@ -1,34 +1,30 @@
-import * as oaklawn from '../../test/fixtures/election-4e31cb17d8-ballot-style-77-precinct-oaklawn-branch-library';
 import { Interpreter } from '.';
+import * as oaklawn from '../../test/fixtures/election-4e31cb17d8-ballot-style-77-precinct-oaklawn-branch-library';
+import { buildInterpreterWithFixtures } from '../../test/helpers/fixtures_to_templates';
+import { interpretTemplate } from '../layout';
 
 test('enforcing test vs live mode', async () => {
   const fixtures = oaklawn;
   const { electionDefinition } = fixtures;
   const interpreter = new Interpreter({ electionDefinition });
-  const template = await interpreter.interpretTemplate(
-    await fixtures.blankPage1.imageData(),
-    await fixtures.blankPage1.metadata({ isTestMode: true })
-  );
+  const templatePage1 = await interpretTemplate({
+    electionDefinition,
+    imageData: await fixtures.blankPage1.imageData(),
+    metadata: await fixtures.blankPage1.metadata({ isTestMode: true }),
+    contestOffset: 0,
+  });
 
-  expect(() => interpreter.addTemplate(template)).toThrowError(
+  expect(() => interpreter.addTemplate(templatePage1)).toThrowError(
     'interpreter configured with testMode=false cannot add templates with isTestMode=true'
   );
 
-  interpreter.addTemplate(
-    await interpreter.interpretTemplate(
-      await fixtures.blankPage1.imageData(),
-      await fixtures.blankPage1.metadata()
-    )
-  );
-  interpreter.addTemplate(
-    await interpreter.interpretTemplate(
-      await fixtures.blankPage2.imageData(),
-      await fixtures.blankPage2.metadata()
-    )
-  );
-
   await expect(
-    interpreter.interpretBallot(
+    (
+      await buildInterpreterWithFixtures({
+        electionDefinition,
+        fixtures: [fixtures.blankPage1, fixtures.blankPage2],
+      })
+    ).interpretBallot(
       await fixtures.blankPage1.imageData(),
       await fixtures.blankPage1.metadata({ isTestMode: true })
     )

--- a/libs/ballot-interpreter-vx/src/interpreter/handles_lines_connecting_contest_boxes.test.ts
+++ b/libs/ballot-interpreter-vx/src/interpreter/handles_lines_connecting_contest_boxes.test.ts
@@ -1,5 +1,5 @@
 import * as hamilton from '../../test/fixtures/election-5c6e578acf-state-of-hamilton-2020';
-import { Interpreter } from '.';
+import { buildInterpreterWithFixtures } from '../../test/helpers/fixtures_to_templates';
 
 /**
  * TODO: Enable this test when contest box identification improves.
@@ -10,26 +10,10 @@ import { Interpreter } from '.';
  */
 test.skip('handles lines connecting contest boxes', async () => {
   const { electionDefinition } = hamilton;
-  const interpreter = new Interpreter({ electionDefinition });
-
-  interpreter.addTemplate(
-    await interpreter.interpretTemplate(
-      await hamilton.blankPage1.imageData(),
-      await hamilton.blankPage1.metadata()
-    )
-  );
-  interpreter.addTemplate(
-    await interpreter.interpretTemplate(
-      await hamilton.blankPage2.imageData(),
-      await hamilton.blankPage2.metadata()
-    )
-  );
-  interpreter.addTemplate(
-    await interpreter.interpretTemplate(
-      await hamilton.blankPage3.imageData(),
-      await hamilton.blankPage3.metadata()
-    )
-  );
+  const interpreter = await buildInterpreterWithFixtures({
+    electionDefinition,
+    fixtures: [hamilton.blankPage1, hamilton.blankPage2, hamilton.blankPage3],
+  });
 
   const { ballot } = await interpreter.interpretBallot(
     await hamilton.filledInPage3.imageData()

--- a/libs/ballot-interpreter-vx/src/interpreter/interpret_bailout_on_skew.test.ts
+++ b/libs/ballot-interpreter-vx/src/interpreter/interpret_bailout_on_skew.test.ts
@@ -1,22 +1,15 @@
 import * as m14Mock from '../../test/fixtures/election-60bfbea106-m14-mock';
 import { Interpreter } from '.';
+import { buildInterpreterWithFixtures } from '../../test/helpers/fixtures_to_templates';
 
 test('does not bail out with 7x7 jiggle', async () => {
   const fixtures = m14Mock;
   const { electionDefinition } = fixtures;
-  const interpreter = new Interpreter({ electionDefinition });
-
-  interpreter.addTemplate(
-    await interpreter.interpretTemplate(
-      await fixtures.templatePage1.imageData()
-    )
-  );
-
-  interpreter.addTemplate(
-    await interpreter.interpretTemplate(
-      await fixtures.templatePage2.imageData()
-    )
-  );
+  const interpreter = await buildInterpreterWithFixtures({
+    electionDefinition,
+    fixtures: [fixtures.templatePage1, fixtures.templatePage2],
+    useFixtureMetadata: false,
+  });
 
   const { ballot } = await interpreter.interpretBallot(
     await fixtures.page1.imageData()

--- a/libs/ballot-interpreter-vx/test/helpers/fixtures_to_templates.ts
+++ b/libs/ballot-interpreter-vx/test/helpers/fixtures_to_templates.ts
@@ -1,0 +1,51 @@
+import { iter } from '@votingworks/basics';
+import {
+  BallotPageLayoutWithImage,
+  ElectionDefinition,
+} from '@votingworks/types';
+import { Interpreter } from '../../src';
+import { interpretMultiPageTemplate } from '../../src/layout';
+import { Fixture } from '../fixtures';
+
+export async function* fixturesToTemplates({
+  electionDefinition,
+  fixtures,
+  useFixtureMetadata = true,
+}: {
+  electionDefinition: ElectionDefinition;
+  fixtures: readonly [Fixture, ...Fixture[]];
+  useFixtureMetadata?: boolean;
+}): AsyncGenerator<BallotPageLayoutWithImage> {
+  yield* interpretMultiPageTemplate({
+    electionDefinition,
+    pages: iter(fixtures)
+      .async()
+      .enumerate()
+      .map(async ([i, page]) => ({
+        pageCount: 2,
+        pageNumber: i + 1,
+        page: await page.imageData(),
+      })),
+    metadata: useFixtureMetadata ? await fixtures[0].metadata() : undefined,
+  });
+}
+
+export async function buildInterpreterWithFixtures({
+  electionDefinition,
+  fixtures,
+  useFixtureMetadata = true,
+}: {
+  electionDefinition: ElectionDefinition;
+  fixtures: readonly [Fixture, ...Fixture[]];
+  useFixtureMetadata?: boolean;
+}): Promise<Interpreter> {
+  const interpreter = new Interpreter({ electionDefinition });
+  for await (const template of fixturesToTemplates({
+    electionDefinition,
+    fixtures,
+    useFixtureMetadata,
+  })) {
+    interpreter.addTemplate(template);
+  }
+  return interpreter;
+}


### PR DESCRIPTION
Investigation into how to stop using/remove `Interpreter#interpretTemplate` per https://github.com/votingworks/vxsuite/pull/3180#discussion_r1145148569.