### PR TITLE
Enable double sheet detection with the option to disable

### DIFF
--- a/apps/scan/backend/schema.sql
+++ b/apps/scan/backend/schema.sql
@@ -8,6 +8,7 @@ create table election (
   polls_state text not null default "polls_closed_initial",
   ballot_count_when_ballot_bag_last_replaced integer not null default 0,
   is_sound_muted boolean not null default false,
+  is_ultrasonic_disabled boolean not null default false,
   marginal_mark_threshold_override real,
   definite_mark_threshold_override real,
   cvrs_backed_up_at datetime,

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -137,6 +137,8 @@ function buildApi(
         markThresholdOverrides: store.getMarkThresholdOverrides(),
         isSoundMuted: store.getIsSoundMuted(),
         isTestMode: store.getTestMode(),
+        isUltrasonicDisabled:
+          !machine.supportsUltrasonic() || store.getIsUltrasonicDisabled(),
         pollsState: store.getPollsState(),
         ballotCountWhenBallotBagLastReplaced:
           store.getBallotCountWhenBallotBagLastReplaced(),
@@ -171,6 +173,10 @@ function buildApi(
 
     setIsSoundMuted(input: { isSoundMuted: boolean }): void {
       store.setIsSoundMuted(input.isSoundMuted);
+    },
+
+    setIsUltrasonicDisabled(input: { isUltrasonicDisabled: boolean }): void {
+      store.setIsUltrasonicDisabled(input.isUltrasonicDisabled);
     },
 
     setTestMode(input: { isTestMode: boolean }): void {
@@ -336,6 +342,10 @@ function buildApi(
     async calibrate(): Promise<boolean> {
       const result = await machine.calibrate?.();
       return result?.isOk() ?? false;
+    },
+
+    supportsUltrasonic(): boolean {
+      return machine.supportsUltrasonic();
     },
 
     async saveScannerReportDataToCard(input: {

--- a/apps/scan/backend/src/scanners/custom/state_machine.ts
+++ b/apps/scan/backend/src/scanners/custom/state_machine.ts
@@ -281,7 +281,6 @@ async function scan({ client, workspace }: Context): Promise<SheetOf<string>> {
     resolution: ImageResolution.RESOLUTION_200_DPI,
     imageColorDepth: ImageColorDepthType.Grey8bpp,
     formStandingAfterScan: FormStanding.HOLD_TICKET,
-    // The A4 scanner does not support double sheet detection.
     doubleSheetDetection: isUltrasonicDisabled
       ? DoubleSheetDetectOpt.DetectOff
       : DoubleSheetDetectOpt.Level1,

--- a/apps/scan/backend/src/scanners/plustek/state_machine.ts
+++ b/apps/scan/backend/src/scanners/plustek/state_machine.ts
@@ -1122,6 +1122,10 @@ export function createPrecinctScannerStateMachine({
       machineService.send('RETURN');
     },
 
+    supportsUltrasonic: () => {
+      return false;
+    },
+
     calibrate: async () => {
       machineService.send('CALIBRATE');
       await waitFor(machineService, (state) => !state.matches('calibrating'), {

--- a/apps/scan/backend/src/server.test.ts
+++ b/apps/scan/backend/src/server.test.ts
@@ -31,6 +31,7 @@ function createPrecinctScannerStateMachineMock(): jest.Mocked<PrecinctScannerSta
     accept: jest.fn(),
     return: jest.fn(),
     calibrate: jest.fn(),
+    supportsUltrasonic: jest.fn(),
   };
 }
 

--- a/apps/scan/backend/src/store.test.ts
+++ b/apps/scan/backend/src/store.test.ts
@@ -118,6 +118,25 @@ test('get/set is sounds muted mode', () => {
   expect(store.getIsSoundMuted()).toEqual(false);
 });
 
+test('get/set is ultrasonic disabled mode', () => {
+  const store = Store.memoryStore();
+
+  // Before setting an election
+  expect(store.getIsUltrasonicDisabled()).toEqual(false);
+  expect(() => store.setIsUltrasonicDisabled(true)).toThrowError();
+
+  store.setElection(stateOfHamilton.electionDefinition.electionData);
+
+  // After setting an election
+  expect(store.getIsUltrasonicDisabled()).toEqual(false);
+
+  store.setIsUltrasonicDisabled(true);
+  expect(store.getIsUltrasonicDisabled()).toEqual(true);
+
+  store.setIsUltrasonicDisabled(false);
+  expect(store.getIsUltrasonicDisabled()).toEqual(false);
+});
+
 test('get/set ballot count when ballot bag last replaced', () => {
   const store = Store.memoryStore();
 

--- a/apps/scan/backend/src/store.ts
+++ b/apps/scan/backend/src/store.ts
@@ -269,7 +269,7 @@ export class Store {
     ) as { isUltrasonicDisabled: number } | undefined;
 
     if (!electionRow) {
-      // we will not mute sounds by default once an election is defined
+      // we will not disable ultrasonic by default once an election is defined
       return false;
     }
 

--- a/apps/scan/backend/src/store.ts
+++ b/apps/scan/backend/src/store.ts
@@ -261,7 +261,23 @@ export class Store {
   }
 
   /**
-   * Sets whether to check the election hash.
+   * Gets whether ultrasonic is disabled.
+   */
+  getIsUltrasonicDisabled(): boolean {
+    const electionRow = this.client.one(
+      'select is_ultrasonic_disabled as isUltrasonicDisabled from election'
+    ) as { isUltrasonicDisabled: number } | undefined;
+
+    if (!electionRow) {
+      // we will not mute sounds by default once an election is defined
+      return false;
+    }
+
+    return Boolean(electionRow.isUltrasonicDisabled);
+  }
+
+  /**
+   * Sets whether or not to mute sounds.
    */
   setIsSoundMuted(isSoundMuted: boolean): void {
     if (!this.hasElection()) {
@@ -271,6 +287,20 @@ export class Store {
     this.client.run(
       'update election set is_sound_muted = ?',
       isSoundMuted ? 1 : 0
+    );
+  }
+
+  /**
+   * Sets whether or not to enable ultrasonic, if supported.
+   */
+  setIsUltrasonicDisabled(isUltrasonicDisabled: boolean): void {
+    if (!this.hasElection()) {
+      throw new Error('Cannot toggle ultrasonic without an election.');
+    }
+
+    this.client.run(
+      'update election set is_ultrasonic_disabled = ?',
+      isUltrasonicDisabled ? 1 : 0
     );
   }
 

--- a/apps/scan/backend/src/types.ts
+++ b/apps/scan/backend/src/types.ts
@@ -46,6 +46,7 @@ export type PrecinctScannerState =
   | 'jammed'
   | 'both_sides_have_paper'
   | 'recovering_from_error'
+  | 'double_sheet_jammed'
   | 'unrecoverable_error';
 
 export type InvalidInterpretationReason =
@@ -98,6 +99,7 @@ export interface PrecinctScannerConfig {
   precinctSelection?: PrecinctSelection;
   markThresholdOverrides?: MarkThresholds;
   isSoundMuted: boolean;
+  isUltrasonicDisabled: boolean;
   // "Config" that is specific to each election session
   isTestMode: boolean;
   pollsState: PollsState;
@@ -112,6 +114,7 @@ export interface PrecinctScannerConfig {
  */
 export interface PrecinctScannerStateMachine {
   status: () => PrecinctScannerMachineStatus;
+  supportsUltrasonic: () => boolean;
   // The commands are non-blocking and do not return a result. They just send an
   // event to the machine. The effects of the event (or any error) will show up
   // in the status.

--- a/apps/scan/frontend/src/api.ts
+++ b/apps/scan/frontend/src/api.ts
@@ -172,6 +172,18 @@ export const setIsSoundMuted = {
   },
 } as const;
 
+export const setIsUltrasonicDisabled = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.setIsUltrasonicDisabled, {
+      async onSuccess() {
+        await queryClient.invalidateQueries(getConfig.queryKey());
+      },
+    });
+  },
+} as const;
+
 export const setTestMode = {
   useMutation() {
     const apiClient = useApiClient();
@@ -280,6 +292,16 @@ export const supportsCalibration = {
   useQuery() {
     const apiClient = useApiClient();
     return useQuery(this.queryKey(), () => apiClient.supportsCalibration());
+  },
+} as const;
+
+export const supportsUltrasonic = {
+  queryKey(): QueryKey {
+    return ['supportsUltrasonic'];
+  },
+  useQuery() {
+    const apiClient = useApiClient();
+    return useQuery(this.queryKey(), () => apiClient.supportsUltrasonic());
   },
 } as const;
 

--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -121,6 +121,7 @@ test('shows insert USB Drive screen when there is no card reader', async () => {
 test('app can load and configure from a usb stick', async () => {
   apiMock.authenticateAsElectionManager(electionSampleDefinition);
   apiMock.expectCheckCalibrationSupported(true);
+  apiMock.expectCheckUltrasonicSupported(false);
 
   apiMock.expectGetConfig({
     electionDefinition: undefined,
@@ -168,6 +169,7 @@ test('app can load and configure from a usb stick', async () => {
 
 test('election manager must set precinct', async () => {
   apiMock.expectCheckCalibrationSupported(true);
+  apiMock.expectCheckUltrasonicSupported(false);
   apiMock.expectGetConfig({
     precinctSelection: undefined,
   });
@@ -205,6 +207,7 @@ test('election manager and poll worker configuration', async () => {
   const electionDefinition = electionSampleDefinition;
   let config: Partial<PrecinctScannerConfig> = { electionDefinition };
   apiMock.expectCheckCalibrationSupported(true);
+  apiMock.expectCheckUltrasonicSupported(false);
   apiMock.expectGetConfig(config);
   apiMock.expectGetScannerStatus(statusNoPaper);
   const { logger } = renderApp();
@@ -401,6 +404,7 @@ async function scanBallot() {
 
 test('voter can cast a ballot that scans successfully ', async () => {
   apiMock.expectCheckCalibrationSupported(true);
+  apiMock.expectCheckUltrasonicSupported(false);
   apiMock.expectGetConfig({
     pollsState: 'polls_open',
   });

--- a/apps/scan/frontend/src/app_unhappy_paths.test.tsx
+++ b/apps/scan/frontend/src/app_unhappy_paths.test.tsx
@@ -69,6 +69,7 @@ test('when backend does not respond shows error screen', async () => {
 
 test('backend fails to unconfigure', async () => {
   apiMock.expectCheckCalibrationSupported(true);
+  apiMock.expectCheckUltrasonicSupported(false);
   apiMock.expectGetConfig();
   apiMock.expectGetScannerStatus({ ...statusNoPaper, canUnconfigure: true });
   apiMock.mockApiClient.unconfigureElection
@@ -239,6 +240,7 @@ test('removing card during calibration', async () => {
   kiosk.getUsbDriveInfo = jest.fn().mockResolvedValue([fakeUsbDrive()]);
   window.kiosk = kiosk;
   apiMock.expectCheckCalibrationSupported(true);
+  apiMock.expectCheckUltrasonicSupported(false);
   apiMock.expectGetScannerStatus(statusNoPaper);
   apiMock.expectGetCastVoteRecordsForTally([]);
   renderApp();

--- a/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
@@ -299,10 +299,8 @@ test('disables ultrasonic properly', async () => {
     .expectCallWith({ isUltrasonicDisabled: true })
     .resolves();
   apiMock.expectGetConfig({ isUltrasonicDisabled: true });
-  userEvent.click(
-    screen.getByRole('button', { name: 'Disable Double Sheet Detection' })
-  );
-  await screen.findByRole('button', { name: 'Enable Double Sheet Detection' });
+  userEvent.click(await screen.findButton('Disable Double Sheet Detection'));
+  await screen.findButton('Enable Double Sheet Detection');
 
   expect(screen.queryByText('Calibrate Scanner')).toBeNull();
   await screen.findByText('Enable Double Sheet Detection');

--- a/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
@@ -64,6 +64,7 @@ function renderScreen(
 
 test('renders date and time settings modal', async () => {
   apiMock.expectCheckCalibrationSupported(true);
+  apiMock.expectCheckUltrasonicSupported(false);
   apiMock.expectGetConfig();
   renderScreen();
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
@@ -99,6 +100,7 @@ test('renders date and time settings modal', async () => {
 
 test('option to set precinct if more than one', async () => {
   apiMock.expectCheckCalibrationSupported(true);
+  apiMock.expectCheckUltrasonicSupported(false);
   apiMock.expectGetConfig();
   const precinct = electionSampleDefinition.election.precincts[0];
   const precinctSelection = singlePrecinctSelectionFor(precinct.id);
@@ -113,6 +115,7 @@ test('option to set precinct if more than one', async () => {
 
 test('no option to change precinct if there is only one precinct', async () => {
   apiMock.expectCheckCalibrationSupported(true);
+  apiMock.expectCheckUltrasonicSupported(false);
   const electionDefinition =
     electionMinimalExhaustiveSampleSinglePrecinctDefinition;
   apiMock.expectGetConfig({
@@ -127,6 +130,7 @@ test('no option to change precinct if there is only one precinct', async () => {
 
 test('export from admin screen', async () => {
   apiMock.expectCheckCalibrationSupported(true);
+  apiMock.expectCheckUltrasonicSupported(false);
   apiMock.expectGetConfig();
   renderScreen();
 
@@ -137,6 +141,7 @@ test('export from admin screen', async () => {
 
 test('unconfigure does not eject a usb drive that is not mounted', async () => {
   apiMock.expectCheckCalibrationSupported(true);
+  apiMock.expectCheckUltrasonicSupported(false);
   apiMock.expectGetConfig();
   const usbDrive = mockUsbDrive('absent');
   renderScreen({
@@ -154,6 +159,7 @@ test('unconfigure does not eject a usb drive that is not mounted', async () => {
 
 test('unconfigure ejects a usb drive when it is mounted', async () => {
   apiMock.expectCheckCalibrationSupported(true);
+  apiMock.expectCheckUltrasonicSupported(false);
   apiMock.expectGetConfig();
   const usbDrive = mockUsbDrive('mounted');
   renderScreen({
@@ -173,6 +179,7 @@ test('unconfigure ejects a usb drive when it is mounted', async () => {
 
 test('unconfigure button is disabled when the machine cannot be unconfigured', async () => {
   apiMock.expectCheckCalibrationSupported(true);
+  apiMock.expectCheckUltrasonicSupported(false);
   apiMock.expectGetConfig();
   renderScreen();
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
@@ -183,6 +190,7 @@ test('unconfigure button is disabled when the machine cannot be unconfigured', a
 
 test('cannot toggle to Test Ballot Mode when the machine cannot be unconfigured', async () => {
   apiMock.expectCheckCalibrationSupported(true);
+  apiMock.expectCheckUltrasonicSupported(false);
   apiMock.expectGetConfig({ isTestMode: false });
   renderScreen();
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
@@ -194,6 +202,7 @@ test('cannot toggle to Test Ballot Mode when the machine cannot be unconfigured'
 
 test('allows overriding mark thresholds', async () => {
   apiMock.expectCheckCalibrationSupported(true);
+  apiMock.expectCheckUltrasonicSupported(false);
   apiMock.expectGetConfig();
   renderScreen();
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
@@ -218,6 +227,7 @@ test('allows overriding mark thresholds', async () => {
 
 test('when sounds are not muted, shows a button to mute sounds', async () => {
   apiMock.expectCheckCalibrationSupported(true);
+  apiMock.expectCheckUltrasonicSupported(false);
   apiMock.expectGetConfig({ isSoundMuted: false });
   renderScreen();
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
@@ -232,6 +242,7 @@ test('when sounds are not muted, shows a button to mute sounds', async () => {
 
 test('when sounds are muted, shows a button to unmute sounds', async () => {
   apiMock.expectCheckCalibrationSupported(true);
+  apiMock.expectCheckUltrasonicSupported(false);
   apiMock.expectGetConfig({ isSoundMuted: true });
   renderScreen();
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
@@ -242,4 +253,57 @@ test('when sounds are muted, shows a button to unmute sounds', async () => {
   apiMock.expectGetConfig({ isSoundMuted: false });
   userEvent.click(screen.getByRole('button', { name: 'Unmute Sounds' }));
   await screen.findByRole('button', { name: 'Mute Sounds' });
+});
+
+test('does not show calibrate or ultrasonic button if not supported', async () => {
+  apiMock.expectCheckCalibrationSupported(false);
+  apiMock.expectCheckUltrasonicSupported(false);
+  apiMock.expectGetConfig();
+  renderScreen();
+  await screen.findByRole('heading', { name: 'Election Manager Settings' });
+
+  expect(screen.queryByText('Calibrate Scanner')).toBeNull();
+  expect(screen.queryByText('Disable Double Sheet Detection')).toBeNull();
+});
+
+test('shows ultrasonic toggle when supported', async () => {
+  apiMock.expectCheckCalibrationSupported(false);
+  apiMock.expectCheckUltrasonicSupported(true);
+  apiMock.expectGetConfig();
+  renderScreen();
+  await screen.findByRole('heading', { name: 'Election Manager Settings' });
+
+  expect(screen.queryByText('Calibrate Scanner')).toBeNull();
+  await screen.findByText('Disable Double Sheet Detection');
+});
+
+test('prompts to enable ultrasonic when disabled ', async () => {
+  apiMock.expectCheckCalibrationSupported(false);
+  apiMock.expectCheckUltrasonicSupported(true);
+  apiMock.expectGetConfig({ isUltrasonicDisabled: true });
+  renderScreen();
+  await screen.findByRole('heading', { name: 'Election Manager Settings' });
+
+  expect(screen.queryByText('Calibrate Scanner')).toBeNull();
+  await screen.findByText('Enable Double Sheet Detection');
+});
+
+test('disables ultrasonic properly', async () => {
+  apiMock.expectCheckCalibrationSupported(false);
+  apiMock.expectCheckUltrasonicSupported(true);
+  apiMock.expectGetConfig();
+  renderScreen();
+  await screen.findByRole('heading', { name: 'Election Manager Settings' });
+
+  apiMock.mockApiClient.setIsUltrasonicDisabled
+    .expectCallWith({ isUltrasonicDisabled: true })
+    .resolves();
+  apiMock.expectGetConfig({ isUltrasonicDisabled: true });
+  userEvent.click(
+    screen.getByRole('button', { name: 'Disable Double Sheet Detection' })
+  );
+  await screen.findByRole('button', { name: 'Enable Double Sheet Detection' });
+
+  expect(screen.queryByText('Calibrate Scanner')).toBeNull();
+  await screen.findByText('Enable Double Sheet Detection');
 });

--- a/apps/scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.tsx
@@ -24,9 +24,11 @@ import { SetMarkThresholdsModal } from '../components/set_mark_thresholds_modal'
 import {
   getConfig,
   setIsSoundMuted,
+  setIsUltrasonicDisabled,
   setPrecinctSelection,
   setTestMode,
   supportsCalibration,
+  supportsUltrasonic,
   unconfigureElection,
 } from '../api';
 import { usePreviewContext } from '../preview_dashboard';
@@ -49,10 +51,12 @@ export function ElectionManagerScreen({
   logger,
 }: ElectionManagerScreenProps): JSX.Element | null {
   const supportsCalibrationQuery = supportsCalibration.useQuery();
+  const supportsUltrasonicQuery = supportsUltrasonic.useQuery();
   const configQuery = getConfig.useQuery();
   const setPrecinctSelectionMutation = setPrecinctSelection.useMutation();
   const setTestModeMutation = setTestMode.useMutation();
   const setIsSoundMutedMutation = setIsSoundMuted.useMutation();
+  const setIsUltrasonicDisabledMutation = setIsUltrasonicDisabled.useMutation();
   const unconfigureMutation = unconfigureElection.useMutation();
 
   const [
@@ -76,6 +80,7 @@ export function ElectionManagerScreen({
     precinctSelection,
     isTestMode,
     isSoundMuted,
+    isUltrasonicDisabled,
     markThresholdOverrides,
     pollsState,
   } = configQuery.data;
@@ -164,17 +169,32 @@ export function ElectionManagerScreen({
           </Button>
         </P>
         <P>
-          <Button
-            disabled={supportsCalibrationQuery.data === false}
-            onPress={() => setIsCalibratingScanner(true)}
-            nonAccessibleTitle={
-              !supportsCalibrationQuery.data
-                ? 'This scanner does not support calibration.'
-                : undefined
-            }
-          >
-            Calibrate Scanner
-          </Button>
+          {supportsCalibrationQuery.data === true && (
+            <Button
+              onPress={() => setIsCalibratingScanner(true)}
+              nonAccessibleTitle={
+                !supportsCalibrationQuery.data
+                  ? 'This scanner does not support calibration.'
+                  : undefined
+              }
+            >
+              Calibrate Scanner
+            </Button>
+          )}
+
+          {supportsUltrasonicQuery.data === true && (
+            <Button
+              onPress={() =>
+                setIsUltrasonicDisabledMutation.mutate({
+                  isUltrasonicDisabled: !isUltrasonicDisabled,
+                })
+              }
+            >
+              {isUltrasonicDisabled
+                ? 'Enable Double Sheet Detection'
+                : 'Disable Double Sheet Detection'}
+            </Button>
+          )}
         </P>
         <P>
           <Button

--- a/apps/scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.tsx
@@ -170,14 +170,7 @@ export function ElectionManagerScreen({
         </P>
         <P>
           {supportsCalibrationQuery.data === true && (
-            <Button
-              onPress={() => setIsCalibratingScanner(true)}
-              nonAccessibleTitle={
-                !supportsCalibrationQuery.data
-                  ? 'This scanner does not support calibration.'
-                  : undefined
-              }
-            >
+            <Button onPress={() => setIsCalibratingScanner(true)}>
               Calibrate Scanner
             </Button>
           )}

--- a/apps/scan/frontend/src/screens/scan_double_sheet_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/scan_double_sheet_screen.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen } from '../../test/react_testing_library';
+import { ScanDoubleSheetScreen } from './scan_double_sheet_screen';
+import {
+  ApiMock,
+  createApiMock,
+  provideApi,
+  statusNoPaper,
+} from '../../test/helpers/mock_api_client';
+
+let apiMock: ApiMock;
+
+beforeEach(() => {
+  apiMock = createApiMock();
+  apiMock.expectGetMachineConfig();
+  apiMock.expectGetConfig();
+  apiMock.expectGetScannerStatus(statusNoPaper);
+});
+
+afterEach(() => {
+  apiMock.mockApiClient.assertComplete();
+});
+
+test('renders double sheet screen as expected', async () => {
+  render(
+    provideApi(apiMock, <ScanDoubleSheetScreen scannedBallotCount={42} />)
+  );
+  await screen.findByText('Ballot Not Counted');
+  await screen.findByText('Multiple sheets detected.');
+});

--- a/apps/scan/frontend/src/screens/scan_double_sheet_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_double_sheet_screen.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import {
+  Caption,
+  CenteredLargeProse,
+  FullScreenIconWrapper,
+  H1,
+  Icons,
+  P,
+} from '@votingworks/ui';
+import { ScreenMainCenterChild } from '../components/layout';
+
+interface Props {
+  scannedBallotCount: number;
+}
+
+export function ScanDoubleSheetScreen({
+  scannedBallotCount,
+}: Props): JSX.Element {
+  return (
+    <ScreenMainCenterChild
+      infoBar={false}
+      ballotCountOverride={scannedBallotCount}
+    >
+      <FullScreenIconWrapper color="danger">
+        <Icons.DangerX />
+      </FullScreenIconWrapper>
+      <CenteredLargeProse>
+        <H1>Ballot Not Counted</H1>
+        <P>Multiple sheets detected.</P>
+        <Caption>Remove your ballot and insert one sheet at a time.</Caption>
+      </CenteredLargeProse>
+    </ScreenMainCenterChild>
+  );
+}
+
+/* istanbul ignore next */
+export function DefaultPreview(): JSX.Element {
+  return <ScanDoubleSheetScreen scannedBallotCount={42} />;
+}

--- a/apps/scan/frontend/src/screens/voter_screen.tsx
+++ b/apps/scan/frontend/src/screens/voter_screen.tsx
@@ -13,6 +13,7 @@ import { ScanProcessingScreen } from './scan_processing_screen';
 import { ScanReturnedBallotScreen } from './scan_returned_ballot_screen';
 import { ScanSuccessScreen } from './scan_success_screen';
 import { ScanWarningScreen } from './scan_warning_screen';
+import { ScanDoubleSheetScreen } from './scan_double_sheet_screen';
 
 interface VoterScreenProps {
   electionDefinition: ElectionDefinition;
@@ -63,6 +64,7 @@ export function VoterScreen({
       }
       case 'rejecting':
       case 'jammed':
+      case 'double_sheet_jammed':
       case 'unrecoverable_error': {
         playError();
         break;
@@ -128,6 +130,12 @@ export function VoterScreen({
     case 'jammed':
       return (
         <ScanJamScreen scannedBallotCount={scannerStatus.ballotsCounted} />
+      );
+    case 'double_sheet_jammed':
+      return (
+        <ScanDoubleSheetScreen
+          scannedBallotCount={scannerStatus.ballotsCounted}
+        />
       );
     case 'both_sides_have_paper':
       return <ScanBusyScreen />;

--- a/apps/scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/scan/frontend/test/helpers/mock_api_client.tsx
@@ -34,6 +34,7 @@ export const machineConfig: MachineConfig = {
 
 const defaultConfig: PrecinctScannerConfig = {
   isSoundMuted: false,
+  isUltrasonicDisabled: false,
   isTestMode: true,
   pollsState: 'polls_closed_initial',
   ballotCountWhenBallotBagLastReplaced: 0,
@@ -169,6 +170,12 @@ export function createApiMock() {
       mockApiClient.supportsCalibration
         .expectCallWith()
         .resolves(supportsCalibration);
+    },
+
+    expectCheckUltrasonicSupported(supportsUltrasonic: boolean): void {
+      mockApiClient.supportsUltrasonic
+        .expectCallWith()
+        .resolves(supportsUltrasonic);
     },
   };
 }

--- a/libs/custom-scanner/src/mocks/simple_scanner.ts
+++ b/libs/custom-scanner/src/mocks/simple_scanner.ts
@@ -69,6 +69,19 @@ export const MOCK_INTERNAL_JAM: ScannerStatus = {
 };
 
 /**
+ * Mock ScannerStatus object for when the custom scanner is experiencing a double sheet situation.
+ */
+export const MOCK_DOUBLE_SHEET: ScannerStatus = {
+  ...MOCK_NO_PAPER,
+  sensorOutputLeftLeft: SensorStatus.PaperPresent,
+  sensorOutputCenterLeft: SensorStatus.PaperPresent,
+  sensorOutputCenterRight: SensorStatus.PaperPresent,
+  sensorOutputRightRight: SensorStatus.PaperPresent,
+  isPaperJam: true,
+  isDoubleSheet: true,
+};
+
+/**
  * Mock ScannerStatus object for when the custom scanner is sees paper on both sides.
  */
 export const MOCK_BOTH_SIDES_HAVE_PAPER: ScannerStatus = {
@@ -89,6 +102,15 @@ export const MOCK_BOTH_SIDES_HAVE_PAPER: ScannerStatus = {
 export const MOCK_JAM_CLEARED: ScannerStatus = {
   ...MOCK_NO_PAPER,
   isPaperJam: true,
+};
+
+/**
+ * Mock ScannerStatus object for when the custom scanner thinks there is a jam but the paper has been cleared.
+ */
+export const MOCK_DOUBLE_SHEET_CLEARED: ScannerStatus = {
+  ...MOCK_NO_PAPER,
+  isPaperJam: true,
+  isDoubleSheet: true,
 };
 
 /**


### PR DESCRIPTION
## Overview
Makes double sheet detection enabled by default but with the option to disable. When there is a double sheet jam shows a specific UI relevant to multiple sheets. 
<!-- add a link to a GitHub Issue here -->
https://github.com/votingworks/vxsuite/issues/3235

## Demo Video or Screenshot

https://user-images.githubusercontent.com/14897017/231652221-0d5aeb23-07cc-4c7f-8d65-fffe78b3f3b3.mov

All scans in above video are two sheets layered on top of one another

## Testing Plan

Manually tested various moments of double sheet feeding, manually tested that killing and restarting app keeps the disable state 

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
