### PR TITLE
ignore hidden files with "." prefix in ballot package dir

### DIFF
--- a/libs/backend/src/ballot_package/ballot_package_io.test.ts
+++ b/libs/backend/src/ballot_package/ballot_package_io.test.ts
@@ -16,7 +16,7 @@ import {
 import { assert } from '@votingworks/basics';
 import { safeParseSystemSettings } from '@votingworks/utils';
 import { join } from 'path';
-import * as fsSync from 'fs';
+import * as fs from 'fs';
 import { Buffer } from 'buffer';
 import { createBallotPackageWithoutTemplates } from './test_utils';
 import { readBallotPackageFromUsb } from './ballot_package_io';
@@ -32,16 +32,14 @@ function assertFilesCreatedInOrder(
   // Ensure our mock actually created the files in the order we expect (the
   // order of the keys in the object above)
   const dirPath = join(usbDrive.mountPoint, 'ballot-packages');
-  const files = fsSync.readdirSync(dirPath);
+  const files = fs.readdirSync(dirPath);
   const filesWithStats = files.map((file) => ({
     file,
-    ...fsSync.statSync(join(dirPath, file)),
+    ...fs.statSync(join(dirPath, file)),
   }));
   assert(filesWithStats[0] !== undefined && filesWithStats[1] !== undefined);
   expect(filesWithStats[0].file).toContain(newerFileName);
   expect(filesWithStats[1].file).toContain(olderFileName);
-  // expect(filesWithStats[0].file).toContain('newer-ballot-package.zip');
-  // expect(filesWithStats[1].file).toContain('older-ballot-package.zip');
   expect(filesWithStats[0].ctime.getTime()).toBeGreaterThan(
     filesWithStats[1].ctime.getTime()
   );
@@ -272,7 +270,7 @@ test('configures using the most recently created ballot package on the usb drive
   );
 });
 
-test('ignores hidden `._`-prefixed files, even if they are newer', async () => {
+test('ignores hidden `.`-prefixed files, even if they are newer', async () => {
   const { electionDefinition } = electionMinimalExhaustiveSampleFixtures;
   const authStatus: InsertedSmartCardAuth.AuthStatus = {
     status: 'logged_in',

--- a/libs/backend/src/ballot_package/ballot_package_io.test.ts
+++ b/libs/backend/src/ballot_package/ballot_package_io.test.ts
@@ -15,9 +15,37 @@ import {
 } from '@votingworks/fixtures';
 import { assert } from '@votingworks/basics';
 import { safeParseSystemSettings } from '@votingworks/utils';
+import { join } from 'path';
+import * as fsSync from 'fs';
+import { Buffer } from 'buffer';
 import { createBallotPackageWithoutTemplates } from './test_utils';
 import { readBallotPackageFromUsb } from './ballot_package_io';
 import { createMockUsb } from '../mock_usb';
+import { UsbDrive } from '../get_usb_drives';
+
+function assertFilesCreatedInOrder(
+  usbDrive: UsbDrive,
+  olderFileName: string,
+  newerFileName: string
+) {
+  assert(usbDrive?.mountPoint !== undefined);
+  // Ensure our mock actually created the files in the order we expect (the
+  // order of the keys in the object above)
+  const dirPath = join(usbDrive.mountPoint, 'ballot-packages');
+  const files = fsSync.readdirSync(dirPath);
+  const filesWithStats = files.map((file) => ({
+    file,
+    ...fsSync.statSync(join(dirPath, file)),
+  }));
+  assert(filesWithStats[0] !== undefined && filesWithStats[1] !== undefined);
+  expect(filesWithStats[0].file).toContain(newerFileName);
+  expect(filesWithStats[1].file).toContain(olderFileName);
+  // expect(filesWithStats[0].file).toContain('newer-ballot-package.zip');
+  // expect(filesWithStats[1].file).toContain('older-ballot-package.zip');
+  expect(filesWithStats[0].ctime.getTime()).toBeGreaterThan(
+    filesWithStats[1].ctime.getTime()
+  );
+}
 
 test('readBallotPackageFromUsb can read a ballot package from usb', async () => {
   const { electionDefinition } = electionMinimalExhaustiveSampleFixtures;
@@ -200,4 +228,87 @@ test('errors if a user is authenticated but is not an election manager', async (
   await expect(
     readBallotPackageFromUsb(authStatus, usbDrive, fakeLogger())
   ).rejects.toThrow('Only election managers may configure a ballot package.');
+});
+
+test('configures using the most recently created ballot package on the usb drive', async () => {
+  const { electionDefinition } = electionMinimalExhaustiveSampleFixtures;
+  const authStatus: InsertedSmartCardAuth.AuthStatus = {
+    status: 'logged_in',
+    user: fakeElectionManagerUser({
+      electionHash: electionDefinition.electionHash,
+    }),
+    sessionExpiresAt: fakeSessionExpiresAt(),
+  };
+
+  const mockUsb = createMockUsb();
+  mockUsb.insertUsbDrive({
+    'ballot-packages': {
+      'older-ballot-package.zip':
+        electionFamousNames2021Fixtures.ballotPackage.asBuffer(),
+      'newer-ballot-package.zip': createBallotPackageWithoutTemplates(
+        electionDefinition,
+        { systemSettingsString: systemSettings.asText() }
+      ),
+    },
+  });
+  const [usbDrive] = await mockUsb.mock.getUsbDrives();
+  assert(usbDrive);
+  assertFilesCreatedInOrder(
+    usbDrive,
+    'older-ballot-package.zip',
+    'newer-ballot-package.zip'
+  );
+
+  const ballotPackageResult = await readBallotPackageFromUsb(
+    authStatus,
+    usbDrive,
+    fakeLogger()
+  );
+  assert(ballotPackageResult.isOk());
+  const ballotPackage = ballotPackageResult.ok();
+  expect(ballotPackage.electionDefinition).toEqual(electionDefinition);
+  expect(ballotPackage.systemSettings).toEqual(
+    safeParseSystemSettings(systemSettings.asText()).unsafeUnwrap()
+  );
+});
+
+test('ignores hidden `._`-prefixed files, even if they are newer', async () => {
+  const { electionDefinition } = electionMinimalExhaustiveSampleFixtures;
+  const authStatus: InsertedSmartCardAuth.AuthStatus = {
+    status: 'logged_in',
+    user: fakeElectionManagerUser({
+      electionHash: electionDefinition.electionHash,
+    }),
+    sessionExpiresAt: fakeSessionExpiresAt(),
+  };
+
+  const mockUsb = createMockUsb();
+  mockUsb.insertUsbDrive({
+    'ballot-packages': {
+      'older-ballot-package.zip': createBallotPackageWithoutTemplates(
+        electionDefinition,
+        { systemSettingsString: systemSettings.asText() }
+      ),
+      '._newer-hidden-file-ballot-package.zip': Buffer.from('not a zip file'),
+    },
+  });
+  const [usbDrive] = await mockUsb.mock.getUsbDrives();
+  assert(usbDrive);
+  assertFilesCreatedInOrder(
+    usbDrive,
+    'older-ballot-package.zip',
+    '._newer-hidden-file-ballot-package.zip'
+  );
+
+  const ballotPackageResult = await readBallotPackageFromUsb(
+    authStatus,
+    usbDrive,
+    fakeLogger()
+  );
+  assert(ballotPackageResult.isOk());
+  const ballotPackage = ballotPackageResult.ok();
+  expect(ballotPackage.electionDefinition).toEqual(electionDefinition);
+  expect(ballotPackage.systemSettings).toEqual(
+    safeParseSystemSettings(systemSettings.asText()).unsafeUnwrap()
+  );
 });

--- a/libs/backend/src/ballot_package/ballot_package_io.ts
+++ b/libs/backend/src/ballot_package/ballot_package_io.ts
@@ -51,7 +51,9 @@ export async function readBallotPackageFromUsb(
 
   const files = await fs.readdir(directoryPath, { withFileTypes: true });
   const ballotPackageFiles = files.filter(
-    (file) => file.isFile() && file.name.endsWith('.zip')
+    // OsX hidden files prefixed with `._` are not valid zip files and will break zip parsing
+    (file) =>
+      file.isFile() && !file.name.startsWith('._') && file.name.endsWith('.zip')
   );
   if (ballotPackageFiles.length === 0) {
     return err('no_ballot_package_on_usb_drive');

--- a/libs/backend/src/ballot_package/ballot_package_io.ts
+++ b/libs/backend/src/ballot_package/ballot_package_io.ts
@@ -51,9 +51,9 @@ export async function readBallotPackageFromUsb(
 
   const files = await fs.readdir(directoryPath, { withFileTypes: true });
   const ballotPackageFiles = files.filter(
-    // OsX hidden files prefixed with `._` are not valid zip files and will break zip parsing
     (file) =>
-      file.isFile() && !file.name.startsWith('._') && file.name.endsWith('.zip')
+      // Ignore hidden files that start with `.`
+      file.isFile() && !file.name.startsWith('.') && file.name.endsWith('.zip')
   );
   if (ballotPackageFiles.length === 0) {
     return err('no_ballot_package_on_usb_drive');


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/3236
When loading ballot packages from a USB, the ballot package IO library will load the newest file in the `ballot-packages` directory. If the newest file is a hidden `._foo.zip` file [left by OS X](https://apple.stackexchange.com/questions/14980/why-are-dot-underscore-files-created-and-how-can-i-avoid-them) the ballot package library will try and fail to parse it as a zip.

This PR makes it so we ignore `._`-prefixed files when reading `ballot-packages`. There's an argument to be made to ignore all hidden files prefixed by `.`, but since we also check for the `.zip` suffix, I don't know of any other cases where an OS would accidentally make `.foo.zip` files.

## Demo Video or Screenshot
Old

https://user-images.githubusercontent.com/1060688/230693060-59ed6677-4b04-439e-8e78-eb0dd1b39808.mov



New

https://user-images.githubusercontent.com/1060688/230693109-5796db99-b2ac-458e-be8d-40b1e68db6fc.mov


## Testing Plan
- added tests for `._` edge case

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added JSDoc comments to any newly introduced exports

