### PR TITLE
test(utils): fix `-0` issue

### DIFF
--- a/libs/utils/src/json_stream.test.ts
+++ b/libs/utils/src/json_stream.test.ts
@@ -15,6 +15,9 @@ async function asString<T>(
 
 test('number', async () => {
   expect(await asString(1)).toEqual('1');
+  expect(await asString(NaN)).toEqual('null');
+  expect(await asString(0)).toEqual('0');
+  expect(await asString(-0)).toEqual('0');
 });
 
 test('string', async () => {
@@ -103,17 +106,12 @@ test('fails with non-serializable objects', async () => {
 
 test('generates correct JSON', async () => {
   await fc.assert(
-    fc.asyncProperty(
-      // filter out -0 because JSON.stringify() converts it to 0
-      fc.jsonObject().filter((v) => !Object.is(v, -0)),
-      fc.boolean(),
-      async (input, compact) => {
-        expect(
-          JSON.parse(
-            await asString(input as JsonStreamInput<unknown>, { compact })
-          )
-        ).toEqual(input);
-      }
-    )
+    fc.asyncProperty(fc.jsonObject(), fc.boolean(), async (input, compact) => {
+      expect(
+        JSON.parse(
+          await asString(input as JsonStreamInput<unknown>, { compact })
+        )
+      ).toEqual(JSON.parse(JSON.stringify(input)));
+    })
   );
 });


### PR DESCRIPTION

## Overview
I'd previously tried to address an issue with this test failing due to `-0` in #3174, but I only filtered `-0` at the top level, so e.g. `{"":-0}` could [still cause issues](https://app.circleci.com/pipelines/github/votingworks/vxsuite/8617/workflows/77db4d0a-38ef-4164-b940-dae71d66a6b7/jobs/238226). This commit fixes the issue by running the input through `JSON.parse(JSON.stringify(…))` which also drops `-0`.

<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot
n/a

## Testing Plan
Automated.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
