### PR TITLE
feat(grout): Serialize Dates

### DIFF
--- a/libs/grout/src/serialization.test.ts
+++ b/libs/grout/src/serialization.test.ts
@@ -44,6 +44,10 @@ test('JSON serialization/deserialization', () => {
   });
   expectToBePreservedExactly([1, [2, 3], [4, [5, 6]]]);
   expectToBePreservedExactly([{ a: 1 }, { b: [{ c: 2 }] }]);
+  // Dates
+  expectToBePreservedExactly(new Date('2020-01-01T00:00:00.000Z'));
+  expectToBePreservedExactly(new Date());
+  expectToBePreservedExactly({ a: new Date() });
   // Error
   expectToBePreservedExactly(new Error('some error'));
   // Result
@@ -77,8 +81,6 @@ test('JSON serialization/deserialization', () => {
   expectToBeRejected(-Infinity);
   expectToBeRejected(() => 1);
   expectToBeRejected({ method: () => 1 });
-  // We could build in support for Dates if we wanted to, but starting out safe by rejecting.
-  expectToBeRejected(new Date());
   // By default, JSON.stringify will call the toJSON method on objects when
   // serializing, but that's bad for us since we won't know how to deserialize
   // in those cases.


### PR DESCRIPTION
## Overview

Task: https://github.com/votingworks/vxsuite/issues/3233

Adds support to Grout for serializing/deserializing Dates. There was a bit of trickiness involving `JSON.stringify` which is explained in a comment.

## Demo Video or Screenshot
N/A

## Testing Plan
Updated automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
