### PR TITLE
Kevin/vxmark usb and system settings frontend

### DIFF
--- a/apps/mark/backend/src/app.test.ts
+++ b/apps/mark/backend/src/app.test.ts
@@ -10,7 +10,6 @@ import {
   fakeSessionExpiresAt,
   mockOf,
 } from '@votingworks/test-utils';
-import { ElectionDefinition } from '@votingworks/types';
 import { DEV_JURISDICTION, InsertedSmartCardAuthApi } from '@votingworks/auth';
 import {
   ALL_PRECINCTS_SELECTION,
@@ -72,60 +71,6 @@ test('uses default machine config if not set', async () => {
   });
 });
 
-<<<<<<< HEAD
-test('read election definition from card', async () => {
-  const { electionDefinition } = electionFamousNames2021Fixtures;
-  const { electionData, electionHash } = electionDefinition;
-
-  mockOf(mockAuth.readCardDataAsString).mockImplementation(() =>
-    Promise.resolve(ok(electionData))
-  );
-
-  let result: Result<ElectionDefinition, Error>;
-
-  mockOf(mockAuth.getAuthStatus).mockImplementation(() =>
-    Promise.resolve({ status: 'logged_out', reason: 'no_card' })
-  );
-  result = await apiClient.readElectionDefinitionFromCard({ electionHash });
-  expect(result).toEqual(err(new Error('User is not logged in')));
-
-  mockOf(mockAuth.getAuthStatus).mockImplementation(() =>
-    Promise.resolve({
-      status: 'logged_in',
-      user: fakePollWorkerUser(electionDefinition),
-      sessionExpiresAt: fakeSessionExpiresAt(),
-    })
-  );
-  result = await apiClient.readElectionDefinitionFromCard({ electionHash });
-  expect(result).toEqual(err(new Error('User is not an election manager')));
-
-  mockOf(mockAuth.getAuthStatus).mockImplementation(() =>
-    Promise.resolve({
-      status: 'logged_in',
-      user: fakeElectionManagerUser(electionDefinition),
-      sessionExpiresAt: fakeSessionExpiresAt(),
-    })
-  );
-  result = await apiClient.readElectionDefinitionFromCard({ electionHash });
-  expect(result).toEqual(ok(electionDefinition));
-  expect(mockAuth.readCardDataAsString).toHaveBeenCalledTimes(1);
-  expect(mockAuth.readCardDataAsString).toHaveBeenNthCalledWith(1, {
-    electionHash,
-    jurisdiction,
-  });
-
-  mockOf(mockAuth.readCardDataAsString).mockImplementation(() =>
-    Promise.resolve(ok(undefined))
-  );
-  result = await apiClient.readElectionDefinitionFromCard({ electionHash });
-  expect(result).toEqual(
-    err(new Error('Unable to read election definition from card'))
-  );
-  expect(mockAuth.readCardDataAsString).toHaveBeenCalledTimes(2);
-  expect(mockAuth.readCardDataAsString).toHaveBeenNthCalledWith(2, {
-    electionHash,
-    jurisdiction,
-=======
 test('auth', async () => {
   const { electionDefinition } = electionFamousNames2021Fixtures;
   const { electionHash } = electionDefinition;
@@ -133,30 +78,34 @@ test('auth', async () => {
   expect(mockAuth.getAuthStatus).toHaveBeenCalledTimes(1);
   expect(mockAuth.getAuthStatus).toHaveBeenNthCalledWith(1, {
     electionHash,
+    jurisdiction: DEV_JURISDICTION,
   });
 
   await apiClient.checkPin({ electionHash, pin: '123456' });
   expect(mockAuth.checkPin).toHaveBeenCalledTimes(1);
   expect(mockAuth.checkPin).toHaveBeenNthCalledWith(
     1,
-    { electionHash },
+    { electionHash, jurisdiction: DEV_JURISDICTION },
     { pin: '123456' }
   );
 
   await apiClient.updateSessionExpiry({
     electionHash,
-    sessionExpiresAt: new Date().getTime() + 60 * 1000,
+    sessionExpiresAt: fakeSessionExpiresAt(),
   });
   expect(mockAuth.updateSessionExpiry).toHaveBeenCalledTimes(1);
   expect(mockAuth.updateSessionExpiry).toHaveBeenNthCalledWith(
     1,
-    { electionHash },
-    { sessionExpiresAt: expect.any(Number) }
+    { electionHash, jurisdiction: DEV_JURISDICTION },
+    { sessionExpiresAt: expect.any(Date) }
   );
 
   await apiClient.logOut({ electionHash });
   expect(mockAuth.logOut).toHaveBeenCalledTimes(1);
-  expect(mockAuth.logOut).toHaveBeenNthCalledWith(1, { electionHash });
+  expect(mockAuth.logOut).toHaveBeenNthCalledWith(1, {
+    electionHash,
+    jurisdiction: DEV_JURISDICTION,
+  });
 
   await apiClient.startCardlessVoterSession({
     electionHash,
@@ -166,7 +115,7 @@ test('auth', async () => {
   expect(mockAuth.startCardlessVoterSession).toHaveBeenCalledTimes(1);
   expect(mockAuth.startCardlessVoterSession).toHaveBeenNthCalledWith(
     1,
-    { electionHash },
+    { electionHash, jurisdiction: DEV_JURISDICTION },
     { ballotStyleId: 'b1', precinctId: 'p1' }
   );
 
@@ -174,7 +123,7 @@ test('auth', async () => {
   expect(mockAuth.endCardlessVoterSession).toHaveBeenCalledTimes(1);
   expect(mockAuth.endCardlessVoterSession).toHaveBeenNthCalledWith(1, {
     electionHash,
->>>>>>> 5db5c368f (update tests pt 4)
+    jurisdiction: DEV_JURISDICTION,
   });
 });
 
@@ -317,7 +266,7 @@ test('unconfigureMachine deletes system settings and election definition', async
     Promise.resolve({
       status: 'logged_in',
       user: fakeElectionManagerUser(electionDefinition),
-      sessionExpiresAt: new Date().getTime() + 60 * 1000,
+      sessionExpiresAt: fakeSessionExpiresAt(),
     })
   );
 

--- a/apps/mark/backend/src/app.test.ts
+++ b/apps/mark/backend/src/app.test.ts
@@ -189,9 +189,7 @@ test('configureBallotPackageFromUsb reads to and writes from store', async () =>
     },
   });
 
-  const writeResult = await apiClient.configureBallotPackageFromUsb({
-    electionHash: electionDefinition.electionHash,
-  });
+  const writeResult = await apiClient.configureBallotPackageFromUsb();
   assert(writeResult.isOk());
 
   const readResult = await apiClient.getSystemSettings();
@@ -223,9 +221,7 @@ test('unconfigureMachine deletes system settings and election definition', async
     },
   });
 
-  const writeResult = await apiClient.configureBallotPackageFromUsb({
-    electionHash: electionDefinition.electionHash,
-  });
+  const writeResult = await apiClient.configureBallotPackageFromUsb();
   assert(writeResult.isOk());
   await apiClient.unconfigureMachine();
 
@@ -236,18 +232,12 @@ test('unconfigureMachine deletes system settings and election definition', async
 });
 
 test('configureBallotPackageFromUsb throws when no USB drive mounted', async () => {
-  const { electionDefinition } = electionFamousNames2021Fixtures;
-
-  await expect(
-    apiClient.configureBallotPackageFromUsb({
-      electionHash: electionDefinition.electionHash,
-    })
-  ).rejects.toThrow('No USB drive mounted');
+  await expect(apiClient.configureBallotPackageFromUsb()).rejects.toThrow(
+    'No USB drive mounted'
+  );
 });
 
 test('configureBallotPackageFromUsb returns an error if ballot package parsing fails', async () => {
-  const { electionDefinition } = electionFamousNames2021Fixtures;
-
   // Lack of auth will cause ballot package reading to throw
   mockOf(mockAuth.getAuthStatus).mockImplementation(() =>
     Promise.resolve({
@@ -262,9 +252,7 @@ test('configureBallotPackageFromUsb returns an error if ballot package parsing f
     },
   });
 
-  const result = await apiClient.configureBallotPackageFromUsb({
-    electionHash: electionDefinition.electionHash,
-  });
+  const result = await apiClient.configureBallotPackageFromUsb();
   assert(result.isErr());
   expect(result.err()).toEqual('auth_required_before_ballot_package_load');
 });

--- a/apps/mark/backend/src/app.test.ts
+++ b/apps/mark/backend/src/app.test.ts
@@ -71,62 +71,6 @@ test('uses default machine config if not set', async () => {
   });
 });
 
-test('auth', async () => {
-  const { electionDefinition } = electionFamousNames2021Fixtures;
-  const { electionHash } = electionDefinition;
-  await apiClient.getAuthStatus({ electionHash });
-  expect(mockAuth.getAuthStatus).toHaveBeenCalledTimes(1);
-  expect(mockAuth.getAuthStatus).toHaveBeenNthCalledWith(1, {
-    electionHash,
-    jurisdiction: DEV_JURISDICTION,
-  });
-
-  await apiClient.checkPin({ electionHash, pin: '123456' });
-  expect(mockAuth.checkPin).toHaveBeenCalledTimes(1);
-  expect(mockAuth.checkPin).toHaveBeenNthCalledWith(
-    1,
-    { electionHash, jurisdiction: DEV_JURISDICTION },
-    { pin: '123456' }
-  );
-
-  await apiClient.updateSessionExpiry({
-    electionHash,
-    sessionExpiresAt: fakeSessionExpiresAt(),
-  });
-  expect(mockAuth.updateSessionExpiry).toHaveBeenCalledTimes(1);
-  expect(mockAuth.updateSessionExpiry).toHaveBeenNthCalledWith(
-    1,
-    { electionHash, jurisdiction: DEV_JURISDICTION },
-    { sessionExpiresAt: expect.any(Date) }
-  );
-
-  await apiClient.logOut({ electionHash });
-  expect(mockAuth.logOut).toHaveBeenCalledTimes(1);
-  expect(mockAuth.logOut).toHaveBeenNthCalledWith(1, {
-    electionHash,
-    jurisdiction: DEV_JURISDICTION,
-  });
-
-  await apiClient.startCardlessVoterSession({
-    electionHash,
-    ballotStyleId: 'b1',
-    precinctId: 'p1',
-  });
-  expect(mockAuth.startCardlessVoterSession).toHaveBeenCalledTimes(1);
-  expect(mockAuth.startCardlessVoterSession).toHaveBeenNthCalledWith(
-    1,
-    { electionHash, jurisdiction: DEV_JURISDICTION },
-    { ballotStyleId: 'b1', precinctId: 'p1' }
-  );
-
-  await apiClient.endCardlessVoterSession({ electionHash });
-  expect(mockAuth.endCardlessVoterSession).toHaveBeenCalledTimes(1);
-  expect(mockAuth.endCardlessVoterSession).toHaveBeenNthCalledWith(1, {
-    electionHash,
-    jurisdiction: DEV_JURISDICTION,
-  });
-});
-
 test('read scanner report data from card', async () => {
   const { electionDefinition } = electionFamousNames2021Fixtures;
   const { electionHash } = electionDefinition;

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -13,11 +13,13 @@ import {
   ElectionDefinition,
   PrecinctId,
   SystemSettings,
+  DEFAULT_SYSTEM_SETTINGS,
 } from '@votingworks/types';
 import { ScannerReportData, ScannerReportDataSchema } from '@votingworks/utils';
 
 import { Usb, readBallotPackageFromUsb } from '@votingworks/backend';
 import { Logger } from '@votingworks/logging';
+import { electionSampleDefinition } from '@votingworks/fixtures';
 import { getMachineConfig } from './machine_config';
 import { Workspace } from './util/workspace';
 
@@ -94,6 +96,17 @@ function buildApi(
     unconfigureMachine() {
       workspace.store.setElection(undefined);
       workspace.store.deleteSystemSettings();
+    },
+
+    configureSampleBallotPackage(): Result<
+      ElectionDefinition,
+      BallotPackageConfigurationError
+    > {
+      const electionDefinition = electionSampleDefinition;
+      const systemSettings = DEFAULT_SYSTEM_SETTINGS;
+      workspace.store.setElection(electionDefinition.electionData);
+      workspace.store.setSystemSettings(systemSettings);
+      return ok(electionDefinition);
     },
 
     async configureBallotPackageFromUsb(input: {

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -109,10 +109,13 @@ function buildApi(
       return ok(electionDefinition);
     },
 
-    async configureBallotPackageFromUsb(input: {
-      electionHash?: string;
-    }): Promise<Result<ElectionDefinition, BallotPackageConfigurationError>> {
-      const machineState = constructAuthMachineState(input);
+    async configureBallotPackageFromUsb(): Promise<
+      Result<ElectionDefinition, BallotPackageConfigurationError>
+    > {
+      // Explicitly pass undefined electionHash because we haven't yet loaded the ballot package.
+      const machineState = constructAuthMachineState({
+        electionHash: undefined,
+      });
       const authStatus = await auth.getAuthStatus(machineState);
 
       const [usbDrive] = await usb.getUsbDrives();

--- a/apps/mark/backend/src/store.test.ts
+++ b/apps/mark/backend/src/store.test.ts
@@ -27,7 +27,7 @@ test('get/set/has election', () => {
   expect(store.getElectionDefinition()).toBeUndefined();
 });
 
-test('get/set system settings', () => {
+test('get/set/delete system settings', () => {
   const store = Store.memoryStore();
 
   expect(store.getSystemSettings()).toBeUndefined();
@@ -37,6 +37,9 @@ test('get/set system settings', () => {
 
   store.setSystemSettings(systemSettings);
   expect(store.getSystemSettings()).toEqual(systemSettings);
+
+  store.deleteSystemSettings();
+  expect(store.getSystemSettings()).toBeUndefined();
 });
 
 test('setSystemSettings can handle boolean values in input', () => {

--- a/apps/mark/backend/src/store.ts
+++ b/apps/mark/backend/src/store.ts
@@ -95,9 +95,17 @@ export class Store {
   }
 
   /**
+   * Deletes system settings
+   */
+  deleteSystemSettings(): void {
+    this.client.run('delete from system_settings');
+  }
+
+  /**
    * Creates a system settings record and returns its ID.
    */
   setSystemSettings(systemSettings: SystemSettings): void {
+    this.client.run('delete from system_settings');
     this.client.run(
       'insert into system_settings (are_poll_worker_card_pins_enabled) values (?)',
       systemSettings.arePollWorkerCardPinsEnabled ? 1 : 0 // No booleans in sqlite3

--- a/apps/mark/frontend/jest.config.js
+++ b/apps/mark/frontend/jest.config.js
@@ -12,14 +12,6 @@ module.exports = {
     '!src/index.tsx',
     '!src/contexts/ballot_context.ts',
   ],
-  coverageThreshold: {
-    global: {
-      statements: 99.7,
-      branches: 99.7,
-      functions: 99.4,
-      lines: 99.8,
-    },
-  },
   resetMocks: true,
   setupFiles: ['react-app-polyfill/jsdom'],
   setupFilesAfterEnv: ['<rootDir>/src/setupTests.tsx'],

--- a/apps/mark/frontend/jest.config.js
+++ b/apps/mark/frontend/jest.config.js
@@ -12,6 +12,14 @@ module.exports = {
     '!src/index.tsx',
     '!src/contexts/ballot_context.ts',
   ],
+  coverageThreshold: {
+    global: {
+      statements: 99.7,
+      branches: 99.7,
+      functions: 99.4,
+      lines: 99.8,
+    },
+  },
   resetMocks: true,
   setupFiles: ['react-app-polyfill/jsdom'],
   setupFilesAfterEnv: ['<rootDir>/src/setupTests.tsx'],

--- a/apps/mark/frontend/src/api.ts
+++ b/apps/mark/frontend/src/api.ts
@@ -13,10 +13,7 @@ import {
   AUTH_STATUS_POLLING_INTERVAL_MS,
   QUERY_CLIENT_DEFAULT_OPTIONS,
 } from '@votingworks/ui';
-import {
-  BallotStyleId,
-  PrecinctId,
-} from '@votingworks/types';
+import { BallotStyleId, PrecinctId } from '@votingworks/types';
 
 export type ApiClient = grout.Client<Api>;
 

--- a/apps/mark/frontend/src/api.ts
+++ b/apps/mark/frontend/src/api.ts
@@ -57,6 +57,7 @@ export const getElectionDefinition = {
   },
 } as const;
 
+/* istanbul ignore next */
 export const getSystemSettings = {
   queryKey(): QueryKey {
     return ['getSystemSettings'];
@@ -205,7 +206,6 @@ export const clearScannerReportDataFromCard = {
   },
 } as const;
 
-/* istanbul ignore next */
 export const configureBallotPackageFromUsb = {
   useMutation(electionHash?: string) {
     const apiClient = useApiClient();
@@ -222,7 +222,6 @@ export const configureBallotPackageFromUsb = {
   },
 } as const;
 
-/* istanbul ignore next */
 export const unconfigureMachine = {
   useMutation() {
     const apiClient = useApiClient();

--- a/apps/mark/frontend/src/api.ts
+++ b/apps/mark/frontend/src/api.ts
@@ -207,18 +207,15 @@ export const clearScannerReportDataFromCard = {
 } as const;
 
 export const configureBallotPackageFromUsb = {
-  useMutation(electionHash?: string) {
+  useMutation() {
     const apiClient = useApiClient();
     const queryClient = useQueryClient();
-    return useMutation(
-      () => apiClient.configureBallotPackageFromUsb({ electionHash }),
-      {
-        async onSuccess() {
-          await queryClient.invalidateQueries(getElectionDefinition.queryKey());
-          await queryClient.invalidateQueries(getSystemSettings.queryKey());
-        },
-      }
-    );
+    return useMutation(() => apiClient.configureBallotPackageFromUsb(), {
+      async onSuccess() {
+        await queryClient.invalidateQueries(getElectionDefinition.queryKey());
+        await queryClient.invalidateQueries(getSystemSettings.queryKey());
+      },
+    });
   },
 } as const;
 

--- a/apps/mark/frontend/src/apimachine_config.test.tsx
+++ b/apps/mark/frontend/src/apimachine_config.test.tsx
@@ -17,6 +17,7 @@ beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
   apiMock = createApiMock();
+  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {

--- a/apps/mark/frontend/src/app.test.tsx
+++ b/apps/mark/frontend/src/app.test.tsx
@@ -48,6 +48,7 @@ it('will throw an error when using default api', async () => {
 });
 
 it('Displays error boundary if the api returns an unexpected error', async () => {
+  apiMock.expectGetElectionDefinition(null);
   apiMock.expectGetMachineConfigToError();
   const storage = new MemoryStorage();
   const hardware = MemoryHardware.buildStandard();
@@ -67,6 +68,7 @@ it('Displays error boundary if the api returns an unexpected error', async () =>
 
 it('prevents context menus from appearing', async () => {
   apiMock.expectGetMachineConfig();
+  apiMock.expectGetElectionDefinition(null);
   render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
 
   const { oncontextmenu } = window;
@@ -86,6 +88,7 @@ it('prevents context menus from appearing', async () => {
 it('uses kiosk storage when in kiosk-browser', async () => {
   const kiosk = fakeKiosk();
   apiMock.expectGetMachineConfig();
+  apiMock.expectGetElectionDefinition(null);
   window.kiosk = kiosk;
   render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
   await advanceTimersAndPromises();
@@ -96,6 +99,7 @@ it('uses kiosk storage when in kiosk-browser', async () => {
 it('changes screen reader settings based on keyboard inputs', async () => {
   const mockTts = fakeTts();
   apiMock.expectGetMachineConfig();
+  apiMock.expectGetElectionDefinition(null);
   const screenReader = new AriaScreenReader(mockTts);
   jest.spyOn(screenReader, 'toggle');
   jest.spyOn(screenReader, 'changeVolume');
@@ -126,6 +130,7 @@ it('uses window.location.reload by default', async () => {
   // enough for general `window.location` use.
   const reload = jest.fn();
   apiMock.expectGetMachineConfig();
+  apiMock.expectGetElectionDefinition(null);
   jest.spyOn(window, 'location', 'get').mockReturnValue({
     ...window.location,
     reload,

--- a/apps/mark/frontend/src/app_ballot_package_config.test.tsx
+++ b/apps/mark/frontend/src/app_ballot_package_config.test.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { FakeKiosk, fakeKiosk, fakeUsbDrive } from '@votingworks/test-utils';
+import { fakeLogger } from '@votingworks/logging';
+import { electionSampleDefinition } from '@votingworks/fixtures';
+import { MemoryHardware, MemoryStorage } from '@votingworks/utils';
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
+import { render, screen } from '../test/react_testing_library';
+import { App } from './app';
+
+let apiMock: ApiMock;
+let kiosk: FakeKiosk;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  window.location.href = '/';
+  apiMock = createApiMock();
+  kiosk = fakeKiosk();
+  window.kiosk = kiosk;
+});
+
+afterEach(() => {
+  apiMock.mockApiClient.assertComplete();
+});
+
+test('renders an error if ballot package config endpoint returns an error', async () => {
+  apiMock.expectGetMachineConfig({
+    screenOrientation: 'portrait',
+  });
+  apiMock.expectGetElectionDefinition(null);
+  apiMock.setAuthStatusElectionManagerLoggedIn(electionSampleDefinition);
+
+  render(
+    <App
+      hardware={MemoryHardware.buildStandard()}
+      storage={new MemoryStorage()}
+      reload={jest.fn()}
+      logger={fakeLogger()}
+      apiClient={apiMock.mockApiClient}
+    />
+  );
+
+  apiMock.expectConfigureBallotPackageFromUsbError('election_hash_mismatch');
+  apiMock.expectGetElectionDefinition(null);
+  kiosk.getUsbDriveInfo.mockResolvedValue([fakeUsbDrive()]);
+  await screen.findByText('Configuring VxMark from USB drive…');
+  await screen.findByText(
+    'The most recent ballot package found is for a different election.'
+  );
+});

--- a/apps/mark/frontend/src/app_card_unhappy_paths.test.tsx
+++ b/apps/mark/frontend/src/app_card_unhappy_paths.test.tsx
@@ -20,6 +20,7 @@ beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
   apiMock = createApiMock();
+  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {

--- a/apps/mark/frontend/src/app_contest_candidate_no_party.test.tsx
+++ b/apps/mark/frontend/src/app_contest_candidate_no_party.test.tsx
@@ -41,6 +41,7 @@ beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
   apiMock = createApiMock();
+  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {

--- a/apps/mark/frontend/src/app_contest_ms_either_neither.test.tsx
+++ b/apps/mark/frontend/src/app_contest_ms_either_neither.test.tsx
@@ -202,6 +202,7 @@ test('Can vote on a Mississippi Either Neither Contest', async () => {
   const hardware = MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
   apiMock.expectGetMachineConfig();
+  apiMock.expectGetElectionDefinition(null);
 
   await setElectionInStorage(storage, electionDefinition);
   await setStateInStorage(storage, {

--- a/apps/mark/frontend/src/app_contest_multi_seat.test.tsx
+++ b/apps/mark/frontend/src/app_contest_multi_seat.test.tsx
@@ -20,6 +20,7 @@ beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
   apiMock = createApiMock();
+  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {

--- a/apps/mark/frontend/src/app_contest_single_seat.test.tsx
+++ b/apps/mark/frontend/src/app_contest_single_seat.test.tsx
@@ -20,6 +20,7 @@ beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
   apiMock = createApiMock();
+  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {

--- a/apps/mark/frontend/src/app_contest_write_in.test.tsx
+++ b/apps/mark/frontend/src/app_contest_write_in.test.tsx
@@ -31,6 +31,7 @@ beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
   apiMock = createApiMock();
+  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {

--- a/apps/mark/frontend/src/app_contest_yes_no.test.tsx
+++ b/apps/mark/frontend/src/app_contest_yes_no.test.tsx
@@ -30,6 +30,7 @@ beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
   apiMock = createApiMock();
+  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {

--- a/apps/mark/frontend/src/app_data.test.tsx
+++ b/apps/mark/frontend/src/app_data.test.tsx
@@ -18,6 +18,7 @@ beforeEach(() => {
   window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetMachineConfig();
+  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {

--- a/apps/mark/frontend/src/app_polls_flows.test.tsx
+++ b/apps/mark/frontend/src/app_polls_flows.test.tsx
@@ -117,10 +117,6 @@ beforeEach(() => {
   window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetMachineConfig();
-  // Using typical configureFromUsbThenRemove doesn't trigger the app state
-  // to update appPrecinct. Somehow this works? But is fragile and will probably
-  // break when we remove frontend election definition state
-  // apiMock.expectGetElectionDefinition(null);
   apiMock.expectGetElectionDefinition(null);
 });
 

--- a/apps/mark/frontend/src/app_polls_flows.test.tsx
+++ b/apps/mark/frontend/src/app_polls_flows.test.tsx
@@ -117,6 +117,11 @@ beforeEach(() => {
   window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetMachineConfig();
+  // Using typical configureFromUsbThenRemove doesn't trigger the app state
+  // to update appPrecinct. Somehow this works? But is fragile and will probably
+  // break when we remove frontend election definition state
+  // apiMock.expectGetElectionDefinition(null);
+  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {
@@ -1546,6 +1551,7 @@ test('tally report: will print but not update polls state appropriate', async ()
 test('full polls flow without tally reports', async () => {
   apiMock = createApiMock();
   apiMock.expectGetMachineConfig();
+  apiMock.expectGetElectionDefinition(null);
   const { renderApp, storage, logger } = buildApp(apiMock);
   await setElectionInStorage(storage, electionSampleDefinition);
   await setStateInStorage(storage, { pollsState: 'polls_closed_initial' });

--- a/apps/mark/frontend/src/app_quit_on_idle.test.tsx
+++ b/apps/mark/frontend/src/app_quit_on_idle.test.tsx
@@ -30,6 +30,7 @@ beforeEach(() => {
   window.location.href = '/';
   window.kiosk = fakeKiosk();
   apiMock = createApiMock();
+  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {

--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -346,7 +346,7 @@ export function AppRoot({
     []
   );
 
-  // Any time election definition is changed in the backend, update the redux store too.
+  // Any time election definition is changed in the backend, update the frontend store too.
   const getElectionDefinitionQuery = getElectionDefinition.useQuery();
   useQueryChangeListener(
     getElectionDefinitionQuery,

--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -688,10 +688,13 @@ export function AppRoot({
   if (isElectionManagerAuth(authStatus)) {
     if (!optionalElectionDefinition) {
       return (
-        <UnconfiguredElectionScreenWrapper
-          usbDriveStatus={usbDrive.status}
-          updateElectionDefinition={updateElectionDefinition}
-        />
+        <React.Fragment>
+          <UnconfiguredElectionScreenWrapper
+            usbDriveStatus={usbDrive.status}
+            updateElectionDefinition={updateElectionDefinition}
+          />
+          <SessionTimeLimitTracker electionHash={electionHash} />
+        </React.Fragment>
       );
     }
 
@@ -711,6 +714,8 @@ export function AppRoot({
             machineConfig={machineConfig}
             screenReader={screenReader}
             unconfigure={unconfigure}
+            isLoading={unconfigureMachineMutation.isLoading}
+            isError={unconfigureMachineMutation.isError}
           />
           <SessionTimeLimitTracker electionHash={electionHash} />
         </React.Fragment>

--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -346,6 +346,7 @@ export function AppRoot({
     []
   );
 
+  // Any time election definition is changed in the backend, update the redux store too.
   const getElectionDefinitionQuery = getElectionDefinition.useQuery();
   useQueryChangeListener(
     getElectionDefinitionQuery,

--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -73,7 +73,7 @@ import { CardErrorScreen } from './pages/card_error_screen';
 import { SystemAdministratorScreen } from './pages/system_administrator_screen';
 import { mergeMsEitherNeitherContests } from './utils/ms_either_neither_contests';
 import { SessionTimeLimitTracker } from './components/session_time_limit_tracker';
-import { UnconfiguredElectionScreenWrapper } from './pages/unconfingured_election_screen_wrapper';
+import { UnconfiguredElectionScreenWrapper } from './pages/unconfigured_election_screen_wrapper';
 
 interface UserState {
   userSettings: UserSettings;
@@ -336,6 +336,7 @@ export function AppRoot({
         )
       : [];
 
+  /** @deprecated Use backend state instead: configureBallotPackageFromUsb.useMutation() and getElectionDefinition.useQuery() */
   const updateElectionDefinition = useCallback(
     (electionDefinition: ElectionDefinition) => {
       dispatchAppState({

--- a/apps/mark/frontend/src/app_setup_errors.test.tsx
+++ b/apps/mark/frontend/src/app_setup_errors.test.tsx
@@ -26,6 +26,7 @@ beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
   apiMock = createApiMock();
+  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {

--- a/apps/mark/frontend/src/app_single_precinct_election.test.tsx
+++ b/apps/mark/frontend/src/app_single_precinct_election.test.tsx
@@ -1,20 +1,22 @@
 import React from 'react';
 import { MemoryHardware, MemoryStorage } from '@votingworks/utils';
 import { electionMinimalExhaustiveSampleSinglePrecinctDefinition } from '@votingworks/fixtures';
-import userEvent from '@testing-library/user-event';
-import { getDisplayElectionHash } from '@votingworks/types';
+import { ElectionDefinition, getDisplayElectionHash } from '@votingworks/types';
 import { ok } from '@votingworks/basics';
+import { fakeKiosk, fakeUsbDrive } from '@votingworks/test-utils';
 import { screen } from '../test/react_testing_library';
 import { render } from '../test/test_utils';
 import { App } from './app';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
 let apiMock: ApiMock;
+let kiosk = fakeKiosk();
 
 beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
   apiMock = createApiMock();
+  kiosk = fakeKiosk();
 });
 
 afterEach(() => {
@@ -23,12 +25,23 @@ afterEach(() => {
 
 jest.setTimeout(15000);
 
+function insertUsbDriveWithBallotPackage(
+  electionDefinition: ElectionDefinition
+) {
+  kiosk.getUsbDriveInfo.mockResolvedValue([fakeUsbDrive()]);
+  apiMock.mockApiClient.configureBallotPackageFromUsb
+    .expectCallWith({ electionHash: undefined })
+    .resolves(ok(electionDefinition));
+  window.kiosk = kiosk;
+}
+
 test('loading election with a single precinct automatically sets precinct', async () => {
   const electionDefinition =
     electionMinimalExhaustiveSampleSinglePrecinctDefinition;
   const hardware = MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
   apiMock.expectGetMachineConfig();
+  apiMock.expectGetElectionDefinition(null);
 
   render(
     <App
@@ -42,15 +55,17 @@ test('loading election with a single precinct automatically sets precinct', asyn
   await screen.findByText('VxMark is Not Configured');
 
   apiMock.setAuthStatusElectionManagerLoggedIn(electionDefinition);
-  apiMock.mockApiClient.readElectionDefinitionFromCard
-    .expectCallWith({ electionHash: undefined })
-    .resolves(ok(electionDefinition));
-  userEvent.click(await screen.findByText('Load Election Definition'));
+  apiMock.expectGetElectionDefinition(electionDefinition);
+
+  // Insert a USB with a ballot package
+  insertUsbDriveWithBallotPackage(electionDefinition);
+
+  await screen.findByText('Configuring VxMark from USB drive…');
   await screen.findByText(getDisplayElectionHash(electionDefinition));
   // Should not be able to select a precinct
   expect(screen.getByTestId('selectPrecinct')).toBeDisabled();
   screen.getByText(
-    'Precinct can not be changed because there is only one precinct configured for this election.'
+    'Precinct cannot be changed because there is only one precinct configured for this election.'
   );
   apiMock.setAuthStatusLoggedOut();
   await screen.findByText('Precinct 1');

--- a/apps/mark/frontend/src/app_test_mode.test.tsx
+++ b/apps/mark/frontend/src/app_test_mode.test.tsx
@@ -20,6 +20,7 @@ beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
   apiMock = createApiMock();
+  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {

--- a/apps/mark/frontend/src/lib/gamepad.test.tsx
+++ b/apps/mark/frontend/src/lib/gamepad.test.tsx
@@ -24,6 +24,7 @@ beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
   apiMock = createApiMock();
+  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {

--- a/apps/mark/frontend/src/pages/admin_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.test.tsx
@@ -12,8 +12,6 @@ import {
 } from '@votingworks/utils';
 import { fakeLogger } from '@votingworks/logging';
 import { QueryClientProvider } from '@tanstack/react-query';
-import userEvent from '@testing-library/user-event';
-import { ok, sleep } from '@votingworks/basics';
 import {
   act,
   fireEvent,
@@ -21,11 +19,7 @@ import {
   within,
 } from '../../test/react_testing_library';
 import { render } from '../../test/test_utils';
-import {
-  election,
-  defaultPrecinctId,
-  electionDefinition,
-} from '../../test/helpers/election';
+import { election, defaultPrecinctId } from '../../test/helpers/election';
 
 import { advanceTimers } from '../../test/helpers/timers';
 
@@ -62,7 +56,6 @@ function renderScreen(props: Partial<AdminScreenProps> = {}) {
           appPrecinct={singlePrecinctSelectionFor(defaultPrecinctId)}
           ballotsPrintedCount={0}
           electionDefinition={asElectionDefinition(election)}
-          updateElectionDefinition={jest.fn()}
           isLiveMode={false}
           updateAppPrecinct={jest.fn()}
           toggleLiveMode={jest.fn()}
@@ -83,7 +76,6 @@ function renderScreen(props: Partial<AdminScreenProps> = {}) {
 test('renders date and time settings modal', async () => {
   renderScreen();
 
-  // Configure with Election Manager Card
   advanceTimers();
 
   // We just do a simple happy path test here, since the libs/ui/set_clock unit
@@ -145,27 +137,6 @@ test('precinct selection disabled if single precinct election', async () => {
   await screen.findByText('Election Manager Actions');
   expect(screen.getByTestId('selectPrecinct')).toBeDisabled();
   screen.getByText(
-    'Precinct can not be changed because there is only one precinct configured for this election.'
-  );
-});
-
-test('election definition loading state', async () => {
-  renderScreen({ electionDefinition: undefined });
-
-  await screen.findByText('Election Manager Actions');
-  apiMock.mockApiClient.readElectionDefinitionFromCard
-    .expectCallWith({ electionHash: undefined })
-    .returns(
-      (async () => {
-        // Add an artificial delay to ensure that the loading state is actually rendered
-        await sleep(1000);
-        return Promise.resolve(ok(electionDefinition));
-      })()
-    );
-  userEvent.click(
-    screen.getByRole('button', { name: 'Load Election Definition' })
-  );
-  await screen.findByText(
-    'Loading Election Definition from Election Manager card…'
+    'Precinct cannot be changed because there is only one precinct configured for this election.'
   );
 });

--- a/apps/mark/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.tsx
@@ -22,15 +22,12 @@ import {
 import { Logger } from '@votingworks/logging';
 // eslint-disable-next-line vx/gts-no-import-export-type
 import type { MachineConfig } from '@votingworks/mark-backend';
-import { assert } from '@votingworks/basics';
 import { ScreenReader } from '../config/types';
-import { getElectionDefinitionFromCard } from '../api';
 
 export interface AdminScreenProps {
   appPrecinct?: PrecinctSelection;
   ballotsPrintedCount: number;
-  electionDefinition?: ElectionDefinition;
-  updateElectionDefinition: (electionDefinition: ElectionDefinition) => void;
+  electionDefinition: ElectionDefinition;
   isLiveMode: boolean;
   updateAppPrecinct: (appPrecinct: PrecinctSelection) => void;
   toggleLiveMode: VoidFunction;
@@ -45,7 +42,6 @@ export function AdminScreen({
   appPrecinct,
   ballotsPrintedCount,
   electionDefinition,
-  updateElectionDefinition,
   isLiveMode,
   updateAppPrecinct,
   toggleLiveMode,
@@ -55,25 +51,7 @@ export function AdminScreen({
   pollsState,
   logger,
 }: AdminScreenProps): JSX.Element {
-  const election = electionDefinition?.election;
-  const electionHash = electionDefinition?.electionHash;
-
-  const electionDefinitionFromCardQuery =
-    getElectionDefinitionFromCard.useQuery(electionHash, {
-      // Disable automatic fetching and only allow manual fetching through .refetch()
-      enabled: false,
-    });
-
-  async function loadElection() {
-    const { data } = await electionDefinitionFromCardQuery.refetch();
-    assert(data !== undefined);
-    const electionDefinitionFromCard = data.ok();
-    // TODO: Handle case that electionDefinitionFromCard is undefined, e.g. because it couldn't be
-    // parsed
-    if (electionDefinitionFromCard) {
-      updateElectionDefinition(electionDefinitionFromCard);
-    }
-  }
+  const { election } = electionDefinition;
 
   // Disable the audiotrack when in admin mode
   useEffect(() => {
@@ -124,7 +102,7 @@ export function AdminScreen({
                   <React.Fragment>
                     <br />
                     <Text small italic as="span">
-                      Precinct can not be changed because there is only one
+                      Precinct cannot be changed because there is only one
                       precinct configured for this election.
                     </Text>
                   </React.Fragment>
@@ -157,25 +135,14 @@ export function AdminScreen({
             <SetClockButton>Update Date and Time</SetClockButton>
           </p>
           <h2>Configuration</h2>
-          {election ? (
-            <p>
-              <Text as="span" voteIcon>
-                Election Definition is loaded.
-              </Text>{' '}
-              <Button variant="danger" small onPress={unconfigure}>
-                Unconfigure Machine
-              </Button>
-            </p>
-          ) : electionDefinitionFromCardQuery.isFetching ? (
-            <p>Loading Election Definition from Election Manager card…</p>
-          ) : (
-            <React.Fragment>
-              <Text warningIcon>Election Definition is not loaded.</Text>
-              <p>
-                <Button onPress={loadElection}>Load Election Definition</Button>
-              </p>
-            </React.Fragment>
-          )}
+          <p>
+            <Text as="span" voteIcon>
+              Election Definition is loaded.
+            </Text>{' '}
+            <Button variant="danger" small onPress={unconfigure}>
+              Unconfigure Machine
+            </Button>
+          </p>
         </Prose>
       </Main>
       {election && (

--- a/apps/mark/frontend/src/pages/replace_election_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/replace_election_screen.test.tsx
@@ -46,12 +46,26 @@ function renderScreen(props: Partial<ReplaceElectionScreenProps> = {}) {
           machineConfig={fakeMachineConfig()}
           screenReader={screenReader}
           unconfigure={jest.fn()}
+          isLoading={false}
+          isError={false}
           {...props}
         />
       </QueryClientProvider>
     </ApiClientContext.Provider>
   );
 }
+
+test('loading state', () => {
+  renderScreen({ isLoading: true });
+
+  userEvent.click(screen.getByText('Unconfiguring election on machine…'));
+});
+
+test('error state', () => {
+  renderScreen({ isError: true });
+
+  userEvent.click(screen.getByText('Error unconfiguring the machine.'));
+});
 
 test('unconfiguring', async () => {
   const unconfigure = jest.fn();

--- a/apps/mark/frontend/src/pages/replace_election_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/replace_election_screen.test.tsx
@@ -1,10 +1,9 @@
+import React from 'react';
 import {
   electionSampleDefinition,
   primaryElectionSampleDefinition,
 } from '@votingworks/fixtures';
-import React from 'react';
 import { QueryClientProvider } from '@tanstack/react-query';
-import { err, ok } from '@votingworks/basics';
 import userEvent from '@testing-library/user-event';
 import { screen } from '../../test/react_testing_library';
 import { fakeMachineConfig } from '../../test/helpers/fake_machine_config';
@@ -19,8 +18,10 @@ import { ApiMock, createApiMock } from '../../test/helpers/mock_api_client';
 import { ApiClientContext, createQueryClient } from '../api';
 
 const machineElectionDefinition = electionSampleDefinition;
-const { electionHash: machineElectionHash } = machineElectionDefinition;
-const cardElectionDefinition = primaryElectionSampleDefinition;
+const authElectionHash = primaryElectionSampleDefinition.electionHash.slice(
+  0,
+  10
+);
 const screenReader = new AriaScreenReader(fakeTts());
 
 let apiMock: ApiMock;
@@ -39,6 +40,8 @@ function renderScreen(props: Partial<ReplaceElectionScreenProps> = {}) {
       <QueryClientProvider client={createQueryClient()}>
         <ReplaceElectionScreen
           ballotsPrintedCount={0}
+          // Election hashes must differ for this screen to be rendered
+          authElectionHash={authElectionHash}
           electionDefinition={machineElectionDefinition}
           machineConfig={fakeMachineConfig()}
           screenReader={screenReader}
@@ -50,65 +53,29 @@ function renderScreen(props: Partial<ReplaceElectionScreenProps> = {}) {
   );
 }
 
-test('reading election definition from card', async () => {
-  apiMock.mockApiClient.readElectionDefinitionFromCard
-    .expectCallWith({ electionHash: machineElectionHash })
-    .resolves(ok(cardElectionDefinition));
-  const unconfigure = jest.fn();
-
-  renderScreen({ unconfigure });
-
-  await screen.findByText(cardElectionDefinition.election.title);
-  expect(unconfigure).not.toHaveBeenCalled();
-});
-
 test('unconfiguring', async () => {
-  apiMock.mockApiClient.readElectionDefinitionFromCard
-    .expectCallWith({ electionHash: machineElectionHash })
-    .resolves(ok(cardElectionDefinition));
   const unconfigure = jest.fn();
-
   renderScreen({ unconfigure });
 
-  await screen.findByText(cardElectionDefinition.election.title);
+  await screen.findByText(authElectionHash);
   userEvent.click(screen.getByText('Remove the Current Election and All Data'));
   expect(unconfigure).toHaveBeenCalled();
 });
 
 test('showing count of ballots printed: 0 ballots', async () => {
-  apiMock.mockApiClient.readElectionDefinitionFromCard
-    .expectCallWith({ electionHash: machineElectionHash })
-    .resolves(ok(cardElectionDefinition));
-
   renderScreen();
 
-  await screen.findByText(cardElectionDefinition.election.title);
+  await screen.findByText(authElectionHash);
   screen.getByText(
     'This machine has not printed any ballots for the current election.'
   );
 });
 
 test('showing count of ballots printed: >0 ballots', async () => {
-  apiMock.mockApiClient.readElectionDefinitionFromCard
-    .expectCallWith({ electionHash: machineElectionHash })
-    .resolves(ok(cardElectionDefinition));
-
   renderScreen({ ballotsPrintedCount: 129 });
 
-  await screen.findByText(cardElectionDefinition.election.title);
+  await screen.findByText(authElectionHash);
   expect(screen.getByText('129 ballots').parentElement?.textContent).toEqual(
     'This machine has printed 129 ballots for the current election.'
-  );
-});
-
-test('error reading election definition from card', async () => {
-  apiMock.mockApiClient.readElectionDefinitionFromCard
-    .expectCallWith({ electionHash: machineElectionHash })
-    .resolves(err(new Error('Unable to read election definition from card')));
-
-  renderScreen();
-
-  await screen.findByText(
-    'Error reading the election definition from Election Manager card.'
   );
 });

--- a/apps/mark/frontend/src/pages/replace_election_screen.tsx
+++ b/apps/mark/frontend/src/pages/replace_election_screen.tsx
@@ -15,7 +15,6 @@ import { DateTime } from 'luxon';
 import pluralize from 'pluralize';
 import React, { useEffect } from 'react';
 import { ScreenReader } from '../config/types';
-import { unconfigureMachine } from '../api';
 
 export interface ReplaceElectionScreenProps {
   appPrecinct?: PrecinctSelection;
@@ -25,6 +24,8 @@ export interface ReplaceElectionScreenProps {
   machineConfig: MachineConfig;
   screenReader: ScreenReader;
   unconfigure(): Promise<void>;
+  isLoading: boolean;
+  isError: boolean;
 }
 
 export function ReplaceElectionScreen({
@@ -35,9 +36,10 @@ export function ReplaceElectionScreen({
   machineConfig,
   screenReader,
   unconfigure,
+  isLoading,
+  isError,
 }: ReplaceElectionScreenProps): JSX.Element {
   const { election, electionHash } = electionDefinition;
-  const unconfigureMachineMutation = unconfigureMachine.useMutation();
 
   useEffect(() => {
     const muted = screenReader.isMuted();
@@ -45,7 +47,7 @@ export function ReplaceElectionScreen({
     return () => screenReader.toggleMuted(muted);
   }, [screenReader]);
 
-  if (unconfigureMachineMutation.isLoading) {
+  if (isLoading) {
     return (
       <Screen>
         <Main padded centerChild>
@@ -57,7 +59,7 @@ export function ReplaceElectionScreen({
     );
   }
 
-  if (unconfigureMachineMutation.isError) {
+  if (isError) {
     return (
       <Screen>
         <Main padded centerChild>

--- a/apps/mark/frontend/src/pages/replace_election_screen.tsx
+++ b/apps/mark/frontend/src/pages/replace_election_screen.tsx
@@ -15,11 +15,12 @@ import { DateTime } from 'luxon';
 import pluralize from 'pluralize';
 import React, { useEffect } from 'react';
 import { ScreenReader } from '../config/types';
-import { getElectionDefinitionFromCard } from '../api';
+import { unconfigureMachine } from '../api';
 
 export interface ReplaceElectionScreenProps {
   appPrecinct?: PrecinctSelection;
   ballotsPrintedCount: number;
+  authElectionHash: string;
   electionDefinition: ElectionDefinition;
   machineConfig: MachineConfig;
   screenReader: ScreenReader;
@@ -29,14 +30,14 @@ export interface ReplaceElectionScreenProps {
 export function ReplaceElectionScreen({
   appPrecinct,
   ballotsPrintedCount,
+  authElectionHash,
   electionDefinition,
   machineConfig,
   screenReader,
   unconfigure,
 }: ReplaceElectionScreenProps): JSX.Element {
   const { election, electionHash } = electionDefinition;
-  const electionDefinitionFromCardQuery =
-    getElectionDefinitionFromCard.useQuery(electionHash);
+  const unconfigureMachineMutation = unconfigureMachine.useMutation();
 
   useEffect(() => {
     const muted = screenReader.isMuted();
@@ -44,28 +45,24 @@ export function ReplaceElectionScreen({
     return () => screenReader.toggleMuted(muted);
   }, [screenReader]);
 
-  if (!electionDefinitionFromCardQuery.isSuccess) {
+  if (unconfigureMachineMutation.isLoading) {
     return (
       <Screen>
         <Main padded centerChild>
           <Prose textCenter>
-            <p>Reading the election definition from Election Manager card…</p>
+            <p>Unconfiguring election on machine…</p>
           </Prose>
         </Main>
       </Screen>
     );
   }
 
-  const electionDefinitionFromCard = electionDefinitionFromCardQuery.data.ok();
-
-  if (!electionDefinitionFromCard) {
+  if (unconfigureMachineMutation.isError) {
     return (
       <Screen>
         <Main padded centerChild>
           <Prose textCenter>
-            <p>
-              Error reading the election definition from Election Manager card.
-            </p>
+            <p>Error unconfiguring the machine.</p>
             <p>Remove card to continue.</p>
           </Prose>
         </Main>
@@ -73,8 +70,6 @@ export function ReplaceElectionScreen({
     );
   }
 
-  const { election: cardElection, electionHash: cardElectionHash } =
-    electionDefinitionFromCard;
   return (
     <Screen>
       <Main padded centerChild>
@@ -94,22 +89,19 @@ export function ReplaceElectionScreen({
               <tr>
                 <th>Title</th>
                 <td>{election.title}</td>
-                <td>{cardElection.title}</td>
               </tr>
               <tr>
                 <th>County</th>
                 <td>{election.county.name}</td>
-                <td>{cardElection.county.name}</td>
               </tr>
               <tr>
                 <th>Date</th>
                 <td>{formatLongDate(DateTime.fromISO(election.date))}</td>
-                <td>{formatLongDate(DateTime.fromISO(cardElection.date))}</td>
               </tr>
               <tr>
                 <th>Election ID</th>
                 <td>{electionHash.slice(0, 10)}</td>
-                <td>{cardElectionHash.slice(0, 10)}</td>
+                <td>{authElectionHash.slice(0, 10)}</td>
               </tr>
               <tr>
                 <th>Ballots Printed</th>
@@ -133,8 +125,8 @@ export function ReplaceElectionScreen({
           <p>Remove the inserted card to cancel.</p>
           <h2>Remove the Current Election</h2>
           <p>
-            You may remove the current election on this machine and then replace
-            it with the election on the card.
+            You may remove the current election on this machine and then attempt
+            to configure from USB.
           </p>
           <p>
             Removing the current election will replace all data on this machine.

--- a/apps/mark/frontend/src/pages/unconfigured_election_screen_wrapper.tsx
+++ b/apps/mark/frontend/src/pages/unconfigured_election_screen_wrapper.tsx
@@ -34,7 +34,7 @@ export function UnconfiguredElectionScreenWrapper(props: Props): JSX.Element {
     }
   });
 
-  const backendError = configureMutation?.data?.err();
+  const backendError = configureMutation.data?.err();
   return (
     <Screen>
       <Main centerChild>

--- a/apps/mark/frontend/src/pages/unconfingured_election_screen_wrapper.tsx
+++ b/apps/mark/frontend/src/pages/unconfingured_election_screen_wrapper.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 import {
   UnconfiguredElectionScreen,
   UsbDriveStatus,
+  Main,
+  Screen,
   useExternalStateChangeListener,
 } from '@votingworks/ui';
 import { ElectionDefinition } from '@votingworks/types';
@@ -34,11 +36,15 @@ export function UnconfiguredElectionScreenWrapper(props: Props): JSX.Element {
 
   const backendError = configureMutation?.data?.err();
   return (
-    <UnconfiguredElectionScreen
-      usbDriveStatus={usbDriveStatus}
-      isElectionManagerAuth
-      backendConfigError={backendError}
-      machineName="VxMark"
-    />
+    <Screen>
+      <Main centerChild>
+        <UnconfiguredElectionScreen
+          usbDriveStatus={usbDriveStatus}
+          isElectionManagerAuth
+          backendConfigError={backendError}
+          machineName="VxMark"
+        />
+      </Main>
+    </Screen>
   );
 }

--- a/apps/mark/frontend/src/pages/unconfingured_election_screen_wrapper.tsx
+++ b/apps/mark/frontend/src/pages/unconfingured_election_screen_wrapper.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import {
+  UnconfiguredElectionScreen,
+  UsbDriveStatus,
+  useExternalStateChangeListener,
+} from '@votingworks/ui';
+import { ElectionDefinition } from '@votingworks/types';
+import { configureBallotPackageFromUsb } from '../api';
+
+interface Props {
+  usbDriveStatus: UsbDriveStatus;
+  updateElectionDefinition: (electionDefinition: ElectionDefinition) => void;
+}
+
+/**
+ * UnconfiguredElectionScreenWrapper wraps the shared UnconfiguredElectionScreen component
+ * with VxMark-specific logic (primarily calls to the VxMark backend)
+ */
+export function UnconfiguredElectionScreenWrapper(props: Props): JSX.Element {
+  const { updateElectionDefinition, usbDriveStatus } = props;
+  const configureMutation = configureBallotPackageFromUsb.useMutation();
+
+  useExternalStateChangeListener(usbDriveStatus, (newUsbDriveStatus) => {
+    if (newUsbDriveStatus === 'mounted') {
+      // Errors are passed to and handled by UnconfiguredElectionScreen
+      void configureMutation.mutateAsync().then((result) => {
+        if (result.isOk()) {
+          updateElectionDefinition(result.ok());
+        }
+      });
+    }
+  });
+
+  const backendError = configureMutation?.data?.err();
+  return (
+    <UnconfiguredElectionScreen
+      usbDriveStatus={usbDriveStatus}
+      isElectionManagerAuth
+      backendConfigError={backendError}
+      machineName="VxMark"
+    />
+  );
+}

--- a/apps/mark/frontend/test/helpers/ballot_package.ts
+++ b/apps/mark/frontend/test/helpers/ballot_package.ts
@@ -9,7 +9,7 @@ import { ApiMock } from './mock_api_client';
  * @param apiMock
  * @param kiosk
  * @param screen
- * @param electionDefinition The election definition to return from apiMock
+ * @param electionDefinition The election definition to return from apiMock.
  */
 export async function configureFromUsbThenRemove(
   apiMock: ApiMock,
@@ -19,8 +19,8 @@ export async function configureFromUsbThenRemove(
 ): Promise<void> {
   // Insert USB
   apiMock.expectConfigureBallotPackageFromUsb(electionDefinition);
-  kiosk.getUsbDriveInfo.mockResolvedValue([fakeUsbDrive()]);
   apiMock.expectGetElectionDefinition(electionDefinition);
+  kiosk.getUsbDriveInfo.mockResolvedValue([fakeUsbDrive()]);
 
   // Remove USB after configuration is done
   await screen.findByText('Configuring VxMark from USB drive…');

--- a/apps/mark/frontend/test/helpers/ballot_package.ts
+++ b/apps/mark/frontend/test/helpers/ballot_package.ts
@@ -1,0 +1,29 @@
+import { FakeKiosk, fakeUsbDrive } from '@votingworks/test-utils';
+import { ElectionDefinition } from '@votingworks/types';
+import { VxScreen } from '@votingworks/ui';
+import { ApiMock } from './mock_api_client';
+
+/**
+ * Simulates inserting a USB drive, configuring the backend with an election definition,
+ * and removing the USB drive.
+ * @param apiMock
+ * @param kiosk
+ * @param screen
+ * @param electionDefinition The election definition to return from apiMock
+ */
+export async function configureFromUsbThenRemove(
+  apiMock: ApiMock,
+  kiosk: FakeKiosk,
+  screen: VxScreen,
+  electionDefinition: ElectionDefinition
+): Promise<void> {
+  // Insert USB
+  apiMock.expectConfigureBallotPackageFromUsb(electionDefinition);
+  kiosk.getUsbDriveInfo.mockResolvedValue([fakeUsbDrive()]);
+  apiMock.expectGetElectionDefinition(electionDefinition);
+
+  // Remove USB after configuration is done
+  await screen.findByText('Configuring VxMark from USB drive…');
+  await screen.findByText('Election Definition is loaded.');
+  kiosk.getUsbDriveInfo.mockResolvedValue([]);
+}

--- a/apps/mark/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/mark/frontend/test/helpers/mock_api_client.tsx
@@ -167,7 +167,7 @@ export function createApiMock() {
         BallotPackageConfigurationError
       > = ok(electionDefinition);
       mockApiClient.configureBallotPackageFromUsb
-        .expectCallWith({ electionHash: undefined })
+        .expectCallWith()
         .resolves(result);
     },
 
@@ -179,7 +179,7 @@ export function createApiMock() {
         BallotPackageConfigurationError
       > = err(error);
       mockApiClient.configureBallotPackageFromUsb
-        .expectCallWith({ electionHash: undefined })
+        .expectCallWith()
         .resolves(result);
     },
   };

--- a/apps/mark/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/mark/frontend/test/helpers/mock_api_client.tsx
@@ -5,10 +5,12 @@ import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
 import type { Api, MachineConfig } from '@votingworks/mark-backend';
 import { QueryClientProvider } from '@tanstack/react-query';
 import {
+  BallotPackageConfigurationError,
   BallotStyleId,
   ElectionDefinition,
   InsertedSmartCardAuth,
   PrecinctId,
+  SystemSettings,
 } from '@votingworks/types';
 import {
   fakeCardlessVoterUser,
@@ -133,6 +135,16 @@ export function createApiMock() {
       });
     },
 
+    expectGetElectionDefinition(electionDefinition: ElectionDefinition | null) {
+      mockApiClient.getElectionDefinition
+        .expectCallWith()
+        .resolves(electionDefinition);
+    },
+
+    expectGetSystemSettings(systemSettings: SystemSettings | null) {
+      mockApiClient.getSystemSettings.expectCallWith().resolves(systemSettings);
+    },
+
     expectGetMachineConfig(props: Partial<MachineConfig> = {}): void {
       mockApiClient.getMachineConfig
         .expectCallWith()
@@ -141,6 +153,22 @@ export function createApiMock() {
 
     expectGetMachineConfigToError(): void {
       mockApiClient.getMachineConfig.expectCallWith().throws('unexpected_err');
+    },
+
+    expectUnconfigureMachine(): void {
+      mockApiClient.unconfigureMachine.expectCallWith().resolves();
+    },
+
+    expectConfigureBallotPackageFromUsb(
+      electionDefinition: ElectionDefinition
+    ): void {
+      const result: Result<
+        ElectionDefinition,
+        BallotPackageConfigurationError
+      > = ok(electionDefinition);
+      mockApiClient.configureBallotPackageFromUsb
+        .expectCallWith({ electionHash: undefined })
+        .resolves(result);
     },
   };
 }

--- a/apps/mark/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/mark/frontend/test/helpers/mock_api_client.tsx
@@ -19,7 +19,7 @@ import {
   fakeSessionExpiresAt,
   fakeSystemAdministratorUser,
 } from '@votingworks/test-utils';
-import { ok, Optional, Result } from '@votingworks/basics';
+import { err, ok, Optional, Result } from '@votingworks/basics';
 import { ScannerReportData } from '@votingworks/utils';
 import { ApiClientContext, createQueryClient } from '../../src/api';
 import { fakeMachineConfig } from './fake_machine_config';
@@ -166,6 +166,18 @@ export function createApiMock() {
         ElectionDefinition,
         BallotPackageConfigurationError
       > = ok(electionDefinition);
+      mockApiClient.configureBallotPackageFromUsb
+        .expectCallWith({ electionHash: undefined })
+        .resolves(result);
+    },
+
+    expectConfigureBallotPackageFromUsbError(
+      error: BallotPackageConfigurationError
+    ): void {
+      const result: Result<
+        ElectionDefinition,
+        BallotPackageConfigurationError
+      > = err(error);
       mockApiClient.configureBallotPackageFromUsb
         .expectCallWith({ electionHash: undefined })
         .resolves(result);

--- a/apps/mark/integration-testing/cypress/support/e2e.js
+++ b/apps/mark/integration-testing/cypress/support/e2e.js
@@ -78,8 +78,13 @@ function endCardlessVoterSession() {
   cy.request('POST', methodUrl('endCardlessVoterSession', 'http://localhost:3000/api'), {});
 }
 
+function configureWithSampleDefinitionAndSystemSettings() {
+  cy.request('POST', methodUrl('configureSampleBallotPackage', 'http://localhost:3000/api'), {});
+}
+
 beforeEach(() => {
   endCardlessVoterSession();
+  configureWithSampleDefinitionAndSystemSettings();
 
   insertElectionManagerCard();
   cy.visit('/');
@@ -89,8 +94,6 @@ beforeEach(() => {
     cy.contains(digit).click();
   }
 
-  // Load election
-  cy.contains('Load Election Definition').click();
   cy.get('#selectPrecinct').select('All Precincts');
   removeCard();
 

--- a/libs/test-utils/src/fake_kiosk.ts
+++ b/libs/test-utils/src/fake_kiosk.ts
@@ -58,6 +58,11 @@ export function fakePrinterInfo(
   };
 }
 
+export type FakeKiosk = jest.Mocked<KioskBrowser.Kiosk> & {
+  devices: BehaviorSubject<Set<KioskBrowser.Device>>;
+  printers: BehaviorSubject<Set<KioskBrowser.PrinterInfo>>;
+};
+
 /**
  * Builds a `Kiosk` instance with mock methods.
  */
@@ -67,10 +72,7 @@ export function fakeKiosk({
 }: {
   battery?: Partial<KioskBrowser.BatteryInfo>;
   printers?: Array<Partial<KioskBrowser.PrinterInfo>>;
-} = {}): jest.Mocked<KioskBrowser.Kiosk> & {
-  devices: BehaviorSubject<Set<KioskBrowser.Device>>;
-  printers: BehaviorSubject<Set<KioskBrowser.PrinterInfo>>;
-} {
+} = {}): FakeKiosk {
   return {
     print: jest.fn().mockResolvedValue(undefined),
     // TODO: Rename to `printToPdf` in kiosk-browser, then update here.


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/3084
https://github.com/votingworks/vxsuite/issues/3207

* VxMark frontend loads election definition from the ballot package on USB instead of card. This reuses `UnconfiguredElectionScreen` factored out from VxScan
* Loading election definition from card has been removed, but we still check against the election hash on the card to enforce that the correct ballot package is being loaded
* VxMark loads system settings from the ballot package

## Demo Video or Screenshot
**Before**

Loading election definition from card:

https://user-images.githubusercontent.com/1060688/231608632-87585327-b544-4a6c-be53-869eea59d119.mov

---

Trying to unlock a configured machine with a card that has been configured with a different election:

https://user-images.githubusercontent.com/1060688/231608719-f6ec5614-9eaa-405d-9332-8e2cf2b336ff.mov

---

**After**

Loading election definition from USB

https://user-images.githubusercontent.com/1060688/231609097-e361738a-460d-4e71-b360-29af6b48a4a1.mov

_Note_ you can see after configuration, React warns there was a state update after component unmount. I think (but am not sure) that comes from the call to `updateElectionDefinition` in `UnconfiguredElectionScreenWrapper` since the warning doesn't fire when configuration fails. If we're removing `electionDefinition` from the frontend store soon it doesn't seem worth it to chase this down, but let me know what you think.

---

Trying to unlock a configured machine with a card that has been configured with a different election:


https://user-images.githubusercontent.com/1060688/231609271-1a05886a-eef3-4194-89c8-1cc5582430a0.mov

---

Trying to configure a fresh machine but card and USB ballot package election hashes don't match:

https://user-images.githubusercontent.com/1060688/231609348-65846ddc-21b5-4190-aa4f-24d90ea9e808.mov


## Testing Plan
* Updated existing tests, including e2e tests, to work with the new USB/React Query flow
* Added an endpoint (but no API client method) for Cypress to hit to configure the machine. Cypress previously configured machines by interacting directly with a file `input` that was removed as part of this change. Cypress has no support for mock USBs so this was the fastest and cleanest way to fix Cypress tests.

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced. (Logging is built in to the ballot package lib)
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
