### PR TITLE
[VxScan] Persist ElectionInfoBar across all screens

### DIFF
--- a/apps/scan/frontend/src/app_root.tsx
+++ b/apps/scan/frontend/src/app_root.tsx
@@ -129,7 +129,7 @@ export function AppRoot({ hardware, logger }: Props): JSX.Element | null {
 
   if (isSystemAdministratorAuth(authStatus)) {
     return (
-      <ScreenMainCenterChild infoBar>
+      <ScreenMainCenterChild>
         <SystemAdministratorScreenContents
           displayRemoveCardToLeavePrompt
           logger={logger}

--- a/apps/scan/frontend/src/components/layout.tsx
+++ b/apps/scan/frontend/src/components/layout.tsx
@@ -12,7 +12,6 @@ import { ScannedBallotCount } from './scanned_ballot_count';
 interface CenteredScreenProps {
   ballotCountOverride?: number;
   children: React.ReactNode;
-  infoBar?: boolean;
   isLiveMode?: boolean;
   infoBarMode?: InfoBarMode;
 }
@@ -20,7 +19,6 @@ interface CenteredScreenProps {
 export function ScreenMainCenterChild({
   ballotCountOverride,
   children,
-  infoBar = true,
   infoBarMode,
   isLiveMode = true,
 }: CenteredScreenProps): JSX.Element | null {
@@ -44,7 +42,7 @@ export function ScreenMainCenterChild({
       <Main padded centerChild style={{ position: 'relative' }}>
         {children}
       </Main>
-      {infoBar && electionDefinition && (
+      {electionDefinition && (
         <ElectionInfoBar
           mode={infoBarMode}
           precinctSelection={precinctSelection}

--- a/apps/scan/frontend/src/components/replace_ballot_bag_screen.tsx
+++ b/apps/scan/frontend/src/components/replace_ballot_bag_screen.tsx
@@ -90,10 +90,7 @@ export function ReplaceBallotBagScreen({
   })();
 
   return (
-    <ScreenMainCenterChild
-      infoBar={false}
-      ballotCountOverride={scannedBallotCount}
-    >
+    <ScreenMainCenterChild ballotCountOverride={scannedBallotCount}>
       {mainContent}
     </ScreenMainCenterChild>
   );

--- a/apps/scan/frontend/src/screens/card_error_screen.tsx
+++ b/apps/scan/frontend/src/screens/card_error_screen.tsx
@@ -5,7 +5,7 @@ import { ScreenMainCenterChild } from '../components/layout';
 
 export function CardErrorScreen(): JSX.Element {
   return (
-    <ScreenMainCenterChild infoBar={false}>
+    <ScreenMainCenterChild>
       <RotateCardImage />
       <CenteredLargeProse>
         <H1>Card is Backwards</H1>

--- a/apps/scan/frontend/src/screens/insert_usb_screen.tsx
+++ b/apps/scan/frontend/src/screens/insert_usb_screen.tsx
@@ -4,7 +4,7 @@ import { ScreenMainCenterChild } from '../components/layout';
 
 export function InsertUsbScreen(): JSX.Element {
   return (
-    <ScreenMainCenterChild infoBar={false}>
+    <ScreenMainCenterChild>
       <CenteredLargeProse>
         <H1>No USB Drive Detected</H1>
         <P>Insert USB drive into the USB hub.</P>

--- a/apps/scan/frontend/src/screens/invalid_card_screen.tsx
+++ b/apps/scan/frontend/src/screens/invalid_card_screen.tsx
@@ -5,7 +5,7 @@ import { ScreenMainCenterChild } from '../components/layout';
 
 export function InvalidCardScreen(): JSX.Element {
   return (
-    <ScreenMainCenterChild infoBar={false}>
+    <ScreenMainCenterChild infoBarMode="pollworker">
       <SharedInvalidCardScreen
         reason="invalid_user_on_card"
         recommendedAction="Remove the card to continue."

--- a/apps/scan/frontend/src/screens/loading_configuration_screen.tsx
+++ b/apps/scan/frontend/src/screens/loading_configuration_screen.tsx
@@ -4,7 +4,7 @@ import { ScreenMainCenterChild } from '../components/layout';
 
 export function LoadingConfigurationScreen(): JSX.Element {
   return (
-    <ScreenMainCenterChild infoBar={false}>
+    <ScreenMainCenterChild>
       <LoadingAnimation />
       <CenteredLargeProse>
         <H1>Loading Configuration…</H1>

--- a/apps/scan/frontend/src/screens/scan_busy_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_busy_screen.tsx
@@ -11,7 +11,7 @@ import { ScreenMainCenterChild } from '../components/layout';
 
 export function ScanBusyScreen(): JSX.Element {
   return (
-    <ScreenMainCenterChild infoBar={false}>
+    <ScreenMainCenterChild>
       <FullScreenIconWrapper color="warning">
         <Icons.Warning />
       </FullScreenIconWrapper>

--- a/apps/scan/frontend/src/screens/scan_error_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_error_screen.tsx
@@ -68,7 +68,6 @@ export function ScanErrorScreen({
   return (
     <ScreenMainCenterChild
       isLiveMode={!isTestMode}
-      infoBar={false}
       ballotCountOverride={scannedBallotCount}
     >
       <FullScreenIconWrapper color="danger">

--- a/apps/scan/frontend/src/screens/scan_jam_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_jam_screen.tsx
@@ -15,10 +15,7 @@ interface Props {
 
 export function ScanJamScreen({ scannedBallotCount }: Props): JSX.Element {
   return (
-    <ScreenMainCenterChild
-      infoBar={false}
-      ballotCountOverride={scannedBallotCount}
-    >
+    <ScreenMainCenterChild ballotCountOverride={scannedBallotCount}>
       <FullScreenIconWrapper color="danger">
         <Icons.DangerX />
       </FullScreenIconWrapper>

--- a/apps/scan/frontend/src/screens/scan_processing_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_processing_screen.tsx
@@ -4,7 +4,7 @@ import { ScreenMainCenterChild } from '../components/layout';
 
 export function ScanProcessingScreen(): JSX.Element {
   return (
-    <ScreenMainCenterChild infoBar={false}>
+    <ScreenMainCenterChild>
       <LoadingAnimation />
       <CenteredLargeProse>
         <H1>Please wait…</H1>

--- a/apps/scan/frontend/src/screens/scan_returned_ballot_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_returned_ballot_screen.tsx
@@ -4,7 +4,7 @@ import { ScreenMainCenterChild } from '../components/layout';
 
 export function ScanReturnedBallotScreen(): JSX.Element {
   return (
-    <ScreenMainCenterChild infoBar={false}>
+    <ScreenMainCenterChild>
       {/* TODO: make a graphic for this screen */}
       <CenteredLargeProse>
         <H1>Remove Your Ballot</H1>

--- a/apps/scan/frontend/src/screens/scan_warning_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_warning_screen.tsx
@@ -114,7 +114,7 @@ function OvervoteWarningScreen({
     .map((c) => c.title);
 
   return (
-    <ScreenMainCenterChild infoBar={false}>
+    <ScreenMainCenterChild>
       <FullScreenIconWrapper color="warning">
         <Icons.Warning />
       </FullScreenIconWrapper>
@@ -203,7 +203,7 @@ function UndervoteWarningScreen({
   }
 
   return (
-    <ScreenMainCenterChild infoBar={false}>
+    <ScreenMainCenterChild>
       <FullScreenIconWrapper color="warning">
         <Icons.Warning />
       </FullScreenIconWrapper>
@@ -284,7 +284,7 @@ function BlankBallotWarningScreen(): JSX.Element {
   const acceptBallotMutation = acceptBallot.useMutation();
   const [confirmTabulate, setConfirmTabulate] = useState(false);
   return (
-    <ScreenMainCenterChild infoBar={false}>
+    <ScreenMainCenterChild>
       <FullScreenIconWrapper color="warning">
         <Icons.Warning />
       </FullScreenIconWrapper>
@@ -330,7 +330,7 @@ function OtherReasonWarningScreen(): JSX.Element {
   const acceptBallotMutation = acceptBallot.useMutation();
   const [confirmTabulate, setConfirmTabulate] = useState(false);
   return (
-    <ScreenMainCenterChild infoBar={false}>
+    <ScreenMainCenterChild>
       <FullScreenIconWrapper color="warning">
         <Icons.Warning />
       </FullScreenIconWrapper>

--- a/apps/scan/frontend/src/screens/setup_scanner_screen.tsx
+++ b/apps/scan/frontend/src/screens/setup_scanner_screen.tsx
@@ -15,10 +15,7 @@ export function SetupScannerScreen({
   // internal wiring issue. Otherwise if we can't detect the scanner, the power
   // cord is likely not plugged in.
   return (
-    <ScreenMainCenterChild
-      infoBar={false}
-      ballotCountOverride={scannedBallotCount}
-    >
+    <ScreenMainCenterChild ballotCountOverride={scannedBallotCount}>
       {batteryIsCharging ? (
         <CenteredLargeProse>
           <H1>Internal Connection Problem</H1>

--- a/apps/scan/frontend/src/screens/unconfigured_election_screen_wrapper.tsx
+++ b/apps/scan/frontend/src/screens/unconfigured_election_screen_wrapper.tsx
@@ -28,7 +28,7 @@ export function UnconfiguredElectionScreenWrapper(props: Props): JSX.Element {
   const error = configureMutation.data?.err();
 
   return (
-    <ScreenMainCenterChild infoBar={false}>
+    <ScreenMainCenterChild>
       <UnconfiguredElectionScreen
         usbDriveStatus={usbDriveStatus}
         isElectionManagerAuth={isElectionManagerAuth}

--- a/apps/scan/frontend/src/screens/unconfigured_precinct_screen.tsx
+++ b/apps/scan/frontend/src/screens/unconfigured_precinct_screen.tsx
@@ -4,7 +4,7 @@ import { ScreenMainCenterChild } from '../components/layout';
 
 export function UnconfiguredPrecinctScreen(): JSX.Element {
   return (
-    <ScreenMainCenterChild infoBar={false}>
+    <ScreenMainCenterChild>
       <CenteredLargeProse>
         <H1>No Precinct Selected</H1>
         <P>Insert an Election Manager card to select a precinct.</P>


### PR DESCRIPTION
## Overview

_Closes https://github.com/votingworks/vxsuite/issues/3126_

Per [discussion in slack](https://votingworks.slack.com/archives/CEL6D3GAD/p1681330267773369), we're going to try out persisting the election info bar on all screens in VxScan, since:
- it's potentially less attention to always have it visible than to have it pop in and out and
- we have a lot more vertical real estate to play with now in portrait mode.

As before, the info bar is still only rendered when there's a configured election.

## Demo Video or Screenshot
<img width="300" src="https://user-images.githubusercontent.com/264902/231829333-7c18dbce-69bc-424d-b2cf-10aa10f8cd83.png"> <img width="300" src="https://user-images.githubusercontent.com/264902/231829357-5bce0db3-f1a5-47d4-a431-e31f4dd059e4.png">

## Testing Plan
- Visual verification

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
