### PR TITLE
fix(admin): Write-in image cropping tweaks

### DIFF
--- a/libs/ballot-interpreter-nh-next/src/layout.rs
+++ b/libs/ballot-interpreter-nh-next/src/layout.rs
@@ -29,9 +29,9 @@ fn build_option_layout(
 ) -> Option<InterpretedContestOptionLayout> {
     // Option bounding box parameters
     // TODO make these configurable in the election definition
-    let column_offset: i32 = -9;
+    let column_offset: i32 = -10;
     let row_offset: i32 = -1;
-    let width: GridUnit = 10;
+    let width: GridUnit = 11;
     let height: GridUnit = 2;
 
     let clamp_row = |row: i32| -> GridUnit {

--- a/libs/ballot-interpreter-nh-next/src/layout.rs
+++ b/libs/ballot-interpreter-nh-next/src/layout.rs
@@ -43,28 +43,43 @@ fn build_option_layout(
 
     let bubble_location = grid_position.location();
 
-    let top_left_grid_point: Point<GridUnit> = Point::new(
+    let top_left_location: Point<GridUnit> = Point::new(
         clamp_column(bubble_location.column as i32 + column_offset),
         clamp_row(bubble_location.row as i32 + row_offset),
     );
-    let bottom_right_grid_point: Point<GridUnit> = Point::new(
+    let bottom_left_location: Point<GridUnit> = Point::new(
+        clamp_column(bubble_location.column as i32 + column_offset),
+        clamp_row(bubble_location.row as i32 + row_offset + height as i32),
+    );
+    let top_right_location: Point<GridUnit> = Point::new(
+        clamp_column(bubble_location.column as i32 + column_offset + width as i32),
+        clamp_row(bubble_location.row as i32 + row_offset),
+    );
+    let bottom_right_location: Point<GridUnit> = Point::new(
         clamp_column(bubble_location.column as i32 + column_offset + width as i32),
         clamp_row(bubble_location.row as i32 + row_offset + height as i32),
     );
 
-    let top_left_subpixel_point =
-        grid.point_for_location(top_left_grid_point.x, top_left_grid_point.y)?;
-    let bottom_right_subpixel_point = grid.point_for_location(
-        bottom_right_grid_point.x as GridUnit,
-        bottom_right_grid_point.y as GridUnit,
-    )?;
+    let top_left_point = grid.point_for_location(top_left_location.x, top_left_location.y)?;
+    let bottom_left_point =
+        grid.point_for_location(bottom_left_location.x, bottom_left_location.y)?;
+    let top_right_point = grid.point_for_location(top_right_location.x, top_right_location.y)?;
+    let bottom_right_point =
+        grid.point_for_location(bottom_right_location.x, bottom_right_location.y)?;
+
+    // We use the furthest points to determine the bounding box so we enclose
+    // content that may have moved further away when skewed.
+    let furthest_left = top_left_point.x.min(bottom_left_point.x);
+    let furthest_right = top_right_point.x.max(bottom_right_point.x);
+    let furthest_top = top_left_point.y.min(top_right_point.y);
+    let furthest_bottom = bottom_left_point.y.max(bottom_right_point.y);
+
+    let furthest_top_left_point = Point::new(furthest_left, furthest_top).round();
+    let furthest_bottom_right_point = Point::new(furthest_right, furthest_bottom).round();
 
     Some(InterpretedContestOptionLayout {
         option_id: grid_position.option_id(),
-        bounds: Rect::from_points(
-            top_left_subpixel_point.round(),
-            bottom_right_subpixel_point.round(),
-        ),
+        bounds: Rect::from_points(furthest_top_left_point, furthest_bottom_right_point),
     })
 }
 

--- a/libs/ballot-interpreter-nh-next/ts/src/__snapshots__/adapter.test.ts.snap
+++ b/libs/ballot-interpreter-nh-next/ts/src/__snapshots__/adapter.test.ts.snap
@@ -6,14 +6,14 @@ exports[`interpret with valid data 1`] = `
     {
       "bounds": {
         "height": 102,
-        "width": 1501,
-        "x": 172,
+        "width": 1551,
+        "x": 122,
         "y": 455,
       },
       "contestId": "Governor-061a401b",
       "corners": [
         {
-          "x": 172,
+          "x": 122,
           "y": 455,
         },
         {
@@ -21,7 +21,7 @@ exports[`interpret with valid data 1`] = `
           "y": 455,
         },
         {
-          "x": 172,
+          "x": 122,
           "y": 557,
         },
         {
@@ -33,8 +33,8 @@ exports[`interpret with valid data 1`] = `
         {
           "bounds": {
             "height": 102,
-            "width": 502,
-            "x": 172,
+            "width": 552,
+            "x": 122,
             "y": 455,
           },
           "definition": {
@@ -63,8 +63,8 @@ exports[`interpret with valid data 1`] = `
         {
           "bounds": {
             "height": 102,
-            "width": 501,
-            "x": 522,
+            "width": 551,
+            "x": 472,
             "y": 455,
           },
           "definition": {
@@ -93,8 +93,8 @@ exports[`interpret with valid data 1`] = `
         {
           "bounds": {
             "height": 102,
-            "width": 501,
-            "x": 872,
+            "width": 551,
+            "x": 822,
             "y": 455,
           },
           "definition": {
@@ -123,8 +123,8 @@ exports[`interpret with valid data 1`] = `
         {
           "bounds": {
             "height": 102,
-            "width": 501,
-            "x": 1172,
+            "width": 551,
+            "x": 1122,
             "y": 455,
           },
           "definition": {
@@ -156,14 +156,14 @@ exports[`interpret with valid data 1`] = `
     {
       "bounds": {
         "height": 102,
-        "width": 1500,
-        "x": 173,
+        "width": 1550,
+        "x": 123,
         "y": 606,
       },
       "contestId": "United-States-Senator-d3f1c75b",
       "corners": [
         {
-          "x": 173,
+          "x": 123,
           "y": 606,
         },
         {
@@ -171,7 +171,7 @@ exports[`interpret with valid data 1`] = `
           "y": 606,
         },
         {
-          "x": 173,
+          "x": 123,
           "y": 708,
         },
         {
@@ -183,8 +183,8 @@ exports[`interpret with valid data 1`] = `
         {
           "bounds": {
             "height": 102,
-            "width": 501,
-            "x": 173,
+            "width": 551,
+            "x": 123,
             "y": 606,
           },
           "definition": {
@@ -212,9 +212,9 @@ exports[`interpret with valid data 1`] = `
         },
         {
           "bounds": {
-            "height": 101,
-            "width": 500,
-            "x": 523,
+            "height": 102,
+            "width": 550,
+            "x": 473,
             "y": 606,
           },
           "definition": {
@@ -243,8 +243,8 @@ exports[`interpret with valid data 1`] = `
         {
           "bounds": {
             "height": 101,
-            "width": 501,
-            "x": 1172,
+            "width": 551,
+            "x": 1122,
             "y": 606,
           },
           "definition": {
@@ -275,15 +275,15 @@ exports[`interpret with valid data 1`] = `
     },
     {
       "bounds": {
-        "height": 102,
-        "width": 1501,
-        "x": 173,
+        "height": 103,
+        "width": 1551,
+        "x": 123,
         "y": 757,
       },
       "contestId": "Representative-in-Congress-24683b44",
       "corners": [
         {
-          "x": 173,
+          "x": 123,
           "y": 757,
         },
         {
@@ -291,20 +291,20 @@ exports[`interpret with valid data 1`] = `
           "y": 757,
         },
         {
-          "x": 173,
-          "y": 859,
+          "x": 123,
+          "y": 860,
         },
         {
           "x": 1674,
-          "y": 859,
+          "y": 860,
         },
       ],
       "options": [
         {
           "bounds": {
-            "height": 102,
-            "width": 501,
-            "x": 173,
+            "height": 103,
+            "width": 551,
+            "x": 123,
             "y": 757,
           },
           "definition": {
@@ -332,9 +332,9 @@ exports[`interpret with valid data 1`] = `
         },
         {
           "bounds": {
-            "height": 102,
-            "width": 501,
-            "x": 523,
+            "height": 103,
+            "width": 551,
+            "x": 473,
             "y": 757,
           },
           "definition": {
@@ -363,8 +363,8 @@ exports[`interpret with valid data 1`] = `
         {
           "bounds": {
             "height": 102,
-            "width": 502,
-            "x": 872,
+            "width": 551,
+            "x": 823,
             "y": 757,
           },
           "definition": {
@@ -393,8 +393,8 @@ exports[`interpret with valid data 1`] = `
         {
           "bounds": {
             "height": 102,
-            "width": 502,
-            "x": 1172,
+            "width": 552,
+            "x": 1122,
             "y": 757,
           },
           "definition": {
@@ -426,14 +426,14 @@ exports[`interpret with valid data 1`] = `
     {
       "bounds": {
         "height": 102,
-        "width": 1501,
-        "x": 173,
+        "width": 1551,
+        "x": 123,
         "y": 908,
       },
       "contestId": "Executive-Councilor-bb22557f",
       "corners": [
         {
-          "x": 173,
+          "x": 123,
           "y": 908,
         },
         {
@@ -441,7 +441,7 @@ exports[`interpret with valid data 1`] = `
           "y": 908,
         },
         {
-          "x": 173,
+          "x": 123,
           "y": 1010,
         },
         {
@@ -453,8 +453,8 @@ exports[`interpret with valid data 1`] = `
         {
           "bounds": {
             "height": 101,
-            "width": 501,
-            "x": 173,
+            "width": 551,
+            "x": 123,
             "y": 909,
           },
           "definition": {
@@ -482,10 +482,10 @@ exports[`interpret with valid data 1`] = `
         },
         {
           "bounds": {
-            "height": 101,
-            "width": 501,
-            "x": 523,
-            "y": 909,
+            "height": 102,
+            "width": 551,
+            "x": 473,
+            "y": 908,
           },
           "definition": {
             "contestId": "Executive-Councilor-bb22557f",
@@ -512,9 +512,9 @@ exports[`interpret with valid data 1`] = `
         },
         {
           "bounds": {
-            "height": 101,
-            "width": 501,
-            "x": 1173,
+            "height": 102,
+            "width": 551,
+            "x": 1123,
             "y": 908,
           },
           "definition": {
@@ -545,37 +545,37 @@ exports[`interpret with valid data 1`] = `
     },
     {
       "bounds": {
-        "height": 102,
-        "width": 1501,
-        "x": 173,
-        "y": 1059,
+        "height": 104,
+        "width": 1551,
+        "x": 123,
+        "y": 1058,
       },
       "contestId": "State-Senator-391381f8",
       "corners": [
         {
-          "x": 173,
-          "y": 1059,
+          "x": 123,
+          "y": 1058,
         },
         {
           "x": 1674,
-          "y": 1059,
+          "y": 1058,
         },
         {
-          "x": 173,
-          "y": 1161,
+          "x": 123,
+          "y": 1162,
         },
         {
           "x": 1674,
-          "y": 1161,
+          "y": 1162,
         },
       ],
       "options": [
         {
           "bounds": {
-            "height": 101,
-            "width": 502,
-            "x": 173,
-            "y": 1060,
+            "height": 103,
+            "width": 552,
+            "x": 123,
+            "y": 1059,
           },
           "definition": {
             "contestId": "State-Senator-391381f8",
@@ -603,8 +603,8 @@ exports[`interpret with valid data 1`] = `
         {
           "bounds": {
             "height": 102,
-            "width": 501,
-            "x": 523,
+            "width": 551,
+            "x": 473,
             "y": 1059,
           },
           "definition": {
@@ -632,10 +632,10 @@ exports[`interpret with valid data 1`] = `
         },
         {
           "bounds": {
-            "height": 101,
-            "width": 501,
-            "x": 1173,
-            "y": 1059,
+            "height": 103,
+            "width": 551,
+            "x": 1123,
+            "y": 1058,
           },
           "definition": {
             "contestId": "State-Senator-391381f8",
@@ -665,37 +665,37 @@ exports[`interpret with valid data 1`] = `
     },
     {
       "bounds": {
-        "height": 354,
-        "width": 1501,
-        "x": 174,
-        "y": 1210,
+        "height": 356,
+        "width": 1551,
+        "x": 124,
+        "y": 1209,
       },
       "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
       "corners": [
         {
-          "x": 174,
-          "y": 1210,
+          "x": 124,
+          "y": 1209,
         },
         {
           "x": 1675,
-          "y": 1210,
+          "y": 1209,
         },
         {
-          "x": 174,
-          "y": 1564,
+          "x": 124,
+          "y": 1565,
         },
         {
           "x": 1675,
-          "y": 1564,
+          "y": 1565,
         },
       ],
       "options": [
         {
           "bounds": {
-            "height": 101,
-            "width": 501,
-            "x": 174,
-            "y": 1262,
+            "height": 102,
+            "width": 551,
+            "x": 124,
+            "y": 1261,
           },
           "definition": {
             "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
@@ -722,9 +722,9 @@ exports[`interpret with valid data 1`] = `
         },
         {
           "bounds": {
-            "height": 101,
-            "width": 501,
-            "x": 174,
+            "height": 102,
+            "width": 551,
+            "x": 124,
             "y": 1362,
           },
           "definition": {
@@ -752,10 +752,10 @@ exports[`interpret with valid data 1`] = `
         },
         {
           "bounds": {
-            "height": 101,
-            "width": 502,
-            "x": 174,
-            "y": 1463,
+            "height": 103,
+            "width": 552,
+            "x": 124,
+            "y": 1462,
           },
           "definition": {
             "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
@@ -782,10 +782,10 @@ exports[`interpret with valid data 1`] = `
         },
         {
           "bounds": {
-            "height": 100,
-            "width": 501,
-            "x": 524,
-            "y": 1211,
+            "height": 102,
+            "width": 551,
+            "x": 474,
+            "y": 1210,
           },
           "definition": {
             "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
@@ -812,10 +812,10 @@ exports[`interpret with valid data 1`] = `
         },
         {
           "bounds": {
-            "height": 101,
-            "width": 501,
-            "x": 524,
-            "y": 1311,
+            "height": 103,
+            "width": 551,
+            "x": 474,
+            "y": 1310,
           },
           "definition": {
             "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
@@ -842,10 +842,10 @@ exports[`interpret with valid data 1`] = `
         },
         {
           "bounds": {
-            "height": 101,
-            "width": 501,
-            "x": 524,
-            "y": 1412,
+            "height": 103,
+            "width": 551,
+            "x": 474,
+            "y": 1411,
           },
           "definition": {
             "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
@@ -872,10 +872,10 @@ exports[`interpret with valid data 1`] = `
         },
         {
           "bounds": {
-            "height": 100,
-            "width": 502,
-            "x": 873,
-            "y": 1261,
+            "height": 102,
+            "width": 551,
+            "x": 824,
+            "y": 1260,
           },
           "definition": {
             "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
@@ -902,10 +902,10 @@ exports[`interpret with valid data 1`] = `
         },
         {
           "bounds": {
-            "height": 101,
-            "width": 501,
-            "x": 874,
-            "y": 1361,
+            "height": 103,
+            "width": 551,
+            "x": 824,
+            "y": 1360,
           },
           "definition": {
             "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
@@ -932,10 +932,10 @@ exports[`interpret with valid data 1`] = `
         },
         {
           "bounds": {
-            "height": 101,
-            "width": 502,
-            "x": 1173,
-            "y": 1210,
+            "height": 102,
+            "width": 552,
+            "x": 1123,
+            "y": 1209,
           },
           "definition": {
             "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
@@ -963,9 +963,9 @@ exports[`interpret with valid data 1`] = `
         },
         {
           "bounds": {
-            "height": 101,
-            "width": 501,
-            "x": 1174,
+            "height": 102,
+            "width": 551,
+            "x": 1124,
             "y": 1310,
           },
           "definition": {
@@ -994,10 +994,10 @@ exports[`interpret with valid data 1`] = `
         },
         {
           "bounds": {
-            "height": 101,
-            "width": 499,
-            "x": 1174,
-            "y": 1411,
+            "height": 103,
+            "width": 551,
+            "x": 1124,
+            "y": 1410,
           },
           "definition": {
             "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
@@ -1027,37 +1027,37 @@ exports[`interpret with valid data 1`] = `
     },
     {
       "bounds": {
-        "height": 102,
-        "width": 1501,
-        "x": 175,
-        "y": 1662,
+        "height": 104,
+        "width": 1551,
+        "x": 125,
+        "y": 1661,
       },
       "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
       "corners": [
         {
-          "x": 175,
-          "y": 1662,
+          "x": 125,
+          "y": 1661,
         },
         {
           "x": 1676,
-          "y": 1662,
+          "y": 1661,
         },
         {
-          "x": 175,
-          "y": 1764,
+          "x": 125,
+          "y": 1765,
         },
         {
           "x": 1676,
-          "y": 1764,
+          "y": 1765,
         },
       ],
       "options": [
         {
           "bounds": {
-            "height": 99,
-            "width": 501,
-            "x": 175,
-            "y": 1665,
+            "height": 102,
+            "width": 551,
+            "x": 125,
+            "y": 1663,
           },
           "definition": {
             "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
@@ -1084,10 +1084,10 @@ exports[`interpret with valid data 1`] = `
         },
         {
           "bounds": {
-            "height": 99,
-            "width": 501,
-            "x": 525,
-            "y": 1664,
+            "height": 102,
+            "width": 551,
+            "x": 475,
+            "y": 1662,
           },
           "definition": {
             "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
@@ -1114,10 +1114,10 @@ exports[`interpret with valid data 1`] = `
         },
         {
           "bounds": {
-            "height": 99,
-            "width": 502,
-            "x": 874,
-            "y": 1663,
+            "height": 102,
+            "width": 551,
+            "x": 825,
+            "y": 1661,
           },
           "definition": {
             "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
@@ -1144,10 +1144,10 @@ exports[`interpret with valid data 1`] = `
         },
         {
           "bounds": {
-            "height": 99,
-            "width": 502,
-            "x": 1174,
-            "y": 1662,
+            "height": 102,
+            "width": 552,
+            "x": 1124,
+            "y": 1661,
           },
           "definition": {
             "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
@@ -1200,14 +1200,14 @@ exports[`interpret with valid data 2`] = `
     {
       "bounds": {
         "height": 102,
-        "width": 1501,
-        "x": 182,
+        "width": 1551,
+        "x": 132,
         "y": 253,
       },
       "contestId": "Sheriff-4243fe0b",
       "corners": [
         {
-          "x": 182,
+          "x": 132,
           "y": 253,
         },
         {
@@ -1215,7 +1215,7 @@ exports[`interpret with valid data 2`] = `
           "y": 253,
         },
         {
-          "x": 182,
+          "x": 132,
           "y": 355,
         },
         {
@@ -1227,8 +1227,8 @@ exports[`interpret with valid data 2`] = `
         {
           "bounds": {
             "height": 102,
-            "width": 501,
-            "x": 182,
+            "width": 551,
+            "x": 132,
             "y": 253,
           },
           "definition": {
@@ -1257,8 +1257,8 @@ exports[`interpret with valid data 2`] = `
         {
           "bounds": {
             "height": 102,
-            "width": 501,
-            "x": 532,
+            "width": 551,
+            "x": 482,
             "y": 253,
           },
           "definition": {
@@ -1287,8 +1287,8 @@ exports[`interpret with valid data 2`] = `
         {
           "bounds": {
             "height": 102,
-            "width": 501,
-            "x": 1182,
+            "width": 551,
+            "x": 1132,
             "y": 253,
           },
           "definition": {
@@ -1320,14 +1320,14 @@ exports[`interpret with valid data 2`] = `
     {
       "bounds": {
         "height": 101,
-        "width": 1501,
-        "x": 182,
+        "width": 1551,
+        "x": 132,
         "y": 405,
       },
       "contestId": "County-Attorney-133f910f",
       "corners": [
         {
-          "x": 182,
+          "x": 132,
           "y": 405,
         },
         {
@@ -1335,7 +1335,7 @@ exports[`interpret with valid data 2`] = `
           "y": 405,
         },
         {
-          "x": 182,
+          "x": 132,
           "y": 506,
         },
         {
@@ -1347,8 +1347,8 @@ exports[`interpret with valid data 2`] = `
         {
           "bounds": {
             "height": 101,
-            "width": 501,
-            "x": 182,
+            "width": 551,
+            "x": 132,
             "y": 405,
           },
           "definition": {
@@ -1377,8 +1377,8 @@ exports[`interpret with valid data 2`] = `
         {
           "bounds": {
             "height": 101,
-            "width": 501,
-            "x": 532,
+            "width": 551,
+            "x": 482,
             "y": 405,
           },
           "definition": {
@@ -1407,8 +1407,8 @@ exports[`interpret with valid data 2`] = `
         {
           "bounds": {
             "height": 101,
-            "width": 501,
-            "x": 1182,
+            "width": 551,
+            "x": 1132,
             "y": 405,
           },
           "definition": {
@@ -1440,14 +1440,14 @@ exports[`interpret with valid data 2`] = `
     {
       "bounds": {
         "height": 103,
-        "width": 1502,
-        "x": 182,
+        "width": 1552,
+        "x": 132,
         "y": 555,
       },
       "contestId": "County-Treasurer-87d25a31",
       "corners": [
         {
-          "x": 182,
+          "x": 132,
           "y": 555,
         },
         {
@@ -1455,7 +1455,7 @@ exports[`interpret with valid data 2`] = `
           "y": 555,
         },
         {
-          "x": 182,
+          "x": 132,
           "y": 658,
         },
         {
@@ -1467,8 +1467,8 @@ exports[`interpret with valid data 2`] = `
         {
           "bounds": {
             "height": 102,
-            "width": 501,
-            "x": 182,
+            "width": 551,
+            "x": 132,
             "y": 555,
           },
           "definition": {
@@ -1497,8 +1497,8 @@ exports[`interpret with valid data 2`] = `
         {
           "bounds": {
             "height": 102,
-            "width": 501,
-            "x": 532,
+            "width": 551,
+            "x": 482,
             "y": 555,
           },
           "definition": {
@@ -1527,8 +1527,8 @@ exports[`interpret with valid data 2`] = `
         {
           "bounds": {
             "height": 102,
-            "width": 502,
-            "x": 1182,
+            "width": 552,
+            "x": 1132,
             "y": 556,
           },
           "definition": {
@@ -1560,14 +1560,14 @@ exports[`interpret with valid data 2`] = `
     {
       "bounds": {
         "height": 102,
-        "width": 1501,
-        "x": 182,
+        "width": 1551,
+        "x": 132,
         "y": 707,
       },
       "contestId": "Register-of-Deeds-a1278df2",
       "corners": [
         {
-          "x": 182,
+          "x": 132,
           "y": 707,
         },
         {
@@ -1575,7 +1575,7 @@ exports[`interpret with valid data 2`] = `
           "y": 707,
         },
         {
-          "x": 182,
+          "x": 132,
           "y": 809,
         },
         {
@@ -1587,8 +1587,8 @@ exports[`interpret with valid data 2`] = `
         {
           "bounds": {
             "height": 101,
-            "width": 501,
-            "x": 182,
+            "width": 551,
+            "x": 132,
             "y": 707,
           },
           "definition": {
@@ -1617,8 +1617,8 @@ exports[`interpret with valid data 2`] = `
         {
           "bounds": {
             "height": 102,
-            "width": 501,
-            "x": 532,
+            "width": 551,
+            "x": 482,
             "y": 707,
           },
           "definition": {
@@ -1647,8 +1647,8 @@ exports[`interpret with valid data 2`] = `
         {
           "bounds": {
             "height": 102,
-            "width": 501,
-            "x": 1182,
+            "width": 551,
+            "x": 1132,
             "y": 707,
           },
           "definition": {
@@ -1680,26 +1680,26 @@ exports[`interpret with valid data 2`] = `
     {
       "bounds": {
         "height": 103,
-        "width": 1500,
-        "x": 182,
+        "width": 1552,
+        "x": 131,
         "y": 857,
       },
       "contestId": "Register-of-Probate-a4117da8",
       "corners": [
         {
-          "x": 182,
+          "x": 131,
           "y": 857,
         },
         {
-          "x": 1682,
+          "x": 1683,
           "y": 857,
         },
         {
-          "x": 182,
+          "x": 131,
           "y": 960,
         },
         {
-          "x": 1682,
+          "x": 1683,
           "y": 960,
         },
       ],
@@ -1707,8 +1707,8 @@ exports[`interpret with valid data 2`] = `
         {
           "bounds": {
             "height": 102,
-            "width": 500,
-            "x": 182,
+            "width": 552,
+            "x": 131,
             "y": 857,
           },
           "definition": {
@@ -1737,8 +1737,8 @@ exports[`interpret with valid data 2`] = `
         {
           "bounds": {
             "height": 102,
-            "width": 500,
-            "x": 532,
+            "width": 552,
+            "x": 481,
             "y": 857,
           },
           "definition": {
@@ -1767,8 +1767,8 @@ exports[`interpret with valid data 2`] = `
         {
           "bounds": {
             "height": 102,
-            "width": 500,
-            "x": 1182,
+            "width": 552,
+            "x": 1131,
             "y": 858,
           },
           "definition": {
@@ -1800,14 +1800,14 @@ exports[`interpret with valid data 2`] = `
     {
       "bounds": {
         "height": 103,
-        "width": 1500,
-        "x": 182,
+        "width": 1550,
+        "x": 132,
         "y": 1008,
       },
       "contestId": "County-Commissioner-d6feed25",
       "corners": [
         {
-          "x": 182,
+          "x": 132,
           "y": 1008,
         },
         {
@@ -1815,7 +1815,7 @@ exports[`interpret with valid data 2`] = `
           "y": 1008,
         },
         {
-          "x": 182,
+          "x": 132,
           "y": 1111,
         },
         {
@@ -1827,8 +1827,8 @@ exports[`interpret with valid data 2`] = `
         {
           "bounds": {
             "height": 102,
-            "width": 501,
-            "x": 182,
+            "width": 551,
+            "x": 132,
             "y": 1008,
           },
           "definition": {
@@ -1857,8 +1857,8 @@ exports[`interpret with valid data 2`] = `
         {
           "bounds": {
             "height": 102,
-            "width": 500,
-            "x": 532,
+            "width": 550,
+            "x": 482,
             "y": 1008,
           },
           "definition": {
@@ -1887,8 +1887,8 @@ exports[`interpret with valid data 2`] = `
         {
           "bounds": {
             "height": 102,
-            "width": 501,
-            "x": 1181,
+            "width": 551,
+            "x": 1131,
             "y": 1009,
           },
           "definition": {
@@ -1920,26 +1920,26 @@ exports[`interpret with valid data 2`] = `
     {
       "bounds": {
         "height": 103,
-        "width": 800,
-        "x": 881,
+        "width": 851,
+        "x": 831,
         "y": 1260,
       },
       "contestId": "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc",
       "corners": [
         {
-          "x": 881,
+          "x": 831,
           "y": 1260,
         },
         {
-          "x": 1681,
+          "x": 1682,
           "y": 1260,
         },
         {
-          "x": 881,
+          "x": 831,
           "y": 1363,
         },
         {
-          "x": 1681,
+          "x": 1682,
           "y": 1363,
         },
       ],
@@ -1947,8 +1947,8 @@ exports[`interpret with valid data 2`] = `
         {
           "bounds": {
             "height": 103,
-            "width": 500,
-            "x": 881,
+            "width": 551,
+            "x": 831,
             "y": 1260,
           },
           "definition": {
@@ -1976,8 +1976,8 @@ exports[`interpret with valid data 2`] = `
         {
           "bounds": {
             "height": 103,
-            "width": 500,
-            "x": 1181,
+            "width": 552,
+            "x": 1130,
             "y": 1260,
           },
           "definition": {

--- a/libs/ballot-interpreter-nh-next/ts/src/__snapshots__/interpret.test.ts.snap
+++ b/libs/ballot-interpreter-nh-next/ts/src/__snapshots__/interpret.test.ts.snap
@@ -5,45 +5,45 @@ exports[`interpret with valid data 1`] = `
   {
     "bounds": {
       "height": 102,
-      "left": 172,
+      "left": 122,
       "top": 455,
-      "width": 1501,
+      "width": 1551,
     },
     "contestId": "Governor-061a401b",
     "options": [
       {
         "bounds": {
           "height": 102,
-          "left": 172,
+          "left": 122,
           "top": 455,
-          "width": 502,
+          "width": 552,
         },
         "optionId": "Josiah-Bartlett-1bb99985",
       },
       {
         "bounds": {
           "height": 102,
-          "left": 522,
+          "left": 472,
           "top": 455,
-          "width": 501,
+          "width": 551,
         },
         "optionId": "Hannah-Dustin-ab4ef7c8",
       },
       {
         "bounds": {
           "height": 102,
-          "left": 872,
+          "left": 822,
           "top": 455,
-          "width": 501,
+          "width": 551,
         },
         "optionId": "John-Spencer-9ffb5970",
       },
       {
         "bounds": {
           "height": 102,
-          "left": 1172,
+          "left": 1122,
           "top": 455,
-          "width": 501,
+          "width": 551,
         },
         "optionId": "write-in-0",
       },
@@ -52,36 +52,36 @@ exports[`interpret with valid data 1`] = `
   {
     "bounds": {
       "height": 102,
-      "left": 173,
+      "left": 123,
       "top": 606,
-      "width": 1500,
+      "width": 1550,
     },
     "contestId": "United-States-Senator-d3f1c75b",
     "options": [
       {
         "bounds": {
           "height": 102,
-          "left": 173,
+          "left": 123,
           "top": 606,
-          "width": 501,
+          "width": 551,
         },
         "optionId": "John-Langdon-5951c8e1",
       },
       {
         "bounds": {
-          "height": 101,
-          "left": 523,
+          "height": 102,
+          "left": 473,
           "top": 606,
-          "width": 500,
+          "width": 550,
         },
         "optionId": "William-Preston-3778fcd5",
       },
       {
         "bounds": {
           "height": 101,
-          "left": 1172,
+          "left": 1122,
           "top": 606,
-          "width": 501,
+          "width": 551,
         },
         "optionId": "write-in-0",
       },
@@ -89,46 +89,46 @@ exports[`interpret with valid data 1`] = `
   },
   {
     "bounds": {
-      "height": 102,
-      "left": 173,
+      "height": 103,
+      "left": 123,
       "top": 757,
-      "width": 1501,
+      "width": 1551,
     },
     "contestId": "Representative-in-Congress-24683b44",
     "options": [
       {
         "bounds": {
-          "height": 102,
-          "left": 173,
+          "height": 103,
+          "left": 123,
           "top": 757,
-          "width": 501,
+          "width": 551,
         },
         "optionId": "Jeremiah-Smith-469560c9",
       },
       {
         "bounds": {
-          "height": 102,
-          "left": 523,
+          "height": 103,
+          "left": 473,
           "top": 757,
-          "width": 501,
+          "width": 551,
         },
         "optionId": "Nicholas-Gilman-1791aed7",
       },
       {
         "bounds": {
           "height": 102,
-          "left": 872,
+          "left": 823,
           "top": 757,
-          "width": 502,
+          "width": 551,
         },
         "optionId": "Richard-Coote-b9095636",
       },
       {
         "bounds": {
           "height": 102,
-          "left": 1172,
+          "left": 1122,
           "top": 757,
-          "width": 502,
+          "width": 552,
         },
         "optionId": "write-in-0",
       },
@@ -137,36 +137,36 @@ exports[`interpret with valid data 1`] = `
   {
     "bounds": {
       "height": 102,
-      "left": 173,
+      "left": 123,
       "top": 908,
-      "width": 1501,
+      "width": 1551,
     },
     "contestId": "Executive-Councilor-bb22557f",
     "options": [
       {
         "bounds": {
           "height": 101,
-          "left": 173,
+          "left": 123,
           "top": 909,
-          "width": 501,
+          "width": 551,
         },
         "optionId": "Anne-Waldron-ee0cbc85",
       },
       {
         "bounds": {
-          "height": 101,
-          "left": 523,
-          "top": 909,
-          "width": 501,
+          "height": 102,
+          "left": 473,
+          "top": 908,
+          "width": 551,
         },
         "optionId": "Daniel-Webster-13f77b2d",
       },
       {
         "bounds": {
-          "height": 101,
-          "left": 1173,
+          "height": 102,
+          "left": 1123,
           "top": 908,
-          "width": 501,
+          "width": 551,
         },
         "optionId": "write-in-0",
       },
@@ -174,37 +174,37 @@ exports[`interpret with valid data 1`] = `
   },
   {
     "bounds": {
-      "height": 102,
-      "left": 173,
-      "top": 1059,
-      "width": 1501,
+      "height": 104,
+      "left": 123,
+      "top": 1058,
+      "width": 1551,
     },
     "contestId": "State-Senator-391381f8",
     "options": [
       {
         "bounds": {
-          "height": 101,
-          "left": 173,
-          "top": 1060,
-          "width": 502,
+          "height": 103,
+          "left": 123,
+          "top": 1059,
+          "width": 552,
         },
         "optionId": "James-Poole-db5ef4bd",
       },
       {
         "bounds": {
           "height": 102,
-          "left": 523,
+          "left": 473,
           "top": 1059,
-          "width": 501,
+          "width": 551,
         },
         "optionId": "Matthew-Thornton-f66fec5e",
       },
       {
         "bounds": {
-          "height": 101,
-          "left": 1173,
-          "top": 1059,
-          "width": 501,
+          "height": 103,
+          "left": 1123,
+          "top": 1058,
+          "width": 551,
         },
         "optionId": "write-in-0",
       },
@@ -212,109 +212,109 @@ exports[`interpret with valid data 1`] = `
   },
   {
     "bounds": {
-      "height": 354,
-      "left": 174,
-      "top": 1210,
-      "width": 1501,
+      "height": 356,
+      "left": 124,
+      "top": 1209,
+      "width": 1551,
     },
     "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
     "options": [
       {
         "bounds": {
-          "height": 101,
-          "left": 174,
-          "top": 1262,
-          "width": 501,
+          "height": 102,
+          "left": 124,
+          "top": 1261,
+          "width": 551,
         },
         "optionId": "Obadiah-Carrigan-5c95145a",
       },
       {
         "bounds": {
-          "height": 101,
-          "left": 174,
+          "height": 102,
+          "left": 124,
           "top": 1362,
-          "width": 501,
+          "width": 551,
         },
         "optionId": "Mary-Baker-Eddy-350785d5",
       },
       {
         "bounds": {
-          "height": 101,
-          "left": 174,
-          "top": 1463,
-          "width": 502,
+          "height": 103,
+          "left": 124,
+          "top": 1462,
+          "width": 552,
         },
         "optionId": "Samuel-Bell-17973275",
       },
       {
         "bounds": {
-          "height": 100,
-          "left": 524,
-          "top": 1211,
-          "width": 501,
+          "height": 102,
+          "left": 474,
+          "top": 1210,
+          "width": 551,
         },
         "optionId": "Samuel-Livermore-f927fef1",
       },
       {
         "bounds": {
-          "height": 101,
-          "left": 524,
-          "top": 1311,
-          "width": 501,
+          "height": 103,
+          "left": 474,
+          "top": 1310,
+          "width": 551,
         },
         "optionId": "Elijah-Miller-a52e6988",
       },
       {
         "bounds": {
-          "height": 101,
-          "left": 524,
-          "top": 1412,
-          "width": 501,
+          "height": 103,
+          "left": 474,
+          "top": 1411,
+          "width": 551,
         },
         "optionId": "Isaac-Hill-d6c9deeb",
       },
       {
         "bounds": {
-          "height": 100,
-          "left": 873,
-          "top": 1261,
-          "width": 502,
+          "height": 102,
+          "left": 824,
+          "top": 1260,
+          "width": 551,
         },
         "optionId": "Abigail-Bartlett-4e46c9d4",
       },
       {
         "bounds": {
-          "height": 101,
-          "left": 874,
-          "top": 1361,
-          "width": 501,
+          "height": 103,
+          "left": 824,
+          "top": 1360,
+          "width": 551,
         },
         "optionId": "Jacob-Freese-b5146505",
       },
       {
         "bounds": {
-          "height": 101,
-          "left": 1173,
-          "top": 1210,
-          "width": 502,
+          "height": 102,
+          "left": 1123,
+          "top": 1209,
+          "width": 552,
         },
         "optionId": "write-in-0",
       },
       {
         "bounds": {
-          "height": 101,
-          "left": 1174,
+          "height": 102,
+          "left": 1124,
           "top": 1310,
-          "width": 501,
+          "width": 551,
         },
         "optionId": "write-in-1",
       },
       {
         "bounds": {
-          "height": 101,
-          "left": 1174,
-          "top": 1411,
-          "width": 499,
+          "height": 103,
+          "left": 1124,
+          "top": 1410,
+          "width": 551,
         },
         "optionId": "write-in-2",
       },
@@ -322,46 +322,46 @@ exports[`interpret with valid data 1`] = `
   },
   {
     "bounds": {
-      "height": 102,
-      "left": 175,
-      "top": 1662,
-      "width": 1501,
+      "height": 104,
+      "left": 125,
+      "top": 1661,
+      "width": 1551,
     },
     "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
     "options": [
       {
         "bounds": {
-          "height": 99,
-          "left": 175,
-          "top": 1665,
-          "width": 501,
+          "height": 102,
+          "left": 125,
+          "top": 1663,
+          "width": 551,
         },
         "optionId": "Abeil-Foster-ded38e36",
       },
       {
         "bounds": {
-          "height": 99,
-          "left": 525,
-          "top": 1664,
-          "width": 501,
+          "height": 102,
+          "left": 475,
+          "top": 1662,
+          "width": 551,
         },
         "optionId": "Charles-H-Hersey-096286a4",
       },
       {
         "bounds": {
-          "height": 99,
-          "left": 874,
-          "top": 1663,
-          "width": 502,
+          "height": 102,
+          "left": 825,
+          "top": 1661,
+          "width": 551,
         },
         "optionId": "William-Lovejoy-fde3c2df",
       },
       {
         "bounds": {
-          "height": 99,
-          "left": 1174,
-          "top": 1662,
-          "width": 502,
+          "height": 102,
+          "left": 1124,
+          "top": 1661,
+          "width": 552,
         },
         "optionId": "write-in-0",
       },
@@ -375,36 +375,36 @@ exports[`interpret with valid data 2`] = `
   {
     "bounds": {
       "height": 102,
-      "left": 182,
+      "left": 132,
       "top": 253,
-      "width": 1501,
+      "width": 1551,
     },
     "contestId": "Sheriff-4243fe0b",
     "options": [
       {
         "bounds": {
           "height": 102,
-          "left": 182,
+          "left": 132,
           "top": 253,
-          "width": 501,
+          "width": 551,
         },
         "optionId": "Edward-Randolph-bf4c848a",
       },
       {
         "bounds": {
           "height": 102,
-          "left": 532,
+          "left": 482,
           "top": 253,
-          "width": 501,
+          "width": 551,
         },
         "optionId": "Edward-Randolph-bf4c848a",
       },
       {
         "bounds": {
           "height": 102,
-          "left": 1182,
+          "left": 1132,
           "top": 253,
-          "width": 501,
+          "width": 551,
         },
         "optionId": "write-in-0",
       },
@@ -413,36 +413,36 @@ exports[`interpret with valid data 2`] = `
   {
     "bounds": {
       "height": 101,
-      "left": 182,
+      "left": 132,
       "top": 405,
-      "width": 1501,
+      "width": 1551,
     },
     "contestId": "County-Attorney-133f910f",
     "options": [
       {
         "bounds": {
           "height": 101,
-          "left": 182,
+          "left": 132,
           "top": 405,
-          "width": 501,
+          "width": 551,
         },
         "optionId": "Ezra-Bartlett-8f95223c",
       },
       {
         "bounds": {
           "height": 101,
-          "left": 532,
+          "left": 482,
           "top": 405,
-          "width": 501,
+          "width": 551,
         },
         "optionId": "Mary-Woolson-dc0b854a",
       },
       {
         "bounds": {
           "height": 101,
-          "left": 1182,
+          "left": 1132,
           "top": 405,
-          "width": 501,
+          "width": 551,
         },
         "optionId": "write-in-0",
       },
@@ -451,36 +451,36 @@ exports[`interpret with valid data 2`] = `
   {
     "bounds": {
       "height": 103,
-      "left": 182,
+      "left": 132,
       "top": 555,
-      "width": 1502,
+      "width": 1552,
     },
     "contestId": "County-Treasurer-87d25a31",
     "options": [
       {
         "bounds": {
           "height": 102,
-          "left": 182,
+          "left": 132,
           "top": 555,
-          "width": 501,
+          "width": 551,
         },
         "optionId": "John-Smith-ef61a579",
       },
       {
         "bounds": {
           "height": 102,
-          "left": 532,
+          "left": 482,
           "top": 555,
-          "width": 501,
+          "width": 551,
         },
         "optionId": "Jane-Jones-9caa141f",
       },
       {
         "bounds": {
           "height": 102,
-          "left": 1182,
+          "left": 1132,
           "top": 556,
-          "width": 502,
+          "width": 552,
         },
         "optionId": "write-in-0",
       },
@@ -489,36 +489,36 @@ exports[`interpret with valid data 2`] = `
   {
     "bounds": {
       "height": 102,
-      "left": 182,
+      "left": 132,
       "top": 707,
-      "width": 1501,
+      "width": 1551,
     },
     "contestId": "Register-of-Deeds-a1278df2",
     "options": [
       {
         "bounds": {
           "height": 101,
-          "left": 182,
+          "left": 132,
           "top": 707,
-          "width": 501,
+          "width": 551,
         },
         "optionId": "John-Mann-b56bbdd3",
       },
       {
         "bounds": {
           "height": 102,
-          "left": 532,
+          "left": 482,
           "top": 707,
-          "width": 501,
+          "width": 551,
         },
         "optionId": "Ellen-A-Stileman-14408737",
       },
       {
         "bounds": {
           "height": 102,
-          "left": 1182,
+          "left": 1132,
           "top": 707,
-          "width": 501,
+          "width": 551,
         },
         "optionId": "write-in-0",
       },
@@ -527,36 +527,36 @@ exports[`interpret with valid data 2`] = `
   {
     "bounds": {
       "height": 103,
-      "left": 182,
+      "left": 131,
       "top": 857,
-      "width": 1500,
+      "width": 1552,
     },
     "contestId": "Register-of-Probate-a4117da8",
     "options": [
       {
         "bounds": {
           "height": 102,
-          "left": 182,
+          "left": 131,
           "top": 857,
-          "width": 500,
+          "width": 552,
         },
         "optionId": "Nathaniel-Parker-56a06c29",
       },
       {
         "bounds": {
           "height": 102,
-          "left": 532,
+          "left": 481,
           "top": 857,
-          "width": 500,
+          "width": 552,
         },
         "optionId": "Claire-Cutts-07a436e7",
       },
       {
         "bounds": {
           "height": 102,
-          "left": 1182,
+          "left": 1131,
           "top": 858,
-          "width": 500,
+          "width": 552,
         },
         "optionId": "write-in-0",
       },
@@ -565,36 +565,36 @@ exports[`interpret with valid data 2`] = `
   {
     "bounds": {
       "height": 103,
-      "left": 182,
+      "left": 132,
       "top": 1008,
-      "width": 1500,
+      "width": 1550,
     },
     "contestId": "County-Commissioner-d6feed25",
     "options": [
       {
         "bounds": {
           "height": 102,
-          "left": 182,
+          "left": 132,
           "top": 1008,
-          "width": 501,
+          "width": 551,
         },
         "optionId": "Ichabod-Goodwin-55e8de1f",
       },
       {
         "bounds": {
           "height": 102,
-          "left": 532,
+          "left": 482,
           "top": 1008,
-          "width": 500,
+          "width": 550,
         },
         "optionId": "Valbe-Cady-ba3af3af",
       },
       {
         "bounds": {
           "height": 102,
-          "left": 1181,
+          "left": 1131,
           "top": 1009,
-          "width": 501,
+          "width": 551,
         },
         "optionId": "write-in-0",
       },
@@ -603,27 +603,27 @@ exports[`interpret with valid data 2`] = `
   {
     "bounds": {
       "height": 103,
-      "left": 881,
+      "left": 831,
       "top": 1260,
-      "width": 800,
+      "width": 851,
     },
     "contestId": "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc",
     "options": [
       {
         "bounds": {
           "height": 103,
-          "left": 881,
+          "left": 831,
           "top": 1260,
-          "width": 500,
+          "width": 551,
         },
         "optionId": "yes",
       },
       {
         "bounds": {
           "height": 103,
-          "left": 1181,
+          "left": 1130,
           "top": 1260,
-          "width": 500,
+          "width": 552,
         },
         "optionId": "no",
       },


### PR DESCRIPTION
## Overview

_Review by commits_

An assortment of small improvements to write-in cropping for the adjudication transcription flow.

## Demo Video or Screenshot

https://user-images.githubusercontent.com/530106/231900491-d11224c8-a19f-445c-81af-8886868af4a1.mov


## Testing Plan
- Updated automated tests
- Manual tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
