### PR TITLE
feat(cental-scan): use NH-next interpreter

### DIFF
--- a/apps/central-scan/backend/package.json
+++ b/apps/central-scan/backend/package.json
@@ -42,6 +42,7 @@
     "@votingworks/backend": "workspace:*",
     "@votingworks/ballot-encoder": "workspace:*",
     "@votingworks/ballot-interpreter-nh": "workspace:*",
+    "@votingworks/ballot-interpreter-nh-next": "workspace:*",
     "@votingworks/ballot-interpreter-vx": "workspace:*",
     "@votingworks/basics": "workspace:*",
     "@votingworks/db": "workspace:*",

--- a/apps/central-scan/backend/src/workers/interpret_nh.ts
+++ b/apps/central-scan/backend/src/workers/interpret_nh.ts
@@ -1,4 +1,4 @@
-import { interpret } from '@votingworks/ballot-interpreter-nh';
+import { interpretCompatible as interpret } from '@votingworks/ballot-interpreter-nh-next';
 import {
   ElectionDefinition,
   PageInterpretationWithFiles,
@@ -52,7 +52,7 @@ export async function call(input: Input): Promise<Output> {
       }
 
       const adjudicationReasons =
-        electionDefinition.election.centralScanAdjudicationReasons;
+        electionDefinition.election.centralScanAdjudicationReasons ?? [];
       const result = await interpret(
         electionDefinition,
         [input.frontImagePath, input.backImagePath],

--- a/apps/central-scan/backend/tsconfig.build.json
+++ b/apps/central-scan/backend/tsconfig.build.json
@@ -14,6 +14,7 @@
     { "path": "../../../libs/auth/tsconfig.build.json" },
     { "path": "../../../libs/ballot-encoder/tsconfig.build.json" },
     { "path": "../../../libs/ballot-interpreter-nh/tsconfig.build.json" },
+    { "path": "../../../libs/ballot-interpreter-nh-next/tsconfig.build.json" },
     { "path": "../../../libs/ballot-interpreter-vx/tsconfig.build.json" },
     { "path": "../../../libs/basics/tsconfig.build.json" },
     { "path": "../../../libs/backend/tsconfig.build.json" },

--- a/apps/central-scan/backend/tsconfig.json
+++ b/apps/central-scan/backend/tsconfig.json
@@ -21,6 +21,7 @@
     { "path": "../../../libs/auth/tsconfig.build.json" },
     { "path": "../../../libs/ballot-encoder/tsconfig.build.json" },
     { "path": "../../../libs/ballot-interpreter-nh/tsconfig.build.json" },
+    { "path": "../../../libs/ballot-interpreter-nh-next/tsconfig.build.json" },
     { "path": "../../../libs/ballot-interpreter-vx/tsconfig.build.json" },
     { "path": "../../../libs/basics/tsconfig.build.json" },
     { "path": "../../../libs/backend/tsconfig.build.json" },

--- a/apps/scan/backend/src/interpret.ts
+++ b/apps/scan/backend/src/interpret.ts
@@ -1,4 +1,5 @@
 import { interpret as interpretNh } from '@votingworks/ballot-interpreter-nh';
+import { interpretCompatible as interpretNhNext } from '@votingworks/ballot-interpreter-nh-next';
 import {
   AdjudicationReason,
   AdjudicationReasonInfo,
@@ -17,7 +18,6 @@ import {
 } from '@votingworks/ballot-interpreter-vx';
 import { time } from '@votingworks/utils';
 import { err, ok, Optional, Result } from '@votingworks/basics';
-import { interpret as interpretNhNext } from './interpret_nh_next_adapter';
 import { Interpreter as VxInterpreter } from './vx_interpreter';
 import { saveSheetImages } from './util/save_images';
 import { rootDebug } from './util/debug';

--- a/libs/ballot-interpreter-nh-next/package.json
+++ b/libs/ballot-interpreter-nh-next/package.json
@@ -23,6 +23,7 @@
   "license": "AGPL-3.0",
   "packageManager": "pnpm@8.1.0",
   "dependencies": {
+    "@votingworks/ballot-interpreter-nh": "workspace:*",
     "@votingworks/basics": "workspace:*",
     "@votingworks/types": "workspace:*",
     "@votingworks/utils": "workspace:*",

--- a/libs/ballot-interpreter-nh-next/ts/src/adapter.test.ts
+++ b/libs/ballot-interpreter-nh-next/ts/src/adapter.test.ts
@@ -1,0 +1,417 @@
+import { assert, ok } from '@votingworks/basics';
+import { electionGridLayoutNewHampshireAmherstFixtures } from '@votingworks/fixtures';
+import { AdjudicationReason, SheetOf } from '@votingworks/types';
+import { convertMarksToAdjudicationInfo, interpret } from './adapter';
+import { BallotSide } from './types';
+
+test('convertMarksToAdjudicationInfo', () => {
+  const { electionDefinition } = electionGridLayoutNewHampshireAmherstFixtures;
+
+  expect(
+    convertMarksToAdjudicationInfo(
+      electionDefinition,
+      {
+        isTestMode: true,
+        adjudicationReasons: [
+          AdjudicationReason.MarginalMark,
+          AdjudicationReason.Overvote,
+        ],
+        markThresholds: {
+          marginal: 0.04,
+          definite: 0.07,
+        },
+      },
+      [
+        [
+          {
+            type: 'option',
+            side: 'front',
+            column: 1,
+            row: 1,
+            contestId: 'Governor-061a401b',
+            optionId: 'Josiah-Bartlett-1bb99985',
+          },
+          {
+            expectedBounds: { left: 0, top: 0, width: 0, height: 0 },
+            matchedBounds: { left: 0, top: 0, width: 0, height: 0 },
+            location: { side: BallotSide.Front, column: 1, row: 1 },
+            matchScore: 1,
+            fillScore: 1,
+          },
+        ],
+        [
+          {
+            type: 'option',
+            side: 'front',
+            column: 1,
+            row: 2,
+            contestId: 'Governor-061a401b',
+            optionId: 'Hannah-Dustin-ab4ef7c8',
+          },
+          {
+            expectedBounds: { left: 0, top: 0, width: 0, height: 0 },
+            matchedBounds: { left: 0, top: 0, width: 0, height: 0 },
+            location: { side: BallotSide.Front, column: 1, row: 2 },
+            matchScore: 1,
+            fillScore: 0.05,
+          },
+        ],
+        [
+          {
+            type: 'option',
+            side: 'front',
+            column: 1,
+            row: 3,
+            contestId: 'Governor-061a401b',
+            optionId: 'John-Spencer-9ffb5970',
+          },
+          {
+            expectedBounds: { left: 0, top: 0, width: 0, height: 0 },
+            matchedBounds: { left: 0, top: 0, width: 0, height: 0 },
+            location: { side: BallotSide.Front, column: 1, row: 3 },
+            matchScore: 1,
+            fillScore: 0,
+          },
+        ],
+        [
+          {
+            type: 'option',
+            side: 'front',
+            column: 1,
+            row: 4,
+            contestId: 'Governor-061a401b',
+            optionId: 'write-in-0',
+          },
+          {
+            expectedBounds: { left: 0, top: 0, width: 0, height: 0 },
+            matchedBounds: { left: 0, top: 0, width: 0, height: 0 },
+            location: { side: BallotSide.Front, column: 1, row: 4 },
+            matchScore: 1,
+            fillScore: 0.07,
+          },
+        ],
+      ]
+    )
+  ).toMatchInlineSnapshot(`
+    {
+      "enabledReasonInfos": [
+        {
+          "contestId": "Governor-061a401b",
+          "optionId": "Hannah-Dustin-ab4ef7c8",
+          "optionIndex": 1,
+          "type": "MarginalMark",
+        },
+        {
+          "contestId": "Governor-061a401b",
+          "expected": 1,
+          "optionIds": [
+            "Josiah-Bartlett-1bb99985",
+            "write-in-0",
+          ],
+          "optionIndexes": [
+            0,
+            3,
+          ],
+          "type": "Overvote",
+        },
+      ],
+      "enabledReasons": [
+        "MarginalMark",
+        "Overvote",
+      ],
+      "ignoredReasonInfos": [],
+      "requiresAdjudication": true,
+    }
+  `);
+});
+
+test('interpret with valid data', async () => {
+  const { electionDefinition } = electionGridLayoutNewHampshireAmherstFixtures;
+  const ballotImagePaths: SheetOf<string> = [
+    electionGridLayoutNewHampshireAmherstFixtures.scanMarkedFront.asFilePath(),
+    electionGridLayoutNewHampshireAmherstFixtures.scanMarkedBack.asFilePath(),
+  ];
+
+  const result = await interpret(electionDefinition, ballotImagePaths, {
+    isTestMode: true,
+    adjudicationReasons: [],
+  });
+  expect(result).toEqual(ok(expect.anything()));
+
+  const [front, back] = result.unsafeUnwrap();
+  assert(front.interpretation.type === 'InterpretedHmpbPage');
+  assert(back.interpretation.type === 'InterpretedHmpbPage');
+  expect(
+    [
+      ...front.interpretation.markInfo.marks,
+      ...back.interpretation.markInfo.marks,
+    ].map((mark) => ({
+      contestId: mark.contestId,
+      optionId: mark.optionId,
+      score: mark.score,
+    }))
+  ).toMatchInlineSnapshot(`
+    [
+      {
+        "contestId": "Governor-061a401b",
+        "optionId": "Josiah-Bartlett-1bb99985",
+        "score": 0.38557693,
+      },
+      {
+        "contestId": "United-States-Senator-d3f1c75b",
+        "optionId": "John-Langdon-5951c8e1",
+        "score": 0,
+      },
+      {
+        "contestId": "Representative-in-Congress-24683b44",
+        "optionId": "Jeremiah-Smith-469560c9",
+        "score": 0,
+      },
+      {
+        "contestId": "Executive-Councilor-bb22557f",
+        "optionId": "Anne-Waldron-ee0cbc85",
+        "score": 0,
+      },
+      {
+        "contestId": "State-Senator-391381f8",
+        "optionId": "James-Poole-db5ef4bd",
+        "score": 0.2875,
+      },
+      {
+        "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+        "optionId": "Obadiah-Carrigan-5c95145a",
+        "score": 0,
+      },
+      {
+        "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+        "optionId": "Mary-Baker-Eddy-350785d5",
+        "score": 0,
+      },
+      {
+        "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+        "optionId": "Samuel-Bell-17973275",
+        "score": 0.3201923,
+      },
+      {
+        "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
+        "optionId": "Abeil-Foster-ded38e36",
+        "score": 0,
+      },
+      {
+        "contestId": "Governor-061a401b",
+        "optionId": "Hannah-Dustin-ab4ef7c8",
+        "score": 0,
+      },
+      {
+        "contestId": "United-States-Senator-d3f1c75b",
+        "optionId": "William-Preston-3778fcd5",
+        "score": 0.37980768,
+      },
+      {
+        "contestId": "Representative-in-Congress-24683b44",
+        "optionId": "Nicholas-Gilman-1791aed7",
+        "score": 0,
+      },
+      {
+        "contestId": "Executive-Councilor-bb22557f",
+        "optionId": "Daniel-Webster-13f77b2d",
+        "score": 0,
+      },
+      {
+        "contestId": "State-Senator-391381f8",
+        "optionId": "Matthew-Thornton-f66fec5e",
+        "score": 0,
+      },
+      {
+        "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+        "optionId": "Samuel-Livermore-f927fef1",
+        "score": 0.3221154,
+      },
+      {
+        "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+        "optionId": "Elijah-Miller-a52e6988",
+        "score": 0,
+      },
+      {
+        "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+        "optionId": "Isaac-Hill-d6c9deeb",
+        "score": 0,
+      },
+      {
+        "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
+        "optionId": "Charles-H-Hersey-096286a4",
+        "score": 0.2778846,
+      },
+      {
+        "contestId": "Governor-061a401b",
+        "optionId": "John-Spencer-9ffb5970",
+        "score": 0,
+      },
+      {
+        "contestId": "Representative-in-Congress-24683b44",
+        "optionId": "Richard-Coote-b9095636",
+        "score": 0.32307693,
+      },
+      {
+        "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+        "optionId": "Abigail-Bartlett-4e46c9d4",
+        "score": 0,
+      },
+      {
+        "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+        "optionId": "Jacob-Freese-b5146505",
+        "score": 0.3326923,
+      },
+      {
+        "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
+        "optionId": "William-Lovejoy-fde3c2df",
+        "score": 0,
+      },
+      {
+        "contestId": "Governor-061a401b",
+        "optionId": "write-in-0",
+        "score": 0,
+      },
+      {
+        "contestId": "United-States-Senator-d3f1c75b",
+        "optionId": "write-in-0",
+        "score": 0,
+      },
+      {
+        "contestId": "Representative-in-Congress-24683b44",
+        "optionId": "write-in-0",
+        "score": 0,
+      },
+      {
+        "contestId": "Executive-Councilor-bb22557f",
+        "optionId": "write-in-0",
+        "score": 0.24903846,
+      },
+      {
+        "contestId": "State-Senator-391381f8",
+        "optionId": "write-in-0",
+        "score": 0,
+      },
+      {
+        "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+        "optionId": "write-in-2",
+        "score": 0,
+      },
+      {
+        "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+        "optionId": "write-in-1",
+        "score": 0,
+      },
+      {
+        "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+        "optionId": "write-in-0",
+        "score": 0,
+      },
+      {
+        "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
+        "optionId": "write-in-0",
+        "score": 0,
+      },
+      {
+        "contestId": "Sheriff-4243fe0b",
+        "optionId": "Edward-Randolph-bf4c848a",
+        "score": 0.30192307,
+      },
+      {
+        "contestId": "County-Attorney-133f910f",
+        "optionId": "Ezra-Bartlett-8f95223c",
+        "score": 0,
+      },
+      {
+        "contestId": "County-Treasurer-87d25a31",
+        "optionId": "John-Smith-ef61a579",
+        "score": 0,
+      },
+      {
+        "contestId": "Register-of-Deeds-a1278df2",
+        "optionId": "John-Mann-b56bbdd3",
+        "score": 0.35192308,
+      },
+      {
+        "contestId": "Register-of-Probate-a4117da8",
+        "optionId": "Nathaniel-Parker-56a06c29",
+        "score": 0,
+      },
+      {
+        "contestId": "County-Commissioner-d6feed25",
+        "optionId": "Ichabod-Goodwin-55e8de1f",
+        "score": 0,
+      },
+      {
+        "contestId": "Sheriff-4243fe0b",
+        "optionId": "Edward-Randolph-bf4c848a",
+        "score": 0,
+      },
+      {
+        "contestId": "County-Attorney-133f910f",
+        "optionId": "Mary-Woolson-dc0b854a",
+        "score": 0.31923077,
+      },
+      {
+        "contestId": "County-Treasurer-87d25a31",
+        "optionId": "Jane-Jones-9caa141f",
+        "score": 0,
+      },
+      {
+        "contestId": "Register-of-Deeds-a1278df2",
+        "optionId": "Ellen-A-Stileman-14408737",
+        "score": 0,
+      },
+      {
+        "contestId": "Register-of-Probate-a4117da8",
+        "optionId": "Claire-Cutts-07a436e7",
+        "score": 0.2971154,
+      },
+      {
+        "contestId": "County-Commissioner-d6feed25",
+        "optionId": "Valbe-Cady-ba3af3af",
+        "score": 0,
+      },
+      {
+        "contestId": "Sheriff-4243fe0b",
+        "optionId": "write-in-0",
+        "score": 0,
+      },
+      {
+        "contestId": "County-Attorney-133f910f",
+        "optionId": "write-in-0",
+        "score": 0,
+      },
+      {
+        "contestId": "County-Treasurer-87d25a31",
+        "optionId": "write-in-0",
+        "score": 0.37115383,
+      },
+      {
+        "contestId": "Register-of-Deeds-a1278df2",
+        "optionId": "write-in-0",
+        "score": 0,
+      },
+      {
+        "contestId": "Register-of-Probate-a4117da8",
+        "optionId": "write-in-0",
+        "score": 0,
+      },
+      {
+        "contestId": "County-Commissioner-d6feed25",
+        "optionId": "write-in-0",
+        "score": 0.30865383,
+      },
+      {
+        "contestId": "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc",
+        "optionId": "yes",
+        "score": 0.32596153,
+      },
+      {
+        "contestId": "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc",
+        "optionId": "no",
+        "score": 0,
+      },
+    ]
+  `);
+});

--- a/libs/ballot-interpreter-nh-next/ts/src/adapter.ts
+++ b/libs/ballot-interpreter-nh-next/ts/src/adapter.ts
@@ -1,5 +1,4 @@
 import * as current from '@votingworks/ballot-interpreter-nh';
-import * as next from '@votingworks/ballot-interpreter-nh-next';
 import {
   assert,
   err,
@@ -11,6 +10,7 @@ import {
 } from '@votingworks/basics';
 import {
   AdjudicationInfo,
+  AdjudicationReason,
   BallotTargetMark,
   BallotType,
   Contests,
@@ -20,7 +20,9 @@ import {
   MarkInfo,
   MarkStatus,
   MarkThresholds,
+  PrecinctId,
   Rect,
+  SheetOf,
   VotesDict,
 } from '@votingworks/types';
 import {
@@ -28,15 +30,29 @@ import {
   ballotAdjudicationReasons,
   convertMarksToVotesDict,
 } from '@votingworks/utils';
+import { interpret as interpretNext } from './interpret';
+import {
+  BallotPageMetadataFront,
+  Geometry,
+  InterpretedBallotCard,
+  InterpretedBallotPage,
+  InterpretResult as NextInterpretResult,
+  ScoredOvalMarks,
+} from './types';
 
 type OkType<T> = T extends Ok<infer U> ? U : never;
 
-type CurrentInterpretResult = Awaited<ReturnType<typeof current.interpret>>;
-type CurrentInterpretOptions = Parameters<typeof current.interpret>[2];
+type InterpretResult = Awaited<ReturnType<typeof current.interpret>>;
+type InterpretOptions = Exclude<
+  Parameters<typeof current.interpret>[2],
+  'adjudicationReasons'
+> & {
+  adjudicationReasons: readonly AdjudicationReason[];
+};
 
 function convertNewHampshireNextMarkToSharedMark(
   contests: Contests,
-  [gridPosition, scoredMark]: next.ScoredOvalMarks[number]
+  [gridPosition, scoredMark]: ScoredOvalMarks[number]
 ): BallotTargetMark {
   assert(scoredMark, 'scoredMark must be defined');
 
@@ -83,20 +99,21 @@ function convertNewHampshireNextMarkToSharedMark(
       : { type: 'yesno', optionId: option.id, ...ballotTargetMarkBase };
   }
 
+  /* istanbul ignore next */
   throwIllegalValue(option);
 }
 
-function convertMarksToAdjudicationInfo(
+/**
+ * Derives adjudication information from the given marks.
+ */
+export function convertMarksToAdjudicationInfo(
   electionDefinition: ElectionDefinition,
-  options: CurrentInterpretOptions,
-  marks: next.ScoredOvalMarks
+  options: InterpretOptions,
+  marks: ScoredOvalMarks
 ): AdjudicationInfo {
   const markThresholds =
     options.markThresholds ?? electionDefinition.election.markThresholds;
-  const enabledReasons =
-    options.adjudicationReasons ??
-    electionDefinition.election.precinctScanAdjudicationReasons ??
-    [];
+  const enabledReasons = options.adjudicationReasons;
   assert(markThresholds, 'markThresholds must be defined');
 
   const contests = electionDefinition.election.contests.filter((c) =>
@@ -105,21 +122,24 @@ function convertMarksToAdjudicationInfo(
   const adjudicationReasonInfos = Array.from(
     ballotAdjudicationReasons(contests, {
       optionMarkStatus: (option) => {
+        // eslint-disable-next-line array-callback-return -- `default` throws
         const contestMarks = marks.filter(([gridPosition]) => {
           if (gridPosition.contestId !== option.contestId) {
             return false;
           }
 
-          if (gridPosition.type === 'option') {
-            return gridPosition.optionId === option.id;
-          }
+          switch (gridPosition.type) {
+            case 'option':
+              return gridPosition.optionId === option.id;
 
-          if (gridPosition.type === 'write-in') {
-            assert(option.type === 'candidate');
-            return gridPosition.writeInIndex === option.writeInIndex;
-          }
+            case 'write-in':
+              assert(option.type === 'candidate');
+              return gridPosition.writeInIndex === option.writeInIndex;
 
-          return false;
+            /* istanbul ignore next */
+            default:
+              throwIllegalValue(gridPosition);
+          }
         });
         assert(
           contestMarks.length > 0,
@@ -157,8 +177,8 @@ function convertMarksToAdjudicationInfo(
 
 function convertMarksToMarkInfo(
   contests: Contests,
-  geometry: next.Geometry,
-  marks: next.ScoredOvalMarks
+  geometry: Geometry,
+  marks: ScoredOvalMarks
 ): MarkInfo {
   const markInfo: MarkInfo = {
     ballotSize: geometry.canvasSize,
@@ -173,7 +193,7 @@ function convertMarksToMarkInfo(
 function convertMarksToVotes(
   contests: Contests,
   markThresholds: MarkThresholds,
-  marks: next.ScoredOvalMarks
+  marks: ScoredOvalMarks
 ): VotesDict {
   return convertMarksToVotesDict(
     contests,
@@ -186,8 +206,8 @@ function convertMarksToVotes(
 
 function buildInterpretedHmpbPageMetadata(
   electionDefinition: ElectionDefinition,
-  options: CurrentInterpretOptions,
-  frontMetadata: next.BallotPageMetadataFront
+  options: InterpretOptions,
+  frontMetadata: BallotPageMetadataFront
 ): HmpbBallotPageMetadata {
   const ballotStyleId = `card-number-${frontMetadata.cardNumber}`;
   const ballotStyle = getBallotStyle({
@@ -199,7 +219,7 @@ function buildInterpretedHmpbPageMetadata(
 
   return {
     ballotStyleId,
-    precinctId: ballotStyle.precincts[0],
+    precinctId: ballotStyle.precincts[0] as PrecinctId,
     ballotType: BallotType.Standard,
     electionHash: electionDefinition.electionHash,
     isTestMode: options.isTestMode,
@@ -210,10 +230,11 @@ function buildInterpretedHmpbPageMetadata(
 
 function convertNextInterpretedBallotPage(
   electionDefinition: ElectionDefinition,
-  options: CurrentInterpretOptions,
-  nextInterpretedBallotCard: next.InterpretedBallotCard,
-  nextInterpretation: next.InterpretedBallotPage
+  options: InterpretOptions,
+  nextInterpretedBallotCard: InterpretedBallotCard,
+  nextInterpretation: InterpretedBallotPage
 ): current.InterpretFileResult {
+  /* istanbul ignore next */
   const markThresholds =
     options.markThresholds ?? electionDefinition.election.markThresholds;
   assert(markThresholds, 'markThresholds must be defined');
@@ -224,8 +245,7 @@ function convertNextInterpretedBallotPage(
       metadata: buildInterpretedHmpbPageMetadata(
         electionDefinition,
         options,
-        nextInterpretedBallotCard.front.grid
-          .metadata as next.BallotPageMetadataFront
+        nextInterpretedBallotCard.front.grid.metadata as BallotPageMetadataFront
       ),
       markInfo: convertMarksToMarkInfo(
         electionDefinition.election.contests,
@@ -248,16 +268,17 @@ function convertNextInterpretedBallotPage(
 
 function convertNextInterpretResult(
   electionDefinition: ElectionDefinition,
-  options: CurrentInterpretOptions,
-  nextResult: next.InterpretResult
-): CurrentInterpretResult {
+  options: InterpretOptions,
+  nextResult: NextInterpretResult
+): InterpretResult {
+  /* istanbul ignore next */
   if (nextResult.isErr()) {
     return err(new Error(JSON.stringify(nextResult.err())));
   }
 
   const ballotCard = nextResult.ok();
   const { front, back } = ballotCard;
-  const currentResult: OkType<CurrentInterpretResult> = [
+  const currentResult: OkType<InterpretResult> = [
     convertNextInterpretedBallotPage(
       electionDefinition,
       options,
@@ -275,15 +296,16 @@ function convertNextInterpretResult(
 }
 
 /**
- * Interprets a scanned ballot using `@votingworks/ballot-interpreter-nh-next`.
+ * Interprets a scanned ballot and returns a result that's compatible with
+ * `@votingworks/ballot-interpreter-nh`.
  */
-export const interpret: typeof current.interpret = (
-  electionDefinition,
-  sheet,
-  options
-) => {
-  const nextResult = next.interpret(electionDefinition, sheet);
+export function interpret(
+  electionDefinition: ElectionDefinition,
+  sheet: SheetOf<string>,
+  options: InterpretOptions
+): Promise<InterpretResult> {
+  const nextResult = interpretNext(electionDefinition, sheet);
   return Promise.resolve(
     convertNextInterpretResult(electionDefinition, options, nextResult)
   );
-};
+}

--- a/libs/ballot-interpreter-nh-next/ts/src/adapter.ts
+++ b/libs/ballot-interpreter-nh-next/ts/src/adapter.ts
@@ -207,7 +207,8 @@ function convertMarksToVotes(
 function buildInterpretedHmpbPageMetadata(
   electionDefinition: ElectionDefinition,
   options: InterpretOptions,
-  frontMetadata: BallotPageMetadataFront
+  frontMetadata: BallotPageMetadataFront,
+  isFrontPage: boolean
 ): HmpbBallotPageMetadata {
   const ballotStyleId = `card-number-${frontMetadata.cardNumber}`;
   const ballotStyle = getBallotStyle({
@@ -224,7 +225,7 @@ function buildInterpretedHmpbPageMetadata(
     electionHash: electionDefinition.electionHash,
     isTestMode: options.isTestMode,
     locales: { primary: 'en-US' },
-    pageNumber: 1,
+    pageNumber: isFrontPage ? 1 : 2,
   };
 }
 
@@ -245,7 +246,9 @@ function convertNextInterpretedBallotPage(
       metadata: buildInterpretedHmpbPageMetadata(
         electionDefinition,
         options,
-        nextInterpretedBallotCard.front.grid.metadata as BallotPageMetadataFront
+        nextInterpretedBallotCard.front.grid
+          .metadata as BallotPageMetadataFront,
+        nextInterpretation === nextInterpretedBallotCard.front
       ),
       markInfo: convertMarksToMarkInfo(
         electionDefinition.election.contests,

--- a/libs/ballot-interpreter-nh-next/ts/src/index.ts
+++ b/libs/ballot-interpreter-nh-next/ts/src/index.ts
@@ -1,3 +1,4 @@
 /* istanbul ignore file */
 export * from './interpret';
 export * from './types';
+export { interpret as interpretCompatible } from './adapter';

--- a/libs/ballot-interpreter-nh-next/tsconfig.build.json
+++ b/libs/ballot-interpreter-nh-next/tsconfig.build.json
@@ -9,6 +9,7 @@
     "declaration": true
   },
   "references": [
+    { "path": "../ballot-interpreter-nh/tsconfig.build.json" },
     { "path": "../basics/tsconfig.build.json" },
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../fixtures/tsconfig.build.json" },

--- a/libs/ballot-interpreter-nh-next/tsconfig.json
+++ b/libs/ballot-interpreter-nh-next/tsconfig.json
@@ -11,6 +11,7 @@
     "skipLibCheck": true
   },
   "references": [
+    { "path": "../ballot-interpreter-nh/tsconfig.build.json" },
     { "path": "../basics/tsconfig.build.json" },
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../fixtures/tsconfig.build.json" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -910,6 +910,9 @@ importers:
       '@votingworks/ballot-interpreter-nh':
         specifier: workspace:*
         version: link:../../../libs/ballot-interpreter-nh
+      '@votingworks/ballot-interpreter-nh-next':
+        specifier: workspace:*
+        version: link:../../../libs/ballot-interpreter-nh-next
       '@votingworks/ballot-interpreter-vx':
         specifier: workspace:*
         version: link:../../../libs/ballot-interpreter-vx
@@ -3252,6 +3255,9 @@ importers:
 
   libs/ballot-interpreter-nh-next:
     dependencies:
+      '@votingworks/ballot-interpreter-nh':
+        specifier: workspace:*
+        version: link:../ballot-interpreter-nh
       '@votingworks/basics':
         specifier: workspace:*
         version: link:../basics


### PR DESCRIPTION
## Overview

This moves the adapter layer from `apps/scan` to `ballot-interpreter-nh-next` itself so `apps/central-scan` can use it, then replaces the `interpret` call from `ballot-interpreter-nh` with the new compatible one from `ballot-interpreter-nh-next`.

This doesn't remove the dependency on `ballot-interpreter-nh` because it wasn't clear that it was safe to do so since it's still used in `store.ts`, though the code that uses it is slated to be removed and may itself be unused.

## Demo Video or Screenshot

https://user-images.githubusercontent.com/1938/230976578-fa2498e6-8964-47cb-95dd-51586aa9f744.mov



## Testing Plan
- [x] Automated
- [x] Manual testing with a real scanner.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
