### PR TITLE
write default system settings

### DIFF
--- a/apps/admin/frontend/src/components/export_election_ballot_package_modal_button.tsx
+++ b/apps/admin/frontend/src/components/export_election_ballot_package_modal_button.tsx
@@ -7,6 +7,7 @@ import { interpretTemplate } from '@votingworks/ballot-interpreter-vx';
 import {
   BallotPageLayout,
   BallotType,
+  DEFAULT_SYSTEM_SETTINGS,
   getElectionLocales,
   getPrecinctById,
   HmpbBallotPageMetadata,
@@ -198,7 +199,7 @@ export function ExportElectionBallotPackageModalButton(): JSX.Element {
       await state.archive.file('election.json', electionData);
       await state.archive.file(
         'systemSettings.json',
-        JSON.stringify(systemSettings || {}, null, 2)
+        JSON.stringify(systemSettings || DEFAULT_SYSTEM_SETTINGS, null, 2)
       );
       await state.archive.file(
         'manifest.json',


### PR DESCRIPTION
## Overview
Write `DEFAULT_SYSTEM_SETTINGS` from VxAdmin.
Fixes a bug where VxAdmin writes `{}` if no system settings are present, but other machines can't read empty object for system settings.

## Demo Video or Screenshot

## Testing Plan
Will do in a separate PR to unblock others

## Checklist
Does not apply
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
