### PR TITLE
refactor(scan): isolate plustek-specific code

### DIFF
--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -38,10 +38,13 @@ import {
   exportCastVoteRecordsToUsbDrive,
 } from './cvrs/export';
 import { PrecinctScannerInterpreter } from './interpret';
-import { PrecinctScannerStateMachine } from './state_machine';
+import {
+  PrecinctScannerStateMachine,
+  PrecinctScannerConfig,
+  PrecinctScannerStatus,
+} from './types';
 import { Workspace } from './util/workspace';
 import { Usb } from './util/usb';
-import { PrecinctScannerConfig, PrecinctScannerStatus } from './types';
 import { getMachineConfig } from './machine_config';
 import { CVR_EXPORT_FORMAT, USE_NH_NEXT } from './globals';
 import { DefaultMarkThresholds } from './store';

--- a/apps/scan/backend/src/index.ts
+++ b/apps/scan/backend/src/index.ts
@@ -1,12 +1,13 @@
 import { LogEventId, Logger, LogSource } from '@votingworks/logging';
-import { createClient } from '@votingworks/plustek-scanner';
+import * as plustekScanner from '@votingworks/plustek-scanner';
 import * as dotenv from 'dotenv';
 import * as dotenvExpand from 'dotenv-expand';
 import fs from 'fs';
 import { NODE_ENV, SCAN_WORKSPACE } from './globals';
 import { createInterpreter, PrecinctScannerInterpreter } from './interpret';
-import * as plustekStateMachine from './state_machine';
+import * as plustekStateMachine from './scanners/plustek/state_machine';
 import * as server from './server';
+import { PrecinctScannerStateMachine } from './types';
 import { createWorkspace, Workspace } from './util/workspace';
 
 export type { Api } from './app';
@@ -57,9 +58,9 @@ async function resolveWorkspace(): Promise<Workspace> {
 function createPrecinctScannerStateMachine(
   workspace: Workspace,
   interpreter: PrecinctScannerInterpreter
-): plustekStateMachine.PrecinctScannerStateMachine {
+): PrecinctScannerStateMachine {
   return plustekStateMachine.createPrecinctScannerStateMachine({
-    createPlustekClient: createClient,
+    createPlustekClient: plustekScanner.createClient,
     workspace,
     interpreter,
     logger,

--- a/apps/scan/backend/src/scanners/plustek/app_config.test.ts
+++ b/apps/scan/backend/src/scanners/plustek/app_config.test.ts
@@ -22,14 +22,13 @@ import {
 import { InsertedSmartCardAuthApi } from '@votingworks/auth';
 import { ElectionDefinition } from '@votingworks/types';
 import {
-  ballotImages,
   configureApp,
   createBallotPackageWithoutTemplates,
   waitForStatus,
-  withApp,
-} from '../test/helpers/app_helpers';
-import { Api } from './app';
-import { SheetInterpretation } from './types';
+} from '../../../test/helpers/shared_helpers';
+import { Api } from '../../app';
+import { SheetInterpretation } from '../../types';
+import { ballotImages, withApp } from '../../../test/helpers/plustek_helpers';
 
 jest.setTimeout(20_000);
 jest.mock('@votingworks/ballot-encoder', () => {

--- a/apps/scan/backend/src/scanners/plustek/app_scan.test.ts
+++ b/apps/scan/backend/src/scanners/plustek/app_scan.test.ts
@@ -16,14 +16,13 @@ import {
 import { Logger } from '@votingworks/logging';
 import { MAX_FAILED_SCAN_ATTEMPTS } from './state_machine';
 import {
-  ballotImages,
   configureApp,
   expectStatus,
   mockInterpretation,
   waitForStatus,
-  withApp,
-} from '../test/helpers/app_helpers';
-import { SheetInterpretation } from './types';
+} from '../../../test/helpers/shared_helpers';
+import { SheetInterpretation } from '../../types';
+import { ballotImages, withApp } from '../../../test/helpers/plustek_helpers';
 
 jest.setTimeout(20_000);
 jest.mock('@votingworks/ballot-encoder', () => {
@@ -434,7 +433,7 @@ test('scan fails due to plustek returning only one file instead of two', async (
       mockPlustek.simulateScanError('only_one_file_returned');
       await waitForStatus(apiClient, {
         state: 'unrecoverable_error',
-        error: 'plustek_error',
+        error: 'client_error',
       });
 
       // Make sure the underlying error got logged correctly

--- a/apps/scan/backend/src/scanners/plustek/app_scan_calibrate.test.ts
+++ b/apps/scan/backend/src/scanners/plustek/app_scan_calibrate.test.ts
@@ -1,10 +1,9 @@
 import {
-  ballotImages,
   configureApp,
   expectStatus,
   waitForStatus,
-  withApp,
-} from '../test/helpers/app_helpers';
+} from '../../../test/helpers/shared_helpers';
+import { ballotImages, withApp } from '../../../test/helpers/plustek_helpers';
 
 jest.setTimeout(20_000);
 jest.mock('@votingworks/ballot-encoder', () => {

--- a/apps/scan/backend/src/scanners/plustek/app_scan_double_sheets.test.ts
+++ b/apps/scan/backend/src/scanners/plustek/app_scan_double_sheets.test.ts
@@ -1,13 +1,12 @@
 import { AdjudicationReason } from '@votingworks/types';
 import {
-  ballotImages,
   configureApp,
   expectStatus,
   mockInterpretation,
   waitForStatus,
-  withApp,
-} from '../test/helpers/app_helpers';
-import { SheetInterpretation } from './types';
+} from '../../../test/helpers/shared_helpers';
+import { SheetInterpretation } from '../../types';
+import { ballotImages, withApp } from '../../../test/helpers/plustek_helpers';
 
 jest.setTimeout(20_000);
 jest.mock('@votingworks/ballot-encoder', () => {

--- a/apps/scan/backend/src/scanners/plustek/app_scan_jam.test.ts
+++ b/apps/scan/backend/src/scanners/plustek/app_scan_jam.test.ts
@@ -1,13 +1,12 @@
 import { AdjudicationReason } from '@votingworks/types';
 import {
-  ballotImages,
   configureApp,
   expectStatus,
   mockInterpretation,
   waitForStatus,
-  withApp,
-} from '../test/helpers/app_helpers';
-import { SheetInterpretation } from './types';
+} from '../../../test/helpers/shared_helpers';
+import { SheetInterpretation } from '../../types';
+import { ballotImages, withApp } from '../../../test/helpers/plustek_helpers';
 
 jest.setTimeout(20_000);
 jest.mock('@votingworks/ballot-encoder', () => {
@@ -44,7 +43,7 @@ test('jam on scan', async () => {
       await apiClient.scanBallot();
       await waitForStatus(apiClient, {
         state: 'recovering_from_error',
-        error: 'plustek_error',
+        error: 'client_error',
       });
       await waitForStatus(apiClient, { state: 'no_paper' });
     }

--- a/apps/scan/backend/src/scanners/plustek/app_scan_power_off.test.ts
+++ b/apps/scan/backend/src/scanners/plustek/app_scan_power_off.test.ts
@@ -1,13 +1,12 @@
 import { AdjudicationReason } from '@votingworks/types';
 import {
-  ballotImages,
   configureApp,
   expectStatus,
   mockInterpretation,
   waitForStatus,
-  withApp,
-} from '../test/helpers/app_helpers';
-import { SheetInterpretation } from './types';
+} from '../../../test/helpers/shared_helpers';
+import { SheetInterpretation } from '../../types';
+import { ballotImages, withApp } from '../../../test/helpers/plustek_helpers';
 
 jest.setTimeout(20_000);
 jest.mock('@votingworks/ballot-encoder', () => {

--- a/apps/scan/backend/src/scanners/plustek/app_scan_precinct_config.test.ts
+++ b/apps/scan/backend/src/scanners/plustek/app_scan_precinct_config.test.ts
@@ -1,11 +1,10 @@
 import {
-  ballotImages,
   configureApp,
   expectStatus,
   waitForStatus,
-  withApp,
-} from '../test/helpers/app_helpers';
-import { SheetInterpretation } from './types';
+} from '../../../test/helpers/shared_helpers';
+import { ballotImages, withApp } from '../../../test/helpers/plustek_helpers';
+import { SheetInterpretation } from '../../types';
 
 jest.setTimeout(20_000);
 jest.mock('@votingworks/ballot-encoder', () => {

--- a/apps/scan/backend/src/scanners/plustek/state_machine.ts
+++ b/apps/scan/backend/src/scanners/plustek/state_machine.ts
@@ -9,13 +9,7 @@ import {
 } from '@votingworks/plustek-scanner';
 import { v4 as uuid } from 'uuid';
 import { Id, SheetOf } from '@votingworks/types';
-import {
-  assert,
-  throwIllegalValue,
-  err,
-  ok,
-  Result,
-} from '@votingworks/basics';
+import { assert, throwIllegalValue, err, ok } from '@votingworks/basics';
 import { switchMap, throwError, timeout, timer } from 'rxjs';
 import {
   assign as xassign,
@@ -31,19 +25,20 @@ import {
 } from 'xstate';
 import { waitFor } from 'xstate/lib/waitFor';
 import { LogEventId, Logger, LogLine } from '@votingworks/logging';
-import { PLUSTEKCTL_PATH } from './globals';
+import { PLUSTEKCTL_PATH } from '../../globals';
 import {
   SheetInterpretationWithPages,
   PrecinctScannerInterpreter,
-} from './interpret';
-import { Store } from './store';
-import { Workspace } from './util/workspace';
-import { rootDebug } from './util/debug';
+} from '../../interpret';
+import { Store } from '../../store';
+import { Workspace } from '../../util/workspace';
+import { rootDebug } from '../../util/debug';
 import {
   PrecinctScannerErrorType,
   PrecinctScannerMachineStatus,
+  PrecinctScannerStateMachine,
   SheetInterpretation,
-} from './types';
+} from '../../types';
 
 const debug = rootDebug.extend('state-machine');
 const debugPaperStatus = debug.extend('paper-status');
@@ -985,26 +980,7 @@ function setupLogging(
 }
 
 function errorToString(error: NonNullable<Context['error']>) {
-  return error instanceof PrecinctScannerError ? error.type : 'plustek_error';
-}
-
-/**
- * The precinct scanner state machine can:
- * - return its status
- * - accept scanning commands
- * - calibrate
- */
-export interface PrecinctScannerStateMachine {
-  status: () => PrecinctScannerMachineStatus;
-  // The commands are non-blocking and do not return a result. They just send an
-  // event to the machine. The effects of the event (or any error) will show up
-  // in the status.
-  scan: () => void;
-  accept: () => void;
-  return: () => void;
-  // Calibrate is the exception, which blocks until calibration is finished and
-  // returns a result.
-  calibrate?: () => Promise<Result<void, string>>;
+  return error instanceof PrecinctScannerError ? error.type : 'client_error';
 }
 
 /**

--- a/apps/scan/backend/src/server.test.ts
+++ b/apps/scan/backend/src/server.test.ts
@@ -5,7 +5,7 @@ import { buildApp } from './app';
 import { PORT } from './globals';
 import { createInterpreter } from './interpret';
 import { start } from './server';
-import { PrecinctScannerStateMachine } from './state_machine';
+import { PrecinctScannerStateMachine } from './types';
 import { createWorkspace, Workspace } from './util/workspace';
 
 jest.mock('./app');

--- a/apps/scan/backend/src/server.ts
+++ b/apps/scan/backend/src/server.ts
@@ -15,7 +15,7 @@ import {
 import { buildApp } from './app';
 import { PORT } from './globals';
 import { PrecinctScannerInterpreter } from './interpret';
-import { PrecinctScannerStateMachine } from './state_machine';
+import { PrecinctScannerStateMachine } from './types';
 import { Usb } from './util/usb';
 import { Workspace } from './util/workspace';
 

--- a/apps/scan/backend/src/types.ts
+++ b/apps/scan/backend/src/types.ts
@@ -1,3 +1,4 @@
+import { Result } from '@votingworks/basics';
 import {
   AdjudicationReasonInfo,
   ElectionDefinition,
@@ -75,7 +76,7 @@ export type PrecinctScannerErrorType =
   | 'unexpected_paper_status'
   | 'unexpected_event'
   | 'calibration_failed'
-  | 'plustek_error';
+  | 'client_error';
 export interface PrecinctScannerMachineStatus {
   state: PrecinctScannerState;
   interpretation?: SheetInterpretation;
@@ -97,4 +98,23 @@ export interface PrecinctScannerConfig {
   isTestMode: boolean;
   pollsState: PollsState;
   ballotCountWhenBallotBagLastReplaced: number;
+}
+
+/**
+ * The precinct scanner state machine can:
+ * - return its status
+ * - accept scanning commands
+ * - calibrate
+ */
+export interface PrecinctScannerStateMachine {
+  status: () => PrecinctScannerMachineStatus;
+  // The commands are non-blocking and do not return a result. They just send an
+  // event to the machine. The effects of the event (or any error) will show up
+  // in the status.
+  scan: () => void;
+  accept: () => void;
+  return: () => void;
+  // Calibrate is the exception, which blocks until calibration is finished and
+  // returns a result.
+  calibrate?: () => Promise<Result<void, string>>;
 }

--- a/apps/scan/backend/test/helpers/plustek_helpers.ts
+++ b/apps/scan/backend/test/helpers/plustek_helpers.ts
@@ -1,0 +1,165 @@
+import {
+  InsertedSmartCardAuthApi,
+  buildMockInsertedSmartCardAuth,
+} from '@votingworks/auth';
+import { Result, deferred, ok } from '@votingworks/basics';
+import {
+  electionFamousNames2021Fixtures,
+  sampleBallotImages,
+} from '@votingworks/fixtures';
+import * as grout from '@votingworks/grout';
+import { Logger, fakeLogger } from '@votingworks/logging';
+import {
+  MockScannerClient,
+  MockScannerClientOptions,
+  ScannerClient,
+} from '@votingworks/plustek-scanner';
+import { Buffer } from 'buffer';
+import { Application } from 'express';
+import { Server } from 'http';
+import { AddressInfo } from 'net';
+import tmp from 'tmp';
+import { Api, buildApp } from '../../src/app';
+import {
+  PrecinctScannerInterpreter,
+  createInterpreter,
+} from '../../src/interpret';
+import {
+  Delays,
+  createPrecinctScannerStateMachine,
+} from '../../src/scanners/plustek/state_machine';
+import { Usb } from '../../src/util/usb';
+import { Workspace, createWorkspace } from '../../src/util/workspace';
+import { createMockUsb, expectStatus, waitForStatus } from './shared_helpers';
+
+type MockFileTree = MockFile | MockDirectory;
+type MockFile = Buffer;
+interface MockDirectory {
+  [name: string]: MockFileTree;
+}
+
+interface MockUsb {
+  insertUsbDrive(contents: MockFileTree): void;
+  removeUsbDrive(): void;
+  mock: jest.Mocked<Usb>;
+}
+
+export async function withApp(
+  {
+    delays = {},
+    mockPlustekOptions = {},
+    preconfiguredWorkspace,
+  }: {
+    delays?: Partial<Delays>;
+    mockPlustekOptions?: Partial<MockScannerClientOptions>;
+    preconfiguredWorkspace?: Workspace;
+  },
+  fn: (context: {
+    apiClient: grout.Client<Api>;
+    app: Application;
+    mockAuth: InsertedSmartCardAuthApi;
+    mockPlustek: MockScannerClient;
+    workspace: Workspace;
+    mockUsb: MockUsb;
+    logger: Logger;
+    interpreter: PrecinctScannerInterpreter;
+    server: Server;
+  }) => Promise<void>
+): Promise<void> {
+  const mockAuth = buildMockInsertedSmartCardAuth();
+  const logger = fakeLogger();
+  const workspace =
+    preconfiguredWorkspace ?? (await createWorkspace(tmp.dirSync().name));
+  const mockPlustek = new MockScannerClient({
+    toggleHoldDuration: 100,
+    passthroughDuration: 100,
+    ...mockPlustekOptions,
+  });
+  const deferredConnect = deferred<void>();
+  async function createPlustekClient(): Promise<Result<ScannerClient, Error>> {
+    await mockPlustek.connect();
+    await deferredConnect.promise;
+    return ok(mockPlustek);
+  }
+  const interpreter = createInterpreter();
+  const precinctScannerMachine = createPrecinctScannerStateMachine({
+    createPlustekClient,
+    workspace,
+    interpreter,
+    logger,
+    delays: {
+      DELAY_RECONNECT: 100,
+      DELAY_ACCEPTED_READY_FOR_NEXT_BALLOT: 100,
+      DELAY_ACCEPTED_RESET_TO_NO_PAPER: 200,
+      DELAY_PAPER_STATUS_POLLING_INTERVAL: 50,
+      ...delays,
+    },
+  });
+  const mockUsb = createMockUsb();
+  const app = buildApp(
+    mockAuth,
+    precinctScannerMachine,
+    interpreter,
+    workspace,
+    mockUsb.mock,
+    logger
+  );
+
+  const server = app.listen();
+  const { port } = server.address() as AddressInfo;
+  const baseUrl = `http://localhost:${port}/api`;
+
+  const apiClient = grout.createClient<Api>({ baseUrl });
+
+  await expectStatus(apiClient, { state: 'connecting' });
+  deferredConnect.resolve();
+  await waitForStatus(apiClient, { state: 'no_paper' });
+
+  try {
+    await fn({
+      apiClient,
+      app,
+      mockAuth,
+      mockPlustek,
+      workspace,
+      mockUsb,
+      logger,
+      interpreter,
+      server,
+    });
+  } finally {
+    const { promise, resolve, reject } = deferred<void>();
+    server.close((error) => (error ? reject(error) : resolve()));
+    await promise;
+    void mockPlustek.stop();
+    workspace.reset();
+  }
+}
+
+export const ballotImages = {
+  completeHmpb: [
+    electionFamousNames2021Fixtures.handMarkedBallotCompletePage1.asFilePath(),
+    electionFamousNames2021Fixtures.handMarkedBallotCompletePage2.asFilePath(),
+  ],
+  completeBmd: [
+    electionFamousNames2021Fixtures.machineMarkedBallotPage1.asFilePath(),
+    electionFamousNames2021Fixtures.machineMarkedBallotPage2.asFilePath(),
+  ],
+  unmarkedHmpb: [
+    electionFamousNames2021Fixtures.handMarkedBallotUnmarkedPage1.asFilePath(),
+    electionFamousNames2021Fixtures.handMarkedBallotUnmarkedPage2.asFilePath(),
+  ],
+  wrongElection: [
+    // A BMD ballot front from a different election
+    sampleBallotImages.sampleBatch1Ballot1.asFilePath(),
+    // Blank BMD ballot back
+    electionFamousNames2021Fixtures.machineMarkedBallotPage2.asFilePath(),
+  ],
+  // The interpreter expects two different image files, so we use two
+  // different blank page images
+  blankSheet: [
+    sampleBallotImages.blankPage.asFilePath(),
+    // Blank BMD ballot back
+    electionFamousNames2021Fixtures.machineMarkedBallotPage2.asFilePath(),
+  ],
+} as const;

--- a/apps/scan/frontend/src/screens/scan_error_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_error_screen.tsx
@@ -51,7 +51,7 @@ export function ScanErrorScreen({
       case 'scanning_timed_out':
       case 'unexpected_paper_status':
       case 'unexpected_event':
-      case 'plustek_error':
+      case 'client_error':
         // These cases require restart, so we don't need to show an error
         // message, since that's handled below.
         return undefined;
@@ -193,7 +193,7 @@ export function UnexpectedPlustekErrorPreview(): JSX.Element {
   return (
     <ScanErrorScreen
       isTestMode={false}
-      error="plustek_error"
+      error="client_error"
       scannedBallotCount={42}
     />
   );


### PR DESCRIPTION
## Overview

<!-- add a link to a GitHub Issue here -->
Progress toward #3166. I'm landing this separately because I've done this bit three times now and `main` keeps changing out from under me and generates conflicts in ways that are hard to resolve.

The next step will be to introduce the Custom scanner support alongside the plustek support.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
