### PR TITLE
[VxScan] Enable VVSG 2.0 default themes

### DIFF
--- a/apps/scan/frontend/src/scan_app_base.tsx
+++ b/apps/scan/frontend/src/scan_app_base.tsx
@@ -1,16 +1,15 @@
 import React from 'react';
 
 import { AppBase } from '@votingworks/ui';
+import { ColorMode, ScreenType, SizeMode } from '@votingworks/types';
 
 export interface AppBaseProps {
   children: React.ReactNode;
 }
 
-// Copied from old App.css
-const BASE_FONT_SIZE_PX = 28;
-
-// TODO: Default to high contrast and vary based on user selection.
-const DEFAULT_COLOR_MODE = 'legacy';
+const DEFAULT_COLOR_MODE: ColorMode = 'contrastMedium';
+const DEFAULT_SCREEN_TYPE: ScreenType = 'elo15';
+const DEFAULT_SIZE_MODE: SizeMode = 'm';
 
 /**
  * Installs global styles and UI themes - should be rendered at the root of the
@@ -21,7 +20,8 @@ export function ScanAppBase({ children }: AppBaseProps): JSX.Element {
     <AppBase
       colorMode={DEFAULT_COLOR_MODE}
       isTouchscreen
-      legacyBaseFontSizePx={BASE_FONT_SIZE_PX}
+      screenType={DEFAULT_SCREEN_TYPE}
+      sizeMode={DEFAULT_SIZE_MODE}
     >
       {children}
     </AppBase>

--- a/libs/types/src/ui_theme.ts
+++ b/libs/types/src/ui_theme.ts
@@ -1,3 +1,6 @@
+/** Supported screen types for VxSuite apps. */
+export type ScreenType = 'builtIn' | 'elo13' | 'elo15';
+
 /** Options for supported UI color themes. */
 export type ColorMode =
   | 'contrastHighDark'
@@ -85,6 +88,7 @@ export interface SizeTheme {
 export interface UiTheme {
   readonly colorMode: ColorMode;
   readonly colors: ColorTheme;
+  readonly screenType: ScreenType;
   readonly sizeMode: SizeMode;
   readonly sizes: SizeTheme;
 }

--- a/libs/ui/src/app_base.tsx
+++ b/libs/ui/src/app_base.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { ThemeProvider } from 'styled-components';
 
-import { ColorMode, SizeMode, UiTheme } from '@votingworks/types';
+import { ColorMode, ScreenType, SizeMode, UiTheme } from '@votingworks/types';
 
 import { GlobalStyles } from './global_styles';
 import { makeTheme } from './themes/make_theme';
@@ -28,6 +28,7 @@ export interface AppBaseProps {
   isTouchscreen?: boolean;
   legacyBaseFontSizePx?: number;
   legacyPrintFontSizePx?: number;
+  screenType?: ScreenType;
   sizeMode?: SizeMode;
 }
 
@@ -42,12 +43,13 @@ export function AppBase(props: AppBaseProps): JSX.Element {
     isTouchscreen = false,
     legacyBaseFontSizePx,
     legacyPrintFontSizePx,
+    screenType = 'builtIn',
     sizeMode = 'legacy',
   } = props;
 
   const theme = useMemo(
-    () => makeTheme({ colorMode, sizeMode }),
-    [colorMode, sizeMode]
+    () => makeTheme({ colorMode, screenType, sizeMode }),
+    [colorMode, screenType, sizeMode]
   );
 
   return (

--- a/libs/ui/src/themes/make_theme.test.ts
+++ b/libs/ui/src/themes/make_theme.test.ts
@@ -34,3 +34,18 @@ test('varies theme based on selected modes', () => {
     darkThemeXl.sizes.fontDefault
   );
 });
+
+test('varies sizes based on screen type', () => {
+  const elo13ScreenTheme = makeTheme({
+    colorMode: 'contrastMedium',
+    screenType: 'elo13',
+    sizeMode: 's',
+  });
+  const elo15ScreenTheme = makeTheme({
+    colorMode: 'contrastMedium',
+    screenType: 'elo15',
+    sizeMode: 's',
+  });
+
+  expect(elo13ScreenTheme.sizes).not.toEqual(elo15ScreenTheme.sizes);
+});


### PR DESCRIPTION
## Overview

Related to: https://github.com/votingworks/vxsuite/issues/3185

Enabling the new VVSG-compliant size/color themes by default in VxScan:
- Merging in the the changes to the theme generation logic in `make_theme` from the `nh-demo` branch - includes an additional `screenType` parameter that we use to calculate the expected pixel density of the screen so we can set font sizes accurately, particularly for the `elo13` and `elo15` screens. The `builtIn` screen type option simply falls back to the web standard 72 PPI, multiplied by `window.devicePixelRatio`.
- Setting the VxScan default theme in `ScanAppBase` to `contrastMedium` color mode and `m` size mode

## Demo Video or Screenshot
### Before/After:
<img width="300" src="https://user-images.githubusercontent.com/264902/231281782-5e442dfb-0503-4e45-8f9a-6561ddafecc0.png"> <img width="300" src="https://user-images.githubusercontent.com/264902/231281841-caba8d0b-114e-458e-9e9e-cbd09097ccc6.png">

## Testing Plan
- Added a test case for the screen-type-based theme variation
- Light manual testing to verify changes - will be tweaking styles over time, so nothing's fully final yet.

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
- [x] I have added JSDoc comments to any newly introduced exports
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
