### PR TITLE
fix(admin): Rearrange transcription screen ballot images for NH town ballots

### DIFF
--- a/apps/admin/frontend/src/screens/write_ins_transcription_screen.tsx
+++ b/apps/admin/frontend/src/screens/write_ins_transcription_screen.tsx
@@ -30,7 +30,6 @@ const IMAGE_SCALE = 0.5; // The images are downscaled by 50% in the export, this
 const BallotViews = styled.div`
   flex: 3;
   background: #455a64;
-  padding-right: 0.5rem;
 `;
 
 const TranscriptionControls = styled.div`
@@ -238,29 +237,34 @@ export function WriteInsTranscriptionScreen({
       <Main flexRow data-testid={`transcribe:${adjudicationId}`}>
         <BallotViews>
           {imageData && (
-            <React.Fragment>
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                padding: '0.5rem',
+              }}
+            >
               <WriteInImage
                 imageUrl={`data:image/png;base64,${imageData.image}`}
-                bounds={imageData.contestCoordinates}
-                margin={0.1}
+                bounds={imageData.writeInCoordinates}
+                margin={0}
               />
-              <div style={{ display: 'flex', paddingTop: '0.5rem' }}>
+              <div style={{ display: 'flex', marginTop: '0.5rem' }}>
                 <div style={{ flex: 0.9 }}>
                   <WriteInImage
-                    // eslint-disable-next-line
-                imageUrl={`data:image/png;base64,${imageData.image}`}
+                    imageUrl={`data:image/png;base64,${imageData.image}`}
                     bounds={imageData.ballotCoordinates}
                   />
                 </div>
-                <div style={{ flex: 1, paddingLeft: '0.5rem' }}>
+                <div style={{ flex: 1, marginLeft: '0.5rem' }}>
                   <WriteInImage
                     imageUrl={`data:image/png;base64,${imageData.image}`}
-                    bounds={imageData.writeInCoordinates}
-                    margin={0.2}
+                    bounds={imageData.contestCoordinates}
+                    margin={0.1}
                   />
                 </div>
               </div>
-            </React.Fragment>
+            </div>
           )}
         </BallotViews>
         <TranscriptionControls>


### PR DESCRIPTION



## Overview

Task: #3143 

The previous ballot image arrangement was optimized for NH state ballots. This is a temp fix that rearranges the images to work well with NH town ballots specifically. A more generalized solution will be coming in a separate PR.

## Demo Video or Screenshot

![image](https://user-images.githubusercontent.com/530106/231540216-4e562d0e-886b-4f7b-a47a-599b1abd7e04.png)


## Testing Plan
Manually tested

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
