### PR TITLE
[VxScan] Tame modal headings to fit in default size mode

### DIFF
--- a/apps/scan/frontend/src/components/calibrate_scanner_modal.tsx
+++ b/apps/scan/frontend/src/components/calibrate_scanner_modal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Button, H1, Modal, P, Prose } from '@votingworks/ui';
+import { Button, Modal, P, Prose } from '@votingworks/ui';
 import { assert } from '@votingworks/basics';
 // eslint-disable-next-line vx/gts-no-import-export-type
 import type { PrecinctScannerStatus } from '@votingworks/scan-backend';
@@ -37,9 +37,9 @@ export function CalibrateScannerModal({
     return (
       <Modal
         centerContent
+        title="Calibration not supported"
         content={
           <Prose textCenter>
-            <H1>Calibration not supported</H1>
             <P>This scanner does not support calibration.</P>
           </Prose>
         }
@@ -51,9 +51,9 @@ export function CalibrateScannerModal({
   if (calibrationState === 'ready') {
     return (
       <Modal
+        title="Calibrate Scanner"
         content={
           <Prose>
-            <H1>Calibrate Scanner</H1>
             <P>
               Insert a <strong>blank sheet of white paper</strong> to calibrate
               the scanner. The sheet will not be returned out the front of the
@@ -87,11 +87,7 @@ export function CalibrateScannerModal({
     return (
       <Modal
         centerContent
-        content={
-          <Prose textCenter>
-            <H1>Calibration succeeded!</H1>
-          </Prose>
-        }
+        title="Calibration succeeded!"
         actions={<Button onPress={onCancel}>Close</Button>}
       />
     );
@@ -101,9 +97,9 @@ export function CalibrateScannerModal({
     return (
       <Modal
         centerContent
+        title="Calibration failed!"
         content={
           <Prose textCenter>
-            <H1>Calibration failed!</H1>
             <P>There was an error while calibrating.</P>
           </Prose>
         }
@@ -124,14 +120,5 @@ export function CalibrateScannerModal({
   }
 
   assert(calibrationState === 'calibrating');
-  return (
-    <Modal
-      centerContent
-      content={
-        <Prose textCenter>
-          <H1>Calibrating…</H1>
-        </Prose>
-      }
-    />
-  );
+  return <Modal centerContent title="Calibrating…" />;
 }

--- a/apps/scan/frontend/src/components/export_backup_modal.tsx
+++ b/apps/scan/frontend/src/components/export_backup_modal.tsx
@@ -1,7 +1,6 @@
 import { throwIllegalValue } from '@votingworks/basics';
 import {
   Button,
-  H1,
   Loading,
   Modal,
   P,
@@ -66,9 +65,9 @@ export function ExportBackupModal({
   if (currentState === ModalState.ERROR) {
     return (
       <Modal
+        title="Failed to Save Backup"
         content={
           <Prose>
-            <H1>Failed to Save Backup</H1>
             <P>{errorMessage}</P>
           </Prose>
         }
@@ -82,9 +81,9 @@ export function ExportBackupModal({
     if (usbDrive.status === 'ejected') {
       return (
         <Modal
+          title="Backup Saved"
           content={
             <Prose>
-              <H1>Backup Saved</H1>
               <P>USB drive successfully ejected.</P>
             </Prose>
           }
@@ -96,9 +95,9 @@ export function ExportBackupModal({
 
     return (
       <Modal
+        title="Backup Saved"
         content={
           <Prose>
-            <H1>Backup Saved</H1>
             <P>
               Backup file saved successfully! You may now eject the USB drive.
             </P>
@@ -137,9 +136,9 @@ export function ExportBackupModal({
       // on the machine for internal debugging use
       return (
         <Modal
+          title="No USB Drive Detected"
           content={
             <Prose>
-              <H1>No USB Drive Detected</H1>
               <P>
                 Please insert a USB drive to save the backup.
                 <UsbImage src="/assets/usb-drive.svg" alt="Insert USB Image" />
@@ -162,9 +161,9 @@ export function ExportBackupModal({
     case 'mounted':
       return (
         <Modal
+          title="Save Backup"
           content={
             <Prose>
-              <H1>Save Backup</H1>
               <UsbImage src="/assets/usb-drive.svg" alt="Insert USB Image" />
               <P>
                 A ZIP file will automatically be saved to the default location

--- a/apps/scan/frontend/src/components/export_results_modal.tsx
+++ b/apps/scan/frontend/src/components/export_results_modal.tsx
@@ -8,7 +8,6 @@ import {
   Modal,
   UsbControllerButton,
   UsbDrive,
-  H1,
   P,
 } from '@votingworks/ui';
 import { throwIllegalValue } from '@votingworks/basics';
@@ -56,9 +55,9 @@ export function ExportResultsModal({
   if (currentState === ModalState.ERROR) {
     return (
       <Modal
+        title="Failed to Save CVRs"
         content={
           <Prose>
-            <H1>Failed to Save CVRs</H1>
             <P>{errorMessage}</P>
           </Prose>
         }
@@ -72,9 +71,9 @@ export function ExportResultsModal({
     if (usbDrive.status === 'ejected') {
       return (
         <Modal
+          title="USB Drive Ejected"
           content={
             <Prose>
-              <H1>USB Drive Ejected</H1>
               <P>You may now take the USB Drive to VxAdmin for tabulation.</P>
             </Prose>
           }
@@ -85,9 +84,9 @@ export function ExportResultsModal({
     }
     return (
       <Modal
+        title="CVRs Saved to USB Drive"
         content={
           <Prose>
-            <H1>CVRs Saved to USB Drive</H1>
             <P>
               You may now eject the USB drive and take it to VxAdmin for
               tabulation.
@@ -132,9 +131,10 @@ export function ExportResultsModal({
       // on the machine for internal debugging use
       return (
         <Modal
+          centerContent
+          title="No USB Drive Detected"
           content={
             <Prose textCenter>
-              <H1>No USB Drive Detected</H1>
               <P>
                 Please insert a USB drive in order to save CVRs.
                 <UsbImage src="/assets/usb-drive.svg" alt="Insert USB Image" />
@@ -157,9 +157,9 @@ export function ExportResultsModal({
     case 'mounted':
       return (
         <Modal
+          title="Save CVRs"
           content={
             <Prose>
-              <H1>Save CVRs</H1>
               <UsbImage src="/assets/usb-drive.svg" alt="Insert USB Image" />
               <P>
                 A CVR file will automatically be saved to the default location

--- a/apps/scan/frontend/src/components/live_check_modal.tsx
+++ b/apps/scan/frontend/src/components/live_check_modal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Button, Prose, Modal, QrCode, H1 } from '@votingworks/ui';
+import { Button, Prose, Modal, QrCode } from '@votingworks/ui';
 import styled from 'styled-components';
 import { ElectionDefinition } from '@votingworks/types';
 import { MachineConfig } from '../config/types';
@@ -45,9 +45,10 @@ export function LiveCheckModal({
 
   return (
     <Modal
+      centerContent
+      title="Live Check"
       content={
         <Prose textCenter>
-          <H1>Live Check</H1>
           <QrCodeWrapper>
             <QrCode value={livecheckUrl} />
           </QrCodeWrapper>

--- a/apps/scan/frontend/src/components/set_mark_thresholds_modal.tsx
+++ b/apps/scan/frontend/src/components/set_mark_thresholds_modal.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 
 import { MarkThresholds } from '@votingworks/types';
-import { Button, Caption, H1, Loading, Modal, P, Prose } from '@votingworks/ui';
+import { Button, Caption, Loading, Modal, P, Prose } from '@votingworks/ui';
 import { assert, throwIllegalValue } from '@votingworks/basics';
 import { setMarkThresholdOverrides } from '../api';
 
@@ -103,9 +103,9 @@ export function SetMarkThresholdsModal({
     case ModalState.ERROR:
       return (
         <Modal
+          title="Error"
           content={
             <Prose>
-              <H1>Error</H1>
               <P>{errorMessage}</P>
             </Prose>
           }
@@ -116,9 +116,9 @@ export function SetMarkThresholdsModal({
     case ModalState.CONFIRM_INTENT:
       return (
         <Modal
+          title="Override Mark Thresholds"
           content={
             <Prose>
-              <H1>Override Mark Thresholds</H1>
               <P>
                 WARNING: Do not proceed unless you have been instructed to do so
                 by a member of VotingWorks staff. Changing mark thresholds will
@@ -146,9 +146,9 @@ export function SetMarkThresholdsModal({
     case ModalState.SET_THRESHOLDS:
       return (
         <Modal
+          title="Override Mark Thresholds"
           content={
             <Prose>
-              <H1>Override Mark Thresholds</H1>
               <P>Definite:</P>
               <input
                 type="number"
@@ -191,9 +191,9 @@ export function SetMarkThresholdsModal({
       assert(markThresholdOverrides);
       return (
         <Modal
+          title="Reset Mark Thresholds"
           content={
             <Prose>
-              <H1>Reset Mark Thresholds</H1>
               <P>Reset thresholds to the election defaults?</P>
               <ThresholdColumns>
                 <div>

--- a/apps/scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.tsx
@@ -214,9 +214,9 @@ export function ElectionManagerScreen({
       )}
       {isShowingToggleTestModeWarningModal && (
         <Modal
+          title="Save Backup to switch to Test Ballot Mode"
           content={
             <Prose>
-              <H1>Save Backup to switch to Test Ballot Mode</H1>
               <P>
                 You must &quot;Save Backup&quot; before you may switch to Test
                 Ballot Mode.
@@ -246,12 +246,12 @@ export function ElectionManagerScreen({
       )}
       {confirmUnconfigure && (
         <Modal
+          title={isUnconfiguring ? undefined : 'Delete All Election Data?'}
           content={
             isUnconfiguring ? (
               <Loading />
             ) : (
               <Prose>
-                <H1>Delete All Election Data?</H1>
                 <P>
                   Do you want to remove all election information and data from
                   this machine?

--- a/apps/scan/frontend/src/screens/scan_warning_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_warning_screen.tsx
@@ -62,6 +62,8 @@ function ConfirmModal({ content, onConfirm, onCancel }: ConfirmModalProps) {
     <Modal
       themeDeprecated={fontSizeTheme.large}
       modalWidth={ModalWidth.Wide}
+      title="Are you sure?"
+      centerContent
       content={content}
       actions={
         <React.Fragment>
@@ -148,7 +150,6 @@ function OvervoteWarningScreen({
         <ConfirmModal
           content={
             <Prose textCenter>
-              <H1>Are you sure?</H1>
               <P>
                 Your votes in {pluralize('contest', contestNames.length, true)}{' '}
                 will not be counted.
@@ -245,7 +246,6 @@ function UndervoteWarningScreen({
         <ConfirmModal
           content={
             <Prose textCenter>
-              <H1>Are you sure?</H1>
               <P>
                 {blankContestNames.length > 0 && (
                   <span>
@@ -313,7 +313,6 @@ function BlankBallotWarningScreen(): JSX.Element {
         <ConfirmModal
           content={
             <Prose textCenter>
-              <H1>Are you sure?</H1>
               <P>No votes will be counted from this ballot.</P>
             </Prose>
           }

--- a/libs/ui/src/modal.stories.tsx
+++ b/libs/ui/src/modal.stories.tsx
@@ -3,11 +3,16 @@ import { Meta } from '@storybook/react';
 
 import { Modal as Component, ModalProps } from './modal';
 import { Button } from './button';
-import { H2, P } from './typography';
+
+const initialProps: ModalProps = {
+  title: 'Confirm Save',
+  content: 'Would you like to save your changes?',
+};
 
 const meta: Meta<typeof Component> = {
   title: 'libs-ui/Modal',
   component: Component,
+  args: initialProps,
 };
 
 export default meta;
@@ -31,12 +36,6 @@ export function Modal(props: ModalProps): JSX.Element {
                 Cancel
               </Button>
             </React.Fragment>
-          }
-          content={
-            <div>
-              <H2 as="h1">Confirm Save</H2>
-              <P>Would you like to save your changes?</P>
-            </div>
           }
           {...props}
         />

--- a/libs/ui/src/modal.test.tsx
+++ b/libs/ui/src/modal.test.tsx
@@ -10,6 +10,7 @@ describe('Modal', () => {
   it('renders a modal with content and actions', () => {
     render(
       <Modal
+        title="Are you sure?"
         content={<div>Do you want to do the thing?</div>}
         actions={
           <React.Fragment>
@@ -21,6 +22,7 @@ describe('Modal', () => {
     );
 
     const modal = screen.getByRole('alertdialog');
+    within(modal).getByRole('heading', { name: 'Are you sure?' });
     within(modal).getByText('Do you want to do the thing?');
     within(modal).getByRole('button', { name: 'Cancel' });
     within(modal).getByRole('button', { name: 'Confirm' });

--- a/libs/ui/src/modal.tsx
+++ b/libs/ui/src/modal.tsx
@@ -8,6 +8,7 @@ import { assert } from '@votingworks/basics';
 
 import { Theme } from './themes';
 import { ButtonBar } from './button_bar';
+import { H2 } from './typography';
 
 /**
  * Controls the maximum width the modal can expand to.
@@ -62,7 +63,7 @@ const ReactModalOverlay = styled('div')<ReactModalOverlayInterface>`
   bottom: 0;
   left: 0;
   z-index: 999; /* Should be above all default UI */
-  background: ${(p) => rgba(p.theme.colors.foreground, 0.75)};
+  background: ${(p) => rgba(p.theme.colors.foreground, 0.9)};
   @media (min-width: 480px) {
     padding: ${({ fullscreen }) => (fullscreen ? '0' : '0.5rem')};
   }
@@ -117,6 +118,7 @@ export interface ModalProps {
   fullscreen?: boolean;
   modalWidth?: ModalWidth;
   themeDeprecated?: Theme;
+  title?: string;
 }
 
 /* istanbul ignore next - unclear why this isn't covered */
@@ -153,6 +155,7 @@ export function Modal({
   onOverlayClick,
   modalWidth,
   themeDeprecated,
+  title,
 }: ModalProps): JSX.Element {
   /* istanbul ignore next - can't get document.getElementById working in test */
   const appElement =
@@ -194,6 +197,7 @@ export function Modal({
       overlayClassName="_"
     >
       <ModalContent centerContent={centerContent} fullscreen={fullscreen}>
+        {title && <H2 as="h1">{title}</H2>}
         {content}
       </ModalContent>
       {actions && <ButtonBar as="div">{actions}</ButtonBar>}


### PR DESCRIPTION
## Overview

_Closes https://github.com/votingworks/vxsuite/issues/3144_

Most instance of the `Modal` content render an `H1`-sized title - this looks a little crowded with the new VVSG themes, even at the default medium text size setting. Swapping these out for a `H2` title instead (using `as="h1"` to maintain proper a11y heading hierarchy.
- Adding an optional `title` prop to the `Modal` component, so we can standardize title styling across modals.
- Moving the custom title elements in VxScan into the `title` prop. Will migrate other apps as needed, when we switch them to the new themes.
- Also reduced the transparency of the background overlay a bit to improve the separation of the modal from the page content - noticed I was having a hard time focusing on the modal on noisy pages like the election manager screen.

## Demo Video or Screenshot
<img width="300" src="https://user-images.githubusercontent.com/264902/231839256-aab97e57-f738-4330-b71d-e8a2e28beae7.png"> <img width="300" src="https://user-images.githubusercontent.com/264902/231839263-8980fe7d-0272-459a-91e7-d9c61301e6d5.png">

<img width="300" src="https://user-images.githubusercontent.com/264902/231839343-6e4bfa14-4a7e-4ab9-bb1b-c8d96e0d1933.png"> <img width="300" src="https://user-images.githubusercontent.com/264902/231839351-4dc84ba9-4539-4d65-98be-c04513c73598.png">

## Testing Plan
- Added test assertion for the new `title` prop in the `Modal`
- Updated storybook.js entry to use the `title` prop
- Visual spot check for some of the affected modals

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
