### PR TITLE
[libs/ui] Let <Prose> override font size for <P> in legacy mode

### DIFF
--- a/apps/mark/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
@@ -194,7 +194,7 @@ exports[`Single Seat Contest 1`] = `
       class="c1"
     >
       <div
-        class="sc-fotPbf hFPARF"
+        class="sc-fotPbf iwtRsQ"
       >
         <p
           class="sc-bqiQRQ jKCqve"
@@ -220,7 +220,7 @@ exports[`Single Seat Contest 1`] = `
         id="contest-header"
       >
         <div
-          class="sc-fotPbf hFPARF"
+          class="sc-fotPbf iwtRsQ"
           id="audiofocus"
         >
           <h1
@@ -277,7 +277,7 @@ exports[`Single Seat Contest 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -303,7 +303,7 @@ exports[`Single Seat Contest 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -329,7 +329,7 @@ exports[`Single Seat Contest 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -355,7 +355,7 @@ exports[`Single Seat Contest 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -381,7 +381,7 @@ exports[`Single Seat Contest 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -407,7 +407,7 @@ exports[`Single Seat Contest 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"

--- a/apps/mark/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
@@ -242,7 +242,7 @@ exports[`Single Seat Contest 1`] = `
       class="c1"
     >
       <div
-        class="sc-fotPbf hFPARF"
+        class="sc-fotPbf iwtRsQ"
       >
         <p
           class="sc-bqiQRQ jKCqve"
@@ -268,7 +268,7 @@ exports[`Single Seat Contest 1`] = `
         id="contest-header"
       >
         <div
-          class="sc-fotPbf hFPARF"
+          class="sc-fotPbf iwtRsQ"
           id="audiofocus"
         >
           <h1
@@ -332,7 +332,7 @@ exports[`Single Seat Contest 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -359,7 +359,7 @@ exports[`Single Seat Contest 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -386,7 +386,7 @@ exports[`Single Seat Contest 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -413,7 +413,7 @@ exports[`Single Seat Contest 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -440,7 +440,7 @@ exports[`Single Seat Contest 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -467,7 +467,7 @@ exports[`Single Seat Contest 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -494,7 +494,7 @@ exports[`Single Seat Contest 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -521,7 +521,7 @@ exports[`Single Seat Contest 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -548,7 +548,7 @@ exports[`Single Seat Contest 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -575,7 +575,7 @@ exports[`Single Seat Contest 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -602,7 +602,7 @@ exports[`Single Seat Contest 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -628,7 +628,7 @@ exports[`Single Seat Contest 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       aria-label="add write-in candidate."

--- a/apps/mark/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
@@ -242,7 +242,7 @@ exports[`Single Seat Contest 1`] = `
       class="c1"
     >
       <div
-        class="sc-fotPbf hFPARF"
+        class="sc-fotPbf iwtRsQ"
       >
         <p
           class="sc-bqiQRQ jKCqve"
@@ -268,7 +268,7 @@ exports[`Single Seat Contest 1`] = `
         id="contest-header"
       >
         <div
-          class="sc-fotPbf hFPARF"
+          class="sc-fotPbf iwtRsQ"
           id="audiofocus"
         >
           <h1
@@ -332,7 +332,7 @@ exports[`Single Seat Contest 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -359,7 +359,7 @@ exports[`Single Seat Contest 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -386,7 +386,7 @@ exports[`Single Seat Contest 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -413,7 +413,7 @@ exports[`Single Seat Contest 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -440,7 +440,7 @@ exports[`Single Seat Contest 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -467,7 +467,7 @@ exports[`Single Seat Contest 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"

--- a/apps/mark/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
@@ -194,7 +194,7 @@ exports[`Single Seat Contest with Write In 1`] = `
       class="c1"
     >
       <div
-        class="sc-fotPbf hFPARF"
+        class="sc-fotPbf iwtRsQ"
       >
         <p
           class="sc-bqiQRQ jKCqve"
@@ -220,7 +220,7 @@ exports[`Single Seat Contest with Write In 1`] = `
         id="contest-header"
       >
         <div
-          class="sc-fotPbf hFPARF"
+          class="sc-fotPbf iwtRsQ"
           id="audiofocus"
         >
           <h1
@@ -277,7 +277,7 @@ exports[`Single Seat Contest with Write In 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -303,7 +303,7 @@ exports[`Single Seat Contest with Write In 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       aria-label="add write-in candidate."

--- a/apps/mark/frontend/src/components/__snapshots__/election_info.test.tsx.snap
+++ b/apps/mark/frontend/src/components/__snapshots__/election_info.test.tsx.snap
@@ -211,7 +211,7 @@ exports[`renders horizontal ElectionInfo with hash when specified 1`] = `
         </svg>
       </div>
       <div
-        class="sc-fotPbf hPPIJd"
+        class="sc-fotPbf hdnDAU"
       >
         <h5
           aria-label=" General Election."
@@ -462,7 +462,7 @@ exports[`renders horizontal ElectionInfo without hash by default 1`] = `
         </svg>
       </div>
       <div
-        class="sc-fotPbf hPPIJd"
+        class="sc-fotPbf hdnDAU"
       >
         <h5
           aria-label=" General Election."
@@ -690,7 +690,7 @@ exports[`renders vertical ElectionInfo with hash when specified 1`] = `
       </svg>
     </div>
     <div
-      class="sc-fotPbf jGmaPB"
+      class="sc-fotPbf ljYHag"
     >
       <h1
         aria-label=" General Election."
@@ -908,7 +908,7 @@ exports[`renders vertical ElectionInfo without hash by default 1`] = `
       </svg>
     </div>
     <div
-      class="sc-fotPbf jGmaPB"
+      class="sc-fotPbf ljYHag"
     >
       <h1
         aria-label=" General Election."

--- a/apps/mark/frontend/src/components/__snapshots__/yes_no_contest.test.tsx.snap
+++ b/apps/mark/frontend/src/components/__snapshots__/yes_no_contest.test.tsx.snap
@@ -131,7 +131,7 @@ exports[`supports yes/no contest allows voting for both yes and no 1`] = `
       id="contest-header"
     >
       <div
-        class="sc-fotPbf hFPARF"
+        class="sc-fotPbf iwtRsQ"
         id="audiofocus"
       >
         <h1
@@ -176,7 +176,7 @@ exports[`supports yes/no contest allows voting for both yes and no 1`] = `
             class="c5"
           >
             <div
-              class="sc-fotPbf hFPARF"
+              class="sc-fotPbf iwtRsQ"
             >
               <p
                 class="sc-bqiQRQ bIFmdQ"
@@ -211,7 +211,7 @@ exports[`supports yes/no contest allows voting for both yes and no 1`] = `
             class="sc-giYgFv hVfOtt"
           >
             <div
-              class="sc-fotPbf hFPARF"
+              class="sc-fotPbf iwtRsQ"
             >
               <p
                 aria-label=" Yes on Ballot Measure 3"
@@ -234,7 +234,7 @@ exports[`supports yes/no contest allows voting for both yes and no 1`] = `
             class="sc-giYgFv hVfOtt"
           >
             <div
-              class="sc-fotPbf hFPARF"
+              class="sc-fotPbf iwtRsQ"
             >
               <p
                 aria-label=" No on Ballot Measure 3"
@@ -430,7 +430,7 @@ exports[`supports yes/no contest displays warning when attempting to change vote
       id="contest-header"
     >
       <div
-        class="sc-fotPbf hFPARF"
+        class="sc-fotPbf iwtRsQ"
         id="audiofocus"
       >
         <h1
@@ -475,7 +475,7 @@ exports[`supports yes/no contest displays warning when attempting to change vote
             class="c5"
           >
             <div
-              class="sc-fotPbf hFPARF"
+              class="sc-fotPbf iwtRsQ"
             >
               <p
                 class="sc-bqiQRQ bIFmdQ"
@@ -510,7 +510,7 @@ exports[`supports yes/no contest displays warning when attempting to change vote
             class="sc-giYgFv hVfOtt"
           >
             <div
-              class="sc-fotPbf hFPARF"
+              class="sc-fotPbf iwtRsQ"
             >
               <p
                 aria-label="Selected, Yes on Ballot Measure 3"
@@ -533,7 +533,7 @@ exports[`supports yes/no contest displays warning when attempting to change vote
             class="sc-giYgFv hVfOtt"
           >
             <div
-              class="sc-fotPbf hFPARF"
+              class="sc-fotPbf iwtRsQ"
             >
               <p
                 aria-label=" No on Ballot Measure 3"

--- a/apps/mark/frontend/src/pages/__snapshots__/cast_ballot_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/cast_ballot_page.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`renders CastBallotPage 1`] = `
     class="sc-jObXwK hbqLlw"
   >
     <div
-      class="sc-fotPbf kMOLcm"
+      class="sc-fotPbf iNBQun"
       id="audiofocus"
     >
       <h1

--- a/apps/mark/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
@@ -183,7 +183,7 @@ exports[`Renders ContestPage 1`] = `
       class="c0"
     >
       <div
-        class="sc-fotPbf hFPARF"
+        class="sc-fotPbf iwtRsQ"
       >
         <p
           class="sc-bqiQRQ jKCqve"
@@ -209,7 +209,7 @@ exports[`Renders ContestPage 1`] = `
         id="contest-header"
       >
         <div
-          class="sc-fotPbf hFPARF"
+          class="sc-fotPbf iwtRsQ"
           id="audiofocus"
         >
           <h1
@@ -266,7 +266,7 @@ exports[`Renders ContestPage 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -293,7 +293,7 @@ exports[`Renders ContestPage 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -320,7 +320,7 @@ exports[`Renders ContestPage 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -347,7 +347,7 @@ exports[`Renders ContestPage 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -374,7 +374,7 @@ exports[`Renders ContestPage 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -401,7 +401,7 @@ exports[`Renders ContestPage 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -711,7 +711,7 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
         id="contest-header"
       >
         <div
-          class="sc-fotPbf hFPARF"
+          class="sc-fotPbf iwtRsQ"
           id="audiofocus"
         >
           <h1
@@ -768,7 +768,7 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -795,7 +795,7 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -822,7 +822,7 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -849,7 +849,7 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -876,7 +876,7 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -903,7 +903,7 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                   class="sc-giYgFv hVfOtt"
                 >
                   <div
-                    class="sc-fotPbf hFPARF"
+                    class="sc-fotPbf iwtRsQ"
                   >
                     <p
                       class="sc-bqiQRQ eyxUBE"
@@ -929,7 +929,7 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
         class="c8"
       >
         <div
-          class="sc-fotPbf hFPARF"
+          class="sc-fotPbf iwtRsQ"
         >
           <p
             class="sc-bqiQRQ boCaWT"
@@ -1012,7 +1012,7 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
               class="c15"
             />
             <div
-              class="sc-fotPbf hPPIJd"
+              class="sc-fotPbf hdnDAU"
             >
               <h5
                 aria-label=" General Election."

--- a/apps/mark/frontend/src/pages/__snapshots__/not_found_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/not_found_page.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`renders NotFoundPage 1`] = `
     class="sc-jObXwK hbqLlw"
   >
     <div
-      class="sc-fotPbf jGmaPB"
+      class="sc-fotPbf ljYHag"
     >
       <h1>
         Page Not Found.

--- a/apps/mark/frontend/src/pages/__snapshots__/start_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/start_page.test.tsx.snap
@@ -123,7 +123,7 @@ exports[`renders StartPage 1`] = `
         />
       </div>
       <div
-        class="sc-fotPbf jGmaPB"
+        class="sc-fotPbf ljYHag"
       >
         <h1
           aria-label="Democratic Primary Election."
@@ -176,7 +176,7 @@ exports[`renders StartPage 1`] = `
     class="c3"
   >
     <div
-      class="sc-fotPbf jGmaPB"
+      class="sc-fotPbf ljYHag"
     >
       <p
         class="c4"
@@ -529,7 +529,7 @@ exports[`renders StartPage with inline SVG 1`] = `
         </svg>
       </div>
       <div
-        class="sc-fotPbf jGmaPB"
+        class="sc-fotPbf ljYHag"
       >
         <h1
           aria-label=" General Election."
@@ -582,7 +582,7 @@ exports[`renders StartPage with inline SVG 1`] = `
     class="c2"
   >
     <div
-      class="sc-fotPbf jGmaPB"
+      class="sc-fotPbf ljYHag"
     >
       <p
         class="c3"
@@ -771,7 +771,7 @@ exports[`renders StartPage with no seal 1`] = `
         class="c1"
       />
       <div
-        class="sc-fotPbf jGmaPB"
+        class="sc-fotPbf ljYHag"
       >
         <h1
           aria-label=" General Election."
@@ -824,7 +824,7 @@ exports[`renders StartPage with no seal 1`] = `
     class="c2"
   >
     <div
-      class="sc-fotPbf jGmaPB"
+      class="sc-fotPbf ljYHag"
     >
       <p
         class="c3"

--- a/libs/ui/src/__snapshots__/bmd_paper_ballot.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/bmd_paper_ballot.test.tsx.snap
@@ -28,6 +28,10 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
   line-height: 1.2;
 }
 
+.c2 p {
+  font-size: 1em;
+}
+
 .c2 h1 {
   margin: 2em 0 1em;
   line-height: 1.1;
@@ -107,6 +111,10 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
 .c9 {
   max-width: 66ch;
   line-height: 1.2;
+}
+
+.c9 p {
+  font-size: 1em;
 }
 
 .c9 h1 {

--- a/libs/ui/src/__snapshots__/loading.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/loading.test.tsx.snap
@@ -28,6 +28,10 @@ exports[`Renders Loading with defaults 1`] = `
   line-height: 1.2;
 }
 
+.c0 p {
+  font-size: 1em;
+}
+
 .c0 h1 {
   margin: 2em 0 1em;
   line-height: 1.1;

--- a/libs/ui/src/__snapshots__/prose.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/prose.test.tsx.snap
@@ -6,6 +6,10 @@ exports[`renders Prose with defaults 1`] = `
   line-height: 1.2;
 }
 
+.c0 p {
+  font-size: 1em;
+}
+
 .c0 h1 {
   margin: 2em 0 1em;
   line-height: 1.1;
@@ -135,6 +139,10 @@ exports[`renders Prose with right-aligned text 1`] = `
   max-width: 66ch;
   text-align: right;
   line-height: 1.2;
+}
+
+.c0 p {
+  font-size: 1em;
 }
 
 .c0 h1 {
@@ -267,6 +275,10 @@ exports[`renders Prose with theme 1`] = `
   line-height: 1.2;
   color: #666666;
   font-size: 10px;
+}
+
+.c0 p {
+  font-size: 1em;
 }
 
 .c0 h1 {

--- a/libs/ui/src/__snapshots__/setup_card_reader_page.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/setup_card_reader_page.test.tsx.snap
@@ -30,6 +30,10 @@ exports[`renders SetupCardReaderPage with no useEffect trigger as expected 1`] =
   font-size: 56px;
 }
 
+.c2 p {
+  font-size: 1em;
+}
+
 .c2 h1 {
   margin: 2em 0 1em;
   line-height: 1.1;

--- a/libs/ui/src/prose.tsx
+++ b/libs/ui/src/prose.tsx
@@ -32,6 +32,9 @@ const legacyStyles = css<ProseProps>`
   line-height: 1.2;
   color: ${({ themeDeprecated }) => themeDeprecated?.color};
   font-size: ${({ themeDeprecated }) => themeDeprecated?.fontSize};
+  & p {
+    font-size: 1em;
+  }
   & h1 {
     margin: 2em 0 1em;
     line-height: 1.1;


### PR DESCRIPTION
## Overview

_Note: Relevant change is in e243ea1ff6be824928ad949d8b1d0d1064543d56 -- the 2nd commit is just test snapshot updates_

Missed this edge case in https://github.com/votingworks/vxsuite/pull/3252 - the `Prose` component was already overriding font sizes for heading components, but not explicitly doing so for paragraph (`p`) elements.

Adding an override for `p` now to preserve old styling when using the legacy theme.

## Demo Video or Screenshot
### Before/After:
<img width="300" src="https://user-images.githubusercontent.com/264902/231266264-4cf2c254-a902-4c88-9f36-a24b512e7a45.png"> <img width="300" src="https://user-images.githubusercontent.com/264902/231266324-c47df1a8-77ac-41e2-84a8-37a0260ff296.png">

## Testing Plan
- Visual verification
- Updated changed snapshots

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
- ~[ ] I have added JSDoc comments to any newly introduced exports~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
