### PR TITLE
[VxScan] Fix undervote warning screen showing two primary buttons

### DIFF
--- a/apps/scan/frontend/src/screens/scan_warning_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_warning_screen.tsx
@@ -226,7 +226,7 @@ function UndervoteWarningScreen({
             Return Ballot
           </Button>{' '}
           or{' '}
-          <Button variant="primary" onPress={() => setConfirmTabulate(true)}>
+          <Button onPress={() => setConfirmTabulate(true)}>
             Cast Ballot As Is
           </Button>
         </ResponsiveButtonParagraph>


### PR DESCRIPTION
## Overview
Noticed the undervote warning screen was showing two primary buttons while auditing VxScan screens. Changing the "Cast Ballot As Is" to a regular button to match the behaviour of the overvote warning screen.

## Demo Video or Screenshot
### Before/After
<img width="300" alt="Screenshot 2023-03-23 at 14 20 22" src="https://user-images.githubusercontent.com/264902/227327345-4a4c4be3-fa1e-4f00-81ba-d95f7d9d6872.png"> <img width="300" alt="Screenshot 2023-03-23 at 14 21 03" src="https://user-images.githubusercontent.com/264902/227327397-dedd3fc6-0d09-4791-9270-ec79c9c7dff6.png">

## Testing Plan
- Visual verification

## Checklist

- [n/a] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [n/a] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
