### PR TITLE
Disable double sheet detection and add ultrasonic settings to custom scanner demo program 

### DIFF
--- a/libs/custom-scanner/src/cli/demo/index.ts
+++ b/libs/custom-scanner/src/cli/demo/index.ts
@@ -80,7 +80,7 @@ export async function main(): Promise<number> {
     'firmware - Print the firmware version',
     'hardware - Print the hardware version ',
     'status - Print the current scanner status',
-    'scan - Scan a sheet',
+    'scan - Scan a sheet, double sheet prevention will be disabled optionally give a second parameter 1-4 to enable double sheet prevention at the given level',
     'reset - Reset the hardware, you will need to call reconnect after issuing this command.',
     'connect - Calls connect on the scanner',
     'disconnect - Calls disconnect on the scanner',
@@ -125,13 +125,28 @@ export async function main(): Promise<number> {
         break;
       }
 
+      case 'scan 0':
+      case 'scan 1':
+      case 'scan 2':
+      case 'scan 3':
+      case 'scan 4':
       case 'scan': {
+        let doubleSheetValue = DoubleSheetDetectOpt.DetectOff;
+        if (line === 'scan 1') {
+          doubleSheetValue = DoubleSheetDetectOpt.Level1;
+        } else if (line === 'scan 2') {
+          doubleSheetValue = DoubleSheetDetectOpt.Level2;
+        } else if (line === 'scan 3') {
+          doubleSheetValue = DoubleSheetDetectOpt.Level3;
+        } else if (line === 'scan 4') {
+          doubleSheetValue = DoubleSheetDetectOpt.Level4;
+        }
         const scanParameters: ScanParameters = {
           wantedScanSide: ScanSide.A_AND_B,
           formStandingAfterScan: FormStanding.HOLD_TICKET,
           resolution: ImageResolution.RESOLUTION_200_DPI,
           imageColorDepth: ImageColorDepthType.Grey8bpp,
-          doubleSheetDetection: DoubleSheetDetectOpt.DetectOff,
+          doubleSheetDetection: doubleSheetValue,
         };
         const scanResult = await scanner.scan(scanParameters);
 

--- a/libs/custom-scanner/src/parameters.ts
+++ b/libs/custom-scanner/src/parameters.ts
@@ -1,5 +1,7 @@
+import { throwIllegalValue } from '@votingworks/basics';
 import { SetScanParametersRequestData } from './protocol';
 import {
+  DoubleSheetDetectOpt,
   ImageResolution,
   ScanParameters,
   UltrasonicSensorLevelInternal,
@@ -35,6 +37,28 @@ const resolutionPropsMap: Record<number, ResolutionProps> = {
 };
 
 /**
+ * Converts the high-level double sheet detection parameter to the specific internal ultrasonic level desired
+ */
+function convertToUltrasonicSensorLevelInternal(
+  option: DoubleSheetDetectOpt
+): UltrasonicSensorLevelInternal {
+  switch (option) {
+    case DoubleSheetDetectOpt.Level1:
+    case DoubleSheetDetectOpt.DetectOff:
+      return UltrasonicSensorLevelInternal.Level1;
+    case DoubleSheetDetectOpt.Level2:
+      return UltrasonicSensorLevelInternal.Level2;
+    case DoubleSheetDetectOpt.Level3:
+      return UltrasonicSensorLevelInternal.Level3;
+    case DoubleSheetDetectOpt.Level4:
+      return UltrasonicSensorLevelInternal.Level4;
+    // istanbul ignore next
+    default:
+      throwIllegalValue(option);
+  }
+}
+
+/**
  * Converts the high-level scan parameters to the low-level internal scan parameters.
  */
 export function convertToInternalScanParameters(
@@ -63,8 +87,11 @@ export function convertToInternalScanParameters(
     acquireLampOff: false,
     acquireNoPaperSensor: true,
     acquireMotorOff: false,
-    ultrasonicSensorLevel: UltrasonicSensorLevelInternal.Level1,
-    disableUltrasonicSensor: false,
+    ultrasonicSensorLevel: convertToUltrasonicSensorLevelInternal(
+      scanParameters.doubleSheetDetection
+    ),
+    disableUltrasonicSensor:
+      scanParameters.doubleSheetDetection === DoubleSheetDetectOpt.DetectOff,
     disableHardwareDeskew: true,
     formStandingAfterScan: scanParameters.formStandingAfterScan,
     wantedScanSide: scanParameters.wantedScanSide,


### PR DESCRIPTION
## Overview
Adds ultrasonic options to the custom scanner demo program and properly feeds through the ultrasonic parameter on scanning, this will disable ultrasonic for all scanning by default. 
<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot

## Testing Plan
Ran demo program with various options, verified with @mattroe on his ultrasonic that double sheet detection was happening when turning it on and not happening by default. 

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
