### PR TITLE
Use Dates again instead of Unix timestamps in milliseconds in auth lib code

### DIFF
--- a/apps/admin/backend/package.json
+++ b/apps/admin/backend/package.json
@@ -53,6 +53,7 @@
     "express": "^4.18.0",
     "fs-extra": "^10.1.0",
     "js-sha256": "^0.9.0",
+    "luxon": "^3.0.0",
     "multer": "^1.4.5-lts.1",
     "uuid": "^8.3.2",
     "zod": "3.14.4"
@@ -65,6 +66,7 @@
     "@types/express": "^4.17.14",
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^26.0.6",
+    "@types/luxon": "^3.0.0",
     "@types/multer": "^1.4.7",
     "@types/node": "16.11.29",
     "@types/supertest": "^2.0.10",

--- a/apps/admin/backend/src/app.auth.test.ts
+++ b/apps/admin/backend/src/app.auth.test.ts
@@ -1,3 +1,4 @@
+import { DateTime } from 'luxon';
 import { DEV_JURISDICTION } from '@votingworks/auth';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 
@@ -52,7 +53,7 @@ test('updateSessionExpiry', async () => {
   await configureMachine(apiClient, auth, electionDefinition);
 
   await apiClient.updateSessionExpiry({
-    sessionExpiresAt: new Date(new Date().getTime() + 60 * 1000),
+    sessionExpiresAt: DateTime.now().plus({ seconds: 60 }).toJSDate(),
   });
   expect(auth.updateSessionExpiry).toHaveBeenCalledTimes(1);
   expect(auth.updateSessionExpiry).toHaveBeenNthCalledWith(
@@ -127,7 +128,7 @@ test('updateSessionExpiry before election definition has been configured', async
   const { apiClient, auth } = buildTestEnvironment();
 
   await apiClient.updateSessionExpiry({
-    sessionExpiresAt: new Date(new Date().getTime() + 60 * 1000),
+    sessionExpiresAt: DateTime.now().plus({ seconds: 60 }).toJSDate(),
   });
   expect(auth.updateSessionExpiry).toHaveBeenCalledTimes(1);
   expect(auth.updateSessionExpiry).toHaveBeenNthCalledWith(

--- a/apps/admin/backend/src/app.auth.test.ts
+++ b/apps/admin/backend/src/app.auth.test.ts
@@ -52,13 +52,13 @@ test('updateSessionExpiry', async () => {
   await configureMachine(apiClient, auth, electionDefinition);
 
   await apiClient.updateSessionExpiry({
-    sessionExpiresAt: new Date().getTime() + 60 * 1000,
+    sessionExpiresAt: new Date(new Date().getTime() + 60 * 1000),
   });
   expect(auth.updateSessionExpiry).toHaveBeenCalledTimes(1);
   expect(auth.updateSessionExpiry).toHaveBeenNthCalledWith(
     1,
     { electionHash, jurisdiction },
-    { sessionExpiresAt: expect.any(Number) }
+    { sessionExpiresAt: expect.any(Date) }
   );
 });
 
@@ -127,12 +127,12 @@ test('updateSessionExpiry before election definition has been configured', async
   const { apiClient, auth } = buildTestEnvironment();
 
   await apiClient.updateSessionExpiry({
-    sessionExpiresAt: new Date().getTime() + 60 * 1000,
+    sessionExpiresAt: new Date(new Date().getTime() + 60 * 1000),
   });
   expect(auth.updateSessionExpiry).toHaveBeenCalledTimes(1);
   expect(auth.updateSessionExpiry).toHaveBeenNthCalledWith(
     1,
     { jurisdiction },
-    { sessionExpiresAt: expect.any(Number) }
+    { sessionExpiresAt: expect.any(Date) }
   );
 });

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -16,7 +16,6 @@ import {
   safeParseNumber,
   SystemSettings,
   SystemSettingsSchema,
-  UnixTimestampInMilliseconds,
 } from '@votingworks/types';
 import {
   assert,
@@ -116,9 +115,7 @@ function buildApi({
       return auth.logOut(constructAuthMachineState(workspace));
     },
 
-    updateSessionExpiry(input: {
-      sessionExpiresAt: UnixTimestampInMilliseconds;
-    }) {
+    updateSessionExpiry(input: { sessionExpiresAt: Date }) {
       return auth.updateSessionExpiry(
         constructAuthMachineState(workspace),
         input

--- a/apps/admin/frontend/src/app.test.tsx
+++ b/apps/admin/frontend/src/app.test.tsx
@@ -208,7 +208,7 @@ test('authentication works', async () => {
     user: fakeElectionManagerUser({
       electionHash: eitherNeitherElectionDefinition.electionHash,
     }),
-    wrongPinEnteredAt: new Date().getTime(),
+    wrongPinEnteredAt: new Date(),
   });
   await screen.findByText('Incorrect PIN. Please try again.');
 

--- a/apps/admin/frontend/src/components/session_time_limit_tracker.tsx
+++ b/apps/admin/frontend/src/components/session_time_limit_tracker.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { UnixTimestampInMilliseconds } from '@votingworks/types';
 import { SessionTimeLimitTracker as SessionTimeLimitTrackerBase } from '@votingworks/ui';
 
 import { getAuthStatus, logOut, updateSessionExpiry } from '../api';
@@ -13,7 +12,7 @@ export function SessionTimeLimitTracker(): JSX.Element {
     <SessionTimeLimitTrackerBase
       authStatus={authStatusQuery.data}
       logOut={() => logOutMutation.mutate()}
-      updateSessionExpiry={(sessionExpiresAt: UnixTimestampInMilliseconds) =>
+      updateSessionExpiry={(sessionExpiresAt: Date) =>
         updateSessionExpiryMutation.mutate({ sessionExpiresAt })
       }
     />

--- a/apps/central-scan/backend/src/auth.test.ts
+++ b/apps/central-scan/backend/src/auth.test.ts
@@ -1,5 +1,6 @@
 import getPort from 'get-port';
 import { Server } from 'http';
+import { DateTime } from 'luxon';
 import { dirSync } from 'tmp';
 import {
   buildMockDippedSmartCardAuth,
@@ -89,7 +90,7 @@ test('logOut', async () => {
 
 test('updateSessionExpiry', async () => {
   await apiClient.updateSessionExpiry({
-    sessionExpiresAt: new Date(new Date().getTime() + 60 * 1000),
+    sessionExpiresAt: DateTime.now().plus({ seconds: 60 }).toJSDate(),
   });
   expect(auth.updateSessionExpiry).toHaveBeenCalledTimes(1);
   expect(auth.updateSessionExpiry).toHaveBeenNthCalledWith(
@@ -131,7 +132,7 @@ test('updateSessionExpiry before election definition has been configured', async
   workspace.store.setElection(undefined);
 
   await apiClient.updateSessionExpiry({
-    sessionExpiresAt: new Date(new Date().getTime() + 60 * 1000),
+    sessionExpiresAt: DateTime.now().plus({ seconds: 60 }).toJSDate(),
   });
   expect(auth.updateSessionExpiry).toHaveBeenCalledTimes(1);
   expect(auth.updateSessionExpiry).toHaveBeenNthCalledWith(

--- a/apps/central-scan/backend/src/auth.test.ts
+++ b/apps/central-scan/backend/src/auth.test.ts
@@ -89,13 +89,13 @@ test('logOut', async () => {
 
 test('updateSessionExpiry', async () => {
   await apiClient.updateSessionExpiry({
-    sessionExpiresAt: new Date().getTime() + 60 * 1000,
+    sessionExpiresAt: new Date(new Date().getTime() + 60 * 1000),
   });
   expect(auth.updateSessionExpiry).toHaveBeenCalledTimes(1);
   expect(auth.updateSessionExpiry).toHaveBeenNthCalledWith(
     1,
     { electionHash, jurisdiction },
-    { sessionExpiresAt: expect.any(Number) }
+    { sessionExpiresAt: expect.any(Date) }
   );
 });
 
@@ -131,12 +131,12 @@ test('updateSessionExpiry before election definition has been configured', async
   workspace.store.setElection(undefined);
 
   await apiClient.updateSessionExpiry({
-    sessionExpiresAt: new Date().getTime() + 60 * 1000,
+    sessionExpiresAt: new Date(new Date().getTime() + 60 * 1000),
   });
   expect(auth.updateSessionExpiry).toHaveBeenCalledTimes(1);
   expect(auth.updateSessionExpiry).toHaveBeenNthCalledWith(
     1,
     { jurisdiction },
-    { sessionExpiresAt: expect.any(Number) }
+    { sessionExpiresAt: expect.any(Date) }
   );
 });

--- a/apps/central-scan/backend/src/central_scanner_app.ts
+++ b/apps/central-scan/backend/src/central_scanner_app.ts
@@ -13,7 +13,6 @@ import {
 import {
   BallotPageLayout,
   BallotPageLayoutSchema,
-  UnixTimestampInMilliseconds,
   safeParse,
   safeParseElectionDefinition,
   safeParseJson,
@@ -88,9 +87,7 @@ function buildApi({
       return auth.logOut(constructAuthMachineState(workspace));
     },
 
-    updateSessionExpiry(input: {
-      sessionExpiresAt: UnixTimestampInMilliseconds;
-    }) {
+    updateSessionExpiry(input: { sessionExpiresAt: Date }) {
       return auth.updateSessionExpiry(
         constructAuthMachineState(workspace),
         input

--- a/apps/central-scan/backend/src/end_to_end.test.ts
+++ b/apps/central-scan/backend/src/end_to_end.test.ts
@@ -1,4 +1,7 @@
-import { buildMockDippedSmartCardAuth } from '@votingworks/auth';
+import {
+  DEV_JURISDICTION,
+  buildMockDippedSmartCardAuth,
+} from '@votingworks/auth';
 import { Exporter } from '@votingworks/backend';
 import {
   asElectionDefinition,
@@ -20,6 +23,7 @@ import {
   clear as clearDateMock,
 } from 'jest-date-mock';
 import { fakeLogger, Logger } from '@votingworks/logging';
+import { fakeSessionExpiresAt } from '@votingworks/test-utils';
 import { makeMockScanner, MockScanner } from '../test/util/mocks';
 import { buildCentralScannerApp } from './central_scanner_app';
 import { Importer } from './importer';
@@ -63,6 +67,8 @@ afterEach(async () => {
   await fsExtra.remove(workspace.path);
 });
 
+const jurisdiction = DEV_JURISDICTION;
+
 test('going through the whole process works', async () => {
   const now = new Date(2018, 5, 27, 0, 0, 0);
 
@@ -70,12 +76,10 @@ test('going through the whole process works', async () => {
     status: 'logged_in',
     user: {
       role: 'election_manager',
+      jurisdiction,
       electionHash: 'abc',
     },
-    programmableCard: {
-      status: 'ready',
-    },
-    sessionExpiresAt: now.valueOf() + 1000,
+    sessionExpiresAt: fakeSessionExpiresAt(),
   });
   setDateMock(now);
 

--- a/apps/central-scan/frontend/src/app.test.tsx
+++ b/apps/central-scan/frontend/src/app.test.tsx
@@ -454,7 +454,7 @@ test('authentication works', async () => {
   setAuthStatus(mockApiClient, {
     status: 'checking_pin',
     user: fakeElectionManagerUser(electionSampleDefinition),
-    wrongPinEnteredAt: new Date().getTime(),
+    wrongPinEnteredAt: new Date(),
   });
   await screen.findByText('Incorrect PIN. Please try again.');
 

--- a/apps/central-scan/frontend/src/components/session_time_limit_tracker.tsx
+++ b/apps/central-scan/frontend/src/components/session_time_limit_tracker.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { UnixTimestampInMilliseconds } from '@votingworks/types';
 import { SessionTimeLimitTracker as SessionTimeLimitTrackerBase } from '@votingworks/ui';
 
 import { getAuthStatus, logOut, updateSessionExpiry } from '../api';
@@ -13,7 +12,7 @@ export function SessionTimeLimitTracker(): JSX.Element {
     <SessionTimeLimitTrackerBase
       authStatus={authStatusQuery.data}
       logOut={() => logOutMutation.mutate()}
-      updateSessionExpiry={(sessionExpiresAt: UnixTimestampInMilliseconds) =>
+      updateSessionExpiry={(sessionExpiresAt: Date) =>
         updateSessionExpiryMutation.mutate({ sessionExpiresAt })
       }
     />

--- a/apps/mark/backend/package.json
+++ b/apps/mark/backend/package.json
@@ -49,6 +49,7 @@
     "express": "^4.18.0",
     "fs-extra": "^11.1.1",
     "js-sha256": "^0.9.0",
+    "luxon": "^3.0.0",
     "tmp": "^0.2.1",
     "zod": "3.14.4"
   },
@@ -58,6 +59,7 @@
     "@types/express": "^4.17.13",
     "@types/fs-extra": "^11.0.1",
     "@types/jest": "^26.0.6",
+    "@types/luxon": "^3.0.0",
     "@types/node": "16.11.29",
     "@types/tmp": "^0.2.3",
     "@typescript-eslint/eslint-plugin": "^5.37.0",

--- a/apps/mark/backend/src/app.auth.test.ts
+++ b/apps/mark/backend/src/app.auth.test.ts
@@ -1,3 +1,4 @@
+import { DateTime } from 'luxon';
 import { DEV_JURISDICTION } from '@votingworks/auth';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 
@@ -46,7 +47,7 @@ test('updateSessionExpiry', async () => {
 
   await apiClient.updateSessionExpiry({
     electionHash,
-    sessionExpiresAt: new Date(new Date().getTime() + 60 * 1000),
+    sessionExpiresAt: DateTime.now().plus({ seconds: 60 }).toJSDate(),
   });
   expect(mockAuth.updateSessionExpiry).toHaveBeenCalledTimes(1);
   expect(mockAuth.updateSessionExpiry).toHaveBeenNthCalledWith(

--- a/apps/mark/backend/src/app.auth.test.ts
+++ b/apps/mark/backend/src/app.auth.test.ts
@@ -46,13 +46,13 @@ test('updateSessionExpiry', async () => {
 
   await apiClient.updateSessionExpiry({
     electionHash,
-    sessionExpiresAt: new Date().getTime() + 60 * 1000,
+    sessionExpiresAt: new Date(new Date().getTime() + 60 * 1000),
   });
   expect(mockAuth.updateSessionExpiry).toHaveBeenCalledTimes(1);
   expect(mockAuth.updateSessionExpiry).toHaveBeenNthCalledWith(
     1,
     { electionHash, jurisdiction },
-    { sessionExpiresAt: expect.any(Number) }
+    { sessionExpiresAt: expect.any(Date) }
   );
 });
 

--- a/apps/mark/backend/src/app.test.ts
+++ b/apps/mark/backend/src/app.test.ts
@@ -230,7 +230,7 @@ test('configureBallotPackageFromUsb reads to and writes from store', async () =>
     Promise.resolve({
       status: 'logged_in',
       user: fakeElectionManagerUser(electionDefinition),
-      sessionExpiresAt: new Date().getTime() + 60 * 1000,
+      sessionExpiresAt: fakeSessionExpiresAt(),
     })
   );
 

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -12,7 +12,6 @@ import {
   BallotStyleId,
   ElectionDefinition,
   PrecinctId,
-  UnixTimestampInMilliseconds,
   SystemSettings,
   safeParseElectionDefinition,
 } from '@votingworks/types';
@@ -63,7 +62,7 @@ function buildApi(
 
     updateSessionExpiry(input: {
       electionHash?: string;
-      sessionExpiresAt: UnixTimestampInMilliseconds;
+      sessionExpiresAt: Date;
     }) {
       return auth.updateSessionExpiry(constructAuthMachineState(input), {
         sessionExpiresAt: input.sessionExpiresAt,

--- a/apps/mark/frontend/src/api.ts
+++ b/apps/mark/frontend/src/api.ts
@@ -18,7 +18,6 @@ import {
   BallotStyleId,
   ElectionDefinition,
   PrecinctId,
-  UnixTimestampInMilliseconds,
 } from '@votingworks/types';
 import { Result } from '@votingworks/basics';
 
@@ -144,7 +143,7 @@ export const updateSessionExpiry = {
     const apiClient = useApiClient();
     const queryClient = useQueryClient();
     return useMutation(
-      (input: { sessionExpiresAt: UnixTimestampInMilliseconds }) =>
+      (input: { sessionExpiresAt: Date }) =>
         apiClient.updateSessionExpiry({ ...input, electionHash }),
       {
         async onSuccess() {

--- a/apps/mark/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark/frontend/src/app_end_to_end.test.tsx
@@ -95,7 +95,7 @@ test('MarkAndPrint end-to-end flow', async () => {
   apiMock.setAuthStatus({
     status: 'checking_pin',
     user: fakeElectionManagerUser({ electionHash }),
-    wrongPinEnteredAt: new Date().getTime(),
+    wrongPinEnteredAt: new Date(),
   });
   await screen.findByText('Incorrect PIN. Please try again.');
 

--- a/apps/mark/frontend/src/components/session_time_limit_tracker.tsx
+++ b/apps/mark/frontend/src/components/session_time_limit_tracker.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { UnixTimestampInMilliseconds } from '@votingworks/types';
 import { SessionTimeLimitTracker as SessionTimeLimitTrackerBase } from '@votingworks/ui';
 
 import { getAuthStatus, logOut, updateSessionExpiry } from '../api';
@@ -19,9 +18,8 @@ export function SessionTimeLimitTracker({ electionHash }: Props): JSX.Element {
       authStatus={authStatusQuery.data}
       logOut={/* istanbul ignore next */ () => logOutMutation.mutate()}
       updateSessionExpiry={
-        /* istanbul ignore next */ (
-          sessionExpiresAt: UnixTimestampInMilliseconds
-        ) => updateSessionExpiryMutation.mutate({ sessionExpiresAt })
+        /* istanbul ignore next */ (sessionExpiresAt: Date) =>
+          updateSessionExpiryMutation.mutate({ sessionExpiresAt })
       }
     />
   );

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -7,7 +7,6 @@ import {
   PollsState,
   PrecinctSelection,
   SinglePrecinctSelection,
-  UnixTimestampInMilliseconds,
 } from '@votingworks/types';
 import {
   ScannerReportData,
@@ -80,9 +79,7 @@ function buildApi(
       return auth.logOut(constructAuthMachineState(workspace));
     },
 
-    updateSessionExpiry(input: {
-      sessionExpiresAt: UnixTimestampInMilliseconds;
-    }) {
+    updateSessionExpiry(input: { sessionExpiresAt: Date }) {
       return auth.updateSessionExpiry(
         constructAuthMachineState(workspace),
         input

--- a/apps/scan/backend/src/app_auth.test.ts
+++ b/apps/scan/backend/src/app_auth.test.ts
@@ -1,3 +1,4 @@
+import { DateTime } from 'luxon';
 import { DEV_JURISDICTION } from '@votingworks/auth';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 
@@ -55,7 +56,7 @@ test('updateSessionExpiry', async () => {
     await configureApp(apiClient, mockUsb, { mockAuth });
 
     await apiClient.updateSessionExpiry({
-      sessionExpiresAt: new Date(new Date().getTime() + 60 * 1000),
+      sessionExpiresAt: DateTime.now().plus({ seconds: 60 }).toJSDate(),
     });
     expect(mockAuth.updateSessionExpiry).toHaveBeenCalledTimes(1);
     expect(mockAuth.updateSessionExpiry).toHaveBeenNthCalledWith(
@@ -97,7 +98,7 @@ test('logOut before election definition has been configured', async () => {
 test('updateSessionExpiry before election definition has been configured', async () => {
   await withApp({}, async ({ apiClient, mockAuth }) => {
     await apiClient.updateSessionExpiry({
-      sessionExpiresAt: new Date(new Date().getTime() + 60 * 1000),
+      sessionExpiresAt: DateTime.now().plus({ seconds: 60 }).toJSDate(),
     });
     expect(mockAuth.updateSessionExpiry).toHaveBeenCalledTimes(1);
     expect(mockAuth.updateSessionExpiry).toHaveBeenNthCalledWith(

--- a/apps/scan/backend/src/app_auth.test.ts
+++ b/apps/scan/backend/src/app_auth.test.ts
@@ -55,13 +55,13 @@ test('updateSessionExpiry', async () => {
     await configureApp(apiClient, mockUsb, { mockAuth });
 
     await apiClient.updateSessionExpiry({
-      sessionExpiresAt: new Date().getTime() + 60 * 1000,
+      sessionExpiresAt: new Date(new Date().getTime() + 60 * 1000),
     });
     expect(mockAuth.updateSessionExpiry).toHaveBeenCalledTimes(1);
     expect(mockAuth.updateSessionExpiry).toHaveBeenNthCalledWith(
       1,
       { electionHash, jurisdiction },
-      { sessionExpiresAt: expect.any(Number) }
+      { sessionExpiresAt: expect.any(Date) }
     );
   });
 });
@@ -97,13 +97,13 @@ test('logOut before election definition has been configured', async () => {
 test('updateSessionExpiry before election definition has been configured', async () => {
   await withApp({}, async ({ apiClient, mockAuth }) => {
     await apiClient.updateSessionExpiry({
-      sessionExpiresAt: new Date().getTime() + 60 * 1000,
+      sessionExpiresAt: new Date(new Date().getTime() + 60 * 1000),
     });
     expect(mockAuth.updateSessionExpiry).toHaveBeenCalledTimes(1);
     expect(mockAuth.updateSessionExpiry).toHaveBeenNthCalledWith(
       1,
       { jurisdiction },
-      { sessionExpiresAt: expect.any(Number) }
+      { sessionExpiresAt: expect.any(Date) }
     );
   });
 });

--- a/apps/scan/backend/src/scanners/custom/app_config.test.ts
+++ b/apps/scan/backend/src/scanners/custom/app_config.test.ts
@@ -295,7 +295,7 @@ test('export CVRs to USB in deprecated VotingWorks format', async () => {
   );
 });
 
-test('setPrecinctSelection will reset polls to closed and update auth instance', async () => {
+test('setPrecinctSelection will reset polls to closed', async () => {
   await withApp({}, async ({ apiClient, mockUsb, workspace, mockAuth }) => {
     await configureApp(apiClient, mockUsb, { mockAuth });
 

--- a/apps/scan/backend/src/scanners/plustek/app_config.test.ts
+++ b/apps/scan/backend/src/scanners/plustek/app_config.test.ts
@@ -243,7 +243,7 @@ test('export CVRs to USB in deprecated VotingWorks format', async () => {
   );
 });
 
-test('setPrecinctSelection will reset polls to closed and update auth instance', async () => {
+test('setPrecinctSelection will reset polls to closed', async () => {
   await withApp({}, async ({ apiClient, mockUsb, workspace, mockAuth }) => {
     await configureApp(apiClient, mockUsb, { mockAuth });
 

--- a/apps/scan/frontend/src/components/session_time_limit_tracker.tsx
+++ b/apps/scan/frontend/src/components/session_time_limit_tracker.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { UnixTimestampInMilliseconds } from '@votingworks/types';
 import { SessionTimeLimitTracker as SessionTimeLimitTrackerBase } from '@votingworks/ui';
 
 import { getAuthStatus, logOut, updateSessionExpiry } from '../api';
@@ -13,7 +12,7 @@ export function SessionTimeLimitTracker(): JSX.Element {
     <SessionTimeLimitTrackerBase
       authStatus={authStatusQuery.data}
       logOut={() => logOutMutation.mutate()}
-      updateSessionExpiry={(sessionExpiresAt: UnixTimestampInMilliseconds) =>
+      updateSessionExpiry={(sessionExpiresAt: Date) =>
         updateSessionExpiryMutation.mutate({ sessionExpiresAt })
       }
     />

--- a/libs/auth/package.json
+++ b/libs/auth/package.json
@@ -38,6 +38,7 @@
     "@votingworks/utils": "workspace:*",
     "base64-js": "^1.3.1",
     "js-sha256": "^0.9.0",
+    "luxon": "^3.0.0",
     "node-fetch": "^2.6.0",
     "pcsclite": "^1.0.1",
     "uuid": "^9.0.0",
@@ -46,6 +47,7 @@
   },
   "devDependencies": {
     "@types/jest": "^27.0.3",
+    "@types/luxon": "^3.0.0",
     "@types/node-fetch": "^2.6.0",
     "@types/uuid": "^9.0.1",
     "@types/yargs": "^17.0.22",

--- a/libs/auth/src/dipped_smart_card_auth.test.ts
+++ b/libs/auth/src/dipped_smart_card_auth.test.ts
@@ -101,13 +101,13 @@ async function logInAsSystemAdministrator(
   expect(await auth.getAuthStatus(machineState)).toEqual({
     status: 'remove_card',
     user: systemAdministratorUser,
-    sessionExpiresAt: expect.any(Number),
+    sessionExpiresAt: expect.any(Date),
   });
   mockCardStatus({ status: 'no_card' });
   expect(await auth.getAuthStatus(machineState)).toEqual({
     status: 'logged_in',
     user: systemAdministratorUser,
-    sessionExpiresAt: expect.any(Number),
+    sessionExpiresAt: expect.any(Date),
     programmableCard: { status: 'no_card' },
   });
   mockOf(mockLogger.log).mockClear();
@@ -132,13 +132,13 @@ async function logInAsElectionManager(
   expect(await auth.getAuthStatus(machineState)).toEqual({
     status: 'remove_card',
     user: electionManagerUser,
-    sessionExpiresAt: expect.any(Number),
+    sessionExpiresAt: expect.any(Date),
   });
   mockCardStatus({ status: 'no_card' });
   expect(await auth.getAuthStatus(machineState)).toEqual({
     status: 'logged_in',
     user: electionManagerUser,
-    sessionExpiresAt: expect.any(Number),
+    sessionExpiresAt: expect.any(Date),
   });
   mockOf(mockLogger.log).mockClear();
 }
@@ -251,7 +251,7 @@ test.each<{
     expectedLoggedInAuthStatus: {
       status: 'logged_in',
       user: systemAdministratorUser,
-      sessionExpiresAt: expect.any(Number),
+      sessionExpiresAt: expect.any(Date),
       programmableCard: { status: 'no_card' },
     },
   },
@@ -263,7 +263,7 @@ test.each<{
     expectedLoggedInAuthStatus: {
       status: 'logged_in',
       user: electionManagerUser,
-      sessionExpiresAt: expect.any(Number),
+      sessionExpiresAt: expect.any(Date),
     },
   },
 ])(
@@ -289,7 +289,7 @@ test.each<{
     expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
       status: 'checking_pin',
       user,
-      wrongPinEnteredAt: expect.any(Number),
+      wrongPinEnteredAt: expect.any(Date),
     });
     expect(mockLogger.log).toHaveBeenCalledTimes(1);
     expect(mockLogger.log).toHaveBeenNthCalledWith(
@@ -307,7 +307,7 @@ test.each<{
     expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
       status: 'remove_card',
       user,
-      sessionExpiresAt: expect.any(Number),
+      sessionExpiresAt: expect.any(Date),
     });
     expect(mockLogger.log).toHaveBeenCalledTimes(2);
     expect(mockLogger.log).toHaveBeenNthCalledWith(
@@ -385,8 +385,8 @@ test('Card lockout', async () => {
   expect(await auth.getAuthStatus(machineState)).toEqual({
     status: 'checking_pin',
     user: electionManagerUser,
-    lockedOutUntil: mockTime.getTime() + 30 * 1000,
-    wrongPinEnteredAt: mockTime.getTime(),
+    lockedOutUntil: new Date(mockTime.getTime() + 30 * 1000),
+    wrongPinEnteredAt: mockTime,
   });
 
   mockCardStatus({ status: 'no_card' });
@@ -409,7 +409,7 @@ test('Card lockout', async () => {
   expect(await auth.getAuthStatus(machineState)).toEqual({
     status: 'checking_pin',
     user: electionManagerUser,
-    lockedOutUntil: mockTime.getTime() + 30 * 1000,
+    lockedOutUntil: new Date(mockTime.getTime() + 30 * 1000),
   });
 
   // Expect checkPin call to be ignored when locked out
@@ -417,7 +417,7 @@ test('Card lockout', async () => {
   expect(await auth.getAuthStatus(machineState)).toEqual({
     status: 'checking_pin',
     user: electionManagerUser,
-    lockedOutUntil: mockTime.getTime() + 30 * 1000,
+    lockedOutUntil: new Date(mockTime.getTime() + 30 * 1000),
   });
 
   mockTime = new Date(mockTime.getTime() + 30 * 1000);
@@ -432,8 +432,8 @@ test('Card lockout', async () => {
   expect(await auth.getAuthStatus(machineState)).toEqual({
     status: 'checking_pin',
     user: electionManagerUser,
-    lockedOutUntil: mockTime.getTime() + 60 * 1000,
-    wrongPinEnteredAt: mockTime.getTime(),
+    lockedOutUntil: new Date(mockTime.getTime() + 60 * 1000),
+    wrongPinEnteredAt: mockTime,
   });
 });
 
@@ -454,7 +454,7 @@ test('Session expiry', async () => {
   expect(await auth.getAuthStatus(machineState)).toEqual({
     status: 'logged_in',
     user: electionManagerUser,
-    sessionExpiresAt: mockTime.getTime() + 2 * 60 * 60 * 1000,
+    sessionExpiresAt: new Date(mockTime.getTime() + 2 * 60 * 60 * 1000),
   });
 
   mockTime = new Date(mockTime.getTime() + 2 * 60 * 60 * 1000);
@@ -478,16 +478,16 @@ test('Updating session expiry', async () => {
   expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
     status: 'logged_in',
     user: electionManagerUser,
-    sessionExpiresAt: mockTime.getTime() + 12 * 60 * 60 * 1000,
+    sessionExpiresAt: new Date(mockTime.getTime() + 12 * 60 * 60 * 1000),
   });
 
   await auth.updateSessionExpiry(defaultMachineState, {
-    sessionExpiresAt: mockTime.getTime() + 60 * 1000,
+    sessionExpiresAt: new Date(mockTime.getTime() + 60 * 1000),
   });
   expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
     status: 'logged_in',
     user: electionManagerUser,
-    sessionExpiresAt: mockTime.getTime() + 60 * 1000,
+    sessionExpiresAt: new Date(mockTime.getTime() + 60 * 1000),
   });
 });
 
@@ -747,7 +747,7 @@ test.each<{
     expect(await auth.getAuthStatus(machineState)).toEqual({
       status: 'logged_in',
       user: systemAdministratorUser,
-      sessionExpiresAt: expect.any(Number),
+      sessionExpiresAt: expect.any(Date),
       programmableCard: { status: 'ready', programmedUser: undefined },
     });
 
@@ -784,7 +784,7 @@ test.each<{
     expect(await auth.getAuthStatus(machineState)).toEqual({
       status: 'logged_in',
       user: systemAdministratorUser,
-      sessionExpiresAt: expect.any(Number),
+      sessionExpiresAt: expect.any(Date),
       programmableCard: { status: 'ready', programmedUser },
     });
 
@@ -815,7 +815,7 @@ test.each<{
     expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
       status: 'logged_in',
       user: systemAdministratorUser,
-      sessionExpiresAt: expect.any(Number),
+      sessionExpiresAt: expect.any(Date),
       programmableCard: { status: 'ready', programmedUser: undefined },
     });
   }
@@ -869,7 +869,7 @@ test.each<{
     expect(await auth.getAuthStatus(machineState)).toEqual({
       status: 'logged_in',
       user: systemAdministratorUser,
-      sessionExpiresAt: expect.any(Number),
+      sessionExpiresAt: expect.any(Date),
       programmableCard: { status: 'ready', programmedUser: undefined },
     });
   }
@@ -919,7 +919,7 @@ test('Checking PIN error handling', async () => {
   expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
     status: 'checking_pin',
     user: electionManagerUser,
-    wrongPinEnteredAt: expect.any(Number),
+    wrongPinEnteredAt: expect.any(Date),
   });
   expect(mockLogger.log).toHaveBeenCalledTimes(2);
   expect(mockLogger.log).toHaveBeenNthCalledWith(
@@ -939,7 +939,7 @@ test('Checking PIN error handling', async () => {
     status: 'checking_pin',
     user: electionManagerUser,
     error: true,
-    wrongPinEnteredAt: expect.any(Number),
+    wrongPinEnteredAt: expect.any(Date),
   });
   expect(mockLogger.log).toHaveBeenCalledTimes(3);
   expect(mockLogger.log).toHaveBeenNthCalledWith(
@@ -957,7 +957,7 @@ test('Checking PIN error handling', async () => {
   expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
     status: 'remove_card',
     user: electionManagerUser,
-    sessionExpiresAt: expect.any(Number),
+    sessionExpiresAt: expect.any(Date),
   });
 });
 
@@ -1007,7 +1007,7 @@ test('Attempting to update session expiry when not logged in', async () => {
   });
 
   await auth.updateSessionExpiry(defaultMachineState, {
-    sessionExpiresAt: new Date().getTime(),
+    sessionExpiresAt: new Date(),
   });
   expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
     status: 'logged_out',
@@ -1028,7 +1028,7 @@ test('Card programming error handling', async () => {
   expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
     status: 'logged_in',
     user: systemAdministratorUser,
-    sessionExpiresAt: expect.any(Number),
+    sessionExpiresAt: expect.any(Date),
     programmableCard: { status: 'card_error' },
   });
 
@@ -1036,7 +1036,7 @@ test('Card programming error handling', async () => {
   expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
     status: 'logged_in',
     user: systemAdministratorUser,
-    sessionExpiresAt: expect.any(Number),
+    sessionExpiresAt: expect.any(Date),
     programmableCard: { status: 'unknown_error' },
   });
 
@@ -1044,7 +1044,7 @@ test('Card programming error handling', async () => {
   expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
     status: 'logged_in',
     user: systemAdministratorUser,
-    sessionExpiresAt: expect.any(Number),
+    sessionExpiresAt: expect.any(Date),
     programmableCard: { status: 'ready', programmedUser: undefined },
   });
 
@@ -1097,7 +1097,7 @@ test('Card unprogramming error handling', async () => {
   expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
     status: 'logged_in',
     user: systemAdministratorUser,
-    sessionExpiresAt: expect.any(Number),
+    sessionExpiresAt: expect.any(Date),
     programmableCard: { status: 'ready', programmedUser: pollWorkerUser },
   });
 
@@ -1268,12 +1268,12 @@ test('SKIP_PIN_ENTRY feature flag', async () => {
   expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
     status: 'remove_card',
     user: electionManagerUser,
-    sessionExpiresAt: expect.any(Number),
+    sessionExpiresAt: expect.any(Date),
   });
   mockCardStatus({ status: 'no_card' });
   expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
     status: 'logged_in',
     user: electionManagerUser,
-    sessionExpiresAt: expect.any(Number),
+    sessionExpiresAt: expect.any(Date),
   });
 });

--- a/libs/auth/src/dipped_smart_card_auth_api.ts
+++ b/libs/auth/src/dipped_smart_card_auth_api.ts
@@ -5,7 +5,6 @@ import {
   OverallSessionTimeLimitHours,
   PollWorkerUser,
   SystemAdministratorUser,
-  UnixTimestampInMilliseconds,
 } from '@votingworks/types';
 
 /**
@@ -24,7 +23,7 @@ export interface DippedSmartCardAuthApi {
   logOut(machineState: DippedSmartCardAuthMachineState): Promise<void>;
   updateSessionExpiry(
     machineState: DippedSmartCardAuthMachineState,
-    input: { sessionExpiresAt: UnixTimestampInMilliseconds }
+    input: { sessionExpiresAt: Date }
   ): Promise<void>;
 
   programCard(

--- a/libs/auth/src/inserted_smart_card_auth.test.ts
+++ b/libs/auth/src/inserted_smart_card_auth.test.ts
@@ -109,7 +109,7 @@ async function logInAsElectionManager(
   expect(await auth.getAuthStatus(machineState)).toEqual({
     status: 'logged_in',
     user: electionManagerUser,
-    sessionExpiresAt: expect.any(Number),
+    sessionExpiresAt: expect.any(Date),
   });
   mockOf(mockLogger.log).mockClear();
 }
@@ -128,7 +128,7 @@ async function logInAsPollWorker(
   expect(await auth.getAuthStatus(machineState)).toEqual({
     status: 'logged_in',
     user: pollWorkerUser,
-    sessionExpiresAt: expect.any(Number),
+    sessionExpiresAt: expect.any(Date),
   });
   mockOf(mockLogger.log).mockClear();
 }
@@ -281,7 +281,7 @@ test.each<{
     expect(await auth.getAuthStatus(machineState)).toEqual({
       status: 'checking_pin',
       user,
-      wrongPinEnteredAt: expect.any(Number),
+      wrongPinEnteredAt: expect.any(Date),
     });
     expect(mockLogger.log).toHaveBeenCalledTimes(1);
     expect(mockLogger.log).toHaveBeenNthCalledWith(
@@ -299,7 +299,7 @@ test.each<{
     expect(await auth.getAuthStatus(machineState)).toEqual({
       status: 'logged_in',
       user,
-      sessionExpiresAt: expect.any(Number),
+      sessionExpiresAt: expect.any(Date),
     });
     expect(mockLogger.log).toHaveBeenCalledTimes(3);
     expect(mockLogger.log).toHaveBeenNthCalledWith(
@@ -356,7 +356,7 @@ test('Login and logout using card without PIN', async () => {
   expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
     status: 'logged_in',
     user: pollWorkerUser,
-    sessionExpiresAt: expect.any(Number),
+    sessionExpiresAt: expect.any(Date),
   });
   expect(mockLogger.log).toHaveBeenCalledTimes(1);
   expect(mockLogger.log).toHaveBeenNthCalledWith(
@@ -418,8 +418,8 @@ test('Card lockout', async () => {
   expect(await auth.getAuthStatus(machineState)).toEqual({
     status: 'checking_pin',
     user: electionManagerUser,
-    lockedOutUntil: mockTime.getTime() + 30 * 1000,
-    wrongPinEnteredAt: mockTime.getTime(),
+    lockedOutUntil: new Date(mockTime.getTime() + 30 * 1000),
+    wrongPinEnteredAt: mockTime,
   });
 
   mockCardStatus({ status: 'no_card' });
@@ -442,7 +442,7 @@ test('Card lockout', async () => {
   expect(await auth.getAuthStatus(machineState)).toEqual({
     status: 'checking_pin',
     user: electionManagerUser,
-    lockedOutUntil: mockTime.getTime() + 30 * 1000,
+    lockedOutUntil: new Date(mockTime.getTime() + 30 * 1000),
   });
 
   // Expect checkPin call to be ignored when locked out
@@ -450,7 +450,7 @@ test('Card lockout', async () => {
   expect(await auth.getAuthStatus(machineState)).toEqual({
     status: 'checking_pin',
     user: electionManagerUser,
-    lockedOutUntil: mockTime.getTime() + 30 * 1000,
+    lockedOutUntil: new Date(mockTime.getTime() + 30 * 1000),
   });
 
   mockTime = new Date(mockTime.getTime() + 30 * 1000);
@@ -465,8 +465,8 @@ test('Card lockout', async () => {
   expect(await auth.getAuthStatus(machineState)).toEqual({
     status: 'checking_pin',
     user: electionManagerUser,
-    lockedOutUntil: mockTime.getTime() + 60 * 1000,
-    wrongPinEnteredAt: mockTime.getTime(),
+    lockedOutUntil: new Date(mockTime.getTime() + 60 * 1000),
+    wrongPinEnteredAt: mockTime,
   });
 });
 
@@ -487,7 +487,7 @@ test('Session expiry', async () => {
   expect(await auth.getAuthStatus(machineState)).toEqual({
     status: 'logged_in',
     user: electionManagerUser,
-    sessionExpiresAt: mockTime.getTime() + 2 * 60 * 60 * 1000,
+    sessionExpiresAt: new Date(mockTime.getTime() + 2 * 60 * 60 * 1000),
   });
 
   mockTime = new Date(mockTime.getTime() + 2 * 60 * 60 * 1000);
@@ -513,16 +513,16 @@ test('Updating session expiry', async () => {
   expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
     status: 'logged_in',
     user: electionManagerUser,
-    sessionExpiresAt: mockTime.getTime() + 12 * 60 * 60 * 1000,
+    sessionExpiresAt: new Date(mockTime.getTime() + 12 * 60 * 60 * 1000),
   });
 
   await auth.updateSessionExpiry(defaultMachineState, {
-    sessionExpiresAt: mockTime.getTime() + 60 * 1000,
+    sessionExpiresAt: new Date(mockTime.getTime() + 60 * 1000),
   });
   expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
     status: 'logged_in',
     user: electionManagerUser,
-    sessionExpiresAt: mockTime.getTime() + 60 * 1000,
+    sessionExpiresAt: new Date(mockTime.getTime() + 60 * 1000),
   });
 });
 
@@ -794,7 +794,7 @@ test('Cardless voter sessions - ending preemptively', async () => {
   expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
     status: 'logged_in',
     user: pollWorkerUser,
-    sessionExpiresAt: expect.any(Number),
+    sessionExpiresAt: expect.any(Date),
     cardlessVoterUser,
   });
   expect(mockLogger.log).toHaveBeenCalledTimes(1);
@@ -813,7 +813,7 @@ test('Cardless voter sessions - ending preemptively', async () => {
   expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
     status: 'logged_in',
     user: pollWorkerUser,
-    sessionExpiresAt: expect.any(Number),
+    sessionExpiresAt: expect.any(Date),
   });
   expect(mockLogger.log).toHaveBeenCalledTimes(2);
   expect(mockLogger.log).toHaveBeenNthCalledWith(
@@ -844,7 +844,7 @@ test('Cardless voter sessions - end-to-end', async () => {
   expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
     status: 'logged_in',
     user: pollWorkerUser,
-    sessionExpiresAt: expect.any(Number),
+    sessionExpiresAt: expect.any(Date),
     cardlessVoterUser,
   });
   expect(mockLogger.log).toHaveBeenCalledTimes(1);
@@ -863,7 +863,7 @@ test('Cardless voter sessions - end-to-end', async () => {
   expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
     status: 'logged_in',
     user: cardlessVoterUser,
-    sessionExpiresAt: expect.any(Number),
+    sessionExpiresAt: expect.any(Date),
   });
   expect(mockLogger.log).toHaveBeenCalledTimes(2);
   expect(mockLogger.log).toHaveBeenNthCalledWith(
@@ -887,7 +887,7 @@ test('Cardless voter sessions - end-to-end', async () => {
   expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
     status: 'logged_in',
     user: pollWorkerUser,
-    sessionExpiresAt: expect.any(Number),
+    sessionExpiresAt: expect.any(Date),
     cardlessVoterUser,
   });
   expect(mockLogger.log).toHaveBeenCalledTimes(3);
@@ -906,7 +906,7 @@ test('Cardless voter sessions - end-to-end', async () => {
   expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
     status: 'logged_in',
     user: cardlessVoterUser,
-    sessionExpiresAt: expect.any(Number),
+    sessionExpiresAt: expect.any(Date),
   });
   expect(mockLogger.log).toHaveBeenCalledTimes(4);
   expect(mockLogger.log).toHaveBeenNthCalledWith(
@@ -1049,7 +1049,7 @@ test('Checking PIN error handling', async () => {
   expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
     status: 'checking_pin',
     user: electionManagerUser,
-    wrongPinEnteredAt: expect.any(Number),
+    wrongPinEnteredAt: expect.any(Date),
   });
   expect(mockLogger.log).toHaveBeenCalledTimes(2);
   expect(mockLogger.log).toHaveBeenNthCalledWith(
@@ -1069,7 +1069,7 @@ test('Checking PIN error handling', async () => {
     status: 'checking_pin',
     user: electionManagerUser,
     error: true,
-    wrongPinEnteredAt: expect.any(Number),
+    wrongPinEnteredAt: expect.any(Date),
   });
   expect(mockLogger.log).toHaveBeenCalledTimes(3);
   expect(mockLogger.log).toHaveBeenNthCalledWith(
@@ -1087,7 +1087,7 @@ test('Checking PIN error handling', async () => {
   expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
     status: 'logged_in',
     user: electionManagerUser,
-    sessionExpiresAt: expect.any(Number),
+    sessionExpiresAt: expect.any(Date),
   });
 });
 
@@ -1137,7 +1137,7 @@ test('Attempting to update session expiry when not logged in', async () => {
   });
 
   await auth.updateSessionExpiry(defaultMachineState, {
-    sessionExpiresAt: new Date().getTime(),
+    sessionExpiresAt: new Date(),
   });
   expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
     status: 'logged_out',
@@ -1184,7 +1184,7 @@ test('Attempting to start a cardless voter session when not a poll worker', asyn
   expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
     status: 'logged_in',
     user: electionManagerUser,
-    sessionExpiresAt: expect.any(Number),
+    sessionExpiresAt: expect.any(Date),
   });
 });
 
@@ -1324,7 +1324,7 @@ test.each<{
     expect(await auth.getAuthStatus(machineState)).toEqual({
       status: 'logged_in',
       user,
-      sessionExpiresAt: expect.any(Number),
+      sessionExpiresAt: expect.any(Date),
     });
   }
 );

--- a/libs/auth/src/inserted_smart_card_auth_api.ts
+++ b/libs/auth/src/inserted_smart_card_auth_api.ts
@@ -5,7 +5,6 @@ import {
   InsertedSmartCardAuth,
   OverallSessionTimeLimitHours,
   PrecinctId,
-  UnixTimestampInMilliseconds,
 } from '@votingworks/types';
 
 /**
@@ -29,7 +28,7 @@ export interface InsertedSmartCardAuthApi {
   logOut(machineState: InsertedSmartCardAuthMachineState): Promise<void>;
   updateSessionExpiry(
     machineState: InsertedSmartCardAuthMachineState,
-    input: { sessionExpiresAt: UnixTimestampInMilliseconds }
+    input: { sessionExpiresAt: Date }
   ): Promise<void>;
 
   startCardlessVoterSession(

--- a/libs/auth/src/lockout.ts
+++ b/libs/auth/src/lockout.ts
@@ -1,3 +1,4 @@
+import { DateTime } from 'luxon';
 import { Optional } from '@votingworks/basics';
 
 const DEFAULT_NUM_INCORRECT_PIN_ATTEMPTS_ALLOWED_BEFORE_CARD_LOCKOUT = 5;
@@ -54,8 +55,8 @@ export function computeCardLockoutEndTime(
     startingCardLockoutDurationSeconds *
     2 ** numIncorrectPinAttemptsPostCardLockout;
 
-  const cardLockoutEndTime = new Date(
-    cardLockoutStartTime.getTime() + cardLockoutDurationSeconds * 1000
-  );
+  const cardLockoutEndTime = DateTime.fromJSDate(cardLockoutStartTime)
+    .plus({ seconds: cardLockoutDurationSeconds })
+    .toJSDate();
   return cardLockoutEndTime;
 }

--- a/libs/auth/src/sessions.ts
+++ b/libs/auth/src/sessions.ts
@@ -1,3 +1,4 @@
+import { DateTime } from 'luxon';
 import {
   DEFAULT_OVERALL_SESSION_TIME_LIMIT_HOURS,
   OverallSessionTimeLimitHours,
@@ -21,7 +22,7 @@ export function computeSessionEndTime(
     overallSessionTimeLimitHours = DEFAULT_OVERALL_SESSION_TIME_LIMIT_HOURS,
   } = sessionConfig;
 
-  return new Date(
-    sessionStartTime.getTime() + overallSessionTimeLimitHours * 60 * 60 * 1000
-  );
+  return DateTime.fromJSDate(sessionStartTime)
+    .plus({ hours: overallSessionTimeLimitHours })
+    .toJSDate();
 }

--- a/libs/test-utils/src/auth.ts
+++ b/libs/test-utils/src/auth.ts
@@ -1,3 +1,4 @@
+import { DateTime } from 'luxon';
 import {
   CardlessVoterUser,
   DEFAULT_OVERALL_SESSION_TIME_LIMIT_HOURS,
@@ -50,8 +51,7 @@ export function fakeCardlessVoterUser(
 }
 
 export function fakeSessionExpiresAt(): Date {
-  return new Date(
-    new Date().getTime() +
-      DEFAULT_OVERALL_SESSION_TIME_LIMIT_HOURS * 60 * 60 * 1000
-  );
+  return DateTime.now()
+    .plus({ hours: DEFAULT_OVERALL_SESSION_TIME_LIMIT_HOURS })
+    .toJSDate();
 }

--- a/libs/test-utils/src/auth.ts
+++ b/libs/test-utils/src/auth.ts
@@ -49,9 +49,9 @@ export function fakeCardlessVoterUser(
   };
 }
 
-export function fakeSessionExpiresAt(): number {
-  return (
+export function fakeSessionExpiresAt(): Date {
+  return new Date(
     new Date().getTime() +
-    DEFAULT_OVERALL_SESSION_TIME_LIMIT_HOURS * 60 * 60 * 1000
+      DEFAULT_OVERALL_SESSION_TIME_LIMIT_HOURS * 60 * 60 * 1000
   );
 }

--- a/libs/types/src/auth/auth.ts
+++ b/libs/types/src/auth/auth.ts
@@ -43,11 +43,6 @@ export const UserRoleSchema: z.ZodSchema<UserRole> = z.union([
 ]);
 
 /**
- * An alias for clarity
- */
-export type UnixTimestampInMilliseconds = number;
-
-/**
  * The inactive/idle session time limit, after which the user must reauthenticate - a VVSG2
  * requirement
  */

--- a/libs/types/src/auth/dipped_smart_card_auth.ts
+++ b/libs/types/src/auth/dipped_smart_card_auth.ts
@@ -1,7 +1,6 @@
 import {
   ElectionManagerUser,
   SystemAdministratorUser,
-  UnixTimestampInMilliseconds,
   UserRole,
   UserWithCard,
 } from './auth';
@@ -22,14 +21,14 @@ export interface CheckingPin {
   readonly status: 'checking_pin';
   readonly user: SystemAdministratorUser | ElectionManagerUser;
   readonly error?: true;
-  readonly lockedOutUntil?: UnixTimestampInMilliseconds;
-  readonly wrongPinEnteredAt?: UnixTimestampInMilliseconds;
+  readonly lockedOutUntil?: Date;
+  readonly wrongPinEnteredAt?: Date;
 }
 
 export interface RemoveCard {
   readonly status: 'remove_card';
   readonly user: SystemAdministratorUser | ElectionManagerUser;
-  readonly sessionExpiresAt: UnixTimestampInMilliseconds;
+  readonly sessionExpiresAt: Date;
 }
 
 interface ProgrammableCardReady {
@@ -46,14 +45,14 @@ export type ProgrammableCard = ProgrammableCardReady | ProgrammableCardNotReady;
 export interface SystemAdministratorLoggedIn {
   readonly status: 'logged_in';
   readonly user: SystemAdministratorUser;
-  readonly sessionExpiresAt: UnixTimestampInMilliseconds;
+  readonly sessionExpiresAt: Date;
   readonly programmableCard: ProgrammableCard;
 }
 
 export interface ElectionManagerLoggedIn {
   readonly status: 'logged_in';
   readonly user: ElectionManagerUser;
-  readonly sessionExpiresAt: UnixTimestampInMilliseconds;
+  readonly sessionExpiresAt: Date;
 }
 
 export type LoggedIn = SystemAdministratorLoggedIn | ElectionManagerLoggedIn;

--- a/libs/types/src/auth/inserted_smart_card_auth.ts
+++ b/libs/types/src/auth/inserted_smart_card_auth.ts
@@ -3,7 +3,6 @@ import {
   ElectionManagerUser,
   PollWorkerUser,
   SystemAdministratorUser,
-  UnixTimestampInMilliseconds,
   UserRole,
 } from './auth';
 
@@ -23,33 +22,33 @@ export interface CheckingPin {
   readonly status: 'checking_pin';
   readonly user: SystemAdministratorUser | ElectionManagerUser | PollWorkerUser;
   readonly error?: true;
-  readonly lockedOutUntil?: UnixTimestampInMilliseconds;
-  readonly wrongPinEnteredAt?: UnixTimestampInMilliseconds;
+  readonly lockedOutUntil?: Date;
+  readonly wrongPinEnteredAt?: Date;
 }
 
 export interface SystemAdministratorLoggedIn {
   readonly status: 'logged_in';
   readonly user: SystemAdministratorUser;
-  readonly sessionExpiresAt: UnixTimestampInMilliseconds;
+  readonly sessionExpiresAt: Date;
 }
 
 export interface ElectionManagerLoggedIn {
   readonly status: 'logged_in';
   readonly user: ElectionManagerUser;
-  readonly sessionExpiresAt: UnixTimestampInMilliseconds;
+  readonly sessionExpiresAt: Date;
 }
 
 export interface PollWorkerLoggedIn {
   readonly status: 'logged_in';
   readonly user: PollWorkerUser;
-  readonly sessionExpiresAt: UnixTimestampInMilliseconds;
+  readonly sessionExpiresAt: Date;
   readonly cardlessVoterUser?: CardlessVoterUser;
 }
 
 export interface CardlessVoterLoggedIn {
   readonly status: 'logged_in';
   readonly user: CardlessVoterUser;
-  readonly sessionExpiresAt: UnixTimestampInMilliseconds;
+  readonly sessionExpiresAt: Date;
 }
 
 export type LoggedIn =

--- a/libs/ui/src/session_time_limit_tracker.tsx
+++ b/libs/ui/src/session_time_limit_tracker.tsx
@@ -7,7 +7,6 @@ import {
   DEFAULT_OVERALL_SESSION_TIME_LIMIT_HOURS,
   DippedSmartCardAuth,
   InsertedSmartCardAuth,
-  UnixTimestampInMilliseconds,
 } from '@votingworks/types';
 
 import { Button } from './button';
@@ -53,7 +52,7 @@ function shouldDisplayTimeLimitPrompt(
 interface SessionTimeLimitTrackerHelperProps {
   authStatus: AuthStatusWithSessionExpiry;
   logOut: () => void;
-  updateSessionExpiry: (sessionExpiresAt: UnixTimestampInMilliseconds) => void;
+  updateSessionExpiry: (sessionExpiresAt: Date) => void;
 }
 
 /**
@@ -85,8 +84,10 @@ function SessionTimeLimitTrackerHelper({
       setHasInactiveSessionTimeLimitBeenHit(true);
       // Have the backend log out in SECONDS_TO_WRAP_UP_AFTER_INACTIVE_SESSION_TIME_LIMIT
       updateSessionExpiry(
-        new Date().getTime() +
-          SECONDS_TO_WRAP_UP_AFTER_INACTIVE_SESSION_TIME_LIMIT * 1000
+        new Date(
+          new Date().getTime() +
+            SECONDS_TO_WRAP_UP_AFTER_INACTIVE_SESSION_TIME_LIMIT * 1000
+        )
       );
     },
     stopOnIdle: true,
@@ -145,7 +146,7 @@ interface SessionTimeLimitTrackerProps {
     | DippedSmartCardAuth.AuthStatus
     | InsertedSmartCardAuth.AuthStatus;
   logOut: () => void;
-  updateSessionExpiry: (sessionExpiresAt: UnixTimestampInMilliseconds) => void;
+  updateSessionExpiry: (sessionExpiresAt: Date) => void;
 }
 
 /**

--- a/libs/ui/src/session_time_limit_tracker.tsx
+++ b/libs/ui/src/session_time_limit_tracker.tsx
@@ -1,4 +1,5 @@
 /* istanbul ignore file */
+import { DateTime } from 'luxon';
 import pluralize from 'pluralize';
 import React, { useState } from 'react';
 import { useIdleTimer } from 'react-idle-timer';
@@ -84,10 +85,11 @@ function SessionTimeLimitTrackerHelper({
       setHasInactiveSessionTimeLimitBeenHit(true);
       // Have the backend log out in SECONDS_TO_WRAP_UP_AFTER_INACTIVE_SESSION_TIME_LIMIT
       updateSessionExpiry(
-        new Date(
-          new Date().getTime() +
-            SECONDS_TO_WRAP_UP_AFTER_INACTIVE_SESSION_TIME_LIMIT * 1000
-        )
+        DateTime.now()
+          .plus({
+            seconds: SECONDS_TO_WRAP_UP_AFTER_INACTIVE_SESSION_TIME_LIMIT,
+          })
+          .toJSDate()
       );
     },
     stopOnIdle: true,

--- a/libs/ui/src/unlock_machine_screen.test.tsx
+++ b/libs/ui/src/unlock_machine_screen.test.tsx
@@ -67,7 +67,7 @@ test('Incorrect PIN', () => {
     <UnlockMachineScreen
       auth={{
         ...checkingPinAuthStatus,
-        wrongPinEnteredAt: new Date().getTime(),
+        wrongPinEnteredAt: new Date(),
       }}
       checkPin={checkPin}
     />
@@ -99,10 +99,8 @@ test.each<{
       <UnlockMachineScreen
         auth={{
           ...checkingPinAuthStatus,
-          lockedOutUntil: new Date().getTime() + 60 * 1000,
-          wrongPinEnteredAt: isWrongPinEnteredAtSet
-            ? new Date().getTime()
-            : undefined,
+          lockedOutUntil: new Date(new Date().getTime() + 60 * 1000),
+          wrongPinEnteredAt: isWrongPinEnteredAtSet ? new Date() : undefined,
         }}
         checkPin={checkPin}
       />
@@ -140,7 +138,7 @@ test('Error checking PIN', () => {
       auth={{
         ...checkingPinAuthStatus,
         error: true,
-        wrongPinEnteredAt: new Date().getTime(),
+        wrongPinEnteredAt: new Date(),
       }}
       checkPin={checkPin}
     />

--- a/libs/ui/src/unlock_machine_screen.test.tsx
+++ b/libs/ui/src/unlock_machine_screen.test.tsx
@@ -1,3 +1,4 @@
+import { DateTime } from 'luxon';
 import MockDate from 'mockdate';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
@@ -6,8 +7,8 @@ import {
   hasTextAcrossElements,
 } from '@votingworks/test-utils';
 import { DippedSmartCardAuth } from '@votingworks/types';
-
 import { act } from '@testing-library/react-hooks';
+
 import { render, screen, waitFor } from '../test/react_testing_library';
 import { UnlockMachineScreen } from './unlock_machine_screen';
 
@@ -99,7 +100,7 @@ test.each<{
       <UnlockMachineScreen
         auth={{
           ...checkingPinAuthStatus,
-          lockedOutUntil: new Date(new Date().getTime() + 60 * 1000),
+          lockedOutUntil: DateTime.now().plus({ seconds: 60 }).toJSDate(),
           wrongPinEnteredAt: isWrongPinEnteredAtSet ? new Date() : undefined,
         }}
         checkPin={checkPin}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,9 @@ importers:
       js-sha256:
         specifier: ^0.9.0
         version: 0.9.0
+      luxon:
+        specifier: ^3.0.0
+        version: 3.3.0
       multer:
         specifier: ^1.4.5-lts.1
         version: 1.4.5-lts.1
@@ -191,6 +194,9 @@ importers:
       '@types/jest':
         specifier: ^26.0.6
         version: 26.0.23
+      '@types/luxon':
+        specifier: ^3.0.0
+        version: 3.2.0
       '@types/multer':
         specifier: ^1.4.7
         version: 1.4.7
@@ -1561,6 +1567,9 @@ importers:
       js-sha256:
         specifier: ^0.9.0
         version: 0.9.0
+      luxon:
+        specifier: ^3.0.0
+        version: 3.3.0
       tmp:
         specifier: ^0.2.1
         version: 0.2.1
@@ -1583,6 +1592,9 @@ importers:
       '@types/jest':
         specifier: ^26.0.6
         version: 26.0.23
+      '@types/luxon':
+        specifier: ^3.0.0
+        version: 3.2.0
       '@types/node':
         specifier: 16.11.29
         version: 16.11.29
@@ -2792,6 +2804,9 @@ importers:
       js-sha256:
         specifier: ^0.9.0
         version: 0.9.0
+      luxon:
+        specifier: ^3.0.0
+        version: 3.3.0
       node-fetch:
         specifier: ^2.6.0
         version: 2.6.7
@@ -2811,6 +2826,9 @@ importers:
       '@types/jest':
         specifier: ^27.0.3
         version: 27.4.1
+      '@types/luxon':
+        specifier: ^3.0.0
+        version: 3.2.0
       '@types/node-fetch':
         specifier: ^2.6.0
         version: 2.6.2
@@ -2879,7 +2897,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: ^27.0.7
-        version: 27.1.5(@babel/core@7.12.3)(@types/jest@27.4.1)(esbuild@0.14.42)(jest@27.5.1)(typescript@4.6.3)
+        version: 27.1.5(@babel/core@7.20.12)(@types/jest@27.4.1)(esbuild@0.14.42)(jest@27.5.1)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -5688,6 +5706,17 @@ packages:
       '@babel/helper-annotate-as-pure': 7.18.6
       regexpu-core: 5.2.2
 
+  /@babel/helper-create-regexp-features-plugin@7.20.5(@babel/core@7.20.12):
+    resolution: {integrity: sha512-m68B1lkg3XDGX5yCvGO0kPx3v9WIYLnzjKfPcQiwntEQa5ZeRkPmo2X/ISJc8qxWGfwUr+kvZAeEzAwLec2r2w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.20.12
+      '@babel/helper-annotate-as-pure': 7.18.6
+      regexpu-core: 5.2.2
+    dev: true
+
   /@babel/helper-define-polyfill-provider@0.3.1(@babel/core@7.20.12):
     resolution: {integrity: sha512-J9hGMpJQmtWmj46B3kBHmL38UhJGhYX7eqkcq+2gsstyYt341HmPeWspihX43yVRA0mS+8GGk2Gckc7bY/HCmA==}
     peerDependencies:
@@ -6083,16 +6112,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.18.6(@babel/core@7.20.12):
-    resolution: {integrity: sha512-Dgxsyg54Fx1d4Nge8UnvTrED63vrwOdPmyvPzlNN/boaliRP54pm3pGzZD1SJUwrBA+Cs/xdG8kXX6Mn/RfISQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.16.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-di8vUHRdf+4aJ7ltXhaDbPoszdkh59AQtJM5soLsuHpQJdFQZOA4uGj0V2u/CZ8bJ/u8ULDL5yq6FO/bCXnKHw==}
@@ -6113,18 +6132,6 @@ packages:
       '@babel/core': ^7.13.0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-      '@babel/plugin-proposal-optional-chaining': 7.20.7(@babel/core@7.12.3)
-    dev: true
-
-  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.20.7(@babel/core@7.20.12):
-    resolution: {integrity: sha512-sbr9+wNE5aXMBBFBICk01tt7sBf2Oc9ikRFEcem/ZORup9IMUdNhW7/wVLEbbtlWOsEubJet46mHAL2C8+2jKQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.13.0
-    dependencies:
-      '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
       '@babel/plugin-proposal-optional-chaining': 7.20.7(@babel/core@7.12.3)
@@ -6156,21 +6163,6 @@ packages:
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.12.3)
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.20.12):
-    resolution: {integrity: sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.12.3)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.12.3)
-    transitivePeerDependencies:
-      - supports-color
 
   /@babel/plugin-proposal-class-properties@7.16.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-IobU0Xme31ewjYOShSIqd/ZGM/r/cuOz2z0MDbNrhF5FW+ZVgi0f2lyeoj9KFPDOAqsYxmLWZte1WOwlvY9aww==}
@@ -6196,7 +6188,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
@@ -6231,20 +6222,6 @@ packages:
       '@babel/core': ^7.12.0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.12.3)
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-proposal-class-static-block@7.20.7(@babel/core@7.20.12):
-    resolution: {integrity: sha512-AveGOoi9DAjUYYuUAG//Ig69GlazLnoyzMw68VCDux+c1tsnnH/OkYcpz/5xzMkEFC6UxjR5Gw1c+iY2wOGVeQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.12.0
-    dependencies:
-      '@babel/core': 7.20.12
       '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.12.3)
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.12.3)
@@ -6286,17 +6263,6 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.12.3)
-    dev: true
-
-  /@babel/plugin-proposal-dynamic-import@7.18.6(@babel/core@7.20.12):
-    resolution: {integrity: sha512-1auuwmK+Rz13SJj36R+jqFPMJWyKEDd7lLSdOj4oJK0UTgGueSAtkrCvz9ewmgyU/P941Rv2fQwZJN8s6QruXw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.12.3)
 
   /@babel/plugin-proposal-export-namespace-from@7.16.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-ZxdtqDXLRGBL64ocZcs7ovt71L3jhC1RGSyR996svrCi3PYqHNkb3SwPJCs8RIzD86s+WPpt2S73+EHCGO+NUA==}
@@ -6316,17 +6282,6 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.12.3)
-    dev: true
-
-  /@babel/plugin-proposal-export-namespace-from@7.18.9(@babel/core@7.20.12):
-    resolution: {integrity: sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.12.3)
 
@@ -6350,17 +6305,6 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.12.3)
-    dev: true
-
-  /@babel/plugin-proposal-json-strings@7.18.6(@babel/core@7.20.12):
-    resolution: {integrity: sha512-lr1peyn9kOdbYc0xr0OdHTZ5FMqS6Di+H0Fz2I/JwMzGmzJETNeOFq2pBySw6X/KFL5EWDjlJuMsUGRFb8fQgQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.12.3)
 
   /@babel/plugin-proposal-logical-assignment-operators@7.16.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-K3XzyZJGQCr00+EtYtrDjmwX7o7PLK6U9bi1nCwkQioRFVUv6dJoxbQjtWVtP+bCPy82bONBKG8NPyQ4+i6yjg==}
@@ -6382,17 +6326,6 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.12.3)
-    dev: true
-
-  /@babel/plugin-proposal-logical-assignment-operators@7.20.7(@babel/core@7.20.12):
-    resolution: {integrity: sha512-y7C7cZgpMIjWlKE5T7eJwp+tnRYM89HmRvWM5EQuB5BoHEONjmQ8lSNmBUwOyy/GFRsohJED51YBF79hE1djug==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.12.3)
 
   /@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.12.3):
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
@@ -6403,7 +6336,6 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.12.3)
-    dev: true
 
   /@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
@@ -6424,7 +6356,6 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.12.3)
-    dev: true
 
   /@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==}
@@ -6462,20 +6393,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.12.3)
       '@babel/plugin-transform-parameters': 7.20.7(@babel/core@7.12.3)
-    dev: true
-
-  /@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.20.12):
-    resolution: {integrity: sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/compat-data': 7.20.10
-      '@babel/core': 7.20.12
-      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.12.3)
-      '@babel/plugin-transform-parameters': 7.20.7(@babel/core@7.12.3)
 
   /@babel/plugin-proposal-optional-catch-binding@7.16.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-eMOH/L4OvWSZAE1VkHbr1vckLG1WUcHGJSLqqQwl2GaUqG6QjddvrOaTUMNYiv77H5IKPMZ9U9P7EaHwvAShfA==}
@@ -6495,17 +6412,6 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.12.3)
-    dev: true
-
-  /@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.20.12):
-    resolution: {integrity: sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.12.3)
 
@@ -6542,7 +6448,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
@@ -6569,7 +6474,6 @@ packages:
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.12.3)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-proposal-private-property-in-object@7.20.5(@babel/core@7.20.12):
     resolution: {integrity: sha512-Vq7b9dUA12ByzB4EjQTPo25sFhY+08pQDBSZRtUAkj7lb7jahaHR5igera16QZ+3my1nYR4dKsNdYj5IjPHilQ==}
@@ -6613,8 +6517,9 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.12.3)
+      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.12.3):
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
@@ -6681,6 +6586,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-syntax-decorators@7.19.0(@babel/core@7.20.12):
     resolution: {integrity: sha512-xaBZUEDntt4faL1yN8oIFlhfXeQAWJW7CLKYsHTUqriCUbj8xOra8bfxxKGi/UwExPFBuPdH4XfHc9rGQhrVkQ==}
@@ -6706,6 +6612,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.12.3):
     resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
@@ -6722,6 +6629,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-syntax-flow@7.18.6(@babel/core@7.12.3):
     resolution: {integrity: sha512-LUbR+KNTBWCUAqRG9ex5Gnzu2IOkt8jRJbHHXFT9q+L9zm7M/QQbEqXyw1n1pohYvOyWC8CjeyjrSaIwiYjK7A==}
@@ -6749,16 +6657,6 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-syntax-import-assertions@7.20.0(@babel/core@7.20.12):
-    resolution: {integrity: sha512-IUh1vakzNoWalR8ch/areW7qFopR2AEw03JlG7BbrDqmQ4X3q9uuipQwSGrUn7oGiemKjtSLDhNtQHzMHr1JdQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.12.3):
@@ -6916,7 +6814,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.20.12):
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
@@ -6972,16 +6869,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-arrow-functions@7.20.7(@babel/core@7.20.12):
-    resolution: {integrity: sha512-3poA5E7dzDomxj9WXWwuD6A5F3kc7VXwIJO+E+J8qtDtS+pXPAhrgEyh+9GBwBgPq1Z+bB+/JD60lp5jsN7JPQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-async-to-generator@7.16.8(@babel/core@7.20.12):
     resolution: {integrity: sha512-MtmUmTJQHCnyJVrScNzNlofQJ3dLFuobYn3mwOTKHnSCMtbNsqvF71GQmJfFjdrXSsAA7iysFmYWw4bXZ20hOg==}
@@ -7009,20 +6896,6 @@ packages:
       '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.12.3)
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@babel/plugin-transform-async-to-generator@7.20.7(@babel/core@7.20.12):
-    resolution: {integrity: sha512-Uo5gwHPT9vgnSXQxqGtpdufUiWp96gk7yiP4Mp5bm1QMkEmLXBO7PAGYbKoJ6DhAwiNkcHFBol/x5zZZkL/t0Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.12.3)
-    transitivePeerDependencies:
-      - supports-color
 
   /@babel/plugin-transform-block-scoped-functions@7.16.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-JUuzlzmF40Z9cXyytcbZEZKckgrQzChbQJw/5PuEHYeqzCsvebDx0K0jWnIIVcmmDOAVctCgnYs0pMcrYj2zJg==}
@@ -7042,16 +6915,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-block-scoped-functions@7.18.6(@babel/core@7.20.12):
-    resolution: {integrity: sha512-ExUcOqpPWnliRcPqves5HJcJOvHvIIWfuS4sroBUenPuMdmW+SMHDakmtS7qOo13sVppmUijqeTv7qqGsvURpQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-block-scoping@7.16.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-ObZev2nxVAYA4bhyusELdo9hb3H+A56bxH3FZMbEImZFiEDYVHXQSJ1hQKFlDnlt8G9bBrCZ5ZpURZUrV4G5qQ==}
@@ -7070,16 +6933,6 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-block-scoping@7.20.11(@babel/core@7.20.12):
-    resolution: {integrity: sha512-tA4N427a7fjf1P0/2I4ScsHGc5jcHPbb30xMbaTke2gxDuWpUfXDuX1FEymJwKk4tuGUvGcejAR6HdZVqmmPyw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-classes@7.16.7(@babel/core@7.20.12):
@@ -7119,26 +6972,6 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@babel/plugin-transform-classes@7.20.7(@babel/core@7.20.12):
-    resolution: {integrity: sha512-LWYbsiXTPKl+oBlXUGlwNlJZetXD5Am+CyBdqhPsDVjM9Jc8jwBJFrKhHf900Kfk2eZG1y9MAG3UNajol7A4VQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.12.3)
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.19.0
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-replace-supers': 7.20.7
-      '@babel/helper-split-export-declaration': 7.18.6
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
 
   /@babel/plugin-transform-computed-properties@7.16.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-gN72G9bcmenVILj//sv1zLNaPyYcOzUho2lIJBMh/iakJ9ygCo/hEF9cpGb61SCMEDxbbyBoVQxrt+bWKu5KGw==}
@@ -7159,17 +6992,6 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/template': 7.20.7
-    dev: true
-
-  /@babel/plugin-transform-computed-properties@7.20.7(@babel/core@7.20.12):
-    resolution: {integrity: sha512-Lz7MvBK6DTjElHAmfu6bfANzKcxpyNPeYBGEafyA6E5HtRpjpZwU+u7Qrgz/2OR0z+5TvKYbPdphfSaAcZBrYQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/template': 7.20.7
 
   /@babel/plugin-transform-destructuring@7.17.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-XVh0r5yq9sLR4vZ6eVZe8FKfIcSgaTBxVBRSYokRj2qksf6QerYnTxz9/GTuKTH/n/HwLP7t6gtlybHetJ/6hQ==}
@@ -7188,16 +7010,6 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-destructuring@7.20.7(@babel/core@7.20.12):
-    resolution: {integrity: sha512-Xwg403sRrZb81IVB79ZPqNQME23yhugYVqgTxAhT99h485F4f+GMELFhhOsscDUB7HCswepKeCKLn/GZvUKoBA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-dotall-regex@7.16.7(@babel/core@7.20.12):
@@ -7228,8 +7040,9 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.12.3)
+      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-transform-duplicate-keys@7.16.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-03DvpbRfvWIXyK0/6QiR1KMTWeT6OcQ7tbhjrXyFS02kjuX/mu5Bvnh5SDSWHxyawit2g5aWhKwI86EE7GUnTw==}
@@ -7248,16 +7061,6 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-duplicate-keys@7.18.9(@babel/core@7.20.12):
-    resolution: {integrity: sha512-d2bmXCtZXYc59/0SanQKbiWINadaJXqtvIQIzd4+hNwkWBgyCd5F/2t1kXoUdvPMrxzPvhK6EMQRROxsue+mfw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-exponentiation-operator@7.16.7(@babel/core@7.20.12):
@@ -7278,17 +7081,6 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-builder-binary-assignment-operator-visitor': 7.18.9
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-exponentiation-operator@7.18.6(@babel/core@7.20.12):
-    resolution: {integrity: sha512-wzEtc0+2c88FVR34aQmiz56dxEkxr2g8DQb/KfaFa1JYXOFVsbhvAonFN6PwVWj++fKmku8NP80plJ5Et4wqHw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.18.9
       '@babel/helper-plugin-utils': 7.20.2
 
@@ -7320,16 +7112,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-for-of@7.18.8(@babel/core@7.20.12):
-    resolution: {integrity: sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-function-name@7.16.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-SU/C68YVwTRxqWj5kgsbKINakGag0KTgq9f2iZEXdStoAbOzLHEBRYzImmA6yFo8YZhJVflvXmIHUO7GWHmxxA==}
@@ -7353,18 +7135,6 @@ packages:
       '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.12.3)
       '@babel/helper-function-name': 7.19.0
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-function-name@7.18.9(@babel/core@7.20.12):
-    resolution: {integrity: sha512-WvIBoRPaJQ5yVHzcnJFor7oS5Ls0PYixlTYE63lCj2RtdQEl15M68FXQlxnG6wdraJIXRdR7KI+hQ7q/9QjrCQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.12.3)
-      '@babel/helper-function-name': 7.19.0
-      '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-literals@7.16.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-6tH8RTpTWI0s2sV6uq3e/C9wPo4PTqqZps4uF0kzQ9/xPLFQtipynvmT1g/dOfEJ+0EQsHhkQ/zyRId8J2b8zQ==}
@@ -7384,16 +7154,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-literals@7.18.9(@babel/core@7.20.12):
-    resolution: {integrity: sha512-IFQDSRoTPnrAIrI5zoZv73IFeZu2dhu6irxQjY9rNjTT53VmKg9fenjvoiOWOkJ6mm4jKVPtdMzBY98Fp4Z4cg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-member-expression-literals@7.16.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-mBruRMbktKQwbxaJof32LT9KLy2f3gH+27a5XSuXo6h7R3vqltl0PgZ80C8ZMKw98Bf8bqt6BEVi3svOh2PzMw==}
@@ -7412,16 +7172,6 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-member-expression-literals@7.18.6(@babel/core@7.20.12):
-    resolution: {integrity: sha512-qSF1ihLGO3q+/g48k85tUjD033C29TNTVB2paCwZPVmOsjn9pClvYYrM2VeJpBY2bcNkuny0YUyTNRyRxJ54KA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-modules-amd@7.16.7(@babel/core@7.20.12):
@@ -7445,19 +7195,6 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-module-transforms': 7.20.11
-      '@babel/helper-plugin-utils': 7.20.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-modules-amd@7.20.11(@babel/core@7.20.12):
-    resolution: {integrity: sha512-NuzCt5IIYOW0O30UvqktzHYR2ud5bOWbY0yaxWZ6G+aFzOMJvrs5YHNikrbdaT15+KNO31nPOy5Fim3ku6Zb5g==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
       '@babel/helper-module-transforms': 7.20.11
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
@@ -7490,7 +7227,6 @@ packages:
       '@babel/helper-simple-access': 7.20.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-transform-modules-commonjs@7.20.11(@babel/core@7.20.12):
     resolution: {integrity: sha512-S8e1f7WQ7cimJQ51JkAaDrEtohVEitXjgCGAS2N8S31Y42E+kWwfSz83LYz57QdBm7q9diARVqanIaH2oVgQnw==}
@@ -7504,6 +7240,7 @@ packages:
       '@babel/helper-simple-access': 7.20.2
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/plugin-transform-modules-systemjs@7.17.8(@babel/core@7.20.12):
     resolution: {integrity: sha512-39reIkMTUVagzgA5x88zDYXPCMT6lcaRKs1+S9K6NKBPErbgO/w/kP8GlNQTC87b412ZTlmNgr3k2JrWgHH+Bw==}
@@ -7528,21 +7265,6 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-module-transforms': 7.20.11
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-validator-identifier': 7.19.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-modules-systemjs@7.20.11(@babel/core@7.20.12):
-    resolution: {integrity: sha512-vVu5g9BPQKSFEmvt2TA4Da5N+QVS66EX21d8uoOihC+OCpUoGvzVsXeqFdtAEfVa5BILAeFt+U7yVmLbQnAJmw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-module-transforms': 7.20.11
       '@babel/helper-plugin-utils': 7.20.2
@@ -7574,19 +7296,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@babel/plugin-transform-modules-umd@7.18.6(@babel/core@7.20.12):
-    resolution: {integrity: sha512-dcegErExVeXcRqNtkRU/z8WlBLnvD4MRnHgNs3MytRO1Mn1sHRyhbcpYbVMGclAqOjdW+9cfkdZno9dFdfKLfQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-module-transforms': 7.20.11
-      '@babel/helper-plugin-utils': 7.20.2
-    transitivePeerDependencies:
-      - supports-color
 
   /@babel/plugin-transform-named-capturing-groups-regex@7.16.8(@babel/core@7.20.12):
     resolution: {integrity: sha512-j3Jw+n5PvpmhRR+mrgIh04puSANCk/T/UA3m3P1MjJkhlK906+ApHhDIqBQDdOgL/r1UYpz4GNclTXxyZrYGSw==}
@@ -7607,17 +7316,6 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.12.3)
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-named-capturing-groups-regex@7.20.5(@babel/core@7.20.12):
-    resolution: {integrity: sha512-mOW4tTzi5iTLnw+78iEq3gr8Aoq4WNRGpmSlrogqaiCBoR1HFhpU4JkpQFOHfeYx3ReVIFWOQJS4aZBRvuZ6mA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-new-target@7.16.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-xiLDzWNMfKoGOpc6t3U+etCE2yRnn3SM09BXqWPIZOBpL2gvVrBWUKnsJx0K/ADi5F5YC5f8APFfWrz25TdlGg==}
@@ -7636,16 +7334,6 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-new-target@7.18.6(@babel/core@7.20.12):
-    resolution: {integrity: sha512-DjwFA/9Iu3Z+vrAn+8pBUGcjhxKguSMlsFqeCKbhb9BAV756v0krzVK04CRDi/4aqmk8BsHb4a/gFcaA5joXRw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-object-super@7.16.7(@babel/core@7.20.12):
@@ -7668,19 +7356,6 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-replace-supers': 7.20.7
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-object-super@7.18.6(@babel/core@7.20.12):
-    resolution: {integrity: sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-replace-supers': 7.20.7
     transitivePeerDependencies:
@@ -7713,6 +7388,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-transform-property-literals@7.16.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-z4FGr9NMGdoIl1RqavCqGG+ZuYjfZ/hkCIeuH6Do7tXmSm0ls11nYVSJqFEUOSJbDab5wC6lRE/w6YjVcr6Hqw==}
@@ -7731,16 +7407,6 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-property-literals@7.18.6(@babel/core@7.20.12):
-    resolution: {integrity: sha512-cYcs6qlgafTud3PAzrrRNbQtfpQ8+y/+M5tKmksS9+M1ckbH6kzY8MrexEM9mcA6JDsukE19iIRvAyYl463sMg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-react-constant-elements@7.12.1(@babel/core@7.20.12):
@@ -7870,17 +7536,6 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
       regenerator-transform: 0.15.1
-    dev: true
-
-  /@babel/plugin-transform-regenerator@7.20.5(@babel/core@7.20.12):
-    resolution: {integrity: sha512-kW/oO7HPBtntbsahzQ0qSE3tFvkFwnbozz3NWFhLGqH75vLEg+sCGngLlhVkePlCs3Jv0dBBHDzCHxNiFAQKCQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-      regenerator-transform: 0.15.1
 
   /@babel/plugin-transform-reserved-words@7.16.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-KQzzDnZ9hWQBjwi5lpY5v9shmm6IVG0U9pB18zvMu2i4H90xpT4gmqwPYsn8rObiadYe2M0gmgsiOIF5A/2rtg==}
@@ -7899,16 +7554,6 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-reserved-words@7.18.6(@babel/core@7.20.12):
-    resolution: {integrity: sha512-oX/4MyMoypzHjFrT1CdivfKZ+XvIPMFXwwxHp/r0Ddy2Vuomt4HDFGmft1TAY2yiTKiNSsh3kjBAzcM8kSdsjA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-runtime@7.19.1(@babel/core@7.20.12):
@@ -7945,16 +7590,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-shorthand-properties@7.18.6(@babel/core@7.20.12):
-    resolution: {integrity: sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-spread@7.16.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-+pjJpgAngb53L0iaA5gU/1MLXJIfXcYepLgXB3esVRf4fqmj8f2cxM3/FKaHsZms08hFQJkFccEWuIpm429TXg==}
@@ -7976,17 +7611,6 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-    dev: true
-
-  /@babel/plugin-transform-spread@7.20.7(@babel/core@7.20.12):
-    resolution: {integrity: sha512-ewBbHQ+1U/VnH1fxltbJqDeWBU1oNLG8Dj11uIv3xVf7nrQu0bPGe5Rf716r7K5Qz+SqtAOVswoVunoiBtGhxw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
 
   /@babel/plugin-transform-sticky-regex@7.16.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-NJa0Bd/87QV5NZZzTuZG5BPJjLYadeSZ9fO6oOUoL4iQx+9EEuw/eEM92SrsT19Yc2jgB1u1hsjqDtH02c3Drw==}
@@ -8005,16 +7629,6 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-sticky-regex@7.18.6(@babel/core@7.20.12):
-    resolution: {integrity: sha512-kfiDrDQ+PBsQDO85yj1icueWMfGfJFKN1KCkndygtu/C9+XUfydLC8Iv5UYJqRwy4zk8EcplRxEOeLyjq1gm6Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-template-literals@7.16.7(@babel/core@7.20.12):
@@ -8035,16 +7649,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-template-literals@7.18.9(@babel/core@7.20.12):
-    resolution: {integrity: sha512-S8cOWfT82gTezpYOiVaGHrCbhlHgKhQt8XH5ES46P2XWmX92yisoZywf5km75wv5sYcXDUCLMmMxOLCtthDgMA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-typeof-symbol@7.16.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-p2rOixCKRJzpg9JB4gjnG4gjWkWa89ZoYUnl9snJ1cWIcTH/hvxZqfO+WjG6T8DRBpctEol5jw1O5rA8gkCokQ==}
@@ -8063,16 +7667,6 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-typeof-symbol@7.18.9(@babel/core@7.20.12):
-    resolution: {integrity: sha512-SRfwTtF11G2aemAZWivL7PD+C9z52v9EvMqH9BuYbabyPuKUvSWks3oCg6041pT925L4zVFqaVBeECwsmlguEw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-typescript@7.16.8(@babel/core@7.20.12):
@@ -8106,16 +7700,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-unicode-escapes@7.18.10(@babel/core@7.20.12):
-    resolution: {integrity: sha512-kKAdAI+YzPgGY/ftStBFXTI1LZFju38rYThnfMykS+IXy8BVx+res7s2fxf1l8I35DV2T97ezo6+SGrXz6B3iQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-unicode-regex@7.16.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-oC5tYYKw56HO75KZVLQ+R/Nl3Hro9kf8iG0hXoaHP7tjAyCpvqBiSNe6vGrZni1Z6MggmUOC6A7VP7AVmw225Q==}
@@ -8135,17 +7719,6 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-unicode-regex@7.18.6(@babel/core@7.20.12):
-    resolution: {integrity: sha512-gE7A6Lt7YLnNOL3Pb9BNeZvi+d8l7tcRrG4+pwJjK9hD2xX4mEvjlQW60G9EEmfXVYRPv9VRQcyegIVHCql/AA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
       '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.12.3)
       '@babel/helper-plugin-utils': 7.20.2
 
@@ -8336,78 +7909,78 @@ packages:
     dependencies:
       '@babel/compat-data': 7.20.10
       '@babel/core': 7.20.12
-      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.20.12)
+      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.12.3)
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-validator-option': 7.18.6
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.18.6(@babel/core@7.20.12)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.20.7(@babel/core@7.20.12)
-      '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.20.12)
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.20.12)
-      '@babel/plugin-proposal-class-static-block': 7.20.7(@babel/core@7.20.12)
-      '@babel/plugin-proposal-dynamic-import': 7.18.6(@babel/core@7.20.12)
-      '@babel/plugin-proposal-export-namespace-from': 7.18.9(@babel/core@7.20.12)
-      '@babel/plugin-proposal-json-strings': 7.18.6(@babel/core@7.20.12)
-      '@babel/plugin-proposal-logical-assignment-operators': 7.20.7(@babel/core@7.20.12)
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.20.12)
-      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.20.12)
-      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.20.12)
-      '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.20.12)
-      '@babel/plugin-proposal-optional-chaining': 7.20.7(@babel/core@7.20.12)
-      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.20.12)
-      '@babel/plugin-proposal-private-property-in-object': 7.20.5(@babel/core@7.20.12)
-      '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.20.12)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.20.12)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.20.12)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.20.12)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.20.12)
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.20.12)
-      '@babel/plugin-syntax-import-assertions': 7.20.0(@babel/core@7.20.12)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.20.12)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.20.12)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.20.12)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.20.12)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.20.12)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.20.12)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.20.12)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.20.12)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.20.12)
-      '@babel/plugin-transform-arrow-functions': 7.20.7(@babel/core@7.20.12)
-      '@babel/plugin-transform-async-to-generator': 7.20.7(@babel/core@7.20.12)
-      '@babel/plugin-transform-block-scoped-functions': 7.18.6(@babel/core@7.20.12)
-      '@babel/plugin-transform-block-scoping': 7.20.11(@babel/core@7.20.12)
-      '@babel/plugin-transform-classes': 7.20.7(@babel/core@7.20.12)
-      '@babel/plugin-transform-computed-properties': 7.20.7(@babel/core@7.20.12)
-      '@babel/plugin-transform-destructuring': 7.20.7(@babel/core@7.20.12)
-      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.20.12)
-      '@babel/plugin-transform-duplicate-keys': 7.18.9(@babel/core@7.20.12)
-      '@babel/plugin-transform-exponentiation-operator': 7.18.6(@babel/core@7.20.12)
-      '@babel/plugin-transform-for-of': 7.18.8(@babel/core@7.20.12)
-      '@babel/plugin-transform-function-name': 7.18.9(@babel/core@7.20.12)
-      '@babel/plugin-transform-literals': 7.18.9(@babel/core@7.20.12)
-      '@babel/plugin-transform-member-expression-literals': 7.18.6(@babel/core@7.20.12)
-      '@babel/plugin-transform-modules-amd': 7.20.11(@babel/core@7.20.12)
-      '@babel/plugin-transform-modules-commonjs': 7.20.11(@babel/core@7.20.12)
-      '@babel/plugin-transform-modules-systemjs': 7.20.11(@babel/core@7.20.12)
-      '@babel/plugin-transform-modules-umd': 7.18.6(@babel/core@7.20.12)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.20.5(@babel/core@7.20.12)
-      '@babel/plugin-transform-new-target': 7.18.6(@babel/core@7.20.12)
-      '@babel/plugin-transform-object-super': 7.18.6(@babel/core@7.20.12)
-      '@babel/plugin-transform-parameters': 7.20.7(@babel/core@7.20.12)
-      '@babel/plugin-transform-property-literals': 7.18.6(@babel/core@7.20.12)
-      '@babel/plugin-transform-regenerator': 7.20.5(@babel/core@7.20.12)
-      '@babel/plugin-transform-reserved-words': 7.18.6(@babel/core@7.20.12)
-      '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.20.12)
-      '@babel/plugin-transform-spread': 7.20.7(@babel/core@7.20.12)
-      '@babel/plugin-transform-sticky-regex': 7.18.6(@babel/core@7.20.12)
-      '@babel/plugin-transform-template-literals': 7.18.9(@babel/core@7.20.12)
-      '@babel/plugin-transform-typeof-symbol': 7.18.9(@babel/core@7.20.12)
-      '@babel/plugin-transform-unicode-escapes': 7.18.10(@babel/core@7.20.12)
-      '@babel/plugin-transform-unicode-regex': 7.18.6(@babel/core@7.20.12)
-      '@babel/preset-modules': 0.1.5(@babel/core@7.20.12)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.20.7(@babel/core@7.12.3)
+      '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.12.3)
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-proposal-class-static-block': 7.20.7(@babel/core@7.12.3)
+      '@babel/plugin-proposal-dynamic-import': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-proposal-export-namespace-from': 7.18.9(@babel/core@7.12.3)
+      '@babel/plugin-proposal-json-strings': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-proposal-logical-assignment-operators': 7.20.7(@babel/core@7.12.3)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.12.3)
+      '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-proposal-optional-chaining': 7.20.7(@babel/core@7.12.3)
+      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-proposal-private-property-in-object': 7.20.5(@babel/core@7.12.3)
+      '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.12.3)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.12.3)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.12.3)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.12.3)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.12.3)
+      '@babel/plugin-syntax-import-assertions': 7.20.0(@babel/core@7.12.3)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.12.3)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.12.3)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.12.3)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.12.3)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.12.3)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.12.3)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.12.3)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.12.3)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-arrow-functions': 7.20.7(@babel/core@7.12.3)
+      '@babel/plugin-transform-async-to-generator': 7.20.7(@babel/core@7.12.3)
+      '@babel/plugin-transform-block-scoped-functions': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-block-scoping': 7.20.11(@babel/core@7.12.3)
+      '@babel/plugin-transform-classes': 7.20.7(@babel/core@7.12.3)
+      '@babel/plugin-transform-computed-properties': 7.20.7(@babel/core@7.12.3)
+      '@babel/plugin-transform-destructuring': 7.20.7(@babel/core@7.12.3)
+      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-duplicate-keys': 7.18.9(@babel/core@7.12.3)
+      '@babel/plugin-transform-exponentiation-operator': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-for-of': 7.18.8(@babel/core@7.12.3)
+      '@babel/plugin-transform-function-name': 7.18.9(@babel/core@7.12.3)
+      '@babel/plugin-transform-literals': 7.18.9(@babel/core@7.12.3)
+      '@babel/plugin-transform-member-expression-literals': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-modules-amd': 7.20.11(@babel/core@7.12.3)
+      '@babel/plugin-transform-modules-commonjs': 7.20.11(@babel/core@7.12.3)
+      '@babel/plugin-transform-modules-systemjs': 7.20.11(@babel/core@7.12.3)
+      '@babel/plugin-transform-modules-umd': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.20.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-new-target': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-object-super': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-parameters': 7.20.7(@babel/core@7.12.3)
+      '@babel/plugin-transform-property-literals': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-regenerator': 7.20.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-reserved-words': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-spread': 7.20.7(@babel/core@7.12.3)
+      '@babel/plugin-transform-sticky-regex': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-template-literals': 7.18.9(@babel/core@7.12.3)
+      '@babel/plugin-transform-typeof-symbol': 7.18.9(@babel/core@7.12.3)
+      '@babel/plugin-transform-unicode-escapes': 7.18.10(@babel/core@7.12.3)
+      '@babel/plugin-transform-unicode-regex': 7.18.6(@babel/core@7.12.3)
+      '@babel/preset-modules': 0.1.5(@babel/core@7.12.3)
       '@babel/types': 7.20.7
-      babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.20.12)
-      babel-plugin-polyfill-corejs3: 0.6.0(@babel/core@7.20.12)
-      babel-plugin-polyfill-regenerator: 0.4.1(@babel/core@7.20.12)
+      babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.12.3)
+      babel-plugin-polyfill-corejs3: 0.6.0(@babel/core@7.12.3)
+      babel-plugin-polyfill-regenerator: 0.4.1(@babel/core@7.12.3)
       core-js-compat: 3.25.1
       semver: 6.3.0
     transitivePeerDependencies:
@@ -8436,7 +8009,6 @@ packages:
       '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.12.3)
       '@babel/types': 7.20.7
       esutils: 2.0.3
-    dev: true
 
   /@babel/preset-modules@0.1.5(@babel/core@7.20.12):
     resolution: {integrity: sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==}
@@ -8445,10 +8017,11 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.12.3)
-      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.20.12)
+      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.20.12)
       '@babel/types': 7.20.7
       esutils: 2.0.3
+    dev: true
 
   /@babel/preset-react@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-zXr6atUmyYdiWRVLOZahakYmOBHtWc2WGCkP8PYTgZi0iJXDY2CN180TdrIW4OGOAdLc7TifzDIvtx6izaRIzg==}
@@ -15100,7 +14673,6 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /babel-plugin-polyfill-corejs2@0.3.3(@babel/core@7.20.12):
     resolution: {integrity: sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==}
@@ -15136,7 +14708,6 @@ packages:
       core-js-compat: 3.25.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /babel-plugin-polyfill-corejs3@0.6.0(@babel/core@7.20.12):
     resolution: {integrity: sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==}
@@ -15169,7 +14740,6 @@ packages:
       '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.12.3)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /babel-plugin-polyfill-regenerator@0.4.1(@babel/core@7.20.12):
     resolution: {integrity: sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==}
@@ -33184,6 +32754,42 @@ packages:
       '@types/jest': 27.4.1
       bs-logger: 0.2.6
       esbuild: 0.16.17
+      fast-json-stable-stringify: 2.1.0
+      jest: 27.5.1
+      jest-util: 27.5.1
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.3.7
+      typescript: 4.6.3
+      yargs-parser: 20.2.9
+    dev: true
+
+  /ts-jest@27.1.5(@babel/core@7.20.12)(@types/jest@27.4.1)(esbuild@0.14.42)(jest@27.5.1)(typescript@4.6.3):
+    resolution: {integrity: sha512-Xv6jBQPoBEvBq/5i2TeSG9tt/nqkbpcurrEG1b+2yfBrcJelOZF9Ml6dmyMh7bcW9JyFbRYpR5rxROSlBLTZHA==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@types/jest': ^27.0.0
+      babel-jest: '>=27.0.0 <28'
+      esbuild: '*'
+      jest: ^27.0.0
+      typescript: '>=3.8 <5.0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@types/jest':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+    dependencies:
+      '@babel/core': 7.20.12
+      '@types/jest': 27.4.1
+      bs-logger: 0.2.6
+      esbuild: 0.14.42
       fast-json-stable-stringify: 2.1.0
       jest: 27.5.1
       jest-util: 27.5.1


### PR DESCRIPTION
## Overview

Since @jonahkagan identified a fix for https://github.com/votingworks/vxsuite/issues/3233 :tada:, we can use Dates again instead of Unix timestamps in milliseconds in auth lib code. (The former are just a bit more convenient than the latter.) This PR switches back to Dates accordingly.

## Testing

- [x] Updated automated tests
- [x] Tested session time limits manually

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A
- [ ] ~I have added JSDoc comments to any newly introduced exports~ N/A