### PR TITLE
[VxScan] Reduce crowding on ElectionManagerScreen

### DIFF
--- a/apps/scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.tsx
@@ -9,8 +9,9 @@ import {
   SetClockButton,
   UsbDrive,
   ChangePrecinctButton,
-  H1,
   P,
+  H2,
+  Caption,
 } from '@votingworks/ui';
 import React, { useState } from 'react';
 // eslint-disable-next-line vx/gts-no-import-export-type
@@ -103,7 +104,7 @@ export function ElectionManagerScreen({
       ballotCountOverride={scannerStatus.ballotsCounted}
     >
       <Prose textCenter>
-        <H1>Election Manager Settings</H1>
+        <H2 as="h1">Election Manager Settings</H2>
         {election.precincts.length > 1 && (
           <P>
             <ChangePrecinctButton
@@ -197,13 +198,14 @@ export function ElectionManagerScreen({
           >
             Delete All Election Data from VxScan
           </Button>
+          <br />
+          {!scannerStatus.canUnconfigure && (
+            <Caption>
+              You must “Save Backup” before you can delete election data from
+              VxScan.
+            </Caption>
+          )}
         </P>
-        {!scannerStatus.canUnconfigure && (
-          <P>
-            You must “Save Backup” before you can delete election data from
-            VxScan.
-          </P>
-        )}
       </Prose>
       {isMarkThresholdModalOpen && (
         <SetMarkThresholdsModal

--- a/libs/ui/src/change_precinct_button.tsx
+++ b/libs/ui/src/change_precinct_button.tsx
@@ -115,7 +115,6 @@ export function ChangePrecinctButton({
       value={dropdownCurrentValue}
       onBlur={handlePrecinctSelectionChange}
       onChange={handlePrecinctSelectionChange}
-      large
       disabled={mode === 'disabled'}
     >
       {mode === 'default' && (


### PR DESCRIPTION
## Overview

At the default VVSG size setting, the Election Manager Screen is getting a little crowded and in some states, content overflows and gets rendered below the fold.

This page could us a re-design, but in the meantime, taming a few elements on the screen so things fit at least at the default "medium" text size:
- Render an `H2`-sized page title instead of `H1` (with `as="h1"` to preserve a11y heading hierarchy)
- Stop rendering the `ChangePrecinctButton` as `<Select large>` so we make a bit of room - it's a little too large now with the VVSG styling.
- Change the disabled button explanation text at the bottom from `<P>` to `<Caption>`

## Demo Video or Screenshot
### Before/After:
<img width="300" src="https://user-images.githubusercontent.com/264902/231886858-6e23bfe2-f5f1-4194-b62e-815b72448bee.png"> <img width="300" src="https://user-images.githubusercontent.com/264902/231886962-ca00e498-8bf4-484c-8011-f2f53248ee76.png">

## Testing Plan
- Visual verification

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
