### PR TITLE
Lead poll worker through unplug/replug in case of unrecoverable error

### DIFF
--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -470,6 +470,20 @@ export function AppRoot({
   }
 
   if (scannerStatus?.state === 'disconnected') {
+    if (computer.batteryIsCharging) {
+      // this means either a serious internal connection problem (USB cable not connected)
+      // or more likely the plustek crashed before scanning, and so now it thinks there's
+      // no plustek connected. Let's instead guide the poll worker to do the right thing.
+      return (
+        <ScanErrorScreen
+          error={scannerStatus.error}
+          isTestMode={isTestMode}
+          scannedBallotCount={scannerStatus.ballotsCounted}
+          restartRequired
+          powerConnected={computer.batteryIsCharging}
+        />
+      );
+    }
     return (
       <SetupScannerScreen
         batteryIsCharging={computer.batteryIsCharging}
@@ -660,6 +674,7 @@ export function AppRoot({
             isTestMode={isTestMode}
             scannedBallotCount={scannerStatus.ballotsCounted}
             restartRequired
+            powerConnected={computer.batteryIsCharging}
           />
         );
       // If an election manager removes their card during calibration, we'll

--- a/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
+++ b/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
@@ -244,8 +244,8 @@ test('shows internal wiring message when there is no plustek scanner, but tablet
       state: 'disconnected',
     });
   render(<App card={card} storage={storage} hardware={hardware} />);
-  await screen.findByRole('heading', { name: 'Internal Connection Problem' });
-  screen.getByText('Please ask a poll worker for help.');
+  await screen.findByRole('heading', { name: 'Scanner Error' });
+  screen.getByText('Ask a poll worker to unplug the power cord.');
 });
 
 test('shows power cable message when there is no plustek scanner and tablet is not plugged in', async () => {
@@ -316,8 +316,8 @@ test('shows instructions to restart when the plustek crashed', async () => {
     });
   render(<App card={card} storage={storage} hardware={hardware} />);
 
-  await screen.findByRole('heading', { name: 'Ballot Not Counted' });
-  screen.getByText('Ask a poll worker to restart the scanner.');
+  await screen.findByRole('heading', { name: 'Scanner Error' });
+  screen.getByText('Ask a poll worker to unplug the power cord.');
   expect(fetchMock.done()).toBe(true);
 });
 

--- a/frontends/precinct-scanner/src/screens/scan_error_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/scan_error_screen.test.tsx
@@ -63,3 +63,34 @@ test('render correct unreadable ballot screen', async () => {
     'There was a problem reading this ballot. Please scan again.'
   );
 });
+
+test('render correct through unrecoverable error', async () => {
+  render(
+    <ScanErrorScreen
+      error="plustek_error"
+      scannedBallotCount={42}
+      restartRequired
+      powerConnected
+      isTestMode
+    />
+  );
+  await screen.findByText('Scanner Error');
+  await screen.findByText('Ask a poll worker to unplug the power cord.');
+});
+
+test('render correct through unrecoverable error with power cord unplugged', async () => {
+  render(
+    <ScanErrorScreen
+      error="plustek_error"
+      scannedBallotCount={42}
+      restartRequired
+      powerConnected={false}
+      isTestMode
+    />
+  );
+
+  await screen.findByText('Scanner Error');
+  await screen.findByText(
+    'Plug the power cord back in to restart the scanner.'
+  );
+});

--- a/services/scan/Makefile
+++ b/services/scan/Makefile
@@ -7,6 +7,7 @@ FORCE:
 
 install:
 	sudo apt-get -y update
+	sudo apt-get install -y uhubctl
 ifeq ($(OS),bionic)
 	sudo apt-get install -y libsane build-essential libx11-dev libjpeg-dev libpng-dev
 endif

--- a/services/scan/src/precinct_scanner_app.test.ts
+++ b/services/scan/src/precinct_scanner_app.test.ts
@@ -1291,7 +1291,7 @@ test('scan fails due to plustek returning only one file instead of two', async (
   await expectStatus(app, { state: 'scanning' });
   mockPlustek.simulateScanError('only_one_file_returned');
   await waitForStatus(app, {
-    state: 'unrecoverable_error',
+    state: 'recovering_from_error',
     error: 'plustek_error',
   });
 

--- a/services/scan/src/precinct_scanner_app.ts
+++ b/services/scan/src/precinct_scanner_app.ts
@@ -575,6 +575,14 @@ export async function buildPrecinctScannerApp(
     }
   );
 
+  app.post<NoParams, OkResponse>(
+    '/precinct-scanner/scanner/retry',
+    (_request, response) => {
+      machine.retry();
+      response.json({ status: 'ok' });
+    }
+  );
+
   app.post<NoParams, Scan.CalibrateResponse>(
     '/precinct-scanner/scanner/calibrate',
     async (_request, response) => {


### PR DESCRIPTION

## Overview

#2844 

## Demo Video or Screenshot

## Testing Plan

## Checklist

~- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
~- [ ] I have added JSDoc comments to any newly introduced exports~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
