### PR TITLE
fix(scan): Remove outdated infoBar prop from double sheet screen

### DIFF
--- a/apps/scan/frontend/src/screens/scan_double_sheet_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_double_sheet_screen.tsx
@@ -17,10 +17,7 @@ export function ScanDoubleSheetScreen({
   scannedBallotCount,
 }: Props): JSX.Element {
   return (
-    <ScreenMainCenterChild
-      infoBar={false}
-      ballotCountOverride={scannedBallotCount}
-    >
+    <ScreenMainCenterChild ballotCountOverride={scannedBallotCount}>
       <FullScreenIconWrapper color="danger">
         <Icons.DangerX />
       </FullScreenIconWrapper>


### PR DESCRIPTION

## Overview

Probably got mixed up in a rebase when #3279 was merged.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
