### PR TITLE
[libs/ui] Add VVSG2-compliant SegmentedButton component

### DIFF
--- a/apps/admin/frontend/src/components/ballot_mode_toggle.tsx
+++ b/apps/admin/frontend/src/components/ballot_mode_toggle.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
-import { Button, SegmentedButton } from '@votingworks/ui';
+import {
+  Button,
+  SegmentedButtonDeprecated as SegmentedButton,
+} from '@votingworks/ui';
 import { Admin } from '@votingworks/api';
 
 interface Props {

--- a/apps/admin/frontend/src/components/ballot_type_toggle.tsx
+++ b/apps/admin/frontend/src/components/ballot_type_toggle.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
-import { Button, SegmentedButton } from '@votingworks/ui';
+import {
+  Button,
+  SegmentedButtonDeprecated as SegmentedButton,
+} from '@votingworks/ui';
 
 interface Props {
   isAbsentee: boolean;

--- a/apps/admin/frontend/src/screens/ballot_list_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_list_screen.tsx
@@ -5,7 +5,7 @@ import pluralize from 'pluralize';
 import { assert, find } from '@votingworks/basics';
 import {
   Button,
-  SegmentedButton,
+  SegmentedButtonDeprecated as SegmentedButton,
   NoWrap,
   Prose,
   Table,

--- a/apps/admin/frontend/src/screens/ballot_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_screen.tsx
@@ -18,7 +18,7 @@ import pluralize from 'pluralize';
 import { LogEventId } from '@votingworks/logging';
 import {
   Button,
-  SegmentedButton,
+  SegmentedButtonDeprecated as SegmentedButton,
   Monospace,
   Prose,
   useStoredState,

--- a/apps/admin/frontend/src/screens/definition_contests_screen.tsx
+++ b/apps/admin/frontend/src/screens/definition_contests_screen.tsx
@@ -14,7 +14,12 @@ import {
   ContestId,
 } from '@votingworks/types';
 
-import { Button, SegmentedButton, Prose, Text } from '@votingworks/ui';
+import {
+  Button,
+  SegmentedButtonDeprecated as SegmentedButton,
+  Prose,
+  Text,
+} from '@votingworks/ui';
 import { readFileAsyncAsString } from '@votingworks/utils';
 import { InputEventFunction, TextareaEventFunction } from '../config/types';
 

--- a/apps/admin/frontend/src/screens/manual_data_import_index_screen.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_import_index_screen.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 import {
   Button,
-  SegmentedButton,
+  SegmentedButtonDeprecated as SegmentedButton,
   Prose,
   Table,
   TD,

--- a/apps/mark/frontend/src/app_cardless_voting.test.tsx
+++ b/apps/mark/frontend/src/app_cardless_voting.test.tsx
@@ -89,8 +89,13 @@ test('Cardless Voting Flow', async () => {
   fireEvent.change(precinctSelect, { target: { value: precinctId } });
   within(screen.getByTestId('electionInfoBar')).getByText(/Center Springfield/);
 
-  fireEvent.click(screen.getByText('Official Ballot Mode'));
-  expect(screen.getButton('Official Ballot Mode')).toBeDisabled();
+  fireEvent.click(
+    screen.getByRole('option', {
+      name: 'Official Ballot Mode',
+      selected: false,
+    })
+  );
+  screen.getByRole('option', { name: 'Official Ballot Mode', selected: true });
 
   // Remove card
   apiMock.setAuthStatusLoggedOut();
@@ -395,8 +400,16 @@ test('poll worker must select a precinct first', async () => {
   fireEvent.change(precinctSelect, { target: { value: precinctId } });
   within(screen.getByTestId('electionInfoBar')).getByText(/All Precincts/);
 
-  fireEvent.click(screen.getByText('Official Ballot Mode'));
-  expect(screen.getButton('Official Ballot Mode')).toBeDisabled();
+  fireEvent.click(
+    screen.getByRole('option', {
+      name: 'Official Ballot Mode',
+      selected: false,
+    })
+  );
+  screen.getByRole('option', {
+    name: 'Official Ballot Mode',
+    selected: true,
+  });
 
   // Remove card
   apiMock.setAuthStatusLoggedOut();

--- a/apps/mark/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark/frontend/src/app_end_to_end.test.tsx
@@ -44,7 +44,7 @@ afterEach(() => {
   apiMock.mockApiClient.assertComplete();
 });
 
-jest.setTimeout(15000);
+jest.setTimeout(20000);
 
 test('MarkAndPrint end-to-end flow', async () => {
   const logger = fakeLogger();
@@ -141,8 +141,13 @@ test('MarkAndPrint end-to-end flow', async () => {
   );
   within(screen.getByTestId('electionInfoBar')).getByText(/Center Springfield/);
 
-  userEvent.click(screen.getByText('Official Ballot Mode'));
-  expect(screen.getButton('Official Ballot Mode')).toBeDisabled();
+  userEvent.click(
+    screen.getByRole('option', {
+      name: 'Official Ballot Mode',
+      selected: false,
+    })
+  );
+  screen.getByRole('option', { name: 'Official Ballot Mode', selected: true });
 
   // Remove card
   apiMock.setAuthStatusLoggedOut();

--- a/apps/mark/frontend/src/components/settings_text_size.tsx
+++ b/apps/mark/frontend/src/components/settings_text_size.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { Button, SegmentedButton } from '@votingworks/ui';
+import {
+  Button,
+  SegmentedButtonDeprecated as SegmentedButton,
+} from '@votingworks/ui';
 
 import {
   SetUserSettings,

--- a/apps/mark/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.tsx
@@ -132,22 +132,16 @@ export function AdminScreen({
               </p>
               <h2>Test Ballot Mode</h2>
               <p>
-                <SegmentedButton>
-                  <Button
-                    onPress={toggleLiveMode}
-                    variant={isLiveMode ? 'regular' : 'primary'}
-                    disabled={!isLiveMode}
-                  >
-                    Test Ballot Mode
-                  </Button>
-                  <Button
-                    onPress={toggleLiveMode}
-                    variant={isLiveMode ? 'primary' : 'regular'}
-                    disabled={isLiveMode}
-                  >
-                    Official Ballot Mode
-                  </Button>
-                </SegmentedButton>
+                <SegmentedButton
+                  label="Test Ballot Mode"
+                  hideLabel
+                  onChange={toggleLiveMode}
+                  options={[
+                    { id: 'test', label: 'Test Ballot Mode' },
+                    { id: 'official', label: 'Official Ballot Mode' },
+                  ]}
+                  selectedOptionId={isLiveMode ? 'official' : 'test'}
+                />
                 <br />
                 <Text small italic as="span">
                   Switching the mode will reset the Ballots Printed count.

--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -227,14 +227,22 @@ test('election manager and poll worker configuration', async () => {
   // Change mode as Election Manager
   apiMock.expectGetScannerStatus(statusNoPaper);
   apiMock.expectSetTestMode(false);
-  config = { ...config, isTestMode: true };
+  config = { ...config, isTestMode: false };
 
   await hackActuallyCleanUpReactModal();
 
   apiMock.expectGetConfig(config);
-  userEvent.click(await screen.findButton('Official Ballot Mode'));
+  userEvent.click(
+    await screen.findByRole('option', {
+      name: 'Official Ballot Mode',
+      selected: false,
+    })
+  );
   await waitFor(() =>
-    expect(screen.getButton('Official Ballot Mode')).toBeDisabled()
+    screen.findByRole('option', {
+      name: 'Official Ballot Mode',
+      selected: true,
+    })
   );
 
   // Change precinct as Election Manager

--- a/apps/scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.tsx
@@ -125,22 +125,16 @@ export function ElectionManagerScreen({
           />
         )}
         <p>
-          <SegmentedButton>
-            <Button
-              large
-              onPress={handleTogglingTestMode}
-              disabled={isTestMode || setTestModeMutation.isLoading}
-            >
-              Test Ballot Mode
-            </Button>
-            <Button
-              large
-              onPress={handleTogglingTestMode}
-              disabled={!isTestMode || setTestModeMutation.isLoading}
-            >
-              Official Ballot Mode
-            </Button>
-          </SegmentedButton>
+          <SegmentedButton
+            disabled={setTestModeMutation.isLoading}
+            label="Ballot Mode:"
+            onChange={handleTogglingTestMode}
+            options={[
+              { id: 'test', label: 'Test Ballot Mode' },
+              { id: 'official', label: 'Official Ballot Mode' },
+            ]}
+            selectedOptionId={isTestMode ? 'test' : 'official'}
+          />
         </p>
         <p>
           <SetClockButton large>

--- a/libs/types/src/ui_theme.ts
+++ b/libs/types/src/ui_theme.ts
@@ -77,6 +77,7 @@ export interface SizeTheme {
   };
   readonly letterSpacingEm: number;
   readonly lineHeight: number;
+  readonly minTouchAreaSeparationPx: number;
   readonly minTouchAreaSizePx: number;
 }
 

--- a/libs/ui/src/button.tsx
+++ b/libs/ui/src/button.tsx
@@ -32,6 +32,7 @@ export interface StyledButtonProps {
   className?: string;
   disabled?: boolean;
   id?: string;
+  role?: string;
   variant?: ButtonVariant;
 
   /** @deprecated Place the button within a flex or grid container instead. */
@@ -160,7 +161,7 @@ function getBorderColor(p: ThemedStyledButtonProps): Color | undefined {
 
 const sizeThemeStyles = css<StyledButtonProps>`
   align-items: center;
-  display: flex;
+  display: inline-flex;
   flex-wrap: wrap;
   justify-content: center;
   font-family: inherit;
@@ -348,7 +349,7 @@ export class Button<T = undefined> extends PureComponent<
   }
 }
 
-export const SegmentedButton = styled.span`
+export const SegmentedButtonDeprecated = styled.span`
   display: inline-flex;
   white-space: nowrap;
   & > button {

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -47,6 +47,7 @@ export * from './react_query';
 export * from './reboot_from_usb_button';
 export * from './reboot_to_bios_button';
 export * from './rotate_card_image';
+export * from './segmented_button';
 export * from './themes/render_with_themes';
 export * from './screen';
 export * from './seal';

--- a/libs/ui/src/segmented_button.stories.tsx
+++ b/libs/ui/src/segmented_button.stories.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+
+import {
+  SegmentedButton as Component,
+  SegmentedButtonOptionId,
+  SegmentedButtonProps,
+} from './segmented_button';
+
+const initialProps: SegmentedButtonProps<string> = {
+  label: 'Ballot Mode:',
+  onChange: () => undefined,
+  options: [
+    {
+      id: 'official',
+      label: 'Official',
+      ariaLabel: 'Enable official ballot mode',
+    },
+    {
+      id: 'test',
+      label: 'Test',
+    },
+    {
+      id: 'sample',
+      label: 'Sample',
+    },
+  ],
+};
+
+const meta: Meta<typeof Component> = {
+  title: 'libs-ui/SegmentedButton',
+  component: Component,
+  args: initialProps,
+  argTypes: {
+    onChange: {},
+  },
+};
+
+export default meta;
+
+export function SegmentedButton(
+  props: SegmentedButtonProps<string>
+): JSX.Element {
+  const [selectedOptionId, setSelectedOptionId] =
+    React.useState<SegmentedButtonOptionId>('test');
+
+  return (
+    <Component
+      {...props}
+      onChange={setSelectedOptionId}
+      selectedOptionId={selectedOptionId}
+    />
+  );
+}

--- a/libs/ui/src/segmented_button.test.tsx
+++ b/libs/ui/src/segmented_button.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '../test/react_testing_library';
+import { SegmentedButton, SegmentedButtonOption } from './segmented_button';
+
+type TestOptionId = 'a' | 'b' | 'c';
+
+const TEST_OPTIONS: ReadonlyArray<SegmentedButtonOption<TestOptionId>> = [
+  { id: 'a', label: 'Option A' },
+  { id: 'b', label: 'Option B' },
+  { id: 'c', label: 'Option C', ariaLabel: 'Enable Option C' },
+];
+
+test('renders all provided options ', () => {
+  const onChange = jest.fn();
+
+  render(
+    <SegmentedButton
+      label="Test Label"
+      onChange={onChange}
+      options={TEST_OPTIONS}
+      selectedOptionId="b"
+    />
+  );
+
+  expect(onChange).not.toHaveBeenCalled();
+
+  // Verify the label is rendered:
+  screen.getByText('Test Label');
+
+  // Verify the options are rendered in an accessible listbox:
+  screen.getByRole('listbox', { name: 'Test Label' });
+
+  //
+  // Verify all option clicks work as expected:
+  //
+  userEvent.click(
+    screen.getByRole('option', { name: 'Option A', selected: false })
+  );
+  expect(onChange).toHaveBeenCalledWith<[TestOptionId]>('a');
+
+  userEvent.click(
+    screen.getByRole('option', { name: 'Option B', selected: true })
+  );
+  expect(onChange).toHaveBeenCalledWith<[TestOptionId]>('b');
+
+  userEvent.click(
+    screen.getByRole('option', { name: 'Enable Option C', selected: false })
+  );
+  expect(onChange).toHaveBeenCalledWith<[TestOptionId]>('c');
+});
+
+test('optionally hides label', () => {
+  const onChange = jest.fn();
+
+  render(
+    <SegmentedButton
+      hideLabel
+      label="Test Label"
+      onChange={onChange}
+      options={TEST_OPTIONS}
+      vertical
+    />
+  );
+
+  // Verify the label is not rendered:
+  expect(screen.queryByText('Test Label')).not.toBeInTheDocument();
+
+  // Verify the options are still rendered in an accessible listbox:
+  screen.getByRole('listbox', { name: 'Test Label' });
+});

--- a/libs/ui/src/segmented_button.tsx
+++ b/libs/ui/src/segmented_button.tsx
@@ -1,0 +1,107 @@
+/* stylelint-disable order/properties-order */
+import React from 'react';
+import styled from 'styled-components';
+
+import { Button } from './button';
+import { Caption } from './typography';
+
+/** Props for {@link SegmentedButton}. */
+export interface SegmentedButtonProps<T extends SegmentedButtonOptionId> {
+  disabled?: boolean;
+  hideLabel?: boolean;
+  label: string;
+  onChange: (newId: T) => void;
+  options: ReadonlyArray<SegmentedButtonOption<T>>;
+  selectedOptionId?: T;
+  vertical?: boolean;
+}
+
+/** Option schema for {@link SegmentedButton}. */
+export interface SegmentedButtonOption<
+  T extends SegmentedButtonOptionId = string
+> {
+  id: T;
+  label: React.ReactNode;
+  ariaLabel?: string;
+}
+
+/** Option ID type for {@link SegmentedButton}. */
+export type SegmentedButtonOptionId = string | number;
+
+const OuterContainer = styled.span`
+  display: inline-block;
+`;
+
+const LabelContainer = styled(Caption)`
+  display: block;
+`;
+
+interface OptionsContainerProps {
+  isVertical?: boolean;
+}
+
+const OptionsContainer = styled.span<OptionsContainerProps>`
+  border: ${(p) => p.theme.sizes.bordersRem.hairline}rem solid
+    ${(p) => p.theme.colors.foreground};
+  border-radius: 0.25rem;
+  display: inline-flex;
+  flex-direction: ${(p) => (p.isVertical ? 'column' : 'row')};
+  gap: ${(p) => p.theme.sizes.minTouchAreaSeparationPx}px;
+  padding: 0.75rem;
+`;
+
+/**
+ * Renders a list of options as labelled buttons, where only one option can be
+ * selected at a time.
+ *
+ * Once an option has been selected, it cannot be de-selected unless a different
+ * option is selected, similar to the behavior of radio buttons.
+ *
+ * This is not a true segmented button, since the buttons have gaps between them
+ * in order to satisfy requirements from VVSG 2.0 Ch 7.2-I – Touch area size.
+ */
+export function SegmentedButton<T extends SegmentedButtonOptionId>(
+  props: SegmentedButtonProps<T>
+): JSX.Element {
+  const {
+    disabled,
+    hideLabel,
+    label,
+    onChange,
+    options,
+    selectedOptionId,
+    vertical,
+  } = props;
+
+  return (
+    <OuterContainer>
+      {!hideLabel && (
+        <LabelContainer aria-hidden weight="semiBold">
+          {label}
+        </LabelContainer>
+      )}
+      <OptionsContainer
+        aria-disabled={disabled}
+        aria-label={label}
+        aria-orientation={vertical ? 'vertical' : 'horizontal'}
+        isVertical={vertical}
+        role="listbox"
+      >
+        {options.map((o) => (
+          <Button
+            aria-label={o.ariaLabel}
+            aria-selected={o.id === selectedOptionId}
+            disabled={disabled}
+            key={o.id}
+            onPress={onChange}
+            role="option"
+            value={o.id}
+            variant={o.id === selectedOptionId ? 'primary' : 'regular'}
+          >
+            {o.label}
+          </Button>
+        ))}
+      </OptionsContainer>
+    </OuterContainer>
+  );
+}

--- a/libs/ui/src/themes/make_theme.ts
+++ b/libs/ui/src/themes/make_theme.ts
@@ -123,6 +123,11 @@ function getFontSize(mode: SizeMode): number {
 const VVSG_MIN_TOUCH_AREA_SIZE_MM = 12.7;
 const VVSG_MIN_TOUCH_AREA_SIZE_PX = mmToPx(VVSG_MIN_TOUCH_AREA_SIZE_MM);
 
+const VVSG_MIN_TOUCH_AREA_SEPARATION_MM = 2.54;
+const VVSG_MIN_TOUCH_AREA_SEPARATION_PX = mmToPx(
+  VVSG_MIN_TOUCH_AREA_SEPARATION_MM
+);
+
 const sizeThemes: Record<SizeMode, SizeTheme> = {
   s: {
     bordersRem: {
@@ -148,6 +153,7 @@ const sizeThemes: Record<SizeMode, SizeTheme> = {
     },
     letterSpacingEm: 0.01,
     lineHeight: 1.3,
+    minTouchAreaSeparationPx: VVSG_MIN_TOUCH_AREA_SEPARATION_PX,
     minTouchAreaSizePx: VVSG_MIN_TOUCH_AREA_SIZE_PX,
   },
   m: {
@@ -174,6 +180,7 @@ const sizeThemes: Record<SizeMode, SizeTheme> = {
     },
     letterSpacingEm: 0.01,
     lineHeight: 1.15,
+    minTouchAreaSeparationPx: VVSG_MIN_TOUCH_AREA_SEPARATION_PX,
     minTouchAreaSizePx: VVSG_MIN_TOUCH_AREA_SIZE_PX,
   },
   l: {
@@ -200,6 +207,7 @@ const sizeThemes: Record<SizeMode, SizeTheme> = {
     },
     letterSpacingEm: 0.005,
     lineHeight: 1.1,
+    minTouchAreaSeparationPx: VVSG_MIN_TOUCH_AREA_SEPARATION_PX,
     minTouchAreaSizePx: VVSG_MIN_TOUCH_AREA_SIZE_PX,
   },
   xl: {
@@ -226,6 +234,7 @@ const sizeThemes: Record<SizeMode, SizeTheme> = {
     },
     letterSpacingEm: 0.005,
     lineHeight: 1.1,
+    minTouchAreaSeparationPx: VVSG_MIN_TOUCH_AREA_SEPARATION_PX,
     minTouchAreaSizePx: VVSG_MIN_TOUCH_AREA_SIZE_PX,
   },
 
@@ -253,6 +262,7 @@ const sizeThemes: Record<SizeMode, SizeTheme> = {
     },
     letterSpacingEm: 0, // Browser default.
     lineHeight: 1.2,
+    minTouchAreaSeparationPx: 0,
     minTouchAreaSizePx: 0,
   },
 };


### PR DESCRIPTION
## Overview

Related to: https://github.com/votingworks/vxsuite/issues/3185

Deprecating the existing `SegmentedButton` component and adding a new one that satisfies VVSG2.0 requirements WRT [size](https://docs.google.com/document/d/1A5UX8Z0v12Vvf_jVOUmrOEvUNah2Xxmtltll6ZJW6Ps/edit#bookmark=id.4wj2pvb6lism), [contrast](https://docs.google.com/document/d/1A5UX8Z0v12Vvf_jVOUmrOEvUNah2Xxmtltll6ZJW6Ps/edit#bookmark=id.9enr31j2ams1) and [touch area size and separation](https://docs.google.com/document/d/1A5UX8Z0v12Vvf_jVOUmrOEvUNah2Xxmtltll6ZJW6Ps/edit#bookmark=id.istc3x4un6r)

Technically no longer a "segmented button", since we needed to add the touch area separation, but kept the naming anyway, since folks might be used to looking for that component for certain use cases.

Only replacing the uses in the voter-facing VxMark & VxScan for now, since those will get the new VVSG themes first.

## Demo Video or Screenshot
https://user-images.githubusercontent.com/264902/230432574-68d5a608-6090-4ffd-b98e-2ccb752d14ed.mov

### In Context - VxScan
#### Before:
<img width="400" alt="Screenshot 2023-04-05 at 14 29 51" src="https://user-images.githubusercontent.com/264902/230432694-6e372189-eecb-4352-9aa9-dbd9fb427af9.png">

#### After:
https://user-images.githubusercontent.com/264902/230432810-493129fe-e79c-4136-adc2-a18ddb0baea4.mov

### In Context - VxMark
https://user-images.githubusercontent.com/264902/230433218-1fba3733-b515-41cd-90bd-90b3f3ae8ad1.mov

## Testing Plan
- Added unit tests for `SegmentedButon`
- Added storybook.js entry for dev/demos/discoverability
- Updated tests that previously expected the options to be rendered as `"button"` roles.

## Checklist

- [n/a] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
