### PR TITLE
Implement card cert expiries

### DIFF
--- a/libs/auth/scripts/generate_dev_keys_and_certs.ts
+++ b/libs/auth/scripts/generate_dev_keys_and_certs.ts
@@ -26,22 +26,22 @@ import { runCommand } from './utils';
 const OPENSSL_CONFIG_PATH = './certs/openssl.cnf';
 
 async function generateDevPrivateKey(): Promise<Buffer> {
-  const privateKeyBase = await openssl([
+  const privateKey = await openssl([
     'ecparam',
     '-genkey',
     '-name',
     'prime256v1',
     '-noout',
   ]);
-  const privateKey = await openssl([
+  const encryptedPrivateKey = await openssl([
     'pkcs8',
     '-topk8',
     '-in',
-    privateKeyBase,
+    privateKey,
     '-passout',
     `pass:${DEV_PRIVATE_KEY_PASSWORD}`,
   ]);
-  return privateKey;
+  return encryptedPrivateKey;
 }
 
 async function extractPublicKeyFromDevPrivateKey(

--- a/libs/auth/src/certs.ts
+++ b/libs/auth/src/certs.ts
@@ -70,10 +70,15 @@ const CustomCertFieldsSchema: z.ZodSchema<CustomCertFields> = z.object({
 });
 
 /**
- * Cert expiries in days
+ * Cert expiries in days. Must be integers.
  */
 export const CERT_EXPIRY_IN_DAYS = {
-  DEV: 36500, // ~100 years
+  CARD_VX_CERT: 365 * 100, // 100 years
+  SYSTEM_ADMINISTRATOR_CARD_VX_ADMIN_CERT: 365 * 5, // 5 years
+  ELECTION_CARD_VX_ADMIN_CERT: Math.round(365 * 0.5), // 6 months
+
+  /** Used by dev/test cert-generation scripts */
+  DEV: 365 * 100, // 100 years
 } as const;
 
 /**

--- a/libs/auth/src/java_card.test.ts
+++ b/libs/auth/src/java_card.test.ts
@@ -736,6 +736,7 @@ test.each<{
   programInput: Parameters<Card['program']>[0];
   expectedCardType: CardType;
   expectedCertSubject: string;
+  expectedExpiryInDays: number;
   isElectionDataWriteExpected: boolean;
   expectedCardDetailsAfterProgramming: CardDetails;
 }>([
@@ -751,6 +752,7 @@ test.each<{
       '/1.3.6.1.4.1.59817.1=card' +
       `/1.3.6.1.4.1.59817.2=${DEV_JURISDICTION}` +
       '/1.3.6.1.4.1.59817.3=system-administrator/',
+    expectedExpiryInDays: 365 * 5,
     isElectionDataWriteExpected: false,
     expectedCardDetailsAfterProgramming: {
       jurisdiction: DEV_JURISDICTION,
@@ -771,6 +773,7 @@ test.each<{
       `/1.3.6.1.4.1.59817.2=${DEV_JURISDICTION}` +
       '/1.3.6.1.4.1.59817.3=election-manager' +
       `/1.3.6.1.4.1.59817.4=${electionHash}/`,
+    expectedExpiryInDays: Math.round(365 * 0.5),
     isElectionDataWriteExpected: true,
     expectedCardDetailsAfterProgramming: {
       jurisdiction: DEV_JURISDICTION,
@@ -789,6 +792,7 @@ test.each<{
       `/1.3.6.1.4.1.59817.2=${DEV_JURISDICTION}` +
       '/1.3.6.1.4.1.59817.3=poll-worker' +
       `/1.3.6.1.4.1.59817.4=${electionHash}/`,
+    expectedExpiryInDays: Math.round(365 * 0.5),
     isElectionDataWriteExpected: false,
     expectedCardDetailsAfterProgramming: {
       jurisdiction: DEV_JURISDICTION,
@@ -809,6 +813,7 @@ test.each<{
       `/1.3.6.1.4.1.59817.2=${DEV_JURISDICTION}` +
       '/1.3.6.1.4.1.59817.3=poll-worker-with-pin' +
       `/1.3.6.1.4.1.59817.4=${electionHash}/`,
+    expectedExpiryInDays: Math.round(365 * 0.5),
     isElectionDataWriteExpected: false,
     expectedCardDetailsAfterProgramming: {
       jurisdiction: DEV_JURISDICTION,
@@ -822,6 +827,7 @@ test.each<{
     programInput,
     expectedCardType,
     expectedCertSubject,
+    expectedExpiryInDays,
     isElectionDataWriteExpected,
     expectedCardDetailsAfterProgramming,
   }) => {
@@ -870,6 +876,7 @@ test.each<{
     expect(createCert).toHaveBeenCalledTimes(1);
     expect(createCert).toHaveBeenNthCalledWith(1, {
       certSubject: expectedCertSubject,
+      expiryInDays: expectedExpiryInDays,
       opensslConfig: './certs/openssl.cnf',
       publicKeyToSign: await publicKeyDerToPem(
         fs.readFileSync(
@@ -1087,6 +1094,7 @@ test('createAndStoreCardVxCert', async () => {
   expect(createCert).toHaveBeenCalledTimes(1);
   expect(createCert).toHaveBeenNthCalledWith(1, {
     certSubject: '/C=US/ST=CA/O=VotingWorks/1.3.6.1.4.1.59817.1=card/',
+    expiryInDays: 365 * 100,
     opensslConfig: './certs/openssl.cnf',
     publicKeyToSign: await publicKeyDerToPem(
       fs.readFileSync(

--- a/libs/auth/src/java_card.ts
+++ b/libs/auth/src/java_card.ts
@@ -27,6 +27,7 @@ import {
 } from './card';
 import { CardReader } from './card_reader';
 import {
+  CERT_EXPIRY_IN_DAYS,
   constructCardCertSubject,
   constructCardCertSubjectWithoutJurisdictionAndCardType,
   parseCardDetailsFromCert,
@@ -293,6 +294,10 @@ export class JavaCard implements Card {
     }
     const cardVxAdminCert = await createCert({
       certSubject: constructCardCertSubject(cardDetails),
+      expiryInDays:
+        user.role === 'system_administrator'
+          ? CERT_EXPIRY_IN_DAYS.SYSTEM_ADMINISTRATOR_CARD_VX_ADMIN_CERT
+          : CERT_EXPIRY_IN_DAYS.ELECTION_CARD_VX_ADMIN_CERT,
       opensslConfig: vxAdminOpensslConfigPath,
       publicKeyToSign: publicKey,
       signingCertAuthorityCert: vxAdminCertAuthorityCertPath,
@@ -709,6 +714,7 @@ export class JavaCard implements Card {
     );
     const cardVxCert = await createCert({
       certSubject: constructCardCertSubjectWithoutJurisdictionAndCardType(),
+      expiryInDays: CERT_EXPIRY_IN_DAYS.CARD_VX_CERT,
       opensslConfig: input.vxOpensslConfigPath,
       publicKeyToSign: publicKey,
       signingCertAuthorityCert: this.vxCertAuthorityCertPath,

--- a/libs/auth/src/openssl.ts
+++ b/libs/auth/src/openssl.ts
@@ -192,7 +192,7 @@ export async function verifySignature({
 export async function createCert({
   certSubject,
   certType = 'standard',
-  expiryInDays = 365,
+  expiryInDays,
   opensslConfig,
   publicKeyToSign,
   signingCertAuthorityCert,
@@ -201,7 +201,7 @@ export async function createCert({
 }: {
   certSubject: string;
   certType?: 'standard' | 'certAuthorityCert';
-  expiryInDays?: number;
+  expiryInDays: number;
   opensslConfig: FilePathOrBuffer;
   publicKeyToSign: FilePathOrBuffer;
   signingCertAuthorityCert: FilePathOrBuffer;

--- a/libs/auth/src/openssl.ts
+++ b/libs/auth/src/openssl.ts
@@ -208,15 +208,23 @@ export async function createCert({
   signingPrivateKey: FilePathOrBuffer;
   signingPrivateKeyPassword: string;
 }): Promise<Buffer> {
+  // TODO: Instead of using a throwaway private key to generate the cert signing request and
+  // injecting the public key we want using -force_pubkey, have the relevant HSM (Java Card, TPM,
+  // etc.) generate the cert signing request
+  const throwawayPrivateKey = await openssl([
+    'ecparam',
+    '-genkey',
+    '-name',
+    'prime256v1',
+    '-noout',
+  ]);
   const certSigningRequest = await openssl([
     'req',
     '-new',
     '-config',
     opensslConfig,
     '-key',
-    signingPrivateKey,
-    '-passin',
-    `pass:${signingPrivateKeyPassword}`,
+    throwawayPrivateKey,
     '-subj',
     certSubject,
   ]);


### PR DESCRIPTION
_Easiest reviewed by commit_

## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/3110

This PR implements card cert expiries, specifically:

- 100 years for VotingWorks-issued card certs 🧓
- 5 years for VxAdmin-issued sys admin card certs 🧒
- 6 months for VxAdmin-issued election card certs 👶

Certs generated by the `generate-dev-keys-and-certs` and `generate-test-keys-and-certs` scripts will continue to last for 100 years.

The PR also cleans up the openssl command that we're using for cert generation for added clarity.

## Testing

- [x] Updated unit tests
- [x] Inspected certs manually

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A
- [x] I have added JSDoc comments to any newly introduced exports