### PR TITLE
add autoscan functionality to custom scanner demo program

### DIFF
--- a/libs/custom-scanner/.gitignore
+++ b/libs/custom-scanner/.gitignore
@@ -1,0 +1,2 @@
+sideA.pgm
+sideB.pgm

--- a/libs/custom-scanner/package.json
+++ b/libs/custom-scanner/package.json
@@ -51,6 +51,7 @@
     "is-ci-cli": "^2.2.0",
     "jest": "^29.3.1",
     "jest-junit": "^15.0.0",
+    "jest-mock-extended": "^3.0.4",
     "jest-watch-typeahead": "0.6.4",
     "preact": "^10.11.3",
     "prettier": "^2.8.2",

--- a/libs/custom-scanner/src/utils/status_watcher.test.ts
+++ b/libs/custom-scanner/src/utils/status_watcher.test.ts
@@ -1,0 +1,216 @@
+import { err, ok } from '@votingworks/basics';
+import fc from 'fast-check';
+import { mock } from 'jest-mock-extended';
+import { arbitraryStatusInternalMessage } from '../../test/arbitraries';
+import { CustomA4Scanner } from '../custom_a4_scanner';
+import { createDuplexChannelMock, DuplexChannelListeners } from '../mocks';
+import { ErrorResponseMessage, StatusInternalMessage } from '../protocol';
+import { convertFromInternalStatus } from '../status';
+import { ErrorCode, ResponseErrorCode } from '../types';
+import { StatusWatcher, watchStatus } from './status_watcher';
+
+test('watchStatus yields initial status', async () => {
+  const { onRead } = mock<DuplexChannelListeners>();
+  const usbChannelMock = createDuplexChannelMock({
+    onRead,
+  });
+  const scanner = new CustomA4Scanner(usbChannelMock);
+
+  (await scanner.connect()).assertOk('connect failed');
+  const internalStatus = fc.sample(arbitraryStatusInternalMessage(), 1)[0]!;
+  onRead.mockResolvedValueOnce(
+    ok(StatusInternalMessage.encode(internalStatus).assertOk('encode failed'))
+  );
+  const watcher = watchStatus(scanner, { interval: 1 });
+  try {
+    const status = await watcher.next();
+    expect(status).toEqual({
+      done: false,
+      value: ok(convertFromInternalStatus(internalStatus).status),
+    });
+  } finally {
+    watcher.stop();
+  }
+});
+
+test('watchStatus in for-await-of loop yields initial status', async () => {
+  const { onRead } = mock<DuplexChannelListeners>();
+  const usbChannelMock = createDuplexChannelMock({ onRead });
+  const scanner = new CustomA4Scanner(usbChannelMock);
+
+  (await scanner.connect()).assertOk('connect failed');
+  const internalStatus = fc.sample(arbitraryStatusInternalMessage(), 1)[0]!;
+  onRead.mockResolvedValueOnce(
+    ok(StatusInternalMessage.encode(internalStatus).assertOk('encode failed'))
+  );
+
+  const watcher = watchStatus(scanner, { interval: 1 });
+  for await (const status of watcher) {
+    try {
+      expect(status).toEqual(
+        ok(convertFromInternalStatus(internalStatus).status)
+      );
+    } finally {
+      watcher.stop();
+    }
+  }
+});
+
+test('watchStatus sleeps 250ms between status checks by default', async () => {
+  const writeTimestamps: number[] = [];
+  const internalStatus = fc.sample(arbitraryStatusInternalMessage(), 1)[0]!;
+  const { onRead } = mock<DuplexChannelListeners>();
+  let watcher!: StatusWatcher;
+  const usbChannelMock = createDuplexChannelMock({
+    onRead,
+
+    onWrite: () => {
+      writeTimestamps.push(Date.now());
+
+      onRead.mockResolvedValueOnce(
+        ok(
+          StatusInternalMessage.encode(internalStatus).assertOk('encode failed')
+        )
+      );
+
+      if (writeTimestamps.length === 3) {
+        watcher.stop();
+      }
+
+      return ok();
+    },
+  });
+
+  const scanner = new CustomA4Scanner(usbChannelMock);
+
+  (await scanner.connect()).assertOk('connect failed');
+  watcher = watchStatus(scanner);
+  try {
+    await watcher.next();
+    await watcher.next();
+    expect(writeTimestamps).toHaveLength(3);
+    const [, secondWriteTimestamp, thirdWriteTimestamp] = writeTimestamps as [
+      number,
+      number,
+      number
+    ];
+    expect(thirdWriteTimestamp - secondWriteTimestamp).toBeGreaterThanOrEqual(
+      250
+    );
+  } finally {
+    watcher.stop();
+  }
+});
+
+test('watchStatus yields status updates', async () => {
+  const { onRead } = mock<DuplexChannelListeners>();
+  const usbChannelMock = createDuplexChannelMock({
+    onRead,
+  });
+  const scanner = new CustomA4Scanner(usbChannelMock);
+
+  (await scanner.connect()).assertOk('connect failed');
+
+  const initialStatus = fc.sample(arbitraryStatusInternalMessage(), 1)[0]!;
+
+  // cheat and use the reserved space to ensure we get a different status
+  initialStatus.reserve1 = 0x01;
+  const nextStatus: StatusInternalMessage = {
+    ...initialStatus,
+    // change something so we can tell it's a different status
+    reserve1: initialStatus.reserve1 + 1,
+  };
+
+  const encodedInitialStatus =
+    StatusInternalMessage.encode(initialStatus).assertOk('encode failed');
+  const encodedNextStatus =
+    StatusInternalMessage.encode(nextStatus).assertOk('encode failed');
+
+  // send the same multiple times but only expect one update since the status
+  // hasn't changed
+  onRead
+    .mockResolvedValueOnce(ok(encodedInitialStatus))
+    .mockResolvedValueOnce(ok(encodedInitialStatus))
+    .mockResolvedValueOnce(ok(encodedInitialStatus))
+    .mockResolvedValueOnce(ok(encodedInitialStatus))
+    .mockResolvedValueOnce(ok(encodedInitialStatus))
+    .mockResolvedValueOnce(ok(encodedNextStatus));
+
+  const watcher = watchStatus(scanner, { interval: 1 });
+
+  try {
+    const status = await watcher.next();
+
+    expect(status).toEqual({
+      done: false,
+      value: ok(convertFromInternalStatus(initialStatus).status),
+    });
+
+    const status2 = await watcher.next();
+    expect(status2).toEqual({
+      done: false,
+      value: ok(convertFromInternalStatus(nextStatus).status),
+    });
+  } finally {
+    watcher.stop();
+  }
+});
+
+test('watchStatus yields errors', async () => {
+  const { onRead } = mock<DuplexChannelListeners>();
+  const usbChannelMock = createDuplexChannelMock({ onRead });
+  const scanner = new CustomA4Scanner(usbChannelMock);
+
+  (await scanner.connect()).assertOk('connect failed');
+
+  const encodedInitialError = ErrorResponseMessage.encode({
+    errorCode: ResponseErrorCode.INVALID_JOB_ID,
+  }).assertOk('encode failed');
+  const encodedNextError = ErrorResponseMessage.encode({
+    errorCode: ResponseErrorCode.INVALID_COMMAND,
+  }).assertOk('encode failed');
+
+  // send the same multiple times but only expect one update since the error
+  // hasn't changed
+  onRead
+    .mockResolvedValueOnce(ok(encodedInitialError))
+    .mockResolvedValueOnce(ok(encodedInitialError))
+    .mockResolvedValueOnce(ok(encodedInitialError))
+    .mockResolvedValueOnce(ok(encodedInitialError))
+    .mockResolvedValueOnce(ok(encodedInitialError))
+    .mockResolvedValueOnce(ok(encodedNextError));
+
+  const watcher = watchStatus(scanner, { interval: 1 });
+
+  try {
+    const status = await watcher.next();
+
+    expect(status).toEqual({
+      done: false,
+      value: err(ErrorCode.JobNotValid),
+    });
+
+    const status2 = await watcher.next();
+    expect(status2).toEqual({
+      done: false,
+      value: err(ErrorCode.InvalidCommand),
+    });
+  } finally {
+    watcher.stop();
+  }
+});
+
+test('watchStatus is done after calling `stop`', async () => {
+  const { onRead } = mock<DuplexChannelListeners>();
+  const usbChannelMock = createDuplexChannelMock({ onRead });
+  const scanner = new CustomA4Scanner(usbChannelMock);
+
+  (await scanner.connect()).assertOk('connect failed');
+  const internalStatus = fc.sample(arbitraryStatusInternalMessage(), 1)[0]!;
+  onRead.mockResolvedValueOnce(
+    ok(StatusInternalMessage.encode(internalStatus).assertOk('encode failed'))
+  );
+  const watcher = watchStatus(scanner, { interval: 1 });
+  watcher.stop();
+  expect(await watcher.next()).toEqual({ done: true, value: undefined });
+});

--- a/libs/custom-scanner/src/utils/status_watcher.ts
+++ b/libs/custom-scanner/src/utils/status_watcher.ts
@@ -1,0 +1,137 @@
+import { ok, Result, sleep, Optional } from '@votingworks/basics';
+import { valuesEncodeEquivalently } from '@votingworks/message-coder';
+import { ErrorCode, ScannerStatus } from '../types';
+import { debug as rootDebug } from '../debug';
+import { StatusInternalMessage } from '../protocol';
+import { CustomScanner } from '../types/custom_scanner';
+import { convertFromInternalStatus } from '../status';
+
+const debug = rootDebug.extend('watchStatus');
+
+const DEFAULT_WATCH_INTERVAL_MS = 250;
+
+/**
+ * Watches the status of the scanner and allows stopping.
+ */
+export interface StatusWatcher
+  extends AsyncIterableIterator<Result<ScannerStatus, ErrorCode>> {
+  stop(): void;
+}
+
+/**
+ * Watches scanner status for changes, yielding promises that resolve with new
+ * values whenever the changes occur. The watcher can be stopped by calling
+ * `stop` on the returned object.
+ *
+ * Unlike all the other public API methods, this method does not block calls
+ * to other public API methods and is not blocked by them. This is because it
+ * is intended to be used in a loop and the status calls should not interfere
+ * with other API calls.
+ *
+ * @example
+ *
+ * ```ts
+ * import { createInterface } from 'readline';
+ * import { openScanner, watchStatus } from '@votingworks/custom';
+ *
+ * const scanner = (await openScanner()).assertOk('failed to open scanner');
+ * const watcher = watchStatus(scanner);
+ * const rl = createInterface(process.stdin);
+ *
+ * rl.on('line', () => {
+ *   watcher.stop();
+ *   rl.close();
+ * });
+ *
+ * process.stdout.write('Press enter to stop watching status.\n');
+ *
+ * for await (const statusResult of watcher) {
+ *   if (statusResult.isErr()) {
+ *     console.error(statusResult.err());
+ *   } else {
+ *     const status = statusResult.ok();
+ *     console.log(status);
+ *   }
+ * }
+ * ```
+ */
+export function watchStatus(
+  scanner: CustomScanner,
+  { interval = DEFAULT_WATCH_INTERVAL_MS }: { interval?: number } = {}
+): StatusWatcher {
+  debug('watching status');
+  let stopping = false;
+  let lastStatusResponse: Optional<Result<StatusInternalMessage, ErrorCode>>;
+
+  async function next(): Promise<
+    IteratorResult<Result<ScannerStatus, ErrorCode>>
+  > {
+    debug('requesting next status');
+    if (stopping) {
+      debug('watching is stopped, returning done');
+      return { done: true, value: undefined };
+    }
+
+    debug('watcher getting status internal');
+    const getStatusRawResult = await scanner.getStatusRaw();
+
+    if (getStatusRawResult.isErr()) {
+      if (
+        lastStatusResponse?.isErr() &&
+        lastStatusResponse.err() === getStatusRawResult.err()
+      ) {
+        debug(
+          'watcher status internal error is the same as last time, waiting %dms before trying again',
+          interval
+        );
+        await sleep(interval);
+        return next();
+      }
+
+      debug('watcher status internal error is different, returning it');
+      lastStatusResponse = getStatusRawResult;
+      return { done: false, value: getStatusRawResult };
+    }
+
+    const statusInternal = getStatusRawResult.ok();
+
+    if (
+      lastStatusResponse?.isOk() &&
+      valuesEncodeEquivalently(
+        StatusInternalMessage,
+        lastStatusResponse.ok(),
+        statusInternal
+      )
+    ) {
+      debug(
+        'watcher status internal is the same as last time, waiting %dms before trying again',
+        interval
+      );
+      await sleep(interval);
+      return next();
+    }
+
+    const { status } = convertFromInternalStatus(statusInternal);
+
+    lastStatusResponse = getStatusRawResult;
+
+    debug('watcher status internal is different, returning it: %o', status);
+    return {
+      done: false,
+      value: ok(status),
+    };
+  }
+
+  return {
+    next,
+
+    stop() {
+      debug('stopping status watcher');
+      stopping = true;
+    },
+
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3651,7 +3651,7 @@ importers:
         version: 4.1.2
       debug:
         specifier: ^4.3.4
-        version: 4.3.4(supports-color@8.1.1)
+        version: 4.3.4
       usb:
         specifier: ^2.6.0
         version: 2.8.3
@@ -3719,6 +3719,9 @@ importers:
       jest-junit:
         specifier: ^15.0.0
         version: 15.0.0
+      jest-mock-extended:
+        specifier: ^3.0.4
+        version: 3.0.4(jest@29.4.3)(typescript@4.6.3)
       jest-watch-typeahead:
         specifier: 0.6.4
         version: 0.6.4(jest@29.4.3)
@@ -3730,7 +3733,7 @@ importers:
         version: 2.8.3
       ts-jest:
         specifier: ^29.0.5
-        version: 29.0.5(@babel/core@7.12.3)(@jest/types@29.5.0)(esbuild@0.17.11)(jest@29.5.0)(typescript@4.6.3)
+        version: 29.0.5(@babel/core@7.20.12)(esbuild@0.16.17)(jest@29.4.3)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -8729,7 +8732,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -12846,7 +12849,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.49.0
       '@typescript-eslint/type-utils': 5.49.0(eslint@8.33.0)(typescript@4.6.3)
       '@typescript-eslint/utils': 5.49.0(eslint@8.33.0)(typescript@4.6.3)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       eslint: 8.33.0
       ignore: 5.2.0
       natural-compare-lite: 1.4.0
@@ -12981,7 +12984,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.49.0
       '@typescript-eslint/types': 5.49.0
       '@typescript-eslint/typescript-estree': 5.49.0(typescript@4.6.3)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       eslint: 8.33.0
       typescript: 4.6.3
     transitivePeerDependencies:
@@ -13115,7 +13118,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.49.0(typescript@4.6.3)
       '@typescript-eslint/utils': 5.49.0(eslint@8.33.0)(typescript@4.6.3)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       eslint: 8.33.0
       tsutils: 3.21.0(typescript@4.6.3)
       typescript: 4.6.3
@@ -19205,7 +19208,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/parser': 5.49.0(eslint@8.33.0)(typescript@4.6.3)
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
       eslint: 8.33.0
       eslint-import-resolver-node: 0.3.7
     transitivePeerDependencies:
@@ -19418,7 +19421,7 @@ packages:
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
       doctrine: 2.1.0
       eslint: 8.33.0
       eslint-import-resolver-node: 0.3.7
@@ -20262,7 +20265,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.1.1
@@ -24729,6 +24732,17 @@ packages:
       slash: 3.0.0
       stack-utils: 2.0.5
 
+  /jest-mock-extended@3.0.4(jest@29.4.3)(typescript@4.6.3):
+    resolution: {integrity: sha512-2ynEZ7IEJNrhrgshklDMhrOdnmW4Nt+PhkyRqZxRgpwMo7JjmFWMzyp0+eSyk+H9KK1QjXI5xTZIw6x7cVDcRg==}
+    peerDependencies:
+      jest: ^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0
+      typescript: ^3.0.0 || ^4.0.0 || ^5.0.0
+    dependencies:
+      jest: 29.4.3(@types/node@18.11.18)
+      ts-essentials: 7.0.3(typescript@4.6.3)
+      typescript: 4.6.3
+    dev: true
+
   /jest-mock@25.5.0:
     resolution: {integrity: sha512-eXWuTV8mKzp/ovHc5+3USJMYsTBhyQ+5A1Mak35dey/RG8GlM4YWVylZuGgVXinaW6tpvk/RSecmF37FKUlpXA==}
     engines: {node: '>= 8.3'}
@@ -25646,7 +25660,7 @@ packages:
       '@babel/generator': 7.20.14
       '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.20.12)
       '@babel/plugin-syntax-typescript': 7.18.6(@babel/core@7.20.12)
-      '@babel/traverse': 7.20.13(supports-color@5.5.0)
+      '@babel/traverse': 7.20.13
       '@babel/types': 7.20.7
       '@jest/expect-utils': 29.4.3
       '@jest/transform': 29.4.3
@@ -32734,6 +32748,14 @@ packages:
     resolution: {integrity: sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==}
     dev: false
 
+  /ts-essentials@7.0.3(typescript@4.6.3):
+    resolution: {integrity: sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==}
+    peerDependencies:
+      typescript: '>=3.7.0'
+    dependencies:
+      typescript: 4.6.3
+    dev: true
+
   /ts-jest@26.5.6(jest@26.6.0)(typescript@4.6.3):
     resolution: {integrity: sha512-rua+rCP8DxpA8b4DQD/6X2HQS8Zy/xzViVYfEs2OQu68tkCuKLV0Md8pmX55+W24uRIyAsf/BajRfxOs+R2MKA==}
     engines: {node: '>= 10'}
@@ -33157,6 +33179,41 @@ packages:
       esbuild: 0.17.11
       fast-json-stable-stringify: 2.1.0
       jest: 29.5.0(@types/node@18.14.6)
+      jest-util: 29.4.3
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.3.7
+      typescript: 4.6.3
+      yargs-parser: 21.1.1
+    dev: true
+
+  /ts-jest@29.0.5(@babel/core@7.20.12)(esbuild@0.16.17)(jest@29.4.3)(typescript@4.6.3):
+    resolution: {integrity: sha512-PL3UciSgIpQ7f6XjVOmbi96vmDHUqAyqDr8YxzopDqX3kfgYtX1cuNeBjP+L9sFXi6nzsGGA6R3fP3DDDJyrxA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@jest/types': ^29.0.0
+      babel-jest: ^29.0.0
+      esbuild: '*'
+      jest: ^29.0.0
+      typescript: '>=4.3'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@jest/types':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+    dependencies:
+      '@babel/core': 7.20.12
+      bs-logger: 0.2.6
+      esbuild: 0.16.17
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.4.3(@types/node@18.11.18)
       jest-util: 29.4.3
       json5: 2.2.3
       lodash.memoize: 4.1.2


### PR DESCRIPTION
## Overview
Adds the ability to go into autoscan mode for load testing in the custom scanner demo program, this will continually watch for paper scan it and eject it without interpretation and keep track of the number of ballots counted. 

cc @benadida this should unblock load testing for you if you run the bin/demo program from libs/custom-scanner here 
