### PR TITLE
fix(ui): Don't show border for fullscreen modals

### DIFF
--- a/libs/ui/src/__snapshots__/modal.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/modal.test.tsx.snap
@@ -106,7 +106,7 @@ exports[`Modal can configure fullscreen 1`] = `
   margin: auto;
   outline: none;
   background: #edeff0;
-  border: 0.15rem solid #263238;
+  border: 0 solid #263238;
   width: 100%;
   overflow: auto;
   -webkit-overflow-scrolling: touch;

--- a/libs/ui/src/modal.tsx
+++ b/libs/ui/src/modal.tsx
@@ -33,8 +33,9 @@ const ReactModalContent = styled('div')<ReactModalContentInterface>`
   margin: auto;
   outline: none;
   background: ${(p) => p.theme.colors.background};
-  border: ${(p) => p.theme.sizes.bordersRem.medium}rem solid
-    ${(p) => p.theme.colors.foreground};
+  border: ${(p) =>
+      p.fullscreen ? '0' : `${p.theme.sizes.bordersRem.medium}rem`}
+    solid ${(p) => p.theme.colors.foreground};
   width: 100%;
   overflow: auto;
   font-size: ${({ themeDeprecated }) => themeDeprecated?.fontSize};


### PR DESCRIPTION
## Overview

Fixes a small bug introduced in https://github.com/votingworks/vxsuite/pull/3230.

## Demo Video or Screenshot

Before
<img width="982" alt="Screen Shot 2023-04-13 at 4 05 24 PM" src="https://user-images.githubusercontent.com/530106/231901914-b8a7200e-71c0-440b-977a-92ddb18aebc8.png">

After
<img width="974" alt="Screen Shot 2023-04-13 at 4 05 10 PM" src="https://user-images.githubusercontent.com/530106/231901919-2030f07a-121a-4f42-8280-f604aa3e348e.png">

## Testing Plan
- Manual test

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
