### PR TITLE
Vxscan vvsg ballot counter

### DIFF
--- a/apps/mark/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
@@ -188,16 +188,16 @@ exports[`Single Seat Contest 1`] = `
   tabindex="-1"
 >
   <div
-    class="sc-giYgFv jxDALN"
+    class="sc-cTApHj iSLYgx"
   >
     <div
       class="c1"
     >
       <div
-        class="sc-hKwCoD gmiWky"
+        class="sc-fotPbf hvTglz"
       >
         <p
-          class="sc-bdvvaa iybVtA"
+          class="sc-bqiQRQ jKCqve"
         >
           This is the
            
@@ -213,14 +213,14 @@ exports[`Single Seat Contest 1`] = `
       </div>
     </div>
     <main
-      class="sc-ezbkgU jVInCL"
+      class="sc-jObXwK jYtfDo"
     >
       <div
         class="c2"
         id="contest-header"
       >
         <div
-          class="sc-hKwCoD gmiWky"
+          class="sc-fotPbf hvTglz"
           id="audiofocus"
         >
           <h1
@@ -235,7 +235,7 @@ exports[`Single Seat Contest 1`] = `
           </h1>
           <p>
             <span
-              class="sc-bdvvaa NLRzK"
+              class="sc-bqiQRQ bIFmdQ"
             >
               Vote for 
               1
@@ -274,13 +274,13 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Joseph Barchi and Joseph Hallaren
@@ -300,13 +300,13 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Adam Cramer and Greg Vuocolo
@@ -326,13 +326,13 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Daniel Court and Amy Blumhardt
@@ -352,13 +352,13 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Alvin Boone and James Lian
@@ -378,13 +378,13 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Ashley Hildebrand-McDougall and James Garritty
@@ -404,13 +404,13 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Martin Patterson and Clay Lariviere
@@ -430,12 +430,12 @@ exports[`Single Seat Contest 1`] = `
     >
       <button
         aria-label="next contest"
-        class="sc-bqiQRQ jGTagp"
+        class="sc-llYToB gQOtdJ"
         id="next"
         type="button"
       >
         <span
-          class="sc-hBURRC gusydx"
+          class="sc-giYgFv hVfOtt"
         >
           <span
             class="c10"
@@ -446,12 +446,12 @@ exports[`Single Seat Contest 1`] = `
       </button>
       <button
         aria-label="previous contest"
-        class="sc-bqiQRQ jGTagp"
+        class="sc-llYToB gQOtdJ"
         id="previous"
         type="button"
       >
         <span
-          class="sc-hBURRC gusydx"
+          class="sc-giYgFv hVfOtt"
         >
           <span
             class="c11"
@@ -462,11 +462,11 @@ exports[`Single Seat Contest 1`] = `
       </button>
       <button
         aria-label="Change Settings"
-        class="sc-bqiQRQ jGTagp"
+        class="sc-llYToB gQOtdJ"
         type="button"
       >
         <span
-          class="sc-hBURRC gusydx"
+          class="sc-giYgFv hVfOtt"
         >
           Settings
         </span>

--- a/apps/mark/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
@@ -236,16 +236,16 @@ exports[`Single Seat Contest 1`] = `
   tabindex="-1"
 >
   <div
-    class="sc-giYgFv jxDALN"
+    class="sc-cTApHj iSLYgx"
   >
     <div
       class="c1"
     >
       <div
-        class="sc-hKwCoD gmiWky"
+        class="sc-fotPbf hvTglz"
       >
         <p
-          class="sc-bdvvaa iybVtA"
+          class="sc-bqiQRQ jKCqve"
         >
           This is the
            
@@ -261,14 +261,14 @@ exports[`Single Seat Contest 1`] = `
       </div>
     </div>
     <main
-      class="sc-ezbkgU jVInCL"
+      class="sc-jObXwK jYtfDo"
     >
       <div
         class="c2"
         id="contest-header"
       >
         <div
-          class="sc-hKwCoD gmiWky"
+          class="sc-fotPbf hvTglz"
           id="audiofocus"
         >
           <h1
@@ -283,7 +283,7 @@ exports[`Single Seat Contest 1`] = `
           </h1>
           <p>
             <span
-              class="sc-bdvvaa NLRzK"
+              class="sc-bqiQRQ bIFmdQ"
             >
               Vote for 
               4
@@ -291,7 +291,7 @@ exports[`Single Seat Contest 1`] = `
             </span>
              
             <span
-              class="sc-bdvvaa hsgYyE"
+              class="sc-bqiQRQ gRKWVK"
             >
               You have selected 
               4
@@ -329,13 +329,13 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Camille Argent
@@ -356,13 +356,13 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Chloe Witherspoon-Smithson
@@ -383,13 +383,13 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Clayton Bainbridge
@@ -410,13 +410,13 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Charlene Hennessey
@@ -437,13 +437,13 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Eric Savoy
@@ -464,13 +464,13 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Susan Tawa
@@ -491,13 +491,13 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Mary Tawa
@@ -518,13 +518,13 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Damian Rangel
@@ -545,13 +545,13 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Valarie Altman
@@ -572,13 +572,13 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Helen Moore
@@ -599,13 +599,13 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Martin Schreiner
@@ -625,10 +625,10 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
                       aria-label="add write-in candidate."
@@ -650,12 +650,12 @@ exports[`Single Seat Contest 1`] = `
     >
       <button
         aria-label="next contest"
-        class="sc-bqiQRQ ihuxhx"
+        class="sc-llYToB fUiwSl"
         id="next"
         type="button"
       >
         <span
-          class="sc-hBURRC gusydx"
+          class="sc-giYgFv hVfOtt"
         >
           <span
             class="c11"
@@ -666,12 +666,12 @@ exports[`Single Seat Contest 1`] = `
       </button>
       <button
         aria-label="previous contest"
-        class="sc-bqiQRQ jGTagp"
+        class="sc-llYToB gQOtdJ"
         id="previous"
         type="button"
       >
         <span
-          class="sc-hBURRC gusydx"
+          class="sc-giYgFv hVfOtt"
         >
           <span
             class="c12"
@@ -682,11 +682,11 @@ exports[`Single Seat Contest 1`] = `
       </button>
       <button
         aria-label="Change Settings"
-        class="sc-bqiQRQ jGTagp"
+        class="sc-llYToB gQOtdJ"
         type="button"
       >
         <span
-          class="sc-hBURRC gusydx"
+          class="sc-giYgFv hVfOtt"
         >
           Settings
         </span>

--- a/apps/mark/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
@@ -236,16 +236,16 @@ exports[`Single Seat Contest 1`] = `
   tabindex="-1"
 >
   <div
-    class="sc-giYgFv jxDALN"
+    class="sc-cTApHj iSLYgx"
   >
     <div
       class="c1"
     >
       <div
-        class="sc-hKwCoD gmiWky"
+        class="sc-fotPbf hvTglz"
       >
         <p
-          class="sc-bdvvaa iybVtA"
+          class="sc-bqiQRQ jKCqve"
         >
           This is the
            
@@ -261,14 +261,14 @@ exports[`Single Seat Contest 1`] = `
       </div>
     </div>
     <main
-      class="sc-ezbkgU jVInCL"
+      class="sc-jObXwK jYtfDo"
     >
       <div
         class="c2"
         id="contest-header"
       >
         <div
-          class="sc-hKwCoD gmiWky"
+          class="sc-fotPbf hvTglz"
           id="audiofocus"
         >
           <h1
@@ -283,7 +283,7 @@ exports[`Single Seat Contest 1`] = `
           </h1>
           <p>
             <span
-              class="sc-bdvvaa NLRzK"
+              class="sc-bqiQRQ bIFmdQ"
             >
               Vote for 
               1
@@ -291,7 +291,7 @@ exports[`Single Seat Contest 1`] = `
             </span>
              
             <span
-              class="sc-bdvvaa hsgYyE"
+              class="sc-bqiQRQ gRKWVK"
             >
               You have selected 
               1
@@ -329,13 +329,13 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Joseph Barchi and Joseph Hallaren
@@ -356,13 +356,13 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Adam Cramer and Greg Vuocolo
@@ -383,13 +383,13 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Daniel Court and Amy Blumhardt
@@ -410,13 +410,13 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Alvin Boone and James Lian
@@ -437,13 +437,13 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Ashley Hildebrand-McDougall and James Garritty
@@ -464,13 +464,13 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Martin Patterson and Clay Lariviere
@@ -491,12 +491,12 @@ exports[`Single Seat Contest 1`] = `
     >
       <button
         aria-label="next contest"
-        class="sc-bqiQRQ ihuxhx"
+        class="sc-llYToB fUiwSl"
         id="next"
         type="button"
       >
         <span
-          class="sc-hBURRC gusydx"
+          class="sc-giYgFv hVfOtt"
         >
           <span
             class="c11"
@@ -507,12 +507,12 @@ exports[`Single Seat Contest 1`] = `
       </button>
       <button
         aria-label="previous contest"
-        class="sc-bqiQRQ jGTagp"
+        class="sc-llYToB gQOtdJ"
         id="previous"
         type="button"
       >
         <span
-          class="sc-hBURRC gusydx"
+          class="sc-giYgFv hVfOtt"
         >
           <span
             class="c12"
@@ -523,11 +523,11 @@ exports[`Single Seat Contest 1`] = `
       </button>
       <button
         aria-label="Change Settings"
-        class="sc-bqiQRQ jGTagp"
+        class="sc-llYToB gQOtdJ"
         type="button"
       >
         <span
-          class="sc-hBURRC gusydx"
+          class="sc-giYgFv hVfOtt"
         >
           Settings
         </span>

--- a/apps/mark/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
@@ -188,16 +188,16 @@ exports[`Single Seat Contest with Write In 1`] = `
   tabindex="-1"
 >
   <div
-    class="sc-giYgFv jxDALN"
+    class="sc-cTApHj iSLYgx"
   >
     <div
       class="c1"
     >
       <div
-        class="sc-hKwCoD gmiWky"
+        class="sc-fotPbf hvTglz"
       >
         <p
-          class="sc-bdvvaa iybVtA"
+          class="sc-bqiQRQ jKCqve"
         >
           This is the
            
@@ -213,14 +213,14 @@ exports[`Single Seat Contest with Write In 1`] = `
       </div>
     </div>
     <main
-      class="sc-ezbkgU jVInCL"
+      class="sc-jObXwK jYtfDo"
     >
       <div
         class="c2"
         id="contest-header"
       >
         <div
-          class="sc-hKwCoD gmiWky"
+          class="sc-fotPbf hvTglz"
           id="audiofocus"
         >
           <h1
@@ -235,7 +235,7 @@ exports[`Single Seat Contest with Write In 1`] = `
           </h1>
           <p>
             <span
-              class="sc-bdvvaa NLRzK"
+              class="sc-bqiQRQ bIFmdQ"
             >
               Vote for 
               1
@@ -274,13 +274,13 @@ exports[`Single Seat Contest with Write In 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Rhadka Ramachandrani
@@ -300,10 +300,10 @@ exports[`Single Seat Contest with Write In 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
                       aria-label="add write-in candidate."
@@ -325,12 +325,12 @@ exports[`Single Seat Contest with Write In 1`] = `
     >
       <button
         aria-label="next contest"
-        class="sc-bqiQRQ jGTagp"
+        class="sc-llYToB gQOtdJ"
         id="next"
         type="button"
       >
         <span
-          class="sc-hBURRC gusydx"
+          class="sc-giYgFv hVfOtt"
         >
           <span
             class="c10"
@@ -341,12 +341,12 @@ exports[`Single Seat Contest with Write In 1`] = `
       </button>
       <button
         aria-label="previous contest"
-        class="sc-bqiQRQ jGTagp"
+        class="sc-llYToB gQOtdJ"
         id="previous"
         type="button"
       >
         <span
-          class="sc-hBURRC gusydx"
+          class="sc-giYgFv hVfOtt"
         >
           <span
             class="c11"
@@ -357,11 +357,11 @@ exports[`Single Seat Contest with Write In 1`] = `
       </button>
       <button
         aria-label="Change Settings"
-        class="sc-bqiQRQ jGTagp"
+        class="sc-llYToB gQOtdJ"
         type="button"
       >
         <span
-          class="sc-hBURRC gusydx"
+          class="sc-giYgFv hVfOtt"
         >
           Settings
         </span>

--- a/apps/mark/frontend/src/components/__snapshots__/choice_button.test.tsx.snap
+++ b/apps/mark/frontend/src/components/__snapshots__/choice_button.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`renders ChoiceButton 1`] = `
   type="button"
 >
   <span
-    class="sc-hBURRC gusydx"
+    class="sc-giYgFv hVfOtt"
   >
     foo
   </span>

--- a/apps/mark/frontend/src/components/__snapshots__/election_info.test.tsx.snap
+++ b/apps/mark/frontend/src/components/__snapshots__/election_info.test.tsx.snap
@@ -211,7 +211,7 @@ exports[`renders horizontal ElectionInfo with hash when specified 1`] = `
         </svg>
       </div>
       <div
-        class="sc-hKwCoD eDCLhO"
+        class="sc-fotPbf dfNDJL"
       >
         <h5
           aria-label=" General Election."
@@ -219,28 +219,28 @@ exports[`renders horizontal ElectionInfo with hash when specified 1`] = `
            General Election
         </h5>
         <p
-          class="sc-bdvvaa iybVtA"
+          class="sc-bqiQRQ jKCqve"
         >
           November 3, 2020
           <br />
           <span
-            class="sc-gsDJrp fUIxJs"
+            class="sc-ksdxAp gMaEyZ"
           >
             Franklin County
             ,
           </span>
            
           <span
-            class="sc-gsDJrp fUIxJs"
+            class="sc-ksdxAp gMaEyZ"
           >
             State of Hamilton
           </span>
         </p>
         <p
-          class="sc-bdvvaa kKHwYn"
+          class="sc-bqiQRQ lpjhJV"
         >
           <span
-            class="sc-gsDJrp fUIxJs"
+            class="sc-ksdxAp gMaEyZ"
           >
             Center Springfield
           </span>
@@ -462,7 +462,7 @@ exports[`renders horizontal ElectionInfo without hash by default 1`] = `
         </svg>
       </div>
       <div
-        class="sc-hKwCoD eDCLhO"
+        class="sc-fotPbf dfNDJL"
       >
         <h5
           aria-label=" General Election."
@@ -470,28 +470,28 @@ exports[`renders horizontal ElectionInfo without hash by default 1`] = `
            General Election
         </h5>
         <p
-          class="sc-bdvvaa iybVtA"
+          class="sc-bqiQRQ jKCqve"
         >
           November 3, 2020
           <br />
           <span
-            class="sc-gsDJrp fUIxJs"
+            class="sc-ksdxAp gMaEyZ"
           >
             Franklin County
             ,
           </span>
            
           <span
-            class="sc-gsDJrp fUIxJs"
+            class="sc-ksdxAp gMaEyZ"
           >
             State of Hamilton
           </span>
         </p>
         <p
-          class="sc-bdvvaa kKHwYn"
+          class="sc-bqiQRQ lpjhJV"
         >
           <span
-            class="sc-gsDJrp fUIxJs"
+            class="sc-ksdxAp gMaEyZ"
           >
             Center Springfield
           </span>
@@ -690,7 +690,7 @@ exports[`renders vertical ElectionInfo with hash when specified 1`] = `
       </svg>
     </div>
     <div
-      class="sc-hKwCoD dOmxmu"
+      class="sc-fotPbf kgCzfn"
     >
       <h1
         aria-label=" General Election."
@@ -708,7 +708,7 @@ exports[`renders vertical ElectionInfo with hash when specified 1`] = `
         <br />
         <strong>
           <span
-            class="sc-gsDJrp fUIxJs"
+            class="sc-ksdxAp gMaEyZ"
           >
             Center Springfield
           </span>
@@ -908,7 +908,7 @@ exports[`renders vertical ElectionInfo without hash by default 1`] = `
       </svg>
     </div>
     <div
-      class="sc-hKwCoD dOmxmu"
+      class="sc-fotPbf kgCzfn"
     >
       <h1
         aria-label=" General Election."
@@ -926,7 +926,7 @@ exports[`renders vertical ElectionInfo without hash by default 1`] = `
         <br />
         <strong>
           <span
-            class="sc-gsDJrp fUIxJs"
+            class="sc-ksdxAp gMaEyZ"
           >
             Center Springfield
           </span>

--- a/apps/mark/frontend/src/components/__snapshots__/settings_text_size.test.tsx.snap
+++ b/apps/mark/frontend/src/components/__snapshots__/settings_text_size.test.tsx.snap
@@ -64,38 +64,38 @@ exports[`renders SettingsTextSize 1`] = `
     Text Size
   </label>
   <span
-    class="sc-fotPbf c1"
+    class="sc-ezbkgU c1"
     data-testid="change-text-size-buttons"
   >
     <button
       aria-label=" Text Size: Small"
-      class="sc-bqiQRQ DAAqi"
+      class="sc-llYToB cpKJaq"
       type="button"
     >
       <span
-        class="sc-hBURRC gusydx"
+        class="sc-giYgFv hVfOtt"
       >
         A
       </span>
     </button>
     <button
       aria-label="Selected Text Size: Medium"
-      class="sc-bqiQRQ dJzIjO"
+      class="sc-llYToB jNKTye"
       type="button"
     >
       <span
-        class="sc-hBURRC gusydx"
+        class="sc-giYgFv hVfOtt"
       >
         A
       </span>
     </button>
     <button
       aria-label=" Text Size: Large"
-      class="sc-bqiQRQ DAAqi"
+      class="sc-llYToB cpKJaq"
       type="button"
     >
       <span
-        class="sc-hBURRC gusydx"
+        class="sc-giYgFv hVfOtt"
       >
         A
       </span>

--- a/apps/mark/frontend/src/components/__snapshots__/yes_no_contest.test.tsx.snap
+++ b/apps/mark/frontend/src/components/__snapshots__/yes_no_contest.test.tsx.snap
@@ -124,14 +124,14 @@ exports[`supports yes/no contest allows voting for both yes and no 1`] = `
 
 <div>
   <main
-    class="sc-ezbkgU jVInCL"
+    class="sc-jObXwK jYtfDo"
   >
     <div
       class="c0"
       id="contest-header"
     >
       <div
-        class="sc-hKwCoD gmiWky"
+        class="sc-fotPbf hvTglz"
         id="audiofocus"
       >
         <h1
@@ -176,10 +176,10 @@ exports[`supports yes/no contest allows voting for both yes and no 1`] = `
             class="c5"
           >
             <div
-              class="sc-hKwCoD gmiWky"
+              class="sc-fotPbf hvTglz"
             >
               <p
-                class="sc-bdvvaa NLRzK"
+                class="sc-bqiQRQ bIFmdQ"
               >
                 <span>
                   Should fishing be banned in all city owned lakes and rivers?
@@ -208,14 +208,14 @@ exports[`supports yes/no contest allows voting for both yes and no 1`] = `
           type="button"
         >
           <span
-            class="sc-hBURRC gusydx"
+            class="sc-giYgFv hVfOtt"
           >
             <div
-              class="sc-hKwCoD gmiWky"
+              class="sc-fotPbf hvTglz"
             >
               <p
                 aria-label=" Yes on Ballot Measure 3"
-                class="sc-bdvvaa eSpfPW"
+                class="sc-bqiQRQ eyxUBE"
               >
                 Yes
               </p>
@@ -231,14 +231,14 @@ exports[`supports yes/no contest allows voting for both yes and no 1`] = `
           type="button"
         >
           <span
-            class="sc-hBURRC gusydx"
+            class="sc-giYgFv hVfOtt"
           >
             <div
-              class="sc-hKwCoD gmiWky"
+              class="sc-fotPbf hvTglz"
             >
               <p
                 aria-label=" No on Ballot Measure 3"
-                class="sc-bdvvaa eSpfPW"
+                class="sc-bqiQRQ eyxUBE"
               >
                 No
               </p>
@@ -423,14 +423,14 @@ exports[`supports yes/no contest displays warning when attempting to change vote
 
 <div>
   <main
-    class="sc-ezbkgU jVInCL"
+    class="sc-jObXwK jYtfDo"
   >
     <div
       class="c0"
       id="contest-header"
     >
       <div
-        class="sc-hKwCoD gmiWky"
+        class="sc-fotPbf hvTglz"
         id="audiofocus"
       >
         <h1
@@ -475,10 +475,10 @@ exports[`supports yes/no contest displays warning when attempting to change vote
             class="c5"
           >
             <div
-              class="sc-hKwCoD gmiWky"
+              class="sc-fotPbf hvTglz"
             >
               <p
-                class="sc-bdvvaa NLRzK"
+                class="sc-bqiQRQ bIFmdQ"
               >
                 <span>
                   Should fishing be banned in all city owned lakes and rivers?
@@ -507,14 +507,14 @@ exports[`supports yes/no contest displays warning when attempting to change vote
           type="button"
         >
           <span
-            class="sc-hBURRC gusydx"
+            class="sc-giYgFv hVfOtt"
           >
             <div
-              class="sc-hKwCoD gmiWky"
+              class="sc-fotPbf hvTglz"
             >
               <p
                 aria-label="Selected, Yes on Ballot Measure 3"
-                class="sc-bdvvaa eSpfPW"
+                class="sc-bqiQRQ eyxUBE"
               >
                 Yes
               </p>
@@ -530,14 +530,14 @@ exports[`supports yes/no contest displays warning when attempting to change vote
           type="button"
         >
           <span
-            class="sc-hBURRC gusydx"
+            class="sc-giYgFv hVfOtt"
           >
             <div
-              class="sc-hKwCoD gmiWky"
+              class="sc-fotPbf hvTglz"
             >
               <p
                 aria-label=" No on Ballot Measure 3"
-                class="sc-bdvvaa eSpfPW"
+                class="sc-bqiQRQ eyxUBE"
               >
                 No
               </p>

--- a/apps/mark/frontend/src/pages/__snapshots__/cast_ballot_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/cast_ballot_page.test.tsx.snap
@@ -38,13 +38,13 @@ exports[`renders CastBallotPage 1`] = `
 }
 
 <div
-  class="sc-giYgFv iAOAuC"
+  class="sc-cTApHj bvoLMG"
 >
   <main
-    class="sc-ezbkgU jjwGyL"
+    class="sc-jObXwK hbqLlw"
   >
     <div
-      class="sc-hKwCoD NKPqV"
+      class="sc-fotPbf cxKIyQ"
       id="audiofocus"
     >
       <h1
@@ -67,7 +67,7 @@ exports[`renders CastBallotPage 1`] = `
             style="left: -0.75em;"
           />
           <p
-            class="sc-bdvvaa NLRzK"
+            class="sc-bqiQRQ bIFmdQ"
           >
             1. Verify your official ballot.
           </p>
@@ -80,7 +80,7 @@ exports[`renders CastBallotPage 1`] = `
             src="/images/instructions-2-scan.svg"
           />
           <p
-            class="sc-bdvvaa NLRzK"
+            class="sc-bqiQRQ bIFmdQ"
           >
             2. Scan your official ballot.
           </p>
@@ -97,11 +97,11 @@ exports[`renders CastBallotPage 1`] = `
       class="c2"
     >
       <button
-        class="sc-bqiQRQ cvycME"
+        class="sc-llYToB iUIsHk"
         type="button"
       >
         <span
-          class="sc-hBURRC gusydx"
+          class="sc-giYgFv hVfOtt"
         >
           Done
         </span>

--- a/apps/mark/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
@@ -177,16 +177,16 @@ exports[`Renders ContestPage 1`] = `
 
 <div>
   <div
-    class="sc-giYgFv jxDALN"
+    class="sc-cTApHj iSLYgx"
   >
     <div
       class="c0"
     >
       <div
-        class="sc-hKwCoD gmiWky"
+        class="sc-fotPbf hvTglz"
       >
         <p
-          class="sc-bdvvaa iybVtA"
+          class="sc-bqiQRQ jKCqve"
         >
           This is the
            
@@ -202,14 +202,14 @@ exports[`Renders ContestPage 1`] = `
       </div>
     </div>
     <main
-      class="sc-ezbkgU jVInCL"
+      class="sc-jObXwK jYtfDo"
     >
       <div
         class="c1"
         id="contest-header"
       >
         <div
-          class="sc-hKwCoD gmiWky"
+          class="sc-fotPbf hvTglz"
           id="audiofocus"
         >
           <h1
@@ -224,7 +224,7 @@ exports[`Renders ContestPage 1`] = `
           </h1>
           <p>
             <span
-              class="sc-bdvvaa NLRzK"
+              class="sc-bqiQRQ bIFmdQ"
             >
               Vote for 
               1
@@ -263,13 +263,13 @@ exports[`Renders ContestPage 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Joseph Barchi and Joseph Hallaren
@@ -290,13 +290,13 @@ exports[`Renders ContestPage 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Adam Cramer and Greg Vuocolo
@@ -317,13 +317,13 @@ exports[`Renders ContestPage 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Daniel Court and Amy Blumhardt
@@ -344,13 +344,13 @@ exports[`Renders ContestPage 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Alvin Boone and James Lian
@@ -371,13 +371,13 @@ exports[`Renders ContestPage 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Ashley Hildebrand-McDougall and James Garritty
@@ -398,13 +398,13 @@ exports[`Renders ContestPage 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Martin Patterson and Clay Lariviere
@@ -425,12 +425,12 @@ exports[`Renders ContestPage 1`] = `
     >
       <button
         aria-label="next contest"
-        class="sc-bqiQRQ jGTagp"
+        class="sc-llYToB gQOtdJ"
         id="next"
         type="button"
       >
         <span
-          class="sc-hBURRC gusydx"
+          class="sc-giYgFv hVfOtt"
         >
           <span
             class="c9"
@@ -441,12 +441,12 @@ exports[`Renders ContestPage 1`] = `
       </button>
       <button
         aria-label="previous contest"
-        class="sc-bqiQRQ jGTagp"
+        class="sc-llYToB gQOtdJ"
         id="previous"
         type="button"
       >
         <span
-          class="sc-hBURRC gusydx"
+          class="sc-giYgFv hVfOtt"
         >
           <span
             class="c10"
@@ -457,11 +457,11 @@ exports[`Renders ContestPage 1`] = `
       </button>
       <button
         aria-label="Change Settings"
-        class="sc-bqiQRQ jGTagp"
+        class="sc-llYToB gQOtdJ"
         type="button"
       >
         <span
-          class="sc-hBURRC gusydx"
+          class="sc-giYgFv hVfOtt"
         >
           Settings
         </span>
@@ -701,17 +701,17 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
 
 <div>
   <div
-    class="sc-giYgFv keeSrJ"
+    class="sc-cTApHj dKgrkB"
   >
     <main
-      class="sc-ezbkgU jVInCL"
+      class="sc-jObXwK jYtfDo"
     >
       <div
         class="c0"
         id="contest-header"
       >
         <div
-          class="sc-hKwCoD gmiWky"
+          class="sc-fotPbf hvTglz"
           id="audiofocus"
         >
           <h1
@@ -726,7 +726,7 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
           </h1>
           <p>
             <span
-              class="sc-bdvvaa NLRzK"
+              class="sc-bqiQRQ bIFmdQ"
             >
               Vote for 
               1
@@ -765,13 +765,13 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Joseph Barchi and Joseph Hallaren
@@ -792,13 +792,13 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Adam Cramer and Greg Vuocolo
@@ -819,13 +819,13 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Daniel Court and Amy Blumhardt
@@ -846,13 +846,13 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Alvin Boone and James Lian
@@ -873,13 +873,13 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Ashley Hildebrand-McDougall and James Garritty
@@ -900,13 +900,13 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-hBURRC gusydx"
+                  class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-hKwCoD gmiWky"
+                    class="sc-fotPbf hvTglz"
                   >
                     <p
-                      class="sc-bdvvaa eSpfPW"
+                      class="sc-bqiQRQ eyxUBE"
                     >
                       <strong>
                         Martin Patterson and Clay Lariviere
@@ -929,10 +929,10 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
         class="c8"
       >
         <div
-          class="sc-hKwCoD gmiWky"
+          class="sc-fotPbf hvTglz"
         >
           <p
-            class="sc-bdvvaa cFJatN"
+            class="sc-bqiQRQ boCaWT"
           >
             This is the 
             <strong>
@@ -946,12 +946,12 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
           <p>
             <button
               aria-label="next contest"
-              class="sc-bqiQRQ jGTagp"
+              class="sc-llYToB gQOtdJ"
               id="next"
               type="button"
             >
               <span
-                class="sc-hBURRC gusydx"
+                class="sc-giYgFv hVfOtt"
               >
                 <span
                   class="c9"
@@ -964,12 +964,12 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
           <p>
             <button
               aria-label="previous contest"
-              class="sc-bqiQRQ DAAqi"
+              class="sc-llYToB cpKJaq"
               id="previous"
               type="button"
             >
               <span
-                class="sc-hBURRC gusydx"
+                class="sc-giYgFv hVfOtt"
               >
                 <span
                   class="c10"
@@ -989,11 +989,11 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
         >
           <button
             aria-label="Change Settings"
-            class="sc-bqiQRQ cvycME"
+            class="sc-llYToB iUIsHk"
             type="button"
           >
             <span
-              class="sc-hBURRC gusydx"
+              class="sc-giYgFv hVfOtt"
             >
               Settings
             </span>
@@ -1012,7 +1012,7 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
               class="c15"
             />
             <div
-              class="sc-hKwCoD eDCLhO"
+              class="sc-fotPbf dfNDJL"
             >
               <h5
                 aria-label=" General Election."
@@ -1020,34 +1020,34 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                  General Election
               </h5>
               <p
-                class="sc-bdvvaa iybVtA"
+                class="sc-bqiQRQ jKCqve"
               >
                 November 3, 2020
                 <br />
                 <span
-                  class="sc-gsDJrp fUIxJs"
+                  class="sc-ksdxAp gMaEyZ"
                 >
                   Franklin County
                   ,
                 </span>
                  
                 <span
-                  class="sc-gsDJrp fUIxJs"
+                  class="sc-ksdxAp gMaEyZ"
                 >
                   State of Hamilton
                 </span>
               </p>
               <p
-                class="sc-bdvvaa kKHwYn"
+                class="sc-bqiQRQ lpjhJV"
               >
                 <span
-                  class="sc-gsDJrp fUIxJs"
+                  class="sc-ksdxAp gMaEyZ"
                 >
                   Center Springfield
                   , 
                 </span>
                 <span
-                  class="sc-gsDJrp fUIxJs"
+                  class="sc-ksdxAp gMaEyZ"
                 >
                   ballot style 
                   12

--- a/apps/mark/frontend/src/pages/__snapshots__/not_found_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/not_found_page.test.tsx.snap
@@ -2,13 +2,13 @@
 
 exports[`renders NotFoundPage 1`] = `
 <div
-  class="sc-giYgFv jxDALN"
+  class="sc-cTApHj iSLYgx"
 >
   <main
-    class="sc-ezbkgU jjwGyL"
+    class="sc-jObXwK hbqLlw"
   >
     <div
-      class="sc-hKwCoD dOmxmu"
+      class="sc-fotPbf kgCzfn"
     >
       <h1>
         Page Not Found.
@@ -22,11 +22,11 @@ exports[`renders NotFoundPage 1`] = `
       </p>
       <p>
         <button
-          class="sc-bqiQRQ cvycME"
+          class="sc-llYToB iUIsHk"
           type="button"
         >
           <span
-            class="sc-hBURRC gusydx"
+            class="sc-giYgFv hVfOtt"
           >
             Start Over
           </span>

--- a/apps/mark/frontend/src/pages/__snapshots__/print_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/print_page.test.tsx.snap
@@ -4,13 +4,13 @@ exports[`prints correct ballot with votes 1`] = `
 <div>
   <div
     aria-hidden="true"
-    class="sc-jRQAMF kQCdaK"
+    class="sc-bkkfTU idIZus"
   >
     <div
-      class="sc-iCfLBT cSkaik"
+      class="sc-dJjZJu kicltX"
     >
       <div
-        class="sc-hKwCoD gmiWky ballot-header-content"
+        class="sc-fotPbf hvTglz ballot-header-content"
       >
         <h2>
           Unofficial TEST Ballot
@@ -29,10 +29,10 @@ exports[`prints correct ballot with votes 1`] = `
         </p>
       </div>
       <div
-        class="sc-furvIG cfpKDm"
+        class="sc-hGPAah bzCOZc"
       >
         <div
-          class="sc-eCImvq gScWpb"
+          class="sc-fFehDp eyHcFf"
         >
           <svg
             height="128"
@@ -73,7 +73,7 @@ exports[`prints correct ballot with votes 1`] = `
                 Ballot ID
               </div>
               <strong
-                class="sc-gsDJrp fUIxJs"
+                class="sc-ksdxAp gMaEyZ"
               >
                 CHhgYxfN5GeqnK8KaVOt1w
               </strong>
@@ -83,25 +83,25 @@ exports[`prints correct ballot with votes 1`] = `
       </div>
     </div>
     <div
-      class="sc-pVTma NVkwn"
+      class="sc-dlVyqM iALMMO"
     >
       <div
-        class="sc-jrQzUz jgYCbw"
+        class="sc-kfPtPH FNcqh"
       >
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               President and Vice-President
             </h3>
             <p
-              class="sc-bdvvaa eSpfPW"
+              class="sc-bqiQRQ eyxUBE"
             >
               <span
-                class="sc-bdvvaa hsgYyE"
+                class="sc-bqiQRQ gRKWVK"
               >
                 Joseph Barchi and Joseph Hallaren
               </span>
@@ -111,35 +111,35 @@ exports[`prints correct ballot with votes 1`] = `
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Representative, District 6
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Lieutenant Governor
             </h3>
             <p
-              class="sc-bdvvaa eSpfPW"
+              class="sc-bqiQRQ eyxUBE"
             >
               <span
-                class="sc-bdvvaa hsgYyE"
+                class="sc-bqiQRQ gRKWVK"
               >
                 Chris Norberg
               </span>
@@ -149,128 +149,128 @@ exports[`prints correct ballot with votes 1`] = `
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Senator, District 31
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Assembly Member, District 54
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Registrar of Wills
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Retain Robert Demergue as Chief Justice?
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Question A: Recovery of Property Damages
             </h3>
             <p
-              class="sc-bdvvaa kdHchw"
+              class="sc-bqiQRQ dSxKfi"
             >
               No
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Question B: Separation of Powers
             </h3>
             <p
-              class="sc-bdvvaa kdHchw"
+              class="sc-bqiQRQ dSxKfi"
             >
               Yes
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Proposition 1: Gambling in Franklin and Fromwit Counties
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Measure 102: Vehicle Abatement Program
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
@@ -286,13 +286,13 @@ exports[`prints correct ballot without votes 1`] = `
 <div>
   <div
     aria-hidden="true"
-    class="sc-jRQAMF kQCdaK"
+    class="sc-bkkfTU idIZus"
   >
     <div
-      class="sc-iCfLBT cSkaik"
+      class="sc-dJjZJu kicltX"
     >
       <div
-        class="sc-hKwCoD gmiWky ballot-header-content"
+        class="sc-fotPbf hvTglz ballot-header-content"
       >
         <h2>
           Unofficial TEST Ballot
@@ -311,10 +311,10 @@ exports[`prints correct ballot without votes 1`] = `
         </p>
       </div>
       <div
-        class="sc-furvIG cfpKDm"
+        class="sc-hGPAah bzCOZc"
       >
         <div
-          class="sc-eCImvq gScWpb"
+          class="sc-fFehDp eyHcFf"
         >
           <svg
             height="128"
@@ -355,7 +355,7 @@ exports[`prints correct ballot without votes 1`] = `
                 Ballot ID
               </div>
               <strong
-                class="sc-gsDJrp fUIxJs"
+                class="sc-ksdxAp gMaEyZ"
               >
                 CHhgYxfN5GeqnK8KaVOt1w
               </strong>
@@ -365,182 +365,182 @@ exports[`prints correct ballot without votes 1`] = `
       </div>
     </div>
     <div
-      class="sc-pVTma NVkwn"
+      class="sc-dlVyqM iALMMO"
     >
       <div
-        class="sc-jrQzUz jgYCbw"
+        class="sc-kfPtPH FNcqh"
       >
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               President and Vice-President
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Representative, District 6
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Lieutenant Governor
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Senator, District 31
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Assembly Member, District 54
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Registrar of Wills
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Retain Robert Demergue as Chief Justice?
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Question A: Recovery of Property Damages
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Question B: Separation of Powers
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Proposition 1: Gambling in Franklin and Fromwit Counties
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Measure 102: Vehicle Abatement Program
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
@@ -556,10 +556,10 @@ exports[`prints correct ballot without votes and inline seal 1`] = `
 <div>
   <div
     aria-hidden="true"
-    class="sc-jRQAMF kQCdaK"
+    class="sc-bkkfTU idIZus"
   >
     <div
-      class="sc-iCfLBT cSkaik"
+      class="sc-dJjZJu kicltX"
     >
       <div
         class="seal"
@@ -730,7 +730,7 @@ exports[`prints correct ballot without votes and inline seal 1`] = `
         </svg>
       </div>
       <div
-        class="sc-hKwCoD gmiWky ballot-header-content"
+        class="sc-fotPbf hvTglz ballot-header-content"
       >
         <h2>
           Unofficial TEST Ballot
@@ -749,10 +749,10 @@ exports[`prints correct ballot without votes and inline seal 1`] = `
         </p>
       </div>
       <div
-        class="sc-furvIG cfpKDm"
+        class="sc-hGPAah bzCOZc"
       >
         <div
-          class="sc-eCImvq gScWpb"
+          class="sc-fFehDp eyHcFf"
         >
           <svg
             height="128"
@@ -793,7 +793,7 @@ exports[`prints correct ballot without votes and inline seal 1`] = `
                 Ballot ID
               </div>
               <strong
-                class="sc-gsDJrp fUIxJs"
+                class="sc-ksdxAp gMaEyZ"
               >
                 CHhgYxfN5GeqnK8KaVOt1w
               </strong>
@@ -803,182 +803,182 @@ exports[`prints correct ballot without votes and inline seal 1`] = `
       </div>
     </div>
     <div
-      class="sc-pVTma NVkwn"
+      class="sc-dlVyqM iALMMO"
     >
       <div
-        class="sc-jrQzUz jgYCbw"
+        class="sc-kfPtPH FNcqh"
       >
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               President and Vice-President
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Representative, District 6
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Lieutenant Governor
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Senator, District 31
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Assembly Member, District 54
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Registrar of Wills
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Retain Robert Demergue as Chief Justice?
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Question A: Recovery of Property Damages
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Question B: Separation of Powers
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Proposition 1: Gambling in Franklin and Fromwit Counties
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Measure 102: Vehicle Abatement Program
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
@@ -994,13 +994,13 @@ exports[`prints correct ballot without votes and no seal 1`] = `
 <div>
   <div
     aria-hidden="true"
-    class="sc-jRQAMF kQCdaK"
+    class="sc-bkkfTU idIZus"
   >
     <div
-      class="sc-iCfLBT cSkaik"
+      class="sc-dJjZJu kicltX"
     >
       <div
-        class="sc-hKwCoD gmiWky ballot-header-content"
+        class="sc-fotPbf hvTglz ballot-header-content"
       >
         <h2>
           Unofficial TEST Ballot
@@ -1019,10 +1019,10 @@ exports[`prints correct ballot without votes and no seal 1`] = `
         </p>
       </div>
       <div
-        class="sc-furvIG cfpKDm"
+        class="sc-hGPAah bzCOZc"
       >
         <div
-          class="sc-eCImvq gScWpb"
+          class="sc-fFehDp eyHcFf"
         >
           <svg
             height="128"
@@ -1063,7 +1063,7 @@ exports[`prints correct ballot without votes and no seal 1`] = `
                 Ballot ID
               </div>
               <strong
-                class="sc-gsDJrp fUIxJs"
+                class="sc-ksdxAp gMaEyZ"
               >
                 CHhgYxfN5GeqnK8KaVOt1w
               </strong>
@@ -1073,182 +1073,182 @@ exports[`prints correct ballot without votes and no seal 1`] = `
       </div>
     </div>
     <div
-      class="sc-pVTma NVkwn"
+      class="sc-dlVyqM iALMMO"
     >
       <div
-        class="sc-jrQzUz jgYCbw"
+        class="sc-kfPtPH FNcqh"
       >
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               President and Vice-President
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Representative, District 6
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Lieutenant Governor
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Senator, District 31
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Assembly Member, District 54
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Registrar of Wills
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Retain Robert Demergue as Chief Justice?
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Question A: Recovery of Property Damages
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Question B: Separation of Powers
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Proposition 1: Gambling in Franklin and Fromwit Counties
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>
           </div>
         </div>
         <div
-          class="sc-kDThTU gkFLxJ"
+          class="sc-fKVsgm jsphhZ"
         >
           <div
-            class="sc-hKwCoD eDCLhO sc-iqsfdx vjIZd"
+            class="sc-fotPbf dfNDJL sc-bBHwJV cyAyBX"
           >
             <h3>
               Measure 102: Vehicle Abatement Program
             </h3>
             <p
-              class="sc-bdvvaa kCcYMa"
+              class="sc-bqiQRQ kMjDAE"
             >
               [no selection]
             </p>

--- a/apps/mark/frontend/src/pages/__snapshots__/start_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/start_page.test.tsx.snap
@@ -103,10 +103,10 @@ exports[`renders StartPage 1`] = `
 }
 
 <div
-  class="sc-giYgFv jxDALN"
+  class="sc-cTApHj iSLYgx"
 >
   <main
-    class="sc-ezbkgU gOgoiU"
+    class="sc-jObXwK iwmPPL"
   >
     <div
       aria-hidden="false"
@@ -123,7 +123,7 @@ exports[`renders StartPage 1`] = `
         />
       </div>
       <div
-        class="sc-hKwCoD dOmxmu"
+        class="sc-fotPbf kgCzfn"
       >
         <h1
           aria-label="Democratic Primary Election."
@@ -141,13 +141,13 @@ exports[`renders StartPage 1`] = `
           <br />
           <strong>
             <span
-              class="sc-gsDJrp fUIxJs"
+              class="sc-ksdxAp gMaEyZ"
             >
               Center Springfield
             </span>
              
             <span
-              class="sc-gsDJrp fUIxJs"
+              class="sc-ksdxAp gMaEyZ"
             >
               (
               12D
@@ -176,19 +176,19 @@ exports[`renders StartPage 1`] = `
     class="c3"
   >
     <div
-      class="sc-hKwCoD dOmxmu"
+      class="sc-fotPbf kgCzfn"
     >
       <p
         class="c4"
       >
         <button
           aria-label="Press the right button to advance to the first contest."
-          class="sc-bqiQRQ ihuxhx"
+          class="sc-llYToB fUiwSl"
           id="next"
           type="button"
         >
           <span
-            class="sc-hBURRC gusydx"
+            class="sc-giYgFv hVfOtt"
           >
             Start Voting
           </span>
@@ -208,38 +208,38 @@ exports[`renders StartPage 1`] = `
             Text Size
           </label>
           <span
-            class="sc-fotPbf c7"
+            class="sc-ezbkgU c7"
             data-testid="change-text-size-buttons"
           >
             <button
               aria-label=" Text Size: Small"
-              class="sc-bqiQRQ DAAqi"
+              class="sc-llYToB cpKJaq"
               type="button"
             >
               <span
-                class="sc-hBURRC gusydx"
+                class="sc-giYgFv hVfOtt"
               >
                 A
               </span>
             </button>
             <button
               aria-label="Selected Text Size: Medium"
-              class="sc-bqiQRQ dJzIjO"
+              class="sc-llYToB jNKTye"
               type="button"
             >
               <span
-                class="sc-hBURRC gusydx"
+                class="sc-giYgFv hVfOtt"
               >
                 A
               </span>
             </button>
             <button
               aria-label=" Text Size: Large"
-              class="sc-bqiQRQ DAAqi"
+              class="sc-llYToB cpKJaq"
               type="button"
             >
               <span
-                class="sc-hBURRC gusydx"
+                class="sc-giYgFv hVfOtt"
               >
                 A
               </span>
@@ -351,10 +351,10 @@ exports[`renders StartPage with inline SVG 1`] = `
 }
 
 <div
-  class="sc-giYgFv jxDALN"
+  class="sc-cTApHj iSLYgx"
 >
   <main
-    class="sc-ezbkgU gOgoiU"
+    class="sc-jObXwK iwmPPL"
   >
     <div
       aria-hidden="false"
@@ -529,7 +529,7 @@ exports[`renders StartPage with inline SVG 1`] = `
         </svg>
       </div>
       <div
-        class="sc-hKwCoD dOmxmu"
+        class="sc-fotPbf kgCzfn"
       >
         <h1
           aria-label=" General Election."
@@ -547,13 +547,13 @@ exports[`renders StartPage with inline SVG 1`] = `
           <br />
           <strong>
             <span
-              class="sc-gsDJrp fUIxJs"
+              class="sc-ksdxAp gMaEyZ"
             >
               Center Springfield
             </span>
              
             <span
-              class="sc-gsDJrp fUIxJs"
+              class="sc-ksdxAp gMaEyZ"
             >
               (
               12
@@ -582,19 +582,19 @@ exports[`renders StartPage with inline SVG 1`] = `
     class="c2"
   >
     <div
-      class="sc-hKwCoD dOmxmu"
+      class="sc-fotPbf kgCzfn"
     >
       <p
         class="c3"
       >
         <button
           aria-label="Press the right button to advance to the first contest."
-          class="sc-bqiQRQ ihuxhx"
+          class="sc-llYToB fUiwSl"
           id="next"
           type="button"
         >
           <span
-            class="sc-hBURRC gusydx"
+            class="sc-giYgFv hVfOtt"
           >
             Start Voting
           </span>
@@ -614,38 +614,38 @@ exports[`renders StartPage with inline SVG 1`] = `
             Text Size
           </label>
           <span
-            class="sc-fotPbf c6"
+            class="sc-ezbkgU c6"
             data-testid="change-text-size-buttons"
           >
             <button
               aria-label=" Text Size: Small"
-              class="sc-bqiQRQ DAAqi"
+              class="sc-llYToB cpKJaq"
               type="button"
             >
               <span
-                class="sc-hBURRC gusydx"
+                class="sc-giYgFv hVfOtt"
               >
                 A
               </span>
             </button>
             <button
               aria-label="Selected Text Size: Medium"
-              class="sc-bqiQRQ dJzIjO"
+              class="sc-llYToB jNKTye"
               type="button"
             >
               <span
-                class="sc-hBURRC gusydx"
+                class="sc-giYgFv hVfOtt"
               >
                 A
               </span>
             </button>
             <button
               aria-label=" Text Size: Large"
-              class="sc-bqiQRQ DAAqi"
+              class="sc-llYToB cpKJaq"
               type="button"
             >
               <span
-                class="sc-hBURRC gusydx"
+                class="sc-giYgFv hVfOtt"
               >
                 A
               </span>
@@ -757,10 +757,10 @@ exports[`renders StartPage with no seal 1`] = `
 }
 
 <div
-  class="sc-giYgFv jxDALN"
+  class="sc-cTApHj iSLYgx"
 >
   <main
-    class="sc-ezbkgU gOgoiU"
+    class="sc-jObXwK iwmPPL"
   >
     <div
       aria-hidden="false"
@@ -771,7 +771,7 @@ exports[`renders StartPage with no seal 1`] = `
         class="c1"
       />
       <div
-        class="sc-hKwCoD dOmxmu"
+        class="sc-fotPbf kgCzfn"
       >
         <h1
           aria-label=" General Election."
@@ -789,13 +789,13 @@ exports[`renders StartPage with no seal 1`] = `
           <br />
           <strong>
             <span
-              class="sc-gsDJrp fUIxJs"
+              class="sc-ksdxAp gMaEyZ"
             >
               Center Springfield
             </span>
              
             <span
-              class="sc-gsDJrp fUIxJs"
+              class="sc-ksdxAp gMaEyZ"
             >
               (
               12
@@ -824,19 +824,19 @@ exports[`renders StartPage with no seal 1`] = `
     class="c2"
   >
     <div
-      class="sc-hKwCoD dOmxmu"
+      class="sc-fotPbf kgCzfn"
     >
       <p
         class="c3"
       >
         <button
           aria-label="Press the right button to advance to the first contest."
-          class="sc-bqiQRQ ihuxhx"
+          class="sc-llYToB fUiwSl"
           id="next"
           type="button"
         >
           <span
-            class="sc-hBURRC gusydx"
+            class="sc-giYgFv hVfOtt"
           >
             Start Voting
           </span>
@@ -856,38 +856,38 @@ exports[`renders StartPage with no seal 1`] = `
             Text Size
           </label>
           <span
-            class="sc-fotPbf c6"
+            class="sc-ezbkgU c6"
             data-testid="change-text-size-buttons"
           >
             <button
               aria-label=" Text Size: Small"
-              class="sc-bqiQRQ DAAqi"
+              class="sc-llYToB cpKJaq"
               type="button"
             >
               <span
-                class="sc-hBURRC gusydx"
+                class="sc-giYgFv hVfOtt"
               >
                 A
               </span>
             </button>
             <button
               aria-label="Selected Text Size: Medium"
-              class="sc-bqiQRQ dJzIjO"
+              class="sc-llYToB jNKTye"
               type="button"
             >
               <span
-                class="sc-hBURRC gusydx"
+                class="sc-giYgFv hVfOtt"
               >
                 A
               </span>
             </button>
             <button
               aria-label=" Text Size: Large"
-              class="sc-bqiQRQ DAAqi"
+              class="sc-llYToB cpKJaq"
               type="button"
             >
               <span
-                class="sc-hBURRC gusydx"
+                class="sc-giYgFv hVfOtt"
               >
                 A
               </span>

--- a/apps/mark/frontend/src/pages/diagnostics_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/diagnostics_screen.test.tsx
@@ -26,10 +26,10 @@ import { fakeTts } from '../../test/helpers/fake_tts';
 // For now, we just hardcode the styled-components generated class names of the
 // Text components with the various icons.
 function expectToHaveSuccessIcon(element: HTMLElement) {
-  expect(element).toHaveClass('sc-bdvvaa jElMFl');
+  expect(element).toHaveClass('sc-bqiQRQ cheCgH');
 }
 function expectToHaveWarningIcon(element: HTMLElement) {
-  expect(element).toHaveClass('sc-bdvvaa gOYdAO');
+  expect(element).toHaveClass('sc-bqiQRQ eMTyqo');
 }
 
 function renderScreen(props: Partial<DiagnosticsScreenProps> = {}) {

--- a/apps/scan/frontend/src/components/layout.tsx
+++ b/apps/scan/frontend/src/components/layout.tsx
@@ -6,9 +6,11 @@ import {
   InfoBarMode,
   TestMode,
 } from '@votingworks/ui';
-import { getConfig, getMachineConfig } from '../api';
+import { getConfig, getMachineConfig, getScannerStatus } from '../api';
+import { ScannedBallotCount } from './scanned_ballot_count';
 
 interface CenteredScreenProps {
+  ballotCountOverride?: number;
   children: React.ReactNode;
   infoBar?: boolean;
   isLiveMode?: boolean;
@@ -16,6 +18,7 @@ interface CenteredScreenProps {
 }
 
 export function ScreenMainCenterChild({
+  ballotCountOverride,
   children,
   infoBar = true,
   infoBarMode,
@@ -23,6 +26,7 @@ export function ScreenMainCenterChild({
 }: CenteredScreenProps): JSX.Element | null {
   const machineConfigQuery = getMachineConfig.useQuery();
   const configQuery = getConfig.useQuery();
+  const scannerStatusQuery = getScannerStatus.useQuery();
 
   if (!(machineConfigQuery.isSuccess && configQuery.isSuccess)) {
     return null;
@@ -30,10 +34,13 @@ export function ScreenMainCenterChild({
 
   const { codeVersion, machineId } = machineConfigQuery.data;
   const { electionDefinition, precinctSelection } = configQuery.data;
+  const ballotCount =
+    ballotCountOverride ?? scannerStatusQuery.data?.ballotsCounted;
 
   return (
     <Screen>
       {!isLiveMode && <TestMode />}
+      {ballotCount !== undefined && <ScannedBallotCount count={ballotCount} />}
       <Main padded centerChild style={{ position: 'relative' }}>
         {children}
       </Main>

--- a/apps/scan/frontend/src/components/replace_ballot_bag_screen.tsx
+++ b/apps/scan/frontend/src/components/replace_ballot_bag_screen.tsx
@@ -6,7 +6,6 @@ import {
   useExternalStateChangeListener,
 } from '@votingworks/ui';
 import { LogEventId, Logger, LogSource } from '@votingworks/logging';
-import { ScannedBallotCount } from './scanned_ballot_count';
 import { ScreenMainCenterChild } from './layout';
 import { BALLOT_BAG_CAPACITY } from '../config/globals';
 import { ExclamationTriangle } from './graphics';
@@ -92,8 +91,10 @@ export function ReplaceBallotBagScreen({
   })();
 
   return (
-    <ScreenMainCenterChild infoBar={false}>
-      <ScannedBallotCount count={scannedBallotCount} />
+    <ScreenMainCenterChild
+      infoBar={false}
+      ballotCountOverride={scannedBallotCount}
+    >
       {mainContent}
     </ScreenMainCenterChild>
   );

--- a/apps/scan/frontend/src/components/scanned_ballot_count.tsx
+++ b/apps/scan/frontend/src/components/scanned_ballot_count.tsx
@@ -1,30 +1,24 @@
 import React from 'react';
-import { Prose } from '@votingworks/ui';
-import { format } from '@votingworks/utils';
+import { BigMetric } from '@votingworks/ui';
 import styled from 'styled-components';
-import { Absolute } from './absolute';
 
 interface Props {
   count: number;
 }
 
 const BallotsScannedContainer = styled.div`
-  padding: 0.5rem 0.75rem;
+  display: inline-block;
+  padding: 0.125rem 0.25rem;
 `;
 
 export function ScannedBallotCount({ count }: Props): JSX.Element {
   return (
-    <Absolute top left>
-      <BallotsScannedContainer>
-        <Prose themeDeprecated={{ fontSize: '1.25rem' }}>
-          <p>Ballots Scanned</p>
-        </Prose>
-        <Prose themeDeprecated={{ fontSize: '3.5rem' }}>
-          <p>
-            <strong data-testid="ballot-count">{format.count(count)}</strong>
-          </p>
-        </Prose>
-      </BallotsScannedContainer>
-    </Absolute>
+    <BallotsScannedContainer>
+      <BigMetric
+        label="Ballots Scanned"
+        value={count}
+        valueElementTestId="ballot-count"
+      />
+    </BallotsScannedContainer>
   );
 }

--- a/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
@@ -37,6 +37,7 @@ beforeEach(() => {
   window.kiosk = fakeKiosk();
   apiMock = createApiMock();
   apiMock.expectGetMachineConfig();
+  apiMock.expectGetScannerStatus(statusNoPaper);
 });
 
 afterEach(() => {

--- a/apps/scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.tsx
@@ -17,7 +17,6 @@ import { Logger, LogSource } from '@votingworks/logging';
 import { CalibrateScannerModal } from '../components/calibrate_scanner_modal';
 import { ExportBackupModal } from '../components/export_backup_modal';
 import { ExportResultsModal } from '../components/export_results_modal';
-import { ScannedBallotCount } from '../components/scanned_ballot_count';
 import { ScreenMainCenterChild } from '../components/layout';
 import { SetMarkThresholdsModal } from '../components/set_mark_thresholds_modal';
 import {
@@ -97,7 +96,10 @@ export function ElectionManagerScreen({
   }
 
   return (
-    <ScreenMainCenterChild infoBarMode="admin">
+    <ScreenMainCenterChild
+      infoBarMode="admin"
+      ballotCountOverride={scannerStatus.ballotsCounted}
+    >
       <Prose textCenter>
         <h1>Election Manager Settings</h1>
         {election.precincts.length > 1 && (
@@ -208,7 +210,6 @@ export function ElectionManagerScreen({
           </p>
         )}
       </Prose>
-      <ScannedBallotCount count={scannerStatus.ballotsCounted} />
       {isMarkThresholdModalOpen && (
         <SetMarkThresholdsModal
           markThresholds={electionDefinition.election.markThresholds}

--- a/apps/scan/frontend/src/screens/insert_ballot_screen.tsx
+++ b/apps/scan/frontend/src/screens/insert_ballot_screen.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { CenteredLargeProse, InsertBallotImage, Text } from '@votingworks/ui';
 import { ScreenMainCenterChild } from '../components/layout';
-import { ScannedBallotCount } from '../components/scanned_ballot_count';
 
 interface Props {
   isLiveMode: boolean;
@@ -15,7 +14,10 @@ export function InsertBallotScreen({
   showNoChargerWarning,
 }: Props): JSX.Element {
   return (
-    <ScreenMainCenterChild isLiveMode={isLiveMode}>
+    <ScreenMainCenterChild
+      isLiveMode={isLiveMode}
+      ballotCountOverride={scannedBallotCount}
+    >
       <InsertBallotImage />
       <CenteredLargeProse>
         <h1>Insert Your Ballot Below</h1>
@@ -27,7 +29,6 @@ export function InsertBallotScreen({
           </Text>
         )}
       </CenteredLargeProse>
-      <ScannedBallotCount count={scannedBallotCount} />
     </ScreenMainCenterChild>
   );
 }

--- a/apps/scan/frontend/src/screens/poll_worker_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.test.tsx
@@ -16,6 +16,7 @@ import {
   createApiMock,
   machineConfig,
   provideApi,
+  statusNoPaper,
 } from '../../test/helpers/mock_api_client';
 
 let apiMock: ApiMock;
@@ -36,6 +37,7 @@ beforeEach(() => {
   apiMock = createApiMock();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetConfig();
+  apiMock.expectGetScannerStatus(statusNoPaper);
 });
 
 afterEach(() => {

--- a/apps/scan/frontend/src/screens/poll_worker_screen.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.tsx
@@ -60,7 +60,6 @@ import { ScreenMainCenterChild } from '../components/layout';
 import { LiveCheckModal } from '../components/live_check_modal';
 
 import { TimesCircle } from '../components/graphics';
-import { ScannedBallotCount } from '../components/scanned_ballot_count';
 import { rootDebug } from '../utils/debug';
 import {
   exportCastVoteRecordsToUsbDrive,
@@ -665,7 +664,6 @@ export function PollWorkerScreen({
           </p>
         )}
       </Prose>
-      <ScannedBallotCount count={scannedBallotCount} />
       {isShowingLiveCheck && (
         <LiveCheckModal
           machineConfig={machineConfig}

--- a/apps/scan/frontend/src/screens/polls_not_open_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/polls_not_open_screen.test.tsx
@@ -10,6 +10,7 @@ import {
   createApiMock,
   machineConfig,
   provideApi,
+  statusNoPaper,
 } from '../../test/helpers/mock_api_client';
 
 const TEST_BALLOT_COUNT = 50;
@@ -22,6 +23,7 @@ beforeEach(() => {
   apiMock.expectGetConfig({
     precinctSelection: singlePrecinctSelectionFor('23'),
   });
+  apiMock.expectGetScannerStatus(statusNoPaper);
 });
 
 afterEach(() => {

--- a/apps/scan/frontend/src/screens/polls_not_open_screen.tsx
+++ b/apps/scan/frontend/src/screens/polls_not_open_screen.tsx
@@ -3,7 +3,6 @@ import { CenteredLargeProse, Text } from '@votingworks/ui';
 import { PollsState } from '@votingworks/types';
 import { DoNotEnter } from '../components/graphics';
 import { ScreenMainCenterChild } from '../components/layout';
-import { ScannedBallotCount } from '../components/scanned_ballot_count';
 
 export interface PollsNotOpenScreenProps {
   isLiveMode: boolean;
@@ -19,7 +18,11 @@ export function PollsNotOpenScreen({
   scannedBallotCount,
 }: PollsNotOpenScreenProps): JSX.Element {
   return (
-    <ScreenMainCenterChild isLiveMode={isLiveMode} infoBarMode="pollworker">
+    <ScreenMainCenterChild
+      isLiveMode={isLiveMode}
+      infoBarMode="pollworker"
+      ballotCountOverride={scannedBallotCount}
+    >
       <DoNotEnter />
       <CenteredLargeProse>
         <h1>
@@ -37,7 +40,6 @@ export function PollsNotOpenScreen({
           </Text>
         )}
       </CenteredLargeProse>
-      <ScannedBallotCount count={scannedBallotCount} />
     </ScreenMainCenterChild>
   );
 }

--- a/apps/scan/frontend/src/screens/scan_error_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/scan_error_screen.test.tsx
@@ -5,6 +5,7 @@ import {
   ApiMock,
   createApiMock,
   provideApi,
+  statusNoPaper,
 } from '../../test/helpers/mock_api_client';
 
 let apiMock: ApiMock;
@@ -13,6 +14,7 @@ beforeEach(() => {
   apiMock = createApiMock();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetConfig();
+  apiMock.expectGetScannerStatus(statusNoPaper);
 });
 
 afterEach(() => {

--- a/apps/scan/frontend/src/screens/scan_error_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_error_screen.tsx
@@ -8,7 +8,6 @@ import type {
 } from '@votingworks/scan-backend';
 import { TimesCircle } from '../components/graphics';
 import { ScreenMainCenterChild } from '../components/layout';
-import { ScannedBallotCount } from '../components/scanned_ballot_count';
 
 export interface Props {
   error?: InvalidInterpretationReason | PrecinctScannerErrorType;
@@ -60,7 +59,11 @@ export function ScanErrorScreen({
     }
   })();
   return (
-    <ScreenMainCenterChild isLiveMode={!isTestMode} infoBar={false}>
+    <ScreenMainCenterChild
+      isLiveMode={!isTestMode}
+      infoBar={false}
+      ballotCountOverride={scannedBallotCount}
+    >
       <TimesCircle />
       <CenteredLargeProse>
         <h1>Ballot Not Counted</h1>
@@ -73,7 +76,6 @@ export function ScanErrorScreen({
           </Text>
         )}
       </CenteredLargeProse>
-      <ScannedBallotCount count={scannedBallotCount} />
     </ScreenMainCenterChild>
   );
 }

--- a/apps/scan/frontend/src/screens/scan_jam_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_jam_screen.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { CenteredLargeProse, Text } from '@votingworks/ui';
 import { TimesCircle } from '../components/graphics';
 import { ScreenMainCenterChild } from '../components/layout';
-import { ScannedBallotCount } from '../components/scanned_ballot_count';
 
 interface Props {
   scannedBallotCount: number;
@@ -10,7 +9,10 @@ interface Props {
 
 export function ScanJamScreen({ scannedBallotCount }: Props): JSX.Element {
   return (
-    <ScreenMainCenterChild infoBar={false}>
+    <ScreenMainCenterChild
+      infoBar={false}
+      ballotCountOverride={scannedBallotCount}
+    >
       <TimesCircle />
       <CenteredLargeProse>
         <h1>Ballot Not Counted</h1>
@@ -19,7 +21,6 @@ export function ScanJamScreen({ scannedBallotCount }: Props): JSX.Element {
           Ask a poll worker for help.
         </Text>
       </CenteredLargeProse>
-      <ScannedBallotCount count={scannedBallotCount} />
     </ScreenMainCenterChild>
   );
 }

--- a/apps/scan/frontend/src/screens/scan_success_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_success_screen.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { CenteredLargeProse } from '@votingworks/ui';
 import { CircleCheck } from '../components/graphics';
-import { ScannedBallotCount } from '../components/scanned_ballot_count';
 
 import { ScreenMainCenterChild } from '../components/layout';
 
@@ -11,13 +10,12 @@ interface Props {
 
 export function ScanSuccessScreen({ scannedBallotCount }: Props): JSX.Element {
   return (
-    <ScreenMainCenterChild>
+    <ScreenMainCenterChild ballotCountOverride={scannedBallotCount}>
       <CircleCheck />
       <CenteredLargeProse>
         <h1>Your ballot was counted!</h1>
         <p>Thank you for voting.</p>
       </CenteredLargeProse>
-      <ScannedBallotCount count={scannedBallotCount} />
     </ScreenMainCenterChild>
   );
 }

--- a/apps/scan/frontend/src/screens/scan_warning_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/scan_warning_screen.test.tsx
@@ -14,6 +14,7 @@ import {
   ApiMock,
   createApiMock,
   provideApi,
+  statusNoPaper,
 } from '../../test/helpers/mock_api_client';
 
 jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
@@ -29,6 +30,7 @@ beforeEach(() => {
   apiMock = createApiMock();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetConfig();
+  apiMock.expectGetScannerStatus(statusNoPaper);
 });
 
 afterEach(() => {

--- a/apps/scan/frontend/src/screens/setup_scanner_screen.tsx
+++ b/apps/scan/frontend/src/screens/setup_scanner_screen.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { CenteredLargeProse, Text } from '@votingworks/ui';
 import { ScreenMainCenterChild } from '../components/layout';
-import { ScannedBallotCount } from '../components/scanned_ballot_count';
 
 interface Props {
   batteryIsCharging: boolean;
@@ -16,7 +15,10 @@ export function SetupScannerScreen({
   // internal wiring issue. Otherwise if we can't detect the scanner, the power
   // cord is likely not plugged in.
   return (
-    <ScreenMainCenterChild infoBar={false}>
+    <ScreenMainCenterChild
+      infoBar={false}
+      ballotCountOverride={scannedBallotCount}
+    >
       {batteryIsCharging ? (
         <CenteredLargeProse>
           <h1>Internal Connection Problem</h1>
@@ -29,9 +31,6 @@ export function SetupScannerScreen({
             Please ask a poll worker to plug in the power cord.
           </Text>
         </CenteredLargeProse>
-      )}
-      {scannedBallotCount !== undefined && (
-        <ScannedBallotCount count={scannedBallotCount} />
       )}
     </ScreenMainCenterChild>
   );

--- a/libs/ui/src/big_metric.stories.tsx
+++ b/libs/ui/src/big_metric.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta } from '@storybook/react';
+
+import { BigMetric, BigMetricProps } from './big_metric';
+
+const initialArgs: BigMetricProps = {
+  label: 'Ballots Scanned',
+  value: 4506,
+};
+
+const meta: Meta<typeof BigMetric> = {
+  title: 'libs-ui/BigMetric',
+  component: BigMetric,
+  args: initialArgs,
+};
+
+export default meta;
+
+export { BigMetric };

--- a/libs/ui/src/big_metric.test.tsx
+++ b/libs/ui/src/big_metric.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { render, screen } from '../test/react_testing_library';
+import { BigMetric } from './big_metric';
+
+test('renders label and formatted value', () => {
+  render(<BigMetric label="Number of Machines" value={2} />);
+  render(<BigMetric label="Ballots Scanned" value={4096} />);
+
+  // Verify labels are rendered:
+  screen.getByText('Number of Machines');
+  screen.getByText('Ballots Scanned');
+
+  // Verify counts are rendered as formatted numbers with accessible labels:
+  expect(screen.getByText('2')).toHaveAccessibleName('Number of Machines: 2');
+  expect(screen.getByText('4,096')).toHaveAccessibleName(
+    'Ballots Scanned: 4,096'
+  );
+});
+
+// To pass satisfy coverage requirements:
+test('renders in both "legacy" and VVSG size modes', () => {
+  render(<BigMetric label="Number of Machines" value={2} />, {
+    vxTheme: { sizeMode: 'legacy' },
+  });
+
+  render(<BigMetric label="Number of Machines" value={2} />, {
+    vxTheme: { sizeMode: 'm' },
+  });
+});

--- a/libs/ui/src/big_metric.test.tsx
+++ b/libs/ui/src/big_metric.test.tsx
@@ -18,7 +18,7 @@ test('renders label and formatted value', () => {
   );
 });
 
-// To pass satisfy coverage requirements:
+// To satisfy coverage requirements:
 test('renders in both "legacy" and VVSG size modes', () => {
   render(<BigMetric label="Number of Machines" value={2} />, {
     vxTheme: { sizeMode: 'legacy' },

--- a/libs/ui/src/big_metric.tsx
+++ b/libs/ui/src/big_metric.tsx
@@ -1,0 +1,57 @@
+/* stylelint-disable order/properties-order */
+import React from 'react';
+import styled from 'styled-components';
+
+import { format } from '@votingworks/utils';
+
+import { H1 } from './typography';
+import { LabelledText } from './labelled_text';
+
+/** Props for {@link BigMetric}. */
+export interface BigMetricProps {
+  label: React.ReactNode;
+  value: number;
+
+  /** For backward compatibility with tests in VxScan */
+  valueElementTestId?: string;
+}
+
+const StyledContainer = styled.span`
+  display: inline-block;
+  font-size: 1rem;
+  line-height: 1;
+  margin-bottom: 0.35rem;
+  text-align: center;
+`;
+
+const StyledValue = styled(H1)`
+  display: inline-block;
+
+  /* TODO: Remove once VxScan is updated to default to the new VVSG size theme: */
+  font-size: ${(p) => (p.theme.sizeMode === 'legacy' ? '72px' : undefined)};
+  line-height: 1;
+  margin: 0;
+`;
+
+/**
+ * Displays a formatted, H1-sized numerical metric value with the given label.
+ */
+export function BigMetric(props: BigMetricProps): JSX.Element {
+  const { label, value, valueElementTestId } = props;
+
+  const formattedValue = format.count(value);
+  const formattedLabel = `${label}: ${formattedValue}`;
+
+  return (
+    <StyledContainer>
+      <LabelledText aria-hidden label={label}>
+        <StyledValue
+          aria-label={formattedLabel}
+          data-testid={valueElementTestId}
+        >
+          {formattedValue}
+        </StyledValue>
+      </LabelledText>
+    </StyledContainer>
+  );
+}

--- a/libs/ui/src/big_metric.tsx
+++ b/libs/ui/src/big_metric.tsx
@@ -44,7 +44,7 @@ export function BigMetric(props: BigMetricProps): JSX.Element {
 
   return (
     <StyledContainer>
-      <LabelledText aria-hidden label={label}>
+      <LabelledText label={<span aria-hidden>{label}</span>}>
         <StyledValue
           aria-label={formattedLabel}
           data-testid={valueElementTestId}

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -1,6 +1,7 @@
 /* istanbul ignore file */
 export * from './app_base';
 export * from './auth';
+export * from './big_metric';
 export * from './bmd_paper_ballot';
 export * from './button';
 export * from './button_bar';
@@ -30,6 +31,7 @@ export * from './icons';
 export * from './input_group';
 export * from './insert_ballot_image';
 export * from './insert_card_image';
+export * from './labelled_text';
 export * from './link_button';
 export * from './loading';
 export * from './loading_animation';


### PR DESCRIPTION
## Overview

Related to: https://github.com/votingworks/vxsuite/issues/3185
Closes: https://github.com/votingworks/vxsuite/issues/3059

Relevant changes in first commit (4b182f0455dce82d1575d9076784011e9bfd0175)
Second commit has test snapshot updates for VxMark (can't figure out why those changed).

- Added `BigMetric` component in libs/ui (builds on `LabelledText`) to use for the `ScannedBallotCount` component in VxScan
- Updated the base VxScan layout to persist the ballot count across all screens, per https://github.com/votingworks/vxsuite/issues/3059

## Demo Video or Screenshot

https://user-images.githubusercontent.com/264902/230153613-86eeeb00-668d-4369-832d-5deea89e2f1c.mov

### In context in VxScan:
<img width="300" alt="Screenshot 2023-04-04 at 17 22 10" src="https://user-images.githubusercontent.com/264902/230153688-c8f8ff13-240f-41eb-a78c-8ebac9dbba28.png">

## Testing Plan
- Added unit test for `BigMetric`
- Updated tests that indirectly render the base layout component to mock out the API call for scanner status

## Checklist

- [n/a] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
