### PR TITLE
Move jurisdiction into user model in prep for non-VxAdmin jurisdiction setting

### DIFF
--- a/apps/admin/backend/src/app.auth.test.ts
+++ b/apps/admin/backend/src/app.auth.test.ts
@@ -1,9 +1,11 @@
+import { DEV_JURISDICTION } from '@votingworks/auth';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 
 import { buildTestEnvironment, configureMachine } from '../test/app';
 
 const { electionDefinition } = electionFamousNames2021Fixtures;
 const { electionData, electionHash } = electionDefinition;
+const jurisdiction = DEV_JURISDICTION;
 
 test('getAuthStatus', async () => {
   const { apiClient, auth } = buildTestEnvironment();
@@ -14,7 +16,10 @@ test('getAuthStatus', async () => {
 
   await apiClient.getAuthStatus();
   expect(auth.getAuthStatus).toHaveBeenCalledTimes(2);
-  expect(auth.getAuthStatus).toHaveBeenNthCalledWith(2, { electionHash });
+  expect(auth.getAuthStatus).toHaveBeenNthCalledWith(2, {
+    electionHash,
+    jurisdiction,
+  });
 });
 
 test('checkPin', async () => {
@@ -25,7 +30,7 @@ test('checkPin', async () => {
   expect(auth.checkPin).toHaveBeenCalledTimes(1);
   expect(auth.checkPin).toHaveBeenNthCalledWith(
     1,
-    { electionHash },
+    { electionHash, jurisdiction },
     { pin: '123456' }
   );
 });
@@ -36,7 +41,10 @@ test('logOut', async () => {
 
   await apiClient.logOut();
   expect(auth.logOut).toHaveBeenCalledTimes(1);
-  expect(auth.logOut).toHaveBeenNthCalledWith(1, { electionHash });
+  expect(auth.logOut).toHaveBeenNthCalledWith(1, {
+    electionHash,
+    jurisdiction,
+  });
 });
 
 test('updateSessionExpiry', async () => {
@@ -49,7 +57,7 @@ test('updateSessionExpiry', async () => {
   expect(auth.updateSessionExpiry).toHaveBeenCalledTimes(1);
   expect(auth.updateSessionExpiry).toHaveBeenNthCalledWith(
     1,
-    { electionHash },
+    { electionHash, jurisdiction },
     { sessionExpiresAt: expect.any(Number) }
   );
 });
@@ -62,7 +70,7 @@ test('programCard', async () => {
   expect(auth.programCard).toHaveBeenCalledTimes(1);
   expect(auth.programCard).toHaveBeenNthCalledWith(
     1,
-    { electionHash },
+    { electionHash, jurisdiction },
     { userRole: 'system_administrator' }
   );
 
@@ -70,7 +78,7 @@ test('programCard', async () => {
   expect(auth.programCard).toHaveBeenCalledTimes(2);
   expect(auth.programCard).toHaveBeenNthCalledWith(
     2,
-    { electionHash },
+    { electionHash, jurisdiction },
     { userRole: 'election_manager', electionData }
   );
 });
@@ -81,7 +89,10 @@ test('unprogramCard', async () => {
 
   void (await apiClient.unprogramCard());
   expect(auth.unprogramCard).toHaveBeenCalledTimes(1);
-  expect(auth.unprogramCard).toHaveBeenNthCalledWith(1, { electionHash });
+  expect(auth.unprogramCard).toHaveBeenNthCalledWith(1, {
+    electionHash,
+    jurisdiction,
+  });
 });
 
 test('getAuthStatus before election definition has been configured', async () => {
@@ -89,7 +100,7 @@ test('getAuthStatus before election definition has been configured', async () =>
 
   await apiClient.getAuthStatus();
   expect(auth.getAuthStatus).toHaveBeenCalledTimes(1);
-  expect(auth.getAuthStatus).toHaveBeenNthCalledWith(1, {});
+  expect(auth.getAuthStatus).toHaveBeenNthCalledWith(1, { jurisdiction });
 });
 
 test('checkPin before election definition has been configured', async () => {
@@ -97,7 +108,11 @@ test('checkPin before election definition has been configured', async () => {
 
   await apiClient.checkPin({ pin: '123456' });
   expect(auth.checkPin).toHaveBeenCalledTimes(1);
-  expect(auth.checkPin).toHaveBeenNthCalledWith(1, {}, { pin: '123456' });
+  expect(auth.checkPin).toHaveBeenNthCalledWith(
+    1,
+    { jurisdiction },
+    { pin: '123456' }
+  );
 });
 
 test('logOut before election definition has been configured', async () => {
@@ -105,7 +120,7 @@ test('logOut before election definition has been configured', async () => {
 
   await apiClient.logOut();
   expect(auth.logOut).toHaveBeenCalledTimes(1);
-  expect(auth.logOut).toHaveBeenNthCalledWith(1, {});
+  expect(auth.logOut).toHaveBeenNthCalledWith(1, { jurisdiction });
 });
 
 test('updateSessionExpiry before election definition has been configured', async () => {
@@ -117,7 +132,7 @@ test('updateSessionExpiry before election definition has been configured', async
   expect(auth.updateSessionExpiry).toHaveBeenCalledTimes(1);
   expect(auth.updateSessionExpiry).toHaveBeenNthCalledWith(
     1,
-    {},
+    { jurisdiction },
     { sessionExpiresAt: expect.any(Number) }
   );
 });

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -35,11 +35,7 @@ import {
 import * as grout from '@votingworks/grout';
 import { promises as fs, Stats } from 'fs';
 import { basename } from 'path';
-import {
-  BooleanEnvironmentVariableName,
-  isFeatureFlagEnabled,
-  parseCastVoteRecordReportDirectoryName,
-} from '@votingworks/utils';
+import { parseCastVoteRecordReportDirectoryName } from '@votingworks/utils';
 import {
   AddCastVoteRecordFileResult,
   ConfigureResult,
@@ -74,11 +70,7 @@ function constructAuthMachineState(
     arePollWorkerCardPinsEnabled: systemSettings?.arePollWorkerCardPinsEnabled,
     electionHash: currentElectionDefinition?.electionHash,
     // TODO: Pull jurisdiction from VxAdmin cert authority cert
-    jurisdiction: isFeatureFlagEnabled(
-      BooleanEnvironmentVariableName.ENABLE_JAVA_CARDS
-    )
-      ? /* istanbul ignore next */ DEV_JURISDICTION
-      : undefined,
+    jurisdiction: DEV_JURISDICTION,
   };
 }
 

--- a/apps/admin/integration-testing/cypress/support/auth.ts
+++ b/apps/admin/integration-testing/cypress/support/auth.ts
@@ -3,12 +3,13 @@ import { methodUrl } from '@votingworks/grout';
 // Importing all of @votingworks/auth causes Cypress tests to fail since Cypress doesn't seem to
 // interact well with PCSC Lite card reader code
 // eslint-disable-next-line vx/no-import-workspace-subfolders
+import { DEV_JURISDICTION } from '@votingworks/auth/src/certs';
+// eslint-disable-next-line vx/no-import-workspace-subfolders
 import {
   mockCard,
   MockFileContents,
 } from '@votingworks/auth/src/mock_file_card';
 
-const JURISDICTION = 'st.jurisdiction';
 const PIN = '000000';
 
 function mockCardCypress(mockFileContents: MockFileContents): void {
@@ -20,8 +21,10 @@ export function mockSystemAdministratorCardInsertion(): void {
     cardStatus: {
       status: 'ready',
       cardDetails: {
-        jurisdiction: JURISDICTION,
-        user: { role: 'system_administrator' },
+        user: {
+          role: 'system_administrator',
+          jurisdiction: DEV_JURISDICTION,
+        },
       },
     },
     pin: PIN,
@@ -39,9 +42,9 @@ export function mockElectionManagerCardInsertion({
     cardStatus: {
       status: 'ready',
       cardDetails: {
-        jurisdiction: JURISDICTION,
         user: {
           role: 'election_manager',
+          jurisdiction: DEV_JURISDICTION,
           electionHash,
         },
       },

--- a/apps/central-scan/backend/src/auth.test.ts
+++ b/apps/central-scan/backend/src/auth.test.ts
@@ -2,6 +2,7 @@ import { Server } from 'http';
 import { dirSync } from 'tmp';
 import {
   buildMockDippedSmartCardAuth,
+  DEV_JURISDICTION,
   DippedSmartCardAuthApi,
 } from '@votingworks/auth';
 import { Exporter } from '@votingworks/backend';
@@ -18,6 +19,7 @@ import { createWorkspace, Workspace } from './util/workspace';
 
 const { electionDefinition } = stateOfHamilton;
 const { electionData, electionHash } = electionDefinition;
+const jurisdiction = DEV_JURISDICTION;
 
 let apiClient: grout.Client<Api>;
 let auth: DippedSmartCardAuthApi;
@@ -53,7 +55,10 @@ afterEach(() => {
 test('getAuthStatus', async () => {
   await apiClient.getAuthStatus();
   expect(auth.getAuthStatus).toHaveBeenCalledTimes(1);
-  expect(auth.getAuthStatus).toHaveBeenNthCalledWith(1, { electionHash });
+  expect(auth.getAuthStatus).toHaveBeenNthCalledWith(1, {
+    electionHash,
+    jurisdiction,
+  });
 });
 
 test('checkPin', async () => {
@@ -61,7 +66,7 @@ test('checkPin', async () => {
   expect(auth.checkPin).toHaveBeenCalledTimes(1);
   expect(auth.checkPin).toHaveBeenNthCalledWith(
     1,
-    { electionHash },
+    { electionHash, jurisdiction },
     { pin: '123456' }
   );
 });
@@ -69,7 +74,10 @@ test('checkPin', async () => {
 test('logOut', async () => {
   await apiClient.logOut();
   expect(auth.logOut).toHaveBeenCalledTimes(1);
-  expect(auth.logOut).toHaveBeenNthCalledWith(1, { electionHash });
+  expect(auth.logOut).toHaveBeenNthCalledWith(1, {
+    electionHash,
+    jurisdiction,
+  });
 });
 
 test('updateSessionExpiry', async () => {
@@ -79,7 +87,7 @@ test('updateSessionExpiry', async () => {
   expect(auth.updateSessionExpiry).toHaveBeenCalledTimes(1);
   expect(auth.updateSessionExpiry).toHaveBeenNthCalledWith(
     1,
-    { electionHash },
+    { electionHash, jurisdiction },
     { sessionExpiresAt: expect.any(Number) }
   );
 });
@@ -89,7 +97,7 @@ test('getAuthStatus before election definition has been configured', async () =>
 
   await apiClient.getAuthStatus();
   expect(auth.getAuthStatus).toHaveBeenCalledTimes(1);
-  expect(auth.getAuthStatus).toHaveBeenNthCalledWith(1, {});
+  expect(auth.getAuthStatus).toHaveBeenNthCalledWith(1, { jurisdiction });
 });
 
 test('checkPin before election definition has been configured', async () => {
@@ -97,7 +105,11 @@ test('checkPin before election definition has been configured', async () => {
 
   await apiClient.checkPin({ pin: '123456' });
   expect(auth.checkPin).toHaveBeenCalledTimes(1);
-  expect(auth.checkPin).toHaveBeenNthCalledWith(1, {}, { pin: '123456' });
+  expect(auth.checkPin).toHaveBeenNthCalledWith(
+    1,
+    { jurisdiction },
+    { pin: '123456' }
+  );
 });
 
 test('logOut before election definition has been configured', async () => {
@@ -105,7 +117,7 @@ test('logOut before election definition has been configured', async () => {
 
   await apiClient.logOut();
   expect(auth.logOut).toHaveBeenCalledTimes(1);
-  expect(auth.logOut).toHaveBeenNthCalledWith(1, {});
+  expect(auth.logOut).toHaveBeenNthCalledWith(1, { jurisdiction });
 });
 
 test('updateSessionExpiry before election definition has been configured', async () => {
@@ -117,7 +129,7 @@ test('updateSessionExpiry before election definition has been configured', async
   expect(auth.updateSessionExpiry).toHaveBeenCalledTimes(1);
   expect(auth.updateSessionExpiry).toHaveBeenNthCalledWith(
     1,
-    {},
+    { jurisdiction },
     { sessionExpiresAt: expect.any(Number) }
   );
 });

--- a/apps/central-scan/backend/src/central_scanner_app.ts
+++ b/apps/central-scan/backend/src/central_scanner_app.ts
@@ -19,10 +19,8 @@ import {
   safeParseJson,
 } from '@votingworks/types';
 import {
-  BooleanEnvironmentVariableName,
   generateElectionBasedSubfolderName,
   generateFilenameForScanningResults,
-  isFeatureFlagEnabled,
   readBallotPackageFromBuffer,
   SCANNER_RESULTS_FOLDER,
 } from '@votingworks/utils';
@@ -59,11 +57,7 @@ function constructAuthMachineState(
   return {
     electionHash: electionDefinition?.electionHash,
     // TODO: Persist jurisdiction in store and pull from there
-    jurisdiction: isFeatureFlagEnabled(
-      BooleanEnvironmentVariableName.ENABLE_JAVA_CARDS
-    )
-      ? /* istanbul ignore next */ DEV_JURISDICTION
-      : undefined,
+    jurisdiction: DEV_JURISDICTION,
   };
 }
 

--- a/apps/central-scan/integration-testing/cypress/e2e/configuration.cy.ts
+++ b/apps/central-scan/integration-testing/cypress/e2e/configuration.cy.ts
@@ -5,12 +5,13 @@ import { sha256 } from 'js-sha256';
 // Importing all of @votingworks/auth causes Cypress tests to fail since Cypress doesn't seem to
 // interact well with PCSC Lite card reader code
 // eslint-disable-next-line vx/no-import-workspace-subfolders
+import { DEV_JURISDICTION } from '@votingworks/auth/src/certs';
+// eslint-disable-next-line vx/no-import-workspace-subfolders
 import {
   mockCard,
   MockFileContents,
 } from '@votingworks/auth/src/mock_file_card';
 
-const JURISDICTION = 'st.jurisdiction';
 const PIN = '000000';
 
 function mockCardCypress(mockFileContents: MockFileContents): void {
@@ -26,9 +27,9 @@ function mockElectionManagerCard() {
         cardStatus: {
           status: 'ready',
           cardDetails: {
-            jurisdiction: JURISDICTION,
             user: {
               role: 'election_manager',
+              jurisdiction: DEV_JURISDICTION,
               electionHash,
             },
           },

--- a/apps/mark/backend/src/app.auth.test.ts
+++ b/apps/mark/backend/src/app.auth.test.ts
@@ -1,9 +1,11 @@
+import { DEV_JURISDICTION } from '@votingworks/auth';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 
 import { createApp } from '../test/app_helpers';
 
 const { electionDefinition } = electionFamousNames2021Fixtures;
 const { electionHash } = electionDefinition;
+const jurisdiction = DEV_JURISDICTION;
 
 test('getAuthStatus', async () => {
   const { apiClient, mockAuth } = createApp();
@@ -12,6 +14,7 @@ test('getAuthStatus', async () => {
   expect(mockAuth.getAuthStatus).toHaveBeenCalledTimes(1);
   expect(mockAuth.getAuthStatus).toHaveBeenNthCalledWith(1, {
     electionHash,
+    jurisdiction,
   });
 });
 
@@ -22,7 +25,7 @@ test('checkPin', async () => {
   expect(mockAuth.checkPin).toHaveBeenCalledTimes(1);
   expect(mockAuth.checkPin).toHaveBeenNthCalledWith(
     1,
-    { electionHash },
+    { electionHash, jurisdiction },
     { pin: '123456' }
   );
 });
@@ -32,7 +35,10 @@ test('logOut', async () => {
 
   await apiClient.logOut({ electionHash });
   expect(mockAuth.logOut).toHaveBeenCalledTimes(1);
-  expect(mockAuth.logOut).toHaveBeenNthCalledWith(1, { electionHash });
+  expect(mockAuth.logOut).toHaveBeenNthCalledWith(1, {
+    electionHash,
+    jurisdiction,
+  });
 });
 
 test('updateSessionExpiry', async () => {
@@ -45,7 +51,7 @@ test('updateSessionExpiry', async () => {
   expect(mockAuth.updateSessionExpiry).toHaveBeenCalledTimes(1);
   expect(mockAuth.updateSessionExpiry).toHaveBeenNthCalledWith(
     1,
-    { electionHash },
+    { electionHash, jurisdiction },
     { sessionExpiresAt: expect.any(Number) }
   );
 });
@@ -61,7 +67,7 @@ test('startCardlessVoterSession', async () => {
   expect(mockAuth.startCardlessVoterSession).toHaveBeenCalledTimes(1);
   expect(mockAuth.startCardlessVoterSession).toHaveBeenNthCalledWith(
     1,
-    { electionHash },
+    { electionHash, jurisdiction },
     { ballotStyleId: 'b1', precinctId: 'p1' }
   );
 });
@@ -73,5 +79,6 @@ test('endCardlessVoterSession', async () => {
   expect(mockAuth.endCardlessVoterSession).toHaveBeenCalledTimes(1);
   expect(mockAuth.endCardlessVoterSession).toHaveBeenNthCalledWith(1, {
     electionHash,
+    jurisdiction,
   });
 });

--- a/apps/mark/backend/src/app.test.ts
+++ b/apps/mark/backend/src/app.test.ts
@@ -10,7 +10,7 @@ import {
   mockOf,
 } from '@votingworks/test-utils';
 import { ElectionDefinition } from '@votingworks/types';
-import { InsertedSmartCardAuthApi } from '@votingworks/auth';
+import { DEV_JURISDICTION, InsertedSmartCardAuthApi } from '@votingworks/auth';
 import {
   ALL_PRECINCTS_SELECTION,
   ReportSourceMachineType,
@@ -42,6 +42,8 @@ afterEach(() => {
   server?.close();
 });
 
+const jurisdiction = DEV_JURISDICTION;
+
 test('uses machine config from env', async () => {
   const originalEnv = process.env;
   process.env = {
@@ -65,57 +67,6 @@ test('uses default machine config if not set', async () => {
     machineId: '0000',
     codeVersion: 'dev',
     screenOrientation: 'portrait',
-  });
-});
-
-test('auth', async () => {
-  const { electionDefinition } = electionFamousNames2021Fixtures;
-  const { electionHash } = electionDefinition;
-  await apiClient.getAuthStatus({ electionHash });
-  expect(mockAuth.getAuthStatus).toHaveBeenCalledTimes(1);
-  expect(mockAuth.getAuthStatus).toHaveBeenNthCalledWith(1, {
-    electionHash,
-  });
-
-  await apiClient.checkPin({ electionHash, pin: '123456' });
-  expect(mockAuth.checkPin).toHaveBeenCalledTimes(1);
-  expect(mockAuth.checkPin).toHaveBeenNthCalledWith(
-    1,
-    { electionHash },
-    { pin: '123456' }
-  );
-
-  await apiClient.updateSessionExpiry({
-    electionHash,
-    sessionExpiresAt: new Date().getTime() + 60 * 1000,
-  });
-  expect(mockAuth.updateSessionExpiry).toHaveBeenCalledTimes(1);
-  expect(mockAuth.updateSessionExpiry).toHaveBeenNthCalledWith(
-    1,
-    { electionHash },
-    { sessionExpiresAt: expect.any(Number) }
-  );
-
-  await apiClient.logOut({ electionHash });
-  expect(mockAuth.logOut).toHaveBeenCalledTimes(1);
-  expect(mockAuth.logOut).toHaveBeenNthCalledWith(1, { electionHash });
-
-  await apiClient.startCardlessVoterSession({
-    electionHash,
-    ballotStyleId: 'b1',
-    precinctId: 'p1',
-  });
-  expect(mockAuth.startCardlessVoterSession).toHaveBeenCalledTimes(1);
-  expect(mockAuth.startCardlessVoterSession).toHaveBeenNthCalledWith(
-    1,
-    { electionHash },
-    { ballotStyleId: 'b1', precinctId: 'p1' }
-  );
-
-  await apiClient.endCardlessVoterSession({ electionHash });
-  expect(mockAuth.endCardlessVoterSession).toHaveBeenCalledTimes(1);
-  expect(mockAuth.endCardlessVoterSession).toHaveBeenNthCalledWith(1, {
-    electionHash,
   });
 });
 
@@ -157,6 +108,7 @@ test('read election definition from card', async () => {
   expect(mockAuth.readCardDataAsString).toHaveBeenCalledTimes(1);
   expect(mockAuth.readCardDataAsString).toHaveBeenNthCalledWith(1, {
     electionHash,
+    jurisdiction,
   });
 
   mockOf(mockAuth.readCardDataAsString).mockImplementation(() =>
@@ -169,6 +121,7 @@ test('read election definition from card', async () => {
   expect(mockAuth.readCardDataAsString).toHaveBeenCalledTimes(2);
   expect(mockAuth.readCardDataAsString).toHaveBeenNthCalledWith(2, {
     electionHash,
+    jurisdiction,
   });
 });
 
@@ -222,7 +175,7 @@ test('read scanner report data from card', async () => {
   expect(mockAuth.readCardData).toHaveBeenCalledTimes(1);
   expect(mockAuth.readCardData).toHaveBeenNthCalledWith(
     1,
-    { electionHash },
+    { electionHash, jurisdiction },
     { schema: ScannerReportDataSchema }
   );
 });
@@ -265,6 +218,7 @@ test('clear scanner report data from card', async () => {
   expect(mockAuth.clearCardData).toHaveBeenCalledTimes(1);
   expect(mockAuth.clearCardData).toHaveBeenNthCalledWith(1, {
     electionHash,
+    jurisdiction,
   });
 });
 

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -16,12 +16,7 @@ import {
   SystemSettings,
   safeParseElectionDefinition,
 } from '@votingworks/types';
-import {
-  BooleanEnvironmentVariableName,
-  isFeatureFlagEnabled,
-  ScannerReportData,
-  ScannerReportDataSchema,
-} from '@votingworks/utils';
+import { ScannerReportData, ScannerReportDataSchema } from '@votingworks/utils';
 
 import { Usb, readBallotPackageFromUsb } from '@votingworks/backend';
 import { Logger } from '@votingworks/logging';
@@ -37,11 +32,7 @@ function constructAuthMachineState({
     // TODO: Persist election definition in store and pull from there
     electionHash,
     // TODO: Persist jurisdiction in store and pull from there
-    jurisdiction: isFeatureFlagEnabled(
-      BooleanEnvironmentVariableName.ENABLE_JAVA_CARDS
-    )
-      ? /* istanbul ignore next */ DEV_JURISDICTION
-      : undefined,
+    jurisdiction: DEV_JURISDICTION,
   };
 }
 

--- a/apps/mark/integration-testing/cypress/support/e2e.js
+++ b/apps/mark/integration-testing/cypress/support/e2e.js
@@ -22,9 +22,10 @@ import { methodUrl } from '@votingworks/grout';
 // Importing all of @votingworks/auth causes Cypress tests to fail since Cypress doesn't seem to
 // interact well with PCSC Lite card reader code
 // eslint-disable-next-line vx/no-import-workspace-subfolders
+import { DEV_JURISDICTION } from '@votingworks/auth/src/certs';
+// eslint-disable-next-line vx/no-import-workspace-subfolders
 import { mockCard } from '@votingworks/auth/src/mock_file_card';
 
-const JURISDICTION = 'st.jurisdiction';
 const { electionData, electionHash } = electionSampleDefinition;
 const PIN = '000000';
 
@@ -37,9 +38,9 @@ function insertElectionManagerCard() {
     cardStatus: {
       status: 'ready',
       cardDetails: {
-        jurisdiction: JURISDICTION,
         user: {
           role: 'election_manager',
+          jurisdiction: DEV_JURISDICTION,
           electionHash,
         },
       },
@@ -54,9 +55,9 @@ function insertPollWorkerCard() {
     cardStatus: {
       status: 'ready',
       cardDetails: {
-        jurisdiction: JURISDICTION,
         user: {
           role: 'poll_worker',
+          jurisdiction: DEV_JURISDICTION,
           electionHash,
         },
         hasPin: false,

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -10,8 +10,6 @@ import {
   UnixTimestampInMilliseconds,
 } from '@votingworks/types';
 import {
-  BooleanEnvironmentVariableName,
-  isFeatureFlagEnabled,
   ScannerReportData,
   ScannerReportDataSchema,
   singlePrecinctSelectionFor,
@@ -53,11 +51,7 @@ function constructAuthMachineState(
   return {
     electionHash: electionDefinition?.electionHash,
     // TODO: Persist jurisdiction in store and pull from there
-    jurisdiction: isFeatureFlagEnabled(
-      BooleanEnvironmentVariableName.ENABLE_JAVA_CARDS
-    )
-      ? /* istanbul ignore next */ DEV_JURISDICTION
-      : undefined,
+    jurisdiction: DEV_JURISDICTION,
   };
 }
 

--- a/apps/scan/backend/src/app_auth.test.ts
+++ b/apps/scan/backend/src/app_auth.test.ts
@@ -1,9 +1,11 @@
+import { DEV_JURISDICTION } from '@votingworks/auth';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 
 import { withApp } from '../test/helpers/custom_helpers';
 import { configureApp } from '../test/helpers/shared_helpers';
 
 const { electionHash } = electionFamousNames2021Fixtures.electionDefinition;
+const jurisdiction = DEV_JURISDICTION;
 
 test('getAuthStatus', async () => {
   await withApp({}, async ({ apiClient, mockAuth, mockUsb }) => {
@@ -14,7 +16,10 @@ test('getAuthStatus', async () => {
 
     await apiClient.getAuthStatus();
     expect(mockAuth.getAuthStatus).toHaveBeenCalledTimes(2);
-    expect(mockAuth.getAuthStatus).toHaveBeenNthCalledWith(2, { electionHash });
+    expect(mockAuth.getAuthStatus).toHaveBeenNthCalledWith(2, {
+      electionHash,
+      jurisdiction,
+    });
   });
 });
 
@@ -26,7 +31,7 @@ test('checkPin', async () => {
     expect(mockAuth.checkPin).toHaveBeenCalledTimes(1);
     expect(mockAuth.checkPin).toHaveBeenNthCalledWith(
       1,
-      { electionHash },
+      { electionHash, jurisdiction },
       { pin: '123456' }
     );
   });
@@ -38,7 +43,10 @@ test('logOut', async () => {
 
     await apiClient.logOut();
     expect(mockAuth.logOut).toHaveBeenCalledTimes(1);
-    expect(mockAuth.logOut).toHaveBeenNthCalledWith(1, { electionHash });
+    expect(mockAuth.logOut).toHaveBeenNthCalledWith(1, {
+      electionHash,
+      jurisdiction,
+    });
   });
 });
 
@@ -52,7 +60,7 @@ test('updateSessionExpiry', async () => {
     expect(mockAuth.updateSessionExpiry).toHaveBeenCalledTimes(1);
     expect(mockAuth.updateSessionExpiry).toHaveBeenNthCalledWith(
       1,
-      { electionHash },
+      { electionHash, jurisdiction },
       { sessionExpiresAt: expect.any(Number) }
     );
   });
@@ -62,7 +70,7 @@ test('getAuthStatus before election definition has been configured', async () =>
   await withApp({}, async ({ apiClient, mockAuth }) => {
     await apiClient.getAuthStatus();
     expect(mockAuth.getAuthStatus).toHaveBeenCalledTimes(1);
-    expect(mockAuth.getAuthStatus).toHaveBeenNthCalledWith(1, {});
+    expect(mockAuth.getAuthStatus).toHaveBeenNthCalledWith(1, { jurisdiction });
   });
 });
 
@@ -70,7 +78,11 @@ test('checkPin before election definition has been configured', async () => {
   await withApp({}, async ({ apiClient, mockAuth }) => {
     await apiClient.checkPin({ pin: '123456' });
     expect(mockAuth.checkPin).toHaveBeenCalledTimes(1);
-    expect(mockAuth.checkPin).toHaveBeenNthCalledWith(1, {}, { pin: '123456' });
+    expect(mockAuth.checkPin).toHaveBeenNthCalledWith(
+      1,
+      { jurisdiction },
+      { pin: '123456' }
+    );
   });
 });
 
@@ -78,7 +90,7 @@ test('logOut before election definition has been configured', async () => {
   await withApp({}, async ({ apiClient, mockAuth }) => {
     await apiClient.logOut();
     expect(mockAuth.logOut).toHaveBeenCalledTimes(1);
-    expect(mockAuth.logOut).toHaveBeenNthCalledWith(1, {});
+    expect(mockAuth.logOut).toHaveBeenNthCalledWith(1, { jurisdiction });
   });
 });
 
@@ -90,7 +102,7 @@ test('updateSessionExpiry before election definition has been configured', async
     expect(mockAuth.updateSessionExpiry).toHaveBeenCalledTimes(1);
     expect(mockAuth.updateSessionExpiry).toHaveBeenNthCalledWith(
       1,
-      {},
+      { jurisdiction },
       { sessionExpiresAt: expect.any(Number) }
     );
   });

--- a/apps/scan/backend/src/scanners/custom/app_scan.test.ts
+++ b/apps/scan/backend/src/scanners/custom/app_scan.test.ts
@@ -16,6 +16,7 @@ import {
 } from '@votingworks/utils';
 import { Logger } from '@votingworks/logging';
 import { ErrorCode, mocks } from '@votingworks/custom-scanner';
+import { DEV_JURISDICTION } from '@votingworks/auth';
 import { MAX_FAILED_SCAN_ATTEMPTS } from './state_machine';
 import {
   configureApp,
@@ -70,6 +71,8 @@ function checkLogs(logger: Logger): void {
     expect.any(Function)
   );
 }
+
+const jurisdiction = DEV_JURISDICTION;
 
 test('configure and scan hmpb', async () => {
   await withApp(
@@ -512,7 +515,7 @@ test('write scanner report data to card', async () => {
     expect(mockAuth.writeCardData).toHaveBeenCalledTimes(1);
     expect(mockAuth.writeCardData).toHaveBeenNthCalledWith(
       1,
-      { electionHash },
+      { electionHash, jurisdiction },
       { data: scannerReportData, schema: ScannerReportDataSchema }
     );
   });

--- a/apps/scan/backend/src/scanners/plustek/app_scan.test.ts
+++ b/apps/scan/backend/src/scanners/plustek/app_scan.test.ts
@@ -15,6 +15,7 @@ import {
   ScannerReportDataSchema,
 } from '@votingworks/utils';
 import { Logger } from '@votingworks/logging';
+import { DEV_JURISDICTION } from '@votingworks/auth';
 import { MAX_FAILED_SCAN_ATTEMPTS } from './state_machine';
 import {
   configureApp,
@@ -69,6 +70,8 @@ function checkLogs(logger: Logger): void {
     expect.any(Function)
   );
 }
+
+const jurisdiction = DEV_JURISDICTION;
 
 test('configure and scan hmpb', async () => {
   await withApp(
@@ -613,7 +616,7 @@ test('write scanner report data to card', async () => {
     expect(mockAuth.writeCardData).toHaveBeenCalledTimes(1);
     expect(mockAuth.writeCardData).toHaveBeenNthCalledWith(
       1,
-      { electionHash },
+      { electionHash, jurisdiction },
       { data: scannerReportData, schema: ScannerReportDataSchema }
     );
   });

--- a/libs/auth/scripts/generate_dev_keys_and_certs.ts
+++ b/libs/auth/scripts/generate_dev_keys_and_certs.ts
@@ -179,30 +179,41 @@ async function generateDevKeysAndCerts({
         {
           cardType: 'system-administrator',
           cardDetails: {
-            jurisdiction: DEV_JURISDICTION,
-            user: { role: 'system_administrator' },
+            user: {
+              role: 'system_administrator',
+              jurisdiction: DEV_JURISDICTION,
+            },
           },
         },
         {
           cardType: 'election-manager',
           cardDetails: {
-            jurisdiction: DEV_JURISDICTION,
-            user: { role: 'election_manager', electionHash },
+            user: {
+              role: 'election_manager',
+              jurisdiction: DEV_JURISDICTION,
+              electionHash,
+            },
           },
         },
         {
           cardType: 'poll-worker',
           cardDetails: {
-            jurisdiction: DEV_JURISDICTION,
-            user: { role: 'poll_worker', electionHash },
+            user: {
+              role: 'poll_worker',
+              jurisdiction: DEV_JURISDICTION,
+              electionHash,
+            },
             hasPin: false,
           },
         },
         {
           cardType: 'poll-worker-with-pin',
           cardDetails: {
-            jurisdiction: DEV_JURISDICTION,
-            user: { role: 'poll_worker', electionHash },
+            user: {
+              role: 'poll_worker',
+              jurisdiction: DEV_JURISDICTION,
+              electionHash,
+            },
             hasPin: true,
           },
         },

--- a/libs/auth/scripts/mock_card.ts
+++ b/libs/auth/scripts/mock_card.ts
@@ -117,8 +117,10 @@ function mockCardWrapper({
         cardStatus: {
           status: 'ready',
           cardDetails: {
-            jurisdiction: DEV_JURISDICTION,
-            user: { role: 'system_administrator' },
+            user: {
+              role: 'system_administrator',
+              jurisdiction: DEV_JURISDICTION,
+            },
           },
         },
         pin: '000000',
@@ -132,8 +134,11 @@ function mockCardWrapper({
         cardStatus: {
           status: 'ready',
           cardDetails: {
-            jurisdiction: DEV_JURISDICTION,
-            user: { role: 'election_manager', electionHash },
+            user: {
+              role: 'election_manager',
+              jurisdiction: DEV_JURISDICTION,
+              electionHash,
+            },
           },
         },
         data: Buffer.from(electionData, 'utf-8'),
@@ -147,8 +152,11 @@ function mockCardWrapper({
         cardStatus: {
           status: 'ready',
           cardDetails: {
-            jurisdiction: DEV_JURISDICTION,
-            user: { role: 'poll_worker', electionHash },
+            user: {
+              role: 'poll_worker',
+              jurisdiction: DEV_JURISDICTION,
+              electionHash,
+            },
             hasPin: false,
           },
         },
@@ -161,8 +169,11 @@ function mockCardWrapper({
         cardStatus: {
           status: 'ready',
           cardDetails: {
-            jurisdiction: DEV_JURISDICTION,
-            user: { role: 'poll_worker', electionHash },
+            user: {
+              role: 'poll_worker',
+              jurisdiction: DEV_JURISDICTION,
+              electionHash,
+            },
             hasPin: true,
           },
         },

--- a/libs/auth/scripts/program_dev_system_administrator_java_card.ts
+++ b/libs/auth/scripts/program_dev_system_administrator_java_card.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import { DEV_JURISDICTION } from '../src/certs';
 import { JavaCard } from '../src/java_card';
 import { constructJavaCardConfig } from '../src/java_card_config';
 import { waitForReadyCardStatus } from './utils';
@@ -16,7 +17,10 @@ async function programDevSystemAdministratorJavaCard(): Promise<void> {
   await waitForReadyCardStatus(card);
   try {
     await card.program({
-      user: { role: 'system_administrator' },
+      user: {
+        role: 'system_administrator',
+        jurisdiction: DEV_JURISDICTION,
+      },
       pin: '000000',
     });
   } catch (error) {

--- a/libs/auth/src/card.test.ts
+++ b/libs/auth/src/card.test.ts
@@ -11,20 +11,16 @@ import {
   CardDetails,
 } from './card';
 
-const jurisdiction = 'st.jurisdiction';
 const systemAdministratorUser = fakeSystemAdministratorUser();
 const electionManagerUser = fakeElectionManagerUser();
 const pollWorkerUser = fakePollWorkerUser();
 const systemAdministratorCardDetails: CardDetails = {
-  jurisdiction,
   user: systemAdministratorUser,
 };
 const electionManagerCardDetails: CardDetails = {
-  jurisdiction,
   user: electionManagerUser,
 };
 const pollWorkerCardDetails: CardDetails = {
-  jurisdiction,
   user: pollWorkerUser,
   hasPin: false,
 };

--- a/libs/auth/src/card.ts
+++ b/libs/auth/src/card.ts
@@ -6,19 +6,16 @@ import {
 } from '@votingworks/types';
 
 interface SystemAdministratorCardDetails {
-  jurisdiction: string;
   numIncorrectPinAttempts?: number;
   user: SystemAdministratorUser;
 }
 
 interface ElectionManagerCardDetails {
-  jurisdiction: string;
   numIncorrectPinAttempts?: number;
   user: ElectionManagerUser;
 }
 
 interface PollWorkerCardDetails {
-  jurisdiction: string;
   numIncorrectPinAttempts?: number;
   user: PollWorkerUser;
 

--- a/libs/auth/src/certs.test.ts
+++ b/libs/auth/src/certs.test.ts
@@ -109,8 +109,7 @@ test.each<{
       `1.3.6.1.4.1.59817.2 = ${jurisdiction}, ` +
       '1.3.6.1.4.1.59817.3 = system-administrator',
     expectedCardDetails: {
-      jurisdiction,
-      user: { role: 'system_administrator' },
+      user: { role: 'system_administrator', jurisdiction },
     },
   },
   {
@@ -121,8 +120,7 @@ test.each<{
       '1.3.6.1.4.1.59817.3 = election-manager, ' +
       `1.3.6.1.4.1.59817.4 = ${electionHash}`,
     expectedCardDetails: {
-      jurisdiction,
-      user: { role: 'election_manager', electionHash },
+      user: { role: 'election_manager', jurisdiction, electionHash },
     },
   },
   {
@@ -133,8 +131,7 @@ test.each<{
       '1.3.6.1.4.1.59817.3 = poll-worker, ' +
       `1.3.6.1.4.1.59817.4 = ${electionHash}`,
     expectedCardDetails: {
-      jurisdiction,
-      user: { role: 'poll_worker', electionHash },
+      user: { role: 'poll_worker', jurisdiction, electionHash },
       hasPin: false,
     },
   },
@@ -146,8 +143,7 @@ test.each<{
       '1.3.6.1.4.1.59817.3 = poll-worker-with-pin, ' +
       `1.3.6.1.4.1.59817.4 = ${electionHash}`,
     expectedCardDetails: {
-      jurisdiction,
-      user: { role: 'poll_worker', electionHash },
+      user: { role: 'poll_worker', jurisdiction, electionHash },
       hasPin: true,
     },
   },
@@ -194,8 +190,7 @@ test.each<{
 }>([
   {
     cardDetails: {
-      jurisdiction,
-      user: { role: 'system_administrator' },
+      user: { role: 'system_administrator', jurisdiction },
     },
     expectedSubject:
       '/C=US/ST=CA/O=VotingWorks' +
@@ -205,8 +200,7 @@ test.each<{
   },
   {
     cardDetails: {
-      jurisdiction,
-      user: { role: 'election_manager', electionHash },
+      user: { role: 'election_manager', jurisdiction, electionHash },
     },
     expectedSubject:
       '/C=US/ST=CA/O=VotingWorks' +
@@ -217,8 +211,7 @@ test.each<{
   },
   {
     cardDetails: {
-      jurisdiction,
-      user: { role: 'poll_worker', electionHash },
+      user: { role: 'poll_worker', jurisdiction, electionHash },
       hasPin: false,
     },
     expectedSubject:
@@ -230,8 +223,7 @@ test.each<{
   },
   {
     cardDetails: {
-      jurisdiction,
-      user: { role: 'poll_worker', electionHash },
+      user: { role: 'poll_worker', jurisdiction, electionHash },
       hasPin: true,
     },
     expectedSubject:

--- a/libs/auth/src/certs.ts
+++ b/libs/auth/src/certs.ts
@@ -134,30 +134,26 @@ export async function parseCardDetailsFromCert(
   switch (cardType) {
     case 'system-administrator': {
       return {
-        jurisdiction,
-        user: { role: 'system_administrator' },
+        user: { role: 'system_administrator', jurisdiction },
       };
     }
     case 'election-manager': {
       assert(electionHash !== undefined);
       return {
-        jurisdiction,
-        user: { role: 'election_manager', electionHash },
+        user: { role: 'election_manager', jurisdiction, electionHash },
       };
     }
     case 'poll-worker': {
       assert(electionHash !== undefined);
       return {
-        jurisdiction,
-        user: { role: 'poll_worker', electionHash },
+        user: { role: 'poll_worker', jurisdiction, electionHash },
         hasPin: false,
       };
     }
     case 'poll-worker-with-pin': {
       assert(electionHash !== undefined);
       return {
-        jurisdiction,
-        user: { role: 'poll_worker', electionHash },
+        user: { role: 'poll_worker', jurisdiction, electionHash },
         hasPin: true,
       };
     }
@@ -172,7 +168,7 @@ export async function parseCardDetailsFromCert(
  * Constructs a VotingWorks card cert subject that can be passed to an openssl command
  */
 export function constructCardCertSubject(cardDetails: CardDetails): string {
-  const { jurisdiction, user } = cardDetails;
+  const { user } = cardDetails;
   const component: CustomCertFields['component'] = 'card';
 
   let cardType: CustomCertFields['cardType'];
@@ -202,7 +198,7 @@ export function constructCardCertSubject(cardDetails: CardDetails): string {
   const entries = [
     ...STANDARD_CERT_FIELDS,
     `${VX_CUSTOM_CERT_FIELD.COMPONENT}=${component}`,
-    `${VX_CUSTOM_CERT_FIELD.JURISDICTION}=${jurisdiction}`,
+    `${VX_CUSTOM_CERT_FIELD.JURISDICTION}=${user.jurisdiction}`,
     `${VX_CUSTOM_CERT_FIELD.CARD_TYPE}=${cardType}`,
   ];
   if (electionHash) {

--- a/libs/auth/src/inserted_smart_card_auth.test.ts
+++ b/libs/auth/src/inserted_smart_card_auth.test.ts
@@ -78,9 +78,12 @@ const defaultMachineState: InsertedSmartCardAuthMachineState = {
   electionHash,
   jurisdiction,
 };
-const systemAdministratorUser = fakeSystemAdministratorUser();
-const electionManagerUser = fakeElectionManagerUser({ electionHash });
-const pollWorkerUser = fakePollWorkerUser({ electionHash });
+const systemAdministratorUser = fakeSystemAdministratorUser({ jurisdiction });
+const electionManagerUser = fakeElectionManagerUser({
+  jurisdiction,
+  electionHash,
+});
+const pollWorkerUser = fakePollWorkerUser({ jurisdiction, electionHash });
 const cardlessVoterUser = fakeCardlessVoterUser();
 
 function mockCardStatus(cardStatus: CardStatus) {
@@ -94,7 +97,6 @@ async function logInAsElectionManager(
   mockCardStatus({
     status: 'ready',
     cardDetails: {
-      jurisdiction,
       user: electionManagerUser,
     },
   });
@@ -119,7 +121,6 @@ async function logInAsPollWorker(
   mockCardStatus({
     status: 'ready',
     cardDetails: {
-      jurisdiction,
       user: pollWorkerUser,
       hasPin: false,
     },
@@ -163,7 +164,6 @@ test.each<{
     cardStatus: {
       status: 'ready',
       cardDetails: {
-        jurisdiction,
         user: systemAdministratorUser,
       },
     },
@@ -237,7 +237,6 @@ test.each<{
     description: 'system administrator card',
     machineState: defaultMachineState,
     cardDetails: {
-      jurisdiction,
       user: systemAdministratorUser,
     },
   },
@@ -245,7 +244,6 @@ test.each<{
     description: 'election manager card',
     machineState: defaultMachineState,
     cardDetails: {
-      jurisdiction,
       user: electionManagerUser,
     },
   },
@@ -256,7 +254,6 @@ test.each<{
       arePollWorkerCardPinsEnabled: true,
     },
     cardDetails: {
-      jurisdiction,
       user: pollWorkerUser,
       hasPin: true,
     },
@@ -352,7 +349,6 @@ test('Login and logout using card without PIN', async () => {
   mockCardStatus({
     status: 'ready',
     cardDetails: {
-      jurisdiction,
       user: pollWorkerUser,
       hasPin: false,
     },
@@ -406,7 +402,6 @@ test('Card lockout', async () => {
   mockCardStatus({
     status: 'ready',
     cardDetails: {
-      jurisdiction,
       numIncorrectPinAttempts: 2,
       user: electionManagerUser,
     },
@@ -440,7 +435,6 @@ test('Card lockout', async () => {
   mockCardStatus({
     status: 'ready',
     cardDetails: {
-      jurisdiction,
       numIncorrectPinAttempts: 3,
       user: electionManagerUser,
     },
@@ -582,8 +576,7 @@ test.each<{
     config: defaultConfig,
     machineState: defaultMachineState,
     cardDetails: {
-      jurisdiction: otherJurisdiction,
-      user: systemAdministratorUser,
+      user: { ...systemAdministratorUser, jurisdiction: otherJurisdiction },
     },
     expectedAuthStatus: {
       status: 'logged_out',
@@ -605,7 +598,6 @@ test.each<{
     config: defaultConfig,
     machineState: { ...defaultMachineState, jurisdiction: undefined },
     cardDetails: {
-      jurisdiction,
       user: systemAdministratorUser,
     },
     expectedAuthStatus: {
@@ -618,7 +610,6 @@ test.each<{
     config: defaultConfig,
     machineState: { ...defaultMachineState, electionHash: undefined },
     cardDetails: {
-      jurisdiction,
       user: electionManagerUser,
     },
     expectedAuthStatus: {
@@ -631,7 +622,6 @@ test.each<{
     config: defaultConfig,
     machineState: { ...defaultMachineState, electionHash: undefined },
     cardDetails: {
-      jurisdiction,
       user: pollWorkerUser,
       hasPin: false,
     },
@@ -655,7 +645,6 @@ test.each<{
     config: defaultConfig,
     machineState: defaultMachineState,
     cardDetails: {
-      jurisdiction,
       user: { ...electionManagerUser, electionHash: otherElectionHash },
     },
     expectedAuthStatus: {
@@ -683,7 +672,6 @@ test.each<{
     },
     machineState: defaultMachineState,
     cardDetails: {
-      jurisdiction,
       user: { ...electionManagerUser, electionHash: otherElectionHash },
     },
     expectedAuthStatus: {
@@ -696,7 +684,6 @@ test.each<{
     config: defaultConfig,
     machineState: defaultMachineState,
     cardDetails: {
-      jurisdiction,
       user: { ...pollWorkerUser, electionHash: otherElectionHash },
       hasPin: false,
     },
@@ -724,7 +711,6 @@ test.each<{
       arePollWorkerCardPinsEnabled: true,
     },
     cardDetails: {
-      jurisdiction,
       user: pollWorkerUser,
       hasPin: false,
     },
@@ -749,7 +735,6 @@ test.each<{
     config: defaultConfig,
     machineState: defaultMachineState,
     cardDetails: {
-      jurisdiction,
       user: pollWorkerUser,
       hasPin: true,
     },
@@ -895,7 +880,6 @@ test('Cardless voter sessions - end-to-end', async () => {
   mockCardStatus({
     status: 'ready',
     cardDetails: {
-      jurisdiction,
       user: pollWorkerUser,
       hasPin: false,
     },
@@ -1031,7 +1015,6 @@ test('Checking PIN error handling', async () => {
   mockCardStatus({
     status: 'ready',
     cardDetails: {
-      jurisdiction,
       user: electionManagerUser,
     },
   });
@@ -1303,7 +1286,6 @@ test.each<{
     description: 'system administrator card',
     machineState: defaultMachineState,
     cardDetails: {
-      jurisdiction,
       user: systemAdministratorUser,
     },
   },
@@ -1311,7 +1293,6 @@ test.each<{
     description: 'election manager card',
     machineState: defaultMachineState,
     cardDetails: {
-      jurisdiction,
       user: electionManagerUser,
     },
   },
@@ -1322,7 +1303,6 @@ test.each<{
       arePollWorkerCardPinsEnabled: true,
     },
     cardDetails: {
-      jurisdiction,
       user: pollWorkerUser,
       hasPin: true,
     },

--- a/libs/auth/src/inserted_smart_card_auth.ts
+++ b/libs/auth/src/inserted_smart_card_auth.ts
@@ -507,11 +507,11 @@ export class InsertedSmartCardAuth implements InsertedSmartCardAuthApi {
       return err('invalid_user_on_card');
     }
 
-    const { jurisdiction, user } = cardDetails;
+    const { user } = cardDetails;
 
     if (
       machineState.jurisdiction &&
-      jurisdiction !== machineState.jurisdiction
+      user.jurisdiction !== machineState.jurisdiction
     ) {
       return err('invalid_user_on_card');
     }

--- a/libs/auth/src/java_card.test.ts
+++ b/libs/auth/src/java_card.test.ts
@@ -90,9 +90,17 @@ afterEach(() => {
 
 const { electionData, electionHash } =
   electionFamousNames2021Fixtures.electionDefinition;
-const systemAdministratorUser = fakeSystemAdministratorUser();
-const electionManagerUser = fakeElectionManagerUser({ electionHash });
-const pollWorkerUser = fakePollWorkerUser({ electionHash });
+const systemAdministratorUser = fakeSystemAdministratorUser({
+  jurisdiction: DEV_JURISDICTION,
+});
+const electionManagerUser = fakeElectionManagerUser({
+  jurisdiction: DEV_JURISDICTION,
+  electionHash,
+});
+const pollWorkerUser = fakePollWorkerUser({
+  jurisdiction: DEV_JURISDICTION,
+  electionHash,
+});
 
 const mockChallenge = 'VotingWorks';
 function customChallengeGenerator(): string {
@@ -387,7 +395,6 @@ test.each<{
     isCardVxAdminPrivateKeySignatureRequestExpected: false,
     isCardGetNumRemainingPinAttemptsRequestExpected: true,
     expectedCardDetails: {
-      jurisdiction: DEV_JURISDICTION,
       user: systemAdministratorUser,
     },
   },
@@ -406,7 +413,6 @@ test.each<{
     isCardVxAdminPrivateKeySignatureRequestExpected: false,
     isCardGetNumRemainingPinAttemptsRequestExpected: true,
     expectedCardDetails: {
-      jurisdiction: DEV_JURISDICTION,
       user: electionManagerUser,
     },
   },
@@ -425,7 +431,6 @@ test.each<{
     isCardVxAdminPrivateKeySignatureRequestExpected: true,
     isCardGetNumRemainingPinAttemptsRequestExpected: false,
     expectedCardDetails: {
-      jurisdiction: DEV_JURISDICTION,
       user: pollWorkerUser,
       hasPin: false,
     },
@@ -446,7 +451,6 @@ test.each<{
     isCardVxAdminPrivateKeySignatureRequestExpected: false,
     isCardGetNumRemainingPinAttemptsRequestExpected: true,
     expectedCardDetails: {
-      jurisdiction: DEV_JURISDICTION,
       user: pollWorkerUser,
       hasPin: true,
     },
@@ -541,7 +545,6 @@ test.each<{
     isCardVxAdminPrivateKeySignatureRequestExpected: false,
     isCardGetNumRemainingPinAttemptsRequestExpected: true,
     expectedCardDetails: {
-      jurisdiction: DEV_JURISDICTION,
       numIncorrectPinAttempts: 5,
       user: electionManagerUser,
     },
@@ -695,7 +698,6 @@ test.each<{
     javaCard.setCardStatus({
       status: 'ready',
       cardDetails: {
-        jurisdiction: DEV_JURISDICTION,
         user: electionManagerUser,
       },
     });
@@ -754,7 +756,6 @@ test.each<{
     expectedExpiryInDays: 365 * 5,
     isElectionDataWriteExpected: false,
     expectedCardDetailsAfterProgramming: {
-      jurisdiction: DEV_JURISDICTION,
       user: systemAdministratorUser,
     },
   },
@@ -775,7 +776,6 @@ test.each<{
     expectedExpiryInDays: Math.round(365 * 0.5),
     isElectionDataWriteExpected: true,
     expectedCardDetailsAfterProgramming: {
-      jurisdiction: DEV_JURISDICTION,
       user: electionManagerUser,
     },
   },
@@ -794,7 +794,6 @@ test.each<{
     expectedExpiryInDays: Math.round(365 * 0.5),
     isElectionDataWriteExpected: false,
     expectedCardDetailsAfterProgramming: {
-      jurisdiction: DEV_JURISDICTION,
       user: pollWorkerUser,
       hasPin: false,
     },
@@ -815,7 +814,6 @@ test.each<{
     expectedExpiryInDays: Math.round(365 * 0.5),
     isElectionDataWriteExpected: false,
     expectedCardDetailsAfterProgramming: {
-      jurisdiction: DEV_JURISDICTION,
       user: pollWorkerUser,
       hasPin: true,
     },

--- a/libs/auth/src/java_card.ts
+++ b/libs/auth/src/java_card.ts
@@ -269,21 +269,22 @@ export class JavaCard implements Card {
       CARD_VX_ADMIN_CERT.PRIVATE_KEY_ID,
       pin
     );
-    const { jurisdiction } = await parseCert(
+    const vxAdminCertAuthorityCertDetails = await parseCert(
       await fs.readFile(vxAdminCertAuthorityCertPath)
     );
+    assert(user.jurisdiction === vxAdminCertAuthorityCertDetails.jurisdiction);
     let cardDetails: CardDetails;
     switch (user.role) {
       case 'system_administrator': {
-        cardDetails = { jurisdiction, user };
+        cardDetails = { user };
         break;
       }
       case 'election_manager': {
-        cardDetails = { jurisdiction, user };
+        cardDetails = { user };
         break;
       }
       case 'poll_worker': {
-        cardDetails = { jurisdiction, user, hasPin };
+        cardDetails = { user, hasPin };
         break;
       }
       /* istanbul ignore next: Compile-time check for completeness */
@@ -425,7 +426,8 @@ export class JavaCard implements Card {
       vxAdminCertAuthorityCert
     );
 
-    // Verify that the VxAdmin cert authority cert is a valid VxAdmin cert, signed by VotingWorks
+    // Verify that the VxAdmin cert authority cert on the card is a valid VxAdmin cert, signed by
+    // VotingWorks
     const vxAdminCertAuthorityCertDetails = await parseCert(
       vxAdminCertAuthorityCert
     );
@@ -441,7 +443,8 @@ export class JavaCard implements Card {
 
     const cardDetails = await parseCardDetailsFromCert(cardVxAdminCert);
     assert(
-      cardDetails.jurisdiction === vxAdminCertAuthorityCertDetails.jurisdiction
+      cardDetails.user.jurisdiction ===
+        vxAdminCertAuthorityCertDetails.jurisdiction
     );
 
     /**

--- a/libs/auth/src/memory_card.ts
+++ b/libs/auth/src/memory_card.ts
@@ -108,17 +108,28 @@ function parseUserDataFromCardSummary(cardSummary: Legacy.CardSummaryReady): {
   switch (cardData.t) {
     case 'system_administrator':
       return {
-        user: { role: 'system_administrator' },
+        user: {
+          role: 'system_administrator',
+          jurisdiction: DEV_JURISDICTION,
+        },
         pin: cardData.p,
       };
     case 'election_manager':
       return {
-        user: { role: 'election_manager', electionHash: cardData.h },
+        user: {
+          role: 'election_manager',
+          jurisdiction: DEV_JURISDICTION,
+          electionHash: cardData.h,
+        },
         pin: cardData.p,
       };
     case 'poll_worker':
       return {
-        user: { role: 'poll_worker', electionHash: cardData.h },
+        user: {
+          role: 'poll_worker',
+          jurisdiction: DEV_JURISDICTION,
+          electionHash: cardData.h,
+        },
         pin: cardData.p,
       };
     /* istanbul ignore next: Compile-time check for completeness */
@@ -158,21 +169,18 @@ export class MemoryCard implements Card {
     switch (user.role) {
       case 'system_administrator': {
         cardDetails = {
-          jurisdiction: DEV_JURISDICTION,
           user,
         };
         break;
       }
       case 'election_manager': {
         cardDetails = {
-          jurisdiction: DEV_JURISDICTION,
           user,
         };
         break;
       }
       case 'poll_worker': {
         cardDetails = {
-          jurisdiction: DEV_JURISDICTION,
           user,
           hasPin: pin !== undefined,
         };

--- a/libs/auth/src/mock_file_card.test.ts
+++ b/libs/auth/src/mock_file_card.test.ts
@@ -21,13 +21,16 @@ const wrongPin = '234567';
 
 const systemAdministratorUser: SystemAdministratorUser = {
   role: 'system_administrator',
+  jurisdiction: DEV_JURISDICTION,
 };
 const electionManagerUser: ElectionManagerUser = {
   role: 'election_manager',
+  jurisdiction: DEV_JURISDICTION,
   electionHash,
 };
 const pollWorkerUser: PollWorkerUser = {
   role: 'poll_worker',
+  jurisdiction: DEV_JURISDICTION,
   electionHash,
 };
 
@@ -41,7 +44,6 @@ test.each<MockFileContents>([
     cardStatus: {
       status: 'ready',
       cardDetails: {
-        jurisdiction: DEV_JURISDICTION,
         user: systemAdministratorUser,
       },
     },
@@ -52,7 +54,6 @@ test.each<MockFileContents>([
     cardStatus: {
       status: 'ready',
       cardDetails: {
-        jurisdiction: DEV_JURISDICTION,
         user: electionManagerUser,
       },
     },
@@ -63,7 +64,6 @@ test.each<MockFileContents>([
     cardStatus: {
       status: 'ready',
       cardDetails: {
-        jurisdiction: DEV_JURISDICTION,
         user: pollWorkerUser,
         hasPin: false,
       },
@@ -75,7 +75,6 @@ test.each<MockFileContents>([
     cardStatus: {
       status: 'ready',
       cardDetails: {
-        jurisdiction: DEV_JURISDICTION,
         user: pollWorkerUser,
         hasPin: true,
       },
@@ -100,7 +99,6 @@ test('MockFileCard basic mocking', async () => {
     cardStatus: {
       status: 'ready',
       cardDetails: {
-        jurisdiction: DEV_JURISDICTION,
         user: systemAdministratorUser,
       },
     },
@@ -109,7 +107,6 @@ test('MockFileCard basic mocking', async () => {
   expect(await card.getCardStatus()).toEqual({
     status: 'ready',
     cardDetails: {
-      jurisdiction: DEV_JURISDICTION,
       user: systemAdministratorUser,
     },
   });
@@ -118,7 +115,6 @@ test('MockFileCard basic mocking', async () => {
     cardStatus: {
       status: 'ready',
       cardDetails: {
-        jurisdiction: DEV_JURISDICTION,
         user: electionManagerUser,
       },
     },
@@ -128,7 +124,6 @@ test('MockFileCard basic mocking', async () => {
   expect(await card.getCardStatus()).toEqual({
     status: 'ready',
     cardDetails: {
-      jurisdiction: DEV_JURISDICTION,
       user: electionManagerUser,
     },
   });
@@ -137,7 +132,6 @@ test('MockFileCard basic mocking', async () => {
     cardStatus: {
       status: 'ready',
       cardDetails: {
-        jurisdiction: DEV_JURISDICTION,
         user: pollWorkerUser,
         hasPin: false,
       },
@@ -146,7 +140,6 @@ test('MockFileCard basic mocking', async () => {
   expect(await card.getCardStatus()).toEqual({
     status: 'ready',
     cardDetails: {
-      jurisdiction: DEV_JURISDICTION,
       user: pollWorkerUser,
       hasPin: false,
     },
@@ -156,7 +149,6 @@ test('MockFileCard basic mocking', async () => {
     cardStatus: {
       status: 'ready',
       cardDetails: {
-        jurisdiction: DEV_JURISDICTION,
         user: pollWorkerUser,
         hasPin: true,
       },
@@ -166,7 +158,6 @@ test('MockFileCard basic mocking', async () => {
   expect(await card.getCardStatus()).toEqual({
     status: 'ready',
     cardDetails: {
-      jurisdiction: DEV_JURISDICTION,
       user: pollWorkerUser,
       hasPin: true,
     },
@@ -188,7 +179,6 @@ test('MockFileCard PIN checking', async () => {
     cardStatus: {
       status: 'ready',
       cardDetails: {
-        jurisdiction: DEV_JURISDICTION,
         user: systemAdministratorUser,
       },
     },
@@ -221,7 +211,6 @@ test('MockFileCard programming', async () => {
   expect(await card.getCardStatus()).toEqual({
     status: 'ready',
     cardDetails: {
-      jurisdiction: DEV_JURISDICTION,
       user: systemAdministratorUser,
     },
   });
@@ -237,7 +226,6 @@ test('MockFileCard programming', async () => {
   expect(await card.getCardStatus()).toEqual({
     status: 'ready',
     cardDetails: {
-      jurisdiction: DEV_JURISDICTION,
       user: electionManagerUser,
     },
   });
@@ -255,7 +243,6 @@ test('MockFileCard programming', async () => {
   expect(await card.getCardStatus()).toEqual({
     status: 'ready',
     cardDetails: {
-      jurisdiction: DEV_JURISDICTION,
       user: pollWorkerUser,
       hasPin: false,
     },
@@ -265,7 +252,6 @@ test('MockFileCard programming', async () => {
   expect(await card.getCardStatus()).toEqual({
     status: 'ready',
     cardDetails: {
-      jurisdiction: DEV_JURISDICTION,
       user: pollWorkerUser,
       hasPin: true,
     },
@@ -278,7 +264,6 @@ test('MockFileCard data reading and writing', async () => {
     cardStatus: {
       status: 'ready',
       cardDetails: {
-        jurisdiction: DEV_JURISDICTION,
         user: pollWorkerUser,
         hasPin: false,
       },

--- a/libs/auth/src/mock_file_card.ts
+++ b/libs/auth/src/mock_file_card.ts
@@ -8,7 +8,6 @@ import {
 } from '@votingworks/types';
 
 import { Card, CardStatus, CheckPinResponse } from './card';
-import { DEV_JURISDICTION } from './certs';
 
 type WriteFileFn = (filePath: string, fileContents: Buffer) => void;
 
@@ -118,7 +117,6 @@ export class MockFileCard implements Card {
       | { user: ElectionManagerUser; pin: string; electionData: string }
       | { user: PollWorkerUser; pin?: string }
   ): Promise<void> {
-    const jurisdiction = DEV_JURISDICTION;
     const { user, pin } = input;
     const hasPin = pin !== undefined;
 
@@ -127,7 +125,7 @@ export class MockFileCard implements Card {
         writeToMockFile({
           cardStatus: {
             status: 'ready',
-            cardDetails: { jurisdiction, user },
+            cardDetails: { user },
           },
           pin,
         });
@@ -138,7 +136,7 @@ export class MockFileCard implements Card {
         writeToMockFile({
           cardStatus: {
             status: 'ready',
-            cardDetails: { jurisdiction, user },
+            cardDetails: { user },
           },
           data: Buffer.from(input.electionData, 'utf-8'),
           pin,
@@ -149,7 +147,7 @@ export class MockFileCard implements Card {
         writeToMockFile({
           cardStatus: {
             status: 'ready',
-            cardDetails: { jurisdiction, user, hasPin },
+            cardDetails: { user, hasPin },
           },
           pin,
         });

--- a/libs/test-utils/src/auth.ts
+++ b/libs/test-utils/src/auth.ts
@@ -11,6 +11,7 @@ export function fakeSystemAdministratorUser(
 ): SystemAdministratorUser {
   return {
     role: 'system_administrator',
+    jurisdiction: 'jurisdiction',
     ...props,
   };
 }
@@ -20,6 +21,7 @@ export function fakeElectionManagerUser(
 ): ElectionManagerUser {
   return {
     role: 'election_manager',
+    jurisdiction: 'jurisdiction',
     electionHash: 'election-hash',
     ...props,
   };
@@ -30,6 +32,7 @@ export function fakePollWorkerUser(
 ): PollWorkerUser {
   return {
     role: 'poll_worker',
+    jurisdiction: 'jurisdiction',
     electionHash: 'election-hash',
     ...props,
   };
@@ -40,8 +43,8 @@ export function fakeCardlessVoterUser(
 ): CardlessVoterUser {
   return {
     role: 'cardless_voter',
-    ballotStyleId: 'fake-ballot-style-id',
-    precinctId: 'fake-precinct-id',
+    ballotStyleId: 'ballot-style-id',
+    precinctId: 'precinct-id',
     ...props,
   };
 }

--- a/libs/types/src/auth/auth.ts
+++ b/libs/types/src/auth/auth.ts
@@ -4,15 +4,18 @@ import { BallotStyleId, PrecinctId } from '../election';
 
 export interface SystemAdministratorUser {
   readonly role: 'system_administrator';
+  readonly jurisdiction: string;
 }
 
 export interface ElectionManagerUser {
   readonly role: 'election_manager';
+  readonly jurisdiction: string;
   readonly electionHash: string;
 }
 
 export interface PollWorkerUser {
   readonly role: 'poll_worker';
+  readonly jurisdiction: string;
   readonly electionHash: string;
 }
 


### PR DESCRIPTION
_Easiest reviewed by commit_

## Overview

Issue link: A first step toward of https://github.com/votingworks/vxsuite/issues/2912

I'll soon be updating VxCentralScan, VxMark, and VxScan to store the current jurisdiction, set when the machine is configured with an election definition and unset when the machine is unconfigured. (This jurisdiction will then be used by the auth lib for jurisdiction validation - logic that's already been set up.)

We'll be getting the jurisdiction during configuration from the election manager card used to unlock the machine, which means that the auth lib needs to somehow expose the jurisdiction on the card. The simplest way to accomplish this was to move jurisdiction into the user model (as opposed to its current location outside the user model at the top-level of the card details model). In retrospect, the user model was always a good fit for this data.

## Testing

- [x] Updated existing tests
- [x] Tested auth manually

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A
- [ ] ~I have added JSDoc comments to any newly introduced exports~ N/A