### PR TITLE
[libs/ui] Apply VVSG themes to Modal component

### DIFF
--- a/libs/ui/src/__snapshots__/modal.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/modal.test.tsx.snap
@@ -16,7 +16,8 @@ exports[`Modal can configure a wider max width 1`] = `
   left: 0;
   margin: auto;
   outline: none;
-  background: #ffffff;
+  background: #edeff0;
+  border: 0.15rem solid #263238;
   width: 100%;
   overflow: auto;
   -webkit-overflow-scrolling: touch;
@@ -34,13 +35,13 @@ exports[`Modal can configure a wider max width 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   overflow: auto;
-  padding: 2rem;
+  padding: 1rem;
 }
 
 @media (min-width:480px) {
   .c0 {
     position: static;
-    border-radius: 0.25rem;
+    border-radius: 0.5rem;
     max-width: 55rem;
     height: auto;
   }
@@ -104,7 +105,8 @@ exports[`Modal can configure fullscreen 1`] = `
   left: 0;
   margin: auto;
   outline: none;
-  background: #ffffff;
+  background: #edeff0;
+  border: 0.15rem solid #263238;
   width: 100%;
   overflow: auto;
   -webkit-overflow-scrolling: touch;

--- a/libs/ui/src/modal.stories.tsx
+++ b/libs/ui/src/modal.stories.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+
+import { Modal as Component, ModalProps } from './modal';
+import { Button } from './button';
+import { H2, P } from './typography';
+
+const meta: Meta<typeof Component> = {
+  title: 'libs-ui/Modal',
+  component: Component,
+};
+
+export default meta;
+
+export function Modal(props: ModalProps): JSX.Element {
+  const [isOpen, setIsOpen] = React.useState(true);
+
+  return (
+    <div>
+      <Button onPress={setIsOpen} value>
+        Open modal
+      </Button>
+      {isOpen && (
+        <Component
+          actions={
+            <React.Fragment>
+              <Button onPress={setIsOpen} value={false} variant="done">
+                Save
+              </Button>
+              <Button onPress={setIsOpen} value={false}>
+                Cancel
+              </Button>
+            </React.Fragment>
+          }
+          content={
+            <div>
+              <H2 as="h1">Confirm Save</H2>
+              <P>Would you like to save your changes?</P>
+            </div>
+          }
+          {...props}
+        />
+      )}
+    </div>
+  );
+}

--- a/libs/ui/src/modal.tsx
+++ b/libs/ui/src/modal.tsx
@@ -1,7 +1,10 @@
-import { assert } from '@votingworks/basics';
+/* stylelint-disable order/properties-order, value-keyword-case, order/order */
 import React, { ReactNode } from 'react';
 import ReactModal from 'react-modal';
 import styled from 'styled-components';
+import { rgba } from 'polished';
+
+import { assert } from '@votingworks/basics';
 
 import { Theme } from './themes';
 import { ButtonBar } from './button_bar';
@@ -29,14 +32,16 @@ const ReactModalContent = styled('div')<ReactModalContentInterface>`
   left: 0;
   margin: auto;
   outline: none;
-  background: #ffffff;
+  background: ${(p) => p.theme.colors.background};
+  border: ${(p) => p.theme.sizes.bordersRem.medium}rem solid
+    ${(p) => p.theme.colors.foreground};
   width: 100%;
   overflow: auto;
   font-size: ${({ themeDeprecated }) => themeDeprecated?.fontSize};
   -webkit-overflow-scrolling: touch;
   @media (min-width: 480px) {
     position: static;
-    border-radius: ${({ fullscreen }) => (fullscreen ? '0' : '0.25rem')};
+    border-radius: ${({ fullscreen }) => (fullscreen ? '0' : '0.5rem')};
     max-width: ${({ fullscreen, modalWidth = ModalWidth.Standard }) =>
       fullscreen ? '100%' : modalWidth};
     height: ${({ fullscreen }) => (fullscreen ? '100%' : 'auto')};
@@ -57,7 +62,7 @@ const ReactModalOverlay = styled('div')<ReactModalOverlayInterface>`
   bottom: 0;
   left: 0;
   z-index: 999; /* Should be above all default UI */
-  background: rgba(0, 0, 0, 0.75);
+  background: ${(p) => rgba(p.theme.colors.foreground, 0.75)};
   @media (min-width: 480px) {
     padding: ${({ fullscreen }) => (fullscreen ? '0' : '0.5rem')};
   }
@@ -80,10 +85,11 @@ const ModalContent = styled('div')<ModalContentInterface>`
   justify-content: ${({ centerContent = false }) =>
     centerContent ? 'center' : undefined};
   overflow: auto;
-  padding: ${({ fullscreen }) => !fullscreen && '2rem'};
+  padding: ${({ fullscreen }) => !fullscreen && '1rem'};
 `;
 
-interface Props {
+/** Props for {@link Modal}. */
+export interface ModalProps {
   ariaLabel?: string;
   // If a Modal is created and destroyed too quickly it can screw up the aria
   // focus elements. In that case use ariaHideApp=true to disable the default
@@ -147,7 +153,7 @@ export function Modal({
   onOverlayClick,
   modalWidth,
   themeDeprecated,
-}: Props): JSX.Element {
+}: ModalProps): JSX.Element {
   /* istanbul ignore next - can't get document.getElementById working in test */
   const appElement =
     document.getElementById('root') ??


### PR DESCRIPTION
## Overview

Related to: https://github.com/votingworks/vxsuite/issues/3185

Minor styling updates to the `Modal` component to use the VVSG-compliant color themes.
- Match modal background to background color for the active theme.
- Thicken border for a bit more contrast between modal content and the translucent overlay behind it.
- Reduced padding to increase usable screen real estate, especially at larger text sizes

## Demo Video or Screenshot

### In Context - Before/After:
<img width="250" src="https://user-images.githubusercontent.com/264902/230491644-e629cb4f-5239-4cfb-885c-d27b2883f204.png"> <img width="250" src="https://user-images.githubusercontent.com/264902/230491753-9fe25c85-4cb8-404d-9c72-72133ee79a95.png"> <img width="250" src="https://user-images.githubusercontent.com/264902/230491818-1dc1cc4e-d7cd-49bc-94a6-bd48e3ea9d7c.png">

## Testing Plan
- Added storybook.js entry for dev/demos
- Updated affected jest snapshots

## Checklist

- [n/a] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
