### PR TITLE
docs: update link to Rust style guide

### DIFF
--- a/docs/development/best_practices/rust.md
+++ b/docs/development/best_practices/rust.md
@@ -1,7 +1,7 @@
 # Rust Style Guide
 
 We follow the
-[Rust Style Guide](https://doc.rust-lang.org/1.0.0/style/style/README.html),
+[Rust Style Guide](https://github.com/rust-lang/style-team/blob/master/guide/guide.md),
 with most of it enforced by `rustfmt` and `clippy`.
 
 ## Basics


### PR DESCRIPTION

## Overview

<!-- add a link to a GitHub Issue here -->
The old one seems to be out of date, but is the first thing that comes up when googling "rust style guide".

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
