### PR TITLE
feat(nh-next): Return normalized images and computed ballot layouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,7 @@ dependencies = [
  "clap",
  "image",
  "imageproc",
+ "itertools",
  "log",
  "logging_timer",
  "neon",

--- a/apps/central-scan/backend/src/cvrs/export.ts
+++ b/apps/central-scan/backend/src/cvrs/export.ts
@@ -94,11 +94,12 @@ export async function* exportCastVoteRecords({
       includeImages && isHmpbSheet(interpretation)
         ? mapSheet(
             interpretation,
-            ({ metadata }) =>
-              store.getBallotPageLayoutForMetadata(
+            ({ metadata, layout }) =>
+              layout ??
+              (store.getBallotPageLayoutForMetadata(
                 metadata,
                 electionDefinition
-              ) as BallotPageLayout
+              ) as BallotPageLayout)
           )
         : undefined
     );

--- a/apps/scan/backend/src/cvrs/export.ts
+++ b/apps/scan/backend/src/cvrs/export.ts
@@ -100,11 +100,12 @@ export async function* exportCastVoteRecords({
       includeImages && isHmpbSheet(interpretation)
         ? mapSheet(
             interpretation,
-            ({ metadata }) =>
-              store.getBallotPageLayoutForMetadata(
+            ({ metadata, layout }) =>
+              layout ??
+              (store.getBallotPageLayoutForMetadata(
                 metadata,
                 electionDefinition
-              ) as BallotPageLayout
+              ) as BallotPageLayout)
           )
         : undefined
     );

--- a/libs/backend/src/scan/cast_vote_records/export.ts
+++ b/libs/backend/src/scan/cast_vote_records/export.ts
@@ -1,5 +1,6 @@
 import {
   BallotIdSchema,
+  BallotPageLayout,
   BallotPageMetadata,
   BatchInfo,
   CVR,
@@ -255,6 +256,7 @@ async function exportPageImageAndLayoutToUsbDrive({
   exporter,
   bucket,
   imageFilename,
+  computedLayout,
   ballotPageLayoutsLookup,
   ballotPageMetadata,
   election,
@@ -263,16 +265,19 @@ async function exportPageImageAndLayoutToUsbDrive({
   exporter: Exporter;
   bucket: string;
   imageFilename: string;
+  computedLayout?: BallotPageLayout;
   ballotPageLayoutsLookup: BallotPageLayoutsLookup;
   ballotPageMetadata: BallotPageMetadata;
   election: Election;
   batchId: string;
 }): Promise<Result<void, ExportDataError>> {
-  const layout = getBallotPageLayout({
-    ballotPageMetadata,
-    ballotPageLayoutsLookup,
-    election,
-  });
+  const layout =
+    computedLayout ??
+    getBallotPageLayout({
+      ballotPageMetadata,
+      ballotPageLayoutsLookup,
+      election,
+    });
   const exportImageResult = await exporter.exportDataToUsbDrive(
     bucket,
     join(CVR_BALLOT_IMAGES_SUBDIRECTORY, batchId, basename(imageFilename)),
@@ -413,6 +418,7 @@ export async function exportCastVoteRecordReportToUsbDrive({
           exporter,
           bucket: reportDirectory,
           imageFilename: frontFilename,
+          computedLayout: front.layout,
           ballotPageMetadata: front.metadata,
           ballotPageLayoutsLookup,
           election,
@@ -430,6 +436,7 @@ export async function exportCastVoteRecordReportToUsbDrive({
           exporter,
           bucket: reportDirectory,
           imageFilename: backFilename,
+          computedLayout: back.layout,
           ballotPageMetadata: back.metadata,
           ballotPageLayoutsLookup,
           election,

--- a/libs/ballot-interpreter-nh-next/Cargo.toml
+++ b/libs/ballot-interpreter-nh-next/Cargo.toml
@@ -21,6 +21,7 @@ rayon = "1.5.3"
 rusttype = "0.9.3"
 serde = { version = "1.0.150", features = ["derive"] }
 serde_json = "1.0.89"
+itertools = "0.10.5"
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/libs/ballot-interpreter-nh-next/README.md
+++ b/libs/ballot-interpreter-nh-next/README.md
@@ -12,8 +12,11 @@ This library requires a
 [supported version of Node and Rust](https://github.com/neon-bindings/neon#platform-support).
 The easiest way to install Rust is via [rustup](https://rustup.rs/).
 
-This fully installs the project, including installing any dependencies and
-running the build.
+Then run:
+
+```sh
+$ pnpm install
+```
 
 ## Build
 

--- a/libs/ballot-interpreter-nh-next/package.json
+++ b/libs/ballot-interpreter-nh-next/package.json
@@ -25,10 +25,12 @@
   "dependencies": {
     "@votingworks/ballot-interpreter-nh": "workspace:*",
     "@votingworks/basics": "workspace:*",
+    "@votingworks/image-utils": "workspace:*",
     "@votingworks/types": "workspace:*",
     "@votingworks/utils": "workspace:*",
     "better-sqlite3": "^8.2.0",
-    "chalk": "^4.1.2"
+    "chalk": "^4.1.2",
+    "tmp": "^0.2.1"
   },
   "devDependencies": {
     "@jest/types": "^29.5.0",
@@ -36,6 +38,7 @@
     "@types/chalk": "^2.2.0",
     "@types/jest": "^29.4.0",
     "@types/node": "16.18.23",
+    "@types/tmp": "^0.2.3",
     "@typescript-eslint/eslint-plugin": "5.37.0",
     "@typescript-eslint/parser": "5.37.0",
     "@votingworks/fixtures": "workspace:*",

--- a/libs/ballot-interpreter-nh-next/src/election.rs
+++ b/libs/ballot-interpreter-nh-next/src/election.rs
@@ -85,7 +85,7 @@ impl GridPosition {
         match self {
             Self::Option { option_id, .. } => option_id.clone(),
             Self::WriteIn { write_in_index, .. } => {
-                OptionId::from(format!("write-in-{}", write_in_index))
+                OptionId::from(format!("write-in-{write_in_index}"))
             }
         }
     }

--- a/libs/ballot-interpreter-nh-next/src/election.rs
+++ b/libs/ballot-interpreter-nh-next/src/election.rs
@@ -73,6 +73,23 @@ impl Display for GridPosition {
 }
 
 impl GridPosition {
+    pub fn contest_id(&self) -> ContestId {
+        match self {
+            Self::Option { contest_id, .. } | Self::WriteIn { contest_id, .. } => {
+                contest_id.clone()
+            }
+        }
+    }
+
+    pub fn option_id(&self) -> OptionId {
+        match self {
+            Self::Option { option_id, .. } => option_id.clone(),
+            Self::WriteIn { write_in_index, .. } => {
+                OptionId::from(format!("write-in-{}", write_in_index))
+            }
+        }
+    }
+
     pub const fn location(&self) -> GridLocation {
         match self {
             Self::Option {

--- a/libs/ballot-interpreter-nh-next/src/geometry.rs
+++ b/libs/ballot-interpreter-nh-next/src/geometry.rs
@@ -64,6 +64,15 @@ impl<T: Sub<Output = T> + AddAssign + Copy> AddAssign for Point<T> {
     }
 }
 
+impl Point<SubPixelUnit> {
+    pub fn round(self) -> Point<PixelPosition> {
+        Point::new(
+            self.x.round() as PixelPosition,
+            self.y.round() as PixelPosition,
+        )
+    }
+}
+
 /// A rectangle area of pixels within an image.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize)]
 pub struct Rect {

--- a/libs/ballot-interpreter-nh-next/src/geometry.rs
+++ b/libs/ballot-interpreter-nh-next/src/geometry.rs
@@ -161,6 +161,20 @@ impl Rect {
             None
         }
     }
+
+    // Returns the smallest rectangle that contains both `self` and `other`.
+    pub fn union(&self, other: &Self) -> Self {
+        let left = self.left.min(other.left);
+        let top = self.top.min(other.top);
+        let right = self.right().max(other.right());
+        let bottom = self.bottom().max(other.bottom());
+        Self::new(
+            left,
+            top,
+            (right - left + 1) as PixelUnit,
+            (bottom - top + 1) as PixelUnit,
+        )
+    }
 }
 
 impl From<Rect> for imageproc::rect::Rect {

--- a/libs/ballot-interpreter-nh-next/src/geometry.rs
+++ b/libs/ballot-interpreter-nh-next/src/geometry.rs
@@ -309,7 +309,7 @@ pub fn normalize_angle(angle: Radians) -> Radians {
 /// Finds the largest subset of rectangles such that a line can be drawn through
 /// all of them for any line within the given tolerance of the given angle.
 pub fn find_largest_subset_intersecting_line(
-    rects: &Vec<Rect>,
+    rects: &[Rect],
     angle: Radians,
     tolerance: Radians,
 ) -> Vec<Rect> {
@@ -338,7 +338,7 @@ pub fn find_largest_subset_intersecting_line(
         })
         // Pick the list of rectangles that is the longest.
         .max_by_key(Vec::len)
-        .unwrap_or(vec![])
+        .unwrap_or_default()
         // Dereference the pointers.
         .iter()
         .map(|r| **r)

--- a/libs/ballot-interpreter-nh-next/src/interpret.rs
+++ b/libs/ballot-interpreter-nh-next/src/interpret.rs
@@ -19,6 +19,8 @@ use crate::geometry::Size;
 use crate::image_utils::find_scanned_document_inset;
 use crate::image_utils::maybe_resize_image_to_fit;
 use crate::image_utils::Inset;
+use crate::layout::build_interpreted_page_layout;
+use crate::layout::InterpretedContestLayout;
 use crate::metadata::BallotPageMetadata;
 use crate::metadata::BallotPageMetadataError;
 use crate::scoring::score_oval_marks_from_grid_layout;
@@ -61,6 +63,7 @@ pub struct InterpretedBallotPage {
     grid: TimingMarkGrid,
     marks: ScoredOvalMarks,
     normalized_image: NormalizedImageBuffer,
+    contest_layouts: Vec<InterpretedContestLayout>,
 }
 #[derive(Debug, Serialize)]
 pub struct InterpretedBallotCard {
@@ -109,6 +112,9 @@ pub enum Error {
     UnexpectedDimensions {
         path: String,
         dimensions: Size<PixelUnit>,
+    },
+    CouldNotComputeLayout {
+        side: BallotSide,
     },
 }
 
@@ -355,16 +361,31 @@ pub fn interpret_ballot_card(side_a_path: &Path, side_b_path: &Path, options: &O
         },
     );
 
+    let front_contest_layouts =
+        build_interpreted_page_layout(&front_grid, grid_layout, BallotSide::Front).ok_or(
+            Error::CouldNotComputeLayout {
+                side: BallotSide::Front,
+            },
+        )?;
+    let back_contest_layouts =
+        build_interpreted_page_layout(&back_grid, grid_layout, BallotSide::Back).ok_or(
+            Error::CouldNotComputeLayout {
+                side: BallotSide::Back,
+            },
+        )?;
+
     Ok(InterpretedBallotCard {
         front: InterpretedBallotPage {
             grid: front_grid,
             marks: front_scored_oval_marks,
             normalized_image: make_normalized_image_buffer(front_image),
+            contest_layouts: front_contest_layouts,
         },
         back: InterpretedBallotPage {
             grid: back_grid,
             marks: back_scored_oval_marks,
             normalized_image: make_normalized_image_buffer(back_image),
+            contest_layouts: back_contest_layouts,
         },
     })
 }

--- a/libs/ballot-interpreter-nh-next/src/layout.rs
+++ b/libs/ballot-interpreter-nh-next/src/layout.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use crate::{
     ballot_card::BallotSide,
     election::{ContestId, GridLayout, GridPosition, OptionId},
-    geometry::{GridUnit, PixelPosition, Point, Rect},
+    geometry::{GridUnit, Point, Rect},
     timing_marks::TimingMarkGrid,
 };
 
@@ -52,26 +52,19 @@ fn build_option_layout(
         clamp_row(bubble_location.row as i32 + row_offset + height as i32),
     );
 
-    let top_left_subpixel_point = grid.point_for_location(
-        top_left_grid_point.x as GridUnit,
-        top_left_grid_point.y as GridUnit,
-    )?;
+    let top_left_subpixel_point =
+        grid.point_for_location(top_left_grid_point.x, top_left_grid_point.y)?;
     let bottom_right_subpixel_point = grid.point_for_location(
         bottom_right_grid_point.x as GridUnit,
         bottom_right_grid_point.y as GridUnit,
     )?;
-    let top_left_pixel_point = Point::new(
-        top_left_subpixel_point.x as PixelPosition,
-        top_left_subpixel_point.y as PixelPosition,
-    );
-    let bottom_right_pixel_point = Point::new(
-        bottom_right_subpixel_point.x as PixelPosition,
-        bottom_right_subpixel_point.y as PixelPosition,
-    );
 
     Some(InterpretedContestOptionLayout {
         option_id: grid_position.option_id(),
-        bounds: Rect::from_points(top_left_pixel_point, bottom_right_pixel_point),
+        bounds: Rect::from_points(
+            top_left_subpixel_point.round(),
+            bottom_right_subpixel_point.round(),
+        ),
     })
 }
 

--- a/libs/ballot-interpreter-nh-next/src/layout.rs
+++ b/libs/ballot-interpreter-nh-next/src/layout.rs
@@ -35,10 +35,10 @@ fn build_option_layout(
     let height: GridUnit = 2;
 
     let clamp_row = |row: i32| -> GridUnit {
-        return row.max(0).min(grid.geometry.grid_size.height as i32 - 1) as GridUnit;
+        row.clamp(0, grid.geometry.grid_size.height as i32 - 1) as GridUnit
     };
     let clamp_column = |column: i32| -> GridUnit {
-        return column.max(0).min(grid.geometry.grid_size.width as i32 - 1) as GridUnit;
+        column.clamp(0, grid.geometry.grid_size.width as i32 - 1) as GridUnit
     };
 
     let bubble_location = grid_position.location();
@@ -69,10 +69,10 @@ fn build_option_layout(
         bottom_right_subpixel_point.y as PixelPosition,
     );
 
-    return Some(InterpretedContestOptionLayout {
-        option_id: grid_position.option_id().clone(),
+    Some(InterpretedContestOptionLayout {
+        option_id: grid_position.option_id(),
         bounds: Rect::from_points(top_left_pixel_point, bottom_right_pixel_point),
-    });
+    })
 }
 
 pub fn build_interpreted_page_layout(

--- a/libs/ballot-interpreter-nh-next/src/layout.rs
+++ b/libs/ballot-interpreter-nh-next/src/layout.rs
@@ -1,0 +1,112 @@
+use itertools::Itertools;
+use serde::Serialize;
+
+use crate::{
+    ballot_card::BallotSide,
+    election::{ContestId, GridLayout, GridPosition, OptionId},
+    geometry::{GridUnit, PixelPosition, Point, Rect},
+    timing_marks::TimingMarkGrid,
+};
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InterpretedContestOptionLayout {
+    option_id: OptionId,
+    bounds: Rect,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InterpretedContestLayout {
+    contest_id: ContestId,
+    bounds: Rect,
+    options: Vec<InterpretedContestOptionLayout>,
+}
+
+fn build_option_layout(
+    grid: &TimingMarkGrid,
+    grid_position: &GridPosition,
+) -> Option<InterpretedContestOptionLayout> {
+    // Option bounding box parameters
+    // TODO make these configurable in the election definition
+    let column_offset: i32 = -9;
+    let row_offset: i32 = -1;
+    let width: GridUnit = 10;
+    let height: GridUnit = 2;
+
+    let clamp_row = |row: i32| -> GridUnit {
+        return row.max(0).min(grid.geometry.grid_size.height as i32 - 1) as GridUnit;
+    };
+    let clamp_column = |column: i32| -> GridUnit {
+        return column.max(0).min(grid.geometry.grid_size.width as i32 - 1) as GridUnit;
+    };
+
+    let bubble_location = grid_position.location();
+
+    let top_left_grid_point: Point<GridUnit> = Point::new(
+        clamp_column(bubble_location.column as i32 + column_offset),
+        clamp_row(bubble_location.row as i32 + row_offset),
+    );
+    let bottom_right_grid_point: Point<GridUnit> = Point::new(
+        clamp_column(bubble_location.column as i32 + column_offset + width as i32),
+        clamp_row(bubble_location.row as i32 + row_offset + height as i32),
+    );
+
+    let top_left_subpixel_point = grid.point_for_location(
+        top_left_grid_point.x as GridUnit,
+        top_left_grid_point.y as GridUnit,
+    )?;
+    let bottom_right_subpixel_point = grid.point_for_location(
+        bottom_right_grid_point.x as GridUnit,
+        bottom_right_grid_point.y as GridUnit,
+    )?;
+    let top_left_pixel_point = Point::new(
+        top_left_subpixel_point.x as PixelPosition,
+        top_left_subpixel_point.y as PixelPosition,
+    );
+    let bottom_right_pixel_point = Point::new(
+        bottom_right_subpixel_point.x as PixelPosition,
+        bottom_right_subpixel_point.y as PixelPosition,
+    );
+
+    return Some(InterpretedContestOptionLayout {
+        option_id: grid_position.option_id().clone(),
+        bounds: Rect::from_points(top_left_pixel_point, bottom_right_pixel_point),
+    });
+}
+
+pub fn build_interpreted_page_layout(
+    grid: &TimingMarkGrid,
+    grid_layout: &GridLayout,
+    side: BallotSide,
+) -> Option<Vec<InterpretedContestLayout>> {
+    let grid_positions_by_contest = grid_layout
+        .grid_positions
+        .iter()
+        .filter(|grid_position| grid_position.location().side == side)
+        .map(|grid_position| (grid_position.contest_id(), grid_position))
+        .into_group_map();
+
+    grid_positions_by_contest
+        .iter()
+        .map(|(contest_id, grid_positions)| {
+            let options = grid_positions
+                .iter()
+                .map(|grid_position| build_option_layout(grid, grid_position))
+                .collect::<Option<Vec<_>>>()?;
+
+            // Use the union of the option bounds as an approximation of the contest bounds
+            let bounds = options
+                .iter()
+                .map(|option| option.bounds)
+                .reduce(|a, b| a.union(&b))
+                .expect("Contest must have options");
+
+            Some(InterpretedContestLayout {
+                contest_id: (*contest_id).clone(),
+                bounds,
+                options,
+            })
+        })
+        .collect::<Option<Vec<_>>>()
+}

--- a/libs/ballot-interpreter-nh-next/src/layout.rs
+++ b/libs/ballot-interpreter-nh-next/src/layout.rs
@@ -73,16 +73,23 @@ pub fn build_interpreted_page_layout(
     grid_layout: &GridLayout,
     side: BallotSide,
 ) -> Option<Vec<InterpretedContestLayout>> {
-    let grid_positions_by_contest = grid_layout
+    let contest_ids_in_grid_layout_order = grid_layout
         .grid_positions
         .iter()
         .filter(|grid_position| grid_position.location().side == side)
-        .map(|grid_position| (grid_position.contest_id(), grid_position))
-        .into_group_map();
+        .map(|grid_position| grid_position.contest_id())
+        .unique()
+        .collect::<Vec<_>>();
 
-    grid_positions_by_contest
+    contest_ids_in_grid_layout_order
         .iter()
-        .map(|(contest_id, grid_positions)| {
+        .map(|contest_id| {
+            let grid_positions = grid_layout
+                .grid_positions
+                .iter()
+                .filter(|grid_position| grid_position.contest_id() == *contest_id)
+                .collect::<Vec<_>>();
+
             let options = grid_positions
                 .iter()
                 .map(|grid_position| build_option_layout(grid, grid_position))
@@ -96,10 +103,10 @@ pub fn build_interpreted_page_layout(
                 .expect("Contest must have options");
 
             Some(InterpretedContestLayout {
-                contest_id: (*contest_id).clone(),
+                contest_id: contest_id.clone(),
                 bounds,
                 options,
             })
         })
-        .collect::<Option<Vec<_>>>()
+        .collect()
 }

--- a/libs/ballot-interpreter-nh-next/src/lib.rs
+++ b/libs/ballot-interpreter-nh-next/src/lib.rs
@@ -9,6 +9,7 @@ mod election;
 mod geometry;
 mod image_utils;
 mod interpret;
+mod layout;
 mod metadata;
 mod scoring;
 mod timing_marks;

--- a/libs/ballot-interpreter-nh-next/src/lib.rs
+++ b/libs/ballot-interpreter-nh-next/src/lib.rs
@@ -48,8 +48,9 @@ impl InterpretError {
     }
 
     fn to_json(&self) -> String {
-        serde_json::to_string(self)
-            .unwrap_or(r#"{"type": "unknown", "message": "Failed to serialize error"}"#.to_string())
+        serde_json::to_string(self).unwrap_or_else(|_| {
+            r#"{"type": "unknown", "message": "Failed to serialize error"}"#.to_string()
+        })
     }
 
     fn json(message: String) -> String {
@@ -89,7 +90,7 @@ fn interpret(mut cx: FunctionContext) -> JsResult<JsObject> {
         Path::new(side_b_path.as_str()),
         &Options {
             election,
-            oval_template: load_oval_template().unwrap(),
+            oval_template: load_oval_template().expect("Failed to load oval template"),
             debug,
         },
     );

--- a/libs/ballot-interpreter-nh-next/src/timing_marks.rs
+++ b/libs/ballot-interpreter-nh-next/src/timing_marks.rs
@@ -155,7 +155,11 @@ impl TimingMarkGrid {
     /// marks for the given row, correcting their position to account for
     /// the marks being cropped during scanning or border removal, and
     /// interpolating between the two based on the column.
-    pub fn point_for_location(&self, column: GridUnit, row: GridUnit) -> Option<Point<f32>> {
+    pub fn point_for_location(
+        &self,
+        column: GridUnit,
+        row: GridUnit,
+    ) -> Option<Point<SubPixelUnit>> {
         if column >= self.geometry.grid_size.width || row >= self.geometry.grid_size.height {
             return None;
         }

--- a/libs/ballot-interpreter-nh-next/ts/src/__snapshots__/adapter.test.ts.snap
+++ b/libs/ballot-interpreter-nh-next/ts/src/__snapshots__/adapter.test.ts.snap
@@ -1,0 +1,2024 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`interpret with valid data 1`] = `
+{
+  "contests": [
+    {
+      "bounds": {
+        "height": 102,
+        "width": 1501,
+        "x": 172,
+        "y": 455,
+      },
+      "contestId": "Governor-061a401b",
+      "corners": [
+        {
+          "x": 172,
+          "y": 455,
+        },
+        {
+          "x": 1673,
+          "y": 455,
+        },
+        {
+          "x": 172,
+          "y": 557,
+        },
+        {
+          "x": 1673,
+          "y": 557,
+        },
+      ],
+      "options": [
+        {
+          "bounds": {
+            "height": 102,
+            "width": 502,
+            "x": 172,
+            "y": 455,
+          },
+          "definition": {
+            "contestId": "Governor-061a401b",
+            "id": "Josiah-Bartlett-1bb99985",
+            "isWriteIn": false,
+            "name": "Josiah Bartlett",
+            "optionIndex": 0,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 102,
+            "width": 501,
+            "x": 522,
+            "y": 455,
+          },
+          "definition": {
+            "contestId": "Governor-061a401b",
+            "id": "Hannah-Dustin-ab4ef7c8",
+            "isWriteIn": false,
+            "name": "Hannah Dustin",
+            "optionIndex": 1,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 102,
+            "width": 501,
+            "x": 872,
+            "y": 455,
+          },
+          "definition": {
+            "contestId": "Governor-061a401b",
+            "id": "John-Spencer-9ffb5970",
+            "isWriteIn": false,
+            "name": "John Spencer",
+            "optionIndex": 2,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 102,
+            "width": 501,
+            "x": 1172,
+            "y": 455,
+          },
+          "definition": {
+            "contestId": "Governor-061a401b",
+            "id": "write-in-0",
+            "isWriteIn": true,
+            "name": "Write-In",
+            "optionIndex": 3,
+            "type": "candidate",
+            "writeInIndex": 0,
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+      ],
+    },
+    {
+      "bounds": {
+        "height": 102,
+        "width": 1500,
+        "x": 173,
+        "y": 606,
+      },
+      "contestId": "United-States-Senator-d3f1c75b",
+      "corners": [
+        {
+          "x": 173,
+          "y": 606,
+        },
+        {
+          "x": 1673,
+          "y": 606,
+        },
+        {
+          "x": 173,
+          "y": 708,
+        },
+        {
+          "x": 1673,
+          "y": 708,
+        },
+      ],
+      "options": [
+        {
+          "bounds": {
+            "height": 102,
+            "width": 501,
+            "x": 173,
+            "y": 606,
+          },
+          "definition": {
+            "contestId": "United-States-Senator-d3f1c75b",
+            "id": "John-Langdon-5951c8e1",
+            "isWriteIn": false,
+            "name": "John Langdon",
+            "optionIndex": 0,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 101,
+            "width": 500,
+            "x": 523,
+            "y": 606,
+          },
+          "definition": {
+            "contestId": "United-States-Senator-d3f1c75b",
+            "id": "William-Preston-3778fcd5",
+            "isWriteIn": false,
+            "name": "William Preston",
+            "optionIndex": 1,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 101,
+            "width": 501,
+            "x": 1172,
+            "y": 606,
+          },
+          "definition": {
+            "contestId": "United-States-Senator-d3f1c75b",
+            "id": "write-in-0",
+            "isWriteIn": true,
+            "name": "Write-In",
+            "optionIndex": 2,
+            "type": "candidate",
+            "writeInIndex": 0,
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+      ],
+    },
+    {
+      "bounds": {
+        "height": 102,
+        "width": 1501,
+        "x": 173,
+        "y": 757,
+      },
+      "contestId": "Representative-in-Congress-24683b44",
+      "corners": [
+        {
+          "x": 173,
+          "y": 757,
+        },
+        {
+          "x": 1674,
+          "y": 757,
+        },
+        {
+          "x": 173,
+          "y": 859,
+        },
+        {
+          "x": 1674,
+          "y": 859,
+        },
+      ],
+      "options": [
+        {
+          "bounds": {
+            "height": 102,
+            "width": 501,
+            "x": 173,
+            "y": 757,
+          },
+          "definition": {
+            "contestId": "Representative-in-Congress-24683b44",
+            "id": "Jeremiah-Smith-469560c9",
+            "isWriteIn": false,
+            "name": "Jeremiah Smith",
+            "optionIndex": 0,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 102,
+            "width": 501,
+            "x": 523,
+            "y": 757,
+          },
+          "definition": {
+            "contestId": "Representative-in-Congress-24683b44",
+            "id": "Nicholas-Gilman-1791aed7",
+            "isWriteIn": false,
+            "name": "Nicholas Gilman",
+            "optionIndex": 1,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 102,
+            "width": 502,
+            "x": 872,
+            "y": 757,
+          },
+          "definition": {
+            "contestId": "Representative-in-Congress-24683b44",
+            "id": "Richard-Coote-b9095636",
+            "isWriteIn": false,
+            "name": "Richard Coote",
+            "optionIndex": 2,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 102,
+            "width": 502,
+            "x": 1172,
+            "y": 757,
+          },
+          "definition": {
+            "contestId": "Representative-in-Congress-24683b44",
+            "id": "write-in-0",
+            "isWriteIn": true,
+            "name": "Write-In",
+            "optionIndex": 3,
+            "type": "candidate",
+            "writeInIndex": 0,
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+      ],
+    },
+    {
+      "bounds": {
+        "height": 102,
+        "width": 1501,
+        "x": 173,
+        "y": 908,
+      },
+      "contestId": "Executive-Councilor-bb22557f",
+      "corners": [
+        {
+          "x": 173,
+          "y": 908,
+        },
+        {
+          "x": 1674,
+          "y": 908,
+        },
+        {
+          "x": 173,
+          "y": 1010,
+        },
+        {
+          "x": 1674,
+          "y": 1010,
+        },
+      ],
+      "options": [
+        {
+          "bounds": {
+            "height": 101,
+            "width": 501,
+            "x": 173,
+            "y": 909,
+          },
+          "definition": {
+            "contestId": "Executive-Councilor-bb22557f",
+            "id": "Anne-Waldron-ee0cbc85",
+            "isWriteIn": false,
+            "name": "Anne Waldron",
+            "optionIndex": 0,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 101,
+            "width": 501,
+            "x": 523,
+            "y": 909,
+          },
+          "definition": {
+            "contestId": "Executive-Councilor-bb22557f",
+            "id": "Daniel-Webster-13f77b2d",
+            "isWriteIn": false,
+            "name": "Daniel Webster",
+            "optionIndex": 1,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 101,
+            "width": 501,
+            "x": 1173,
+            "y": 908,
+          },
+          "definition": {
+            "contestId": "Executive-Councilor-bb22557f",
+            "id": "write-in-0",
+            "isWriteIn": true,
+            "name": "Write-In",
+            "optionIndex": 2,
+            "type": "candidate",
+            "writeInIndex": 0,
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+      ],
+    },
+    {
+      "bounds": {
+        "height": 102,
+        "width": 1501,
+        "x": 173,
+        "y": 1059,
+      },
+      "contestId": "State-Senator-391381f8",
+      "corners": [
+        {
+          "x": 173,
+          "y": 1059,
+        },
+        {
+          "x": 1674,
+          "y": 1059,
+        },
+        {
+          "x": 173,
+          "y": 1161,
+        },
+        {
+          "x": 1674,
+          "y": 1161,
+        },
+      ],
+      "options": [
+        {
+          "bounds": {
+            "height": 101,
+            "width": 502,
+            "x": 173,
+            "y": 1060,
+          },
+          "definition": {
+            "contestId": "State-Senator-391381f8",
+            "id": "James-Poole-db5ef4bd",
+            "isWriteIn": false,
+            "name": "James Poole",
+            "optionIndex": 0,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 102,
+            "width": 501,
+            "x": 523,
+            "y": 1059,
+          },
+          "definition": {
+            "contestId": "State-Senator-391381f8",
+            "id": "Matthew-Thornton-f66fec5e",
+            "isWriteIn": false,
+            "name": "Matthew Thornton",
+            "optionIndex": 1,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 101,
+            "width": 501,
+            "x": 1173,
+            "y": 1059,
+          },
+          "definition": {
+            "contestId": "State-Senator-391381f8",
+            "id": "write-in-0",
+            "isWriteIn": true,
+            "name": "Write-In",
+            "optionIndex": 2,
+            "type": "candidate",
+            "writeInIndex": 0,
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+      ],
+    },
+    {
+      "bounds": {
+        "height": 354,
+        "width": 1501,
+        "x": 174,
+        "y": 1210,
+      },
+      "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+      "corners": [
+        {
+          "x": 174,
+          "y": 1210,
+        },
+        {
+          "x": 1675,
+          "y": 1210,
+        },
+        {
+          "x": 174,
+          "y": 1564,
+        },
+        {
+          "x": 1675,
+          "y": 1564,
+        },
+      ],
+      "options": [
+        {
+          "bounds": {
+            "height": 101,
+            "width": 501,
+            "x": 174,
+            "y": 1262,
+          },
+          "definition": {
+            "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+            "id": "Obadiah-Carrigan-5c95145a",
+            "isWriteIn": false,
+            "name": "Obadiah Carrigan",
+            "optionIndex": 0,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 101,
+            "width": 501,
+            "x": 174,
+            "y": 1362,
+          },
+          "definition": {
+            "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+            "id": "Mary-Baker-Eddy-350785d5",
+            "isWriteIn": false,
+            "name": "Mary Baker Eddy",
+            "optionIndex": 1,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 101,
+            "width": 502,
+            "x": 174,
+            "y": 1463,
+          },
+          "definition": {
+            "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+            "id": "Samuel-Bell-17973275",
+            "isWriteIn": false,
+            "name": "Samuel Bell",
+            "optionIndex": 2,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 100,
+            "width": 501,
+            "x": 524,
+            "y": 1211,
+          },
+          "definition": {
+            "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+            "id": "Samuel-Livermore-f927fef1",
+            "isWriteIn": false,
+            "name": "Samuel Livermore",
+            "optionIndex": 3,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 101,
+            "width": 501,
+            "x": 524,
+            "y": 1311,
+          },
+          "definition": {
+            "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+            "id": "Elijah-Miller-a52e6988",
+            "isWriteIn": false,
+            "name": "Elijah Miller",
+            "optionIndex": 4,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 101,
+            "width": 501,
+            "x": 524,
+            "y": 1412,
+          },
+          "definition": {
+            "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+            "id": "Isaac-Hill-d6c9deeb",
+            "isWriteIn": false,
+            "name": "Isaac Hill",
+            "optionIndex": 5,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 100,
+            "width": 502,
+            "x": 873,
+            "y": 1261,
+          },
+          "definition": {
+            "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+            "id": "Abigail-Bartlett-4e46c9d4",
+            "isWriteIn": false,
+            "name": "Abigail Bartlett",
+            "optionIndex": 6,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 101,
+            "width": 501,
+            "x": 874,
+            "y": 1361,
+          },
+          "definition": {
+            "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+            "id": "Jacob-Freese-b5146505",
+            "isWriteIn": false,
+            "name": "Jacob Freese",
+            "optionIndex": 7,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 101,
+            "width": 502,
+            "x": 1173,
+            "y": 1210,
+          },
+          "definition": {
+            "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+            "id": "write-in-0",
+            "isWriteIn": true,
+            "name": "Write-In",
+            "optionIndex": 8,
+            "type": "candidate",
+            "writeInIndex": 0,
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 101,
+            "width": 501,
+            "x": 1174,
+            "y": 1310,
+          },
+          "definition": {
+            "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+            "id": "write-in-1",
+            "isWriteIn": true,
+            "name": "Write-In",
+            "optionIndex": 9,
+            "type": "candidate",
+            "writeInIndex": 1,
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 101,
+            "width": 499,
+            "x": 1174,
+            "y": 1411,
+          },
+          "definition": {
+            "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+            "id": "write-in-2",
+            "isWriteIn": true,
+            "name": "Write-In",
+            "optionIndex": 10,
+            "type": "candidate",
+            "writeInIndex": 2,
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+      ],
+    },
+    {
+      "bounds": {
+        "height": 102,
+        "width": 1501,
+        "x": 175,
+        "y": 1662,
+      },
+      "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
+      "corners": [
+        {
+          "x": 175,
+          "y": 1662,
+        },
+        {
+          "x": 1676,
+          "y": 1662,
+        },
+        {
+          "x": 175,
+          "y": 1764,
+        },
+        {
+          "x": 1676,
+          "y": 1764,
+        },
+      ],
+      "options": [
+        {
+          "bounds": {
+            "height": 99,
+            "width": 501,
+            "x": 175,
+            "y": 1665,
+          },
+          "definition": {
+            "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
+            "id": "Abeil-Foster-ded38e36",
+            "isWriteIn": false,
+            "name": "Abeil Foster",
+            "optionIndex": 0,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 99,
+            "width": 501,
+            "x": 525,
+            "y": 1664,
+          },
+          "definition": {
+            "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
+            "id": "Charles-H-Hersey-096286a4",
+            "isWriteIn": false,
+            "name": "Charles H. Hersey",
+            "optionIndex": 1,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 99,
+            "width": 502,
+            "x": 874,
+            "y": 1663,
+          },
+          "definition": {
+            "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
+            "id": "William-Lovejoy-fde3c2df",
+            "isWriteIn": false,
+            "name": "William Lovejoy",
+            "optionIndex": 2,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 99,
+            "width": 502,
+            "x": 1174,
+            "y": 1662,
+          },
+          "definition": {
+            "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
+            "id": "write-in-0",
+            "isWriteIn": true,
+            "name": "Write-In",
+            "optionIndex": 3,
+            "type": "candidate",
+            "writeInIndex": 0,
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+      ],
+    },
+  ],
+  "metadata": {
+    "ballotStyleId": "card-number-3",
+    "ballotType": 0,
+    "electionHash": "87034971ecdd76161d159d4d77d75c276fe4166300aa4c8ea66c65f61a01c4e4",
+    "isTestMode": true,
+    "locales": {
+      "primary": "en-US",
+    },
+    "pageNumber": 1,
+    "precinctId": "town-id-00701-precinct-id-",
+  },
+  "pageSize": {
+    "height": 2200,
+    "width": 1696,
+  },
+}
+`;
+
+exports[`interpret with valid data 2`] = `
+{
+  "contests": [
+    {
+      "bounds": {
+        "height": 102,
+        "width": 1501,
+        "x": 182,
+        "y": 253,
+      },
+      "contestId": "Sheriff-4243fe0b",
+      "corners": [
+        {
+          "x": 182,
+          "y": 253,
+        },
+        {
+          "x": 1683,
+          "y": 253,
+        },
+        {
+          "x": 182,
+          "y": 355,
+        },
+        {
+          "x": 1683,
+          "y": 355,
+        },
+      ],
+      "options": [
+        {
+          "bounds": {
+            "height": 102,
+            "width": 501,
+            "x": 182,
+            "y": 253,
+          },
+          "definition": {
+            "contestId": "Sheriff-4243fe0b",
+            "id": "Edward-Randolph-bf4c848a",
+            "isWriteIn": false,
+            "name": "Edward Randolph",
+            "optionIndex": 0,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 102,
+            "width": 501,
+            "x": 532,
+            "y": 253,
+          },
+          "definition": {
+            "contestId": "Sheriff-4243fe0b",
+            "id": "Edward-Randolph-bf4c848a",
+            "isWriteIn": false,
+            "name": "Edward Randolph",
+            "optionIndex": 0,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 102,
+            "width": 501,
+            "x": 1182,
+            "y": 253,
+          },
+          "definition": {
+            "contestId": "Sheriff-4243fe0b",
+            "id": "write-in-0",
+            "isWriteIn": true,
+            "name": "Write-In",
+            "optionIndex": 1,
+            "type": "candidate",
+            "writeInIndex": 0,
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+      ],
+    },
+    {
+      "bounds": {
+        "height": 101,
+        "width": 1501,
+        "x": 182,
+        "y": 405,
+      },
+      "contestId": "County-Attorney-133f910f",
+      "corners": [
+        {
+          "x": 182,
+          "y": 405,
+        },
+        {
+          "x": 1683,
+          "y": 405,
+        },
+        {
+          "x": 182,
+          "y": 506,
+        },
+        {
+          "x": 1683,
+          "y": 506,
+        },
+      ],
+      "options": [
+        {
+          "bounds": {
+            "height": 101,
+            "width": 501,
+            "x": 182,
+            "y": 405,
+          },
+          "definition": {
+            "contestId": "County-Attorney-133f910f",
+            "id": "Ezra-Bartlett-8f95223c",
+            "isWriteIn": false,
+            "name": "Ezra Bartlett",
+            "optionIndex": 0,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 101,
+            "width": 501,
+            "x": 532,
+            "y": 405,
+          },
+          "definition": {
+            "contestId": "County-Attorney-133f910f",
+            "id": "Mary-Woolson-dc0b854a",
+            "isWriteIn": false,
+            "name": "Mary Woolson",
+            "optionIndex": 1,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 101,
+            "width": 501,
+            "x": 1182,
+            "y": 405,
+          },
+          "definition": {
+            "contestId": "County-Attorney-133f910f",
+            "id": "write-in-0",
+            "isWriteIn": true,
+            "name": "Write-In",
+            "optionIndex": 2,
+            "type": "candidate",
+            "writeInIndex": 0,
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+      ],
+    },
+    {
+      "bounds": {
+        "height": 103,
+        "width": 1502,
+        "x": 182,
+        "y": 555,
+      },
+      "contestId": "County-Treasurer-87d25a31",
+      "corners": [
+        {
+          "x": 182,
+          "y": 555,
+        },
+        {
+          "x": 1684,
+          "y": 555,
+        },
+        {
+          "x": 182,
+          "y": 658,
+        },
+        {
+          "x": 1684,
+          "y": 658,
+        },
+      ],
+      "options": [
+        {
+          "bounds": {
+            "height": 102,
+            "width": 501,
+            "x": 182,
+            "y": 555,
+          },
+          "definition": {
+            "contestId": "County-Treasurer-87d25a31",
+            "id": "John-Smith-ef61a579",
+            "isWriteIn": false,
+            "name": "John Smith",
+            "optionIndex": 0,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 102,
+            "width": 501,
+            "x": 532,
+            "y": 555,
+          },
+          "definition": {
+            "contestId": "County-Treasurer-87d25a31",
+            "id": "Jane-Jones-9caa141f",
+            "isWriteIn": false,
+            "name": "Jane Jones",
+            "optionIndex": 1,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 102,
+            "width": 502,
+            "x": 1182,
+            "y": 556,
+          },
+          "definition": {
+            "contestId": "County-Treasurer-87d25a31",
+            "id": "write-in-0",
+            "isWriteIn": true,
+            "name": "Write-In",
+            "optionIndex": 2,
+            "type": "candidate",
+            "writeInIndex": 0,
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+      ],
+    },
+    {
+      "bounds": {
+        "height": 102,
+        "width": 1501,
+        "x": 182,
+        "y": 707,
+      },
+      "contestId": "Register-of-Deeds-a1278df2",
+      "corners": [
+        {
+          "x": 182,
+          "y": 707,
+        },
+        {
+          "x": 1683,
+          "y": 707,
+        },
+        {
+          "x": 182,
+          "y": 809,
+        },
+        {
+          "x": 1683,
+          "y": 809,
+        },
+      ],
+      "options": [
+        {
+          "bounds": {
+            "height": 101,
+            "width": 501,
+            "x": 182,
+            "y": 707,
+          },
+          "definition": {
+            "contestId": "Register-of-Deeds-a1278df2",
+            "id": "John-Mann-b56bbdd3",
+            "isWriteIn": false,
+            "name": "John Mann",
+            "optionIndex": 0,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 102,
+            "width": 501,
+            "x": 532,
+            "y": 707,
+          },
+          "definition": {
+            "contestId": "Register-of-Deeds-a1278df2",
+            "id": "Ellen-A-Stileman-14408737",
+            "isWriteIn": false,
+            "name": "Ellen A. Stileman",
+            "optionIndex": 1,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 102,
+            "width": 501,
+            "x": 1182,
+            "y": 707,
+          },
+          "definition": {
+            "contestId": "Register-of-Deeds-a1278df2",
+            "id": "write-in-0",
+            "isWriteIn": true,
+            "name": "Write-In",
+            "optionIndex": 2,
+            "type": "candidate",
+            "writeInIndex": 0,
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+      ],
+    },
+    {
+      "bounds": {
+        "height": 103,
+        "width": 1500,
+        "x": 182,
+        "y": 857,
+      },
+      "contestId": "Register-of-Probate-a4117da8",
+      "corners": [
+        {
+          "x": 182,
+          "y": 857,
+        },
+        {
+          "x": 1682,
+          "y": 857,
+        },
+        {
+          "x": 182,
+          "y": 960,
+        },
+        {
+          "x": 1682,
+          "y": 960,
+        },
+      ],
+      "options": [
+        {
+          "bounds": {
+            "height": 102,
+            "width": 500,
+            "x": 182,
+            "y": 857,
+          },
+          "definition": {
+            "contestId": "Register-of-Probate-a4117da8",
+            "id": "Nathaniel-Parker-56a06c29",
+            "isWriteIn": false,
+            "name": "Nathaniel Parker",
+            "optionIndex": 0,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 102,
+            "width": 500,
+            "x": 532,
+            "y": 857,
+          },
+          "definition": {
+            "contestId": "Register-of-Probate-a4117da8",
+            "id": "Claire-Cutts-07a436e7",
+            "isWriteIn": false,
+            "name": "Claire Cutts",
+            "optionIndex": 1,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 102,
+            "width": 500,
+            "x": 1182,
+            "y": 858,
+          },
+          "definition": {
+            "contestId": "Register-of-Probate-a4117da8",
+            "id": "write-in-0",
+            "isWriteIn": true,
+            "name": "Write-In",
+            "optionIndex": 2,
+            "type": "candidate",
+            "writeInIndex": 0,
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+      ],
+    },
+    {
+      "bounds": {
+        "height": 103,
+        "width": 1500,
+        "x": 182,
+        "y": 1008,
+      },
+      "contestId": "County-Commissioner-d6feed25",
+      "corners": [
+        {
+          "x": 182,
+          "y": 1008,
+        },
+        {
+          "x": 1682,
+          "y": 1008,
+        },
+        {
+          "x": 182,
+          "y": 1111,
+        },
+        {
+          "x": 1682,
+          "y": 1111,
+        },
+      ],
+      "options": [
+        {
+          "bounds": {
+            "height": 102,
+            "width": 501,
+            "x": 182,
+            "y": 1008,
+          },
+          "definition": {
+            "contestId": "County-Commissioner-d6feed25",
+            "id": "Ichabod-Goodwin-55e8de1f",
+            "isWriteIn": false,
+            "name": "Ichabod Goodwin",
+            "optionIndex": 0,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 102,
+            "width": 500,
+            "x": 532,
+            "y": 1008,
+          },
+          "definition": {
+            "contestId": "County-Commissioner-d6feed25",
+            "id": "Valbe-Cady-ba3af3af",
+            "isWriteIn": false,
+            "name": "Valbe Cady",
+            "optionIndex": 1,
+            "type": "candidate",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 102,
+            "width": 501,
+            "x": 1181,
+            "y": 1009,
+          },
+          "definition": {
+            "contestId": "County-Commissioner-d6feed25",
+            "id": "write-in-0",
+            "isWriteIn": true,
+            "name": "Write-In",
+            "optionIndex": 2,
+            "type": "candidate",
+            "writeInIndex": 0,
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+      ],
+    },
+    {
+      "bounds": {
+        "height": 103,
+        "width": 800,
+        "x": 881,
+        "y": 1260,
+      },
+      "contestId": "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc",
+      "corners": [
+        {
+          "x": 881,
+          "y": 1260,
+        },
+        {
+          "x": 1681,
+          "y": 1260,
+        },
+        {
+          "x": 881,
+          "y": 1363,
+        },
+        {
+          "x": 1681,
+          "y": 1363,
+        },
+      ],
+      "options": [
+        {
+          "bounds": {
+            "height": 103,
+            "width": 500,
+            "x": 881,
+            "y": 1260,
+          },
+          "definition": {
+            "contestId": "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc",
+            "id": "yes",
+            "name": "Yes",
+            "optionIndex": 0,
+            "type": "yesno",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "bounds": {
+            "height": 103,
+            "width": 500,
+            "x": 1181,
+            "y": 1260,
+          },
+          "definition": {
+            "contestId": "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc",
+            "id": "no",
+            "name": "No",
+            "optionIndex": 1,
+            "type": "yesno",
+          },
+          "target": {
+            "bounds": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+            "inner": {
+              "height": 1,
+              "width": 1,
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+      ],
+    },
+  ],
+  "metadata": {
+    "ballotStyleId": "card-number-3",
+    "ballotType": 0,
+    "electionHash": "87034971ecdd76161d159d4d77d75c276fe4166300aa4c8ea66c65f61a01c4e4",
+    "isTestMode": true,
+    "locales": {
+      "primary": "en-US",
+    },
+    "pageNumber": 2,
+    "precinctId": "town-id-00701-precinct-id-",
+  },
+  "pageSize": {
+    "height": 2200,
+    "width": 1696,
+  },
+}
+`;

--- a/libs/ballot-interpreter-nh-next/ts/src/__snapshots__/interpret.test.ts.snap
+++ b/libs/ballot-interpreter-nh-next/ts/src/__snapshots__/interpret.test.ts.snap
@@ -1,0 +1,633 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`interpret with valid data 1`] = `
+[
+  {
+    "bounds": {
+      "height": 102,
+      "left": 172,
+      "top": 455,
+      "width": 1501,
+    },
+    "contestId": "Governor-061a401b",
+    "options": [
+      {
+        "bounds": {
+          "height": 102,
+          "left": 172,
+          "top": 455,
+          "width": 502,
+        },
+        "optionId": "Josiah-Bartlett-1bb99985",
+      },
+      {
+        "bounds": {
+          "height": 102,
+          "left": 522,
+          "top": 455,
+          "width": 501,
+        },
+        "optionId": "Hannah-Dustin-ab4ef7c8",
+      },
+      {
+        "bounds": {
+          "height": 102,
+          "left": 872,
+          "top": 455,
+          "width": 501,
+        },
+        "optionId": "John-Spencer-9ffb5970",
+      },
+      {
+        "bounds": {
+          "height": 102,
+          "left": 1172,
+          "top": 455,
+          "width": 501,
+        },
+        "optionId": "write-in-0",
+      },
+    ],
+  },
+  {
+    "bounds": {
+      "height": 102,
+      "left": 173,
+      "top": 606,
+      "width": 1500,
+    },
+    "contestId": "United-States-Senator-d3f1c75b",
+    "options": [
+      {
+        "bounds": {
+          "height": 102,
+          "left": 173,
+          "top": 606,
+          "width": 501,
+        },
+        "optionId": "John-Langdon-5951c8e1",
+      },
+      {
+        "bounds": {
+          "height": 101,
+          "left": 523,
+          "top": 606,
+          "width": 500,
+        },
+        "optionId": "William-Preston-3778fcd5",
+      },
+      {
+        "bounds": {
+          "height": 101,
+          "left": 1172,
+          "top": 606,
+          "width": 501,
+        },
+        "optionId": "write-in-0",
+      },
+    ],
+  },
+  {
+    "bounds": {
+      "height": 102,
+      "left": 173,
+      "top": 757,
+      "width": 1501,
+    },
+    "contestId": "Representative-in-Congress-24683b44",
+    "options": [
+      {
+        "bounds": {
+          "height": 102,
+          "left": 173,
+          "top": 757,
+          "width": 501,
+        },
+        "optionId": "Jeremiah-Smith-469560c9",
+      },
+      {
+        "bounds": {
+          "height": 102,
+          "left": 523,
+          "top": 757,
+          "width": 501,
+        },
+        "optionId": "Nicholas-Gilman-1791aed7",
+      },
+      {
+        "bounds": {
+          "height": 102,
+          "left": 872,
+          "top": 757,
+          "width": 502,
+        },
+        "optionId": "Richard-Coote-b9095636",
+      },
+      {
+        "bounds": {
+          "height": 102,
+          "left": 1172,
+          "top": 757,
+          "width": 502,
+        },
+        "optionId": "write-in-0",
+      },
+    ],
+  },
+  {
+    "bounds": {
+      "height": 102,
+      "left": 173,
+      "top": 908,
+      "width": 1501,
+    },
+    "contestId": "Executive-Councilor-bb22557f",
+    "options": [
+      {
+        "bounds": {
+          "height": 101,
+          "left": 173,
+          "top": 909,
+          "width": 501,
+        },
+        "optionId": "Anne-Waldron-ee0cbc85",
+      },
+      {
+        "bounds": {
+          "height": 101,
+          "left": 523,
+          "top": 909,
+          "width": 501,
+        },
+        "optionId": "Daniel-Webster-13f77b2d",
+      },
+      {
+        "bounds": {
+          "height": 101,
+          "left": 1173,
+          "top": 908,
+          "width": 501,
+        },
+        "optionId": "write-in-0",
+      },
+    ],
+  },
+  {
+    "bounds": {
+      "height": 102,
+      "left": 173,
+      "top": 1059,
+      "width": 1501,
+    },
+    "contestId": "State-Senator-391381f8",
+    "options": [
+      {
+        "bounds": {
+          "height": 101,
+          "left": 173,
+          "top": 1060,
+          "width": 502,
+        },
+        "optionId": "James-Poole-db5ef4bd",
+      },
+      {
+        "bounds": {
+          "height": 102,
+          "left": 523,
+          "top": 1059,
+          "width": 501,
+        },
+        "optionId": "Matthew-Thornton-f66fec5e",
+      },
+      {
+        "bounds": {
+          "height": 101,
+          "left": 1173,
+          "top": 1059,
+          "width": 501,
+        },
+        "optionId": "write-in-0",
+      },
+    ],
+  },
+  {
+    "bounds": {
+      "height": 354,
+      "left": 174,
+      "top": 1210,
+      "width": 1501,
+    },
+    "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+    "options": [
+      {
+        "bounds": {
+          "height": 101,
+          "left": 174,
+          "top": 1262,
+          "width": 501,
+        },
+        "optionId": "Obadiah-Carrigan-5c95145a",
+      },
+      {
+        "bounds": {
+          "height": 101,
+          "left": 174,
+          "top": 1362,
+          "width": 501,
+        },
+        "optionId": "Mary-Baker-Eddy-350785d5",
+      },
+      {
+        "bounds": {
+          "height": 101,
+          "left": 174,
+          "top": 1463,
+          "width": 502,
+        },
+        "optionId": "Samuel-Bell-17973275",
+      },
+      {
+        "bounds": {
+          "height": 100,
+          "left": 524,
+          "top": 1211,
+          "width": 501,
+        },
+        "optionId": "Samuel-Livermore-f927fef1",
+      },
+      {
+        "bounds": {
+          "height": 101,
+          "left": 524,
+          "top": 1311,
+          "width": 501,
+        },
+        "optionId": "Elijah-Miller-a52e6988",
+      },
+      {
+        "bounds": {
+          "height": 101,
+          "left": 524,
+          "top": 1412,
+          "width": 501,
+        },
+        "optionId": "Isaac-Hill-d6c9deeb",
+      },
+      {
+        "bounds": {
+          "height": 100,
+          "left": 873,
+          "top": 1261,
+          "width": 502,
+        },
+        "optionId": "Abigail-Bartlett-4e46c9d4",
+      },
+      {
+        "bounds": {
+          "height": 101,
+          "left": 874,
+          "top": 1361,
+          "width": 501,
+        },
+        "optionId": "Jacob-Freese-b5146505",
+      },
+      {
+        "bounds": {
+          "height": 101,
+          "left": 1173,
+          "top": 1210,
+          "width": 502,
+        },
+        "optionId": "write-in-0",
+      },
+      {
+        "bounds": {
+          "height": 101,
+          "left": 1174,
+          "top": 1310,
+          "width": 501,
+        },
+        "optionId": "write-in-1",
+      },
+      {
+        "bounds": {
+          "height": 101,
+          "left": 1174,
+          "top": 1411,
+          "width": 499,
+        },
+        "optionId": "write-in-2",
+      },
+    ],
+  },
+  {
+    "bounds": {
+      "height": 102,
+      "left": 175,
+      "top": 1662,
+      "width": 1501,
+    },
+    "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
+    "options": [
+      {
+        "bounds": {
+          "height": 99,
+          "left": 175,
+          "top": 1665,
+          "width": 501,
+        },
+        "optionId": "Abeil-Foster-ded38e36",
+      },
+      {
+        "bounds": {
+          "height": 99,
+          "left": 525,
+          "top": 1664,
+          "width": 501,
+        },
+        "optionId": "Charles-H-Hersey-096286a4",
+      },
+      {
+        "bounds": {
+          "height": 99,
+          "left": 874,
+          "top": 1663,
+          "width": 502,
+        },
+        "optionId": "William-Lovejoy-fde3c2df",
+      },
+      {
+        "bounds": {
+          "height": 99,
+          "left": 1174,
+          "top": 1662,
+          "width": 502,
+        },
+        "optionId": "write-in-0",
+      },
+    ],
+  },
+]
+`;
+
+exports[`interpret with valid data 2`] = `
+[
+  {
+    "bounds": {
+      "height": 102,
+      "left": 182,
+      "top": 253,
+      "width": 1501,
+    },
+    "contestId": "Sheriff-4243fe0b",
+    "options": [
+      {
+        "bounds": {
+          "height": 102,
+          "left": 182,
+          "top": 253,
+          "width": 501,
+        },
+        "optionId": "Edward-Randolph-bf4c848a",
+      },
+      {
+        "bounds": {
+          "height": 102,
+          "left": 532,
+          "top": 253,
+          "width": 501,
+        },
+        "optionId": "Edward-Randolph-bf4c848a",
+      },
+      {
+        "bounds": {
+          "height": 102,
+          "left": 1182,
+          "top": 253,
+          "width": 501,
+        },
+        "optionId": "write-in-0",
+      },
+    ],
+  },
+  {
+    "bounds": {
+      "height": 101,
+      "left": 182,
+      "top": 405,
+      "width": 1501,
+    },
+    "contestId": "County-Attorney-133f910f",
+    "options": [
+      {
+        "bounds": {
+          "height": 101,
+          "left": 182,
+          "top": 405,
+          "width": 501,
+        },
+        "optionId": "Ezra-Bartlett-8f95223c",
+      },
+      {
+        "bounds": {
+          "height": 101,
+          "left": 532,
+          "top": 405,
+          "width": 501,
+        },
+        "optionId": "Mary-Woolson-dc0b854a",
+      },
+      {
+        "bounds": {
+          "height": 101,
+          "left": 1182,
+          "top": 405,
+          "width": 501,
+        },
+        "optionId": "write-in-0",
+      },
+    ],
+  },
+  {
+    "bounds": {
+      "height": 103,
+      "left": 182,
+      "top": 555,
+      "width": 1502,
+    },
+    "contestId": "County-Treasurer-87d25a31",
+    "options": [
+      {
+        "bounds": {
+          "height": 102,
+          "left": 182,
+          "top": 555,
+          "width": 501,
+        },
+        "optionId": "John-Smith-ef61a579",
+      },
+      {
+        "bounds": {
+          "height": 102,
+          "left": 532,
+          "top": 555,
+          "width": 501,
+        },
+        "optionId": "Jane-Jones-9caa141f",
+      },
+      {
+        "bounds": {
+          "height": 102,
+          "left": 1182,
+          "top": 556,
+          "width": 502,
+        },
+        "optionId": "write-in-0",
+      },
+    ],
+  },
+  {
+    "bounds": {
+      "height": 102,
+      "left": 182,
+      "top": 707,
+      "width": 1501,
+    },
+    "contestId": "Register-of-Deeds-a1278df2",
+    "options": [
+      {
+        "bounds": {
+          "height": 101,
+          "left": 182,
+          "top": 707,
+          "width": 501,
+        },
+        "optionId": "John-Mann-b56bbdd3",
+      },
+      {
+        "bounds": {
+          "height": 102,
+          "left": 532,
+          "top": 707,
+          "width": 501,
+        },
+        "optionId": "Ellen-A-Stileman-14408737",
+      },
+      {
+        "bounds": {
+          "height": 102,
+          "left": 1182,
+          "top": 707,
+          "width": 501,
+        },
+        "optionId": "write-in-0",
+      },
+    ],
+  },
+  {
+    "bounds": {
+      "height": 103,
+      "left": 182,
+      "top": 857,
+      "width": 1500,
+    },
+    "contestId": "Register-of-Probate-a4117da8",
+    "options": [
+      {
+        "bounds": {
+          "height": 102,
+          "left": 182,
+          "top": 857,
+          "width": 500,
+        },
+        "optionId": "Nathaniel-Parker-56a06c29",
+      },
+      {
+        "bounds": {
+          "height": 102,
+          "left": 532,
+          "top": 857,
+          "width": 500,
+        },
+        "optionId": "Claire-Cutts-07a436e7",
+      },
+      {
+        "bounds": {
+          "height": 102,
+          "left": 1182,
+          "top": 858,
+          "width": 500,
+        },
+        "optionId": "write-in-0",
+      },
+    ],
+  },
+  {
+    "bounds": {
+      "height": 103,
+      "left": 182,
+      "top": 1008,
+      "width": 1500,
+    },
+    "contestId": "County-Commissioner-d6feed25",
+    "options": [
+      {
+        "bounds": {
+          "height": 102,
+          "left": 182,
+          "top": 1008,
+          "width": 501,
+        },
+        "optionId": "Ichabod-Goodwin-55e8de1f",
+      },
+      {
+        "bounds": {
+          "height": 102,
+          "left": 532,
+          "top": 1008,
+          "width": 500,
+        },
+        "optionId": "Valbe-Cady-ba3af3af",
+      },
+      {
+        "bounds": {
+          "height": 102,
+          "left": 1181,
+          "top": 1009,
+          "width": 501,
+        },
+        "optionId": "write-in-0",
+      },
+    ],
+  },
+  {
+    "bounds": {
+      "height": 103,
+      "left": 881,
+      "top": 1260,
+      "width": 800,
+    },
+    "contestId": "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc",
+    "options": [
+      {
+        "bounds": {
+          "height": 103,
+          "left": 881,
+          "top": 1260,
+          "width": 500,
+        },
+        "optionId": "yes",
+      },
+      {
+        "bounds": {
+          "height": 103,
+          "left": 1181,
+          "top": 1260,
+          "width": 500,
+        },
+        "optionId": "no",
+      },
+    ],
+  },
+]
+`;

--- a/libs/ballot-interpreter-nh-next/ts/src/adapter.test.ts
+++ b/libs/ballot-interpreter-nh-next/ts/src/adapter.test.ts
@@ -141,6 +141,10 @@ test('interpret with valid data', async () => {
   const [front, back] = result.unsafeUnwrap();
   assert(front.interpretation.type === 'InterpretedHmpbPage');
   assert(back.interpretation.type === 'InterpretedHmpbPage');
+  expect(front.normalizedImage).toBeDefined();
+  expect(back.normalizedImage).toBeDefined();
+  expect(front.interpretation.layout).toMatchSnapshot();
+  expect(back.interpretation.layout).toMatchSnapshot();
   expect(
     [
       ...front.interpretation.markInfo.marks,

--- a/libs/ballot-interpreter-nh-next/ts/src/adapter.ts
+++ b/libs/ballot-interpreter-nh-next/ts/src/adapter.ts
@@ -11,9 +11,13 @@ import {
 import {
   AdjudicationInfo,
   AdjudicationReason,
+  AnyContest,
+  BallotPageContestLayout,
+  BallotPageContestOptionLayout,
   BallotTargetMark,
   BallotType,
   Contests,
+  Corners,
   ElectionDefinition,
   getBallotStyle,
   HmpbBallotPageMetadata,
@@ -35,9 +39,11 @@ import {
   BallotPageMetadataFront,
   Geometry,
   InterpretedBallotCard,
-  InterpretedBallotPage,
   InterpretResult as NextInterpretResult,
   ScoredOvalMarks,
+  Rect as NextRect,
+  InterpretedContestLayout,
+  InterpretedContestOptionLayout,
 } from './types';
 
 type OkType<T> = T extends Ok<infer U> ? U : never;
@@ -229,6 +235,64 @@ function buildInterpretedHmpbPageMetadata(
   };
 }
 
+function convertContestLayouts(
+  contests: Contests,
+  contestLayouts: InterpretedContestLayout[]
+): BallotPageContestLayout[] {
+  function convertRect(rect: NextRect): Rect {
+    return {
+      x: rect.left,
+      y: rect.top,
+      width: rect.width,
+      height: rect.height,
+    };
+  }
+
+  function rectToCorners(rect: NextRect): Corners {
+    return [
+      // Top left
+      { x: rect.left, y: rect.top },
+      // Top right
+      { x: rect.left + rect.width, y: rect.top },
+      // Bottom left
+      { x: rect.left, y: rect.top + rect.height },
+      // Bottom right
+      { x: rect.left + rect.width, y: rect.top + rect.height },
+    ];
+  }
+
+  function convertContestOptionLayout(
+    contest: AnyContest,
+    { bounds, optionId }: InterpretedContestOptionLayout
+  ): BallotPageContestOptionLayout {
+    const option = iter(allContestOptions(contest)).find(
+      (o) => o.id === optionId
+    );
+    assert(option, `option ${optionId} not found`);
+    return {
+      definition: option,
+      bounds: convertRect(bounds),
+      // TODO is this needed? Filled with a dummy value for now
+      target: {
+        bounds: { x: 0, y: 0, width: 1, height: 1 },
+        inner: { x: 0, y: 0, width: 1, height: 1 },
+      },
+    };
+  }
+
+  return contestLayouts.map(({ contestId, bounds, options }) => {
+    const contest = find(contests, (c) => c.id === contestId);
+    return {
+      contestId,
+      bounds: convertRect(bounds),
+      corners: rectToCorners(bounds),
+      options: options.map((option) =>
+        convertContestOptionLayout(contest, option)
+      ),
+    };
+  });
+}
+
 function convertNextInterpretedBallotPage(
   electionDefinition: ElectionDefinition,
   options: InterpretOptions,
@@ -240,17 +304,18 @@ function convertNextInterpretedBallotPage(
     options.markThresholds ?? electionDefinition.election.markThresholds;
   assert(markThresholds, 'markThresholds must be defined');
 
+  const metadata = buildInterpretedHmpbPageMetadata(
+    electionDefinition,
+    options,
+    nextInterpretedBallotCard.front.grid.metadata as BallotPageMetadataFront,
+    side
+  );
+
   const nextInterpretation = nextInterpretedBallotCard[side];
   return {
     interpretation: {
       type: 'InterpretedHmpbPage',
-      metadata: buildInterpretedHmpbPageMetadata(
-        electionDefinition,
-        options,
-        nextInterpretedBallotCard.front.grid
-          .metadata as BallotPageMetadataFront,
-        side
-      ),
+      metadata,
       markInfo: convertMarksToMarkInfo(
         electionDefinition.election.contests,
         nextInterpretation.grid.geometry,
@@ -266,6 +331,14 @@ function convertNextInterpretedBallotPage(
         markThresholds,
         nextInterpretation.marks
       ),
+      layout: {
+        pageSize: nextInterpretation.grid.geometry.canvasSize,
+        metadata,
+        contests: convertContestLayouts(
+          electionDefinition.election.contests,
+          nextInterpretation.contestLayouts
+        ),
+      },
     },
     normalizedImage: {
       ...nextInterpretation.normalizedImage,

--- a/libs/ballot-interpreter-nh-next/ts/src/adapter.ts
+++ b/libs/ballot-interpreter-nh-next/ts/src/adapter.ts
@@ -266,6 +266,10 @@ function convertNextInterpretedBallotPage(
         nextInterpretation.marks
       ),
     },
+    normalizedImage: {
+      ...nextInterpretation.normalizedImage,
+      data: new Uint8ClampedArray(nextInterpretation.normalizedImage.data),
+    },
   };
 }
 

--- a/libs/ballot-interpreter-nh-next/ts/src/adapter.ts
+++ b/libs/ballot-interpreter-nh-next/ts/src/adapter.ts
@@ -208,7 +208,7 @@ function buildInterpretedHmpbPageMetadata(
   electionDefinition: ElectionDefinition,
   options: InterpretOptions,
   frontMetadata: BallotPageMetadataFront,
-  isFrontPage: boolean
+  side: 'front' | 'back'
 ): HmpbBallotPageMetadata {
   const ballotStyleId = `card-number-${frontMetadata.cardNumber}`;
   const ballotStyle = getBallotStyle({
@@ -225,7 +225,7 @@ function buildInterpretedHmpbPageMetadata(
     electionHash: electionDefinition.electionHash,
     isTestMode: options.isTestMode,
     locales: { primary: 'en-US' },
-    pageNumber: isFrontPage ? 1 : 2,
+    pageNumber: side === 'front' ? 1 : 2,
   };
 }
 
@@ -233,13 +233,14 @@ function convertNextInterpretedBallotPage(
   electionDefinition: ElectionDefinition,
   options: InterpretOptions,
   nextInterpretedBallotCard: InterpretedBallotCard,
-  nextInterpretation: InterpretedBallotPage
+  side: 'front' | 'back'
 ): current.InterpretFileResult {
   /* istanbul ignore next */
   const markThresholds =
     options.markThresholds ?? electionDefinition.election.markThresholds;
   assert(markThresholds, 'markThresholds must be defined');
 
+  const nextInterpretation = nextInterpretedBallotCard[side];
   return {
     interpretation: {
       type: 'InterpretedHmpbPage',
@@ -248,7 +249,7 @@ function convertNextInterpretedBallotPage(
         options,
         nextInterpretedBallotCard.front.grid
           .metadata as BallotPageMetadataFront,
-        nextInterpretation === nextInterpretedBallotCard.front
+        side
       ),
       markInfo: convertMarksToMarkInfo(
         electionDefinition.election.contests,
@@ -284,19 +285,18 @@ function convertNextInterpretResult(
   }
 
   const ballotCard = nextResult.ok();
-  const { front, back } = ballotCard;
   const currentResult: OkType<InterpretResult> = [
     convertNextInterpretedBallotPage(
       electionDefinition,
       options,
       ballotCard,
-      front
+      'front'
     ),
     convertNextInterpretedBallotPage(
       electionDefinition,
       options,
       ballotCard,
-      back
+      'back'
     ),
   ];
   return ok(currentResult);

--- a/libs/ballot-interpreter-nh-next/ts/src/interpret.ts
+++ b/libs/ballot-interpreter-nh-next/ts/src/interpret.ts
@@ -41,7 +41,19 @@ export function interpret(
 
   const value = parseJsonResult.ok();
 
-  return result.success
-    ? ok(value as InterpretedBallotCard)
-    : err(value as InterpretError);
+  if (!result.success) {
+    return err(value as InterpretError);
+  }
+
+  const interpretedBallotCard = value as InterpretedBallotCard;
+
+  // The normalized images are not included in the JSON string for performance
+  // reasons. Instead, they are transferred as `ImageData`-compatible objects
+  // which transfers the pixel data as a fast memory copy. As a result, we need
+  // to add them back in here.
+  const { frontNormalizedImage, backNormalizedImage } = result;
+  interpretedBallotCard.front.normalizedImage = frontNormalizedImage;
+  interpretedBallotCard.back.normalizedImage = backNormalizedImage;
+
+  return ok(interpretedBallotCard);
 }

--- a/libs/ballot-interpreter-nh-next/ts/src/rust-addon.d.ts
+++ b/libs/ballot-interpreter-nh-next/ts/src/rust-addon.d.ts
@@ -1,10 +1,17 @@
 /**
  * The result of calling `interpret`.
  */
-export interface BridgeInterpretResult {
-  success: boolean;
-  value: string;
-}
+export type BridgeInterpretResult =
+  | {
+      success: false;
+      value: string;
+    }
+  | {
+      success: true;
+      value: string;
+      frontNormalizedImage: ImageData;
+      backNormalizedImage: ImageData;
+    };
 
 /**
  * Type of the Rust `interpret` implementation. Under normal circumstances,

--- a/libs/ballot-interpreter-nh-next/ts/src/types.ts
+++ b/libs/ballot-interpreter-nh-next/ts/src/types.ts
@@ -95,6 +95,14 @@ export interface InterpretedBallotCard {
 export interface InterpretedBallotPage {
   grid: TimingMarkGrid;
   marks: ScoredOvalMarks;
+  normalizedImage: NormalizedImageBuffer;
+}
+
+/** Image data for the normalized ballot image produced during interpetation. */
+export interface NormalizedImageBuffer {
+  width: u32;
+  height: u32;
+  data: number[];
 }
 
 /** An array of optional marks and their corresponding grid positions. */

--- a/libs/ballot-interpreter-nh-next/ts/src/types.ts
+++ b/libs/ballot-interpreter-nh-next/ts/src/types.ts
@@ -95,15 +95,8 @@ export interface InterpretedBallotCard {
 export interface InterpretedBallotPage {
   grid: TimingMarkGrid;
   marks: ScoredOvalMarks;
-  normalizedImage: NormalizedImageBuffer;
+  normalizedImage: ImageData;
   contestLayouts: InterpretedContestLayout[];
-}
-
-/** Image data for the normalized ballot image produced during interpetation. */
-export interface NormalizedImageBuffer {
-  width: u32;
-  height: u32;
-  data: number[];
 }
 
 /** The pixel bounds outlining a contest option in the normalized ballot image. */

--- a/libs/ballot-interpreter-nh-next/ts/src/types.ts
+++ b/libs/ballot-interpreter-nh-next/ts/src/types.ts
@@ -96,6 +96,7 @@ export interface InterpretedBallotPage {
   grid: TimingMarkGrid;
   marks: ScoredOvalMarks;
   normalizedImage: NormalizedImageBuffer;
+  contestLayouts: InterpretedContestLayout[];
 }
 
 /** Image data for the normalized ballot image produced during interpetation. */
@@ -103,6 +104,19 @@ export interface NormalizedImageBuffer {
   width: u32;
   height: u32;
   data: number[];
+}
+
+/** The pixel bounds outlining a contest option in the normalized ballot image. */
+export interface InterpretedContestOptionLayout {
+  optionId: string;
+  bounds: Rect;
+}
+
+/** The pixel bounds outlining a contest in the normalized ballot image. */
+export interface InterpretedContestLayout {
+  contestId: string;
+  bounds: Rect;
+  options: InterpretedContestOptionLayout[];
 }
 
 /** An array of optional marks and their corresponding grid positions. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3282,6 +3282,9 @@ importers:
       '@votingworks/basics':
         specifier: workspace:*
         version: link:../basics
+      '@votingworks/image-utils':
+        specifier: workspace:*
+        version: link:../image-utils
       '@votingworks/types':
         specifier: workspace:*
         version: link:../types
@@ -3294,6 +3297,9 @@ importers:
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
+      tmp:
+        specifier: ^0.2.1
+        version: 0.2.1
     devDependencies:
       '@jest/types':
         specifier: ^29.5.0
@@ -3310,6 +3316,9 @@ importers:
       '@types/node':
         specifier: 16.18.23
         version: 16.18.23
+      '@types/tmp':
+        specifier: ^0.2.3
+        version: 0.2.3
       '@typescript-eslint/eslint-plugin':
         specifier: 5.37.0
         version: 5.37.0(@typescript-eslint/parser@5.37.0)(eslint@8.23.1)(typescript@4.6.3)


### PR DESCRIPTION
## Overview

Task: #3143

In order to get write-in adjudication working with the nh-next interpreter, we modify the interpreter to return normalized ballot images and computed ballot layout information.

_Review by commit_

## Demo Video or Screenshot
N/A

## Testing Plan
- Manual tests
- Added some basic automated tests (mainly testing plumbing, plus a few invariants on the computed layouts)
- @eventualbuddha did performance testing

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
