### PR TITLE
chore(git): add Rust `target` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 
 # production
 build
+target
 *-*.*.*.tgz
 *.tsbuildinfo
 


### PR DESCRIPTION
## Overview

Rust has a `target` directory that is used for build artifacts. Ignoring it at the root is useful when working on a Rust project that isn't checked into all branches, preventing all the `target` files from being shown as untracked when switching branches.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
