### PR TITLE
[libs/ui] Update <Caption> to work with <Prose> in legacy mode

### DIFF
--- a/libs/ui/src/__snapshots__/election_info_bar.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/election_info_bar.test.tsx.snap
@@ -28,14 +28,14 @@ exports[`Renders ElectionInfoBar with appropriate information 1`] = `
   font-weight: 400;
   line-height: 1.2;
   margin: 0;
-  font-size: 0.75rem;
+  font-size: 0.75em;
 }
 
 .c9 {
   font-size: 1em;
   line-height: 1.2;
   margin: 0;
-  font-size: 0.75rem;
+  font-size: 0.75em;
 }
 
 .c12 {
@@ -44,7 +44,7 @@ exports[`Renders ElectionInfoBar with appropriate information 1`] = `
   line-height: 1.2;
   margin: 0;
   white-space: nowrap;
-  font-size: 0.75rem;
+  font-size: 0.75em;
 }
 
 .c13 {
@@ -52,7 +52,7 @@ exports[`Renders ElectionInfoBar with appropriate information 1`] = `
   line-height: 1.2;
   margin: 0;
   white-space: nowrap;
-  font-size: 0.75rem;
+  font-size: 0.75em;
 }
 
 .c5 {

--- a/libs/ui/src/typography.tsx
+++ b/libs/ui/src/typography.tsx
@@ -69,7 +69,12 @@ const StyledFont = styled.span<FontProps>`
 const StyledCaption = styled.span<FontProps>`
   ${fontStyles}
 
-  font-size: 0.75rem;
+  /*
+   * Legacy styling wraps text elements with a <Prose> component on which a base
+   * font size is set, so we preserve that behaviour by using em instead of rem
+   * when using the "legacy" size theme.
+   */
+  font-size: ${(p) => (p.theme.sizeMode === 'legacy' ? '0.75em' : '0.75rem')};
 `;
 
 const StyledP = styled.p<FontProps>`


### PR DESCRIPTION
## Overview

Similar to https://github.com/votingworks/vxsuite/pull/3259, the old `<Prose>` component is intended to override font sizes for child elements, but since the new `<Caption>` component sets an explicit `rem`-based font-size, that slipped through the cracks in previous PRs.

This conditionally sets the `<Caption>` size to `0.75em` or `0.75rem`, for legacy and VVSG-compliant themes respectively.

## Demo Video or Screenshot
### Before/After: 
<img width="300" src="https://user-images.githubusercontent.com/264902/231284936-0fee8998-1615-4e22-bb3f-8a10a7acb56e.png"> <img width="300" src="https://user-images.githubusercontent.com/264902/231284984-d00f73cb-7dca-440c-8c05-dce5cf5b314a.png">

## Testing Plan
- Visual verification

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
- ~[ ] I have added JSDoc comments to any newly introduced exports~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
