### PR TITLE
feat(test-utils): add `suppressingConsoleOutput` helper

### DIFF
--- a/apps/mark/frontend/src/app.test.tsx
+++ b/apps/mark/frontend/src/app.test.tsx
@@ -1,4 +1,4 @@
-import { fakeKiosk } from '@votingworks/test-utils';
+import { fakeKiosk, suppressingConsoleOutput } from '@votingworks/test-utils';
 import {
   ALL_PRECINCTS_SELECTION,
   MemoryHardware,
@@ -40,30 +40,29 @@ it('will throw an error when using default api', async () => {
     },
   });
   const hardware = MemoryHardware.buildStandard();
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  jest.spyOn(console, 'error').mockImplementation(() => {});
 
-  render(<App hardware={hardware} />);
-
-  await screen.findByText('Something went wrong');
+  await suppressingConsoleOutput(async () => {
+    render(<App hardware={hardware} />);
+    await screen.findByText('Something went wrong');
+  });
 });
 
 it('Displays error boundary if the api returns an unexpected error', async () => {
   apiMock.expectGetMachineConfigToError();
   const storage = new MemoryStorage();
   const hardware = MemoryHardware.buildStandard();
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  jest.spyOn(console, 'error').mockImplementation(() => {});
-  render(
-    <App
-      hardware={hardware}
-      storage={storage}
-      apiClient={apiMock.mockApiClient}
-      reload={jest.fn()}
-    />
-  );
-  await advanceTimersAndPromises();
-  screen.getByText('Something went wrong');
+  await suppressingConsoleOutput(async () => {
+    render(
+      <App
+        hardware={hardware}
+        storage={storage}
+        apiClient={apiMock.mockApiClient}
+        reload={jest.fn()}
+      />
+    );
+    await advanceTimersAndPromises();
+    screen.getByText('Something went wrong');
+  });
 });
 
 it('prevents context menus from appearing', async () => {

--- a/libs/test-utils/package.json
+++ b/libs/test-utils/package.json
@@ -39,6 +39,7 @@
     "@votingworks/basics": "workspace:*",
     "@votingworks/types": "workspace:*",
     "buffer": "^6.0.3",
+    "chalk": "4",
     "deep-eql": "^4.1.3",
     "fast-check": "^2.18.0",
     "jest-diff": "^27.3.1",

--- a/libs/test-utils/src/console.test.ts
+++ b/libs/test-utils/src/console.test.ts
@@ -1,0 +1,41 @@
+/* eslint-disable no-console */
+import { suppressingConsoleOutput } from './console';
+
+test.each(['log', 'warn', 'error'] as const)(
+  'suppressingConsoleOutput replaces console.%s with a mock',
+  (method) => {
+    suppressingConsoleOutput(() => {
+      console[method]('test');
+      expect(console[method]).toHaveBeenNthCalledWith(1, 'test');
+    });
+    expect('mock' in console[method]).toEqual(false);
+  }
+);
+
+test('suppressingConsoleOutput returns the value returned by the callback', () => {
+  expect(suppressingConsoleOutput(() => 'test')).toEqual('test');
+  expect('mock' in console.log).toEqual(false);
+});
+
+test('suppressingConsoleOutput resolves to the value returned by the callback', async () => {
+  await expect(
+    suppressingConsoleOutput(async () => await Promise.resolve('test'))
+  ).resolves.toEqual('test');
+  expect('mock' in console.log).toEqual(false);
+});
+
+test('suppressingConsoleOutput throws the error thrown by the callback', () => {
+  expect(() =>
+    suppressingConsoleOutput(() => {
+      throw new Error('test');
+    })
+  ).toThrowError('test');
+  expect('mock' in console.log).toEqual(false);
+});
+
+test('suppressingConsoleOutput rejects with the error thrown by the callback', async () => {
+  await expect(
+    suppressingConsoleOutput(() => Promise.reject(new Error('test')))
+  ).rejects.toThrowError('test');
+  expect('mock' in console.log).toEqual(false);
+});

--- a/libs/test-utils/src/console.ts
+++ b/libs/test-utils/src/console.ts
@@ -1,0 +1,64 @@
+/* eslint-disable no-console */
+import { MaybePromise, Optional } from '@votingworks/basics';
+
+/**
+ * Suppresses console output during the execution of a function. Resolves to the
+ * return value of the function.
+ */
+export function suppressingConsoleOutput<T>(fn: () => Promise<T>): Promise<T>;
+
+/**
+ * Suppresses console output during the execution of a function. Returns the
+ * return value of the function.
+ */
+export function suppressingConsoleOutput<T>(fn: () => T): T;
+
+export function suppressingConsoleOutput<T>(
+  fn: () => MaybePromise<T>
+): MaybePromise<T> {
+  jest.spyOn(console, 'log').mockReturnValue();
+  jest.spyOn(console, 'warn').mockReturnValue();
+  jest.spyOn(console, 'error').mockReturnValue();
+
+  function cleanup() {
+    jest.spyOn(console, 'log').mockRestore();
+    jest.spyOn(console, 'warn').mockRestore();
+    jest.spyOn(console, 'error').mockRestore();
+  }
+
+  let value: Optional<MaybePromise<T>>;
+  let error: unknown;
+  let success = false;
+
+  try {
+    value = fn();
+    success = true;
+  } catch (e) {
+    error = e;
+  }
+
+  if (!success) {
+    cleanup();
+    throw error;
+  }
+
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as Promise<T>).then === 'function'
+  ) {
+    return (value as Promise<T>).then(
+      (v) => {
+        cleanup();
+        return v;
+      },
+      (e) => {
+        cleanup();
+        throw e;
+      }
+    );
+  }
+
+  cleanup();
+  return value as T;
+}

--- a/libs/test-utils/src/console.ts
+++ b/libs/test-utils/src/console.ts
@@ -1,5 +1,94 @@
-/* eslint-disable no-console */
+import chalk from 'chalk';
 import { MaybePromise, Optional } from '@votingworks/basics';
+
+const capturedCallCountsByTest = new Map<
+  string,
+  Map<'log' | 'warn' | 'error', { count: number }>
+>();
+
+/**
+ * Strips ANSI escape codes from a string. When printing a box around a string
+ * with ANSI escape codes, the box will be the wrong size. This function removes
+ * the ANSI escape codes so that the box is the correct size.
+ */
+function stripAnsi(str: string): string {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/\x1b\[[0-9;]*m/g, '');
+}
+
+function printLinesInBox(lines: string[], out: NodeJS.WritableStream) {
+  const boxTopLeft = '┌';
+  const boxTopRight = '┐';
+  const boxTopAndBottom = '─';
+  const boxLeft = '│';
+  const boxRight = '│';
+  const boxBottomLeft = '└';
+  const boxBottomRight = '┘';
+
+  const longestLine = lines.reduce(
+    (longest, line) => Math.max(longest, stripAnsi(line).length),
+    0
+  );
+
+  const boxTop = `${boxTopLeft}${boxTopAndBottom.repeat(
+    longestLine + 2
+  )}${boxTopRight}`;
+  const boxBottom = `${boxBottomLeft}${boxTopAndBottom.repeat(
+    longestLine + 2
+  )}${boxBottomRight}`;
+
+  out.write(chalk.dim(`${boxTop}\n`));
+  for (const line of lines) {
+    out.write(
+      chalk.dim(
+        `${boxLeft} ${line}${' '.repeat(
+          longestLine - stripAnsi(line).length
+        )} ${boxRight}\n`
+      )
+    );
+  }
+  out.write(chalk.dim(`${boxBottom}\n`));
+}
+
+beforeAll(() => {
+  capturedCallCountsByTest.clear();
+});
+
+afterAll(() => {
+  const shouldPrintSummary = process.env['CI'] !== 'true';
+
+  if (!shouldPrintSummary) {
+    return;
+  }
+
+  const allSummaries = Array.from(capturedCallCountsByTest).flatMap(
+    ([testName, capturedCallCounts]) => {
+      const summaries = Array.from(capturedCallCounts.entries())
+        .filter(([, { count }]) => count > 0)
+        .map(([name, { count }]) => `${count} ${name}`);
+
+      return summaries.length > 0
+        ? [`${testName} (${summaries.join(', ')})`]
+        : [];
+    }
+  );
+
+  if (allSummaries.length > 0) {
+    printLinesInBox(
+      [
+        '🤫 Some tests suppressed console output:',
+        '',
+        ...allSummaries,
+        '',
+        `Run with ${chalk.italic(
+          'SUPPRESS_CONSOLE_OUTPUT=false'
+        )} to see the output.`,
+      ],
+      process.stderr
+    );
+    process.stderr.write('\n');
+  }
+});
 
 /**
  * Suppresses console output during the execution of a function. Resolves to the
@@ -16,9 +105,32 @@ export function suppressingConsoleOutput<T>(fn: () => T): T;
 export function suppressingConsoleOutput<T>(
   fn: () => MaybePromise<T>
 ): MaybePromise<T> {
-  jest.spyOn(console, 'log').mockReturnValue();
-  jest.spyOn(console, 'warn').mockReturnValue();
-  jest.spyOn(console, 'error').mockReturnValue();
+  if (process.env['SUPPRESS_CONSOLE_OUTPUT'] === 'false') {
+    return fn();
+  }
+
+  const { currentTestName } = expect.getState();
+  const capturedCallCounts =
+    capturedCallCountsByTest.get(currentTestName) ??
+    new Map([
+      ['log', { count: 0 }],
+      ['warn', { count: 0 }],
+      ['error', { count: 0 }],
+    ]);
+  capturedCallCountsByTest.set(currentTestName, capturedCallCounts);
+  const logStats = capturedCallCounts.get('log') as { count: number };
+  const warnStats = capturedCallCounts.get('warn') as { count: number };
+  const errorStats = capturedCallCounts.get('error') as { count: number };
+
+  jest.spyOn(console, 'log').mockImplementation(() => {
+    logStats.count += 1;
+  });
+  jest.spyOn(console, 'warn').mockImplementation(() => {
+    warnStats.count += 1;
+  });
+  jest.spyOn(console, 'error').mockImplementation(() => {
+    errorStats.count += 1;
+  });
 
   function cleanup() {
     jest.spyOn(console, 'log').mockRestore();

--- a/libs/test-utils/src/console.ts
+++ b/libs/test-utils/src/console.ts
@@ -50,45 +50,49 @@ function printLinesInBox(lines: string[], out: NodeJS.WritableStream) {
   out.write(chalk.dim(`${boxBottom}\n`));
 }
 
-beforeAll(() => {
-  capturedCallCountsByTest.clear();
-});
+if (typeof beforeAll === 'function' && typeof afterAll === 'function') {
+  beforeAll(() => {
+    capturedCallCountsByTest.clear();
+  });
 
-afterAll(() => {
-  const shouldPrintSummary = process.env['CI'] !== 'true';
+  afterAll(() => {
+    const shouldPrintSummary = process.env['CI'] !== 'true';
 
-  if (!shouldPrintSummary) {
-    return;
-  }
-
-  const allSummaries = Array.from(capturedCallCountsByTest).flatMap(
-    ([testName, capturedCallCounts]) => {
-      const summaries = Array.from(capturedCallCounts.entries())
-        .filter(([, { count }]) => count > 0)
-        .map(([name, { count }]) => `${count} ${name}${count > 1 ? 's' : ''}`);
-
-      return summaries.length > 0
-        ? [`${testName} (${summaries.join(', ')})`]
-        : [];
+    if (!shouldPrintSummary) {
+      return;
     }
-  );
 
-  if (allSummaries.length > 0) {
-    printLinesInBox(
-      [
-        '🤫 Some tests suppressed console output:',
-        '',
-        ...allSummaries,
-        '',
-        `Run with ${chalk.italic(
-          'SUPPRESS_CONSOLE_OUTPUT=false'
-        )} to see the output.`,
-      ],
-      process.stderr
+    const allSummaries = Array.from(capturedCallCountsByTest).flatMap(
+      ([testName, capturedCallCounts]) => {
+        const summaries = Array.from(capturedCallCounts.entries())
+          .filter(([, { count }]) => count > 0)
+          .map(
+            ([name, { count }]) => `${count} ${name}${count > 1 ? 's' : ''}`
+          );
+
+        return summaries.length > 0
+          ? [`${testName} (${summaries.join(', ')})`]
+          : [];
+      }
     );
-    process.stderr.write('\n');
-  }
-});
+
+    if (allSummaries.length > 0) {
+      printLinesInBox(
+        [
+          '🤫 Some tests suppressed console output:',
+          '',
+          ...allSummaries,
+          '',
+          `Run with ${chalk.italic(
+            'SUPPRESS_CONSOLE_OUTPUT=false'
+          )} to see the output.`,
+        ],
+        process.stderr
+      );
+      process.stderr.write('\n');
+    }
+  });
+}
 
 /**
  * Suppresses console output during the execution of a function. Resolves to the

--- a/libs/test-utils/src/console.ts
+++ b/libs/test-utils/src/console.ts
@@ -65,7 +65,7 @@ afterAll(() => {
     ([testName, capturedCallCounts]) => {
       const summaries = Array.from(capturedCallCounts.entries())
         .filter(([, { count }]) => count > 0)
-        .map(([name, { count }]) => `${count} ${name}`);
+        .map(([name, { count }]) => `${count} ${name}${count > 1 ? 's' : ''}`);
 
       return summaries.length > 0
         ? [`${testName} (${summaries.join(', ')})`]

--- a/libs/test-utils/src/index.ts
+++ b/libs/test-utils/src/index.ts
@@ -4,6 +4,7 @@ export * from './auth';
 export * from './cast_vote_record';
 export * from './child_process';
 export * from './compressed_tallies';
+export * from './console';
 export * from './expect_print';
 export * from './fake_file_writer';
 export * from './fake_kiosk';

--- a/libs/ui/src/error_boundary.test.tsx
+++ b/libs/ui/src/error_boundary.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { suppressingConsoleOutput } from '@votingworks/test-utils';
 import { render, screen } from '../test/react_testing_library';
 import { ErrorBoundary } from './error_boundary';
 
@@ -6,13 +7,14 @@ test('renders error when there is an error', async () => {
   function ThrowError(): JSX.Element {
     throw new Error('error');
   }
-  jest.spyOn(console, 'error').mockReturnValue();
-  render(
-    <ErrorBoundary errorMessage="jellyfish">
-      <ThrowError />
-    </ErrorBoundary>
-  );
-  await screen.findByText('jellyfish');
+  await suppressingConsoleOutput(async () => {
+    render(
+      <ErrorBoundary errorMessage="jellyfish">
+        <ThrowError />
+      </ErrorBoundary>
+    );
+    await screen.findByText('jellyfish');
+  });
 });
 
 test('renders children when there is no error', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4732,6 +4732,9 @@ importers:
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
+      chalk:
+        specifier: '4'
+        version: 4.1.2
       deep-eql:
         specifier: ^4.1.3
         version: 4.1.3
@@ -5163,7 +5166,7 @@ importers:
         version: 2.2.0
       jest:
         specifier: ^27.3.1
-        version: 27.3.1
+        version: 27.3.1(canvas@2.9.1)
       jest-junit:
         specifier: ^14.0.1
         version: 14.0.1
@@ -5220,7 +5223,7 @@ importers:
         version: 1.10.0
       ts-jest:
         specifier: ^27.0.7
-        version: 27.0.7(@babel/core@7.20.12)(@types/jest@27.0.3)(jest@27.3.1)(typescript@4.6.3)
+        version: 27.0.7(@babel/core@7.12.3)(@types/jest@27.0.3)(jest@27.3.1)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -5488,10 +5491,10 @@ packages:
       '@babel/helpers': 7.20.13
       '@babel/parser': 7.20.13
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.13
+      '@babel/traverse': 7.20.13(supports-color@5.5.0)
       '@babel/types': 7.20.7
       convert-source-map: 1.8.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.0
@@ -5633,8 +5636,8 @@ packages:
       '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.20.12)
       '@babel/helper-module-imports': 7.18.6
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/traverse': 7.20.13
-      debug: 4.3.4
+      '@babel/traverse': 7.20.13(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.1
       semver: 6.3.0
@@ -5650,7 +5653,7 @@ packages:
       '@babel/core': 7.20.12
       '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.20.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.1
       semver: 6.3.0
@@ -5799,7 +5802,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/helper-validator-identifier': 7.19.1
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.13
+      '@babel/traverse': 7.20.13(supports-color@5.5.0)
       '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
@@ -5857,7 +5860,7 @@ packages:
       '@babel/helper-member-expression-to-functions': 7.20.7
       '@babel/helper-optimise-call-expression': 7.18.6
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.13
+      '@babel/traverse': 7.20.13(supports-color@5.5.0)
       '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
@@ -5926,7 +5929,7 @@ packages:
     dependencies:
       '@babel/helper-function-name': 7.19.0
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.13
+      '@babel/traverse': 7.20.13(supports-color@5.5.0)
       '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
@@ -5938,7 +5941,7 @@ packages:
     dependencies:
       '@babel/helper-function-name': 7.19.0
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.13
+      '@babel/traverse': 7.20.13(supports-color@5.5.0)
       '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
@@ -5958,7 +5961,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.13
+      '@babel/traverse': 7.20.13(supports-color@5.5.0)
       '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
@@ -6430,6 +6433,16 @@ packages:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
 
+  /@babel/plugin-syntax-flow@7.18.6(@babel/core@7.12.3):
+    resolution: {integrity: sha512-LUbR+KNTBWCUAqRG9ex5Gnzu2IOkt8jRJbHHXFT9q+L9zm7M/QQbEqXyw1n1pohYvOyWC8CjeyjrSaIwiYjK7A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
   /@babel/plugin-syntax-flow@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-LUbR+KNTBWCUAqRG9ex5Gnzu2IOkt8jRJbHHXFT9q+L9zm7M/QQbEqXyw1n1pohYvOyWC8CjeyjrSaIwiYjK7A==}
     engines: {node: '>=6.9.0'}
@@ -6479,6 +6492,16 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
+
+  /@babel/plugin-syntax-jsx@7.18.6(@babel/core@7.12.3):
+    resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.12.3
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-syntax-jsx@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
@@ -7215,6 +7238,20 @@ packages:
       '@babel/types': 7.20.7
     dev: true
 
+  /@babel/plugin-transform-react-jsx@7.20.13(@babel/core@7.12.3):
+    resolution: {integrity: sha512-MmTZx/bkUrfJhhYAYt3Urjm+h8DQGrPrnKQ94jLo7NLuOU+T89a7IByhKmrb8SKhrIYIQ0FN0CHMbnFRen4qNw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.12.3
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.12.3)
+      '@babel/types': 7.20.7
+    dev: true
+
   /@babel/plugin-transform-react-jsx@7.20.13(@babel/core@7.20.12):
     resolution: {integrity: sha512-MmTZx/bkUrfJhhYAYt3Urjm+h8DQGrPrnKQ94jLo7NLuOU+T89a7IByhKmrb8SKhrIYIQ0FN0CHMbnFRen4qNw==}
     engines: {node: '>=6.9.0'}
@@ -7740,7 +7777,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.14.5
       '@babel/parser': 7.20.13
       '@babel/types': 7.20.7
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -7759,23 +7796,6 @@ packages:
       '@babel/parser': 7.20.13
       '@babel/types': 7.20.7
       debug: 4.3.4(supports-color@8.1.1)
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-
-  /@babel/traverse@7.20.13:
-    resolution: {integrity: sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.20.14
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.19.0
-      '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.20.13
-      '@babel/types': 7.20.7
-      debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -7837,7 +7857,7 @@ packages:
       '@babel/plugin-proposal-class-properties': 7.16.7(@babel/core@7.20.12)
       '@babel/preset-env': 7.16.11(@babel/core@7.20.12)
       '@babel/preset-typescript': 7.16.7(@babel/core@7.20.12)
-      '@babel/traverse': 7.20.13
+      '@babel/traverse': 7.20.13(supports-color@5.5.0)
       '@babel/types': 7.20.7
       '@codemod/core': 2.0.1
       '@codemod/parser': 1.2.1
@@ -8607,7 +8627,7 @@ packages:
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       espree: 7.3.1
       globals: 13.20.0
       ignore: 4.0.6
@@ -8624,7 +8644,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       espree: 9.4.0
       globals: 13.20.0
       ignore: 5.2.0
@@ -8719,7 +8739,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8857,51 +8877,6 @@ packages:
       - ts-node
       - utf-8-validate
 
-  /@jest/core@27.3.1:
-    resolution: {integrity: sha512-DMNE90RR5QKx0EA+wqe3/TNEwiRpOkhshKNxtLxd4rt3IZpCt+RSL+FoJsGeblRZmqdK4upHA/mKKGPPRAifhg==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/console': 27.5.1
-      '@jest/reporters': 27.3.1
-      '@jest/test-result': 27.5.1
-      '@jest/transform': 27.5.1
-      '@jest/types': 27.5.1
-      '@types/node': 18.14.6
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      emittery: 0.8.1
-      exit: 0.1.2
-      graceful-fs: 4.2.10
-      jest-changed-files: 27.3.0
-      jest-config: 27.3.1
-      jest-haste-map: 27.3.1
-      jest-message-util: 27.5.1
-      jest-regex-util: 27.5.1
-      jest-resolve: 27.5.1
-      jest-resolve-dependencies: 27.3.1
-      jest-runner: 27.5.1
-      jest-runtime: 27.5.1
-      jest-snapshot: 27.5.1
-      jest-util: 27.5.1
-      jest-validate: 27.3.1
-      jest-watcher: 27.5.1
-      micromatch: 4.0.5
-      rimraf: 3.0.2
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - bufferutil
-      - canvas
-      - supports-color
-      - ts-node
-      - utf-8-validate
-    dev: true
-
   /@jest/core@27.3.1(canvas@2.9.1):
     resolution: {integrity: sha512-DMNE90RR5QKx0EA+wqe3/TNEwiRpOkhshKNxtLxd4rt3IZpCt+RSL+FoJsGeblRZmqdK4upHA/mKKGPPRAifhg==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -8979,51 +8954,6 @@ packages:
       jest-snapshot: 27.5.1
       jest-util: 27.5.1
       jest-validate: 27.4.2
-      jest-watcher: 27.5.1
-      micromatch: 4.0.5
-      rimraf: 3.0.2
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - bufferutil
-      - canvas
-      - supports-color
-      - ts-node
-      - utf-8-validate
-    dev: true
-
-  /@jest/core@27.5.1:
-    resolution: {integrity: sha512-AK6/UTrvQD0Cd24NSqmIA6rKsu0tKIxfiCducZvqxYdmMisOYAsdItspT+fQDQYARPf8XgjAFZi0ogW2agH5nQ==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/console': 27.5.1
-      '@jest/reporters': 27.5.1
-      '@jest/test-result': 27.5.1
-      '@jest/transform': 27.5.1
-      '@jest/types': 27.5.1
-      '@types/node': 18.14.6
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      emittery: 0.8.1
-      exit: 0.1.2
-      graceful-fs: 4.2.10
-      jest-changed-files: 27.5.1
-      jest-config: 27.5.1
-      jest-haste-map: 27.5.1
-      jest-message-util: 27.5.1
-      jest-regex-util: 27.5.1
-      jest-resolve: 27.5.1
-      jest-resolve-dependencies: 27.5.1
-      jest-runner: 27.5.1
-      jest-runtime: 27.5.1
-      jest-snapshot: 27.5.1
-      jest-util: 27.5.1
-      jest-validate: 27.5.1
       jest-watcher: 27.5.1
       micromatch: 4.0.5
       rimraf: 3.0.2
@@ -10317,7 +10247,7 @@ packages:
       magic-string: 0.27.0
       react-docgen-typescript: 2.2.2(typescript@4.9.4)
       typescript: 4.9.4
-      vite: 4.0.4
+      vite: 4.0.4(@types/node@16.11.29)
     dev: true
 
   /@jridgewell/gen-mapping@0.1.1:
@@ -10998,7 +10928,7 @@ packages:
       ejs: 3.1.8
       esbuild: 0.16.17
       esbuild-plugin-alias: 0.2.1
-      express: 4.18.2
+      express: 4.18.2(supports-color@6.1.0)
       find-cache-dir: 3.3.1
       fs-extra: 9.1.0
       process: 0.11.10
@@ -11035,7 +10965,7 @@ packages:
       '@storybook/types': 7.0.0-beta.31
       browser-assert: 1.2.1
       es-module-lexer: 0.9.3
-      express: 4.18.2
+      express: 4.18.2(supports-color@6.1.0)
       fs-extra: 9.1.0
       glob: 7.2.3
       glob-promise: 4.2.2(glob@7.2.3)
@@ -11043,7 +10973,7 @@ packages:
       rollup: 3.11.0
       slash: 3.0.0
       typescript: 4.9.4
-      vite: 4.0.4
+      vite: 4.0.4(@types/node@16.11.29)
       vite-plugin-externals: 0.5.1(vite@4.0.4)
     transitivePeerDependencies:
       - supports-color
@@ -11094,7 +11024,7 @@ packages:
       detect-indent: 6.1.0
       envinfo: 7.8.1
       execa: 5.1.1
-      express: 4.18.2
+      express: 4.18.2(supports-color@6.1.0)
       find-up: 5.0.0
       fs-extra: 9.1.0
       get-port: 5.1.1
@@ -11196,7 +11126,7 @@ packages:
       chalk: 4.1.2
       esbuild: 0.16.17
       esbuild-register: 3.4.2(esbuild@0.16.17)
-      express: 4.18.2
+      express: 4.18.2(supports-color@6.1.0)
       file-system-cache: 2.0.2
       find-up: 5.0.0
       fs-extra: 9.1.0
@@ -11242,9 +11172,9 @@ packages:
       boxen: 5.1.2
       chalk: 4.1.2
       cli-table3: 0.6.2
-      compression: 1.7.4
+      compression: 1.7.4(supports-color@6.1.0)
       detect-port: 1.5.1
-      express: 4.18.2
+      express: 4.18.2(supports-color@6.1.0)
       fs-extra: 9.1.0
       globby: 11.1.0
       ip: 2.0.0
@@ -11440,7 +11370,7 @@ packages:
       react: 17.0.2
       react-docgen: 6.0.0-alpha.3
       react-dom: 17.0.1(react@17.0.2)
-      vite: 4.0.4
+      vite: 4.0.4(@types/node@16.11.29)
     transitivePeerDependencies:
       - '@preact/preset-vite'
       - supports-color
@@ -11575,7 +11505,7 @@ packages:
       '@storybook/channels': 7.0.0-beta.31
       '@types/babel__core': 7.20.0
       '@types/express': 4.17.14
-      express: 4.18.2
+      express: 4.18.2(supports-color@6.1.0)
       file-system-cache: 2.0.2
     transitivePeerDependencies:
       - supports-color
@@ -11589,7 +11519,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       postcss: 7.0.35
-      postcss-syntax: 0.36.2(postcss@7.0.35)
+      postcss-syntax: 0.36.2(postcss-html@0.36.0)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@7.0.35)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11602,7 +11532,7 @@ packages:
       postcss-syntax: '>=0.36.2'
     dependencies:
       postcss: 7.0.35
-      postcss-syntax: 0.36.2(postcss@7.0.35)
+      postcss-syntax: 0.36.2(postcss-html@0.36.0)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@7.0.35)
       remark: 13.0.0
       unist-util-find-all-after: 3.0.2
     transitivePeerDependencies:
@@ -11998,7 +11928,7 @@ packages:
     resolution: {integrity: sha512-1zzPV9FDe1I/WHhRkf9SNgqtRJWZqrBWgu7JGveuHmmyR9CnAPCie2N/x+iHrgnpYBIcCJWHBoMRv2TRWktsvw==}
     deprecated: This is a stub types definition for chalk (https://github.com/chalk/chalk). chalk provides its own type definitions, so you don't need @types/chalk installed!
     dependencies:
-      chalk: 5.2.0
+      chalk: 4.1.2
     dev: true
 
   /@types/compression@1.7.2:
@@ -12765,7 +12695,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.37.0
       '@typescript-eslint/type-utils': 5.37.0(eslint@8.23.1)(typescript@4.6.3)
       '@typescript-eslint/utils': 5.37.0(eslint@8.23.1)(typescript@4.6.3)
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.23.1
       functional-red-black-tree: 1.0.1
       ignore: 5.2.0
@@ -12819,7 +12749,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.49.0
       '@typescript-eslint/type-utils': 5.49.0(eslint@8.23.1)(typescript@4.6.3)
       '@typescript-eslint/utils': 5.49.0(eslint@8.23.1)(typescript@4.6.3)
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.23.1
       ignore: 5.2.0
       natural-compare-lite: 1.4.0
@@ -12923,11 +12853,12 @@ packages:
       '@typescript-eslint/scope-manager': 5.37.0
       '@typescript-eslint/types': 5.37.0
       '@typescript-eslint/typescript-estree': 5.37.0(typescript@4.6.3)
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.23.1
       typescript: 4.6.3
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@typescript-eslint/parser@5.37.0(eslint@8.33.0)(typescript@4.6.3):
     resolution: {integrity: sha512-01VzI/ipYKuaG5PkE5+qyJ6m02fVALmMPY3Qq5BHflDx3y4VobbLdHQkSMg9VPRS4KdNt4oYTMaomFoHonBGAw==}
@@ -12962,7 +12893,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.49.0
       '@typescript-eslint/types': 5.49.0
       '@typescript-eslint/typescript-estree': 5.49.0(typescript@4.6.3)
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.23.1
       typescript: 4.6.3
     transitivePeerDependencies:
@@ -13056,7 +12987,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.37.0(typescript@4.6.3)
       '@typescript-eslint/utils': 5.37.0(eslint@8.23.1)(typescript@4.6.3)
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.23.1
       tsutils: 3.21.0(typescript@4.6.3)
       typescript: 4.6.3
@@ -13095,7 +13026,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.49.0(typescript@4.6.3)
       '@typescript-eslint/utils': 5.49.0(eslint@8.23.1)(typescript@4.6.3)
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.23.1
       tsutils: 3.21.0(typescript@4.6.3)
       typescript: 4.6.3
@@ -13176,7 +13107,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.22.0
       '@typescript-eslint/visitor-keys': 5.22.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.7
@@ -13218,7 +13149,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.37.0
       '@typescript-eslint/visitor-keys': 5.37.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.7
@@ -13238,7 +13169,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.49.0
       '@typescript-eslint/visitor-keys': 5.49.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.7
@@ -13447,7 +13378,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.19.6(@babel/core@7.20.12)
       magic-string: 0.27.0
       react-refresh: 0.14.0
-      vite: 4.0.4
+      vite: 4.0.4(@types/node@16.11.29)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -13689,7 +13620,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14742,26 +14673,6 @@ packages:
   /bn.js@5.1.3:
     resolution: {integrity: sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==}
 
-  /body-parser@1.20.1:
-    resolution: {integrity: sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==}
-    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
-    dependencies:
-      bytes: 3.1.2
-      content-type: 1.0.4
-      debug: 2.6.9
-      depd: 2.0.0
-      destroy: 1.2.0
-      http-errors: 2.0.0
-      iconv-lite: 0.4.24
-      on-finished: 2.4.1
-      qs: 6.11.0
-      raw-body: 2.5.1
-      type-is: 1.6.18
-      unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /body-parser@1.20.1(supports-color@6.1.0):
     resolution: {integrity: sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -14827,24 +14738,6 @@ packages:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
     dependencies:
       balanced-match: 1.0.2
-    dev: true
-
-  /braces@2.3.2:
-    resolution: {integrity: sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      arr-flatten: 1.1.0
-      array-unique: 0.3.2
-      extend-shallow: 2.0.1
-      fill-range: 4.0.0
-      isobject: 3.0.1
-      repeat-element: 1.1.4
-      snapdragon: 0.8.2
-      snapdragon-node: 2.1.1
-      split-string: 3.1.0
-      to-regex: 3.0.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /braces@2.3.2(supports-color@6.1.0):
@@ -15620,21 +15513,6 @@ packages:
     dependencies:
       mime-db: 1.52.0
 
-  /compression@1.7.4:
-    resolution: {integrity: sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==}
-    engines: {node: '>= 0.8.0'}
-    dependencies:
-      accepts: 1.3.8
-      bytes: 3.0.0
-      compressible: 2.0.18
-      debug: 2.6.9
-      on-headers: 1.0.2
-      safe-buffer: 5.1.2
-      vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /compression@1.7.4(supports-color@6.1.0):
     resolution: {integrity: sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==}
     engines: {node: '>= 0.8.0'}
@@ -15648,7 +15526,6 @@ packages:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -16296,16 +16173,6 @@ packages:
     resolution: {integrity: sha512-ER7EjqVAMkRRsxNCC5YqJ9d9VQYuWdGt7aiH2qA5R5wt8ZmWaP2dLUSIK6y/kVzLMlmh1Tvu5xUf4M/wdGJ5KA==}
     dev: false
 
-  /debug@2.6.9:
-    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.0.0
-
   /debug@2.6.9(supports-color@6.1.0):
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -16316,16 +16183,6 @@ packages:
     dependencies:
       ms: 2.0.0
       supports-color: 6.1.0
-
-  /debug@3.2.7:
-    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.3
 
   /debug@3.2.7(supports-color@5.5.0):
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -16397,17 +16254,6 @@ packages:
     dependencies:
       ms: 2.1.2
     dev: false
-
-  /debug@4.3.4:
-    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.2
 
   /debug@4.3.4(supports-color@5.5.0):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -16687,7 +16533,7 @@ packages:
     hasBin: true
     dependencies:
       address: 1.1.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -18087,7 +17933,7 @@ packages:
     peerDependencies:
       esbuild: '>=0.12 <1'
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       esbuild: 0.16.17
     transitivePeerDependencies:
       - supports-color
@@ -18804,7 +18650,7 @@ packages:
     dependencies:
       confusing-browser-globals: 1.0.11
       eslint: 8.23.1
-      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.37.0)(eslint@8.23.1)
+      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.21.0)(eslint@8.23.1)
       object.assign: 4.1.4
       object.entries: 1.1.5
       semver: 6.3.0
@@ -18836,7 +18682,7 @@ packages:
     dependencies:
       eslint: 8.23.1
       eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.26.0)(eslint@8.23.1)
-      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.37.0)(eslint@8.23.1)
+      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.21.0)(eslint@8.23.1)
       eslint-plugin-jsx-a11y: 6.6.1(eslint@8.23.1)
       eslint-plugin-react: 7.31.8(eslint@8.23.1)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.23.1)
@@ -19025,7 +18871,7 @@ packages:
   /eslint-import-resolver-node@0.3.6:
     resolution: {integrity: sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==}
     dependencies:
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@8.1.1)
       resolve: 1.22.1
     transitivePeerDependencies:
       - supports-color
@@ -19033,7 +18879,7 @@ packages:
   /eslint-import-resolver-node@0.3.7:
     resolution: {integrity: sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==}
     dependencies:
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@8.1.1)
       is-core-module: 2.11.0
       resolve: 1.22.1
     transitivePeerDependencies:
@@ -19066,7 +18912,6 @@ packages:
       eslint-import-resolver-node: 0.3.7
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.21.0)(eslint-import-resolver-node@0.3.7)(eslint@8.33.0):
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
@@ -19119,11 +18964,12 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/parser': 5.37.0(eslint@8.23.1)(typescript@4.6.3)
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@8.1.1)
       eslint: 8.23.1
       eslint-import-resolver-node: 0.3.7
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.37.0)(eslint-import-resolver-node@0.3.7)(eslint@8.33.0):
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
@@ -19176,7 +19022,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/parser': 5.49.0(eslint@8.23.1)(typescript@4.6.3)
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@8.1.1)
       eslint: 8.23.1
       eslint-import-resolver-node: 0.3.7
     transitivePeerDependencies:
@@ -19239,8 +19085,8 @@ packages:
       '@babel/plugin-transform-react-jsx': ^7.14.9
       eslint: ^8.1.0
     dependencies:
-      '@babel/plugin-syntax-flow': 7.18.6(@babel/core@7.20.12)
-      '@babel/plugin-transform-react-jsx': 7.20.13(@babel/core@7.20.12)
+      '@babel/plugin-syntax-flow': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-react-jsx': 7.20.13(@babel/core@7.12.3)
       eslint: 8.23.1
       lodash: 4.17.21
       string-natural-compare: 3.0.1
@@ -19275,7 +19121,6 @@ packages:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
-    dev: false
 
   /eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.37.0)(eslint@8.23.1):
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
@@ -19290,7 +19135,7 @@ packages:
       '@typescript-eslint/parser': 5.37.0(eslint@8.23.1)(typescript@4.6.3)
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@6.1.0)
       doctrine: 2.1.0
       eslint: 8.23.1
       eslint-import-resolver-node: 0.3.7
@@ -19306,6 +19151,7 @@ packages:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
+    dev: true
 
   /eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.37.0)(eslint@8.33.0):
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
@@ -19385,7 +19231,7 @@ packages:
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@8.1.1)
       doctrine: 2.1.0
       eslint: 8.23.1
       eslint-import-resolver-node: 0.3.7
@@ -19497,7 +19343,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 5.49.0(@typescript-eslint/parser@5.49.0)(eslint@8.23.1)(typescript@4.6.3)
       '@typescript-eslint/experimental-utils': 5.37.0(eslint@8.23.1)(typescript@4.6.3)
       eslint: 8.23.1
-      jest: 27.3.1
+      jest: 27.3.1(canvas@2.9.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -19519,7 +19365,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 5.37.0(@typescript-eslint/parser@5.37.0)(eslint@8.23.1)(typescript@4.6.3)
       '@typescript-eslint/utils': 5.22.0(eslint@8.23.1)(typescript@4.6.3)
       eslint: 8.23.1
-      jest: 27.3.1
+      jest: 27.3.1(canvas@2.9.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -20165,7 +20011,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       doctrine: 3.0.0
       enquirer: 2.3.6
       escape-string-regexp: 4.0.0
@@ -20215,7 +20061,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.1.1
@@ -20344,7 +20190,7 @@ packages:
     resolution: {integrity: sha512-YNF+mZ/Wu2FU/gvmzuWtYc8rloubL7wfXCTgouFrnjGVXPA/EeYYA7pupXWrb3Iv1cTBeSSxxJIbK23l4MRNqg==}
     engines: {node: '>=8.3.0'}
     dependencies:
-      '@babel/traverse': 7.20.13
+      '@babel/traverse': 7.20.13(supports-color@5.5.0)
       '@babel/types': 7.20.7
       c8: 7.12.0
     transitivePeerDependencies:
@@ -20480,21 +20326,6 @@ packages:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
 
-  /expand-brackets@2.1.4:
-    resolution: {integrity: sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      debug: 2.6.9
-      define-property: 0.2.5
-      extend-shallow: 2.0.1
-      posix-character-classes: 0.1.1
-      regex-not: 1.0.2
-      snapdragon: 0.8.2
-      to-regex: 3.0.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /expand-brackets@2.1.4(supports-color@6.1.0):
     resolution: {integrity: sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA==}
     engines: {node: '>=0.10.0'}
@@ -20582,45 +20413,6 @@ packages:
       jest-message-util: 29.5.0
       jest-util: 29.5.0
 
-  /express@4.18.2:
-    resolution: {integrity: sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==}
-    engines: {node: '>= 0.10.0'}
-    dependencies:
-      accepts: 1.3.8
-      array-flatten: 1.1.1
-      body-parser: 1.20.1
-      content-disposition: 0.5.4
-      content-type: 1.0.4
-      cookie: 0.5.0
-      cookie-signature: 1.0.6
-      debug: 2.6.9
-      depd: 2.0.0
-      encodeurl: 1.0.2
-      escape-html: 1.0.3
-      etag: 1.8.1
-      finalhandler: 1.2.0
-      fresh: 0.5.2
-      http-errors: 2.0.0
-      merge-descriptors: 1.0.1
-      methods: 1.1.2
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      path-to-regexp: 0.1.7
-      proxy-addr: 2.0.7
-      qs: 6.11.0
-      range-parser: 1.2.1
-      safe-buffer: 5.2.1
-      send: 0.18.0
-      serve-static: 1.15.0
-      setprototypeof: 1.2.0
-      statuses: 2.0.1
-      type-is: 1.6.18
-      utils-merge: 1.0.1
-      vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /express@4.18.2(supports-color@6.1.0):
     resolution: {integrity: sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==}
     engines: {node: '>= 0.10.0'}
@@ -20681,22 +20473,6 @@ packages:
   /extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
-  /extglob@2.0.4:
-    resolution: {integrity: sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      array-unique: 0.3.2
-      define-property: 1.0.0
-      expand-brackets: 2.1.4
-      extend-shallow: 2.0.1
-      fragment-cache: 0.2.1
-      regex-not: 1.0.2
-      snapdragon: 0.8.2
-      to-regex: 3.0.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /extglob@2.0.4(supports-color@6.1.0):
     resolution: {integrity: sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==}
     engines: {node: '>=0.10.0'}
@@ -20717,7 +20493,7 @@ packages:
     hasBin: true
     dependencies:
       concat-stream: 1.6.2
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@6.1.0)
       mkdirp: 0.5.6
       yauzl: 2.10.0
     transitivePeerDependencies:
@@ -20939,21 +20715,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       to-regex-range: 5.0.1
-
-  /finalhandler@1.2.0:
-    resolution: {integrity: sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==}
-    engines: {node: '>= 0.8'}
-    dependencies:
-      debug: 2.6.9
-      encodeurl: 1.0.2
-      escape-html: 1.0.3
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      statuses: 2.0.1
-      unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /finalhandler@1.2.0(supports-color@6.1.0):
     resolution: {integrity: sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==}
@@ -21956,7 +21717,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -22032,7 +21793,7 @@ packages:
     engines: {node: '>= 6.0.0'}
     dependencies:
       agent-base: 5.1.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -22042,7 +21803,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -22772,7 +22533,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -23034,36 +22795,6 @@ packages:
       - supports-color
       - ts-node
       - utf-8-validate
-
-  /jest-cli@27.3.1:
-    resolution: {integrity: sha512-WHnCqpfK+6EvT62me6WVs8NhtbjAS4/6vZJnk7/2+oOr50cwAzG4Wxt6RXX0hu6m1169ZGMlhYYUNeKBXCph/Q==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 27.5.1
-      '@jest/test-result': 27.5.1
-      '@jest/types': 27.5.1
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.10
-      import-local: 3.1.0
-      jest-config: 27.3.1
-      jest-util: 27.5.1
-      jest-validate: 27.3.1
-      prompts: 2.4.2
-      yargs: 16.2.0
-    transitivePeerDependencies:
-      - bufferutil
-      - canvas
-      - supports-color
-      - ts-node
-      - utf-8-validate
-    dev: true
 
   /jest-cli@27.3.1(canvas@2.9.1):
     resolution: {integrity: sha512-WHnCqpfK+6EvT62me6WVs8NhtbjAS4/6vZJnk7/2+oOr50cwAzG4Wxt6RXX0hu6m1169ZGMlhYYUNeKBXCph/Q==}
@@ -23384,43 +23115,6 @@ packages:
       - supports-color
       - utf-8-validate
 
-  /jest-config@27.3.1:
-    resolution: {integrity: sha512-KY8xOIbIACZ/vdYCKSopL44I0xboxC751IX+DXL2+Wx6DKNycyEfV3rryC3BPm5Uq/BBqDoMrKuqLEUNJmMKKg==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    peerDependencies:
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      ts-node:
-        optional: true
-    dependencies:
-      '@babel/core': 7.20.12
-      '@jest/test-sequencer': 27.5.1
-      '@jest/types': 27.5.1
-      babel-jest: 27.5.1(@babel/core@7.20.12)
-      chalk: 4.1.2
-      ci-info: 3.3.2
-      deepmerge: 4.2.2
-      glob: 7.2.3
-      graceful-fs: 4.2.10
-      jest-circus: 27.5.1
-      jest-environment-jsdom: 27.5.1
-      jest-environment-node: 27.5.1
-      jest-get-type: 27.5.1
-      jest-jasmine2: 27.5.1
-      jest-regex-util: 27.5.1
-      jest-resolve: 27.5.1
-      jest-runner: 27.5.1
-      jest-util: 27.5.1
-      jest-validate: 27.5.1
-      micromatch: 4.0.5
-      pretty-format: 27.5.1
-    transitivePeerDependencies:
-      - bufferutil
-      - canvas
-      - supports-color
-      - utf-8-validate
-    dev: true
-
   /jest-config@27.3.1(canvas@2.9.1):
     resolution: {integrity: sha512-KY8xOIbIACZ/vdYCKSopL44I0xboxC751IX+DXL2+Wx6DKNycyEfV3rryC3BPm5Uq/BBqDoMrKuqLEUNJmMKKg==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -23489,46 +23183,6 @@ packages:
       micromatch: 4.0.5
       pretty-format: 27.5.1
       slash: 3.0.0
-    transitivePeerDependencies:
-      - bufferutil
-      - canvas
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /jest-config@27.5.1:
-    resolution: {integrity: sha512-5sAsjm6tGdsVbW9ahcChPAFCk4IlkQUknH5AvKjuLTSlcO/wCZKyFdn7Rg0EkC+OGgWODEy2hDpWB1PgzH0JNA==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    peerDependencies:
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      ts-node:
-        optional: true
-    dependencies:
-      '@babel/core': 7.20.12
-      '@jest/test-sequencer': 27.5.1
-      '@jest/types': 27.5.1
-      babel-jest: 27.5.1(@babel/core@7.20.12)
-      chalk: 4.1.2
-      ci-info: 3.3.2
-      deepmerge: 4.2.2
-      glob: 7.2.3
-      graceful-fs: 4.2.10
-      jest-circus: 27.5.1
-      jest-environment-jsdom: 27.5.1
-      jest-environment-node: 27.5.1
-      jest-get-type: 27.5.1
-      jest-jasmine2: 27.5.1
-      jest-regex-util: 27.5.1
-      jest-resolve: 27.5.1
-      jest-runner: 27.5.1
-      jest-util: 27.5.1
-      jest-validate: 27.5.1
-      micromatch: 4.0.5
-      parse-json: 5.2.0
-      pretty-format: 27.5.1
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -24158,24 +23812,6 @@ packages:
       - canvas
       - supports-color
       - utf-8-validate
-
-  /jest-environment-jsdom@27.5.1:
-    resolution: {integrity: sha512-TFBvkTC1Hnnnrka/fUb56atfDtJ9VMZ94JkjTbggl1PEpwrYtUBKMezB3inLmWqQsXYLcMwNoDQwoBTAvFfsfw==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    dependencies:
-      '@jest/environment': 27.5.1
-      '@jest/fake-timers': 27.5.1
-      '@jest/types': 27.5.1
-      '@types/node': 18.14.6
-      jest-mock: 27.5.1
-      jest-util: 27.5.1
-      jsdom: 16.7.0
-    transitivePeerDependencies:
-      - bufferutil
-      - canvas
-      - supports-color
-      - utf-8-validate
-    dev: true
 
   /jest-environment-jsdom@27.5.1(canvas@2.9.1):
     resolution: {integrity: sha512-TFBvkTC1Hnnnrka/fUb56atfDtJ9VMZ94JkjTbggl1PEpwrYtUBKMezB3inLmWqQsXYLcMwNoDQwoBTAvFfsfw==}
@@ -25137,38 +24773,6 @@ packages:
       - ts-node
       - utf-8-validate
 
-  /jest-runner@27.5.1:
-    resolution: {integrity: sha512-g4NPsM4mFCOwFKXO4p/H/kWGdJp9V8kURY2lX8Me2drgXqG7rrZAx5kv+5H7wtt/cdFIjhqYx1HrlqWHaOvDaQ==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    dependencies:
-      '@jest/console': 27.5.1
-      '@jest/environment': 27.5.1
-      '@jest/test-result': 27.5.1
-      '@jest/transform': 27.5.1
-      '@jest/types': 27.5.1
-      '@types/node': 18.14.6
-      chalk: 4.1.2
-      emittery: 0.8.1
-      graceful-fs: 4.2.10
-      jest-docblock: 27.5.1
-      jest-environment-jsdom: 27.5.1
-      jest-environment-node: 27.5.1
-      jest-haste-map: 27.5.1
-      jest-leak-detector: 27.5.1
-      jest-message-util: 27.5.1
-      jest-resolve: 27.5.1
-      jest-runtime: 27.5.1
-      jest-util: 27.5.1
-      jest-worker: 27.5.1
-      source-map-support: 0.5.21
-      throat: 6.0.1
-    transitivePeerDependencies:
-      - bufferutil
-      - canvas
-      - supports-color
-      - utf-8-validate
-    dev: true
-
   /jest-runner@27.5.1(canvas@2.9.1):
     resolution: {integrity: sha512-g4NPsM4mFCOwFKXO4p/H/kWGdJp9V8kURY2lX8Me2drgXqG7rrZAx5kv+5H7wtt/cdFIjhqYx1HrlqWHaOvDaQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -25552,7 +25156,7 @@ packages:
       '@babel/core': 7.20.12
       '@babel/generator': 7.20.14
       '@babel/plugin-syntax-typescript': 7.18.6(@babel/core@7.20.12)
-      '@babel/traverse': 7.20.13
+      '@babel/traverse': 7.20.13(supports-color@5.5.0)
       '@babel/types': 7.20.7
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
@@ -25998,7 +25602,7 @@ packages:
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
-      jest: 27.3.1
+      jest: 27.3.1(canvas@2.9.1)
       jest-regex-util: 27.5.1
       jest-watcher: 27.5.1
       slash: 3.0.0
@@ -26334,27 +25938,6 @@ packages:
       - ts-node
       - utf-8-validate
 
-  /jest@27.3.1:
-    resolution: {integrity: sha512-U2AX0AgQGd5EzMsiZpYt8HyZ+nSVIh5ujQ9CPp9EQZJMjXIiSZpJNweZl0swatKRoqHWgGKM3zaSwm4Zaz87ng==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 27.3.1
-      import-local: 3.0.3
-      jest-cli: 27.3.1
-    transitivePeerDependencies:
-      - bufferutil
-      - canvas
-      - supports-color
-      - ts-node
-      - utf-8-validate
-    dev: true
-
   /jest@27.3.1(canvas@2.9.1):
     resolution: {integrity: sha512-U2AX0AgQGd5EzMsiZpYt8HyZ+nSVIh5ujQ9CPp9EQZJMjXIiSZpJNweZl0swatKRoqHWgGKM3zaSwm4Zaz87ng==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -26618,7 +26201,7 @@ packages:
       chalk: 4.1.2
       flow-parser: 0.198.2
       graceful-fs: 4.2.10
-      micromatch: 3.1.10
+      micromatch: 3.1.10(supports-color@6.1.0)
       neo-async: 2.6.2
       node-dir: 0.1.17
       recast: 0.20.5
@@ -26626,48 +26209,6 @@ packages:
       write-file-atomic: 2.4.3
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /jsdom@16.7.0:
-    resolution: {integrity: sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      canvas: ^2.5.0
-    peerDependenciesMeta:
-      canvas:
-        optional: true
-    dependencies:
-      abab: 2.0.6
-      acorn: 8.8.1
-      acorn-globals: 6.0.0
-      cssom: 0.4.4
-      cssstyle: 2.3.0
-      data-urls: 2.0.0
-      decimal.js: 10.4.1
-      domexception: 2.0.1
-      escodegen: 2.0.0
-      form-data: 3.0.1
-      html-encoding-sniffer: 2.0.1
-      http-proxy-agent: 4.0.1
-      https-proxy-agent: 5.0.1
-      is-potential-custom-element-name: 1.0.1
-      nwsapi: 2.2.2
-      parse5: 6.0.1
-      saxes: 5.0.1
-      symbol-tree: 3.2.4
-      tough-cookie: 4.1.2
-      w3c-hr-time: 1.0.2
-      w3c-xmlserializer: 2.0.0
-      webidl-conversions: 6.1.0
-      whatwg-encoding: 1.0.5
-      whatwg-mimetype: 2.3.0
-      whatwg-url: 8.7.0
-      ws: 7.5.7
-      xml-name-validator: 3.0.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
     dev: true
 
   /jsdom@16.7.0(canvas@2.9.1):
@@ -27059,7 +26600,7 @@ packages:
       cli-truncate: 2.1.0
       commander: 7.2.0
       cosmiconfig: 7.0.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       dedent: 0.7.0
       enquirer: 2.3.6
       execa: 5.1.1
@@ -27541,29 +27082,8 @@ packages:
   /micromark@2.11.2:
     resolution: {integrity: sha512-IXuP76p2uj8uMg4FQc1cRE7lPCLsfAXuEfdjtdO55VRiFO1asrCSQ5g43NmPqFtRwzEnEhafRVzn2jg0UiKArQ==}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       parse-entities: 2.0.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /micromatch@3.1.10:
-    resolution: {integrity: sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      arr-diff: 4.0.0
-      array-unique: 0.3.2
-      braces: 2.3.2
-      define-property: 2.0.2
-      extend-shallow: 3.0.2
-      extglob: 2.0.4
-      fragment-cache: 0.2.1
-      kind-of: 6.0.3
-      nanomatch: 1.2.13
-      object.pick: 1.3.0
-      regex-not: 1.0.2
-      snapdragon: 0.8.2
-      to-regex: 3.0.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -27889,25 +27409,6 @@ packages:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-
-  /nanomatch@1.2.13:
-    resolution: {integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      arr-diff: 4.0.0
-      array-unique: 0.3.2
-      define-property: 2.0.2
-      extend-shallow: 3.0.2
-      fragment-cache: 0.2.1
-      is-windows: 1.0.2
-      kind-of: 6.0.3
-      object.pick: 1.3.0
-      regex-not: 1.0.2
-      snapdragon: 0.8.2
-      to-regex: 3.0.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /nanomatch@1.2.13(supports-color@6.1.0):
     resolution: {integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==}
@@ -29022,7 +28523,7 @@ packages:
     dependencies:
       htmlparser2: 3.10.1
       postcss: 7.0.35
-      postcss-syntax: 0.36.2(postcss@7.0.35)
+      postcss-syntax: 0.36.2(postcss-html@0.36.0)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@7.0.35)
     dev: true
 
   /postcss-image-set-function@3.0.1:
@@ -29491,7 +28992,7 @@ packages:
       svgo: 1.3.2
     dev: false
 
-  /postcss-syntax@0.36.2(postcss@7.0.35):
+  /postcss-syntax@0.36.2(postcss-html@0.36.0)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@7.0.35):
     resolution: {integrity: sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==}
     peerDependencies:
       postcss: '>=5.0.0'
@@ -29513,6 +29014,9 @@ packages:
         optional: true
     dependencies:
       postcss: 7.0.35
+      postcss-html: 0.36.0(postcss-syntax@0.36.2)(postcss@7.0.35)
+      postcss-less: 3.1.4
+      postcss-scss: 2.1.1
     dev: true
 
   /postcss-unique-selectors@4.0.1:
@@ -29886,7 +29390,7 @@ packages:
     engines: {node: '>=8.16.0'}
     dependencies:
       '@types/mime-types': 2.1.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       extract-zip: 1.7.0
       https-proxy-agent: 4.0.0
       mime: 2.4.7
@@ -31177,27 +30681,6 @@ packages:
     dependencies:
       lru-cache: 6.0.0
 
-  /send@0.18.0:
-    resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
-    engines: {node: '>= 0.8.0'}
-    dependencies:
-      debug: 2.6.9
-      depd: 2.0.0
-      destroy: 1.2.0
-      encodeurl: 1.0.2
-      escape-html: 1.0.3
-      etag: 1.8.1
-      fresh: 0.5.2
-      http-errors: 2.0.0
-      mime: 1.6.0
-      ms: 2.1.3
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      statuses: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /send@0.18.0(supports-color@6.1.0):
     resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
     engines: {node: '>= 0.8.0'}
@@ -31254,18 +30737,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
-
-  /serve-static@1.15.0:
-    resolution: {integrity: sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==}
-    engines: {node: '>= 0.8.0'}
-    dependencies:
-      encodeurl: 1.0.2
-      escape-html: 1.0.3
-      parseurl: 1.3.3
-      send: 0.18.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /serve-static@1.15.0(supports-color@6.1.0):
     resolution: {integrity: sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==}
@@ -31444,22 +30915,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       kind-of: 3.2.2
-
-  /snapdragon@0.8.2:
-    resolution: {integrity: sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      base: 0.11.2
-      debug: 2.6.9
-      define-property: 0.2.5
-      extend-shallow: 2.0.1
-      map-cache: 0.2.2
-      source-map: 0.5.7
-      source-map-resolve: 0.5.3
-      use: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /snapdragon@0.8.2(supports-color@6.1.0):
     resolution: {integrity: sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==}
@@ -32212,7 +31667,7 @@ packages:
       balanced-match: 1.0.2
       chalk: 4.1.2
       cosmiconfig: 7.0.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       execall: 2.0.0
       fast-glob: 3.2.11
       fastest-levenshtein: 1.0.12
@@ -32241,7 +31696,7 @@ packages:
       postcss-sass: 0.4.4
       postcss-scss: 2.1.1
       postcss-selector-parser: 6.0.4
-      postcss-syntax: 0.36.2(postcss@7.0.35)
+      postcss-syntax: 0.36.2(postcss-html@0.36.0)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@7.0.35)
       postcss-value-parser: 4.1.0
       resolve-from: 5.0.0
       slash: 3.0.0
@@ -32800,38 +32255,6 @@ packages:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       jest: 27.3.1(canvas@2.9.1)
-      jest-util: 27.3.1
-      json5: 2.2.0
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.3.7
-      typescript: 4.6.3
-      yargs-parser: 20.2.9
-    dev: true
-
-  /ts-jest@27.0.7(@babel/core@7.20.12)(@types/jest@27.0.3)(jest@27.3.1)(typescript@4.6.3):
-    resolution: {integrity: sha512-O41shibMqzdafpuP+CkrOL7ykbmLh+FqQrXEmV9CydQ5JBk0Sj0uAEF5TNNe94fZWKm3yYvWa/IbyV4Yg1zK2Q==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@types/jest': ^27.0.0
-      babel-jest: '>=27.0.0 <28'
-      jest: ^27.0.0
-      typescript: '>=3.8 <5.0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@types/jest':
-        optional: true
-      babel-jest:
-        optional: true
-    dependencies:
-      '@babel/core': 7.20.12
-      '@types/jest': 27.0.3
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      jest: 27.3.1
       jest-util: 27.3.1
       json5: 2.2.0
       lodash.memoize: 4.1.2
@@ -33795,7 +33218,7 @@ packages:
       es-module-lexer: 0.4.1
       fs-extra: 10.1.0
       magic-string: 0.25.7
-      vite: 4.0.4
+      vite: 4.0.4(@types/node@16.11.29)
     dev: true
 
   /vite@2.9.13:
@@ -33818,39 +33241,6 @@ packages:
       postcss: 8.4.14
       resolve: 1.22.1
       rollup: 2.75.5
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
-
-  /vite@4.0.4:
-    resolution: {integrity: sha512-xevPU7M8FU0i/80DMR+YhgrzR5KS2ORy1B4xcX/cXLsvnUWvfHuqMmVU6N0YiJ4JWGRJJsLCgjEzKjG9/GKoSw==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      esbuild: 0.16.17
-      postcss: 8.4.21
-      resolve: 1.22.1
-      rollup: 3.11.0
     optionalDependencies:
       fsevents: 2.3.2
     dev: true


### PR DESCRIPTION
## Overview
Some of our tests, especially when testing `react-query` error handling, log to `console.log` or `console.error` in a way that pollutes the test output. This helper makes it easy to avoid that.

<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot
<img width="601" alt="image" src="https://user-images.githubusercontent.com/1938/230517658-bb8d97a3-c895-414a-a621-b13b295ec745.png">
<img width="677" alt="image" src="https://user-images.githubusercontent.com/1938/230518075-b74b65ec-aa74-4015-907e-6c087fe71c08.png">

## Testing Plan
Automated tests.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
