### PR TITLE
[VxScan] Update 'Insert Ballot' screen copy for VxScanMax

### DIFF
--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -395,7 +395,7 @@ async function scanBallot() {
 
   apiMock.expectGetScannerStatus(statusBallotCounted);
   jest.advanceTimersByTime(POLLING_INTERVAL_FOR_SCANNER_STATUS_MS);
-  await screen.findByText('Insert Your Ballot Below');
+  await screen.findByText('Insert Your Ballot Above');
   expect(screen.getByTestId('ballot-count').textContent).toEqual('1');
 }
 
@@ -406,7 +406,7 @@ test('voter can cast a ballot that scans successfully ', async () => {
   });
   apiMock.expectGetScannerStatus(statusNoPaper);
   renderApp();
-  await screen.findByText('Insert Your Ballot Below');
+  await screen.findByText('Insert Your Ballot Above');
   screen.getByText('Scan one ballot sheet at a time.');
   screen.getByText('General Election');
   screen.getByText(/Franklin County/);
@@ -515,7 +515,7 @@ test('voter can cast a ballot that needs review and adjudicate as desired', asyn
   apiMock.expectGetConfig({ pollsState: 'polls_open' });
   apiMock.expectGetScannerStatus(statusNoPaper);
   renderApp();
-  await screen.findByText('Insert Your Ballot Below');
+  await screen.findByText('Insert Your Ballot Above');
 
   const interpretation: SheetInterpretation = {
     type: 'NeedsReviewSheet',
@@ -554,7 +554,7 @@ test('voter can cast a ballot that needs review and adjudicate as desired', asyn
     scannerStatus({ state: 'no_paper', ballotsCounted: 1 })
   );
   jest.advanceTimersByTime(POLLING_INTERVAL_FOR_SCANNER_STATUS_MS);
-  await screen.findByText('Insert Your Ballot Below');
+  await screen.findByText('Insert Your Ballot Above');
   expect(screen.getByTestId('ballot-count').textContent).toEqual('1');
 });
 
@@ -562,7 +562,7 @@ test('voter tries to cast ballot that is rejected', async () => {
   apiMock.expectGetConfig({ pollsState: 'polls_open' });
   apiMock.expectGetScannerStatus(statusNoPaper);
   renderApp();
-  await screen.findByText('Insert Your Ballot Below');
+  await screen.findByText('Insert Your Ballot Above');
 
   apiMock.expectGetScannerStatus(scannerStatus({ state: 'ready_to_scan' }));
   apiMock.mockApiClient.scanBallot.expectCallWith().resolves();
@@ -587,7 +587,7 @@ test('voter tries to cast ballot that is rejected', async () => {
 
   // When the voter removes the ballot return to the insert ballot screen
   apiMock.expectGetScannerStatus(statusNoPaper);
-  await screen.findByText('Insert Your Ballot Below');
+  await screen.findByText('Insert Your Ballot Above');
 });
 
 test('voter can cast another ballot while the success screen is showing', async () => {
@@ -657,7 +657,7 @@ test('no printer: poll worker can open and close polls without scanning any ball
     'Insert poll worker card into VxMark to print the report.'
   );
   apiMock.removeCard();
-  await screen.findByText('Insert Your Ballot Below');
+  await screen.findByText('Insert Your Ballot Above');
 
   // Close Polls Flow
   apiMock.expectGetCastVoteRecordsForTally([]);
@@ -703,7 +703,7 @@ test('with printer: poll worker can open and close polls without scanning any ba
   screen.getByRole('button', { name: 'Print Additional Polls Opened Report' });
   screen.getByText('Remove the poll worker card', { exact: false });
   apiMock.removeCard();
-  await screen.findByText('Insert Your Ballot Below');
+  await screen.findByText('Insert Your Ballot Above');
 
   // Close Polls Flow
   apiMock.expectGetCastVoteRecordsForTally([]);
@@ -747,7 +747,7 @@ test('no printer: open polls, scan ballot, close polls, save results', async () 
     apiMock.mockApiClient.saveScannerReportDataToCard
   ).toHaveBeenCalledTimes(1);
   apiMock.removeCard();
-  await screen.findByText('Insert Your Ballot Below');
+  await screen.findByText('Insert Your Ballot Above');
 
   await scanBallot();
 
@@ -825,7 +825,7 @@ test('poll worker can open, pause, unpause, and close poll without scanning any 
     'Insert poll worker card into VxMark to print the report.'
   );
   apiMock.removeCard();
-  await screen.findByText('Insert Your Ballot Below');
+  await screen.findByText('Insert Your Ballot Above');
 
   // Pause Voting Flow
   apiMock.expectGetCastVoteRecordsForTally([]);
@@ -853,7 +853,7 @@ test('poll worker can open, pause, unpause, and close poll without scanning any 
     'Insert poll worker card into VxMark to print the report.'
   );
   apiMock.removeCard();
-  await screen.findByText('Insert Your Ballot Below');
+  await screen.findByText('Insert Your Ballot Above');
 
   // Close Polls Flow
   apiMock.expectGetCastVoteRecordsForTally([]);
@@ -964,7 +964,7 @@ test('replace ballot bag flow', async () => {
   });
   apiMock.expectGetScannerStatus(statusNoPaper);
   const { logger } = renderApp();
-  await screen.findByText('Insert Your Ballot Below');
+  await screen.findByText('Insert Your Ballot Above');
 
   await scanBallot();
 
@@ -1006,7 +1006,7 @@ test('replace ballot bag flow', async () => {
   });
   apiMock.removeCard();
   await advanceTimersAndPromises(3);
-  await screen.findByText('Insert Your Ballot Below');
+  await screen.findByText('Insert Your Ballot Above');
 
   expect(logger.log).toHaveBeenCalledWith(
     LogEventId.BallotBagReplaced,
@@ -1022,7 +1022,7 @@ test('replace ballot bag flow', async () => {
     })
   );
   await advanceTimersAndPromises(1);
-  await screen.findByText('Insert Your Ballot Below');
+  await screen.findByText('Insert Your Ballot Above');
 
   // Prompts again if new threshold has been reached
   apiMock.expectGetScannerStatus(

--- a/apps/scan/frontend/src/app_tally_report_paths.test.tsx
+++ b/apps/scan/frontend/src/app_tally_report_paths.test.tsx
@@ -353,7 +353,7 @@ test('printing: polls closed, primary election, all precincts + quickresults on'
   apiMock.expectGetConfig({ electionDefinition, pollsState: 'polls_open' });
   apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 3 });
   renderApp({ connectPrinter: true });
-  await screen.findByText('Insert Your Ballot Below');
+  await screen.findByText('Insert Your Ballot Above');
 
   // Close the polls
   await closePolls({
@@ -583,7 +583,7 @@ test('saving to card: polls closed, primary election, all precincts', async () =
   apiMock.expectGetConfig({ electionDefinition, pollsState: 'polls_open' });
   apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 3 });
   renderApp({ connectPrinter: false });
-  await screen.findByText('Insert Your Ballot Below');
+  await screen.findByText('Insert Your Ballot Above');
 
   // Close the polls
   await closePolls({
@@ -708,7 +708,7 @@ test('printing: polls closed, primary election, single precinct + check addition
   });
   apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 3 });
   renderApp({ connectPrinter: true });
-  await screen.findByText('Insert Your Ballot Below');
+  await screen.findByText('Insert Your Ballot Above');
 
   // Close the polls
   await closePolls({
@@ -856,7 +856,7 @@ test('saving to card: polls closed, primary election, single precinct', async ()
   });
   apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 3 });
   renderApp({ connectPrinter: false });
-  await screen.findByText('Insert Your Ballot Below');
+  await screen.findByText('Insert Your Ballot Above');
 
   // Close the polls
   await closePolls({
@@ -938,7 +938,7 @@ test('printing: polls closed, general election, all precincts', async () => {
   apiMock.expectGetConfig({ electionDefinition, pollsState: 'polls_open' });
   apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 });
   renderApp({ connectPrinter: true });
-  await screen.findByText('Insert Your Ballot Below');
+  await screen.findByText('Insert Your Ballot Above');
 
   // Close the polls
   await closePolls({
@@ -1026,7 +1026,7 @@ test('saving to card: polls closed, general election, all precincts', async () =
   apiMock.expectGetConfig({ electionDefinition, pollsState: 'polls_open' });
   apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 });
   renderApp({ connectPrinter: false });
-  await screen.findByText('Insert Your Ballot Below');
+  await screen.findByText('Insert Your Ballot Above');
 
   // Close the polls
   await closePolls({
@@ -1115,7 +1115,7 @@ test('printing: polls closed, general election, single precinct', async () => {
   });
   apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 });
   renderApp({ connectPrinter: true });
-  await screen.findByText('Insert Your Ballot Below');
+  await screen.findByText('Insert Your Ballot Above');
 
   // Close the polls
   await closePolls({
@@ -1180,7 +1180,7 @@ test('saving to card: polls closed, general election, single precinct', async ()
   });
   apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 });
   renderApp({ connectPrinter: false });
-  await screen.findByText('Insert Your Ballot Below');
+  await screen.findByText('Insert Your Ballot Above');
 
   // Close the polls
   await closePolls({
@@ -1284,7 +1284,7 @@ test('printing: polls closed, general election with non-partisan contests, all p
   });
   apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 4 });
   renderApp({ connectPrinter: true });
-  await screen.findByText('Insert Your Ballot Below');
+  await screen.findByText('Insert Your Ballot Above');
 
   await closePolls({
     electionDefinition,
@@ -1368,7 +1368,7 @@ test('saving to card: polls closed, general election with non-partisan contests,
   });
   apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 4 });
   renderApp({ connectPrinter: false });
-  await screen.findByText('Insert Your Ballot Below');
+  await screen.findByText('Insert Your Ballot Above');
 
   // Close the polls
   await closePolls({
@@ -1452,7 +1452,7 @@ test('printing: polls paused', async () => {
   });
   apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 });
   renderApp({ connectPrinter: true });
-  await screen.findByText('Insert Your Ballot Below');
+  await screen.findByText('Insert Your Ballot Above');
 
   // Pause the polls
   apiMock.expectGetCastVoteRecordsForTally(GENERAL_SINGLE_PRECINCT_CVRS);
@@ -1492,7 +1492,7 @@ test('saving to card: polls paused', async () => {
   });
   apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 });
   renderApp({ connectPrinter: false });
-  await screen.findByText('Insert Your Ballot Below');
+  await screen.findByText('Insert Your Ballot Above');
 
   // Pause the polls
   apiMock.expectGetCastVoteRecordsForTally(GENERAL_SINGLE_PRECINCT_CVRS);

--- a/apps/scan/frontend/src/app_unhappy_paths.test.tsx
+++ b/apps/scan/frontend/src/app_unhappy_paths.test.tsx
@@ -223,7 +223,7 @@ test('App shows warning message to connect to power when disconnected', async ()
 
   // Remove pollworker card
   apiMock.removeCard();
-  await screen.findByText('Insert Your Ballot Below');
+  await screen.findByText('Insert Your Ballot Above');
   // There should be no warning about power
   expect(screen.queryByText('No Power Detected.')).toBeNull();
   // Disconnect from power and check for warning
@@ -252,7 +252,7 @@ test('removing card during calibration', async () => {
   apiMock.expectGetConfig({ pollsState: 'polls_open' });
   await screen.findByText('Polls are open.');
   apiMock.removeCard();
-  await screen.findByText('Insert Your Ballot Below');
+  await screen.findByText('Insert Your Ballot Above');
 
   // Start calibrating
   apiMock.authenticateAsElectionManager(electionSampleDefinition);
@@ -283,5 +283,5 @@ test('removing card during calibration', async () => {
 
   apiMock.expectGetScannerStatus(statusNoPaper);
   resolve(true);
-  await screen.findByText('Insert Your Ballot Below');
+  await screen.findByText('Insert Your Ballot Above');
 });

--- a/apps/scan/frontend/src/screens/insert_ballot_screen.tsx
+++ b/apps/scan/frontend/src/screens/insert_ballot_screen.tsx
@@ -26,9 +26,9 @@ export function InsertBallotScreen({
       isLiveMode={isLiveMode}
       ballotCountOverride={scannedBallotCount}
     >
-      <InsertBallotImage />
+      <InsertBallotImage ballotFeedLocation="top" />
       <CenteredLargeProse>
-        <H1>Insert Your Ballot Below</H1>
+        <H1>Insert Your Ballot Above</H1>
         <P>Scan one ballot sheet at a time.</P>
         {showNoChargerWarning && (
           <Caption color="warning">


### PR DESCRIPTION
## Overview

_Code change in 1st commit, test updates in 2nd_

Related to: https://github.com/votingworks/vxsuite/issues/3185

- Updating copy on the "Insert Ballot" screen to reflect new ballot feed tray location on the VxScanMax.
- Also removing the arrow in the animation - it was decided it would be confusing if it points upward, so dropping altogether.

## Demo Video or Screenshot
### Before/After:
<img width="300" src="https://user-images.githubusercontent.com/264902/231538777-e0953542-465b-4e5f-ade7-24af79be1a94.png"> <img width="300" src="https://user-images.githubusercontent.com/264902/231538907-9890b500-f629-4cab-82a7-d295b4709c20.png">

## Testing Plan
- Manual verification
- Updated tests that expect the old wording

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
