### PR TITLE
feat(basics): add `#flatMap`

### DIFF
--- a/libs/basics/src/iterators/async_iterator_plus.test.ts
+++ b/libs/basics/src/iterators/async_iterator_plus.test.ts
@@ -81,12 +81,12 @@ test('chain', async () => {
 });
 
 test('zip', async () => {
-  expect(await iter([]).async().zip(iter([]).async()).toArray()).toEqual([]);
+  expect(await iter([]).async().zip(iter([])).toArray()).toEqual([]);
   expect(await iter([1]).async().zip().toArray()).toEqual([[1]]);
   expect(
     await iter([1])
       .async()
-      .zip(iter([2]).async())
+      .zip(iter([2]))
       .toArray()
   ).toEqual([[1, 2]]);
   expect(
@@ -306,6 +306,30 @@ test('first', async () => {
   expect(await iter([]).async().first()).toEqual(undefined);
   expect(await iter([1]).async().first()).toEqual(1);
   expect(await iter([1, 2, 3]).async().first()).toEqual(1);
+});
+
+test('flatMap', async () => {
+  expect(
+    await iter([])
+      .async()
+      .flatMap(() => [])
+      .toArray()
+  ).toEqual([]);
+  expect(
+    await iter([1, 2, 3])
+      .async()
+      .flatMap((a) => [a, a])
+      .toArray()
+  ).toEqual([1, 1, 2, 2, 3, 3]);
+  expect(
+    await iter([1, 2, 3])
+      .async()
+      .flatMap(async function* double(a) {
+        yield await Promise.resolve(a);
+        yield a;
+      })
+      .toArray()
+  ).toEqual([1, 1, 2, 2, 3, 3]);
 });
 
 test('last', async () => {

--- a/libs/basics/src/iterators/async_iterator_plus.ts
+++ b/libs/basics/src/iterators/async_iterator_plus.ts
@@ -153,6 +153,21 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
     return (await iterable[Symbol.asyncIterator]().next()).value;
   }
 
+  flatMap<U>(
+    fn: (value: T, index: number) => Iterable<U> | AsyncIterable<U>
+  ): AsyncIteratorPlus<U> {
+    const { iterable } = this;
+    return new AsyncIteratorPlusImpl(
+      (async function* gen() {
+        let index = 0;
+        for await (const value of iterable) {
+          yield* fn(value, index);
+          index += 1;
+        }
+      })()
+    ) as AsyncIteratorPlus<U>;
+  }
+
   async last(): Promise<T | undefined> {
     let lastElement: T | undefined;
     for await (const it of this.iterable) {
@@ -335,35 +350,41 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   }
 
   zip(): AsyncIteratorPlus<[T]>;
-  zip<U>(other: AsyncIterable<U>): AsyncIteratorPlus<[T, U]>;
+  zip<U>(other: Iterable<U> | AsyncIterable<U>): AsyncIteratorPlus<[T, U]>;
   zip<U, V>(
-    other1: AsyncIterable<U>,
-    other2: AsyncIterable<V>
+    other1: Iterable<U> | AsyncIterable<U>,
+    other2: Iterable<V> | AsyncIterable<V>
   ): AsyncIteratorPlus<[T, U, V]>;
   zip<U, V, W>(
-    other1: AsyncIterable<U>,
-    other2: AsyncIterable<V>,
-    other3: AsyncIterable<W>
+    other1: Iterable<U> | AsyncIterable<U>,
+    other2: Iterable<V> | AsyncIterable<V>,
+    other3: Iterable<W> | AsyncIterable<W>
   ): AsyncIteratorPlus<[T, U, V, W]>;
   zip<U, V, W, X>(
-    other1: AsyncIterable<U>,
-    other2: AsyncIterable<V>,
-    other3: AsyncIterable<W>,
-    other4: AsyncIterable<X>
+    other1: Iterable<U> | AsyncIterable<U>,
+    other2: Iterable<V> | AsyncIterable<V>,
+    other3: Iterable<W> | AsyncIterable<W>,
+    other4: Iterable<X> | AsyncIterable<X>
   ): AsyncIteratorPlus<[T, U, V, W, X]>;
   zip<U, V, W, X, Y>(
-    other1: AsyncIterable<U>,
-    other2: AsyncIterable<V>,
-    other3: AsyncIterable<W>,
-    other4: AsyncIterable<X>,
-    other5: AsyncIterable<Y>
+    other1: Iterable<U> | AsyncIterable<U>,
+    other2: Iterable<V> | AsyncIterable<V>,
+    other3: Iterable<W> | AsyncIterable<W>,
+    other4: Iterable<X> | AsyncIterable<X>,
+    other5: Iterable<Y> | AsyncIterable<Y>
   ): AsyncIteratorPlus<[T, U, V, W, X, Y]>;
-  zip(...others: Array<AsyncIterable<unknown>>): AsyncIteratorPlus<unknown[]> {
+  zip(
+    ...others: Array<Iterable<unknown> | AsyncIterable<unknown>>
+  ): AsyncIteratorPlus<unknown[]> {
     const { iterable } = this;
     return new AsyncIteratorPlusImpl(
       (async function* gen() {
-        const iterators = [iterable, ...others].map((it) =>
-          it[Symbol.asyncIterator]()
+        const iterators = [iterable, ...others].map(
+          (it) =>
+            /* istanbul ignore next */
+            (it as AsyncIterable<unknown>)[Symbol.asyncIterator]?.() ??
+            /* istanbul ignore next */
+            (it as Iterable<unknown>)[Symbol.iterator]?.()
         );
 
         while (true) {
@@ -385,28 +406,28 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   }
 
   zipMin(): AsyncIteratorPlus<[T]>;
-  zipMin<U>(other: AsyncIterable<U>): AsyncIteratorPlus<[T, U]>;
+  zipMin<U>(other: Iterable<U> | AsyncIterable<U>): AsyncIteratorPlus<[T, U]>;
   zipMin<U, V>(
-    other1: AsyncIterable<U>,
-    other2: AsyncIterable<V>
+    other1: Iterable<U> | AsyncIterable<U>,
+    other2: Iterable<V> | AsyncIterable<V>
   ): AsyncIteratorPlus<[T, U, V]>;
   zipMin<U, V, W>(
-    other1: AsyncIterable<U>,
-    other2: AsyncIterable<V>,
-    other3: AsyncIterable<W>
+    other1: Iterable<U> | AsyncIterable<U>,
+    other2: Iterable<V> | AsyncIterable<V>,
+    other3: Iterable<W> | AsyncIterable<W>
   ): AsyncIteratorPlus<[T, U, V, W]>;
   zipMin<U, V, W, X>(
-    other1: AsyncIterable<U>,
-    other2: AsyncIterable<V>,
-    other3: AsyncIterable<W>,
-    other4: AsyncIterable<X>
+    other1: Iterable<U> | AsyncIterable<U>,
+    other2: Iterable<V> | AsyncIterable<V>,
+    other3: Iterable<W> | AsyncIterable<W>,
+    other4: Iterable<X> | AsyncIterable<X>
   ): AsyncIteratorPlus<[T, U, V, W, X]>;
   zipMin<U, V, W, X, Y>(
-    other1: AsyncIterable<U>,
-    other2: AsyncIterable<V>,
-    other3: AsyncIterable<W>,
-    other4: AsyncIterable<X>,
-    other5: AsyncIterable<Y>
+    other1: Iterable<U> | AsyncIterable<U>,
+    other2: Iterable<V> | AsyncIterable<V>,
+    other3: Iterable<W> | AsyncIterable<W>,
+    other4: Iterable<X> | AsyncIterable<X>,
+    other5: Iterable<Y> | AsyncIterable<Y>
   ): AsyncIteratorPlus<[T, U, V, W, X, Y]>;
   zipMin(
     ...others: Array<AsyncIterable<unknown>>

--- a/libs/basics/src/iterators/iterator_plus.test.ts
+++ b/libs/basics/src/iterators/iterator_plus.test.ts
@@ -227,6 +227,27 @@ test('first', () => {
   expect(iter([1, 2, 3]).first()).toEqual(1);
 });
 
+test('flatMap', () => {
+  expect(
+    iter([])
+      .flatMap(() => [])
+      .toArray()
+  ).toEqual([]);
+  expect(
+    iter([1, 2, 3])
+      .flatMap((a) => [a, a])
+      .toArray()
+  ).toEqual([1, 1, 2, 2, 3, 3]);
+  expect(
+    iter([1, 2, 3])
+      .flatMap(function* double(a) {
+        yield a;
+        yield a;
+      })
+      .toArray()
+  ).toEqual([1, 1, 2, 2, 3, 3]);
+});
+
 test('last', () => {
   expect(iter([]).last()).toEqual(undefined);
   expect(iter([1]).last()).toEqual(1);

--- a/libs/basics/src/iterators/iterator_plus.ts
+++ b/libs/basics/src/iterators/iterator_plus.ts
@@ -162,6 +162,19 @@ export class IteratorPlusImpl<T> implements IteratorPlus<T>, AsyncIterable<T> {
     return iterable[Symbol.iterator]().next().value;
   }
 
+  flatMap<U>(fn: (value: T, index: number) => Iterable<U>): IteratorPlus<U> {
+    const { iterable } = this;
+    return new IteratorPlusImpl(
+      (function* gen() {
+        let index = 0;
+        for (const value of iterable) {
+          yield* fn(value, index);
+          index += 1;
+        }
+      })()
+    );
+  }
+
   last(): T | undefined {
     let lastElement: T | undefined;
     for (const it of this.iterable) {

--- a/libs/basics/src/iterators/types.ts
+++ b/libs/basics/src/iterators/types.ts
@@ -80,6 +80,11 @@ export interface IteratorPlus<T> extends Iterable<T> {
   first(): T | undefined;
 
   /**
+   * Maps elements to an iterable of `U` and flattens the result.
+   */
+  flatMap<U>(fn: (value: T, index: number) => Iterable<U>): IteratorPlus<U>;
+
+  /**
    * Returns the last element of `this` or `undefined` if `this` is empty.
    * Consumes the entire contained iterable.
    */
@@ -396,6 +401,13 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
   first(): Promise<T | undefined>;
 
   /**
+   * Maps elements to an async iterable of `U` and flattens the result.
+   */
+  flatMap<U>(
+    fn: (value: T, index: number) => Iterable<U> | AsyncIterable<U>
+  ): AsyncIteratorPlus<U>;
+
+  /**
    * Returns the last element of `this` or `undefined` if `this` is empty.
    * Consumes the entire contained iterable.
    */
@@ -524,7 +536,7 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
    *
    * @throws if not all iterables are the same length
    */
-  zip<U>(other: AsyncIterable<U>): AsyncIteratorPlus<[T, U]>;
+  zip<U>(other: Iterable<U> | AsyncIterable<U>): AsyncIteratorPlus<[T, U]>;
 
   /**
    * Yields tuples of size 3 with elements from `this`, `other1`, and `other2`.
@@ -532,8 +544,8 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
    * @throws if not all iterables are the same length
    */
   zip<U, V>(
-    other1: AsyncIterable<U>,
-    other2: AsyncIterable<V>
+    other1: Iterable<U> | AsyncIterable<U>,
+    other2: Iterable<V> | AsyncIterable<V>
   ): AsyncIteratorPlus<[T, U, V]>;
 
   /**
@@ -543,9 +555,9 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
    * @throws if not all iterables are the same length
    */
   zip<U, V, W>(
-    other1: AsyncIterable<U>,
-    other2: AsyncIterable<V>,
-    other3: AsyncIterable<W>
+    other1: Iterable<U> | AsyncIterable<U>,
+    other2: Iterable<V> | AsyncIterable<V>,
+    other3: Iterable<W> | AsyncIterable<W>
   ): AsyncIteratorPlus<[T, U, V, W]>;
 
   /**
@@ -555,10 +567,10 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
    * @throws if not all iterables are the same length
    */
   zip<U, V, W, X>(
-    other1: AsyncIterable<U>,
-    other2: AsyncIterable<V>,
-    other3: AsyncIterable<W>,
-    other4: AsyncIterable<X>
+    other1: Iterable<U> | AsyncIterable<U>,
+    other2: Iterable<V> | AsyncIterable<V>,
+    other3: Iterable<W> | AsyncIterable<W>,
+    other4: Iterable<X> | AsyncIterable<X>
   ): AsyncIteratorPlus<[T, U, V, W, X]>;
 
   /**
@@ -568,11 +580,11 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
    * @throws if not all iterables are the same length
    */
   zip<U, V, W, X, Y>(
-    other1: AsyncIterable<U>,
-    other2: AsyncIterable<V>,
-    other3: AsyncIterable<W>,
-    other4: AsyncIterable<X>,
-    other5: AsyncIterable<Y>
+    other1: Iterable<U> | AsyncIterable<U>,
+    other2: Iterable<V> | AsyncIterable<V>,
+    other3: Iterable<W> | AsyncIterable<W>,
+    other4: Iterable<X> | AsyncIterable<X>,
+    other5: Iterable<Y> | AsyncIterable<Y>
   ): AsyncIteratorPlus<[T, U, V, W, X, Y]>;
 
   /**
@@ -584,15 +596,15 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
    * Yields tuples of size 2 with elements from `this` and `other` until one
    * iterable is exhausted.
    */
-  zipMin<U>(other: AsyncIterable<U>): AsyncIteratorPlus<[T, U]>;
+  zipMin<U>(other: Iterable<U> | AsyncIterable<U>): AsyncIteratorPlus<[T, U]>;
 
   /**
    * Yields tuples of size 3 with elements from `this`, `other1`, and `other2`
    * until one iterable is exhausted.
    */
   zipMin<U, V>(
-    other1: AsyncIterable<U>,
-    other2: AsyncIterable<V>
+    other1: Iterable<U> | AsyncIterable<U>,
+    other2: Iterable<V> | AsyncIterable<V>
   ): AsyncIteratorPlus<[T, U, V]>;
 
   /**
@@ -600,9 +612,9 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
    * `other3` until one iterable is exhausted.
    */
   zipMin<U, V, W>(
-    other1: AsyncIterable<U>,
-    other2: AsyncIterable<V>,
-    other3: AsyncIterable<W>
+    other1: Iterable<U> | AsyncIterable<U>,
+    other2: Iterable<V> | AsyncIterable<V>,
+    other3: Iterable<W> | AsyncIterable<W>
   ): AsyncIteratorPlus<[T, U, V, W]>;
 
   /**
@@ -610,10 +622,10 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
    * `other3`, and `other4` until one iterable is exhausted.
    */
   zipMin<U, V, W, X>(
-    other1: AsyncIterable<U>,
-    other2: AsyncIterable<V>,
-    other3: AsyncIterable<W>,
-    other4: AsyncIterable<X>
+    other1: Iterable<U> | AsyncIterable<U>,
+    other2: Iterable<V> | AsyncIterable<V>,
+    other3: Iterable<W> | AsyncIterable<W>,
+    other4: Iterable<X> | AsyncIterable<X>
   ): AsyncIteratorPlus<[T, U, V, W, X]>;
 
   /**
@@ -621,10 +633,10 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
    * `other3`, `other4`, and `other5` until one iterable is exhausted.
    */
   zipMin<U, V, W, X, Y>(
-    other1: AsyncIterable<U>,
-    other2: AsyncIterable<V>,
-    other3: AsyncIterable<W>,
-    other4: AsyncIterable<X>,
-    other5: AsyncIterable<Y>
+    other1: Iterable<U> | AsyncIterable<U>,
+    other2: Iterable<V> | AsyncIterable<V>,
+    other3: Iterable<W> | AsyncIterable<W>,
+    other4: Iterable<X> | AsyncIterable<X>,
+    other5: Iterable<Y> | AsyncIterable<Y>
   ): AsyncIteratorPlus<[T, U, V, W, X, Y]>;
 }


### PR DESCRIPTION

## Overview
Also improves support for the async iterable methods to take either async or sync iterables.

<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot
```ts
/// BEFORE
const loadedLayouts: BallotPageLayoutWithImage[] = [];

for (const [pdf, layouts] of templates) {
  for await (const { page, pageNumber } of pdfToImages(pdf, { scale: 2 })) {
    const ballotPageLayout = layouts[pageNumber - 1];
    loadedLayouts.push({
      ballotPageLayout,
      imageData: page,
    });
  }
}

this.cachedLayouts = loadedLayouts;
return loadedLayouts;

/// AFTER
this.cachedLayouts = await iter(templates)
  .async()
  .flatMap(([pdf, layouts]) =>
    iter(pdfToImages(pdf, { scale: 2 }))
      .zip(layouts)
      .map(([{ page: imageData }, ballotPageLayout]) => ({
        ballotPageLayout,
        imageData,
      }))
  )
  .toArray();
return this.cachedLayouts;
```

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
