### PR TITLE
Ensure invalid card screen is displayed when VxScan is unconfigured (bug fix)

### DIFF
--- a/apps/scan/frontend/src/app_root.tsx
+++ b/apps/scan/frontend/src/app_root.tsx
@@ -115,6 +115,10 @@ export function AppRoot({ hardware, logger }: Props): JSX.Element | null {
     return <CardErrorScreen />;
   }
 
+  if (authStatus.status === 'logged_out' && authStatus.reason !== 'no_card') {
+    return <InvalidCardScreen />;
+  }
+
   if (
     authStatus.status === 'checking_pin' &&
     authStatus.user.role === 'system_administrator'
@@ -229,10 +233,6 @@ export function AppRoot({ hardware, logger }: Props): JSX.Element | null {
         logger={logger}
       />
     );
-  }
-
-  if (authStatus.status === 'logged_out' && authStatus.reason !== 'no_card') {
-    return <InvalidCardScreen />;
   }
 
   // When no card is inserted, we're in "voter" mode

--- a/apps/scan/frontend/src/components/layout.tsx
+++ b/apps/scan/frontend/src/components/layout.tsx
@@ -38,7 +38,9 @@ export function ScreenMainCenterChild({
   return (
     <Screen>
       {!isLiveMode && <TestMode />}
-      {ballotCount !== undefined && <ScannedBallotCount count={ballotCount} />}
+      {ballotCount !== undefined && electionDefinition && (
+        <ScannedBallotCount count={ballotCount} />
+      )}
       <Main padded centerChild style={{ position: 'relative' }}>
         {children}
       </Main>


### PR DESCRIPTION
## Overview

@carolinemodic just uncovered a confusing sequence in VxScan. When VxScan is unconfigured, inserting an invalid card doesn't surface the invalid card screen; it surfaces a variation of the screen that was already being displayed.

This PR ensures that the invalid card screen is displayed when VxScan is unconfigured. It also updates the ballot count to only be displayed once VxScan has been configured.

## Demo Videos

### Before

https://user-images.githubusercontent.com/12616928/232066809-85833909-f9be-4413-87e5-fef05e69ad15.mov

### After

https://user-images.githubusercontent.com/12616928/232067833-d395fe7a-3a0f-4637-b759-b858975746bb.mov

## Testing

- [x] Added a unit test to prevent regressions
- [x] Tested manually

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates