### PR TITLE
Unconfigure Screen Re-Render Cycle Fix

### DIFF
--- a/apps/admin/frontend/src/screens/unconfigured_screen.tsx
+++ b/apps/admin/frontend/src/screens/unconfigured_screen.tsx
@@ -344,7 +344,7 @@ export function UnconfiguredScreen(): JSX.Element {
           <HorizontalRule />
           <p>
             <Button small onPress={resetUploadFilesAndGoBack}>
-              back
+              Back
             </Button>
           </p>
         </Prose>

--- a/apps/admin/frontend/src/screens/unconfigured_screen.tsx
+++ b/apps/admin/frontend/src/screens/unconfigured_screen.tsx
@@ -242,11 +242,25 @@ export function UnconfiguredScreen(): JSX.Element {
         return;
       }
 
-      setInputConversionFiles(files.inputFiles);
+      if (
+        inputConversionFiles.length !== files.inputFiles.length ||
+        files.inputFiles.some(
+          (inputFile, index) =>
+            inputFile.path !== inputConversionFiles[index].path
+        )
+      ) {
+        setInputConversionFiles(files.inputFiles);
+      }
     } catch (error) {
       console.log('failed updateStatus()', error); // eslint-disable-line no-console
     }
-  }, [client, getOutputFile, isMounted, processInputFiles]);
+  }, [
+    client,
+    getOutputFile,
+    inputConversionFiles,
+    isMounted,
+    processInputFiles,
+  ]);
 
   async function submitFile({ file, name }: InputFile) {
     try {


### PR DESCRIPTION
## Overview

I noticed when working in VxAdmin that the `UnconfiguredScreen` was rendering around 1000 times / second. After some debugging, I found there was re-rendering loop:

1. `UnconfiguredScreen` renders
2. `configureMutation` changes - @jonahkagan, every time we use `useMutation` it's a distinct entity because the `useMutation` function creates and returns a new function. Is this desirable behavior? Could it be memoized?
3. `configureMutateAsync` callback changes
4. `getOutputFile` callback changes
5. `updateStatus` callback changes
6. `useEffect` runs
7. `updateStatus` called
8. `setInputConversionFiles` called
9. `inputConversionFiles` state changes
10. `UnconfiguredScreen` renders
11. ...

I must have introduced this in #3052.

I'm not sure why, but this re-rendering loop was preventing me from accessing the NH File Conversion menu. I would click `Convert from NH File` and the app would freeze, not crash. 

I have a small fix in this PR to limit the cycle and only call `setInputConversionFiles` when necessary. It's not an ideal solution but it is a fix.

The bigger issue seems to be how we're trying to keep the UI state in sync with the converter service state, and doing so outside of `grout` so they don't play nicely. Ideally all the conversion stuff would be moved to the backend but, with much of it intended to leave the product, that seems not worth it at the moment.

## Demo Video or Screenshot

console logs before:
<img width="1272" alt="Screen Shot 2023-03-24 at 1 09 01 PM" src="https://user-images.githubusercontent.com/37960853/227628871-2f927e15-8603-4a02-a06b-99a95f96e9cf.png">

console logs after:
<img width="1247" alt="Screen Shot 2023-03-24 at 1 08 27 PM" src="https://user-images.githubusercontent.com/37960853/227628980-29f831d1-8e98-4629-9bd4-76c55af57763.png">
