### PR TITLE
feat(scan): always use `nh-next` interpreter

### DIFF
--- a/apps/scan/backend/README.md
+++ b/apps/scan/backend/README.md
@@ -39,16 +39,6 @@ VxScan uses the Custom A4 scanner by default. To use the Plustek VTM-300, set
 SCANNER_MODEL=plustek pnpm start
 ```
 
-### `USE_NH_NEXT`
-
-VxScan uses the `@votingworks/ballot-interpreter-nh` package by default. To use
-the faster `@votingworks/ballot-interpreter-nh-next` package, set `USE_NH_NEXT`
-to `true`:
-
-```sh
-USE_NH_NEXT=true pnpm start
-```
-
 ## Testing
 
 ```sh

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -43,7 +43,7 @@ import {
 import { Workspace } from './util/workspace';
 import { Usb } from './util/usb';
 import { getMachineConfig } from './machine_config';
-import { CVR_EXPORT_FORMAT, USE_NH_NEXT } from './globals';
+import { CVR_EXPORT_FORMAT } from './globals';
 import { DefaultMarkThresholds } from './store';
 
 function constructAuthMachineState(
@@ -326,7 +326,6 @@ function buildApi(
         testMode: store.getTestMode(),
         markThresholdOverrides: store.getMarkThresholdOverrides(),
         ballotImagesPath: workspace.ballotImagesPath,
-        useNhNext: USE_NH_NEXT,
       });
       machine.scan();
     },

--- a/apps/scan/backend/src/env.d.ts
+++ b/apps/scan/backend/src/env.d.ts
@@ -9,7 +9,6 @@ declare namespace NodeJS {
     readonly VX_MACHINE_ID?: string;
     readonly VX_CODE_VERSION?: string;
     readonly CVR_EXPORT_FORMAT?: 'cdf' | 'vxf';
-    readonly USE_NH_NEXT?: string;
     readonly SCANNER_MODEL?: 'custom' | 'plustek';
   }
 }

--- a/apps/scan/backend/src/globals.ts
+++ b/apps/scan/backend/src/globals.ts
@@ -49,12 +49,6 @@ export const CVR_EXPORT_FORMAT = process.env.CVR_EXPORT_FORMAT ?? 'vxf';
  */
 export const { PLUSTEKCTL_PATH } = process.env;
 
-/**
- * Determines whether to the use next generation NH ballot interpreter.
- */
-export const USE_NH_NEXT =
-  process.env.USE_NH_NEXT === '1' || process.env.USE_NH_NEXT === 'true';
-
 const ScannerModelSchema = z.union([z.literal('custom'), z.literal('plustek')]);
 
 /**

--- a/apps/scan/backend/src/interpret.test.ts
+++ b/apps/scan/backend/src/interpret.test.ts
@@ -34,28 +34,24 @@ afterEach(async () => {
   await fs.rm(ballotImagesPath, { recursive: true });
 });
 
-test.each([true, false])(
-  'NH interpreter (next=%s) of overvote yields a sheet that needs to be reviewed',
-  async (useNhNext) => {
-    const interpreter = createInterpreter();
+test('NH interpreter of overvote yields a sheet that needs to be reviewed', async () => {
+  const interpreter = createInterpreter();
 
-    interpreter.configure({
-      electionDefinition:
-        electionGridLayoutNewHampshireAmherstFixtures.electionDefinition,
-      precinctSelection: ALL_PRECINCTS_SELECTION,
-      layouts: [],
-      ballotImagesPath,
-      testMode: true,
-      useNhNext,
-    });
+  interpreter.configure({
+    electionDefinition:
+      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition,
+    precinctSelection: ALL_PRECINCTS_SELECTION,
+    layouts: [],
+    ballotImagesPath,
+    testMode: true,
+  });
 
-    const result = await interpreter.interpret(
-      'foo-sheet-id',
-      ballotImages.overvoteBallot
-    );
-    expect(result.ok()?.type).toEqual('NeedsReviewSheet');
-  }
-);
+  const result = await interpreter.interpret(
+    'foo-sheet-id',
+    ballotImages.overvoteBallot
+  );
+  expect(result.ok()?.type).toEqual('NeedsReviewSheet');
+});
 
 test.each([true, false])(
   'NH interpreter with testMode=%s',
@@ -69,7 +65,6 @@ test.each([true, false])(
       layouts: [],
       ballotImagesPath,
       testMode,
-      useNhNext: true,
     });
 
     const sheet = (

--- a/apps/scan/backend/src/interpret.ts
+++ b/apps/scan/backend/src/interpret.ts
@@ -1,5 +1,4 @@
-import { interpret as interpretNh } from '@votingworks/ballot-interpreter-nh';
-import { interpretCompatible as interpretNhNext } from '@votingworks/ballot-interpreter-nh-next';
+import { interpretCompatible as interpretNh } from '@votingworks/ballot-interpreter-nh-next';
 import {
   AdjudicationReason,
   AdjudicationReasonInfo,
@@ -30,7 +29,6 @@ export interface InterpreterConfig {
   readonly ballotImagesPath: string;
   readonly markThresholdOverrides?: MarkThresholds;
   readonly testMode: boolean;
-  readonly useNhNext: boolean;
 }
 
 /**
@@ -171,16 +169,12 @@ async function nhInterpret(
 
   const { electionDefinition, ballotImagesPath, markThresholdOverrides } =
     config;
-  const result = await (config.useNhNext ? interpretNhNext : interpretNh)(
-    electionDefinition,
-    sheet,
-    {
-      isTestMode: config.testMode,
-      markThresholds: markThresholdOverrides,
-      adjudicationReasons:
-        electionDefinition.election.precinctScanAdjudicationReasons ?? [],
-    }
-  );
+  const result = await interpretNh(electionDefinition, sheet, {
+    isTestMode: config.testMode,
+    markThresholds: markThresholdOverrides,
+    adjudicationReasons:
+      electionDefinition.election.precinctScanAdjudicationReasons ?? [],
+  });
 
   timer.checkpoint('finishedInterpretation');
 

--- a/apps/scan/backend/src/vx_interpreter.test.ts
+++ b/apps/scan/backend/src/vx_interpreter.test.ts
@@ -108,7 +108,6 @@ test('properly scans a BMD ballot with a phantom QR code on back', async () => {
     testMode: true,
     layouts: [],
     ballotImagesPath: interpreterOutputPath,
-    useNhNext: false,
   });
 
   const interpretation = (

--- a/libs/ballot-interpreter-nh/src/interpret/index.ts
+++ b/libs/ballot-interpreter-nh/src/interpret/index.ts
@@ -51,6 +51,8 @@ export interface InterpretFileResult {
 
 /**
  * Interpret a ballot scan sheet.
+ *
+ * @deprecated Use `@votingworks/ballot-interpreter-nh-next` instead.
  */
 export async function interpret(
   electionDefinition: ElectionDefinition,


### PR DESCRIPTION

## Overview

It's shown to be reliable and fast, and it's too easy to forget the `USE_NH_NEXT` environment variable.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [ ] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
