### PR TITLE
add power down button to vxscan

### DIFF
--- a/apps/scan/frontend/src/screens/poll_worker_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.test.tsx
@@ -279,7 +279,8 @@ test('no transitions from polls closed final', async () => {
   await screen.findByText(
     'Voting is complete and the polls cannot be reopened.'
   );
-  expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  // There should only be the power down button
+  expect(screen.queryAllByRole('button')).toHaveLength(1);
 });
 
 // confirm that we have an alert and logging that meet VVSG 2.0 1.1.3-B

--- a/apps/scan/frontend/src/screens/poll_worker_screen.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.tsx
@@ -14,6 +14,7 @@ import {
   LoadingAnimation,
   H1,
   P,
+  PowerDownButton,
 } from '@votingworks/ui';
 import {
   BallotCountDetails,
@@ -660,6 +661,7 @@ export function PollWorkerScreen({
       <Prose textCenter>
         <H1>Poll Worker Actions</H1>
         {pollsTransitionActions}
+        <PowerDownButton logger={logger} userRole="poll_worker" />
         {isFeatureFlagEnabled(BooleanEnvironmentVariableName.LIVECHECK) && (
           <P>
             <Button onPress={() => setIsShowingLiveCheck(true)}>

--- a/libs/@types/kiosk-browser/kiosk-browser.d.ts
+++ b/libs/@types/kiosk-browser/kiosk-browser.d.ts
@@ -260,6 +260,8 @@ declare namespace KioskBrowser {
 
     rebootToBios(): Promise<void>;
 
+    powerDown(): Promise<void>;
+
     prepareToBootFromUsb(): Promise<boolean>;
   }
 }

--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -358,6 +358,10 @@ IDs are logged with each log to identify the log being written.
 **Type:** [user-action](#user-action)  
 **Description:** User has triggered a reboot of the machine.  
 **Machines:** All
+### power-down-machine
+**Type:** [user-action](#user-action)  
+**Description:** User has triggered the machine to power down.  
+**Machines:** All
 ### ballot-package-load-from-usb-complete
 **Type:** [user-action](#user-action)  
 **Description:** The ballot package has been read from the USB drive. Success or failure indicated by disposition.  

--- a/libs/logging/src/log_documentation.test.ts
+++ b/libs/logging/src/log_documentation.test.ts
@@ -27,7 +27,7 @@ describe('test cdf documentation generation', () => {
     expect(structuredData.DeviceModel).toEqual('VxAdmin 1.0');
     expect(structuredData.GeneratedDate).toEqual('2020-07-24T00:00:00.000Z');
     expect(structuredData.EventTypeDescription).toHaveLength(5);
-    expect(structuredData.EventIdDescription).toHaveLength(55);
+    expect(structuredData.EventIdDescription).toHaveLength(56);
     // Make sure VxAdminFrontend specific logs are included.
     expect(structuredData.EventIdDescription).toContainEqual(
       expect.objectContaining({
@@ -65,7 +65,7 @@ describe('test cdf documentation generation', () => {
     expect(structuredData.DeviceModel).toEqual('VxCentralScan');
     expect(structuredData.GeneratedDate).toEqual('2020-07-24T00:00:00.000Z');
     expect(structuredData.EventTypeDescription).toHaveLength(5);
-    expect(structuredData.EventIdDescription).toHaveLength(60);
+    expect(structuredData.EventIdDescription).toHaveLength(61);
     // Make sure VxCentralScanApp specific logs are included.
     expect(structuredData.EventIdDescription).toContainEqual(
       expect.objectContaining({

--- a/libs/logging/src/log_event_ids.ts
+++ b/libs/logging/src/log_event_ids.ts
@@ -107,6 +107,7 @@ export enum LogEventId {
   PrepareBootFromUsbInit = 'prepare-boot-from-usb-init',
   PrepareBootFromUsbComplete = 'prepare-boot-from-usb-complete',
   RebootMachine = 'reboot-machine',
+  PowerDown = 'power-down-machine',
   BallotPackageLoadedFromUsb = 'ballot-package-load-from-usb-complete',
 
   // Precinct Machine (VxMark + VxScan) State
@@ -765,6 +766,11 @@ const RebootMachine: LogDetails = {
   eventType: LogEventType.UserAction,
   documentationMessage: 'User has triggered a reboot of the machine.',
 };
+const PowerDown: LogDetails = {
+  eventId: LogEventId.PowerDown,
+  eventType: LogEventType.UserAction,
+  documentationMessage: 'User has triggered the machine to power down.',
+};
 
 const PollsOpened: LogDetails = {
   eventId: LogEventId.PollsOpened,
@@ -1067,6 +1073,8 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return PrepareBootFromUsbComplete;
     case LogEventId.RebootMachine:
       return RebootMachine;
+    case LogEventId.PowerDown:
+      return PowerDown;
     case LogEventId.PollsOpened:
       return PollsOpened;
     case LogEventId.VotingPaused:

--- a/libs/test-utils/src/fake_kiosk.ts
+++ b/libs/test-utils/src/fake_kiosk.ts
@@ -108,5 +108,6 @@ export function fakeKiosk({
     reboot: jest.fn(),
     rebootToBios: jest.fn(),
     prepareToBootFromUsb: jest.fn(),
+    powerDown: jest.fn(),
   };
 }

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -80,3 +80,4 @@ export * from './export_logs_modal';
 export * from './graphics';
 export * from './types';
 export * from './unconfigured_election_screen';
+export * from './power_down_button';

--- a/libs/ui/src/power_down_button.test.tsx
+++ b/libs/ui/src/power_down_button.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { fakeKiosk } from '@votingworks/test-utils';
+import { Logger, LogSource } from '@votingworks/logging';
+import { render, screen, waitFor } from '../test/react_testing_library';
+
+import { PowerDownButton } from './power_down_button';
+
+beforeEach(() => {
+  window.kiosk = fakeKiosk();
+});
+
+test('renders as expected.', async () => {
+  render(
+    <PowerDownButton
+      logger={new Logger(LogSource.VxAdminFrontend)}
+      userRole="poll_worker"
+    />
+  );
+
+  userEvent.click(screen.getByText('Power Down'));
+  await screen.findByText(/Powering Down/);
+  await waitFor(() => expect(window.kiosk!.powerDown).toHaveBeenCalledTimes(1));
+});

--- a/libs/ui/src/power_down_button.tsx
+++ b/libs/ui/src/power_down_button.tsx
@@ -1,0 +1,32 @@
+import { LogEventId, Logger } from '@votingworks/logging';
+import { assert } from '@votingworks/basics';
+import React, { useState } from 'react';
+import { UserRole } from '@votingworks/types';
+import { Button } from './button';
+import { Loading } from './loading';
+import { Modal } from './modal';
+
+interface Props {
+  logger: Logger;
+  userRole: UserRole;
+}
+
+/**
+ * Button that powers down the machine.
+ */
+export function PowerDownButton({ logger, userRole }: Props): JSX.Element {
+  const [isPoweringDown, setIsPoweringDown] = useState(false);
+  async function reboot() {
+    assert(window.kiosk);
+    await logger.log(LogEventId.PowerDown, userRole, {
+      message: 'User triggered the machine to power down.',
+    });
+    setIsPoweringDown(true);
+    await window.kiosk.powerDown();
+  }
+
+  if (isPoweringDown) {
+    return <Modal content={<Loading>Powering Down</Loading>} />;
+  }
+  return <Button onPress={reboot}>Power Down</Button>;
+}

--- a/libs/ui/src/system_administrator_screen_contents.tsx
+++ b/libs/ui/src/system_administrator_screen_contents.tsx
@@ -11,6 +11,7 @@ import { UnconfigureMachineButton } from './unconfigure_machine_button';
 import { ResetPollsToPausedButton } from './reset_polls_to_paused_button';
 import { UsbDriveStatus } from './hooks/use_usb_drive';
 import { P } from './typography';
+import { PowerDownButton } from './power_down_button';
 
 interface Props {
   displayRemoveCardToLeavePrompt?: boolean;
@@ -61,6 +62,9 @@ export function SystemAdministratorScreenContents({
         </P>
         <P>
           <RebootToBiosButton logger={logger} />
+        </P>
+        <P>
+          <PowerDownButton logger={logger} userRole="system_administrator" />
         </P>
         <P>
           <UnconfigureMachineButton


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/3178
<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot

https://user-images.githubusercontent.com/14897017/231341026-c8d4e465-3eef-4ff9-a031-aec1600be599.mov



## Testing Plan

Manually tested through both poll worker and sys admin screens, will require locked down image testing to some degree. 

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
