### PR TITLE
refactor(central-scan): extract "Delete Batch" modal

### DIFF
--- a/apps/central-scan/backend/package.json
+++ b/apps/central-scan/backend/package.json
@@ -102,6 +102,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-vx": "workspace:*",
     "fast-check": "^2.23.2",
+    "get-port": "5",
     "is-ci-cli": "^2.1.2",
     "jest": "^26.6.3",
     "jest-date-mock": "^1.0.8",

--- a/apps/central-scan/backend/src/central_scanner_app.test.ts
+++ b/apps/central-scan/backend/src/central_scanner_app.test.ts
@@ -37,6 +37,7 @@ import {
   DippedSmartCardAuthApi,
 } from '@votingworks/auth';
 import { Server } from 'http';
+import { Logger, fakeLogger } from '@votingworks/logging';
 import * as stateOfHamilton from '../test/fixtures/state-of-hamilton';
 import { makeMock } from '../test/util/mocks';
 import { Importer } from './importer';
@@ -57,6 +58,7 @@ let auth: DippedSmartCardAuthApi;
 let importer: jest.Mocked<Importer>;
 let server: Server;
 let workspace: Workspace;
+let logger: Logger;
 
 beforeEach(async () => {
   mockGetUsbDrives.mockReset();
@@ -78,7 +80,14 @@ beforeEach(async () => {
     ballotMetadata,
     getMockBallotPageLayoutsWithImages(ballotMetadata, 2)
   );
-  app = await buildCentralScannerApp({ auth, exporter, importer, workspace });
+  logger = fakeLogger();
+  app = await buildCentralScannerApp({
+    auth,
+    exporter,
+    importer,
+    workspace,
+    logger,
+  });
 });
 
 afterEach(async () => {

--- a/apps/central-scan/backend/src/central_scanner_app.ts
+++ b/apps/central-scan/backend/src/central_scanner_app.ts
@@ -733,17 +733,6 @@ export async function buildCentralScannerApp({
     }
   );
 
-  deprecatedApiRouter.delete(
-    '/central-scanner/scan/batch/:batchId',
-    (request, response) => {
-      if (store.deleteBatch(request.params.batchId)) {
-        response.json({ status: 'ok' });
-      } else {
-        response.status(404).end();
-      }
-    }
-  );
-
   deprecatedApiRouter.get<NoParams, Scan.GetNextReviewSheetResponse>(
     '/central-scanner/scan/hmpb/review/next-sheet',
     (_request, response) => {

--- a/apps/central-scan/backend/src/central_scanner_app.ts
+++ b/apps/central-scan/backend/src/central_scanner_app.ts
@@ -35,6 +35,7 @@ import path from 'path';
 import { PassThrough } from 'stream';
 import { z } from 'zod';
 import * as grout from '@votingworks/grout';
+import { LogEventId, Logger, LoggingUserRole } from '@votingworks/logging';
 import { backupToUsbDrive } from './backup';
 import { Importer } from './importer';
 import { Workspace } from './util/workspace';
@@ -50,6 +51,7 @@ export interface AppOptions {
   exporter: Exporter;
   importer: Importer;
   workspace: Workspace;
+  logger: Logger;
 }
 
 function constructAuthMachineState(
@@ -67,7 +69,18 @@ function constructAuthMachineState(
   };
 }
 
-function buildApi(auth: DippedSmartCardAuthApi, workspace: Workspace) {
+function buildApi({
+  auth,
+  workspace,
+  logger,
+}: Pick<AppOptions, 'auth' | 'workspace' | 'logger'>) {
+  async function getUserRole(): Promise<LoggingUserRole> {
+    const authStatus = await auth.getAuthStatus(
+      constructAuthMachineState(workspace)
+    );
+    return authStatus.status === 'logged_in' ? authStatus.user.role : 'unknown';
+  }
+
   return grout.createApi({
     getAuthStatus() {
       return auth.getAuthStatus(constructAuthMachineState(workspace));
@@ -89,6 +102,38 @@ function buildApi(auth: DippedSmartCardAuthApi, workspace: Workspace) {
         input
       );
     },
+
+    async deleteBatch({ batchId }: { batchId: string }) {
+      const userRole = await getUserRole();
+      const numberOfBallotsInBatch = workspace.store
+        .batchStatus()
+        .find((batch) => batch.id === batchId)?.count;
+
+      await logger.log(LogEventId.DeleteScanBatchInit, userRole, {
+        message: `User deleting batch id ${batchId}...`,
+        numberOfBallotsInBatch,
+        batchId,
+      });
+
+      try {
+        workspace.store.deleteBatch(batchId);
+        await logger.log(LogEventId.DeleteScanBatchComplete, userRole, {
+          disposition: 'success',
+          message: `User successfully deleted batch id: ${batchId} containing ${numberOfBallotsInBatch} ballots.`,
+          numberOfBallotsInBatch,
+          batchId,
+        });
+      } catch (error) {
+        assert(error instanceof Error);
+        await logger.log(LogEventId.DeleteScanBatchComplete, userRole, {
+          disposition: 'failure',
+          message: `Error deleting batch id: ${batchId}.`,
+          error: error.message,
+          result: 'Batch not deleted.',
+        });
+        throw error;
+      }
+    },
   });
 }
 
@@ -106,11 +151,12 @@ export async function buildCentralScannerApp({
   exporter,
   importer,
   workspace,
+  logger,
 }: AppOptions): Promise<Application> {
   const { store } = workspace;
 
   const app: Application = express();
-  const api = buildApi(auth, workspace);
+  const api = buildApi({ auth, workspace, logger });
   app.use('/api', grout.buildRouter(api, express));
 
   const upload = multer({

--- a/apps/central-scan/backend/src/end_to_end.test.ts
+++ b/apps/central-scan/backend/src/end_to_end.test.ts
@@ -22,6 +22,7 @@ import {
   advanceTo as setDateMock,
   clear as clearDateMock,
 } from 'jest-date-mock';
+import { fakeLogger, Logger } from '@votingworks/logging';
 import { makeMockScanner, MockScanner } from '../test/util/mocks';
 import { buildCentralScannerApp } from './central_scanner_app';
 import { Importer } from './importer';
@@ -41,6 +42,7 @@ let auth: DippedSmartCardAuthApi;
 let importer: Importer;
 let workspace: Workspace;
 let scanner: MockScanner;
+let logger: Logger;
 
 beforeEach(async () => {
   auth = buildMockDippedSmartCardAuth();
@@ -50,7 +52,14 @@ beforeEach(async () => {
     workspace,
     scanner,
   });
-  app = await buildCentralScannerApp({ auth, exporter, importer, workspace });
+  logger = fakeLogger();
+  app = await buildCentralScannerApp({
+    auth,
+    exporter,
+    importer,
+    workspace,
+    logger,
+  });
 });
 
 afterEach(async () => {

--- a/apps/central-scan/backend/src/end_to_end_hmpb.test.ts
+++ b/apps/central-scan/backend/src/end_to_end_hmpb.test.ts
@@ -22,6 +22,7 @@ import {
   buildMockDippedSmartCardAuth,
   DippedSmartCardAuthApi,
 } from '@votingworks/auth';
+import { fakeLogger, Logger } from '@votingworks/logging';
 import * as stateOfHamilton from '../test/fixtures/state-of-hamilton';
 import { makeMockScanner, MockScanner } from '../test/util/mocks';
 import { Importer } from './importer';
@@ -66,13 +67,21 @@ let workspace: Workspace;
 let scanner: MockScanner;
 let importer: Importer;
 let app: Application;
+let logger: Logger;
 
 beforeEach(async () => {
   auth = buildMockDippedSmartCardAuth();
   workspace = await createWorkspace(dirSync().name);
   scanner = makeMockScanner();
   importer = new Importer({ workspace, scanner });
-  app = await buildCentralScannerApp({ auth, exporter, importer, workspace });
+  logger = fakeLogger();
+  app = await buildCentralScannerApp({
+    auth,
+    exporter,
+    importer,
+    workspace,
+    logger,
+  });
 });
 
 afterEach(async () => {

--- a/apps/central-scan/backend/src/server.ts
+++ b/apps/central-scan/backend/src/server.ts
@@ -112,6 +112,7 @@ export async function start({
       exporter: resolvedExporter,
       importer: resolvedImporter,
       workspace: resolvedWorkspace,
+      logger,
     }));
 
   // cleanup incomplete batches from before

--- a/apps/central-scan/frontend/src/api.ts
+++ b/apps/central-scan/frontend/src/api.ts
@@ -78,8 +78,15 @@ export const logOut = {
 export const updateSessionExpiry = {
   useMutation() {
     const apiClient = useApiClient();
+    return useMutation(apiClient.updateSessionExpiry);
+  },
+} as const;
+
+export const deleteBatch = {
+  useMutation() {
+    const apiClient = useApiClient();
     const queryClient = useQueryClient();
-    return useMutation(apiClient.updateSessionExpiry, {
+    return useMutation(apiClient.deleteBatch, {
       async onSuccess() {
         // Because we poll auth status with high frequency, this invalidation isn't strictly
         // necessary

--- a/apps/central-scan/frontend/src/app_root.tsx
+++ b/apps/central-scan/frontend/src/app_root.tsx
@@ -441,39 +441,6 @@ export function AppRoot({
     [history, refreshConfig]
   );
 
-  const deleteBatch = useCallback(
-    async (id: string) => {
-      try {
-        const batch = status.batches.find((b) => b.id === id);
-        const numberOfBallotsInBatch = batch?.count ?? 0;
-        await logger.log(LogEventId.DeleteScanBatchInit, userRole, {
-          message: `User deleting batch id ${id}...`,
-          numberOfBallotsInBatch,
-          batchId: id,
-        });
-        await fetch(`/central-scanner/scan/batch/${id}`, {
-          method: 'DELETE',
-        });
-        await logger.log(LogEventId.DeleteScanBatchComplete, userRole, {
-          disposition: 'success',
-          message: `User successfully deleted batch id: ${id} containing ${numberOfBallotsInBatch} ballots.`,
-          numberOfBallotsInBatch,
-          batchId: id,
-        });
-      } catch (error) {
-        assert(error instanceof Error);
-        await logger.log(LogEventId.DeleteScanBatchComplete, userRole, {
-          disposition: 'failure',
-          message: `Error deleting batch id: ${id}.`,
-          error: error.message,
-          result: 'Batch not deleted, user shown error.',
-        });
-        throw error;
-      }
-    },
-    [logger, userRole, status.batches]
-  );
-
   useInterval(
     useCallback(async () => {
       if (electionDefinition) {
@@ -652,11 +619,7 @@ export function AppRoot({
           <Route path="/">
             <Screen>
               <Main padded>
-                <DashboardScreen
-                  isScanning={isScanning}
-                  status={status}
-                  deleteBatch={deleteBatch}
-                />
+                <DashboardScreen isScanning={isScanning} status={status} />
               </Main>
               <MainNav isTestMode={isTestMode}>
                 <UsbControllerButton

--- a/apps/central-scan/frontend/src/components/delete_batch_modal.test.tsx
+++ b/apps/central-scan/frontend/src/components/delete_batch_modal.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
-import { suppressingConsoleOutput } from '@votingworks/test-utils';
 import { MockApiClient, createMockApiClient, provideApi } from '../../test/api';
 import { render, screen, waitFor } from '../../test/react_testing_library';
 import { DeleteBatchModal } from './delete_batch_modal';
@@ -31,29 +30,6 @@ test('allows canceling', async () => {
 
   userEvent.click(screen.getByText('Cancel'));
   expect(onClose).toHaveBeenCalled();
-});
-
-test('displays errors', async () => {
-  const onClose = jest.fn();
-
-  render(
-    provideApi(
-      mockApiClient,
-      <DeleteBatchModal batchId="a" batchLabel="Batch 1" onClose={onClose} />
-    )
-  );
-
-  await screen.findByText('Delete ‘Batch 1’?');
-  expect(onClose).not.toHaveBeenCalled();
-
-  mockApiClient.deleteBatch
-    .expectCallWith({ batchId: 'a' })
-    .throws(new Error('batch is a teapot'));
-
-  await suppressingConsoleOutput(async () => {
-    userEvent.click(screen.getByText('Yes, Delete Batch'));
-    await screen.findByText('Error: batch is a teapot');
-  });
 });
 
 test('closes on success', async () => {

--- a/apps/central-scan/frontend/src/components/delete_batch_modal.test.tsx
+++ b/apps/central-scan/frontend/src/components/delete_batch_modal.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { suppressingConsoleOutput } from '@votingworks/test-utils';
+import { MockApiClient, createMockApiClient, provideApi } from '../../test/api';
+import { render, screen, waitFor } from '../../test/react_testing_library';
+import { DeleteBatchModal } from './delete_batch_modal';
+
+let mockApiClient: MockApiClient;
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+  mockApiClient = createMockApiClient();
+});
+
+afterEach(() => {
+  mockApiClient.assertComplete();
+});
+
+test('allows canceling', async () => {
+  const onClose = jest.fn();
+
+  render(
+    provideApi(
+      mockApiClient,
+      <DeleteBatchModal batchId="a" batchLabel="Batch 1" onClose={onClose} />
+    )
+  );
+
+  await screen.findByText('Delete ‘Batch 1’?');
+  expect(onClose).not.toHaveBeenCalled();
+
+  userEvent.click(screen.getByText('Cancel'));
+  expect(onClose).toHaveBeenCalled();
+});
+
+test('displays errors', async () => {
+  const onClose = jest.fn();
+
+  render(
+    provideApi(
+      mockApiClient,
+      <DeleteBatchModal batchId="a" batchLabel="Batch 1" onClose={onClose} />
+    )
+  );
+
+  await screen.findByText('Delete ‘Batch 1’?');
+  expect(onClose).not.toHaveBeenCalled();
+
+  mockApiClient.deleteBatch
+    .expectCallWith({ batchId: 'a' })
+    .throws(new Error('batch is a teapot'));
+
+  await suppressingConsoleOutput(async () => {
+    userEvent.click(screen.getByText('Yes, Delete Batch'));
+    await screen.findByText('Error: batch is a teapot');
+  });
+});
+
+test('closes on success', async () => {
+  const onClose = jest.fn();
+
+  render(
+    provideApi(
+      mockApiClient,
+      <DeleteBatchModal batchId="a" batchLabel="Batch 1" onClose={onClose} />
+    )
+  );
+
+  await screen.findByText('Delete ‘Batch 1’?');
+  expect(onClose).not.toHaveBeenCalled();
+
+  mockApiClient.deleteBatch.expectCallWith({ batchId: 'a' }).resolves();
+  userEvent.click(screen.getByText('Yes, Delete Batch'));
+  await waitFor(() => {
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/apps/central-scan/frontend/src/components/delete_batch_modal.tsx
+++ b/apps/central-scan/frontend/src/components/delete_batch_modal.tsx
@@ -1,0 +1,55 @@
+import { Button, Modal, Prose, Text } from '@votingworks/ui';
+import React from 'react';
+import * as api from '../api';
+
+export interface Props {
+  batchId: string;
+  batchLabel: string;
+  onClose: () => void;
+}
+
+/**
+ * Provides a modal for confirming the deletion of a scanned ballot batch.
+ */
+export function DeleteBatchModal({
+  batchId,
+  batchLabel,
+  onClose,
+}: Props): JSX.Element {
+  const deleteBatchMutation = api.deleteBatch.useMutation();
+
+  function doDeleteBatch() {
+    deleteBatchMutation.mutate({ batchId }, { onSuccess: onClose });
+  }
+
+  return (
+    <Modal
+      centerContent
+      onOverlayClick={onClose}
+      content={
+        <Prose textCenter>
+          <h1>Delete ‘{batchLabel}’?</h1>
+          <p>This action cannot be undone.</p>
+          {deleteBatchMutation.error && (
+            <Text error>{`${deleteBatchMutation.error}`}</Text>
+          )}
+        </Prose>
+      }
+      actions={
+        <React.Fragment>
+          <Button
+            variant="danger"
+            onPress={doDeleteBatch}
+            disabled={!deleteBatchMutation.isIdle}
+            autoFocus
+          >
+            {deleteBatchMutation.isLoading ? 'Deleting…' : 'Yes, Delete Batch'}
+          </Button>
+          <Button onPress={onClose} disabled={!deleteBatchMutation.isIdle}>
+            Cancel
+          </Button>
+        </React.Fragment>
+      }
+    />
+  );
+}

--- a/apps/central-scan/frontend/test/api.tsx
+++ b/apps/central-scan/frontend/test/api.tsx
@@ -1,6 +1,9 @@
+import React from 'react';
 import type { Api } from '@votingworks/central-scan-backend'; // eslint-disable-line vx/gts-no-import-export-type
 import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
 import { DippedSmartCardAuth } from '@votingworks/types';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { ApiClientContext, createQueryClient } from '../src/api';
 
 export type MockApiClient = MockClient<Api>;
 
@@ -13,4 +16,17 @@ export function setAuthStatus(
   authStatus: DippedSmartCardAuth.AuthStatus
 ): void {
   mockApiClient.getAuthStatus.expectRepeatedCallsWith().resolves(authStatus);
+}
+
+export function provideApi(
+  apiMock: ReturnType<typeof createMockApiClient>,
+  children: React.ReactNode
+): JSX.Element {
+  return (
+    <ApiClientContext.Provider value={apiMock}>
+      <QueryClientProvider client={createQueryClient()}>
+        {children}
+      </QueryClientProvider>
+    </ApiClientContext.Provider>
+  );
 }

--- a/libs/auth/src/test_utils.ts
+++ b/libs/auth/src/test_utils.ts
@@ -4,7 +4,7 @@ import { InsertedSmartCardAuthApi } from './inserted_smart_card_auth_api';
 /**
  * Builds a mock dipped smart card auth instance for application-level tests
  */
-export function buildMockDippedSmartCardAuth(): DippedSmartCardAuthApi {
+export function buildMockDippedSmartCardAuth(): jest.Mocked<DippedSmartCardAuthApi> {
   return {
     getAuthStatus: jest.fn(),
     checkPin: jest.fn(),
@@ -18,7 +18,7 @@ export function buildMockDippedSmartCardAuth(): DippedSmartCardAuthApi {
 /**
  * Builds a mock inserted smart card auth instance for application-level tests
  */
-export function buildMockInsertedSmartCardAuth(): InsertedSmartCardAuthApi {
+export function buildMockInsertedSmartCardAuth(): jest.Mocked<InsertedSmartCardAuthApi> {
   return {
     getAuthStatus: jest.fn(),
     checkPin: jest.fn(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1085,6 +1085,9 @@ importers:
       fast-check:
         specifier: ^2.23.2
         version: 2.23.2
+      get-port:
+        specifier: '5'
+        version: 5.1.1
       is-ci-cli:
         specifier: ^2.1.2
         version: 2.2.0


### PR DESCRIPTION

## Overview
I wanted to try out transitioning an API endpoint to use Grout and this seemed like a good one to illustrate both the actual Grout usage and how using `react-query` with a mutation can simplify our client code.

<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot
n/a

## Testing Plan
New automated tests, light manual testing.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
