### PR TITLE
[libs/ui] Apply VVSG2 themes to ButtonBar component

### DIFF
--- a/libs/ui/src/__snapshots__/button_bar.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/button_bar.test.tsx.snap
@@ -13,20 +13,20 @@ exports[`renders ButtonBar 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  border-bottom: 1px solid rgb(169,169,169);
-  background: rgba(0,0,0,0.05);
-  padding: 0.25rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  border-top: 0.05rem solid #263238;
+  padding: 0.75rem;
+  gap: 7.2px;
 }
 
 .c0 > *:first-child {
   -webkit-order: 2;
   -ms-flex-order: 2;
   order: 2;
-  min-width: 50%;
+  min-width: 40%;
 }
 
 .c0 > * {
@@ -34,7 +34,6 @@ exports[`renders ButtonBar 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
-  margin: 0.25rem;
 }
 
 @media print {
@@ -60,9 +59,9 @@ exports[`renders ButtonBar 1`] = `
   }
 }
 
-<nav
+<div
   class="c0"
 >
   foo
-</nav>
+</div>
 `;

--- a/libs/ui/src/button_bar.stories.tsx
+++ b/libs/ui/src/button_bar.stories.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+
+import { ButtonBar as Component } from './button_bar';
+import { Button } from './button';
+import { P } from './typography';
+
+const meta: Meta<typeof Component> = {
+  title: 'libs-ui/ButtonBar',
+  component: Component,
+};
+
+export default meta;
+
+export function ButtonBar(): JSX.Element {
+  const [lastButtonPressed, setLastButtonPressed] = React.useState<string>('');
+
+  return (
+    <div>
+      <P>Last button pressed: {lastButtonPressed}</P>
+      <Component>
+        <Button
+          variant="primary"
+          onPress={setLastButtonPressed}
+          value="Button A"
+        >
+          Button A
+        </Button>
+        <Button onPress={setLastButtonPressed} value="Button B">
+          Button B
+        </Button>
+        <Button onPress={setLastButtonPressed} value="Button C">
+          Button C
+        </Button>
+      </Component>
+    </div>
+  );
+}

--- a/libs/ui/src/button_bar.tsx
+++ b/libs/ui/src/button_bar.tsx
@@ -1,22 +1,22 @@
 import styled from 'styled-components';
 
-export const ButtonBar = styled('nav')`
+export const ButtonBar = styled('div')`
   display: flex;
   flex-wrap: wrap-reverse;
   align-items: center;
-  justify-content: space-between;
-  border-bottom: 1px solid rgb(169, 169, 169);
-  background: rgba(0, 0, 0, 0.05);
-  padding: 0.25rem;
+  justify-content: center;
+  border-top: ${(p) => p.theme.sizes.bordersRem.hairline}rem solid
+    ${(p) => p.theme.colors.foreground};
+  padding: 0.75rem;
+  gap: ${(p) => p.theme.sizes.minTouchAreaSeparationPx}px;
 
   & > *:first-child {
     order: 2;
-    min-width: 50%;
+    min-width: 40%;
   }
 
   & > * {
     flex-grow: 1;
-    margin: 0.25rem;
   }
   & > *:only-child {
     @media (min-width: 480px) {

--- a/libs/ui/src/themes/make_theme.ts
+++ b/libs/ui/src/themes/make_theme.ts
@@ -262,7 +262,7 @@ const sizeThemes: Record<SizeMode, SizeTheme> = {
     },
     letterSpacingEm: 0, // Browser default.
     lineHeight: 1.2,
-    minTouchAreaSeparationPx: 0,
+    minTouchAreaSeparationPx: VVSG_MIN_TOUCH_AREA_SEPARATION_PX,
     minTouchAreaSizePx: 0,
   },
 };


### PR DESCRIPTION
## Overview

Related to: https://github.com/votingworks/vxsuite/issues/3185

Updating the `ButtonBar` component to satisfy VVSG 2.0 requirements WRT [size](https://docs.google.com/document/d/1A5UX8Z0v12Vvf_jVOUmrOEvUNah2Xxmtltll6ZJW6Ps/edit#bookmark=id.4wj2pvb6lism), [contrast](https://docs.google.com/document/d/1A5UX8Z0v12Vvf_jVOUmrOEvUNah2Xxmtltll6ZJW6Ps/edit#bookmark=id.9enr31j2ams1) and [touch area size and separation](https://docs.google.com/document/d/1A5UX8Z0v12Vvf_jVOUmrOEvUNah2Xxmtltll6ZJW6Ps/edit#bookmark=id.istc3x4un6r)

No changes to the child element ordering, but did replace the `<nav>` container element with a `<div>` since that better describes its role and the `ButtonBar` is currently only used in the `Modal`

## Demo Video or Screenshot
https://user-images.githubusercontent.com/264902/230469515-de9f7490-3cf1-4fb7-953b-b73cd14f879b.mov

### In Context - Before/After for legacy styling:
<img width="300" alt="Screenshot 2023-04-04 at 17 22 10" src="https://user-images.githubusercontent.com/264902/230468130-71e19ff0-8b42-4a64-806c-500432a3bd00.png"> <img width="300" alt="Screenshot 2023-04-04 at 17 22 10" src="https://user-images.githubusercontent.com/264902/230469666-5993fa3f-d590-4df8-9e2f-765e6ef14272.png">

### In Context - With VVSG themes applied:
<img width="300" alt="Screenshot 2023-04-04 at 17 22 10" src="https://user-images.githubusercontent.com/264902/230468294-e79f0e80-21fd-4ddf-ad94-b64e1b57eda9.png">

## Testing Plan
- Added storybook.js entry for dev/demos
- Updated affected snapshots
- Verified legacy styling isn't broken 

## Checklist

- [n/a] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [n/a] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
