### PR TITLE
Improve PIN entry UX

### DIFF
--- a/apps/admin/frontend/src/components/election_manager.tsx
+++ b/apps/admin/frontend/src/components/election_manager.tsx
@@ -53,7 +53,13 @@ export function ElectionManager(): JSX.Element {
     return (
       <UnlockMachineScreen
         auth={auth}
-        checkPin={(pin) => checkPinMutation.mutate({ pin })}
+        checkPin={async (pin) => {
+          try {
+            await checkPinMutation.mutateAsync({ pin });
+          } catch {
+            // Handled by default query client error handling
+          }
+        }}
       />
     );
   }

--- a/apps/central-scan/frontend/src/app_root.tsx
+++ b/apps/central-scan/frontend/src/app_root.tsx
@@ -500,7 +500,13 @@ export function AppRoot({
     return (
       <UnlockMachineScreen
         auth={authStatus}
-        checkPin={(pin) => checkPinMutation.mutate({ pin })}
+        checkPin={async (pin) => {
+          try {
+            await checkPinMutation.mutateAsync({ pin });
+          } catch {
+            // Handled by default query client error handling
+          }
+        }}
       />
     );
   }

--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -662,7 +662,13 @@ export function AppRoot({
     return (
       <UnlockMachineScreen
         auth={authStatus}
-        checkPin={(pin) => checkPinMutation.mutate({ pin })}
+        checkPin={async (pin) => {
+          try {
+            await checkPinMutation.mutateAsync({ pin });
+          } catch {
+            // Handled by default query client error handling
+          }
+        }}
       />
     );
   }

--- a/apps/scan/frontend/src/app_root.tsx
+++ b/apps/scan/frontend/src/app_root.tsx
@@ -126,7 +126,13 @@ export function AppRoot({ hardware, logger }: Props): JSX.Element | null {
     return (
       <UnlockMachineScreen
         auth={authStatus}
-        checkPin={(pin: string) => checkPinMutation.mutate({ pin })}
+        checkPin={async (pin) => {
+          try {
+            await checkPinMutation.mutateAsync({ pin });
+          } catch {
+            // Handled by default query client error handling
+          }
+        }}
       />
     );
   }
@@ -176,7 +182,13 @@ export function AppRoot({ hardware, logger }: Props): JSX.Element | null {
     return (
       <UnlockMachineScreen
         auth={authStatus}
-        checkPin={(pin: string) => checkPinMutation.mutate({ pin })}
+        checkPin={async (pin) => {
+          try {
+            await checkPinMutation.mutateAsync({ pin });
+          } catch {
+            // Handled by default query client error handling
+          }
+        }}
       />
     );
   }

--- a/apps/scan/frontend/src/screens/poll_worker_screen.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.tsx
@@ -154,7 +154,7 @@ export function PollWorkerScreen({
         scannerReportData,
       });
     } catch {
-      // Handled by query client's default error handling
+      // Handled by default query client error handling
       return false;
     }
     return result.isOk();

--- a/libs/ui/src/unlock_machine_screen.tsx
+++ b/libs/ui/src/unlock_machine_screen.tsx
@@ -41,7 +41,7 @@ type CheckingPinAuth =
 
 interface Props {
   auth: CheckingPinAuth;
-  checkPin: (pin: string) => void;
+  checkPin: (pin: string) => Promise<void>;
   grayBackground?: boolean;
 }
 
@@ -51,15 +51,18 @@ export function UnlockMachineScreen({
   grayBackground,
 }: Props): JSX.Element {
   const [currentPin, setCurrentPin] = useState('');
+  const [isCheckingPin, setIsCheckingPin] = useState(false);
   const now = useNow().toJSDate();
 
   const handleNumberEntry = useCallback(
-    (digit: number) => {
+    async (digit: number) => {
       const pin = `${currentPin}${digit}`.slice(0, SECURITY_PIN_LENGTH);
       setCurrentPin(pin);
       if (pin.length === SECURITY_PIN_LENGTH) {
-        checkPin(pin);
+        setIsCheckingPin(true);
+        await checkPin(pin);
         setCurrentPin('');
+        setIsCheckingPin(false);
       }
     },
     [checkPin, currentPin]
@@ -118,7 +121,7 @@ export function UnlockMachineScreen({
           <EnteredCode>{currentPinDisplayString}</EnteredCode>
           <NumberPadWrapper>
             <NumberPad
-              disabled={isLockedOut}
+              disabled={isCheckingPin || isLockedOut}
               onButtonPress={handleNumberEntry}
               onBackspace={handleBackspace}
               onClear={handleClear}


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/3275

Due to a number of reasons, including moving auth to the backend, using a synchronous react-query method, and PIN checking becoming a slower operation with Java Cards, the PIN entry UX has become a bit funky. After you submit your PIN, the PIN immediately clears, but checking doesn't finish until after a noticeable delay. You can still press the keypad in the interim.

This PR makes the simplest possible change to improve the UX, disabling the keypad while PIN-checking is in progress and not clearing the PIN until PIN-checking is complete.

Still plenty of room for improvement (e.g. you can sometimes catch a flicker as the PIN clears, before we proceed to the next screen) but just wanted to get something simple in place before the NH pilot code freeze 🧊

## Demo Videos

### VxAdmin, before

https://user-images.githubusercontent.com/12616928/232112223-d7c652ff-0901-44c7-a581-5c0525c5f6b5.mov

### VxAdmin, after

https://user-images.githubusercontent.com/12616928/232112267-5e6781b7-adaf-423a-8ad6-1d53aee7a1d1.mov

### VxScan, before

https://user-images.githubusercontent.com/12616928/232112295-ead296d0-ea56-41cc-9645-288e2f8e45ef.mov

### VxScan, after

https://user-images.githubusercontent.com/12616928/232112325-7e86be16-55b1-42b4-bcad-8617ae19bc75.mov

## Testing

- [x] Tested manually

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates