### PR TITLE
[VxScan] Hide 'Ballot Mode' control label on election manager screen

### DIFF
--- a/apps/scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.tsx
@@ -134,6 +134,7 @@ export function ElectionManagerScreen({
           <SegmentedButton
             disabled={setTestModeMutation.isLoading}
             label="Ballot Mode:"
+            hideLabel
             onChange={handleTogglingTestMode}
             options={[
               { id: 'test', label: 'Test Ballot Mode' },

--- a/libs/ui/src/segmented_button.tsx
+++ b/libs/ui/src/segmented_button.tsx
@@ -9,6 +9,10 @@ import { Caption } from './typography';
 export interface SegmentedButtonProps<T extends SegmentedButtonOptionId> {
   disabled?: boolean;
   hideLabel?: boolean;
+  /**
+   * Required for a11y - use {@link hideLabel} to visually hide the label, while
+   * still allowing it to be assigned to the control for screen readers.
+   */
   label: string;
   onChange: (newId: T) => void;
   options: ReadonlyArray<SegmentedButtonOption<T>>;


### PR DESCRIPTION
## Overview

Per design feedback, removing the "Ballot Mode" label from the SegmentedButton control on the election manager screen.

Also adding documentation on the `label` prop for `SegmentedButton` to make it clearer why it's required.

## Demo Video or Screenshot
<img width="300" src="https://user-images.githubusercontent.com/264902/231806081-7622fe68-260d-4f5e-b8c6-be3be132a5e6.png"> <img width="300" src="https://user-images.githubusercontent.com/264902/231806102-2120a072-ed15-42f5-a8a7-5ae36d5613a7.png">

## Testing Plan
- Visual verification

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
